### PR TITLE
feat(pane): optional pane metadata API for external tooling (PR 1/2)

### DIFF
--- a/src/main/pipe/handlers/__tests__/pane.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/pane.rpc.test.ts
@@ -1,0 +1,277 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserWindow } from 'electron';
+import { RpcRouter } from '../../RpcRouter';
+import { registerPaneRpc } from '../pane.rpc';
+import { PANE_METADATA_MAX_BYTES } from '../../../../shared/types';
+
+const { sendToRendererMock } = vi.hoisted(() => ({
+  sendToRendererMock: vi.fn(),
+}));
+
+vi.mock('../_bridge', () => ({
+  sendToRenderer: sendToRendererMock,
+}));
+
+const fakeWindow = {} as BrowserWindow;
+
+function setupRouter(): RpcRouter {
+  const router = new RpcRouter();
+  registerPaneRpc(router, () => fakeWindow);
+  return router;
+}
+
+describe('pane.rpc — metadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sendToRendererMock.mockResolvedValue({ ok: true });
+  });
+
+  describe('pane.setMetadata', () => {
+    it('forwards a sanitized patch with merge=true by default', async () => {
+      const router = setupRouter();
+      const res = await router.dispatch({
+        id: 'rpc-1',
+        method: 'pane.setMetadata',
+        params: { paneId: 'pane-x', label: 'Backend', role: 'service' },
+      });
+
+      expect(res.ok).toBe(true);
+      expect(sendToRendererMock).toHaveBeenCalledTimes(1);
+      const [, method, payload] = sendToRendererMock.mock.calls[0];
+      expect(method).toBe('pane.setMetadata');
+      expect(payload).toMatchObject({
+        paneId: 'pane-x',
+        merge: true,
+        patch: { label: 'Backend', role: 'service' },
+      });
+    });
+
+    it('honors merge=false when caller passes it', async () => {
+      const router = setupRouter();
+      await router.dispatch({
+        id: 'rpc-2',
+        method: 'pane.setMetadata',
+        params: { paneId: 'pane-x', status: 'idle', merge: false },
+      });
+
+      const [, , payload] = sendToRendererMock.mock.calls[0];
+      expect(payload).toMatchObject({ merge: false, patch: { status: 'idle' } });
+    });
+
+    it('rejects when label exceeds 64 chars', async () => {
+      const router = setupRouter();
+      const longLabel = 'a'.repeat(65);
+      const res = await router.dispatch({
+        id: 'rpc-3',
+        method: 'pane.setMetadata',
+        params: { label: longLabel },
+      });
+
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.error).toMatch(/label/);
+      }
+      expect(sendToRendererMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects when status exceeds 128 chars', async () => {
+      const router = setupRouter();
+      const res = await router.dispatch({
+        id: 'rpc-4',
+        method: 'pane.setMetadata',
+        params: { status: 's'.repeat(129) },
+      });
+
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error).toMatch(/status/);
+    });
+
+    it('rejects non-string values inside custom map', async () => {
+      const router = setupRouter();
+      const res = await router.dispatch({
+        id: 'rpc-5',
+        method: 'pane.setMetadata',
+        params: { custom: { count: 42 } as unknown as Record<string, string> },
+      });
+
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error).toMatch(/custom\.count/);
+      expect(sendToRendererMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects when custom is an array, not an object', async () => {
+      const router = setupRouter();
+      const res = await router.dispatch({
+        id: 'rpc-6',
+        method: 'pane.setMetadata',
+        params: { custom: ['nope'] as unknown as Record<string, string> },
+      });
+
+      expect(res.ok).toBe(false);
+    });
+
+    it('rejects oversized payload over 8KB cap', async () => {
+      const router = setupRouter();
+      const huge = 'x'.repeat(PANE_METADATA_MAX_BYTES + 50);
+      const res = await router.dispatch({
+        id: 'rpc-7',
+        method: 'pane.setMetadata',
+        params: { custom: { blob: huge } },
+      });
+
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error).toMatch(/exceeds/);
+      expect(sendToRendererMock).not.toHaveBeenCalled();
+    });
+
+    it('forwards undefined paneId so renderer falls back to active pane', async () => {
+      const router = setupRouter();
+      await router.dispatch({
+        id: 'rpc-8',
+        method: 'pane.setMetadata',
+        params: { label: 'Active' },
+      });
+      const [, , payload] = sendToRendererMock.mock.calls[0];
+      expect(payload.paneId).toBeUndefined();
+    });
+  });
+
+  describe('pane.getMetadata', () => {
+    it('forwards paneId to renderer', async () => {
+      const router = setupRouter();
+      sendToRendererMock.mockResolvedValueOnce({
+        paneId: 'pane-x',
+        metadata: { label: 'Backend' },
+      });
+
+      const res = await router.dispatch({
+        id: 'rpc-9',
+        method: 'pane.getMetadata',
+        params: { paneId: 'pane-x' },
+      });
+
+      expect(res.ok).toBe(true);
+      expect(sendToRendererMock).toHaveBeenCalledWith(
+        expect.any(Function),
+        'pane.getMetadata',
+        { paneId: 'pane-x' },
+      );
+    });
+
+    it('passes undefined paneId through when omitted', async () => {
+      const router = setupRouter();
+      await router.dispatch({
+        id: 'rpc-10',
+        method: 'pane.getMetadata',
+        params: {},
+      });
+      const [, , payload] = sendToRendererMock.mock.calls[0];
+      expect(payload.paneId).toBeUndefined();
+    });
+  });
+
+  describe('pane.clearMetadata', () => {
+    it('forwards paneId to renderer', async () => {
+      const router = setupRouter();
+      const res = await router.dispatch({
+        id: 'rpc-11',
+        method: 'pane.clearMetadata',
+        params: { paneId: 'pane-x' },
+      });
+      expect(res.ok).toBe(true);
+      const [, method, payload] = sendToRendererMock.mock.calls[0];
+      expect(method).toBe('pane.clearMetadata');
+      expect(payload).toEqual({ paneId: 'pane-x', workspaceId: undefined });
+    });
+  });
+
+  describe('review fixes', () => {
+    it('1.1 — forwards workspaceId for setMetadata so cross-workspace writes are scoped', async () => {
+      const router = setupRouter();
+      await router.dispatch({
+        id: 'rpc-fix-1',
+        method: 'pane.setMetadata',
+        params: { workspaceId: 'ws-caller', paneId: 'pane-y', label: 'X' },
+      });
+      const [, , payload] = sendToRendererMock.mock.calls[0];
+      expect(payload.workspaceId).toBe('ws-caller');
+    });
+
+    it('1.1 — forwards workspaceId for getMetadata + clearMetadata', async () => {
+      const router = setupRouter();
+      await router.dispatch({
+        id: 'rpc-fix-2',
+        method: 'pane.getMetadata',
+        params: { workspaceId: 'ws-caller' },
+      });
+      await router.dispatch({
+        id: 'rpc-fix-3',
+        method: 'pane.clearMetadata',
+        params: { workspaceId: 'ws-caller' },
+      });
+      const getCall = sendToRendererMock.mock.calls[0];
+      const clearCall = sendToRendererMock.mock.calls[1];
+      expect(getCall[2]).toEqual({ paneId: undefined, workspaceId: 'ws-caller' });
+      expect(clearCall[2]).toEqual({ paneId: undefined, workspaceId: 'ws-caller' });
+    });
+
+    it('1.2 — rejects role exceeding 64 chars', async () => {
+      const router = setupRouter();
+      const res = await router.dispatch({
+        id: 'rpc-fix-4',
+        method: 'pane.setMetadata',
+        params: { role: 'r'.repeat(65) },
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error).toMatch(/role/);
+      expect(sendToRendererMock).not.toHaveBeenCalled();
+    });
+
+    it('1.3 — rejects empty custom key', async () => {
+      const router = setupRouter();
+      const res = await router.dispatch({
+        id: 'rpc-fix-5',
+        method: 'pane.setMetadata',
+        params: { custom: { '': 'value' } },
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error).toMatch(/empty/);
+    });
+
+    it('1.3 — rejects custom key exceeding 64 chars', async () => {
+      const router = setupRouter();
+      const res = await router.dispatch({
+        id: 'rpc-fix-6',
+        method: 'pane.setMetadata',
+        params: { custom: { ['k'.repeat(65)]: 'value' } },
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error).toMatch(/key exceeds/);
+    });
+
+    it('1.3 — rejects custom maps with > 32 entries', async () => {
+      const router = setupRouter();
+      const custom: Record<string, string> = {};
+      for (let i = 0; i < 33; i++) custom[`k${i}`] = 'v';
+      const res = await router.dispatch({
+        id: 'rpc-fix-7',
+        method: 'pane.setMetadata',
+        params: { custom },
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error).toMatch(/32 entries/);
+    });
+
+    it('1.3 — accepts custom map at exactly the entry limit', async () => {
+      const router = setupRouter();
+      const custom: Record<string, string> = {};
+      for (let i = 0; i < 32; i++) custom[`k${i}`] = 'v';
+      const res = await router.dispatch({
+        id: 'rpc-fix-8',
+        method: 'pane.setMetadata',
+        params: { custom },
+      });
+      expect(res.ok).toBe(true);
+    });
+  });
+});

--- a/src/main/pipe/handlers/pane.rpc.ts
+++ b/src/main/pipe/handlers/pane.rpc.ts
@@ -1,8 +1,89 @@
 import type { BrowserWindow } from 'electron';
 import type { RpcRouter } from '../RpcRouter';
 import { sendToRenderer } from './_bridge';
+import {
+  PANE_METADATA_MAX_BYTES,
+  PANE_METADATA_LABEL_MAX,
+  PANE_METADATA_ROLE_MAX,
+  PANE_METADATA_STATUS_MAX,
+  PANE_METADATA_CUSTOM_KEY_MAX,
+  PANE_METADATA_CUSTOM_MAX_ENTRIES,
+} from '../../../shared/types';
 
 type GetWindow = () => BrowserWindow | null;
+
+interface MetadataPatchInput {
+  label?: unknown;
+  role?: unknown;
+  status?: unknown;
+  custom?: unknown;
+}
+
+interface SanitizedPatch {
+  label?: string;
+  role?: string;
+  status?: string;
+  custom?: Record<string, string>;
+}
+
+function sanitizeMetadataPatch(input: MetadataPatchInput): SanitizedPatch | { error: string } {
+  const out: SanitizedPatch = {};
+
+  if (input.label !== undefined) {
+    if (typeof input.label !== 'string') return { error: '"label" must be a string' };
+    if (input.label.length > PANE_METADATA_LABEL_MAX) {
+      return { error: `"label" exceeds ${PANE_METADATA_LABEL_MAX} chars` };
+    }
+    out.label = input.label;
+  }
+  if (input.role !== undefined) {
+    if (typeof input.role !== 'string') return { error: '"role" must be a string' };
+    if (input.role.length > PANE_METADATA_ROLE_MAX) {
+      return { error: `"role" exceeds ${PANE_METADATA_ROLE_MAX} chars` };
+    }
+    out.role = input.role;
+  }
+  if (input.status !== undefined) {
+    if (typeof input.status !== 'string') return { error: '"status" must be a string' };
+    if (input.status.length > PANE_METADATA_STATUS_MAX) {
+      return { error: `"status" exceeds ${PANE_METADATA_STATUS_MAX} chars` };
+    }
+    out.status = input.status;
+  }
+  if (input.custom !== undefined) {
+    if (
+      typeof input.custom !== 'object' ||
+      input.custom === null ||
+      Array.isArray(input.custom)
+    ) {
+      return { error: '"custom" must be an object of string→string' };
+    }
+    const entries = Object.entries(input.custom);
+    if (entries.length > PANE_METADATA_CUSTOM_MAX_ENTRIES) {
+      return { error: `"custom" exceeds ${PANE_METADATA_CUSTOM_MAX_ENTRIES} entries` };
+    }
+    const custom: Record<string, string> = {};
+    for (const [k, v] of entries) {
+      if (k.length === 0) {
+        return { error: '"custom" key cannot be empty' };
+      }
+      if (k.length > PANE_METADATA_CUSTOM_KEY_MAX) {
+        return { error: `"custom" key exceeds ${PANE_METADATA_CUSTOM_KEY_MAX} chars` };
+      }
+      if (typeof v !== 'string') {
+        return { error: `"custom.${k}" must be a string` };
+      }
+      custom[k] = v;
+    }
+    out.custom = custom;
+  }
+
+  // Hard cap on serialized size — prevents bloated session.json.
+  if (JSON.stringify(out).length > PANE_METADATA_MAX_BYTES) {
+    return { error: `metadata exceeds ${PANE_METADATA_MAX_BYTES} bytes` };
+  }
+  return out;
+}
 
 export function registerPaneRpc(router: RpcRouter, getWindow: GetWindow): void {
   /**
@@ -35,5 +116,50 @@ export function registerPaneRpc(router: RpcRouter, getWindow: GetWindow): void {
       );
     }
     return sendToRenderer(getWindow, 'pane.split', { direction });
+  });
+
+  /**
+   * pane.setMetadata — set descriptive metadata on a leaf pane.
+   * params: { paneId?, workspaceId?, label?, role?, status?, custom?, merge? }
+   * External MCP callers SHOULD pass workspaceId so writes stay scoped to the
+   * caller's workspace and don't get hijacked to whichever ws the user is
+   * currently viewing. paneId omitted → active pane in the targeted workspace.
+   * merge defaults to true (patch-style); false replaces the metadata object.
+   */
+  router.register('pane.setMetadata', (params) => {
+    const paneId = typeof params['paneId'] === 'string' ? params['paneId'] : undefined;
+    const workspaceId = typeof params['workspaceId'] === 'string' ? params['workspaceId'] : undefined;
+    const merge = params['merge'] !== false; // default true
+
+    const sanitized = sanitizeMetadataPatch(params as MetadataPatchInput);
+    if ('error' in sanitized) {
+      return Promise.reject(new Error(`pane.setMetadata: ${sanitized.error}`));
+    }
+    return sendToRenderer(getWindow, 'pane.setMetadata', {
+      paneId,
+      workspaceId,
+      patch: sanitized,
+      merge,
+    });
+  });
+
+  /**
+   * pane.getMetadata — read metadata for a leaf pane.
+   * params: { paneId?, workspaceId? } — omitted workspaceId → active workspace.
+   */
+  router.register('pane.getMetadata', (params) => {
+    const paneId = typeof params['paneId'] === 'string' ? params['paneId'] : undefined;
+    const workspaceId = typeof params['workspaceId'] === 'string' ? params['workspaceId'] : undefined;
+    return sendToRenderer(getWindow, 'pane.getMetadata', { paneId, workspaceId });
+  });
+
+  /**
+   * pane.clearMetadata — drop all metadata for a leaf pane.
+   * params: { paneId?, workspaceId? }
+   */
+  router.register('pane.clearMetadata', (params) => {
+    const paneId = typeof params['paneId'] === 'string' ? params['paneId'] : undefined;
+    const workspaceId = typeof params['workspaceId'] === 'string' ? params['workspaceId'] : undefined;
+    return sendToRenderer(getWindow, 'pane.clearMetadata', { paneId, workspaceId });
   });
 }

--- a/src/main/pipe/handlers/system.rpc.ts
+++ b/src/main/pipe/handlers/system.rpc.ts
@@ -27,10 +27,16 @@ export function registerSystemRpc(router: RpcRouter): void {
   });
 
   /**
-   * system.capabilities — returns the full list of registered RPC method names.
-   * Sourced from the single-source-of-truth array in shared/rpc.ts.
+   * system.capabilities — returns the full list of registered RPC method names
+   * plus a feature flag map so external tooling can detect optional surfaces
+   * (pane metadata, future event bus, etc.) without inferring from method names.
    */
   router.register('system.capabilities', (_params) => {
-    return Promise.resolve({ methods: ALL_RPC_METHODS });
+    return Promise.resolve({
+      methods: ALL_RPC_METHODS,
+      features: {
+        paneMetadata: true,
+      },
+    });
   });
 }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -283,11 +283,49 @@ server.tool(
 
 server.tool(
   'pane_list',
-  'List all panes in a workspace with CWD and git branch info. Omit workspaceId to list the active workspace.',
+  'List all panes in a workspace with CWD, git branch, and metadata. Omit workspaceId to list the active workspace.',
   {
     workspaceId: z.string().optional().describe('Target a specific workspace by ID. Omit to use the active workspace.'),
   },
   async ({ workspaceId }) => callRpc('pane.list', workspaceId ? { workspaceId } : {}),
+);
+
+server.tool(
+  'pane_set_metadata',
+  'Attach descriptive metadata (label/role/status + custom k/v) to a leaf pane in the calling workspace. The custom map is deep-merged when merge=true, so cooperating tools can each write their own keys without clobbering. Set merge=false to replace the entire metadata object. Omit paneId to target the active pane in the calling workspace.',
+  {
+    paneId: z.string().optional().describe('Target leaf pane id. Omit to use the active pane in the calling workspace.'),
+    label: z.string().max(64).optional().describe('Short human label, e.g. "Backend".'),
+    role: z.string().max(64).optional().describe('Free-form role tag, e.g. "service" or "test-runner".'),
+    status: z.string().max(128).optional().describe('Current status, e.g. "running-tests".'),
+    custom: z.record(z.string(), z.string()).optional().describe('Additional string→string properties for tool-specific data. Deep-merged with existing custom map when merge=true.'),
+    merge: z.boolean().optional().describe('Default true (patch + deep-merge custom). Set false to replace the entire metadata object.'),
+  },
+  async ({ paneId, label, role, status, custom, merge }) => {
+    const workspaceId = await requireWorkspaceId();
+    const params: Record<string, unknown> = { workspaceId };
+    if (paneId !== undefined) params['paneId'] = paneId;
+    if (label !== undefined) params['label'] = label;
+    if (role !== undefined) params['role'] = role;
+    if (status !== undefined) params['status'] = status;
+    if (custom !== undefined) params['custom'] = custom;
+    if (merge !== undefined) params['merge'] = merge;
+    return callRpc('pane.setMetadata', params);
+  },
+);
+
+server.tool(
+  'pane_get_metadata',
+  'Read the metadata attached to a leaf pane in the calling workspace. Returns { paneId, metadata } or null metadata if none set.',
+  {
+    paneId: z.string().optional().describe('Target leaf pane id. Omit to use the active pane in the calling workspace.'),
+  },
+  async ({ paneId }) => {
+    const workspaceId = await requireWorkspaceId();
+    const params: Record<string, unknown> = { workspaceId };
+    if (paneId !== undefined) params['paneId'] = paneId;
+    return callRpc('pane.getMetadata', params);
+  },
 );
 
 // === A2A (Agent-to-Agent) tools ===

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -339,6 +339,7 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
         active: l.id === ws.activePaneId,
         cwd: liveCwd || firstSurface?.cwd,
         gitBranch: liveGitBranch,
+        metadata: l.metadata,
       };
     });
   }
