### PR TITLE
feat(metadata): M0-a — MetadataStore module + 28 unit tests

### DIFF
--- a/src/main/metadata/MetadataStore.ts
+++ b/src/main/metadata/MetadataStore.ts
@@ -158,11 +158,23 @@ export class MetadataStore {
     }
 
     const merged = this.merge(existing?.metadata ?? {}, sanitized, mode);
+    merged.updatedAt = Date.now();
+
+    // Validate the post-merge shape after every field that will be stored
+    // is present. Two cumulative limits:
+    //   1. custom entry count — sanitize() only sees the patch, so a chain
+    //      of merge-mode writes could grow the stored custom past the cap.
+    //   2. total byte cap — JSON.stringify the final committed shape
+    //      (updatedAt + version-less metadata) to ensure boundary payloads
+    //      that pass with just sanitized fields still fail once updatedAt
+    //      is appended.
+    if (merged.custom && Object.keys(merged.custom).length > PANE_METADATA_CUSTOM_MAX_ENTRIES) {
+      throw new Error(`"custom" exceeds ${PANE_METADATA_CUSTOM_MAX_ENTRIES} entries`);
+    }
     if (JSON.stringify(merged).length > PANE_METADATA_MAX_BYTES) {
       throw new Error(`metadata exceeds ${PANE_METADATA_MAX_BYTES} bytes`);
     }
 
-    merged.updatedAt = Date.now();
     const newVersion = currentVersion + 1;
     const workspaceId = opts.workspaceId ?? existing?.workspaceId ?? '';
 
@@ -411,14 +423,17 @@ export class MetadataStore {
     }
 
     if (mode === 'replaceShared') {
-      // Replace top-level shared fields wholesale; preserve custom from base
-      // unless patch explicitly provides one.
+      // Replace top-level shared fields wholesale; preserve base.custom
+      // wholesale. patch.custom is silently ignored — callers that need to
+      // write custom should use 'merge' (additive) or 'replace' (full
+      // overwrite). This is the substrate guarantee that lets one tool
+      // claim the shared display vocabulary without touching another
+      // tool's namespaced state. See docs/PROTOCOL.md §1.4.
       const result: PaneMetadata = {};
       if (base.custom !== undefined) result.custom = { ...base.custom };
       if (patch.label !== undefined) result.label = patch.label;
       if (patch.role !== undefined) result.role = patch.role;
       if (patch.status !== undefined) result.status = patch.status;
-      if (patch.custom !== undefined) result.custom = { ...patch.custom };
       return result;
     }
 

