### PR TITLE
feat(cross-platform): allow Unix shell basenames in PTY allowlist

### DIFF
--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -11,10 +11,13 @@ import { updateCwd } from './metadata.handler';
 import { wrapHandler } from '../wrapHandler';
 
 /**
- * Allowed shell basenames (case-insensitive on Windows).
+ * Allowed shell basenames (compared case-insensitively).
  * Only these executables may be spawned via IPC.
+ * Windows entries keep `.exe`; Unix entries (mac/linux) are bare basenames
+ * so that detector paths like `/bin/zsh` or `/opt/homebrew/bin/pwsh` resolve.
  */
 const ALLOWED_SHELLS = new Set([
+  // Windows
   'powershell.exe',
   'pwsh.exe',
   'cmd.exe',
@@ -22,6 +25,12 @@ const ALLOWED_SHELLS = new Set([
   'wsl.exe',
   'git-bash.exe',
   'sh.exe',
+  // Unix (mac/linux)
+  'zsh',
+  'bash',
+  'fish',
+  'pwsh',
+  'sh',
 ]);
 
 function isAllowedShell(shell: string): boolean {


### PR DESCRIPTION
## Summary

- `pty.handler.ts`의 `ALLOWED_SHELLS`에 Unix 베이스네임 5개 추가: `zsh`, `bash`, `fish`, `pwsh`, `sh`
- 주석 갱신 — compared case-insensitively, Windows/Unix 구분 명시

## Why

PR #10(`3a83124`)이 머지되면서 `ShellDetector.getDefault()`가 처음 PTY default로 사용되기 시작. 그러나 detector가 mac/linux에서 반환하는 경로(`/bin/zsh`, `/bin/bash`, `/usr/bin/fish`, `/opt/homebrew/bin/pwsh` 등)의 베이스네임은 allowlist에 없어 `PTY_CREATE: shell not allowed` 에러 발생.

cross-platform 진행 상태 메모리 1.19 항목 처리.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/main/pty/__tests__/ShellDetector.test.ts` — 8/8 pass
- [x] cross-platform CI baseline (3 OS) — branch push 후 자동 실행
- [ ] mac/linux 실기 검증 — Phase 2/3에서

🤖 Generated with [Claude Code](https://claude.com/claude-code)