@@ -356,6 +357,65 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       params.direction === 'vertical' ? 'vertical' : 'horizontal';
     store.splitPane(ws.activePaneId, direction);
     return { ok: true };
+  }
+
+  if (method === 'pane.setMetadata') {
+    // Workspace scoping: external MCP callers MUST pass workspaceId so writes
+    // can't be hijacked into whichever workspace the user happens to focus.
+    // Internal callers may omit it and fall back to the active workspace.
+    const wsId = typeof params.workspaceId === 'string' && params.workspaceId.length > 0
+      ? params.workspaceId
+      : store.activeWorkspaceId;
+    const ws = store.workspaces.find((w) => w.id === wsId);
+    if (!ws) return { error: `pane.setMetadata: workspace "${wsId}" not found` };
+    const paneId = typeof params.paneId === 'string' && params.paneId.length > 0
+      ? params.paneId
+      : ws.activePaneId;
+    const target = findPaneById(ws.rootPane, paneId);
+    if (!target || target.type !== 'leaf') {
+      return { error: `pane.setMetadata: leaf pane "${paneId}" not found in workspace "${wsId}"` };
+    }
+    const patch = (params.patch && typeof params.patch === 'object' ? params.patch : {}) as Partial<import('../../shared/types').PaneMetadata>;
+    const merge = params.merge !== false;
+    try {
+      store.setPaneMetadata(paneId, patch, { merge, workspaceId: wsId });
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : String(err) };
+    }
+    return { ok: true, paneId, metadata: useStore.getState().getPaneMetadata(paneId, { workspaceId: wsId }) };
+  }
+
+  if (method === 'pane.getMetadata') {
+    const wsId = typeof params.workspaceId === 'string' && params.workspaceId.length > 0
+      ? params.workspaceId
+      : store.activeWorkspaceId;
+    const ws = store.workspaces.find((w) => w.id === wsId);
+    if (!ws) return { error: `pane.getMetadata: workspace "${wsId}" not found` };
+    const paneId = typeof params.paneId === 'string' && params.paneId.length > 0
+      ? params.paneId
+      : ws.activePaneId;
+    const target = findPaneById(ws.rootPane, paneId);
+    if (!target || target.type !== 'leaf') {
+      return { error: `pane.getMetadata: leaf pane "${paneId}" not found in workspace "${wsId}"` };
+    }
+    return { paneId, metadata: target.metadata };
+  }
+
+  if (method === 'pane.clearMetadata') {
+    const wsId = typeof params.workspaceId === 'string' && params.workspaceId.length > 0
+      ? params.workspaceId
+      : store.activeWorkspaceId;
+    const ws = store.workspaces.find((w) => w.id === wsId);
+    if (!ws) return { error: `pane.clearMetadata: workspace "${wsId}" not found` };
+    const paneId = typeof params.paneId === 'string' && params.paneId.length > 0
+      ? params.paneId
+      : ws.activePaneId;
+    const target = findPaneById(ws.rootPane, paneId);
+    if (!target || target.type !== 'leaf') {
+      return { error: `pane.clearMetadata: leaf pane "${paneId}" not found in workspace "${wsId}"` };
+    }
+    store.clearPaneMetadata(paneId, { workspaceId: wsId });
+    return { ok: true, paneId };
   }
 
   // -------------------------------------------------------------------------

