### PR TITLE
docs(mcp-spec): clarify metadata path / event topic namespaces before enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ Thumbs.db
 .context/
 .gstack/
 .team/
+.local-scratch/
 
 # Private roadmap / strategy docs (not for public repo)
 docs/EDITIONS.md

--- a/docs/api/mcp-plugin-spec.md
+++ b/docs/api/mcp-plugin-spec.md
@@ -129,6 +129,49 @@ The path-glob is intentionally narrow — wmux does not import `minimatch` or an
 
 The reference implementation is `globToRegex` in `src/main/mcp/permissionGrammar.ts`. Plugins SHOULD treat the glob as advisory in the first PR (no enforcement yet) but emit valid grammar so they're ready for the follow-up.
 
+### 3.4 Metadata path namespace
+
+`meta.read` and `meta.write` use dotted JSON paths into `PaneMetadata` (`src/shared/types.ts`) as the path-glob namespace:
+
+| Path | Field | Owner |
+|---|---|---|
+| `label` | shared display label | shared |
+| `role` | shared semantic role | shared |
+| `status` | shared status string | shared |
+| `custom.<key>[.<subkey>...]` | tool-owned subtree (`custom: Record<string, string>`) | declaring plugin |
+
+Default rule:
+
+- `meta.write` (no `:glob`) authorizes writes to **every** metadata path, including shared display fields.
+- `meta.write:custom.myPlugin.*` authorizes writes to `custom.myPlugin.<single-segment>` only. Shared fields (`label`, `role`, `status`) and other plugins' `custom.*` subtrees are rejected at enforcement.
+- A plugin that needs a specific shared field declares it explicitly (e.g. `meta.write:status` for a health monitor, or `meta.write:label` for a labeller). Plugins that want all shared fields request the unscoped `meta.write` and accept the broader approval prompt.
+- `meta.read` follows the same namespace and default rule on the read side.
+
+`updatedAt` is substrate-maintained and not writeable by plugins regardless of declared `meta.write` glob.
+
+### 3.5 Event topic namespace
+
+`events.subscribe` uses dot-separated event topic names as the path-glob namespace. The substrate intentionally uses one capability + topic glob rather than minting a new capability per event type, so the event surface can grow without expanding the whitelist.
+
+| Glob | Matches |
+|---|---|
+| `events.subscribe` | every event topic (broad) |
+| `events.subscribe:pane.*` | `pane.created`, `pane.closed`, `pane.focused`, `pane.metadata.changed` |
+| `events.subscribe:pane.metadata.changed` | only that single topic |
+| `events.subscribe:pane.metadata.**` | metadata events (depth-tolerant) |
+| `events.subscribe:process.*` | `process.started`, `process.exited` |
+| `events.subscribe:agent.lifecycle` | the single `agent.lifecycle` topic (sub-kind rides in payload) |
+
+Current top-level event topics (see `src/shared/events.ts` `WmuxEventType` for the authoritative union): `pane.created`, `pane.closed`, `pane.focused`, `pane.metadata.changed`, `workspace.metadata.changed`, `process.started`, `process.exited`, `agent.lifecycle`. New topics are additive and matched by the same glob namespace; plugins SHOULD declare the broadest glob they're willing to be approved against.
+
+### 3.6 Terminal-content risk class
+
+`terminal.read` and `pane.search` are classified as **terminal-content** capabilities — declaring either grants the plugin visibility into user terminal sessions (`pane.search` returns matched logical lines plus up to two surrounding context lines, 500-char truncated). This risk class is categorically distinct from metadata and event access.
+
+The future approval dialog (next PR) SHOULD surface terminal-content capabilities with stronger user-facing language than metadata or event capabilities, so the asymmetry stays visible to the user at approval time.
+
+`terminal.send` is also high-risk (it writes input to a live pane) and gets its own approval prompt.
+
 ---
 
 ## 4. Declaration flow


### PR DESCRIPTION
## Summary

Answers four boundary questions raised by @alphabeen in #31 on Phase 2.1 follow-up, before the enforcement PR lands and these decisions become load-bearing. Pure docs — no code changes, no test deltas.

The questions:

1. Should shared display fields (`label`, `role`, `status`) be permissioned separately from tool-owned `custom.<tool>.*` paths?
2. Should a plugin holding only `meta.write:custom.myPlugin.*` be unable to write top-level `status`?
3. How should `terminal.read` / cross-pane search map to `wmuxPermissions`, given they have a different risk profile?
4. Coarse `events.subscribe` vs granular `events:pane.metadata.changed`?

The existing grammar in `permissionGrammar.ts` already supports the partitioning these questions imply; the spec was silent on the **default rules** that the enforcement PR will encode. This PR closes that silence.

## Changes

Three new subsections in `docs/api/mcp-plugin-spec.md`:

- **§3.4 Metadata path namespace** — `meta.{read,write}` use dotted JSON paths into `PaneMetadata` as the glob namespace. Default rule: unscoped `meta.write` covers every path; `meta.write:custom.myPlugin.*` restricts to that subtree (shared `label`/`role`/`status` rejected at enforcement). Plugins that need a specific shared field declare it explicitly (`meta.write:status`). `updatedAt` is substrate-maintained and never writeable.

- **§3.5 Event topic namespace** — `events.subscribe` is a single capability + topic glob, not per-event-type capabilities, so the event surface grows additively without expanding the whitelist. Lists the authoritative topics from `WmuxEventType` (`src/shared/events.ts`), including the single `agent.lifecycle` topic where sub-kind rides in the payload.

- **§3.6 Terminal-content risk class** — categorizes `terminal.read` and `pane.search` together (both expose user terminal content; `pane.search` returns 500-char-truncated matched lines + context). Notes the future approval dialog SHOULD surface them with stronger language than metadata/events. `terminal.send` flagged high-risk with its own prompt.

Also gitignores `.local-scratch/` for local drafts.

## Why now

Enforcement PR (method dispatch gating against declared permissions) is the next substrate item. Reviewing that PR with the default rules unsettled would multiply review cost — better to settle the spec text first.

## Verification

- `docs/api/mcp-plugin-spec.md` cross-checked against:
  - `src/main/mcp/permissionGrammar.ts` capability whitelist (matches)
  - `src/shared/types.ts` `PaneMetadata` shape (matches)
  - `src/shared/events.ts` `WmuxEventType` union (matches — fixed initial draft that incorrectly used `agent.lifecycle.*`)
  - `src/renderer/utils/searchEngine.ts` for `pane.search` output shape (matched-line + context, 500-char cap)
- No code touched, no tests added or modified.

## Test plan

- [x] `git diff main..HEAD` shows docs-only + gitignore changes
- [ ] Reviewer sanity-check that the documented topics/paths/risk-class match current code
- [ ] Reviewer confirm default rule for `meta.write:custom.foo.*` against shared fields is the desired enforcement semantic

cc @alphabeen — this PR answers the four questions from your #31 follow-up. No review cycles requested given your bandwidth note; merging this will give the enforcement PR a settled reference.

Closes (none — refs #31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)