### PR TITLE
feat(mcp): Phase 2.1 — MCP plugin identity + permission grammar (record-only)

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -263,23 +263,50 @@ The substrate has four enforcement points. All four exist to prevent one MCP fro
 
 | # | Point | Status | Notes |
 |---|---|---|---|
-| 1 | Method dispatch | v3.0 (new in Phase 2.1) | `wmuxPermissions` in the MCP server manifest declares which methods this server may call. RPC dispatcher rejects unauthorized calls. |
-| 2 | Metadata path write | v3.0 (new in Phase 2.1) | `wmuxPermissions` may scope writes to specific `custom.<namespace>.*` paths. Writes outside the allowed paths are rejected. |
-| 3 | Event subscription | v3.0 (new in Phase 2.1) | `events.poll` filters are enforced against `wmuxPermissions`. A server that hasn't declared subscription to `pane.created` can't see those events even if it polls. |
-| 4 | Workspace claim | **v2.7.2 (already shipped)** | `mcp.claimWorkspace` binds an MCP server to a workspace. Subsequent writes targeting other workspaces are rejected. |
+| 1 | Method dispatch | Phase 2.1 follow-up (record-only in first PR) | `wmuxPermissions` declared via `mcp.declarePermissions` filters which RPC methods this plugin may call. Enforcement lands in the follow-up PR; the first PR only records declarations to the trust DB so plugins can wire grammar today. |
+| 2 | Metadata path write | Phase 2.1 follow-up (record-only in first PR) | `meta.write[:<path-glob>]` scopes writes to specific `custom.<namespace>.*` paths. Same staging as #1. |
+| 3 | Event subscription | Phase 2.1 follow-up (record-only in first PR) | `events.subscribe[:<type-glob>]` scopes which events `events.poll` may return. Same staging as #1. |
+| 4 | Workspace claim | **v2.7.2 (already shipped)** | `mcp.claimWorkspace` binds a plugin to a workspace. Subsequent writes targeting other workspaces are rejected. Unrelated to `wmuxPermissions` grammar — predates it. |
 
-`wmuxPermissions` syntax (Phase 2.1 spec, draft): `<capability>[:<path-glob>]`. Examples:
+### 4.1 Identity (Phase 2.1 first PR — shipped)
+
+Plugin identity rides the JSON-RPC envelope as `clientName` (and optional `clientVersion`). The MCP server (`src/mcp/index.ts`) populates them from the MCP `InitializeRequest.clientInfo` so the substrate can attribute every call to a declared plugin. Identity is **declared, not verified** — there is no root-of-trust today; threat-model details live in `api/mcp-plugin-spec.md`.
+
+Requests without `clientName` are recorded as `legacy` so future enforcement can grandfather them or prompt the user, never silently bypass.
+
+The trust DB lives at `~/.wmux/plugin-trust.json` (atomic-write, single-process owner = wmux main). Per-plugin record shape (`PluginIdentityRecord` in `src/shared/rpc.ts`):
+
+```jsonc
+{
+  "name": "claude-ai",          // MCP clientInfo.name
+  "version": "1.0.94",          // MCP clientInfo.version (optional)
+  "declaredCapabilities": ["pane.read", "meta.write:custom.dashboard.*"],
+  "rationale": "Optional human-readable hint shown in the future approval UI",
+  "status": "unconfirmed",      // unconfirmed | trusted | denied | legacy
+  "firstSeen": 1715800000000,
+  "lastSeen": 1715800012345
+}
+```
+
+### 4.2 Declaration RPCs (Phase 2.1 first PR — shipped, record-only)
+
+Plugins announce themselves with two RPCs. Both are idempotent and never reject existing user-issued trust state.
+
+- `mcp.identify({ name, version? })` — fired automatically by the wmux-bundled MCP server when the MCP `InitializeRequest` completes. External plugins (non-wmux MCP servers) MAY call it explicitly.
+- `mcp.declarePermissions({ permissions: string[], rationale? })` — plugin declares the full capability set it expects to use. Grammar errors reject the entire declaration; nothing is partial.
+
+### 4.3 `wmuxPermissions` grammar
+
+`<capability>[:<path-glob>]`. Examples:
 
 - `pane.read` — read pane state and metadata.
 - `meta.write` — write any pane's metadata (top-level + custom).
 - `meta.write:custom.dashboard.*` — write only the `dashboard.*` paths inside `custom`.
 - `events.subscribe:pane.*` — subscribe to `pane.created`, `pane.closed`, `pane.focused`, `pane.metadata.changed`.
 
-Per-plugin identity is the MCP server name. Two servers with the same name on the same wmux instance is a registration error.
+`wmux.*` is reserved. The complete capability whitelist, the path-glob rules (`*` excludes `.`, `**` includes it), and the threat model are in `api/mcp-plugin-spec.md`.
 
 **Raw RPC bypass policy:** all four enforcement points are at method-dispatch level. There's no "internal" path that skips them; the IPC handler entry point is the chokepoint. The substrate does not expose a "trusted" mode that lets a plugin opt out of enforcement.
-
-(Full `wmuxPermissions` spec lands in `api/mcp-plugin-spec.md` during Phase 2.1. This section is the contract sketch.)
 
 ---
 

