### PR TITLE
docs(substrate): phase 0 — inventory, contract, PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,103 @@
+<!--
+Thanks for contributing to wmux. Fill the template out — reviewers use it as the
+landing checklist. Sections that don't apply: write "n/a" rather than deleting
+the header, so reviewers know you considered them.
+-->
+
+## Summary
+
+<!-- One or two sentences. What changed and why. -->
+
+## Changes
+
+<!--
+Bulleted list of substantive changes. Keep it tight; the diff is the source of
+truth, this is the index.
+-->
+
+-
+-
+
+## CHANGELOG entry
+
+<!--
+Required for every PR that touches user-visible behavior or the external
+substrate surface. Skip ONLY for internal-only refactors (with a note saying
+"no CHANGELOG — internal only" below).
+
+Use the Keep-a-Changelog sections. Pick the ones that apply; delete the rest.
+The release writer will copy this verbatim into CHANGELOG.md.
+-->
+
+### Added
+
+-
+
+### Changed
+
+-
+
+### Deprecated
+
+-
+
+### Removed
+
+-
+
+### Fixed
+
+-
+
+### Security
+
+-
+
+## Stability tier impact
+
+<!--
+Check one. Definitions in docs/api/versioning.md.
+
+- [ ] No external surface touched (internal refactor / docs / tests / CI).
+- [ ] Additive change to a `stable` surface (new optional param, new field, new event type).
+- [ ] Breaking change to a `stable` surface (requires major bump — block until release planning is in scope).
+- [ ] Change to an `experimental` surface (note in release notes).
+- [ ] Change to an `internal` surface (no contract impact).
+-->
+
+## Substrate contract impact (Substrate 3.0)
+
+<!--
+If this PR touches any of these, link to the relevant docs section that needs
+updating in the same PR or in a follow-up:
+
+- PaneMetadata wire shape, mergeMode, version semantics → docs/PROTOCOL.md §1
+- EventBus envelope, cursor semantics, bootId → docs/PROTOCOL.md §2, §3
+- Permission enforcement points → docs/PROTOCOL.md §4
+- Named Pipe security → docs/PROTOCOL.md §5
+- New RPC method / event type → docs/api/inventory.md + docs/api/stability.md
+
+Write "n/a" if nothing here applies.
+-->
+
+## Test plan
+
+<!--
+- Unit tests added / updated: which paths.
+- Integration / dynamic tests: link the script or describe the harness.
+- Manual verification: what you did locally, especially for UI/UX changes.
+
+CI must pass before merge — don't ship if you haven't run the full suite locally.
+-->
+
+## Related issues / PRs
+
+<!-- e.g. Closes #123, Tracks #18, Stacked on #16 -->
+
+## Reviewer checklist
+
+- [ ] CHANGELOG entry above is filled in or explicitly marked n/a.
+- [ ] Stability tier impact is correctly classified.
+- [ ] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed.
+- [ ] Tests cover the new behavior and the regression case (if a bug fix).
+- [ ] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # wmux — Windows Terminal Multiplexer for AI Agents (tmux alternative)
 
