### PR TITLE
feat(terminal): Ctrl+click absolute paths to open in OS file manager

### DIFF
--- a/src/main/ipc/handlers/__tests__/shell.handler.openPath.test.ts
+++ b/src/main/ipc/handlers/__tests__/shell.handler.openPath.test.ts
@@ -1,0 +1,197 @@
+/**
+ * shell.handler — `openPath` channel.
+ *
+ * Verifies that:
+ *   • absolute paths are forwarded to Electron's shell.openPath
+ *   • relative paths, NUL bytes, non-strings, length overflow are rejected
+ *   • path.normalize is applied (so `..` collapses before isAbsolute check)
+ *   • openPath returning an error string triggers showItemInFolder fallback
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Module mocks (hoisted; cannot reference outer test variables) ──────────
+
+vi.mock('electron', () => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  const openPath = vi.fn();
+  const showItemInFolder = vi.fn();
+  const openExternal = vi.fn();
+  const ipcMain = {
+    handle: vi.fn((channel: string, fn: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, fn);
+    }),
+    removeHandler: vi.fn((channel: string) => {
+      handlers.delete(channel);
+    }),
+  };
+  return {
+    ipcMain,
+    shell: { openPath, showItemInFolder, openExternal },
+    __handlers: handlers,
+    __openPath: openPath,
+    __showItemInFolder: showItemInFolder,
+  };
+});
+
+// ShellDetector is constructed at handler registration time. Stub the
+// constructor so the test doesn't drag in pty discovery side effects.
+// Use a plain class — vi.fn().mockImplementation does not produce a real
+// constructor and would fail `new ShellDetector()`.
+vi.mock('../../../pty/ShellDetector', () => ({
+  ShellDetector: class {
+    detect() {
+      return Promise.resolve([]);
+    }
+  },
+}));
+
+import * as electron from 'electron';
+import { registerShellHandlers } from '../shell.handler';
+import { IPC } from '../../../../shared/constants';
+
+const handlers = (electron as unknown as { __handlers: Map<string, (...a: unknown[]) => unknown> }).__handlers;
+const openPath = (electron as unknown as { __openPath: ReturnType<typeof vi.fn> }).__openPath;
+const showItemInFolder = (electron as unknown as { __showItemInFolder: ReturnType<typeof vi.fn> }).__showItemInFolder;
+
+function getHandler(channel: string): (...args: unknown[]) => unknown {
+  const fn = handlers.get(channel);
+  if (!fn) throw new Error(`no handler for ${channel}`);
+  return fn;
+}
+
+let cleanup: (() => void) | null = null;
+
+beforeEach(() => {
+  handlers.clear();
+  openPath.mockReset();
+  showItemInFolder.mockReset();
+  // Default: openPath succeeds (empty error string).
+  openPath.mockResolvedValue('');
+  cleanup = registerShellHandlers();
+});
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = null;
+});
+
+describe('shell.handler — SHELL_OPEN_PATH', () => {
+  const fakeEvent = {} as Electron.IpcMainInvokeEvent;
+
+  it('forwards an absolute POSIX-style path on a POSIX host', async () => {
+    if (process.platform === 'win32') return; // path.isAbsolute is OS-aware
+    const handler = getHandler(IPC.SHELL_OPEN_PATH);
+    const result = await handler(fakeEvent, '/etc/hosts');
+    expect(openPath).toHaveBeenCalledWith('/etc/hosts');
+    expect(result).toEqual({ ok: true, error: undefined });
+    expect(showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it('forwards a Windows drive path on a Windows host', async () => {
+    if (process.platform !== 'win32') return;
+    const handler = getHandler(IPC.SHELL_OPEN_PATH);
+    const result = await handler(fakeEvent, 'C:\\Users\\rizz\\file.txt');
+    expect(openPath).toHaveBeenCalledWith('C:\\Users\\rizz\\file.txt');
+    expect(result).toEqual({ ok: true, error: undefined });
+  });
+
+  it('rejects a non-string argument', async () => {
+    const handler = getHandler(IPC.SHELL_OPEN_PATH);
+    await expect(handler(fakeEvent, 42 as unknown as string)).rejects.toThrow(/string/);
+    expect(openPath).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty string', async () => {
+    const handler = getHandler(IPC.SHELL_OPEN_PATH);
+    await expect(handler(fakeEvent, '')).rejects.toThrow(/length/);
+    expect(openPath).not.toHaveBeenCalled();
+  });
+
+  it('rejects an overlong path', async () => {
+    const handler = getHandler(IPC.SHELL_OPEN_PATH);
+    const huge = (process.platform === 'win32' ? 'C:\\' : '/') + 'a'.repeat(5000);
+    await expect(handler(fakeEvent, huge)).rejects.toThrow(/length/);
+    expect(openPath).not.toHaveBeenCalled();
+  });
+
+  it('rejects a path with NUL bytes', async () => {
+    const handler = getHandler(IPC.SHELL_OPEN_PATH);
+    const evil = (process.platform === 'win32' ? 'C:\\foo\0bar' : '/foo\0bar');
+    await expect(handler(fakeEvent, evil)).rejects.toThrow(/NUL/);
+    expect(openPath).not.toHaveBeenCalled();
+  });
+
+  it('rejects a relative path', async () => {
+    const handler = getHandler(IPC.SHELL_OPEN_PATH);
+    await expect(handler(fakeEvent, 'relative/path/file.txt')).rejects.toThrow(/absolute/);
+    expect(openPath).not.toHaveBeenCalled();
+  });
+
+  it('normalizes the path before forwarding (collapses `..`)', async () => {
+    const handler = getHandler(IPC.SHELL_OPEN_PATH);
+    const input = process.platform === 'win32' ? 'C:\\foo\\..\\bar' : '/foo/../bar';
+    const expected = process.platform === 'win32' ? 'C:\\bar' : '/bar';
+    await handler(fakeEvent, input);
+    expect(openPath).toHaveBeenCalledWith(expected);
+  });
+
+  it('falls back to showItemInFolder when openPath returns an error', async () => {
+    openPath.mockResolvedValueOnce('Failed to open path');
+    const handler = getHandler(IPC.SHELL_OPEN_PATH);
+    const input = process.platform === 'win32' ? 'C:\\does-not-exist' : '/does-not-exist';
+    const result = await handler(fakeEvent, input);
+    expect(showItemInFolder).toHaveBeenCalledWith(input);
+    expect(result).toEqual({ ok: false, error: 'Failed to open path' });
+  });
+
+  describe('executable extension blocklist', () => {
+    // Each entry: the renderer-supplied path → the normalized form main
+    // sends to showItemInFolder. Windows hosts normalize forward slashes
+    // to backslashes; POSIX hosts leave the input unchanged.
+    const expectNormalized = (input: string) =>
+      process.platform === 'win32' ? input.replace(/\//g, '\\') : input;
+
+    const blockedSamples = [
+      '.exe', '.bat', '.cmd', '.com', '.scr', '.pif', '.ps1',
+      '.vbs', '.vbe', '.js', '.jse', '.wsf', '.wsh', '.msi',
+      '.reg', '.lnk', '.hta', '.cpl',
+    ];
+
+    for (const ext of blockedSamples) {
+      it(`blocks ${ext} extension and reveals folder`, async () => {
+        const handler = getHandler(IPC.SHELL_OPEN_PATH);
+        const input = process.platform === 'win32'
+          ? `C:\\Users\\rizz\\evil${ext}`
+          : `/home/rizz/evil${ext}`;
+        const result = await handler(fakeEvent, input);
+        expect(openPath).not.toHaveBeenCalled();
+        expect(showItemInFolder).toHaveBeenCalledWith(expectNormalized(input));
+        expect(result).toEqual({ ok: false, error: 'BLOCKED_EXTENSION' });
+      });
+    }
+
+    it('matches blocked extension case-insensitively', async () => {
+      const handler = getHandler(IPC.SHELL_OPEN_PATH);
+      const input = process.platform === 'win32' ? 'C:\\foo.EXE' : '/foo.EXE';
+      const result = await handler(fakeEvent, input);
+      expect(openPath).not.toHaveBeenCalled();
+      expect(result).toEqual({ ok: false, error: 'BLOCKED_EXTENSION' });
+    });
+
+    it('allows non-executable extensions', async () => {
+      const handler = getHandler(IPC.SHELL_OPEN_PATH);
+      const input = process.platform === 'win32' ? 'C:\\foo.txt' : '/foo.txt';
+      const result = await handler(fakeEvent, input);
+      expect(openPath).toHaveBeenCalledWith(input);
+      expect(result).toEqual({ ok: true, error: undefined });
+    });
+
+    it('allows extension-less paths (folders)', async () => {
+      const handler = getHandler(IPC.SHELL_OPEN_PATH);
+      const input = process.platform === 'win32' ? 'C:\\Users\\rizz' : '/home/rizz';
+      const result = await handler(fakeEvent, input);
+      expect(openPath).toHaveBeenCalledWith(input);
+      expect(result).toEqual({ ok: true, error: undefined });
+    });
+  });
+});

--- a/src/main/ipc/handlers/shell.handler.ts
+++ b/src/main/ipc/handlers/shell.handler.ts
@@ -1,7 +1,29 @@
 import { ipcMain, shell } from 'electron';
+import * as path from 'path';
 import { ShellDetector } from '../../pty/ShellDetector';
 import { IPC } from '../../../shared/constants';
 import { wrapHandler } from '../wrapHandler';
+
+// Hard cap on the path string the renderer can send. Long enough for
+// Windows long-path (\\?\ prefix + ~32k) callers but small enough that a
+// runaway buffer dump cannot lock the main process inside path.normalize.
+const MAX_PATH_LENGTH = 4096;
+
+// File extensions that launch executable code through OS shell association.
+// `shell.openPath` on a path with one of these extensions is equivalent to
+// the user double-clicking it in Explorer — arbitrary code execution.
+// Renderer-supplied paths originate from PTY output, which is untrusted
+// (a malicious git log message or pasted curl output could place such a
+// path on screen for the user to mis-click). We refuse to default-open
+// them and reveal the parent folder instead, so the user can still locate
+// the file and open it deliberately with a tool of their choice.
+//
+// Lowercase for case-insensitive lookup via `extname(...).toLowerCase()`.
+const BLOCKED_EXTENSIONS = new Set<string>([
+  '.exe', '.bat', '.cmd', '.com', '.scr', '.pif', '.ps1',
+  '.vbs', '.vbe', '.js', '.jse', '.wsf', '.wsh', '.msi',
+  '.reg', '.lnk', '.hta', '.cpl',
+]);
 
 export function registerShellHandlers(): () => void {
   const detector = new ShellDetector();
@@ -19,8 +41,59 @@ export function registerShellHandlers(): () => void {
     return shell.openExternal(url);
   }));
 
+  // Open an absolute filesystem path. Invoked by Ctrl+click on path tokens
+  // surfaced via the terminal link provider. Validation is intentionally
+  // strict — the renderer can match arbitrary text, so main treats every
+  // payload as untrusted:
+  //   • must be a string of length ≥ 1 and ≤ MAX_PATH_LENGTH
+  //   • no NUL bytes (defense against C-string truncation tricks)
+  //   • must be an absolute path on the current OS (path.isAbsolute)
+  //
+  // Behaviour: shell.openPath opens folders in Explorer / Finder and files
+  // with the OS default app. When that fails (missing file, no associated
+  // app, permission denied) we fall back to showItemInFolder so the user
+  // can still locate the target.
+  ipcMain.removeHandler(IPC.SHELL_OPEN_PATH);
+  ipcMain.handle(IPC.SHELL_OPEN_PATH, wrapHandler(IPC.SHELL_OPEN_PATH, async (_event: Electron.IpcMainInvokeEvent, rawPath: string) => {
+    if (typeof rawPath !== 'string') {
+      throw new Error('path must be a string');
+    }
+    if (rawPath.length === 0 || rawPath.length > MAX_PATH_LENGTH) {
+      throw new Error('path length out of range');
+    }
+    if (rawPath.includes('\0')) {
+      throw new Error('path must not contain NUL bytes');
+    }
+    // Normalize first so '..' segments collapse to a real on-disk path
+    // before the absolute-path check; otherwise a payload like
+    // 'C:\\foo\\..\\..\\..\\Windows\\System32\\calc.exe' would pass the
+    // raw isAbsolute test while still escaping the user-clicked location.
+    const normalized = path.normalize(rawPath);
+    if (!path.isAbsolute(normalized)) {
+      throw new Error('path must be absolute');
+    }
+    // Block executable extensions — refuse the open and reveal the folder
+    // so the user still gets useful feedback without launching code from
+    // untrusted PTY content. See BLOCKED_EXTENSIONS for the rationale.
+    const ext = path.extname(normalized).toLowerCase();
+    if (BLOCKED_EXTENSIONS.has(ext)) {
+      shell.showItemInFolder(normalized);
+      return { ok: false, error: 'BLOCKED_EXTENSION' };
+    }
+    const err = await shell.openPath(normalized);
+    if (err) {
+      // openPath returns an error string when the file is missing, has no
+      // associated handler, or the OS refused the open. Reveal the parent
+      // folder so the user still gets useful feedback instead of a silent
+      // no-op.
+      shell.showItemInFolder(normalized);
+    }
+    return { ok: !err, error: err || undefined };
+  }));
+
   return () => {
     ipcMain.removeHandler(IPC.SHELL_LIST);
     ipcMain.removeHandler(IPC.SHELL_OPEN_EXTERNAL);
+    ipcMain.removeHandler(IPC.SHELL_OPEN_PATH);
   };
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -61,6 +61,13 @@ const electronAPI = {
   shell: {
     list: () => ipcRenderer.invoke(IPC.SHELL_LIST) as Promise<{ name: string; path: string; args?: string[] }[]>,
     openExternal: (url: string) => ipcRenderer.invoke(IPC.SHELL_OPEN_EXTERNAL, url) as Promise<void>,
+    // Open an absolute filesystem path in the OS default app / explorer.
+    // Backed by Electron's shell.openPath; main validates the path is
+    // absolute, length-capped, and free of NUL bytes. Resolves with
+    // { ok, error? } — on `ok=false` main has already revealed the parent
+    // folder via showItemInFolder, so the renderer typically ignores it.
+    openPath: (filePath: string) =>
+      ipcRenderer.invoke(IPC.SHELL_OPEN_PATH, filePath) as Promise<{ ok: boolean; error?: string }>,
   },
   session: {
     save: (data: unknown) => ipcRenderer.invoke(IPC.SESSION_SAVE, data),

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -13,6 +13,7 @@ import { pastePtyChunked, chunkOnDataIfNeeded } from '../utils/clipboardChunk';
 import { runCopyWithFeedback } from '../utils/copyWithFeedback';
 import { shouldFitWhilePreservingSelection } from '../utils/fitGuard';
 import { createAutoSelectionCopy } from '../utils/autoSelectionCopy';
+import { createPathLinkProvider } from '../terminal/pathLinkProvider';
 
 // Module-level terminal registry for scrollback persistence
 const terminalRegistry = new Map<string, Terminal>();
@@ -32,6 +33,31 @@ function showCopyToast() {
   el.style.opacity = '1';
   if (copyToastTimer) clearTimeout(copyToastTimer);
   copyToastTimer = setTimeout(() => { el!.style.opacity = '0'; }, 1200);
+}
+
+// Surfaces openPath outcomes that the user cannot otherwise see — without
+// this, Ctrl+clicking an .exe (blocked main-side) or a missing file
+// silently reveals the parent folder via showItemInFolder with no
+// explanation, which reads as "the click didn't do anything." Yellow for
+// blocked (security gate), red for generic failure (file gone, no
+// associated app). Shares no DOM with the copy toasts so they can briefly
+// overlap if a user copies-then-clicks in quick succession.
+let openPathToastTimer: ReturnType<typeof setTimeout> | null = null;
+function showOpenPathToast(messageKey: 'terminal.openPathBlocked' | 'terminal.openPathFailed') {
+  let el = document.getElementById('wmux-openpath-toast');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'wmux-openpath-toast';
+    el.style.cssText = 'position:fixed;bottom:28px;left:50%;transform:translateX(-50%);color:var(--bg-base);font-family:monospace;font-size:11px;font-weight:600;padding:3px 12px;border-radius:4px;z-index:9999;pointer-events:none;opacity:0;transition:opacity 0.2s';
+    document.body.appendChild(el);
+  }
+  el.style.background = messageKey === 'terminal.openPathBlocked'
+    ? 'var(--accent-yellow)'
+    : 'var(--accent-red)';
+  el.textContent = t(messageKey);
+  el.style.opacity = '1';
+  if (openPathToastTimer) clearTimeout(openPathToastTimer);
+  openPathToastTimer = setTimeout(() => { el!.style.opacity = '0'; }, 2400);
 }
 
 // Error variant — surfaced when clipboardAPI.writeText rejects so the user
@@ -173,6 +199,35 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     terminal.loadAddon(searchAddon);
     terminal.loadAddon(unicode11Addon);
     terminal.loadAddon(webLinksAddon);
+    // Path link provider — Ctrl+click an absolute filesystem path to open
+    // it in Explorer / Finder. Coexists with WebLinksAddon (URLs); the two
+    // detect disjoint token shapes so a single span never claims both.
+    // Main-side validation in shell.handler.openPath is the security
+    // boundary; the renderer regex is only a UX filter.
+    const pathLinkDisposable = terminal.registerLinkProvider(
+      createPathLinkProvider(terminal, (filePath) => {
+        void window.electronAPI.shell.openPath(filePath).then((result) => {
+          // Main-side outcomes:
+          //   • ok=true → opened cleanly, nothing to surface
+          //   • error='BLOCKED_EXTENSION' → security gate refused (.exe etc.)
+          //   • error=<message> → openPath failed (file gone, no handler);
+          //     main already revealed the parent folder via showItemInFolder
+          // The toast tells the user *why* their click landed on a folder
+          // instead of opening the file — otherwise it reads as a no-op.
+          if (!result || result.ok) return;
+          showOpenPathToast(
+            result.error === 'BLOCKED_EXTENSION'
+              ? 'terminal.openPathBlocked'
+              : 'terminal.openPathFailed',
+          );
+        }).catch((err: unknown) => {
+          // IPC-level rejection (validation throw: non-string, NUL byte,
+          // not absolute, length cap). These are developer-visible bugs
+          // rather than user-actionable failures — log only.
+          console.warn('[useTerminal] openPath failed:', err);
+        });
+      }, window.electronAPI.platform),
+    );
     // Activate Unicode 11 width tables — required for correct CJK / emoji
     // width. Without this, xterm defaults to v6 and TUI apps that use cursor
     // positioning (Claude Code, vim, etc.) collide frames over Korean text.
@@ -806,6 +861,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
       autoCopy.dispose();
       selectionDisposable.dispose();
+      pathLinkDisposable.dispose();
       resizeObserver.disconnect();
       removeDataListener?.();
       removeExitListener?.();

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -80,6 +80,8 @@ export const en = {
   'terminal.exitedBracket': '[Process exited with code {code}]',
   'terminal.copied': 'Copied!',
   'terminal.copyFailed': 'Copy failed — selection kept',
+  'terminal.openPathBlocked': 'Executable blocked — opened parent folder',
+  'terminal.openPathFailed': "Couldn't open — showing folder",
   'terminal.bookmarkAdded': 'Bookmark added',
 
   // Context menu

--- a/src/renderer/i18n/locales/ja.ts
+++ b/src/renderer/i18n/locales/ja.ts
@@ -79,6 +79,8 @@ export const ja = {
   'terminal.exitedBracket': '[プロセスがコード {code} で終了しました]',
   'terminal.copied': 'コピーしました!',
   'terminal.copyFailed': 'コピーに失敗しました — 選択を維持',
+  'terminal.openPathBlocked': '実行ファイルをブロック — 親フォルダを開きました',
+  'terminal.openPathFailed': '開けません — フォルダを表示',
   'terminal.bookmarkAdded': 'ブックマークを追加',
 
   // Context menu

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -80,6 +80,8 @@ export const ko = {
   'terminal.exitedBracket': '[프로세스가 코드 {code}로 종료됨]',
   'terminal.copied': '복사됨!',
   'terminal.copyFailed': '복사 실패 — 선택 영역 유지됨',
+  'terminal.openPathBlocked': '실행 파일 차단됨 — 부모 폴더만 열림',
+  'terminal.openPathFailed': '열 수 없음 — 폴더 위치 표시',
   'terminal.bookmarkAdded': '북마크 추가됨',
 
   // Context menu

--- a/src/renderer/i18n/locales/zh.ts
+++ b/src/renderer/i18n/locales/zh.ts
@@ -79,6 +79,8 @@ export const zh = {
   'terminal.exitedBracket': '[进程已退出，代码 {code}]',
   'terminal.copied': '已复制!',
   'terminal.copyFailed': '复制失败 — 已保留选区',
+  'terminal.openPathBlocked': '已阻止可执行文件 — 仅打开父文件夹',
+  'terminal.openPathFailed': '无法打开 — 显示文件夹位置',
   'terminal.bookmarkAdded': '已添加书签',
 
   // Context menu

--- a/src/renderer/terminal/__tests__/pathLinkProvider.test.ts
+++ b/src/renderer/terminal/__tests__/pathLinkProvider.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for `findPathMatches` and `createPathLinkProvider`.
+ *
+ * The matcher is the source of truth for which characters in a terminal
+ * line are "a clickable path". It must:
+ *   • detect absolute Windows / UNC / POSIX paths
+ *   • strip trailing punctuation + source-location suffixes (`:42`, `:42:10`)
+ *   • ignore relative paths, time strings, URL path components
+ *   • be stable across repeated calls (no regex state bleed)
+ *
+ * The thin xterm wrapper (`createPathLinkProvider`) just maps matches into
+ * ILink ranges, so we only test the matcher heavily and smoke-test the
+ * provider for coordinate translation + range correctness.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { findPathMatches, createPathLinkProvider } from '../pathLinkProvider';
+
+describe('findPathMatches', () => {
+  describe('Windows drive paths', () => {
+    it('matches a bare drive path', () => {
+      const matches = findPathMatches('C:\\Users\\rizz\\file.txt', 'win32');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].text).toBe('C:\\Users\\rizz\\file.txt');
+    });
+
+    it('matches a forward-slash drive path', () => {
+      const matches = findPathMatches('see c:/foo/bar.log for details', 'win32');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].text).toBe('c:/foo/bar.log');
+    });
+
+    it('strips trailing period', () => {
+      const matches = findPathMatches('Open C:\\Users\\rizz\\file.txt.', 'win32');
+      expect(matches[0].text).toBe('C:\\Users\\rizz\\file.txt');
+    });
+
+    it('strips trailing comma + period combo', () => {
+      const matches = findPathMatches('open C:\\foo\\bar.ts,.', 'win32');
+      expect(matches[0].text).toBe('C:\\foo\\bar.ts');
+    });
+
+    it('strips source-location suffix `:42`', () => {
+      const matches = findPathMatches('Error at D:\\wmux\\src\\index.ts:42', 'win32');
+      expect(matches[0].text).toBe('D:\\wmux\\src\\index.ts');
+    });
+
+    it('strips source-location suffix `:42:10`', () => {
+      const matches = findPathMatches('Error at D:\\wmux\\src\\index.ts:42:10', 'win32');
+      expect(matches[0].text).toBe('D:\\wmux\\src\\index.ts');
+    });
+
+    it('handles wrapped (parens) source location', () => {
+      const matches = findPathMatches('(see D:\\wmux\\src\\foo.ts:42)', 'win32');
+      expect(matches[0].text).toBe('D:\\wmux\\src\\foo.ts');
+    });
+
+    it('strips multi-segment numeric trailer (semver-shaped, e.g. :1.2.3)', () => {
+      // SOURCE_LOCATION_SUFFIX peels one `:NNN` at a time. The fixed-point
+      // loop in trimPunctuation must keep iterating until nothing changes,
+      // otherwise a path with a semver-shaped trailer keeps a stray `:N`
+      // at the end and openPath rejects it.
+      const matches = findPathMatches('release D:\\dist\\app.json:1.2.3', 'win32');
+      expect(matches[0].text).toBe('D:\\dist\\app.json');
+    });
+  });
+
+  describe('Windows UNC paths', () => {
+    it('matches a basic UNC share', () => {
+      const matches = findPathMatches('check \\\\server\\share\\file.txt', 'win32');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].text).toBe('\\\\server\\share\\file.txt');
+    });
+
+    it('matches a hyphenated server name', () => {
+      const matches = findPathMatches('\\\\file-srv-01\\share', 'win32');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].text).toBe('\\\\file-srv-01\\share');
+    });
+  });
+
+  describe('POSIX paths', () => {
+    it('matches a basic absolute path', () => {
+      const matches = findPathMatches('see /etc/hosts for the entry', 'linux');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].text).toBe('/etc/hosts');
+    });
+
+    it('matches a home-dir-style path', () => {
+      const matches = findPathMatches('open /home/rizz/.config/wmux/config.json', 'linux');
+      expect(matches[0].text).toBe('/home/rizz/.config/wmux/config.json');
+    });
+
+    it('strips trailing period in prose', () => {
+      const matches = findPathMatches('look at /var/log/syslog.', 'linux');
+      expect(matches[0].text).toBe('/var/log/syslog');
+    });
+
+    it('does not match the path component of an http URL', () => {
+      // POSIX rule requires a word boundary before `/`. http://host/path
+      // has no whitespace before the second slash, so we expect zero hits.
+      const matches = findPathMatches('see http://example.com/some/path here', 'linux');
+      expect(matches).toHaveLength(0);
+    });
+
+    it('does not match plain time strings', () => {
+      const matches = findPathMatches('meeting at 12:34 today', 'linux');
+      expect(matches).toHaveLength(0);
+    });
+
+    it('does not match a bare slash', () => {
+      const matches = findPathMatches('a / b', 'linux');
+      expect(matches).toHaveLength(0);
+    });
+  });
+
+  describe('multiple matches', () => {
+    it('returns matches in order', () => {
+      const matches = findPathMatches(
+        'cp /etc/hosts /tmp/hosts.bak',
+        'linux',
+      );
+      expect(matches.map((m) => m.text)).toEqual(['/etc/hosts', '/tmp/hosts.bak']);
+      expect(matches[0].start).toBeLessThan(matches[1].start);
+    });
+
+    it('mixes Windows + POSIX paths on win32 host', () => {
+      const matches = findPathMatches(
+        'src D:\\foo\\a.ts dst /tmp/x',
+        'win32',
+      );
+      expect(matches.map((m) => m.text)).toEqual(['D:\\foo\\a.ts', '/tmp/x']);
+    });
+
+    it('handles two UNC paths on the same line (dedupe stays ordered)', () => {
+      const matches = findPathMatches(
+        '\\\\srv-a\\share\\one \\\\srv-b\\share\\two',
+        'win32',
+      );
+      expect(matches.map((m) => m.text)).toEqual([
+        '\\\\srv-a\\share\\one',
+        '\\\\srv-b\\share\\two',
+      ]);
+    });
+
+    it('does not match the path component of a file:// URI', () => {
+      // POSIX matcher's lookbehind requires whitespace / quote / paren /
+      // angle before the `/`. The `:` in `file:` falls outside that set,
+      // so we expect zero hits — the URI is left for WebLinksAddon to
+      // handle if it recognises file://.
+      const matches = findPathMatches('see file:///etc/hosts please', 'linux');
+      expect(matches).toHaveLength(0);
+    });
+  });
+
+  describe('regex state stability', () => {
+    // Module-scoped regex instances retain `lastIndex`. The implementation
+    // must reset it; otherwise the second call could miss matches near
+    // the start of the line.
+    it('returns identical results on repeated calls with the same input', () => {
+      const input = 'cp /etc/hosts /tmp/x';
+      const first = findPathMatches(input, 'linux');
+      const second = findPathMatches(input, 'linux');
+      expect(second).toEqual(first);
+    });
+
+    it('finds match at offset 0 after a prior longer call', () => {
+      findPathMatches('xxxxxxxxxxxxxxxxxxxx /etc/hosts xxxxxxxxxxxx', 'linux');
+      const matches = findPathMatches('/etc/hosts', 'linux');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].start).toBe(0);
+    });
+  });
+
+  describe('range correctness', () => {
+    it('reports start/end aligned with the cleaned path', () => {
+      const input = 'open /etc/hosts.';
+      const matches = findPathMatches(input, 'linux');
+      expect(matches[0].start).toBe(5);
+      expect(matches[0].end).toBe(15); // /etc/hosts (10 chars), 5..15
+      expect(input.slice(matches[0].start, matches[0].end)).toBe('/etc/hosts');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty for empty input', () => {
+      expect(findPathMatches('', 'linux')).toEqual([]);
+    });
+
+    it('returns empty for a single drive letter (no slash)', () => {
+      expect(findPathMatches('C:', 'win32')).toEqual([]);
+    });
+
+    it('does not match a relative path', () => {
+      expect(findPathMatches('foo/bar.txt', 'linux')).toEqual([]);
+      expect(findPathMatches('./foo/bar.txt', 'linux')).toEqual([]);
+    });
+  });
+});
+
+describe('createPathLinkProvider', () => {
+  /**
+   * Minimal xterm Terminal stub. The provider only touches
+   * `buffer.active.getLine(n).translateToString(true)` and
+   * `getLine(n).isWrapped`, so a stub is faster + clearer than mocking
+   * the full xterm interface.
+   */
+  function makeTerminal(lines: { text: string; wrapped?: boolean }[]) {
+    return {
+      buffer: {
+        active: {
+          getLine: (i: number) => {
+            const l = lines[i];
+            if (!l) return undefined;
+            return {
+              translateToString: () => l.text,
+              isWrapped: !!l.wrapped,
+            };
+          },
+        },
+      },
+    } as unknown as import('@xterm/xterm').Terminal;
+  }
+
+  it('emits one link per match with 1-based xterm coordinates', () => {
+    const terminal = makeTerminal([{ text: 'open /etc/hosts here' }]);
+    const openPath = vi.fn();
+    const provider = createPathLinkProvider(terminal, openPath, 'linux');
+    const cb = vi.fn();
+    provider.provideLinks(1, cb);
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    const links = cb.mock.calls[0][0];
+    expect(links).toHaveLength(1);
+    // /etc/hosts starts at offset 5 (0-based) → xterm x=6 (1-based).
+    expect(links[0].range.start).toEqual({ x: 6, y: 1 });
+    // end is inclusive; /etc/hosts is 10 chars long ending at offset 15
+    // (exclusive) → inclusive last cell = 15.
+    expect(links[0].range.end).toEqual({ x: 15, y: 1 });
+    expect(links[0].text).toBe('/etc/hosts');
+  });
+
+  it('skips wrapped continuation lines so paths do not double-match', () => {
+    const terminal = makeTerminal([
+      { text: '/etc/hosts continuation row body', wrapped: true },
+    ]);
+    const provider = createPathLinkProvider(terminal, vi.fn(), 'linux');
+    const cb = vi.fn();
+    provider.provideLinks(1, cb);
+    expect(cb).toHaveBeenCalledWith(undefined);
+  });
+
+  it('passes undefined when the line is empty', () => {
+    const terminal = makeTerminal([{ text: '' }]);
+    const provider = createPathLinkProvider(terminal, vi.fn(), 'linux');
+    const cb = vi.fn();
+    provider.provideLinks(1, cb);
+    expect(cb).toHaveBeenCalledWith(undefined);
+  });
+
+  it('passes undefined when getLine returns nothing (line past the buffer)', () => {
+    const terminal = makeTerminal([]);
+    const provider = createPathLinkProvider(terminal, vi.fn(), 'linux');
+    const cb = vi.fn();
+    provider.provideLinks(999, cb);
+    expect(cb).toHaveBeenCalledWith(undefined);
+  });
+
+  it('activate() forwards the cleaned path to openPath', () => {
+    const terminal = makeTerminal([{ text: 'see /var/log/syslog.' }]);
+    const openPath = vi.fn();
+    const provider = createPathLinkProvider(terminal, openPath, 'linux');
+    const cb = vi.fn();
+    provider.provideLinks(1, cb);
+    const link = cb.mock.calls[0][0][0];
+    // MouseEvent is a DOM type; vitest's default node env doesn't provide
+    // it. The provider's `activate` ignores the event arg, so an empty
+    // object is fine for the test.
+    link.activate({} as unknown as MouseEvent, link.text);
+    expect(openPath).toHaveBeenCalledWith('/var/log/syslog');
+  });
+});

