### PR TITLE
v2.14.0: session-replacement fix + lifecycle observability + token ACL hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.0] — 2026-05-29 — Session-replacement fix + lifecycle observability + token ACL hardening
+
+Fixes the reported instability where, while running several Claude Code windows, "the daemon resets and sessions get replaced by new empty windows." Root-caused via a multi-expert review (see `plans/RCA-daemon-session-replacement-2026-05-29.md`): the daemon process never actually dies (uptime is monotonic). The renderer's reconnect/reconcile path could not distinguish a *transient* failure from a *permanent* one and destructively cleared live `ptyId`s, making Terminal self-create empty sessions while the daemon still held the originals.
+
+### Fixed — live sessions replaced on reconnect (RCA A1/A2)
+- `pty.reconnect` now tags failures `transient` (pipe-not-writable / RPC threw during handler swap) vs permanent (session dead). `useTerminal` retries transient failures with short backoff instead of immediately clearing the surface — a live session no longer gets discarded on a momentary blip.
+- `AppLayout` reconcile preserves all `ptyId`s when the daemon returns an empty session list (almost always "not ready yet", not "all dead"). The late-reconnect (`daemon:connected`) path is now abort/timeout/catch guarded and never falls through to `clearAllPtyState`.
+- `RECONCILE_TIMEOUT_MS` is now derived from `DAEMON_RPC_TIMEOUT_MS` in `shared/timeouts.ts` (15s > 10s), removing the asymmetry that let a slow-but-successful `pty.list` trip the destructive startup fallback.
+
+### Added — daemon/main lifecycle observability (RCA A8)
+- Structured `[lifecycle]` logging on daemon `attachSession`/`detachSession`, main `daemon:connected` emit, `DaemonClient.connect` error codes (EPERM etc.), `pty.list` live-session count, and the renderer's destructive `ptyId`-clear decisions (mirrored into the main log). Reconnect/session-replacement events are now diagnosable post-hoc instead of invisible.
+
+### Security — token file ACL re-hardening (RCA A12)
+- `secureWriteTokenFile` only locked permissions when a token was freshly written; a token loaded from disk kept whatever (possibly broad, inherited) ACL it had. New `reHardenTokenFileAcl()` re-applies a restrictive ACL (Windows `icacls`) / `chmod 0600` (POSIX) on the existing `daemon-auth-token` and `~/.wmux-auth-token` at load time. Best-effort: never crashes a live daemon.
+
+### Fixed — session config merge + prefix mode
+- Merge session config against defaults on load and harden prefix mode handling.
+- Skip keybinding back-fill on key collision.
+
 ## [2.13.0] — 2026-05-29 — OSC 133 EventBus tee + agent.awaiting_input lifecycle
 
 Extends the `agent.lifecycle` event in `wmux_events_poll` with two new substrate signals so orchestrator SDKs and any MCP consumer can react to shell command lifecycle and agent approval prompts without polling `terminal_read_events`. Both signals are wired BOTH on the local-mode PTYBridge path AND on the daemon-mode DaemonNotificationRouter path (the default production path).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",

