### PR TITLE
fix(daemon): ProcessMonitor.watch immediate first probe — closes CI flake

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -117,20 +117,11 @@
 - **Depends on:** None.
 - **Priority:** P3 (purely a maintenance nit)
 
-## (P3) Pre-existing daemon ProcessMonitor flake
-- **What:** `src/daemon/__tests__/ProcessMonitor.test.ts > watch calls onDead
-  when process does not exist` times out under CPU-contention conditions in
-  the full vitest suite, but passes 11/11 in isolation.
-- **Why:** Flake is purely a CPU-contention timeout in the Windows process
-  probe. Surfaces in ~1 in 5 full-suite runs. Completely unrelated to
-  notification work but flagged in three separate Phase 3 reviews (T9, T11,
-  T12) so worth tracking.
-- **Pros:** Reduces CI flake noise + future review confusion.
-- **Cons:** Daemon process probing is timing-sensitive; lengthening timeout
-  may mask a real regression. Investigation required first.
-- **Context:** `src/daemon/__tests__/ProcessMonitor.test.ts` line ~24 onwards.
-  Likely fix: bump the timeout (currently 5000ms; full-suite run takes ~14s
-  for the daemon block alone). Verify the test still catches an actual dead
-  process.
-- **Depends on:** None.
-- **Priority:** P3 (CI hygiene)
+<!-- (P3) Pre-existing daemon ProcessMonitor flake — RESOLVED 2026-05-22.
+     Root cause: watch() relied on the CHECK_INTERVAL_MS setInterval tick
+     for the first probe; under CPU contention a 50ms interval + two tasklist
+     execs (1-6s each) could exceed the test's 5s default it() timeout.
+     Fix: watch() now triggers an immediate first runBatchCheck (production
+     code) AND the test's outer it() timeout is bumped to 20s with a 15s
+     vi.waitFor budget. Verified stable across 5 consecutive full-suite runs. -->
+

--- a/src/daemon/ProcessMonitor.ts
+++ b/src/daemon/ProcessMonitor.ts
@@ -105,6 +105,10 @@ export class ProcessMonitor {
     this.unwatch(sessionId);
     this.watchedPids.set(sessionId, { pid, onDead });
     this.ensureBatchInterval();
+    // Immediate first check so a PID that is already dead at watch() time
+    // doesn't have to wait CHECK_INTERVAL_MS for the first interval tick.
+    // batchRunning guards against concurrent overlap with a running cycle.
+    void this.runBatchCheck();
   }
 
   /** Stop monitoring a specific session. */

--- a/src/daemon/__tests__/ProcessMonitor.test.ts
+++ b/src/daemon/__tests__/ProcessMonitor.test.ts
@@ -31,14 +31,18 @@ describe('ProcessMonitor', () => {
       // Watch a PID that does not exist
       monitor.watch('sess-fake', 99999999, onDead);
 
-      // Wait for the async check to complete
+      // Wait for the async check to complete. On Windows, watch() now triggers
+      // an immediate first runBatchCheck (ProcessMonitor.ts), but tasklist
+      // exec under CI CPU contention can take 1-6s per call and the cycle
+      // does two of them (batch + per-PID re-verify). 15s buffer keeps this
+      // robust against parallel-suite latency without masking real bugs.
       await vi.waitFor(() => {
         expect(onDead).toHaveBeenCalledTimes(1);
-      }, { timeout: 5000 });
+      }, { timeout: 15000 });
     } finally {
       Object.defineProperty(ProcessMonitor, 'CHECK_INTERVAL_MS', { value: origInterval, configurable: true });
     }
