### PR TITLE
fix(test): runSnapshotOnce — defuse 7-day time bomb in lastActivity fixture

### DIFF
--- a/src/daemon/__tests__/runSnapshotOnce.test.ts
+++ b/src/daemon/__tests__/runSnapshotOnce.test.ts
@@ -71,6 +71,11 @@ describe('createSnapshotRunner (A1b — extracted from periodic interval body)',
   // session 019e2af8.
   it('merges cap-skipped sessions from existing sessions.json into the save', async () => {
     const sessionsFile = path.join(tmpDir, 'sessions.json');
+    // lastActivity is dynamic so SUSPENDED_TTL_HOURS (7 days in StateWriter.load)
+    // never expires this fixture. The original hardcoded '2026-05-15' silently
+    // expired exactly 7 days later and broke this test on every CI run after
+    // 2026-05-22T00:00Z, regardless of any code change.
+    const recentIso = new Date(Date.now() - 60 * 60 * 1000).toISOString();
     fs.writeFileSync(
       sessionsFile,
       JSON.stringify({
@@ -85,8 +90,8 @@ describe('createSnapshotRunner (A1b — extracted from periodic interval body)',
             cols: 80,
             rows: 24,
             pid: 999,
-            createdAt: '2026-05-15T00:00:00Z',
-            lastActivity: '2026-05-15T00:00:00Z',
+            createdAt: recentIso,
+            lastActivity: recentIso,
             deadTtlHours: 24,
           },
         ],


### PR DESCRIPTION
## Summary

main CI started failing on every run after 2026-05-22T00:00:00Z, unrelated to any code change. Root cause: `src/daemon/__tests__/runSnapshotOnce.test.ts` line 88-89 used a hardcoded ISO date (`'2026-05-15T00:00:00Z'`) for a `suspended` session fixture. `StateWriter.load()` prunes any session whose `state === 'suspended'` and whose `lastActivity` is older than `SUSPENDED_TTL_HOURS = 7 * 24 = 168h`. Exactly 7 days after the hardcoded date — 2026-05-22T00:00Z — the fixture silently crossed the TTL boundary and the test asserting `['cap-skipped', 'live-one']` started receiving `['live-one']` instead.

PR #56 (merged 2026-05-21T12:08Z, ~156h after the fixture date) was the last CI run that passed. PR #57 (merged 2026-05-22T00:56Z, ~168.93h) was the first to fail, but the failure has nothing to do with PR #57's diff — it's the time bomb expiring.

## Failing test path

`src/daemon/__tests__/runSnapshotOnce.test.ts:107` →
`StateWriter.ts:194-209` (prunes when `now - lastActivity > 168h`) →
`SUSPENDED_TTL_HOURS = 7 * 24` constant.

## Fix

Compute `lastActivity` dynamically from `Date.now() - 1h` so the fixture is always well within the 168h window:

```ts
const recentIso = new Date(Date.now() - 60 * 60 * 1000).toISOString();
// ...
createdAt: recentIso,
lastActivity: recentIso,
```

Two-line change. No production code touched. The `'takes sessionManager state as authoritative'` test at line 134 uses `'2026-01-01T00:00:00Z'` but its fixture has `state: 'detached'`, which `StateWriter.load()` does not prune (detached is runtime-only and is not on the prune path), so it survives.

## Verification

- `npx vitest run src/daemon/__tests__/runSnapshotOnce.test.ts`: 7/7 pass.
- `npx vitest run` full suite: 1664/1665 pass. The single remaining failure is `src/daemon/__tests__/ProcessMonitor.test.ts > watch calls onDead when process does not exist` — a pre-existing CPU-contention flake tracked as P3 in TODOS.md, completely unrelated to this fix or to PR #57. Passes 11/11 in isolation.
- `npx tsc --noEmit -p .`: clean.

## Why this slipped through

The test was introduced in commit 21b24d3 (v2.9.1, mid-May 2026). Local + CI runs during the first ~7 days were inside the TTL window. After that, the test was guaranteed to fail. No code change can fix it without addressing the time dependency. PR #57's merge timing was incidental — main would have gone red on the first CI run after 2026-05-22T00:00Z regardless.

## Test Plan

- [x] vitest runSnapshotOnce: 7/7 pass
- [x] vitest full suite (excluding pre-existing ProcessMonitor flake): 1664/1664 pass
- [x] tsc --noEmit -p . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