--- a/src/main/metadata/MetadataStore.ts
+++ b/src/main/metadata/MetadataStore.ts
@@ -1,0 +1,444 @@
+// === wmux MetadataStore (M0-a) ===
+//
+// Authoritative store for PaneMetadata in the main process. Replaces the
+// renderer paneSlice as the metadata source of truth (M0-d removes the
+// renderer write path; M0-b re-points the RPC handlers here).
+//
+// This module is INTENTIONALLY isolated in M0-a — handler wiring, paneSlice
+// mirror conversion, and SessionManager persistence integration land in
+// later M0 PRs. M0-a ships the store + its unit tests; no call sites change.
+//
+// Design contract: docs/internal/m0-design.md
+// Wire contract:   docs/PROTOCOL.md §1
+//
+// Concurrency model:
+//   - Single-threaded JS = automatic serialization across set() calls
+//     (race #5 in the design doc).
+//   - The synchronous critical section (validate → check version → merge →
+//     bump version → commit → emit) holds across one `set()` invocation,
+//     so two concurrent callers observe a monotonic version sequence
+//     without locking.
+//   - Persistence is handled in M0-e via SessionManager.hydrate/serialize.
+//     M0-a exposes the API (`hydrate`, `serialize`, `migrate`) but does
+//     not yet wire it into the dump path.
+
+import type { PaneMetadata } from '../../shared/types';
+import {
+  PANE_METADATA_MAX_BYTES,
+  PANE_METADATA_LABEL_MAX,
+  PANE_METADATA_ROLE_MAX,
+  PANE_METADATA_STATUS_MAX,
+  PANE_METADATA_CUSTOM_KEY_MAX,
+  PANE_METADATA_CUSTOM_MAX_ENTRIES,
+} from '../../shared/types';
+import { eventBus as defaultEventBus, EventBus } from '../events/EventBus';
+
+// === Public types ===
+
+export type MergeMode = 'merge' | 'replace' | 'replaceShared';
+
+export interface SetOptions {
+  mergeMode?: MergeMode;
+  expectedVersion?: number;
+  /**
+   * Workspace this write is scoped to. Used as the `workspaceId` on the
+   * emitted `pane.metadata.changed` event. If omitted, falls back to the
+   * workspaceId remembered from a prior set() on this pane. If neither
+   * is known, the event is skipped (the store still commits — this only
+   * matters for the event surface).
+   */
+  workspaceId?: string;
+}
+
+export type SetResult =
+  | { ok: true; version: number; metadata: PaneMetadata }
+  | { ok: false; error: 'VERSION_CONFLICT'; currentVersion: number };
+
+export interface MetadataEntry {
+  metadata: PaneMetadata;
+  version: number;
+}
+
+export interface SnapshotEntry {
+  paneId: string;
+  workspaceId: string;
+  metadata: PaneMetadata;
+  version: number;
+}
+
+export interface Snapshot {
+  asOfSeq: number;
+  bootId: string;
+  entries: SnapshotEntry[];
+}
+
+export const METADATA_SCHEMA_VERSION = 1 as const;
+
+export interface PersistedShape {
+  schema_version: typeof METADATA_SCHEMA_VERSION;
+  entries: SnapshotEntry[];
+}
+
+// === Internal ===
+
+interface InternalEntry {
+  metadata: PaneMetadata;
+  version: number;
+  /** Remembered for event emission on subsequent set/clear/onPaneDeleted. */
+  workspaceId: string;
+}
+
+function cloneMetadata(meta: PaneMetadata): PaneMetadata {
+  const out: PaneMetadata = {};
+  if (meta.label !== undefined) out.label = meta.label;
+  if (meta.role !== undefined) out.role = meta.role;
+  if (meta.status !== undefined) out.status = meta.status;
+  if (meta.custom !== undefined) out.custom = { ...meta.custom };
+  if (meta.updatedAt !== undefined) out.updatedAt = meta.updatedAt;
+  return out;
+}
+
+function isEmptyMetadata(meta: PaneMetadata): boolean {
+  return (
+    meta.label === undefined &&
+    meta.role === undefined &&
+    meta.status === undefined &&
+    (meta.custom === undefined || Object.keys(meta.custom).length === 0)
+  );
+}
+
+// === Store ===
+
+export class MetadataStore {
+  private readonly bus: EventBus;
+  private readonly map = new Map<string, InternalEntry>();
+
+  constructor(opts?: { eventBus?: EventBus }) {
+    this.bus = opts?.eventBus ?? defaultEventBus;
+  }
+
+  /**
+   * Reads the latest committed metadata + version for a pane.
+   * Returns `{ metadata: {}, version: 0 }` when no metadata has ever been
+   * set on this paneId — `version: 0` is the "never written" sentinel.
+   */
+  get(paneId: string): MetadataEntry {
+    const entry = this.map.get(paneId);
+    if (!entry) return { metadata: {}, version: 0 };
+    return { metadata: cloneMetadata(entry.metadata), version: entry.version };
+  }
+
+  /**
+   * Single synchronous critical section.
+   *
+   *   1. validate(patch)         → throws on invalid input (no version bump)
+   *   2. concurrency check       → returns VERSION_CONFLICT on mismatch
+   *   3. compute merged shape    → mergeMode semantics
+   *   4. enforce MAX_BYTES       → throws if post-merge exceeds cap
+   *   5. bump version            → currentVersion + 1
+   *   6. commit in-memory        → map.set(paneId, ...)
+   *   7. emit event              → EventBus.emit('pane.metadata.changed')
+   *
+   * Persistence (step 6.5 in the design doc — persist-then-publish) lands
+   * in M0-b/e. M0-a sequences commit → emit synchronously.
+   */
+  set(
+    paneId: string,
+    patch: Partial<PaneMetadata>,
+    opts: SetOptions = {},
+  ): SetResult {
+    const sanitized = this.sanitize(patch);
+    const mode: MergeMode = opts.mergeMode ?? 'merge';
+
+    const existing = this.map.get(paneId);
+    const currentVersion = existing?.version ?? 0;
+
+    if (opts.expectedVersion !== undefined && opts.expectedVersion !== currentVersion) {
+      return { ok: false, error: 'VERSION_CONFLICT', currentVersion };
+    }
+
+    const merged = this.merge(existing?.metadata ?? {}, sanitized, mode);
+    if (JSON.stringify(merged).length > PANE_METADATA_MAX_BYTES) {
+      throw new Error(`metadata exceeds ${PANE_METADATA_MAX_BYTES} bytes`);
+    }
+
+    merged.updatedAt = Date.now();
+    const newVersion = currentVersion + 1;
+    const workspaceId = opts.workspaceId ?? existing?.workspaceId ?? '';
+
+    this.map.set(paneId, {
+      metadata: merged,
+      version: newVersion,
+      workspaceId,
+    });
+
+    if (workspaceId) {
+      this.bus.emit({
+        type: 'pane.metadata.changed',
+        workspaceId,
+        paneId,
+        metadata: cloneMetadata(merged),
+        version: newVersion,
+      });
+    }
+
+    return {
+      ok: true,
+      version: newVersion,
+      metadata: cloneMetadata(merged),
+    };
+  }
+
+  /**
+   * Drops all metadata for a pane while keeping the version counter
+   * monotonic. Always succeeds (no concurrency check — clear is idempotent).
+   * Emits `pane.metadata.changed` with empty metadata + bumped version.
+   *
+   * If the pane has no prior entry, returns version 0 without bumping
+   * (no event emitted — there was nothing to clear).
+   */
+  clear(paneId: string): SetResult {
+    const existing = this.map.get(paneId);
+    if (!existing) {
+      return { ok: true, version: 0, metadata: {} };
+    }
+
+    const newVersion = existing.version + 1;
+    const workspaceId = existing.workspaceId;
+    const cleared: PaneMetadata = {};
+
+    this.map.set(paneId, {
+      metadata: cleared,
+      version: newVersion,
+      workspaceId,
+    });
+
+    if (workspaceId) {
+      this.bus.emit({
+        type: 'pane.metadata.changed',
+        workspaceId,
+        paneId,
+        metadata: {},
+        version: newVersion,
+      });
+    }
+
+    return { ok: true, version: newVersion, metadata: {} };
+  }
+
+  /**
+   * Atomic snapshot of the store + the EventBus seq watermark.
+   * Used by `pane.list` (M0-c) so external clients can reconcile their
+   * cached state against a known consistent point.
+   *
+   * Single-threaded JS guarantees that `latestSeq()` and the map iteration
+   * happen in the same task — no concurrent emit() can land between them.
+   */
+  snapshot(): Snapshot {
+    const entries: SnapshotEntry[] = [];
+    for (const [paneId, entry] of this.map.entries()) {
+      entries.push({
+        paneId,
+        workspaceId: entry.workspaceId,
+        metadata: cloneMetadata(entry.metadata),
+        version: entry.version,
+      });
+    }
+    return {
+      asOfSeq: this.bus.latestSeq(),
+      bootId: this.bus.bootId,
+      entries,
+    };
+  }
+
+  /**
+   * Replaces the in-memory store with the given persisted shape. Called by
+   * SessionManager on app boot (M0-e). Drops any in-memory entries first.
+   * Unknown schema versions throw — callers can catch and fall back to a
+   * clean store.
+   *
+   * No events are emitted by hydrate(); subscribers learn about state via
+   * the next pane.list call after boot.
+   */
+  hydrate(serialized: PersistedShape): void {
+    const migrated = this.migrate(serialized, METADATA_SCHEMA_VERSION);
+    this.map.clear();
+    for (const entry of migrated.entries) {
+      this.map.set(entry.paneId, {
+        metadata: cloneMetadata(entry.metadata),
+        version: entry.version,
+        workspaceId: entry.workspaceId,
+      });
+    }
+  }
+
+  /**
+   * Returns the persistable shape of the store. Cleared entries (metadata
+   * with no fields set) are dropped to keep session.json compact —
+   * race #4 (paneId recycle) is in-process only; once a session is dumped
+   * and re-hydrated, a recycled paneId starts at version 0 again.
+   * In practice this never triggers because wmux paneIds are random UUIDs.
+   */
+  serialize(): PersistedShape {
+    const entries: SnapshotEntry[] = [];
+    for (const [paneId, entry] of this.map.entries()) {
+      if (isEmptyMetadata(entry.metadata)) continue;
+      entries.push({
+        paneId,
+        workspaceId: entry.workspaceId,
+        metadata: cloneMetadata(entry.metadata),
+        version: entry.version,
+      });
+    }
+    return {
+      schema_version: METADATA_SCHEMA_VERSION,
+      entries,
+    };
+  }
+
+  /**
+   * Migrates a persisted shape to a target schema version. Phase 1 ships
+   * at schema 1 so this is currently identity-or-throw. Migration table
+   * grows in v3.1+ as schema evolves.
+   */
+  migrate(input: PersistedShape, to: typeof METADATA_SCHEMA_VERSION): PersistedShape {
+    if (input.schema_version === to) return input;
+    throw new Error(`unsupported metadata schema_version: ${String(input.schema_version)}`);
+  }
+
+  /**
+   * Called when a pane is destroyed (M0-e adds the IPC for the renderer
+   * to signal this). Clears the metadata but keeps the entry slot so the
+   * version counter remains monotonic — protects race #4 in case the same
+   * paneId is ever recycled within one daemon run.
+   *
+   * Emits a final `pane.metadata.changed` event with empty metadata + the
+   * bumped version so subscribers can drop their mirror entry cleanly.
+   */
+  onPaneDeleted(paneId: string): void {
+    const existing = this.map.get(paneId);
+    if (!existing) return;
+
+    const newVersion = existing.version + 1;
+    const workspaceId = existing.workspaceId;
+
+    this.map.set(paneId, {
+      metadata: {},
+      version: newVersion,
+      workspaceId,
+    });
+
+    if (workspaceId) {
+      this.bus.emit({
+        type: 'pane.metadata.changed',
+        workspaceId,
+        paneId,
+        metadata: {},
+        version: newVersion,
+      });
+    }
+  }
+
+  /** Test-only: drops all state. Not exposed via RPC or MCP. */
+  reset(): void {
+    this.map.clear();
+  }
+
+  // === Internals ===
+
+  private sanitize(input: Partial<PaneMetadata>): Partial<PaneMetadata> {
+    const out: Partial<PaneMetadata> = {};
+    if (input.label !== undefined) {
+      if (typeof input.label !== 'string') throw new Error('"label" must be a string');
+      if (input.label.length > PANE_METADATA_LABEL_MAX) {
+        throw new Error(`"label" exceeds ${PANE_METADATA_LABEL_MAX} chars`);
+      }
+      out.label = input.label;
+    }
+    if (input.role !== undefined) {
+      if (typeof input.role !== 'string') throw new Error('"role" must be a string');
+      if (input.role.length > PANE_METADATA_ROLE_MAX) {
+        throw new Error(`"role" exceeds ${PANE_METADATA_ROLE_MAX} chars`);
+      }
+      out.role = input.role;
+    }
+    if (input.status !== undefined) {
+      if (typeof input.status !== 'string') throw new Error('"status" must be a string');
+      if (input.status.length > PANE_METADATA_STATUS_MAX) {
+        throw new Error(`"status" exceeds ${PANE_METADATA_STATUS_MAX} chars`);
+      }
+      out.status = input.status;
+    }
+    if (input.custom !== undefined) {
+      if (
+        typeof input.custom !== 'object' ||
+        input.custom === null ||
+        Array.isArray(input.custom)
+      ) {
+        throw new Error('"custom" must be an object of string→string');
+      }
+      const entries = Object.entries(input.custom);
+      if (entries.length > PANE_METADATA_CUSTOM_MAX_ENTRIES) {
+        throw new Error(`"custom" exceeds ${PANE_METADATA_CUSTOM_MAX_ENTRIES} entries`);
+      }
+      const custom: Record<string, string> = {};
+      for (const [k, v] of entries) {
+        if (k.length === 0) throw new Error('"custom" key cannot be empty');
+        if (k.length > PANE_METADATA_CUSTOM_KEY_MAX) {
+          throw new Error(`"custom" key exceeds ${PANE_METADATA_CUSTOM_KEY_MAX} chars`);
+        }
+        if (typeof v !== 'string') throw new Error(`"custom.${k}" must be a string`);
+        custom[k] = v;
+      }
+      out.custom = custom;
+    }
+    return out;
+  }
+
+  private merge(
+    base: PaneMetadata,
+    patch: Partial<PaneMetadata>,
+    mode: MergeMode,
+  ): PaneMetadata {
+    if (mode === 'replace') {
+      // Full overwrite: only patch fields survive.
+      const result: PaneMetadata = {};
+      if (patch.label !== undefined) result.label = patch.label;
+      if (patch.role !== undefined) result.role = patch.role;
+      if (patch.status !== undefined) result.status = patch.status;
+      if (patch.custom !== undefined) result.custom = { ...patch.custom };
+      return result;
+    }
+
+    if (mode === 'replaceShared') {
+      // Replace top-level shared fields wholesale; preserve custom from base
+      // unless patch explicitly provides one.
+      const result: PaneMetadata = {};
+      if (base.custom !== undefined) result.custom = { ...base.custom };
+      if (patch.label !== undefined) result.label = patch.label;
+      if (patch.role !== undefined) result.role = patch.role;
+      if (patch.status !== undefined) result.status = patch.status;
+      if (patch.custom !== undefined) result.custom = { ...patch.custom };
+      return result;
+    }
+
+    // 'merge' — patch-style with one-level deep-merge on custom.
+    const result: PaneMetadata = {
+      ...(base.label !== undefined && { label: base.label }),
+      ...(base.role !== undefined && { role: base.role }),
+      ...(base.status !== undefined && { status: base.status }),
+    };
+    if (base.custom !== undefined) result.custom = { ...base.custom };
+
+    if (patch.label !== undefined) result.label = patch.label;
+    if (patch.role !== undefined) result.role = patch.role;
+    if (patch.status !== undefined) result.status = patch.status;
+    if (patch.custom !== undefined) {
+      result.custom = { ...(result.custom ?? {}), ...patch.custom };
+    }
+    return result;
+  }
+}
+
+// Module-level singleton — main process only.
+export const metadataStore = new MetadataStore();

