### PR TITLE
substrate: SECURITY.md + filesystem hardening on daemon startup (Phase 3.2 baseline)

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,128 @@
+# wmux Substrate — Security Model
+
+> **Status:** Draft 1 (Phase 0 / Phase 3.2 baseline). Companion to the [substrate protocol](./PROTOCOL.md) and the v3.0 [stability contract](./api/stability.md).
+> **Audience:** plugin authors, integrators, security reviewers, and anyone trying to decide whether wmux fits a given threat model.
+
+This document states the wmux substrate's security posture. It is deliberately narrow about what wmux protects against and explicit about what it does not. The substrate's identity is a small neutral core plus a plugin layer (§4 of `PROTOCOL.md`); the security model follows the same shape — small core guarantees, hard delegations to the OS, and a clear list of out-of-scope threats.
+
+---
+
+## 0. The substrate's security stance
+
+wmux is a **terminal substrate, not a secure data vault**. Its job is to own panes, terminal I/O, and the event bus, and to expose a stable surface to external tools. It is not designed to be a confidentiality boundary against same-user adversaries on the same machine.
+
+If a workflow demands strong at-rest confidentiality (compliance-grade key material, regulated PII, classified data), the correct primitive is OS-level isolation — Windows Sandbox, a Hyper-V or VirtualBox VM, a container — and wmux running inside it. wmux does not replace those primitives.
+
+This is the same trade-off as `tmux` and most terminal multiplexers: persistence and recoverability are surface-level features, and confidentiality is delegated to the operating system.
+
+---
+
+## 1. What wmux guarantees
+
+The following are first-class commitments. Regressions here are bugs.
+
+### 1.1 At-rest file mode
+
+- POSIX (`macOS`, `Linux`): `~/.wmux/` and every file inside it are created with mode `0o600` (owner read/write only). Directories are `0o700`.
+- Windows: `%USERPROFILE%\.wmux\` inherits the user profile ACL by default. The daemon additionally hardens the directory ACL on startup to remove inherited groups and grant the current user only (see §1.2).
+
+### 1.2 NTFS ACL hardening (Windows)
+
+On daemon startup, wmux invokes `icacls` to:
+
+1. Disable ACL inheritance on `%USERPROFILE%\.wmux\`.
+2. Remove all granted principals except the current user.
+3. Grant the current user full control, propagating to existing children.
+
+This is a defense-in-depth measure on top of the default profile ACL. The hardening is idempotent and runs once per daemon boot.
+
+### 1.3 Cloud-sync exclusion signals
+
+On Windows, the daemon applies three signals to `%USERPROFILE%\.wmux\` and its `buffers\` subdirectory on startup:
+
+1. **Hidden + System NTFS attributes** (`attrib +H +S`). Many backup utilities skip system-hidden folders by default.
+2. **Not-content-indexed attribute** (`attrib +I`). Windows Search ignores the contents, so scrollback never surfaces in a Search index.
+3. **`.no-cloud-sync.txt` notice file** at the directory root. A plain-text note humans see when browsing the folder in Explorer or a sync-tool UI, instructing them to exclude it from cloud sync, backup, or indexing tools.
+
+These are *opportunistic* signals. They are not a guaranteed exclusion. OneDrive's Known Folder Move only targets Desktop, Documents, Pictures, Music, and Videos by default, so `%USERPROFILE%\.wmux\` is normally outside its scope; users who explicitly redirect their profile root or use Windows Backup must add an exclusion in their backup tool. Third-party sync engines (Dropbox, Google Drive, etc.) each have their own ignore configuration that wmux cannot influence. Users are responsible for confirming exclusion in the engines they run.
+
+POSIX systems have no equivalent ambient cloud-sync layer; the `0o700` directory mode is sufficient.
+
+### 1.4 Named Pipe authentication
+
+The daemon's Named Pipe (Windows) and Unix socket (POSIX) carry a per-boot auth token. The token file is mode `0o600` (POSIX) and lives under `~/.wmux/`. Clients without the token are rejected before any RPC is dispatched.
+
+### 1.5 Per-plugin permission enforcement
+
+MCP plugins declare `wmuxPermissions` in their manifest. The substrate enforces those at four points (method · path · event · workspace claim) on every RPC and event delivery. A plugin without `pane.read` permission for a given pane never sees that pane's content via the substrate API.
+
+Permission enforcement is a substrate guarantee for plugin access through documented surfaces. It is *not* a sandbox: a same-user plugin process can read disk files directly without going through the substrate. Plugin disk access is governed by §1.1 and §1.2.
+
+---
+
+## 2. What wmux delegates to the operating system
+
+| Concern | OS primitive |
+|---|---|
+| At-rest disk encryption | BitLocker (Windows), FileVault (macOS), LUKS / dm-crypt (Linux) |
+| Process-to-process isolation | OS user accounts, ACLs, process tokens |
+| Memory protection | OS memory manager (no `mlock`, no pinning) |
+| Pagefile / swap leak | OS-level pagefile encryption (BitLocker on Windows, encrypted swap on macOS/Linux) |
+| Crash-dump scrubbing | OS crash-dump policy (Windows Error Reporting opt-out, etc.) |
+| Network confidentiality (PTY over remote shells) | The user's SSH / VPN / TLS stack |
+
+If your threat model requires any of these, configure the OS layer. wmux does not duplicate them.
+
+---
+
+## 3. What wmux does NOT try to protect against
+
+Stated explicitly so reviewers and operators don't infer guarantees that don't exist.
+
+- **Same-user malware or unauthorized processes.** A process running as the same user can read `~/.wmux/` directly, attach a debugger to the daemon, or inspect process memory. No application-level mitigation defeats this.
+- **Pagefile / swap leak of PTY bytes.** Scrollback lives in process memory and is subject to normal OS paging. Use OS-level pagefile encryption if this matters.
+- **Crash dumps.** A daemon or renderer crash may produce a dump containing scrollback bytes. Disable crash dumps at the OS level if this matters.
+- **GPU / framebuffer memory inspection.** Rendered terminal text passes through the GPU; same-user GPU memory access can recover it.
+- **Side-channel timing attacks** against PTY input or rendering.
+- **Cloud sync engines that ignore the exclusion marker** (§1.3). The user must configure those tools directly.
+- **Compromised plugins running as the same user.** Permission enforcement (§1.5) defends documented substrate access only. A compromised plugin process can do anything its user account can do.
+- **Network-level attacks on PTY data carried over shells the user opens.** wmux is the multiplexer; SSH / VPN / TLS are the user's responsibility.
+
+---
+
+## 4. For high-sensitivity workflows
+
+If a session is sensitive enough that the above out-of-scope items matter, the correct posture is OS-level isolation:
+
+- **Short-lived secret handling** (env dumps, key prints, AWS CLI output): run the shell inside a transient Windows Sandbox or Hyper-V VM. Close the sandbox when done. wmux outside the sandbox never sees the bytes.
+- **Compliance-regulated workflows** (PCI, HIPAA, classified): run wmux inside a regulated VM with the appropriate disk encryption, swap encryption, and crash-dump policy. The substrate's `~/.wmux/` lives inside the VM and inherits the VM's protections.
+- **Multi-tenant developer machines** where the user account itself is not trusted: do not use wmux. The substrate explicitly does not protect against same-user adversaries.
+
+There is no per-session "secure mode" toggle in wmux. The substrate is neutral: every session gets the same persistence and recovery guarantees described in `PROTOCOL.md`, and confidentiality is achieved by OS-level isolation, not by per-session opt-outs.
+
+---
+
+## 5. Reporting security issues
+
+Security issues should be reported privately. Use GitHub's "Report a vulnerability" workflow on the wmux repository, or email the maintainer directly (see repository README). Please do not file public issues for security-relevant findings until a fix is available.
+
+What we consider a security issue:
+
+- A defect that violates a §1 guarantee (e.g., a code path that writes a substrate file with broader ACL than stated).
+- A documented substrate surface that returns data to a plugin without honoring `wmuxPermissions`.
+- A token-handling defect in the Named Pipe / socket layer.
+- Substrate-side parsing or deserialization defects exploitable from the plugin side.
+
+What we do not consider a wmux security issue:
+
+- Same-user disclosure paths covered by §3.
+- Cloud-sync engines mirroring `~/.wmux/` despite §1.3 (configure the sync tool).
+- PTY content disclosure through tools the user runs *inside* a pane (that's the inner program's surface, not wmux's).
+
+---
+
+## 6. Change log
+
+| Date | Change |
+|---|---|
+| 2026-05-16 | Initial draft. Phase 0 baseline; expanded during Phase 3.2 Security review. |

--- a/scripts/substrate-hardening-dynamic.mjs
+++ b/scripts/substrate-hardening-dynamic.mjs
@@ -1,0 +1,397 @@
+#!/usr/bin/env node
+/**
+ * Substrate v3.0 Phase 3.2 dynamic test — substrate filesystem hardening.
+ *
+ * Spawns the BUNDLED daemon (dist/daemon-bundle/index.js) in an isolated
+ * USERPROFILE/HOME and verifies that acquireLock()'s hardenWmuxDir pass
+ * actually executed against the OS layer — not just that the source
+ * string matches, which is all the unit suite can lock.
+ *
+ * Scenarios:
+ *
+ *   H1  fresh-dir hardening (Windows-only)
+ *       Spawns daemon against an empty test home. After daemon-pipe
+ *       appears (= acquireLock returned = hardenWmuxDir already ran),
+ *       asserts the OS-level artifacts:
+ *         a) icacls inheritance is disabled and the current user is
+ *            granted (F).
+ *         b) attrib shows H, S, and I flags on the dir and on buffers/.
+ *         c) .no-cloud-sync.txt exists with the substrate marker text.
+ *
+ *   H2  idempotent re-run (Windows-only)
+ *       Re-spawns the daemon against the SAME test home where H1 left
+ *       hardened artifacts. Asserts:
+ *         a) Daemon still starts cleanly (no acquireLock failure).
+ *         b) Notice file content is byte-identical (idempotent overwrite).
+ *         c) ACL + attrib state unchanged (re-applying does not corrupt).
+ *
+ *   H3  POSIX early-return parity
+ *       On POSIX (macOS/Linux), spawns daemon against a fresh test home
+ *       and asserts:
+ *         a) Daemon starts cleanly (no icacls / attrib errors leak).
+ *         b) The wmux dir does NOT have a .no-cloud-sync.txt (POSIX
+ *            path early-returns before the write).
+ *         c) Directory mode is 0o700 (from acquireLock's mkdirSync,
+ *            unchanged by hardening pass).
+ *
+ * Manual checklist parity:
+ *   PR #40's test plan lists "icacls / attrib / notice file" as three
+ *   manual verifications. H1 + H2 cover those automatically. The manual
+ *   list stays as a real-Windows-environment final smoke test (the
+ *   isolated-USERPROFILE pattern here is high-fidelity but not identical
+ *   to a real user's installation profile).
+ */
+import { spawn, execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const DAEMON_BUNDLE = path.join(REPO_ROOT, 'dist', 'daemon-bundle', 'index.js');
+
+if (!fs.existsSync(DAEMON_BUNDLE)) {
+  console.error('Daemon bundle missing — run `npm run build:daemon` first');
+  process.exit(2);
+}
+
+// Helpers ---------------------------------------------------------------
+
+function makeTestHome() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-hardening-dyn-'));
+  return home;
+}
+
+function makePipeName(tag) {
+  if (process.platform === 'win32') {
+    return `\\\\.\\pipe\\wmux-hardening-test-${tag}`;
+  }
+  return path.join(os.tmpdir(), `wmux-hardening-test-${tag}.sock`);
+}
+
+function writeConfig(wmuxDir, pipeName, authToken) {
+  fs.mkdirSync(wmuxDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(wmuxDir, 'config.json'),
+    JSON.stringify(
+      {
+        version: 1,
+        daemon: { pipeName, logLevel: 'warn', autoStart: true },
+        session: {
+          defaultShell: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
+          defaultCols: 80,
+          defaultRows: 24,
+          bufferSizeMb: 8,
+          bufferMaxMb: 64,
+          deadSessionTtlHours: 24,
+          deadSessionDumpBuffer: true,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(path.join(wmuxDir, 'daemon-auth-token'), authToken, 'utf-8');
+}
+
+function spawnDaemon(testHome) {
+  return spawn(process.execPath, [DAEMON_BUNDLE], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      USERPROFILE: testHome,
+      HOME: testHome,
+      HOMEDRIVE: undefined,
+      HOMEPATH: undefined,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+async function waitForPipeFile(wmuxDir, timeoutMs = 10_000) {
+  const pipeFile = path.join(wmuxDir, 'daemon-pipe');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(pipeFile)) return fs.readFileSync(pipeFile, 'utf-8').trim();
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error('daemon-pipe did not appear within timeout');
+}
+
+async function killDaemon(child) {
+  if (child.killed) return;
+  child.kill('SIGTERM');
+  await new Promise((r) => setTimeout(r, 800));
+  if (!child.killed) child.kill('SIGKILL');
+}
+
+// Windows verification helpers -----------------------------------------
+
+function runIcacls(target) {
+  const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+  const icacls = path.join(systemRoot, 'System32', 'icacls.exe');
+  return execFileSync(icacls, [target], {
+    encoding: 'utf-8',
+    timeout: 5000,
+    windowsHide: true,
+  });
+}
+
+function runAttrib(target) {
+  const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+  const attrib = path.join(systemRoot, 'System32', 'attrib.exe');
+  return execFileSync(attrib, [target], {
+    encoding: 'utf-8',
+    timeout: 5000,
+    windowsHide: true,
+  });
+}
+
+/**
+ * Parse icacls output for the hardening invariants.
+ * Returns { inheritanceDisabled, currentUserHasFullControl, raw }.
+ *
+ * icacls output for a hardened dir typically looks like:
+ *   C:\path\.wmux NT AUTHORITY\SYSTEM:(I)(OI)(CI)(F)   (before /inheritance:r)
+ *   C:\path\.wmux DOMAIN\user:(OI)(CI)(F)             (after /grant:r)
+ *
+ * After our hardening pass, inherited (I) entries should be absent and
+ * the current user grant should be present with (F) and inheritance
+ * propagation flags (OI)(CI).
+ */
+function parseIcacls(output) {
+  const lines = output.split(/\r?\n/);
+  const username = process.env.USERNAME || os.userInfo().username;
+  // Any line with (I) marks an inherited entry.
+  const inheritedLines = lines.filter((l) => /\(I\)/.test(l) && !/^Successfully/i.test(l));
+  // Current user with (F) — accept any prefix (DOMAIN\user, COMPUTER\user, or bare user).
+  const userPattern = new RegExp(`(^|\\\\)${username}:.*\\(F\\)`, 'i');
+  const currentUserHasFullControl = lines.some((l) => userPattern.test(l));
+  return {
+    inheritanceDisabled: inheritedLines.length === 0,
+    currentUserHasFullControl,
+    inheritedLineCount: inheritedLines.length,
+    raw: output.trim(),
+  };
+}
+
+/**
+ * Parse attrib output for the hardening invariants.
+ *   "A  SHI  C:\path\.wmux"  → H, S, I flags present
+ *
+ * The flag column shows letters at fixed positions but rather than
+ * parsing columns we accept any presence of H, S, and I in the output
+ * line for the target. Returns { hidden, system, notIndexed, raw }.
+ */
+function parseAttrib(output, target) {
+  const targetLine = output
+    .split(/\r?\n/)
+    .find((l) => l.trim().endsWith(target) || l.toLowerCase().includes(target.toLowerCase()));
+  if (!targetLine) {
+    return { hidden: false, system: false, notIndexed: false, raw: output.trim(), targetLineMissing: true };
+  }
+  // attrib uses a fixed-width flag column on Windows. Strip the path
+  // from the line and inspect the remaining flag column directly —
+  // letters may be adjacent ("SH I" or "ASHRI"), so a word-boundary
+  // regex misses them. Simple character containment is correct because
+  // the path has already been removed.
+  const flagPart = targetLine.replace(target, '').toUpperCase();
+  return {
+    hidden: flagPart.includes('H'),
+    system: flagPart.includes('S'),
+    notIndexed: flagPart.includes('I'),
+    raw: targetLine.trim(),
+  };
+}
+
+// Scenarios ------------------------------------------------------------
+
+async function runH1(report) {
+  if (process.platform !== 'win32') {
+    report.push({ scenario: 'H1', skipped: 'not win32', pass: null });
+    return;
+  }
+  const testHome = makeTestHome();
+  const wmuxDir = path.join(testHome, '.wmux');
+  const pipeName = makePipeName(`H1-${randomUUID().slice(0, 8)}`);
+  const authToken = randomUUID();
+  writeConfig(wmuxDir, pipeName, authToken);
+
+  const child = spawnDaemon(testHome);
+  let stderr = '';
+  child.stderr.on('data', (d) => { stderr += d.toString(); });
+
+  try {
+    await waitForPipeFile(wmuxDir);
+    // Give hardenWmuxDir's awaited icacls/attrib calls one extra moment
+    // to settle on slow CI volumes — acquireLock awaits them all, so the
+    // pipe file appearing means they returned, but the OS-level effect
+    // is observable immediately after that.
+    await new Promise((r) => setTimeout(r, 200));
+
+    // (a) icacls — inheritance disabled + current user has (F).
+    const icaclsOutput = runIcacls(wmuxDir);
+    const aclState = parseIcacls(icaclsOutput);
+
+    // (b) attrib — H, S, I on dir and buffers/.
+    const attribDirOutput = runAttrib(wmuxDir);
+    const dirAttribs = parseAttrib(attribDirOutput, wmuxDir);
+    const buffersDir = path.join(wmuxDir, 'buffers');
+    let buffersAttribs = { hidden: false, system: false, notIndexed: false };
+    if (fs.existsSync(buffersDir)) {
+      const attribBuffersOutput = runAttrib(buffersDir);
+      buffersAttribs = parseAttrib(attribBuffersOutput, buffersDir);
+    }
+
+    // (c) notice file present + content matches substrate marker.
+    const noticePath = path.join(wmuxDir, '.no-cloud-sync.txt');
+    const noticeExists = fs.existsSync(noticePath);
+    const noticeContent = noticeExists ? fs.readFileSync(noticePath, 'utf-8') : '';
+    const noticeHasSubstrateText = /wmux substrate state directory/.test(noticeContent);
+    const noticeHasSyncToolList = /OneDrive, Dropbox, Google Drive/.test(noticeContent);
+
+    const pass =
+      aclState.inheritanceDisabled &&
+      aclState.currentUserHasFullControl &&
+      dirAttribs.hidden && dirAttribs.system && dirAttribs.notIndexed &&
+      buffersAttribs.hidden && buffersAttribs.system && buffersAttribs.notIndexed &&
+      noticeExists && noticeHasSubstrateText && noticeHasSyncToolList;
+
+    report.push({
+      scenario: 'H1',
+      pass,
+      acl: aclState,
+      dirAttribs,
+      buffersAttribs,
+      notice: { exists: noticeExists, hasSubstrateText: noticeHasSubstrateText, hasSyncToolList: noticeHasSyncToolList },
+    });
+  } catch (err) {
+    if (stderr) console.error(`[H1] daemon stderr tail:\n${stderr.slice(-2000)}`);
+    report.push({ scenario: 'H1', pass: false, error: err.message });
+  } finally {
+    await killDaemon(child);
+    try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+}
+
+async function runH2(report) {
+  if (process.platform !== 'win32') {
+    report.push({ scenario: 'H2', skipped: 'not win32', pass: null });
+    return;
+  }
+  const testHome = makeTestHome();
+  const wmuxDir = path.join(testHome, '.wmux');
+  const pipeName1 = makePipeName(`H2a-${randomUUID().slice(0, 8)}`);
+  const pipeName2 = makePipeName(`H2b-${randomUUID().slice(0, 8)}`);
+  const authToken = randomUUID();
+  writeConfig(wmuxDir, pipeName1, authToken);
+
+  let noticeFirst = '';
+  let noticeSecond = '';
+  let aclFirst = null;
+  let aclSecond = null;
+  let secondDaemonClean = false;
+
+  try {
+    // First daemon: lets hardening run once.
+    const child1 = spawnDaemon(testHome);
+    try {
+      await waitForPipeFile(wmuxDir);
+      await new Promise((r) => setTimeout(r, 200));
+      noticeFirst = fs.readFileSync(path.join(wmuxDir, '.no-cloud-sync.txt'), 'utf-8');
+      aclFirst = parseIcacls(runIcacls(wmuxDir));
+    } finally {
+      await killDaemon(child1);
+    }
+
+    // Rewrite config to use a new pipe name so the second daemon spins up
+    // cleanly (the first daemon's pipe-name file is now stale).
+    writeConfig(wmuxDir, pipeName2, authToken);
+
+    // Second daemon: hardening should re-run idempotently.
+    const child2 = spawnDaemon(testHome);
+    let stderr2 = '';
+    child2.stderr.on('data', (d) => { stderr2 += d.toString(); });
+    try {
+      await waitForPipeFile(wmuxDir);
+      secondDaemonClean = !/error|EACCES|EPERM/i.test(stderr2);
+      await new Promise((r) => setTimeout(r, 200));
+      noticeSecond = fs.readFileSync(path.join(wmuxDir, '.no-cloud-sync.txt'), 'utf-8');
+      aclSecond = parseIcacls(runIcacls(wmuxDir));
+    } finally {
+      await killDaemon(child2);
+    }
+
+    const noticeUnchanged = noticeFirst === noticeSecond;
+    const aclStillHardened =
+      aclSecond.inheritanceDisabled && aclSecond.currentUserHasFullControl;
+    const pass = secondDaemonClean && noticeUnchanged && aclStillHardened;
+
+    report.push({
+      scenario: 'H2',
+      pass,
+      secondDaemonClean,
+      noticeUnchanged,
+      aclStillHardened,
+    });
+  } catch (err) {
+    report.push({ scenario: 'H2', pass: false, error: err.message });
+  } finally {
+    try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+}
+
+async function runH3(report) {
+  if (process.platform === 'win32') {
+    report.push({ scenario: 'H3', skipped: 'win32 covered by H1/H2', pass: null });
+    return;
+  }
+  const testHome = makeTestHome();
+  const wmuxDir = path.join(testHome, '.wmux');
+  const pipeName = makePipeName(`H3-${randomUUID().slice(0, 8)}`);
+  const authToken = randomUUID();
+  writeConfig(wmuxDir, pipeName, authToken);
+
+  const child = spawnDaemon(testHome);
+  let stderr = '';
+  child.stderr.on('data', (d) => { stderr += d.toString(); });
+
+  try {
+    await waitForPipeFile(wmuxDir);
+    const daemonClean = !/icacls|attrib|EACCES|EPERM/i.test(stderr);
+    const noticeAbsent = !fs.existsSync(path.join(wmuxDir, '.no-cloud-sync.txt'));
+    const dirStat = fs.statSync(wmuxDir);
+    // 0o700 mode check: low 9 bits equal to 0o700.
+    const dirMode0o700 = (dirStat.mode & 0o777) === 0o700;
+    const pass = daemonClean && noticeAbsent && dirMode0o700;
+    report.push({ scenario: 'H3', pass, daemonClean, noticeAbsent, dirMode0o700, dirMode: (dirStat.mode & 0o777).toString(8) });
+  } catch (err) {
+    report.push({ scenario: 'H3', pass: false, error: err.message });
+  } finally {
+    await killDaemon(child);
+    try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+}
+
+// Main -----------------------------------------------------------------
+
+async function main() {
+  const report = [];
+  console.log(`Substrate hardening dynamic test — platform=${process.platform}`);
+  await runH1(report);
+  await runH2(report);
+  await runH3(report);
+
+  console.log('\n=== Results ===');
+  for (const r of report) console.log(JSON.stringify(r, null, 2));
+
+  const failures = report.filter((r) => r.pass === false);
+  const skipped = report.filter((r) => r.pass === null);
+  console.log(`\n${report.length - failures.length - skipped.length} pass, ${failures.length} fail, ${skipped.length} skip`);
+  process.exit(failures.length === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -11,6 +11,7 @@ import { Watchdog } from './Watchdog';
 import { selectRecoverableSessions } from './recoverySelector';
 import { createSnapshotRunner } from './snapshotRunner';
 import { RingBuffer } from './RingBuffer';
+import { hardenWmuxDir } from './util/fileSystemHardening';
 import type { DaemonState } from './types';
 import type { DaemonEvent, DaemonCreateSessionParams, DaemonSessionIdParams, DaemonResizeParams } from '../shared/rpc';
 
@@ -182,6 +183,11 @@ async function acquireLock(): Promise<boolean> {
     // Note: mode is no-op on Windows; use icacls for NTFS ACLs
     fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
+
+  // Best-effort NTFS ACL + cloud-sync exclusion hardening on Windows.
+  // POSIX is a no-op (mode 0o700 above already covers it). Idempotent
+  // across daemon restarts; failures log and do not block startup.
+  await hardenWmuxDir(dir, (msg, ...rest) => log('warn', msg, ...rest));
 
   // Attempt exclusive lock file creation to prevent race conditions
   try {

--- a/src/daemon/util/__tests__/fileSystemHardening.test.ts
+++ b/src/daemon/util/__tests__/fileSystemHardening.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Source-level invariants for the substrate filesystem hardening pass.
+//
+// The full behavior (icacls/attrib execution on a real NTFS volume) is a
+// platform-integration concern that cannot be reliably asserted in a
+// unit test on POSIX CI runners or sandboxed Windows agents. We lock
+// the source contract here so refactors do not silently drop the
+// hardening call or its required arguments. Mirrors the A4 source-
+// invariant pattern from the Phase A test suite.
+
+describe('fileSystemHardening — source invariants', () => {
+  const helperPath = path.join(__dirname, '..', 'fileSystemHardening.ts');
+  const indexPath = path.join(__dirname, '..', '..', 'index.ts');
+
+  it('hardenWmuxDir is invoked from acquireLock startup path', () => {
+    const indexSrc = fs.readFileSync(indexPath, 'utf-8');
+    // Import is present.
+    expect(indexSrc).toMatch(
+      /import\s*\{\s*hardenWmuxDir\s*\}\s*from\s*['"]\.\/util\/fileSystemHardening['"]/,
+    );
+    // Awaited call site inside acquireLock (the dir-creation function).
+    expect(indexSrc).toMatch(/await\s+hardenWmuxDir\(dir/);
+  });
+
+  it('POSIX path early-returns without invoking any system binary', () => {
+    const helperSrc = fs.readFileSync(helperPath, 'utf-8');
+    expect(helperSrc).toMatch(/process\.platform\s*!==\s*'win32'/);
+  });
+
+  it('uses icacls to disable ACL inheritance + grant current user only', () => {
+    const helperSrc = fs.readFileSync(helperPath, 'utf-8');
+    expect(helperSrc).toMatch(/icacls\.exe/);
+    expect(helperSrc).toMatch(/'\/inheritance:r'/);
+    expect(helperSrc).toMatch(/'\/grant:r'/);
+    // Per-user grant uses (OI)(CI)F so inheritance flags propagate.
+    expect(helperSrc).toMatch(/\(OI\)\(CI\)F/);
+  });
+
+  it('sets Hidden + System + NotIndexed attributes on dir and buffers/', () => {
+    const helperSrc = fs.readFileSync(helperPath, 'utf-8');
+    expect(helperSrc).toMatch(/attrib\.exe/);
+    expect(helperSrc).toMatch(/'\+H'/);
+    expect(helperSrc).toMatch(/'\+S'/);
+    expect(helperSrc).toMatch(/'\+I'/);
+    // /D flag applies to directories.
+    expect(helperSrc).toMatch(/'\/D'/);
+    // Both the root dir and the buffers/ subdir get the attribute pass.
+    expect(helperSrc).toMatch(/for\s*\(\s*const\s+target\s+of\s*\[\s*dir\s*,\s*buffersDir\s*\]/);
+  });
+
+  it('writes the no-cloud-sync notice file with substrate-specific wording', () => {
+    const helperSrc = fs.readFileSync(helperPath, 'utf-8');
+    expect(helperSrc).toMatch(/\.no-cloud-sync\.txt/);
+    expect(helperSrc).toMatch(/wmux substrate state directory/);
+    expect(helperSrc).toMatch(/OneDrive, Dropbox, Google Drive/);
+    expect(helperSrc).toMatch(/docs\/SECURITY\.md/);
+    // Notice file uses 0o600.
+    expect(helperSrc).toMatch(/mode:\s*0o600/);
+  });
+
+  it('every external call is wrapped in try/catch — daemon must boot even if icacls/attrib fail', () => {
+    const helperSrc = fs.readFileSync(helperPath, 'utf-8');
+    // Counted: icacls /inheritance:r, icacls /grant:r, attrib (per target), notice write.
+    // Each in its own try/catch with a warn callback. We assert the
+    // helper text contains at least 4 distinct try blocks.
+    const tryBlocks = helperSrc.match(/try\s*\{/g) ?? [];
+    expect(tryBlocks.length).toBeGreaterThanOrEqual(4);
+    // The warn parameter exists with a console.warn default.
+    expect(helperSrc).toMatch(/warn:\s*WarnLogger\s*=\s*console\.warn/);
+  });
+});

--- a/src/daemon/util/fileSystemHardening.ts
+++ b/src/daemon/util/fileSystemHardening.ts
@@ -1,0 +1,116 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const execFileAsync = promisify(execFile);
+
+const NO_SYNC_NOTICE_FILENAME = '.no-cloud-sync.txt';
+const NO_SYNC_NOTICE_BODY =
+  'wmux substrate state directory.\r\n' +
+  '\r\n' +
+  'This folder contains terminal scrollback buffers and session metadata.\r\n' +
+  'Exclude it from cloud sync, backup, or indexing tools that mirror your\r\n' +
+  'user profile (OneDrive, Dropbox, Google Drive, Windows Backup, etc.).\r\n' +
+  '\r\n' +
+  'See docs/SECURITY.md in the wmux repository for the full security model.\r\n';
+
+const EXEC_TIMEOUT_MS = 5000;
+
+type WarnLogger = (message: string, ...rest: unknown[]) => void;
+
+function systemBinary(name: string): string {
+  const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+  return path.join(systemRoot, 'System32', name);
+}
+
+/**
+ * Best-effort filesystem hardening for the wmux substrate state directory.
+ *
+ * Windows (NTFS):
+ *   1. icacls disables ACL inheritance on the directory and grants the
+ *      current user only (full control, propagated to children). Defense-
+ *      in-depth on top of the default user profile ACL.
+ *   2. attrib sets Hidden + System + NotIndexed on the directory and the
+ *      buffers/ subdirectory so Windows Search ignores them and
+ *      conservative backup tools skip them.
+ *   3. Writes a plain-text .no-cloud-sync.txt notice at the directory
+ *      root so users browsing in Explorer or a sync-tool UI see the
+ *      exclusion guidance.
+ *
+ * POSIX (macOS, Linux):
+ *   - Early return. The directory was created mode 0o700 in acquireLock()
+ *     and per-file modes are 0o600. No additional hardening needed.
+ *
+ * All operations are best-effort: every step is independently wrapped so
+ * one failure (missing system binary, AV interference) does not block
+ * the daemon from booting. Idempotent — safe to call on every startup.
+ */
+export async function hardenWmuxDir(
+  dir: string,
+  warn: WarnLogger = console.warn,
+): Promise<void> {
+  if (process.platform !== 'win32') {
+    return;
+  }
+
+  // (1) icacls — disable inheritance, grant current user only.
+  const username = process.env.USERNAME || os.userInfo().username;
+  if (username) {
+    const icacls = systemBinary('icacls.exe');
+    try {
+      await execFileAsync(icacls, [dir, '/inheritance:r'], {
+        timeout: EXEC_TIMEOUT_MS,
+        windowsHide: true,
+      });
+    } catch (err) {
+      warn('[hardenWmuxDir] icacls /inheritance:r failed:', (err as Error).message);
+    }
+    try {
+      await execFileAsync(
+        icacls,
+        [dir, '/grant:r', `${username}:(OI)(CI)F`],
+        { timeout: EXEC_TIMEOUT_MS, windowsHide: true },
+      );
+    } catch (err) {
+      warn('[hardenWmuxDir] icacls /grant:r failed:', (err as Error).message);
+    }
+  }
+
+  // (2) attrib — Hidden + System + NotIndexed on dir and buffers/.
+  const buffersDir = path.join(dir, 'buffers');
+  try {
+    fs.mkdirSync(buffersDir, { recursive: true, mode: 0o700 });
+  } catch (err) {
+    warn('[hardenWmuxDir] mkdir buffers failed:', (err as Error).message);
+  }
+
+  const attrib = systemBinary('attrib.exe');
+  for (const target of [dir, buffersDir]) {
+    try {
+      await execFileAsync(attrib, ['+H', '+S', '+I', target, '/D'], {
+        timeout: EXEC_TIMEOUT_MS,
+        windowsHide: true,
+      });
+    } catch (err) {
+      warn('[hardenWmuxDir] attrib failed for', target, ':', (err as Error).message);
+    }
+  }
+
+  // (3) Plain-text no-cloud-sync notice file. Idempotent overwrite.
+  try {
+    const noticePath = path.join(dir, NO_SYNC_NOTICE_FILENAME);
+    fs.writeFileSync(noticePath, NO_SYNC_NOTICE_BODY, {
+      encoding: 'utf-8',
+      mode: 0o600,
+    });
+  } catch (err) {
+    warn('[hardenWmuxDir] notice write failed:', (err as Error).message);
+  }
+}
+
+export const __testing__ = {
+  NO_SYNC_NOTICE_FILENAME,
+  NO_SYNC_NOTICE_BODY,
+};


### PR DESCRIPTION
> Re-open of PR #40 — original auto-closed when its stacked base branch (`feat/pane-leaf-cap`) was deleted on PR #39's squash merge. Same commits, now retargeted directly to `main`.

## Summary

Three commits that begin the substrate v3.0 Phase 3.2 (Security review) scope, sitting on top of the just-merged Phase A (v2.9.1):

- **2d9b3ff** `docs(security):` substrate security model + Phase 3.2 baseline doc (`docs/SECURITY.md`)
- **6a10c1b** `feat(daemon):` substrate filesystem hardening on startup (icacls + attrib + cloud-sync notice file)
- **c0f893b** `test(daemon):` substrate filesystem hardening dynamic verification (`scripts/substrate-hardening-dynamic.mjs`)

## Why these belong to the substrate, not a per-session feature

Recent design discussion considered adding a per-session "secure mode" opt-out (mark a pane secure → no disk persistence, mirror tmux semantics). On substrate alignment review against `plans/generic-wandering-teapot.md`, that direction was rejected:

- **Neutrality violation.** The substrate's identity is "neutral, LSP-for-terminals." A per-session secure flag injects opinionated business logic into substrate state and forces every plugin to learn special-case semantics.
- **Plugin permission model conflict.** `wmuxPermissions` enforcement (PROTOCOL §4) cannot meaningfully scope a `secure` flag — either secure sessions are invisible (breaking `pane.read` semantics) or visible (adding a third dimension to the permission grid).
- **Recovery promise split.** Phase A's "process death across recovery" guarantee becomes two guarantees if some sessions opt out. The substrate stops being a single coherent promise.

The substrate-aligned answer is **uniform filesystem hardening + honest disclosure of the security model** — what this PR ships.

## What the doc commit changes

`docs/SECURITY.md` declares the substrate's security posture as a Phase 0 / Phase 3.2 baseline:

- **§1 What we guarantee:** file mode 0o600 (POSIX), NTFS ACL hardening (Windows), cloud-sync exclusion signals, Named Pipe auth token, per-plugin permission enforcement.
- **§2 What we delegate to the OS:** disk encryption, process isolation, pagefile, crash dumps, network confidentiality.
- **§3 What we do NOT try to protect against:** same-user adversaries, side channels, compromised plugins, cloud-sync engines that ignore exclusion markers.
- **§4 For high-sensitivity workflows:** OS-level isolation (Sandbox, VM, container) is the correct primitive. No per-session "secure mode".

Structure mirrors the Phase 0 doc set (`PROTOCOL.md`, `api/stability.md`).

## What the daemon commit changes

`acquireLock()` in `src/daemon/index.ts` runs a best-effort hardening pass on the wmux state directory after creating it. Windows-only; POSIX early-returns since mode 0o700 already covers it.

Three signals, all idempotent across daemon restarts:

1. **icacls** disables ACL inheritance on `%USERPROFILE%\.wmux\` and grants the current user only with `(OI)(CI)F` (full control, propagated to children).
2. **attrib** sets Hidden + System + NotIndexed (`+H +S +I /D`) on the directory and the `buffers/` subdirectory.
3. **`.no-cloud-sync.txt`** plain-text notice at the directory root with explicit guidance to exclude the folder from OneDrive, Dropbox, Google Drive, Windows Backup, etc.

Every external call is independently `try/catch`'d and routed to the daemon log. A missing `icacls.exe` or AV interference cannot block daemon startup.

## Dynamic verification

`scripts/substrate-hardening-dynamic.mjs` spawns the bundled daemon in an isolated `USERPROFILE` and verifies OS-level artifacts:

- **H1** (Windows-only): icacls inheritance disabled + current user granted (F), attrib H/S/I on dir + buffers/, `.no-cloud-sync.txt` exists with substrate marker text.
- **H2** (Windows-only): second daemon spawn against the same hardened home — daemon boots clean, notice file byte-identical (idempotent), ACL state preserved.
- **H3** (POSIX): daemon starts clean, no notice file written, dir mode is 0o700 (early-return parity).

Local Windows result: **2 pass, 0 fail, 1 skip** (H3 platform skip).

## Test plan

- [x] Source-level invariant test: `src/daemon/util/__tests__/fileSystemHardening.test.ts` — 6 assertions covering import + call site, icacls/attrib arguments, notice file content, try/catch wrapping pattern.
- [x] `npx vitest run src/daemon` — 30 files / 351 tests pass.
- [x] `npx tsc -p tsconfig.daemon.json --noEmit` — clean.
- [x] `node scripts/substrate-hardening-dynamic.mjs` — H1 + H2 pass on Windows (real icacls, attrib, notice file on disk).
- [ ] POSIX runners (macOS/Linux) in CI — H3 will run automatically once CI matrix executes this branch.

## Substrate trajectory anchors

- v3.0 plan Phase 3.2 (Week 10 Security review) lists "Named Pipe ACL hardening" as a scope item. This PR extends the same layer to disk artifacts.
- `docs/SECURITY.md` becomes the baseline document the Phase 3.2 review checks against.
- `secure-mode-archive` local-only branch (not pushed) preserves the rejected per-session approach for reference. See `feedback_substrate_neutrality` in the team memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)