### PR TITLE
Use detected shells for default terminal selection

### DIFF
--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -24,6 +24,7 @@ import { useIpc } from '../../hooks/useIpc';
 import type { SessionData, PaneLeaf, Pane, Surface } from '../../../shared/types';
 import { Terminal } from '@xterm/xterm';
 import { terminalRegistry } from '../../hooks/useTerminal';
+import { withDefaultShell } from '../../utils/ptyCreateOptions';
 
 /** Map shell executable path to a human-readable display name. */
 function shellDisplayName(shellPath: string): string {
@@ -274,7 +275,9 @@ export default function AppLayout() {
             } else {
               console.log(`[AppLayout] Surface ${surface.id}: ptyId ${surface.ptyId} not in daemon, creating new PTY`);
               try {
-                const newPty = await window.electronAPI.pty.create({ cwd: surface.cwd, workspaceId: wsId });
+                const newPty = await window.electronAPI.pty.create(
+                  withDefaultShell({ cwd: surface.cwd, workspaceId: wsId }, useStore.getState().defaultShell)
+                );
                 useStore.getState().updateSurfacePtyId(pane.id, surface.id, newPty.id);
               } catch (err) {
                 console.error(`[AppLayout] Failed to create replacement PTY:`, err);
@@ -388,7 +391,9 @@ export default function AppLayout() {
 
     for (const leaf of emptyLeaves) {
       const paneId = leaf.id;
-      window.electronAPI.pty.create({ workspaceId: wsId }).then((result: { id: string; shell?: string; cwd?: string }) => {
+      window.electronAPI.pty.create(
+        withDefaultShell({ workspaceId: wsId }, useStore.getState().defaultShell)
+      ).then((result: { id: string; shell?: string; cwd?: string }) => {
         if (cancelled) {
           window.electronAPI.pty.dispose(result.id);
           return;

--- a/src/renderer/components/Palette/CommandPalette.tsx
+++ b/src/renderer/components/Palette/CommandPalette.tsx
@@ -3,6 +3,7 @@ import { useStore } from '../../stores';
 import PaletteItem, { type PaletteItemData, type PaletteCategory } from './PaletteItem';
 import { useT } from '../../hooks/useT';
 import { useIpc } from '../../hooks/useIpc';
+import { withDefaultShell } from '../../utils/ptyCreateOptions';
 
 // ---------------------------------------------------------------------------
 // SVG Icons (inline, no external dependency)
@@ -209,7 +210,7 @@ export default function CommandPalette() {
           const ws = state.workspaces.find((w) => w.id === state.activeWorkspaceId);
           if (ws) {
             void ipcInvoke<{ id: string }>(() =>
-              window.electronAPI.pty.create({ workspaceId: ws.id })
+              window.electronAPI.pty.create(withDefaultShell({ workspaceId: ws.id }, state.defaultShell))
             ).then((result) => {
               if (result.ok) {
                 useStore.getState().addSurface(ws.activePaneId, result.data.id, 'Terminal', '');

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -9,6 +9,7 @@ import BrowserPanel from '../Browser/BrowserPanel';
 import EditorPanel from '../Editor/EditorPanel';
 import SurfaceTabs from './SurfaceTabs';
 import { ErrorBoundary } from '../ErrorBoundary';
+import { withDefaultShell } from '../../utils/ptyCreateOptions';
 
 interface PaneProps {
   pane: PaneLeaf;
@@ -59,16 +60,17 @@ export default function PaneComponent({ pane, isActive, isWorkspaceVisible = tru
   }, [pane.id, pane.surfaces, setActivePane, markRead]);
 
   const activeWorkspaceId = useStore((s) => s.activeWorkspaceId);
+  const defaultShell = useStore((s) => s.defaultShell);
   const { invoke: ipcInvoke } = useIpc();
   const handleAddSurface = useCallback(async () => {
     const result = await ipcInvoke<{ id: string }>(() =>
-      window.electronAPI.pty.create({ workspaceId: activeWorkspaceId })
+      window.electronAPI.pty.create(withDefaultShell({ workspaceId: activeWorkspaceId }, defaultShell))
     );
     if (result.ok) {
       addSurface(pane.id, result.data.id, 'Terminal', '');
     }
     // On failure, useIpc already surfaced a toast. No-op here.
-  }, [pane.id, addSurface, activeWorkspaceId, ipcInvoke]);
+  }, [pane.id, addSurface, activeWorkspaceId, defaultShell, ipcInvoke]);
 
   const closePane = useStore((s) => s.closePane);
 

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -9,6 +9,7 @@ import type { CustomThemeColors } from '../../../shared/types';
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 type TabId = 'general' | 'appearance' | 'notifications' | 'shortcuts' | 'about';
+type ShellInfo = { name: string; path: string; args?: string[] };
 
 // ─── Icon components ──────────────────────────────────────────────────────────
 
@@ -181,12 +182,28 @@ function KbdRow({ keys, description }: { keys: string; description: string }) {
 
 // ─── Static config (product names — no translation needed) ───────────────────
 
-const SHELL_OPTIONS = [
-  { value: 'powershell', label: 'PowerShell' },
-  { value: 'cmd',        label: 'Command Prompt' },
-  { value: 'gitbash',   label: 'Git Bash' },
-  { value: 'wsl',        label: 'WSL' },
-];
+function resolveDefaultShellPath(current: string, shells: ShellInfo[]): string {
+  const existing = shells.find((shell) => shell.path === current);
+  if (existing) return existing.path;
+
+  const lower = current.toLowerCase();
+  const basename = (shell: ShellInfo) => shell.path.replace(/\\/g, '/').split('/').pop()?.toLowerCase() || '';
+
+  if (lower === 'powershell') {
+    return shells.find((shell) => basename(shell) === 'powershell.exe')?.path || shells[0].path;
+  }
+  if (lower === 'cmd') {
+    return shells.find((shell) => basename(shell) === 'cmd.exe')?.path || shells[0].path;
+  }
+  if (lower === 'gitbash') {
+    return shells.find((shell) => shell.name === 'Git Bash')?.path || shells[0].path;
+  }
+  if (lower === 'wsl') {
+    return shells.find((shell) => basename(shell) === 'wsl.exe')?.path || shells[0].path;
+  }
+
+  return shells[0].path;
+}
 
 const FONT_FAMILY_OPTIONS = [
   { value: 'Cascadia Code',    label: 'Cascadia Code' },
@@ -401,11 +418,30 @@ function TabGeneral() {
   const scrollbackLines = useStore((s) => s.scrollbackLines);
   const setScrollbackLines = useStore((s) => s.setScrollbackLines);
   const autoUpdateEnabled = useStore((s) => s.autoUpdateEnabled);
+  const [detectedShells, setDetectedShells] = useState<ShellInfo[]>([]);
   const storeSetAutoUpdate = useStore((s) => s.setAutoUpdateEnabled);
   const setAutoUpdateEnabled = (enabled: boolean) => {
     storeSetAutoUpdate(enabled);
     window.electronAPI.settings.setAutoUpdateEnabled(enabled);
   };
+  const shellOptions = detectedShells.map((shell) => ({ value: shell.path, label: shell.name }));
+
+  useEffect(() => {
+    let cancelled = false;
+    window.electronAPI.shell.list()
+      .then((shells) => {
+        if (cancelled) return;
+        setDetectedShells(shells);
+        const shellPaths = new Set(shells.map((shell) => shell.path));
+        if (shells.length > 0 && !shellPaths.has(useStore.getState().defaultShell)) {
+          setDefaultShell(resolveDefaultShellPath(useStore.getState().defaultShell, shells));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setDetectedShells([]);
+      });
+    return () => { cancelled = true; };
+  }, [setDefaultShell]);
 
   return (
     <div className="flex flex-col gap-4">
@@ -439,7 +475,7 @@ function TabGeneral() {
             label={t('settings.defaultShell')}
             value={defaultShell}
             onChange={setDefaultShell}
-            options={SHELL_OPTIONS}
+            options={shellOptions}
           />
         </SettingRow>
         <SettingRow label={t('settings.scrollbackLines')} description={t('settings.scrollbackDesc')}>

--- a/src/renderer/components/Terminal/FloatingPane.tsx
+++ b/src/renderer/components/Terminal/FloatingPane.tsx
@@ -2,11 +2,13 @@ import { useRef, useEffect, useCallback } from 'react';
 import { useTerminal } from '../../hooks/useTerminal';
 import { useStore } from '../../stores';
 import { useT } from '../../hooks/useT';
+import { withDefaultShell } from '../../utils/ptyCreateOptions';
 import '@xterm/xterm/css/xterm.css';
 
 export default function FloatingPane() {
   const floatingPaneVisible = useStore((s) => s.floatingPaneVisible);
   const floatingPanePtyId = useStore((s) => s.floatingPanePtyId);
+  const defaultShell = useStore((s) => s.defaultShell);
   const toggleFloatingPane = useStore((s) => s.toggleFloatingPane);
   const setFloatingPanePtyId = useStore((s) => s.setFloatingPanePtyId);
   const t = useT();
@@ -21,13 +23,13 @@ export default function FloatingPane() {
     if (creatingRef.current) return;
 
     creatingRef.current = true;
-    window.electronAPI.pty.create({}).then((result: { id: string }) => {
+    window.electronAPI.pty.create(withDefaultShell({}, defaultShell)).then((result: { id: string }) => {
       setFloatingPanePtyId(result.id);
       creatingRef.current = false;
     }).catch(() => {
       creatingRef.current = false;
     });
-  }, [floatingPaneVisible, floatingPanePtyId, setFloatingPanePtyId]);
+  }, [defaultShell, floatingPaneVisible, floatingPanePtyId, setFloatingPanePtyId]);
 
   useTerminal(containerRef, {
     ptyId: floatingPanePtyId,

--- a/src/renderer/components/Terminal/Terminal.tsx
+++ b/src/renderer/components/Terminal/Terminal.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import { useTerminal, type ContextMenuEvent } from '../../hooks/useTerminal';
 import { useStore } from '../../stores';
 import { useIpc } from '../../hooks/useIpc';
+import { withDefaultShell } from '../../utils/ptyCreateOptions';
 import ViCopyMode from './ViCopyMode';
 import SearchBar from './SearchBar';
 import BookmarkIndicator from './BookmarkIndicator';
@@ -98,9 +99,10 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
     }
 
     const workspaceId = useStore.getState().activeWorkspaceId;
+    const defaultShell = useStore.getState().defaultShell;
     console.log(`[Terminal] Creating new PTY: shell=${shell}, cwd=${cwd}, cols=${cols}, rows=${rows}, ws=${workspaceId}`);
     void ipcInvokeRef.current<{ id: string }>(() =>
-      window.electronAPI.pty.create({ shell, cwd, cols, rows, workspaceId })
+      window.electronAPI.pty.create(withDefaultShell({ shell, cwd, cols, rows, workspaceId }, defaultShell))
     ).then((result) => {
       if (!result.ok) {
         // Toast surfaced by useIpc (e.g. DAEMON_DISCONNECTED). Nothing to do.

--- a/src/renderer/hooks/useKeyboard.ts
+++ b/src/renderer/hooks/useKeyboard.ts
@@ -3,6 +3,7 @@ import { useStore } from '../stores';
 import { findLeaf } from '../../shared/paneUtils';
 import { terminalRegistry } from './useTerminal';
 import { t } from '../i18n';
+import { withDefaultShell } from '../utils/ptyCreateOptions';
 
 // Lightweight bookmark toast — reuses the same DOM element pattern as showCopyToast
 let bookmarkToastTimer: ReturnType<typeof setTimeout> | null = null;
@@ -264,7 +265,7 @@ export function useKeyboard() {
         const state = store.getState();
         const ws = state.workspaces.find((w) => w.id === state.activeWorkspaceId);
         if (ws) {
-          window.electronAPI.pty.create({ workspaceId: ws.id }).then((result: { id: string }) => {
+          window.electronAPI.pty.create(withDefaultShell({ workspaceId: ws.id }, state.defaultShell)).then((result: { id: string }) => {
             store.getState().addSurface(ws.activePaneId, result.id, 'Terminal', '');
           });
         }

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useStore } from '../stores';
+import { withDefaultShell } from '../utils/ptyCreateOptions';
 import type { Pane, PaneLeaf, Surface } from '../../shared/types';
 import { validateMessage } from '../../shared/types';
 import type { Message, Part, TaskState, Artifact, AgentSkill } from '../../shared/types';
@@ -182,7 +183,9 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
 
     let ptyId: string;
     try {
-      const created = await window.electronAPI.pty.create({ workspaceId: newWsId });
+      const created = await window.electronAPI.pty.create(
+        withDefaultShell({ workspaceId: newWsId }, useStore.getState().defaultShell)
+      );
       ptyId = created.id;
     } catch (err) {
       // Roll back: remove the empty workspace so we don't leave orphans.
@@ -252,7 +255,7 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     const cwd = typeof params.cwd === 'string' ? params.cwd : '';
 
     const { id: ptyId } = await window.electronAPI.pty.create({
-      shell: shell || undefined,
+      ...withDefaultShell({ shell: shell || undefined }, store.defaultShell),
       cwd: cwd || undefined,
       workspaceId: ws.id,
     });

--- a/src/renderer/utils/__tests__/ptyCreateOptions.test.ts
+++ b/src/renderer/utils/__tests__/ptyCreateOptions.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { withDefaultShell } from '../ptyCreateOptions';
+
+describe('withDefaultShell', () => {
+  it('uses the stored detected shell path when no shell is specified', () => {
+    expect(withDefaultShell({ workspaceId: 'ws-1' }, 'C:\\Program Files\\PowerShell\\7\\pwsh.exe')).toEqual({
+      workspaceId: 'ws-1',
+      shell: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+    });
+  });
+
+  it('keeps an explicitly requested shell', () => {
+    expect(withDefaultShell({ shell: 'cmd.exe' }, 'C:\\Program Files\\PowerShell\\7\\pwsh.exe')).toEqual({
+      shell: 'cmd.exe',
+    });
+  });
+
+  it('does not pass legacy setting aliases as executable shell values', () => {
+    expect(withDefaultShell({ workspaceId: 'ws-1' }, 'powershell')).toEqual({
+      workspaceId: 'ws-1',
+    });
+  });
+});

--- a/src/renderer/utils/ptyCreateOptions.ts
+++ b/src/renderer/utils/ptyCreateOptions.ts
@@ -1,0 +1,24 @@
+export interface PtyCreateOptions {
+  shell?: string;
+  cwd?: string;
+  cols?: number;
+  rows?: number;
+  workspaceId?: string;
+  surfaceId?: string;
+}
+
+const LEGACY_DEFAULT_SHELL_VALUES = new Set(['powershell', 'cmd', 'gitbash', 'wsl']);
+
+function isExecutableShellValue(shell: string | undefined): shell is string {
+  if (!shell) return false;
+  if (LEGACY_DEFAULT_SHELL_VALUES.has(shell)) return false;
+  return shell.includes('\\') || shell.includes('/') || shell.toLowerCase().endsWith('.exe');
+}
+
+export function withDefaultShell<T extends PtyCreateOptions>(
+  options: T,
+  defaultShell: string | undefined,
+): T & { shell?: string } {
+  if (options.shell || !isExecutableShellValue(defaultShell)) return options;
+  return { ...options, shell: defaultShell };
+}


### PR DESCRIPTION
## Summary
- Populate the default shell dropdown from the detected shell list instead of static aliases
- Store detected executable paths and migrate legacy shell aliases to detected paths
- Apply the selected default shell across renderer PTY creation entrypoints

## Verification
- node .\\node_modules\\typescript\\bin\\tsc --noEmit
- npm test