### PR TITLE
fix(session): merge config against defaults on load + harden prefix mode

### DIFF
--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -203,6 +203,13 @@ function buildSessionData(dumped: Map<string, boolean>): SessionData {
     cheatSheetDismissed: state.cheatSheetDismissed,
     floatingPanePtyId: state.floatingPanePtyId ?? undefined,
     prefixConfig: state.prefixConfig,
+    // Persist user-created layout templates + recent commands so they survive
+    // restart. loadSession (workspaceSlice) reads these back; builtins are
+    // re-seeded from BUILTIN_TEMPLATES on load, so we exclude them here to
+    // avoid bloat and stale duplicates. recentCommands follows the optional-
+    // field convention (omit when empty) used above for tokenDataByPty.
+    layoutTemplates: state.layoutTemplates.filter((t) => !t.builtin),
+    recentCommands: state.recentCommands.length > 0 ? state.recentCommands : undefined,
   };
 }
 

--- a/src/renderer/hooks/useKeyboard.ts
+++ b/src/renderer/hooks/useKeyboard.ts
@@ -257,8 +257,19 @@ export function useKeyboard() {
           return;
         }
 
-        // Ignore bare modifier keys (Shift, Control, Alt, Meta)
+        // Ignore bare modifier keys (Shift, Control, Alt, Meta) — the user is
+        // mid-chord reaching for a modified binding (e.g. Shift before '%' / '"'
+        // / '&' / '?' / ':'). clearPrefixTimeout() already ran above before the
+        // key was classified, so re-arm the auto-exit timer here; otherwise a
+        // lone modifier tap would leave prefix mode active with no timeout and
+        // the next keypress — even minutes later — would be treated as a prefix
+        // command. Exiting outright instead would make the Shift-reached
+        // bindings unreachable, so re-arming is the behavior-preserving fix.
         if (['Shift', 'Control', 'Alt', 'Meta'].includes(key)) {
+          prefixTimeoutRef.current = setTimeout(() => {
+            store.getState().setPrefixMode(false);
+            prefixTimeoutRef.current = null;
+          }, PREFIX_TIMEOUT_MS);
           return;
         }
 
@@ -272,10 +283,13 @@ export function useKeyboard() {
           return;
         }
 
-        // Unknown key → show error briefly, then exit
-        const displayKey = key.length === 1 ? key : key;
+        // Unknown key → show error briefly, then exit. Use exitPrefixMode()
+        // (not a bare setPrefixMode(false)) so prefix-mode teardown stays in
+        // one place; the prefix timeout was already cleared above but this
+        // keeps the cleanup symmetric with every other exit path.
+        const displayKey = key.length === 1 ? key.toUpperCase() : key;
         store.getState().setPrefixError(`Unknown: ${displayKey}`);
-        store.getState().setPrefixMode(false);
+        exitPrefixMode();
         setTimeout(() => {
           store.getState().setPrefixError(null);
         }, PREFIX_ERROR_DISPLAY_MS);

--- a/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
+++ b/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { createWorkspaceSlice, type WorkspaceSlice } from '../workspaceSlice';
-import type { Company, Pane, SessionData, Workspace } from '../../../../shared/types';
+import { DEFAULT_PREFIX_CONFIG, DEFAULT_CUSTOM_KEYBINDINGS, type Company, type Pane, type SessionData, type Workspace } from '../../../../shared/types';
 
 // Fix 0 — minimum cross-slice state surface that workspaceSlice.loadSession
 // and clearAllPtyState mutate. We intentionally don't pull in the full
