### PR TITLE
fix(hooks): prune HookSignalRouter ledger on PTY disposal (#64)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ Thumbs.db
 .context/
 .gstack/
 .team/
+.local-scratch/
 
 # Private roadmap / strategy docs (not for public repo)
 docs/EDITIONS.md

--- a/src/main/hooks/HookSignalRouter.ts
+++ b/src/main/hooks/HookSignalRouter.ts
@@ -178,6 +178,32 @@ export class HookSignalRouter {
   }
 
   /**
+   * Drop every ledger entry for a given ptyId. Called from PTYBridge's
+   * cleanupInstance when a PTY is disposed (UI close, MCP destroy, exit)
+   * so the ledger doesn't accumulate dead-ptyId entries over a long
+   * daemon lifetime.
+   *
+   * Keys are formed as `${slug}:${ptyId}:${kind}` in `key()`. ptyIds are
+   * UUIDs in production and never contain `:`, so the substring check
+   * `:${ptyId}:` is unambiguous; agent slugs and signal kinds are bound
+   * to a finite enum that also never contains `:`.
+   *
+   * Returns the number of entries removed (testing aid, not a contract).
+   */
+  dropPty(ptyId: string): number {
+    if (!ptyId) return 0;
+    const needle = `:${ptyId}:`;
+    let removed = 0;
+    for (const k of this.ledger.keys()) {
+      if (k.includes(needle)) {
+        this.ledger.delete(k);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  /**
    * Ledger key includes `kind` (codex review round 2, P1 #7). Without it,
    * an `agent.activity` event would overwrite a recent `agent.stop`
    * entry on the same (slug, ptyId), defeating dedup for the case where

--- a/src/main/hooks/__tests__/HookSignalRouter.test.ts
+++ b/src/main/hooks/__tests__/HookSignalRouter.test.ts
@@ -166,4 +166,41 @@ describe('HookSignalRouter', () => {
       expect(d).toBe('emit');
     });
   });
+
+  describe('dropPty', () => {
+    it('removes every entry for the given ptyId, keeps other PTYs intact', () => {
+      // Populate ledger across two PTYs, multiple agents and kinds.
+      router.recordDetector('claude', 'agent.stop', 'pty-a', 1000);
+      router.recordDetector('claude', 'agent.activity', 'pty-a', 1000);
+      router.recordDetector('codex', 'agent.stop', 'pty-a', 1000);
+      router.recordDetector('claude', 'agent.stop', 'pty-b', 1000);
+
+      const removed = router.dropPty('pty-a');
+      expect(removed).toBe(3);
+
+      // pty-a entries gone — fresh emit decision allowed within window.
+      expect(router.recordDetector('claude', 'agent.stop', 'pty-a', 1100)).toBe('emit');
+      expect(router.recordDetector('codex', 'agent.stop', 'pty-a', 1100)).toBe('emit');
+
+      // pty-b entry preserved — same kind within window still deduped.
+      expect(router.recordDetector('claude', 'agent.stop', 'pty-b', 1100)).toBe('dedup');
+    });
+
+    it('returns 0 for an unknown ptyId and never throws on empty input', () => {
+      expect(router.dropPty('never-seen')).toBe(0);
+      expect(router.dropPty('')).toBe(0);
+    });
+
+    it('does not partial-match prefixes (substring guard)', () => {
+      // Guard against accidental prefix collisions — if dropPty used
+      // `startsWith(ptyId)` or similar, dropping `p1` would nuke `p10`.
+      router.recordDetector('claude', 'agent.stop', 'p1', 1000);
+      router.recordDetector('claude', 'agent.stop', 'p10', 1000);
+
+      expect(router.dropPty('p1')).toBe(1);
+
+      // p10 entry survives, same kind within window still deduped.
+      expect(router.recordDetector('claude', 'agent.stop', 'p10', 1100)).toBe('dedup');
+    });
+  });
 });

--- a/src/main/pty/PTYBridge.ts
+++ b/src/main/pty/PTYBridge.ts
@@ -181,6 +181,17 @@ export class PTYBridge {
     this.middlewareStacks.delete(ptyId);
     removeCwd(ptyId);
     removeBranch(ptyId);
+
+    // Prune HookSignalRouter ledger entries for this PTY. Without this,
+    // ledger entries (one per slug × kind seen) linger forever and the
+    // map grows monotonically across PTY spawn/dispose cycles. Bridge
+    // already owns the hookRouter reference so the call is local.
+    try {
+      this.getHookRouter?.()?.dropPty(ptyId);
+    } catch (err) {
+      console.warn('[PTYBridge] hookRouter.dropPty error:', err);
+    }
+
     this.ptyManager.remove(ptyId);
   }
 


### PR DESCRIPTION
## Summary

Closes #64.

`HookSignalRouter.ledger` was a `Map` with no eviction path. Each `recordHook`/`recordDetector` call inserted a `(slug, ptyId, kind)` entry, but nothing removed them when a PTY was disposed. PR #63 wired `recordDetector` into PTYBridge + DaemonNotificationRouter, so every inner-agent turn end now writes — what was a quiet leak became a growing map of dead-ptyId entries across pane spawn/dispose cycles × turn kinds × six agent slugs over a long daemon lifetime.

## Fix

Two lines of plumbing:

- **`HookSignalRouter.dropPty(ptyId)`** removes every ledger entry whose key contains `:${ptyId}:`. Returns the removed count (testing aid). Keys are formed as `${slug}:${ptyId}:${kind}` and neither slug nor kind contains `:`, so the substring guard is unambiguous — verified by a regression test that drops `p1` and asserts `p10` survives.
- **`PTYBridge.cleanupInstance`** calls `getHookRouter()?.dropPty(ptyId)` alongside the other per-PTY teardown. `cleanupInstance` is the single drain point every disposal path funnels through (`onExit`, manual `PTYManager.dispose`, MCP-driven destroy), so the call catches every case without needing an EventBus subscription.

## Tests

Three new unit tests in `src/main/hooks/__tests__/HookSignalRouter.test.ts`:

- cross-PTY isolation — dropping pty-a leaves pty-b deduping correctly
- safe no-op for unknown and empty ptyIds
- substring-collision guard against prefix matches like `p1` vs `p10`

Total tests across `src/main/pty/__tests__/` + `src/main/hooks/__tests__/`: **167 passing**, no regressions. `npx tsc --noEmit` clean.

## Test plan

- [x] `npx vitest run src/main/hooks/__tests__/HookSignalRouter.test.ts` → 17 passing (14 existing + 3 new)
- [x] `npx vitest run src/main/pty/__tests__/ src/main/hooks/__tests__/` → 167 passing
- [x] `npx tsc --noEmit` → clean
- [ ] Reviewer confirm `cleanupInstance` is the right hook point (vs subscribing to EventBus `pane.closed`)

Also gitignores `.local-scratch/` for local response drafts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)