### PR TITLE
feat(hooks): Phase 1.5 signal-health + Phase 2 usage meter + env-first routing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "wmux",
   "owner": {
     "name": "wmux",
-    "url": "https://github.com/iamwongeeeee/wmux"
+    "url": "https://github.com/openwong2kim/wmux"
   },
   "metadata": {
     "description": "wmux Claude Code integrations — hook bridges and future usage meters.",

--- a/integrations/claude/.claude-plugin/plugin.json
+++ b/integrations/claude/.claude-plugin/plugin.json
@@ -4,9 +4,9 @@
   "description": "Deterministic Claude Code → wmux notifications via PostToolUse / Stop / SubagentStop / SessionStart hooks. Replaces wmux's regex-based agent detector with 100%-accurate hook signals when this plugin is installed.",
   "author": {
     "name": "wmux",
-    "url": "https://github.com/iamwongeeeee/wmux"
+    "url": "https://github.com/openwong2kim/wmux"
   },
-  "homepage": "https://github.com/iamwongeeeee/wmux",
+  "homepage": "https://github.com/openwong2kim/wmux",
   "license": "MIT",
   "keywords": ["wmux", "terminal", "notifications", "hooks"]
 }

--- a/integrations/claude/README.md
+++ b/integrations/claude/README.md
@@ -19,17 +19,37 @@ This plugin is the bridge: hook fires → bridge reads stdin and
 
 ## Install
 
+### Option A — from GitHub (typical)
+
 Run inside Claude Code:
 
 ```
-/plugin marketplace add iamwongeeeee/wmux
-/plugin install wmux-claude-integration
+/plugin marketplace add openwong2kim/wmux
+/plugin install wmux-claude-integration@wmux
 ```
 
-After install, restart your Claude Code session for the hooks to take
-effect. wmux must be running to receive signals; if it isn't, the
-bridge logs the miss to `~/.wmux/bridge.log` and exits 0 so Claude is
-not slowed down.
+### Option B — from a local checkout (dev / dogfood before merge)
+
+If you've cloned this repo and want to test the plugin against the
+current branch without pushing to GitHub first:
+
+```
+/plugin marketplace add D:/wmux
+/plugin install wmux-claude-integration@wmux
+```
+
+Substitute your local clone path. Claude Code reads
+`.claude-plugin/marketplace.json` from that directory.
+
+### After either path
+
+Restart your Claude Code session for the hooks to take effect. wmux
+must be running to receive signals; if it isn't, the bridge logs the
+miss to `~/.wmux/bridge.log` and exits 0 so Claude is not slowed
+down.
+
+When you edit `bin/wmux-bridge.mjs` locally, run `/plugin reload` in
+Claude Code (or restart the session) to pick up the change.
 
 ## Architecture
 
@@ -114,7 +134,7 @@ ladder above. Silent slipping is the worst failure mode — every
 cut is recorded in this README and in `plans/wmux-claude-integration.md`.
 
 If any of these matter for your dogfood case, file an issue on
-`iamwongeeeee/wmux` and we'll prioritize Phase 1.5.
+`openwong2kim/wmux` and we'll prioritize Phase 1.5.
 
 ## Troubleshooting
 

--- a/integrations/claude/bin/wmux-bridge.mjs
+++ b/integrations/claude/bin/wmux-bridge.mjs
@@ -309,6 +309,22 @@ async function main() {
     usage = extractUsageFromTranscript(payload.transcript_path);
   }
 
+  // Env-first routing identifiers. When Claude Code runs inside a wmux
+  // pane, the PTYManager injects WMUX_WORKSPACE_ID / WMUX_SURFACE_ID into
+  // the shell env. Claude Code → bridge subprocess inherits the env. The
+  // daemon prefers these over cwd because cwd matching is ambiguous when
+  // multiple workspaces share a path (e.g. two panes opened in the same
+  // repo). User dogfood 2026-05-24 hit this: workspace 4 turn-end was
+  // routing to workspace 2's toast because both had the same cwd.
+  const envWorkspaceId =
+    typeof process.env.WMUX_WORKSPACE_ID === 'string' && process.env.WMUX_WORKSPACE_ID.length > 0
+      ? process.env.WMUX_WORKSPACE_ID
+      : undefined;
+  const envSurfaceId =
+    typeof process.env.WMUX_SURFACE_ID === 'string' && process.env.WMUX_SURFACE_ID.length > 0
+      ? process.env.WMUX_SURFACE_ID
+      : undefined;
+
   // Build the AgentSignal envelope. Schema mirrors
   // integrations/shared/signal-types.ts (kept in sync manually because
   // this is JS-only).
@@ -316,10 +332,24 @@ async function main() {
     kind: HOOK_TO_KIND[hookName],
     agent: 'claude',
     agentSessionId: (payload && typeof payload.session_id === 'string') ? payload.session_id : undefined,
+    workspaceId: envWorkspaceId,
+    surfaceId: envSurfaceId,
     cwd: payloadCwd ?? process.cwd(),
     payload: { ...(payload ?? {}), ...(usage ? { usage } : {}) },
     ts: Date.now(),
   };
