### PR TITLE
fix(multiview): sticky group across navigation + MiniSidebar feature parity

### DIFF
--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -25,7 +25,7 @@ import { useNotificationListener } from '../../hooks/useNotificationListener';
 import { useRpcBridge } from '../../hooks/useRpcBridge';
 import { useResizeGuard } from '../../hooks/useResizeGuard';
 import { useIpc } from '../../hooks/useIpc';
-import type { SessionData, PaneLeaf, Pane, Surface } from '../../../shared/types';
+import type { SessionData, PaneLeaf, Pane, Surface, Workspace } from '../../../shared/types';
 import { FIRST_RUN_REOPEN_EVENT } from '../../../shared/firstRun';
 import { isFileDrag } from '../../../shared/dragDrop';
 import { Terminal } from '@xterm/xterm';
@@ -537,8 +537,11 @@ export default function AppLayout() {
       <ErrorBoundary name="Main">
       <div className="flex-1 min-w-0 flex flex-col">
         <StatusBar />
-        {/* Render workspaces: single view or multiview grid (Ctrl+click selected) */}
-        {multiviewIds.length >= 2 ? (
+        {/* Render workspaces: single view or multiview grid (Ctrl+click selected).
+            Grid renders only when the active workspace is a member of the saved
+            multiview group, so clicking outside the group shows that workspace's
+            single view while the group is preserved for later restoration. */}
+        {multiviewIds.length >= 2 && multiviewIds.includes(activeWorkspaceId) ? (
           <div
             className="flex-1 min-h-0"
             style={{
@@ -551,7 +554,10 @@ export default function AppLayout() {
               backgroundColor: 'var(--bg-surface)',
             }}
           >
-            {workspaces.filter((ws) => multiviewIds.includes(ws.id)).map((ws) => (
+            {multiviewIds
+              .map((id) => workspaces.find((w) => w.id === id))
+              .filter((ws): ws is Workspace => ws !== undefined)
+              .map((ws) => (
               <div
                 key={ws.id}
                 className="relative flex flex-col min-w-0 min-h-0 overflow-hidden cursor-pointer"

--- a/src/renderer/components/Sidebar/MiniSidebar.tsx
+++ b/src/renderer/components/Sidebar/MiniSidebar.tsx
@@ -1,5 +1,7 @@
+import { useRef, useState } from 'react';
 import { useStore } from '../../stores';
 import { useT } from '../../hooks/useT';
+import { AGENT_STATUS_ICON } from './agentStatusIcon';
 
 export default function MiniSidebar() {
   const t = useT();
@@ -8,11 +10,18 @@ export default function MiniSidebar() {
   const activeWorkspaceId = useStore((s) => s.activeWorkspaceId);
   const setActiveWorkspace = useStore((s) => s.setActiveWorkspace);
   const toggleSidebar = useStore((s) => s.toggleSidebar);
-  const totalUnread = useStore((s) =>
-    s.notifications.filter((n) => !n.read).length,
-  );
+  const toggleMultiviewWorkspace = useStore((s) => s.toggleMultiviewWorkspace);
+  const multiviewIds = useStore((s) => s.multiviewIds);
+  const reorderWorkspace = useStore((s) => s.reorderWorkspace);
+  const notifications = useStore((s) => s.notifications);
+  const totalUnread = notifications.filter((n) => !n.read).length;
 
   const addWorkspace = useStore((s) => s.addWorkspace);
+
+  // Drag state per render — refs avoid re-render on every dragover tick.
+  const dragStartTimeRef = useRef<number>(0);
+  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+  const [dropIndicator, setDropIndicator] = useState<{ index: number; side: 'above' | 'below' } | null>(null);
 
   return (
     <div className={`flex flex-col h-full bg-[var(--bg-mantle)] ${sidebarPosition === 'right' ? 'border-l' : 'border-r'} border-[var(--bg-surface)]`} style={{ width: 48 }}>
@@ -30,21 +39,110 @@ export default function MiniSidebar() {
       <div className="flex-1 overflow-y-auto py-2 flex flex-col items-center gap-1">
         {workspaces.map((ws, i) => {
           const isActive = ws.id === activeWorkspaceId;
-          const initial = ws.name.charAt(0).toUpperCase();
+          const isMultiview = multiviewIds.includes(ws.id);
+          const isDragging = draggingIndex === i;
+          const unreadCount = notifications.filter((n) => !n.read && n.workspaceId === ws.id).length;
+          const agentStatus = ws.metadata?.agentStatus;
+          const agentIcon = agentStatus && agentStatus !== 'idle' ? AGENT_STATUS_ICON[agentStatus] : null;
+          // Initial + position so workspaces with identical prefixes (W, W, W…)
+          // remain distinguishable in the 48px rail.
+          const label = `${ws.name.charAt(0).toUpperCase()}${i + 1}`;
+
+          const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+            // Suppress click that fires immediately after a drag.
+            if (Date.now() - dragStartTimeRef.current < 200) return;
+            if (e.ctrlKey) {
+              e.preventDefault();
+              toggleMultiviewWorkspace(ws.id);
+            } else {
+              setActiveWorkspace(ws.id);
+            }
+          };
+
+          const handleDragStart = (e: React.DragEvent<HTMLButtonElement>) => {
+            dragStartTimeRef.current = Date.now();
+            e.dataTransfer.setData('text/plain', String(i));
+            e.dataTransfer.effectAllowed = 'move';
+            setDraggingIndex(i);
+          };
+
+          const handleDragEnd = () => {
+            setDraggingIndex(null);
+            setDropIndicator(null);
+          };
+
+          const handleDragOver = (e: React.DragEvent<HTMLButtonElement>) => {
+            e.preventDefault();
+            e.dataTransfer.dropEffect = 'move';
+            const rect = e.currentTarget.getBoundingClientRect();
+            const midY = rect.top + rect.height / 2;
+            setDropIndicator({ index: i, side: e.clientY < midY ? 'above' : 'below' });
+          };
+
+          const handleDragLeave = (e: React.DragEvent<HTMLButtonElement>) => {
+            if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+              setDropIndicator((prev) => (prev?.index === i ? null : prev));
+            }
+          };
+
+          const handleDrop = (e: React.DragEvent<HTMLButtonElement>) => {
+            e.preventDefault();
+            setDropIndicator(null);
+            const fromIndex = parseInt(e.dataTransfer.getData('text/plain'), 10);
+            if (isNaN(fromIndex) || fromIndex === i) return;
+            const rect = e.currentTarget.getBoundingClientRect();
+            const midY = rect.top + rect.height / 2;
+            const toIndex = e.clientY < midY
+              ? (fromIndex < i ? i - 1 : i)
+              : (fromIndex > i ? i + 1 : i);
+            reorderWorkspace(fromIndex, toIndex);
+          };
+
+          const showIndicator = dropIndicator?.index === i;
 
           return (
-            <button
-              key={ws.id}
-              className={`w-8 h-8 rounded-md flex items-center justify-center text-xs font-bold font-mono transition-colors ${
-                isActive
-                  ? 'bg-[var(--bg-surface)] text-[var(--text-main)]'
-                  : 'text-[var(--text-muted)] hover:bg-[rgba(var(--bg-surface-rgb),0.5)] hover:text-[var(--text-sub)]'
-              }`}
-              onClick={() => setActiveWorkspace(ws.id)}
-              title={`${ws.name} (Ctrl+${i + 1})`}
-            >
-              {initial}
-            </button>
+            <div key={ws.id} className="relative w-8">
+              {showIndicator && dropIndicator.side === 'above' && (
+                <div className="absolute top-0 left-0 right-0 h-0.5 bg-[var(--accent-blue)] rounded-full z-10 -translate-y-px" />
+              )}
+              <button
+                draggable
+                className={`relative w-8 h-8 rounded-md flex items-center justify-center text-[10px] font-bold font-mono select-none transition-colors ${
+                  isActive
+                    ? 'bg-[var(--bg-surface)] text-[var(--text-main)]'
+                    : 'text-[var(--text-muted)] hover:bg-[rgba(var(--bg-surface-rgb),0.5)] hover:text-[var(--text-sub)]'
+                } ${isDragging ? 'opacity-40' : 'opacity-100'}`}
+                style={isMultiview ? { borderLeft: '2px solid var(--accent-blue)' } : undefined}
+                onClick={handleClick}
+                onDragStart={handleDragStart}
+                onDragEnd={handleDragEnd}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                title={`${ws.name} (Ctrl+${i + 1})`}
+              >
+                {label}
+                {unreadCount > 0 && (
+                  <span
+                    className="absolute -top-0.5 -right-0.5 bg-[var(--accent-blue)] text-[var(--bg-base)] text-[8px] font-bold rounded-full min-w-[12px] h-3 flex items-center justify-center px-0.5 leading-none"
+                    title={t('sidebar.unreadCount', { count: unreadCount })}
+                  >
+                    {unreadCount > 9 ? '9+' : unreadCount}
+                  </span>
+                )}
+                {agentIcon && (
+                  <span
+                    className={`absolute -bottom-0.5 -right-0.5 text-[8px] leading-none ${agentIcon.className} ${agentStatus === 'running' ? 'animate-pulse' : ''}`}
+                    title={`${ws.metadata?.agentName ? `${ws.metadata.agentName} — ` : ''}${t(agentIcon.labelKey)}`}
+                  >
+                    {agentIcon.dot}
+                  </span>
+                )}
+              </button>
+              {showIndicator && dropIndicator.side === 'below' && (
+                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-[var(--accent-blue)] rounded-full z-10 translate-y-px" />
+              )}
+            </div>
           );
         })}
       </div>

--- a/src/renderer/components/Sidebar/WorkspaceItem.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceItem.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import type { AgentStatus, Workspace } from '../../../shared/types';
 import { useStore } from '../../stores';
 import { useT } from '../../hooks/useT';
+import { AGENT_STATUS_ICON } from './agentStatusIcon';
 
 interface WorkspaceItemProps {
   workspace: Workspace;
@@ -15,15 +16,6 @@ interface WorkspaceItemProps {
   onCopyInfo: () => void;
   onReorder: (fromIndex: number, toIndex: number) => void;
 }
-
-// Maps AgentStatus to a colored dot indicator character and Tailwind color class.
-const AGENT_STATUS_ICON: Record<AgentStatus, { dot: string; className: string; labelKey: string }> = {
-  running:  { dot: '●', className: 'text-[var(--accent-blue)]', labelKey: 'workspace.agentRunning' },
-  complete: { dot: '●', className: 'text-[var(--accent-green)]', labelKey: 'workspace.agentComplete' },
-  error:    { dot: '●', className: 'text-[var(--accent-red)]', labelKey: 'workspace.agentError' },
-  waiting:  { dot: '●', className: 'text-[var(--accent-yellow)]', labelKey: 'workspace.agentWaiting' },
-  idle:     { dot: '●', className: 'text-[var(--text-muted)]', labelKey: 'workspace.agentIdle' },
-};
 
 function AgentStatusDot({ status, agentName }: { status: AgentStatus; agentName?: string }): React.ReactElement {
   const t = useT();

--- a/src/renderer/components/Sidebar/agentStatusIcon.ts
+++ b/src/renderer/components/Sidebar/agentStatusIcon.ts
@@ -1,0 +1,11 @@
+import type { AgentStatus } from '../../../shared/types';
+
+// Shared mapping from agent status → visual indicator. Used by WorkspaceItem
+// (full sidebar) and MiniSidebar so they stay in lockstep when statuses change.
+export const AGENT_STATUS_ICON: Record<AgentStatus, { dot: string; className: string; labelKey: string }> = {
+  running:  { dot: '●', className: 'text-[var(--accent-blue)]', labelKey: 'workspace.agentRunning' },
+  complete: { dot: '●', className: 'text-[var(--accent-green)]', labelKey: 'workspace.agentComplete' },
+  error:    { dot: '●', className: 'text-[var(--accent-red)]', labelKey: 'workspace.agentError' },
+  waiting:  { dot: '●', className: 'text-[var(--accent-yellow)]', labelKey: 'workspace.agentWaiting' },
+  idle:     { dot: '●', className: 'text-[var(--text-muted)]', labelKey: 'workspace.agentIdle' },
+};

--- a/src/renderer/stores/slices/__tests__/uiSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/uiSlice.test.ts
@@ -151,3 +151,66 @@ describe('UISlice — first-run + cheat sheet flags', () => {
     expect(store.getState().cheatSheetDismissed).toBe(true);
   });
 });
+
+describe('UISlice — multiview', () => {
+  // toggleMultiviewWorkspace reads state.activeWorkspaceId, which lives on
+  // WorkspaceSlice. The test store overlays an activeWorkspaceId field after
+  // slice construction so we exercise the cross-slice behavior in isolation.
+  function setActive(store: ReturnType<typeof createTestStore>, id: string) {
+    // @ts-expect-error — augmenting TestState with cross-slice field
+    store.setState({ activeWorkspaceId: id });
+  }
+
+  it('seeds the group with active when starting fresh', () => {
+    const store = createTestStore();
+    setActive(store, 'A');
+    store.getState().toggleMultiviewWorkspace('B');
+    expect(store.getState().multiviewIds).toEqual(['A', 'B']);
+  });
+
+  it('preserves Ctrl-click order across subsequent toggles', () => {
+    const store = createTestStore();
+    setActive(store, 'A');
+    store.getState().toggleMultiviewWorkspace('C');
+    store.getState().toggleMultiviewWorkspace('B');
+    // Active seeded first, then C, then B — render iterates this exact order.
+    expect(store.getState().multiviewIds).toEqual(['A', 'C', 'B']);
+  });
+
+  it('reseeds with new active when toggling outside a stale saved group', () => {
+    // Regression: after preserving the saved group across setActiveWorkspace,
+    // starting a fresh multiview from a non-member workspace must reset to
+    // [newActive, newId] — otherwise AppLayout keeps the grid hidden because
+    // the active id is not in multiviewIds. Caught by Codex 2026-05-12.
+    const store = createTestStore();
+    setActive(store, 'A');
+    store.getState().toggleMultiviewWorkspace('B'); // multiview = [A, B]
+    expect(store.getState().multiviewIds).toEqual(['A', 'B']);
+
+    setActive(store, 'C'); // user plain-clicks C; group preserved but active outside
+    store.getState().toggleMultiviewWorkspace('D'); // Ctrl-click D to start new multiview
+
+    expect(store.getState().multiviewIds).toEqual(['C', 'D']);
+  });
+
+  it('clears multiview when toggling down to a single member', () => {
+    const store = createTestStore();
+    setActive(store, 'A');
+    store.getState().toggleMultiviewWorkspace('B');
+    expect(store.getState().multiviewIds).toEqual(['A', 'B']);
+
+    store.getState().toggleMultiviewWorkspace('B'); // toggle B off
+    expect(store.getState().multiviewIds).toEqual([]);
+  });
+
+  it('clearMultiview empties the saved group', () => {
+    const store = createTestStore();
+    setActive(store, 'A');
+    store.getState().toggleMultiviewWorkspace('B');
+    store.getState().toggleMultiviewWorkspace('C');
+    expect(store.getState().multiviewIds).toEqual(['A', 'B', 'C']);
+
+    store.getState().clearMultiview();
+    expect(store.getState().multiviewIds).toEqual([]);
+  });
+});

--- a/src/renderer/stores/slices/__tests__/workspaceSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/workspaceSlice.test.ts
@@ -49,13 +49,12 @@ describe('WorkspaceSlice.setActiveWorkspace', () => {
     expect(store.getState().activeWorkspaceId).toBe(wsA.id);
   });
 
-  // Regression: 멀티뷰 상태에서 다른 탭을 눌러도 화면이 안 바뀌던 버그.
-  // Cause: AppLayout renders the multiview grid whenever multiviewIds.length
-  // >= 2, regardless of activeWorkspaceId. So plain-clicking a non-multiview
-  // tab updated activeWorkspaceId silently while the layout kept showing the
-  // old grid. Fix: setActiveWorkspace exits multiview when the target isn't
-  // part of it.
-  it('exits multiview when switching to a workspace not in the multiview set', () => {
+  // 멀티뷰 그룹은 명시적으로 해제하기 전까지 유지된다. 사용자가 그룹 외부
+  // 워크스페이스를 단순 클릭하면 그 워크스페이스의 단일 뷰로 전환되지만,
+  // 저장된 그룹은 그대로 보존돼서 그룹 멤버를 다시 누르면 그리드가 복원된다.
+  // (그리드 표시 조건은 AppLayout에서 activeWorkspaceId가 multiviewIds에
+  // 포함된 경우로 게이트됨 — 첫 회귀 "다른 탭 눌러도 화면 안 바뀜"도 같이 해결.)
+  it('preserves the saved multiview group when switching outside of it', () => {
     const store = createTestStore(
       [wsA, wsB, wsC],
       wsA.id,
@@ -64,7 +63,7 @@ describe('WorkspaceSlice.setActiveWorkspace', () => {
     store.getState().setActiveWorkspace(wsC.id); // C is NOT in multiview
 
     expect(store.getState().activeWorkspaceId).toBe(wsC.id);
-    expect(store.getState().multiviewIds).toEqual([]);
+    expect(store.getState().multiviewIds).toEqual([wsA.id, wsB.id]);
   });
 
   it('keeps multiview intact when switching to a workspace already in it', () => {

--- a/src/renderer/stores/slices/uiSlice.ts
+++ b/src/renderer/stores/slices/uiSlice.ts
@@ -373,9 +373,13 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
     if (idx >= 0) {
       state.multiviewIds.splice(idx, 1);
     } else {
-      // Add active workspace too if first selection
-      if (state.multiviewIds.length === 0) {
-        state.multiviewIds.push(state.activeWorkspaceId);
+      // Seed with active when starting fresh, OR when a previously saved group
+      // is still around but the user has navigated away from it (active is not
+      // a member). The second case appears as "Ctrl-click does nothing" because
+      // AppLayout gates the grid on active ∈ multiviewIds — without reseeding,
+      // the new id gets appended to the stale group and the grid stays hidden.
+      if (state.multiviewIds.length === 0 || !state.multiviewIds.includes(state.activeWorkspaceId)) {
+        state.multiviewIds = [state.activeWorkspaceId];
       }
       if (!state.multiviewIds.includes(wsId)) {
         state.multiviewIds.push(wsId);

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -96,16 +96,11 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
     setActiveWorkspace: (id) => set((state: StoreState) => {
       if (!state.workspaces.some((w: Workspace) => w.id === id)) return;
       state.activeWorkspaceId = id;
-      // If multiview is active and the user is switching to a workspace that
-      // isn't part of it, exit multiview. Without this, the active ID updates
-      // silently but the layout keeps rendering the multiview grid — the
-      // visible "다른 탭 눌러도 화면 안 바뀜" bug. Clicking a tab that IS in
-      // multiview leaves it intact (just updates focus). All callers benefit:
-      // sidebar plain-click, Ctrl+1..9, notification jump, command palette,
-      // external RPC routing — they all converge through this setter.
-      if (state.multiviewIds.length >= 2 && !state.multiviewIds.includes(id)) {
-        state.multiviewIds = [];
-      }
+      // multiviewIds is intentionally preserved here. AppLayout renders the
+      // grid only when activeWorkspaceId is part of multiviewIds, so switching
+      // to a non-multiview workspace shows its single view while the saved
+      // group survives — clicking any member restores the grid. Explicit
+      // disband still works via the ✕ button or Ctrl+Shift+G (clearMultiview).
     }),
 
     renameWorkspace: (id, name) => set((state: StoreState) => {


### PR DESCRIPTION
## Summary

- Multiview groups stay sticky across navigation (preserved until explicitly disbanded)
- Grid renders in Ctrl-click order, not workspace array order
- MiniSidebar (collapsed sidebar) gains feature parity with the expanded sidebar

## Background

Three bugs reported by the user:

1. Ctrl-click order ignored — multiview always rendered in workspace order
2. Plain-clicking a workspace outside the multiview group cleared the group entirely
3. Collapsed sidebar lost multiview indicator, drag-and-drop, and showed only "W" for every workspace

## Changes

### Multiview behavior
- `setActiveWorkspace` no longer clears `multiviewIds`; the saved group survives navigation
- `AppLayout` renders the grid only when `activeWorkspaceId ∈ multiviewIds` (this also fixes the older regression where clicking outside the group did not change the view)
- `AppLayout` iterates `multiviewIds` and looks up workspaces, preserving Ctrl-click order
- `toggleMultiviewWorkspace` reseeds with the active workspace when the saved group is stale (active is not a member). Without this, Ctrl-click appeared to do nothing because the grid stayed gated. Caught by Codex review.

### MiniSidebar parity
- Multiview indicator (left blue border)
- Ctrl-click toggles multiview membership
- Drag-and-drop reordering with above/below drop indicators
- Labels `W1, W2, W3 ...` (first initial + index) so workspaces with identical prefixes stay distinct
- Top-right unread count badge per workspace
- Bottom-right agent status dot (pulses while running)

### Shared
- `AGENT_STATUS_ICON` extracted to `src/renderer/components/Sidebar/agentStatusIcon.ts` so both sidebars stay in lockstep

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (943 tests, +5 new multiview regression tests)
- [x] Codex review: GATE PASS
- [x] Local dogfood: both expanded and collapsed sidebar verified

## Verified scenarios

- [x] `[A, B]` saved → click `C` → single view of `C` renders, `[A, B]` preserved
- [x] `[A, B]` saved → click `C` → click `A` → grid restored as `[A, B]`
- [x] `[A, B]` saved → click `C` → Ctrl-click `D` → new group `[C, D]` (reseed)
- [x] Ctrl-click order `A → C → B` → grid renders in `[A, C, B]` order
- [x] Collapsed sidebar: Ctrl-click toggle, drag reorder, multiview indicator all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)