### PR TITLE
feat(search): cross-pane search with progressive disclosure UI + MCP tool

### DIFF
--- a/decisions.md
+++ b/decisions.md
@@ -1,166 +1,87 @@
-# Decisions Log
+# Decisions Log — Cross-Pane Search
 
-## Template
+<!-- Most recent first. -->
 
-### [YYYY-MM-DD] Decision Title
-**Background**: Why this decision is needed
-**Options**:
-1. Option A — pros / cons
-2. Option B — pros / cons
-3. Option C — pros / cons
+### [2026-05-09] D9. v1 scope = 'workspace' only (cross-ws defer to v2)
+**Background**: Architect 리뷰 F2 (P0) + F3 (P1) — main 측 RPC handler가 caller identity를 모르니 외부 MCP가 `scope: 'all'`로 다른 ws text 누출 가능. UI cross-ws도 비밀번호/.env 등 의도치 않은 노출.
+**Chosen**: v1 RPC `pane.search` params에서 `scope` 파라미터 제거. UI에서도 Ctrl+Shift+F (All Workspaces) 토글 미노출. 기본=현재 ws, 단일 가능 동작.
+**Rationale**: v1 가장 단순/안전한 baseline. 외부 MCP는 자기 workspaceId로 자동 스코프 (PR #16 패턴). cross-ws 권한 분리 + 설정 게이트는 v2 작업으로 명시.
+**Impact**:
+- D4 갱신 (해당 결정 무효화).
+- P0 (F2) 자동 해결 — `scope='all'` 자체가 없어짐.
+- F3 자동 해결 — UI 토글 없음.
+- v2 task 후보: cross-workspace search (default off setting + RPC-layer caller-identity gate + `mcp.claimWorkspace`-class scope enforcement).
 
-**Chosen**: Option [X]
-**Rationale**: Why this option was selected
-**Impact**: What changes as a result
+### [2026-05-09] D8. Panel auto-expand threshold — 10 (with hysteresis)
+**Chosen**: 10개 결과 초과 시 dropdown → panel 자동 전환. **Hysteresis**: open at >10, close at <=5. 사용자가 명시적으로 panel 닫으면 같은 query session에서는 자동 재오픈 안 함 (sticky bit). Architect 리뷰 F7 반영.
+**Rationale**: hysteresis 없으면 입력 중 결과 8↔12 사이에서 panel 깜빡거림. UX-hostile.
 
----
+### [2026-05-09] D7. Scrollback dump 검색 — 제외 (v1)
+**Chosen**: live pane만 (= **`terminalRegistry`에 마운트된 Terminal 인스턴스**)
+**Rationale**: F10 명확화 — "live pane"의 정의는 "PTY가 살아있음"이 아니라 "Terminal 컴포넌트가 마운트되어 있음." PTY exit돼도 buffer 살아있으면 사용자에게 보이므로 검색해야. 95% 케이스 커버. dead-session dump 파일은 v2.
 
-<!-- Add decisions below. Most recent first. -->
+### [2026-05-09] D6. 정규식 지원 — 포함, 잘못된 패턴은 다른 처리
+**Chosen**: regex 모드. RPC는 잘못된 패턴 → error. UI는 `SyntaxError` catch → input 빨간 테두리 + tooltip. 토스트 X. F8 반영.
 
-### [2026-04-17] D1. 안정성·영속성 스코프 확정
-**Background**: wmux daemon의 안정성/영속성 개선 디벨롭 방향을 설정. A(방어)/B(방어+복원)/C(A+B+UX) 세 옵션 제시.
-**Options**:
-1. A만 — IPC 에러 핸들링 + write mutex. 체감 개선 작음.
-2. A + B — A 전체 + 스키마 마이그레이션 + 손상 파일 격리 + .bak rotation. 명확한 가치("데이터 안 잃음 + 업그레이드 안전").
-3. A + B + C — B 전체 + 복원 UI + RingBuffer 설정화 + 수동 스냅샷. 범위가 커서 지연 위험.
+### [2026-05-09] D5. MCP tool 노출 — 포함, result shape spec
+**Chosen**: `wmux_search_panes(query, regex?)` (scope 제거됨, D9 참조).
+**Result shape** (F6 반영):
+```ts
+{
+  resultShapeVersion: 1,
+  results: Array<{
+    paneId: string,
+    surfaceId: string,
+    ptyId: string,
+    lineIdx: number,        // logical line (post wrap-coalescing, F1)
+    text: string,           // matched logical line
+    contextBefore: string[], // 2 lines (default), configurable
+    contextAfter: string[],
+    paneLabel?: string,     // PR #16 metadata when available; missing OK
+  }>,
+  truncated: boolean,
+  totalMatches: number,
+  workspaceId: string,      // echoed for caller verification
+}
+```
+- 결과 cap: 200개. 초과 시 `truncated: true`.
+- `paneLabel`은 PR #16 metadata가 있을 때만. 없어도 깨지지 않음 (F9).
 
-**Chosen**: Option 2 (A + B)
-**Rationale**: 체감 가치와 완성 가능성의 균형. C는 후속 이터레이션으로 분리.
-**Impact**: Large 경로 확정. 예상 파일 10~12개, teammate 5~6명, 2~3일.
+### [2026-05-09] D4. (DEPRECATED — D9가 대체)
+~~검색 범위 — 현재 ws 기본 + 토글로 All Workspaces~~
 
----
+### [2026-05-09] D3. 검색 엔진 — On-demand grep over xterm Terminal.buffer (with wrap-coalescing)
+**Chosen**: 검색 시점에만 모든 leaf pane의 `terminalRegistry`에서 Terminal 가져와 `buffer.active.getLine(i).translateToString(true)` 순회.
+**Wrap-coalescing** (F1 반영): `BufferLine.isWrapped`로 연속된 wrapped row를 한 logical line으로 병합. 예: 80-col에서 200-char 로그는 3 row지만 1 logical line. `lineIdx`는 logical line 인덱스, 원래 `baseY+offset`은 별도 보관해서 결과 클릭 시 `scrollToLine`에 사용.
+**ptyId → workspaceId 역매핑** (F12 반영): 검색 entry 시점에 `store.workspaces` walk로 일회성 Map<ptyId, workspaceId> 빌드. 검색 결과 필터링/태깅에 사용.
+**RingBuffer 사용 안 함** (F4 반영): daemon RingBuffer는 ANSI raw bytes + 다른 wrap geometry. 검색 source는 xterm.js buffer로 통일. 향후 indexing 진화 시에도 RingBuffer 안 씀.
+**Performance guard** (F11 반영): per-pane 스캔 cap = 20,000 lines (config 가능). 초과 시 응답에 `truncated: true`. 또는 1k row마다 `queueMicrotask`로 yield해서 UI block 방지.
+**Rationale**: 메모리 비용 0, indexing 복잡도 회피. 10 pane × 20k lines × 100 chars ≈ 20MB string scan, 수백 ms 이내 (yield 후크 포함).
 
-### [2026-04-17] D2. Write mutex 구현 방식
-**Background**: StateWriter/SessionManager concurrent write race 방지 필요.
-**Chosen**: 자체 Promise 큐 (의존성 없음, 30~50줄)
-**Rationale**: 외부 의존성 추가 최소화, 테스트 단순화, 프로젝트 일관성.
-**Impact**: `src/daemon/util/AsyncQueue.ts` 신규. StateWriter/SessionManager에서 사용.
+### [2026-05-09] D2. Task size — Large
+파일 10+, 새 UX 패턴, 의존성 4. Full Path.
 
----
-
-### [2026-04-17] D3. 스키마 마이그레이션 전략
-**Background**: SessionData/DaemonState의 version up 처리 필요.
-**Chosen**: Lazy (load 시 변환, 다음 save에서 새 포맷 기록)
-**Rationale**: 롤백 쉬움, 변환 실패 시 영향 국지화, 시작 지연 없음.
-**Impact**: `src/daemon/migrations/` 디렉토리 신설. 각 마이그레이션 파일은 순수 함수 `migrate(input: vN) => vN+1`. SessionManager/StateWriter의 load 경로에서 version 체크 후 체이닝.
-
----
-
-### [2026-04-17] D4. 손상 파일 복구 전략
-**Background**: validate 실패 시 현재는 null 반환 → 빈 세션으로 출발. 사용자 데이터 무음 손실.
-**Chosen**: 격리 + 사일런트 fallback + 구조화 로그
-- 손상 파일을 `corrupted.{timestamp}.bak`로 이름 변경 후 보존
-- `.bak` fallback 시도 → 실패 시 fresh start
-- daemon log에 `CORRUPT_FILE` 이벤트 구조화 기록
-- UI 알림(토스트)은 Phase C 스코프로 분리
-**Rationale**: 데이터 보존 + 디버깅 가능성 확보. UI 통합은 스코프 경계 밖.
-**Impact**: SessionManager/StateWriter의 load 경로 수정. 격리 파일은 .bak rotation 대상에서 제외.
-
----
-
-### [2026-04-17] D5. .bak rotation 전략
-**Background**: 현재 .bak 파일이 무한정 누적됨. 장기 사용 시 디스크 낭비 + 디렉토리 성능 저하.
-**Chosen**: Count-based, 최근 3개 유지 (`.bak.1`, `.bak.2`, `.bak.3`)
-**Rationale**: 1개는 부족(연속 손상 대응 불가), 5개는 과함. 3개는 "직전 저장 2회 + 격리 전 1회" 커버.
-**Impact**: StateWriter/SessionManager에 `rotateBackups()` 헬퍼 추가. save 성공 시 호출.
-
----
-
-### [2026-04-17] D6. IPC 에러 핸들링 패턴
-**Background**: `registerHandlers.ts`에 try/catch 전무. daemon 끊기면 renderer 무반응.
-**Chosen**: Per-handler wrapper helper (`wrapHandler(fn)`)
-- 모든 ipcMain.handle을 wrapper로 감싸 표준 에러 응답 `{ok: false, error: {code, message}}` 반환
-- daemon 연결 실패는 명시적 에러 코드(`DAEMON_DISCONNECTED`)로 분류
-- renderer에서 공통 에러 훅으로 토스트 표시 (최소 구현)
-**Rationale**: Electron ipcMain에 전역 middleware 네이티브 지원 없음. wrapper가 가장 간결.
-**Impact**: `src/main/ipc/wrapHandler.ts` 신규. 기존 모든 ipcMain.handle 호출을 wrapper로 마이그레이션.
+### [2026-05-09] D1. UX shape — progressive disclosure
+search bar dropdown (default) + auto-expand panel (>10 results). hysteresis는 D8 참조.
 
 ---
 
-### [2026-04-17] D7. Architect Review 반영 수정 (Amendments)
-**Background**: architect-reviewer가 Conditional Pass 판정. 3개 Critical + 몇 개 Important 조건 수용.
+## Architect 리뷰 결과 (Phase 1, 2026-05-09)
 
-**A. D2 수정 (AsyncQueue 적용 범위)**
-- `saveImmediate`는 **동기 시그니처 유지**. daemon의 14개 호출부(shutdown/suspend emergency sync 경로 포함)가 동기 전제이므로 파괴적 변경 금지.
-- AsyncQueue는 `saveDebounced`와 비종료 경로에만 적용.
-- `flushSync()` 메서드 신설: 큐 drain + synchronous write. 프로세스 종료 핸들러에서 호출.
-- coalescing 옵션: 세션 상태는 스냅샷이므로 큐에 쌓인 write는 마지막 것만 유효.
+### P0 — 디자인에 반영 완료
+- F2 RPC-layer scope enforcement → D9로 cross-ws 자체 제거하여 자동 해결.
 
-**B. D3 수정 (Premigrate 스냅샷)**
-- Lazy 체이닝 중간 실패 시 원본 오염 방지를 위해 load 직후 `sessions.v{N}.premigrate.bak` 일회성 스냅샷.
-- 이미 존재하면 skip.
-- 마이그레이션은 메모리에서만 수행, 모든 step 성공 후에만 새 버전 저장.
+### P1 — 디자인에 반영 완료
+- F1 wrapped lines coalescing → D3 (engine spec).
+- F3 cross-ws UI 누출 → D9.
+- F6 MCP result shape → D5.
+- F10 dead-PTY pane → D7 ("live pane = Terminal mounted").
+- F12 ptyId→wsId 역매핑 → D3.
 
-**C. D6 수정 (IPC wrapper 2단계 분리)**
-- 1단계: 공통 try/catch + 구조화 로깅만 전 핸들러에 즉시 적용. 성공 시 raw value, 실패 시 throw는 유지.
-- 2단계: `{ok, data, error}` 정규화는 renderer 측 `useIpc` 어댑터 훅에서 흡수. 기존 60+ 호출부는 점진 마이그레이션.
-- DAEMON_DISCONNECTED 감지: 핸들러가 던진 에러의 `code` 속성을 wrapper가 분류만 담당.
-
-**D. D5 수정 (Rotation 세부)**
-- rename 직후에 rename 체인(`.bak.2→.bak.3`, `.bak.1→.bak.2`, `.bak→.bak.1`). copy 금지.
-- 읽기 경로: primary → .bak → .bak.1 → .bak.2 → .bak.3. 하나라도 valid면 즉시 승격 save.
-
-**E. D4 수정 (격리 경로)**
-- 격리 파일은 `corrupted/` 서브디렉토리로 분리.
-- 로테이터는 파일명 allowlist regex (`^sessions\.json\.bak(\.[123])?$`)로 corrupted 제외.
-- 누적 방지: 시간 30일 경과 + 개수 10개 초과 이중 정책.
-
-**F. D8 신규. 공통 atomic-write 모듈 선행 추출**
-- `src/daemon/util/atomicWrite.ts` (또는 `src/shared/persist/`) 신규.
-- SessionManager(main 측)과 StateWriter(daemon 측)의 중복 atomic-write 코드를 공통화.
-- D3/D4/D5 로직을 한 번만 구현하도록 보장. **구현 순서 단계 1로 확정.**
-
----
-
-### [2026-04-17] D9. 구현 순서 확정
-단계 1. 공통 atomicWrite 모듈 추출 + 회귀 테스트 (D8)
-단계 2. AsyncQueue + flushSync (D2 수정본)
-단계 3. IPC wrapper 1단계 (try/catch + 로깅) (D6 수정본)
-단계 4. .bak rotation (D5 수정본)
-단계 5. 손상 파일 격리 + corrupted/ 서브디렉토리 (D4 수정본)
-단계 6. Lazy 마이그레이션 + premigrate 스냅샷 (D3 수정본)
-
-renderer 어댑터 훅(D6 2단계)은 단계 3 이후 별도 병렬 가능.
-각 단계는 기본 순차. 독립 가능 구간은 Phase 2 DAG에서 식별.
-
----
-
-### [2026-04-17] D10. Plan Review 반영 (파일 충돌 방지 + 스코프 보강)
-**Background**: code-reviewer가 Conditional Pass 판정. 4개 핵심 수정 필요.
-
-**A. T1 분해 → T1a + T1b**
-- T1a: atomicWrite 스캐폴딩 + 인터페이스 freeze (호출부 미수정). Wave 1의 유일한 blocker.
-- T1b: StateWriter/SessionManager 마이그레이션 (T1a 완료 후).
-
-**B. atomicWrite 파일 물리 분리**
-- `src/daemon/util/atomicWrite/core.ts` — 기본 tmp→bak→rename (T1a)
-- `src/daemon/util/atomicWrite/rotation.ts` — .bak 체인 (T5)
-- `src/daemon/util/atomicWrite/migrate.ts` — version load 훅 (T7)
-- `src/daemon/util/atomicWrite/index.ts` — 조합 재export
-- 이로써 Wave 2 worktree 충돌 제거.
-
-**C. T3 분해 → T3a + T3b**
-- T3a: wrapper 모듈 + 대표 핸들러 3개 + 통합 테스트. (Wave 1)
-- T3b: 전면 롤아웃. (Wave 3로 이동)
-
-**D. 통합/호환성/릴리스 태스크 신규**
-- T12: daemon crash-restore 통합 테스트 (Wave 4)
-- T13: migration × rotation × corruption 시나리오 E2E (Wave 4)
-- T14: 기존 배포 데이터 호환성 스냅샷 테스트 (Wave 4)
-- T15: CHANGELOG + 업그레이드/롤백 가이드 (Wave 4, 의존 없음)
-
-**E. T8 프로덕션 영향 축소**
-- 샘플 마이그레이션은 `__tests__/fixtures`에만 둠.
-- 프로덕션 레지스트리는 identity 유지. `CURRENT_VERSION=1`.
-- T11에서만 v1→v2 체이닝 검증.
-
-**F. DAG 수정 (Wave 2 병렬화 개선)**
-- T5, T7 → T1a 의존 (T1b 아님). T1a 완료 즉시 시작 가능.
-- T2 → T1b 의존.
-- T6 → T5, T1a 의존.
-
-**G. Minor 보강**
-- premigrate.bak 수명: rotation 대상 제외 + 수동 정리(로그 경고). 자동 정리는 스코프 외.
-- 로그 포맷: JSON lines, `{ts, level, event, ...payload}`.
-- T2 coalescing 의미론: "같은 key enqueue 시 마지막 값만 실행", FIFO는 key 간 순서 보장 → T9에 명세 테스트.
-- T6 시간 기반 정리: `Date.now()` 대신 `clock: () => number` 주입 → fake clock 테스트.
+### P2 — Follow-up tracking (구현 후 별도 issue)
+- F4 indexing 진화 시 RingBuffer 안 씀 명시 → D3에 명시.
+- F5 SearchAddon decorations on inactive panes (auto-copy debouncer trigger 회피) → 구현 시 inactive pane은 decorate 안 하고 coordinate만 저장. 사용자가 navigate 시점에 decorate.
+- F7 hysteresis → D8 반영.
+- F8 regex error UI → D6 반영.
+- F9 PR #16 metadata 비종속 + resultShapeVersion → D5 반영.
+- F11 buffer scan cap → D3 반영 (20k lines/pane, queueMicrotask yield).

--- a/handoff.md
+++ b/handoff.md
@@ -1,41 +1,36 @@
 # Teammate Handoff
 
 ## Session State (세션 복구용 필수 필드)
-- **current_phase**: [Phase 0/1/2/3/3.5/4/5/R]
-- **completed_tasks**: [완료된 태스크 ID 목록]
-- **blocked_items**: [블로킹 이슈]
-- **next_steps**: [다음에 해야 할 일]
-- **active_worktrees**: [활성 worktree 경로 + 상태]
+- **current_phase**: 0 (초기화 완료, Phase 1 진입 직전)
+- **completed_tasks**: []
+- **blocked_items**: []
+- **next_steps**: Phase 1 — 디자인 정제 (검색 인덱싱 전략, 정규식, scrollback dump 포함 여부, MCP tool 노출, threshold 임계값) + architect-reviewer 검증
+- **active_worktrees**: []
 
 ## Outgoing Teammate Summary
-- **Role**: [what this teammate was doing]
-- **Agent**: [subagent_type used]
-- **Termination reason**: [completed / stuck / error loop / context full / timeout]
+(아직 teammate 없음)
 
 ## What Was Completed
-- [bullet list of done work]
-- Files created/modified: [paths]
+- Phase 0: branch 생성, 기록 파일 초기화
 
 ## What Remains
-- [bullet list of remaining tasks]
-- Expected approach: [brief strategy]
+- Phase 1: 디자인 brainstorming + architect 리뷰
+- Phase 2: 태스크 분해 + DAG + code-reviewer 리뷰
+- Phase 3: 구현 (병렬 worktree)
+- Phase 3.5: 통합 병합
+- Phase 4: 코드 리뷰
+- Phase 5: 마무리 (테스트 + 머지/PR 결정)
 
-## Gotchas & Warnings
-- [things the next teammate should know]
-- [edge cases discovered]
-- [failed approaches — don't repeat these]
+## Gotchas / 컨텍스트
+- 메인 베이스에 PR #19 클립보드 fix 머지됨 (`useTerminal.ts` 수정). 이번 작업은 같은 파일 (search bar) 건드릴 수 있어서 충돌 주의.
+- 현재 PR 상태:
+  - PR #16 (pane metadata) — in review, base `main`
+  - PR #17 (events poll) — in review, base `feature/pane-metadata` (stack)
+- 외부 툴링 RFC (#15, alphabeen) 진행 중 — Cross-pane search MCP tool로 노출 시 그 RFC와 시너지
 
-## Key File Paths
-- [list of files relevant to this work]
-
-## Interface Changes (다른 모듈에 영향)
-- [API 계약 변경, 공유 타입 변경, DB 스키마 변경 등]
-
----
-
-## For Incoming Teammate
-
-Read this handoff, then:
-1. Confirm understanding of remaining tasks
-2. Submit your plan before starting
-3. Report at checkpoints
+## Key Files
+- `src/renderer/hooks/useTerminal.ts` — 기존 SearchAddon 통합 위치
+- `src/renderer/components/Terminal/` — 검색 bar UI 위치
+- `src/main/pipe/handlers/` — 새 RPC handler 위치
+- `src/mcp/index.ts` — MCP tool 노출 위치
+- `src/shared/rpc.ts` — RPC method union 추가

--- a/progress.md
+++ b/progress.md
@@ -8,7 +8,7 @@
 - **Size**: Large (Full Path)
 - **Effort**: 1.5-2일 (code-reviewer 산정)
 - **Teammates**: 7 tasks (병렬 가능 4개 동시 max, opus, worktree)
-- **Done**: 0/7 | In Progress: 0 | Waiting: 7 | Blocked: 0
+- **Done**: 3/7 (T-A `eb0b6fe`, T-B `4c45aca`, integrated `03f47d7`, T-C this commit) | In Progress: 0 | Waiting: 4 | Blocked: 0
 
 ## Keyboard
 
@@ -189,12 +189,12 @@ T-G (tests for T-B/T-C/T-D/T-F): [T-B, T-C, T-D, T-F]
 ## By Module
 
 ### Backend (RPC layer + engine)
-- [ ] T-A types + main handler
-- [ ] T-B search engine util
+- [x] T-A types + main handler (commit eb0b6fe)
+- [x] T-B search engine util (commit 4c45aca)
 - [ ] T-D MCP tool
 
 ### Frontend (UI + handler + state)
-- [ ] T-C renderer handler + searchSlice skeleton
+- [x] T-C renderer handler + searchSlice skeleton (this commit)
 - [ ] T-E search bar + i18n
 - [ ] T-F panel + hysteresis
 

--- a/progress.md
+++ b/progress.md
@@ -1,71 +1,202 @@
-# Progress — Terminal Bugs Fix (4건 통합)
+# Progress — Cross-Pane Search
 
 ## Summary
-- **Phase**: 0 → 3 (구현 시작)
-- **Started**: 2026-05-06
-- **Branch**: `team/2026-05-06/terminal-bugs-fix`
-- **Size**: Medium (Fast Path: Phase 0 → 3 → 5)
-- **Teammates**: 2 (병렬 worktree, opus)
+- **Phase**: 2 (계획 — code-reviewer 재검증 대기)
+- **Started**: 2026-05-09
+- **Branch**: `team/2026-05-09/cross-pane-search`
+- **Base**: `main` (PR #19 클립보드 fix 머지 후 최신)
+- **Size**: Large (Full Path)
+- **Effort**: 1.5-2일 (code-reviewer 산정)
+- **Teammates**: 7 tasks (병렬 가능 4개 동시 max, opus, worktree)
+- **Done**: 0/7 | In Progress: 0 | Waiting: 7 | Blocked: 0
 
-## 4가지 버그 — 전문가 진단 (read-only 완료)
+## Keyboard
 
-| # | 증상 | Root cause | 신뢰도 |
-|---|------|------------|--------|
-| 1 | 큰 출력 시 freeze + CPU/RAM 풀가동 | PTYBridge onData 백프레셔 0 + OscParser O(n²) concat + ActivityMonitor 타이머 폭주 | 9/10 |
-| 2 | Ctrl+V paste 일부 누락 | useTerminal Ctrl+V 핸들러 청킹 부재 → pty.handler 100K silent drop | 9/10 |
-| 3 | Copy 완전 안 됨 | fire-and-forget IPC + Win32 클립보드 lock contention + 무조건 토스트 → silent failure | 9/10 |
-| 4 | 마지막 문단만 복사 | ResizeObserver fit() during drag → xterm onResize의 unconditional clearSelection | 7/10 |
+- **Cross-pane 트리거**: 기존 Ctrl+F bar에 'All Panes' 토글 (single keybind, 단순화)
+- **Ctrl+Shift+F**: v2 cross-workspace 검색용 예약 (v1 미사용)
 
-## 인터페이스 계약 (병렬 안전)
-
-1. `clipboardAPI.writeText(text: string): Promise<void>` — 실패 시 **throw** (validation/size/lock 모두)
-2. `pty.write` 100K 초과 시 main에서 **console.warn** 후 silent drop (backstop 유지)
-3. `Terminal` 옵션에 `windowsPty: { backend: 'conpty', buildNumber: 21376 }` 추가는 renderer 단독
-
-## 작업 그룹 (파일 소유권)
-
-### Teammate A — Main side
-**파일**: `src/main/pty/PTYBridge.ts`, `src/main/pty/OscParser.ts`, `src/main/pty/ActivityMonitor.ts`, `src/main/ipc/handlers/pty.handler.ts`, `src/main/ipc/handlers/clipboard.handler.ts`
-
-**태스크**:
-- A1: PTYBridge onData에 micro-batch 누적기 (~8ms flush)
-- A2: OscParser slice 기반으로 변경 (O(n²) → O(n))
-- A3: ActivityMonitor.feed에 100ms 타임스탬프 가드
-- A4: pty.handler 100K 가드에 console.warn 추가
-- A5: clipboard.handler silent return → typed throw (`CLIPBOARD_TOO_LARGE`, `CLIPBOARD_INVALID_TYPE`)
-- A6: 신규/보강 테스트 (PTYBridge batch, OscParser slice, ActivityMonitor guard, clipboard throw)
-
-### Teammate B — Renderer side
-**파일**: `src/renderer/hooks/useTerminal.ts`, `src/renderer/components/Terminal/Terminal.tsx`, `src/preload/preload.ts`
-
-**태스크**:
-- B1: Terminal 옵션에 `windowsPty` 추가 (xterm 6 reflow 활성화)
-- B2: ResizeObserver 콜백 + font/theme effect에 `hasSelection()` 가드
-- B3: Ctrl+V/Ctrl+Shift+V 핸들러에 4096 청킹 도입 (우클릭 path와 동일 패턴)
-- B4: Ctrl+C/Ctrl+Shift+C/우클릭 copy + handleCopy를 await + try/catch로 변경
-- B5: showCopyToast는 Promise resolve 후에만 실행, 실패 시 showCopyErrorToast
-- B6: clipboardAPI 타입 시그니처를 `Promise<void>` (실패 throw)로 명시
-- B7: 신규/보강 테스트 (paste 청킹, copy 에러 경로, hasSelection 가드)
-
-## DAG (Medium이지만 명확화)
+## DAG
 
 ```
-A (main): []           ← 인터페이스 계약 합의됨, 단독 진행 가능
-B (renderer): []       ← 인터페이스 계약 합의됨, 단독 진행 가능
-머지: [A, B]           ← Phase 3.5에서 통합
-통합 테스트: [머지]    ← Phase 5
+T-A (types + RPC method + minimal main handler): []
+T-B (search engine util — pure function): []
+T-C (renderer handler in useRpcBridge + searchSlice skeleton): [T-A, T-B]
+T-D (MCP tool registration): [T-A]
+T-E (search bar UI extension): [T-C]
+T-F (panel UI + hysteresis state machine): [T-C]   # T-E와 병렬 (다른 파일)
+T-G (tests for T-B/T-C/T-D/T-F): [T-B, T-C, T-D, T-F]
 ```
 
-## 검증
+병렬 라운드:
+- Round 1 (worktree 2): T-A, T-B
+- Round 2 (worktree 2): T-C, T-D
+- Round 3 (worktree 2): T-E, T-F
+- Round 4 (worktree 1): T-G
 
-- 단위 테스트: `npm run test`
-- 타입 체크: `tsc --noEmit` (또는 `npm run lint` 포함)
-- 수동: 큰 출력 reproducer, 200KB Ctrl+V, 멀티문단 드래그-복사
+## Tasks
 
-## Status
+### T-A. Types + RPC method + main handler skeleton
+- **Owner**: backend-developer
+- **Deps**: []
+- **Files**:
+  - `src/shared/rpc.ts` — `'pane.search'` union + array entry
+  - `src/shared/types.ts` — `PaneSearchResult`, `PaneSearchResponse` types (D5 스펙)
+  - `src/main/pipe/handlers/pane.rpc.ts` — `pane.search` handler that forwards to renderer via `sendToRenderer(getWindow, 'pane.search', params)`
+- **Public types** (T-C가 import):
+  ```ts
+  export interface PaneSearchResult {
+    paneId: string; surfaceId: string; ptyId: string;
+    lineIdx: number;            // logical line idx (post wrap-coalesce)
+    text: string;               // matched logical line, 500 chars cap
+    contextBefore: string[];    // 2 lines, each 500 chars cap
+    contextAfter: string[];
+    paneLabel?: string;         // PR #16 metadata if present
+  }
+  export interface PaneSearchResponse {
+    resultShapeVersion: 1;
+    results: PaneSearchResult[];
+    truncated: boolean;
+    totalMatches: number;
+    workspaceId: string;
+  }
+  ```
+- **Acceptance**:
+  - `RpcMethod` union + `ALL_RPC_METHODS` array에 `'pane.search'` 등장
+  - 위 타입 export
+  - main handler가 `query: string` validation (빈 문자열 거부) + optional `regex: boolean` 받아 forward
+  - tsc clean
+- **검증**: `npx tsc --noEmit` + 기존 pane.rpc test 회귀 X
 
-- [x] Phase 0: 크기 판단, 브랜치 생성, progress.md 작성
-- [ ] Phase 3: Teammate A 병렬 (worktree)
-- [ ] Phase 3: Teammate B 병렬 (worktree)
-- [ ] Phase 3.5: 머지 + 통합 테스트
-- [ ] Phase 5: 전체 테스트 + 마무리 옵션 결정
+### T-B. Search engine util (pure function)
+- **Owner**: backend-developer
+- **Deps**: []
+- **Files**:
+  - `src/renderer/utils/searchEngine.ts` (신규) — `searchInBuffer(buffer, query, opts): MatchInBuffer[]`
+- **Internal types** (T-B 소유, T-C가 매핑):
+  ```ts
+  export interface SearchOpts {
+    regex?: boolean;
+    contextLines?: number;       // default 2
+    perBufferLineCap?: number;   // default 20_000
+    remainingBudget: number;     // T-C가 매 pane마다 decrement
+  }
+  export interface MatchInBuffer {
+    lineIdx: number;            // logical line, post-coalesce
+    physicalBaseY: number;      // 원래 buffer baseY+offset (scrollToLine용)
+    text: string;               // 500 chars cap
+    contextBefore: string[];    // 500 chars cap each
+    contextAfter: string[];
+  }
+  ```
+- **Acceptance**:
+  - `BufferLine.isWrapped` 기반 wrap-coalescing → logical line 단위 (N1)
+  - 각 logical line 텍스트 500 chars cap (N1)
+  - regex 모드 — 잘못된 패턴 throw `SyntaxError` (UI에서 catch)
+  - per-buffer cap (default 20k lines) 적용 (D3 F11)
+  - context lines (default 2) — logical line 단위, 500 chars cap each (N1)
+  - `remainingBudget` 도달 시 early return (G2: T-C가 pane 간 분배)
+  - pure 함수 (DOM/electron 의존 X)
+- **검증**: T-G에서 unit tests
+
+### T-C. Renderer handler + searchSlice skeleton
+- **Owner**: frontend-developer
+- **Deps**: [T-A, T-B]
+- **Files**:
+  - `src/renderer/hooks/useRpcBridge.ts` — `'pane.search'` method case
+  - `src/renderer/stores/slices/searchSlice.ts` (신규 skeleton — T-F가 hysteresis 채움)
+- **searchSlice skeleton** (T-C 책임):
+  ```ts
+  interface SearchSlice {
+    query: string;
+    results: PaneSearchResult[];
+    truncated: boolean;
+    totalMatches: number;
+    panelOpen: boolean;          // T-F가 hysteresis 로직 추가
+    panelStickyClosed: boolean;  // T-F가 sticky 로직 추가
+    runSearch: (query: string, regex: boolean) => Promise<void>;
+    clearSearch: () => void;
+  }
+  ```
+- **Acceptance**:
+  - `terminalRegistry` 사용 (D7)
+  - mutation safety: keys snapshot + per-pane try/catch (N2)
+  - ptyId→workspaceId 역매핑 (`store.workspaces` walk, F12)
+  - paneLabel: `paneLeaf.metadata?.label ?? undefined` — undefined OK, no throw (N4, G3)
+  - `searchInBuffer` 호출 — 매 pane마다 `remainingBudget` 전달, 결과 받아 누적, 200 도달 시 break (G2 breadth-first)
+  - 응답: T-A의 `PaneSearchResponse` 그대로
+- **검증**: T-G에 RPC dispatch 테스트 (mock terminalRegistry)
+
+### T-D. MCP tool — wmux_search_panes
+- **Owner**: mcp-developer
+- **Deps**: [T-A]
+- **Files**:
+  - `src/mcp/index.ts` — `server.tool('wmux_search_panes', ..., async ({query, regex}) => {...})`
+- **Acceptance**:
+  - tool description 명시 (use case: AI 자율 추론)
+  - workspaceId은 `requireWorkspaceId()` 자동 (cross-ws 차단)
+  - params: `query` required, `regex` optional. **scope 없음** (D9)
+  - 응답을 callRpc 통해 그대로 반환
+- **검증**: tsc + T-G에서 mock RPC test
+
+### T-E. Search bar UI — All Panes 토글 + dropdown
+- **Owner**: frontend-developer
+- **Deps**: [T-C]
+- **Files**:
+  - `src/renderer/components/Terminal/SearchBar.tsx` — All Panes 토글, regex 토글, 결과 dropdown
+  - `src/renderer/i18n/locales/{en,ko,ja,zh}.ts` — 새 i18n 키 (M1):
+    - `search.allPanes`, `search.regexMode`, `search.noResults`, `search.showInPanel`, `search.matchedLine` 등
+- **Acceptance**:
+  - 기존 단일 pane 검색 회귀 X
+  - All Panes 토글 ON 시 `searchSlice.runSearch(query, regex)` 호출
+  - 잘못된 regex → red border + tooltip (D6, F8)
+  - 결과 ≤10 → inline dropdown
+  - 결과 클릭 → 해당 pane focus + scrollToLine(physicalBaseY)
+  - i18n 키 4 locale 모두 채움
+- **검증**: 기존 SearchBar 테스트 회귀 + 신규 토글 테스트 (T-G)
+
+### T-F. Panel UI + hysteresis state machine
+- **Owner**: frontend-developer
+- **Deps**: [T-C]   # 다른 파일이라 T-E와 병렬
+- **Files**:
+  - `src/renderer/components/Search/SearchResultsPanel.tsx` (신규)
+  - `src/renderer/stores/slices/searchSlice.ts` (확장 — T-C가 만든 skeleton에 hysteresis 추가)
+- **searchSlice 추가 로직**:
+  - `panelOpen` derive: `results.length > 10 && !panelStickyClosed`
+  - 사용자가 panel 닫으면 `panelStickyClosed = true`
+  - **session reset** (sticky 해제): `query === ''` OR `Math.abs(newQuery.length - prevQuery.length) > 2` OR `!newQuery.startsWith(prevQuery) && !prevQuery.startsWith(newQuery)` (G4)
+- **Acceptance**:
+  - panel 클릭 → 해당 pane focus + scrollToLine
+  - paneLabel 표시 (있을 때) — "Backend (running): line 42 → JWT error"
+  - session reset 메트릭 위 그대로
+  - i18n 키 사용 (T-E와 공유)
+- **검증**: T-G에 hysteresis state machine 테스트
+
+### T-G. Tests
+- **Owner**: test-automator
+- **Deps**: [T-B, T-C, T-D, T-F]
+- **Files**:
+  - `src/renderer/utils/__tests__/searchEngine.test.ts` (신규)
+  - `src/renderer/utils/__tests__/fixtures/wrappedBuffer.ts` (신규 — wrap-coalescing fixture, M3)
+  - `src/main/pipe/handlers/__tests__/pane.rpc.test.ts` 확장 — `pane.search` dispatch
+  - `src/renderer/stores/slices/__tests__/searchSlice.test.ts` (신규) — hysteresis state machine
+  - `src/renderer/hooks/__tests__/useRpcBridge.search.test.ts` (옵션) — registry walk + budget decrement
+- **Acceptance**:
+  - searchEngine: wrap-coalescing (3 wrapped rows → 1 logical), regex match/error, 200 cap, 20k buffer cap, empty buffer, context lines, budget exhaustion
+  - pane.rpc: query validation, regex param forwarding, error handling
+  - searchSlice: open >10 트리거, close <=5 트리거, sticky bit, session reset (3가지 reset 트리거 모두)
+- **검증**: vitest 그린, 회귀 0건
+
+## By Module
+
+### Backend (RPC layer + engine)
+- [ ] T-A types + main handler
+- [ ] T-B search engine util
+- [ ] T-D MCP tool
+
+### Frontend (UI + handler + state)
+- [ ] T-C renderer handler + searchSlice skeleton
+- [ ] T-E search bar + i18n
+- [ ] T-F panel + hysteresis
+
+### Tests
+- [ ] T-G unit + integration + fixture

--- a/src/main/pipe/handlers/__tests__/pane.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/pane.rpc.test.ts
@@ -150,6 +150,67 @@ describe('pane.rpc — search', () => {
     expect(sendToRendererMock).not.toHaveBeenCalled();
   });
 
+  // C1 — workspaceId forwarding. The main handler must thread the caller's
+  // workspaceId through so the renderer scopes the search to that workspace
+  // (not whichever the user happens to be viewing).
+  it('forwards workspaceId when caller provides it (C1)', async () => {
+    const router = register();
+    const response = await router.dispatch({
+      id: '10',
+      method: 'pane.search',
+      params: { query: 'foo', workspaceId: 'ws-caller' },
+    });
+
+    expect(response.ok).toBe(true);
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      'pane.search',
+      { query: 'foo', workspaceId: 'ws-caller' },
+    );
+  });
+
+  it('forwards workspaceId together with regex when both are provided (C1)', async () => {
+    const router = register();
+    await router.dispatch({
+      id: '11',
+      method: 'pane.search',
+      params: { query: 'foo', regex: true, workspaceId: 'ws-caller' },
+    });
+
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      'pane.search',
+      { query: 'foo', regex: true, workspaceId: 'ws-caller' },
+    );
+  });
+
+  it('omits workspaceId from forwarded payload when caller did not provide it (C1)', async () => {
+    const router = register();
+    await router.dispatch({
+      id: '12',
+      method: 'pane.search',
+      params: { query: 'foo' },
+    });
+
+    const forwardedPayload = sendToRendererMock.mock.calls[0][2] as Record<string, unknown>;
+    expect('workspaceId' in forwardedPayload).toBe(false);
+  });
+
+  it('rejects a non-string workspaceId (C1)', async () => {
+    const router = register();
+    const response = await router.dispatch({
+      id: '13',
+      method: 'pane.search',
+      params: { query: 'foo', workspaceId: 42 as unknown as string },
+    });
+
+    expect(response.ok).toBe(false);
+    if (!response.ok) {
+      expect(response.error).toMatch(/string/);
+    }
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+  });
+
   it('returns the renderer response payload to the caller', async () => {
     const router = register();
     const fakeResponse = {
@@ -160,6 +221,7 @@ describe('pane.rpc — search', () => {
           surfaceId: 's1',
           ptyId: 'pty1',
           lineIdx: 5,
+          physicalBaseY: 5,
           text: 'matched line',
           contextBefore: [],
           contextAfter: [],

--- a/src/main/pipe/handlers/__tests__/pane.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/pane.rpc.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserWindow } from 'electron';
+import { RpcRouter } from '../../RpcRouter';
+import { registerPaneRpc } from '../pane.rpc';
+
+const { sendToRendererMock } = vi.hoisted(() => ({
+  sendToRendererMock: vi.fn(),
+}));
+
+vi.mock('../_bridge', () => ({
+  sendToRenderer: sendToRendererMock,
+}));
+
+function register(): RpcRouter {
+  const router = new RpcRouter();
+  registerPaneRpc(router, (() => null) as () => BrowserWindow | null);
+  return router;
+}
+
+describe('pane.rpc — search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sendToRendererMock.mockResolvedValue({
+      resultShapeVersion: 1,
+      results: [],
+      truncated: false,
+      totalMatches: 0,
+      workspaceId: 'ws-1',
+    });
+  });
+
+  it('forwards a valid query to the renderer', async () => {
+    const router = register();
+    const response = await router.dispatch({
+      id: '1',
+      method: 'pane.search',
+      params: { query: 'foo' },
+    });
+
+    expect(response.ok).toBe(true);
+    expect(sendToRendererMock).toHaveBeenCalledTimes(1);
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      'pane.search',
+      { query: 'foo' },
+    );
+  });
+
+  it('forwards the regex flag when provided as a boolean', async () => {
+    const router = register();
+    const response = await router.dispatch({
+      id: '2',
+      method: 'pane.search',
+      params: { query: 'foo', regex: true },
+    });
+
+    expect(response.ok).toBe(true);
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      'pane.search',
+      { query: 'foo', regex: true },
+    );
+  });
+
+  it('omits regex from forwarded payload when caller did not provide it', async () => {
+    const router = register();
+    await router.dispatch({
+      id: '3',
+      method: 'pane.search',
+      params: { query: 'foo' },
+    });
+
+    const forwardedPayload = sendToRendererMock.mock.calls[0][2] as Record<string, unknown>;
+    expect(forwardedPayload).toEqual({ query: 'foo' });
+    expect('regex' in forwardedPayload).toBe(false);
+  });
+
+  it('forwards regex: false explicitly when caller provided it', async () => {
+    const router = register();
+    await router.dispatch({
+      id: '4',
+      method: 'pane.search',
+      params: { query: 'foo', regex: false },
+    });
+
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      'pane.search',
+      { query: 'foo', regex: false },
+    );
+  });
+
+  it('rejects an empty query', async () => {
+    const router = register();
+    const response = await router.dispatch({
+      id: '5',
+      method: 'pane.search',
+      params: { query: '' },
+    });
+
+    expect(response.ok).toBe(false);
+    if (!response.ok) {
+      expect(response.error).toMatch(/non-empty/);
+    }
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing query (params has no `query` key)', async () => {
+    const router = register();
+    const response = await router.dispatch({
+      id: '6',
+      method: 'pane.search',
+      params: {},
+    });
+
+    expect(response.ok).toBe(false);
+    if (!response.ok) {
+      expect(response.error).toMatch(/string/);
+    }
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-string query', async () => {
+    const router = register();
+    const response = await router.dispatch({
+      id: '7',
+      method: 'pane.search',
+      params: { query: 42 as unknown as string },
+    });
+
+    expect(response.ok).toBe(false);
+    if (!response.ok) {
+      expect(response.error).toMatch(/string/);
+    }
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-boolean regex flag (e.g. string "true")', async () => {
+    const router = register();
+    const response = await router.dispatch({
+      id: '8',
+      method: 'pane.search',
+      params: { query: 'x', regex: 'true' as unknown as boolean },
+    });
+
+    expect(response.ok).toBe(false);
+    if (!response.ok) {
+      expect(response.error).toMatch(/boolean/);
+    }
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the renderer response payload to the caller', async () => {
+    const router = register();
+    const fakeResponse = {
+      resultShapeVersion: 1,
+      results: [
+        {
+          paneId: 'p1',
+          surfaceId: 's1',
+          ptyId: 'pty1',
+          lineIdx: 5,
+          text: 'matched line',
+          contextBefore: [],
+          contextAfter: [],
+        },
+      ],
+      truncated: false,
+      totalMatches: 1,
+      workspaceId: 'ws-1',
+    };
+    sendToRendererMock.mockResolvedValueOnce(fakeResponse);
+
+    const response = await router.dispatch({
+      id: '9',
+      method: 'pane.search',
+      params: { query: 'matched' },
+    });
+
+    expect(response.ok).toBe(true);
+    if (response.ok) {
+      expect(response.result).toEqual(fakeResponse);
+    }
+  });
+});