--- a/plans/RCA-daemon-session-replacement-2026-05-29.md
+++ b/plans/RCA-daemon-session-replacement-2026-05-29.md
@@ -1,0 +1,92 @@
+# RCA: "데몬 초기화 → 세션 신규 교체" 안정성/보안 근본원인 분석
+
+> 작성일 2026-05-29 · 전문가 10명 진단 → 12개 안건 취합 → 6개 안건 × 3명(근본원인검증/수정설계/적대적반증) 심층검토 → 합성
+> 검토 규모: 35 에이전트, ~307만 토큰, 763회 코드 조사
+
+## 0. 한 줄 결론
+
+**"데몬이 초기화된다"는 멘탈 모델은 틀렸다.** 데몬 프로세스는 죽지 않는다(uptime 단조증가·메모리 안정·bootId 불변으로 확정). 진짜 버그는 **렌더러(및 main)의 재연결/reconcile 로직이 "일시적 실패"와 "영구 사망"을 구분하지 못하고, 살아있는 세션의 `ptyId`를 파괴적으로 비워 `Terminal`이 빈 신규 세션을 self-create** 하는 것이다. 데몬은 기존 세션을 그대로 들고 있으므로(고아화) 데몬 로그에 흔적이 없다 → 사용자에겐 "창은 유지, 세션만 신규 교체"로 보인다.
+
+핵심 결함 클래스(모든 direct 안건이 수렴): **"한 번 실패 = 즉시 세션 폐기" — 비파괴(non-destructive) 보장의 부재.**
+
+## 1. 확정된 사실 (코드 + 런타임 로그 교차검증)
+
+- 데몬 프로세스 생존: `daemon-2026-05-28.log` uptime 39,611s→48,463s 단조증가, 메모리 ~100MB.
+- launcher `ensureDaemon`이 살아있는 데몬 발견 시 `spawned:false`로 재사용(`launcher.ts:381-384`) → 재연결돼도 uptime 리셋 없음 → 로그와 정합.
+- `main onInstall`이 초기/재연결 구분 없이 `webContents.send('daemon:connected')`(`index.ts:591`) → 렌더러 `reconcilePtys()` 재실행.
+- 종착점: `Terminal.tsx:68-138` `externalPtyId` falsy → `pty.create`로 신규 빈 데몬 세션 생성.
+
+## 2. 직접 근본원인 (버그 direct)
+
+### A1 — 렌더러 reconcile/reconnect의 거짓 사망 판정 → 파괴적 폐기 [CRITICAL, confidence: HIGH]
+살아있는 세션을 죽은 것으로 오판하는 두 경로:
+- **경로1 (reconcile):** `pty.list`(=`daemon.listSessions`)가 데몬 recover 중 **빈/부분 배열을 "성공적으로" 반환**하면 `AppLayout.tsx:419-425`가 `activeIds.has(ptyId)=false`로 보고 `updateSurfacePtyId('')`로 폐기.
+- **경로2 (useTerminal mount):** `daemon:connected`로 5개 Terminal이 동시 `pty.reconnect` 재발사 → handler-swap 윈도/pipe-not-writable에서 `{success:false}`/throw → `clearSurfacePtyIdByPty`(`useTerminal.ts:672-689, 779-796`)로 즉시 폐기.
+- 두 경로 모두 `ptyId=''` → `Terminal` self-create. **5개 중 일부만 팅기는 비결정성**은 경로2의 swap/probe 윈도 경쟁으로 설명됨.
+- 5명 전문가가 독립적으로 1순위 지목(강한 수렴).
+
+### A2 — reconcile 타임아웃(5s) < RPC 타임아웃(10s) 비대칭 [CRITICAL, MEDIUM]
+- `RECONCILE_TIMEOUT_MS=5_000`(`AppLayout.tsx:76`) < `RPC_TIMEOUT_MS=10_000`(`DaemonClient.ts:7`). 데몬이 6~9초 내 정상 응답 가능한데도 렌더러가 5초에 먼저 포기 → `catch`에서 `clearAllPtyState()`(전 세션 폐기, startup 경로).
+- **정정(적대적 검증):** "데몬 이벤트루프 stall" 가설은 코드상 반박됨(`listSessions`는 동기 인메모리 연산). 5초 초과의 실제 트리거는 named-pipe/IPC 왕복 지연. mid-session 팅김의 직접원인은 비대칭이 아니라 `daemon.onConnected→reconcilePtys`의 stale-list clear(=A1 경로1).
+
+### A4 — health-probe(3×3s) 오탐 → 강제 respawn/재연결 폭풍 [HIGH, MEDIUM]
+- `runHealthPing`(`DaemonRespawnController.ts:301-325`): 3초 타임아웃 ping을 3연속 실패하면 timeout/unauthorized/일시 stall/진짜 hang을 **구분 없이** "hang" 단정 → `handleDisconnect`+respawn → `daemon:connected` 재발신 → A1 발화.
+- 5세션 고부하로 이벤트루프 ~9초 stall 시 살아있는 데몬 오탐 → "하루 2회" 산발성과 정합.
+- **잠복 변종:** `launcher.ts:500-533` two-shot ping마저 실패하면 검증된 진짜 데몬을 `SIGKILL` → 더 심한 데이터 손실.
+- **미확정(적대적 검증):** 비SIGKILL(데몬 재사용) 경로에서 "오탐→세션 교체"의 인과는 코드상 자동으로 이어지지 않음(데몬 listSessions는 부분/공집합 레이스가 없음). 실제 사건이 SIGKILL 경로였는지 비SIGKILL이었는지는 **로그 부재로 판별 불가** → A8 필요.
+
+### A6 — 제어 파이프 단절 복원력 부재 + 무관용 reconnect [HIGH, MEDIUM]
+- `DaemonClient.connect`(`DaemonClient.ts:42-64`)는 `net.createConnection` 1회만 시도, `err.code` 무시, TCP fallback 없음(대조: `wmux-client.ts:158-192`는 보유). `disconnectSync`는 pending RPC를 reject만(replay 없음).
+- Windows EPERM/ECONNRESET(AV 스캔·핸들 경합)으로 일시 단절 → 영구 실패로 취급 → A1 경로로 세션 폐기 전파.
+
+## 3. 메타 결함 — 이것을 가장 먼저 고쳐야 한다
+
+### A8 — 라이프사이클/연결 관측성 전무 [HIGH] **(8명 전원 독립 지적, 최강 수렴)**
+- `attach`/`detach`/`reconnect`/`rebind`/`ptyId-clear`/`auth-fail`이 데몬·main 어디에도 로깅되지 않음. 렌더러의 파괴적 결정은 `console.log`로만 남아 데몬 로그와 상관분석 불가.
+- **결과: A1·A2·A4·A6 중 어느 경로가 실제 어제 팅김을 일으켰는지 코드만으로 단정 불가.** 적대적 검증이 반복해서 "로그 없이는 그럴듯한 추측"이라 결론.
+- → **수정·재발감시·가설 확정의 전제 조건. P0 최우선.**
+
+## 4. 기여/배경 요인
+
+| 안건 | 내용 | 판정 |
+|------|------|------|
+| A3 | `daemon:connected` 재발신 → 가드 없는 late reconcile | **강등(LOW)**. reconcile v2는 이미 비파괴적이라 단독 원인 아님. 진짜 용의자는 `useTerminal.ts:728/658`의 조건부 `terminal.reset()`(스크롤백만 소실) |
+| A5 | wmic.exe 부재 → `getBootId()` `uptime-` 폴백 | **버그 비인과로 반증(HIGH→LOW)**. bootId는 데몬 생애 1회 캐시되어 안정적이고, 영향 지점은 `recoverSessions`(startup 한정, 데몬 무재시작 시 미실행)뿐. **사실이지만 세션 교체와 무관.** 코드 위생 차원 수정만 권고 |
+| A7 | SessionPipe 단일클라 재접속 레이스 + 비원자 attach → 데이터/입력 먹통(체감 "빈 세션") | HIGH |
+| A9 | sessions.json 부분기록·경합·NaN TTL → 세션 메타 유실 | HIGH |
+| A10 | RingBuffer 8MB 포화 + `bufferMaxMb=64` 미적용 → 장시간 세션 스크롤백 영구 손실 | MEDIUM. "컨텍스트 사라짐"의 일부는 교체가 아닌 정상 포화 |
+| A11 | 데몬 모드 pid-map 영구 누수 + PID 재사용 미검증 | MEDIUM(별도 워크스페이스 난립) |
+
+### ⚠️ A5에 대한 정정 (초기 분석 수정)
+초기에 런타임 로그에서 "reboot detected 28건" + "어제 PC = Win11 최신 = wmic 없음"을 근거로 A5(bootId)를 어제 버그의 유력 원인으로 격상했으나, **안건당 3명 심층검토의 적대적 반증이 이를 코드로 반박**했다: bootId는 OS 부팅감지가 제어흐름을 바꾸는 곳이 `recoverSessions`(데몬 startup 한정) 단 한 곳뿐이고, 데몬이 재시작되지 않았으므로 라이브 세션 교체에 닿을 경로가 없다. **사실관찰은 맞지만 인과는 틀렸다.** 진짜 원인은 렌더러 reconnect/reconcile(A1)이다.
+
+## 5. 보안 — 별도 트랙 (버그 무관, 프로덕션 영향 큼)
+
+### A12 [HIGH]
+1. 토큰 ACL 재하드닝 부재 — `daemon-auth-token`이 Administrators/SYSTEM/CodexSandboxUsers에 읽기 노출(`.wmux-backup-acl-broken-*` 2개가 과거 사고 입증).
+2. Windows TCP fallback이 127.0.0.1에 항상 열리고 단일 토큰만으로 인증 → 동일 호스트 임의 프로세스가 RPC 호출 가능.
+3. SSRF: `browser_navigate`가 검증 후 hostname 재해석(loadURL) → DNS 리바인딩 TOCTOU; 127.0.0.0/8 전체 허용.
+4. `McpRegistrar`가 `~/.claude.json`을 부팅마다 비원자·비잠금 read-modify-write로 덮어씀 → 사용자 설정 유실 위험.
+
+## 6. 처방 — 단일 원칙으로 수렴
+
+> **"데몬이 살아있는 한, 살아있는 ptyId를 절대 파괴적으로 비우지 않는다."**
+
+공통 수정:
+- reconcile 비파괴화: `pty.list`가 빈/부분/throw일 때 그 사이클 **no-op(보존)**. 개별 부재는 즉시 clear 대신 **2-strike**(짧은 backoff 후 재조회, 2연속 부재일 때만 사망 확정). 사망 확정은 가급적 명시적 `session:died` 신호에만.
+- `pty.reconnect` 실패 시 error code로 "영구 부재(session not found/dead)" vs "일시 실패(pipe not writable yet)"를 구분 → 일시 실패는 재시도(2~3s 상한).
+- 타임아웃 단일 소스화: `shared/timeouts.ts`에서 `RECONCILE = DAEMON_RPC + 5s` 파생(독립 표류 차단).
+- late-reconnect(`AppLayout.tsx:623-636`)에 startup과 동일한 abort/timeout/generation 가드 + catch에서 `clearAllPtyState` 금지.
+
+## 7. 실행 우선순위
+
+- **P0 (즉시):**
+  1. **A8 관측성 로깅** — attach/detach/reconnect/ptyId-clear/health-hang/list-count를 데몬·main 공통 logSink에 구조화 기록. (진단·확정의 전제)
+  2. **A1 비파괴 reconcile/reconnect** — 어느 트리거든 공통으로 차단. "하루 2번 팅김"을 직접 멈춤.
+- **P1:** A2(타임아웃 단일소스), A4(health-probe 보수화: 임계 3→5, 타임아웃 3s→5s, 이벤트루프 self-stall 감지, SIGKILL 전 재확인), A6(파이프 재시도/EPERM 분기/TCP fallback).
+- **P2:** A7(attach 직렬화·원자화), A9(load 실패와 빈상태 구분), A10(bufferMaxMb 적용), A3(`terminal.reset` 가드).
+- **별도 보안 트랙:** A12.
+
+## 8. 정직한 한계
+
+코드만으로는 어제 "2번 팅김"의 **정확한 단일 트리거**(A1 reconcile vs A4 health-probe vs A6 파이프단절 vs `useTerminal.reset`)를 확정할 수 없다 — 모두 동일 종착점(빈 세션 self-create)으로 수렴하지만 발화 선행조건이 로그로 입증되지 않았다. **올바른 순서: A8 로깅을 먼저 배포 → 다음 재발 시 로그로 트리거 확정.** 단, A1 비파괴화는 모든 트리거를 공통 차단하므로 로그 확정을 기다리지 말고 즉시 적용한다.

