### PR TITLE
fix: restore workspace drag reorder

### DIFF
--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -5,6 +5,7 @@ import type {
   RegisterMcpResult,
   SampleTaskStartPayload,
 } from '../shared/firstRun';
+import { isFileDrag } from '../shared/dragDrop';
 
 /** Mirrors {@link McpStatusPayload} in src/main/ipc/handlers/mcp.handler.ts. */
 interface McpStatusPayload {
@@ -224,10 +225,12 @@ const fileDropCallbacks: ((paths: string[]) => void)[] = [];
 
 document.addEventListener('DOMContentLoaded', () => {
   document.addEventListener('dragover', (e) => {
+    if (!isFileDrag(e.dataTransfer)) return;
     e.preventDefault();
     if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
   });
   document.addEventListener('drop', (e) => {
+    if (!isFileDrag(e.dataTransfer)) return;
     e.preventDefault();
     const files = e.dataTransfer?.files;
     if (!files || files.length === 0) return;

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -27,6 +27,7 @@ import { useResizeGuard } from '../../hooks/useResizeGuard';
 import { useIpc } from '../../hooks/useIpc';
 import type { SessionData, PaneLeaf, Pane, Surface } from '../../../shared/types';
 import { FIRST_RUN_REOPEN_EVENT } from '../../../shared/firstRun';
+import { isFileDrag } from '../../../shared/dragDrop';
 import { Terminal } from '@xterm/xterm';
 import { terminalRegistry } from '../../hooks/useTerminal';
 import { withDefaultShell } from '../../utils/ptyCreateOptions';
@@ -241,12 +242,14 @@ export default function AppLayout() {
 
     // Visual drag overlay
     const onEnter = (e: DragEvent) => {
+      if (!isFileDrag(e.dataTransfer)) return;
       e.preventDefault();
       if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
       dragCounterRef.current++;
       if (dragCounterRef.current === 1) setIsDragging(true);
     };
-    const onLeave = () => {
+    const onLeave = (e: DragEvent) => {
+      if (!isFileDrag(e.dataTransfer)) return;
       dragCounterRef.current--;
       if (dragCounterRef.current <= 0) {
         dragCounterRef.current = 0;

--- a/src/shared/__tests__/dragDrop.test.ts
+++ b/src/shared/__tests__/dragDrop.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { isFileDrag } from '../dragDrop';
+
+describe('isFileDrag', () => {
+  it('returns false when no dataTransfer is present', () => {
+    expect(isFileDrag(null)).toBe(false);
+    expect(isFileDrag(undefined)).toBe(false);
+  });
+
+  it('returns false for internal text drags', () => {
+    expect(isFileDrag({ types: ['text/plain'] })).toBe(false);
+  });
+
+  it('returns true when DataTransfer types include Files', () => {
+    expect(isFileDrag({ types: ['Files'] })).toBe(true);
+  });
+
+  it('returns true when files are present even without types', () => {
+    expect(isFileDrag({ files: { length: 1 } })).toBe(true);
+  });
+});

--- a/src/shared/dragDrop.ts
+++ b/src/shared/dragDrop.ts
@@ -1,0 +1,30 @@
+type DragTypesLike = ArrayLike<string> & {
+  contains?: (type: string) => boolean;
+  includes?: (type: string) => boolean;
+};
+
+export interface DragDataTransferLike {
+  types?: DragTypesLike | null;
+  files?: { length: number } | null;
+}
+
+const FILES_DATA_TRANSFER_TYPE = 'Files';
+
+export function isFileDrag(dataTransfer: DragDataTransferLike | null | undefined): boolean {
+  if (!dataTransfer) return false;
+
+  const types = dataTransfer.types;
+  if (types) {
+    if (typeof types.contains === 'function' && types.contains(FILES_DATA_TRANSFER_TYPE)) {
+      return true;
+    }
+    if (typeof types.includes === 'function' && types.includes(FILES_DATA_TRANSFER_TYPE)) {
+      return true;
+    }
+    for (let i = 0; i < types.length; i++) {
+      if (types[i] === FILES_DATA_TRANSFER_TYPE) return true;
+    }
+  }
+
+  return (dataTransfer.files?.length ?? 0) > 0;
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                    
                                                                                                                                                                                                                
Fix workspace drag-and-drop reordering in the left sidebar.                                                                                                                                                   
                                                                                                                                                                                                                
The global file-drop handlers were treating internal workspace drag events like OS file drops, which interfered with the `move` drag operation used by workspace reordering.                                  
                                                                                                                                                                                                                
## Changes                                                                                                                                                                                                    
                                                                                                                                                                                                                
- Add a shared file-drag detector for `DataTransfer`                                                                                                                                                          
- Limit global file-drop handlers to actual OS file drags                                                                                                                                                     
- Limit the file-drop overlay to actual OS file drags                                                                                                                                                         
- Add regression tests for internal non-file drag payloads                                                                                                                                                    
                                                                                                                                                                                                                
## PR Checklist                                                                                                                                                                                               
                                                                                                                                                                                                                
- [x] `npx tsc --noEmit` passes                                                                                                                                                                               
- [x] `npm test` passes                                                                                                                                                                                       
- [x] New code has tests                                                                                                                                                                                      
- [x] Commit messages are clear and descriptive                                                                                                                                                               
                                                                                                                                                                                                                
## Testing                                                                                                                                                                                                    
                                                                                                                                                                                                                
- `npm test -- dragDrop workspaceSlice`                                                                                                                                                                       
- `npx tsc --noEmit --project tsconfig.json`                                                                                                                                                                  
- `npx eslint src\shared\dragDrop.ts src\shared\__tests__\dragDrop.test.ts src\preload\preload.ts`

---

좌측 사이드바에서 워크스페이스를 드래그해 순서를 변경할 수 없던 문제를 수정했습니다.

전역 파일 드롭 핸들러가 내부 워크스페이스 드래그 이벤트까지 OS 파일 드래그처럼 처리하면서, 워크스페이스 정렬에 필요한 `move` 드래그 동작과 충돌하고 있었습니다.

- `DataTransfer`가 실제 파일 드래그인지 판별하는 공통 헬퍼 추가
- 전역 파일 드롭 핸들러가 OS 파일 드래그에만 반응하도록 제한
- 파일 드롭 오버레이도 OS 파일 드래그일 때만 표시되도록 제한
- 내부 `text/plain` 드래그가 파일 드래그로 처리되지 않는 회귀 테스트 추가