### PR TITLE
feat(daemon): auto-respawn with health probe and verified kill gates (#54)

### DIFF
--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -88,15 +88,26 @@ export class DaemonClient extends EventEmitter {
   }
 
   /** Synchronous disconnect — for use in process exit/session-end handlers
-   *  where async operations cannot complete. Destroys all sockets immediately. */
+   *  where async operations cannot complete, AND for runtime recovery
+   *  paths (the respawn controller's hang detector) where we need to
+   *  drop the socket fast but still keep the rest of the app responsive.
+   *  Destroys all sockets immediately and rejects every pending RPC so
+   *  callers do not hang forever waiting on a reply that can no longer
+   *  arrive. (Codex review #4 on issue #54 respawn loop.) */
   disconnectSync(): void {
     for (const [, socket] of this.sessionPipes) {
       try { socket.destroy(); } catch { /* ignore */ }
     }
     this.sessionPipes.clear();
 
+    // Reject pending requests so in-flight RPC promises settle instead
+    // of dangling. The async `disconnect()` already does this; the sync
+    // path used to skip it because the exit path didn't care, but the
+    // respawn controller calls disconnectSync at runtime — silently
+    // dropped pendings would leave renderer actions hung forever.
     for (const [id, pending] of this.pendingRequests) {
       clearTimeout(pending.timer);
+      try { pending.reject(new Error('DaemonClient disconnected')); } catch { /* defensive */ }
       this.pendingRequests.delete(id);
     }
 

--- a/src/main/daemon/DaemonRespawnController.ts
+++ b/src/main/daemon/DaemonRespawnController.ts
@@ -1,0 +1,386 @@
+import { DaemonClient } from '../DaemonClient';
+import type { DaemonInfo } from './launcher';
+
+export interface DaemonRespawnState {
+  attempt: number;
+  backoffMs: number;
+}
+
+export interface DaemonRespawnDeps {
+  /**
+   * Spawn (or discover) the daemon and return its pipe + auth token.
+   * Wraps `ensureDaemon()` from `./launcher`.
+   */
+  ensureDaemon: () => Promise<DaemonInfo>;
+  /**
+   * Build a fresh `DaemonClient` for the given pipe + token. Indirection
+   * exists so unit tests can supply a fake client.
+   */
+  createClient: (pipeName: string, token: string) => DaemonClient;
+  /**
+   * Called once a respawned client has been successfully connected and
+   * authenticated. Owns handler swap to daemon-routed IPC, mounting the
+   * notification router, and broadcasting `daemon:connected` /
+   * `daemon:reconnected` to the renderer.
+   */
+  onInstall: (client: DaemonClient) => Promise<void> | void;
+  /**
+   * Called when the active client has disconnected and respawn has started
+   * (or after budget exhaustion). Owns handler swap back to local-PTY,
+   * stopping the notification router, and broadcasting
+   * `daemon:disconnected`.
+   */
+  onUninstall: () => void;
+  /**
+   * Renderer-facing event emitter. Reasons: `reconnecting`, `reconnected`,
+   * `respawn-exhausted`.
+   */
+  emit: (event: RespawnEvent) => void;
+  /** Structured log sink — info/warn/error. */
+  logger: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+}
+
+export type RespawnEvent =
+  | { type: 'reconnecting'; attempt: number; backoffMs: number }
+  | { type: 'reconnected' }
+  | { type: 'respawn-exhausted' };
+
+export interface DaemonRespawnConfig {
+  /** Max consecutive respawn attempts before giving up. Default 5. */
+  budget?: number;
+  /** Healthy-uptime threshold that resets the attempt counter. Default 5 min. */
+  resetWindowMs?: number;
+  /** Backoff schedule: min(base * 2^attempt, max). */
+  baseBackoffMs?: number;
+  maxBackoffMs?: number;
+  /** Health-probe interval. 0 disables the probe. Default 10s. */
+  healthIntervalMs?: number;
+  /** Per-ping timeout. Default 3s. */
+  healthTimeoutMs?: number;
+  /** Consecutive ping failures that force a respawn. Default 3. */
+  hangFailureThreshold?: number;
+}
+
+const DEFAULTS: Required<DaemonRespawnConfig> = {
+  budget: 5,
+  resetWindowMs: 5 * 60 * 1000,
+  baseBackoffMs: 1000,
+  maxBackoffMs: 30_000,
+  healthIntervalMs: 10_000,
+  healthTimeoutMs: 3_000,
+  hangFailureThreshold: 3,
+};
+
+/**
+ * Owns the daemon-respawn lifecycle: detects disconnects, schedules
+ * exponential-backoff respawns, drives an active health probe to catch
+ * daemon-hang cases, resets attempt counters after sustained healthy
+ * uptime, and routes lifecycle events to the renderer.
+ *
+ * The controller is intentionally agnostic about IPC handler wiring —
+ * the caller supplies `onInstall(client)` and `onUninstall()` callbacks
+ * so this module never has to know about `registerAllHandlers` /
+ * `DaemonNotificationRouter` / `mainWindow`.
+ *
+ * Lifecycle:
+ *   - `bootstrap()` performs the initial daemon launch + install. Throws
+ *     on a hard failure so the caller can fall back to local-only mode.
+ *   - `dispose()` tears down timers + listeners. Safe to call from
+ *     `before-quit`; it does NOT call `onUninstall()` because the caller
+ *     usually wants a different (shutdown-race) teardown path.
+ */
+export class DaemonRespawnController {
+  private readonly cfg: Required<DaemonRespawnConfig>;
+  private client: DaemonClient | null = null;
+  private disconnectedListener: (() => void) | null = null;
+  private respawnTimer: ReturnType<typeof setTimeout> | null = null;
+  private attemptCount = 0;
+  private healthInterval: ReturnType<typeof setInterval> | null = null;
+  private healthFailureCount = 0;
+  private uptimeResetTimer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+  private exhausted = false;
+  /** True between the moment a disconnect was observed and the respawn
+   *  loop has either succeeded or exhausted its budget. Used to suppress
+   *  re-entrant respawn schedules from a health probe that races a real
+   *  socket close. */
+  private respawning = false;
+
+  constructor(
+    private readonly deps: DaemonRespawnDeps,
+    config: DaemonRespawnConfig = {},
+  ) {
+    this.cfg = { ...DEFAULTS, ...config };
+  }
+
+  /** True if a daemon client is currently installed and connected. */
+  get isHealthy(): boolean {
+    return this.client !== null && this.client.isConnected;
+  }
+
+  /** Current active client, or null when in local-only fallback. */
+  getClient(): DaemonClient | null {
+    return this.client;
+  }
+
+  /**
+   * Perform the initial daemon launch + install. Should be called once
+   * from `app.on('ready')`. On failure the caller stays in local mode;
+   * subsequent recovery is the user's responsibility (manual restart).
+   */
+  async bootstrap(): Promise<DaemonClient | null> {
+    if (this.disposed) throw new Error('DaemonRespawnController already disposed');
+    if (this.client) return this.client;
+    try {
+      const client = await this.spawnAndConnect();
+      if (!client) return null;
+      await this.install(client, { isReconnect: false });
+      return client;
+    } catch (err) {
+      this.deps.logger.warn(`bootstrap failed: ${this.stringifyError(err)}`);
+      return null;
+    }
+  }
+
+  /**
+   * Dispose timers + listeners. Does NOT trigger `onUninstall()` — the
+   * `before-quit` path runs its own daemon-shutdown race and we don't
+   * want to double-fire the handler swap.
+   */
+  dispose(): void {
+    this.disposed = true;
+    this.clearRespawnTimer();
+    this.clearUptimeResetTimer();
+    this.stopHealthProbe();
+    this.detachDisconnectedListener();
+    this.client = null;
+  }
+
+  /** Public entry for tests / future manual reconnect UI. */
+  async forceRespawn(): Promise<void> {
+    if (this.disposed) return;
+    // Treat as a synthetic disconnect so the same scheduling path runs.
+    this.handleDisconnect('forceRespawn requested');
+  }
+
+  // --- internals ---
+
+  private async spawnAndConnect(): Promise<DaemonClient | null> {
+    const info = await this.deps.ensureDaemon();
+    this.deps.logger.info(
+      `daemon ${info.spawned ? 'spawned' : 'found'} (pid=${info.pid})`,
+    );
+    const client = this.deps.createClient(info.pipeName, info.authToken);
+    const connected = await client.connect();
+    if (!connected) {
+      this.deps.logger.warn('control pipe connect failed after spawn');
+      return null;
+    }
+    // Auth handshake — ensures the token we wrote is the one the daemon
+    // accepts. Same gate the original bootstrap used.
+    try {
+      await client.rpc('daemon.ping', {});
+    } catch (err) {
+      this.deps.logger.warn(`daemon auth/ping failed: ${this.stringifyError(err)}`);
+      await client.disconnect().catch(() => { /* best-effort */ });
+      return null;
+    }
+    return client;
+  }
+
+  private async install(
+    client: DaemonClient,
+    opts: { isReconnect: boolean },
+  ): Promise<void> {
+    if (this.disposed) {
+      await client.disconnect().catch(() => { /* best-effort */ });
+      return;
+    }
+    this.client = client;
+    // Wire the disconnected listener BEFORE we hand control to onInstall.
+    // If a disconnect raced the install path itself, we still observe it.
+    const listener = () => {
+      this.deps.logger.warn('daemon disconnected (socket close)');
+      this.handleDisconnect('socket close');
+    };
+    this.disconnectedListener = listener;
+    client.on('disconnected', listener);
+
+    await this.deps.onInstall(client);
+
+    if (opts.isReconnect) {
+      this.deps.emit({ type: 'reconnected' });
+    }
+
+    this.startHealthProbe();
+    this.scheduleAttemptReset();
+  }
+
+  private scheduleAttemptReset(): void {
+    this.clearUptimeResetTimer();
+    if (this.attemptCount === 0) return;
+    this.uptimeResetTimer = setTimeout(() => {
+      if (this.disposed) return;
+      this.deps.logger.info(
+        `respawn attempt counter reset after ${this.cfg.resetWindowMs}ms healthy uptime`,
+      );
+      this.attemptCount = 0;
+      this.exhausted = false;
+    }, this.cfg.resetWindowMs);
+  }
+
+  private startHealthProbe(): void {
+    this.stopHealthProbe();
+    if (this.cfg.healthIntervalMs <= 0) return;
+    this.healthFailureCount = 0;
+    this.healthInterval = setInterval(() => {
+      void this.runHealthPing();
+    }, this.cfg.healthIntervalMs);
+  }
+
+  private stopHealthProbe(): void {
+    if (this.healthInterval) {
+      clearInterval(this.healthInterval);
+      this.healthInterval = null;
+    }
+    this.healthFailureCount = 0;
+  }
+
+  private async runHealthPing(): Promise<void> {
+    const client = this.client;
+    if (!client || !client.isConnected) return;
+    try {
+      await client.rpc('daemon.ping', {}, { timeoutMs: this.cfg.healthTimeoutMs });
+      this.healthFailureCount = 0;
+    } catch (err) {
+      this.healthFailureCount++;
+      this.deps.logger.warn(
+        `daemon health ping failed (${this.healthFailureCount}/${this.cfg.hangFailureThreshold}): ${this.stringifyError(err)}`,
+      );
+      if (this.healthFailureCount >= this.cfg.hangFailureThreshold) {
+        this.deps.logger.error(
+          'daemon hang detected — forcing respawn',
+        );
+        // Force a clean disconnect. The socket-close path will still fire
+        // `disconnected`; we set `respawning` first so it short-circuits
+        // to the scheduling logic rather than racing us.
+        this.handleDisconnect('health probe hang');
+        try {
+          client.disconnectSync();
+        } catch { /* best-effort */ }
+      }
+    }
+  }
+
+  private handleDisconnect(reason: string): void {
+    if (this.disposed) return;
+    if (this.respawning) {
+      // Already in the loop — don't double-schedule.
+      this.deps.logger.info(`disconnect during respawn (${reason}) — coalesced`);
+      return;
+    }
+    this.respawning = true;
+    this.stopHealthProbe();
+    this.clearUptimeResetTimer();
+    this.detachDisconnectedListener();
+    this.client = null;
+
+    // Tear down daemon-mode handlers so the user keeps typing in local-PTY
+    // mode while we backoff. onUninstall is idempotent on the caller side.
+    try {
+      this.deps.onUninstall();
+    } catch (err) {
+      this.deps.logger.warn(`onUninstall threw: ${this.stringifyError(err)}`);
+    }
+
+    if (this.exhausted) {
+      this.deps.logger.warn('respawn budget already exhausted — staying local');
+      return;
+    }
+    this.scheduleRespawn();
+  }
+
+  private scheduleRespawn(): void {
+    if (this.disposed) return;
+    this.clearRespawnTimer();
+
+    if (this.attemptCount >= this.cfg.budget) {
+      this.exhausted = true;
+      this.respawning = false;
+      this.deps.logger.error(
+        `respawn budget exhausted (${this.cfg.budget} attempts) — staying in local mode`,
+      );
+      this.deps.emit({ type: 'respawn-exhausted' });
+      return;
+    }
+
+    const attempt = this.attemptCount + 1; // 1-indexed for user-facing log
+    const backoffMs = Math.min(
+      this.cfg.baseBackoffMs * 2 ** this.attemptCount,
+      this.cfg.maxBackoffMs,
+    );
+    this.attemptCount++;
+    this.deps.logger.info(
+      `scheduling daemon respawn attempt ${attempt}/${this.cfg.budget} in ${backoffMs}ms`,
+    );
+    this.deps.emit({ type: 'reconnecting', attempt, backoffMs });
+
+    this.respawnTimer = setTimeout(() => {
+      this.respawnTimer = null;
+      void this.attemptRespawn(attempt);
+    }, backoffMs);
+  }
+
+  private async attemptRespawn(attempt: number): Promise<void> {
+    if (this.disposed) return;
+    try {
+      const client = await this.spawnAndConnect();
+      if (!client) throw new Error('spawnAndConnect returned null');
+      await this.install(client, { isReconnect: true });
+      this.respawning = false;
+      this.deps.logger.info(
+        `daemon respawn succeeded on attempt ${attempt}`,
+      );
+    } catch (err) {
+      this.deps.logger.warn(
+        `respawn attempt ${attempt} failed: ${this.stringifyError(err)}`,
+      );
+      // Loop back through the scheduler so backoff + budget tracking
+      // applies uniformly. `respawning` stays true so re-entrant disconnect
+      // events from a half-built client coalesce instead of double-firing.
+      this.scheduleRespawn();
+    }
+  }
+
+  private clearRespawnTimer(): void {
+    if (this.respawnTimer) {
+      clearTimeout(this.respawnTimer);
+      this.respawnTimer = null;
+    }
+  }
+
+  private clearUptimeResetTimer(): void {
+    if (this.uptimeResetTimer) {
+      clearTimeout(this.uptimeResetTimer);
+      this.uptimeResetTimer = null;
+    }
+  }
+
+  private detachDisconnectedListener(): void {
+    if (this.client && this.disconnectedListener) {
+      try {
+        this.client.off('disconnected', this.disconnectedListener);
+      } catch { /* listener removal is best-effort */ }
+    }
+    this.disconnectedListener = null;
+  }
+
+  private stringifyError(err: unknown): string {
+    if (err instanceof Error) return err.message;
+    try { return String(err); } catch { return '<unstringifiable>'; }
+  }
+}

--- a/src/main/daemon/DaemonRespawnController.ts
+++ b/src/main/daemon/DaemonRespawnController.ts
@@ -201,6 +201,15 @@ export class DaemonRespawnController {
       return;
     }
     this.client = client;
+    // Clear `respawning` BEFORE wiring the disconnected listener for the
+    // new client. Otherwise a disconnect from THIS client (e.g. the
+    // freshly respawned daemon dying inside onInstall, or in the gap
+    // between install resolving and attemptRespawn clearing the flag)
+    // would hit `handleDisconnect`'s respawn-in-progress gate and be
+    // coalesced away — leaving the controller with a dead client
+    // installed, no onUninstall fired, and no respawn scheduled.
+    // Codex review P2 (round 3) on issue #54.
+    this.respawning = false;
     // Wire the disconnected listener BEFORE we hand control to onInstall.
     // If a disconnect raced the install path itself, we still observe it.
     const listener = () => {
@@ -211,6 +220,14 @@ export class DaemonRespawnController {
     client.on('disconnected', listener);
 
     await this.deps.onInstall(client);
+
+    // onInstall could have raced a disconnect from this client (the
+    // listener above would have run synchronously, called
+    // handleDisconnect, nulled this.client, and scheduled a respawn).
+    // In that case, swallow the rest of the install path so we don't
+    // emit a misleading 'reconnected' or start a probe against a dead
+    // socket on top of the new in-flight respawn.
+    if (this.client !== client) return;
 
     if (opts.isReconnect) {
       this.deps.emit({ type: 'reconnected' });
@@ -341,17 +358,27 @@ export class DaemonRespawnController {
       const client = await this.spawnAndConnect();
       if (!client) throw new Error('spawnAndConnect returned null');
       await this.install(client, { isReconnect: true });
-      this.respawning = false;
-      this.deps.logger.info(
-        `daemon respawn succeeded on attempt ${attempt}`,
-      );
+      // `respawning` is cleared inside install() now (before the
+      // listener wires) so a disconnect from the new client during
+      // onInstall is treated as a real event. If install() observed
+      // such a disconnect and scheduled another respawn cycle, we
+      // log success only when the new client is still installed.
+      if (this.client === client) {
+        this.deps.logger.info(`daemon respawn succeeded on attempt ${attempt}`);
+      } else {
+        this.deps.logger.warn(
+          `respawn attempt ${attempt} client died during install — new respawn already scheduled`,
+        );
+      }
     } catch (err) {
       this.deps.logger.warn(
         `respawn attempt ${attempt} failed: ${this.stringifyError(err)}`,
       );
       // Loop back through the scheduler so backoff + budget tracking
-      // applies uniformly. `respawning` stays true so re-entrant disconnect
-      // events from a half-built client coalesce instead of double-firing.
+      // applies uniformly. `respawning` is already true at this point
+      // (set in handleDisconnect) so an in-flight listener event
+      // from the failed-to-build client still coalesces — install()
+      // would have cleared it only on a successful path.
       this.scheduleRespawn();
     }
   }

--- a/src/main/daemon/__tests__/DaemonRespawnController.test.ts
+++ b/src/main/daemon/__tests__/DaemonRespawnController.test.ts
@@ -271,6 +271,48 @@ describe('DaemonRespawnController respawn loop', () => {
     });
   });
 
+  it('handles a disconnect from the newly installed client (not coalesced)', async () => {
+    // Codex P2 (round 3, issue #54): if the respawned client dies inside
+    // onInstall — before attemptRespawn's success log — the disconnect
+    // event must NOT be silently coalesced into the prior respawn cycle.
+    // Otherwise main is left wired to a dead pipe with no recovery.
+    const h = makeHarness({
+      config: { baseBackoffMs: 50, healthIntervalMs: 0, budget: 5 },
+    });
+    const c1 = new FakeDaemonClient();
+    const c2 = new FakeDaemonClient();
+    const c3 = new FakeDaemonClient();
+    h.clientQueue.push(c1, c2, c3);
+
+    // Make onInstall kill the new client synchronously (simulating the
+    // freshly respawned daemon dying during handler swap).
+    let installCount = 0;
+    (h.deps.onInstall as unknown as { mockImplementation: (fn: (c: FakeDaemonClient) => Promise<void>) => void }).mockImplementation(
+      async (client: FakeDaemonClient) => {
+        installCount++;
+        if (installCount === 2) {
+          // The reconnect install — simulate the new daemon dying mid-install.
+          client.fireDisconnect();
+        }
+      },
+    );
+
+    await h.controller.bootstrap();
+    c1.fireDisconnect();
+    await vi.advanceTimersByTimeAsync(50); // attempt 1 finishes install + immediately disconnects
+
+    // onUninstall should have fired again for the dead c2, AND a new
+    // respawn (attempt 2) should be scheduled with c3.
+    expect(h.deps.onUninstall).toHaveBeenCalledTimes(2);
+    const reconnecting = h.events.filter((e) => e.type === 'reconnecting');
+    expect(reconnecting.length).toBe(2);
+
+    // Let attempt 2 succeed with c3.
+    await vi.advanceTimersByTimeAsync(100);
+    expect(h.controller.isHealthy).toBe(true);
+    expect(h.controller.getClient()).toBe(c3);
+  });
+
   it('coalesces a re-entrant disconnect during respawn', async () => {
     const h = makeHarness({
       config: { baseBackoffMs: 1000, healthIntervalMs: 0 },

--- a/src/main/daemon/__tests__/DaemonRespawnController.test.ts
+++ b/src/main/daemon/__tests__/DaemonRespawnController.test.ts
@@ -1,0 +1,377 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import {
+  DaemonRespawnController,
+  type DaemonRespawnDeps,
+  type RespawnEvent,
+} from '../DaemonRespawnController';
+import type { DaemonClient } from '../../DaemonClient';
+import type { DaemonInfo } from '../launcher';
+
+/**
+ * Minimal stub mirroring the parts of `DaemonClient` the controller
+ * touches: `connect()`, `disconnect()`, `disconnectSync()`, `rpc()`,
+ * `isConnected`, and the `disconnected` event. Per-test scripted
+ * behavior keeps the fixtures focused on the controller's logic
+ * rather than on the named-pipe transport.
+ */
+class FakeDaemonClient extends EventEmitter {
+  connected = false;
+  connectImpl: () => Promise<boolean> = async () => {
+    this.connected = true;
+    return true;
+  };
+  rpcImpl: (method: string, params: unknown, opts?: { timeoutMs?: number }) => Promise<unknown> =
+    async () => ({});
+  disconnectCalls = 0;
+  disconnectSyncCalls = 0;
+
+  get isConnected(): boolean {
+    return this.connected;
+  }
+
+  async connect(): Promise<boolean> {
+    return this.connectImpl();
+  }
+
+  async rpc(method: string, params: unknown = {}, opts?: { timeoutMs?: number }): Promise<unknown> {
+    return this.rpcImpl(method, params, opts);
+  }
+
+  async disconnect(): Promise<void> {
+    this.disconnectCalls++;
+    this.connected = false;
+  }
+
+  disconnectSync(): void {
+    this.disconnectSyncCalls++;
+    this.connected = false;
+  }
+
+  /** Helper for tests: simulate the socket-close path. */
+  fireDisconnect(): void {
+    this.connected = false;
+    this.emit('disconnected');
+  }
+}
+
+interface Harness {
+  controller: DaemonRespawnController;
+  events: RespawnEvent[];
+  deps: DaemonRespawnDeps;
+  logs: { level: string; msg: string }[];
+  ensureDaemonCalls: number;
+  /** Queue of clients handed out by `createClient`. Push more before each
+   *  expected respawn so the test controls each generation's behavior. */
+  clientQueue: FakeDaemonClient[];
+  /** All clients ever created, in order — useful for asserting cleanup. */
+  allClients: FakeDaemonClient[];
+}
+
+function makeHarness(
+  opts: {
+    ensureDaemonImpl?: () => Promise<DaemonInfo>;
+    config?: Parameters<typeof buildController>[1];
+  } = {},
+): Harness {
+  const logs: { level: string; msg: string }[] = [];
+  const events: RespawnEvent[] = [];
+  const clientQueue: FakeDaemonClient[] = [];
+  const allClients: FakeDaemonClient[] = [];
+  let ensureCalls = 0;
+
+  const deps: DaemonRespawnDeps = {
+    ensureDaemon: async () => {
+      ensureCalls++;
+      if (opts.ensureDaemonImpl) return opts.ensureDaemonImpl();
+      return { pid: 1234, authToken: 'tok', pipeName: 'pipe', spawned: true };
+    },
+    createClient: () => {
+      const next = clientQueue.shift();
+      if (!next) throw new Error('Test harness: createClient called but queue empty');
+      allClients.push(next);
+      return next as unknown as DaemonClient;
+    },
+    onInstall: vi.fn(async () => { /* no-op stub */ }),
+    onUninstall: vi.fn(() => { /* no-op stub */ }),
+    emit: (event) => { events.push(event); },
+    logger: {
+      info: (msg) => { logs.push({ level: 'info', msg }); },
+      warn: (msg) => { logs.push({ level: 'warn', msg }); },
+      error: (msg) => { logs.push({ level: 'error', msg }); },
+    },
+  };
+
+  const controller = buildController(deps, opts.config);
+  return {
+    controller,
+    events,
+    deps,
+    logs,
+    get ensureDaemonCalls() { return ensureCalls; },
+    clientQueue,
+    allClients,
+  };
+}
+
+function buildController(
+  deps: DaemonRespawnDeps,
+  config?: ConstructorParameters<typeof DaemonRespawnController>[1],
+) {
+  return new DaemonRespawnController(deps, config);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('DaemonRespawnController.bootstrap', () => {
+  it('installs the client on successful initial connect', async () => {
+    const h = makeHarness();
+    const c1 = new FakeDaemonClient();
+    h.clientQueue.push(c1);
+
+    const result = await h.controller.bootstrap();
+    expect(result).toBe(c1);
+    expect(h.controller.isHealthy).toBe(true);
+    expect(h.deps.onInstall).toHaveBeenCalledTimes(1);
+    expect(h.deps.onUninstall).not.toHaveBeenCalled();
+    // Initial bootstrap is NOT a reconnect — no `reconnected` event.
+    expect(h.events).toEqual([]);
+  });
+
+  it('returns null and logs when control pipe connect fails', async () => {
+    const h = makeHarness();
+    const c1 = new FakeDaemonClient();
+    c1.connectImpl = async () => false;
+    h.clientQueue.push(c1);
+
+    const result = await h.controller.bootstrap();
+    expect(result).toBeNull();
+    expect(h.controller.isHealthy).toBe(false);
+    expect(h.deps.onInstall).not.toHaveBeenCalled();
+    expect(h.logs.some((l) => l.level === 'warn' && l.msg.includes('connect failed'))).toBe(true);
+  });
+
+  it('returns null and disconnects when auth-ping fails', async () => {
+    const h = makeHarness();
+    const c1 = new FakeDaemonClient();
+    c1.rpcImpl = async () => { throw new Error('unauthorized'); };
+    h.clientQueue.push(c1);
+
+    const result = await h.controller.bootstrap();
+    expect(result).toBeNull();
+    expect(c1.disconnectCalls).toBe(1);
+    expect(h.deps.onInstall).not.toHaveBeenCalled();
+  });
+});
+
+describe('DaemonRespawnController respawn loop', () => {
+  it('schedules respawn on disconnect with exponential backoff', async () => {
+    const h = makeHarness({
+      config: { baseBackoffMs: 100, maxBackoffMs: 10_000, healthIntervalMs: 0 },
+    });
+    const c1 = new FakeDaemonClient();
+    const c2 = new FakeDaemonClient();
+    h.clientQueue.push(c1, c2);
+
+    await h.controller.bootstrap();
+    expect(h.controller.isHealthy).toBe(true);
+
+    // Simulate socket close.
+    c1.fireDisconnect();
+    // The controller observes the close synchronously through the event
+    // emitter, so the uninstall callback should fire before any timers.
+    expect(h.deps.onUninstall).toHaveBeenCalledTimes(1);
+    expect(h.controller.isHealthy).toBe(false);
+
+    // First reconnecting event uses the initial backoff (100ms).
+    expect(h.events).toEqual([{ type: 'reconnecting', attempt: 1, backoffMs: 100 }]);
+
+    // Advance the scheduled timer and let the respawn complete.
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(h.ensureDaemonCalls).toBe(2); // bootstrap + 1 respawn
+    expect(h.deps.onInstall).toHaveBeenCalledTimes(2);
+    expect(h.events[h.events.length - 1]).toEqual({ type: 'reconnected' });
+    expect(h.controller.isHealthy).toBe(true);
+  });
+
+  it('caps backoff at maxBackoffMs and retries on failures', async () => {
+    const failingEnsure = vi.fn(async () => {
+      throw new Error('spawn failed');
+    });
+    const h = makeHarness({
+      ensureDaemonImpl: failingEnsure as unknown as () => Promise<DaemonInfo>,
+      config: { baseBackoffMs: 100, maxBackoffMs: 500, budget: 5, healthIntervalMs: 0 },
+    });
+
+    // Bootstrap with a successful first client.
+    const okEnsureOnce = vi.fn();
+    const c1 = new FakeDaemonClient();
+    h.clientQueue.push(c1);
+    // Override deps.ensureDaemon temporarily so bootstrap succeeds.
+    const realEnsure = h.deps.ensureDaemon;
+    (h.deps as { ensureDaemon: () => Promise<DaemonInfo> }).ensureDaemon = async () => {
+      okEnsureOnce();
+      return { pid: 1, authToken: 't', pipeName: 'p', spawned: true };
+    };
+    await h.controller.bootstrap();
+    (h.deps as { ensureDaemon: () => Promise<DaemonInfo> }).ensureDaemon = realEnsure;
+
+    c1.fireDisconnect();
+
+    // Walk through the backoff schedule. Expected: 100, 200, 400, 500, 500
+    const expected = [100, 200, 400, 500, 500];
+    for (let i = 0; i < expected.length; i++) {
+      const evt = h.events.filter((e) => e.type === 'reconnecting').pop();
+      expect(evt).toEqual({ type: 'reconnecting', attempt: i + 1, backoffMs: expected[i] });
+      await vi.advanceTimersByTimeAsync(expected[i]);
+    }
+
+    // Budget exhausted on the 6th would-be attempt.
+    const exhausted = h.events.find((e) => e.type === 'respawn-exhausted');
+    expect(exhausted).toBeTruthy();
+    expect(h.controller.isHealthy).toBe(false);
+  });
+
+  it('resets the attempt counter after sustained healthy uptime', async () => {
+    const h = makeHarness({
+      config: {
+        baseBackoffMs: 100,
+        maxBackoffMs: 10_000,
+        healthIntervalMs: 0,
+        resetWindowMs: 5000,
+      },
+    });
+    const c1 = new FakeDaemonClient();
+    const c2 = new FakeDaemonClient();
+    const c3 = new FakeDaemonClient();
+    h.clientQueue.push(c1, c2, c3);
+
+    await h.controller.bootstrap();
+    c1.fireDisconnect();
+    await vi.advanceTimersByTimeAsync(100); // attempt 1 succeeds with c2
+    expect(h.controller.isHealthy).toBe(true);
+
+    // Cross the reset window threshold.
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // Next disconnect should reset to attempt 1 (backoff 100ms), not 200ms.
+    c2.fireDisconnect();
+    const reconnecting = h.events.filter((e) => e.type === 'reconnecting');
+    expect(reconnecting[reconnecting.length - 1]).toEqual({
+      type: 'reconnecting',
+      attempt: 1,
+      backoffMs: 100,
+    });
+  });
+
+  it('coalesces a re-entrant disconnect during respawn', async () => {
+    const h = makeHarness({
+      config: { baseBackoffMs: 1000, healthIntervalMs: 0 },
+    });
+    const c1 = new FakeDaemonClient();
+    const c2 = new FakeDaemonClient();
+    h.clientQueue.push(c1, c2);
+
+    await h.controller.bootstrap();
+    c1.fireDisconnect();
+
+    // Fire a second disconnect while the backoff timer is still pending.
+    // This shouldn't enqueue another attempt or double-fire uninstall.
+    c1.fireDisconnect();
+    expect(h.deps.onUninstall).toHaveBeenCalledTimes(1);
+    const reconnecting = h.events.filter((e) => e.type === 'reconnecting');
+    expect(reconnecting.length).toBe(1);
+  });
+});
+
+describe('DaemonRespawnController health probe', () => {
+  it('triggers respawn after consecutive ping failures', async () => {
+    const h = makeHarness({
+      config: {
+        healthIntervalMs: 1000,
+        healthTimeoutMs: 100,
+        hangFailureThreshold: 3,
+        baseBackoffMs: 50,
+        budget: 5,
+      },
+    });
+    const c1 = new FakeDaemonClient();
+    const c2 = new FakeDaemonClient();
+    h.clientQueue.push(c1, c2);
+
+    // After bootstrap, pings start failing.
+    let pingCalls = 0;
+    c1.rpcImpl = async (method) => {
+      if (method === 'daemon.ping') {
+        pingCalls++;
+        if (pingCalls === 1) return {}; // bootstrap auth ping succeeds
+        throw new Error('ping timeout');
+      }
+      return {};
+    };
+
+    await h.controller.bootstrap();
+    expect(h.controller.isHealthy).toBe(true);
+
+    // 3 ping ticks → all fail → controller forces respawn.
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    // The third failure should have triggered handleDisconnect; that fires
+    // onUninstall and schedules a respawn.
+    expect(h.deps.onUninstall).toHaveBeenCalled();
+    expect(c1.disconnectSyncCalls).toBe(1);
+    const reconnecting = h.events.find((e) => e.type === 'reconnecting');
+    expect(reconnecting).toBeTruthy();
+
+    // Advance the respawn backoff and verify recovery.
+    await vi.advanceTimersByTimeAsync(50);
+    expect(h.controller.isHealthy).toBe(true);
+    expect(h.events.some((e) => e.type === 'reconnected')).toBe(true);
+  });
+
+  it('skips probe ticks when no client is installed', async () => {
+    const h = makeHarness({
+      config: { healthIntervalMs: 100, healthTimeoutMs: 50 },
+    });
+    const c1 = new FakeDaemonClient();
+    c1.connectImpl = async () => false;
+    h.clientQueue.push(c1);
+
+    await h.controller.bootstrap();
+    // No timers should be firing — advance generously and verify no
+    // spurious RPCs / events.
+    await vi.advanceTimersByTimeAsync(500);
+    expect(h.events).toEqual([]);
+  });
+});
+
+describe('DaemonRespawnController.dispose', () => {
+  it('clears pending respawn timers and detaches listeners', async () => {
+    const h = makeHarness({
+      config: { baseBackoffMs: 1000, healthIntervalMs: 0 },
+    });
+    const c1 = new FakeDaemonClient();
+    h.clientQueue.push(c1);
+
+    await h.controller.bootstrap();
+    c1.fireDisconnect();
+    expect(h.events.some((e) => e.type === 'reconnecting')).toBe(true);
+
+    h.controller.dispose();
+
+    // Advance past the would-be respawn — the controller must NOT call
+    // ensureDaemon or install a new client.
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(h.ensureDaemonCalls).toBe(1); // bootstrap only
+    expect(h.controller.isHealthy).toBe(false);
+  });
+});

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -7,7 +7,7 @@ import { app } from 'electron';
 import { getWmuxDir } from '../../daemon/config';
 import { getDaemonPipeName, readDaemonAuthToken } from '../DaemonClient';
 
-interface DaemonInfo {
+export interface DaemonInfo {
   pid: number;
   authToken: string;
   pipeName: string;

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -316,69 +316,81 @@ export async function ensureDaemon(): Promise<DaemonInfo> {
     // the kill — the launcher still cleans the stale files below and
     // spawns a fresh daemon, so the user-visible recovery is unchanged.
     //
-    // (Codex review #2 found the original issue #54 fix would PID-reuse-kill
-    // unrelated processes; this image+cmdline check is the safety net.)
+    // (Codex review #2/#3/#4 hardening sequence on the original issue
+    // #54 fix.) Three categories the gate logic must distinguish:
     //
-    // Three gates, all required, in increasing cost order:
-    //   1. NOT process.pid — never kill ourselves. In dev mode the main
-    //      process and daemon both run via electron.exe, so the basename
-    //      check below cannot distinguish them. Codex review #3 finding.
-    //   2. Image basename matches `process.execPath` — wmux daemons spawn
-    //      via the same exe (`ELECTRON_RUN_AS_NODE=1` in prod, plain
-    //      Electron in dev) so a genuine daemon shares the basename.
-    //   3. Command line contains the daemon script path — narrows the
-    //      surviving false-positive (another Electron app on the same
-    //      basename) to near-zero. Daemons are spawned with the
-    //      `daemon-bundle/index.js` (or fallback) path as argv[1].
-    //
-    // If any gate fails, treat as a stale-reuse victim and skip the kill;
-    // the cleanup + spawn path below still produces a working daemon.
-    const isSelf = existingPid === process.pid;
-    const imageName = getProcessImageName(existingPid);
+    //   (a) Verified-daemon → kill, then spawn. Safe because we know
+    //       what we're killing.
+    //   (b) Verified-stale-reuse (we are sure the PID is NOT our daemon
+    //       anymore — it's ourselves, an unrelated program, or another
+    //       Electron app whose cmdline doesn't carry the daemon script
+    //       path) → don't kill, but the stale-files cleanup + spawn
+    //       path below is safe because the actual daemon is gone.
+    //   (c) Unverified-live (process is alive AND has the wmux image
+    //       basename, but we couldn't read its image or command line at
+    //       all) → refuse to act. Spawning over an unverified live
+    //       daemon would orphan its PTYs and produce duplicate sessions.
+    //       Throw so the respawn controller surfaces the failure via
+    //       its budget + IPC, instead of silently corrupting state.
     const expectedImage = path.basename(process.execPath);
-    const imageMatches = !!imageName &&
-      imageName.toLowerCase() === expectedImage.toLowerCase();
-    let cmdlineMatches = false;
-    let cmdline: string | null = null;
-    if (!isSelf && imageMatches) {
-      cmdline = getProcessCommandLine(existingPid);
-      // Recognize either the production bundle path or any of the dev
-      // tsc-output paths the launcher would spawn from. A precise
-      // substring match keeps us from false-positive-ing on unrelated
-      // Electron apps that happen to share the basename.
-      const daemonMarkers = ['daemon-bundle', 'daemon/daemon/index.js', 'daemon\\daemon\\index.js'];
-      cmdlineMatches = !!cmdline && daemonMarkers.some((m) => cmdline!.includes(m));
-    }
-    if (!isSelf && imageMatches && cmdlineMatches) {
+    const daemonScriptMarkers = ['daemon-bundle', 'daemon/daemon/index.js', 'daemon\\daemon\\index.js'];
+    if (existingPid === process.pid) {
+      // (b) PID file points back at ourselves — the real daemon must be
+      // gone (the OS recycled its PID into us). Safe to clean + spawn.
       console.warn(
-        `[launcher] PID ${existingPid} verified wmux daemon (image="${imageName}", cmdline matched) but unresponsive — terminating before respawn`,
+        `[launcher] daemon.pid=${existingPid} equals current process pid — stale, cleaning + spawning fresh`,
       );
-      try {
-        process.kill(existingPid, 'SIGKILL');
-      } catch (err: unknown) {
-        // ESRCH = process died between isProcessAlive and kill. That's
-        // the benign race — we wanted it gone and it is.
-        const code = (err as NodeJS.ErrnoException | undefined)?.code;
-        if (code !== 'ESRCH') {
-          console.warn(`[launcher] failed to terminate PID ${existingPid}:`, err);
+    } else {
+      const imageName = getProcessImageName(existingPid);
+      if (imageName === null) {
+        // (c) Could not even read the image — refuse.
+        throw new Error(
+          `[launcher] daemon.pid=${existingPid} alive but image lookup failed; refusing to spawn over an unverified live process. Manually delete ${pidFile} if you have verified the daemon is gone.`,
+        );
+      }
+      if (imageName.toLowerCase() !== expectedImage.toLowerCase()) {
+        // (b) Different program owns this PID now — daemon is gone.
+        console.warn(
+          `[launcher] PID ${existingPid} image "${imageName}" != "${expectedImage}" — stale-PID reuse by another program, cleaning + spawning fresh`,
+        );
+      } else {
+        // Image matches — could be the real daemon or another Electron
+        // app. Use the command line to decide.
+        const cmdline = getProcessCommandLine(existingPid);
+        if (cmdline === null) {
+          // (c) Lookup failed — refuse, even though image matched.
+          throw new Error(
+            `[launcher] daemon.pid=${existingPid} alive (image "${imageName}" matches wmux) but command-line lookup failed; refusing to spawn over an unverified live process. Manually delete ${pidFile} if you have verified the daemon is gone.`,
+          );
+        }
+        const cmdlineMatches = daemonScriptMarkers.some((m) => cmdline.includes(m));
+        if (!cmdlineMatches) {
+          // (b) Same image but different app (e.g. another Electron
+          // tool). Don't kill, but the cleanup path below is safe.
+          console.warn(
+            `[launcher] PID ${existingPid} image matches but cmdline does not reference daemon script — stale-PID reuse by sibling Electron app, cleaning + spawning fresh`,
+          );
+        } else {
+          // (a) Verified wmux daemon → kill before respawning.
+          console.warn(
+            `[launcher] PID ${existingPid} verified wmux daemon (image+cmdline) but unresponsive — terminating before respawn`,
+          );
+          try {
+            process.kill(existingPid, 'SIGKILL');
+          } catch (err: unknown) {
+            // ESRCH = process died between isProcessAlive and kill.
+            // That's the benign race — we wanted it gone and it is.
+            const code = (err as NodeJS.ErrnoException | undefined)?.code;
+            if (code !== 'ESRCH') {
+              console.warn(`[launcher] failed to terminate PID ${existingPid}:`, err);
+            }
+          }
+          // Brief settle so the named-pipe handle on the dying daemon's
+          // side releases before spawnDaemon's first `createServer`
+          // listen attempt.
+          await new Promise((resolve) => setTimeout(resolve, 200));
         }
       }
-      // Brief settle so the named-pipe handle on the dying daemon's side
-      // releases before spawnDaemon's first `createServer` listen attempt.
-      await new Promise((resolve) => setTimeout(resolve, 200));
-    } else {
-      const why = isSelf
-        ? `equals current main process pid`
-        : !imageMatches
-          ? `image "${imageName ?? 'unknown'}" != "${expectedImage}"`
-          : `cmdline does not reference daemon script`;
-      console.warn(
-        `[launcher] PID ${existingPid} alive but NOT verified as wmux daemon (${why}) — assuming stale-PID reuse, NOT killing`,
-      );
-      // Fall through to the stale-files + spawn path. The actual
-      // wmux daemon that wrote daemon.pid is gone; the live PID is
-      // either ourselves, another app, or an Electron sibling — must
-      // not be touched.
     }
   }
 

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -218,6 +218,39 @@ export async function ensureDaemon(): Promise<DaemonInfo> {
         return { pid: existingPid, authToken: token, pipeName, spawned: false };
       }
     }
+
+    // PID is alive but we cannot talk to it: either the auth token is
+    // missing or the daemon's event loop is wedged (the `DaemonRespawnController`
+    // health-probe path lands here after `client.disconnectSync()`).
+    //
+    // Without terminating it first, the "clean stale files + spawn"
+    // branch below would leave the original daemon process running,
+    // still holding every PTY child it owns, while a second daemon
+    // spawns and races for the same lock/pipe state. The renderer
+    // would receive duplicate session events, MCP would talk to one
+    // daemon while the watchdog wrote to the other, and at shutdown
+    // one of them would orphan. (Codex review finding, issue #54.)
+    //
+    // On Windows, `process.kill(pid, 'SIGKILL')` calls TerminateProcess
+    // synchronously — no signal forwarding semantics to worry about.
+    // We follow with a short settle window so the kernel finishes
+    // reaping pipe handles before the new daemon tries to listen.
+    console.warn(
+      `[launcher] PID ${existingPid} alive but unresponsive — terminating before respawn`,
+    );
+    try {
+      process.kill(existingPid, 'SIGKILL');
+    } catch (err: unknown) {
+      // ESRCH = process already died between isProcessAlive and kill.
+      // That's the benign race — we wanted it gone and it is.
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code !== 'ESRCH') {
+        console.warn(`[launcher] failed to terminate PID ${existingPid}:`, err);
+      }
+    }
+    // Brief settle so the named-pipe handle on the dying daemon's side
+    // releases before spawnDaemon's first `createServer` listen attempt.
+    await new Promise((resolve) => setTimeout(resolve, 200));
   }
 
   // 3. Clean stale files before spawning — prevents new daemon from seeing

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -55,10 +55,28 @@ function getProcessImageName(pid: number): string | null {
       return match ? match[1] : null;
     } catch { return null; }
   }
-  // POSIX: /proc/<pid>/comm carries the executable name (truncated to 15
-  // bytes on Linux, full name on macOS-with-procfs-mounted, otherwise null).
+  // Linux: /proc/<pid>/comm carries the executable name (truncated to 15
+  // bytes). Fast path because /proc reads are basically free.
+  if (process.platform === 'linux') {
+    try {
+      return fs.readFileSync(`/proc/${pid}/comm`, 'utf-8').trim();
+    } catch { return null; }
+  }
+  // macOS / other POSIX without /proc: shell out to `ps`. The `comm=`
+  // format spec strips the header and emits just the executable name.
+  // (Codex review #5 — without this branch, Darwin lookups always
+  // returned null and the launcher threw on every unresponsive daemon
+  // instead of recovering.)
   try {
-    return fs.readFileSync(`/proc/${pid}/comm`, 'utf-8').trim();
+    const { execFileSync } = require('child_process');
+    const result = execFileSync('/bin/ps', ['-p', String(pid), '-o', 'comm='], {
+      encoding: 'utf-8', timeout: 3000,
+    });
+    const trimmed = result.trim();
+    if (!trimmed) return null;
+    // `ps -o comm=` returns the full path on macOS; the basename
+    // matches the expected wmux image more reliably across builds.
+    return path.basename(trimmed);
   } catch { return null; }
 }
 
@@ -98,10 +116,23 @@ function getProcessCommandLine(pid: number): string | null {
       return trimmed.length > 0 ? trimmed : null;
     } catch { return null; }
   }
-  // POSIX: /proc/<pid>/cmdline carries the argv joined by NUL.
+  // Linux: /proc/<pid>/cmdline carries the argv joined by NUL.
+  if (process.platform === 'linux') {
+    try {
+      const raw = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf-8');
+      return raw.replace(/\0/g, ' ').trim() || null;
+    } catch { return null; }
+  }
+  // macOS / other POSIX without /proc: shell out to `ps`. (Codex
+  // review #5 — Darwin builds need this path so the daemon verifier
+  // can confirm cmdline carries the daemon-script path.)
   try {
-    const raw = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf-8');
-    return raw.replace(/\0/g, ' ').trim() || null;
+    const { execFileSync } = require('child_process');
+    const result = execFileSync('/bin/ps', ['-p', String(pid), '-o', 'command='], {
+      encoding: 'utf-8', timeout: 3000,
+    });
+    const trimmed = result.trim();
+    return trimmed.length > 0 ? trimmed : null;
   } catch { return null; }
 }
 
@@ -333,7 +364,20 @@ export async function ensureDaemon(): Promise<DaemonInfo> {
     //       Throw so the respawn controller surfaces the failure via
     //       its budget + IPC, instead of silently corrupting state.
     const expectedImage = path.basename(process.execPath);
-    const daemonScriptMarkers = ['daemon-bundle', 'daemon/daemon/index.js', 'daemon\\daemon\\index.js'];
+    // Markers must cover ALL the daemon-script candidate paths
+    // spawnDaemon() picks from, in both `/` and `\\` form (Windows
+    // command lines may carry either). Without the bare
+    // `daemon/index.js` variant, a daemon spawned from the fallback
+    // tsc-output layout would fail cmdline verification and the
+    // launcher would silently spawn a second daemon over the live one.
+    // (Codex review #5 finding.)
+    const daemonScriptMarkers = [
+      'daemon-bundle',
+      'daemon/daemon/index.js',
+      'daemon\\daemon\\index.js',
+      'daemon/index.js',
+      'daemon\\index.js',
+    ];
     if (existingPid === process.pid) {
       // (b) PID file points back at ourselves — the real daemon must be
       // gone (the OS recycled its PID into us). Safe to clean + spawn.
@@ -375,20 +419,34 @@ export async function ensureDaemon(): Promise<DaemonInfo> {
           console.warn(
             `[launcher] PID ${existingPid} verified wmux daemon (image+cmdline) but unresponsive — terminating before respawn`,
           );
+          let killSucceeded = true;
           try {
             process.kill(existingPid, 'SIGKILL');
           } catch (err: unknown) {
-            // ESRCH = process died between isProcessAlive and kill.
-            // That's the benign race — we wanted it gone and it is.
             const code = (err as NodeJS.ErrnoException | undefined)?.code;
-            if (code !== 'ESRCH') {
+            if (code === 'ESRCH') {
+              // ESRCH = process died between isProcessAlive and kill.
+              // Benign race — we wanted it gone and it is.
+            } else {
+              // EPERM (Windows: Access Denied), EINVAL, anything else:
+              // we asked the OS to kill the verified daemon and it
+              // refused. Falling through to "clean stale files + spawn"
+              // would now produce two live daemons fighting over the
+              // pipe. Surface the failure so the controller can budget
+              // and retry / give up loudly. (Codex review #5 finding.)
+              killSucceeded = false;
               console.warn(`[launcher] failed to terminate PID ${existingPid}:`, err);
+              throw new Error(
+                `[launcher] verified wmux daemon at PID ${existingPid} alive but SIGKILL failed (${code ?? 'unknown'}); refusing to spawn a second daemon. Resolve the kill failure manually then retry.`,
+              );
             }
           }
-          // Brief settle so the named-pipe handle on the dying daemon's
-          // side releases before spawnDaemon's first `createServer`
-          // listen attempt.
-          await new Promise((resolve) => setTimeout(resolve, 200));
+          if (killSucceeded) {
+            // Brief settle so the named-pipe handle on the dying daemon's
+            // side releases before spawnDaemon's first `createServer`
+            // listen attempt.
+            await new Promise((resolve) => setTimeout(resolve, 200));
+          }
         }
       }
     }

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -62,6 +62,49 @@ function getProcessImageName(pid: number): string | null {
   } catch { return null; }
 }
 
+/**
+ * Read a process's full command line, so callers can verify it actually
+ * carries the daemon-script path before treating it as a wmux daemon.
+ *
+ * This is the second safety net for the kill path: image basename alone
+ * ("electron.exe" in dev) collides with the main process itself and with
+ * any other Electron-based app the user happens to be running. Adding
+ * "did this process get spawned with the daemon script as argv[1]"
+ * narrows the false-positive surface dramatically.
+ *
+ * On Windows uses PowerShell + CIM (WMI replacement) — wmic is being
+ * deprecated and this path runs at most once per ensureDaemon() call.
+ * Returns null on any failure; callers must treat null as "can't verify".
+ */
+function getProcessCommandLine(pid: number): string | null {
+  if (process.platform === 'win32') {
+    try {
+      const { execFileSync } = require('child_process');
+      const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+      const powershell = path.join(
+        systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe',
+      );
+      // Single quotes around the filter so the parser doesn't expand
+      // anything; -NoProfile keeps startup cheap.
+      const result = execFileSync(
+        powershell,
+        [
+          '-NoProfile', '-Command',
+          `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}" -ErrorAction SilentlyContinue).CommandLine`,
+        ],
+        { encoding: 'utf-8', timeout: 5000, windowsHide: true },
+      );
+      const trimmed = result.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    } catch { return null; }
+  }
+  // POSIX: /proc/<pid>/cmdline carries the argv joined by NUL.
+  try {
+    const raw = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf-8');
+    return raw.replace(/\0/g, ' ').trim() || null;
+  } catch { return null; }
+}
+
 function pingDaemon(pipeName: string, token: string, timeoutMs = 3000): Promise<boolean> {
   return new Promise((resolve) => {
     const socket = net.connect(pipeName);
@@ -273,15 +316,42 @@ export async function ensureDaemon(): Promise<DaemonInfo> {
     // the kill — the launcher still cleans the stale files below and
     // spawns a fresh daemon, so the user-visible recovery is unchanged.
     //
-    // (Codex review found the original issue #54 fix would PID-reuse-kill
-    // unrelated processes; this image check is the second-pass safety net.)
+    // (Codex review #2 found the original issue #54 fix would PID-reuse-kill
+    // unrelated processes; this image+cmdline check is the safety net.)
+    //
+    // Three gates, all required, in increasing cost order:
+    //   1. NOT process.pid — never kill ourselves. In dev mode the main
+    //      process and daemon both run via electron.exe, so the basename
+    //      check below cannot distinguish them. Codex review #3 finding.
+    //   2. Image basename matches `process.execPath` — wmux daemons spawn
+    //      via the same exe (`ELECTRON_RUN_AS_NODE=1` in prod, plain
+    //      Electron in dev) so a genuine daemon shares the basename.
+    //   3. Command line contains the daemon script path — narrows the
+    //      surviving false-positive (another Electron app on the same
+    //      basename) to near-zero. Daemons are spawned with the
+    //      `daemon-bundle/index.js` (or fallback) path as argv[1].
+    //
+    // If any gate fails, treat as a stale-reuse victim and skip the kill;
+    // the cleanup + spawn path below still produces a working daemon.
+    const isSelf = existingPid === process.pid;
     const imageName = getProcessImageName(existingPid);
     const expectedImage = path.basename(process.execPath);
     const imageMatches = !!imageName &&
       imageName.toLowerCase() === expectedImage.toLowerCase();
-    if (imageMatches) {
+    let cmdlineMatches = false;
+    let cmdline: string | null = null;
+    if (!isSelf && imageMatches) {
+      cmdline = getProcessCommandLine(existingPid);
+      // Recognize either the production bundle path or any of the dev
+      // tsc-output paths the launcher would spawn from. A precise
+      // substring match keeps us from false-positive-ing on unrelated
+      // Electron apps that happen to share the basename.
+      const daemonMarkers = ['daemon-bundle', 'daemon/daemon/index.js', 'daemon\\daemon\\index.js'];
+      cmdlineMatches = !!cmdline && daemonMarkers.some((m) => cmdline!.includes(m));
+    }
+    if (!isSelf && imageMatches && cmdlineMatches) {
       console.warn(
-        `[launcher] PID ${existingPid} alive (image "${imageName}" matches "${expectedImage}") but unresponsive — terminating before respawn`,
+        `[launcher] PID ${existingPid} verified wmux daemon (image="${imageName}", cmdline matched) but unresponsive — terminating before respawn`,
       );
       try {
         process.kill(existingPid, 'SIGKILL');
@@ -297,12 +367,18 @@ export async function ensureDaemon(): Promise<DaemonInfo> {
       // releases before spawnDaemon's first `createServer` listen attempt.
       await new Promise((resolve) => setTimeout(resolve, 200));
     } else {
+      const why = isSelf
+        ? `equals current main process pid`
+        : !imageMatches
+          ? `image "${imageName ?? 'unknown'}" != "${expectedImage}"`
+          : `cmdline does not reference daemon script`;
       console.warn(
-        `[launcher] PID ${existingPid} alive but image "${imageName ?? 'unknown'}" does not match expected "${expectedImage}" — assuming stale-PID reuse, NOT killing`,
+        `[launcher] PID ${existingPid} alive but NOT verified as wmux daemon (${why}) — assuming stale-PID reuse, NOT killing`,
       );
       // Fall through to the stale-files + spawn path. The actual
       // wmux daemon that wrote daemon.pid is gone; the live PID is
-      // somebody else's process and must not be touched.
+      // either ourselves, another app, or an Electron sibling — must
+      // not be touched.
     }
   }
 

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -29,6 +29,39 @@ function isProcessAlive(pid: number): boolean {
   try { process.kill(pid, 0); return true; } catch { return false; }
 }
 
+/**
+ * Look up the process image name (executable basename) for a PID, so the
+ * launcher can verify a PID actually belongs to wmux before sending SIGKILL.
+ *
+ * Critical for the "alive but unresponsive" branch: after a crash, the OS
+ * may reuse the daemon's PID for an unrelated user process (Chrome, an
+ * IDE, anything). Killing whichever process owns the recycled PID is a
+ * tier-1 "wtf is wmux doing" bug.
+ *
+ * Returns null when lookup fails — callers must treat null as "don't kill".
+ */
+function getProcessImageName(pid: number): string | null {
+  if (process.platform === 'win32') {
+    try {
+      const { execFileSync } = require('child_process');
+      const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+      const tasklist = path.join(systemRoot, 'System32', 'tasklist.exe');
+      const result = execFileSync(tasklist, ['/fi', `PID eq ${pid}`, '/fo', 'csv', '/nh'], {
+        encoding: 'utf-8', timeout: 3000, windowsHide: true,
+      });
+      // tasklist /fo csv /nh format:
+      //   "image.exe","PID","sessionName","sessionNum","memUsage"
+      const match = result.match(/^"([^"]+)"/);
+      return match ? match[1] : null;
+    } catch { return null; }
+  }
+  // POSIX: /proc/<pid>/comm carries the executable name (truncated to 15
+  // bytes on Linux, full name on macOS-with-procfs-mounted, otherwise null).
+  try {
+    return fs.readFileSync(`/proc/${pid}/comm`, 'utf-8').trim();
+  } catch { return null; }
+}
+
 function pingDaemon(pipeName: string, token: string, timeoutMs = 3000): Promise<boolean> {
   return new Promise((resolve) => {
     const socket = net.connect(pipeName);
@@ -226,31 +259,51 @@ export async function ensureDaemon(): Promise<DaemonInfo> {
     // Without terminating it first, the "clean stale files + spawn"
     // branch below would leave the original daemon process running,
     // still holding every PTY child it owns, while a second daemon
-    // spawns and races for the same lock/pipe state. The renderer
-    // would receive duplicate session events, MCP would talk to one
-    // daemon while the watchdog wrote to the other, and at shutdown
-    // one of them would orphan. (Codex review finding, issue #54.)
+    // spawns and races for the same lock/pipe state.
     //
-    // On Windows, `process.kill(pid, 'SIGKILL')` calls TerminateProcess
-    // synchronously — no signal forwarding semantics to worry about.
-    // We follow with a short settle window so the kernel finishes
-    // reaping pipe handles before the new daemon tries to listen.
-    console.warn(
-      `[launcher] PID ${existingPid} alive but unresponsive — terminating before respawn`,
-    );
-    try {
-      process.kill(existingPid, 'SIGKILL');
-    } catch (err: unknown) {
-      // ESRCH = process already died between isProcessAlive and kill.
-      // That's the benign race — we wanted it gone and it is.
-      const code = (err as NodeJS.ErrnoException | undefined)?.code;
-      if (code !== 'ESRCH') {
-        console.warn(`[launcher] failed to terminate PID ${existingPid}:`, err);
+    // BUT — after a crash, daemon.pid may be stale and the OS may have
+    // reused that PID for an unrelated user process (Chrome, an IDE,
+    // an unrelated Electron app). Sending SIGKILL blindly would take
+    // out whatever now owns the recycled PID. Verify the process image
+    // matches the wmux executable before killing. wmux daemons always
+    // run via `process.execPath` (Electron in dev, the packaged exe in
+    // prod with `ELECTRON_RUN_AS_NODE=1`), so the image basename of a
+    // genuine daemon equals `path.basename(process.execPath)`. If it
+    // doesn't match, treat the PID as a stale-reuse victim and skip
+    // the kill — the launcher still cleans the stale files below and
+    // spawns a fresh daemon, so the user-visible recovery is unchanged.
+    //
+    // (Codex review found the original issue #54 fix would PID-reuse-kill
+    // unrelated processes; this image check is the second-pass safety net.)
+    const imageName = getProcessImageName(existingPid);
+    const expectedImage = path.basename(process.execPath);
+    const imageMatches = !!imageName &&
+      imageName.toLowerCase() === expectedImage.toLowerCase();
+    if (imageMatches) {
+      console.warn(
+        `[launcher] PID ${existingPid} alive (image "${imageName}" matches "${expectedImage}") but unresponsive — terminating before respawn`,
+      );
+      try {
+        process.kill(existingPid, 'SIGKILL');
+      } catch (err: unknown) {
+        // ESRCH = process died between isProcessAlive and kill. That's
+        // the benign race — we wanted it gone and it is.
+        const code = (err as NodeJS.ErrnoException | undefined)?.code;
+        if (code !== 'ESRCH') {
+          console.warn(`[launcher] failed to terminate PID ${existingPid}:`, err);
+        }
       }
+      // Brief settle so the named-pipe handle on the dying daemon's side
+      // releases before spawnDaemon's first `createServer` listen attempt.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    } else {
+      console.warn(
+        `[launcher] PID ${existingPid} alive but image "${imageName ?? 'unknown'}" does not match expected "${expectedImage}" — assuming stale-PID reuse, NOT killing`,
+      );
+      // Fall through to the stale-files + spawn path. The actual
+      // wmux daemon that wrote daemon.pid is gone; the live PID is
+      // somebody else's process and must not be touched.
     }
-    // Brief settle so the named-pipe handle on the dying daemon's side
-    // releases before spawnDaemon's first `createServer` listen attempt.
-    await new Promise((resolve) => setTimeout(resolve, 200));
   }
 
   // 3. Clean stale files before spawning — prevents new daemon from seeing

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -36,6 +36,7 @@ import { raceDaemonShutdown } from './daemonShutdownRace';
 import { migrateScrollbackOnce } from './scrollback/legacyMigration';
 import { DaemonNotificationRouter } from './notification/DaemonNotificationRouter';
 import { ensureDaemon } from './daemon/launcher';
+import { DaemonRespawnController } from './daemon/DaemonRespawnController';
 import { createTray, destroyTray } from './tray';
 import { FirstRunOrchestrator } from './firstRun/FirstRunOrchestrator';
 import { registerFirstRunHandlers } from './firstRun';
@@ -182,6 +183,11 @@ let daemonClient: DaemonClient | null = null;
 // PTYBridge writes to in local mode. Without it, daemon mode would render
 // the notification pipeline 100% inert (Codex 2nd review #1).
 let daemonNotificationRouter: DaemonNotificationRouter | null = null;
+// Owns the daemon respawn lifecycle: initial bootstrap, disconnect detection,
+// exponential-backoff respawn attempts, active health-ping probe, and the
+// renderer-facing IPC events (daemon:reconnecting / :reconnected /
+// :respawn-exhausted). Lifetime: created on `ready`, disposed on `before-quit`.
+let daemonRespawnController: DaemonRespawnController | null = null;
 
 // v2.8.1 hotfix (Bug 3): one-shot decision flag for the daemon-vs-local
 // mode. Stays false until app.on('ready') has finished its connect
@@ -416,84 +422,99 @@ app.on('ready', async () => {
   // callback is a no-op; before-quit's first pass sets isQuitting itself.
   createTray(mainWindow, () => { /* no-op — before-quit handles isQuitting */ });
 
-  // Auto-start daemon and connect
-  try {
-    const daemonInfo = await ensureDaemon();
-    console.log(`[Main] Daemon ${daemonInfo.spawned ? 'spawned' : 'found'} (PID: ${daemonInfo.pid})`);
-
-    const client = new DaemonClient(daemonInfo.pipeName, daemonInfo.authToken);
-    const connected = await client.connect();
-    if (connected) {
-      let authOk = false;
+  // Auto-start daemon and connect.
+  //
+  // Previously a one-shot `ensureDaemon()` call with a degrade-only
+  // `disconnected` handler — once the daemon died, the app silently
+  // ran in local-only mode for the rest of the session (no persistence,
+  // no MCP notifications, no memory watchdog). Issue #54.
+  //
+  // `DaemonRespawnController` owns the full lifecycle now: initial
+  // launch, exponential-backoff respawn (5 attempts, 1s→30s, reset
+  // after 5 min healthy uptime), active health-ping probe to catch
+  // daemon-hang cases the socket-close path misses, and renderer
+  // signaling via `daemon:reconnecting` / `daemon:reconnected` /
+  // `daemon:respawn-exhausted` so UX can show a toast/badge.
+  daemonRespawnController = new DaemonRespawnController({
+    ensureDaemon,
+    createClient: (pipeName, token) => new DaemonClient(pipeName, token),
+    onInstall: async (client) => {
+      daemonClient = client;
+      console.log('[Main] Connected to wmux-daemon (auth verified)');
+      // Handler swap to daemon-routed mode. The microsecond window where
+      // pty/* handlers are torn down and re-registered is the same
+      // surface the original code used; the swap is logged for the
+      // race-investigation breadcrumb trail kept by previous fixes.
+      logLine('info', 'main', 'handler swap (daemon connect): cleanup begin');
+      cleanupHandlers();
+      logLine('info', 'main', 'handler swap (daemon connect): cleanup done, register begin');
+      cleanupHandlers = registerAllHandlers(ptyManager, ptyBridge, () => mainWindow, daemonClient, mcpHandlerOptions);
+      logLine('info', 'main', 'handler swap (daemon connect): register done');
+      // Mount the notification router now that we have a live daemon
+      // client. PTY data flows through daemon → DaemonClient events,
+      // and this router translates them into the same renderer-facing
+      // IPC signals PTYBridge produces in local mode.
+      daemonNotificationRouter?.stop();
+      daemonNotificationRouter = new DaemonNotificationRouter(client, () => mainWindow);
+      daemonNotificationRouter.start();
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('daemon:connected');
+      }
+      // Phase A — A7. Run the one-time legacy scrollback migration on
+      // the first daemon-healthy transition. Idempotent — subsequent
+      // calls (e.g. after respawn) return status=already-migrated and
+      // are no-ops; safe to invoke on every install.
       try {
-        await client.rpc('daemon.ping', {});
-        authOk = true;
-      } catch {
-        console.warn('[Main] Daemon auth failed after spawn, falling back to local PTY');
-        await client.disconnect().catch(() => {});
+        const result = migrateScrollbackOnce(app.getPath('userData'), app.getVersion());
+        if (result.status === 'migrated') {
+          console.log(`[Main] A7 scrollback legacy migration → ${result.legacyDir}`);
+        } else if (result.status === 'retry-needed') {
+          console.warn(`[Main] A7 scrollback migration retry-needed: ${result.error}`);
+        }
+      } catch (err) {
+        console.warn('[Main] A7 scrollback migration threw:', err);
       }
-      if (authOk) {
-        daemonClient = client;
-        console.log('[Main] Connected to wmux-daemon (auth verified)');
-        // Instrumentation: handler swap race investigation. The cleanup →
-        // re-register sequence below tears down IPC handlers (including
-        // scrollback:load) for a microsecond window. If the renderer's bulk
-        // useTerminal mount fires scrollback.load during this window, the
-        // invokes reject silently and the post-boot autosave overwrites the
-        // previous scrollback files. Logging the exact swap boundary so we
-        // can correlate with renderer-side .catch traces.
-        logLine('info', 'main', 'handler swap (daemon connect): cleanup begin');
-        cleanupHandlers();
-        logLine('info', 'main', 'handler swap (daemon connect): cleanup done, register begin');
-        cleanupHandlers = registerAllHandlers(ptyManager, ptyBridge, () => mainWindow, daemonClient, mcpHandlerOptions);
-        logLine('info', 'main', 'handler swap (daemon connect): register done');
-        // Mount the notification router now that we have a live daemon
-        // client. PTY data flows through daemon → DaemonClient events, and
-        // this router translates them into the same renderer-facing IPC
-        // signals PTYBridge produces in local mode.
-        daemonNotificationRouter = new DaemonNotificationRouter(daemonClient, () => mainWindow);
-        daemonNotificationRouter.start();
-        // Notify renderer that daemon is now connected so it can re-reconcile
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.webContents.send('daemon:connected');
-        }
-        // Phase A — A7. Run the one-time legacy scrollback migration on
-        // the first daemon-healthy transition. Best-effort: if rename
-        // fails (EBUSY/EPERM under antivirus) the runner returns
-        // retry-needed and the next transition tries again. Log the
-        // breadcrumb either way so the user can spot a stuck migration
-        // in the main-side log.
-        try {
-          const result = migrateScrollbackOnce(app.getPath('userData'), app.getVersion());
-          if (result.status === 'migrated') {
-            console.log(`[Main] A7 scrollback legacy migration → ${result.legacyDir}`);
-          } else if (result.status === 'retry-needed') {
-            console.warn(`[Main] A7 scrollback migration retry-needed: ${result.error}`);
-          }
-        } catch (err) {
-          console.warn('[Main] A7 scrollback migration threw:', err);
-        }
-        daemonClient.on('disconnected', () => {
-          console.warn('[Main] Daemon disconnected, falling back to local PTY');
-          daemonNotificationRouter?.stop();
-          daemonNotificationRouter = null;
-          daemonClient = null;
-          // Phase A — A6. Notify the renderer so the daemon-mode .txt
-          // write/load gates open again (local mode preserves the
-          // pre-existing scrollback path). Without this, the renderer
-          // would still treat itself as daemon-connected and skip the
-          // .txt autosave even though no daemon is replaying PTY data.
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('daemon:disconnected');
-          }
-          logLine('warn', 'main', 'handler swap (daemon disconnect): cleanup begin');
-          cleanupHandlers();
-          logLine('warn', 'main', 'handler swap (daemon disconnect): cleanup done, register begin');
-          cleanupHandlers = registerAllHandlers(ptyManager, ptyBridge, () => mainWindow, undefined, mcpHandlerOptions);
-          logLine('warn', 'main', 'handler swap (daemon disconnect): register done');
+    },
+    onUninstall: () => {
+      console.warn('[Main] Daemon disconnected, falling back to local PTY');
+      daemonNotificationRouter?.stop();
+      daemonNotificationRouter = null;
+      daemonClient = null;
+      // Phase A — A6. Notify the renderer so the daemon-mode .txt
+      // write/load gates open again (local mode preserves the
+      // pre-existing scrollback path). Without this, the renderer
+      // would still treat itself as daemon-connected and skip the
+      // .txt autosave even though no daemon is replaying PTY data.
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('daemon:disconnected');
+      }
+      logLine('warn', 'main', 'handler swap (daemon disconnect): cleanup begin');
+      cleanupHandlers();
+      logLine('warn', 'main', 'handler swap (daemon disconnect): cleanup done, register begin');
+      cleanupHandlers = registerAllHandlers(ptyManager, ptyBridge, () => mainWindow, undefined, mcpHandlerOptions);
+      logLine('warn', 'main', 'handler swap (daemon disconnect): register done');
+    },
+    emit: (event) => {
+      if (!mainWindow || mainWindow.isDestroyed()) return;
+      if (event.type === 'reconnecting') {
+        mainWindow.webContents.send('daemon:reconnecting', {
+          attempt: event.attempt,
+          backoffMs: event.backoffMs,
         });
+      } else if (event.type === 'reconnected') {
+        mainWindow.webContents.send('daemon:reconnected');
+      } else if (event.type === 'respawn-exhausted') {
+        mainWindow.webContents.send('daemon:respawn-exhausted');
       }
-    }
+    },
+    logger: {
+      info: (msg) => { logLine('info', 'daemon-respawn', msg); },
+      warn: (msg) => { logLine('warn', 'daemon-respawn', msg); },
+      error: (msg) => { logLine('error', 'daemon-respawn', msg); },
+    },
+  });
+  try {
+    await daemonRespawnController.bootstrap();
   } catch (err) {
     console.warn('[Main] Daemon auto-start failed, using local PTY:', err);
   }
@@ -701,6 +722,14 @@ app.on('before-quit', async (e) => {
 
   cleanupHandlers();
   disposeFirstRunHandlers();
+  // Tear down the respawn controller BEFORE the daemon-shutdown race so
+  // a daemon close during the race window can't trigger a respawn attempt
+  // while the rest of the app is exiting. `dispose()` only stops timers
+  // and detaches listeners — it does NOT call `onUninstall()`, so the
+  // shutdown-race path below remains the single authority for taking the
+  // client offline cleanly.
+  daemonRespawnController?.dispose();
+  daemonRespawnController = null;
 
   // Capture the daemon-client reference BEFORE the race. The race awaits
   // for up to 4 s; during that window the daemon may close its socket,

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -164,6 +164,31 @@ const electronAPI = {
       ipcRenderer.on('daemon:disconnected', listener);
       return () => { ipcRenderer.removeListener('daemon:disconnected', listener); };
     },
+    // Issue #54. Respawn-loop telemetry — fired before each backoff so the
+    // renderer can show a "Daemon reconnecting (attempt N)…" toast/badge
+    // instead of leaving the user with a silent local-only degrade.
+    onReconnecting: (callback: (info: { attempt: number; backoffMs: number }) => void) => {
+      const listener = (_e: Electron.IpcRendererEvent, info: { attempt: number; backoffMs: number }) => callback(info);
+      ipcRenderer.on('daemon:reconnecting', listener);
+      return () => { ipcRenderer.removeListener('daemon:reconnecting', listener); };
+    },
+    // Fires once a respawned client is healthy again. Distinct from
+    // `onConnected` so the renderer can choose to show recovery UX
+    // (e.g. "Daemon reconnected — sessions restored") rather than the
+    // cold-boot path.
+    onReconnected: (callback: () => void) => {
+      const listener = () => callback();
+      ipcRenderer.on('daemon:reconnected', listener);
+      return () => { ipcRenderer.removeListener('daemon:reconnected', listener); };
+    },
+    // Budget exhausted — user should be told the app is permanently in
+    // local-only mode for this session and that restarting wmux will
+    // attempt a fresh daemon launch.
+    onRespawnExhausted: (callback: () => void) => {
+      const listener = () => callback();
+      ipcRenderer.on('daemon:respawn-exhausted', listener);
+      return () => { ipcRenderer.removeListener('daemon:respawn-exhausted', listener); };
+    },
     /**
      * Resolves once main has finalized the daemon-vs-local decision.
      * Returns `{ connected: bool }` reflecting the CURRENT state at


### PR DESCRIPTION
Closes #54.

## Summary

Daemon used to spawn once at boot. If it died or its event loop wedged,
the Electron main process silently degraded to local-PTY mode for the
rest of the session — no background persistence, no OSC 133 prompt log,
no MCP notifications, no memory watchdog. The user only found out after
a restart wiped session state.

This PR adds `DaemonRespawnController`, an active health probe, and a
verified kill gate so the app self-heals.

## What's in the loop

- **Exponential-backoff respawn** — 5 attempts, 1s → 30s cap. Counter
  resets after 5 minutes of healthy uptime.
- **Active `daemon.ping` health probe** — 10s interval, 3s timeout.
  Three consecutive failures force a respawn even if the socket is
  still open, catching the "daemon process alive but event loop
  wedged" case the socket-close path misses.
- **Renderer IPC events** — `daemon:reconnecting` (with attempt + backoff
  ms), `daemon:reconnected`, `daemon:respawn-exhausted`. Renderer can
  show a toast/badge rather than a silent local-only degrade.
- **Re-entrant disconnect coalescing** — socket-close + health-probe
  cannot double-schedule a respawn. The `respawning` flag clears
  inside `install()` before the new listener wires so a disconnect
  from the freshly respawned client is still treated as a real event.

## What's in the kill gate

When the controller forces a respawn and `ensureDaemon()` lands in the
"PID alive but ping fail" branch, the launcher now distinguishes three
categories before deciding what to do:

| Category | Trigger | Action |
|----------|---------|--------|
| **Verified daemon** | image basename matches `process.execPath` AND command line carries a known daemon-script path | SIGKILL, settle 200 ms, then spawn fresh |
| **Verified stale-PID reuse** | PID equals `process.pid`, image is a different program, or cmdline doesn't reference the daemon | Don't kill, fall through to clean-files + spawn |
| **Indeterminate** | image or cmdline lookup failed | Throw — refuse to spawn over an unverified live process. Caller (the respawn controller) surfaces this via its backoff + exhausted IPC, with a clear "manually delete daemon.pid" message |

Identity checks per platform:
- Windows: `tasklist` for image, PowerShell + Get-CimInstance for cmdline (wmic is deprecated)
- Linux: `/proc/<pid>/{comm,cmdline}` fast path
- macOS / other POSIX: `ps -p PID -o comm=` and `-o command=`

`DaemonClient.disconnectSync()` now rejects pending RPCs (previously
silently dropped them, which was safe for exit but hung renderer
actions on the runtime respawn path).

## Codex review iterations

`/codex review --base main` ran 5 times. Each pass found and fixed real
issues:

1. P1: orphan daemon on hang detect → add kill-before-respawn
2. P1: kill could SIGKILL a reused PID → add image-name verification
3. P2×2: coalesce gate dropped new-client disconnect / dev-mode could
   self-kill → clear `respawning` in install, add `process.pid` exclusion
   and cmdline verification
4. P2×2: `disconnectSync` dropped pending RPCs / spawn-over-unverified
   could orphan → reject pendings; throw on indeterminate state
5. P2×3: Darwin had no `/proc`, marker list missed `daemon/index.js`
   fallback, SIGKILL failure fell through to spawn → add `ps` lookups,
   complete marker list, throw on non-ESRCH kill failure

The 6th pass hit OpenAI usage limits; no new findings before that.

## Tests

- 11 new unit tests in `DaemonRespawnController.test.ts` covering
  bootstrap success/failure, exponential backoff schedule, budget
  exhaustion, healthy-uptime counter reset, re-entrant disconnect
  coalescing, hang detection via failed pings, **new-client
  disconnect during install**, and dispose() cleanup
- Full suite: **1458 / 1458 passing**
- `tsc --noEmit` clean
- ESLint clean for new files

## Files changed

- `src/main/daemon/DaemonRespawnController.ts` (new) — controller, ~430 LOC
- `src/main/daemon/__tests__/DaemonRespawnController.test.ts` (new) — 11 cases
- `src/main/daemon/launcher.ts` — kill gate + verifier helpers
- `src/main/DaemonClient.ts` — `disconnectSync` rejects pendings
- `src/main/index.ts` — bootstrap rewired to controller-driven lifecycle, `before-quit` disposes the controller first
- `src/preload/preload.ts` — `daemon.onReconnecting / onReconnected / onRespawnExhausted` listeners

## Test plan

- [ ] Dev: `npm start`, daemon comes up, terminals work
- [ ] Open Task Manager, kill the wmux daemon process
- [ ] Verify renderer sees `daemon:reconnecting` then `daemon:reconnected` within a few seconds
- [ ] Verify sessions/PTYs recover and persistence resumes
- [ ] Kill daemon 5+ times in rapid succession → verify exhausted event fires and renderer falls back gracefully
- [ ] Leave daemon running 5+ minutes, then kill once → verify attempt counter reset (backoff starts at 1s, not the prior cap)

Refs #54