--- a/src/main/pipe/handlers/pane.rpc.ts
+++ b/src/main/pipe/handlers/pane.rpc.ts
@@ -38,12 +38,14 @@ export function registerPaneRpc(router: RpcRouter, getWindow: GetWindow): void {
   });
 
   /**
-   * pane.search — cross-pane search across the current workspace's live panes
-   * params: { query: string, regex?: boolean }
+   * pane.search — cross-pane search across a workspace's live panes
+   * params: { query: string, regex?: boolean, workspaceId?: string }
    *
-   * Validation only happens here; workspace scope is enforced in the renderer
-   * (T-C) since `terminalRegistry` only contains currently-rendered terminals
-   * scoped to workspaces. Cross-workspace search is deferred to v2 (D9).
+   * The `workspaceId` (when present) is forwarded so the renderer handler
+   * (C1 fix) can scope the search to the CALLING workspace rather than
+   * whichever workspace the user happens to be viewing in the UI. Internal
+   * renderer callers omit it and the handler falls back to the active
+   * workspace. Cross-workspace search is deferred to v2 (D9).
    */
   router.register('pane.search', (params) => {
     if (typeof params['query'] !== 'string' || params['query'].length === 0) {
@@ -53,9 +55,16 @@ export function registerPaneRpc(router: RpcRouter, getWindow: GetWindow): void {
     if (regex !== undefined && typeof regex !== 'boolean') {
       return Promise.reject(new Error('pane.search: "regex" must be a boolean if provided'));
     }
+    const workspaceId = params['workspaceId'];
+    if (workspaceId !== undefined && typeof workspaceId !== 'string') {
+      return Promise.reject(
+        new Error('pane.search: "workspaceId" must be a string if provided'),
+      );
+    }
     return sendToRenderer(getWindow, 'pane.search', {
       query: params['query'],
       ...(regex !== undefined && { regex }),
+      ...(workspaceId !== undefined && { workspaceId }),
     });
   });
 }

--- a/src/main/pipe/handlers/pane.rpc.ts
+++ b/src/main/pipe/handlers/pane.rpc.ts
@@ -36,4 +36,26 @@ export function registerPaneRpc(router: RpcRouter, getWindow: GetWindow): void {
     }
     return sendToRenderer(getWindow, 'pane.split', { direction });
   });
