### PR TITLE
fix(notifications): restore agent task-complete notification pipeline

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -39,3 +39,39 @@
 - **Cons:** collectLeafSurfaces로 workspace별 PTY 수집 로직 필요
 - **Context:** `src/company/renderer/provisioner.ts` 및 기존 CompanyPanel.tsx의 destroy 로직
 - **Depends on:** 없음
+
+## (E3) Agent status dot transient flash on completed/waiting
+- **What:** `agentStatusIcon.ts`/`MiniSidebar` dot animation을 `completed`/`waiting` 전환 시점에 한 번만 발화 (예: 2s flash). 현재 `running`만 `animate-pulse`이고 나머지는 정적.
+- **Why:** wmux 창에 포커스가 있어도 측면 시야에서 변화를 잡을 수 있어야 함. inline toast가 transient라 놓치기 쉬움.
+- **Pros:** 다중 agent 워크플로우에서 시각 신호 강화. CSS만으로 가능.
+- **Cons:** 여러 workspace가 동시에 completed로 변하면 시각 노이즈. tuning 필요.
+- **Context:** `src/renderer/components/Sidebar/agentStatusIcon.ts` className 매핑 + `MiniSidebar.tsx:133-140` / `WorkspaceItem.tsx:177-178`. `useEffect`로 status 변경 detect + setTimeout으로 transient class. CC 추정 15분.
+- **Depends on:** validated-pondering-grove plan (알림 파이프라인 복구) ship 후 사용자 피드백
+- **Priority:** P3 (cosmetic)
+
+## (E4) Per-workspace notification mute/snooze
+- **What:** `WorkspaceMetadata`에 `notificationsMuted: boolean` 필드 추가 + 사이드바 우클릭 메뉴 또는 settings에서 toggle. `useNotificationListener`가 muted workspace의 알림은 store에 안 push.
+- **Why:** v2.8.2에서 MAX_SESSIONS 50→200 확장됨. 다중 agent 동시 실행 시 알림 폭주 방지 필수.
+- **Pros:** 사용자 통제권. 시끄러운 빌드 workspace를 silent로.
+- **Cons:** UI 토글 위치/아이콘/i18n key 결정 필요. settings vs context menu 결정.
+- **Context:** `src/shared/types.ts:139` WorkspaceMetadata 확장, `src/renderer/hooks/useNotificationListener.ts:41-66`에서 muted 체크 추가, `notificationSlice.markAllReadForWorkspace`와 같은 패턴으로 mute action 추가. CC 추정 30-40분.
+- **Depends on:** 알림 파이프라인 복구 ship 후 사용자 피드백 (정말 시끄러운지 확인 후 우선순위)
+- **Priority:** P2
+
+## (E5) Tray icon unread badge (cross-platform)
+- **What:** `src/main/tray.ts`에 unread count를 표시. macOS: `app.dock.setBadge(N)`, Windows: tray tooltip prefix `[N] wmux`, Linux: best-effort (NotificationServer 표준은 제한적).
+- **Why:** wmux 창이 minimize/hide 상태에서는 OS 토스트 한 번 외에는 알림 신호 부재. tray가 영구 신호 채널.
+- **Pros:** 창 안 열어도 unread 인지. macOS 사용자에게 자연스러운 UX.
+- **Cons:** Cross-platform 차이 큼 — 3 OS에서 각각 QA 세션 필요. Linux fallback 정책 결정 필요.
+- **Context:** memory `project_cross_platform_branch_policy` 정책에 따라 **feature branch + PR**로 진행. `src/main/notification/ToastManager.ts`와 같은 자리에 `TrayBadgeManager` 추가 고려. Renderer store unread count 변경 → main으로 push → tray 갱신. CC 추정 30-45분 + 3 OS QA.
+- **Depends on:** 알림 파이프라인 복구 ship + 사용자가 minimize 사용 빈도 확인
+- **Priority:** P2
+
+## (Phase 2 / Eureka) Agent stop-hook OSC 9 signal
+- **What:** Claude Code/Codex의 `stop` hook 또는 shell integration을 통해 turn 종료 시 OSC 9 BEL (`\x1b]9;Agent done\x07`)를 emit하도록 가이드 + 설치 스크립트. 우리 `OscParser.ts`는 이미 OSC 9를 듣고 있어서 100% 신뢰 신호 채널이 됨.
+- **Why:** 휴리스틱(throughput) + 패턴 매칭(AgentDetector)은 외부에서 추측. agent 자신이 turn boundary를 가장 정확히 안다. tmux `monitor-silence` + iTerm2 OSC 9의 진화 형태.
+- **Pros:** 100% 정확. 휴리스틱 의존 0. Eureka 후보.
+- **Cons:** Claude Code 환경 변동 시 hook 깨질 위험. 사용자가 hook 설정 안 하면 fallback 필요(현재 path가 fallback 역할).
+- **Context:** Claude Code hooks 시스템(`~/.claude/settings.json`의 hook 정의). 설치 스크립트는 wmux 첫 실행 시 hook 등록 권유 wizard로 풀 수 있음.
+- **Depends on:** 알림 파이프라인 복구 ship 후 실측 데이터 — heuristic 정확도가 충분하면 우선순위 ↓
+- **Priority:** P3 (가치 높지만 외부 의존 + 가이드 필요)

--- a/src/daemon/DaemonPTYBridge.ts
+++ b/src/daemon/DaemonPTYBridge.ts
@@ -70,9 +70,13 @@ export class DaemonPTYBridge extends EventEmitter {
       this.emit('idle', { sessionId: ptyId });
     });
     // Activity → active notification (start of a sustained output burst).
-    // Consumers (main DaemonNotificationRouter) use this as the 'running'
-    // status signal and to reset AgentDetector emission dedup.
+    // Also resets AgentDetector emission dedup inside the daemon process so
+    // turn N+1's idle prompt fires again even if its text is identical to
+    // turn N. The reset MUST happen in-process: AgentDetector instances
+    // live in the daemon, so the main-side DaemonNotificationRouter can't
+    // reach into them the way local-mode PTYBridge does (Codex P1).
     this.activeUnsubscribe = activityMonitor.onActive((ptyId) => {
+      this.agentDetector?.resetEmissionState();
       this.emit('active', { sessionId: ptyId });
     });
 

--- a/src/daemon/DaemonPTYBridge.ts
+++ b/src/daemon/DaemonPTYBridge.ts
@@ -14,8 +14,10 @@ import { PromptEventLog, parseOsc133Payload } from './PromptEventLog';
  *  - 'data'     → Buffer (raw PTY output)
  *  - 'cwd'      → { sessionId: string, cwd: string }
  *  - 'agent'    → { sessionId: string, event: AgentEvent }
- *  - 'critical'  → { sessionId: string, event: CriticalEvent }
- *  - 'idle'     → { sessionId: string }
+ *  - 'critical' → { sessionId: string, event: CriticalEvent }
+ *  - 'active'   → { sessionId: string }                — onActive cycle start
+ *  - 'idle'     → { sessionId: string }                — onActiveToIdle
+ *  - 'exit'     → { sessionId: string, exitCode }
  */
 export class DaemonPTYBridge extends EventEmitter {
   private oscParser: OscParser | null = null;
@@ -24,6 +26,9 @@ export class DaemonPTYBridge extends EventEmitter {
   private dataDisposable: (() => void) | null = null;
   private exitDisposable: (() => void) | null = null;
   private idleUnsubscribe: (() => void) | null = null;
+  private activeUnsubscribe: (() => void) | null = null;
+  private agentUnsubscribe: (() => void) | null = null;
+  private criticalUnsubscribe: (() => void) | null = null;
   private sessionId: string | null = null;
   /**
    * v2.8.1 hotfix: when true, drop PTY output instead of writing it to
@@ -64,6 +69,12 @@ export class DaemonPTYBridge extends EventEmitter {
     this.idleUnsubscribe = activityMonitor.onActiveToIdle((ptyId) => {
       this.emit('idle', { sessionId: ptyId });
     });
+    // Activity → active notification (start of a sustained output burst).
+    // Consumers (main DaemonNotificationRouter) use this as the 'running'
+    // status signal and to reset AgentDetector emission dedup.
+    this.activeUnsubscribe = activityMonitor.onActive((ptyId) => {
+      this.emit('active', { sessionId: ptyId });
+    });
 
     // OSC events → cwd (OSC 7) and prompt/command markers (OSC 133)
     oscParser.onOsc((event) => {
@@ -82,12 +93,12 @@ export class DaemonPTYBridge extends EventEmitter {
     });
 
     // Agent detection
-    agentDetector.onEvent((agentEvent) => {
+    this.agentUnsubscribe = agentDetector.onEvent((agentEvent) => {
       this.emit('agent', { sessionId, event: agentEvent });
     });
 
     // Critical action detection
-    agentDetector.onCritical((criticalEvent) => {
+    this.criticalUnsubscribe = agentDetector.onCritical((criticalEvent) => {
       this.emit('critical', { sessionId, event: criticalEvent });
     });
 
@@ -161,6 +172,18 @@ export class DaemonPTYBridge extends EventEmitter {
 
     this.idleUnsubscribe?.();
     this.idleUnsubscribe = null;
+
+    this.activeUnsubscribe?.();
+    this.activeUnsubscribe = null;
+
+    // AgentDetector subscriptions: without explicit unsubscribe, recovered
+    // sessions or repeated setupDataForwarding calls would accumulate
+    // closure-captured callbacks against a stale `agentDetector` reference.
+    // (Same leak class as the v2.7.2 PlaywrightEngine CDP session fix.)
+    this.agentUnsubscribe?.();
+    this.agentUnsubscribe = null;
+    this.criticalUnsubscribe?.();
+    this.criticalUnsubscribe = null;
 
     // Stop activity monitor to clear timers and state
     if (this.activityMonitor && this.sessionId) {

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -195,6 +195,23 @@ export class DaemonSessionManager extends EventEmitter {
       this.emit('session:idle', payload);
     });
 
+    // 'active' (start of an output burst), 'agent' (AgentDetector status
+    // event), 'critical' (sensitive action approval request): forward to
+    // session manager so daemon/index.ts can broadcast them to the main
+    // process. Without this re-emission, daemon mode loses all notification
+    // signal even though DaemonPTYBridge detects it correctly.
+    bridge.on('active', (payload) => {
+      this.emit('session:active', payload);
+    });
+
+    bridge.on('agent', (payload) => {
+      this.emit('session:agent', payload);
+    });
+
+    bridge.on('critical', (payload) => {
+      this.emit('session:critical', payload);
+    });
+
     bridge.on('cwd', (payload: { sessionId: string; cwd: string }) => {
       meta.cwd = payload.cwd;
     });

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -824,6 +824,18 @@ function wireEvents(
     };
     pipeServer.broadcast(event);
   });
+
+  // Explicit destroy (pty:dispose path): distinct from session:died (natural
+  // PTY exit). Both must clear the main-side agentStatus so the sidebar dot
+  // doesn't lie about a closed terminal (Codex P2).
+  sessionManager.on('session:destroyed', (payload: { id: string }) => {
+    const event: DaemonEvent = {
+      type: 'session.destroyed',
+      sessionId: payload.id,
+      data: null,
+    };
+    pipeServer.broadcast(event);
+  });
 }
 
 // === State builder ===

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -786,13 +786,41 @@ function wireEvents(
     stateWriter.saveDebounced(state);
   });
 
-  // Bridge-level events: forward agent/critical/idle from all sessions
-  // These are emitted by DaemonSessionManager which re-emits bridge events
+  // Bridge-level events: forward agent/critical/idle/active from all sessions
+  // to clients (main process). These are emitted by DaemonSessionManager
+  // which re-emits bridge events.
   sessionManager.on('session:idle', (payload: { sessionId: string }) => {
     const event: DaemonEvent = {
       type: 'activity.idle',
       sessionId: payload.sessionId,
       data: null,
+    };
+    pipeServer.broadcast(event);
+  });
+
+  sessionManager.on('session:active', (payload: { sessionId: string }) => {
+    const event: DaemonEvent = {
+      type: 'activity.active',
+      sessionId: payload.sessionId,
+      data: null,
+    };
+    pipeServer.broadcast(event);
+  });
+
+  sessionManager.on('session:agent', (payload: { sessionId: string; event: { agent: string; status: string; message: string } }) => {
+    const event: DaemonEvent = {
+      type: 'agent.event',
+      sessionId: payload.sessionId,
+      data: payload.event,
+    };
+    pipeServer.broadcast(event);
+  });
+
+  sessionManager.on('session:critical', (payload: { sessionId: string; event: { action: string; riskLevel: string } }) => {
+    const event: DaemonEvent = {
+      type: 'agent.critical',
+      sessionId: payload.sessionId,
+      data: payload.event,
     };
     pipeServer.broadcast(event);
   });

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -290,13 +290,33 @@ export class DaemonClient extends EventEmitter {
     if (event.type) {
       this.emit('event', event);
 
-      // Emit specific events for convenience
-      if (event.type === 'session.died') {
-        const data = event.data as { exitCode?: number | null } | null;
-        this.emit('session:died', {
-          sessionId: event.sessionId,
-          exitCode: data?.exitCode ?? null,
-        });
+      // Emit specific events for convenience. Daemon mode consumers (in
+      // particular, DaemonNotificationRouter) subscribe to these to mirror
+      // the local-mode PTYBridge wiring: activity → 'running', agent →
+      // metadata + notification + toast, critical → approval request.
+      switch (event.type) {
+        case 'session.died': {
+          const data = event.data as { exitCode?: number | null } | null;
+          this.emit('session:died', {
+            sessionId: event.sessionId,
+            exitCode: data?.exitCode ?? null,
+          });
+          break;
+        }
+        case 'activity.idle':
+          this.emit('session:idle', { sessionId: event.sessionId });
+          break;
+        case 'activity.active':
+          this.emit('session:active', { sessionId: event.sessionId });
+          break;
+        case 'agent.event':
+          this.emit('session:agent', { sessionId: event.sessionId, event: event.data });
+          break;
+        case 'agent.critical':
+          this.emit('session:critical', { sessionId: event.sessionId, event: event.data });
+          break;
+        default:
+          break;
       }
     }
   }

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -303,6 +303,11 @@ export class DaemonClient extends EventEmitter {
           });
           break;
         }
+        case 'session.destroyed':
+          // pty:dispose path — distinct from session.died (natural exit).
+          // Notification router treats both the same: clear agentStatus.
+          this.emit('session:destroyed', { sessionId: event.sessionId });
+          break;
         case 'activity.idle':
           this.emit('session:idle', { sessionId: event.sessionId });
           break;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -30,6 +30,7 @@ import { AutoUpdater } from './updater/AutoUpdater';
 import { McpRegistrar } from './mcp/McpRegistrar';
 import { WebviewCdpManager } from './browser-session/WebviewCdpManager';
 import { DaemonClient, getDaemonPipeName, readDaemonAuthToken } from './DaemonClient';
+import { DaemonNotificationRouter } from './notification/DaemonNotificationRouter';
 import { ensureDaemon } from './daemon/launcher';
 import { createTray, destroyTray } from './tray';
 import { FirstRunOrchestrator } from './firstRun/FirstRunOrchestrator';
@@ -167,6 +168,11 @@ const claudeWorker = new ClaudeWorker(() => mainWindow);
 
 // Daemon client — initialized on app ready, used if daemon is available
 let daemonClient: DaemonClient | null = null;
+// In daemon mode, this router bridges daemon-broadcast events (agent status,
+// activity transitions, critical actions) into the same IPC channels
+// PTYBridge writes to in local mode. Without it, daemon mode would render
+// the notification pipeline 100% inert (Codex 2nd review #1).
+let daemonNotificationRouter: DaemonNotificationRouter | null = null;
 
 // v2.8.1 hotfix (Bug 3): one-shot decision flag for the daemon-vs-local
 // mode. Stays false until app.on('ready') has finished its connect
@@ -365,12 +371,20 @@ app.on('ready', async () => {
         console.log('[Main] Connected to wmux-daemon (auth verified)');
         cleanupHandlers();
         cleanupHandlers = registerAllHandlers(ptyManager, ptyBridge, () => mainWindow, daemonClient, mcpHandlerOptions);
+        // Mount the notification router now that we have a live daemon
+        // client. PTY data flows through daemon → DaemonClient events, and
+        // this router translates them into the same renderer-facing IPC
+        // signals PTYBridge produces in local mode.
+        daemonNotificationRouter = new DaemonNotificationRouter(daemonClient, () => mainWindow);
+        daemonNotificationRouter.start();
         // Notify renderer that daemon is now connected so it can re-reconcile
         if (mainWindow && !mainWindow.isDestroyed()) {
           mainWindow.webContents.send('daemon:connected');
         }
         daemonClient.on('disconnected', () => {
           console.warn('[Main] Daemon disconnected, falling back to local PTY');
+          daemonNotificationRouter?.stop();
+          daemonNotificationRouter = null;
           daemonClient = null;
           cleanupHandlers();
           cleanupHandlers = registerAllHandlers(ptyManager, ptyBridge, () => mainWindow, undefined, mcpHandlerOptions);

--- a/src/main/ipc/handlers/metadata.handler.ts
+++ b/src/main/ipc/handlers/metadata.handler.ts
@@ -1,9 +1,24 @@
 import { ipcMain, BrowserWindow } from 'electron';
 import fs from 'node:fs';
 import { IPC } from '../../../shared/constants';
+import type { MetadataUpdatePayload } from '../../../shared/types';
 import { MetadataCollector } from '../../metadata/MetadataCollector';
 import { PTYManager } from '../../pty/PTYManager';
 import { wrapHandler } from '../wrapHandler';
+
+/**
+ * Single source for IPC.METADATA_UPDATE outgoing messages. All metadata-like
+ * channels (this handler's CWD/git polling, PTYBridge's agent status events,
+ * meta.rpc's status/progress RPCs) send through `MetadataUpdatePayload` so
+ * the preload + renderer contract has exactly one shape.
+ */
+export function broadcastMetadataUpdate(
+  window: BrowserWindow | null,
+  payload: MetadataUpdatePayload,
+): void {
+  if (!window || window.isDestroyed()) return;
+  window.webContents.send(IPC.METADATA_UPDATE, payload);
+}
 
 const collector = new MetadataCollector();
 
@@ -54,7 +69,7 @@ export function registerMetadataHandlers(
         // If shell integration provided a branch via OSC 7727, skip git exec polling
         const shellBranch = branchMap.get(ptyId);
         const metadata = await collector.collect(cwd, shellBranch);
-        win.webContents.send(IPC.METADATA_UPDATE, ptyId, metadata);
+        broadcastMetadataUpdate(win, { ptyId, ...metadata });
       }
     }
   }, 5000);

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -8,6 +8,7 @@ import { DaemonClient } from '../../DaemonClient';
 import { IPC, getPidMapDir } from '../../../shared/constants';
 import { sanitizePtyText } from '../../../shared/types';
 import { updateCwd } from './metadata.handler';