-> **Run Claude Code + Codex + Gemini CLI side by side on Windows.**
-> Native Windows terminal multiplexer with split panes, MCP bridge, and browser automation — the fastest way to run multiple AI CLI coding agents in a single window. A modern tmux alternative for Windows, no WSL required.
+> **wmux is LSP-for-terminals** — a neutral substrate that lets external tools build workflow intelligence on top of any terminal session.
+> Native Windows terminal multiplexer with split panes, MCP bridge, and browser automation — purpose-built for running Claude Code, Codex CLI, and Gemini CLI side by side. No WSL required.
 
 [![Windows 10/11](https://img.shields.io/badge/Windows-10%2F11-0078D6?logo=windows&logoColor=white)](https://github.com/openwong2kim/wmux/releases/latest)
 [![Electron 41](https://img.shields.io/badge/Electron-41-47848F?logo=electron&logoColor=white)](https://www.electronjs.org/)

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1,0 +1,313 @@
+# wmux Substrate Protocol
+
+> **Status:** Draft 1 (Phase 0 deliverable for Substrate 3.0). Expanded during Phase 1 M3 as the M0 MetadataStore lands.
+> **Audience:** plugin authors, dashboard builders, orchestrators, and anyone integrating wmux as a substrate.
+> **Companion docs:** [`api/inventory.md`](./api/inventory.md), [`api/versioning.md`](./api/versioning.md), [`api/stability.md`](./api/stability.md).
+
+This document is the substrate contract. It describes the wire-level rules that external tools rely on, in enough detail to write a correct client without reading wmux source code.
+
+---
+
+## 0. Foundational model
+
+wmux is a **terminal substrate**: it owns panes, terminal I/O, and the event bus. It does not own workflow logic. External tools (MCP plugins, dashboards, orchestrators) build workflow intelligence on top of these primitives.
+
+Three contract layers:
+
+1. **State surface:** `PaneMetadata` (per-pane) and `WorkspaceMetadata` (per-workspace). Mutable. Reads return the latest committed state.
+2. **Event surface:** an in-memory ring buffer of lifecycle events, polled via `events.poll`. Lets clients react without continuous state polling.
+3. **Identity surface:** `workspaceId`, `paneId`, `ptyId`, `bootId`, MCP server name, and the Named Pipe token. Determines who is talking to whom and what state survives daemon restarts.
+
+The protocol below is the contract between wmux and clients across these three layers.
+
+---
+
+## 1. PaneMetadata semantics
+
+### 1.1 Layered status
+
+PaneMetadata has two layers:
+
+- **Top-level fields** (`label`, `role`, `status`) — *shared display vocabulary*. Any tool may read or write. Reflects the most relevant human-facing workflow state at any given moment. Used by current and future wmux UI surfaces (pane headers, search results, sidebars) and by other tools that want a quick read of "what's this pane doing."
+- **`custom` object** — *tool-specific extension*. Opaque to wmux. Each tool writes under its own namespace; deep-merge ensures cooperating tools don't clobber each other's keys.
+
+This split came out of the RFC #15 discussion. The principle:
+
+> Top-level fields are read by humans and other tools at a glance. Tool-specific richness lives under `custom.<tool>.*` and is parsed only by the tool that wrote it.
+
+Multiple tools may write to `status` (the shared top-level field). wmux does not mediate. The convention is **last writer wins** for the shared field, with each tool also keeping its own rich state under `custom.<toolName>.status` (or similar). Tools that need precedence enforcement coordinate among themselves; wmux does not enforce ownership.
+
+Optimistic concurrency (§1.3) is the substrate-level primitive for coordination when two writers race on the same field.
+
+### 1.2 Namespacing convention
+
+`custom` is a flat `Record<string, string>` (one-level deep-merged on `setMetadata`). The convention for keys:
+
+- `<toolName>.<keyName>` — e.g. `orchestrator.taskId`, `qa.status`, `dashboard.lastRender`.
+- Keys without a dot are permitted but discouraged; they're prone to semantic collision across tools.
+- Reserved namespaces:
+  - `wmux.*` — reserved for wmux itself (currently unused, claimed for future protocol-level fields).
+  - `wmux.<server-name>.*` — reserved for an MCP server with that name. Per-plugin identity (see §4) anchors the namespace.
+
+Cooperating tools should agree on namespacing out-of-band. The substrate does not validate namespace ownership; that's a §4 permission concern, not a §1 contract concern.
+
+### 1.3 Versioning and optimistic concurrency
+
+Each pane's metadata has a monotonic `version: number`, starting at 0 (no metadata ever set) and incrementing by 1 on every successful `setMetadata` or `clearMetadata`.
+
+**`expectedVersion` (optional):**
+
+```jsonc
+// pane.setMetadata params
+{
+  "paneId": "p-123",
+  "workspaceId": "ws-1",
+  "status": "running",
+  "expectedVersion": 7   // ← optimistic-concurrency check
+}
+```
+
+If the current version is not `7`, the call returns JSON-RPC error `-32001`:
+
+```jsonc
+{
+  "id": "req-42",
+  "ok": false,
+  "error": "VERSION_CONFLICT",
+  "currentVersion": 11   // ← actual current version
+}
+```
+
+The caller decides whether to retry (after re-reading or re-merging) or surrender.
+
+**`expectedVersion` omitted:** no check; the call always commits. This is the v2.x behavior and stays the default for clients that haven't migrated to optimistic concurrency.
+
+**Version is committed in the same transaction as the merged shape.** The `mergeMode` evaluation, validation, persistence, and event emission all happen inside one synchronous critical section in the main-process `MetadataStore` (single-threaded JS provides natural serialization). The `version` returned on a successful write is always the version of the post-merge shape; the `pane.metadata.changed` event carries the same value.
+
+### 1.4 mergeMode semantics
+
+The v3.0 wire format has three modes:
+
+| `mergeMode` | Semantics |
+|---|---|
+| `'merge'` (default) | Patch-style. Top-level fields in the patch overwrite existing values. The `custom` object deep-merges one level: keys in `patch.custom` overwrite same-named keys in `existing.custom`; other existing keys are preserved. |
+| `'replace'` | Full overwrite. The new metadata equals exactly `patch`; everything not in `patch` is dropped, including `custom`. |
+| `'replaceShared'` | Replace top-level shared fields (`label`, `role`, `status`) but preserve `custom`. Intended for tools that want to take ownership of the shared display vocabulary without disturbing other tools' tool-specific state. |
+
+Legacy `merge: boolean` parameter remains for backwards compatibility:
+
+- `merge: true` ⇒ `mergeMode: 'merge'`
+- `merge: false` ⇒ `mergeMode: 'replace'`
+
+Passing both `merge` and `mergeMode` is an error. New clients should use `mergeMode` and stop sending `merge`.
+
+### 1.5 Validation
+
+Inputs are validated before commit. Failures return a JSON-RPC error with a descriptive message and **do not** increment `version`. Limits live in [`api/stability.md`](./api/stability.md#validation-limits-v30-baseline-values).
+
+---
+
+## 2. Event bus contract
+
+### 2.1 Polling model
+
+The event bus is **pull, not push**. Clients call `events.poll(cursor)`; the bus returns all events with `seq > cursor` (subject to filters), plus a new cursor and a `bootId`.
+
+Stdio MCP transport doesn't carry server-initiated notifications cleanly, and `daemon.readPromptEvents` already establishes the pull pattern. The 1024-event ring covers minutes of typical activity; bursts beyond that surface as `droppedCount > 0` and trigger client-side reconciliation via §2.5.
+
+### 2.2 Cursor is opaque
+
+Today, `cursor` is a monotonic 64-bit integer assigned by the bus. **Clients must not depend on this.** The substrate guarantees only:
+
+- `cursor: 0` always means "replay from oldest in the ring."
+- `nextCursor` returned from `events.poll` is the right value to pass back on the next poll. Do not increment, sort, or compare it.
+- `nextCursor` is monotonically non-decreasing across calls from the same client (strictly increasing only when new events were delivered). Specifically: `nextCursor >= priorCursor` always; `nextCursor > priorCursor` if and only if at least one event was scanned past the cursor (including filter no-matches, which still advance the cursor — see §2.3).
+
+Future evolutions (sharded rings, segmented cursors) may change the underlying encoding without notice. Opaque-cursor clients are unaffected.
+
+### 2.3 Filtered polling
+
+`events.poll` accepts `types?: WmuxEventType[]` and `workspaceId?: string` filters. The cursor advances on **scanned** events, not just matched ones — a subscriber filtering for `process.exited` across a busy bus doesn't re-scan unmatched events on every poll.
+
+### 2.4 `bootId` and daemon restart
+
+`bootId` is a UUIDv4 stamped at `EventBus` construction. Every `events.poll` response, every `pane.list` response, and `system.capabilities().features.events.bootId` all return the same value for the lifetime of a main-process run.
+
+**Mismatch across calls means the daemon restarted under the caller.** Required client action:
+
+1. Drop all cached state — pane ids, pty ids, cursors, last-seen workspace metadata.
+2. Re-hydrate via `pane.list` (returns a new `asOfSeq` and `bootId`).
+3. Resume `events.poll` with `cursor: asOfSeq`.
+
+`bootId` mismatch is a stricter signal than `resync: true`. Cursor-window drift is recoverable by re-polling; daemon restart invalidates the entire seq space.
+
+**Atomicity:** the `bootId` is set once when `EventBus` is constructed. It does not change while the main process is alive; the construction happens before any RPC handler can return a response. Clients can rely on the value remaining constant across the lifetime of a successful connection.
+
+### 2.5 Snapshot reconciliation (`resync: true` and `droppedCount`)
+
+If the caller's cursor drifted past the ring window (`cursor + 1 < oldestSeq`) **or** is in the future (`cursor > latestSeq`), the response carries `resync: true`. The `droppedCount` field is set when the drift is past the ring window (the daemon knows exactly how many events were missed).
+
+Required client action on `resync: true`:
+
+1. Stop trusting cached pane state.
+2. Call `pane.list` to get a fresh snapshot. The response carries `{ asOfSeq, bootId, panes }`.
+3. If `bootId` differs from your last known value, treat as a daemon restart (§2.4): drop everything else cached too.
+4. Resume `events.poll` with `cursor: asOfSeq`.
+
+`pane.list` is the substrate's snapshot primitive. It returns the full pane tree with metadata + version per pane, plus the `asOfSeq` watermark that anchors event replay.
+
+### 2.6 PollResult fields, full
+
+```jsonc
+{
+  "events": [/* WmuxEvent[] with seq > effectiveCursor */],
+  "nextCursor": 412,
+  "priorCursor": 380,    // ← echoes the cursor you passed in
+  "bootId": "550e8400-e29b-41d4-a716-446655440000",
+  "droppedCount": 3,     // ← set if drifted past ring window
+  "resync": true         // ← set if drift or future cursor
+}
+```
+
+`priorCursor` and `droppedCount` are diagnostic — clients can log them to detect partner-side problems (the caller was paused, the bus was too small for the burst rate, etc.).
+
+### 2.7 Ordering caveat
+
+Event `seq` is monotonic in **arrival order**, not in **causal order**. Two independent producers (PTYBridge in main; paneSlice via preload IPC) write to the bus on different paths. Within one producer, order is preserved; across producers, a same-tick `pane.created` (renderer-published) and `process.started` (main-published) can land in the bus in either order.
+
+Clients must not assume `seq` order implies causal order across producer boundaries. Use timestamps (`ts`) for cross-producer reasoning when ordering matters.
+
+---
+
+## 3. Snapshot envelope (`pane.list`)
+
+`pane.list` is more than a list. It returns:
+
+```jsonc
+{
+  "asOfSeq": 412,
+  "bootId": "550e8400-e29b-41d4-a716-446655440000",
+  "panes": [
+    {
+      "id": "p-1",
+      "type": "leaf",
+      // …tree structure…
+      "metadata": { /* PaneMetadata */ },
+      "version": 7                       // ← per-pane metadata version
+    }
+    // …more panes…
+  ]
+}
+```
+
+**Properties:**
+
+- `asOfSeq` is the EventBus seq at the moment the snapshot was assembled. Events with `seq <= asOfSeq` are already reflected in `panes[*].metadata`; events with `seq > asOfSeq` are the next ones to consume via `events.poll(cursor: asOfSeq)`.
+- `bootId` matches the EventBus's current value. Use it to detect daemon restarts.
+- Snapshot is atomic from the client's perspective: the entire response is a consistent slice of state at `asOfSeq`. Internally, the M0 transaction-aware MetadataStore guarantees this — `pane.list` reads from a snapshot view of the store, not interleaved with concurrent writes.
+
+This is the reconciliation primitive for §2.5.
+
+---
+
+## 4. Permission enforcement
+
+The substrate has four enforcement points. All four exist to prevent one MCP from doing something it wasn't authorized to do.
+
+| # | Point | Status | Notes |
+|---|---|---|---|
+| 1 | Method dispatch | v3.0 (new in Phase 2.1) | `wmuxPermissions` in the MCP server manifest declares which methods this server may call. RPC dispatcher rejects unauthorized calls. |
+| 2 | Metadata path write | v3.0 (new in Phase 2.1) | `wmuxPermissions` may scope writes to specific `custom.<namespace>.*` paths. Writes outside the allowed paths are rejected. |
+| 3 | Event subscription | v3.0 (new in Phase 2.1) | `events.poll` filters are enforced against `wmuxPermissions`. A server that hasn't declared subscription to `pane.created` can't see those events even if it polls. |
+| 4 | Workspace claim | **v2.7.2 (already shipped)** | `mcp.claimWorkspace` binds an MCP server to a workspace. Subsequent writes targeting other workspaces are rejected. |
+
+`wmuxPermissions` syntax (Phase 2.1 spec, draft): `<capability>[:<path-glob>]`. Examples:
+
+- `pane.read` — read pane state and metadata.
+- `meta.write` — write any pane's metadata (top-level + custom).
+- `meta.write:custom.dashboard.*` — write only the `dashboard.*` paths inside `custom`.
+- `events.subscribe:pane.*` — subscribe to `pane.created`, `pane.closed`, `pane.focused`, `pane.metadata.changed`.
+
+Per-plugin identity is the MCP server name. Two servers with the same name on the same wmux instance is a registration error.
+
+**Raw RPC bypass policy:** all four enforcement points are at method-dispatch level. There's no "internal" path that skips them; the IPC handler entry point is the chokepoint. The substrate does not expose a "trusted" mode that lets a plugin opt out of enforcement.
+
+(Full `wmuxPermissions` spec lands in `api/mcp-plugin-spec.md` during Phase 2.1. This section is the contract sketch.)
+
+---
+
+## 5. Named Pipe security model
+
+The wmux daemon exposes the JSON-RPC surface over a Windows Named Pipe at `\\.\pipe\wmux-rpc-<token>`.
+
+### 5.1 Token-based authentication
+
+Every connection must present the token from `%APPDATA%\wmux\pipe-token` in the first request:
+
+```jsonc
+{
+  "id": "req-1",
+  "method": "system.identify",
+  "params": {},
+  "token": "<base64-encoded-token>"
+}
+```
+
+The token is a 256-bit random value generated on first daemon launch and persisted to disk. The file is written with `secureWriteTokenFile` — Windows OS ACLs restrict read access to the current user's SID; other users on the same machine cannot read it. The token is rotated only on explicit request (planned CLI: `wmux pipe rotate-token`).
+
+### 5.2 Connection cap
+
+`MAX_CONNECTIONS = 50` concurrent client connections per daemon. A new connection beyond the cap is rejected immediately. The cap protects against runaway plugin scenarios where a misbehaving client opens connections in a loop.
+
+### 5.3 Why not ACL the pipe itself?
+
+The pipe is created with a default DACL that allows the current user's processes to connect. Earlier plans proposed restricting the pipe DACL further; that approach was retired because:
+
+- The token model already provides per-process authentication independently of OS user identity.
+- Windows pipe DACL semantics interact awkwardly with elevated processes (admin shells reaching a non-elevated wmux daemon and vice versa).
+- Token rotation is a clean recovery primitive; DACL re-tightening requires daemon restart.
+
+The current model is: OS isolates users, token isolates processes, `mcp.claimWorkspace` isolates workspaces within a process, and `wmuxPermissions` isolates capability classes within a workspace. Defense in depth, with the token acting as the primary security boundary.
+
+### 5.4 What the token does NOT authenticate
+
+- **Plugin identity beyond "you have the token."** Two MCP servers connecting with the same token are distinguishable only by the `system.identify` they declare. The `wmuxPermissions`-based plugin identity model is the v3.0 strengthening of this.
+- **Workspace ownership.** Any token-holder can read any workspace's state by default. `mcp.claimWorkspace` is the opt-in scoping mechanism; tools that don't claim get read-only-style access to the full surface.
+- **Transport encryption.** Named Pipe is a local IPC; the OS is the trust boundary. Cross-machine access would require a different transport (WebSocket + TLS, planned for v3.1+).
+
+---
+
+## 6. Identity model
+
+| Identifier | Lifetime | Cache invalidation signal |
+|---|---|---|
+| `workspaceId` | persisted across daemon restarts | — (stable) |
+| `paneId` | one daemon run | `bootId` change |
+| `ptyId` | one PTY process | `process.exited` event |
+| `bootId` | one main-process run | itself (mismatch = restart) |
+| MCP server name | stable as long as the server is registered | re-registration |
+| Pipe token | persisted on disk; rotated explicitly | token rotation event (planned) |
+
+The two stable-across-restart identifiers are `workspaceId` and MCP server name. Everything else is single-run; clients must reconcile via `pane.list` after a `bootId` change.
+
+---
+
+## 7. Known limitations and v3.0 boundaries
+
+Things external clients may run into that aren't bugs but are explicit substrate boundaries:
+
+- **Workspace identity blocker (open).** The `project_workspace_identity_fix.md` issue exists but is being investigated in Phase 1 M4. Today, an MCP server that claims workspace A and then writes metadata with an explicit `workspaceId: B` is rejected (correct), but the active-pane resolution path when *no* `workspaceId` is provided can hijack to whichever workspace the user is viewing. External callers SHOULD pass `workspaceId` explicitly to bypass this.
+- **No buffer access yet.** `terminal.readEvents` covers structured prompt events; arbitrary scrollback buffer reads are partial via `input.readScreen`. The cross-workspace policy gate for full buffer access is a v3.1+ design item.
+- **Cursor evolution.** The opaque-cursor guarantee is a forward-compat hedge. If sharded rings ship in v3.x, the encoding may change; opaque-cursor clients are unaffected by design.
+- **Layered status precedence.** The substrate does not enforce precedence among writers of the top-level `status` field. Last writer wins. Tools that need precedence should coordinate via `custom.<tool>.status` and pick one tool to own the shared field.
+- **Cross-producer ordering.** `seq` is arrival order, not causal order. See §2.7.
+
+---
+
+## 8. Change history of this document
+
+| Version | Date | Notes |
+|---|---|---|
+| Draft 1 | 2026-05-12 | Phase 0 initial draft. Covers PaneMetadata layered status, mergeMode, version + expectedVersion, bootId, cursor opaqueness, snapshot envelope, permission enforcement (sketch), Named Pipe security model. Phase 1 M3 will expand. |
+
+This document evolves alongside the implementation. Changes that affect the wire contract require a major-version bump per [`api/versioning.md`](./api/versioning.md). Changes that clarify existing semantics ship in any release.

--- a/docs/api/inventory.md
+++ b/docs/api/inventory.md
@@ -1,0 +1,225 @@
+# wmux Public Surface Inventory
+
+> **Baseline:** v2.8.4 (`main` @ c2fd6c6). Phase 0 deliverable for the Substrate 3.0 plan.
+> **Purpose:** one document that lists every RPC method, MCP tool, and event type wmux exposes to external tooling, with a `stability` tier so consumers can plan around what is and isn't covered by the v3.0 contract.
+> **Companion docs:** [`versioning.md`](./versioning.md) (semver + tier semantics), [`stability.md`](./stability.md) (v3.0 stable-surface guarantees), [`../PROTOCOL.md`](../PROTOCOL.md) (substrate contract).
+
+---
+
+## Stability tiers at a glance
+
+| Tier | Meaning | Breaking-change policy |
+|---|---|---|
+| **stable** | Covered by the v3.0 substrate contract. Wire shape + semantics frozen. | Only on a major version bump. Additive changes (new optional fields, new event types) allowed within a major. |
+| **experimental** | Shipped and supported, but the wire shape or semantics may evolve before being promoted to stable. Includes Company Mode and the browser/CDP surface. | Breaking changes allowed within a major; release notes flag them. |
+| **internal** | Implementation detail. Not part of the external contract. Documented here only so external tooling knows what *not* to depend on. | May change without notice. |
+
+The stability tier is reported by `system.capabilities` in v3.0 (planned addition). Today, callers can read this document as the source of truth.
+
+---
+
+## RPC methods (JSON-RPC over Named Pipe)
+
+Transport: Named Pipe (`\\.\pipe\wmux-rpc-<token>`), token-authenticated (`PipeServer`). The MCP host hosts these as tools (see [MCP tools](#mcp-tools) below); other clients can connect directly with the token from `%APPDATA%\wmux\pipe-token`.
+
+### Workspace surface
+
+| Method | Params | Tier | Notes |
+|---|---|---|---|
+| `workspace.list` | — | stable | Returns all workspaces with their metadata. |
+| `workspace.new` | `{ name?, cwd? }` | stable | Creates a new workspace. |
+| `workspace.focus` | `{ id }` | stable | Switches the active workspace. |
+| `workspace.close` | `{ id }` | stable | Closes a workspace (with PTY cleanup). |
+| `workspace.current` | — | stable | Returns the active workspace id. |
+
+### Surface (window) surface
+
+| Method | Params | Tier | Notes |
+|---|---|---|---|
+| `surface.list` | — | stable | All wmux windows. |
+| `surface.new` | — | stable | Opens a new wmux window. |
+| `surface.focus` | `{ id }` | stable | Focuses an existing window. |
+| `surface.close` | `{ id }` | stable | Closes a window. |
+
+### Pane surface (the core substrate read/write)
+
+| Method | Params | Tier | Notes |
+|---|---|---|---|
+| `pane.list` | `{ workspaceId? }` | stable | Returns `{ asOfSeq, bootId, panes }` envelope. `asOfSeq` is the EventBus seq at snapshot time; clients reconciling after `resync: true` drain events with `seq > asOfSeq`. `bootId` mismatch ⇒ drop all caches. |
+| `pane.focus` | `{ id }` | stable | Focuses a leaf pane. |
+| `pane.split` | `{ direction: 'horizontal' \| 'vertical' }` | stable | Splits the active pane. |
+| `pane.setMetadata` | `{ paneId?, workspaceId?, label?, role?, status?, custom?, merge? }` | stable | External MCP callers SHOULD pass `workspaceId` (see `mcp.claimWorkspace`). `merge` defaults to true; `custom` deep-merges one level. **v3.0 will add `expectedVersion` and replace `merge: boolean` with `mergeMode: 'merge'\|'replace'\|'replaceShared'` (backwards-compatible).** |
+| `pane.getMetadata` | `{ paneId?, workspaceId? }` | stable | Reads metadata for a leaf pane. |
+| `pane.clearMetadata` | `{ paneId?, workspaceId? }` | stable | Drops all metadata for a leaf pane. |
+| `pane.search` | `{ query, regex?, workspaceId? }` | stable | Cross-pane content search within a workspace. Scoped to the caller's workspace. |
+
+Validation limits live in `src/shared/types.ts` (PANE_METADATA_MAX_BYTES, PANE_METADATA_LABEL_MAX, etc.) and are reported on validation failure.
+
+### Event bus
+
+| Method | Params | Tier | Notes |
+|---|---|---|---|
+| `events.poll` | `{ cursor?, types?, workspaceId?, max? }` | stable | Pull events with `seq > cursor`. Returns `{ events, nextCursor, priorCursor, bootId, droppedCount?, resync? }`. See [Event types](#event-types) below. Polling, not push — stdio MCP transport doesn't carry server-initiated notifications cleanly. |
+
+### Terminal I/O surface
+
+| Method | Params | Tier | Notes |
+|---|---|---|---|
+| `input.send` | `{ text, paneId?, workspaceId? }` | stable | Send literal text to a pane's PTY. |
+| `input.sendKey` | `{ key, paneId?, workspaceId? }` | stable | Send a control key sequence. |
+| `input.readScreen` | `{ paneId?, workspaceId? }` | stable | Read the current visible terminal buffer. |
+| `terminal.readEvents` | `{ paneId?, workspaceId?, sinceSeq? }` | stable | Read structured terminal output events (prompt detection, etc.). |
+
+### Identity & capability
+
+| Method | Params | Tier | Notes |
+|---|---|---|---|
+| `system.identify` | — | stable | `{ app, version, platform, electronVersion }`. |
+| `system.capabilities` | — | stable | Lists all registered RPC methods + feature flags. v3.0 will add a stability-tier map per feature. |
+| `mcp.claimWorkspace` | `{ workspaceId }` | stable | An MCP client binds itself to a workspace. Subsequent metadata / event writes are scoped to it. Added in v2.7.2 to prevent active-pane hijacking by external MCPs. |
+
+### Display vocabulary (shared workspace state)
+
+| Method | Params | Tier | Notes |
+|---|---|---|---|
+| `notify` | `{ message, kind?, paneId?, workspaceId? }` | stable | OS notification + in-app banner. |
+| `meta.setStatus` | `{ status, workspaceId? }` | stable | Workspace-level status (shared display field). |
+| `meta.setProgress` | `{ progress, workspaceId? }` | stable | Workspace-level progress (shared display field). |
+| `meta.setSkills` | `{ skills }` | stable | A2A agent self-description for `a2a.discover`. |
+
+### Agent-to-Agent (A2A) surface
+
+| Method | Params | Tier | Notes |
+|---|---|---|---|
+| `a2a.resolve.identity` | `{ workspaceId? }` | stable | Returns the canonical identity for a workspace's agent. |
+| `a2a.whoami` | — | stable | The calling MCP's claimed identity. |
+| `a2a.discover` | `{ filter? }` | stable | Lists other agents in the local wmux instance. |
+| `a2a.task.send` | `{ to, kind, payload, requiresExecuteApproval? }` | stable | v2.7.3 added execute-approval gate (see memory `project_a2a_execute_gate.md`). |
+| `a2a.task.query` | `{ id }` | stable | |
+| `a2a.task.update` | `{ id, status, result? }` | stable | |
+| `a2a.task.cancel` | `{ id }` | stable | |
+| `a2a.broadcast` | `{ kind, payload }` | stable | |
+
+### Browser / CDP surface
+
+| Method | Params | Tier | Notes |
+|---|---|---|---|
+| `browser.open` | `{ url? }` | experimental | The browser/CDP surface backs the MCP `browser_*` tools. Wire shapes may evolve before v3.0. Currently the primary AI-agent capability driver, but not part of the substrate identity. |
+| `browser.navigate`, `browser.goBack`, `browser.close` | various | experimental | |
+| `browser.session.{start,stop,status,list}` | various | experimental | |
+| `browser.type.humanlike`, `browser.type.cdp`, `browser.click.cdp`, `browser.press.cdp` | various | experimental | |
+| `browser.cdp.target`, `browser.cdp.info` | various | experimental | |
+| `browser.screenshot`, `browser.evaluate` | various | experimental | |
+
+The full list lives in `src/shared/rpc.ts` (`ALL_RPC_METHODS`). For the MCP-facing tool names (which are the actual external API for most consumers), see [MCP tools](#mcp-tools).
+
+### Daemon (internal IPC, not part of substrate contract)
+
+| Method | Tier | Notes |
+|---|---|---|
+| `daemon.createSession`, `daemon.destroySession`, `daemon.attachSession`, `daemon.detachSession`, `daemon.resizeSession`, `daemon.listSessions`, `daemon.readPromptEvents`, `daemon.ping`, `daemon.shutdown`, `daemon.compact` | **internal** | Used by the wmux Electron client to manage the PTY daemon process. External tooling should not call these — use the pane/terminal surfaces instead. |
+
+### Company Mode (deferred to Phase 4 gate)
+
+| Method | Tier | Notes |
+|---|---|---|
+| `company.{create, destroy, status, addDept, removeDept, addMember, removeMember, broadcast, sendDept, sendMember, message, save, restore, templates, worktreeSetup, mergeDept, provision, provisionAll, provisionCeo}` | **experimental** | 3-tier orchestration (CEO → Department → Teammate). Per the Substrate 3.0 decision (memory `project_company_mode_vision.md`), Company Mode is being re-evaluated at the post-v3.0 gate as a first-party reference orchestrator on top of the substrate, not a core wmux feature. |
+| `company.a2a.{whoami, send, broadcast, inbox, ack, status}` | **experimental** | Company-scoped A2A surface. |
+
+---
+
+## MCP tools
+
+The wmux MCP server (hosted in-process, named-pipe transport to the daemon) exposes a curated subset of the RPC surface as MCP tools. Tool names match `mcp__wmux__<tool>` when used from a Claude Desktop / Claude Code client.
+
+### Substrate surface (stable in v3.0)
+
+| MCP tool | Backs RPC method | Notes |
+|---|---|---|
+| `pane_list` | `pane.list` | Returns the snapshot envelope `{ asOfSeq, bootId, panes }`. |
+| `pane_get_metadata` | `pane.getMetadata` | |
+| `pane_set_metadata` | `pane.setMetadata` | The substrate write entrypoint. |
+| `workspace_list` | `workspace.list` | |
+| `surface_list` | `surface.list` | |
+| `terminal_read` | `input.readScreen` | |
+| `terminal_read_events` | `terminal.readEvents` | Structured prompt-detected events. |
+| `terminal_send` | `input.send` | |
+| `terminal_send_key` | `input.sendKey` | |
+| `wmux_events_poll` | `events.poll` | Pull-based event stream. |
+| `wmux_search_panes` | `pane.search` | |
+| `send_message` | (composite — combines `input.send` semantics) | |
+
+### A2A surface (stable)
+
+| MCP tool | Backs RPC method |
+|---|---|
+| `a2a_whoami` | `a2a.whoami` |
+| `a2a_discover` | `a2a.discover` |
+| `a2a_set_skills` | `meta.setSkills` |
+| `a2a_task_send` | `a2a.task.send` |
+| `a2a_task_query` | `a2a.task.query` |
+| `a2a_task_update` | `a2a.task.update` |
+| `a2a_task_cancel` | `a2a.task.cancel` |
+| `a2a_broadcast` | `a2a.broadcast` |
+
+### Company A2A (experimental)
+
+| MCP tool | Notes |
+|---|---|
+| `company_a2a_whoami`, `company_a2a_send`, `company_a2a_broadcast`, `company_a2a_inbox`, `company_a2a_ack`, `company_a2a_status` | Company-scoped agent messaging. Behind the Phase 4 gate. |
+
+### Browser / CDP (experimental)
+
+| MCP tool family | Count | Notes |
+|---|---|---|
+| `browser_*` (open, close, navigate, navigate_back, screenshot, fill, type, click, hover, drag, press_key, scroll, scroll_into_view, snapshot, smart_snapshot, console, cookies, dialog, download, evaluate, extract_data, extract_text, file_upload, highlight, network, pdf, resize, response_body, select, session_list, session_start, session_status, session_stop, storage, tabs, trace, wait, wait_for_download, emulate) | ~40 | Wire shapes may evolve before v3.0. Backs Claude Code / Codex / Gemini CLI browser-control use cases. |
+
+---
+
+## Event types
+
+The EventBus (`src/main/events/EventBus.ts`) is an in-memory ring buffer of `RING_CAPACITY = 1024` events with `POLL_DEFAULT_MAX = 256`. Workspace scoping is applied at poll time. Each main-process run has a `bootId` (UUIDv4) that invalidates client caches on daemon restart.
+
+| Event type | Tier | Wire shape (key fields beyond `seq`/`ts`/`workspaceId`/`type`) |
+|---|---|---|
+| `pane.created` | stable | `paneId`, `parentBranchId?` |
+| `pane.closed` | stable | `paneId` |
+| `pane.focused` | stable | `paneId`, `previousPaneId?` |
+| `pane.metadata.changed` | stable | `paneId`, `metadata: PaneMetadata` |
+| `workspace.metadata.changed` | stable | `metadata: WorkspaceMetadata`, `patch: Partial<WorkspaceMetadata>` |
+| `process.started` | stable | `ptyId`, `pid?`, `shell` |
+| `process.exited` | stable | `ptyId`, `exitCode`, `signal?` |
+
+**Ordering caveat:** `seq` is monotonic in **arrival order**, not in **causal order**. Two independent producers (PTYBridge in main process; paneSlice via preload IPC) write to the bus on different paths. Within one producer, order is preserved; across producers, a same-tick `pane.created` (renderer-published) and `process.started` (main-published) can land in the bus in either order. Clients must not assume seq order implies causal order across producer boundaries.
+
+**v3.0 cursor contract** (planned, see [`../PROTOCOL.md`](../PROTOCOL.md)): cursor is **opaque**. Today it happens to be a monotonic 64-bit integer, but clients must pass back whatever `nextCursor` they received without interpretation. `cursor: 0` always means "replay from oldest in the ring."
+
+---
+
+## Identity / addressing model
+
+| Identifier | Stable across daemon restarts? | Notes |
+|---|---|---|
+| `workspaceId` | yes (session-persisted) | Stable. External tools should claim via `mcp.claimWorkspace`. |
+| `paneId` | no (invalidated on `bootId` change) | Recreated per main-process run. Persisted in `session.json` but new ids are minted if the session restore fails partially. |
+| `ptyId` | no | One-to-one with PTY processes; lifetime tied to the underlying shell. |
+| `bootId` | no — that's the whole point | Stamped at EventBus construction. Mismatch ⇒ client drops all cached pane/pty ids and cursors. |
+| MCP server name | yes | Used as the v3.0 plugin namespace anchor (`wmux.<server-name>.*`). |
+| Token (Named Pipe) | yes (rotated only on explicit rotate) | Persisted under `%APPDATA%\wmux\pipe-token` with OS ACL restriction. See [`../PROTOCOL.md`](../PROTOCOL.md) §Named Pipe security. |
+
+---
+
+## What's intentionally not in this inventory
+
+- **Daemon internals.** `src/main/pty/*`, `src/main/session/SessionManager.ts` — these are reachable through the public surfaces above but their internal contracts are not part of the substrate.
+- **Renderer-internal IPC.** The `pane:*` / `workspace:*` channels used between Electron main and the renderer process are not part of the external surface. External tooling reaches the same state through the RPC surface.
+- **CLI commands.** `wmux <command>` flags are stabilized separately. v3.0 stabilizes the JSON-output mode of a small set (`wmux mcp`) and defers full `--json --format` standardization to v3.1.
+
+---
+
+## How this inventory is used downstream
+
+- [`versioning.md`](./versioning.md) cites the tier column.
+- [`stability.md`](./stability.md) freezes the "stable" tier subset as the v3.0 contract.
+- [`../PROTOCOL.md`](../PROTOCOL.md) elaborates on the wire contract for the stable surfaces.
+- `system.capabilities` will report the tier map programmatically in v3.0.

--- a/docs/api/stability.md
+++ b/docs/api/stability.md
@@ -1,0 +1,277 @@
+# wmux v3.0 Stable Surface
+
+> **Status:** Phase 0 deliverable for Substrate 3.0. Freezes the v3.0 substrate contract.
+> **Audience:** plugin authors and external orchestrators planning long-lived integrations.
+> **Companion docs:** [`inventory.md`](./inventory.md) (full surface list with tiers), [`versioning.md`](./versioning.md) (semver + tier semantics), [`../PROTOCOL.md`](../PROTOCOL.md) (wire contract).
+
+---
+
+## What this document is
+
+The v3.0 substrate contract is a *subset* of the inventory. This file lists every surface that ships with `stable` guarantees, plus the precise scope of what's guaranteed for each.
+
+A v3.0 `stable` surface is:
+
+1. **Wire-shape-frozen.** Parameter names, return field names, JSON-RPC error codes, event envelope keys — fixed for the v3.x lifetime.
+2. **Semantics-frozen.** Same input ⇒ same output and side effects.
+3. **Additive-only.** New optional parameters and new fields may appear in minor releases (`3.1.0`, `3.2.0`, …). New event types may be added. Existing fields don't disappear and don't change meaning.
+4. **Removable only on a major** (v4.0+), with at least one minor's deprecation notice.
+
+A v3.0 `stable` client — one that uses only the surfaces in this document, ignores unknown fields, and feature-detects via `system.capabilities` — is guaranteed to keep working across every v3.x release.
+
+---
+
+## Substrate core (the metadata + events surface)
+
+This is the heart of the substrate contract — the surface RFC #15 was about.
+
+### `pane.list`
+
+**Method:** `pane.list`
+**Params:** `{ workspaceId?: string }`
+**Returns:** `{ asOfSeq: number, bootId: string, panes: PaneListEntry[] }`
+
+- `asOfSeq` is the EventBus seq at snapshot time. Clients reconciling after `resync: true` must drain events with `seq > asOfSeq`.
+- `bootId` is stable for the lifetime of the main-process run. Mismatch ⇒ client drops all cached pane ids, pty ids, and cursors.
+- Each `PaneListEntry` contains pane tree info plus `metadata: PaneMetadata` (with `version` in v3.0+).
+
+`pane.list` is the snapshot-reconciliation primitive for the event bus. Combined with `events.poll`, it gives external tools a complete recovery path under burst writes or daemon restarts.
+
+### `pane.setMetadata`
+
+**Method:** `pane.setMetadata`
+**Params:** `{ paneId?, workspaceId?, label?, role?, status?, custom?, mergeMode?, merge?, expectedVersion? }`
+**Returns (success):** `{ ok: true, version: number, metadata: PaneMetadata }`
+**Returns (version conflict, v3.0+):** JSON-RPC error code `-32001` with `{ error: 'VERSION_CONFLICT', currentVersion: number }`
+
+- Stable validation limits: `PANE_METADATA_MAX_BYTES`, `PANE_METADATA_LABEL_MAX`, `PANE_METADATA_ROLE_MAX`, `PANE_METADATA_STATUS_MAX`, `PANE_METADATA_CUSTOM_KEY_MAX`, `PANE_METADATA_CUSTOM_MAX_ENTRIES`. Numeric values may grow in minors but cannot shrink within v3.x.
+- `mergeMode` accepts `'merge'` (default — patch-style, with one-level deep-merge on `custom`), `'replace'` (full overwrite of the entire metadata object), and `'replaceShared'` (replace `label`/`role`/`status` while preserving `custom`).
+- Legacy `merge: boolean` is preserved as a shortcut: `merge: true` ⇒ `mergeMode: 'merge'`, `merge: false` ⇒ `mergeMode: 'replace'`.
+- `expectedVersion` enables optimistic concurrency. Mismatch returns `VERSION_CONFLICT` with the current version; client decides whether to retry.
+- Omitting `expectedVersion` opts out of version checks. Equivalent to the v2.x semantics.
+- Per-pane `version` is monotonic. Each successful `set` increments by 1. `version: 0` is the "no metadata ever set" sentinel.
+
+### `pane.getMetadata`
+
+**Method:** `pane.getMetadata`
+**Params:** `{ paneId?, workspaceId? }`
+**Returns:** `{ metadata: PaneMetadata | undefined, version: number }`
+
+Reads return the latest committed metadata + version. No event emitted.
+
+### `pane.clearMetadata`
+
+**Method:** `pane.clearMetadata`
+**Params:** `{ paneId?, workspaceId? }`
+**Returns:** `{ ok: true, version: number }`
+
+Drops all metadata for a pane. Emits `pane.metadata.changed` with the new (empty) metadata. Increments `version`.
+
+### `events.poll`
+
+**Method:** `events.poll`
+**Params:** `{ cursor?: number, types?: WmuxEventType[], workspaceId?: string, max?: number }`
+**Returns:** `{ events, nextCursor, priorCursor, bootId, droppedCount?, resync? }`
+
+- Cursor is **opaque**. Clients pass `nextCursor` back as-is on the next poll. Do not increment, sort, or compare across runs.
+- Default cursor is `0` — replay from the oldest event in the ring.
+- `priorCursor` echoes the cursor the caller passed in. Used for diagnostics.
+- `resync: true` indicates the caller's cursor drifted past the ring window OR the daemon restarted. Client must reconcile via `pane.list`.
+- `droppedCount` is set when known (drift past ring) and reports the number of events the caller missed.
+- `bootId` is present on every response. Mismatch ⇒ daemon restarted; drop all caches.
+- Event ordering: monotonic in **arrival order**, not in **causal order** (see [`inventory.md`](./inventory.md#event-types) for the cross-producer caveat).
+
+Stable event types:
+
+| Type | Wire shape (beyond `seq`/`ts`/`workspaceId`/`type`) |
+|---|---|
+| `pane.created` | `paneId`, `parentBranchId?` |
+| `pane.closed` | `paneId` |
+| `pane.focused` | `paneId`, `previousPaneId?` |
+| `pane.metadata.changed` | `paneId`, `metadata`, `version` (v3.0+) |
+| `workspace.metadata.changed` | `metadata`, `patch` |
+| `process.started` | `ptyId`, `pid?`, `shell` |
+| `process.exited` | `ptyId`, `exitCode`, `signal?` |
+
+Ring sizing (`RING_CAPACITY = 1024`, `POLL_DEFAULT_MAX = 256`) is an implementation detail. Both may grow in minors but cannot shrink within v3.x.
+
+---
+
+## Identity and trust
+
+### `mcp.claimWorkspace`
+
+**Method:** `mcp.claimWorkspace`
+**Params:** `{ workspaceId: string }`
+**Returns:** `{ ok: true }`
+
+Stable contract: after a successful claim, all subsequent metadata writes and event subscriptions from this MCP client are scoped to the claimed workspace. Writes targeting other workspaces are rejected with a permission error.
+
+Added in v2.7.2 to prevent active-pane hijacking by external MCPs. Stays unchanged in v3.0.
+
+### `system.identify`
+
+**Method:** `system.identify`
+**Params:** — none —
+**Returns:** `{ app: 'wmux', version: string, platform: NodeJS.Platform, electronVersion: string }`
+
+Identity probe. Stable shape; new fields may be added in minors.
+
+### `system.capabilities`
+
+**Method:** `system.capabilities`
+**Params:** — none —
+**Returns:** `{ methods: string[], features: { paneMetadata: ..., events: ..., stabilityTiers?: ... } }`
+
+`methods` is the full list of registered RPC method names. `features.events.bootId` and `features.events.maxRingSize` are stable.
+
+`features.paneMetadata` returns a sub-object in v3.0: `{ optimisticConcurrency: true, mergeModes: ['merge', 'replace', 'replaceShared'] }`. v2.x returns `true` (boolean). Clients should treat truthy and object shapes both as "metadata feature present" and feature-detect specific sub-features by key presence.
+
+`features.stabilityTiers` (v3.0+) reports the tier for each method/feature, mirroring this document programmatically. Clients can use it for capability-based degradation.
+
+---
+
+## Terminal I/O
+
+### `input.send`
+
+**Method:** `input.send`
+**Params:** `{ text: string, paneId?, workspaceId? }`
+**Returns:** `{ ok: true }`
+
+Sends literal text to a pane's PTY. Targeting falls back to the active pane in the active workspace.
+
+### `input.sendKey`
+
+**Method:** `input.sendKey`
+**Params:** `{ key: string, paneId?, workspaceId? }`
+**Returns:** `{ ok: true }`
+
+Sends a control-key sequence. Key names follow xterm conventions (`'Enter'`, `'Backspace'`, `'C-a'`, etc.).
+
+### `input.readScreen`
+
+**Method:** `input.readScreen`
+**Params:** `{ paneId?, workspaceId? }`
+**Returns:** `{ text: string }`
+
+Reads the current visible terminal buffer as plain text.
+
+### `terminal.readEvents`
+
+**Method:** `terminal.readEvents`
+**Params:** `{ paneId?, workspaceId?, sinceSeq? }`
+**Returns:** `{ events: PromptEvent[], nextSeq: number }`
+
+Reads structured terminal output events (prompt detection, agent status events). Wire-shape stable; the set of `PromptEvent` types is additive-only within v3.x.
+
+---
+
+## Workspace and surface
+
+| Method | Stable contract |
+|---|---|
+| `workspace.list` | Returns all workspaces with their metadata. Workspace ids are stable across daemon restarts. |
+| `workspace.new` | Creates a new workspace. Returns the new workspace id. |
+| `workspace.focus` | Switches the active workspace. Idempotent. |
+| `workspace.close` | Closes a workspace and cleans up its PTYs. |
+| `workspace.current` | Returns the active workspace id. |
+| `surface.list` | All wmux windows. |
+| `surface.new` | Opens a new wmux window. |
+| `surface.focus` | Focuses an existing window. |
+| `surface.close` | Closes a window. |
+| `pane.focus` | Focuses a leaf pane within the active workspace. |
+| `pane.split` | Splits the active pane. Returns the new pane id. |
+| `pane.search` | Cross-pane content search within a workspace. Scoped to the calling workspace. |
+
+---
+
+## Display vocabulary (shared display state)
+
+These shape the workspace/pane state that other tools (and the future wmux UI) read as "what's going on here?"
+
+| Method | Stable contract |
+|---|---|
+| `notify` | OS notification + in-app banner. |
+| `meta.setStatus` | Workspace-level shared status field. Last-writer-wins semantics; v3.0 documents the layered-status convention (see [`../PROTOCOL.md`](../PROTOCOL.md#layered-status)). |
+| `meta.setProgress` | Workspace-level shared progress field. Same semantics as `setStatus`. |
+| `meta.setSkills` | A2A agent self-description for `a2a.discover`. |
+
+---
+
+## Agent-to-Agent (A2A)
+
+Stable in v3.0. All A2A surfaces continue with the v2.7.3 execute-approval contract.
+
+| Method | Stable contract |
+|---|---|
+| `a2a.resolve.identity` | Returns the canonical identity for a workspace's agent. |
+| `a2a.whoami` | The calling MCP's claimed identity. |
+| `a2a.discover` | Lists other agents in the local wmux instance. |
+| `a2a.task.send` | Send a task with optional `requiresExecuteApproval`. |
+| `a2a.task.query` | Fetch the status of a task by id. |
+| `a2a.task.update` | Update task status. |
+| `a2a.task.cancel` | Cancel an in-flight task. |
+| `a2a.broadcast` | Send a typed broadcast to all discoverable agents. |
+
+---
+
+## Validation limits (v3.0 baseline values)
+
+These can grow in minor releases; they cannot shrink within v3.x.
+
+| Limit | v3.0 value | Notes |
+|---|---|---|
+| `PANE_METADATA_MAX_BYTES` | 8192 | Hard cap on serialized PaneMetadata size. |
+| `PANE_METADATA_LABEL_MAX` | 64 | Max chars in `label`. |
+| `PANE_METADATA_ROLE_MAX` | 32 | Max chars in `role`. |
+| `PANE_METADATA_STATUS_MAX` | 64 | Max chars in `status`. |
+| `PANE_METADATA_CUSTOM_KEY_MAX` | 64 | Max chars in a `custom` key. |
+| `PANE_METADATA_CUSTOM_MAX_ENTRIES` | 64 | Max entries in `custom`. |
+| `RING_CAPACITY` (events) | 1024 | Event bus ring buffer size. |
+| `POLL_DEFAULT_MAX` | 256 | Default per-poll event cap. |
+| `MAX_CONNECTIONS` (Named Pipe) | 50 | Concurrent client connections. |
+
+---
+
+## Error contract
+
+All `stable` JSON-RPC methods follow the JSON-RPC 2.0 error model with these additional reserved codes:
+
+| Code | Meaning | Used by |
+|---|---|---|
+| `-32001` | `VERSION_CONFLICT` — `expectedVersion` mismatch | `pane.setMetadata` |
+| `-32002` | `WORKSPACE_NOT_CLAIMED` — caller hasn't claimed the workspace they're trying to write to | `pane.setMetadata`, `meta.setStatus`, `meta.setProgress` |
+| `-32003` | `RESOURCE_EXHAUSTED` — session cap reached | session-creating methods (see v2.8.2 release notes) |
+
+Additional codes may be added in minors; clients should treat unknown error codes as recoverable-or-not-based on the JSON-RPC error message.
+
+---
+
+## What is NOT in the stable surface
+
+Listed here so clients know what to avoid binding to.
+
+- **All `experimental` surfaces from [`inventory.md`](./inventory.md):** browser/CDP, Company Mode, company A2A. These may move within v3.x and need feature-detection.
+- **All `internal` surfaces from [`inventory.md`](./inventory.md):** `daemon.*`. Use the pane/terminal/workspace surfaces instead.
+- **Renderer-internal IPC channels:** `pane:*`, `workspace:*` via the Electron preload bridge. Not reachable over the public JSON-RPC surface; external tooling must not rely on them.
+- **Implementation-internal IDs:** `paneId` and `ptyId` are stable only within a single daemon run (`bootId` window). Clients that persist these must reconcile via `pane.list` on `bootId` mismatch.
+- **Specific cursor numeric values:** treat as opaque. The fact that `nextCursor` is monotonic int64 today is an implementation detail.
+- **CLI flag set (beyond `wmux mcp`):** the full `wmux <command> --json --format` standardization lands in v3.1.
+
+---
+
+## Forward-compatibility contract for clients
+
+A v3.0-aware client that follows these patterns is guaranteed to work across all v3.x releases:
+
+1. **Use only the methods in this document.**
+2. **Ignore unknown fields in returned objects.** Don't assume the shape is exhaustive.
+3. **Feature-detect via `system.capabilities`** rather than parsing version strings.
+4. **Pass `nextCursor` back unchanged.** No arithmetic, no comparisons.
+5. **Compare `bootId` on every `events.poll` / `pane.list` response.** Mismatch ⇒ drop caches.
+6. **Reconcile on `resync: true`.** Call `pane.list` to rehydrate; resume polling at `asOfSeq`.
+7. **Handle unknown JSON-RPC error codes** as "this call didn't succeed; check the message; retry if the message suggests it."
+8. **For metadata writes, prefer `expectedVersion` when concurrency matters** and skip it when you're the only writer.
+
+These are the patterns the v3.0 [`../PROTOCOL.md`](../PROTOCOL.md) elaborates on.

--- a/docs/api/stability.md
+++ b/docs/api/stability.md
@@ -224,10 +224,10 @@ These can grow in minor releases; they cannot shrink within v3.x.
 |---|---|---|
 | `PANE_METADATA_MAX_BYTES` | 8192 | Hard cap on serialized PaneMetadata size. |
 | `PANE_METADATA_LABEL_MAX` | 64 | Max chars in `label`. |
-| `PANE_METADATA_ROLE_MAX` | 32 | Max chars in `role`. |
-| `PANE_METADATA_STATUS_MAX` | 64 | Max chars in `status`. |
+| `PANE_METADATA_ROLE_MAX` | 64 | Max chars in `role`. |
+| `PANE_METADATA_STATUS_MAX` | 128 | Max chars in `status`. |
 | `PANE_METADATA_CUSTOM_KEY_MAX` | 64 | Max chars in a `custom` key. |
-| `PANE_METADATA_CUSTOM_MAX_ENTRIES` | 64 | Max entries in `custom`. |
+| `PANE_METADATA_CUSTOM_MAX_ENTRIES` | 32 | Max entries in `custom`. |
 | `RING_CAPACITY` (events) | 1024 | Event bus ring buffer size. |
 | `POLL_DEFAULT_MAX` | 256 | Default per-poll event cap. |
 | `MAX_CONNECTIONS` (Named Pipe) | 50 | Concurrent client connections. |

--- a/docs/api/versioning.md
+++ b/docs/api/versioning.md
@@ -87,7 +87,7 @@ v3.0 is a major bump but **not a wire-break release**. Substrate 3.0 = "the subs
 - `pane.setMetadata` gains a `mergeMode: 'merge' | 'replace' | 'replaceShared'` parameter. The legacy `merge: boolean` parameter still works (`merge: true` ⇒ `mergeMode: 'merge'`; `merge: false` ⇒ `mergeMode: 'replace'`). Callers see no breaking change.
 - `pane.setMetadata` reply gains `version: number`. Callers that ignore extra fields see no change.
 - `pane.metadata.changed` event envelope gains `version: number`.
-- `pane.list` snapshot envelope gains per-pane `metadata.version: number`.
+- `pane.list` snapshot envelope gains a per-pane `version: number` field — a **sibling of `metadata`**, not nested inside it. See [`../PROTOCOL.md`](../PROTOCOL.md#3-snapshot-envelope-panelist) §3 for the full envelope shape.
 - `system.capabilities.features` gains a stability-tier map.
 - New `wmuxPermissions` field in MCP server manifests (no impact on plugins that don't set it).
 

--- a/docs/api/versioning.md
+++ b/docs/api/versioning.md
@@ -1,0 +1,216 @@
+# wmux Versioning Policy
+
+> **Status:** Phase 0 deliverable for Substrate 3.0. Replaces the implicit "ship semver and hope" policy that governed v0.x → v2.8.x.
+> **Audience:** external tooling authors (MCP plugins, dashboards, orchestrators) and the wmux release process.
+> **Companion docs:** [`inventory.md`](./inventory.md), [`stability.md`](./stability.md).
+
+---
+
+## TL;DR
+
+- **Semver, strictly.** Major bumps are the only place breaking changes ship. Within a major, every change is either additive or behavior-preserving.
+- **Three stability tiers**: `stable` / `experimental` / `internal`. The `stable` tier is the v3.0 substrate contract. The other two are documented but not warranty-covered.
+- **v2.x → v3.0 is a "substrate identity" release**, not a wire break. The auto-updater path (winget · Chocolatey · electron-updater) treats it as a normal upgrade.
+- **No 1.0 reset.** We considered renaming v2.8.x → v1.0 substrate but the auto-updater compares `1.0.0 < 2.9.0` as a downgrade. Marketing carries "Substrate 1.0" as a tagline alongside the v3.0 semver.
+
+---
+
+## The version triple
+
+wmux versions follow `MAJOR.MINOR.PATCH`, applied as in [semver 2.0](https://semver.org).
+
+| Bump | Trigger | External-tool impact |
+|---|---|---|
+| **PATCH** (`3.0.0 → 3.0.1`) | Bug fix in any tier. Documentation. Internal refactor. Performance work that doesn't change the wire shape. | None. Drop in. |
+| **MINOR** (`3.0.x → 3.1.0`) | New `stable` surface (new RPC method, new event type, new optional field). New `experimental` surface. Promotion `experimental → stable`. Deprecation announcement (still works, but a warning is emitted). | Additive. Existing code keeps working. Clients can opt in to new surfaces. |
+| **MAJOR** (`3.x → 4.0.0`) | Breaking change to any `stable` surface. Removal of a previously-stable surface (after one major's worth of deprecation). Renaming. | Coordinated migration. Release notes carry a migration guide. |
+
+`experimental` surfaces can break within a minor; release notes call them out.
+
+`internal` surfaces can change in any release.
+
+---
+
+## Stability tiers — semantics
+
+These are the tiers declared in [`inventory.md`](./inventory.md). They are the basis for the breaking-change policy above.
+
+### `stable`
+
+A method, event type, or field marked `stable`:
+
+- **Wire shape is frozen** for the current major. Names of parameters, names of returned fields, JSON-RPC error codes, event envelope keys — all fixed.
+- **Semantics are frozen** for the current major. The same input shape produces the same output shape and the same side effects.
+- **Additions are allowed.** New optional parameters, new fields in returned objects, new event types — these don't break clients that ignore them, so they ship in minors.
+- **Removal requires a major + one-major deprecation window.** A `stable` surface marked deprecated in v3.x continues to work; it may only be removed in v4.0+.
+
+A client that uses only `stable` surfaces, reads the `system.capabilities` tier map, and gracefully ignores fields it doesn't recognize is guaranteed forward-compatible within a major.
+
+### `experimental`
+
+- **May change wire shape or semantics within a major.** Release notes will call it out.
+- **Typically newer surfaces** that need real-world feedback before being promoted, OR older surfaces whose contract is still being reshaped (Company Mode falls in the latter bucket — Phase 4 gate decides its trajectory).
+- **MAY be promoted to `stable`** in any minor release.
+- **MAY be removed**, with a deprecation window of at least one minor release.
+
+### `internal`
+
+- **Not part of the external contract.** Documented here only so external tooling knows what *not* to depend on.
+- **May change in any release** — patch, minor, or major.
+- External callers reaching internal surfaces (e.g. raw `daemon.*` calls) accept that updates will likely break them. The substrate exposes equivalent functionality through `stable` surfaces.
+
+---
+
+## Deprecation process
+
+When a `stable` surface needs to go away:
+
+1. **Minor release N**: surface is marked deprecated. It still works identically. A console warning is emitted on every call. Release notes name a replacement.
+2. **Minor release N+k** (at least one minor later): surface still works, warning still emitted. Migration guide updated with any patterns the community has reported.
+3. **Major release M**: surface may be removed. Replacement is the only path forward.
+
+Removal is not automatic at the next major. A deprecated surface can sit deprecated for multiple majors if its cost is low.
+
+`experimental` surfaces follow the same shape but with a shorter window — usually deprecation in minor N, removal in minor N+1.
+
+---
+
+## How v2.x → v3.0 works (the "Substrate 3.0" release)
+
+v3.0 is a major bump but **not a wire-break release**. Substrate 3.0 = "the substrate identity becomes the headline" + a small set of additive wire changes that close gaps surfaced by external tooling builders (issue #15, RFC discussion).
+
+### What changes in v3.0 vs. v2.8.x
+
+**Wire-shape additions (all backwards-compatible):**
+
+- `pane.setMetadata` gains an optional `expectedVersion` parameter for optimistic concurrency. Callers that omit it opt out of version checks (same behavior as today).
+- `pane.setMetadata` gains a `mergeMode: 'merge' | 'replace' | 'replaceShared'` parameter. The legacy `merge: boolean` parameter still works (`merge: true` ⇒ `mergeMode: 'merge'`; `merge: false` ⇒ `mergeMode: 'replace'`). Callers see no breaking change.
+- `pane.setMetadata` reply gains `version: number`. Callers that ignore extra fields see no change.
+- `pane.metadata.changed` event envelope gains `version: number`.
+- `pane.list` snapshot envelope gains per-pane `metadata.version: number`.
+- `system.capabilities.features` gains a stability-tier map.
+- New `wmuxPermissions` field in MCP server manifests (no impact on plugins that don't set it).
+
+**Internal authority migration (no external impact):**
+
+- The `MetadataStore` becomes the main-process authority for pane metadata. Today, the renderer's `paneSlice` is authoritative and the main process forwards writes to it via IPC. After v3.0, main writes directly to the `MetadataStore` and the renderer mirrors. External callers see the same JSON-RPC contract; the change is invisible to them. See [`../internal/paneSlice-callsite-inventory.md`](../internal/paneSlice-callsite-inventory.md) for the migration shape.
+
+**Substrate identity:**
+
+- README + announcement positioning shifts from "AI agent terminal" to "LSP-for-terminals — a neutral substrate that lets external tools build workflow intelligence on top of any terminal session." The product capabilities are a superset of v2.8.x; the framing is what's new.
+
+### Why call it v3.0 instead of v1.0 (or v2.9)?
+
+Three options were considered.
+
+**Option A: v2.9.0** (minor bump). Rejected. The substrate identity shift is large enough to warrant external coordination — release notes, announcement, plugin convention. Calling it a minor undersells the contract investment.
+
+**Option B: v1.0** (reset to mark "substrate 1.0"). Rejected. winget, Chocolatey, and electron-updater all compare `1.0.0 < 2.9.0` and treat the install as a downgrade. The auto-updater pipeline would either refuse to update or require a manual reinstall by every existing user.
+
+**Option C: v3.0 + "Substrate 1.0" tagline** (chosen). Semver continuity preserved. Auto-updater works unchanged across winget · Chocolatey · electron-updater. Marketing/announcement carries "Substrate 1.0 — substrate-era v3.0" as the headline, similar to how Bun shipped "Bun 1.0" while remaining `1.0.0` in semver.
+
+### v2.x → v3.0 compatibility guarantees
+
+- All `stable` RPC methods and event types continue to work with their v2.x wire shape.
+- The legacy `merge: boolean` parameter on `pane.setMetadata` is preserved as a shortcut for the new `mergeMode` field.
+- `session.json` files written by v2.x load cleanly in v3.0 (missing `version` fields normalize to 0; first subsequent write becomes 1).
+- The Named Pipe token contract is unchanged; v2.x clients connect to v3.0 daemons without coordination.
+- The MCP server registration contract is unchanged for plugins that don't declare `wmuxPermissions` (treated as "no permissions requested" with the existing implicit-trust behavior).
+
+### What v2.x clients lose by not updating
+
+- No `expectedVersion` optimistic concurrency. Two MCPs writing to the same `status` field still last-writes-wins for v2.x clients.
+- No `mergeMode: 'replaceShared'`. v2.x callers can't intentionally rewrite the shared-display fields without overwriting `custom`.
+- No bootId/droppedCount-driven snapshot reconciliation. v2.x clients that drift past the ring window silently miss events.
+
+These are improvements, not corrections — v2.x clients have a workable contract. The v3.0 surface gives them strictly more, without taking anything away.
+
+---
+
+## Auto-updater compatibility matrix
+
+| Channel | Comparison rule | v2.8.x → v3.0.0 result |
+|---|---|---|
+| winget | `Microsoft.WinGet.SemanticVersion` (semver 2.0 strict) | `2.8.4 < 3.0.0` ⇒ normal upgrade path. |
+| Chocolatey | `[NuGet.Versioning.SemanticVersion]` (semver 2.0) | `2.8.4 < 3.0.0` ⇒ normal upgrade path. |
+| electron-updater (in-app) | `semver` npm package | `2.8.4 < 3.0.0` ⇒ normal upgrade path. |
+| GitHub Releases tag sort | string + integer-aware | `v2.8.4 < v3.0.0` ⇒ correct ordering in release listings. |
+
+The v3.0 release blocker (per Codex 1st review) was "do all three auto-update channels treat v3 as an upgrade from v2?" — verified above; release proceeds.
+
+A v1.0-reset path would have failed all three.
+
+---
+
+## Patch release stream (v2.9.x)
+
+Per the Substrate 3.0 plan, a small set of stability fixes (the TODOs.md group flagged in v2.8.x — daemon reconnect on tray restore, pane split max-depth guard, `destroyCompanyWithCleanup` race, member workspace PTY leak, DESIGN.md scaffold) ship on a separate v2.9.x patch stream rather than blocking v3.0.
+
+- v2.9.0 ships the M0 transaction-aware MetadataStore (the bulk of Phase 1 — the actual breaking-free of authority from renderer to main).
+- v2.9.1+ patches absorb the TODOs.md stability backlog. Independent of v3.0 schedule.
+
+v2.9.x is the active patch line until v3.0 ships; users on v2.9.x receive patches automatically through the same auto-update channels.
+
+---
+
+## Version-aware client patterns
+
+Recommended patterns for clients that need to support multiple wmux versions:
+
+### Feature detection over version comparison
+
+Prefer:
+
+```typescript
+const caps = await rpc.call('system.capabilities', {});
+if (caps.features.paneMetadata?.optimisticConcurrency) {
+  // Use expectedVersion.
+} else {
+  // Fall back to no version checks.
+}
+```
+
+Over:
+
+```typescript
+const identity = await rpc.call('system.identify', {});
+if (semver.gte(identity.version, '3.0.0')) { /* … */ }
+```
+
+Feature flags are stable across the entire minor line; version strings can move underneath you for reasons unrelated to the feature you care about.
+
+### bootId comparison on every poll
+
+```typescript
+const result = await rpc.call('events.poll', { cursor: lastCursor });
+if (result.bootId !== knownBootId) {
+  // Daemon restarted under us — drop ALL cached state.
+  cachedPaneIds.clear();
+  cachedPtyIds.clear();
+  lastCursor = 0;
+  knownBootId = result.bootId;
+  // Re-hydrate via pane.list snapshot.
+}
+```
+
+`bootId` is the v3.0-stable signal for cache invalidation. It works for v2.7.x+ as well (added with the EventBus).
+
+### Cursor passed through, not interpreted
+
+```typescript
+const result = await rpc.call('events.poll', { cursor: lastCursor });
+lastCursor = result.nextCursor;     // ← pass through
+// Don't compute lastCursor + 1, don't sort, don't assume monotonicity.
+```
+
+Even though `nextCursor` is monotonic today, the protocol treats it as opaque to leave room for future cursor evolutions (sharded rings, segmented cursors).
+
+---
+
+## Release cadence (informational, not a contract)
+
+- Patch: as needed for fixes. Typical cadence is 1–2 per month while a minor is active.
+- Minor: when a coherent feature set is ready. No fixed cadence.
+- Major: rare. The expectation is one major every 12–18 months.
+
+This is the operational target, not a guarantee. The contract is the tier-based breaking-change policy above.

--- a/docs/internal/m0-design.md
+++ b/docs/internal/m0-design.md
@@ -1,0 +1,441 @@
+# M0 — Transaction-aware MetadataStore Design
+
+> **Status:** Phase 1 design doc, pre-implementation. Reviewed against `paneSlice-callsite-inventory.md`, `docs/PROTOCOL.md` §1, and the 2nd Codex eng-review findings.
+> **Scope:** the integrated metadata authority migration. M0.A + M0.B + M0.C + M0.D + M0.E + M0.F — all six sub-items ship together, because splitting them lets M5 (persistence) undo M0 (transaction) assumptions.
+> **Out of scope:** the broader pane-tree authority migration (branches, sizes, active-pane). M0 lifts metadata only and explicitly keeps tree authority in `paneSlice`.
+> **Target release:** v2.9.0. Six weeks (Plan Week 3–8).
+
+---
+
+## 0. Why M0 is one unit, not six
+
+The 2nd Codex review surfaced this. The naive split into M0 (authority migration), M1 (`expectedVersion`), M2 (`mergeMode`), and M5 (persistence) looks reasonable on a roadmap but breaks at the transaction boundary.
+
+- **`mergeMode` + `version` are one decision.** The version is incremented based on the post-merge shape. Computing the merge in the renderer and the version in main (M0+M2 split) introduces a window where the two can diverge.
+- **`expectedVersion` + persistence are one decision.** A successful concurrency check must persist before it's visible to other clients (otherwise a crash between check-pass and persist makes the "winning" write disappear). M0+M5 split makes this impossible to enforce cleanly.
+- **Snapshot reconciliation depends on a single source of truth.** `pane.list` returning a consistent `{ asOfSeq, bootId, metadata-per-pane }` snapshot requires that `metadata` and `seq` come from the same store at the same instant. With paneSlice as the metadata authority and EventBus in main, you can't take an atomic snapshot.
+
+Conclusion: M0 is the *whole* transaction-aware MetadataStore. The wire-format additions (`expectedVersion`, `mergeMode`, `version` echo, snapshot envelope) ride on top of the same single PR.
+
+---
+
+## 1. Inputs
+
+| Source | What it constrains |
+|---|---|
+| `docs/internal/paneSlice-callsite-inventory.md` | The mirror has a narrow blast radius. No React component reads `PaneMetadata.{label,role,status,custom}` today. Stale-tick window has no user-visible effect at v3.0 ship. |
+| `docs/PROTOCOL.md` §1 | Wire contract: layered status, mergeMode three values, version monotonic, `VERSION_CONFLICT` JSON-RPC `-32001`. Backwards compat: legacy `merge: boolean` preserved. |
+| `docs/PROTOCOL.md` §2 | Event bus contract: cursor opaque, `bootId` invalidation, `droppedCount`+`resync` semantics, cross-producer ordering caveat. |
+| `docs/PROTOCOL.md` §3 | `pane.list` snapshot envelope: `{ asOfSeq, bootId, panes[*].{metadata, version} }`. |
+| Codex 2nd review (NOT CLEARED → user-delegated full acceptance) | All 6 race specs must be in the design doc + 8 verification gates + 4-week → 6-week Phase 1 budget. |
+
+---
+
+## 2. `MetadataStore` API
+
+Lives in `src/main/metadata/MetadataStore.ts`. Module-level singleton, main process only.
+
+```typescript
+import type { PaneMetadata } from '../../shared/types';
+
+export type MergeMode = 'merge' | 'replace' | 'replaceShared';
+
+export interface SetOptions {
+  mergeMode?: MergeMode;        // default: 'merge'
+  expectedVersion?: number;     // omitted ⇒ no concurrency check
+}
+
+export type SetResult =
+  | { ok: true; version: number; metadata: PaneMetadata }
+  | { ok: false; error: 'VERSION_CONFLICT'; currentVersion: number };
+
+export interface MetadataEntry {
+  metadata: PaneMetadata;
+  version: number;              // 0 = never set; first set ⇒ 1
+}
+
+export interface Snapshot {
+  asOfSeq: number;              // EventBus.latestSeq() at snapshot moment
+  bootId: string;               // EventBus.bootId
+  entries: Array<{ paneId: string; metadata: PaneMetadata; version: number }>;
+}
+
+export interface PersistedShape {
+  schema_version: 1;            // bump for future migrations
+  entries: Array<{
+    paneId: string;
+    workspaceId: string;
+    metadata: PaneMetadata;
+    version: number;
+  }>;
+}
+
+export class MetadataStore {
+  // === CRUD ===
+  get(paneId: string): MetadataEntry;
+    // Always returns. Empty pane ⇒ { metadata: {}, version: 0 }.
+
+  set(
+    paneId: string,
+    patch: Partial<PaneMetadata>,
+    opts?: SetOptions,
+  ): SetResult;
+    // Synchronous critical section:
+    //   1. Validate patch (size, char limits) → reject if invalid (throws, no version bump).
+    //   2. Concurrency check: if expectedVersion provided && current.version !== expectedVersion
+    //      → return { ok: false, error: 'VERSION_CONFLICT', currentVersion }. No mutation.
+    //   3. Compute merged shape per mergeMode.
+    //   4. Increment version on the merged shape.
+    //   5. Stage the new entry (not yet persisted, not yet published).
+    //   6. Persist via SessionManager (atomic write).
+    //   7. Commit the staged entry in-memory.
+    //   8. Publish `pane.metadata.changed` event via EventBus.
+    //   9. Return { ok: true, version, metadata }.
+    //
+    // If step 6 fails, the entry is NOT committed, NOT published. Caller sees a throw.
+
+  clear(paneId: string): SetResult;
+    // Same flow as set(paneId, {}, { mergeMode: 'replace' }) but the metadata
+    // field on the resulting event is `{}` (empty), and version still increments.
+
+  // === Snapshot ===
+  snapshot(): Snapshot;
+    // Synchronous. Reads the current in-memory store. asOfSeq = EventBus.latestSeq()
+    // at the same instant — captured atomically before any subsequent set() can
+    // increment seq. (Single-threaded JS = serialization guarantee.)
+
+  // === Persistence ===
+  hydrate(serialized: PersistedShape): void;
+    // Called on app boot after SessionManager loads session.json.
+    // Drops any in-memory entries; rebuilds from serialized.
+    // schema_version mismatch ⇒ migrate() before rebuild.
+
+  serialize(): PersistedShape;
+    // Called on session dump. Returns the full store.
+
+  migrate(input: PersistedShape, toVersion: 1): PersistedShape;
+    // Phase 1 ships at schema_version 1. Migration table grows in v3.1+.
+
+  // === Lifecycle ===
+  onPaneDeleted(paneId: string): void;
+    // Removes the entry, emits a `pane.metadata.changed` event with
+    // `{ metadata: {}, version: <bumped> }` so subscribers can drop their
+    // mirror entry. (Bumping version on delete prevents pane-id-recycle
+    // confusion — see Race #4.)
+}
+
+export const metadataStore: MetadataStore;  // module-level singleton
+```
+
+**Invariants:**
+
+- `version` is monotonic per pane. Never decreases. Never skips.
+- `version = 0` ⇒ no metadata ever set on this pane.
+- After `set()` returns `{ ok: true, version: V }`, subsequent `get(paneId).version === V` is guaranteed (synchronous).
+- After `set()` returns `{ ok: true }`, the event was already published. Subscribers may receive it before, during, or after `set()` returns to the caller, but never *more than one* tick later.
+- `snapshot().asOfSeq` is the EventBus seq at the moment the snapshot's in-memory read happened. Any event with `seq > asOfSeq` was emitted after the snapshot was taken; clients reconciling via the snapshot drain events with `seq > asOfSeq` to catch up.
+
+---
+
+## 3. Mutation flow: persist-then-publish
+
+```
+Caller                  MetadataStore           SessionManager      EventBus
+  |                         |                         |                |
+  |--- set(paneId, patch) ->|                         |                |
+  |                         |--- validate, concurrency-check          |
+  |                         |--- compute merged shape                  |
+  |                         |--- compute new version                   |
+  |                         |--- persist(serialized) ----------------->|
+  |                         |<------------ atomic write ok ------------|
+  |                         |--- commit in-memory                     |
+  |                         |--- emit(pane.metadata.changed) -------------------->|
+  |<-- { ok, version, ... } |                                                       |
+```
+
+**Why persist before publish?**
+
+If we publish first, a subscriber can act on the event before the write is durable. A crash in between (after publish, before persist completes) means the subscriber acted on data that doesn't survive restart — silent state divergence.
+
+Persist-then-publish guarantees that anyone who sees the event sees it because the write is durable. A crash after persist but before publish loses the event (no client sees it), but the data is on disk and the next `pane.list` snapshot reflects it; clients reconcile via the standard `bootId`/`resync` path.
+
+**Why is this synchronous?**
+
+Single-threaded JS gives us natural serialization across `set()` calls. Two concurrent `set()`s for the same pane queue at the JS event loop boundary — there's no preemption. The synchronous flow above is the entire critical section; no `await`s inside steps 1–8.
+
+`SessionManager.persist()` does involve a disk write, but it's done with the synchronous `secureWriteTokenFile`-style atomic rename pattern (the same pattern used for the pipe token). Disk I/O happens, but inside the same JS task. No other `set()` can interleave.
+
+If `persist()` becomes async in the future (e.g. moves to a worker thread for performance), the flow gains a microtask boundary at step 6 → 7. The design must then add a per-pane lock to prevent two `set()`s from racing across that boundary. This is the only place where the "single-threaded JS = automatic serialization" assumption is load-bearing.
+
+---
+
+## 4. Race specifications
+
+All six races identified by the 2nd Codex review. Each has a design answer here and a corresponding test in §6.
+
+### Race #1: publish-vs-persist ordering
+
+**Scenario:** crash between commit-in-memory and persist completion.
+
+**Resolution:** persist before commit (step 6 in §3 happens before step 7). If persist throws, the in-memory commit doesn't happen, the event doesn't fire, and the caller sees a throw. From the caller's perspective the write didn't happen. From any subscriber's perspective the event never fired. From disk's perspective the previous value is intact.
+
+If crash happens *between* persist completing and the in-memory commit (extremely narrow window, single-process synchronous code), restart hydrates from the persisted value — which is the *new* value. Subscribers don't see an event for it but the next `bootId`-mismatch recovery sweeps it in.
+
+Trade-off: the narrow crash window can lose an event without losing data. Acceptable; clients have the `bootId` recovery primitive for exactly this.
+
+### Race #2: setMetadata return value vs event delivery
+
+**Scenario:** the caller of `set()` is also subscribed to `pane.metadata.changed` events. Could the event arrive before `set()` returns, or after, or both?
+
+**Resolution:** `set()` return value carries the same `version` as the event. Order doesn't matter — both are idempotent given the version. Subscribers that maintain a `lastSeenVersion` per pane discard events with `version <= lastSeen`.
+
+Both the return value and the event are emitted from the same synchronous critical section, so they have the same total ordering across all observers. The only ambiguity is which arrives at a *given* observer first; the contract is "both refer to the same write, both are idempotent."
+
+### Race #3: renderer initial hydration race with events
+
+**Scenario:** the renderer mounts and subscribes to `pane.metadata.changed`. Between subscription and the first `pane.list` snapshot fetch, events fire. The renderer might miss them, or double-apply them (apply once via event, again via snapshot).
+
+**Resolution:** the renderer's mount sequence is:
+
+1. Subscribe to `events.poll` with `cursor: 0` (queue events as they arrive; don't apply yet).
+2. Call `pane.list` → receive `{ asOfSeq, bootId, panes }`. Apply the snapshot to paneSlice (mirror).
+3. Apply queued events with `seq > asOfSeq` only. Discard events with `seq <= asOfSeq` (already in snapshot).
+4. Resume normal poll loop from `cursor: asOfSeq`.
+
+This is the standard snapshot+catchup pattern. The `asOfSeq` watermark is the join point.
+
+### Race #4: pane delete/recreate with same/recycled ID
+
+**Scenario:** pane `p-7` is closed (metadata cleared), then a new pane is created and happens to get id `p-7`. A subscriber that was tracking `p-7`'s metadata might confuse the two.
+
+**Resolution:** `MetadataStore.onPaneDeleted(paneId)` increments the version on the deleted entry's slot to `version+1` before clearing it, and emits a `pane.metadata.changed` event with empty metadata + the bumped version. The bumped version makes "delete" visible to subscribers as a normal version transition.
+
+When a new pane is created with a recycled id, its first metadata write starts at the deleted entry's last-known version + 1 (the store keeps the version counter across the delete; only the metadata clears). Subscribers tracking by version see strict monotonicity and don't get fooled.
+
+In practice, wmux's `paneId` generator (`generateId('pane')`) uses randomized UUIDs, so recycling is exceedingly unlikely. But the version contract handles it correctly regardless.
+
+### Race #5: concurrent writes from MCP / pipe RPC / renderer-UI bridge
+
+**Scenario:** three sources of write — external MCP via `pane.setMetadata`, internal pipe RPC, renderer-initiated UI action (future). All target the same pane.
+
+**Resolution:** all three paths enter `MetadataStore.set()` at the main-process entry point. Single-threaded JS serializes them at the JS task boundary. There's no preemption, so no two `set()` calls overlap.
+
+`expectedVersion` is the coordination primitive for callers that care about ordering. Without it, last-writer-wins applies, which is the v2.x behavior preserved.
+
+### Race #6: feedback loop (mirror update triggers a write)
+
+**Scenario:** paneSlice receives a `pane.metadata.changed` event, updates its mirror, and a subscriber to paneSlice (e.g. a React component) triggers a write back to main. This write produces another event, which updates the mirror again, which triggers another write…
+
+**Resolution:** compile-time protection. paneSlice's exported interface does NOT include `setPaneMetadata` or `clearPaneMetadata` after M0.C. The only API on paneSlice's shape is a mirror-update internal method, not exported on the slice's TypeScript type.
+
+React components or other renderer code wanting to write metadata must go through the RPC bridge (`useRpcBridge`), which calls `pane.setMetadata` over the pipe → main process → `MetadataStore`. The renderer never writes paneSlice's metadata directly.
+
+This is enforced at compile time via the TypeScript interface, not at runtime. A bug that adds a back door (e.g. exporting the setter) is caught by the type checker before tests run.
+
+---
+
+## 5. Wire-format additions (v3.0)
+
+All additive, all backwards-compatible. Documented in `docs/PROTOCOL.md` §1; this section enumerates them for implementation.
+
+### `pane.setMetadata` params (v3.0)
+
+```jsonc
+{
+  "paneId": "p-1",                    // existing
+  "workspaceId": "ws-1",              // existing
+  "label": "Backend",                 // existing (any of label/role/status/custom optional)
+  "role": "service",
+  "status": "running",
+  "custom": { "orchestrator.taskId": "T-42" },
+
+  "mergeMode": "merge",               // NEW: 'merge' | 'replace' | 'replaceShared'
+                                      //      omitted ⇒ defaults to 'merge'
+  "merge": true,                      // legacy: equivalent to mergeMode (rejected if both present)
+  "expectedVersion": 7                // NEW: opt-in optimistic concurrency
+}
+```
+
+### `pane.setMetadata` reply (v3.0)
+
+```jsonc
+// Success
+{ "ok": true, "paneId": "p-1", "version": 8, "metadata": { /* full merged shape */ } }
+
+// Version conflict (JSON-RPC error)
+// id: <req-id>
+// error: { code: -32001, message: "VERSION_CONFLICT", data: { currentVersion: 11 } }
+```
+
+### `pane.metadata.changed` event (v3.0)
+
+```jsonc
+{
+  "seq": 412,
+  "ts": 1715500000000,
+  "type": "pane.metadata.changed",
+  "workspaceId": "ws-1",
+  "paneId": "p-1",
+  "metadata": { /* PaneMetadata */ },
+  "version": 8                       // NEW
+}
+```
+
+### `pane.list` per-pane entry (v3.0)
+
+```jsonc
+{
+  "id": "p-1",
+  "type": "leaf",
+  "surfaces": [ /* ... */ ],
+  "activeSurfaceId": "s-1",
+  "metadata": { /* PaneMetadata */ },
+  "version": 8                       // NEW: per-pane metadata version
+}
+```
+
+### `system.capabilities` feature flag (v3.0)
+
+```jsonc
+{
+  "methods": [/* ... */],
+  "features": {
+    "paneMetadata": {                // CHANGED: was `true`, now object
+      "optimisticConcurrency": true,
+      "mergeModes": ["merge", "replace", "replaceShared"]
+    },
+    "events": { /* unchanged */ }
+  }
+}
+```
+
+Old clients that read `features.paneMetadata` as a boolean see truthy (`{ ... }` is truthy). New clients feature-detect by key presence.
+
+---
+
+## 6. Test budget — 38 new tests
+
+Aligned with the plan's per-module breakdown.
+
+### M0.A — MetadataStore CRUD + version (5)
+
+- `get` on empty pane returns `{ metadata: {}, version: 0 }`.
+- `set` first time bumps version 0 → 1.
+- `clear` bumps version + emits event with empty metadata.
+- `snapshot` returns all entries with their current `{ metadata, version }`.
+- `onPaneDeleted` bumps version, emits empty-metadata event, then removes entry on next `get`.
+
+### M0.A — mergeMode + version transaction (4)
+
+- `mergeMode: 'merge'` patches top-level + deep-merges `custom` one level.
+- `mergeMode: 'replace'` overwrites the entire metadata, including `custom`.
+- `mergeMode: 'replaceShared'` replaces top-level shared fields but preserves `custom`.
+- After any mergeMode, version is bumped on the **post-merge** shape (not patch input).
+
+### M0.A — optimistic concurrency (5)
+
+- `set` without `expectedVersion`: always commits, returns new version.
+- `set` with matching `expectedVersion`: commits, returns new version.
+- `set` with mismatched `expectedVersion`: returns `VERSION_CONFLICT` + `currentVersion`. No mutation. No event.
+- `set` with `expectedVersion: 0` on empty pane: commits as first write.
+- `set` reply always echoes `version`; subsequent `get` returns the same.
+
+### M0.B — persist-then-publish ordering (1)
+
+- `SessionManager.persist` throws → in-memory state unchanged, no event published, caller sees throw.
+
+### M0.B — return vs event idempotence (1)
+
+- Subscriber receives event with same version as the `set` reply; applying both yields identical state.
+
+### M0.C — paneSlice direct write protection (1)
+
+- TypeScript type-check fails when consuming code tries to call `paneSlice.setPaneMetadata` (compile-time guard, verified via `tsc --noEmit` test harness).
+
+### M0.D — snapshot reconciliation (2)
+
+- Ring overflow burst → `droppedCount > 0` → client calls `pane.list` → state matches store.
+- `bootId` mismatch → client forced full rehydrate → cached pane ids cleared first.
+
+### M0.E — 6 race specs (6)
+
+One test per race in §4. Each test reproduces the scenario and verifies the design's resolution.
+
+### M0.F — persistence (4)
+
+- Session.json with no `version` field on entries loads cleanly (normalized to 0).
+- Session.json with no `schema_version` envelope is treated as schema v1.
+- `migrate(input, 1)` is a smoke pass-through; throws on unknown schema.
+- Crash window: persist-completed entries hydrate after restart; pre-persist entries don't.
+
+### Critical regression — backwards compat (1)
+
+- v2.8.x client sending `merge: false` (boolean) gets `mergeMode: 'replace'` semantics — full overwrite.
+
+### Codex 2nd review — 8 additional verification gates (8)
+
+- Ring overflow burst → automatic resync via `pane.list`.
+- Renderer late mount → applies snapshot then events with `seq > asOfSeq`; no double-apply.
+- Session restore + immediate write → version starts at restored value, not 0.
+- v2.8 session.json + v2.8 `merge: false` client → still works after upgrade.
+- Direct preload write attempt → compile error (caught by §6 §M0.C test).
+- Burst write event ordering → events arrive in version-monotonic order per pane.
+- Persistence crash window → after restart, store reflects last successful persist.
+- `pane.list` snapshot ≡ `MetadataStore` state (no stale renderer mirror leakage).
+
+### Pipe token security (2 — eng-review A2)
+
+- `secureWriteTokenFile` ACL: file is owner-readable, group/others denied.
+- Other-user read attempt: rejected at OS level.
+
+---
+
+## 7. PR sequence
+
+The M0 PR is large but coherent. Recommended split for review hygiene:
+
+| PR | Scope | LOC estimate | Risk |
+|---|---|---|---|
+| **M0-a** | `MetadataStore.ts` neuk + unit tests + `PersistedShape` type. No call sites changed yet. | ~600 LOC + 22 tests | Low. Isolated module. |
+| **M0-b** | Rewrite `pane.rpc.ts` handlers to call `MetadataStore` directly. `sendToRenderer` removed for the 3 metadata methods. paneSlice still writes (parallel path); the rewrite emits events from main. | ~150 LOC | Medium. Race window during parallel path — gated by feature flag. |
+| **M0-c** | Snapshot reconciliation in `pane.list`. `MetadataStore.snapshot()` integration. | ~80 LOC + 2 tests | Low. |
+| **M0-d** | paneSlice mirror-only conversion. Remove `setPaneMetadata` / `clearPaneMetadata` from `PaneSlice` interface. Event-driven mirror update. | ~120 LOC + 1 test | High. Type-check break propagates. |
+| **M0-e** | `SessionManager` migration to `MetadataStore.serialize()` / `hydrate()`. v2.x compat tests. | ~100 LOC + 4 tests | Medium. Session-restore regression risk. |
+| **M0-f** | Wire-format additions: `mergeMode` param, `expectedVersion` param, `version` in reply + events + `pane.list`. `system.capabilities` feature object. | ~80 LOC + 9 tests | Low. Pure additive. |
+
+Each PR independently lands without breaking master. M0-d is the highest-risk because it changes the renderer write path; landing it after M0-b means main is already authoritative when the renderer loses its write privileges.
+
+Estimate: 6 PRs over 4–5 weeks, leaving 1–2 weeks of buffer for unforeseen rework.
+
+Or one giant PR. Either is defensible — review fatigue vs. risk concentration trade-off. Lean toward the split for the first major substrate migration.
+
+---
+
+## 8. Open questions
+
+These don't block design; they affect implementation tactics.
+
+1. **`SessionManager` autosave timing.** Today autosave runs on a timer + on quit. M0's persist-then-publish ordering assumes synchronous persist inside the `set()` critical section. Does `SessionManager.persist()` already support synchronous write, or does it need a refactor to expose a sync path?
+
+2. **`pane.list` tree composition.** The renderer currently composes `pane.list` because the pane tree (branches, sizes, active-pane) lives in `paneSlice`. After M0, metadata comes from `MetadataStore`; tree still comes from paneSlice. The `pane.list` handler in main has to join the two. Cleanest path: main calls renderer to get the tree shape, then injects `MetadataStore.snapshot()` data into each leaf node before returning. Alternative: also lift tree authority to main — out of scope for M0.
+
+3. **Two-store consistency between `MetadataStore` and `SessionManager`.** If a pane is deleted in `paneSlice` (renderer-initiated), main needs to be told to call `MetadataStore.onPaneDeleted()`. Today there's no such IPC channel. M0-e adds a `pane.deleted` IPC event for this. Question: should it be a JSON-RPC method (call from renderer to main) or an Electron IPC event (one-way)?
+
+4. **Migration ordering.** Existing session.json dumps have metadata embedded in the pane tree (under `PaneLeaf.metadata`). After M0, metadata lives separately in `MetadataStore.serialize()`. The first boot after upgrade needs to read v2.x dumps, extract metadata into `MetadataStore`, and write back the v3.0 dump shape (tree without inline metadata + separate metadata table). Smooth path: `MetadataStore.hydrate()` accepts both shapes (v2.x inline + v3.0 separate) and SessionManager writes only the v3.0 shape going forward.
+
+5. **`MetadataStore.snapshot()` performance under high write load.** Test: 1000 writes/sec for 60 seconds, then a `snapshot()` mid-burst — does it block the main process noticeably? If yes, the snapshot needs to be copy-on-write or use a different read pattern. Profile in M0-c.
+
+---
+
+## 9. Definition of done for M0
+
+- All 38 tests pass.
+- TypeScript type-check passes with paneSlice's metadata setters removed from the exported interface.
+- Manual dynamic test: 1000 writes/sec for 60 seconds → renderer mirror eventually consistent → `pane.list` snapshot matches store.
+- v2.x session.json loads and runs without prompting migration UI.
+- v2.x MCP client using `merge: false` continues to work.
+- New v3.0 client using `expectedVersion` + `mergeMode` works end-to-end.
+- `docs/PROTOCOL.md` §1 updated with any wire-shape refinements discovered during implementation.
+- v2.9.0 ship + 1-week regression window with 0 user-reported regressions.
+
+After M0 lands, Phase 1 is complete. Phase 2 (MCP plugin convention) starts in parallel with v2.9.x patch stream (TODOs.md backlog).

--- a/docs/internal/paneSlice-callsite-inventory.md
+++ b/docs/internal/paneSlice-callsite-inventory.md
@@ -1,0 +1,114 @@
+# paneSlice Metadata Callsite Inventory (Phase 0.9)
+
+> **Status:** internal pre-work for Phase 1 M0 (transaction-aware MetadataStore).
+> **Scope:** every read/write path that touches `PaneLeaf.metadata` (i.e. `PaneMetadata`).
+> **Excludes:** `WorkspaceMetadata`, `Company` metadata, `A2A task.metadata`, `Message` metadata — those are separate stores and the M0 migration does not touch them.
+> **Baseline:** v2.8.4 (`main` @ c2fd6c6) on branch `feature/substrate-phase-0`.
+
+Codex 2nd review identified labels / roles / status badges / restore state / pane.list rendering / company/workspace UI as risk surfaces for the M0 paneSlice → mirror migration. This document walks each one and grades the actual coupling level so M0 can size the mirror contract accurately.
+
+---
+
+## TL;DR
+
+**PaneMetadata is structurally a write-mostly, read-by-externals surface.**
+
+- The only **writer in main process** path today is `pane.setMetadata` / `pane.clearMetadata` → renderer hop → `paneSlice` (the bug M0 must fix).
+- The only **internal reader** of `paneSlice` metadata fields is `pane.search` (label-substring match, `useRpcBridge.ts:466`) and `pane.list` response shaping (`useRpcBridge.ts:354`, both wire it back outward).
+- No React component renders `leaf.metadata.{label,role,status,custom}` for the user — `label`/`role`/`status` are display-vocabulary contract for external tools and the future wmux UI, but no current view subscribes to them.
+- Persistence is on the dump path of `SessionManager` (separate slice — out of scope for this inventory beyond noting that M0.F replaces the entry point).
+
+→ **The M0 paneSlice-to-mirror conversion has a very narrow blast radius.** The "labels / roles / status badges / restore state" callsite class flagged by codex is real **as a future contract**, but **not yet wired into the renderer view layer**. M0 can flip the authority to the main process without breaking any user-visible read; the only contracts at risk are wire-shape contracts (pane.list response, pane.search result, events.poll metadata changed event), all of which are owned by the substrate surface and tested at that level.
+
+---
+
+## Write callsites (must be re-pointed at MetadataStore in M0.B/C)
+
+| Callsite | Direction | Notes |
+|---|---|---|
+| `src/main/pipe/handlers/pane.rpc.ts:141` `pane.setMetadata` | external → main → renderer → store | The authoritative external write entrypoint. `sendToRenderer` is the bug. M0.B replaces with `MetadataStore.set()` direct call. |
+| `src/main/pipe/handlers/pane.rpc.ts:172` `pane.clearMetadata` | external → main → renderer → store | Same shape as setMetadata. M0.B replaces. |
+| `src/renderer/hooks/useRpcBridge.ts:393` `store.setPaneMetadata(...)` IPC handler | renderer IPC inbound | After M0.C, IPC channel is removed; main writes to MetadataStore directly. paneSlice receives the change as a mirror update via `pane.metadata.changed` event. |
+| `src/renderer/hooks/useRpcBridge.ts:429` `store.clearPaneMetadata(...)` IPC handler | renderer IPC inbound | Same. |
+| `src/renderer/stores/slices/paneSlice.ts:239` `setPaneMetadata` | renderer-internal | **The current authority.** M0.C removes the write code path entirely (compile-time guard via not exporting the setter from `PaneSlice`). Only the mirror update remains. |
+| `src/renderer/stores/slices/paneSlice.ts:287` `clearPaneMetadata` | renderer-internal | Same — remove. |
+| `src/renderer/events/publisher.ts:47` `publishPaneMetadataChanged` | renderer → main → EventBus | After M0.B (persist-then-publish), main process emits the event directly from `MetadataStore.set()`. This publisher call becomes unused for pane metadata (still used for renderer-originated pane.created/closed/focused). |
+
+**Risk:** none of these are user-visible UI. The wire-shape contracts (`pane.setMetadata` JSON-RPC params + reply, `pane.metadata.changed` event envelope) are owned by external tooling tests, not view-layer tests.
+
+---
+
+## Read callsites (mirror correctness gates)
+
+These are the paths where a stale paneSlice mirror would cause a substrate contract violation. The M0 design must guarantee these are reconciled within one event tick after a write or after a `droppedCount > 0` resync.
+
+| Callsite | What it reads | Risk if stale |
+|---|---|---|
+| `src/renderer/hooks/useRpcBridge.ts:354` `pane.list` response builder — `metadata: l.metadata` | reads `PaneLeaf.metadata` for every leaf in the workspace | **High** — `pane.list` is the snapshot envelope external tools use to reconcile after `resync: true`. Stale data here = silent state divergence for the external tool. **M0.D snapshot reconciliation rule fixes this by sourcing `pane.list` from `MetadataStore.snapshot()` instead of paneSlice.** |
+| `src/renderer/hooks/useRpcBridge.ts:397` `pane.setMetadata` reply — `metadata: getPaneMetadata(...)` | reads back the freshly-written metadata for the JSON-RPC reply | **Medium** — caller expects to see their own write reflected. After M0.B, this reads from `MetadataStore.get()` directly (no mirror involved). Eliminated. |
+| `src/renderer/hooks/useRpcBridge.ts:413` `pane.getMetadata` reply — `metadata: target.metadata` | reads `PaneLeaf.metadata` via direct tree walk | **Medium** — same shape as L397. After M0.B, routed through `MetadataStore.get()`. Eliminated. |
+| `src/renderer/hooks/useRpcBridge.ts:466` `pane.search` — `leaf.metadata?.label` for fallback match | reads `PaneMetadata.label` for label-substring match | **Low** — if mirror lags by one event, a pane just renamed via setMetadata might not appear in cross-pane search until the next event tick. User-recoverable (re-search). Acceptable mirror semantics. |
+| `src/renderer/stores/slices/paneSlice.ts:251–256` `setPaneMetadata` internal merge — reads `target.metadata.custom` for deep-merge | reads current metadata to compute merged shape | **N/A after M0** — the merge happens in `MetadataStore.set()` on main process; renderer no longer computes it. |
+| `src/renderer/stores/slices/paneSlice.ts:277` `getPaneMetadata` | reads `PaneLeaf.metadata` | **Removed** — paneSlice no longer exposes the getter after M0.C. Internal readers either read the mirror directly or call out to main via RPC. Currently zero non-test callers, so the export simply goes away. |
+| `src/renderer/stores/slices/paneSlice.ts:283` early-return when target is a branch | type guard, not a read | not affected |
+
+**Open question for M0:** the `MetadataStore.snapshot()` call inside `pane.list` (currently the renderer composes the response from its own tree) — does M0 keep the renderer round-trip for `pane.list` (since the tree shape itself is renderer-owned via paneSlice's branches/sizes/active-pane data) but inject metadata from MetadataStore? Or does M0 also lift pane tree authority? **Provisional answer:** keep tree authority in renderer; inject metadata only. That keeps M0 scoped to metadata + persistence and defers tree authority migration to a separate phase.
+
+---
+
+## Display-vocabulary readers (label / role / status as UI contract)
+
+Codex 2nd review flagged labels / roles / status badges as a risk surface. Grep results for `leaf.metadata.label`, `metadata?.role`, `metadata?.status` across `src/renderer`:
+
+| Surface | Currently renders PaneMetadata? | Notes |
+|---|---|---|
+| Pane title bars / split headers | No | Pane title comes from `surface` (terminal session metadata), not PaneMetadata. |
+| StatusBar (`src/renderer/components/StatusBar/StatusBar.tsx:76`) | No | Reads `WorkspaceMetadata.gitBranch`, not PaneMetadata. |
+| MiniSidebar / WorkspaceItem | No | Reads `WorkspaceMetadata.agentName`, `agentStatus`. Not PaneMetadata. |
+| AppLayout (`AppLayout.tsx:357`) | No | Reads `WorkspaceMetadata.agentStatus`. Not PaneMetadata. |
+| FileTreePanel (`FileTreePanel.tsx:269`) | No | Reads `WorkspaceMetadata.cwd`. Not PaneMetadata. |
+| Command palette | No | Pane name comes from `surface` data, not `PaneMetadata.label`. |
+
+**Verdict:** today no React view subscribes to `PaneMetadata.{label,role,status,custom}`. The substrate exposes the surface for external tools; the wmux GUI itself does not yet render it. This means M0's mirror can lag by one event tick without any user-visible regression.
+
+This is a *future* coupling — once a future wmux UI starts rendering `metadata.label` on pane headers (planned for v3.1+), the mirror's eventual-consistency contract becomes user-visible. M0's snapshot reconciliation (`pane.list` after `droppedCount > 0` or `bootId mismatch`) is sized for that future case.
+
+---
+
+## Restore state (M0.F persistence absorption)
+
+| Callsite | Notes |
+|---|---|
+| `src/main/session/SessionManager.ts` (dump/hydrate) | Currently serializes `PaneLeaf.metadata` as part of the workspace tree via the renderer's session state. M0.F replaces with `MetadataStore.serialize()` / `.hydrate()`. The store becomes the persistence source of truth; SessionManager calls into it. |
+| `session.json` schema | Existing dumps have no `version` field on metadata entries. M0.A normalizes missing version → 0; first subsequent set → 1. No migration script needed for v2.x → v3.0. Forward-compat: M0.F adds a `schema_version` envelope to the dump so future migrations have an anchor. |
+
+**Race:** `SessionManager` dump runs on quit and on autosave (separate slice). M0.B's "persist-then-publish" ordering must coordinate with autosave timing — open design item for M0 implementation, not for this inventory.
+
+---
+
+## Tests already at the boundary
+
+- `src/renderer/stores/slices/__tests__/paneSlice.metadata.test.ts` — 19 tests on the current renderer authority. After M0.C, these split: behavioral tests (merge / replace / cap enforcement / workspace scoping) migrate to `MetadataStore` unit tests; mirror tests (event subscription → paneSlice reflects change) stay.
+- `src/renderer/stores/slices/__tests__/paneSlice.events.test.ts` — `pane.metadata.changed` event publish on write. After M0.B, this becomes a main-process test (EventBus publish on `MetadataStore.set()`).
+- `src/main/pipe/handlers/__tests__/pane.rpc.test.ts` — JSON-RPC handler-level. Untouched by M0 conceptually; setMetadata internals change but the wire contract stays the same (modulo the new `expectedVersion` / `mergeMode` additions, which are separate test cases).
+- `src/main/events/__tests__/EventBus.test.ts` — bus invariants. Untouched.
+
+**Net test impact:** ~19 tests migrate slices, plus new tests for `MetadataStore` itself (estimate ~38 per plan budget). No test deletion.
+
+---
+
+## Inputs delivered to M0
+
+This inventory feeds three concrete decisions for the M0 design PR:
+
+1. **Mirror contract surface area is small.** `pane.list` (in `useRpcBridge.ts:354`) is the one read site that must be reconciled atomically with a `MetadataStore.snapshot()` call. Every other read site is either (a) a writer's own reply (eliminated when authority moves) or (b) a fuzzy-search fallback (`pane.search`) where eventual consistency is fine.
+2. **Compile-time write protection in paneSlice is feasible** because no non-test caller currently invokes `setPaneMetadata` / `clearPaneMetadata` outside `useRpcBridge`. Removing the setters from the slice's exported interface is a no-op for view code.
+3. **No view-layer migration needed.** No React component reads `PaneMetadata.{label,role,status,custom}` today; the mirror's stale-tick window has no user-visible effect at v3.0 ship. Future UI work (v3.1+) will need the snapshot reconciliation contract M0.D establishes, but does not block v3.0.
+
+---
+
+## Open follow-ups (not blocking M0)
+
+- `SessionManager` autosave timing vs. `MetadataStore` persist-then-publish ordering — design item for M0 implementation.
+- Whether to lift pane-tree authority (branches/sizes/active-pane) to main process as well — explicitly deferred; M0 keeps tree authority in renderer and lifts only metadata.
+- Whether to expose `pane.getMetadata` over JSON-RPC after M0 makes `pane.list` cover the same data — keep it for now (per-pane fetch is cheaper than full list for some external tooling patterns).


### PR DESCRIPTION
## Summary

Substrate 3.0 Phase 0 — the external-contract paperwork that locks in what already shipped (v2.8.0 PaneMetadata + EventBus + bootId + `mcp.claimWorkspace`) and stakes out the v3.0 stable surface ahead of the M0 metadata-store work.

No code surface changes. Pure docs + a PR template + the README positioning shift to LSP-for-terminals.

Tracks #31. Builds on the RFC discussion in #15.

## Changes

- **README** opens with the LSP-for-terminals framing (substrate identity) while preserving the AI-agent value prop and tmux-alternative keywords.
- **`docs/api/inventory.md`** catalogs every RPC method, MCP tool, and event type with a stability tier (`stable` / `experimental` / `internal`).
- **`docs/api/versioning.md`** formalizes semver + tier semantics. Documents v2.x → v3.0 auto-updater compatibility (winget · Chocolatey · electron-updater all upgrade cleanly) and explains the v3.0 + "Substrate 1.0" tagline decision over a v1.0 reset.
- **`docs/api/stability.md`** freezes the v3.0 stable-surface contract: `pane.list` snapshot envelope, `pane.{set,get,clear}Metadata` with `expectedVersion` + `mergeMode`, `events.poll` cursor + `bootId` + `resync` semantics, `mcp.claimWorkspace`, validation limits, error codes.
- **`docs/PROTOCOL.md`** (draft 1) is the substrate wire contract: layered status, namespacing, optimistic concurrency, mergeMode semantics, cursor opaqueness, snapshot reconciliation, 4-point permission enforcement sketch, Named Pipe token security model.
- **`docs/internal/paneSlice-callsite-inventory.md`** is the M0 pre-work required by the 2nd Codex review. Walks every read/write touching `PaneLeaf.metadata` and confirms the mirror migration has a narrow blast radius — no React component currently subscribes to the display-vocabulary fields.
- **`.github/PULL_REQUEST_TEMPLATE.md`** adds CHANGELOG sections + stability-tier classification so every PR self-classifies its contract impact.

## CHANGELOG entry

### Added

- Substrate 3.0 contract documentation: `docs/PROTOCOL.md`, `docs/api/{inventory,versioning,stability}.md`.
- PR template with CHANGELOG + stability-tier sections.

### Changed

- README opens with the LSP-for-terminals substrate framing.

### Deprecated

n/a

### Removed

n/a

### Fixed

n/a

### Security

n/a

## Stability tier impact

- [x] No external surface touched (internal refactor / docs / tests / CI).

This PR ships only documentation and the README framing. Every RPC method, event type, and MCP tool stays identical at the wire level. The stability tiers declared in `docs/api/inventory.md` and `docs/api/stability.md` describe the **existing** surface as of v2.8.4; the wire contract itself is unchanged.

## Substrate contract impact (Substrate 3.0)

This PR **declares** the substrate contract for the first time. Future PRs that touch the wire shape will reference `docs/PROTOCOL.md` as the spec.

- `docs/PROTOCOL.md` §1 (PaneMetadata): documents the existing v2.8 semantics + sketches the v3.0 additions (`expectedVersion`, `mergeMode`) that Phase 1 M0 will implement.
- `docs/PROTOCOL.md` §2 (event bus): documents the existing `events.poll` contract end-to-end — cursor opaqueness, `bootId` invalidation, `droppedCount` + `resync` semantics, the cross-producer ordering caveat.
- `docs/PROTOCOL.md` §4 (permission enforcement): sketches the 4 enforcement points. Workspace claim (v2.7.2) is already shipped; the other three are Phase 2.1 work.
- `docs/PROTOCOL.md` §5 (Named Pipe security): documents the token + `secureWriteTokenFile` + `MAX_CONNECTIONS=50` model that already exists.

## Test plan

Docs-only PR. No CI behavior change. Verification:

- [x] All cross-references between `inventory.md` / `versioning.md` / `stability.md` / `PROTOCOL.md` resolve.
- [x] README still renders correctly on GitHub (badge alignment, keyword list intact).
- [x] `.github/PULL_REQUEST_TEMPLATE.md` shows up on new PR creation.
- [x] Tracking issue #31 references this PR's deliverables in the Phase 0 checklist.

## Related issues / PRs

- Tracks #31
- Builds on #15 (RFC), #18 (external tooling primitives)
