### PR TITLE
feat: add daemon session persistence and recovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "productName": "wmux",
   "version": "2.3.1",
   "description": "Windows terminal multiplexer with MCP server for AI agents",
-  "license": "MIT",
   "private": true,
   "main": ".vite/build/index.js",
   "bin": {
@@ -33,6 +32,7 @@
     "name": "openwong2kim",
     "email": "100856670+openwong2kim@users.noreply.github.com"
   },
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/openwong2kim/wmux.git"

--- a/src/daemon/RingBuffer.ts
+++ b/src/daemon/RingBuffer.ts
@@ -1,3 +1,6 @@
+import { writeFile } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
+
 /**
  * Fixed-size circular byte buffer for storing ConPTY output per session.
  * Preserves raw bytes including ANSI escape sequences without any filtering.
@@ -91,4 +94,20 @@ export class RingBuffer {
     return this.capacity;
   }
 
+  /** Dump the buffer contents to a file (for DEAD session log preservation). */
+  async dumpToFile(filePath: string): Promise<void> {
+    const data = this.readAll();
+    // Note: mode is no-op on Windows; use icacls for NTFS ACLs
+    await writeFile(filePath, data, { mode: 0o600 });
+  }
+
+  /** Create a RingBuffer pre-filled with data loaded from a file. */
+  static loadFromFile(filePath: string, capacityBytes: number): RingBuffer {
+    const data = readFileSync(filePath);
+    const rb = new RingBuffer(capacityBytes);
+    if (data.length > 0) {
+      rb.write(data);
+    }
+    return rb;
+  }
 }

