### PR TITLE
fix(notification): cache workspace.list result in DaemonNotificationRouter (#65)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ Thumbs.db
 .context/
 .gstack/
 .team/
+.local-scratch/
 
 # Private roadmap / strategy docs (not for public repo)
 docs/EDITIONS.md

--- a/src/main/notification/DaemonNotificationRouter.ts
+++ b/src/main/notification/DaemonNotificationRouter.ts
@@ -57,9 +57,23 @@ interface WorkspaceListEntry {
   ptyIds?: string[];
 }
 
+/**
+ * TTL for the workspace.list IPC cache (ms). The workspace tree is reshaped
+ * only by user action (create/delete/rename), which is rare — but agent
+ * lifecycle events fan in continuously during multi-pane work. A 2s window
+ * is long enough to coalesce bursts of events from one turn while remaining
+ * short enough that any UI mutation reflects in under a UX heartbeat. The
+ * cache is also actively invalidated on `workspace.metadata.changed`
+ * EventBus emits, so the TTL is the worst-case staleness for surfaces that
+ * don't publish to that event (workspace create/delete go through other
+ * paths that we conservatively rely on the TTL to catch).
+ */
+const WORKSPACE_LIST_CACHE_TTL_MS = 2_000;
+
 export class DaemonNotificationRouter {
   private cleanups: Array<() => void> = [];
   private lastAgentEventAt = new Map<string, number>();
+  private workspaceCache: { value: WorkspaceListEntry[]; ts: number } | null = null;
 
   constructor(
     private daemonClient: DaemonClient,
@@ -69,6 +83,9 @@ export class DaemonNotificationRouter {
     // path so hook+detector pairs collapse to one emit / one dedup. Without
     // it we still emit (decision:'emit'), which is the legacy fallback.
     private getHookRouter?: () => HookSignalRouter | null,
+    // Optional clock override. Used by tests so cache-TTL behavior can be
+    // exercised deterministically without faking globals.
+    private now: () => number = Date.now,
   ) {}
 
   /**
@@ -77,16 +94,39 @@ export class DaemonNotificationRouter {
    * scoping. Best-effort — returns null on any IPC failure, in which case
    * the caller skips the EventBus tee (a stray-workspaced lifecycle event
    * would route to the wrong subscriber, so dropping is safer).
+   *
+   * The result is cached for `WORKSPACE_LIST_CACHE_TTL_MS`. Without this,
+   * every detector-sourced `agent.lifecycle` emit triggered a fresh
+   * round-trip — for a 5-pane × 10-turn session that was 50 unnecessary
+   * IPC hops worth of pure latency. The cache is also wiped on
+   * `workspace.metadata.changed` EventBus emits so user-visible workspace
+   * mutations don't have to wait out the full TTL.
    */
   private async resolveWorkspaceIdForPty(ptyId: string): Promise<string | null> {
+    const cached = this.workspaceCache;
+    if (cached && this.now() - cached.ts < WORKSPACE_LIST_CACHE_TTL_MS) {
+      return findWorkspaceIdForPty(ptyId, cached.value);
+    }
     try {
       const result = (await sendToRenderer(this.getWindow, 'workspace.list')) as unknown;
       if (!Array.isArray(result)) return null;
-      return findWorkspaceIdForPty(ptyId, result as WorkspaceListEntry[]);
+      const list = result as WorkspaceListEntry[];
+      this.workspaceCache = { value: list, ts: this.now() };
+      return findWorkspaceIdForPty(ptyId, list);
     } catch (err) {
       console.warn('[DaemonNotificationRouter] workspace.list resolve failed:', err);
       return null;
     }
+  }
+
+  /**
+   * Drop the cached workspace.list result. Called from the
+   * `workspace.metadata.changed` subscription registered in `start()`, and
+   * exposed for tests that exercise invalidation without involving the
+   * EventBus.
+   */
+  invalidateWorkspaceCache(): void {
+    this.workspaceCache = null;
   }
 
   /**
@@ -259,6 +299,16 @@ export class DaemonNotificationRouter {
     this.daemonClient.on('session:died', onSessionEnd);
     this.daemonClient.on('session:destroyed', onSessionEnd);
 
+    // Invalidate the workspace.list cache whenever a workspace's metadata
+    // mutates. Workspace creation/deletion does not currently publish to
+    // this event, so the TTL is the worst-case staleness for those paths
+    // (UI flow rarely overlaps a sub-2s race with notification routing).
+    const unsubscribeMeta = eventBus.subscribe((event) => {
+      if (event.type === 'workspace.metadata.changed') {
+        this.invalidateWorkspaceCache();
+      }
+    });
+
     this.cleanups.push(
       () => this.daemonClient.off('session:agent', onAgent),
       () => this.daemonClient.off('session:active', onActive),
@@ -266,6 +316,7 @@ export class DaemonNotificationRouter {
       () => this.daemonClient.off('session:critical', onCritical),
       () => this.daemonClient.off('session:died', onSessionEnd),
       () => this.daemonClient.off('session:destroyed', onSessionEnd),
+      unsubscribeMeta,
     );
   }
 
@@ -275,5 +326,6 @@ export class DaemonNotificationRouter {
     }
     this.cleanups.length = 0;
     this.lastAgentEventAt.clear();
+    this.workspaceCache = null;
   }
 }

--- a/src/main/notification/__tests__/DaemonNotificationRouter.cache.test.ts
+++ b/src/main/notification/__tests__/DaemonNotificationRouter.cache.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { DaemonClient } from '../../DaemonClient';
+import { eventBus } from '../../events/EventBus';
+
+// Mock the renderer IPC layer so we can count workspace.list round-trips
+// without spinning up an Electron BrowserWindow. The mock returns a fixed
+// shape; each call increments the spy counter so cache hits are observable.
+vi.mock('../../pipe/handlers/_bridge', () => ({
+  sendToRenderer: vi.fn(),
+}));
+
+// Imported after vi.mock so the module sees the mocked dependency.
+import { sendToRenderer } from '../../pipe/handlers/_bridge';
+import { DaemonNotificationRouter } from '../DaemonNotificationRouter';
+
+const sendToRendererMock = vi.mocked(sendToRenderer);
+
+const FIXTURE_WORKSPACE_LIST = [
+  { id: 'ws-1', name: 'Workspace 1', activePtyId: 'pty-a', ptyIds: ['pty-a', 'pty-b'] },
+  { id: 'ws-2', name: 'Workspace 2', activePtyId: 'pty-c', ptyIds: ['pty-c'] },
+];
+
+function makeRouter(now: () => number) {
+  const fakeDaemon = {
+    on: vi.fn(),
+    off: vi.fn(),
+  } as unknown as DaemonClient;
+  const router = new DaemonNotificationRouter(fakeDaemon, () => null, undefined, now);
+  return { router, fakeDaemon };
+}
+
+// Accessor for the private resolveWorkspaceIdForPty so the test can exercise
+// the cache without needing to round-trip through emitDetectorLifecycle (which
+// would also drag in EventBus + ledger surface unrelated to the cache).
+function resolve(router: DaemonNotificationRouter, ptyId: string): Promise<string | null> {
+  return (router as unknown as {
+    resolveWorkspaceIdForPty(ptyId: string): Promise<string | null>;
+  }).resolveWorkspaceIdForPty(ptyId);
+}
+
+describe('DaemonNotificationRouter workspace.list cache', () => {
+  beforeEach(() => {
+    sendToRendererMock.mockReset();
+    sendToRendererMock.mockResolvedValue(FIXTURE_WORKSPACE_LIST);
+    eventBus.reset();
+  });
+
+  afterEach(() => {
+    eventBus.reset();
+  });
+
+  it('first lookup fetches workspace.list; second lookup within TTL is served from cache', async () => {
+    let t = 1_000_000;
+    const { router } = makeRouter(() => t);
+
+    expect(await resolve(router, 'pty-a')).toBe('ws-1');
+    expect(sendToRendererMock).toHaveBeenCalledTimes(1);
+
+    // 500ms later — still inside the 2s TTL.
+    t += 500;
+    expect(await resolve(router, 'pty-c')).toBe('ws-2');
+    expect(sendToRendererMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches once the TTL window has elapsed', async () => {
+    let t = 1_000_000;
+    const { router } = makeRouter(() => t);
+
+    expect(await resolve(router, 'pty-a')).toBe('ws-1');
+    expect(sendToRendererMock).toHaveBeenCalledTimes(1);
+
+    // 2_001ms after the cached fetch — strictly outside the 2s window.
+    t += 2_001;
+    expect(await resolve(router, 'pty-a')).toBe('ws-1');
+    expect(sendToRendererMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidateWorkspaceCache() forces the next lookup to refetch', async () => {
+    let t = 1_000_000;
+    const { router } = makeRouter(() => t);
+
+    await resolve(router, 'pty-a');
+    expect(sendToRendererMock).toHaveBeenCalledTimes(1);
+
+    router.invalidateWorkspaceCache();
+    await resolve(router, 'pty-a');
+    expect(sendToRendererMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('workspace.metadata.changed EventBus emit invalidates the cache via start() subscription', async () => {
+    let t = 1_000_000;
+    const { router } = makeRouter(() => t);
+
+    router.start();
+    try {
+      await resolve(router, 'pty-a');
+      expect(sendToRendererMock).toHaveBeenCalledTimes(1);
+
+      eventBus.emit({
+        type: 'workspace.metadata.changed',
+        workspaceId: 'ws-1',
+        metadata: {} as never,
+        patch: {},
+      });
+
+      // Within TTL but cache was wiped — should refetch.
+      t += 100;
+      await resolve(router, 'pty-a');
+      expect(sendToRendererMock).toHaveBeenCalledTimes(2);
+    } finally {
+      router.stop();
+    }
+  });
+
+  it('unrelated EventBus emits (e.g. pane.created) do not invalidate the cache', async () => {
+    let t = 1_000_000;
+    const { router } = makeRouter(() => t);
+
+    router.start();
+    try {
+      await resolve(router, 'pty-a');
+      expect(sendToRendererMock).toHaveBeenCalledTimes(1);
+
+      eventBus.emit({ type: 'pane.created', workspaceId: 'ws-1', paneId: 'pane-x' });
+
+      t += 100;
+      await resolve(router, 'pty-a');
+      // Still 1 — pane.created should not have wiped the cache.
+      expect(sendToRendererMock).toHaveBeenCalledTimes(1);
+    } finally {
+      router.stop();
+    }
+  });
+
+  it('stop() drops the cache so a restarted router does not serve stale entries', async () => {
+    let t = 1_000_000;
+    const { router } = makeRouter(() => t);
+
+    await resolve(router, 'pty-a');
+    expect(sendToRendererMock).toHaveBeenCalledTimes(1);
+
+    router.stop();
+    // Even within TTL, post-stop lookup must refetch.
+    t += 100;
+    await resolve(router, 'pty-a');
+    expect(sendToRendererMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('IPC failure does not poison the cache — next call retries', async () => {
+    let t = 1_000_000;
+    const { router } = makeRouter(() => t);
+
+    sendToRendererMock.mockRejectedValueOnce(new Error('renderer detached'));
+    expect(await resolve(router, 'pty-a')).toBeNull();
+    expect(sendToRendererMock).toHaveBeenCalledTimes(1);
+
+    sendToRendererMock.mockResolvedValueOnce(FIXTURE_WORKSPACE_LIST);
+    t += 100;
+    expect(await resolve(router, 'pty-a')).toBe('ws-1');
+    expect(sendToRendererMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #65.

`DaemonNotificationRouter.resolveWorkspaceIdForPty` fired a fresh `workspace.list` IPC round-trip every time `emitDetectorLifecycle` ran. Since PR #63 wired that path into every daemon `session:agent` event with status `waiting`/`complete`, a busy multi-pane session burned N renderer round-trips per session × turn for a workspace tree that almost never changed.

Conservative math: 5-pane × 10-turn session = ~50 IPC hops (~250-1000ms cumulative) for state that was static the whole time.

## Fix

- **2s TTL cache** on the router. `resolveWorkspaceIdForPty` consults the cache before reaching for the renderer; on miss/expiry it does one IPC round-trip and stamps the result.
- **`start()` subscribes to EventBus** and wipes the cache on every `workspace.metadata.changed` so user-visible workspace mutations reflect immediately instead of waiting out the TTL. Unsubscribe is registered in `cleanups` so `stop()` tears it down.
- **`invalidateWorkspaceCache()`** public method for tests + future hooks that want to force-refresh without going through the EventBus.
- **Optional `now` constructor argument** (defaults to `Date.now`) so tests can advance the clock deterministically without faking globals.
- **`stop()` also nulls the cache** so a restarted router never serves stale pre-stop entries.

## Worst-case staleness

Workspace creation/deletion does not publish to `workspace.metadata.changed` today, so the 2s TTL is the worst-case staleness for those paths. The notification flow doesn't race user-visible workspace mutations in practice (UI flow rarely opens/closes a workspace mid-agent-turn), so accepting the TTL for those is conservative-and-cheap; the common case — agent activity bursting against an unchanged tree — gets the full coalesce benefit.

## Tests

Seven new unit tests in `src/main/notification/__tests__/DaemonNotificationRouter.cache.test.ts`:

- cache hit within TTL
- refetch after TTL expiry
- explicit `invalidateWorkspaceCache()` forces refetch
- `workspace.metadata.changed` EventBus emit triggers invalidation via `start()` subscription
- unrelated events (`pane.created`) do not invalidate the cache
- `stop()` clears the cache (restarted router doesn't serve pre-stop state)
- IPC failure does not poison the cache — next call retries

`vi.mock` is used to stub `sendToRenderer` so Electron's IPC layer doesn't need to spin up. Cache behavior is exercised through a `(router as any).resolveWorkspaceIdForPty(ptyId)` cast since that method is private; the public `invalidateWorkspaceCache()` is also exercised directly.

## Test plan

- [x] `npx vitest run src/main/notification/__tests__/DaemonNotificationRouter.cache.test.ts` → 7 passing
- [x] `npx vitest run src/main/notification/__tests__/ src/main/events/__tests__/` → 43 passing (no regression in sendNotification, ToastManager, or EventBus suites)
- [x] `npx tsc --noEmit` → clean
- [ ] Reviewer confirm the 2s TTL is acceptable for workspace create/delete (no `workspace.metadata.changed` emit on those paths today)

Also gitignores `.local-scratch/` for local response drafts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)