### PR TITLE
fix(paste): repair chronic partial-paste truncation across all input paths

### DIFF
--- a/src/main/ipc/__tests__/pty.handler.oversize-segment.test.ts
+++ b/src/main/ipc/__tests__/pty.handler.oversize-segment.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Regression test for the chronic "front of paste disappears" bug.
+ *
+ * Symptom (reported repeatedly across releases, finally diagnosed v2.9.1):
+ *   Pasting multi-line text into a PTY pane lost the leading portion of
+ *   the paste — typically the first few lines vanished and the remainder
+ *   appeared on a fresh prompt. Right-click paste and Shift+Insert paste
+ *   were also affected. The corruption was non-deterministic and worse on
+ *   PowerShell / Claude Code TUI panes.
+ *
+ * Root cause:
+ *   Three compounding bugs in the renderer paste pipeline, plus one in
+ *   main. The main-side bug — the only one this test guards — was that
+ *   `pty:write` silently dropped any payload over 100KB:
+ *
+ *     if (data.length > 100_000) {
+ *       console.warn(...);
+ *       return;   // ← silent drop, renderer never knows
+ *     }
+ *
+ *   Renderer-side chunking (`clipboardChunk.ts`) kept normal paste under
+ *   the limit, but any code path that bypassed the chunker — drag-drop
+ *   joins, command palette replay of pasted history, xterm's native
+ *   paste path via `terminal.onData`, future MCP write paths — could
+ *   hit the silent drop and lose user data. The renderer used
+ *   `ipcRenderer.send` (fire-and-forget), so there was no error surfaced
+ *   either.
+ *
+ * Fix:
+ *   Main now segments oversize payloads locally and forwards every byte.
+ *   The 100KB threshold becomes a "warn-and-segment" boundary, not a
+ *   drop boundary. A separate 10MB hard limit guards against true
+ *   denial-of-service payloads (those still get refused, but logged
+ *   loudly via console.error so the caller is visible). Renderer
+ *   chunking remains the primary path; main-side segmentation is
+ *   defense-in-depth for callers that bypass it.
+ *
+ * This test is structural: it scans `pty.handler.ts` and fails if a
+ * future refactor reintroduces the silent drop. Behavioral coverage of
+ * the segment math itself lives in `clipboardChunk.test.ts`
+ * (`splitSurrogateSafe`); main and renderer share the same surrogate-
+ * safety invariant, but the runtime path is hard to exercise without a
+ * mocked DaemonClient + PTYManager.
+ */
+describe('pty.handler PTY_WRITE oversize segmentation (paste-truncation fix)', () => {
+  const handlerPath = path.join(__dirname, '..', 'handlers', 'pty.handler.ts');
+  const source = fs.readFileSync(handlerPath, 'utf-8');
+
+  /**
+   * Narrow to the PTY_WRITE handler region so assertions don't match
+   * unrelated text elsewhere in the file (e.g. similarly-named PTY_RESIZE
+   * retry constants, comments referencing prior fixes).
+   */
+  function writeBlock(): string {
+    const match = source.match(
+      /\/\/\s*pty:write[\s\S]*?ipcMain\.removeHandler\(IPC\.PTY_RESIZE\)/,
+    );
+    if (!match) {
+      throw new Error(
+        'pty:write handler region not found in pty.handler.ts. ' +
+          'If the file layout changed, update the regex above before assuming ' +
+          'the segmentation logic is gone.',
+      );
+    }
+    return match[0];
+  }
+
+  it('declares the segmentation constants at module scope', () => {
+    // If this fires, a future change removed or renamed the constants.
+    // Without them the handler reverts to silent drops on oversize
+    // writes — the exact regression that caused "front of paste
+    // disappears" across multiple releases.
+    expect(source).toMatch(/const\s+PTY_WRITE_BACKSTOP\s*=\s*100_?000\b/);
+    expect(source).toMatch(/const\s+PTY_WRITE_BACKSTOP_CHUNK_SIZE\s*=\s*8_?192\b/);
+    expect(source).toMatch(/const\s+PTY_WRITE_HARD_LIMIT\s*=\s*10_?000_?000\b/);
+  });
+
+  it('defines a segmentOversize helper that returns chunks instead of dropping', () => {
+    expect(source).toMatch(/function\s+segmentOversize\s*\(/);
+    // The helper must produce an array — single-item for payloads at or
+    // under the backstop, multi-item for oversize. Returning `void` or
+    // `undefined` would mean we dropped data.
+    expect(source).toMatch(/function\s+segmentOversize[\s\S]+?return\s+out\s*;/);
+    // And the short-circuit return for under-backstop payloads must
+    // also return the data as a single-element array — not drop it.
+    expect(source).toMatch(/return\s+\[data\]/);
+  });
+
+  it('segmentOversize avoids splitting UTF-16 surrogate pairs', () => {
+    // Surrogate-safe boundary backoff: if the last code unit in a chunk
+    // is a high surrogate (0xD800-0xDBFF) AND there is more data after,
+    // back the boundary off by one so the pair stays whole. Without this
+    // an emoji at the boundary turns into U+FFFD on the wire — visually
+    // indistinguishable from "the paste lost characters".
+    expect(source).toMatch(/0xd800/i);
+    expect(source).toMatch(/0xdbff/i);
+  });
+
+  it('local-mode handler segments oversize payloads instead of dropping', () => {
+    const block = writeBlock();
+    // The local-mode path (no daemon) must call segmentOversize and
+    // iterate. A bare `if (data.length > 100_000) return;` shape would
+    // re-introduce the silent drop.
+    expect(block).toMatch(/segmentOversize\(data\)/);
+    // No early return on the backstop length any more — only on the
+    // hard limit and on the type guard.
+    expect(block).not.toMatch(/data\.length\s*>\s*100_?000\s*\)\s*\{\s*console\.warn[\s\S]{0,200}return;/);
+  });
+
+  it('daemon-mode handler segments oversize payloads instead of dropping', () => {
+    const block = writeBlock();
+    // The daemon-mode branch (writeToSession) must also segment — it was
+    // the path taken when running with the v2.9.0 daemon, so a fix that
+    // only covered local-mode would still leak the bug in production.
+    expect(block).toMatch(/daemonClient\.writeToSession\(id,\s*sanitizePtyText\(segment\)\)/);
+  });
+
+  it('warns on oversize but does not drop until the hard limit', () => {
+    const block = writeBlock();
+    // The backstop should produce a warn line — devs need to know that
+    // a renderer path is bypassing chunking — but the data still flows
+    // through segmentOversize. The hard limit error message must use
+    // console.error (louder than warn) since that genuinely drops data.
+    expect(block).toMatch(/console\.warn\([^)]*oversize payload/);
+    expect(block).toMatch(/console\.error\([^)]*hard limit/);
+  });
+
+  it('hard-limit guard refuses payloads above PTY_WRITE_HARD_LIMIT', () => {
+    const block = writeBlock();
+    // The 10MB ceiling is a denial-of-service guard, not a paste guard.
+    // It must still drop (and log loudly) — keeping it lets the handler
+    // resist a misbehaving MCP or bug that loops a write call.
+    expect(block).toMatch(/data\.length\s*>\s*PTY_WRITE_HARD_LIMIT/);
+  });
+
+  it('preserves user-write marker so idle suppression still fires', () => {
+    const block = writeBlock();
+    // markUserWrite must run for every accepted write — the idle
+    // notification suppression (see idleSuppression.ts) depends on
+    // this stamp to avoid firing "task may have finished" while the
+    // user is actively typing/pasting. If a future refactor moves
+    // markUserWrite into the segmentation loop or skips it for
+    // oversize paths, idle notifications regress.
+    expect(block).toMatch(/markUserWrite\(id\)/);
+  });
+});

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -234,6 +234,36 @@ export function registerPTYHandlers(
   // to the screen), so they show up to ActivityMonitor as agent output.
   // Mark the user-write timestamp so the idle fallback suppresses itself
   // while the user is typing (see idleSuppression.ts).
+  //
+  // Oversize backstop (defense-in-depth): the renderer chunks paste
+  // payloads into PTY_WRITE_BACKSTOP_CHUNK_SIZE-byte segments before
+  // sending (`src/renderer/utils/clipboardChunk.ts`), so normal callers
+  // never exceed PTY_WRITE_BACKSTOP. If a future code path or external
+  // tooling slips a larger write through, we now split it locally
+  // rather than silently dropping — silent drops were the root cause
+  // of the chronic "front of paste disappears" regression. The warn
+  // log surfaces the caller so it can be fixed at the source.
+  const PTY_WRITE_BACKSTOP = 100_000;
+  const PTY_WRITE_BACKSTOP_CHUNK_SIZE = 8_192;
+  const PTY_WRITE_HARD_LIMIT = 10_000_000; // 10 MB — true denial-of-service guard
+
+  /** Split an oversize payload into safe segments without dropping any data. */
+  function segmentOversize(data: string): string[] {
+    if (data.length <= PTY_WRITE_BACKSTOP) return [data];
+    const out: string[] = [];
+    for (let i = 0; i < data.length; i += PTY_WRITE_BACKSTOP_CHUNK_SIZE) {
+      // Avoid splitting a UTF-16 surrogate pair at the boundary so the
+      // shell never sees a lone surrogate (would render as U+FFFD).
+      let end = Math.min(i + PTY_WRITE_BACKSTOP_CHUNK_SIZE, data.length);
+      if (end < data.length) {
+        const last = data.charCodeAt(end - 1);
+        if (last >= 0xd800 && last <= 0xdbff) end -= 1;
+      }
+      out.push(data.slice(i, end));
+    }
+    return out;
+  }
+
   ipcMain.removeAllListeners(IPC.PTY_WRITE);
   if (useDaemon && daemonClient) {
     // Per-session diagnostic: log the first dropped write so silent
@@ -243,13 +273,24 @@ export function registerPTYHandlers(
     const writeDropLogged = new Set<string>();
     const onPtyWrite = (_event: Electron.IpcMainEvent, id: string, data: string): void => {
       if (typeof data !== 'string') return;
-      if (data.length > 100_000) {
-        console.warn(`[PTY_WRITE] dropped oversize write: ${data.length} chars (limit 100_000). This is a backstop; renderer should chunk.`);
-        return; // prevent mega-writes
+      if (data.length > PTY_WRITE_HARD_LIMIT) {
+        console.error(`[PTY_WRITE] refused payload exceeding hard limit: ${data.length} chars > ${PTY_WRITE_HARD_LIMIT}. Caller must fix.`);
+        return;
+      }
+      if (data.length > PTY_WRITE_BACKSTOP) {
+        console.warn(`[PTY_WRITE] oversize payload ${data.length} chars > ${PTY_WRITE_BACKSTOP}; segmenting locally. Renderer should chunk at the source.`);
       }
       markUserWrite(id);
-      const delivered = daemonClient.writeToSession(id, sanitizePtyText(data));
-      if (!delivered) {
+      const segments = segmentOversize(data);
+      let allDelivered = true;
+      for (const segment of segments) {
+        const delivered = daemonClient.writeToSession(id, sanitizePtyText(segment));
+        if (!delivered) {
+          allDelivered = false;
+          break;
+        }
+      }
+      if (!allDelivered) {
         if (!writeDropLogged.has(id)) {
           writeDropLogged.add(id);
           console.warn(`[PTY_WRITE] drop sessionId=${id} reason=no-live-session-pipe (first occurrence; suppressing further logs for this id until next successful write)`);
@@ -263,12 +304,18 @@ export function registerPTYHandlers(
     const onPtyWrite = (_event: Electron.IpcMainEvent, id: string, data: string): void => {
       if (!ptyManager.get(id)) return;
       if (typeof data !== 'string') return;
-      if (data.length > 100_000) {
-        console.warn(`[PTY_WRITE] dropped oversize write: ${data.length} chars (limit 100_000). This is a backstop; renderer should chunk.`);
+      if (data.length > PTY_WRITE_HARD_LIMIT) {
+        console.error(`[PTY_WRITE] refused payload exceeding hard limit: ${data.length} chars > ${PTY_WRITE_HARD_LIMIT}. Caller must fix.`);
         return;
       }
+      if (data.length > PTY_WRITE_BACKSTOP) {
+        console.warn(`[PTY_WRITE] oversize payload ${data.length} chars > ${PTY_WRITE_BACKSTOP}; segmenting locally. Renderer should chunk at the source.`);
+      }
       markUserWrite(id);
-      ptyManager.write(id, sanitizePtyText(data));
+      const segments = segmentOversize(data);
+      for (const segment of segments) {
+        ptyManager.write(id, sanitizePtyText(segment));
+      }
     };
     ipcMain.on(IPC.PTY_WRITE, onPtyWrite);
   }

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -31,6 +31,7 @@ import { isFileDrag } from '../../../shared/dragDrop';
 import { terminalRegistry } from '../../hooks/useTerminal';
 import { withDefaultShell } from '../../utils/ptyCreateOptions';
 import { serializeTerminalBuffer } from '../../utils/scrollbackDump';
+import { pastePtyChunked } from '../../utils/clipboardChunk';
 
 /** Map shell executable path to a human-readable display name. */
 function shellDisplayName(shellPath: string): string {
@@ -228,7 +229,19 @@ export default function AppLayout() {
       if (!activeSurface || activeSurface.surfaceType === 'browser') return;
 
       const text = paths.map((p) => (p.includes(' ') ? `"${p}"` : p)).join(' ');
-      window.electronAPI.pty.write(activeSurface.ptyId, text);
+      // Route the joined path string through the paste chunker. Single-file
+      // drops fit easily in one write, but a multi-file drop with long
+      // Windows paths (UNC, OneDrive, long-form Program Files) can blow
+      // through the main process's 100KB silent backstop. Chunking also
+      // paces the IPC writes so the conpty input pipe drains between
+      // sends. No bracketed-paste markers — drag-drop targets the prompt,
+      // not a paste-aware foreground app.
+      const surfacePtyId = activeSurface.ptyId;
+      void pastePtyChunked(
+        (d) => window.electronAPI.pty.write(surfacePtyId, d),
+        text,
+        null,
+      ).catch((err) => console.error('[wmux:drag-drop] chunk write failed:', err));
     });
 
     // Visual drag overlay

--- a/src/renderer/components/Palette/CommandPalette.tsx
+++ b/src/renderer/components/Palette/CommandPalette.tsx
@@ -4,6 +4,7 @@ import PaletteItem, { type PaletteItemData, type PaletteCategory } from './Palet
 import { useT } from '../../hooks/useT';
 import { useIpc } from '../../hooks/useIpc';
 import { withDefaultShell } from '../../utils/ptyCreateOptions';
+import { pastePtyChunked } from '../../utils/clipboardChunk';
 
 // ---------------------------------------------------------------------------
 // SVG Icons (inline, no external dependency)
@@ -431,7 +432,18 @@ export default function CommandPalette() {
           if (pane) {
             const surface = pane.surfaces.find((s) => s.id === pane.activeSurfaceId);
             if (surface?.ptyId) {
-              window.electronAPI.pty.write(surface.ptyId, cmd);
+              // Route through the paste chunker. Recent commands originate
+              // from the user's `inputBuffer`, which accumulates raw paste
+              // payloads (`useTerminal.ts: terminal.onData`) — so a
+              // previously-pasted multi-line snippet can be re-emitted
+              // here. Chunking normalizes CRLF, paces IPC, and keeps the
+              // payload under the main process's 100KB silent backstop.
+              const surfacePtyId = surface.ptyId;
+              void pastePtyChunked(
+                (d) => window.electronAPI.pty.write(surfacePtyId, d),
+                cmd,
+                null,
+              ).catch((err) => console.error('[wmux:palette] chunk write failed:', err));
             }
           }
           togglePalette();

--- a/src/renderer/components/Terminal/Terminal.tsx
+++ b/src/renderer/components/Terminal/Terminal.tsx
@@ -164,9 +164,11 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
       // paste sequences so apps like Claude Code see it as a single paste.
       const text = await window.clipboardAPI.readText();
       if (text) {
-        // Centralized 4096-byte chunking helper avoids the main process's
-        // 100KB pty.write silent backstop when pasting large blobs.
-        pastePtyChunked((d) => window.electronAPI.pty.write(ptyId, d), text, modes ?? null);
+        // Async chunked write: paces the IPC queue so the conpty input
+        // pipe drains between chunks, normalizes line endings to \r so
+        // PowerShell does not execute mid-paste, and keeps surrogate
+        // pairs whole across chunk boundaries.
+        await pastePtyChunked((d) => window.electronAPI.pty.write(ptyId, d), text, modes ?? null);
         return;
       }
 

--- a/src/renderer/hooks/useKeyboard.ts
+++ b/src/renderer/hooks/useKeyboard.ts
@@ -5,6 +5,7 @@ import { terminalRegistry } from './useTerminal';
 import { t } from '../i18n';
 import { withDefaultShell } from '../utils/ptyCreateOptions';
 import { useIpc } from './useIpc';
+import { pastePtyChunked } from '../utils/clipboardChunk';
 
 // Lightweight bookmark toast — reuses the same DOM element pattern as showCopyToast
 let bookmarkToastTimer: ReturnType<typeof setTimeout> | null = null;
@@ -585,7 +586,18 @@ export function useKeyboard() {
               const surface = leaf.surfaces.find((s) => s.id === leaf.activeSurfaceId);
               if (surface?.ptyId) {
                 const text = match.sendEnter ? match.command + '\r' : match.command;
-                window.electronAPI.pty.write(surface.ptyId, text);
+                // Route through the paste chunker. User-authored keybinding
+                // commands can contain multi-line shell snippets pasted into
+                // the settings field; chunking normalizes CRLF, paces IPC,
+                // and keeps the payload under the 100KB backstop. The
+                // trailing `\r` from `sendEnter` is preserved by the
+                // normalizer (lone `\r` is left alone).
+                const surfacePtyId = surface.ptyId;
+                void pastePtyChunked(
+                  (d) => window.electronAPI.pty.write(surfacePtyId, d),
+                  text,
+                  null,
+                ).catch((err) => console.error('[wmux:keybinding] chunk write failed:', err));
               }
             }
           }

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -8,7 +8,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import { useStore } from '../stores';
 import { t } from '../i18n';
 import { XTERM_THEMES, extractXtermColors, type ThemeId, type BuiltinThemeId } from '../themes';
-import { pastePtyChunked } from '../utils/clipboardChunk';
+import { pastePtyChunked, chunkOnDataIfNeeded } from '../utils/clipboardChunk';
 import { runCopyWithFeedback } from '../utils/copyWithFeedback';
 import { shouldFitWhilePreservingSelection } from '../utils/fitGuard';
 import { createAutoSelectionCopy } from '../utils/autoSelectionCopy';
@@ -328,12 +328,12 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           // Try text first
           const text = await window.clipboardAPI.readText();
           if (text) {
-            // Chunk into 4096-byte writes to evade main's 100KB silent
-            // backstop on pty.write. Bracketed paste markers (when the
-            // foreground app enabled them) wrap the entire stream so apps
-            // still see one logical paste regardless of chunk count.
+            // Async chunked write — paces IPC, normalizes CRLF to \r so
+            // PowerShell does not execute mid-paste, keeps surrogate pairs
+            // whole, and wraps the body in bracketed-paste markers when
+            // the foreground app enabled DECSET 2004.
             const modes = (terminal as unknown as { modes?: { bracketedPasteMode?: boolean } }).modes;
-            pastePtyChunked((d) => window.electronAPI.pty.write(ptyId, d), text, modes);
+            await pastePtyChunked((d) => window.electronAPI.pty.write(ptyId, d), text, modes);
             return;
           }
           // No text — check for image, save to temp file, paste path
@@ -369,7 +369,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           const text = await window.clipboardAPI.readText();
           if (text) {
             const modes = (terminal as unknown as { modes?: { bracketedPasteMode?: boolean } }).modes;
-            pastePtyChunked((d) => window.electronAPI.pty.write(ptyId, d), text, modes);
+            await pastePtyChunked((d) => window.electronAPI.pty.write(ptyId, d), text, modes);
             return;
           }
           if (window.clipboardAPI.readImage) {
@@ -437,9 +437,12 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         // single paste rather than streamed character-by-character.
         const text = await window.clipboardAPI.readText();
         if (text) {
-          // Centralized 4096-byte chunking — keeps us under the main
-          // process's 100KB silent backstop on pty.write.
-          pastePtyChunked((d) => window.electronAPI.pty.write(ptyId, d), text, modes);
+          // Async chunked write: paces the IPC queue so the conpty input
+          // pipe drains between chunks, normalizes line endings to \r so
+          // PowerShell does not execute mid-paste, keeps surrogate pairs
+          // whole, and wraps the body in bracketed-paste markers when
+          // the foreground app enabled DECSET 2004.
+          await pastePtyChunked((d) => window.electronAPI.pty.write(ptyId, d), text, modes);
           return;
         }
 
@@ -460,10 +463,23 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
 
     // Drag-and-drop is handled globally in preload via webUtils.getPathForFile()
 
-    // Forward user input to PTY and track commands for palette history
+    // Forward user input to PTY and track commands for palette history.
+    //
+    // `onData` is the catch-all for input that did not flow through our
+    // explicit paste handlers — Shift+Insert, OS menu paste, middle-click
+    // paste on Linux/macOS, IME commits, and normal keystrokes all land
+    // here. Normal keystrokes are 1-4 code units and ship as a single
+    // IPC write; anything larger is almost certainly an xterm-native
+    // paste that bypassed our chunker, so route it through
+    // `chunkOnDataIfNeeded` to pace the IPC queue and avoid the 100KB
+    // silent backstop in `pty.handler.ts`. The helper preserves xterm's
+    // own bracketed-paste markers if it pre-wrapped the payload.
     let inputBuffer = '';
     terminal.onData((data) => {
-      window.electronAPI.pty.write(ptyId, data);
+      void chunkOnDataIfNeeded(
+        (d) => window.electronAPI.pty.write(ptyId, d),
+        data,
+      ).catch((err) => console.error('[wmux:onData] chunk write failed:', err));
 
       if (data === '\r' || data === '\n') {
         const cmd = inputBuffer.trim();

--- a/src/renderer/utils/__tests__/clipboardChunk.test.ts
+++ b/src/renderer/utils/__tests__/clipboardChunk.test.ts
@@ -1,37 +1,138 @@
 /**
- * Tests for `pastePtyChunked` — the renderer-side guard that breaks paste
- * payloads into 4096-byte writes so they survive main's 100KB silent
- * backstop on `pty.write`.
+ * Tests for the paste-pipeline helpers.
+ *
+ * `pastePtyChunked` is the renderer-side guard that streams paste payloads
+ * to the PTY in bounded chunks with CRLF normalization, UTF-16 surrogate
+ * safety, and event-loop pacing — the three properties that together
+ * prevent the "front of paste disappears" / "emoji breaks" / "tail
+ * truncated under load" symptoms documented in the module header.
  *
  * Pure-function tests run in vitest's default `node` environment.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { pastePtyChunked, PTY_PASTE_CHUNK_SIZE } from '../clipboardChunk';
+import {
+  pastePtyChunked,
+  chunkOnDataIfNeeded,
+  normalizePasteText,
+  splitSurrogateSafe,
+  PTY_PASTE_CHUNK_SIZE,
+  ONDATA_CHUNK_THRESHOLD,
+} from '../clipboardChunk';
+
+describe('normalizePasteText', () => {
+  it('collapses \\r\\n to \\r (Windows clipboard format)', () => {
+    expect(normalizePasteText('line1\r\nline2\r\nline3')).toBe('line1\rline2\rline3');
+  });
+
+  it('collapses lone \\n to \\r (POSIX source pasted via WSL/Wine clipboard)', () => {
+    expect(normalizePasteText('line1\nline2\nline3')).toBe('line1\rline2\rline3');
+  });
+
+  it('leaves lone \\r unchanged', () => {
+    expect(normalizePasteText('line1\rline2')).toBe('line1\rline2');
+  });
+
+  it('handles mixed line endings in a single payload', () => {
+    expect(normalizePasteText('a\r\nb\nc\rd')).toBe('a\rb\rc\rd');
+  });
+
+  it('is a no-op for empty input', () => {
+    expect(normalizePasteText('')).toBe('');
+  });
+
+  it('preserves non-line-ending content verbatim', () => {
+    expect(normalizePasteText('hello world!@#$%^&*()')).toBe('hello world!@#$%^&*()');
+  });
+});
+
+describe('splitSurrogateSafe', () => {
+  it('returns the input as a single chunk when below size', () => {
+    expect(splitSurrogateSafe('abc', 10)).toEqual(['abc']);
+  });
+
+  it('splits exactly at size when there is no surrogate at the boundary', () => {
+    const text = 'aaaaaaaaaa'; // 10 chars
+    expect(splitSurrogateSafe(text, 4)).toEqual(['aaaa', 'aaaa', 'aa']);
+  });
+
+  it('never splits a surrogate pair (single astral codepoint U+1F600)', () => {
+    // U+1F600 (😀) = high surrogate U+D83D + low surrogate U+DE00
+    // Build a string where the size-N boundary lands between them.
+    // 4 ASCII chars + 1 emoji = 6 code units. Slice at size=5 would split
+    // the pair; the safe splitter should back off by one to size=4.
+    const text = 'aaaa\u{1F600}bb';
+    const out = splitSurrogateSafe(text, 5);
+    // Reassembly must be lossless.
+    expect(out.join('')).toBe(text);
+    // No chunk should contain a lone surrogate.
+    for (const chunk of out) {
+      for (let i = 0; i < chunk.length; i++) {
+        const code = chunk.charCodeAt(i);
+        if (code >= 0xd800 && code <= 0xdbff) {
+          // High surrogate — next code unit in same chunk must be a low
+          // surrogate (not the end of the chunk).
+          expect(i + 1).toBeLessThan(chunk.length);
+          const next = chunk.charCodeAt(i + 1);
+          expect(next).toBeGreaterThanOrEqual(0xdc00);
+          expect(next).toBeLessThanOrEqual(0xdfff);
+        }
+      }
+    }
+  });
+
+  it('handles many adjacent surrogate pairs across multiple chunk boundaries', () => {
+    const emoji = '\u{1F600}'.repeat(10); // 20 code units
+    const out = splitSurrogateSafe(emoji, 3);
+    expect(out.join('')).toBe(emoji);
+    for (const chunk of out) {
+      // Each chunk must have even length to avoid orphan surrogates,
+      // because every codepoint here is 2 code units. The safe splitter
+      // backs off odd boundaries to even ones.
+      expect(chunk.length % 2).toBe(0);
+    }
+  });
+});
 
 describe('pastePtyChunked', () => {
-  it('is a no-op for empty text', () => {
+  it('is a no-op for empty text', async () => {
     const writes: string[] = [];
-    pastePtyChunked((d) => writes.push(d), '', { bracketedPasteMode: true });
+    await pastePtyChunked((d) => writes.push(d), '', { bracketedPasteMode: true });
     expect(writes).toEqual([]);
   });
 
-  it('writes a single chunk for short payload without bracketed paste', () => {
+  it('writes a single chunk for short payload without bracketed paste', async () => {
     const writes: string[] = [];
-    pastePtyChunked((d) => writes.push(d), 'hello world');
+    await pastePtyChunked((d) => writes.push(d), 'hello world');
     expect(writes).toEqual(['hello world']);
   });
 
-  it('wraps short payload with bracketed-paste markers as a single write (fast path)', () => {
+  it('normalizes CRLF before chunking (Windows clipboard → CR-only output)', async () => {
     const writes: string[] = [];
-    pastePtyChunked((d) => writes.push(d), 'hi', { bracketedPasteMode: true });
+    await pastePtyChunked((d) => writes.push(d), 'line1\r\nline2\r\nline3');
+    expect(writes).toEqual(['line1\rline2\rline3']);
+    // Critical invariant: no \r\n on the wire — PowerShell would treat the
+    // \r as immediate Enter and the \n would render as ^J.
+    for (const w of writes) {
+      expect(w).not.toMatch(/\r\n/);
+    }
+  });
+
+  it('normalizes lone \\n to \\r', async () => {
+    const writes: string[] = [];
+    await pastePtyChunked((d) => writes.push(d), 'line1\nline2');
+    expect(writes).toEqual(['line1\rline2']);
+  });
+
+  it('wraps short payload with bracketed-paste markers as a single write (fast path)', async () => {
+    const writes: string[] = [];
+    await pastePtyChunked((d) => writes.push(d), 'hi', { bracketedPasteMode: true });
     expect(writes).toEqual(['\x1b[200~hi\x1b[201~']);
   });
 
-  it('chunks a >4096-byte payload and skips bracketed markers when mode is off', () => {
+  it('chunks a > PTY_PASTE_CHUNK_SIZE payload without bracketed markers', async () => {
     const writes: string[] = [];
     const text = 'a'.repeat(PTY_PASTE_CHUNK_SIZE * 3 + 17);
-    pastePtyChunked((d) => writes.push(d), text);
-    // 3 full chunks + tail
+    await pastePtyChunked((d) => writes.push(d), text);
     expect(writes.length).toBe(4);
     expect(writes[0].length).toBe(PTY_PASTE_CHUNK_SIZE);
     expect(writes[1].length).toBe(PTY_PASTE_CHUNK_SIZE);
@@ -40,53 +141,146 @@ describe('pastePtyChunked', () => {
     expect(writes.join('')).toBe(text);
   });
 
-  it('chunks a >4096-byte payload and brackets the entire stream once', () => {
+  it('chunks a > PTY_PASTE_CHUNK_SIZE payload and brackets the entire stream once', async () => {
     const writes: string[] = [];
     const text = 'b'.repeat(PTY_PASTE_CHUNK_SIZE * 2 + 5);
-    pastePtyChunked((d) => writes.push(d), text, { bracketedPasteMode: true });
+    await pastePtyChunked((d) => writes.push(d), text, { bracketedPasteMode: true });
     expect(writes[0]).toBe('\x1b[200~');
     expect(writes[writes.length - 1]).toBe('\x1b[201~');
-    // 2 prefix-marker + 3 data chunks + 1 suffix-marker
-    expect(writes.length).toBe(5);
+    expect(writes.length).toBe(5); // 1 open + 3 data + 1 close
     const dataOnly = writes.slice(1, -1).join('');
     expect(dataOnly).toBe(text);
   });
 
-  it('handles a 200KB payload with chunk count > 49', () => {
+  it('handles a 200KB payload without exceeding chunk size', async () => {
     const writes: string[] = [];
-    const text = 'x'.repeat(200 * 1024); // 204_800
-    pastePtyChunked((d) => writes.push(d), text, { bracketedPasteMode: true });
+    const text = 'x'.repeat(200 * 1024);
+    await pastePtyChunked((d) => writes.push(d), text, { bracketedPasteMode: true });
     expect(writes[0]).toBe('\x1b[200~');
     expect(writes[writes.length - 1]).toBe('\x1b[201~');
-    const expectedDataChunks = Math.ceil(text.length / PTY_PASTE_CHUNK_SIZE);
-    expect(writes.length).toBe(expectedDataChunks + 2);
-    // No single write exceeds the chunk size — the property that protects us
-    // from main's 100KB silent backstop.
     for (const w of writes.slice(1, -1)) {
       expect(w.length).toBeLessThanOrEqual(PTY_PASTE_CHUNK_SIZE);
     }
+    // The 100KB main-side backstop never receives a write larger than
+    // PTY_PASTE_CHUNK_SIZE — this is the property that survives that guard.
+    for (const w of writes) {
+      expect(w.length).toBeLessThan(100_000);
+    }
   });
 
-  it('exact-multiple boundary: payload is N * chunk size with no remainder', () => {
+  it('exact-multiple boundary: payload is N * chunk size with no remainder', async () => {
     const writes: string[] = [];
     const text = 'c'.repeat(PTY_PASTE_CHUNK_SIZE * 2);
-    pastePtyChunked((d) => writes.push(d), text);
+    await pastePtyChunked((d) => writes.push(d), text);
     expect(writes.length).toBe(2);
     expect(writes[0].length).toBe(PTY_PASTE_CHUNK_SIZE);
     expect(writes[1].length).toBe(PTY_PASTE_CHUNK_SIZE);
   });
 
-  it('passes through callback rejections (callback throws → throws)', () => {
+  it('does not split a surrogate pair at a chunk boundary', async () => {
+    const writes: string[] = [];
+    // Build a payload where a naive chunker would split a surrogate pair:
+    // (PTY_PASTE_CHUNK_SIZE - 1) ASCII chars + 1 emoji (2 code units).
+    // Naive slice(0, 4096) ends at the high surrogate; safe splitter
+    // backs off to 4095 to keep the pair together.
+    const ascii = 'a'.repeat(PTY_PASTE_CHUNK_SIZE - 1);
+    const emoji = '\u{1F600}';
+    const tail = 'bcd';
+    const text = ascii + emoji + tail;
+    await pastePtyChunked((d) => writes.push(d), text);
+    expect(writes.join('')).toBe(text);
+    // First chunk must end with the high surrogate's PAIR (both halves) or
+    // before the surrogate entirely — never with a lone high surrogate.
+    const first = writes[0];
+    const lastCode = first.charCodeAt(first.length - 1);
+    expect(lastCode < 0xd800 || lastCode > 0xdbff).toBe(true);
+  });
+
+  it('passes through callback rejections', async () => {
     const err = new Error('write fail');
     const fn = vi.fn(() => {
       throw err;
     });
-    expect(() => pastePtyChunked(fn, 'short', undefined)).toThrowError(err);
+    await expect(
+      pastePtyChunked(fn, 'short', undefined),
+    ).rejects.toThrow(err);
   });
 
-  it('treats null modes the same as undefined (no bracketed paste)', () => {
+  it('treats null modes the same as undefined (no bracketed paste)', async () => {
     const writes: string[] = [];
-    pastePtyChunked((d) => writes.push(d), 'data', null as unknown as undefined);
+    await pastePtyChunked((d) => writes.push(d), 'data', null as unknown as undefined);
     expect(writes).toEqual(['data']);
+  });
+
+  it('emits bracketed open/close markers atomically adjacent to body writes', async () => {
+    // No yield between open marker and first data chunk, and none between
+    // last data chunk and close marker — this is the invariant that
+    // prevents another paste from interleaving its markers/data between
+    // ours.
+    const writes: Array<{ chunk: string; tick: number }> = [];
+    let tick = 0;
+    const realSetTimeout = global.setTimeout;
+    // Monkey-patch setTimeout to bump tick whenever the chunker yields.
+    vi.stubGlobal('setTimeout', ((fn: () => void, ms?: number) => {
+      tick += 1;
+      return realSetTimeout(fn, ms ?? 0);
+    }) as unknown as typeof setTimeout);
+    try {
+      const text = 'd'.repeat(PTY_PASTE_CHUNK_SIZE * 2 + 1);
+      await pastePtyChunked(
+        (d) => writes.push({ chunk: d, tick }),
+        text,
+        { bracketedPasteMode: true },
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    // Open marker arrives at tick 0 (no yield before it).
+    expect(writes[0].chunk).toBe('\x1b[200~');
+    expect(writes[0].tick).toBe(0);
+    // First data chunk also at tick 0 — adjacent to the open marker.
+    expect(writes[1].tick).toBe(0);
+    // Close marker arrives at the same tick as the last data chunk —
+    // no yield between final body and close.
+    const closeIdx = writes.length - 1;
+    expect(writes[closeIdx].chunk).toBe('\x1b[201~');
+    expect(writes[closeIdx].tick).toBe(writes[closeIdx - 1].tick);
+  });
+});
+
+describe('chunkOnDataIfNeeded', () => {
+  it('passes through normal-size onData payloads without chunking', async () => {
+    const writes: string[] = [];
+    await chunkOnDataIfNeeded((d) => writes.push(d), 'abc');
+    expect(writes).toEqual(['abc']);
+  });
+
+  it('passes through payloads at the threshold boundary unchunked', async () => {
+    const writes: string[] = [];
+    const text = 'x'.repeat(ONDATA_CHUNK_THRESHOLD);
+    await chunkOnDataIfNeeded((d) => writes.push(d), text);
+    expect(writes).toEqual([text]);
+  });
+
+  it('chunks payloads above the threshold (bare paste from xterm onData)', async () => {
+    const writes: string[] = [];
+    const text = 'y'.repeat(PTY_PASTE_CHUNK_SIZE * 2 + 100);
+    await chunkOnDataIfNeeded((d) => writes.push(d), text);
+    for (const w of writes) {
+      expect(w.length).toBeLessThanOrEqual(PTY_PASTE_CHUNK_SIZE);
+    }
+    expect(writes.join('')).toBe(text);
+  });
+
+  it('preserves bracketed paste markers when xterm pre-wrapped the payload', async () => {
+    const writes: string[] = [];
+    const body = 'z'.repeat(PTY_PASTE_CHUNK_SIZE + 50);
+    const wrapped = `\x1b[200~${body}\x1b[201~`;
+    await chunkOnDataIfNeeded((d) => writes.push(d), wrapped);
+    // Open + close markers come back out around the chunked body.
+    expect(writes[0]).toBe('\x1b[200~');
+    expect(writes[writes.length - 1]).toBe('\x1b[201~');
+    // Body is preserved (concatenation of the middle chunks).
+    expect(writes.slice(1, -1).join('')).toBe(body);
   });
 });

--- a/src/renderer/utils/clipboardChunk.ts
+++ b/src/renderer/utils/clipboardChunk.ts
@@ -1,20 +1,48 @@
 /**
  * Helpers for safely streaming clipboard text into the PTY.
  *
- * Background:
- * The main process enforces a 100KB silent backstop on `pty.write` to protect
- * against unbounded buffer growth. A naive single-write paste of a large blob
- * will be dropped wholesale by main, causing user-visible data loss.
+ * Why this exists:
+ *   xterm.js handles paste itself when its native paste event fires
+ *   (`Clipboard.ts` normalizes CRLF and wraps in bracketed-paste markers
+ *   when the foreground app enabled DECSET 2004). wmux intercepts Ctrl+V,
+ *   right-click paste, and drag-drop directly so we can read from
+ *   Electron's clipboard API (not the browser's, which is gated and racy).
+ *   That bypasses xterm's paste pipeline, so this module re-implements the
+ *   three guarantees a terminal paste needs:
  *
- * Renderer therefore splits paste payloads into 4096-byte chunks before
- * sending — well below any reasonable backstop and matching xterm's
- * historical PTY ingest patterns. When bracketed paste mode is enabled the
- * `\x1b[200~` / `\x1b[201~` markers wrap the entire stream so the foreground
- * application still sees a single paste, regardless of chunk count.
+ *     1. **CRLF normalization** — collapse \r\n / \n / \r to a single CR.
+ *        PowerShell PSReadLine treats lone \r as Enter, so an unnormalized
+ *        chunk boundary between \r and \n executed the first line mid-paste
+ *        and dropped the remainder onto a fresh prompt. That was the
+ *        "front of paste disappears" symptom.
+ *
+ *     2. **UTF-16 surrogate safety** — never split an astral codepoint
+ *        (emoji, CJK supplementary) across two chunks. UTF-16 high
+ *        surrogates land at code-unit boundaries 0xD800-0xDBFF; if the
+ *        chunk boundary falls between high and low surrogate, the
+ *        chunked write produces a broken (`�`) character on the wire.
+ *
+ *     3. **IPC pacing** — yield to the event loop between chunks so the
+ *        conpty input pipe drains. node-pty does not surface
+ *        back-pressure to the JS layer (`IPty.write` is void), so a
+ *        synchronous loop firing N IPC messages in one tick can overrun
+ *        the ~64KB conpty pipe buffer on Windows.
+ *
+ *   The main process also enforces a 100KB silent backstop on `pty.write`
+ *   (see `pty.handler.ts`) — chunking keeps us safely below that limit
+ *   even when the user pastes a megabyte of log output.
  */
 
-/** Maximum bytes per `pty.write` call. Keeps us under the main backstop. */
+/** Maximum UTF-16 code units per `pty.write` call. Far below main's backstop. */
 export const PTY_PASTE_CHUNK_SIZE = 4096;
+
+/**
+ * Lower threshold for `onData`-originated payloads worth chunking. Normal
+ * keystrokes — even multi-byte IME commits or escape sequences — fit in
+ * well under 256 units; anything larger is almost certainly a paste that
+ * leaked through xterm's native paste path and should be chunked + paced.
+ */
+export const ONDATA_CHUNK_THRESHOLD = 1024;
 
 /** Minimal subset of xterm's `Terminal.modes` we read for paste behavior. */
 export interface TerminalModesLike {
@@ -25,30 +53,162 @@ export interface TerminalModesLike {
 export type PtyWriteFn = (data: string) => void;
 
 /**
- * Stream `text` into the PTY using `PTY_PASTE_CHUNK_SIZE` chunks.
- * When bracketed paste mode is active, wraps the chunked stream with the
- * standard CSI markers so the foreground app receives one logical paste.
+ * Normalize line endings in pasted text to a single carriage return.
+ *
+ * Matches xterm.js's own paste normalization (`Clipboard.ts:13-14` in xterm
+ * v5) so wmux's bypass path produces the same on-the-wire bytes as the
+ * native paste path. Specifically:
+ *
+ *   - Windows clipboard contents arrive as `\r\n` — collapse to `\r`.
+ *   - Lone `\n` (typical of *nix sources pasted via Wine / WSL clipboards)
+ *     becomes `\r` so a TUI that expects Enter as CR still triggers.
+ *   - Lone `\r` is left as `\r` (already correct).
+ *
+ * Why `\r` and not `\n`: every interactive shell on every supported
+ * platform (PowerShell, cmd, bash, zsh, fish) accepts `\r` as Enter via
+ * its line discipline; some Windows shells (notably PSReadLine) do not
+ * recognize `\n` at all and would render it as `^J`. Bracketed paste
+ * mode, when enabled by the foreground app, suppresses Enter handling
+ * for the paste body — so `\r` inside a bracket pair is rendered as a
+ * newline, not executed.
  */
-export function pastePtyChunked(
+export function normalizePasteText(text: string): string {
+  if (!text) return text;
+  return text.replace(/\r\n|\r|\n/g, '\r');
+}
+
+/**
+ * Split `text` into chunks of at most `size` UTF-16 code units, never
+ * splitting a surrogate pair across a boundary. Returns chunks in order.
+ *
+ * UTF-16 represents codepoints U+10000 and above (most emoji, CJK
+ * supplementary, mathematical alphanumerics) as a surrogate pair: one
+ * high surrogate (0xD800-0xDBFF) followed by one low surrogate
+ * (0xDC00-0xDFFF). Splitting between them produces two lone surrogates,
+ * which the receiving shell renders as the U+FFFD replacement character.
+ * That is functionally indistinguishable from a "the paste lost some
+ * characters" bug from the user's perspective.
+ */
+export function splitSurrogateSafe(text: string, size: number): string[] {
+  if (text.length <= size) return [text];
+  const out: string[] = [];
+  let i = 0;
+  while (i < text.length) {
+    let end = Math.min(i + size, text.length);
+    // If the would-be last code unit is a high surrogate and there is at
+    // least one more code unit after it, back off by one so the pair
+    // stays together. The deferred low surrogate joins the next chunk.
+    if (end < text.length) {
+      const last = text.charCodeAt(end - 1);
+      if (last >= 0xd800 && last <= 0xdbff) end -= 1;
+    }
+    out.push(text.slice(i, end));
+    i = end;
+  }
+  return out;
+}
+
+/**
+ * Yield control to the event loop so queued IPC writes can drain and the
+ * conpty input pipe can be read by the shell. `setTimeout(0)` is the
+ * renderer-side equivalent of Node's `setImmediate` — both relinquish the
+ * current macrotask. We use a 0ms timeout rather than `queueMicrotask`
+ * because microtasks would re-enter before the IPC dispatch macrotask had
+ * a chance to send our previous chunk.
+ */
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Stream `text` into the PTY using `PTY_PASTE_CHUNK_SIZE` chunks.
+ *
+ * Async: yields to the event loop between chunks so the IPC queue and
+ * conpty input pipe drain — without yielding, a 100KB paste can saturate
+ * the conpty 64KB buffer and the kernel will start discarding writes.
+ *
+ * When bracketed paste mode is active, wraps the stream with the standard
+ * CSI markers so the foreground app receives one logical paste even when
+ * the body crosses several chunk boundaries. Markers are written
+ * synchronously next to the surrounding chunks (no yield between marker
+ * and first/last chunk) so a fast Ctrl+V repeat cannot interleave two
+ * paste streams between marker and body.
+ *
+ * Newlines are normalized to `\r` before chunking (see
+ * `normalizePasteText`) to match xterm.js's own paste pipeline.
+ */
+export async function pastePtyChunked(
   write: PtyWriteFn,
   text: string,
   modes?: TerminalModesLike | null,
-): void {
+): Promise<void> {
   if (!text) return;
 
+  const normalized = normalizePasteText(text);
   const bracketed = !!modes?.bracketedPasteMode;
   const size = PTY_PASTE_CHUNK_SIZE;
 
   // Fast path: short payload + bracketed mode → single write keeps the wire
-  // traffic minimal, and matches the prior code's semantics.
-  if (bracketed && text.length <= size) {
-    write(`\x1b[200~${text}\x1b[201~`);
+  // traffic minimal, prevents any marker/body race, and matches the prior
+  // code's semantics for the common-case command paste.
+  if (bracketed && normalized.length <= size) {
+    write(`\x1b[200~${normalized}\x1b[201~`);
     return;
   }
 
+  // Fast path: short payload, no bracketed mode → single write, no yield.
+  if (!bracketed && normalized.length <= size) {
+    write(normalized);
+    return;
+  }
+
+  const chunks = splitSurrogateSafe(normalized, size);
+
   if (bracketed) write('\x1b[200~');
-  for (let i = 0; i < text.length; i += size) {
-    write(text.slice(i, i + size));
+  for (let i = 0; i < chunks.length; i++) {
+    write(chunks[i]);
+    // Yield between chunks (but not after the last one — no point).
+    if (i < chunks.length - 1) await yieldToEventLoop();
   }
   if (bracketed) write('\x1b[201~');
+}
+
+/**
+ * Route an `onData`-originated payload through the paste chunker when the
+ * length suggests it is a paste that leaked through xterm.js's native
+ * paste pipeline (Shift+Insert, OS menu paste, middle-click on Linux).
+ * Normal keystrokes — single chars, escape sequences, IME commits —
+ * stay on the direct fast path.
+ *
+ * If xterm has already wrapped the payload in bracketed-paste markers
+ * (foreground app enabled DECSET 2004), the markers are stripped before
+ * chunking and re-applied around the chunked body so the markers remain
+ * atomic with the data they wrap.
+ */
+export async function chunkOnDataIfNeeded(
+  write: PtyWriteFn,
+  data: string,
+): Promise<void> {
+  if (data.length <= ONDATA_CHUNK_THRESHOLD) {
+    write(data);
+    return;
+  }
+
+  // Detect xterm-applied bracketed paste wrapping so we can keep markers
+  // atomic with the body when re-chunking. The markers are exactly 6 code
+  // units each: ESC [ 2 0 0 ~ and ESC [ 2 0 1 ~.
+  const hasOpen = data.startsWith('\x1b[200~');
+  const hasClose = data.endsWith('\x1b[201~');
+  let inner = data;
+  if (hasOpen) inner = inner.slice(6);
+  if (hasClose) inner = inner.slice(0, -6);
+
+  // If we detected a wrap, treat as bracketed regardless of the terminal's
+  // current mode (the foreground app already received the open marker
+  // intent from xterm).
+  const modes: TerminalModesLike | null = hasOpen || hasClose
+    ? { bracketedPasteMode: true }
+    : null;
+
+  await pastePtyChunked(write, inner, modes);
 }


### PR DESCRIPTION
## Summary

Repairs user-visible paste truncation in PTY panes (especially PowerShell + Claude Code TUI), where the leading portion of multi-line pastes vanished and the remainder landed on a fresh prompt.

## Root causes (all fixed)

1. **No CRLF normalization.** Ctrl+V / right-click / Shift+Insert handlers bypassed xterm's `\r\n` → `\r` normalization, so the 4 KiB chunker could split between `\r` and `\n` and PSReadLine executed the partial first line.
2. **UTF-16 chunking ignored surrogate pairs.** `text.slice()` at the 4096 code-unit boundary could split astral codepoints (emoji, CJK supplementary) into lone surrogates → `U+FFFD` on the wire.
3. **Synchronous IPC firehose.** N writes in one event-loop tick saturated the ~64 KiB conpty input pipe; node-pty exposes no back-pressure so writes past pipe capacity were silently lost.
4. **Native xterm paste path bypassed the chunker entirely.** `terminal.onData` forwarded the whole payload unchunked.
5. **Drag-drop / palette replay / keybinding command-injection** all wrote directly without chunking.
6. **`pty.handler.ts` silently dropped any payload over 100 KB** — `ipcRenderer.send` is fire-and-forget so callers never knew.

## Fix surface

- `clipboardChunk.ts`: `normalizePasteText`, `splitSurrogateSafe`, async `pastePtyChunked` with `setTimeout(0)` yields, atomic bracketed-paste markers, new `chunkOnDataIfNeeded` helper for large `terminal.onData` payloads.
- `useTerminal.ts`: all three paste handlers `await pastePtyChunked`; `terminal.onData` routes through `chunkOnDataIfNeeded` (threshold 1024) so Shift+Insert / OS-menu paste / middle-click also get treatment.
- `Terminal.tsx`, `AppLayout.tsx`, `CommandPalette.tsx`, `useKeyboard.ts`: every remaining renderer-side `pty.write` call site routes through the chunker.
- `pty.handler.ts`: replaces the silent 100 KB drop with defense-in-depth local segmentation. Payloads in (100 KB, 10 MB] are split into 8 KiB surrogate-safe segments and forwarded; payloads over the 10 MB hard limit are still refused, now via `console.error`.

## Tests

- `clipboardChunk.test.ts`: 31 cases — CRLF normalization, lone `\n`, surrogate-pair safety at chunk boundaries, bracketed-marker atomicity via setTimeout tick counter, 200 KB stress, and `chunkOnDataIfNeeded` behaviour for bare vs. pre-wrapped onData payloads.
- `pty.handler.oversize-segment.test.ts` (new): structural regression test that fails if a future refactor reintroduces the silent drop or removes the segment-then-write loop.

## Test plan

- [x] `npx vitest run src/renderer/utils/__tests__/clipboardChunk.test.ts`
- [x] Manual paste test in PowerShell pane with multi-line text
- [x] Manual paste test in Claude Code TUI pane
- [x] Paste with emoji / CJK supplementary chars at chunk boundaries
- [x] Drag-drop multi-file with long Windows paths