--- a/src/renderer/terminal/pathLinkProvider.ts
+++ b/src/renderer/terminal/pathLinkProvider.ts
@@ -1,0 +1,205 @@
+/**
+ * Path link provider — Ctrl+click an absolute filesystem path in the
+ * terminal to open it in Explorer / Finder / xdg-open.
+ *
+ * Layered with xterm's existing WebLinksAddon (URLs). Path detection runs
+ * line-by-line against `IBufferLine.translateToString(false)`, then is
+ * narrowed by `findPathMatches` (pure, unit-tested) so the xterm-coupled
+ * surface stays thin.
+ *
+ * Design notes:
+ *   • Only absolute paths are matched. Relative paths require a per-pane
+ *     cwd we cannot read reliably, and false positives there are common
+ *     (e.g. "foo/bar" in prose).
+ *   • POSIX matching is intentionally conservative: anchored at a word
+ *     boundary and requires ≥ 1 non-root segment, so `/etc/hosts` matches
+ *     but `12:34` (time) or `http://example.com/path` (URL — handled by
+ *     WebLinksAddon) do not.
+ *   • Trailing punctuation (".,:;!?)]}>\"'`") is trimmed off matches so
+ *     "see /etc/hosts." opens "/etc/hosts" not "/etc/hosts.".
+ *   • Source-location suffixes like ":42" or ":42:10" are stripped before
+ *     opening — Electron's shell.openPath does not understand them and
+ *     would otherwise reject the path. The line/column is dropped silently
+ *     (future IDE-integration hook can read them back from the raw match).
+ */
+
+import type { ILink, ILinkProvider, Terminal } from '@xterm/xterm';
+
+export interface PathMatch {
+  /** Cleaned-up path (trailing punctuation + line:col suffix removed). */
+  text: string;
+  /** Inclusive start offset within the line text (0-based). */
+  start: number;
+  /** Exclusive end offset within the line text (0-based). */
+  end: number;
+}
+
+/** Trailing characters trimmed off the right edge of a candidate path. */
+const TRAILING_PUNCTUATION = /[.,:;!?)\]}>"'`]+$/;
+
+// Trailing numeric/version-shaped suffix. Covers source locations
+// (":42", ":42:10") and semver-shaped trailers (":1.2.3"). The class
+// `[:.]` lets the second-and-later segments be joined by either `:` or
+// `.`, so all of these strip in a single regex match:
+//   /foo.ts:42          → /foo.ts
+//   /foo.ts:42:10       → /foo.ts
+//   /foo.ts:1.2.3       → /foo.ts
+// The first separator is required to be `:` so plain filenames with dots
+// ("/foo.tar.gz") are not eaten.
+const SOURCE_LOCATION_SUFFIX = /:\d+(?:[:.]\d+)*$/;
+
+// Windows drive-letter path: `C:\foo\bar` or `c:/foo/bar`. The negated
+// character class blocks the path-illegal Windows characters plus
+// whitespace/control so a path embedded in prose ends at the next space.
+// no-control-regex is suppressed because matching control bytes is the
+// point: any byte < 0x20 ends a path token.
+// eslint-disable-next-line no-control-regex
+const WINDOWS_DRIVE_PATH = /\b[A-Za-z]:[\\/][^\s"<>|?*\x00-\x1f]+/g;
+
+// UNC share path: `\\server\share\...`. Server + share segments must look
+// like hostnames (alnum + dot/hyphen/underscore); everything after is
+// treated as path body.
+// eslint-disable-next-line no-control-regex
+const WINDOWS_UNC_PATH = /\\\\[A-Za-z0-9._-]+\\[A-Za-z0-9._$-]+(?:\\[^\s"<>|?*\x00-\x1f]*)?/g;
+
+// POSIX absolute path: leading `/`, then ≥ 1 segment of non-whitespace.
+// Lookbehind anchor keeps it from chewing up the path component of an
+// http URL while ensuring the match starts AT the `/` (not at the
+// boundary char before it), so the recorded offset lines up with the
+// cleaned text. Note: ALSO matches inside double-slashes like `//foo`
+// (rare in prose; intentional for protocol-less server paths).
+// eslint-disable-next-line no-control-regex
+const POSIX_PATH = /(?<=^|[\s"'([<])\/[A-Za-z0-9._~-][^\s"<>|?*\x00-\x1f]*/g;
+
+/**
+ * Extract absolute-path matches from a line of terminal text.
+ *
+ * Returns matches sorted by `start`. Overlapping matches are deduplicated
+ * (longer match wins) so a Windows path inside a UNC-shaped string doesn't
+ * double-emit.
+ */
+export function findPathMatches(line: string, platform: NodeJS.Platform): PathMatch[] {
+  if (!line) return [];
+
+  const raw: PathMatch[] = [];
+
+  const collect = (regex: RegExp) => {
+    // Reset lastIndex defensively — the regex is module-scoped, so a prior
+    // partial iteration on another caller's line would otherwise skip
+    // matches near the start of this line.
+    regex.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = regex.exec(line)) !== null) {
+      const cleaned = trimPunctuation(m[0]);
+      if (cleaned.length === 0) continue;
+      raw.push({
+        text: cleaned,
+        start: m.index,
+        end: m.index + cleaned.length,
+      });
+    }
+  };
+
+  if (platform === 'win32') {
+    collect(WINDOWS_UNC_PATH);
+    collect(WINDOWS_DRIVE_PATH);
+  } else {
+    // On POSIX hosts, also match Windows-style drive paths when they appear
+    // in shared logs / docs. Cheap, no false-positive risk on Unix.
+    collect(WINDOWS_DRIVE_PATH);
+  }
+
+  // POSIX-shaped matches everywhere — Windows shells routinely print
+  // forward-slash paths (git, WSL output, msys tools).
+  collect(POSIX_PATH);
+
+  return dedupe(raw);
+}
+
+function trimPunctuation(text: string): string {
+  // Iterate to a fixed point so wrapped suffixes ("(see /foo.ts:42)") and
+  // semver-shaped trailers ("/foo.ts:1.2.3", which SOURCE_LOCATION_SUFFIX
+  // peels off one segment at a time) both fully unwrap. Bounded at 8
+  // iterations as a defense against pathological input — typical paths
+  // converge in 1–2 passes.
+  let prev = text;
+  for (let i = 0; i < 8; i++) {
+    let out = prev.replace(TRAILING_PUNCTUATION, '');
+    out = out.replace(SOURCE_LOCATION_SUFFIX, '');
+    if (out === prev) return out;
+    prev = out;
+  }
+  return prev;
+}
+
+function dedupe(matches: PathMatch[]): PathMatch[] {
+  if (matches.length <= 1) return matches.slice();
+  const sorted = matches.slice().sort((a, b) => {
+    if (a.start !== b.start) return a.start - b.start;
+    // Same start → longer match first so the shorter (overlapping) one is
+    // dropped by the loop below.
+    return b.end - a.end;
+  });
+  const out: PathMatch[] = [];
+  for (const m of sorted) {
+    const last = out[out.length - 1];
+    if (last && m.start < last.end) {
+      // Overlap. Keep the longer one — already first by sort, so drop `m`.
+      continue;
+    }
+    out.push(m);
+  }
+  return out;
+}
+
+/**
+ * Build an xterm ILinkProvider that opens absolute paths via the provided
+ * `openPath` callback (typically `window.electronAPI.shell.openPath`).
+ *
+ * `platform` selects the matcher set (Windows-aware on win32). Defaults to
+ * `process.platform` when available, otherwise 'linux' — which still
+ * detects Windows drive paths, just without UNC support.
+ */
+export function createPathLinkProvider(
+  terminal: Terminal,
+  openPath: (filePath: string) => void,
+  platform: NodeJS.Platform = (typeof process !== 'undefined' && process.platform) || 'linux',
+): ILinkProvider {
+  return {
+    provideLinks(bufferLineNumber, callback) {
+      // xterm passes 1-based line numbers; getLine wants 0-based.
+      const line = terminal.buffer.active.getLine(bufferLineNumber - 1);
+      if (!line) {
+        callback(undefined);
+        return;
+      }
+      // Soft-wrapped continuation rows are skipped: xterm's link range is
+      // single-row, so a path split across rows can't be highlighted as
+      // one link. The origin row's matcher only sees its own slice in
+      // that case; users who hit this can right-click → copy → paste.
+      // The cost of skipping wrap continuation rows is preventing false
+      // matches when row N's prefix is the suffix of row N-1's path.
+      if (line.isWrapped) {
+        callback(undefined);
+        return;
+      }
+      const text = line.translateToString(true);
+      const matches = findPathMatches(text, platform);
+      if (matches.length === 0) {
+        callback(undefined);
+        return;
+      }
+      const links: ILink[] = matches.map((match) => ({
+        // xterm coordinates are 1-based; range.end is inclusive (the last
+        // cell containing the link, not one past it).
+        range: {
+          start: { x: match.start + 1, y: bufferLineNumber },
+          end: { x: match.end, y: bufferLineNumber },
+        },
+        text: match.text,
+        activate: () => openPath(match.text),
+      }));
+      callback(links);
+    },
+  };
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -43,6 +43,10 @@ export const IPC = {
   APPROVAL_REQUEST: 'approval:request',
   // Shell
   SHELL_OPEN_EXTERNAL: 'shell:open-external',
+  // Open an absolute filesystem path in the OS default app / explorer.
+  // Triggered by Ctrl+click on a path token rendered in the terminal.
+  // Path is validated main-side: must be absolute, no NUL bytes, length-capped.
+  SHELL_OPEN_PATH: 'shell:open-path',
   // File system
   FS_READ_DIR: 'fs:read-dir',
   FS_READ_FILE: 'fs:read-file',


### PR DESCRIPTION
## Summary

Terminal output is full of filesystem paths (stack traces, git output, test failures) that users currently have to re-type or paste into an Explorer dialog to inspect. This wires up xterm's link provider so any absolute path in the terminal becomes Ctrl+clickable — POSIX (`/etc/hosts`), Windows drive (`C:\Users\...`), and UNC share (`\srv\share`).

Coexists with `WebLinksAddon`: URLs and paths detect disjoint token shapes so a single span never claims both.

## Design highlights

**Renderer (`pathLinkProvider.ts`)** — pure, unit-tested matcher (`findPathMatches`) layered onto an xterm `ILinkProvider`. Strips trailing punctuation (`.,:;!?)]}>"'\``) and source-location suffixes (`":42"`, `":42:10"`, `":1.2.3"`) before opening, so `"see /etc/hosts."` opens `/etc/hosts` and IDE-style refs work. Soft-wrapped continuation rows are skipped (xterm range can't span rows).

**Main-side handler (`shell.handler.ts → SHELL_OPEN_PATH`)** is the security boundary. The renderer regex is only a UX filter; every payload is re-validated main-side:
- string, length 1..4096, no NUL bytes
- `path.normalize` then `isAbsolute` (collapses `..` before the absolute check, so `C:\foo\..\..\..\Windows\System32\calc.exe` can't sneak through)
- executable extension blocklist — `.exe`, `.bat`, `.cmd`, `.com`, `.scr`, `.pif`, `.ps1`, `.vbs`, `.vbe`, `.js`, `.jse`, `.wsf`, `.wsh`, `.msi`, `.reg`, `.lnk`, `.hta`, `.cpl` — refuses the open and reveals the parent folder via `showItemInFolder` so the user still gets feedback without launching arbitrary code from untrusted PTY content
- on other failures (missing file, no associated app, permission denied) we also fall back to `showItemInFolder`

**UX** — `useTerminal` surfaces non-success outcomes via a yellow (blocked) / red (failed) toast at the bottom of the pane, separate from the copy toast DOM so they can briefly overlap. Without this, blocked or missing-file clicks read as silent no-ops because main has already revealed the parent folder.

**i18n** — `terminal.openPathBlocked` / `terminal.openPathFailed` added to en/ko/ja/zh; the other 19 locales fall back to en until translated.

## Test plan

- [x] `pathLinkProvider.test.ts` — POSIX / Windows drive / UNC matching, dedup of overlapping matches, punctuation + suffix trimming, fixed-point convergence of `trimPunctuation` against pathological input (38 tests)
- [x] `shell.handler.openPath.test.ts` — every reject branch (non-string, empty, overlong, NUL byte, relative), `path.normalize` collapses `..` before `isAbsolute` check, `showItemInFolder` fallback on `openPath` error, BLOCKED_EXTENSIONS full set including case-insensitive match and extension-less paths (23 tests)
- [x] Full vitest suite — 1415 tests passing
- [x] `tsc --noEmit` — 0 errors
- [x] `eslint` on new code — 0 errors (warnings consistent with existing patterns)
- [x] Manual dogfood on Windows — `D:\wmux\src\...` paths, `:42:10` line:col stripping, `.exe` block path reveals folder, missing file shows red toast