@@ -366,5 +366,77 @@ describe('WorkspaceSlice.clearAllPtyState — Fix 0 fallback', () => {
     expect(store.getState().company).toBeNull();
     expect(() => store.getState().clearAllPtyState()).not.toThrow();
     expect(store.getState().company).toBeNull();
+  });
+});
+
+// Forward-compat config merge: a session saved by an older build must not strip
+// newly-shipped default bindings/keybindings on load. Regression guard for the
+// "prefix + arrow does nothing after upgrade" bug.
+describe('WorkspaceSlice.loadSession — config merge (forward-compat)', () => {
+  function makeSession(extra: Partial<SessionData>): SessionData {
+    const ws: Workspace = {
+      id: 'ws-1',
+      name: 'WS',
+      rootPane: makeBrowserSurfaceTree('https://example.com'),
+      activePaneId: 'pane-root',
+    };
+    return {
+      workspaces: [ws],
+      activeWorkspaceId: ws.id,
+      sidebarVisible: true,
+      ...extra,
+    } as unknown as SessionData;
+  }
+
+  it('back-fills new default prefix bindings (arrow keys) absent from a stale saved config', () => {
+    const store = createTestStore();
+    // Simulate a session saved before arrow-key bindings existed: no Arrow* keys,
+    // and a rebound 'x' (toggleZoom instead of the default closePane).
+    store.getState().loadSession(
+      makeSession({ prefixConfig: { key: 'KeyA', bindings: { 'x': 'toggleZoom', ':': 'commandPalette' } } as unknown as SessionData['prefixConfig'] })
+    );
+    const cfg = store.getState().prefixConfig as { key: string; bindings: Record<string, string> };
+    // New default bindings are present after load…
+    expect(cfg.bindings['ArrowUp']).toBe('focusUp');
+    expect(cfg.bindings['ArrowDown']).toBe('focusDown');
+    expect(cfg.bindings['ArrowLeft']).toBe('focusLeft');
+    expect(cfg.bindings['ArrowRight']).toBe('focusRight');
+    // …saved rebinding wins on collision with the default…
+    expect(cfg.bindings['x']).toBe('toggleZoom');
+    // …and the user's prefix key is preserved.
+    expect(cfg.key).toBe('KeyA');
+  });
+
+  it('falls back to DEFAULT_PREFIX_CONFIG.key when the saved prefix key is missing', () => {
+    const store = createTestStore();
+    store.getState().loadSession(
+      makeSession({ prefixConfig: { bindings: {} } as unknown as SessionData['prefixConfig'] })
+    );
+    const cfg = store.getState().prefixConfig as { key: string; bindings: Record<string, string> };
+    expect(cfg.key).toBe(DEFAULT_PREFIX_CONFIG.key);
+    expect(cfg.bindings['ArrowUp']).toBe('focusUp');
+  });
+
+  it('back-fills a missing default keybinding while preserving saved entries', () => {
+    const store = createTestStore();
+    store.getState().loadSession(
+      makeSession({ customKeybindings: [{ id: 'kb-user-1', key: 'F8', label: 'Mine', command: 'echo hi', sendEnter: true }] })
+    );
+    const kbs = store.getState().customKeybindings as { id: string }[];
+    const ids = kbs.map((k) => k.id);
+    expect(ids).toContain('kb-user-1');
+    expect(ids).toContain('kb-default-f7'); // back-filled from DEFAULT_CUSTOM_KEYBINDINGS
+  });
+
+  it('keeps the saved (edited) default keybinding rather than the built-in on id collision', () => {
+    const store = createTestStore();
+    store.getState().loadSession(
+      makeSession({ customKeybindings: [{ id: 'kb-default-f7', key: 'F7', label: 'Edited', command: 'custom', sendEnter: false }] })
+    );
+    const kbs = store.getState().customKeybindings as { id: string; label: string; command: string }[];
+    const f7 = kbs.filter((k) => k.id === 'kb-default-f7');
+    expect(f7).toHaveLength(1); // not duplicated
+    expect(f7[0].label).toBe('Edited'); // saved edit wins over the built-in default
+    expect(DEFAULT_CUSTOM_KEYBINDINGS[0].command).toBe('claude --dangerously-skip-permissions');
   });
 });

--- a/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
+++ b/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
@@ -428,6 +428,31 @@ describe('WorkspaceSlice.loadSession — config merge (forward-compat)', () => {
     expect(ids).toContain('kb-default-f7'); // back-filled from DEFAULT_CUSTOM_KEYBINDINGS
   });
 