-  });
+  }, 20000); // outer it() timeout — must exceed waitFor's 15s budget
 
   it('unwatch stops monitoring a session', async () => {
     monitor = new ProcessMonitor();

--- a/src/daemon/__tests__/runSnapshotOnce.test.ts
+++ b/src/daemon/__tests__/runSnapshotOnce.test.ts
@@ -71,6 +71,11 @@ describe('createSnapshotRunner (A1b — extracted from periodic interval body)',
   // session 019e2af8.
   it('merges cap-skipped sessions from existing sessions.json into the save', async () => {
     const sessionsFile = path.join(tmpDir, 'sessions.json');
+    // lastActivity is dynamic so SUSPENDED_TTL_HOURS (7 days in StateWriter.load)
+    // never expires this fixture. The original hardcoded '2026-05-15' silently
+    // expired exactly 7 days later and broke this test on every CI run after
+    // 2026-05-22T00:00Z, regardless of any code change.
+    const recentIso = new Date(Date.now() - 60 * 60 * 1000).toISOString();
     fs.writeFileSync(
       sessionsFile,
       JSON.stringify({
@@ -85,8 +90,8 @@ describe('createSnapshotRunner (A1b — extracted from periodic interval body)',
             cols: 80,
             rows: 24,
             pid: 999,
-            createdAt: '2026-05-15T00:00:00Z',
-            lastActivity: '2026-05-15T00:00:00Z',
+            createdAt: recentIso,
+            lastActivity: recentIso,
             deadTtlHours: 24,
           },
         ],


### PR DESCRIPTION
## Summary

Resolves the long-standing CI flake on `src/daemon/__tests__/ProcessMonitor.test.ts > watch calls onDead when process does not exist`. Surfaced in ~1/5 full-suite runs but passed in isolation. Tracked as P3 in TODOS.md after three Phase 3 reviews flagged it. PR #58 closed the time-bomb on `runSnapshotOnce`; this one closes the remaining CI red.

## Root Cause

`ProcessMonitor.watch(sessionId, pid, onDead)` registered the PID, set up the `CHECK_INTERVAL_MS` `setInterval`, and returned — leaving the first probe to the first tick. The test reduces the interval to 50ms so polling fires fast, but each cycle runs **two** Windows `tasklist` execs:

1. `tasklist /fo csv /nh` — the batch process list (`batchCheckAlive`)
2. `tasklist /fi PID eq <pid>` — per-PID re-verify (`isAlive`, added to defend against cascade-fire from a malformed batch)

On Windows under CI CPU contention, each `tasklist` exec runs 1-6s. Worst case = 12s+ before `onDead` fires. The test's `it()` had vitest's default 5000ms timeout. Inevitable timeout under load.

## Fix (two parts)

**Production — `src/daemon/ProcessMonitor.ts` `watch()`:**
```ts
this.watchedPids.set(sessionId, { pid, onDead });
this.ensureBatchInterval();
// NEW: immediate first check
void this.runBatchCheck();
```
- `batchRunning` flag inside `runBatchCheck` already guards against concurrent overlap with an already-running cycle.
- Side benefit: production code now detects already-dead PIDs immediately instead of waiting up to 5s for the next interval tick. Net latency improvement for real workload.

**Test — `src/daemon/__tests__/ProcessMonitor.test.ts`:**
```ts
}, 20000); // outer it() timeout — must exceed waitFor's 15s budget
```
- Outer `it()` timeout bumped 5000ms → 20000ms.
- Inner `vi.waitFor` budget already 15s after this fix.
- Comments explain the `tasklist` latency floor so future tuners don't shrink it back.

## Verification

5 consecutive full-suite runs, all green:
```
Test Files  136 passed (136)
     Tests  1665 passed (1665)
```

Before this fix: ~1/5 runs failed on the same test.

## What did NOT change

- `CHECK_INTERVAL_MS` (5000 in production, 50 in the test override) — intentional.
- The per-PID re-verify logic (`tasklist /fi PID eq`) — that's the cascade-fire defense for production. Keeping both calls.
- Other tests in the same file — they already passed and were not flake-prone.

## Test Plan

- [x] vitest ProcessMonitor.test.ts: 11/11 pass (3 isolated runs)
- [x] vitest full suite: 1665/1665 pass (5 consecutive runs)
- [x] tsc --noEmit -p . clean

## TODOS.md

Removed the corresponding "(P3) Pre-existing daemon ProcessMonitor flake" entry, with a marker comment recording the resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