--- a/src/daemon/DaemonPipeServer.ts
+++ b/src/daemon/DaemonPipeServer.ts
@@ -4,7 +4,7 @@ import crypto from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
 import type { RpcRequest, RpcResponse } from '../shared/rpc';
-import { secureWriteTokenFile } from '../shared/security';
+import { secureWriteTokenFile, reHardenTokenFileAcl } from '../shared/security';
 
 const MAX_LINE_BUFFER = 1024 * 1024; // 1 MB — prevent OOM from malicious clients
 
@@ -75,6 +75,12 @@ export class DaemonPipeServer {
       const existing = fs.readFileSync(tokenPath, 'utf8').trim();
       if (existing) {
         this.authToken = existing;
+        // RCA A12 — re-harden the ACL on the EXISTING token file. Tokens created
+        // by older versions (or carrying broad inherited ACLs) would otherwise
+        // remain readable by Administrators/SYSTEM/other local accounts, letting
+        // any local process steal the token and drive the daemon RPC surface.
+        const hardened = reHardenTokenFileAcl(tokenPath);
+        console.log(`[lifecycle] daemon auth token loaded from disk — ACL re-harden ${hardened ? 'ok' : 'FAILED (token perms may be loose)'}`);
         return this.authToken;
       }
     } catch {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -662,6 +662,11 @@ function registerRpcHandlers(
     // recovered session has its .buf refreshed inside the first 30 s window.
     triggerSnapshot();
 
+    // RCA A8 — log the attach lifecycle event. Previously success was silent,
+    // so a client re-attaching (the renderer reconnect path) left no daemon-side
+    // trace to correlate with renderer ptyId-clear / session-replacement.
+    log('info', `[lifecycle] attachSession id=${p.id} pipe=${managed ? 'started' : 'no-managed-session'} total=${sessionManager.listSessions().length}`);
+
     return { ok: true };
   });
 
@@ -691,6 +696,9 @@ function registerRpcHandlers(
 
     const state = buildState(sessionManager);
     stateWriter.saveImmediate(state);
+
+    // RCA A8 — log the detach lifecycle event (was silent on success).
+    log('info', `[lifecycle] detachSession id=${p.id} total=${sessionManager.listSessions().length}`);
 
     return { ok: true };
   });

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -3,8 +3,11 @@ import { EventEmitter } from 'node:events';
 import crypto from 'node:crypto';
 import type { RpcResponse, DaemonEvent } from '../shared/rpc';
 import { FLUSH_DONE_MARKER } from '../daemon/SessionPipe';
+import { DAEMON_RPC_TIMEOUT_MS } from '../shared/timeouts';
 
