### PR TITLE
fix(v2.8.2): RESOURCE_EXHAUSTED toast + Electron envelope match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.2] — 2026-05-11 — Session Cap Headroom + Silent-Failure Fix
+
+@alphabeen 이 v2.8.1 출시 직후 PR #25 로 보고한 두 문제를 한 patch 에 묶는다. v2.8.1 의 startup brick 픽스 이후에도 **runtime accumulation** 시나리오 (X close 후 daemon 이 유지하는 detached 세션이 며칠에 걸쳐 누적) 에서는 hard cap 50 에 다시 도달했고, 더 나쁜 건 cap throw 가 renderer 의 `Ctrl+T` 핸들러에서 silent 하게 묻혀 단축키가 무반응처럼 보이던 결함이다. v2.8.1 사용자는 즉시 업그레이드 권장.
+
+### Fixed
+
+- **데몬 세션 hard cap 50 → 200 상향** — #25, @alphabeen. v2.8.0 의 세션 영속화 이후 cap 의 의미가 "한 세션 동안 최대 동시 PTY" → "lifetime 누적 detached PTY 총합" 으로 바뀐 결과, multi-workspace + 빈번한 split 사용자는 며칠 내 50 에 재도달. 50 자체는 [commit 989dd8a](https://github.com/openwong2kim/wmux/commit/989dd8a) 의 보안 하드닝 단계에서 정한 DoS 휴리스틱이었고 200 도 같은 카테고리 안. soft cap 40 (recovery) / 7-day suspended TTL 정책은 무변경. 헤드룸 10 → 160. 근본 해결 (orphan detached GC) 은 v2.9 트랙으로 별도 검토. 구현: `src/daemon/DaemonSessionManager.ts`, `src/daemon/index.ts` 주석 동기화.
+- **`pty.create` rejection 이 묻혀 단축키 무반응처럼 보이던 회귀** — @alphabeen 이 PR #25 description 에서 짚어준 두 번째 문제. cap 도달 시 daemon 이 actionable 에러 (`Cannot create new terminal: 200 active sessions already running. Close some panes (or restart wmux) and try again.`) 를 throw 하는데 renderer 의 세 호출 지점 (`useKeyboard` Ctrl+T 핸들러 / `AppLayout` empty-leaf 자동 PTY / `FloatingPane` 첫 열림) 모두 `.then()` 만 달고 `.catch()` 누락 (또는 silent catch) 이라 rejection 이 묻히고 단축키가 무반응처럼 보였다. v2.8.1 Bug 1 의 actionable error 의도가 무력화되던 결함.
+  - **신규 IPC 에러 코드 `RESOURCE_EXHAUSTED`** — `wrapHandler` 의 `classifyError` 가 cap 메시지 패턴 (`cannot create new terminal` + `active sessions already running`) 을 감지해 분류. 메시지에 `[RESOURCE_EXHAUSTED]` prefix 가 stamp 되어 renderer 가 분기 가능.
+  - **`useIpc` 매핑** — `DEFAULT_MESSAGES['RESOURCE_EXHAUSTED']` = "터미널 세션 한도에 도달했습니다. 일부 pane을 닫거나 wmux를 재시작한 뒤 다시 시도해주세요.", level `'warn'`. UNKNOWN 으로 매핑되어 generic "알 수 없는 오류" 토스트가 뜨던 path 차단.
+  - **세 호출 지점 모두 `ipcInvoke` wrap 으로 통일** — `useKeyboard` Ctrl+T (ref 패턴으로 once-on-mount effect 안에서 사용), `AppLayout` empty-leaf 자동 PTY effect, `FloatingPane` 첫 PTY 생성. 모두 `result.ok` 분기 + 실패 시 toast 자동 게재.
+  - 구현: `src/main/ipc/wrapHandler.ts`, `src/renderer/hooks/useIpc.ts`, `src/renderer/hooks/useKeyboard.ts`, `src/renderer/components/Layout/AppLayout.tsx`, `src/renderer/components/Terminal/FloatingPane.tsx`. 4 unit tests 추가 (wrapHandler RESOURCE_EXHAUSTED classification + message prefix stamping + useIpc 매핑).
+
+### Migration Notes
+
+- 자동. 클라이언트 / 외부 MCP 통합 측에 변경 없음. 신규 `RESOURCE_EXHAUSTED` 코드는 내부 IPC 경계 안쪽에서만 사용 (renderer ↔ main).
+
 ## [2.8.1] — 2026-05-10 — Session Recovery Stability Hotfix
 
 @alphabeen 이 v2.8.0 출시 직후 보고한 세 가지 회귀 — 시간이 갈수록 wmux 가 사용 불가 상태로 빠지던 critical, recovered pane 출력이 깨지던 high, 매 시작마다 generic 에러 토스트가 뜨던 medium — 을 한 릴리스에 묶어 수정한다. v2.8.0 사용자는 즉시 업그레이드 권장 — 자동 마이그레이션이 누적된 `sessions.json` 을 첫 실행 시 정리한다.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **신규 IPC 에러 코드 `RESOURCE_EXHAUSTED`** — `wrapHandler` 의 `classifyError` 가 cap 메시지 패턴 (`cannot create new terminal` + `active sessions already running`) 을 감지해 분류. 메시지에 `[RESOURCE_EXHAUSTED]` prefix 가 stamp 되어 renderer 가 분기 가능.
   - **`useIpc` 매핑** — `DEFAULT_MESSAGES['RESOURCE_EXHAUSTED']` = "터미널 세션 한도에 도달했습니다. 일부 pane을 닫거나 wmux를 재시작한 뒤 다시 시도해주세요.", level `'warn'`. UNKNOWN 으로 매핑되어 generic "알 수 없는 오류" 토스트가 뜨던 path 차단.
   - **세 호출 지점 모두 `ipcInvoke` wrap 으로 통일** — `useKeyboard` Ctrl+T (ref 패턴으로 once-on-mount effect 안에서 사용), `AppLayout` empty-leaf 자동 PTY effect, `FloatingPane` 첫 PTY 생성. 모두 `result.ok` 분기 + 실패 시 toast 자동 게재.
