### PR TITLE
feat(cross-platform): batch 2C — wmux mcp CLI + brew detector + macOS error wire-up + SMAppService research

### DIFF
--- a/docs/macos-autostart.md
+++ b/docs/macos-autostart.md
@@ -1,0 +1,275 @@
+# macOS Auto-Start (Login Item) — Research
+
+> Status: research only, no code yet. Consumed by the future
+> `src/main/autostart/macos.ts` implementation in a later cross-platform
+> porting batch.
+>
+> Author context: Outside Voice T5 raised that the wmux cross-platform
+> plan calls `app.setLoginItemSettings({ openAtLogin: true, openAsHidden: true })`
+> on macOS, but `SMLoginItemSetEnabled` was deprecated in macOS 13 (Ventura)
+> in favour of `SMAppService` + an in-bundle helper. This document resolves
+> that concern and recommends a path before any code lands.
+>
+> Date: 2026-04-28. Researcher worked from Windows; no macOS hardware
+> validation was performed. Items requiring on-device validation are flagged
+> in the "Open questions" section.
+
+## Background
+
+wmux currently depends on `electron@41.0.3` (released 2026-03-11). The
+upstream cross-platform plan for macOS is to call:
+
+```ts
+app.setLoginItemSettings({ openAtLogin: true, openAsHidden: true })
+```
+
+Two facts make that call non-trivial on modern macOS:
+
+1. `SMLoginItemSetEnabled` (the framework wmux/Electron historically used
+   under the hood) is deprecated as of macOS 13. Apple replaced it with
+   `SMAppService`, which can either treat the **main app bundle itself** as
+   the login item (`SMAppService.mainApp`) or load a nested **helper app
+   bundle** at `Contents/Library/LoginItems/Helper.app/`
+   (`SMAppService.loginItem(identifier:)`).
+2. The `openAsHidden` boolean is explicitly documented by Electron as
+   *"This does not work on macOS 13 and up."* The Electron API reference
+   also notes the same for `wasOpenedAsHidden` and `restoreState`. ([Electron app docs][electron-app])
+
+The good news is that Electron migrated `app.{set|get}LoginItemSettings`
+to `SMAppService` in [PR #37244][pr-37244], merged on 2023-10-16 and
+shipped in **Electron 29**. wmux is on Electron 41, so we get the modern
+implementation for free — provided we accept the deprecations above and
+provided the app is **signed and notarized**.
+
+## Findings
+
+### Electron 41 `app.setLoginItemSettings` — what it actually does on macOS
+
+I read the current Electron source on `main` (which matches the v29+
+branch behaviour) to confirm exactly which native API gets called.
+
+In `shell/browser/browser_mac.mm`, `Browser::SetLoginItemSettings`
+branches on `@available(macOS 13, *)`:
+
+- **macOS 13+ path** calls `platform_util::SetLoginItemEnabled(type,
+  service_name, open_at_login)` after migrating any old
+  `LSSharedFileList` registration off the deprecated API.
+- **Pre-13 path** still uses `base::mac::AddToLoginItems` /
+  `RemoveFromLoginItems`, which wraps `LSSharedFileList`.
+
+In `shell/common/platform_util_mac.mm`, the `type` string maps directly to
+`SMAppService` constructors:
+
+```objc
+// Confirmed in electron/electron@main, shell/common/platform_util_mac.mm
+if (type == "mainAppService")     return [SMAppService mainAppService];
+else if (type == "agentService")  return [SMAppService agentServiceWithPlistName:service_name];
+else if (type == "daemonService") return [SMAppService daemonServiceWithPlistName:service_name];
+else if (type == "loginItemService")
+  return [SMAppService loginItemServiceWithIdentifier:service_name];
+```
+
+So on Electron 41 + macOS 13+:
+
+| Caller code | Underlying native call |
+|---|---|
+| `setLoginItemSettings({ openAtLogin: true })` (default `type: 'mainAppService'`) | `[[SMAppService mainAppService] registerAndReturnError:...]` |
+| `setLoginItemSettings({ openAtLogin: true, type: 'loginItemService', serviceName: 'com.wmux.helper' })` | `[[SMAppService loginItemServiceWithIdentifier:@"com.wmux.helper"] register...]` |
+
+`mainAppService` does **not** require a helper bundle — the main `.app`
+itself is what gets registered. This is the central insight that changes
+the cost analysis below.
+
+Behavioural notes from issues / PRs / community:
+
+- **Signing + notarization is effectively required.** In Electron issue
+  [#45672][issue-45672], maintainers and other contributors reproduced the
+  "doesn't work on macOS 15" report and concluded that the new
+  `SMAppService` path silently fails for unsigned/un-notarized apps.
+  Quote from the thread (nikwen, 2025-02): *"I just tested on Electron
+  v34.2.0. Everything works flawlessly if the application is signed and
+  notarized."* Older `LSSharedFileList`-based Electron versions (≤ 28)
+  worked without signing; the new API is stricter.
+- **`openAsHidden` is silently dropped.** Per Electron docs and issue
+  [#37228][issue-37228], the field is preserved in object form but has no
+  effect on macOS 13+. To launch hidden, the app must check at startup
+  whether it was launched-at-login (e.g. via the absence of dock
+  activation / inspecting `process.argv` for a launch-at-login marker)
+  and call `app.dock.hide()` itself.
+- **MAS parity.** PR #37244 explicitly unifies MAS and non-MAS builds on
+  `SMAppService`, closing [#37560][issue-37560]. We don't ship to MAS
+  today, but if we ever do, the same code path applies.
+
+Sources: [Electron app.setLoginItemSettings docs][electron-app],
+[PR #37244][pr-37244], `electron/electron` source files
+`shell/browser/browser_mac.mm` and `shell/common/platform_util_mac.mm`
+on `main` (read 2026-04-28 via `gh api`).
+
+### SMAppService API — what it actually requires
+
+There are three relevant `SMAppService` constructors. wmux only cares
+about two of them (`mainAppService` and `loginItemService`); daemon /
+agent are out of scope.
+
+**`SMAppService.mainApp` (Electron `type: 'mainAppService'`)**
+
+- **Helper bundle:** none. The main `.app` is the login item.
+- **Info.plist:** no extra keys. Standard `CFBundleIdentifier`,
+  `CFBundleExecutable` etc. that Electron Forge already produces.
+- **Code:** Apple's recommended Swift snippet is `try
+  SMAppService.mainApp.register()` / `unregister()` / read
+  `SMAppService.mainApp.status`. Electron wraps all of this. ([nilcoalescing][nilcoalescing])
+- **User experience on first enable:** macOS shows a system notification
+  *"“wmux” Added to Login Items"* with a "Open Login Items
+  Settings…" button. The user can disable it from
+  System Settings → General → Login Items → "Open at Login" list (and
+  also from "Allow in the Background"). If the user disables it there,
+  `status` flips to `.requiresApproval` and re-registering re-prompts.
+- **Signing / notarization:** required in practice (see above).
+- **Availability:** macOS 13.0+. Older macOS still falls through to
+  Electron's `LSSharedFileList` path.
+
+**`SMAppService.loginItem(identifier:)` (Electron `type: 'loginItemService'`)**
+
+- **Helper bundle:** required, **nested inside the main `.app`**:
+  ```
+  wmux.app/
+    Contents/
+      Library/
+        LoginItems/
+          wmux-launcher.app/        <-- nested .app
+            Contents/
+              Info.plist            <-- CFBundleIdentifier = "com.wmux.launcher"
+              MacOS/
+                wmux-launcher       <-- tiny native binary that re-launches main app
+  ```
+- **Identifier passed to the API is the *bundle ID* of the helper**, not
+  a plist filename. This contradicts older Apple docs and is clarified by
+  Apple DTS engineer Quinn in [Apple Forums thread 719862][apple-forum-719862]
+  (filed as Apple radar FB11786569).
+- **Helper Info.plist must include** at minimum `CFBundleIdentifier`,
+  `CFBundleExecutable`, `CFBundlePackageType` (`APPL`), and almost
+  always `LSUIElement = YES` (so the helper has no dock icon /
+  no menu bar). ([theevilbit blog][theevilbit])
+- **Code signing:** the helper must be signed with the same Team ID as
+  the main app, and the helper must be notarized as part of the main
+  bundle. electron-builder does not have a first-class option for nested
+  `.app` bundles in `Contents/Library/LoginItems/` (the existing
+  `helperBundleId` family of options refer to Chromium's GPU/Renderer
+  helpers, not login-item helpers). It can be done via `extraFiles` plus
+  custom `afterSign` / `afterPack` hooks, but it is non-trivial and
+  unusual for the JS/Electron ecosystem. ([electron-builder mac docs][eb-mac])
+- **No off-the-shelf npm wrapper.** I searched npm + GitHub for community
+  modules that ship a prebuilt `SMAppService.loginItem` helper for
+  Electron and found none as of 2026-04. Closest analogue is Sindre's
+  Swift-only `LaunchAtLogin` (and its now-retired
+  `LaunchAtLogin-Legacy`), which is not Electron-friendly. The Rust
+  community has `smappservice-rs`, also not directly useful from
+  Electron.
+
+Sources: [Apple SMAppService][apple-smappservice],
+[Apple `loginItem(identifier:)`][apple-loginitem],
+[Apple Forums 719862 — Quinn][apple-forum-719862],
+[theevilbit blog][theevilbit],
+[electron-builder MacConfiguration][eb-mac].
+
+## Options
+
+| Option | Effort | Stability | UX | Recommendation |
+|---|---|---|---|---|
+| **A: `app.setLoginItemSettings({ openAtLogin: true })` as-is (default `mainAppService`)** | **Low** (already in plan) | **Future-proof** — Electron already routes through `SMAppService.mainApp` on macOS 13+. The deprecated `openAsHidden` field is silently ignored, but the actual login-item registration is on the modern API. | Same one-toggle UX as Windows/Linux. macOS shows a one-time "Added to Login Items" notification on first enable. "Launch hidden" must be implemented separately by the app (check launch reason at startup, call `app.dock.hide()`). | **Recommended for v3.x macOS GA.** |
+| **B: Nested helper `.app` + `loginItemService`** | **High** (~3–5 engineering days incl. Forge build hooks, helper binary, signing wiring, on-device validation, troubleshooting first-run approval flow) | Future-proof, but adds a moving part (the helper binary) that must be kept signed/notarized in lockstep with the main app. | Slightly cleaner "background only" semantics — the helper can launch headlessly and decide whether to surface the main app. Tradeoff: extra entry in System Settings → Login Items. | Not recommended unless we discover a concrete gap with Option A (e.g. main-app launch is too slow to be a login item, or user complaints about the dock-flash on startup). Revisit only if needed. |
+| **C: Skip auto-start on macOS at first ship; document manual instructions** | **None** | N/A | Worse than Win/Linux parity; users have to add wmux to Login Items themselves via System Settings. | Acceptable interim if signing+notarization isn't ready by ship-day; otherwise inferior to A. |
+
+### Why not Option B
+
+The "wmux plan needs a helper bundle" framing in T5's outside voice is
+based on the older `SMLoginItemSetEnabled` model where a helper was
+mandatory. Under modern `SMAppService`, the helper is one of two
+available shapes, not the only shape — and `mainApp` (which Electron
+calls by default) does not need one. The cost of B is real (Forge build
+pipeline changes, native helper binary, signing wiring, additional
+notarization surface, additional approval prompt to explain to users)
+and the benefit is small for a tray-resident app like wmux.
+
+## Recommended Path
+
+**Adopt Option A.** Concrete work items to add to the next porting batch:
+
+1. **`src/main/autostart/macos.ts`** — call
+   `app.setLoginItemSettings({ openAtLogin: enabled })` (omit
+   `openAsHidden` entirely on macOS to avoid passing a no-op flag; do
+   not pass `type` so we get the default `mainAppService`). Read state
+   back via `app.getLoginItemSettings().openAtLogin`. Treat
+   `status === 'requires-approval'` as "user disabled it in System
+   Settings — show a one-line hint linking to System Settings if they
+   re-enable from inside wmux."
+2. **Launch-hidden replacement** — at startup, if the process was
+   launched as a login item (Electron exposes
+   `app.getLoginItemSettings().wasOpenedAtLogin`, but that field is
+   *also* deprecated on macOS 13+; safer to detect via
+   `process.argv.includes('--hidden')` passed by the autostart wiring or
+   via `app.dock.isVisible()` heuristic), call `app.dock.hide()` before
+   the first window opens. Validate on hardware before claiming parity.
+3. **Signing + notarization gate in CI** — the macOS auto-start feature
+   silently fails for unsigned/un-notarized builds. Add a release
+   checklist item: "`pnpm dist:mac` artifact must pass `spctl
+   --assess` and `stapler validate` before publishing." Tracking issue
+   pre-condition for the macOS port shipping.
+4. **First-run approval UX** — after the first time wmux calls
+   `setLoginItemSettings({ openAtLogin: true })`, macOS shows its own
+   notification. We do not need to ship an in-app modal, but the
+   Settings → Startup screen should display the live status returned by
+   `getLoginItemSettings()` so the user can see if they later disabled
+   it from System Settings.
+5. **Docs** — add to user-facing release notes: *"On macOS, enabling
+   Launch at Login adds wmux to System Settings → General → Login Items.
+   You can disable it there at any time."*
+
+Defer Option B unless on-device testing surfaces a concrete blocker that
+`mainAppService` cannot solve.
+
+## Open questions (require macOS hardware to settle)
+
+- **Notarized launch-hidden behaviour.** Confirm that, with no window
+  shown and `app.dock.hide()` called early, wmux launches into the tray
+  silently with no dock flash on macOS 14 and 15.
+- **`wasOpenedAtLogin` reliability on Electron 41.** Apple removed the
+  underlying signal in macOS 13. Test whether Electron still fills this
+  field for default `mainAppService` registrations, or whether we need
+  an explicit `--hidden` arg passed by something we control.
+- **Migration from old API.** Any pre-v3 macOS install that registered
+  via the legacy API will be migrated by Electron's `RemoveFromLoginItems`
+  call before re-registering on the new one. Verify that this round-trip
+  doesn't trigger a duplicate "Added to Login Items" notification.
+- **Apple-Silicon first-run delay.** Some community reports note a 1–2 s
+  initialisation delay on the first SMAppService registration. Worth
+  confirming with QA that this doesn't visibly stall the Settings
+  toggle.
+
+## References
+
+- [Electron — `app.setLoginItemSettings` API docs][electron-app] — primary doc, lists the new `type` / `serviceName` params and the `openAsHidden` deprecation.
+- [Electron PR #37244 — feat: update `app.{set|get}LoginItemSettings`][pr-37244] — the migration PR (merged 2023-10-16, shipped in Electron 29). Wmux is on Electron 41 ⇒ we get this for free.
+- `electron/electron` source on `main` — `shell/browser/browser_mac.mm` (`Browser::SetLoginItemSettings`) and `shell/common/platform_util_mac.mm` (`GetServiceForType`, `SetLoginItemEnabled`). Read via `gh api ... .raw` on 2026-04-28.
+- [Electron issue #45672 — setLoginItemSettings openAtLogin not working on macOS][issue-45672] — confirms the new path requires signing + notarization (resolved as "WAI, app must be signed").
+- [Electron issue #37228 — `openAsHidden` not respected on Ventura][issue-37228] — closed as not planned; the field is intentionally a no-op on macOS 13+.
+- [Electron issue #37560 — MAS build][issue-37560] — closed by PR #37244, MAS now uses the same SMAppService path.
+- [Apple — `SMAppService` class reference][apple-smappservice]
+- [Apple — `SMAppService.loginItem(identifier:)`][apple-loginitem]
+- [Apple Developer Forums #719862 — Quinn on registering login items][apple-forum-719862] — clarifies that the parameter is the helper *bundle ID*, helper lives at `Caller.app/Contents/Library/LoginItems/Helper.app/`, and `.notFound` is the normal first-time status.
+- [theevilbit — macOS Service Management quick notes][theevilbit] — practical walkthrough of `SMAppService` registration, status flow, and approval requirement.
+- [Costello — Add launch at login setting to a macOS app][nilcoalescing] — minimal `SMAppService.mainApp` Swift example; corroborates that no helper bundle is needed for `mainApp`.
+- [electron-builder — Mac configuration][eb-mac] — confirms there is no first-class option for `Contents/Library/LoginItems/*.app` nested helper bundles; Option B would need custom `afterPack` hooks.
+
+[electron-app]: https://www.electronjs.org/docs/latest/api/app
+[pr-37244]: https://github.com/electron/electron/pull/37244
+[issue-45672]: https://github.com/electron/electron/issues/45672
+[issue-37228]: https://github.com/electron/electron/issues/37228
+[issue-37560]: https://github.com/electron/electron/issues/37560
+[apple-smappservice]: https://developer.apple.com/documentation/servicemanagement/smappservice
+[apple-loginitem]: https://developer.apple.com/documentation/servicemanagement/smappservice/loginitem(identifier:)
+[apple-forum-719862]: https://developer.apple.com/forums/thread/719862
+[theevilbit]: https://theevilbit.github.io/posts/smappservice/
+[nilcoalescing]: https://nilcoalescing.com/blog/LaunchAtLoginSetting/
+[eb-mac]: https://www.electron.build/mac.html

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1,0 +1,363 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * `wmux mcp …` — inspect / manage Claude Code MCP registration without
+ * touching the running wmux daemon. Reading and editing `~/.claude.json`
+ * directly means the user can verify the integration even when the GUI app
+ * is not running, which matches the DX-D4 decision (CLI as a one-line
+ * verification path; Settings panel as the GUI parity).
+ *
+ * NOTE (cross-platform): currently uses `~/.claude.json` on every OS. macOS
+ * Claude Desktop may use `~/Library/Application Support/Claude/` instead —
+ * macOS verification pending — see plan Phase 1.17 prereq. Do NOT add the
+ * macOS-specific path speculatively here; ship that as a separate change
+ * once empirically verified.
+ */
+
+const HELP_TEXT = `
+wmux mcp — inspect / manage Claude Code MCP registration
+
+USAGE
+  wmux mcp <subcommand> [--json]
+
+SUBCOMMANDS
+  check        Show whether wmux + wmux-a2a MCP servers are registered.
+  register     Add wmux + wmux-a2a entries to ~/.claude.json (no-daemon).
+               Note: written paths point at this CLI's own bundle layout — for
+               a GUI re-register that uses the running app's resolved paths,
+               use Settings → General → MCP → Re-register.
+  unregister   Remove the wmux + wmux-a2a keys from ~/.claude.json.
+               Other MCP entries are left untouched.
+
+GLOBAL FLAGS
+  --json       Output raw JSON (useful for scripting).
+`.trimStart();
+
+function getClaudeJsonPath(): string {
+  return path.join(os.homedir(), '.claude.json');
+}
+
+interface ServerStatus {
+  registered: boolean;
+  path: string | null;
+}
+
+interface CheckResult {
+  wmux: ServerStatus;
+  wmuxA2a: ServerStatus;
+  configPath: string;
+  configExists: boolean;
+  /** ISO 8601 string, or null when the config file does not exist. */
+  configModified: string | null;
+}
+
+function extractScriptPath(entry: unknown): string | null {
+  if (!entry || typeof entry !== 'object') return null;
+  const args = (entry as { args?: unknown }).args;
+  if (!Array.isArray(args) || args.length === 0) return null;
+  const first = args[0];
+  return typeof first === 'string' && first.length > 0 ? first : null;
+}
+
+/**
+ * Read `~/.claude.json` and report which wmux MCP keys are present. Pure read
+ * — never creates the file. Corrupted / partial JSON yields "not registered"
+ * rather than throwing, mirroring `McpRegistrar.getStatus()` semantics.
+ */
+function checkStatus(): CheckResult {
+  const configPath = getClaudeJsonPath();
+  let configExists = false;
+  let configModified: string | null = null;
+  try {
+    const stat = fs.statSync(configPath);
+    configExists = stat.isFile();
+    configModified = configExists ? stat.mtime.toISOString() : null;
+  } catch {
+    configExists = false;
+  }
+
+  let wmuxPath: string | null = null;
+  let a2aPath: string | null = null;
+  if (configExists) {
+    try {
+      const raw = fs.readFileSync(configPath, 'utf8');
+      const config = JSON.parse(raw, (key, value) => {
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') return undefined;
+        return value;
+      }) as { mcpServers?: Record<string, unknown> };
+      const servers = config && typeof config === 'object' ? config.mcpServers : null;
+      if (servers && typeof servers === 'object') {
+        wmuxPath = extractScriptPath(servers['wmux']);
+        a2aPath = extractScriptPath(servers['wmux-a2a']);
+      }
+    } catch {
+      // Malformed JSON — treat as not-registered.
+    }
+  }
+
+  return {
+    wmux: { registered: wmuxPath !== null, path: wmuxPath },
+    wmuxA2a: { registered: a2aPath !== null, path: a2aPath },
+    configPath,
+    configExists,
+    configModified,
+  };
+}
+
+function formatModified(iso: string | null): string {
+  if (!iso) return 'does not exist';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  // YYYY-MM-DD HH:MM (local time) — readable, no locale-specific commas.
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return (
+    `modified ${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+    `${pad(d.getHours())}:${pad(d.getMinutes())}`
+  );
+}
+
+function printCheck(result: CheckResult, jsonMode: boolean): void {
+  if (jsonMode) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  const fmt = (status: ServerStatus): string =>
+    status.registered ? `registered → ${status.path}` : 'NOT REGISTERED';
+
+  console.log(`wmux:        ${fmt(result.wmux)}`);
+  console.log(`wmux-a2a:    ${fmt(result.wmuxA2a)}`);
+  if (result.configExists) {
+    console.log(`config file: ${result.configPath} (${formatModified(result.configModified)})`);
+  } else {
+    console.log(`config file: ${result.configPath} (does not exist)`);
+  }
+  if (!result.wmux.registered || !result.wmuxA2a.registered) {
+    console.log('Run `wmux mcp register` to enable Claude Code integration.');
+  }
+}
+
+/**
+ * Find the bundled MCP scripts when this CLI is invoked from a packaged
+ * install. The CLI bundle lives in `dist/cli-bundle/index.js` next to
+ * `dist/mcp-bundle/index.js` (or in the legacy `dist/mcp/mcp/index.js`
+ * layout). Returns null when neither candidate exists, in which case the
+ * caller should advise the user to use the GUI Re-register button instead.
+ */
+function findScript(candidateRelative: string[]): string | null {
+  // Walk up from the bundled CLI's directory looking for the candidate path.
+  let dir = __dirname;
+  for (let i = 0; i < 6; i++) {
+    for (const rel of candidateRelative) {
+      const candidate = path.join(dir, rel);
+      if (fs.existsSync(candidate)) return candidate;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+interface RegisterOutcome {
+  configPath: string;
+  wmuxScript: string | null;
+  a2aScript: string | null;
+  /** Keys this command actually wrote, e.g. ['wmux', 'wmux-a2a']. */
+  wrote: string[];
+  /** Warning shown when no script could be located. */
+  warning: string | null;
+}
+
+/**
+ * Atomic write — same pattern as McpRegistrar.writeJson — so a partial write
+ * can never leave Claude Code with an unparseable config file.
+ */
+function writeJsonAtomic(filePath: string, data: unknown): void {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const tmp = filePath + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', 'utf8');
+  fs.renameSync(tmp, filePath);
+}
+
+function registerEntries(): RegisterOutcome {
+  const configPath = getClaudeJsonPath();
+  // CLI-side script discovery: try the packaged dist layouts. When wmux is run
+  // from source dev mode the GUI registers the dev paths on first launch, so
+  // this branch only matters for CLI-only / no-GUI flows.
+  const wmuxScript = findScript([
+    path.join('mcp-bundle', 'index.js'),
+    path.join('dist', 'mcp-bundle', 'index.js'),
+    path.join('dist', 'mcp', 'mcp', 'index.js'),
+  ]);
+  const a2aScript = findScript([
+    path.join('a2a-bundle', 'index.js'),
+    path.join('dist', 'a2a-bundle', 'index.js'),
+    path.join('dist', 'mcp', 'mcp', 'a2a', 'index.js'),
+  ]);
+
+  if (!wmuxScript && !a2aScript) {
+    return {
+      configPath,
+      wmuxScript: null,
+      a2aScript: null,
+      wrote: [],
+      warning:
+        'Could not locate the wmux MCP bundle next to this CLI. Open the wmux app once and use Settings → General → MCP → Re-register, or reinstall wmux.',
+    };
+  }
+
+  let config: Record<string, unknown> = {};
+  if (fs.existsSync(configPath)) {
+    try {
+      config = JSON.parse(fs.readFileSync(configPath, 'utf8'), (key, value) => {
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') return undefined;
+        return value;
+      }) as Record<string, unknown>;
+    } catch {
+      // Corrupted — start fresh rather than overwrite silently? We choose
+      // overwrite to recover a broken config; the prior contents are gone
+      // but at least Claude Code can parse the file again.
+      config = {};
+    }
+  }
+
+  const servers = (config.mcpServers && typeof config.mcpServers === 'object'
+    ? (config.mcpServers as Record<string, unknown>)
+    : {}) as Record<string, unknown>;
+
+  const wrote: string[] = [];
+  if (wmuxScript) {
+    servers['wmux'] = { command: 'node', args: [wmuxScript] };
+    wrote.push('wmux');
+  }
+  if (a2aScript) {
+    servers['wmux-a2a'] = { command: 'node', args: [a2aScript] };
+    wrote.push('wmux-a2a');
+  }
+  config.mcpServers = servers;
+
+  writeJsonAtomic(configPath, config);
+
+  return {
+    configPath,
+    wmuxScript,
+    a2aScript,
+    wrote,
+    warning: wmuxScript && a2aScript
+      ? null
+      : 'Only some MCP scripts were located — partial registration written. Use Settings → MCP → Re-register from the running app for full coverage.',
+  };
+}
+
+interface UnregisterOutcome {
+  configPath: string;
+  removed: string[];
+  configExisted: boolean;
+}
+
+function unregisterEntries(): UnregisterOutcome {
+  const configPath = getClaudeJsonPath();
+  if (!fs.existsSync(configPath)) {
+    return { configPath, removed: [], configExisted: false };
+  }
+
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, 'utf8'), (key, value) => {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') return undefined;
+      return value;
+    }) as Record<string, unknown>;
+  } catch {
+    // Corrupted — nothing to remove safely; bail out to avoid silently
+    // overwriting the user's broken-but-recoverable file.
+    return { configPath, removed: [], configExisted: true };
+  }
+
+  const servers = config.mcpServers;
+  if (!servers || typeof servers !== 'object') {
+    return { configPath, removed: [], configExisted: true };
+  }
+
+  const serversMap = servers as Record<string, unknown>;
+  const removed: string[] = [];
+  for (const key of ['wmux', 'wmux-a2a']) {
+    if (key in serversMap) {
+      delete serversMap[key];
+      removed.push(key);
+    }
+  }
+
+  if (removed.length === 0) {
+    return { configPath, removed, configExisted: true };
+  }
+
+  if (Object.keys(serversMap).length === 0) {
+    delete config.mcpServers;
+  }
+  writeJsonAtomic(configPath, config);
+
+  return { configPath, removed, configExisted: true };
+}
+
+export async function handleMcp(args: string[], jsonMode: boolean): Promise<void> {
+  const sub = args[0];
+
+  if (!sub || sub === '--help' || sub === '-h') {
+    process.stdout.write(HELP_TEXT);
+    process.exit(sub ? 0 : 1);
+    return;
+  }
+
+  switch (sub) {
+    case 'check': {
+      printCheck(checkStatus(), jsonMode);
+      return;
+    }
+
+    case 'register': {
+      const outcome = registerEntries();
+      if (jsonMode) {
+        console.log(JSON.stringify(outcome, null, 2));
+        return;
+      }
+      if (outcome.wrote.length === 0) {
+        if (outcome.warning) console.error(outcome.warning);
+        process.exit(1);
+        return;
+      }
+      console.log(`Wrote ${outcome.wrote.join(', ')} to ${outcome.configPath}`);
+      if (outcome.wmuxScript) console.log(`  wmux     → ${outcome.wmuxScript}`);
+      if (outcome.a2aScript) console.log(`  wmux-a2a → ${outcome.a2aScript}`);
+      if (outcome.warning) console.warn(outcome.warning);
+      console.log('Restart Claude Code to pick up the new servers.');
+      return;
+    }
+
+    case 'unregister': {
+      const outcome = unregisterEntries();
+      if (jsonMode) {
+        console.log(JSON.stringify(outcome, null, 2));
+        return;
+      }
+      if (!outcome.configExisted) {
+        console.log(`No config file at ${outcome.configPath} — nothing to unregister.`);
+        return;
+      }
+      if (outcome.removed.length === 0) {
+        console.log('wmux + wmux-a2a were not registered — nothing changed.');
+        return;
+      }
+      console.log(`Removed ${outcome.removed.join(', ')} from ${outcome.configPath}`);
+      return;
+    }
+
+    default: {
+      console.error(`Unknown mcp subcommand: "${sub}". Run 'wmux mcp --help' for usage.`);
+      process.exit(1);
+    }
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,6 +12,7 @@ import { handleInput } from './commands/input';
 import { handleNotify } from './commands/notify';
 import { handleSystem } from './commands/system';
 import { handleBrowser } from './commands/browser';
+import { handleMcp } from './commands/mcp';
 
 const HELP_TEXT = `
 wmux CLI
@@ -58,6 +59,11 @@ BROWSER COMMANDS
   browser session stop              Stop the active browser session
   browser session status            Show active session status
   browser session list              List available profiles
+
+MCP COMMANDS
+  mcp check                         Show whether wmux MCP servers are registered
+  mcp register                      Add wmux entries to ~/.claude.json
+  mcp unregister                    Remove wmux entries from ~/.claude.json
 
 GLOBAL FLAGS
   --json      Output raw JSON (useful for scripting)
@@ -131,6 +137,8 @@ async function main(): Promise<void> {
       await handleSystem(cmd, rest, jsonMode);
     } else if (cmd === 'browser') {
       await handleBrowser(rest, jsonMode);
+    } else if (cmd === 'mcp') {
+      await handleMcp(rest, jsonMode);
     } else {
       console.error(`Unknown command: "${cmd}". Run 'wmux --help' for usage.`);
       process.exit(1);

--- a/src/main/autostart/BrewDetector.ts
+++ b/src/main/autostart/BrewDetector.ts
@@ -1,0 +1,36 @@
+import * as fs from 'fs';
+import { isMac } from '../../shared/platform';
+
+const BREW_CASKROOM_PATHS = [
+  '/opt/homebrew/Caskroom/wmux',  // Apple Silicon (default Homebrew prefix)
+  '/usr/local/Caskroom/wmux',     // Intel Mac (legacy Homebrew prefix)
+];
+
+/**
+ * Returns true when this wmux installation appears to come from Homebrew Cask.
+ * Used to disable in-app auto-update so brew/cask can manage upgrades.
+ *
+ * Detection: cask receipt directories live under Caskroom regardless of where
+ * the .app is symlinked. This works even when Finder-launched apps don't have
+ * brew on PATH (which would make `brew list --cask` always fail).
+ */
+export function isBrewInstalled(): boolean {
+  if (!isMac) return false;
+  for (const p of BREW_CASKROOM_PATHS) {
+    try {
+      if (fs.existsSync(p) && fs.statSync(p).isDirectory()) return true;
+    } catch { /* skip */ }
+  }
+  return false;
+}
+
+/** Returns the Caskroom path that matched, for diagnostics. */
+export function getBrewCaskroomPath(): string | null {
+  if (!isMac) return null;
+  for (const p of BREW_CASKROOM_PATHS) {
+    try {
+      if (fs.existsSync(p) && fs.statSync(p).isDirectory()) return p;
+    } catch { /* skip */ }
+  }
+  return null;
+}

--- a/src/main/autostart/__tests__/BrewDetector.test.ts
+++ b/src/main/autostart/__tests__/BrewDetector.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ----- fs mock -----------------------------------------------------------
+//
+// We intercept fs.existsSync and fs.statSync so each test can declare which
+// Caskroom path "exists" and what its stat looks like. The vi.hoisted block
+// keeps the mock factory and the tests pointing at the same vi.fn() handles
+// despite vi.mock() being hoisted above all imports.
+const fsMocks = vi.hoisted(() => {
+  return {
+    existsSync: vi.fn(),
+    statSync: vi.fn(),
+  };
+});
+
+vi.mock('fs', () => ({
+  existsSync: fsMocks.existsSync,
+  statSync: fsMocks.statSync,
+}));
+
+// ----- platform mock -----------------------------------------------------
+//
+// Default state is mac. Per-OS suites below call vi.resetModules() and
+// vi.doMock to flip isMac to false (linux/win) before re-importing the SUT.
+vi.mock('../../../shared/platform', () => ({
+  isMac: true,
+}));
+
+const APPLE_SILICON = '/opt/homebrew/Caskroom/wmux';
+const INTEL_MAC = '/usr/local/Caskroom/wmux';
+
+function makeStat(isDir: boolean) {
+  return { isDirectory: () => isDir };
+}
+
+describe('BrewDetector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fsMocks.existsSync.mockReturnValue(false);
+    fsMocks.statSync.mockReturnValue(makeStat(false));
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  describe('on macOS', () => {
+    // Top-level vi.mock already sets isMac: true. No re-mock needed.
+
+    it('returns true and the Apple Silicon path when /opt/homebrew/Caskroom/wmux exists', async () => {
+      fsMocks.existsSync.mockImplementation((p: string) => p === APPLE_SILICON);
+      fsMocks.statSync.mockImplementation((p: string) => makeStat(p === APPLE_SILICON));
+
+      const { isBrewInstalled, getBrewCaskroomPath } = await import('../BrewDetector');
+      expect(isBrewInstalled()).toBe(true);
+      expect(getBrewCaskroomPath()).toBe(APPLE_SILICON);
+    });
+
+    it('returns true and the Intel path when /usr/local/Caskroom/wmux exists', async () => {
+      fsMocks.existsSync.mockImplementation((p: string) => p === INTEL_MAC);
+      fsMocks.statSync.mockImplementation((p: string) => makeStat(p === INTEL_MAC));
+
+      const { isBrewInstalled, getBrewCaskroomPath } = await import('../BrewDetector');
+      expect(isBrewInstalled()).toBe(true);
+      expect(getBrewCaskroomPath()).toBe(INTEL_MAC);
+    });
+
+    it('returns false and null when neither Caskroom path exists', async () => {
+      fsMocks.existsSync.mockReturnValue(false);
+
+      const { isBrewInstalled, getBrewCaskroomPath } = await import('../BrewDetector');
+      expect(isBrewInstalled()).toBe(false);
+      expect(getBrewCaskroomPath()).toBeNull();
+    });
+
+    it('returns false when the path exists but is not a directory (cask installs always make dirs)', async () => {
+      fsMocks.existsSync.mockReturnValue(true);
+      fsMocks.statSync.mockReturnValue(makeStat(false));
+
+      const { isBrewInstalled, getBrewCaskroomPath } = await import('../BrewDetector');
+      expect(isBrewInstalled()).toBe(false);
+      expect(getBrewCaskroomPath()).toBeNull();
+    });
+
+    it('treats existsSync exceptions as non-existence (catch/skip semantics)', async () => {
+      fsMocks.existsSync.mockImplementation(() => {
+        throw new Error('EACCES: permission denied');
+      });
+
+      const { isBrewInstalled, getBrewCaskroomPath } = await import('../BrewDetector');
+      // Must not throw — both queries should return the negative case.
+      expect(() => isBrewInstalled()).not.toThrow();
+      expect(isBrewInstalled()).toBe(false);
+      expect(getBrewCaskroomPath()).toBeNull();
+    });
+
+    it('treats statSync exceptions as non-existence (catch/skip semantics)', async () => {
+      fsMocks.existsSync.mockReturnValue(true);
+      fsMocks.statSync.mockImplementation(() => {
+        throw new Error('ENOENT: race — gone after existsSync');
+      });
+
+      const { isBrewInstalled, getBrewCaskroomPath } = await import('../BrewDetector');
+      expect(isBrewInstalled()).toBe(false);
+      expect(getBrewCaskroomPath()).toBeNull();
+    });
+
+    it('prefers Apple Silicon path over Intel when both exist (probe order)', async () => {
+      fsMocks.existsSync.mockReturnValue(true);
+      fsMocks.statSync.mockReturnValue(makeStat(true));
+
+      const { getBrewCaskroomPath } = await import('../BrewDetector');
+      expect(getBrewCaskroomPath()).toBe(APPLE_SILICON);
+    });
+  });
+
+  describe('on Linux', () => {
+    beforeEach(() => {
+      vi.resetModules();
+      vi.doMock('../../../shared/platform', () => ({ isMac: false }));
+    });
+
+    it('returns false / null without touching the filesystem', async () => {
+      // Prime fs to "exist" so we'd get a false positive if isMac guard were missing.
+      fsMocks.existsSync.mockReturnValue(true);
+      fsMocks.statSync.mockReturnValue(makeStat(true));
+
+      const { isBrewInstalled, getBrewCaskroomPath } = await import('../BrewDetector');
+      expect(isBrewInstalled()).toBe(false);
+      expect(getBrewCaskroomPath()).toBeNull();
+      // Hard guarantee: the isMac short-circuit must skip the loop entirely.
+      expect(fsMocks.existsSync).not.toHaveBeenCalled();
+      expect(fsMocks.statSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('on Windows', () => {
+    beforeEach(() => {
+      vi.resetModules();
+      vi.doMock('../../../shared/platform', () => ({ isMac: false }));
+    });
+
+    it('returns false / null without touching the filesystem', async () => {
+      fsMocks.existsSync.mockReturnValue(true);
+      fsMocks.statSync.mockReturnValue(makeStat(true));
+
+      const { isBrewInstalled, getBrewCaskroomPath } = await import('../BrewDetector');
+      expect(isBrewInstalled()).toBe(false);
+      expect(getBrewCaskroomPath()).toBeNull();
+      expect(fsMocks.existsSync).not.toHaveBeenCalled();
+      expect(fsMocks.statSync).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -164,7 +164,21 @@ const claudeWorker = new ClaudeWorker(() => mainWindow);
 // Daemon client — initialized on app ready, used if daemon is available
 let daemonClient: DaemonClient | null = null;
 
-let cleanupHandlers = registerAllHandlers(ptyManager, ptyBridge, () => mainWindow);
+// Settings panel (MCP section) + `wmux mcp` CLI parity. Lazy token getter
+// because pipeServer.getAuthToken() reads the file written during startup,
+// which may not have happened yet when handlers are first registered.
+const mcpHandlerOptions = {
+  mcpRegistrar,
+  getMcpAuthToken: (): string | null => {
+    try {
+      return pipeServer.getAuthToken();
+    } catch {
+      return null;
+    }
+  },
+};
+
+let cleanupHandlers = registerAllHandlers(ptyManager, ptyBridge, () => mainWindow, undefined, mcpHandlerOptions);
 
 // Module-scope crash tracking so activate-created windows share the same counters
 let lastCrashTime = 0;
@@ -187,7 +201,7 @@ function attachWindowRecovery(win: BrowserWindow): void {
       return;
     }
     cleanupHandlers();
-    cleanupHandlers = registerAllHandlers(ptyManager, ptyBridge, () => mainWindow, daemonClient ?? undefined);
+    cleanupHandlers = registerAllHandlers(ptyManager, ptyBridge, () => mainWindow, daemonClient ?? undefined, mcpHandlerOptions);
     const activePtys = ptyManager.getActiveInstances();
     console.log(`[Main] ${activePtys.length} PTY(s) still alive — reloading renderer`);
     setTimeout(() => {
@@ -204,7 +218,7 @@ function attachWindowRecovery(win: BrowserWindow): void {
       if (mainWindow && !mainWindow.isDestroyed()) {
         console.warn('[Main] Renderer still unresponsive after 10s — reloading');
         cleanupHandlers();
-        cleanupHandlers = registerAllHandlers(ptyManager, ptyBridge, () => mainWindow, daemonClient ?? undefined);
+        cleanupHandlers = registerAllHandlers(ptyManager, ptyBridge, () => mainWindow, daemonClient ?? undefined, mcpHandlerOptions);
         mainWindow.reload();
       }
     }, 10_000);
@@ -275,7 +289,7 @@ app.on('ready', async () => {
         daemonClient = client;
         console.log('[Main] Connected to wmux-daemon (auth verified)');
         cleanupHandlers();
-        cleanupHandlers = registerAllHandlers(ptyManager, ptyBridge, () => mainWindow, daemonClient);
+        cleanupHandlers = registerAllHandlers(ptyManager, ptyBridge, () => mainWindow, daemonClient, mcpHandlerOptions);
         // Notify renderer that daemon is now connected so it can re-reconcile
         if (mainWindow && !mainWindow.isDestroyed()) {
           mainWindow.webContents.send('daemon:connected');
@@ -284,7 +298,7 @@ app.on('ready', async () => {
           console.warn('[Main] Daemon disconnected, falling back to local PTY');
           daemonClient = null;
           cleanupHandlers();
-          cleanupHandlers = registerAllHandlers(ptyManager, ptyBridge, () => mainWindow);
+          cleanupHandlers = registerAllHandlers(ptyManager, ptyBridge, () => mainWindow, undefined, mcpHandlerOptions);
         });
       }
     }

--- a/src/main/ipc/handlers/mcp.handler.ts
+++ b/src/main/ipc/handlers/mcp.handler.ts
@@ -1,0 +1,87 @@
+import { ipcMain } from 'electron';
+import { IPC } from '../../../shared/constants';
+import { wrapHandler } from '../wrapHandler';
+import type { McpRegistrar, McpRegistrarStatus } from '../../mcp/McpRegistrar';
+
+/**
+ * Serializable shape returned to the renderer. Mirrors {@link McpRegistrarStatus}
+ * but converts Date → ISO string so it survives Electron's structured clone
+ * across the IPC boundary without surprising consumers (Date is technically
+ * cloneable, but ISO strings are friendlier for the React side that just
+ * formats them for display).
+ */
+export interface McpStatusPayload {
+  wmux: { registered: boolean; path: string | null };
+  wmuxA2a: { registered: boolean; path: string | null };
+  configPath: string;
+  configExists: boolean;
+  /** ISO 8601 string, or null when the config file does not exist. */
+  configModified: string | null;
+}
+
+function serialize(status: McpRegistrarStatus): McpStatusPayload {
+  return {
+    wmux: status.wmux,
+    wmuxA2a: status.wmuxA2a,
+    configPath: status.configPath,
+    configExists: status.configExists,
+    configModified: status.configModified ? status.configModified.toISOString() : null,
+  };
+}
+
+/**
+ * Register IPC handlers that surface MCP integration state to the renderer
+ * (Settings → General → MCP section). Mirrors the `wmux mcp …` CLI commands so
+ * users can verify / reset registration from either GUI or terminal.
+ *
+ * @param registrar    The shared McpRegistrar instance (owned by main/index.ts).
+ * @param getAuthToken Lazy accessor for the active pipe-server auth token. The
+ *                     re-register path needs the live token; we read it lazily
+ *                     so this handler can be wired up before the pipe server
+ *                     finishes starting (it logs and refuses gracefully if the
+ *                     token isn't available yet).
+ */
+export function registerMcpHandlers(
+  registrar: McpRegistrar,
+  getAuthToken: () => string | null,
+): () => void {
+  // wrapHandler is variadic and treats its first argument (the IpcMainInvokeEvent)
+  // as transport plumbing; we can omit the parameter entirely on the inner
+  // handler since none of these read renderer/sender info.
+  ipcMain.removeHandler(IPC.MCP_CHECK);
+  ipcMain.handle(
+    IPC.MCP_CHECK,
+    wrapHandler(IPC.MCP_CHECK, async (): Promise<McpStatusPayload> => {
+      return serialize(registrar.getStatus());
+    }),
+  );
+
+  ipcMain.removeHandler(IPC.MCP_REREGISTER);
+  ipcMain.handle(
+    IPC.MCP_REREGISTER,
+    wrapHandler(IPC.MCP_REREGISTER, async (): Promise<McpStatusPayload> => {
+      const token = getAuthToken();
+      if (!token) {
+        // Pipe server not yet ready — surface to renderer rather than crash.
+        throw new Error('MCP re-register unavailable: auth token not ready (pipe server still starting)');
+      }
+      registrar.register(token);
+      return serialize(registrar.getStatus());
+    }),
+  );
+
+  ipcMain.removeHandler(IPC.MCP_UNREGISTER);
+  ipcMain.handle(
+    IPC.MCP_UNREGISTER,
+    wrapHandler(IPC.MCP_UNREGISTER, async (): Promise<McpStatusPayload> => {
+      registrar.forceUnregister();
+      return serialize(registrar.getStatus());
+    }),
+  );
+
+  return () => {
+    ipcMain.removeHandler(IPC.MCP_CHECK);
+    ipcMain.removeHandler(IPC.MCP_REREGISTER);
+    ipcMain.removeHandler(IPC.MCP_UNREGISTER);
+  };
+}

--- a/src/main/ipc/registerHandlers.ts
+++ b/src/main/ipc/registerHandlers.ts
@@ -2,20 +2,30 @@ import { ipcMain, type BrowserWindow } from 'electron';
 import { PTYManager } from '../pty/PTYManager';
 import { PTYBridge } from '../pty/PTYBridge';
 import { DaemonClient } from '../DaemonClient';
+import { McpRegistrar } from '../mcp/McpRegistrar';
 import { registerPTYHandlers } from './handlers/pty.handler';
 import { registerSessionHandlers } from './handlers/session.handler';
 import { registerShellHandlers } from './handlers/shell.handler';
 import { registerMetadataHandlers } from './handlers/metadata.handler';
 import { registerClipboardHandlers } from './handlers/clipboard.handler';
 import { registerFsHandlers } from './handlers/fs.handler';
+import { registerMcpHandlers } from './handlers/mcp.handler';
 import { IPC } from '../../shared/constants';
 import { toastManager } from '../pipe/handlers/notify.rpc';
+
+export interface RegisterHandlersOptions {
+  /** McpRegistrar instance shared with main/index — exposes Settings MCP IPC. */
+  mcpRegistrar?: McpRegistrar;
+  /** Lazy accessor for the live pipe-server auth token, used by mcp:reregister. */
+  getMcpAuthToken?: () => string | null;
+}
 
 export function registerAllHandlers(
   ptyManager: PTYManager,
   ptyBridge: PTYBridge,
   getWindow: () => BrowserWindow | null,
   daemonClient?: DaemonClient,
+  options: RegisterHandlersOptions = {},
 ): () => void {
   const cleanupPty = registerPTYHandlers(ptyManager, ptyBridge, daemonClient, getWindow);
   const cleanupSession = registerSessionHandlers();
@@ -23,6 +33,9 @@ export function registerAllHandlers(
   const cleanupMetadata = registerMetadataHandlers(ptyManager, getWindow);
   registerClipboardHandlers();
   const cleanupFs = registerFsHandlers();
+  const cleanupMcp = options.mcpRegistrar
+    ? registerMcpHandlers(options.mcpRegistrar, options.getMcpAuthToken ?? (() => null))
+    : null;
 
   // Sync toast setting from renderer
   const onToastEnabled = (_event: Electron.IpcMainEvent, enabled: boolean): void => {
@@ -45,6 +58,7 @@ export function registerAllHandlers(
     cleanupShell();
     cleanupMetadata();
     cleanupFs();
+    if (cleanupMcp) cleanupMcp();
     ipcMain.removeAllListeners(IPC.TOAST_ENABLED);
     ipcMain.removeAllListeners(IPC.WINDOW_HIDE);
   };

--- a/src/main/mcp/McpRegistrar.ts
+++ b/src/main/mcp/McpRegistrar.ts
@@ -3,6 +3,26 @@ import * as path from 'path';
 import { app } from 'electron';
 import { getAuthTokenPath, getPipeName } from '../../shared/constants';
 import { secureWriteTokenFile } from '../../shared/security';
+import { isMac } from '../../shared/platform';
+import { formatMacosError, MACOS_ERRORS } from '../../shared/errors/macos';
+
+/** Per-server registration state surfaced via getStatus(). */
+export interface McpServerStatus {
+  registered: boolean;
+  /** Resolved script path written to ~/.claude.json, or null when not registered. */
+  path: string | null;
+}
+
+/** Aggregate snapshot of MCP integration state for CLI / Settings UI. */
+export interface McpRegistrarStatus {
+  wmux: McpServerStatus;
+  wmuxA2a: McpServerStatus;
+  /** Absolute path to the Claude Code user config file (~/.claude.json). */
+  configPath: string;
+  configExists: boolean;
+  /** Last-modified timestamp (mtime) of the config file, or null when missing. */
+  configModified: Date | null;
+}
 
 /**
  * Registers/unregisters the wmux MCP server in Claude Code's config files
@@ -14,6 +34,12 @@ import { secureWriteTokenFile } from '../../shared/security';
  *
  * Config files written:
  *   1. ~/.claude.json   (user-level MCP config — where Claude Code reads mcpServers)
+ *
+ * NOTE (cross-platform): the path `~/.claude.json` is currently used on every
+ * OS. macOS Claude Desktop may use `~/Library/Application Support/Claude/`
+ * instead — macOS verification pending — see plan Phase 1.17 prereq. Do NOT
+ * add the macOS-specific path here speculatively; gate that behind empirical
+ * verification and ship as a separate change.
  */
 export class McpRegistrar {
   private readonly claudeJsonPath: string;
@@ -26,6 +52,78 @@ export class McpRegistrar {
     const home = app.getPath('home');
     this.claudeJsonPath = path.join(home, '.claude.json');
     this.authTokenPath = getAuthTokenPath();
+  }
+
+  /** Absolute path to the Claude Code user config file. */
+  getClaudeJsonPath(): string {
+    return this.claudeJsonPath;
+  }
+
+  /**
+   * Read-only snapshot of MCP registration state. Used by `wmux mcp check`
+   * and the Settings → General → MCP section to surface whether Claude Code
+   * can discover the wmux MCP servers.
+   *
+   * Pure read — never creates the config file or its parent directory, never
+   * throws. Corrupted JSON or missing files yield "not registered".
+   */
+  getStatus(): McpRegistrarStatus {
+    let configExists = false;
+    let configModified: Date | null = null;
+    try {
+      const stat = fs.statSync(this.claudeJsonPath);
+      configExists = stat.isFile();
+      configModified = configExists ? stat.mtime : null;
+    } catch {
+      configExists = false;
+    }
+
+    let wmuxPath: string | null = null;
+    let a2aPath: string | null = null;
+    if (configExists) {
+      try {
+        const raw = fs.readFileSync(this.claudeJsonPath, 'utf8');
+        const config = JSON.parse(raw, (key, value) => {
+          if (key === '__proto__' || key === 'constructor' || key === 'prototype') return undefined;
+          return value;
+        }) as { mcpServers?: Record<string, unknown> };
+        const servers = config && typeof config === 'object' ? config.mcpServers : null;
+        if (servers && typeof servers === 'object') {
+          wmuxPath = extractScriptPath(servers['wmux']);
+          a2aPath = extractScriptPath(servers['wmux-a2a']);
+        }
+      } catch {
+        // Corrupted config — surface as "not registered" rather than throw.
+      }
+    }
+
+    return {
+      wmux: { registered: wmuxPath !== null, path: wmuxPath },
+      wmuxA2a: { registered: a2aPath !== null, path: a2aPath },
+      configPath: this.claudeJsonPath,
+      configExists,
+      configModified,
+    };
+  }
+
+  /**
+   * Force-remove the wmux + wmux-a2a keys from ~/.claude.json. Unlike
+   * {@link unregister} (intentionally a no-op to avoid the chicken-and-egg
+   * problem on app quit), this is invoked from explicit user actions — the
+   * `wmux mcp unregister` CLI and the Settings panel "Unregister" button.
+   *
+   * Other mcpServers entries are left untouched.
+   */
+  forceUnregister(): void {
+    try {
+      this.unregisterFromClaudeJson(['wmux', 'wmux-a2a']);
+      this.ownedKeys.delete('wmux');
+      this.ownedKeys.delete('wmux-a2a');
+      this.registered = false;
+      console.log('[McpRegistrar] Force-unregistered wmux + wmux-a2a from ~/.claude.json');
+    } catch (err) {
+      console.error('[McpRegistrar] Failed to force-unregister:', err);
+    }
   }
 
   /**
@@ -72,6 +170,14 @@ export class McpRegistrar {
       console.log(`[McpRegistrar] Registered wmux MCP → ${mcpScript}`);
     } catch (err) {
       console.error('[McpRegistrar] Failed to register:', err);
+      // macOS users hitting Time Machine restore / sudo-written ~/.claude.json
+      // see ENOACCES/EACCES/EPERM and have no way to know the fix is `chmod 600`.
+      // Surface the catalog entry so the next stderr line shows the exact command.
+      // Other platforms / other errors are unaffected.
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (isMac && (code === 'EACCES' || code === 'ENOACCES' || code === 'EPERM')) {
+        console.error('\n' + formatMacosError(MACOS_ERRORS.mcpPermissionDenied));
+      }
     }
   }
 
@@ -228,4 +334,20 @@ export class McpRegistrar {
     fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2) + '\n', 'utf8');
     fs.renameSync(tmpPath, filePath);
   }
+}
+
+/**
+ * Extract the MCP script path from a `mcpServers[key]` entry.
+ *
+ * wmux always writes entries shaped `{ command: 'node', args: [scriptPath] }`,
+ * so the script path is the first arg. Returns null when the entry is absent
+ * or malformed (foreign edits, schema drift) — getStatus() then reports the
+ * server as not registered rather than fabricating a path.
+ */
+function extractScriptPath(entry: unknown): string | null {
+  if (!entry || typeof entry !== 'object') return null;
+  const args = (entry as { args?: unknown }).args;
+  if (!Array.isArray(args) || args.length === 0) return null;
+  const first = args[0];
+  return typeof first === 'string' && first.length > 0 ? first : null;
 }

--- a/src/main/mcp/__tests__/McpRegistrar.test.ts
+++ b/src/main/mcp/__tests__/McpRegistrar.test.ts
@@ -1,0 +1,177 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Use a per-test temp directory as the simulated home so we can exercise
+// real fs reads/writes without touching the developer's actual ~/.claude.json.
+let tmpHome = '';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (key: string) => {
+      if (key === 'home') return tmpHome;
+      throw new Error(`unexpected getPath(${key}) in test`);
+    },
+    isPackaged: false,
+    getAppPath: () => tmpHome, // dev-mode script discovery walks up; harmless here
+  },
+}));
+
+// secureWriteTokenFile is invoked by register(); stub it so we don't try to
+// run icacls / chmod under tests.
+vi.mock('../../../shared/security', () => ({
+  secureWriteTokenFile: vi.fn(),
+}));
+
+// Avoid requiring the real macOS error catalogue at import time.
+vi.mock('../../../shared/errors/macos', () => ({
+  formatMacosError: vi.fn(() => ''),
+  MACOS_ERRORS: { mcpPermissionDenied: { code: 'TEST', summary: '', remedy: '' } },
+}));
+
+vi.mock('../../../shared/platform', () => ({ isMac: false }));
+
+// IMPORTANT: import the SUT after vi.mock() declarations.
+import { McpRegistrar } from '../McpRegistrar';
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-mcp-test-'));
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe('McpRegistrar.getStatus', () => {
+  it('reports both servers as not registered when ~/.claude.json is absent', () => {
+    const registrar = new McpRegistrar();
+    const status = registrar.getStatus();
+
+    expect(status.configExists).toBe(false);
+    expect(status.configModified).toBeNull();
+    expect(status.wmux).toEqual({ registered: false, path: null });
+    expect(status.wmuxA2a).toEqual({ registered: false, path: null });
+    expect(status.configPath).toBe(path.join(tmpHome, '.claude.json'));
+  });
+
+  it('does NOT create ~/.claude.json as a side effect of getStatus', () => {
+    const registrar = new McpRegistrar();
+    registrar.getStatus();
+    expect(fs.existsSync(path.join(tmpHome, '.claude.json'))).toBe(false);
+  });
+
+  it('extracts registered script paths from ~/.claude.json', () => {
+    const cfg = {
+      mcpServers: {
+        wmux: { command: 'node', args: ['/abs/path/to/mcp-bundle/index.js'] },
+        'wmux-a2a': { command: 'node', args: ['/abs/path/to/a2a-bundle/index.js'] },
+        // Unrelated entry must be ignored, not considered for our status.
+        'someone-else': { command: 'node', args: ['/elsewhere/index.js'] },
+      },
+    };
+    fs.writeFileSync(path.join(tmpHome, '.claude.json'), JSON.stringify(cfg), 'utf8');
+
+    const registrar = new McpRegistrar();
+    const status = registrar.getStatus();
+
+    expect(status.configExists).toBe(true);
+    expect(status.configModified).toBeInstanceOf(Date);
+    expect(status.wmux).toEqual({ registered: true, path: '/abs/path/to/mcp-bundle/index.js' });
+    expect(status.wmuxA2a).toEqual({ registered: true, path: '/abs/path/to/a2a-bundle/index.js' });
+  });
+
+  it('treats malformed entries as not registered', () => {
+    const cfg = {
+      mcpServers: {
+        wmux: { command: 'node' /* missing args */ },
+        'wmux-a2a': { command: 'node', args: [] /* empty */ },
+      },
+    };
+    fs.writeFileSync(path.join(tmpHome, '.claude.json'), JSON.stringify(cfg), 'utf8');
+
+    const status = new McpRegistrar().getStatus();
+    expect(status.wmux.registered).toBe(false);
+    expect(status.wmuxA2a.registered).toBe(false);
+  });
+
+  it('returns "not registered" rather than throwing on corrupted JSON', () => {
+    fs.writeFileSync(path.join(tmpHome, '.claude.json'), '{ this is not json', 'utf8');
+
+    const status = new McpRegistrar().getStatus();
+    expect(status.configExists).toBe(true);
+    expect(status.wmux.registered).toBe(false);
+    expect(status.wmuxA2a.registered).toBe(false);
+  });
+});
+
+describe('McpRegistrar.forceUnregister', () => {
+  it('removes only wmux + wmux-a2a, leaving foreign entries intact', () => {
+    const cfg = {
+      mcpServers: {
+        wmux: { command: 'node', args: ['/x/wmux.js'] },
+        'wmux-a2a': { command: 'node', args: ['/x/a2a.js'] },
+        'someone-else': { command: 'node', args: ['/y/other.js'] },
+      },
+      otherTopLevel: { keep: true },
+    };
+    fs.writeFileSync(path.join(tmpHome, '.claude.json'), JSON.stringify(cfg), 'utf8');
+
+    new McpRegistrar().forceUnregister();
+
+    const after = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, '.claude.json'), 'utf8'),
+    ) as { mcpServers?: Record<string, unknown>; otherTopLevel?: unknown };
+    expect(after.mcpServers).toEqual({
+      'someone-else': { command: 'node', args: ['/y/other.js'] },
+    });
+    expect(after.otherTopLevel).toEqual({ keep: true });
+  });
+
+  it('drops the empty mcpServers object when wmux were the only entries', () => {
+    const cfg = {
+      mcpServers: {
+        wmux: { command: 'node', args: ['/x/wmux.js'] },
+        'wmux-a2a': { command: 'node', args: ['/x/a2a.js'] },
+      },
+    };
+    fs.writeFileSync(path.join(tmpHome, '.claude.json'), JSON.stringify(cfg), 'utf8');
+
+    new McpRegistrar().forceUnregister();
+
+    const after = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, '.claude.json'), 'utf8'),
+    ) as { mcpServers?: unknown };
+    expect(after.mcpServers).toBeUndefined();
+  });
+
+  it('is a safe no-op when ~/.claude.json does not exist', () => {
+    expect(() => new McpRegistrar().forceUnregister()).not.toThrow();
+    // Should not have created the file.
+    expect(fs.existsSync(path.join(tmpHome, '.claude.json'))).toBe(false);
+  });
+});
+
+describe('McpRegistrar.unregister (legacy no-op)', () => {
+  it('does NOT remove keys (preserves the chicken-and-egg fix)', () => {
+    const cfg = {
+      mcpServers: {
+        wmux: { command: 'node', args: ['/x/wmux.js'] },
+        'wmux-a2a': { command: 'node', args: ['/x/a2a.js'] },
+      },
+    };
+    fs.writeFileSync(path.join(tmpHome, '.claude.json'), JSON.stringify(cfg), 'utf8');
+
+    new McpRegistrar().unregister();
+
+    const after = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, '.claude.json'), 'utf8'),
+    ) as { mcpServers?: Record<string, unknown> };
+    expect(after.mcpServers?.wmux).toBeDefined();
+    expect(after.mcpServers?.['wmux-a2a']).toBeDefined();
+  });
+});

--- a/src/mcp/playwright/PlaywrightEngine.ts
+++ b/src/mcp/playwright/PlaywrightEngine.ts
@@ -1,5 +1,7 @@
 import { chromium, type Browser, type BrowserContext, type Page, type CDPSession } from 'playwright-core';
 import { sendRpc } from '../wmux-client';
+import { isMac } from '../../shared/platform';
+import { formatMacosError, MACOS_ERRORS } from '../../shared/errors/macos';
 
 interface CdpTargetInfo {
   surfaceId: string;
@@ -111,12 +113,14 @@ export class PlaywrightEngine {
   async ensureConnected(): Promise<void> {
     if (this.browser?.isConnected()) return;
 
+    let lastError: unknown = null;
     for (let attempt = 1; attempt <= MAX_CONNECT_RETRIES; attempt++) {
       try {
         const info = (await sendRpc('browser.cdp.info')) as CdpInfoResponse;
         await this.connect(info.cdpPort);
         return;
       } catch (err) {
+        lastError = err;
         console.error(
           `[PlaywrightEngine] Connection attempt ${attempt}/${MAX_CONNECT_RETRIES} failed:`,
           err instanceof Error ? err.message : String(err),
@@ -124,6 +128,25 @@ export class PlaywrightEngine {
         if (attempt < MAX_CONNECT_RETRIES) {
           await sleep(RETRY_DELAY_MS);
         }
+      }
+    }
+
+    // macOS Gatekeeper can quarantine the runtime-downloaded Chromium binary
+    // (allow-jit entitlement + un-notarized cache combo). The exact error
+    // wording varies across playwright-core versions, so trigger on any
+    // failure-after-all-retries when the message hints at chromium/launch/
+    // executable problems. Print the catalog entry once to stderr (logged
+    // only — does not change the throw below or any retry behavior).
+    if (isMac && lastError) {
+      const msg = (lastError instanceof Error ? lastError.message : String(lastError)).toLowerCase();
+      if (
+        msg.includes('chromium') ||
+        msg.includes('executable') ||
+        msg.includes('launch') ||
+        msg.includes('gatekeeper') ||
+        msg.includes('quarantine')
+      ) {
+        console.error('\n' + formatMacosError(MACOS_ERRORS.playwrightChromiumQuarantine));
       }
     }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,15 @@
 import { contextBridge, ipcRenderer } from 'electron';
 import { IPC } from '../shared/constants';
 
+/** Mirrors {@link McpStatusPayload} in src/main/ipc/handlers/mcp.handler.ts. */
+interface McpStatusPayload {
+  wmux: { registered: boolean; path: string | null };
+  wmuxA2a: { registered: boolean; path: string | null };
+  configPath: string;
+  configExists: boolean;
+  configModified: string | null;
+}
+
 const electronAPI = {
   // OS-aware shortcut mapping support — renderer cannot read process.platform
   // directly under sandbox + contextIsolation, so expose it here.
@@ -94,6 +103,11 @@ const electronAPI = {
       ipcRenderer.on('daemon:connected', listener);
       return () => { ipcRenderer.removeListener('daemon:connected', listener); };
     },
+  },
+  mcp: {
+    check: () => ipcRenderer.invoke(IPC.MCP_CHECK) as Promise<McpStatusPayload>,
+    reregister: () => ipcRenderer.invoke(IPC.MCP_REREGISTER) as Promise<McpStatusPayload>,
+    unregister: () => ipcRenderer.invoke(IPC.MCP_UNREGISTER) as Promise<McpStatusPayload>,
   },
   token: {
     onUpdate: (callback: (ptyId: string, event: { inputTokens: number; outputTokens: number; cacheRead: number; cacheWrite: number; cost: number; totalCost: number; totalInputTokens: number; totalOutputTokens: number }) => void) => {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,6 +1,15 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import { IPC } from '../shared/constants';
 
+/** Mirrors {@link McpStatusPayload} in src/main/ipc/handlers/mcp.handler.ts. */
+interface McpStatusPayload {
+  wmux: { registered: boolean; path: string | null };
+  wmuxA2a: { registered: boolean; path: string | null };
+  configPath: string;
+  configExists: boolean;
+  configModified: string | null;
+}
+
 const electronAPI = {
   // OS-aware shortcut mapping support — renderer cannot read process.platform
   // directly under sandbox + contextIsolation, so expose it here.
@@ -111,6 +120,11 @@ const electronAPI = {
       ipcRenderer.on('daemon:connected', listener);
       return () => { ipcRenderer.removeListener('daemon:connected', listener); };
     },
+  },
+  mcp: {
+    check: () => ipcRenderer.invoke(IPC.MCP_CHECK) as Promise<McpStatusPayload>,
+    reregister: () => ipcRenderer.invoke(IPC.MCP_REREGISTER) as Promise<McpStatusPayload>,
+    unregister: () => ipcRenderer.invoke(IPC.MCP_UNREGISTER) as Promise<McpStatusPayload>,
   },
   token: {
     onUpdate: (callback: (ptyId: string, event: { inputTokens: number; outputTokens: number; cacheRead: number; cacheWrite: number; cost: number; totalCost: number; totalInputTokens: number; totalOutputTokens: number }) => void) => {

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -285,6 +285,205 @@ function disposePaneTree(pane: { type: string; surfaces?: Array<{ ptyId?: string
   }
 }
 
+// ─── MCP integration status ──────────────────────────────────────────────────
+
+/** Mirror of McpStatusPayload in main/ipc/handlers/mcp.handler.ts. */
+interface McpStatusPayload {
+  wmux: { registered: boolean; path: string | null };
+  wmuxA2a: { registered: boolean; path: string | null };
+  configPath: string;
+  configExists: boolean;
+  configModified: string | null;
+}
+
+interface ElectronMcpApi {
+  check: () => Promise<McpStatusPayload>;
+  reregister: () => Promise<McpStatusPayload>;
+  unregister: () => Promise<McpStatusPayload>;
+}
+
+/**
+ * MCP servers panel in Settings → General. Surfaces whether `~/.claude.json`
+ * has the wmux + wmux-a2a MCP entries, plus Re-register / Unregister buttons.
+ *
+ * Mirrors the `wmux mcp check` CLI output so users have a one-stop way to
+ * verify Claude Code can discover the wmux MCP bridge — DX D4 decision.
+ */
+function McpStatusSection() {
+  const [status, setStatus] = useState<McpStatusPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [confirmingUnregister, setConfirmingUnregister] = useState(false);
+  const [pending, setPending] = useState<'reregister' | 'unregister' | null>(null);
+  // NOT_FOUND is expected when running the dev shell with no main wired up;
+  // silence those toasts so the empty state renders cleanly.
+  const { invoke: ipcInvoke } = useIpc({ silent: ['NOT_FOUND', 'UNKNOWN'] });
+
+  // Lazily access the API so this component is safe to render in tests where
+  // the preload has not exposed mcp yet.
+  const mcpApi = (window.electronAPI as unknown as { mcp?: ElectronMcpApi }).mcp;
+
+  const refresh = useCallback(async () => {
+    if (!mcpApi) {
+      setLoading(false);
+      return;
+    }
+    const result = await ipcInvoke(() => mcpApi.check());
+    if (result.ok) setStatus(result.data);
+    setLoading(false);
+  }, [ipcInvoke, mcpApi]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleReregister = useCallback(async () => {
+    if (!mcpApi) return;
+    setPending('reregister');
+    const result = await ipcInvoke(() => mcpApi.reregister());
+    if (result.ok) setStatus(result.data);
+    setPending(null);
+  }, [ipcInvoke, mcpApi]);
+
+  const handleUnregister = useCallback(async () => {
+    if (!mcpApi) return;
+    setPending('unregister');
+    const result = await ipcInvoke(() => mcpApi.unregister());
+    if (result.ok) setStatus(result.data);
+    setPending(null);
+    setConfirmingUnregister(false);
+  }, [ipcInvoke, mcpApi]);
+
+  // Section is hidden entirely when the preload doesn't expose the API —
+  // keeps older dev builds clean and avoids "phantom" buttons that error.
+  if (!mcpApi && !loading) return null;
+
+  const renderRow = (
+    label: string,
+    server: { registered: boolean; path: string | null },
+  ) => (
+    <div
+      className="px-3 py-2 rounded-lg flex items-center justify-between gap-3"
+      style={{ backgroundColor: 'var(--bg-mantle)', border: '1px solid var(--bg-surface)' }}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span
+            className="text-[10px] font-mono w-3 text-center"
+            style={{ color: server.registered ? 'var(--accent-green, #a6e3a1)' : 'var(--accent-red, #f38ba8)' }}
+          >
+            {server.registered ? '✓' : '✗'}
+          </span>
+          <span className="text-sm text-[color:var(--text-main)] font-mono">{label}</span>
+        </div>
+        {server.path && (
+          <p
+            className="text-[10px] text-[color:var(--text-muted)] mt-0.5 font-mono truncate"
+            title={server.path}
+          >
+            {server.path}
+          </p>
+        )}
+        {!server.registered && (
+          <p className="text-[10px] text-[color:var(--text-muted)] mt-0.5">
+            Not registered in Claude Code config
+          </p>
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <SectionLabel label="MCP Servers" />
+      {loading ? (
+        <div
+          className="px-3 py-2 rounded-lg text-[11px] text-[color:var(--text-muted)]"
+          style={{ backgroundColor: 'var(--bg-mantle)', border: '1px solid var(--bg-surface)' }}
+        >
+          Checking ~/.claude.json…
+        </div>
+      ) : status ? (
+        <>
+          {renderRow('wmux', status.wmux)}
+          {renderRow('wmux-a2a', status.wmuxA2a)}
+          <div
+            className="px-3 py-2 rounded-lg flex items-center justify-between gap-3"
+            style={{ backgroundColor: 'var(--bg-mantle)', border: '1px solid var(--bg-surface)' }}
+          >
+            <div className="min-w-0 flex-1">
+              <p className="text-[11px] text-[color:var(--text-sub)] font-mono truncate" title={status.configPath}>
+                {status.configPath}
+              </p>
+              <p className="text-[10px] text-[color:var(--text-muted)] mt-0.5">
+                {status.configExists
+                  ? status.configModified
+                    ? `modified ${new Date(status.configModified).toLocaleString()}`
+                    : 'config file present'
+                  : 'config file does not exist'}
+              </p>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <button
+                onClick={() => void handleReregister()}
+                disabled={pending !== null}
+                className="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
+                style={{
+                  backgroundColor: 'var(--bg-surface)',
+                  color: 'var(--accent-blue)',
+                  border: '1px solid var(--bg-overlay)',
+                  opacity: pending ? 0.5 : 1,
+                }}
+              >
+                {pending === 'reregister' ? '…' : 'Re-register'}
+              </button>
+              {confirmingUnregister ? (
+                <>
+                  <button
+                    onClick={() => void handleUnregister()}
+                    disabled={pending !== null}
+                    className="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
+                    style={{ backgroundColor: 'var(--accent-red)', color: 'var(--bg-base)' }}
+                  >
+                    {pending === 'unregister' ? '…' : 'Confirm'}
+                  </button>
+                  <button
+                    onClick={() => setConfirmingUnregister(false)}
+                    disabled={pending !== null}
+                    className="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
+                    style={{ backgroundColor: 'var(--bg-surface)', color: 'var(--text-main)' }}
+                  >
+                    Cancel
+                  </button>
+                </>
+              ) : (
+                <button
+                  onClick={() => setConfirmingUnregister(true)}
+                  disabled={pending !== null}
+                  className="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
+                  style={{
+                    backgroundColor: 'var(--bg-surface)',
+                    color: 'var(--accent-red)',
+                    border: '1px solid var(--bg-overlay)',
+                  }}
+                >
+                  Unregister
+                </button>
+              )}
+            </div>
+          </div>
+        </>
+      ) : (
+        <div
+          className="px-3 py-2 rounded-lg text-[11px] text-[color:var(--text-muted)]"
+          style={{ backgroundColor: 'var(--bg-mantle)', border: '1px solid var(--bg-surface)' }}
+        >
+          MCP status unavailable. Restart wmux and try again.
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ─── Update status widget ─────────────────────────────────────────────────────
 
 type UpdateState = 'idle' | 'checking' | 'available' | 'downloaded' | 'not-available' | 'error';
@@ -482,6 +681,9 @@ function TabGeneral() {
           </button>
         </SettingRow>
       </div>
+
+      {/* MCP integration */}
+      <McpStatusSection />
 
       {/* Reset */}
       <ResetSection />

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -52,6 +52,10 @@ export const IPC = {
   TOKEN_UPDATE: 'token:update',
   // Window control
   WINDOW_HIDE: 'window:hide',
+  // MCP integration status / management (Settings panel + CLI parity)
+  MCP_CHECK: 'mcp:check',
+  MCP_REREGISTER: 'mcp:reregister',
+  MCP_UNREGISTER: 'mcp:unregister',
 } as const;
 
 // Named Pipe / Unix socket path for wmux API

--- a/src/shared/electron.d.ts
+++ b/src/shared/electron.d.ts
@@ -16,6 +16,29 @@ declare global {
         unwatch: (dirPath: string) => Promise<void>;
         onChanged: (callback: (dirPath: string) => void) => () => void;
       };
+      mcp?: {
+        check: () => Promise<{
+          wmux: { registered: boolean; path: string | null };
+          wmuxA2a: { registered: boolean; path: string | null };
+          configPath: string;
+          configExists: boolean;
+          configModified: string | null;
+        }>;
+        reregister: () => Promise<{
+          wmux: { registered: boolean; path: string | null };
+          wmuxA2a: { registered: boolean; path: string | null };
+          configPath: string;
+          configExists: boolean;
+          configModified: string | null;
+        }>;
+        unregister: () => Promise<{
+          wmux: { registered: boolean; path: string | null };
+          wmuxA2a: { registered: boolean; path: string | null };
+          configPath: string;
+          configExists: boolean;
+          configModified: string | null;
+        }>;
+      };
     };
     clipboardAPI: {
       writeText: (text: string) => Promise<void>;


### PR DESCRIPTION
## Summary

Batch 2C of the macOS/Linux port. Three workstreams: a user-facing MCP status surface, Outside-Voice T4 brew detection, and research that closed Outside-Voice T5 without a code change.

- **wmux mcp CLI + Settings MCP section** (Phase 1.17, DX D4): `wmux mcp check/register/unregister` works without daemon. McpRegistrar gains `getStatus()` + `forceUnregister()`. New IPC channels (`mcp:check`, `mcp:reregister`, `mcp:unregister`). Settings General tab gets an MCP Servers section with status, paths, Re-register / Unregister buttons.
- **BrewDetector** (Outside Voice T4): probes `/opt/homebrew/Caskroom/wmux` and `/usr/local/Caskroom/wmux` directly so Finder-launched apps (where `brew` is not in PATH) detect cask installs reliably.
- **macOS error catalog wire-up** (Phase 1.16 wire-up): McpRegistrar EACCES → `mcpPermissionDenied` message. PlaywrightEngine launch failure with chromium/quarantine keywords → `playwrightChromiumQuarantine` message. Both gated on `isMac`. PTY spawn wire-up skipped (no try/catch around spawn).
- **SMAppService research** (Outside Voice T5 — closed): Electron PR #37244 (v29) already migrated `app.setLoginItemSettings` to SMAppService internally. wmux v41 inherits this — **no helper bundle required**. Two follow-ups documented (drop `openAsHidden`, use `app.dock.hide()` for launch-hidden). Full research note in `docs/macos-autostart.md`.

## Test plan

- [x] `npx vitest run` — 617 tests passing (56 files, +18 from new McpRegistrar + BrewDetector tests)
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx eslint --max-warnings=0` on all 5 new files — clean
- [x] `npm run build:cli` + smoke test: `wmux mcp check`, `wmux mcp check --json`, `wmux mcp` (help) on Windows
- [x] Code-read review: every macOS path is `isMac`-gated; Windows behavior byte-identical
- [ ] **macOS manual QA** (cannot run from Windows host):
  - `wmux mcp check` produces correct output (verify ~/.claude.json path is correct)
  - Settings → MCP section shows registered status correctly
  - BrewDetector returns true after `brew install openwong2kim/tap/wmux` (deferred — needs Phase 2 brew tap)
  - macOS error messages render correctly when triggered
- [ ] CI Cross-Platform Baseline (this PR triggers it on push) — 3 OS green expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)