### PR TITLE
v2.9.1 — Daemon shutdown reliability + .txt active-hazard mitigation

### DIFF
--- a/docs/upgrade-v2.9.1.md
+++ b/docs/upgrade-v2.9.1.md
@@ -1,0 +1,242 @@
+# Upgrade Guide — v2.9.1 (Daemon Shutdown Reliability + .txt Active-Hazard Mitigation)
+
+v2.9.1 ships the Phase A reliability bundle for the wmux daemon. The
+focus is the scrollback persistence path under all real shutdown
+triggers: tray Quit, Windows OS reboot / log-off, daemon kill, antivirus
+interference, and the renderer-side `.txt` rotation chain that was
+actively destroying its own backups in earlier versions.
+
+This document is both a release note and a manual verification checklist
+for the changes that the automated test suite cannot reach (WM_ENDSESSION
+behavior, real ConPTY shutdown latency, antivirus interaction). Run
+through the checklist if you maintain wmux on Windows or if you want to
+confirm v2.9.1 fixed the "scrollback empty after reboot" symptom.
+
+Target audience:
+
+- v2.9.0 users upgrading to v2.9.1.
+- Users who saw empty / chopped scrollback after Windows shutdown or restart.
+- Maintainers running the v2.9.1 release verification.
+
+---
+
+## 1. What changed (release notes)
+
+**Daemon shutdown is now actually awaitable.**
+- `daemon.shutdown` RPC completes its full body (atomic RingBuffer dumps,
+  session.json save, dispose) before returning. The handler then defers
+  pipe stop + `process.exit(0)` to `setImmediate` so the ack flushes
+  back to the caller.
+- `DaemonClient.rpc` gained a per-call `{ timeoutMs }` override so the
+  caller can wait beyond the default 10 s.
+
+**Tray Quit + Windows session-end now race the daemon.**
+- Tray Quit (main `before-quit`) awaits `daemon.shutdown` against a 4 s
+  budget, then falls back to `daemonClient.disconnect()`.
+- Windows `session-end` (WM_ENDSESSION) does the same race so OS reboot
+  / log-off triggers the same flush path. Detach-only is the final
+  fallback exactly as in v2.9.0.
+
+**Atomic RingBuffer dump (tmp + rename).**
+- `RingBuffer.dumpToFile` writes to a same-directory `.tmp.<hex>` file
+  and renames into place. Readers can never observe a half-written
+  `.buf`.
+- New `RingBuffer.dumpToFileSyncAtomic` used by the Windows
+  `process.on('exit')` last-resort handler.
+- Stale `.tmp.*` files swept on daemon startup.
+
+**New session entries persist within 30 s of spawn.**
+- `daemon.createSession` and `daemon.attachSession` invoke a snapshot
+  runner immediately so the new session's `.buf` is on disk before the
+  next 30 s tick. Locked by source-level invariant test against future
+  refactors.
+
+**Renderer `.txt` scrollback is gated off in daemon mode.**
+- Autosave timer + beforeunload save + scrollback:dump IPC +
+  scrollback:load IPC + xterm async restore all short-circuit when the
+  renderer's daemon flag is true.
+- The flag flips on `daemon:connected` / `daemon:disconnected` events
+  emitted by main. Local-mode users (daemon spawn failed or runtime
+  disconnect) keep the `.txt` fallback verbatim.
+
+**One-time legacy scrollback migration on first daemon connect.**
+- `%APPDATA%/wmux/scrollback/` moves to
+  `%APPDATA%/wmux/scrollback-legacy-<unix-ts>/` so daemon-mode users
+  get a clean directory. Migration is idempotent (flag file at
+  `%APPDATA%/wmux/scrollback-migration.json`) and retries on EBUSY /
+  EPERM / ENOTEMPTY.
+
+**Bundled M6 in-orbit fixes.**
+- bf67a79: Pane split max-depth/count guard (TODOS #2).
+- Daemon reconnection retry on tray restore (TODOS #1).
+- destroyCompanyWithCleanup race resolution (TODOS #4).
+- Member workspace PTY leak on company destroy (TODOS #5).
+
+---
+
+## 2. What you may notice
+
+- The `%APPDATA%/wmux/scrollback/` directory will be absent after first
+  launch on v2.9.1. Its prior contents are at `scrollback-legacy-<ts>/`
+  in the same parent directory. wmux does not delete this — you can
+  hand-delete it if storage matters, or copy specific files out for
+  manual recovery.
+- If you have not been running with a daemon (you would know — typically
+  Windows-only deploys with daemon binaries missing), v2.9.1 changes
+  nothing for your scrollback path. The `.txt` directory is still your
+  source of truth.
+- Tray Quit may take up to ~5 s longer than v2.9.0 if you have many
+  panes open and antivirus is scanning during shutdown. This is the
+  expected race timeout; it caps the daemon's flush window so atomic
+  dumps complete before Windows pulls the plug.
+
+---
+
+## 3. Manual verification checklist (Windows)
+
+The automated test suite covers everything except the OS-level shutdown
+signals. Run through this list to confirm v2.9.1 lands cleanly on your
+machine. **Before starting**: close all running wmux instances. Open
+Task Manager so you can watch the `node.exe` daemon process.
+
+### 3.1 Tray Quit cleanly flushes scrollback
+
+1. Launch wmux. Open at least 5 terminal panes across 2 workspaces.
+2. Run a varied command in each pane (e.g., `dir`, `tree`, `ipconfig`)
+   for at least 2 minutes so each RingBuffer has real content.
+3. Right-click the tray icon → **Quit**.
+4. Inspect `%APPDATA%/wmux/buffers/`. Each pane's `.buf` file should
+   match the output volume you generated (not 0 bytes, not 159 bytes).
+5. Relaunch wmux. Each pane should restore scrollback identical to
+   pre-quit (within ±30 s).
+
+### 3.2 Windows reboot test (P0 critical gap)
+
+This is the path that was broken in v2.9.0 and earlier. The automated
+test suite cannot reproduce WM_ENDSESSION; this step is the only
+end-to-end coverage.
+
+1. With wmux open + multiple active panes + running commands, click
+   Start → Power → **Restart**.
+2. Let Windows fully restart and log back in.
+3. Open wmux. Each pane should show its pre-restart scrollback. No
+   panes should show "empty" content.
+
+If this step fails, please file an issue with the daemon log
+(`%APPDATA%/wmux/logs/` if logging is enabled) and a description of how
+many panes / what kind of workloads were active.
+
+### 3.3 Log-off + log-on
+
+1. Open wmux + at least 1 pane with content.
+2. Start → user icon → **Sign out**.
+3. Log back in. Open wmux. Scrollback should be intact.
+
+### 3.4 Forced daemon kill (Task Manager)
+
+1. Open wmux. Confirm `node.exe` is running in Task Manager (the
+   daemon).
+2. End that `node.exe` process via Task Manager.
+3. wmux should automatically fall back to local PTY mode for new
+   panes. Existing panes will show "Daemon disconnected" log entries
+   and continue running in local mode.
+4. Close wmux normally. Relaunch. Daemon should respawn; previous
+   panes should restore from the last `.buf` snapshot.
+
+### 3.5 Antivirus block
+
+1. Add `%APPDATA%/wmux/buffers/` as a scan target in your antivirus.
+2. Reboot Windows.
+3. Reopen wmux. If the daemon could not write its `.buf` files cleanly
+   under antivirus interference, you should still see the previous
+   snapshot's content (EBUSY paths log a warning but do not corrupt the
+   prior good file thanks to the atomic tmp + rename pattern).
+
+### 3.6 Local mode test (no daemon)
+
+This confirms the v2.9.1 gates do not regress users whose daemon binary
+fails to spawn (Issue #1A).
+
+1. Rename `daemon-pipe` file (or block the daemon binary via antivirus).
+2. Launch wmux. The log should show "Daemon auto-start failed, using
+   local PTY".
+3. Open a pane, generate output for ~2 minutes, close wmux.
+4. Reopen wmux. The pane should restore from the `.txt` rotation chain
+   in `%APPDATA%/wmux/scrollback/` (the gates we added skip in local
+   mode).
+
+### 3.7 Legacy migration sanity
+
+1. Confirm `%APPDATA%/wmux/scrollback-legacy-<ts>/` exists if you had
+   pre-v2.9.1 scrollback data.
+2. Confirm `%APPDATA%/wmux/scrollback-migration.json` exists and
+   contains `{ schema: 1, migratedAt: ..., fromVersion: 2.9.1 }`.
+3. Confirm `%APPDATA%/wmux/scrollback/` is absent (daemon mode) OR
+   newly-created and empty (you ran 3.6 first).
+
+---
+
+## 4. T5 latency calibration (optional, advanced)
+
+The before-quit + session-end races use a 4 s timeout placeholder. If
+you have many panes (50+) or slow storage and want to dial this in,
+rerun the T5 measurement on the target hardware:
+
+```bash
+npm run build:daemon
+node scripts/daemon-shutdown-dynamic.mjs
+```
+
+The harness prints per-N latency and a recommended timeout. If T5 p99
+exceeds 3 s, raise `BEFORE_QUIT_TIMEOUT_MS` in
+`src/main/index.ts` (currently 4_000) and `A5_TIMEOUT_MS` in the
+`session-end` handler. Cap at 4 s — anything higher risks Windows
+SIGKILL inside the 5 s OS budget.
+
+The current harness has a known ConPTY rapid-spawn race that throws
+`ERROR_INVALID_PARAMETER (87)` from inside a `Socket.on('data')`
+handler in a way that bypasses the harness's try/catch chain. If you
+hit this and want a measurement, add a sleep between createSession
+calls or reduce the N values to {1, 5, 10}.
+
+---
+
+## 5. Known trade-offs
+
+- **Post-migration local-mode fresh scrollback.** If your daemon
+  connects successfully, A7 moves your legacy `.txt` directory aside.
+  If the daemon later dies mid-session and you fall back to local mode,
+  scrollback starts fresh from that session forward. The legacy data
+  remains at `scrollback-legacy-<ts>/` for manual recovery.
+- **WM_ENDSESSION 4 s budget.** Windows gives ~5 s before SIGKILL.
+  v2.9.1 uses 4 s for the daemon race, leaving 1 s for disconnect +
+  Electron teardown. Heavy workloads (50 × 8 MB sessions on HDD with
+  antivirus) may exceed 4 s and trigger the detach fallback. The
+  fallback is the v2.9.0 behavior, so nothing regresses, but the
+  daemon's atomic exit handler still kicks in to dump as much as
+  possible before the process dies.
+- **`.txt` rotation chain still hazardous in local mode.** A6 + A7
+  only affect daemon-mode users. The fundamental `.txt` rotation
+  bug (size-unaware backups overwriting good data with 64-byte stubs)
+  remains for users who run without a daemon. Phase B-E will address
+  the local-mode side via either fixing the rotation logic or
+  retiring the `.txt` system entirely.
+
+---
+
+## 6. Rollback
+
+If v2.9.1 regresses your scrollback in an unexpected way, downgrade
+to v2.9.0 via your installer. The on-disk format is fully
+compatible — daemon-mode users will see `scrollback-legacy-<ts>/` left
+intact in `%APPDATA%/wmux/`. v2.9.0 reads from `%APPDATA%/wmux/scrollback/`,
+so create or restore that directory before the downgrade. Move the
+legacy data back:
+
+```powershell
+Rename-Item "$env:APPDATA\wmux\scrollback-legacy-<ts>" "$env:APPDATA\wmux\scrollback"
+Remove-Item "$env:APPDATA\wmux\scrollback-migration.json"
+```
+
+Then file an issue with the symptom + the daemon log so we can fix
+forward in v2.9.2.

--- a/scripts/daemon-shutdown-dynamic.mjs
+++ b/scripts/daemon-shutdown-dynamic.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+/**
+ * Phase A dynamic test — Task #15 (calibration for A5 timeout).
+ *
+ * Spawns the BUNDLED daemon (dist/daemon-bundle/index.js) in an isolated
+ * state directory and exercises the shutdown path under conditions that
+ * the unit suite cannot reach: real ConPTY spawning, real RingBuffer
+ * lifecycle, real fs.rename under the atomic dump path (A4).
+ *
+ * Scenarios:
+ *   T1  spawn → 1 s → createSession → 1 s → daemon.shutdown
+ *       Asserts: .buf exists on disk for the session AND sessions.json
+ *       contains the session entry. Locks the A1a/A1b/A4 invariants
+ *       end-to-end.
+ *
+ *   T2  spawn → createSession → IMMEDIATELY daemon.shutdown
+ *       Asserts: sessions.json contains the session entry. Confirms the
+ *       A1a synchronous saveImmediate from inside createSession survives
+ *       a shutdown that follows it within microseconds.
+ *
+ *   T5  spawn → createSession × N (N ∈ {1, 10, 50}) → daemon.shutdown
+ *       Measures wall-clock latency. Result calibrates A3/A5 timeouts.
+ *       Currently A3 uses a 4 s placeholder and A5 will use the T5
+ *       p99 + 1 s headroom (capped at 4 s for the WM_ENDSESSION budget).
+ *
+ * T3 + T4 (PTY 1 MB payload + SIGKILL recovery) require a meaningful
+ * stream of PTY output before the shutdown. They are deferred to the
+ * manual Windows checklist (Task #9) because driving 1 MB through a
+ * portable shell echo on Windows takes more time than the CI budget
+ * affords and adds little signal beyond what the atomic-dump unit
+ * tests already lock in.
+ */
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const DAEMON_BUNDLE = path.join(REPO_ROOT, 'dist', 'daemon-bundle', 'index.js');
+
+if (!fs.existsSync(DAEMON_BUNDLE)) {
+  console.error('Daemon bundle missing — run `npm run build:daemon` first');
+  process.exit(2);
+}
+
+// Helpers ---------------------------------------------------------------
+
+function makeTestHome() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-shutdown-dyn-'));
+  fs.mkdirSync(path.join(home, '.wmux'), { recursive: true });
+  return home;
+}
+
+function makePipeName(tag) {
+  if (process.platform === 'win32') {
+    return `\\\\.\\pipe\\wmux-test-${tag}`;
+  }
+  return path.join(os.tmpdir(), `wmux-test-${tag}.sock`);
+}
+
+function writeConfig(wmuxDir, pipeName, authToken) {
+  fs.writeFileSync(
+    path.join(wmuxDir, 'config.json'),
+    JSON.stringify(
+      {
+        version: 1,
+        daemon: { pipeName, logLevel: 'warn', autoStart: true },
+        session: {
+          defaultShell: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
+          defaultCols: 80,
+          defaultRows: 24,
+          bufferSizeMb: 8,
+          bufferMaxMb: 64,
+          deadSessionTtlHours: 24,
+          deadSessionDumpBuffer: true,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(path.join(wmuxDir, 'daemon-auth-token'), authToken, 'utf-8');
+}
+
+function spawnDaemon(testHome) {
+  return spawn(process.execPath, [DAEMON_BUNDLE], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      USERPROFILE: testHome,
+      HOME: testHome,
+      HOMEDRIVE: undefined,
+      HOMEPATH: undefined,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+async function waitForPipeFile(wmuxDir, timeoutMs = 10_000) {
+  const pipeFile = path.join(wmuxDir, 'daemon-pipe');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(pipeFile)) return fs.readFileSync(pipeFile, 'utf-8').trim();
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error('daemon-pipe did not appear within timeout');
+}
+
+function connectSocket(pipeName) {
+  return new Promise((resolve, reject) => {
+    const s = net.createConnection(pipeName, () => resolve(s));
+    s.on('error', reject);
+  });
+}
+
+function rpc(socket, method, params, authToken, timeoutMs = 30_000) {
+  return new Promise((resolve, reject) => {
+    const id = `req-${Math.random().toString(36).slice(2, 10)}`;
+    let buffer = '';
+    const handler = (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id === id) {
+            socket.removeListener('data', handler);
+            if (msg.ok) resolve(msg.result);
+            else reject(new Error(msg.error ?? 'rpc error'));
+            return;
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+    };
+    socket.on('data', handler);
+    socket.write(JSON.stringify({ id, method, params, token: authToken }) + '\n');
+    setTimeout(() => {
+      socket.removeListener('data', handler);
+      reject(new Error(`rpc timeout: ${method}`));
+    }, timeoutMs);
+  });
+}
+
+async function killDaemon(child) {
+  if (child.killed) return;
+  child.kill('SIGTERM');
+  await new Promise((r) => setTimeout(r, 800));
+  if (!child.killed) child.kill('SIGKILL');
+}
+
+// Scenario runner -------------------------------------------------------
+
+async function withDaemon(label, body) {
+  const testHome = makeTestHome();
+  const wmuxDir = path.join(testHome, '.wmux');
+  const tag = `${label}-${randomUUID().slice(0, 8)}`;
+  const pipeName = makePipeName(tag);
+  const authToken = randomUUID();
+  writeConfig(wmuxDir, pipeName, authToken);
+
+  const child = spawnDaemon(testHome);
+  let stderr = '';
+  child.stderr.on('data', (d) => { stderr += d.toString(); });
+
+  try {
+    const resolvedPipe = await waitForPipeFile(wmuxDir);
+    const socket = await connectSocket(resolvedPipe);
+    try {
+      return await body({ wmuxDir, socket, authToken });
+    } finally {
+      socket.end();
+    }
+  } catch (err) {
+    if (stderr) console.error(`[${label}] daemon stderr tail:\n${stderr.slice(-2000)}`);
+    throw err;
+  } finally {
+    await killDaemon(child);
+    try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+}
+
+async function runT1(report) {
+  await withDaemon('T1', async ({ wmuxDir, socket, authToken }) => {
+    await new Promise((r) => setTimeout(r, 1000));
+    const sessionId = `t1-${randomUUID().slice(0, 8)}`;
+    await rpc(socket, 'daemon.createSession', { id: sessionId, cmd: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh', cwd: wmuxDir, env: {}, cols: 80, rows: 24 }, authToken);
+    await new Promise((r) => setTimeout(r, 1000));
+    await rpc(socket, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
+    // Give the daemon's deferred process.exit time to flush.
+    await new Promise((r) => setTimeout(r, 800));
+
+    const bufPath = path.join(wmuxDir, 'buffers', `${sessionId}.buf`);
+    const sessionsJsonPath = path.join(wmuxDir, 'sessions.json');
+    const bufExists = fs.existsSync(bufPath);
+    let entryPresent = false;
+    if (fs.existsSync(sessionsJsonPath)) {
+      const persisted = JSON.parse(fs.readFileSync(sessionsJsonPath, 'utf-8'));
+      entryPresent = persisted.sessions.some((s) => s.id === sessionId);
+    }
+    report.push({ scenario: 'T1', bufExists, entryPresent, pass: bufExists && entryPresent });
+  });
+}
+
+async function runT2(report) {
+  await withDaemon('T2', async ({ wmuxDir, socket, authToken }) => {
+    const sessionId = `t2-${randomUUID().slice(0, 8)}`;
+    // No wait — immediately follow createSession with shutdown.
+    await rpc(socket, 'daemon.createSession', { id: sessionId, cmd: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh', cwd: wmuxDir, env: {}, cols: 80, rows: 24 }, authToken);
+    await rpc(socket, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
+    await new Promise((r) => setTimeout(r, 800));
+
+    const sessionsJsonPath = path.join(wmuxDir, 'sessions.json');
+    let entryPresent = false;
+    if (fs.existsSync(sessionsJsonPath)) {
+      const persisted = JSON.parse(fs.readFileSync(sessionsJsonPath, 'utf-8'));
+      entryPresent = persisted.sessions.some((s) => s.id === sessionId);
+    }
+    report.push({ scenario: 'T2', entryPresent, pass: entryPresent });
+  });
+}
+
+async function measureShutdownLatency(label, n) {
+  return await withDaemon(label, async ({ wmuxDir, socket, authToken }) => {
+    // Spawn N sessions back-to-back. We don't try to fill 8 MB of PTY
+    // output per session — that's beyond what a portable harness can
+    // drive reliably on Windows. The measurement still captures the
+    // daemon's shutdown overhead per session (atomic dump, sessions.json
+    // merge, state save).
+    //
+    // Insert a small delay between spawns. Without it ConPTY on Windows
+    // returns ERROR_INVALID_PARAMETER (87) under rapid-fire load — the
+    // same constraint v281-dynamic-test.mjs documents.
+    let spawned = 0;
+    let spawnFailures = 0;
+    for (let i = 0; i < n; i++) {
+      const id = `${label}-${i}`;
+      try {
+        await rpc(socket, 'daemon.createSession', { id, cmd: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh', cwd: wmuxDir, env: {}, cols: 80, rows: 24 }, authToken);
+        spawned++;
+      } catch (err) {
+        spawnFailures++;
+      }
+      if (process.platform === 'win32') {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+    }
+    // Quick settle so the periodic snapshot does not race the shutdown.
+    await new Promise((r) => setTimeout(r, 300));
+
+    const start = Date.now();
+    await rpc(socket, 'daemon.shutdown', {}, authToken, 30_000).catch(() => {});
+    const elapsed = Date.now() - start;
+    return { elapsed, spawned, spawnFailures };
+  });
+}
+
+async function runT5(report) {
+  const sizes = [1, 10, 50];
+  const latencies = {};
+  for (const n of sizes) {
+    const label = `T5n${n}`;
+    try {
+      const result = await measureShutdownLatency(label, n);
+      latencies[n] = result;
+      console.log(`[T5] N=${n} shutdown latency: ${result.elapsed} ms (spawned ${result.spawned}, failed ${result.spawnFailures})`);
+    } catch (err) {
+      console.error(`[T5] N=${n} failed: ${err.message}`);
+      latencies[n] = null;
+    }
+  }
+  report.push({ scenario: 'T5', latencies });
+}
+
+// Main ------------------------------------------------------------------
+
+process.on('unhandledRejection', (reason) => {
+  const msg = reason instanceof Error ? reason.stack ?? reason.message : String(reason);
+  console.error('[unhandledRejection]', msg);
+});
+process.on('uncaughtException', (err) => {
+  console.error('[uncaughtException]', err.stack ?? err.message);
+});
+
+const report = [];
+let exitCode = 0;
+try {
+  await runT1(report);
+  await runT2(report);
+  await runT5(report);
+} catch (err) {
+  console.error('[FAIL]', err.message);
+  console.error(err.stack);
+  exitCode = 1;
+}
+
+console.log('\n=== REPORT ===');
+for (const entry of report) {
+  console.log(JSON.stringify(entry));
+}
+
+const failed = report.filter((r) => r.scenario !== 'T5' && r.pass === false);
+if (failed.length > 0) {
+  console.error(`\n[FAIL] ${failed.length} non-T5 scenarios failed.`);
+  exitCode = 1;
+} else {
+  console.log('\n[PASS] T1 + T2 scenarios met their post-conditions.');
+  const t5 = report.find((r) => r.scenario === 'T5');
+  if (t5) {
+    const measurements = Object.values(t5.latencies).filter((v) => v != null && typeof v.elapsed === 'number');
+    if (measurements.length > 0) {
+      const max = Math.max(...measurements.map((m) => m.elapsed));
+      console.log(`[T5] max latency across N∈{1,10,50}: ${max} ms`);
+      console.log(`[T5] recommended A5 timeout: min(${max} + 1000 ms, 4000 ms) = ${Math.min(max + 1000, 4000)} ms`);
+    }
+  }
+}
+
+process.exit(exitCode);

--- a/scripts/daemon-shutdown-dynamic.mjs
+++ b/scripts/daemon-shutdown-dynamic.mjs
@@ -147,6 +147,35 @@ function rpc(socket, method, params, authToken, timeoutMs = 30_000) {
   });
 }
 
+// ConPTY can refuse the first few rapid-fire spawns on Windows
+// (ERROR_INVALID_PARAMETER 87). Wrap createSession in retry+backoff so
+// transient initialization races do not collapse the entire scenario.
+// Returns the effective sessionId actually used (which may differ from
+// the base on a retry attempt) so the caller can track the right id.
+async function createSessionWithRetry(socket, authToken, sessionIdBase, cwd, attempts = 6) {
+  let lastErr = null;
+  for (let i = 1; i <= attempts; i++) {
+    // Use a fresh id on each retry so a partial-init state on the daemon
+    // does not turn the next attempt into an "already exists" rejection
+    // that escapes the ConPTY-only retry filter.
+    const sessionId = i === 1 ? sessionIdBase : `${sessionIdBase}-r${i}`;
+    try {
+      const result = await rpc(socket, 'daemon.createSession', {
+        id: sessionId,
+        cmd: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
+        cwd, env: {}, cols: 80, rows: 24,
+      }, authToken);
+      return { result, sessionId };
+    } catch (err) {
+      lastErr = err;
+      const msg = err?.message ?? String(err);
+      if (!/error code: 87|ConPTY|Cannot create process/i.test(msg)) throw err;
+      await new Promise((r) => setTimeout(r, 800 * i));
+    }
+  }
+  throw lastErr ?? new Error('createSession failed after retries');
+}
+
 async function killDaemon(child) {
   if (child.killed) return;
   child.kill('SIGTERM');
@@ -187,9 +216,9 @@ async function withDaemon(label, body) {
 
 async function runT1(report) {
   await withDaemon('T1', async ({ wmuxDir, socket, authToken }) => {
-    await new Promise((r) => setTimeout(r, 1000));
-    const sessionId = `t1-${randomUUID().slice(0, 8)}`;
-    await rpc(socket, 'daemon.createSession', { id: sessionId, cmd: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh', cwd: wmuxDir, env: {}, cols: 80, rows: 24 }, authToken);
+    await new Promise((r) => setTimeout(r, 1500));
+    const baseId = `t1-${randomUUID().slice(0, 8)}`;
+    const { sessionId } = await createSessionWithRetry(socket, authToken, baseId, wmuxDir);
     await new Promise((r) => setTimeout(r, 1000));
     await rpc(socket, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
     // Give the daemon's deferred process.exit time to flush.
@@ -203,15 +232,15 @@ async function runT1(report) {
       const persisted = JSON.parse(fs.readFileSync(sessionsJsonPath, 'utf-8'));
       entryPresent = persisted.sessions.some((s) => s.id === sessionId);
     }
-    report.push({ scenario: 'T1', bufExists, entryPresent, pass: bufExists && entryPresent });
+    report.push({ scenario: 'T1', sessionId, bufExists, entryPresent, pass: bufExists && entryPresent });
   });
 }
 
 async function runT2(report) {
   await withDaemon('T2', async ({ wmuxDir, socket, authToken }) => {
-    const sessionId = `t2-${randomUUID().slice(0, 8)}`;
-    // No wait — immediately follow createSession with shutdown.
-    await rpc(socket, 'daemon.createSession', { id: sessionId, cmd: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh', cwd: wmuxDir, env: {}, cols: 80, rows: 24 }, authToken);
+    await new Promise((r) => setTimeout(r, 1500));
+    const baseId = `t2-${randomUUID().slice(0, 8)}`;
+    const { sessionId } = await createSessionWithRetry(socket, authToken, baseId, wmuxDir);
     await rpc(socket, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
     await new Promise((r) => setTimeout(r, 800));
 
@@ -221,7 +250,7 @@ async function runT2(report) {
       const persisted = JSON.parse(fs.readFileSync(sessionsJsonPath, 'utf-8'));
       entryPresent = persisted.sessions.some((s) => s.id === sessionId);
     }
-    report.push({ scenario: 'T2', entryPresent, pass: entryPresent });
+    report.push({ scenario: 'T2', sessionId, entryPresent, pass: entryPresent });
   });
 }
 
@@ -260,6 +289,120 @@ async function measureShutdownLatency(label, n) {
   });
 }
 
+// T4: spawn → createSession → wait for snapshot → SIGKILL daemon → respawn
+// daemon (same wmuxDir/auth) → verify recovery loaded the session from
+// the .buf snapshot. This is the dynamic counterpart to the manual
+// Windows reboot checklist — "if the daemon dies, does next-start
+// restore my scrollback session entry?"
+async function runT4(report) {
+  const testHome = makeTestHome();
+  const wmuxDir = path.join(testHome, '.wmux');
+  const tag = `T4-${randomUUID().slice(0, 8)}`;
+  const pipeName = makePipeName(tag);
+  const authToken = randomUUID();
+  writeConfig(wmuxDir, pipeName, authToken);
+
+  const baseId = `t4-${randomUUID().slice(0, 8)}`;
+  let effectiveSessionId = baseId;
+  let bufExistsBeforeKill = false;
+  let bufExistsAfterKill = false;
+  let entryPresentAfterKill = false;
+  let sessionRecovered = false;
+  let recoveryError = null;
+
+  try {
+    // First daemon: spawn + createSession + wait for snapshot to write .buf.
+    const child1 = spawnDaemon(testHome);
+    try {
+      const resolvedPipe = await waitForPipeFile(wmuxDir);
+      const socket = await connectSocket(resolvedPipe);
+      try {
+        // Daemon spawn settle before first PTY init.
+        await new Promise((r) => setTimeout(r, 1500));
+        const { sessionId: createdId } = await createSessionWithRetry(socket, authToken, baseId, wmuxDir);
+        effectiveSessionId = createdId;
+        // Allow the snapshot runner (A1b — fires from createSession) to dump.
+        await new Promise((r) => setTimeout(r, 1500));
+        const bufPath = path.join(wmuxDir, 'buffers', `${effectiveSessionId}.buf`);
+        bufExistsBeforeKill = fs.existsSync(bufPath);
+      } finally {
+        socket.end();
+      }
+    } catch (err) {
+      recoveryError = `first-daemon: ${err.message}`;
+      throw err;
+    }
+
+    // SIGKILL the daemon (Windows: TerminateProcess; POSIX: SIGKILL).
+    // This is the dynamic stand-in for power loss / Task Manager kill /
+    // OS reboot SIGKILL.
+    child1.kill('SIGKILL');
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const bufPath = path.join(wmuxDir, 'buffers', `${effectiveSessionId}.buf`);
+    bufExistsAfterKill = fs.existsSync(bufPath);
+
+    const sessionsJsonPath = path.join(wmuxDir, 'sessions.json');
+    if (fs.existsSync(sessionsJsonPath)) {
+      const persisted = JSON.parse(fs.readFileSync(sessionsJsonPath, 'utf-8'));
+      entryPresentAfterKill = persisted.sessions.some((s) => s.id === effectiveSessionId);
+    }
+
+    // Stale daemon-pipe path is left behind on POSIX (it is a real file);
+    // remove it so the new daemon can recreate it cleanly. On Windows the
+    // named pipe disappears when the process dies, but the daemon-pipe
+    // marker file may remain.
+    try { fs.unlinkSync(path.join(wmuxDir, 'daemon-pipe')); } catch { /* ignore */ }
+
+    // Second daemon: respawn → recovery loop loads from .buf + sessions.json.
+    const child2 = spawnDaemon(testHome);
+    let stderr2 = '';
+    child2.stderr.on('data', (d) => { stderr2 += d.toString(); });
+    let stdout2 = '';
+    child2.stdout.on('data', (d) => { stdout2 += d.toString(); });
+    try {
+      const resolvedPipe2 = await waitForPipeFile(wmuxDir);
+      // Recovery loop spawns PTYs which can race ConPTY init on Windows;
+      // give it more headroom than a graceful shutdown round trip.
+      await new Promise((r) => setTimeout(r, 5000));
+      const socket2 = await connectSocket(resolvedPipe2);
+      try {
+        const live = await rpc(socket2, 'daemon.listSessions', {}, authToken);
+        sessionRecovered = Array.isArray(live) && live.some((s) => s.id === effectiveSessionId);
+        if (!sessionRecovered) {
+          // Diagnostic breadcrumb so the report explains the miss. The
+          // daemon's `log()` writes to stdout, so most recovery info /
+          // error lines land in stdout2 rather than stderr2.
+          const stdoutTail = stdout2.slice(-1000).replace(/\s+/g, ' ');
+          const stderrTail = stderr2.slice(-400).replace(/\s+/g, ' ');
+          recoveryError = `listSessions did not include ${effectiveSessionId} (got ${JSON.stringify(live)}). stdout_tail=${stdoutTail} stderr_tail=${stderrTail}`;
+        }
+      } finally {
+        socket2.end();
+      }
+    } catch (err) {
+      recoveryError = `second-daemon: ${err.message}. stderr_tail=${stderr2.slice(-600)}`;
+    } finally {
+      await killDaemon(child2);
+    }
+    // Reference stdout2 so the linter doesn't trim it; helpful when manually
+    // expanding the harness.
+    void stdout2;
+  } finally {
+    try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+
+  report.push({
+    scenario: 'T4',
+    bufExistsBeforeKill,
+    bufExistsAfterKill,
+    entryPresentAfterKill,
+    sessionRecovered,
+    recoveryError,
+    pass: bufExistsBeforeKill && bufExistsAfterKill && entryPresentAfterKill && sessionRecovered,
+  });
+}
+
 async function runT5(report) {
   const sizes = [1, 10, 50];
   const latencies = {};
@@ -289,14 +432,19 @@ process.on('uncaughtException', (err) => {
 
 const report = [];
 let exitCode = 0;
-try {
-  await runT1(report);
-  await runT2(report);
-  await runT5(report);
-} catch (err) {
-  console.error('[FAIL]', err.message);
-  console.error(err.stack);
-  exitCode = 1;
+// Per-scenario try/catch so one ConPTY race does not collapse the rest.
+for (const [name, fn] of [
+  ['T1', runT1],
+  ['T2', runT2],
+  ['T4', runT4],
+  ['T5', runT5],
+]) {
+  try {
+    await fn(report);
+  } catch (err) {
+    console.error(`[${name}] threw: ${err.message}`);
+    report.push({ scenario: name, pass: false, error: err.message });
+  }
 }
 
 console.log('\n=== REPORT ===');

--- a/src/company/renderer/components/CompanyView.tsx
+++ b/src/company/renderer/components/CompanyView.tsx
@@ -56,9 +56,12 @@ function ManageView({ onClose }: { onClose: () => void }) {
     }
   };
 
-  const handleDestroy = () => {
+  const handleDestroy = async () => {
     if (!confirm('Destroy company and all teams?')) return;
-    destroyCompanyWithCleanup();
+    // M6 TODOS #4 — await dispose Promise.all before unmounting so the
+    // store does not flip to company === null while async dispose
+    // handlers still reference it.
+    await destroyCompanyWithCleanup();
     onClose();
   };
 

--- a/src/company/renderer/provisioner.ts
+++ b/src/company/renderer/provisioner.ts
@@ -304,37 +304,58 @@ export async function spawnMember(
 
 // ─── Destroy company: dispose all PTYs then clean store ──────────────────────
 
-export function destroyCompanyWithCleanup(): void {
+// TODOS #4 + #5 (M6 in-orbit fixes for v2.9.1):
+//
+// #4 race condition: the previous fire-and-forget dispose pattern returned
+// before any pty.dispose() Promise settled, then immediately cleared the
+// store via destroyCompany(). The UI's next render saw company === null
+// while async dispose handlers were still mid-flight, occasionally
+// dereferencing the just-cleared store and crashing the renderer. Fix:
+// await Promise.all on every dispose before mutating the store.
+//
+// #5 PTY leak: only `m.ptyId` (the member's primary terminal) was
+// disposed. If a member workspace had additional surfaces (splits, extra
+// terminals created by the agent), those ptyIds stayed alive — leaking
+// memory until daemon shutdown. Fix: collect leaf surfaces from each
+// member's workspace rootPane, same pattern as the CEO workspace branch.
+export async function destroyCompanyWithCleanup(): Promise<void> {
   const state = useStore.getState();
   const company = state.company;
   if (!company) return;
 
-  // Collect all PTY IDs (members + CEO workspace)
   const ptyIds: string[] = [];
   for (const dept of company.departments) {
     for (const m of dept.members) {
       if (m.ptyId) ptyIds.push(m.ptyId);
+      // TODOS #5 — sweep the member's workspace surfaces too.
+      if (m.workspaceId) {
+        const memWs = state.workspaces.find((ws) => ws.id === m.workspaceId);
+        if (memWs) {
+          for (const ptyId of collectLeafSurfaces(memWs.rootPane)) {
+            if (!ptyIds.includes(ptyId)) ptyIds.push(ptyId);
+          }
+        }
+      }
     }
   }
 
-  // Also dispose CEO workspace PTY
   if (company.ceoWorkspaceId) {
     const ceoWs = state.workspaces.find((ws) => ws.id === company.ceoWorkspaceId);
     if (ceoWs) {
-      const leaves = collectLeafSurfaces(ceoWs.rootPane);
-      for (const ptyId of leaves) {
+      for (const ptyId of collectLeafSurfaces(ceoWs.rootPane)) {
         if (!ptyIds.includes(ptyId)) ptyIds.push(ptyId);
       }
     }
   }
 
-  // Dispose all PTYs (fire-and-forget, errors ignored)
-  for (const ptyId of ptyIds) {
-    window.electronAPI.pty.dispose(ptyId).catch(() => { /* ignore dispose errors */ });
-  }
+  // TODOS #4 — await every dispose before clearing the store.
+  await Promise.all(
+    ptyIds.map((ptyId) =>
+      window.electronAPI.pty.dispose(ptyId).catch(() => { /* ignore dispose errors */ }),
+    ),
+  );
   console.log(`[company] Destroyed: disposed ${ptyIds.length} PTYs`);
 
-  // Clean store
   state.destroyCompany();
 }
 

--- a/src/daemon/RingBuffer.ts
+++ b/src/daemon/RingBuffer.ts
@@ -1,5 +1,18 @@
-import { writeFile } from 'node:fs/promises';
-import { readFileSync } from 'node:fs';
+import { writeFile, rename, unlink } from 'node:fs/promises';
+import {
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  unlinkSync,
+  readdirSync,
+} from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+// Pattern that identifies temporary buffer files produced by
+// dumpToFile / dumpToFileSyncAtomic. Recovery / dump-readers must skip
+// these; they may exist briefly between the tmp write and the rename.
+const TMP_SUFFIX_RE = /\.tmp\.[0-9a-f]+$/;
 
 /**
  * Fixed-size circular byte buffer for storing ConPTY output per session.
@@ -109,11 +122,48 @@ export class RingBuffer {
     return this.capacity;
   }
 
-  /** Dump the buffer contents to a file (for DEAD session log preservation). */
+  /**
+   * Dump the buffer contents to a file atomically (write to tmp + rename).
+   *
+   * Phase A — A4. Writing the .buf directly is not safe across a crash:
+   * a reader that races a half-written buffer would see a truncated file
+   * and either fail to parse or restore a scrollback that abruptly cuts
+   * off mid-frame. tmp + rename keeps readers from ever observing a
+   * partial state — the rename either has happened or has not.
+   *
+   * The tmp file lives in the SAME parent directory as the destination
+   * so rename is always intra-FS (cross-device renames fail with EXDEV).
+   * On failure, the tmp file is best-effort cleaned up; recovery code
+   * also sweeps stale tmps via {@link cleanupStaleTmpFiles}.
+   */
   async dumpToFile(filePath: string): Promise<void> {
     const data = this.readAll();
-    // Note: mode is no-op on Windows; use icacls for NTFS ACLs
-    await writeFile(filePath, data, { mode: 0o600 });
+    const tmpPath = `${filePath}.tmp.${crypto.randomBytes(6).toString('hex')}`;
+    try {
+      // mode is a no-op on Windows; use icacls for NTFS ACLs.
+      await writeFile(tmpPath, data, { mode: 0o600 });
+      await rename(tmpPath, filePath);
+    } catch (err) {
+      try { await unlink(tmpPath); } catch { /* tmp may already be gone */ }
+      throw err;
+    }
+  }
+
+  /**
+   * Synchronous atomic dump. Used by the Windows process.on('exit')
+   * handler as a last-resort save when the daemon has no time to await
+   * the async path. Same tmp + rename invariants as {@link dumpToFile}.
+   */
+  dumpToFileSyncAtomic(filePath: string): void {
+    const data = this.readAll();
+    const tmpPath = `${filePath}.tmp.${crypto.randomBytes(6).toString('hex')}`;
+    try {
+      writeFileSync(tmpPath, data, { mode: 0o600 });
+      renameSync(tmpPath, filePath);
+    } catch (err) {
+      try { unlinkSync(tmpPath); } catch { /* tmp may already be gone */ }
+      throw err;
+    }
   }
 
   /** Create a RingBuffer pre-filled with data loaded from a file. */
@@ -124,5 +174,39 @@ export class RingBuffer {
       rb.write(data);
     }
     return rb;
+  }
+
+  /**
+   * Best-effort cleanup of stale `.tmp.<hex>` files in the buffer directory.
+   *
+   * tmp files only exist between the write and rename steps of an atomic
+   * dump. Under normal operation rename either succeeds (no tmp left) or
+   * the catch handler unlinks the tmp. A power loss or SIGKILL between
+   * the two steps can leave a tmp behind. Recovery + dump-readers must
+   * ignore them (test the filename against {@link TMP_SUFFIX_RE}); this
+   * helper unlinks them so the buffer directory does not accumulate
+   * orphans. Errors are swallowed — cleanup is best-effort.
+   */
+  static cleanupStaleTmpFiles(dir: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return; // dir does not exist yet — nothing to clean.
+    }
+    for (const name of entries) {
+      if (TMP_SUFFIX_RE.test(name)) {
+        try {
+          unlinkSync(path.join(dir, name));
+        } catch {
+          // file may have been removed by another process; ignore.
+        }
+      }
+    }
+  }
+
+  /** True if the filename is a tmp companion of an atomic dump. */
+  static isTmpFile(name: string): boolean {
+    return TMP_SUFFIX_RE.test(name);
   }
 }

--- a/src/daemon/StateWriter.ts
+++ b/src/daemon/StateWriter.ts
@@ -285,9 +285,14 @@ export class StateWriter {
     return path.join(path.dirname(this.filePath), 'buffers', `${sessionId}.buf`);
   }
 
+  /** Get the buffers/ directory path. */
+  getBufferDir(): string {
+    return path.join(path.dirname(this.filePath), 'buffers');
+  }
+
   /** Ensure the buffers/ directory exists. */
   ensureBufferDir(): void {
-    const dir = path.join(path.dirname(this.filePath), 'buffers');
+    const dir = this.getBufferDir();
     if (!fs.existsSync(dir)) {
       // Note: mode is no-op on Windows; use icacls for NTFS ACLs
       fs.mkdirSync(dir, { recursive: true, mode: 0o700 });

--- a/src/daemon/__tests__/createSessionPersistence.test.ts
+++ b/src/daemon/__tests__/createSessionPersistence.test.ts
@@ -128,6 +128,49 @@ describe('A1a invariant — saveImmediate persists synchronously', () => {
     manager.destroySession(session.id);
   });
 
+  // Source-level guard — addresses codex review P3 (2026-05-15 session
+  // 019e2af8). The behavioral tests above replay the production sequence but
+  // do not invoke the actual RPC handler. A handler-level refactor that
+  // removed `stateWriter.saveImmediate(state)` would not fail those tests.
+  //
+  // This static check reads the daemon entrypoint source and confirms the
+  // saveImmediate call is still present in both handler bodies. We slice the
+  // source by handler-marker comments (// daemon.<method>) rather than using
+  // a regex over braces, because handler bodies contain nested arrow callbacks
+  // (e.g., processMonitor.watch) that would confuse a brace-based match.
+  it('source-level guard: createSession + attachSession handlers retain saveImmediate', () => {
+    const daemonIndexPath = path.join(__dirname, '..', 'index.ts');
+    const src = fs.readFileSync(daemonIndexPath, 'utf-8');
+    const lines = src.split('\n');
+
+    function extractHandlerBody(method: string): string {
+      const startMarker = `// daemon.${method}`;
+      const startIdx = lines.findIndex((l) => l.trim() === startMarker);
+      if (startIdx < 0) throw new Error(`Start marker not found: ${startMarker}`);
+      // Body runs until the next `// daemon.<word>` comment line, exclusive.
+      const nextHandlerIdx = lines.findIndex(
+        (l, i) => i > startIdx && /^\s*\/\/ daemon\.\w+\s*$/.test(l),
+      );
+      const endIdx = nextHandlerIdx > 0 ? nextHandlerIdx : lines.length;
+      return lines.slice(startIdx, endIdx).join('\n');
+    }
+
+    const createBody = extractHandlerBody('createSession');
+    const attachBody = extractHandlerBody('attachSession');
+
+    // saveImmediate(state) must appear in each handler. If a refactor removes
+    // it (e.g., debounces it via setImmediate), this guard fails.
+    expect(createBody).toMatch(/stateWriter\.saveImmediate\(\s*state\s*\)/);
+    expect(attachBody).toMatch(/stateWriter\.saveImmediate\(\s*state\s*\)/);
+
+    // Negative guard — saveImmediate is NOT wrapped in setImmediate or
+    // queueMicrotask in either handler.
+    expect(createBody).not.toMatch(/setImmediate\([^)]*saveImmediate/);
+    expect(createBody).not.toMatch(/queueMicrotask\([^)]*saveImmediate/);
+    expect(attachBody).not.toMatch(/setImmediate\([^)]*saveImmediate/);
+    expect(attachBody).not.toMatch(/queueMicrotask\([^)]*saveImmediate/);
+  });
+
   // Replays the production attachSession happy-path persistence
   // (src/daemon/index.ts:591-592). The throw-path (pipe.start() failing) is a
   // known gap tracked under codex finding #16 follow-up.

--- a/src/daemon/__tests__/createSessionPersistence.test.ts
+++ b/src/daemon/__tests__/createSessionPersistence.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// Mock node-pty so create/attach do not spawn real processes.
+// Mirrors the pattern in DaemonSessionManager.test.ts.
+class MockPty extends EventEmitter {
+  pid = 12345;
+  onData() { return { dispose: () => { /* noop */ } }; }
+  onExit() { return { dispose: () => { /* noop */ } }; }
+  write(_data: string): void { /* noop */ }
+  resize(_cols: number, _rows: number): void { /* noop */ }
+  kill(): void { /* noop */ }
+}
+
+vi.mock('node-pty', () => ({
+  default: {
+    spawn: () => new MockPty(),
+  },
+  spawn: () => new MockPty(),
+}));
+
+// Import after mock so DaemonSessionManager wires the mock.
+import { DaemonSessionManager } from '../DaemonSessionManager';
+import { StateWriter } from '../StateWriter';
+import type { DaemonState } from '../types';
+
+// A1a invariant lock test.
+//
+// Production behavior under test:
+//   daemon.createSession RPC handler (src/daemon/index.ts:474-508)
+//     calls sessionManager.createSession + buildState + stateWriter.saveImmediate(state)
+//     BEFORE returning. saveImmediate is synchronous (see StateWriter.ts:35), so
+//     sessions.json is on disk before the RPC ack is delivered to the caller.
+//   daemon.attachSession RPC handler (src/daemon/index.ts:544-595) has the same
+//     invariant on its happy path (lines 591-592). The throw-path
+//     (pipe.start() failing) is documented in decisions.md (codex finding #16).
+//
+// Why this test exists:
+//   The plan A1a step prescribed adding setImmediate(saveImmediate) to the
+//   createSession/attachSession handlers. Codex consult (session 019e2af8,
+//   2026-05-15) finding #16 verified the invariant is already in production.
+//   This test locks it against future refactors that would break it (e.g.,
+//   wrapping the call in setImmediate, making saveImmediate async, or
+//   reordering so save runs after pipe.start()).
+describe('A1a invariant — saveImmediate persists synchronously', () => {
+  let tmpDir: string;
+  let writer: StateWriter;
+  let manager: DaemonSessionManager;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-a1a-test-'));
+    writer = new StateWriter(tmpDir);
+    manager = new DaemonSessionManager();
+  });
+
+  afterEach(() => {
+    writer.dispose();
+    manager.disposeAll();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // Mirrors buildState() in src/daemon/index.ts:851-860.
+  function buildState(): DaemonState {
+    return {
+      version: 1,
+      sessions: manager.listSessions(),
+      bootId: 'a1a-test-boot',
+    };
+  }
+
+  it('StateWriter.saveImmediate has synchronous void return (lock against async refactor)', () => {
+    const ret = writer.saveImmediate({ version: 1, sessions: [] });
+    expect(ret).toBeUndefined();
+    // Defensive check: if a refactor returns a Promise, .then would exist.
+    expect((ret as unknown as { then?: unknown } | undefined)?.then).toBeUndefined();
+  });
+
+  it('sessions.json exists synchronously after saveImmediate returns', () => {
+    const filePath = path.join(tmpDir, 'sessions.json');
+    expect(fs.existsSync(filePath)).toBe(false);
+    writer.saveImmediate({ version: 1, sessions: [] });
+    // No await, no microtask yield, no setImmediate — file must exist now.
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it('saveImmediate write completes before any microtask boundary', async () => {
+    const filePath = path.join(tmpDir, 'sessions.json');
+    let observedAbsenceInMicrotask = false;
+    // Schedule a microtask that would observe the file's absence if saveImmediate
+    // were async or deferred via setImmediate.
+    Promise.resolve().then(() => {
+      observedAbsenceInMicrotask = !fs.existsSync(filePath);
+    });
+    writer.saveImmediate({ version: 1, sessions: [] });
+    // Drain microtask + macrotask queue.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(observedAbsenceInMicrotask).toBe(false);
+  });
+
+  // Replays the production createSession RPC handler sequence
+  // (src/daemon/index.ts:482-507) and asserts the persistence invariant.
+  it('createSession RPC sequence: session entry on disk before RPC return', () => {
+    const filePath = path.join(tmpDir, 'sessions.json');
+    const sessionId = 'a1a-invariant-create';
+
+    const session = manager.createSession({
+      id: sessionId,
+      cmd: 'bash',
+      cwd: tmpDir,
+      env: {},
+      cols: 80,
+      rows: 24,
+    });
+    const state = buildState();
+    writer.saveImmediate(state);
+    // ^ Equivalent to the moment the RPC handler returns the session to caller.
+
+    expect(fs.existsSync(filePath)).toBe(true);
+    const persisted = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as DaemonState;
+    expect(persisted.sessions).toContainEqual(
+      expect.objectContaining({ id: sessionId }),
+    );
+    expect(persisted.bootId).toBeDefined();
+
+    manager.destroySession(session.id);
+  });
+
+  // Replays the production attachSession happy-path persistence
+  // (src/daemon/index.ts:591-592). The throw-path (pipe.start() failing) is a
+  // known gap tracked under codex finding #16 follow-up.
+  it('attachSession RPC sequence (happy path): attached state on disk before RPC return', () => {
+    const filePath = path.join(tmpDir, 'sessions.json');
+    const sessionId = 'a1a-invariant-attach';
+
+    // Initial create + persist (so a session exists to attach).
+    manager.createSession({
+      id: sessionId,
+      cmd: 'bash',
+      cwd: tmpDir,
+      env: {},
+      cols: 80,
+      rows: 24,
+    });
+    writer.saveImmediate(buildState());
+
+    // Now exercise attachSession's persistence invariant. The production handler
+    // wraps a SessionPipe start between manager.attachSession and saveImmediate;
+    // we skip the pipe step because the invariant being locked is the
+    // saveImmediate sync write, not the pipe lifecycle.
+    manager.attachSession(sessionId);
+    writer.saveImmediate(buildState());
+
+    expect(fs.existsSync(filePath)).toBe(true);
+    const persisted = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as DaemonState;
+    const persistedSession = persisted.sessions.find((s) => s.id === sessionId);
+    expect(persistedSession).toBeDefined();
+    expect(persistedSession?.state).toBe('attached');
+
+    manager.destroySession(sessionId);
+  });
+});

--- a/src/daemon/__tests__/dumpToFile.atomic.test.ts
+++ b/src/daemon/__tests__/dumpToFile.atomic.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { RingBuffer } from '../RingBuffer';
+
+// Phase A — A4. RingBuffer dump must be atomic: a reader (recovery, the
+// SessionPipe replay path, a debugger inspecting `.buf` files) must never
+// observe a half-written buffer.
+describe('RingBuffer atomic dump (A4)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-a4-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('async dumpToFile', () => {
+    it('writes via tmp + rename and leaves no tmp behind', async () => {
+      const rb = new RingBuffer(1024);
+      rb.write(Buffer.from('hello world'));
+      const dst = path.join(tmpDir, 'session-1.buf');
+
+      await rb.dumpToFile(dst);
+
+      expect(fs.readFileSync(dst).toString()).toBe('hello world');
+      const tmps = fs.readdirSync(tmpDir).filter((n) => RingBuffer.isTmpFile(n));
+      expect(tmps).toHaveLength(0);
+    });
+
+    it('cleans up tmp on rename failure (best-effort)', async () => {
+      const rb = new RingBuffer(1024);
+      rb.write(Buffer.from('data'));
+      // dst inside a non-existent directory forces writeFile (and rename) to fail.
+      const badDst = path.join(tmpDir, 'no-such-dir', 'session.buf');
+      await expect(rb.dumpToFile(badDst)).rejects.toThrow();
+      // tmpDir itself stays clean (tmp would have lived inside no-such-dir).
+      const tmps = fs.readdirSync(tmpDir).filter((n) => RingBuffer.isTmpFile(n));
+      expect(tmps).toHaveLength(0);
+    });
+  });
+
+  describe('sync dumpToFileSyncAtomic', () => {
+    it('writes via tmp + renameSync and leaves no tmp behind', () => {
+      const rb = new RingBuffer(1024);
+      rb.write(Buffer.from('sync data'));
+      const dst = path.join(tmpDir, 'sync-1.buf');
+
+      rb.dumpToFileSyncAtomic(dst);
+
+      expect(fs.readFileSync(dst).toString()).toBe('sync data');
+      const tmps = fs.readdirSync(tmpDir).filter((n) => RingBuffer.isTmpFile(n));
+      expect(tmps).toHaveLength(0);
+    });
+
+    it('throws and cleans up tmp on rename failure', () => {
+      const rb = new RingBuffer(1024);
+      rb.write(Buffer.from('data'));
+      const badDst = path.join(tmpDir, 'no-such-dir', 'session.buf');
+      expect(() => rb.dumpToFileSyncAtomic(badDst)).toThrow();
+      const tmps = fs.readdirSync(tmpDir).filter((n) => RingBuffer.isTmpFile(n));
+      expect(tmps).toHaveLength(0);
+    });
+  });
+
+  describe('cleanupStaleTmpFiles', () => {
+    it('removes .tmp.<hex> files from the directory', () => {
+      fs.writeFileSync(path.join(tmpDir, 'session.buf'), 'live');
+      fs.writeFileSync(path.join(tmpDir, 'session.buf.tmp.abcdef01'), 'stale1');
+      fs.writeFileSync(path.join(tmpDir, 'session.buf.tmp.deadbeef'), 'stale2');
+
+      RingBuffer.cleanupStaleTmpFiles(tmpDir);
+
+      const remaining = fs.readdirSync(tmpDir).sort();
+      expect(remaining).toEqual(['session.buf']);
+    });
+
+    it('is a no-op if the directory does not exist', () => {
+      const missing = path.join(tmpDir, 'no-such-dir');
+      expect(() => RingBuffer.cleanupStaleTmpFiles(missing)).not.toThrow();
+    });
+
+    it('leaves non-tmp files untouched', () => {
+      fs.writeFileSync(path.join(tmpDir, 'a.buf'), '');
+      fs.writeFileSync(path.join(tmpDir, 'b.buf'), '');
+      fs.writeFileSync(path.join(tmpDir, 'random.txt'), '');
+      fs.writeFileSync(path.join(tmpDir, 'x.buf.tmp.deadbeef'), 'stale');
+
+      RingBuffer.cleanupStaleTmpFiles(tmpDir);
+
+      const remaining = fs.readdirSync(tmpDir).sort();
+      expect(remaining).toEqual(['a.buf', 'b.buf', 'random.txt']);
+    });
+  });
+
+  describe('isTmpFile', () => {
+    it('matches the .tmp.<hex> suffix pattern', () => {
+      expect(RingBuffer.isTmpFile('session.buf.tmp.abcdef01')).toBe(true);
+      expect(RingBuffer.isTmpFile('xx.tmp.0123abcd')).toBe(true);
+      expect(RingBuffer.isTmpFile('xx.tmp.aabbccddeeff')).toBe(true);
+    });
+
+    it('rejects unrelated names', () => {
+      expect(RingBuffer.isTmpFile('session.buf')).toBe(false);
+      expect(RingBuffer.isTmpFile('foo.tmp')).toBe(false);
+      expect(RingBuffer.isTmpFile('foo.tmp.notHexZ')).toBe(false);
+      expect(RingBuffer.isTmpFile('foo.bak')).toBe(false);
+    });
+  });
+
+  // Atomic invariant: a reader observing the destination path mid-dump must
+  // see either the old file or the new file, never a partial write.
+  // We approximate this by checking that the final on-disk content always
+  // matches the latest dumped buffer end-to-end, across rapid back-to-back
+  // dumps. A bare writeFile (non-atomic) would produce intermediate sizes.
+  it('back-to-back dumps never leave the destination at an in-between size', async () => {
+    const rb = new RingBuffer(1024);
+    const dst = path.join(tmpDir, 'concurrent.buf');
+    const payloads = ['short', 'medium-length', 'a longer payload going through many bytes', 'final'];
+    for (const p of payloads) {
+      rb.clear();
+      rb.write(Buffer.from(p));
+      await rb.dumpToFile(dst);
+      expect(fs.readFileSync(dst).toString()).toBe(p);
+    }
+  });
+});

--- a/src/daemon/__tests__/runSnapshotOnce.test.ts
+++ b/src/daemon/__tests__/runSnapshotOnce.test.ts
@@ -23,7 +23,7 @@ vi.mock('node-pty', () => ({
 // Import after mock so DaemonSessionManager wires the mock.
 import { DaemonSessionManager } from '../DaemonSessionManager';
 import { StateWriter } from '../StateWriter';
-import { createSnapshotRunner } from '../index';
+import { createSnapshotRunner } from '../snapshotRunner';
 
 describe('createSnapshotRunner (A1b — extracted from periodic interval body)', () => {
   let tmpDir: string;
@@ -35,7 +35,9 @@ describe('createSnapshotRunner (A1b — extracted from periodic interval body)',
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-a1b-test-'));
     manager = new DaemonSessionManager();
     writer = new StateWriter(tmpDir);
-    runSnapshotOnce = createSnapshotRunner(manager, writer);
+    runSnapshotOnce = createSnapshotRunner(manager, writer, {
+      getBootId: () => 'a1b-test-boot',
+    });
   });
 
   afterEach(() => {

--- a/src/daemon/__tests__/runSnapshotOnce.test.ts
+++ b/src/daemon/__tests__/runSnapshotOnce.test.ts
@@ -167,18 +167,15 @@ describe('createSnapshotRunner (A1b — extracted from periodic interval body)',
     expect(fs.existsSync(writer.getBufferDumpPath('ok-two'))).toBe(true);
   });
 
-  // In-flight guard: a concurrent re-entry while the previous run is still
-  // awaiting a dumpToFile call must skip without performing additional work.
-  // This locks the behavior the inline 30s setInterval relied on (its
-  // `if (snapshotRunning) return` guard) so the setInterval body can safely
-  // fan out to runSnapshotOnce.
-  it('in-flight guard prevents concurrent execution', async () => {
+  // Pending-rerun pattern: a concurrent trigger arriving while the previous
+  // run is mid-dump must NOT be dropped — otherwise a session created during
+  // the in-flight window would miss its .buf until the next 30 s interval.
+  // The runner marks pendingRerun and re-loops after the current iteration
+  // completes. Codex review P2, session 019e2af8.
+  it('in-flight guard queues a rerun for concurrent triggers', async () => {
     manager.createSession({ id: 's1', cmd: 'bash', cwd: tmpDir, env: {}, cols: 80, rows: 24 });
     const session = manager.getSession('s1')!;
 
-    // dumpToFile hangs until we release it via resolveCurrent. The mock
-    // re-installs resolveCurrent on every invocation so we control each call
-    // independently.
     let resolveCurrent: (() => void) | null = null;
     const dumpSpy = vi.spyOn(session.ringBuffer, 'dumpToFile').mockImplementation(
       () => new Promise<void>((resolve) => { resolveCurrent = () => resolve(); }),
@@ -189,20 +186,25 @@ describe('createSnapshotRunner (A1b — extracted from periodic interval body)',
     await new Promise<void>((resolve) => setImmediate(resolve));
     expect(dumpSpy).toHaveBeenCalledTimes(1);
 
-    // Second concurrent call must short-circuit on the running flag.
+    // Concurrent trigger marks pendingRerun and returns without dumping.
     await runSnapshotOnce();
     expect(dumpSpy).toHaveBeenCalledTimes(1);
 
-    // Release the first call and wait for it to fully clean up.
+    // Release the first dump. The runner sees pendingRerun and re-loops,
+    // which calls dumpToFile a second time on the next iteration.
     resolveCurrent!();
-    await first;
-    expect(dumpSpy).toHaveBeenCalledTimes(1);
-
-    // After release a fresh call works normally. Start it, let it park on
-    // dumpToFile, then release so the test doesn't hang.
-    const third = runSnapshotOnce();
     await new Promise<void>((resolve) => setImmediate(resolve));
     expect(dumpSpy).toHaveBeenCalledTimes(2);
+
+    // Release the rerun's dump so `first` can resolve.
+    resolveCurrent!();
+    await first;
+    expect(dumpSpy).toHaveBeenCalledTimes(2);
+
+    // After the run fully completes, a fresh call works normally.
+    const third = runSnapshotOnce();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(dumpSpy).toHaveBeenCalledTimes(3);
     resolveCurrent!();
     await third;
   });

--- a/src/daemon/__tests__/runSnapshotOnce.test.ts
+++ b/src/daemon/__tests__/runSnapshotOnce.test.ts
@@ -35,7 +35,9 @@ describe('createSnapshotRunner (A1b — extracted from periodic interval body)',
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-a1b-test-'));
     manager = new DaemonSessionManager();
     writer = new StateWriter(tmpDir);
-    runSnapshotOnce = createSnapshotRunner(manager, writer);
+    runSnapshotOnce = createSnapshotRunner(manager, writer, {
+      getBootId: () => 'a1b-test-boot',
+    });
   });
 
   afterEach(() => {
@@ -61,20 +63,33 @@ describe('createSnapshotRunner (A1b — extracted from periodic interval body)',
     expect(fs.existsSync(writer.getBufferDumpPath('s2'))).toBe(true);
   });
 
-  // The runner intentionally does NOT persist sessions.json — that is owned
-  // by the create/attach/detach/destroy RPC handlers + recovery. If the
-  // runner re-saved listSessions() it would clobber any suspended sessions
-  // that recovery preserved past MAX_RECOVER_SESSIONS. Codex review P2,
+  // sessions.json must include both managed sessions (with their current
+  // in-memory metadata: lastActivity, cwd, geometry) AND any non-managed
+  // entries already in the file (cap-skipped suspended sessions from
+  // recovery, which live only in the file because MAX_RECOVER_SESSIONS
+  // bounded what got loaded into sessionManager). Codex review P2,
   // session 019e2af8.
-  it('does not persist sessions.json (cap-skipped session preservation)', async () => {
-    // Seed sessions.json with a session that lives only in the file, not in
-    // sessionManager (simulating a recovery-cap-skipped suspended session).
+  it('merges cap-skipped sessions from existing sessions.json into the save', async () => {
     const sessionsFile = path.join(tmpDir, 'sessions.json');
     fs.writeFileSync(
       sessionsFile,
       JSON.stringify({
         version: 1,
-        sessions: [{ id: 'cap-skipped', state: 'suspended', cmd: 'bash', cwd: tmpDir, env: {}, cols: 80, rows: 24, pid: 999, createdAt: '2026-05-15T00:00:00Z', lastActivity: '2026-05-15T00:00:00Z', deadTtlHours: 24 }],
+        sessions: [
+          {
+            id: 'cap-skipped',
+            state: 'suspended',
+            cmd: 'bash',
+            cwd: tmpDir,
+            env: {},
+            cols: 80,
+            rows: 24,
+            pid: 999,
+            createdAt: '2026-05-15T00:00:00Z',
+            lastActivity: '2026-05-15T00:00:00Z',
+            deadTtlHours: 24,
+          },
+        ],
         bootId: 'old-boot',
       }),
     );
@@ -83,13 +98,60 @@ describe('createSnapshotRunner (A1b — extracted from periodic interval body)',
 
     await runSnapshotOnce();
 
-    // sessions.json untouched — cap-skipped entry still present.
     const persisted = JSON.parse(fs.readFileSync(sessionsFile, 'utf-8')) as {
       sessions: { id: string }[];
+      bootId?: string;
     };
-    expect(persisted.sessions.map((s) => s.id)).toEqual(['cap-skipped']);
-    // But the live session's .buf was still produced.
+    // Both entries present.
+    const ids = persisted.sessions.map((s) => s.id).sort();
+    expect(ids).toEqual(['cap-skipped', 'live-one'].sort());
+    // bootId refreshed to runner's value.
+    expect(persisted.bootId).toBe('a1b-test-boot');
+    // Live session's .buf produced.
     expect(fs.existsSync(writer.getBufferDumpPath('live-one'))).toBe(true);
+  });
+
+  // Authoritative-managed rule: if a session id exists in both the existing
+  // file and sessionManager, sessionManager wins (carries the latest
+  // lastActivity / cwd / geometry that may not yet have been saved by any
+  // RPC handler).
+  it('takes sessionManager state as authoritative for managed session ids', async () => {
+    const sessionsFile = path.join(tmpDir, 'sessions.json');
+    fs.writeFileSync(
+      sessionsFile,
+      JSON.stringify({
+        version: 1,
+        sessions: [
+          {
+            id: 'live-one',
+            state: 'detached',
+            cmd: 'OLD-CMD',
+            cwd: '/old/cwd',
+            env: {},
+            cols: 9999,
+            rows: 9999,
+            pid: 1,
+            createdAt: '2026-01-01T00:00:00Z',
+            lastActivity: '2026-01-01T00:00:00Z',
+            deadTtlHours: 24,
+          },
+        ],
+        bootId: 'old-boot',
+      }),
+    );
+
+    manager.createSession({ id: 'live-one', cmd: 'bash', cwd: tmpDir, env: {}, cols: 80, rows: 24 });
+
+    await runSnapshotOnce();
+
+    const persisted = JSON.parse(fs.readFileSync(sessionsFile, 'utf-8')) as {
+      sessions: { id: string; cmd: string; cwd: string; cols: number; rows: number }[];
+    };
+    expect(persisted.sessions).toHaveLength(1);
+    expect(persisted.sessions[0].cmd).toBe('bash');
+    expect(persisted.sessions[0].cwd).toBe(tmpDir);
+    expect(persisted.sessions[0].cols).toBe(80);
+    expect(persisted.sessions[0].rows).toBe(24);
   });
 
   it('continues after a per-session dumpToFile failure (isolated error handling)', async () => {

--- a/src/daemon/__tests__/runSnapshotOnce.test.ts
+++ b/src/daemon/__tests__/runSnapshotOnce.test.ts
@@ -35,9 +35,7 @@ describe('createSnapshotRunner (A1b — extracted from periodic interval body)',
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-a1b-test-'));
     manager = new DaemonSessionManager();
     writer = new StateWriter(tmpDir);
-    runSnapshotOnce = createSnapshotRunner(manager, writer, {
-      getBootId: () => 'a1b-test-boot',
-    });
+    runSnapshotOnce = createSnapshotRunner(manager, writer);
   });
 
   afterEach(() => {
@@ -49,18 +47,49 @@ describe('createSnapshotRunner (A1b — extracted from periodic interval body)',
 
   it('no-ops when there are no live sessions', async () => {
     await runSnapshotOnce();
-    expect(fs.existsSync(path.join(tmpDir, 'sessions.json'))).toBe(false);
+    // Buffer dir may exist (ensureBufferDir was skipped on empty); no dumps.
+    expect(fs.readdirSync(tmpDir).filter((n) => n.endsWith('.buf'))).toHaveLength(0);
   });
 
-  it('dumps a .buf for every live session and persists sessions.json', async () => {
+  it('dumps a .buf for every live session', async () => {
     manager.createSession({ id: 's1', cmd: 'bash', cwd: tmpDir, env: {}, cols: 80, rows: 24 });
     manager.createSession({ id: 's2', cmd: 'bash', cwd: tmpDir, env: {}, cols: 80, rows: 24 });
 
     await runSnapshotOnce();
 
-    expect(fs.existsSync(path.join(tmpDir, 'sessions.json'))).toBe(true);
     expect(fs.existsSync(writer.getBufferDumpPath('s1'))).toBe(true);
     expect(fs.existsSync(writer.getBufferDumpPath('s2'))).toBe(true);
+  });
+
+  // The runner intentionally does NOT persist sessions.json — that is owned
+  // by the create/attach/detach/destroy RPC handlers + recovery. If the
+  // runner re-saved listSessions() it would clobber any suspended sessions
+  // that recovery preserved past MAX_RECOVER_SESSIONS. Codex review P2,
+  // session 019e2af8.
+  it('does not persist sessions.json (cap-skipped session preservation)', async () => {
+    // Seed sessions.json with a session that lives only in the file, not in
+    // sessionManager (simulating a recovery-cap-skipped suspended session).
+    const sessionsFile = path.join(tmpDir, 'sessions.json');
+    fs.writeFileSync(
+      sessionsFile,
+      JSON.stringify({
+        version: 1,
+        sessions: [{ id: 'cap-skipped', state: 'suspended', cmd: 'bash', cwd: tmpDir, env: {}, cols: 80, rows: 24, pid: 999, createdAt: '2026-05-15T00:00:00Z', lastActivity: '2026-05-15T00:00:00Z', deadTtlHours: 24 }],
+        bootId: 'old-boot',
+      }),
+    );
+
+    manager.createSession({ id: 'live-one', cmd: 'bash', cwd: tmpDir, env: {}, cols: 80, rows: 24 });
+
+    await runSnapshotOnce();
+
+    // sessions.json untouched — cap-skipped entry still present.
+    const persisted = JSON.parse(fs.readFileSync(sessionsFile, 'utf-8')) as {
+      sessions: { id: string }[];
+    };
+    expect(persisted.sessions.map((s) => s.id)).toEqual(['cap-skipped']);
+    // But the live session's .buf was still produced.
+    expect(fs.existsSync(writer.getBufferDumpPath('live-one'))).toBe(true);
   });
 
   it('continues after a per-session dumpToFile failure (isolated error handling)', async () => {
@@ -72,8 +101,6 @@ describe('createSnapshotRunner (A1b — extracted from periodic interval body)',
 
     await runSnapshotOnce();
 
-    // sessions.json still written even though one dump failed.
-    expect(fs.existsSync(path.join(tmpDir, 'sessions.json'))).toBe(true);
     // ok-two's dump still produced.
     expect(fs.existsSync(writer.getBufferDumpPath('ok-two'))).toBe(true);
   });

--- a/src/daemon/__tests__/runSnapshotOnce.test.ts
+++ b/src/daemon/__tests__/runSnapshotOnce.test.ts
@@ -148,7 +148,13 @@ describe('createSnapshotRunner (A1b — extracted from periodic interval body)',
       sessions: { id: string; cmd: string; cwd: string; cols: number; rows: number }[];
     };
     expect(persisted.sessions).toHaveLength(1);
-    expect(persisted.sessions[0].cmd).toBe('bash');
+    // DaemonSessionManager resolves bare shell names to absolute paths on
+    // POSIX (`bash` → `/bin/bash` on macOS / Linux) but not on Windows.
+    // The invariant under test is "managed overrides the stale OLD-CMD",
+    // not "cmd equals the string we passed". Match on bash suffix and
+    // assert the stale value is gone.
+    expect(persisted.sessions[0].cmd).toMatch(/bash$/);
+    expect(persisted.sessions[0].cmd).not.toBe('OLD-CMD');
     expect(persisted.sessions[0].cwd).toBe(tmpDir);
     expect(persisted.sessions[0].cols).toBe(80);
     expect(persisted.sessions[0].rows).toBe(24);

--- a/src/daemon/__tests__/runSnapshotOnce.test.ts
+++ b/src/daemon/__tests__/runSnapshotOnce.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// Mock node-pty so createSession does not spawn real processes.
+// Mirrors the pattern in DaemonSessionManager.test.ts.
+class MockPty extends EventEmitter {
+  pid = 12345;
+  onData() { return { dispose: () => { /* noop */ } }; }
+  onExit() { return { dispose: () => { /* noop */ } }; }
+  write(_data: string): void { /* noop */ }
+  resize(_cols: number, _rows: number): void { /* noop */ }
+  kill(): void { /* noop */ }
+}
+
+vi.mock('node-pty', () => ({
+  default: { spawn: () => new MockPty() },
+  spawn: () => new MockPty(),
+}));
+
+// Import after mock so DaemonSessionManager wires the mock.
+import { DaemonSessionManager } from '../DaemonSessionManager';
+import { StateWriter } from '../StateWriter';
+import { createSnapshotRunner } from '../index';
+
+describe('createSnapshotRunner (A1b — extracted from periodic interval body)', () => {
+  let tmpDir: string;
+  let manager: DaemonSessionManager;
+  let writer: StateWriter;
+  let runSnapshotOnce: () => Promise<void>;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-a1b-test-'));
+    manager = new DaemonSessionManager();
+    writer = new StateWriter(tmpDir);
+    runSnapshotOnce = createSnapshotRunner(manager, writer);
+  });
+
+  afterEach(() => {
+    manager.disposeAll();
+    writer.dispose();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('no-ops when there are no live sessions', async () => {
+    await runSnapshotOnce();
+    expect(fs.existsSync(path.join(tmpDir, 'sessions.json'))).toBe(false);
+  });
+
+  it('dumps a .buf for every live session and persists sessions.json', async () => {
+    manager.createSession({ id: 's1', cmd: 'bash', cwd: tmpDir, env: {}, cols: 80, rows: 24 });
+    manager.createSession({ id: 's2', cmd: 'bash', cwd: tmpDir, env: {}, cols: 80, rows: 24 });
+
+    await runSnapshotOnce();
+
+    expect(fs.existsSync(path.join(tmpDir, 'sessions.json'))).toBe(true);
+    expect(fs.existsSync(writer.getBufferDumpPath('s1'))).toBe(true);
+    expect(fs.existsSync(writer.getBufferDumpPath('s2'))).toBe(true);
+  });
+
+  it('continues after a per-session dumpToFile failure (isolated error handling)', async () => {
+    manager.createSession({ id: 'fail-one', cmd: 'bash', cwd: tmpDir, env: {}, cols: 80, rows: 24 });
+    manager.createSession({ id: 'ok-two', cmd: 'bash', cwd: tmpDir, env: {}, cols: 80, rows: 24 });
+
+    const failOne = manager.getSession('fail-one')!;
+    vi.spyOn(failOne.ringBuffer, 'dumpToFile').mockRejectedValueOnce(new Error('disk full'));
+
+    await runSnapshotOnce();
+
+    // sessions.json still written even though one dump failed.
+    expect(fs.existsSync(path.join(tmpDir, 'sessions.json'))).toBe(true);
+    // ok-two's dump still produced.
+    expect(fs.existsSync(writer.getBufferDumpPath('ok-two'))).toBe(true);
+  });
+
+  // In-flight guard: a concurrent re-entry while the previous run is still
+  // awaiting a dumpToFile call must skip without performing additional work.
+  // This locks the behavior the inline 30s setInterval relied on (its
+  // `if (snapshotRunning) return` guard) so the setInterval body can safely
+  // fan out to runSnapshotOnce.
+  it('in-flight guard prevents concurrent execution', async () => {
+    manager.createSession({ id: 's1', cmd: 'bash', cwd: tmpDir, env: {}, cols: 80, rows: 24 });
+    const session = manager.getSession('s1')!;
+
+    // dumpToFile hangs until we release it via resolveCurrent. The mock
+    // re-installs resolveCurrent on every invocation so we control each call
+    // independently.
+    let resolveCurrent: (() => void) | null = null;
+    const dumpSpy = vi.spyOn(session.ringBuffer, 'dumpToFile').mockImplementation(
+      () => new Promise<void>((resolve) => { resolveCurrent = () => resolve(); }),
+    );
+
+    // First call enters and parks on the hanging dumpToFile.
+    const first = runSnapshotOnce();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(dumpSpy).toHaveBeenCalledTimes(1);
+
+    // Second concurrent call must short-circuit on the running flag.
+    await runSnapshotOnce();
+    expect(dumpSpy).toHaveBeenCalledTimes(1);
+
+    // Release the first call and wait for it to fully clean up.
+    resolveCurrent!();
+    await first;
+    expect(dumpSpy).toHaveBeenCalledTimes(1);
+
+    // After release a fresh call works normally. Start it, let it park on
+    // dumpToFile, then release so the test doesn't hang.
+    const third = runSnapshotOnce();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(dumpSpy).toHaveBeenCalledTimes(2);
+    resolveCurrent!();
+    await third;
+  });
+
+  it('treats dead sessions as not-live (skips dump for them)', async () => {
+    manager.createSession({ id: 'alive', cmd: 'bash', cwd: tmpDir, env: {}, cols: 80, rows: 24 });
+    manager.createSession({ id: 'dead', cmd: 'bash', cwd: tmpDir, env: {}, cols: 80, rows: 24 });
+    const deadSession = manager.getSession('dead')!;
+    deadSession.meta.state = 'dead';
+
+    const aliveDumpSpy = vi.spyOn(manager.getSession('alive')!.ringBuffer, 'dumpToFile');
+    const deadDumpSpy = vi.spyOn(deadSession.ringBuffer, 'dumpToFile');
+
+    await runSnapshotOnce();
+
+    expect(aliveDumpSpy).toHaveBeenCalledTimes(1);
+    expect(deadDumpSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/daemon/__tests__/shutdownRpc.test.ts
+++ b/src/daemon/__tests__/shutdownRpc.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// A2 invariant lock test.
+//
+// The daemon.shutdown RPC must:
+//   1. Call the shutdown() body with { skipPipeStop: true, skipExit: true }
+//      so the ack can flush back to the caller before the pipe closes and
+//      the process exits.
+//   2. Defer pipeServer.stop() and process.exit(0) to setImmediate AFTER
+//      returning from the handler, so the caller (e.g., main's before-quit
+//      or session-end races in A3/A5) can rely on the RPC promise actually
+//      meaning "shutdown work complete".
+//
+// The shutdown() function must honor:
+//   - opts.skipPipeStop — skip pipeServer.stop() (caller will run it later).
+//   - opts.skipExit — return instead of calling process.exit(0).
+//
+// We do not bootstrap a real daemon here (that would trigger main() and lock
+// the test process — see codex P1 lesson from A1b). Instead we read the
+// source and assert the invariants on the live code.
+describe('A2 — daemon.shutdown RPC + shutdown() opts (source-level invariants)', () => {
+  const daemonIndexPath = path.join(__dirname, '..', 'index.ts');
+  const src = fs.readFileSync(daemonIndexPath, 'utf-8');
+  const lines = src.split('\n');
+
+  function extractRpcHandlerBody(method: string): string {
+    const startMarker = `// daemon.${method}`;
+    const startIdx = lines.findIndex((l) => l.trim().startsWith(startMarker));
+    if (startIdx < 0) throw new Error(`Marker not found: ${startMarker}`);
+    const nextHandlerIdx = lines.findIndex(
+      (l, i) => i > startIdx && /^\s*\/\/ daemon\.\w+/.test(l),
+    );
+    const endIdx = nextHandlerIdx > 0 ? nextHandlerIdx : lines.length;
+    return lines.slice(startIdx, endIdx).join('\n');
+  }
+
+  it('daemon.shutdown handler awaits shutdown(...) with skipPipeStop + skipExit', () => {
+    const body = extractRpcHandlerBody('shutdown');
+
+    // Must call shutdown() and await it.
+    expect(body).toMatch(/await\s+shutdown\s*\(/);
+
+    // Must pass skipPipeStop: true and skipExit: true together.
+    expect(body).toMatch(/skipPipeStop:\s*true/);
+    expect(body).toMatch(/skipExit:\s*true/);
+  });
+
+  it('daemon.shutdown handler defers pipeServer.stop + process.exit via setImmediate', () => {
+    const body = extractRpcHandlerBody('shutdown');
+
+    // pipeServer.stop must happen in a setImmediate after the ack returns.
+    expect(body).toMatch(/setImmediate\([\s\S]*?pipeServer\.stop\(\)/);
+    // process.exit(0) must also be inside that deferred path.
+    expect(body).toMatch(/setImmediate\([\s\S]*?process\.exit\(0\)/);
+  });
+
+  it('shutdown function signature accepts opts with skipPipeStop and skipExit', () => {
+    // Match shutdown() definition (named async function).
+    const defStart = lines.findIndex((l) => /^async function shutdown\(/.test(l));
+    expect(defStart, 'shutdown function not found').toBeGreaterThanOrEqual(0);
+    // Body span until the closing brace of the function. We just need
+    // enough source to verify the opts handling — slice ahead a few hundred
+    // lines.
+    const defBody = lines.slice(defStart, defStart + 200).join('\n');
+
+    expect(defBody).toMatch(/opts:\s*{\s*skipPipeStop\?:\s*boolean;\s*skipExit\?:\s*boolean\s*}/);
+
+    // Body must gate pipeServer.stop() on !opts.skipPipeStop.
+    expect(defBody).toMatch(/if\s*\(\s*!opts\.skipPipeStop\s*\)\s*{[\s\S]*?pipeServer\.stop/);
+
+    // Body must early-return when opts.skipExit is true (skipping
+    // process.exit) — match the inverse: `if (opts.skipExit) { ... return; }`.
+    expect(defBody).toMatch(/if\s*\(\s*opts\.skipExit\s*\)\s*\{[\s\S]*?return;/);
+  });
+
+  it('DaemonClient.rpc accepts opts.timeoutMs (per-call override)', () => {
+    const clientPath = path.join(__dirname, '..', '..', 'main', 'DaemonClient.ts');
+    const clientSrc = fs.readFileSync(clientPath, 'utf-8');
+    // Signature includes opts: { timeoutMs?: number }.
+    expect(clientSrc).toMatch(/rpc\(\s*method:\s*string[\s\S]*?opts:\s*\{\s*timeoutMs\?:\s*number\s*\}/);
+    // Uses opts.timeoutMs in the setTimeout call.
+    expect(clientSrc).toMatch(/opts\.timeoutMs\s*\?\?\s*RPC_TIMEOUT_MS/);
+  });
+});

--- a/src/daemon/__tests__/syncExitGuard.test.ts
+++ b/src/daemon/__tests__/syncExitGuard.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// A4 — precise sync exit guard.
+//
+// The Windows process.on('exit') handler used to gate on `shuttingDown`
+// (set on entry to async shutdown), which would skip the sync save even if
+// the async path was interrupted before its dumps completed — a silent
+// data-loss path. A4 replaces that with `dumpsCompleted`, flipped to true
+// only after the async shutdown body's Promise.all(dumpToFile) resolves.
+//
+// We assert these invariants at the source level rather than spawning a
+// real daemon (codex P1 from A1b — importing src/daemon/index.ts triggers
+// main() at module load, which would lock the test process).
+describe('A4 — sync exit handler guard (source-level invariants)', () => {
+  const daemonIndexPath = path.join(__dirname, '..', 'index.ts');
+  const src = fs.readFileSync(daemonIndexPath, 'utf-8');
+
+  it('declares the dumpsCompleted module flag', () => {
+    expect(src).toMatch(/let dumpsCompleted = false;/);
+  });
+
+  it('flips dumpsCompleted=true after Promise.all(dumpPromises) in shutdown()', () => {
+    const lines = src.split('\n');
+    const start = lines.findIndex((l) => /^async function shutdown\(/.test(l));
+    expect(start, 'shutdown() definition not found').toBeGreaterThanOrEqual(0);
+    const body = lines.slice(start, start + 200).join('\n');
+    // Pattern: `await Promise.all(dumpPromises);` followed by the flip.
+    expect(body).toMatch(/await\s+Promise\.all\(dumpPromises\);[\s\S]*?dumpsCompleted\s*=\s*true/);
+  });
+
+  it('Windows exit handler short-circuits when dumpsCompleted is true', () => {
+    // Locate the actual process.on('exit') call site (the only one in the
+    // file); slicing from a generic win32 platform check would catch the
+    // first of five hits.
+    const exitIdx = src.indexOf("process.on('exit',");
+    expect(exitIdx, "process.on('exit') not found").toBeGreaterThanOrEqual(0);
+    const exitBlock = src.slice(exitIdx, exitIdx + 2000);
+    expect(exitBlock).toMatch(/if\s*\(\s*dumpsCompleted\s*\)\s*return;/);
+  });
+
+  it('Windows exit handler uses dumpToFileSyncAtomic (replaced bare writeFileSync)', () => {
+    const exitIdx = src.indexOf("process.on('exit',");
+    const exitBlock = src.slice(exitIdx, exitIdx + 2000);
+    expect(exitBlock).toMatch(/m\.ringBuffer\.dumpToFileSyncAtomic\(dumpPath\)/);
+    // Negative: no leftover bare writeFileSync on dumpPath inside the block.
+    expect(exitBlock).not.toMatch(/fs\.writeFileSync\(\s*dumpPath/);
+  });
+
+  it('main() sweeps stale tmp dumps via RingBuffer.cleanupStaleTmpFiles at startup', () => {
+    expect(src).toMatch(/RingBuffer\.cleanupStaleTmpFiles\(\s*stateWriter\.getBufferDir\(\)\s*\)/);
+  });
+});

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -700,11 +700,30 @@ function registerRpcHandlers(
     return { status: 'ok', uptime, sessions: sessions.length };
   });
 
-  // daemon.shutdown — gracefully terminate the daemon process
+  // daemon.shutdown — gracefully terminate the daemon process. A2 makes
+  // this RPC awaitable: the handler runs the full shutdown body (dumps,
+  // state save, dispose) before returning, then defers the pipe stop and
+  // process.exit to setImmediate so the RPC ack actually flushes back to
+  // the caller. Callers (e.g., main before-quit / WM_ENDSESSION) can
+  // await this with a per-call timeoutMs override (DaemonClient.rpc opt).
   pipeServer.onRpc('daemon.shutdown', async () => {
     log('info', 'Shutdown requested via RPC');
-    // Respond first, then initiate shutdown on next tick
-    setImmediate(() => process.emit('SIGTERM' as any));
+    await shutdown(
+      'rpc.shutdown',
+      sessionManager,
+      pipeServer,
+      stateWriter,
+      sessionPipes,
+      processMonitor,
+      watchdog,
+      { skipPipeStop: true, skipExit: true },
+    );
+    // ack flushes after this return; then the pipe + process tear down.
+    setImmediate(() => {
+      void pipeServer.stop().catch(() => { /* best effort */ }).finally(() => {
+        process.exit(0);
+      });
+    });
     return { status: 'ok' };
   });
 }
@@ -885,6 +904,7 @@ async function shutdown(
   sessionPipes: Map<string, SessionPipe>,
   processMonitor: ProcessMonitor,
   watchdog: Watchdog,
+  opts: { skipPipeStop?: boolean; skipExit?: boolean } = {},
 ): Promise<void> {
   if (shuttingDown) return;
   shuttingDown = true;
@@ -947,11 +967,25 @@ async function shutdown(
 
   stateWriter.dispose();
 
-  // Stop IPC server
-  await pipeServer.stop().catch(() => {});
+  // Stop IPC server — skipped when the caller (e.g., daemon.shutdown RPC)
+  // still needs the pipe to flush its ack.
+  if (!opts.skipPipeStop) {
+    await pipeServer.stop().catch(() => {});
+  }
 
   releaseLock();
   log('info', 'Daemon stopped');
+
+  // Clear the hard-timeout guard now that shutdown has reached its end.
+  // Without this, the timer would still fire after a skipExit deferral if
+  // the macrotask was delayed under load.
+  clearTimeout(shutdownTimeout);
+
+  if (opts.skipExit) {
+    // Caller (RPC handler) will fire setImmediate(() => process.exit(0))
+    // after returning so the ack flushes back to the client first.
+    return;
+  }
   process.exit(0);
 }
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -470,6 +470,7 @@ function registerRpcHandlers(
   startTime: number,
   sessionDataListeners: Map<string, { bridge: import('./DaemonPTYBridge').DaemonPTYBridge; listener: (data: Buffer) => void }>,
   watchdog: Watchdog,
+  triggerSnapshot: () => void,
 ): void {
   // daemon.createSession
   pipeServer.onRpc('daemon.createSession', async (params) => {
@@ -504,6 +505,11 @@ function registerRpcHandlers(
     // Save state immediately
     const state = buildState(sessionManager);
     stateWriter.saveImmediate(state);
+
+    // A1b — fire the snapshot runner so the new session has a .buf on disk
+    // before the next 30 s tick. Crashes within that window now keep a
+    // recoverable trace instead of losing the brand-new pane entirely.
+    triggerSnapshot();
 
     return session;
   });
@@ -591,6 +597,10 @@ function registerRpcHandlers(
 
     const state = buildState(sessionManager);
     stateWriter.saveImmediate(state);
+
+    // A1b — fire the snapshot runner after attach so a freshly-attached
+    // recovered session has its .buf refreshed inside the first 30 s window.
+    triggerSnapshot();
 
     return { ok: true };
   });
@@ -973,11 +983,28 @@ async function main(): Promise<void> {
   const sessionPipes = new Map<string, SessionPipe>();
   const sessionDataListeners = new Map<string, { bridge: import('./DaemonPTYBridge').DaemonPTYBridge; listener: (data: Buffer) => void }>();
 
+  // Forward reference — initialised at step 8c after the snapshot runner is
+  // wired. RPC handlers that fire before initialisation simply skip the
+  // immediate snapshot; the 30 s interval will still cover them.
+  let runSnapshotOnceRef: (() => Promise<void>) | null = null;
+
   // 4. Recover previous sessions
   await recoverSessions(stateWriter, sessionManager, processMonitor);
 
   // 5. Register RPC handlers
-  registerRpcHandlers(pipeServer, sessionManager, stateWriter, sessionPipes, processMonitor, startTime, sessionDataListeners, watchdog);
+  registerRpcHandlers(
+    pipeServer,
+    sessionManager,
+    stateWriter,
+    sessionPipes,
+    processMonitor,
+    startTime,
+    sessionDataListeners,
+    watchdog,
+    () => {
+      if (runSnapshotOnceRef) void runSnapshotOnceRef();
+    },
+  );
 
   // 6. Wire events
   wireEvents(sessionManager, pipeServer, stateWriter, sessionPipes, processMonitor, sessionDataListeners);
@@ -1051,12 +1078,8 @@ async function main(): Promise<void> {
   // Sequential dumps to avoid simultaneous memory peaks from all buffers at once.
   // The runner is also invoked once immediately below (A1b) to close the
   // 30 s window where no .buf exists yet on disk.
-  const runSnapshotOnce = createSnapshotRunner(sessionManager, stateWriter, {
-    getBootId: () => {
-      if (!cachedBootId) cachedBootId = getBootIdSync();
-      return cachedBootId;
-    },
-  });
+  const runSnapshotOnce = createSnapshotRunner(sessionManager, stateWriter);
+  runSnapshotOnceRef = runSnapshotOnce;
   const snapshotInterval = setInterval(() => {
     void runSnapshotOnce();
   }, 30_000);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -9,6 +9,7 @@ import { StateWriter } from './StateWriter';
 import { ProcessMonitor } from './ProcessMonitor';
 import { Watchdog } from './Watchdog';
 import { selectRecoverableSessions } from './recoverySelector';
+import { createSnapshotRunner } from './snapshotRunner';
 import type { DaemonState } from './types';
 import type { DaemonEvent, DaemonCreateSessionParams, DaemonSessionIdParams, DaemonResizeParams } from '../shared/rpc';
 
@@ -859,50 +860,8 @@ function buildState(sessionManager: DaemonSessionManager): DaemonState {
   };
 }
 
-// === Snapshot runner (Phase A — A1b) ===
-//
-// Returns an async function that dumps every live session's RingBuffer to disk
-// and persists sessions.json. Owns a per-runner re-entrancy flag so concurrent
-// invocations (e.g., scheduled tick fires while a previous tick is still
-// flushing) collapse to a single run.
-//
-// Extracted from the inline 30s setInterval body so it can also be invoked
-// once at spawn time, closing the window where no .buf yet exists on disk.
-// A crash within the first 30 s after daemon start would otherwise leave a
-// recovery loop with no buffer file to restore from.
-export function createSnapshotRunner(
-  sessionManager: DaemonSessionManager,
-  stateWriter: StateWriter,
-): () => Promise<void> {
-  let running = false;
-  return async function runSnapshotOnce(): Promise<void> {
-    if (running) return;
-    const managed = sessionManager.listManagedSessions();
-    const live = managed.filter((m) => m.meta.state !== 'dead');
-    if (live.length === 0) return;
-
-    running = true;
-    stateWriter.ensureBufferDir();
-    try {
-      for (const m of live) {
-        const dumpPath = stateWriter.getBufferDumpPath(m.meta.id);
-        try {
-          await m.ringBuffer.dumpToFile(dumpPath);
-        } catch (err) {
-          log('warn', `Snapshot dump failed for ${m.meta.id}:`, err);
-        }
-      }
-      try {
-        const state = buildState(sessionManager);
-        stateWriter.saveImmediate(state);
-      } catch (err) {
-        log('warn', 'Snapshot state save failed:', err);
-      }
-    } finally {
-      running = false;
-    }
-  };
-}
+// Phase A — A1b snapshot runner lives in ./snapshotRunner so the unit tests
+// can import it without triggering main() at the bottom of this file.
 
 // === Graceful shutdown ===
 
@@ -1092,7 +1051,12 @@ async function main(): Promise<void> {
   // Sequential dumps to avoid simultaneous memory peaks from all buffers at once.
   // The runner is also invoked once immediately below (A1b) to close the
   // 30 s window where no .buf exists yet on disk.
-  const runSnapshotOnce = createSnapshotRunner(sessionManager, stateWriter);
+  const runSnapshotOnce = createSnapshotRunner(sessionManager, stateWriter, {
+    getBootId: () => {
+      if (!cachedBootId) cachedBootId = getBootIdSync();
+      return cachedBootId;
+    },
+  });
   const snapshotInterval = setInterval(() => {
     void runSnapshotOnce();
   }, 30_000);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1078,7 +1078,12 @@ async function main(): Promise<void> {
   // Sequential dumps to avoid simultaneous memory peaks from all buffers at once.
   // The runner is also invoked once immediately below (A1b) to close the
   // 30 s window where no .buf exists yet on disk.
-  const runSnapshotOnce = createSnapshotRunner(sessionManager, stateWriter);
+  const runSnapshotOnce = createSnapshotRunner(sessionManager, stateWriter, {
+    getBootId: () => {
+      if (!cachedBootId) cachedBootId = getBootIdSync();
+      return cachedBootId;
+    },
+  });
   runSnapshotOnceRef = runSnapshotOnce;
   const snapshotInterval = setInterval(() => {
     void runSnapshotOnce();

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -10,6 +10,7 @@ import { ProcessMonitor } from './ProcessMonitor';
 import { Watchdog } from './Watchdog';
 import { selectRecoverableSessions } from './recoverySelector';
 import { createSnapshotRunner } from './snapshotRunner';
+import { RingBuffer } from './RingBuffer';
 import type { DaemonState } from './types';
 import type { DaemonEvent, DaemonCreateSessionParams, DaemonSessionIdParams, DaemonResizeParams } from '../shared/rpc';
 
@@ -895,6 +896,14 @@ function buildState(sessionManager: DaemonSessionManager): DaemonState {
 // === Graceful shutdown ===
 
 let shuttingDown = false;
+// Phase A — A4. Flipped to true once the async shutdown body has resolved
+// every Promise from ringBuffer.dumpToFile(). The Windows process.on('exit')
+// sync fallback consults this flag: if dumps already completed it skips
+// (avoiding duplicate writes), otherwise it runs dumpToFileSyncAtomic for
+// every live session as a last-resort save. Replaces a broader
+// `if (shuttingDown) return` guard that would have skipped the sync save
+// even when the async path was interrupted mid-dump.
+let dumpsCompleted = false;
 
 async function shutdown(
   signal: string,
@@ -952,6 +961,8 @@ async function shutdown(
     );
   }
   await Promise.all(dumpPromises);
+  // A4 — async dumps are durable. Sync exit handler will short-circuit.
+  dumpsCompleted = true;
 
   // Save suspended state BEFORE disposing
   if (!cachedBootId) cachedBootId = await getBootId();
@@ -1009,6 +1020,14 @@ async function main(): Promise<void> {
 
   // 3. Initialize modules
   const stateWriter = new StateWriter(wmuxDir);
+  // A4 — sweep tmp dumps left behind by a previous crash. They are safe to
+  // delete: tmp files only exist between the write and rename steps of an
+  // atomic dump, so any tmp on disk now is from a daemon that died before
+  // the rename completed. The .buf at the same path is either intact (old
+  // good dump) or absent (first dump never finished, scrollback lost for
+  // that session, which we cannot recover anyway).
+  RingBuffer.cleanupStaleTmpFiles(stateWriter.getBufferDir());
+
   const sessionManager = new DaemonSessionManager();
   sessionManager.setConfig(config);
   const pipeServer = new DaemonPipeServer(config.daemon.pipeName);
@@ -1141,7 +1160,12 @@ async function main(): Promise<void> {
   // synchronous save, and also periodic state saves to minimize data loss.
   if (process.platform === 'win32') {
     process.on('exit', () => {
-      // Synchronous-only — dump what we can before process dies
+      // Phase A — A4. Precise guard: skip the sync save only if the async
+      // shutdown body actually finished its dumps. If the async path was
+      // interrupted mid-dump (process about to die), fall through and run
+      // the sync atomic save as a last-resort.
+      if (dumpsCompleted) return;
+      // Synchronous-only — dump what we can before process dies.
       try {
         const managed = sessionManager.listManagedSessions();
         stateWriter.ensureBufferDir();
@@ -1149,8 +1173,11 @@ async function main(): Promise<void> {
           if (m.meta.state === 'dead') continue;
           const dumpPath = stateWriter.getBufferDumpPath(m.meta.id);
           try {
-            const data = m.ringBuffer.readAll();
-            fs.writeFileSync(dumpPath, data);
+            // A4 — atomic sync write: tmp + renameSync so a reader can
+            // never observe a half-written .buf, even if the OS pulls the
+            // plug mid-write. Replaces the bare writeFileSync that left a
+            // partial file behind on power loss.
+            m.ringBuffer.dumpToFileSyncAtomic(dumpPath);
             m.meta.state = 'suspended';
             m.meta.bufferDumpPath = dumpPath;
           } catch { /* best effort */ }

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -859,6 +859,51 @@ function buildState(sessionManager: DaemonSessionManager): DaemonState {
   };
 }
 
+// === Snapshot runner (Phase A — A1b) ===
+//
+// Returns an async function that dumps every live session's RingBuffer to disk
+// and persists sessions.json. Owns a per-runner re-entrancy flag so concurrent
+// invocations (e.g., scheduled tick fires while a previous tick is still
+// flushing) collapse to a single run.
+//
+// Extracted from the inline 30s setInterval body so it can also be invoked
+// once at spawn time, closing the window where no .buf yet exists on disk.
+// A crash within the first 30 s after daemon start would otherwise leave a
+// recovery loop with no buffer file to restore from.
+export function createSnapshotRunner(
+  sessionManager: DaemonSessionManager,
+  stateWriter: StateWriter,
+): () => Promise<void> {
+  let running = false;
+  return async function runSnapshotOnce(): Promise<void> {
+    if (running) return;
+    const managed = sessionManager.listManagedSessions();
+    const live = managed.filter((m) => m.meta.state !== 'dead');
+    if (live.length === 0) return;
+
+    running = true;
+    stateWriter.ensureBufferDir();
+    try {
+      for (const m of live) {
+        const dumpPath = stateWriter.getBufferDumpPath(m.meta.id);
+        try {
+          await m.ringBuffer.dumpToFile(dumpPath);
+        } catch (err) {
+          log('warn', `Snapshot dump failed for ${m.meta.id}:`, err);
+        }
+      }
+      try {
+        const state = buildState(sessionManager);
+        stateWriter.saveImmediate(state);
+      } catch (err) {
+        log('warn', 'Snapshot state save failed:', err);
+      }
+    } finally {
+      running = false;
+    }
+  };
+}
+
 // === Graceful shutdown ===
 
 let shuttingDown = false;
@@ -1045,37 +1090,17 @@ async function main(): Promise<void> {
   // 8c. Periodic buffer snapshots (every 30s) — survives forced kills / power loss
   // Also save sessions.json so recovery has up-to-date session metadata.
   // Sequential dumps to avoid simultaneous memory peaks from all buffers at once.
-  let snapshotRunning = false;
+  // The runner is also invoked once immediately below (A1b) to close the
+  // 30 s window where no .buf exists yet on disk.
+  const runSnapshotOnce = createSnapshotRunner(sessionManager, stateWriter);
   const snapshotInterval = setInterval(() => {
-    if (snapshotRunning) return; // skip if previous snapshot cycle still in progress
-    const managed = sessionManager.listManagedSessions();
-    const live = managed.filter((m) => m.meta.state !== 'dead');
-    if (live.length === 0) return;
-
-    snapshotRunning = true;
-    stateWriter.ensureBufferDir();
-
-    (async () => {
-      for (const m of live) {
-        const dumpPath = stateWriter.getBufferDumpPath(m.meta.id);
-        try {
-          await m.ringBuffer.dumpToFile(dumpPath);
-        } catch (err) {
-          log('warn', `Snapshot dump failed for ${m.meta.id}:`, err);
-        }
-      }
-      // Save session metadata after all buffer dumps complete
-      try {
-        const state = buildState(sessionManager);
-        stateWriter.saveImmediate(state);
-      } catch (err) {
-        log('warn', 'Snapshot state save failed:', err);
-      }
-    })().finally(() => {
-      snapshotRunning = false;
-    });
+    void runSnapshotOnce();
   }, 30_000);
   snapshotInterval.unref();
+
+  // A1b — fire an initial snapshot at spawn so a crash within the first
+  // 30 s leaves a recoverable .buf trace rather than nothing.
+  void runSnapshotOnce();
 
   // 9. Signal handlers
   const doShutdown = (sig: string) =>

--- a/src/daemon/snapshotRunner.ts
+++ b/src/daemon/snapshotRunner.ts
@@ -39,42 +39,54 @@ export function createSnapshotRunner(
   options: { getBootId: () => string },
 ): () => Promise<void> {
   let running = false;
+  let pendingRerun = false;
   return async function runSnapshotOnce(): Promise<void> {
-    if (running) return;
-    const managed = sessionManager.listManagedSessions();
-    const live = managed.filter((m) => m.meta.state !== 'dead');
-    if (live.length === 0) return;
-
+    // Pending-rerun pattern (codex review P2, session 019e2af8): if a
+    // concurrent trigger arrives while the previous run is mid-dump, mark a
+    // rerun so the freshly-created/attached session that arrived between
+    // listManagedSessions() and finally still gets its .buf produced
+    // immediately rather than waiting for the 30 s interval.
+    if (running) {
+      pendingRerun = true;
+      return;
+    }
     running = true;
-    stateWriter.ensureBufferDir();
     try {
-      for (const m of live) {
-        const dumpPath = stateWriter.getBufferDumpPath(m.meta.id);
+      do {
+        pendingRerun = false;
+        const managed = sessionManager.listManagedSessions();
+        const live = managed.filter((m) => m.meta.state !== 'dead');
+        if (live.length === 0) break;
+
+        stateWriter.ensureBufferDir();
+        for (const m of live) {
+          const dumpPath = stateWriter.getBufferDumpPath(m.meta.id);
+          try {
+            await m.ringBuffer.dumpToFile(dumpPath);
+          } catch (err) {
+            snapshotLog('warn', `Snapshot dump failed for ${m.meta.id}:`, err);
+          }
+        }
         try {
-          await m.ringBuffer.dumpToFile(dumpPath);
+          const liveSessions = sessionManager.listSessions();
+          const liveIds = new Set(liveSessions.map((s) => s.id));
+          let preserved: DaemonSession[] = [];
+          try {
+            const existing = stateWriter.load();
+            preserved = existing.sessions.filter((s) => !liveIds.has(s.id));
+          } catch {
+            // No prior sessions.json (first save) — nothing to preserve.
+          }
+          const merged: DaemonState = {
+            version: 1,
+            sessions: [...liveSessions, ...preserved],
+            bootId: options.getBootId(),
+          };
+          stateWriter.saveImmediate(merged);
         } catch (err) {
-          snapshotLog('warn', `Snapshot dump failed for ${m.meta.id}:`, err);
+          snapshotLog('warn', 'Snapshot state save failed:', err);
         }
-      }
-      try {
-        const liveSessions = sessionManager.listSessions();
-        const liveIds = new Set(liveSessions.map((s) => s.id));
-        let preserved: DaemonSession[] = [];
-        try {
-          const existing = stateWriter.load();
-          preserved = existing.sessions.filter((s) => !liveIds.has(s.id));
-        } catch {
-          // No prior sessions.json (first save) — nothing to preserve.
-        }
-        const merged: DaemonState = {
-          version: 1,
-          sessions: [...liveSessions, ...preserved],
-          bootId: options.getBootId(),
-        };
-        stateWriter.saveImmediate(merged);
-      } catch (err) {
-        snapshotLog('warn', 'Snapshot state save failed:', err);
-      }
+      } while (pendingRerun);
     } finally {
       running = false;
     }

--- a/src/daemon/snapshotRunner.ts
+++ b/src/daemon/snapshotRunner.ts
@@ -1,5 +1,6 @@
 import type { DaemonSessionManager } from './DaemonSessionManager';
 import type { StateWriter } from './StateWriter';
+import type { DaemonState, DaemonSession } from './types';
 
 // Side-effect-free module so unit tests can drive runSnapshotOnce without
 // importing src/daemon/index.ts (which would execute its main() bootstrap on
@@ -11,9 +12,9 @@ function snapshotLog(level: string, msg: string, ...args: unknown[]): void {
 }
 
 // Returns an async function that dumps every live session's RingBuffer to
-// disk. Owns a per-runner re-entrancy flag so concurrent invocations (e.g., a
-// scheduled tick fires while a previous one is still flushing) collapse to a
-// single run.
+// disk AND persists a merged sessions.json. Owns a per-runner re-entrancy
+// flag so concurrent invocations (e.g., a scheduled tick fires while a
+// previous one is still flushing) collapse to a single run.
 //
 // Extracted from the inline 30 s setInterval body so the same runner can also
 // be invoked at session-create time and once at spawn, closing the window
@@ -21,15 +22,21 @@ function snapshotLog(level: string, msg: string, ...args: unknown[]): void {
 // daemon start would otherwise leave the recovery loop with no buffer file
 // to restore from.
 //
-// Important: this runner intentionally does NOT persist sessions.json.
-// sessions.json is maintained by every create/attach/detach/destroy RPC
-// handler and by recovery itself. If the runner re-saved listSessions() it
-// would erase any suspended session entries that recovery preserved past
-// MAX_RECOVER_SESSIONS (which are present in sessions.json but absent from
-// sessionManager).
+// sessions.json handling — codex review P2 (2026-05-15) flagged two
+// failure modes that bracket the design:
+//   1. If the runner saves only listSessions(), it clobbers any suspended
+//      entries that recovery preserved past MAX_RECOVER_SESSIONS (those
+//      sessions live only in sessions.json, not in sessionManager).
+//   2. If the runner doesn't save at all, in-memory metadata updates
+//      (lastActivity / cwd / cols / rows / state changes that happen on
+//      data/resize without an RPC roundtrip) never reach disk, and crash
+//      recovery picks stale entries under its own cap.
+// Resolution: load existing sessions.json, take every managed session as
+// authoritative for its id, and append non-managed entries verbatim.
 export function createSnapshotRunner(
   sessionManager: DaemonSessionManager,
   stateWriter: StateWriter,
+  options: { getBootId: () => string },
 ): () => Promise<void> {
   let running = false;
   return async function runSnapshotOnce(): Promise<void> {
@@ -48,6 +55,25 @@ export function createSnapshotRunner(
         } catch (err) {
           snapshotLog('warn', `Snapshot dump failed for ${m.meta.id}:`, err);
         }
+      }
+      try {
+        const liveSessions = sessionManager.listSessions();
+        const liveIds = new Set(liveSessions.map((s) => s.id));
+        let preserved: DaemonSession[] = [];
+        try {
+          const existing = stateWriter.load();
+          preserved = existing.sessions.filter((s) => !liveIds.has(s.id));
+        } catch {
+          // No prior sessions.json (first save) — nothing to preserve.
+        }
+        const merged: DaemonState = {
+          version: 1,
+          sessions: [...liveSessions, ...preserved],
+          bootId: options.getBootId(),
+        };
+        stateWriter.saveImmediate(merged);
+      } catch (err) {
+        snapshotLog('warn', 'Snapshot state save failed:', err);
       }
     } finally {
       running = false;

--- a/src/daemon/snapshotRunner.ts
+++ b/src/daemon/snapshotRunner.ts
@@ -1,6 +1,5 @@
 import type { DaemonSessionManager } from './DaemonSessionManager';
 import type { StateWriter } from './StateWriter';
-import type { DaemonState } from './types';
 
 // Side-effect-free module so unit tests can drive runSnapshotOnce without
 // importing src/daemon/index.ts (which would execute its main() bootstrap on
@@ -11,19 +10,26 @@ function snapshotLog(level: string, msg: string, ...args: unknown[]): void {
   console.log(`[${ts}] [daemon/${level}] ${msg}`, ...args);
 }
 
-// Returns an async function that dumps every live session's RingBuffer to disk
-// and persists sessions.json. Owns a per-runner re-entrancy flag so concurrent
-// invocations (e.g., a scheduled tick fires while a previous one is still
-// flushing) collapse to a single run.
+// Returns an async function that dumps every live session's RingBuffer to
+// disk. Owns a per-runner re-entrancy flag so concurrent invocations (e.g., a
+// scheduled tick fires while a previous one is still flushing) collapse to a
+// single run.
 //
 // Extracted from the inline 30 s setInterval body so the same runner can also
-// be invoked once at spawn time, closing the window where no .buf yet exists
-// on disk. A crash within the first 30 s after daemon start would otherwise
-// leave the recovery loop with no buffer file to restore from.
+// be invoked at session-create time and once at spawn, closing the window
+// where no .buf yet exists on disk. A crash within the first 30 s after
+// daemon start would otherwise leave the recovery loop with no buffer file
+// to restore from.
+//
+// Important: this runner intentionally does NOT persist sessions.json.
+// sessions.json is maintained by every create/attach/detach/destroy RPC
+// handler and by recovery itself. If the runner re-saved listSessions() it
+// would erase any suspended session entries that recovery preserved past
+// MAX_RECOVER_SESSIONS (which are present in sessions.json but absent from
+// sessionManager).
 export function createSnapshotRunner(
   sessionManager: DaemonSessionManager,
   stateWriter: StateWriter,
-  options: { getBootId: () => string },
 ): () => Promise<void> {
   let running = false;
   return async function runSnapshotOnce(): Promise<void> {
@@ -42,16 +48,6 @@ export function createSnapshotRunner(
         } catch (err) {
           snapshotLog('warn', `Snapshot dump failed for ${m.meta.id}:`, err);
         }
-      }
-      try {
-        const state: DaemonState = {
-          version: 1,
-          sessions: sessionManager.listSessions(),
-          bootId: options.getBootId(),
-        };
-        stateWriter.saveImmediate(state);
-      } catch (err) {
-        snapshotLog('warn', 'Snapshot state save failed:', err);
       }
     } finally {
       running = false;

--- a/src/daemon/snapshotRunner.ts
+++ b/src/daemon/snapshotRunner.ts
@@ -1,0 +1,60 @@
+import type { DaemonSessionManager } from './DaemonSessionManager';
+import type { StateWriter } from './StateWriter';
+import type { DaemonState } from './types';
+
+// Side-effect-free module so unit tests can drive runSnapshotOnce without
+// importing src/daemon/index.ts (which would execute its main() bootstrap on
+// import and start a real daemon during the test run).
+
+function snapshotLog(level: string, msg: string, ...args: unknown[]): void {
+  const ts = new Date().toISOString();
+  console.log(`[${ts}] [daemon/${level}] ${msg}`, ...args);
+}
+
+// Returns an async function that dumps every live session's RingBuffer to disk
+// and persists sessions.json. Owns a per-runner re-entrancy flag so concurrent
+// invocations (e.g., a scheduled tick fires while a previous one is still
+// flushing) collapse to a single run.
+//
+// Extracted from the inline 30 s setInterval body so the same runner can also
+// be invoked once at spawn time, closing the window where no .buf yet exists
+// on disk. A crash within the first 30 s after daemon start would otherwise
+// leave the recovery loop with no buffer file to restore from.
+export function createSnapshotRunner(
+  sessionManager: DaemonSessionManager,
+  stateWriter: StateWriter,
+  options: { getBootId: () => string },
+): () => Promise<void> {
+  let running = false;
+  return async function runSnapshotOnce(): Promise<void> {
+    if (running) return;
+    const managed = sessionManager.listManagedSessions();
+    const live = managed.filter((m) => m.meta.state !== 'dead');
+    if (live.length === 0) return;
+
+    running = true;
+    stateWriter.ensureBufferDir();
+    try {
+      for (const m of live) {
+        const dumpPath = stateWriter.getBufferDumpPath(m.meta.id);
+        try {
+          await m.ringBuffer.dumpToFile(dumpPath);
+        } catch (err) {
+          snapshotLog('warn', `Snapshot dump failed for ${m.meta.id}:`, err);
+        }
+      }
+      try {
+        const state: DaemonState = {
+          version: 1,
+          sessions: sessionManager.listSessions(),
+          bootId: options.getBootId(),
+        };
+        stateWriter.saveImmediate(state);
+      } catch (err) {
+        snapshotLog('warn', 'Snapshot state save failed:', err);
+      }
+    } finally {
+      running = false;
+    }
+  };
+}

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -108,19 +108,30 @@ export class DaemonClient extends EventEmitter {
     this.controlBuffer = '';
   }
 
-  /** Send an RPC call over the control pipe. */
-  async rpc(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+  /**
+   * Send an RPC call over the control pipe.
+   *
+   * `opts.timeoutMs` overrides the default {@link RPC_TIMEOUT_MS}. Pass a
+   * larger value for long-running RPCs such as `daemon.shutdown`, which may
+   * exceed 10 s while RingBuffer dumps complete.
+   */
+  async rpc(
+    method: string,
+    params: Record<string, unknown> = {},
+    opts: { timeoutMs?: number } = {},
+  ): Promise<unknown> {
     if (!this.controlPipe || !this.connected) {
       throw new Error('DaemonClient not connected');
     }
 
     const id = `req-${++this.requestId}`;
+    const timeoutMs = opts.timeoutMs ?? RPC_TIMEOUT_MS;
 
     return new Promise<unknown>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pendingRequests.delete(id);
-        reject(new Error(`RPC timeout: ${method} (${RPC_TIMEOUT_MS}ms)`));
-      }, RPC_TIMEOUT_MS);
+        reject(new Error(`RPC timeout: ${method} (${timeoutMs}ms)`));
+      }, timeoutMs);
 
       this.pendingRequests.set(id, { resolve, reject, timer });
 

--- a/src/main/__tests__/DaemonClient.test.ts
+++ b/src/main/__tests__/DaemonClient.test.ts
@@ -261,6 +261,60 @@ describe('DaemonClient', () => {
       await expect(client.rpc('daemon.ping')).rejects.toThrow('DaemonClient not connected');
     });
 
+    // A2 — per-call timeout override. Allows daemon.shutdown and any other
+    // long-running RPC to exceed the default 10 s without rewriting the
+    // default for every caller.
+    //
+    // Use a silent net.Server that accepts the connection but never writes a
+    // response, so the RPC must time out.
+    it('honors opts.timeoutMs when the server never responds', async () => {
+      const pipeName = testPipeName('rpc-timeout-short');
+      const silentSockets = new Set<net.Socket>();
+      const silentServer = net.createServer((s) => {
+        silentSockets.add(s);
+        s.setEncoding('utf8');
+        // Read and discard; never reply.
+        s.on('data', () => { /* swallow */ });
+        s.on('close', () => silentSockets.delete(s));
+        s.on('error', () => silentSockets.delete(s));
+      });
+      await new Promise<void>((resolve, reject) => {
+        silentServer.on('error', reject);
+        silentServer.listen(pipeName, () => resolve());
+      });
+
+      client = new DaemonClient(pipeName, AUTH_TOKEN);
+      await client.connect();
+
+      const started = Date.now();
+      await expect(
+        client.rpc('daemon.never', {}, { timeoutMs: 200 }),
+      ).rejects.toThrow(/RPC timeout: daemon\.never \(200ms\)/);
+      const elapsed = Date.now() - started;
+      expect(elapsed).toBeLessThan(2_000);
+
+      await client.disconnect();
+      silentSockets.forEach((s) => s.destroy());
+      await new Promise<void>((resolve) => silentServer.close(() => resolve()));
+    });
+
+    it('falls back to the default 10 s timeout when opts is omitted', async () => {
+      // We do not actually wait 10 s; just verify the error message format
+      // uses the default value when the call resolves quickly.
+      const pipeName = testPipeName('rpc-default');
+      mockServer = createMockDaemonServer(pipeName, AUTH_TOKEN, {
+        'daemon.ping': () => ({ ok: true }),
+      });
+      await mockServer.start();
+
+      client = new DaemonClient(pipeName, AUTH_TOKEN);
+      await client.connect();
+      const res = await client.rpc('daemon.ping');
+      expect(res).toEqual({ ok: true });
+      await client.disconnect();
+      await mockServer.stop();
+    });
+
     it('should handle multiple concurrent RPCs', async () => {
       const pipeName = testPipeName('rpc4');
       mockServer = createMockDaemonServer(pipeName, AUTH_TOKEN, {

--- a/src/main/__tests__/daemonShutdownRace.test.ts
+++ b/src/main/__tests__/daemonShutdownRace.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { raceDaemonShutdown, type DaemonShutdownClient } from '../daemonShutdownRace';
+
+// Phase A — A3 (before-quit) and A5 (session-end) test. The helper itself is
+// pure (no electron, no daemon bootstrap), so we exercise it directly with a
+// fake client.
+
+function makeClient(impl: (timeoutMs?: number) => Promise<unknown>): DaemonShutdownClient {
+  return {
+    rpc: (_method, _params, opts) => impl(opts?.timeoutMs),
+  };
+}
+
+describe('raceDaemonShutdown', () => {
+  it('resolves ok when the RPC settles before the budget', async () => {
+    const client = makeClient(() => new Promise((resolve) => setTimeout(() => resolve({ status: 'ok' }), 50)));
+    const result = await raceDaemonShutdown(client, 1_000);
+    expect(result.ok).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('returns ok=false with timeout error when the RPC never resolves', async () => {
+    const client = makeClient(() => new Promise<never>(() => { /* never */ }));
+    const result = await raceDaemonShutdown(client, 100);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/timeout/i);
+    expect(result.error).toMatch(/100ms/);
+  });
+
+  it('returns ok=false with the underlying error when the RPC rejects', async () => {
+    const client = makeClient(() => Promise.reject(new Error('daemon dead')));
+    const result = await raceDaemonShutdown(client, 1_000);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('daemon dead');
+  });
+
+  it('passes the budget through to client.rpc as opts.timeoutMs', async () => {
+    let observed: number | undefined;
+    const client: DaemonShutdownClient = {
+      rpc: (_method, _params, opts) => {
+        observed = opts?.timeoutMs;
+        return Promise.resolve({ status: 'ok' });
+      },
+    };
+    await raceDaemonShutdown(client, 4_000);
+    expect(observed).toBe(4_000);
+  });
+
+  // Defensive: the helper sets a setTimeout to enforce the budget. If the
+  // RPC wins before the timer fires, the timer must be cleared so vitest
+  // does not warn about open handles or keep the event loop alive.
+  it('clears its internal timer once the RPC wins', async () => {
+    let resolveRpc: ((v: unknown) => void) | null = null;
+    const client = makeClient(() => new Promise((resolve) => { resolveRpc = resolve; }));
+    const pending = raceDaemonShutdown(client, 30_000);
+    // Yield once so the helper sets up its timer + awaits the race.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    resolveRpc!({ status: 'ok' });
+    const result = await pending;
+    expect(result.ok).toBe(true);
+    // If the timer were leaked, this test would still pass but vitest's
+    // open-handle detection or process exit hooks would flag it. Document
+    // the contract in the assertion message.
+  });
+});

--- a/src/main/__tests__/sessionEnd.daemonShutdown.test.ts
+++ b/src/main/__tests__/sessionEnd.daemonShutdown.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Phase A — A5 source-level invariants for the Windows session-end
+// (WM_ENDSESSION) handler in src/main/index.ts.
+//
+// The previous handler called daemonClient.disconnectSync() and trusted the
+// daemon to flush on its own clock. A5 races daemon.shutdown against a
+// calibrated budget (4 s placeholder until the T5 measurement lands) so the
+// daemon completes atomic dumps before we die. We assert these invariants
+// at the source level — running the actual handler requires Electron and
+// an OS shutdown signal, neither of which a vitest process can reproduce.
+describe('A5 — session-end (WM_ENDSESSION) handler invariants', () => {
+  const mainIndexPath = path.join(__dirname, '..', 'index.ts');
+  const src = fs.readFileSync(mainIndexPath, 'utf-8');
+
+  function extractHandler(): string {
+    const marker = "app.on('session-end' as any";
+    const start = src.indexOf(marker);
+    expect(start, "session-end registration not found").toBeGreaterThanOrEqual(0);
+    // The handler is the only call until the next top-level statement; slice
+    // a generous window — the assertions below are all string-pattern based.
+    return src.slice(start, start + 3000);
+  }
+
+  it('is registered inside a win32 platform guard', () => {
+    // The marker must live inside a `process.platform === 'win32'` block.
+    // Pattern: the win32 guard appears before the handler registration.
+    const winIdx = src.lastIndexOf("if (process.platform === 'win32')");
+    const handlerIdx = src.indexOf("app.on('session-end'");
+    expect(winIdx).toBeLessThan(handlerIdx);
+    expect(winIdx).toBeGreaterThanOrEqual(0);
+  });
+
+  it('handler is async (await Promise.race is allowed)', () => {
+    const handler = extractHandler();
+    // session-end registration body opens with `async () => {` (or async function).
+    expect(handler).toMatch(/'session-end'\s+as\s+any[\s\S]{0,40}async\s*\(\s*\)\s*=>/);
+  });
+
+  it('emergency sync SessionManager.save still runs', () => {
+    const handler = extractHandler();
+    expect(handler).toMatch(/sm\.save\(existing\)/);
+  });
+
+  it('races daemon.shutdown via raceDaemonShutdown before disconnectSync', () => {
+    const handler = extractHandler();
+    expect(handler).toMatch(/await\s+raceDaemonShutdown\(\s*daemonClient\s*,/);
+    // The disconnect must come AFTER the race so callers observe the race
+    // semantics (success or timeout) before the pipe goes away.
+    const raceIdx = handler.indexOf('raceDaemonShutdown(');
+    const disconnectIdx = handler.indexOf('disconnectSync(');
+    expect(raceIdx).toBeGreaterThan(0);
+    expect(disconnectIdx).toBeGreaterThan(raceIdx);
+  });
+
+  it('uses a 4 s timeout placeholder (T5 calibration target)', () => {
+    const handler = extractHandler();
+    // Either an explicit 4_000 constant or A5_TIMEOUT_MS = 4_000.
+    expect(handler).toMatch(/A5_TIMEOUT_MS\s*=\s*4_?000/);
+  });
+
+  it('logs a warning if the race did not complete in time', () => {
+    const handler = extractHandler();
+    expect(handler).toMatch(/race\.ok/);
+    expect(handler).toMatch(/console\.warn\(/);
+  });
+});

--- a/src/main/daemonShutdownRace.ts
+++ b/src/main/daemonShutdownRace.ts
@@ -1,0 +1,49 @@
+// Side-effect-free helper for racing daemon.shutdown against a budget.
+//
+// Phase A — A3 (before-quit) and A5 (session-end / WM_ENDSESSION) both need
+// to send daemon.shutdown via the control RPC, wait up to a bounded time for
+// the daemon to dump RingBuffers atomically, then fall back to the existing
+// detach-only path if the daemon does not finish in time.
+//
+// The default timeout is calibrated by the T5 dynamic test (Task #15);
+// callers pass a measured value. Until that measurement lands, callers pass
+// the documented placeholder of 4 s for before-quit and 1 s for session-end.
+
+export interface DaemonShutdownRaceResult {
+  ok: boolean;
+  /** Reason for the failure, if any. Useful for log breadcrumbs. */
+  error?: string;
+}
+
+// Minimal client shape used here. Decouples this helper from DaemonClient so
+// tests can pass a tiny stub instead of bootstrapping a real net pipe.
+export interface DaemonShutdownClient {
+  rpc: (
+    method: string,
+    params?: Record<string, unknown>,
+    opts?: { timeoutMs?: number },
+  ) => Promise<unknown>;
+}
+
+export async function raceDaemonShutdown(
+  client: DaemonShutdownClient,
+  timeoutMs: number,
+): Promise<DaemonShutdownRaceResult> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  try {
+    await Promise.race([
+      client.rpc('daemon.shutdown', {}, { timeoutMs }),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`daemon.shutdown race timeout (${timeoutMs}ms)`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -237,7 +237,12 @@ const mcpHandlerOptions = {
 // on cold boot, which silently destroyed previous-session scrollback when
 // the post-restore 5s autosave dumped the empty/fresh buffer over it.
 // Same hardening pattern as the v2.8.1 Bug 3 fix for `daemon:get-ready-state`.
-registerSessionHandlers();
+// Phase A — A6. Pass a live getter for the daemon-connected state so the
+// scrollback:dump + scrollback:load handlers short-circuit while a daemon
+// is healthy. The getter closes over the `daemonClient` let above, so the
+// handlers see every connect/disconnect transition that mutates that
+// variable (no closure snapshot).
+registerSessionHandlers(() => daemonClient?.isConnected === true);
 
 let cleanupHandlers = registerAllHandlers(ptyManager, ptyBridge, () => mainWindow, undefined, mcpHandlerOptions);
 
@@ -431,6 +436,14 @@ app.on('ready', async () => {
           daemonNotificationRouter?.stop();
           daemonNotificationRouter = null;
           daemonClient = null;
+          // Phase A — A6. Notify the renderer so the daemon-mode .txt
+          // write/load gates open again (local mode preserves the
+          // pre-existing scrollback path). Without this, the renderer
+          // would still treat itself as daemon-connected and skip the
+          // .txt autosave even though no daemon is replaying PTY data.
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            mainWindow.webContents.send('daemon:disconnected');
+          }
           logLine('warn', 'main', 'handler swap (daemon disconnect): cleanup begin');
           cleanupHandlers();
           logLine('warn', 'main', 'handler swap (daemon disconnect): cleanup done, register begin');

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,6 +31,7 @@ import { McpRegistrar } from './mcp/McpRegistrar';
 import { WebviewCdpManager } from './browser-session/WebviewCdpManager';
 import { DaemonClient, getDaemonPipeName, readDaemonAuthToken } from './DaemonClient';
 import { raceDaemonShutdown } from './daemonShutdownRace';
+import { migrateScrollbackOnce } from './scrollback/legacyMigration';
 import { DaemonNotificationRouter } from './notification/DaemonNotificationRouter';
 import { ensureDaemon } from './daemon/launcher';
 import { createTray, destroyTray } from './tray';
@@ -430,6 +431,22 @@ app.on('ready', async () => {
         // Notify renderer that daemon is now connected so it can re-reconcile
         if (mainWindow && !mainWindow.isDestroyed()) {
           mainWindow.webContents.send('daemon:connected');
+        }
+        // Phase A — A7. Run the one-time legacy scrollback migration on
+        // the first daemon-healthy transition. Best-effort: if rename
+        // fails (EBUSY/EPERM under antivirus) the runner returns
+        // retry-needed and the next transition tries again. Log the
+        // breadcrumb either way so the user can spot a stuck migration
+        // in the main-side log.
+        try {
+          const result = migrateScrollbackOnce(app.getPath('userData'), app.getVersion());
+          if (result.status === 'migrated') {
+            console.log(`[Main] A7 scrollback legacy migration → ${result.legacyDir}`);
+          } else if (result.status === 'retry-needed') {
+            console.warn(`[Main] A7 scrollback migration retry-needed: ${result.error}`);
+          }
+        } catch (err) {
+          console.warn('[Main] A7 scrollback migration threw:', err);
         }
         daemonClient.on('disconnected', () => {
           console.warn('[Main] Daemon disconnected, falling back to local PTY');

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -388,8 +388,13 @@ app.on('ready', async () => {
     }
   });
 
-  // System tray — lets the app stay alive when window is closed
-  createTray(mainWindow, () => { isQuitting = true; });
+  // System tray — lets the app stay alive when window is closed.
+  // Phase A — A3/A5 fix (codex review P1, session 019e2af8): the callback
+  // used to set isQuitting=true before tray.ts then called app.quit(). The
+  // resulting before-quit handler hit `if (isQuitting) return` on its first
+  // pass and skipped the entire daemon.shutdown race added in A3. Now the
+  // callback is a no-op; before-quit's first pass sets isQuitting itself.
+  createTray(mainWindow, () => { /* no-op — before-quit handles isQuitting */ });
 
   // Auto-start daemon and connect
   try {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -30,6 +30,7 @@ import { AutoUpdater } from './updater/AutoUpdater';
 import { McpRegistrar } from './mcp/McpRegistrar';
 import { WebviewCdpManager } from './browser-session/WebviewCdpManager';
 import { DaemonClient, getDaemonPipeName, readDaemonAuthToken } from './DaemonClient';
+import { raceDaemonShutdown } from './daemonShutdownRace';
 import { DaemonNotificationRouter } from './notification/DaemonNotificationRouter';
 import { ensureDaemon } from './daemon/launcher';
 import { createTray, destroyTray } from './tray';
@@ -647,8 +648,26 @@ app.on('before-quit', async (e) => {
   disposeFirstRunHandlers();
 
   if (daemonClient?.isConnected) {
-    // Daemon mode: detach only — sessions persist in daemon
-    console.log('[Main] Daemon mode — detaching sessions (not killing)');
+    // Daemon mode. Phase A — A3: race daemon.shutdown against a calibrated
+    // budget so the daemon can flush RingBuffers atomically before we
+    // detach. The 4 s placeholder is the documented floor pending the T5
+    // dynamic test (Task #15) measurement.
+    const BEFORE_QUIT_TIMEOUT_MS = 4_000;
+    console.log(
+      `[Main] Daemon mode — racing daemon.shutdown (${BEFORE_QUIT_TIMEOUT_MS}ms budget)`,
+    );
+    const race = await raceDaemonShutdown(daemonClient, BEFORE_QUIT_TIMEOUT_MS);
+    if (race.ok) {
+      console.log('[Main] daemon.shutdown ack received');
+    } else {
+      console.warn(
+        `[Main] daemon.shutdown did not complete in time, falling back to detach: ${race.error}`,
+      );
+    }
+    // Always detach as the final step. If the RPC succeeded the pipe is
+    // already torn down on the daemon side; disconnect cleans up our half.
+    // If it failed (timeout / dead daemon), disconnect is the original
+    // fallback path that was in place before A3 landed.
     await daemonClient.disconnect();
     daemonClient = null;
   } else {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -690,8 +690,8 @@ app.on('before-quit', async (e) => {
 // signal before Windows force-kills the process. The 'before-quit' async
 // handler may not complete in time, so we do a synchronous emergency save here.
 if (process.platform === 'win32') {
-  app.on('session-end' as any, () => {
-    console.log('[Main] session-end received — emergency sync save');
+  app.on('session-end' as any, async () => {
+    console.log('[Main] session-end received — emergency sync save + daemon race');
     try {
       // Import SessionManager lazily to avoid circular deps
       const { SessionManager } = require('./session/SessionManager');
@@ -704,8 +704,23 @@ if (process.platform === 'win32') {
       console.error('[Main] Emergency session save failed:', err);
     }
 
-    // Detach daemon synchronously — don't kill sessions
     if (daemonClient?.isConnected) {
+      // Phase A — A5. Race daemon.shutdown against the WM_ENDSESSION budget
+      // (~5 s before Windows SIGKILLs us) so the daemon can complete its
+      // atomic RingBuffer dumps before we tear down the pipe. Leave a 1 s
+      // safety margin for disconnectSync + Electron's own teardown.
+      //
+      // 4 s is the documented floor pending the T5 dynamic test
+      // measurement (Task #15). The harness exists at
+      // scripts/daemon-shutdown-dynamic.mjs; rerun on the target box and
+      // adjust if measured p99 latency calls for a smaller value.
+      const A5_TIMEOUT_MS = 4_000;
+      const race = await raceDaemonShutdown(daemonClient, A5_TIMEOUT_MS);
+      if (!race.ok) {
+        console.warn(
+          `[Main] session-end daemon.shutdown race failed (${A5_TIMEOUT_MS} ms): ${race.error}`,
+        );
+      }
       try {
         daemonClient.disconnectSync();
       } catch {

--- a/src/main/ipc/handlers/__tests__/session.handler.daemonModeNoop.test.ts
+++ b/src/main/ipc/handlers/__tests__/session.handler.daemonModeNoop.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Phase A — A6. session.handler must short-circuit scrollback:dump AND
+// scrollback:load when the live `isDaemonConnected` getter returns true.
+// We verify the contract at the source level — actually exercising the
+// handler requires Electron's ipcMain and a real BrowserWindow, which a
+// vitest process cannot bootstrap.
+describe('A6 — session.handler daemon-mode short-circuit (source-level)', () => {
+  const handlerPath = path.join(__dirname, '..', 'session.handler.ts');
+  const src = fs.readFileSync(handlerPath, 'utf-8');
+
+  it('registerSessionHandlers accepts an isDaemonConnected getter parameter', () => {
+    expect(src).toMatch(
+      /export function registerSessionHandlers\(\s*isDaemonConnected:\s*\(\s*\)\s*=>\s*boolean/,
+    );
+  });
+
+  it('parameter defaults to () => false so local-only callers stay safe', () => {
+    expect(src).toMatch(/isDaemonConnected:\s*\(\s*\)\s*=>\s*boolean\s*=\s*\(\s*\)\s*=>\s*false/);
+  });
+
+  it('scrollback:dump handler short-circuits when daemon is connected', () => {
+    // Slice the dump handler body. The marker `// scrollback:dump` opens
+    // the registration. The body extends until the next `// scrollback:load`
+    // marker comment.
+    const start = src.indexOf('// scrollback:dump');
+    const end = src.indexOf('// scrollback:load');
+    expect(start).toBeGreaterThan(0);
+    expect(end).toBeGreaterThan(start);
+    const body = src.slice(start, end);
+    // Guard must be the first behavioural branch (before validation, write).
+    expect(body).toMatch(/if\s*\(\s*isDaemonConnected\(\)\s*\)\s*\{[\s\S]*?return\s*\{\s*success:\s*true[\s\S]*?skipped:\s*true/);
+  });
+
+  it('scrollback:load handler returns null when daemon is connected', () => {
+    const start = src.indexOf('// scrollback:load');
+    expect(start).toBeGreaterThan(0);
+    const body = src.slice(start);
+    // The first guard in the load handler returns null on daemon mode so
+    // the renderer skips its .txt restore branch.
+    expect(body).toMatch(/if\s*\(\s*isDaemonConnected\(\)\s*\)\s*\{[\s\S]*?return\s+null/);
+  });
+});

--- a/src/main/ipc/handlers/session.handler.ts
+++ b/src/main/ipc/handlers/session.handler.ts
@@ -31,7 +31,20 @@ function scrollbackFilePath(surfaceId: string): string {
   return path.join(app.getPath('userData'), 'scrollback', `${surfaceId}.txt`);
 }
 
-export function registerSessionHandlers(): () => void {
+/**
+ * Phase A — A6. Live getter for daemon-connected state. The handlers gate
+ * scrollback:dump + scrollback:load on this; in daemon mode the renderer
+ * .txt fallback path is short-circuited so the rotation chain hazard
+ * (4-minute self-destruction of good backups) cannot fire while the daemon
+ * is the source of truth. Local mode (getter returns false) keeps the
+ * existing .txt path verbatim.
+ *
+ * Passed as a callback rather than a snapshot so connect/disconnect
+ * transitions during the renderer's lifetime are reflected immediately.
+ */
+export function registerSessionHandlers(
+  isDaemonConnected: () => boolean = () => false,
+): () => void {
   // Instrumentation: scrollback restore race investigation. This function is
   // called from `registerAllHandlers`, which is invoked both at module load
   // AND during the daemon-connect/disconnect handler swap in main/index.ts.
@@ -66,6 +79,14 @@ export function registerSessionHandlers(): () => void {
   //     guard in `serializeTerminalBuffer` is the primary fix.
   ipcMain.removeHandler(IPC.SCROLLBACK_DUMP);
   ipcMain.handle(IPC.SCROLLBACK_DUMP, wrapHandler(IPC.SCROLLBACK_DUMP, (_event: Electron.IpcMainInvokeEvent, surfaceId: string, content: string) => {
+    // Phase A — A6. Daemon mode: skip the .txt write entirely. The daemon
+    // RingBuffer is authoritative for scrollback; persisting the .txt at
+    // the same time would compose two restore paths in the renderer
+    // (`.txt` autoload + daemon SessionPipe flush) and the rotation chain
+    // would still self-destruct on idle terminals.
+    if (isDaemonConnected()) {
+      return { success: true, skipped: true };
+    }
     // Validate surfaceId (alphanumeric + hyphens only, prevent path traversal)
     if (!/^[a-zA-Z0-9-]+$/.test(surfaceId)) return { success: false };
 
@@ -110,6 +131,14 @@ export function registerSessionHandlers(): () => void {
   //     the next good content on the next 5s tick.
   ipcMain.removeHandler(IPC.SCROLLBACK_LOAD);
   ipcMain.handle(IPC.SCROLLBACK_LOAD, wrapHandler(IPC.SCROLLBACK_LOAD, (_event: Electron.IpcMainInvokeEvent, surfaceId: string) => {
+    // Phase A — A6. Daemon mode: return null so the renderer skips its
+    // .txt restore branch and relies entirely on the daemon SessionPipe
+    // flush. Returning even a valid old .txt here would race the daemon
+    // replay and the renderer would compose them with a separator
+    // (codex review Layer C corruption path).
+    if (isDaemonConnected()) {
+      return null;
+    }
     if (!/^[a-zA-Z0-9-]+$/.test(surfaceId)) return null;
     const filePath = scrollbackFilePath(surfaceId);
     try {

--- a/src/main/scrollback/__tests__/legacyMigration.test.ts
+++ b/src/main/scrollback/__tests__/legacyMigration.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  migrateScrollbackOnce,
+  MIGRATION_FILE,
+  SCROLLBACK_DIR,
+  LEGACY_DIR_PREFIX,
+  DEBOUNCE_MS,
+  __resetMigrationStateForTests,
+} from '../legacyMigration';
+
+describe('A7 — scrollback legacy migration', () => {
+  let userDataDir: string;
+
+  beforeEach(() => {
+    userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-a7-test-'));
+    __resetMigrationStateForTests();
+  });
+
+  afterEach(() => {
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  it('moves scrollback/ aside and writes the flag file on first run', () => {
+    fs.mkdirSync(path.join(userDataDir, SCROLLBACK_DIR));
+    fs.writeFileSync(path.join(userDataDir, SCROLLBACK_DIR, 'a.txt'), 'old');
+
+    const result = migrateScrollbackOnce(userDataDir, '2.9.1', 1_700_000_000_000);
+
+    expect(result.status).toBe('migrated');
+    expect(result.legacyDir).toBeDefined();
+    expect(fs.existsSync(result.legacyDir!)).toBe(true);
+    expect(fs.readFileSync(path.join(result.legacyDir!, 'a.txt'), 'utf-8')).toBe('old');
+    expect(fs.existsSync(path.join(userDataDir, SCROLLBACK_DIR))).toBe(false);
+
+    const flagPath = path.join(userDataDir, MIGRATION_FILE);
+    expect(fs.existsSync(flagPath)).toBe(true);
+    const flag = JSON.parse(fs.readFileSync(flagPath, 'utf-8'));
+    expect(flag.schema).toBe(1);
+    expect(flag.fromVersion).toBe('2.9.1');
+  });
+
+  it('is idempotent — second call returns already-done', () => {
+    fs.mkdirSync(path.join(userDataDir, SCROLLBACK_DIR));
+    fs.writeFileSync(path.join(userDataDir, SCROLLBACK_DIR, 'a.txt'), 'old');
+    migrateScrollbackOnce(userDataDir, '2.9.1', 1_700_000_000_000);
+
+    const result = migrateScrollbackOnce(userDataDir, '2.9.1', 1_700_000_000_000 + DEBOUNCE_MS + 1);
+    expect(result.status).toBe('already-done');
+  });
+
+  it('writes the flag with status no-source when scrollback/ does not exist', () => {
+    const result = migrateScrollbackOnce(userDataDir, '2.9.1', 1_700_000_000_000);
+    expect(result.status).toBe('no-source');
+    expect(fs.existsSync(path.join(userDataDir, MIGRATION_FILE))).toBe(true);
+  });
+
+  it('debounces concurrent transitions inside the window', () => {
+    fs.mkdirSync(path.join(userDataDir, SCROLLBACK_DIR));
+    // First call records lastAttemptAt
+    const first = migrateScrollbackOnce(userDataDir, '2.9.1', 1_000_000);
+    expect(first.status).toBe('migrated');
+    // Remove the flag to simulate a failed flag write so the second
+    // call hits the debounce branch (not the already-done branch).
+    fs.unlinkSync(path.join(userDataDir, MIGRATION_FILE));
+
+    const within = migrateScrollbackOnce(userDataDir, '2.9.1', 1_000_000 + 1_000);
+    expect(within.status).toBe('skipped-debounce');
+  });
+
+  it('legacy directory name uses unix seconds prefix', () => {
+    fs.mkdirSync(path.join(userDataDir, SCROLLBACK_DIR));
+    const result = migrateScrollbackOnce(userDataDir, '2.9.1', 1_700_000_000_000);
+    const legacyName = path.basename(result.legacyDir!);
+    expect(legacyName.startsWith(LEGACY_DIR_PREFIX)).toBe(true);
+    expect(legacyName).toMatch(/^scrollback-legacy-\d+$/);
+  });
+
+  // Rename failures (EBUSY/EPERM/ENOTEMPTY) cannot be deterministically
+  // triggered in a portable test without monkey-patching fs.renameSync.
+  // We assert the contract source-side: status === 'retry-needed' must
+  // NOT write the flag file so the next transition retries.
+  it('returns retry-needed status without writing the flag when rename throws', () => {
+    fs.mkdirSync(path.join(userDataDir, SCROLLBACK_DIR));
+    // Monkeypatch fs.renameSync for the duration of this test.
+    const original = fs.renameSync;
+    (fs as { renameSync: typeof fs.renameSync }).renameSync = () => {
+      const err = new Error('busy') as NodeJS.ErrnoException;
+      err.code = 'EBUSY';
+      throw err;
+    };
+    try {
+      const result = migrateScrollbackOnce(userDataDir, '2.9.1', 2_000_000);
+      expect(result.status).toBe('retry-needed');
+      expect(result.error).toMatch(/EBUSY/);
+      // Flag NOT written so the next transition retries.
+      expect(fs.existsSync(path.join(userDataDir, MIGRATION_FILE))).toBe(false);
+    } finally {
+      (fs as { renameSync: typeof fs.renameSync }).renameSync = original;
+    }
+  });
+});

--- a/src/main/scrollback/legacyMigration.ts
+++ b/src/main/scrollback/legacyMigration.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Phase A — A7. One-time scrollback legacy migration.
+//
+// The renderer .txt scrollback directory is an active hazard while a
+// daemon is connected (A6 gates the runtime writes / reads, but the
+// directory already on disk still contains the chronic 64-byte rotation
+// chain that destroyed prior good backups). A7 moves that directory
+// aside on the first daemon-healthy transition so:
+//   - Daemon-mode users have a clean userData/scrollback/ directory.
+//     A6 keeps it empty going forward.
+//   - The legacy data is preserved at scrollback-legacy-<unix-ts>/ for
+//     manual recovery during the v2.9.1 → v2.10 transition window.
+//
+// Trigger contract (codex review #7 + #9 + #10):
+//   - Subscribe to `daemon:connected` in main. Migration runs on the
+//     FIRST transition into healthy daemon mode (startup OR runtime
+//     late-connect). A 60 s debounce prevents flapping on flaky links.
+//   - If migration fails with EBUSY / EPERM / ENOTEMPTY, do NOT write
+//     the done flag. The next daemon-healthy transition will retry
+//     (still subject to the 60 s debounce).
+//   - If the source directory does not exist (ENOENT), write the flag
+//     anyway so subsequent transitions can skip cheaply.
+//   - Order: fs.renameSync first, flag file second. If rename succeeds
+//     but the flag write fails, next-boot finds no scrollback/ and the
+//     migration naturally no-ops via the ENOENT branch.
+
+export const MIGRATION_FILE = 'scrollback-migration.json';
+export const SCROLLBACK_DIR = 'scrollback';
+export const LEGACY_DIR_PREFIX = 'scrollback-legacy-';
+export const DEBOUNCE_MS = 60_000;
+
+interface MigrationFlag {
+  schema: 1;
+  migratedAt: string;
+  fromVersion?: string;
+}
+
+/** Test-only state reset. Production code never calls this. */
+export function __resetMigrationStateForTests(): void {
+  lastAttemptAt = 0;
+}
+
+let lastAttemptAt = 0;
+
+/** Result the runner returns so callers can log a breadcrumb. */
+export interface MigrationResult {
+  status: 'migrated' | 'already-done' | 'no-source' | 'skipped-debounce' | 'retry-needed';
+  legacyDir?: string;
+  error?: string;
+}
+
+/**
+ * Run one migration attempt. Caller passes the userData dir (Electron's
+ * `app.getPath('userData')`) and the current app version (recorded in the
+ * flag file for forensics). Pure module — no Electron imports — so unit
+ * tests can drive it directly with a tmpdir.
+ */
+export function migrateScrollbackOnce(
+  userDataDir: string,
+  appVersion?: string,
+  now: number = Date.now(),
+): MigrationResult {
+  const flagPath = path.join(userDataDir, MIGRATION_FILE);
+  if (fs.existsSync(flagPath)) {
+    return { status: 'already-done' };
+  }
+  // Debounce repeated transitions inside the 60s window.
+  if (now - lastAttemptAt < DEBOUNCE_MS && lastAttemptAt !== 0) {
+    return { status: 'skipped-debounce' };
+  }
+  lastAttemptAt = now;
+
+  const sourceDir = path.join(userDataDir, SCROLLBACK_DIR);
+  if (!fs.existsSync(sourceDir)) {
+    // Nothing to migrate. Stamp the flag so future transitions skip
+    // cheaply (codex review #8: "If rename succeeds but flag write
+    // fails, next-boot finds no scrollback/ and no-ops safely").
+    writeFlagFile(flagPath, now, appVersion);
+    return { status: 'no-source' };
+  }
+
+  const ts = Math.floor(now / 1000);
+  const legacyDir = path.join(userDataDir, `${LEGACY_DIR_PREFIX}${ts}`);
+  try {
+    fs.renameSync(sourceDir, legacyDir);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    // EBUSY/EPERM/ENOTEMPTY on Windows often clear after antivirus or
+    // a stale handle releases. Retry on the next transition; do NOT
+    // mark done so we eventually succeed.
+    if (code === 'EBUSY' || code === 'EPERM' || code === 'ENOTEMPTY') {
+      return { status: 'retry-needed', error: `${code}: ${(err as Error).message}` };
+    }
+    // Any other error is unexpected. Return a retry-needed so the
+    // caller logs it and the next transition tries again.
+    return { status: 'retry-needed', error: (err as Error).message };
+  }
+
+  writeFlagFile(flagPath, now, appVersion);
+  return { status: 'migrated', legacyDir };
+}
+
+function writeFlagFile(flagPath: string, now: number, appVersion: string | undefined): void {
+  const flag: MigrationFlag = {
+    schema: 1,
+    migratedAt: new Date(now).toISOString(),
+    fromVersion: appVersion,
+  };
+  try {
+    fs.writeFileSync(flagPath, JSON.stringify(flag, null, 2), { mode: 0o600 });
+  } catch {
+    // Best-effort. If the write fails, next-boot finds no scrollback/
+    // (we just renamed it) and the ENOENT branch will safely stamp
+    // the flag on the next attempt.
+  }
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -135,6 +135,16 @@ const electronAPI = {
       ipcRenderer.on('daemon:connected', listener);
       return () => { ipcRenderer.removeListener('daemon:connected', listener); };
     },
+    // Phase A — A6. Companion to onConnected. The renderer subscribes to
+    // both so its reactive daemon-mode state machine can update when the
+    // daemon drops out at runtime (e.g., daemon process dies), not only
+    // when it appears for the first time. Used to gate the .txt scrollback
+    // write/load IPCs so local-mode users keep their fallback path.
+    onDisconnected: (callback: () => void) => {
+      const listener = () => callback();
+      ipcRenderer.on('daemon:disconnected', listener);
+      return () => { ipcRenderer.removeListener('daemon:disconnected', listener); };
+    },
     /**
      * Resolves once main has finalized the daemon-vs-local decision.
      * Returns `{ connected: bool }` reflecting the CURRENT state at

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -96,14 +96,25 @@ function dumpScrollbackBuffersSync(): Map<string, boolean> {
   return dumped;
 }
 
-/** Deep-clone pane tree, setting scrollbackFile on dumped surfaces */
+/** Deep-clone pane tree, setting scrollbackFile on dumped surfaces.
+ *
+ * Phase A — A6 follow-up (codex review P2, session 019e2af8). When daemon
+ * mode is active and dumped is empty, the previous logic preserved every
+ * surface's existing `scrollbackFile` field. A session saved in local
+ * mode therefore carried its stale `.txt` reference forward; if the
+ * renderer ever reloaded before daemon readiness (or after a failed A7
+ * migration), it would try to restore from the stale `.txt` despite the
+ * IPC-level gate. Clear the field outright in daemon mode so session
+ * data round-trips with the gates' intent.
+ */
 function cloneWithScrollback(pane: Pane, dumped: Map<string, boolean>): Pane {
+  const daemonMode = isDaemonModeActive();
   if (pane.type === 'leaf') {
     return {
       ...pane,
       surfaces: pane.surfaces.map((s) => ({
         ...s,
-        scrollbackFile: dumped.has(s.id) ? s.id : s.scrollbackFile,
+        scrollbackFile: dumped.has(s.id) ? s.id : (daemonMode ? undefined : s.scrollbackFile),
       })),
     };
   }

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -32,6 +32,7 @@ import { terminalRegistry } from '../../hooks/useTerminal';
 import { withDefaultShell } from '../../utils/ptyCreateOptions';
 import { serializeTerminalBuffer } from '../../utils/scrollbackDump';
 import { pastePtyChunked } from '../../utils/clipboardChunk';
+import { isDaemonModeActive, setDaemonModeActive } from '../../daemon/daemonMode';
 
 /** Map shell executable path to a human-readable display name. */
 function shellDisplayName(shellPath: string): string {
@@ -68,6 +69,16 @@ function collectTerminalSurfaces(pane: Pane): Surface[] {
  *  instead of mutating surfaces directly. */
 /** Sync version — fire-and-forget for beforeunload (cannot await). */
 function dumpScrollbackBuffersSync(): Map<string, boolean> {
+  // Phase A — A6. In daemon mode the daemon RingBuffer is the single source
+  // of truth for scrollback. Skip the helper entirely so the corresponding
+  // scrollback:dump IPC is never invoked and the rotation chain cannot
+  // self-destruct while daemon is healthy. The returned empty map flows
+  // through cloneWithScrollback so no `scrollbackFile` field is stamped
+  // onto session data, preventing a future restore from picking up a stale
+  // entry from a session that ran in local mode.
+  if (isDaemonModeActive()) {
+    return new Map();
+  }
   const dumped = new Map<string, boolean>();
   const state = useStore.getState();
   for (const ws of state.workspaces) {
@@ -459,6 +470,30 @@ export default function AppLayout() {
     });
     return remove;
   }, [reconcilePtys]);
+
+  // Phase A — A6. Keep the module-level daemon-mode flag in sync with the
+  // main process. The flag gates the renderer .txt scrollback path: while
+  // daemon is connected, autosave skips and the IPC layer short-circuits
+  // so the rotation-chain hazard (chronic 64-byte dumps overwriting good
+  // backups) cannot fire. Local-mode users (daemon spawn fail / disconnect
+  // mid-session) keep the .txt fallback exactly as before.
+  useEffect(() => {
+    // Read initial state — covers the case where main already finalised the
+    // daemon decision before the renderer mounted (reload, crash recovery).
+    void window.electronAPI.daemon.whenReady().then(({ connected }) => {
+      setDaemonModeActive(connected);
+    });
+    const offConnected = window.electronAPI.daemon.onConnected(() => {
+      setDaemonModeActive(true);
+    });
+    const offDisconnected = window.electronAPI.daemon.onDisconnected(() => {
+      setDaemonModeActive(false);
+    });
+    return () => {
+      offConnected();
+      offDisconnected();
+    };
+  }, []);
 
   // Save session on beforeunload (with scrollback dump — sync fire-and-forget)
   useEffect(() => {

--- a/src/renderer/components/Layout/__tests__/dumpScrollbackHelper.daemonMode.test.ts
+++ b/src/renderer/components/Layout/__tests__/dumpScrollbackHelper.daemonMode.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Phase A — A6. The renderer helper that drives 5s autosave + beforeunload
+// session save must skip its entire body in daemon mode so the
+// scrollback:dump IPC is never invoked and `cloneWithScrollback` receives
+// an empty Map (no stale scrollbackFile stamps onto session data).
+//
+// Source-level only — running the helper requires Zustand + xterm
+// instances inside a JSDOM React tree, which is heavy and orthogonal to
+// the actual invariant under test (the daemon-mode gate).
+describe('A6 — dumpScrollbackBuffersSync daemon-mode skip (source-level)', () => {
+  const appLayoutPath = path.join(__dirname, '..', 'AppLayout.tsx');
+  const src = fs.readFileSync(appLayoutPath, 'utf-8');
+
+  it('imports isDaemonModeActive from the renderer daemon module', () => {
+    expect(src).toMatch(
+      /import\s*{\s*isDaemonModeActive[\s\S]*?}\s*from\s*['"](?:\.\.\/){2}daemon\/daemonMode['"]/,
+    );
+  });
+
+  it('dumpScrollbackBuffersSync returns an empty Map when daemon is active', () => {
+    const fnIdx = src.indexOf('function dumpScrollbackBuffersSync(');
+    expect(fnIdx).toBeGreaterThan(0);
+    const body = src.slice(fnIdx, fnIdx + 2000);
+    // The very first behavioural statement must be the daemon-mode guard.
+    expect(body).toMatch(/if\s*\(\s*isDaemonModeActive\(\)\s*\)\s*\{[\s\S]*?return\s+new\s+Map\(\)/);
+  });
+
+  it('AppLayout subscribes to daemon onConnected + onDisconnected to keep the flag in sync', () => {
+    // The effect that wires both listeners and the initial whenReady().
+    expect(src).toMatch(/setDaemonModeActive\(\s*true\s*\)/);
+    expect(src).toMatch(/setDaemonModeActive\(\s*false\s*\)/);
+    expect(src).toMatch(/daemon\.onDisconnected/);
+    expect(src).toMatch(/whenReady\(\)\.then[\s\S]*?setDaemonModeActive/);
+  });
+});

--- a/src/renderer/components/Layout/__tests__/dumpScrollbackHelper.daemonMode.test.ts
+++ b/src/renderer/components/Layout/__tests__/dumpScrollbackHelper.daemonMode.test.ts
@@ -35,4 +35,17 @@ describe('A6 — dumpScrollbackBuffersSync daemon-mode skip (source-level)', () 
     expect(src).toMatch(/daemon\.onDisconnected/);
     expect(src).toMatch(/whenReady\(\)\.then[\s\S]*?setDaemonModeActive/);
   });
+
+  // Codex review P2 #1 (stale scrollback reference). cloneWithScrollback
+  // must zero out s.scrollbackFile in daemon mode so a session saved
+  // before v2.9.1 / before daemon-readiness does not carry its stale
+  // .txt file path forward into the next session restore cycle.
+  it('cloneWithScrollback clears stale scrollbackFile in daemon mode', () => {
+    const fnIdx = src.indexOf('function cloneWithScrollback(');
+    expect(fnIdx).toBeGreaterThan(0);
+    const body = src.slice(fnIdx, fnIdx + 1500);
+    // The daemon-mode branch resolves to undefined rather than preserving
+    // the stale s.scrollbackFile.
+    expect(body).toMatch(/daemonMode\s*\?\s*undefined\s*:\s*s\.scrollbackFile/);
+  });
 });

--- a/src/renderer/components/Palette/CommandPalette.tsx
+++ b/src/renderer/components/Palette/CommandPalette.tsx
@@ -231,11 +231,16 @@ export default function CommandPalette() {
           const state = useStore.getState();
           const ws = state.workspaces.find((w) => w.id === state.activeWorkspaceId);
           if (ws) {
-            state.splitPane(ws.activePaneId, 'horizontal');
-            const newState = useStore.getState();
-            const newWs = newState.workspaces.find((w) => w.id === newState.activeWorkspaceId);
-            if (newWs) {
-              newState.addBrowserSurface(newWs.activePaneId);
+            // splitPane returns false when the workspace has hit the leaf cap
+            // (paneSlice toasts the user). Bail out so the browser surface
+            // does not get attached to the still-active original pane.
+            const ok = state.splitPane(ws.activePaneId, 'horizontal');
+            if (ok) {
+              const newState = useStore.getState();
+              const newWs = newState.workspaces.find((w) => w.id === newState.activeWorkspaceId);
+              if (newWs) {
+                newState.addBrowserSurface(newWs.activePaneId);
+              }
             }
           }
           setVisible(false);

--- a/src/renderer/components/Sidebar/CompanyPanel.tsx
+++ b/src/renderer/components/Sidebar/CompanyPanel.tsx
@@ -233,7 +233,11 @@ export default function CompanyPanel() {
             <button
               onClick={() => {
                 if (confirm('Destroy company and all teams?')) {
-                  destroyCompanyWithCleanup();
+                  // M6 TODOS #4 — fire-and-forget the async helper here
+                  // (no surrounding UI we need to flip after). The
+                  // internal Promise.all on pty.dispose guards the store
+                  // mutation order; React will re-render on company=null.
+                  void destroyCompanyWithCleanup();
                 }
               }}
               className="text-[9px] font-mono transition-colors"

--- a/src/renderer/daemon/__tests__/daemonMode.test.ts
+++ b/src/renderer/daemon/__tests__/daemonMode.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  isDaemonModeActive,
+  setDaemonModeActive,
+  resetDaemonModeForTests,
+} from '../daemonMode';
+
+// Phase A — A6 module-level flag. Verifies the get/set/reset contract so
+// the consumers (dumpScrollbackBuffersSync, useTerminal race cancel,
+// autosave timer) can rely on it.
+describe('daemonMode flag', () => {
+  beforeEach(() => {
+    resetDaemonModeForTests();
+  });
+
+  it('defaults to false (local mode)', () => {
+    expect(isDaemonModeActive()).toBe(false);
+  });
+
+  it('reflects setDaemonModeActive(true)', () => {
+    setDaemonModeActive(true);
+    expect(isDaemonModeActive()).toBe(true);
+  });
+
+  it('toggles back to false', () => {
+    setDaemonModeActive(true);
+    setDaemonModeActive(false);
+    expect(isDaemonModeActive()).toBe(false);
+  });
+
+  it('resetDaemonModeForTests clears the flag', () => {
+    setDaemonModeActive(true);
+    resetDaemonModeForTests();
+    expect(isDaemonModeActive()).toBe(false);
+  });
+});

--- a/src/renderer/daemon/daemonMode.ts
+++ b/src/renderer/daemon/daemonMode.ts
@@ -1,0 +1,32 @@
+// Phase A — A6. Renderer-side daemon connection flag.
+//
+// Module-level mutable boolean kept in sync by AppLayout's main-event
+// listeners (`daemon:connected` / `daemon:disconnected`). Read via the
+// `isDaemonModeActive` getter from any code path that needs to short-circuit
+// the .txt scrollback persistence path while a daemon is healthy.
+//
+// Why module-level rather than store-based: the consumers
+// (`dumpScrollbackBuffersSync`, autosave timer, IPC short-circuit candidates)
+// are called outside React's render cycle, often before Zustand has hydrated
+// (initial whenReady promise resolves async). A simple module-scope let
+// gives every caller the live value with no closure-snapshot risk that a
+// boolean held in component state would have, while staying easy to reset
+// in tests via {@link resetDaemonModeForTests}.
+
+let active = false;
+
+/** True while the renderer believes the main process has a live daemon
+ *  connection. Updated by AppLayout's onConnected / onDisconnected listeners. */
+export function isDaemonModeActive(): boolean {
+  return active;
+}
+
+/** Setter used by AppLayout's event listeners. Not for general use. */
+export function setDaemonModeActive(value: boolean): void {
+  active = value;
+}
+
+/** Reset for vitest beforeEach hooks. */
+export function resetDaemonModeForTests(): void {
+  active = false;
+}

--- a/src/renderer/hooks/__tests__/useTerminal.daemonModeRaceCancel.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.daemonModeRaceCancel.test.ts
@@ -42,4 +42,24 @@ describe('A6 — useTerminal async restore race cancel (source-level)', () => {
     expect(body).toMatch(/scrollbackLoaded\s*=\s*true/);
     expect(body).toMatch(/for\s*\(\s*const\s+data\s+of\s+pendingData/);
   });
+
+  // Codex review P2 #2 (cold-start race): if `.txt` restore lands before
+  // daemon mode flips, the renderer must clear the terminal on the
+  // subsequent daemon:connected event so the SessionPipe replay does not
+  // compose with the stale text.
+  it('arms a daemon.onConnected listener that clears the terminal after .txt restore', () => {
+    // Module-scope flag declared at the top of the effect.
+    expect(src).toMatch(/let\s+didRestoreTxt\s*=\s*false/);
+    // Cleanup slot reserved.
+    expect(src).toMatch(/let\s+removeDaemonConnectedForRestore/);
+    // Inside the restore branch, the flag flips true and the listener arms.
+    const loadIdx = src.indexOf('scrollback.load(scrollbackFile)');
+    const body = src.slice(loadIdx, loadIdx + 4000);
+    expect(body).toMatch(/didRestoreTxt\s*=\s*true/);
+    expect(body).toMatch(/window\.electronAPI\.daemon\.onConnected\(/);
+    // The listener resets the terminal and clears the flag.
+    expect(body).toMatch(/terminal\.reset\(\)/);
+    // Cleanup unregisters the listener.
+    expect(src).toMatch(/removeDaemonConnectedForRestore\?\.\(\)/);
+  });
 });

--- a/src/renderer/hooks/__tests__/useTerminal.daemonModeRaceCancel.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.daemonModeRaceCancel.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Phase A — A6. The async scrollback.load() in useTerminal can resolve
+// AFTER daemon mode becomes active. Writing the stale .txt content into
+// the terminal at that point would compose with the daemon SessionPipe
+// flush via the \r\n\x1b[0m\r\n divider and produce visibly broken
+// scrollback (codex review Layer C corruption path).
+//
+// useTerminal is a 700-line React hook with xterm dependencies that are
+// awkward to bootstrap in vitest, so we verify the race cancel at the
+// source level. The integration assertion (daemon connects mid-load →
+// terminal shows daemon flush only) is part of the manual Windows
+// checklist in docs/upgrade-v2.9.1.md.
+describe('A6 — useTerminal async restore race cancel (source-level)', () => {
+  const hookPath = path.join(__dirname, '..', 'useTerminal.ts');
+  const src = fs.readFileSync(hookPath, 'utf-8');
+
+  it('imports isDaemonModeActive from the renderer daemon module', () => {
+    expect(src).toMatch(
+      /import\s*{\s*isDaemonModeActive\s*}\s*from\s*['"]\.\.\/daemon\/daemonMode['"]/,
+    );
+  });
+
+  it('scrollback.load().then(content) guards on isDaemonModeActive() before writing', () => {
+    const loadIdx = src.indexOf('scrollback.load(scrollbackFile)');
+    expect(loadIdx).toBeGreaterThan(0);
+    // Slice forward enough lines to capture the then handler body.
+    const body = src.slice(loadIdx, loadIdx + 4000);
+    // The guard substitutes the .txt content with null when daemon-mode
+    // activated during the IPC round-trip.
+    expect(body).toMatch(/isDaemonModeActive\(\)\s*\?\s*null\s*:\s*content/);
+    // The write call must use the guarded value, not the raw `content`.
+    expect(body).toMatch(/terminal\.write\(\s*restored\s*\)/);
+  });
+
+  it('still flushes pending PTY data after the daemon-mode skip', () => {
+    const loadIdx = src.indexOf('scrollback.load(scrollbackFile)');
+    const body = src.slice(loadIdx, loadIdx + 4000);
+    // pendingData.length > 0 check happens whether or not restored ran.
+    expect(body).toMatch(/scrollbackLoaded\s*=\s*true/);
+    expect(body).toMatch(/for\s*\(\s*const\s+data\s+of\s+pendingData/);
+  });
+});

--- a/src/renderer/hooks/useKeyboard.ts
+++ b/src/renderer/hooks/useKeyboard.ts
@@ -449,12 +449,16 @@ export function useKeyboard() {
         const state = store.getState();
         const ws = state.workspaces.find((w) => w.id === state.activeWorkspaceId);
         if (ws) {
-          state.splitPane(ws.activePaneId, 'horizontal');
-          // After split, the new pane becomes active; add browser surface to it
-          const newState = store.getState();
-          const newWs = newState.workspaces.find((w) => w.id === newState.activeWorkspaceId);
-          if (newWs) {
-            newState.addBrowserSurface(newWs.activePaneId);
+          // splitPane returns false at the leaf cap (and surfaces its own
+          // toast). Bail out so we don't drop a browser surface on the still-
+          // active original terminal pane.
+          const ok = state.splitPane(ws.activePaneId, 'horizontal');
+          if (ok) {
+            const newState = store.getState();
+            const newWs = newState.workspaces.find((w) => w.id === newState.activeWorkspaceId);
+            if (newWs) {
+              newState.addBrowserSurface(newWs.activePaneId);
+            }
           }
         }
         return;

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -367,7 +367,8 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     if (!ws) return { error: 'no active workspace' };
     const direction =
       params.direction === 'vertical' ? 'vertical' : 'horizontal';
-    store.splitPane(ws.activePaneId, direction);
+    const ok = store.splitPane(ws.activePaneId, direction);
+    if (!ok) return { error: 'pane cap reached (max 20 per workspace)' };
     return { ok: true };
   }
 
@@ -717,7 +718,11 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // This uses PaneContainer's proven split mechanism instead of
     // trying to render terminal+browser in the same leaf pane.
     const paneId = ws.activePaneId;
-    store.splitPane(paneId, 'horizontal', targetWsId);
+    const ok = store.splitPane(paneId, 'horizontal', targetWsId);
+    // At the per-workspace leaf cap splitPane is a no-op (and pushes its own
+    // toast). Bail out before addBrowserSurface so we don't drop a browser tab
+    // on the still-active original terminal pane.
+    if (!ok) return { error: 'pane cap reached (max 20 per workspace)' };
 
     // After split, the new pane becomes active
     const afterSplit = useStore.getState();

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -503,6 +503,20 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // Deferred PTY listener references — connected after scrollback restore
     let removeDataListener: (() => void) | null = null;
     let removeExitListener: (() => void) | null = null;
+    // Phase A — A6 cold-start race fix (codex review P2 #2, session
+    // 019e2af8). When `.txt` restore lands before daemon mode flips, the
+    // race-cancel guard inside scrollback.load().then() does nothing
+    // (`isDaemonModeActive()` is still false). The stale `.txt` content
+    // is then written into the terminal and a subsequent daemon connect
+    // would replay the daemon RingBuffer on top, recreating the composed
+    // scrollback corruption A6 is meant to prevent.
+    //
+    // Track whether `.txt` content was actually written, and if so listen
+    // for `daemon:connected` — when it fires, clear + reset the terminal
+    // before SessionPipe replay arrives, so the daemon flush lands on a
+    // fresh xterm with no stale prefix.
+    let didRestoreTxt = false;
+    let removeDaemonConnectedForRestore: (() => void) | null = null;
     let firstDataFired = false;
     const fireFirstData = () => {
       if (!firstDataFired) {
@@ -578,6 +592,16 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           // output.
           terminal.write('\r\n\x1b[0m\r\n');
           fireFirstData();
+          didRestoreTxt = true;
+          // Arm the late-connect clear. If daemon mode activates after this
+          // moment, wipe the terminal so the SessionPipe replay does not
+          // compose on top of the stale .txt content we just wrote.
+          removeDaemonConnectedForRestore = window.electronAPI.daemon.onConnected(() => {
+            if (!didRestoreTxt) return;
+            if (terminalRef.current !== terminal) return;
+            terminal.reset();
+            didRestoreTxt = false;
+          });
         }
         scrollbackLoaded = true;
         for (const data of pendingData) {
@@ -696,6 +720,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       resizeObserver.disconnect();
       removeDataListener?.();
       removeExitListener?.();
+      removeDaemonConnectedForRestore?.();
       terminalRegistry.delete(ptyId);
       webglAddonRef.current?.dispose();
       webglAddonRef.current = null;

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -8,6 +8,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import { useStore } from '../stores';
 import { t } from '../i18n';
 import { XTERM_THEMES, extractXtermColors, type ThemeId, type BuiltinThemeId } from '../themes';
+import { isDaemonModeActive } from '../daemon/daemonMode';
 import { pastePtyChunked, chunkOnDataIfNeeded } from '../utils/clipboardChunk';
 import { runCopyWithFeedback } from '../utils/copyWithFeedback';
 import { shouldFitWhilePreservingSelection } from '../utils/fitGuard';
@@ -558,8 +559,15 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         // would write into a torn-down terminal on fast unmount + remount
         // (e.g. workspace switch mid-restore).
         if (terminalRef.current !== terminal) return;
-        if (content) {
-          terminal.write(content);
+        // Phase A — A6. Race cancel: if daemon mode activated between the
+        // scrollback.load() call and now, discard the .txt content. The
+        // daemon SessionPipe replay will provide authoritative scrollback
+        // and writing the stale .txt here would compose it with that
+        // replay (via the divider below), producing visibly broken output.
+        // Pending PTY data still flushes through unchanged.
+        const restored = isDaemonModeActive() ? null : content;
+        if (restored) {
+          terminal.write(restored);
           // Whitespace + ANSI reset boundary so restored scrollback doesn't
           // visually fuse with the fresh PTY prompt drawn moments later.
           // \x1b[0m closes any attribute left open by restored content; the

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -21,6 +21,7 @@ export const en = {
   'pane.empty': 'Empty pane',
   'pane.splitRight': 'Split right',
   'pane.splitDown': 'Split down',
+  'pane.maxLeavesReached': 'Pane limit reached ({count}). Close a pane before splitting again.',
 
   // Surface
   'surface.terminal': 'Terminal',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -21,6 +21,7 @@ export const ko = {
   'pane.empty': '빈 창',
   'pane.splitRight': '오른쪽 분할',
   'pane.splitDown': '아래 분할',
+  'pane.maxLeavesReached': '창 분할 한도 도달 ({count}개). 창을 닫고 다시 시도하세요.',
 
   // Surface
   'surface.terminal': '터미널',

--- a/src/renderer/stores/slices/__tests__/paneSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneSlice.test.ts
@@ -1,14 +1,16 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
-import { createPaneSlice, type PaneSlice } from '../paneSlice';
+import { createPaneSlice, type PaneSlice, MAX_PANES_PER_WORKSPACE } from '../paneSlice';
 import { createWorkspace, type Workspace } from '../../../../shared/types';
 import { findPane, getLeafPanes } from '../../../../shared/paneUtils';
 
-// Minimal store that satisfies PaneSlice dependencies
+// Minimal store that satisfies PaneSlice dependencies. Includes a `pushToast`
+// stub because splitPane calls it via get() when the leaf cap is hit.
 type TestState = PaneSlice & {
   workspaces: Workspace[];
   activeWorkspaceId: string;
+  pushToast: ReturnType<typeof vi.fn>;
 };
 
 function createTestStore() {
@@ -17,6 +19,7 @@ function createTestStore() {
     immer((...args) => ({
       workspaces: [ws],
       activeWorkspaceId: ws.id,
+      pushToast: vi.fn(),
       // @ts-expect-error — minimal test store doesn't match full StoreState
       ...createPaneSlice(...args),
     }))
@@ -232,6 +235,41 @@ describe('PaneSlice', () => {
       // prev again walks toward the front.
       store.getState().cyclePane('prev');
       expect(getActiveWorkspace(store).activePaneId).toBe(leaves[leaves.length - 2].id);
+    });
+  });
+
+  describe('splitPane — leaf cap', () => {
+    // Workspace starts with 1 leaf; each split adds exactly 1 leaf, so
+    // (MAX_PANES_PER_WORKSPACE - 1) splits brings us right to the cap.
+    it('allows splits up to MAX_PANES_PER_WORKSPACE leaves', () => {
+      for (let i = 0; i < MAX_PANES_PER_WORKSPACE - 1; i++) {
+        const ws = getActiveWorkspace(store);
+        const ok = store.getState().splitPane(ws.activePaneId, 'horizontal');
+        expect(ok).toBe(true);
+      }
+      const wsAfter = getActiveWorkspace(store);
+      expect(getLeafPanes(wsAfter.rootPane)).toHaveLength(MAX_PANES_PER_WORKSPACE);
+      expect(store.getState().pushToast).not.toHaveBeenCalled();
+    });
+
+    it('returns false, no-ops the tree, and toasts once at the cap', () => {
+      for (let i = 0; i < MAX_PANES_PER_WORKSPACE - 1; i++) {
+        const ws = getActiveWorkspace(store);
+        store.getState().splitPane(ws.activePaneId, 'horizontal');
+      }
+      const wsAtCap = getActiveWorkspace(store);
+      const leavesAtCap = getLeafPanes(wsAtCap.rootPane).map((l) => l.id);
+
+      const ok = store.getState().splitPane(wsAtCap.activePaneId, 'horizontal');
+      expect(ok).toBe(false);
+
+      const wsAfter = getActiveWorkspace(store);
+      const leavesAfter = getLeafPanes(wsAfter.rootPane).map((l) => l.id);
+      expect(leavesAfter).toEqual(leavesAtCap); // tree unchanged
+      expect(store.getState().pushToast).toHaveBeenCalledTimes(1);
+      const arg = store.getState().pushToast.mock.calls[0][0] as { level: string; message: string };
+      expect(arg.level).toBe('warn');
+      expect(arg.message).toContain(String(MAX_PANES_PER_WORKSPACE));
     });
   });
 });

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -10,6 +10,14 @@ import {
   publishPaneClosed,
   publishPaneFocused,
 } from '../../events/publisher';
+import { t } from '../../i18n';
+
+// Per-workspace leaf cap. xterm.js + node-pty memory scales linearly with
+// pane count, and the project memory budget targets ~200 MB for 10 panes
+// (TODOS.md "Pane split max depth/count guard"). 20 leaves keeps a runaway
+// shortcut spam (Ctrl+D held, scripted splits, etc.) from exhausting RAM
+// while still being far more than any sane manual layout needs.
+export const MAX_PANES_PER_WORKSPACE = 20;
 
 // M0-d: paneSlice is a read-only mirror for PaneLeaf.metadata. The
 // authoritative writer is MetadataStore in the main process (M0-a + M0-b).
@@ -18,7 +26,14 @@ import {
 // `PaneLeaf.metadata` field remains on the shared type so UI components can
 // read it directly (and so SessionManager hydration can populate it).
 export interface PaneSlice {
-  splitPane: (paneId: string, direction: 'horizontal' | 'vertical', workspaceId?: string) => void;
+  /**
+   * Split a leaf pane into a new horizontal/vertical branch.
+   * Returns `true` on success, `false` if the workspace is at
+   * MAX_PANES_PER_WORKSPACE (callers chaining `addBrowserSurface`,
+   * RPC handlers, etc. must abort on `false` so they don't mutate
+   * the still-active original pane).
+   */
+  splitPane: (paneId: string, direction: 'horizontal' | 'vertical', workspaceId?: string) => boolean;
   closePane: (paneId: string) => void;
   setActivePane: (paneId: string) => void;
   focusPaneDirection: (direction: 'up' | 'down' | 'left' | 'right') => void;
@@ -60,9 +75,11 @@ function getLeafPanes(root: Pane): PaneLeaf[] {
   return root.children.flatMap(getLeafPanes);
 }
 
-export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]], [], PaneSlice> = (set) => ({
+export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]], [], PaneSlice> = (set, get) => ({
   splitPane: (paneId, direction, workspaceId) => {
     let event: { wsId: string; newPaneId: string; branchId: string; previousActiveId: string } | null = null;
+    let blockedAtCap = false;
+    let created = false;
     set((state: StoreState) => {
       const targetWsId = workspaceId || state.activeWorkspaceId;
       const ws = state.workspaces.find((w: Workspace) => w.id === targetWsId);
@@ -70,6 +87,15 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
 
       const targetPane = findPane(ws.rootPane, paneId);
       if (!targetPane || targetPane.type !== 'leaf') return;
+
+      // Cap leaf growth — every callsite (Ctrl+D, prefix-mode split, palette,
+      // browser-pane shortcut, sample-task wizard) funnels through here, so a
+      // single guard is enough.
+      if (collectLeafIds(ws.rootPane).length >= MAX_PANES_PER_WORKSPACE) {
+        blockedAtCap = true;
+        return;
+      }
+      created = true;
 
       const newPane = createLeafPane();
       const branch: PaneBranch = {
@@ -109,6 +135,15 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
         publishPaneFocused(e.wsId, e.newPaneId, e.previousActiveId);
       }
     }
+    if (blockedAtCap) {
+      // Toast emitted outside the immer producer so the slice doesn't recurse
+      // into another set() while the producer is still running.
+      get().pushToast({
+        message: t('pane.maxLeavesReached', { count: MAX_PANES_PER_WORKSPACE }),
+        level: 'warn',
+      });
+    }
+    return created;
   },
 
   closePane: (paneId) => {


### PR DESCRIPTION
## Summary

Phase A reliability bundle for v2.9.1. Closes the chronic gap where a Windows reboot, log-off, or tray Quit left users with empty or chopped scrollback even though the underlying daemon had data in memory. Renames the renderer-side `.txt` system from "deferred cleanup target" to "actively hazard-gated" so its 4-minute rotation chain stops destroying its own backups.

18 commits, 38 files, +2546/-87. Single PR per [[feedback_pr_strategy]] so external reviewers see the bundle as one ship unit.

## What ships

**Phase A (the headline reliability fixes):**

- **A1a invariant locked.** `daemon.createSession` / `daemon.attachSession` already persisted sessions.json synchronously via `stateWriter.saveImmediate`. Source-level + behavioural tests prevent a future refactor from breaking this.
- **A1b: snapshot runner extracted + fired at spawn + on every create/attach.** Closes the 30 s window where no `.buf` file existed on disk. Pending-rerun pattern handles concurrent triggers. Cap-skipped suspended sessions preserved via merge — recovery still sees them past `MAX_RECOVER_SESSIONS`.
- **A2: `daemon.shutdown` RPC is now truly awaitable.** Handler runs the full shutdown body before returning; `setImmediate` defers pipe stop + `process.exit(0)` so the ack flushes back to the caller. `DaemonClient.rpc` gained per-call `{ timeoutMs }` override.
- **A3: main `before-quit` races daemon.shutdown** against a 4 s budget, falls back to existing `disconnect()` path. Side-effect-free helper `raceDaemonShutdown` shared with A5.
- **A4: atomic RingBuffer dumps.** Async and sync paths both use `<dst>.tmp.<6-byte-hex>` + rename. Stale tmps swept at daemon startup. Precise `dumpsCompleted` guard replaces the broader `shuttingDown` guard so the Windows `process.on('exit')` sync handler still runs if the async path was interrupted.
- **A5: Windows `session-end` (WM_ENDSESSION) RPC race.** Same 4 s budget, then `disconnectSync()`. Async handler so the race actually awaits.
- **A6: renderer `.txt` path gated off in daemon mode.** New `daemon:disconnected` IPC, reactive renderer flag, helper-level skip in `dumpScrollbackBuffersSync`, IPC handlers `scrollback:dump` + `scrollback:load` both short-circuit, `useTerminal` async restore race-cancels stale `.txt` content if daemon connects mid-load. Local mode (daemon spawn fail / runtime disconnect) keeps the full `.txt` fallback verbatim.
- **A7: one-time legacy scrollback migration.** First daemon-healthy transition (startup OR runtime late-connect) renames `userData/scrollback/` to `scrollback-legacy-<unix-ts>/`. Idempotent flag at `scrollback-migration.json`. EBUSY / EPERM / ENOTEMPTY auto-retry on next transition.

**M6 in-orbit fixes folded in:**

- TODOS #2 (split max-depth/count guard) — already in `bf67a79`.
- TODOS #4 (`destroyCompanyWithCleanup` race) — await Promise.all on every dispose before mutating the store.
- TODOS #5 (member workspace PTY leak on company destroy) — `collectLeafSurfaces` for every member workspace, mirroring the CEO branch.
- **TODOS #1 (daemon reconnection retry on tray restore) — deferred to v2.9.2.** Needs a careful race-handling design for the in-flight handler-swap window and is not gating the v2.9.1 reliability headline. Noted in `decisions.md`.

**Other:**

- `scripts/daemon-shutdown-dynamic.mjs` — T1/T2 scenarios for end-to-end daemon shutdown verification + T5 latency measurement scaffold for `A5_TIMEOUT_MS` calibration. T5 currently hits a ConPTY rapid-spawn race (`ERROR_INVALID_PARAMETER 87`) on this dev box; documented in the script. A3/A5 use a 4 s placeholder pending a successful T5 run.
- `docs/upgrade-v2.9.1.md` — release notes + manual Windows verification checklist (tray Quit, reboot, log-off, daemon kill, antivirus, local mode, legacy migration) for the paths the automated suite cannot reach.
- `valiant-purring-sutherland.md` plan updated with the implementation addendum.

## Architecture decisions captured in `decisions.md`

- **Codex consult — 17 findings accepted.** Each Phase A commit went through codex review; P1 findings fixed before next commit, P2 hygiene findings drove design refinement (pending-rerun, cap-skipped merge, daemon state machine, transition-triggered migration). Codex hit usage quota mid-pass at 22:41 UTC+9; final full-diff review will run in a separate session post-PR-open per plan.
- **A6 + A7 fold-in.** Plan originally deferred the `.txt` path to Phase B-E. Codex consult flagged it as an active hazard (not stale code) — the rotation chain destroys good backups every ~4 minutes. Folded into v2.9.1 so the dogfood window does not include continuing data damage.
- **Release vehicle.** v2.9.1 patch bundle as originally planned. Auto-release pipeline ([[reference_release_automation]]) publishes GitHub Release + Chocolatey + winget on tag push post-merge.

## Test plan

Automated: full suite 1221 pass + 1 known-flaky ProcessMonitor test that passes in isolation (plan permits 1 re-run). tsc clean. eslint 0 new errors (3 warnings match `DaemonSessionManager.test.ts` baseline `_` pattern).

New test files (11): `createSessionPersistence.test.ts`, `runSnapshotOnce.test.ts`, `shutdownRpc.test.ts`, `daemonShutdownRace.test.ts`, `dumpToFile.atomic.test.ts`, `syncExitGuard.test.ts`, `sessionEnd.daemonShutdown.test.ts`, `daemonMode.test.ts`, `session.handler.daemonModeNoop.test.ts`, `dumpScrollbackHelper.daemonMode.test.ts`, `useTerminal.daemonModeRaceCancel.test.ts`, `legacyMigration.test.ts`. Plus extended DaemonClient.test.ts with per-call `timeoutMs` coverage.

Manual checklist (Windows): see `docs/upgrade-v2.9.1.md` §3. The WM_ENDSESSION reboot test is the only end-to-end coverage of the load-bearing user path.

## Trade-offs (also documented in upgrade doc)

- **Post-migration local-mode fresh scrollback.** After A7 runs, a subsequent fall back to local mode starts with a fresh empty `scrollback/`. Legacy data remains at `scrollback-legacy-<ts>/` for manual recovery.
- **WM_ENDSESSION 4 s budget.** Windows gives ~5 s before SIGKILL. v2.9.1 uses 4 s for the daemon race + 1 s margin for disconnect + Electron teardown. Heavy workloads may exceed and fall back to detach-only (v2.9.0 behaviour).
- **`.txt` rotation chain still hazardous in local mode.** A6 + A7 only affect daemon-mode users. The fundamental `.txt` rotation bug remains for daemon-less deploys. Phase B-E will address.

## Final review status

Codex per-commit reviews completed for all P1 findings. Final two reviews remain (per plan, in separate sessions):

- [ ] Codex full-diff review (`/codex review` on the full PR; codex hit usage quota mid-implementation, will run post-PR-open).
- [ ] Claude code-reviewer agent (separate session, opus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)