--- a/src/daemon/StateWriter.ts
+++ b/src/daemon/StateWriter.ts
@@ -1,0 +1,202 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { DaemonState, DaemonSession } from './types';
+
+const DEBOUNCE_MS = 30_000;
+
+/**
+ * Persists DaemonState (sessions.json) to disk using atomic write pattern.
+ * Mirrors SessionManager's tmp → bak → rename strategy.
+ */
+export class StateWriter {
+  private filePath: string;
+  private tmpPath: string;
+  private bakPath: string;
+  private debounceTimer: NodeJS.Timeout | null = null;
+  private pendingState: DaemonState | null = null;
+
+  constructor(baseDir: string) {
+    this.filePath = path.join(baseDir, 'sessions.json');
+    this.tmpPath = this.filePath + '.tmp';
+    this.bakPath = this.filePath + '.bak';
+  }
+
+  /** Immediately write state to disk (session create/destroy/state change). */
+  saveImmediate(state: DaemonState): void {
+    try {
+      const dir = path.dirname(this.filePath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+
+      const json = JSON.stringify(state, null, 2);
+
+      // 1. Write to temporary file
+      // Note: mode is no-op on Windows; use icacls for NTFS ACLs
+      fs.writeFileSync(this.tmpPath, json, { encoding: 'utf-8', mode: 0o600 });
+
+      // 2. Backup current file (if it exists)
+      if (fs.existsSync(this.filePath)) {
+        try {
+          fs.renameSync(this.filePath, this.bakPath);
+        } catch (bakErr) {
+          console.warn('[StateWriter] Failed to create backup:', bakErr);
+          // Continue — saving is more important than backing up
+        }
+      }
+
+      // 3. Atomic rename: tmp → sessions.json
+      fs.renameSync(this.tmpPath, this.filePath);
+
+      // Clear pending since we just saved
+      this.pendingState = null;
+    } catch (err) {
+      console.error('[StateWriter] Failed to save state:', err);
+      // Clean up tmp file if it exists
+      try {
+        if (fs.existsSync(this.tmpPath)) fs.unlinkSync(this.tmpPath);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+  }
+
+  /** Debounced save — coalesces frequent updates (e.g. lastActivity) over 30s. */
+  saveDebounced(state: DaemonState): void {
+    this.pendingState = state;
+
+    if (this.debounceTimer !== null) {
+      return; // Timer already running; state will be picked up when it fires
+    }
+
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      if (this.pendingState !== null) {
+        this.saveImmediate(this.pendingState);
+      }
+    }, DEBOUNCE_MS);
+  }
+
+  /** Load state from disk. Falls back to .bak on failure. Prunes expired DEAD sessions. */
+  load(): DaemonState {
+    const empty: DaemonState = { version: 1, sessions: [] };
+
+    let state: DaemonState | null = null;
+
+    // Try primary
+    try {
+      state = this.parseStateFile(this.filePath);
+    } catch (err) {
+      console.error('[StateWriter] Failed to load primary state:', err);
+    }
+
+    // Fallback to backup
+    if (!state) {
+      try {
+        console.warn('[StateWriter] Trying backup...');
+        state = this.parseStateFile(this.bakPath);
+        if (state) {
+          console.warn('[StateWriter] Recovered state from backup.');
+        }
+      } catch (bakErr) {
+        console.error('[StateWriter] Backup recovery also failed:', bakErr);
+      }
+    }
+
+    if (!state) {
+      return empty;
+    }
+
+    // Prune DEAD sessions that exceeded their TTL
+    state.sessions = state.sessions.filter((s) => {
+      if (s.state !== 'dead') return true;
+      const deadSince = new Date(s.lastActivity).getTime();
+      const ttlMs = s.deadTtlHours * 60 * 60 * 1000;
+      return Date.now() - deadSince < ttlMs;
+    });
+
+    return state;
+  }
+
+  /** Flush pending debounce — if there is pending state, write it immediately. */
+  flush(): void {
+    if (this.debounceTimer !== null) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    if (this.pendingState !== null) {
+      this.saveImmediate(this.pendingState);
+    }
+  }
+
+  /** Clean up timers (daemon shutdown). Flushes pending state first. */
+  dispose(): void {
+    this.flush();
+  }
+
+  /** Get the path where a session's scrollback buffer should be dumped. */
+  getBufferDumpPath(sessionId: string): string {
+    return path.join(path.dirname(this.filePath), 'buffers', `${sessionId}.buf`);
+  }
+
+  /** Ensure the buffers/ directory exists. */
+  ensureBufferDir(): void {
+    const dir = path.join(path.dirname(this.filePath), 'buffers');
+    if (!fs.existsSync(dir)) {
+      // Note: mode is no-op on Windows; use icacls for NTFS ACLs
+      fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
+  }
+
+  /** Remove orphaned .buf files not referenced by any session. */
+  cleanOrphanedBuffers(activeIds: Set<string>): void {
+    const dir = path.join(path.dirname(this.filePath), 'buffers');
+    if (!fs.existsSync(dir)) return;
+    try {
+      for (const file of fs.readdirSync(dir)) {
+        if (!file.endsWith('.buf')) continue;
+        const id = file.replace(/\.buf$/, '');
+        if (!activeIds.has(id)) {
+          try { fs.unlinkSync(path.join(dir, file)); } catch { /* ignore */ }
+        }
+      }
+    } catch { /* ignore */ }
+  }
+
+  // ── Internal helpers ──────────────────────────────────────────────
+
+  private parseStateFile(filePath: string): DaemonState | null {
+    if (!fs.existsSync(filePath)) return null;
+
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    if (!raw) return null;
+
+    const parsed: unknown = JSON.parse(raw, (key, value) => {
+      // Prototype pollution guard
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        return undefined;
+      }
+      return value;
+    });
+
+    return this.validateState(parsed);
+  }
+
+  private validateState(parsed: unknown): DaemonState | null {
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    const obj = parsed as Record<string, unknown>;
+
+    if (typeof obj['version'] !== 'number') return null;
+    if (!Array.isArray(obj['sessions'])) return null;
+
+    // Validate each session has minimum required fields
+    for (const s of obj['sessions'] as unknown[]) {
+      if (typeof s !== 'object' || s === null) return null;
+      const sess = s as Record<string, unknown>;
+      if (typeof sess['id'] !== 'string') return null;
+      if (typeof sess['state'] !== 'string') return null;
+    }
+
+    return parsed as DaemonState;
+  }
+}

--- a/src/daemon/__tests__/RingBuffer.test.ts
+++ b/src/daemon/__tests__/RingBuffer.test.ts
@@ -1,5 +1,22 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
 import { RingBuffer } from '../RingBuffer';
+
+/** Temp files created during tests — cleaned up in afterEach */
+const tempFiles: string[] = [];
+
+afterEach(() => {
+  for (const f of tempFiles) {
+    try {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+  tempFiles.length = 0;
+});
 
 describe('RingBuffer', () => {
   // 1. Basic write + readAll
@@ -71,7 +88,20 @@ describe('RingBuffer', () => {
     expect(rb.totalCapacity).toBe(32);
   });
 
-  // 7. Empty buffer readAll returns empty Buffer
+  // 7. dumpToFile writes buffer contents to disk
+  it('dumps buffer contents to a file', async () => {
+    const rb = new RingBuffer(64);
+    rb.write(Buffer.from('dump-test-content'));
+
+    const tmpFile = path.join(os.tmpdir(), `wmux-rb-test-${Date.now()}.bin`);
+    tempFiles.push(tmpFile);
+
+    await rb.dumpToFile(tmpFile);
+    const ondisk = fs.readFileSync(tmpFile);
+    expect(ondisk.toString()).toBe('dump-test-content');
+  });
+
+  // 8. Empty buffer readAll returns empty Buffer
   it('returns an empty Buffer when nothing has been written', () => {
     const rb = new RingBuffer(16);
     const result = rb.readAll();
@@ -125,4 +155,44 @@ describe('RingBuffer', () => {
     expect(rb.readAll().toString()).toBe('ABCDEFGH');
   });
 
+  // loadFromFile: round-trip dump → load
+  it('loadFromFile restores buffer contents from a dump', async () => {
+    const rb = new RingBuffer(64);
+    rb.write(Buffer.from('hello-from-dump'));
+
+    const tmpFile = path.join(os.tmpdir(), `wmux-rb-load-${Date.now()}.bin`);
+    tempFiles.push(tmpFile);
+
+    await rb.dumpToFile(tmpFile);
+
+    const restored = RingBuffer.loadFromFile(tmpFile, 64);
+    expect(restored.readAll().toString()).toBe('hello-from-dump');
+    expect(restored.size).toBe(15);
+  });
+
+  // loadFromFile: data larger than capacity keeps only tail
+  it('loadFromFile truncates to capacity when file is larger', async () => {
+    const rb = new RingBuffer(32);
+    rb.write(Buffer.from('A'.repeat(32)));
+
+    const tmpFile = path.join(os.tmpdir(), `wmux-rb-load-big-${Date.now()}.bin`);
+    tempFiles.push(tmpFile);
+
+    await rb.dumpToFile(tmpFile);
+
+    const restored = RingBuffer.loadFromFile(tmpFile, 8);
+    expect(restored.readAll().toString()).toBe('A'.repeat(8));
+    expect(restored.size).toBe(8);
+  });
+
+  // loadFromFile: empty file produces empty buffer
+  it('loadFromFile with empty file produces empty buffer', () => {
+    const tmpFile = path.join(os.tmpdir(), `wmux-rb-load-empty-${Date.now()}.bin`);
+    tempFiles.push(tmpFile);
+    fs.writeFileSync(tmpFile, '');
+
+    const restored = RingBuffer.loadFromFile(tmpFile, 16);
+    expect(restored.size).toBe(0);
+    expect(restored.readAll().length).toBe(0);
+  });
 });

--- a/src/daemon/__tests__/StateWriter.test.ts
+++ b/src/daemon/__tests__/StateWriter.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { StateWriter } from '../StateWriter';
+import type { DaemonState, DaemonSession } from '../types';
+
+let tmpDir: string;
+let writer: StateWriter;
+
+function makeSession(overrides: Partial<DaemonSession> = {}): DaemonSession {
+  return {
+    id: 'sess-1',
+    state: 'detached',
+    createdAt: new Date().toISOString(),
+    lastActivity: new Date().toISOString(),
+    pid: 12345,
+    cmd: 'bash',
+    cwd: '/tmp',
+    env: {},
+    cols: 120,
+    rows: 30,
+    deadTtlHours: 24,
+    ...overrides,
+  };
+}
+
+function makeState(sessions: DaemonSession[] = []): DaemonState {
+  return { version: 1, sessions };
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-statewriter-test-'));
+  writer = new StateWriter(tmpDir);
+});
+
+afterEach(() => {
+  writer.dispose();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('StateWriter', () => {
+  it('saveImmediate creates sessions.json', () => {
+    const state = makeState([makeSession()]);
+    writer.saveImmediate(state);
+
+    const filePath = path.join(tmpDir, 'sessions.json');
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const loaded = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(loaded.version).toBe(1);
+    expect(loaded.sessions).toHaveLength(1);
+    expect(loaded.sessions[0].id).toBe('sess-1');
+  });
+
+  it('load restores saved data', () => {
+    const state = makeState([makeSession({ id: 'abc' })]);
+    writer.saveImmediate(state);
+
+    const loaded = writer.load();
+    expect(loaded.version).toBe(1);
+    expect(loaded.sessions).toHaveLength(1);
+    expect(loaded.sessions[0].id).toBe('abc');
+  });
+
+  it('load falls back to .bak when primary is corrupt', () => {
+    // Save valid state first (creates .bak on second save)
+    const state = makeState([makeSession({ id: 'good' })]);
+    writer.saveImmediate(state);
+
+    // Second save — the first becomes .bak
+    const state2 = makeState([makeSession({ id: 'good2' })]);
+    writer.saveImmediate(state2);
+
+    // Corrupt the primary file
+    const filePath = path.join(tmpDir, 'sessions.json');
+    fs.writeFileSync(filePath, '{{not valid json', 'utf-8');
+
+    const loaded = writer.load();
+    // Should recover from .bak which has the first save's state
+    expect(loaded.sessions).toHaveLength(1);
+    expect(loaded.sessions[0].id).toBe('good');
+  });
+
+  it('saveDebounced does not write immediately', () => {
+    vi.useFakeTimers();
+    try {
+      const state = makeState([makeSession()]);
+      writer.saveDebounced(state);
+
+      const filePath = path.join(tmpDir, 'sessions.json');
+      expect(fs.existsSync(filePath)).toBe(false);
+
+      // Advance past debounce interval (30s)
+      vi.advanceTimersByTime(30_000);
+
+      expect(fs.existsSync(filePath)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('saveDebounced coalesces multiple calls within debounce window', () => {
+    vi.useFakeTimers();
+    try {
+      writer.saveDebounced(makeState([makeSession({ id: 'v1' })]));
+
+      vi.advanceTimersByTime(10_000);
+      writer.saveDebounced(makeState([makeSession({ id: 'v2' })]));
+
+      vi.advanceTimersByTime(10_000);
+      writer.saveDebounced(makeState([makeSession({ id: 'v3' })]));
+
+      // Timer from first call fires at 30s
+      vi.advanceTimersByTime(10_000);
+
+      const filePath = path.join(tmpDir, 'sessions.json');
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      const loaded = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      // Should have the latest pending state
+      expect(loaded.sessions[0].id).toBe('v3');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('flush writes pending state immediately', () => {
+    vi.useFakeTimers();
+    try {
+      const state = makeState([makeSession({ id: 'flushed' })]);
+      writer.saveDebounced(state);
+
+      const filePath = path.join(tmpDir, 'sessions.json');
+      expect(fs.existsSync(filePath)).toBe(false);
+
+      writer.flush();
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      const loaded = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      expect(loaded.sessions[0].id).toBe('flushed');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('dispose clears timers and flushes pending', () => {
+    vi.useFakeTimers();
+    try {
+      const state = makeState([makeSession({ id: 'disposed' })]);
+      writer.saveDebounced(state);
+
+      writer.dispose();
+
+      const filePath = path.join(tmpDir, 'sessions.json');
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      const loaded = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      expect(loaded.sessions[0].id).toBe('disposed');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('load prunes DEAD sessions past their TTL', () => {
+    const now = Date.now();
+    // Dead session from 25 hours ago with 24h TTL — should be pruned
+    const expired = makeSession({
+      id: 'expired',
+      state: 'dead',
+      lastActivity: new Date(now - 25 * 60 * 60 * 1000).toISOString(),
+      deadTtlHours: 24,
+    });
+    // Dead session from 1 hour ago with 24h TTL — should survive
+    const recent = makeSession({
+      id: 'recent-dead',
+      state: 'dead',
+      lastActivity: new Date(now - 1 * 60 * 60 * 1000).toISOString(),
+      deadTtlHours: 24,
+    });
+    // Alive session — always survives
+    const alive = makeSession({ id: 'alive', state: 'attached' });
+
+    writer.saveImmediate(makeState([expired, recent, alive]));
+
+    const loaded = writer.load();
+    const ids = loaded.sessions.map((s) => s.id);
+
+    expect(ids).not.toContain('expired');
+    expect(ids).toContain('recent-dead');
+    expect(ids).toContain('alive');
+  });
+
+  it('rejects prototype pollution keys in JSON', () => {
+    const filePath = path.join(tmpDir, 'sessions.json');
+    const poisoned = JSON.stringify({
+      version: 1,
+      sessions: [],
+      '__proto__': { admin: true },
+      'constructor': { prototype: { isAdmin: true } },
+    });
+    fs.writeFileSync(filePath, poisoned, 'utf-8');
+
+    const loaded = writer.load();
+    // Should load without pollution
+    expect(loaded.version).toBe(1);
+    expect(loaded.sessions).toHaveLength(0);
+
+    // Verify no pollution on Object prototype
+    const plain: Record<string, unknown> = {};
+    expect(plain['admin']).toBeUndefined();
+    expect(plain['isAdmin']).toBeUndefined();
+  });
+
+  it('load returns empty state when no files exist', () => {
+    const loaded = writer.load();
+    expect(loaded.version).toBe(1);
+    expect(loaded.sessions).toHaveLength(0);
+  });
+
+  it('atomic write creates .bak file', () => {
+    writer.saveImmediate(makeState([makeSession({ id: 'first' })]));
+    writer.saveImmediate(makeState([makeSession({ id: 'second' })]));
+
+    const bakPath = path.join(tmpDir, 'sessions.json.bak');
+    expect(fs.existsSync(bakPath)).toBe(true);
+
+    const bakData = JSON.parse(fs.readFileSync(bakPath, 'utf-8'));
+    expect(bakData.sessions[0].id).toBe('first');
+  });
+
+  it('no .tmp residue after successful save', () => {
+    writer.saveImmediate(makeState([makeSession()]));
+    const tmpPath = path.join(tmpDir, 'sessions.json.tmp');
+    expect(fs.existsSync(tmpPath)).toBe(false);
+  });
+
+  it('getBufferDumpPath returns path under buffers/', () => {
+    const dumpPath = writer.getBufferDumpPath('sess-abc');
+    expect(dumpPath).toBe(path.join(tmpDir, 'buffers', 'sess-abc.buf'));
+  });
+
+  it('ensureBufferDir creates the buffers directory', () => {
+    const bufDir = path.join(tmpDir, 'buffers');
+    expect(fs.existsSync(bufDir)).toBe(false);
+    writer.ensureBufferDir();
+    expect(fs.existsSync(bufDir)).toBe(true);
+    // idempotent
+    writer.ensureBufferDir();
+    expect(fs.existsSync(bufDir)).toBe(true);
+  });
+
+  it('cleanOrphanedBuffers removes unreferenced .buf files', () => {
+    writer.ensureBufferDir();
+    const bufDir = path.join(tmpDir, 'buffers');
+
+    // Create some buffer files
+    fs.writeFileSync(path.join(bufDir, 'keep.buf'), 'data');
+    fs.writeFileSync(path.join(bufDir, 'orphan.buf'), 'data');
+    fs.writeFileSync(path.join(bufDir, 'other.txt'), 'data'); // non-.buf ignored
+
+    writer.cleanOrphanedBuffers(new Set(['keep']));
+
+    expect(fs.existsSync(path.join(bufDir, 'keep.buf'))).toBe(true);
+    expect(fs.existsSync(path.join(bufDir, 'orphan.buf'))).toBe(false);
+    expect(fs.existsSync(path.join(bufDir, 'other.txt'))).toBe(true);
+  });
+});

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,11 +1,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import os from 'node:os';
 import { loadConfig, getWmuxDir } from './config';
 import { DaemonSessionManager } from './DaemonSessionManager';
 import { DaemonPipeServer } from './DaemonPipeServer';
 import { SessionPipe } from './SessionPipe';
+import { StateWriter } from './StateWriter';
 import { ProcessMonitor } from './ProcessMonitor';
 import { Watchdog } from './Watchdog';
+import type { DaemonState } from './types';
 import type { DaemonEvent, DaemonCreateSessionParams, DaemonSessionIdParams, DaemonResizeParams } from '../shared/rpc';
 
 // === Constants ===
@@ -116,11 +119,164 @@ function releaseLock(): void {
   }
 }
 
+// === Session recovery ===
+
+async function recoverSessions(
+  stateWriter: StateWriter,
+  sessionManager: DaemonSessionManager,
+  processMonitor: ProcessMonitor,
+): Promise<void> {
+  const state = stateWriter.load();
+  let changed = false;
+  const recoveredIds = new Set<string>();
+
+  for (const session of state.sessions) {
+    if (session.state === 'dead') continue;
+
+    if (session.state === 'suspended' && session.bufferDumpPath) {
+      // Attempt to recover suspended session
+      try {
+        let scrollbackData: Buffer | undefined;
+        if (fs.existsSync(session.bufferDumpPath)) {
+          scrollbackData = fs.readFileSync(session.bufferDumpPath);
+        }
+
+        // Verify cwd still exists; fall back to homedir
+        const cwd = fs.existsSync(session.cwd) ? session.cwd : os.homedir();
+
+        const recovered = sessionManager.createSession({
+          id: session.id,
+          cmd: session.cmd,
+          cwd,
+          env: session.env,
+          cols: session.cols,
+          rows: session.rows,
+          agent: session.agent,
+          createdAt: session.createdAt,
+          scrollbackData,
+        });
+
+        // Start process monitoring for the new PTY
+        processMonitor.watch(recovered.id, recovered.pid, () => {
+          const managed = sessionManager.getSession(recovered.id);
+          if (managed && managed.meta.state !== 'dead') {
+            managed.meta.state = 'dead';
+            sessionManager.emit('session:died', { id: recovered.id, exitCode: null });
+          }
+        });
+
+        // Clean up dump file
+        try { fs.unlinkSync(session.bufferDumpPath); } catch { /* ignore */ }
+
+        recoveredIds.add(session.id);
+        changed = true;
+        log('info', `Recovered session ${session.id} in ${cwd}`);
+      } catch (err) {
+        log('error', `Failed to recover session ${session.id}:`, err);
+        session.state = 'dead';
+        session.exitCode = null;
+        changed = true;
+      }
+    } else {
+      // Non-suspended live session — check for periodic snapshot buf file
+      // (written every 30s, survives forced kills / power loss)
+      if (await ProcessMonitor.isAlive(session.pid)) {
+        try { process.kill(session.pid); } catch { /* ignore */ }
+      }
+
+      const snapshotPath = stateWriter.getBufferDumpPath(session.id);
+      if (fs.existsSync(snapshotPath)) {
+        try {
+          const scrollbackData = fs.readFileSync(snapshotPath);
+          const cwd = fs.existsSync(session.cwd) ? session.cwd : os.homedir();
+
+          const recovered = sessionManager.createSession({
+            id: session.id,
+            cmd: session.cmd,
+            cwd,
+            env: session.env,
+            cols: session.cols,
+            rows: session.rows,
+            agent: session.agent,
+            createdAt: session.createdAt,
+            scrollbackData,
+          });
+
+          processMonitor.watch(recovered.id, recovered.pid, () => {
+            const managed = sessionManager.getSession(recovered.id);
+            if (managed && managed.meta.state !== 'dead') {
+              managed.meta.state = 'dead';
+              sessionManager.emit('session:died', { id: recovered.id, exitCode: null });
+            }
+          });
+
+          try { fs.unlinkSync(snapshotPath); } catch { /* ignore */ }
+          recoveredIds.add(session.id);
+          changed = true;
+          log('info', `Recovered session ${session.id} from snapshot in ${cwd}`);
+          continue;
+        } catch (err) {
+          log('error', `Failed to recover session ${session.id} from snapshot:`, err);
+        }
+      }
+
+      // No snapshot file found — still try to recover the session
+      // with an empty scrollback rather than marking it dead.
+      // This handles cases where the daemon was killed before
+      // the 30s snapshot interval fired (e.g. immediate reboot).
+      try {
+        const cwd = fs.existsSync(session.cwd) ? session.cwd : os.homedir();
+        const recovered = sessionManager.createSession({
+          id: session.id,
+          cmd: session.cmd,
+          cwd,
+          env: session.env,
+          cols: session.cols,
+          rows: session.rows,
+          agent: session.agent,
+          createdAt: session.createdAt,
+        });
+
+        processMonitor.watch(recovered.id, recovered.pid, () => {
+          const managed = sessionManager.getSession(recovered.id);
+          if (managed && managed.meta.state !== 'dead') {
+            managed.meta.state = 'dead';
+            sessionManager.emit('session:died', { id: recovered.id, exitCode: null });
+          }
+        });
+
+        recoveredIds.add(session.id);
+        changed = true;
+        log('info', `Recovered session ${session.id} without scrollback in ${cwd}`);
+      } catch (err) {
+        log('error', `Failed to recover session ${session.id}:`, err);
+        session.state = 'dead';
+        session.exitCode = null;
+        changed = true;
+      }
+    }
+  }
+
+  if (changed) {
+    // Build combined state: recovered (live) sessions + dead sessions from loaded state
+    const liveState = buildState(sessionManager);
+    const deadFromState = state.sessions.filter(
+      (s) => s.state === 'dead' && !recoveredIds.has(s.id),
+    );
+    liveState.sessions.push(...deadFromState);
+    stateWriter.saveImmediate(liveState);
+  }
+
+  // Clean up orphaned buffer files
+  stateWriter.cleanOrphanedBuffers(recoveredIds);
+}
+
 // === RPC handler registration ===
 
 function registerRpcHandlers(
   pipeServer: DaemonPipeServer,
   sessionManager: DaemonSessionManager,
+  stateWriter: StateWriter,
   sessionPipes: Map<string, SessionPipe>,
   processMonitor: ProcessMonitor,
   startTime: number,
@@ -157,6 +313,10 @@ function registerRpcHandlers(
       }
     });
 
+    // Save state immediately
+    const state = buildState(sessionManager);
+    stateWriter.saveImmediate(state);
+
     return session;
   });
 
@@ -182,6 +342,13 @@ function registerRpcHandlers(
     processMonitor.unwatch(p.id);
 
     sessionManager.destroySession(p.id);
+
+    // Clean up buffer dump file if exists
+    const bufPath = stateWriter.getBufferDumpPath(p.id);
+    try { if (fs.existsSync(bufPath)) fs.unlinkSync(bufPath); } catch { /* ignore */ }
+
+    const state = buildState(sessionManager);
+    stateWriter.saveImmediate(state);
 
     return { ok: true };
   });
@@ -226,6 +393,9 @@ function registerRpcHandlers(
       await pipe.start();
     }
 
+    const state = buildState(sessionManager);
+    stateWriter.saveImmediate(state);
+
     return { ok: true };
   });
 
@@ -248,6 +418,9 @@ function registerRpcHandlers(
     }
 
     sessionManager.detachSession(p.id);
+
+    const state = buildState(sessionManager);
+    stateWriter.saveImmediate(state);
 
     return { ok: true };
   });
@@ -277,6 +450,7 @@ function registerRpcHandlers(
 function wireEvents(
   sessionManager: DaemonSessionManager,
   pipeServer: DaemonPipeServer,
+  stateWriter: StateWriter,
   sessionPipes: Map<string, SessionPipe>,
   processMonitor: ProcessMonitor,
   sessionDataListeners: Map<string, { bridge: import('./DaemonPTYBridge').DaemonPTYBridge; listener: (data: Buffer) => void }>,
@@ -306,6 +480,26 @@ function wireEvents(
 
     // Stop process monitoring
     processMonitor.unwatch(payload.id);
+
+    // Clean up buffer dump file — dead sessions don't need snapshots
+    const bufPath = stateWriter.getBufferDumpPath(payload.id);
+    try { if (fs.existsSync(bufPath)) fs.unlinkSync(bufPath); } catch { /* ignore */ }
+
+    // Save state
+    const state = buildState(sessionManager);
+    stateWriter.saveImmediate(state);
+  });
+
+  // session:created → save state (debounced since saveImmediate is called in RPC handler)
+  sessionManager.on('session:created', () => {
+    const state = buildState(sessionManager);
+    stateWriter.saveDebounced(state);
+  });
+
+  // session:stateChanged → save state debounced
+  sessionManager.on('session:stateChanged', () => {
+    const state = buildState(sessionManager);
+    stateWriter.saveDebounced(state);
   });
 
   // Bridge-level events: forward agent/critical/idle from all sessions
@@ -320,6 +514,15 @@ function wireEvents(
   });
 }
 
+// === State builder ===
+
+function buildState(sessionManager: DaemonSessionManager): DaemonState {
+  return {
+    version: 1,
+    sessions: sessionManager.listSessions(),
+  };
+}
+
 // === Graceful shutdown ===
 
 let shuttingDown = false;
@@ -328,6 +531,7 @@ async function shutdown(
   signal: string,
   sessionManager: DaemonSessionManager,
   pipeServer: DaemonPipeServer,
+  stateWriter: StateWriter,
   sessionPipes: Map<string, SessionPipe>,
   processMonitor: ProcessMonitor,
   watchdog: Watchdog,
@@ -357,8 +561,39 @@ async function shutdown(
   await Promise.all(pipeStops);
   sessionPipes.clear();
 
+  // Dump scrollback buffers and mark live sessions as suspended for recovery
+  const managedSessions = sessionManager.listManagedSessions();
+  stateWriter.ensureBufferDir();
+
+  const dumpPromises: Promise<void>[] = [];
+  for (const managed of managedSessions) {
+    if (managed.meta.state === 'dead') continue;
+
+    const dumpPath = stateWriter.getBufferDumpPath(managed.meta.id);
+    dumpPromises.push(
+      managed.ringBuffer.dumpToFile(dumpPath).then(() => {
+        managed.meta.state = 'suspended';
+        managed.meta.bufferDumpPath = dumpPath;
+        log('info', `Suspended session ${managed.meta.id} (buffer: ${managed.ringBuffer.size} bytes)`);
+      }).catch((err) => {
+        log('warn', `Failed to dump buffer for ${managed.meta.id}:`, err);
+        managed.meta.state = 'dead';
+      }),
+    );
+  }
+  await Promise.all(dumpPromises);
+
+  // Save suspended state BEFORE disposing
+  const suspendState: DaemonState = {
+    version: 1,
+    sessions: managedSessions.map((m) => ({ ...m.meta })),
+  };
+  stateWriter.saveImmediate(suspendState);
+
   // Dispose all sessions (kills PTYs, clears map)
   sessionManager.disposeAll();
+
+  stateWriter.dispose();
 
   // Stop IPC server
   await pipeServer.stop().catch(() => {});
@@ -384,6 +619,7 @@ async function main(): Promise<void> {
   log('info', `Config loaded (logLevel=${config.daemon.logLevel})`);
 
   // 3. Initialize modules
+  const stateWriter = new StateWriter(wmuxDir);
   const sessionManager = new DaemonSessionManager();
   sessionManager.setConfig(config);
   const pipeServer = new DaemonPipeServer(config.daemon.pipeName);
@@ -392,11 +628,14 @@ async function main(): Promise<void> {
   const sessionPipes = new Map<string, SessionPipe>();
   const sessionDataListeners = new Map<string, { bridge: import('./DaemonPTYBridge').DaemonPTYBridge; listener: (data: Buffer) => void }>();
 
-  // 4. Register RPC handlers
-  registerRpcHandlers(pipeServer, sessionManager, sessionPipes, processMonitor, startTime, sessionDataListeners, watchdog);
+  // 4. Recover previous sessions
+  await recoverSessions(stateWriter, sessionManager, processMonitor);
 
-  // 5. Wire events
-  wireEvents(sessionManager, pipeServer, sessionPipes, processMonitor, sessionDataListeners);
+  // 5. Register RPC handlers
+  registerRpcHandlers(pipeServer, sessionManager, stateWriter, sessionPipes, processMonitor, startTime, sessionDataListeners, watchdog);
+
+  // 6. Wire events
+  wireEvents(sessionManager, pipeServer, stateWriter, sessionPipes, processMonitor, sessionDataListeners);
 
   // 7. Start control pipe
   await pipeServer.start();
@@ -416,8 +655,14 @@ async function main(): Promise<void> {
       let reaped = 0;
       for (const managed of sessionManager.listManagedSessions()) {
         if (managed.meta.state !== 'dead') continue;
+        const bufPath = stateWriter.getBufferDumpPath(managed.meta.id);
+        try { if (fs.existsSync(bufPath)) fs.unlinkSync(bufPath); } catch { /* ignore */ }
         sessionManager.destroySession(managed.meta.id);
         reaped++;
+      }
+      if (reaped > 0) {
+        const state = buildState(sessionManager);
+        stateWriter.saveImmediate(state);
       }
       return reaped;
     },
@@ -442,29 +687,75 @@ async function main(): Promise<void> {
       const deadSince = new Date(managed.meta.lastActivity).getTime();
       const ttlMs = managed.meta.deadTtlHours * 60 * 60 * 1000;
       if (Date.now() - deadSince >= ttlMs) {
+        const bufPath = stateWriter.getBufferDumpPath(managed.meta.id);
+        try { if (fs.existsSync(bufPath)) fs.unlinkSync(bufPath); } catch { /* ignore */ }
         sessionManager.destroySession(managed.meta.id);
         reaped++;
       }
     }
     if (reaped > 0) {
       log('info', `Reaped ${reaped} expired dead session(s)`);
+      const state = buildState(sessionManager);
+      stateWriter.saveImmediate(state);
     }
   }, 60 * 60 * 1000); // Every hour
   reapInterval.unref();
 
+  // 8c. Periodic buffer snapshots (every 30s) — survives forced kills / power loss
+  // Also save sessions.json so recovery has up-to-date session metadata
+  const snapshotInterval = setInterval(() => {
+    const managed = sessionManager.listManagedSessions();
+    const live = managed.filter((m) => m.meta.state !== 'dead');
+    if (live.length === 0) return;
+
+    stateWriter.ensureBufferDir();
+    const dumps = live.map((m) => {
+      const dumpPath = stateWriter.getBufferDumpPath(m.meta.id);
+      return m.ringBuffer.dumpToFile(dumpPath).catch((err) => {
+        log('warn', `Snapshot dump failed for ${m.meta.id}:`, err);
+      });
+    });
+
+    // Save session metadata only after all buffer dumps complete (atomicity)
+    Promise.all(dumps).then(() => {
+      const state = buildState(sessionManager);
+      stateWriter.saveImmediate(state);
+    });
+  }, 30_000);
+  snapshotInterval.unref();
+
   // 9. Signal handlers
   const doShutdown = (sig: string) =>
-    shutdown(sig, sessionManager, pipeServer, sessionPipes, processMonitor, watchdog);
+    shutdown(sig, sessionManager, pipeServer, stateWriter, sessionPipes, processMonitor, watchdog);
 
   process.on('SIGTERM', () => doShutdown('SIGTERM'));
   process.on('SIGINT', () => doShutdown('SIGINT'));
 
   // Windows-specific: handle OS shutdown/logoff/restart.
+  // Detached Node processes on Windows don't receive SIGTERM on shutdown.
+  // 'beforeExit' won't fire either. We use the 'exit' event as a last-resort
+  // synchronous save, and also periodic state saves to minimize data loss.
   if (process.platform === 'win32') {
     process.on('exit', () => {
+      // Synchronous-only — dump what we can before process dies
       try {
-        sessionManager.disposeAll();
-        releaseLock();
+        const managed = sessionManager.listManagedSessions();
+        stateWriter.ensureBufferDir();
+        for (const m of managed) {
+          if (m.meta.state === 'dead') continue;
+          const dumpPath = stateWriter.getBufferDumpPath(m.meta.id);
+          try {
+            const data = m.ringBuffer.readAll();
+            fs.writeFileSync(dumpPath, data);
+            m.meta.state = 'suspended';
+            m.meta.bufferDumpPath = dumpPath;
+          } catch { /* best effort */ }
+        }
+        const suspendState: DaemonState = {
+          version: 1,
+          sessions: managed.map((m) => ({ ...m.meta })),
+        };
+        stateWriter.saveImmediate(suspendState);
       } catch { /* best effort */ }
     });
   }

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -1,9 +1,9 @@
 // === Daemon-specific type definitions ===
 
 /** Session lifecycle state */
-export type DaemonSessionState = 'detached' | 'attached' | 'dead';
+export type DaemonSessionState = 'detached' | 'attached' | 'dead' | 'suspended';
 
-/** Per-session metadata */
+/** Per-session metadata persisted to sessions.json */
 export interface DaemonSession {
   id: string;
   state: DaemonSessionState;
@@ -23,6 +23,13 @@ export interface DaemonSession {
   exitCode?: number | null;
   exitSignal?: string | null;
   deadTtlHours: number;
+  bufferDumpPath?: string;
+}
+
+/** Top-level schema for ~/.wmux/sessions.json */
+export interface DaemonState {
+  version: number;
+  sessions: DaemonSession[];
 }
 
 /** Daemon configuration (~/.wmux/config.json) */

--- a/src/main/ipc/handlers/session.handler.ts
+++ b/src/main/ipc/handlers/session.handler.ts
@@ -1,20 +1,56 @@
-import { ipcMain } from 'electron';
+import { ipcMain, app } from 'electron';
+import * as fs from 'fs';
+import * as path from 'path';
 import { IPC } from '../../../shared/constants';
+import { SessionManager } from '../../session/SessionManager';
+import type { SessionData } from '../../../shared/types';
+
+const sessionManager = new SessionManager();
 
 export function registerSessionHandlers(): () => void {
-  // Session save/load — no-op (daemon holds all state in memory)
   ipcMain.removeHandler(IPC.SESSION_SAVE);
-  ipcMain.handle(IPC.SESSION_SAVE, () => ({ success: true }));
+  ipcMain.handle(IPC.SESSION_SAVE, (_event, data: SessionData) => {
+    sessionManager.save(data);
+    return { success: true };
+  });
 
   ipcMain.removeHandler(IPC.SESSION_LOAD);
-  ipcMain.handle(IPC.SESSION_LOAD, () => null);
+  ipcMain.handle(IPC.SESSION_LOAD, () => {
+    return sessionManager.load();
+  });
 
-  // Scrollback persistence removed — daemon RingBuffer is the source of truth
+  // scrollback:dump — write terminal buffer to file
   ipcMain.removeHandler(IPC.SCROLLBACK_DUMP);
-  ipcMain.handle(IPC.SCROLLBACK_DUMP, () => ({ success: true }));
+  ipcMain.handle(IPC.SCROLLBACK_DUMP, (_event, surfaceId: string, content: string) => {
+    // Validate surfaceId (alphanumeric + hyphens only, prevent path traversal)
+    if (!/^[a-zA-Z0-9-]+$/.test(surfaceId)) return { success: false };
+    const dir = path.join(app.getPath('userData'), 'scrollback');
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const filePath = path.join(dir, `${surfaceId}.txt`);
+    // Cap at 5MB to prevent disk bloat
+    const capped = content.length > 5 * 1024 * 1024 ? content.slice(-5 * 1024 * 1024) : content;
+    fs.writeFileSync(filePath, capped, 'utf-8');
+    return { success: true };
+  });
 
+  // scrollback:load — read terminal buffer from file
   ipcMain.removeHandler(IPC.SCROLLBACK_LOAD);
-  ipcMain.handle(IPC.SCROLLBACK_LOAD, () => null);
+  ipcMain.handle(IPC.SCROLLBACK_LOAD, (_event, surfaceId: string) => {
+    if (!/^[a-zA-Z0-9-]+$/.test(surfaceId)) return null;
+    const filePath = path.join(app.getPath('userData'), 'scrollback', `${surfaceId}.txt`);
+    try {
+      if (!fs.existsSync(filePath)) return null;
+      const content = fs.readFileSync(filePath, 'utf-8');
+      // Don't delete scrollback files here — they are overwritten by the
+      // next periodic dump cycle (every 5s).  Deleting on load created a
+      // window where a crash between load and the next dump would lose
+      // all scrollback data because session.json still referenced the
+      // (now-deleted) file.
+      return content;
+    } catch {
+      return null;
+    }
+  });
 
   return () => {
     ipcMain.removeHandler(IPC.SESSION_SAVE);

--- a/src/main/session/SessionManager.ts
+++ b/src/main/session/SessionManager.ts
@@ -1,0 +1,102 @@
+import { app } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { SessionData } from '../../shared/types';
+
+export class SessionManager {
+  private filePath: string;
+  private tmpPath: string;
+  private bakPath: string;
+
+  constructor() {
+    this.filePath = path.join(app.getPath('userData'), 'session.json');
+    this.tmpPath = this.filePath + '.tmp';
+    this.bakPath = this.filePath + '.bak';
+  }
+
+  /**
+   * Atomic save: write to .tmp, backup existing to .bak, then rename .tmp → session.json.
+   * If the process crashes mid-write, only the .tmp file is corrupted;
+   * the original session.json (or .bak) remains intact.
+   */
+  save(data: SessionData): void {
+    try {
+      const dir = path.dirname(this.filePath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+
+      const json = JSON.stringify(data, null, 2);
+
+      // 1. Write to temporary file
+      fs.writeFileSync(this.tmpPath, json, 'utf-8');
+
+      // 2. Backup current session file (if it exists)
+      if (fs.existsSync(this.filePath)) {
+        try {
+          fs.renameSync(this.filePath, this.bakPath);
+        } catch (bakErr) {
+          console.warn('[SessionManager] Failed to create backup:', bakErr);
+          // Continue — saving is more important than backing up
+        }
+      }
+
+      // 3. Atomic rename: tmp → session.json
+      fs.renameSync(this.tmpPath, this.filePath);
+    } catch (err) {
+      console.error('[SessionManager] Failed to save session:', err);
+      // Clean up tmp file if it exists
+      try {
+        if (fs.existsSync(this.tmpPath)) fs.unlinkSync(this.tmpPath);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+  }
+
+  private validateSession(parsed: unknown): SessionData | null {
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !Array.isArray((parsed as Record<string, unknown>)['workspaces']) ||
+      typeof (parsed as Record<string, unknown>)['activeWorkspaceId'] !== 'string'
+    ) {
+      return null;
+    }
+    return parsed as SessionData;
+  }
+
+  private parseSessionFile(filePath: string): SessionData | null {
+    if (!fs.existsSync(filePath)) return null;
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw, (key, value) => {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') return undefined;
+      return value;
+    });
+    return this.validateSession(parsed);
+  }
+
+  load(): SessionData | null {
+    try {
+      const result = this.parseSessionFile(this.filePath);
+      if (result) return result;
+    } catch (err) {
+      console.error('[SessionManager] Failed to load primary session:', err);
+    }
+
+    // Primary missing, empty, corrupt, or failed schema — try backup
+    try {
+      console.warn('[SessionManager] Trying backup...');
+      const result = this.parseSessionFile(this.bakPath);
+      if (result) {
+        console.warn('[SessionManager] Recovered session from backup.');
+        return result;
+      }
+    } catch (bakErr) {
+      console.error('[SessionManager] Backup recovery also failed:', bakErr);
+    }
+
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
Add daemon-backed session persistence and recovery as a standalone feature.

## What this adds
- persist daemon session metadata to ~/.wmux/sessions.json
- persist periodic terminal buffer snapshots to ~/.wmux/buffers/*.buf
- recover live and suspended daemon sessions on startup
- restore renderer session/layout and scrollback IPC persistence
- reintroduce tests for StateWriter and ring buffer dump/load behavior

## Why
This is the daemon persistence/recovery functionality that was intentionally split out from the earlier security PR so it can be reviewed on its own.

## Verification
- npx tsc --noEmit
- npm test