--- a/src/renderer/stores/slices/__tests__/paneSlice.metadata.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneSlice.metadata.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { createPaneSlice, type PaneSlice } from '../paneSlice';
+import {
+  createWorkspace,
+  PANE_METADATA_MAX_BYTES,
+  type Workspace,
+} from '../../../../shared/types';
+
+type TestState = PaneSlice & {
+  workspaces: Workspace[];
+  activeWorkspaceId: string;
+};
+
+function createTestStore() {
+  const ws = createWorkspace('Test');
+  return create<TestState>()(
+    immer((...args) => ({
+      workspaces: [ws],
+      activeWorkspaceId: ws.id,
+      // @ts-expect-error — minimal test store doesn't match full StoreState
+      ...createPaneSlice(...args),
+    }))
+  );
+}
+
+function createTwoWorkspaceStore() {
+  const wsA = createWorkspace('A');
+  const wsB = createWorkspace('B');
+  return create<TestState>()(
+    immer((...args) => ({
+      workspaces: [wsA, wsB],
+      activeWorkspaceId: wsA.id,
+      // @ts-expect-error — minimal test store doesn't match full StoreState
+      ...createPaneSlice(...args),
+    }))
+  );
+}
+
+describe('PaneSlice — metadata', () => {
+  let store: ReturnType<typeof createTestStore>;
+  let paneId: string;
+
+  beforeEach(() => {
+    store = createTestStore();
+    paneId = store.getState().workspaces[0].rootPane.id;
+  });
+
+  describe('setPaneMetadata', () => {
+    it('sets initial metadata with updatedAt populated', () => {
+      const before = Date.now();
+      store.getState().setPaneMetadata(paneId, { label: 'Backend', role: 'service' });
+      const after = Date.now();
+
+      const meta = store.getState().getPaneMetadata(paneId);
+      expect(meta).toBeDefined();
+      expect(meta?.label).toBe('Backend');
+      expect(meta?.role).toBe('service');
+      expect(meta?.updatedAt).toBeGreaterThanOrEqual(before);
+      expect(meta?.updatedAt).toBeLessThanOrEqual(after);
+    });
+
+    it('merges by default (preserves existing fields)', () => {
+      store.getState().setPaneMetadata(paneId, { label: 'Backend', role: 'service' });
+      store.getState().setPaneMetadata(paneId, { status: 'running-tests' });
+
+      const meta = store.getState().getPaneMetadata(paneId);
+      expect(meta?.label).toBe('Backend');
+      expect(meta?.role).toBe('service');
+      expect(meta?.status).toBe('running-tests');
+    });
+
+    it('replaces when merge=false', () => {
+      store.getState().setPaneMetadata(paneId, { label: 'Backend', role: 'service' });
+      store.getState().setPaneMetadata(paneId, { status: 'idle' }, { merge: false });
+
+      const meta = store.getState().getPaneMetadata(paneId);
+      expect(meta?.label).toBeUndefined();
+      expect(meta?.role).toBeUndefined();
+      expect(meta?.status).toBe('idle');
+    });
+
+    it('persists custom string→string map', () => {
+      store.getState().setPaneMetadata(paneId, {
+        custom: { gitWorktree: 'feat/foo', tier: 'staging' },
+      });
+      const meta = store.getState().getPaneMetadata(paneId);
+      expect(meta?.custom).toEqual({ gitWorktree: 'feat/foo', tier: 'staging' });
+    });
+
+    it('rejects metadata exceeding 8KB cap', () => {
+      const huge = 'x'.repeat(PANE_METADATA_MAX_BYTES + 100);
+      expect(() =>
+        store.getState().setPaneMetadata(paneId, { custom: { blob: huge } })
+      ).toThrow(/exceeds/);
+
+      // No partial state — slice should not have been mutated.
+      expect(store.getState().getPaneMetadata(paneId)).toBeUndefined();
+    });
+
+    it('is a no-op for unknown paneId', () => {
+      store.getState().setPaneMetadata('does-not-exist', { label: 'Ghost' });
+      expect(store.getState().getPaneMetadata('does-not-exist')).toBeUndefined();
+    });
+  });
+
+  describe('getPaneMetadata', () => {
+    it('returns undefined when no metadata set', () => {
+      expect(store.getState().getPaneMetadata(paneId)).toBeUndefined();
+    });
+
+    it('returns undefined for non-leaf panes (branches)', () => {
+      // Split to create a branch
+      store.getState().splitPane(paneId, 'horizontal');
+      const ws = store.getState().workspaces[0];
+      const branchId = ws.rootPane.id; // root is now a branch
+
+      expect(store.getState().getPaneMetadata(branchId)).toBeUndefined();
+    });
+  });
+
+  describe('clearPaneMetadata', () => {
+    it('drops all metadata', () => {
+      store.getState().setPaneMetadata(paneId, {
+        label: 'Backend',
+        custom: { foo: 'bar' },
+      });
+      expect(store.getState().getPaneMetadata(paneId)).toBeDefined();
+
+      store.getState().clearPaneMetadata(paneId);
+      expect(store.getState().getPaneMetadata(paneId)).toBeUndefined();
+    });
+
+    it('is safe on a pane that never had metadata', () => {
+      expect(() => store.getState().clearPaneMetadata(paneId)).not.toThrow();
+      expect(store.getState().getPaneMetadata(paneId)).toBeUndefined();
+    });
+  });
+
+  describe('metadata survives pane operations', () => {
+    it('a pane keeps its metadata after splitPane creates a sibling', () => {
+      store.getState().setPaneMetadata(paneId, { label: 'Original' });
+      store.getState().splitPane(paneId, 'horizontal');
+
+      // After split the original leaf is cloned into the branch's first child;
+      // its id is preserved. Verify metadata is intact via getPaneMetadata.
+      const meta = store.getState().getPaneMetadata(paneId);
+      expect(meta?.label).toBe('Original');
+    });
+  });
+
+  describe('custom map deep-merge (review fix 6.1)', () => {
+    it('preserves existing custom keys when patch only sets a new key', () => {
+      store.getState().setPaneMetadata(paneId, {
+        custom: { gitWorktree: 'feat/foo', tier: 'staging' },
+      });
+      store.getState().setPaneMetadata(paneId, {
+        custom: { tagger: 'mcp-x' },
+      });
+
+      const meta = store.getState().getPaneMetadata(paneId);
+      expect(meta?.custom).toEqual({
+        gitWorktree: 'feat/foo',
+        tier: 'staging',
+        tagger: 'mcp-x',
+      });
+    });
+
+    it('overwrites the same key when both writes touch it', () => {
+      store.getState().setPaneMetadata(paneId, { custom: { tier: 'dev' } });
+      store.getState().setPaneMetadata(paneId, { custom: { tier: 'prod' } });
+
+      expect(store.getState().getPaneMetadata(paneId)?.custom).toEqual({ tier: 'prod' });
+    });
+
+    it('merge=false replaces the entire custom map', () => {
+      store.getState().setPaneMetadata(paneId, { custom: { a: '1', b: '2' } });
+      store.getState().setPaneMetadata(paneId, { custom: { c: '3' } }, { merge: false });
+
+      expect(store.getState().getPaneMetadata(paneId)?.custom).toEqual({ c: '3' });
+    });
+  });
+
+  describe('cross-workspace scoping (review fix 1.1)', () => {
+    it('writes to the targeted workspace, not just active', () => {
+      const twoStore = createTwoWorkspaceStore();
+      const wsA = twoStore.getState().workspaces[0];
+      const wsB = twoStore.getState().workspaces[1];
+      const paneA = wsA.rootPane.id;
+      const paneB = wsB.rootPane.id;
+
+      // Active is A, but write to B's pane explicitly.
+      twoStore.getState().setPaneMetadata(paneB, { label: 'B-only' }, { workspaceId: wsB.id });
+
+      expect(twoStore.getState().getPaneMetadata(paneB, { workspaceId: wsB.id })?.label).toBe('B-only');
+      // A's pane was untouched.
+      expect(twoStore.getState().getPaneMetadata(paneA, { workspaceId: wsA.id })).toBeUndefined();
+    });
+
+    it('silent no-op when paneId belongs to a different workspace than workspaceId', () => {
+      const twoStore = createTwoWorkspaceStore();
+      const wsA = twoStore.getState().workspaces[0];
+      const wsB = twoStore.getState().workspaces[1];
+      const paneA = wsA.rootPane.id;
+
+      // paneA exists in workspace A, but caller targets workspace B.
+      twoStore.getState().setPaneMetadata(paneA, { label: 'should-not-land' }, { workspaceId: wsB.id });
+
+      // Pane A in A: untouched.
+      expect(twoStore.getState().getPaneMetadata(paneA, { workspaceId: wsA.id })).toBeUndefined();
+      // Pane A queried as if in B: also undefined.
+      expect(twoStore.getState().getPaneMetadata(paneA, { workspaceId: wsB.id })).toBeUndefined();
+    });
+
+    it('clearPaneMetadata respects workspaceId opts', () => {
+      const twoStore = createTwoWorkspaceStore();
+      const wsB = twoStore.getState().workspaces[1];
+      const paneB = wsB.rootPane.id;
+
+      twoStore.getState().setPaneMetadata(paneB, { label: 'B' }, { workspaceId: wsB.id });
+      twoStore.getState().clearPaneMetadata(paneB, { workspaceId: wsB.id });
+
+      expect(twoStore.getState().getPaneMetadata(paneB, { workspaceId: wsB.id })).toBeUndefined();
+    });
+  });
+});

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -1,7 +1,11 @@
 import type { StateCreator } from 'zustand';
 import type { StoreState } from '../index';
