### PR TITLE
feat(mcp): Phase 2.2 — MCP plugin permission enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — Phase 2.2 MCP plugin permission enforcement
+
+Lands the active enforcement layer on top of the Phase 2.1 record-only identity + grammar substrate (PR #48) and the spec-side default rules (PR #68). Plugins that declare a capability set via `mcp.declarePermissions` now have those declarations verified against every RPC they issue; mismatches return a structured `RpcRejection` describing the per-path failure, and unconfirmed declarations surface a user-approval prompt before the call can proceed.
+
+### Added
+
+- **`PermissionEnforcer` substrate (`src/main/mcp/PermissionEnforcer.ts`)** — pure-function permission gate. Given a method, params, request context, and trust record, returns `allow`, `reject`, or `partial`. Same function runs in both shadow and enforce modes; only the dispatcher's reaction changes.
+- **Single declarative `methodCapabilityMap`** — `Record<RpcMethod, RequiredCapability>` covering the full 96-method RPC surface. `tsc --noEmit` enforces totality so a new method without a gate entry fails the build. Identity bootstrap (`mcp.identify`, `mcp.declarePermissions`, `system.identify`, `system.capabilities`) is `capability: null`. Internal surfaces (daemon, company, surface, hooks) map to the reserved `wmux.internal` capability that no plugin can declare.
+- **Structured `RpcRejection` discriminated union** on `RpcResponse`'s failure arm — `capability-not-declared`, `path-not-allowed`, `paths-partially-allowed` (with `{allowed, rejected[]}`), and `identity-status` (with optional `pendingApproval.promptId`). Additive on the existing `{ok:false; error}` arm; every `switch (r.ok)` site keeps narrowing.
+- **`ShadowRejectionLogger` + JSONL audit log at `~/.wmux/shadow-rejections.log`** — discriminated entries (`rejection` / `legacy-traffic`). 1 MiB cap with single-generation rotation. Sync writes wrapped in try/catch — telemetry must never affect RPC throughput.
+- **`LegacyTrafficCounter`** — per-method milestones (1st / 10th / 100th / 1000th / 10000th call) for envelope-less RPCs, flushed to the shadow log. Replaces the previous process-once trust-DB write for accurate v3.1 surfacing data.
+- **`ApprovalQueue`** — `(clientName, hash(declaredCapabilities))` dedupe key, synchronous promptId minting + async resolution. On approve/deny, writes through `PluginTrustStore.setUserDecision`. Multiple inflight RPCs from the same plugin during a prompt coalesce onto one modal.
+- **`PermissionApprovalDialog`** — risk-class-grouped capability list with asymmetric wording. Terminal-content (`terminal.read`, `pane.search`) and terminal-input (`terminal.send`) get critical-severity copy that names the concrete privilege ("can read what's on your screen, including secrets"); metadata / events / pane-lifecycle / workspace get neutral copy. Browser and A2A get caution.
+- **`mcp.mode` config flag** in `~/.wmux/config.json` — `shadow` or `enforce`. Production wmux defaults to `enforce`; dev (`electron-forge start` / `NODE_ENV=test`) defaults to `shadow` for dogfood rollback safety.
+- **`PluginTrustStore.setUserDecision(name, 'trusted' | 'denied')`** — explicit user-decision write path. Seeds a fresh record when a prompt fires before `mcp.identify` lands.
+- **Spec §4.4 "Enforcement contract"** — documents the wire shape, retry idiom, mode flag, and worked glob example (`meta.write:custom.foo` ≠ `custom.foo.bar` without trailing `*` or `**`).
+- **`inventory.md` Phase 2.2 capability map** — per-method capability + path-source + risk-class column.
+
+### Changed
+
+- `RpcRouter.dispatch` now calls the enforcer before invoking the handler. In `shadow` mode, the would-be rejection is logged and the handler still runs (no behavior change for v2.x callers). In `enforce` mode, a non-allow outcome returns the RpcResponse failure WITHOUT calling the handler. `legacy` callers (no `clientName` envelope) and identity-bootstrap RPCs are always allowed.
+- `ApprovalQueue.requestApproval` returns `{ promptId, resolution }` — the promptId is available synchronously so the dispatcher can thread it into the rejection without awaiting the user's decision.
+
+### Notes for plugin authors
+
+- Plugins SHOULD retry on `rejection.pendingApproval.promptId` with 1–5 s backoff. The substrate doesn't pin a socket waiting for the user (50-connection cap; OAuth `authorization_pending` precedent).
+- `meta.write:custom.foo` matches the EXACT path `custom.foo`. Declare `meta.write:custom.foo.*` or `meta.write:custom.foo.**` to cover the subtree.
+- `events.poll` is `partial`-mode multi-path: subscribing to mixed-allowed topics returns the allowed subset with a `paths-partially-allowed` rejection on the failure arm carrying both `allowed` and `rejected` lists. `pane.setMetadata` and `pane.clearMetadata` are `all-or-nothing`.
+
 ## [2.11.0] — 2026-05-26 — Orchestrator substrate + Claude Code hook plugin
 
 Lands the substrate piece that the new [`@wmux/orchestrator`](https://github.com/openwong2kim/wmux-orchestrator) npm SDK consumes, plus the Claude Code hook plugin integration that delivers sub-200ms agent-completion signals (vs the heuristic regex detector). Minor version bump because the new `agent.lifecycle` event type is additive — no breaking changes vs v2.10.x clients.

--- a/docs/api/inventory.md
+++ b/docs/api/inventory.md
@@ -223,3 +223,55 @@ The EventBus (`src/main/events/EventBus.ts`) is an in-memory ring buffer of `RIN
 - [`stability.md`](./stability.md) freezes the "stable" tier subset as the v3.0 contract.
 - [`../PROTOCOL.md`](../PROTOCOL.md) elaborates on the wire contract for the stable surfaces.
 - `system.capabilities` will report the tier map programmatically in v3.0.
+
+---
+
+## Permission gate (Phase 2.2)
+
+Every RPC method maps to a single declarative entry in `src/main/mcp/methodCapabilityMap.ts`. The enforcer (`PermissionEnforcer.check`) consults this table at dispatch time to decide whether the caller's declared `wmuxPermissions` cover the request. See [`mcp-plugin-spec.md` §4.4](./mcp-plugin-spec.md#44-enforcement-contract-phase-22) for the wire contract and retry idiom.
+
+The capability column below summarises the table. Three sentinels:
+
+- `null` — identity-bootstrap / system-introspection method; no capability required. Any caller can invoke regardless of trust state.
+- `wmux.internal` — reserved-prefix capability that NO plugin can ever declare (`permissionGrammar.ts` rejects `wmux.*` at declaration time). Internal-only surfaces. Legacy callers (no `clientName` envelope) still grandfather through.
+- `<capability>` — must match one of `KNOWN_CAPABILITIES` (spec §3.2).
+
+### Capability map (subset — full table in code)
+
+| Method | Capability | Path source | Risk class |
+|---|---|---|---|
+| `mcp.identify` | `null` (bootstrap) | — | — |
+| `mcp.declarePermissions` | `null` (bootstrap) | — | — |
+| `mcp.claimWorkspace` | `workspace.claim` | — | workspace |
+| `pane.list` / `pane.focus` | `pane.read` | — | pane-lifecycle |
+| `pane.split` | `pane.create` | — | pane-lifecycle |
+| `pane.search` | `pane.search` | — | **terminal-content** |
+| `pane.setMetadata` | `meta.write` | each present field → path | metadata |
+| `pane.getMetadata` | `meta.read` | — (v3.0 reads whole record) | metadata |
+| `pane.clearMetadata` | `meta.write` | shared paths (label/role/status) | metadata |
+| `events.poll` | `events.subscribe` | `params.types` (`**` if absent) | events |
+| `input.send` / `input.sendKey` | `terminal.send` | — | **terminal-input** |
+| `input.readScreen` / `terminal.readEvents` | `terminal.read` | — | **terminal-content** |
+| `meta.setStatus` / `meta.setProgress` / `meta.setSkills` | `meta.write` | — | metadata |
+| `system.identify` / `system.capabilities` | `null` (bootstrap) | — | — |
+| `browser.navigate` / `browser.open` / `browser.goBack` / `browser.close` | `browser.navigate` | — | browser |
+| `browser.click.cdp` | `browser.click` | — | browser |
+| `browser.type.humanlike` / `browser.type.cdp` / `browser.press.cdp` | `browser.type` | — | browser |
+| `browser.screenshot` | `browser.screenshot` | — | browser |
+| `browser.evaluate` | `browser.evaluate` | — | browser |
+| `browser.session.status` / `browser.session.list` / `browser.cdp.target` / `browser.cdp.info` | `browser.read` | — | browser |
+| `browser.session.start` / `browser.session.stop` | `browser.navigate` | — | browser |
+| `a2a.whoami` / `a2a.discover` / `a2a.resolve.identity` / `a2a.task.query` | `a2a.read` | — | a2a |
+| `a2a.task.send` / `a2a.task.update` / `a2a.broadcast` | `a2a.send` | — | a2a |
+| `a2a.task.cancel` | `a2a.execute` | — | a2a |
+| `workspace.list` / `workspace.current` | `workspace.read` | — | workspace |
+| `workspace.new` / `workspace.focus` / `workspace.close` | `wmux.internal` | — | — |
+| `surface.list` / `surface.new` / `surface.focus` / `surface.close` | `wmux.internal` | — | — |
+| `daemon.*` | `wmux.internal` | — | — |
+| `company.*` | `wmux.internal` | — | — |
+| `notify` | `wmux.internal` | — | — |
+| `hooks.signal` | `wmux.internal` | — | — |
+
+Methods marked **bold** are surfaced in the approval dialog with stronger user-facing language (spec §3.6 — terminal-content / terminal-input risk classes).
+
+The full machine-readable map (with path extractors and `multiPathMode` flags) lives at `src/main/mcp/methodCapabilityMap.ts`. `tsc --noEmit` enforces totality via `Record<RpcMethod, ...>` so a new RPC method without a map entry fails the build.

--- a/docs/api/mcp-plugin-spec.md
+++ b/docs/api/mcp-plugin-spec.md
@@ -253,7 +253,81 @@ Forbidden automated transitions (only the user-approval dialog can perform these
 - `denied → anything` (never regresses)
 - `trusted → trusted` after a widening (must demote and re-approve)
 
-### 4.4 Trust DB location
+### 4.4 Enforcement contract (Phase 2.2)
+
+Once a plugin has identified itself and declared its capability set, every subsequent RPC is gated against the trust record. The substrate either calls the handler (the plugin is `trusted` and the capability+path match its declaration), or it returns an `RpcResponse` failure with a structured `rejection` field carrying machine-readable detail.
+
+**Mode flag.** `~/.wmux/config.json` carries an optional `mcp.mode` field:
+
+```jsonc
+{
+  "version": 1,
+  "daemon": { ... },
+  "session": { ... },
+  "mcp": { "mode": "enforce" }   // "shadow" | "enforce"
+}
+```
+
+- Production wmux defaults to `enforce` (the v3.0 ship target).
+- Dev wmux (electron-forge / `npm start` / `NODE_ENV=test`) defaults to `shadow` — rejection decisions are logged to `~/.wmux/shadow-rejections.log` but the handler still runs, so a bad delta during dogfood doesn't lock the developer out.
+- Users can override either way explicitly via the config key.
+
+**Wire shape.** The `RpcResponse` failure arm carries a `rejection?: RpcRejection` discriminated union (see `src/shared/rpc.ts`):
+
+```ts
+type RpcRejection =
+  | { reason: 'capability-not-declared'; method; capability }
+  | { reason: 'path-not-allowed'; method; capability; path; declared }
+  | { reason: 'paths-partially-allowed'; method; capability;
+      allowed: string[]; rejected: { path; declared }[] }
+  | { reason: 'identity-status'; method; capability; status;
+      pendingApproval?: { promptId } };
+```
+
+The existing `error: string` field carries a human-readable summary suitable for log output; clients that want per-path detail or want to drive an auto-retry loop branch on `rejection.reason`.
+
+**`pendingApproval.promptId` retry idiom.** When a plugin tries to use a declared capability before the user has approved its declaration, the rejection carries:
+
+```jsonc
+{
+  "ok": false,
+  "error": "pane.list: awaiting user approval (promptId=abc123)",
+  "rejection": {
+    "reason": "identity-status",
+    "method": "pane.list",
+    "capability": "pane.read",
+    "status": "unconfirmed",
+    "pendingApproval": { "promptId": "abc123" }
+  }
+}
+```
+
+This is intentionally non-blocking — the substrate doesn't pin a socket waiting for the user's response (50-connection cap + renderer-stall fault tolerance + OAuth `authorization_pending` precedent). Plugins should:
+
+1. Surface the `pendingApproval` state to their own user (e.g. "wmux is waiting for permission approval").
+2. Retry the same RPC on a small backoff (1–5 s) until the response no longer carries `pendingApproval`.
+3. If `rejection.status` flips to `denied` on a retry, stop — the user explicitly rejected the declaration and the substrate will continue to deny.
+
+The `@wmux/orchestrator` SDK ships a `withApprovalRetry()` helper that wraps this idiom; external integrators can copy the pattern from the orchestrator README.
+
+**Worked glob example.** A plugin declaring:
+
+```
+meta.write:custom.foo
+```
+
+is authorised to write to the EXACT path `custom.foo`. It is NOT authorised to write to `custom.foo.bar` — the substrate's `*` glob stops at the path separator. To match the whole subtree, declare either:
+
+- `meta.write:custom.foo.*` — single-segment children (`custom.foo.x`, `custom.foo.y`).
+- `meta.write:custom.foo.**` — full recursive subtree (`custom.foo.x.y.z`).
+
+`meta.write` (no `:glob`) authorises every metadata path including shared `label`/`role`/`status`. Plugins should declare the narrowest glob that covers their actual writes — the approval prompt renders the declared globs verbatim so the user can verify scope.
+
+**Multi-path partial rejection.** `events.poll` with multiple types in `params.types` is in `partial` multi-path mode: if some topics match the declaration and some don't, the wire returns `paths-partially-allowed` on the failure arm with `allowed: [...]` and `rejected: [...]` arrays. Clients should drop the rejected topics from their next poll. `pane.setMetadata` and `pane.clearMetadata` are `all-or-nothing` — any path miss wholesale-rejects the call (writes can't silently drop fields).
+
+**Identity bootstrap exemption.** `mcp.identify`, `mcp.declarePermissions`, `system.identify`, and `system.capabilities` are exempt from the gate — they have `capability: null` in the method table. A plugin in `unconfirmed` or `denied` state can still call these to refresh its identity or query substrate capabilities; everything else returns a structured rejection.
+
+### 4.5 Trust DB location
 
 `~/.wmux/plugin-trust.json` (on Windows, `%USERPROFILE%\.wmux\plugin-trust.json`).
 

--- a/plans/phase-2-2-enforcement.md
+++ b/plans/phase-2-2-enforcement.md
@@ -1,0 +1,266 @@
+# Phase 2.2 — MCP Plugin Permission Enforcement
+
+Status: DRAFT v2 (planning only — Q1/Q2/Q3 resolved by sub-agent second opinions, no code this session)
+Spawned from: `plans/generic-wandering-teapot.md` (Substrate 3.0 Phase 2 row)
+Predecessors: PR #48 (record-only identity + grammar), PR #49 (trust-DB invariants), PR #68 (spec §3.4/§3.5/§3.6 default rules)
+Tracking: issue #31 (Substrate 3.0 roadmap), comment-thread with @alphabeen
+Review trail: `architect-reviewer` + `backend-architect` independent skims (2026-05-27), both grounded in code reads of `RpcRouter`, `permissionGrammar`, `rpc.ts`, `PipeServer`, `PluginIdentity`, `PluginTrustStore`.
+
+## Why this plan exists
+
+Phase 2.1 shipped the identity + grammar substrate **record-only**. Every `mcp.identify` and `mcp.declarePermissions` writes to `~/.wmux/plugin-trust.json` but no RPC is gated. The substrate now knows who's talking and what they say they want, and the spec (PR #68 §3.4/§3.5/§3.6) defines the boundaries. What's missing is the wall.
+
+Phase 2.2 puts the wall in:
+
+1. **Method-dispatch gate** — RPC call with a capability the caller didn't declare → reject.
+2. **Metadata-path gate** — `pane.setMetadata` with a path the caller's `meta.write` glob doesn't match → reject.
+3. **Event-topic gate** — `events.subscribe` payload restricted to topics matching the caller's declared globs.
+4. **Approval dialog** — user-visible prompt for `unconfirmed` declarations; renders terminal-content capabilities (`terminal.read`, `pane.search`) with stronger language than metadata/events.
+
+The external-tooling reviewer (@alphabeen, issue #31) explicitly asked for **structured per-path rejection errors** so plugin authors can debug declaration vs runtime mismatch without guessing — that's a first-class requirement here, not a follow-up.
+
+## Boundary constraints (from memory + spec)
+
+- `[[feedback_substrate_neutrality]]` — substrate stays neutral. Enforcement is a substrate concern (record + gate + persist), but the *opinion* (which capability gates which method) lives in a single declarative table that any future reviewer can read at a glance.
+- `[[feedback_no_ship_without_user_verification]]` — user dogfood between code-complete and PR push.
+- `[[feedback_pr_strategy]]` — external reviewer (alphabeen) in the loop → 1 PR + commits. Stacked PRs only for self-review hygiene if scope balloons.
+- `[[feedback_pr_commit_english]]` — PR body, commit message, code comments all English.
+- `[[feedback_push_confirm]]` — user confirms before push.
+- `[[reference_dynamic_test_pattern]]` — daemon subprocess + RPC probe e2e pattern, see `src/main/mcp/__tests__/phase-2-1-e2e.test.ts`.
+- Spec §3.4 (metadata path namespace), §3.5 (event topic namespace), §3.6 (terminal-content risk class) — authoritative semantics. Implementation MUST cite spec lines in code comments where defaults are encoded.
+
+## Surface map (what we touch)
+
+```
+docs/api/
+├── mcp-plugin-spec.md          (§4 — declaration flow; extend with §4.4 enforcement contract)
+├── inventory.md                 (annotate each RPC tool with its capability + path-scope rule)
+└── stability.md                 (no change — gates are additive, not a breaking promise)
+
+src/main/pipe/
+├── RpcRouter.ts                 (PRIMARY GATE — central dispatch wrapper, ctx → permission check)
+└── handlers/                    (each handler MAY do post-gate path-glob check for nested resource paths)
+    ├── meta.rpc.ts              (pane.setMetadata / pane.getMetadata — needs path-glob check)
+    ├── events.rpc.ts            (events.subscribe — needs topic-glob check + filter pipeline)
+    ├── pane.rpc.ts              (pane.search — terminal-content risk class)
+    ├── input.rpc.ts             (terminal.send — capability check only)
+    └── ...                      (all others gated by capability only at dispatch level)
+
+src/main/mcp/
+├── PluginIdentity.ts            (existing — read trust state)
+├── PluginTrustStore.ts          (existing — persist updates from approval)
+├── permissionGrammar.ts         (existing — parse + match)
+├── methodCapabilityMap.ts       (NEW — single source of truth: method → required capability)
+├── PermissionEnforcer.ts        (NEW — pure-function gate: (method, params, ctx, trust) → allow|reject)
+└── ApprovalQueue.ts             (NEW — debounced approval prompt orchestrator)
+
+src/renderer/
+└── components/Approval/
+    ├── PermissionApprovalDialog.tsx       (NEW — modal renders declared capabilities with risk classes)
+    └── PermissionApprovalDialog.test.tsx  (NEW)
+
+src/shared/
+└── rpc.ts                       (extend RpcResponse with structured rejection variant)
+```
+
+## Architectural decisions
+
+### D1. Fully central gate (capability AND path)
+
+`RpcRouter.dispatch` (`src/main/pipe/RpcRouter.ts:53-117`) is already the single entry point that pulls `clientName`/`clientVersion` into `RpcContext` and runs the legacy-contact recorder. The permission gate goes at the same layer — for **both** the capability check and the path-glob check. Path extraction is data-driven from `methodCapabilityMap` via a `pathFromParams?: (params) => string | string[] | undefined` extractor.
+
+- **One place to audit.** Future reviewer reads `RpcRouter.dispatch` + `methodCapabilityMap` and sees every rejection path. No handler can quietly skip gating.
+- **`tsc` enforces totality.** `Record<RpcMethod, RequiredCapability>` makes a new RPC method without a map entry a compile-time error. "I added a method but forgot to gate it" is caught at build, not in review.
+- **Blast radius is asymmetric in the right direction.** Misconfigured `pathFromParams` extractor fails *closed* (legitimate calls rejected, surfaced by shadow-mode metric in D7 step 3). Forgotten handler-local check fails *open* (silent over-grant — exactly the bug enforcement exists to prevent). Centralization makes the dangerous failure mode loud.
+- **Multi-path support is built into the extractor return type.** `string | string[] | undefined` covers `pane.setMetadata` (single path), `events.poll` (subscriber may pass a topic array), and the no-path methods (`undefined`). The enforcer returns `{ allowed: string[], rejected: { path, declared }[] }` for the multi-path case so handlers can subscribe to the allowed subset and surface the rejected list per @alphabeen's structured-rejection ask (D3) — handlers never reimplement rejection plumbing.
+- **Escape hatch for state-dependent paths.** A method that needs handler-resolved state (e.g. `paneId → workspaceId` lookup before path is knowable) uses an explicit sentinel `pathFromParams: 'handler-resolves'` in the map and the handler MUST call `PermissionEnforcer.checkPath(ctx, capability, resolvedPath)` itself. Documented sentinel keeps the table the single source of truth even for exceptions.
+
+**Resolves Q1** (architect-reviewer + backend-architect concurrence, both citing the "audit + compile-time totality" argument).
+
+### D2. Method → capability mapping in a single declarative table
+
+```ts
+// src/main/mcp/methodCapabilityMap.ts
+//
+// Capability and method are DIFFERENT layers: `events.subscribe` is the
+// capability name (spec §3.5, see permissionGrammar.ts KNOWN_CAPABILITIES),
+// while `events.poll` is the actual RPC method on the wire (src/shared/rpc.ts).
+// The map keys are RPC methods; `capability` is the declared name that
+// `wmuxPermissions` grants. Same logic for `terminal.read` capability vs
+// `terminal.readEvents` / `input.readScreen` methods.
+
+import type { RpcMethod } from '../../shared/rpc';
+
+type Capability = string;  // values from KNOWN_CAPABILITIES, intersected at runtime
+type PathExtractor = (params: Record<string, unknown>) => string | string[] | undefined;
+
+export interface RequiredCapability {
+  /** Null means "no capability required" — identity bootstrap RPCs only. */
+  capability: Capability | null;
+  /** Optional extractor; if absent the gate only checks capability. */
+  pathFromParams?: PathExtractor | 'handler-resolves';
+  /** Risk class drives approval-dialog wording (D5). */
+  riskClass?: 'terminal-content' | 'terminal-input' | 'system';
+}
+
+export const METHOD_CAPABILITY: Record<RpcMethod, RequiredCapability> = {
+  // Identity bootstrap — MUST stay unconditionally callable so a fresh
+  // plugin can declare itself. Mirrors IDENTITY_OWN_METHODS in RpcRouter.ts.
+  'mcp.identify': { capability: null },
+  'mcp.declarePermissions': { capability: null },
+
+  // Pane lifecycle
+  'pane.list': { capability: 'pane.read' },
+  'pane.split': { capability: 'pane.create' },
+  'pane.focus': { capability: 'pane.read' },
+  'pane.search': { capability: 'pane.search', riskClass: 'terminal-content' },
+
+  // Metadata — path is the dotted JSON path into PaneMetadata (spec §3.4)
+  'pane.setMetadata': { capability: 'meta.write', pathFromParams: (p) => p.path as string | undefined },
+  'pane.getMetadata': { capability: 'meta.read',  pathFromParams: (p) => p.path as string | undefined },
+  'pane.clearMetadata': { capability: 'meta.write', pathFromParams: (p) => p.path as string | undefined },
+
+  // Events — capability is `events.subscribe`, wire method is `events.poll`.
+  // Topic filter for the poll comes off `p.topics` (array) or `p.topic`.
+  'events.poll': {
+    capability: 'events.subscribe',
+    pathFromParams: (p) => (Array.isArray(p.topics) ? p.topics as string[] : p.topic as string | undefined),
+  },
+
+  // Terminal IO
+  'input.send':         { capability: 'terminal.send', riskClass: 'terminal-input' },
+  'input.sendKey':      { capability: 'terminal.send', riskClass: 'terminal-input' },
+  'input.readScreen':   { capability: 'terminal.read', riskClass: 'terminal-content' },
+  'terminal.readEvents': { capability: 'terminal.read', riskClass: 'terminal-content' },
+
+  // ...full surface covered when the table is implemented; tsc enforces totality.
+};
+```
+
+This is **the** opinionated piece of substrate. One table, one place to add a method, one place to argue about classification. `tsc` enforces totality via `Record<RpcMethod, ...>` so a new RPC method that doesn't appear in the table fails compilation. Identity bootstrap RPCs (`mcp.identify`, `mcp.declarePermissions`) appear in the table with `capability: null` rather than as a hard-coded enforcer special case — the table stays the single source of truth (architect-reviewer + backend-architect both flagged this).
+
+### D3. Structured per-path rejection (alphabeen's ask)
+
+`RpcResponse` in `src/shared/rpc.ts` is **already a discriminated union** (`{ id; ok: true; result } | { id; ok: false; error }`). Phase 2.2 extends the failure arm only, preserving narrowing semantics for every existing `switch (r.ok)` site (architect-reviewer caught this — earlier draft incorrectly flattened the shape).
+
+```ts
+// src/shared/rpc.ts — additive ONLY to the ok:false arm
+export type RpcRejection =
+  | { reason: 'capability-not-declared'; method: RpcMethod; capability: string }
+  | { reason: 'path-not-allowed'; method: RpcMethod; capability: string;
+      path: string; declared: string[] }   // single-path methods (pane.setMetadata)
+  | { reason: 'paths-partially-allowed'; method: RpcMethod; capability: string;
+      allowed: string[]; rejected: { path: string; declared: string[] }[] }
+                                            // multi-path methods (events.poll)
+  | { reason: 'identity-status'; method: RpcMethod; status: 'denied' | 'unconfirmed';
+      capability: string; pendingApproval?: { promptId: string } }
+  | { reason: 'unknown-method'; method: string };
+
+export type RpcResponse =
+  | { id: string; ok: true;  result: unknown }
+  | { id: string; ok: false; error: string; rejection?: RpcRejection };  // rejection is ADDITIVE on the existing failure arm
+```
+
+Mirrors PR #49's discriminated-union pattern: callers that read `error` keep working; new plugin authors branch on `rejection.reason` for precise diagnostics. The generic `error` string for `path-not-allowed` reads:
+
+> `pane.setMetadata: path "status" not allowed by declared meta.write globs [custom.myPlugin.*]`
+
+— so it's also useful without consulting the union.
+
+`paths-partially-allowed` (the multi-path variant) lets `events.poll` return successful results for the allowed topic subset while surfacing the rejected ones in the same response. Without that split, an MCP client subscribing to `[pane.created, agent.lifecycle]` with only `events.subscribe:pane.*` declared would have to either get a wholesale reject (poor UX) or silently lose the `agent.lifecycle` events (worse). Backend-architect specifically called this shape out as the natural extension of @alphabeen's per-path-rejection ask.
+
+### D4. Trust-state ladder during enforcement (resolves Q2)
+
+| Status | What gate does |
+|---|---|
+| `trusted` | Allow if capability + path match declaration. |
+| `unconfirmed` | **Reject** with `{reason: 'identity-status', status: 'unconfirmed', pendingApproval: {promptId}}`. Do NOT block the socket. ApprovalQueue dedupes prompts per `(clientName, declaredCapabilities-hash)`. Client retries on `pendingApproval`; on user approve → `trusted`, next call (or retry) succeeds. |
+| `legacy` | Allow + audit (preserve v2.x callers). Eligible for promotion to `unconfirmed` when the caller learns to send `clientName`. Spec §2.3 already exempts `legacy` from automated demotion. |
+| `denied` | Reject with `{reason: 'identity-status', status: 'denied'}`. No prompt. User must edit `plugin-trust.json` manually to restore. Spec §4.3: "`denied` never regresses." |
+
+**Why reject-with-retry, not block** (both reviewers concurrent):
+
+- `PipeServer.MAX_CONNECTIONS = 50` is a hard socket cap. Blocking pins sockets across a human-scale modal interaction (seconds-to-minutes). 5 unconfirmed plugins × 3 boot-time calls = 15 sockets parked = 30% of the pool gone behind one AFK user. Reject-with-retry releases the socket immediately.
+- The approval dialog is on the Electron renderer. Blocking RPC handlers in main waiting on a renderer round-trip creates a substrate-wide failure mode when the renderer stalls (xterm fit churn, GPU stall, devtools open — all observed wmux pathologies per `[[reference_terminal_fit_guards]]`). Reject-with-retry decouples renderer health from RPC throughput.
+- Deadlock risk: a plugin making a gated call from inside a synchronous MCP `tools/call` would block the host LLM-side conversation if we held the socket. Reject-with-retry is the same shape as OAuth `authorization_pending` — well-established async pattern with documented client idiom.
+- IPC timeouts compound the blocking failure mode: most MCP clients use 30s–60s RPC timeout; if the user doesn't pick in time the plugin sees a generic timeout and may auto-retry, creating duplicate prompts. With explicit `pendingApproval` the wait is in the protocol — the client decides whether to back off, batch, or surface "waiting for approval" UI to its own user.
+
+`@wmux/orchestrator` (already shipped, see `[[project_orchestrator_v0_1_1_shipped]]`) gets a `withApprovalRetry()` helper documenting the idiom (~20 LOC). External integrators copy the pattern from the orchestrator README.
+
+`legacy` allow-list keeps existing integrations alive across the v2 → v3 cut. **Resolves Q3**: surfacing legacy calls as user-visible warnings is deferred to v3.1 — Phase 2.2 logs them to shadow-mode telemetry (D7) so v3.1 can build a settings panel on top of populated data, but doesn't ship the panel itself. Both reviewers concurrent: a warning a user can't act on is an anti-pattern, and post-enforcement-launch warning noise undermines trust in the warning system when real rejections start firing.
+
+### D5. Approval dialog wording asymmetry (alphabeen reminder)
+
+Single modal component reads the declared `wmuxPermissions` array, groups by risk class from `methodCapabilityMap`, and renders:
+
+- **Metadata + events** (low risk) — neutral wording: *"can label your panes, can subscribe to pane lifecycle events"*.
+- **Terminal content** (`terminal.read`, `pane.search`) — bold + warning color: *"can read what's on your screen, including secrets, agent output, and command history"*.
+- **Terminal input** (`terminal.send`) — bold + warning color: *"can type into your panes as if you were typing"*.
+- **A2A / browser / others** — case-by-case wording in the same risk-class table.
+
+The wording table lives next to `methodCapabilityMap` so risk class and label move together.
+
+### D6. Test strategy
+
+Three layers:
+
+1. **Unit** — `PermissionEnforcer.check(...)` is pure-function; cover all rejection branches + every `riskClass` × capability matrix in `methodCapabilityMap`.
+2. **Integration** — RpcRouter dispatch tests using a synthetic `RpcRequest` and a fake `PluginTrustStore`. Cover identity-state ladder transitions.
+3. **E2E dynamic** — extend `phase-2-1-e2e.test.ts` (or new `phase-2-2-e2e.test.ts`) using `[[reference_dynamic_test_pattern]]`: bundled daemon subprocess + RPC probe. Drives the full envelope-with-clientName + declare + attempt-call + observe-rejection-shape cycle through the production code path. This is the test that gives external integrators confidence.
+
+Approval dialog has its own RTL/Vitest UI tests separate from the gate logic.
+
+### D7. Phased rollout inside the PR
+
+To keep the diff legible and dogfood-safe:
+
+1. **Pre-commit 1**: `methodCapabilityMap` + `PermissionEnforcer` (pure modules, fully central per D1, identity-bootstrap sentinel `capability: null`, unit tests).
+2. **Pre-commit 2**: extend `RpcResponse` failure arm with `rejection` (additive type, preserves discriminated union, no behavior change).
+3. **Pre-commit 3**: `RpcRouter.dispatch` wires `PermissionEnforcer` in **shadow mode** — runs the check, logs the would-be rejection, does NOT block. Logged to a dedicated ring buffer / append-only log under `~/.wmux/shadow-rejections.log`, **NOT** persisted on `PluginIdentityRecord` (backend-architect: trust-DB LRU cap can evict shadow evidence under hostile churn).
+4. **Pre-commit 4**: legacy-recorder upgrade — `RpcRouter.legacyContactPersisted` (line 40) is process-once today, which under-counts legacy traffic during a dogfood window. Lift to per-`(clientName-or-pid, method)` counts (best-effort, capped, written to the same shadow log) so v3.1 can build the legacy-surfacing UI on real data. Stays a no-op for `clientName`-stamped requests.
+5. **Pre-commit 5**: `ApprovalQueue` + `PermissionApprovalDialog` (UI + queue dedupe by `(clientName, declaredCapabilities-hash)`, no wiring yet).
+6. **Pre-commit 6**: flip from shadow → enforce, **gated by a user-toggleable feature flag** in `~/.wmux/config.json` (default `enforce` in v3.0 release; dev wmux defaults to `shadow` so dogfood can flip back on a bad delta without rebuilding). This is the load-bearing commit reviewers focus on.
+7. **Pre-commit 7**: docs (spec §4.4 enforcement contract incl. worked `*` vs `**` example for `custom.foo` vs `custom.foo.bar` semantics — backend-architect: trailing-dot glob behavior will trip @alphabeen's first integration if undocumented; inventory.md per-tool capability rows).
+
+Commits 1–5 don't change runtime behavior. Commit 6 does, and only after dogfood proves shadow-mode rejection counts match expectations across at least one full multi-plugin session.
+
+## Open questions — RESOLVED (sub-agent second opinion, 2026-05-27)
+
+Two reviewers (architect-reviewer + backend-architect) skimmed this plan independently, each grounded in fresh reads of `RpcRouter.ts`, `permissionGrammar.ts`, `rpc.ts`, `PipeServer.ts`, `PluginIdentity.ts`, `PluginTrustStore.ts`, and spec §3-§5. All three calls came back with concurrent recommendations.
+
+- **Q1 → D1 fully-central.** Both reviewers preferred lifting the path-glob check into the central gate via `pathFromParams: (params) => string | string[] | undefined`. The earlier "hybrid" framing was a half-measure: handler-local path checks fail *open* (silent over-grant — the exact bug enforcement exists to prevent) while a misconfigured central extractor fails *closed* (caught by shadow mode in D7 step 3). `Record<RpcMethod, ...>` totality gives a compile-time error for any new method that forgets to gate.
+- **Q2 → D4 reject-with-pendingApproval.** Both reviewers rejected the "block server-side" alternative on socket-cap grounds (`MAX_CONNECTIONS = 50` × human-scale approval latency = DoS vector against own pool), renderer-stall fault tolerance, deadlock from synchronous MCP tool calls, and OAuth `authorization_pending` precedent. The discriminated union (D3) already names `pendingApproval: { promptId }` — the wire contract is built for retry.
+- **Q3 → D4 silent grandfather for v3.0, surfacing deferred to v3.1.** Both reviewers flagged that a warning the user can't act on (they can't add `clientName` to someone else's code) is an anti-pattern, and warning noise immediately after launching enforcement undermines trust when real rejections start firing. Shadow-mode telemetry (D7 step 3+4) collects the data without shipping UI, so v3.1 can build the panel on real counts.
+
+## Additional substantive concerns from review
+
+Surfaced by one or both sub-agent skims; folded into the design above.
+
+- **`mcp.identify` / `mcp.declarePermissions` self-exemption** — D2 table now has them with `capability: null` instead of hard-coded special case in the enforcer. Mirrors `IDENTITY_OWN_METHODS` in `RpcRouter.ts:27-30`. Without this, a fresh plugin can't declare itself (chicken-and-egg deadlock).
+- **`RpcResponse` is already a discriminated union** — D3 rewritten to preserve `{ok:true; result} | {ok:false; error}` narrowing; `rejection` is additive to the failure arm only. The earlier draft flattened the shape and would have broken every `switch (r.ok)` site in the codebase.
+- **Capability ≠ method layer** — D2 commentary now spells out `events.subscribe` (capability) vs `events.poll` (method); the `terminal.read` capability covers `terminal.readEvents` / `input.readScreen` methods. Caught by architect-reviewer; the live spec §3.5 + `KNOWN_CAPABILITIES` are internally consistent — only the plan example was mislabeled.
+- **Shadow metrics on a separate log, not on `PluginIdentityRecord`** — `MAX_PLUGIN_TRUST_ENTRIES = 1024` LRU eviction (`PluginTrustStore.ts:35-58`) can evict shadow-mode evidence under hostile churn. D7 step 3 now writes shadow rejections to a dedicated ring buffer / log file.
+- **Process-once legacy recorder is wrong for shadow accounting** — `RpcRouter.legacyContactPersisted` (line 40) fires only on the first envelope-less RPC per process. Three different legacy callers in one session = only the first recorded. D7 step 4 lifts this to per-(client-or-pid, method) counts in the shadow log so v3.1 has accurate data.
+- **Shadow → enforce should be a user-toggleable feature flag**, not a one-way code switch. D7 step 6 amended: `~/.wmux/config.json` flag, prod defaults to `enforce`, dev defaults to `shadow` for rollback safety during the dogfood window.
+- **`*` doesn't match `.` — counterintuitive glob behavior must be documented.** `permissionGrammar.ts:78` makes `*` stop at the path separator, so `meta.write:custom.foo` does NOT grant `custom.foo.bar`; the declaration must be `custom.foo.*` (single segment) or `custom.foo.**` (recursive). D7 step 7 adds a worked example in spec §4.4 so @alphabeen's first integration doesn't misdeclare.
+- **Multi-path rejection shape `{allowed, rejected}`** — backend-architect suggestion folded into D3. `events.poll` with mixed-grant topic array gets the subset that passed plus structured per-rejected-path detail, no wholesale-reject penalty.
+
+## What's NOT in this plan
+
+- Capability revocation CLI (`wmux mcp permissions <name> --revoke <capability>`) — spec §5 calls it out as a follow-up PR. Manual edit of `plugin-trust.json` is the v3.0 workflow.
+- Per-connection identity pinning (preventing a plugin from rotating `clientName` mid-session) — spec §7 defers.
+- Cryptographic plugin tokens / signed manifests — v3.1+ roadmap.
+- WASM sandbox — out of scope forever (plugins run as their own OS process).
+- Marketplace UI — out of band.
+
+## Ship checklist (when implementation starts, NOT this session)
+
+- [ ] D1–D7 design decisions resolved (after Q1–Q3 second opinion).
+- [ ] Pre-commit 1–4 implemented + unit/integration tests green + `tsc --noEmit` clean.
+- [ ] Shadow-mode metric collected in dev wmux dogfood for ≥30 minutes across at least 2 plugin clients (Claude Code + Codex). Shadow rejections match expectations.
+- [ ] Pre-commit 5–7 implemented; dialog approved by user in dev wmux.
+- [ ] E2E dynamic test passes on local Windows + at least one POSIX leg.
+- [ ] CHANGELOG entry under v2.x.x (release flow).
+- [ ] PR body: link issue #31, PR #48, PR #49, PR #68, this plan.
+- [ ] cc @alphabeen in PR body — no expectation of review cycles.
+- [ ] User confirms push (memory rule).

--- a/src/main/audit/__tests__/legacyTrafficCounter.test.ts
+++ b/src/main/audit/__tests__/legacyTrafficCounter.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_MILESTONES,
+  LegacyTrafficCounter,
+  MAX_TRACKED_METHODS,
+} from '../legacyTrafficCounter';
+
+describe('LegacyTrafficCounter.record', () => {
+  it('fires sink at the default milestones (1, 10, 100, ...)', () => {
+    const sink = vi.fn();
+    const counter = new LegacyTrafficCounter({ sink });
+    for (let i = 0; i < 100; i++) counter.record('pane.list');
+    // Expect calls at 1, 10, 100 (3 milestones)
+    expect(sink).toHaveBeenCalledTimes(3);
+    expect(sink.mock.calls.map((c) => c[0].count)).toEqual([1, 10, 100]);
+  });
+
+  it('does not fire on counts between milestones', () => {
+    const sink = vi.fn();
+    const counter = new LegacyTrafficCounter({ sink });
+    counter.record('pane.list');
+    counter.record('pane.list');
+    counter.record('pane.list');
+    // After 3 calls, only the 1st milestone fired.
+    expect(sink).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts methods independently', () => {
+    const sink = vi.fn();
+    const counter = new LegacyTrafficCounter({ sink });
+    counter.record('pane.list');
+    counter.record('pane.focus');
+    counter.record('pane.list');
+    expect(counter.getCount('pane.list')).toBe(2);
+    expect(counter.getCount('pane.focus')).toBe(1);
+    expect(sink).toHaveBeenCalledTimes(2); // 1st call for each method
+  });
+
+  it('respects custom milestones', () => {
+    const sink = vi.fn();
+    const counter = new LegacyTrafficCounter({ sink, milestones: [3, 5] });
+    for (let i = 0; i < 7; i++) counter.record('pane.list');
+    expect(sink.mock.calls.map((c) => c[0].count)).toEqual([3, 5]);
+  });
+
+  it('keeps counting past the last milestone but stops emitting', () => {
+    const sink = vi.fn();
+    const counter = new LegacyTrafficCounter({ sink, milestones: [1, 10] });
+    for (let i = 0; i < 1000; i++) counter.record('pane.list');
+    expect(counter.getCount('pane.list')).toBe(1000);
+    expect(sink).toHaveBeenCalledTimes(2);
+  });
+
+  it('caps tracked methods (DoS guard)', () => {
+    const sink = vi.fn();
+    const counter = new LegacyTrafficCounter({
+      sink,
+      maxTrackedMethods: 3,
+    });
+    counter.record('pane.list');
+    counter.record('pane.focus');
+    counter.record('events.poll');
+    // 4th distinct method gets dropped silently.
+    counter.record('input.send');
+    expect(counter.getCount('pane.list')).toBe(1);
+    expect(counter.getCount('input.send')).toBe(0);
+    // Existing methods still increment.
+    counter.record('pane.list');
+    expect(counter.getCount('pane.list')).toBe(2);
+  });
+
+  it('swallows sink errors so audit telemetry never breaks the caller', () => {
+    const counter = new LegacyTrafficCounter({
+      sink: () => {
+        throw new Error('disk full');
+      },
+    });
+    expect(() => counter.record('pane.list')).not.toThrow();
+    expect(counter.getCount('pane.list')).toBe(1);
+  });
+
+  it('exports the documented DEFAULT_MILESTONES + MAX_TRACKED_METHODS', () => {
+    // Pinning the constants so a future refactor can't silently drop a
+    // milestone (which would invalidate cross-version log analysis).
+    expect(DEFAULT_MILESTONES).toEqual([1, 10, 100, 1000, 10000]);
+    expect(MAX_TRACKED_METHODS).toBeGreaterThanOrEqual(96);
+  });
+});
+
+describe('LegacyTrafficCounter.reset', () => {
+  it('drops all state and re-fires the 1st milestone on the next record', () => {
+    const sink = vi.fn();
+    const counter = new LegacyTrafficCounter({ sink });
+    counter.record('pane.list');
+    counter.reset();
+    counter.record('pane.list');
+    expect(sink).toHaveBeenCalledTimes(2);
+    expect(sink.mock.calls[1][0].count).toBe(1);
+    expect(counter.getCount('pane.list')).toBe(1);
+  });
+});

--- a/src/main/audit/__tests__/shadowRejectionLog.test.ts
+++ b/src/main/audit/__tests__/shadowRejectionLog.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ShadowRejectionLogger } from '../shadowRejectionLog';
+
+let tmpDir: string;
+let logPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-shadow-test-'));
+  logPath = path.join(tmpDir, 'shadow-rejections.log');
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* tmpdir cleanup is best-effort across platforms */
+  }
+});
+
+describe('ShadowRejectionLogger.append', () => {
+  it('writes a JSONL line per append', () => {
+    let ts = 1_700_000_000_000;
+    const log = new ShadowRejectionLogger({
+      path: logPath,
+      now: () => ++ts,
+    });
+    log.append({
+      clientName: 'p1',
+      method: 'pane.list',
+      rejection: {
+        reason: 'capability-not-declared',
+        method: 'pane.list',
+        capability: 'pane.read',
+      },
+    });
+    log.append({
+      clientName: 'p2',
+      method: 'events.poll',
+      rejection: {
+        reason: 'paths-partially-allowed',
+        method: 'events.poll',
+        capability: 'events.subscribe',
+        allowed: ['pane.created'],
+        rejected: [{ path: 'agent.lifecycle', declared: ['pane.*'] }],
+      },
+    });
+    const entries = log.readAll();
+    expect(entries).toHaveLength(2);
+    expect(entries[0].clientName).toBe('p1');
+    expect(entries[0].method).toBe('pane.list');
+    expect(entries[0].rejection.reason).toBe('capability-not-declared');
+    expect(entries[1].clientName).toBe('p2');
+    expect(entries[1].rejection.reason).toBe('paths-partially-allowed');
+  });
+
+  it('preserves undefined clientName (envelope-less callers)', () => {
+    const log = new ShadowRejectionLogger({ path: logPath });
+    log.append({
+      clientName: undefined,
+      method: 'pane.list',
+      rejection: {
+        reason: 'capability-not-declared',
+        method: 'pane.list',
+        capability: 'pane.read',
+      },
+    });
+    const entries = log.readAll();
+    expect(entries).toHaveLength(1);
+    // JSON.stringify drops undefined keys, so the field round-trips as missing
+    // — equivalent to undefined for our purposes.
+    expect(entries[0].clientName).toBeUndefined();
+  });
+
+  it('creates the parent directory if missing', () => {
+    const nested = path.join(tmpDir, 'sub', 'dir', 'shadow.log');
+    const log = new ShadowRejectionLogger({ path: nested });
+    log.append({
+      clientName: 'p1',
+      method: 'pane.list',
+      rejection: {
+        reason: 'capability-not-declared',
+        method: 'pane.list',
+        capability: 'pane.read',
+      },
+    });
+    expect(fs.existsSync(nested)).toBe(true);
+  });
+
+  it('rotates when the file exceeds maxBytes', () => {
+    // Tiny cap so a single rejection record (≈150 B) blows it on the first
+    // post-write check. rotateIfNeeded examines size BEFORE appending, so
+    // the first call writes without rotating; the second call sees a
+    // post-first-append size that exceeds the cap and rotates.
+    const log = new ShadowRejectionLogger({
+      path: logPath,
+      maxBytes: 50,
+    });
+    log.append({
+      clientName: 'p1',
+      method: 'pane.list',
+      rejection: {
+        reason: 'capability-not-declared',
+        method: 'pane.list',
+        capability: 'pane.read',
+      },
+    });
+    // First append doesn't rotate (file is brand new, no prior size).
+    expect(fs.existsSync(logPath)).toBe(true);
+    expect(fs.existsSync(logPath + '.1')).toBe(false);
+
+    // Second append finds the file > maxBytes and triggers rotation.
+    log.append({
+      clientName: 'p2',
+      method: 'events.poll',
+      rejection: {
+        reason: 'paths-partially-allowed',
+        method: 'events.poll',
+        capability: 'events.subscribe',
+        allowed: ['pane.created'],
+        rejected: [{ path: 'agent.lifecycle', declared: ['pane.*'] }],
+      },
+    });
+    expect(fs.existsSync(logPath + '.1')).toBe(true);
+    // New file contains only the post-rotation entry.
+    const entries = log.readAll();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].clientName).toBe('p2');
+  });
+
+  it('swallows fs errors so shadow logging never breaks RPC dispatch', () => {
+    // Point the logger at a path that can't possibly be created (a file
+    // appearing where a directory would need to go).
+    const blocker = path.join(tmpDir, 'blocker');
+    fs.writeFileSync(blocker, '');
+    const log = new ShadowRejectionLogger({
+      path: path.join(blocker, 'subfile', 'log.log'),
+    });
+    // Should not throw despite ensureDir failing.
+    expect(() =>
+      log.append({
+        clientName: 'p1',
+        method: 'pane.list',
+        rejection: {
+          reason: 'capability-not-declared',
+          method: 'pane.list',
+          capability: 'pane.read',
+        },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/main/audit/__tests__/shadowRejectionLog.test.ts
+++ b/src/main/audit/__tests__/shadowRejectionLog.test.ts
@@ -2,7 +2,15 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { ShadowRejectionLogger } from '../shadowRejectionLog';
+import {
+  ShadowRejectionLogger,
+  type ShadowAuditEntry,
+  type ShadowRejectionEntry,
+} from '../shadowRejectionLog';
+
+function rejectionEntries(entries: ShadowAuditEntry[]): ShadowRejectionEntry[] {
+  return entries.filter((e): e is ShadowRejectionEntry => e.entryKind === 'rejection');
+}
 
 let tmpDir: string;
 let logPath: string;
@@ -47,7 +55,7 @@ describe('ShadowRejectionLogger.append', () => {
         rejected: [{ path: 'agent.lifecycle', declared: ['pane.*'] }],
       },
     });
-    const entries = log.readAll();
+    const entries = rejectionEntries(log.readAll());
     expect(entries).toHaveLength(2);
     expect(entries[0].clientName).toBe('p1');
     expect(entries[0].method).toBe('pane.list');
@@ -67,7 +75,7 @@ describe('ShadowRejectionLogger.append', () => {
         capability: 'pane.read',
       },
     });
-    const entries = log.readAll();
+    const entries = rejectionEntries(log.readAll());
     expect(entries).toHaveLength(1);
     // JSON.stringify drops undefined keys, so the field round-trips as missing
     // — equivalent to undefined for our purposes.
@@ -125,9 +133,38 @@ describe('ShadowRejectionLogger.append', () => {
     });
     expect(fs.existsSync(logPath + '.1')).toBe(true);
     // New file contains only the post-rotation entry.
-    const entries = log.readAll();
+    const entries = rejectionEntries(log.readAll());
     expect(entries).toHaveLength(1);
     expect(entries[0].clientName).toBe('p2');
+  });
+
+  it('writes legacy-traffic entries with entryKind discrimination', () => {
+    const log = new ShadowRejectionLogger({ path: logPath });
+    log.append({
+      clientName: 'p1',
+      method: 'pane.list',
+      rejection: {
+        reason: 'capability-not-declared',
+        method: 'pane.list',
+        capability: 'pane.read',
+      },
+    });
+    log.appendLegacyTraffic({ method: 'pane.list', count: 10 });
+    log.appendLegacyTraffic({ method: 'events.poll', count: 100 });
+
+    const all = log.readAll();
+    expect(all).toHaveLength(3);
+    expect(all[0].entryKind).toBe('rejection');
+    expect(all[1].entryKind).toBe('legacy-traffic');
+    expect(all[2].entryKind).toBe('legacy-traffic');
+    if (all[1].entryKind === 'legacy-traffic') {
+      expect(all[1].method).toBe('pane.list');
+      expect(all[1].count).toBe(10);
+    }
+    if (all[2].entryKind === 'legacy-traffic') {
+      expect(all[2].method).toBe('events.poll');
+      expect(all[2].count).toBe(100);
+    }
   });
 
   it('swallows fs errors so shadow logging never breaks RPC dispatch', () => {

--- a/src/main/audit/legacyTrafficCounter.ts
+++ b/src/main/audit/legacyTrafficCounter.ts
@@ -1,0 +1,90 @@
+// LegacyTrafficCounter — per-method call counter for envelope-less RPCs
+// (Phase 2.2 pre-commit 4).
+//
+// Why: RpcRouter's pre-Phase-2.2 legacy bookkeeping was process-once — the
+// trust DB gets a single `legacy` row per process and that's it. Useful for
+// "did legacy traffic happen at all?" but useless for "which methods are
+// the biggest legacy hot-paths?" — exactly the question v3.1's user-facing
+// "your old plugins are calling these RPCs" panel needs answered.
+//
+// This counter accumulates per-method counts in memory and flushes milestones
+// (1st, 10th, 100th, 1000th, 10000th call) to the shadow audit log so v3.1
+// can build the surfacing UI on real data without needing a long-running
+// telemetry pipeline. Counts above the last milestone keep accumulating in
+// memory but stop emitting log entries (preventing log spam under heavy
+// legacy traffic) — the in-memory value can still be inspected via
+// `getCount`.
+//
+// Bounded: a hostile / pathological caller cycling through RPC methods
+// can't grow the counter map unboundedly. The map size is capped; once
+// at cap, additional method names are dropped on the floor.
+
+import type { RpcMethod } from '../../shared/rpc';
+
+/** Sink invoked when a method's count crosses a milestone threshold. */
+export type LegacyTrafficSink = (input: {
+  method: RpcMethod;
+  count: number;
+}) => void;
+
+/** Counts at which a sink call fires. Geometric so log spam stays bounded. */
+export const DEFAULT_MILESTONES: readonly number[] = [1, 10, 100, 1000, 10000];
+
+/**
+ * Cap on the number of distinct methods tracked. The wire surface is ~96
+ * methods today; a buggy or hostile caller fuzzing method names can't
+ * inflate the map past this. Excess methods are simply not recorded —
+ * acceptable since the counter is best-effort telemetry, not gating logic.
+ */
+export const MAX_TRACKED_METHODS = 256;
+
+export interface LegacyTrafficCounterOptions {
+  sink?: LegacyTrafficSink;
+  milestones?: readonly number[];
+  maxTrackedMethods?: number;
+}
+
+export class LegacyTrafficCounter {
+  private readonly counts = new Map<RpcMethod, number>();
+  private readonly sink: LegacyTrafficSink | undefined;
+  private readonly milestones: ReadonlySet<number>;
+  private readonly maxMethods: number;
+
+  constructor(options: LegacyTrafficCounterOptions = {}) {
+    this.sink = options.sink;
+    this.milestones = new Set(options.milestones ?? DEFAULT_MILESTONES);
+    this.maxMethods = options.maxTrackedMethods ?? MAX_TRACKED_METHODS;
+  }
+
+  /**
+   * Record one envelope-less call. If the resulting count is one of the
+   * configured milestones, fire the sink. Sink errors are swallowed —
+   * audit telemetry must never affect RPC throughput.
+   */
+  record(method: RpcMethod): void {
+    const existing = this.counts.get(method);
+    if (existing === undefined && this.counts.size >= this.maxMethods) {
+      // Tracked-method cap reached; drop this new method on the floor.
+      return;
+    }
+    const next = (existing ?? 0) + 1;
+    this.counts.set(method, next);
+    if (this.milestones.has(next) && this.sink) {
+      try {
+        this.sink({ method, count: next });
+      } catch {
+        /* swallow */
+      }
+    }
+  }
+
+  /** Test/observability helper. */
+  getCount(method: RpcMethod): number {
+    return this.counts.get(method) ?? 0;
+  }
+
+  /** Test helper — drops all state. */
+  reset(): void {
+    this.counts.clear();
+  }
+}

--- a/src/main/audit/shadowRejectionLog.ts
+++ b/src/main/audit/shadowRejectionLog.ts
@@ -1,0 +1,149 @@
+// Shadow rejection log — append-only JSONL file at
+// `~/.wmux/shadow-rejections.log` that captures what the Phase 2.2
+// permission enforcer WOULD have rejected during the v3.0 dogfood window
+// before enforcement flips on.
+//
+// Why a dedicated log, NOT a field on PluginIdentityRecord (plan D7 step 3):
+//   - PluginTrustStore caps the DB at MAX_PLUGIN_TRUST_ENTRIES = 1024 with
+//     LRU eviction. A hostile or buggy client that re-handshakes under
+//     fresh names could push real shadow evidence out of the trust DB
+//     before v3.1 ever reads it.
+//   - The trust DB is per-plugin-name; shadow evidence is per-call. Mixing
+//     them dilutes both. Better to keep the trust DB as user-curated state
+//     and put audit traffic in its own file.
+//
+// File format: JSONL (one JSON record per line). Easy to `tail -f`, easy
+// to ingest with `jq`, and the v3.1 surfacing UI can stream-parse it
+// without loading the whole file.
+//
+// Rotation: when the live file exceeds `maxBytes`, rename it to `.1` (over-
+// writing any previous backup) and start fresh. Single-generation rotation
+// — shadow telemetry is ephemeral, multi-generation backup chain is
+// over-engineering. If rename fails (Windows file-lock race), we truncate
+// to keep the file bounded; losing shadow data is preferable to growing
+// disk usage unbounded.
+//
+// Writes are SYNC (`appendFileSync`). Each shadow entry is <1 KB so the
+// fs hit is well under 1 ms — well below the noise floor of RPC dispatch.
+// All writes are wrapped in try/catch: shadow logging must NEVER affect
+// RPC throughput or surface errors to plugins.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { getWmuxHomeDir } from '../../shared/constants';
+import type { RpcMethod, RpcRejection } from '../../shared/rpc';
+
+export interface ShadowRejectionEntry {
+  /** Unix ms timestamp. */
+  ts: number;
+  /** Caller's declared clientName, or undefined for envelope-less callers. */
+  clientName: string | undefined;
+  /** RPC method that triggered the (would-be) rejection. */
+  method: RpcMethod;
+  /** The structured rejection the enforcer produced. */
+  rejection: RpcRejection;
+}
+
+export interface ShadowRejectionLoggerOptions {
+  /** Override the log file path (tests). Default: `~/.wmux/shadow-rejections.log`. */
+  path?: string;
+  /** Rotation threshold in bytes. Default: 1 MiB. */
+  maxBytes?: number;
+  /**
+   * Override the time source for deterministic tests. Default: Date.now.
+   * Production callers should NOT pass this — the live clock is the right
+   * source of truth for an audit log.
+   */
+  now?: () => number;
+}
+
+const DEFAULT_MAX_BYTES = 1024 * 1024;
+
+export class ShadowRejectionLogger {
+  private readonly filePath: string;
+  private readonly maxBytes: number;
+  private readonly now: () => number;
+
+  constructor(options: ShadowRejectionLoggerOptions = {}) {
+    this.filePath =
+      options.path ?? `${getWmuxHomeDir()}/shadow-rejections.log`;
+    this.maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+    this.now = options.now ?? Date.now;
+  }
+
+  /**
+   * Record a would-be rejection. Best-effort: any I/O failure is silently
+   * swallowed so the RPC dispatch loop is never penalised by a full disk,
+   * locked file, or missing parent directory.
+   */
+  append(input: {
+    clientName: string | undefined;
+    method: RpcMethod;
+    rejection: RpcRejection;
+  }): void {
+    const entry: ShadowRejectionEntry = {
+      ts: this.now(),
+      clientName: input.clientName,
+      method: input.method,
+      rejection: input.rejection,
+    };
+    try {
+      this.ensureDir();
+      this.rotateIfNeeded();
+      // JSONL: one record per line. JSON.stringify on a typed object never
+      // throws for our shape, so the try/catch above only covers fs errors.
+      fs.appendFileSync(this.filePath, JSON.stringify(entry) + '\n', {
+        encoding: 'utf8',
+      });
+    } catch {
+      // Swallow. Shadow telemetry must not affect RPC throughput.
+    }
+  }
+
+  /** Test-only: read the log back as parsed entries. */
+  readAll(): ShadowRejectionEntry[] {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this.filePath, 'utf8');
+    } catch {
+      return [];
+    }
+    const out: ShadowRejectionEntry[] = [];
+    for (const line of raw.split('\n')) {
+      if (line.length === 0) continue;
+      try {
+        out.push(JSON.parse(line) as ShadowRejectionEntry);
+      } catch {
+        // Tolerate partial writes / hand-edits: skip malformed lines.
+      }
+    }
+    return out;
+  }
+
+  private ensureDir(): void {
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+  }
+
+  private rotateIfNeeded(): void {
+    let size = 0;
+    try {
+      size = fs.statSync(this.filePath).size;
+    } catch {
+      return; // file doesn't exist yet — nothing to rotate
+    }
+    if (size < this.maxBytes) return;
+    const backupPath = `${this.filePath}.1`;
+    try {
+      fs.renameSync(this.filePath, backupPath);
+    } catch {
+      // Windows file-lock race or permissions issue. Truncate as fallback
+      // so the log doesn't grow forever; data loss is acceptable for
+      // shadow-mode audit.
+      try {
+        fs.truncateSync(this.filePath, 0);
+      } catch {
+        /* swallow */
+      }
+    }
+  }
+}

--- a/src/main/audit/shadowRejectionLog.ts
+++ b/src/main/audit/shadowRejectionLog.ts
@@ -33,7 +33,22 @@ import * as path from 'path';
 import { getWmuxHomeDir } from '../../shared/constants';
 import type { RpcMethod, RpcRejection } from '../../shared/rpc';
 
+/**
+ * Discriminated union of audit entries written to the shadow log. v3.0
+ * starts with two kinds:
+ *
+ *   - 'rejection'       — would-be permission rejection (shadow mode)
+ *   - 'legacy-traffic'  — per-method legacy (envelope-less) call counts,
+ *                          emitted at threshold milestones (1, 10, 100, ...)
+ *
+ * Read-back of pre-2.2-pre-commit-4 entries (no `entryKind` field) is not
+ * needed because this log is only meaningful inside a single dogfood
+ * window; rotation eats older entries. New entries always carry `entryKind`.
+ */
+export type ShadowAuditEntry = ShadowRejectionEntry | LegacyTrafficEntry;
+
 export interface ShadowRejectionEntry {
+  entryKind: 'rejection';
   /** Unix ms timestamp. */
   ts: number;
   /** Caller's declared clientName, or undefined for envelope-less callers. */
@@ -42,6 +57,18 @@ export interface ShadowRejectionEntry {
   method: RpcMethod;
   /** The structured rejection the enforcer produced. */
   rejection: RpcRejection;
+}
+
+/**
+ * Legacy traffic milestone — emitted by LegacyTrafficCounter when an
+ * envelope-less RPC method count crosses one of its threshold values.
+ * `count` is the running total at the moment the milestone fired.
+ */
+export interface LegacyTrafficEntry {
+  entryKind: 'legacy-traffic';
+  ts: number;
+  method: RpcMethod;
+  count: number;
 }
 
 export interface ShadowRejectionLoggerOptions {
@@ -81,12 +108,29 @@ export class ShadowRejectionLogger {
     method: RpcMethod;
     rejection: RpcRejection;
   }): void {
-    const entry: ShadowRejectionEntry = {
+    this.writeEntry({
+      entryKind: 'rejection',
       ts: this.now(),
       clientName: input.clientName,
       method: input.method,
       rejection: input.rejection,
-    };
+    });
+  }
+
+  /**
+   * Record a legacy-traffic milestone crossing. Same best-effort guarantees
+   * as `append`. Called by LegacyTrafficCounter at threshold counts.
+   */
+  appendLegacyTraffic(input: { method: RpcMethod; count: number }): void {
+    this.writeEntry({
+      entryKind: 'legacy-traffic',
+      ts: this.now(),
+      method: input.method,
+      count: input.count,
+    });
+  }
+
+  private writeEntry(entry: ShadowAuditEntry): void {
     try {
       this.ensureDir();
       this.rotateIfNeeded();
@@ -101,18 +145,18 @@ export class ShadowRejectionLogger {
   }
 
   /** Test-only: read the log back as parsed entries. */
-  readAll(): ShadowRejectionEntry[] {
+  readAll(): ShadowAuditEntry[] {
     let raw: string;
     try {
       raw = fs.readFileSync(this.filePath, 'utf8');
     } catch {
       return [];
     }
-    const out: ShadowRejectionEntry[] = [];
+    const out: ShadowAuditEntry[] = [];
     for (const line of raw.split('\n')) {
       if (line.length === 0) continue;
       try {
-        out.push(JSON.parse(line) as ShadowRejectionEntry);
+        out.push(JSON.parse(line) as ShadowAuditEntry);
       } catch {
         // Tolerate partial writes / hand-edits: skip malformed lines.
       }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,6 +34,8 @@ import { registerMcpPluginRpc } from './pipe/handlers/mcp.rpc';
 import { getPluginTrustStore } from './mcp/PluginTrustStore';
 import { ShadowRejectionLogger } from './audit/shadowRejectionLog';
 import { LegacyTrafficCounter } from './audit/legacyTrafficCounter';
+import { ApprovalQueue } from './mcp/ApprovalQueue';
+import { resolveEnforcementMode } from './mcp/enforcementMode';
 import { ClaudeWorker } from './a2a/ClaudeWorker';
 import { AutoUpdater } from './updater/AutoUpdater';
 import { McpRegistrar } from './mcp/McpRegistrar';
@@ -418,6 +420,46 @@ const legacyTrafficCounter = new LegacyTrafficCounter({
   },
 });
 rpcRouter.setLegacyTrafficCounter(legacyTrafficCounter);
+
+// Phase 2.2 pre-commit 6: enforcement mode + approval queue.
+// Production wmux defaults to `enforce`; dev (electron-forge / npm start)
+// defaults to `shadow` so a bad delta doesn't lock the developer out.
+// Override via `mcp.mode` in `~/.wmux/config.json`.
+const isDevEnvironment = !app.isPackaged || process.env.NODE_ENV === 'development';
+const enforcementMode = resolveEnforcementMode({ isDev: isDevEnvironment });
+rpcRouter.setEnforcementMode(enforcementMode);
+
+const approvalQueue = new ApprovalQueue(getPluginTrustStore(), {
+  openPrompt: (info) => {
+    const win = mainWindow;
+    if (!win || win.isDestroyed()) return;
+    try {
+      win.webContents.send(IPC.PERMISSION_PROMPT_OPEN, info);
+    } catch {
+      /* renderer might be mid-reload — the next request will surface */
+    }
+  },
+});
+rpcRouter.setApprovalQueue(approvalQueue);
+
+ipcMain.handle(
+  IPC.PERMISSION_PROMPT_RESOLVE,
+  async (_event, payload: { promptId: string; approved: boolean }) => {
+    if (
+      !payload ||
+      typeof payload.promptId !== 'string' ||
+      typeof payload.approved !== 'boolean'
+    ) {
+      return { ok: false, error: 'invalid permission prompt payload' };
+    }
+    await approvalQueue.resolvePrompt(payload.promptId, payload.approved);
+    return { ok: true };
+  },
+);
+
+console.log(
+  `[Main] Phase 2.2 enforcement mode: ${enforcementMode} (dev=${isDevEnvironment})`,
+);
 
 // IPC: webview CDP registration
 ipcMain.handle('browser:register-webview', async (_event, surfaceId: string, webContentsId: number) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -33,6 +33,7 @@ import { registerEventsRpc } from './pipe/handlers/events.rpc';
 import { registerMcpPluginRpc } from './pipe/handlers/mcp.rpc';
 import { getPluginTrustStore } from './mcp/PluginTrustStore';
 import { ShadowRejectionLogger } from './audit/shadowRejectionLog';
+import { LegacyTrafficCounter } from './audit/legacyTrafficCounter';
 import { ClaudeWorker } from './a2a/ClaudeWorker';
 import { AutoUpdater } from './updater/AutoUpdater';
 import { McpRegistrar } from './mcp/McpRegistrar';
@@ -406,6 +407,17 @@ rpcRouter.setTrustLookup((clientName) =>
 rpcRouter.setShadowRejectionSink((entry) => {
   shadowRejectionLogger.append(entry);
 });
+
+// Per-method legacy traffic counter (Phase 2.2 pre-commit 4). Milestone
+// crossings (1st, 10th, 100th, 1000th, 10000th call) emit a summary row to
+// the shadow audit log. The trust-DB write above remains process-once and
+// independent — this counter is purely audit telemetry.
+const legacyTrafficCounter = new LegacyTrafficCounter({
+  sink: ({ method, count }) => {
+    shadowRejectionLogger.appendLegacyTraffic({ method, count });
+  },
+});
+rpcRouter.setLegacyTrafficCounter(legacyTrafficCounter);
 
 // IPC: webview CDP registration
 ipcMain.handle('browser:register-webview', async (_event, surfaceId: string, webContentsId: number) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,6 +32,7 @@ import { registerCompanyRpc } from './pipe/handlers/company.rpc';
 import { registerEventsRpc } from './pipe/handlers/events.rpc';
 import { registerMcpPluginRpc } from './pipe/handlers/mcp.rpc';
 import { getPluginTrustStore } from './mcp/PluginTrustStore';
+import { ShadowRejectionLogger } from './audit/shadowRejectionLog';
 import { ClaudeWorker } from './a2a/ClaudeWorker';
 import { AutoUpdater } from './updater/AutoUpdater';
 import { McpRegistrar } from './mcp/McpRegistrar';
@@ -392,6 +393,18 @@ rpcRouter.setLegacyContactRecorder(() => {
     .catch(() => {
       /* trust-store writes are best-effort; never block RPC */
     });
+});
+
+// Phase 2.2 enforcement substrate (shadow mode). Trust lookups consult the
+// existing plugin-trust.json store; would-be rejections are appended to
+// `~/.wmux/shadow-rejections.log` for the v3.0 dogfood window before the
+// pre-commit-6 flip turns rejections into hard RPC failures.
+const shadowRejectionLogger = new ShadowRejectionLogger();
+rpcRouter.setTrustLookup((clientName) =>
+  getPluginTrustStore().get(clientName),
+);
+rpcRouter.setShadowRejectionSink((entry) => {
+  shadowRejectionLogger.append(entry);
 });
 
 // IPC: webview CDP registration

--- a/src/main/mcp/ApprovalQueue.ts
+++ b/src/main/mcp/ApprovalQueue.ts
@@ -1,0 +1,226 @@
+// ApprovalQueue — debounced + deduplicated user-approval orchestrator for
+// Phase 2.2 enforcement (plan D7 step 5).
+//
+// Pre-commit 5 ships the queue in isolation (no RpcRouter wiring, no
+// renderer IPC plumbing). Pre-commit 6 will:
+//   - Call `requestApproval(...)` from RpcRouter.dispatch when the
+//     enforcer rejects with status='unconfirmed', threading the returned
+//     `promptId` into the RpcRejection's `pendingApproval` slot.
+//   - Wire an IPC callback so renderer's PermissionApprovalDialog can
+//     resolve a prompt via `resolvePrompt(promptId, approved)`.
+//
+// Dedupe model (plan D4): a request is a `(clientName, hash(sorted
+// declaredCapabilities))` pair. Two RPCs from the same plugin landing
+// while a prompt is open coalesce onto the same prompt — the user only
+// sees one modal regardless of how many concurrent RPCs are racing in.
+// When the user resolves it, every coalesced caller gets the same answer.
+//
+// Persistence: on resolve, the queue writes the user's decision through
+// PluginTrustStore.setUserDecision so the next prompt for the same plugin
+// reads the persisted state (and the enforcer can short-circuit denied
+// plugins without ever surfacing another modal).
+
+import { createHash } from 'node:crypto';
+import type { PluginIdentityRecord } from '../../shared/rpc';
+import type { PluginTrustStore } from './PluginTrustStore';
+
+/**
+ * Information about a pending prompt that gets shipped to the renderer to
+ * drive the dialog. Plain JSON-serialisable so it can ride over IPC.
+ */
+export interface ApprovalPromptInfo {
+  promptId: string;
+  clientName: string;
+  declaredCapabilities: string[];
+  rationale?: string;
+}
+
+/** Callback the queue invokes when a fresh prompt should appear on screen. */
+export type ApprovalPromptOpener = (info: ApprovalPromptInfo) => void;
+
+/** Resolution shape returned to every coalesced caller. */
+export interface ApprovalResult {
+  approved: boolean;
+  promptId: string;
+  /** The trust record after persistence. Undefined if the persistence write failed. */
+  identity: PluginIdentityRecord | undefined;
+}
+
+interface PendingPrompt {
+  promptId: string;
+  clientName: string;
+  declaredCapabilities: string[];
+  rationale: string | undefined;
+  /** All waiters coalesced onto this prompt — each gets the same outcome. */
+  resolvers: ((r: ApprovalResult) => void)[];
+  rejecters: ((err: Error) => void)[];
+}
+
+export interface ApprovalQueueOptions {
+  /**
+   * Called to notify the renderer that a fresh prompt should appear. The
+   * queue does NOT block on this — duplicates from the same caller are
+   * dropped so the renderer dialog only opens once per dedupe key.
+   */
+  openPrompt: ApprovalPromptOpener;
+  /**
+   * Optional override for the prompt-id factory (test determinism). Default
+   * uses crypto.randomUUID().
+   */
+  mintPromptId?: () => string;
+}
+
+function hashCapabilities(caps: readonly string[]): string {
+  // Sort first so order doesn't change the key. Capabilities are short
+  // strings; SHA-256 is overkill but keeps the substring set deterministic
+  // and adversary-proof. Truncate to 16 hex chars (8 bytes) — collision
+  // probability against the ~50 entry cap on the trust DB is negligible.
+  const sorted = [...caps].sort();
+  return createHash('sha256').update(sorted.join('\n')).digest('hex').slice(0, 16);
+}
+
+function dedupKey(clientName: string, caps: readonly string[]): string {
+  return `${clientName}::${hashCapabilities(caps)}`;
+}
+
+function defaultMintPromptId(): string {
+  // Lazy import so unit tests in environments without webcrypto still work.
+  // Node 20+ has globalThis.crypto.randomUUID by default.
+  return (globalThis.crypto?.randomUUID?.() ?? `prompt-${Math.random().toString(36).slice(2, 12)}`);
+}
+
+export class ApprovalQueue {
+  private readonly inflight = new Map<string, PendingPrompt>();
+  private readonly byPromptId = new Map<string, string>(); // promptId → dedupKey
+  private readonly openPrompt: ApprovalPromptOpener;
+  private readonly mintPromptId: () => string;
+  private readonly trustStore: PluginTrustStore;
+
+  constructor(trustStore: PluginTrustStore, options: ApprovalQueueOptions) {
+    this.trustStore = trustStore;
+    this.openPrompt = options.openPrompt;
+    this.mintPromptId = options.mintPromptId ?? defaultMintPromptId;
+  }
+
+  /**
+   * Request user approval for a (clientName, declaredCapabilities) pair.
+   * Returns a promise that resolves once the user clicks Approve/Deny
+   * (possibly via another concurrent caller's prompt — see dedupe above).
+   *
+   * Multiple inflight calls with the same dedupe key share a prompt; the
+   * renderer only sees one modal.
+   */
+  requestApproval(input: {
+    clientName: string;
+    declaredCapabilities: readonly string[];
+    rationale?: string;
+  }): Promise<ApprovalResult> {
+    const key = dedupKey(input.clientName, input.declaredCapabilities);
+    const existing = this.inflight.get(key);
+    if (existing) {
+      return new Promise<ApprovalResult>((resolve, reject) => {
+        existing.resolvers.push(resolve);
+        existing.rejecters.push(reject);
+      });
+    }
+    const promptId = this.mintPromptId();
+    const pending: PendingPrompt = {
+      promptId,
+      clientName: input.clientName,
+      declaredCapabilities: [...input.declaredCapabilities],
+      rationale: input.rationale,
+      resolvers: [],
+      rejecters: [],
+    };
+    this.inflight.set(key, pending);
+    this.byPromptId.set(promptId, key);
+    const promise = new Promise<ApprovalResult>((resolve, reject) => {
+      pending.resolvers.push(resolve);
+      pending.rejecters.push(reject);
+    });
+    // Fire the opener. Failures here MUST NOT throw past the queue —
+    // a renderer that's mid-shutdown can drop the IPC; subsequent calls
+    // for the same key continue to coalesce and will receive whatever
+    // resolution arrives. If the renderer never resolves, all callers
+    // hang — that's the same failure mode as any IPC RPC.
+    try {
+      this.openPrompt({
+        promptId,
+        clientName: input.clientName,
+        declaredCapabilities: [...input.declaredCapabilities],
+        rationale: input.rationale,
+      });
+    } catch {
+      /* swallow — best-effort renderer notification */
+    }
+    return promise;
+  }
+
+  /**
+   * Resolve a prompt with the user's decision. Persists the decision to
+   * the trust DB, then fans out the resolution to every coalesced caller.
+   * Idempotent — a duplicate resolve (e.g. user clicks twice, or renderer
+   * re-sends) is a no-op.
+   */
+  async resolvePrompt(promptId: string, approved: boolean): Promise<void> {
+    const key = this.byPromptId.get(promptId);
+    if (!key) return; // already resolved (or never existed)
+    const pending = this.inflight.get(key);
+    if (!pending) return;
+    this.byPromptId.delete(promptId);
+    this.inflight.delete(key);
+
+    let identity: PluginIdentityRecord | undefined;
+    try {
+      identity = await this.trustStore.setUserDecision(
+        pending.clientName,
+        approved ? 'trusted' : 'denied',
+      );
+    } catch {
+      // Trust-DB write failed — still resolve the waiters so they don't
+      // hang. The next RPC from this plugin will re-trigger the enforcer
+      // (which will check the in-disk state — which didn't change).
+    }
+    const result: ApprovalResult = {
+      approved,
+      promptId,
+      identity,
+    };
+    // Snapshot the resolvers before fanning out so a re-entrant call into
+    // requestApproval from a resolver can't see the cleared state.
+    for (const r of pending.resolvers) {
+      try {
+        r(result);
+      } catch {
+        /* swallow — one bad waiter must not affect the others */
+      }
+    }
+  }
+
+  /**
+   * Cancel a prompt (e.g. plugin disconnected before the user clicked).
+   * Every coalesced caller receives a rejection. The trust DB is NOT
+   * touched — the user never made a decision.
+   */
+  cancelPrompt(promptId: string, reason: string): void {
+    const key = this.byPromptId.get(promptId);
+    if (!key) return;
+    const pending = this.inflight.get(key);
+    if (!pending) return;
+    this.byPromptId.delete(promptId);
+    this.inflight.delete(key);
+    const err = new Error(`Approval prompt cancelled: ${reason}`);
+    for (const r of pending.rejecters) {
+      try {
+        r(err);
+      } catch {
+        /* swallow */
+      }
+    }
+  }
+
+  /** Test/observability helper. */
+  inflightCount(): number {
+    return this.inflight.size;
+  }
+}

--- a/src/main/mcp/ApprovalQueue.ts
+++ b/src/main/mcp/ApprovalQueue.ts
@@ -46,6 +46,18 @@ export interface ApprovalResult {
   identity: PluginIdentityRecord | undefined;
 }
 
+/**
+ * Return shape of `requestApproval`. The promptId is available
+ * synchronously so the RpcRouter dispatch path can thread it into the
+ * `pendingApproval.promptId` slot of an identity-status rejection without
+ * awaiting the user's decision. The `resolution` promise resolves when the
+ * user clicks Approve/Deny (or cancellation rejects it).
+ */
+export interface ApprovalHandle {
+  promptId: string;
+  resolution: Promise<ApprovalResult>;
+}
+
 interface PendingPrompt {
   promptId: string;
   clientName: string;
@@ -104,24 +116,33 @@ export class ApprovalQueue {
 
   /**
    * Request user approval for a (clientName, declaredCapabilities) pair.
-   * Returns a promise that resolves once the user clicks Approve/Deny
-   * (possibly via another concurrent caller's prompt — see dedupe above).
+   *
+   * Returns an `ApprovalHandle` with:
+   *   - `promptId` (synchronously available): the dispatcher threads this
+   *     into the `pendingApproval.promptId` slot of the identity-status
+   *     rejection so the client can correlate the response with the
+   *     eventual approve/deny decision.
+   *   - `resolution`: a promise that resolves once the user clicks
+   *     Approve/Deny (possibly via another concurrent caller's prompt —
+   *     see dedupe above).
    *
    * Multiple inflight calls with the same dedupe key share a prompt; the
-   * renderer only sees one modal.
+   * renderer only sees one modal. Coalesced callers receive identical
+   * `promptId`s and the same eventual resolution.
    */
   requestApproval(input: {
     clientName: string;
     declaredCapabilities: readonly string[];
     rationale?: string;
-  }): Promise<ApprovalResult> {
+  }): ApprovalHandle {
     const key = dedupKey(input.clientName, input.declaredCapabilities);
     const existing = this.inflight.get(key);
     if (existing) {
-      return new Promise<ApprovalResult>((resolve, reject) => {
+      const resolution = new Promise<ApprovalResult>((resolve, reject) => {
         existing.resolvers.push(resolve);
         existing.rejecters.push(reject);
       });
+      return { promptId: existing.promptId, resolution };
     }
     const promptId = this.mintPromptId();
     const pending: PendingPrompt = {
@@ -134,7 +155,7 @@ export class ApprovalQueue {
     };
     this.inflight.set(key, pending);
     this.byPromptId.set(promptId, key);
-    const promise = new Promise<ApprovalResult>((resolve, reject) => {
+    const resolution = new Promise<ApprovalResult>((resolve, reject) => {
       pending.resolvers.push(resolve);
       pending.rejecters.push(reject);
     });
@@ -153,7 +174,7 @@ export class ApprovalQueue {
     } catch {
       /* swallow — best-effort renderer notification */
     }
-    return promise;
+    return { promptId, resolution };
   }
 
   /**

--- a/src/main/mcp/PermissionEnforcer.ts
+++ b/src/main/mcp/PermissionEnforcer.ts
@@ -1,0 +1,347 @@
+// PermissionEnforcer — pure-function permission gate for the Phase 2.2
+// enforcement layer. Given a method, params, request context, and the
+// caller's trust record, returns one of:
+//
+//   - { kind: 'allow' }
+//       Capability declared and (if applicable) every requested path is
+//       covered by the declaration. Handler runs as normal.
+//
+//   - { kind: 'reject'; rejection: RpcRejection }
+//       Either the capability wasn't declared, every requested path was
+//       rejected, the trust state forbids it (denied / unconfirmed), or
+//       a multi-path method in 'all-or-nothing' mode had any path fail.
+//       Caller MUST NOT invoke the handler.
+//
+//   - { kind: 'partial'; allowedPaths: string[]; rejection: RpcRejection }
+//       Multi-path method in 'partial' mode where some paths matched and
+//       some didn't. Dispatcher passes `allowedPaths` to the handler
+//       (rewriting params if needed) and attaches the `rejection` field
+//       (the `paths-partially-allowed` variant) to the success response
+//       so the client knows what was filtered. See plan D3 for the wire
+//       contract — Pre-commit 2 wires `rejection` into the RpcResponse
+//       `ok: true` arm to carry this case.
+//
+// Design notes (plan D1, D4):
+//   - Pure function. No I/O, no time, no side effects. Trust state is read
+//     once upstream and passed in. This makes the enforcer trivially
+//     unit-testable and means the same function runs in both shadow mode
+//     (log the rejection) and enforce mode (return the rejection).
+//   - Identity-bootstrap RPCs (mcp.identify / mcp.declarePermissions) carry
+//     `capability: null` in methodCapabilityMap; the enforcer recognises
+//     this and allows unconditionally. NO hard-coded special-case here.
+//   - `legacy` status (no clientName envelope upstream) is allowed and
+//     recorded by the shadow log in Pre-commit 3+4. The enforcer treats it
+//     as 'allow' so substrate ships without breaking v2.x callers.
+//   - `denied` is rejected with no pendingApproval (spec §4.3: denied
+//     never regresses). User must edit plugin-trust.json by hand.
+//   - `unconfirmed` is rejected with `pendingApproval` so the client can
+//     retry once the user approves. The `promptId` is filled in by the
+//     ApprovalQueue at dispatch time (Pre-commit 5), not here — the
+//     enforcer returns it as `undefined` and the dispatcher overwrites.
+
+import type {
+  PluginIdentityRecord,
+  RpcContext,
+  RpcMethod,
+  RpcRejection,
+} from '../../shared/rpc';
+import {
+  METHOD_CAPABILITY,
+  type PathExtractor,
+  type RequiredCapability,
+} from './methodCapabilityMap';
+import {
+  parsePermission,
+  type ParsedPermission,
+} from './permissionGrammar';
+
+export type EnforcerOutcome =
+  | { kind: 'allow' }
+  | { kind: 'reject'; rejection: RpcRejection }
+  | {
+      kind: 'partial';
+      allowedPaths: string[];
+      rejection: Extract<RpcRejection, { reason: 'paths-partially-allowed' }>;
+    };
+
+export interface EnforcerInput {
+  method: RpcMethod;
+  params: Record<string, unknown>;
+  ctx: RpcContext;
+  /** Trust record for `ctx.clientName`, or `undefined` if none exists. */
+  trust: PluginIdentityRecord | undefined;
+}
+
+/**
+ * Result of looking up matching declared permissions for a (capability,
+ * trust-record) pair. `unrestricted` means at least one declaration was for
+ * the capability with no `:glob` (broadest grant). `scoped` carries each
+ * declaration's pathRegex + glob string for path matching.
+ */
+interface CapabilityGrant {
+  unrestricted: boolean;
+  scoped: { pathGlob: string; pathRegex: RegExp }[];
+}
+
+function findCapabilityGrant(
+  trust: PluginIdentityRecord | undefined,
+  capability: string,
+): CapabilityGrant {
+  const grant: CapabilityGrant = { unrestricted: false, scoped: [] };
+  if (!trust || !trust.declaredCapabilities) return grant;
+  for (const raw of trust.declaredCapabilities) {
+    const parsed = parsePermission(raw);
+    if (!parsed.ok) continue; // malformed declarations can't grant anything
+    const p: ParsedPermission = parsed.permission;
+    if (p.capability !== capability) continue;
+    if (!p.pathGlob || !p.pathRegex) {
+      grant.unrestricted = true;
+    } else {
+      grant.scoped.push({ pathGlob: p.pathGlob, pathRegex: p.pathRegex });
+    }
+  }
+  return grant;
+}
+
+function declaredGlobsFromGrant(grant: CapabilityGrant): string[] {
+  // For surfacing "what you declared" in rejections. Unrestricted is
+  // represented by the capability name alone (no glob suffix).
+  const out: string[] = [];
+  if (grant.unrestricted) out.push('(no glob — unrestricted)');
+  for (const s of grant.scoped) out.push(s.pathGlob);
+  return out;
+}
+
+function hasAnyDeclarationFor(grant: CapabilityGrant): boolean {
+  return grant.unrestricted || grant.scoped.length > 0;
+}
+
+function pathAllowed(grant: CapabilityGrant, path: string): boolean {
+  if (grant.unrestricted) return true;
+  for (const s of grant.scoped) {
+    if (s.pathRegex.test(path)) return true;
+  }
+  return false;
+}
+
+function extractPaths(
+  extractor: PathExtractor,
+  params: Record<string, unknown>,
+): string | string[] | undefined | 'handler-resolves' {
+  if (extractor === 'handler-resolves') return 'handler-resolves';
+  return extractor(params);
+}
+
+/**
+ * Main entry. Returns the outcome the dispatcher should act on.
+ */
+export function check(input: EnforcerInput): EnforcerOutcome {
+  const entry: RequiredCapability | undefined = METHOD_CAPABILITY[input.method];
+
+  // Totality safety net: `Record<RpcMethod, ...>` makes this branch
+  // statically unreachable, but a future map edit could leave a hole and
+  // we'd rather close-fail than open-fail. Surface the gap to shadow logs.
+  if (!entry) {
+    return {
+      kind: 'reject',
+      rejection: {
+        reason: 'capability-not-declared',
+        method: input.method,
+        capability: '(unmapped — methodCapabilityMap missing entry)',
+      },
+    };
+  }
+
+  // Identity bootstrap (mcp.identify / mcp.declarePermissions / system.*) —
+  // no capability needed regardless of trust state.
+  if (entry.capability === null) {
+    return { kind: 'allow' };
+  }
+
+  // Legacy: caller didn't send a clientName envelope, RpcRouter is already
+  // grandfathering them via the legacy recorder. Allow at this layer.
+  if (!input.ctx.clientName) {
+    return { kind: 'allow' };
+  }
+
+  // Plugin self-named but isn't in the trust DB yet. Treat as unconfirmed —
+  // they need to call mcp.identify + mcp.declarePermissions first. The
+  // ApprovalQueue can't generate a prompt because there's nothing declared,
+  // so `pendingApproval` is omitted and the human-readable error tells
+  // the plugin author what to do.
+  if (!input.trust) {
+    return {
+      kind: 'reject',
+      rejection: {
+        reason: 'identity-status',
+        method: input.method,
+        capability: entry.capability,
+        status: 'unconfirmed',
+        // No pendingApproval — the plugin hasn't declared yet.
+      },
+    };
+  }
+
+  // Trust-state ladder (plan D4).
+  if (input.trust.status === 'denied') {
+    return {
+      kind: 'reject',
+      rejection: {
+        reason: 'identity-status',
+        method: input.method,
+        capability: entry.capability,
+        status: 'denied',
+        // spec §4.3: denied never regresses, no pendingApproval offered
+      },
+    };
+  }
+  if (input.trust.status === 'unconfirmed') {
+    return {
+      kind: 'reject',
+      rejection: {
+        reason: 'identity-status',
+        method: input.method,
+        capability: entry.capability,
+        status: 'unconfirmed',
+        // ApprovalQueue (Pre-commit 5) overwrites this with a real promptId
+        // at dispatch time. Enforcer is pure — it doesn't mint IDs.
+      },
+    };
+  }
+  if (input.trust.status === 'legacy') {
+    // Grandfathered. Shadow log records it (Pre-commit 4).
+    return { kind: 'allow' };
+  }
+
+  // status === 'trusted'. Capability declaration must include this entry's
+  // capability. Reserved 'wmux.internal' can never appear in a declaration
+  // (RESERVED_PREFIXES in permissionGrammar rejects it at declaration time)
+  // so internal methods always fall through to capability-not-declared here.
+  const grant = findCapabilityGrant(input.trust, entry.capability);
+  if (!hasAnyDeclarationFor(grant)) {
+    return {
+      kind: 'reject',
+      rejection: {
+        reason: 'capability-not-declared',
+        method: input.method,
+        capability: entry.capability,
+      },
+    };
+  }
+
+  // Capability matched. Now check the path (if applicable).
+  if (!entry.pathFromParams) {
+    return { kind: 'allow' };
+  }
+
+  const extracted = extractPaths(entry.pathFromParams, input.params);
+  if (extracted === 'handler-resolves') {
+    // Handler will call PermissionEnforcer.checkPath itself. The capability
+    // check has passed; allow at this layer.
+    return { kind: 'allow' };
+  }
+  if (extracted === undefined) {
+    // No path payload to check (e.g. setMetadata with no fields populated —
+    // a no-op that the handler still validates against schema). Allow.
+    return { kind: 'allow' };
+  }
+
+  // Normalise to array for unified loop. Track single-vs-multi for the
+  // rejection variant choice.
+  const isSingle = typeof extracted === 'string';
+  const paths: string[] = isSingle ? [extracted] : extracted;
+
+  const allowed: string[] = [];
+  const rejected: { path: string; declared: string[] }[] = [];
+  const declaredGlobs = declaredGlobsFromGrant(grant);
+  for (const p of paths) {
+    if (pathAllowed(grant, p)) allowed.push(p);
+    else rejected.push({ path: p, declared: declaredGlobs });
+  }
+
+  if (rejected.length === 0) return { kind: 'allow' };
+
+  // Single-path method: wholesale reject with the simpler variant.
+  if (isSingle) {
+    const r = rejected[0];
+    return {
+      kind: 'reject',
+      rejection: {
+        reason: 'path-not-allowed',
+        method: input.method,
+        capability: entry.capability,
+        path: r.path,
+        declared: r.declared,
+      },
+    };
+  }
+
+  // Multi-path method. Behavior depends on the method's mode (plan D2).
+  const mode = entry.multiPathMode ?? 'all-or-nothing';
+  if (mode === 'all-or-nothing' || allowed.length === 0) {
+    // For 'all-or-nothing' OR when nothing was allowed (no partial benefit
+    // anyway), reject wholesale with the partial-rejection shape so the
+    // client still sees per-path detail.
+    return {
+      kind: 'reject',
+      rejection: {
+        reason: 'paths-partially-allowed',
+        method: input.method,
+        capability: entry.capability,
+        allowed,
+        rejected,
+      },
+    };
+  }
+
+  // mode === 'partial' and at least one path was allowed: caller proceeds
+  // with the allowed subset, response carries the rejection detail.
+  return {
+    kind: 'partial',
+    allowedPaths: allowed,
+    rejection: {
+      reason: 'paths-partially-allowed',
+      method: input.method,
+      capability: entry.capability,
+      allowed,
+      rejected,
+    },
+  };
+}
+
+/**
+ * Handler-side path check, for methods declared `pathFromParams:
+ * 'handler-resolves'`. Pure function; the handler resolves whatever state
+ * it needs (paneId → workspaceId → owning plugin) and calls this with the
+ * final path string. Returns the same outcome shape as `check` for a
+ * single-path case (never returns 'partial').
+ */
+export function checkPath(
+  trust: PluginIdentityRecord,
+  method: RpcMethod,
+  capability: string,
+  path: string,
+): EnforcerOutcome {
+  const grant = findCapabilityGrant(trust, capability);
+  if (!hasAnyDeclarationFor(grant)) {
+    return {
+      kind: 'reject',
+      rejection: {
+        reason: 'capability-not-declared',
+        method,
+        capability,
+      },
+    };
+  }
+  if (pathAllowed(grant, path)) return { kind: 'allow' };
+  return {
+    kind: 'reject',
+    rejection: {
+      reason: 'path-not-allowed',
+      method,
+      capability,
+      path,
+      declared: declaredGlobsFromGrant(grant),
+    },
+  };
+}

--- a/src/main/mcp/PluginTrustStore.ts
+++ b/src/main/mcp/PluginTrustStore.ts
@@ -252,6 +252,43 @@ export class PluginTrustStore {
     });
   }
 
+  /**
+   * Record an explicit user decision from the approval dialog (Phase 2.2
+   * pre-commit 5). The user has clicked Approve or Deny against a specific
+   * `(clientName, declaredCapabilities)` pair; that decision MUST stick:
+   *
+   *   - 'trusted' — bypasses applyContact/applyDeclaration's auto-demotion
+   *     since the user explicitly approved the current declaration. If no
+   *     record exists yet (a prompt that fired before mcp.identify
+   *     landed), seed a minimal trusted entry.
+   *   - 'denied' — spec §4.3 "denied never regresses". The next
+   *     applyContact or applyDeclaration call will read this status and
+   *     refuse to upgrade away from it.
+   *
+   * `lastSeen` advances. `declaredCapabilities` are NOT overwritten — the
+   * decision applies to whatever set was active when the user clicked.
+   */
+  async setUserDecision(
+    name: string,
+    status: 'trusted' | 'denied',
+  ): Promise<PluginIdentityRecord> {
+    const safeName = clampName(name);
+    return this.mutate((db) => {
+      const existing = ownPlugin(db, safeName);
+      const t = Date.now();
+      const next: PluginIdentityRecord = existing
+        ? { ...existing, status, lastSeen: t }
+        : {
+            name: safeName,
+            status,
+            firstSeen: t,
+            lastSeen: t,
+          };
+      db.plugins[safeName] = next;
+      return next;
+    });
+  }
+
   // Record an RPC call that arrived without a clientName envelope.
   // Pre-v2.10 callers and the wmux-bundled MCP server's pre-handshake RPCs
   // land here. Status is `legacy` on first contact and refreshes via

--- a/src/main/mcp/__tests__/ApprovalQueue.test.ts
+++ b/src/main/mcp/__tests__/ApprovalQueue.test.ts
@@ -40,19 +40,29 @@ afterEach(() => {
 });
 
 describe('ApprovalQueue.requestApproval', () => {
-  it('opens a prompt and resolves on approve', async () => {
+  it('opens a prompt and exposes promptId synchronously', () => {
     const queue = makeQueue();
-    const p = queue.requestApproval({
+    const handle = queue.requestApproval({
       clientName: 'plugin-a',
       declaredCapabilities: ['pane.read'],
     });
+    // promptId available BEFORE the user clicks anything — this is what
+    // RpcRouter threads into rejection.pendingApproval.
+    expect(handle.promptId).toBe('prompt-1');
     expect(opened).toHaveLength(1);
     expect(opened[0].promptId).toBe('prompt-1');
     expect(opened[0].clientName).toBe('plugin-a');
     expect(opened[0].declaredCapabilities).toEqual(['pane.read']);
+  });
 
-    await queue.resolvePrompt('prompt-1', true);
-    const result = await p;
+  it('resolves with trusted status on approve', async () => {
+    const queue = makeQueue();
+    const handle = queue.requestApproval({
+      clientName: 'plugin-a',
+      declaredCapabilities: ['pane.read'],
+    });
+    await queue.resolvePrompt(handle.promptId, true);
+    const result = await handle.resolution;
     expect(result.approved).toBe(true);
     expect(result.promptId).toBe('prompt-1');
     expect(result.identity?.status).toBe('trusted');
@@ -61,31 +71,30 @@ describe('ApprovalQueue.requestApproval', () => {
 
   it('persists denied status (spec §4.3)', async () => {
     const queue = makeQueue();
-    const p = queue.requestApproval({
+    const handle = queue.requestApproval({
       clientName: 'plugin-b',
       declaredCapabilities: ['terminal.read'],
     });
-    await queue.resolvePrompt('prompt-1', false);
-    const result = await p;
+    await queue.resolvePrompt(handle.promptId, false);
+    const result = await handle.resolution;
     expect(result.approved).toBe(false);
     expect(result.identity?.status).toBe('denied');
 
-    // Subsequent reads see the denied state on disk.
     const onDisk = JSON.parse(fs.readFileSync(dbPath, 'utf8'));
     expect(onDisk.plugins['plugin-b'].status).toBe('denied');
   });
 
   it('dedupes concurrent requests with identical (clientName, capabilities)', async () => {
     const queue = makeQueue();
-    const p1 = queue.requestApproval({
+    const h1 = queue.requestApproval({
       clientName: 'plugin-c',
       declaredCapabilities: ['pane.read', 'meta.read'],
     });
-    const p2 = queue.requestApproval({
+    const h2 = queue.requestApproval({
       clientName: 'plugin-c',
       declaredCapabilities: ['pane.read', 'meta.read'],
     });
-    const p3 = queue.requestApproval({
+    const h3 = queue.requestApproval({
       clientName: 'plugin-c',
       // Same set in different order — still same dedupe key.
       declaredCapabilities: ['meta.read', 'pane.read'],
@@ -94,17 +103,23 @@ describe('ApprovalQueue.requestApproval', () => {
     // Only one prompt opened despite three requestApproval calls.
     expect(opened).toHaveLength(1);
     expect(queue.inflightCount()).toBe(1);
+    // All three handles share the same promptId.
+    expect(h1.promptId).toBe('prompt-1');
+    expect(h2.promptId).toBe('prompt-1');
+    expect(h3.promptId).toBe('prompt-1');
 
     await queue.resolvePrompt('prompt-1', true);
-    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+    const [r1, r2, r3] = await Promise.all([
+      h1.resolution,
+      h2.resolution,
+      h3.resolution,
+    ]);
     expect(r1.approved).toBe(true);
     expect(r2.approved).toBe(true);
     expect(r3.approved).toBe(true);
-    expect(r1.promptId).toBe(r2.promptId);
-    expect(r2.promptId).toBe(r3.promptId);
   });
 
-  it('treats different capability sets as different prompts', async () => {
+  it('treats different capability sets as different prompts', () => {
     const queue = makeQueue();
     queue.requestApproval({
       clientName: 'plugin-d',
@@ -119,7 +134,7 @@ describe('ApprovalQueue.requestApproval', () => {
     expect(queue.inflightCount()).toBe(2);
   });
 
-  it('treats different plugin names as different prompts', async () => {
+  it('treats different plugin names as different prompts', () => {
     const queue = makeQueue();
     queue.requestApproval({
       clientName: 'plugin-e',
@@ -139,26 +154,21 @@ describe('ApprovalQueue.requestApproval', () => {
       },
       mintPromptId: mintId,
     });
-    const p = queue.requestApproval({
+    const handle = queue.requestApproval({
       clientName: 'plugin-g',
       declaredCapabilities: ['pane.read'],
     });
-    // Promise must still be pending — the queue is still tracking it.
+    expect(handle.promptId).toBe('prompt-1');
     expect(queue.inflightCount()).toBe(1);
-    await queue.resolvePrompt('prompt-1', true);
-    const result = await p;
+    await queue.resolvePrompt(handle.promptId, true);
+    const result = await handle.resolution;
     expect(result.approved).toBe(true);
   });
 
   it('keeps coalesced waiters whole when the trust-store write fails', async () => {
-    // Point the store at an unwritable location to force setUserDecision throw.
     const badStore = new PluginTrustStore(
       path.join(tmpDir, 'no-such-dir', 'plugin-trust.json'),
     );
-    // Try a write to ensure subsequent ones also fail (atomicWriteJSON throws
-    // when the parent dir can't be created — but we mkdir via ensureWmuxHomeDir
-    // which targets a fixed path. To force a failure deterministically, stub
-    // setUserDecision.
     const stubbed = badStore as unknown as {
       setUserDecision: () => Promise<never>;
     };
@@ -170,14 +180,12 @@ describe('ApprovalQueue.requestApproval', () => {
       openPrompt: (info) => opened.push(info),
       mintPromptId: mintId,
     });
-    const p = queue.requestApproval({
+    const handle = queue.requestApproval({
       clientName: 'plugin-h',
       declaredCapabilities: ['pane.read'],
     });
-    await queue.resolvePrompt('prompt-1', true);
-    const result = await p;
-    // Approved decision is communicated to the waiter; identity is
-    // undefined because the persistence write failed.
+    await queue.resolvePrompt(handle.promptId, true);
+    const result = await handle.resolution;
     expect(result.approved).toBe(true);
     expect(result.identity).toBeUndefined();
   });
@@ -186,18 +194,20 @@ describe('ApprovalQueue.requestApproval', () => {
 describe('ApprovalQueue.resolvePrompt', () => {
   it('is a no-op for unknown promptIds', async () => {
     const queue = makeQueue();
-    await expect(queue.resolvePrompt('does-not-exist', true)).resolves.toBeUndefined();
+    await expect(
+      queue.resolvePrompt('does-not-exist', true),
+    ).resolves.toBeUndefined();
   });
 
   it('is idempotent (second resolve does nothing)', async () => {
     const queue = makeQueue();
-    const p = queue.requestApproval({
+    const handle = queue.requestApproval({
       clientName: 'plugin-i',
       declaredCapabilities: ['pane.read'],
     });
-    await queue.resolvePrompt('prompt-1', true);
-    await queue.resolvePrompt('prompt-1', false); // second call — no-op
-    const result = await p;
+    await queue.resolvePrompt(handle.promptId, true);
+    await queue.resolvePrompt(handle.promptId, false); // second call — no-op
+    const result = await handle.resolution;
     expect(result.approved).toBe(true);
   });
 });
@@ -205,21 +215,23 @@ describe('ApprovalQueue.resolvePrompt', () => {
 describe('ApprovalQueue.cancelPrompt', () => {
   it('rejects all coalesced waiters with the cancellation reason', async () => {
     const queue = makeQueue();
-    const p1 = queue.requestApproval({
+    const h1 = queue.requestApproval({
       clientName: 'plugin-j',
       declaredCapabilities: ['pane.read'],
     });
-    const p2 = queue.requestApproval({
+    const h2 = queue.requestApproval({
       clientName: 'plugin-j',
       declaredCapabilities: ['pane.read'],
     });
-    queue.cancelPrompt('prompt-1', 'plugin disconnected');
-    await expect(p1).rejects.toThrow(/plugin disconnected/);
-    await expect(p2).rejects.toThrow(/plugin disconnected/);
+    queue.cancelPrompt(h1.promptId, 'plugin disconnected');
+    await expect(h1.resolution).rejects.toThrow(/plugin disconnected/);
+    await expect(h2.resolution).rejects.toThrow(/plugin disconnected/);
   });
 
   it('is a no-op for unknown promptIds', () => {
     const queue = makeQueue();
-    expect(() => queue.cancelPrompt('does-not-exist', 'whatever')).not.toThrow();
+    expect(() =>
+      queue.cancelPrompt('does-not-exist', 'whatever'),
+    ).not.toThrow();
   });
 });

--- a/src/main/mcp/__tests__/ApprovalQueue.test.ts
+++ b/src/main/mcp/__tests__/ApprovalQueue.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ApprovalQueue, type ApprovalPromptInfo } from '../ApprovalQueue';
+import { PluginTrustStore } from '../PluginTrustStore';
+
+let tmpDir = '';
+let dbPath = '';
+let store: PluginTrustStore;
+let opened: ApprovalPromptInfo[] = [];
+
+let nextPromptId = 1;
+function mintId(): string {
+  return `prompt-${nextPromptId++}`;
+}
+
+function makeQueue(): ApprovalQueue {
+  opened = [];
+  return new ApprovalQueue(store, {
+    openPrompt: (info) => opened.push(info),
+    mintPromptId: mintId,
+  });
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-approval-test-'));
+  dbPath = path.join(tmpDir, 'plugin-trust.json');
+  store = new PluginTrustStore(dbPath);
+  nextPromptId = 1;
+  opened = [];
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe('ApprovalQueue.requestApproval', () => {
+  it('opens a prompt and resolves on approve', async () => {
+    const queue = makeQueue();
+    const p = queue.requestApproval({
+      clientName: 'plugin-a',
+      declaredCapabilities: ['pane.read'],
+    });
+    expect(opened).toHaveLength(1);
+    expect(opened[0].promptId).toBe('prompt-1');
+    expect(opened[0].clientName).toBe('plugin-a');
+    expect(opened[0].declaredCapabilities).toEqual(['pane.read']);
+
+    await queue.resolvePrompt('prompt-1', true);
+    const result = await p;
+    expect(result.approved).toBe(true);
+    expect(result.promptId).toBe('prompt-1');
+    expect(result.identity?.status).toBe('trusted');
+    expect(result.identity?.name).toBe('plugin-a');
+  });
+
+  it('persists denied status (spec §4.3)', async () => {
+    const queue = makeQueue();
+    const p = queue.requestApproval({
+      clientName: 'plugin-b',
+      declaredCapabilities: ['terminal.read'],
+    });
+    await queue.resolvePrompt('prompt-1', false);
+    const result = await p;
+    expect(result.approved).toBe(false);
+    expect(result.identity?.status).toBe('denied');
+
+    // Subsequent reads see the denied state on disk.
+    const onDisk = JSON.parse(fs.readFileSync(dbPath, 'utf8'));
+    expect(onDisk.plugins['plugin-b'].status).toBe('denied');
+  });
+
+  it('dedupes concurrent requests with identical (clientName, capabilities)', async () => {
+    const queue = makeQueue();
+    const p1 = queue.requestApproval({
+      clientName: 'plugin-c',
+      declaredCapabilities: ['pane.read', 'meta.read'],
+    });
+    const p2 = queue.requestApproval({
+      clientName: 'plugin-c',
+      declaredCapabilities: ['pane.read', 'meta.read'],
+    });
+    const p3 = queue.requestApproval({
+      clientName: 'plugin-c',
+      // Same set in different order — still same dedupe key.
+      declaredCapabilities: ['meta.read', 'pane.read'],
+    });
+
+    // Only one prompt opened despite three requestApproval calls.
+    expect(opened).toHaveLength(1);
+    expect(queue.inflightCount()).toBe(1);
+
+    await queue.resolvePrompt('prompt-1', true);
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+    expect(r1.approved).toBe(true);
+    expect(r2.approved).toBe(true);
+    expect(r3.approved).toBe(true);
+    expect(r1.promptId).toBe(r2.promptId);
+    expect(r2.promptId).toBe(r3.promptId);
+  });
+
+  it('treats different capability sets as different prompts', async () => {
+    const queue = makeQueue();
+    queue.requestApproval({
+      clientName: 'plugin-d',
+      declaredCapabilities: ['pane.read'],
+    });
+    queue.requestApproval({
+      clientName: 'plugin-d',
+      // Different set → distinct prompt
+      declaredCapabilities: ['pane.read', 'meta.write'],
+    });
+    expect(opened).toHaveLength(2);
+    expect(queue.inflightCount()).toBe(2);
+  });
+
+  it('treats different plugin names as different prompts', async () => {
+    const queue = makeQueue();
+    queue.requestApproval({
+      clientName: 'plugin-e',
+      declaredCapabilities: ['pane.read'],
+    });
+    queue.requestApproval({
+      clientName: 'plugin-f',
+      declaredCapabilities: ['pane.read'],
+    });
+    expect(opened).toHaveLength(2);
+  });
+
+  it('survives an opener that throws', async () => {
+    const queue = new ApprovalQueue(store, {
+      openPrompt: () => {
+        throw new Error('renderer dead');
+      },
+      mintPromptId: mintId,
+    });
+    const p = queue.requestApproval({
+      clientName: 'plugin-g',
+      declaredCapabilities: ['pane.read'],
+    });
+    // Promise must still be pending — the queue is still tracking it.
+    expect(queue.inflightCount()).toBe(1);
+    await queue.resolvePrompt('prompt-1', true);
+    const result = await p;
+    expect(result.approved).toBe(true);
+  });
+
+  it('keeps coalesced waiters whole when the trust-store write fails', async () => {
+    // Point the store at an unwritable location to force setUserDecision throw.
+    const badStore = new PluginTrustStore(
+      path.join(tmpDir, 'no-such-dir', 'plugin-trust.json'),
+    );
+    // Try a write to ensure subsequent ones also fail (atomicWriteJSON throws
+    // when the parent dir can't be created — but we mkdir via ensureWmuxHomeDir
+    // which targets a fixed path. To force a failure deterministically, stub
+    // setUserDecision.
+    const stubbed = badStore as unknown as {
+      setUserDecision: () => Promise<never>;
+    };
+    stubbed.setUserDecision = vi.fn(async () => {
+      throw new Error('disk write failed');
+    });
+
+    const queue = new ApprovalQueue(badStore, {
+      openPrompt: (info) => opened.push(info),
+      mintPromptId: mintId,
+    });
+    const p = queue.requestApproval({
+      clientName: 'plugin-h',
+      declaredCapabilities: ['pane.read'],
+    });
+    await queue.resolvePrompt('prompt-1', true);
+    const result = await p;
+    // Approved decision is communicated to the waiter; identity is
+    // undefined because the persistence write failed.
+    expect(result.approved).toBe(true);
+    expect(result.identity).toBeUndefined();
+  });
+});
+
+describe('ApprovalQueue.resolvePrompt', () => {
+  it('is a no-op for unknown promptIds', async () => {
+    const queue = makeQueue();
+    await expect(queue.resolvePrompt('does-not-exist', true)).resolves.toBeUndefined();
+  });
+
+  it('is idempotent (second resolve does nothing)', async () => {
+    const queue = makeQueue();
+    const p = queue.requestApproval({
+      clientName: 'plugin-i',
+      declaredCapabilities: ['pane.read'],
+    });
+    await queue.resolvePrompt('prompt-1', true);
+    await queue.resolvePrompt('prompt-1', false); // second call — no-op
+    const result = await p;
+    expect(result.approved).toBe(true);
+  });
+});
+
+describe('ApprovalQueue.cancelPrompt', () => {
+  it('rejects all coalesced waiters with the cancellation reason', async () => {
+    const queue = makeQueue();
+    const p1 = queue.requestApproval({
+      clientName: 'plugin-j',
+      declaredCapabilities: ['pane.read'],
+    });
+    const p2 = queue.requestApproval({
+      clientName: 'plugin-j',
+      declaredCapabilities: ['pane.read'],
+    });
+    queue.cancelPrompt('prompt-1', 'plugin disconnected');
+    await expect(p1).rejects.toThrow(/plugin disconnected/);
+    await expect(p2).rejects.toThrow(/plugin disconnected/);
+  });
+
+  it('is a no-op for unknown promptIds', () => {
+    const queue = makeQueue();
+    expect(() => queue.cancelPrompt('does-not-exist', 'whatever')).not.toThrow();
+  });
+});

--- a/src/main/mcp/__tests__/PermissionEnforcer.test.ts
+++ b/src/main/mcp/__tests__/PermissionEnforcer.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it } from 'vitest';
+import type { PluginIdentityRecord, RpcContext } from '../../../shared/rpc';
+import { check, checkPath } from '../PermissionEnforcer';
+
+function trust(
+  overrides: Partial<PluginIdentityRecord> & Pick<PluginIdentityRecord, 'name' | 'status'>,
+): PluginIdentityRecord {
+  return {
+    firstSeen: 1000,
+    lastSeen: 2000,
+    ...overrides,
+  };
+}
+
+function ctx(clientName?: string): RpcContext {
+  return clientName ? { clientName } : {};
+}
+
+describe('PermissionEnforcer.check — identity bootstrap', () => {
+  it('allows mcp.identify with no trust record', () => {
+    const out = check({ method: 'mcp.identify', params: {}, ctx: ctx('p1'), trust: undefined });
+    expect(out).toEqual({ kind: 'allow' });
+  });
+
+  it('allows mcp.declarePermissions even when status=denied', () => {
+    const out = check({
+      method: 'mcp.declarePermissions',
+      params: {},
+      ctx: ctx('p1'),
+      trust: trust({ name: 'p1', status: 'denied' }),
+    });
+    expect(out).toEqual({ kind: 'allow' });
+  });
+
+  it('allows system.identify and system.capabilities unconditionally', () => {
+    for (const method of ['system.identify', 'system.capabilities'] as const) {
+      const out = check({ method, params: {}, ctx: ctx('p1'), trust: undefined });
+      expect(out).toEqual({ kind: 'allow' });
+    }
+  });
+});
+
+describe('PermissionEnforcer.check — legacy (no clientName)', () => {
+  it('allows when ctx.clientName is missing', () => {
+    const out = check({ method: 'pane.list', params: {}, ctx: ctx(), trust: undefined });
+    expect(out).toEqual({ kind: 'allow' });
+  });
+
+  it('allows when trust.status === legacy', () => {
+    const out = check({
+      method: 'pane.list',
+      params: {},
+      ctx: ctx('p1'),
+      trust: trust({ name: 'p1', status: 'legacy' }),
+    });
+    expect(out).toEqual({ kind: 'allow' });
+  });
+});
+
+describe('PermissionEnforcer.check — denied trust', () => {
+  it('rejects with identity-status:denied and no pendingApproval', () => {
+    const out = check({
+      method: 'pane.list',
+      params: {},
+      ctx: ctx('p1'),
+      trust: trust({ name: 'p1', status: 'denied', declaredCapabilities: ['pane.read'] }),
+    });
+    expect(out.kind).toBe('reject');
+    if (out.kind !== 'reject') throw new Error('expected reject');
+    expect(out.rejection.reason).toBe('identity-status');
+    if (out.rejection.reason !== 'identity-status') throw new Error('narrow');
+    expect(out.rejection.status).toBe('denied');
+    expect(out.rejection.pendingApproval).toBeUndefined();
+  });
+});
+
+describe('PermissionEnforcer.check — unconfirmed', () => {
+  it('rejects with identity-status:unconfirmed (enforcer leaves promptId for dispatcher)', () => {
+    const out = check({
+      method: 'pane.list',
+      params: {},
+      ctx: ctx('p1'),
+      trust: trust({ name: 'p1', status: 'unconfirmed', declaredCapabilities: ['pane.read'] }),
+    });
+    if (out.kind !== 'reject' || out.rejection.reason !== 'identity-status') {
+      throw new Error('expected identity-status rejection');
+    }
+    expect(out.rejection.status).toBe('unconfirmed');
+    expect(out.rejection.pendingApproval).toBeUndefined();
+  });
+
+  it('rejects clientName-stamped requests with no trust record as unconfirmed', () => {
+    const out = check({ method: 'pane.list', params: {}, ctx: ctx('p1'), trust: undefined });
+    if (out.kind !== 'reject' || out.rejection.reason !== 'identity-status') {
+      throw new Error('expected identity-status rejection');
+    }
+    expect(out.rejection.status).toBe('unconfirmed');
+  });
+});
+
+describe('PermissionEnforcer.check — trusted: capability check', () => {
+  it('rejects when capability not declared', () => {
+    const out = check({
+      method: 'pane.list',
+      params: {},
+      ctx: ctx('p1'),
+      trust: trust({ name: 'p1', status: 'trusted', declaredCapabilities: ['meta.read'] }),
+    });
+    if (out.kind !== 'reject' || out.rejection.reason !== 'capability-not-declared') {
+      throw new Error('expected capability-not-declared');
+    }
+    expect(out.rejection.capability).toBe('pane.read');
+  });
+
+  it('allows when capability declared unrestricted (no glob)', () => {
+    const out = check({
+      method: 'pane.list',
+      params: {},
+      ctx: ctx('p1'),
+      trust: trust({ name: 'p1', status: 'trusted', declaredCapabilities: ['pane.read'] }),
+    });
+    expect(out).toEqual({ kind: 'allow' });
+  });
+
+  it('always rejects wmux.internal methods (capability is reserved-prefix, never declared)', () => {
+    // A plugin can't even successfully declare 'wmux.internal' (RESERVED_PREFIXES),
+    // so any declaration list always misses the capability. The map entry for
+    // daemon.shutdown points to wmux.internal, so trusted plugins with a
+    // legitimate-looking declaration still bounce.
+    const out = check({
+      method: 'daemon.shutdown',
+      params: {},
+      ctx: ctx('p1'),
+      trust: trust({
+        name: 'p1',
+        status: 'trusted',
+        declaredCapabilities: ['pane.read', 'meta.write'],
+      }),
+    });
+    if (out.kind !== 'reject' || out.rejection.reason !== 'capability-not-declared') {
+      throw new Error('expected capability-not-declared');
+    }
+    expect(out.rejection.capability).toBe('wmux.internal');
+  });
+});
+
+describe('PermissionEnforcer.check — trusted: path check (single-path)', () => {
+  it('allows pane.setMetadata when declared meta.write covers all touched fields', () => {
+    const out = check({
+      method: 'pane.setMetadata',
+      params: { label: 'foo', custom: { dash: 'on' } },
+      ctx: ctx('p1'),
+      trust: trust({
+        name: 'p1',
+        status: 'trusted',
+        declaredCapabilities: ['meta.write'],
+      }),
+    });
+    expect(out).toEqual({ kind: 'allow' });
+  });
+
+  it('rejects pane.setMetadata when scoped declaration misses a field (all-or-nothing)', () => {
+    const out = check({
+      method: 'pane.setMetadata',
+      params: { label: 'foo', custom: { dash: 'on' } },
+      ctx: ctx('p1'),
+      trust: trust({
+        name: 'p1',
+        status: 'trusted',
+        declaredCapabilities: ['meta.write:custom.*'],
+      }),
+    });
+    // setMetadata is all-or-nothing; mixed result becomes a wholesale reject
+    // with the paths-partially-allowed variant (so per-path detail surfaces).
+    if (out.kind !== 'reject' || out.rejection.reason !== 'paths-partially-allowed') {
+      throw new Error('expected paths-partially-allowed');
+    }
+    expect(out.rejection.allowed).toEqual(['custom.dash']);
+    expect(out.rejection.rejected.map((r) => r.path)).toEqual(['label']);
+  });
+
+  it('uses path-not-allowed (single-path variant) when extractor returns a bare string', () => {
+    // events.poll with undefined types yields the literal path '**' (not an
+    // array), so a scoped declaration that doesn't match triggers the
+    // single-path rejection shape — distinct from the multi-path
+    // paths-partially-allowed variant exercised by array-returning extractors.
+    const out = check({
+      method: 'events.poll',
+      params: {},
+      ctx: ctx('p1'),
+      trust: trust({
+        name: 'p1',
+        status: 'trusted',
+        declaredCapabilities: ['events.subscribe:pane.*'],
+      }),
+    });
+    if (out.kind !== 'reject' || out.rejection.reason !== 'path-not-allowed') {
+      throw new Error('expected path-not-allowed');
+    }
+    expect(out.rejection.path).toBe('**');
+    expect(out.rejection.declared).toEqual(['pane.*']);
+  });
+
+  it('respects spec §3.4 single-* vs double-** semantics', () => {
+    // `meta.write:custom.foo.*` does NOT cover `custom.foo.bar.baz`.
+    const out = check({
+      method: 'pane.setMetadata',
+      params: { custom: { 'foo.bar.baz': 'x' } },
+      ctx: ctx('p1'),
+      trust: trust({
+        name: 'p1',
+        status: 'trusted',
+        declaredCapabilities: ['meta.write:custom.foo.*'],
+      }),
+    });
+    // The custom key 'foo.bar.baz' is rendered as path 'custom.foo.bar.baz'
+    // which contains internal dots; the glob's single-* stops at dots →
+    // no match → rejected. (Plugin should declare meta.write:custom.foo.**)
+    expect(out.kind).toBe('reject');
+  });
+});
+
+describe('PermissionEnforcer.check — trusted: multi-path partial mode (events.poll)', () => {
+  it('returns partial when some topics match the events.subscribe glob', () => {
+    const out = check({
+      method: 'events.poll',
+      params: { types: ['pane.created', 'agent.lifecycle'] },
+      ctx: ctx('p1'),
+      trust: trust({
+        name: 'p1',
+        status: 'trusted',
+        declaredCapabilities: ['events.subscribe:pane.*'],
+      }),
+    });
+    if (out.kind !== 'partial') throw new Error('expected partial outcome');
+    expect(out.allowedPaths).toEqual(['pane.created']);
+    expect(out.rejection.allowed).toEqual(['pane.created']);
+    expect(out.rejection.rejected.map((r) => r.path)).toEqual(['agent.lifecycle']);
+  });
+
+  it('rejects wholesale when no topic matches', () => {
+    const out = check({
+      method: 'events.poll',
+      params: { types: ['process.started', 'process.exited'] },
+      ctx: ctx('p1'),
+      trust: trust({
+        name: 'p1',
+        status: 'trusted',
+        declaredCapabilities: ['events.subscribe:pane.*'],
+      }),
+    });
+    if (out.kind !== 'reject' || out.rejection.reason !== 'paths-partially-allowed') {
+      throw new Error('expected paths-partially-allowed reject');
+    }
+    expect(out.rejection.allowed).toEqual([]);
+    expect(out.rejection.rejected).toHaveLength(2);
+  });
+
+  it('rejects wildcard poll against scoped declaration', () => {
+    // Empty types → `**` path → only unrestricted events.subscribe matches.
+    const out = check({
+      method: 'events.poll',
+      params: {},
+      ctx: ctx('p1'),
+      trust: trust({
+        name: 'p1',
+        status: 'trusted',
+        declaredCapabilities: ['events.subscribe:pane.*'],
+      }),
+    });
+    expect(out.kind).toBe('reject');
+  });
+
+  it('allows wildcard poll against unrestricted events.subscribe', () => {
+    const out = check({
+      method: 'events.poll',
+      params: {},
+      ctx: ctx('p1'),
+      trust: trust({
+        name: 'p1',
+        status: 'trusted',
+        declaredCapabilities: ['events.subscribe'],
+      }),
+    });
+    expect(out).toEqual({ kind: 'allow' });
+  });
+});
+
+describe('PermissionEnforcer.checkPath — handler-resolved path', () => {
+  it('allows when declaration matches the resolved path', () => {
+    const t = trust({
+      name: 'p1',
+      status: 'trusted',
+      declaredCapabilities: ['meta.write:custom.dashboard.*'],
+    });
+    const out = checkPath(t, 'pane.setMetadata', 'meta.write', 'custom.dashboard.label');
+    expect(out).toEqual({ kind: 'allow' });
+  });
+
+  it('rejects when declaration does not match', () => {
+    const t = trust({
+      name: 'p1',
+      status: 'trusted',
+      declaredCapabilities: ['meta.write:custom.dashboard.*'],
+    });
+    const out = checkPath(t, 'pane.setMetadata', 'meta.write', 'label');
+    if (out.kind !== 'reject' || out.rejection.reason !== 'path-not-allowed') {
+      throw new Error('expected path-not-allowed');
+    }
+    expect(out.rejection.path).toBe('label');
+  });
+
+  it('rejects when capability not declared at all', () => {
+    const t = trust({
+      name: 'p1',
+      status: 'trusted',
+      declaredCapabilities: ['meta.read'],
+    });
+    const out = checkPath(t, 'pane.setMetadata', 'meta.write', 'label');
+    if (out.kind !== 'reject' || out.rejection.reason !== 'capability-not-declared') {
+      throw new Error('expected capability-not-declared');
+    }
+  });
+});

--- a/src/main/mcp/__tests__/PluginTrustStore.test.ts
+++ b/src/main/mcp/__tests__/PluginTrustStore.test.ts
@@ -302,3 +302,43 @@ describe('PluginTrustStore LRU eviction', () => {
     expect(list).toHaveLength(3);
   });
 });
+
+describe('PluginTrustStore.setUserDecision (Phase 2.2 pre-commit 5)', () => {
+  it('persists a trusted decision on a fresh plugin (no prior record)', async () => {
+    const store = new PluginTrustStore(dbPath);
+    const rec = await store.setUserDecision('fresh-plugin', 'trusted');
+    expect(rec.status).toBe('trusted');
+    expect(rec.name).toBe('fresh-plugin');
+    expect(rec.firstSeen).toBeGreaterThan(0);
+    expect(rec.lastSeen).toBe(rec.firstSeen);
+  });
+
+  it('persists a denied decision and survives a fresh store instance', async () => {
+    const store = new PluginTrustStore(dbPath);
+    await store.upsertContact('p1', '1.0.0');
+    await store.setUserDecision('p1', 'denied');
+    const reincarnated = new PluginTrustStore(dbPath);
+    const reloaded = await reincarnated.get('p1');
+    expect(reloaded?.status).toBe('denied');
+    expect(reloaded?.version).toBe('1.0.0');
+  });
+
+  it('overwrites prior trusted/denied/unconfirmed state explicitly', async () => {
+    const store = new PluginTrustStore(dbPath);
+    await store.upsertDeclaration('p1', ['pane.read']);
+    expect((await store.get('p1'))?.status).toBe('unconfirmed');
+    await store.setUserDecision('p1', 'trusted');
+    expect((await store.get('p1'))?.status).toBe('trusted');
+    await store.setUserDecision('p1', 'denied');
+    expect((await store.get('p1'))?.status).toBe('denied');
+    // declaredCapabilities preserved across decisions.
+    expect((await store.get('p1'))?.declaredCapabilities).toEqual(['pane.read']);
+  });
+
+  it('clamps oversized plugin names like every other write path', async () => {
+    const store = new PluginTrustStore(dbPath);
+    const huge = 'X'.repeat(MAX_PLUGIN_NAME_LEN + 100);
+    const rec = await store.setUserDecision(huge, 'trusted');
+    expect(rec.name.length).toBeLessThanOrEqual(MAX_PLUGIN_NAME_LEN);
+  });
+});

--- a/src/main/mcp/__tests__/methodCapabilityMap.test.ts
+++ b/src/main/mcp/__tests__/methodCapabilityMap.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { ALL_RPC_METHODS, type RpcMethod } from '../../../shared/rpc';
+import { METHOD_CAPABILITY } from '../methodCapabilityMap';
+import { listKnownCapabilities } from '../permissionGrammar';
+
+describe('methodCapabilityMap totality', () => {
+  it('has an entry for every RpcMethod', () => {
+    for (const method of ALL_RPC_METHODS) {
+      expect(METHOD_CAPABILITY[method]).toBeDefined();
+    }
+  });
+
+  it('has no entries for unknown methods (no over-declaration)', () => {
+    const declared = new Set(Object.keys(METHOD_CAPABILITY));
+    const known = new Set<string>(ALL_RPC_METHODS as readonly string[]);
+    for (const k of declared) {
+      expect(known.has(k)).toBe(true);
+    }
+  });
+});
+
+describe('methodCapabilityMap capability validity', () => {
+  it('every non-null, non-internal capability appears in KNOWN_CAPABILITIES', () => {
+    const known = new Set(listKnownCapabilities());
+    for (const method of ALL_RPC_METHODS) {
+      const cap = METHOD_CAPABILITY[method].capability;
+      if (cap === null) continue;
+      if (cap === 'wmux.internal') continue;
+      expect(known.has(cap), `method=${method} capability=${cap}`).toBe(true);
+    }
+  });
+
+  it('identity bootstrap methods declare capability: null', () => {
+    expect(METHOD_CAPABILITY['mcp.identify'].capability).toBeNull();
+    expect(METHOD_CAPABILITY['mcp.declarePermissions'].capability).toBeNull();
+    expect(METHOD_CAPABILITY['system.identify'].capability).toBeNull();
+    expect(METHOD_CAPABILITY['system.capabilities'].capability).toBeNull();
+  });
+});
+
+describe('methodCapabilityMap risk class wiring', () => {
+  const expectations: Array<[RpcMethod, string]> = [
+    ['input.send', 'terminal-input'],
+    ['input.sendKey', 'terminal-input'],
+    ['input.readScreen', 'terminal-content'],
+    ['terminal.readEvents', 'terminal-content'],
+    ['pane.search', 'terminal-content'],
+    ['pane.setMetadata', 'metadata'],
+    ['pane.getMetadata', 'metadata'],
+    ['pane.clearMetadata', 'metadata'],
+    ['events.poll', 'events'],
+    ['browser.screenshot', 'browser'],
+    ['a2a.task.send', 'a2a'],
+  ];
+  for (const [method, klass] of expectations) {
+    it(`${method} → ${klass}`, () => {
+      expect(METHOD_CAPABILITY[method].riskClass).toBe(klass);
+    });
+  }
+});
+
+describe('methodCapabilityMap path extractor behavior', () => {
+  it('pane.setMetadata extracts label/role/status + custom.* paths', () => {
+    const ext = METHOD_CAPABILITY['pane.setMetadata'].pathFromParams;
+    if (typeof ext !== 'function') throw new Error('expected function');
+    expect(ext({ label: 'foo' })).toEqual(['label']);
+    expect(ext({ label: 'a', role: 'b', status: 'c' })).toEqual(['label', 'role', 'status']);
+    expect(ext({ custom: { dashboard: 'on', counter: '42' } })).toEqual([
+      'custom.dashboard',
+      'custom.counter',
+    ]);
+    expect(ext({ label: 'x', custom: { foo: 'y' } })).toEqual(['label', 'custom.foo']);
+    expect(ext({})).toBeUndefined();
+    // Non-object custom is ignored, not crashed
+    expect(ext({ custom: 'oops' })).toBeUndefined();
+  });
+
+  it('pane.clearMetadata enumerates shared paths regardless of params', () => {
+    const ext = METHOD_CAPABILITY['pane.clearMetadata'].pathFromParams;
+    if (typeof ext !== 'function') throw new Error('expected function');
+    expect(ext({})).toEqual(['label', 'role', 'status']);
+    expect(ext({ paneId: 'p1' })).toEqual(['label', 'role', 'status']);
+  });
+
+  it('events.poll returns ** for undefined types (full subscription)', () => {
+    const ext = METHOD_CAPABILITY['events.poll'].pathFromParams;
+    if (typeof ext !== 'function') throw new Error('expected function');
+    expect(ext({})).toBe('**');
+    expect(ext({ types: [] })).toBe('**');
+  });
+
+  it('events.poll passes through string array of types', () => {
+    const ext = METHOD_CAPABILITY['events.poll'].pathFromParams;
+    if (typeof ext !== 'function') throw new Error('expected function');
+    expect(ext({ types: ['pane.created', 'agent.lifecycle'] })).toEqual([
+      'pane.created',
+      'agent.lifecycle',
+    ]);
+  });
+});
+
+describe('methodCapabilityMap multi-path mode', () => {
+  it('pane.setMetadata is all-or-nothing (writes shouldn\'t silently drop fields)', () => {
+    expect(METHOD_CAPABILITY['pane.setMetadata'].multiPathMode).toBe('all-or-nothing');
+  });
+  it('pane.clearMetadata is all-or-nothing (can\'t partially-clear)', () => {
+    expect(METHOD_CAPABILITY['pane.clearMetadata'].multiPathMode).toBe('all-or-nothing');
+  });
+  it('events.poll is partial (filter to allowed topics is fine)', () => {
+    expect(METHOD_CAPABILITY['events.poll'].multiPathMode).toBe('partial');
+  });
+});

--- a/src/main/mcp/__tests__/methodCapabilityMap.test.ts
+++ b/src/main/mcp/__tests__/methodCapabilityMap.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { ALL_RPC_METHODS, type RpcMethod } from '../../../shared/rpc';
-import { METHOD_CAPABILITY } from '../methodCapabilityMap';
+import {
+  CAPABILITY_RISK_CLASS,
+  METHOD_CAPABILITY,
+  RISK_CLASS_COPY,
+  type RiskClass,
+} from '../methodCapabilityMap';
 import { listKnownCapabilities } from '../permissionGrammar';
 
 describe('methodCapabilityMap totality', () => {
@@ -96,6 +101,62 @@ describe('methodCapabilityMap path extractor behavior', () => {
       'pane.created',
       'agent.lifecycle',
     ]);
+  });
+});
+
+describe('CAPABILITY_RISK_CLASS — wording table coverage (Phase 2.2 pre-commit 5)', () => {
+  it('classifies every grantable capability from KNOWN_CAPABILITIES', () => {
+    const known = listKnownCapabilities();
+    for (const cap of known) {
+      expect(
+        CAPABILITY_RISK_CLASS[cap],
+        `capability ${cap} has no risk class — approval dialog would render fallback copy`,
+      ).toBeDefined();
+    }
+  });
+
+  it('uses only well-defined risk classes from RISK_CLASS_COPY', () => {
+    for (const [cap, klass] of Object.entries(CAPABILITY_RISK_CLASS)) {
+      expect(
+        RISK_CLASS_COPY[klass],
+        `capability ${cap} → risk class ${klass} has no copy entry`,
+      ).toBeDefined();
+    }
+  });
+
+  it('flags terminal.read and pane.search as terminal-content (spec §3.6)', () => {
+    expect(CAPABILITY_RISK_CLASS['terminal.read']).toBe('terminal-content');
+    expect(CAPABILITY_RISK_CLASS['pane.search']).toBe('terminal-content');
+  });
+
+  it('flags terminal.send as terminal-input (spec §3.6)', () => {
+    expect(CAPABILITY_RISK_CLASS['terminal.send']).toBe('terminal-input');
+  });
+});
+
+describe('RISK_CLASS_COPY — wording asymmetry (plan D5)', () => {
+  it('rates terminal-content and terminal-input as critical severity', () => {
+    expect(RISK_CLASS_COPY['terminal-content'].severity).toBe('critical');
+    expect(RISK_CLASS_COPY['terminal-input'].severity).toBe('critical');
+  });
+
+  it('rates metadata, events, pane-lifecycle, and workspace as neutral', () => {
+    const neutrals: RiskClass[] = ['metadata', 'events', 'pane-lifecycle', 'workspace'];
+    for (const r of neutrals) {
+      expect(RISK_CLASS_COPY[r].severity).toBe('neutral');
+    }
+  });
+
+  it('rates browser and a2a as caution', () => {
+    expect(RISK_CLASS_COPY['browser'].severity).toBe('caution');
+    expect(RISK_CLASS_COPY['a2a'].severity).toBe('caution');
+  });
+
+  it('uses concrete user-facing language for terminal-content (no euphemisms)', () => {
+    // The copy must name the concrete privilege, not soften it. This pins
+    // the asymmetry against future "let's be friendlier" refactors.
+    const detail = RISK_CLASS_COPY['terminal-content'].detail;
+    expect(detail).toMatch(/secrets|read|screen/i);
   });
 });
 

--- a/src/main/mcp/__tests__/phase-2-2-dynamic.test.ts
+++ b/src/main/mcp/__tests__/phase-2-2-dynamic.test.ts
@@ -29,6 +29,8 @@ import {
   type LegacyTrafficEntry,
 } from '../../audit/shadowRejectionLog';
 import { LegacyTrafficCounter } from '../../audit/legacyTrafficCounter';
+import { ApprovalQueue, type ApprovalPromptInfo } from '../ApprovalQueue';
+import type { RpcRejection } from '../../../shared/rpc';
 
 let tmpDir = '';
 let dbPath = '';
@@ -341,5 +343,159 @@ describe('phase 2.2 dynamic — full plugin lifecycle against real disk', () => 
     const byMethod = new Map(legacy.map((e) => [e.method, e.count]));
     expect(byMethod.get('pane.list')).toBe(1);
     expect(byMethod.get('input.send')).toBe(1);
+  });
+});
+
+describe('phase 2.2 dynamic — enforce mode (pre-commit 6)', () => {
+  let opened: ApprovalPromptInfo[] = [];
+  let approvalQueue: ApprovalQueue;
+  let promptCounter = 0;
+
+  beforeEach(() => {
+    opened = [];
+    promptCounter = 0;
+    approvalQueue = new ApprovalQueue(store, {
+      openPrompt: (info) => opened.push(info),
+      mintPromptId: () => `e-prompt-${++promptCounter}`,
+    });
+    router.setEnforcementMode('enforce');
+    router.setApprovalQueue(approvalQueue);
+  });
+
+  it('returns rejection (handler NOT invoked) in enforce mode for capability-not-declared', async () => {
+    let handlerRan = false;
+    router.register('input.send', async () => {
+      handlerRan = true;
+      return { ok: true };
+    });
+    await store.upsertContact('p-strict', '1.0.0');
+    await store.upsertDeclaration('p-strict', ['pane.read']);
+    // Forge trusted state.
+    const raw = JSON.parse(fs.readFileSync(dbPath, 'utf8'));
+    raw.plugins['p-strict'].status = 'trusted';
+    fs.writeFileSync(dbPath, JSON.stringify(raw));
+    store.invalidateCache();
+
+    const r = await router.dispatch({
+      id: 'enforce-1',
+      method: 'input.send',
+      params: { text: 'hi' },
+      clientName: 'p-strict',
+    });
+    expect(handlerRan).toBe(false);
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected failure');
+    expect(r.rejection).toBeDefined();
+    expect(r.rejection?.reason).toBe('capability-not-declared');
+    expect(r.error).toMatch(/terminal\.send.*not declared/i);
+  });
+
+  it('threads pendingApproval.promptId into identity-status:unconfirmed rejections', async () => {
+    // Plugin declares capabilities but hasn't been approved yet.
+    await store.upsertContact('p-pending', '1.0.0');
+    await store.upsertDeclaration('p-pending', ['pane.read', 'meta.write']);
+    // status stays 'unconfirmed' — no forging.
+
+    const r = await router.dispatch({
+      id: 'enforce-2',
+      method: 'pane.list',
+      params: {},
+      clientName: 'p-pending',
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected failure');
+    const rej = r.rejection;
+    expect(rej?.reason).toBe('identity-status');
+    if (rej?.reason !== 'identity-status') throw new Error('narrow');
+    expect(rej.status).toBe('unconfirmed');
+    expect(rej.pendingApproval?.promptId).toBeDefined();
+    // The same promptId appears in the renderer-bound info.
+    expect(opened).toHaveLength(1);
+    expect(opened[0].promptId).toBe(rej.pendingApproval?.promptId);
+    expect(opened[0].clientName).toBe('p-pending');
+    expect(opened[0].declaredCapabilities).toEqual(['pane.read', 'meta.write']);
+  });
+
+  it('does NOT mint a prompt for denied plugins (spec §4.3)', async () => {
+    await store.upsertContact('p-denied');
+    await store.upsertDeclaration('p-denied', ['pane.read']);
+    const raw = JSON.parse(fs.readFileSync(dbPath, 'utf8'));
+    raw.plugins['p-denied'].status = 'denied';
+    fs.writeFileSync(dbPath, JSON.stringify(raw));
+    store.invalidateCache();
+
+    const r = await router.dispatch({
+      id: 'enforce-3',
+      method: 'pane.list',
+      params: {},
+      clientName: 'p-denied',
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected failure');
+    expect(r.rejection?.reason).toBe('identity-status');
+    if (r.rejection?.reason === 'identity-status') {
+      expect(r.rejection.status).toBe('denied');
+      expect(r.rejection.pendingApproval).toBeUndefined();
+    }
+    expect(opened).toHaveLength(0);
+  });
+
+  it('resolves the prompt → next call succeeds with the same capability', async () => {
+    router.register('pane.list', async () => ({ panes: [] }));
+    await store.upsertContact('p-flow');
+    await store.upsertDeclaration('p-flow', ['pane.read']);
+
+    // First call: unconfirmed → reject + prompt.
+    const r1 = await router.dispatch({
+      id: 'flow-1',
+      method: 'pane.list',
+      params: {},
+      clientName: 'p-flow',
+    });
+    expect(r1.ok).toBe(false);
+    if (r1.ok) throw new Error('expected failure');
+    const promptId = (r1.rejection as RpcRejection & { reason: 'identity-status' })
+      .pendingApproval?.promptId;
+    expect(promptId).toBeDefined();
+
+    // User clicks Approve.
+    await approvalQueue.resolvePrompt(promptId as string, true);
+    store.invalidateCache();
+    await settle();
+
+    // Second call: trusted now → handler runs, response ok.
+    const r2 = await router.dispatch({
+      id: 'flow-2',
+      method: 'pane.list',
+      params: {},
+      clientName: 'p-flow',
+    });
+    expect(r2.ok).toBe(true);
+  });
+
+  it('still allows identity-bootstrap RPCs in enforce mode (mcp.identify + mcp.declarePermissions)', async () => {
+    const r = await router.dispatch({
+      id: 'boot-1',
+      method: 'mcp.identify',
+      params: {},
+      clientName: 'p-bootstrap',
+    });
+    expect(r.ok).toBe(true);
+    const d = await router.dispatch({
+      id: 'boot-2',
+      method: 'mcp.declarePermissions',
+      params: { permissions: ['pane.read'] },
+      clientName: 'p-bootstrap',
+    });
+    expect(d.ok).toBe(true);
+  });
+
+  it('allows legacy callers (no clientName envelope) in enforce mode', async () => {
+    const r = await router.dispatch({
+      id: 'legacy-1',
+      method: 'pane.list',
+      params: {},
+    });
+    expect(r.ok).toBe(true);
   });
 });

--- a/src/main/mcp/__tests__/phase-2-2-dynamic.test.ts
+++ b/src/main/mcp/__tests__/phase-2-2-dynamic.test.ts
@@ -1,0 +1,345 @@
+// Phase 2.2 dynamic verification — exercises the production wiring for the
+// shadow-mode enforcement substrate against a real on-disk PluginTrustStore
+// + ShadowRejectionLogger + LegacyTrafficCounter in an isolated tmpdir.
+//
+// Mirrors src/main/index.ts:
+//
+//   rpcRouter.setLegacyContactRecorder(...);
+//   rpcRouter.setTrustLookup((n) => store.get(n));
+//   rpcRouter.setShadowRejectionSink((e) => logger.append(e));
+//   rpcRouter.setLegacyTrafficCounter(counter);
+//
+// Then replays a realistic plugin lifecycle and reads back what landed on
+// disk in `shadow-rejections.log` to confirm the enforcer + side-channels
+// produce the expected audit trail. Any failure here means the integration
+// between RpcRouter, PluginTrustStore, the enforcer, and the shadow log
+// drifted in a way the per-module suites would not catch.
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { RpcRouter } from '../../pipe/RpcRouter';
+import { PluginTrustStore } from '../PluginTrustStore';
+import { registerMcpPluginRpc } from '../../pipe/handlers/mcp.rpc';
+import {
+  ShadowRejectionLogger,
+  type ShadowAuditEntry,
+  type ShadowRejectionEntry,
+  type LegacyTrafficEntry,
+} from '../../audit/shadowRejectionLog';
+import { LegacyTrafficCounter } from '../../audit/legacyTrafficCounter';
+
+let tmpDir = '';
+let dbPath = '';
+let logPath = '';
+let store: PluginTrustStore;
+let router: RpcRouter;
+let shadowLogger: ShadowRejectionLogger;
+let counter: LegacyTrafficCounter;
+
+let pendingWrites: Promise<unknown>[] = [];
+
+async function drainWrites(): Promise<void> {
+  const batch = pendingWrites;
+  pendingWrites = [];
+  await Promise.all(batch);
+}
+
+const settle = (ms = 5) => new Promise<void>((r) => setTimeout(r, ms));
+
+function readLog(): ShadowAuditEntry[] {
+  return shadowLogger.readAll();
+}
+
+function rejectionEntries(): ShadowRejectionEntry[] {
+  return readLog().filter(
+    (e): e is ShadowRejectionEntry => e.entryKind === 'rejection',
+  );
+}
+
+function legacyEntries(): LegacyTrafficEntry[] {
+  return readLog().filter(
+    (e): e is LegacyTrafficEntry => e.entryKind === 'legacy-traffic',
+  );
+}
+
+function wireProductionPath(): void {
+  // Identity handlers
+  registerMcpPluginRpc(router, store);
+  // A representative gated handler — pane.list requires `pane.read`.
+  router.register('pane.list', async () => ({ panes: [] }));
+  // A multi-path handler — pane.setMetadata extracts paths from params.
+  router.register('pane.setMetadata', async () => ({
+    ok: true,
+    paneId: 'p1',
+    metadata: { custom: {} },
+    version: 1,
+  }));
+  // events.poll for the multi-path partial scenario.
+  router.register('events.poll', async () => ({ events: [], cursor: 0 }));
+  // input.send for the terminal-content / terminal-input risk class.
+  router.register('input.send', async () => ({ ok: true }));
+
+  router.setLegacyContactRecorder(() => {
+    const p = store.upsertLegacyContact().catch(() => undefined);
+    pendingWrites.push(p);
+  });
+  router.setTrustLookup(async (name) => store.get(name));
+  router.setShadowRejectionSink((entry) => shadowLogger.append(entry));
+  router.setLegacyTrafficCounter(counter);
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-phase22-dyn-'));
+  dbPath = path.join(tmpDir, 'plugin-trust.json');
+  logPath = path.join(tmpDir, 'shadow-rejections.log');
+  store = new PluginTrustStore(dbPath);
+  shadowLogger = new ShadowRejectionLogger({ path: logPath });
+  counter = new LegacyTrafficCounter({
+    sink: ({ method, count }) =>
+      shadowLogger.appendLegacyTraffic({ method, count }),
+    // Custom milestones so the test doesn't need 100+ RPCs to hit one.
+    milestones: [1, 3, 5],
+  });
+  router = new RpcRouter();
+  pendingWrites = [];
+  wireProductionPath();
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe('phase 2.2 dynamic — full plugin lifecycle against real disk', () => {
+  it('replays the unconfirmed → trusted → capability-mismatch sequence', async () => {
+    // === Step 1: envelope-less RPC. Legacy path runs — trust DB gets a
+    // 'legacy' row, traffic counter ticks (milestone 1 → log entry), but
+    // the enforcer ALLOWS legacy so no shadow rejection lands.
+    await router.dispatch({ id: 's1', method: 'pane.list', params: {} });
+    await drainWrites();
+    await settle();
+
+    expect(fs.existsSync(dbPath)).toBe(true);
+    expect(legacyEntries()).toHaveLength(1);
+    expect(legacyEntries()[0].method).toBe('pane.list');
+    expect(legacyEntries()[0].count).toBe(1);
+    expect(rejectionEntries()).toHaveLength(0);
+
+    // === Step 2: envelope-with-clientName but no trust record yet. Spec
+    // says plugins must call mcp.identify first; if they don't, enforcer
+    // returns identity-status:unconfirmed (no pendingApproval — nothing
+    // declared). Shadow log records the would-be rejection.
+    await router.dispatch({
+      id: 's2',
+      method: 'pane.list',
+      params: {},
+      clientName: 'fresh-plugin',
+    });
+    await drainWrites();
+    await settle();
+
+    const rejs = rejectionEntries();
+    expect(rejs).toHaveLength(1);
+    expect(rejs[0].clientName).toBe('fresh-plugin');
+    expect(rejs[0].method).toBe('pane.list');
+    expect(rejs[0].rejection.reason).toBe('identity-status');
+    if (rejs[0].rejection.reason === 'identity-status') {
+      expect(rejs[0].rejection.status).toBe('unconfirmed');
+      expect(rejs[0].rejection.pendingApproval).toBeUndefined();
+    }
+
+    // === Step 3: proper handshake. mcp.identify + mcp.declarePermissions
+    // are capability:null in the map, so the enforcer allows; trust DB
+    // grows an 'unconfirmed' row with the declared capability set.
+    await router.dispatch({
+      id: 's3a',
+      method: 'mcp.identify',
+      params: {},
+      clientName: 'demo-plugin',
+      clientVersion: '0.1.0',
+    });
+    await router.dispatch({
+      id: 's3b',
+      method: 'mcp.declarePermissions',
+      params: { permissions: ['pane.read', 'meta.write:custom.foo.*'] },
+      clientName: 'demo-plugin',
+    });
+    await drainWrites();
+    await settle();
+
+    const onDiskAfterDeclare = JSON.parse(fs.readFileSync(dbPath, 'utf8'));
+    expect(onDiskAfterDeclare.plugins['demo-plugin'].status).toBe(
+      'unconfirmed',
+    );
+    expect(onDiskAfterDeclare.plugins['demo-plugin'].declaredCapabilities).toEqual([
+      'pane.read',
+      'meta.write:custom.foo.*',
+    ]);
+    // mcp.identify + mcp.declarePermissions don't emit rejections — still 1.
+    expect(rejectionEntries()).toHaveLength(1);
+
+    // === Step 4: unconfirmed plugin tries to use a declared capability.
+    // Even though `pane.read` IS declared, the trust status is still
+    // 'unconfirmed', so the enforcer rejects with identity-status. Shadow
+    // mode logs but still runs the handler.
+    const r4 = await router.dispatch({
+      id: 's4',
+      method: 'pane.list',
+      params: {},
+      clientName: 'demo-plugin',
+    });
+    expect(r4.ok).toBe(true); // shadow does not block
+    await drainWrites();
+    await settle();
+    const rejsAfter4 = rejectionEntries();
+    expect(rejsAfter4).toHaveLength(2);
+    expect(rejsAfter4[1].clientName).toBe('demo-plugin');
+    expect(rejsAfter4[1].rejection.reason).toBe('identity-status');
+
+    // === Step 5: forge user-approved 'trusted' state (no UI in this PR).
+    const raw = JSON.parse(fs.readFileSync(dbPath, 'utf8'));
+    raw.plugins['demo-plugin'].status = 'trusted';
+    fs.writeFileSync(dbPath, JSON.stringify(raw));
+    store.invalidateCache();
+
+    // Now declared capability matches → allow → no new shadow entry.
+    await router.dispatch({
+      id: 's5',
+      method: 'pane.list',
+      params: {},
+      clientName: 'demo-plugin',
+    });
+    await drainWrites();
+    await settle();
+    expect(rejectionEntries()).toHaveLength(2); // unchanged
+
+    // === Step 6: trusted plugin tries an UNDECLARED capability
+    // (input.send → terminal.send, not declared). Enforcer rejects with
+    // capability-not-declared. Shadow logs.
+    await router.dispatch({
+      id: 's6',
+      method: 'input.send',
+      params: { text: 'hi' },
+      clientName: 'demo-plugin',
+    });
+    await drainWrites();
+    await settle();
+    const rejsAfter6 = rejectionEntries();
+    expect(rejsAfter6).toHaveLength(3);
+    expect(rejsAfter6[2].method).toBe('input.send');
+    expect(rejsAfter6[2].rejection.reason).toBe('capability-not-declared');
+    if (rejsAfter6[2].rejection.reason === 'capability-not-declared') {
+      expect(rejsAfter6[2].rejection.capability).toBe('terminal.send');
+    }
+
+    // === Step 7: trusted plugin tries setMetadata with a path NOT covered
+    // by its declaration (`meta.write:custom.foo.*` covers custom.foo.X
+    // but NOT 'label'). Multi-path 'all-or-nothing' → paths-partially-
+    // allowed rejection variant with per-path detail.
+    await router.dispatch({
+      id: 's7',
+      method: 'pane.setMetadata',
+      params: { label: 'new-label', custom: { 'foo.x': 'val' } },
+      clientName: 'demo-plugin',
+    });
+    await drainWrites();
+    await settle();
+    const rejsAfter7 = rejectionEntries();
+    expect(rejsAfter7).toHaveLength(4);
+    const r7 = rejsAfter7[3];
+    expect(r7.method).toBe('pane.setMetadata');
+    expect(r7.rejection.reason).toBe('paths-partially-allowed');
+    if (r7.rejection.reason === 'paths-partially-allowed') {
+      expect(r7.rejection.allowed).toEqual(['custom.foo.x']);
+      expect(r7.rejection.rejected.map((x) => x.path)).toEqual(['label']);
+    }
+
+    // === Step 8: trusted plugin tries setMetadata with ONLY-allowed paths
+    // (custom.foo.bar). Enforcer allows → no new shadow entry.
+    await router.dispatch({
+      id: 's8',
+      method: 'pane.setMetadata',
+      params: { custom: { 'foo.bar': 'val' } },
+      clientName: 'demo-plugin',
+    });
+    await drainWrites();
+    await settle();
+    expect(rejectionEntries()).toHaveLength(4); // unchanged
+
+    // === Step 9: identity-bootstrap RPCs (mcp.identify) always allowed.
+    // No shadow log even though the caller is in a hostile trust state.
+    raw.plugins['demo-plugin'].status = 'denied';
+    fs.writeFileSync(dbPath, JSON.stringify(raw));
+    store.invalidateCache();
+    await router.dispatch({
+      id: 's9',
+      method: 'mcp.identify',
+      params: {},
+      clientName: 'demo-plugin',
+    });
+    await drainWrites();
+    await settle();
+    expect(rejectionEntries()).toHaveLength(4); // unchanged
+
+    // === Step 10: denied plugin trying real RPC → identity-status:denied
+    // shadow log entry, no pendingApproval (spec §4.3: denied never
+    // regresses).
+    await router.dispatch({
+      id: 's10',
+      method: 'pane.list',
+      params: {},
+      clientName: 'demo-plugin',
+    });
+    await drainWrites();
+    await settle();
+    const rejs10 = rejectionEntries();
+    expect(rejs10).toHaveLength(5);
+    expect(rejs10[4].rejection.reason).toBe('identity-status');
+    if (rejs10[4].rejection.reason === 'identity-status') {
+      expect(rejs10[4].rejection.status).toBe('denied');
+      expect(rejs10[4].rejection.pendingApproval).toBeUndefined();
+    }
+  });
+
+  it('produces legacy-traffic milestones at configured thresholds', async () => {
+    // 6 envelope-less RPCs against `pane.list`. With milestones=[1,3,5],
+    // log gets entries at calls 1, 3, 5 (3 entries).
+    for (let i = 0; i < 6; i++) {
+      await router.dispatch({
+        id: `legacy-${i}`,
+        method: 'pane.list',
+        params: {},
+      });
+    }
+    await drainWrites();
+    await settle();
+
+    const legacy = legacyEntries();
+    expect(legacy).toHaveLength(3);
+    expect(legacy.map((e) => e.count)).toEqual([1, 3, 5]);
+    expect(legacy.every((e) => e.method === 'pane.list')).toBe(true);
+
+    // No rejection entries — legacy is allowed.
+    expect(rejectionEntries()).toHaveLength(0);
+  });
+
+  it('counts distinct methods separately', async () => {
+    await router.dispatch({ id: 'a-1', method: 'pane.list', params: {} });
+    await router.dispatch({ id: 'b-1', method: 'input.send', params: { text: 'x' } });
+    await router.dispatch({ id: 'a-2', method: 'pane.list', params: {} });
+    await drainWrites();
+    await settle();
+
+    // Each method's first call hits milestone 1 → 2 entries total.
+    const legacy = legacyEntries();
+    expect(legacy).toHaveLength(2);
+    const byMethod = new Map(legacy.map((e) => [e.method, e.count]));
+    expect(byMethod.get('pane.list')).toBe(1);
+    expect(byMethod.get('input.send')).toBe(1);
+  });
+});

--- a/src/main/mcp/enforcementMode.ts
+++ b/src/main/mcp/enforcementMode.ts
@@ -1,0 +1,76 @@
+// Phase 2.2 enforcement mode loader (pre-commit 6).
+//
+// Reads `mcp.mode` from `~/.wmux/config.json` to decide whether RpcRouter
+// should ENFORCE permission rejections (return RpcResponse failures) or
+// just SHADOW-log them and proceed to the handler.
+//
+// Defaults are environment-aware:
+//   - Production wmux:  enforce  (the v3.0 ship target)
+//   - Dev wmux (electron-forge start, npm start, vitest, etc.):
+//                       shadow   (rollback safety during dogfood — a bad
+//                                 delta doesn't lock out internal RPCs)
+//
+// Override path: a user (or a dev who wants to dogfood enforce mode) can
+// set `mcp.mode` in `~/.wmux/config.json` explicitly. The daemon's
+// validateConfig is strict on its own fields but ignores unknown sections,
+// so this stays compatible with the existing daemon config schema.
+
+import * as fs from 'fs';
+import { getConfigPath } from '../../daemon/config';
+
+export type EnforcementMode = 'shadow' | 'enforce';
+
+export interface EnforcementModeResolveOptions {
+  /** When true, default to 'shadow' (dogfood safety). When false, default to 'enforce'. */
+  isDev: boolean;
+  /** Override the config path for tests. */
+  configPath?: string;
+}
+
+export function resolveEnforcementMode(
+  opts: EnforcementModeResolveOptions,
+): EnforcementMode {
+  const defaultMode: EnforcementMode = opts.isDev ? 'shadow' : 'enforce';
+  const cfgPath = opts.configPath ?? getConfigPath();
+  let raw: string;
+  try {
+    raw = fs.readFileSync(cfgPath, 'utf-8');
+  } catch {
+    return defaultMode;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw, (key, value) => {
+      // Prototype pollution guard — mirrors daemon/config.ts.
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        return undefined;
+      }
+      return value;
+    });
+  } catch {
+    return defaultMode;
+  }
+  if (!parsed || typeof parsed !== 'object') return defaultMode;
+  const mcp = (parsed as Record<string, unknown>).mcp;
+  if (!mcp || typeof mcp !== 'object') return defaultMode;
+  const mode = (mcp as Record<string, unknown>).mode;
+  if (mode === 'shadow' || mode === 'enforce') return mode;
+  return defaultMode;
+}
+
+/**
+ * Convenience: is this the dev electron-forge / vitest environment? Used
+ * by main/index.ts to pick the right default at boot.
+ *
+ * `electron-forge start` / `npm start` set NODE_ENV=development. Test
+ * harness (vitest) sets NODE_ENV=test. Either way, the substrate should
+ * default to shadow so a bad commit doesn't lock the developer out.
+ */
+export function detectIsDev(): boolean {
+  const env = process.env.NODE_ENV;
+  if (env === 'development' || env === 'test') return true;
+  // Electron exposes `app.isPackaged` — false when running from source.
+  // Avoid importing electron here so this stays usable from unit tests;
+  // main/index.ts passes the explicit flag.
+  return false;
+}

--- a/src/main/mcp/methodCapabilityMap.ts
+++ b/src/main/mcp/methodCapabilityMap.ts
@@ -1,0 +1,301 @@
+// Single declarative source of truth: which capability gates each RPC method,
+// and (when applicable) how to extract path strings from request params for
+// the path-glob check.
+//
+// Phase 2.2 design (plan D1/D2): the central gate at RpcRouter.dispatch
+// resolves both the capability check AND the path check from this table.
+// `Record<RpcMethod, RequiredCapability>` makes a new RPC method without an
+// entry a TypeScript compile-time error — "I added a method but forgot to
+// gate it" surfaces in `tsc --noEmit`, not in code review.
+//
+// Capability layer vs method layer (spec §3.5):
+//   - capability names come from KNOWN_CAPABILITIES in permissionGrammar.ts
+//     (`events.subscribe`, `terminal.read`, ...)
+//   - RPC methods are the wire names (`events.poll`, `input.readScreen`, ...)
+// One capability can gate several methods (e.g. `terminal.read` gates both
+// `input.readScreen` and `terminal.readEvents`).
+//
+// Identity bootstrap (`mcp.identify`, `mcp.declarePermissions`) appears in
+// the table with `capability: null` rather than being a hard-coded enforcer
+// special case (architect-reviewer + backend-architect both flagged this in
+// the plan-review pass — the table stays single-source-of-truth even for
+// "no gate" methods).
+//
+// Internal-only surfaces (daemon control, company subsystem, surface
+// arrangement) map to the reserved `wmux.internal` capability. The
+// permissionGrammar reserves the `wmux.` prefix, so no plugin can ever
+// declare it; legacy callers (no `clientName` envelope) fall through the
+// grandfather path in RpcRouter and stay allowed during the v3.0 transition.
+
+import type { RpcMethod } from '../../shared/rpc';
+
+/**
+ * Capability declared by a plugin (matched against KNOWN_CAPABILITIES in
+ * permissionGrammar.ts at parse time) or one of two sentinels:
+ *   - `null`             — method is bootstrap-exempt; no capability needed
+ *   - `'wmux.internal'`  — substrate-internal method; reserved prefix, no
+ *                          plugin can ever satisfy this. Legacy (no envelope)
+ *                          callers grandfather through RpcRouter's existing
+ *                          legacy path.
+ */
+export type RequiredCapabilityName = string | null;
+
+/**
+ * Extracts the path strings being touched by a request, for the path-glob
+ * check. Return types:
+ *   - `undefined`           — method has no path to check (capability-only gate)
+ *   - `string`              — single path (single-path methods like pane.setMetadata)
+ *   - `string[]`            — multiple paths (e.g. events.poll with `types: [...]`)
+ *
+ * The `'handler-resolves'` sentinel reserves an escape hatch for methods
+ * whose path can only be known after handler-side resolution (e.g. when a
+ * `paneId` must be looked up to determine its workspace before the path is
+ * knowable). Such handlers MUST call `PermissionEnforcer.checkPath` themselves;
+ * the central gate only verifies the capability for them.
+ */
+export type PathExtractor =
+  | ((params: Record<string, unknown>) => string | string[] | undefined)
+  | 'handler-resolves';
+
+/**
+ * Risk class — drives the approval-dialog wording table (plan D5). The
+ * enforcer itself doesn't read this; ApprovalQueue uses it when rendering.
+ */
+export type RiskClass =
+  | 'terminal-content' // reads what's on the user's screen
+  | 'terminal-input'   // types into the user's panes
+  | 'browser'          // controls a Playwright browser
+  | 'metadata'         // labels / status / custom map writes
+  | 'events'           // event subscription
+  | 'pane-lifecycle'   // create/focus/list panes
+  | 'workspace'        // workspace claim/read
+  | 'a2a'              // agent-to-agent messaging
+  | 'internal';        // wmux.internal — never surfaced
+
+/**
+ * When `pathFromParams` yields multiple paths and some match the declaration
+ * while others don't, the dispatcher needs to know whether the method can
+ * proceed on the allowed subset:
+ *
+ *   - `'partial'`        — pass allowed paths through to handler (e.g. events.poll
+ *                          filtering to allowed topics)
+ *   - `'all-or-nothing'` — wholesale reject (e.g. pane.clearMetadata: cannot
+ *                          partially-clear)
+ *
+ * Default is `'all-or-nothing'`; only opt into partial when the handler's
+ * semantics support it.
+ */
+export type MultiPathMode = 'partial' | 'all-or-nothing';
+
+export interface RequiredCapability {
+  capability: RequiredCapabilityName;
+  pathFromParams?: PathExtractor;
+  riskClass?: RiskClass;
+  multiPathMode?: MultiPathMode;
+}
+
+// === Path extractors ===
+//
+// Pulled out as named functions so a stack trace in shadow-mode rejection
+// telemetry points at the right extractor, and so each can be unit-tested
+// in isolation.
+
+/** pane.setMetadata: each top-level field present in params contributes one path. */
+function pathsFromSetMetadata(params: Record<string, unknown>): string[] | undefined {
+  const paths: string[] = [];
+  if (typeof params.label === 'string') paths.push('label');
+  if (typeof params.role === 'string') paths.push('role');
+  if (typeof params.status === 'string') paths.push('status');
+  if (params.custom && typeof params.custom === 'object' && !Array.isArray(params.custom)) {
+    for (const key of Object.keys(params.custom as Record<string, unknown>)) {
+      paths.push(`custom.${key}`);
+    }
+  }
+  return paths.length > 0 ? paths : undefined;
+}
+
+/**
+ * pane.clearMetadata wipes the whole record. We enumerate shared paths
+ * explicitly so a plugin restricted to `meta.write:custom.foo.*` fails the
+ * gate (it must not nuke shared label/role/status owned by other plugins
+ * or the user). Custom subtrees can't be enumerated without reading the
+ * store, so the gate accepts the shared-paths check as a proxy for "broad
+ * meta.write" — a plugin with only `meta.write:custom.foo.*` will fail on
+ * 'label' and the all-or-nothing mode rejects wholesale.
+ */
+function pathsFromClearMetadata(): string[] {
+  return ['label', 'role', 'status'];
+}
+
+/**
+ * events.poll requests an event subscription filtered by `types`. Undefined
+ * means "all types" — represented as the literal path string `'**'` so a
+ * declaration like `events.subscribe:pane.*` (with its `^pane\.[^.]*$`
+ * regex) won't match (correctly requiring unrestricted `events.subscribe`).
+ */
+function pathsFromEventsPoll(params: Record<string, unknown>): string | string[] {
+  const types = params.types;
+  if (Array.isArray(types)) {
+    const filtered = types.filter((t): t is string => typeof t === 'string');
+    return filtered.length > 0 ? filtered : '**';
+  }
+  return '**';
+}
+
+// === The map ===
+
+export const METHOD_CAPABILITY: Record<RpcMethod, RequiredCapability> = {
+  // --- Identity bootstrap (spec §4.1, §4.2) ---
+  // MUST stay unconditionally callable so a fresh plugin can declare itself.
+  // Mirrors IDENTITY_OWN_METHODS in RpcRouter.ts.
+  'mcp.identify': { capability: null },
+  'mcp.declarePermissions': { capability: null },
+
+  // mcp.claimWorkspace lets a plugin attribute its RPCs to a specific
+  // workspace pane. External MCP plugins use this on connect to scope
+  // subsequent calls. `workspace.claim` is in KNOWN_CAPABILITIES.
+  'mcp.claimWorkspace': { capability: 'workspace.claim', riskClass: 'workspace' },
+
+  // --- Workspace / surface (spec leaves these internal for v3.0) ---
+  'workspace.list':    { capability: 'workspace.read', riskClass: 'workspace' },
+  'workspace.current': { capability: 'workspace.read', riskClass: 'workspace' },
+  'workspace.new':     { capability: 'wmux.internal' },
+  'workspace.focus':   { capability: 'wmux.internal' },
+  'workspace.close':   { capability: 'wmux.internal' },
+  'surface.list':      { capability: 'wmux.internal' },
+  'surface.new':       { capability: 'wmux.internal' },
+  'surface.focus':     { capability: 'wmux.internal' },
+  'surface.close':     { capability: 'wmux.internal' },
+
+  // --- Pane lifecycle ---
+  'pane.list':   { capability: 'pane.read', riskClass: 'pane-lifecycle' },
+  'pane.focus':  { capability: 'pane.read', riskClass: 'pane-lifecycle' },
+  'pane.split':  { capability: 'pane.create', riskClass: 'pane-lifecycle' },
+  'pane.search': { capability: 'pane.search', riskClass: 'terminal-content' },
+
+  // --- Metadata (spec §3.4) ---
+  'pane.setMetadata': {
+    capability: 'meta.write',
+    pathFromParams: pathsFromSetMetadata,
+    riskClass: 'metadata',
+    multiPathMode: 'all-or-nothing',
+  },
+  // getMetadata returns the whole blob; per-field filtering is a v3.1
+  // feature (would require handler-side projection). For v3.0 the gate
+  // checks capability only — declaring `meta.read:custom.foo.*` still
+  // returns the full record, scoped reads come later.
+  'pane.getMetadata': { capability: 'meta.read', riskClass: 'metadata' },
+  'pane.clearMetadata': {
+    capability: 'meta.write',
+    pathFromParams: pathsFromClearMetadata,
+    riskClass: 'metadata',
+    multiPathMode: 'all-or-nothing',
+  },
+
+  // --- Workspace-level meta (status/progress text). The §3.4 path
+  //     namespace is pane-scoped; workspace-level keys aren't yet enumerated
+  //     in the spec, so for v3.0 these gate on `meta.write` capability with
+  //     no per-field path check. Tighter scoping is a v3.1 follow-up.
+  'meta.setStatus':   { capability: 'meta.write', riskClass: 'metadata' },
+  'meta.setProgress': { capability: 'meta.write', riskClass: 'metadata' },
+  'meta.setSkills':   { capability: 'meta.write', riskClass: 'metadata' },
+
+  // --- Events (spec §3.5). Capability is `events.subscribe`; method is
+  //     `events.poll`. `params.types` controls the topic filter; undefined
+  //     means "everything" which only an unrestricted declaration satisfies.
+  'events.poll': {
+    capability: 'events.subscribe',
+    pathFromParams: pathsFromEventsPoll,
+    riskClass: 'events',
+    multiPathMode: 'partial',
+  },
+
+  // --- Terminal IO (spec §3.6) ---
+  'input.send':          { capability: 'terminal.send', riskClass: 'terminal-input' },
+  'input.sendKey':       { capability: 'terminal.send', riskClass: 'terminal-input' },
+  'input.readScreen':    { capability: 'terminal.read', riskClass: 'terminal-content' },
+  'terminal.readEvents': { capability: 'terminal.read', riskClass: 'terminal-content' },
+
+  // --- Notifications (substrate-side; bundled UI only) ---
+  'notify': { capability: 'wmux.internal' },
+
+  // --- System introspection. Identity-style bootstrap: any caller can ask
+  //     what version of wmux they're talking to or what capabilities are
+  //     exposed. No data leak; less than what a probe-by-error would yield.
+  'system.identify':     { capability: null },
+  'system.capabilities': { capability: null },
+
+  // --- Browser (Playwright). Plugins declaring these get the browser
+  //     risk-class prompt; all are gated against KNOWN_CAPABILITIES entries.
+  'browser.open':              { capability: 'browser.navigate', riskClass: 'browser' },
+  'browser.navigate':          { capability: 'browser.navigate', riskClass: 'browser' },
+  'browser.goBack':            { capability: 'browser.navigate', riskClass: 'browser' },
+  'browser.close':             { capability: 'browser.navigate', riskClass: 'browser' },
+  'browser.session.start':     { capability: 'browser.navigate', riskClass: 'browser' },
+  'browser.session.stop':      { capability: 'browser.navigate', riskClass: 'browser' },
+  'browser.session.status':    { capability: 'browser.read',     riskClass: 'browser' },
+  'browser.session.list':      { capability: 'browser.read',     riskClass: 'browser' },
+  'browser.type.humanlike':    { capability: 'browser.type',     riskClass: 'browser' },
+  'browser.cdp.target':        { capability: 'browser.read',     riskClass: 'browser' },
+  'browser.cdp.info':          { capability: 'browser.read',     riskClass: 'browser' },
+  'browser.screenshot':        { capability: 'browser.screenshot', riskClass: 'browser' },
+  'browser.evaluate':          { capability: 'browser.evaluate',   riskClass: 'browser' },
+  'browser.type.cdp':          { capability: 'browser.type',  riskClass: 'browser' },
+  'browser.click.cdp':         { capability: 'browser.click', riskClass: 'browser' },
+  'browser.press.cdp':         { capability: 'browser.type',  riskClass: 'browser' },
+
+  // --- Daemon control. Internal-only; reserved capability.
+  'daemon.createSession':    { capability: 'wmux.internal' },
+  'daemon.destroySession':   { capability: 'wmux.internal' },
+  'daemon.attachSession':    { capability: 'wmux.internal' },
+  'daemon.detachSession':    { capability: 'wmux.internal' },
+  'daemon.resizeSession':    { capability: 'wmux.internal' },
+  'daemon.listSessions':     { capability: 'wmux.internal' },
+  'daemon.readPromptEvents': { capability: 'wmux.internal' },
+  'daemon.ping':             { capability: 'wmux.internal' },
+  'daemon.shutdown':         { capability: 'wmux.internal' },
+  'daemon.compact':          { capability: 'wmux.internal' },
+
+  // --- A2A (agent-to-agent) ---
+  'a2a.resolve.identity': { capability: 'a2a.read',    riskClass: 'a2a' },
+  'a2a.whoami':           { capability: 'a2a.read',    riskClass: 'a2a' },
+  'a2a.discover':         { capability: 'a2a.read',    riskClass: 'a2a' },
+  'a2a.task.send':        { capability: 'a2a.send',    riskClass: 'a2a' },
+  'a2a.task.query':       { capability: 'a2a.read',    riskClass: 'a2a' },
+  'a2a.task.update':      { capability: 'a2a.send',    riskClass: 'a2a' },
+  'a2a.task.cancel':      { capability: 'a2a.execute', riskClass: 'a2a' },
+  'a2a.broadcast':        { capability: 'a2a.send',    riskClass: 'a2a' },
+
+  // --- Company subsystem (substrate-internal team/orchestration). All
+  //     internal for v3.0; can be re-classified once spec covers a2a teams.
+  'company.create':         { capability: 'wmux.internal' },
+  'company.destroy':        { capability: 'wmux.internal' },
+  'company.status':         { capability: 'wmux.internal' },
+  'company.addDept':        { capability: 'wmux.internal' },
+  'company.removeDept':     { capability: 'wmux.internal' },
+  'company.addMember':      { capability: 'wmux.internal' },
+  'company.removeMember':   { capability: 'wmux.internal' },
+  'company.broadcast':      { capability: 'wmux.internal' },
+  'company.sendDept':       { capability: 'wmux.internal' },
+  'company.sendMember':     { capability: 'wmux.internal' },
+  'company.message':        { capability: 'wmux.internal' },
+  'company.save':           { capability: 'wmux.internal' },
+  'company.restore':        { capability: 'wmux.internal' },
+  'company.templates':      { capability: 'wmux.internal' },
+  'company.worktreeSetup':  { capability: 'wmux.internal' },
+  'company.mergeDept':      { capability: 'wmux.internal' },
+  'company.a2a.whoami':     { capability: 'wmux.internal' },
+  'company.a2a.send':       { capability: 'wmux.internal' },
+  'company.a2a.broadcast':  { capability: 'wmux.internal' },
+  'company.a2a.inbox':      { capability: 'wmux.internal' },
+  'company.a2a.ack':        { capability: 'wmux.internal' },
+  'company.a2a.status':     { capability: 'wmux.internal' },
+  'company.provision':      { capability: 'wmux.internal' },
+  'company.provisionAll':   { capability: 'wmux.internal' },
+  'company.provisionCeo':   { capability: 'wmux.internal' },
+
+  // --- Hooks (Phase 1 hook plugin) ---
+  // Internal channel from the wmux-bundled hook plugin. No external plugin
+  // should fire these — `wmux.internal` keeps the gate closed.
+  'hooks.signal': { capability: 'wmux.internal' },
+};

--- a/src/main/mcp/methodCapabilityMap.ts
+++ b/src/main/mcp/methodCapabilityMap.ts
@@ -299,3 +299,128 @@ export const METHOD_CAPABILITY: Record<RpcMethod, RequiredCapability> = {
   // should fire these — `wmux.internal` keeps the gate closed.
   'hooks.signal': { capability: 'wmux.internal' },
 };
+
+/**
+ * Capability → RiskClass lookup. The methodCapabilityMap above is keyed by
+ * RPC method; the approval dialog needs to classify each *capability* a
+ * plugin declared, regardless of which methods that capability gates. This
+ * table is the second axis.
+ *
+ * Keep in sync with KNOWN_CAPABILITIES in permissionGrammar.ts — every
+ * grantable capability MUST appear here so the approval dialog can render
+ * appropriate copy. A future test pins this invariant.
+ *
+ * `wmux.internal` is intentionally absent: it's a reserved prefix that
+ * never appears in a plugin's declaration, so the dialog never renders it.
+ */
+export const CAPABILITY_RISK_CLASS: Record<string, RiskClass> = {
+  // Pane lifecycle and content
+  'pane.read':       'pane-lifecycle',
+  'pane.write':      'pane-lifecycle',
+  'pane.create':     'pane-lifecycle',
+  'pane.delete':     'pane-lifecycle',
+  'pane.search':     'terminal-content',
+  // Metadata
+  'meta.read':       'metadata',
+  'meta.write':      'metadata',
+  // Events
+  'events.subscribe':'events',
+  // Workspaces
+  'workspace.read':  'workspace',
+  'workspace.claim': 'workspace',
+  // Terminal IO
+  'terminal.send':   'terminal-input',
+  'terminal.read':   'terminal-content',
+  // Browser
+  'browser.navigate':  'browser',
+  'browser.click':     'browser',
+  'browser.type':      'browser',
+  'browser.screenshot':'browser',
+  'browser.evaluate':  'browser',
+  'browser.read':      'browser',
+  // A2A
+  'a2a.send':    'a2a',
+  'a2a.execute': 'a2a',
+  'a2a.read':    'a2a',
+};
+
+/**
+ * Risk-class → user-facing copy for the approval dialog (plan D5).
+ *
+ * Wording asymmetry is intentional. Terminal-content/input get bold-warning
+ * language that names the concrete privilege ("read what's on your screen,
+ * including secrets") — this is the difference between "I clicked Approve
+ * because metadata sounds harmless" and "I clicked Approve knowing exactly
+ * what I gave away." Metadata, events, pane-lifecycle, and workspace are
+ * intentionally neutral — they don't expose user data.
+ *
+ * `severity` drives the dialog's accent color (warning vs caution vs none).
+ * `summary` is the headline shown next to the capability name. `detail` is
+ * the paragraph shown in expanded view.
+ */
+export interface RiskClassCopy {
+  /** Severity level — drives visual treatment (color, icon, font weight). */
+  severity: 'critical' | 'caution' | 'neutral';
+  /** Short headline displayed inline with the capability name. */
+  summary: string;
+  /** Expanded paragraph explaining what the user is agreeing to. */
+  detail: string;
+}
+
+export const RISK_CLASS_COPY: Record<RiskClass, RiskClassCopy> = {
+  'terminal-content': {
+    severity: 'critical',
+    summary: 'Can read what is on your screen',
+    detail:
+      'Includes secrets, agent output, command history, and anything else visible in your terminal panes — even content that was on screen before the plugin connected.',
+  },
+  'terminal-input': {
+    severity: 'critical',
+    summary: 'Can type into your panes as if it were you',
+    detail:
+      'The plugin can send keystrokes (including Enter, Ctrl+C, and editor commands) to any pane in this workspace. Treat this with the same trust level as giving someone your keyboard.',
+  },
+  'browser': {
+    severity: 'caution',
+    summary: 'Can control a Playwright browser session',
+    detail:
+      'The plugin can open pages, click elements, type text, run JavaScript, and capture screenshots. Sites you log into in this browser are reachable by the plugin.',
+  },
+  'a2a': {
+    severity: 'caution',
+    summary: 'Can send and read agent-to-agent messages',
+    detail:
+      'The plugin can dispatch tasks to other agents in your wmux session and read their responses. `a2a.execute` additionally lets it spawn agents with bypassPermissions.',
+  },
+  'metadata': {
+    severity: 'neutral',
+    summary: 'Can label your panes',
+    detail:
+      'Reads and writes pane labels, statuses, and a per-plugin custom data map. Does not see terminal contents — only the substrate-managed metadata layer.',
+  },
+  'events': {
+    severity: 'neutral',
+    summary: 'Can subscribe to pane lifecycle events',
+    detail:
+      'Receives notifications when panes are created, closed, focused, or have their metadata changed. Payloads contain pane IDs and metadata, never terminal content.',
+  },
+  'pane-lifecycle': {
+    severity: 'neutral',
+    summary: 'Can list, create, and focus panes',
+    detail:
+      'The plugin can enumerate your panes and manipulate the layout. It cannot read terminal contents through these capabilities alone.',
+  },
+  'workspace': {
+    severity: 'neutral',
+    summary: 'Can read and claim workspaces',
+    detail:
+      'The plugin can see the list of workspaces and attribute its RPC calls to a specific one. No data leakage between workspaces.',
+  },
+  'internal': {
+    severity: 'critical',
+    summary: 'wmux internal — should never be shown to user',
+    detail:
+      'Reserved capability that no plugin can declare. If you see this in an approval dialog, file a bug.',
+  },
+};
+

--- a/src/main/pipe/RpcRouter.ts
+++ b/src/main/pipe/RpcRouter.ts
@@ -25,6 +25,17 @@ type RpcHandler = (
 type LegacyContactRecorder = (method: RpcMethod) => void;
 
 /**
+ * Counter for per-method legacy traffic (Phase 2.2 pre-commit 4). Lifts
+ * the process-once trust-DB write to a per-(envelope-less-method)
+ * counter so v3.1 can surface accurate "your old integrations are
+ * calling these RPCs" data. Best-effort: failures must never affect
+ * dispatch. Wired in main/index.ts to LegacyTrafficCounter; unit tests
+ * stub with a vi.fn(). When unset, the router behaves as if no counter
+ * is configured (no record, no log).
+ */
+type LegacyTrafficCounter = { record(method: RpcMethod): void };
+
+/**
  * Async lookup that resolves a clientName to the caller's current trust
  * record (or undefined if none exists). Wired by main/index.ts to
  * PluginTrustStore.get(); tests inject a synchronous stub. RpcRouter
@@ -57,6 +68,7 @@ const IDENTITY_OWN_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
 export class RpcRouter {
   private readonly handlers = new Map<RpcMethod, RpcHandler>();
   private legacyRecorder: LegacyContactRecorder | undefined;
+  private legacyTrafficCounter: LegacyTrafficCounter | undefined;
   private trustLookup: TrustLookup | undefined;
   private shadowSink: ShadowRejectionSink | undefined;
   // Process-once flag — the legacy bucket is a single audit entry, not a
@@ -75,6 +87,16 @@ export class RpcRouter {
   setLegacyContactRecorder(recorder: LegacyContactRecorder | undefined): void {
     this.legacyRecorder = recorder;
     this.legacyContactPersisted = false;
+  }
+
+  /**
+   * Wire the per-method legacy traffic counter (Phase 2.2 pre-commit 4).
+   * Called for EVERY envelope-less RPC (not process-once like the trust-DB
+   * recorder above). main/index.ts injects LegacyTrafficCounter pointed at
+   * the shadow audit log; unset is a no-op for tests that don't care.
+   */
+  setLegacyTrafficCounter(counter: LegacyTrafficCounter | undefined): void {
+    this.legacyTrafficCounter = counter;
   }
 
   /**
@@ -129,21 +151,37 @@ export class RpcRouter {
           : undefined,
     };
 
-    // Spec §2.2: requests without `clientName` are recorded as `legacy` so
-    // the enforcement PR can grandfather pre-v2.10 callers. Fire-and-forget
-    // and gated on a process-once flag (see comment on the field) — the
-    // recorder failing must never affect the actual RPC response.
-    if (
-      !ctx.clientName &&
-      !this.legacyContactPersisted &&
-      this.legacyRecorder &&
-      !IDENTITY_OWN_METHODS.has(request.method)
-    ) {
-      this.legacyContactPersisted = true;
-      try {
-        this.legacyRecorder(request.method);
-      } catch {
-        /* swallow — trust-store writes are best-effort */
+    // Spec §2.2: requests without `clientName` are recorded as `legacy`.
+    // Two side-channels fire here:
+    //
+    //   1. Process-once trust-DB write (`legacyRecorder`) — one row per
+    //      process in `~/.wmux/plugin-trust.json`. Enough to signal "this
+    //      process saw legacy traffic" without disk-pounding on every RPC.
+    //
+    //   2. Per-method counter (`legacyTrafficCounter`, Phase 2.2 pre-commit
+    //      4) — every call ticks a counter; threshold milestones flush a
+    //      summary entry to the shadow audit log so v3.1 can surface
+    //      accurate per-method legacy traffic data.
+    //
+    // Both are gated on `!IDENTITY_OWN_METHODS` so the identity bootstrap
+    // handlers (which own their own recording) don't double-count. Both
+    // are fire-and-forget and wrapped in try/catch — they MUST NOT
+    // affect dispatch latency or response.
+    if (!ctx.clientName && !IDENTITY_OWN_METHODS.has(request.method)) {
+      if (!this.legacyContactPersisted && this.legacyRecorder) {
+        this.legacyContactPersisted = true;
+        try {
+          this.legacyRecorder(request.method);
+        } catch {
+          /* swallow — trust-store writes are best-effort */
+        }
+      }
+      if (this.legacyTrafficCounter) {
+        try {
+          this.legacyTrafficCounter.record(request.method);
+        } catch {
+          /* swallow — counter is best-effort telemetry */
+        }
       }
     }
 

--- a/src/main/pipe/RpcRouter.ts
+++ b/src/main/pipe/RpcRouter.ts
@@ -1,9 +1,12 @@
 import type {
+  PluginIdentityRecord,
   RpcContext,
   RpcMethod,
+  RpcRejection,
   RpcRequest,
   RpcResponse,
 } from '../../shared/rpc';
+import { check as enforcerCheck } from '../mcp/PermissionEnforcer';
 
 // Handlers receive a per-request context as an optional second argument.
 // Existing handlers `(params) => ...` keep compiling because the extra
@@ -21,6 +24,28 @@ type RpcHandler = (
 // real ~/.wmux state.
 type LegacyContactRecorder = (method: RpcMethod) => void;
 
+/**
+ * Async lookup that resolves a clientName to the caller's current trust
+ * record (or undefined if none exists). Wired by main/index.ts to
+ * PluginTrustStore.get(); tests inject a synchronous stub. RpcRouter
+ * deliberately does NOT import PluginTrustStore directly — the trust
+ * store has FS side effects and the router must stay unit-testable
+ * without touching ~/.wmux state.
+ */
+type TrustLookup = (clientName: string) => Promise<PluginIdentityRecord | undefined>;
+
+/**
+ * Side-channel sink for would-be rejections during shadow mode. Wired by
+ * main/index.ts to ShadowRejectionLogger.append; the router calls it for
+ * every non-allow enforcer outcome regardless of whether dispatch ends up
+ * delivering the handler's result.
+ */
+type ShadowRejectionSink = (input: {
+  clientName: string | undefined;
+  method: RpcMethod;
+  rejection: RpcRejection;
+}) => void;
+
 // Methods that handle plugin identity themselves — they must NOT trigger
 // a parallel legacy write because their own handlers do the right thing
 // (record an `unconfirmed` contact via the resolved name).
@@ -32,6 +57,8 @@ const IDENTITY_OWN_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
 export class RpcRouter {
   private readonly handlers = new Map<RpcMethod, RpcHandler>();
   private legacyRecorder: LegacyContactRecorder | undefined;
+  private trustLookup: TrustLookup | undefined;
+  private shadowSink: ShadowRejectionSink | undefined;
   // Process-once flag — the legacy bucket is a single audit entry, not a
   // per-request log. After the first envelope-less RPC reaches the wire,
   // subsequent calls don't re-touch the trust DB until the process restarts.
@@ -48,6 +75,27 @@ export class RpcRouter {
   setLegacyContactRecorder(recorder: LegacyContactRecorder | undefined): void {
     this.legacyRecorder = recorder;
     this.legacyContactPersisted = false;
+  }
+
+  /**
+   * Phase 2.2 enforcer wiring (shadow mode). main/index.ts injects a lookup
+   * backed by PluginTrustStore.get; tests inject synchronous stubs. When
+   * unset, the enforcer runs with trust=undefined for every request (which
+   * is treated as legacy/grandfather → allow), making the router behave
+   * identically to pre-Phase-2.2 dispatch.
+   */
+  setTrustLookup(lookup: TrustLookup | undefined): void {
+    this.trustLookup = lookup;
+  }
+
+  /**
+   * Phase 2.2 shadow-mode sink. main/index.ts injects ShadowRejectionLogger;
+   * tests pass a vi.fn() to assert calls. When unset, would-be rejections
+   * are not recorded — useful for unit tests that don't care about the side
+   * channel.
+   */
+  setShadowRejectionSink(sink: ShadowRejectionSink | undefined): void {
+    this.shadowSink = sink;
   }
 
   async dispatch(request: RpcRequest): Promise<RpcResponse> {
@@ -96,6 +144,48 @@ export class RpcRouter {
         this.legacyRecorder(request.method);
       } catch {
         /* swallow — trust-store writes are best-effort */
+      }
+    }
+
+    // Phase 2.2 enforcement (shadow mode in this commit).
+    //
+    // Trust lookup is awaited only when a clientName is present — the
+    // enforcer's first-line branches (identity bootstrap, no-clientName
+    // legacy path) don't need a record, so we save a microtask hop on
+    // every legacy / pre-handshake RPC.
+    //
+    // Behaviour in this commit (pre-commit 3, shadow only): we call the
+    // enforcer, record any non-allow outcome to the shadow sink, and THEN
+    // proceed to invoke the handler regardless. This populates the shadow
+    // log with would-be rejections during the v3.0 dogfood window. The
+    // enforce-mode flip (pre-commit 6) will gate handler invocation on
+    // the outcome and convert rejections into RpcResponse failures.
+    let trust: PluginIdentityRecord | undefined;
+    if (ctx.clientName && this.trustLookup) {
+      try {
+        trust = await this.trustLookup(ctx.clientName);
+      } catch {
+        // Trust DB read errors fall through as undefined — the enforcer
+        // treats that as "self-named but not yet recorded" (unconfirmed),
+        // which in shadow mode just generates a log entry.
+        trust = undefined;
+      }
+    }
+    const outcome = enforcerCheck({
+      method: request.method,
+      params: request.params ?? {},
+      ctx,
+      trust,
+    });
+    if (outcome.kind !== 'allow' && this.shadowSink) {
+      try {
+        this.shadowSink({
+          clientName: ctx.clientName,
+          method: request.method,
+          rejection: outcome.rejection,
+        });
+      } catch {
+        /* shadow logging must never affect dispatch */
       }
     }
 

--- a/src/main/pipe/RpcRouter.ts
+++ b/src/main/pipe/RpcRouter.ts
@@ -7,6 +7,8 @@ import type {
   RpcResponse,
 } from '../../shared/rpc';
 import { check as enforcerCheck } from '../mcp/PermissionEnforcer';
+import type { EnforcementMode } from '../mcp/enforcementMode';
+import type { ApprovalQueue } from '../mcp/ApprovalQueue';
 
 // Handlers receive a per-request context as an optional second argument.
 // Existing handlers `(params) => ...` keep compiling because the extra
@@ -71,6 +73,20 @@ export class RpcRouter {
   private legacyTrafficCounter: LegacyTrafficCounter | undefined;
   private trustLookup: TrustLookup | undefined;
   private shadowSink: ShadowRejectionSink | undefined;
+  /**
+   * Phase 2.2 pre-commit 6: enforcement mode. Default is `shadow` so a
+   * router that was never explicitly set up (unit tests, transitional
+   * code paths) preserves pre-Phase-2.2 behavior. main/index.ts calls
+   * `setEnforcementMode` after reading `~/.wmux/config.json`.
+   */
+  private enforcementMode: EnforcementMode = 'shadow';
+  /**
+   * Phase 2.2 pre-commit 6: approval queue. When set AND mode === 'enforce'
+   * AND the enforcer rejects with identity-status:unconfirmed for a plugin
+   * that has declared capabilities, dispatch fires a prompt and threads
+   * the synchronously-available promptId into rejection.pendingApproval.
+   */
+  private approvalQueue: ApprovalQueue | undefined;
   // Process-once flag — the legacy bucket is a single audit entry, not a
   // per-request log. After the first envelope-less RPC reaches the wire,
   // subsequent calls don't re-touch the trust DB until the process restarts.
@@ -118,6 +134,26 @@ export class RpcRouter {
    */
   setShadowRejectionSink(sink: ShadowRejectionSink | undefined): void {
     this.shadowSink = sink;
+  }
+
+  /**
+   * Phase 2.2 pre-commit 6: switch between shadow (log + proceed) and
+   * enforce (log + return rejection). The mode is read from
+   * `~/.wmux/config.json` at main/index.ts boot time.
+   */
+  setEnforcementMode(mode: EnforcementMode): void {
+    this.enforcementMode = mode;
+  }
+
+  /**
+   * Phase 2.2 pre-commit 6: inject the approval queue. main/index.ts wires
+   * this with a renderer-IPC opener. When the enforcer rejects an
+   * unconfirmed plugin that has declared a capability set, the dispatcher
+   * fires `requestApproval` to surface the prompt and threads the
+   * synchronously-available promptId into the rejection.
+   */
+  setApprovalQueue(queue: ApprovalQueue | undefined): void {
+    this.approvalQueue = queue;
   }
 
   async dispatch(request: RpcRequest): Promise<RpcResponse> {
@@ -227,6 +263,53 @@ export class RpcRouter {
       }
     }
 
+    // Pre-commit 6: enforce-mode short-circuit. When mode is 'enforce',
+    // a non-allow outcome turns into an RPC failure response — the handler
+    // is NOT invoked. In 'shadow' mode (dogfood default), we still call
+    // the handler after logging, preserving pre-2.2 behavior.
+    if (outcome.kind !== 'allow' && this.enforcementMode === 'enforce') {
+      let rejection: RpcRejection = outcome.rejection;
+      // For unconfirmed identity with a non-empty declaration, surface an
+      // approval prompt and thread the synchronously-minted promptId into
+      // the rejection so the client can correlate its retry. The resolution
+      // promise is NOT awaited — clients poll/retry on their own cadence
+      // (OAuth `authorization_pending` precedent, plan D4).
+      if (
+        rejection.reason === 'identity-status' &&
+        rejection.status === 'unconfirmed' &&
+        trust?.declaredCapabilities &&
+        trust.declaredCapabilities.length > 0 &&
+        this.approvalQueue
+      ) {
+        try {
+          const handle = this.approvalQueue.requestApproval({
+            clientName: ctx.clientName ?? trust.name,
+            declaredCapabilities: trust.declaredCapabilities,
+            rationale: trust.rationale,
+          });
+          rejection = {
+            ...rejection,
+            pendingApproval: { promptId: handle.promptId },
+          };
+          // Intentionally not awaiting handle.resolution — dispatch returns
+          // immediately and the user's eventual decision is consumed by
+          // the next RPC the plugin makes.
+          handle.resolution.catch(() => {
+            /* swallow cancellations; downstream IPC error handlers cover the rest */
+          });
+        } catch {
+          /* approval queue failure must not block dispatch */
+        }
+      }
+      const errorMessage = renderRejectionMessage(rejection);
+      return {
+        id: request.id,
+        ok: false,
+        error: errorMessage,
+        rejection,
+      };
+    }
+
     try {
       const result = await handler(request.params ?? {}, ctx);
       return {
@@ -242,5 +325,30 @@ export class RpcRouter {
         error: message,
       };
     }
+  }
+}
+
+/**
+ * Human-readable error message for an RpcRejection. Composed inline at
+ * dispatch time so external clients reading only `error` (without the
+ * structured `rejection`) still see something useful. The structured
+ * variant has the full per-path detail.
+ */
+function renderRejectionMessage(r: RpcRejection): string {
+  switch (r.reason) {
+    case 'capability-not-declared':
+      return `${r.method}: capability "${r.capability}" was not declared by this plugin`;
+    case 'path-not-allowed':
+      return `${r.method}: path "${r.path}" not allowed by declared ${r.capability} globs [${r.declared.join(', ')}]`;
+    case 'paths-partially-allowed':
+      return `${r.method}: ${r.rejected.length} of ${r.allowed.length + r.rejected.length} paths not covered by declared ${r.capability} globs`;
+    case 'identity-status':
+      if (r.status === 'denied') {
+        return `${r.method}: plugin is denied; edit ~/.wmux/plugin-trust.json to restore`;
+      }
+      if (r.pendingApproval) {
+        return `${r.method}: awaiting user approval (promptId=${r.pendingApproval.promptId})`;
+      }
+      return `${r.method}: plugin is unconfirmed; call mcp.identify + mcp.declarePermissions first`;
   }
 }

--- a/src/main/pipe/__tests__/RpcRouter.test.ts
+++ b/src/main/pipe/__tests__/RpcRouter.test.ts
@@ -319,3 +319,84 @@ describe('RpcRouter shadow-mode enforcement wiring', () => {
     expect(response.ok).toBe(true);
   });
 });
+
+describe('RpcRouter legacy traffic counter', () => {
+  it('ticks on every envelope-less RPC (not process-once like the trust recorder)', async () => {
+    const router = makeRouter();
+    const counter = { record: vi.fn() };
+    router.setLegacyTrafficCounter(counter);
+
+    await router.dispatch({ id: 'r-1', method: 'pane.list', params: {} });
+    await router.dispatch({ id: 'r-2', method: 'pane.list', params: {} });
+    await router.dispatch({ id: 'r-3', method: 'pane.list', params: {} });
+
+    expect(counter.record).toHaveBeenCalledTimes(3);
+    expect(counter.record.mock.calls.map((c) => c[0])).toEqual([
+      'pane.list',
+      'pane.list',
+      'pane.list',
+    ]);
+  });
+
+  it('does NOT tick for envelope-carrying requests', async () => {
+    const router = makeRouter();
+    const counter = { record: vi.fn() };
+    router.setLegacyTrafficCounter(counter);
+
+    await router.dispatch({
+      id: 'r-1',
+      method: 'pane.list',
+      params: {},
+      clientName: 'p1',
+    });
+    expect(counter.record).not.toHaveBeenCalled();
+  });
+
+  it('does NOT tick for identity-bootstrap RPCs (handler owns identity recording)', async () => {
+    const router = new RpcRouter();
+    router.register('mcp.identify', async () => ({ ok: true }));
+    router.register('mcp.declarePermissions', async () => ({ ok: true }));
+    const counter = { record: vi.fn() };
+    router.setLegacyTrafficCounter(counter);
+
+    await router.dispatch({ id: 'r-1', method: 'mcp.identify', params: {} });
+    await router.dispatch({
+      id: 'r-2',
+      method: 'mcp.declarePermissions',
+      params: {},
+    });
+    expect(counter.record).not.toHaveBeenCalled();
+  });
+
+  it('runs in parallel with the process-once trust recorder (both fire on first call)', async () => {
+    const router = makeRouter();
+    const recorder = vi.fn();
+    const counter = { record: vi.fn() };
+    router.setLegacyContactRecorder(recorder);
+    router.setLegacyTrafficCounter(counter);
+
+    await router.dispatch({ id: 'r-1', method: 'pane.list', params: {} });
+    expect(recorder).toHaveBeenCalledTimes(1);
+    expect(counter.record).toHaveBeenCalledTimes(1);
+
+    // Second call: recorder is process-once (silent), counter keeps ticking.
+    await router.dispatch({ id: 'r-2', method: 'pane.list', params: {} });
+    expect(recorder).toHaveBeenCalledTimes(1);
+    expect(counter.record).toHaveBeenCalledTimes(2);
+  });
+
+  it('survives a throwing counter without failing the RPC', async () => {
+    const router = makeRouter();
+    router.setLegacyTrafficCounter({
+      record: () => {
+        throw new Error('counter blew up');
+      },
+    });
+    const response = await router.dispatch({
+      id: 'r-1',
+      method: 'pane.list',
+      params: {},
+    });
+    expect(response.ok).toBe(true);
+  });
+});

--- a/src/main/pipe/__tests__/RpcRouter.test.ts
+++ b/src/main/pipe/__tests__/RpcRouter.test.ts
@@ -1,11 +1,17 @@
 // Direct tests for the RpcRouter dispatch + envelope-context plumbing.
-// These cover the Phase 2.1 additions: per-request context lift, optional
-// handler second arg backwards-compat, and the legacy-contact recorder
-// that fires when an RPC arrives without a clientName envelope.
+// Covers Phase 2.1 additions (per-request context lift, optional handler
+// second arg backwards-compat, legacy-contact recorder) AND the Phase 2.2
+// shadow-mode enforcement wiring: trust lookup, would-be rejection
+// recording, and the "shadow never blocks" guarantee.
 
 import { describe, expect, it, vi } from 'vitest';
 import { RpcRouter } from '../RpcRouter';
-import type { RpcContext, RpcMethod } from '../../../shared/rpc';
+import type {
+  PluginIdentityRecord,
+  RpcContext,
+  RpcMethod,
+  RpcRejection,
+} from '../../../shared/rpc';
 
 type HandlerSig = (
   params: Record<string, unknown>,
@@ -134,5 +140,182 @@ describe('RpcRouter legacy-contact recorder', () => {
     router.setLegacyContactRecorder(second);
     await router.dispatch({ id: 'r-2', method: 'pane.list' as RpcMethod, params: {} });
     expect(second).toHaveBeenCalledTimes(1);
+  });
+});
+
+// === Phase 2.2 — shadow-mode enforcement ===
+
+function trustRecord(
+  overrides: Partial<PluginIdentityRecord> &
+    Pick<PluginIdentityRecord, 'name' | 'status'>,
+): PluginIdentityRecord {
+  return { firstSeen: 1000, lastSeen: 2000, ...overrides };
+}
+
+describe('RpcRouter shadow-mode enforcement wiring', () => {
+  it('queries trust lookup only for envelope-carrying requests', async () => {
+    const router = makeRouter();
+    const lookup = vi.fn(async () => undefined);
+    router.setTrustLookup(lookup);
+
+    await router.dispatch({ id: 'r-1', method: 'pane.list', params: {} });
+    expect(lookup).not.toHaveBeenCalled();
+
+    await router.dispatch({
+      id: 'r-2',
+      method: 'pane.list',
+      params: {},
+      clientName: 'p1',
+    });
+    expect(lookup).toHaveBeenCalledWith('p1');
+  });
+
+  it('proceeds to handler even when enforcer would reject (shadow does not block)', async () => {
+    const router = new RpcRouter();
+    const handler = vi.fn(async () => 'handler-ran');
+    router.register('pane.list', handler);
+    router.setTrustLookup(async () =>
+      trustRecord({
+        name: 'p1',
+        status: 'trusted',
+        declaredCapabilities: ['meta.read'],
+      }),
+    );
+    const sink = vi.fn();
+    router.setShadowRejectionSink(sink);
+
+    const response = await router.dispatch({
+      id: 'r-1',
+      method: 'pane.list',
+      params: {},
+      clientName: 'p1',
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(response.ok).toBe(true);
+    if (response.ok) expect(response.result).toBe('handler-ran');
+    expect(sink).toHaveBeenCalledTimes(1);
+    const sinkCall = sink.mock.calls[0][0] as {
+      clientName: string | undefined;
+      method: RpcMethod;
+      rejection: RpcRejection;
+    };
+    expect(sinkCall.method).toBe('pane.list');
+    expect(sinkCall.clientName).toBe('p1');
+    expect(sinkCall.rejection.reason).toBe('capability-not-declared');
+  });
+
+  it('does not log when the enforcer allows', async () => {
+    const router = new RpcRouter();
+    router.register('pane.list', async () => ({ panes: [] }));
+    router.setTrustLookup(async () =>
+      trustRecord({
+        name: 'p1',
+        status: 'trusted',
+        declaredCapabilities: ['pane.read'],
+      }),
+    );
+    const sink = vi.fn();
+    router.setShadowRejectionSink(sink);
+
+    await router.dispatch({
+      id: 'r-1',
+      method: 'pane.list',
+      params: {},
+      clientName: 'p1',
+    });
+    expect(sink).not.toHaveBeenCalled();
+  });
+
+  it('treats clientName-stamped requests with no trust record as unconfirmed (shadow logs, handler still runs)', async () => {
+    const router = makeRouter();
+    router.setTrustLookup(async () => undefined);
+    const sink = vi.fn();
+    router.setShadowRejectionSink(sink);
+
+    const response = await router.dispatch({
+      id: 'r-1',
+      method: 'pane.list',
+      params: {},
+      clientName: 'fresh-plugin',
+    });
+    expect(response.ok).toBe(true);
+    expect(sink).toHaveBeenCalledTimes(1);
+    const r = (sink.mock.calls[0][0] as { rejection: RpcRejection }).rejection;
+    expect(r.reason).toBe('identity-status');
+    if (r.reason === 'identity-status') expect(r.status).toBe('unconfirmed');
+  });
+
+  it('rejects identity-status=denied in shadow (handler still runs)', async () => {
+    const router = makeRouter();
+    router.setTrustLookup(async () =>
+      trustRecord({
+        name: 'p1',
+        status: 'denied',
+        declaredCapabilities: ['pane.read'],
+      }),
+    );
+    const sink = vi.fn();
+    router.setShadowRejectionSink(sink);
+
+    const response = await router.dispatch({
+      id: 'r-1',
+      method: 'pane.list',
+      params: {},
+      clientName: 'p1',
+    });
+    expect(response.ok).toBe(true); // shadow mode never blocks
+    const r = (sink.mock.calls[0][0] as { rejection: RpcRejection }).rejection;
+    expect(r.reason).toBe('identity-status');
+    if (r.reason === 'identity-status') expect(r.status).toBe('denied');
+  });
+
+  it('does not log identity bootstrap RPCs (capability: null in the map)', async () => {
+    const router = new RpcRouter();
+    router.register('mcp.identify', async () => ({ ok: true }));
+    router.setTrustLookup(async () => undefined);
+    const sink = vi.fn();
+    router.setShadowRejectionSink(sink);
+
+    await router.dispatch({
+      id: 'r-1',
+      method: 'mcp.identify',
+      params: {},
+      clientName: 'fresh-plugin',
+    });
+    expect(sink).not.toHaveBeenCalled();
+  });
+
+  it('swallows trust-lookup errors and treats them as no-record (shadow still runs)', async () => {
+    const router = makeRouter();
+    router.setTrustLookup(async () => {
+      throw new Error('disk read failed');
+    });
+    const sink = vi.fn();
+    router.setShadowRejectionSink(sink);
+
+    const response = await router.dispatch({
+      id: 'r-1',
+      method: 'pane.list',
+      params: {},
+      clientName: 'p1',
+    });
+    expect(response.ok).toBe(true);
+    // Treated as no-record → unconfirmed → shadow log fires.
+    expect(sink).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows shadow-sink errors so dispatch never fails because of telemetry', async () => {
+    const router = makeRouter();
+    router.setTrustLookup(async () => undefined);
+    router.setShadowRejectionSink(() => {
+      throw new Error('disk full');
+    });
+    const response = await router.dispatch({
+      id: 'r-1',
+      method: 'pane.list',
+      params: {},
+      clientName: 'p1',
+    });
+    expect(response.ok).toBe(true);
   });
 });

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -399,6 +399,34 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 };
 
+// Phase 2.2 — MCP plugin permission approval bridge.
+// Main fires PERMISSION_PROMPT_OPEN with the ApprovalPromptInfo payload
+// when an unconfirmed plugin needs the user's approval; the renderer's
+// PermissionApprovalDialog renders it and sends the decision back via
+// PERMISSION_PROMPT_RESOLVE. Both channels are shape-validated downstream
+// so a stale renderer can't corrupt the queue.
+(electronAPI as Record<string, unknown>).permissionPrompt = {
+  onOpen: (
+    callback: (info: {
+      promptId: string;
+      clientName: string;
+      declaredCapabilities: string[];
+      rationale?: string;
+    }) => void,
+  ) => {
+    const listener = (_event: unknown, info: Parameters<typeof callback>[0]) => callback(info);
+    ipcRenderer.on(IPC.PERMISSION_PROMPT_OPEN, listener);
+    return () => {
+      ipcRenderer.removeListener(IPC.PERMISSION_PROMPT_OPEN, listener);
+    };
+  },
+  resolve: (promptId: string, approved: boolean) =>
+    ipcRenderer.invoke(IPC.PERMISSION_PROMPT_RESOLVE, {
+      promptId,
+      approved,
+    }) as Promise<{ ok: boolean; error?: string }>,
+};
+
 contextBridge.exposeInMainWorld('electronAPI', electronAPI);
 
 /**

--- a/src/renderer/components/Approval/PermissionApprovalDialog.tsx
+++ b/src/renderer/components/Approval/PermissionApprovalDialog.tsx
@@ -1,0 +1,241 @@
+// Permission approval dialog (Phase 2.2 pre-commit 5).
+//
+// Stateless presentational component. The parsed prompt data + click
+// handlers are passed as props so:
+//   - The component can be rendered by the store-wired container that
+//     Pre-commit 6 will ship (subscribes to `pendingPermissionApproval`).
+//   - Tests render it via `renderToStaticMarkup` without needing a DOM
+//     library — the wording-asymmetry checks the Phase 2.2 risk-class
+//     copy table is intact.
+//
+// Layout mirrors `A2a/ExecuteApprovalDialog.tsx`: a centered modal with
+// risk-class grouping, per-group color treatment, and Approve/Deny on the
+// right rail. The risk-class severity drives the accent color so the
+// terminal-content / terminal-input asymmetry (plan D5) is immediately
+// visible — "can label your panes" sits in neutral grey, "can read what's
+// on your screen" sits in warning red.
+
+import {
+  CAPABILITY_RISK_CLASS,
+  RISK_CLASS_COPY,
+  type RiskClass,
+  type RiskClassCopy,
+} from '../../../main/mcp/methodCapabilityMap';
+import { parsePermission } from '../../../main/mcp/permissionGrammar';
+
+export interface PermissionApprovalDialogProps {
+  /** Plugin name (e.g. `claude-ai`, `my-org.my-tool`). */
+  clientName: string;
+  /**
+   * Permission strings as the plugin declared them (e.g.
+   * `meta.write:custom.dash.*`). Parsed for display; unknown grammar
+   * entries fall through with a neutral classification rather than
+   * crashing the dialog.
+   */
+  declaredCapabilities: readonly string[];
+  /** Optional reason text from the plugin's mcp.declarePermissions call. */
+  rationale?: string;
+  /** Called when the user clicks Approve. */
+  onApprove: () => void;
+  /** Called when the user clicks Deny. */
+  onDeny: () => void;
+}
+
+/**
+ * One row in the dialog's grouped capability list. Exported so tests can
+ * verify the grouping logic separately from the render.
+ */
+export interface CapabilityGroup {
+  riskClass: RiskClass;
+  copy: RiskClassCopy;
+  capabilities: { raw: string; capability: string; pathGlob?: string }[];
+}
+
+/**
+ * Group declared capabilities by risk class. Order of groups follows
+ * `GROUP_RENDER_ORDER` so critical items always appear first regardless of
+ * declaration order in the wire payload.
+ */
+const GROUP_RENDER_ORDER: RiskClass[] = [
+  'terminal-content',
+  'terminal-input',
+  'browser',
+  'a2a',
+  'metadata',
+  'events',
+  'pane-lifecycle',
+  'workspace',
+  'internal',
+];
+
+export function groupCapabilities(
+  declared: readonly string[],
+): CapabilityGroup[] {
+  const groups = new Map<RiskClass, CapabilityGroup>();
+  for (const raw of declared) {
+    const parsed = parsePermission(raw);
+    if (!parsed.ok) continue; // skip malformed; substrate already rejected at declare-time
+    const cap = parsed.permission.capability;
+    const risk =
+      CAPABILITY_RISK_CLASS[cap] ?? ('metadata' as RiskClass); // safe fallback
+    let group = groups.get(risk);
+    if (!group) {
+      group = {
+        riskClass: risk,
+        copy: RISK_CLASS_COPY[risk],
+        capabilities: [],
+      };
+      groups.set(risk, group);
+    }
+    group.capabilities.push({
+      raw,
+      capability: cap,
+      pathGlob: parsed.permission.pathGlob,
+    });
+  }
+  return GROUP_RENDER_ORDER.filter((r) => groups.has(r)).map(
+    (r) => groups.get(r) as CapabilityGroup,
+  );
+}
+
+function severityAccent(severity: RiskClassCopy['severity']): string {
+  switch (severity) {
+    case 'critical':
+      return 'var(--accent-red)';
+    case 'caution':
+      return 'var(--accent-yellow)';
+    case 'neutral':
+      return 'var(--text-subtle)';
+  }
+}
+
+/**
+ * Pure presentational dialog. The store-wired container in Pre-commit 6
+ * wraps this with `useStore` / IPC bindings.
+ */
+export function PermissionApprovalDialogView(
+  props: PermissionApprovalDialogProps,
+) {
+  const groups = groupCapabilities(props.declaredCapabilities);
+  const hasCritical = groups.some((g) => g.copy.severity === 'critical');
+  return (
+    <div
+      className="fixed inset-0 z-[70] flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.65)' }}
+      role="alertdialog"
+      aria-labelledby="permission-approval-title"
+    >
+      <div
+        className="flex flex-col gap-4 p-5 rounded-xl"
+        style={{
+          width: 540,
+          maxWidth: '92vw',
+          maxHeight: '90vh',
+          overflowY: 'auto',
+          backgroundColor: 'var(--bg-base)',
+          border: `1px solid ${hasCritical ? 'var(--accent-red)' : 'var(--accent-yellow)'}`,
+          boxShadow: '0 25px 60px rgba(0,0,0,0.75)',
+        }}
+      >
+        <div className="flex items-center gap-2">
+          <span
+            style={{
+              color: hasCritical ? 'var(--accent-red)' : 'var(--accent-yellow)',
+              fontSize: 18,
+            }}
+          >
+            {hasCritical ? '⚠' : '⚠'}
+          </span>
+          <p
+            id="permission-approval-title"
+            className="text-sm font-semibold font-mono"
+            style={{ color: 'var(--text-main)' }}
+          >
+            Plugin requesting permissions
+          </p>
+        </div>
+
+        <div className="text-xs font-mono" style={{ color: 'var(--text-sub)' }}>
+          <span style={{ color: 'var(--text-subtle)' }}>plugin:</span>{' '}
+          <span style={{ color: 'var(--text-main)' }}>{props.clientName}</span>
+        </div>
+
+        {props.rationale ? (
+          <div
+            className="text-xs p-3 rounded-md italic"
+            style={{
+              backgroundColor: 'var(--bg-mantle)',
+              color: 'var(--text-sub2)',
+            }}
+          >
+            "{props.rationale}"
+          </div>
+        ) : null}
+
+        <div className="flex flex-col gap-3">
+          {groups.map((group) => (
+            <div
+              key={group.riskClass}
+              className="flex flex-col gap-1 p-3 rounded-md"
+              style={{
+                backgroundColor: 'var(--bg-surface)',
+                borderLeft: `3px solid ${severityAccent(group.copy.severity)}`,
+              }}
+            >
+              <div
+                className="text-xs font-semibold"
+                style={{
+                  color:
+                    group.copy.severity === 'critical'
+                      ? 'var(--accent-red)'
+                      : group.copy.severity === 'caution'
+                        ? 'var(--accent-yellow)'
+                        : 'var(--text-main)',
+                  fontWeight: group.copy.severity === 'critical' ? 700 : 600,
+                }}
+              >
+                {group.copy.summary}
+              </div>
+              <div className="text-xs" style={{ color: 'var(--text-sub)' }}>
+                {group.copy.detail}
+              </div>
+              <ul
+                className="text-[11px] font-mono mt-1"
+                style={{ color: 'var(--text-sub2)' }}
+              >
+                {group.capabilities.map((cap, idx) => (
+                  <li key={`${cap.raw}-${idx}`}>· {cap.raw}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex items-center justify-end gap-2">
+          <button
+            onClick={props.onDeny}
+            className="px-4 py-1.5 rounded-lg text-xs font-medium transition-colors"
+            style={{
+              backgroundColor: 'var(--bg-surface)',
+              color: 'var(--text-subtle)',
+            }}
+          >
+            Deny
+          </button>
+          <button
+            onClick={props.onApprove}
+            className="px-4 py-1.5 rounded-lg text-xs font-medium transition-colors"
+            style={{
+              backgroundColor: hasCritical
+                ? 'var(--accent-red)'
+                : 'var(--accent-yellow)',
+              color: 'var(--bg-base)',
+            }}
+          >
+            Approve
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/Approval/PermissionApprovalDialogContainer.tsx
+++ b/src/renderer/components/Approval/PermissionApprovalDialogContainer.tsx
@@ -1,0 +1,59 @@
+// Store-wired container for the Phase 2.2 permission approval dialog
+// (pre-commit 6).
+//
+// Subscribes to the `permissionPrompt.onOpen` IPC channel exposed by
+// preload.ts. When the main process fires a prompt, the container holds
+// the latest info in local state and renders the dialog. Clicking Approve
+// or Deny calls `permissionPrompt.resolve(promptId, approved)` and clears
+// the local state. Local state is intentional — there's only ever one
+// permission prompt visible at a time, and the ApprovalQueue's dedupe
+// guarantees no two prompts share a key.
+
+import { useEffect, useState } from 'react';
+import { PermissionApprovalDialogView } from './PermissionApprovalDialog';
+
+interface PromptInfo {
+  promptId: string;
+  clientName: string;
+  declaredCapabilities: string[];
+  rationale?: string;
+}
+
+export default function PermissionApprovalDialogContainer() {
+  const [pending, setPending] = useState<PromptInfo | null>(null);
+
+  useEffect(() => {
+    const api = window.electronAPI.permissionPrompt;
+    if (!api) return; // preload may not expose this in older bundles
+    const off = api.onOpen((info) => {
+      setPending(info);
+    });
+    return off;
+  }, []);
+
+  if (!pending) return null;
+
+  const respond = async (approved: boolean) => {
+    const api = window.electronAPI.permissionPrompt;
+    if (!api) {
+      setPending(null);
+      return;
+    }
+    try {
+      await api.resolve(pending.promptId, approved);
+    } catch {
+      /* main-side error is non-fatal; UX-wise we still close the dialog */
+    }
+    setPending(null);
+  };
+
+  return (
+    <PermissionApprovalDialogView
+      clientName={pending.clientName}
+      declaredCapabilities={pending.declaredCapabilities}
+      rationale={pending.rationale}
+      onApprove={() => void respond(true)}
+      onDeny={() => void respond(false)}
+    />
+  );
+}

--- a/src/renderer/components/Approval/__tests__/PermissionApprovalDialog.test.tsx
+++ b/src/renderer/components/Approval/__tests__/PermissionApprovalDialog.test.tsx
@@ -1,0 +1,170 @@
+// Permission approval dialog tests (Phase 2.2 pre-commit 5).
+//
+// Vitest runs in node env without jsdom — same pattern as
+// NotificationPanel.test.tsx: pure helper coverage + `renderToStaticMarkup`
+// against the stateless view. The dialog has no internal state, so static
+// markup is enough to verify the wording-asymmetry contract.
+
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { createElement } from 'react';
+import {
+  groupCapabilities,
+  PermissionApprovalDialogView,
+  type PermissionApprovalDialogProps,
+} from '../PermissionApprovalDialog';
+
+const noop = () => undefined;
+
+function defaultProps(
+  overrides: Partial<PermissionApprovalDialogProps> = {},
+): PermissionApprovalDialogProps {
+  return {
+    clientName: 'demo-plugin',
+    declaredCapabilities: ['pane.read'],
+    onApprove: noop,
+    onDeny: noop,
+    ...overrides,
+  };
+}
+
+describe('groupCapabilities', () => {
+  it('groups by risk class', () => {
+    const groups = groupCapabilities([
+      'pane.read',
+      'meta.write:custom.foo.*',
+      'terminal.read',
+    ]);
+    const byClass = new Map(groups.map((g) => [g.riskClass, g]));
+    expect(byClass.get('pane-lifecycle')?.capabilities.map((c) => c.raw)).toEqual([
+      'pane.read',
+    ]);
+    expect(byClass.get('metadata')?.capabilities.map((c) => c.raw)).toEqual([
+      'meta.write:custom.foo.*',
+    ]);
+    expect(byClass.get('terminal-content')?.capabilities.map((c) => c.raw)).toEqual([
+      'terminal.read',
+    ]);
+  });
+
+  it('puts critical groups before neutral ones (asymmetry visible at a glance)', () => {
+    const groups = groupCapabilities([
+      'meta.write',
+      'pane.read',
+      'terminal.read',
+      'terminal.send',
+    ]);
+    // The fixed order is: terminal-content → terminal-input → browser →
+    // a2a → metadata → events → pane-lifecycle → workspace → internal.
+    // So critical groups (terminal-content, terminal-input) come first.
+    expect(groups[0].riskClass).toBe('terminal-content');
+    expect(groups[1].riskClass).toBe('terminal-input');
+    // Metadata follows after the critical band.
+    const metaIdx = groups.findIndex((g) => g.riskClass === 'metadata');
+    const paneIdx = groups.findIndex((g) => g.riskClass === 'pane-lifecycle');
+    expect(metaIdx).toBeLessThan(paneIdx);
+    // Both neutrals come after the critical band.
+    expect(metaIdx).toBeGreaterThan(1);
+  });
+
+  it('parses path-glob suffixes onto each capability entry', () => {
+    const groups = groupCapabilities([
+      'meta.write:custom.dash.*',
+      'meta.read:custom.dash.*',
+    ]);
+    const meta = groups.find((g) => g.riskClass === 'metadata');
+    expect(meta?.capabilities).toHaveLength(2);
+    expect(meta?.capabilities[0].pathGlob).toBe('custom.dash.*');
+    expect(meta?.capabilities[1].pathGlob).toBe('custom.dash.*');
+  });
+
+  it('skips malformed entries silently (substrate already rejected them at declare-time)', () => {
+    const groups = groupCapabilities([
+      'pane.read',
+      'made.up.capability', // unknown — parser returns ok:false
+    ]);
+    const total = groups.reduce((acc, g) => acc + g.capabilities.length, 0);
+    expect(total).toBe(1);
+  });
+});
+
+describe('PermissionApprovalDialogView — rendering', () => {
+  it('renders the plugin name and at least one capability row', () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        PermissionApprovalDialogView,
+        defaultProps({ declaredCapabilities: ['pane.read', 'meta.write'] }),
+      ),
+    );
+    expect(html).toContain('demo-plugin');
+    expect(html).toContain('pane.read');
+    expect(html).toContain('meta.write');
+  });
+
+  it('renders terminal-content copy in bold-critical wording', () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        PermissionApprovalDialogView,
+        defaultProps({ declaredCapabilities: ['terminal.read'] }),
+      ),
+    );
+    // Risk-class summary text appears verbatim.
+    expect(html).toContain('Can read what is on your screen');
+    // Critical severity drives accent-red color (CSS var name appears in the
+    // inline style for the section's border or text color).
+    expect(html).toMatch(/accent-red/);
+  });
+
+  it('renders metadata copy with neutral wording (no scary language)', () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        PermissionApprovalDialogView,
+        defaultProps({ declaredCapabilities: ['meta.write'] }),
+      ),
+    );
+    expect(html).toContain('Can label your panes');
+    // No accent-red treatment for a pure-metadata dialog.
+    expect(html).not.toMatch(/accent-red/);
+  });
+
+  it('renders rationale verbatim when provided', () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        PermissionApprovalDialogView,
+        defaultProps({
+          rationale: 'demo dashboard sample text',
+        }),
+      ),
+    );
+    expect(html).toContain('demo dashboard sample text');
+  });
+
+  it('skips the rationale block when not provided', () => {
+    const html = renderToStaticMarkup(
+      createElement(PermissionApprovalDialogView, defaultProps()),
+    );
+    // No italic rationale block in markup.
+    expect(html).not.toMatch(/font-style:\s*italic/);
+  });
+
+  it('renders Approve and Deny buttons with the action labels', () => {
+    const html = renderToStaticMarkup(
+      createElement(PermissionApprovalDialogView, defaultProps()),
+    );
+    expect(html).toContain('>Approve<');
+    expect(html).toContain('>Deny<');
+  });
+
+  it('uses critical accent when ANY declared capability is critical', () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        PermissionApprovalDialogView,
+        defaultProps({
+          declaredCapabilities: ['meta.write', 'terminal.read'],
+        }),
+      ),
+    );
+    // Critical present → Approve button styled with accent-red.
+    expect(html).toMatch(/accent-red/);
+  });
+});

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -11,6 +11,7 @@ import SettingsPanel from '../Settings/SettingsPanel';
 import FileTreePanel from '../FileTree/FileTreePanel';
 import ApprovalDialog from '../Company/ApprovalDialog';
 import ExecuteApprovalDialog from '../A2a/ExecuteApprovalDialog';
+import PermissionApprovalDialogContainer from '../Approval/PermissionApprovalDialogContainer';
 import CompanyView from '../Company/CompanyView';
 import MessageFeedPanel from '../Company/MessageFeedPanel';
 import OnboardingOverlay from '../Onboarding/OnboardingOverlay';
@@ -905,6 +906,7 @@ export default function AppLayout() {
       <SettingsPanel />
       <ApprovalDialog />
       <ExecuteApprovalDialog />
+      <PermissionApprovalDialogContainer />
 
       {onboardingActive && (
         <OnboardingOverlay onComplete={() => { completeOnboarding(); }} />

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -41,6 +41,13 @@ export const IPC = {
   AUTO_UPDATE_ENABLED: 'settings:auto-update-enabled',
   // Agent critical action approval
   APPROVAL_REQUEST: 'approval:request',
+  // Phase 2.2 — MCP plugin permission approval (main → renderer subscribe,
+  // renderer → main response). Emitted when the enforcer rejects an
+  // unconfirmed plugin in enforce mode and the ApprovalQueue mints a
+  // prompt. The renderer's PermissionApprovalDialog renders the prompt
+  // and sends the user's decision back over PERMISSION_PROMPT_RESOLVE.
+  PERMISSION_PROMPT_OPEN: 'permission:prompt-open',
+  PERMISSION_PROMPT_RESOLVE: 'permission:prompt-resolve',
   // Shell
   SHELL_OPEN_EXTERNAL: 'shell:open-external',
   // Open an absolute filesystem path in the OS default app / explorer.

--- a/src/shared/electron.d.ts
+++ b/src/shared/electron.d.ts
@@ -54,6 +54,25 @@ declare global {
         onSampleTaskReady: (callback: () => void) => () => void;
         onSampleTaskTimeout: (callback: () => void) => () => void;
       };
+      /**
+       * Phase 2.2 — MCP plugin permission approval. Main fires `onOpen`
+       * with the prompt payload; renderer resolves via `resolve(promptId,
+       * approved)`. See `PermissionApprovalDialog` for the UX.
+       */
+      permissionPrompt?: {
+        onOpen: (
+          callback: (info: {
+            promptId: string;
+            clientName: string;
+            declaredCapabilities: string[];
+            rationale?: string;
+          }) => void,
+        ) => () => void;
+        resolve: (
+          promptId: string,
+          approved: boolean,
+        ) => Promise<{ ok: boolean; error?: string }>;
+      };
     };
     clipboardAPI: {
       /**

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -33,7 +33,7 @@ export interface RpcContext {
 
 export type RpcResponse =
   | { id: string; ok: true; result: unknown }
-  | { id: string; ok: false; error: string };
+  | { id: string; ok: false; error: string; rejection?: RpcRejection };
 
 // Structured rejection surfaced by the Phase 2.2 permission enforcer.
 //

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -35,6 +35,46 @@ export type RpcResponse =
   | { id: string; ok: true; result: unknown }
   | { id: string; ok: false; error: string };
 
+// Structured rejection surfaced by the Phase 2.2 permission enforcer.
+//
+// Defined here as a standalone exported type so the enforcer module (pure,
+// non-wire-format) can share a vocabulary with the eventual RpcResponse
+// extension that carries it. Pre-commit 2 wires this into RpcResponse;
+// callers that switch on `r.ok` keep narrowing as before, and ones that
+// want machine-readable rejection detail branch on `rejection.reason`.
+//
+// `pendingApproval.promptId` is minted by ApprovalQueue (Pre-commit 5) so
+// the client can correlate a rejection with the user-facing prompt and
+// retry once the prompt resolves — see plan D4 for the OAuth
+// `authorization_pending` precedent.
+export type RpcRejection =
+  | {
+      reason: 'capability-not-declared';
+      method: RpcMethod;
+      capability: string;
+    }
+  | {
+      reason: 'path-not-allowed';
+      method: RpcMethod;
+      capability: string;
+      path: string;
+      declared: string[];
+    }
+  | {
+      reason: 'paths-partially-allowed';
+      method: RpcMethod;
+      capability: string;
+      allowed: string[];
+      rejected: { path: string; declared: string[] }[];
+    }
+  | {
+      reason: 'identity-status';
+      method: RpcMethod;
+      capability: string;
+      status: 'denied' | 'unconfirmed';
+      pendingApproval?: { promptId: string };
+    };
+
 // === RPC Method definitions ===
 export type RpcMethod =
   | 'workspace.list'


### PR DESCRIPTION
## Summary

Lands the active enforcement layer on top of the Phase 2.1 record-only identity + grammar substrate (#48) and the spec-side default rules (#68). Plugins that declare a capability set via `mcp.declarePermissions` now have those declarations verified against every RPC they issue.

- Pure-function `PermissionEnforcer` checks capability + path against the trust record at every dispatch.
- Single declarative `methodCapabilityMap` (`Record<RpcMethod, RequiredCapability>` — `tsc --noEmit` enforces totality).
- Structured `RpcRejection` discriminated union on the `RpcResponse` failure arm (`capability-not-declared`, `path-not-allowed`, `paths-partially-allowed`, `identity-status`).
- Per-method legacy traffic counter + JSONL shadow audit log under `~/.wmux/shadow-rejections.log`.
- Risk-class-grouped `PermissionApprovalDialog` with asymmetric wording (terminal-content / terminal-input get bold-warning copy; metadata / events get neutral copy).
- `mcp.mode` feature flag in `~/.wmux/config.json` — production defaults to `enforce`, dev defaults to `shadow` for dogfood rollback safety.

cc @alphabeen — closes #31's structured-per-path rejection ask (D3 in the plan).

## Architecture decisions (D1–D7, plan)

Architectural choices were socialised through architect-reviewer + backend-architect second opinions before code; both reviewers concurrent on every load-bearing call.

- **D1: Fully central gate.** Both capability and path checked at `RpcRouter.dispatch` via a data-driven `pathFromParams: (params) => string | string[]` extractor. `Record<RpcMethod, ...>` gives compile-time totality. Handler-local checks reserved for state-dependent paths via the `'handler-resolves'` sentinel.
- **D2: Single declarative method→capability table.** Identity bootstrap (`mcp.identify`, `mcp.declarePermissions`, `system.identify`, `system.capabilities`) is `capability: null` in the table — NOT a hard-coded special case in the enforcer.
- **D3: Discriminated `RpcRejection` union, additive on the failure arm only.** Preserves narrowing for every existing `switch (r.ok)` call site.
- **D4: Reject-with-`pendingApproval`, not block.** OAuth `authorization_pending` precedent. Blocking would pin sockets (50-conn cap → DoS against own pool) and create a substrate-wide failure mode when the renderer stalls. Plugins retry on the `promptId`.
- **D5: Wording asymmetry.** Risk class drives the dialog copy. Terminal-content / terminal-input get critical severity with concrete language ("can read what's on your screen, including secrets"); metadata / events / pane-lifecycle / workspace get neutral copy.
- **D6: 3-layer tests** — pure-function unit + RpcRouter integration + e2e dynamic against real disk.
- **D7: 7-commit phased rollout.** Shadow mode (commits 1–4) collects audit data without affecting behavior; commit 5 ships the UI inert; commit 6 flips the gate behind a user-toggleable feature flag.

## What's in this PR

| Commit | Scope |
|---|---|
| `3b53824` | Plan doc (D1–D7 decisions, predecessors, surface map) |
| `8d647cb` | Pre-commit 1: `methodCapabilityMap` + `PermissionEnforcer` (pure modules + 44 unit tests) |
| `35d9a3f` | Pre-commit 2: `RpcRejection` on `RpcResponse` failure arm (additive type, no behavior change) |
| `ff154ed` | Pre-commit 3: RpcRouter shadow-mode wiring + `ShadowRejectionLogger` |
| `6c30be7` | Pre-commit 4: `LegacyTrafficCounter` (per-method milestones, JSONL audit) |
| `a3becae` | End-to-end shadow-mode dynamic verification (10-step plugin lifecycle against real disk) |
| `d93db44` | Pre-commit 5: `ApprovalQueue` + `PermissionApprovalDialog` + risk-class wording infrastructure |
| `546979e` | Pre-commit 6: enforce-mode flip + `~/.wmux/config.json` `mcp.mode` + renderer IPC wiring |
| `b8de89a` | Pre-commit 7: spec §4.4 + inventory.md capability map + CHANGELOG |

## Test plan

- [x] Full vitest suite: **1931/1931 green** (1815 before this PR + 116 new tests — unit, integration, e2e dynamic).
- [x] `tsc --noEmit` clean on every commit.
- [x] End-to-end dynamic test (`phase-2-2-dynamic.test.ts`) replays a 10-step plugin lifecycle (legacy → unconfirmed → trusted → denied) against real disk; reads back `plugin-trust.json` AND `shadow-rejections.log` for every transition.
- [x] Enforce-mode test covers: capability-not-declared rejection, identity-status:unconfirmed with threaded `pendingApproval.promptId`, denied plugins do NOT mint prompts, full reject→approve→retry flow, bootstrap RPCs still allowed, legacy callers still allowed.
- [ ] User dogfood in dev wmux (`mcp.mode: shadow` default) across ≥2 plugin clients before merge.

## Predecessors / links

- Builds on #48 (record-only identity + grammar)
- Builds on #49 (trust-DB invariants)
- Builds on #68 (spec §3.4 / §3.5 / §3.6 default rules)
- Tracks #31 (Substrate 3.0 roadmap, alphabeen's structured-rejection ask)
- Plan: `plans/phase-2-2-enforcement.md` (committed in `3b53824`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)