### PR TITLE
fix(daemon): raise MAX_SESSIONS 50 → 200

### DIFF
--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -87,11 +87,14 @@ export class DaemonSessionManager extends EventEmitter {
     }
 
     // Guard against resource exhaustion from unbounded session creation.
-    // The error message is user-facing — it surfaces through createSession
-    // RPC errors all the way to the renderer. Phrase it as an action the
-    // user can actually take so a 50-session lockout doesn't read as a
-    // generic "unknown error" toast.
-    const MAX_SESSIONS = 50;
+    // The error message is user-facing — phrase it as an action the user
+    // can actually take so a cap lockout doesn't read as a generic toast.
+    //
+    // 50 → 200: the v2.8.1 soft cap (MAX_RECOVER_SESSIONS=40) only gates
+    // startup recovery. Detached sessions still accumulate at runtime
+    // because the daemon keeps them alive across X-closes, so 50 is too
+    // tight for multi-workspace users. Soft-cap policy unchanged.
+    const MAX_SESSIONS = 200;
     if (this.sessions.size >= MAX_SESSIONS) {
       throw new Error(
         `Cannot create new terminal: ${MAX_SESSIONS} active sessions already running. ` +

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -305,16 +305,15 @@ describe('DaemonSessionManager', () => {
 
   // v2.8.1 hotfix: actionable error at MAX_SESSIONS (Bug 1)
   it('throws an actionable error when the session cap is reached', () => {
-    // Create the first 50 sessions successfully.
-    for (let i = 0; i < 50; i++) {
+    for (let i = 0; i < 200; i++) {
       manager.createSession({ id: `cap-${i}`, cmd: 'cmd.exe', cwd: '.' });
     }
-    // The 51st must fail with a message the UI can show verbatim. The
+    // The 201st must fail with a message the UI can show verbatim. The
     // pre-v2.8.1 message was "Maximum session limit (50) reached" which
     // surfaced as a generic "unknown error" toast in the renderer.
     expect(() =>
-      manager.createSession({ id: 'cap-51', cmd: 'cmd.exe', cwd: '.' }),
-    ).toThrow(/Cannot create new terminal: 50 active sessions already running/);
+      manager.createSession({ id: 'cap-201', cmd: 'cmd.exe', cwd: '.' }),
+    ).toThrow(/Cannot create new terminal: 200 active sessions already running/);
   });
 
   // v2.8.1 hotfix: deferred output mode for recovered sessions (Bug 2)

--- a/src/daemon/__tests__/v281BrickRecovery.integration.test.ts
+++ b/src/daemon/__tests__/v281BrickRecovery.integration.test.ts
@@ -131,9 +131,9 @@ describe('v2.8.1 brick recovery — full Bug 1 flow', () => {
     }
 
     // The combined effect: the v2.8.0 lockout is broken on first
-    // launch — only 40 PTYs spawn during recovery, the daemon's
-    // hard MAX_SESSIONS=50 cap retains 10 free slots for new panes.
-    expect(recoverableIds.size).toBeLessThan(50);
+    // launch — only 40 PTYs spawn during recovery, leaving headroom
+    // for new panes well below MAX_SESSIONS.
+    expect(recoverableIds.size).toBeLessThan(200);
   });
 
   it('a 12-session healthy machine recovers all 12 unchanged', () => {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -16,7 +16,7 @@ import type { DaemonEvent, DaemonCreateSessionParams, DaemonSessionIdParams, Dae
 const wmuxDir = getWmuxDir();
 
 // Recovery soft cap. The hard PTY ceiling lives in DaemonSessionManager
-// (MAX_SESSIONS = 50). Recovery has its own lower bound so a state file
+// (MAX_SESSIONS = 200). Recovery has its own lower bound so a state file
 // inflated by past v2.8.0 accumulation can't consume every slot before
 // the user creates their first new pane. Sessions beyond this cap stay
 // suspended in state.sessions and become recoverable on a subsequent


### PR DESCRIPTION
## 배경

저는 wmux를 사용할 때 보통 **4–5개의 워크스페이스**를 열어두고, split pane도 꽤 많이 사용하는 편입니다.

`v2.8.1`로 업그레이드한 이후에도 다음과 같은 문제가 반복적으로 발생했습니다.

- `Ctrl+T`가 무반응이 됨
- 특정 워크스페이스의 터미널이 빈 상태로 열림

로컬 환경에서 디버깅해본 결과, 원인은 hard cap에 도달하는 것이었습니다.

```ts
MAX_SESSIONS = 50
```

다중 워크스페이스 레이아웃을 쓰는 입장에서 `50`은 생각보다 금방 차더라고요.

---

## What and Why

이번 PR은 다음 값을 상향합니다.

```ts
MAX_SESSIONS: 50 → 200
```

기존의 soft cap 및 TTL cleanup 정책은 그대로 유지됩니다.

`v2.8.1`에서는 startup brick 문제는 해결되었지만, runtime accumulation 문제는 여전히 남아있습니다.

`MAX_RECOVER_SESSIONS = 40`은 daemon 재시작 시 recovery 개수만 제한할 뿐, 실제 hard cap인 `50` 자체는 그대로 유지됩니다.

daemon은 wmux 창을 `X` 버튼으로 닫아도 detached session을 유지하는 영속 프로세스이기 때문에, 워크스페이스 사용량이 많은 유저의 경우 며칠만 지나도 다시 cap에 도달하게 됩니다.

---

## 실측 결과 (로컬 머신)

`sessions.json` 기준:

```
총 entries: 50
attached: 13
detached: 37
suspended: 0
```

- 모든 PID는 살아있는 상태 (`tasklist` 확인)
- renderer surface 18개 중 실제 `ptyId` 매핑이 남아있는 것은 8개뿐

cap에 도달하면 `pty.create`가 throw 됩니다. 그런데 현재 renderer의 `Ctrl+T` 핸들러는 `.catch()` 없이 결과를 바로 dereference하고 있어서 rejection이 조용히 묻혀버립니다. 사용자 입장에서는 단축키가 그냥 "아무 반응 없는 것처럼" 보이게 되는 구조입니다.

---

## 결과

로컬에서 `MAX_SESSIONS = 200`으로 패치한 뒤 동일 문제가 재발하지 않았고, 안정적으로 동작했습니다.

---

## 변경 사항

- `src/daemon/DaemonSessionManager.ts` — `MAX_SESSIONS` 50 → 200, 상향 이유 주석 추가
- `src/daemon/index.ts` — `MAX_RECOVER_SESSIONS` 주변 주석의 숫자 참조만 동기화 (cap 자체는 40 유지)
- `src/daemon/__tests__/DaemonSessionManager.test.ts` — cap assertion 201번째에서 throw로 수정
- `src/daemon/__tests__/v281BrickRecovery.integration.test.ts` — `toBeLessThan(50)` → `toBeLessThan(200)`

---

## Checklist

- [x] `npx tsc --noEmit` 통과
- [x] `npm test` 통과
  - daemon: `299/299`
  - 전체 930개 중 `PortAllocator` 관련 1건 실패는 `v2.8.1` base에서도 동일하게 재현되는 환경 이슈 (포트 점유 충돌)이며, 본 변경과 무관
- [x] 신규 변경사항에 대한 테스트 포함
- [x] Commit message 규칙 준수: `fix(daemon): raise MAX_SESSIONS 50 → 200`

---

## 참고

`v2.8.0` 대응 당시 [issue #22 코멘트](https://github.com/openwong2kim/wmux/issues/22#issuecomment-4413945866)에서도 `MAX_SESSIONS = 200` patch를 언급했었습니다. `v2.8.1`에서는 soft cap = 40 방향으로 정리되면서 hard cap 상향 자체는 upstream에 반영되지 않은 것 같아 이번 PR로 제안드립니다.

---

## 마치며

저처럼 워크스페이스를 여러 개 열어두고 쓰는 분들께는 이 변경이 도움이 될 것 같아 올려봤습니다.

orphan session GC 같은 근본적인 해결도 고민해봤는데, 메인테이너의 설계 방향(detached 세션은 재연결 대상이지 정리 대상이 아니다)과 어긋날 것 같아 이번에는 건드리지 않았습니다. 단순히 상한선이 너무 낮다는 점만 건드린 보수적인 변경입니다.

별도 이슈를 먼저 열지 않은 이유는, 수정 범위가 상수 하나라 PR만으로도 충분히 의도 전달이 될 것 같았기 때문입니다.

머지하시기 전에 의도와 맞는지 코멘트 남겨주시면 감사하겠습니다. 만약 `50` 유지가 의도적인 결정이셨다면 말씀해주세요 — orphan session 처리 방향으로 별도 논의를 이어가고 싶습니다.