--- a/src/main/metadata/__tests__/MetadataStore.test.ts
+++ b/src/main/metadata/__tests__/MetadataStore.test.ts
@@ -1,0 +1,429 @@
+// === MetadataStore unit tests (M0-a) ===
+//
+// Covers CRUD + version monotonicity, mergeMode semantics, optimistic
+// concurrency (expectedVersion), snapshot/hydrate/serialize/migrate,
+// onPaneDeleted, validation guards, and EventBus emission shape.
+//
+// EventBus is injected per-test so emit() interactions can be observed
+// in isolation from the module-level singleton.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { EventBus } from '../../events/EventBus';
+import {
+  MetadataStore,
+  METADATA_SCHEMA_VERSION,
+  type PersistedShape,
+} from '../MetadataStore';
+import {
+  PANE_METADATA_LABEL_MAX,
+  PANE_METADATA_CUSTOM_MAX_ENTRIES,
+  PANE_METADATA_MAX_BYTES,
+} from '../../../shared/types';
+
+describe('MetadataStore', () => {
+  let bus: EventBus;
+  let store: MetadataStore;
+
+  beforeEach(() => {
+    bus = new EventBus();
+    store = new MetadataStore({ eventBus: bus });
+  });
+
+  // ===========================================================================
+  // CRUD + version
+  // ===========================================================================
+
+  describe('get + set + clear + version', () => {
+    it('get on empty pane returns version 0 with empty metadata', () => {
+      const result = store.get('p-1');
+      expect(result.version).toBe(0);
+      expect(result.metadata).toEqual({});
+    });
+
+    it('first set bumps version 0 → 1 and returns merged metadata', () => {
+      const result = store.set('p-1', { label: 'Backend' }, { workspaceId: 'ws-1' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.version).toBe(1);
+      expect(result.metadata.label).toBe('Backend');
+
+      const read = store.get('p-1');
+      expect(read.version).toBe(1);
+      expect(read.metadata.label).toBe('Backend');
+    });
+
+    it('clear on a pane with metadata bumps version + empties the shape', () => {
+      store.set('p-1', { label: 'Backend', role: 'service' }, { workspaceId: 'ws-1' });
+      const result = store.clear('p-1');
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.version).toBe(2);
+      expect(result.metadata).toEqual({});
+
+      const read = store.get('p-1');
+      expect(read.metadata.label).toBeUndefined();
+      expect(read.metadata.role).toBeUndefined();
+      // Version stays at 2 (post-clear), monotonic across the lifecycle.
+      expect(read.version).toBe(2);
+    });
+
+    it('clear on a never-written pane is a no-op (no event, version 0)', () => {
+      const beforeCursor = bus.latestSeq();
+      const result = store.clear('p-never');
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.version).toBe(0);
+      expect(bus.latestSeq()).toBe(beforeCursor); // no event emitted
+    });
+
+    it('onPaneDeleted keeps the version counter monotonic for recycled IDs', () => {
+      store.set('p-recycle', { label: 'First' }, { workspaceId: 'ws-1' }); // v1
+      store.set('p-recycle', { status: 'running' }, { workspaceId: 'ws-1' }); // v2
+      store.onPaneDeleted('p-recycle');                                       // v3 (empty)
+
+      // The pane is "deleted" but the entry slot lingers so a recycled
+      // paneId in the same daemon run can't trick subscribers into seeing
+      // a fake version reset.
+      const afterDelete = store.get('p-recycle');
+      expect(afterDelete.version).toBe(3);
+      expect(afterDelete.metadata).toEqual({});
+
+      // A new write under the recycled id starts from v3 + 1 = v4.
+      const writeAfter = store.set('p-recycle', { label: 'Recycled' }, { workspaceId: 'ws-1' });
+      expect(writeAfter.ok).toBe(true);
+      if (writeAfter.ok) expect(writeAfter.version).toBe(4);
+    });
+  });
+
+  // ===========================================================================
+  // mergeMode
+  // ===========================================================================
+
+  describe('mergeMode', () => {
+    beforeEach(() => {
+      store.set(
+        'p-1',
+        {
+          label: 'Backend',
+          role: 'service',
+          custom: { 'orchestrator.taskId': 'T-1', 'qa.status': 'pending' },
+        },
+        { workspaceId: 'ws-1' },
+      );
+    });
+
+    it("'merge' (default) patches top-level + deep-merges custom one level", () => {
+      const result = store.set(
+        'p-1',
+        { status: 'running', custom: { 'qa.status': 'passing', 'dashboard.live': 'true' } },
+        { workspaceId: 'ws-1' },
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.metadata.label).toBe('Backend');     // preserved
+      expect(result.metadata.role).toBe('service');      // preserved
+      expect(result.metadata.status).toBe('running');    // patched
+      expect(result.metadata.custom).toEqual({
+        'orchestrator.taskId': 'T-1',                    // preserved
+        'qa.status': 'passing',                          // overwritten
+        'dashboard.live': 'true',                        // added
+      });
+    });
+
+    it("'replace' fully overwrites — patch shape is the new shape", () => {
+      const result = store.set(
+        'p-1',
+        { status: 'fresh' },
+        { mergeMode: 'replace', workspaceId: 'ws-1' },
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.metadata.label).toBeUndefined();
+      expect(result.metadata.role).toBeUndefined();
+      expect(result.metadata.status).toBe('fresh');
+      expect(result.metadata.custom).toBeUndefined();
+    });
+
+    it("'replaceShared' replaces top-level shared fields but preserves custom", () => {
+      const result = store.set(
+        'p-1',
+        { label: 'NewLabel', status: 'fresh' },
+        { mergeMode: 'replaceShared', workspaceId: 'ws-1' },
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.metadata.label).toBe('NewLabel');
+      expect(result.metadata.role).toBeUndefined();      // dropped — replaceShared discards omitted shared fields
+      expect(result.metadata.status).toBe('fresh');
+      expect(result.metadata.custom).toEqual({
+        'orchestrator.taskId': 'T-1',
+        'qa.status': 'pending',
+      });                                                // preserved
+    });
+
+    it('version is bumped on the post-merge shape, regardless of mode', () => {
+      // p-1 is at v1 after the beforeEach.
+      const replace = store.set('p-1', {}, { mergeMode: 'replace', workspaceId: 'ws-1' });
+      expect(replace.ok).toBe(true);
+      if (replace.ok) expect(replace.version).toBe(2);
+
+      const merge = store.set('p-1', { label: 'A' }, { workspaceId: 'ws-1' });
+      expect(merge.ok).toBe(true);
+      if (merge.ok) expect(merge.version).toBe(3);
+
+      const replaceShared = store.set(
+        'p-1',
+        { role: 'r' },
+        { mergeMode: 'replaceShared', workspaceId: 'ws-1' },
+      );
+      expect(replaceShared.ok).toBe(true);
+      if (replaceShared.ok) expect(replaceShared.version).toBe(4);
+    });
+  });
+
+  // ===========================================================================
+  // Optimistic concurrency
+  // ===========================================================================
+
+  describe('expectedVersion (optimistic concurrency)', () => {
+    it('without expectedVersion always commits regardless of current version', () => {
+      store.set('p-1', { label: 'A' }, { workspaceId: 'ws-1' }); // v1
+      store.set('p-1', { label: 'B' }, { workspaceId: 'ws-1' }); // v2
+      const result = store.set('p-1', { label: 'C' }, { workspaceId: 'ws-1' });
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.version).toBe(3);
+    });
+
+    it('with matching expectedVersion commits and bumps', () => {
+      store.set('p-1', { label: 'A' }, { workspaceId: 'ws-1' }); // v1
+      const result = store.set(
+        'p-1',
+        { label: 'B' },
+        { workspaceId: 'ws-1', expectedVersion: 1 },
+      );
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.version).toBe(2);
+    });
+
+    it('with mismatched expectedVersion returns VERSION_CONFLICT + currentVersion (no mutation)', () => {
+      store.set('p-1', { label: 'A' }, { workspaceId: 'ws-1' }); // v1
+      store.set('p-1', { label: 'B' }, { workspaceId: 'ws-1' }); // v2
+
+      const beforeCursor = bus.latestSeq();
+      const result = store.set(
+        'p-1',
+        { label: 'C' },
+        { workspaceId: 'ws-1', expectedVersion: 1 },          // stale
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toBe('VERSION_CONFLICT');
+      expect(result.currentVersion).toBe(2);
+
+      // Mutation did NOT happen.
+      const read = store.get('p-1');
+      expect(read.version).toBe(2);
+      expect(read.metadata.label).toBe('B');
+
+      // Event was NOT emitted.
+      expect(bus.latestSeq()).toBe(beforeCursor);
+    });
+
+    it('expectedVersion: 0 on a never-written pane commits as the first write', () => {
+      const result = store.set(
+        'p-fresh',
+        { label: 'Hello' },
+        { workspaceId: 'ws-1', expectedVersion: 0 },
+      );
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.version).toBe(1);
+        expect(result.metadata.label).toBe('Hello');
+      }
+    });
+
+    it('set reply echoes version that subsequent get reproduces (idempotence anchor)', () => {
+      const a = store.set('p-1', { label: 'A' }, { workspaceId: 'ws-1' });
+      expect(a.ok).toBe(true);
+      if (!a.ok) return;
+      const fromGet = store.get('p-1');
+      expect(fromGet.version).toBe(a.version);
+      expect(fromGet.metadata.label).toBe('A');
+    });
+  });
+
+  // ===========================================================================
+  // Validation + size caps
+  // ===========================================================================
+
+  describe('validation', () => {
+    it('rejects label exceeding PANE_METADATA_LABEL_MAX', () => {
+      const long = 'x'.repeat(PANE_METADATA_LABEL_MAX + 1);
+      expect(() =>
+        store.set('p-1', { label: long }, { workspaceId: 'ws-1' }),
+      ).toThrow(/"label" exceeds/);
+    });
+
+    it('rejects custom with more than PANE_METADATA_CUSTOM_MAX_ENTRIES entries', () => {
+      const custom: Record<string, string> = {};
+      for (let i = 0; i <= PANE_METADATA_CUSTOM_MAX_ENTRIES; i++) {
+        custom[`k${i}`] = 'v';
+      }
+      expect(() =>
+        store.set('p-1', { custom }, { workspaceId: 'ws-1' }),
+      ).toThrow(/"custom" exceeds/);
+    });
+
+    it('rejects merged shape exceeding PANE_METADATA_MAX_BYTES', () => {
+      // Build a payload right at the cap by stuffing custom values.
+      // The cap is on JSON.stringify(merged); we craft custom entries
+      // that drive the merged size past the limit.
+      const bigValue = 'x'.repeat(Math.floor(PANE_METADATA_MAX_BYTES / 4));
+      const custom: Record<string, string> = {};
+      for (let i = 0; i < 8; i++) custom[`k${i}`] = bigValue;
+      expect(() =>
+        store.set('p-1', { custom }, { workspaceId: 'ws-1' }),
+      ).toThrow(/exceeds .* bytes/);
+    });
+
+    it('does not bump version on validation failure', () => {
+      store.set('p-1', { label: 'A' }, { workspaceId: 'ws-1' }); // v1
+      const beforeCursor = bus.latestSeq();
+      expect(() =>
+        store.set('p-1', { label: 'x'.repeat(PANE_METADATA_LABEL_MAX + 1) }, { workspaceId: 'ws-1' }),
+      ).toThrow();
+      expect(store.get('p-1').version).toBe(1);   // unchanged
+      expect(bus.latestSeq()).toBe(beforeCursor); // no event emitted
+    });
+  });
+
+  // ===========================================================================
+  // Snapshot
+  // ===========================================================================
+
+  describe('snapshot', () => {
+    it('returns asOfSeq matching EventBus.latestSeq() at the snapshot moment', () => {
+      store.set('p-1', { label: 'A' }, { workspaceId: 'ws-1' });
+      store.set('p-2', { label: 'B' }, { workspaceId: 'ws-1' });
+      const snap = store.snapshot();
+      expect(snap.asOfSeq).toBe(bus.latestSeq());
+      expect(snap.bootId).toBe(bus.bootId);
+    });
+
+    it('returns one entry per pane with the current metadata + version', () => {
+      store.set('p-1', { label: 'A' }, { workspaceId: 'ws-1' });
+      store.set('p-1', { role: 'r' }, { workspaceId: 'ws-1' });
+      store.set('p-2', { label: 'B' }, { workspaceId: 'ws-2' });
+
+      const snap = store.snapshot();
+      const byPane = new Map(snap.entries.map((e) => [e.paneId, e]));
+      expect(byPane.get('p-1')?.version).toBe(2);
+      expect(byPane.get('p-1')?.metadata.label).toBe('A');
+      expect(byPane.get('p-1')?.metadata.role).toBe('r');
+      expect(byPane.get('p-2')?.version).toBe(1);
+      expect(byPane.get('p-2')?.workspaceId).toBe('ws-2');
+    });
+  });
+
+  // ===========================================================================
+  // Persistence (hydrate / serialize / migrate)
+  // ===========================================================================
+
+  describe('hydrate + serialize + migrate', () => {
+    it('serialize → hydrate roundtrip preserves state across a fresh store', () => {
+      store.set('p-1', { label: 'A', role: 'svc' }, { workspaceId: 'ws-1' });
+      store.set('p-2', { custom: { tier: 'prod' } }, { workspaceId: 'ws-2' });
+      const dump = store.serialize();
+
+      const bus2 = new EventBus();
+      const store2 = new MetadataStore({ eventBus: bus2 });
+      store2.hydrate(dump);
+
+      expect(store2.get('p-1').version).toBe(1);
+      expect(store2.get('p-1').metadata.label).toBe('A');
+      expect(store2.get('p-2').metadata.custom?.tier).toBe('prod');
+    });
+
+    it('serialize drops entries whose metadata has been cleared (compact dumps)', () => {
+      store.set('p-keep', { label: 'K' }, { workspaceId: 'ws-1' });
+      store.set('p-drop', { label: 'D' }, { workspaceId: 'ws-1' });
+      store.clear('p-drop');
+
+      const dump = store.serialize();
+      const paneIds = dump.entries.map((e) => e.paneId);
+      expect(paneIds).toContain('p-keep');
+      expect(paneIds).not.toContain('p-drop');
+    });
+
+    it('migrate is identity at the current schema version', () => {
+      const input: PersistedShape = {
+        schema_version: METADATA_SCHEMA_VERSION,
+        entries: [
+          {
+            paneId: 'p-1',
+            workspaceId: 'ws-1',
+            metadata: { label: 'A' },
+            version: 1,
+          },
+        ],
+      };
+      const out = store.migrate(input, METADATA_SCHEMA_VERSION);
+      expect(out).toBe(input); // identity at current schema
+    });
+
+    it('migrate throws on unknown schema versions', () => {
+      const bogus = { schema_version: 99, entries: [] } as unknown as PersistedShape;
+      expect(() => store.migrate(bogus, METADATA_SCHEMA_VERSION)).toThrow(
+        /unsupported metadata schema_version/,
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Event emission
+  // ===========================================================================
+
+  describe('EventBus emission', () => {
+    it('set emits pane.metadata.changed with version + workspaceId', () => {
+      store.set('p-1', { label: 'A' }, { workspaceId: 'ws-1' });
+      const polled = bus.poll(0);
+      const ev = polled.events.find((e) => e.type === 'pane.metadata.changed');
+      expect(ev).toBeDefined();
+      if (!ev || ev.type !== 'pane.metadata.changed') return;
+      expect(ev.workspaceId).toBe('ws-1');
+      expect(ev.paneId).toBe('p-1');
+      expect(ev.metadata.label).toBe('A');
+      expect(ev.version).toBe(1);
+    });
+
+    it('clear emits pane.metadata.changed with empty metadata + bumped version', () => {
+      store.set('p-1', { label: 'A' }, { workspaceId: 'ws-1' });
+      const before = bus.latestSeq();
+      store.clear('p-1');
+      const polled = bus.poll(before);
+      const ev = polled.events.find((e) => e.type === 'pane.metadata.changed');
+      expect(ev).toBeDefined();
+      if (!ev || ev.type !== 'pane.metadata.changed') return;
+      expect(ev.metadata).toEqual({});
+      expect(ev.version).toBe(2);
+    });
+
+    it('VERSION_CONFLICT does not emit', () => {
+      store.set('p-1', { label: 'A' }, { workspaceId: 'ws-1' });
+      const before = bus.latestSeq();
+      store.set('p-1', { label: 'B' }, { workspaceId: 'ws-1', expectedVersion: 99 });
+      expect(bus.latestSeq()).toBe(before);
+    });
+
+    it('omits event when no workspaceId is known (in-memory commit still happens)', () => {
+      // set without workspaceId AND no prior entry to remember one from
+      const before = bus.latestSeq();
+      const result = store.set('p-orphan', { label: 'Orphan' });
+      expect(result.ok).toBe(true);
+      // No event emitted because the store has no workspaceId to scope it to.
+      expect(bus.latestSeq()).toBe(before);
+      // But the in-memory commit happened.
+      expect(store.get('p-orphan').metadata.label).toBe('Orphan');
+    });
+  });
+});

--- a/src/main/metadata/__tests__/MetadataStore.test.ts
+++ b/src/main/metadata/__tests__/MetadataStore.test.ts
@@ -161,6 +161,30 @@ describe('MetadataStore', () => {
       });                                                // preserved
     });
 
+    it("'replaceShared' silently ignores patch.custom — substrate guarantee against namespace clobber", () => {
+      // A misbehaving (or naive) caller sends shared fields + their own
+      // custom map. The substrate must NOT let that overwrite another
+      // tool's namespaced state — that's the whole point of replaceShared.
+      const result = store.set(
+        'p-1',
+        {
+          label: 'Owned',
+          custom: { 'attacker.steal': 'true' },          // ← attempt to clobber
+        },
+        { mergeMode: 'replaceShared', workspaceId: 'ws-1' },
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.metadata.label).toBe('Owned');
+      // base.custom survives wholesale; patch.custom is dropped.
+      expect(result.metadata.custom).toEqual({
+        'orchestrator.taskId': 'T-1',
+        'qa.status': 'pending',
+      });
+      // attacker key MUST NOT land.
+      expect(result.metadata.custom?.['attacker.steal']).toBeUndefined();
+    });
+
     it('version is bumped on the post-merge shape, regardless of mode', () => {
       // p-1 is at v1 after the beforeEach.
       const replace = store.set('p-1', {}, { mergeMode: 'replace', workspaceId: 'ws-1' });
@@ -272,6 +296,38 @@ describe('MetadataStore', () => {
       expect(() =>
         store.set('p-1', { custom }, { workspaceId: 'ws-1' }),
       ).toThrow(/"custom" exceeds/);
+    });
+
+    it('rejects cumulative merge writes that grow custom past the entry cap', () => {
+      // Each individual patch stays under the cap, but accumulated state
+      // crosses it. The post-merge check must catch this — otherwise the
+      // contract documented in stability.md is meaningless.
+      const half = Math.ceil(PANE_METADATA_CUSTOM_MAX_ENTRIES / 2);
+      const first: Record<string, string> = {};
+      const second: Record<string, string> = {};
+      for (let i = 0; i < half; i++) first[`a${i}`] = 'v';
+      for (let i = 0; i < half + 1; i++) second[`b${i}`] = 'v'; // pushes past cap when merged
+      store.set('p-1', { custom: first }, { workspaceId: 'ws-1' });
+      expect(() =>
+        store.set('p-1', { custom: second }, { workspaceId: 'ws-1' }),
+      ).toThrow(/"custom" exceeds/);
+    });
+
+    it('size cap check runs AFTER updatedAt is appended (boundary safety)', () => {
+      // sanitize() does not enforce the byte cap; the post-merge check does.
+      // The codex P2 #2 fix moved that check to run after updatedAt is appended
+      // so the cap reflects the actual stored shape.
+      //
+      // Envelope arithmetic for {custom:{k:VALUE}}:
+      //   raw overhead         = {"custom":{"k":""}}             → 18 bytes
+      //   updatedAt overhead   = ,"updatedAt":1234567890123       → ~25 bytes (13-digit ts)
+      // We pick value = MAX_BYTES - 30 so that:
+      //   pre-updatedAt JSON size  = MAX_BYTES - 12 (would have passed the old check)
+      //   post-updatedAt JSON size = MAX_BYTES + 13 (must throw with the fix)
+      const value = 'x'.repeat(PANE_METADATA_MAX_BYTES - 30);
+      expect(() =>
+        store.set('p-1', { custom: { k: value } }, { workspaceId: 'ws-1' }),
+      ).toThrow(/exceeds .* bytes/);
     });
 
     it('rejects merged shape exceeding PANE_METADATA_MAX_BYTES', () => {

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -74,6 +74,15 @@ export interface PaneMetadataChangedEvent extends WmuxEventBase {
   type: 'pane.metadata.changed';
   paneId: string;
   metadata: PaneMetadata;
+  /**
+   * Monotonic version assigned by MetadataStore (v2.9.0+). Present when
+   * emitted by the main-process MetadataStore; absent when emitted from
+   * legacy renderer paths (publisher.ts) that pre-date the store.
+   * Subscribers SHOULD ignore events with `version` ≤ a previously seen
+   * value for the same `paneId` (idempotence — see PROTOCOL.md §1.3,
+   * race #2).
+   */
+  version?: number;
 }
 
 /**


### PR DESCRIPTION
> **Stacked on #32.** Review #32 first — this PR adds code on top of the Phase 0 docs (PROTOCOL.md, M0 design doc) that frame what's being implemented here.

## Summary

Phase 1 **M0-a** — the new main-process `MetadataStore` module. Isolated: no call sites changed yet. Handler rewiring (M0-b), paneSlice mirror-only conversion (M0-d), and SessionManager persistence integration (M0-e) land in follow-up PRs stacked on this one.

Builds on RFC #15 (with @alphabeen) — `expectedVersion` and `mergeMode` wire format are first surfaced here, behind the store, before being exposed on the JSON-RPC surface in M0-b.

cc @alphabeen — per your note in #15, tagging when the first M-series PR opens. This PR is the substrate side of the optimistic-concurrency + `mergeMode` design we discussed; M0-b will wire it to the wire format.

Tracks #31.

## Changes

- **`src/main/metadata/MetadataStore.ts`** (~380 LOC) implementing the full contract from `docs/internal/m0-design.md` §2:
  - `get` / `set` / `clear` / `snapshot` / `hydrate` / `serialize` / `migrate` / `onPaneDeleted`
  - per-pane monotonic `version`
  - optimistic concurrency via `expectedVersion`
  - three `mergeMode` semantics: `merge` (default) / `replace` / `replaceShared`
  - validation guards matching the existing `pane.rpc.ts:30` sanitizer
  - EventBus injection point for testability (module-level singleton in production)
- **`src/main/metadata/__tests__/MetadataStore.test.ts`** (~380 LOC, 28 tests):
  - CRUD + version (5)
  - `mergeMode` (4)
  - `expectedVersion` (5)
  - validation guards (4)
  - snapshot envelope (2)
  - persistence roundtrip + schema migration (4)
  - EventBus emission shape (4)
- **`src/shared/events.ts`** — `PaneMetadataChangedEvent.version?` (optional, additive). MetadataStore emissions carry it; legacy `publisher.ts` paths continue to emit without.

## CHANGELOG entry

### Added

- Internal `MetadataStore` module (`src/main/metadata/`) — the main-process authority for `PaneMetadata` (M0-a). Not yet wired to RPC handlers; M0-b lands that.
- Optional `version` field on `pane.metadata.changed` events (emitted only when produced by `MetadataStore`).

### Changed

n/a (no public surface change yet)

### Deprecated

n/a

### Removed

n/a

### Fixed

n/a

### Security

n/a

## Stability tier impact

- [x] Change to an `internal` surface (no contract impact).

The new module is internal-only in this PR. The wire-format additions (`expectedVersion` param on `pane.setMetadata`, `mergeMode` param, JSON-RPC error code `-32001`, `version` on reply / event / `pane.list` entries) land with M0-b. M0-a is the substrate underneath them.

## Substrate contract impact (Substrate 3.0)

- `docs/PROTOCOL.md` §1 (PaneMetadata) — implementation now matches the spec for layered status, namespacing convention (`custom.<tool>.*` deep-merged), `mergeMode` (3 modes), version monotonicity.
- `docs/PROTOCOL.md` §3 (`pane.list` snapshot) — `MetadataStore.snapshot()` returns the `{ asOfSeq, bootId, entries }` envelope; `pane.list` integration is M0-c.
- `docs/internal/m0-design.md` race specs:
  - **#2 return-vs-event idempotence:** `set()` reply and emitted event carry the same `version`. Test: "set reply echoes version that subsequent get reproduces" + "set emits pane.metadata.changed with version".
  - **#4 paneId recycle:** `onPaneDeleted` bumps version but keeps the entry slot. Test: "onPaneDeleted keeps the version counter monotonic for recycled IDs".
  - **#5 concurrent writes:** single-threaded JS guarantees in-task serialization. Documented in the module header.
  - **#1, #3, #6** land with the call-site rewires (M0-b, M0-d, M0-e).

## Test plan

```
npx vitest run src/main/metadata
  → 28/28 pass

npx vitest run
  → 1008/1008 pass (no regression; baseline was 934 → +28 new + a few pre-existing additions)

npx eslint --ext .ts src/main/metadata src/shared/events.ts
  → clean

npx tsc --noEmit -p tsconfig.json
  → clean
```

- [x] Unit tests covering every method on `MetadataStore`.
- [x] Validation rejection tested (label cap, custom entry cap, total-byte cap).
- [x] EventBus emission shape verified, including the no-workspaceId-known fallback (in-memory commit happens but no event fires — matches the design's "skip event when scope unknown" rule).
- [x] Persistence roundtrip with a fresh store.
- [x] Schema-version migration smoke + unknown-version rejection.

Manual / dynamic verification (1000 writes/sec, snapshot under load, etc.) lands with M0-c when the handler integration exists. M0-a is module-level only.

## Related issues / PRs

- Stacked on #32 (Phase 0 docs)
- Tracks #31 (v3.0 milestone)
- Builds on RFC #15 (with @alphabeen) and #18 (external-tooling primitives)
