### PR TITLE
fix(mcp/terminal_send): add optional `submit` flag to commit text with Enter

### DIFF
--- a/src/main/pipe/handlers/input.rpc.ts
+++ b/src/main/pipe/handlers/input.rpc.ts
@@ -107,21 +107,30 @@ export function registerInputRpc(
     await assertWorkspaceOwnsPty(getWindow, ptyId, callerWs, 'input.send');
 
     const safeText = params['raw'] === true ? text : sanitizePtyText(text);
+    // submit=true appends \r so the text is committed (Enter pressed). We do
+    // not append when the sanitized text already ends in \r to avoid a stray
+    // empty submit. Carriage return is the canonical commit byte for both
+    // line-mode shells and TUI input widgets (xterm/Claude Code/REPLs); \n
+    // would land as a soft newline in the input widget instead.
+    const payload =
+      params['submit'] === true && !safeText.endsWith('\r')
+        ? safeText + '\r'
+        : safeText;
 
     // Try local PTYManager first, then daemon
     const instance = ptyManager.get(ptyId);
     if (instance) {
-      ptyManager.write(ptyId, safeText);
+      ptyManager.write(ptyId, payload);
     } else {
       const dc = getDaemonClient?.();
       if (dc?.isConnected) {
-        dc.writeToSession(ptyId, safeText);
+        dc.writeToSession(ptyId, payload);
       } else {
         throw new Error(`input.send: PTY not found — id="${ptyId}"`);
       }
     }
 
-    return { ok: true, ptyId };
+    return { ok: true, ptyId, submitted: params['submit'] === true };
   });
 
   /**

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -239,15 +239,19 @@ server.tool(
 
 server.tool(
   'terminal_send',
-  'Send text to a terminal. Omit ptyId to target the active terminal. Use surface_list() to discover available PTY IDs. To send messages to OTHER workspaces, use a2a_task_send or a2a_broadcast instead.',
+  'Send text to a terminal. By default the text is written as-is — no Enter is pressed, so a shell command or TUI chat prompt will sit on the input line without being committed. Pass `submit: true` to append a carriage return (\\r) so the text is committed, equivalent to pressing Enter. Omit ptyId to target the active terminal. Use surface_list() to discover available PTY IDs. To send messages to OTHER workspaces, use a2a_task_send or a2a_broadcast instead.',
   {
     text: z.string().describe('Text to send to the terminal'),
     ptyId: z.string().optional().describe('Target a specific terminal by PTY ID. Omit to use the active terminal. Get PTY IDs from surface_list().'),
+    submit: z.boolean().optional().describe('When true, append a carriage return (\\r) after the text so it is committed — equivalent to pressing Enter. Use this for shell commands and TUI chat prompts (e.g. Claude Code, REPLs). Default: false (text is written as-is; you must call terminal_send_key({ key: "enter" }) separately to commit).'),
   },
-  async ({ text, ptyId }) => {
+  async ({ text, ptyId, submit }) => {
     const workspaceId = await requireWorkspaceId();
     const effective = ptyId ?? (await resolveDefaultPtyId()) ?? undefined;
-    return callRpc('input.send', effective ? { text, ptyId: effective, workspaceId } : { text, workspaceId });
+    const base: Record<string, unknown> = { text, workspaceId };
+    if (effective) base.ptyId = effective;
+    if (submit) base.submit = true;
+    return callRpc('input.send', base);
   },
 );
 


### PR DESCRIPTION
## Summary

- `terminal_send` previously wrote text to the target PTY as-is, with no carriage return. Agents using it to push a shell command or a TUI chat prompt (e.g. into another Claude Code pane) saw the text land on the input line and stay there — no Enter pressed, just a soft newline.
- Add `submit?: boolean` (default `false`, so existing behavior is preserved). When `true`, the `input.send` RPC appends a single `\r` to the sanitized text, guarded against double-submit when the caller already terminates with `\r`. The RPC response exposes a `submitted` flag so callers can confirm commit semantics.
- No other tools change. `terminal_send_key({ key: "enter" })` remains available for callers that want to keep paste and commit decoupled.

## Behavior

| Call | Bytes written to PTY |
|------|----------------------|
| `terminal_send({ text: "ls" })` | `ls` (legacy, unchanged) |
| `terminal_send({ text: "ls", submit: true })` | `ls\r` (Enter committed) |
| `terminal_send({ text: "ls\r", submit: true })` | `ls\r` (no double `\r`) |

## Test plan

- [x] `tsc --noEmit` clean (full project + MCP project)
- [x] `eslint` on changed files — no new errors
- [x] `vitest run` — 1308 pass; the single failure (`ProcessMonitor.test.ts > watch calls onDead when process does not exist`) is a pre-existing Windows-only `node-pty` `AttachConsole` flake unrelated to this change
- [x] Dev dogfood: ran `npm start` against a multi-pane workspace, called `terminal_send({ submit: true })` from one pane into a Claude Code pane in another — message was committed; `submit: false` / omitted reproduced the legacy "text only" behavior

## Notes

- Default is `false` on purpose: callers that already split paste and Enter (existing `terminal_send` + `terminal_send_key` flows, A2A `silent` mode) keep working with no change.
- Carriage return (`\r`) is the canonical commit byte for both line-mode shells and TUI input widgets (xterm / Claude Code / REPLs). `\n` would land as a soft newline inside the input widget instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)