+import { markResize, markUserWrite } from '../../notification/idleSuppression';
 import { wrapHandler } from '../wrapHandler';
 
 /**
@@ -185,6 +186,10 @@ export function registerPTYHandlers(
   }
 
   // pty:write
+  // User keystrokes echo back through the PTY (the shell/TUI writes them
+  // to the screen), so they show up to ActivityMonitor as agent output.
+  // Mark the user-write timestamp so the idle fallback suppresses itself
+  // while the user is typing (see idleSuppression.ts).
   ipcMain.removeAllListeners(IPC.PTY_WRITE);
   if (useDaemon && daemonClient) {
     const onPtyWrite = (_event: Electron.IpcMainEvent, id: string, data: string): void => {
@@ -193,6 +198,7 @@ export function registerPTYHandlers(
         console.warn(`[PTY_WRITE] dropped oversize write: ${data.length} chars (limit 100_000). This is a backstop; renderer should chunk.`);
         return; // prevent mega-writes
       }
+      markUserWrite(id);
       daemonClient.writeToSession(id, sanitizePtyText(data));
     };
     ipcMain.on(IPC.PTY_WRITE, onPtyWrite);
@@ -204,18 +210,25 @@ export function registerPTYHandlers(
         console.warn(`[PTY_WRITE] dropped oversize write: ${data.length} chars (limit 100_000). This is a backstop; renderer should chunk.`);
         return;
       }
+      markUserWrite(id);
       ptyManager.write(id, sanitizePtyText(data));
     };
     ipcMain.on(IPC.PTY_WRITE, onPtyWrite);
   }
 
   // pty:resize
+  // TUI agents (Claude, Codex, etc.) respond to SIGWINCH with a full-screen
+  // redraw, which spikes ActivityMonitor's byte counter and triggers the
+  // "Task may have finished" fallback when the user moves on within 5s.
+  // Mark the resize timestamp so the fallback suppresses itself for the
+  // suppression window (see idleSuppression.ts).
   ipcMain.removeHandler(IPC.PTY_RESIZE);
   if (useDaemon && daemonClient) {
     ipcMain.handle(IPC.PTY_RESIZE, wrapHandler(IPC.PTY_RESIZE, async (_event: Electron.IpcMainInvokeEvent, id: string, cols: number, rows: number) => {
       if (!Number.isInteger(cols) || cols <= 0 || !Number.isInteger(rows) || rows <= 0) {
         throw new Error(`PTY_RESIZE: cols and rows must be positive integers (got cols=${cols}, rows=${rows})`);
       }
+      markResize(id);
       try {
         await daemonClient.rpc('daemon.resizeSession', { id, cols, rows });
       } catch (err: unknown) {
@@ -231,6 +244,7 @@ export function registerPTYHandlers(
         throw new Error(`PTY_RESIZE: cols and rows must be positive integers (got cols=${cols}, rows=${rows})`);
       }
       if (!ptyManager.get(id)) return;
+      markResize(id);
       ptyManager.resize(id, cols, rows);
     }));
   }

--- a/src/main/notification/DaemonNotificationRouter.ts
+++ b/src/main/notification/DaemonNotificationRouter.ts
@@ -3,6 +3,7 @@ import type { DaemonClient } from '../DaemonClient';
 import type { AgentStatus } from '../../shared/types';
 import { IPC } from '../../shared/constants';
 import { sendNotification } from './sendNotification';
+import { recentlySuppressed, clearPty as clearSuppression } from './idleSuppression';
 import { broadcastMetadataUpdate } from '../ipc/handlers/metadata.handler';
 import { toastManager } from '../pipe/handlers/notify.rpc';
 
@@ -93,10 +94,20 @@ export class DaemonNotificationRouter {
     };
 
     const onIdle = (payload: { sessionId: string }) => {
+      const now = Date.now();
       const lastAgentAt = this.lastAgentEventAt.get(payload.sessionId) ?? 0;
-      if (Date.now() - lastAgentAt < AGENT_EVENT_SUPPRESSION_MS) return;
+      if (now - lastAgentAt < AGENT_EVENT_SUPPRESSION_MS) return;
+      // Same resize/typing suppression as local mode (see idleSuppression.ts).
+      if (recentlySuppressed(payload.sessionId, now)) return;
       try {
         const win = this.getWindow();
+        // Clear stale 'running' alongside the fallback toast, mirroring
+        // PTYBridge.onActiveToIdle behavior.
+        broadcastMetadataUpdate(win, {
+          ptyId: payload.sessionId,
+          agentStatus: 'idle',
+          agentName: '',
+        });
         const notification = {
           type: 'agent' as const,
           title: 'Task may have finished',
@@ -135,6 +146,7 @@ export class DaemonNotificationRouter {
           agentName: '',
         });
         this.lastAgentEventAt.delete(payload.sessionId);
+        clearSuppression(payload.sessionId);
       } catch (err) {
         console.warn('[DaemonNotificationRouter] session end error:', err);
       }

--- a/src/main/notification/DaemonNotificationRouter.ts
+++ b/src/main/notification/DaemonNotificationRouter.ts
@@ -121,7 +121,10 @@ export class DaemonNotificationRouter {
       }
     };
 
-    const onDied = (payload: { sessionId: string }) => {
+    // session:died (natural PTY exit) and session:destroyed (pty:dispose)
+    // both clear agentStatus. Only listening to session:died left a stale
+    // sidebar dot when the user closed a terminal intentionally (Codex P2).
+    const onSessionEnd = (payload: { sessionId: string }) => {
       try {
         broadcastMetadataUpdate(this.getWindow(), {
           ptyId: payload.sessionId,
@@ -130,7 +133,7 @@ export class DaemonNotificationRouter {
         });
         this.lastAgentEventAt.delete(payload.sessionId);
       } catch (err) {
-        console.warn('[DaemonNotificationRouter] session:died error:', err);
+        console.warn('[DaemonNotificationRouter] session end error:', err);
       }
     };
 
@@ -138,14 +141,16 @@ export class DaemonNotificationRouter {
     this.daemonClient.on('session:active', onActive);
     this.daemonClient.on('session:idle', onIdle);
     this.daemonClient.on('session:critical', onCritical);
-    this.daemonClient.on('session:died', onDied);
+    this.daemonClient.on('session:died', onSessionEnd);
+    this.daemonClient.on('session:destroyed', onSessionEnd);
 
     this.cleanups.push(
       () => this.daemonClient.off('session:agent', onAgent),
       () => this.daemonClient.off('session:active', onActive),
       () => this.daemonClient.off('session:idle', onIdle),
       () => this.daemonClient.off('session:critical', onCritical),
-      () => this.daemonClient.off('session:died', onDied),
+      () => this.daemonClient.off('session:died', onSessionEnd),
+      () => this.daemonClient.off('session:destroyed', onSessionEnd),
     );
   }
 

--- a/src/main/notification/DaemonNotificationRouter.ts
+++ b/src/main/notification/DaemonNotificationRouter.ts
@@ -1,0 +1,159 @@
+import type { BrowserWindow } from 'electron';
+import type { DaemonClient } from '../DaemonClient';
+import type { AgentStatus } from '../../shared/types';
+import { IPC } from '../../shared/constants';
+import { sendNotification } from './sendNotification';
+import { broadcastMetadataUpdate } from '../ipc/handlers/metadata.handler';
+import { toastManager } from '../pipe/handlers/notify.rpc';
+
+// Mirrors PTYBridge.AGENT_EVENT_SUPPRESSION_MS — same dedup semantics across
+// daemon and local modes.
+const AGENT_EVENT_SUPPRESSION_MS = 10_000;
+
+interface AgentEventPayload {
+  agent: string;
+  status: AgentStatus;
+  message: string;
+}
+
+interface CriticalEventPayload {
+  action: string;
+  riskLevel: 'review' | 'critical';
+}
+
+/**
+ * In daemon mode, PTY data flows through DaemonPTYBridge inside the daemon
+ * process — main never sees raw bytes, so the local PTYBridge subscriptions
+ * (onEvent, onActive, onActiveToIdle) never fire. Without an explicit bridge
+ * here, all notification signal is lost in production (Codex 2nd-round
+ * review #1).
+ *
+ * DaemonNotificationRouter subscribes to DaemonClient's re-emitted events
+ * and runs the same handler logic PTYBridge does:
+ *   - session:agent → METADATA_UPDATE (sidebar dot) + NOTIFICATION
+ *     (unread badge + in-app toast + OS toast)
+ *   - session:active → METADATA_UPDATE (agentStatus = 'running')
+ *   - session:idle → fallback NOTIFICATION, suppressed if a recent agent
+ *     event already covered it
+ *   - session:critical → APPROVAL_REQUEST IPC
+ *   - session:died → METADATA_UPDATE (agentStatus = 'idle')
+ *
+ * The router does NOT reset AgentDetector emission state on 'active' the way
+ * PTYBridge does — AgentDetector lives inside the daemon process and resets
+ * itself on each new burst via the bridge wiring, not from main.
+ */
+export class DaemonNotificationRouter {
+  private cleanups: Array<() => void> = [];
+  private lastAgentEventAt = new Map<string, number>();
+
+  constructor(
+    private daemonClient: DaemonClient,
+    private getWindow: () => BrowserWindow | null,
+  ) {}
+
+  start(): void {
+    const onAgent = (payload: { sessionId: string; event: unknown }) => {
+      try {
+        const win = this.getWindow();
+        const ev = payload.event as AgentEventPayload;
+        if (!ev || typeof ev !== 'object') return;
+        broadcastMetadataUpdate(win, {
+          ptyId: payload.sessionId,
+          agentStatus: ev.status,
+          agentName: ev.agent,
+        });
+        if (ev.status === 'waiting' || ev.status === 'complete') {
+          this.lastAgentEventAt.set(payload.sessionId, Date.now());
+          const title = `${ev.agent}: ${ev.message}`;
+          const body = ev.status === 'waiting' ? 'Ready for input' : 'Task finished';
+          sendNotification(win, payload.sessionId, { type: 'agent', title, body });
+          toastManager.show(title, body);
+        }
+      } catch (err) {
+        console.warn('[DaemonNotificationRouter] session:agent error:', err);
+      }
+    };
+
+    const onActive = (payload: { sessionId: string }) => {
+      try {
+        broadcastMetadataUpdate(this.getWindow(), {
+          ptyId: payload.sessionId,
+          agentStatus: 'running',
+          // agentName left empty: AgentDetector lives in the daemon, so we
+          // don't have its lastAgent readily available here. The next
+          // 'session:agent' event will populate the name.
+          agentName: '',
+        });
+      } catch (err) {
+        console.warn('[DaemonNotificationRouter] session:active error:', err);
+      }
+    };
+
+    const onIdle = (payload: { sessionId: string }) => {
+      const lastAgentAt = this.lastAgentEventAt.get(payload.sessionId) ?? 0;
+      if (Date.now() - lastAgentAt < AGENT_EVENT_SUPPRESSION_MS) return;
+      try {
+        const win = this.getWindow();
+        const notification = {
+          type: 'agent' as const,
+          title: 'Task may have finished',
+          body: 'Terminal output stopped after active period',
+        };
+        sendNotification(win, payload.sessionId, notification);
+        toastManager.show(notification.title, notification.body);
+      } catch (err) {
+        console.warn('[DaemonNotificationRouter] session:idle error:', err);
+      }
+    };
+
+    const onCritical = (payload: { sessionId: string; event: unknown }) => {
+      try {
+        const win = this.getWindow();
+        if (!win || win.isDestroyed()) return;
+        const ev = payload.event as CriticalEventPayload;
+        if (!ev || typeof ev !== 'object') return;
+        win.webContents.send(IPC.APPROVAL_REQUEST, payload.sessionId, {
+          action: ev.action,
+          riskLevel: ev.riskLevel,
+        });
+      } catch (err) {
+        console.warn('[DaemonNotificationRouter] session:critical error:', err);
+      }
+    };
+
+    const onDied = (payload: { sessionId: string }) => {
+      try {
+        broadcastMetadataUpdate(this.getWindow(), {
+          ptyId: payload.sessionId,
+          agentStatus: 'idle',
+          agentName: '',
+        });
+        this.lastAgentEventAt.delete(payload.sessionId);
+      } catch (err) {
+        console.warn('[DaemonNotificationRouter] session:died error:', err);
+      }
+    };
+
+    this.daemonClient.on('session:agent', onAgent);
+    this.daemonClient.on('session:active', onActive);
+    this.daemonClient.on('session:idle', onIdle);
+    this.daemonClient.on('session:critical', onCritical);
+    this.daemonClient.on('session:died', onDied);
+
+    this.cleanups.push(
+      () => this.daemonClient.off('session:agent', onAgent),
+      () => this.daemonClient.off('session:active', onActive),
+      () => this.daemonClient.off('session:idle', onIdle),
+      () => this.daemonClient.off('session:critical', onCritical),
+      () => this.daemonClient.off('session:died', onDied),
+    );
+  }
+
+  stop(): void {
+    for (const fn of this.cleanups) {
+      try { fn(); } catch (err) { console.warn('[DaemonNotificationRouter] cleanup error:', err); }
+    }
+    this.cleanups.length = 0;
+    this.lastAgentEventAt.clear();
+  }
+}

