### PR TITLE
feat(events): cursor-based JSON-RPC event bus for pane/process lifecycle (PR 2/2)

### DIFF
--- a/src/main/events/EventBus.ts
+++ b/src/main/events/EventBus.ts
@@ -1,0 +1,123 @@
+// === wmux EventBus ===
+//
+// In-memory ring buffer that captures pane/process lifecycle events and lets
+// external clients pull them via `events.poll(cursor)`. Single global ring of
+// RING_CAPACITY events; workspace scoping is done at poll time.
+//
+// Workflow:
+//   - Producers (paneSlice via IPC, PTYBridge directly) call `eventBus.emit(...)`
+//     with a partial event; EventBus stamps `seq` + `ts` and stores it.
+//   - Consumers call `eventBus.poll(cursor)` with the seq of their last seen
+//     event; the bus returns all events with `seq > cursor` matching the
+//     filter, plus the new cursor and a `resync` flag if the caller drifted
+//     past the ring window.
+
+import type {
+  WmuxEvent,
+  WmuxEventType,
+} from '../../shared/events';
+import { RING_CAPACITY, POLL_DEFAULT_MAX } from '../../shared/events';
+
+export interface EmitInput {
+  type: WmuxEventType;
+  workspaceId: string;
+  // Type-specific fields are passed through unchanged.
+  [k: string]: unknown;
+}
+
+export interface PollOptions {
+  types?: readonly WmuxEventType[];
+  workspaceId?: string;
+  max?: number;
+}
+
+export interface PollResult {
+  events: WmuxEvent[];
+  nextCursor: number;
+  resync?: true;
+}
+
+export class EventBus {
+  private readonly buf: (WmuxEvent | undefined)[] = new Array(RING_CAPACITY);
+  private head = 0;        // next write index
+  private nextSeq = 1;     // monotonic
+  private size = 0;        // number of valid entries
+
+  emit(input: EmitInput): WmuxEvent {
+    const event = {
+      ...input,
+      seq: this.nextSeq++,
+      ts: Date.now(),
+    } as WmuxEvent;
+
+    this.buf[this.head] = event;
+    this.head = (this.head + 1) % RING_CAPACITY;
+    if (this.size < RING_CAPACITY) this.size++;
+    return event;
+  }
+
+  /**
+   * Lowest seq still present in the ring. Useful for stale-cursor detection.
+   * Returns 0 when the ring is empty.
+   */
+  oldestSeq(): number {
+    if (this.size === 0) return 0;
+    // The oldest entry sits at (head - size + RING_CAPACITY) % RING_CAPACITY.
+    const oldestIdx = (this.head - this.size + RING_CAPACITY) % RING_CAPACITY;
+    return this.buf[oldestIdx]?.seq ?? 0;
+  }
+
+  /**
+   * Latest seq written. 0 when the ring is empty. Used as the next cursor
+   * for callers who want "everything from now on".
+   */
+  latestSeq(): number {
+    return this.nextSeq - 1;
+  }
+
+  poll(cursor: number, opts?: PollOptions): PollResult {
+    const max = Math.max(1, Math.min(opts?.max ?? POLL_DEFAULT_MAX, RING_CAPACITY));
+    const typeFilter = opts?.types && opts.types.length > 0 ? new Set(opts.types) : null;
+    const wsFilter = opts?.workspaceId;
+
+    const oldest = this.oldestSeq();
+    // The caller's next-expected event has seq = cursor + 1. If that's lower
+    // than the oldest event still in the ring, they've drifted and lost
+    // events — flag resync so the caller can reconcile via pane.list.
+    const resync = oldest > 0 && cursor + 1 < oldest ? true : undefined;
+    const effectiveCursor = resync ? oldest - 1 : cursor;
+
+    // Walk from oldest to newest in seq order.
+    const out: WmuxEvent[] = [];
+    if (this.size > 0) {
+      const start = (this.head - this.size + RING_CAPACITY) % RING_CAPACITY;
+      for (let i = 0; i < this.size; i++) {
+        const idx = (start + i) % RING_CAPACITY;
+        const ev = this.buf[idx];
+        if (!ev) continue;
+        if (ev.seq <= effectiveCursor) continue;
+        if (typeFilter && !typeFilter.has(ev.type)) continue;
+        if (wsFilter && ev.workspaceId !== wsFilter) continue;
+        out.push(ev);
+        if (out.length >= max) break;
+      }
+    }
+
+    const nextCursor = out.length > 0
+      ? out[out.length - 1].seq
+      : Math.max(effectiveCursor, this.latestSeq());
+
+    return resync ? { events: out, nextCursor, resync } : { events: out, nextCursor };
+  }
+
+  /** Clear all events. Test-only; not exposed to RPC. */
+  reset(): void {
+    for (let i = 0; i < this.buf.length; i++) this.buf[i] = undefined;
+    this.head = 0;
+    this.nextSeq = 1;
+    this.size = 0;
+  }
+}
+
+// Module-level singleton — main process only.
+export const eventBus = new EventBus();

--- a/src/main/events/EventBus.ts
+++ b/src/main/events/EventBus.ts
@@ -12,6 +12,7 @@
 //     filter, plus the new cursor and a `resync` flag if the caller drifted
 //     past the ring window.
 
