### PR TITLE
fix(main): capture daemonClient before before-quit race to avoid null deref

### DIFF
--- a/src/main/__tests__/beforeQuitDisconnectRace.test.ts
+++ b/src/main/__tests__/beforeQuitDisconnectRace.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Source-level invariants for the before-quit daemon disconnect race fix.
+//
+// User dogfood (2026-05-16, 48-PTY daemon) hit this sequence in
+// src/main/index.ts:
+//
+//   1. before-quit checks `daemonClient?.isConnected`.
+//   2. `raceDaemonShutdown(daemonClient, 4000)` awaits up to 4 s.
+//   3. During the wait, daemon closes socket → module-level
+//      `daemonClient.on('disconnected')` handler fires and sets
+//      `daemonClient = null`.
+//   4. race times out (daemon shutdown was running long for 48 PTYs).
+//   5. `await daemonClient.disconnect()` dereferences null →
+//      "Cannot read properties of null (reading 'disconnect')" →
+//      unhandled rejection blocks app.quit() and the tray Quit
+//      leaves main process alive.
+//
+// Fix: capture `daemonClient` into a local `clientAtQuit` BEFORE the race,
+// and use that local for the post-race disconnect, wrapped in try/catch so
+// a torn-down socket does not throw past the quit sequence.
+
+describe('before-quit daemon disconnect race — source invariants', () => {
+  const indexPath = path.join(__dirname, '..', 'index.ts');
+  const indexSrc = fs.readFileSync(indexPath, 'utf-8');
+
+  it('captures daemonClient into clientAtQuit before the race', () => {
+    expect(indexSrc).toMatch(/const\s+clientAtQuit\s*=\s*daemonClient\s*;/);
+    // The capture happens before the isConnected check + race.
+    const capturePos = indexSrc.indexOf('const clientAtQuit = daemonClient');
+    const racePos = indexSrc.indexOf('raceDaemonShutdown(clientAtQuit');
+    expect(capturePos).toBeGreaterThan(0);
+    expect(racePos).toBeGreaterThan(capturePos);
+  });
+
+  it('races shutdown using the local capture (not module-level daemonClient)', () => {
+    expect(indexSrc).toMatch(/raceDaemonShutdown\(\s*clientAtQuit\s*,/);
+    // No call to raceDaemonShutdown using the module-level variable
+    // inside the before-quit handler.
+    const beforeQuitBlock = indexSrc.slice(
+      indexSrc.indexOf("app.on('before-quit'"),
+      indexSrc.indexOf("app.on('session-end'"),
+    );
+    expect(beforeQuitBlock).not.toMatch(/raceDaemonShutdown\(\s*daemonClient\s*,/);
+  });
+
+  it('post-race disconnect targets the local capture inside a try/catch', () => {
+    const beforeQuitBlock = indexSrc.slice(
+      indexSrc.indexOf("app.on('before-quit'"),
+      indexSrc.indexOf("app.on('session-end'"),
+    );
+    expect(beforeQuitBlock).toMatch(
+      /try\s*\{[\s\S]*?await\s+clientAtQuit\.disconnect\(\)\s*;[\s\S]*?\}\s*catch/,
+    );
+  });
+
+  it("'disconnected' handler still nulls module-level daemonClient (race precondition is intentional)", () => {
+    // The handler that races against us is the one we documented in the
+    // capture comment. Locking the null assignment here means a refactor
+    // that drops it (and therefore would defeat this whole class of bug
+    // by accident) gets a heads-up failure that points at the dependency.
+    expect(indexSrc).toMatch(
+      /daemonClient\.on\(\s*['"]disconnected['"][\s\S]*?daemonClient\s*=\s*null/,
+    );
+  });
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -682,7 +682,16 @@ app.on('before-quit', async (e) => {
   cleanupHandlers();
   disposeFirstRunHandlers();
 
-  if (daemonClient?.isConnected) {
+  // Capture the daemon-client reference BEFORE the race. The race awaits
+  // for up to 4 s; during that window the daemon may close its socket,
+  // which fires the module-level `daemonClient.on('disconnected')` handler
+  // and sets `daemonClient = null`. Without a local capture, the post-race
+  // `daemonClient.disconnect()` call dereferences null and the resulting
+  // unhandled rejection prevents app.quit() from completing — the tray
+  // Quit silently leaves the main process alive. Observed in user dogfood
+  // 2026-05-16 on a 48-PTY daemon where shutdown ran past the 4 s budget.
+  const clientAtQuit = daemonClient;
+  if (clientAtQuit?.isConnected) {
     // Daemon mode. Phase A — A3: race daemon.shutdown against a calibrated
     // budget so the daemon can flush RingBuffers atomically before we
     // detach. The 4 s placeholder is the documented floor pending the T5
@@ -691,7 +700,7 @@ app.on('before-quit', async (e) => {
     console.log(
       `[Main] Daemon mode — racing daemon.shutdown (${BEFORE_QUIT_TIMEOUT_MS}ms budget)`,
     );
-    const race = await raceDaemonShutdown(daemonClient, BEFORE_QUIT_TIMEOUT_MS);
+    const race = await raceDaemonShutdown(clientAtQuit, BEFORE_QUIT_TIMEOUT_MS);
     if (race.ok) {
       console.log('[Main] daemon.shutdown ack received');
     } else {
@@ -702,8 +711,15 @@ app.on('before-quit', async (e) => {
     // Always detach as the final step. If the RPC succeeded the pipe is
     // already torn down on the daemon side; disconnect cleans up our half.
     // If it failed (timeout / dead daemon), disconnect is the original
-    // fallback path that was in place before A3 landed.
-    await daemonClient.disconnect();
+    // fallback path that was in place before A3 landed. Best-effort: if
+    // the 'disconnected' handler already nulled module-level state and
+    // tore down the socket, our disconnect() may throw — swallow it so
+    // the quit sequence below still runs.
+    try {
+      await clientAtQuit.disconnect();
+    } catch (err) {
+      console.warn('[Main] post-race disconnect threw (likely already torn down):', err);
+    }
     daemonClient = null;
   } else {
     // Local mode: kill all PTYs


### PR DESCRIPTION
## Summary
- The `before-quit` handler dereferenced module-level `daemonClient` after `raceDaemonShutdown` (4 s budget). During that window the daemon could close its socket, fire the module-level `daemonClient.on('disconnected')` handler, and set `daemonClient = null`. The post-race `await daemonClient.disconnect()` then dereferenced null and the resulting unhandled rejection blocked `app.quit()` — tray Quit left the main process alive on a 48-PTY daemon (user dogfood, 2026-05-16).
- Capture `daemonClient` into a local `clientAtQuit` before the race; reuse that local for `raceDaemonShutdown` and the post-race `disconnect()`, wrapped in try/catch so a torn-down socket no longer escapes the quit sequence.
- Add 4 source-level invariants pinning capture order, race target, try/catch placement, and the `'disconnected'` handler that creates the race precondition — a future refactor reverting to the module-level variable fails loudly.

## Test plan
- [x] `npx vitest run src/main/__tests__/beforeQuitDisconnectRace.test.ts` — 4 passed
- [x] Live dogfood (Windows 11, 48-PTY daemon): tray Quit reproduces the 4 s shutdown race timeout (`[Main] daemon.shutdown did not complete in time, falling back to detach`), but main + daemon now both exit cleanly. `Get-Process wmux,wmux-daemon` returns no processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)