-  - 구현: `src/main/ipc/wrapHandler.ts`, `src/renderer/hooks/useIpc.ts`, `src/renderer/hooks/useKeyboard.ts`, `src/renderer/components/Layout/AppLayout.tsx`, `src/renderer/components/Terminal/FloatingPane.tsx`. 4 unit tests 추가 (wrapHandler RESOURCE_EXHAUSTED classification + message prefix stamping + useIpc 매핑).
+  - **Electron invoke envelope wrap 처리** — codex P2 review 에서 잡힌 결함. `ipcRenderer.invoke` 가 main side 에러를 renderer 로 전달할 때 메시지를 `Error invoking remote method 'X': Error: <orig>` 형태로 감싸서, `useIpc` 의 `MESSAGE_CODE_PREFIX` 가 `^` anchor 였던 탓에 `[RESOURCE_EXHAUSTED]` stamp 가 envelope 뒤로 밀려 매칭 실패 → 모든 coded error 가 다시 UNKNOWN 으로 떨어지던 path 차단. renderer regex 만 anchor 제거 (main side 는 자기 raw output 매칭이라 anchor 유지). 알phabeen 이 PR #25 description 에서 짚어준 결함이 두 번 일어나지 않도록 회귀 테스트 추가.
+  - 구현: `src/main/ipc/wrapHandler.ts`, `src/renderer/hooks/useIpc.ts`, `src/renderer/hooks/useKeyboard.ts`, `src/renderer/components/Layout/AppLayout.tsx`, `src/renderer/components/Terminal/FloatingPane.tsx`. 6 unit tests 추가 (wrapHandler RESOURCE_EXHAUSTED classification + message prefix stamping + useIpc default 매핑 + Electron-wrapped envelope classification).
 
 ### Migration Notes
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",

--- a/src/main/ipc/__tests__/wrapHandler.test.ts
+++ b/src/main/ipc/__tests__/wrapHandler.test.ts
@@ -77,6 +77,35 @@ describe('wrapHandler', () => {
     expect(entry.error_code).toBe('DAEMON_DISCONNECTED' satisfies IpcErrorCode);
   });
 
