### PR TITLE
fix(terminal): close remaining clipboard-copy gaps after v2.7.4

### DIFF
--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -224,6 +224,14 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         webglAddonRef.current = null;
         loadWebgl();
       }
+      // Selection-preservation guard — this is mostly defensive (fonts.ready
+      // resolves on mount before the user can select anything), but pinning
+      // the contract here prevents future regressions if anything triggers
+      // a font load mid-session.
+      if (!shouldFitWhilePreservingSelection(terminalRef.current)) {
+        console.debug('[Terminal] fonts.ready fit skipped — active selection');
+        return;
+      }
       fitAddon.fit();
       terminal.refresh(0, terminal.rows - 1);
     });
@@ -232,6 +240,32 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     let lastSentCols = 0;
     let lastSentRows = 0;
     let resizeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    // Auto-copy on selection (debounced) — selection survives just long enough
+    // for the user to release the mouse, then we push it to the clipboard.
+    // Without this, the only path is the explicit Ctrl+C / right-click flow,
+    // which loses selections that get wiped by PTY data, focus changes, or
+    // any fit() that slipped past the guards. Debounce coalesces the storm
+    // of onSelectionChange events that fire during a drag (one per cell).
+    //
+    // We deliberately do NOT show the success toast here — the user didn't
+    // press a key, so a flashing "Copied!" would be UI noise. Errors are
+    // also swallowed: the explicit Ctrl+C path will surface them properly
+    // when the user actually presses the keybind.
+    let selectionCopyTimer: ReturnType<typeof setTimeout> | null = null;
+    const SELECTION_COPY_DEBOUNCE_MS = 150;
+    const selectionDisposable = terminal.onSelectionChange(() => {
+      if (selectionCopyTimer) clearTimeout(selectionCopyTimer);
+      selectionCopyTimer = setTimeout(() => {
+        selectionCopyTimer = null;
+        const sel = terminal.getSelection();
+        if (!sel || sel.length === 0) return;
+        void window.clipboardAPI.writeText(sel).catch(() => {
+          // Silent — Ctrl+C / right-click paths still show error toasts
+          // when the user explicitly retries.
+        });
+      }, SELECTION_COPY_DEBOUNCE_MS);
+    });
 
     // Clipboard + shortcut handling
     terminal.attachCustomKeyEventHandler((e) => {
@@ -591,6 +625,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
 
     return () => {
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
+      if (selectionCopyTimer) clearTimeout(selectionCopyTimer);
+      selectionDisposable.dispose();
       resizeObserver.disconnect();
       removeDataListener?.();
       removeExitListener?.();
@@ -630,8 +666,17 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       if (!webglAddonRef.current && loadWebglRef.current) {
         loadWebglRef.current();
       }
-      // Defer fit to allow CSS display change to take effect before measuring
+      // Defer fit to allow CSS display change to take effect before measuring.
+      // Selection-preservation guard — workspace/tab switch then immediate
+      // selection + Ctrl+C used to wipe the selection because this fit had
+      // no guard (unlike ResizeObserver and font/theme paths). The next
+      // ResizeObserver tick (after selection is released) handles the
+      // deferred resize naturally.
       const id = requestAnimationFrame(() => {
+        if (!shouldFitWhilePreservingSelection(terminalRef.current)) {
+          console.debug('[Terminal] visibility fit skipped — active selection');
+          return;
+        }
         fit();
       });
       return () => cancelAnimationFrame(id);

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -11,6 +11,7 @@ import { XTERM_THEMES, extractXtermColors, type ThemeId, type BuiltinThemeId } f
 import { pastePtyChunked } from '../utils/clipboardChunk';
 import { runCopyWithFeedback } from '../utils/copyWithFeedback';
 import { shouldFitWhilePreservingSelection } from '../utils/fitGuard';
+import { createAutoSelectionCopy } from '../utils/autoSelectionCopy';
 
 // Module-level terminal registry for scrollback persistence
 const terminalRegistry = new Map<string, Terminal>();
@@ -245,26 +246,17 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // for the user to release the mouse, then we push it to the clipboard.
     // Without this, the only path is the explicit Ctrl+C / right-click flow,
     // which loses selections that get wiped by PTY data, focus changes, or
-    // any fit() that slipped past the guards. Debounce coalesces the storm
-    // of onSelectionChange events that fire during a drag (one per cell).
-    //
-    // We deliberately do NOT show the success toast here — the user didn't
-    // press a key, so a flashing "Copied!" would be UI noise. Errors are
-    // also swallowed: the explicit Ctrl+C path will surface them properly
-    // when the user actually presses the keybind.
-    let selectionCopyTimer: ReturnType<typeof setTimeout> | null = null;
-    const SELECTION_COPY_DEBOUNCE_MS = 150;
+    // any fit() that slipped past the guards. The debounce + empty-filter
+    // logic lives in `createAutoSelectionCopy` so it can be unit-tested
+    // without xterm. We deliberately do NOT show the success toast here —
+    // auto-copy wasn't keybind-triggered, so a flashing "Copied!" would be
+    // UI noise. Errors are also silent: the explicit Ctrl+C path still
+    // surfaces them on retry.
+    const autoCopy = createAutoSelectionCopy({
+      write: (text) => window.clipboardAPI.writeText(text),
+    });
     const selectionDisposable = terminal.onSelectionChange(() => {
-      if (selectionCopyTimer) clearTimeout(selectionCopyTimer);
-      selectionCopyTimer = setTimeout(() => {
-        selectionCopyTimer = null;
-        const sel = terminal.getSelection();
-        if (!sel || sel.length === 0) return;
-        void window.clipboardAPI.writeText(sel).catch(() => {
-          // Silent — Ctrl+C / right-click paths still show error toasts
-          // when the user explicitly retries.
-        });
-      }, SELECTION_COPY_DEBOUNCE_MS);
+      autoCopy.onSelection(terminal.getSelection());
     });
 
     // Clipboard + shortcut handling
@@ -625,7 +617,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
 
     return () => {
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
-      if (selectionCopyTimer) clearTimeout(selectionCopyTimer);
+      autoCopy.dispose();
       selectionDisposable.dispose();
       resizeObserver.disconnect();
       removeDataListener?.();

--- a/src/renderer/utils/__tests__/autoSelectionCopy.test.ts
+++ b/src/renderer/utils/__tests__/autoSelectionCopy.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createAutoSelectionCopy } from '../autoSelectionCopy';
+
+describe('createAutoSelectionCopy', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('writes the latest selection after the debounce window', () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const handle = createAutoSelectionCopy({ write, debounceMs: 100 });
+
+    handle.onSelection('hello');
+
+    expect(write).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(100);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith('hello');
+  });
+
+  it('coalesces rapid selection changes into a single write', () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const handle = createAutoSelectionCopy({ write, debounceMs: 100 });
+
+    // Simulate the per-cell storm during a drag.
+    handle.onSelection('h');
+    vi.advanceTimersByTime(20);
+    handle.onSelection('he');
+    vi.advanceTimersByTime(20);
+    handle.onSelection('hel');
+    vi.advanceTimersByTime(20);
+    handle.onSelection('hell');
+    vi.advanceTimersByTime(20);
+    handle.onSelection('hello');
+
+    expect(write).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith('hello');
+  });
+
+  it('ignores empty selections (clearing should not clobber clipboard)', () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const handle = createAutoSelectionCopy({ write, debounceMs: 50 });
+
+    handle.onSelection('');
+    vi.advanceTimersByTime(50);
+
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('replaces a pending non-empty write when the selection clears mid-debounce', () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const handle = createAutoSelectionCopy({ write, debounceMs: 100 });
+
+    handle.onSelection('hello');
+    vi.advanceTimersByTime(50);
+    // User clicks elsewhere before debounce fires — selection clears.
+    handle.onSelection('');
+    vi.advanceTimersByTime(100);
+
+    // The previous write was canceled and the empty selection bailed.
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('swallows write errors silently (explicit copy path handles toasts)', async () => {
+    const write = vi.fn().mockRejectedValue(new Error('CLIPBOARD_WRITE_FAILED'));
+    const handle = createAutoSelectionCopy({ write, debounceMs: 50 });
+
+    handle.onSelection('hello');
+    vi.advanceTimersByTime(50);
+
+    // Pump microtasks so the .catch() runs without an unhandled rejection.
+    await vi.runAllTimersAsync();
+
+    expect(write).toHaveBeenCalledTimes(1);
+    // No throw observed — failure is silent.
+  });
+
+  it('dispose() cancels pending writes', () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const handle = createAutoSelectionCopy({ write, debounceMs: 100 });
+
+    handle.onSelection('hello');
+    vi.advanceTimersByTime(50);
+    handle.dispose();
+    vi.advanceTimersByTime(100);
+
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('dispose() is safe to call multiple times', () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const handle = createAutoSelectionCopy({ write });
+
+    expect(() => {
+      handle.dispose();
+      handle.dispose();
+    }).not.toThrow();
+  });
+
+  it('uses the default 150ms debounce when none specified', () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const handle = createAutoSelectionCopy({ write });
+
+    handle.onSelection('x');
+    vi.advanceTimersByTime(149);
+    expect(write).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  it('a selection that arrives after dispose() is honored (handle is reusable)', () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const handle = createAutoSelectionCopy({ write, debounceMs: 50 });
+
+    handle.dispose();
+    handle.onSelection('reborn');
+    vi.advanceTimersByTime(50);
+
+    expect(write).toHaveBeenCalledWith('reborn');
+  });
+});

--- a/src/renderer/utils/autoSelectionCopy.ts
+++ b/src/renderer/utils/autoSelectionCopy.ts
@@ -1,0 +1,66 @@
+/**
+ * Debounced auto-copy on terminal selection change.
+ *
+ * Background:
+ * Terminal `onSelectionChange` fires once per cell during a drag — for a
+ * 50-char selection that's 50 IPC writes if we copy on every event. We
+ * debounce so only the final selection (after the user releases) reaches
+ * the clipboard. Empty selections are ignored (clearing a selection should
+ * not clobber whatever the user had on the clipboard before).
+ *
+ * Failures are silent here — the explicit Ctrl+C / right-click paths still
+ * surface clipboard errors via their own toast when the user retries.
+ *
+ * Extracted from useTerminal.ts so the timing + filtering logic can be
+ * unit-tested without pulling in xterm + Electron + DOM.
+ */
+
+export interface AutoSelectionCopyDeps {
+  /** Bridge to `window.clipboardAPI.writeText` (or any equivalent). */
+  write: (text: string) => Promise<unknown>;
+  /** Debounce window in ms. Defaults to 150. */
+  debounceMs?: number;
+  /**
+   * Optional override for setTimeout/clearTimeout — used by tests with
+   * vitest's `vi.useFakeTimers()`. Defaults to globalThis.
+   */
+  setTimeoutFn?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clearTimeoutFn?: (handle: ReturnType<typeof setTimeout>) => void;
+}
+
+export interface AutoSelectionCopyHandle {
+  /** Call from the terminal's onSelectionChange callback. */
+  onSelection: (selection: string) => void;
+  /** Cancel any pending debounced write. Call on unmount. */
+  dispose: () => void;
+}
+
+const DEFAULT_DEBOUNCE_MS = 150;
+
+export function createAutoSelectionCopy(deps: AutoSelectionCopyDeps): AutoSelectionCopyHandle {
+  const debounceMs = deps.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  const setT = deps.setTimeoutFn ?? ((fn, ms) => setTimeout(fn, ms));
+  const clearT = deps.clearTimeoutFn ?? ((h) => clearTimeout(h));
+
+  let pending: ReturnType<typeof setTimeout> | null = null;
+
+  const onSelection = (selection: string): void => {
+    if (pending) clearT(pending);
+    pending = setT(() => {
+      pending = null;
+      if (!selection || selection.length === 0) return;
+      void deps.write(selection).catch(() => {
+        // Silent — explicit copy paths still surface errors when retried.
+      });
+    }, debounceMs);
+  };
+
+  const dispose = (): void => {
+    if (pending) {
+      clearT(pending);
+      pending = null;
+    }
+  };
+
+  return { onSelection, dispose };
+}


### PR DESCRIPTION
## Summary

User reported clipboard copy still fails intermittently after v2.7.4 — no error toast, just "sometimes nothing happens." Pattern unknown.

Root-cause investigation (`/investigate`) traced it to **two unguarded `fit()` paths v2.7.4 missed** and **a structural gap**: the only copy paths (explicit Ctrl+C / right-click) race against any selection-clearing event between the user making the selection and pressing the keybind. PTY data, focus changes, workspace switch, font load — anything that triggers selection clear *before* Ctrl+C — drops the user into the SIGINT branch, no clipboard call ever happens, and the user sees nothing.

## What's fixed

1. **`isVisible` useEffect fit() now respects selection** ([useTerminal.ts:670](useTerminal.ts:670))
   v2.7.4 added the `shouldFitWhilePreservingSelection` guard to ResizeObserver and the font/theme effect, but missed this one. Workspace/tab switch followed by an immediate selection used to lose the selection on the deferred fit.

2. **`document.fonts.ready` fit() now respects selection** ([useTerminal.ts:227](useTerminal.ts:227))
   Mostly defensive — fonts.ready resolves on mount before the user can select anything — but pins the contract so a future mid-session font load can't regress.

3. **Debounced `onSelectionChange` auto-copy** ([useTerminal.ts:244](useTerminal.ts:244))
   When the user releases a drag selection, push it to the clipboard via the same main-IPC path Ctrl+C uses (size cap, Win32 lock retry, error toast all preserved). 150ms debounce coalesces the per-cell `onSelectionChange` storm during drag.

   - **Silent on success** — auto-copy wasn't requested by a keybind, so a flashing "Copied!" toast would be UI noise.
   - **Silent on error** — the explicit Ctrl+C path still surfaces clipboard failures when the user actually retries; we don't double-toast for the implicit path.
   - **Cleanup** — selection listener disposed, debounce timer cleared on unmount alongside the existing resize timer.

## Why polling/auto-copy instead of `xterm copyOnSelect: true`

xterm's built-in `copyOnSelect` uses `navigator.clipboard.writeText` directly, bypassing wmux's main-IPC clipboard handler. That handler exists for a reason — 1MB size cap, Win32 lock contention retry, structured error toasts (CLIPBOARD_TOO_LARGE / CLIPBOARD_INVALID_TYPE / CLIPBOARD_WRITE_FAILED). Bypassing it would drop those guarantees. The `onSelectionChange` listener gives the same UX while keeping the IPC contract intact.

## Test plan

Failure mode was non-deterministic, so unit tests can't fully simulate it. Manual smoke needed before merge:

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 776/776 pass (no regressions)
- [ ] Manual: drag-select text in a terminal → release → paste in another app → text matches.
- [ ] Manual: `tail -f` a busy log → drag-select while output flows → release → text in clipboard.
- [ ] Manual: select text → switch workspace → switch back → text still selected (visible) → Ctrl+C → text copied.
- [ ] Manual: select text → click outside terminal → selection clears (intentional, xterm behavior) → no stale clipboard write.
- [ ] Manual: long selection (>1MB) → graceful error toast on explicit Ctrl+C, silent on auto-copy.
- [ ] Manual: regression — Ctrl+C with no selection still sends SIGINT (not a copy attempt).

## Out of scope (deferred)

- xterm `copyOnSelect: true` — would require routing xterm's clipboard write through our IPC, larger surgery
- "Copied!" feedback for auto-copy — could add a quieter visual (e.g. brief selection flash) without going full toast
- Selection history / multi-select clipboard ring — separate feature

## Related

- Continues v2.7.4's "마지막 문단만 복사" fix line (#commit 9ea8f66) — covers the gaps that fix didn't reach
- Independent of #16 / #17 (external tooling RFC) — clipboard layer untouched there

🤖 Generated with [Claude Code](https://claude.com/claude-code)