### PR TITLE
feat(scrollback): v2.8.x → v2.9.0 chopped-dump recovery tool

### DIFF
--- a/docs/upgrade-v2.9.0.md
+++ b/docs/upgrade-v2.9.0.md
@@ -1,0 +1,192 @@
+# Upgrade Guide — v2.9.0 (Substrate 3.0 — Phase 0 + M0)
+
+v2.9.0 ships the wmux Substrate 3.0 foundation along with a hardening
+pass for scrollback persistence and pane input reliability. The
+substrate work (MetadataStore, optimistic concurrency, mergeMode,
+contract documentation) is wire-compatible with v2.8.x and requires no
+user action. The reliability fixes change how scrollback files are
+persisted on disk, and v2.8.x users will see a one-time migration of
+any pre-existing corrupted dumps. This document explains what to
+expect and how to recover content if needed.
+
+대상 독자:
+
+- v2.8.x를 사용 중이고 v2.9.0으로 업그레이드하는 일반 사용자
+- v2.8.x에서 "재부팅 후 일부 패널 스크롤백이 비어 보이는" 증상을 겪은 사용자
+- 디스크에 새로 생기는 `corrupted/` 폴더가 무엇인지 알고 싶은 사용자
+
+---
+
+## 1. What changed
+
+v2.9.0의 사용자 영향 변화는 두 부류다.
+
+**1) 스크롤백 손상 픽스 (P0 layered defense).**
+v2.8.x의 xterm `FitAddon`은 컨테이너가 숨김/0폭 상태일 때 `cols`를 ~2로
+collapse하는 케이스가 있었다. 그 순간 5초마다 일어나는 스크롤백 dump가
+xterm 버퍼를 잡으면 각 행이 1~2글자만 들어간 채로 파일에 저장됐다.
+다음 부팅 때 renderer는 그 chopped 콘텐츠를 새 xterm에 복원해버리고,
+다음 5초 dump가 같은 chopped 상태를 다시 디스크에 적어 — 자기증식
+손상 루프. 시각적으로는 "재부팅하면 스크롤백이 빈 상태로 보임".
+
+v2.9.0은 네 층의 방어를 더해 이 루프를 끊는다.
+
+- dump-time `cols`/`rows`/`offsetWidth` eligibility 가드 — dump 자체를
+  거부하므로 디스크 오염이 시작되지 않는다.
+- 모든 `fit()` 사이트가 컨테이너 가시성 가드를 통과하도록 정렬.
+- IPC `SCROLLBACK_DUMP`에서 한 번 더 시그니처 검증.
+- IPC `SCROLLBACK_LOAD`가 chopped 시그니처 검출 시 격리(`corrupted/`).
+
+**2) 패널 입력 먹통 픽스 (M0 reconcile race).**
+부팅 직후 daemon이 막 연결된 시점에 두 번의 PTY reconcile이 동시에
+달려서 일부 surface가 input-mute로 빠지는 경합이 있었다. 워크스페이스를
+한 번 토글하면 풀리던 증상. v2.9.0은 reconcile에 in-flight 가드를
+넣고, 각 walk마다 workspace snapshot을 다시 읽어 동시 spawn이
+가려지지 않게 했다.
+
+세부는 PR #34 본문과 CHANGELOG를 참고.
+
+---
+
+## 2. New directories on disk
+
+플랫폼별 `{userData}` 경로:
+
+| 플랫폼  | 경로                                              |
+| ------- | ------------------------------------------------- |
+| Windows | `%APPDATA%\wmux\`                                 |
+| macOS   | `~/Library/Application Support/wmux/`             |
+| Linux   | `~/.config/wmux/`                                 |
+
+v2.9.0에서 새로 등장하거나 거동이 바뀌는 항목:
+
+- **`scrollback/{surface}.txt.bak[.{1,2,3}]`** — 5세대 회전 백업.
+  매번 dump가 atomic write로 들어가면서 이전 primary를 `.bak`으로,
+  `.bak`을 `.bak.1`로 미는 식으로 회전한다. 하나의 잘못된 dump가
+  들어와도 최대 4세대 이전까지 살아남는다.
+- **`scrollback/corrupted/{surface}.txt.{timestamp}.bak`** — 격리된
+  손상 파일. v2.8.x에서 chopped 상태로 저장된 dump가 v2.9.0 첫 부팅
+  때 감지되어 여기로 이동한다. 30일 / 폴더당 10파일까지 보관 후
+  자동 정리.
+- **세션 / metadata 파일들의 `.bak` 회전 체인** — 이미 v2.7.x부터
+  존재하던 것으로, v2.9.0에서 scrollback도 같은 보호를 받게 됐다.
+
+---
+
+## 3. First launch after upgrade — what to expect
+
+v2.8.x에서 chopped dump 파일이 디스크에 남아 있던 사용자는 v2.9.0 첫
+부팅에서 다음 시퀀스를 보게 된다.
+
+1. 세션 복원이 각 surface의 스크롤백 파일을 읽으려고 시도한다.
+2. `corruption.ts`의 검출기가 chopped 시그니처 (median 비공백 행 길이
+   ≤ 3자, CRLF 바이트 비율 ≥ 0.3)를 감지한다.
+3. 검출된 파일은 `corrupted/{surface}.txt.{timestamp}.bak`으로
+   이동하고, `.bak` 회전 체인을 한 단계씩 fallback으로 시도한다.
+4. 회전 체인의 모든 슬롯이 chopped이면 `null`이 반환되어 renderer는
+   비어 있는 새 xterm을 띄운다. 그 surface는 "스크롤백이 비어 있는
+   상태"로 시작한다.
+5. 깨끗한 슬롯이 회전 체인 어딘가에 살아 있으면 그게 복원된다.
+
+**중요**: 격리는 데이터를 삭제하지 않는다. 원본 chopped 바이트는
+`corrupted/`에 그대로 보존되어 있어, 필요하면 그 raw 데이터에서
+사람이 읽을 수 있는 텍스트를 추출할 수 있다 (다음 절).
+
+---
+
+## 4. Recovering chopped scrollback from `corrupted/`
+
+`corrupted/`에 들어간 파일들은 cols=2 reflow의 산물이라 사람이
+읽기엔 깨져 보이지만, 단순한 역연산으로 텍스트 콘텐츠는 회수된다.
+저장소에 포함된 마이그레이션 스크립트가 이 작업을 한다.
+
+```sh
+node scripts/recover-scrollback.mjs --verbose
+```
+
+기본 동작:
+
+- 입력: `%APPDATA%\wmux\scrollback\corrupted\` (Windows). 다른
+  플랫폼은 `~/.config/wmux/scrollback/corrupted/`.
+- 출력: `~\wmux-recovered-YYYY-MM-DD\` (홈 디렉토리).
+- 각 격리 파일에 대해:
+  - chopped 시그니처가 맞으면 reverse-reflow로 텍스트 복원 후
+    `.recovered.txt`로 출력 디렉토리에 저장.
+  - 시그니처와 다른 (실제로는 손상되지 않은) 파일은 건너뜀.
+
+옵션:
+
+| 옵션                        | 동작                                                       |
+| --------------------------- | ---------------------------------------------------------- |
+| `-i, --input <dir>`         | 소스 디렉토리 지정                                         |
+| `-o, --output <dir>`        | 출력 디렉토리 지정                                         |
+| `-n, --dry-run`             | 분석만, 파일은 쓰지 않음                                   |
+| `-v, --verbose`             | 파일별 통계 + 첫 80자 미리보기 출력                        |
+| `-h, --help`                | 사용법 표시                                                |
+
+**복원 한계.** 사용자가 실제로 enter 친 줄 경계 중 빈 줄로 분리되지
+않은 것은 다음 줄과 연결돼서 한 줄로 보인다. 텍스트 콘텐츠 자체는
+손실되지 않지만, 원본의 정확한 줄 구조는 근사치다. AI 에이전트
+대화나 명령 출력의 의미는 충분히 추출 가능하다.
+
+**예시.** 원본 chopped 파일이 다음과 같다면:
+
+```
+PS\r\n C\r\n:\\\r\nUs\r\ner\r\ns\\\r\nri\r\nzz\r\n>
+```
+
+복원 결과:
+
+```
+PS C:\Users\rizz>
+```
+
+스크립트는 read-only로 동작한다. `corrupted/` 원본은 절대 수정하지
+않으며, 결과는 별도 출력 디렉토리에 새 파일로만 쓴다.
+
+---
+
+## 5. Rollback
+
+v2.9.0의 디스크 변경은 모두 additive하다 (`corrupted/` 서브디렉토리
+생성 + `.bak.{1,2,3}` 회전 슬롯 추가). v2.8.x로 다운그레이드해도
+기존 파일은 그대로 읽힌다 — v2.8.x는 추가 슬롯을 단순히 무시한다.
+
+다만 `corrupted/` 디렉토리는 v2.8.x가 인식하지 못한다. 다운그레이드
+후에도 디스크에는 남아있지만 wmux는 더 이상 읽거나 정리하지 않으며
+직접 삭제해도 안전하다.
+
+---
+
+## 6. FAQ
+
+**Q. 재부팅 후 일부 패널이 비어 보이는데 정상인가?**
+
+v2.8.x에서 이미 디스크에 저장돼 있던 dump가 chopped 상태였다면,
+v2.9.0 첫 부팅에서 그 파일들은 격리되고 해당 패널은 빈 새 xterm으로
+시작된다. **데이터를 v2.9.0이 버린 게 아니라 v2.8.x 시점에 이미
+chopped 형태로 저장되어 있던 것**을 v2.9.0이 검출만 한 것이다.
+사람이 읽을 수 있는 텍스트로의 회수는 §4 스크립트로 가능.
+
+**Q. `corrupted/` 폴더를 직접 지워도 되나?**
+
+된다. 격리된 파일은 30일 / 폴더당 10파일까지 자동 정리되지만,
+수동 삭제해도 wmux 동작에 영향이 없다. §4의 복원 스크립트를
+돌릴 의향이 있다면 삭제 전에 먼저 실행해두는 편이 좋다.
+
+**Q. v2.9.0 이후 새로 쌓이는 스크롤백도 chopped될 수 있나?**
+
+dump-time eligibility 가드가 cols/rows/offsetWidth를 검사해 dump
+자체가 거부되고, IPC handler가 한 번 더 시그니처 검증을 한다. 또한
+모든 `fit()` 호출 사이트에 컨테이너 가시성 가드가 들어가 있어
+collapse 자체가 잘 일어나지 않는다. 만약 어떤 새로운 경로로 chopped
+파일이 생기더라도 회전 체인 4세대가 살아 있으므로 즉시 fallback
+복구된다.
+
+**Q. 스크롤백 복원이 항상 정확한 줄 구조를 재현하지 않는다는 게
+무슨 의미인가?**
+
+cols=2 reflow는 "줄 바꿈"과 "wrap"을 같은 CRLF로 만든다. 두 빈 줄
+사이에 끼어 있던 명령 출력은 paragraph boundary로 살아남지만, 빈
+줄 없이 연속된 두 명령은 합쳐져 한 줄로 보인다. 텍스트 의미는
+온전하다.

--- a/scripts/__tests__/recover-scrollback.test.mjs
+++ b/scripts/__tests__/recover-scrollback.test.mjs
@@ -1,0 +1,285 @@
+/**
+ * Unit tests for the v2.8.x → v2.9.0 scrollback recovery tool.
+ *
+ * Scope:
+ *   - Detector mirrors `src/main/scrollback/corruption.ts` behaviour
+ *     (flag production v2.8.4 chopped patterns, abstain on clean output
+ *     and on tiny / sparse inputs).
+ *   - Reverse reflow preserves character content of the chopped input
+ *     and converts paragraph-style blank rows into single-newline
+ *     separators.
+ *   - CLI arg parsing handles the documented options + rejects
+ *     unknown flags with a non-zero exit code.
+ *   - End-to-end `processFile` reads a fixture, classifies, recovers,
+ *     and (when `outDir` set + not dryRun) writes the recovered text.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  isLikelyChoppedScrollback,
+  reverseReflowFromCols2,
+  scanContent,
+  processFile,
+  main,
+} from '../recover-scrollback.mjs';
+
+// ── Fixture builders ───────────────────────────────────────────────────────
+
+function colsCollapseFixture(text, charsPerLine = 2, paddingBlankLines = 80) {
+  const out = [];
+  for (let i = 0; i < paddingBlankLines; i++) out.push('');
+  for (let i = 0; i < text.length; i += charsPerLine) {
+    out.push(text.slice(i, i + charsPerLine));
+  }
+  return out.join('\r\n');
+}
+
+// ── Detector parity with production ────────────────────────────────────────
+
+describe('isLikelyChoppedScrollback', () => {
+  it('flags a 2-char-per-line chopped fixture (with padding)', () => {
+    const fx = colsCollapseFixture(
+      'PS C:\\Users\\rizz> claude' +
+        'Accessing workspace:' +
+        'C:\\Users\\rizz' +
+        'Quick safety check: Is this a project you created or trust?' +
+        '(Like your own code, a well-known open source project)',
+      2,
+      80,
+    );
+    expect(isLikelyChoppedScrollback(fx)).toBe(true);
+  });
+
+  it('flags the real production pattern (median=1, mixed max widths)', () => {
+    const lines = [];
+    for (let i = 0; i < 50; i++) lines.push('');
+    for (let i = 0; i < 10; i++) lines.push('this is a 30-char-ish pre-collapse line ' + i);
+    for (let i = 0; i < 5000; i++) lines.push(i % 2 === 0 ? 'a' : 'bc');
+    expect(isLikelyChoppedScrollback(lines.join('\r\n'))).toBe(true);
+  });
+
+  it('does not flag normal mixed-length output', () => {
+    const content = [
+      'PS C:\\Users\\rizz> ls',
+      '',
+      '    Directory: C:\\Users\\rizz',
+      '',
+      'Mode                LastWriteTime         Length Name',
+      '----                -------------         ------ ----',
+      'd-----        2026-05-14 14:30                AppData',
+      'd-----        2026-05-14 10:15                Documents',
+      '-a----        2026-05-14 09:01           1234 example.txt',
+      '',
+      'PS C:\\Users\\rizz> echo "hello world"',
+      'hello world',
+      'PS C:\\Users\\rizz> ',
+    ].join('\r\n');
+    expect(isLikelyChoppedScrollback(content)).toBe(false);
+  });
+
+  it('does not flag short or sparse input', () => {
+    expect(isLikelyChoppedScrollback('')).toBe(false);
+    expect(isLikelyChoppedScrollback('PS> ls\r\n')).toBe(false);
+    const sparse =
+      '\r\n'.repeat(100) + 'PS C:\\Users\\rizz> \r\n' + '\r\n'.repeat(20);
+    expect(isLikelyChoppedScrollback(sparse)).toBe(false);
+  });
+
+  it('does not flag a narrow-pane real session (~20-char lines)', () => {
+    const lines = Array.from({ length: 100 }, (_, i) => `narrow line ${i}!`);
+    expect(isLikelyChoppedScrollback(lines.join('\r\n'))).toBe(false);
+  });
+});
+
+// ── scanContent stats ──────────────────────────────────────────────────────
+
+describe('scanContent', () => {
+  it('returns total/CRLF bytes and per-line lengths', () => {
+    const content = ['abcde', 'fg', 'hijkl'].join('\r\n');
+    const r = scanContent(content);
+    expect(r.totalBytes).toBe(content.length);
+    expect(r.crlfBytes).toBe(4); // 2 separators × 2 bytes
+    expect(r.nonEmptyLengths).toEqual([5, 2, 5]);
+  });
+
+  it('counts a trailing line with no CRLF', () => {
+    const r = scanContent('abc');
+    expect(r.nonEmptyLengths).toEqual([3]);
+    expect(r.crlfBytes).toBe(0);
+  });
+});
+
+// ── Reverse reflow ─────────────────────────────────────────────────────────
+
+describe('reverseReflowFromCols2', () => {
+  it('joins single-char rows into a recovered paragraph', () => {
+    const fx = colsCollapseFixture('CommandNotFoundException', 2, 0);
+    expect(reverseReflowFromCols2(fx)).toBe('CommandNotFoundException');
+  });
+
+  it('treats a blank row as paragraph boundary', () => {
+    // Two paragraphs separated by a blank row. Each paragraph's chopped
+    // rows should fuse into one logical line; the blank row should
+    // survive as exactly one `\n` boundary.
+    const fx =
+      colsCollapseFixture('PSecho hi', 2, 0) +
+      '\r\n\r\n' +
+      colsCollapseFixture('rrooww22', 2, 0);
+    const recovered = reverseReflowFromCols2(fx);
+    const lines = recovered.split('\n');
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    expect(recovered).toContain('PSecho hi');
+    expect(recovered).toContain('rrooww22');
+    // Blank-row separator should survive.
+    expect(recovered.indexOf('PSecho hi')).toBeLessThan(recovered.indexOf('rrooww22'));
+  });
+
+  it('is a pure transform — does not abstain on small clean input', () => {
+    // `reverseReflowFromCols2` is intentionally NOT gated on the
+    // corruption detector. The detector check lives in `processFile`
+    // (so the caller can choose). Asserting raw transform here: a
+    // 3-row input with no blanks collapses to a single concatenated
+    // paragraph.
+    const result = reverseReflowFromCols2('PS> ls\r\nfile1.txt\r\nfile2.txt');
+    expect(result).toBe('PS> lsfile1.txtfile2.txt');
+  });
+
+  it('strips leading blank padding', () => {
+    const fx = '\r\n'.repeat(80) + colsCollapseFixture('Hello', 2, 0);
+    const recovered = reverseReflowFromCols2(fx);
+    expect(recovered.startsWith('Hello') || recovered === 'Hello').toBe(true);
+  });
+});
+
+// ── processFile end-to-end ─────────────────────────────────────────────────
+
+describe('processFile', () => {
+  let tmpDir;
+  let outDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-recover-test-'));
+    outDir = path.join(tmpDir, 'out');
+    fs.mkdirSync(outDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes a recovered file for a chopped input', () => {
+    const src = path.join(tmpDir, 'surface-abc.txt.1700000000000.bak');
+    const fx = colsCollapseFixture(
+      'PS C:\\Users\\rizz> command output here'.repeat(20),
+      2,
+      40,
+    );
+    fs.writeFileSync(src, fx, 'utf-8');
+
+    const result = processFile(src, { outDir });
+    expect(result.corrupt).toBe(true);
+    expect(result.recoveredBytes).toBeGreaterThan(0);
+    expect(result.outPath).toMatch(/surface-abc\.txt\.recovered\.txt$/);
+    expect(fs.existsSync(result.outPath)).toBe(true);
+    const written = fs.readFileSync(result.outPath, 'utf-8');
+    expect(written).toContain('command output here');
+  });
+
+  it('does not write when content is not chopped', () => {
+    const src = path.join(tmpDir, 'surface-clean.txt.1700000000000.bak');
+    const content = Array.from({ length: 30 }, (_, i) => `log line ${i} with some text`).join('\r\n');
+    fs.writeFileSync(src, content, 'utf-8');
+
+    const result = processFile(src, { outDir });
+    expect(result.corrupt).toBe(false);
+    expect(result.outPath).toBeNull();
+    expect(fs.readdirSync(outDir).length).toBe(0);
+  });
+
+  it('honours dry-run (no file written even for corrupt input)', () => {
+    const src = path.join(tmpDir, 'surface-abc.txt.1700000000000.bak');
+    // Need >256 bytes + >20 non-empty lines to trigger the detector.
+    const longText = 'hello world hello world '.repeat(50);
+    fs.writeFileSync(src, colsCollapseFixture(longText, 2, 30), 'utf-8');
+
+    const result = processFile(src, { outDir, dryRun: true });
+    expect(result.corrupt).toBe(true);
+    expect(fs.readdirSync(outDir).length).toBe(0);
+  });
+
+  it('derives output name from quarantined naming convention', () => {
+    const src = path.join(
+      tmpDir,
+      'surface-94241a2a-8c69-4cca-8f62-4d780b6b2b4e.txt.bak.1778754626473.bak',
+    );
+    fs.writeFileSync(src, colsCollapseFixture('a'.repeat(2000), 2, 30), 'utf-8');
+    const result = processFile(src, { outDir });
+    // .bak.1778754626473.bak → .bak (the trailing timestamp suffix stripped)
+    expect(result.outPath).toMatch(
+      /surface-94241a2a-8c69-4cca-8f62-4d780b6b2b4e\.txt\.bak\.recovered\.txt$/,
+    );
+  });
+});
+
+// ── CLI plumbing ───────────────────────────────────────────────────────────
+
+describe('main (CLI)', () => {
+  let logs;
+  let errs;
+  let origLog;
+  let origErr;
+  let origExitCode;
+
+  beforeEach(() => {
+    logs = [];
+    errs = [];
+    origLog = console.log;
+    origErr = console.error;
+    origExitCode = process.exitCode;
+    console.log = (...args) => logs.push(args.join(' '));
+    console.error = (...args) => errs.push(args.join(' '));
+  });
+
+  afterEach(() => {
+    console.log = origLog;
+    console.error = origErr;
+    process.exitCode = origExitCode;
+  });
+
+  it('prints help on --help and does not error', () => {
+    main(['--help']);
+    expect(logs.join('\n')).toMatch(/USAGE/);
+    expect(process.exitCode).not.toBe(2);
+  });
+
+  it('rejects unknown flag with exit code 2', () => {
+    main(['--bogus']);
+    expect(process.exitCode).toBe(2);
+    expect(errs.join('\n')).toMatch(/error:/);
+  });
+
+  it('reports input dir missing with exit code 1', () => {
+    const fake = path.join(os.tmpdir(), 'wmux-recover-does-not-exist-' + Date.now());
+    main(['--input', fake]);
+    expect(process.exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/input dir does not exist/);
+  });
+
+  it('skips writing in dry-run mode', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-recover-cli-test-'));
+    try {
+      const src = path.join(tmpDir, 'surface-x.txt.1700000000000.bak');
+      fs.writeFileSync(src, colsCollapseFixture('helloworld'.repeat(20), 2, 30), 'utf-8');
+      const outDir = path.join(tmpDir, 'out');
+      main(['--input', tmpDir, '--output', outDir, '--dry-run']);
+      expect(fs.existsSync(outDir)).toBe(false); // dry-run skips mkdir
+      expect(logs.join('\n')).toMatch(/CORRUPT/);
+      expect(logs.join('\n')).toMatch(/dry-run/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/recover-scrollback.mjs
+++ b/scripts/recover-scrollback.mjs
@@ -1,7 +1,12 @@
-#!/usr/bin/env node
 // =============================================================================
 // recover-scrollback.mjs — one-shot recovery for v2.8.x → v2.9.0 migration
 // =============================================================================
+//
+// Invoked via `node scripts/recover-scrollback.mjs` (no shebang). Importing
+// a shebang'd ESM module is unreliable under vitest on Windows — the
+// shebang is left in place and Node's ESM parser fails with
+// `SyntaxError: Invalid or unexpected token`. Keep the entry point
+// node-prefixed so the file stays import-safe.
 //
 // Background
 // ----------

--- a/scripts/recover-scrollback.mjs
+++ b/scripts/recover-scrollback.mjs
@@ -1,0 +1,342 @@
+#!/usr/bin/env node
+// =============================================================================
+// recover-scrollback.mjs — one-shot recovery for v2.8.x → v2.9.0 migration
+// =============================================================================
+//
+// Background
+// ----------
+// In wmux v2.8.x the renderer's `serializeTerminalBuffer` could dump the
+// xterm buffer while a FitAddon collapse had reflowed cols to ~2 (hidden
+// container, minimize, layout teardown). The on-disk dump captured that
+// state as a column of single characters separated by CRLF:
+//
+//     PS\r\n C\r\n:\\\r\nUs\r\ner\r\ns\\\r\nri\r\nzz\r\n>
+//
+// v2.9.0 ships a fix that prevents new corruption AND moves any
+// already-corrupt files into `<userData>/wmux/scrollback/corrupted/`
+// on first launch (with full backup chain preserved) so the user does
+// not lose access to the raw bytes. This tool reads those quarantined
+// files and reverse-reflows them back into human-readable text.
+//
+// Heuristic
+// ---------
+// 1. Skip files whose content does NOT match the cols-collapse signature
+//    (median non-empty line length ≤ 3 chars AND CRLF byte ratio ≥ 0.3).
+//    Recovering a non-corrupt file would produce nonsense.
+// 2. For corrupt files:
+//      - Split on `\r\n` into physical rows.
+//      - Empty / whitespace-only rows are paragraph boundaries (they
+//        were genuinely blank rows in xterm).
+//      - Non-empty rows concatenate (no separator — the CRLF between
+//        them was a wrap point, not a real newline).
+//      - Output paragraphs joined with `\n`.
+//
+// Limits
+// ------
+//   - Real newlines that the user typed are mostly recovered if they
+//     happened to leave a blank row between commands; otherwise they
+//     fuse with the following line. The character content is preserved
+//     losslessly; only the exact wrap structure is approximate.
+//   - This tool is read-only against the source dir. It writes to a
+//     separate output dir (default: ~/wmux-recovered-<date>). The
+//     quarantined originals are never modified.
+//
+// CLI
+// ---
+//     node scripts/recover-scrollback.mjs [options]
+//
+// Options:
+//     -i, --input <dir>     Source dir of quarantined files
+//                           (default: %APPDATA%/wmux/scrollback/corrupted/)
+//     -o, --output <dir>    Output dir for recovered .txt files
+//                           (default: ~/wmux-recovered-YYYY-MM-DD)
+//     -n, --dry-run         Analyze and report without writing
+//     -v, --verbose         Per-file stats + preview
+//     -h, --help            Show this help
+// =============================================================================
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { parseArgs } from 'node:util';
+
+// ── Tunables (mirror corruption.ts) ────────────────────────────────────────
+
+/** Files below this byte count are too small to reliably classify. */
+const MIN_CONTENT_BYTES_TO_JUDGE = 256;
+/** Need at least this many non-empty lines for a stable median. */
+const MIN_NONEMPTY_LINES_TO_JUDGE = 20;
+/** Median non-empty line length at or below this triggers the corrupt verdict. */
+const MAX_MEDIAN_NONEMPTY_LEN_FOR_CORRUPT = 3;
+/** CRLF byte ratio at or above this triggers the corrupt verdict. */
+const MIN_CRLF_BYTE_RATIO_FOR_CORRUPT = 0.3;
+
+const CR = 0x0d;
+const LF = 0x0a;
+
+// ── Pure functions (testable) ──────────────────────────────────────────────
+
+/** Single-pass scan returning the stats the verdict heuristic needs. */
+export function scanContent(content) {
+  const totalBytes = content.length;
+  let crlfBytes = 0;
+  const nonEmptyLengths = [];
+  let lineStart = 0;
+  for (let i = 0; i < totalBytes; i++) {
+    const c = content.charCodeAt(i);
+    if (c === CR && i + 1 < totalBytes && content.charCodeAt(i + 1) === LF) {
+      const lineLen = i - lineStart;
+      if (lineLen > 0) nonEmptyLengths.push(lineLen);
+      crlfBytes += 2;
+      i += 1;
+      lineStart = i + 1;
+    } else if (c === LF) {
+      const lineLen = i - lineStart;
+      if (lineLen > 0) nonEmptyLengths.push(lineLen);
+      crlfBytes += 1;
+      lineStart = i + 1;
+    }
+  }
+  if (lineStart < totalBytes) nonEmptyLengths.push(totalBytes - lineStart);
+  return { totalBytes, crlfBytes, nonEmptyLengths };
+}
+
+function medianAscending(sortedAsc) {
+  const n = sortedAsc.length;
+  if (n === 0) return 0;
+  const mid = Math.floor(n / 2);
+  if (n % 2 === 1) return sortedAsc[mid];
+  return (sortedAsc[mid - 1] + sortedAsc[mid]) / 2;
+}
+
+/**
+ * Mirror of `analyzeScrollbackContent` from
+ * `src/main/scrollback/corruption.ts`. Kept in sync by convention; the
+ * algorithm is small and stable. If the production detector is ever
+ * tuned, mirror the change here AND the test fixture below.
+ */
+export function isLikelyChoppedScrollback(content) {
+  if (!content || content.length < MIN_CONTENT_BYTES_TO_JUDGE) return false;
+  const { totalBytes, crlfBytes, nonEmptyLengths } = scanContent(content);
+  if (nonEmptyLengths.length < MIN_NONEMPTY_LINES_TO_JUDGE) return false;
+  const sorted = [...nonEmptyLengths].sort((a, b) => a - b);
+  const median = medianAscending(sorted);
+  const ratio = totalBytes > 0 ? crlfBytes / totalBytes : 0;
+  if (median > MAX_MEDIAN_NONEMPTY_LEN_FOR_CORRUPT) return false;
+  if (ratio < MIN_CRLF_BYTE_RATIO_FOR_CORRUPT) return false;
+  return true;
+}
+
+/**
+ * Reverse-reflow a cols=2 chopped buffer back into readable text.
+ *
+ * Algorithm
+ *   - Split on `\r\n`.
+ *   - Whitespace-only or empty rows are paragraph boundaries (carrying
+ *     at most one blank line of separation into the output).
+ *   - Non-empty rows concatenate with no separator within a paragraph.
+ *   - Paragraphs join with `\n`.
+ *
+ * **Pure transform** — does NOT gate on the corruption detector. Apply
+ * `isLikelyChoppedScrollback(raw)` first when the caller needs the
+ * abstain behaviour (see `processFile` for the file-level wrapper that
+ * does exactly that).
+ */
+export function reverseReflowFromCols2(raw) {
+  const rows = raw.split('\r\n');
+  const paragraphs = [];
+  let current = '';
+  let sawBlank = false;
+
+  for (const row of rows) {
+    if (row.length === 0 || /^\s+$/.test(row)) {
+      if (current.length > 0) {
+        paragraphs.push(current);
+        current = '';
+      }
+      sawBlank = true;
+    } else {
+      if (sawBlank && paragraphs.length > 0) {
+        paragraphs.push(''); // marker for one blank line between paragraphs
+      }
+      sawBlank = false;
+      current += row;
+    }
+  }
+  if (current.length > 0) paragraphs.push(current);
+  return paragraphs.join('\n');
+}
+
+// ── CLI plumbing ───────────────────────────────────────────────────────────
+
+const HELP = `recover-scrollback — reverse-reflow chopped wmux scrollback dumps
+
+USAGE
+    node scripts/recover-scrollback.mjs [options]
+
+OPTIONS
+    -i, --input <dir>     Source dir of quarantined files
+                          (default: %APPDATA%/wmux/scrollback/corrupted)
+    -o, --output <dir>    Output dir for recovered .txt files
+                          (default: ~/wmux-recovered-YYYY-MM-DD)
+    -n, --dry-run         Analyze and report without writing
+    -v, --verbose         Print per-file stats + first 80 chars preview
+    -h, --help            Show this help
+`;
+
+function defaultInputDir() {
+  const appData = process.env.APPDATA;
+  if (appData) return path.join(appData, 'wmux', 'scrollback', 'corrupted');
+  // Linux / macOS — wmux is Windows-only today but be future-friendly.
+  return path.join(os.homedir(), '.config', 'wmux', 'scrollback', 'corrupted');
+}
+
+function defaultOutputDir() {
+  const date = new Date().toISOString().slice(0, 10);
+  return path.join(os.homedir(), `wmux-recovered-${date}`);
+}
+
+function deriveOutputName(quarantineName) {
+  // Quarantined names look like:
+  //   surface-<uuid>.txt.<ts>.bak
+  //   surface-<uuid>.txt.bak.<ts>.bak
+  // Strip the trailing `.<ts>.bak` produced by quarantine, then add .recovered.txt.
+  return (
+    quarantineName.replace(/\.\d+\.bak$/, '') + '.recovered.txt'
+  );
+}
+
+export function processFile(srcPath, { dryRun = false, verbose = false, outDir } = {}) {
+  const raw = fs.readFileSync(srcPath, 'utf-8');
+  const stats = scanContent(raw);
+  const sorted = [...stats.nonEmptyLengths].sort((a, b) => a - b);
+  const median = medianAscending(sorted);
+  const ratio = stats.totalBytes > 0 ? stats.crlfBytes / stats.totalBytes : 0;
+  const corrupt = isLikelyChoppedScrollback(raw);
+
+  let recovered = null;
+  let outPath = null;
+  if (corrupt) {
+    recovered = reverseReflowFromCols2(raw);
+    if (outDir) {
+      outPath = path.join(outDir, deriveOutputName(path.basename(srcPath)));
+      if (!dryRun) fs.writeFileSync(outPath, recovered, 'utf-8');
+    }
+  }
+
+  return {
+    src: srcPath,
+    bytes: stats.totalBytes,
+    nonEmptyLines: stats.nonEmptyLengths.length,
+    median,
+    crlfRatio: ratio,
+    corrupt,
+    recoveredBytes: recovered ? recovered.length : 0,
+    outPath,
+    preview: recovered ? recovered.slice(0, 80).replace(/\n/g, ' / ') : null,
+  };
+}
+
+function formatReport(rows, verbose) {
+  const lines = [];
+  for (const r of rows) {
+    const base = path.basename(r.src);
+    if (r.corrupt) {
+      lines.push(
+        `  CORRUPT  ${base.padEnd(60)} ${String(r.bytes).padStart(6)}B → ${String(r.recoveredBytes).padStart(5)}B${r.outPath ? '  → ' + r.outPath : ''}`,
+      );
+    } else {
+      lines.push(
+        `  SKIP     ${base.padEnd(60)} ${String(r.bytes).padStart(6)}B  (median=${r.median}, crlfRatio=${r.crlfRatio.toFixed(3)})`,
+      );
+    }
+    if (verbose && r.corrupt && r.preview) {
+      lines.push(`           preview: ${r.preview}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function parseCliArgs(argv) {
+  return parseArgs({
+    args: argv,
+    options: {
+      input: { type: 'string', short: 'i' },
+      output: { type: 'string', short: 'o' },
+      'dry-run': { type: 'boolean', short: 'n' },
+      verbose: { type: 'boolean', short: 'v' },
+      help: { type: 'boolean', short: 'h' },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+}
+
+export function main(argv = process.argv.slice(2)) {
+  let parsed;
+  try {
+    parsed = parseCliArgs(argv);
+  } catch (err) {
+    console.error(`error: ${err.message}\n`);
+    console.error(HELP);
+    process.exitCode = 2;
+    return;
+  }
+
+  if (parsed.values.help) {
+    console.log(HELP);
+    return;
+  }
+
+  const inputDir = parsed.values.input ?? defaultInputDir();
+  const outputDir = parsed.values.output ?? defaultOutputDir();
+  const dryRun = parsed.values['dry-run'] ?? false;
+  const verbose = parsed.values.verbose ?? false;
+
+  if (!fs.existsSync(inputDir)) {
+    console.error(`error: input dir does not exist: ${inputDir}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const entries = fs.readdirSync(inputDir).filter((f) => f.endsWith('.bak'));
+  if (entries.length === 0) {
+    console.log(`No quarantined files found in ${inputDir}`);
+    return;
+  }
+
+  if (!dryRun) fs.mkdirSync(outputDir, { recursive: true });
+
+  console.log(`Source: ${inputDir}`);
+  console.log(`Output: ${dryRun ? '(dry-run, nothing written)' : outputDir}`);
+  console.log(`Files:  ${entries.length}\n`);
+
+  const results = [];
+  for (const name of entries) {
+    const src = path.join(inputDir, name);
+    const result = processFile(src, {
+      dryRun,
+      verbose,
+      outDir: dryRun ? null : outputDir,
+    });
+    results.push(result);
+  }
+
+  console.log(formatReport(results, verbose));
+
+  const corruptCount = results.filter((r) => r.corrupt).length;
+  const skipCount = results.length - corruptCount;
+  console.log('');
+  console.log(`Done — ${corruptCount} recovered, ${skipCount} skipped.`);
+  if (!dryRun && corruptCount > 0) {
+    console.log(`Open ${outputDir} to read the recovered text.`);
+  }
+}
+
+// Run as CLI only when invoked directly.
+const invokedDirectly =
+  import.meta.url === `file://${process.argv[1]}` ||
+  import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`;
+if (invokedDirectly) {
+  main();
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,13 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['src/**/__tests__/**/*.test.{ts,tsx}'],
+    include: [
+      'src/**/__tests__/**/*.test.{ts,tsx}',
+      // Operational scripts (migration tooling) keep their tests
+      // alongside the source so the algorithm and the test fixture stay
+      // in lockstep. Pure ESM (no TS / no Vite transform required).
+      'scripts/__tests__/**/*.test.mjs',
+    ],
     environment: 'node',
   },
 });


### PR DESCRIPTION
## Summary

Follow-up to #34. Ships the migration tool for v2.8.x users whose pre-existing chopped scrollback dumps got quarantined into `userData/wmux/scrollback/corrupted/` on first v2.9.0 launch. Reverse-reflows the chopped bytes back into human-readable text. Read-only against the source dir; writes recovered `.txt` files to a separate output dir.

## What this PR ships

- **`scripts/recover-scrollback.mjs`** — ESM CLI with `node:util` `parseArgs`. Defaults to the Windows quarantine path; `-i` / `-o` overrides for other layouts. `-n` dry-run + `-v` verbose for sanity checks before committing to a recovery output dir. Pure-JS so users do not need `tsx` or a build step.
- **`scripts/__tests__/recover-scrollback.test.mjs`** — 19 unit tests covering:
  - detector parity with `src/main/scrollback/corruption.ts` (flag production v2.8.4 patterns, abstain on clean / sparse / narrow-pane / single-long-line inputs),
  - the pure reverse-reflow transform (paragraph-boundary semantics, leading blank-padding strip, pass-through behaviour on clean input),
  - `processFile` end-to-end against tmpfs fixtures (writes recovered file, derives output name from quarantine convention, honours `--dry-run`),
  - CLI arg plumbing (`--help` / unknown flag / missing dir / dry-run skip).
- **`docs/upgrade-v2.9.0.md`** — user-facing migration guide (Korean). What `corrupted/` is, what to expect on first launch after upgrade, how to run the recovery script, recovery limits, FAQ, rollback semantics.
- **`vitest.config.ts`** — include `scripts/__tests__/**/*.test.mjs` so operational tooling stays under the same test runner.

## Recovery algorithm

Detector parity with `src/main/scrollback/corruption.ts` is by convention — `isLikelyChoppedScrollback` and the `MIN_*` / `MAX_*` thresholds are duplicated in `scripts/recover-scrollback.mjs` to keep the script standalone (no TS compile step, no `tsx` dependency for users). The algorithm is small and stable; a refactor would update both call-sites + the test fixture together.

The reverse-reflow itself is a small pure transform:

1. Split on `\r\n` into physical rows.
2. Empty / whitespace-only rows are paragraph boundaries (they were genuinely blank rows in xterm).
3. Non-empty rows concat with no separator within a paragraph (the CRLF between them was a wrap point, not a newline).
4. Join paragraphs with `\n`.

Character content is preserved losslessly; the exact wrap structure of the pre-collapse output is approximate. Real enter-keys that the user typed survive when they happened to leave a blank row in the buffer; otherwise they fuse with the following line.

## Verification

Tests:

```
npx vitest run scripts/__tests__/recover-scrollback.test.mjs
  → 19/19 pass
```

Dogfood against the actual `corrupted/` snapshot from production v2.8.4 (10 quarantined files):

```
$ node scripts/recover-scrollback.mjs --dry-run --verbose
Files:  10
  CORRUPT  surface-3e3c322d-…  34895B → 15471B
    preview: ommandNotFoundException /  / PS C:\Users\rizz> /  / dd : 'd' 용어가 cmdlet, 함수, 스크립트 ...
  CORRUPT  surface-4b432716-…   6916B →  2694B
    preview: PS C:\Users\rizz> claude /  / ───────── Accessing workspace: /  /  C
  CORRUPT  surface-d70569e4-…  10714B →  4583B
    preview: PS /  / C:\Users\rizz> /  / claude /  / ───── Accessing workspace ...
  CORRUPT  surface-dcf3ef9f-…   5032B →  2144B
    preview: PS C:\Users\rizz> claude --dangerously-skip-permissions /  / ───
  CORRUPT  surface-307b03ad-…   1123B →   267B
    preview: PS C:\Users\rizz>  /  / PS C:\Users\rizz>  /  / PS C:\Users\rizz> ...
```

Korean PowerShell error message preserved, `claude` invocation + Accessing-workspace banner readable, prompt-only panes condensed correctly.

## CHANGELOG entry

### Added

- `scripts/recover-scrollback.mjs` — read-only migration CLI that reverse-reflows quarantined chopped scrollback dumps. See `docs/upgrade-v2.9.0.md` for usage.
- `docs/upgrade-v2.9.0.md` — v2.8.x → v2.9.0 migration guide covering the new `corrupted/` subdirectory, recovery script usage, FAQ, and rollback notes.

### Changed

- `vitest.config.ts` now includes `scripts/__tests__/**/*.test.mjs` so operational scripts can carry tests alongside the source.

## Stability tier impact

- [x] Tooling-only change. No user-data layout change, no IPC / RPC / MCP surface change. The `corrupted/` directory it reads was already created by #34.

## Related

- Follows #34 (Substrate 3.0 — Phase 0 + M0)
- Closes the "v2.8.x migration" carveout noted in #34's Known Limitations