+  it('does NOT back-fill a default whose key a saved binding already repurposed under a different id', () => {
+    // Runtime lookup is by key (first match wins), so resurrecting kb-default-f7
+    // ahead of a user's own F7 binding would shadow it. Guard against that.
+    const store = createTestStore();
+    store.getState().loadSession(
+      makeSession({ customKeybindings: [{ id: 'kb-user-f7', key: 'F7', label: 'My F7', command: 'vim', sendEnter: true }] })
+    );
+    const kbs = store.getState().customKeybindings as { id: string; key: string }[];
+    const f7Bindings = kbs.filter((k) => k.key === 'F7');
+    expect(f7Bindings).toHaveLength(1); // built-in NOT back-filled — no key collision shadow
+    expect(f7Bindings[0].id).toBe('kb-user-f7');
+    expect(kbs.map((k) => k.id)).not.toContain('kb-default-f7');
+  });
+
+  it('places saved entries before back-filled defaults so saved bindings win the key lookup', () => {
+    const store = createTestStore();
+    store.getState().loadSession(
+      makeSession({ customKeybindings: [{ id: 'kb-user-1', key: 'F9', label: 'Mine', command: 'ls', sendEnter: true }] })
+    );
+    const kbs = store.getState().customKeybindings as { id: string }[];
+    // kb-user-1 (F9, no collision with F7 default) first, kb-default-f7 back-filled after.
+    expect(kbs[0].id).toBe('kb-user-1');
+    expect(kbs.map((k) => k.id)).toContain('kb-default-f7');
+  });
+
   it('keeps the saved (edited) default keybinding rather than the built-in on id collision', () => {
     const store = createTestStore();
     store.getState().loadSession(

--- a/src/renderer/stores/slices/uiSlice.ts
+++ b/src/renderer/stores/slices/uiSlice.ts
@@ -15,6 +15,7 @@ import {
   type PrefixConfig,
   BUILTIN_TEMPLATES,
   DEFAULT_PREFIX_CONFIG,
+  DEFAULT_CUSTOM_KEYBINDINGS,
 } from '../../../shared/types';
 import { applyCustomCssVars, clearCustomCssVars, DEFAULT_CUSTOM_THEME, migrateCustomThemeColors } from '../../themes';
 
@@ -659,15 +660,10 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
   }),
 
   // ─── Custom keybindings ──────────────────────────────────────────────
-  customKeybindings: [
-    {
-      id: 'kb-default-f7',
-      key: 'F7',
-      label: 'Claude (skip permissions)',
-      command: 'claude --dangerously-skip-permissions',
-      sendEnter: true,
-    },
-  ],
+  // Seed from the shared DEFAULT_CUSTOM_KEYBINDINGS constant (single source of
+  // truth shared with the workspaceSlice load-merge). Deep-copy each entry so
+  // the module-level constant can never be mutated through store state.
+  customKeybindings: DEFAULT_CUSTOM_KEYBINDINGS.map((kb) => ({ ...kb })),
 
   addKeybinding: (kb) => set((state) => {
     state.customKeybindings.push({
@@ -827,7 +823,9 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
     state.prefixError = msg;
   }),
 
-  prefixConfig: { ...DEFAULT_PREFIX_CONFIG },
+  // Deep-copy bindings so the module-level DEFAULT_PREFIX_CONFIG.bindings map
+  // is never shared by reference with store state (matches resetPrefixConfig).
+  prefixConfig: { ...DEFAULT_PREFIX_CONFIG, bindings: { ...DEFAULT_PREFIX_CONFIG.bindings } },
 
   setPrefixKey: (keyCode) => set((state) => {
     state.prefixConfig.key = keyCode;

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -1,6 +1,6 @@
 import type { StateCreator } from 'zustand';
 import type { StoreState } from '../index';
-import { createWorkspace, generateId, BUILTIN_TEMPLATES, type Pane, type PaneLeaf, type SessionData, type Workspace, type WorkspaceMetadata } from '../../../shared/types';
+import { createWorkspace, generateId, BUILTIN_TEMPLATES, DEFAULT_PREFIX_CONFIG, DEFAULT_CUSTOM_KEYBINDINGS, type Pane, type PaneLeaf, type SessionData, type Workspace, type WorkspaceMetadata } from '../../../shared/types';
 import { getPresetById } from '../../../shared/layoutPresets';
 import { setLocale as i18nSetLocale, type Locale } from '../../i18n';
 import { applyCustomCssVars, migrateThemeId, migrateCustomThemeColors } from '../../themes';
@@ -295,7 +295,19 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
         window.electronAPI.settings.setToastEnabled(data.toastEnabled);
       }
       if (data.notificationRingEnabled != null) state.notificationRingEnabled = data.notificationRingEnabled;
-      if (data.customKeybindings) state.customKeybindings = data.customKeybindings;
+      if (data.customKeybindings) {
+        // Merge saved keybindings with current built-in defaults (mirrors the
+        // layoutTemplates merge below). Saved entries win on id collision so a
+        // user's edit to a default binding is preserved; built-in defaults
+        // (id 'kb-default-*') the saved session predates are back-filled so
+        // shipping a new default never silently drops it on a cross-version
+        // upgrade. Trade-off (same as the prefixConfig merge): a default the
+        // user deleted is re-added on next load — acceptable until a tombstone
+        // schema exists.
+        const savedIds = new Set(data.customKeybindings.map((k) => k.id));
+        const missingDefaults = DEFAULT_CUSTOM_KEYBINDINGS.filter((k) => !savedIds.has(k.id));
+        state.customKeybindings = [...missingDefaults.map((k) => ({ ...k })), ...data.customKeybindings];
+      }
       if (data.autoUpdateEnabled != null) {
         state.autoUpdateEnabled = data.autoUpdateEnabled;
         window.electronAPI.settings.setAutoUpdateEnabled(data.autoUpdateEnabled);
@@ -321,7 +333,22 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
         ];
       }
       if (data.recentCommands) state.recentCommands = data.recentCommands;
-      if (data.prefixConfig) state.prefixConfig = data.prefixConfig;
+      if (data.prefixConfig) {
+        // Merge the saved bindings ON TOP of DEFAULT_PREFIX_CONFIG instead of
+        // wholesale replacement (mirrors the layoutTemplates merge above). A
+        // session saved before a default binding existed — e.g. the arrow-key
+        // pane-focus bindings (ArrowUp/Down/Left/Right) added in a later
+        // release — carries a bindings map missing those keys; a wholesale
+        // replace would overwrite the in-memory default and leave prefix+arrow
+        // navigation permanently dead. Saved/rebound keys still win on
+        // collision so user customizations are preserved. Trade-off: a default
+        // the user deliberately removed is re-added on next load (acceptable
+        // until a removed-defaults tombstone schema exists).
+        state.prefixConfig = {
+          key: data.prefixConfig.key ?? DEFAULT_PREFIX_CONFIG.key,
+          bindings: { ...DEFAULT_PREFIX_CONFIG.bindings, ...data.prefixConfig.bindings },
+        };
+      }
     }),
 
     // ─── Fix 0 fallback (cross-slice atomic clear) ───────────────────────

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -297,16 +297,25 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
       if (data.notificationRingEnabled != null) state.notificationRingEnabled = data.notificationRingEnabled;
       if (data.customKeybindings) {
         // Merge saved keybindings with current built-in defaults (mirrors the
-        // layoutTemplates merge below). Saved entries win on id collision so a
-        // user's edit to a default binding is preserved; built-in defaults
-        // (id 'kb-default-*') the saved session predates are back-filled so
-        // shipping a new default never silently drops it on a cross-version
-        // upgrade. Trade-off (same as the prefixConfig merge): a default the
-        // user deleted is re-added on next load — acceptable until a tombstone
-        // schema exists.
+        // layoutTemplates merge below). Built-in defaults (id 'kb-default-*')
+        // the saved session predates are back-filled so shipping a new default
+        // never silently drops it on a cross-version upgrade.
+        //
+        // The runtime lookup matches by KEY (useKeyboard:
+        // customKeybindings.find((kb) => kb.key === pressed), first match
+        // wins), so we (a) keep saved entries FIRST and (b) back-fill a default
+        // only when neither its id NOR its key is already taken by a saved
+        // entry. Otherwise resurrecting a default would shadow a user binding
+        // that repurposed the same key under a different id. Trade-off (same as
+        // the prefixConfig merge): a default the user deleted outright — with
+        // no replacement on that key — is re-added on next load. Acceptable
+        // until a removed-defaults tombstone schema exists.
         const savedIds = new Set(data.customKeybindings.map((k) => k.id));
-        const missingDefaults = DEFAULT_CUSTOM_KEYBINDINGS.filter((k) => !savedIds.has(k.id));
-        state.customKeybindings = [...missingDefaults.map((k) => ({ ...k })), ...data.customKeybindings];
+        const savedKeys = new Set(data.customKeybindings.map((k) => k.key));
+        const missingDefaults = DEFAULT_CUSTOM_KEYBINDINGS.filter(
+          (k) => !savedIds.has(k.id) && !savedKeys.has(k.key),
+        );
+        state.customKeybindings = [...data.customKeybindings, ...missingDefaults.map((k) => ({ ...k }))];
       }
       if (data.autoUpdateEnabled != null) {
         state.autoUpdateEnabled = data.autoUpdateEnabled;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -263,6 +263,24 @@ export interface CustomKeybinding {
   sendEnter: boolean; // append \n after command
 }
 
+/**
+ * Built-in custom keybindings seeded into uiSlice initial state and used as
+ * the backfill source when restoring a saved session. Single source of truth
+ * so the load-merge in workspaceSlice never drifts from the uiSlice default.
+ * Entries are identified by their `kb-default-*` id; user edits to a default
+ * win on load (saved entry kept), while a default missing from an older saved
+ * session is back-filled so shipping a new built-in never silently drops it.
+ */
+export const DEFAULT_CUSTOM_KEYBINDINGS: CustomKeybinding[] = [
+  {
+    id: 'kb-default-f7',
+    key: 'F7',
+    label: 'Claude (skip permissions)',
+    command: 'claude --dangerously-skip-permissions',
+    sendEnter: true,
+  },
+];
+
 // === Prefix mode bindings ===
 export interface PrefixConfig {
   key: string;  // e.code value for the prefix trigger, e.g. 'KeyB'


### PR DESCRIPTION
## Summary

Fixes the reported regression where **prefix + arrow key pane navigation does nothing** — even after the arrow bindings were added to `DEFAULT_PREFIX_CONFIG`. Root cause was a session-load antipattern that silently dropped newly-shipped defaults for any user whose saved session predated them, plus a handful of adjacent prefix-mode and persistence bugs surfaced by a 5-expert review pass.

## Root cause

`workspaceSlice.loadSession` **wholesale-replaced** `prefixConfig` with the saved payload (`state.prefixConfig = data.prefixConfig`), with no merge against current defaults. A session saved before the arrow-key bindings (`ArrowUp/Down/Left/Right → focusUp/Down/Left/Right`) existed carried a `bindings` map missing those keys; on load it overwrote the in-memory default, so `useKeyboard`'s `prefixConfig.bindings[key]` lookup returned `undefined` and prefix+arrow no-oped forever after restart. The existing `layoutTemplates` + `BUILTIN_TEMPLATES` merge already guards against exactly this — `loadSession` was the one place that skipped it.

## Changes

**Session config merge (forward-compat)**
- `loadSession` now merges `prefixConfig.bindings` on top of `DEFAULT_PREFIX_CONFIG.bindings` (saved entries win on collision; missing defaults back-filled; prefix `key` falls back to the default for malformed payloads).
- `loadSession` merges `customKeybindings` against `DEFAULT_CUSTOM_KEYBINDINGS`. Saved entries kept first; a default is back-filled only when neither its **id nor its key** collides with a saved entry — the runtime lookup matches by key (first match wins), so a naive prepend would shadow a user binding that repurposed the same key (caught by codex review, P2).
- Promote the built-in F7 keybinding to a shared `DEFAULT_CUSTOM_KEYBINDINGS` constant so `uiSlice` init and the load-merge share one source of truth.

**Persistence data loss**
- `AppLayout.buildSessionData` never persisted `layoutTemplates` or `recentCommands`, so `loadSession` always read them back empty — user layout templates and command history were lost on every restart. Now persisted (non-builtin templates only; `recentCommands` omitted when empty, matching the existing optional-field convention).

**Prefix-mode hardening (`useKeyboard`)**
- Bare modifier keys (Shift/Control/Alt/Meta) cleared the auto-exit timeout but never re-armed it, leaving prefix mode active indefinitely — the next keypress, even minutes later, fired a prefix command. Now re-arms the 2s timeout (exiting outright would make the Shift-reached bindings `% " & ? :` unreachable).
- Unknown-key path uses `exitPrefixMode()` for symmetric teardown and uppercases the displayed key (the old ternary was a no-op).
- Deep-copy `DEFAULT_PREFIX_CONFIG.bindings` at `uiSlice` init to match `resetPrefixConfig` and avoid sharing the module-level map by reference.

## Trade-off

The merges are additive: a default the user deliberately removed (with no replacement on that key) is re-added on next load. This matches the existing `layoutTemplates` precedent and is conventional for config defaults; a removed-defaults tombstone schema is the principled long-term fix but is out of scope.

## Review process

- 5-expert parallel bug review (keyboard/input, state-persistence, PTY/terminal, pane/layout/focus, IPC/MCP/daemon); confirmed concerns each got a 2-expert draft + adversarial-verify fix-design pair.
- Accumulator-style "wholesale replace" findings for `memberCosts`/`tokenDataByPty` were rejected as false positives (those are runtime state, not defaults). `focusPaneDirection` / `activePaneId` / `terminalRegistry` flags were medium/low confidence and left out of scope.
- **codex review:** round 1 found 1×[P2] (key-collision shadow) → fixed; round 2 clean (gate PASS).

## Test plan

- `2010` tests pass; `tsc --noEmit` clean; no new lint violations (the 3 pre-existing AppLayout lint errors are unchanged on base).
- New `loadSession` regression coverage: arrow back-fill, prefix-key fallback, keybinding back-fill, saved-wins-on-id-collision, **no back-fill on key collision**, saved-before-defaults ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