+import { randomUUID } from 'node:crypto';
 import type {
   WmuxEvent,
   WmuxEventType,
@@ -34,6 +35,17 @@ export interface PollOptions {
 export interface PollResult {
   events: WmuxEvent[];
   nextCursor: number;
+  /** Caller's cursor as received — echoes back so clients can log drops. */
+  priorCursor: number;
+  /**
+   * Stable identifier for this main-process run. Mismatch across polls means
+   * the daemon restarted under the caller and ALL cached state (pane ids,
+   * pty ids, cursors) must be discarded. Always present.
+   */
+  bootId: string;
+  /** Number of events the caller missed before this poll, when known. */
+  droppedCount?: number;
+  /** True when the caller's cursor drifted past the ring (or jumped ahead). */
   resync?: true;
 }
 
@@ -42,6 +54,8 @@ export class EventBus {
   private head = 0;        // next write index
   private nextSeq = 1;     // monotonic
   private size = 0;        // number of valid entries
+  /** UUID stamped at construction. Invalidates client caches on daemon restart. */
+  readonly bootId: string = randomUUID();
 
   emit(input: EmitInput): WmuxEvent {
     const event = {
@@ -81,14 +95,26 @@ export class EventBus {
     const wsFilter = opts?.workspaceId;
 
     const oldest = this.oldestSeq();
-    // The caller's next-expected event has seq = cursor + 1. If that's lower
-    // than the oldest event still in the ring, they've drifted and lost
-    // events — flag resync so the caller can reconcile via pane.list.
-    const resync = oldest > 0 && cursor + 1 < oldest ? true : undefined;
-    const effectiveCursor = resync ? oldest - 1 : cursor;
+    const latest = this.latestSeq();
+    // Resync triggers when:
+    //  (a) caller drifted past the ring window (cursor + 1 < oldest), OR
+    //  (b) caller's cursor is in the future (cursor > latest) — daemon
+    //      restarted under them OR client crafted a bogus cursor.
+    // Either way, every cached pane/seq is suspect; bootId comparison gives
+    // the client a clean recovery signal.
+    const drifted = oldest > 0 && cursor + 1 < oldest;
+    const ahead = cursor > latest;
+    const resync = drifted || ahead ? true : undefined;
+    const effectiveCursor = resync ? Math.max(0, oldest - 1) : cursor;
+    const droppedCount = drifted ? oldest - cursor - 1 : undefined;
 
-    // Walk from oldest to newest in seq order.
+    // Walk from oldest to newest in seq order. Track the last *scanned* seq
+    // (regardless of filter match) so subsequent polls don't re-scan events
+    // that simply didn't match the filter — otherwise a filtered subscriber
+    // pays O(N) per poll for events it never wants.
     const out: WmuxEvent[] = [];
+    let lastScannedSeq = effectiveCursor;
+    let reachedMax = false;
     if (this.size > 0) {
       const start = (this.head - this.size + RING_CAPACITY) % RING_CAPACITY;
       for (let i = 0; i < this.size; i++) {
@@ -96,18 +122,36 @@ export class EventBus {
         const ev = this.buf[idx];
         if (!ev) continue;
         if (ev.seq <= effectiveCursor) continue;
+        lastScannedSeq = ev.seq;
         if (typeFilter && !typeFilter.has(ev.type)) continue;
         if (wsFilter && ev.workspaceId !== wsFilter) continue;
         out.push(ev);
-        if (out.length >= max) break;
+        if (out.length >= max) {
+          reachedMax = true;
+          break;
+        }
       }
     }
 
-    const nextCursor = out.length > 0
+    // Cursor advancement:
+    //  - If max truncated the page, the caller still has matching events to
+    //    pick up — advance only to the last delivered event.
+    //  - Otherwise, the loop drained everything in the ring; jump cursor to
+    //    `lastScannedSeq` (covers filter no-matches) clamped to `latest` so
+    //    a filtered subscriber doesn't re-scan the same N entries each poll.
+    const nextCursor = reachedMax
       ? out[out.length - 1].seq
-      : Math.max(effectiveCursor, this.latestSeq());
+      : Math.max(lastScannedSeq, latest);
 
-    return resync ? { events: out, nextCursor, resync } : { events: out, nextCursor };
+    const result: PollResult = {
+      events: out,
+      nextCursor,
+      priorCursor: cursor,
+      bootId: this.bootId,
+    };
+    if (resync) result.resync = true;
+    if (droppedCount !== undefined && droppedCount > 0) result.droppedCount = droppedCount;
+    return result;
   }
 
   /** Clear all events. Test-only; not exposed to RPC. */

--- a/src/main/events/__tests__/EventBus.test.ts
+++ b/src/main/events/__tests__/EventBus.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { EventBus } from '../EventBus';
 import { RING_CAPACITY } from '../../../shared/events';
 
+// Note: existing tests that check `nextCursor` semantics remain valid. The
+// review fixes (5a bootId, 5a cursor>latest resync, 1a cursor advance under
+// filter, 2a priorCursor+droppedCount) add new behavior on top.
+
 describe('EventBus', () => {
   let bus: EventBus;
   beforeEach(() => {
@@ -137,6 +141,95 @@ describe('EventBus', () => {
       bus.reset();
       expect(bus.latestSeq()).toBe(0);
       expect(bus.poll(0).events).toEqual([]);
+    });
+  });
+
+  describe('bootId (review fix 5a)', () => {
+    it('exposes a stable bootId on every poll response', () => {
+      const r1 = bus.poll(0);
+      const r2 = bus.poll(0);
+      expect(r1.bootId).toBe(r2.bootId);
+      expect(typeof r1.bootId).toBe('string');
+      expect(r1.bootId.length).toBeGreaterThan(0);
+    });
+
+    it('two EventBus instances have different bootIds', () => {
+      const a = new EventBus();
+      const b = new EventBus();
+      expect(a.bootId).not.toBe(b.bootId);
+    });
+  });
+
+  describe('priorCursor + droppedCount (review fix 2a)', () => {
+    it('echoes priorCursor regardless of cursor validity', () => {
+      const r = bus.poll(42);
+      expect(r.priorCursor).toBe(42);
+    });
+
+    it('reports droppedCount when cursor drifted past the ring', () => {
+      for (let i = 0; i < RING_CAPACITY + 10; i++) {
+        bus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: `p${i}` });
+      }
+      // oldest = 11. Caller cursor = 5 → missed 5..10 (6 events).
+      const r = bus.poll(5);
+      expect(r.resync).toBe(true);
+      expect(r.droppedCount).toBe(5); // oldest - cursor - 1 = 11 - 5 - 1
+    });
+
+    it('omits droppedCount when no drift', () => {
+      bus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: 'p1' });
+      const r = bus.poll(0);
+      expect(r.droppedCount).toBeUndefined();
+      expect(r.resync).toBeUndefined();
+    });
+  });
+
+  describe('cursor ahead of latest (review fix 5a)', () => {
+    it('triggers resync when cursor > latestSeq (daemon-restart smell)', () => {
+      bus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: 'p1' });
+      // latestSeq=1; caller is 999 ahead — only possible after a daemon restart.
+      const r = bus.poll(999);
+      expect(r.resync).toBe(true);
+      // After resync we serve from oldest forward.
+      expect(r.events).toHaveLength(1);
+    });
+  });
+
+  describe('cursor advances under filter (review fix 1a)', () => {
+    it('does not re-scan filter no-matches on subsequent polls', () => {
+      // 50 pane events, then 5 process events.
+      for (let i = 0; i < 50; i++) {
+        bus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: `p${i}` });
+      }
+      for (let i = 0; i < 5; i++) {
+        bus.emit({ type: 'process.started', workspaceId: 'ws-1', ptyId: `t${i}`, shell: 'pwsh' });
+      }
+
+      // First poll for process.* — gets 5 matches but cursor must advance
+      // past the 50 pane events too, otherwise next poll re-scans them.
+      const r1 = bus.poll(0, { types: ['process.started'] });
+      expect(r1.events).toHaveLength(5);
+      expect(r1.nextCursor).toBe(55); // last scanned (or latest), NOT 55 vs 5
+
+      // No new events. Second poll should return empty without re-scanning
+      // the 50 pane.created entries.
+      const r2 = bus.poll(r1.nextCursor, { types: ['process.started'] });
+      expect(r2.events).toEqual([]);
+      expect(r2.nextCursor).toBe(55);
+    });
+
+    it('preserves catch-up semantics when max truncates the page', () => {
+      for (let i = 0; i < 10; i++) {
+        bus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: `p${i}` });
+      }
+      // max=3 — caller still has 7 events to pick up. Cursor must be the
+      // last DELIVERED seq, not latest, so the next poll catches up.
+      const r1 = bus.poll(0, { max: 3 });
+      expect(r1.events).toHaveLength(3);
+      expect(r1.nextCursor).toBe(3);
+
+      const r2 = bus.poll(r1.nextCursor, { max: 3 });
+      expect(r2.events.map((e) => e.seq)).toEqual([4, 5, 6]);
     });
   });
 });

--- a/src/main/events/__tests__/EventBus.test.ts
+++ b/src/main/events/__tests__/EventBus.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { EventBus } from '../EventBus';
+import { RING_CAPACITY } from '../../../shared/events';
+
+describe('EventBus', () => {
+  let bus: EventBus;
+  beforeEach(() => {
+    bus = new EventBus();
+  });
+
+  describe('emit + poll', () => {
+    it('emits with monotonic seq + ts', () => {
+      const a = bus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: 'p1' });
+      const b = bus.emit({ type: 'pane.closed', workspaceId: 'ws-1', paneId: 'p1' });
+      expect(a.seq).toBe(1);
+      expect(b.seq).toBe(2);
+      expect(b.ts).toBeGreaterThanOrEqual(a.ts);
+    });
+
+    it('returns events newer than cursor', () => {
+      bus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: 'p1' });
+      bus.emit({ type: 'pane.closed', workspaceId: 'ws-1', paneId: 'p1' });
+      bus.emit({ type: 'pane.focused', workspaceId: 'ws-1', paneId: 'p2' });
+
+      const r = bus.poll(1);
+      expect(r.events.map((e) => e.seq)).toEqual([2, 3]);
+      expect(r.nextCursor).toBe(3);
+      expect(r.resync).toBeUndefined();
+    });
+
+    it('returns empty + nextCursor=latestSeq when caller is up to date', () => {
+      bus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: 'p1' });
+      bus.emit({ type: 'pane.closed', workspaceId: 'ws-1', paneId: 'p1' });
+
+      const r = bus.poll(2);
+      expect(r.events).toEqual([]);
+      expect(r.nextCursor).toBe(2);
+    });
+
+    it('cursor=0 replays everything still in the ring', () => {
+      bus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: 'p1' });
+      bus.emit({ type: 'pane.closed', workspaceId: 'ws-1', paneId: 'p1' });
+      const r = bus.poll(0);
+      expect(r.events.map((e) => e.seq)).toEqual([1, 2]);
+    });
+  });
+
+  describe('ring overflow', () => {
+    it('drops oldest when capacity exceeded; oldestSeq advances', () => {
+      // Fill to capacity + 5 extras.
+      for (let i = 0; i < RING_CAPACITY + 5; i++) {
+        bus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: `p${i}` });
+      }
+      expect(bus.latestSeq()).toBe(RING_CAPACITY + 5);
+      // Oldest seq should be 6 (1..5 evicted).
+      expect(bus.oldestSeq()).toBe(6);
+
+      const r = bus.poll(0);
+      // cursor=0 < oldestSeq-1=5 → resync flag fires.
+      expect(r.resync).toBe(true);
+      // Returns up to 256 events by default; at most RING_CAPACITY in the ring.
+      expect(r.events.length).toBeLessThanOrEqual(256);
+      // First returned event should be at or after oldestSeq.
+      expect(r.events[0].seq).toBeGreaterThanOrEqual(6);
+    });
+
+    it('resync fires only when cursor < oldestSeq - 1', () => {
+      // Capacity-1 events; ring not yet wrapped.
+      for (let i = 0; i < RING_CAPACITY; i++) {
+        bus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: `p${i}` });
+      }
+      // Now wrap by 3.
+      for (let i = 0; i < 3; i++) {
+        bus.emit({ type: 'pane.closed', workspaceId: 'ws-1', paneId: `p${i}` });
+      }
+      expect(bus.oldestSeq()).toBe(4);
+
+      // Caller's cursor=3 → cursor < oldestSeq (4) but cursor === oldestSeq-1 → no resync.
+      const noResync = bus.poll(3);
+      expect(noResync.resync).toBeUndefined();
+
+      // cursor=2 → strictly older than oldestSeq-1 → resync.
+      const resync = bus.poll(2);
+      expect(resync.resync).toBe(true);
+    });
+  });
+
+  describe('filters', () => {
+    it('type filter narrows results', () => {
+      bus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: 'p1' });
+      bus.emit({ type: 'pane.closed', workspaceId: 'ws-1', paneId: 'p1' });
+      bus.emit({ type: 'process.started', workspaceId: 'ws-1', ptyId: 't1', shell: 'pwsh' });
+
+      const r = bus.poll(0, { types: ['process.started'] });
+      expect(r.events).toHaveLength(1);
+      expect(r.events[0].type).toBe('process.started');
+      // nextCursor is the seq of the matched event, not latest.
+      expect(r.nextCursor).toBe(3);
+    });
+
+    it('workspaceId filter scopes to one workspace', () => {
+      bus.emit({ type: 'pane.created', workspaceId: 'ws-A', paneId: 'pA' });
+      bus.emit({ type: 'pane.created', workspaceId: 'ws-B', paneId: 'pB' });
+      bus.emit({ type: 'pane.closed', workspaceId: 'ws-A', paneId: 'pA' });
+
+      const r = bus.poll(0, { workspaceId: 'ws-A' });
+      expect(r.events.map((e) => e.workspaceId)).toEqual(['ws-A', 'ws-A']);
+    });
+
+    it('combined type + workspace filter', () => {
+      bus.emit({ type: 'pane.created', workspaceId: 'ws-A', paneId: 'p' });
+      bus.emit({ type: 'pane.closed', workspaceId: 'ws-A', paneId: 'p' });
+      bus.emit({ type: 'pane.created', workspaceId: 'ws-B', paneId: 'p' });
+
+      const r = bus.poll(0, { types: ['pane.created'], workspaceId: 'ws-A' });
+      expect(r.events).toHaveLength(1);
+      expect(r.events[0].workspaceId).toBe('ws-A');
+    });
+  });
+
+  describe('max', () => {
+    it('caps result count at max', () => {
+      for (let i = 0; i < 10; i++) {
+        bus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: `p${i}` });
+      }
+      const r = bus.poll(0, { max: 3 });
+      expect(r.events).toHaveLength(3);
+      expect(r.nextCursor).toBe(3); // last returned seq
+    });
+  });
+
+  describe('reset', () => {
+    it('clears the ring and resets seq counter', () => {
+      bus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: 'p1' });
+      bus.emit({ type: 'pane.closed', workspaceId: 'ws-1', paneId: 'p1' });
+      expect(bus.latestSeq()).toBe(2);
+      bus.reset();
+      expect(bus.latestSeq()).toBe(0);
+      expect(bus.poll(0).events).toEqual([]);
+    });
+  });
+});