-import type { Pane, PaneLeaf, PaneBranch, Workspace } from '../../../shared/types';
-import { createLeafPane, generateId } from '../../../shared/types';
+import type { Pane, PaneLeaf, PaneBranch, PaneMetadata, Workspace } from '../../../shared/types';
+import {
+  createLeafPane,
+  generateId,
+  PANE_METADATA_MAX_BYTES,
+} from '../../../shared/types';
 
 export interface PaneSlice {
   splitPane: (paneId: string, direction: 'horizontal' | 'vertical', workspaceId?: string) => void;
@@ -11,6 +15,9 @@ export interface PaneSlice {
   updatePaneSizes: (branchId: string, sizes: number[]) => void;
   resizeActivePane: (direction: 'left' | 'right' | 'up' | 'down', amount: number) => void;
   equalizePaneSizes: () => void;
+  setPaneMetadata: (paneId: string, patch: Partial<PaneMetadata>, opts?: { merge?: boolean; workspaceId?: string }) => void;
+  getPaneMetadata: (paneId: string, opts?: { workspaceId?: string }) => PaneMetadata | undefined;
+  clearPaneMetadata: (paneId: string, opts?: { workspaceId?: string }) => void;
 }
 
 function findPane(root: Pane, id: string): Pane | null {
@@ -177,6 +184,62 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
     if (!parent || parent.type !== 'branch') return;
     const equal = 100 / parent.children.length;
     parent.sizes = parent.children.map(() => equal);
+  }),
+
+  setPaneMetadata: (paneId, patch, opts) => {
+    const merge = opts?.merge !== false;
+    // Compute next metadata outside set() so we can validate size before mutating.
+    const state = get();
+    const targetWsId = opts?.workspaceId ?? state.activeWorkspaceId;
+    const ws = state.workspaces.find((w: Workspace) => w.id === targetWsId);
+    if (!ws) return;
+    const target = findPane(ws.rootPane, paneId);
+    if (!target || target.type !== 'leaf') return;
+
+    let next: PaneMetadata;
+    if (merge) {
+      next = { ...(target.metadata ?? {}), ...patch };
+      // Deep-merge `custom` one level so cooperating callers don't clobber each
+      // other's keys when both write to the same pane. Caller can still drop a
+      // key by setting it to "" or by using merge:false.
+      if (patch.custom !== undefined) {
+        next.custom = { ...(target.metadata?.custom ?? {}), ...patch.custom };
+      }
+    } else {
+      next = { ...patch };
+    }
+    next.updatedAt = Date.now();
+
+    if (JSON.stringify(next).length > PANE_METADATA_MAX_BYTES) {
+      throw new Error(`setPaneMetadata: metadata exceeds ${PANE_METADATA_MAX_BYTES} bytes`);
+    }
+
+    set((draft: StoreState) => {
+      const draftWs = draft.workspaces.find((w: Workspace) => w.id === targetWsId);
+      if (!draftWs) return;
+      const draftTarget = findPane(draftWs.rootPane, paneId);
+      if (!draftTarget || draftTarget.type !== 'leaf') return;
+      draftTarget.metadata = next;
+    });
+  },
+
+  getPaneMetadata: (paneId, opts) => {
+    const state = get();
+    const targetWsId = opts?.workspaceId ?? state.activeWorkspaceId;
+    const ws = state.workspaces.find((w: Workspace) => w.id === targetWsId);
+    if (!ws) return undefined;
+    const target = findPane(ws.rootPane, paneId);
+    if (!target || target.type !== 'leaf') return undefined;
+    return target.metadata;
+  },
+
+  clearPaneMetadata: (paneId, opts) => set((state: StoreState) => {
+    const targetWsId = opts?.workspaceId ?? state.activeWorkspaceId;
+    const ws = state.workspaces.find((w: Workspace) => w.id === targetWsId);
+    if (!ws) return;
+    const target = findPane(ws.rootPane, paneId);
+    if (!target || target.type !== 'leaf') return;
+    target.metadata = undefined;
   }),
 
   focusPaneDirection: (direction) => set((state: StoreState) => {

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -25,6 +25,9 @@ export type RpcMethod =
   | 'pane.list'
   | 'pane.focus'
   | 'pane.split'
+  | 'pane.setMetadata'
+  | 'pane.getMetadata'
+  | 'pane.clearMetadata'
   | 'input.send'
   | 'input.sendKey'
   | 'input.readScreen'
@@ -110,6 +113,9 @@ export const ALL_RPC_METHODS = [
   'pane.list',
   'pane.focus',
   'pane.split',
+  'pane.setMetadata',
+  'pane.getMetadata',
+  'pane.clearMetadata',
   'input.send',
   'input.sendKey',
   'input.readScreen',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -52,7 +52,26 @@ export interface PaneLeaf {
   type: 'leaf';
   surfaces: Surface[];
   activeSurfaceId: string;
+  metadata?: PaneMetadata;
 }
+
+// === Pane Metadata: optional descriptive labels for external tooling ===
+// Total serialized size capped at PANE_METADATA_MAX_BYTES so a misbehaving
+// caller can't bloat session.json. Branches never carry metadata — only leaves.
+export interface PaneMetadata {
+  label?: string;
+  role?: string;
+  status?: string;
+  custom?: Record<string, string>;
+  updatedAt?: number;
+}
+
+export const PANE_METADATA_MAX_BYTES = 8 * 1024;
+export const PANE_METADATA_LABEL_MAX = 64;
+export const PANE_METADATA_ROLE_MAX = 64;
+export const PANE_METADATA_STATUS_MAX = 128;
+export const PANE_METADATA_CUSTOM_KEY_MAX = 64;
+export const PANE_METADATA_CUSTOM_MAX_ENTRIES = 32;
 
 export interface PaneBranch {
   id: string;


### PR DESCRIPTION
> Tracks: #18 · Refs: #15

## Summary

First half of the external tooling RFC discussed in #15 with @alphabeen.
Adds optional descriptive metadata on leaf panes that external MCP tools
(Claude Code, Codex CLI, third-party agents) can read/write to annotate
workflow state. Pure additive — zero impact on existing clients.

JSON-RPC events follow as PR #17 (stacked on this branch).

## What's in

- **Type**: `PaneMetadata { label, role, status, custom: Record<string,string>, updatedAt }` on `PaneLeaf`
- **Caps**: 8KB serialized total, label ≤64, role ≤64, status ≤128, custom ≤32 entries × 64-char keys
- **RPC**: `pane.setMetadata` / `pane.getMetadata` / `pane.clearMetadata` (additive — listed in `system.capabilities`)
- **MCP tools**: `pane_set_metadata` / `pane_get_metadata` (auto-pin to caller's workspaceId)
- **Capability flag**: `system.capabilities().features.paneMetadata = true` for client detection
- **Persistence**: piggybacks on existing `SessionManager` JSON dump — backwards-compat (optional field)

## Security / correctness fixes baked in

After self-review with an adversarial subagent, four issues were caught and fixed in the same diff:

1. **Cross-workspace hijack** — `pane.setMetadata` previously fell back to `state.activeWorkspaceId` when paneId was omitted, allowing an MCP in workspace A to write into workspace B if the user was viewing B. Same class as the v2.7.2 `mcp.claimWorkspace` fix. Now the MCP tool auto-fills `workspaceId` from `requireWorkspaceId()` and the slice scopes lookups by it.
2. **`custom` map silent data loss** — shallow-merge clobbered other tools' keys. Now deep-merged one level on `merge=true`, so cooperating MCPs can each write their own keys.
3. **`role` length cap missing** — added `PANE_METADATA_ROLE_MAX = 64` mirroring label.
4. **`custom` key validation** — empty keys rejected, key length ≤64, entry count ≤32.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 811/811 pass (798 baseline + 13 new)
- [x] `npm run build:mcp` — clean
- [ ] Manual: external Claude Code in wmux PTY → `pane_set_metadata({label: "Backend", role: "service"})` → `pane_get_metadata()` returns same. Restart app. Re-query → metadata persisted.
- [ ] Manual: workspace A external MCP → set metadata while user views workspace B → confirm metadata lands in A's pane, not B's.
- [ ] Manual: two MCPs both write to `custom` → second's keys merged with first's, no clobber.

## Out of scope (PR #17 follows)

- JSON-RPC events (`pane.created` / `closed` / `focused` / `metadata.changed` / `process.started` / `exited`) via polling endpoint
- `EventBus` ring buffer + per-workspace filter
- `wmux_events_poll` MCP tool

## Out of scope (deferred indefinitely)

- Pane buffer access policy gates (already partial via `terminal_read*`)
- Push/SSE event delivery
- Cross-workspace metadata writes (not a use case yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)