+  // v2.8.2 — daemon session cap (MAX_SESSIONS) reached.
+  // Without this classifier the renderer falls back to a generic
+  // "알 수 없는 오류" toast and hides the actionable instruction the
+  // daemon attached to the error message.
+  it('classifies the daemon session-cap error as RESOURCE_EXHAUSTED', async () => {
+    const wrapped = wrapHandler('pty:create', (_event: unknown) => {
+      throw new Error(
+        'Cannot create new terminal: 200 active sessions already running. ' +
+          'Close some panes (or restart wmux) and try again.',
+      );
+    });
+    await expect(wrapped({} as never)).rejects.toThrow();
+    const entry = parseLoggedEntry(writtenLines[0]);
+    expect(entry.error_code).toBe('RESOURCE_EXHAUSTED' satisfies IpcErrorCode);
+  });
+
+  it('stamps the RESOURCE_EXHAUSTED code into the message prefix', async () => {
+    const err = new Error(
+      'Cannot create new terminal: 200 active sessions already running. ' +
+        'Close some panes (or restart wmux) and try again.',
+    );
+    const wrapped = wrapHandler('pty:create', (_event: unknown) => {
+      throw err;
+    });
+    await expect(wrapped({} as never)).rejects.toBe(err);
+    expect((err as unknown as { code?: string }).code).toBe('RESOURCE_EXHAUSTED');
+    expect(err.message.startsWith('[RESOURCE_EXHAUSTED] ')).toBe(true);
+  });
+
   it('classifies an unrelated error as UNKNOWN', async () => {
     const wrapped = wrapHandler('test:ch', (_event: unknown) => {
       throw new Error('some random problem');

--- a/src/main/ipc/wrapHandler.ts
+++ b/src/main/ipc/wrapHandler.ts
@@ -32,9 +32,13 @@ const KNOWN_CODES: ReadonlySet<IpcErrorCode> = new Set<IpcErrorCode>([
 
 /**
  * Matches a leading `[CODE] ` prefix written by the wrapper so we can
- * detect that a message has already been stamped. Kept in sync with
- * the renderer-side regex in `useIpc.ts` — if you change one, change
- * the other.
+ * detect that a message has already been stamped (avoids double-stamping
+ * if a handler is wrapped twice). Only the main-side regex is anchored
+ * because we're matching against our own raw output here. The
+ * renderer-side regex in `useIpc.ts` deliberately drops the anchor —
+ * Electron wraps the message envelope (`Error invoking remote method
+ * '...': Error: <msg>`) before it reaches the renderer, so the stamp
+ * is no longer at the start.
  */
 const MESSAGE_CODE_PREFIX =
   /^\[(DAEMON_DISCONNECTED|VALIDATION_ERROR|NOT_FOUND|PERMISSION_DENIED|RESOURCE_EXHAUSTED|UNKNOWN)\] /;

--- a/src/main/ipc/wrapHandler.ts
+++ b/src/main/ipc/wrapHandler.ts
@@ -18,6 +18,7 @@ export type IpcErrorCode =
   | 'VALIDATION_ERROR'
   | 'NOT_FOUND'
   | 'PERMISSION_DENIED'
+  | 'RESOURCE_EXHAUSTED'
   | 'UNKNOWN';
 
 const KNOWN_CODES: ReadonlySet<IpcErrorCode> = new Set<IpcErrorCode>([
@@ -25,6 +26,7 @@ const KNOWN_CODES: ReadonlySet<IpcErrorCode> = new Set<IpcErrorCode>([
   'VALIDATION_ERROR',
   'NOT_FOUND',
   'PERMISSION_DENIED',
+  'RESOURCE_EXHAUSTED',
   'UNKNOWN',
 ]);
 
@@ -35,7 +37,7 @@ const KNOWN_CODES: ReadonlySet<IpcErrorCode> = new Set<IpcErrorCode>([
  * the other.
  */
 const MESSAGE_CODE_PREFIX =
-  /^\[(DAEMON_DISCONNECTED|VALIDATION_ERROR|NOT_FOUND|PERMISSION_DENIED|UNKNOWN)\] /;
+  /^\[(DAEMON_DISCONNECTED|VALIDATION_ERROR|NOT_FOUND|PERMISSION_DENIED|RESOURCE_EXHAUSTED|UNKNOWN)\] /;
 
 export interface StructuredLogEntry {
   ts: number;
@@ -71,6 +73,18 @@ function classifyError(err: unknown): IpcErrorCode {
     lower.includes('daemon is not connected')
   ) {
     return 'DAEMON_DISCONNECTED';
+  }
+
+  // Daemon session cap reached. Phrasing comes from
+  // `DaemonSessionManager.createSession` — keep this matcher in sync.
+  // Without classification the renderer would surface a generic
+  // "알 수 없는 오류" toast, which hides the actionable instruction
+  // (close some panes / restart wmux) that the daemon attached.
+  if (
+    lower.includes('cannot create new terminal') &&
+    lower.includes('active sessions already running')
+  ) {
+    return 'RESOURCE_EXHAUSTED';
   }
 
   return 'UNKNOWN';

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -472,27 +472,35 @@ export default function AppLayout() {
 
     for (const leaf of emptyLeaves) {
       const paneId = leaf.id;
-      window.electronAPI.pty.create(
-        withDefaultShell({ workspaceId: wsId }, useStore.getState().defaultShell)
-      ).then((result: { id: string; shell?: string; cwd?: string }) => {
+      // Wrap through ipcInvoke so a rejected pty.create (e.g.
+      // RESOURCE_EXHAUSTED when the daemon session cap is hit during a
+      // Ctrl+D split) surfaces an actionable toast instead of leaving the
+      // split as a permanent empty-leaf placeholder.
+      void ipcInvoke<{ id: string; shell?: string; cwd?: string }>(() =>
+        window.electronAPI.pty.create(
+          withDefaultShell({ workspaceId: wsId }, useStore.getState().defaultShell)
+        )
+      ).then((result) => {
+        if (!result.ok) return; // toast surfaced by useIpc
+        const created = result.data;
         if (cancelled) {
-          window.electronAPI.pty.dispose(result.id);
+          window.electronAPI.pty.dispose(created.id);
           return;
         }
-        const shellName = result.shell ? shellDisplayName(result.shell) : 'Terminal';
-        addSurface(paneId, result.id, shellName, result.cwd || '');
+        const shellName = created.shell ? shellDisplayName(created.shell) : 'Terminal';
+        addSurface(paneId, created.id, shellName, created.cwd || '');
         // Set initial CWD in workspace metadata from first pane
-        if (result.cwd) {
+        if (created.cwd) {
           const currentMeta = useStore.getState().workspaces.find((w) => w.id === wsId)?.metadata;
           if (!currentMeta?.cwd) {
-            useStore.getState().updateWorkspaceMetadata(wsId, { cwd: result.cwd });
+            useStore.getState().updateWorkspaceMetadata(wsId, { cwd: created.cwd });
           }
         }
       });
     }
 
     return () => { cancelled = true; };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- collectEmptyLeaves & addSurface are stable; emptyLeafIdsKey is the meaningful trigger
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- collectEmptyLeaves & addSurface & ipcInvoke are stable; emptyLeafIdsKey is the meaningful trigger
   }, [activeWorkspace?.id, emptyLeafIdsKey]);
 
   // Wizard close handler (T8a). Mirrors firstRunCompleted into uiSlice (main

--- a/src/renderer/components/Terminal/FloatingPane.tsx
+++ b/src/renderer/components/Terminal/FloatingPane.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect, useCallback } from 'react';
 import { useTerminal } from '../../hooks/useTerminal';
 import { useStore } from '../../stores';
 import { useT } from '../../hooks/useT';
+import { useIpc } from '../../hooks/useIpc';
 import { withDefaultShell } from '../../utils/ptyCreateOptions';
 import '@xterm/xterm/css/xterm.css';
 
@@ -12,24 +13,31 @@ export default function FloatingPane() {
   const toggleFloatingPane = useStore((s) => s.toggleFloatingPane);
   const setFloatingPanePtyId = useStore((s) => s.setFloatingPanePtyId);
   const t = useT();
+  const { invoke: ipcInvoke } = useIpc();
 
   const containerRef = useRef<HTMLDivElement>(null);
   const creatingRef = useRef(false);
 
-  // Create PTY on first open
+  // Create PTY on first open. Routed through ipcInvoke so a RESOURCE_EXHAUSTED
+  // rejection (daemon session cap reached) shows an actionable toast instead
+  // of being silently swallowed by the previous .catch(() => {}) — that left
+  // the floating pane shortcut looking unresponsive when the cap was hit.
   useEffect(() => {
     if (!floatingPaneVisible) return;
     if (floatingPanePtyId) return;
     if (creatingRef.current) return;
 
     creatingRef.current = true;
-    window.electronAPI.pty.create(withDefaultShell({}, defaultShell)).then((result: { id: string }) => {
-      setFloatingPanePtyId(result.id);
-      creatingRef.current = false;
-    }).catch(() => {
+    void ipcInvoke<{ id: string }>(() =>
+      window.electronAPI.pty.create(withDefaultShell({}, defaultShell))
+    ).then((result) => {
+      if (result.ok) {
+        setFloatingPanePtyId(result.data.id);
+      }
+      // On failure useIpc already surfaced a toast.
       creatingRef.current = false;
     });
-  }, [defaultShell, floatingPaneVisible, floatingPanePtyId, setFloatingPanePtyId]);
+  }, [defaultShell, floatingPaneVisible, floatingPanePtyId, setFloatingPanePtyId, ipcInvoke]);
 
   useTerminal(containerRef, {
     ptyId: floatingPanePtyId,

--- a/src/renderer/hooks/__tests__/useIpc.test.ts
+++ b/src/renderer/hooks/__tests__/useIpc.test.ts
@@ -48,6 +48,7 @@ describe('useIpc / createInvoke', () => {
       { code: 'VALIDATION_ERROR',    expected: '요청이 유효하지 않습니다.' },
       { code: 'NOT_FOUND',           expected: '항목을 찾을 수 없습니다.' },
       { code: 'PERMISSION_DENIED',   expected: '권한이 거부되었습니다.' },
+      { code: 'RESOURCE_EXHAUSTED',  expected: '터미널 세션 한도에 도달했습니다. 일부 pane을 닫거나 wmux를 재시작한 뒤 다시 시도해주세요.' },
       { code: 'UNKNOWN',             expected: '알 수 없는 오류가 발생했습니다.' },
     ];
 

--- a/src/renderer/hooks/__tests__/useIpc.test.ts
+++ b/src/renderer/hooks/__tests__/useIpc.test.ts
@@ -207,6 +207,26 @@ describe('useIpc / createInvoke', () => {
       if (!result.ok) expect(result.error.code).toBe('NOT_FOUND');
     });
 
+    // v2.8.2 — codex P2: Electron also wraps the message envelope before
+    // it reaches the renderer (`Error invoking remote method '...': Error:
+    // <orig>`). If we anchor the prefix regex to `^`, the stamp is hidden
+    // behind the envelope and every coded error falls through to UNKNOWN.
+    // These cases lock in the un-anchored behaviour.
+    it('classifies by `[CODE] ` token even when Electron prepends the invoke envelope', async () => {
+      const invoke = createInvoke(undefined, toastSpy);
+      const wrapped = new Error(
+        `Error invoking remote method 'pty:create': Error: [RESOURCE_EXHAUSTED] Cannot create new terminal: 200 active sessions already running. Close some panes (or restart wmux) and try again.`,
+      );
+      const result = await invoke(async () => { throw wrapped; });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('RESOURCE_EXHAUSTED');
+        expect(result.error.message).toBe(
+          '터미널 세션 한도에 도달했습니다. 일부 pane을 닫거나 wmux를 재시작한 뒤 다시 시도해주세요.',
+        );
+      }
+    });
+
     it('classifies each known code via the message-prefix path', async () => {
       const invoke = createInvoke(undefined, toastSpy);
       const codes: IpcErrorCode[] = [
@@ -214,6 +234,7 @@ describe('useIpc / createInvoke', () => {
         'VALIDATION_ERROR',
         'NOT_FOUND',
         'PERMISSION_DENIED',
+        'RESOURCE_EXHAUSTED',
         'UNKNOWN',
       ];
       for (const code of codes) {

--- a/src/renderer/hooks/useIpc.ts
+++ b/src/renderer/hooks/useIpc.ts
@@ -34,16 +34,26 @@ const KNOWN_CODES: ReadonlySet<IpcErrorCode> = new Set<IpcErrorCode>([
 ]);
 
 /**
- * Matches a `[CODE] ` prefix written by `wrapHandler` in the main
- * process. Electron's IPC serializer can drop own properties on
- * `Error` instances (`err.code` included), so the main side also
- * stamps the code into the message as a prefix. This regex is the
- * fallback path when `err.code` did not survive the IPC boundary.
- * Kept in sync with the main-side regex — if you change one, change
- * the other.
+ * Matches a `[CODE] ` token written by `wrapHandler` in the main process.
+ * Electron's IPC serializer drops own properties on `Error` instances
+ * (`err.code` included) AND wraps the message itself — what arrives
+ * here typically looks like:
+ *   `Error invoking remote method 'pty:create': Error: [CODE] <orig msg>`
+ * so the token is NOT anchored to the start of the string. The
+ * alternation only matches known codes, so a literal `[UNKNOWN]` token
+ * elsewhere in user content is the only theoretical false positive — and
+ * if our own wrapHandler stamped it, classifying as UNKNOWN is correct
+ * anyway. Keep the wrapHandler-side regex anchored (`^`) because there
+ * the message starts with our stamp; only the renderer needs the looser
+ * match because Electron prepends the invoke envelope.
+ *
+ * v2.8.2 fix — pre-v2.8.2 the renderer regex was also anchored, so
+ * RESOURCE_EXHAUSTED (and every other coded error) silently fell
+ * through to UNKNOWN whenever Electron wrapped the message, which
+ * was the common case.
  */
 const MESSAGE_CODE_PREFIX =
-  /^\[(DAEMON_DISCONNECTED|VALIDATION_ERROR|NOT_FOUND|PERMISSION_DENIED|RESOURCE_EXHAUSTED|UNKNOWN)\] /;
+  /\[(DAEMON_DISCONNECTED|VALIDATION_ERROR|NOT_FOUND|PERMISSION_DENIED|RESOURCE_EXHAUSTED|UNKNOWN)\] /;
 
 export interface IpcErrorShape {
   code: IpcErrorCode;

--- a/src/renderer/hooks/useIpc.ts
+++ b/src/renderer/hooks/useIpc.ts
@@ -21,6 +21,7 @@ export type IpcErrorCode =
   | 'VALIDATION_ERROR'
   | 'NOT_FOUND'
   | 'PERMISSION_DENIED'
+  | 'RESOURCE_EXHAUSTED'
   | 'UNKNOWN';
 
 const KNOWN_CODES: ReadonlySet<IpcErrorCode> = new Set<IpcErrorCode>([
@@ -28,6 +29,7 @@ const KNOWN_CODES: ReadonlySet<IpcErrorCode> = new Set<IpcErrorCode>([
   'VALIDATION_ERROR',
   'NOT_FOUND',
   'PERMISSION_DENIED',
+  'RESOURCE_EXHAUSTED',
   'UNKNOWN',
 ]);
 
@@ -41,7 +43,7 @@ const KNOWN_CODES: ReadonlySet<IpcErrorCode> = new Set<IpcErrorCode>([
  * the other.
  */
 const MESSAGE_CODE_PREFIX =
-  /^\[(DAEMON_DISCONNECTED|VALIDATION_ERROR|NOT_FOUND|PERMISSION_DENIED|UNKNOWN)\] /;
+  /^\[(DAEMON_DISCONNECTED|VALIDATION_ERROR|NOT_FOUND|PERMISSION_DENIED|RESOURCE_EXHAUSTED|UNKNOWN)\] /;
 
 export interface IpcErrorShape {
   code: IpcErrorCode;
@@ -68,6 +70,7 @@ const DEFAULT_MESSAGES: Record<IpcErrorCode, string> = {
   VALIDATION_ERROR: '요청이 유효하지 않습니다.',
   NOT_FOUND: '항목을 찾을 수 없습니다.',
   PERMISSION_DENIED: '권한이 거부되었습니다.',
+  RESOURCE_EXHAUSTED: '터미널 세션 한도에 도달했습니다. 일부 pane을 닫거나 wmux를 재시작한 뒤 다시 시도해주세요.',
   UNKNOWN: '알 수 없는 오류가 발생했습니다.',
 };
 
@@ -77,6 +80,7 @@ const CODE_TO_LEVEL: Record<IpcErrorCode, 'info' | 'warn' | 'error'> = {
   VALIDATION_ERROR: 'warn',
   NOT_FOUND: 'info',
   PERMISSION_DENIED: 'error',
+  RESOURCE_EXHAUSTED: 'warn',
   UNKNOWN: 'error',
 };
 

--- a/src/renderer/hooks/useKeyboard.ts
+++ b/src/renderer/hooks/useKeyboard.ts
@@ -4,6 +4,7 @@ import { findLeaf } from '../../shared/paneUtils';
 import { terminalRegistry } from './useTerminal';
 import { t } from '../i18n';
 import { withDefaultShell } from '../utils/ptyCreateOptions';
+import { useIpc } from './useIpc';
 
 // Lightweight bookmark toast — reuses the same DOM element pattern as showCopyToast
 let bookmarkToastTimer: ReturnType<typeof setTimeout> | null = null;
@@ -56,6 +57,14 @@ function disposePanePtys(pane: import('../../shared/types').Pane): void {
 export function useKeyboard() {
   const store = useStore;
   const prefixTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Capture the IPC invoker via ref so the once-on-mount effect below can
+  // call it without re-binding when the memoised invoke identity changes.
+  // Used to surface RESOURCE_EXHAUSTED toasts on Ctrl+T when the daemon
+  // session cap is hit (without this, the rejected pty.create promise
+  // would be silently dropped and the shortcut would look unresponsive).
+  const { invoke: ipcInvoke } = useIpc();
+  const ipcInvokeRef = useRef(ipcInvoke);
+  ipcInvokeRef.current = ipcInvoke;
 
   useEffect(() => {
     // Action registry — maps action IDs to implementations
@@ -281,8 +290,17 @@ export function useKeyboard() {
         const state = store.getState();
         const ws = state.workspaces.find((w) => w.id === state.activeWorkspaceId);
         if (ws) {
-          window.electronAPI.pty.create(withDefaultShell({ workspaceId: ws.id }, state.defaultShell)).then((result: { id: string }) => {
-            store.getState().addSurface(ws.activePaneId, result.id, 'Terminal', '');
+          // Wrap pty.create through useIpc so that a rejected promise (most
+          // notably MAX_SESSIONS cap reached → RESOURCE_EXHAUSTED) surfaces
+          // an actionable toast instead of being silently dropped — the
+          // pre-v2.8.2 .then-only chain made the shortcut look unresponsive.
+          void ipcInvokeRef.current<{ id: string }>(() =>
+            window.electronAPI.pty.create(withDefaultShell({ workspaceId: ws.id }, state.defaultShell))
+          ).then((result) => {
+            if (result.ok) {
+              store.getState().addSurface(ws.activePaneId, result.data.id, 'Terminal', '');
+            }
+            // On failure useIpc already surfaced a toast — nothing to do here.
           });
         }
         return;


### PR DESCRIPTION
Follow-up to PR #25 — closes the silent-failure path @alphabeen flagged in the PR description.

## Background

@alphabeen, while writing PR #25 (MAX_SESSIONS 50→200), pointed out that cap-reached throws were being silently dropped in the renderer:

> cap에 도달하면 `pty.create`가 throw 됩니다. 그런데 현재 renderer의 `Ctrl+T` 핸들러는 `.catch()` 없이 결과를 바로 dereference하고 있어서 rejection이 조용히 묻혀버립니다. 사용자 입장에서는 단축키가 그냥 "아무 반응 없는 것처럼" 보이게 되는 구조입니다.

v2.8.1 Bug 1 made the daemon error actionable (`Cannot create new terminal: 200 active sessions already running. Close some panes (or restart wmux) and try again.`) but the renderer side never surfaced it. This PR closes that hole.

## Three renderer call sites had no catch

- `useKeyboard.ts:284` — Ctrl+T handler. `.then()` only, rejection dropped.
- `AppLayout.tsx:475` — empty-leaf auto-PTY effect. After a Ctrl+D split, a cap-rejected create leaves the leaf as a permanent "빈 창" placeholder.
- `FloatingPane.tsx:26` — floating pane shortcut (Ctrl+\`). Silent `.catch(() => {})` swallowed everything including cap errors.

All three now route through `ipcInvoke` so a rejected promise surfaces a toast via the existing `useIpc` plumbing.

## New IPC error code: `RESOURCE_EXHAUSTED`

`UNKNOWN` was mapping the actionable cap message to a generic "알 수 없는 오류가 발생했습니다." toast — the same anti-pattern v2.8.1 was meant to close. Added a dedicated code:

- **`wrapHandler.classifyError`** matches the daemon cap message pattern (`cannot create new terminal` + `active sessions already running`) and stamps `[RESOURCE_EXHAUSTED] ` into the message.
- **`useIpc.DEFAULT_MESSAGES['RESOURCE_EXHAUSTED']`** = `"터미널 세션 한도에 도달했습니다. 일부 pane을 닫거나 wmux를 재시작한 뒤 다시 시도해주세요."` at `'warn'` level.

## Codex P2: Electron invoke-envelope wrapping

`/codex review` against this branch caught a second silent-failure path that would have undone the fix above:

> When `ipcRenderer.invoke` receives a thrown main-process error, Electron can reject with a renderer-side message like `Error invoking remote method 'pty:create': Error: [RESOURCE_EXHAUSTED] ...` while dropping the custom `err.code`. Because this fallback regex is anchored to the beginning of the message, the newly added `RESOURCE_EXHAUSTED` prefix is not detected in that serialization path, so session-cap failures can still be mapped to `UNKNOWN` and show the generic toast.

This applies to **every** coded error, not just `RESOURCE_EXHAUSTED` — Electron wraps the message envelope before it reaches the renderer, and `useIpc.MESSAGE_CODE_PREFIX` was anchored to `^`, so the stamp was hidden behind the envelope.

**Fix**: drop the anchor on the renderer side only (`wrapHandler` keeps its anchor because it's matching its own raw output to avoid double-stamping). The alternation is restricted to `KNOWN_CODES`, so the looser match has near-zero false-positive risk.

## Tests

- 934 passing (929 baseline → +5)
- New: `wrapHandler` classifies `RESOURCE_EXHAUSTED` from cap message (1), stamps `[RESOURCE_EXHAUSTED] ` prefix (1), `useIpc` default-message mapping (1), `useIpc` classifies through Electron envelope (1), `useIpc` message-prefix path covers all known codes (1 case added to existing loop).
- `tsc --noEmit` clean. `npm run build:daemon` (158.4kb) + `npm run build:mcp` clean.

## Reviews

- `/codex review` — caught 1 P2 (Electron envelope path). Fixed in `5985fd6`.

## Test plan

- [ ] Pre-merge: \`npm test\` shows 934/934 on CI
- [ ] Pre-merge: \`tsc --noEmit\` clean
- [ ] Manual (cap toast): build a state where `MAX_SESSIONS=200` is reached, press Ctrl+T; confirm the actionable Korean toast appears at `'warn'` level (not the generic "알 수 없는 오류")
- [ ] Manual (split path): Ctrl+D in a maxed-out state; confirm the empty leaf does **not** stay as a "빈 창" placeholder and a toast appears instead
- [ ] Manual (floating pane): Ctrl+\` in a maxed-out state; confirm the toast appears (previously silent)
- [ ] Manual (other errors): trigger a generic daemon failure (kill the daemon mid-session); confirm `DAEMON_DISCONNECTED` toast still routes correctly through the envelope path

## Migration

Automatic. No client / external MCP changes. The new `RESOURCE_EXHAUSTED` code is internal to renderer ↔ main IPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — codex P2 review fold-in