### PR TITLE
feat(panes): cap workspace splits at 20 leaves with toast feedback

### DIFF
--- a/src/renderer/hooks/useKeyboard.ts
+++ b/src/renderer/hooks/useKeyboard.ts
@@ -449,12 +449,16 @@ export function useKeyboard() {
         const state = store.getState();
         const ws = state.workspaces.find((w) => w.id === state.activeWorkspaceId);
         if (ws) {
-          state.splitPane(ws.activePaneId, 'horizontal');
-          // After split, the new pane becomes active; add browser surface to it
-          const newState = store.getState();
-          const newWs = newState.workspaces.find((w) => w.id === newState.activeWorkspaceId);
-          if (newWs) {
-            newState.addBrowserSurface(newWs.activePaneId);
+          // splitPane returns false at the leaf cap (and surfaces its own
+          // toast). Bail out so we don't drop a browser surface on the still-
+          // active original terminal pane.
+          const ok = state.splitPane(ws.activePaneId, 'horizontal');
+          if (ok) {
+            const newState = store.getState();
+            const newWs = newState.workspaces.find((w) => w.id === newState.activeWorkspaceId);
+            if (newWs) {
+              newState.addBrowserSurface(newWs.activePaneId);
+            }
           }
         }
         return;

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -367,7 +367,8 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     if (!ws) return { error: 'no active workspace' };
     const direction =
       params.direction === 'vertical' ? 'vertical' : 'horizontal';
-    store.splitPane(ws.activePaneId, direction);
+    const ok = store.splitPane(ws.activePaneId, direction);
+    if (!ok) return { error: 'pane cap reached (max 20 per workspace)' };
     return { ok: true };
   }
 
@@ -717,7 +718,11 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // This uses PaneContainer's proven split mechanism instead of
     // trying to render terminal+browser in the same leaf pane.
     const paneId = ws.activePaneId;
-    store.splitPane(paneId, 'horizontal', targetWsId);
+    const ok = store.splitPane(paneId, 'horizontal', targetWsId);
+    // At the per-workspace leaf cap splitPane is a no-op (and pushes its own
+    // toast). Bail out before addBrowserSurface so we don't drop a browser tab
+    // on the still-active original terminal pane.
+    if (!ok) return { error: 'pane cap reached (max 20 per workspace)' };
 
     // After split, the new pane becomes active
     const afterSplit = useStore.getState();

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -21,6 +21,7 @@ export const en = {
   'pane.empty': 'Empty pane',
   'pane.splitRight': 'Split right',
   'pane.splitDown': 'Split down',
+  'pane.maxLeavesReached': 'Pane limit reached ({count}). Close a pane before splitting again.',
 
   // Surface
   'surface.terminal': 'Terminal',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -21,6 +21,7 @@ export const ko = {
   'pane.empty': '빈 창',
   'pane.splitRight': '오른쪽 분할',
   'pane.splitDown': '아래 분할',
+  'pane.maxLeavesReached': '창 분할 한도 도달 ({count}개). 창을 닫고 다시 시도하세요.',
 
   // Surface
   'surface.terminal': '터미널',

--- a/src/renderer/stores/slices/__tests__/paneSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneSlice.test.ts
@@ -1,14 +1,16 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
-import { createPaneSlice, type PaneSlice } from '../paneSlice';
+import { createPaneSlice, type PaneSlice, MAX_PANES_PER_WORKSPACE } from '../paneSlice';
 import { createWorkspace, type Workspace } from '../../../../shared/types';
 import { findPane, getLeafPanes } from '../../../../shared/paneUtils';
 
-// Minimal store that satisfies PaneSlice dependencies
+// Minimal store that satisfies PaneSlice dependencies. Includes a `pushToast`
+// stub because splitPane calls it via get() when the leaf cap is hit.
 type TestState = PaneSlice & {
   workspaces: Workspace[];
   activeWorkspaceId: string;
+  pushToast: ReturnType<typeof vi.fn>;
 };
 
 function createTestStore() {
@@ -17,6 +19,7 @@ function createTestStore() {
     immer((...args) => ({
       workspaces: [ws],
       activeWorkspaceId: ws.id,
+      pushToast: vi.fn(),
       // @ts-expect-error — minimal test store doesn't match full StoreState
       ...createPaneSlice(...args),
     }))
@@ -232,6 +235,41 @@ describe('PaneSlice', () => {
       // prev again walks toward the front.
       store.getState().cyclePane('prev');
       expect(getActiveWorkspace(store).activePaneId).toBe(leaves[leaves.length - 2].id);
+    });
+  });
+
+  describe('splitPane — leaf cap', () => {
+    // Workspace starts with 1 leaf; each split adds exactly 1 leaf, so
+    // (MAX_PANES_PER_WORKSPACE - 1) splits brings us right to the cap.
+    it('allows splits up to MAX_PANES_PER_WORKSPACE leaves', () => {
+      for (let i = 0; i < MAX_PANES_PER_WORKSPACE - 1; i++) {
+        const ws = getActiveWorkspace(store);
+        const ok = store.getState().splitPane(ws.activePaneId, 'horizontal');
+        expect(ok).toBe(true);
+      }
+      const wsAfter = getActiveWorkspace(store);
+      expect(getLeafPanes(wsAfter.rootPane)).toHaveLength(MAX_PANES_PER_WORKSPACE);
+      expect(store.getState().pushToast).not.toHaveBeenCalled();
+    });
+
+    it('returns false, no-ops the tree, and toasts once at the cap', () => {
+      for (let i = 0; i < MAX_PANES_PER_WORKSPACE - 1; i++) {
+        const ws = getActiveWorkspace(store);
+        store.getState().splitPane(ws.activePaneId, 'horizontal');
+      }
+      const wsAtCap = getActiveWorkspace(store);
+      const leavesAtCap = getLeafPanes(wsAtCap.rootPane).map((l) => l.id);
+
+      const ok = store.getState().splitPane(wsAtCap.activePaneId, 'horizontal');
+      expect(ok).toBe(false);
+
+      const wsAfter = getActiveWorkspace(store);
+      const leavesAfter = getLeafPanes(wsAfter.rootPane).map((l) => l.id);
+      expect(leavesAfter).toEqual(leavesAtCap); // tree unchanged
+      expect(store.getState().pushToast).toHaveBeenCalledTimes(1);
+      const arg = store.getState().pushToast.mock.calls[0][0] as { level: string; message: string };
+      expect(arg.level).toBe('warn');
+      expect(arg.message).toContain(String(MAX_PANES_PER_WORKSPACE));
     });
   });
 });

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -10,6 +10,14 @@ import {
   publishPaneClosed,
   publishPaneFocused,
 } from '../../events/publisher';
+import { t } from '../../i18n';
+
+// Per-workspace leaf cap. xterm.js + node-pty memory scales linearly with
+// pane count, and the project memory budget targets ~200 MB for 10 panes
+// (TODOS.md "Pane split max depth/count guard"). 20 leaves keeps a runaway
+// shortcut spam (Ctrl+D held, scripted splits, etc.) from exhausting RAM
+// while still being far more than any sane manual layout needs.
+export const MAX_PANES_PER_WORKSPACE = 20;
 
 // M0-d: paneSlice is a read-only mirror for PaneLeaf.metadata. The
 // authoritative writer is MetadataStore in the main process (M0-a + M0-b).
@@ -18,7 +26,14 @@ import {
 // `PaneLeaf.metadata` field remains on the shared type so UI components can
 // read it directly (and so SessionManager hydration can populate it).
 export interface PaneSlice {
-  splitPane: (paneId: string, direction: 'horizontal' | 'vertical', workspaceId?: string) => void;
+  /**
+   * Split a leaf pane into a new horizontal/vertical branch.
+   * Returns `true` on success, `false` if the workspace is at
+   * MAX_PANES_PER_WORKSPACE (callers chaining `addBrowserSurface`,
+   * RPC handlers, etc. must abort on `false` so they don't mutate
+   * the still-active original pane).
+   */
+  splitPane: (paneId: string, direction: 'horizontal' | 'vertical', workspaceId?: string) => boolean;
   closePane: (paneId: string) => void;
   setActivePane: (paneId: string) => void;
   focusPaneDirection: (direction: 'up' | 'down' | 'left' | 'right') => void;
@@ -60,9 +75,11 @@ function getLeafPanes(root: Pane): PaneLeaf[] {
   return root.children.flatMap(getLeafPanes);
 }
 
-export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]], [], PaneSlice> = (set) => ({
+export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]], [], PaneSlice> = (set, get) => ({
   splitPane: (paneId, direction, workspaceId) => {
     let event: { wsId: string; newPaneId: string; branchId: string; previousActiveId: string } | null = null;
+    let blockedAtCap = false;
+    let created = false;
     set((state: StoreState) => {
       const targetWsId = workspaceId || state.activeWorkspaceId;
       const ws = state.workspaces.find((w: Workspace) => w.id === targetWsId);
@@ -70,6 +87,15 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
 
       const targetPane = findPane(ws.rootPane, paneId);
       if (!targetPane || targetPane.type !== 'leaf') return;
+
+      // Cap leaf growth — every callsite (Ctrl+D, prefix-mode split, palette,
+      // browser-pane shortcut, sample-task wizard) funnels through here, so a
+      // single guard is enough.
+      if (collectLeafIds(ws.rootPane).length >= MAX_PANES_PER_WORKSPACE) {
+        blockedAtCap = true;
+        return;
+      }
+      created = true;
 
       const newPane = createLeafPane();
       const branch: PaneBranch = {
@@ -109,6 +135,15 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
         publishPaneFocused(e.wsId, e.newPaneId, e.previousActiveId);
       }
     }
+    if (blockedAtCap) {
+      // Toast emitted outside the immer producer so the slice doesn't recurse
+      // into another set() while the producer is still running.
+      get().pushToast({
+        message: t('pane.maxLeavesReached', { count: MAX_PANES_PER_WORKSPACE }),
+        level: 'warn',
+      });
+    }
+    return created;
   },
 
   closePane: (paneId) => {


### PR DESCRIPTION
## Summary

Prevents runaway pane growth (held Ctrl+D, scripted splits, programmatic abuse) from blowing past the project's "200 MB for 10 panes" memory budget. xterm.js + node-pty memory scales linearly with leaf count, so an unbounded splitter eventually exhausts RAM.

## Implementation

- New exported constant `MAX_PANES_PER_WORKSPACE = 20` in `paneSlice`. 20 is generous — every realistic manual layout fits comfortably.
- `splitPane` checks `collectLeafIds(ws.rootPane).length` inside its immer producer. At cap: sets a `blockedAtCap` flag and returns without mutating the tree. After the producer finishes, `get().pushToast()` surfaces a `warn`-level toast so the user knows why nothing happened.
- **`splitPane` now returns `boolean`** (true on success, false at cap). Callers that chain follow-up actions on the assumption the split succeeded must check this:
  - `useKeyboard.ts` Ctrl+Shift+L (browser pane shortcut) skips `addBrowserSurface` so the browser tab doesn't drop on the still-active original terminal pane.
  - `useRpcBridge.ts` `pane.split` RPC returns `"pane cap reached"` instead of `{ok: true}`.
  - `useRpcBridge.ts` `browser.open` RPC returns the same error before invoking `addBrowserSurface`, which previously would have attached the browser to the wrong pane and lied with `{ok: true}`.
  - Pure-split callers (CommandPalette, useKeyboard's plain Ctrl+D / Ctrl+Shift+D, prefix-mode actions) ignore the return value — they have nothing to chain.
- Toast message uses a new i18n key `pane.maxLeavesReached` with `{count}` interpolation. `en` + `ko` added; `ja`/`zh` fall back to `en` automatically via the existing fallback in `i18n/index.ts`.
- Single-source guard at the slice. Every callsite (Ctrl+D, Ctrl+Shift+D, Ctrl+Shift+L browser pane, prefix-mode split, palette commands, sample task wizard, RPC `pane.split`, RPC `browser.open`) funnels through `splitPane`, so no other guards are needed.

## Why this design

Codex review (P2): "Return split failure to callers at the pane cap." Original draft made `splitPane` a silent no-op except for the toast — chained callers like `useRpcBridge.browser.open` would still mutate the active terminal pane (adding a browser tab to the wrong place) and return `{ok: true}`. Returning a boolean and updating every chained caller fixes this cleanly. Source: `src/renderer/stores/slices/paneSlice.ts:86-89` flagged in codex review.

## Tests

- `paneSlice.test.ts` gains a `pushToast: vi.fn()` stub on the test store (`PaneSlice.splitPane` now reads it via `get()`).
- New `splitPane — leaf cap` describe with two cases:
  1. In-bounds splits return `true` and don't toast (asserted on every iteration up to `MAX_PANES_PER_WORKSPACE` leaves).
  2. The cap-hitting split returns `false`, leaves the tree unchanged, and fires exactly one warn-level toast whose message includes the cap count.

## Test plan

- [x] `npx vitest run src/renderer` — 271/271 pass
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] codex review (`high` reasoning) — GATE: PASS, the one P2 finding addressed in the same commit
- [ ] Manual: open 20 panes via Ctrl+D, confirm toast appears on 21st
- [ ] Manual: at cap, trigger MCP `browser.open` — confirm error returned and no browser tab added to wrong pane
- [ ] Manual: at cap, hit Ctrl+Shift+L — confirm toast + no browser surface dropped on the active terminal