--- a/src/main/events/__tests__/EventBus.test.ts
+++ b/src/main/events/__tests__/EventBus.test.ts
@@ -195,6 +195,24 @@ describe('EventBus', () => {
     });
   });
 
+  describe('garbage cursor inputs (review fix follow-up — defensive)', () => {
+    it('Number.MAX_SAFE_INTEGER triggers resync, not silent zero events', () => {
+      bus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: 'p1' });
+      bus.emit({ type: 'pane.closed', workspaceId: 'ws-1', paneId: 'p1' });
+
+      const r = bus.poll(Number.MAX_SAFE_INTEGER);
+      expect(r.resync).toBe(true);
+      // After resync we get all remaining events from oldest forward.
+      expect(r.events.length).toBe(2);
+    });
+
+    it('extremely large but finite cursor still triggers resync via cursor>latest', () => {
+      bus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: 'p1' });
+      const r = bus.poll(1e15);
+      expect(r.resync).toBe(true);
+    });
+  });
+
   describe('cursor advances under filter (review fix 1a)', () => {
     it('does not re-scan filter no-matches on subsequent polls', () => {
       // 50 pane events, then 5 process events.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,6 +23,7 @@ import { registerSystemRpc } from './pipe/handlers/system.rpc';
 import { registerBrowserRpc } from './pipe/handlers/browser.rpc';
 import { registerA2aRpc } from './pipe/handlers/a2a.rpc';
 import { registerCompanyRpc } from './pipe/handlers/company.rpc';
+import { registerEventsRpc } from './pipe/handlers/events.rpc';
 import { ClaudeWorker } from './a2a/ClaudeWorker';
 import { AutoUpdater } from './updater/AutoUpdater';
 import { McpRegistrar } from './mcp/McpRegistrar';
@@ -264,6 +265,7 @@ registerSystemRpc(rpcRouter);
 registerBrowserRpc(rpcRouter, () => mainWindow, webviewCdpManager);
 registerA2aRpc(rpcRouter, () => mainWindow, claudeWorker);
 registerCompanyRpc(rpcRouter, () => mainWindow);
+registerEventsRpc(rpcRouter);
 
 // IPC: webview CDP registration
 ipcMain.handle('browser:register-webview', async (_event, surfaceId: string, webContentsId: number) => {

--- a/src/main/ipc/registerHandlers.ts
+++ b/src/main/ipc/registerHandlers.ts
@@ -12,6 +12,10 @@ import { registerFsHandlers } from './handlers/fs.handler';
 import { registerMcpHandlers } from './handlers/mcp.handler';
 import { IPC } from '../../shared/constants';
 import { toastManager } from '../pipe/handlers/notify.rpc';
+import { eventBus } from '../events/EventBus';
+import { WMUX_EVENT_TYPES, type WmuxEventType } from '../../shared/events';
+
+const EVENT_TYPE_SET = new Set<WmuxEventType>(WMUX_EVENT_TYPES);
 
 export interface RegisterHandlersOptions {
   /** McpRegistrar instance shared with main/index — exposes Settings MCP IPC. */
@@ -51,6 +55,25 @@ export function registerAllHandlers(
   };
   ipcMain.removeAllListeners(IPC.WINDOW_HIDE);
   ipcMain.on(IPC.WINDOW_HIDE, onWindowHide);
+
+  // EventBus publish from renderer (one-way). Validates the event type and
+  // workspaceId at the trust boundary so a misbehaving renderer can't poison
+  // the ring with arbitrary shapes; type-specific fields ride through as-is.
+  const onEventsPublish = (_event: Electron.IpcMainEvent, input: unknown): void => {
+    if (!input || typeof input !== 'object') return;
+    const obj = input as Record<string, unknown>;
+    const type = obj['type'];
+    const workspaceId = obj['workspaceId'];
+    if (typeof type !== 'string' || !EVENT_TYPE_SET.has(type as WmuxEventType)) return;
+    if (typeof workspaceId !== 'string' || workspaceId.length === 0) return;
+    try {
+      eventBus.emit({ ...obj, type: type as WmuxEventType, workspaceId });
+    } catch {
+      // Telemetry must not crash the IPC channel — swallow and move on.
+    }
+  };
+  ipcMain.removeAllListeners(IPC.EVENTS_PUBLISH);
+  ipcMain.on(IPC.EVENTS_PUBLISH, onEventsPublish);
 
   return () => {
     cleanupPty();

--- a/src/main/pipe/handlers/__tests__/events.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/events.rpc.test.ts
@@ -109,4 +109,22 @@ describe('events.rpc — events.poll', () => {
       expect(result.events).toHaveLength(2);
     }
   });
+
+  it('exposes bootId + priorCursor on every response (review fixes 5a, 2a)', async () => {
+    eventBus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: 'p1' });
+
+    const router = setupRouter();
+    const res = await router.dispatch({
+      id: 'fix-1',
+      method: 'events.poll',
+      params: { cursor: 7 },
+    });
+
+    if (res.ok) {
+      const result = res.result as { bootId: string; priorCursor: number };
+      expect(typeof result.bootId).toBe('string');
+      expect(result.bootId.length).toBeGreaterThan(0);
+      expect(result.priorCursor).toBe(7);
+    }
+  });
 });

--- a/src/main/pipe/handlers/__tests__/events.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/events.rpc.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { RpcRouter } from '../../RpcRouter';
+import { registerEventsRpc } from '../events.rpc';
+import { eventBus } from '../../../events/EventBus';
+
+function setupRouter(): RpcRouter {
+  const router = new RpcRouter();
+  registerEventsRpc(router);
+  return router;
+}
+
+describe('events.rpc — events.poll', () => {
+  beforeEach(() => {
+    eventBus.reset();
+  });
+
+  it('returns events with cursor and types defaults', async () => {
+    eventBus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: 'p1' });
+    eventBus.emit({ type: 'pane.closed', workspaceId: 'ws-1', paneId: 'p1' });
+
+    const router = setupRouter();
+    const res = await router.dispatch({ id: '1', method: 'events.poll', params: {} });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      const result = res.result as { events: unknown[]; nextCursor: number };
+      expect(result.events).toHaveLength(2);
+      expect(result.nextCursor).toBe(2);
+    }
+  });
+
+  it('honors cursor param', async () => {
+    eventBus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: 'p1' });
+    eventBus.emit({ type: 'pane.closed', workspaceId: 'ws-1', paneId: 'p1' });
+    eventBus.emit({ type: 'pane.focused', workspaceId: 'ws-1', paneId: 'p2' });
+
+    const router = setupRouter();
+    const res = await router.dispatch({ id: '2', method: 'events.poll', params: { cursor: 1 } });
+
+    if (res.ok) {
+      const result = res.result as { events: { seq: number }[] };
+      expect(result.events.map((e) => e.seq)).toEqual([2, 3]);
+    }
+  });
+
+  it('honors workspaceId scope', async () => {
+    eventBus.emit({ type: 'pane.created', workspaceId: 'ws-A', paneId: 'pA' });
+    eventBus.emit({ type: 'pane.created', workspaceId: 'ws-B', paneId: 'pB' });
+    eventBus.emit({ type: 'pane.focused', workspaceId: 'ws-A', paneId: 'pA' });
+
+    const router = setupRouter();
+    const res = await router.dispatch({ id: '3', method: 'events.poll', params: { workspaceId: 'ws-A' } });
+
+    if (res.ok) {
+      const result = res.result as { events: { workspaceId: string }[] };
+      expect(result.events.every((e) => e.workspaceId === 'ws-A')).toBe(true);
+    }
+  });
+
+  it('honors types filter and drops unknown types silently', async () => {
+    eventBus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: 'p1' });
+    eventBus.emit({ type: 'process.started', workspaceId: 'ws-1', ptyId: 't1', shell: 'pwsh' });
+
+    const router = setupRouter();
+    const res = await router.dispatch({
+      id: '4',
+      method: 'events.poll',
+      params: { types: ['process.started', 'not-a-real-type'] },
+    });
+
+    if (res.ok) {
+      const result = res.result as { events: { type: string }[] };
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0].type).toBe('process.started');
+    }
+  });
+
+  it('clamps cursor to non-negative integer', async () => {
+    eventBus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: 'p1' });
+
+    const router = setupRouter();
+    const res = await router.dispatch({
+      id: '5',
+      method: 'events.poll',
+      params: { cursor: -50 },
+    });
+
+    if (res.ok) {
+      const result = res.result as { events: unknown[] };
+      // Negative cursor clamps to 0, so we still get the event.
+      expect(result.events).toHaveLength(1);
+    }
+  });
+
+  it('honors max param', async () => {
+    for (let i = 0; i < 5; i++) {
+      eventBus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: `p${i}` });
+    }
+
+    const router = setupRouter();
+    const res = await router.dispatch({
+      id: '6',
+      method: 'events.poll',
+      params: { max: 2 },
+    });
+
+    if (res.ok) {
+      const result = res.result as { events: unknown[] };
+      expect(result.events).toHaveLength(2);
+    }
+  });
+});

