### PR TITLE
feat(events): OSC 133 EventBus tee + agent.awaiting_input detector

### DIFF
--- a/integrations/shared/signal-types.ts
+++ b/integrations/shared/signal-types.ts
@@ -13,16 +13,25 @@
 /**
  * The kind of signal. Dispatch keys at the daemon side.
  *
- * - agent.stop          — agent finished its turn. Strongest "task done" signal.
- * - agent.activity      — per-tool-call activity ping (optional, may be dropped if too noisy).
- * - agent.subagent_stop — subagent finished (e.g. /team mode coordinator).
- * - agent.session_start — agent session began. Used to clear stale metadata.
+ * - agent.stop            — agent finished its turn. Strongest "task done" signal.
+ * - agent.activity        — per-tool-call activity ping (optional, may be dropped if too noisy).
+ * - agent.subagent_stop   — subagent finished (e.g. /team mode coordinator).
+ * - agent.session_start   — agent session began. Used to clear stale metadata.
+ * - agent.awaiting_input  — agent paused mid-turn for a y/N or approval prompt.
+ *                           Detector-only kind in v2.13.0: emitted by the
+ *                           regex-based AgentDetector when a confirmation
+ *                           pattern matches on a previously-gated agent. Hook
+ *                           bridges are not expected to emit this kind today;
+ *                           it is included in the union so HookSignalRouter
+ *                           can dedup detector signals through the same ledger
+ *                           shape used for `agent.stop`.
  */
 export type AgentSignalKind =
   | 'agent.stop'
   | 'agent.activity'
   | 'agent.subagent_stop'