-const RPC_TIMEOUT_MS = 10_000;
+// RCA A2 — single source of truth in shared/timeouts.ts so the renderer's
+// RECONCILE_TIMEOUT_MS can be derived from (and stay greater than) this value.
+const RPC_TIMEOUT_MS = DAEMON_RPC_TIMEOUT_MS;
 const MAX_LINE_BUFFER = 1024 * 1024; // 1 MB
 
 interface PendingRequest {
@@ -44,6 +47,10 @@ export class DaemonClient extends EventEmitter {
 
     return new Promise<boolean>((resolve) => {
       const timeout = setTimeout(() => {
+        // RCA A6/A8 — record connect timeouts. Previously this resolved(false)
+        // with no trace, so a daemon that was alive but slow to accept on the
+        // control pipe was indistinguishable from a dead one in the logs.
+        console.warn(`[lifecycle] DaemonClient.connect timeout (5s) pipe=${this.pipeName}`);
         socket.destroy();
         resolve(false);
       }, 5_000);
@@ -56,8 +63,14 @@ export class DaemonClient extends EventEmitter {
         resolve(true);
       });
 
-      socket.on('error', () => {
+      socket.on('error', (err: NodeJS.ErrnoException) => {
+        // RCA A6/A8 — surface the error CODE (EPERM/ECONNREFUSED/ENOENT). On
+        // Windows EPERM here indicates AV scan / handle contention on the named
+        // pipe — a transient, retryable condition — not a dead daemon. The
+        // pre-fix code dropped the error entirely, which is the single biggest
+        // reason the control-pipe disconnect class was undiagnosable.
         clearTimeout(timeout);
+        console.warn(`[lifecycle] DaemonClient.connect error code=${err?.code ?? '?'} pipe=${this.pipeName} msg=${err?.message ?? String(err)}`);
         resolve(false);
       });
     });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -588,6 +588,13 @@ app.on('ready', async () => {
       daemonNotificationRouter = new DaemonNotificationRouter(client, () => mainWindow, () => hookSignalRouter);
       daemonNotificationRouter.start();
       if (mainWindow && !mainWindow.isDestroyed()) {
+        // RCA A3/A8 — every install (initial AND every reconnect/respawn) emits
+        // daemon:connected, which drives the renderer's late reconcile. Logging
+        // the emit makes the "reconnect → re-reconcile" cadence visible in the
+        // main log file so it can be correlated with any renderer ptyId-clear.
+        // The preceding handler-swap lines + any 'daemon hang detected' /
+        // 'respawn attempt' lines above distinguish initial from reconnect.
+        logLine('info', 'main', 'emitting daemon:connected → renderer will re-reconcile PTYs');
         mainWindow.webContents.send('daemon:connected');
       }
       // Phase A — A7. Run the one-time legacy scrollback migration on

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -464,9 +464,15 @@ export function registerPTYHandlers(
     ipcMain.handle(IPC.PTY_LIST, wrapHandler(IPC.PTY_LIST, async () => {
       const sessions = await daemonClient.rpc('daemon.listSessions', {}) as Array<{ id: string; cmd: string; state: string }>;
       // Map to same shape as local PTYManager.getActiveInstances()
-      return sessions
+      const live = sessions
         .filter(s => s.state !== 'dead')
         .map(s => ({ id: s.id, shell: s.cmd }));
+      // RCA A8 — log the count the renderer's reconcile will act on. An empty
+      // or short list here, correlated with a renderer ptyId-clear, is the
+      // signature of the session-replacement bug. Without this line the
+      // decision was invisible in the daemon/main logs.
+      console.log(`[lifecycle] pty.list -> ${live.length} live session(s) of ${sessions.length} total`);
+      return live;
     }));
   } else {
     ipcMain.handle(IPC.PTY_LIST, wrapHandler(IPC.PTY_LIST, () => {
@@ -482,7 +488,11 @@ export function registerPTYHandlers(
         const sessions = await daemonClient.rpc('daemon.listSessions', {}) as Array<{ id: string; cmd: string; state: string; pid?: number }>;
         const session = sessions.find(s => s.id === id);
         if (!session || session.state === 'dead') {
-          return { success: false, error: 'Session not found or dead' };
+          // RCA A1 — permanent failure: the daemon authoritatively reports the
+          // session as absent or dead. Safe for the renderer to clear the
+          // ptyId and self-create. transient:false signals "do not retry".
+          console.log(`[lifecycle] pty.reconnect id=${id} result=fail code=session-dead (transient=false)`);
+          return { success: false, error: 'Session not found or dead', code: 'session-dead', transient: false };
         }
 
         // Reconnect is an explicit fresh-attach intent — pass forceFresh
@@ -500,7 +510,14 @@ export function registerPTYHandlers(
         // bug we're trying to prevent here.
         const probeOk = daemonClient.isSessionPipeWritable(id);
         if (!probeOk) {
-          return { success: false, error: 'Session pipe not writable after reconnect' };
+          // RCA A1 — transient failure: the session is alive in the daemon but
+          // the freshly-attached pipe is not writable yet (forceFresh tears the
+          // old socket down asynchronously; the daemon-side close can arrive a
+          // tick after connect resolves). The renderer must NOT clear the ptyId
+          // — it should retry, otherwise a live session gets replaced by an
+          // empty one. transient:true signals "retry".
+          console.log(`[lifecycle] pty.reconnect id=${id} result=fail code=pipe-not-writable (transient=true)`);
+          return { success: false, error: 'Session pipe not writable after reconnect', code: 'pipe-not-writable', transient: true };
         }
 
         // Re-anchor the PID → ptyId identity map. A surviving shell keeps its
@@ -528,9 +545,16 @@ export function registerPTYHandlers(
         };
         setSessionDataListener(id, onSessionData as (...args: unknown[]) => void);
 
+        console.log(`[lifecycle] pty.reconnect id=${id} result=ok pid=${session.pid ?? '?'}`);
         return { success: true, id: session.id, shell: session.cmd };
       } catch (err) {
-        return { success: false, error: err instanceof Error ? err.message : String(err) };
+        // RCA A1 — RPC threw (timeout, ECONNRESET, handler swap mid-call).
+        // This is a transient infrastructure failure, NOT proof the session is
+        // dead. transient:true so the renderer retries rather than discarding
+        // the session.
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(`[lifecycle] pty.reconnect id=${id} result=fail code=rpc-error transient=true err=${msg}`);
+        return { success: false, error: msg, code: 'rpc-error', transient: true };
       }
     }));
   } else {

--- a/src/main/pipe/PipeServer.ts
+++ b/src/main/pipe/PipeServer.ts
@@ -2,7 +2,7 @@ import * as net from 'net';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
 import { getPipeName, getAuthTokenPath, getTcpPortPath } from '../../shared/constants';
-import { secureWriteTokenFile } from '../../shared/security';
+import { secureWriteTokenFile, reHardenTokenFileAcl } from '../../shared/security';
 import type { RpcRequest } from '../../shared/rpc';
 import { RpcRouter } from './RpcRouter';
 
@@ -33,7 +33,16 @@ export class PipeServer {
   private loadOrCreateToken(): string {
     try {
       const existing = fs.readFileSync(getAuthTokenPath(), 'utf8').trim();
-      if (existing) return existing;
+      if (existing) {
+        // RCA A12 — re-harden the ACL on the existing ~/.wmux-auth-token. See
+        // reHardenTokenFileAcl(): the write path locks perms only on creation,
+        // so a token loaded from disk could remain broadly readable.
+        const hardened = reHardenTokenFileAcl(getAuthTokenPath());
+        if (!hardened) {
+          console.warn('[PipeServer] auth token ACL re-harden failed — file perms may be loose');
+        }
+        return existing;
+      }
     } catch { /* file doesn't exist yet */ }
     // Persist the freshly generated token immediately so MCP clients and other
     // processes don't see an empty token file during the window between server

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -34,7 +34,11 @@ const electronAPI = {
     list: () =>
       ipcRenderer.invoke(IPC.PTY_LIST) as Promise<{ id: string; shell: string }[]>,
     reconnect: (id: string) =>
-      ipcRenderer.invoke(IPC.PTY_RECONNECT, id) as Promise<{ success: boolean; id?: string; shell?: string; error?: string }>,
+      // RCA A1 — `transient` distinguishes a recoverable failure (pipe not
+      // writable yet, RPC threw during a handler-swap window) from a permanent
+      // one (session genuinely dead). The renderer retries transient failures
+      // instead of immediately clearing the ptyId and replacing the session.
+      ipcRenderer.invoke(IPC.PTY_RECONNECT, id) as Promise<{ success: boolean; id?: string; shell?: string; error?: string; code?: string; transient?: boolean }>,
     onData: (callback: (id: string, data: string) => void) => {
       const listener = (_event: Electron.IpcRendererEvent, id: string, data: string) => callback(id, data);
       ipcRenderer.on(IPC.PTY_DATA, listener);

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -35,6 +35,7 @@ import { withDefaultShell } from '../../utils/ptyCreateOptions';
 import { serializeTerminalBuffer } from '../../utils/scrollbackDump';
 import { pastePtyChunked } from '../../utils/clipboardChunk';
 import { isDaemonModeActive, setDaemonModeActive } from '../../daemon/daemonMode';
+import { RECONCILE_TIMEOUT_MS } from '../../../shared/timeouts';
 
 /**
  * Fix 0 — startup reconcile timeout.
@@ -72,8 +73,13 @@ import { isDaemonModeActive, setDaemonModeActive } from '../../daemon/daemonMode
  * Generation token prevents late-arriving reconcile from mutating store
  * after a fresher startup ran. AbortController propagates cancellation
  * into reconcilePtys so its `signal.aborted` checks early-return.
+ *
+ * RCA A2 — RECONCILE_TIMEOUT_MS now lives in shared/timeouts.ts and is
+ * derived as DAEMON_RPC_TIMEOUT_MS + 5s (= 15s). Previously this was a
+ * standalone 5_000 that had drifted BELOW the 10s RPC ceiling, so a daemon
+ * that answered pty.list in 6–9s under load still lost the race and the
+ * startup catch wiped every live session via clearAllPtyState().
  */
-const RECONCILE_TIMEOUT_MS = 5_000;
 
 /** Map shell executable path to a human-readable display name. */
 function shellDisplayName(shellPath: string): string {
@@ -397,6 +403,29 @@ export default function AppLayout() {
         const activeIds = new Set(activePtys.map((p: { id: string }) => p.id));
         console.log('[AppLayout] Daemon active PTYs:', [...activeIds]);
 
+        // RCA A1 — empty-list guard (the single most important non-destructive
+        // change). `pty.list` returning ZERO live sessions on a reconnect
+        // almost always means the daemon/RPC isn't ready yet (main just
+        // reconnected, daemon mid-rehydrate), NOT that every session died.
+        // The pre-fix code would then clear every surface's ptyId and let
+        // Terminal self-create empty sessions — exactly the reported
+        // "daemon reset, all sessions replaced" bug. Preserve everything this
+        // cycle; useTerminal mount re-validates each ptyId individually (with
+        // retry), and a subsequent reconcile / daemon:connected runs again
+        // once the list is populated. A genuine "all sessions dead" state is
+        // rare and self-heals on the next mount's reconnect.
+        const hasSavedPtyIds = useStore.getState().workspaces.some(ws => {
+          const walk = (p: Pane): boolean =>
+            p.type === 'leaf'
+              ? p.surfaces.some(s => !!s.ptyId)
+              : p.children.some(walk);
+          return walk(ws.rootPane);
+        });
+        if (activeIds.size === 0 && hasSavedPtyIds) {
+          console.warn('[lifecycle] reconcile: daemon returned 0 live sessions but saved ptyIds exist — preserving all (no destructive clear, likely daemon not ready yet)');
+          return;
+        }
+
         // Fix 0 (round 3) — reconcile is now ONLY a liveness check.
         //
         // The PTY_DATA-loss race we hit in dogfood: reconcile used to call
@@ -427,7 +456,14 @@ export default function AppLayout() {
                 console.log(`[AppLayout] Surface ${surface.id}: ptyId ${surface.ptyId} alive in daemon, Terminal will reconnect on mount`);
                 // Leave ptyId in place. useTerminal mount reconnects.
               } else {
-                console.log(`[AppLayout] Surface ${surface.id}: ptyId ${surface.ptyId} not in daemon, clearing for Terminal self-create`);
+                // RCA A8 — this is a destructive decision (live ptyId → ''),
+                // logged at warn so it lands in the main log file (mirrored via
+                // the webContents console-message listener) and can be
+                // correlated with the daemon's pty.list count. Reached only
+                // when the daemon returned a NON-empty list that omits this
+                // ptyId (empty lists are preserved above), so this is a
+                // genuinely-absent session per the daemon's own snapshot.
+                console.warn(`[lifecycle] reconcile clearing ptyId=${surface.ptyId} surface=${surface.id} (absent from daemon's ${activeIds.size}-session list) → Terminal self-create`);
                 useStore.getState().updateSurfacePtyId(pane.id, surface.id, '');
               }
             }
@@ -628,11 +664,31 @@ export default function AppLayout() {
   // renderer may have already reconciled with empty pty list
   // before main process finished connecting to daemon).
   useEffect(() => {
+    let activeCtl: AbortController | null = null;
     const remove = window.electronAPI.daemon.onConnected(() => {
-      console.log('[AppLayout] Daemon connected late — re-reconciling PTYs');
-      reconcilePtys();
+      console.log('[lifecycle] daemon connected late — re-reconciling PTYs');
+      // RCA A1/A3 — the late reconcile previously ran as a bare
+      // reconcilePtys() with NO abort, timeout, or catch (unlike the startup
+      // path's 5 guards). A pty.list rejection here escaped as an unhandled
+      // rejection, and the call could outlive a fresher reconcile. Add an
+      // abort+timeout and swallow failures by PRESERVING ptyIds — crucially we
+      // never fall through to clearAllPtyState here (that destructive fallback
+      // is startup-only). reconcilePtys is itself non-destructive on empty
+      // lists now (A1 empty-list guard), so a transient blip preserves state.
+      activeCtl?.abort();
+      const ctl = new AbortController();
+      activeCtl = ctl;
+      const timer = setTimeout(() => ctl.abort(), RECONCILE_TIMEOUT_MS);
+      void reconcilePtys(ctl.signal)
+        .catch((err) => {
+          console.warn('[lifecycle] late reconcile failed — preserving ptyIds (no clear):', err);
+        })
+        .finally(() => clearTimeout(timer));
     });
-    return remove;
+    return () => {
+      activeCtl?.abort();
+      remove();
+    };
   }, [reconcilePtys]);
 
   // Phase A — A6. Keep the module-level daemon-mode flag in sync with the

--- a/src/renderer/hooks/__tests__/reconnectPtyWithRetry.test.ts
+++ b/src/renderer/hooks/__tests__/reconnectPtyWithRetry.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { reconnectPtyWithRetry, RECONNECT_BACKOFFS_MS } from '../reconnectPtyWithRetry';
+
+// RCA A1 regression suite. The bug: any pty.reconnect failure immediately
+// cleared the ptyId, replacing a live session with an empty one. These tests
+// lock in the non-destructive contract.
+
+const noSleep = () => Promise.resolve();
+const alwaysCurrent = () => true;
+const noLog = () => { /* silent in tests */ };
+
+describe('reconnectPtyWithRetry (RCA A1 non-destructive contract)', () => {
+  it('success on first try → never clears the ptyId', async () => {
+    const clearPtyId = vi.fn();
+    const reconnect = vi.fn(async () => ({ success: true }));
+    await reconnectPtyWithRetry('pty-1', alwaysCurrent, { reconnect, clearPtyId, sleep: noSleep, log: noLog });
+    expect(reconnect).toHaveBeenCalledTimes(1);
+    expect(clearPtyId).not.toHaveBeenCalled();
+  });
+
+  it('permanent failure (transient:false) → clears immediately, no retry', async () => {
+    const clearPtyId = vi.fn();
+    const reconnect = vi.fn(async () => ({ success: false, transient: false, error: 'Session not found or dead' }));
+    await reconnectPtyWithRetry('pty-dead', alwaysCurrent, { reconnect, clearPtyId, sleep: noSleep, log: noLog });
+    expect(reconnect).toHaveBeenCalledTimes(1); // no retry on permanent
+    expect(clearPtyId).toHaveBeenCalledWith('pty-dead');
+  });
+
+  it('transient failure then success → retries and PRESERVES the session (never clears)', async () => {
+    const clearPtyId = vi.fn();
+    let calls = 0;
+    const reconnect = vi.fn(async () => {
+      calls++;
+      return calls === 1
+        ? { success: false, transient: true, error: 'Session pipe not writable after reconnect' }
+        : { success: true };
+    });
+    await reconnectPtyWithRetry('pty-live', alwaysCurrent, { reconnect, clearPtyId, sleep: noSleep, log: noLog });
+    expect(reconnect).toHaveBeenCalledTimes(2);
+    expect(clearPtyId).not.toHaveBeenCalled(); // the whole point: live session survives a transient blip
+  });
+
+  it('a thrown RPC is treated as transient → retried, not cleared on first failure', async () => {
+    const clearPtyId = vi.fn();
+    let calls = 0;
+    const reconnect = vi.fn(async () => {
+      calls++;
+      if (calls === 1) throw new Error('handler swap: no handler registered');
+      return { success: true };
+    });
+    await reconnectPtyWithRetry('pty-swap', alwaysCurrent, { reconnect, clearPtyId, sleep: noSleep, log: noLog });
+    expect(reconnect).toHaveBeenCalledTimes(2);
+    expect(clearPtyId).not.toHaveBeenCalled();
+  });
+
+  it('transient failures exhaust all retries → clears as last resort', async () => {
+    const clearPtyId = vi.fn();
+    const reconnect = vi.fn(async () => ({ success: false, transient: true, error: 'still not writable' }));
+    await reconnectPtyWithRetry('pty-stuck', alwaysCurrent, { reconnect, clearPtyId, sleep: noSleep, log: noLog });
+    // initial attempt + one per backoff slot
+    expect(reconnect).toHaveBeenCalledTimes(RECONNECT_BACKOFFS_MS.length + 1);
+    expect(clearPtyId).toHaveBeenCalledWith('pty-stuck');
+  });
+
+  it('terminal unmounts mid-retry → bails without clearing', async () => {
+    const clearPtyId = vi.fn();
+    const reconnect = vi.fn(async () => ({ success: false, transient: true }));
+    let alive = true;
+    const isCurrent = () => alive;
+    // After the first failed attempt, simulate unmount before the next loop turn.
+    const sleep = vi.fn(async () => { alive = false; });
+    await reconnectPtyWithRetry('pty-unmount', isCurrent, { reconnect, clearPtyId, sleep, log: noLog });
+    expect(clearPtyId).not.toHaveBeenCalled(); // never mutate a torn-down terminal
+  });
+});

--- a/src/renderer/hooks/reconnectPtyWithRetry.ts
+++ b/src/renderer/hooks/reconnectPtyWithRetry.ts
@@ -1,0 +1,84 @@
+/**
+ * RCA A1 — reconnect a live daemon session with retry, distinguishing
+ * transient from permanent failure.
+ *
+ * Extracted from useTerminal so the policy can be unit-tested in isolation
+ * (no xterm / zustand / electron import needed). Dependencies are injected.
+ *
+ * The pre-fix code called `pty.reconnect(ptyId)` once and, on ANY failure,
+ * immediately cleared the surface's ptyId — making Terminal self-create a
+ * fresh empty session. That conflated two very different situations:
+ *
+ *   - permanent (transient:false): the daemon reports the session genuinely
+ *     dead → clearing is correct (the next mount self-creates).
+ *   - transient (transient:true / unknown): the session is alive but the
+ *     freshly-attached pipe is not writable yet, or the RPC threw during a
+ *     main-side handler-swap window → clearing here DESTROYS a live session.
+ *     This is the reported "daemon reset, session replaced" bug.
+ *
+ * We retry transient failures with short backoff and only clear as a last
+ * resort after retries are exhausted. `isCurrent()` lets the caller bail the
+ * moment the terminal unmounts so we never mutate state for a torn-down view.
+ */
+
+export interface ReconnectResult {
+  success: boolean;
+  error?: string;
+  transient?: boolean;
+}
+
+export interface ReconnectDeps {
+  /** Invoke the pty.reconnect RPC. */
+  reconnect: (id: string) => Promise<ReconnectResult>;
+  /** Clear the surface's ptyId so the next mount self-creates. */
+  clearPtyId: (id: string) => void;
+  /** Sleep between retries. Injectable so tests don't wait real time. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Optional structured logger. Defaults to console. */
+  log?: (level: 'warn' | 'error', message: string) => void;
+}
+
+/** Backoff schedule for transient retries. ~2.8s cumulative ceiling. */
+export const RECONNECT_BACKOFFS_MS = [400, 900, 1500];
+
+export async function reconnectPtyWithRetry(
+  ptyId: string,
+  isCurrent: () => boolean,
+  deps: ReconnectDeps,
+): Promise<void> {
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const log = deps.log ?? ((level, message) => {
+    // eslint-disable-next-line no-console
+    console[level](message);
+  });
+
+  let lastErr = '<no error>';
+  for (let attempt = 0; attempt <= RECONNECT_BACKOFFS_MS.length; attempt++) {
+    if (!isCurrent()) return; // terminal unmounted mid-retry — stop, mutate nothing
+    let result: ReconnectResult | undefined;
+    try {
+      result = await deps.reconnect(ptyId);
+    } catch (err) {
+      // A thrown RPC is a transient infrastructure failure, not proof of death.
+      lastErr = err instanceof Error ? err.message : String(err);
+      result = { success: false, transient: true, error: lastErr };
+    }
+    if (result?.success) return;
+    lastErr = result?.error ?? '<no error>';
+    // Permanent failure (daemon says the session is dead): clear now, no retry.
+    if (result?.transient === false) {
+      log('warn', `[useTerminal] pty.reconnect ${ptyId} permanent failure (${lastErr}) — clearing ptyId for self-create`);
+      if (isCurrent()) deps.clearPtyId(ptyId);
+      return;
+    }
+    // Transient (or unknown): back off and retry unless attempts are exhausted.
+    if (attempt < RECONNECT_BACKOFFS_MS.length) {
+      log('warn', `[useTerminal] pty.reconnect ${ptyId} transient failure (${lastErr}) — retry ${attempt + 1}/${RECONNECT_BACKOFFS_MS.length} after ${RECONNECT_BACKOFFS_MS[attempt]}ms`);
+      await sleep(RECONNECT_BACKOFFS_MS[attempt]);
+    }
+  }
+  // Exhausted all retries on transient failures. Clear as a last resort so the
+  // surface doesn't keep a stale ptyId that silently never forwards input.
+  log('error', `[useTerminal] pty.reconnect ${ptyId} still failing after ${RECONNECT_BACKOFFS_MS.length} retries (${lastErr}) — clearing ptyId`);
+  if (isCurrent()) deps.clearPtyId(ptyId);
+}

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -15,10 +15,20 @@ import { runCopyWithFeedback } from '../utils/copyWithFeedback';
 import { shouldFitWhilePreservingSelection } from '../utils/fitGuard';
 import { createAutoSelectionCopy } from '../utils/autoSelectionCopy';
 import { createPathLinkProvider } from '../terminal/pathLinkProvider';
+import { reconnectPtyWithRetry as reconnectPtyWithRetryImpl } from './reconnectPtyWithRetry';
 
 // Module-level terminal registry for scrollback persistence
 const terminalRegistry = new Map<string, Terminal>();
 export { terminalRegistry };
+
+// RCA A1 — reconnect-with-retry policy lives in its own module so it can be
+// unit-tested without xterm/zustand/electron. Bound to the live deps here.
+function reconnectPtyWithRetry(ptyId: string, isCurrent: () => boolean): Promise<void> {
+  return reconnectPtyWithRetryImpl(ptyId, isCurrent, {
+    reconnect: (id) => window.electronAPI.pty.reconnect(id),
+    clearPtyId: (id) => useStore.getState().clearSurfacePtyIdByPty(id),
+  });
+}
 
 // Lightweight copy feedback toast — injects/removes a DOM element
 let copyToastTimer: ReturnType<typeof setTimeout> | null = null;
@@ -670,22 +680,10 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // ptyIds, the daemon-side ringBuffer is essentially empty, so a
       // re-attach replays at most the shell prompt — visible cost zero.
       if (daemonModeAtMount) {
-        void window.electronAPI.pty.reconnect(ptyId).then((result) => {
-          // Codex P1 — pty.reconnect resolves with { success: false } when
-          // the session died between AppLayout's liveness check and our
-          // mount call. Without this branch the Terminal would keep the
-          // stale ptyId and silently never get input forwarded —
-          // reproducing the exact input-mute class Fix 0 set out to
-          // eliminate. Clear the surface ptyId so the next mount falls
-          // into Terminal.tsx's self-create path.
-          if (!result?.success) {
-            console.warn(`[useTerminal] pty.reconnect rejected ${ptyId}: ${result?.error ?? '<no error>'}`);
-            useStore.getState().clearSurfacePtyIdByPty(ptyId);
-          }
-        }).catch((err: unknown) => {
-          console.warn(`[useTerminal] pty.reconnect threw for ${ptyId}: ${err instanceof Error ? err.message : String(err)}`);
-          useStore.getState().clearSurfacePtyIdByPty(ptyId);
-        });
+        // RCA A1 — retry transient reconnect failures instead of immediately
+        // clearing the ptyId. See reconnectPtyWithRetry() for the full
+        // rationale. Only a daemon-confirmed dead session clears on the spot.
+        void reconnectPtyWithRetry(ptyId, () => terminalRef.current === terminal);
       }
 
       window.electronAPI.scrollback.load(scrollbackFile).then((content) => {
@@ -776,23 +774,9 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       terminalRegistry.set(ptyId, terminal);
       // Fix 0 (round 3) — trigger pty.reconnect after listener is wired.
       // See the scrollback branch above for the full rationale.
+      // RCA A1 — retry transient failures (see reconnectPtyWithRetry()).
       if (daemonModeAtMount) {
-        void window.electronAPI.pty.reconnect(ptyId).then((result) => {
-          // Codex P1 — pty.reconnect resolves with { success: false } when
-          // the session died between AppLayout's liveness check and our
-          // mount call. Without this branch the Terminal would keep the
-          // stale ptyId and silently never get input forwarded —
-          // reproducing the exact input-mute class Fix 0 set out to
-          // eliminate. Clear the surface ptyId so the next mount falls
-          // into Terminal.tsx's self-create path.
-          if (!result?.success) {
-            console.warn(`[useTerminal] pty.reconnect rejected ${ptyId}: ${result?.error ?? '<no error>'}`);
-            useStore.getState().clearSurfacePtyIdByPty(ptyId);
-          }
-        }).catch((err: unknown) => {
-          console.warn(`[useTerminal] pty.reconnect threw for ${ptyId}: ${err instanceof Error ? err.message : String(err)}`);
-          useStore.getState().clearSurfacePtyIdByPty(ptyId);
-        });
+        void reconnectPtyWithRetry(ptyId, () => terminalRef.current === terminal);
       }
     }
 

--- a/src/shared/__tests__/security.test.ts
+++ b/src/shared/__tests__/security.test.ts
@@ -6,6 +6,7 @@ const fsMock = vi.hoisted(() => ({
   mkdirSync: vi.fn(),
   writeFileSync: vi.fn(),
   unlinkSync: vi.fn(),
+  chmodSync: vi.fn(),
 }));
 
 const execFileSyncMock = vi.hoisted(() => vi.fn());
@@ -15,6 +16,7 @@ vi.mock('fs', () => ({
   mkdirSync: fsMock.mkdirSync,
   writeFileSync: fsMock.writeFileSync,
   unlinkSync: fsMock.unlinkSync,
+  chmodSync: fsMock.chmodSync,
 }));
 
 vi.mock('child_process', () => ({
@@ -75,5 +77,70 @@ describe('secureWriteTokenFile', () => {
       `Failed to set secure ACL on ${tokenPath}: icacls failed`,
     );
     expect(fsMock.unlinkSync).toHaveBeenCalledWith(tokenPath);
+  });
+});
+
+// RCA A12 — re-hardening an EXISTING token file's permissions without
+// rewriting its contents (the bug: tokens loaded from disk kept loose ACLs).
+describe('reHardenTokenFileAcl', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    // clearAllMocks resets call history but NOT mockImplementation; the prior
+    // describe's failing-icacls test would otherwise leak its throw into here.
+    execFileSyncMock.mockReset();
+    fsMock.chmodSync.mockReset();
+  });
+
+  it('re-applies the restrictive ACL on Windows and returns true', async () => {
+    vi.stubEnv('USERNAME', 'tester');
+    vi.stubEnv('SystemRoot', 'C:\\Windows');
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+
+    const { reHardenTokenFileAcl } = await import('../security');
+    const tokenPath = path.join('C:', 'Users', 'tester', '.wmux-auth-token');
+
+    const ok = reHardenTokenFileAcl(tokenPath);
+
+    expect(ok).toBe(true);
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      'C:\\Windows\\System32\\icacls.exe',
+      [tokenPath, '/inheritance:r', '/grant:r', 'tester:F'],
+      { windowsHide: true },
+    );
+    // Must NOT rewrite the token contents — only the ACL.
+    expect(fsMock.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('chmods to 0600 on POSIX and returns true', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+
+    const { reHardenTokenFileAcl } = await import('../security');
+    const tokenPath = '/home/tester/.wmux-auth-token';
+
+    const ok = reHardenTokenFileAcl(tokenPath);
+
+    expect(ok).toBe(true);
+    expect(fsMock.chmodSync).toHaveBeenCalledWith(tokenPath, 0o600);
+    expect(fsMock.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('returns false (does NOT throw) when hardening fails — best-effort', async () => {
+    vi.stubEnv('USERNAME', 'tester');
+    vi.stubEnv('SystemRoot', 'C:\\Windows');
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error('icacls denied');
+    });
+
+    const { reHardenTokenFileAcl } = await import('../security');
+    const tokenPath = path.join('C:', 'Users', 'tester', '.wmux-auth-token');
+
+    // A live daemon must not crash because it couldn't tighten perms.
+    expect(() => reHardenTokenFileAcl(tokenPath)).not.toThrow();
+    expect(reHardenTokenFileAcl(tokenPath)).toBe(false);
+    // The existing (possibly-loose) token file is NOT deleted — unlike the
+    // write path, we keep the working token rather than break auth.
+    expect(fsMock.unlinkSync).not.toHaveBeenCalled();
   });
 });

--- a/src/shared/security.ts
+++ b/src/shared/security.ts
@@ -2,6 +2,22 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
 
+/**
+ * Apply a restrictive Windows ACL to an existing file: strip inheritance and
+ * grant Full control to ONLY the current user. Throws on failure (callers
+ * decide whether that is fatal). Shared by the write path (secureWriteTokenFile)
+ * and the re-harden path (reHardenTokenFileAcl).
+ */
+function applyRestrictiveWindowsAcl(filePath: string): void {
+  const icacls = `${process.env.SystemRoot || 'C:\\Windows'}\\System32\\icacls.exe`;
+  execFileSync(icacls, [
+    filePath,
+    '/inheritance:r',
+    '/grant:r',
+    `${process.env.USERNAME}:F`,
+  ], { windowsHide: true });
+}
+
 export function secureWriteTokenFile(filePath: string, token: string): void {
   const dir = path.dirname(filePath);
   if (!fs.existsSync(dir)) {
@@ -12,13 +28,7 @@ export function secureWriteTokenFile(filePath: string, token: string): void {
 
   if (process.platform === 'win32') {
     try {
-      const icacls = `${process.env.SystemRoot || 'C:\\Windows'}\\System32\\icacls.exe`;
-      execFileSync(icacls, [
-        filePath,
-        '/inheritance:r',
-        '/grant:r',
-        `${process.env.USERNAME}:F`,
-      ], { windowsHide: true });
+      applyRestrictiveWindowsAcl(filePath);
     } catch (aclErr) {
       console.warn('[secureWriteTokenFile] Could not set file ACL:', aclErr);
       try {
@@ -29,5 +39,37 @@ export function secureWriteTokenFile(filePath: string, token: string): void {
       const message = aclErr instanceof Error ? aclErr.message : String(aclErr);
       throw new Error(`Failed to set secure ACL on ${filePath}: ${message}`);
     }
+  }
+}
+
+/**
+ * RCA A12 — re-harden the ACL/permissions of an ALREADY-EXISTING token file
+ * WITHOUT rewriting its contents.
+ *
+ * Why this exists: secureWriteTokenFile only locks permissions when a token is
+ * freshly WRITTEN. A token loaded from disk (the common path on every run after
+ * first launch) kept whatever ACL it already had — including broad inherited
+ * ACLs that granted read to Administrators / SYSTEM / other local accounts.
+ * Real incident evidence in this very repo: the `~/.wmux-backup-acl-broken-*`
+ * directories. A leaked daemon/main auth token lets any local process drive the
+ * RPC surface (spawn PTYs, read sessions, navigate the browser).
+ *
+ * Best-effort by design: a live daemon/app must NOT fail to start just because
+ * it couldn't tighten an existing file's permissions. Logs and returns false on
+ * failure so callers can surface it without aborting. Returns true when the
+ * restrictive ACL/mode was successfully (re)applied.
+ */
+export function reHardenTokenFileAcl(filePath: string): boolean {
+  try {
+    if (process.platform === 'win32') {
+      applyRestrictiveWindowsAcl(filePath);
+    } else {
+      // POSIX: ensure owner-only read/write on the existing file.
+      fs.chmodSync(filePath, 0o600);
+    }
+    return true;
+  } catch (err) {
+    console.warn(`[reHardenTokenFileAcl] could not re-harden ${filePath}:`, err);
+    return false;
   }
 }

--- a/src/shared/timeouts.ts
+++ b/src/shared/timeouts.ts
@@ -1,0 +1,28 @@
+/**
+ * Single source of truth for cross-process timeout values.
+ *
+ * Why this file exists (RCA A2, 2026-05-29): the renderer's startup reconcile
+ * timeout (`AppLayout.tsx`) and the main↔daemon RPC timeout (`DaemonClient.ts`)
+ * were defined independently and drifted out of order — RECONCILE (5s) became
+ * SHORTER than the RPC ceiling (10s). A daemon that legitimately answered in
+ * 6–9s under load still lost the race, and the renderer's catch fired
+ * `clearAllPtyState()`, replacing every live session with a fresh empty one.
+ *
+ * The invariant that must hold: RECONCILE_TIMEOUT_MS > DAEMON_RPC_TIMEOUT_MS,
+ * so the RPC always gets a chance to resolve (or reject) before the renderer
+ * gives up and falls back to its destructive path. Derive one from the other
+ * here and import on both sides so they can never drift again.
+ *
+ * This module has zero runtime dependencies and is safe to import from the
+ * daemon, main, and renderer bundles alike.
+ */
+
+/** main↔daemon JSON-RPC per-request timeout. */
+export const DAEMON_RPC_TIMEOUT_MS = 10_000;
+
+/**
+ * Renderer startup reconcile timeout. Must exceed the RPC ceiling with a
+ * margin so a single slow-but-successful `pty.list` (= daemon.listSessions)
+ * never trips the destructive startup fallback.
+ */
+export const RECONCILE_TIMEOUT_MS = DAEMON_RPC_TIMEOUT_MS + 5_000;


### PR DESCRIPTION
## What & why

Fixes the reported instability: running several Claude Code windows, "the daemon resets and sessions get replaced by new empty windows." Root-caused via a multi-expert review (see `plans/RCA-daemon-session-replacement-2026-05-29.md`).

**The daemon never actually dies** (uptime is monotonic). The renderer reconnect/reconcile path could not distinguish a *transient* failure from a *permanent* one and destructively cleared live `ptyId`s, so Terminal self-created empty sessions while the daemon still held the originals.

## Changes (3 commits)

1. **fix(daemon): preserve live sessions across reconnect + lifecycle observability (RCA A1/A2/A8)**
   - `pty.reconnect` tags failures `transient` vs permanent; `useTerminal` retries transient failures (`reconnectPtyWithRetry`) instead of clearing immediately
   - `AppLayout` reconcile preserves all `ptyId`s on an empty daemon list; late-reconnect path is abort/timeout/catch guarded and never `clearAllPtyState`
   - `RECONCILE_TIMEOUT_MS` derived from `DAEMON_RPC_TIMEOUT_MS` in `shared/timeouts.ts` (15s > 10s)
   - `[lifecycle]` logging across daemon/main/renderer

2. **security(auth): re-harden ACL on existing token files (RCA A12)**
   - `reHardenTokenFileAcl()` re-applies restrictive ACL/chmod on existing `daemon-auth-token` and `~/.wmux-auth-token` at load (was only locked on fresh write)

3. **chore(release): v2.14.0** — version bump + CHANGELOG

## Verification

- `tsc --noEmit` (main/renderer) + `tsc -p tsconfig.daemon.json`: clean
- `vitest run`: 159 files, 2019 tests pass (incl. 9 new regression tests: 6 reconnect-retry + 3 token ACL)
- New file lint: clean

## Known limitation

Code alone cannot pin the exact trigger of yesterday's incident (A1 reconcile vs A4 health-probe vs A6 pipe-disconnect) — all converge on the same empty-session symptom. The A8 logging added here makes the next occurrence diagnosable; A1's non-destructive guard blocks the symptom regardless of trigger. A4/A6 remain as follow-up (P1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)