+
+  // Diagnostic dump for verification harnesses (scripts/verify-bridge-env-capture.mjs).
+  // Stripped from production by the WMUX_BRIDGE_DEBUG gate — token never crosses
+  // this branch. Payload usage block is stripped because transcript content can
+  // be large and is not what we want to verify.
+  if (process.env.WMUX_BRIDGE_DEBUG === '1') {
+    const { payload: envelopePayload, ...envelopeMeta } = envelope;
+    const usageOnly = envelopePayload && envelopePayload.usage ? { usage: envelopePayload.usage } : {};
+    process.stderr.write(
+      `WMUX_BRIDGE_DEBUG_ENVELOPE=${JSON.stringify({ ...envelopeMeta, payloadKeys: Object.keys(envelopePayload ?? {}), ...usageOnly })}\n`,
+    );
+  }
 
   const request = {
     id: `bridge-${randomUUID()}`,

--- a/integrations/shared/__tests__/signal-types.test.ts
+++ b/integrations/shared/__tests__/signal-types.test.ts
@@ -69,4 +69,20 @@ describe('isAgentSignal', () => {
   it('rejects non-string agentSessionId when present', () => {
     expect(isAgentSignal({ ...valid, agentSessionId: 12345 })).toBe(false);
   });
+
+  // Env-first routing fields (Codex P1 #7 promoted 2026-05-24)
+  it('accepts valid workspaceId / surfaceId', () => {
+    expect(isAgentSignal({ ...valid, workspaceId: 'ws-abc' })).toBe(true);
+    expect(isAgentSignal({ ...valid, workspaceId: 'ws-abc', surfaceId: 'surface-xyz' })).toBe(true);
+  });
+
+  it('rejects empty workspaceId / surfaceId', () => {
+    expect(isAgentSignal({ ...valid, workspaceId: '' })).toBe(false);
+    expect(isAgentSignal({ ...valid, surfaceId: '' })).toBe(false);
+  });
+
+  it('rejects non-string workspaceId / surfaceId', () => {
+    expect(isAgentSignal({ ...valid, workspaceId: 42 })).toBe(false);
+    expect(isAgentSignal({ ...valid, surfaceId: { id: 'x' } })).toBe(false);
+  });
 });

--- a/integrations/shared/signal-types.ts
+++ b/integrations/shared/signal-types.ts
@@ -40,10 +40,23 @@ export type AgentSlug = 'claude' | 'codex' | 'gemini' | 'aider' | 'opencode' | '
 /**
  * Canonical envelope. All fields are required UNLESS marked optional.
  *
- * `cwd` is the resolution key the daemon uses to map this signal back
- * to a wmux ptyId. Bridges MUST set `cwd` to the working directory of
- * the agent process (NOT the wmux workspace's stored cwd — those can
- * diverge if the user `cd`s mid-session).
+ * Routing priority (daemon-side, `resolvePtyIdForSignal`):
+ *   1. `workspaceId` (from WMUX_WORKSPACE_ID env, set by wmux PTYManager)
+ *      — strongest signal. When the user runs Claude inside a wmux pane,
+ *      the env propagates through Claude Code's subprocess spawn and
+ *      lands here. Routing is deterministic regardless of cwd overlap
+ *      between workspaces.
+ *   2. `surfaceId` (from WMUX_SURFACE_ID env) — refines workspaceId when
+ *      a workspace has multiple surfaces. Optional even when workspaceId
+ *      is present.
+ *   3. `cwd` — fallback for sessions started outside a wmux pane, OR
+ *      for older bridges that don't fill the env fields. Resolved via
+ *      exact + longest-prefix match against `workspace.metadata.cwd`.
+ *
+ * Bridges MUST set `cwd` (workflow user expects), MAY set `workspaceId` /
+ * `surfaceId` when the env is available. Codex round 1 P1 #7 + user
+ * dogfood report 2026-05-24 (workspace 4 turn-end → workspace 2 toast)
+ * promoted env-first from deferred TODO to required.
  *
  * `ts` is the hook FIRE time in Unix ms, captured by the bridge before
  * the RPC roundtrip. Used by SignalLatencyMeter to compute the
@@ -58,6 +71,10 @@ export interface AgentSignal {
   kind: AgentSignalKind;
   agent: AgentSlug;
   agentSessionId?: string;
+  /** WMUX_WORKSPACE_ID env value when the bridge runs inside a wmux pane. */
+  workspaceId?: string;
+  /** WMUX_SURFACE_ID env value. Refines workspaceId for multi-surface workspaces. */
+  surfaceId?: string;
   cwd: string;
   payload: Record<string, unknown>;
   ts: number;
@@ -109,5 +126,10 @@ export function isAgentSignal(value: unknown): value is AgentSignal {
   // (claude review 2026-05-23 P2 #5.)
   if (v['payload'] === null || typeof v['payload'] !== 'object' || Array.isArray(v['payload'])) return false;
   if (v['agentSessionId'] !== undefined && typeof v['agentSessionId'] !== 'string') return false;
+  // Env-first routing fields (optional). Empty string is rejected so a
+  // misconfigured bridge can't accidentally tunnel routing through cwd
+  // by sending an obviously-bad workspaceId.
+  if (v['workspaceId'] !== undefined && (typeof v['workspaceId'] !== 'string' || v['workspaceId'].length === 0)) return false;
+  if (v['surfaceId'] !== undefined && (typeof v['surfaceId'] !== 'string' || v['surfaceId'].length === 0)) return false;
   return true;
 }

--- a/plans/wmux-claude-integration.md
+++ b/plans/wmux-claude-integration.md
@@ -103,7 +103,7 @@ Split trigger: after Phase 2 ships AND we see meaningful adoption outside wmux u
 | 3 | SubagentStop hook | /team mode subagent completion routing |
 | 4 | SessionStart hook | Metadata reset trigger (clear stale state) |
 | 5 | Hook ↔ AgentDetector dedup | Hook signal wins; AgentDetector is fallback when plugin absent |
-| 6 | Plugin marketplace entry | `marketplace.json` so users run `/plugin marketplace add iamwongeeeee/wmux` |
+| 6 | Plugin marketplace entry | `marketplace.json` so users run `/plugin marketplace add openwong2kim/wmux` |
 | 7 | First-run onboarding banner | NotificationPanel header prompts install when wmux detects Claude Code use without plugin |
 | 8 | **Agent-agnostic architecture** (CEO 2026-05-22) | `integrations/shared/` at top level + canonical signal envelope. Phase 3 cost pre-amortized |
 | 9 | **Hook signal latency telemetry** (CEO 2026-05-22) | Local-only ring buffer (max 100 entries) recording (claude turn-end → wmux toast) delta. Settings panel shows P50/P95. No remote telemetry, no opt-in needed because data never leaves disk |
@@ -114,7 +114,7 @@ Note: items 21/22/23 from the prior revision (marker-based settings.json editing
 
 ```
 USER ACTION (one time):
-  /plugin marketplace add iamwongeeeee/wmux
+  /plugin marketplace add openwong2kim/wmux
   /plugin install wmux-claude-integration
 
 CLAUDE CODE LOADS PLUGIN:
@@ -402,7 +402,7 @@ notification is too quiet to notice").
 
 ## Open questions for next CEO review of this plan
 
-1. Should the marketplace entry be on the official `claude-plugins-official` marketplace or only on a wmux-owned marketplace (`iamwongeeeee/wmux`)? Trade-off: discoverability vs. review cycle dependency.
+1. Should the marketplace entry be on the official `claude-plugins-official` marketplace or only on a wmux-owned marketplace (`openwong2kim/wmux`)? Trade-off: discoverability vs. review cycle dependency.
 2. Default to "plugin auto-detected" silent-detect, or always show the install banner once on first Claude Code use? UX feel.
 3. Plugin uninstall — should wmux Settings include a "Disable hook integration" toggle that doesn't actually uninstall the plugin (just stops processing signals), for users who want to keep the plugin but pause it temporarily?
 4. Telemetry — is hook arrival latency something we want to measure? If yes, where does the data go (existing wmux telemetry, or none)?

--- a/scripts/verify-bridge-env-capture.mjs
+++ b/scripts/verify-bridge-env-capture.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// Dynamic verification for Codex P1 #7 + 2026-05-25 dogfood fix:
+//   - wmux-bridge.mjs must capture process.env.WMUX_WORKSPACE_ID /
+//     WMUX_SURFACE_ID into the AgentSignal envelope (env-first routing).
+//   - Empty env values must produce `undefined` envelope fields (not "").
+//   - Cwd from payload.cwd should override process.cwd() when present.
+//
+// Strategy: spawn the bridge with WMUX_BRIDGE_DEBUG=1, feed a minimal
+// Stop hook JSON on stdin, and read the WMUX_BRIDGE_DEBUG_ENVELOPE=...
+// line from stderr. Assert the captured fields match the env vars set
+// for the spawn. No wmux daemon is required — the bridge's pipe RPC
+// will fail (no daemon at the fake pipe path), but the envelope dump
+// happens *before* the RPC, so we still get our evidence.
+//
+// Exits 0 on all assertions passing, 1 on any mismatch. Prints a short
+// pass/fail line per case so the harness output is grep-able.
+
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BRIDGE = resolve(__dirname, '..', 'integrations', 'claude', 'bin', 'wmux-bridge.mjs');
+
+const cases = [
+  {
+    name: 'both env vars present',
+    env: { WMUX_WORKSPACE_ID: 'ws-test-1', WMUX_SURFACE_ID: 'surface-test-1' },
+    payload: { session_id: 'sess-1', cwd: 'C:\\fake\\path' },
+    expect: { workspaceId: 'ws-test-1', surfaceId: 'surface-test-1', cwd: 'C:\\fake\\path' },
+  },
+  {
+    name: 'workspaceId only',
+    env: { WMUX_WORKSPACE_ID: 'ws-test-2' },
+    payload: { session_id: 'sess-2' },
+    expect: { workspaceId: 'ws-test-2', surfaceId: undefined },
+  },
+  {
+    name: 'empty env strings → undefined envelope fields',
+    env: { WMUX_WORKSPACE_ID: '', WMUX_SURFACE_ID: '' },
+    payload: { session_id: 'sess-3' },
+    expect: { workspaceId: undefined, surfaceId: undefined },
+  },
+  {
+    name: 'no env at all → undefined envelope fields',
+    env: {},
+    payload: { session_id: 'sess-4' },
+    expect: { workspaceId: undefined, surfaceId: undefined },
+  },
+];
+
+// Create a temp dir so we don't pollute ~/.wmux/bridge.log with verification runs.
+const tmpHome = mkdtempSync(join(tmpdir(), 'wmux-bridge-verify-'));
+// Bridge bails before envelope build when `~/.wmux-auth-token` is missing
+// (production correctness — token must exist before sending RPC). Drop a
+// fake token so the envelope is built and the debug dump runs. The token
+// never leaves the bridge in this test because the RPC will fail at the
+// named pipe step (no daemon at the fake pipe path).
+writeFileSync(join(tmpHome, '.wmux-auth-token'), 'fake-verification-token');
+
+let failures = 0;
+for (const tc of cases) {
+  const childEnv = {
+    PATH: process.env.PATH,
+    USERPROFILE: tmpHome,
+    HOME: tmpHome,
+    WMUX_BRIDGE_DEBUG: '1',
+    ...tc.env,
+  };
+  const proc = spawn(process.execPath, [BRIDGE, 'Stop'], { env: childEnv, stdio: ['pipe', 'pipe', 'pipe'] });
+  proc.stdin.write(JSON.stringify(tc.payload));
+  proc.stdin.end();
+  let stderr = '';
+  proc.stderr.on('data', (b) => { stderr += b.toString(); });
+  // eslint-disable-next-line no-await-in-loop
+  await new Promise((res) => proc.on('close', res));
+  const match = /WMUX_BRIDGE_DEBUG_ENVELOPE=(.+)/.exec(stderr);
+  if (!match) {
+    console.error(`FAIL [${tc.name}] — no debug envelope in stderr. stderr was:\n${stderr.slice(0, 400)}`);
+    failures += 1;
+    continue;
+  }
+  let envelope;
+  try {
+    envelope = JSON.parse(match[1]);
+  } catch (err) {
+    console.error(`FAIL [${tc.name}] — could not parse envelope JSON: ${String(err)}`);
+    failures += 1;
+    continue;
+  }
+  const checks = [];
+  for (const [k, v] of Object.entries(tc.expect)) {
+    const actual = envelope[k];
+    const ok = actual === v;
+    checks.push({ k, expected: v, actual, ok });
+  }
+  const allOk = checks.every((c) => c.ok);
+  if (allOk) {
+    console.log(`PASS [${tc.name}] — envelope.workspaceId=${envelope.workspaceId ?? 'undef'}, surfaceId=${envelope.surfaceId ?? 'undef'}, cwd=${envelope.cwd}`);
+  } else {
+    failures += 1;
+    console.error(`FAIL [${tc.name}]`);
+    for (const c of checks) {
+      if (!c.ok) console.error(`  - ${c.k}: expected ${JSON.stringify(c.expected)}, got ${JSON.stringify(c.actual)}`);
+    }
+  }
+}
+
+rmSync(tmpHome, { recursive: true, force: true });
+if (failures > 0) {
+  console.error(`\n${failures} case(s) failed.`);
+  process.exit(1);
+}
+console.log('\nAll bridge env-capture cases passed.');

--- a/src/main/claude/UsageApi.ts
+++ b/src/main/claude/UsageApi.ts
@@ -1,0 +1,168 @@
+// Anthropic 1-token dummy POST + rate-limit header parser.
+//
+// Strategy (validated by `openwong2kim/claude-token-check`):
+//   1. POST a Haiku 4.5 request with `max_tokens: 1` and a 1-token body.
+//   2. Don't care about the response body. The interesting data is the
+//      four `anthropic-ratelimit-unified-*` headers.
+//   3. Return a UsageSnapshot. On 401/403, throw Unauthorized — the
+//      caller (UsagePoller) interprets that as "Claude Code logged out,
+//      pause the poller and surface the error in the UI".
+//
+// Token policy:
+//   - The token is passed in by the caller. We never read it from disk
+//     here, never write it anywhere, never log it. Error messages strip
+//     anything that could carry a secret (see UsageApiError below).
+//   - The endpoint is hardcoded to Anthropic's public API. No env-var
+//     override, no proxy, no telemetry sink.
+
+/** Snapshot returned to the caller. All fields plain numbers so the
+ *  shape stays IPC-friendly. */
+export interface UsageSnapshot {
+  /** 5h window utilization, 0–100 (integer percent, rounded). */
+  sessionPct: number;
+  /** 5h window reset time, Unix epoch SECONDS. 0 means "header missing
+   *  / clock skew" — caller can render as "unknown" rather than 0. */
+  sessionResetEpochSec: number;
+  /** 7d window utilization, 0–100. */
+  weeklyPct: number;
+  /** 7d window reset time, Unix epoch SECONDS. */
+  weeklyResetEpochSec: number;
+  /** When we fetched. Unix epoch ms. */
+  fetchedAtMs: number;
+}
+
+/** Discriminated error union. The UI maps these to copy strings. */
+export type UsageApiError =
+  | { kind: 'unauthorized' }
+  | { kind: 'http'; status: number; statusText: string }
+  | { kind: 'network'; message: string }
+  | { kind: 'malformed'; message: string };
+
+export class UsageApiException extends Error {
+  readonly detail: UsageApiError;
+  constructor(detail: UsageApiError, message: string) {
+    super(message);
+    this.name = 'UsageApiException';
+    this.detail = detail;
+  }
+}
+
+const ENDPOINT = 'https://api.anthropic.com/v1/messages';
+
+// User-Agent that matches the validated token-check setup. The OAuth
+// beta endpoint pairs with a Claude-Code-flavored UA in the reference
+// impl. We don't try a wmux-branded UA yet — if Anthropic gates the
+// rate-limit headers on UA, we'd be the ones to find out, and the
+// failure mode is silent (no headers, no UI update). Re-evaluate after
+// dogfood.
+const USER_AGENT = 'claude-code/2.1.5';
+const ANTHROPIC_VERSION = '2023-06-01';
+const ANTHROPIC_BETA = 'oauth-2025-04-20';
+const MODEL = 'claude-haiku-4-5-20251001';
+
+const BODY = JSON.stringify({
+  model: MODEL,
+  max_tokens: 1,
+  messages: [{ role: 'user', content: 'hi' }],
+});
+
+/**
+ * Send the 1-token probe and parse the rate-limit headers. Resolves
+ * with a snapshot on 2xx; throws UsageApiException for everything else.
+ *
+ * `fetchImpl` defaults to global fetch (Electron main process has it).
+ * Tests inject a stub.
+ */
+export async function fetchUsage(
+  accessToken: string,
+  fetchImpl: typeof fetch = fetch,
+  timeoutMs = 20_000,
+): Promise<UsageSnapshot> {
+  // 20s upper bound. Anthropic's typical p99 is well under this; the
+  // budget exists so a hung TCP connection / TLS handshake can't wedge
+  // UsagePoller's `inflight` flag forever (Codex review 2026-05-24 P2 #4).
+  const controller = new AbortController();
+  const abortTimer = setTimeout(() => controller.abort(), timeoutMs);
+  let response: Response;
+  try {
+    response = await fetchImpl(ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'anthropic-version': ANTHROPIC_VERSION,
+        'anthropic-beta': ANTHROPIC_BETA,
+        'content-type': 'application/json',
+        'user-agent': USER_AGENT,
+        authorization: `Bearer ${accessToken}`,
+      },
+      body: BODY,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    const aborted =
+      (err instanceof Error && err.name === 'AbortError') ||
+      (err instanceof DOMException && err.name === 'AbortError');
+    const message = aborted
+      ? `timed out after ${timeoutMs}ms`
+      : (err instanceof Error ? err.message : 'fetch failed');
+    throw new UsageApiException({ kind: 'network', message }, message);
+  } finally {
+    clearTimeout(abortTimer);
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    // Drain body to free the socket; ignore the contents — they can
+    // include token-bearing error envelopes we don't want to keep.
+    try { await response.text(); } catch { /* ignore */ }
+    throw new UsageApiException({ kind: 'unauthorized' }, `HTTP ${response.status}`);
+  }
+  if (!response.ok) {
+    const statusText = response.statusText || `status ${response.status}`;
+    try { await response.text(); } catch { /* ignore */ }
+    throw new UsageApiException(
+      { kind: 'http', status: response.status, statusText },
+      `HTTP ${response.status} ${statusText}`,
+    );
+  }
+
+  // Headers parse independently of the body. We don't await response
+  // body parsing for happy path either — abort the body stream once we
+  // have the headers to free the socket. (Some fetch impls buffer the
+  // body anyway; we don't depend on it.)
+  try { await response.text(); } catch { /* ignore */ }
+
+  return parseSnapshot(response.headers, Date.now());
+}
+
+/**
+ * Pure helper. Exported so tests can drive it with mocked Headers and
+ * an injected `now`.
+ */
+export function parseSnapshot(headers: Headers, nowMs: number): UsageSnapshot {
+  return {
+    sessionPct: readPercent(headers, 'anthropic-ratelimit-unified-5h-utilization'),
+    sessionResetEpochSec: readEpochSeconds(headers, 'anthropic-ratelimit-unified-5h-reset'),
+    weeklyPct: readPercent(headers, 'anthropic-ratelimit-unified-7d-utilization'),
+    weeklyResetEpochSec: readEpochSeconds(headers, 'anthropic-ratelimit-unified-7d-reset'),
+    fetchedAtMs: nowMs,
+  };
+}
+
+/** Utilization headers ship as a decimal 0.0–1.0. We convert to integer
+ *  percent (rounded). Missing/non-numeric headers report 0 — caller
+ *  combines with status to decide if 0% means "fresh" vs "no data". */
+function readPercent(headers: Headers, key: string): number {
+  const raw = headers.get(key);
+  if (!raw) return 0;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(100, Math.round(n * 100)));
+}
+
+/** Reset headers ship as Unix epoch seconds. */
+function readEpochSeconds(headers: Headers, key: string): number {
+  const raw = headers.get(key);
+  if (!raw) return 0;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.round(n);
+}

--- a/src/main/claude/UsagePoller.ts
+++ b/src/main/claude/UsagePoller.ts
@@ -1,0 +1,316 @@
+// Anthropic 5h/7d usage poller. Wraps loadClaudeCredential + fetchUsage
+// behind a lifecycle the main process can start/stop/refresh on demand.
+//
+// Cadence: 1 hour default (matches `openwong2kim/claude-token-check`).
+// Configurable via constructor injection so tests can run on millisecond
+// scales. The poller is opt-in — the user must flip the Settings toggle
+// before `start()` is called. While off, this module does ZERO disk
+// reads and ZERO network requests.
+//
+// Failure handling:
+//   - Credential not found (Claude Code not logged in) → emit
+//     'token-missing' status, do not retry until `refreshNow()` is
+//     called or the credential file is observed to appear (future
+//     follow-up — for now manual refresh is the recovery).
+//   - 401/403 (token expired or revoked) → emit 'unauthorized' status
+//     and STOP the interval. User must re-login and toggle Settings
+//     off/on (or click manual refresh).
+//   - Network / 5xx → emit 'network-error' / 'http-error' with the
+//     last error. The interval KEEPS RUNNING; next tick is the retry.
+//     Avoids the failure mode where a transient outage permanently
+//     darkens the StatusBar widget.
+//
+// Window visibility: `setWindowVisible(isVisible)` lets main hook the
+// BrowserWindow `'show'` / `'hide'` events. When the window has been
+// hidden ≥ 30 minutes, we skip the next poll tick to avoid burning the
+// user's API quota for a UI nobody is looking at. The next `show`
+// triggers an immediate catch-up fetch.
+
+import { loadClaudeCredential, type LoadResult } from './claudeCredential';
+import { fetchUsage, UsageApiException, type UsageSnapshot } from './UsageApi';
+
+export type PollerStatus =
+  /** Toggle is off; nothing happening. */
+  | 'idle'
+  /** Last fetch succeeded — `snapshot` is non-null. */
+  | 'ok'
+  /** Claude Code is not logged in / credential file missing. */
+  | 'token-missing'
+  /** Anthropic returned 401/403. Poller paused. */
+  | 'unauthorized'
+  /** Non-auth HTTP failure. Poller keeps running, retrying. */
+  | 'http-error'
+  /** Network failure. Poller keeps running, retrying. */
+  | 'network-error'
+  /** Local read error (credential file unreadable for non-ENOENT reason). */
+  | 'read-error';
+
+export interface PollerState {
+  status: PollerStatus;
+  /** Last successful snapshot. Persists across transient failures so the
+   *  UI can keep rendering the last known good value with a stale
+   *  indicator. Null until the first successful fetch in this session. */
+  snapshot: UsageSnapshot | null;
+  /** Last error message in human-readable form. Null when status is
+   *  'idle' or 'ok'. We deliberately do NOT include the access token
+   *  or any Bearer-shaped header in this string. */
+  lastError: string | null;
+  /** Subscription tier from `.credentials.json`. Surfaces to UI even
+   *  when status is 'unauthorized' so the user remembers what plan they
+   *  were on. */
+  subscriptionType: string | null;
+}
+
+export interface PollerOptions {
+  /** Interval between polls in ms. Default 1h. */
+  intervalMs?: number;
+  /** Skip a tick if the window has been hidden longer than this. Default 30 min. */
+  hiddenSkipThresholdMs?: number;
+  /** Injectable for tests. */
+  now?: () => number;
+  /** Injectable for tests. */
+  fetchImpl?: typeof fetch;
+  /** Injectable for tests. */
+  loadCredential?: () => Promise<LoadResult>;
+}
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+const THIRTY_MIN_MS = 30 * 60 * 1000;
+
+/**
+ * Owns a single in-process interval. The poller is created once and
+ * started/stopped by the toggle. Multiple start() calls without stop()
+ * are no-ops (idempotent). Disposal is final — call dispose() during
+ * before-quit so the interval doesn't fire during shutdown.
+ */
+export class UsagePoller {
+  private readonly intervalMs: number;
+  private readonly hiddenSkipThresholdMs: number;
+  private readonly now: () => number;
+  private readonly fetchImpl: typeof fetch;
+  private readonly loadCredential: () => Promise<LoadResult>;
+
+  private state: PollerState = {
+    status: 'idle',
+    snapshot: null,
+    lastError: null,
+    subscriptionType: null,
+  };
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private immediateTimer: ReturnType<typeof setTimeout> | null = null;
+  private inflight = false;
+  private windowVisible = true;
+  private windowHiddenAtMs = 0;
+  private disposed = false;
+
+  private readonly listeners = new Set<(state: PollerState) => void>();
+
+  constructor(opts: PollerOptions = {}) {
+    this.intervalMs = opts.intervalMs ?? ONE_HOUR_MS;
+    this.hiddenSkipThresholdMs = opts.hiddenSkipThresholdMs ?? THIRTY_MIN_MS;
+    this.now = opts.now ?? (() => Date.now());
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.loadCredential = opts.loadCredential ?? loadClaudeCredential;
+  }
+
+  /** Idempotent. Starts the interval AND triggers an immediate fetch
+   *  so the first snapshot doesn't sit blank for an hour. */
+  start(): void {
+    if (this.disposed) return;
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, this.intervalMs);
+    // Immediate first fetch (deliberate: don't make the user wait for
+    // the interval). `setTimeout(fn, 0)` rather than queueMicrotask so
+    // tests can drive it via `vi.advanceTimersByTimeAsync(0)`. The
+    // 0-delay also keeps it strictly asynchronous so a synchronous
+    // start()-then-stop() pair still cancels cleanly via the timer
+    // cleared above.
+    this.immediateTimer = setTimeout(() => {
+      this.immediateTimer = null;
+      void this.tick();
+    }, 0);
+  }
+
+  /** Stop the interval. State is preserved so the last snapshot keeps
+   *  rendering until the next start() (or until the UI is told to
+   *  hide). Idempotent. */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    if (this.immediateTimer) {
+      clearTimeout(this.immediateTimer);
+      this.immediateTimer = null;
+    }
+    if (this.state.status !== 'idle') {
+      this.setState({ status: 'idle' });
+    }
+  }
+
+  /** Manual refresh — the StatusBar widget's "refresh now" button. The
+   *  caller is responsible for the 5-minute cooldown (kept in UI state).
+   *  Returns the snapshot for callers that want to await the result. */
+  async refreshNow(): Promise<PollerState> {
+    if (this.disposed) return this.state;
+    await this.tick();
+    return this.state;
+  }
+
+  /** Hook window show/hide so we don't burn API calls while the user
+   *  is away. Called from main/index.ts on BrowserWindow events. */
+  setWindowVisible(isVisible: boolean): void {
+    if (isVisible === this.windowVisible) return;
+    this.windowVisible = isVisible;
+    if (!isVisible) {
+      this.windowHiddenAtMs = this.now();
+    } else {
+      this.windowHiddenAtMs = 0;
+      // Window came back — kick a fresh fetch so the user doesn't wait
+      // up to an hour for the next tick.
+      if (this.timer && !this.disposed) {
+        void this.tick();
+      }
+    }
+  }
+
+  /** Subscribe to state changes (StatusBar + Settings card). Multiple
+   *  subscribers OK. Returns idempotent unsubscribe. */
+  onStateChange(cb: (state: PollerState) => void): () => void {
+    this.listeners.add(cb);
+    return () => {
+      this.listeners.delete(cb);
+    };
+  }
+
+  getState(): PollerState {
+    return this.state;
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.stop();
+    this.listeners.clear();
+  }
+
+  /** Single poll iteration. Guarded against re-entry so a 1h interval
+   *  tick can't overlap a slow in-flight fetch. */
+  private async tick(): Promise<void> {
+    if (this.disposed) return;
+    if (this.inflight) return;
+    // Hidden-window skip — only applies to interval-driven ticks, NOT
+    // explicit refreshNow() or window-show kicks. Caller-driven probes
+    // are always honored.
+    if (!this.windowVisible && this.windowHiddenAtMs > 0) {
+      const hiddenForMs = this.now() - this.windowHiddenAtMs;
+      if (hiddenForMs >= this.hiddenSkipThresholdMs) {
+        // Skip this tick; state unchanged.
+        return;
+      }
+    }
+    this.inflight = true;
+    try {
+      const credResult = await this.loadCredential();
+      if (!credResult.ok) {
+        if (credResult.reason === 'not-found') {
+          this.setState({
+            status: 'token-missing',
+            lastError: null,
+            subscriptionType: null,
+          });
+          return;
+        }
+        this.setState({
+          status: 'read-error',
+          lastError: credResult.detail ?? credResult.reason,
+        });
+        return;
+      }
+      const { credential } = credResult;
+      try {
+        const snapshot = await fetchUsage(credential.accessToken, this.fetchImpl);
+        this.setState({
+          status: 'ok',
+          snapshot,
+          lastError: null,
+          subscriptionType: credential.subscriptionType,
+        });
+      } catch (err) {
+        if (err instanceof UsageApiException) {
+          if (err.detail.kind === 'unauthorized') {
+            // STOP the interval — the credential is bad and pummeling
+            // Anthropic with 401s helps nobody. User must re-login then
+            // re-toggle.
+            this.stop();
+            this.setState({
+              status: 'unauthorized',
+              lastError: 'HTTP 401/403',
+              subscriptionType: credential.subscriptionType,
+            });
+            return;
+          }
+          if (err.detail.kind === 'http') {
+            this.setState({
+              status: 'http-error',
+              lastError: `HTTP ${err.detail.status} ${err.detail.statusText}`,
+              subscriptionType: credential.subscriptionType,
+            });
+            return;
+          }
+          if (err.detail.kind === 'network') {
+            this.setState({
+              status: 'network-error',
+              lastError: err.detail.message,
+              subscriptionType: credential.subscriptionType,
+            });
+            return;
+          }
+          this.setState({
+            status: 'http-error',
+            lastError: err.message,
+            subscriptionType: credential.subscriptionType,
+          });
+          return;
+        }
+        // Unknown error class — treat as network for retry semantics.
+        const msg = err instanceof Error ? err.message : 'unknown';
+        this.setState({
+          status: 'network-error',
+          lastError: msg,
+          subscriptionType: credential.subscriptionType,
+        });
+      }
+    } finally {
+      this.inflight = false;
+    }
+  }
+
+  private setState(patch: Partial<PollerState>): void {
+    const next: PollerState = {
+      ...this.state,
+      ...patch,
+    };
+    // No-op when nothing observable changed (status + snapshot + error
+    // are the dimensions the UI listens on; ignore deep equality on
+    // snapshot since it's an immutable object replacement).
+    if (
+      next.status === this.state.status &&
+      next.snapshot === this.state.snapshot &&
+      next.lastError === this.state.lastError &&
+      next.subscriptionType === this.state.subscriptionType
+    ) {
+      return;
+    }
+    this.state = next;
+    for (const cb of this.listeners) {
+      try {
+        cb(next);
+      } catch {
+        // Swallow; one bad subscriber must not block siblings or the
+        // poller's own state advance.
+      }
+    }
+  }
+}

--- a/src/main/claude/__tests__/UsageApi.test.ts
+++ b/src/main/claude/__tests__/UsageApi.test.ts
@@ -1,0 +1,141 @@
+/**
+ * UsageApi tests — focus on the pure header-parser and the typed-error
+ * mapping. Network is mocked via a stub fetchImpl so the test doesn't
+ * touch Anthropic. The mock response is constructed with the global
+ * `Response` constructor (available in vitest's node 22 runtime).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { fetchUsage, parseSnapshot, UsageApiException } from '../UsageApi';
+
+const FIXED_NOW = 1_700_000_000_000;
+
+describe('parseSnapshot (pure)', () => {
+  it('converts decimal utilization to integer percent, rounded', () => {
+    const headers = new Headers({
+      'anthropic-ratelimit-unified-5h-utilization': '0.234',
+      'anthropic-ratelimit-unified-5h-reset': '1700001234',
+      'anthropic-ratelimit-unified-7d-utilization': '0.078',
+      'anthropic-ratelimit-unified-7d-reset': '1700009999',
+    });
+    const snapshot = parseSnapshot(headers, FIXED_NOW);
+    expect(snapshot.sessionPct).toBe(23);
+    expect(snapshot.weeklyPct).toBe(8);
+    expect(snapshot.sessionResetEpochSec).toBe(1700001234);
+    expect(snapshot.weeklyResetEpochSec).toBe(1700009999);
+    expect(snapshot.fetchedAtMs).toBe(FIXED_NOW);
+  });
+
+  it('clamps percent to [0, 100]', () => {
+    const headers = new Headers({
+      'anthropic-ratelimit-unified-5h-utilization': '1.234', // 123% → 100
+      'anthropic-ratelimit-unified-7d-utilization': '-0.5', // negative → 0
+    });
+    const snapshot = parseSnapshot(headers, FIXED_NOW);
+    expect(snapshot.sessionPct).toBe(100);
+    expect(snapshot.weeklyPct).toBe(0);
+  });
+
+  it('reports 0 for missing headers (caller distinguishes via fetch status)', () => {
+    const headers = new Headers();
+    const snapshot = parseSnapshot(headers, FIXED_NOW);
+    expect(snapshot).toEqual({
+      sessionPct: 0,
+      sessionResetEpochSec: 0,
+      weeklyPct: 0,
+      weeklyResetEpochSec: 0,
+      fetchedAtMs: FIXED_NOW,
+    });
+  });
+
+  it('reports 0 for non-numeric headers', () => {
+    const headers = new Headers({
+      'anthropic-ratelimit-unified-5h-utilization': 'not a number',
+      'anthropic-ratelimit-unified-5h-reset': 'NaN',
+    });
+    const snapshot = parseSnapshot(headers, FIXED_NOW);
+    expect(snapshot.sessionPct).toBe(0);
+    expect(snapshot.sessionResetEpochSec).toBe(0);
+  });
+
+  it('rounds reset epoch to integer seconds', () => {
+    const headers = new Headers({
+      'anthropic-ratelimit-unified-5h-reset': '1700001234.6',
+    });
+    expect(parseSnapshot(headers, FIXED_NOW).sessionResetEpochSec).toBe(1700001235);
+  });
+});
+
+describe('fetchUsage (with mocked fetch)', () => {
+  function makeFetch(response: Response): typeof fetch {
+    return vi.fn().mockResolvedValue(response) as unknown as typeof fetch;
+  }
+
+  it('returns parsed snapshot on 200', async () => {
+    const headers = new Headers({
+      'anthropic-ratelimit-unified-5h-utilization': '0.42',
+      'anthropic-ratelimit-unified-5h-reset': '1700001000',
+      'anthropic-ratelimit-unified-7d-utilization': '0.12',
+      'anthropic-ratelimit-unified-7d-reset': '1700009000',
+    });
+    const fetchImpl = makeFetch(new Response('{}', { status: 200, headers }));
+    const snapshot = await fetchUsage('sk-ant-token-1234567890', fetchImpl);
+    expect(snapshot.sessionPct).toBe(42);
+    expect(snapshot.weeklyPct).toBe(12);
+  });
+
+  it('throws UsageApiException(unauthorized) on 401', async () => {
+    const fetchImpl = makeFetch(new Response('unauth', { status: 401 }));
+    await expect(fetchUsage('sk-ant-token-1234567890', fetchImpl)).rejects.toMatchObject({
+      detail: { kind: 'unauthorized' },
+    });
+  });
+
+  it('throws UsageApiException(unauthorized) on 403', async () => {
+    const fetchImpl = makeFetch(new Response('forbidden', { status: 403 }));
+    await expect(fetchUsage('sk-ant-token-1234567890', fetchImpl)).rejects.toMatchObject({
+      detail: { kind: 'unauthorized' },
+    });
+  });
+
+  it('throws UsageApiException(http) on 5xx with status preserved', async () => {
+    const fetchImpl = makeFetch(new Response('overload', { status: 529, statusText: 'Overloaded' }));
+    try {
+      await fetchUsage('sk-ant-token-1234567890', fetchImpl);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(UsageApiException);
+      expect((err as UsageApiException).detail).toEqual({
+        kind: 'http',
+        status: 529,
+        statusText: 'Overloaded',
+      });
+    }
+  });
+
+  it('throws UsageApiException(network) when fetch itself rejects', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('ECONNREFUSED')) as unknown as typeof fetch;
+    try {
+      await fetchUsage('sk-ant-token-1234567890', fetchImpl);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(UsageApiException);
+      const detail = (err as UsageApiException).detail;
+      expect(detail.kind).toBe('network');
+      if (detail.kind === 'network') {
+        expect(detail.message).toBe('ECONNREFUSED');
+      }
+    }
+  });
+
+  it('sends Bearer token + claude-code UA + oauth beta header', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('{}', { status: 200, headers: new Headers() })) as unknown as typeof fetch;
+    await fetchUsage('sk-ant-test-1234567890', fetchImpl);
+    const [, init] = (fetchImpl as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.authorization).toBe('Bearer sk-ant-test-1234567890');
+    expect(headers['user-agent']).toMatch(/^claude-code\//);
+    expect(headers['anthropic-beta']).toBe('oauth-2025-04-20');
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+    expect(init.method).toBe('POST');
+  });
+});

--- a/src/main/claude/__tests__/UsagePoller.test.ts
+++ b/src/main/claude/__tests__/UsagePoller.test.ts
@@ -1,0 +1,282 @@
+/**
+ * UsagePoller lifecycle tests. Uses fake timers and injected fetch/load
+ * so a real polling cadence is simulated in milliseconds.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { UsagePoller, type PollerState } from '../UsagePoller';
+import type { LoadResult } from '../claudeCredential';
+
+const ANY_TOKEN = 'sk-ant-test-1234567890';
+
+const OK_CREDENTIAL: LoadResult = {
+  ok: true,
+  credential: {
+    accessToken: ANY_TOKEN,
+    subscriptionType: 'pro',
+    rateLimitTier: 'standard',
+    expiresAtMs: null,
+  },
+};
+
+function makeOkFetch(): typeof fetch {
+  const headers = new Headers({
+    'anthropic-ratelimit-unified-5h-utilization': '0.5',
+    'anthropic-ratelimit-unified-5h-reset': '1700000000',
+    'anthropic-ratelimit-unified-7d-utilization': '0.1',
+    'anthropic-ratelimit-unified-7d-reset': '1700100000',
+  });
+  return vi.fn().mockResolvedValue(new Response('{}', { status: 200, headers })) as unknown as typeof fetch;
+}
+
+function makeFlushPromises(): () => Promise<void> {
+  // Microtask queue is drained by `await Promise.resolve()` chains; we
+  // need enough chains to cover queueMicrotask → loadCredential await
+  // → fetchUsage await → setState. 5 chains is overkill-safe.
+  return async () => {
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+  };
+}
+
+describe('UsagePoller', () => {
+  let flushPromises: () => Promise<void>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    flushPromises = makeFlushPromises();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts in idle state', () => {
+    const poller = new UsagePoller({
+      intervalMs: 1000,
+      loadCredential: async () => OK_CREDENTIAL,
+      fetchImpl: makeOkFetch(),
+    });
+    expect(poller.getState().status).toBe('idle');
+    poller.dispose();
+  });
+
+  it('fires an immediate fetch on start (queueMicrotask, not interval)', async () => {
+    const onState = vi.fn();
+    const poller = new UsagePoller({
+      intervalMs: 100_000, // way beyond test, ensures the microtask is the source
+      loadCredential: async () => OK_CREDENTIAL,
+      fetchImpl: makeOkFetch(),
+    });
+    poller.onStateChange(onState);
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    const state = poller.getState();
+    expect(state.status).toBe('ok');
+    expect(state.snapshot?.sessionPct).toBe(50);
+    poller.dispose();
+  });
+
+  it('records subscriptionType from the credential on success', async () => {
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      loadCredential: async () => OK_CREDENTIAL,
+      fetchImpl: makeOkFetch(),
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(poller.getState().subscriptionType).toBe('pro');
+    poller.dispose();
+  });
+
+  it('emits token-missing when credential not found', async () => {
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      loadCredential: async () => ({ ok: false, reason: 'not-found' }),
+      fetchImpl: makeOkFetch(),
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(poller.getState().status).toBe('token-missing');
+    poller.dispose();
+  });
+
+  it('stops poller and emits unauthorized on 401', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response('unauth', { status: 401 }),
+    ) as unknown as typeof fetch;
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      loadCredential: async () => OK_CREDENTIAL,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(poller.getState().status).toBe('unauthorized');
+    // Interval should be cleared — advancing time should NOT trigger a refetch.
+    (fetchImpl as unknown as ReturnType<typeof vi.fn>).mockClear();
+    vi.advanceTimersByTime(300_000);
+    await flushPromises();
+    expect(poller.getState().status).toBe('unauthorized');
+    poller.dispose();
+  });
+
+  it('keeps poller running on network error (retries on next tick)', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockResolvedValueOnce(
+        new Response('{}', {
+          status: 200,
+          headers: new Headers({
+            'anthropic-ratelimit-unified-5h-utilization': '0.42',
+            'anthropic-ratelimit-unified-5h-reset': '1700000000',
+            'anthropic-ratelimit-unified-7d-utilization': '0.05',
+            'anthropic-ratelimit-unified-7d-reset': '1700100000',
+          }),
+        }),
+      ) as unknown as typeof fetch;
+    const poller = new UsagePoller({
+      intervalMs: 1000,
+      loadCredential: async () => OK_CREDENTIAL,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(poller.getState().status).toBe('network-error');
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushPromises();
+    expect(poller.getState().status).toBe('ok');
+    expect(poller.getState().snapshot?.sessionPct).toBe(42);
+    poller.dispose();
+  });
+
+  it('refreshNow() bypasses interval timing', async () => {
+    const fetchImpl = makeOkFetch();
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      loadCredential: async () => OK_CREDENTIAL,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    const firstCall = (fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+    await poller.refreshNow();
+    expect((fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(firstCall + 1);
+    poller.dispose();
+  });
+
+  it('hidden-window skip applies after threshold, NOT before', async () => {
+    const fetchImpl = makeOkFetch();
+    let mockNow = 1_700_000_000_000;
+    const poller = new UsagePoller({
+      intervalMs: 1000,
+      hiddenSkipThresholdMs: 5000,
+      now: () => mockNow,
+      loadCredential: async () => OK_CREDENTIAL,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    const initialCallCount = (fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+    // Hide window.
+    poller.setWindowVisible(false);
+    // 2s later — within threshold — interval should still fire.
+    mockNow += 2000;
+    vi.advanceTimersByTime(1000);
+    await flushPromises();
+    const within = (fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+    expect(within).toBeGreaterThan(initialCallCount);
+    // 10s later — past threshold — interval should skip.
+    mockNow += 10_000;
+    const beforeSkip = (fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+    vi.advanceTimersByTime(1000);
+    await flushPromises();
+    expect((fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(beforeSkip);
+    poller.dispose();
+  });
+
+  it('window-show triggers an immediate catch-up fetch', async () => {
+    const fetchImpl = makeOkFetch();
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      loadCredential: async () => OK_CREDENTIAL,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    poller.setWindowVisible(false);
+    const beforeShow = (fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+    poller.setWindowVisible(true);
+    await flushPromises();
+    expect((fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(beforeShow + 1);
+    poller.dispose();
+  });
+
+  it('stop() returns to idle and stops the interval', async () => {
+    const fetchImpl = makeOkFetch();
+    const poller = new UsagePoller({
+      intervalMs: 1000,
+      loadCredential: async () => OK_CREDENTIAL,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    poller.stop();
+    expect(poller.getState().status).toBe('idle');
+    const before = (fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+    vi.advanceTimersByTime(10_000);
+    await flushPromises();
+    expect((fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(before);
+    poller.dispose();
+  });
+
+  it('multiple subscribers receive identical state updates', async () => {
+    const sub1 = vi.fn();
+    const sub2 = vi.fn();
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      loadCredential: async () => OK_CREDENTIAL,
+      fetchImpl: makeOkFetch(),
+    });
+    poller.onStateChange(sub1);
+    poller.onStateChange(sub2);
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(sub1).toHaveBeenCalled();
+    expect(sub2).toHaveBeenCalled();
+    const last1 = sub1.mock.calls[sub1.mock.calls.length - 1][0] as PollerState;
+    const last2 = sub2.mock.calls[sub2.mock.calls.length - 1][0] as PollerState;
+    expect(last1).toEqual(last2);
+    poller.dispose();
+  });
+
+  it('unsubscribe stops further callbacks (idempotent)', async () => {
+    const sub = vi.fn();
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      loadCredential: async () => OK_CREDENTIAL,
+      fetchImpl: makeOkFetch(),
+    });
+    const unsub = poller.onStateChange(sub);
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    const initial = sub.mock.calls.length;
+    unsub();
+    unsub(); // idempotent
+    await poller.refreshNow();
+    expect(sub.mock.calls.length).toBe(initial);
+    poller.dispose();
+  });
+});

--- a/src/main/claude/__tests__/claudeCredential.test.ts
+++ b/src/main/claude/__tests__/claudeCredential.test.ts
@@ -1,0 +1,143 @@
+/**
+ * extractAccessToken / extractCredentialMetadata pure-function tests.
+ *
+ * Mirrors the Swift TokenStore behavior from
+ * `openwong2kim/claude-token-check` so cross-platform parity is
+ * locked. The actual platform branches (Keychain shell-out, file read)
+ * are not unit-tested here — they're integration concerns covered at
+ * dogfood time.
+ */
+import { describe, it, expect } from 'vitest';
+import { extractAccessToken, extractCredentialMetadata } from '../claudeCredential';
+
+describe('extractAccessToken', () => {
+  it('returns null on empty / whitespace blob', () => {
+    expect(extractAccessToken('')).toBeNull();
+    expect(extractAccessToken('   ')).toBeNull();
+    expect(extractAccessToken('\n\t')).toBeNull();
+  });
+
+  it('pulls direct accessToken from a flat JSON object', () => {
+    const blob = JSON.stringify({ accessToken: 'sk-ant-xyz-1234567890ABCDEF' });
+    expect(extractAccessToken(blob)).toBe('sk-ant-xyz-1234567890ABCDEF');
+  });
+
+  it('pulls nested accessToken from claudeAiOauth wrapper (Windows shape)', () => {
+    const blob = JSON.stringify({
+      claudeAiOauth: { accessToken: 'sk-ant-deadbeefdeadbeef', refreshToken: 'r' },
+    });
+    expect(extractAccessToken(blob)).toBe('sk-ant-deadbeefdeadbeef');
+  });
+
+  it('pulls nested accessToken regardless of wrapper key name', () => {
+    // The Swift impl iterates `json.values`, so wrapper key is irrelevant.
+    const blob = JSON.stringify({ someUnknownWrapper: { accessToken: 'sk-ant-xyz1234567890' } });
+    expect(extractAccessToken(blob)).toBe('sk-ant-xyz1234567890');
+  });
+
+  it('returns null when direct accessToken is empty string', () => {
+    expect(extractAccessToken(JSON.stringify({ accessToken: '' }))).toBeNull();
+  });
+
+  it('returns null when nested accessToken is empty', () => {
+    expect(
+      extractAccessToken(JSON.stringify({ claudeAiOauth: { accessToken: '' } })),
+    ).toBeNull();
+  });
+
+  it('falls back to raw-token regex when blob is not JSON', () => {
+    expect(extractAccessToken('sk-ant-deadbeef.deadbeef-XYZ_1234567890')).toBe(
+      'sk-ant-deadbeef.deadbeef-XYZ_1234567890',
+    );
+  });
+
+  it('rejects raw tokens shorter than 20 chars (regex floor)', () => {
+    expect(extractAccessToken('short')).toBeNull();
+    expect(extractAccessToken('abc-1234567890')).toBeNull();
+  });
+
+  it('rejects raw blobs with whitespace inside', () => {
+    expect(extractAccessToken('sk-ant has whitespace inside')).toBeNull();
+  });
+
+  it('handles JSON wrapped in whitespace', () => {
+    const blob = `\n  ${JSON.stringify({ accessToken: 'sk-ant-padded-token-1234567890' })}  \n`;
+    expect(extractAccessToken(blob)).toBe('sk-ant-padded-token-1234567890');
+  });
+
+  it('returns null for malformed JSON without a fallback raw token shape', () => {
+    expect(extractAccessToken('{"accessToken": "missing-quote}')).toBeNull();
+  });
+});
+
+describe('extractCredentialMetadata', () => {
+  it('reads subscriptionType + rateLimitTier + expiresAt from claudeAiOauth wrapper', () => {
+    const blob = JSON.stringify({
+      claudeAiOauth: {
+        accessToken: 'sk-ant-xyz1234567890',
+        refreshToken: 'r',
+        expiresAt: 1_750_000_000_000,
+        subscriptionType: 'pro',
+        rateLimitTier: 'standard',
+      },
+    });
+    expect(extractCredentialMetadata(blob)).toEqual({
+      subscriptionType: 'pro',
+      rateLimitTier: 'standard',
+      expiresAtMs: 1_750_000_000_000,
+    });
+  });
+
+  it('returns nulls for raw-token blob (no metadata available)', () => {
+    expect(extractCredentialMetadata('sk-ant-raw-token-1234567890')).toEqual({
+      subscriptionType: null,
+      rateLimitTier: null,
+      expiresAtMs: null,
+    });
+  });
+
+  it('returns nulls for empty / malformed JSON', () => {
+    expect(extractCredentialMetadata('')).toEqual({
+      subscriptionType: null,
+      rateLimitTier: null,
+      expiresAtMs: null,
+    });
+    expect(extractCredentialMetadata('{not json}')).toEqual({
+      subscriptionType: null,
+      rateLimitTier: null,
+      expiresAtMs: null,
+    });
+  });
+
+  it('returns nulls when metadata fields are missing or wrong type', () => {
+    const blob = JSON.stringify({
+      claudeAiOauth: {
+        accessToken: 'sk-ant-xyz1234567890',
+        subscriptionType: 42, // wrong type
+        expiresAt: 'not a number',
+      },
+    });
+    expect(extractCredentialMetadata(blob)).toEqual({
+      subscriptionType: null,
+      rateLimitTier: null,
+      expiresAtMs: null,
+    });
+  });
+
+  it('falls through to top-level if nested object has no metadata', () => {
+    const blob = JSON.stringify({
+      subscriptionType: 'team',
+      claudeAiOauth: { accessToken: 'sk-ant-xyz1234567890' },
+    });
+    expect(extractCredentialMetadata(blob).subscriptionType).toBe('team');
+  });
+
+  it('reads partial metadata when only one field present', () => {
+    const blob = JSON.stringify({ claudeAiOauth: { subscriptionType: 'max' } });
+    expect(extractCredentialMetadata(blob)).toEqual({
+      subscriptionType: 'max',
+      rateLimitTier: null,
+      expiresAtMs: null,
+    });
+  });
+});

--- a/src/main/claude/claudeCredential.ts
+++ b/src/main/claude/claudeCredential.ts
@@ -1,0 +1,263 @@
+// Cross-platform reader for the Claude Code OAuth credential.
+//
+// JS port of `openwong2kim/claude-token-check`'s TokenStore.swift, with
+// added Windows + Linux branches. The whole module is **read-only**: we
+// never write the credential back to disk, never log its contents, and
+// never send the token anywhere except the Anthropic API (handled in
+// UsageApi.ts).
+//
+// Storage by platform:
+//
+//   macOS   — Keychain (Generic password, service "Claude Code-credentials",
+//             account == current user). Read via `security` CLI shell-out.
+//   Windows — `%USERPROFILE%\.claude\.credentials.json` plain JSON file.
+//             Confirmed shape on user's machine 2026-05-24:
+//             { claudeAiOauth: { accessToken, refreshToken, expiresAt,
+//                                scopes, rateLimitTier, subscriptionType } }
+//   Linux   — Try `~/.claude/.credentials.json` first (same shape as
+//             Windows). libsecret integration is a follow-up if demand
+//             surfaces. No silent fallback to env vars — we want explicit
+//             "token not found" rather than picking up an ambient credential.
+//
+// Subscription tier comes from the credential metadata directly
+// (subscriptionType), so we never have to infer Pro/Max/Team from the
+// API rate-limit values.
+
+import { promisify } from 'node:util';
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const execFileAsync = promisify(execFile);
+
+/** Result returned by loadClaudeCredential. Token-bearing fields are
+ *  intentionally NOT included in any string representation; callers
+ *  should pull just what they need and pass the access token to
+ *  UsageApi without ever stringifying this whole object into a log. */
+export interface ClaudeCredential {
+  accessToken: string;
+  /** Subscription tier as reported by Claude Code (e.g. "pro", "max",
+   *  "team", "free"). Free-form string — we surface it as-is to the UI
+   *  but do not match it against an enum, so Anthropic adding new tiers
+   *  doesn't break us. */
+  subscriptionType: string | null;
+  /** Per-tier descriptor from Anthropic. Currently informational only. */
+  rateLimitTier: string | null;
+  /** Token expiry, milliseconds since Unix epoch. null when unknown
+   *  (raw-token storage form has no expiry metadata). */
+  expiresAtMs: number | null;
+}
+
+export type LoadResult =
+  | { ok: true; credential: ClaudeCredential }
+  | { ok: false; reason: 'not-found' | 'unsupported-platform' | 'read-error'; detail?: string };
+
+/**
+ * Read the active Claude Code OAuth credential for the current user.
+ *
+ * Returns `{ok: false}` (NOT a thrown error) for the common "not logged
+ * in" case so callers can switch on `reason` without try/catch. Network
+ * / OS-API errors still resolve to `{ok: false, reason: 'read-error'}`
+ * with the underlying message tucked in `detail` — useful for logging
+ * the FAILURE but never the credential itself.
+ */
+export async function loadClaudeCredential(): Promise<LoadResult> {
+  try {
+    if (process.platform === 'darwin') {
+      return await loadFromMacKeychain();
+    }
+    if (process.platform === 'win32') {
+      return await loadFromWindowsJson();
+    }
+    if (process.platform === 'linux') {
+      // Linux Claude Code stores credentials in the same json shape as
+      // Windows when launched outside a keyring. libsecret support is a
+      // follow-up — explicit miss rather than silent fallback.
+      return await loadFromWindowsJson();
+    }
+    return { ok: false, reason: 'unsupported-platform' };
+  } catch (err) {
+    // Whatever upstream threw, sanitize: keep the error class + message,
+    // strip anything that looks like it could be a token. Defense in
+    // depth — the loaders below should already filter, but a Node
+    // error propagating from low-level fs could in theory carry path
+    // strings that contain user info.
+    const detail = sanitizeError(err);
+    return { ok: false, reason: 'read-error', detail };
+  }
+}
+
+async function loadFromMacKeychain(): Promise<LoadResult> {
+  // `security find-generic-password -s "Claude Code-credentials" -a <user> -w`
+  // prints the secret as the entire stdout (no extra formatting). exit
+  // code 44 ("specified item not found") means "user hasn't logged into
+  // Claude Code yet" — distinct from any other failure.
+  //
+  // 5s timeout (Codex review 2026-05-24 P2 #4): a hung Keychain prompt
+  // (e.g. corrupted keychain, hostile child of `security`, or user
+  // interactively denying access in a system prompt) would otherwise
+  // wedge UsagePoller's `inflight` flag forever and silently disable
+  // the meter. Better to surface a one-time timeout to the UI than
+  // freeze the entire feature.
+  const username = os.userInfo().username;
+  try {
+    const { stdout } = await execFileAsync('security', [
+      'find-generic-password',
+      '-s',
+      'Claude Code-credentials',
+      '-a',
+      username,
+      '-w',
+    ], { timeout: 5_000 });
+    const token = extractAccessToken(stdout);
+    if (!token) return { ok: false, reason: 'not-found' };
+    // macOS Keychain stores only the secret — there's no companion
+    // metadata for expiry/tier. Best effort: read the same blob as JSON
+    // and pull metadata if the blob is the JSON shape (token-check
+    // confirms both raw and JSON forms exist in the wild).
+    return {
+      ok: true,
+      credential: buildCredentialFromBlob(token, stdout),
+    };
+  } catch (err) {
+    if (isItemNotFoundError(err)) {
+      return { ok: false, reason: 'not-found' };
+    }
+    throw err;
+  }
+}
+
+async function loadFromWindowsJson(): Promise<LoadResult> {
+  const credentialPath = path.join(os.homedir(), '.claude', '.credentials.json');
+  let raw: string;
+  try {
+    raw = await readFile(credentialPath, 'utf8');
+  } catch (err) {
+    if (isFileNotFoundError(err)) {
+      return { ok: false, reason: 'not-found' };
+    }
+    throw err;
+  }
+  const token = extractAccessToken(raw);
+  if (!token) return { ok: false, reason: 'not-found' };
+  return {
+    ok: true,
+    credential: buildCredentialFromBlob(token, raw),
+  };
+}
+
+/**
+ * Pull the access token out of a Keychain/JSON blob. Mirrors the Swift
+ * TokenStore.extractAccessToken behavior so platforms agree:
+ *  1. Try `json.accessToken` directly.
+ *  2. Try `json[*].accessToken` (matches the `{claudeAiOauth: {accessToken}}` shape).
+ *  3. Fall back to the regex for a raw token blob (≥20 url-safe chars).
+ *
+ * Exported for unit testing.
+ */
+export function extractAccessToken(blob: string): string | null {
+  const trimmed = blob.trim();
+  if (!trimmed) return null;
+
+  // Form 1+2: JSON.
+  try {
+    const json = JSON.parse(trimmed) as unknown;
+    if (json && typeof json === 'object') {
+      const direct = (json as Record<string, unknown>)['accessToken'];
+      if (typeof direct === 'string' && direct.length > 0) return direct;
+      // Nested one level deep — token-check's `claudeAiOauth.accessToken`.
+      for (const value of Object.values(json as Record<string, unknown>)) {
+        if (value && typeof value === 'object') {
+          const nested = (value as Record<string, unknown>)['accessToken'];
+          if (typeof nested === 'string' && nested.length > 0) return nested;
+        }
+      }
+    }
+  } catch {
+    // Not JSON — fall through to raw-token regex.
+  }
+
+  // Form 3: raw token blob.
+  if (/^[A-Za-z0-9_\-.~+/=]{20,}$/.test(trimmed)) return trimmed;
+
+  return null;
+}
+
+/** Extract the surrounding metadata block from a JSON-form blob, if
+ *  present. Returns nulls when the blob is a raw token. Exported for
+ *  unit tests. */
+export function extractCredentialMetadata(blob: string): {
+  subscriptionType: string | null;
+  rateLimitTier: string | null;
+  expiresAtMs: number | null;
+} {
+  const empty = { subscriptionType: null, rateLimitTier: null, expiresAtMs: null };
+  const trimmed = blob.trim();
+  if (!trimmed) return empty;
+  try {
+    const json = JSON.parse(trimmed) as unknown;
+    if (!json || typeof json !== 'object') return empty;
+    const top = json as Record<string, unknown>;
+    // The credential schema observed on Windows nests one level deep
+    // under `claudeAiOauth`. We also look at the top level so a future
+    // schema flattening doesn't break us silently.
+    for (const candidate of [top, ...Object.values(top).filter(isPlainObject)]) {
+      const c = candidate as Record<string, unknown>;
+      const subscriptionType = pickString(c, 'subscriptionType');
+      const rateLimitTier = pickString(c, 'rateLimitTier');
+      const expiresAtRaw = c['expiresAt'];
+      const expiresAtMs =
+        typeof expiresAtRaw === 'number' && Number.isFinite(expiresAtRaw) ? expiresAtRaw : null;
+      if (subscriptionType || rateLimitTier || expiresAtMs !== null) {
+        return { subscriptionType, rateLimitTier, expiresAtMs };
+      }
+    }
+  } catch {
+    /* not JSON */
+  }
+  return empty;
+}
+
+function buildCredentialFromBlob(accessToken: string, blob: string): ClaudeCredential {
+  const { subscriptionType, rateLimitTier, expiresAtMs } = extractCredentialMetadata(blob);
+  return { accessToken, subscriptionType, rateLimitTier, expiresAtMs };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function pickString(obj: Record<string, unknown>, key: string): string | null {
+  const v = obj[key];
+  return typeof v === 'string' && v.length > 0 ? v : null;
+}
+
+function isItemNotFoundError(err: unknown): boolean {
+  // `security` exits 44 with stderr "could not be found" when the
+  // service+account doesn't exist. node child_process attaches stderr
+  // and code on the thrown ExecFileException.
+  if (!err || typeof err !== 'object') return false;
+  const e = err as { code?: unknown; stderr?: unknown };
+  if (typeof e.code === 'number' && e.code === 44) return true;
+  if (typeof e.stderr === 'string' && /could not be found/i.test(e.stderr)) return true;
+  return false;
+}
+
+function isFileNotFoundError(err: unknown): boolean {
+  return !!err && typeof err === 'object' && (err as { code?: unknown }).code === 'ENOENT';
+}
+
+function sanitizeError(err: unknown): string {
+  // Defensive: never include anything that could plausibly be a token in
+  // the returned detail string. We accept the readable error class +
+  // numeric error code, and drop the message entirely if it's long
+  // enough to potentially carry a secret. Real errors here are file
+  // permission / missing binary / etc — they fit in < 200 chars.
+  if (!err || typeof err !== 'object') return 'unknown error';
+  const e = err as { name?: unknown; code?: unknown; message?: unknown };
+  const name = typeof e.name === 'string' ? e.name : 'Error';
+  const code = typeof e.code === 'string' || typeof e.code === 'number' ? String(e.code) : '';
+  const message = typeof e.message === 'string' && e.message.length < 200 ? e.message : '';
+  return [name, code, message].filter(Boolean).join(' ');
+}

--- a/src/main/hooks/SignalLatencyMeter.ts
+++ b/src/main/hooks/SignalLatencyMeter.ts
@@ -15,16 +15,26 @@
 //   Bridge captures ts = Date.now()
 //      │ (RPC: hooks.signal)
 //      ▼
-//   HookSignalRouter.dispatch()
-//      │ calls SignalLatencyMeter.recordSignal(signal.ts, now)
+//   hooks.rpc.ts (registerHooksRpc handler)
+//      │ 1. isAgentSignal(params) validate
+//      │ 2. meter.recordSignal(agent, fireTs)       — pre-workspace (Codex P1#2)
+//      │ 3. resolve cwd → ptyId (may miss)
+//      │ 4. meter.recordWorkspaceMatch(matched)     — separate counter
+//      │ 5. emit/dedup via HookSignalRouter
 //      ▼
-//   ring buffer (max 100 entries, oldest evicted)
+//   ring buffer (max 100 entries, oldest evicted) + workspaceMatchRate
 //      │
 //      ▼
-//   uiSlice reads getStats() periodically (or push on update)
+//   meter.onStatsChange listeners (1Hz throttle in registerHooksRpc subscriber)
 //      │
 //      ▼
-//   Settings → ClaudeIntegrationSection "Signal health" card
+//   win.webContents.send(IPC.SIGNAL_HEALTH_UPDATE, stats)
+//      │
+//      ▼
+//   preload signalHealth.onUpdate → uiSlice.setHookSignalHealth
+//      │
+//      ▼
+//   Settings → ClaudeIntegrationSection (tri-state card)
 
 import type { AgentSlug } from '../../../integrations/shared/signal-types';
 
@@ -53,6 +63,18 @@ export interface LatencyStats {
   lastSignalAt: number | null;
   /** Per-agent breakdown of fill counts. */
   perAgent: Partial<Record<AgentSlug, number>>;
+  /**
+   * Cumulative workspace-cwd match results since process start. Distinct
+   * dimension from `total` (ring entries are recorded BEFORE workspace
+   * match; this counter records the outcome). Codex P1#2: lets the
+   * Settings card surface "plugin works but Claude is running outside
+   * any wmux workspace" instead of conflating it with "plugin not
+   * firing." Neither counter is decremented.
+   */
+  workspaceMatchRate: {
+    matched: number;
+    missed: number;
+  };
 }
 
 /** Fixed ring buffer capacity. Chosen so the structure is bounded at
@@ -71,6 +93,11 @@ export class SignalLatencyMeter {
   private writeIdx = 0;
   /** Lifetime emission count, never decremented. */
   private totalSeen = 0;
+  /** Workspace cwd-match outcomes since process start. Never decremented. */
+  private matchedCount = 0;
+  private missedCount = 0;
+  /** onStatsChange subscribers. Single-fire; no buffering. */
+  private readonly listeners = new Set<(stats: LatencyStats) => void>();
 
   /**
    * Record a single hook arrival.
@@ -97,6 +124,62 @@ export class SignalLatencyMeter {
     }
     this.writeIdx = (this.writeIdx + 1) % MAX_BUFFER;
     this.totalSeen += 1;
+    this.emit();
+  }
+
+  /**
+   * Record the outcome of cwd → ptyId resolution for a signal that was
+   * already recorded via recordSignal. Split from recordSignal so that
+   * the latency ring stays cwd-agnostic and the workspace-match counter
+   * stays a separate dimension (Codex P1#2). Callers should invoke this
+   * once per recordSignal call, after attempting the lookup.
+   */
+  recordWorkspaceMatch(matched: boolean): void {
+    if (matched) {
+      this.matchedCount += 1;
+    } else {
+      this.missedCount += 1;
+    }
+    this.emit();
+  }
+
+  /**
+   * Subscribe to stats changes. Listeners receive a fresh `getStats()`
+   * snapshot synchronously on every recordSignal / recordWorkspaceMatch.
+   * Returns an unsubscribe function; calling it more than once is a
+   * no-op (Set.delete is idempotent on missing keys).
+   *
+   * Callers MUST hold the returned unsubscribe for the meter's lifetime
+   * (registerHooksRpc → main/index.ts before-quit). HMR test teardown
+   * also relies on this contract.
+   */
+  onStatsChange(cb: (stats: LatencyStats) => void): () => void {
+    this.listeners.add(cb);
+    return () => {
+      this.listeners.delete(cb);
+    };
+  }
+
+  /**
+   * Internal — fan-out to listeners. Snapshot once and pass the same
+   * object to every subscriber so a buggy subscriber that mutates
+   * cannot poison its siblings (defensive; the type is readonly in
+   * practice, but TS can't enforce that across IPC).
+   */
+  private emit(): void {
+    if (this.listeners.size === 0) return;
+    const stats = this.getStats();
+    for (const cb of this.listeners) {
+      try {
+        cb(stats);
+      } catch (err) {
+        // Never let a listener throw out of recordSignal. The latency
+        // ring is critical-path observability; one bad subscriber must
+        // not block future signal recording.
+        // eslint-disable-next-line no-console
+        console.warn('[SignalLatencyMeter] listener threw:', err);
+      }
+    }
   }
 
   /**
@@ -104,6 +187,10 @@ export class SignalLatencyMeter {
    * so this is fine to call on every Settings panel render.
    */
   getStats(): LatencyStats {
+    const workspaceMatchRate = {
+      matched: this.matchedCount,
+      missed: this.missedCount,
+    };
     const count = this.entries.length;
     if (count === 0) {
       return {
@@ -113,6 +200,7 @@ export class SignalLatencyMeter {
         p95: null,
         lastSignalAt: null,
         perAgent: {},
+        workspaceMatchRate,
       };
     }
 
@@ -139,6 +227,7 @@ export class SignalLatencyMeter {
       p95,
       lastSignalAt: lastSignalAt === -Infinity ? null : lastSignalAt,
       perAgent,
+      workspaceMatchRate,
     };
   }
 
@@ -165,6 +254,9 @@ export class SignalLatencyMeter {
     this.entries.length = 0;
     this.writeIdx = 0;
     this.totalSeen = 0;
+    this.matchedCount = 0;
+    this.missedCount = 0;
+    this.listeners.clear();
   }
 }
 

--- a/src/main/hooks/__tests__/SignalLatencyMeter.test.ts
+++ b/src/main/hooks/__tests__/SignalLatencyMeter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { SignalLatencyMeter, MAX_BUFFER } from '../SignalLatencyMeter';
 
 describe('SignalLatencyMeter', () => {
@@ -17,6 +17,7 @@ describe('SignalLatencyMeter', () => {
       expect(stats.p95).toBeNull();
       expect(stats.lastSignalAt).toBeNull();
       expect(stats.perAgent).toEqual({});
+      expect(stats.workspaceMatchRate).toEqual({ matched: 0, missed: 0 });
     });
 
     it('isStale() returns true with empty buffer regardless of threshold', () => {
@@ -144,6 +145,120 @@ describe('SignalLatencyMeter', () => {
       expect(stats.count).toBe(0);
       expect(stats.total).toBe(0);
       expect(stats.lastSignalAt).toBeNull();
+    });
+
+    it('clears workspace-match counters and listeners', () => {
+      const cb = vi.fn();
+      meter.onStatsChange(cb);
+      meter.recordWorkspaceMatch(true);
+      meter.recordWorkspaceMatch(false);
+      meter.resetForTests();
+      expect(meter.getStats().workspaceMatchRate).toEqual({ matched: 0, missed: 0 });
+      // Listener was cleared — further records do not invoke it.
+      cb.mockClear();
+      meter.recordSignal('claude', 0, 100);
+      expect(cb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('recordWorkspaceMatch (Codex P1#2)', () => {
+    it('increments matched counter on true', () => {
+      meter.recordWorkspaceMatch(true);
+      meter.recordWorkspaceMatch(true);
+      expect(meter.getStats().workspaceMatchRate).toEqual({ matched: 2, missed: 0 });
+    });
+
+    it('increments missed counter on false', () => {
+      meter.recordWorkspaceMatch(false);
+      meter.recordWorkspaceMatch(false);
+      meter.recordWorkspaceMatch(false);
+      expect(meter.getStats().workspaceMatchRate).toEqual({ matched: 0, missed: 3 });
+    });
+
+    it('counters are independent of the latency ring buffer', () => {
+      // recordSignal does NOT touch matched/missed.
+      meter.recordSignal('claude', 0, 100);
+      meter.recordSignal('claude', 0, 200);
+      expect(meter.getStats().workspaceMatchRate).toEqual({ matched: 0, missed: 0 });
+      // recordWorkspaceMatch does NOT touch the ring buffer / lastSignalAt.
+      const beforeLastTs = meter.getStats().lastSignalAt;
+      meter.recordWorkspaceMatch(true);
+      meter.recordWorkspaceMatch(false);
+      const afterLastTs = meter.getStats().lastSignalAt;
+      expect(afterLastTs).toBe(beforeLastTs);
+      expect(meter.getStats().count).toBe(2); // unchanged ring count
+    });
+  });
+
+  describe('onStatsChange emitter', () => {
+    it('fires synchronously on recordSignal', () => {
+      const cb = vi.fn();
+      meter.onStatsChange(cb);
+      meter.recordSignal('claude', 0, 100);
+      expect(cb).toHaveBeenCalledTimes(1);
+      const [stats] = cb.mock.calls[0];
+      expect(stats.count).toBe(1);
+      expect(stats.lastSignalAt).toBe(100);
+    });
+
+    it('fires synchronously on recordWorkspaceMatch', () => {
+      const cb = vi.fn();
+      meter.onStatsChange(cb);
+      meter.recordWorkspaceMatch(true);
+      meter.recordWorkspaceMatch(false);
+      expect(cb).toHaveBeenCalledTimes(2);
+      const [, secondStats] = cb.mock.calls;
+      expect(secondStats[0].workspaceMatchRate).toEqual({ matched: 1, missed: 1 });
+    });
+
+    it('returns unsubscribe that stops further emissions', () => {
+      const cb = vi.fn();
+      const unsubscribe = meter.onStatsChange(cb);
+      meter.recordSignal('claude', 0, 100);
+      expect(cb).toHaveBeenCalledTimes(1);
+      unsubscribe();
+      meter.recordSignal('claude', 0, 200);
+      expect(cb).toHaveBeenCalledTimes(1); // no new call
+    });
+
+    it('unsubscribe is idempotent (double-call is a no-op)', () => {
+      const cb = vi.fn();
+      const unsubscribe = meter.onStatsChange(cb);
+      unsubscribe();
+      unsubscribe();
+      expect(() => meter.recordSignal('claude', 0, 100)).not.toThrow();
+    });
+
+    it('multiple subscribers all receive the same snapshot', () => {
+      const cb1 = vi.fn();
+      const cb2 = vi.fn();
+      meter.onStatsChange(cb1);
+      meter.onStatsChange(cb2);
+      meter.recordSignal('claude', 0, 100);
+      expect(cb1).toHaveBeenCalledTimes(1);
+      expect(cb2).toHaveBeenCalledTimes(1);
+      // Same stats object identity is not required, but the data is identical.
+      expect(cb1.mock.calls[0][0]).toEqual(cb2.mock.calls[0][0]);
+    });
+
+    it('a throwing subscriber does not block sibling subscribers', () => {
+      const throwing = vi.fn(() => {
+        throw new Error('bad subscriber');
+      });
+      const sibling = vi.fn();
+      meter.onStatsChange(throwing);
+      meter.onStatsChange(sibling);
+      // Should swallow the throw and still invoke sibling.
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      meter.recordSignal('claude', 0, 100);
+      expect(sibling).toHaveBeenCalledTimes(1);
+      consoleSpy.mockRestore();
+    });
+
+    it('does not run emit when no listeners are attached (perf path)', () => {
+      // No listeners — recordSignal must not throw and must complete.
+      expect(() => meter.recordSignal('claude', 0, 100)).not.toThrow();
+      expect(meter.getStats().count).toBe(1);
     });
   });
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,6 +22,8 @@ import { registerNotifyRpc } from './pipe/handlers/notify.rpc';
 import { registerMetaRpc } from './pipe/handlers/meta.rpc';
 import { registerSystemRpc } from './pipe/handlers/system.rpc';
 import { registerHooksRpc } from './pipe/handlers/hooks.rpc';
+import { UsagePoller } from './claude/UsagePoller';
+import { IPC } from '../shared/constants';
 import { HookSignalRouter } from './hooks/HookSignalRouter';
 import { SignalLatencyMeter } from './hooks/SignalLatencyMeter';
 import { registerBrowserRpc } from './pipe/handlers/browser.rpc';
@@ -348,7 +350,33 @@ registerA2aRpc(rpcRouter, () => mainWindow, claudeWorker);
 registerCompanyRpc(rpcRouter, () => mainWindow);
 registerEventsRpc(rpcRouter);
 registerMcpPluginRpc(rpcRouter);
-registerHooksRpc(rpcRouter, () => mainWindow, hookSignalRouter);
+// Returns an unsubscribe for the signal-health push subscription. Called from
+// before-quit so HMR reload / shutdown does not leak the listener.
+const disposeHooksRpc = registerHooksRpc(rpcRouter, () => mainWindow, hookSignalRouter);
+
+// ─── Phase 2 — Anthropic 5h/7d usage meter ──────────────────────────────────
+// Opt-in. Stays idle until the renderer sends IPC.USAGE_TOGGLE with `true`.
+// Window visibility is hooked below in the BrowserWindow event wire-up.
+const usagePoller = new UsagePoller();
+const disposeUsagePollerListener = usagePoller.onStateChange((state) => {
+  const win = mainWindow;
+  if (win && !win.isDestroyed()) {
+    win.webContents.send(IPC.USAGE_UPDATE, state);
+  }
+});
+ipcMain.on(IPC.USAGE_TOGGLE, (_event, enabled: unknown) => {
+  if (enabled === true) {
+    usagePoller.start();
+  } else {
+    usagePoller.stop();
+  }
+});
+ipcMain.on(IPC.USAGE_REFRESH, () => {
+  // refreshNow() is fire-and-forget here — the listener above will
+  // push the resulting state to the renderer. Wrapping in `void` so
+  // the floating promise doesn't trip lint.
+  void usagePoller.refreshNow();
+});
 
 // Wire the legacy-contact bookkeeping so envelope-less RPCs land in
 // plugin-trust.json as a `legacy` audit entry, per spec §2.2.
@@ -436,6 +464,13 @@ app.on('ready', async () => {
       mainWindow!.hide();
     }
   });
+
+  // Phase 2 — UsagePoller hidden-window cost control. We treat tray-hide
+  // as "user not looking" so the poller's 30-min skip threshold kicks in
+  // and we don't burn Anthropic quota for a UI nobody sees. Show always
+  // unpauses immediately and forces a catch-up fetch.
+  mainWindow.on('hide', () => { usagePoller.setWindowVisible(false); });
+  mainWindow.on('show', () => { usagePoller.setWindowVisible(true); });
 
   // System tray — lets the app stay alive when window is closed.
   // Phase A — A3/A5 fix (codex review P1, session 019e2af8): the callback
@@ -762,6 +797,9 @@ app.on('before-quit', async (e) => {
 
   cleanupHandlers();
   disposeFirstRunHandlers();
+  disposeHooksRpc();
+  disposeUsagePollerListener();
+  usagePoller.dispose();
   // Tear down the respawn controller BEFORE the daemon-shutdown race so
   // a daemon close during the race window can't trigger a respawn attempt
   // while the rest of the app is exiting. `dispose()` only stops timers

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -5,7 +5,7 @@ import { StringDecoder } from 'node:string_decoder';
 import { PTYManager } from '../../pty/PTYManager';
 import { PTYBridge } from '../../pty/PTYBridge';
 import { DaemonClient } from '../../DaemonClient';
-import { IPC, getPidMapDir } from '../../../shared/constants';
+import { IPC, getPidMapDir, ENV_KEYS } from '../../../shared/constants';
 import { sanitizePtyText } from '../../../shared/types';
 import { updateCwd } from './metadata.handler';
 import { markResize, markUserWrite } from '../../notification/idleSuppression';
@@ -182,7 +182,7 @@ export function registerPTYHandlers(
   // pty:create
   ipcMain.removeHandler(IPC.PTY_CREATE);
   if (useDaemon && daemonClient) {
-    ipcMain.handle(IPC.PTY_CREATE, wrapHandler(IPC.PTY_CREATE, async (_event: Electron.IpcMainInvokeEvent, options?: { shell?: string; cwd?: string; cols?: number; rows?: number; workspaceId?: string }) => {
+    ipcMain.handle(IPC.PTY_CREATE, wrapHandler(IPC.PTY_CREATE, async (_event: Electron.IpcMainInvokeEvent, options?: { shell?: string; cwd?: string; cols?: number; rows?: number; workspaceId?: string; surfaceId?: string }) => {
       if (options?.shell !== undefined && !isAllowedShell(options.shell)) {
         throw new Error(`PTY_CREATE: shell not allowed: ${options.shell}`);
       }
@@ -195,6 +195,29 @@ export function registerPTYHandlers(
       const crypto = require('crypto');
       const sessionId = `daemon-${crypto.randomUUID().slice(0, 8)}`;
 
+      // Identity env vars for the spawned shell. The daemon's
+      // `buildSafeChildEnv` passes WMUX_WORKSPACE_ID / WMUX_SURFACE_ID
+      // through (only WMUX_AUTH* is stripped), so PTY children — and
+      // any tooling that spawns from them like the Claude Code hook
+      // bridge — can use the env for deterministic routing instead of
+      // ambiguous cwd matching. (User dogfood 2026-05-24: workspace 4
+      // turn-end was landing on workspace 2's toast because both had
+      // cwd C:\Users\rizz. Env-first now resolves it.)
+      //
+      // Without this, daemon-mode sessions get a bare `globalThis.process.env`
+      // baseline that has no wmux identity at all — main process never had
+      // WMUX_WORKSPACE_ID/SURFACE_ID in its own env (those are PTY-level).
+      const identityEnv: Record<string, string> = {};
+      if (options?.workspaceId) identityEnv[ENV_KEYS.WORKSPACE_ID] = options.workspaceId;
+      if (options?.surfaceId) identityEnv[ENV_KEYS.SURFACE_ID] = options.surfaceId;
+      // Merge with main process env so the daemon's buildSafeChildEnv starts
+      // from a complete baseline (PATH, USERPROFILE, etc.) plus our identity.
+      const sessionEnv: Record<string, string> = {};
+      for (const [k, v] of Object.entries(globalThis.process.env)) {
+        if (typeof v === 'string') sessionEnv[k] = v;
+      }
+      Object.assign(sessionEnv, identityEnv);
+
       // Create session via daemon RPC
       const result = await daemonClient.rpc('daemon.createSession', {
         id: sessionId,
@@ -202,6 +225,7 @@ export function registerPTYHandlers(
         cwd: effectiveCwd,
         cols: options?.cols || 80,
         rows: options?.rows || 24,
+        env: sessionEnv,
       });
 
       // Attach to the session (makes daemon start the SessionPipe server)

--- a/src/main/pipe/handlers/__tests__/hooks.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/hooks.rpc.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { resolvePtyIdForCwd, extractUsageFromPayload } from '../hooks.rpc';
+import { resolvePtyIdForCwd, resolvePtyIdForSignal, extractUsageFromPayload } from '../hooks.rpc';
+import type { AgentSignal } from '../../../../../integrations/shared/signal-types';
+
+function signal(overrides: Partial<AgentSignal>): AgentSignal {
+  return {
+    kind: 'agent.stop',
+    agent: 'claude',
+    cwd: '/foo/bar',
+    payload: {},
+    ts: 1_700_000_000_000,
+    ...overrides,
+  };
+}
 
 describe('resolvePtyIdForCwd', () => {
   it('exact cwd match returns activePtyId', () => {
@@ -99,6 +111,65 @@ describe('resolvePtyIdForCwd', () => {
       { id: 'w2', name: 'exact', metadata: { cwd: '/foo/bar' }, activePtyId: 'p2', ptyIds: ['p2'] },
     ]);
     expect(got).toBe('p2');
+  });
+});
+
+describe('resolvePtyIdForSignal — env-first routing (Codex P1 #7 fix)', () => {
+  const workspaces = [
+    { id: 'ws-2', name: 'Workspace 2', metadata: { cwd: '/repo' }, activePtyId: 'p2', ptyIds: ['p2'] },
+    { id: 'ws-4', name: 'Workspace 4', metadata: { cwd: '/repo' }, activePtyId: 'p4', ptyIds: ['p4'] },
+  ];
+
+  it('workspaceId env match wins over cwd ambiguity (the bug user dogfood hit)', () => {
+    // Both ws-2 and ws-4 have cwd '/repo' — pure cwd routing would
+    // return p2 (first match). Env-first routes to ws-4 deterministically.
+    const got = resolvePtyIdForSignal(signal({ workspaceId: 'ws-4', cwd: '/repo' }), workspaces);
+    expect(got).toBe('p4');
+  });
+
+  it('workspaceId env match wins even when cwd would match a different workspace', () => {
+    // ws-2 has cwd '/foo' but the signal env says ws-4. Env wins.
+    const ws = [
+      { id: 'ws-2', name: 'A', metadata: { cwd: '/foo' }, activePtyId: 'p2', ptyIds: ['p2'] },
+      { id: 'ws-4', name: 'B', metadata: { cwd: '/bar' }, activePtyId: 'p4', ptyIds: ['p4'] },
+    ];
+    const got = resolvePtyIdForSignal(signal({ workspaceId: 'ws-4', cwd: '/foo' }), ws);
+    expect(got).toBe('p4');
+  });
+
+  it('falls back to cwd when workspaceId is absent', () => {
+    const got = resolvePtyIdForSignal(signal({ cwd: '/repo' }), workspaces);
+    // No env → cwd exact match → first workspaces entry wins (ws-2's p2).
+    expect(got).toBe('p2');
+  });
+
+  it('falls back to cwd when workspaceId references a closed workspace', () => {
+    // Stale env (workspace closed). Recover via cwd matching.
+    const got = resolvePtyIdForSignal(
+      signal({ workspaceId: 'ws-deleted', cwd: '/repo' }),
+      workspaces,
+    );
+    expect(got).toBe('p2');
+  });
+
+  it('returns null when env workspaceId stale AND cwd has no match', () => {
+    const got = resolvePtyIdForSignal(
+      signal({ workspaceId: 'ws-deleted', cwd: '/not-wmux' }),
+      workspaces,
+    );
+    expect(got).toBeNull();
+  });
+
+  it('workspaceId matches but workspace has no ptyId → fall back to cwd', () => {
+    const ws = [
+      { id: 'ws-empty', name: 'empty', metadata: { cwd: '/elsewhere' } },
+      { id: 'ws-with-cwd', name: 'with-cwd', metadata: { cwd: '/repo' }, activePtyId: 'pX', ptyIds: ['pX'] },
+    ];
+    const got = resolvePtyIdForSignal(
+      signal({ workspaceId: 'ws-empty', cwd: '/repo' }),
+      ws,
+    );
+    expect(got).toBe('pX');
   });
 });
 

--- a/src/main/pipe/handlers/hooks.rpc.ts
+++ b/src/main/pipe/handlers/hooks.rpc.ts
@@ -23,11 +23,20 @@
 //      ▼
 //   RpcRouter.dispatch('hooks.signal') → THIS HANDLER
 //      │ 1. isAgentSignal(params) validate
-//      │ 2. resolve cwd → {workspaceId, ptyId} via workspace.list
-//      │ 3. HookSignalRouter.recordHook → 'emit' or 'dedup'
-//      │ 4. if emit: sendNotification(win, ptyId, {...})
+//      │ 2. meter.recordSignal(agent, fireTs) — workspace-match-agnostic
+//      │    (Codex P1#2: surface plugin health even for cwds outside any
+//      │    wmux workspace)
+//      │ 3. resolve cwd → {workspaceId, ptyId} via workspace.list
+//      │ 4. meter.recordWorkspaceMatch(ptyId != null) — separate counter
+//      │ 5. if matched: forward token usage, run dedup, emit notification
+//      │    if not matched: respond with no-workspace-match
 //      ▼
 //   Response: { ok: true } or { ok: false, reason: '...' }
+//
+// Separately, registerHooksRpc subscribes to meter.onStatsChange and
+// pushes LatencyStats snapshots to the renderer via
+// IPC.SIGNAL_HEALTH_UPDATE (1Hz throttle). The renderer feeds them into
+// uiSlice.setHookSignalHealth for the Settings → Claude integration card.
 
 import type { BrowserWindow } from 'electron';
 import type { RpcRouter } from '../RpcRouter';
@@ -58,12 +67,20 @@ interface WorkspaceListEntry {
  * `getWindow` returns the active BrowserWindow so we can:
  *   a) call workspace.list via sendToRenderer to resolve cwd
  *   b) call sendNotification with the resolved ptyId
+ *   c) push SIGNAL_HEALTH_UPDATE snapshots
+ *
+ * Returns an unsubscribe function that detaches the signal-health
+ * listener. The caller (main/index.ts) MUST invoke it on shutdown so
+ * HMR / test teardown does not leak subscriptions. Idempotent on
+ * repeated invocation.
  */
 export function registerHooksRpc(
   router: RpcRouter,
   getWindow: GetWindow,
   hookRouter: HookSignalRouter,
-): void {
+): () => void {
+  const meter = hookRouter.getLatencyMeter();
+
   router.register('hooks.signal', async (params): Promise<HookSignalResponse> => {
     // 1. Envelope validation. Reject anything that doesn't match the
     //    canonical shape — bridges from older wmux versions, malformed
@@ -73,37 +90,50 @@ export function registerHooksRpc(
     }
     const signal: AgentSignal = params;
 
-    // 2. Resolve cwd → ptyId. We query the renderer-side workspace list
-    //    every time because the workspace tree changes more often than
-    //    hooks fire. A 1-RTT round-trip to the renderer is fine at
-    //    the hook fire rate (≤ a few per turn).
+    // 2. Latency observability runs BEFORE workspace match so that
+    //    plugin signals from cwds outside any wmux workspace still
+    //    count toward "plugin is alive" (Codex P1#2). The workspace
+    //    match outcome is tracked as a separate counter below.
+    meter.recordSignal(signal.agent, signal.ts);
+
+    // 3. Resolve signal → ptyId. Env-first (workspaceId/surfaceId from
+    //    WMUX_* env vars that wmux PTYManager injects into the shell)
+    //    with cwd matching as the fallback for sessions started outside
+    //    a wmux pane. We query the renderer-side workspace list every
+    //    time because the workspace tree changes more often than hooks
+    //    fire; a 1-RTT round-trip to the renderer is fine at the hook
+    //    fire rate (≤ a few per turn).
     const workspaces = await safeListWorkspaces(getWindow);
     if (!workspaces) {
+      // Record as a miss because we couldn't determine match either
+      // way — better than silently skewing the counter to "matched".
+      meter.recordWorkspaceMatch(false);
       return { ok: false, reason: 'internal-error' };
     }
 
-    const ptyId = resolvePtyIdForCwd(signal.cwd, workspaces);
+    const ptyId = resolvePtyIdForSignal(signal, workspaces);
+    meter.recordWorkspaceMatch(ptyId != null);
     if (!ptyId) {
       // No wmux workspace owns this cwd. Bridge fired but the user's
       // Claude Code session is running OUTSIDE any wmux-managed dir.
-      // This is expected when Claude is used standalone; we just drop.
+      // This is expected when Claude is used standalone; we just drop
+      // the per-pane notification. Signal health (above) still records.
       return { ok: false, reason: 'no-workspace-match' };
     }
 
-    // 3. Latency observability runs for EVERY signal kind, regardless
-    //    of whether the kind is one that emits a user-visible
-    //    notification. We always learned something about plugin
-    //    health from the round-trip.
-    hookRouter.getLatencyMeter().recordSignal(signal.agent, signal.ts);
-
-    // 3b. Forward token usage if the bridge included it. Stop /
-    //     SubagentStop bridges read the transcript JSONL and embed a
-    //     `usage` block; we reuse the same IPC channel
-    //     (TOKEN_UPDATE) the regex-based TokenTracker already uses,
-    //     so renderer-side handling (useNotificationListener +
-    //     tokenSlice) is unchanged. Hook-derived numbers are
-    //     authoritative and arrive on every turn; TokenTracker
-    //     remains the fallback for users without the plugin.
+    // 4. Forward token usage if the bridge included it. Stop /
+    //    SubagentStop bridges read the transcript JSONL and embed a
+    //    `usage` block; we reuse the same IPC channel
+    //    (TOKEN_UPDATE) the regex-based TokenTracker already uses,
+    //    so renderer-side handling (useNotificationListener +
+    //    tokenSlice) is unchanged. Hook-derived numbers are
+    //    authoritative and arrive on every turn; TokenTracker
+    //    remains the fallback for users without the plugin.
+    //
+    //    NOTE: Token IPC is intentionally workspace-match-gated (unlike
+    //    signal-health above). Token data is per-pane (needs a ptyId
+    //    target); signal-health is global plugin status (no target
+    //    required). Two consumers, two data shapes. Don't conflate.
     const usage = extractUsageFromPayload(signal.payload);
     if (usage) {
       const win = getWindow();
@@ -117,7 +147,7 @@ export function registerHooksRpc(
       }
     }
 
-    // 4. Emit decision. PostToolUse / SessionStart never produce a
+    // 5. Emit decision. PostToolUse / SessionStart never produce a
     //    toast (would be spam — codex round-2 P1 #5). They also
     //    DO NOT write to the dedup ledger (claude review 2026-05-23
     //    P2 #6) because a no-emit ledger entry would silently block
@@ -145,6 +175,96 @@ export function registerHooksRpc(
     }
     return { ok: true };
   });
+
+  // ─── Signal-health push to renderer ─────────────────────────────────────
+  //
+  // Subscribe once. Every recordSignal / recordWorkspaceMatch fires the
+  // listener with a fresh stats snapshot. Wrap in a 1Hz leading+trailing
+  // throttle so burst events (a tool-call-heavy turn) don't flood the
+  // renderer with redundant IPC traffic; the user-visible card refreshes
+  // at most once per second, which is well below the human perception
+  // threshold and well above the renderer's measured re-render cost.
+  const throttledPush = throttle1Hz((stats) => {
+    const win = getWindow();
+    if (win && !win.isDestroyed()) {
+      win.webContents.send(IPC.SIGNAL_HEALTH_UPDATE, stats);
+    }
+  });
+  const unsubscribe = meter.onStatsChange(throttledPush);
+
+  // Push the current snapshot once so a freshly-reloaded renderer
+  // doesn't sit with an empty/stale uiSlice until the next hook fires.
+  // Same guard as the throttled handler — getWindow() may not be ready
+  // yet at registration time (registerHooksRpc runs before BrowserWindow
+  // is fully constructed in main/index.ts), in which case the next real
+  // signal will populate it.
+  const initialWin = getWindow();
+  if (initialWin && !initialWin.isDestroyed()) {
+    initialWin.webContents.send(IPC.SIGNAL_HEALTH_UPDATE, meter.getStats());
+  }
+
+  return () => {
+    unsubscribe();
+    throttledPush.cancel();
+  };
+}
+
+/**
+ * 1Hz leading + trailing throttle. Inline so this handler stays
+ * dependency-free (no lodash pull-in for one tiny helper).
+ *
+ * Behavior:
+ *  - Leading: first call fires immediately.
+ *  - Trailing: if more calls arrive within the 1s window, the LAST one
+ *    fires once the window closes. Intermediate values are dropped —
+ *    safe because each LatencyStats snapshot is a full state replacement,
+ *    not a delta.
+ *  - cancel() clears any pending trailing fire (used at unsubscribe).
+ */
+function throttle1Hz<T>(fn: (arg: T) => void): ((arg: T) => void) & { cancel: () => void } {
+  const WINDOW_MS = 1000;
+  let lastFiredAt = 0;
+  let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+  let pendingArg: T | null = null;
+
+  const wrapped = ((arg: T): void => {
+    const now = Date.now();
+    const elapsed = now - lastFiredAt;
+    if (elapsed >= WINDOW_MS) {
+      // Leading edge.
+      lastFiredAt = now;
+      pendingArg = null;
+      if (pendingTimer) {
+        clearTimeout(pendingTimer);
+        pendingTimer = null;
+      }
+      fn(arg);
+    } else {
+      // Schedule trailing fire, replacing any previously-pending arg.
+      pendingArg = arg;
+      if (!pendingTimer) {
+        pendingTimer = setTimeout(() => {
+          pendingTimer = null;
+          if (pendingArg !== null) {
+            lastFiredAt = Date.now();
+            const finalArg = pendingArg;
+            pendingArg = null;
+            fn(finalArg);
+          }
+        }, WINDOW_MS - elapsed);
+      }
+    }
+  }) as ((arg: T) => void) & { cancel: () => void };
+
+  wrapped.cancel = () => {
+    if (pendingTimer) {
+      clearTimeout(pendingTimer);
+      pendingTimer = null;
+    }
+    pendingArg = null;
+  };
+
+  return wrapped;
 }
 
 /**
@@ -164,6 +284,47 @@ async function safeListWorkspaces(getWindow: GetWindow): Promise<WorkspaceListEn
 }
 
 /**
+ * Resolve an AgentSignal to a ptyId using env-first routing.
+ *
+ * Priority:
+ *   1. `signal.workspaceId` matches a workspace.id → use that workspace's
+ *      activePtyId (refined by `signal.surfaceId` when the workspace.list
+ *      response carries surface metadata — currently it doesn't; surfaceId
+ *      is forensic-only until workspace.list is extended).
+ *   2. cwd-based matching (resolvePtyIdForCwd) — exact then longest-prefix.
+ *      Used when the bridge ran outside a wmux pane (no env vars) OR
+ *      when the env workspaceId is stale (workspace closed but the
+ *      bridge subprocess still has the inherited env).
+ *   3. null — caller emits 'no-workspace-match'.
+ *
+ * Codex P1 #7 + user dogfood 2026-05-24 (workspace 4 turn-end was
+ * landing in workspace 2's toast because both workspaces had the same
+ * cwd) — cwd alone is ambiguous when two panes share a path. Env-first
+ * makes the routing deterministic for the in-pane case.
+ */
+export function resolvePtyIdForSignal(
+  signal: AgentSignal,
+  workspaces: WorkspaceListEntry[],
+): string | null {
+  if (signal.workspaceId) {
+    const match = workspaces.find((w) => w.id === signal.workspaceId);
+    if (match) {
+      // surfaceId-aware routing requires workspace.list to expose a
+      // surface→ptyId mapping. Until that extension lands, surfaceId is
+      // forensic only and we fall through to activePtyId. (See plan
+      // follow-up #5: workspace.list surfaces extension.)
+      const ptyId = match.activePtyId ?? match.ptyIds?.[0] ?? null;
+      if (ptyId) return ptyId;
+      // workspaceId matched a known workspace but the workspace has no
+      // ptyId. Fall through to cwd matching as a defensive recovery —
+      // a freshly-created workspace with the env set but no surfaces
+      // yet would land here.
+    }
+  }
+  return resolvePtyIdForCwd(signal.cwd, workspaces);
+}
+
+/**
  * cwd matching strategy:
  *   1. EXACT match against workspace.metadata.cwd → returns activePtyId
  *   2. PREFIX match (signal cwd is a subdirectory of a workspace cwd) →
@@ -171,9 +332,8 @@ async function safeListWorkspaces(getWindow: GetWindow): Promise<WorkspaceListEn
  *   3. No match → null (bridge fired in a non-wmux cwd)
  *
  * Strategy #2 is the practical answer to "user `cd`s into a subdir
- * mid-session" without requiring an env-based resolver. Codex P1 #7
- * (WMUX_WORKSPACE_ID env-first) is deferred — when implemented it
- * becomes step 0, and cwd matching becomes the fallback.
+ * mid-session" without requiring an env-based resolver. Used as the
+ * fallback by `resolvePtyIdForSignal` when env vars are absent.
  */
 export function resolvePtyIdForCwd(
   signalCwd: string,

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -238,6 +238,79 @@ const electronAPI = {
       return () => { ipcRenderer.removeListener(IPC.TOKEN_UPDATE, listener); };
     },
   },
+  // Phase 1.5 — Claude Code plugin signal-health push. Main fires whenever
+  // SignalLatencyMeter stats change (throttled to 1Hz). Payload mirrors
+  // `LatencyStats` from src/main/hooks/SignalLatencyMeter.ts. Mirrored here
+  // to avoid a renderer→main type import; renderer uses the structural
+  // shape only.
+  signalHealth: {
+    onUpdate: (
+      callback: (stats: {
+        total: number;
+        count: number;
+        p50: number | null;
+        p95: number | null;
+        lastSignalAt: number | null;
+        perAgent: Record<string, number>;
+        workspaceMatchRate: { matched: number; missed: number };
+      }) => void,
+    ) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        stats: {
+          total: number;
+          count: number;
+          p50: number | null;
+          p95: number | null;
+          lastSignalAt: number | null;
+          perAgent: Record<string, number>;
+          workspaceMatchRate: { matched: number; missed: number };
+        },
+      ) => callback(stats);
+      ipcRenderer.on(IPC.SIGNAL_HEALTH_UPDATE, listener);
+      return () => { ipcRenderer.removeListener(IPC.SIGNAL_HEALTH_UPDATE, listener); };
+    },
+  },
+  // Phase 2 — Anthropic 5h/7d usage meter. Push channel from UsagePoller.
+  // Shape mirrors `PollerState` from src/main/claude/UsagePoller.ts.
+  // The renderer treats the snapshot as opaque: it's read but never
+  // mutated, and the access token is intentionally absent from the
+  // payload (the poller strips it before emitting).
+  usage: {
+    onUpdate: (
+      callback: (state: {
+        status:
+          | 'idle'
+          | 'ok'
+          | 'token-missing'
+          | 'unauthorized'
+          | 'http-error'
+          | 'network-error'
+          | 'read-error';
+        snapshot: {
+          sessionPct: number;
+          sessionResetEpochSec: number;
+          weeklyPct: number;
+          weeklyResetEpochSec: number;
+          fetchedAtMs: number;
+        } | null;
+        lastError: string | null;
+        subscriptionType: string | null;
+      }) => void,
+    ) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        state: Parameters<typeof callback>[0],
+      ) => callback(state);
+      ipcRenderer.on(IPC.USAGE_UPDATE, listener);
+      return () => { ipcRenderer.removeListener(IPC.USAGE_UPDATE, listener); };
+    },
+    /** Toggle the poller on/off. Persisted in uiSlice and synced to
+     *  main on every change. Main starts/stops the interval. */
+    setEnabled: (enabled: boolean) => ipcRenderer.send(IPC.USAGE_TOGGLE, enabled),
+    /** Manual refresh. UI is responsible for the 5-minute cooldown. */
+    refresh: () => ipcRenderer.send(IPC.USAGE_REFRESH),
+  },
   window: {
     hide: () => ipcRenderer.send(IPC.WINDOW_HIDE),
     // T6 Notification System Expansion — recall the user via the Windows

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -114,18 +114,21 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
     }
   }, [pane.id, pane.surfaces, setActivePane, markRead, setPaneNotificationRing]);
 
-  const activeWorkspaceId = useStore((s) => s.activeWorkspaceId);
   const defaultShell = useStore((s) => s.defaultShell);
   const { invoke: ipcInvoke } = useIpc();
   const handleAddSurface = useCallback(async () => {
+    // Use the owning workspace id from the prop, NOT global activeWorkspaceId
+    // — multiview can leave this Pane mounted while a different tile holds
+    // focus, and the global value would tag the new PTY with the wrong
+    // workspace. Codex P1 fix 2026-05-24.
     const result = await ipcInvoke<{ id: string }>(() =>
-      window.electronAPI.pty.create(withDefaultShell({ workspaceId: activeWorkspaceId }, defaultShell))
+      window.electronAPI.pty.create(withDefaultShell({ workspaceId: workspace.id }, defaultShell))
     );
     if (result.ok) {
       addSurface(pane.id, result.data.id, 'Terminal', '');
     }
     // On failure, useIpc already surfaced a toast. No-op here.
-  }, [pane.id, addSurface, activeWorkspaceId, defaultShell, ipcInvoke]);
+  }, [pane.id, addSurface, workspace.id, defaultShell, ipcInvoke]);
 
   const closePane = useStore((s) => s.closePane);
 
@@ -164,6 +167,7 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
 
       <SplitSurfaceView
         pane={pane}
+        workspaceId={workspace.id}
         activeSurfaceId={pane.activeSurfaceId}
         isWorkspaceVisible={isWorkspaceVisible}
         onCloseSurface={handleCloseSurface}
@@ -178,6 +182,7 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
 /** Renders surfaces with a resizable split when both terminals and browsers coexist */
 function SplitSurfaceView({
   pane,
+  workspaceId,
   activeSurfaceId,
   isWorkspaceVisible,
   onCloseSurface,
@@ -185,6 +190,9 @@ function SplitSurfaceView({
   emptyMessage,
 }: {
   pane: PaneLeaf;
+  /** Owning workspace id — threaded through to TerminalComponent so PTY
+   *  create uses the correct WMUX_WORKSPACE_ID env (Codex P1 2026-05-24). */
+  workspaceId: string;
   activeSurfaceId: string;
   isWorkspaceVisible: boolean;
   onCloseSurface: (id: string) => void;
@@ -239,6 +247,8 @@ function SplitSurfaceView({
               isWorkspaceVisible={isWorkspaceVisible}
               onPtyCreated={(ptyId) => onPtyCreated(surface.id, ptyId)}
               scrollbackFile={surface.scrollbackFile}
+              workspaceId={workspaceId}
+              surfaceId={surface.id}
             />
           ),
         )}
@@ -261,6 +271,8 @@ function SplitSurfaceView({
                 isWorkspaceVisible={isWorkspaceVisible}
                 onPtyCreated={(ptyId) => onPtyCreated(surface.id, ptyId)}
                 scrollbackFile={surface.scrollbackFile}
+                workspaceId={workspaceId}
+                surfaceId={surface.id}
               />
             ))}
           </div>

--- a/src/renderer/components/Settings/ClaudeIntegrationSection.tsx
+++ b/src/renderer/components/Settings/ClaudeIntegrationSection.tsx
@@ -1,0 +1,417 @@
+// Settings → Claude integration card.
+//
+// Tri-state surface driven by `uiSlice.hookSignalHealth`:
+//
+//                ┌──────────┐
+//                │ Unknown  │  initial; count === 0
+//                └────┬─────┘
+//                     │ first signal arrives
+//                     ▼
+//                ┌──────────┐
+//        ┌───────│ Detected │◀───── any new signal recordSignal
+//        │       └────┬─────┘
+//        │            │
+//        │            │ no signal for ≥ STALE_THRESHOLD_MS
+//        │            ▼
+//        │       ┌──────────┐
+//        └───────│  Stale   │ (returns to Detected on next signal)
+//        new sig └──────────┘
+//
+// There is no Unknown → Stale transition: stale is only meaningful once at
+// least one signal has been seen. Initial-state-after-restart with prior
+// signals lost falls back to Unknown again (state is renderer-local, not
+// persisted).
+//
+// The card never derives plugin install state from the signal stream alone
+// (Codex P0): "Unknown" intentionally reads as ambiguous between "plugin
+// not installed" and "installed but quiet". A real install probe is a
+// follow-up — until then the install hint is shown in the Unknown state
+// and the user resolves the ambiguity by trying the install command.
+
+import { useEffect, useState } from 'react';
+import { useStore } from '../../stores';
+import { useT } from '../../hooks/useT';
+
+export const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24h
+
+// Install command pair. Marketplace name comes from /.claude-plugin/marketplace.json
+// (owner=openwong2kim, name=wmux). Plugin name from integrations/claude/.claude-plugin/plugin.json.
+// Both commands on one clipboard payload, newline-separated. Exported so unit
+// tests can assert the exact payload written to the clipboard.
+export const INSTALL_COMMAND =
+  '/plugin marketplace add openwong2kim/wmux\n/plugin install wmux-claude-integration@wmux';
+
+/**
+ * Format a "time since" string given a millisecond delta. Uses
+ * Intl.RelativeTimeFormat for native i18n. Locale comes from store.
+ */
+function useRelativeTimeFromNow(): (ts: number | null) => string | null {
+  const locale = useStore((s) => s.locale);
+  return (ts: number | null) => {
+    if (ts === null) return null;
+    const deltaMs = Date.now() - ts;
+    const fmt = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+    const sec = Math.round(deltaMs / 1000);
+    if (sec < 60) return fmt.format(-sec, 'second');
+    const min = Math.round(sec / 60);
+    if (min < 60) return fmt.format(-min, 'minute');
+    const hr = Math.round(min / 60);
+    if (hr < 24) return fmt.format(-hr, 'hour');
+    const day = Math.round(hr / 24);
+    return fmt.format(-day, 'day');
+  };
+}
+
+export type CardState =
+  | { kind: 'unknown' }
+  | { kind: 'detected'; relTime: string }
+  | { kind: 'stale'; relTime: string };
+
+/**
+ * Pure derivation: given the live stats + a relative-time formatter + the
+ * current clock cursor, decide which of the three card states applies.
+ * Exported so unit tests can drive the state machine directly without
+ * mounting React.
+ */
+export function deriveState(
+  count: number,
+  lastSignalAt: number | null,
+  relFormatter: (ts: number | null) => string | null,
+  now: number,
+): CardState {
+  if (count === 0 || lastSignalAt === null) return { kind: 'unknown' };
+  const isStale = now - lastSignalAt > STALE_THRESHOLD_MS;
+  const relTime = relFormatter(lastSignalAt) ?? '';
+  return isStale ? { kind: 'stale', relTime } : { kind: 'detected', relTime };
+}
+
+/**
+ * Settings → Claude integration tab content. Single card today; the surface
+ * is intentionally narrow so future additions (install-probe banner,
+ * per-pane token panel) can layer on without restructuring the layout.
+ */
+export function ClaudeIntegrationSection() {
+  const t = useT();
+  const health = useStore((s) => s.hookSignalHealth);
+  const formatRel = useRelativeTimeFromNow();
+  // `now` cursor so the "Xm ago" string and stale gate refresh once a
+  // minute without needing a per-signal re-render trigger.
+  const [now, setNow] = useState<number>(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const cardState = deriveState(health.count, health.lastSignalAt, formatRel, now);
+
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'error'>('idle');
+  const onCopyInstall = async () => {
+    try {
+      await window.clipboardAPI.writeText(INSTALL_COMMAND);
+      setCopyState('copied');
+      setTimeout(() => setCopyState('idle'), 2000);
+    } catch {
+      setCopyState('error');
+      setTimeout(() => setCopyState('idle'), 2500);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Card>
+        <CardHeader title={t('claudeIntegration.signalHealth.title')} />
+        {cardState.kind === 'unknown' && (
+          <UnknownBody t={t} onCopy={onCopyInstall} copyState={copyState} />
+        )}
+        {cardState.kind === 'detected' && (
+          <DetectedBody t={t} health={health} relTime={cardState.relTime} />
+        )}
+        {cardState.kind === 'stale' && (
+          <StaleBody t={t} relTime={cardState.relTime} onCopy={onCopyInstall} copyState={copyState} />
+        )}
+      </Card>
+      <UsageCard t={t} />
+    </div>
+  );
+}
+
+// ─── Phase 2 — Anthropic 5h/7d usage meter card ─────────────────────────────
+
+const REFRESH_COOLDOWN_MS = 5 * 60 * 1000; // 5 min, matches token-check
+
+function UsageCard({
+  t,
+}: {
+  t: (key: string, vars?: Record<string, string | number>) => string;
+}) {
+  const enabled = useStore((s) => s.anthropicUsageEnabled);
+  const setEnabled = useStore((s) => s.setAnthropicUsageEnabled);
+  const usage = useStore((s) => s.anthropicUsage);
+  const [lastRefreshAtMs, setLastRefreshAtMs] = useState<number>(0);
+  const now = useNowEverySec();
+  const cooldownRemainingMs = Math.max(0, lastRefreshAtMs + REFRESH_COOLDOWN_MS - now);
+  const inCooldown = cooldownRemainingMs > 0;
+
+  const onRefresh = () => {
+    if (inCooldown) return;
+    window.electronAPI.usage.refresh();
+    setLastRefreshAtMs(Date.now());
+  };
+
+  return (
+    <Card>
+      <CardHeader title={t('claudeIntegration.usage.title')} />
+      <p className="text-xs text-[color:var(--text-muted)] leading-relaxed">
+        {t('claudeIntegration.usage.description')}
+      </p>
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-[color:var(--text-main)]">
+          {t('claudeIntegration.usage.enableLabel')}
+        </span>
+        <ToggleSwitch
+          checked={enabled}
+          onChange={setEnabled}
+          ariaLabel={t('claudeIntegration.usage.enableLabel')}
+        />
+      </div>
+      {enabled && <UsageStatusLine t={t} usage={usage} now={now} />}
+      {enabled && (
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={inCooldown}
+          className="self-start text-[11px] font-mono px-2.5 py-1.5 rounded-md transition-colors disabled:opacity-50"
+          style={{
+            backgroundColor: 'var(--bg-surface)',
+            color: 'var(--text-main)',
+            border: '1px solid var(--bg-overlay)',
+          }}
+        >
+          {inCooldown
+            ? t('claudeIntegration.usage.refreshCooldown', {
+                seconds: Math.ceil(cooldownRemainingMs / 1000),
+              })
+            : t('claudeIntegration.usage.refreshButton')}
+        </button>
+      )}
+    </Card>
+  );
+}
+
+function useNowEverySec(): number {
+  const [now, setNow] = useState<number>(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return now;
+}
+
+function UsageStatusLine({
+  t,
+  usage,
+  now,
+}: {
+  t: (key: string, vars?: Record<string, string | number>) => string;
+  usage: ReturnType<typeof useStore.getState>['anthropicUsage'];
+  now: number;
+}) {
+  if (usage.status === 'idle') return null;
+  if (usage.status === 'ok' && usage.snapshot) {
+    return (
+      <div className="flex flex-col gap-1 text-xs font-mono">
+        <span className="text-[color:var(--text-main)]">
+          5h {usage.snapshot.sessionPct}% {'·'} 7d {usage.snapshot.weeklyPct}%
+        </span>
+        {usage.subscriptionType && (
+          <span className="text-[color:var(--text-muted)]">
+            {t('claudeIntegration.usage.subscription', { tier: usage.subscriptionType })}
+          </span>
+        )}
+        <span className="text-[color:var(--text-muted)]">
+          {t('claudeIntegration.usage.lastFetched', {
+            ago: formatAgo(usage.snapshot.fetchedAtMs, now, t),
+          })}
+        </span>
+      </div>
+    );
+  }
+  // Error states — surface the human-readable code + optional detail.
+  return (
+    <div className="flex flex-col gap-1 text-xs">
+      <span className="text-[var(--accent-red)] font-mono">
+        {t(`claudeIntegration.usage.status.${usage.status}` as never)}
+      </span>
+      {usage.lastError && (
+        <span className="text-[color:var(--text-muted)] font-mono">{usage.lastError}</span>
+      )}
+    </div>
+  );
+}
+
+function formatAgo(
+  thenMs: number,
+  nowMs: number,
+  t: (key: string, vars?: Record<string, string | number>) => string,
+): string {
+  const ageMin = Math.floor(Math.max(0, nowMs - thenMs) / 60_000);
+  if (ageMin <= 0) return t('claudeIntegration.usage.justNow');
+  if (ageMin < 60) return t('claudeIntegration.usage.minutesAgo', { n: ageMin });
+  const ageHr = Math.floor(ageMin / 60);
+  if (ageHr < 24) return t('claudeIntegration.usage.hoursAgo', { n: ageHr });
+  return t('claudeIntegration.usage.daysAgo', { n: Math.floor(ageHr / 24) });
+}
+
+function ToggleSwitch({
+  checked,
+  onChange,
+  ariaLabel,
+}: {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  ariaLabel: string;
+}) {
+  return (
+    <button
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      onClick={() => onChange(!checked)}
+      className="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none shrink-0"
+      style={{ backgroundColor: checked ? 'var(--accent-blue)' : 'var(--bg-overlay)' }}
+    >
+      <span
+        className="inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform"
+        style={{ transform: checked ? 'translateX(18px)' : 'translateX(2px)' }}
+      />
+    </button>
+  );
+}
+
+// ─── Subcomponents ──────────────────────────────────────────────────────────
+
+function Card({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="rounded-lg p-4 flex flex-col gap-3"
+      style={{ backgroundColor: 'var(--bg-mantle)', border: '1px solid var(--bg-surface)' }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function CardHeader({ title }: { title: string }) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="text-sm font-semibold text-[color:var(--text-main)] font-mono">{title}</span>
+    </div>
+  );
+}
+
+function UnknownBody({
+  t,
+  onCopy,
+  copyState,
+}: {
+  t: (key: string, vars?: Record<string, string | number>) => string;
+  onCopy: () => void;
+  copyState: 'idle' | 'copied' | 'error';
+}) {
+  return (
+    <>
+      <p className="text-xs text-[color:var(--text-muted)] leading-relaxed">
+        {t('claudeIntegration.signalHealth.unknownBody')}
+      </p>
+      <CopyInstallButton t={t} onCopy={onCopy} state={copyState} />
+    </>
+  );
+}
+
+function DetectedBody({
+  t,
+  health,
+  relTime,
+}: {
+  t: (key: string, vars?: Record<string, string | number>) => string;
+  health: ReturnType<typeof useStore.getState>['hookSignalHealth'];
+  relTime: string;
+}) {
+  const p50 = health.p50 ?? 0;
+  const p95 = health.p95 ?? 0;
+  const matched = health.workspaceMatchRate.matched;
+  const missed = health.workspaceMatchRate.missed;
+  const totalAttempts = matched + missed;
+  return (
+    <div className="flex flex-col gap-1.5 text-xs">
+      <p className="text-[color:var(--text-main)]">
+        {t('claudeIntegration.signalHealth.detectedLastReceived', { rel: relTime })}
+      </p>
+      <p className="text-[color:var(--text-muted)] font-mono">
+        {t('claudeIntegration.signalHealth.detectedLatencyFormat', {
+          p50: Math.round(p50),
+          p95: Math.round(p95),
+          count: health.count,
+        })}
+      </p>
+      <p className="text-[color:var(--text-muted)] font-mono">
+        {t('claudeIntegration.signalHealth.workspaceMatchFormat', {
+          matched,
+          total: totalAttempts,
+        })}
+      </p>
+    </div>
+  );
+}
+
+function StaleBody({
+  t,
+  relTime,
+  onCopy,
+  copyState,
+}: {
+  t: (key: string, vars?: Record<string, string | number>) => string;
+  relTime: string;
+  onCopy: () => void;
+  copyState: 'idle' | 'copied' | 'error';
+}) {
+  return (
+    <>
+      <p className="text-xs text-[color:var(--text-muted)] leading-relaxed">
+        {t('claudeIntegration.signalHealth.staleBody', { rel: relTime })}
+      </p>
+      <CopyInstallButton t={t} onCopy={onCopy} state={copyState} />
+    </>
+  );
+}
+
+function CopyInstallButton({
+  t,
+  onCopy,
+  state,
+}: {
+  t: (key: string, vars?: Record<string, string | number>) => string;
+  onCopy: () => void;
+  state: 'idle' | 'copied' | 'error';
+}) {
+  const label =
+    state === 'copied'
+      ? t('claudeIntegration.signalHealth.copySuccess')
+      : state === 'error'
+        ? t('claudeIntegration.signalHealth.copyError')
+        : t('claudeIntegration.signalHealth.copyInstallCommand');
+  return (
+    <button
+      type="button"
+      onClick={onCopy}
+      className="self-start text-[11px] font-mono px-2.5 py-1.5 rounded-md transition-colors"
+      style={{
+        backgroundColor: 'var(--bg-surface)',
+        color: 'var(--text-main)',
+        border: '1px solid var(--bg-overlay)',
+      }}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -16,10 +16,11 @@ import {
 import type { CustomThemeColors, XtermThemeColors } from '../../../shared/types';
 import type { FirstRunCheckResult } from '../../../shared/firstRun';
 import { FIRST_RUN_REOPEN_EVENT } from '../../../shared/firstRun';
+import { ClaudeIntegrationSection } from './ClaudeIntegrationSection';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-type TabId = 'general' | 'appearance' | 'notifications' | 'shortcuts' | 'first-run-setup' | 'about';
+type TabId = 'general' | 'appearance' | 'notifications' | 'shortcuts' | 'claude-integration' | 'first-run-setup' | 'about';
 type ShellInfo = { name: string; path: string; args?: string[] };
 
 // ─── Icon components ──────────────────────────────────────────────────────────
@@ -2230,12 +2231,13 @@ export default function SettingsPanel() {
   const panelRef = useRef<HTMLDivElement>(null);
 
   const tabs: { id: TabId; label: string; icon: string }[] = [
-    { id: 'general',         label: t('settings.tabGeneral'),       icon: '⚙' },
-    { id: 'appearance',      label: t('settings.tabAppearance'),    icon: '◑' },
-    { id: 'notifications',   label: t('settings.tabNotifications'), icon: '◎' },
-    { id: 'shortcuts',       label: t('settings.tabShortcuts'),     icon: '⌨' },
-    { id: 'first-run-setup', label: t('settings.firstRunSetup'),    icon: '◇' },
-    { id: 'about',           label: t('settings.tabAbout'),         icon: 'ℹ' },
+    { id: 'general',            label: t('settings.tabGeneral'),         icon: '⚙' },
+    { id: 'appearance',         label: t('settings.tabAppearance'),      icon: '◑' },
+    { id: 'notifications',      label: t('settings.tabNotifications'),   icon: '◎' },
+    { id: 'shortcuts',          label: t('settings.tabShortcuts'),       icon: '⌨' },
+    { id: 'claude-integration', label: t('claudeIntegration.tab'),       icon: '◈' },
+    { id: 'first-run-setup',    label: t('settings.firstRunSetup'),      icon: '◇' },
+    { id: 'about',              label: t('settings.tabAbout'),           icon: 'ℹ' },
   ];
 
   // Close on Escape
@@ -2325,12 +2327,13 @@ export default function SettingsPanel() {
 
           {/* Right content */}
           <div className="flex-1 overflow-y-auto px-5 py-4">
-            {activeTab === 'general'         && <TabGeneral />}
-            {activeTab === 'appearance'      && <TabAppearance />}
-            {activeTab === 'notifications'   && <TabNotifications />}
-            {activeTab === 'shortcuts'       && <TabShortcuts />}
-            {activeTab === 'first-run-setup' && <TabFirstRunSetup />}
-            {activeTab === 'about'           && <TabAbout />}
+            {activeTab === 'general'            && <TabGeneral />}
+            {activeTab === 'appearance'         && <TabAppearance />}
+            {activeTab === 'notifications'      && <TabNotifications />}
+            {activeTab === 'shortcuts'          && <TabShortcuts />}
+            {activeTab === 'claude-integration' && <ClaudeIntegrationSection />}
+            {activeTab === 'first-run-setup'    && <TabFirstRunSetup />}
+            {activeTab === 'about'              && <TabAbout />}
           </div>
         </div>
 

--- a/src/renderer/components/Settings/__tests__/ClaudeIntegrationSection.test.tsx
+++ b/src/renderer/components/Settings/__tests__/ClaudeIntegrationSection.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Tests for the ClaudeIntegrationSection card.
+ *
+ * Vitest runs in `node` env without a DOM library (see vitest.config.ts:17),
+ * so we mirror the SettingsPanel.firstRunSection pattern:
+ *   1. Pure helpers (`deriveState`) tested directly.
+ *   2. Constants (`INSTALL_COMMAND`, `STALE_THRESHOLD_MS`) asserted.
+ * The component's wiring (useStore subscription, setInterval refresh,
+ * clipboardAPI write) is exercised via the live renderer at dogfood time;
+ * the data-flow logic is what we lock down here.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  deriveState,
+  INSTALL_COMMAND,
+  STALE_THRESHOLD_MS,
+} from '../ClaudeIntegrationSection';
+
+const NOW = 1_700_000_000_000;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+const stubFormatter = (ts: number | null): string | null =>
+  ts === null ? null : `at ${ts}`;
+
+describe('deriveState — tri-state derivation', () => {
+  it('returns "unknown" when count === 0 (initial state)', () => {
+    const state = deriveState(0, null, stubFormatter, NOW);
+    expect(state).toEqual({ kind: 'unknown' });
+  });
+
+  it('returns "unknown" when count > 0 but lastSignalAt is null (defensive)', () => {
+    // The runtime path produces a non-null lastSignalAt as soon as count >= 1,
+    // but if the field ever desyncs, the card must not crash on rel-formatting.
+    const state = deriveState(5, null, stubFormatter, NOW);
+    expect(state).toEqual({ kind: 'unknown' });
+  });
+
+  it('returns "detected" when lastSignalAt is within STALE_THRESHOLD_MS', () => {
+    const lastSignalAt = NOW - 30 * 60 * 1000; // 30 minutes ago
+    const state = deriveState(10, lastSignalAt, stubFormatter, NOW);
+    expect(state.kind).toBe('detected');
+    if (state.kind === 'detected') {
+      expect(state.relTime).toBe(`at ${lastSignalAt}`);
+    }
+  });
+
+  it('returns "stale" when lastSignalAt is older than STALE_THRESHOLD_MS', () => {
+    const lastSignalAt = NOW - STALE_THRESHOLD_MS - ONE_HOUR_MS; // 25 hours ago
+    const state = deriveState(10, lastSignalAt, stubFormatter, NOW);
+    expect(state.kind).toBe('stale');
+    if (state.kind === 'stale') {
+      expect(state.relTime).toBe(`at ${lastSignalAt}`);
+    }
+  });
+
+  it('boundary: exactly STALE_THRESHOLD_MS old is still "detected"', () => {
+    const lastSignalAt = NOW - STALE_THRESHOLD_MS;
+    const state = deriveState(10, lastSignalAt, stubFormatter, NOW);
+    expect(state.kind).toBe('detected');
+  });
+
+  it('boundary: STALE_THRESHOLD_MS + 1ms old flips to "stale"', () => {
+    const lastSignalAt = NOW - STALE_THRESHOLD_MS - 1;
+    const state = deriveState(10, lastSignalAt, stubFormatter, NOW);
+    expect(state.kind).toBe('stale');
+  });
+
+  it('uses the relFormatter result; empty-string fallback when formatter returns null', () => {
+    const nullFormatter = vi.fn(() => null);
+    const state = deriveState(1, NOW - 1000, nullFormatter, NOW);
+    expect(state.kind).toBe('detected');
+    if (state.kind === 'detected') {
+      expect(state.relTime).toBe('');
+    }
+    expect(nullFormatter).toHaveBeenCalledWith(NOW - 1000);
+  });
+});
+
+describe('INSTALL_COMMAND payload', () => {
+  it('is a two-line slash-command pair for clipboard copy', () => {
+    const lines = INSTALL_COMMAND.split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatch(/^\/plugin marketplace add /);
+    expect(lines[1]).toMatch(/^\/plugin install /);
+  });
+
+  it('references the openwong2kim/wmux marketplace and the wmux-claude-integration plugin', () => {
+    expect(INSTALL_COMMAND).toContain('openwong2kim/wmux');
+    expect(INSTALL_COMMAND).toContain('wmux-claude-integration');
+  });
+
+  it('plugin install command pins the marketplace via @-suffix', () => {
+    // Prevents the install from picking a same-named plugin from a
+    // different marketplace if the user has more than one configured.
+    expect(INSTALL_COMMAND).toContain('@wmux');
+  });
+});
+
+describe('STALE_THRESHOLD_MS', () => {
+  it('is 24 hours expressed in milliseconds', () => {
+    expect(STALE_THRESHOLD_MS).toBe(24 * 60 * 60 * 1000);
+  });
+});

--- a/src/renderer/components/StatusBar/StatusBar.tsx
+++ b/src/renderer/components/StatusBar/StatusBar.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { useStore } from '../../stores';
 import { useT } from '../../hooks/useT';
 import type { Notification, Pane, PaneLeaf, Workspace } from '../../../shared/types';
+import { UsageWidgetView } from './UsageWidget';
 
 /** Resolve the ptyId of the active pane's active surface */
 function getActivePtyId(rootPane: Pane | undefined, activePaneId: string): string | null {
@@ -163,6 +164,12 @@ export default function StatusBar() {
   );
   const activeTokenData = activePtyId ? tokenDataByPty[activePtyId] : undefined;
 
+  // Anthropic 5h/7d usage state. Hidden entirely when status === 'idle'
+  // (Settings toggle off). `nowMs` is the existing per-second clock used
+  // for time display — countdown math reuses the same cursor.
+  const usage = useStore((s) => s.anthropicUsage);
+  const nowMs = time.getTime();
+
   return (
     <div className="flex items-center justify-between h-6 px-3 border-b border-[var(--bg-surface)] text-[10px] text-[var(--text-muted)] shrink-0 select-none font-mono" style={{ backgroundColor: 'var(--bg-mantle)' }} data-onboarding-target="status-bar">
       {/* Left: workspace + branch */}
@@ -212,6 +219,13 @@ export default function StatusBar() {
             )}
           </span>
         )}
+        <UsageWidgetView
+          status={usage.status}
+          snapshot={usage.snapshot}
+          lastError={usage.lastError}
+          subscriptionType={usage.subscriptionType}
+          nowMs={nowMs}
+        />
         <NotificationBellBadgeView unreadCount={unreadCount} onActivate={toggleNotificationPanel} />
         {memUsage && <span>{memUsage}</span>}
         <span>{timeStr}</span>

--- a/src/renderer/components/StatusBar/UsageWidget.tsx
+++ b/src/renderer/components/StatusBar/UsageWidget.tsx
@@ -1,0 +1,177 @@
+// StatusBar mini widget for Anthropic 5h/7d usage utilization.
+//
+// Rendered to the right of the per-pane token display. Hidden entirely
+// when the Settings toggle is off (status === 'idle'). Color tiers match
+// the threshold conventions established in the Settings card:
+//   < 70%  → neutral (text-muted)
+//   70–89% → warning (accent-yellow)
+//   ≥ 90%  → danger  (accent-red)
+//
+// The component itself is presentational — pure (props in / JSX out).
+// `StatusBar.tsx` reads `uiSlice.anthropicUsage` and passes it down so
+// vitest's `renderToStaticMarkup` can drive snapshots without a real
+// store. Helpers (`tierColorClass`, `formatResetCountdown`) are exported
+// so they can be unit-tested independently.
+
+import type { ReactElement } from 'react';
+import { useT } from '../../hooks/useT';
+
+export type UsageStatus =
+  | 'idle'
+  | 'ok'
+  | 'token-missing'
+  | 'unauthorized'
+  | 'http-error'
+  | 'network-error'
+  | 'read-error';
+
+export interface UsageWidgetProps {
+  status: UsageStatus;
+  snapshot: {
+    sessionPct: number;
+    sessionResetEpochSec: number;
+    weeklyPct: number;
+    weeklyResetEpochSec: number;
+    fetchedAtMs: number;
+  } | null;
+  lastError: string | null;
+  subscriptionType: string | null;
+  /** Provides current clock for relative-time math. Pulled from a parent
+   *  `useState`/`setInterval` cursor so the widget refreshes its
+   *  countdowns without forcing parent rerenders on every clock tick. */
+  nowMs: number;
+}
+
+/** Pure tier mapping. Exported for unit tests. */
+export function tierColorClass(pct: number): string {
+  if (pct >= 90) return 'text-[var(--accent-red)]';
+  if (pct >= 70) return 'text-[var(--accent-yellow)]';
+  return 'text-[var(--text-sub2)]';
+}
+
+/** Format a Unix epoch (seconds) as a coarse "Xh Ym" countdown. Used
+ *  for the tooltip's reset display. Negative or zero → empty string
+ *  (caller decides how to render "unknown"). Exported for unit tests. */
+export function formatResetCountdown(epochSec: number, nowMs: number): string {
+  if (!epochSec || epochSec <= 0) return '';
+  const remainingSec = epochSec - Math.floor(nowMs / 1000);
+  if (remainingSec <= 0) return '';
+  const days = Math.floor(remainingSec / 86_400);
+  const hours = Math.floor((remainingSec % 86_400) / 3_600);
+  const minutes = Math.floor((remainingSec % 3_600) / 60);
+  if (days > 0) {
+    return `${days}d ${hours}h`;
+  }
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+}
+
+/** Format the last-fetched timestamp as a coarse "Xm ago". */
+export function formatFetchedAgo(fetchedAtMs: number, nowMs: number): string {
+  if (!fetchedAtMs) return '';
+  const ageMs = Math.max(0, nowMs - fetchedAtMs);
+  const ageMin = Math.floor(ageMs / 60_000);
+  if (ageMin <= 0) return 'just now';
+  if (ageMin < 60) return `${ageMin}m ago`;
+  const ageHr = Math.floor(ageMin / 60);
+  if (ageHr < 24) return `${ageHr}h ago`;
+  const ageDay = Math.floor(ageHr / 24);
+  return `${ageDay}d ago`;
+}
+
+/**
+ * Presentational StatusBar widget. Renders nothing when status === 'idle'.
+ *
+ * Error states get a colored dot prefix instead of percentages so a
+ * stale widget can't masquerade as a live one — `5h 23% · 7d 8%`
+ * pretending to be fresh during an outage was the failure mode we want
+ * to avoid.
+ */
+export function UsageWidgetView(props: UsageWidgetProps): ReactElement | null {
+  const { status, snapshot, lastError, subscriptionType, nowMs } = props;
+  if (status === 'idle') return null;
+
+  // ─── Error states ──────────────────────────────────────────────────────
+  if (status !== 'ok' || !snapshot) {
+    // TS doesn't narrow through the disjunction (status !== 'ok' could
+    // still type-include 'ok' if snapshot is null). Explicit cast to
+    // the error-only subset since 'idle' was filtered above and 'ok'
+    // never reaches this branch via the runtime check.
+    return (
+      <ErrorChip
+        status={status as Exclude<UsageStatus, 'idle' | 'ok'>}
+        lastError={lastError}
+      />
+    );
+  }
+
+  // ─── OK state — main display ───────────────────────────────────────────
+  const { sessionPct, sessionResetEpochSec, weeklyPct, weeklyResetEpochSec, fetchedAtMs } =
+    snapshot;
+  const sessionColor = tierColorClass(sessionPct);
+  const weeklyColor = tierColorClass(weeklyPct);
+  const tooltip = buildOkTooltip({
+    sessionPct,
+    sessionResetEpochSec,
+    weeklyPct,
+    weeklyResetEpochSec,
+    fetchedAtMs,
+    subscriptionType,
+    nowMs,
+  });
+  return (
+    <span title={tooltip} data-testid="usage-widget-ok">
+      <span className={sessionColor}>5h {sessionPct}%</span>
+      <span className="text-[var(--text-muted)]"> {'·'} </span>
+      <span className={weeklyColor}>7d {weeklyPct}%</span>
+    </span>
+  );
+}
+
+function ErrorChip({
+  status,
+  lastError,
+}: {
+  status: Exclude<UsageStatus, 'idle' | 'ok'>;
+  lastError: string | null;
+}) {
+  const t = useT();
+  // We pull the human-readable label and tooltip body from i18n so the
+  // chip is localizable. The dot color is fixed because semantic meaning
+  // ("something broken, click for detail") is what we want to convey.
+  const labelKey = `claudeIntegration.usage.status.${status}` as const;
+  const tooltipParts = [t(labelKey)];
+  if (lastError) tooltipParts.push(lastError);
+  return (
+    <span
+      title={tooltipParts.join(' — ')}
+      className="text-[var(--accent-red)] font-mono"
+      data-testid={`usage-widget-${status}`}
+    >
+      {'●'} {t(labelKey)}
+    </span>
+  );
+}
+
+function buildOkTooltip(args: {
+  sessionPct: number;
+  sessionResetEpochSec: number;
+  weeklyPct: number;
+  weeklyResetEpochSec: number;
+  fetchedAtMs: number;
+  subscriptionType: string | null;
+  nowMs: number;
+}): string {
+  const session = formatResetCountdown(args.sessionResetEpochSec, args.nowMs);
+  const weekly = formatResetCountdown(args.weeklyResetEpochSec, args.nowMs);
+  const fetched = formatFetchedAgo(args.fetchedAtMs, args.nowMs);
+  const lines = [
+    `5h: ${args.sessionPct}%${session ? ` (reset ${session})` : ''}`,
+    `7d: ${args.weeklyPct}%${weekly ? ` (reset ${weekly})` : ''}`,
+  ];
+  if (args.subscriptionType) lines.push(`Plan: ${args.subscriptionType}`);
+  if (fetched) lines.push(`Fetched: ${fetched}`);
+  return lines.join(' · ');
+}

--- a/src/renderer/components/Terminal/Terminal.tsx
+++ b/src/renderer/components/Terminal/Terminal.tsx
@@ -27,9 +27,16 @@ interface TerminalProps {
   isWorkspaceVisible?: boolean;
   /** If set, scrollback content will be restored from this file on mount */
   scrollbackFile?: string;
+  /** ID of the workspace this terminal belongs to. Used at PTY-create time
+   *  so the spawned shell gets the correct WMUX_WORKSPACE_ID env (Codex
+   *  review 2026-05-24 P1: previously read global activeWorkspaceId which
+   *  is wrong during boot reconcile + multiview). */
+  workspaceId?: string;
+  /** ID of the surface this terminal occupies. Sent as WMUX_SURFACE_ID. */
+  surfaceId?: string;
 }
 
-export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, onPtyCreated, isActive = true, isWorkspaceVisible = true, scrollbackFile }: TerminalProps) {
+export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, onPtyCreated, isActive = true, isWorkspaceVisible = true, scrollbackFile, workspaceId: ownerWorkspaceId, surfaceId: ownerSurfaceId }: TerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [ptyId, setPtyId] = useState<string | null>(externalPtyId || null);
   const creatingRef = useRef(false);
@@ -100,11 +107,19 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
       rows = Math.max(2, Math.floor((container.offsetHeight - padding) / lineHeight));
     }
 
-    const workspaceId = useStore.getState().activeWorkspaceId;
+    // Owner identity, not global active. Codex P1 fix 2026-05-24: the
+    // previous `useStore.getState().activeWorkspaceId` read produced wrong
+    // env on workspace boot reconcile (all PTYs got the workspace that
+    // happened to be active at restore time) and during multiview rendering
+    // (every tile saw the focused tile's workspace). The owner prop is
+    // threaded down from Pane → Terminal so the correct identity reaches
+    // the daemon at PTY-create time.
+    const workspaceId = ownerWorkspaceId ?? useStore.getState().activeWorkspaceId;
+    const surfaceId = ownerSurfaceId;
     const defaultShell = useStore.getState().defaultShell;
-    console.log(`[Terminal] Creating new PTY: shell=${shell}, cwd=${cwd}, cols=${cols}, rows=${rows}, ws=${workspaceId}`);
+    console.log(`[Terminal] Creating new PTY: shell=${shell}, cwd=${cwd}, cols=${cols}, rows=${rows}, ws=${workspaceId}, surface=${surfaceId ?? '-'}`);
     void ipcInvokeRef.current<{ id: string }>(() =>
-      window.electronAPI.pty.create(withDefaultShell({ shell, cwd, cols, rows, workspaceId }, defaultShell))
+      window.electronAPI.pty.create(withDefaultShell({ shell, cwd, cols, rows, workspaceId, surfaceId }, defaultShell))
     ).then((result) => {
       if (!result.ok) {
         // Toast surfaced by useIpc (e.g. DAEMON_DISCONNECTED). Nothing to do.

--- a/src/renderer/hooks/useNotificationListener.ts
+++ b/src/renderer/hooks/useNotificationListener.ts
@@ -366,12 +366,37 @@ export function useNotificationListener() {
       useStore.getState().updateTokenData(ptyId, data);
     });
 
+    // Phase 1.5 — Claude Code hook signal health. Main throttles to 1Hz so
+    // this fires at most once per second. Just slots into the existing
+    // uiSlice field; no derived state required.
+    const unsubSignalHealth = window.electronAPI.signalHealth.onUpdate((stats) => {
+      useStore.getState().setHookSignalHealth(stats);
+    });
+
+    // Phase 2 — Anthropic 5h/7d usage meter. Main pushes a PollerState
+    // snapshot on initial fetch, hourly tick, manual refresh, and on
+    // error transitions. Renderer treats the payload as opaque.
+    const unsubUsage = window.electronAPI.usage.onUpdate((state) => {
+      useStore.getState().setAnthropicUsage(state);
+    });
+    // Hydrate main from persisted opt-in. Main boots with the poller
+    // stopped; if the user had it enabled before app restart, the
+    // SessionData restore in workspaceSlice.loadSession sets
+    // `anthropicUsageEnabled` back to true, and we mirror that to
+    // main here so the poller starts again. Calling setEnabled on a
+    // poller already in the requested state is a no-op (idempotent).
+    if (useStore.getState().anthropicUsageEnabled) {
+      window.electronAPI.usage.setEnabled(true);
+    }
+
     return () => {
       unsubNotif();
       unsubCwd();
       unsubMeta();
       unsubGitBranch();
       unsubToken();
+      unsubSignalHealth();
+      unsubUsage();
       // Reset throttlers so a hot-reloaded listener doesn't inherit stale
       // last-fire timestamps that would suppress the first notification.
       flashFrameThrottler.cancel();

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -357,6 +357,41 @@ export const en = {
   'settings.firstRunSetup.statusNotRegistered': 'not registered',
   'settings.firstRunSetup.openWizard': 'Open setup wizard',
   'settings.firstRunSetup.showCheatSheet': 'Show keyboard cheat sheet',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
+  'claudeIntegration.tab': 'Claude integration',
+  'claudeIntegration.signalHealth.title': 'Plugin signal health',
+  'claudeIntegration.signalHealth.unknownBody':
+    'Plugin status: not yet observed. Install with the command below in Claude Code. wmux confirms detection once the first hook fires.',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'Last signal {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'Latency P50 {p50}ms · P95 {p95}ms · {count} samples',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'Workspace match: {matched}/{total} hooks resolved to a wmux pane',
+  'claudeIntegration.signalHealth.staleBody':
+    'Plugin status: stale. Last hook arrived {rel} — the plugin may have stopped firing or Claude Code is idle.',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'Copy install command',
+  'claudeIntegration.signalHealth.copySuccess': 'Copied — paste into Claude Code',
+  'claudeIntegration.signalHealth.copyError': 'Copy failed — clipboard locked',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Anthropic usage meter (5h / 7d)',
+  'claudeIntegration.usage.description':
+    "Reads your Claude Code OAuth token from local storage and probes Anthropic with a 1-token Haiku request to read the rate-limit headers. The probe is billed to your own quota (≈ negligible). Token is never written back, never logged, only sent to api.anthropic.com.",
+  'claudeIntegration.usage.enableLabel': 'Show 5h / 7d utilization in status bar',
+  'claudeIntegration.usage.refreshButton': 'Refresh now',
+  'claudeIntegration.usage.refreshCooldown': 'Refresh available in {seconds}s',
+  'claudeIntegration.usage.subscription': 'Plan: {tier}',
+  'claudeIntegration.usage.lastFetched': 'Last fetched: {ago}',
+  'claudeIntegration.usage.justNow': 'just now',
+  'claudeIntegration.usage.minutesAgo': '{n}m ago',
+  'claudeIntegration.usage.hoursAgo': '{n}h ago',
+  'claudeIntegration.usage.daysAgo': '{n}d ago',
+  'claudeIntegration.usage.status.token-missing': 'Claude Code not logged in',
+  'claudeIntegration.usage.status.unauthorized': 'Token expired — log in to Claude Code again',
+  'claudeIntegration.usage.status.http-error': 'Anthropic API error',
+  'claudeIntegration.usage.status.network-error': 'Network error',
+  'claudeIntegration.usage.status.read-error': 'Credential read error',
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -342,4 +342,39 @@ export const ko = {
   'settings.firstRunSetup.statusNotRegistered': '미등록',
   'settings.firstRunSetup.openWizard': '설정 마법사 열기',
   'settings.firstRunSetup.showCheatSheet': '키보드 치트시트 보기',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
+  'claudeIntegration.tab': 'Claude 연동',
+  'claudeIntegration.signalHealth.title': '플러그인 신호 상태',
+  'claudeIntegration.signalHealth.unknownBody':
+    '플러그인 상태: 아직 신호가 관측되지 않았습니다. Claude Code에서 아래 명령을 실행해 설치하세요. 첫 hook이 발생하면 wmux가 자동으로 감지합니다.',
+  'claudeIntegration.signalHealth.detectedLastReceived': '마지막 신호 {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    '지연 P50 {p50}ms · P95 {p95}ms · 샘플 {count}건',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    '워크스페이스 매칭: {matched}/{total} hook이 wmux pane으로 해결됨',
+  'claudeIntegration.signalHealth.staleBody':
+    '플러그인 상태: 오래됨. 마지막 hook이 {rel}에 도착했습니다 — 플러그인이 멈췄거나 Claude Code가 휴면 상태일 수 있습니다.',
+  'claudeIntegration.signalHealth.copyInstallCommand': '설치 명령 복사',
+  'claudeIntegration.signalHealth.copySuccess': '복사됨 — Claude Code에 붙여넣기',
+  'claudeIntegration.signalHealth.copyError': '복사 실패 — 클립보드 잠김',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Anthropic 사용량 표기 (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'Claude Code의 OAuth 토큰을 로컬에서 읽어 Anthropic에 1토큰 Haiku 더미 요청을 보내고 rate-limit 헤더를 파싱합니다. 본인 quota에서 차감됩니다 (사실상 무료 수준). 토큰은 디스크에 다시 쓰지 않고, 로그에 남기지 않으며, api.anthropic.com으로만 전송됩니다.',
+  'claudeIntegration.usage.enableLabel': '상태 표시줄에 5h / 7d 사용률 표기',
+  'claudeIntegration.usage.refreshButton': '지금 새로고침',
+  'claudeIntegration.usage.refreshCooldown': '{seconds}초 후 새로고침 가능',
+  'claudeIntegration.usage.subscription': '플랜: {tier}',
+  'claudeIntegration.usage.lastFetched': '마지막 조회: {ago}',
+  'claudeIntegration.usage.justNow': '방금 전',
+  'claudeIntegration.usage.minutesAgo': '{n}분 전',
+  'claudeIntegration.usage.hoursAgo': '{n}시간 전',
+  'claudeIntegration.usage.daysAgo': '{n}일 전',
+  'claudeIntegration.usage.status.token-missing': 'Claude Code 로그인 안 됨',
+  'claudeIntegration.usage.status.unauthorized': '토큰 만료 — Claude Code에 다시 로그인 필요',
+  'claudeIntegration.usage.status.http-error': 'Anthropic API 에러',
+  'claudeIntegration.usage.status.network-error': '네트워크 에러',
+  'claudeIntegration.usage.status.read-error': '자격 증명 읽기 실패',
 } as const;

--- a/src/renderer/stores/slices/uiSlice.ts
+++ b/src/renderer/stores/slices/uiSlice.ts
@@ -134,21 +134,29 @@ export interface UISlice {
   notificationSoundChoice: 'default' | 'none';
   setNotificationSoundChoice: (choice: 'default' | 'none') => void;
 
-  // ─── Claude Code hook integration (Phase 1) ──────────────────────────────
+  // ─── Claude Code hook integration (Phase 1.5) ────────────────────────────
   // Driven by main process: whenever a hook signal arrives via the
   // wmux-claude-integration plugin, main pushes the updated signal-health
-  // snapshot to the renderer. Renderer-local state lets us display the
-  // health card in Settings without a hot RPC round-trip per render.
+  // snapshot to the renderer (throttled to 1Hz in registerHooksRpc).
+  // Renderer-local state lets us display the health card in Settings
+  // without a hot RPC round-trip per render.
   //
-  // signalHealth.lastSignalAt === null means "no hook ever observed in
-  // this process lifetime" — distinct from a stale plugin (lastSignalAt
-  // older than threshold). The Settings card handles both branches.
+  // Tri-state derivation in Settings → ClaudeIntegrationSection:
+  //   - count === 0 → "Unknown / not yet observed" (plugin not installed,
+  //     or installed but no hook fired yet)
+  //   - count > 0 && !isStale(24h) → "Detected" (live stats)
+  //   - count > 0 && isStale(24h) → "Stale"
+  // workspaceMatchRate is a separate dimension: even when the plugin is
+  // working, hook fires from outside any wmux workspace bump `missed`
+  // without affecting the tri-state.
   hookSignalHealth: {
     total: number;
     count: number;
     p50: number | null;
     p95: number | null;
     lastSignalAt: number | null;
+    perAgent: Record<string, number>;
+    workspaceMatchRate: { matched: number; missed: number };
   };
   setHookSignalHealth: (health: {
     total: number;
@@ -156,6 +164,8 @@ export interface UISlice {
     p50: number | null;
     p95: number | null;
     lastSignalAt: number | null;
+    perAgent: Record<string, number>;
+    workspaceMatchRate: { matched: number; missed: number };
   }) => void;
 
   /** User has dismissed the first-run "install wmux-claude-integration"
@@ -163,6 +173,53 @@ export interface UISlice {
    *  fields pattern (see toastEnabled). */
   hookOnboardingDismissed: boolean;
   setHookOnboardingDismissed: (dismissed: boolean) => void;
+
+  // ─── Phase 2 — Anthropic usage meter ────────────────────────────────────
+  // Opt-in. When `anthropicUsageEnabled` flips to true, the renderer sends
+  // IPC.USAGE_TOGGLE and main starts the UsagePoller. The poller pushes
+  // PollerState snapshots via IPC.USAGE_UPDATE and they land here in
+  // `anthropicUsage`. The access token itself is NEVER part of this state —
+  // it stays in main process memory during a fetch and is discarded.
+  anthropicUsageEnabled: boolean;
+  setAnthropicUsageEnabled: (enabled: boolean) => void;
+  anthropicUsage: {
+    status:
+      | 'idle'
+      | 'ok'
+      | 'token-missing'
+      | 'unauthorized'
+      | 'http-error'
+      | 'network-error'
+      | 'read-error';
+    snapshot: {
+      sessionPct: number;
+      sessionResetEpochSec: number;
+      weeklyPct: number;
+      weeklyResetEpochSec: number;
+      fetchedAtMs: number;
+    } | null;
+    lastError: string | null;
+    subscriptionType: string | null;
+  };
+  setAnthropicUsage: (state: {
+    status:
+      | 'idle'
+      | 'ok'
+      | 'token-missing'
+      | 'unauthorized'
+      | 'http-error'
+      | 'network-error'
+      | 'read-error';
+    snapshot: {
+      sessionPct: number;
+      sessionResetEpochSec: number;
+      weeklyPct: number;
+      weeklyResetEpochSec: number;
+      fetchedAtMs: number;
+    } | null;
+    lastError: string | null;
+    subscriptionType: string | null;
+  }) => void;
 
   // ─── Multiview ─────────────────────────────────────────────────────────
   multiviewIds: string[];
@@ -515,13 +572,15 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
     state.notificationSoundChoice = choice;
   }),
 
-  // ─── Claude Code hook integration (Phase 1) ──────────────────────────────
+  // ─── Claude Code hook integration (Phase 1.5) ────────────────────────────
   hookSignalHealth: {
     total: 0,
     count: 0,
     p50: null,
     p95: null,
     lastSignalAt: null,
+    perAgent: {},
+    workspaceMatchRate: { matched: 0, missed: 0 },
   },
 
   setHookSignalHealth: (health) => set((state) => {
@@ -532,6 +591,26 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
 
   setHookOnboardingDismissed: (dismissed) => set((state) => {
     state.hookOnboardingDismissed = dismissed;
+  }),
+
+  // ─── Phase 2 — Anthropic usage meter ────────────────────────────────────
+  anthropicUsageEnabled: false,
+  setAnthropicUsageEnabled: (enabled) => {
+    // Sync to main so the poller starts/stops. The IPC send is fire-and-
+    // forget; main acknowledges via the next USAGE_UPDATE push.
+    window.electronAPI.usage.setEnabled(enabled);
+    set((state) => {
+      state.anthropicUsageEnabled = enabled;
+    });
+  },
+  anthropicUsage: {
+    status: 'idle',
+    snapshot: null,
+    lastError: null,
+    subscriptionType: null,
+  },
+  setAnthropicUsage: (next) => set((state) => {
+    state.anthropicUsage = next;
   }),
 
   // ─── Multiview ─────────────────────────────────────────────────────────

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -59,6 +59,25 @@ export const IPC = {
   SCROLLBACK_LOAD: 'scrollback:load',
   // Token tracking
   TOKEN_UPDATE: 'token:update',
+  // Claude Code hook signal health (Phase 1.5). Push channel — main process
+  // emits whenever SignalLatencyMeter stats change (throttled to 1Hz in
+  // registerHooksRpc). Payload: LatencyStats snapshot. Renderer subscribes
+  // via preload `signalHealth.onUpdate` and feeds uiSlice.setHookSignalHealth.
+  SIGNAL_HEALTH_UPDATE: 'signal-health:update',
+  // Anthropic 5h/7d usage meter (Phase 2). Push channel — UsagePoller in
+  // main process emits whenever its state changes (initial fetch, hourly
+  // tick, manual refresh, 401, network error). Payload: PollerState.
+  // Renderer subscribes via preload `usage.onUpdate` and feeds
+  // uiSlice.setAnthropicUsage.
+  USAGE_UPDATE: 'usage:update',
+  // Renderer → main: opt-in / opt-out toggle for the Anthropic usage
+  // meter (Settings → Claude 연동 → Anthropic 사용량 표기 토글). Main
+  // starts/stops the UsagePoller on receipt.
+  USAGE_TOGGLE: 'usage:toggle',
+  // Renderer → main: manual refresh (StatusBar mini widget / Settings
+  // "지금 새로고침" button). Triggers an immediate poll regardless of
+  // interval timing. Caller enforces a UI-side cooldown (5 min).
+  USAGE_REFRESH: 'usage:refresh',
   // EventBus publish — renderer→main one-way for pane lifecycle events
   EVENTS_PUBLISH: 'events:publish',
   // Window control


### PR DESCRIPTION
## Summary

Three layered changes on the wmux × Claude Code integration plugin, shipping together after CEO + Eng + Codex review (twice) and a user dogfood session that surfaced a workspace-routing bug.

- **Phase 1.5 — signal-health substrate**: Settings → Claude 연동 카드 (Unknown / Detected / Stale), workspace-match counters, 1Hz IPC push from main to renderer. Phase 1 backbone now has visible plugin status.
- **Phase 2 — Anthropic 5h/7d usage meter**: StatusBar mini widget (`5h X% · 7d Y%`) + Settings opt-in toggle. Reads OAuth credential from local Keychain / `.credentials.json`, sends a 1-token Haiku probe, parses the four `anthropic-ratelimit-unified-*` headers. Token never written back, never logged.
- **Env-first hook routing fix** (Codex P1#7 promoted): user dogfood found that workspace 4 turn-end was producing toasts in workspace 2 because both workspaces shared `C:\Users\rizz` cwd. AgentSignal envelope gained `workspaceId` + `surfaceId`; PTYManager + daemon now inject `WMUX_WORKSPACE_ID` / `WMUX_SURFACE_ID` env vars; bridge captures them; `hooks.rpc.ts:resolvePtyIdForSignal` matches env-first with cwd fallback. Pane/Terminal use owning workspace prop instead of global `activeWorkspaceId` state (Codex 2026-05-25 P1 fix — global state was wrong during boot reconcile + multiview).

Commit: `66d5f1d`. Branch: `feat/agent-hook-plugin-phase-1` (includes earlier Phase 1 backbone commits a6c9049 → 3666f2c).

## Review history

| Round | Trigger | Status |
|-------|---------|--------|
| CEO 2026-05-23 | `/plan-ceo-review` SELECTIVE EXPANSION | Codex re-scope drove the plan to substrate-only |
| Codex 2026-05-23 | post-CEO outside voice | 9 findings (P0×1 + P1×6 + P2×1 + P3×1) — all resolved or layer-dropped |
| Eng 2026-05-23 | `/plan-eng-review` | 5 findings — function names, interface location, gating asymmetry, state machine diagram, stale ASCII |
| Codex 2026-05-25 | post-dogfood | 7 findings — P1 env-source fix applied, P2 timeouts applied, others deferred |

## Verification

### Static + automated
- `npx tsc --noEmit` — 0 errors
- `npm test` — 1793 / 1793 passed (vitest)
- `node scripts/verify-bridge-env-capture.mjs` — 4 / 4 end-to-end cases passed (production bridge.mjs spawned with `WMUX_BRIDGE_DEBUG=1`, envelope.workspaceId/surfaceId asserted)
- `npx eslint <changed files>` — 0 regressions from this branch (remaining warnings predate it)
- Dev wmux boot — PipeServer listening, app.on(ready) fired, 0 errors

### Dogfood verification (required before this PR moves out of draft)
Run on `feat/agent-hook-plugin-phase-1` checkout:

1. Restart wmux to pick up the new daemon env injection (existing PTYs were spawned without `WMUX_WORKSPACE_ID` and need to be recreated).
2. Open Settings → Claude 연동 → toggle "Anthropic 사용량 표기" ON.
3. Verify StatusBar shows `5h X% · 7d Y%` within 2 seconds; tooltip shows plan tier + reset countdown.
4. In a fresh PTY pane: `echo \"WS:$env:WMUX_WORKSPACE_ID|SF:$env:WMUX_SURFACE_ID\"` — both IDs must be non-empty and must match the owning workspace.
5. Open two workspaces with the SAME cwd. Run Claude Code in each. Trigger turn-end in workspace B. Verify the toast / pane ring lands on workspace B (not workspace A — that was the bug).

### Not addressed in this PR (follow-up)
- **`surfaceId`-aware routing**: workspace.list response has no surface→ptyId map, so multi-surface same-workspace routing still falls back to `activePtyId`. Plumbing for `workspaceId` is the deterministic fix the user dogfood needed; surfaces are a smaller refinement.
- **Linux `libsecret`**: cross-platform credential reader falls back to `~/.claude/.credentials.json` only.
- **macOS Keychain non-default account**: assumes Keychain account == `os.userInfo().username`. Matches the openwong2kim/claude-token-check reference impl.
- **User-Agent**: hardcoded `claude-code/2.1.5` to pair with the OAuth beta header (matches token-check). wmux-branded UA is a candidate for a follow-up dogfood.

## Test plan checklist
- [x] Type-safe (tsc 0 errors)
- [x] Unit tests pass (1793 / 1793)
- [x] Bridge env-capture verified end-to-end
- [x] Codex P1 fix applied (Pane/Terminal owner props)
- [x] Codex P2#4 fix applied (UsagePoller timeouts)
- [ ] User dogfood pass (1-5 above) — gating the draft → ready transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)