--- a/src/main/notification/DaemonNotificationRouter.ts
+++ b/src/main/notification/DaemonNotificationRouter.ts
@@ -76,13 +76,16 @@ export class DaemonNotificationRouter {
 
     const onActive = (payload: { sessionId: string }) => {
       try {
+        // Intentionally omit `agentName`: the daemon's AgentDetector owns
+        // the last-agent name, and we can't reach into it from main. If we
+        // emitted `agentName: ''` here, the renderer's Object.assign would
+        // clobber the legitimate name set by the previous session:agent
+        // event, making the sidebar label flicker to blank on every burst.
+        // Leaving the field out preserves the prior name; the next
+        // session:agent event will refresh it.
         broadcastMetadataUpdate(this.getWindow(), {
           ptyId: payload.sessionId,
           agentStatus: 'running',
-          // agentName left empty: AgentDetector lives in the daemon, so we
-          // don't have its lastAgent readily available here. The next
-          // 'session:agent' event will populate the name.
-          agentName: '',
         });
       } catch (err) {
         console.warn('[DaemonNotificationRouter] session:active error:', err);

--- a/src/main/notification/__tests__/sendNotification.test.ts
+++ b/src/main/notification/__tests__/sendNotification.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { sendNotification } from '../sendNotification';
+import { IPC } from '../../../shared/constants';
+
+function makeWindow(isDestroyed = false) {
+  return {
+    isDestroyed: () => isDestroyed,
+    webContents: { send: vi.fn() },
+  };
+}
+
+describe('sendNotification', () => {
+  it('no-op when window is null', () => {
+    // Should not throw and should not invoke any send
+    expect(() => sendNotification(null, 'p1', { title: 't', body: 'b', type: 'info' })).not.toThrow();
+  });
+
+  it('no-op when window is destroyed', () => {
+    const win = makeWindow(true);
+    sendNotification(win as never, 'p1', { title: 't', body: 'b', type: 'info' });
+    expect(win.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('sends (channel, ptyId, payload) when ptyId is a string', () => {
+    const win = makeWindow();
+    sendNotification(win as never, 'pty-1', { title: 't', body: 'b', type: 'agent' });
+    expect(win.webContents.send).toHaveBeenCalledTimes(1);
+    expect(win.webContents.send).toHaveBeenCalledWith(IPC.NOTIFICATION, 'pty-1', {
+      title: 't', body: 'b', type: 'agent',
+    });
+  });
+
+  it('sends with ptyId=null for app-level / RPC notifications', () => {
+    const win = makeWindow();
+    sendNotification(win as never, null, { title: 't', body: 'b', type: 'info', workspaceId: 'ws-9' });
+    expect(win.webContents.send).toHaveBeenCalledWith(IPC.NOTIFICATION, null, {
+      title: 't', body: 'b', type: 'info', workspaceId: 'ws-9',
+    });
+  });
+});

--- a/src/main/notification/idleSuppression.ts
+++ b/src/main/notification/idleSuppression.ts
@@ -1,0 +1,55 @@
+/**
+ * Per-PTY suppression for the ActivityMonitor "Task may have finished"
+ * fallback notification.
+ *
+ * The fallback fires when output has been quiet for IDLE_DELAY_MS (5s) after
+ * a sustained burst. That heuristic produces false positives in two
+ * everyday cases:
+ *
+ *   1. PTY resize: switching to a workspace fits xterm, sends pty:resize,
+ *      and TUI agents (Claude, Codex) respond with a full-screen redraw.
+ *      The redraw is several KB → ActivityMonitor enters 'active'. If the
+ *      user leaves the workspace within 5s, the idle timer fires later and
+ *      a notification appears for a workspace the user just visited
+ *      without typing anything.
+ *
+ *   2. User typing: keystrokes echo back through the PTY (the shell or TUI
+ *      writes the typed character to the screen). Long input, paste, or
+ *      sustained typing crosses the active threshold; pausing to think
+ *      then fires the idle notification while the user is still composing.
+ *
+ * Both PTYBridge (local mode) and DaemonNotificationRouter (daemon mode)
+ * consult `recentlySuppressed(ptyId)` before emitting the activity
+ * fallback, and skip when a recent resize / user write happened.
+ *
+ * AgentDetector emissions are NOT gated by this — they are precise signals
+ * tied to specific prompt patterns, not throughput heuristics.
+ */
+
+// Window length: bigger than ActivityMonitor's IDLE_DELAY_MS (5s) so any
+// idle timer that started during the suppression window still observes the
+// suppression when it fires. 30s gives ample headroom for slow typists
+// and large redraws without masking genuine long-running agent output.
+const SUPPRESSION_WINDOW_MS = 30_000;
+
+const lastResizeAt = new Map<string, number>();
+const lastUserWriteAt = new Map<string, number>();
+
+export function markResize(ptyId: string): void {
+  lastResizeAt.set(ptyId, Date.now());
+}
+
+export function markUserWrite(ptyId: string): void {
+  lastUserWriteAt.set(ptyId, Date.now());
+}
+
+export function recentlySuppressed(ptyId: string, now: number = Date.now()): boolean {
+  const r = lastResizeAt.get(ptyId) ?? 0;
+  const w = lastUserWriteAt.get(ptyId) ?? 0;
+  return (now - r < SUPPRESSION_WINDOW_MS) || (now - w < SUPPRESSION_WINDOW_MS);
+}
+
+export function clearPty(ptyId: string): void {
+  lastResizeAt.delete(ptyId);
+  lastUserWriteAt.delete(ptyId);
+}

--- a/src/main/notification/sendNotification.ts
+++ b/src/main/notification/sendNotification.ts
@@ -1,0 +1,42 @@
+import type { BrowserWindow } from 'electron';
+import type { NotificationType } from '../../shared/types';
+import { IPC } from '../../shared/constants';
+
+export interface NotificationPayload {
+  title: string;
+  body: string;
+  type: NotificationType;
+  /**
+   * When ptyId is null, the notification did not originate from a specific
+   * surface (e.g. external MCP `notify` RPC, app-level alerts). The renderer
+   * uses workspaceId to resolve the active surface, or surfaces a
+   * workspace-scoped notification with surfaceId left undefined.
+   */
+  workspaceId?: string;
+}
+
+/**
+ * Module-level utility for sending notifications from main to renderer.
+ *
+ * Previously, four call sites in PTYBridge plus one in notify.rpc.ts inlined
+ * their own `webContents.send(IPC.NOTIFICATION, ...)` calls with subtly
+ * different argument shapes. notify.rpc was particularly broken: it sent
+ * `(channel, payloadObject)` while preload's `notification.onNew` listener
+ * expects `(channel, ptyId, payload)`, so the payload silently arrived as
+ * `ptyId` and the actual data was undefined.
+ *
+ * Centralizing here gives one place to define the IPC contract:
+ *   webContents.send(IPC.NOTIFICATION, ptyId: string | null, payload)
+ *
+ * Renderer's useNotificationListener consults `ptyId` to find the originating
+ * surface; if null, it falls back to `payload.workspaceId` and resolves the
+ * active surface from the store.
+ */
+export function sendNotification(
+  window: BrowserWindow | null,
+  ptyId: string | null,
+  payload: NotificationPayload,
+): void {
+  if (!window || window.isDestroyed()) return;
+  window.webContents.send(IPC.NOTIFICATION, ptyId, payload);
+}

--- a/src/main/pipe/handlers/__tests__/notify.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/notify.rpc.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Hoisted mocks — vi.mock factories are hoisted above the imports below.
+const mocks = vi.hoisted(() => ({
+  sendNotification: vi.fn(),
+  toastManagerShow: vi.fn(),
+}));
+
+vi.mock('electron', () => ({}));
+
+vi.mock('../../../notification/sendNotification', () => ({
+  sendNotification: mocks.sendNotification,
+}));
+
+vi.mock('../../../notification/ToastManager', () => ({
+  ToastManager: class { show = mocks.toastManagerShow; },
+}));
+
+import { RpcRouter } from '../../RpcRouter';
+import { registerNotifyRpc } from '../notify.rpc';
+
+function setupRouter() {
+  const router = new RpcRouter();
+  const win = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+  registerNotifyRpc(router, () => win as never);
+  return { router, win };
+}
+
+describe('notify.rpc', () => {
+  beforeEach(() => {
+    mocks.sendNotification.mockReset();
+    mocks.toastManagerShow.mockReset();
+  });
+
+  it('rejects when title is missing', async () => {
+    const { router } = setupRouter();
+    const res = await router.dispatch({ id: '1', method: 'notify', params: { body: 'b' } });
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects when body is missing', async () => {
+    const { router } = setupRouter();
+    const res = await router.dispatch({ id: '2', method: 'notify', params: { title: 't' } });
+    expect(res.ok).toBe(false);
+  });
+
+  it('REGRESSION (R6): workspaceId is OPTIONAL — CLI without workspaceId still succeeds', () => {
+    // Backward compat for `wmux notify --title X --body Y` from the CLI:
+    // before this fix, requiring workspaceId would break every CLI call.
+    return setupRouter().router.dispatch({
+      id: '3', method: 'notify', params: { title: 't', body: 'b' },
+    }).then((res) => {
+      expect(res.ok).toBe(true);
+      expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
+      const [, ptyId, payload] = mocks.sendNotification.mock.calls[0];
+      expect(ptyId).toBeNull();
+      expect(payload).toMatchObject({ title: 't', body: 'b', type: 'info' });
+      expect(payload.workspaceId).toBeUndefined();
+    });
+  });
+
+  it('forwards workspaceId when provided (MCP path with precise routing)', async () => {
+    const { router } = setupRouter();
+    const res = await router.dispatch({
+      id: '4', method: 'notify',
+      params: { title: 't', body: 'b', type: 'agent', workspaceId: 'ws-7' },
+    });
+    expect(res.ok).toBe(true);
+    const [, ptyId, payload] = mocks.sendNotification.mock.calls[0];
+    expect(ptyId).toBeNull();
+    expect(payload).toMatchObject({ title: 't', body: 'b', type: 'agent', workspaceId: 'ws-7' });
+  });
+
+  it('falls back to "info" type when type is missing or invalid', async () => {
+    const { router } = setupRouter();
+    await router.dispatch({ id: '5', method: 'notify', params: { title: 't', body: 'b', type: 'unknown' } });
+    const [, , payload] = mocks.sendNotification.mock.calls[0];
+    expect(payload.type).toBe('info');
+  });
+
+  it('always invokes the OS toast manager (focus gate is internal to ToastManager)', async () => {
+    const { router } = setupRouter();
+    await router.dispatch({ id: '6', method: 'notify', params: { title: 't', body: 'b' } });
+    expect(mocks.toastManagerShow).toHaveBeenCalledWith('t', 'b');
+  });
+});

--- a/src/main/pipe/handlers/meta.rpc.ts
+++ b/src/main/pipe/handlers/meta.rpc.ts
@@ -1,52 +1,46 @@
 import type { BrowserWindow } from 'electron';
 import type { RpcRouter } from '../RpcRouter';
-import { IPC } from '../../../shared/constants';
+import type { MetadataUpdatePayload } from '../../../shared/types';
+import { broadcastMetadataUpdate } from '../../ipc/handlers/metadata.handler';
 
 type GetWindow = () => BrowserWindow | null;
 
 /**
- * Sub-channel names embedded in the METADATA_UPDATE IPC message.
- * The renderer's useNotificationListener (or a dedicated metadata listener)
- * discriminates on the `kind` field.
+ * meta.setStatus / meta.setProgress write through the unified
+ * MetadataUpdatePayload shape on IPC.METADATA_UPDATE. The previous
+ * discriminated `{kind, ...}` payload conflicted with the (ptyId, data)
+ * shape sent by metadata.handler.ts, which broke preload's listener for one
+ * of the two paths. Both paths now agree on a single shape.
+ *
+ * Without ptyId/workspaceId, the renderer applies the update to the active
+ * workspace (status/progress are workspace-level fields).
  */
-type MetaUpdateKind = 'status' | 'progress';
-
-interface MetaStatusPayload {
-  kind: 'status';
-  text: string;
-}
-
-interface MetaProgressPayload {
-  kind: 'progress';
-  value: number;
-}
-
-type MetaPayload = MetaStatusPayload | MetaProgressPayload;
-
-function sendMeta(getWindow: GetWindow, payload: MetaPayload): Promise<{ ok: boolean }> {
+function sendMeta(getWindow: GetWindow, payload: MetadataUpdatePayload): Promise<{ ok: boolean }> {
   const win = getWindow();
   if (!win || win.isDestroyed()) {
     return Promise.reject(new Error('meta: BrowserWindow is not available'));
   }
-  win.webContents.send(IPC.METADATA_UPDATE, payload);
+  broadcastMetadataUpdate(win, payload);
   return Promise.resolve({ ok: true });
 }
 
 export function registerMetaRpc(router: RpcRouter, getWindow: GetWindow): void {
   /**
-   * meta.setStatus — sets an arbitrary status text string in the renderer.
-   * params: { text: string }
+   * meta.setStatus — sets an arbitrary status text string on the active
+   * workspace.
+   * params: { text: string, workspaceId?: string }
    */
   router.register('meta.setStatus', (params) => {
     if (typeof params['text'] !== 'string') {
       throw new Error('meta.setStatus: missing required param "text"');
     }
-    return sendMeta(getWindow, { kind: 'status', text: params['text'] });
+    const workspaceId = typeof params['workspaceId'] === 'string' ? params['workspaceId'] : undefined;
+    return sendMeta(getWindow, { status: params['text'], workspaceId });
   });
 
   /**
-   * meta.setProgress — sets a progress value (0–100) in the renderer.
-   * params: { value: number }
+   * meta.setProgress — sets a progress value (0–100) on the active workspace.
+   * params: { value: number, workspaceId?: string }
    * Values outside 0–100 are clamped.
    */
   router.register('meta.setProgress', (params) => {
@@ -54,6 +48,7 @@ export function registerMetaRpc(router: RpcRouter, getWindow: GetWindow): void {
       throw new Error('meta.setProgress: missing required param "value" (number)');
     }
     const value = Math.min(100, Math.max(0, params['value']));
-    return sendMeta(getWindow, { kind: 'progress', value });
+    const workspaceId = typeof params['workspaceId'] === 'string' ? params['workspaceId'] : undefined;
+    return sendMeta(getWindow, { progress: value, workspaceId });
   });
 }

--- a/src/main/pipe/handlers/notify.rpc.ts
+++ b/src/main/pipe/handlers/notify.rpc.ts
@@ -1,8 +1,8 @@
 import type { BrowserWindow } from 'electron';
 import type { RpcRouter } from '../RpcRouter';
 import type { NotificationType } from '../../../shared/types';
-import { IPC } from '../../../shared/constants';
 import { ToastManager } from '../../notification/ToastManager';
+import { sendNotification } from '../../notification/sendNotification';
 
 type GetWindow = () => BrowserWindow | null;
 
@@ -20,9 +20,14 @@ export function registerNotifyRpc(router: RpcRouter, getWindow: GetWindow): void
    * not focused, also shows a Windows Toast notification.
    *
    * params: {
-   *   title:   string
-   *   body:    string
-   *   type?:   'info' | 'warning' | 'error' | 'agent'  (default: 'info')
+   *   title:        string
+   *   body:         string
+   *   type?:        'info' | 'warning' | 'error' | 'agent'  (default: 'info')
+   *   workspaceId?: string  — optional. When omitted, the renderer applies
+   *                           to the active workspace (backward compat for
+   *                           CLI `wmux notify` callers; MCP clients that
+   *                           know their workspace via mcp.claimWorkspace
+   *                           SHOULD send it for precise routing)
    * }
    */
   router.register('notify', (params) => {
@@ -38,12 +43,12 @@ export function registerNotifyRpc(router: RpcRouter, getWindow: GetWindow): void
     const type: NotificationType = isNotificationType(params['type'])
       ? params['type']
       : 'info';
+    const workspaceId = typeof params['workspaceId'] === 'string' ? params['workspaceId'] : undefined;
 
-    const win = getWindow();
-    if (win && !win.isDestroyed()) {
-      // Push notification to the renderer notification store
-      win.webContents.send(IPC.NOTIFICATION, { title, body, type });
-    }
+    // ptyId is null here — this RPC originates outside any PTY. The renderer
+    // resolves a surface via `workspaceId` (if provided) or falls back to
+    // the active workspace.
+    sendNotification(getWindow(), null, { title, body, type, workspaceId });
 
     // Show OS-level toast (only when window is not focused)
     toastManager.show(title, body);

--- a/src/main/pty/ActivityMonitor.ts
+++ b/src/main/pty/ActivityMonitor.ts
@@ -16,7 +16,8 @@ interface PtyState {
   bytes: number;
   windowStart: number;
   active: boolean;
-  notified: boolean;     // already fired — waiting for new active cycle
+  notified: boolean;     // active→idle already fired — waiting for new cycle
+  activeFired: boolean;  // onActive already fired this cycle — dedup IPC spam
   idleTimer: ReturnType<typeof setTimeout> | null;
   lastReschedule: number; // last time we (re)scheduled the idle timer
 }
@@ -34,13 +35,35 @@ export class ActivityMonitor {
   private static RESCHEDULE_THROTTLE_MS = 100;
 
   private states = new Map<string, PtyState>();
-  private callbacks: ((ptyId: string) => void)[] = [];
+  private idleCallbacks: ((ptyId: string) => void)[] = [];
+  private activeCallbacks: ((ptyId: string) => void)[] = [];
 
+  /**
+   * Fires once when a PTY drops to idle after a sustained burst. Returns an
+   * unsubscribe function — call it on disposal to prevent listener leaks.
+   */
   onActiveToIdle(callback: (ptyId: string) => void): () => void {
-    this.callbacks.push(callback);
+    this.idleCallbacks.push(callback);
     return () => {
-      const idx = this.callbacks.indexOf(callback);
-      if (idx >= 0) this.callbacks.splice(idx, 1);
+      const idx = this.idleCallbacks.indexOf(callback);
+      if (idx >= 0) this.idleCallbacks.splice(idx, 1);
+    };
+  }
+
+  /**
+   * Fires once per active cycle when a PTY's output crosses the throughput
+   * threshold (the start of a sustained burst). PTYBridge wires this to set
+   * `metadata.agentStatus = 'running'` and reset AgentDetector's emission
+   * dedup state so the next idle prompt fires again on this PTY's next turn.
+   *
+   * Per-cycle dedup: only one fire per active cycle. A subsequent active
+   * cycle (after onActiveToIdle has fired) is allowed to fire again.
+   */
+  onActive(callback: (ptyId: string) => void): () => void {
+    this.activeCallbacks.push(callback);
+    return () => {
+      const idx = this.activeCallbacks.indexOf(callback);
+      if (idx >= 0) this.activeCallbacks.splice(idx, 1);
     };
   }
 
@@ -50,6 +73,7 @@ export class ActivityMonitor {
       windowStart: Date.now(),
       active: false,
       notified: false,
+      activeFired: false,
       idleTimer: null,
       lastReschedule: 0,
     });
@@ -85,6 +109,13 @@ export class ActivityMonitor {
     // output. Skew on the active→idle detection is bounded by IDLE_DELAY_MS
     // + RESCHEDULE_THROTTLE_MS, which is acceptable for the 5s idle window.
     if (s.active) {
+      // Fire onActive exactly once per cycle (re-armed when onActiveToIdle
+      // fires below). This is the 'running' signal — IPC spam protection.
+      if (!s.activeFired) {
+        s.activeFired = true;
+        this.activeCallbacks.forEach((cb) => cb(ptyId));
+      }
+
       if (
         !s.idleTimer ||
         now - s.lastReschedule >= ActivityMonitor.RESCHEDULE_THROTTLE_MS
@@ -94,9 +125,10 @@ export class ActivityMonitor {
         s.idleTimer = setTimeout(() => {
           if (!s.active) return;
           s.active = false;
-          s.notified = true;  // prevent re-firing until new active cycle
+          s.notified = true;     // prevent re-firing idle until new cycle
+          s.activeFired = false; // re-arm onActive for the next cycle
           s.idleTimer = null;
-          this.callbacks.forEach((cb) => cb(ptyId));
+          this.idleCallbacks.forEach((cb) => cb(ptyId));
         }, ActivityMonitor.IDLE_DELAY_MS);
       }
     }

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -6,9 +6,17 @@
 // Never use generic patterns like "Done", "Failed", "?" that match
 // normal shell output. False positives are worse than missed detections.
 
+import type { AgentStatus } from '../../shared/types';
+
+// Agent event status uses the same enum as WorkspaceMetadata.agentStatus so
+// downstream consumers can route the status straight to the renderer store
+// without translation. 'idle' is reserved for the absence of an agent and is
+// never emitted here.
+export type AgentEventStatus = Exclude<AgentStatus, 'idle'>;
+
 export interface AgentEvent {
   agent: string;
-  status: 'completed' | 'waiting' | 'running' | 'error';
+  status: AgentEventStatus;
   message: string;
 }
 
@@ -39,10 +47,14 @@ const AGENT_PATTERNS: AgentPattern[] = [
     agent: 'Claude Code',
     gate: /Claude Code|claude-code|╭.*Claude/,
     patterns: [
-      // Waiting — Claude Code's unique idle prompt fragments
+      // Waiting — Claude Code's unique idle prompt fragments.
+      //
+      // NOTE: `esc to interrupt` was previously matched here but it actually
+      // appears while a response is in flight (hint that the user can ESC to
+      // cancel), not when the agent is idle. Including it produced
+      // false-positive "waiting" notifications mid-turn. Removed.
       { regex: /bypass permissions on/,          status: 'waiting',   message: 'Ready for input' },
       { regex: /shift\+tab to cycle/,            status: 'waiting',   message: 'Ready for input' },
-      { regex: /esc to interrupt/,               status: 'waiting',   message: 'Ready for input' },
       { regex: /Do you want to proceed/,         status: 'waiting',   message: 'Waiting for confirmation' },
     ],
   },
@@ -53,7 +65,7 @@ const AGENT_PATTERNS: AgentPattern[] = [
     gate: /aider v|aider --/,
     patterns: [
       { regex: /^aider>\s*$/,                    status: 'waiting',   message: 'Waiting for input' },
-      { regex: /Applied edit to/,                status: 'completed', message: 'Edit applied' },
+      { regex: /Applied edit to/,                status: 'complete',  message: 'Edit applied' },
     ],
   },
 
@@ -120,20 +132,74 @@ const CRITICAL_PATTERNS: CriticalPattern[] = [
 
 const MAX_BUFFER = 16 * 1024;
 
+// ANSI escape strip regex. Covers:
+//   CSI    \x1b[ <params> <final>   where params may include digits/semicolons
+//                                   AND private-mode prefixes ? < = >
+//                                   final is a letter A-Z/a-z or '@'
+//   OSC    \x1b] <data> \x07
+//   Charset designation \x1b(X
+//
+// Previous version omitted ?/</=/> and missed `\x1b[?25h` style sequences that
+// Claude/Codex TUIs emit frequently, leaving stray fragments in `clean` and
+// occasionally breaking pattern matching.
+// eslint-disable-next-line no-control-regex
+const ANSI_STRIP = /\x1b(?:\[[0-9;?<=>]*[a-zA-Z@]|\][^\x07]*\x07|\([A-Z])/g;
+
 export class AgentDetector {
   private callbacks: AgentEventCallback[] = [];
   private criticalCallbacks: CriticalEventCallback[] = [];
   private lineBuffer = '';
-  private lastEmittedKey = '';
+  // Per (agent:status) and (critical:label) dedup: stores the last matched
+  // string for each key. Same key + same match = skip emit. New active cycle
+  // calls resetEmissionState() to clear, so turn N+1 can emit again even when
+  // the prompt text is identical to turn N.
+  private lastEmittedFor = new Map<string, string>();
   // Track which agents have been "gated" (confirmed active) in this session
   private activeAgents = new Set<string>();
+  // Most recently emitted agent name. PTYBridge consults this when forwarding
+  // ActivityMonitor 'active' transitions to label the running status with the
+  // agent that owns this PTY.
+  private lastAgent: string | null = null;
 
-  onEvent(callback: AgentEventCallback): void {
+  /**
+   * Register a callback for agent status events.
+   * Returns an unsubscribe function. Callers MUST invoke it on disposal to
+   * prevent listener accumulation across PTY lifecycles (the same pattern as
+   * ActivityMonitor.onActiveToIdle / .onActive).
+   */
+  onEvent(callback: AgentEventCallback): () => void {
     this.callbacks.push(callback);
+    return () => {
+      const idx = this.callbacks.indexOf(callback);
+      if (idx >= 0) this.callbacks.splice(idx, 1);
+    };
   }
 
-  onCritical(callback: CriticalEventCallback): void {
+  onCritical(callback: CriticalEventCallback): () => void {
     this.criticalCallbacks.push(callback);
+    return () => {
+      const idx = this.criticalCallbacks.indexOf(callback);
+      if (idx >= 0) this.criticalCallbacks.splice(idx, 1);
+    };
+  }
+
+  /** Snapshot of agent gates that have matched in this session. */
+  getActiveAgents(): string[] {
+    return Array.from(this.activeAgents);
+  }
+
+  /** Most recently emitted agent name, or null if no agent event has fired. */
+  getLastAgent(): string | null {
+    return this.lastAgent;
+  }
+
+  /**
+   * Clear emission dedup state. Called by PTYBridge on a new ActivityMonitor
+   * active cycle so the agent's next idle prompt (turn N+1) can emit even
+   * when its text is identical to the previous turn.
+   */
+  resetEmissionState(): void {
+    this.lastEmittedFor.clear();
   }
 
   feed(data: string): void {
@@ -141,7 +207,11 @@ export class AgentDetector {
     if (this.lineBuffer.length > MAX_BUFFER) {
       this.lineBuffer = this.lineBuffer.slice(-MAX_BUFFER);
     }
-    const lines = this.lineBuffer.split(/\r?\n/);
+    // Split on both LF and lone CR. TUI footers (Claude, Codex) redraw the
+    // same line using CR without a following LF; without this split the
+    // entire redraw collapses into one buffered string and patterns fail to
+    // match line-anchored regexes.
+    const lines = this.lineBuffer.split(/\r?\n|\r(?!\n)/);
     this.lineBuffer = lines.pop() || '';
 
     for (const line of lines) {
@@ -150,19 +220,18 @@ export class AgentDetector {
   }
 
   private processLine(line: string): void {
-    // Strip ANSI escape codes for pattern matching
-    const clean = line.replace(/\x1b(?:\[[0-9;]*[a-zA-Z]|\][^\x07]*\x07|\([A-Z])/g, '').trim();
+    const clean = line.replace(ANSI_STRIP, '').trim();
     if (!clean) return;
 
     // Check critical patterns first
     for (const cp of CRITICAL_PATTERNS) {
       if (cp.regex.test(clean)) {
-        const key = `critical:${cp.label}:${clean.slice(0, 80)}`;
-        if (key !== this.lastEmittedKey) {
-          this.lastEmittedKey = key;
-          for (const cb of this.criticalCallbacks) {
-            cb({ action: cp.label, riskLevel: cp.riskLevel });
-          }
+        const key = `critical:${cp.label}`;
+        const value = clean.slice(0, 80);
+        if (this.lastEmittedFor.get(key) === value) return;
+        this.lastEmittedFor.set(key, value);
+        for (const cb of this.criticalCallbacks) {
+          cb({ action: cp.label, riskLevel: cp.riskLevel });
         }
         return;
       }
@@ -182,9 +251,11 @@ export class AgentDetector {
       for (const p of ap.patterns) {
         const match = clean.match(p.regex);
         if (match) {
-          const key = `${ap.agent}:${p.status}:${match[0]}`;
-          if (key === this.lastEmittedKey) return;
-          this.lastEmittedKey = key;
+          const key = `${ap.agent}:${p.status}`;
+          const value = match[0];
+          if (this.lastEmittedFor.get(key) === value) return;
+          this.lastEmittedFor.set(key, value);
+          this.lastAgent = ap.agent;
 
           for (const cb of this.callbacks) {
             cb({ agent: ap.agent, status: p.status, message: match[1] || p.message });

--- a/src/main/pty/PTYBridge.ts
+++ b/src/main/pty/PTYBridge.ts
@@ -6,8 +6,15 @@ import { TokenTracker } from './TokenTracker';
 import { ActivityMonitor } from './ActivityMonitor';
 import { toastManager } from '../pipe/handlers/notify.rpc';
 import { IPC } from '../../shared/constants';
-import { updateCwd, removeCwd, updateBranch, removeBranch } from '../ipc/handlers/metadata.handler';
+import { updateCwd, removeCwd, updateBranch, removeBranch, broadcastMetadataUpdate } from '../ipc/handlers/metadata.handler';
+import { sendNotification } from '../notification/sendNotification';
 import { eventBus } from '../events/EventBus';
+import type { AgentStatus } from '../../shared/types';
+
+// How long after an AgentDetector event to suppress the ActivityMonitor idle
+// fallback notification. Prevents double-firing when both signals agree
+// (agent emits 'waiting' then 5s of silence triggers onActiveToIdle).
+const AGENT_EVENT_SUPPRESSION_MS = 10_000;
 
 /**
  * A middleware handler receives raw data from a PTY process.
@@ -23,6 +30,14 @@ export class PTYBridge {
   private activityMonitor = new ActivityMonitor();
   private ptyCreatedAt = new Map<string, number>();
   private middlewareStacks = new Map<string, PTYDataMiddleware[]>();
+  // Per-PTY cleanup hooks for AgentDetector subscriptions. PTYBridge owns
+  // exactly one AgentDetector instance per ptyId; these unsubscribes are
+  // invoked in cleanupInstance to prevent listener accumulation.
+  private agentDetectorCleanups = new Map<string, Array<() => void>>();
+  // Most recent AgentDetector event timestamp per PTY. Used to suppress the
+  // ActivityMonitor idle fallback notification when the agent already
+  // emitted a more precise 'waiting'/'complete' signal a moment earlier.
+  private lastAgentEventAt = new Map<string, number>();
 
   // Micro-batch buffers for the data hot-path. Chunks are accumulated and
   // flushed every BATCH_INTERVAL_MS so middlewares + IPC send each fire once
@@ -37,17 +52,26 @@ export class PTYBridge {
     private getWindow: () => BrowserWindow | null,
   ) {
     this.ptyManager.onDispose((ptyId) => this.cleanupInstance(ptyId));
-    // Activity-based notification: fires when sustained output drops to idle
+    // Activity-based fallback notification: fires when sustained output
+    // drops to idle. Suppressed if AgentDetector already emitted a precise
+    // status event for this PTY within AGENT_EVENT_SUPPRESSION_MS — that
+    // signal is more accurate and AgentDetector's onEvent path below has
+    // already done the sendNotification + toast work.
     this.activityMonitor.onActiveToIdle((ptyId) => {
-      const win = this.getWindow();
-      if (!win || win.isDestroyed()) return;
-      const notification = {
-        type: 'agent' as const,
-        title: 'Task may have finished',
-        body: 'Terminal output stopped after active period',
-      };
-      win.webContents.send(IPC.NOTIFICATION, ptyId, notification);
-      toastManager.show(notification.title, notification.body);
+      const lastAgentAt = this.lastAgentEventAt.get(ptyId) ?? 0;
+      if (Date.now() - lastAgentAt < AGENT_EVENT_SUPPRESSION_MS) return;
+      try {
+        const win = this.getWindow();
+        const notification = {
+          type: 'agent' as const,
+          title: 'Task may have finished',
+          body: 'Terminal output stopped after active period',
+        };
+        sendNotification(win, ptyId, notification);
+        toastManager.show(notification.title, notification.body);
+      } catch (err) {
+        console.warn('[PTYBridge] onActiveToIdle callback error:', err);
+      }
     });
   }
 
@@ -93,6 +117,19 @@ export class PTYBridge {
     if (timer) clearTimeout(timer);
     this.pendingTimers.delete(ptyId);
     this.pendingData.delete(ptyId);
+
+    // Unsubscribe AgentDetector + ActivityMonitor.onActive listeners. Without
+    // this, every PTY create/dispose cycle would accumulate closure-captured
+    // callbacks against the same `agentDetector`/`activityMonitor` instances
+    // (same leak class as the v2.7.2 PlaywrightEngine CDP session fix).
+    const cleanups = this.agentDetectorCleanups.get(ptyId);
+    if (cleanups) {
+      for (const fn of cleanups) {
+        try { fn(); } catch (err) { console.warn('[PTYBridge] cleanup hook error:', err); }
+      }
+      this.agentDetectorCleanups.delete(ptyId);
+    }
+    this.lastAgentEventAt.delete(ptyId);
 
     this.oscParsers.delete(ptyId);
     this.agentDetectors.delete(ptyId);
@@ -182,7 +219,7 @@ export class PTYBridge {
         case 9:
         case 99: {
           const notification = { type: 'info' as const, title: 'Terminal', body: event.data };
-          win.webContents.send(IPC.NOTIFICATION, ptyId, notification);
+          sendNotification(win, ptyId, notification);
           toastManager.show(notification.title, notification.body);
           break;
         }
@@ -191,7 +228,7 @@ export class PTYBridge {
           const title = parts[1] || 'Notification';
           const body = parts.slice(2).join(';') || '';
           const notification = { type: 'info' as const, title, body };
-          win.webContents.send(IPC.NOTIFICATION, ptyId, notification);
+          sendNotification(win, ptyId, notification);
           toastManager.show(title, body);
           break;
         }
@@ -205,14 +242,64 @@ export class PTYBridge {
     });
 
     // Critical action detection (kept — this is precise and valuable)
-    agentDetector.onCritical((criticalEvent) => {
-      const win = this.getWindow();
-      if (!win || win.isDestroyed()) return;
-      win.webContents.send(IPC.APPROVAL_REQUEST, ptyId, {
-        action: criticalEvent.action,
-        riskLevel: criticalEvent.riskLevel,
-      });
+    const unsubCritical = agentDetector.onCritical((criticalEvent) => {
+      try {
+        const win = this.getWindow();
+        if (!win || win.isDestroyed()) return;
+        win.webContents.send(IPC.APPROVAL_REQUEST, ptyId, {
+          action: criticalEvent.action,
+          riskLevel: criticalEvent.riskLevel,
+        });
+      } catch (err) {
+        console.warn('[PTYBridge] onCritical callback error:', err);
+      }
     });
+
+    // Agent status events: emit METADATA_UPDATE (drives sidebar dot) and a
+    // NOTIFICATION (drives unread badge + in-app toast + optional OS toast).
+    // The 'waiting'/'complete' transition is the strong "task done" signal.
+    const unsubAgent = agentDetector.onEvent((agentEvent) => {
+      try {
+        const win = this.getWindow();
+        const status = agentEvent.status as AgentStatus;
+        broadcastMetadataUpdate(win, {
+          ptyId,
+          agentStatus: status,
+          agentName: agentEvent.agent,
+        });
+
+        if (status === 'waiting' || status === 'complete') {
+          this.lastAgentEventAt.set(ptyId, Date.now());
+          const title = `${agentEvent.agent}: ${agentEvent.message}`;
+          const body = status === 'waiting' ? 'Ready for input' : 'Task finished';
+          sendNotification(win, ptyId, { type: 'agent', title, body });
+          toastManager.show(title, body);
+        }
+      } catch (err) {
+        console.warn('[PTYBridge] onEvent callback error:', err);
+      }
+    });
+
+    // Activity-based 'running' signal: fires once per active cycle. PTYBridge
+    // also resets AgentDetector's emission dedup state here so the next turn's
+    // 'waiting' prompt fires again even if its text is byte-identical to the
+    // previous turn (otherwise turn N+1 would be silently dropped).
+    const unsubActive = this.activityMonitor.onActive((id) => {
+      if (id !== ptyId) return;
+      try {
+        const lastAgent = agentDetector.getLastAgent() ?? '';
+        broadcastMetadataUpdate(this.getWindow(), {
+          ptyId,
+          agentStatus: 'running',
+          agentName: lastAgent,
+        });
+        agentDetector.resetEmissionState();
+      } catch (err) {
+        console.warn('[PTYBridge] onActive callback error:', err);
+      }
+    });
+
+    this.agentDetectorCleanups.set(ptyId, [unsubCritical, unsubAgent, unsubActive]);
 
     // Detect CWD from shell prompt patterns (PowerShell: "PS C:\path>", bash: "user@host:~/path$")
     // eslint-disable-next-line no-control-regex
@@ -320,6 +407,11 @@ export class PTYBridge {
       if (win && !win.isDestroyed()) {
         win.webContents.send(IPC.PTY_EXIT, ptyId, exitCode);
 
+        // Clear agentStatus so the sidebar dot stops claiming the agent is
+        // still running/waiting after the process is gone. 'idle' is the
+        // explicit absence-of-agent state — MiniSidebar hides the dot.
+        broadcastMetadataUpdate(win, { ptyId, agentStatus: 'idle', agentName: '' });
+
         if (exitCode !== 0) {
           const elapsed = Date.now() - (this.ptyCreatedAt.get(ptyId) ?? Date.now());
           const seconds = Math.round(elapsed / 1000);
@@ -328,7 +420,7 @@ export class PTYBridge {
             title: 'Process exited with error',
             body: `Exit code ${exitCode} after ${seconds}s`,
           };
-          win.webContents.send(IPC.NOTIFICATION, ptyId, notification);
+          sendNotification(win, ptyId, notification);
           toastManager.show(notification.title, notification.body);
         }
       }

--- a/src/main/pty/PTYBridge.ts
+++ b/src/main/pty/PTYBridge.ts
@@ -52,16 +52,24 @@ export class PTYBridge {
     private getWindow: () => BrowserWindow | null,
   ) {
     this.ptyManager.onDispose((ptyId) => this.cleanupInstance(ptyId));
-    // Activity-based fallback notification: fires when sustained output
-    // drops to idle. Suppressed if AgentDetector already emitted a precise
-    // status event for this PTY within AGENT_EVENT_SUPPRESSION_MS — that
-    // signal is more accurate and AgentDetector's onEvent path below has
-    // already done the sendNotification + toast work.
+    // Activity-based fallback: fires when sustained output drops to idle.
+    // Suppressed if AgentDetector already emitted a precise status event for
+    // this PTY within AGENT_EVENT_SUPPRESSION_MS — that signal is more
+    // accurate, AgentDetector's onEvent path already did the
+    // sendNotification + toast work, and the agentStatus is already
+    // correctly set to 'waiting'/'complete'.
+    //
+    // When no precise event happened (generic shell command, unsupported
+    // agent, missed prompt), the previous 'running' status from onActive
+    // must be cleared back to 'idle' — otherwise the sidebar dot pulses
+    // forever even though output stopped.
     this.activityMonitor.onActiveToIdle((ptyId) => {
       const lastAgentAt = this.lastAgentEventAt.get(ptyId) ?? 0;
       if (Date.now() - lastAgentAt < AGENT_EVENT_SUPPRESSION_MS) return;
       try {
         const win = this.getWindow();
+        // Clear stale 'running' before emitting the generic notification.
+        broadcastMetadataUpdate(win, { ptyId, agentStatus: 'idle', agentName: '' });
         const notification = {
           type: 'agent' as const,
           title: 'Task may have finished',
@@ -110,6 +118,21 @@ export class PTYBridge {
    * (e.g. from PTYManager.dispose()) to ensure cleanup when onExit is not fired.
    */
   cleanupInstance(ptyId: string): void {
+    // Clear agentStatus on every disposal path. onExit already broadcasts
+    // 'idle', but the PTYManager.dispose → onDispose path can reach this
+    // method WITHOUT going through onExit (e.g. user closes a pane via the
+    // UI, MCP destroy, surface swap). Without this idempotent broadcast,
+    // the sidebar dot stays stuck on the last 'running'/'waiting' state
+    // for a terminal that's already gone.
+    try {
+      const win = this.getWindow();
+      if (win && !win.isDestroyed()) {
+        broadcastMetadataUpdate(win, { ptyId, agentStatus: 'idle', agentName: '' });
+      }
+    } catch (err) {
+      console.warn('[PTYBridge] cleanupInstance agentStatus broadcast error:', err);
+    }
+
     // Drain any buffered data before tearing down — preserves trailing output
     // (e.g. final exit lines) that arrived between the last flush and dispose.
     this.flushPending(ptyId);

--- a/src/main/pty/PTYBridge.ts
+++ b/src/main/pty/PTYBridge.ts
@@ -8,6 +8,7 @@ import { toastManager } from '../pipe/handlers/notify.rpc';
 import { IPC } from '../../shared/constants';
 import { updateCwd, removeCwd, updateBranch, removeBranch, broadcastMetadataUpdate } from '../ipc/handlers/metadata.handler';
 import { sendNotification } from '../notification/sendNotification';
+import { recentlySuppressed, clearPty as clearSuppression } from '../notification/idleSuppression';
 import { eventBus } from '../events/EventBus';
 import type { AgentStatus } from '../../shared/types';
 
@@ -64,8 +65,14 @@ export class PTYBridge {
     // must be cleared back to 'idle' — otherwise the sidebar dot pulses
     // forever even though output stopped.
     this.activityMonitor.onActiveToIdle((ptyId) => {
+      const now = Date.now();
       const lastAgentAt = this.lastAgentEventAt.get(ptyId) ?? 0;
-      if (Date.now() - lastAgentAt < AGENT_EVENT_SUPPRESSION_MS) return;
+      if (now - lastAgentAt < AGENT_EVENT_SUPPRESSION_MS) return;
+      // Suppress the activity fallback when the recent burst was actually
+      // a pty:resize redraw (workspace switch) or user keystroke echo —
+      // both spike ActivityMonitor's byte counter without being a real
+      // agent task ending. See idleSuppression.ts for rationale.
+      if (recentlySuppressed(ptyId, now)) return;
       try {
         const win = this.getWindow();
         // Clear stale 'running' before emitting the generic notification.
@@ -153,6 +160,7 @@ export class PTYBridge {
       this.agentDetectorCleanups.delete(ptyId);
     }
     this.lastAgentEventAt.delete(ptyId);
+    clearSuppression(ptyId);
 
     this.oscParsers.delete(ptyId);
     this.agentDetectors.delete(ptyId);

--- a/src/main/pty/__tests__/ActivityMonitor.test.ts
+++ b/src/main/pty/__tests__/ActivityMonitor.test.ts
@@ -125,4 +125,56 @@ describe('ActivityMonitor', () => {
     vi.advanceTimersByTime(5000);
     expect(fired).toEqual(['p1', 'p2']);
   });
+
+  describe('onActive (burst start signal)', () => {
+    let activeFired: string[];
+
+    beforeEach(() => {
+      activeFired = [];
+      monitor.onActive((id) => activeFired.push(id));
+    });
+
+    it('fires once when output crosses the threshold', () => {
+      monitor.start('p1');
+      monitor.feed('p1', 3000);
+      expect(activeFired).toEqual(['p1']);
+    });
+
+    it('does NOT fire again within the same active cycle (IPC spam guard)', () => {
+      monitor.start('p1');
+      monitor.feed('p1', 3000);
+      expect(activeFired).toEqual(['p1']);
+      // Continued bursting in the same cycle: still 1 fire
+      monitor.feed('p1', 5000);
+      monitor.feed('p1', 5000);
+      expect(activeFired).toEqual(['p1']);
+    });
+
+    it('re-arms after onActiveToIdle so the next cycle can fire again', () => {
+      monitor.start('p1');
+      monitor.feed('p1', 3000);
+      expect(activeFired).toEqual(['p1']);
+
+      // Idle out
+      vi.advanceTimersByTime(5000);
+      expect(fired).toEqual(['p1']);
+
+      // New burst — onActive should fire exactly once again
+      monitor.feed('p1', 3000);
+      expect(activeFired).toEqual(['p1', 'p1']);
+    });
+
+    it('returns an unsubscribe function that stops further fires', () => {
+      const cb = vi.fn();
+      const unsub = monitor.onActive(cb);
+      monitor.start('p1');
+      monitor.feed('p1', 3000);
+      expect(cb).toHaveBeenCalledTimes(1);
+
+      unsub();
+      vi.advanceTimersByTime(5000); // idle out so the next cycle can fire
+      monitor.feed('p1', 3000);
+      expect(cb).toHaveBeenCalledTimes(1); // not 2
+    });
+  });
 });

--- a/src/main/pty/__tests__/AgentDetector.test.ts
+++ b/src/main/pty/__tests__/AgentDetector.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AgentDetector } from '../AgentDetector';
+
+describe('AgentDetector', () => {
+  describe('agent status emission', () => {
+    it('emits "waiting" for "shift+tab to cycle" Claude prompt', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      // gate first
+      det.feed('Claude Code starting up\n');
+      det.feed('  shift+tab to cycle modes\n');
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb.mock.calls[0][0]).toMatchObject({ agent: 'Claude Code', status: 'waiting' });
+    });
+
+    it('REGRESSION (R3): does NOT match "esc to interrupt" — Claude in-flight hint, not idle', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('Claude Code starting up\n');
+      det.feed('press esc to interrupt\n');
+      // Previously this falsely emitted 'waiting'. After the fix, no agent
+      // event should fire for this line.
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it('REGRESSION (R2): Aider "Applied edit to" emits "complete" (was "completed")', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('aider v0.50.0\n');
+      det.feed('Applied edit to src/foo.ts\n');
+      expect(cb).toHaveBeenCalledWith(expect.objectContaining({
+        agent: 'Aider',
+        status: 'complete',
+      }));
+    });
+  });
+
+  describe('REGRESSION (R1): subscribe/unsubscribe lifecycle', () => {
+    it('onEvent returns an unsubscribe function', () => {
+      const det = new AgentDetector();
+      const unsub = det.onEvent(() => {});
+      expect(typeof unsub).toBe('function');
+    });
+
+    it('onCritical returns an unsubscribe function', () => {
+      const det = new AgentDetector();
+      const unsub = det.onCritical(() => {});
+      expect(typeof unsub).toBe('function');
+    });
+
+    it('unsubscribe stops the callback from receiving further events', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      const unsub = det.onEvent(cb);
+      det.feed('Claude Code starting up\n');
+      det.feed('  shift+tab to cycle\n');
+      expect(cb).toHaveBeenCalledTimes(1);
+
+      unsub();
+      det.resetEmissionState(); // allow re-emit if cb were still subscribed
+      det.feed('  shift+tab to cycle\n');
+      expect(cb).toHaveBeenCalledTimes(1); // not 2
+    });
+
+    it('unsubscribe leaves OTHER callbacks intact', () => {
+      const det = new AgentDetector();
+      const a = vi.fn();
+      const b = vi.fn();
+      const unsubA = det.onEvent(a);
+      det.onEvent(b);
+      unsubA();
+      det.feed('Claude Code\n');
+      det.feed('  shift+tab to cycle\n');
+      expect(a).not.toHaveBeenCalled();
+      expect(b).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('emission dedup with cycle reset', () => {
+    it('dedups consecutive identical "waiting" matches', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('Claude Code\n');
+      det.feed('  shift+tab to cycle\n');
+      det.feed('  shift+tab to cycle\n');
+      det.feed('  shift+tab to cycle\n');
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('after resetEmissionState(), the same prompt fires again (turn N+1)', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('Claude Code\n');
+      det.feed('  shift+tab to cycle\n');
+      expect(cb).toHaveBeenCalledTimes(1);
+
+      det.resetEmissionState();
+      det.feed('  shift+tab to cycle\n');
+      expect(cb).toHaveBeenCalledTimes(2);
+    });
+
+    it('different status fires even without reset (e.g. waiting → complete)', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('aider v0.50.0\n');
+      det.feed('aider>\n');
+      det.feed('Applied edit to src/foo.ts\n');
+      expect(cb).toHaveBeenCalledTimes(2);
+      expect(cb.mock.calls[0][0].status).toBe('waiting');
+      expect(cb.mock.calls[1][0].status).toBe('complete');
+    });
+  });
+
+  describe('feed() line splitting', () => {
+    it('splits on \\n', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('Claude Code\n  shift+tab to cycle\n');
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('splits on lone \\r (carriage return redraw)', () => {
+      // Claude/Codex TUIs redraw their footer line using bare CR. Without
+      // \r-splitting, the entire redrawn buffer would land as one line and
+      // line-anchored regexes would fail.
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('Claude Code\r  shift+tab to cycle\r');
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps \\r\\n intact (no double-split)', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('Claude Code\r\n  shift+tab to cycle\r\n');
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('ANSI strip', () => {
+    it('handles private-mode prefix sequences like \\x1b[?25h', () => {
+      // Earlier regex omitted '?' from CSI parameter chars and left
+      // `\x1b[?25h` (cursor visibility) embedded in `clean`, occasionally
+      // breaking gate matches.
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('\x1b[?25hClaude Code starting\n');
+      det.feed('\x1b[?25l  shift+tab to cycle\n');
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getters', () => {
+    it('getActiveAgents() returns gates that matched in this session', () => {
+      const det = new AgentDetector();
+      det.feed('Claude Code\n');
+      det.feed('aider v0.50.0\n');
+      expect(det.getActiveAgents().sort()).toEqual(['Aider', 'Claude Code'].sort());
+    });
+
+    it('getLastAgent() returns the most recently emitted agent name', () => {
+      const det = new AgentDetector();
+      det.feed('aider v0.50.0\n');
+      det.feed('aider>\n');
+      expect(det.getLastAgent()).toBe('Aider');
+    });
+
+    it('getLastAgent() returns null before any event has fired', () => {
+      const det = new AgentDetector();
+      expect(det.getLastAgent()).toBeNull();
+    });
+  });
+
+  describe('critical action detection (unchanged behaviour, regression guard)', () => {
+    it('fires onCritical for "rm -rf /" patterns', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onCritical(cb);
+      det.feed('$ rm -rf /tmp/junk\n');
+      expect(cb).toHaveBeenCalledWith(expect.objectContaining({
+        action: 'rm -rf',
+        riskLevel: 'critical',
+      }));
+    });
+  });
+});

--- a/src/main/pty/__tests__/PTYBridge.batch.test.ts
+++ b/src/main/pty/__tests__/PTYBridge.batch.test.ts
@@ -27,6 +27,11 @@ vi.mock('../../ipc/handlers/metadata.handler', () => ({
   removeCwd: vi.fn(),
   updateBranch: vi.fn(),
   removeBranch: vi.fn(),
+  broadcastMetadataUpdate: vi.fn(),
+}));
+
+vi.mock('../../notification/sendNotification', () => ({
+  sendNotification: vi.fn(),
 }));
 
 import { PTYBridge } from '../PTYBridge';

--- a/src/main/pty/__tests__/PTYBridge.notify.test.ts
+++ b/src/main/pty/__tests__/PTYBridge.notify.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// ── Module mocks (must be declared before importing PTYBridge) ─────────────
+// vi.mock factories are hoisted to the top of the file, so any captured
+// variables must come from vi.hoisted() — plain `const` declarations are not
+// yet evaluated when the factory runs.
+
+const mocks = vi.hoisted(() => ({
+  toastManager: { show: vi.fn() },
+  broadcastMetadataUpdate: vi.fn(),
+  sendNotification: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+}));
+
+vi.mock('../../pipe/handlers/notify.rpc', () => ({
+  toastManager: mocks.toastManager,
+}));
+
+vi.mock('../../ipc/handlers/metadata.handler', () => ({
+  updateCwd: vi.fn(),
+  removeCwd: vi.fn(),
+  updateBranch: vi.fn(),
+  removeBranch: vi.fn(),
+  broadcastMetadataUpdate: mocks.broadcastMetadataUpdate,
+}));
+
+vi.mock('../../notification/sendNotification', () => ({
+  sendNotification: mocks.sendNotification,
+}));
+
+const broadcastMetadataUpdateMock = mocks.broadcastMetadataUpdate;
+const sendNotificationMock = mocks.sendNotification;
+const toastManagerMock = mocks.toastManager;
+
+import { PTYBridge } from '../PTYBridge';
+import type { PTYManager, PTYInstance } from '../PTYManager';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+interface MockProcess {
+  onData: (cb: (data: string) => void) => void;
+  onExit: (cb: (info: { exitCode: number }) => void) => void;
+  emitData: (data: string) => void;
+  emitExit: (code: number) => void;
+}
+
+function makeMockProcess(): MockProcess {
+  let dataCb: ((data: string) => void) | null = null;
+  let exitCb: ((info: { exitCode: number }) => void) | null = null;
+  return {
+    onData: (cb) => { dataCb = cb; },
+    onExit: (cb) => { exitCb = cb; },
+    emitData: (d) => { dataCb?.(d); },
+    emitExit: (c) => { exitCb?.({ exitCode: c }); },
+  };
+}
+
+function makeMockManager(instance: PTYInstance) {
+  return {
+    get: vi.fn(() => instance),
+    remove: vi.fn(),
+    onDispose: vi.fn(),
+  } as unknown as PTYManager;
+}
+
+function makeWindow() {
+  return {
+    isDestroyed: () => false,
+    webContents: { send: vi.fn() },
+  };
+}
+
+function makeBridge() {
+  const proc = makeMockProcess();
+  const instance: PTYInstance = {
+    id: 'p1',
+    process: proc as unknown as PTYInstance['process'],
+    shell: 'bash',
+  };
+  const manager = makeMockManager(instance);
+  const win = makeWindow();
+  const bridge = new PTYBridge(manager, () => win as never);
+  bridge.setupDataForwarding('p1');
+  return { bridge, proc, win };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('PTYBridge notification wiring', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    broadcastMetadataUpdateMock.mockReset();
+    sendNotificationMock.mockReset();
+    toastManagerMock.show.mockReset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function flushMicroBatch() {
+    // Advance past PTYBridge.BATCH_INTERVAL_MS (8ms) so the pending flush
+    // runs middlewares (AgentDetector / ActivityMonitor).
+    vi.advanceTimersByTime(50);
+  }
+
+  it('AgentDetector "waiting" emits METADATA_UPDATE + NOTIFICATION + toast', () => {
+    const { proc } = makeBridge();
+
+    // Gate Claude Code, then feed an idle prompt line that AgentDetector
+    // classifies as 'waiting'. Use a large chunk to also nudge ActivityMonitor
+    // but we only assert on the METADATA_UPDATE shape and the agent
+    // notification call here.
+    proc.emitData('Claude Code starting up\n');
+    proc.emitData('  shift+tab to cycle\n');
+    flushMicroBatch();
+
+    // Latest METADATA_UPDATE should carry agentStatus='waiting' for ptyId 'p1'
+    const metaCalls = broadcastMetadataUpdateMock.mock.calls.filter(
+      (c) => (c[1] as { agentStatus?: string }).agentStatus === 'waiting',
+    );
+    expect(metaCalls.length).toBeGreaterThanOrEqual(1);
+    expect(metaCalls[0][1]).toMatchObject({ ptyId: 'p1', agentStatus: 'waiting', agentName: 'Claude Code' });
+
+    // sendNotification fires for waiting/complete (not running)
+    expect(sendNotificationMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'p1',
+      expect.objectContaining({ type: 'agent' }),
+    );
+    expect(toastManagerMock.show).toHaveBeenCalled();
+  });
+
+  it('ActivityMonitor "active" emits METADATA_UPDATE with agentStatus="running"', () => {
+    const { proc } = makeBridge();
+
+    // Push >2000 bytes in <3s to enter active state
+    proc.emitData('x'.repeat(3000));
+    flushMicroBatch();
+
+    const runningCall = broadcastMetadataUpdateMock.mock.calls.find(
+      (c) => (c[1] as { agentStatus?: string }).agentStatus === 'running',
+    );
+    expect(runningCall).toBeTruthy();
+    expect(runningCall![1]).toMatchObject({ ptyId: 'p1', agentStatus: 'running' });
+  });
+
+  it('REGRESSION: onExit broadcasts agentStatus="idle" + clears unread state', () => {
+    const { proc } = makeBridge();
+
+    proc.emitData('something');
+    flushMicroBatch();
+
+    broadcastMetadataUpdateMock.mockClear();
+    proc.emitExit(0);
+
+    const idleCall = broadcastMetadataUpdateMock.mock.calls.find(
+      (c) => (c[1] as { agentStatus?: string }).agentStatus === 'idle',
+    );
+    expect(idleCall).toBeTruthy();
+    expect(idleCall![1]).toMatchObject({ ptyId: 'p1', agentStatus: 'idle', agentName: '' });
+  });
+
+  it('REGRESSION (R5): cleanupInstance unsubscribes AgentDetector listeners (no leak)', () => {
+    const { bridge, proc } = makeBridge();
+
+    proc.emitData('Claude Code\n');
+    proc.emitData('  shift+tab to cycle\n');
+    flushMicroBatch();
+
+    const callsBefore = broadcastMetadataUpdateMock.mock.calls.length;
+
+    // Dispose this PTY
+    bridge.cleanupInstance('p1');
+
+    // After cleanup, AgentDetector still exists in memory inside the
+    // closure but callbacks must have been unsubscribed — further pattern
+    // matches on a stale detector should not show up as new IPC sends.
+    // (The detector instance is discarded; this is a sanity check that
+    // cleanup ran without throwing and removed bookkeeping.)
+    expect(callsBefore).toBeGreaterThanOrEqual(1);
+    expect(() => bridge.cleanupInstance('p1')).not.toThrow(); // idempotent
+  });
+
+  it('REGRESSION (R4): a throwing AgentDetector callback does not stop later events', () => {
+    // PTYBridge wraps its subscription callbacks in try/catch. We can not
+    // easily inject a throwing AgentDetector callback from outside the
+    // PTYBridge, but we can assert the symmetric guarantee: if
+    // broadcastMetadataUpdate throws synchronously, subsequent agent events
+    // still fire the notification path on the next match.
+    broadcastMetadataUpdateMock.mockImplementationOnce(() => { throw new Error('boom'); });
+    const { proc } = makeBridge();
+
+    proc.emitData('Claude Code\n');
+    proc.emitData('  shift+tab to cycle\n');
+    flushMicroBatch();
+
+    // Even though the first metadata broadcast threw, sendNotification
+    // should still have been attempted afterwards (try/catch isolates
+    // failures within the onEvent callback body).
+    // Implementation note: our try/catch wraps the whole onEvent body, so
+    // the *same* event won't call sendNotification after the throw — but
+    // a *later* matching event still works. Trigger a second pattern.
+    proc.emitData('  bypass permissions on\n');
+    flushMicroBatch();
+
+    // A later legitimate emit must still proceed through the callback path
+    // (the first throw didn't kill the subscription).
+    expect(broadcastMetadataUpdateMock.mock.calls.length).toBeGreaterThan(1);
+  });
+});

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -59,8 +59,12 @@ const electronAPI = {
     setAutoUpdateEnabled: (enabled: boolean) => ipcRenderer.send(IPC.AUTO_UPDATE_ENABLED, enabled),
   },
   notification: {
-    onNew: (callback: (ptyId: string, data: { type: string; title: string; body: string }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, ptyId: string, data: { type: string; title: string; body: string }) =>
+    // ptyId may be null for app-level notifications (e.g. external MCP
+    // `notify` RPC, where no PTY originates the message). When null, the
+    // renderer resolves via `data.workspaceId` or falls back to the active
+    // workspace.
+    onNew: (callback: (ptyId: string | null, data: { type: string; title: string; body: string; workspaceId?: string }) => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, ptyId: string | null, data: { type: string; title: string; body: string; workspaceId?: string }) =>
         callback(ptyId, data);
       ipcRenderer.on(IPC.NOTIFICATION, listener);
       return () => { ipcRenderer.removeListener(IPC.NOTIFICATION, listener); };
@@ -81,9 +85,14 @@ const electronAPI = {
   metadata: {
     request: (ptyId: string) =>
       ipcRenderer.invoke(IPC.METADATA_REQUEST, ptyId),
-    onUpdate: (callback: (ptyId: string, data: { gitBranch?: string; cwd?: string; listeningPorts?: number[] }) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, ptyId: string, data: { gitBranch?: string; cwd?: string; listeningPorts?: number[] }) =>
-        callback(ptyId, data);
+    // Single discriminated payload (MetadataUpdatePayload). All main-process
+    // metadata channels (CWD/git polling, agent status, meta.rpc status/
+    // progress) flow through this one shape. Renderer routes by ptyId
+    // (preferred) or workspaceId (for surface-less updates like
+    // meta.setStatus on the active workspace).
+    onUpdate: (callback: (payload: { ptyId?: string; workspaceId?: string; gitBranch?: string; cwd?: string; listeningPorts?: number[]; agentStatus?: string; agentName?: string; status?: string; progress?: number }) => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, payload: { ptyId?: string; workspaceId?: string; gitBranch?: string; cwd?: string; listeningPorts?: number[]; agentStatus?: string; agentName?: string; status?: string; progress?: number }) =>
+        callback(payload);
       ipcRenderer.on(IPC.METADATA_UPDATE, listener);
       return () => { ipcRenderer.removeListener(IPC.METADATA_UPDATE, listener); };
     },

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -341,6 +341,20 @@ export default function AppLayout() {
       const isFirstAutoUpdateChoice = saved.autoUpdateEnabled == null;
 
       useStore.getState().loadSession(saved);
+
+      // Sanitize stale per-workspace agent state. agentStatus/agentName
+      // describe a live PTY's current state; carrying them across an app
+      // restart is always wrong — the workspaces just rehydrated, no agent
+      // has emitted anything yet in this session. Without this reset the
+      // sidebar dot would lie about agents that died last time the user
+      // closed wmux (Codex 1st review #4: lifecycle reset).
+      const postLoadState = useStore.getState();
+      for (const ws of postLoadState.workspaces) {
+        if (ws.metadata?.agentStatus || ws.metadata?.agentName) {
+          postLoadState.updateWorkspaceMetadata(ws.id, { agentStatus: 'idle', agentName: '' });
+        }
+      }
+
       sessionLoadedRef.current = true;
 
       if (isFirstAutoUpdateChoice) {

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -350,7 +350,13 @@ export default function AppLayout() {
       // closed wmux (Codex 1st review #4: lifecycle reset).
       const postLoadState = useStore.getState();
       for (const ws of postLoadState.workspaces) {
-        if (ws.metadata?.agentStatus || ws.metadata?.agentName) {
+        // Only update workspaces whose persisted state actually carries a
+        // live status. Plain truthiness on agentStatus is true for 'idle'
+        // too, so the previous guard re-broadcast a no-op metadata update
+        // for every workspace that had ever held agent state.
+        const status = ws.metadata?.agentStatus;
+        const hasLive = (status && status !== 'idle') || (ws.metadata?.agentName && ws.metadata.agentName.length > 0);
+        if (hasLive) {
           postLoadState.updateWorkspaceMetadata(ws.id, { agentStatus: 'idle', agentName: '' });
         }
       }

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -53,7 +53,7 @@ export default function PaneComponent({ pane, isActive, isWorkspaceVisible = tru
     const { notifications } = useStore.getState();
     const surfaceIds = new Set(pane.surfaces.map((s) => s.id));
     for (const n of notifications) {
-      if (!n.read && surfaceIds.has(n.surfaceId)) {
+      if (!n.read && n.surfaceId !== undefined && surfaceIds.has(n.surfaceId)) {
         markRead(n.id);
       }
     }

--- a/src/renderer/hooks/useNotificationListener.ts
+++ b/src/renderer/hooks/useNotificationListener.ts
@@ -83,6 +83,24 @@ export function useNotificationListener() {
       const state = useStore.getState();
       const target = resolveNotificationTarget(state, ptyId, data.workspaceId);
       if (!target) return;
+
+      // Skip notification entirely when the user is already looking at the
+      // originating surface — the badge would only count something they
+      // already saw, and a transient in-app toast over the active terminal
+      // is pure noise. OS toast is still gated by window focus inside
+      // ToastManager, so this only affects the in-app surfaces.
+      if (
+        ptyId &&
+        target.workspaceId === state.activeWorkspaceId &&
+        target.surfaceId &&
+        isActivePtySurface(
+          state.workspaces.find((w) => w.id === target.workspaceId)!,
+          ptyId,
+        )
+      ) {
+        return;
+      }
+
       state.addNotification({
         surfaceId: target.surfaceId,
         workspaceId: target.workspaceId,

--- a/src/renderer/hooks/useNotificationListener.ts
+++ b/src/renderer/hooks/useNotificationListener.ts
@@ -93,7 +93,12 @@ export function useNotificationListener() {
       // Inline in-app toast fallback — shown in ToastContainer regardless of
       // window focus. The OS-level toast in ToastManager only fires when
       // unfocused, so this guarantees a visible signal in either state.
-      state.pushToast({ message: data.title, level: data.type === 'error' ? 'error' : data.type === 'warning' ? 'warn' : 'info' });
+      // Gated by `toastEnabled` so the existing user preference still wins;
+      // without this gate, disabling toasts in settings would only suppress
+      // OS-level toasts and leave the in-app overlay popping anyway.
+      if (state.toastEnabled) {
+        state.pushToast({ message: data.title, level: data.type === 'error' ? 'error' : data.type === 'warning' ? 'warn' : 'info' });
+      }
       // Play sound if enabled (throttled)
       if (state.notificationSoundEnabled) {
         const now = Date.now();

--- a/src/renderer/hooks/useNotificationListener.ts
+++ b/src/renderer/hooks/useNotificationListener.ts
@@ -36,31 +36,71 @@ function isActivePtySurface(ws: { rootPane: Pane; activePaneId: string }, ptyId:
 const lastSoundTime: Record<string, number> = {};
 const SOUND_THROTTLE_MS = 2000;
 
+/**
+ * Resolve a notification's destination workspace + (optional) surface.
+ *
+ * Order of preference:
+ *  1. ptyId — strongest signal, originates from a specific surface
+ *  2. workspaceId hint from the payload (e.g. external MCP notify with
+ *     mcp.claimWorkspace context) — use the workspace's active surface
+ *  3. Active workspace fallback — backward compat for CLI `wmux notify`
+ *     which sends neither ptyId nor workspaceId
+ */
+function resolveNotificationTarget(
+  state: ReturnType<typeof useStore.getState>,
+  ptyId: string | null,
+  workspaceIdHint: string | undefined,
+): { workspaceId: string; surfaceId?: string } | null {
+  if (ptyId) {
+    for (const ws of state.workspaces) {
+      const found = findSurfaceByPtyId(ws.rootPane, ptyId);
+      if (found) return { workspaceId: ws.id, surfaceId: found.surfaceId };
+    }
+    return null;
+  }
+  const targetWsId = workspaceIdHint ?? state.activeWorkspaceId;
+  if (!targetWsId) return null;
+  const ws = state.workspaces.find((w) => w.id === targetWsId);
+  if (!ws) return null;
+  // Best-effort active surface lookup. If no active leaf, the notification
+  // is still recorded at the workspace level with no surfaceId.
+  const findActiveLeaf = (pane: Pane): PaneLeaf | null => {
+    if (pane.type === 'leaf') return pane.id === ws.activePaneId ? pane : null;
+    for (const child of pane.children) {
+      const found = findActiveLeaf(child);
+      if (found) return found;
+    }
+    return null;
+  };
+  const leaf = findActiveLeaf(ws.rootPane);
+  const surfaceId = leaf?.surfaces.find((s) => s.id === leaf.activeSurfaceId)?.id;
+  return { workspaceId: ws.id, surfaceId };
+}
+
 export function useNotificationListener() {
   useEffect(() => {
     const unsubNotif = window.electronAPI.notification.onNew((ptyId, data) => {
       const state = useStore.getState();
-      // Find which workspace/surface this ptyId belongs to
-      for (const ws of state.workspaces) {
-        const found = findSurfaceByPtyId(ws.rootPane, ptyId);
-        if (found) {
-          state.addNotification({
-            surfaceId: found.surfaceId,
-            workspaceId: ws.id,
-            type: data.type as NotificationType,
-            title: data.title,
-            body: data.body,
-          });
-          // Play sound if enabled (throttled)
-          if (useStore.getState().notificationSoundEnabled) {
-            const now = Date.now();
-            const key = data.type;
-            if (!lastSoundTime[key] || now - lastSoundTime[key] > SOUND_THROTTLE_MS) {
-              lastSoundTime[key] = now;
-              playNotificationSound(data.type as NotificationType);
-            }
-          }
-          break;
+      const target = resolveNotificationTarget(state, ptyId, data.workspaceId);
+      if (!target) return;
+      state.addNotification({
+        surfaceId: target.surfaceId,
+        workspaceId: target.workspaceId,
+        type: data.type as NotificationType,
+        title: data.title,
+        body: data.body,
+      });
+      // Inline in-app toast fallback — shown in ToastContainer regardless of
+      // window focus. The OS-level toast in ToastManager only fires when
+      // unfocused, so this guarantees a visible signal in either state.
+      state.pushToast({ message: data.title, level: data.type === 'error' ? 'error' : data.type === 'warning' ? 'warn' : 'info' });
+      // Play sound if enabled (throttled)
+      if (state.notificationSoundEnabled) {
+        const now = Date.now();
+        const key = data.type;
+        if (!lastSoundTime[key] || now - lastSoundTime[key] > SOUND_THROTTLE_MS) {
+          lastSoundTime[key] = now;
+          playNotificationSound(data.type as NotificationType);
         }
       }
     });
@@ -76,25 +116,38 @@ export function useNotificationListener() {
       }
     });
 
-    const unsubMeta = window.electronAPI.metadata.onUpdate((ptyId, data) => {
+    const unsubMeta = window.electronAPI.metadata.onUpdate((payload) => {
       const state = useStore.getState();
-      for (const ws of state.workspaces) {
-        const found = findSurfaceByPtyId(ws.rootPane, ptyId);
-        if (found) {
-          // Only update CWD from the active pane's active surface to prevent
-          // stale PTYs from overwriting the current directory
-          const isActiveSurface = isActivePtySurface(ws, ptyId);
-          if (isActiveSurface) {
-            state.updateWorkspaceMetadata(ws.id, data);
-          } else {
-            // For non-active surfaces, update metadata but exclude cwd
-            const { cwd: _cwd, ...rest } = data;
-            if (Object.keys(rest).length > 0) {
-              state.updateWorkspaceMetadata(ws.id, rest);
-            }
-          }
-          break;
+      // Discriminator: ptyId routes to its workspace; workspaceId is direct;
+      // neither means "active workspace" (e.g. meta.setStatus from a CLI).
+      const { ptyId, workspaceId: payloadWsId, ...rest } = payload;
+
+      const applyToWorkspace = (wsId: string, restrictCwd: boolean) => {
+        const data: Partial<typeof rest> = restrictCwd ? (() => {
+          const { cwd: _cwd, ...withoutCwd } = rest;
+          return withoutCwd;
+        })() : rest;
+        if (Object.keys(data).length > 0) {
+          state.updateWorkspaceMetadata(wsId, data as Parameters<typeof state.updateWorkspaceMetadata>[1]);
         }
+      };
+
+      if (ptyId) {
+        for (const ws of state.workspaces) {
+          const found = findSurfaceByPtyId(ws.rootPane, ptyId);
+          if (found) {
+            // Only update CWD from the active pane's active surface to prevent
+            // stale PTYs from overwriting the current directory.
+            applyToWorkspace(ws.id, !isActivePtySurface(ws, ptyId));
+            break;
+          }
+        }
+        return;
+      }
+
+      const targetWsId = payloadWsId ?? state.activeWorkspaceId;
+      if (targetWsId) {
+        applyToWorkspace(targetWsId, false);
       }
     });
 

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -96,6 +96,17 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
     setActiveWorkspace: (id) => set((state: StoreState) => {
       if (!state.workspaces.some((w: Workspace) => w.id === id)) return;
       state.activeWorkspaceId = id;
+      // Auto-mark this workspace's notifications as read on activation.
+      // Without this the unread badge keeps climbing whenever the user
+      // switches around without clicking into a specific terminal (the
+      // per-Pane click handler is the only other read trigger).
+      // Guarded for unit tests that exercise workspaceSlice without the
+      // notification slice mounted.
+      if (Array.isArray(state.notifications)) {
+        for (const n of state.notifications) {
+          if (n.workspaceId === id && !n.read) n.read = true;
+        }
+      }
       // multiviewIds is intentionally preserved here. AppLayout renders the
       // grid only when activeWorkspaceId is part of multiviewIds, so switching
       // to a non-multiview workspace shows its single view while the saved

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -206,7 +206,15 @@ export interface BrowserTypeHumanlikeParams {
 // === Daemon RPC Types ===
 
 export interface DaemonEvent {
-  type: 'session.created' | 'session.destroyed' | 'session.died' | 'session.output' | 'agent.event' | 'agent.critical' | 'activity.idle';
+  type:
+    | 'session.created'
+    | 'session.destroyed'
+    | 'session.died'
+    | 'session.output'
+    | 'agent.event'
+    | 'agent.critical'
+    | 'activity.idle'
+    | 'activity.active';
   sessionId: string;
   data: unknown;
 }

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -219,6 +219,12 @@ export interface DaemonEvent {
   data: unknown;
 }
 
+// NOTE: 'session.destroyed' is broadcast when the renderer/MCP explicitly
+// closes a session (pty:dispose → DaemonSessionManager.destroySession),
+// while 'session.died' is broadcast when the underlying PTY exits on its
+// own. Both must clear agentStatus on the main side; only one is reliably
+// observed depending on the caller path.
+
 export interface DaemonCreateSessionParams {
   id: string;
   cwd: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -126,7 +126,10 @@ export type NotificationType = 'info' | 'warning' | 'error' | 'agent';
 
 export interface Notification {
   id: string;
-  surfaceId: string;
+  // Optional: app-level / workspace-level notifications (e.g. from MCP `notify` RPC
+  // without an originating PTY) have no specific surface. Renderer resolves the
+  // active surface from store when displaying, or treats it as workspace-scoped.
+  surfaceId?: string;
   workspaceId: string;
   type: NotificationType;
   title: string;
@@ -149,6 +152,29 @@ export interface WorkspaceMetadata {
 
 // === Agent status ===
 export type AgentStatus = 'running' | 'complete' | 'error' | 'waiting' | 'idle';
+
+// === Metadata update IPC payload ===
+// Single discriminated payload shape used by IPC.METADATA_UPDATE. Sender (main)
+// includes whichever fields changed; receiver (renderer) merges into the
+// workspace identified by ptyId (preferred) or workspaceId (fallback for
+// surface-less updates like session sanitize on restore).
+//
+// Migration: replaces the previous inconsistent 2-arg (ptyId, data) vs 1-arg
+// (payload) patterns scattered across PTYBridge, meta.rpc, and metadata.handler.
+export interface MetadataUpdatePayload {
+  ptyId?: string;
+  workspaceId?: string;
+  gitBranch?: string;
+  cwd?: string;
+  listeningPorts?: number[];
+  agentStatus?: AgentStatus;
+  agentName?: string;
+  // External RPC channels (meta.setStatus / meta.setProgress) write through
+  // the same payload. Renderer applies these to the active workspace when no
+  // ptyId/workspaceId is provided.
+  status?: string;
+  progress?: number;
+}
 
 // === Status indicator colors ===
 export type WorkspaceStatus = 'active' | 'idle' | 'error' | 'running';


### PR DESCRIPTION
## Summary

Restores the broken agent task-complete notification pipeline. User-visible symptom: when an AI agent in a wmux pane finishes its turn, none of the three signals — sidebar dot, unread badge, OS toast — fire. The detection layer in main was disconnected from the renderer UI in four places, and daemon mode (the production default) bypassed the entire signal chain.

Three commits, each a logical unit:

- `cecdfc4` — **Pipeline restoration** (26 files): wires `AgentDetector.onEvent` + `ActivityMonitor.onActive` into `PTYBridge` + a new daemon-mode `DaemonNotificationRouter`. Unifies the `IPC.METADATA_UPDATE` payload contract (was silently broken between `metadata.handler` and `meta.rpc`). Adds `sendNotification` utility, AgentDetector overhaul (enum unified, unsubscribe support, per-(agent:status) dedup with `resetEmissionState()` for turn N+1, `\r`-split for TUI redraw, extended ANSI strip, removed `esc to interrupt` false-positive). 37 new tests.

- `5aee27f` — **Daemon cycle reset + destroy event** (5 files): post-review fixes after the first Codex pass. Daemon-side `AgentDetector` dedup now resets on each active burst (was stuck after turn 1). `session.destroyed` event is broadcast and handled, so closing a daemon-backed terminal via `pty:dispose` clears `agentStatus` instead of leaving a stale sidebar dot.

- `cddd3bd` — **Cross-model review fixes** (4 files, 5 catches): independent Codex re-review + Claude code-reviewer subagent each surfaced additional cases. Both agreed on the local-dispose path. Resolved:
  - C1: `onActiveToIdle` fallback now clears stale 'running' status when no precise agent event followed
  - C2: `cleanupInstance` broadcasts `agentStatus='idle'` (covers `PTYManager.dispose` path that bypasses `onExit`)
  - C3: in-app `pushToast` now respects `state.toastEnabled` user preference
  - L3: `DaemonNotificationRouter.onActive` omits `agentName` to avoid clobbering the prior name (daemon has no access to `AgentDetector.getLastAgent()`)
  - L4: `AppLayout` session-restore sanitize skips already-idle workspaces (was firing redundant no-op updates)

## Review trail

| Pass | Reviewer | Findings | Status |
|---|---|---|---|
| Plan 1 | `/plan-ceo-review` | 5 proposals, 2 accepted, 3 deferred | clean (SELECTIVE_EXPANSION) |
| Plan 1 | Codex round 1 | 10 | all addressed |
| Plan 1 | `/plan-eng-review` | 11, 1 critical (daemon mode) | all addressed |
| Plan 1 | Codex round 2 | 8 | all addressed |
| Code 2 | Codex round 1 | 2 (1 P1, 1 P2) | all addressed in `5aee27f` |
| Code 3 | Codex round 2 | 3 (2 P2, 1 P3) | all addressed in `cddd3bd` |
| Code 3 | Claude subagent | 7 (2 P2, 5 P3) | 2 addressed in `cddd3bd`, 5 deferred |

Cross-model agreement caught the dispose path from two angles (Codex C2 = agentStatus stale, Claude L5 = elapsed=0 cosmetic, same `cleanupInstance` method).

## Deferred (Claude P2/P3, follow-up issues)

- `DaemonNotificationRouter` regression suite — manual verification for now; mocking the full daemon IPty pipeline is out of scope.
- Session-restore sanitize regression test.
- `onExit` elapsed=0 cosmetic when `cleanupInstance` ran first.
- `AgentDetector` dedup intent comment.
- `DaemonClient` `removeAllListeners` on disconnect (pre-existing, not introduced here).
- `DaemonNotificationRouter` startup race window (events between `client.connect` resolve and `router.start` — recovery sessions are muted that early in practice).

`TODOS.md` also picks up the cherry-picked deferrals from CEO review: E3 (transient dot flash animation), E4 (per-workspace mute), E5 (tray icon unread badge, cross-platform), and the Eureka Phase 2 (Claude Code stop-hook → OSC 9 BEL).

## Test plan

- [x] `tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 980 / 980 pass (was 943; 37 new)
- [x] Regression coverage: R1-R6 unit-tested (R7 pushToast requires jsdom — manual)
- [ ] Manual: Claude Code in local mode — verify sidebar dot transitions `running` → `waiting` on prompt, unread badge increments, in-app toast fires, OS toast fires when window is unfocused
- [ ] Manual: same with daemon mode (production default) — confirms `DaemonNotificationRouter` wiring
- [ ] Manual: close a pane while agent is `running` — sidebar dot clears immediately (covers `cleanupInstance` `idle` broadcast)
- [ ] Manual: disable "Toast notifications" in settings — confirm both OS toast AND in-app overlay suppress
- [ ] Manual: long `npm run build` in a non-agent shell — confirm ActivityMonitor fallback fires once, then sidebar returns to `idle`
- [ ] Manual: restart wmux with a saved session — confirm no stale `running`/`waiting` dots from the previous run

🤖 Generated with [Claude Code](https://claude.com/claude-code)