-  | 'agent.session_start';
+  | 'agent.session_start'
+  | 'agent.awaiting_input';
 
 /**
  * SLUG-form agent identifiers. Matches AgentPattern.slug in AgentDetector.ts.

--- a/scripts/osc133-awaiting-input-dynamic.mjs
+++ b/scripts/osc133-awaiting-input-dynamic.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+/**
+ * PR #76 dynamic verification — end-to-end exercise of:
+ *   1. OSC 133 D EventBus tee (source:'osc133' lifecycle events)
+ *   2. agent.awaiting_input lifecycle (Claude approval-prompt regex)
+ *
+ * Both signals are wired BOTH on the local-mode PTYBridge path AND
+ * (after Codex round-1 P1) on the daemon-mode DaemonNotificationRouter
+ * path. The packaged Electron app boots in daemon mode by default, so
+ * this script exercises the daemon path — the production path Codex
+ * R1 caught as missing.
+ *
+ * Strategy: spawn the packaged Electron app, connect to its pipe,
+ * write a real PowerShell command into a PTY that emits OSC 133;D;<n>
+ * raw bytes, then poll the EventBus for the matching agent.lifecycle
+ * event. For awaiting_input, write a command that prints both the
+ * Claude gate phrase and an approval-prompt line.
+ *
+ * Isolation pattern: same as orchestrator-flow-dynamic.mjs — temp
+ * HOME, win32 pipe pre-flight, SIGKILL fallback.
+ */
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+const APP_EXE = path.join(REPO_ROOT, 'out', 'wmux-win32-x64', 'wmux.exe');
+const PIPE_NAME = `\\\\.\\pipe\\wmux-${os.userInfo().username}`;
+
+if (!fs.existsSync(APP_EXE)) {
+  console.error(`Packaged app missing at ${APP_EXE}. Run \`npm run package\` first.`);
+  process.exit(2);
+}
+
+function pipeAlive() {
+  return new Promise((resolve) => {
+    const sock = net.createConnection(PIPE_NAME);
+    const done = (val) => { try { sock.destroy(); } catch {} resolve(val); };
+    sock.once('connect', () => done(true));
+    sock.once('error', () => done(false));
+    setTimeout(() => done(false), 300);
+  });
+}
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-pr76-dyn-'));
+const AUTH_TOKEN_PATH = path.join(TEST_HOME, '.wmux-auth-token');
+
+let appProc;
+const cleanup = () => new Promise((resolve) => {
+  if (appProc && !appProc.killed) {
+    try { appProc.kill('SIGTERM'); } catch {}
+  }
+  setTimeout(() => {
+    if (appProc && !appProc.killed) { try { appProc.kill('SIGKILL'); } catch {} }
+    try { fs.rmSync(TEST_HOME, { recursive: true, force: true }); } catch {}
+    resolve();
+  }, 1500);
+});
+process.on('exit', () => {
+  if (appProc && !appProc.killed) { try { appProc.kill('SIGKILL'); } catch {} }
+});
+process.on('SIGINT', async () => { await cleanup(); process.exit(130); });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (label, fn, timeoutMs = 30000, intervalMs = 200) => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try { const v = await fn(); if (v) return v; } catch {}
+    await sleep(intervalMs);
+  }
+  throw new Error(`timeout waiting for ${label} after ${timeoutMs}ms`);
+};
+
+async function rpc(method, params = {}, token) {
+  return new Promise((resolve, reject) => {
+    const sock = net.createConnection(PIPE_NAME);
+    let buf = '';
+    let settled = false;
+    const id = randomUUID();
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try { sock.destroy(); } catch {}
+      reject(new Error(`rpc timeout: ${method}`));
+    }, 10000);
+
+    sock.once('connect', () => {
+      sock.write(JSON.stringify({ id, method, params, token }) + '\n');
+    });
+    sock.on('data', (chunk) => {
+      buf += chunk.toString('utf-8');
+      let nl;
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (!line) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id === id) {
+            settled = true;
+            clearTimeout(timer);
+            try { sock.destroy(); } catch {}
+            if (msg.ok === false) return reject(new Error(msg.error));
+            return resolve(msg.result ?? msg);
+          }
+        } catch { /* ignore non-json */ }
+      }
+    });
+    sock.once('error', (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+const checks = [];
+const check = (name, ok, detail) => {
+  checks.push({ name, ok, detail });
+  console.log(`${ok ? '✅' : '❌'} ${name}${detail ? ` — ${detail}` : ''}`);
+};
+
+// Poll until at least one event of `kind` shows up, or timeout. Returns the
+// first matching event (or null on timeout). Updates cursor in-place so the
+// caller can chain polls without seeing stale events.
+async function pollUntilEvent(token, wsId, cursorRef, predicate, label, timeoutMs = 8000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const poll = await rpc('events.poll', {
+      workspaceId: wsId,
+      cursor: cursorRef.value,
+      types: ['agent.lifecycle'],
+    }, token);
+    cursorRef.value = poll.nextCursor;
+    const events = poll.events ?? [];
+    const match = events.find(predicate);
+    if (match) return { event: match, all: events };
+    await sleep(200);
+  }
+  return { event: null, all: [] };
+}
+
+(async () => {
+  console.log(`pipe: ${PIPE_NAME}`);
+  console.log(`temp HOME: ${TEST_HOME}`);
+
+  if (await pipeAlive()) {
+    console.error('A wmux pipe already exists for this Windows user — aborting.');
+    await cleanup();
+    process.exit(3);
+  }
+
+  const isolatedEnv = {
+    ...process.env,
+    USERPROFILE: TEST_HOME,
+    HOME: TEST_HOME,
+    HOMEDRIVE: undefined,
+    HOMEPATH: undefined,
+    APPDATA: path.join(TEST_HOME, 'AppData', 'Roaming'),
+    LOCALAPPDATA: path.join(TEST_HOME, 'AppData', 'Local'),
+    WMUX_DISABLE_CDP: 'true',
+  };
+  fs.mkdirSync(isolatedEnv.APPDATA, { recursive: true });
+  fs.mkdirSync(isolatedEnv.LOCALAPPDATA, { recursive: true });
+
+  console.log('--- spawning Electron app ---');
+  appProc = spawn(APP_EXE, [], {
+    cwd: REPO_ROOT,
+    env: isolatedEnv,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: false,
+  });
+  appProc.stdout.on('data', (b) => process.stderr.write(`[app] ${b}`));
+  appProc.stderr.on('data', (b) => process.stderr.write(`[app:err] ${b}`));
+  appProc.on('exit', (code) => console.error(`[app] exited with ${code}`));
+
+  await waitFor('auth token file', () => fs.existsSync(AUTH_TOKEN_PATH), 30000);
+  const token = fs.readFileSync(AUTH_TOKEN_PATH, 'utf-8').trim();
+  console.log(`--- auth token loaded (${token.length} chars) ---`);
+
+  await waitFor('pipe ready', () => pipeAlive(), 15000);
+  console.log('--- pipe accepting connections ---');
+
+  // Give the renderer time to spin up its default workspace + pane + PTY.
+  await sleep(3500);
+
+  // 1) workspace.list — grab the default workspace + its activePtyId.
+  const wsResult = await rpc('workspace.list', {}, token);
+  const workspaces = wsResult?.workspaces ?? wsResult ?? [];
+  check('workspace.list returns >=1 workspace', workspaces.length >= 1, `count=${workspaces.length}`);
+  if (workspaces.length === 0) { await cleanup(); process.exit(1); }
+  const ws = workspaces[0];
+  const wsId = ws.id || ws.workspaceId;
+  const ptyId = ws.activePtyId ?? (Array.isArray(ws.ptyIds) ? ws.ptyIds[0] : null);
+  check('workspace has an active PTY', typeof ptyId === 'string' && ptyId.length > 0, `ptyId=${ptyId}`);
+  if (!ptyId) { await cleanup(); process.exit(1); }
+
+  // Baseline cursor — anything before this point (process.started, etc.)
+  // we discard. By-ref so pollUntilEvent can advance it.
+  const baseline = await rpc('events.poll', { workspaceId: wsId, types: ['agent.lifecycle'] }, token);
+  const cursorRef = { value: baseline.nextCursor };
+  check('events.poll accepts agent.lifecycle filter', Array.isArray(baseline?.events), `bootId=${baseline?.bootId?.slice(0, 8)}…`);
+
+  // Settle the shell prompt so any startup noise lands before our writes.
+  await sleep(800);
+
+  // ── Test 1: OSC 133 D with exitCode 0 (clean shell command lifecycle) ──
+  // We emit OSC 133 raw bytes via a PowerShell Write-Host with the
+  // [char]27 and [char]7 escapes. The shell prints ESC ] 133 ; D ; 0 BEL
+  // to its stdout; OscParser inside DaemonPTYBridge parses it; the daemon
+  // broadcasts a 'prompt.event'; DaemonNotificationRouter mirrors it as
+  // source:'osc133' on the EventBus.
+  const osc133D0 =
+    `[Console]::Write([char]27 + ']133;D;0' + [char]7)`;
+  await rpc('input.send', { ptyId, text: osc133D0, submit: true, raw: true }, token);
+  const r1 = await pollUntilEvent(
+    token, wsId, cursorRef,
+    (e) => e.type === 'agent.lifecycle' && e.source === 'osc133' && e.exitCode === 0,
+    'osc133 D exit=0',
+  );
+  check('OSC 133 D;0 → agent.lifecycle source:"osc133" with exitCode 0', !!r1.event, JSON.stringify(r1.event ?? { sawCount: r1.all.length }));
+  if (r1.event) {
+    check('  workspaceId scoped to caller', r1.event.workspaceId === wsId, `got=${r1.event.workspaceId}`);
+    check('  kind is agent.stop (osc133 lifecycle category)', r1.event.kind === 'agent.stop', `kind=${r1.event.kind}`);
+    check('  decision is emit (osc133 bypasses dedup ledger)', r1.event.decision === 'emit', `decision=${r1.event.decision}`);
+    check('  ptyId attached', r1.event.ptyId === ptyId, `ptyId=${r1.event.ptyId}`);
+    // agent may be null OR 'claude' depending on whether previous shell
+    // output gated the detector. Either is valid at this point; we tighten
+    // in Test 3 once the gate is explicitly tripped.
+    check('  agent field present (null or known slug)',
+      r1.event.agent === null || typeof r1.event.agent === 'string',
+      `agent=${r1.event.agent}`);
+  }
+
+  // ── Test 2: OSC 133 D with non-zero exit code ──
+  const osc133D1 =
+    `[Console]::Write([char]27 + ']133;D;1' + [char]7)`;
+  await rpc('input.send', { ptyId, text: osc133D1, submit: true, raw: true }, token);
+  const r2 = await pollUntilEvent(
+    token, wsId, cursorRef,
+    (e) => e.type === 'agent.lifecycle' && e.source === 'osc133' && e.exitCode === 1,
+    'osc133 D exit=1',
+  );
+  check('OSC 133 D;1 → agent.lifecycle with exitCode 1', !!r2.event, JSON.stringify(r2.event ?? { sawCount: r2.all.length }));
+
+  // ── Test 3: agent.awaiting_input via Claude gate + approval prompt ──
+  // First print the gate phrase to flip the AgentDetector into the Claude
+  // Code recognizer state, then print the approval line. The new
+  // line-end-anchored regex matches `Do you want to proceed?` on a line of
+  // its own; conversational mentions are rejected.
+  const gateAndPrompt =
+    `Write-Host 'Claude Code'; Write-Host 'Do you want to proceed?'`;
+  await rpc('input.send', { ptyId, text: gateAndPrompt, submit: true, raw: true }, token);
+  const r3 = await pollUntilEvent(
+    token, wsId, cursorRef,
+    (e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input',
+    'agent.awaiting_input lifecycle',
+  );
+  check('Claude gate + approval prompt → kind:"agent.awaiting_input"', !!r3.event, JSON.stringify(r3.event ?? { sawCount: r3.all.length }));
+  if (r3.event) {
+    check('  source is detector (regex-based)', r3.event.source === 'detector', `source=${r3.event.source}`);
+    check('  agent is claude (slug from gated detector)', r3.event.agent === 'claude', `agent=${r3.event.agent}`);
+    check('  workspaceId scoped', r3.event.workspaceId === wsId, `got=${r3.event.workspaceId}`);
+  }
+
+  // ── Test 4: Conversational mention does NOT trigger awaiting_input ──
+  // Round-5 P2 fix: full-line anchor rejects leading conversational
+  // phrases. We print a sentence that embeds the phrase mid-line, then
+  // verify no NEW awaiting_input event landed.
+  const cursorBeforeFalse = cursorRef.value;
+  const falsePositive =
+    `Write-Host 'Answer Do you want to proceed? with caution'`;
+  await rpc('input.send', { ptyId, text: falsePositive, submit: true, raw: true }, token);
+  // Sleep enough for any (mis)emit to land, then drain.
+  await sleep(2000);
+  const drainPoll = await rpc('events.poll', {
+    workspaceId: wsId,
+    cursor: cursorBeforeFalse,
+    types: ['agent.lifecycle'],
+  }, token);
+  cursorRef.value = drainPoll.nextCursor;
+  const awaitingAfterFalse = (drainPoll.events ?? []).filter(
+    (e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input',
+  );
+  check('Conversational "Do you want to proceed?" mid-line → no awaiting_input',
+    awaitingAfterFalse.length === 0,
+    `count=${awaitingAfterFalse.length}`);
+
+  // ── Summary ──────────────────────────────────────────────────────────
+  const passed = checks.filter((c) => c.ok).length;
+  const failed = checks.filter((c) => !c.ok).length;
+  console.log('\n──────────────────────────────────────────');
+  console.log(`PR #76 dynamic verification: ${passed}/${checks.length} passed`);
+  if (failed > 0) {
+    console.error(`\nFailures:`);
+    for (const c of checks) {
+      if (!c.ok) console.error(`  ❌ ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
+    }
+  }
+  console.log('──────────────────────────────────────────');
+
+  await cleanup();
+  process.exit(failed > 0 ? 1 : 0);
+})().catch(async (err) => {
+  console.error('Fatal:', err);
+  await cleanup();
+  process.exit(1);
+});

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -212,6 +212,17 @@ export class DaemonSessionManager extends EventEmitter {
       this.emit('session:critical', payload);
     });
 
+    // OSC 133 shell integration markers — daemon-side parsing populates
+    // PromptEventLog (canonical, byte-offset indexed); this re-emit teases
+    // out the same parsed PromptEvent so main-process notification routing
+    // can tee the D (command_end) marker to the EventBus as a
+    // `source:'osc133'` agent.lifecycle event. Without it, daemon-backed
+    // panes (the default production path) miss osc133 lifecycle entirely
+    // even though the daemon detects every marker correctly.
+    bridge.on('prompt', (payload) => {
+      this.emit('session:prompt', payload);
+    });
+
     bridge.on('cwd', (payload: { sessionId: string; cwd: string }) => {
       meta.cwd = payload.cwd;
     });

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -915,6 +915,21 @@ function wireEvents(
     pipeServer.broadcast(event);
   });
 
+  // OSC 133 prompt/command markers — broadcast to main so
+  // DaemonNotificationRouter can mirror the local-mode PTYBridge OSC 133
+  // tee onto the EventBus as `source:'osc133'` agent.lifecycle events.
+  // Daemon-side PromptEventLog remains the byte-offset authoritative log
+  // used by `terminal_read_events`; this broadcast is a parallel projection
+  // for workspaceId-scoped poll consumers.
+  sessionManager.on('session:prompt', (payload: { sessionId: string; event: { type: string; ts: number; byteOffset: number; exitCode?: number } }) => {
+    const event: DaemonEvent = {
+      type: 'prompt.event',
+      sessionId: payload.sessionId,
+      data: payload.event,
+    };
+    pipeServer.broadcast(event);
+  });
+
   // Explicit destroy (pty:dispose path): distinct from session:died (natural
   // PTY exit). Both must clear the main-side agentStatus so the sidebar dot
   // doesn't lie about a closed terminal (Codex P2).

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -385,6 +385,13 @@ export class DaemonClient extends EventEmitter {
         case 'agent.critical':
           this.emit('session:critical', { sessionId: event.sessionId, event: event.data });
           break;
+        case 'prompt.event':
+          // OSC 133 shell-integration marker (A/B/C/D) parsed in the daemon.
+          // DaemonNotificationRouter consumes this to tee the D variant onto
+          // the EventBus as a `source:'osc133'` agent.lifecycle event,
+          // matching the local-mode PTYBridge.OscParser case 133 path.
+          this.emit('session:prompt', { sessionId: event.sessionId, event: event.data });
+          break;
         default:
           break;
       }

--- a/src/main/notification/DaemonNotificationRouter.ts
+++ b/src/main/notification/DaemonNotificationRouter.ts
@@ -73,6 +73,19 @@ const WORKSPACE_LIST_CACHE_TTL_MS = 2_000;
 export class DaemonNotificationRouter {
   private cleanups: Array<() => void> = [];
   private lastAgentEventAt = new Map<string, number>();
+  /**
+   * Per-PTY last-known agent display name. Populated on every
+   * `session:agent` event so the `session:prompt` (OSC 133) handler can
+   * attach an agent slug to the EventBus tee. Without this cache, OSC 133
+   * events emitted in daemon mode would always carry `agent: null` even
+   * when AgentDetector has already gated a Claude Code / Codex CLI / ...
+   * session — losing parity with the local-mode PTYBridge case 133 path
+   * which reads `agentDetector.getLastAgent()` directly.
+   *
+   * Cleared on `session:died` / `session:destroyed` (alongside
+   * `lastAgentEventAt`) so stale agent labels never leak across PTY reuse.
+   */
+  private lastAgentNameByPty = new Map<string, string>();
   private workspaceCache: { value: WorkspaceListEntry[]; ts: number } | null = null;
 
   constructor(
@@ -150,7 +163,11 @@ export class DaemonNotificationRouter {
    * No throw path — daemon notification flow is best-effort and a tee
    * failure must never break the toast/sidebar update.
    */
-  private async emitDetectorLifecycle(ptyId: string, agentName: string): Promise<void> {
+  private async emitDetectorLifecycle(
+    ptyId: string,
+    agentName: string,
+    kind: 'agent.stop' | 'agent.awaiting_input' = 'agent.stop',
+  ): Promise<void> {
     try {
       const slug = agentDisplayToSlug(agentName);
       if (!slug) return;
@@ -159,7 +176,7 @@ export class DaemonNotificationRouter {
       // ~50-200ms workspace.list round-trip to match local-mode semantics.
       const hookRouter = this.getHookRouter?.() ?? null;
       const decision = hookRouter
-        ? hookRouter.recordDetector(slug, 'agent.stop', ptyId)
+        ? hookRouter.recordDetector(slug, kind, ptyId)
         : 'emit';
       // Now do the workspace lookup. If it fails or returns null we drop
       // the event entirely (event without scope = wrong subscriber routing)
@@ -171,13 +188,47 @@ export class DaemonNotificationRouter {
         type: 'agent.lifecycle',
         workspaceId,
         ptyId,
-        kind: 'agent.stop',
+        kind,
         source: 'detector',
         agent: slug,
         decision,
       });
     } catch (err) {
       console.warn('[DaemonNotificationRouter] emitDetectorLifecycle error:', err);
+    }
+  }
+
+  /**
+   * OSC 133 mirror of PTYBridge's case 133 path for daemon-backed PTYs.
+   * Fires on every `command_end` PromptEvent forwarded from the daemon.
+   * Unlike `emitDetectorLifecycle`, this path:
+   *   - never goes through `HookSignalRouter.recordDetector` (OSC 133 is
+   *     shell command lifecycle, not agent-turn boundaries — dedup against
+   *     hook signals would conflate two different semantic levels)
+   *   - resolves agent slug from `lastAgentNameByPty` (best-effort);
+   *     emits `agent: null` when no agent context is gated, matching the
+   *     local-mode behavior
+   *   - sets `exitCode` from the parsed marker (`null` when the shell
+   *     omitted the suffix on `OSC 133;D`)
+   */
+  private async emitOsc133Lifecycle(ptyId: string, exitCode: number | null): Promise<void> {
+    try {
+      const workspaceId = await this.resolveWorkspaceIdForPty(ptyId);
+      if (!workspaceId) return;
+      const lastAgentName = this.lastAgentNameByPty.get(ptyId) ?? '';
+      const agentSlug = agentDisplayToSlug(lastAgentName) ?? null;
+      eventBus.emit({
+        type: 'agent.lifecycle',
+        workspaceId,
+        ptyId,
+        kind: 'agent.stop',
+        source: 'osc133',
+        agent: agentSlug,
+        decision: 'emit',
+        exitCode,
+      });
+    } catch (err) {
+      console.warn('[DaemonNotificationRouter] emitOsc133Lifecycle error:', err);
     }
   }
 
@@ -192,10 +243,20 @@ export class DaemonNotificationRouter {
           agentStatus: ev.status,
           agentName: ev.agent,
         });
-        if (ev.status === 'waiting' || ev.status === 'complete') {
+        // Cache the agent display name for any subsequent OSC 133
+        // command_end on this PTY. Daemon mode has no direct equivalent
+        // of `agentDetector.getLastAgent()` because the detector lives in
+        // the daemon process — the freshest signal main sees is each
+        // session:agent payload.
+        if (ev.agent) {
+          this.lastAgentNameByPty.set(payload.sessionId, ev.agent);
+        }
+        if (ev.status === 'waiting' || ev.status === 'complete' || ev.status === 'awaiting_input') {
           this.lastAgentEventAt.set(payload.sessionId, Date.now());
           const title = `${ev.agent}: ${ev.message}`;
-          const body = ev.status === 'waiting' ? 'Ready for input' : 'Task finished';
+          const body = ev.status === 'awaiting_input'
+            ? 'Awaiting input'
+            : ev.status === 'waiting' ? 'Ready for input' : 'Task finished';
           sendNotification(win, payload.sessionId, { type: 'agent', title, body });
           toastManager.show(title, body);
 
@@ -208,10 +269,34 @@ export class DaemonNotificationRouter {
           // and ledger update fire-and-forget — we don't await before
           // returning from the IPC handler, so the toast/sendNotification
           // path above is never blocked on a renderer round-trip.
-          void this.emitDetectorLifecycle(payload.sessionId, ev.agent);
+          //
+          // `awaiting_input` maps to its own lifecycle kind so orchestrators
+          // can distinguish "turn ended, next instruction please" from
+          // "agent paused mid-turn for a y/N answer". Parity with the
+          // local-mode PTYBridge.onEvent path added in the same patch.
+          const kind = ev.status === 'awaiting_input' ? 'agent.awaiting_input' : 'agent.stop';
+          void this.emitDetectorLifecycle(payload.sessionId, ev.agent, kind);
         }
       } catch (err) {
         console.warn('[DaemonNotificationRouter] session:agent error:', err);
+      }
+    };
+
+    // OSC 133 D markers from daemon mode. Mirror of PTYBridge.OscParser
+    // case 133 — the daemon already parsed the payload and forwarded a
+    // PromptEvent; we only need to dispatch `command_end` to the
+    // EventBus tee (PromptEventLog inside the daemon is the canonical
+    // byte-offset log; this is the parallel projection for
+    // workspaceId-scoped poll consumers).
+    const onPrompt = (payload: { sessionId: string; event: unknown }) => {
+      try {
+        const ev = payload.event as { type?: string; exitCode?: number } | null;
+        if (!ev || typeof ev !== 'object') return;
+        if (ev.type !== 'command_end') return;
+        const exitCode = typeof ev.exitCode === 'number' ? ev.exitCode : null;
+        void this.emitOsc133Lifecycle(payload.sessionId, exitCode);
+      } catch (err) {
+        console.warn('[DaemonNotificationRouter] session:prompt error:', err);
       }
     };
 
@@ -286,6 +371,7 @@ export class DaemonNotificationRouter {
           agentName: '',
         });
         this.lastAgentEventAt.delete(payload.sessionId);
+        this.lastAgentNameByPty.delete(payload.sessionId);
         clearSuppression(payload.sessionId);
       } catch (err) {
         console.warn('[DaemonNotificationRouter] session end error:', err);
@@ -296,6 +382,7 @@ export class DaemonNotificationRouter {
     this.daemonClient.on('session:active', onActive);
     this.daemonClient.on('session:idle', onIdle);
     this.daemonClient.on('session:critical', onCritical);
+    this.daemonClient.on('session:prompt', onPrompt);
     this.daemonClient.on('session:died', onSessionEnd);
     this.daemonClient.on('session:destroyed', onSessionEnd);
 
@@ -314,6 +401,7 @@ export class DaemonNotificationRouter {
       () => this.daemonClient.off('session:active', onActive),
       () => this.daemonClient.off('session:idle', onIdle),
       () => this.daemonClient.off('session:critical', onCritical),
+      () => this.daemonClient.off('session:prompt', onPrompt),
       () => this.daemonClient.off('session:died', onSessionEnd),
       () => this.daemonClient.off('session:destroyed', onSessionEnd),
       unsubscribeMeta,
@@ -326,6 +414,7 @@ export class DaemonNotificationRouter {
     }
     this.cleanups.length = 0;
     this.lastAgentEventAt.clear();
+    this.lastAgentNameByPty.clear();
     this.workspaceCache = null;
   }
 }

--- a/src/main/notification/DaemonNotificationRouter.ts
+++ b/src/main/notification/DaemonNotificationRouter.ts
@@ -212,11 +212,18 @@ export class DaemonNotificationRouter {
    *     omitted the suffix on `OSC 133;D`)
    */
   private async emitOsc133Lifecycle(ptyId: string, exitCode: number | null): Promise<void> {
+    // Snapshot the agent slug BEFORE awaiting workspace.list. The shell may
+    // emit `OSC 133;D` then redraw the prompt and trigger a `session:agent`
+    // update in the same burst; if we resolved the slug after the await,
+    // the cache could already reflect a future turn's agent, mis-attributing
+    // this command_end. This matches PTYBridge's local-mode case 133 path,
+    // which reads `agentDetector.getLastAgent()` synchronously before any
+    // EventBus emit (Codex round-2 P2).
+    const lastAgentName = this.lastAgentNameByPty.get(ptyId) ?? '';
+    const agentSlug = agentDisplayToSlug(lastAgentName) ?? null;
     try {
       const workspaceId = await this.resolveWorkspaceIdForPty(ptyId);
       if (!workspaceId) return;
-      const lastAgentName = this.lastAgentNameByPty.get(ptyId) ?? '';
-      const agentSlug = agentDisplayToSlug(lastAgentName) ?? null;
       eventBus.emit({
         type: 'agent.lifecycle',
         workspaceId,

--- a/src/main/notification/__tests__/DaemonNotificationRouter.lifecycle.test.ts
+++ b/src/main/notification/__tests__/DaemonNotificationRouter.lifecycle.test.ts
@@ -1,0 +1,284 @@
+// Tests for the `agent.lifecycle` EventBus tee fired from
+// DaemonNotificationRouter. Two sources are covered:
+//
+//   - detector — session:agent payloads with status 'waiting' / 'complete'
+//                emit kind:'agent.stop'; status 'awaiting_input' emits
+//                kind:'agent.awaiting_input' (new in PR #76).
+//   - osc133   — session:prompt payloads with type:'command_end' tee onto
+//                the EventBus as source:'osc133' (new in PR #76, daemon-mode
+//                mirror of PTYBridge.OscParser case 133).
+//
+// The existing cache test (DaemonNotificationRouter.cache.test.ts) covers
+// the workspace.list resolution path; this file focuses on dispatch shape.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { DaemonClient } from '../../DaemonClient';
+import type { HookSignalRouter } from '../../hooks/HookSignalRouter';
+import { eventBus } from '../../events/EventBus';
+
+vi.mock('electron', () => ({ BrowserWindow: class {} }));
+
+vi.mock('../../pipe/handlers/notify.rpc', () => ({
+  toastManager: { show: vi.fn() },
+}));
+
+vi.mock('../../ipc/handlers/metadata.handler', () => ({
+  broadcastMetadataUpdate: vi.fn(),
+}));
+
+vi.mock('../sendNotification', () => ({
+  sendNotification: vi.fn(),
+}));
+
+vi.mock('../idleSuppression', () => ({
+  recentlySuppressed: vi.fn().mockReturnValue(false),
+  clearPty: vi.fn(),
+}));
+
+vi.mock('../../pipe/handlers/_bridge', () => ({
+  sendToRenderer: vi.fn(),
+}));
+
+import { sendToRenderer } from '../../pipe/handlers/_bridge';
+import { DaemonNotificationRouter } from '../DaemonNotificationRouter';
+
+const sendToRendererMock = vi.mocked(sendToRenderer);
+
+const FIXTURE_WORKSPACE_LIST = [
+  { id: 'ws-1', name: 'Workspace 1', activePtyId: 'pty-a', ptyIds: ['pty-a', 'pty-b'] },
+];
+
+interface CapturedListeners {
+  agent?: (payload: { sessionId: string; event: unknown }) => void;
+  prompt?: (payload: { sessionId: string; event: unknown }) => void;
+  died?: (payload: { sessionId: string }) => void;
+}
+
+function makeRouter(opts: { hookRouter?: HookSignalRouter | null } = {}) {
+  const captured: CapturedListeners = {};
+  const fakeDaemon = {
+    on: vi.fn((event: string, cb: (payload: never) => void) => {
+      if (event === 'session:agent') captured.agent = cb as CapturedListeners['agent'];
+      if (event === 'session:prompt') captured.prompt = cb as CapturedListeners['prompt'];
+      if (event === 'session:died') captured.died = cb as CapturedListeners['died'];
+    }),
+    off: vi.fn(),
+  } as unknown as DaemonClient;
+  const getHookRouter = opts.hookRouter !== undefined ? () => opts.hookRouter ?? null : undefined;
+  const router = new DaemonNotificationRouter(fakeDaemon, () => null, getHookRouter);
+  router.start();
+  return { router, captured };
+}
+
+function stubHookRouter(decision: 'emit' | 'dedup'): HookSignalRouter {
+  return {
+    recordDetector: vi.fn().mockReturnValue(decision),
+    recordHook: vi.fn().mockReturnValue('emit'),
+  } as unknown as HookSignalRouter;
+}
+
+function pollLifecycle() {
+  return eventBus.poll(0, { types: ['agent.lifecycle'] }).events;
+}
+
+async function flushMicrotasks(): Promise<void> {
+  // emitDetectorLifecycle / emitOsc133Lifecycle await resolveWorkspaceIdForPty,
+  // which awaits the mocked sendToRenderer. Two ticks is enough to settle both.
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  sendToRendererMock.mockReset();
+  sendToRendererMock.mockResolvedValue(FIXTURE_WORKSPACE_LIST);
+  eventBus.reset();
+});
+
+afterEach(() => {
+  eventBus.reset();
+});
+
+describe('DaemonNotificationRouter — detector lifecycle tee (awaiting_input)', () => {
+  it('emits kind:"agent.awaiting_input" when session:agent reports status awaiting_input', async () => {
+    const { router, captured } = makeRouter();
+    try {
+      captured.agent!({
+        sessionId: 'pty-a',
+        event: { agent: 'Claude Code', status: 'awaiting_input', message: 'Approval requested' },
+      });
+      await flushMicrotasks();
+
+      const events = pollLifecycle();
+      const awaiting = events.find((e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input');
+      expect(awaiting).toMatchObject({
+        type: 'agent.lifecycle',
+        workspaceId: 'ws-1',
+        ptyId: 'pty-a',
+        kind: 'agent.awaiting_input',
+        source: 'detector',
+        agent: 'claude',
+        decision: 'emit',
+      });
+    } finally {
+      router.stop();
+    }
+  });
+
+  it('still emits kind:"agent.stop" for waiting/complete (regression)', async () => {
+    const { router, captured } = makeRouter();
+    try {
+      captured.agent!({
+        sessionId: 'pty-a',
+        event: { agent: 'Claude Code', status: 'waiting', message: 'Ready for input' },
+      });
+      await flushMicrotasks();
+
+      const events = pollLifecycle();
+      expect(events.length).toBe(1);
+      expect(events[0]).toMatchObject({ kind: 'agent.stop', source: 'detector' });
+    } finally {
+      router.stop();
+    }
+  });
+
+  it('routes awaiting_input through HookSignalRouter.recordDetector with the matching kind', async () => {
+    const router = stubHookRouter('emit');
+    const { router: nr, captured } = makeRouter({ hookRouter: router });
+    try {
+      captured.agent!({
+        sessionId: 'pty-a',
+        event: { agent: 'Claude Code', status: 'awaiting_input', message: 'Approval requested' },
+      });
+      await flushMicrotasks();
+
+      expect(router.recordDetector).toHaveBeenCalledWith('claude', 'agent.awaiting_input', 'pty-a');
+    } finally {
+      nr.stop();
+    }
+  });
+});
+
+describe('DaemonNotificationRouter — osc133 lifecycle tee', () => {
+  it('emits source:"osc133" on session:prompt with type:"command_end" and exitCode 0', async () => {
+    const { router, captured } = makeRouter();
+    try {
+      captured.prompt!({
+        sessionId: 'pty-a',
+        event: { type: 'command_end', ts: 1000, byteOffset: 42, exitCode: 0 },
+      });
+      await flushMicrotasks();
+
+      const events = pollLifecycle();
+      expect(events.length).toBe(1);
+      expect(events[0]).toMatchObject({
+        type: 'agent.lifecycle',
+        workspaceId: 'ws-1',
+        ptyId: 'pty-a',
+        kind: 'agent.stop',
+        source: 'osc133',
+        agent: null,
+        decision: 'emit',
+        exitCode: 0,
+      });
+    } finally {
+      router.stop();
+    }
+  });
+
+  it('emits exitCode null when command_end omits an exit code', async () => {
+    const { router, captured } = makeRouter();
+    try {
+      captured.prompt!({
+        sessionId: 'pty-a',
+        event: { type: 'command_end', ts: 1000, byteOffset: 42 },
+      });
+      await flushMicrotasks();
+
+      const events = pollLifecycle();
+      expect(events[0]).toMatchObject({ source: 'osc133', exitCode: null });
+    } finally {
+      router.stop();
+    }
+  });
+
+  it('ignores prompt_start / prompt_end / command_start (D-only emit)', async () => {
+    const { router, captured } = makeRouter();
+    try {
+      captured.prompt!({ sessionId: 'pty-a', event: { type: 'prompt_start', ts: 1, byteOffset: 0 } });
+      captured.prompt!({ sessionId: 'pty-a', event: { type: 'command_start', ts: 2, byteOffset: 5 } });
+      await flushMicrotasks();
+
+      expect(pollLifecycle()).toHaveLength(0);
+    } finally {
+      router.stop();
+    }
+  });
+
+  it('attaches the cached agent slug when a session:agent was seen first', async () => {
+    const { router, captured } = makeRouter();
+    try {
+      // First an agent event populates the lastAgentNameByPty cache.
+      captured.agent!({
+        sessionId: 'pty-a',
+        event: { agent: 'Claude Code', status: 'running', message: 'Working' },
+      });
+      await flushMicrotasks();
+      eventBus.reset(); // Drop the implicit detector emit; isolate osc133.
+
+      captured.prompt!({
+        sessionId: 'pty-a',
+        event: { type: 'command_end', ts: 1000, byteOffset: 42, exitCode: 1 },
+      });
+      await flushMicrotasks();
+
+      const events = pollLifecycle();
+      expect(events[0]).toMatchObject({ source: 'osc133', agent: 'claude', exitCode: 1 });
+    } finally {
+      router.stop();
+    }
+  });
+
+  it('osc133 bypasses HookSignalRouter — always decision:"emit"', async () => {
+    const router = stubHookRouter('dedup');
+    const { router: nr, captured } = makeRouter({ hookRouter: router });
+    try {
+      captured.prompt!({
+        sessionId: 'pty-a',
+        event: { type: 'command_end', ts: 1000, byteOffset: 42, exitCode: 0 },
+      });
+      await flushMicrotasks();
+
+      const events = pollLifecycle();
+      expect(events[0]).toMatchObject({ source: 'osc133', decision: 'emit' });
+      // recordDetector must NOT be called for osc133 — it's shell command
+      // lifecycle, not agent-turn boundaries.
+      expect(router.recordDetector).not.toHaveBeenCalled();
+    } finally {
+      nr.stop();
+    }
+  });
+
+  it('session:died clears the cached agent slug so subsequent osc133 emits null', async () => {
+    const { router, captured } = makeRouter();
+    try {
+      captured.agent!({
+        sessionId: 'pty-a',
+        event: { agent: 'Claude Code', status: 'running', message: 'Working' },
+      });
+      await flushMicrotasks();
+      captured.died!({ sessionId: 'pty-a' });
+
+      eventBus.reset();
+      captured.prompt!({
+        sessionId: 'pty-a',
+        event: { type: 'command_end', ts: 1000, byteOffset: 42, exitCode: 0 },
+      });
+      await flushMicrotasks();
+
+      const events = pollLifecycle();
+      expect(events[0]).toMatchObject({ source: 'osc133', agent: null });
+    } finally {
+      router.stop();
+    }
+  });
+});

--- a/src/main/notification/__tests__/DaemonNotificationRouter.lifecycle.test.ts
+++ b/src/main/notification/__tests__/DaemonNotificationRouter.lifecycle.test.ts
@@ -281,4 +281,55 @@ describe('DaemonNotificationRouter — osc133 lifecycle tee', () => {
       router.stop();
     }
   });
+
+  it('snapshots the cached agent slug BEFORE awaiting workspace.list (race fix)', async () => {
+    // Codex round-2 P2 — shell may emit OSC 133;D and then redraw the
+    // prompt, which fires a session:agent burst, all while the OSC 133
+    // tee is mid-await on workspace.list. If the slug were read AFTER
+    // the await it would reflect the new turn's agent, mis-attributing
+    // the just-completed command. PTYBridge local-mode snapshots
+    // `agentDetector.getLastAgent()` synchronously before any await;
+    // daemon-mode must match.
+    let resolveWorkspaceListRpc: (value: typeof FIXTURE_WORKSPACE_LIST) => void = () => {};
+    sendToRendererMock.mockImplementationOnce(
+      () => new Promise((res) => { resolveWorkspaceListRpc = res; }),
+    );
+
+    const { router, captured } = makeRouter();
+    try {
+      // Seed the cache with Claude (running is metadata-only — does NOT
+      // trigger emitDetectorLifecycle, so sendToRenderer is NOT consumed).
+      captured.agent!({
+        sessionId: 'pty-a',
+        event: { agent: 'Claude Code', status: 'running', message: 'Working' },
+      });
+
+      // OSC 133;D arrives — emitOsc133Lifecycle captures 'Claude Code'
+      // synchronously, then awaits the mocked workspace.list above.
+      captured.prompt!({
+        sessionId: 'pty-a',
+        event: { type: 'command_end', ts: 1000, byteOffset: 42, exitCode: 0 },
+      });
+
+      // While the await is pending, the shell redraws and a new agent
+      // gate fires — the cache flips to Codex CLI.
+      captured.agent!({
+        sessionId: 'pty-a',
+        event: { agent: 'Codex CLI', status: 'running', message: 'Working' },
+      });
+
+      // Now resolve the workspace.list RPC; the OSC 133 emit completes.
+      resolveWorkspaceListRpc(FIXTURE_WORKSPACE_LIST);
+      await flushMicrotasks();
+
+      const osc = pollLifecycle().find(
+        (e) => e.type === 'agent.lifecycle' && (e as { source?: string }).source === 'osc133',
+      );
+      // Must be 'claude' — the slug snapshot at command_end time, NOT
+      // 'codex' which the cache now holds.
+      expect(osc).toMatchObject({ source: 'osc133', agent: 'claude' });
+    } finally {
+      router.stop();
+    }
+  });
 });

--- a/src/main/pipe/handlers/hooks.rpc.ts
+++ b/src/main/pipe/handlers/hooks.rpc.ts
@@ -468,6 +468,8 @@ function titleFor(signal: AgentSignal): string {
       return `${display}: Activity`;
     case 'agent.session_start':
       return `${display}: Session started`;
+    case 'agent.awaiting_input':
+      return `${display}: Awaiting input`;
   }
 }
 
@@ -484,6 +486,8 @@ function bodyFor(signal: AgentSignal): string {
       return 'Tool call completed';
     case 'agent.session_start':
       return 'Session initialized';
+    case 'agent.awaiting_input':
+      return 'Approval requested';
   }
 }
 

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -131,31 +131,33 @@ const AGENT_PATTERNS: AgentPattern[] = [
       // approval responses into the PTY, false positives here are
       // particularly costly.
       //
-      // Trailing class accepts whitespace and the full set of box-drawing
-      // glyphs Claude's TUI uses to frame prompt lines:
+      // Trailing AND leading character classes accept whitespace and the
+      // full set of box-drawing glyphs Claude's TUI uses to frame prompt
+      // lines:
       //   straight:   │ ║ ┃ ═ ━ ─ ┄ ┅ ┆ ┇ ┈ ┉
       //   corners:    ╭ ╮ ╯ ╰ ╔ ╗ ╝ ╚ ┌ ┐ ┘ └
       //   separators: · ─
       // Round-3 P2: omitting corners caused boxed prompt lines ending in
       // `╮` or `╯` to be skipped. Round-4 P2: omitting `─` (U+2500, light
       // horizontal) missed boxed prompts like `╭─ Do you want to
-      // proceed? ─╮` where the horizontal border butts up against the
-      // text.
+      // proceed? ─╮`. Round-5 P2: omitting the leading anchor allowed
+      // conversational lines such as `Please click Allow tool use for
+      // Bash` to slip through — the round-2 comment promised "real
+      // prompts occupy the whole line" but the regex only checked the
+      // suffix. The whole-line constraint now applies on both ends.
       //
       // Tool-name pattern covers TWO and only two forms:
       //   - Claude's built-in tool labels: `[A-Z][A-Za-z]+` (Bash, Edit,
-      //     Write, WebFetch, ...). Capitalized + no underscores.
-      //   - MCP namespaced form: `mcp__<server>__<tool>` with literal
-      //     `mcp__` prefix and at least one `__` segment.
-      // Round-4 P2: the prior `[A-Za-z_][A-Za-z0-9_]*` accepted any
-      // single-underscore identifier such as `Bash_command`, which let
-      // conversational lines like
-      //   `Please click Allow tool use for Bash_command │`
-      // re-introduce the false positive the round-2 anchor was meant to
-      // eliminate. The split alternation now rejects single-underscore
-      // identifiers while still admitting the canonical MCP form.
-      { regex: /\bDo you want to proceed\?[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/,                                              status: 'awaiting_input',   message: 'Approval requested' },
-      { regex: /\bAllow tool use for (?:[A-Z][A-Za-z]+|mcp__[A-Za-z0-9_]+)\??[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/, status: 'awaiting_input',   message: 'Tool approval requested' },
+      //     Write, WebFetch, TodoWrite, ExitPlanMode, ...). Capitalized,
+      //     no underscores or hyphens.
+      //   - Canonical MCP namespaced form: `mcp__<server>__<tool>` with
+      //     literal `mcp__` prefix, at least two `__` segments, and
+      //     hyphens permitted inside the server/tool ids
+      //     (`mcp__context7__get-library-docs`). Round-5 P2: the prior
+      //     `mcp__[A-Za-z0-9_]+` rejected hyphens and accepted
+      //     non-canonical single-`__` names like `mcp__github_create_issue`.
+      { regex: /^[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*Do you want to proceed\?[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/,                                                                                  status: 'awaiting_input',   message: 'Approval requested' },
+      { regex: /^[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*Allow tool use for (?:[A-Z][A-Za-z]+|mcp__[A-Za-z0-9-]+__[A-Za-z0-9_-]+)\??[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/, status: 'awaiting_input',   message: 'Tool approval requested' },
     ],
   },
 

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -120,10 +120,19 @@ const AGENT_PATTERNS: AgentPattern[] = [
       // Approval prompts — Claude Code is paused mid-turn waiting for the user
       // to pick an option. Orchestrators can react to 'awaiting_input' to feed
       // pre-approved answers without waiting for the full turn to end.
-      // `Do you want to proceed` is followed by a numbered option list ("1.
-      // Yes / 2. No"); `Allow tool use` appears on Bash/Edit approval gates.
-      { regex: /Do you want to proceed/,         status: 'awaiting_input',   message: 'Approval requested' },
-      { regex: /Allow tool use/,                 status: 'awaiting_input',   message: 'Tool approval requested' },
+      //
+      // The patterns below are anchored to the approval-prompt SHAPE rather
+      // than to the phrase appearing anywhere on the line: a literal `?` for
+      // `Do you want to proceed?`, and the Claude-specific `Allow tool use
+      // for <Bash|Edit|Write|...>` form. Codex round-1 P2 catch: an
+      // unanchored `Do you want to proceed` matched Claude conversational
+      // output that included the phrase rhetorically; an unanchored
+      // `Allow tool use` matched any explanation of how tool gates work
+      // (docs, debug logs, the agent describing its own permission model).
+      // False positives here are particularly costly because orchestrators
+      // may auto-feed approval responses into the PTY.
+      { regex: /\bDo you want to proceed\?/,           status: 'awaiting_input',   message: 'Approval requested' },
+      { regex: /\bAllow tool use for [A-Z][A-Za-z]+/,  status: 'awaiting_input',   message: 'Tool approval requested' },
     ],
   },
 

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -83,13 +83,15 @@ export function agentDisplayToSlug(display: string): AgentSlug | undefined {
  */
 export function agentStatusToSignalKind(
   status: AgentEventStatus,
-): 'agent.stop' | 'agent.activity' | null {
+): 'agent.stop' | 'agent.activity' | 'agent.awaiting_input' | null {
   switch (status) {
     case 'waiting':
     case 'complete':
       return 'agent.stop';
     case 'running':
       return 'agent.activity';
+    case 'awaiting_input':
+      return 'agent.awaiting_input';
     default:
       return null;
   }
@@ -113,9 +115,15 @@ const AGENT_PATTERNS: AgentPattern[] = [
       // appears while a response is in flight (hint that the user can ESC to
       // cancel), not when the agent is idle. Including it produced
       // false-positive "waiting" notifications mid-turn. Removed.
-      { regex: /bypass permissions on/,          status: 'waiting',   message: 'Ready for input' },
-      { regex: /shift\+tab to cycle/,            status: 'waiting',   message: 'Ready for input' },
-      { regex: /Do you want to proceed/,         status: 'waiting',   message: 'Waiting for confirmation' },
+      { regex: /bypass permissions on/,          status: 'waiting',          message: 'Ready for input' },
+      { regex: /shift\+tab to cycle/,            status: 'waiting',          message: 'Ready for input' },
+      // Approval prompts — Claude Code is paused mid-turn waiting for the user
+      // to pick an option. Orchestrators can react to 'awaiting_input' to feed
+      // pre-approved answers without waiting for the full turn to end.
+      // `Do you want to proceed` is followed by a numbered option list ("1.
+      // Yes / 2. No"); `Allow tool use` appears on Bash/Edit approval gates.
+      { regex: /Do you want to proceed/,         status: 'awaiting_input',   message: 'Approval requested' },
+      { regex: /Allow tool use/,                 status: 'awaiting_input',   message: 'Tool approval requested' },
     ],
   },
 

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -133,18 +133,29 @@ const AGENT_PATTERNS: AgentPattern[] = [
       //
       // Trailing class accepts whitespace and the full set of box-drawing
       // glyphs Claude's TUI uses to frame prompt lines:
-      //   straight: │ ║ ┃ ═ ━ ┄ ┅ ┆ ┇
-      //   corners:  ╭ ╮ ╯ ╰ ╔ ╗ ╝ ╚ ┌ ┐ ┘ └
-      //   dots/sep: · (added for early-frame variants)
+      //   straight:   │ ║ ┃ ═ ━ ─ ┄ ┅ ┆ ┇ ┈ ┉
+      //   corners:    ╭ ╮ ╯ ╰ ╔ ╗ ╝ ╚ ┌ ┐ ┘ └
+      //   separators: · ─
       // Round-3 P2: omitting corners caused boxed prompt lines ending in
-      // `╮` or `╯` to be skipped, mis-firing as false negatives.
+      // `╮` or `╯` to be skipped. Round-4 P2: omitting `─` (U+2500, light
+      // horizontal) missed boxed prompts like `╭─ Do you want to
+      // proceed? ─╮` where the horizontal border butts up against the
+      // text.
       //
-      // Tool-name pattern covers both Claude's built-in tool labels
-      // (`Bash`, `Edit`, `Write`, `WebFetch`...) and the MCP namespaced
-      // form (`mcp__github__create_issue`). Restricting to `[A-Z][A-Za-z]+`
-      // missed MCP variants entirely (Round-3 P2 false negative).
-      { regex: /\bDo you want to proceed\?[\s│║┃═━┄┅┆┇╭╮╯╰╔╗╝╚┌┐┘└·]*$/,                                  status: 'awaiting_input',   message: 'Approval requested' },
-      { regex: /\bAllow tool use for [A-Za-z_][A-Za-z0-9_]*(?:__[A-Za-z0-9_]+)*\??[\s│║┃═━┄┅┆┇╭╮╯╰╔╗╝╚┌┐┘└·]*$/, status: 'awaiting_input',   message: 'Tool approval requested' },
+      // Tool-name pattern covers TWO and only two forms:
+      //   - Claude's built-in tool labels: `[A-Z][A-Za-z]+` (Bash, Edit,
+      //     Write, WebFetch, ...). Capitalized + no underscores.
+      //   - MCP namespaced form: `mcp__<server>__<tool>` with literal
+      //     `mcp__` prefix and at least one `__` segment.
+      // Round-4 P2: the prior `[A-Za-z_][A-Za-z0-9_]*` accepted any
+      // single-underscore identifier such as `Bash_command`, which let
+      // conversational lines like
+      //   `Please click Allow tool use for Bash_command │`
+      // re-introduce the false positive the round-2 anchor was meant to
+      // eliminate. The split alternation now rejects single-underscore
+      // identifiers while still admitting the canonical MCP form.
+      { regex: /\bDo you want to proceed\?[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/,                                              status: 'awaiting_input',   message: 'Approval requested' },
+      { regex: /\bAllow tool use for (?:[A-Z][A-Za-z]+|mcp__[A-Za-z0-9_]+)\??[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/, status: 'awaiting_input',   message: 'Tool approval requested' },
     ],
   },
 

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -131,12 +131,20 @@ const AGENT_PATTERNS: AgentPattern[] = [
       // approval responses into the PTY, false positives here are
       // particularly costly.
       //
-      // Trailing class accepts whitespace and box-drawing glyphs Claude's
-      // TUI uses to frame prompt lines (`│ ║ ┃ ═ ━ ┄ ┅ ┆ ┇`). Anything else
-      // after the matched phrase means there's more sentence content on the
-      // line and the match is rejected.
-      { regex: /\bDo you want to proceed\?[\s│║┃═━┄┅┆┇·]*$/,          status: 'awaiting_input',   message: 'Approval requested' },
-      { regex: /\bAllow tool use for [A-Z][A-Za-z]+\??[\s│║┃═━┄┅┆┇·]*$/, status: 'awaiting_input',   message: 'Tool approval requested' },
+      // Trailing class accepts whitespace and the full set of box-drawing
+      // glyphs Claude's TUI uses to frame prompt lines:
+      //   straight: │ ║ ┃ ═ ━ ┄ ┅ ┆ ┇
+      //   corners:  ╭ ╮ ╯ ╰ ╔ ╗ ╝ ╚ ┌ ┐ ┘ └
+      //   dots/sep: · (added for early-frame variants)
+      // Round-3 P2: omitting corners caused boxed prompt lines ending in
+      // `╮` or `╯` to be skipped, mis-firing as false negatives.
+      //
+      // Tool-name pattern covers both Claude's built-in tool labels
+      // (`Bash`, `Edit`, `Write`, `WebFetch`...) and the MCP namespaced
+      // form (`mcp__github__create_issue`). Restricting to `[A-Z][A-Za-z]+`
+      // missed MCP variants entirely (Round-3 P2 false negative).
+      { regex: /\bDo you want to proceed\?[\s│║┃═━┄┅┆┇╭╮╯╰╔╗╝╚┌┐┘└·]*$/,                                  status: 'awaiting_input',   message: 'Approval requested' },
+      { regex: /\bAllow tool use for [A-Za-z_][A-Za-z0-9_]*(?:__[A-Za-z0-9_]+)*\??[\s│║┃═━┄┅┆┇╭╮╯╰╔╗╝╚┌┐┘└·]*$/, status: 'awaiting_input',   message: 'Tool approval requested' },
     ],
   },
 

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -121,18 +121,22 @@ const AGENT_PATTERNS: AgentPattern[] = [
       // to pick an option. Orchestrators can react to 'awaiting_input' to feed
       // pre-approved answers without waiting for the full turn to end.
       //
-      // The patterns below are anchored to the approval-prompt SHAPE rather
-      // than to the phrase appearing anywhere on the line: a literal `?` for
-      // `Do you want to proceed?`, and the Claude-specific `Allow tool use
-      // for <Bash|Edit|Write|...>` form. Codex round-1 P2 catch: an
-      // unanchored `Do you want to proceed` matched Claude conversational
-      // output that included the phrase rhetorically; an unanchored
-      // `Allow tool use` matched any explanation of how tool gates work
-      // (docs, debug logs, the agent describing its own permission model).
-      // False positives here are particularly costly because orchestrators
-      // may auto-feed approval responses into the PTY.
-      { regex: /\bDo you want to proceed\?/,           status: 'awaiting_input',   message: 'Approval requested' },
-      { regex: /\bAllow tool use for [A-Z][A-Za-z]+/,  status: 'awaiting_input',   message: 'Tool approval requested' },
+      // The patterns are anchored to the END of the line: a real approval
+      // prompt occupies the whole line (possibly inside Claude's box-drawing
+      // frame), whereas conversational mentions are followed by more sentence
+      // text. Codex round-1/round-2 P2: an unanchored `Do you want to
+      // proceed` matched `If the CLI asks "Do you want to proceed?", choose
+      // no`, and unanchored `Allow tool use` matched `click Allow tool use
+      // for Bash` in plain text. Because orchestrators may auto-feed
+      // approval responses into the PTY, false positives here are
+      // particularly costly.
+      //
+      // Trailing class accepts whitespace and box-drawing glyphs Claude's
+      // TUI uses to frame prompt lines (`│ ║ ┃ ═ ━ ┄ ┅ ┆ ┇`). Anything else
+      // after the matched phrase means there's more sentence content on the
+      // line and the match is rejected.
+      { regex: /\bDo you want to proceed\?[\s│║┃═━┄┅┆┇·]*$/,          status: 'awaiting_input',   message: 'Approval requested' },
+      { regex: /\bAllow tool use for [A-Z][A-Za-z]+\??[\s│║┃═━┄┅┆┇·]*$/, status: 'awaiting_input',   message: 'Tool approval requested' },
     ],
   },
 

--- a/src/main/pty/PTYBridge.ts
+++ b/src/main/pty/PTYBridge.ts
@@ -291,6 +291,56 @@ export class PTYBridge {
           win.webContents.send(IPC.GIT_BRANCH_CHANGED, ptyId, event.data);
           break;
         }
+        case 133: {
+          // OSC 133 shell integration — semantic prompt boundaries.
+          //   A — prompt start (shell ready for user input)
+          //   B — prompt end (prompt drawn)
+          //   C — command start (Enter pressed, output follows)
+          //   D[;<exitCode>] — command end (process finished)
+          //
+          // Only the D marker is teed to the EventBus today. It's a shell-
+          // agnostic, latency-zero signal that any CLI (npm, pytest, make,
+          // git...) emits when wrapped by shell integration. Orchestrators
+          // can poll wmux_events_poll for `source:'osc133'` lifecycle events
+          // instead of round-tripping through `terminal_read_events`, picking
+          // up command exits ~1-2s before the regex-based AgentDetector would.
+          //
+          // OSC 133 doesn't identify the agent — it's a generic shell signal —
+          // so `agent` is set to the detector's last-known agent slug for the
+          // PTY when one is gated, otherwise null. Hook/detector lifecycle
+          // events always carry a non-null agent; null is the discriminator
+          // for "no agent context, but a shell command completed".
+          //
+          // Daemon-side PromptEventLog (src/daemon/PromptEventLog.ts) is the
+          // authoritative byte-offset log used by `terminal_read_events`;
+          // the EventBus tee here is a parallel projection for the
+          // workspaceId-scoped poll path. The two streams may interleave but
+          // never disagree about what happened — both parse the same OSC 133
+          // bytes from the same PTY data path.
+          const payload = event.data || '';
+          const parts = payload.split(';');
+          if (parts[0] === 'D' && instance.workspaceId) {
+            let exitCode: number | null = null;
+            if (parts.length > 1 && parts[1].length > 0) {
+              const parsed = Number.parseInt(parts[1], 10);
+              if (!Number.isNaN(parsed)) {
+                exitCode = parsed;
+              }
+            }
+            const agentSlug = agentDisplayToSlug(agentDetector.getLastAgent() ?? '') ?? null;
+            eventBus.emit({
+              type: 'agent.lifecycle',
+              workspaceId: instance.workspaceId,
+              ptyId,
+              kind: 'agent.stop',
+              source: 'osc133',
+              agent: agentSlug,
+              decision: 'emit',
+              exitCode,
+            });
+          }
+          break;
+        }
       }
     });
 
@@ -321,39 +371,46 @@ export class PTYBridge {
           agentName: agentEvent.agent,
         });
 
-        if (status === 'waiting' || status === 'complete') {
+        if (status === 'waiting' || status === 'complete' || status === 'awaiting_input') {
           this.lastAgentEventAt.set(ptyId, Date.now());
           const title = `${agentEvent.agent}: ${agentEvent.message}`;
-          const body = status === 'waiting' ? 'Ready for input' : 'Task finished';
+          const body = status === 'awaiting_input'
+            ? 'Awaiting input'
+            : status === 'waiting' ? 'Ready for input' : 'Task finished';
           sendNotification(win, ptyId, { type: 'agent', title, body });
           toastManager.show(title, body);
 
           // Tee to EventBus for external observers (orchestrator clients).
-          // Both 'waiting' and 'complete' collapse to kind:'agent.stop' —
-          // they represent the same user-visible event ("turn finished,
-          // ready for next input"), matching the hook-side dedup mapping
-          // in HookSignalRouter. Call `recordDetector` before emitting
-          // so the ledger sees this side of the dedup window: a hook+
-          // detector pair for the same turn now resolves to one 'emit'
-          // and one 'dedup', not two emits. Without this, an orchestrator
-          // filtering on `decision === 'emit'` would re-run follow-up
-          // work twice on the standard plugin-plus-detector setup. The
-          // existing sendNotification/toast above is unchanged — that
-          // dedup gate lives in the hook path, not here, and is
-          // pre-existing scope. Skip when workspaceId is unknown — same
-          // gate as the process.started emit above.
+          // 'waiting' and 'complete' collapse to kind:'agent.stop' — they
+          // represent the same user-visible event ("turn finished, ready
+          // for next input"), matching the hook-side dedup mapping in
+          // HookSignalRouter. 'awaiting_input' maps to its own kind so
+          // orchestrators can distinguish "turn ended, send next task"
+          // from "agent paused mid-turn, send y/N answer". Call
+          // `recordDetector` before emitting so the ledger sees this side
+          // of the dedup window: a hook+detector pair for the same turn
+          // now resolves to one 'emit' and one 'dedup', not two emits.
+          // Without this, an orchestrator filtering on `decision === 'emit'`
+          // would re-run follow-up work twice on the standard
+          // plugin-plus-detector setup. The existing sendNotification/toast
+          // above is unchanged — that dedup gate lives in the hook path,
+          // not here, and is pre-existing scope. Skip when workspaceId is
+          // unknown — same gate as the process.started emit above.
           if (instance.workspaceId) {
             const slug = agentDisplayToSlug(agentEvent.agent);
             if (slug) {
+              const lifecycleKind = status === 'awaiting_input'
+                ? 'agent.awaiting_input' as const
+                : 'agent.stop' as const;
               const hookRouter = this.getHookRouter?.() ?? null;
               const decision = hookRouter
-                ? hookRouter.recordDetector(slug, 'agent.stop', ptyId)
+                ? hookRouter.recordDetector(slug, lifecycleKind, ptyId)
                 : 'emit';
               eventBus.emit({
                 type: 'agent.lifecycle',
                 workspaceId: instance.workspaceId,
                 ptyId,
-                kind: 'agent.stop',
+                kind: lifecycleKind,
                 source: 'detector',
                 agent: slug,
                 decision,

--- a/src/main/pty/__tests__/PTYBridge.lifecycle.test.ts
+++ b/src/main/pty/__tests__/PTYBridge.lifecycle.test.ts
@@ -333,6 +333,80 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     );
     expect(awaiting).toBeUndefined();
   });
+
+  it('does NOT emit awaiting_input when a leading conversational phrase precedes "Allow tool use for X"', () => {
+    // Codex round-5 P2 — the suffix anchor passed `Please click Allow
+    // tool use for Bash` because nothing constrained what came before
+    // the phrase. The leading anchor now requires whitespace/box-frame
+    // glyphs as prefix.
+    const { proc } = makeBridge({ workspaceId: 'ws-a' });
+
+    proc.emitData('Claude Code\n');
+    proc.emitData('Please click Allow tool use for Bash\n');
+    flush();
+
+    const awaiting = pollLifecycle().find(
+      (e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input',
+    );
+    expect(awaiting).toBeUndefined();
+  });
+
+  it('does NOT emit awaiting_input when a leading conversational phrase precedes "Do you want to proceed?"', () => {
+    const { proc } = makeBridge({ workspaceId: 'ws-a' });
+
+    proc.emitData('Claude Code\n');
+    proc.emitData('Answer Do you want to proceed?\n');
+    flush();
+
+    const awaiting = pollLifecycle().find(
+      (e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input',
+    );
+    expect(awaiting).toBeUndefined();
+  });
+
+  it('matches canonical MCP tool names with hyphens (mcp__server__tool-with-hyphens)', () => {
+    // Codex round-5 P2 — the prior `mcp__[A-Za-z0-9_]+` regex rejected
+    // hyphenated MCP tool names like `mcp__context7__get-library-docs`.
+    const { proc } = makeBridge({ workspaceId: 'ws-a' });
+
+    proc.emitData('Claude Code\n');
+    proc.emitData('Allow tool use for mcp__context7__get-library-docs?\n');
+    flush();
+
+    const awaiting = pollLifecycle().find(
+      (e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input',
+    );
+    expect(awaiting).toBeDefined();
+  });
+
+  it('rejects non-canonical MCP tool names with a single underscore segment', () => {
+    // Codex round-5 P2 — `mcp__github_create_issue` (single `__`, then
+    // single `_`) is not the canonical `mcp__<server>__<tool>` form;
+    // the regex now requires two `__` separators.
+    const { proc } = makeBridge({ workspaceId: 'ws-a' });
+
+    proc.emitData('Claude Code\n');
+    proc.emitData('Allow tool use for mcp__github_create_issue?\n');
+    flush();
+
+    const awaiting = pollLifecycle().find(
+      (e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input',
+    );
+    expect(awaiting).toBeUndefined();
+  });
+
+  it('matches Claude built-in tool labels with longer PascalCase (TodoWrite, ExitPlanMode)', () => {
+    const { proc } = makeBridge({ workspaceId: 'ws-a' });
+
+    proc.emitData('Claude Code\n');
+    proc.emitData('Allow tool use for TodoWrite?\n');
+    flush();
+
+    const awaiting = pollLifecycle().find(
+      (e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input',
+    );
+    expect(awaiting).toBeDefined();
+  });
 });
 
 describe('PTYBridge — agent.lifecycle EventBus tee (osc133 source)', () => {

--- a/src/main/pty/__tests__/PTYBridge.lifecycle.test.ts
+++ b/src/main/pty/__tests__/PTYBridge.lifecycle.test.ts
@@ -299,6 +299,40 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     );
     expect(awaiting).toBeDefined();
   });
+
+  it('matches boxed prompt lines that use light-horizontal border (─)', () => {
+    // Codex round-4 P2 — `╭─ Do you want to proceed? ─╮` is a real Claude
+    // approval prompt variant. The U+2500 light-horizontal glyph must be
+    // in the trailing whitelist.
+    const { proc } = makeBridge({ workspaceId: 'ws-a' });
+
+    proc.emitData('Claude Code\n');
+    proc.emitData('╭─ Do you want to proceed? ─╮\n');
+    flush();
+
+    const awaiting = pollLifecycle().find(
+      (e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input',
+    );
+    expect(awaiting).toBeDefined();
+  });
+
+  it('does NOT emit awaiting_input for "Allow tool use for Bash_command" with single-underscore tail', () => {
+    // Codex round-4 P2 — the round-3 broadening accepted single-underscore
+    // identifiers, which let conversational text like `Please click Allow
+    // tool use for Bash_command │` slip back through. The split
+    // alternation (capitalized built-in OR mcp__ prefix) now rejects this
+    // shape.
+    const { proc } = makeBridge({ workspaceId: 'ws-a' });
+
+    proc.emitData('Claude Code\n');
+    proc.emitData('Please click Allow tool use for Bash_command │\n');
+    flush();
+
+    const awaiting = pollLifecycle().find(
+      (e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input',
+    );
+    expect(awaiting).toBeUndefined();
+  });
 });
 
 describe('PTYBridge — agent.lifecycle EventBus tee (osc133 source)', () => {

--- a/src/main/pty/__tests__/PTYBridge.lifecycle.test.ts
+++ b/src/main/pty/__tests__/PTYBridge.lifecycle.test.ts
@@ -222,6 +222,50 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
       decision: 'emit',
     });
   });
+
+  it('does NOT emit awaiting_input for conversational "Do you want to proceed?" mentions', () => {
+    // Codex round-2 P2 catch — the phrase embedded in a longer sentence
+    // (e.g. Claude documenting how an approval gate looks) must not fire
+    // awaiting_input. The line-end anchor on the regex ensures only the
+    // real prompt line matches.
+    const { proc } = makeBridge({ workspaceId: 'ws-a' });
+
+    proc.emitData('Claude Code\n');
+    proc.emitData('If the CLI asks "Do you want to proceed?", choose no\n');
+    flush();
+
+    const awaiting = pollLifecycle().find(
+      (e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input',
+    );
+    expect(awaiting).toBeUndefined();
+  });
+
+  it('still matches a real approval line wrapped in Claude box-drawing chars', () => {
+    // Realistic Claude TUI line: `│ Do you want to proceed?   │`
+    const { proc } = makeBridge({ workspaceId: 'ws-a' });
+
+    proc.emitData('Claude Code\n');
+    proc.emitData('│ Do you want to proceed?   │\n');
+    flush();
+
+    const awaiting = pollLifecycle().find(
+      (e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input',
+    );
+    expect(awaiting).toBeDefined();
+  });
+
+  it('does NOT emit awaiting_input for conversational "Allow tool use for X" mentions mid-sentence', () => {
+    const { proc } = makeBridge({ workspaceId: 'ws-a' });
+
+    proc.emitData('Claude Code\n');
+    proc.emitData('click Allow tool use for Bash to enable git push\n');
+    flush();
+
+    const awaiting = pollLifecycle().find(
+      (e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input',
+    );
+    expect(awaiting).toBeUndefined();
+  });
 });
 
 describe('PTYBridge — agent.lifecycle EventBus tee (osc133 source)', () => {

--- a/src/main/pty/__tests__/PTYBridge.lifecycle.test.ts
+++ b/src/main/pty/__tests__/PTYBridge.lifecycle.test.ts
@@ -201,4 +201,132 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     expect(events.length).toBeGreaterThanOrEqual(1);
     expect(events[0]).toMatchObject({ source: 'detector', decision: 'emit' });
   });
+
+  it('emits agent.lifecycle source:"awaiting_input" when AgentDetector matches an approval prompt', () => {
+    const { proc } = makeBridge({ workspaceId: 'ws-a' });
+
+    proc.emitData('Claude Code\n');
+    proc.emitData('Do you want to proceed?\n');
+    flush();
+
+    const events = pollLifecycle();
+    const awaiting = events.find((e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input');
+    expect(awaiting).toBeDefined();
+    expect(awaiting).toMatchObject({
+      type: 'agent.lifecycle',
+      ptyId: 'pty-1',
+      workspaceId: 'ws-a',
+      kind: 'agent.awaiting_input',
+      source: 'detector',
+      agent: 'claude',
+      decision: 'emit',
+    });
+  });
+});
+
+describe('PTYBridge — agent.lifecycle EventBus tee (osc133 source)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    eventBus.reset();
+    mocks.broadcastMetadataUpdate.mockReset();
+    mocks.sendNotification.mockReset();
+    mocks.toastManager.show.mockReset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function flush() {
+    vi.advanceTimersByTime(50);
+  }
+
+  // OSC 133 wire format: ESC ] 133 ; <subcmd> [; <args>] BEL
+  const OSC_133_D_OK = '\x1b]133;D;0\x07';
+  const OSC_133_D_FAIL = '\x1b]133;D;1\x07';
+  const OSC_133_D_NO_EXIT = '\x1b]133;D\x07';
+  const OSC_133_A = '\x1b]133;A\x07';
+
+  it('emits source:"osc133" with parsed exitCode on OSC 133 D;<exitCode>', () => {
+    const { proc } = makeBridge({ workspaceId: 'ws-a' });
+
+    proc.emitData(OSC_133_D_OK);
+    flush();
+
+    const events = pollLifecycle();
+    expect(events.length).toBe(1);
+    expect(events[0]).toMatchObject({
+      type: 'agent.lifecycle',
+      ptyId: 'pty-1',
+      workspaceId: 'ws-a',
+      kind: 'agent.stop',
+      source: 'osc133',
+      agent: null,
+      decision: 'emit',
+      exitCode: 0,
+    });
+  });
+
+  it('emits exitCode null when OSC 133 D carries no exit code suffix', () => {
+    const { proc } = makeBridge({ workspaceId: 'ws-a' });
+
+    proc.emitData(OSC_133_D_NO_EXIT);
+    flush();
+
+    const events = pollLifecycle();
+    expect(events.length).toBe(1);
+    expect(events[0]).toMatchObject({ source: 'osc133', exitCode: null });
+  });
+
+  it('does NOT emit for non-D subcommands (A/B/C)', () => {
+    const { proc } = makeBridge({ workspaceId: 'ws-a' });
+
+    proc.emitData(OSC_133_A);
+    flush();
+
+    expect(pollLifecycle()).toHaveLength(0);
+  });
+
+  it('does NOT emit when workspaceId is unknown', () => {
+    const { proc } = makeBridge({});
+
+    proc.emitData(OSC_133_D_OK);
+    flush();
+
+    expect(pollLifecycle()).toHaveLength(0);
+  });
+
+  it('sets agent to the detector last-known slug when a gated agent is active', () => {
+    const { proc } = makeBridge({ workspaceId: 'ws-a' });
+
+    // Gate the Claude Code detector first so getLastAgent() returns 'Claude Code'.
+    proc.emitData('Claude Code\n');
+    proc.emitData('  shift+tab to cycle\n');
+    flush();
+    // Drain the detector-source lifecycle event so the next poll sees only osc133.
+    eventBus.reset();
+
+    proc.emitData(OSC_133_D_FAIL);
+    flush();
+
+    const events = pollLifecycle();
+    expect(events.length).toBe(1);
+    expect(events[0]).toMatchObject({
+      source: 'osc133',
+      agent: 'claude',
+      exitCode: 1,
+    });
+  });
+
+  it('osc133 events bypass HookSignalRouter dedup (always decision:"emit")', () => {
+    const router = stubHookRouter('dedup');
+    const { proc } = makeBridge({ workspaceId: 'ws-a', hookRouter: router });
+
+    proc.emitData(OSC_133_D_OK);
+    flush();
+
+    const events = pollLifecycle();
+    expect(events.length).toBe(1);
+    expect(events[0]).toMatchObject({ source: 'osc133', decision: 'emit' });
+    expect(router.recordDetector).not.toHaveBeenCalled();
+  });
 });

--- a/src/main/pty/__tests__/PTYBridge.lifecycle.test.ts
+++ b/src/main/pty/__tests__/PTYBridge.lifecycle.test.ts
@@ -266,6 +266,39 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     );
     expect(awaiting).toBeUndefined();
   });
+
+  it('matches approval prompt lines that end with box corner glyphs (╮/╯)', () => {
+    // Codex round-3 P2 — Claude's TUI sometimes terminates a boxed prompt
+    // line with a corner glyph instead of a vertical edge. Without these
+    // in the trailing whitelist, real approval prompts go unrecognized.
+    const { proc } = makeBridge({ workspaceId: 'ws-a' });
+
+    proc.emitData('Claude Code\n');
+    proc.emitData('│ Do you want to proceed? ╮\n');
+    flush();
+
+    const awaiting = pollLifecycle().find(
+      (e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input',
+    );
+    expect(awaiting).toBeDefined();
+  });
+
+  it('matches "Allow tool use for <MCP tool name>" with double-underscore namespace', () => {
+    // Codex round-3 P2 — MCP tools are named like
+    // `mcp__github__create_issue`. The original [A-Z][A-Za-z]+ class
+    // rejected them, so approval prompts for MCP tools fired no
+    // awaiting_input event. Pattern now covers the namespaced form.
+    const { proc } = makeBridge({ workspaceId: 'ws-a' });
+
+    proc.emitData('Claude Code\n');
+    proc.emitData('Allow tool use for mcp__github__create_issue?\n');
+    flush();
+
+    const awaiting = pollLifecycle().find(
+      (e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input',
+    );
+    expect(awaiting).toBeDefined();
+  });
 });
 
 describe('PTYBridge — agent.lifecycle EventBus tee (osc133 source)', () => {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -413,7 +413,7 @@ server.tool(
         'agent.lifecycle',
       ]))
       .optional()
-      .describe('Filter to specific event types. Omit to receive all types. `agent.lifecycle` fires when an inner Claude Code (or other supported agent) finishes a turn; carries ptyId, kind (agent.stop|agent.subagent_stop), source (hook|detector), agent slug, and decision (emit|dedup).'),
+      .describe('Filter to specific event types. Omit to receive all types. `agent.lifecycle` carries ptyId, kind (agent.stop|agent.subagent_stop|agent.awaiting_input), source (hook|detector|osc133), agent slug (nullable when source=osc133 and no agent context), decision (emit|dedup), and optional exitCode (osc133 only). It fires on three signals: (1) an inner agent (Claude Code, Codex CLI, ...) finishes a turn (source=hook|detector, kind=agent.stop), (2) an agent surfaces a y/N approval prompt mid-turn (source=detector, kind=agent.awaiting_input), or (3) any OSC 133-instrumented shell command completes (source=osc133, kind=agent.stop, with exitCode). Orchestrators that previously polled `terminal_read_events` for OSC 133 boundaries can switch to ring-buffer polling here at the same cadence.'),
     max: z.number().int().positive().max(1024).optional().describe('Max events to return per poll. Default 256.'),
   },
   async ({ cursor, types, max }) => {

--- a/src/renderer/components/Sidebar/agentStatusIcon.ts
+++ b/src/renderer/components/Sidebar/agentStatusIcon.ts
@@ -3,9 +3,10 @@ import type { AgentStatus } from '../../../shared/types';
 // Shared mapping from agent status → visual indicator. Used by WorkspaceItem
 // (full sidebar) and MiniSidebar so they stay in lockstep when statuses change.
 export const AGENT_STATUS_ICON: Record<AgentStatus, { dot: string; className: string; labelKey: string }> = {
-  running:  { dot: '●', className: 'text-[var(--accent-blue)]', labelKey: 'workspace.agentRunning' },
-  complete: { dot: '●', className: 'text-[var(--accent-green)]', labelKey: 'workspace.agentComplete' },
-  error:    { dot: '●', className: 'text-[var(--accent-red)]', labelKey: 'workspace.agentError' },
-  waiting:  { dot: '●', className: 'text-[var(--accent-yellow)]', labelKey: 'workspace.agentWaiting' },
-  idle:     { dot: '●', className: 'text-[var(--text-muted)]', labelKey: 'workspace.agentIdle' },
+  running:        { dot: '●', className: 'text-[var(--accent-blue)]',   labelKey: 'workspace.agentRunning' },
+  complete:       { dot: '●', className: 'text-[var(--accent-green)]',  labelKey: 'workspace.agentComplete' },
+  error:          { dot: '●', className: 'text-[var(--accent-red)]',    labelKey: 'workspace.agentError' },
+  waiting:        { dot: '●', className: 'text-[var(--accent-yellow)]', labelKey: 'workspace.agentWaiting' },
+  awaiting_input: { dot: '●', className: 'text-[var(--accent-yellow)]', labelKey: 'workspace.agentAwaitingInput' },
+  idle:           { dot: '●', className: 'text-[var(--text-muted)]',    labelKey: 'workspace.agentIdle' },
 };

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -15,6 +15,7 @@ export const en = {
   'workspace.agentComplete': 'Agent complete',
   'workspace.agentError': 'Agent error',
   'workspace.agentWaiting': 'Agent waiting',
+  'workspace.agentAwaitingInput': 'Agent awaiting input',
   'workspace.agentIdle': 'Agent idle',
   'workspace.close': 'Close workspace',
   'workspace.copyInfo': 'Copy session info',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -15,6 +15,7 @@ export const ko = {
   'workspace.agentComplete': '에이전트 완료',
   'workspace.agentError': '에이전트 오류',
   'workspace.agentWaiting': '에이전트 대기 중',
+  'workspace.agentAwaitingInput': '에이전트 입력 대기',
   'workspace.agentIdle': '에이전트 유휴',
   'workspace.close': '워크스페이스 닫기',
   'workspace.copyInfo': '세션 정보 복사',

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -130,15 +130,26 @@ export interface ProcessExitedEvent extends WmuxEventBase {
 }
 
 /**
- * Fires when an inner agent (Claude Code, etc.) finishes a turn or subagent
- * spans. Sourced from either the Claude Code hook bridge (`source:'hook'`,
- * deterministic, sub-200ms) or the regex-based AgentDetector
- * (`source:'detector'`, heuristic, ~1-2s lag). Both sources stream so the
- * caller can compare and choose; the dedup ledger inside HookSignalRouter
- * decides whether a fan-out notification fires, and `decision` reflects
- * that outcome — but the event itself is emitted regardless so external
- * consumers (orchestrator clients) see both signals for forensic / replay
- * purposes.
+ * Fires when an inner agent (Claude Code, etc.) finishes a turn, surfaces a
+ * y/N approval prompt, or a generic shell command completes under OSC 133
+ * shell integration. Three sources stream so callers can compare and pick:
+ *
+ *   - `source:'hook'`      — Claude Code hook bridge. Deterministic, sub-200ms.
+ *                             Carries `agent` (the hook plugin knows who fired).
+ *   - `source:'detector'`  — Regex-based AgentDetector. Heuristic, ~1-2s lag.
+ *                             Carries `agent` (regex gates identify the agent).
+ *   - `source:'osc133'`    — Shell integration OSC 133 D marker. Latency-zero,
+ *                             shell-agnostic (any CLI: npm, pytest, make...).
+ *                             `agent` may be `null` when no agent context is
+ *                             known; `exitCode` is set when the marker carried
+ *                             one (`OSC 133;D;<n>`).
+ *
+ * The dedup ledger inside HookSignalRouter decides whether a fan-out
+ * notification fires (`decision`); the event itself is emitted regardless so
+ * external consumers (orchestrator clients) see all three signals for
+ * forensic / replay purposes. OSC 133 events are not dedup-gated — they
+ * represent shell command lifecycle, not agent turn boundaries — and always
+ * carry `decision:'emit'`.
  *
  * Intentionally omitted: `agent.activity` (per-tool-call) and
  * `agent.session_start`. activity events can fire 5-30 times per turn per
@@ -155,21 +166,44 @@ export interface AgentLifecycleEvent extends WmuxEventBase {
   type: 'agent.lifecycle';
   ptyId: string;
   /**
-   * 'agent.stop' = turn finished. 'agent.subagent_stop' = nested subagent
-   * (e.g. /team coordinator) returned. Other AgentSignalKind values are
-   * NOT emitted here — see the doc comment above for rationale.
+   * 'agent.stop'           — turn finished, ready for next user input.
+   * 'agent.subagent_stop'  — nested subagent (e.g. /team coordinator) returned.
+   * 'agent.awaiting_input' — agent paused mid-turn for a y/N / approval prompt
+   *                          and is blocked until the user responds. Emitted
+   *                          by AgentDetector when a confirmation regex matches
+   *                          on a previously-gated agent. Distinct from
+   *                          'agent.stop' (which signals turn completion);
+   *                          orchestrators that auto-approve trusted operations
+   *                          can react to this kind to feed input back without
+   *                          waiting for the turn to end.
+   *
+   * Other AgentSignalKind values are NOT emitted here — see the doc comment
+   * above for rationale.
    */
-  kind: 'agent.stop' | 'agent.subagent_stop';
-  source: 'hook' | 'detector';
-  agent: AgentSlug;
+  kind: 'agent.stop' | 'agent.subagent_stop' | 'agent.awaiting_input';
+  source: 'hook' | 'detector' | 'osc133';
+  /**
+   * Canonical agent slug. `null` only when `source:'osc133'` and no agent
+   * context is known for the PTY (e.g. plain shell command in a non-agent
+   * pane). Hook and detector sources always carry a non-null agent.
+   */
+  agent: AgentSlug | null;
   /**
    * 'emit' = HookSignalRouter decided to fan out a notification.
    * 'dedup' = a same-pane same-kind signal already emitted within the
    * dedup window, so no notification fired. The lifecycle event itself
    * is published either way for observability; consumers that only want
-   * "first-of-kind" signals filter on `decision === 'emit'`.
+   * "first-of-kind" signals filter on `decision === 'emit'`. OSC 133
+   * events are always 'emit' (no dedup applies to shell command lifecycle).
    */
   decision: 'emit' | 'dedup';
+  /**
+   * Process exit code reported by the OSC 133 D marker, when present.
+   * Only set for `source:'osc133'`; absent or `null` for hook/detector
+   * sources (which signal agent-turn boundaries, not process exits).
+   * `null` when the shell emitted `OSC 133;D` without an exit code suffix.
+   */
+  exitCode?: number | null;
 }
 
 export type WmuxEvent =

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -284,7 +284,8 @@ export interface DaemonEvent {
     | 'agent.event'
     | 'agent.critical'
     | 'activity.idle'
-    | 'activity.active';
+    | 'activity.active'
+    | 'prompt.event';
   sessionId: string;
   data: unknown;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -157,7 +157,16 @@ export interface WorkspaceMetadata {
 }
 
 // === Agent status ===
-export type AgentStatus = 'running' | 'complete' | 'error' | 'waiting' | 'idle';
+// 'awaiting_input' — agent paused mid-turn for a confirmation prompt (y/N,
+// approval gate) and is blocked until the user responds. Distinct from
+// 'waiting' (which means "turn ended, ready for next instruction").
+export type AgentStatus =
+  | 'running'
+  | 'complete'
+  | 'error'
+  | 'waiting'
+  | 'awaiting_input'
+  | 'idle';
 
 // === Metadata update IPC payload ===
 // Single discriminated payload shape used by IPC.METADATA_UPDATE. Sender (main)


### PR DESCRIPTION
## Summary

wmux-side v0.2-A from the [orchestrator v0.2 plan](https://github.com/openwong2kim/wmux-orchestrator/blob/main/plans/v0-2-plan.md). Extends the `agent.lifecycle` event with two new substrate signals that any `wmux_events_poll` consumer (orchestrator SDK, third-party MCP) can react to without polling `terminal_read_events`.

### Two new signals

1. **`source: 'osc133'`** — OSC 133 D markers are teed to the EventBus alongside the existing daemon-side `PromptEventLog`. Shell-agnostic and latency-zero: any CLI wrapped by shell integration (npm, pytest, make, git…) now publishes `kind: 'agent.stop'` with parsed `exitCode` the moment it finishes. `agent` is the `AgentDetector` last-known slug when one is gated, otherwise `null`. OSC 133 events bypass `HookSignalRouter` dedup (always `decision: 'emit'`) — they represent shell command lifecycle, not agent-turn boundaries.

2. **`kind: 'agent.awaiting_input'`** — `AgentDetector` emits a distinct lifecycle kind when an agent surfaces a y/N or approval prompt mid-turn (Claude Code patterns `Do you want to proceed`, `Allow tool use`). Distinct from `agent.stop`: orchestrators that auto-approve trusted operations can react to this kind to feed input back without waiting for the turn to end. Routed through `recordDetector` so the dedup ledger sees it the same way it sees `agent.stop`.

## Type changes (substrate)

| Field | Before | After |
|---|---|---|
| `AgentLifecycleEvent.source` | `'hook' \| 'detector'` | `'hook' \| 'detector' \| 'osc133'` |
| `AgentLifecycleEvent.kind` | `'agent.stop' \| 'agent.subagent_stop'` | + `'agent.awaiting_input'` |
| `AgentLifecycleEvent.agent` | `AgentSlug` | `AgentSlug \| null` (null only when `source === 'osc133'` and no agent context) |
| `AgentLifecycleEvent.exitCode` | — | `?: number \| null` (set only for `source === 'osc133'`) |
| `AgentStatus` | … `'waiting' \| 'idle'` | + `'awaiting_input'` |
| `AgentSignalKind` (hook envelope) | … `'agent.session_start'` | + `'agent.awaiting_input'` (detector-only emit today) |

## UI / i18n

- Sidebar `awaiting_input` dot (yellow, same hue as `waiting` — different label).
- `workspace.agentAwaitingInput`: en (\`Agent awaiting input\`) and ko (\`에이전트 입력 대기\`). Other 21 locales fall through `Partial<TranslationMap>` to en.

## MCP surface

`wmux_events_poll` describe updated to enumerate the three sources, new kind, and `exitCode` so MCP-aware orchestrators discover the contract from introspection alone. No new tool, no breaking change to existing event type enum.

## Why this is additive

- All existing consumers see no change in `agent.stop` / `agent.subagent_stop` event shape.
- `agent: null` only appears with `source: 'osc133'`; orchestrators that filter `source !== 'osc133'` see no nullable change.
- `exitCode` is optional; absent on hook/detector paths exactly as before.
- OSC 133 path is gated on `workspaceId` (same gate as `process.started` tee) — CLI/test PTYs without workspace context emit nothing, matching detector-source behavior.

## Test plan

- [x] tsc clean (fixed pre-existing exhaustive-switch debt in `hooks.rpc.ts` `titleFor`/`bodyFor` while extending `AgentSignalKind`)
- [x] Full suite: **1982/1982 pass** (+7 new lifecycle tests, +44 elsewhere from upstream merges in 2.12.0)
- [x] New PTYBridge.lifecycle.test.ts cases:
  - awaiting_input detector path emits `kind: 'agent.awaiting_input'`
  - osc133 with exit code 0 → `exitCode: 0`
  - osc133 with no exit suffix → `exitCode: null`
  - osc133 A/B/C subcommands → no emit (D-only)
  - osc133 without workspaceId → no emit
  - osc133 with gated Claude Code → `agent: 'claude'`
  - osc133 bypasses `HookSignalRouter.recordDetector`
- [ ] **Dogfood pending**: dev wmux → trigger Claude Code approval prompt → verify yellow `awaiting_input` dot + EventBus event
- [ ] **Dogfood pending**: shell integration enabled → run `echo hi` → verify `source:'osc133'` lifecycle event in `wmux_events_poll` output

## Out of scope

- Orchestrator SDK adoption (`waitForShellCommand` switching from `terminal_read_events` polling to EventBus ring-buffer polling) — ships as `@wmux/orchestrator` v0.2.0 in a separate repo.
- SSE/WebSocket push transport — orchestrator plan v0.2-B, deferred.
- Hook-side `agent.awaiting_input` emit (Claude Code hook plugin) — kind is in the AgentSignalKind union so it can be wired later without breaking the envelope; today only the detector emits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)