### PR TITLE
Add winget publishing step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,3 +73,15 @@ jobs:
         shell: pwsh
         env:
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+          
+      - name: Publish to winget
+        if: env.WINGET_TOKEN != ''
+        continue-on-error: true
+        uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: openwong2kim.wmux
+          version: ${{ steps.pkg.outputs.version }}
+          installers-regex: '\.Setup\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a `Publish to winget` step to the release workflow so that future tag pushes automatically submit a PR to microsoft/winget-pkgs with the new version.

## Details

- Uses `vedantmgoyal2009/winget-releaser@v2`
- - Identifier: `openwong2kim.wmux`
- - Matches `*Setup.exe` assets from the GitHub Release
- - Gated by `env.WINGET_TOKEN != ''` and `continue-on-error: true` so the job does not fail if the token is missing
- - `v2.7.0` itself will still need a manual PR to winget-pkgs (submitted separately), since this automation takes effect from the next tag
## Required secret

A repository secret named `WINGET_TOKEN` must be added before the next release. It should be a GitHub Personal Access Token (classic) with `public_repo` scope (fine-grained: read/write access to a fork of microsoft/winget-pkgs).