+
+  /**
+   * pane.search — cross-pane search across the current workspace's live panes
+   * params: { query: string, regex?: boolean }
+   *
+   * Validation only happens here; workspace scope is enforced in the renderer
+   * (T-C) since `terminalRegistry` only contains currently-rendered terminals
+   * scoped to workspaces. Cross-workspace search is deferred to v2 (D9).
+   */
+  router.register('pane.search', (params) => {
+    if (typeof params['query'] !== 'string' || params['query'].length === 0) {
+      return Promise.reject(new Error('pane.search: "query" must be a non-empty string'));
+    }
+    const regex = params['regex'];
+    if (regex !== undefined && typeof regex !== 'boolean') {
+      return Promise.reject(new Error('pane.search: "regex" must be a boolean if provided'));
+    }
+    return sendToRenderer(getWindow, 'pane.search', {
+      query: params['query'],
+      ...(regex !== undefined && { regex }),
+    });
+  });
 }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -292,10 +292,10 @@ server.tool(
 
 server.tool(
   'wmux_search_panes',
-  'Search across all live terminal panes in the calling workspace for a query string. Returns matches with paneId + matched line text + 2 lines of surrounding context, plus an optional pane label when one has been set. Use this when you want to autonomously locate which pane has the JWT error, the failing test, the build warning, the dev-server crash, etc. — instead of polling each pane individually with terminal_read. Scope is the caller\'s own workspace only (cross-workspace search is not exposed in v1). Searches live panes only — i.e. terminal panes currently mounted in the UI; dead-session scrollback dumps are out of scope for v1. Returns up to 200 matches; truncated=true indicates more were found. For substring search pass query alone; for regex set regex=true (invalid regex returns an error).',
+  'Search across all live terminal panes in the caller\'s workspace. Returns up to 200 matches with paneId + matched line + 2-line context (truncated=true means more were found). Use to find which pane has the JWT error, failing test, or build warning instead of polling each pane individually. Live panes only (v1); regex uses JS RegExp with default flags (case-sensitive, no inline `(?i)` — use `[Ee]rror` for case-insensitive).',
   {
     query: z.string().min(1).describe('The text to search for. Required, non-empty. Treated as a literal substring unless regex=true.'),
-    regex: z.boolean().optional().describe('If true, treat query as a JavaScript regex pattern (e.g. "ERROR|WARN", "\\\\bTODO\\\\b"). Invalid pattern returns an error. Default false (substring match).'),
+    regex: z.boolean().optional().describe('If true, treat query as a JavaScript regex pattern (e.g. "ERROR|WARN", "\\\\bTODO\\\\b"). Default flags only — case-sensitive, no inline `(?i)`. Invalid pattern returns an error. Default false.'),
   },
   async ({ query, regex }) => {
     const workspaceId = await requireWorkspaceId();

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -290,6 +290,21 @@ server.tool(
   async ({ workspaceId }) => callRpc('pane.list', workspaceId ? { workspaceId } : {}),
 );
 
+server.tool(
+  'wmux_search_panes',
+  'Search across all live terminal panes in the calling workspace for a query string. Returns matches with paneId + matched line text + 2 lines of surrounding context, plus an optional pane label when one has been set. Use this when you want to autonomously locate which pane has the JWT error, the failing test, the build warning, the dev-server crash, etc. — instead of polling each pane individually with terminal_read. Scope is the caller\'s own workspace only (cross-workspace search is not exposed in v1). Searches live panes only — i.e. terminal panes currently mounted in the UI; dead-session scrollback dumps are out of scope for v1. Returns up to 200 matches; truncated=true indicates more were found. For substring search pass query alone; for regex set regex=true (invalid regex returns an error).',
+  {
+    query: z.string().min(1).describe('The text to search for. Required, non-empty. Treated as a literal substring unless regex=true.'),
+    regex: z.boolean().optional().describe('If true, treat query as a JavaScript regex pattern (e.g. "ERROR|WARN", "\\\\bTODO\\\\b"). Invalid pattern returns an error. Default false (substring match).'),
+  },
+  async ({ query, regex }) => {
+    const workspaceId = await requireWorkspaceId();
+    const params: Record<string, unknown> = { workspaceId, query };
+    if (regex !== undefined) params.regex = regex;
+    return callRpc('pane.search', params);
+  },
+);
+
 // === A2A (Agent-to-Agent) tools ===
 
 // 1. a2a_whoami — Identify this workspace

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -178,6 +178,9 @@ export default function AppLayout() {
   const activeWorkspace = workspaces.find((w) => w.id === activeWorkspaceId);
 
   const prefixMode = useStore((s) => s.prefixMode);
+  // Gate the cross-pane SearchResultsPanel mount at the layout level so its
+  // 6-field zustand subscription doesn't run when the panel is closed (I3).
+  const searchPanelOpen = useStore((s) => s.searchPanelOpen);
   const onboardingActive = useStore((s) => s.onboardingActive);
   const onboardingCompleted = useStore((s) => s.onboardingCompleted);
   const startOnboarding = useStore((s) => s.startOnboarding);
@@ -597,11 +600,14 @@ export default function AppLayout() {
       )}
       <NotificationPanel />
       <MessageFeedPanel />
-      {/* Cross-pane search results panel (T-F). Self-gates on
-          searchPanelOpen — no cost when closed. */}
-      <ErrorBoundary name="SearchResultsPanel">
-        <SearchResultsPanel />
-      </ErrorBoundary>
+      {/* Cross-pane search results panel (T-F). Mount-gated on
+          searchPanelOpen at this level (I3) so the panel's 6-field zustand
+          subscriptions don't run when closed. */}
+      {searchPanelOpen && (
+        <ErrorBoundary name="SearchResultsPanel">
+          <SearchResultsPanel />
+        </ErrorBoundary>
+      )}
       <CommandPalette />
       <SettingsPanel />
       <ApprovalDialog />

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -18,6 +18,7 @@ import FirstRunWizard from '../FirstRunWizard';
 import KeyboardCheatSheet from '../KeyboardCheatSheet';
 import ToastContainer from '../Toast/ToastContainer';
 import FloatingPane from '../Terminal/FloatingPane';
+import SearchResultsPanel from '../Search/SearchResultsPanel';
 import { ErrorBoundary } from '../ErrorBoundary';
 import { useKeyboard } from '../../hooks/useKeyboard';
 import { useNotificationListener } from '../../hooks/useNotificationListener';
@@ -596,6 +597,11 @@ export default function AppLayout() {
       )}
       <NotificationPanel />
       <MessageFeedPanel />
+      {/* Cross-pane search results panel (T-F). Self-gates on
+          searchPanelOpen — no cost when closed. */}
+      <ErrorBoundary name="SearchResultsPanel">
+        <SearchResultsPanel />
+      </ErrorBoundary>
       <CommandPalette />
       <SettingsPanel />
       <ApprovalDialog />

--- a/src/renderer/components/Search/SearchResultsPanel.tsx
+++ b/src/renderer/components/Search/SearchResultsPanel.tsx
@@ -1,0 +1,178 @@
+import { useMemo } from 'react';
+import { useStore } from '../../stores';
+import { useT } from '../../hooks/useT';
+import { terminalRegistry } from '../../hooks/useTerminal';
+import type { PaneSearchResult } from '../../../shared/types';
+
+/**
+ * Cross-pane search results panel (T-F, see decisions D8).
+ *
+ * Mounts at the workspace layout level and is conditionally rendered when
+ * `searchPanelOpen === true`. The hysteresis machine that flips that flag
+ * lives in `searchSlice.runSearch` — this component is a pure consumer.
+ *
+ * Layout: docked along the bottom of the viewport (16rem tall). The right
+ * side is reserved for `NotificationPanel` (also `fixed right-0`), so a
+ * bottom panel keeps the two from overlapping. The active terminal area
+ * naturally reflows above the panel because we use `fixed bottom-0` —
+ * future iterations may switch to a sibling flex-row in AppLayout if we
+ * want true layout reflow.
+ *
+ * NOTE on scroll-to-line precision: PaneSearchResult only exposes the
+ * post-wrap-coalescing `lineIdx` (logical line). The original physical
+ * row (`physicalBaseY` from the engine's MatchInBuffer) is intentionally
+ * not part of the public PaneSearchResult shape — that contract was
+ * frozen by T-A. We therefore use `lineIdx` as a best-effort scroll
+ * target. The discrepancy only matters when a logical line spans many
+ * wrapped rows and the user expects an exact landing row.
+ *
+ * TODO(v2): thread `physicalBaseY` through PaneSearchResult as a separate
+ * optional field (NOT replacing lineIdx — clients downstream of T-A may
+ * already depend on lineIdx semantics) so click-to-scroll is exact.
+ */
+export default function SearchResultsPanel() {
+  const t = useT();
+  const open = useStore((s) => s.searchPanelOpen);
+  const query = useStore((s) => s.searchQuery);
+  const results = useStore((s) => s.searchResults);
+  const truncated = useStore((s) => s.searchTruncated);
+  const totalMatches = useStore((s) => s.searchTotalMatches);
+  const closeSearchPanel = useStore((s) => s.closeSearchPanel);
+  const setActivePane = useStore((s) => s.setActivePane);
+
+  // Stable, sorted view: group by paneLabel/paneId so users can scan a
+  // pane's hits together. We don't mutate the slice here.
+  const orderedResults = useMemo(() => {
+    return [...results].sort((a, b) => {
+      const ka = a.paneLabel ?? a.paneId;
+      const kb = b.paneLabel ?? b.paneId;
+      if (ka !== kb) return ka.localeCompare(kb);
+      return a.lineIdx - b.lineIdx;
+    });
+  }, [results]);
+
+  if (!open) return null;
+
+  const onResultClick = (r: PaneSearchResult) => {
+    setActivePane(r.paneId);
+    // Best-effort scroll-to-line — see file header for the
+    // physicalBaseY-vs-lineIdx caveat.
+    const term = terminalRegistry.get(r.ptyId);
+    if (term) {
+      try {
+        term.scrollToLine(r.lineIdx);
+      } catch {
+        // xterm.scrollToLine may throw if the line index is out of range
+        // (e.g. buffer rotated since the search ran). Swallow — the pane
+        // is at least focused and the user can re-search.
+      }
+    }
+  };
+
+  // i18n keys T-E will provide. The i18n `t()` helper falls back to the
+  // raw key string when a translation is missing, so missing keys render
+  // as e.g. "search.noResults" until T-E lands — no crash.
+  const matchedLineLabel = (lineIdx: number) =>
+    t('search.matchedLine', { line: lineIdx });
+
+  return (
+    <div
+      className="fixed bottom-0 left-0 right-0 z-40 flex flex-col shadow-2xl"
+      style={{
+        height: '16rem',
+        backgroundColor: 'var(--bg-mantle)',
+        borderTop: '1px solid var(--bg-surface)',
+      }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {/* Header */}
+      <div
+        className="flex items-center justify-between px-4 py-2 shrink-0"
+        style={{ borderBottom: '1px solid var(--bg-surface)' }}
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-sm font-bold text-[var(--text-main)]">
+            Search Results
+          </span>
+          <span
+            className="text-xs truncate"
+            style={{ color: 'var(--text-sub)', maxWidth: '32rem' }}
+            title={query}
+          >
+            &quot;{query}&quot;
+          </span>
+          <span
+            className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full shrink-0"
+            style={{
+              backgroundColor: 'var(--accent-blue)',
+              color: 'var(--bg-base)',
+            }}
+          >
+            {truncated ? `${totalMatches}+ matches` : `${totalMatches} matches`}
+          </span>
+        </div>
+        <button
+          onClick={closeSearchPanel}
+          title={t('search.closeTooltip')}
+          className="flex items-center justify-center w-6 h-6 rounded transition-colors hover:bg-[var(--bg-overlay)]"
+          style={{ color: 'var(--text-sub2)' }}
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path
+              d="M2 2l8 8M10 2l-8 8"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {orderedResults.length === 0 ? (
+          <div
+            className="flex items-center justify-center h-full text-xs"
+            style={{ color: 'var(--text-sub2)' }}
+          >
+            {t('search.noResults')}
+          </div>
+        ) : (
+          <ul className="divide-y" style={{ borderColor: 'var(--bg-surface)' }}>
+            {orderedResults.map((r, idx) => {
+              const label = r.paneLabel ?? '(unlabeled)';
+              return (
+                <li
+                  key={`${r.paneId}-${r.lineIdx}-${idx}`}
+                  onClick={() => onResultClick(r)}
+                  className="flex items-baseline gap-2 px-4 py-1.5 cursor-pointer text-xs hover:bg-[var(--bg-overlay)]"
+                  style={{ color: 'var(--text-main)' }}
+                >
+                  <span
+                    className="shrink-0 font-mono font-semibold"
+                    style={{ color: 'var(--accent-blue)' }}
+                  >
+                    [{label}]
+                  </span>
+                  <span
+                    className="shrink-0 font-mono"
+                    style={{ color: 'var(--text-sub)' }}
+                  >
+                    · {matchedLineLabel(r.lineIdx)} ·
+                  </span>
+                  <span
+                    className="font-mono truncate"
+                    title={r.text}
+                    style={{ color: 'var(--text-main)' }}
+                  >
+                    {r.text}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/Search/SearchResultsPanel.tsx
+++ b/src/renderer/components/Search/SearchResultsPanel.tsx
@@ -7,9 +7,10 @@ import type { PaneSearchResult } from '../../../shared/types';
 /**
  * Cross-pane search results panel (T-F, see decisions D8).
  *
- * Mounts at the workspace layout level and is conditionally rendered when
- * `searchPanelOpen === true`. The hysteresis machine that flips that flag
- * lives in `searchSlice.runSearch` — this component is a pure consumer.
+ * Mount-gated by AppLayout on `searchPanelOpen` (I3) — when closed, this
+ * component is unmounted and its zustand subscriptions don't run. The
+ * hysteresis machine that flips `searchPanelOpen` lives in
+ * `searchSlice.runSearch`; this component is a pure consumer.
  *
  * Layout: docked along the bottom of the viewport (16rem tall). The right
  * side is reserved for `NotificationPanel` (also `fixed right-0`), so a
@@ -18,21 +19,14 @@ import type { PaneSearchResult } from '../../../shared/types';
  * future iterations may switch to a sibling flex-row in AppLayout if we
  * want true layout reflow.
  *
- * NOTE on scroll-to-line precision: PaneSearchResult only exposes the
- * post-wrap-coalescing `lineIdx` (logical line). The original physical
- * row (`physicalBaseY` from the engine's MatchInBuffer) is intentionally
- * not part of the public PaneSearchResult shape — that contract was
- * frozen by T-A. We therefore use `lineIdx` as a best-effort scroll
- * target. The discrepancy only matters when a logical line spans many
- * wrapped rows and the user expects an exact landing row.
- *
- * TODO(v2): thread `physicalBaseY` through PaneSearchResult as a separate
- * optional field (NOT replacing lineIdx — clients downstream of T-A may
- * already depend on lineIdx semantics) so click-to-scroll is exact.
+ * Scroll precision: result clicks call `xterm.scrollToLine(physicalBaseY)`
+ * (I6) — the physical buffer row of the first wrapped row composing the
+ * matched logical line. This lands exactly on the start of the matched
+ * line even when wrap-coalescing combined multiple physical rows into one
+ * logical line.
  */
 export default function SearchResultsPanel() {
   const t = useT();
-  const open = useStore((s) => s.searchPanelOpen);
   const query = useStore((s) => s.searchQuery);
   const results = useStore((s) => s.searchResults);
   const truncated = useStore((s) => s.searchTruncated);
@@ -51,16 +45,18 @@ export default function SearchResultsPanel() {
     });
   }, [results]);
 
-  if (!open) return null;
+  // Note: open-gating is done at the AppLayout mount boundary (I3). No
+  // local `if (!open) return null;` — by the time this component renders
+  // the panel is open by construction.
 
   const onResultClick = (r: PaneSearchResult) => {
     setActivePane(r.paneId);
-    // Best-effort scroll-to-line — see file header for the
-    // physicalBaseY-vs-lineIdx caveat.
+    // Use physicalBaseY (I6) — xterm's scrollToLine expects a physical row
+    // index, not a logical (post-wrap-coalesce) line index.
     const term = terminalRegistry.get(r.ptyId);
     if (term) {
       try {
-        term.scrollToLine(r.lineIdx);
+        term.scrollToLine(r.physicalBaseY);
       } catch {
         // xterm.scrollToLine may throw if the line index is out of range
         // (e.g. buffer rotated since the search ran). Swallow — the pane
@@ -92,7 +88,7 @@ export default function SearchResultsPanel() {
       >
         <div className="flex items-center gap-2 min-w-0">
           <span className="text-sm font-bold text-[var(--text-main)]">
-            Search Results
+            {t('search.panelTitle')}
           </span>
           <span
             className="text-xs truncate"
@@ -108,7 +104,9 @@ export default function SearchResultsPanel() {
               color: 'var(--bg-base)',
             }}
           >
-            {truncated ? `${totalMatches}+ matches` : `${totalMatches} matches`}
+            {truncated
+              ? t('search.matchesCountTruncated')
+              : t('search.matchesCount', { count: totalMatches })}
           </span>
         </div>
         <button
@@ -140,7 +138,7 @@ export default function SearchResultsPanel() {
         ) : (
           <ul className="divide-y" style={{ borderColor: 'var(--bg-surface)' }}>
             {orderedResults.map((r, idx) => {
-              const label = r.paneLabel ?? '(unlabeled)';
+              const label = r.paneLabel ?? t('search.unlabeled');
               return (
                 <li
                   key={`${r.paneId}-${r.lineIdx}-${idx}`}

--- a/src/renderer/components/Terminal/SearchBar.tsx
+++ b/src/renderer/components/Terminal/SearchBar.tsx
@@ -71,16 +71,11 @@ export default function SearchBar({ onFindNext, onFindPrevious, onClose }: Searc
     return () => window.removeEventListener('keydown', handler);
   }, [onClose]);
 
-  // When the bar unmounts (close) or the user toggles back to single-pane
-  // mode, clear any leftover cross-pane state so a stale dropdown doesn't
-  // appear next time the bar opens or T-F's panel doesn't resurrect.
-  useEffect(() => {
-    return () => {
-      // Defensive: only clear cross-pane state we authored. The single-pane
-      // SearchAddon `clearSearch` is wired via Terminal.tsx → useTerminal.
-      clearCrossPaneSearch();
-    };
-  }, [clearCrossPaneSearch]);
+  // I5: do NOT clear cross-pane state on unmount. The results panel (T-F)
+  // is meant to be independently dismissable per D8 — wiping panel state
+  // every time the user toggles Ctrl+F closed would defeat the sticky
+  // model. Cross-pane state is cleared explicitly when the user leaves
+  // All-Panes mode via `toggleAllPanes` (below).
 
   const runCrossPaneSearch = useCallback(
     (q: string) => {
@@ -190,12 +185,15 @@ export default function SearchBar({ onFindNext, onFindPrevious, onClose }: Searc
       }
       const term = terminalRegistry.get(r.ptyId);
       if (term) {
-        // NOTE: we use lineIdx (logical line, post-wrap-coalesce) for the
-        // scroll target. The handler does not currently surface
-        // physicalBaseY in the public PaneSearchResult shape — see
-        // src/shared/types.ts. xterm's scrollToLine accepts any in-range
-        // value and clamps internally, so this is best-effort.
-        term.scrollToLine(r.lineIdx);
+        // I6: use physicalBaseY (xterm expects a physical row index, not a
+        // post-wrap-coalesce logical line index). M3: wrap in try/catch —
+        // scrollToLine can throw if the buffer has rotated since the search
+        // executed.
+        try {
+          term.scrollToLine(r.physicalBaseY);
+        } catch {
+          // pane is at least focused; user can re-search to refresh.
+        }
       }
     },
     [],
@@ -372,7 +370,7 @@ export default function SearchBar({ onFindNext, onFindPrevious, onClose }: Searc
                 className="shrink-0 font-medium"
                 style={{ color: 'var(--text-sub2)', minWidth: '40px' }}
               >
-                {r.paneLabel ?? '(unlabeled)'}
+                {r.paneLabel ?? t('search.unlabeled')}
               </span>
               <span className="shrink-0" style={{ color: 'var(--text-subtle)' }}>
                 {t('search.matchedLine', { line: r.lineIdx + 1 })}

--- a/src/renderer/components/Terminal/SearchBar.tsx
+++ b/src/renderer/components/Terminal/SearchBar.tsx
@@ -1,5 +1,8 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { useT } from '../../hooks/useT';
+import { useStore } from '../../stores';
+import { terminalRegistry } from '../../hooks/useTerminal';
+import type { PaneSearchResult } from '../../../shared/types';
 
 const MAX_HISTORY = 50;
 const searchHistory: string[] = [];
@@ -10,13 +13,48 @@ interface SearchBarProps {
   onClose: () => void;
 }
 
+/**
+ * Truncates result text for inline dropdown display so a single very long
+ * matched line cannot blow out the dropdown width or wrap into many rows.
+ */
+function truncateMatch(text: string, max = 80): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1) + '…';
+}
+
 export default function SearchBar({ onFindNext, onFindPrevious, onClose }: SearchBarProps) {
   const t = useT();
   const [query, setQuery] = useState('');
   const [useRegex, setUseRegex] = useState(false);
+  const [allPanes, setAllPanes] = useState(false);
   const [historyIdx, setHistoryIdx] = useState(-1);
   const savedQueryRef = useRef('');
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Cross-pane search state — read directly from searchSlice (T-C).
+  // Selecting individual fields rather than the whole slice keeps re-renders
+  // minimal: we only re-render when these specific values change.
+  const searchResults = useStore((s) => s.searchResults);
+  const searchTotalMatches = useStore((s) => s.searchTotalMatches);
+  const searchQuery = useStore((s) => s.searchQuery);
+  const runSearch = useStore((s) => s.runSearch);
+  const clearCrossPaneSearch = useStore((s) => s.clearSearch);
+
+  // Regex validation runs synchronously on every keystroke when the regex
+  // toggle is on. We surface the SyntaxError message inline (red border +
+  // tooltip) and SUPPRESS search execution — matching D6/F8.
+  const regexError = useMemo<string | null>(() => {
+    if (!useRegex) return null;
+    if (!query) return null;
+    try {
+      // Construction is enough — we don't need to execute it here.
+      // eslint-disable-next-line no-new
+      new RegExp(query);
+      return null;
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  }, [useRegex, query]);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -33,44 +71,90 @@ export default function SearchBar({ onFindNext, onFindPrevious, onClose }: Searc
     return () => window.removeEventListener('keydown', handler);
   }, [onClose]);
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      if (searchHistory.length === 0) return;
-      if (historyIdx === -1) savedQueryRef.current = query;
-      const newIdx = Math.min(historyIdx + 1, searchHistory.length - 1);
-      setHistoryIdx(newIdx);
-      setQuery(searchHistory[searchHistory.length - 1 - newIdx]);
-      return;
-    }
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      if (historyIdx <= 0) {
-        setHistoryIdx(-1);
-        setQuery(savedQueryRef.current);
+  // When the bar unmounts (close) or the user toggles back to single-pane
+  // mode, clear any leftover cross-pane state so a stale dropdown doesn't
+  // appear next time the bar opens or T-F's panel doesn't resurrect.
+  useEffect(() => {
+    return () => {
+      // Defensive: only clear cross-pane state we authored. The single-pane
+      // SearchAddon `clearSearch` is wired via Terminal.tsx → useTerminal.
+      clearCrossPaneSearch();
+    };
+  }, [clearCrossPaneSearch]);
+
+  const runCrossPaneSearch = useCallback(
+    (q: string) => {
+      if (!q.trim()) return;
+      if (regexError) return; // suppress on invalid regex (D6)
+      void runSearch(q, useRegex);
+    },
+    [regexError, runSearch, useRegex],
+  );
+
+  const recordHistory = useCallback((q: string) => {
+    if (!q.trim()) return;
+    const existing = searchHistory.indexOf(q);
+    if (existing >= 0) searchHistory.splice(existing, 1);
+    searchHistory.push(q);
+    if (searchHistory.length > MAX_HISTORY) searchHistory.shift();
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        if (searchHistory.length === 0) return;
+        if (historyIdx === -1) savedQueryRef.current = query;
+        const newIdx = Math.min(historyIdx + 1, searchHistory.length - 1);
+        setHistoryIdx(newIdx);
+        setQuery(searchHistory[searchHistory.length - 1 - newIdx]);
         return;
       }
-      const newIdx = historyIdx - 1;
-      setHistoryIdx(newIdx);
-      setQuery(searchHistory[searchHistory.length - 1 - newIdx]);
-      return;
-    }
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      if (query.trim()) {
-        const existing = searchHistory.indexOf(query);
-        if (existing >= 0) searchHistory.splice(existing, 1);
-        searchHistory.push(query);
-        if (searchHistory.length > MAX_HISTORY) searchHistory.shift();
-        setHistoryIdx(-1);
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        if (historyIdx <= 0) {
+          setHistoryIdx(-1);
+          setQuery(savedQueryRef.current);
+          return;
+        }
+        const newIdx = historyIdx - 1;
+        setHistoryIdx(newIdx);
+        setQuery(searchHistory[searchHistory.length - 1 - newIdx]);
+        return;
       }
-      if (e.shiftKey) {
-        onFindPrevious(query, useRegex);
-      } else {
-        onFindNext(query, useRegex);
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (query.trim()) {
+          recordHistory(query);
+          setHistoryIdx(-1);
+        }
+        if (allPanes) {
+          // Cross-pane: Enter (or Shift+Enter) re-runs the search. There's
+          // no "next/prev" semantic since results are listed in the dropdown
+          // rather than highlighted in a single buffer.
+          runCrossPaneSearch(query);
+          return;
+        }
+        if (regexError) return; // single-pane: also suppress on invalid regex
+        if (e.shiftKey) {
+          onFindPrevious(query, useRegex);
+        } else {
+          onFindNext(query, useRegex);
+        }
       }
-    }
-  }, [query, useRegex, historyIdx, onFindNext, onFindPrevious]);
+    },
+    [
+      query,
+      useRegex,
+      historyIdx,
+      onFindNext,
+      onFindPrevious,
+      allPanes,
+      recordHistory,
+      runCrossPaneSearch,
+      regexError,
+    ],
+  );
 
   const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(e.target.value);
@@ -81,95 +165,267 @@ export default function SearchBar({ onFindNext, onFindPrevious, onClose }: Searc
     setUseRegex((prev) => !prev);
   }, []);
 
+  const toggleAllPanes = useCallback(() => {
+    setAllPanes((prev) => {
+      const next = !prev;
+      // Leaving All Panes mode → wipe any lingering cross-pane state so the
+      // dropdown disappears and T-F's panel doesn't reopen on next entry.
+      if (!next) {
+        clearCrossPaneSearch();
+      }
+      return next;
+    });
+  }, [clearCrossPaneSearch]);
+
+  // Click handler for an individual result row in the inline dropdown.
+  // Safe-by-construction: if the pane (or its terminal instance) was disposed
+  // between search execution and click, terminalRegistry.get returns
+  // undefined and we silently no-op.
+  const handleResultClick = useCallback(
+    (r: PaneSearchResult) => {
+      try {
+        useStore.getState().setActivePane(r.paneId);
+      } catch {
+        // setActivePane will no-op for unknown ids, but we guard anyway.
+      }
+      const term = terminalRegistry.get(r.ptyId);
+      if (term) {
+        // NOTE: we use lineIdx (logical line, post-wrap-coalesce) for the
+        // scroll target. The handler does not currently surface
+        // physicalBaseY in the public PaneSearchResult shape — see
+        // src/shared/types.ts. xterm's scrollToLine accepts any in-range
+        // value and clamps internally, so this is best-effort.
+        term.scrollToLine(r.lineIdx);
+      }
+    },
+    [],
+  );
+
+  // Whether the inline dropdown is appropriate. The panel (T-F) handles the
+  // >10 case, so we render either the dropdown OR the "open panel" hint —
+  // never both.
+  const showDropdown =
+    allPanes && searchQuery.length > 0 && searchResults.length > 0 && searchResults.length <= 10;
+  const showPanelHint =
+    allPanes && searchQuery.length > 0 && searchResults.length > 10;
+  const showNoResults =
+    allPanes &&
+    searchQuery.length > 0 &&
+    searchResults.length === 0 &&
+    !regexError &&
+    // Only after the runSearch promise has resolved — we approximate that by
+    // checking that searchQuery (set by the slice on success) matches what
+    // the user typed. Avoids a flicker of "No results" between keystroke and
+    // response.
+    searchQuery === query.trim();
+
+  const inputBorderColor = regexError ? 'var(--accent-red)' : 'transparent';
+
   return (
     <div
-      className="absolute top-0 right-2 z-50 flex items-center gap-1 px-2 py-1.5 rounded-b-md shadow-lg"
-      style={{
-        background: 'var(--bg-surface)',
-        border: '1px solid var(--bg-overlay)',
-        borderTop: 'none',
-        minWidth: '280px',
-      }}
+      className="absolute top-0 right-2 z-50 flex flex-col"
       onClick={(e) => e.stopPropagation()}
+      style={{ minWidth: '320px' }}
     >
-      {/* Search icon */}
-      <svg
-        width="13"
-        height="13"
-        viewBox="0 0 16 16"
-        fill="none"
-        className="shrink-0 text-[var(--text-subtle)]"
-        style={{ color: 'var(--text-subtle)' }}
-      >
-        <circle cx="6.5" cy="6.5" r="4.5" stroke="currentColor" strokeWidth="1.5" />
-        <line x1="10" y1="10" x2="14" y2="14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-      </svg>
-
-      {/* Input */}
-      <input
-        ref={inputRef}
-        type="text"
-        value={query}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        placeholder={t('search.placeholder')}
-        className="flex-1 bg-transparent outline-none text-xs"
+      {/* Bar row */}
+      <div
+        className="flex items-center gap-1 px-2 py-1.5 rounded-b-md shadow-lg"
         style={{
-          color: 'var(--text-main)',
-          caretColor: 'var(--accent-cursor)',
-          minWidth: 0,
-        }}
-        spellCheck={false}
-      />
-
-      {/* Regex toggle */}
-      <button
-        onClick={toggleRegex}
-        title={t('search.regexTooltip')}
-        className="flex items-center justify-center w-5 h-5 rounded transition-colors shrink-0"
-        style={{
-          background: useRegex ? 'var(--accent-yellow)' : 'transparent',
-          color: useRegex ? 'var(--bg-base)' : 'var(--text-sub2)',
+          background: 'var(--bg-surface)',
+          border: '1px solid var(--bg-overlay)',
+          borderTop: 'none',
         }}
       >
-        <span className="text-[10px] font-bold leading-none">.*</span>
-      </button>
-
-      {/* Previous (Shift+Enter) */}
-      <button
-        onClick={() => onFindPrevious(query, useRegex)}
-        title={t('search.prevTooltip')}
-        className="flex items-center justify-center w-5 h-5 rounded transition-colors hover:bg-[var(--bg-overlay)] text-[var(--text-sub2)] hover:text-[var(--text-main)] shrink-0"
-      >
-        <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-          <path d="M5 8L2 5l3-3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-          <path d="M8 8L5 5l3-3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        {/* Search icon */}
+        <svg
+          width="13"
+          height="13"
+          viewBox="0 0 16 16"
+          fill="none"
+          className="shrink-0 text-[var(--text-subtle)]"
+          style={{ color: 'var(--text-subtle)' }}
+        >
+          <circle cx="6.5" cy="6.5" r="4.5" stroke="currentColor" strokeWidth="1.5" />
+          <line x1="10" y1="10" x2="14" y2="14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
         </svg>
-      </button>
 
-      {/* Next (Enter) */}
-      <button
-        onClick={() => onFindNext(query, useRegex)}
-        title={t('search.nextTooltip')}
-        className="flex items-center justify-center w-5 h-5 rounded transition-colors hover:bg-[var(--bg-overlay)] text-[var(--text-sub2)] hover:text-[var(--text-main)] shrink-0"
-      >
-        <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-          <path d="M2 2l3 3-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-          <path d="M5 2l3 3-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      </button>
+        {/* Input */}
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder={t('search.placeholder')}
+          title={regexError ? t('search.invalidRegex', { message: regexError }) : undefined}
+          className="flex-1 bg-transparent outline-none text-xs px-1 rounded-sm"
+          style={{
+            color: 'var(--text-main)',
+            caretColor: 'var(--accent-cursor)',
+            minWidth: 0,
+            border: `1px solid ${inputBorderColor}`,
+          }}
+          spellCheck={false}
+        />
 
-      {/* Close */}
-      <button
-        onClick={onClose}
-        title={t('search.closeTooltip')}
-        className="flex items-center justify-center w-5 h-5 rounded transition-colors hover:bg-[var(--bg-overlay)] text-[var(--text-subtle)] hover:text-[var(--accent-red)] shrink-0"
-      >
-        <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-          <line x1="2" y1="2" x2="8" y2="8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-          <line x1="8" y1="2" x2="2" y2="8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-        </svg>
-      </button>
+        {/* All Panes toggle */}
+        <button
+          onClick={toggleAllPanes}
+          title={t('search.allPanes')}
+          aria-pressed={allPanes}
+          className="flex items-center justify-center h-5 px-1.5 rounded transition-colors shrink-0"
+          style={{
+            background: allPanes ? 'var(--accent-cursor)' : 'transparent',
+            color: allPanes ? 'var(--bg-base)' : 'var(--text-sub2)',
+          }}
+        >
+          <span className="text-[10px] font-bold leading-none">{t('search.allPanes')}</span>
+        </button>
+
+        {/* Regex toggle */}
+        <button
+          onClick={toggleRegex}
+          title={t('search.regexMode')}
+          aria-pressed={useRegex}
+          className="flex items-center justify-center w-5 h-5 rounded transition-colors shrink-0"
+          style={{
+            background: useRegex ? 'var(--accent-yellow)' : 'transparent',
+            color: useRegex ? 'var(--bg-base)' : 'var(--text-sub2)',
+          }}
+        >
+          <span className="text-[10px] font-bold leading-none">.*</span>
+        </button>
+
+        {/* Previous / Next — only shown in single-pane mode (no concept of
+            "next match" when results are listed cross-pane). */}
+        {!allPanes && (
+          <>
+            <button
+              onClick={() => {
+                if (regexError) return;
+                onFindPrevious(query, useRegex);
+              }}
+              title={t('search.prevTooltip')}
+              className="flex items-center justify-center w-5 h-5 rounded transition-colors hover:bg-[var(--bg-overlay)] text-[var(--text-sub2)] hover:text-[var(--text-main)] shrink-0"
+            >
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                <path d="M5 8L2 5l3-3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M8 8L5 5l3-3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </button>
+
+            <button
+              onClick={() => {
+                if (regexError) return;
+                onFindNext(query, useRegex);
+              }}
+              title={t('search.nextTooltip')}
+              className="flex items-center justify-center w-5 h-5 rounded transition-colors hover:bg-[var(--bg-overlay)] text-[var(--text-sub2)] hover:text-[var(--text-main)] shrink-0"
+            >
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                <path d="M2 2l3 3-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M5 2l3 3-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </button>
+          </>
+        )}
+
+        {/* Close */}
+        <button
+          onClick={onClose}
+          title={t('search.closeTooltip')}
+          className="flex items-center justify-center w-5 h-5 rounded transition-colors hover:bg-[var(--bg-overlay)] text-[var(--text-subtle)] hover:text-[var(--accent-red)] shrink-0"
+        >
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+            <line x1="2" y1="2" x2="8" y2="8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            <line x1="8" y1="2" x2="2" y2="8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Inline dropdown — small result lists (≤10). T-F's panel handles
+          larger result sets via searchPanelOpen + hysteresis. */}
+      {showDropdown && (
+        <ul
+          className="mt-0.5 rounded-md shadow-lg overflow-hidden"
+          style={{
+            background: 'var(--bg-surface)',
+            border: '1px solid var(--bg-overlay)',
+            maxHeight: '40vh',
+            overflowY: 'auto',
+            listStyle: 'none',
+            padding: 0,
+            margin: 0,
+          }}
+          role="listbox"
+        >
+          {searchResults.map((r, i) => (
+            <li
+              key={`${r.paneId}-${r.ptyId}-${r.lineIdx}-${i}`}
+              role="option"
+              aria-selected={false}
+              onClick={() => handleResultClick(r)}
+              className="flex items-baseline gap-2 px-2 py-1 cursor-pointer hover:bg-[var(--bg-overlay)]"
+              style={{ fontSize: '11px', color: 'var(--text-main)' }}
+            >
+              <span
+                className="shrink-0 font-medium"
+                style={{ color: 'var(--text-sub2)', minWidth: '40px' }}
+              >
+                {r.paneLabel ?? '(unlabeled)'}
+              </span>
+              <span className="shrink-0" style={{ color: 'var(--text-subtle)' }}>
+                {t('search.matchedLine', { line: r.lineIdx + 1 })}
+              </span>
+              <span
+                className="flex-1 truncate font-mono"
+                style={{ color: 'var(--text-main)' }}
+              >
+                {truncateMatch(r.text)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* "Open panel" hint — for >10 results. The actual panel is rendered
+          by T-F (SearchResultsPanel) reading the same searchSlice state. */}
+      {showPanelHint && (
+        <button
+          onClick={() => {
+            // Best-effort: clear the panel sticky-closed bit so T-F's
+            // hysteresis logic can re-open it. We don't mutate panelOpen
+            // ourselves — that's T-F's responsibility — but resetting the
+            // sticky bit is safe and matches user intent ("open panel").
+            useStore.setState((state) => {
+              state.searchPanelStickyClosed = false;
+              state.searchPanelOpen = true;
+            });
+          }}
+          className="mt-0.5 px-2 py-1 rounded-md text-[11px] text-left hover:bg-[var(--bg-overlay)] transition-colors"
+          style={{
+            background: 'var(--bg-surface)',
+            border: '1px solid var(--bg-overlay)',
+            color: 'var(--text-main)',
+          }}
+        >
+          {t('search.showInPanel', { count: searchTotalMatches })}
+        </button>
+      )}
+
+      {/* Empty-result hint */}
+      {showNoResults && (
+        <div
+          className="mt-0.5 px-2 py-1 rounded-md text-[11px]"
+          style={{
+            background: 'var(--bg-surface)',
+            border: '1px solid var(--bg-overlay)',
+            color: 'var(--text-subtle)',
+          }}
+        >
+          {t('search.noResults')}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -4,12 +4,14 @@ import { withDefaultShell } from '../utils/ptyCreateOptions';
 import type { Pane, PaneLeaf, Surface } from '../../shared/types';
 import { validateMessage } from '../../shared/types';
 import type { Message, Part, TaskState, Artifact, AgentSkill } from '../../shared/types';
+import type { PaneSearchResult, PaneSearchResponse } from '../../shared/types';
 import { generateId } from '../../shared/types';
 import { handleCompanyRpc } from '../../company/renderer/rpcHandlers';
 import { formatA2aMessage, formatA2aBroadcast } from '../utils/a2aFormat';
 import type { A2aPriority } from '../utils/a2aFormat';
 import { setExecuteApprovalResolver } from '../utils/executeApproval';
 import { terminalRegistry } from './useTerminal';
+import { searchInBuffer, type SearchableBuffer } from '../utils/searchEngine';
 
 // ---------------------------------------------------------------------------
 // Pane tree utilities
@@ -73,6 +75,15 @@ export function useRpcBridge(): void {
       },
     );
 
+    // ── In-renderer entry point for searchSlice ─────────────────────────────
+    // The search engine reads from xterm.js Terminal instances which only
+    // exist in the renderer. Exposing a thin global lets the zustand slice
+    // invoke `pane.search` directly without a useless renderer→main→renderer
+    // IPC round trip.
+    (window as unknown as { __wmuxRunPaneSearch: (q: string, r: boolean) => Promise<RpcResult> })
+      .__wmuxRunPaneSearch = (query: string, regex: boolean) =>
+        handleRpcMethod('pane.search', { query, regex });
+
     // A2A task garbage collection timer — prune terminal-state tasks every 5 min
     const gcTimer = setInterval(() => {
       useStore.getState().gcTerminalTasks();
@@ -81,6 +92,7 @@ export function useRpcBridge(): void {
     return () => {
       cleanupRpc();
       clearInterval(gcTimer);
+      delete (window as unknown as { __wmuxRunPaneSearch?: unknown }).__wmuxRunPaneSearch;
     };
   }, []);
 }
@@ -356,6 +368,90 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       params.direction === 'vertical' ? 'vertical' : 'horizontal';
     store.splitPane(ws.activePaneId, direction);
     return { ok: true };
+  }
+
+  if (method === 'pane.search') {
+    const query = String(params['query'] ?? '');
+    const regex = params['regex'] === true;
+    if (query.length === 0) return { error: 'pane.search: empty query' };
+
+    const ws = store.workspaces.find((w) => w.id === store.activeWorkspaceId);
+    if (!ws) return { error: 'pane.search: no active workspace' };
+
+    // Build ptyId → workspaceId reverse map (current ws only — D9, v1 scope='workspace')
+    // and ptyId → paneId map for result tagging.
+    const ptyToPaneId = new Map<string, string>();
+    const ptyToSurfaceId = new Map<string, string>();
+    const ptyToPaneLabel = new Map<string, string | undefined>();
+    const leaves = findLeafPanes(ws.rootPane);
+    for (const leaf of leaves) {
+      // PR #16 may add `metadata.label` to PaneLeaf — read defensively so we
+      // neither depend on the field's existence nor throw if it's missing.
+      const leafMeta = (leaf as PaneLeaf & { metadata?: { label?: string } }).metadata;
+      const leafLabel = leafMeta?.label;
+      for (const s of leaf.surfaces) {
+        if (s.ptyId) {
+          ptyToPaneId.set(s.ptyId, leaf.id);
+          ptyToSurfaceId.set(s.ptyId, s.id);
+          ptyToPaneLabel.set(s.ptyId, leafLabel);
+        }
+      }
+    }
+
+    const TOTAL_BUDGET = 200;
+    let remainingBudget = TOTAL_BUDGET;
+    const results: PaneSearchResult[] = [];
+    let totalMatches = 0;
+
+    // Snapshot registry keys to make mutation during iteration safe (N2).
+    const ptyIds = Array.from(terminalRegistry.keys());
+    for (const ptyId of ptyIds) {
+      if (remainingBudget <= 0) break;
+      const paneId = ptyToPaneId.get(ptyId);
+      if (!paneId) continue; // pty not in current workspace
+      const term = terminalRegistry.get(ptyId);
+      if (!term) continue; // unmounted between snapshot and read
+      try {
+        // Adapt xterm Buffer to SearchableBuffer (it already conforms structurally)
+        const matches = searchInBuffer(
+          term.buffer.active as unknown as SearchableBuffer,
+          query,
+          { regex, contextLines: 2, perBufferLineCap: 20_000, remainingBudget },
+        );
+        totalMatches += matches.length;
+        for (const m of matches) {
+          const label = ptyToPaneLabel.get(ptyId);
+          const result: PaneSearchResult = {
+            paneId,
+            surfaceId: ptyToSurfaceId.get(ptyId)!,
+            ptyId,
+            lineIdx: m.lineIdx,
+            text: m.text,
+            contextBefore: m.contextBefore,
+            contextAfter: m.contextAfter,
+            ...(label !== undefined && { paneLabel: label }),
+          };
+          results.push(result);
+          remainingBudget--;
+          if (remainingBudget <= 0) break;
+        }
+      } catch (err) {
+        // SyntaxError from invalid regex — propagate as RPC error
+        if (err instanceof SyntaxError) {
+          return { error: `pane.search: invalid regex: ${err.message}` };
+        }
+        // Per-pane errors (e.g., disposed terminal): skip silently (N2)
+      }
+    }
+
+    const response: PaneSearchResponse = {
+      resultShapeVersion: 1,
+      results,
+      truncated: totalMatches > TOTAL_BUDGET,
+      totalMatches,
+      workspaceId: ws.id,
+    };
+    return response;
   }
 
   // -------------------------------------------------------------------------

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -375,8 +375,24 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     const regex = params['regex'] === true;
     if (query.length === 0) return { error: 'pane.search: empty query' };
 
-    const ws = store.workspaces.find((w) => w.id === store.activeWorkspaceId);
-    if (!ws) return { error: 'pane.search: no active workspace' };
+    // ─── Workspace scope (C1, decisions D9) ──────────────────────────────
+    // External MCP callers pass `workspaceId` via T-D so the search is
+    // scoped to the CALLING workspace, not whichever the user is currently
+    // viewing in the UI. Internal renderer callers (SearchBar) omit
+    // `workspaceId` and fall back to the active workspace.
+    const requestedWsId =
+      typeof params['workspaceId'] === 'string' && (params['workspaceId'] as string).length > 0
+        ? (params['workspaceId'] as string)
+        : store.activeWorkspaceId;
+    const ws = store.workspaces.find((w) => w.id === requestedWsId);
+    if (!ws) {
+      // Validate explicitly so an external caller passing a stale/invalid
+      // workspaceId gets a clear error instead of silently empty results.
+      if (typeof params['workspaceId'] === 'string' && (params['workspaceId'] as string).length > 0) {
+        return { error: `pane.search: workspace "${requestedWsId}" not found` };
+      }
+      return { error: 'pane.search: no active workspace' };
+    }
 
     // Build ptyId → workspaceId reverse map (current ws only — D9, v1 scope='workspace')
     // and ptyId → paneId map for result tagging.
@@ -402,17 +418,33 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     let remainingBudget = TOTAL_BUDGET;
     const results: PaneSearchResult[] = [];
     let totalMatches = 0;
+    // ─── Truncation tracking (I1) ────────────────────────────────────────
+    // We can't know "true total" without re-scanning post-cap, so semantics
+    // are: truncated=true iff the budget hit zero AND there were panes left
+    // to scan (or the per-pane engine returned exactly `remainingBudget`
+    // matches, signalling more were available). This is the closest honest
+    // approximation without a second-pass scan.
+    let truncated = false;
 
     // Snapshot registry keys to make mutation during iteration safe (N2).
     const ptyIds = Array.from(terminalRegistry.keys());
-    for (const ptyId of ptyIds) {
-      if (remainingBudget <= 0) break;
+    // Keep only ptyIds that belong to the resolved workspace so the
+    // "panes-left" check below is meaningful.
+    const scannablePtyIds = ptyIds.filter((id) => ptyToPaneId.has(id));
+    for (let pIdx = 0; pIdx < scannablePtyIds.length; pIdx++) {
+      const ptyId = scannablePtyIds[pIdx];
+      if (remainingBudget <= 0) {
+        // Budget exhausted before we got to this pane → more matches likely.
+        truncated = true;
+        break;
+      }
       const paneId = ptyToPaneId.get(ptyId);
-      if (!paneId) continue; // pty not in current workspace
+      if (!paneId) continue; // belt-and-braces; filtered above already
       const term = terminalRegistry.get(ptyId);
       if (!term) continue; // unmounted between snapshot and read
       try {
         // Adapt xterm Buffer to SearchableBuffer (it already conforms structurally)
+        const requestedBudget = remainingBudget;
         const matches = searchInBuffer(
           term.buffer.active as unknown as SearchableBuffer,
           query,
@@ -426,6 +458,7 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
             surfaceId: ptyToSurfaceId.get(ptyId)!,
             ptyId,
             lineIdx: m.lineIdx,
+            physicalBaseY: m.physicalBaseY,
             text: m.text,
             contextBefore: m.contextBefore,
             contextAfter: m.contextAfter,
@@ -434,6 +467,12 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
           results.push(result);
           remainingBudget--;
           if (remainingBudget <= 0) break;
+        }
+        // If the engine returned EXACTLY the budget we gave it, more matches
+        // may exist in this same buffer that were cut off — truncated.
+        if (matches.length === requestedBudget && remainingBudget <= 0) {
+          // There may also be unscanned panes after this — both flag as truncated.
+          truncated = true;
         }
       } catch (err) {
         // SyntaxError from invalid regex — propagate as RPC error
@@ -447,9 +486,9 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     const response: PaneSearchResponse = {
       resultShapeVersion: 1,
       results,
-      truncated: totalMatches > TOTAL_BUDGET,
+      truncated,
       totalMatches,
-      workspaceId: ws.id,
+      workspaceId: ws.id, // C1: echo the RESOLVED workspace, not the active one.
     };
     return response;
   }

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -32,6 +32,12 @@ export const en = {
   'search.nextTooltip': 'Next result (Enter)',
   'search.closeTooltip': 'Close (ESC)',
   'search.regexTooltip': 'Use regular expression',
+  'search.allPanes': 'All Panes',
+  'search.regexMode': 'Regex',
+  'search.noResults': 'No results',
+  'search.showInPanel': '{count} results — open panel',
+  'search.matchedLine': 'Line {line}',
+  'search.invalidRegex': 'Invalid regex: {message}',
 
   // Notification
   'notification.title': 'Notifications',

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -38,6 +38,10 @@ export const en = {
   'search.showInPanel': '{count} results — open panel',
   'search.matchedLine': 'Line {line}',
   'search.invalidRegex': 'Invalid regex: {message}',
+  'search.panelTitle': 'Search Results',
+  'search.matchesCount': '{count} matches',
+  'search.matchesCountTruncated': '200+ matches',
+  'search.unlabeled': '(unlabeled)',
 
   // Notification
   'notification.title': 'Notifications',

--- a/src/renderer/i18n/locales/ja.ts
+++ b/src/renderer/i18n/locales/ja.ts
@@ -38,6 +38,10 @@ export const ja = {
   'search.showInPanel': '{count}件の結果 — パネルを開く',
   'search.matchedLine': '{line}行目',
   'search.invalidRegex': '無効な正規表現: {message}',
+  'search.panelTitle': '検索結果',
+  'search.matchesCount': '{count}件の結果',
+  'search.matchesCountTruncated': '200件以上の結果',
+  'search.unlabeled': '(無題)',
 
   // Notification
   'notification.title': '通知',

--- a/src/renderer/i18n/locales/ja.ts
+++ b/src/renderer/i18n/locales/ja.ts
@@ -32,6 +32,12 @@ export const ja = {
   'search.nextTooltip': '次の結果 (Enter)',
   'search.closeTooltip': '閉じる (ESC)',
   'search.regexTooltip': '正規表現を使用',
+  'search.allPanes': '全パネル',
+  'search.regexMode': '正規表現',
+  'search.noResults': '結果なし',
+  'search.showInPanel': '{count}件の結果 — パネルを開く',
+  'search.matchedLine': '{line}行目',
+  'search.invalidRegex': '無効な正規表現: {message}',
 
   // Notification
   'notification.title': '通知',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -32,6 +32,12 @@ export const ko = {
   'search.nextTooltip': '다음 결과 (Enter)',
   'search.closeTooltip': '닫기 (ESC)',
   'search.regexTooltip': '정규식 사용',
+  'search.allPanes': '모든 팬',
+  'search.regexMode': '정규식',
+  'search.noResults': '결과 없음',
+  'search.showInPanel': '{count}개 결과 — 패널 열기',
+  'search.matchedLine': '{line}행',
+  'search.invalidRegex': '유효하지 않은 정규식: {message}',
 
   // Notification
   'notification.title': '알림',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -32,12 +32,16 @@ export const ko = {
   'search.nextTooltip': '다음 결과 (Enter)',
   'search.closeTooltip': '닫기 (ESC)',
   'search.regexTooltip': '정규식 사용',
-  'search.allPanes': '모든 팬',
+  'search.allPanes': '모든 창',
   'search.regexMode': '정규식',
   'search.noResults': '결과 없음',
   'search.showInPanel': '{count}개 결과 — 패널 열기',
   'search.matchedLine': '{line}행',
   'search.invalidRegex': '유효하지 않은 정규식: {message}',
+  'search.panelTitle': '검색 결과',
+  'search.matchesCount': '{count}개 결과',
+  'search.matchesCountTruncated': '200+개 결과',
+  'search.unlabeled': '(이름 없음)',
 
   // Notification
   'notification.title': '알림',

--- a/src/renderer/i18n/locales/zh.ts
+++ b/src/renderer/i18n/locales/zh.ts
@@ -32,6 +32,12 @@ export const zh = {
   'search.nextTooltip': '下一个结果 (Enter)',
   'search.closeTooltip': '关闭 (ESC)',
   'search.regexTooltip': '使用正则表达式',
+  'search.allPanes': '全部分屏',
+  'search.regexMode': '正则',
+  'search.noResults': '无结果',
+  'search.showInPanel': '{count}个结果 — 打开面板',
+  'search.matchedLine': '第{line}行',
+  'search.invalidRegex': '无效正则: {message}',
 
   // Notification
   'notification.title': '通知',

--- a/src/renderer/i18n/locales/zh.ts
+++ b/src/renderer/i18n/locales/zh.ts
@@ -38,6 +38,10 @@ export const zh = {
   'search.showInPanel': '{count}个结果 — 打开面板',
   'search.matchedLine': '第{line}行',
   'search.invalidRegex': '无效正则: {message}',
+  'search.panelTitle': '搜索结果',
+  'search.matchesCount': '{count}个结果',
+  'search.matchesCountTruncated': '200+个结果',
+  'search.unlabeled': '(未命名)',
 
   // Notification
   'notification.title': '通知',

--- a/src/renderer/stores/index.ts
+++ b/src/renderer/stores/index.ts
@@ -9,8 +9,9 @@ import { createA2aSlice, type A2aSlice } from './slices/a2aSlice';
 import { createCompanySlice, type CompanySlice } from './slices/companySlice';
 import { createTokenSlice, type TokenSlice } from './slices/tokenSlice';
 import { createToastSlice, type ToastSlice } from './slices/toastSlice';
+import { createSearchSlice, type SearchSlice } from './slices/searchSlice';
 
-export type StoreState = WorkspaceSlice & PaneSlice & SurfaceSlice & UISlice & NotificationSlice & A2aSlice & CompanySlice & TokenSlice & ToastSlice;
+export type StoreState = WorkspaceSlice & PaneSlice & SurfaceSlice & UISlice & NotificationSlice & A2aSlice & CompanySlice & TokenSlice & ToastSlice & SearchSlice;
 
 export const useStore = create<StoreState>()(
   immer((...args) => ({
@@ -23,5 +24,6 @@ export const useStore = create<StoreState>()(
     ...createCompanySlice(...args),
     ...createTokenSlice(...args),
     ...createToastSlice(...args),
+    ...createSearchSlice(...args),
   }))
 );

--- a/src/renderer/stores/slices/__tests__/searchSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/searchSlice.test.ts
@@ -24,6 +24,7 @@ function makeResult(idx: number): PaneSearchResult {
     surfaceId: `surface-${idx}`,
     ptyId: `pty-${idx}`,
     lineIdx: idx,
+    physicalBaseY: idx,
     text: `match ${idx}`,
     contextBefore: [],
     contextAfter: [],
@@ -292,14 +293,21 @@ describe('searchSlice — truncation echo', () => {
 });
 
 describe('searchSlice — bridge missing', () => {
-  it('runSearch silently bails when window.__wmuxRunPaneSearch is not defined', async () => {
+  it('runSearch bails (no state change) and logs a warn when window.__wmuxRunPaneSearch is not defined', async () => {
     // Window present but bridge not set — slice's no-op branch must trigger.
     g.window = {};
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const store = createTestStore();
 
     // No throw, no state change.
     await expect(store.getState().runSearch('foo', false)).resolves.toBeUndefined();
     expect(store.getState().searchQuery).toBe('');
     expect(store.getState().searchResults).toEqual([]);
+    // I7: bridge-missing condition is logged so DevTools surfaces the
+    // timing edge case (without sentinel-erroring the user-visible state).
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('runSearch invoked before bridge mounted'),
+    );
+    warnSpy.mockRestore();
   });
 });

--- a/src/renderer/stores/slices/__tests__/searchSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/searchSlice.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { createSearchSlice, type SearchSlice } from '../searchSlice';
+import type { PaneSearchResult, PaneSearchResponse } from '../../../../shared/types';
+
+// Minimal store carrying only SearchSlice — mirrors paneSlice/a2aSlice test
+// pattern. The `@ts-expect-error` is unavoidable because createSearchSlice's
+// StateCreator is typed against the full StoreState union.
+type TestState = SearchSlice;
+
+function createTestStore() {
+  return create<TestState>()(
+    immer((...args) => ({
+      // @ts-expect-error — minimal test store doesn't match full StoreState
+      ...createSearchSlice(...args),
+    })),
+  );
+}
+
+function makeResult(idx: number): PaneSearchResult {
+  return {
+    paneId: `pane-${idx}`,
+    surfaceId: `surface-${idx}`,
+    ptyId: `pty-${idx}`,
+    lineIdx: idx,
+    text: `match ${idx}`,
+    contextBefore: [],
+    contextAfter: [],
+  };
+}
+
+function makeResponse(count: number, totalMatches?: number): PaneSearchResponse {
+  return {
+    resultShapeVersion: 1,
+    results: Array.from({ length: count }, (_, i) => makeResult(i)),
+    truncated: typeof totalMatches === 'number' && totalMatches > count,
+    totalMatches: totalMatches ?? count,
+    workspaceId: 'ws-1',
+  };
+}
+
+type BridgeFn = (query: string, regex: boolean) => Promise<unknown>;
+
+interface MockedWindow {
+  __wmuxRunPaneSearch?: BridgeFn;
+}
+
+// vitest's default `node` environment doesn't define `window`. The slice
+// dereferences `window.__wmuxRunPaneSearch` so we install a stub on
+// globalThis to satisfy that lookup. Each test seeds the bridge fn (or
+// deletes it for the "missing bridge" case).
+const g = globalThis as unknown as { window?: MockedWindow };
+let bridgeMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  bridgeMock = vi.fn();
+  g.window = { __wmuxRunPaneSearch: bridgeMock as unknown as BridgeFn };
+});
+
+afterEach(() => {
+  delete g.window;
+});
+
+describe('searchSlice — initial state', () => {
+  it('starts with empty/false defaults', () => {
+    const store = createTestStore();
+    const s = store.getState();
+    expect(s.searchQuery).toBe('');
+    expect(s.searchResults).toEqual([]);
+    expect(s.searchTruncated).toBe(false);
+    expect(s.searchTotalMatches).toBe(0);
+    expect(s.searchPanelOpen).toBe(false);
+    expect(s.searchPanelStickyClosed).toBe(false);
+  });
+});
+
+describe('searchSlice — runSearch (empty query)', () => {
+  it('clears all state including the sticky bit', async () => {
+    const store = createTestStore();
+    // Seed some pre-existing dirty state including sticky=true.
+    store.setState((s) => {
+      s.searchQuery = 'old';
+      s.searchResults = [makeResult(0)];
+      s.searchTruncated = true;
+      s.searchTotalMatches = 99;
+      s.searchPanelOpen = true;
+      s.searchPanelStickyClosed = true;
+    });
+
+    await store.getState().runSearch('', false);
+
+    const s = store.getState();
+    expect(s.searchQuery).toBe('');
+    expect(s.searchResults).toEqual([]);
+    expect(s.searchTruncated).toBe(false);
+    expect(s.searchTotalMatches).toBe(0);
+    expect(s.searchPanelOpen).toBe(false);
+    expect(s.searchPanelStickyClosed).toBe(false);
+    // Bridge must NOT be invoked for empty queries.
+    expect(bridgeMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('searchSlice — hysteresis triggers', () => {
+  it('with 3 results: state populated, panel stays closed (≤5)', async () => {
+    bridgeMock.mockResolvedValueOnce(makeResponse(3));
+    const store = createTestStore();
+
+    await store.getState().runSearch('foo', false);
+
+    const s = store.getState();
+    expect(s.searchQuery).toBe('foo');
+    expect(s.searchResults).toHaveLength(3);
+    expect(s.searchPanelOpen).toBe(false);
+  });
+
+  it('with 8 results (dead zone, was closed): panel stays closed', async () => {
+    bridgeMock.mockResolvedValueOnce(makeResponse(8));
+    const store = createTestStore();
+
+    await store.getState().runSearch('foo', false);
+
+    expect(store.getState().searchPanelOpen).toBe(false);
+  });
+
+  it('with 15 results (>10 trigger): panel opens', async () => {
+    bridgeMock.mockResolvedValueOnce(makeResponse(15));
+    const store = createTestStore();
+
+    await store.getState().runSearch('foo', false);
+
+    expect(store.getState().searchPanelOpen).toBe(true);
+  });
+
+  it('was open, results drop to 8 (dead zone): panel stays open', async () => {
+    bridgeMock
+      .mockResolvedValueOnce(makeResponse(15))
+      .mockResolvedValueOnce(makeResponse(8));
+    const store = createTestStore();
+
+    await store.getState().runSearch('foo', false);
+    expect(store.getState().searchPanelOpen).toBe(true);
+
+    // Prefix-extend the query so this is NOT a session reset.
+    await store.getState().runSearch('foob', false);
+    expect(store.getState().searchPanelOpen).toBe(true);
+  });
+
+  it('was open, results drop to 3 (≤5 trigger): panel closes', async () => {
+    bridgeMock
+      .mockResolvedValueOnce(makeResponse(15))
+      .mockResolvedValueOnce(makeResponse(3));
+    const store = createTestStore();
+
+    await store.getState().runSearch('foo', false);
+    expect(store.getState().searchPanelOpen).toBe(true);
+
+    await store.getState().runSearch('foob', false);
+    expect(store.getState().searchPanelOpen).toBe(false);
+  });
+});
+
+describe('searchSlice — sticky bit', () => {
+  it('closeSearchPanel sets the sticky bit and blocks auto-reopen on subsequent runSearch with 15 results', async () => {
+    bridgeMock
+      .mockResolvedValueOnce(makeResponse(15))
+      .mockResolvedValueOnce(makeResponse(15));
+    const store = createTestStore();
+
+    // 1. Trigger panel open via hysteresis.
+    await store.getState().runSearch('foo', false);
+    expect(store.getState().searchPanelOpen).toBe(true);
+
+    // 2. User explicitly dismisses panel.
+    store.getState().closeSearchPanel();
+    expect(store.getState().searchPanelOpen).toBe(false);
+    expect(store.getState().searchPanelStickyClosed).toBe(true);
+
+    // 3. Prefix-extending query (no session reset) returns 15 results — sticky
+    //    must keep panel closed.
+    await store.getState().runSearch('foob', false);
+    expect(store.getState().searchPanelOpen).toBe(false);
+    expect(store.getState().searchPanelStickyClosed).toBe(true);
+  });
+
+  it('session reset (length delta > 2) clears sticky and panel reopens', async () => {
+    bridgeMock
+      .mockResolvedValueOnce(makeResponse(15))
+      .mockResolvedValueOnce(makeResponse(15));
+    const store = createTestStore();
+
+    // Initial query "ab" (len 2) → open → user dismiss.
+    await store.getState().runSearch('ab', false);
+    store.getState().closeSearchPanel();
+    expect(store.getState().searchPanelStickyClosed).toBe(true);
+
+    // "abcde" — len delta = 3 → sessionReset = true → sticky cleared.
+    await store.getState().runSearch('abcde', false);
+    expect(store.getState().searchPanelStickyClosed).toBe(false);
+    expect(store.getState().searchPanelOpen).toBe(true);
+  });
+
+  it('session reset (not a prefix extension) clears sticky', async () => {
+    bridgeMock
+      .mockResolvedValueOnce(makeResponse(15))
+      .mockResolvedValueOnce(makeResponse(15));
+    const store = createTestStore();
+
+    await store.getState().runSearch('abc', false);
+    store.getState().closeSearchPanel();
+    expect(store.getState().searchPanelStickyClosed).toBe(true);
+
+    // "xyz" — neither side is a prefix of the other → sessionReset = true.
+    await store.getState().runSearch('xyz', false);
+    expect(store.getState().searchPanelStickyClosed).toBe(false);
+    expect(store.getState().searchPanelOpen).toBe(true);
+  });
+
+  it('prefix extension does NOT clear sticky (delta ≤ 2 and prefix match)', async () => {
+    bridgeMock
+      .mockResolvedValueOnce(makeResponse(15))
+      .mockResolvedValueOnce(makeResponse(15));
+    const store = createTestStore();
+
+    await store.getState().runSearch('ab', false);
+    store.getState().closeSearchPanel();
+    expect(store.getState().searchPanelStickyClosed).toBe(true);
+
+    // "abcd" — prev "ab" is a prefix, delta = 2 → NOT a session reset.
+    await store.getState().runSearch('abcd', false);
+    expect(store.getState().searchPanelStickyClosed).toBe(true);
+    expect(store.getState().searchPanelOpen).toBe(false);
+  });
+
+  it('openSearchPanel clears the sticky bit so subsequent searches respect normal hysteresis', async () => {
+    bridgeMock
+      .mockResolvedValueOnce(makeResponse(15))
+      .mockResolvedValueOnce(makeResponse(15));
+    const store = createTestStore();
+
+    await store.getState().runSearch('foo', false);
+    store.getState().closeSearchPanel();
+    expect(store.getState().searchPanelStickyClosed).toBe(true);
+
+    // Explicit user open.
+    store.getState().openSearchPanel();
+    expect(store.getState().searchPanelOpen).toBe(true);
+    expect(store.getState().searchPanelStickyClosed).toBe(false);
+
+    // Prefix-extending search with 15 results — hysteresis should keep open
+    // and sticky should still be false.
+    await store.getState().runSearch('foob', false);
+    expect(store.getState().searchPanelOpen).toBe(true);
+    expect(store.getState().searchPanelStickyClosed).toBe(false);
+  });
+});
+
+describe('searchSlice — clearSearch', () => {
+  it('resets everything including the sticky bit', async () => {
+    bridgeMock.mockResolvedValueOnce(makeResponse(15));
+    const store = createTestStore();
+    await store.getState().runSearch('foo', false);
+    store.getState().closeSearchPanel();
+    expect(store.getState().searchPanelStickyClosed).toBe(true);
+
+    store.getState().clearSearch();
+
+    const s = store.getState();
+    expect(s.searchQuery).toBe('');
+    expect(s.searchResults).toEqual([]);
+    expect(s.searchTruncated).toBe(false);
+    expect(s.searchTotalMatches).toBe(0);
+    expect(s.searchPanelOpen).toBe(false);
+    expect(s.searchPanelStickyClosed).toBe(false);
+  });
+});
+
+describe('searchSlice — truncation echo', () => {
+  it('propagates truncated flag and totalMatches from the bridge response', async () => {
+    bridgeMock.mockResolvedValueOnce(makeResponse(200, 423));
+    const store = createTestStore();
+
+    await store.getState().runSearch('foo', false);
+
+    const s = store.getState();
+    expect(s.searchResults).toHaveLength(200);
+    expect(s.searchTruncated).toBe(true);
+    expect(s.searchTotalMatches).toBe(423);
+    expect(s.searchPanelOpen).toBe(true); // 200 > 10
+  });
+});
+
+describe('searchSlice — bridge missing', () => {
+  it('runSearch silently bails when window.__wmuxRunPaneSearch is not defined', async () => {
+    // Window present but bridge not set — slice's no-op branch must trigger.
+    g.window = {};
+    const store = createTestStore();
+
+    // No throw, no state change.
+    await expect(store.getState().runSearch('foo', false)).resolves.toBeUndefined();
+    expect(store.getState().searchQuery).toBe('');
+    expect(store.getState().searchResults).toEqual([]);
+  });
+});

--- a/src/renderer/stores/slices/searchSlice.ts
+++ b/src/renderer/stores/slices/searchSlice.ts
@@ -51,6 +51,18 @@ export interface SearchSlice {
   runSearch: (query: string, regex: boolean) => Promise<void>;
   /** Reset all search state, including the panel sticky bit. */
   clearSearch: () => void;
+  /**
+   * User explicitly closed the results panel. Sets the sticky bit so the
+   * hysteresis machine in `runSearch` does not auto-reopen for this query
+   * session (cleared on session reset — see D8).
+   */
+  closeSearchPanel: () => void;
+  /**
+   * User explicitly opened the panel (e.g. "Show in panel" affordance in
+   * the search bar). Clears the sticky bit since this is an explicit intent
+   * to keep the panel open.
+   */
+  openSearchPanel: () => void;
 }
 
 export const createSearchSlice: StateCreator<
@@ -58,7 +70,7 @@ export const createSearchSlice: StateCreator<
   [['zustand/immer', never]],
   [],
   SearchSlice
-> = (set) => ({
+> = (set, get) => ({
   searchQuery: '',
   searchResults: [],
   searchTruncated: false,
@@ -67,17 +79,39 @@ export const createSearchSlice: StateCreator<
   searchPanelStickyClosed: false,
 
   runSearch: async (query, regex) => {
+    // Capture prev query BEFORE the new search runs so we can compute the
+    // session-reset metric below (G4). Reading via `get()` is required —
+    // immer's draft inside `set` would observe the post-update value.
+    const prev = get().searchQuery;
+
     if (!query) {
+      // Empty query is treated as a clear: zero results AND fully reset
+      // panel state (closed + sticky cleared). T-F (D8) — empty-query is
+      // an explicit session reset, so the next non-empty query starts the
+      // hysteresis machine in a clean state.
       set((state: StoreState) => {
         state.searchQuery = '';
         state.searchResults = [];
         state.searchTruncated = false;
         state.searchTotalMatches = 0;
-        // Panel reset on empty query is T-F's responsibility (session reset
-        // logic). T-C only zeros the result data here.
+        state.searchPanelOpen = false;
+        state.searchPanelStickyClosed = false;
       });
       return;
     }
+
+    // ─── Session-reset metric (D8 / G4) ────────────────────────────────
+    // The sticky-closed bit only persists within a "search session". A
+    // session resets when:
+    //   - prev query is empty (we were idle), OR
+    //   - the length delta is > 2 chars (likely a wholly new query, not
+    //     incremental typing/backspacing), OR
+    //   - neither the old nor new query is a prefix of the other (the
+    //     user retyped, not extended).
+    const lengthDeltaTooBig = Math.abs(query.length - prev.length) > 2;
+    const notPrefixExtension =
+      prev.length > 0 && !query.startsWith(prev) && !prev.startsWith(query);
+    const sessionReset = !prev || lengthDeltaTooBig || notPrefixExtension;
 
     // The bridge global is wired up by `useRpcBridge`'s useEffect. If this
     // slice is consulted before that hook mounts (e.g. tests, SSR-ish flows)
@@ -99,6 +133,27 @@ export const createSearchSlice: StateCreator<
         state.searchResults = r.results;
         state.searchTruncated = r.truncated;
         state.searchTotalMatches = r.totalMatches;
+
+        // ─── Hysteresis state machine (D8) ─────────────────────────────
+        //   - >10 results → open
+        //   - ≤5 results  → close
+        //   - 6-10 results (dead zone) → keep current visibility
+        //   - sticky-closed bit blocks auto-open within the same session;
+        //     a session reset clears it before applying the rule above.
+        if (sessionReset) {
+          state.searchPanelStickyClosed = false;
+        }
+        const wasOpen = state.searchPanelOpen;
+        if (!state.searchPanelStickyClosed) {
+          if (r.results.length > 10) {
+            state.searchPanelOpen = true;
+          } else if (r.results.length <= 5) {
+            state.searchPanelOpen = false;
+          } else {
+            // 6-10 hysteresis dead zone — preserve current visibility.
+            state.searchPanelOpen = wasOpen;
+          }
+        }
       });
     }
   },
@@ -109,7 +164,25 @@ export const createSearchSlice: StateCreator<
       state.searchResults = [];
       state.searchTruncated = false;
       state.searchTotalMatches = 0;
+      // clearSearch is a session reset by definition — drop the sticky bit
+      // so the next runSearch starts in a clean hysteresis state (D8).
       state.searchPanelOpen = false;
+      state.searchPanelStickyClosed = false;
+    }),
+
+  closeSearchPanel: () =>
+    set((state: StoreState) => {
+      state.searchPanelOpen = false;
+      // Sticky until the next session reset (empty query / length jump /
+      // non-prefix retype). See `runSearch` above.
+      state.searchPanelStickyClosed = true;
+    }),
+
+  openSearchPanel: () =>
+    set((state: StoreState) => {
+      state.searchPanelOpen = true;
+      // Explicit user intent to open — clear sticky so subsequent edits
+      // within the dead zone don't re-close it on the user.
       state.searchPanelStickyClosed = false;
     }),
 });

--- a/src/renderer/stores/slices/searchSlice.ts
+++ b/src/renderer/stores/slices/searchSlice.ts
@@ -1,0 +1,115 @@
+import type { StateCreator } from 'zustand';
+import type { StoreState } from '../index';
+import type { PaneSearchResult } from '../../../shared/types';
+
+/**
+ * Cross-pane search state (T-C skeleton).
+ *
+ * T-C owns: query / results / truncated / totalMatches + `runSearch` /
+ * `clearSearch` actions, plus declaring the panel hysteresis fields so T-E
+ * can read them.
+ *
+ * T-F will own: writes to `searchPanelOpen` / `searchPanelStickyClosed`
+ * (auto-expand at >10, auto-collapse at <=5, sticky-closed bit, session
+ * resets — see decisions D8 / D9 and progress.md T-F).
+ *
+ * The actual search engine lives in `utils/searchEngine.ts` and is invoked
+ * via the `pane.search` RPC handler in `useRpcBridge.ts`. Because that
+ * engine reads xterm.js Terminal instances which only exist in the renderer,
+ * `useRpcBridge` exposes a `window.__wmuxRunPaneSearch` global that the
+ * action below calls directly — avoiding a pointless renderer→main→renderer
+ * IPC round trip.
+ */
+export interface SearchSlice {
+  /** Last query string that produced `searchResults`. Empty when cleared. */
+  searchQuery: string;
+  /** Most recent result set (capped at 200, see D5). */
+  searchResults: PaneSearchResult[];
+  /** True when the engine hit the 200-result budget. */
+  searchTruncated: boolean;
+  /**
+   * Pre-cap match count, useful for the "200+ matches" UI hint. May exceed
+   * `searchResults.length` when `searchTruncated` is true.
+   */
+  searchTotalMatches: number;
+  /**
+   * Auto-expanded results panel visibility. T-F flips this based on D8
+   * hysteresis (open >10, close <=5). T-C only initializes/clears it.
+   */
+  searchPanelOpen: boolean;
+  /**
+   * Sticky bit set when the user explicitly dismisses the panel — prevents
+   * auto-reopen until a session reset (T-F). T-C only initializes/clears it.
+   */
+  searchPanelStickyClosed: boolean;
+
+  /**
+   * Run the cross-pane search through the renderer-side bridge.
+   * No-op (resets state) on empty query. Errors from the bridge (e.g.
+   * invalid regex) are swallowed here — T-E owns user-visible error UI.
+   */
+  runSearch: (query: string, regex: boolean) => Promise<void>;
+  /** Reset all search state, including the panel sticky bit. */
+  clearSearch: () => void;
+}
+
+export const createSearchSlice: StateCreator<
+  StoreState,
+  [['zustand/immer', never]],
+  [],
+  SearchSlice
+> = (set) => ({
+  searchQuery: '',
+  searchResults: [],
+  searchTruncated: false,
+  searchTotalMatches: 0,
+  searchPanelOpen: false,
+  searchPanelStickyClosed: false,
+
+  runSearch: async (query, regex) => {
+    if (!query) {
+      set((state: StoreState) => {
+        state.searchQuery = '';
+        state.searchResults = [];
+        state.searchTruncated = false;
+        state.searchTotalMatches = 0;
+        // Panel reset on empty query is T-F's responsibility (session reset
+        // logic). T-C only zeros the result data here.
+      });
+      return;
+    }
+
+    // The bridge global is wired up by `useRpcBridge`'s useEffect. If this
+    // slice is consulted before that hook mounts (e.g. tests, SSR-ish flows)
+    // we silently bail — T-E will handle the empty-result UI.
+    const fn = (window as unknown as {
+      __wmuxRunPaneSearch?: (q: string, r: boolean) => Promise<unknown>;
+    }).__wmuxRunPaneSearch;
+    if (!fn) return;
+
+    const result = await fn(query, regex);
+    if (result && typeof result === 'object' && !('error' in result)) {
+      const r = result as {
+        results: PaneSearchResult[];
+        truncated: boolean;
+        totalMatches: number;
+      };
+      set((state: StoreState) => {
+        state.searchQuery = query;
+        state.searchResults = r.results;
+        state.searchTruncated = r.truncated;
+        state.searchTotalMatches = r.totalMatches;
+      });
+    }
+  },
+
+  clearSearch: () =>
+    set((state: StoreState) => {
+      state.searchQuery = '';
+      state.searchResults = [];
+      state.searchTruncated = false;
+      state.searchTotalMatches = 0;
+      state.searchPanelOpen = false;
+      state.searchPanelStickyClosed = false;
+    }),
+});

--- a/src/renderer/stores/slices/searchSlice.ts
+++ b/src/renderer/stores/slices/searchSlice.ts
@@ -114,12 +114,20 @@ export const createSearchSlice: StateCreator<
     const sessionReset = !prev || lengthDeltaTooBig || notPrefixExtension;
 
     // The bridge global is wired up by `useRpcBridge`'s useEffect. If this
-    // slice is consulted before that hook mounts (e.g. tests, SSR-ish flows)
-    // we silently bail — T-E will handle the empty-result UI.
+    // slice is consulted before that hook mounts (e.g. tests, SSR-ish flows,
+    // very early load) we bail without mutating state. We log a warning
+    // (I7) so this timing edge case is visible in DevTools when debugging
+    // — sentinel error in user-visible state would be wrong here since the
+    // condition resolves itself within a tick of the bridge mounting.
     const fn = (window as unknown as {
       __wmuxRunPaneSearch?: (q: string, r: boolean) => Promise<unknown>;
     }).__wmuxRunPaneSearch;
-    if (!fn) return;
+    if (!fn) {
+      console.warn(
+        '[searchSlice] runSearch invoked before bridge mounted — query ignored',
+      );
+      return;
+    }
 
     const result = await fn(query, regex);
     if (result && typeof result === 'object' && !('error' in result)) {

--- a/src/renderer/utils/__tests__/fixtures/wrappedBuffer.ts
+++ b/src/renderer/utils/__tests__/fixtures/wrappedBuffer.ts
@@ -1,0 +1,68 @@
+/**
+ * Test fixtures for `searchInBuffer` (T-B).
+ *
+ * Provides duck-typed `SearchableBuffer` builders so tests stay decoupled
+ * from xterm.js. Each row is described by `{ text, isWrapped }`; the helper
+ * exposes the minimal surface the engine reads (`length`, `getLine`).
+ */
+import type {
+  SearchableBuffer,
+  SearchableBufferLine,
+} from '../../searchEngine';
+
+export interface FixtureRow {
+  text: string;
+  isWrapped?: boolean;
+}
+
+/**
+ * Build a minimal `SearchableBuffer` from a flat array of row descriptors.
+ * The returned object satisfies the engine's duck-typed interface — no xterm
+ * dependency.
+ */
+export function makeBuffer(rows: FixtureRow[]): SearchableBuffer {
+  return {
+    length: rows.length,
+    getLine(idx: number): SearchableBufferLine | undefined {
+      const r = rows[idx];
+      if (!r) return undefined;
+      return {
+        isWrapped: r.isWrapped ?? false,
+        translateToString: () => r.text,
+      };
+    },
+  };
+}
+
+/**
+ * Build a buffer where one row index returns `undefined` (simulating the
+ * defensive code path in `buildLogicalLines` for an unexpectedly missing row).
+ */
+export function makeBufferWithGap(
+  rows: FixtureRow[],
+  gapIdx: number,
+): SearchableBuffer {
+  return {
+    length: rows.length,
+    getLine(idx: number): SearchableBufferLine | undefined {
+      if (idx === gapIdx) return undefined;
+      const r = rows[idx];
+      if (!r) return undefined;
+      return {
+        isWrapped: r.isWrapped ?? false,
+        translateToString: () => r.text,
+      };
+    },
+  };
+}
+
+/**
+ * A 200-char logical line wrapped across 3 physical rows of 80 cols
+ * (80 + 80 + 40). Row 0 is the start of the wrap chain; rows 1–2 are
+ * marked `isWrapped: true`.
+ */
+export const WRAPPED_3ROW_LINE: FixtureRow[] = [
+  { text: 'a'.repeat(80), isWrapped: false },
+  { text: 'b'.repeat(80), isWrapped: true },
+  { text: 'c'.repeat(40), isWrapped: true },
+];

--- a/src/renderer/utils/__tests__/searchEngine.test.ts
+++ b/src/renderer/utils/__tests__/searchEngine.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from 'vitest';
+import { searchInBuffer, type SearchableBuffer } from '../searchEngine';
+import {
+  makeBuffer,
+  makeBufferWithGap,
+  WRAPPED_3ROW_LINE,
+} from './fixtures/wrappedBuffer';
+
+const HUGE_BUDGET = 1000;
+
+describe('searchInBuffer — basic guards', () => {
+  it('returns [] for an empty query', () => {
+    const buf = makeBuffer([{ text: 'hello world' }]);
+    expect(searchInBuffer(buf, '', { remainingBudget: HUGE_BUDGET })).toEqual([]);
+  });
+
+  it('returns [] for an empty buffer', () => {
+    const buf = makeBuffer([]);
+    expect(searchInBuffer(buf, 'anything', { remainingBudget: HUGE_BUDGET })).toEqual([]);
+  });
+
+  it('returns [] when remainingBudget is 0', () => {
+    const buf = makeBuffer([{ text: 'hello world' }]);
+    expect(searchInBuffer(buf, 'hello', { remainingBudget: 0 })).toEqual([]);
+  });
+});
+
+describe('searchInBuffer — single-row substring match', () => {
+  it('matches a substring on a single non-wrapped row', () => {
+    const buf = makeBuffer([
+      { text: 'unrelated' },
+      { text: 'the quick brown fox' },
+      { text: 'final' },
+    ]);
+    const matches = searchInBuffer(buf, 'brown', { remainingBudget: HUGE_BUDGET });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].text).toBe('the quick brown fox');
+    expect(matches[0].physicalBaseY).toBe(1);
+  });
+
+  it('returns no matches when the substring is absent (single-row miss)', () => {
+    const buf = makeBuffer([{ text: 'the quick brown fox' }]);
+    const matches = searchInBuffer(buf, 'cat', { remainingBudget: HUGE_BUDGET });
+    expect(matches).toEqual([]);
+  });
+});
+
+describe('searchInBuffer — wrap-coalescing', () => {
+  it('coalesces a 3-row wrapped logical line and reports ONE match for content in the middle row', () => {
+    const buf = makeBuffer(WRAPPED_3ROW_LINE);
+    const matches = searchInBuffer(buf, 'bbbbb', { remainingBudget: HUGE_BUDGET });
+    // Must be 1 match, NOT 3 — the wrap-coalescing collapses physical rows
+    // 0..2 into a single logical line of 200 chars.
+    expect(matches).toHaveLength(1);
+    expect(matches[0].lineIdx).toBe(0);
+    // physicalBaseY points at the FIRST physical row of the chain so
+    // `terminal.scrollToLine` lands on the start of the wrap.
+    expect(matches[0].physicalBaseY).toBe(0);
+  });
+
+  it('matches a query that spans the boundary between two wrapped physical rows', () => {
+    const buf = makeBuffer(WRAPPED_3ROW_LINE);
+    // Last 5 'b's of row 1 + first 5 'c's of row 2 — only matchable if
+    // wrap-coalescing concatenates the row texts before searching.
+    const matches = searchInBuffer(buf, 'bbbbbccccc', { remainingBudget: HUGE_BUDGET });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].lineIdx).toBe(0);
+    expect(matches[0].physicalBaseY).toBe(0);
+  });
+
+  it('treats two consecutive non-wrapped rows as separate logical lines', () => {
+    const buf = makeBuffer([
+      { text: 'line one with foo' },
+      { text: 'line two with foo', isWrapped: false },
+    ]);
+    const matches = searchInBuffer(buf, 'foo', { remainingBudget: HUGE_BUDGET });
+    expect(matches).toHaveLength(2);
+    expect(matches[0].physicalBaseY).toBe(0);
+    expect(matches[1].physicalBaseY).toBe(1);
+  });
+});
+
+describe('searchInBuffer — 500 char text cap', () => {
+  it('truncates the matched logical line text to 500 chars', () => {
+    // 800-char logical line — 'X' followed by 'needle' followed by 'Y' fillers.
+    // We put the needle near the start so the 500-char prefix still contains it.
+    const longText = 'a'.repeat(50) + 'needle' + 'a'.repeat(800 - 50 - 6);
+    expect(longText.length).toBe(800);
+    const buf = makeBuffer([{ text: longText }]);
+    const matches = searchInBuffer(buf, 'needle', { remainingBudget: HUGE_BUDGET });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].text.length).toBe(500);
+    expect(matches[0].text.startsWith('a'.repeat(50) + 'needle')).toBe(true);
+  });
+
+  it('truncates context lines to 500 chars each', () => {
+    const longContext = 'c'.repeat(800);
+    const buf = makeBuffer([
+      { text: longContext },
+      { text: 'needle here' },
+      { text: longContext },
+    ]);
+    const matches = searchInBuffer(buf, 'needle', { remainingBudget: HUGE_BUDGET });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].contextBefore[0].length).toBe(500);
+    expect(matches[0].contextAfter[0].length).toBe(500);
+  });
+});
+
+describe('searchInBuffer — context lines', () => {
+  it('returns 2 context lines on each side by default', () => {
+    const buf = makeBuffer([
+      { text: 'before-2' },
+      { text: 'before-1' },
+      { text: 'match here' },
+      { text: 'after-1' },
+      { text: 'after-2' },
+    ]);
+    const matches = searchInBuffer(buf, 'match', { remainingBudget: HUGE_BUDGET });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].contextBefore).toEqual(['before-2', 'before-1']);
+    expect(matches[0].contextAfter).toEqual(['after-1', 'after-2']);
+  });
+
+  it('returns empty context arrays when contextLines = 0', () => {
+    const buf = makeBuffer([
+      { text: 'before' },
+      { text: 'match here' },
+      { text: 'after' },
+    ]);
+    const matches = searchInBuffer(buf, 'match', {
+      remainingBudget: HUGE_BUDGET,
+      contextLines: 0,
+    });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].contextBefore).toEqual([]);
+    expect(matches[0].contextAfter).toEqual([]);
+  });
+
+  it('clamps context at the start of the buffer', () => {
+    const buf = makeBuffer([
+      { text: 'match here' },
+      { text: 'after-1' },
+      { text: 'after-2' },
+    ]);
+    const matches = searchInBuffer(buf, 'match', { remainingBudget: HUGE_BUDGET });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].contextBefore).toEqual([]);
+    expect(matches[0].contextAfter).toEqual(['after-1', 'after-2']);
+  });
+
+  it('clamps context at the end of the buffer', () => {
+    const buf = makeBuffer([
+      { text: 'before-2' },
+      { text: 'before-1' },
+      { text: 'match here' },
+    ]);
+    const matches = searchInBuffer(buf, 'match', { remainingBudget: HUGE_BUDGET });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].contextBefore).toEqual(['before-2', 'before-1']);
+    expect(matches[0].contextAfter).toEqual([]);
+  });
+});
+
+describe('searchInBuffer — regex', () => {
+  it('matches when regex: true and pattern is valid', () => {
+    const buf = makeBuffer([
+      { text: 'info ok' },
+      { text: 'error 42' },
+      { text: 'warn 7' },
+    ]);
+    const matches = searchInBuffer(buf, '^err.*\\d+$', {
+      remainingBudget: HUGE_BUDGET,
+      regex: true,
+    });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].text).toBe('error 42');
+  });
+
+  it('throws SyntaxError (not generic Error) for an invalid regex pattern', () => {
+    const buf = makeBuffer([{ text: 'anything' }]);
+    let thrown: unknown;
+    try {
+      searchInBuffer(buf, '[unclosed', {
+        remainingBudget: HUGE_BUDGET,
+        regex: true,
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(SyntaxError);
+  });
+});
+
+describe('searchInBuffer — budget enforcement', () => {
+  it('stops early when remainingBudget is reached', () => {
+    const rows = Array.from({ length: 5 }, () => ({ text: 'needle here' }));
+    const buf = makeBuffer(rows);
+    const matches = searchInBuffer(buf, 'needle', { remainingBudget: 2 });
+    expect(matches).toHaveLength(2);
+    expect(matches[0].physicalBaseY).toBe(0);
+    expect(matches[1].physicalBaseY).toBe(1);
+  });
+});
+
+describe('searchInBuffer — perBufferLineCap', () => {
+  it('only scans up to perBufferLineCap physical rows', () => {
+    // 100 rows, all containing 'needle' — but cap=10 means rows 0..9 only.
+    const rows = Array.from({ length: 100 }, () => ({ text: 'needle here' }));
+    const buf = makeBuffer(rows);
+    const matches = searchInBuffer(buf, 'needle', {
+      remainingBudget: HUGE_BUDGET,
+      perBufferLineCap: 10,
+    });
+    expect(matches).toHaveLength(10);
+    // Last match must come from physical row index < 10.
+    expect(matches[matches.length - 1].physicalBaseY).toBeLessThan(10);
+  });
+});
+
+describe('searchInBuffer — defensive paths', () => {
+  it('skips an undefined row gracefully without throwing', () => {
+    const rows = [
+      { text: 'first match', isWrapped: false },
+      { text: 'GAP-PLACEHOLDER', isWrapped: false }, // index 1 returns undefined
+      { text: 'last match', isWrapped: false },
+    ];
+    const buf: SearchableBuffer = makeBufferWithGap(rows, 1);
+    expect(() =>
+      searchInBuffer(buf, 'match', { remainingBudget: HUGE_BUDGET }),
+    ).not.toThrow();
+    const matches = searchInBuffer(buf, 'match', { remainingBudget: HUGE_BUDGET });
+    // Both real rows still yield matches; the gap row is skipped.
+    expect(matches).toHaveLength(2);
+    expect(matches[0].physicalBaseY).toBe(0);
+    expect(matches[1].physicalBaseY).toBe(2);
+  });
+});
+
+describe('searchInBuffer — result ordering', () => {
+  it('returns results in ascending physicalBaseY order (forward scan)', () => {
+    const rows = [
+      { text: 'no' },
+      { text: 'yes-A' },
+      { text: 'no' },
+      { text: 'yes-B' },
+      { text: 'no' },
+      { text: 'yes-C' },
+    ];
+    const buf = makeBuffer(rows);
+    const matches = searchInBuffer(buf, 'yes', { remainingBudget: HUGE_BUDGET });
+    expect(matches.map((m) => m.physicalBaseY)).toEqual([1, 3, 5]);
+  });
+});

--- a/src/renderer/utils/searchEngine.ts
+++ b/src/renderer/utils/searchEngine.ts
@@ -33,7 +33,14 @@ const DEFAULT_CONTEXT_LINES = 2;
 const DEFAULT_BUFFER_LINE_CAP = 20_000;
 
 export interface SearchOpts {
-  /** Treat `query` as a JS RegExp pattern. Invalid patterns throw `SyntaxError`. */
+  /**
+   * Treat `query` as a JS RegExp pattern. Invalid patterns throw `SyntaxError`.
+   *
+   * Regex semantics: the pattern is fed to `new RegExp(query)` with NO flags.
+   * That means matching is case-sensitive, unicode mode is off, and inline
+   * flag groups like `(?i)` are NOT supported by JavaScript's RegExp — use
+   * character classes for case-insensitivity (e.g. `[Ee]rror`) instead.
+   */
   regex?: boolean;
   /** Logical lines kept on each side of a match. Defaults to 2. */
   contextLines?: number;
@@ -166,6 +173,11 @@ function capLine(s: string): string {
  * - Stops early once `remainingBudget` matches are produced.
  * - Returns `[]` for an empty `query` rather than throwing — the RPC layer
  *   (T-A) is responsible for rejecting empty queries before this is called.
+ *
+ * Regex flags: `new RegExp(query)` is invoked with NO flags — case-sensitive,
+ * unicode off. JavaScript's RegExp does NOT honor inline flag groups like
+ * `(?i)`; that syntax raises a SyntaxError. To do case-insensitive matching
+ * use a character class (e.g. `[Ee]rror`).
  *
  * @throws SyntaxError when `opts.regex` is true and `query` is not a valid
  *   JS regex pattern. The native `RegExp` constructor's error is allowed to

--- a/src/renderer/utils/searchEngine.ts
+++ b/src/renderer/utils/searchEngine.ts
@@ -1,0 +1,241 @@
+/**
+ * Pure search engine over an xterm.js Buffer-shaped input.
+ *
+ * Used by the cross-pane search feature (T-C wires this up). Kept import-free
+ * (no xterm/electron/react/window) so it can be unit-tested in vitest's
+ * default `node` environment and runs deterministically for any conforming
+ * duck-typed buffer.
+ *
+ * Wrap-coalescing
+ * ---------------
+ * xterm represents a soft-wrapped line as N physical rows where the 2..N
+ * rows have `isWrapped === true`. For human-facing search ("find this URL
+ * even though it spans 3 visual rows"), we coalesce those rows into a single
+ * logical line before matching. The match's `physicalBaseY` keeps the index
+ * of the FIRST physical row so callers can `terminal.scrollToLine(...)`.
+ *
+ * Caps applied (in this order)
+ * ----------------------------
+ * 1. `perBufferLineCap` on PHYSICAL row scan (default 20_000) — protects
+ *    against runaway scrollback.
+ * 2. `remainingBudget` on returned matches — caller decrements between panes
+ *    for breadth-first cross-pane behavior.
+ * 3. 500 char truncation on match text and each context line.
+ */
+
+/** Per-line truncation cap. Applied to match text and every context line. */
+const LINE_CHAR_CAP = 500;
+
+/** Default surrounding logical lines kept on each side of a match. */
+const DEFAULT_CONTEXT_LINES = 2;
+
+/** Default ceiling on physical rows scanned per buffer. */
+const DEFAULT_BUFFER_LINE_CAP = 20_000;
+
+export interface SearchOpts {
+  /** Treat `query` as a JS RegExp pattern. Invalid patterns throw `SyntaxError`. */
+  regex?: boolean;
+  /** Logical lines kept on each side of a match. Defaults to 2. */
+  contextLines?: number;
+  /** Hard cap on physical rows scanned. Defaults to 20_000. */
+  perBufferLineCap?: number;
+  /**
+   * Hard cap on matches returned. Caller (T-C) decrements between panes so
+   * the global 200-result cap is enforced breadth-first across panes.
+   */
+  remainingBudget: number;
+}
+
+export interface MatchInBuffer {
+  /** Logical line index (after wrap-coalescing). */
+  lineIdx: number;
+  /**
+   * Original buffer index of the FIRST physical row in the logical line.
+   * Suitable input for `terminal.scrollToLine(physicalBaseY)`.
+   */
+  physicalBaseY: number;
+  /** Matched logical line text, truncated to 500 chars. */
+  text: string;
+  /** Up to `contextLines` logical lines BEFORE the match, each 500-char capped. */
+  contextBefore: string[];
+  /** Up to `contextLines` logical lines AFTER the match, each 500-char capped. */
+  contextAfter: string[];
+}
+
+/**
+ * Minimal xterm.js BufferLine surface area we depend on. Declared locally
+ * so this module stays import-free and easy to test with plain objects.
+ */
+export interface SearchableBufferLine {
+  /**
+   * `true` when this physical row is the continuation of a soft-wrapped line
+   * that started on the previous row.
+   */
+  isWrapped: boolean;
+  /**
+   * Returns the row's text. xterm strips ANSI/SGR sequences and (when
+   * `trimRight` is true) trailing whitespace produced by the terminal grid.
+   */
+  translateToString(trimRight: boolean): string;
+}
+
+/** Minimal xterm.js Buffer surface area we depend on. */
+export interface SearchableBuffer {
+  /** Total physical row count (scrollback + viewport). */
+  length: number;
+  /** Returns the row at `idx`, or `undefined` if out of range. */
+  getLine(idx: number): SearchableBufferLine | undefined;
+}
+
+/** A coalesced logical line — one match candidate. */
+interface LogicalLine {
+  text: string;
+  /** Index of the first physical row that composes this logical line. */
+  physicalBaseY: number;
+}
+
+/**
+ * Walk the buffer once, joining wrapped continuations into logical lines.
+ *
+ * Stops at `maxPhysicalRows` regardless of mid-wrap state — a wrapped chain
+ * crossing the cap is truncated at the cap boundary. This is the explicit
+ * trade-off documented in T-B's spec.
+ */
+function buildLogicalLines(
+  buffer: SearchableBuffer,
+  maxPhysicalRows: number,
+): LogicalLine[] {
+  const lines: LogicalLine[] = [];
+  const scanLimit = Math.min(buffer.length, maxPhysicalRows);
+
+  let currentText = '';
+  let currentBaseY = -1;
+
+  for (let i = 0; i < scanLimit; i++) {
+    const row = buffer.getLine(i);
+    if (!row) {
+      // Defensive: if a row is unexpectedly missing, flush any in-progress
+      // logical line and resume — we don't want to silently merge across a
+      // gap, since `isWrapped` is unobservable for the missing row.
+      if (currentBaseY !== -1) {
+        lines.push({ text: currentText, physicalBaseY: currentBaseY });
+        currentText = '';
+        currentBaseY = -1;
+      }
+      continue;
+    }
+
+    const rowText = row.translateToString(true);
+
+    // Row 0 is by definition the start of a logical line; xterm should never
+    // mark it `isWrapped`, but we treat it as a fresh start defensively.
+    const isContinuation = i > 0 && row.isWrapped;
+
+    if (isContinuation && currentBaseY !== -1) {
+      currentText += rowText;
+    } else {
+      // Flush the previous logical line (if any) before starting a new one.
+      if (currentBaseY !== -1) {
+        lines.push({ text: currentText, physicalBaseY: currentBaseY });
+      }
+      currentText = rowText;
+      currentBaseY = i;
+    }
+  }
+
+  if (currentBaseY !== -1) {
+    lines.push({ text: currentText, physicalBaseY: currentBaseY });
+  }
+
+  return lines;
+}
+
+/** Cap a single string to `LINE_CHAR_CAP` chars. */
+function capLine(s: string): string {
+  return s.length > LINE_CHAR_CAP ? s.slice(0, LINE_CHAR_CAP) : s;
+}
+
+/**
+ * Search a buffer for matches and return logical-line hits with context.
+ *
+ * Behavior summary (full spec in module docstring):
+ * - Coalesces wrapped physical rows into logical lines.
+ * - Substring match by default; pass `regex: true` for `new RegExp(query)`.
+ * - Returns matches in ascending `physicalBaseY` order — caller does not
+ *   re-sort.
+ * - Stops early once `remainingBudget` matches are produced.
+ * - Returns `[]` for an empty `query` rather than throwing — the RPC layer
+ *   (T-A) is responsible for rejecting empty queries before this is called.
+ *
+ * @throws SyntaxError when `opts.regex` is true and `query` is not a valid
+ *   JS regex pattern. The native `RegExp` constructor's error is allowed to
+ *   propagate so callers can present it verbatim to the user.
+ */
+export function searchInBuffer(
+  buffer: SearchableBuffer,
+  query: string,
+  opts: SearchOpts,
+): MatchInBuffer[] {
+  // Empty query is a no-op — guard mirrors T-A's RPC validation but stays
+  // defensive in case the engine is invoked from another caller.
+  if (query.length === 0) return [];
+
+  const budget = opts.remainingBudget;
+  if (budget <= 0) return [];
+
+  const contextLines =
+    typeof opts.contextLines === 'number' && opts.contextLines >= 0
+      ? Math.floor(opts.contextLines)
+      : DEFAULT_CONTEXT_LINES;
+  const perBufferLineCap =
+    typeof opts.perBufferLineCap === 'number' && opts.perBufferLineCap >= 0
+      ? Math.floor(opts.perBufferLineCap)
+      : DEFAULT_BUFFER_LINE_CAP;
+
+  // `new RegExp` throws SyntaxError for invalid patterns; we deliberately
+  // let it bubble per the engine contract (UI catches and styles the input).
+  const matcher: (text: string) => boolean = opts.regex
+    ? (() => {
+        const re = new RegExp(query);
+        return (text: string) => re.test(text);
+      })()
+    : (text: string) => text.includes(query);
+
+  const logical = buildLogicalLines(buffer, perBufferLineCap);
+  if (logical.length === 0) return [];
+
+  const results: MatchInBuffer[] = [];
+
+  for (let i = 0; i < logical.length; i++) {
+    const line = logical[i];
+    if (!matcher(line.text)) continue;
+
+    const before: string[] = [];
+    if (contextLines > 0) {
+      const start = Math.max(0, i - contextLines);
+      for (let j = start; j < i; j++) {
+        before.push(capLine(logical[j].text));
+      }
+    }
+
+    const after: string[] = [];
+    if (contextLines > 0) {
+      const end = Math.min(logical.length, i + 1 + contextLines);
+      for (let j = i + 1; j < end; j++) {
+        after.push(capLine(logical[j].text));
+      }
+    }
+
+    results.push({
+      lineIdx: i,
+      physicalBaseY: line.physicalBaseY,
+      text: capLine(line.text),
+      contextBefore: before,
+      contextAfter: after,
+    });
+
+    if (results.length >= budget) break;
+  }
+
+  return results;
+}

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -25,6 +25,7 @@ export type RpcMethod =
   | 'pane.list'
   | 'pane.focus'
   | 'pane.split'
+  | 'pane.search'
   | 'input.send'
   | 'input.sendKey'
   | 'input.readScreen'
@@ -110,6 +111,7 @@ export const ALL_RPC_METHODS = [
   'pane.list',
   'pane.focus',
   'pane.split',
+  'pane.search',
   'input.send',
   'input.sendKey',
   'input.readScreen',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -81,6 +81,13 @@ export interface PaneSearchResult {
   surfaceId: string;
   ptyId: string;
   lineIdx: number;             // logical line idx (post wrap-coalesce — see T-B)
+  /**
+   * Physical row index of the FIRST row composing the matched logical line.
+   * This is the value to feed into `xterm.scrollToLine(...)` — feeding
+   * `lineIdx` instead would land on the wrong row when wrap-coalescing
+   * collapsed multiple physical rows into one logical line. (I6 fix.)
+   */
+  physicalBaseY: number;
   text: string;                // matched logical line, ≤500 chars
   contextBefore: string[];     // up to N (default 2) lines, each ≤500 chars
   contextAfter: string[];

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -75,6 +75,26 @@ export interface Workspace {
   companyDeptName?: string;
 }
 
+// === Cross-Pane Search (T-A) ===
+export interface PaneSearchResult {
+  paneId: string;
+  surfaceId: string;
+  ptyId: string;
+  lineIdx: number;             // logical line idx (post wrap-coalesce — see T-B)
+  text: string;                // matched logical line, ≤500 chars
+  contextBefore: string[];     // up to N (default 2) lines, each ≤500 chars
+  contextAfter: string[];
+  paneLabel?: string;          // optional — populated when PR #16 metadata is present
+}
+
+export interface PaneSearchResponse {
+  resultShapeVersion: 1;       // literal type, not number — for exhaustive switches
+  results: PaneSearchResult[];
+  truncated: boolean;
+  totalMatches: number;
+  workspaceId: string;
+}
+
 // === Notification ===
 export type NotificationType = 'info' | 'warning' | 'error' | 'agent';
 


### PR DESCRIPTION
## Summary

New feature — search across all live terminal panes in the current workspace. wmux's first cross-pane primitive: `Ctrl+F` → `All Panes` toggle → results in dropdown (≤10) or auto-expanding panel (>10) with progressive disclosure. Also exposed as MCP tool `wmux_search_panes` so AI agents can autonomously reason "which pane has the JWT error" instead of polling each pane.

Built via team mode (Large): Phase 0 → 1 (architect-reviewer) → 2 (code-reviewer) → 3 (5 parallel teammates) → 4 (code-reviewer + fix cycle) → 5.

## What's in

- **`pane.search` RPC** + `PaneSearchResult` / `PaneSearchResponse` types (`resultShapeVersion: 1` literal)
- **Pure search engine** (`searchInBuffer`) — wrap-coalescing via `BufferLine.isWrapped`, regex support (case-sensitive by default — see notes), per-buffer 20k line cap, `remainingBudget` for breadth-first cross-pane truncation
- **MCP tool** `wmux_search_panes(query, regex?)` — auto-scoped to caller's workspaceId
- **SearchBar extension** — `All Panes` toggle, regex toggle, inline dropdown for ≤10 results, "open panel" CTA for >10, red border + tooltip on invalid regex
- **SearchResultsPanel** — bottom drawer, click-to-jump (`scrollToLine(physicalBaseY)`), hysteresis state machine (open >10 / close ≤5, 6-10 dead zone, sticky bit until session reset)
- **44 unit tests** — engine wrap-coalescing, slice hysteresis (length-delta-2 reset, prefix-extension preserves sticky), RPC validation
- **i18n** — 4 locales (en/ko/ja/zh), 10 keys total

## Design decisions captured (`decisions.md`)

D1-D9 + N1-N5 from architect review:
- v1 = current workspace only (cross-workspace deferred to v2 with explicit setting + RPC-layer caller-identity gate)
- On-demand grep over xterm buffer (not background indexing — memory cost 0)
- Result shape with `resultShapeVersion: 1` for forward compat
- Hysteresis with sticky bit for progressive disclosure
- 200-result cap, 500-char per-line cap

## Security / correctness fixes from Phase 4 review

After 1 critical + 7 important findings from internal code review:
1. **Workspace scope leak** — handler now resolves `params.workspaceId` first (external MCP) and falls back to active workspace (internal UI). Same class as v2.7.2 `mcp.claimWorkspace` fix.
2. **`truncated` flag** — flips when budget exhausted with panes left to scan, not "always false."
3. **Panel mount** — gated at AppLayout level (`{searchPanelOpen && ...}`) so subscriptions don't fire when closed.
4. **i18n completeness** — all 4 locales got `panelTitle`, `matchesCount`, `matchesCountTruncated`, `unlabeled`.
5. **Sticky preservation** — SearchBar unmount no longer wipes panel state; D8 sticky model intact.
6. **`physicalBaseY` plumbed** — clicks scroll to correct physical row in wrapped lines (not logical line).
7. **Bridge-missing diagnostic** — `console.warn` on early-load timing edge instead of silent bail.
8. **Korean orthography** — "모든 팬" → "모든 창" (consistent with existing `pane.empty` "빈 창").

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — **833/833** pass (789 baseline + 44 new)
- [x] `npm run build:mcp` — clean
- [ ] Manual smoke (recommended before merge):
  - Open 3 panes, run `tail -f` of different logs in each → `Ctrl+F` → All Panes → search "ERROR" → results from multiple panes appear in dropdown.
  - Generate >10 matches → panel auto-expands. Click result → focus jumps to that pane + scrolls to the matched line.
  - Close panel via × → search again with similar query (within 2 chars) → panel STAYS closed (sticky). Type a totally different query → panel reopens (session reset).
  - Invalid regex (e.g. `[unclosed`) with regex toggle ON → red border + tooltip with SyntaxError message; no toast.
  - External Claude Code: `wmux_search_panes({query: "TODO"})` → results scoped to caller's workspace only.

## Out of scope (deferred to v2)

- **Cross-workspace search** — needs explicit setting (default off) + RPC-layer caller-identity gate; security boundary requires more design.
- **Dead session scrollback dump search** — needs file I/O + dump format parsing.
- **Background indexing** — current 50ms scan over 50k lines is fast enough; revisit only if perf complaints.
- **Regex flag UI** — `(?i)` not supported by JS RegExp; users use `[Ee]rror` for now.

## Stats

- 22 files changed, +2446 / -374
- 10 commits across 7 tasks (T-A through T-G + 1 fix commit)
- ~2 wall-clock hours via team mode (Large path with parallel teammates)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via team mode