--- a/src/main/pipe/handlers/__tests__/pane.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/pane.rpc.test.ts
@@ -274,4 +274,37 @@ describe('pane.rpc — metadata', () => {
       expect(res.ok).toBe(true);
     });
   });
+
+  describe('pane.list snapshot wrapper (review fix 2b + 5a)', () => {
+    it('wraps the renderer response with asOfSeq + bootId', async () => {
+      sendToRendererMock.mockResolvedValueOnce([
+        { id: 'p1', surfaceCount: 1, active: true },
+      ]);
+
+      const router = setupRouter();
+      const res = await router.dispatch({ id: 'rpc-list-1', method: 'pane.list', params: {} });
+
+      expect(res.ok).toBe(true);
+      if (res.ok) {
+        const result = res.result as { asOfSeq: number; bootId: string; panes: unknown[] };
+        expect(typeof result.asOfSeq).toBe('number');
+        expect(typeof result.bootId).toBe('string');
+        expect(result.bootId.length).toBeGreaterThan(0);
+        expect(result.panes).toHaveLength(1);
+      }
+    });
+
+    it('forwards workspaceId param to the renderer', async () => {
+      sendToRendererMock.mockResolvedValueOnce([]);
+      const router = setupRouter();
+      await router.dispatch({
+        id: 'rpc-list-2',
+        method: 'pane.list',
+        params: { workspaceId: 'ws-target' },
+      });
+      const [, method, payload] = sendToRendererMock.mock.calls[0];
+      expect(method).toBe('pane.list');
+      expect(payload).toMatchObject({ workspaceId: 'ws-target' });
+    });
+  });
 });

--- a/src/main/pipe/handlers/events.rpc.ts
+++ b/src/main/pipe/handlers/events.rpc.ts
@@ -1,0 +1,44 @@
+import type { RpcRouter } from '../RpcRouter';
+import { eventBus } from '../../events/EventBus';
+import { WMUX_EVENT_TYPES, type WmuxEventType } from '../../../shared/events';
+
+const TYPE_SET = new Set<WmuxEventType>(WMUX_EVENT_TYPES);
+
+function parseTypes(raw: unknown): WmuxEventType[] | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (!Array.isArray(raw)) return undefined;
+  const out: WmuxEventType[] = [];
+  for (const t of raw) {
+    if (typeof t === 'string' && TYPE_SET.has(t as WmuxEventType)) {
+      out.push(t as WmuxEventType);
+    }
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+export function registerEventsRpc(router: RpcRouter): void {
+  /**
+   * events.poll — pull events newer than `cursor`.
+   * params: { cursor?: number, types?: WmuxEventType[], workspaceId?: string, max?: number }
+   *
+   * Default cursor is 0 (replay from oldest in the ring). External callers
+   * SHOULD scope to their own `workspaceId` so they don't see other
+   * workspaces' lifecycle. The renderer hop is bypassed — main answers
+   * directly from the in-process ring.
+   */
+  router.register('events.poll', (params) => {
+    const cursor = typeof params['cursor'] === 'number' && Number.isFinite(params['cursor'])
+      ? Math.max(0, Math.floor(params['cursor']))
+      : 0;
+    const workspaceId = typeof params['workspaceId'] === 'string' && params['workspaceId'].length > 0
+      ? params['workspaceId']
+      : undefined;
+    const max = typeof params['max'] === 'number' && Number.isFinite(params['max'])
+      ? Math.max(1, Math.floor(params['max']))
+      : undefined;
+    const types = parseTypes(params['types']);
+
+    const result = eventBus.poll(cursor, { types, workspaceId, max });
+    return Promise.resolve(result);
+  });
+}

--- a/src/main/pipe/handlers/pane.rpc.ts
+++ b/src/main/pipe/handlers/pane.rpc.ts
@@ -9,6 +9,7 @@ import {
   PANE_METADATA_CUSTOM_KEY_MAX,
   PANE_METADATA_CUSTOM_MAX_ENTRIES,
 } from '../../../shared/types';
+import { eventBus } from '../../events/EventBus';
 
 type GetWindow = () => BrowserWindow | null;
 
@@ -87,11 +88,22 @@ function sanitizeMetadataPatch(input: MetadataPatchInput): SanitizedPatch | { er
 
 export function registerPaneRpc(router: RpcRouter, getWindow: GetWindow): void {
   /**
-   * pane.list — returns all panes (leaf nodes) of the current workspace
+   * pane.list — returns all panes (leaf nodes) of the current workspace,
+   * wrapped in a snapshot envelope. `asOfSeq` is the EventBus seq at the
+   * moment of the snapshot — clients reconciling after a `resync` should
+   * drain events with `seq > asOfSeq`. `bootId` invalidates cached state
+   * across daemon restarts (mismatch ⇒ drop ALL caches, including pane ids).
+   *
+   * Wire shape: `{ asOfSeq: number, bootId: string, panes: PaneListEntry[] }`.
    */
-  router.register('pane.list', (_params) =>
-    sendToRenderer(getWindow, 'pane.list'),
-  );
+  router.register('pane.list', async (params) => {
+    const panes = await sendToRenderer(getWindow, 'pane.list', params);
+    return {
+      asOfSeq: eventBus.latestSeq(),
+      bootId: eventBus.bootId,
+      panes,
+    };
+  });
 
   /**
    * pane.focus — focuses a specific pane

--- a/src/main/pipe/handlers/system.rpc.ts
+++ b/src/main/pipe/handlers/system.rpc.ts
@@ -1,6 +1,7 @@
 import { app } from 'electron';
 import type { RpcRouter } from '../RpcRouter';
 import { ALL_RPC_METHODS } from '../../../shared/rpc';
+import { WMUX_EVENT_TYPES, RING_CAPACITY } from '../../../shared/events';
 
 /**
  * Shape returned by system.identify.
@@ -36,6 +37,10 @@ export function registerSystemRpc(router: RpcRouter): void {
       methods: ALL_RPC_METHODS,
       features: {
         paneMetadata: true,
+        events: {
+          types: WMUX_EVENT_TYPES,
+          maxRingSize: RING_CAPACITY,
+        },
       },
     });
   });

--- a/src/main/pipe/handlers/system.rpc.ts
+++ b/src/main/pipe/handlers/system.rpc.ts
@@ -2,6 +2,7 @@ import { app } from 'electron';
 import type { RpcRouter } from '../RpcRouter';
 import { ALL_RPC_METHODS } from '../../../shared/rpc';
 import { WMUX_EVENT_TYPES, RING_CAPACITY } from '../../../shared/events';
+import { eventBus } from '../../events/EventBus';
 
 /**
  * Shape returned by system.identify.
@@ -40,6 +41,10 @@ export function registerSystemRpc(router: RpcRouter): void {
         events: {
           types: WMUX_EVENT_TYPES,
           maxRingSize: RING_CAPACITY,
+          // Stable for the lifetime of this main-process run. Clients that
+          // see bootId change between calls must drop all cached state —
+          // pane ids, pty ids, and event cursors are all invalidated.
+          bootId: eventBus.bootId,
         },
       },
     });

--- a/src/main/pty/PTYBridge.ts
+++ b/src/main/pty/PTYBridge.ts
@@ -7,6 +7,7 @@ import { ActivityMonitor } from './ActivityMonitor';
 import { toastManager } from '../pipe/handlers/notify.rpc';
 import { IPC } from '../../shared/constants';
 import { updateCwd, removeCwd, updateBranch, removeBranch } from '../ipc/handlers/metadata.handler';
+import { eventBus } from '../events/EventBus';
 
 /**
  * A middleware handler receives raw data from a PTY process.
@@ -135,6 +136,19 @@ export class PTYBridge {
 
     this.ptyCreatedAt.set(ptyId, Date.now());
     this.activityMonitor.start(ptyId);
+
+    // Surface process lifecycle to the EventBus for external tooling. Skip
+    // PTYs that were created without a workspace context (CLI/tests) — those
+    // can't be polled by workspace-scoped clients anyway.
+    if (instance.workspaceId) {
+      eventBus.emit({
+        type: 'process.started',
+        workspaceId: instance.workspaceId,
+        ptyId,
+        pid: instance.process.pid,
+        shell: instance.shell,
+      });
+    }
 
     const oscParser = new OscParser();
     this.oscParsers.set(ptyId, oscParser);
@@ -286,10 +300,21 @@ export class PTYBridge {
       }
     });
 
-    instance.process.onExit(({ exitCode }) => {
+    instance.process.onExit(({ exitCode, signal }) => {
       // Drain any buffered output before signalling exit so the renderer
       // sees the final lines (e.g. exit banner) before PTY_EXIT.
       this.flushPending(ptyId);
+
+      // Surface process exit to the EventBus before cleanup wipes our state.
+      if (instance.workspaceId) {
+        eventBus.emit({
+          type: 'process.exited',
+          workspaceId: instance.workspaceId,
+          ptyId,
+          exitCode: typeof exitCode === 'number' ? exitCode : null,
+          ...(typeof signal === 'number' ? { signal: String(signal) } : {}),
+        });
+      }
 
       const win = this.getWindow();
       if (win && !win.isDestroyed()) {

--- a/src/main/pty/PTYManager.ts
+++ b/src/main/pty/PTYManager.ts
@@ -12,6 +12,13 @@ export interface PTYInstance {
   id: string;
   process: pty.IPty;
   shell: string;
+  /**
+   * Workspace this PTY belongs to. Captured at create time so the EventBus
+   * can scope process.* events without consulting the renderer state.
+   * Optional — undefined when the PTY was created without a workspace context
+   * (CLI tools, tests). Used only for EventBus scoping; absence skips emission.
+   */
+  workspaceId?: string;
 }
 
 const MAX_PTY_INSTANCES = 20;
@@ -154,7 +161,12 @@ export class PTYManager {
       useConpty: true,
     });
 
-    const instance: PTYInstance = { id, process: ptyProcess, shell };
+    const instance: PTYInstance = {
+      id,
+      process: ptyProcess,
+      shell,
+      ...(options?.workspaceId ? { workspaceId: options.workspaceId } : {}),
+    };
     this.instances.set(id, instance);
 
     // Write PID->workspaceId mapping so MCP servers can resolve identity

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -328,6 +328,27 @@ server.tool(
   },
 );
 
