### PR TITLE
docs(readme): add @wmux/orchestrator SDK pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Launch wmux and the MCP server registers automatically. Claude Code just works:
 
 **Multi-agent:** Every browser tool accepts `surfaceId` — each Claude Code session controls its own browser independently. A2A (agent-to-agent) tools route messages between sibling agents in the same wmux instance.
 
+**Programmatic orchestration:** If you want to drive multiple wmux panes from your own script (TypeScript / Node), the MCP surface is wrapped by [`@wmux/orchestrator`](https://github.com/openwong2kim/wmux-orchestrator) — a small client-side SDK that gives you `sendAndWait`, `sendCommandAndWait` (OSC 133 exit codes), atomic pane claim, fan-out, and `agent.lifecycle` event subscription. Composes the primitives above, ships independently from wmux.
+
 ### 5. Session persistence — survives restart and reboot
 
 Terminal sessions survive app restarts. Close wmux and reopen — your sessions are still there, scrollback intact.


### PR DESCRIPTION
## Summary

Adds one paragraph in the MCP integration section of the README pointing readers to [`@wmux/orchestrator`](https://github.com/openwong2kim/wmux-orchestrator) — the client-side SDK that wraps wmux''s MCP surface for programmatic multi-pane orchestration.

## Why now

`@wmux/orchestrator` v0.1.0 + v0.1.1 shipped as GitHub Releases on the orchestrator repo. The SDK consumes only already-shipped wmux primitives (`agent.lifecycle` EventBus from PR #63, atomic `pane_set_metadata`, `terminal_read_events` for OSC 133, `terminal_send`, `wmux_events_poll`). No wmux changes are required for v0.1.x.

This README pointer lets people who land on the wmux page discover the SDK if they need programmatic orchestration. Substrate-neutrality preserved — the SDK is mentioned as an independent client of the MCP surface, not bundled.

## Test plan

- [x] Local preview of README diff — renders correctly
- [x] Link to https://github.com/openwong2kim/wmux-orchestrator resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)