--- a/docs/api/mcp-plugin-spec.md
+++ b/docs/api/mcp-plugin-spec.md
@@ -1,0 +1,255 @@
+# wmux MCP Plugin Specification
+
+> **Status:** Draft 1 (Phase 2.1 first PR — identity + declaration wired, enforcement deferred to follow-up PR).
+> **Audience:** authors of MCP servers and clients that connect to wmux.
+> **Companion docs:** [`PROTOCOL.md`](../PROTOCOL.md) §4 (permission enforcement), [`api/versioning.md`](./versioning.md), [`api/stability.md`](./stability.md).
+
+This document is the contract between wmux and external MCP clients that act as **plugins**. A plugin is any MCP client that connects to the wmux MCP server over stdio (Claude Code, Cursor, Codex, OpenClaw, custom integrations). wmux does not spawn plugins; plugins connect to wmux.
+
+If you are building a tool that integrates with wmux, this is your starting point.
+
+---
+
+## 1. What is an MCP plugin in wmux?
+
+wmux is a substrate, not a plugin host. The MCP server bundled with wmux (`src/mcp/index.ts`) exposes the substrate surface to any MCP-capable client. A "plugin" in wmux is therefore an **MCP client that has registered its identity with the substrate and declared which capabilities it intends to use**.
+
+There is no separate plugin manager, no `wmux-plugin.json`, no `wmux plugin install` command. The plugin model rides the existing MCP protocol surface; substrate adds:
+
+1. A grammar (`wmuxPermissions`) for plugins to declare their intent.
+2. Two RPCs (`mcp.identify`, `mcp.declarePermissions`) for plugins to send that declaration.
+3. A trust database (`~/.wmux/plugin-trust.json`) for the substrate to remember the declaration across reconnects.
+
+The first-PR scope is record-only. Enforcement (rejecting calls that exceed declared permissions, prompting the user for approval) lands in a follow-up PR.
+
+---
+
+## 2. Identity
+
+### 2.1 Source
+
+Plugin identity is the `clientInfo.name` field from the MCP `InitializeRequest`. The MCP protocol requires this field on every initialize request; wmux trusts the value the client sends.
+
+The wmux-bundled MCP server (`src/mcp/index.ts`) captures `clientInfo.name` and `clientInfo.version` automatically and forwards them to substrate via the `mcp.identify` RPC. Plugins that connect through their own MCP server may call `mcp.identify` explicitly.
+
+### 2.2 Wire format
+
+Every JSON-RPC request to wmux MAY include two optional envelope fields:
+
+```jsonc
+{
+  "id": "uuid",
+  "method": "pane.list",
+  "params": { /* ... */ },
+  "token": "<wmux auth token>",
+  "clientName": "claude-ai",      // declared plugin identity
+  "clientVersion": "1.0.94"       // optional
+}
+```
+
+Requests without `clientName` are recorded as `legacy` so the substrate can grandfather them or prompt the user during the follow-up PR.
+
+### 2.3 Threat model
+
+> **The substrate trusts the declared name. It does not verify the name.**
+
+There is no root-of-trust today: any process holding the wmux auth token can claim any `clientName`. The current threat model accepts this because:
+
+1. The wmux auth token is itself a local secret protected by OS file permissions; a process that has it has already cleared the substrate's authentication bar.
+2. The intended security boundary is **user-driven approval** of declared capabilities, not cryptographic identity. The user reads the displayed name and decides whether to trust it.
+3. Future hardening (wmux-issued plugin tokens, signed manifests) is on the v3.1+ roadmap.
+
+Known spoofing scenarios:
+
+| Scenario | Substrate behavior |
+|---|---|
+| Two processes both claim `clientName: "claude-ai"` | Both write to the same trust-DB entry; `lastSeen` reflects the most recent contact. capability declarations overwrite each other (last writer wins). |
+| Plugin claims a different name in different RPCs | Each name is recorded independently. The substrate does not cross-check or pin identity within a connection in this first PR. |
+| Plugin claims `wmux` (the bundled identity) | Allowed today. Future enforcement may reject reserved names. |
+
+Plugins SHOULD pick a stable, namespaced identity (`my-org.my-tool`, not `tool`) so user-issued trust state survives upgrades.
+
+---
+
+## 3. `wmuxPermissions` grammar
+
+### 3.1 Shape
+
+`<capability>[:<path-glob>]`
+
+- `capability` is drawn from a finite whitelist (§3.2).
+- `path-glob` is optional and scopes the capability to a subset of the substrate surface.
+- The separator is a single `:` between the capability and the glob.
+
+Examples:
+
+| String | Meaning |
+|---|---|
+| `pane.read` | Read pane state and metadata for any pane in the plugin's workspace. |
+| `meta.write` | Write any pane's metadata (top-level fields + entire `custom` object). |
+| `meta.write:custom.dashboard.*` | Write only `custom.dashboard.<anything>` paths. |
+| `meta.write:custom.dashboard.**` | Same, but `**` also crosses `.` so nested keys match. |
+| `events.subscribe:pane.*` | Subscribe to `pane.created`, `pane.closed`, `pane.focused`, `pane.metadata.changed`. |
+
+### 3.2 Capability whitelist (v3.0)
+
+```
+pane.read           pane.write          pane.create         pane.delete
+pane.search
+
+meta.read           meta.write
+
+events.subscribe
+
+workspace.read      workspace.claim
+
+terminal.send       terminal.read
+
+browser.navigate    browser.click       browser.type
+browser.screenshot  browser.evaluate    browser.read
+
+a2a.send            a2a.execute         a2a.read
+```
+
+Reserved prefixes (declaring these is always rejected):
+
+- `wmux.*` — substrate-internal surface.
+
+### 3.3 Path-glob rules
+
+The path-glob is intentionally narrow — wmux does not import `minimatch` or any glob library to keep the substrate dependency surface small.
+
+- `*` matches any run of characters **except** `.` (the path separator stand-in).
+- `**` matches any run of characters **including** `.`.
+- Everything else is a literal regex match. `.` is a literal separator.
+- The match is anchored — the glob must consume the whole path.
+
+The reference implementation is `globToRegex` in `src/main/mcp/permissionGrammar.ts`. Plugins SHOULD treat the glob as advisory in the first PR (no enforcement yet) but emit valid grammar so they're ready for the follow-up.
+
+---
+
+## 4. Declaration flow
+
+### 4.1 First contact
+
+Plugins announce themselves once per connection lifetime. The wmux-bundled MCP server does this automatically via its `oninitialized` hook; external MCP clients SHOULD call `mcp.identify` themselves right after their initialize handshake.
+
+```
+mcp.identify({
+  name: "my-org.my-tool",
+  version: "1.2.0"
+})
+```
+
+Returns the current `PluginIdentityRecord` (creating a fresh `unconfirmed` entry if this is first contact, refreshing `lastSeen` if not).
+
+### 4.2 Permission declaration
+
+Plugins declare the full capability set they expect to use:
+
+```
+mcp.declarePermissions({
+  permissions: [
+    "pane.read",
+    "meta.write:custom.my-org.*",
+    "events.subscribe:pane.*"
+  ],
+  rationale: "Tracks pane lifecycle for the my-org dashboard."
+})
+```
+
+Behaviour:
+
+- The entire array is parsed against §3. If **any** entry is malformed, the whole declaration is rejected — plugins cannot half-declare.
+- Accepted declarations overwrite any prior declaration from the same `clientName`. There is no union/merge in the first PR.
+- The persisted record preserves the raw strings the plugin sent so future parsers can re-validate against an updated grammar.
+- `rationale` is optional, surfaced verbatim in the future approval dialog.
+
+### 4.3 Trust states
+
+A `PluginIdentityRecord` carries a `status` field:
+
+| Status | Meaning | Set by |
+|---|---|---|
+| `unconfirmed` | Identity recorded; user has not seen or approved the plugin yet. | First-contact RPC. |
+| `trusted` | User approved the declared capability set. | Future PR (approval dialog). |
+| `denied` | User rejected the plugin. | Future PR. |
+| `legacy` | Identity inferred from RPC traffic with no `clientName` envelope (pre-v2.10 callers, non-MCP clients). | RPC dispatch fallback. |
+
+Transitions in the first PR are limited to `legacy → unconfirmed` (when a previously-legacy plugin learns to send `clientName`) and `lastSeen` refreshes within the same status. User-issued `trusted`/`denied` cannot regress to `unconfirmed`.
+
+### 4.4 Trust DB location
+
+`~/.wmux/plugin-trust.json` (on Windows, `%USERPROFILE%\.wmux\plugin-trust.json`).
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "plugins": {
+    "claude-ai": {
+      "name": "claude-ai",
+      "version": "1.0.94",
+      "declaredCapabilities": ["pane.read"],
+      "status": "unconfirmed",
+      "firstSeen": 1715800000000,
+      "lastSeen": 1715800012345
+    }
+  }
+}
+```
+
+- Written atomically via `atomicWriteJSON` (`src/daemon/util/atomicWrite/core.ts`).
+- The wmux main process owns the file; no other process should write it.
+- It is **not** a credential store. Treat it as user-readable index data.
+
+---
+
+## 5. Lifecycle
+
+| Phase | First PR | Follow-up PR |
+|---|---|---|
+| Install / first contact | `mcp.identify` records `unconfirmed`. | (same) |
+| Capability declaration | `mcp.declarePermissions` records grammar. | (same) |
+| User approval | Not yet — declarations sit at `unconfirmed`. | Approval dialog prompts user; status moves to `trusted` or `denied`. |
+| Enforcement at method dispatch | None. | `denied` plugins blocked at RPC dispatcher; `unconfirmed` allowed (legacy grandfather). |
+| Capability revocation | Manual edit of `plugin-trust.json`. | `wmux mcp permissions <name> --revoke <capability>`. |
+| Identity rotation | Not supported — `name` is the trust key. | (same) |
+
+---
+
+## 6. Connection caps and resource limits
+
+- `MAX_CONNECTIONS = 50` on the wmux Named Pipe / TCP fallback (`src/main/pipe/PipeServer.ts`). Each MCP plugin opens one or more transient sockets; the trust DB has no separate cap on **plugin count**, only on **active connections**.
+- Per-socket rate limit: 50 RPC calls/sec. Global rate limit: 200/sec.
+- Both limits are pre-`clientName` (rate is enforced on the wire, not the identity).
+
+---
+
+## 7. What's not in v3.0
+
+- **wmux-issued plugin tokens** — substrate trusts declared `clientName` only.
+- **Signed manifests** — no cryptographic check on declarations.
+- **WASM sandbox** — plugins run as their own OS process; wmux does not isolate them.
+- **Marketplace UI** — discovery is out-of-band (GitHub topic `wmux-plugin`).
+- **Capability revocation CLI** — manual file edit only.
+- **Per-connection identity pinning** — a plugin may rotate `clientName` mid-session in the first PR.
+- **Trust-DB migration tools** — schema v1 only; future versions will define migrators.
+
+---
+
+## 8. Reference implementation
+
+Substrate side:
+
+- `src/shared/rpc.ts` — envelope types (`RpcRequest.clientName`, `PluginIdentityRecord`).
+- `src/main/mcp/PluginIdentity.ts` — domain transitions.
+- `src/main/mcp/permissionGrammar.ts` — grammar parser.
+- `src/main/mcp/PluginTrustStore.ts` — atomic-write CRUD.
+- `src/main/pipe/handlers/mcp.rpc.ts` — `mcp.identify` and `mcp.declarePermissions` handlers.
+
+MCP-server side (the wmux-bundled MCP server, which is itself the reference plugin host):
+
+- `src/mcp/index.ts` — `oninitialized` hook captures `clientInfo` and fires `mcp.identify`.
+- `src/mcp/wmux-client.ts` — `setClientIdentity` stamps every outbound RPC envelope.
+
+External plugin authors building their own MCP servers can copy the pattern: capture `clientInfo` from the MCP SDK, attach `clientName`/`clientVersion` to the wmux auth-token-bearing JSON-RPC payload, then call `mcp.identify` once.

--- a/docs/api/mcp-plugin-spec.md
+++ b/docs/api/mcp-plugin-spec.md
@@ -66,6 +66,8 @@ Known spoofing scenarios:
 | Two processes both claim `clientName: "claude-ai"` | Both write to the same trust-DB entry; `lastSeen` reflects the most recent contact. capability declarations overwrite each other (last writer wins). |
 | Plugin claims a different name in different RPCs | Each name is recorded independently. The substrate does not cross-check or pin identity within a connection in this first PR. |
 | Plugin claims `wmux` (the bundled identity) | Allowed today. Future enforcement may reject reserved names. |
+| Trusted plugin re-declares a widened capability set | Status is preserved (`trusted` stays `trusted`) and `declaredCapabilities` is overwritten wholesale. In this record-only PR the field is unread, so the widening is dormant. **The follow-up enforcement PR MUST detect set-difference vs the previously approved capabilities and demote to `unconfirmed`** before honouring the new surface. Tracked at `applyDeclaration` in `src/main/mcp/PluginIdentity.ts`. |
+| Hostile `clientName` (`__proto__`, `toString`, multi-MB string) | Trust DB stores plugin records in a null-prototype map and clamps names to `MAX_PLUGIN_NAME_LEN = 256`. Prototype keys cannot collide with `Object.prototype`; oversize names are truncated, never rejected, so the audit trail is preserved. |
 
 Plugins SHOULD pick a stable, namespaced identity (`my-org.my-tool`, not `tool`) so user-issued trust state survives upgrades.
 
@@ -79,7 +81,7 @@ Plugins SHOULD pick a stable, namespaced identity (`my-org.my-tool`, not `tool`)
 
 - `capability` is drawn from a finite whitelist (§3.2).
 - `path-glob` is optional and scopes the capability to a subset of the substrate surface.
-- The separator is a single `:` between the capability and the glob.
+- The separator is the **first** `:` in the string. Additional `:` characters inside the glob are treated as literal characters (regex-escaped during compilation), so values like `meta.write:custom.foo:bar` parse to capability `meta.write` and glob `custom.foo:bar`.
 
 Examples:
 
@@ -163,7 +165,7 @@ Behaviour:
 - The entire array is parsed against §3. If **any** entry is malformed, the whole declaration is rejected — plugins cannot half-declare.
 - Accepted declarations overwrite any prior declaration from the same `clientName`. There is no union/merge in the first PR.
 - The persisted record preserves the raw strings the plugin sent so future parsers can re-validate against an updated grammar.
-- `rationale` is optional, surfaced verbatim in the future approval dialog.
+- `rationale` is optional, surfaced verbatim in the future approval dialog. Omitting it on a re-declaration **clears** any previously stored rationale — the trust DB always reflects the most recent declaration, not a cumulative history.
 
 ### 4.3 Trust states
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -25,6 +25,7 @@ import { registerBrowserRpc } from './pipe/handlers/browser.rpc';
 import { registerA2aRpc } from './pipe/handlers/a2a.rpc';
 import { registerCompanyRpc } from './pipe/handlers/company.rpc';
 import { registerEventsRpc } from './pipe/handlers/events.rpc';
+import { registerMcpPluginRpc } from './pipe/handlers/mcp.rpc';
 import { ClaudeWorker } from './a2a/ClaudeWorker';
 import { AutoUpdater } from './updater/AutoUpdater';
 import { McpRegistrar } from './mcp/McpRegistrar';
@@ -330,6 +331,7 @@ registerBrowserRpc(rpcRouter, () => mainWindow, webviewCdpManager);
 registerA2aRpc(rpcRouter, () => mainWindow, claudeWorker);
 registerCompanyRpc(rpcRouter, () => mainWindow);
 registerEventsRpc(rpcRouter);
+registerMcpPluginRpc(rpcRouter);
 
 // IPC: webview CDP registration
 ipcMain.handle('browser:register-webview', async (_event, surfaceId: string, webContentsId: number) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,6 +26,7 @@ import { registerA2aRpc } from './pipe/handlers/a2a.rpc';
 import { registerCompanyRpc } from './pipe/handlers/company.rpc';
 import { registerEventsRpc } from './pipe/handlers/events.rpc';
 import { registerMcpPluginRpc } from './pipe/handlers/mcp.rpc';
+import { getPluginTrustStore } from './mcp/PluginTrustStore';
 import { ClaudeWorker } from './a2a/ClaudeWorker';
 import { AutoUpdater } from './updater/AutoUpdater';
 import { McpRegistrar } from './mcp/McpRegistrar';
@@ -332,6 +333,17 @@ registerA2aRpc(rpcRouter, () => mainWindow, claudeWorker);
 registerCompanyRpc(rpcRouter, () => mainWindow);
 registerEventsRpc(rpcRouter);
 registerMcpPluginRpc(rpcRouter);
+
+// Wire the legacy-contact bookkeeping so envelope-less RPCs land in
+// plugin-trust.json as a `legacy` audit entry, per spec §2.2.
+// fire-and-forget — the recorder must never affect dispatch latency.
+rpcRouter.setLegacyContactRecorder(() => {
+  void getPluginTrustStore()
+    .upsertLegacyContact()
+    .catch(() => {
+      /* trust-store writes are best-effort; never block RPC */
+    });
+});
 
 // IPC: webview CDP registration
 ipcMain.handle('browser:register-webview', async (_event, surfaceId: string, webContentsId: number) => {

--- a/src/main/mcp/PluginIdentity.ts
+++ b/src/main/mcp/PluginIdentity.ts
@@ -22,6 +22,19 @@ function sanitizeVersion(version: string | undefined | null): string | undefined
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+// Forward-compat guard: a record loaded from a future schema version
+// (or a hand-edited file) may carry a status outside our union. Treat
+// anything we don't recognise as `unconfirmed` so the trust-status
+// invariant below ('trusted'/'denied' never regress) can't be subverted
+// by writing `status: "anything-else"` to disk.
+function knownStatus(s: unknown): s is PluginTrustStatus {
+  return s === 'unconfirmed' || s === 'trusted' || s === 'denied' || s === 'legacy';
+}
+
+function currentStatusOf(record: PluginIdentityRecord): PluginTrustStatus {
+  return knownStatus(record.status) ? record.status : 'unconfirmed';
+}
+
 // Fresh identity created on first contact via `mcp.identify`. Recorded with
 // status='unconfirmed' so a future user-approval PR can promote to trusted
 // or denied without re-introducing the record.
@@ -60,8 +73,8 @@ export function applyContact(
   existing: PluginIdentityRecord,
   rawVersion: string | undefined,
 ): PluginIdentityRecord {
-  const nextStatus: PluginTrustStatus =
-    existing.status === 'legacy' ? 'unconfirmed' : existing.status;
+  const cur = currentStatusOf(existing);
+  const nextStatus: PluginTrustStatus = cur === 'legacy' ? 'unconfirmed' : cur;
   return {
     ...existing,
     version: sanitizeVersion(rawVersion) ?? existing.version,
@@ -75,13 +88,21 @@ export function applyContact(
 // back to 'unconfirmed'. The declared capability list is overwritten
 // wholesale; capability unions across reconnects are intentionally not
 // supported until the user-approval PR defines reconciliation semantics.
+//
+// TODO(enforcement-PR): a `trusted` plugin can currently re-declare a
+// widened capability set and keep the `trusted` status. The follow-up PR
+// MUST detect capability widening (set-difference against the previously
+// approved declaredCapabilities) and demote to `unconfirmed` so the user
+// re-approves. See docs/api/mcp-plugin-spec.md §2.3 (spoofing scenarios).
+// In this record-only PR the risk is dormant because no enforcement reads
+// the field yet.
 export function applyDeclaration(
   existing: PluginIdentityRecord,
   capabilities: string[],
   rationale?: string,
 ): PluginIdentityRecord {
-  const nextStatus: PluginTrustStatus =
-    existing.status === 'legacy' ? 'unconfirmed' : existing.status;
+  const cur = currentStatusOf(existing);
+  const nextStatus: PluginTrustStatus = cur === 'legacy' ? 'unconfirmed' : cur;
   return {
     ...existing,
     declaredCapabilities: [...capabilities],

--- a/src/main/mcp/PluginIdentity.ts
+++ b/src/main/mcp/PluginIdentity.ts
@@ -1,0 +1,92 @@
+// Helpers for constructing per-connection plugin identities. The domain
+// record type lives in src/shared/rpc.ts (PluginIdentityRecord) so it can
+// also be consumed by clients reading the trust DB shape. This module
+// keeps the construction/transition logic.
+
+import type { PluginIdentityRecord, PluginTrustStatus } from '../../shared/rpc';
+
+const UNKNOWN_PLUGIN_NAME = 'unknown';
+
+function now(): number {
+  return Date.now();
+}
+
+function sanitizeName(name: string | undefined | null): string {
+  const trimmed = typeof name === 'string' ? name.trim() : '';
+  return trimmed.length > 0 ? trimmed : UNKNOWN_PLUGIN_NAME;
+}
+
+function sanitizeVersion(version: string | undefined | null): string | undefined {
+  if (typeof version !== 'string') return undefined;
+  const trimmed = version.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+// Fresh identity created on first contact via `mcp.identify`. Recorded with
+// status='unconfirmed' so a future user-approval PR can promote to trusted
+// or denied without re-introducing the record.
+export function unconfirmedIdentity(
+  rawName: string | undefined,
+  rawVersion?: string,
+): PluginIdentityRecord {
+  const t = now();
+  return {
+    name: sanitizeName(rawName),
+    version: sanitizeVersion(rawVersion),
+    status: 'unconfirmed',
+    firstSeen: t,
+    lastSeen: t,
+  };
+}
+
+// Identity inferred when an RPC arrives without a clientName envelope —
+// pre-v2.10 callers or non-MCP clients. Recorded so future enforcement
+// can grandfather them and surface in audit logs.
+export function legacyIdentity(rawName?: string): PluginIdentityRecord {
+  const t = now();
+  return {
+    name: sanitizeName(rawName),
+    status: 'legacy',
+    firstSeen: t,
+    lastSeen: t,
+  };
+}
+
+// Apply a fresh contact to an existing record. Used by `mcp.identify` when
+// the plugin reconnects: lastSeen advances, version refreshes, but the
+// user-issued trust status (trusted/denied) must NOT be overwritten — only
+// `legacy` is allowed to upgrade to `unconfirmed`.
+export function applyContact(
+  existing: PluginIdentityRecord,
+  rawVersion: string | undefined,
+): PluginIdentityRecord {
+  const nextStatus: PluginTrustStatus =
+    existing.status === 'legacy' ? 'unconfirmed' : existing.status;
+  return {
+    ...existing,
+    version: sanitizeVersion(rawVersion) ?? existing.version,
+    status: nextStatus,
+    lastSeen: now(),
+  };
+}
+
+// Apply a permission declaration. Same trust-status invariant as
+// applyContact — declaring permissions cannot upgrade a 'denied' plugin
+// back to 'unconfirmed'. The declared capability list is overwritten
+// wholesale; capability unions across reconnects are intentionally not
+// supported until the user-approval PR defines reconciliation semantics.
+export function applyDeclaration(
+  existing: PluginIdentityRecord,
+  capabilities: string[],
+  rationale?: string,
+): PluginIdentityRecord {
+  const nextStatus: PluginTrustStatus =
+    existing.status === 'legacy' ? 'unconfirmed' : existing.status;
+  return {
+    ...existing,
+    declaredCapabilities: [...capabilities],
+    rationale: typeof rationale === 'string' ? rationale.trim() || undefined : undefined,
+    status: nextStatus,
+    lastSeen: now(),
+  };
+}

--- a/src/main/mcp/PluginTrustStore.ts
+++ b/src/main/mcp/PluginTrustStore.ts
@@ -18,22 +18,78 @@ import {
   atomicReadJSON,
 } from '../../daemon/util/atomicWrite';
 import { getPluginTrustPath, getWmuxHomeDir } from '../../shared/constants';
-import type { PluginIdentityRecord } from '../../shared/rpc';
+import type { PluginIdentityRecord, PluginTrustStatus } from '../../shared/rpc';
 import {
   applyContact,
   applyDeclaration,
+  legacyIdentity,
   unconfirmedIdentity,
 } from './PluginIdentity';
 
 export const PLUGIN_TRUST_SCHEMA_VERSION = 1 as const;
+
+// Plugin names ride in over the wire from any client holding the wmux auth
+// token. Cap the key length so a malicious caller can't grow plugin-trust.json
+// unboundedly. 256 chars is generous for `org.tool-name@semver` patterns; the
+// DB-wide entry cap is a separate enforcement-PR concern.
+export const MAX_PLUGIN_NAME_LEN = 256 as const;
 
 export interface PluginTrustDb {
   schemaVersion: number;
   plugins: Record<string, PluginIdentityRecord>;
 }
 
+// All plugin maps use a null-prototype object so a clientName like
+// "__proto__" / "toString" / "hasOwnProperty" can never collide with
+// Object.prototype and either read inherited values or mutate the prototype.
+function newPluginMap(): Record<string, PluginIdentityRecord> {
+  return Object.create(null);
+}
+
 function emptyDb(): PluginTrustDb {
-  return { schemaVersion: PLUGIN_TRUST_SCHEMA_VERSION, plugins: {} };
+  return { schemaVersion: PLUGIN_TRUST_SCHEMA_VERSION, plugins: newPluginMap() };
+}
+
+// Defensive own-property lookup. db.plugins is built from JSON.parse output
+// or hand-constructed null-proto maps, but a corrupt/forward-compat read
+// could still hand us a prototype-tainted object — never trust the shape.
+function ownPlugin(
+  db: PluginTrustDb,
+  name: string,
+): PluginIdentityRecord | undefined {
+  return Object.prototype.hasOwnProperty.call(db.plugins, name)
+    ? db.plugins[name]
+    : undefined;
+}
+
+const KNOWN_STATUSES: ReadonlySet<PluginTrustStatus> = new Set([
+  'unconfirmed',
+  'trusted',
+  'denied',
+  'legacy',
+]);
+
+// Coerce a freshly-loaded record into a valid PluginIdentityRecord. Drops
+// entries whose `status` isn't one of the four known values so downstream
+// transitions never branch on `undefined`. Forward-compat: extra fields are
+// passed through unchanged.
+function normalizeRecord(raw: unknown): PluginIdentityRecord | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const r = raw as Partial<PluginIdentityRecord>;
+  if (typeof r.name !== 'string' || r.name.length === 0) return undefined;
+  if (!r.status || !KNOWN_STATUSES.has(r.status as PluginTrustStatus)) {
+    return undefined;
+  }
+  return r as PluginIdentityRecord;
+}
+
+// Bound plugin name length so a hostile clientName can't disk-fill us. We
+// truncate rather than reject because the trust DB write is best-effort
+// from RpcRouter's legacy path; a thrown error would lose the audit entry.
+function clampName(name: string): string {
+  return name.length <= MAX_PLUGIN_NAME_LEN
+    ? name
+    : name.slice(0, MAX_PLUGIN_NAME_LEN);
 }
 
 function ensureWmuxHomeDir(): void {
@@ -74,27 +130,36 @@ export class PluginTrustStore {
   }
 
   // Coerce whatever was on disk into the current schema shape. Unknown
-  // future versions are accepted as-is (forward-compat); v1 entries
-  // missing optional fields are passed through unchanged.
+  // future versions are accepted as-is (forward-compat); v1 entries with
+  // valid `name` + `status` pass through; malformed entries are dropped
+  // (silently — boot tolerance trumps strict validation here).
   private normalize(parsed: PluginTrustDb | null): PluginTrustDb {
     if (!parsed || typeof parsed !== 'object') return emptyDb();
     const schemaVersion =
       typeof parsed.schemaVersion === 'number' && parsed.schemaVersion > 0
         ? parsed.schemaVersion
         : PLUGIN_TRUST_SCHEMA_VERSION;
-    const plugins =
-      parsed.plugins && typeof parsed.plugins === 'object' ? parsed.plugins : {};
+    const sourcePlugins =
+      parsed.plugins && typeof parsed.plugins === 'object'
+        ? (parsed.plugins as Record<string, unknown>)
+        : {};
+    const plugins = newPluginMap();
+    for (const key of Object.keys(sourcePlugins)) {
+      if (!Object.prototype.hasOwnProperty.call(sourcePlugins, key)) continue;
+      const rec = normalizeRecord(sourcePlugins[key]);
+      if (rec) plugins[clampName(key)] = rec;
+    }
     return { schemaVersion, plugins };
   }
 
   async get(name: string): Promise<PluginIdentityRecord | undefined> {
     const db = await this.load();
-    return db.plugins[name];
+    return ownPlugin(db, clampName(name));
   }
 
   async list(): Promise<PluginIdentityRecord[]> {
     const db = await this.load();
-    return Object.values(db.plugins);
+    return Object.keys(db.plugins).map((k) => db.plugins[k]);
   }
 
   // Record a first contact (or refresh `lastSeen`/`version` on a known
@@ -103,12 +168,13 @@ export class PluginTrustStore {
     name: string,
     version?: string,
   ): Promise<PluginIdentityRecord> {
+    const safeName = clampName(name);
     return this.mutate((db) => {
-      const existing = db.plugins[name];
+      const existing = ownPlugin(db, safeName);
       const next = existing
         ? applyContact(existing, version)
-        : unconfirmedIdentity(name, version);
-      db.plugins[name] = next;
+        : unconfirmedIdentity(safeName, version);
+      db.plugins[safeName] = next;
       return next;
     });
   }
@@ -121,10 +187,37 @@ export class PluginTrustStore {
     rationale?: string,
     version?: string,
   ): Promise<PluginIdentityRecord> {
+    const safeName = clampName(name);
     return this.mutate((db) => {
-      const existing = db.plugins[name] ?? unconfirmedIdentity(name, version);
+      const existing =
+        ownPlugin(db, safeName) ?? unconfirmedIdentity(safeName, version);
       const next = applyDeclaration(existing, capabilities, rationale);
-      db.plugins[name] = next;
+      db.plugins[safeName] = next;
+      return next;
+    });
+  }
+
+  // Record an RPC call that arrived without a clientName envelope.
+  // Pre-v2.10 callers and the wmux-bundled MCP server's pre-handshake RPCs
+  // land here. Status is `legacy` on first contact and refreshes via
+  // applyContact (which respects the trust-status invariant) on repeats.
+  // Caller controls the name; defaults to 'unknown' so all envelope-less
+  // callers collapse to a single audit entry instead of fragmenting the DB.
+  async upsertLegacyContact(
+    name?: string,
+    version?: string,
+  ): Promise<PluginIdentityRecord> {
+    const safeName = clampName(
+      typeof name === 'string' && name.trim().length > 0
+        ? name.trim()
+        : 'unknown',
+    );
+    return this.mutate((db) => {
+      const existing = ownPlugin(db, safeName);
+      const next = existing
+        ? applyContact(existing, version)
+        : legacyIdentity(safeName);
+      db.plugins[safeName] = next;
       return next;
     });
   }

--- a/src/main/mcp/PluginTrustStore.ts
+++ b/src/main/mcp/PluginTrustStore.ts
@@ -1,0 +1,171 @@
+// PluginTrustStore — persists declared MCP plugin identities to
+// `~/.wmux/plugin-trust.json` so substrate can track who connected, what
+// capabilities they claimed they would need, and what trust state the user
+// has assigned. NOT a secret store (no credentials).
+//
+// All writes go through `atomicWriteJSON` to avoid torn files on crash.
+// Reads tolerate a missing/corrupt file by treating it as an empty DB so
+// substrate boot never fails on first-run.
+//
+// Concurrency: the store is intentionally single-instance per main process.
+// The `load → mutate → write` cycle is serialised inside the class via a
+// shared promise chain to prevent interleaved writes from clobbering each
+// other in burst workloads (e.g. 10 plugins reconnecting simultaneously).
+
+import * as fs from 'fs';
+import {
+  atomicWriteJSON,
+  atomicReadJSON,
+} from '../../daemon/util/atomicWrite';
+import { getPluginTrustPath, getWmuxHomeDir } from '../../shared/constants';
+import type { PluginIdentityRecord } from '../../shared/rpc';
+import {
+  applyContact,
+  applyDeclaration,
+  unconfirmedIdentity,
+} from './PluginIdentity';
+
+export const PLUGIN_TRUST_SCHEMA_VERSION = 1 as const;
+
+export interface PluginTrustDb {
+  schemaVersion: number;
+  plugins: Record<string, PluginIdentityRecord>;
+}
+
+function emptyDb(): PluginTrustDb {
+  return { schemaVersion: PLUGIN_TRUST_SCHEMA_VERSION, plugins: {} };
+}
+
+function ensureWmuxHomeDir(): void {
+  const dir = getWmuxHomeDir();
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch {
+    // mkdir failures bubble up later when atomicWriteJSON tries to write
+  }
+}
+
+export class PluginTrustStore {
+  private readonly path: string;
+  private cache: PluginTrustDb | null = null;
+  private writeChain: Promise<void> = Promise.resolve();
+
+  constructor(targetPath: string = getPluginTrustPath()) {
+    this.path = targetPath;
+  }
+
+  // Read the on-disk DB, tolerating absence and corruption. Cached in
+  // memory until the next write so subsequent reads don't re-parse JSON.
+  async load(): Promise<PluginTrustDb> {
+    if (this.cache) return this.cache;
+    try {
+      const parsed = await atomicReadJSON<PluginTrustDb>(this.path);
+      this.cache = this.normalize(parsed);
+    } catch (err) {
+      // Corrupt file or unexpected I/O error — surface a warning but boot
+      // anyway. Future PR can decide whether to quarantine the bad file.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[PluginTrustStore] load failed, starting empty: ${String(err)}`,
+      );
+      this.cache = emptyDb();
+    }
+    return this.cache;
+  }
+
+  // Coerce whatever was on disk into the current schema shape. Unknown
+  // future versions are accepted as-is (forward-compat); v1 entries
+  // missing optional fields are passed through unchanged.
+  private normalize(parsed: PluginTrustDb | null): PluginTrustDb {
+    if (!parsed || typeof parsed !== 'object') return emptyDb();
+    const schemaVersion =
+      typeof parsed.schemaVersion === 'number' && parsed.schemaVersion > 0
+        ? parsed.schemaVersion
+        : PLUGIN_TRUST_SCHEMA_VERSION;
+    const plugins =
+      parsed.plugins && typeof parsed.plugins === 'object' ? parsed.plugins : {};
+    return { schemaVersion, plugins };
+  }
+
+  async get(name: string): Promise<PluginIdentityRecord | undefined> {
+    const db = await this.load();
+    return db.plugins[name];
+  }
+
+  async list(): Promise<PluginIdentityRecord[]> {
+    const db = await this.load();
+    return Object.values(db.plugins);
+  }
+
+  // Record a first contact (or refresh `lastSeen`/`version` on a known
+  // plugin). Returns the post-write record.
+  async upsertContact(
+    name: string,
+    version?: string,
+  ): Promise<PluginIdentityRecord> {
+    return this.mutate((db) => {
+      const existing = db.plugins[name];
+      const next = existing
+        ? applyContact(existing, version)
+        : unconfirmedIdentity(name, version);
+      db.plugins[name] = next;
+      return next;
+    });
+  }
+
+  // Record a declared capability set. If no contact has been recorded yet
+  // (e.g. plugin skipped `mcp.identify`), this seeds a fresh entry.
+  async upsertDeclaration(
+    name: string,
+    capabilities: string[],
+    rationale?: string,
+    version?: string,
+  ): Promise<PluginIdentityRecord> {
+    return this.mutate((db) => {
+      const existing = db.plugins[name] ?? unconfirmedIdentity(name, version);
+      const next = applyDeclaration(existing, capabilities, rationale);
+      db.plugins[name] = next;
+      return next;
+    });
+  }
+
+  // Serialise a mutation behind the write chain so two callers don't race
+  // on `load → mutate → persist`. The mutator may read AND write the db
+  // in place; we then re-cache and persist atomically.
+  private mutate<T>(mutator: (db: PluginTrustDb) => T): Promise<T> {
+    const chained = this.writeChain.then(async () => {
+      const db = await this.load();
+      const result = mutator(db);
+      this.cache = db;
+      ensureWmuxHomeDir();
+      await atomicWriteJSON(this.path, db);
+      return result;
+    });
+    this.writeChain = chained.then(
+      () => undefined,
+      () => undefined, // swallow errors in chain so one bad write doesn't block the next
+    );
+    return chained;
+  }
+
+  // Test-only: drop in-memory cache so next read goes to disk.
+  invalidateCache(): void {
+    this.cache = null;
+  }
+}
+
+// Process-singleton accessor — the trust store has no per-call state and
+// must serialise writes globally. Tests can construct standalone instances
+// with a custom path.
+let singleton: PluginTrustStore | null = null;
+
+export function getPluginTrustStore(): PluginTrustStore {
+  if (!singleton) singleton = new PluginTrustStore();
+  return singleton;
+}
+
+// Test-only reset hook so unit tests can swap in a fresh store after
+// pointing the path env at a tmpdir.
+export function __resetPluginTrustStoreForTests(): void {
+  singleton = null;
+}