+server.tool(
+  'wmux_events_poll',
+  'Poll the wmux EventBus for pane and process lifecycle events. Cursor-based: pass `cursor` = the last `seq` you saw (start with 0 to replay from oldest in the ring). Returns { events, nextCursor, resync? }. `resync: true` means your cursor drifted past the in-memory ring (1024 events) and you should reconcile via pane_list. Events are auto-scoped to the calling workspace.',
+  {
+    cursor: z.number().int().nonnegative().optional().describe('Last seen seq number. Default 0 = replay all events still in the ring.'),
+    types: z
+      .array(z.enum(['pane.created', 'pane.closed', 'pane.focused', 'pane.metadata.changed', 'process.started', 'process.exited']))
+      .optional()
+      .describe('Filter to specific event types. Omit to receive all types.'),
+    max: z.number().int().positive().max(1024).optional().describe('Max events to return per poll. Default 256.'),
+  },
+  async ({ cursor, types, max }) => {
+    const workspaceId = await requireWorkspaceId();
+    const params: Record<string, unknown> = { workspaceId };
+    if (cursor !== undefined) params['cursor'] = cursor;
+    if (types !== undefined) params['types'] = types;
+    if (max !== undefined) params['max'] = max;
+    return callRpc('events.poll', params);
+  },
+);
+
 // === A2A (Agent-to-Agent) tools ===
 
 // 1. a2a_whoami — Identify this workspace

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -298,7 +298,7 @@ server.tool(
     label: z.string().max(64).optional().describe('Short human label, e.g. "Backend".'),
     role: z.string().max(64).optional().describe('Free-form role tag, e.g. "service" or "test-runner".'),
     status: z.string().max(128).optional().describe('Current status, e.g. "running-tests".'),
-    custom: z.record(z.string(), z.string()).optional().describe('Additional string→string properties for tool-specific data. Deep-merged with existing custom map when merge=true.'),
+    custom: z.record(z.string(), z.string()).optional().describe('Additional string→string properties for tool-specific data. Deep-merged with existing custom map when merge=true. Recommended convention: namespace your keys with a tool prefix (e.g. "orchestrator.taskId", "qa.status") to avoid semantic collisions with other cooperating tools.'),
     merge: z.boolean().optional().describe('Default true (patch + deep-merge custom). Set false to replace the entire metadata object.'),
   },
   async ({ paneId, label, role, status, custom, merge }) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -120,6 +120,16 @@ const electronAPI = {
   window: {
     hide: () => ipcRenderer.send(IPC.WINDOW_HIDE),
   },
+  events: {
+    /**
+     * One-way publish of a pane lifecycle event to the main-process EventBus.
+     * Caller passes a partial event object (`type`, `workspaceId`, plus
+     * type-specific fields); main stamps `seq` and `ts`. Failures are
+     * swallowed — telemetry must never break a state mutation.
+     */
+    publish: (input: { type: string; workspaceId: string; [k: string]: unknown }) =>
+      ipcRenderer.send(IPC.EVENTS_PUBLISH, input),
+  },
   scrollback: {
     dump: (surfaceId: string, content: string) =>
       ipcRenderer.invoke(IPC.SCROLLBACK_DUMP, surfaceId, content),

--- a/src/renderer/events/publisher.ts
+++ b/src/renderer/events/publisher.ts
@@ -1,0 +1,48 @@
+// === Renderer-side EventBus publisher ===
+//
+// Thin shim around the preload IPC channel. Slice methods call these helpers
+// inside their state mutations so external tooling can poll the EventBus on
+// main and see pane lifecycle. Failures are swallowed — telemetry never
+// breaks a state mutation.
+
+import type { PaneMetadata } from '../../shared/types';
+import type { WmuxEventType } from '../../shared/events';
+
+interface ElectronEventsAPI {
+  publish: (input: { type: string; workspaceId: string; [k: string]: unknown }) => void;
+}
+
+interface ElectronAPIMaybe {
+  events?: ElectronEventsAPI;
+}
+
+declare const window: { electronAPI?: ElectronAPIMaybe } & Window;
+
+function publish(input: { type: WmuxEventType; workspaceId: string; [k: string]: unknown }): void {
+  try {
+    const api = (typeof window !== 'undefined' ? window.electronAPI : undefined)?.events;
+    api?.publish?.(input);
+  } catch {
+    // Swallow — never let publish failure surface into the state mutation.
+  }
+}
+
+export function publishPaneCreated(workspaceId: string, paneId: string, parentBranchId?: string): void {
+  publish({ type: 'pane.created', workspaceId, paneId, ...(parentBranchId ? { parentBranchId } : {}) });
+}
+
+export function publishPaneClosed(workspaceId: string, paneId: string): void {
+  publish({ type: 'pane.closed', workspaceId, paneId });
+}
+
+export function publishPaneFocused(workspaceId: string, paneId: string, previousPaneId?: string): void {
+  publish({ type: 'pane.focused', workspaceId, paneId, ...(previousPaneId ? { previousPaneId } : {}) });
+}
+
+export function publishPaneMetadataChanged(
+  workspaceId: string,
+  paneId: string,
+  metadata: PaneMetadata,
+): void {
+  publish({ type: 'pane.metadata.changed', workspaceId, paneId, metadata });
+}

--- a/src/renderer/events/publisher.ts
+++ b/src/renderer/events/publisher.ts
@@ -5,7 +5,7 @@
 // main and see pane lifecycle. Failures are swallowed — telemetry never
 // breaks a state mutation.
 
-import type { PaneMetadata } from '../../shared/types';
+import type { PaneMetadata, WorkspaceMetadata } from '../../shared/types';
 import type { WmuxEventType } from '../../shared/events';
 
 interface ElectronEventsAPI {
@@ -45,4 +45,12 @@ export function publishPaneMetadataChanged(
   metadata: PaneMetadata,
 ): void {
   publish({ type: 'pane.metadata.changed', workspaceId, paneId, metadata });
+}
+
+export function publishWorkspaceMetadataChanged(
+  workspaceId: string,
+  metadata: WorkspaceMetadata,
+  patch: Partial<WorkspaceMetadata>,
+): void {
+  publish({ type: 'workspace.metadata.changed', workspaceId, metadata, patch });
 }

--- a/src/renderer/stores/slices/__tests__/paneSlice.events.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneSlice.events.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { createPaneSlice, type PaneSlice } from '../paneSlice';
+import { createWorkspace, type Workspace } from '../../../../shared/types';
+
+// Capture publisher calls — paneSlice imports from this module.
+const publishCalls: Array<{ fn: string; args: unknown[] }> = [];
+vi.mock('../../../events/publisher', () => ({
+  publishPaneCreated: (...args: unknown[]) => { publishCalls.push({ fn: 'pane.created', args }); },
+  publishPaneClosed: (...args: unknown[]) => { publishCalls.push({ fn: 'pane.closed', args }); },
+  publishPaneFocused: (...args: unknown[]) => { publishCalls.push({ fn: 'pane.focused', args }); },
+  publishPaneMetadataChanged: (...args: unknown[]) => { publishCalls.push({ fn: 'pane.metadata.changed', args }); },
+}));
+
+type TestState = PaneSlice & {
+  workspaces: Workspace[];
+  activeWorkspaceId: string;
+};
+
+function createTestStore() {
+  const ws = createWorkspace('Test');
+  return create<TestState>()(
+    immer((...args) => ({
+      workspaces: [ws],
+      activeWorkspaceId: ws.id,
+      // @ts-expect-error — minimal test store doesn't match full StoreState
+      ...createPaneSlice(...args),
+    }))
+  );
+}
+
+describe('paneSlice — event publication', () => {
+  let store: ReturnType<typeof createTestStore>;
+  let wsId: string;
+  let rootPaneId: string;
+
+  beforeEach(() => {
+    publishCalls.length = 0;
+    store = createTestStore();
+    const ws = store.getState().workspaces[0];
+    wsId = ws.id;
+    rootPaneId = ws.rootPane.id;
+  });
+
+  describe('splitPane', () => {
+    it('publishes pane.created for the new sibling', () => {
+      store.getState().splitPane(rootPaneId, 'horizontal');
+      const created = publishCalls.find((c) => c.fn === 'pane.created');
+      expect(created).toBeDefined();
+      expect(created?.args[0]).toBe(wsId);
+      // args: (wsId, newPaneId, branchId)
+      expect(typeof created?.args[1]).toBe('string');
+      expect(typeof created?.args[2]).toBe('string');
+    });
+
+    it('publishes pane.focused when active pane changes', () => {
+      store.getState().splitPane(rootPaneId, 'horizontal');
+      const focused = publishCalls.find((c) => c.fn === 'pane.focused');
+      expect(focused).toBeDefined();
+      // (wsId, newActiveId, previousActiveId)
+      expect(focused?.args[0]).toBe(wsId);
+      expect(focused?.args[2]).toBe(rootPaneId);
+    });
+  });
+
+  describe('closePane', () => {
+    it('publishes pane.closed for the dropped leaf', () => {
+      store.getState().splitPane(rootPaneId, 'horizontal');
+      const newPaneId = store.getState().workspaces[0].activePaneId;
+      publishCalls.length = 0; // reset so we only see closePane events
+
+      store.getState().closePane(newPaneId);
+      const closed = publishCalls.find((c) => c.fn === 'pane.closed');
+      expect(closed).toBeDefined();
+      expect(closed?.args).toEqual([wsId, newPaneId]);
+    });
+
+    it('publishes pane.focused when active changes after close', () => {
+      store.getState().splitPane(rootPaneId, 'horizontal');
+      const newPaneId = store.getState().workspaces[0].activePaneId;
+      publishCalls.length = 0;
+
+      store.getState().closePane(newPaneId);
+      const focused = publishCalls.find((c) => c.fn === 'pane.focused');
+      expect(focused).toBeDefined();
+    });
+  });
+
+  describe('setActivePane', () => {
+    it('publishes pane.focused only when paneId actually changes', () => {
+      // Split so we have two leaves to swap between.
+      store.getState().splitPane(rootPaneId, 'horizontal');
+      const newPaneId = store.getState().workspaces[0].activePaneId;
+      publishCalls.length = 0;
+
+      // No-op: setting the already-active pane.
+      store.getState().setActivePane(newPaneId);
+      expect(publishCalls.filter((c) => c.fn === 'pane.focused')).toHaveLength(0);
+
+      // Real change.
+      store.getState().setActivePane(rootPaneId);
+      const focused = publishCalls.find((c) => c.fn === 'pane.focused');
+      expect(focused).toBeDefined();
+      expect(focused?.args[0]).toBe(wsId);
+      expect(focused?.args[1]).toBe(rootPaneId);
+      expect(focused?.args[2]).toBe(newPaneId);
+    });
+
+    it('does not publish when paneId is unknown', () => {
+      store.getState().setActivePane('does-not-exist');
+      expect(publishCalls.filter((c) => c.fn === 'pane.focused')).toHaveLength(0);
+    });
+  });
+
+  describe('setPaneMetadata', () => {
+    it('publishes pane.metadata.changed with the merged metadata', () => {
+      store.getState().setPaneMetadata(rootPaneId, { label: 'Backend' });
+      const event = publishCalls.find((c) => c.fn === 'pane.metadata.changed');
+      expect(event).toBeDefined();
+      expect(event?.args[0]).toBe(wsId);
+      expect(event?.args[1]).toBe(rootPaneId);
+      expect((event?.args[2] as { label?: string }).label).toBe('Backend');
+    });
+
+    it('does not publish on size-cap rejection', () => {
+      const huge = 'x'.repeat(10_000);
+      try {
+        store.getState().setPaneMetadata(rootPaneId, { custom: { blob: huge } });
+      } catch { /* expected */ }
+      expect(publishCalls.filter((c) => c.fn === 'pane.metadata.changed')).toHaveLength(0);
+    });
+  });
+});

--- a/src/renderer/stores/slices/__tests__/workspaceSlice.events.test.ts
+++ b/src/renderer/stores/slices/__tests__/workspaceSlice.events.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { createWorkspaceSlice, type WorkspaceSlice } from '../workspaceSlice';
+
+// Capture publisher calls — workspaceSlice imports from this module.
+const publishCalls: Array<{ fn: string; args: unknown[] }> = [];
+vi.mock('../../../events/publisher', () => ({
+  publishWorkspaceMetadataChanged: (...args: unknown[]) => {
+    publishCalls.push({ fn: 'workspace.metadata.changed', args });
+  },
+}));
+
+type TestState = WorkspaceSlice;
+
+function createTestStore() {
+  return create<TestState>()(
+    immer((...args) => ({
+      // @ts-expect-error — minimal test store doesn't match full StoreState
+      ...createWorkspaceSlice(...args),
+    }))
+  );
+}
+
+describe('workspaceSlice — workspace.metadata.changed publication (review fix 6a)', () => {
+  let store: ReturnType<typeof createTestStore>;
+  let wsId: string;
+
+  beforeEach(() => {
+    publishCalls.length = 0;
+    store = createTestStore();
+    // Make sure there's at least one workspace; use the first auto-created.
+    wsId = store.getState().workspaces[0]?.id ?? '';
+    if (!wsId) {
+      store.getState().addWorkspace('Test');
+      wsId = store.getState().workspaces[0].id;
+    }
+  });
+
+  it('publishes when status changes', () => {
+    store.getState().updateWorkspaceMetadata(wsId, { status: 'running' });
+
+    const ev = publishCalls.find((c) => c.fn === 'workspace.metadata.changed');
+    expect(ev).toBeDefined();
+    expect(ev?.args[0]).toBe(wsId);
+    expect((ev?.args[1] as { status?: string }).status).toBe('running');
+    expect(ev?.args[2]).toEqual({ status: 'running' });
+  });
+
+  it('publishes when progress changes', () => {
+    store.getState().updateWorkspaceMetadata(wsId, { progress: 42 });
+
+    const ev = publishCalls.find((c) => c.fn === 'workspace.metadata.changed');
+    expect(ev).toBeDefined();
+    expect((ev?.args[1] as { progress?: number }).progress).toBe(42);
+    expect(ev?.args[2]).toEqual({ progress: 42 });
+  });
+
+  it('publishes the FULL post-update snapshot in arg[1] and JUST the patch in arg[2]', () => {
+    store.getState().updateWorkspaceMetadata(wsId, { status: 'idle' });
+    publishCalls.length = 0;
+
+    store.getState().updateWorkspaceMetadata(wsId, { progress: 80 });
+    const ev = publishCalls[0];
+    // Full snapshot has both fields.
+    expect((ev.args[1] as { status?: string; progress?: number })).toMatchObject({
+      status: 'idle',
+      progress: 80,
+    });
+    // Patch only carries the keys this call wrote.
+    expect(ev.args[2]).toEqual({ progress: 80 });
+  });
+
+  it('does not publish for unknown workspace id (silent no-op)', () => {
+    store.getState().updateWorkspaceMetadata('does-not-exist', { status: 'x' });
+    expect(publishCalls).toHaveLength(0);
+  });
+
+  it('publishes shell-hook updates the same as user-driven ones (cwd, gitBranch, etc.)', () => {
+    store.getState().updateWorkspaceMetadata(wsId, { cwd: 'D:/wmux', gitBranch: 'feature/x' });
+    const ev = publishCalls[0];
+    expect(ev.args[2]).toEqual({ cwd: 'D:/wmux', gitBranch: 'feature/x' });
+    // Note: chatty PTY hooks may emit many of these; throttling is a deliberate
+    // follow-up (see #18) — for now any update emits.
+  });
+});

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -6,6 +6,12 @@ import {
   generateId,
   PANE_METADATA_MAX_BYTES,
 } from '../../../shared/types';
+import {
+  publishPaneCreated,
+  publishPaneClosed,
+  publishPaneFocused,
+  publishPaneMetadataChanged,
+} from '../../events/publisher';
 
 export interface PaneSlice {
   splitPane: (paneId: string, direction: 'horizontal' | 'vertical', workspaceId?: string) => void;
@@ -53,82 +59,126 @@ function getLeafPanes(root: Pane): PaneLeaf[] {
 }
 
 export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]], [], PaneSlice> = (set, get) => ({
-  splitPane: (paneId, direction, workspaceId) => set((state: StoreState) => {
-    const targetWsId = workspaceId || state.activeWorkspaceId;
-    const ws = state.workspaces.find((w: Workspace) => w.id === targetWsId);
-    if (!ws) return;
+  splitPane: (paneId, direction, workspaceId) => {
+    let event: { wsId: string; newPaneId: string; branchId: string; previousActiveId: string } | null = null;
+    set((state: StoreState) => {
+      const targetWsId = workspaceId || state.activeWorkspaceId;
+      const ws = state.workspaces.find((w: Workspace) => w.id === targetWsId);
+      if (!ws) return;
 
-    const targetPane = findPane(ws.rootPane, paneId);
-    if (!targetPane || targetPane.type !== 'leaf') return;
+      const targetPane = findPane(ws.rootPane, paneId);
+      if (!targetPane || targetPane.type !== 'leaf') return;
 
-    const newPane = createLeafPane();
-    const branch: PaneBranch = {
-      id: generateId('pane'),
-      type: 'branch',
-      direction,
-      children: [{ ...targetPane }, newPane],
-      sizes: [50, 50],
-    };
+      const newPane = createLeafPane();
+      const branch: PaneBranch = {
+        id: generateId('pane'),
+        type: 'branch',
+        direction,
+        children: [{ ...targetPane }, newPane],
+        sizes: [50, 50],
+      };
 
-    // Replace target with branch
-    const parent = findParent(ws.rootPane, paneId);
-    if (parent) {
-      const idx = parent.children.findIndex((c) => c.id === paneId);
-      if (idx !== -1) {
-        parent.children[idx] = branch;
-      }
-    } else {
-      // Target is the root
-      ws.rootPane = branch;
-    }
-
-    ws.activePaneId = newPane.id;
-  }),
-
-  closePane: (paneId) => set((state: StoreState) => {
-    const ws = state.workspaces.find((w: Workspace) => w.id === state.activeWorkspaceId);
-    if (!ws) return;
-
-    const parent = findParent(ws.rootPane, paneId);
-    if (!parent) {
-      // Can't close root pane, but can clear its surfaces
-      return;
-    }
-
-    const idx = parent.children.findIndex((c) => c.id === paneId);
-    if (idx === -1) return;
-
-    parent.children.splice(idx, 1);
-
-    if (parent.children.length === 1) {
-      // Collapse: replace parent with the remaining child
-      const remaining = parent.children[0];
-      const grandParent = findParent(ws.rootPane, parent.id);
-      if (grandParent) {
-        const parentIdx = grandParent.children.findIndex((c) => c.id === parent.id);
-        if (parentIdx !== -1) {
-          grandParent.children[parentIdx] = remaining;
+      // Replace target with branch
+      const parent = findParent(ws.rootPane, paneId);
+      if (parent) {
+        const idx = parent.children.findIndex((c) => c.id === paneId);
+        if (idx !== -1) {
+          parent.children[idx] = branch;
         }
       } else {
-        // Parent was root
-        ws.rootPane = remaining;
+        // Target is the root
+        ws.rootPane = branch;
+      }
+
+      const previousActiveId = ws.activePaneId;
+      ws.activePaneId = newPane.id;
+
+      event = {
+        wsId: targetWsId,
+        newPaneId: newPane.id,
+        branchId: branch.id,
+        previousActiveId,
+      };
+    });
+    if (event) {
+      const e = event as { wsId: string; newPaneId: string; branchId: string; previousActiveId: string };
+      publishPaneCreated(e.wsId, e.newPaneId, e.branchId);
+      if (e.previousActiveId !== e.newPaneId) {
+        publishPaneFocused(e.wsId, e.newPaneId, e.previousActiveId);
       }
     }
+  },
 
-    // Update active pane
-    const leaves = getLeafPanes(ws.rootPane);
-    if (leaves.length > 0 && !leaves.some((l) => l.id === ws.activePaneId)) {
-      ws.activePaneId = leaves[0].id;
+  closePane: (paneId) => {
+    let event: { wsId: string; closedPaneId: string; previousActiveId: string; newActiveId: string | null } | null = null;
+    set((state: StoreState) => {
+      const ws = state.workspaces.find((w: Workspace) => w.id === state.activeWorkspaceId);
+      if (!ws) return;
+
+      const parent = findParent(ws.rootPane, paneId);
+      if (!parent) {
+        // Can't close root pane, but can clear its surfaces
+        return;
+      }
+
+      const idx = parent.children.findIndex((c) => c.id === paneId);
+      if (idx === -1) return;
+
+      const previousActiveId = ws.activePaneId;
+      parent.children.splice(idx, 1);
+
+      if (parent.children.length === 1) {
+        // Collapse: replace parent with the remaining child
+        const remaining = parent.children[0];
+        const grandParent = findParent(ws.rootPane, parent.id);
+        if (grandParent) {
+          const parentIdx = grandParent.children.findIndex((c) => c.id === parent.id);
+          if (parentIdx !== -1) {
+            grandParent.children[parentIdx] = remaining;
+          }
+        } else {
+          // Parent was root
+          ws.rootPane = remaining;
+        }
+      }
+
+      // Update active pane
+      const leaves = getLeafPanes(ws.rootPane);
+      if (leaves.length > 0 && !leaves.some((l) => l.id === ws.activePaneId)) {
+        ws.activePaneId = leaves[0].id;
+      }
+
+      event = {
+        wsId: ws.id,
+        closedPaneId: paneId,
+        previousActiveId,
+        newActiveId: ws.activePaneId !== previousActiveId ? ws.activePaneId : null,
+      };
+    });
+    if (event) {
+      const e = event as { wsId: string; closedPaneId: string; previousActiveId: string; newActiveId: string | null };
+      publishPaneClosed(e.wsId, e.closedPaneId);
+      if (e.newActiveId) {
+        publishPaneFocused(e.wsId, e.newActiveId, e.previousActiveId);
+      }
     }
-  }),
+  },
 
-  setActivePane: (paneId) => set((state: StoreState) => {
-    const ws = state.workspaces.find((w: Workspace) => w.id === state.activeWorkspaceId);
-    if (!ws) return;
-    if (findPane(ws.rootPane, paneId)) {
+  setActivePane: (paneId) => {
+    let event: { wsId: string; paneId: string; previousActiveId: string } | null = null;
+    set((state: StoreState) => {
+      const ws = state.workspaces.find((w: Workspace) => w.id === state.activeWorkspaceId);
+      if (!ws) return;
+      if (!findPane(ws.rootPane, paneId)) return;
+      if (ws.activePaneId === paneId) return; // No-op when already active.
+      event = { wsId: ws.id, paneId, previousActiveId: ws.activePaneId };
       ws.activePaneId = paneId;
+    });
+    if (event) {
+      const e = event as { wsId: string; paneId: string; previousActiveId: string };
+      publishPaneFocused(e.wsId, e.paneId, e.previousActiveId);
     }
-  }),
+  },
 
   updatePaneSizes: (branchId, sizes) => set((state: StoreState) => {
     const ws = state.workspaces.find((w: Workspace) => w.id === state.activeWorkspaceId);
@@ -221,6 +271,7 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
       if (!draftTarget || draftTarget.type !== 'leaf') return;
       draftTarget.metadata = next;
     });
+    publishPaneMetadataChanged(targetWsId, paneId, next);
   },
 
   getPaneMetadata: (paneId, opts) => {
@@ -242,7 +293,9 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
     target.metadata = undefined;
   }),
 
-  focusPaneDirection: (direction) => set((state: StoreState) => {
+  focusPaneDirection: (direction) => {
+    let event: { wsId: string; paneId: string; previousActiveId: string } | null = null;
+    set((state: StoreState) => {
     const ws = state.workspaces.find((w: Workspace) => w.id === state.activeWorkspaceId);
     if (!ws) return;
 
@@ -287,8 +340,14 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
     };
 
     const targetId = navigate(ws.activePaneId, direction);
-    if (targetId) {
+    if (targetId && targetId !== ws.activePaneId) {
+      event = { wsId: ws.id, paneId: targetId, previousActiveId: ws.activePaneId };
       ws.activePaneId = targetId;
     }
-  }),
+    });
+    if (event) {
+      const e = event as { wsId: string; paneId: string; previousActiveId: string };
+      publishPaneFocused(e.wsId, e.paneId, e.previousActiveId);
+    }
+  },
 });

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -4,6 +4,7 @@ import { createWorkspace, generateId, BUILTIN_TEMPLATES, type Pane, type PaneLea
 import { getPresetById } from '../../../shared/layoutPresets';
 import { setLocale as i18nSetLocale, type Locale } from '../../i18n';
 import { applyCustomCssVars, migrateThemeId } from '../../themes';
+import { publishWorkspaceMetadataChanged } from '../../events/publisher';
 
 /** Collect all leaf panes from a pane tree */
 function collectLeafPanes(pane: Pane): PaneLeaf[] {
@@ -112,13 +113,20 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
       if (ws) ws.name = name;
     }),
 
-    updateWorkspaceMetadata: (id, metadata) => set((state: StoreState) => {
-      const ws = state.workspaces.find((w: Workspace) => w.id === id);
-      if (ws) {
+    updateWorkspaceMetadata: (id, metadata) => {
+      let publishPayload: { wsId: string; full: WorkspaceMetadata; patch: Partial<WorkspaceMetadata> } | null = null;
+      set((state: StoreState) => {
+        const ws = state.workspaces.find((w: Workspace) => w.id === id);
+        if (!ws) return;
         if (!ws.metadata) ws.metadata = {};
         Object.assign(ws.metadata, metadata);
+        publishPayload = { wsId: ws.id, full: { ...ws.metadata }, patch: metadata };
+      });
+      if (publishPayload) {
+        const p = publishPayload as { wsId: string; full: WorkspaceMetadata; patch: Partial<WorkspaceMetadata> };
+        publishWorkspaceMetadataChanged(p.wsId, p.full, p.patch);
       }
-    }),
+    },
 
     reorderWorkspace: (fromIndex, toIndex) => set((state: StoreState) => {
       if (fromIndex === toIndex) return;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -50,6 +50,8 @@ export const IPC = {
   SCROLLBACK_LOAD: 'scrollback:load',
   // Token tracking
   TOKEN_UPDATE: 'token:update',
+  // EventBus publish — renderer→main one-way for pane lifecycle events
+  EVENTS_PUBLISH: 'events:publish',
   // Window control
   WINDOW_HIDE: 'window:hide',
   // MCP integration status / management (Settings panel + CLI parity)

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -7,10 +7,23 @@
 //
 // The ring is in-memory only and lives for the lifetime of the main process.
 // Daemon restarts clear the ring; clients that drift past the ring window get
-// a `resync: true` flag and should reconcile via `pane.list`.
+// a `resync: true` flag and should reconcile via `pane.list`. Each main-process
+// run also gets a `bootId` (UUIDv4) so clients can distinguish "we drifted
+// past the window" from "the daemon restarted under us" — the latter
+// invalidates the entire seq space, not just the events you missed.
 //
 // Workspace scoping: each event carries a `workspaceId`; `events.poll` filters
 // by the caller's claimed workspace by default so workspaces stay isolated.
+//
+// === Ordering caveat ===
+//
+// `seq` is monotonic in **arrival order**, not in **causal order**. Two
+// independent producers (PTYBridge emits in-process from main; paneSlice
+// publishes through preload IPC) write to the bus on different paths. Within
+// one producer the order is preserved, but across producers a same-tick
+// `pane.created` (renderer-published) and `process.started` (main-published)
+// can land in the bus in either order. Clients must not assume seq order
+// implies causal order across producer boundaries.
 
 import type { PaneMetadata } from './types';
 

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -1,0 +1,87 @@
+// === wmux Event Bus types ===
+//
+// Lightweight event surface for external tooling (Claude Code, third-party MCPs)
+// that want to react to pane/process lifecycle without polling the full state.
+// Events are pull-only via `events.poll(cursor)` — pull cursor is the seq number
+// of the last seen event; the bus returns events with `seq > cursor`.
+//
+// The ring is in-memory only and lives for the lifetime of the main process.
+// Daemon restarts clear the ring; clients that drift past the ring window get
+// a `resync: true` flag and should reconcile via `pane.list`.
+//
+// Workspace scoping: each event carries a `workspaceId`; `events.poll` filters
+// by the caller's claimed workspace by default so workspaces stay isolated.
+
+import type { PaneMetadata } from './types';
+
+export type WmuxEventType =
+  | 'pane.created'
+  | 'pane.closed'
+  | 'pane.focused'
+  | 'pane.metadata.changed'
+  | 'process.started'
+  | 'process.exited';
+
+export const WMUX_EVENT_TYPES: readonly WmuxEventType[] = [
+  'pane.created',
+  'pane.closed',
+  'pane.focused',
+  'pane.metadata.changed',
+  'process.started',
+  'process.exited',
+] as const;
+
+export interface WmuxEventBase {
+  seq: number;          // monotonic; cursor for poll
+  ts: number;           // ms epoch
+  workspaceId: string;
+  type: WmuxEventType;
+}
+
+export interface PaneCreatedEvent extends WmuxEventBase {
+  type: 'pane.created';
+  paneId: string;
+  parentBranchId?: string;
+}
+
+export interface PaneClosedEvent extends WmuxEventBase {
+  type: 'pane.closed';
+  paneId: string;
+}
+
+export interface PaneFocusedEvent extends WmuxEventBase {
+  type: 'pane.focused';
+  paneId: string;
+  previousPaneId?: string;
+}
+
+export interface PaneMetadataChangedEvent extends WmuxEventBase {
+  type: 'pane.metadata.changed';
+  paneId: string;
+  metadata: PaneMetadata;
+}
+
+export interface ProcessStartedEvent extends WmuxEventBase {
+  type: 'process.started';
+  ptyId: string;
+  pid?: number;
+  shell: string;
+}
+
+export interface ProcessExitedEvent extends WmuxEventBase {
+  type: 'process.exited';
+  ptyId: string;
+  exitCode: number | null;
+  signal?: string;
+}
+
+export type WmuxEvent =
+  | PaneCreatedEvent
+  | PaneClosedEvent
+  | PaneFocusedEvent
+  | PaneMetadataChangedEvent
+  | ProcessStartedEvent
+  | ProcessExitedEvent;
+
+export const RING_CAPACITY = 1024;
+export const POLL_DEFAULT_MAX = 256;

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -25,13 +25,14 @@
 // can land in the bus in either order. Clients must not assume seq order
 // implies causal order across producer boundaries.
 
-import type { PaneMetadata } from './types';
+import type { PaneMetadata, WorkspaceMetadata } from './types';
 
 export type WmuxEventType =
   | 'pane.created'
   | 'pane.closed'
   | 'pane.focused'
   | 'pane.metadata.changed'
+  | 'workspace.metadata.changed'
   | 'process.started'
   | 'process.exited';
 
@@ -40,6 +41,7 @@ export const WMUX_EVENT_TYPES: readonly WmuxEventType[] = [
   'pane.closed',
   'pane.focused',
   'pane.metadata.changed',
+  'workspace.metadata.changed',
   'process.started',
   'process.exited',
 ] as const;
@@ -74,6 +76,19 @@ export interface PaneMetadataChangedEvent extends WmuxEventBase {
   metadata: PaneMetadata;
 }
 
+/**
+ * Fires when WorkspaceMetadata mutates (cwd, gitBranch, listeningPorts,
+ * status, progress, agentName, agentStatus, lastNotification). The full
+ * post-mutation metadata snapshot is included so clients don't need to
+ * re-query. `patch` carries the keys that the caller actually wrote, so
+ * dashboards can distinguish "user set status" from "shell hook updated cwd".
+ */
+export interface WorkspaceMetadataChangedEvent extends WmuxEventBase {
+  type: 'workspace.metadata.changed';
+  metadata: WorkspaceMetadata;
+  patch: Partial<WorkspaceMetadata>;
+}
+
 export interface ProcessStartedEvent extends WmuxEventBase {
   type: 'process.started';
   ptyId: string;
@@ -93,6 +108,7 @@ export type WmuxEvent =
   | PaneClosedEvent
   | PaneFocusedEvent
   | PaneMetadataChangedEvent
+  | WorkspaceMetadataChangedEvent
   | ProcessStartedEvent
   | ProcessExitedEvent;
 

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -28,6 +28,7 @@ export type RpcMethod =
   | 'pane.setMetadata'
   | 'pane.getMetadata'
   | 'pane.clearMetadata'
+  | 'events.poll'
   | 'input.send'
   | 'input.sendKey'
   | 'input.readScreen'
@@ -116,6 +117,7 @@ export const ALL_RPC_METHODS = [
   'pane.setMetadata',
   'pane.getMetadata',
   'pane.clearMetadata',
+  'events.poll',
   'input.send',
   'input.sendKey',
   'input.readScreen',


### PR DESCRIPTION
> Tracks: #18 · Refs: #15 · Stacked on: #16

## Summary

Second half of the external tooling RFC (#15 from @alphabeen). Adds the
EventBus that external MCP tools (Claude Code, third-party agents) poll to
react to pane/process lifecycle without scraping state.

**Stacked on #16 (pane metadata).** When that lands, this PR's base will
auto-retarget to `main`.

## What's in

- **`WmuxEventType`** union: `pane.created` / `pane.closed` / `pane.focused` / `pane.metadata.changed` / `process.started` / `process.exited`
- **`EventBus`** singleton (`src/main/events/EventBus.ts`): 1024-event ring, monotonic `seq` cursor, stale-cursor `resync: true` flag when caller drifts past the window, per-workspace + per-type filtering at poll time
- **RPC**: `events.poll({ cursor, types?, workspaceId?, max? })` answered directly from main (no renderer hop)
- **MCP tool**: `wmux_events_poll` — auto-scoped to caller's workspace via `requireWorkspaceId()`
- **Producers**:
  - `paneSlice` — `splitPane` / `closePane` / `setActivePane` / `focusPaneDirection` / `setPaneMetadata` publish via preload IPC channel `events:publish`
  - `PTYBridge` — `process.started` on attach, `process.exited` in `onExit` callback (uses `PTYInstance.workspaceId` captured at `PTYManager.create`)
- **Capability flag**: `system.capabilities().features.events = { types: [...], maxRingSize: 1024 }`
- **Stdio-friendly**: polling only, no push/SSE — matches `daemon.readPromptEvents` precedent

## Design choices

- **Polling vs push**: stdio MCP transport doesn't carry server-initiated notifications cleanly. Polling at 1-5s intervals + 1024-event ring covers minutes of activity without state loss.
- **Single global ring + filter at poll**: simpler than per-workspace buffers; 1024 entries × ~200B = ~200KB resident memory, trivial.
- **Trust boundary at IPC**: renderer-published events are validated for `type` (must be in `WMUX_EVENT_TYPES`) and `workspaceId` (must be non-empty string) before reaching the bus. Bad events drop silently.
- **`process.exited` workspaceId scoping**: `PTYInstance.workspaceId` is optional; PTYs without workspace context (CLI, tests) skip emission entirely so test mocks don't break.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 836/836 pass (PR #16 baseline 811 + 25 new)
- [x] `npm run build:mcp` — clean
- [ ] Manual: external Claude Code → `wmux_events_poll({cursor: 0})` → see initial events. Split a new pane in the wmux UI → next poll returns `pane.created` + `pane.focused` with monotonic `seq`.
- [ ] Manual: `exit` in a terminal → next poll returns `process.exited` with the correct exit code.
- [ ] Manual: 1024+ events emitted, then poll with stale cursor → response includes `resync: true`.
- [ ] Manual: workspace A's MCP polls → only A's events visible (B's events filtered out).

## Out of scope (future PRs)

- Push/SSE event delivery (revisit if poll latency becomes a UX problem)
- Event persistence across daemon restarts
- Cross-workspace metadata writes
- Pane buffer access policy gates (already partial via `terminal_read*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)