### PR TITLE
feat(mcp): Phase 2.1 follow-up — trust-DB invariants (widening demote, LRU cap, structured rejection, transport-close clear)

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -293,7 +293,13 @@ The trust DB lives at `~/.wmux/plugin-trust.json` (atomic-write, single-process 
 Plugins announce themselves with two RPCs. Both are idempotent and never reject existing user-issued trust state.
 
 - `mcp.identify({ name, version? })` — fired automatically by the wmux-bundled MCP server when the MCP `InitializeRequest` completes. External plugins (non-wmux MCP servers) MAY call it explicitly.
-- `mcp.declarePermissions({ permissions: string[], rationale? })` — plugin declares the full capability set it expects to use. Grammar errors reject the entire declaration; nothing is partial.
+- `mcp.declarePermissions({ permissions: string[], rationale? })` — plugin declares the full capability set it expects to use. Returns a discriminated union: `{ ok: true, identity, accepted }` on full acceptance, `{ ok: false, errors }` with per-entry `{ index, permission, reason }` when any entry fails grammar. Whole-declaration rejection — wmux does not partially accept. The RPC envelope stays `ok: true` whenever the call reached the handler; application outcome rides in `result.ok`.
+
+#### Trust-DB invariants (Phase 2.1 follow-up — shipped)
+
+- **Capability widening demotes `trusted`.** A re-declaration that introduces any capability string not present in the previously approved set drops status from `trusted` to `unconfirmed`. Subset / identical re-declarations preserve `trusted`. `denied` never regresses to `unconfirmed` regardless of re-declaration content.
+- **LRU eviction caps trust-DB growth.** `MAX_PLUGIN_TRUST_ENTRIES = 1024`. When the cap is exceeded, the substrate evicts `legacy` entries first (oldest `lastSeen` first), then `unconfirmed`. `trusted` and `denied` are exempt — user decisions persist even if they overflow the cap.
+- **Transport close clears in-process identity.** The wmux-bundled MCP server calls `clearClientIdentity()` from its `transport.onclose` handler so trailing RPC traffic stamps an envelope-less request and falls back to the substrate's `legacy` audit path. A reconnect must re-run the MCP initialize handshake.
 
 ### 4.3 `wmuxPermissions` grammar
 
@@ -406,5 +412,6 @@ Things external clients may run into that aren't bugs but are explicit substrate
 |---|---|---|
 | Draft 1 | 2026-05-12 | Phase 0 initial draft. Covers PaneMetadata layered status, mergeMode, version + expectedVersion, bootId, cursor opaqueness, snapshot envelope, permission enforcement (sketch), Named Pipe security model. Phase 1 M3 will expand. |
 | Draft 2 | 2026-05-16 | Phase 1 M4 — adds §6.1 `workspaceId` resolution paths (env / PID-tree walk / `mcp.claimWorkspace` / legacy `activeWorkspaceId` fallback). §7 limitation entry rewritten to point at §6.1 and to define the path-D removal as a Phase 2.1 work item rather than a v3.0 blocker. |
+| Draft 3 | 2026-05-18 | Phase 2.1 follow-up — §4.2 adds structured rejection result for `mcp.declarePermissions` (discriminated union with per-entry `errors`) and the trust-DB invariants subsection: capability-widening demotion, LRU eviction cap, transport-close identity clear. No method-dispatch enforcement yet. |
 
 This document evolves alongside the implementation. Changes that affect the wire contract require a major-version bump per [`api/versioning.md`](./api/versioning.md). Changes that clarify existing semantics ship in any release.

--- a/docs/api/mcp-plugin-spec.md
+++ b/docs/api/mcp-plugin-spec.md
@@ -165,7 +165,8 @@ Behaviour:
 
 - The entire array is parsed against §3. If **any** entry is malformed, the whole declaration is rejected — plugins cannot half-declare.
 - Accepted declarations overwrite any prior declaration from the same `clientName`. There is no union/merge in the first PR.
-- The persisted record preserves the raw strings the plugin sent so future parsers can re-validate against an updated grammar.
+- Leading and trailing whitespace on each entry is stripped before storage so that cosmetic reformatting (e.g. trailing newlines from a codegen template) does not register as a capability change. The widening detector in §2.3 operates on the stored (trimmed) form, not the wire form.
+- The persisted record preserves the (trimmed) strings the plugin sent so future parsers can re-validate against an updated grammar.
 - `rationale` is optional, surfaced verbatim in the future approval dialog. Omitting it on a re-declaration **clears** any previously stored rationale — the trust DB always reflects the most recent declaration, not a cumulative history.
 
 Result shape is a discriminated union:

--- a/docs/api/mcp-plugin-spec.md
+++ b/docs/api/mcp-plugin-spec.md
@@ -1,6 +1,6 @@
 # wmux MCP Plugin Specification
 
-> **Status:** Draft 1 (Phase 2.1 first PR — identity + declaration wired, enforcement deferred to follow-up PR).
+> **Status:** Draft 2 (Phase 2.1 follow-up — trust-DB invariants tightened: widening-demotion, LRU eviction, structured rejection, transport-close identity clear. Method-dispatch enforcement still deferred to a later PR).
 > **Audience:** authors of MCP servers and clients that connect to wmux.
 > **Companion docs:** [`PROTOCOL.md`](../PROTOCOL.md) §4 (permission enforcement), [`api/versioning.md`](./versioning.md), [`api/stability.md`](./stability.md).
 
@@ -66,8 +66,9 @@ Known spoofing scenarios:
 | Two processes both claim `clientName: "claude-ai"` | Both write to the same trust-DB entry; `lastSeen` reflects the most recent contact. capability declarations overwrite each other (last writer wins). |
 | Plugin claims a different name in different RPCs | Each name is recorded independently. The substrate does not cross-check or pin identity within a connection in this first PR. |
 | Plugin claims `wmux` (the bundled identity) | Allowed today. Future enforcement may reject reserved names. |
-| Trusted plugin re-declares a widened capability set | Status is preserved (`trusted` stays `trusted`) and `declaredCapabilities` is overwritten wholesale. In this record-only PR the field is unread, so the widening is dormant. **The follow-up enforcement PR MUST detect set-difference vs the previously approved capabilities and demote to `unconfirmed`** before honouring the new surface. Tracked at `applyDeclaration` in `src/main/mcp/PluginIdentity.ts`. |
+| Trusted plugin re-declares a widened capability set | Substrate computes `set-difference(new, old)` on the raw declaration strings. Any capability not present in the previously approved set demotes status `trusted → unconfirmed`. Same-set or narrowed re-declarations preserve `trusted`. `denied` is never re-promoted by either path. Implemented in `applyDeclaration` (`src/main/mcp/PluginIdentity.ts`). |
 | Hostile `clientName` (`__proto__`, `toString`, multi-MB string) | Trust DB stores plugin records in a null-prototype map and clamps names to `MAX_PLUGIN_NAME_LEN = 256`. Prototype keys cannot collide with `Object.prototype`; oversize names are truncated, never rejected, so the audit trail is preserved. |
+| Hostile churn under fresh names (a process re-handshakes with a new `clientName` every reconnect) | DB-wide LRU cap (`MAX_PLUGIN_TRUST_ENTRIES = 1024`) bounds growth. Eviction order: `legacy` first, then `unconfirmed`, both by oldest `lastSeen`. `trusted` and `denied` are **never** evicted — user-curated state is sticky even if it overflows the cap. |
 
 Plugins SHOULD pick a stable, namespaced identity (`my-org.my-tool`, not `tool`) so user-issued trust state survives upgrades.
 
@@ -167,6 +168,24 @@ Behaviour:
 - The persisted record preserves the raw strings the plugin sent so future parsers can re-validate against an updated grammar.
 - `rationale` is optional, surfaced verbatim in the future approval dialog. Omitting it on a re-declaration **clears** any previously stored rationale — the trust DB always reflects the most recent declaration, not a cumulative history.
 
+Result shape is a discriminated union:
+
+```jsonc
+// Acceptance — every entry parsed and the declaration was persisted.
+{ "ok": true,
+  "identity": { /* PluginIdentityRecord */ },
+  "accepted": ["pane.read", "meta.write:custom.my-org.*"] }
+
+// Rejection — at least one entry failed grammar; nothing was persisted.
+{ "ok": false,
+  "errors": [
+    { "index": 1, "permission": "pane.teleport",
+      "reason": "unknown capability \"pane.teleport\"" }
+  ] }
+```
+
+`index` is the 0-based position in the original `permissions` array. `index: -1` is reserved for top-level shape errors (e.g. `permissions` not an array). The RPC envelope itself stays `ok: true` whenever the call reached the handler — the application-level outcome rides in `result.ok` so plugins can distinguish "wmux is unreachable" from "wmux declined our declaration."
+
 ### 4.3 Trust states
 
 A `PluginIdentityRecord` carries a `status` field:
@@ -178,7 +197,17 @@ A `PluginIdentityRecord` carries a `status` field:
 | `denied` | User rejected the plugin. | Future PR. |
 | `legacy` | Identity inferred from RPC traffic with no `clientName` envelope (pre-v2.10 callers, non-MCP clients). | RPC dispatch fallback. |
 
-Transitions in the first PR are limited to `legacy → unconfirmed` (when a previously-legacy plugin learns to send `clientName`) and `lastSeen` refreshes within the same status. User-issued `trusted`/`denied` cannot regress to `unconfirmed`.
+Allowed automated transitions:
+
+- `legacy → unconfirmed` — a previously-legacy plugin learns to send `clientName`.
+- `trusted → unconfirmed` — a trusted plugin re-declares a **widened** capability set (any string not in the previously approved declaration). Same-set or narrowed re-declarations preserve `trusted`.
+- Same-status `lastSeen` refresh.
+
+Forbidden automated transitions (only the user-approval dialog can perform these — landing in a follow-up PR):
+
+- `unconfirmed → trusted` / `unconfirmed → denied`
+- `denied → anything` (never regresses)
+- `trusted → trusted` after a widening (must demote and re-approve)
 
 ### 4.4 Trust DB location
 
@@ -203,6 +232,7 @@ Transitions in the first PR are limited to `legacy → unconfirmed` (when a prev
 - Written atomically via `atomicWriteJSON` (`src/daemon/util/atomicWrite/core.ts`).
 - The wmux main process owns the file; no other process should write it.
 - It is **not** a credential store. Treat it as user-readable index data.
+- Capped at `MAX_PLUGIN_TRUST_ENTRIES = 1024` entries. The LRU evictor runs after every mutation; eviction prefers `legacy` over `unconfirmed`, both ordered by oldest `lastSeen`. `trusted` and `denied` entries are exempt — if user-issued state alone exceeds the cap, the DB is allowed to overflow rather than discard the user's decisions.
 
 ---
 
@@ -255,3 +285,9 @@ MCP-server side (the wmux-bundled MCP server, which is itself the reference plug
 - `src/mcp/wmux-client.ts` — `setClientIdentity` stamps every outbound RPC envelope.
 
 External plugin authors building their own MCP servers can copy the pattern: capture `clientInfo` from the MCP SDK, attach `clientName`/`clientVersion` to the wmux auth-token-bearing JSON-RPC payload, then call `mcp.identify` once.
+
+### 8.1 Transport-close contract
+
+When the MCP transport closes (process shutdown, SIGINT, host disconnect), the wmux-bundled MCP server calls `clearClientIdentity()` from `src/mcp/wmux-client.ts`. This drops the cached `clientName`/`clientVersion` from module scope so any trailing RPC traffic (e.g. cleanup work scheduled during the shutdown handler) stamps an envelope-less request and falls back to the substrate's `legacy` audit path instead of mis-attributing the call to a plugin that has already disconnected.
+
+A reconnect MUST re-run the MCP initialize handshake to re-establish identity; there is no replay of cached identity across transport boundaries. External MCP servers SHOULD mirror this contract when implementing their own transport-close cleanup.

--- a/src/main/mcp/PluginIdentity.ts
+++ b/src/main/mcp/PluginIdentity.ts
@@ -83,26 +83,44 @@ export function applyContact(
   };
 }
 
-// Apply a permission declaration. Same trust-status invariant as
-// applyContact — declaring permissions cannot upgrade a 'denied' plugin
-// back to 'unconfirmed'. The declared capability list is overwritten
-// wholesale; capability unions across reconnects are intentionally not
-// supported until the user-approval PR defines reconciliation semantics.
-//
-// TODO(enforcement-PR): a `trusted` plugin can currently re-declare a
-// widened capability set and keep the `trusted` status. The follow-up PR
-// MUST detect capability widening (set-difference against the previously
-// approved declaredCapabilities) and demote to `unconfirmed` so the user
-// re-approves. See docs/api/mcp-plugin-spec.md §2.3 (spoofing scenarios).
-// In this record-only PR the risk is dormant because no enforcement reads
-// the field yet.
+// True when `next` contains at least one capability string that was not in
+// `prev`. A null/empty `prev` with non-empty `next` is also widening — a
+// `trusted` record without a stored declaration is anomalous (hand edit or
+// corrupt write), so we err on the side of demoting and forcing re-approval
+// rather than letting the declaration ride on inherited trust.
+function isWidenedDeclaration(
+  prev: readonly string[] | undefined,
+  next: readonly string[],
+): boolean {
+  if (!prev || prev.length === 0) return next.length > 0;
+  const prevSet = new Set(prev);
+  for (const cap of next) {
+    if (!prevSet.has(cap)) return true;
+  }
+  return false;
+}
+
+// Apply a permission declaration. Trust-status invariant: 'denied' never
+// regresses. 'legacy' upgrades to 'unconfirmed'. 'trusted' is preserved as
+// long as the new declaration is a subset of the previously approved
+// capability set — any widening (a new capability string the user has not
+// approved) demotes back to 'unconfirmed' so the user re-approves. Same
+// rule applies if the prior declaration was missing entirely. Spec
+// §2.3 / §4.3 codify this transition.
 export function applyDeclaration(
   existing: PluginIdentityRecord,
   capabilities: string[],
   rationale?: string,
 ): PluginIdentityRecord {
   const cur = currentStatusOf(existing);
-  const nextStatus: PluginTrustStatus = cur === 'legacy' ? 'unconfirmed' : cur;
+  let nextStatus: PluginTrustStatus;
+  if (cur === 'legacy') {
+    nextStatus = 'unconfirmed';
+  } else if (cur === 'trusted' && isWidenedDeclaration(existing.declaredCapabilities, capabilities)) {
+    nextStatus = 'unconfirmed';
+  } else {
+    nextStatus = cur;
+  }
   return {
     ...existing,
     declaredCapabilities: [...capabilities],

--- a/src/main/mcp/PluginTrustStore.ts
+++ b/src/main/mcp/PluginTrustStore.ts
@@ -30,9 +30,25 @@ export const PLUGIN_TRUST_SCHEMA_VERSION = 1 as const;
 
 // Plugin names ride in over the wire from any client holding the wmux auth
 // token. Cap the key length so a malicious caller can't grow plugin-trust.json
-// unboundedly. 256 chars is generous for `org.tool-name@semver` patterns; the
-// DB-wide entry cap is a separate enforcement-PR concern.
+// unboundedly. 256 chars is generous for `org.tool-name@semver` patterns.
 export const MAX_PLUGIN_NAME_LEN = 256 as const;
+
+// DB-wide entry cap. A hostile or buggy client that re-handshakes under
+// fresh names could fragment the trust DB indefinitely; the LRU eviction
+// in `mutate` keeps growth bounded. 1024 entries × ~512 B/record ≈ 512 KB
+// worst case on disk, well below practical limits. User-curated state
+// ('trusted' / 'denied') is exempt from eviction — see `evictIfOverCap`.
+export const MAX_PLUGIN_TRUST_ENTRIES = 1024 as const;
+
+// Eviction priority across status tiers. Lower = evicted first. 'trusted'
+// and 'denied' carry a user decision and are never evicted by this path;
+// their rank is informational (sort never reaches them).
+const EVICTION_RANK: Readonly<Record<PluginTrustStatus, number>> = {
+  legacy: 0,
+  unconfirmed: 1,
+  trusted: 99,
+  denied: 99,
+};
 
 export interface PluginTrustDb {
   schemaVersion: number;
@@ -101,13 +117,52 @@ function ensureWmuxHomeDir(): void {
   }
 }
 
+// Drop the oldest evictable entries until the DB fits under `entryCap`.
+// Eviction order: 'legacy' before 'unconfirmed'; within a tier, smallest
+// `lastSeen` first. 'trusted' and 'denied' are protected — if user-issued
+// decisions alone exceed the cap, the DB is allowed to overflow rather
+// than discard user state. The DB is mutated in place.
+function evictIfOverCap(db: PluginTrustDb, entryCap: number): void {
+  const keys = Object.keys(db.plugins);
+  const overflow = keys.length - entryCap;
+  if (overflow <= 0) return;
+  const evictable: Array<{ key: string; status: PluginTrustStatus; lastSeen: number }> = [];
+  for (const key of keys) {
+    if (!Object.prototype.hasOwnProperty.call(db.plugins, key)) continue;
+    const rec = db.plugins[key];
+    if (rec.status === 'trusted' || rec.status === 'denied') continue;
+    evictable.push({ key, status: rec.status, lastSeen: rec.lastSeen });
+  }
+  evictable.sort((a, b) => {
+    const rank = EVICTION_RANK[a.status] - EVICTION_RANK[b.status];
+    if (rank !== 0) return rank;
+    return a.lastSeen - b.lastSeen;
+  });
+  for (let i = 0; i < overflow && i < evictable.length; i++) {
+    delete db.plugins[evictable[i].key];
+  }
+}
+
+export interface PluginTrustStoreOptions {
+  /** Override the DB-wide entry cap (default MAX_PLUGIN_TRUST_ENTRIES). */
+  entryCap?: number;
+}
+
 export class PluginTrustStore {
   private readonly path: string;
+  private readonly entryCap: number;
   private cache: PluginTrustDb | null = null;
   private writeChain: Promise<void> = Promise.resolve();
 
-  constructor(targetPath: string = getPluginTrustPath()) {
+  constructor(
+    targetPath: string = getPluginTrustPath(),
+    options: PluginTrustStoreOptions = {},
+  ) {
     this.path = targetPath;
+    this.entryCap =
+      typeof options.entryCap === 'number' && options.entryCap > 0
+        ? Math.floor(options.entryCap)
+        : MAX_PLUGIN_TRUST_ENTRIES;
   }
 
   // Read the on-disk DB, tolerating absence and corruption. Cached in
@@ -224,11 +279,15 @@ export class PluginTrustStore {
 
   // Serialise a mutation behind the write chain so two callers don't race
   // on `load → mutate → persist`. The mutator may read AND write the db
-  // in place; we then re-cache and persist atomically.
+  // in place; we then re-cache, evict any over-cap entries, and persist
+  // atomically. Eviction runs AFTER the mutator so a freshly-upserted
+  // record participates in the LRU comparison (its lastSeen is current,
+  // so it's never the oldest).
   private mutate<T>(mutator: (db: PluginTrustDb) => T): Promise<T> {
     const chained = this.writeChain.then(async () => {
       const db = await this.load();
       const result = mutator(db);
+      evictIfOverCap(db, this.entryCap);
       this.cache = db;
       ensureWmuxHomeDir();
       await atomicWriteJSON(this.path, db);

--- a/src/main/mcp/__tests__/PluginIdentity.test.ts
+++ b/src/main/mcp/__tests__/PluginIdentity.test.ts
@@ -52,17 +52,66 @@ describe('PluginIdentity trust-status invariant', () => {
     expect(applyContact(fresh, undefined).status).toBe('unconfirmed');
   });
 
-  it('applyDeclaration preserves trusted but replaces capabilities', () => {
-    // Escalation trap: this is the documented hazard for the enforcement PR.
-    // The trust-status invariant is preserved (status stays 'trusted'); the
-    // PR-level decision to also DEMOTE on widening lives in the follow-up.
+  it('applyDeclaration preserves trusted on identical re-declaration', () => {
+    const trusted = makeRecord({
+      status: 'trusted',
+      declaredCapabilities: ['pane.read', 'meta.write'],
+    });
+    const next = applyDeclaration(trusted, ['pane.read', 'meta.write']);
+    expect(next.status).toBe('trusted');
+    expect(next.declaredCapabilities).toEqual(['pane.read', 'meta.write']);
+  });
+
+  it('applyDeclaration preserves trusted when capabilities are narrowed', () => {
+    // Subset-of-approved is safe — the user already consented to a superset.
+    const trusted = makeRecord({
+      status: 'trusted',
+      declaredCapabilities: ['pane.read', 'meta.write', 'events.subscribe'],
+    });
+    const next = applyDeclaration(trusted, ['pane.read', 'meta.write']);
+    expect(next.status).toBe('trusted');
+    expect(next.declaredCapabilities).toEqual(['pane.read', 'meta.write']);
+  });
+
+  it('applyDeclaration demotes trusted → unconfirmed when capabilities widen', () => {
+    // Escalation trap closed: a trusted plugin cannot silently broaden its
+    // approved surface. The user must re-approve. Spec §2.3 / §4.3.
     const trusted = makeRecord({
       status: 'trusted',
       declaredCapabilities: ['pane.read'],
     });
     const next = applyDeclaration(trusted, ['pane.read', 'meta.write']);
-    expect(next.status).toBe('trusted');
+    expect(next.status).toBe('unconfirmed');
     expect(next.declaredCapabilities).toEqual(['pane.read', 'meta.write']);
+  });
+
+  it('applyDeclaration treats path-glob changes as widening at the string level', () => {
+    // String-set comparison: `meta.write:custom.x.*` and `meta.write:custom.y.*`
+    // are different strings even though both share the `meta.write` capability.
+    // Conservative: anything not present verbatim in the approved set is new.
+    const trusted = makeRecord({
+      status: 'trusted',
+      declaredCapabilities: ['meta.write:custom.x.*'],
+    });
+    const next = applyDeclaration(trusted, ['meta.write:custom.y.*']);
+    expect(next.status).toBe('unconfirmed');
+  });
+
+  it('applyDeclaration demotes trusted with missing declaredCapabilities', () => {
+    // Anomalous on-disk state (hand edit, schema drift): trusted without a
+    // recorded declaration cannot be trusted-by-inheritance for a fresh one.
+    const oddTrusted = makeRecord({ status: 'trusted' });
+    const next = applyDeclaration(oddTrusted, ['pane.read']);
+    expect(next.status).toBe('unconfirmed');
+  });
+
+  it('applyDeclaration leaves denied unchanged even on capability widening', () => {
+    const denied = makeRecord({
+      status: 'denied',
+      declaredCapabilities: ['pane.read'],
+    });
+    const next = applyDeclaration(denied, ['pane.read', 'meta.write']);
+    expect(next.status).toBe('denied');
   });
 
   it('applyDeclaration preserves denied', () => {

--- a/src/main/mcp/__tests__/PluginIdentity.test.ts
+++ b/src/main/mcp/__tests__/PluginIdentity.test.ts
@@ -85,6 +85,22 @@ describe('PluginIdentity trust-status invariant', () => {
     expect(next.declaredCapabilities).toEqual(['pane.read', 'meta.write']);
   });
 
+  it('applyDeclaration preserves trusted when only whitespace changes', () => {
+    // The handler trims wire-form permissions before passing them through,
+    // so applyDeclaration sees a canonical form on both sides. A trusted
+    // plugin that reformats its codegen template (e.g. adding a trailing
+    // space accidentally) must not lose trust over cosmetics. This test
+    // pins the *post-trim* equivalence — see mcp.rpc.ts:93-104 for the
+    // pre-applyDeclaration normalization step.
+    const trusted = makeRecord({
+      status: 'trusted',
+      declaredCapabilities: ['pane.read', 'meta.write:custom.x.*'],
+    });
+    // Same set, identical strings — applyDeclaration alone shouldn't demote.
+    const next = applyDeclaration(trusted, ['pane.read', 'meta.write:custom.x.*']);
+    expect(next.status).toBe('trusted');
+  });
+
   it('applyDeclaration treats path-glob changes as widening at the string level', () => {
     // String-set comparison: `meta.write:custom.x.*` and `meta.write:custom.y.*`
     // are different strings even though both share the `meta.write` capability.

--- a/src/main/mcp/__tests__/PluginTrustStore.test.ts
+++ b/src/main/mcp/__tests__/PluginTrustStore.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   MAX_PLUGIN_NAME_LEN,
+  MAX_PLUGIN_TRUST_ENTRIES,
   PLUGIN_TRUST_SCHEMA_VERSION,
   PluginTrustStore,
 } from '../PluginTrustStore';
@@ -200,5 +201,104 @@ describe('PluginTrustStore hostile-input hardening', () => {
     const store = new PluginTrustStore(dbPath);
     const list = await store.list();
     expect(list.map((p) => p.name)).toEqual(['good']);
+  });
+});
+
+describe('PluginTrustStore LRU eviction', () => {
+  // Forge an on-disk DB so we can plant entries with arbitrary lastSeen +
+  // status without going through the upsert helpers (which always stamp
+  // lastSeen = now()). This lets us assert eviction order deterministically.
+  function writeDb(
+    plugins: Array<{
+      name: string;
+      status: 'unconfirmed' | 'legacy' | 'trusted' | 'denied';
+      lastSeen: number;
+      firstSeen?: number;
+    }>,
+  ): void {
+    const db = {
+      schemaVersion: PLUGIN_TRUST_SCHEMA_VERSION,
+      plugins: Object.fromEntries(
+        plugins.map((p) => [
+          p.name,
+          {
+            name: p.name,
+            status: p.status,
+            firstSeen: p.firstSeen ?? p.lastSeen,
+            lastSeen: p.lastSeen,
+          },
+        ]),
+      ),
+    };
+    fs.writeFileSync(dbPath, JSON.stringify(db));
+  }
+
+  it('evicts the oldest unconfirmed entry when the cap is exceeded', async () => {
+    writeDb([
+      { name: 'oldest', status: 'unconfirmed', lastSeen: 100 },
+      { name: 'middle', status: 'unconfirmed', lastSeen: 200 },
+      { name: 'newest', status: 'unconfirmed', lastSeen: 300 },
+    ]);
+    const store = new PluginTrustStore(dbPath, { entryCap: 3 });
+    // Adding a fourth entry pushes the DB to 4; LRU brings it back to 3.
+    await store.upsertContact('fresh');
+    const list = await store.list();
+    const names = list.map((p) => p.name).sort();
+    expect(names).toEqual(['fresh', 'middle', 'newest']);
+  });
+
+  it('evicts legacy entries before unconfirmed regardless of lastSeen', async () => {
+    // 'legacy' rank < 'unconfirmed' rank — a very-recent legacy still goes
+    // first because the substrate trusts envelope-bearing contacts more.
+    writeDb([
+      { name: 'old-unconfirmed', status: 'unconfirmed', lastSeen: 100 },
+      { name: 'fresh-legacy', status: 'legacy', lastSeen: 999 },
+    ]);
+    const store = new PluginTrustStore(dbPath, { entryCap: 2 });
+    await store.upsertContact('newcomer');
+    const list = await store.list();
+    expect(list.map((p) => p.name).sort()).toEqual(['newcomer', 'old-unconfirmed']);
+  });
+
+  it('skips trusted entries when picking the eviction victim', async () => {
+    // Cap is 3, DB starts at 3, adding one tips it over by 1. The only
+    // evictable record (unconfirmed-c) goes; both trusted entries survive.
+    writeDb([
+      { name: 'trusted-a', status: 'trusted', lastSeen: 100 },
+      { name: 'trusted-b', status: 'trusted', lastSeen: 200 },
+      { name: 'unconfirmed-c', status: 'unconfirmed', lastSeen: 300 },
+    ]);
+    const store = new PluginTrustStore(dbPath, { entryCap: 3 });
+    await store.upsertContact('newcomer');
+    const list = await store.list();
+    const names = list.map((p) => p.name).sort();
+    expect(names).toEqual(['newcomer', 'trusted-a', 'trusted-b']);
+  });
+
+  it('never evicts denied entries (user decision is sticky)', async () => {
+    writeDb([
+      { name: 'denied-a', status: 'denied', lastSeen: 100 },
+      { name: 'unconfirmed-b', status: 'unconfirmed', lastSeen: 200 },
+    ]);
+    const store = new PluginTrustStore(dbPath, { entryCap: 1 });
+    await store.upsertContact('fresh');
+    const list = await store.list();
+    const names = list.map((p) => p.name).sort();
+    expect(names).toContain('denied-a');
+    expect(names).not.toContain('unconfirmed-b');
+  });
+
+  it('allows the DB to exceed the cap when only protected entries remain', async () => {
+    writeDb([
+      { name: 't1', status: 'trusted', lastSeen: 100 },
+      { name: 't2', status: 'trusted', lastSeen: 200 },
+      { name: 'd1', status: 'denied', lastSeen: 300 },
+    ]);
+    const store = new PluginTrustStore(dbPath, { entryCap: 1 });
+    // Touch one of the records via upsertContact (which mutates → triggers
+    // eviction). No evictable entry exists, so the DB stays as-is.
+    await store.upsertContact('t1');
+    const list = await store.list();
+    expect(list).toHaveLength(3);
   });
 });

--- a/src/main/mcp/__tests__/permissionGrammar.test.ts
+++ b/src/main/mcp/__tests__/permissionGrammar.test.ts
@@ -132,12 +132,29 @@ describe('permissionGrammar.parsePermissionList', () => {
     const result = parsePermissionList(['pane.read', 'bogus.capability']);
     expect(result.parsed).toHaveLength(1);
     expect(result.errors).toHaveLength(1);
-    expect(result.errors[0]).toMatch(/unknown capability/);
+    expect(result.errors[0].reason).toMatch(/unknown capability/);
+    // Per-entry rejection carries the original index + value verbatim so
+    // callers can render "permission #N is invalid" against the input.
+    expect(result.errors[0].index).toBe(1);
+    expect(result.errors[0].permission).toBe('bogus.capability');
   });
 
-  it('rejects non-array input', () => {
-    expect(parsePermissionList('pane.read').errors).toContain(
-      'permissions must be an array',
-    );
+  it('preserves non-string entries verbatim in the rejection record', () => {
+    // A plugin that sent a number where a string was expected should see
+    // the original value echoed back, not a coerced one.
+    const result = parsePermissionList(['pane.read', 42, null]);
+    expect(result.parsed).toHaveLength(1);
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0].index).toBe(1);
+    expect(result.errors[0].permission).toBe(42);
+    expect(result.errors[1].index).toBe(2);
+    expect(result.errors[1].permission).toBeNull();
+  });
+
+  it('rejects non-array input with a sentinel index of -1', () => {
+    const result = parsePermissionList('pane.read');
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].index).toBe(-1);
+    expect(result.errors[0].reason).toBe('permissions must be an array');
   });
 });

--- a/src/main/mcp/__tests__/phase-2-1-e2e.test.ts
+++ b/src/main/mcp/__tests__/phase-2-1-e2e.test.ts
@@ -24,7 +24,10 @@ import {
   PluginTrustStore,
 } from '../PluginTrustStore';
 import { registerMcpPluginRpc } from '../../pipe/handlers/mcp.rpc';
-import type { McpIdentifyResult } from '../../../shared/rpc';
+import type {
+  McpDeclarePermissionsResult,
+  McpIdentifyResult,
+} from '../../../shared/rpc';
 
 let tmpDir = '';
 let dbPath = '';
@@ -193,7 +196,9 @@ describe('phase 2.1 production wiring — multi-step RPC sequence', () => {
     }
 
     // === Step 6: malformed declarePermissions must NOT corrupt the DB.
-    // The entire declaration is rejected; no plugin entry is mutated.
+    // The RPC envelope succeeds (ok=true) but `result.ok=false` carries
+    // structured per-entry rejection — see McpDeclarePermissionsResult
+    // union in shared/rpc.ts.
     const beforeMalformed = readDbFromDisk();
     const malformed = await router.dispatch({
       id: 's6',
@@ -203,7 +208,17 @@ describe('phase 2.1 production wiring — multi-step RPC sequence', () => {
       },
       clientName: 'claude-ai',
     });
-    expect(malformed.ok).toBe(false);
+    expect(malformed.ok).toBe(true);
+    if (malformed.ok) {
+      const result = malformed.result as McpDeclarePermissionsResult;
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].index).toBe(1);
+        expect(result.errors[0].permission).toBe('made.up.capability');
+        expect(result.errors[0].reason).toMatch(/unknown capability/);
+      }
+    }
     await drainWrites();
     await settle();
     const afterMalformed = readDbFromDisk();
@@ -240,6 +255,61 @@ describe('phase 2.1 production wiring — multi-step RPC sequence', () => {
     // Trust-status invariant — the prior 'unconfirmed' from step 3 was
     // preserved across the declaration (no regression, no upgrade).
     expect(reloaded?.status).toBe('unconfirmed');
+  });
+
+  it('demotes a trusted plugin to unconfirmed when it widens its declared capabilities', async () => {
+    // First handshake + declaration establishes the unconfirmed entry.
+    await router.dispatch({
+      id: 't-1',
+      method: 'mcp.identify',
+      params: {},
+      clientName: 'demo-plugin',
+    });
+    await router.dispatch({
+      id: 't-2',
+      method: 'mcp.declarePermissions',
+      params: { permissions: ['pane.read'] },
+      clientName: 'demo-plugin',
+    });
+    await drainWrites();
+    await settle();
+
+    // Forge a user-approved 'trusted' state on disk — no UI in this PR.
+    // The next read goes through atomicReadJSON; invalidate the in-memory
+    // cache so the trust DB picks up our manual edit.
+    const raw = JSON.parse(fs.readFileSync(dbPath, 'utf8'));
+    raw.plugins['demo-plugin'].status = 'trusted';
+    fs.writeFileSync(dbPath, JSON.stringify(raw));
+    store.invalidateCache();
+
+    // Widen the declaration — adds a capability the user never approved.
+    // Spec §2.3 / §4.3: status must demote so the user re-approves.
+    const widened = await router.dispatch({
+      id: 't-3',
+      method: 'mcp.declarePermissions',
+      params: { permissions: ['pane.read', 'meta.write'] },
+      clientName: 'demo-plugin',
+    });
+    expect(widened.ok).toBe(true);
+    await drainWrites();
+    await settle();
+
+    const onDisk = readDbFromDisk();
+    expect(onDisk.plugins['demo-plugin'].status).toBe('unconfirmed');
+
+    // A subsequent re-declaration that stays within the previously-approved
+    // surface (subset of original ['pane.read']) does NOT re-promote — only
+    // the user can move out of 'unconfirmed'.
+    await router.dispatch({
+      id: 't-4',
+      method: 'mcp.declarePermissions',
+      params: { permissions: ['pane.read'] },
+      clientName: 'demo-plugin',
+    });
+    await drainWrites();
+    await settle();
+    const onDiskAfterNarrow = readDbFromDisk();
+    expect(onDiskAfterNarrow.plugins['demo-plugin'].status).toBe('unconfirmed');
   });
 
   it('survives a corrupt disk file by loading empty and overwriting on next write', async () => {

--- a/src/main/mcp/permissionGrammar.ts
+++ b/src/main/mcp/permissionGrammar.ts
@@ -122,21 +122,41 @@ export function parsePermission(spec: unknown): PermissionParseResult {
   return { ok: true, permission: parsed };
 }
 
+// Per-entry rejection emitted by `parsePermissionList`. Carries enough
+// detail for the caller to point at the offending element in the original
+// input — the position survives across the wire so plugins can render
+// "permission #2 is unknown" instead of guessing.
+export interface PermissionParseError {
+  /**
+   * Index into the original input array. `-1` is reserved for the
+   * top-level "input is not an array" error which has no per-entry context.
+   */
+  index: number;
+  /** The original input value, unchanged — `unknown` to surface non-strings. */
+  permission: unknown;
+  /** Human-readable explanation from `parsePermission`. */
+  reason: string;
+}
+
 export interface PermissionListParseResult {
   parsed: ParsedPermission[];
-  errors: string[];
+  errors: PermissionParseError[];
 }
 
 export function parsePermissionList(input: unknown): PermissionListParseResult {
   if (!Array.isArray(input)) {
-    return { parsed: [], errors: ['permissions must be an array'] };
+    return {
+      parsed: [],
+      errors: [{ index: -1, permission: input, reason: 'permissions must be an array' }],
+    };
   }
   const parsed: ParsedPermission[] = [];
-  const errors: string[] = [];
-  for (const entry of input) {
+  const errors: PermissionParseError[] = [];
+  for (let i = 0; i < input.length; i++) {
+    const entry = input[i];
     const result = parsePermission(entry);
     if (result.ok) parsed.push(result.permission);
-    else errors.push(result.error);
+    else errors.push({ index: i, permission: entry, reason: result.error });
   }
   return { parsed, errors };
 }

--- a/src/main/pipe/handlers/__tests__/mcp.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/mcp.rpc.test.ts
@@ -113,6 +113,8 @@ describe('mcp.declarePermissions', () => {
     expect(response.ok).toBe(true);
     if (!response.ok) return;
     const result = response.result as McpDeclarePermissionsResult;
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
     expect(result.accepted).toEqual([
       'pane.read',
       'meta.write:custom.dashboard.*',
@@ -121,20 +123,46 @@ describe('mcp.declarePermissions', () => {
     expect(result.identity.rationale).toBe('demo');
   });
 
-  it('rejects the entire declaration on any grammar error', async () => {
+  it('rejects the entire declaration with structured per-entry errors', async () => {
+    // RPC envelope stays ok=true (the call itself succeeded); application
+    // outcome is `result.ok=false` with per-entry rejection detail.
     const response = await router.dispatch({
       id: 'r-5',
       method: 'mcp.declarePermissions',
       params: {
-        permissions: ['pane.read', 'pane.teleport'],
+        permissions: ['pane.read', 'pane.teleport', 42],
       },
       clientName: 'demo-plugin',
     });
-    expect(response.ok).toBe(false);
-    if (response.ok) return;
-    expect(response.error).toMatch(/unknown capability/);
+    expect(response.ok).toBe(true);
+    if (!response.ok) return;
+    const result = response.result as McpDeclarePermissionsResult;
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0].index).toBe(1);
+    expect(result.errors[0].permission).toBe('pane.teleport');
+    expect(result.errors[0].reason).toMatch(/unknown capability/);
+    expect(result.errors[1].index).toBe(2);
+    expect(result.errors[1].permission).toBe(42);
     // Nothing should have been persisted under the rejected name
     expect(await store.get('demo-plugin')).toBeUndefined();
+  });
+
+  it('returns a structured rejection when permissions is not an array', async () => {
+    const response = await router.dispatch({
+      id: 'r-5b',
+      method: 'mcp.declarePermissions',
+      params: { permissions: 'pane.read' as unknown as string[] },
+      clientName: 'demo-plugin',
+    });
+    expect(response.ok).toBe(true);
+    if (!response.ok) return;
+    const result = response.result as McpDeclarePermissionsResult;
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors[0].index).toBe(-1);
+    expect(result.errors[0].reason).toBe('permissions must be an array');
   });
 
   it('records the caller under "unknown" when no clientName is present', async () => {
@@ -152,6 +180,8 @@ describe('mcp.declarePermissions', () => {
     expect(response.ok).toBe(true);
     if (!response.ok) return;
     const result = response.result as McpDeclarePermissionsResult;
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
     expect(result.identity.name).toBe('unknown');
     expect(result.identity.status).toBe('unconfirmed');
   });

--- a/src/main/pipe/handlers/__tests__/mcp.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/mcp.rpc.test.ts
@@ -149,6 +149,69 @@ describe('mcp.declarePermissions', () => {
     expect(await store.get('demo-plugin')).toBeUndefined();
   });
 
+  it('trims wire-form whitespace before persisting the declaration', async () => {
+    // The handler must normalize leading/trailing whitespace so that a
+    // trusted plugin re-declaring `'pane.read '` doesn't trigger spurious
+    // widening demotion (set-diff would see the formatted-vs-unformatted
+    // strings as different capabilities). Spec §4.2 — substrate stores the
+    // trimmed form, not the wire form.
+    const response = await router.dispatch({
+      id: 'r-trim',
+      method: 'mcp.declarePermissions',
+      params: {
+        permissions: ['  pane.read', 'meta.write:custom.x.*  ', '\tevents.subscribe\n'],
+      },
+      clientName: 'demo-plugin',
+    });
+    expect(response.ok).toBe(true);
+    if (!response.ok) return;
+    const result = response.result as McpDeclarePermissionsResult;
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.accepted).toEqual([
+      'pane.read',
+      'meta.write:custom.x.*',
+      'events.subscribe',
+    ]);
+    expect(result.identity.declaredCapabilities).toEqual(result.accepted);
+  });
+
+  it('does not demote a trusted plugin when re-declaring with whitespace differences', async () => {
+    // F-1 end-to-end: declare → forge trusted on disk → re-declare with
+    // cosmetic whitespace changes → assert still trusted. This guards the
+    // template-reformat regression path the cross-model review surfaced.
+    await router.dispatch({
+      id: 'r-trim-1',
+      method: 'mcp.declarePermissions',
+      params: { permissions: ['pane.read', 'meta.write:custom.x.*'] },
+      clientName: 'trim-test',
+    });
+    // Forge trusted on disk (no user-approval UI yet in this PR).
+    const persisted = await store.get('trim-test');
+    expect(persisted).toBeDefined();
+    if (!persisted) return;
+    // Write through the store's mutate path to keep cache/disk consistent.
+    const raw = JSON.parse(fs.readFileSync(dbPath, 'utf8'));
+    raw.plugins['trim-test'].status = 'trusted';
+    fs.writeFileSync(dbPath, JSON.stringify(raw));
+    store.invalidateCache();
+
+    // Same capability set, just reformatted with whitespace.
+    const reDeclare = await router.dispatch({
+      id: 'r-trim-2',
+      method: 'mcp.declarePermissions',
+      params: { permissions: ['  pane.read  ', '\tmeta.write:custom.x.*\n'] },
+      clientName: 'trim-test',
+    });
+    expect(reDeclare.ok).toBe(true);
+    if (!reDeclare.ok) return;
+    const result = reDeclare.result as McpDeclarePermissionsResult;
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Trust survives the cosmetic re-declaration.
+    expect(result.identity.status).toBe('trusted');
+  });
+
   it('returns a structured rejection when permissions is not an array', async () => {
     const response = await router.dispatch({
       id: 'r-5b',

--- a/src/main/pipe/handlers/mcp.rpc.ts
+++ b/src/main/pipe/handlers/mcp.rpc.ts
@@ -60,15 +60,30 @@ export function registerMcpPluginRpc(
   // needs. Parses against the wmuxPermissions grammar; rejects the whole
   // declaration if any entry is malformed so plugins can't half-declare
   // and accidentally exclude themselves from future enforcement.
+  //
+  // Returns the structured McpDeclarePermissionsResult union — RPC envelope
+  // stays `ok: true` (the call itself succeeded) while application-level
+  // outcome rides in `result.ok`. This lets plugins see per-entry rejection
+  // detail (index + reason) without the wire envelope growing JSON-RPC
+  // error-data support. Spec §4.2.
   router.register('mcp.declarePermissions', async (rawParams, ctx) => {
     const params = (rawParams ?? {}) as Partial<McpDeclarePermissionsParams>;
     const { name } = resolveCallerName(ctx, undefined);
 
     const list = parsePermissionList(params.permissions);
     if (list.errors.length > 0) {
-      throw new Error(
-        `mcp.declarePermissions rejected: ${list.errors.join('; ')}`,
-      );
+      // Whole-declaration rejection: do NOT persist anything under `name`.
+      // Plugins re-submit a corrected declaration; partial state would
+      // confuse the future user-approval prompt.
+      const rejection: McpDeclarePermissionsResult = {
+        ok: false,
+        errors: list.errors.map((e) => ({
+          index: e.index,
+          permission: e.permission,
+          reason: e.reason,
+        })),
+      };
+      return rejection;
     }
 
     // Echo capability strings the plugin sent. We persist the raw input

--- a/src/main/pipe/handlers/mcp.rpc.ts
+++ b/src/main/pipe/handlers/mcp.rpc.ts
@@ -86,12 +86,20 @@ export function registerMcpPluginRpc(
       return rejection;
     }
 
-    // Echo capability strings the plugin sent. We persist the raw input
-    // (not the parsed shape) so future PRs can re-parse against an updated
-    // grammar without losing the declaration. `parsed` is used only to
+    // Echo capability strings the plugin sent, trimmed of leading/trailing
+    // whitespace. We persist the trimmed form (not a fully canonical parse)
+    // so future PRs can re-parse against an updated grammar without losing
+    // the declaration. Trimming closes a widening false-positive: the
+    // grammar parser already trims for validation (parsePermission line 88),
+    // so storing the untrimmed wire form would make set-difference in
+    // applyDeclaration treat `'pane.read '` and `'pane.read'` as distinct
+    // capabilities and spuriously demote `trusted` plugins that reformat
+    // their codegen templates between handshakes. `parsed` is used only to
     // confirm grammar acceptance; enforcement comes later.
     const accepted = Array.isArray(params.permissions)
-      ? params.permissions.filter((p): p is string => typeof p === 'string')
+      ? params.permissions
+          .filter((p): p is string => typeof p === 'string')
+          .map((p) => p.trim())
       : [];
     const rationale =
       typeof params.rationale === 'string' ? params.rationale : undefined;

--- a/src/mcp/__tests__/wmux-client.identity.test.ts
+++ b/src/mcp/__tests__/wmux-client.identity.test.ts
@@ -1,0 +1,49 @@
+// Identity-envelope round-trip for the MCP-side wmux-client wrapper.
+//
+// Verifies that:
+//   1. `setClientIdentity` populates the module-scoped name/version.
+//   2. `clearClientIdentity` resets them to undefined — so post-close RPCs
+//      stamp an envelope-less request and substrate records them as legacy.
+//   3. Whitespace-only inputs are treated as empty (no envelope stamping).
+//
+// We assert on `getClientIdentity` rather than spying on the wire because
+// `attemptRpc` opens a real socket; the in-process getter mirrors the same
+// module state that `attemptRpc` reads when building the envelope.
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  clearClientIdentity,
+  getClientIdentity,
+  setClientIdentity,
+} from '../wmux-client';
+
+describe('wmux-client declared identity', () => {
+  beforeEach(() => {
+    clearClientIdentity();
+  });
+
+  it('round-trips name and version through setClientIdentity', () => {
+    setClientIdentity('claude-ai', '1.0.94');
+    expect(getClientIdentity()).toEqual({ name: 'claude-ai', version: '1.0.94' });
+  });
+
+  it('clearClientIdentity wipes both fields back to undefined', () => {
+    setClientIdentity('claude-ai', '1.0.94');
+    clearClientIdentity();
+    expect(getClientIdentity()).toEqual({ name: undefined, version: undefined });
+  });
+
+  it('treats whitespace-only strings as empty', () => {
+    // Defensive against an MCP host that ships clientInfo with padding —
+    // an envelope with `clientName: "   "` is worse than no envelope at
+    // all because it bypasses the legacy audit path on the wmux side.
+    setClientIdentity('   ', '\t\n');
+    expect(getClientIdentity()).toEqual({ name: undefined, version: undefined });
+  });
+
+  it('clearClientIdentity is idempotent', () => {
+    clearClientIdentity();
+    clearClientIdentity();
+    expect(getClientIdentity()).toEqual({ name: undefined, version: undefined });
+  });
+});

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -2,7 +2,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { sendRpc, setClientIdentity } from './wmux-client';
+import { clearClientIdentity, sendRpc, setClientIdentity } from './wmux-client';
 import type { RpcMethod } from '../shared/rpc';
 import { resolveDefaultPtyId as resolveDefaultPtyIdImpl } from './paneResolver';
 import { PlaywrightEngine } from './playwright/PlaywrightEngine';
@@ -656,9 +656,14 @@ async function main(): Promise<void> {
   wireClientIdentityHook();
   await server.connect(transport);
 
-  // Clean up Playwright connection when transport closes
+  // Clean up Playwright connection when transport closes. Also drop the
+  // declared plugin identity so any trailing RPC traffic falls back to
+  // the substrate's legacy audit path instead of stamping a stale name —
+  // a reconnect must re-run the MCP initialize handshake to re-establish
+  // identity (see wireClientIdentityHook above).
   transport.onclose = async () => {
     console.log('[wmux-mcp] Transport closed, disconnecting Playwright');
+    clearClientIdentity();
     await PlaywrightEngine.getInstance().disconnect();
   };
 

--- a/src/mcp/wmux-client.ts
+++ b/src/mcp/wmux-client.ts
@@ -23,6 +23,18 @@ export function setClientIdentity(name?: string, version?: string): void {
   CLIENT_VERSION = trimmedVersion.length > 0 ? trimmedVersion : undefined;
 }
 
+// Drop the declared identity so any further outbound RPC stamps an
+// envelope-less request and falls through to the substrate's `legacy`
+// audit path. Called from the MCP transport.onclose handler — after the
+// transport tears down, an old name lingering in module scope would
+// misattribute trailing RPC traffic (e.g. cleanup work) to a plugin that
+// has already disconnected. A reconnect must re-run the initialize
+// handshake to re-establish identity, which is the intended contract.
+export function clearClientIdentity(): void {
+  CLIENT_NAME = undefined;
+  CLIENT_VERSION = undefined;
+}
+
 export function getClientIdentity(): { name?: string; version?: string } {
   return { name: CLIENT_NAME, version: CLIENT_VERSION };
 }

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -425,12 +425,38 @@ export interface McpDeclarePermissionsParams {
   rationale?: string;
 }
 
-export interface McpDeclarePermissionsResult {
-  ok: true;
-  identity: PluginIdentityRecord;
-  /**
-   * Parsed permission echoes — useful for clients verifying that wmux
-   * accepted the grammar they sent. Order matches `params.permissions`.
-   */
-  accepted: string[];
+/**
+ * Per-entry rejection surfaced through `McpDeclarePermissionsResult` when
+ * the declaration is rejected. Plugins can map `index` back to the entry
+ * they sent, see the original (possibly non-string) value, and render the
+ * reason inline next to it. `index = -1` is reserved for the top-level
+ * "permissions is not an array" error which has no per-entry context.
+ */
+export interface PermissionRejection {
+  index: number;
+  permission: unknown;
+  reason: string;
 }
+
+/**
+ * Result of `mcp.declarePermissions`. The union shape lets plugins receive
+ * structured per-entry feedback on rejection without the wire envelope
+ * having to grow JSON-RPC error-data support. Acceptance carries the
+ * identity record and the echoed capability list; rejection carries one
+ * `PermissionRejection` per malformed entry. Whole-declaration rejection
+ * is preserved — `accepted` only appears when every entry parsed.
+ */
+export type McpDeclarePermissionsResult =
+  | {
+      ok: true;
+      identity: PluginIdentityRecord;
+      /**
+       * Parsed permission echoes — useful for clients verifying that wmux
+       * accepted the grammar they sent. Order matches `params.permissions`.
+       */
+      accepted: string[];
+    }
+  | {
+      ok: false;
+      errors: PermissionRejection[];
+    };


### PR DESCRIPTION
## Summary

Tightens four trust-DB invariants left as TODOs by PR #48 (record-only identity + permission grammar). All four close enforcement-PR prerequisites without yet introducing method-dispatch enforcement.

Tracks against #31 Phase 2 → `docs/api/mcp-plugin-spec.md` hardening + permission-record durability before the enforcement PR.

## What changed (4 invariants)

### 1. `applyDeclaration` trusted-widening demote
String-set diff on raw permission strings: any capability not present in the previously approved `declaredCapabilities` drops status `trusted → unconfirmed`. Subset / identical re-declarations preserve `trusted`. `denied` never regresses. Anomalous `trusted` with no prior declaration is treated as widening (defensive).

`src/main/mcp/PluginIdentity.ts:86-127` (new `isWidenedDeclaration` + updated `applyDeclaration`)

### 2. `PluginTrustStore` LRU eviction
`MAX_PLUGIN_TRUST_ENTRIES = 1024`. New `evictIfOverCap` runs after every mutator. Eviction order: `legacy` first (rank 0), then `unconfirmed` (rank 1), both by oldest `lastSeen`. `trusted`/`denied` exempt — user state can overflow cap.

`src/main/mcp/PluginTrustStore.ts:35-58, 125-144, 188-201`

### 3. `mcp.declarePermissions` structured rejection
`McpDeclarePermissionsResult` is now a discriminated union: `{ok:true, identity, accepted}` | `{ok:false, errors:[{index, permission, reason}]}`. `parsePermissionList` tracks per-entry index. Top-level "not an array" error uses `index: -1` sentinel. RPC envelope stays `ok=true`; application outcome rides in `result.ok`. No partial accept.

`src/shared/rpc.ts` (union type) + `src/main/pipe/handlers/mcp.rpc.ts` + `src/main/mcp/permissionGrammar.ts`

### 4. `clearClientIdentity` on MCP transport close
New export. `transport.onclose` handler in MCP entry point now calls it (alongside existing Playwright disconnect) so trailing RPC traffic stamps envelope-less and falls back to substrate's legacy audit path.

`src/mcp/wmux-client.ts:26-37` + `src/mcp/index.ts:660-668`

## F-1 follow-up fix (second commit)

Cross-model review surfaced a whitespace-sensitivity bug in the widening detector: the grammar parser trimmed for validation but the handler persisted the untrimmed wire form, so `'pane.read '` and `'pane.read'` were treated as distinct capabilities. A trusted plugin reformatting its codegen template would lose trust over cosmetics. Fix: trim each entry at the handler boundary so storage matches the parsed form.

`src/main/pipe/handlers/mcp.rpc.ts:93-104` (`.map((p) => p.trim())`)

## Tests

- Suite: 1306 → **1326** (+20). 0 regression.
- TS: `npx tsc --noEmit` clean.
- New unit coverage: widening matrix (`PluginIdentity.test.ts`), LRU eviction tiers + protected-overflow (`PluginTrustStore.test.ts`), structured error shape + non-string preservation (`permissionGrammar.test.ts`), union narrowing + partial + top-level rejection (`mcp.rpc.test.ts`), set/clear/whitespace/idempotent (`wmux-client.identity.test.ts` — new file).
- New e2e: forge-trusted-on-disk → widen via RPC dispatch → assert demoted (`phase-2-1-e2e.test.ts:260-313`).
- F-1 regression test: forge-trusted-on-disk + re-declare with whitespace-only diff → trust survives (`mcp.rpc.test.ts`).

## Cross-model review

| Reviewer | Verdict | Findings |
|---|---|---|
| codex (`/codex review --base main`) | **PASS** | 0 |
| Claude code-reviewer agent | **PASS_WITH_NITS** | 7×[P3], 0×[P1]/[P2] |

Claude single-finder F-1 (whitespace sensitivity) fixed in commit 2. Remaining 6 nits tracked as follow-ups (see below) — none ship-blocking.

## Docs

- `docs/api/mcp-plugin-spec.md` Draft 2: §2.3 widening row rewritten + new LRU row, §4.2 union shape, §4.3 transition matrix, §8.1 transport-close contract, §4.2 whitespace normalization note (from F-1).
- `docs/PROTOCOL.md` Draft 3: §4.2 trust-DB invariants subsection.

## Out of scope (next PR)

Method-dispatch / metadata-path / event-subscription enforcement. Trust-DB invariants are now strong enough that the enforcement PR can read them as authoritative.

## Follow-up items ([P3] from cross-model review)

These ship as separate issues — none block this PR:

- **F-2** anomalous trusted-no-prior-declaration corner case (comment vs implementation alignment).
- **F-3** LRU abuse vector — defensive eviction floor / hot pool (spec §2.3 documents the threat; mitigation deferred).
- **F-4** `docs/api/stability.md` note on the envelope-vs-result semantic shift.
- **F-5** SIGTERM/SIGINT path doesn't explicitly call `clearClientIdentity` (process is exiting; doc accuracy nit).
- **F-6** integration test for `transport.onclose → clearClientIdentity` wiring (two-line plumbing currently unit-tested at module level).
- **F-7** explicit test for LRU eviction under concurrent `writeChain` mutate serialization (implicitly correct but not asserted).

## Test plan

- [x] `npm test` — 1326 passed
- [x] `npx tsc --noEmit` — clean
- [x] `codex review --base main` — PASS
- [x] Claude code-reviewer cross-model — PASS_WITH_NITS (all [P3])
- [x] F-1 fix verified via dedicated whitespace re-declaration test
- [ ] External reviewer pass (@alphabeen or other Phase 2 reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)