--- a/src/main/mcp/__tests__/PluginIdentity.test.ts
+++ b/src/main/mcp/__tests__/PluginIdentity.test.ts
@@ -1,0 +1,109 @@
+// Trust-status invariant tests for the PluginIdentity transition helpers.
+//
+// These are the load-bearing assertions of Phase 2.1: once the user has
+// approved or rejected a plugin, no automated path may regress that
+// decision. The spec (docs/api/mcp-plugin-spec.md §4.3) lists the four
+// allowed transitions and forbids the rest; this suite exercises every
+// row in that table directly so the enforcement PR can rely on it.
+
+import { describe, expect, it } from 'vitest';
+import {
+  applyContact,
+  applyDeclaration,
+  legacyIdentity,
+  unconfirmedIdentity,
+} from '../PluginIdentity';
+import type { PluginIdentityRecord } from '../../../shared/rpc';
+
+function makeRecord(
+  overrides: Partial<PluginIdentityRecord> & { status: PluginIdentityRecord['status'] },
+): PluginIdentityRecord {
+  return {
+    name: 'demo',
+    firstSeen: 1_000,
+    lastSeen: 1_000,
+    ...overrides,
+  };
+}
+
+describe('PluginIdentity trust-status invariant', () => {
+  it('applyContact preserves trusted', () => {
+    const trusted = makeRecord({ status: 'trusted', version: '1.0' });
+    const next = applyContact(trusted, '1.1');
+    expect(next.status).toBe('trusted');
+    expect(next.version).toBe('1.1');
+    expect(next.lastSeen).toBeGreaterThanOrEqual(trusted.lastSeen);
+  });
+
+  it('applyContact preserves denied', () => {
+    const denied = makeRecord({ status: 'denied' });
+    const next = applyContact(denied, undefined);
+    expect(next.status).toBe('denied');
+  });
+
+  it('applyContact upgrades legacy to unconfirmed', () => {
+    const legacy = makeRecord({ status: 'legacy' });
+    const next = applyContact(legacy, '0.1');
+    expect(next.status).toBe('unconfirmed');
+  });
+
+  it('applyContact keeps unconfirmed as unconfirmed', () => {
+    const fresh = makeRecord({ status: 'unconfirmed' });
+    expect(applyContact(fresh, undefined).status).toBe('unconfirmed');
+  });
+
+  it('applyDeclaration preserves trusted but replaces capabilities', () => {
+    // Escalation trap: this is the documented hazard for the enforcement PR.
+    // The trust-status invariant is preserved (status stays 'trusted'); the
+    // PR-level decision to also DEMOTE on widening lives in the follow-up.
+    const trusted = makeRecord({
+      status: 'trusted',
+      declaredCapabilities: ['pane.read'],
+    });
+    const next = applyDeclaration(trusted, ['pane.read', 'meta.write']);
+    expect(next.status).toBe('trusted');
+    expect(next.declaredCapabilities).toEqual(['pane.read', 'meta.write']);
+  });
+
+  it('applyDeclaration preserves denied', () => {
+    const denied = makeRecord({ status: 'denied' });
+    expect(applyDeclaration(denied, ['pane.read']).status).toBe('denied');
+  });
+
+  it('applyDeclaration upgrades legacy to unconfirmed', () => {
+    const legacy = makeRecord({ status: 'legacy' });
+    expect(applyDeclaration(legacy, ['pane.read']).status).toBe('unconfirmed');
+  });
+
+  it('coerces unknown status values to unconfirmed (forward-compat guard)', () => {
+    // A future schema version (or a hand-edited file) could write a status
+    // value outside the union. Without the guard, applyContact would copy
+    // the bogus status through unchanged and break downstream branching.
+    const weird = {
+      name: 'demo',
+      firstSeen: 1_000,
+      lastSeen: 1_000,
+      status: 'future-state' as unknown as PluginIdentityRecord['status'],
+    } satisfies PluginIdentityRecord;
+    expect(applyContact(weird, undefined).status).toBe('unconfirmed');
+    expect(applyDeclaration(weird, []).status).toBe('unconfirmed');
+  });
+
+  it('unconfirmedIdentity and legacyIdentity build records with the documented statuses', () => {
+    expect(unconfirmedIdentity('a').status).toBe('unconfirmed');
+    expect(legacyIdentity('b').status).toBe('legacy');
+  });
+
+  it('applyDeclaration clears rationale when omitted on re-declare', () => {
+    // Spec §4.2: rationale is part of the most-recent declaration, not a
+    // cumulative history.
+    const withRationale = makeRecord({
+      status: 'unconfirmed',
+      declaredCapabilities: ['pane.read'],
+      rationale: 'first',
+    });
+    expect(
+      applyDeclaration(withRationale, ['pane.read']).rationale,
+    ).toBeUndefined();
+  });
+});

--- a/src/main/mcp/__tests__/PluginTrustStore.test.ts
+++ b/src/main/mcp/__tests__/PluginTrustStore.test.ts
@@ -1,0 +1,118 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  PLUGIN_TRUST_SCHEMA_VERSION,
+  PluginTrustStore,
+} from '../PluginTrustStore';
+
+let tmpDir = '';
+let dbPath = '';
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-trust-test-'));
+  dbPath = path.join(tmpDir, 'plugin-trust.json');
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe('PluginTrustStore.upsertContact', () => {
+  it('creates a fresh unconfirmed record on first contact', async () => {
+    const store = new PluginTrustStore(dbPath);
+    const identity = await store.upsertContact('claude-ai', '1.0.94');
+    expect(identity.name).toBe('claude-ai');
+    expect(identity.version).toBe('1.0.94');
+    expect(identity.status).toBe('unconfirmed');
+    expect(identity.firstSeen).toBeGreaterThan(0);
+    expect(identity.lastSeen).toBe(identity.firstSeen);
+  });
+
+  it('persists the record atomically and is recoverable across instances', async () => {
+    await new PluginTrustStore(dbPath).upsertContact('claude-ai', '1.0.94');
+    const onDisk = JSON.parse(fs.readFileSync(dbPath, 'utf8'));
+    expect(onDisk.schemaVersion).toBe(PLUGIN_TRUST_SCHEMA_VERSION);
+    expect(onDisk.plugins['claude-ai'].name).toBe('claude-ai');
+
+    // Fresh store instance reads the same data
+    const fresh = new PluginTrustStore(dbPath);
+    const list = await fresh.list();
+    expect(list).toHaveLength(1);
+    expect(list[0].name).toBe('claude-ai');
+  });
+
+  it('refreshes lastSeen without resetting firstSeen on reconnect', async () => {
+    const store = new PluginTrustStore(dbPath);
+    const first = await store.upsertContact('claude-ai', '1.0.0');
+    // Bump the clock perceptibly so lastSeen advances
+    await new Promise((r) => setTimeout(r, 5));
+    const second = await store.upsertContact('claude-ai', '1.0.1');
+    expect(second.firstSeen).toBe(first.firstSeen);
+    expect(second.lastSeen).toBeGreaterThanOrEqual(first.lastSeen);
+    expect(second.version).toBe('1.0.1');
+  });
+});
+
+describe('PluginTrustStore.upsertDeclaration', () => {
+  it('records the declared capability list and rationale', async () => {
+    const store = new PluginTrustStore(dbPath);
+    await store.upsertContact('claude-ai');
+    const identity = await store.upsertDeclaration(
+      'claude-ai',
+      ['pane.read', 'meta.write:custom.x.*'],
+      'tracks pane lifecycle',
+    );
+    expect(identity.declaredCapabilities).toEqual([
+      'pane.read',
+      'meta.write:custom.x.*',
+    ]);
+    expect(identity.rationale).toBe('tracks pane lifecycle');
+  });
+
+  it('seeds an entry when no prior contact exists', async () => {
+    const store = new PluginTrustStore(dbPath);
+    const identity = await store.upsertDeclaration('orphan-tool', ['pane.read']);
+    expect(identity.status).toBe('unconfirmed');
+    expect(identity.declaredCapabilities).toEqual(['pane.read']);
+  });
+
+  it('overwrites the prior declaration (no merge)', async () => {
+    const store = new PluginTrustStore(dbPath);
+    await store.upsertDeclaration('claude-ai', ['pane.read', 'meta.write']);
+    const second = await store.upsertDeclaration('claude-ai', ['events.subscribe']);
+    expect(second.declaredCapabilities).toEqual(['events.subscribe']);
+  });
+});
+
+describe('PluginTrustStore.load', () => {
+  it('tolerates a missing file as an empty DB', async () => {
+    const store = new PluginTrustStore(dbPath);
+    const db = await store.load();
+    expect(db.plugins).toEqual({});
+    expect(db.schemaVersion).toBe(PLUGIN_TRUST_SCHEMA_VERSION);
+  });
+
+  it('tolerates a corrupt file by starting empty', async () => {
+    fs.writeFileSync(dbPath, '{not valid json');
+    const store = new PluginTrustStore(dbPath);
+    const db = await store.load();
+    expect(db.plugins).toEqual({});
+  });
+
+  it('serialises concurrent writes without losing entries', async () => {
+    const store = new PluginTrustStore(dbPath);
+    await Promise.all([
+      store.upsertContact('a'),
+      store.upsertContact('b'),
+      store.upsertContact('c'),
+    ]);
+    const list = await store.list();
+    expect(list.map((p) => p.name).sort()).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/src/main/mcp/__tests__/PluginTrustStore.test.ts
+++ b/src/main/mcp/__tests__/PluginTrustStore.test.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  MAX_PLUGIN_NAME_LEN,
   PLUGIN_TRUST_SCHEMA_VERSION,
   PluginTrustStore,
 } from '../PluginTrustStore';
@@ -94,7 +95,7 @@ describe('PluginTrustStore.load', () => {
   it('tolerates a missing file as an empty DB', async () => {
     const store = new PluginTrustStore(dbPath);
     const db = await store.load();
-    expect(db.plugins).toEqual({});
+    expect(Object.keys(db.plugins)).toEqual([]);
     expect(db.schemaVersion).toBe(PLUGIN_TRUST_SCHEMA_VERSION);
   });
 
@@ -102,7 +103,7 @@ describe('PluginTrustStore.load', () => {
     fs.writeFileSync(dbPath, '{not valid json');
     const store = new PluginTrustStore(dbPath);
     const db = await store.load();
-    expect(db.plugins).toEqual({});
+    expect(Object.keys(db.plugins)).toEqual([]);
   });
 
   it('serialises concurrent writes without losing entries', async () => {
@@ -114,5 +115,90 @@ describe('PluginTrustStore.load', () => {
     ]);
     const list = await store.list();
     expect(list.map((p) => p.name).sort()).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('PluginTrustStore.upsertLegacyContact', () => {
+  it('records an envelope-less contact as legacy', async () => {
+    const store = new PluginTrustStore(dbPath);
+    const identity = await store.upsertLegacyContact();
+    expect(identity.name).toBe('unknown');
+    expect(identity.status).toBe('legacy');
+  });
+
+  it('upgrades a legacy entry to unconfirmed when applyContact runs again', async () => {
+    // Two passes through the legacy path simulate a second envelope-less
+    // RPC reaching the substrate after the audit row already exists.
+    const store = new PluginTrustStore(dbPath);
+    await store.upsertLegacyContact();
+    const second = await store.upsertLegacyContact();
+    expect(second.status).toBe('unconfirmed');
+  });
+
+  it('preserves a user-issued trust state when the same name re-appears as legacy', async () => {
+    // If a name was previously approved by the user (trusted), an
+    // envelope-less call must NOT regress that decision.
+    const store = new PluginTrustStore(dbPath);
+    await store.upsertContact('claude-ai');
+    // Forge a trusted state by overwriting on disk — the public API has no
+    // user-approval surface yet (planned for the enforcement PR).
+    const raw = JSON.parse(fs.readFileSync(dbPath, 'utf8'));
+    raw.plugins['claude-ai'].status = 'trusted';
+    fs.writeFileSync(dbPath, JSON.stringify(raw));
+    const fresh = new PluginTrustStore(dbPath);
+    const next = await fresh.upsertLegacyContact('claude-ai');
+    expect(next.status).toBe('trusted');
+  });
+});
+
+describe('PluginTrustStore hostile-input hardening', () => {
+  it('does not collide with Object.prototype keys', async () => {
+    const store = new PluginTrustStore(dbPath);
+    // Sending `__proto__` as a clientName must not mutate Object.prototype
+    // nor allow inherited values to leak through `get`.
+    await store.upsertContact('__proto__');
+    expect(({} as Record<string, unknown>).poisoned).toBeUndefined();
+    const stored = await store.get('__proto__');
+    expect(stored?.name).toBe('__proto__');
+    expect(stored?.status).toBe('unconfirmed');
+    // Built-in keys like `toString` must not return Object.prototype's method.
+    expect(await store.get('toString')).toBeUndefined();
+  });
+
+  it('truncates oversize plugin names instead of rejecting them', async () => {
+    const store = new PluginTrustStore(dbPath);
+    const huge = 'a'.repeat(MAX_PLUGIN_NAME_LEN + 50);
+    const stored = await store.upsertContact(huge);
+    expect(stored.name.length).toBe(MAX_PLUGIN_NAME_LEN);
+    // The truncated key is what subsequent lookups will use.
+    expect(await store.get(huge)).toBeDefined();
+  });
+
+  it('drops on-disk entries with an invalid status during normalize', async () => {
+    // A future schema version or hand edit might put a status outside the
+    // known union onto disk. load() must drop such entries rather than
+    // surface them — otherwise downstream branching on PluginTrustStatus
+    // sees `undefined` and the trust-status invariant cannot hold.
+    const corrupt = {
+      schemaVersion: PLUGIN_TRUST_SCHEMA_VERSION,
+      plugins: {
+        good: {
+          name: 'good',
+          status: 'unconfirmed',
+          firstSeen: 1,
+          lastSeen: 1,
+        },
+        bad: {
+          name: 'bad',
+          status: 'future-state',
+          firstSeen: 1,
+          lastSeen: 1,
+        },
+      },
+    };
+    fs.writeFileSync(dbPath, JSON.stringify(corrupt));
+    const store = new PluginTrustStore(dbPath);
+    const list = await store.list();
+    expect(list.map((p) => p.name)).toEqual(['good']);
   });
 });

--- a/src/main/mcp/__tests__/permissionGrammar.test.ts
+++ b/src/main/mcp/__tests__/permissionGrammar.test.ts
@@ -69,6 +69,56 @@ describe('permissionGrammar.globToRegex', () => {
     // the `+` is a literal, not a regex repetition operator
     expect(re.test('events.pollllspecial')).toBe(false);
   });
+
+  it('handles a bare * (any non-dot run, including empty)', () => {
+    const re = globToRegex('*');
+    expect(re.test('')).toBe(true);
+    expect(re.test('label')).toBe(true);
+    expect(re.test('with.dot')).toBe(false);
+  });
+
+  it('handles a bare ** (any run, dots included)', () => {
+    const re = globToRegex('**');
+    expect(re.test('')).toBe(true);
+    expect(re.test('a.b.c.d')).toBe(true);
+  });
+
+  it('handles leading * (e.g. *.foo)', () => {
+    const re = globToRegex('*.foo');
+    expect(re.test('a.foo')).toBe(true);
+    expect(re.test('.foo')).toBe(true);
+    expect(re.test('a.b.foo')).toBe(false);
+  });
+
+  it('handles a glob with no dots', () => {
+    const re = globToRegex('foo');
+    expect(re.test('foo')).toBe(true);
+    expect(re.test('foo.bar')).toBe(false);
+    expect(re.test('xfoo')).toBe(false);
+  });
+
+  it('escapes triple-star degenerately as **+single-star', () => {
+    // ***  →  ** + *  →  .*[^.]*  — matches any run; behaviour is
+    // intentionally undefined-but-safe (no regex compile error, no
+    // catastrophic backtracking).
+    expect(() => globToRegex('***')).not.toThrow();
+  });
+});
+
+describe('permissionGrammar.parsePermission — separator semantics', () => {
+  it('treats colons after the first one as literal glob characters', () => {
+    // Spec §3.1: the first `:` splits capability from glob; further colons
+    // belong to the glob and are regex-escaped during compilation.
+    const result = parsePermission('meta.write:custom.foo:bar');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.permission.capability).toBe('meta.write');
+      expect(result.permission.pathGlob).toBe('custom.foo:bar');
+      expect(result.permission.pathRegex?.test('custom.foo:bar')).toBe(true);
+      // The literal `:` must NOT match `x` (i.e. not regex-special).
+      expect(result.permission.pathRegex?.test('custom.fooXbar')).toBe(false);
+    }
+  });
 });
 
 describe('permissionGrammar.parsePermissionList', () => {

--- a/src/main/mcp/__tests__/permissionGrammar.test.ts
+++ b/src/main/mcp/__tests__/permissionGrammar.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  globToRegex,
+  parsePermission,
+  parsePermissionList,
+} from '../permissionGrammar';
+
+describe('permissionGrammar.parsePermission', () => {
+  it('accepts a bare capability', () => {
+    const result = parsePermission('pane.read');
+    expect(result).toEqual({ ok: true, permission: { capability: 'pane.read' } });
+  });
+
+  it('accepts a capability with a path glob', () => {
+    const result = parsePermission('meta.write:custom.dashboard.*');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.permission.capability).toBe('meta.write');
+      expect(result.permission.pathGlob).toBe('custom.dashboard.*');
+      expect(result.permission.pathRegex).toBeInstanceOf(RegExp);
+    }
+  });
+
+  it('rejects unknown capabilities', () => {
+    const result = parsePermission('pane.teleport');
+    expect(result).toEqual({
+      ok: false,
+      error: 'unknown capability "pane.teleport"',
+    });
+  });
+
+  it('rejects reserved wmux.* capabilities', () => {
+    const result = parsePermission('wmux.internal');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/reserved/);
+  });
+
+  it('rejects empty strings and empty path globs', () => {
+    expect(parsePermission('').ok).toBe(false);
+    expect(parsePermission('meta.write:').ok).toBe(false);
+  });
+
+  it('rejects non-string input', () => {
+    expect(parsePermission(42).ok).toBe(false);
+    expect(parsePermission(null).ok).toBe(false);
+    expect(parsePermission(undefined).ok).toBe(false);
+  });
+});
+
+describe('permissionGrammar.globToRegex', () => {
+  it('treats * as "any except dot"', () => {
+    const re = globToRegex('custom.dashboard.*');
+    expect(re.test('custom.dashboard.label')).toBe(true);
+    // single * does NOT cross a dot
+    expect(re.test('custom.dashboard.nested.label')).toBe(false);
+    expect(re.test('custom.other.label')).toBe(false);
+  });
+
+  it('treats ** as "any including dot"', () => {
+    const re = globToRegex('custom.dashboard.**');
+    expect(re.test('custom.dashboard.label')).toBe(true);
+    expect(re.test('custom.dashboard.nested.deep.label')).toBe(true);
+    expect(re.test('custom.other.label')).toBe(false);
+  });
+
+  it('escapes regex metacharacters in literal segments', () => {
+    const re = globToRegex('events.poll+special');
+    expect(re.test('events.poll+special')).toBe(true);
+    // the `+` is a literal, not a regex repetition operator
+    expect(re.test('events.pollllspecial')).toBe(false);
+  });
+});
+
+describe('permissionGrammar.parsePermissionList', () => {
+  it('parses all entries when valid', () => {
+    const result = parsePermissionList(['pane.read', 'meta.write:custom.x.*']);
+    expect(result.errors).toEqual([]);
+    expect(result.parsed).toHaveLength(2);
+  });
+
+  it('collects errors and parses successes', () => {
+    const result = parsePermissionList(['pane.read', 'bogus.capability']);
+    expect(result.parsed).toHaveLength(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatch(/unknown capability/);
+  });
+
+  it('rejects non-array input', () => {
+    expect(parsePermissionList('pane.read').errors).toContain(
+      'permissions must be an array',
+    );
+  });
+});

--- a/src/main/mcp/__tests__/phase-2-1-e2e.test.ts
+++ b/src/main/mcp/__tests__/phase-2-1-e2e.test.ts
@@ -1,0 +1,272 @@
+// Phase 2.1 dynamic verification — exercises the production wiring path
+// in a single multi-step sequence, with assertions on the raw bytes on
+// disk rather than the in-memory cache.
+//
+// This is NOT a unit test of any single module. It mirrors main/index.ts:
+//
+//   rpcRouter.setLegacyContactRecorder(() => {
+//     void getPluginTrustStore().upsertLegacyContact().catch(...);
+//   });
+//
+// and replays a realistic sequence of envelope-less + envelope-bearing
+// RPCs against an isolated tmpdir trust DB, then verifies what landed on
+// disk. Treat any failure here as a sign that the integration between
+// RpcRouter, PluginTrustStore, and atomicWrite changed in a way the
+// per-module suites would not catch.
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { RpcRouter } from '../../pipe/RpcRouter';
+import {
+  MAX_PLUGIN_NAME_LEN,
+  PluginTrustStore,
+} from '../PluginTrustStore';
+import { registerMcpPluginRpc } from '../../pipe/handlers/mcp.rpc';
+import type { McpIdentifyResult } from '../../../shared/rpc';
+
+let tmpDir = '';
+let dbPath = '';
+let store: PluginTrustStore;
+let router: RpcRouter;
+
+// Tracks the fire-and-forget promises the legacy recorder enqueues so
+// the test can await them between assertions. Production uses the same
+// recorder shape minus the tracker — see main/index.ts.
+let pendingWrites: Promise<unknown>[] = [];
+
+async function drainWrites(): Promise<void> {
+  // Pull and clear so a later RPC can enqueue a fresh batch without
+  // re-awaiting the previous ones. settle() afterwards lets the next
+  // microtask tick land any cache invalidation in PluginTrustStore.
+  const batch = pendingWrites;
+  pendingWrites = [];
+  await Promise.all(batch);
+}
+
+// Mirror the wiring from src/main/index.ts. The recorder closure captures
+// the tmpdir-backed store instead of the singleton so the test does not
+// touch ~/.wmux on the dev box. The only deviation from production is
+// the `pendingWrites.push` — we instrument the awaitable so the test
+// can deterministically inspect disk state after each RPC.
+function wireProductionPath(): void {
+  registerMcpPluginRpc(router, store);
+  // Same handler used in production for any non-mcp RPC. We pick pane.list
+  // because it is the most-frequently-called handler and exercises the
+  // exact dispatch path the legacy-recorder gates on.
+  router.register('pane.list', async () => ({ panes: [] }));
+  router.setLegacyContactRecorder(() => {
+    const p = store.upsertLegacyContact().catch(() => {
+      /* swallow — best-effort audit, never blocks RPC */
+    });
+    pendingWrites.push(p);
+  });
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-phase21-e2e-'));
+  dbPath = path.join(tmpDir, 'plugin-trust.json');
+  store = new PluginTrustStore(dbPath);
+  router = new RpcRouter();
+  pendingWrites = [];
+  wireProductionPath();
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+// Sleep long enough that lastSeen advances perceptibly between RPCs.
+// PluginIdentity uses Date.now() so the resolution is millisecond.
+const settle = (ms = 5) => new Promise<void>((r) => setTimeout(r, ms));
+
+// Read raw bytes from disk (bypassing PluginTrustStore's cache) so the
+// assertions reflect what survived atomicWriteJSON, not the in-memory
+// state. Fails if the file is missing or unparseable — caller decides.
+function readDbFromDisk(): {
+  schemaVersion: number;
+  plugins: Record<string, { status: string; name: string }>;
+} {
+  const raw = fs.readFileSync(dbPath, 'utf8');
+  return JSON.parse(raw);
+}
+
+describe('phase 2.1 production wiring — multi-step RPC sequence', () => {
+  it('replays a realistic plugin lifecycle and verifies disk state at each step', async () => {
+    // === Step 1: envelope-less RPC (pre-v2.10 caller or pre-handshake race)
+    // Expected: legacy 'unknown' entry persisted, status === 'legacy'.
+    await router.dispatch({ id: 's1', method: 'pane.list', params: {} });
+    // Fire-and-forget audit write — let the next tick land it on disk.
+    await drainWrites();
+    await settle();
+
+    expect(fs.existsSync(dbPath)).toBe(true);
+    {
+      const onDisk = readDbFromDisk();
+      expect(Object.keys(onDisk.plugins)).toEqual(['unknown']);
+      expect(onDisk.plugins.unknown.status).toBe('legacy');
+    }
+
+    // === Step 2: second envelope-less RPC — process-once flag must
+    // suppress a second trust-DB write. We watch mtime instead of the
+    // record itself because applyContact would advance lastSeen.
+    const mtimeAfterStep1 = fs.statSync(dbPath).mtimeMs;
+    await settle(10);
+    await router.dispatch({ id: 's2', method: 'pane.list', params: {} });
+    await drainWrites();
+    await settle();
+    const mtimeAfterStep2 = fs.statSync(dbPath).mtimeMs;
+    expect(mtimeAfterStep2).toBe(mtimeAfterStep1);
+
+    // === Step 3: envelope-bearing mcp.identify — distinct entry recorded
+    // as 'unconfirmed', the bundled MCP server's handshake path.
+    const response = await router.dispatch({
+      id: 's3',
+      method: 'mcp.identify',
+      params: {},
+      clientName: 'claude-ai',
+      clientVersion: '1.0.94',
+    });
+    expect(response.ok).toBe(true);
+    if (response.ok) {
+      const result = response.result as McpIdentifyResult;
+      expect(result.identity.status).toBe('unconfirmed');
+      expect(result.identity.name).toBe('claude-ai');
+    }
+    await drainWrites();
+    await settle();
+    {
+      const onDisk = readDbFromDisk();
+      expect(Object.keys(onDisk.plugins).sort()).toEqual(
+        ['claude-ai', 'unknown'].sort(),
+      );
+      expect(onDisk.plugins['claude-ai'].status).toBe('unconfirmed');
+      expect(onDisk.plugins.unknown.status).toBe('legacy');
+    }
+
+    // === Step 4: hostile clientName — '__proto__' must NOT pollute the
+    // global Object prototype and MUST land as an own-key in the DB.
+    await router.dispatch({
+      id: 's4',
+      method: 'mcp.identify',
+      params: {},
+      clientName: '__proto__',
+    });
+    await drainWrites();
+    await settle();
+    // Process-wide Object prototype must remain clean.
+    expect(({} as Record<string, unknown>).status).toBeUndefined();
+    expect(({} as Record<string, unknown>).declaredCapabilities).toBeUndefined();
+    {
+      const onDisk = readDbFromDisk();
+      expect(
+        Object.prototype.hasOwnProperty.call(onDisk.plugins, '__proto__'),
+      ).toBe(true);
+    }
+
+    // === Step 5: oversize clientName — substrate clamps to MAX length;
+    // the audit row is preserved (truncated) rather than rejected.
+    const huge = 'X'.repeat(MAX_PLUGIN_NAME_LEN + 100);
+    await router.dispatch({
+      id: 's5',
+      method: 'mcp.identify',
+      params: {},
+      clientName: huge,
+    });
+    await drainWrites();
+    await settle();
+    {
+      const onDisk = readDbFromDisk();
+      const truncated = 'X'.repeat(MAX_PLUGIN_NAME_LEN);
+      expect(
+        Object.prototype.hasOwnProperty.call(onDisk.plugins, truncated),
+      ).toBe(true);
+      // The full-length key must NOT exist — clamp, not store-twice.
+      expect(
+        Object.prototype.hasOwnProperty.call(onDisk.plugins, huge),
+      ).toBe(false);
+    }
+
+    // === Step 6: malformed declarePermissions must NOT corrupt the DB.
+    // The entire declaration is rejected; no plugin entry is mutated.
+    const beforeMalformed = readDbFromDisk();
+    const malformed = await router.dispatch({
+      id: 's6',
+      method: 'mcp.declarePermissions',
+      params: {
+        permissions: ['pane.read', 'made.up.capability'],
+      },
+      clientName: 'claude-ai',
+    });
+    expect(malformed.ok).toBe(false);
+    await drainWrites();
+    await settle();
+    const afterMalformed = readDbFromDisk();
+    // Identity entry exists from step 3, but capabilities must still be
+    // undefined — the malformed call did NOT seed anything.
+    expect(afterMalformed.plugins['claude-ai']).toEqual(
+      beforeMalformed.plugins['claude-ai'],
+    );
+
+    // === Step 7: well-formed declarePermissions — capability list is
+    // recorded verbatim and survives a fresh PluginTrustStore instance.
+    const goodDeclare = await router.dispatch({
+      id: 's7',
+      method: 'mcp.declarePermissions',
+      params: {
+        permissions: ['pane.read', 'meta.write:custom.dash.*'],
+        rationale: 'demo dashboard',
+      },
+      clientName: 'claude-ai',
+    });
+    expect(goodDeclare.ok).toBe(true);
+    await drainWrites();
+    await settle();
+
+    // Round-trip through a brand new store instance — the cache from
+    // the original store is bypassed entirely.
+    const reincarnated = new PluginTrustStore(dbPath);
+    const reloaded = await reincarnated.get('claude-ai');
+    expect(reloaded?.declaredCapabilities).toEqual([
+      'pane.read',
+      'meta.write:custom.dash.*',
+    ]);
+    expect(reloaded?.rationale).toBe('demo dashboard');
+    // Trust-status invariant — the prior 'unconfirmed' from step 3 was
+    // preserved across the declaration (no regression, no upgrade).
+    expect(reloaded?.status).toBe('unconfirmed');
+  });
+
+  it('survives a corrupt disk file by loading empty and overwriting on next write', async () => {
+    // Plant a corrupt file under the test path. The store must boot
+    // (return empty DB) and the next write must succeed without
+    // throwing — even though atomicWriteJSON rotates the bad file to
+    // .bak first.
+    fs.writeFileSync(dbPath, '{this is not valid json');
+    const localRouter = new RpcRouter();
+    const localStore = new PluginTrustStore(dbPath);
+    registerMcpPluginRpc(localRouter, localStore);
+    localRouter.setLegacyContactRecorder(() =>
+      void localStore.upsertLegacyContact().catch(() => undefined),
+    );
+    localRouter.register('pane.list', async () => ({ panes: [] }));
+
+    const response = await localRouter.dispatch({
+      id: 'recovery',
+      method: 'mcp.identify',
+      params: {},
+      clientName: 'recovery-test',
+    });
+    expect(response.ok).toBe(true);
+    await drainWrites();
+    await settle();
+
+    const onDisk = readDbFromDisk();
+    expect(onDisk.plugins['recovery-test']?.status).toBe('unconfirmed');
+  });
+});

--- a/src/main/mcp/permissionGrammar.ts
+++ b/src/main/mcp/permissionGrammar.ts
@@ -1,0 +1,142 @@
+// wmuxPermissions grammar: `<capability>[:<path-glob>]`
+//
+// Substrate-side parser for the declared permission strings that plugins
+// (external MCP clients) send via `mcp.declarePermissions`. Pattern is
+// inspired by VS Code's `activationEvents` and Zellij's plugin-permission
+// RFC: a finite capability whitelist plus an optional path/topic glob.
+//
+// This module is pure data → grammar validation only. Enforcement (matching
+// declared permissions against incoming RPC calls) lives in the follow-up PR
+// alongside the user-approval dialog.
+
+const KNOWN_CAPABILITIES = new Set<string>([
+  // Pane lifecycle and content
+  'pane.read',
+  'pane.write',
+  'pane.create',
+  'pane.delete',
+  'pane.search',
+  // Metadata
+  'meta.read',
+  'meta.write',
+  // Events
+  'events.subscribe',
+  // Workspaces
+  'workspace.read',
+  'workspace.claim',
+  // Terminal IO (input.send / terminal.readEvents)
+  'terminal.send',
+  'terminal.read',
+  // Browser tools (Playwright)
+  'browser.navigate',
+  'browser.click',
+  'browser.type',
+  'browser.screenshot',
+  'browser.evaluate',
+  'browser.read',
+  // Agent-to-agent
+  'a2a.send',
+  'a2a.execute',
+  'a2a.read',
+]);
+
+// Reserved capability prefix — substrate-internal surface, never grantable
+// to a plugin. Future hardening can extend this list (e.g. 'system.*').
+const RESERVED_PREFIXES = ['wmux.'];
+
+export interface ParsedPermission {
+  capability: string;
+  pathGlob?: string;
+  pathRegex?: RegExp;
+}
+
+export type PermissionParseResult =
+  | { ok: true; permission: ParsedPermission }
+  | { ok: false; error: string };
+
+export function listKnownCapabilities(): string[] {
+  return Array.from(KNOWN_CAPABILITIES).sort();
+}
+
+// Convert a wmuxPermissions path-glob into a RegExp.
+//
+// Rules (intentionally narrow so substrate doesn't import a glob library):
+//   - `*`  matches any run of characters except `.` (path separator stand-in)
+//   - `**` matches any run of characters including `.`
+//   - All other regex metacharacters are escaped — `.` is a literal separator
+//   - Anchored to start and end (whole-path match)
+const DOUBLE_STAR_SENTINEL = '__WMUX_GLOB_DOUBLESTAR__';
+
+export function globToRegex(glob: string): RegExp {
+  // 1. Escape regex metacharacters except `*` so the glob substitution below
+  //    is the only thing that matters for star handling.
+  let pattern = glob.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+  // 2. Stash `**` behind a sentinel BEFORE single-star expansion, so the
+  //    single-star pass below doesn't double-expand it.
+  pattern = pattern.replace(/\*\*/g, DOUBLE_STAR_SENTINEL);
+  // 3. Single-star: anything except `.`
+  pattern = pattern.replace(/\*/g, '[^.]*');
+  // 4. Restore double-star to `.*` (anything, including `.`)
+  pattern = pattern.split(DOUBLE_STAR_SENTINEL).join('.*');
+  return new RegExp(`^${pattern}$`);
+}
+
+export function parsePermission(spec: unknown): PermissionParseResult {
+  if (typeof spec !== 'string') {
+    return { ok: false, error: 'permission must be a string' };
+  }
+  const trimmed = spec.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, error: 'permission must not be empty' };
+  }
+
+  const colonIdx = trimmed.indexOf(':');
+  const capability = colonIdx === -1 ? trimmed : trimmed.slice(0, colonIdx);
+  const pathGlob = colonIdx === -1 ? undefined : trimmed.slice(colonIdx + 1);
+
+  if (capability.length === 0) {
+    return { ok: false, error: `permission "${spec}" has empty capability` };
+  }
+  if (RESERVED_PREFIXES.some((p) => capability.startsWith(p))) {
+    return { ok: false, error: `capability "${capability}" is reserved` };
+  }
+  if (!KNOWN_CAPABILITIES.has(capability)) {
+    return { ok: false, error: `unknown capability "${capability}"` };
+  }
+  if (pathGlob !== undefined && pathGlob.length === 0) {
+    return { ok: false, error: `permission "${spec}" has empty path glob` };
+  }
+
+  const parsed: ParsedPermission = { capability };
+  if (pathGlob !== undefined) {
+    parsed.pathGlob = pathGlob;
+    try {
+      parsed.pathRegex = globToRegex(pathGlob);
+    } catch (err) {
+      return {
+        ok: false,
+        error: `permission "${spec}" path glob invalid: ${String(err)}`,
+      };
+    }
+  }
+  return { ok: true, permission: parsed };
+}
+
+export interface PermissionListParseResult {
+  parsed: ParsedPermission[];
+  errors: string[];
+}
+
+export function parsePermissionList(input: unknown): PermissionListParseResult {
+  if (!Array.isArray(input)) {
+    return { parsed: [], errors: ['permissions must be an array'] };
+  }
+  const parsed: ParsedPermission[] = [];
+  const errors: string[] = [];
+  for (const entry of input) {
+    const result = parsePermission(entry);
+    if (result.ok) parsed.push(result.permission);
+    else errors.push(result.error);
+  }
+  return { parsed, errors };
+}

--- a/src/main/pipe/RpcRouter.ts
+++ b/src/main/pipe/RpcRouter.ts
@@ -1,6 +1,17 @@
-import type { RpcMethod, RpcRequest, RpcResponse } from '../../shared/rpc';
+import type {
+  RpcContext,
+  RpcMethod,
+  RpcRequest,
+  RpcResponse,
+} from '../../shared/rpc';
 
-type RpcHandler = (params: Record<string, unknown>) => Promise<unknown>;
+// Handlers receive a per-request context as an optional second argument.
+// Existing handlers `(params) => ...` keep compiling because the extra
+// argument is simply ignored at the call site.
+type RpcHandler = (
+  params: Record<string, unknown>,
+  ctx?: RpcContext,
+) => Promise<unknown>;
 
 export class RpcRouter {
   private readonly handlers = new Map<RpcMethod, RpcHandler>();
@@ -27,8 +38,21 @@ export class RpcRouter {
       };
     }
 
+    // Lift the optional identity envelope into the per-request context so
+    // handlers don't reach back into PipeServer internals.
+    const ctx: RpcContext = {
+      clientName:
+        typeof request.clientName === 'string' && request.clientName.trim().length > 0
+          ? request.clientName.trim()
+          : undefined,
+      clientVersion:
+        typeof request.clientVersion === 'string' && request.clientVersion.trim().length > 0
+          ? request.clientVersion.trim()
+          : undefined,
+    };
+
     try {
-      const result = await handler(request.params ?? {});
+      const result = await handler(request.params ?? {}, ctx);
       return {
         id: request.id,
         ok: true,

--- a/src/main/pipe/RpcRouter.ts
+++ b/src/main/pipe/RpcRouter.ts
@@ -13,11 +13,41 @@ type RpcHandler = (
   ctx?: RpcContext,
 ) => Promise<unknown>;
 
+// Optional sink for legacy-contact bookkeeping — wired in main/index.ts
+// to PluginTrustStore.upsertLegacyContact so an envelope-less RPC ends up
+// in plugin-trust.json as a `legacy` record. RpcRouter does not import
+// the trust store directly: it stays storage-agnostic, tests opt in by
+// passing their own recorder, and unit tests stay isolated from the
+// real ~/.wmux state.
+type LegacyContactRecorder = (method: RpcMethod) => void;
+
+// Methods that handle plugin identity themselves — they must NOT trigger
+// a parallel legacy write because their own handlers do the right thing
+// (record an `unconfirmed` contact via the resolved name).
+const IDENTITY_OWN_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
+  'mcp.identify',
+  'mcp.declarePermissions',
+]);
+
 export class RpcRouter {
   private readonly handlers = new Map<RpcMethod, RpcHandler>();
+  private legacyRecorder: LegacyContactRecorder | undefined;
+  // Process-once flag — the legacy bucket is a single audit entry, not a
+  // per-request log. After the first envelope-less RPC reaches the wire,
+  // subsequent calls don't re-touch the trust DB until the process restarts.
+  // Sufficient to satisfy spec §2.2 ("recorded as legacy") without producing
+  // hot-path disk writes on every legacy RPC.
+  private legacyContactPersisted = false;
 
   register(method: RpcMethod, handler: RpcHandler): void {
     this.handlers.set(method, handler);
+  }
+
+  // Wire the trust-store side. main/index.ts injects a recorder backed by
+  // PluginTrustStore.upsertLegacyContact; tests leave it unset for isolation.
+  setLegacyContactRecorder(recorder: LegacyContactRecorder | undefined): void {
+    this.legacyRecorder = recorder;
+    this.legacyContactPersisted = false;
   }
 
   async dispatch(request: RpcRequest): Promise<RpcResponse> {
@@ -50,6 +80,24 @@ export class RpcRouter {
           ? request.clientVersion.trim()
           : undefined,
     };
+
+    // Spec §2.2: requests without `clientName` are recorded as `legacy` so
+    // the enforcement PR can grandfather pre-v2.10 callers. Fire-and-forget
+    // and gated on a process-once flag (see comment on the field) — the
+    // recorder failing must never affect the actual RPC response.
+    if (
+      !ctx.clientName &&
+      !this.legacyContactPersisted &&
+      this.legacyRecorder &&
+      !IDENTITY_OWN_METHODS.has(request.method)
+    ) {
+      this.legacyContactPersisted = true;
+      try {
+        this.legacyRecorder(request.method);
+      } catch {
+        /* swallow — trust-store writes are best-effort */
+      }
+    }
 
     try {
       const result = await handler(request.params ?? {}, ctx);

--- a/src/main/pipe/__tests__/RpcRouter.test.ts
+++ b/src/main/pipe/__tests__/RpcRouter.test.ts
@@ -1,0 +1,138 @@
+// Direct tests for the RpcRouter dispatch + envelope-context plumbing.
+// These cover the Phase 2.1 additions: per-request context lift, optional
+// handler second arg backwards-compat, and the legacy-contact recorder
+// that fires when an RPC arrives without a clientName envelope.
+
+import { describe, expect, it, vi } from 'vitest';
+import { RpcRouter } from '../RpcRouter';
+import type { RpcContext, RpcMethod } from '../../../shared/rpc';
+
+type HandlerSig = (
+  params: Record<string, unknown>,
+  ctx?: RpcContext,
+) => Promise<unknown>;
+
+function makeRouter() {
+  const router = new RpcRouter();
+  router.register('pane.list', async () => ({ panes: [] }));
+  return router;
+}
+
+describe('RpcRouter dispatch envelope', () => {
+  it('lifts clientName / clientVersion into the handler context', async () => {
+    const router = new RpcRouter();
+    const handler = vi.fn<HandlerSig>(async () => 'ok');
+    router.register('pane.list', handler);
+    await router.dispatch({
+      id: 'r-1',
+      method: 'pane.list',
+      params: {},
+      clientName: 'claude-ai',
+      clientVersion: '1.2.3',
+    });
+    const [, ctx] = handler.mock.calls[0];
+    expect(ctx?.clientName).toBe('claude-ai');
+    expect(ctx?.clientVersion).toBe('1.2.3');
+  });
+
+  it('treats whitespace-only envelope fields as absent', async () => {
+    const router = new RpcRouter();
+    const handler = vi.fn<HandlerSig>(async () => 'ok');
+    router.register('pane.list', handler);
+    await router.dispatch({
+      id: 'r-2',
+      method: 'pane.list',
+      params: {},
+      clientName: '   ',
+      clientVersion: '',
+    });
+    const [, ctx] = handler.mock.calls[0];
+    expect(ctx?.clientName).toBeUndefined();
+    expect(ctx?.clientVersion).toBeUndefined();
+  });
+
+  it('keeps legacy zero-arg / single-arg handlers working (backwards-compat)', async () => {
+    const router = new RpcRouter();
+    router.register('pane.list', async (params) => ({ echoed: params }));
+    const response = await router.dispatch({
+      id: 'r-3',
+      method: 'pane.list',
+      params: { hello: 'world' },
+    });
+    expect(response.ok).toBe(true);
+    if (response.ok) expect(response.result).toEqual({ echoed: { hello: 'world' } });
+  });
+});
+
+describe('RpcRouter legacy-contact recorder', () => {
+  it('fires once per process when the first envelope-less RPC dispatches', async () => {
+    const router = makeRouter();
+    const recorder = vi.fn();
+    router.setLegacyContactRecorder(recorder);
+
+    await router.dispatch({ id: 'r-1', method: 'pane.list', params: {} });
+    await router.dispatch({ id: 'r-2', method: 'pane.list', params: {} });
+    await router.dispatch({ id: 'r-3', method: 'pane.list', params: {} });
+
+    expect(recorder).toHaveBeenCalledTimes(1);
+    expect(recorder).toHaveBeenCalledWith('pane.list');
+  });
+
+  it('does not fire when the envelope carries a clientName', async () => {
+    const router = makeRouter();
+    const recorder = vi.fn();
+    router.setLegacyContactRecorder(recorder);
+
+    await router.dispatch({
+      id: 'r-1',
+      method: 'pane.list',
+      params: {},
+      clientName: 'claude-ai',
+    });
+    expect(recorder).not.toHaveBeenCalled();
+  });
+
+  it('does not fire for mcp.identify / mcp.declarePermissions (handler owns identity)', async () => {
+    const router = new RpcRouter();
+    router.register('mcp.identify', async () => ({ ok: true }));
+    router.register('mcp.declarePermissions', async () => ({ ok: true }));
+    const recorder = vi.fn();
+    router.setLegacyContactRecorder(recorder);
+
+    await router.dispatch({ id: 'r-1', method: 'mcp.identify', params: {} });
+    await router.dispatch({
+      id: 'r-2',
+      method: 'mcp.declarePermissions',
+      params: {},
+    });
+    expect(recorder).not.toHaveBeenCalled();
+  });
+
+  it('survives a throwing recorder without failing the RPC', async () => {
+    // Trust-store writes are best-effort; if the recorder throws, the
+    // request itself must still resolve normally.
+    const router = makeRouter();
+    router.setLegacyContactRecorder(() => {
+      throw new Error('disk full');
+    });
+    const response = await router.dispatch({
+      id: 'r-1',
+      method: 'pane.list',
+      params: {},
+    });
+    expect(response.ok).toBe(true);
+  });
+
+  it('resets the once-flag when the recorder is replaced (test ergonomics)', async () => {
+    const router = makeRouter();
+    const first = vi.fn();
+    router.setLegacyContactRecorder(first);
+    await router.dispatch({ id: 'r-1', method: 'pane.list' as RpcMethod, params: {} });
+    expect(first).toHaveBeenCalledTimes(1);
+
+    const second = vi.fn();
+    router.setLegacyContactRecorder(second);
+    await router.dispatch({ id: 'r-2', method: 'pane.list' as RpcMethod, params: {} });
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/main/pipe/handlers/__tests__/mcp.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/mcp.rpc.test.ts
@@ -1,0 +1,136 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { RpcRouter } from '../../RpcRouter';
+import { registerMcpPluginRpc } from '../mcp.rpc';
+import { PluginTrustStore } from '../../../mcp/PluginTrustStore';
+import type { McpDeclarePermissionsResult, McpIdentifyResult } from '../../../../shared/rpc';
+
+let tmpDir = '';
+let dbPath = '';
+let store: PluginTrustStore;
+let router: RpcRouter;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-mcp-rpc-test-'));
+  dbPath = path.join(tmpDir, 'plugin-trust.json');
+  store = new PluginTrustStore(dbPath);
+  router = new RpcRouter();
+  registerMcpPluginRpc(router, store);
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe('mcp.identify', () => {
+  it('records the caller from the request envelope', async () => {
+    const response = await router.dispatch({
+      id: 'r-1',
+      method: 'mcp.identify',
+      params: { version: '1.0.94' },
+      clientName: 'claude-ai',
+      clientVersion: '1.0.94',
+    });
+    expect(response.ok).toBe(true);
+    if (!response.ok) return;
+    const result = response.result as McpIdentifyResult;
+    expect(result.identity.name).toBe('claude-ai');
+    expect(result.identity.version).toBe('1.0.94');
+    expect(result.identity.status).toBe('unconfirmed');
+
+    // Trust DB persisted the entry
+    const persisted = await store.get('claude-ai');
+    expect(persisted?.name).toBe('claude-ai');
+  });
+
+  it('falls back to params.name when envelope is missing', async () => {
+    const response = await router.dispatch({
+      id: 'r-2',
+      method: 'mcp.identify',
+      params: { name: 'cursor-ai' },
+    });
+    expect(response.ok).toBe(true);
+    if (!response.ok) return;
+    const result = response.result as McpIdentifyResult;
+    expect(result.identity.name).toBe('cursor-ai');
+  });
+
+  it('refreshes lastSeen on subsequent calls', async () => {
+    await router.dispatch({
+      id: 'r-3a',
+      method: 'mcp.identify',
+      params: {},
+      clientName: 'claude-ai',
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    const second = await router.dispatch({
+      id: 'r-3b',
+      method: 'mcp.identify',
+      params: {},
+      clientName: 'claude-ai',
+    });
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+    const result = second.result as McpIdentifyResult;
+    expect(result.identity.lastSeen).toBeGreaterThanOrEqual(result.identity.firstSeen);
+  });
+});
+
+describe('mcp.declarePermissions', () => {
+  it('records the declared capability set', async () => {
+    const response = await router.dispatch({
+      id: 'r-4',
+      method: 'mcp.declarePermissions',
+      params: {
+        permissions: ['pane.read', 'meta.write:custom.dashboard.*'],
+        rationale: 'demo',
+      },
+      clientName: 'demo-plugin',
+    });
+    expect(response.ok).toBe(true);
+    if (!response.ok) return;
+    const result = response.result as McpDeclarePermissionsResult;
+    expect(result.accepted).toEqual([
+      'pane.read',
+      'meta.write:custom.dashboard.*',
+    ]);
+    expect(result.identity.declaredCapabilities).toEqual(result.accepted);
+    expect(result.identity.rationale).toBe('demo');
+  });
+
+  it('rejects the entire declaration on any grammar error', async () => {
+    const response = await router.dispatch({
+      id: 'r-5',
+      method: 'mcp.declarePermissions',
+      params: {
+        permissions: ['pane.read', 'pane.teleport'],
+      },
+      clientName: 'demo-plugin',
+    });
+    expect(response.ok).toBe(false);
+    if (response.ok) return;
+    expect(response.error).toMatch(/unknown capability/);
+    // Nothing should have been persisted under the rejected name
+    expect(await store.get('demo-plugin')).toBeUndefined();
+  });
+
+  it('records the caller as legacy when no clientName is present', async () => {
+    // Plugin sends a valid permission declaration but no envelope identity —
+    // the substrate records the call under "unknown" so audit logs surface it.
+    const response = await router.dispatch({
+      id: 'r-6',
+      method: 'mcp.declarePermissions',
+      params: { permissions: ['pane.read'] },
+    });
+    expect(response.ok).toBe(true);
+    if (!response.ok) return;
+    const result = response.result as McpDeclarePermissionsResult;
+    expect(result.identity.name).toBe('unknown');
+  });
+});

--- a/src/main/pipe/handlers/__tests__/mcp.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/mcp.rpc.test.ts
@@ -61,6 +61,23 @@ describe('mcp.identify', () => {
     expect(result.identity.name).toBe('cursor-ai');
   });
 
+  it('envelope clientName wins over params.name when both are present', async () => {
+    // Spec contract (mcp.rpc.ts:23-24): the wire envelope is authoritative
+    // so a plugin can't claim a different identity per-call by stuffing
+    // params.name with someone else's name.
+    const response = await router.dispatch({
+      id: 'r-2b',
+      method: 'mcp.identify',
+      params: { name: 'forged-name' },
+      clientName: 'envelope-name',
+    });
+    expect(response.ok).toBe(true);
+    if (!response.ok) return;
+    const result = response.result as McpIdentifyResult;
+    expect(result.identity.name).toBe('envelope-name');
+    expect(await store.get('forged-name')).toBeUndefined();
+  });
+
   it('refreshes lastSeen on subsequent calls', async () => {
     await router.dispatch({
       id: 'r-3a',
@@ -120,9 +137,13 @@ describe('mcp.declarePermissions', () => {
     expect(await store.get('demo-plugin')).toBeUndefined();
   });
 
-  it('records the caller as legacy when no clientName is present', async () => {
-    // Plugin sends a valid permission declaration but no envelope identity —
-    // the substrate records the call under "unknown" so audit logs surface it.
+  it('records the caller under "unknown" when no clientName is present', async () => {
+    // Plugin sends a valid permission declaration but no envelope identity.
+    // mcp.declarePermissions is an identity-owning method (the handler is
+    // the one writing to the trust DB), so the resulting record is
+    // 'unconfirmed' — the spec's `legacy` status is reserved for the
+    // RpcRouter-level audit row produced by envelope-less calls to NON-mcp
+    // methods (see RpcRouter.legacyRecorder).
     const response = await router.dispatch({
       id: 'r-6',
       method: 'mcp.declarePermissions',
@@ -132,5 +153,6 @@ describe('mcp.declarePermissions', () => {
     if (!response.ok) return;
     const result = response.result as McpDeclarePermissionsResult;
     expect(result.identity.name).toBe('unknown');
+    expect(result.identity.status).toBe('unconfirmed');
   });
 });

--- a/src/main/pipe/handlers/mcp.rpc.ts
+++ b/src/main/pipe/handlers/mcp.rpc.ts
@@ -1,0 +1,97 @@
+// MCP plugin identity / permission-declaration handlers.
+//
+// Two record-only RPCs that wire identity through the substrate without
+// gating any existing behavior. A follow-up PR will introduce enforcement
+// (method dispatch / metadata path write / event subscription) on top of
+// the trust DB seeded here. See `docs/api/mcp-plugin-spec.md`.
+
+import type { RpcRouter } from '../RpcRouter';
+import type {
+  McpDeclarePermissionsParams,
+  McpDeclarePermissionsResult,
+  McpIdentifyParams,
+  McpIdentifyResult,
+  RpcContext,
+} from '../../../shared/rpc';
+import {
+  getPluginTrustStore,
+  PluginTrustStore,
+} from '../../mcp/PluginTrustStore';
+import { parsePermissionList } from '../../mcp/permissionGrammar';
+
+// Resolve the caller's declared name with the request envelope taking
+// priority over the params body, so a plugin can't claim to be one name in
+// `mcp.identify` while sending RPCs under another `clientName`.
+function resolveCallerName(
+  ctx: RpcContext | undefined,
+  rawNameFromParams: unknown,
+): { name: string; usedSource: 'envelope' | 'params' | 'unknown' } {
+  const envelopeName =
+    typeof ctx?.clientName === 'string' ? ctx.clientName.trim() : '';
+  if (envelopeName.length > 0) {
+    return { name: envelopeName, usedSource: 'envelope' };
+  }
+  if (typeof rawNameFromParams === 'string' && rawNameFromParams.trim().length > 0) {
+    return { name: rawNameFromParams.trim(), usedSource: 'params' };
+  }
+  return { name: 'unknown', usedSource: 'unknown' };
+}
+
+export function registerMcpPluginRpc(
+  router: RpcRouter,
+  storeOverride?: PluginTrustStore,
+): void {
+  const store = storeOverride ?? getPluginTrustStore();
+
+  // mcp.identify — first-contact handshake. Records the plugin in the
+  // trust DB and returns the current record. Idempotent: existing entries
+  // refresh `lastSeen`; user-issued trust state ('trusted' | 'denied') is
+  // preserved.
+  router.register('mcp.identify', async (rawParams, ctx) => {
+    const params = (rawParams ?? {}) as Partial<McpIdentifyParams>;
+    const { name } = resolveCallerName(ctx, params.name);
+    const version = typeof params.version === 'string' ? params.version : ctx?.clientVersion;
+    const identity = await store.upsertContact(name, version);
+    const result: McpIdentifyResult = { ok: true, identity };
+    return result;
+  });
+
+  // mcp.declarePermissions — record the capability set the plugin says it
+  // needs. Parses against the wmuxPermissions grammar; rejects the whole
+  // declaration if any entry is malformed so plugins can't half-declare
+  // and accidentally exclude themselves from future enforcement.
+  router.register('mcp.declarePermissions', async (rawParams, ctx) => {
+    const params = (rawParams ?? {}) as Partial<McpDeclarePermissionsParams>;
+    const { name } = resolveCallerName(ctx, undefined);
+
+    const list = parsePermissionList(params.permissions);
+    if (list.errors.length > 0) {
+      throw new Error(
+        `mcp.declarePermissions rejected: ${list.errors.join('; ')}`,
+      );
+    }
+
+    // Echo capability strings the plugin sent. We persist the raw input
+    // (not the parsed shape) so future PRs can re-parse against an updated
+    // grammar without losing the declaration. `parsed` is used only to
+    // confirm grammar acceptance; enforcement comes later.
+    const accepted = Array.isArray(params.permissions)
+      ? params.permissions.filter((p): p is string => typeof p === 'string')
+      : [];
+    const rationale =
+      typeof params.rationale === 'string' ? params.rationale : undefined;
+
+    const identity = await store.upsertDeclaration(
+      name,
+      accepted,
+      rationale,
+      ctx?.clientVersion,
+    );
+    const result: McpDeclarePermissionsResult = {
+      ok: true,
+      identity,
+      accepted,
+    };
+    return result;
+  });
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -2,7 +2,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { sendRpc } from './wmux-client';
+import { sendRpc, setClientIdentity } from './wmux-client';
 import type { RpcMethod } from '../shared/rpc';
 import { resolveDefaultPtyId as resolveDefaultPtyIdImpl } from './paneResolver';
 import { PlaywrightEngine } from './playwright/PlaywrightEngine';
@@ -623,8 +623,37 @@ server.tool(
 
 // === Start server ===
 
+// Hook the MCP initialize handshake so wmux substrate learns the declared
+// plugin identity (clientInfo.name + version). Fire `mcp.identify` once so
+// the trust DB picks up first-contact metadata — record-only, no
+// enforcement. See docs/api/mcp-plugin-spec.md.
+function wireClientIdentityHook(): void {
+  const underlying = (server as unknown as { server?: {
+    oninitialized?: () => void;
+    getClientVersion?: () => { name?: string; version?: string } | undefined;
+  } }).server;
+  if (!underlying) return;
+  underlying.oninitialized = () => {
+    try {
+      const info = underlying.getClientVersion?.();
+      const name = info?.name?.trim() || undefined;
+      const version = info?.version?.trim() || undefined;
+      if (!name) return;
+      setClientIdentity(name, version);
+      // Fire-and-forget — the trust DB write is best-effort; failures must
+      // never block the MCP handshake from completing.
+      sendRpc('mcp.identify', { name, version }).catch(() => {
+        /* substrate may be unavailable mid-restart; legacy path takes over */
+      });
+    } catch {
+      /* swallow — identity is non-essential to MCP operation */
+    }
+  };
+}
+
 async function main(): Promise<void> {
   const transport = new StdioServerTransport();
+  wireClientIdentityHook();
   await server.connect(transport);
 
   // Clean up Playwright connection when transport closes

--- a/src/mcp/wmux-client.ts
+++ b/src/mcp/wmux-client.ts
@@ -8,6 +8,25 @@ const TIMEOUT_MS = 10000;
 const RETRY_COUNT = 3;
 const RETRY_DELAY_MS = 1000;
 
+// Module-scoped declared identity. Populated by `setClientIdentity` from
+// the MCP `InitializeRequest` handler (src/mcp/index.ts). Every outbound
+// RPC stamps the envelope with this so PluginTrustStore can attribute the
+// call. May be undefined for the very first RPCs that race the MCP
+// initialize handshake — wmux treats those as 'legacy' and records them.
+let CLIENT_NAME: string | undefined;
+let CLIENT_VERSION: string | undefined;
+
+export function setClientIdentity(name?: string, version?: string): void {
+  const trimmedName = typeof name === 'string' ? name.trim() : '';
+  const trimmedVersion = typeof version === 'string' ? version.trim() : '';
+  CLIENT_NAME = trimmedName.length > 0 ? trimmedName : undefined;
+  CLIENT_VERSION = trimmedVersion.length > 0 ? trimmedVersion : undefined;
+}
+
+export function getClientIdentity(): { name?: string; version?: string } {
+  return { name: CLIENT_NAME, version: CLIENT_VERSION };
+}
+
 function readAuthToken(): string | undefined {
   // File takes priority — always read the latest token from disk.
   // Env vars may be stale (Claude Code caches them across MCP restarts).
@@ -35,7 +54,10 @@ function attemptRpc(
 ): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const id = crypto.randomUUID();
-    const request = JSON.stringify({ id, method, params, token }) + '\n';
+    const envelope: Record<string, unknown> = { id, method, params, token };
+    if (CLIENT_NAME) envelope.clientName = CLIENT_NAME;
+    if (CLIENT_VERSION) envelope.clientVersion = CLIENT_VERSION;
+    const request = JSON.stringify(envelope) + '\n';
 
     const socket = typeof target === 'string' ? net.connect(target) : net.connect(target);
     let buffer = '';

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -117,3 +117,18 @@ export function getTcpPortPath(): string {
   const home = process.env.USERPROFILE || process.env.HOME || '';
   return `${home}/.wmux-tcp-port`;
 }
+
+// wmux user home directory — root for plugin-trust.json, pid-map/, and other
+// substrate state that needs to survive across wmux restarts. Single source
+// of truth so callers don't reimplement the USERPROFILE/HOME dance.
+export function getWmuxHomeDir(): string {
+  const home = process.env.USERPROFILE || process.env.HOME || '';
+  return `${home}/.wmux`;
+}
+
+// Plugin trust database — see `docs/api/mcp-plugin-spec.md`. Written by main
+// process via `PluginTrustStore` (atomicWriteJSON). NOT a secret — it stores
+// declared identities and user-issued trust grants, not credentials.
+export function getPluginTrustPath(): string {
+  return `${getWmuxHomeDir()}/plugin-trust.json`;
+}

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -5,6 +5,30 @@ export interface RpcRequest {
   method: RpcMethod;
   params: Record<string, unknown>;
   token?: string;
+  /**
+   * v2.10.0+ — declared plugin identity. Carries the MCP `clientInfo.name`
+   * (and version) from the MCP server stdio handshake so handlers can attribute
+   * each call to a plugin. Optional and additive — pre-v2.10 callers still
+   * authenticate by token alone and are treated as `legacy` identities.
+   *
+   * Substrate stance: this is a declared identity, not a verified one. There is
+   * no root-of-trust; any caller can self-name. Permission enforcement (planned
+   * in a follow-up PR) treats unknown names as `legacy` and applies user-issued
+   * trust state from `~/.wmux/plugin-trust.json` to known names. See
+   * `docs/api/mcp-plugin-spec.md` for the threat model.
+   */
+  clientName?: string;
+  clientVersion?: string;
+}
+
+/**
+ * Per-request context surfaced to RPC handlers — populated by PipeServer
+ * from RpcRequest fields. Handlers receive this as an optional second
+ * argument so legacy handlers `(params) => ...` keep compiling.
+ */
+export interface RpcContext {
+  clientName?: string;
+  clientVersion?: string;
 }
 
 export type RpcResponse =
@@ -35,6 +59,8 @@ export type RpcMethod =
   | 'input.readScreen'
   | 'terminal.readEvents'
   | 'mcp.claimWorkspace'
+  | 'mcp.identify'
+  | 'mcp.declarePermissions'
   | 'notify'
   | 'meta.setStatus'
   | 'meta.setProgress'
@@ -125,6 +151,8 @@ export const ALL_RPC_METHODS = [
   'input.readScreen',
   'terminal.readEvents',
   'mcp.claimWorkspace',
+  'mcp.identify',
+  'mcp.declarePermissions',
   'notify',
   'meta.setStatus',
   'meta.setProgress',
@@ -350,3 +378,59 @@ export interface PaneMetadataCapabilities {
  * structured error data.
  */
 export const RPC_VERSION_CONFLICT = -32001 as const;
+
+// === MCP Plugin Identity RPC types (Phase 2.1, v2.10+) ===
+//
+// Two record-only RPCs that wire per-client identity through the substrate.
+// Enforcement is intentionally absent in this revision — handlers persist
+// declared state to `~/.wmux/plugin-trust.json` and return the recorded
+// identity. A follow-up PR will introduce permission checks at the three
+// remaining enforcement points (method dispatch, metadata path write,
+// event subscription).
+
+/**
+ * Trust state for a plugin entry in `~/.wmux/plugin-trust.json`.
+ *
+ *   - 'unconfirmed' — recorded by `mcp.identify` or `mcp.declarePermissions`,
+ *                     not yet shown to the user (no prompt UI in this PR)
+ *   - 'trusted'     — user approved the declared capability set (future PR)
+ *   - 'denied'      — user rejected the plugin (future PR)
+ *   - 'legacy'      — observed via RPC traffic without a clientName envelope
+ *                     (pre-v2.10 callers, or non-MCP RPC clients)
+ */
+export type PluginTrustStatus = 'unconfirmed' | 'trusted' | 'denied' | 'legacy';
+
+export interface PluginIdentityRecord {
+  name: string;
+  version?: string;
+  declaredCapabilities?: string[];
+  rationale?: string;
+  status: PluginTrustStatus;
+  firstSeen: number;
+  lastSeen: number;
+}
+
+export interface McpIdentifyParams {
+  name: string;
+  version?: string;
+}
+
+export interface McpIdentifyResult {
+  ok: true;
+  identity: PluginIdentityRecord;
+}
+
+export interface McpDeclarePermissionsParams {
+  permissions: string[];
+  rationale?: string;
+}
+
+export interface McpDeclarePermissionsResult {
+  ok: true;
+  identity: PluginIdentityRecord;
+  /**
+   * Parsed permission echoes — useful for clients verifying that wmux
+   * accepted the grammar they sent. Order matches `params.permissions`.
+   */
+  accepted: string[];
+}


### PR DESCRIPTION
## Summary

Substrate Phase 2.1 first PR — lands the contract between wmux and external MCP clients. Record-only: persists plugin identity and declared capabilities to `~/.wmux/plugin-trust.json` without gating any existing RPC. Enforcement at method dispatch / metadata path writes / event subscriptions is deferred to the follow-up PR.

## What ships

- **Spec doc** (`docs/api/mcp-plugin-spec.md`) — wire format, threat model, `wmuxPermissions` grammar, capability whitelist, trust-state lifecycle, trust-DB shape. The starting point for anyone integrating an MCP client with wmux.
- **Domain modules** under `src/main/mcp/`:
  - `PluginIdentity.ts` — pure transition helpers; enforces the trust-status invariant (`trusted` / `denied` never regress; `legacy` → `unconfirmed` on next contact).
  - `permissionGrammar.ts` — `<capability>[:<path-glob>]` parser. `*` matches non-dot runs; `**` crosses dots. Anchored regex compilation, no `minimatch` / glob library dependency.
  - `PluginTrustStore.ts` — atomic CRUD over `~/.wmux/plugin-trust.json` via `atomicWriteJSON`. Null-prototype map for plugin entries (hostile clientName hardening), `MAX_PLUGIN_NAME_LEN = 256` clamp, on-load schema validation that drops entries with unknown status.
- **RPC handlers** (`src/main/pipe/handlers/mcp.rpc.ts`):
  - `mcp.identify` — first-contact handshake, idempotent across reconnects.
  - `mcp.declarePermissions` — parses against the grammar; rejects the whole declaration if any entry is malformed.
- **Pipe-level integration** (`src/main/pipe/RpcRouter.ts`):
  - Optional `clientName` / `clientVersion` envelope lifted into per-request `RpcContext`.
  - `LegacyContactRecorder` hook fires fire-and-forget for envelope-less RPCs to non-mcp methods, satisfying spec §2.2's "recorded as legacy" promise without blocking dispatch latency.
- **Bundled MCP server** (`src/mcp/index.ts`, `src/mcp/wmux-client.ts`):
  - `oninitialized` hook captures `clientInfo` from the MCP SDK and fires `mcp.identify` once.
  - Every outbound RPC envelope is stamped with the captured identity.

## Commits

1. `40f9288` docs(api): MCP plugin spec — identity + declaration contract
2. `95b31f7` feat(mcp): plugin identity domain + permission grammar + trust store
3. `5a4eca4` feat(mcp): wire mcp.identify / mcp.declarePermissions through RPC pipe + bundled MCP server
4. `5a25da3` fix(mcp): codex + claude review fixes — prototype pollution, status invariant, legacy bookkeeping
5. `3812264` test(mcp): phase 2.1 dynamic e2e — production-wiring sequence with disk-state assertions

Commit 4 folds in two independent code reviews (CODEX + Claude code-reviewer agent). The fixes there cover: prototype pollution via null-prototype maps + own-key reads, forward-compat status validation, `MAX_PLUGIN_NAME_LEN` clamp, an explicit `TODO(enforcement-PR)` comment on the trusted-plugin widening hazard, and the missing legacy-contact bookkeeping the prior commits had omitted.

## Test plan

- [x] Unit tests: 1,306 / 1,306 passing (1,273 baseline + 33 new in this PR)
  - `PluginIdentity.test.ts` (NEW) — every trust-state transition row from spec §4.3, plus forward-compat coercion and the documented escalation-trap behaviour.
  - `RpcRouter.test.ts` (NEW) — envelope lift, whitespace handling, backwards-compat for single-arg handlers, all five `LegacyContactRecorder` scenarios.
  - `PluginTrustStore.test.ts` — hostile-input hardening (`__proto__`, oversize names, invalid status drops), `upsertLegacyContact` happy path, trusted-status-preserved-across-legacy-revisit.
  - `permissionGrammar.test.ts` — bare `*` / `**`, leading `*`, no-dot glob, triple-star degenerate input, colons-in-glob clarification.
  - `mcp.rpc.test.ts` — envelope-wins-over-params priority + tightened legacy status assertion.
- [x] `npx tsc --noEmit` clean
- [x] `npm run build:mcp` success
- [x] Dynamic e2e (`phase-2-1-e2e.test.ts`) — eight-step production-wiring sequence with on-disk byte assertions, plus a corrupt-file recovery scenario.

## Threat model recap

The trust DB does NOT verify identity — `clientName` is declared, not authenticated. Spec §2.3 documents this stance and the four known spoofing scenarios. The substrate security boundary is user-driven approval of declared capabilities (planned for the enforcement PR), not cryptographic identity. Future hardening (wmux-issued plugin tokens, signed manifests) is on the v3.1+ roadmap.

## Deferred to the enforcement PR

- Capability widening detection on `trusted` re-declarations (TODO comment at `PluginIdentity.ts` `applyDeclaration`, spec §2.3 row).
- DB-wide entry cap (LRU on `lastSeen`).
- Structured error responses for partial-list parse failures.
- `clearClientIdentity` on MCP transport close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)