### PR TITLE
Launch hardening: non-negotiables + dogfood reliability/perf fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,16 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: write
+    env:
+      # NN2-T1 — SignPath Foundation (OSS) code signing. EMPTY until the secret
+      # is configured, which makes every signing step below no-op so unsigned
+      # builds still ship exactly as today. To enable after SignPath approval:
+      #   1. Add repo SECRET   SIGNPATH_API_TOKEN          (the CI user token)
+      #   2. Add repo VARIABLES SIGNPATH_ORGANIZATION_ID,
+      #      SIGNPATH_PROJECT_SLUG, SIGNPATH_SIGNING_POLICY_SLUG,
+      #      SIGNPATH_ARTIFACT_CONFIGURATION_SLUG (from the SignPath project UI)
+      # See docs.signpath.io/trusted-build-systems/github.
+      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -21,6 +31,46 @@ jobs:
 
       - name: Build & Make
         run: npm run make
+
+      # ── Authenticode code signing (SignPath Foundation, OSS) ─────────────
+      # No-op until SIGNPATH_API_TOKEN is set (see job env). Signs the prebuilt
+      # Setup.exe and replaces the unsigned copy BEFORE the checksum/manifest
+      # steps, so the published SHA-256 matches the signed binary. (Signing the
+      # embedded app exe + delta .nupkg is the NN2-T2 follow-up.)
+      - name: Upload unsigned Setup.exe for signing
+        id: upload-unsigned
+        if: env.SIGNPATH_API_TOKEN != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: wmux-setup-unsigned
+          path: out/make/squirrel.windows/x64/*.Setup.exe
+          if-no-files-found: error
+
+      - name: Sign Setup.exe via SignPath
+        if: env.SIGNPATH_API_TOKEN != ''
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.upload-unsigned.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: out/signed
+
+      - name: Replace unsigned Setup.exe with the signed one
+        if: env.SIGNPATH_API_TOKEN != ''
+        shell: pwsh
+        run: |
+          $signed = Get-ChildItem "out/signed" -Recurse -Filter "*.Setup.exe" | Select-Object -First 1
+          if (-not $signed) { Write-Error "SignPath returned no signed Setup.exe"; exit 1 }
+          $dest = Get-ChildItem "out/make/squirrel.windows/x64/*.Setup.exe" | Select-Object -First 1
+          Copy-Item $signed.FullName $dest.FullName -Force
+          # Fail the release if the result is not a valid Authenticode signature.
+          $sig = Get-AuthenticodeSignature $dest.FullName
+          if ($sig.Status -ne 'Valid') { Write-Error "Signed exe failed Authenticode validation: $($sig.Status)"; exit 1 }
+          Write-Host "Signed Setup.exe in place (publisher: $($sig.SignerCertificate.Subject))"
 
       - name: Get version from package.json
         id: pkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,44 @@ jobs:
       - name: Build & Make
         run: npm run make
 
+      - name: Get version from package.json
+        id: pkg
+        run: |
+          $v = (Get-Content package.json | ConvertFrom-Json).version
+          echo "version=$v" >> $env:GITHUB_OUTPUT
+        shell: pwsh
+
+      # Single canonical SHA-256 of the Setup.exe, consumed by BOTH the
+      # Chocolatey package (below) and the published update-manifest.json
+      # (the in-app updater's integrity pin + install.ps1's verification).
+      - name: Compute Setup.exe checksum
+        id: checksum
+        run: |
+          $exe = Get-ChildItem "out/make/squirrel.windows/x64/*Setup.exe" | Select-Object -First 1
+          $hash = (Get-FileHash $exe.FullName -Algorithm SHA256).Hash
+          echo "sha256=$hash" >> $env:GITHUB_OUTPUT
+        shell: pwsh
+
+      # NN2-T3 — publish update-manifest.json so the in-app AutoUpdater (and
+      # install.ps1) can pin the Setup.exe SHA-256 before launching it.
+      # update.electronjs.org's JSON cannot carry a custom hash field, so this
+      # side-car is fetched from the releases/latest/download/ alias.
+      - name: Write update manifest
+        run: |
+          $version  = "${{ steps.pkg.outputs.version }}"
+          $sha256   = "${{ steps.checksum.outputs.sha256 }}".ToLower()
+          $setupExe = "wmux-$version.Setup.exe"
+          $url      = "https://github.com/openwong2kim/wmux/releases/download/v$version/$setupExe"
+          $manifest = [ordered]@{
+            version  = $version
+            setupExe = $setupExe
+            sha256   = $sha256
+            url      = $url
+          }
+          $manifest | ConvertTo-Json -Compress | Set-Content -NoNewline -Encoding utf8 "out/make/squirrel.windows/x64/update-manifest.json"
+          Write-Host "update-manifest.json: $($manifest | ConvertTo-Json -Compress)"
+        shell: pwsh
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -35,23 +73,9 @@ jobs:
             out/make/squirrel.windows/x64/*.exe
             out/make/squirrel.windows/x64/*.nupkg
             out/make/squirrel.windows/x64/RELEASES
+            out/make/squirrel.windows/x64/update-manifest.json
           generate_release_notes: true
           draft: false
-
-      - name: Get version from package.json
-        id: pkg
-        run: |
-          $v = (Get-Content package.json | ConvertFrom-Json).version
-          echo "version=$v" >> $env:GITHUB_OUTPUT
-        shell: pwsh
-
-      - name: Compute Setup.exe checksum
-        id: checksum
-        run: |
-          $exe = Get-ChildItem "out/make/squirrel.windows/x64/*Setup.exe" | Select-Object -First 1
-          $hash = (Get-FileHash $exe.FullName -Algorithm SHA256).Hash
-          echo "sha256=$hash" >> $env:GITHUB_OUTPUT
-        shell: pwsh
 
       - name: Build Chocolatey package
         run: |
@@ -73,7 +97,7 @@ jobs:
         shell: pwsh
         env:
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
-          
+
       - name: Publish to winget
         if: env.WINGET_TOKEN != ''
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Terminal sessions survive app restarts. Close wmux and reopen — your sessions 
 - PTY input sanitization — prevents command injection
 - Randomized CDP port — no fixed debug port
 - Memory pressure watchdog — reaps dead sessions at 750MB, blocks new ones at 1GB
-- Electron Fuses — RunAsNode disabled, cookie encryption enabled
+- Electron Fuses — cookie encryption on; Node CLI inspect args and `NODE_OPTIONS` env disabled; app loads only from asar. (`RunAsNode` stays **enabled** — the background daemon is spawned as a detached Node process from `wmux.exe` via `ELECTRON_RUN_AS_NODE=1`.)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,14 @@ choco install wmux
 
 > **Seeing a "Windows protected your PC" warning?** The installer isn't code-signed yet, so Windows SmartScreen flags it as from an unknown publisher. It's safe to proceed — click **More info → Run anyway**. Installing via **winget** or **Chocolatey** above avoids this prompt entirely, since those package managers run in a trusted context.
 
-**One-liner (PowerShell):**
+**One-liner (PowerShell):** downloads the prebuilt Setup.exe from the latest release and verifies its SHA-256 before launching it (no Node/Python/build tools needed).
 ```powershell
 irm https://raw.githubusercontent.com/openwong2kim/wmux/main/install.ps1 | iex
+```
+
+Want to build from source instead (needs Node 18+, Python 3, and VS C++ Build Tools — auto-installed)?
+```powershell
+$env:WMUX_FROM_SOURCE=1; irm https://raw.githubusercontent.com/openwong2kim/wmux/main/install.ps1 | iex
 ```
 
 ---
@@ -243,7 +248,7 @@ npm run make       # Build installer
 - Python 3.x (for node-gyp)
 - Visual Studio Build Tools with C++ workload
 
-The `install.ps1` script auto-installs Python and VS Build Tools if missing.
+The `install.ps1` script auto-installs Python and VS Build Tools if missing **only when building from source** (`-FromSource` / `WMUX_FROM_SOURCE=1`). The default one-liner downloads the prebuilt Setup.exe and needs none of these.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ choco install wmux
 
 **Installer:** [Download wmux Setup.exe](https://github.com/openwong2kim/wmux/releases/latest)
 
-> **Seeing a "Windows protected your PC" warning?** The installer isn't code-signed yet, so Windows SmartScreen flags it as from an unknown publisher. It's safe to proceed — click **More info → Run anyway**. Installing via **winget** or **Chocolatey** above avoids this prompt entirely, since those package managers run in a trusted context.
+> **Seeing a "Windows protected your PC" warning?** The installer is not yet Authenticode-signed (free code signing via SignPath is being set up — see **Code signing** below), so Windows SmartScreen flags it as from an unknown publisher. It's safe to proceed — click **More info → Run anyway**. Installing via **winget** or **Chocolatey** above avoids this prompt entirely, since those package managers run in a trusted context.
 
 **One-liner (PowerShell):** downloads the prebuilt Setup.exe from the latest release and verifies its SHA-256 before launching it (no Node/Python/build tools needed).
 ```powershell
@@ -55,6 +55,8 @@ Want to build from source instead (needs Node 18+, Python 3, and VS C++ Build To
 ```powershell
 $env:WMUX_FROM_SOURCE=1; irm https://raw.githubusercontent.com/openwong2kim/wmux/main/install.ps1 | iex
 ```
+
+**Code signing** — Free Authenticode code signing for Windows builds is provided by [SignPath.io](https://signpath.io/), certificate by the [SignPath Foundation](https://signpath.org/).
 
 ---
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -333,7 +333,7 @@ Every connection must present the token from `%APPDATA%\wmux\pipe-token` in the 
 }
 ```
 
-The token is a 256-bit random value generated on first daemon launch and persisted to disk. The file is written with `secureWriteTokenFile` — Windows OS ACLs restrict read access to the current user's SID; other users on the same machine cannot read it. The token is rotated only on explicit request (planned CLI: `wmux pipe rotate-token`).
+The token is a random UUIDv4 (122 bits of entropy, via `crypto.randomUUID()`) generated on first daemon launch and persisted to disk; it is reused across boots and rotated only on explicit request (planned CLI: `wmux pipe rotate-token`). The file is written with `secureWriteTokenFile` and re-hardened on every load by `reHardenTokenFileAcl` — on Windows the ACL is set via `icacls /inheritance:r /grant:r %USERNAME%:F` (inheritance stripped, current user granted Full control), so no other local account can read it.
 
 ### 5.2 Connection cap
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -30,7 +30,7 @@ The following are first-class commitments. Regressions here are bugs.
 
 ### 1.2 Named Pipe authentication
 
-The wmux daemon exposes its RPC surface over a Windows Named Pipe (or Unix socket on POSIX). Every connection must present the per-boot auth token from `%USERPROFILE%\.wmux-auth-token` (POSIX: `~/.wmux-auth-token`). The token file is mode `0o600` and written via the `secureWriteTokenFile` helper, which applies an OS-level ACL restricting read to the current user's SID. Clients without the token are rejected before any RPC is dispatched. See `PROTOCOL.md` §5 for the full token model.
+The wmux daemon exposes its RPC surface over a Windows Named Pipe (or Unix socket on POSIX). Every connection must present the per-user auth token from `%USERPROFILE%\.wmux-auth-token` (POSIX: `~/.wmux-auth-token`) — a random UUIDv4 (122 bits) persisted to disk and reused across boots, rotated only on explicit request. The token file is mode `0o600` and written via the `secureWriteTokenFile` helper; on Windows it strips inherited ACEs and grants the current user Full control (`icacls /inheritance:r /grant:r %USERNAME%:F`), so no other local account can read it. The same ACL is re-applied on **every load** via `reHardenTokenFileAcl` (RCA A12 / v2.14.0), not just on first write. Clients without the token are rejected before any RPC is dispatched. See `PROTOCOL.md` §5 for the full token model.
 
 ### 1.3 Per-plugin permission enforcement (Phase 2.1, planned)
 
@@ -39,6 +39,18 @@ MCP plugins declare `wmuxPermissions` in their manifest. The substrate enforces 
 Permission enforcement is a substrate guarantee for plugin access through documented surfaces. It is *not* a sandbox: a same-user plugin process can read disk files directly without going through the substrate. Plugin disk access is governed by §1.1.
 
 > Status: Phase 2.1 implementation work item. The contract above is the Phase 0 declaration of intent; enforcement code ships across the v3.0 release window. See `plans/generic-wandering-teapot.md`.
+
+### 1.4 Packaging fuse posture
+
+The shipped Electron build sets these fuses (`forge.config.ts`), recorded here so the disabled ones are on the record and not mistaken for oversights:
+
+- `EnableCookieEncryption`: **on**.
+- `EnableNodeOptionsEnvironmentVariable` / `EnableNodeCliInspectArguments`: **off**.
+- `OnlyLoadAppFromAsar`: **on** — the app only loads from the packaged asar.
+- `EnableEmbeddedAsarIntegrityValidation`: **off** — *intentional*. The `postPackage` hook repacks `app.asar` to bundle `node-pty`, which changes the asar hash; enabling this fuse would FATAL at runtime. `OnlyLoadAppFromAsar` still constrains load origin.
+- `RunAsNode`: **on** — *required*. The background daemon is spawned as a detached Node process from `wmux.exe` via `ELECTRON_RUN_AS_NODE=1`. Acceptable for a terminal multiplexer that already executes arbitrary shell commands.
+
+The in-app updater downloads the `Setup.exe` itself and verifies a pinned SHA-256 (published in `update-manifest.json` by CI) before launching it — fail-closed, so a tampered or unverifiable artifact is never run. Authenticode code signing of the installer + update artifacts is **not yet in place** (pending a code-signing certificate); until it lands, direct downloads still trip the SmartScreen "unknown publisher" prompt and the updater's trust floor is the SHA-256 pin, not a signature. See the release pipeline (`.github/workflows/release.yml`).
 
 ---
 

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -175,12 +175,14 @@ const config: ForgeConfig = {
       // Required: daemon process uses ELECTRON_RUN_AS_NODE=1 to spawn
       // a detached Node.js process from wmux.exe. Acceptable for a terminal
       // multiplexer that already executes arbitrary shell commands.
+      // Documented in README §6 + docs/SECURITY.md §1.4 — keep in sync.
       [FuseV1Options.RunAsNode]: true,
       [FuseV1Options.EnableCookieEncryption]: true,
       [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
       [FuseV1Options.EnableNodeCliInspectArguments]: false,
       // Disabled: postPackage hook repacks asar (for node-pty), which changes the hash.
       // Enabling this causes FATAL integrity check failure at runtime.
+      // Documented in docs/SECURITY.md §1.4 — keep in sync.
       [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: false,
       [FuseV1Options.OnlyLoadAppFromAsar]: true,
     }),

--- a/install.ps1
+++ b/install.ps1
@@ -3,10 +3,19 @@
 .SYNOPSIS
     wmux installer for Windows
 .DESCRIPTION
-    Downloads and installs wmux — AI Agent Terminal for Windows
+    Downloads and runs the prebuilt wmux Setup.exe from the latest GitHub
+    Release, verifying its SHA-256 against the published update-manifest.json
+    before launching it.
+
+    Build-from-source is opt-in (needs Node, Python, and VS C++ Build Tools):
+      - one-liner:  $env:WMUX_FROM_SOURCE=1; irm <url>/install.ps1 | iex
+      - file:       pwsh -File install.ps1 -FromSource
 .EXAMPLE
     irm https://raw.githubusercontent.com/openwong2kim/wmux/main/install.ps1 | iex
+.EXAMPLE
+    $env:WMUX_FROM_SOURCE=1; irm https://raw.githubusercontent.com/openwong2kim/wmux/main/install.ps1 | iex
 #>
+param([switch]$FromSource)
 
 $ErrorActionPreference = 'Stop'
 
@@ -16,6 +25,10 @@ $ErrorActionPreference = 'Stop'
 # Fix encoding: native commands (git, winget, npm) output UTF-8,
 # but PowerShell defaults to system locale (e.g. CP949 on Korean Windows)
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+# `irm | iex` cannot pass parameters, so the env var is the supported opt-in for
+# the piped one-liner; -FromSource is for `pwsh -File install.ps1`.
+if ($env:WMUX_FROM_SOURCE -in '1', 'true', 'yes', 'on') { $FromSource = $true }
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -143,10 +156,116 @@ if (-not $env:LOCALAPPDATA -or -not $installDir) {
 Write-Host ""
 Write-Host "  wmux installer" -ForegroundColor Cyan
 Write-Host "  AI Agent Terminal for Windows" -ForegroundColor DarkGray
+if ($FromSource) { Write-Host "  (build-from-source mode)" -ForegroundColor DarkGray }
 Write-Host ""
 
 # ---------------------------------------------------------------------------
-# Prerequisites
+# Resolve the latest release (needed by both the download and source paths)
+# ---------------------------------------------------------------------------
+
+Write-Host "  [*] Checking latest release..." -ForegroundColor DarkGray
+
+$release = $null
+$version = 'main'
+try {
+    $release = Invoke-RestMethod "https://api.github.com/repos/$repo/releases/latest" `
+        -Headers @{ 'User-Agent' = 'wmux-installer' } `
+        -TimeoutSec 15
+    $version = $release.tag_name
+    if ($version -notmatch '^v?\d+\.\d+') {
+        Write-Host "  [*] Unexpected version format '$version'" -ForegroundColor Yellow
+        if (-not $FromSource) {
+            Write-Host "  [!] Cannot resolve a release to download. Build from source instead:" -ForegroundColor Red
+            Write-Host "       `$env:WMUX_FROM_SOURCE=1; irm <url>/install.ps1 | iex" -ForegroundColor Yellow
+            return
+        }
+        $version = 'main'
+    } else {
+        Write-Host "  [*] Latest version: $version" -ForegroundColor Green
+    }
+} catch {
+    if (-not $FromSource) {
+        Write-Host "  [!] Could not query the latest release ($($_.Exception.Message))." -ForegroundColor Red
+        Write-Host "       Build from source instead: `$env:WMUX_FROM_SOURCE=1; irm <url>/install.ps1 | iex" -ForegroundColor Yellow
+        return
+    }
+    Write-Host "  [*] No releases found, building from main branch ($($_.Exception.Message))" -ForegroundColor Yellow
+    $version = 'main'
+}
+
+# ===========================================================================
+# DEFAULT PATH — download the prebuilt Setup.exe and verify its SHA-256
+# ===========================================================================
+
+if (-not $FromSource) {
+    if (-not $release -or -not $release.assets) {
+        Write-Host "  [!] No release assets found. Build from source instead (-FromSource)." -ForegroundColor Red
+        return
+    }
+
+    $setupAsset = $release.assets | Where-Object { $_.name -match '\.Setup\.exe$' } | Select-Object -First 1
+    $manifestAsset = $release.assets | Where-Object { $_.name -eq 'update-manifest.json' } | Select-Object -First 1
+    if (-not $setupAsset) {
+        Write-Host "  [!] No Setup.exe asset in the latest release. Build from source instead (-FromSource)." -ForegroundColor Red
+        return
+    }
+
+    Write-Host "  [1/3] Downloading $($setupAsset.name)..." -ForegroundColor DarkGray
+    $tempExe = Join-Path $env:TEMP "wmux-$($version.TrimStart('v')).Setup.exe"
+    $ProgressPreference = 'SilentlyContinue'  # massively speeds up Invoke-WebRequest
+    try {
+        Invoke-WebRequest -Uri $setupAsset.browser_download_url -OutFile $tempExe `
+            -Headers @{ 'User-Agent' = 'wmux-installer' } -TimeoutSec 300
+    } catch {
+        Write-Host "  [!] Download failed: $($_.Exception.Message)" -ForegroundColor Red
+        return
+    }
+
+    # Integrity: verify SHA-256 against the published manifest when available.
+    # TODO(NN2): once Authenticode signing lands, also verify
+    # (Get-AuthenticodeSignature $tempExe).Status -eq 'Valid' and the publisher.
+    $expectedSha = $null
+    if ($manifestAsset) {
+        try {
+            $manifest = Invoke-RestMethod $manifestAsset.browser_download_url `
+                -Headers @{ 'User-Agent' = 'wmux-installer' } -TimeoutSec 15
+            $expectedSha = $manifest.sha256
+        } catch {
+            Write-Host "  [*] Could not fetch update-manifest.json ($($_.Exception.Message))" -ForegroundColor Yellow
+        }
+    }
+    if ($expectedSha) {
+        $actualSha = (Get-FileHash $tempExe -Algorithm SHA256).Hash
+        if ($actualSha.ToLower() -ne $expectedSha.ToLower()) {
+            Remove-Item $tempExe -Force -ErrorAction SilentlyContinue
+            Write-Host "  [!] SHA-256 mismatch — download may be corrupt or tampered. Aborting." -ForegroundColor Red
+            Write-Host "       expected $($expectedSha.ToLower())" -ForegroundColor Red
+            Write-Host "       actual   $($actualSha.ToLower())" -ForegroundColor Red
+            return
+        }
+        Write-Host "  [2/3] Verified SHA-256" -ForegroundColor Green
+    } else {
+        Write-Host "  [2/3] No checksum manifest for this release — skipping SHA-256 verification" -ForegroundColor Yellow
+    }
+
+    Write-Host "  [3/3] Launching installer..." -ForegroundColor Green
+    Start-Process -FilePath $tempExe
+    Write-Host ""
+    Write-Host "  Installation started — follow the Setup window to finish." -ForegroundColor Green
+    Write-Host ""
+    Write-Host "  Note: the installer is not yet code-signed, so Windows SmartScreen may" -ForegroundColor DarkGray
+    Write-Host "        show 'unknown publisher' — click More info -> Run anyway." -ForegroundColor DarkGray
+    Write-Host ""
+    return
+}
+
+# ===========================================================================
+# BUILD-FROM-SOURCE PATH (opt-in via -FromSource / WMUX_FROM_SOURCE=1)
+# Requires Git, Node 18+, Python 3, and VS C++ Build Tools (auto-installed).
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Prerequisites (source build only)
 # ---------------------------------------------------------------------------
 
 # Git
@@ -211,7 +330,7 @@ if (Test-Path $vsWhere) {
 
 if (-not $hasVCTools) {
     # Check if Build Tools product exists (without VCTools workload)
-    $buildToolsInstanceId = $null
+    $buildToolsInstallPath = $null
     if (Test-Path $vsWhere) {
         $btJson = Get-NativeOutput { & $vsWhere -products Microsoft.VisualStudio.Product.BuildTools -format json }
         $btInstalls = @(ConvertFrom-JsonSafe $btJson)
@@ -226,9 +345,9 @@ if (-not $hasVCTools) {
         # --instanceId and --wait are not recognized by setup.exe (exit code 87).
         # Use setup.exe directly with --installPath.
         Write-Host "  [*] Build Tools found but C++ workload missing — adding VCTools..." -ForegroundColor Yellow
-        $setupExe = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
-        if (Test-Path $setupExe) {
-            Invoke-NativeCommand { & "$setupExe" modify --installPath "$buildToolsInstallPath" --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --passive --norestart }
+        $vsSetupExe = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
+        if (Test-Path $vsSetupExe) {
+            Invoke-NativeCommand { & "$vsSetupExe" modify --installPath "$buildToolsInstallPath" --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --passive --norestart }
             Write-Host "  [*] C++ workload added" -ForegroundColor Green
         } else {
             Write-Host "  [!] VS setup.exe not found. Add 'Desktop development with C++' workload manually." -ForegroundColor Red
@@ -295,29 +414,10 @@ if (-not $hasVCTools) {
 }
 
 # ---------------------------------------------------------------------------
-# Install
+# Clone + build
 # ---------------------------------------------------------------------------
 
-Write-Host "  [1/5] Checking latest release..." -ForegroundColor DarkGray
-
-try {
-    $release = Invoke-RestMethod "https://api.github.com/repos/$repo/releases/latest" `
-        -Headers @{ 'User-Agent' = 'wmux-installer' } `
-        -TimeoutSec 15
-    $version = $release.tag_name
-    # Validate version format
-    if ($version -notmatch '^v?\d+\.\d+') {
-        Write-Host "  [1/5] Unexpected version format '$version', using main branch" -ForegroundColor Yellow
-        $version = "main"
-    } else {
-        Write-Host "  [1/5] Latest version: $version" -ForegroundColor Green
-    }
-} catch {
-    $version = "main"
-    Write-Host "  [1/5] No releases found, installing from main branch ($($_.Exception.Message))" -ForegroundColor Yellow
-}
-
-Write-Host "  [2/5] Cloning repository..." -ForegroundColor DarkGray
+Write-Host "  [1/5] Cloning repository..." -ForegroundColor DarkGray
 
 if (Test-Path $installDir) {
     # Check for junction/symlink before removing
@@ -415,13 +515,13 @@ if ($wmuxPath) {
 # Launch Setup.exe
 # ---------------------------------------------------------------------------
 
-$setupExe = Get-ChildItem "$installDir\out\make\squirrel.windows\x64" -Filter "*.exe" -ErrorAction SilentlyContinue |
+$builtSetupExe = Get-ChildItem "$installDir\out\make\squirrel.windows\x64" -Filter "*.exe" -ErrorAction SilentlyContinue |
     Where-Object { $_.Name -match 'Setup' } |
     Select-Object -First 1
 
-if ($setupExe) {
-    Write-Host "  [5/5] Launching installer: $($setupExe.Name)..." -ForegroundColor Green
-    Start-Process -FilePath $setupExe.FullName
+if ($builtSetupExe) {
+    Write-Host "  [5/5] Launching installer: $($builtSetupExe.Name)..." -ForegroundColor Green
+    Start-Process -FilePath $builtSetupExe.FullName
 } else {
     Write-Host "  [5/5] Setup.exe not found — run manually from:" -ForegroundColor Yellow
     Write-Host "    $installDir\out\make\squirrel.windows\x64\" -ForegroundColor White

--- a/integrations/claude/bin/wmux-bridge.mjs
+++ b/integrations/claude/bin/wmux-bridge.mjs
@@ -221,6 +221,12 @@ function sendRpc(pipePath, request, timeoutMs = HOOK_TIMEOUT_MS) {
     const sock = createConnection(pipePath);
     let buffer = '';
     let settled = false;
+    // Track whether the request bytes were written. A reset/broken-pipe AFTER
+    // the write still surfaces via sock.on('error') as connect-error, but the
+    // server may have already received and processed the signal — retrying it
+    // would double-fire the notification. Only a failure BEFORE the write
+    // (`wrote === false`) is safe to retry. (codex review 2026-05-29 P2.)
+    let wrote = false;
 
     const settle = (result) => {
       if (settled) return;
@@ -235,6 +241,7 @@ function sendRpc(pipePath, request, timeoutMs = HOOK_TIMEOUT_MS) {
 
     sock.on('connect', () => {
       sock.write(JSON.stringify(request) + '\n');
+      wrote = true;
     });
     sock.on('data', (chunk) => {
       buffer += chunk.toString('utf8');
@@ -251,7 +258,8 @@ function sendRpc(pipePath, request, timeoutMs = HOOK_TIMEOUT_MS) {
     });
     sock.on('error', (err) => {
       clearTimeout(timer);
-      settle({ ok: false, error: 'connect-error', detail: err.code ?? err.message });
+      // retryable only if the request was never written (pre-connect failure).
+      settle({ ok: false, error: 'connect-error', detail: err.code ?? err.message, retryable: !wrote });
     });
     sock.on('close', () => {
       clearTimeout(timer);
@@ -276,8 +284,13 @@ async function sendRpcWithRetry(pipePath, request) {
     last = await sendRpc(pipePath, request, remaining);
     // Anything but a connect-error means the server was reached — return it.
     if (last.error !== 'connect-error') return last;
-    // Only a TRANSIENT connect code is worth retrying; ENOENT/absent → drop.
-    if (!TRANSIENT_CONNECT_CODES.has(last.detail) || attempt >= CONNECT_RETRY_BACKOFFS_MS.length) {
+    // Retry ONLY when: the request was never written (retryable, so no
+    // double-fire), the code is transient (pipe exists but contended — not an
+    // absent ENOENT), and we have attempts left. A reset/broken-pipe AFTER the
+    // write has retryable===false and is returned as-is. (codex 2026-05-29 P2.)
+    if (last.retryable === false
+        || !TRANSIENT_CONNECT_CODES.has(last.detail)
+        || attempt >= CONNECT_RETRY_BACKOFFS_MS.length) {
       return last;
     }
     const backoff = CONNECT_RETRY_BACKOFFS_MS[attempt++];

--- a/integrations/claude/bin/wmux-bridge.mjs
+++ b/integrations/claude/bin/wmux-bridge.mjs
@@ -27,6 +27,20 @@ import { randomUUID } from 'node:crypto';
 
 const HOOK_TIMEOUT_MS = 2000; // hard cap so we never slow Claude
 const BRIDGE_VERSION = '0.1.0';
+
+// A2 (2026-05-29 user dogfood: 8 connect-errors during a brief main-process
+// restart / handler-swap window): retry a TRANSIENT connect failure a few
+// times WITHIN the HOOK_TIMEOUT_MS budget. A pipe that is ABSENT (ENOENT —
+// wmux not running) is NOT retried, so plugin users without wmux open are
+// never slowed; only a pipe that EXISTS but is momentarily contended is
+// retried. The total stays under HOOK_TIMEOUT_MS so a hook never slows Claude
+// beyond the existing cap. We retry ONLY connect-errors (never successfully
+// sent) so a retry can't double-fire the signal.
+const CONNECT_RETRY_BACKOFFS_MS = [100, 250];
+const TRANSIENT_CONNECT_CODES = new Set([
+  'EPERM', 'ECONNREFUSED', 'ECONNRESET', 'EPIPE', 'ETIMEDOUT', 'EBUSY', 'EAGAIN',
+]);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 // Cap stdin at 1MB. PostToolUse payloads can balloon when a tool returns
 // a big diff or file content; we have no business forwarding that
 // over the RPC channel. Truncation note is logged so the user sees the
@@ -202,7 +216,7 @@ async function readStdin() {
 
 // ----- RPC over named pipe ------------------------------------------------
 
-function sendRpc(pipePath, request) {
+function sendRpc(pipePath, request, timeoutMs = HOOK_TIMEOUT_MS) {
   return new Promise((resolve) => {
     const sock = createConnection(pipePath);
     let buffer = '';
@@ -217,7 +231,7 @@ function sendRpc(pipePath, request) {
 
     const timer = setTimeout(() => {
       settle({ ok: false, error: 'timeout' });
-    }, HOOK_TIMEOUT_MS);
+    }, timeoutMs);
 
     sock.on('connect', () => {
       sock.write(JSON.stringify(request) + '\n');
@@ -244,6 +258,32 @@ function sendRpc(pipePath, request) {
       settle({ ok: false, error: 'closed-without-response' });
     });
   });
+}
+
+// A2 — sendRpc with bounded connect retry. Retries ONLY transient
+// connect-errors (pipe exists but momentarily contended: EPERM/ECONNRESET/…),
+// never an absent pipe (ENOENT → wmux not running, drop fast) and never a
+// reached-server outcome (a response, timeout mid-request, or close-after-send
+// — retrying those risks a duplicate signal). The shared deadline keeps the
+// total under HOOK_TIMEOUT_MS so a hook never slows Claude beyond the cap.
+async function sendRpcWithRetry(pipePath, request) {
+  const deadline = Date.now() + HOOK_TIMEOUT_MS;
+  let attempt = 0;
+  let last = { ok: false, error: 'timeout' };
+  for (;;) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return last;
+    last = await sendRpc(pipePath, request, remaining);
+    // Anything but a connect-error means the server was reached — return it.
+    if (last.error !== 'connect-error') return last;
+    // Only a TRANSIENT connect code is worth retrying; ENOENT/absent → drop.
+    if (!TRANSIENT_CONNECT_CODES.has(last.detail) || attempt >= CONNECT_RETRY_BACKOFFS_MS.length) {
+      return last;
+    }
+    const backoff = CONNECT_RETRY_BACKOFFS_MS[attempt++];
+    if (Date.now() + backoff >= deadline) return last;
+    await sleep(backoff);
+  }
 }
 
 // ----- Main ---------------------------------------------------------------
@@ -358,7 +398,7 @@ async function main() {
     token,
   };
 
-  const rpcResult = await sendRpc(getPipeName(), request);
+  const rpcResult = await sendRpcWithRetry(getPipeName(), request);
 
   // RpcResponse wraps the handler's return in { id, ok, result, error }.
   // The handler returns { ok, reason? } as well, so we need to unwrap
@@ -379,6 +419,7 @@ async function main() {
     logEvent('rpc-failed', {
       hook: hookName,
       error: rpcResult?.error ?? 'unknown',
+      detail: rpcResult?.detail, // connect-error code (ENOENT/EPERM/…) for diagnosis
     });
   }
 }

--- a/plans/wmux-nonnegotiables-execution-plan-2026-05-29.md
+++ b/plans/wmux-nonnegotiables-execution-plan-2026-05-29.md
@@ -1,0 +1,199 @@
+# wmux 출시 필수 과제(Non-Negotiables) — 실행 계획서 / 작업 분해
+
+> 작성일: 2026-05-29 · 근거: 전략 보고서 `plans/wmux-number-one-terminal-strategy-2026-05-29.md` §5 · 방법: 6-영역 병렬 소스조사 워크플로우(영역별 general-purpose 에이전트가 `D:\wmux` 실제 코드를 file:line 검증) + 시퀀싱 비평
+> 범위: 성장/런치 푸시 *이전에* 반드시 끝내야 하는 6개 필수 과제를 **41개 빌드 가능 task**로 분해. 각 task = id · 파일(file:line) · 변경 · effort · risk · 의존성 · 수용기준 · 테스트. 상세 원본은 `D:\wmux\.local-scratch\nn-{1..6}.json`, 교차검토는 `nn-critic.json`.
+> 전제(소스 검증 완료): wmux는 릴리스에 `wmux-<ver>.Setup.exe`를 이미 발행(`release.yml:31-39`), SHA-256도 이미 계산(`release.yml:48-54`)하나 choco nupkg에만 주입. install.ps1·서명·AutoUpdater·partial-list reconcile·README보안문구의 갭은 전부 실재 확인.
+
+---
+
+## 0. 먼저 내려야 할 결정 (계획을 가르는 분기 — 권고안 포함)
+
+| # | 결정 | 권고 (근거) | 영향 task |
+|---|---|---|---|
+| **D1 ⭐** | **NN1(미서명 exe 다운로드 기본화)을 NN2-T1 서명 전에 공개 런치할 것인가?** | **NN1 엔지니어링은 지금 진행하되, 성장/런치 푸시는 서명(NN2-T1) 착지 후로 게이트.** 미서명 다운로드 기본화는 SmartScreen 'Run anyway'를 그대로 유발 — 전략 §5가 엔터프라이즈 실격이라 부른 바로 그 패턴. 그 사이 SHA-256 핀(NN1-T3 / NN2-T3·T4)이 임시 무결성 바닥. | NN1 전체, NN2-T0/T1 |
+| **D2** | install.ps1 `--from-source` 진입 방식 (`irm\|iex`는 인자 못 받음) | **`$env:WMUX_FROM_SOURCE=1` 환경변수 + `-FromSource` 스위치 병행**, 기본은 다운로드 | NN1-T1 |
+| **D3** | 서명 공급자 | **SignPath.io Foundation(OSS 무료, 서버측 서명)** 우선 — 솔로/무자금에 최적. 캘린더 리드타임이 더 짧으면 Azure Trusted Signing(~$10/월, SmartScreen 평판 축적 빠름) | NN2-T0/T1 |
+| **D4** | AutoUpdater 서명검증 정상상태 정책 | **토글 뒤에서 출시 → 모든 릴리스가 안정적으로 서명됨이 확인된 후 fail-closed 상시화.** 미서명 릴리스가 섞이면 업데이트가 막히므로 롤아웃 창에선 토글 | NN2-T5 |
+| **D5** | EditorPanel Save | **버튼 숨김(NN5-T5-ALT)** — 거의 무위험. 임의 파일 쓰기 권한 확장(T5a)은 트러스트 바운더리 확대라 데모용으론 과함 | NN5-T5a/b vs T5-ALT |
+| **D6** | ligature 렌더러 | **NN5-T2 스파이크 결과에 종속.** xterm ligature 애드온은 DOM 렌더러 전용(WebGL에서 no-op 가능성). 스파이크가 WebGL 비호환 확정 시 → 데모에서 ligature 제외 or 기본 Cascadia Code만 보장 (L 공수 가능성) | NN5-T1~T4 |
+| **D7** | 토큰 엔트로피 문서 불일치 | **A: 문서 수정**(`UUIDv4/122-bit, 디스크 영속`)이 NN4 범위에 맞음. 엔트로피 강화 원하면 B: `crypto.randomBytes(32)` 코드 변경(med risk, 토큰 호환 회귀테스트 필요) | NN4-T5 |
+| **D8** | 텔레메트리 동의 모델·엔드포인트·보존 | **명시적 default-OFF + 1회 동의 프롬프트**(silent default-OFF만이면 런치 퍼널 과소집계). 엔드포인트=프라이버시 친화 SaaS or 자체 집계기, 보존창=90일 권고 | NN6-T1/T4/T6/T7 |
+| **D9** | winget vs squirrel 채널 구분 | 초기엔 winget을 'squirrel'에 folding 허용(단순) → 이후 winget 매니페스트 마커로 분리 | NN6-T2/T3 |
+
+> ⭐ **D1이 마일스톤 구조를 결정한다.** 아래 계획은 권고안(NN1 엔지니어링 즉시 + 런치는 서명 게이트)을 전제로 시퀀싱했다.
+
+---
+
+## 1. 전체 작업 목록 (41 task)
+
+| id | 제목 | effort | risk | dependsOn | 트랙/게이트 |
+|---|---|---|---|---|---|
+| **NN1 — install.ps1 펀널 (총 1-2d)** |
+| NN1-T1 | `-FromSource`/env 진입 방식 결정·문서화 | s | med | — | 키스톤 |
+| NN1-T2 | 최신 릴리스에서 Setup.exe 자산 URL 해석·다운로드 | m | med | T1 | |
+| NN1-T3 | 다운로드본 SHA-256 검증(릴리스에 `.sha256` 사이드카 발행) | m | med | T2 | **safe-gate(무결성)** · release.yml 공유⚠ |
+| NN1-T4 | 검증된 Setup.exe 실행 + 메시징 정리 | s | low | T2,T3 | |
+| NN1-T5 | 소스빌드(clone+npm+rebuild+make)와 툴체인 자동설치를 `-FromSource` 뒤로 게이트 | m | **high** | T1,T4 | 회귀위험 — 늦게 |
+| NN1-T6 | docstring '거짓말' 수정 + README 카피 일치 | xs | low | T1,T5 | |
+| **NN2 — 코드서명 + 업데이트 무결성 (총 3-5d, 외부 인증서 리드타임 별도)** |
+| NN2-T0 | [소유자/외부] 서명 신원 취득(SignPath OSS or Azure Trusted Signing) | m | high | — | **롱폴 — 즉시 시작, 엔지니어링 0** |
+| NN2-T1 | make 단계에서 wmux.exe + Setup.exe 서명 | l | high | T0 | **런치 게이트(D1)** |
+| NN2-T2 | 자동업데이트 아티팩트(.nupkg 내장 exe + RELEASES) 서명 + CI 미서명 가드 | m | med | T1 | |
+| NN2-T3 | Setup.exe SHA-256를 `update-manifest.json`로 발행 | s | low | — | **safe-gate** · release.yml 공유⚠ |
+| NN2-T4 | 업데이터: 디스크 다운로드 → SHA-256 핀 검증 → 실행(fail-closed) | l | **high** | T3 | **safe-gate(공급망)** |
+| NN2-T5 | 업데이터: Authenticode 서명 검증(토글 뒤, 서명 후) | m | med | T4,T1,T2 | |
+| NN2-T6 | 서명/무결성 문서 + 보안 불릿 일치 | xs | low | T1,T4,T5 | |
+| **NN3 — 신뢰성 (총 2-3d, 3개 독립 트랙)** |
+| NN3-T1 | reconcile 2-strike 재조회 가드(비어있지 않은 리스트 누락 ptyId 파괴 전 재조회) | m | med | — | **safe-gate(최우선 — 라이브 세션 파괴 경로)** |
+| NN3-T2 | 2-strike 결정을 순수·주입가능 헬퍼로 추출(테스트성) | s | low | T1 | |
+| NN3-T3 | `daemon.ping`에 event-loop lag 메트릭 추가(busy vs hung 구분) | s | low | — | Track2 |
+| NN3-T4 | health-probe 강화: 3→5 / 3s→5s + busy 관용 | m | med | T3 | Track2 |
+| NN3-T5 | health-probe 기존 테스트 갱신 + busy 매트릭스 | s | low | T4 | Track2 |
+| NN3-T6 | 데몬측 localhost TCP fallback 리스너 + 포트파일(`~/.wmux-daemon-tcp-port`) | m | med | — | Track3(선결) |
+| NN3-T7 | DaemonClient.connect TCP fallback(win32) | m | med | T6,T8 | Track3 |
+| NN3-T8 | DaemonClient.connect 재시도+백오프+에러분류(EPERM/ECONNRESET=transient) | m | med | — | Track3(이것만으로 대부분 회복) |
+| NN3-T9 | 통합테스트: transient connect 실패 end-to-end 회복 | s | low | T7,T8 | Track3 |
+| **NN4 — 보안 문서/코드 불일치 (총 ~0.5d)** |
+| NN4-T1 | README §6 'RunAsNode disabled' 거짓 수정 | xs | low | — | **safe-gate(유일한 명백 허위)** |
+| NN4-T2 | asar 무결성 OFF 자세를 SECURITY.md에 명문화 | xs | low | — | |
+| NN4-T3 | SECURITY.md §1.2 토큰-ACL 문구를 icacls 실제 의미로 정정 | xs | low | — | |
+| NN4-T4 | 코드↔문서 교차참조 주석(드리프트 재발 방지) | xs | low | T1,T2,T3 | 맨 마지막 |
+| NN4-T5 | 토큰 엔트로피 드리프트(256-bit vs UUIDv4) 결정·수정 | s | med | — | D7 |
+| **NN5 — 데모 크레더빌리티 (총 1.5-2.5d, 2개 독립 트랙)** |
+| NN5-T1 | `@xterm/addon-ligatures` 의존성 추가(xterm6 호환) | s | med | — | ligature 트랙 |
+| NN5-T2 | WebGL vs ligature 렌더러 충돌 스파이크·결정 | m | **high** | T1 | **리스크 게이트** |
+| NN5-T3 | LigaturesAddon를 애드온 라이프사이클에 로드 | m | med | T2 | |
+| NN5-T4 | ligature+WebGL caveat 코드 주석 | xs | low | T3 | |
+| NN5-T5-ALT | **[권고]** Save 버튼 제거(읽기전용 명확화) | s | low | — | editor 트랙(D5) |
+| NN5-T5a | (대안) FS_WRITE_FILE를 비민감 임의파일로 완화 | m | **high** | — | T5-ALT와 배타 |
+| NN5-T5b | (대안) Save 버튼을 fs.writeFile에 연결 | m | med | T5a | T5-ALT와 배타 |
+| **NN6 — 퍼널 텔레메트리 (총 2-3d, 런치 안전게이트 아님)** |
+| NN6-T1 | PII-free 이벤트 스키마 + 공유 타입 + `assertNoPii` | s | low | — | 기반 |
+| NN6-T2 | 설치 시점 채널 마커 기록(4채널) | m | med | T1 | NN1과 충돌⚠ |
+| NN6-T3 | ChannelDetector — 런타임 채널 해석 | m | med | T1,T2 | |
+| NN6-T4 | TelemetryService — local-first 큐·동의 게이트·배치 전송 | l | med | T1,T3 | 코어 |
+| NN6-T5 | activation/first-run/install 신호 훅포인트 배선 | m | med | T4 | |
+| NN6-T6 | 동의 UI + IPC 브리지(opt-in 토글) | l | med | T4,T1 | |
+| NN6-T7 | 프라이버시·데이터거버넌스 문서 + 엔드포인트 문서 | s | low | T1 | |
+
+---
+
+## 2. 의존성·병렬 트랙
+
+```
+[즉시·캘린더] NN2-T0 서명 신원 취득 ───────(엔지니어링 0, 며칠~몇 주 대기)──► NN2-T1 ► T2 ► T5
+
+병렬 가능한 엔지니어링 트랙 (서로 disjoint 파일):
+  A. NN1 펀널        : install.ps1 (+ release.yml 체크섬 — NN2-T3와 직렬화⚠)
+  B. NN2 무결성      : src/main/updater/AutoUpdater.ts + release.yml(manifest)  [서명 불필요, 먼저 가능]
+  C. NN3 신뢰성      : Track1=renderer/AppLayout · Track2=daemon+Controller · Track3=DaemonClient  (3개 내부도 독립)
+  D. NN4 문서        : README + docs/SECURITY.md + PROTOCOL.md  (T4만 T1-3 뒤)
+  E. NN5 데모        : ligature(useTerminal) · editor(EditorPanel)  (2 트랙 독립)
+  F. NN6 텔레메트리  : T1→T3→T4→T5 (critical), T6·T7 병렬  [런치 후]
+
+⚠ 공유 파일 충돌 — 직렬화 필수:
+  • release.yml 체크섬/gh-release 구간: NN1-T3(.sha256 사이드카)와 NN2-T3(update-manifest.json)가
+    같은 Get-FileHash(48-54)+files(34-37)를 건드림 → 하나의 CI 스텝으로 통합, 먼저 출시하는 쪽이 소유.
+  • NN6-T2가 install.ps1 clone 직후(343) 'source' 마커를 쓰는데, NN1이 기본 경로에서 clone을 제거 →
+    NN6-T2는 NN1의 -FromSource 분기에 종속되게 재작성(기본 다운로드 경로는 'squirrel'/squirrel-firstrun).
+  • NN5-T5a 채택 시 렌더러 임의쓰기 확대 → NN4/SECURITY.md 갱신 필요(미계획 NN5→NN4 의존). T5-ALT면 무관.
+```
+
+---
+
+## 3. 최소 안전 출시 게이트 (트래픽 전 반드시)
+
+> 비평가 결론: **트래픽을 끌기 전 진짜 게이트는 다음 3.5개뿐.** 나머지는 런치 후 trailing 가능.
+
+1. **NN3-T1 (+T2)** — partial-list reconcile 2-strike 가드. *오늘 라이브 세션을 파괴할 수 있는 최고 심각도 정확성 버그*(`AppLayout.tsx:458-467`), 렌더러 자체완결·저위험. **단일 최우선.**
+2. **NN2-T3 + NN2-T4** — SHA-256 발행 + 업데이터 다운로드-검증-실행(fail-closed). 현재 업데이터는 미검증 바이너리를 그대로 실행(`AutoUpdater.ts:154`). 인증서 없이도 가능, 공급망 최대 갭 차단.
+3. **NN4-T1** — 'RunAsNode disabled' 허위 1줄 수정. 유일한 명백 보안 허위.
+4. **NN1(T1-T6) + 런치 게이트** — 펀널 거짓말 제거. **단, 미서명 다운로드 기본을 NN2-T1 서명 전에 GA하지 말 것**(D1). 서명이 늦으면 소스빌드 기본을 잠깐 더 유지하는 편이, SmartScreen 트리거하는 미서명 다운로드 펀널보다 낫다.
+
+**런치 후 trailing 허용**: NN2-T0/T1/T2/T5 전체 서명(인증서 롱폴; SHA-256가 임시 바닥), NN3 Track2(health-probe 튜닝)·Track3(connect 재시도/TCP — TCP는 win32-EPERM 특화라 가장 미룰 만함), NN5 ligature+editor(데모 녹화만 블록, 라이브 트래픽 무관), NN4-T2~T5 문서 철저화, **NN6 전체**(성장 계측 — 안전 게이트 아님).
+
+---
+
+## 4. 마일스톤 (권고 시퀀스)
+
+### M0 — "Day 0 즉시" (병렬, 엔지니어링 ~반나절 + 외부 착수)
+- ▶ **NN2-T0** 서명 신원 취득 착수(외부 대기 — 가장 먼저 킥오프, 엔지니어링 자원 0)
+- ▶ **NN4-T1** RunAsNode 허위 수정 (xs, 무위험, 무의존 — 즉시 신뢰 리스크 감소)
+- ▶ **NN3-T1 → T2** reconcile 2-strike 가드 + 헬퍼 추출 (최고가치·저위험·자체완결)
+
+### M1 — "안전 바닥" (M0와 겹쳐 진행)
+- **NN2-T3 + NN2-T4** SHA-256 발행 + 업데이터 fail-closed 검증 (서명 불필요)
+- **NN1-T1→T2→T3→T4→T5→T6** 펀널 수정 (T5 최고위험 — 기본 다운로드 경로 T2-T4 검증 후 착지). *NN1-T3는 NN2-T3와 release.yml 직렬화*
+- **NN3 Track2** (T3→T4→T5) busy 데몬 오respawn 방지 — 병렬
+- **NN3 Track3** (T8 먼저 → T6→T7→T9; 일정 빠듯하면 T8만, TCP는 보류)
+
+### M2 — "서명 착지 시" (NN2-T0 인증서 도착 후, 비서명 트랙과 병렬)
+- **NN2-T1 → T2 → T5** exe 서명 → 업데이트 아티팩트 서명 → 업데이터 Authenticode 검증(토글)
+- **NN4-T2/T3/T5 → T4(맨 끝)** 문서 철저화
+- **NN5** ligature 트랙(T1→T2 스파이크→T3→T4) + editor 트랙(T5-ALT 권고)
+- ✅ **여기서 공개 런치 게이트 충족** (서명 + 펀널 + 신뢰성 + 데모)
+
+### M3 — "런치 후 / 성장 계측"
+- **NN6 전체** (T1→T3→T4→T5, T6·T7 병렬) — 채널 분포·활성화율 측정 시작 (NN1과 채널마커 재조율 필수)
+
+---
+
+## 5. 영역별 핵심 검증 사실 (요약 — 상세는 `.local-scratch/nn-*.json`)
+
+- **NN1**: `install.ps1:303-307` 릴리스 API에서 `tag_name`만 읽음 → `339-343` git clone → `354-369` 풀 소스빌드 → `202-295` VS BuildTools 무조건 프로비저닝. docstring(5) "Downloads and installs"는 거짓. 릴리스 자산명 `wmux-<ver>.Setup.exe` 결정적(`forge.config.ts:21`). `irm|iex`는 param 못 받음 → env var 필요.
+- **NN2**: CI에 Authenticode 0(`release.yml`). SHA-256는 계산되나 choco에만(`63`). `AutoUpdater.ts:154`는 미검증 URL `shell.openExternal`. `update.electronjs.org` JSON엔 hash 필드 없음 → 사이드카 manifest 필요. forge 7.11은 `packagerConfig.windowsSign` 지원.
+- **NN3**: `AppLayout.tsx:424-427` 빈-리스트 가드 OK / `458-468` partial-list 파괴적 clear 여전히 열림(재조회 없음). `DaemonRespawnController.ts:79-87` 기본 3/3000. `daemon.ping`(764-769)에 lag 메트릭 없음. `DaemonClient.connect:44-77` 단발·재시도/TCP 없음. **데몬 제어전송은 named-pipe 전용**(TCP 리스너 없음 → T6 선결). 재사용 패턴: `reconnectPtyWithRetry.ts`(backoff [400,900,1500]), `shared/timeouts.ts`(single-source), `wmux-client.ts`(TCP fallback 참조).
+- **NN4**: `README.md:133` 'RunAsNode disabled' vs `forge.config.ts:178` `true`(유일 명백 허위; 정당화는 코드 주석 175-177에 이미 존재). asar 무결성 OFF(184)는 문서 미기재. SECURITY.md §1.1(디렉터리 icacls 철회)는 **정확** — icacls는 토큰파일에만 매 로드 실행(`security.ts:65`, RCA A12). PROTOCOL.md:336 '256-bit'는 실제 `randomUUID`(122-bit) — 드리프트.
+- **NN5**: ligature 애드온 미설치(`package.json:77-82`). 터미널/애드온 생성은 `useTerminal.ts:195-220`, WebGL 지연로드 `261-281`(컨텍스트 cap 설계 256-260). **ligature 애드온은 DOM 렌더러 전용 → WebGL no-op 가능성(핵심 리스크)**. 기본폰트 Cascadia Code(ligature 가능)만 번들. EditorPanel Save 하드 비활성(`EditorPanel.tsx:114-122`). `FS_WRITE_FILE` 핸들러 존재하나 basename `CLAUDE.md`로 잠김(`fs.handler.ts:143`).
+- **NN6**: 제품 텔레메트리 전무(usage meter 토글만 존재). 4채널 모두 마커 미기록. activation 신호 후보: `McpRegistrar.getStatus`, `AgentDetector`(콘텐츠 미캡처 불변식 — 반드시 보존), `SampleTaskRunner`/`FirstRunOrchestrator`. IPC/preload/consent 패턴은 firstRun·usage 토글 미러링. local-first 저장 `~/.wmux`(atomicWriteJSON).
+
+---
+
+## 6. 비코드 산출물 (별도 추적 — 어떤 분해에도 없음)
+- **20-30초 모션 데모** (Claude Code+Codex+Gemini 3-pane, 하나가 실제 브라우저 구동, 완료가 OSC-133로 표면화) — README GIF + 랜딩. **NN5/NN6 모두 코드범위 밖이라 명시적으로 누락** → 별도 자산 제작 task로 추적해야 조용히 슬립 안 함.
+- 랜딩 페이지(`wmux.dev` 등) + Show HN/r/ClaudeAI 런치 조율 + Sponsors/FUNDING.yml — 전략 §6 GTM, 코드 외.
+
+## 7. 시퀀싱 리스크 (비평가 적출 — 계획에 반영됨)
+- **NN1 GA가 미서명이면 SmartScreen 그대로** → D1 게이트로 해소.
+- **release.yml 이중 체크섬**(NN1-T3 ↔ NN2-T3) → 단일 CI 스텝 통합.
+- **NN6-T2가 NN1의 새 기본경로를 오라벨** → NN1 -FromSource 분기 종속으로 재작성.
+- **NN2-T5 fail-closed 브릭 위험** → 토글 + 정상상태 정책(D4) 사전 결정.
+- **NN1-T5 회귀**(소스빌드 깨짐) — install.ps1 자동테스트 부재 → 최소 PSScriptAnalyzer + mock-download dry-run CI 추가 권고.
+- **NN3-T1 2-strike 백오프가 RECONCILE_TIMEOUT_MS(15s) 예산 초과 금지** → 예산 단언 추가.
+- **NN3-T8 connect 재시도 × Controller respawn 백오프 이중 백오프** → 수치 상한 명시(T9에서 단언).
+- **NN5-T2 스파이크가 WebGL 비호환 확정 시 ligature는 S/M가 아니라 L** → 폴백(Cascadia Code 기본 수용 or 데모서 ligature 제외) 준비.
+
+---
+
+## 8. 지금 당장 (Next actions)
+1. **D1·D3·D5·D8 결정 확정** (서명 게이트 / 공급자 / Save / 텔레메트리 동의) — 나머지 결정은 권고 기본값으로 진행 가능.
+2. **NN2-T0 서명 신원 취득 착수** (외부 롱폴 — 오늘 시작).
+3. **M0 3종 즉시 구현 가능**: NN4-T1(허위 1줄) · NN3-T1+T2(라이브 세션 파괴 경로 차단) · NN2-T3+T4(업데이터 fail-closed) — 전부 인증서 불필요.
+
+> 어느 것이든 바로 착수 가능: ① M0 세트 구현(브랜치+PR), ② NN1 펀널 수정, ③ NN3-T1 2-strike 가드 구현 + 테스트, ④ release.yml 통합 체크섬 스텝. 지시 주시면 해당 task의 코드 작업을 시작합니다.
+
+---
+
+## 9. 구현 상태 (2026-05-29, 브랜치 `team/2026-05-29/launch-non-negotiables`)
+
+전체 vitest **2049/2049 통과(162 파일), 회귀 0.** 인증서가 필요 없는 항목은 전부 구현·테스트·로컬 커밋 완료. push/PR은 사용자 승인 대기로 보류.
+
+| 영역 | 상태 | 커밋 / 비고 |
+|---|---|---|
+| **NN3-T1/T2** partial-list 2-strike 가드 | ✅ 완료 | `reconcileWithReQuery.ts`(순수 헬퍼) + AppLayout 배선 + 8 테스트. **안전게이트 최우선** |
+| **NN2-T3/T4** 업데이터 fail-closed SHA-256 | ✅ 완료 | `verifyUpdate.ts`(11 테스트) + AutoUpdater 다운로드-검증-실행 + release.yml `update-manifest.json` |
+| **NN4-T1** README RunAsNode 허위 | ✅ 완료 | |
+| **NN3-T8** connect 재시도+분류(A6) | ✅ 완료 | `daemonConnectRetry.ts`(순수) + DaemonClient + 14 테스트 |
+| **NN3-T3/T4/T5** health-probe(A4) | ✅ 완료 | daemon.ping eventLoopLagMs + DEFAULTS 5/5000 + busy 관용 + 2 신규 테스트 |
+| **NN4-T2/T3/T4/T5** 문서/코드 보안 일치 | ✅ 완료 | SECURITY.md §1.2/§1.4, PROTOCOL.md 토큰, 코드 교차참조. (T5=문서수정 옵션A) |
+| **NN5-T5-ALT** EditorPanel Save 숨김 | ✅ 완료 | |
+| **NN1** install.ps1 다운로드 기본화 | ✅ 구현(PS AST 파싱검증) | 소스빌드 `-FromSource`/`WMUX_FROM_SOURCE` opt-in. **⚠ 깨끗한 Windows VM end-to-end 검증 필요** |
+| **NN3-T6/T7** 데몬 TCP fallback | ⏸ 보류 | win32-EPERM 특화·데몬 TCP 리스너 신설 필요. 비평가도 "가장 미룰 만함". T8이 회복력 대부분 제공 |
+| **NN2-T0/T1/T2/T5** Authenticode 서명 | ⏸ 보류 | **외부 인증서(SignPath/Azure) 취득 = 소유자 작업.** 서명 인프라는 인증서 도착 후. SHA-256 핀이 임시 무결성 바닥 |
+| **NN5-T1~T4** ligature | ⏸ 보류 | xterm ligature 애드온이 WebGL 비호환 가능성 → **GUI 런타임 스파이크(T2) 필요**, 헤드리스 불가. 결과에 따라 L 공수 |
+| **NN6** 텔레메트리 7 task | ⏸ 보류 | 런치 안전게이트 아님(성장 계측). 엔드포인트/보존/동의 = 소유자 결정 필요. 대형(2-3d) |
+| 모션 데모 자산 | ⏸ 보류 | 비코드 산출물 |
+
+**남은 게이트:** 공개 런치 전 D1(서명 게이트) 결정 + NN2 서명 착지 + NN1 VM 검증 + 모션 데모. 그 외 안전게이트(신뢰성·무결성·문서)는 이 브랜치에서 충족.
+
+**커밋 9개** (안전게이트 3.5 + 신뢰성 하드닝 + 문서 + 펀널). 다음: 사용자 승인 시 push + PR(필요 시 영역별 분할), 또는 보류 항목(서명·ligature 스파이크·NN6) 착수.

--- a/plans/wmux-number-one-terminal-strategy-2026-05-29.md
+++ b/plans/wmux-number-one-terminal-strategy-2026-05-29.md
@@ -1,0 +1,248 @@
+# wmux를 "1위 터미널"로 만드는 길 — 전략 보고서
+
+> 작성일: 2026-05-29 · 대상 버전: v2.14.0 · 방법: 20-에이전트 멀티 워크플로우(내부감사 5축 + 경쟁리서치 5세그먼트 + 전략테제 4종 + 투자심사 채점 + 적대적 CEO 검증 + 완전성 비평), 핵심 사실은 `D:\wmux` 소스 line-level 검증
+> 한 줄 결론: **"종합 1위 터미널"은 구조적으로 불가능하다. 그러나 "Windows에서 AI 코딩 에이전트를 여러 개 돌리는 1위 터미널/콕핏"이라는 카테고리는 현재 무주공산이며 2~3년간 방어 가능하다 — 거기서 1위가 되는 것이 유일하게 이길 수 있는 1위다.**
+
+---
+
+## 0. 임원 요약 (먼저 읽으세요)
+
+**상황(S).** wmux는 v2.14.0까지 58개 태그를 거쳐 진짜로 희소한 기술 자산 두 개를 만들었다: ① CDP 기반 브라우저 자동화(47+ `browser_*` MCP 툴, React 제어입력·CJK·DNS-rebinding SSRF 방어 — 수주~수개월짜리 작업), ② 데몬 측 OSC 133 시맨틱 이벤트 로그(exit code까지 붙은 `agent.lifecycle`, 데몬 재기동에도 생존). 이건 "LSP-for-terminals"라는 말이 코드로 실재하는 부분이다.
+
+**문제(C).** 그런데 목표가 "1위 터미널"로 잡혀 있다. 내부감사 5명 중 5명, 경쟁리서치 5명 전원, 그리고 적대적 CEO 검증자가 **독립적으로 같은 결론**에 도달했다: 종합 1위는 죽은 목표다. wmux는 Electron(메모리·콜드스타트 세금 구조적), Windows 전용(macOS/Linux 코드 경로는 CI에서 한 번도 실행된 적 없음 — informational 표기), 코드서명 없음, ligature/SSH/프로파일/설정파일 없음. 상대는 OS 기본 탑재 Windows Terminal(무료·서명·선탑재), 네이티브 Ghostty/WezTerm/Alacritty(2~3ms 레이턴시, 30~45MB), $73M Warp다. 솔로 메인테이너(주 8~12시간 무급)가 이 축들에서 동시에 이길 길은 없다. 그리고 그 축들 중 일부(레이턴시·유휴 RSS·네이티브 도달)는 **유일한 해자인 Chromium/CDP 스택을 지우지 않는 한 고칠 수 없다.**
+
+**질문(Q).** 그럼 무엇의 1위가 되어야 하는가? 어떻게?
+
+**답(A).**
+1. **카테고리를 재정의한다.** "1위 = 'Windows에서 WSL 없이 Claude Code/Codex/Gemini를 여러 개 병렬로 돌리는 가장 추천받는 방법'." 이 슬롯은 현재 **비어 있다**(Ghostty/Kitty/cmux는 Windows 미지원, psmux는 MCP·브라우저 없음, Warp는 범용·클라우드 의존). 측정 가능하고, 솔로가 12개월 내 도달 가능하며, 2~3년 방어 가능하다.
+2. **전략 = Thesis D(유통 우선)를 0~6개월 척추로, Thesis A(포지셔닝 "Windows 에이전트 콕핏")를 서사로, Thesis B(서브스트레이트/프로토콜)를 12~24개월 병렬 해자 트랙으로. Thesis C(크로스플랫폼)는 기각.** (4개 테제 채점: A 71 / D 68 / B 47 / C 33)
+3. **성장 푸시 전에 반드시 고쳐야 하는 6개 — 전부 소스로 검증됨**: ① install.ps1의 거짓말(소스 빌드) ② 코드서명 + 자동업데이트 무결성 ③ partial-list reconcile 파괴적 clear(아직 열려 있음) + 데몬 health-probe/재연결 강화 ④ README↔코드 보안 불일치(RunAsNode) ⑤ 모션 데모 ⑥ 퍼널 텔레메트리.
+4. **가장 날카로운 통찰**: wmux는 자기 서브스트레이트가 대체하려고 만든 바로 그 휴리스틱 위에 제품을 얹어 놨다(Company mode가 OSC-133 이벤트를 두고 글자(❯) 감시 + `setTimeout(8000)` + 자연어 프롬프트 주입을 쓴다). "자기 서브스트레이트를 먹어라(eat your own substrate)" — 이 한 수가 가장 깊은 기술 자산을 가장 눈에 띄는 제품 주장으로 바꾼다.
+
+**가장 큰 위협**: IDE 내장 멀티에이전트(VSCode 1.109·Cursor·Windsurf, 전부 2026 Q1; 개발자 75.9%가 VS Code에 산다 — **existential 등급**). wmux의 진짜 싸움은 다른 터미널이 아니라 "에디터가 터미널 카테고리를 통째로 삼키는 것"이다.
+
+---
+
+## 1. "1위"의 정직한 재정의
+
+"1위 터미널"은 세 가지 전혀 다른 주장으로 쪼개진다. 솔직하게 분리하지 않으면 전략 전체가 망가진다.
+
+| 해석 | 도달 가능성 | 이유 |
+|---|---|---|
+| **종합 1위 터미널** (설치 기반·레이턴시·범용) | ❌ 불가능 | OS 기본 Windows Terminal(103K★, 선탑재), 네이티브 Ghostty(55K★, 2ms), $73M Warp. Electron·Windows전용·미서명이 동시에 발목. |
+| **1위 Windows 터미널** | ❌ 불가능 | Windows Terminal이 기본 탑재. 전환 비용 0을 이길 수 없다. |
+| **1위 "Windows AI-에이전트 터미널/오케스트레이션 콕핏"** | ✅ **가능·방어 가능(2~3년)** | 경쟁자 전원이 이 교집합에 구멍이 있다. wmux만 (agent-aware + multiplexer + browser + session-daemon)을 Windows에서 전부 가진 유일점. |
+
+**시장 규모(추정, ±후술 주의)**: 종합 터미널 시장 $5.6B~$16B(승자독식 아님) vs. 정직한 니치 **$500M~$2B**. Windows에서 2~5개 에이전트를 병렬 구동하는 개발자 **5만~20만 명**(추정). 작지만 무주공산이고 상향(에이전트 채택 곡선)이 가파르다.
+
+> **이게 후퇴가 아니라 집중이다.** Vertical SaaS는 23.9% CAGR로 수평 도구를 능가한다. "깊은 니치를 소유"하는 것이 "넓은 점유율"을 이긴다. Ghostty(macOS 성능)·Kitty(Linux)·cmux(macOS AI)는 모두 플랫폼 전문가다. wmux의 플랫폼+용도 전문화는 같은 플레이북이다.
+
+---
+
+## 2. 경쟁 지형 — 진짜 전장은 "다른 터미널"이 아니다
+
+리서치 5세그먼트가 드러낸 구조: wmux의 진짜 경쟁군은 **AI 에이전트 오케스트레이션 도구**이지, 다른 터미널 에뮬레이터가 아니다.
+
+### 2-1. 위협 등급 정리 (리서치 종합)
+
+| 경쟁자 | 분류 | wmux 위협 | 핵심 |
+|---|---|---|---|
+| **IDE 내장 멀티에이전트** (VSCode 1.109 / Cursor / Windsurf) | 에디터 | 🔴 **존재론적** | 2026 Q1 전부 출시. 개발자 75.9%가 VS Code에 거주. "별도 터미널을 아예 안 연다"가 카테고리 자체를 축소. |
+| **Windows Terminal** (MS, 기본 탑재) | 인커번트 | 🔴 **존재론적** | 103K★, Win11 선탑재, 무료·서명. MS가 세션 영속성·에이전트 인지를 추가하면 즉시 위협. |
+| **Warp** ($73M, 2026-04 오픈소스) | AI 터미널 | 🟠 high | 700K 유저(추정·출처 불일치), Windows 지원(출처 불일치), 엔터프라이즈 SSO/spend. 단 멀티플렉서·세션데몬·브라우저 자동화 없음. |
+| **psmux** (Rust, Windows 네이티브, 2026-02) | 멀티플렉서 | 🟠 high | **wmux의 정확한 니치를 직격**. tmux 호환, 네이티브, SmartScreen 부담 0. 단 MCP·브라우저·관측성 없음. 6~12개월 내 MCP+세션영속 패리티 도달이 핵심 리스크. |
+| **VS Code 통합 터미널** | 에디터 | 🟠 high | 75.9% 도달. 단 세션 영속·진짜 멀티플렉싱 없음. |
+| **WezTerm** | 네이티브 멀티플렉서 | 🟠 high | 유일한 진짜 크로스플랫폼 멀티플렉서. AI 없음. OSC133+에이전트 사이드바를 붙이면 직접 대체재. |
+| **LangGraph / Composio / Conductor / Emdash / Nimbalyst** | 에이전트 오케스트레이터 | 🟠 high~medium | $260M·$29M·MS백업·YC백업. 단 Windows 네이티브 터미널·브라우저 자동화 없음. git-worktree 오케스트레이션은 이미 표준화 중(wmux엔 코어에 없음 — 갭). |
+| **Ghostty / Alacritty / Kitty** | 네이티브 고성능 | 🟢 low | 성능의 바(2~3ms/30~45MB)를 세움. 그러나 Windows 미지원 + 멀티플렉서/AI 아님. wmux를 직접 대체 못 함. |
+| **Cursor / Claude Code / Copilot** | 에이전트 자체 | 🟢 none~tailwind | Claude Code 성공 = wmux 순풍(수요 창출). 단 Anthropic이 1st-party 오케스트레이션을 내면 wmux 상품화 위험. |
+
+### 2-2. 시장이 가는 방향 (puck)
+
+- **"터미널이 에이전트를 실행"에서 "터미널이 에이전트를 오케스트레이션"으로** 이동. 멀티플렉싱은 table-stakes로 상품화되고, 차별화는 *MCP로 무엇을 할 수 있는가*(브라우저 자동화·오케스트레이션·승인 게이트)로 이동.
+- **MCP는 이미 table-stakes**(2026, 9,400+ 서버·+58% QoQ). 자동 등록은 더 이상 차별점이 아니라 입장료. **차별점은 그 위에서 무엇을 하느냐.**
+- **git-worktree 격리**가 병렬 코딩 에이전트의 기대 표준이 됨(Composio·Bernstein·Emdash 전부 구현). **wmux 코어엔 없음 → 갭.**
+- **A2A 1.0**(Linux Foundation, 150+ 조직)이 위에서 "에이전트/터미널 구동" 인터페이스를 표준화 중. → wmux의 **독자 와이어 프로토콜이 표준에 흡수당하면 "아무도 안 겨냥하는 사투리"가 될 위험.**
+- 결론: 2027까지 **에이전트-중심 멀티플렉서는 2~3개로 통합**. 살아남는 조건 = (a) Windows 네이티브/우선, (b) 브라우저 인지, (c) 세션 영속, (d) MCP 통합, (e) 페이월/IDE 락인 없음. **wmux는 이 묘사에 들어맞고, psmux가 바짝 뒤따른다.**
+
+---
+
+## 3. wmux 자산·약점 — 냉정 진단 (내부감사 5축 종합)
+
+### 3-1. 진짜 해자 (weekend-cloneable 아님, 소스 확인됨)
+
+1. **CDP 브라우저 자동화** — `src/mcp/playwright/`. 47+ 툴, `browser_trace`/`network`/`response_body`/`extract_data`, 멀티세션. React 제어입력+CJK, `navigationPolicy.ts`의 **resolution-time DNS-rebinding 방어**(literal-IP 차단이 아니라 resolve 후 모든 A/AAAA 레코드 재검증). 에이전트가 사용자의 로그인된 브라우저를 모는 상황의 위협에 맞춘 `security.ts`(위험 JS·민감 도메인 게이팅). → **전환의 단일 최강 이유.**
+2. **데몬 측 OSC 133 시맨틱 이벤트 로그** — `src/daemon/shell-integration.ts`(INTEGRATION_VERSION=3). PSReadLine/PROMPT_COMMAND 훅, `$?`/`$LASTEXITCODE`를 프롬프트 첫 구문으로 스냅샷(VS Code/Windows Terminal을 무는 exit-code-reset 함정 회피). byte-offset 인덱싱된 `PromptEventLog` → `terminal_read_events` + `agent.lifecycle`(exitCode 포함, 데몬 재기동 생존). → **"LSP-for-terminals"의 코드 실재.**
+3. **데몬 기반 세션 영속성** — RingBuffer 원자적 덤프, `FLUSH_DONE_MARKER` 프로토콜, 앱 재시작+리부팅 생존. 복제 난이도 높음.
+4. **자동 등록 MCP** — `McpRegistrar.ts`가 `~/.claude.json`에 원자적 기록, 업그레이드 시 stale 경로 덮어쓰기, 프로토타입 오염 가드. "Claude Code가 그냥 된다"는 활성화 순간. (단 개념 자체는 복제 가능.)
+5. **동결된 semver 계층 와이어 계약** — `PROTOCOL.md` + `tsc`로 totality 강제되는 96-method capability map + 승인 큐. **솔로 프로젝트에서 극히 희귀한 규율** — 그 자체가 전환비용 해자의 씨앗.
+
+### 3-2. 진짜 약점 (정직하게)
+
+- **정체성 혼동**: 마케팅은 "tmux 대안/멀티플렉서", 시장은 "오케스트레이터". 헤드라인 자산(브라우저·MCP·A2A)이 정적 스크린샷 한 장에 **안 보인다.**
+- **모트 오배치(mis-housed)**: 최강 자산(브라우저 브리지)은 터미널과 독립적으로 가치 있는데 무거운 Electron 앱 전체를 켜야만 닿는다. 경쟁자가 동일 브리지를 **standalone MCP 서버로 출시하면 번들 명분이 사라진다.**
+- **Company mode/A2A는 해자가 아니다(데모웨어)**: `CompanyView.tsx` 라우팅 컴포넌트는 문자 그대로 `return null`(실제 321줄 UI는 별도로 존재하나 레거시 스텁이 남아 혼란). 오케스트레이션은 `waitForClaudeReady` 글자 감시 + `setTimeout(8000)` + `/plan` PTY 붙여넣기 + "[WMUX-MSG]를 직접 출력하지 마세요" 자연어 애원에 의존. **다중 시간 실행을 못 버틴다.** A2A 태스크 상태는 렌더러 Zustand에 있고 30분 후 GC·500개 cap → **재시작 시 진행 중 상태 소실**(오케스트레이션 플랫폼엔 치명적).
+- **@wmux/orchestrator SDK가 리포에 없다** — 마케팅하는 개발자-대면 API가 소스 검증 불가능한 외부 npm 패키지. **플랫폼의 정문이 블랙박스.**
+- **table-stakes 갭**: ligature 없음, sixel/이미지 프로토콜 없음, 셸 프로파일 런처 없음(Windows Terminal의 킬러 기능), SSH 없음, 버전관리 가능한 설정파일 없음(GUI 전용 — dotfiles 파워유저 배제), EditorPanel Save 하드 비활성(미완성 신호).
+- **퍼널/유통이 윗단에서 새는 중**(아래 §6).
+- **신뢰성 이야기가 어리다**(아래 §6, §10).
+- **수익화·자금 0**: Sponsors도, pro/team 티어도, 라이선스 인프라도 없음. 솔로 메인테이너 주 8~12시간 무급. **버스 팩터 = 가장 깊은 모트 자산(데몬·권한게이트·신원해소)에 집중.**
+
+### 3-3. 솔직한 모트 평가 (시간 한정)
+
+> **2-layer, 비대칭, 2~3년 한정.** 내구층 = OSC-133 이벤트 로그 + CDP 브라우저(둘 다 복제 난이도 높음). 위치층 = AI-DNA 보유자(Warp·IDE)는 멀티플렉서/세션데몬이 아니고, 멀티플렉서 DNA 보유자(psmux·Zellij·WezTerm)는 브라우저·자동MCP·관측성이 없다. wmux만 교집합. **단 영원하지 않다** — psmux가 갭을 닫거나 IDE가 카테고리를 삼키기 전에 **커뮤니티 기본값 지위 + 전환비용(MCP·세션·worktree 관성)으로 현금화**해야 한다.
+
+---
+
+## 4. 전략 경로 — 4개 테제 채점과 권고
+
+투자심사 채점(0~100, 솔로 메인테이너 적합도 가중):
+
+| 테제 | 점수 | 평결 | 치명적 결함 |
+|---|---|---|---|
+| **A. 카테고리 킹** (Windows 에이전트 콕핏) | **71** | 전략 채택, 스코프 절반으로 | 솔로 8~12h/주에 13개 워크스트림을 3개 지평에 나열 — 벤처팀 로드맵. 락인을 만드는 12~24개월 수가 정작 안 나올 가능성이 가장 큼. |
+| **D. 유통 우선** (펀널을 이겨라) | **68** | 가장 강한 실전 테제, 0~12개월 척추로 채택. 단 모트 전략은 아님 | 이미 인정한 "못 지킬 위치"를 이기려 최적화. 내구 자산 심화를 12~24개월로 *미룸* → 1년간 복제 가능한 200줄 `McpRegistrar`로 트래픽 유도. |
+| **B. 서브스트레이트/프로토콜** (pane이 아니라 protocol을 이겨라) | **47** | 프레임은 채택, 1차 GTM은 기각, 12~24개월 병렬 보험 | 솔로·무자금이 소유한 양면 네트워크효과 콜드스타트 베팅. "2번째 구현체를 직접 짜라"는 곧 자기 적합성 데모일 뿐 외생 수요 0. |
+| **C. 크로스플랫폼 + Electron세금 제거** | **33** | **기각** | 자기모순: "Electron세금 제거"와 "CDP 모트 유지"는 양립 불가(모트가 Electron 때문에 존재). 유일한 방어 카테고리를 버리고 $73M Warp와 3개 OS 정면전. macOS/Linux 코드는 CI에서 실행된 적 없음. |
+
+### 권고 = **하이브리드** (적대적 CEO 검증자 + 판정관 합의)
+
+```
+NOW(0~6개월)      ── Thesis D를 글자 그대로 실행 (§5 non-negotiables)
+서사              ── Thesis A의 "Windows 에이전트 콕핏" 포지셔닝 채택 (D의 wedge와 동일 정신)
+6~24개월(병렬)    ── Thesis B의 값싼 보험 한 수: 데몬+OSC133 서브스트레이트를 렌더러에서 분리
+                     (미래 셸 재작성에도 모트 생존) + "자기 서브스트레이트 먹기" + 지속가능성 바닥
+기각             ── Thesis C (크로스플랫폼). 단 perf 청소 같은 OS-무관 전술만 graft.
+```
+
+**왜 이 조합인가**: 네 테제의 0~3개월 수는 거의 동일하다(install 수정·서명·신뢰성·데모·런치). 그러니 거기서 갈라질 게 아니라 **먼저 다 하고**, 그 다음 **브라우저 사용률 텔레메트리가 A(브라우저가 wedge) vs B(서브스트레이트가 wedge)를 결정하게 한다**(§9의 $0 실험). C만은 처음부터 기각 — 유일한 방어 카테고리를 버리는 유일한 옵션이기 때문.
+
+---
+
+## 5. 절대 타협 불가 — 성장 푸시 전에 반드시 (전부 소스 검증)
+
+> 이 6개는 "어떤 테제가 이기든" 공통 전제다. 고치기 전에 트래픽을 끌면, wmux가 구애하는 바로 그 커뮤니티에서 단 한 번의 런치를 안티팬 물결로 바꾼다.
+
+1. **install.ps1의 거짓말을 고쳐라.** `install.ps1`은 line 304에서 GitHub releases API를 호출하지만 *버전 태그만* 읽고, 그 태그를 git-clone 후 `npm install` + `electron-rebuild` + `npm run make`로 **소스 컴파일**한다(line 340-368, VS C++ Build Tools 자동설치). docstring은 "Downloads and installs"라고 적혀 있다. → **사전빌드 서명 Setup.exe를 다운로드**하도록 변경(릴리스 자산 조회 코드는 이미 있음). 소스 빌드는 `--from-source` 플래그 뒤로. **최저 노력·최고 ROI, 거의 순수 이득.**
+2. **코드서명 + 자동업데이트 무결성.** `release.yml`에 Authenticode 0(winget/choco push + choco checksum만). README가 "More info → Run anyway"를 직접 안내. → SignPath(OSS 무료) 또는 Azure Trusted Signing(~$10/월)으로 설치본 + 자동업데이트 아티팩트 서명, `AutoUpdater.ts`에 SHA-256 핀(현재 미검증 URL로 `shell.openExternal`만 함). **서명된 .exe가 유기적 발견 트래픽을 받는 유일한 채널**(winget/choco는 pull-only). `~/.claude.json`을 자동 편집하고 로그인 브라우저를 모는 도구가 "Run anyway"를 가르치는 것은 즉각적 엔터프라이즈 실격.
+3. **신뢰성 잔여 경로를 닫아라(소스로 검증한 정확한 상태).**
+   - ✅ *이미 고쳐짐*: 재앙적 "빈 세션 자가생성" 버그 — reconcile는 이제 liveness check만(`AppLayout.tsx:429-444`, "Fix 0 round 3"), `pty.reconnect`는 listener 등록 후 `useTerminal` mount가 수행(replay-before-listener 데이터손실 해소). 빈-리스트 케이스도 가드(424-427).
+   - ❌ *아직 열림*: **partial-list 파괴적 clear** — `AppLayout.tsx:466-467`이 *비어있지 않은* 데몬 리스트에서 누락된 live ptyId를 즉시 단발성으로 `updateSurfacePtyId(...,'')` 처리. 2-strike 재조회 가드 없음. 주석(459-465)조차 "a destructive decision"이라 명시. 데몬이 재수화 중 부분 스냅샷을 반환하면(RCA가 지목한 바로 그 레이스) 첫 사이클에 live 세션을 파괴적으로 비운다. → **백오프 재조회 2-strike 가드 추가.**
+   - ❌ *아직 열림(A4)*: `DaemonRespawnController` 기본값 `hangFailureThreshold:3`/`healthTimeoutMs:3000` 유지. RCA 권고는 3→5/3s→5s + event-loop self-stall 감지. 바쁜 데몬을 hung으로 오판 → 강제 respawn → `daemon:connected` 재발 → reconcile 재트리거.
+   - ❌ *아직 열림(A6)*: `DaemonClient.connect()`는 단발 `net.createConnection`(재시도·TCP fallback 없음). Windows에서 AV 스캔이 transient EPERM을 상시 유발 → 50ms 블립이 데몬 끊김 캐스케이드로. (`wmux-client.ts`엔 이미 fallback 존재 — 미러링.)
+4. **README↔코드 보안 불일치 해소.** README는 "Electron Fuses — RunAsNode disabled"라 주장하나 `forge.config.ts:178`은 `RunAsNode:true`(데몬 detached 스폰 때문), `:184`는 asar 무결성 검증 off. `SECURITY.md`(§1.1)는 icacls 하드닝이 *철회*됐다는데 `src/shared/security.ts`는 매 로드마다 icacls를 *실행*한다. **보안에 회의적인 에이전트 유저(=핵심 청중)는 주장을 config와 diff하고 신뢰 서사 전체를 깎는다.** 둘 중 하나로 일치시켜라.
+5. **모션 데모 한 개를 출시하라.** 20~30초: Claude Code+Codex+Gemini 3-pane, 하나가 실제 브라우저를 몰고, 완료가 OSC-133 이벤트로 표면화. **하드-to-clone 모트가 현재 정적 스크린샷 한 장에 전혀 안 보인다.** 멀티-pane 시각 제품의 최고 레버리지 전환 자산.
+6. **퍼널을 계측하라.** 프라이버시 존중 텔레메트리. 현재 winget vs choco vs exe vs 소스빌드 분포·활성화율을 모른다 — **유통(승부를 가르는 단 하나)을 측정 못 하면 관리 못 한다.**
+
+---
+
+## 6. 유통·브랜드·발견 — 진짜 병목
+
+- **단 하나의 가장 큰 병목 = 윗단 발견**(설치 메커니즘 아님). winget/choco는 pull-only 채널 — 유저가 이미 `openwong2kim.wmux`를 알아야 한다. 이름에 트래픽 소스가 없다. 코드서명은 가장 시끄러운 갭이지만 2차 문제(이미 릴리스를 찾은 소수만 도움 받음).
+- **이름**: `wmux`는 니치엔 좋지만(짧고 "Windows tmux" 신호) 발견엔 최악(검색·발음 불가, 도메인·브랜드 표면 없음, winget id가 모호한 핸들 뒤에 묻힘).
+- **랜딩 페이지 없음**(homepage가 GitHub README만 가리킴) → SEO/전환 표면·이메일 캡처 없음.
+- **커뮤니티 온램프 0**: Discord·discussions·issue 템플릿·good-first-issue·CONTRIBUTORS 없음 → 스타 플라이휠 진입로 없음.
+- **콘텐츠 0**: "best terminal 2026" 토론이 벌어지는 YouTube/Dev.to/HN에 부재.
+
+**처방**: ① 서명+설치 수정 후 **Show HN + r/ClaudeAI + r/commandline 조율 런치**(데모 GIF 앵커). ② `awesome-claude-code` 리스트 / Claude Code 생태계 문서 / 이미 존재하나 미마케팅된 `.claude-plugin/marketplace.json`에 "Windows 멀티에이전트 추천 런타임"으로 등재. ③ 미니 랜딩 페이지 + 텔레메트리. ④ **"Claude에게 직접 물어봤을 때 추천되는" 발견**을 최적화(에이전트 시대의 새 유통 채널). ⑤ 메인테이너 스토리 공개(Ghostty/WezTerm가 증명한 창업자 서사 → 스타).
+
+---
+
+## 7. 실행 로드맵
+
+### 90일 (0~3개월) — "퍼널을 막고, 신뢰를 세우고, 모트를 보이게"
+- [ ] install.ps1 → 사전빌드 서명 exe 다운로드 (`--from-source` 분리)
+- [ ] 코드서명(installer + 자동업데이트) + AutoUpdater SHA-256 핀
+- [ ] `AppLayout.tsx:466` partial-list 2-strike 가드 + A4 health-probe(3→5/3s→5s+self-stall) + A6 connect 재시도/TCP fallback
+- [ ] README↔forge.config 보안 불일치 해소 + 다른 보안 불릿 전수 대조
+- [ ] 20~30초 모션 데모(README + 랜딩) · ligature 1-dep 추가 · EditorPanel Save 완성 or 숨김
+- [ ] 프라이버시 존중 텔레메트리(활성화율·채널 분포)
+- [ ] 포지셔닝 전면 교체 → "Windows 에이전트 콕핏" / "best terminal"·크로스플랫폼은 각주화
+- [ ] 조율 런치(Show HN + r/ClaudeAI + r/commandline) + GitHub Sponsors/FUNDING.yml
+- [ ] **$0 실험**: `browser_*` 세션당 호출률 계측 → 브라우저 수요 가설 검증/기각 → A vs B 결정 게이트
+
+### 6~12개월 — "데모를 플랫폼으로 / 자기 서브스트레이트 먹기"
+- [ ] **A2A 태스크 상태를 렌더러 Zustand → 데몬 원자적 스토어**로 이전(재시작 생존)
+- [ ] Company mode를 OSC-133 `agent.lifecycle` 이벤트 기반으로 재작성(글자 감시·`setTimeout(8000)`·`/plan` 붙여넣기·NL 애원 제거)
+- [ ] `@wmux/orchestrator`를 **리포 내 소스 가시·데몬 테스트 SDK**로 검증·이전
+- [ ] 에이전트-운영 감사/관측 레이어: MCP 툴 호출 append-only 로그(pane/plugin 신원+결과) + 멀티에이전트 대시보드(라이프사이클 타임라인, live-session vs 1GB 예산)
+- [ ] per-plugin `wmuxPermissions` 강제 착지 + dangerous-action을 **PTY write 전 입력측 승인 게이트**로(현재는 사후 토스트 — 차단 불가)
+- [ ] git-worktree 오케스트레이션을 코어에 추가(상품화 중인 table-stakes 갭 메우기)
+- [ ] 콘텐츠 5~8편(롱테일 쿼리 타겟) + 생태계 등재
+- [ ] zsh/fish OSC-133 커버 + cmd.exe 미지원 명문화
+
+### 12~24개월 — "카테고리 소유를 내구 해자로"
+- [ ] 외부(non-wmux) 2번째 구현체 1개 이상이 `events.poll`+trust DB 소비(프로토콜 → 플랫폼 전환의 단일 결정 지표)
+- [ ] 데몬+OSC133 서브스트레이트를 렌더러에서 분리(미래 셸 재작성 헤지 — Thesis B의 값싼 보험)
+- [ ] 오픈코어 "wmux Teams": OSS 코어 MIT 유지 + 유료 티어가 Company/orchestrator/worktree/감사로그 수익화(엔터프라이즈향 hard-to-clone 표면)
+- [ ] (조건부) 니치가 확실히 잠긴 *후에만* macOS — 척추가 아니라 Phase 2로
+
+---
+
+## 8. 수익화·지속가능성
+
+- **현재 = 자금 0, 수익 코드 0, Sponsors 0.** 신뢰성 이야기가 성숙할 자원이 없다.
+- **즉시**: GitHub Sponsors + FUNDING.yml + 투명 로드맵/신뢰성 페이지(최저 비용 지속가능성 신호).
+- **중기(니치 잠근 후)**: **오픈코어** — 단일유저 OSS는 MIT 무료(스타 플라이휠 보존), 유료 **wmux Teams**가 Company-mode + orchestrator SDK + worktree 오케스트레이션 + 감사로그를 수익화. 이게 자연스러운 유료 wedge인 이유: 정확히 *기업이* 가치를 두는, 복제 어려운 엔터프라이즈향 표면이기 때문.
+- **단 엔터프라이즈/감사 표면은 솔로 소유가 아니라 파트너·연기 후보로.** 서명·감사·RBAC/SSO·provenance가 다 없는 상태에서 유료 Teams를 니치 소유 전에 쫓으면 조기·희석.
+- **자금만으론 버스 팩터를 못 고친다 — 코드를 쓰는 건 2번째 커미터다.** issue 템플릿·good-first-issue(ligature/프로파일/설정파일 같은 table-stakes 갭)·CONTRIBUTING(데몬/권한/신원 핫스팟 매핑)으로 다중 기여자 전환을 Sponsors와 **병행**.
+
+---
+
+## 9. 존재론적 위협 · Kill Criteria · 인커번트 대응
+
+### Kill / Pivot 기준 (적대적 CEO 검증자)
+- **18개월에** r/ClaudeAI·HN·Claude Code 문서에서 "Windows에서 Claude Code 여러 개 돌리기"의 *지명된 기본 답*이 아니면 → 순수 서브스트레이트/SDK로 피벗 or GUI 야망 정리.
+- **텔레메트리 후** `browser_*` 호출률이 미미하면 → 브라우저-헤드라인 베팅 기각, 데모를 멀티에이전트 오케스트레이션+세션영속으로 재초점(= B로 기운다).
+- **12개월 내** 외부 2번째 구현체가 없으면 → 플랫폼/SDK 테제 폐기(1-구현체 프로토콜은 네트워크효과 0).
+- **EXISTENTIAL KILL**: Anthropic/Claude Code(또는 Cursor/Warp)가 Windows 1st-party 멀티에이전트 오케스트레이션을 내거나 축복하면 → 가장 깊은 방어 니치(세션-데몬 신뢰성+감사)로 즉시 후퇴 or 종료.
+- **신뢰성 stop-loss**: 런치 푸시 후 2번째 공개 파괴적 세션손실 사고 = 구애하던 커뮤니티에서 신뢰 회복 불가 → 모든 GTM 동결, 한 릴리스 사이클 신뢰성에 올인.
+- **C 시도 시 stop-loss**: 서명+노타라이즈 macOS GA 6개월 내 신규설치의 ~25% 미달이면 멀티-OS 즉시 중단.
+
+### 인커번트 대응 (각본을 미리 써라)
+가장 치명적 2수와 동일한 방어:
+- (a) **MS가 Windows Terminal에 세션 영속+에이전트 인지 추가** / (b) **Anthropic이 Windows 1st-party 오케스트레이션 출시**
+- 방어 = **감사로그 + worktree + MCP 워크플로우 관성으로 전환비용 심화 + 커뮤니티 기본값 지위를 빠르게 확보.** 트리거 조건과 대응을 보고서에 명시해 전략을 가정-의존이 아니라 강건하게.
+
+---
+
+## 10. 빠진 각도 / 추가 리스크 (완전성 비평이 잡아낸 것)
+
+1. **법적/IP 노출**: 에이전트가 사용자 로그인 세션(Gmail·뱅킹·GitHub·Okta)을 클릭/입력하는 것 + `anti-detection.ts`의 `navigator.webdriver` 스푸핑은 문자 그대로 우회 코드 → ToS 위반·CAPTCHA 우회·CFAA 질문. 헤드라인 모트를 마케팅하기 *전에* 법무/ToS 리뷰. "에이전트가 *당신의* 앱을 자동화"(1st-party, 동의/allowlist)로 재포지셔닝하거나 책임을 문서화.
+2. **데이터 거버넌스**: 999K 스크롤백 디스크 영속 + 계획된 감사로그 + 브라우저 세션 자료 = 민감정보(터미널 출력의 시크릿, 에이전트가 읽은 PII) 캡처. 권고한 감사로그가 오히려 **최대 신규 PII/시크릿 책임**이 될 수 있다 → at-rest 암호화·보존/리댁션 정책(envFilter가 아는 시크릿 자동 스트립)·데이터 흐름도와 함께 출시.
+3. **에이전트 실행 비용 경제**: 3~5개 에이전트 병렬 = 토큰/API 비용 폭증. `CostEstimator/CostDashboard`가 부분 존재 → **"놀랄 청구서 없이 5개 에이전트"**를 1급 기능·wedge로(per-pane 토큰, 예산 상한 도달 시 일시정지). 1GB 데몬 천장보다 월 청구서가 먼저 충돌할 수 있다.
+4. **접근성(a11y)**: 정부·대기업 조달의 하드 요건(스크린리더·키보드 전용·WCAG). 현재 전무 — Electron/React엔 리스크이자 잠재 차별점.
+5. **버스 팩터의 진짜 해법 = 2번째 커미터**(§8). 돈이 아니라.
+6. **"터미널이 옳은 폼팩터인가"라는 급진 옵션**: 75.9%가 VS Code에 살고 IDE 내장이 existential인데, **GUI를 버리고 헤드리스 서브스트레이트 + VS Code/JetBrains 확장만 출시**하는 옵션을 어떤 테제도 진지하게 스트레스 테스트하지 않았다. Thesis B가 손짓하지만 Electron GUI를 플래그십으로 유지. 텔레메트리가 GUI 이탈을 보이면 진지하게 검토할 카드.
+
+---
+
+## 11. 성공 지표 (KPI)
+
+| 지표 | 목표 | 비고 |
+|---|---|---|
+| **TTHW** (one-liner→첫 에이전트 태스크 MCP 동작) | < 5분 | 현재: 자주 실패하는 다분 컴파일 |
+| **활성화율** (설치→MCP 확인된 첫 에이전트 태스크) | > 40% (6개월) | 경쟁자 아무도 측정 안 함 — 핵심 KPI |
+| **검색/추천 슬롯** | 롱테일 ≥3개 #1 + 커뮤니티 추천 리스트 ≥3 등재 (12개월) | "run multiple Claude Code Windows" 등 |
+| **서명 .exe 설치 점유** | SmartScreen 벽 후 0 → 성장하는 다수 | 서명 효과 측정 |
+| **신뢰성 SLO** | 90일 롤링 파괴적 세션손실 0 (라이프사이클 로그가 증거) | 공개 신뢰성 페이지 |
+| **브라우저 wedge 검증** | 세션당 `browser_*` 호출률 | A vs B 결정 게이트($0 실험) |
+| **플랫폼 증명** | 외부(non-wmux) 구현체 ≥1이 `events.poll`+trust DB 소비 | 프로토콜→플랫폼 전환의 단일 결정 지표 |
+| **지속가능성** | Sponsors live + 첫 유료 Teams 시트 | 오픈코어 wedge 검증 |
+
+---
+
+## 12. 부록 — 사실 검증 노트 (보고서를 정직하게 쓰기 위한 주의)
+
+리서치 단계에서 인용된 수치 중 **출처·일관성이 약한 것**을 명시한다. 의사결정에 쓰되 "추정/예시"로 취급할 것:
+
+- **Warp 유저 수·Windows 상태가 출처 간 불일치**: 세그먼트마다 "500K" vs "700K+", "Windows 2024-2025 출시/2026초 GA" vs "2026-05 기준 미출시". → "Warp는 $73M 펀딩·2026-04 오픈소스, Windows 지원을 출시했거나 출시 중(출처 상이)"로만 단정.
+- **메모리 수치(wmux ~180MB, Warp ~380MB, Ghostty 45MB)는 wmux에 대해 미벤치마크**. 업계 인용/추정이지 wmux 실측 아님. → §5에 "재현 가능 벤치 스위트 발행" 권고가 들어간 이유.
+- **TAM($500M~$2B), Windows 개발자 5만~20만, $10M+ ARR floor, Claude Code 18%/CSAT 91%/NPS 54, MCP 9,400 서버 등은 출처 없는 bottoms-up 추정 또는 내부 불일치**(예: Windows 개발자 비중 "48%" vs "72%"가 같은 보고서에서 충돌). → **예시적 규모감**으로만 사용.
+- **"winget/choco는 발견 트래픽 ~0"은 미입증 가설**(winget엔 의미 있는 검색·CLI 발견 존재). GTM 우선순위(서명-우선)를 형성하므로 단정 금지.
+- **신뢰성 사실 분쟁 해소(소스 직접 확인, `AppLayout.tsx:408-492`)**: 재앙적 자가생성 벡터는 *제거됨*, 빈-리스트 케이스는 *가드됨*, **partial-list 파괴적 clear(466-467)는 여전히 열려 있음(2-strike 가드 없음)**. "버그 고쳐짐"도 "버그 그대로"도 아닌 — **재앙 경로는 닫혔고 좁은 잔여 경로가 남았다.**
+
+---
+
+### 한 문장으로
+> wmux는 "1위 터미널"이 될 수 없지만, **"Windows에서 AI 에이전트를 여러 개 돌리는 1위 콕핏"**이 될 수 있다 — 단 (1) 펀널의 거짓말·미서명·partial-list 신뢰성 구멍을 *트래픽 전에* 막고, (2) 모트를 정적 스크린샷에서 모션 데모로 끌어내고, (3) 자기 OSC-133 서브스트레이트를 먹어 데모웨어 Company mode를 진짜 플랫폼으로 바꾸고, (4) IDE 내장 멀티에이전트가 카테고리를 삼키기 전에 커뮤니티 기본값 지위로 현금화할 때에만. 종합 1위를 쫓는 매 사이클은 유일하게 이길 수 있는 1위에서 빼앗긴 사이클이다.

--- a/src/daemon/SessionPipe.ts
+++ b/src/daemon/SessionPipe.ts
@@ -49,8 +49,50 @@ export class SessionPipe {
 
     const pipeName = this.getPipeName();
 
+    // On Unix, remove a stale socket file left by a prior run.
+    if (process.platform !== 'win32') {
+      try {
+        const stat = fs.lstatSync(pipeName);
+        if (stat.isSocket()) {
+          fs.unlinkSync(pipeName);
+        }
+      } catch {
+        // File doesn't exist — fine
+      }
+    }
+
+    // RCA (2026-05-28 dogfood): a session pane died when its named pipe could
+    // not bind — `EADDRINUSE: \\.\pipe\wmux-session-<id>` — because a PRIOR
+    // SessionPipe for the same sessionId had not yet released the name
+    // (renderer detach/reattach, daemon reconnect). On Windows the OS frees a
+    // named-pipe name shortly after the previous handle closes, so retry
+    // EADDRINUSE a few times with short backoff before giving up. Any other
+    // listen error (or exhausted retries) propagates to the caller as before.
+    const MAX_BIND_ATTEMPTS = 5;
+    const BIND_RETRY_MS = 100;
+    for (let attempt = 1; attempt <= MAX_BIND_ATTEMPTS; attempt++) {
+      try {
+        await this.listenOnce(pipeName);
+        return;
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException)?.code;
+        if (code === 'EADDRINUSE' && attempt < MAX_BIND_ATTEMPTS) {
+          await new Promise<void>((r) => setTimeout(r, BIND_RETRY_MS));
+          continue;
+        }
+        throw err;
+      }
+    }
+  }
+
+  /**
+   * Single bind attempt. Resolves once listening (and assigns this.server),
+   * rejects on the first listen error. The server is created fresh per attempt
+   * and closed on error so a retry can rebind cleanly.
+   */
+  private listenOnce(pipeName: string): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      this.server = net.createServer((socket) => {
+      const server = net.createServer((socket) => {
         // Pre-auth connection throttle: Named Pipe DACL cannot be restricted from
         // Node.js (libuv limitation), so brute-force token guessers are rate-capped
         // at the accept() layer before reaching auth.
@@ -75,25 +117,21 @@ export class SessionPipe {
       });
 
       // Single connection only
-      this.server.maxConnections = 1;
+      server.maxConnections = 1;
 
-      this.server.on('error', (err: NodeJS.ErrnoException) => {
+      let settled = false;
+      server.on('error', (err: NodeJS.ErrnoException) => {
+        if (settled) return;
+        settled = true;
+        // Close the failed server so a retry can rebind the same name cleanly.
+        try { server.close(); } catch { /* ignore */ }
         reject(err);
       });
 
-      // On Unix, remove stale socket file
-      if (process.platform !== 'win32') {
-        try {
-          const stat = fs.lstatSync(pipeName);
-          if (stat.isSocket()) {
-            fs.unlinkSync(pipeName);
-          }
-        } catch {
-          // File doesn't exist — fine
-        }
-      }
-
-      this.server.listen(pipeName, () => {
+      server.listen(pipeName, () => {
+        if (settled) return;
+        settled = true;
+        this.server = server;
         resolve();
       });
     });

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -14,9 +14,17 @@ import { RingBuffer } from './RingBuffer';
 import { initDaemonLogSink } from './util/logSink';
 import type { DaemonState } from './types';
 import type { DaemonEvent, DaemonCreateSessionParams, DaemonSessionIdParams, DaemonResizeParams } from '../shared/rpc';
+import { monitorEventLoopDelay } from 'node:perf_hooks';
 
 // === Constants ===
 const wmuxDir = getWmuxDir();
+
+// RCA A4 — event-loop lag monitor. Enabled once at module load; daemon.ping
+// reports the mean lag (ms) since the previous ping so the main-side health
+// probe (DaemonRespawnController) can tell a busy-but-responsive daemon from a
+// hung one and skip a false-positive respawn under CPU load.
+const eventLoopMonitor = monitorEventLoopDelay({ resolution: 20 });
+eventLoopMonitor.enable();
 
 // Install the file log sink before any log() / console.* call below. The
 // launcher spawns this process with `stdio: 'ignore'`, so without this
@@ -765,7 +773,14 @@ function registerRpcHandlers(
   pipeServer.onRpc('daemon.ping', async () => {
     const sessions = sessionManager.listSessions();
     const uptime = Math.floor((Date.now() - startTime) / 1000);
-    return { status: 'ok', uptime, sessions: sessions.length };
+    // RCA A4 — report event-loop lag (ms) so the controller distinguishes a
+    // busy-but-responsive daemon from a hung one. histogram.mean is in
+    // nanoseconds and is NaN before the first sample; reset so the next ping
+    // reflects lag since this one.
+    const meanNs = eventLoopMonitor.mean;
+    const eventLoopLagMs = Number.isFinite(meanNs) ? Math.round(meanNs / 1e6) : 0;
+    eventLoopMonitor.reset();
+    return { status: 'ok', uptime, sessions: sessions.length, eventLoopLagMs };
   });
 
   // daemon.shutdown — gracefully terminate the daemon process. A2 makes

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -4,6 +4,7 @@ import crypto from 'node:crypto';
 import type { RpcResponse, DaemonEvent } from '../shared/rpc';
 import { FLUSH_DONE_MARKER } from '../daemon/SessionPipe';
 import { DAEMON_RPC_TIMEOUT_MS } from '../shared/timeouts';
+import { connectWithRetry, type ConnectAttemptResult } from './daemonConnectRetry';
 
 // RCA A2 — single source of truth in shared/timeouts.ts so the renderer's
 // RECONCILE_TIMEOUT_MS can be derived from (and stay greater than) this value.
@@ -41,18 +42,40 @@ export class DaemonClient extends EventEmitter {
     super();
   }
 
-  /** Attempt to connect to daemon control pipe. Returns false on failure (for fallback). */
+  /**
+   * Connect to the daemon control pipe. Returns false on failure (for fallback).
+   *
+   * RCA A6 — wraps the connect attempt in a bounded retry: a transient Windows
+   * named-pipe blip (EPERM/ECONNRESET from AV scan / handle contention) is
+   * retried with short backoff instead of being treated as a dead daemon, while
+   * a genuinely-absent daemon (ENOENT/ECONNREFUSED) still returns false fast
+   * with no retry. The retry policy is the pure, unit-tested connectWithRetry.
+   */
   async connect(): Promise<boolean> {
     if (this.connected) return true;
+    return connectWithRetry({
+      attempt: () => this.attemptConnect(),
+      isConnected: () => this.connected,
+      log: (message) => console.warn(`[lifecycle] DaemonClient.connect ${message} pipe=${this.pipeName}`),
+    });
+  }
 
-    return new Promise<boolean>((resolve) => {
+  /** A single control-pipe connect attempt, classified for the retry layer. */
+  private attemptConnect(): Promise<ConnectAttemptResult> {
+    return new Promise<ConnectAttemptResult>((resolve) => {
+      let settled = false;
+      const finish = (r: ConnectAttemptResult): void => {
+        if (settled) return;
+        settled = true;
+        resolve(r);
+      };
       const timeout = setTimeout(() => {
-        // RCA A6/A8 — record connect timeouts. Previously this resolved(false)
-        // with no trace, so a daemon that was alive but slow to accept on the
-        // control pipe was indistinguishable from a dead one in the logs.
-        console.warn(`[lifecycle] DaemonClient.connect timeout (5s) pipe=${this.pipeName}`);
+        // RCA A6/A8 — record connect timeouts. A daemon that is alive but slow
+        // to accept on the control pipe is a transient condition (retried),
+        // not a dead one; the timeout is surfaced in the log either way.
+        console.warn(`[lifecycle] DaemonClient.connect attempt timeout (5s) pipe=${this.pipeName}`);
         socket.destroy();
-        resolve(false);
+        finish({ ok: false, timedOut: true });
       }, 5_000);
 
       const socket = net.createConnection(this.pipeName, () => {
@@ -60,18 +83,17 @@ export class DaemonClient extends EventEmitter {
         this.controlPipe = socket;
         this.connected = true;
         this.setupControlPipe(socket);
-        resolve(true);
+        finish({ ok: true });
       });
 
       socket.on('error', (err: NodeJS.ErrnoException) => {
-        // RCA A6/A8 — surface the error CODE (EPERM/ECONNREFUSED/ENOENT). On
-        // Windows EPERM here indicates AV scan / handle contention on the named
-        // pipe — a transient, retryable condition — not a dead daemon. The
-        // pre-fix code dropped the error entirely, which is the single biggest
-        // reason the control-pipe disconnect class was undiagnosable.
+        // RCA A6/A8 — surface the error CODE (EPERM/ECONNREFUSED/ENOENT) and
+        // hand it to classifyConnectFailure: EPERM/ECONNRESET on Windows are
+        // transient (AV scan / handle contention) and get retried; ENOENT /
+        // ECONNREFUSED mean the daemon is genuinely absent and fail fast.
         clearTimeout(timeout);
         console.warn(`[lifecycle] DaemonClient.connect error code=${err?.code ?? '?'} pipe=${this.pipeName} msg=${err?.message ?? String(err)}`);
-        resolve(false);
+        finish({ ok: false, code: err?.code });
       });
     });
   }

--- a/src/main/__tests__/daemonConnectRetry.test.ts
+++ b/src/main/__tests__/daemonConnectRetry.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  connectWithRetry,
+  classifyConnectFailure,
+  DAEMON_CONNECT_BACKOFFS_MS,
+  type ConnectAttemptResult,
+} from '../daemonConnectRetry';
+
+// RCA A6 — control-pipe connect retry. The bug: a single transient Windows
+// named-pipe blip (EPERM/ECONNRESET from AV scan / handle contention) was
+// treated as a dead daemon. These tests lock in: retry transient, fail fast on
+// genuinely-absent (ENOENT/ECONNREFUSED), bounded retries.
+
+const noSleep = () => Promise.resolve();
+const noLog = () => { /* silent */ };
+
+describe('classifyConnectFailure', () => {
+  it('ENOENT and ECONNREFUSED are permanent (daemon absent)', () => {
+    expect(classifyConnectFailure('ENOENT', false)).toBe('permanent');
+    expect(classifyConnectFailure('ECONNREFUSED', false)).toBe('permanent');
+  });
+  it('EPERM / ECONNRESET / unknown / timeout are transient', () => {
+    expect(classifyConnectFailure('EPERM', false)).toBe('transient');
+    expect(classifyConnectFailure('ECONNRESET', false)).toBe('transient');
+    expect(classifyConnectFailure('EPIPE', false)).toBe('transient');
+    expect(classifyConnectFailure(undefined, false)).toBe('transient');
+    expect(classifyConnectFailure('ENOENT', true)).toBe('transient'); // a timeout always retries
+  });
+});
+
+describe('connectWithRetry', () => {
+  const ok = (): ConnectAttemptResult => ({ ok: true });
+  const err = (code: string): ConnectAttemptResult => ({ ok: false, code });
+  const timeout = (): ConnectAttemptResult => ({ ok: false, timedOut: true });
+
+  it('succeeds on the first attempt → true, no retry', async () => {
+    const attempt = vi.fn(async () => ok());
+    const r = await connectWithRetry({ attempt, sleep: noSleep, log: noLog });
+    expect(r).toBe(true);
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it('permanent failure (ENOENT) → false, exactly one attempt (no retry)', async () => {
+    const attempt = vi.fn(async () => err('ENOENT'));
+    const sleep = vi.fn(noSleep);
+    const r = await connectWithRetry({ attempt, sleep, log: noLog });
+    expect(r).toBe(false);
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('permanent failure (ECONNREFUSED) → false fast', async () => {
+    const attempt = vi.fn(async () => err('ECONNREFUSED'));
+    const r = await connectWithRetry({ attempt, sleep: noSleep, log: noLog });
+    expect(r).toBe(false);
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it('transient (EPERM) then success → true, retried', async () => {
+    let n = 0;
+    const attempt = vi.fn(async () => (++n === 1 ? err('EPERM') : ok()));
+    const sleep = vi.fn(noSleep);
+    const r = await connectWithRetry({ attempt, sleep, log: noLog });
+    expect(r).toBe(true);
+    expect(attempt).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it('transient timeout then success → true', async () => {
+    let n = 0;
+    const attempt = vi.fn(async () => (++n === 1 ? timeout() : ok()));
+    const r = await connectWithRetry({ attempt, sleep: noSleep, log: noLog });
+    expect(r).toBe(true);
+    expect(attempt).toHaveBeenCalledTimes(2);
+  });
+
+  it('all transient → exhausts the backoff budget then false', async () => {
+    const attempt = vi.fn(async () => err('ECONNRESET'));
+    const r = await connectWithRetry({ attempt, sleep: noSleep, log: noLog });
+    expect(r).toBe(false);
+    // initial attempt + one per backoff slot
+    expect(attempt).toHaveBeenCalledTimes(DAEMON_CONNECT_BACKOFFS_MS.length + 1);
+  });
+
+  it('isConnected() already true → returns true without attempting (concurrent win)', async () => {
+    const attempt = vi.fn(async () => ok());
+    const r = await connectWithRetry({ attempt, isConnected: () => true, sleep: noSleep, log: noLog });
+    expect(r).toBe(true);
+    expect(attempt).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/daemon/DaemonRespawnController.ts
+++ b/src/main/daemon/DaemonRespawnController.ts
@@ -70,9 +70,9 @@ export interface DaemonRespawnConfig {
   maxBackoffMs?: number;
   /** Health-probe interval. 0 disables the probe. Default 10s. */
   healthIntervalMs?: number;
-  /** Per-ping timeout. Default 3s. */
+  /** Per-ping timeout. Default 5s (RCA A4 — tolerate a busy daemon). */
   healthTimeoutMs?: number;
-  /** Consecutive ping failures that force a respawn. Default 3. */
+  /** Consecutive ping failures that force a respawn. Default 5 (RCA A4). */
   hangFailureThreshold?: number;
 }
 
@@ -82,9 +82,16 @@ const DEFAULTS: Required<DaemonRespawnConfig> = {
   baseBackoffMs: 1000,
   maxBackoffMs: 30_000,
   healthIntervalMs: 10_000,
-  healthTimeoutMs: 3_000,
-  hangFailureThreshold: 3,
+  // RCA A4 — raised from 3s/3 so a daemon under CPU load (the ~9s event-loop
+  // stall the RCA described) is not mistaken for a hang and force-respawned,
+  // which would re-emit daemon:connected and re-trigger the reconcile path.
+  healthTimeoutMs: 5_000,
+  hangFailureThreshold: 5,
 };
+
+// RCA A4 — a successful ping reporting event-loop lag at/above this is logged
+// as "busy but responsive" (never escalated; a daemon that answers is alive).
+const BUSY_LAG_WARN_MS = 1_000;
 
 /**
  * Owns the daemon-respawn lifecycle: detects disconnects, schedules
@@ -302,8 +309,17 @@ export class DaemonRespawnController {
     const client = this.client;
     if (!client || !client.isConnected) return;
     try {
-      await client.rpc('daemon.ping', {}, { timeoutMs: this.cfg.healthTimeoutMs });
+      const pong = (await client.rpc('daemon.ping', {}, { timeoutMs: this.cfg.healthTimeoutMs })) as
+        | { eventLoopLagMs?: number }
+        | undefined;
       this.healthFailureCount = 0;
+      // RCA A4 — a ping that SUCCEEDS proves the daemon is alive even if its
+      // event loop is lagging under load. Never escalate on a successful ping;
+      // just surface the busy state for observability.
+      const lag = pong?.eventLoopLagMs;
+      if (typeof lag === 'number' && lag >= BUSY_LAG_WARN_MS) {
+        this.deps.logger.info(`daemon busy but responsive (event-loop lag ~${lag}ms) — not a hang`);
+      }
     } catch (err) {
       this.healthFailureCount++;
       this.deps.logger.warn(

--- a/src/main/daemon/__tests__/DaemonRespawnController.test.ts
+++ b/src/main/daemon/__tests__/DaemonRespawnController.test.ts
@@ -448,6 +448,59 @@ describe('DaemonRespawnController health probe', () => {
     expect(h.events.some((e) => e.type === 'reconnected')).toBe(true);
   });
 
+  it('a busy-but-responsive daemon (pings succeed with high event-loop lag) is never respawned (RCA A4)', async () => {
+    const h = makeHarness({
+      config: { healthIntervalMs: 1000, healthTimeoutMs: 5000, baseBackoffMs: 50, budget: 5 },
+    });
+    const c1 = new FakeDaemonClient();
+    h.clientQueue.push(c1);
+    // Every ping SUCCEEDS but reports a lagging event loop (busy under load).
+    c1.rpcImpl = async (method) =>
+      method === 'daemon.ping' ? { status: 'ok', eventLoopLagMs: 4000 } : {};
+
+    await h.controller.bootstrap();
+    expect(h.controller.isHealthy).toBe(true);
+
+    // Many ticks — a daemon that keeps answering is alive, never force-respawned.
+    for (let i = 0; i < 10; i++) await vi.advanceTimersByTimeAsync(1000);
+
+    expect(h.deps.onUninstall).not.toHaveBeenCalled();
+    expect(c1.disconnectSyncCalls).toBe(0);
+    expect(h.events.some((e) => e.type === 'reconnecting')).toBe(false);
+    expect(h.controller.isHealthy).toBe(true);
+  });
+
+  it('uses the default hangFailureThreshold of 5 (4 failures tolerated, 5th respawns) (RCA A4)', async () => {
+    const h = makeHarness({
+      // No hangFailureThreshold override → DEFAULTS (now 5, was 3).
+      config: { healthIntervalMs: 1000, healthTimeoutMs: 100, baseBackoffMs: 50, budget: 5 },
+    });
+    const c1 = new FakeDaemonClient();
+    const c2 = new FakeDaemonClient();
+    h.clientQueue.push(c1, c2);
+
+    let pingCalls = 0;
+    c1.rpcImpl = async (method) => {
+      if (method === 'daemon.ping') {
+        pingCalls++;
+        if (pingCalls === 1) return {}; // bootstrap auth ping succeeds
+        throw new Error('ping timeout');
+      }
+      return {};
+    };
+
+    await h.controller.bootstrap();
+
+    // 4 failing ticks — below the default threshold of 5 → no respawn yet.
+    for (let i = 0; i < 4; i++) await vi.advanceTimersByTimeAsync(1000);
+    expect(h.deps.onUninstall).not.toHaveBeenCalled();
+
+    // 5th consecutive failure → respawn.
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(h.deps.onUninstall).toHaveBeenCalled();
+    expect(c1.disconnectSyncCalls).toBe(1);
+  });
+
   it('skips probe ticks when no client is installed', async () => {
     const h = makeHarness({
       config: { healthIntervalMs: 100, healthTimeoutMs: 50 },

--- a/src/main/daemonConnectRetry.ts
+++ b/src/main/daemonConnectRetry.ts
@@ -1,0 +1,94 @@
+/**
+ * RCA A6 — control-pipe connect retry + error classification.
+ *
+ * DaemonClient.connect() was a SINGLE-SHOT net.createConnection: on any error
+ * or timeout it resolved(false) with no retry. On Windows, AV scans and handle
+ * contention cause transient named-pipe EPERM/ECONNRESET constantly — so a 50ms
+ * blip was treated identically to a dead daemon, turning a momentary hiccup into
+ * a full control-pipe disconnect cascade (which can re-trigger the reconcile
+ * path). wmux-client.ts already retried + fell back; DaemonClient did not.
+ *
+ * This module holds the retry policy as a pure, dependency-injected function
+ * (no electron/net import) so it can be unit-tested in isolation, mirroring
+ * reconnectPtyWithRetry. The classification rule is the crux: only ENOENT /
+ * ECONNREFUSED mean the daemon is genuinely absent (don't retry); everything
+ * else is transient and worth a bounded retry.
+ */
+
+export interface ConnectAttemptResult {
+  ok: boolean;
+  /** The socket error code (EPERM/ECONNREFUSED/ENOENT/…) when ok === false. */
+  code?: string;
+  /** True when the attempt hit the per-attempt connect timeout. */
+  timedOut?: boolean;
+}
+
+export type ConnectFailureClass = 'permanent' | 'transient';
+
+/**
+ * ENOENT (pipe/socket absent) and ECONNREFUSED (nothing listening) mean the
+ * daemon is genuinely not present — retrying is pointless, return fast.
+ * Everything else (EPERM / ECONNRESET / EPIPE / ETIMEDOUT / a timeout / an
+ * unknown code) is a transient Windows named-pipe condition worth a retry.
+ */
+export function classifyConnectFailure(
+  code: string | undefined,
+  timedOut: boolean | undefined,
+): ConnectFailureClass {
+  if (timedOut) return 'transient';
+  if (code === 'ENOENT' || code === 'ECONNREFUSED') return 'permanent';
+  return 'transient';
+}
+
+/**
+ * Bounded backoff. Kept small (sum 1.7s) so connect's internal retry does not
+ * compound badly with DaemonRespawnController's whole-respawn backoff. The only
+ * way to approach the worst case (4 × the 5s per-attempt timeout) is a pipe that
+ * repeatedly accepts-then-hangs, which is not the EPERM/ECONNRESET blip this
+ * guards against — those fail fast via the 'error' event.
+ */
+export const DAEMON_CONNECT_BACKOFFS_MS = [200, 500, 1000];
+
+export interface ConnectRetryDeps {
+  /** Perform one connect attempt. */
+  attempt: () => Promise<ConnectAttemptResult>;
+  /** Sleep between retries. Injectable so tests don't wait real time. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Bail early (return true) if a concurrent path already connected. */
+  isConnected?: () => boolean;
+  /** Optional structured logger. */
+  log?: (message: string) => void;
+  /** Override the backoff schedule (default DAEMON_CONNECT_BACKOFFS_MS). */
+  backoffsMs?: number[];
+}
+
+/**
+ * Retry a connect attempt with bounded backoff, stopping immediately (fast
+ * false) on a PERMANENT failure and retrying TRANSIENT failures.
+ */
+export async function connectWithRetry(deps: ConnectRetryDeps): Promise<boolean> {
+  const backoffs = deps.backoffsMs ?? DAEMON_CONNECT_BACKOFFS_MS;
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const isConnected = deps.isConnected ?? (() => false);
+  const log = deps.log ?? (() => { /* silent by default */ });
+
+  for (let attempt = 0; attempt <= backoffs.length; attempt++) {
+    if (isConnected()) return true; // a concurrent connect won the race
+    const result = await deps.attempt();
+    if (result.ok) return true;
+
+    if (classifyConnectFailure(result.code, result.timedOut) === 'permanent') {
+      log(`permanent connect failure code=${result.code ?? '?'} — daemon not present, no retry`);
+      return false;
+    }
+
+    if (attempt < backoffs.length) {
+      log(
+        `transient connect failure ${result.timedOut ? 'timeout' : 'code=' + (result.code ?? '?')} — retry ${attempt + 1}/${backoffs.length} after ${backoffs[attempt]}ms`,
+      );
+      await sleep(backoffs[attempt]);
+    }
+  }
+  log(`connect exhausted ${backoffs.length} retries`);
+  return false;
+}

--- a/src/main/hooks/HookFloodMeter.ts
+++ b/src/main/hooks/HookFloodMeter.ts
@@ -1,0 +1,76 @@
+/**
+ * HookFloodMeter — postmortem-visible observability for the hook-RPC path.
+ *
+ * RCA (2026-05-29 user dogfood): a tool-heavy turn flooded the bridge with 2s
+ * timeouts because every hook did a renderer workspace.list round-trip. The
+ * A1 fix (short-TTL + coalescing cache in hooks.rpc) collapses the round-trips,
+ * but the maintainer was flying blind: the flood was only visible by manually
+ * tallying bridge.log. This meter tracks, in a rolling window, how many hook
+ * signals experienced a SLOW or FAILED workspace.list fetch (= renderer
+ * throttled / event loop busy — the flood precursor) and emits one summary log
+ * line per window so a postmortem (or live tail) shows the flood directly.
+ *
+ * Pure + dependency-free so it unit-tests without electron/IPC. The periodic
+ * flush + log wiring lives in hooks.rpc (registerHooksRpc).
+ */
+
+export interface HookFloodSample {
+  /** True when the workspace.list fetch was slow or failed (renderer slow). */
+  degraded: boolean;
+  /** Wall-clock ms the workspace.list resolution took for this signal. */
+  fetchMs: number;
+}
+
+export interface HookFloodSummary {
+  windowMs: number;
+  total: number;
+  degraded: number;
+  maxFetchMs: number;
+}
+
+export class HookFloodMeter {
+  private total = 0;
+  private degraded = 0;
+  private maxFetchMs = 0;
+
+  record(sample: HookFloodSample): void {
+    this.total++;
+    if (sample.degraded) this.degraded++;
+    if (sample.fetchMs > this.maxFetchMs) this.maxFetchMs = sample.fetchMs;
+  }
+
+  /**
+   * Snapshot the current window and RESET. Returns null when no signals were
+   * recorded in the window (so the logger stays silent on an idle wmux instead
+   * of emitting a "0 signals" line every interval).
+   */
+  flush(windowMs: number): HookFloodSummary | null {
+    if (this.total === 0) return null;
+    const summary: HookFloodSummary = {
+      windowMs,
+      total: this.total,
+      degraded: this.degraded,
+      maxFetchMs: this.maxFetchMs,
+    };
+    this.total = 0;
+    this.degraded = 0;
+    this.maxFetchMs = 0;
+    return summary;
+  }
+}
+
+/**
+ * Format a window summary into a log line + level. Warns when a meaningful
+ * fraction of signals were degraded (a real flood, not a one-off slow fetch).
+ */
+export function describeHookFlood(s: HookFloodSummary): { level: 'info' | 'warn'; message: string } {
+  const secs = Math.round(s.windowMs / 1000);
+  const pct = s.total > 0 ? Math.round((s.degraded / s.total) * 100) : 0;
+  const base = `[hooks] last ${secs}s: ${s.total} signals, ${s.degraded} degraded (${pct}% slow/failed workspace.list), maxFetch ${s.maxFetchMs}ms`;
+  // Flood = a non-trivial sample AND ≥10% degraded. Below that, a stray slow
+  // fetch is noise, not a pattern worth a warning.
+  const isFlood = s.total >= 10 && s.degraded / s.total >= 0.1;
+  return isFlood
+    ? { level: 'warn', message: `${base} — possible hook-RPC flood (renderer slow/throttled or event loop busy)` }
+    : { level: 'info', message: base };
+}

--- a/src/main/hooks/__tests__/HookFloodMeter.test.ts
+++ b/src/main/hooks/__tests__/HookFloodMeter.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { HookFloodMeter, describeHookFlood } from '../HookFloodMeter';
+
+describe('HookFloodMeter', () => {
+  it('flush() returns null when no signals were recorded (idle window stays silent)', () => {
+    const m = new HookFloodMeter();
+    expect(m.flush(30_000)).toBeNull();
+  });
+
+  it('tallies total, degraded, and maxFetch then resets on flush', () => {
+    const m = new HookFloodMeter();
+    m.record({ degraded: false, fetchMs: 2 });
+    m.record({ degraded: true, fetchMs: 1500 });
+    m.record({ degraded: false, fetchMs: 40 });
+
+    const s = m.flush(30_000);
+    expect(s).toEqual({ windowMs: 30_000, total: 3, degraded: 1, maxFetchMs: 1500 });
+
+    // Window reset — a subsequent idle flush is null.
+    expect(m.flush(30_000)).toBeNull();
+  });
+
+  it('accumulates across records within a window', () => {
+    const m = new HookFloodMeter();
+    for (let i = 0; i < 5; i++) m.record({ degraded: i % 2 === 0, fetchMs: i });
+    const s = m.flush(10_000);
+    expect(s?.total).toBe(5);
+    expect(s?.degraded).toBe(3); // i = 0,2,4
+  });
+});
+
+describe('describeHookFlood', () => {
+  it('info level for a healthy window (mostly fresh cache hits)', () => {
+    const { level, message } = describeHookFlood({ windowMs: 30_000, total: 100, degraded: 2, maxFetchMs: 30 });
+    expect(level).toBe('info');
+    expect(message).toContain('100 signals');
+    expect(message).toContain('2 degraded');
+    expect(message).toContain('2%');
+  });
+
+  it('warn level when ≥10% of a non-trivial sample is degraded (flood)', () => {
+    const { level, message } = describeHookFlood({ windowMs: 30_000, total: 50, degraded: 20, maxFetchMs: 1900 });
+    expect(level).toBe('warn');
+    expect(message).toContain('flood');
+    expect(message).toContain('40%');
+  });
+
+  it('stays info for a tiny sample even if proportionally degraded (avoid one-off noise)', () => {
+    // 2/3 degraded but total < 10 → not a pattern worth warning.
+    const { level } = describeHookFlood({ windowMs: 30_000, total: 3, degraded: 2, maxFetchMs: 800 });
+    expect(level).toBe('info');
+  });
+});

--- a/src/main/pipe/handlers/__tests__/hooks.rpc.cache.test.ts
+++ b/src/main/pipe/handlers/__tests__/hooks.rpc.cache.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createWorkspaceListCache, WORKSPACE_LIST_CACHE_TTL_MS } from '../hooks.rpc';
+
+// RCA (2026-05-29 dogfood): the handler did a renderer workspace.list
+// round-trip on EVERY hook signal, so a tool-heavy turn flooded the bridge
+// with 2s timeouts. These tests lock in the short-TTL + coalescing cache that
+// collapses a burst into a single round-trip and serves stale on refresh
+// failure (renderer throttled) instead of dropping the hook.
+
+type WS = { id: string; name: string };
+const list = (id: string): WS[] => [{ id, name: id }];
+
+describe('createWorkspaceListCache', () => {
+  it('serves a fresh cache hit within the TTL without re-fetching', async () => {
+    let t = 1000;
+    const fetchList = vi.fn(async () => list('a'));
+    const cache = createWorkspaceListCache(fetchList, () => t);
+
+    expect(await cache.get()).toEqual(list('a'));
+    t += WORKSPACE_LIST_CACHE_TTL_MS - 1; // still inside the window
+    expect(await cache.get()).toEqual(list('a'));
+
+    expect(fetchList).toHaveBeenCalledTimes(1); // second get() was a cache hit
+  });
+
+  it('coalesces a burst of concurrent misses into ONE fetch', async () => {
+    let resolveFetch!: (v: WS[]) => void;
+    const fetchList = vi.fn(() => new Promise<WS[]>((r) => { resolveFetch = r; }));
+    const cache = createWorkspaceListCache(fetchList, () => 0);
+
+    // 50 hooks fire "simultaneously" before the first round-trip resolves.
+    const all = Promise.all(Array.from({ length: 50 }, () => cache.get()));
+    resolveFetch(list('a'));
+    const results = await all;
+
+    expect(fetchList).toHaveBeenCalledTimes(1); // the whole burst shared one RTT
+    for (const r of results) expect(r).toEqual(list('a'));
+  });
+
+  it('re-fetches once the TTL expires', async () => {
+    let t = 0;
+    const fetchList = vi.fn(async () => list(`v${t}`));
+    const cache = createWorkspaceListCache(fetchList, () => t);
+
+    expect(await cache.get()).toEqual(list('v0'));
+    t += WORKSPACE_LIST_CACHE_TTL_MS; // exactly at the boundary → expired
+    expect(await cache.get()).toEqual(list(`v${t}`));
+    expect(fetchList).toHaveBeenCalledTimes(2);
+  });
+
+  it('serves the last-known list when a refresh fails/times out (renderer throttled)', async () => {
+    let t = 0;
+    let attempt = 0;
+    const fetchList = vi.fn(async () => (attempt++ === 0 ? list('good') : null));
+    const cache = createWorkspaceListCache(fetchList, () => t);
+
+    expect(await cache.get()).toEqual(list('good')); // populate cache
+    t += WORKSPACE_LIST_CACHE_TTL_MS + 1; // expire
+    // refresh returns null (timeout) — must serve stale, NOT drop the hook
+    expect(await cache.get()).toEqual(list('good'));
+    expect(fetchList).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null when nothing has ever been fetched successfully', async () => {
+    const fetchList = vi.fn(async () => null);
+    const cache = createWorkspaceListCache(fetchList, () => 0);
+    expect(await cache.get()).toBeNull();
+  });
+});

--- a/src/main/pipe/handlers/hooks.rpc.ts
+++ b/src/main/pipe/handlers/hooks.rpc.ts
@@ -61,6 +61,24 @@ interface WorkspaceListEntry {
   ptyIds?: string[];
 }
 
+// RCA (2026-05-29 dogfood, bridge.log): the handler used to do a renderer
+// `workspace.list` round-trip on EVERY hook signal. PostToolUse fires per
+// tool call, so a tool-heavy turn — especially with the window backgrounded
+// (Chromium throttles renderer timers/IPC) or the renderer busy flushing a
+// large terminal buffer — made every hook's round-trip (sendToRenderer
+// default 5s) exceed the bridge's 2s hard timeout. Result: bridge.log floods
+// with `timeout` (~11.6% of signals, 94% PostToolUse) and notifications /
+// token-tracking silently drop; in the worst bursts the daemon event loop is
+// blocked enough that daemon.ping fails 3× and the main-process supervisor
+// force-respawns the daemon. The workspace tree changes far less often than
+// hooks fire, so we serve a short-TTL cache and coalesce concurrent fetches
+// into a single round-trip, and fall back to the last-known list when a
+// refresh times out (renderer throttled) rather than dropping the hook.
+export const WORKSPACE_LIST_CACHE_TTL_MS = 2_000;
+// Keep the per-fetch cap under the bridge's HOOK_TIMEOUT_MS (2s) so a cache
+// miss against a slow renderer still returns (stale) before the bridge bails.
+const WORKSPACE_LIST_FETCH_TIMEOUT_MS = 1_500;
+
 /**
  * Register `hooks.signal` on the router. Must be called once at boot
  * (main/index.ts) after both the PipeServer and HookSignalRouter exist.
@@ -81,6 +99,9 @@ export function registerHooksRpc(
   hookRouter: HookSignalRouter,
 ): () => void {
   const meter = hookRouter.getLatencyMeter();
+  // Short-TTL, coalescing cache so a burst of hooks in one turn collapses to
+  // a single workspace.list round-trip (see WORKSPACE_LIST_CACHE_TTL_MS note).
+  const workspaceCache = createWorkspaceListCache(() => safeListWorkspaces(getWindow));
 
   router.register('hooks.signal', async (params): Promise<HookSignalResponse> => {
     // 1. Envelope validation. Reject anything that doesn't match the
@@ -100,11 +121,10 @@ export function registerHooksRpc(
     // 3. Resolve signal → ptyId. Env-first (workspaceId/surfaceId from
     //    WMUX_* env vars that wmux PTYManager injects into the shell)
     //    with cwd matching as the fallback for sessions started outside
-    //    a wmux pane. We query the renderer-side workspace list every
-    //    time because the workspace tree changes more often than hooks
-    //    fire; a 1-RTT round-trip to the renderer is fine at the hook
-    //    fire rate (≤ a few per turn).
-    const workspaces = await safeListWorkspaces(getWindow);
+    //    a wmux pane. The workspace list comes from a short-TTL coalescing
+    //    cache (NOT a fresh round-trip per hook — that flooded the bridge
+    //    with 2s timeouts under load; see the cache note above).
+    const workspaces = await workspaceCache.get();
     if (!workspaces) {
       // Record as a miss because we couldn't determine match either
       // way — better than silently skewing the counter to "matched".
@@ -313,13 +333,64 @@ function throttle1Hz<T>(fn: (arg: T) => void): ((arg: T) => void) & { cancel: ()
  */
 async function safeListWorkspaces(getWindow: GetWindow): Promise<WorkspaceListEntry[] | null> {
   try {
-    const result = (await sendToRenderer(getWindow, 'workspace.list')) as unknown;
+    const result = (await sendToRenderer(getWindow, 'workspace.list', {}, {
+      timeoutMs: WORKSPACE_LIST_FETCH_TIMEOUT_MS,
+    })) as unknown;
     if (!Array.isArray(result)) return null;
     return result as WorkspaceListEntry[];
   } catch (err) {
     console.warn('[hooks.rpc] workspace.list failed:', err);
     return null;
   }
+}
+
+interface WorkspaceListCache {
+  /**
+   * Resolve the workspace list, serving a cached snapshot when it is younger
+   * than WORKSPACE_LIST_CACHE_TTL_MS and coalescing concurrent misses into a
+   * single round-trip. Returns the last-known list if a refresh fails/times
+   * out (renderer throttled), or null if nothing has ever been fetched.
+   */
+  get(): Promise<WorkspaceListEntry[] | null>;
+}
+
+/**
+ * Build a workspace.list cache. Created once in registerHooksRpc so its
+ * closure state (cached value, timestamp, in-flight promise) lives for the
+ * handler's lifetime. See WORKSPACE_LIST_CACHE_TTL_MS for the why.
+ *
+ * `fetchList` and `now` are injected so the TTL + coalescing behavior is
+ * unit-testable without an electron BrowserWindow / IPC mock.
+ */
+export function createWorkspaceListCache(
+  fetchList: () => Promise<WorkspaceListEntry[] | null>,
+  now: () => number = Date.now,
+): WorkspaceListCache {
+  let cached: WorkspaceListEntry[] | null = null;
+  let cachedAt = 0;
+  let inFlight: Promise<WorkspaceListEntry[] | null> | null = null;
+
+  return {
+    async get(): Promise<WorkspaceListEntry[] | null> {
+      if (cached && now() - cachedAt < WORKSPACE_LIST_CACHE_TTL_MS) {
+        return cached; // fresh hit — no renderer round-trip
+      }
+      if (inFlight) return inFlight; // coalesce a burst into one round-trip
+      inFlight = (async () => {
+        const fresh = await fetchList();
+        if (fresh) {
+          cached = fresh;
+          cachedAt = now();
+        }
+        inFlight = null;
+        // On a failed/timed-out refresh, serve the last-known list rather than
+        // dropping the hook — a ≤2s-stale workspace map routes the toast/token
+        // correctly in the overwhelmingly common case (tree rarely changes).
+        return fresh ?? cached;
+      })();
+      return inFlight;
+    },
+  };
 }
 
 /**

--- a/src/main/pipe/handlers/hooks.rpc.ts
+++ b/src/main/pipe/handlers/hooks.rpc.ts
@@ -43,6 +43,7 @@ import type { RpcRouter } from '../RpcRouter';
 import { sendToRenderer } from './_bridge';
 import { sendNotification } from '../../notification/sendNotification';
 import type { HookSignalRouter } from '../../hooks/HookSignalRouter';
+import { HookFloodMeter, describeHookFlood } from '../../hooks/HookFloodMeter';
 import { eventBus } from '../../events/EventBus';
 import { IPC } from '../../../shared/constants';
 import {
@@ -79,6 +80,12 @@ export const WORKSPACE_LIST_CACHE_TTL_MS = 2_000;
 // miss against a slow renderer still returns (stale) before the bridge bails.
 const WORKSPACE_LIST_FETCH_TIMEOUT_MS = 1_500;
 
+// Observability (HookFloodMeter): a hook is "degraded" when its workspace.list
+// resolution took longer than this — i.e. it missed the cache and the renderer
+// was slow to answer (the flood precursor). Logged in a rolling summary.
+const HOOK_DEGRADED_FETCH_MS = 500;
+const HOOK_FLOOD_LOG_INTERVAL_MS = 30_000;
+
 /**
  * Register `hooks.signal` on the router. Must be called once at boot
  * (main/index.ts) after both the PipeServer and HookSignalRouter exist.
@@ -103,6 +110,19 @@ export function registerHooksRpc(
   // a single workspace.list round-trip (see WORKSPACE_LIST_CACHE_TTL_MS note).
   const workspaceCache = createWorkspaceListCache(() => safeListWorkspaces(getWindow));
 
+  // Observability: surface a hook-RPC flood in the main log (postmortem
+  // visible) by tallying slow/failed workspace.list resolutions per window.
+  const floodMeter = new HookFloodMeter();
+  const floodTimer = setInterval(() => {
+    const summary = floodMeter.flush(HOOK_FLOOD_LOG_INTERVAL_MS);
+    if (!summary) return;
+    const { level, message } = describeHookFlood(summary);
+    if (level === 'warn') console.warn(message);
+    else console.log(message);
+  }, HOOK_FLOOD_LOG_INTERVAL_MS);
+  // Never keep the process alive for the flood logger.
+  floodTimer.unref?.();
+
   router.register('hooks.signal', async (params): Promise<HookSignalResponse> => {
     // 1. Envelope validation. Reject anything that doesn't match the
     //    canonical shape — bridges from older wmux versions, malformed
@@ -124,7 +144,10 @@ export function registerHooksRpc(
     //    a wmux pane. The workspace list comes from a short-TTL coalescing
     //    cache (NOT a fresh round-trip per hook — that flooded the bridge
     //    with 2s timeouts under load; see the cache note above).
+    const fetchStart = Date.now();
     const workspaces = await workspaceCache.get();
+    const fetchMs = Date.now() - fetchStart;
+    floodMeter.record({ degraded: fetchMs > HOOK_DEGRADED_FETCH_MS || !workspaces, fetchMs });
     if (!workspaces) {
       // Record as a miss because we couldn't determine match either
       // way — better than silently skewing the counter to "matched".
@@ -265,6 +288,7 @@ export function registerHooksRpc(
   return () => {
     unsubscribe();
     throttledPush.cancel();
+    clearInterval(floodTimer);
   };
 }
 

--- a/src/main/updater/AutoUpdater.ts
+++ b/src/main/updater/AutoUpdater.ts
@@ -9,10 +9,19 @@
  */
 
 import { autoUpdater, app, type BrowserWindow, ipcMain, net, shell } from 'electron';
+import { createWriteStream } from 'node:fs';
+import { unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
 import { IPC } from '../../shared/constants';
+import { isAllowedDownloadUrl, digestsEqual, validateManifest, type UpdateManifest } from './verifyUpdate';
 
 const REPO = 'openwong2kim/wmux';
 const UPDATE_SERVER = `https://update.electronjs.org/${REPO}/win32/${app.getVersion()}`;
+// CI publishes update-manifest.json (version + setupExe + sha256 + url) as a
+// release asset; the "latest" alias always points at the newest release. The
+// updater pins the Setup.exe SHA-256 against this before installing.
+const MANIFEST_URL = `https://github.com/${REPO}/releases/latest/download/update-manifest.json`;
 
 // 업데이트 자동 확인 간격 (30분)
 const CHECK_INTERVAL_MS = 30 * 60 * 1000;
@@ -120,6 +129,85 @@ export class AutoUpdater {
     });
   }
 
+  /** Fetch the CI-published update manifest (raw JSON; validated by caller). */
+  private fetchManifest(): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const request = net.request(MANIFEST_URL);
+      let body = '';
+      request.on('response', (response) => {
+        if (response.statusCode !== 200) {
+          reject(new Error(`update manifest server returned ${response.statusCode}`));
+          return;
+        }
+        response.on('data', (chunk) => { body += chunk.toString(); });
+        response.on('end', () => {
+          try {
+            resolve(JSON.parse(body));
+          } catch {
+            reject(new Error('invalid JSON in update manifest'));
+          }
+        });
+      });
+      request.on('error', (err) => reject(err));
+      request.end();
+    });
+  }
+
+  /**
+   * Download manifest.url to a temp file, streaming through a SHA-256 hash, and
+   * verify it matches manifest.sha256. Resolves the temp path on a verified
+   * match; rejects on any transport error or digest mismatch (caller cleans up
+   * and aborts — fail-closed).
+   */
+  private downloadAndVerify(manifest: UpdateManifest): Promise<string> {
+    return new Promise((resolve, reject) => {
+      // Defense in depth: validateManifest already allowlist-checked the URL;
+      // re-assert before opening the socket.
+      if (!isAllowedDownloadUrl(manifest.url)) {
+        reject(new Error(`download url not allowed: ${manifest.url}`));
+        return;
+      }
+      const dest = join(app.getPath('temp'), `wmux-update-${manifest.version}-${process.pid}.Setup.exe`);
+      const hash = createHash('sha256');
+      const out = createWriteStream(dest);
+      let settled = false;
+      const fail = (err: Error) => {
+        if (settled) return;
+        settled = true;
+        out.destroy();
+        reject(err);
+      };
+
+      const request = net.request(manifest.url);
+      request.on('response', (response) => {
+        if (response.statusCode !== 200) {
+          fail(new Error(`installer download returned ${response.statusCode}`));
+          return;
+        }
+        response.on('data', (chunk: Buffer) => {
+          hash.update(chunk);
+          out.write(chunk);
+        });
+        response.on('end', () => {
+          out.end(() => {
+            if (settled) return;
+            const actual = hash.digest('hex');
+            if (digestsEqual(actual, manifest.sha256)) {
+              settled = true;
+              resolve(dest);
+            } else {
+              fail(new Error(`sha256 mismatch: expected ${manifest.sha256}, got ${actual}`));
+            }
+          });
+        });
+        response.on('error', (err) => fail(err instanceof Error ? err : new Error(String(err))));
+      });
+      request.on('error', (err) => fail(err instanceof Error ? err : new Error(String(err))));
+      out.on('error', (err) => fail(err instanceof Error ? err : new Error(String(err))));
+      request.end();
+    });
+  }
+
   private registerIpcHandlers(): void {
     ipcMain.on(IPC.AUTO_UPDATE_ENABLED, (_event, enabled: boolean) => {
       this.setEnabled(enabled);
@@ -135,7 +223,8 @@ export class AutoUpdater {
     });
 
     ipcMain.handle(IPC.UPDATE_INSTALL, async () => {
-      if (!this.pendingUpdate) return;
+      const pending = this.pendingUpdate;
+      if (!pending) return;
 
       const win = this.getWindow();
       if (win && !win.isDestroyed() && !win.webContents.isCrashed()) {
@@ -150,8 +239,37 @@ export class AutoUpdater {
         }
       }
 
-      // Open the Setup.exe download URL — user installs the new version
-      shell.openExternal(this.pendingUpdate.url);
+      // NN2-T4 — fail-closed download-verify-launch. Never hand the user an
+      // unverified binary (the old path was shell.openExternal on an unchecked
+      // URL). Fetch the CI-published SHA-256 manifest, download the Setup.exe
+      // ourselves, verify its digest, and only then launch the LOCAL file. Any
+      // failure aborts the install and surfaces an error — no openExternal
+      // fallback, so a tampered/unverifiable artifact can never run.
+      let tempPath: string | null = null;
+      try {
+        const manifestRaw = await this.fetchManifest();
+        const validated = validateManifest(manifestRaw, pending.name);
+        if (!validated.ok) {
+          throw new Error(`update manifest rejected: ${validated.reason}`);
+        }
+        tempPath = await this.downloadAndVerify(validated.manifest);
+        console.log('[AutoUpdater] Update verified (sha256 match) — launching installer');
+        const openErr = await shell.openPath(tempPath);
+        if (openErr) {
+          // openPath resolves to a non-empty error string on failure.
+          throw new Error(`failed to launch verified installer: ${openErr}`);
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error('[AutoUpdater] install aborted (fail-closed):', message);
+        if (tempPath) {
+          await unlink(tempPath).catch(() => { /* best-effort cleanup */ });
+        }
+        this.sendToRenderer(IPC.UPDATE_ERROR, {
+          status: 'error',
+          message: `Update could not be verified and was not installed: ${message}`,
+        });
+      }
     });
   }
 

--- a/src/main/updater/__tests__/verifyUpdate.test.ts
+++ b/src/main/updater/__tests__/verifyUpdate.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeVersion,
+  isAllowedDownloadUrl,
+  digestsEqual,
+  sha256Hex,
+  validateManifest,
+} from '../verifyUpdate';
+
+// NN2-T4 — the fail-closed verification core. The pre-fix updater launched an
+// UNVERIFIED binary from a URL taken verbatim from the update server. These
+// tests lock in the security decisions: only https github.com downloads, exact
+// SHA-256 match, manifest must match the offered version, reject on any doubt.
+
+const VALID_SHA = 'a'.repeat(64);
+const validManifest = (over: Record<string, unknown> = {}) => ({
+  version: '2.14.1',
+  setupExe: 'wmux-2.14.1.Setup.exe',
+  sha256: VALID_SHA,
+  url: 'https://github.com/openwong2kim/wmux/releases/download/v2.14.1/wmux-2.14.1.Setup.exe',
+  ...over,
+});
+
+describe('normalizeVersion', () => {
+  it('strips a leading v (any case) and trims', () => {
+    expect(normalizeVersion('v2.14.0')).toBe('2.14.0');
+    expect(normalizeVersion('2.14.0')).toBe('2.14.0');
+    expect(normalizeVersion('  V1.0 ')).toBe('1.0');
+  });
+});
+
+describe('isAllowedDownloadUrl', () => {
+  it('accepts https github.com and *.github.com', () => {
+    expect(isAllowedDownloadUrl('https://github.com/o/r/releases/download/v1/x.exe')).toBe(true);
+    expect(isAllowedDownloadUrl('https://api.github.com/x')).toBe(true);
+  });
+  it('rejects non-https, non-github hosts, and garbage', () => {
+    expect(isAllowedDownloadUrl('http://github.com/x')).toBe(false);
+    expect(isAllowedDownloadUrl('https://evil.com/x.exe')).toBe(false);
+    expect(isAllowedDownloadUrl('https://github.com.evil.com/x')).toBe(false);
+    expect(isAllowedDownloadUrl('ftp://github.com/x')).toBe(false);
+    expect(isAllowedDownloadUrl('not a url')).toBe(false);
+  });
+});
+
+describe('digestsEqual', () => {
+  it('matches case-insensitively', () => {
+    expect(digestsEqual('ABCDEF', 'abcdef')).toBe(true);
+    expect(digestsEqual('a'.repeat(64), 'A'.repeat(64))).toBe(true);
+  });
+  it('rejects differing content, differing length, and empty', () => {
+    expect(digestsEqual('abcdef', 'abcde0')).toBe(false);
+    expect(digestsEqual('abc', 'abcdef')).toBe(false);
+    expect(digestsEqual('', '')).toBe(false);
+  });
+});
+
+describe('sha256Hex', () => {
+  it('matches known vectors', () => {
+    expect(sha256Hex(Buffer.from(''))).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+    expect(sha256Hex(Buffer.from('abc'))).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+  });
+});
+
+describe('validateManifest', () => {
+  it('accepts a well-formed manifest whose version matches the offered update (v-prefix tolerant)', () => {
+    const r = validateManifest(validManifest(), 'v2.14.1');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.manifest.url).toContain('github.com');
+  });
+
+  it('rejects a version mismatch (stale/wrong manifest)', () => {
+    const r = validateManifest(validManifest(), '2.99.0');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects a sha256 that is not a 64-char hex digest', () => {
+    expect(validateManifest(validManifest({ sha256: 'deadbeef' }), '2.14.1').ok).toBe(false);
+    expect(validateManifest(validManifest({ sha256: 'z'.repeat(64) }), '2.14.1').ok).toBe(false);
+  });
+
+  it('rejects a non-github / non-https download url', () => {
+    expect(validateManifest(validManifest({ url: 'https://evil.com/x.exe' }), '2.14.1').ok).toBe(false);
+    expect(validateManifest(validManifest({ url: 'http://github.com/x.exe' }), '2.14.1').ok).toBe(false);
+  });
+
+  it('rejects missing fields and non-objects', () => {
+    expect(validateManifest({ version: '2.14.1' }, '2.14.1').ok).toBe(false);
+    expect(validateManifest(null, '2.14.1').ok).toBe(false);
+    expect(validateManifest('nope', '2.14.1').ok).toBe(false);
+  });
+});

--- a/src/main/updater/verifyUpdate.ts
+++ b/src/main/updater/verifyUpdate.ts
@@ -1,0 +1,98 @@
+/**
+ * NN2-T4 — pure, electron-free verification logic for the auto-updater.
+ *
+ * Before v2.14.x the updater handed the user an UNVERIFIED binary: it called
+ * shell.openExternal(url) on a URL taken verbatim from the update server, with
+ * no integrity check at all. A compromised release artifact or a redirect MITM
+ * was undetectable client-side — the single biggest supply-chain gap for a tool
+ * that auto-edits ~/.claude.json and drives a logged-in browser.
+ *
+ * This module holds the security decisions (URL allowlist, manifest validation,
+ * constant-time digest comparison) as pure functions so they can be unit-tested
+ * without electron. AutoUpdater wires the download/launch plumbing around them.
+ * The contract is FAIL-CLOSED: any uncertainty rejects the install.
+ */
+
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+export interface UpdateManifest {
+  version: string;
+  setupExe: string;
+  sha256: string;
+  url: string;
+}
+
+export type ManifestResult =
+  | { ok: true; manifest: UpdateManifest }
+  | { ok: false; reason: string };
+
+/** Strip a leading "v" so "v2.14.0" and "2.14.0" compare equal. */
+export function normalizeVersion(v: string): string {
+  return v.trim().replace(/^v/i, '');
+}
+
+/**
+ * Only https downloads from github.com (the release host) are accepted. The
+ * release asset 302-redirects to objects.githubusercontent.com; we validate the
+ * INITIAL url here and let the HTTP client follow the redirect.
+ */
+export function isAllowedDownloadUrl(rawUrl: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  if (u.protocol !== 'https:') return false;
+  const host = u.hostname.toLowerCase();
+  return host === 'github.com' || host.endsWith('.github.com');
+}
+
+/** Constant-time, case-insensitive comparison of two hex digests. */
+export function digestsEqual(a: string, b: string): boolean {
+  const na = a.trim().toLowerCase();
+  const nb = b.trim().toLowerCase();
+  if (na.length === 0 || na.length !== nb.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(na, 'utf8'), Buffer.from(nb, 'utf8'));
+  } catch {
+    return false;
+  }
+}
+
+/** SHA-256 hex digest of a buffer. */
+export function sha256Hex(data: Buffer): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+/**
+ * Validate a fetched manifest is well-formed, points at an allowlisted https
+ * github.com URL, carries a 64-char hex SHA-256, and matches the version the
+ * update server offered (defends against a stale/wrong manifest). Returns a
+ * typed, trusted manifest or a rejection reason.
+ */
+export function validateManifest(raw: unknown, offeredVersion: string): ManifestResult {
+  if (!raw || typeof raw !== 'object') return { ok: false, reason: 'manifest is not an object' };
+  const o = raw as Record<string, unknown>;
+  if (
+    typeof o.version !== 'string' ||
+    typeof o.setupExe !== 'string' ||
+    typeof o.sha256 !== 'string' ||
+    typeof o.url !== 'string'
+  ) {
+    return { ok: false, reason: 'manifest missing required string fields (version/setupExe/sha256/url)' };
+  }
+  if (!/^[a-f0-9]{64}$/i.test(o.sha256.trim())) {
+    return { ok: false, reason: 'sha256 is not a 64-char hex digest' };
+  }
+  if (!isAllowedDownloadUrl(o.url)) {
+    return { ok: false, reason: `download url is not an allowed https github.com url: ${o.url}` };
+  }
+  if (normalizeVersion(o.version) !== normalizeVersion(offeredVersion)) {
+    return { ok: false, reason: `manifest version "${o.version}" does not match offered update "${offeredVersion}"` };
+  }
+  return {
+    ok: true,
+    manifest: { version: o.version, setupExe: o.setupExe, sha256: o.sha256.trim(), url: o.url },
+  };
+}

--- a/src/renderer/components/Editor/EditorPanel.tsx
+++ b/src/renderer/components/Editor/EditorPanel.tsx
@@ -111,15 +111,12 @@ export default function EditorPanel({ filePath, isActive, surfaceId }: EditorPan
         >
           {editing ? 'View' : 'Edit'}
         </button>
-        {editing && (
-          <button
-            className="px-2 py-0.5 rounded text-[10px] bg-[var(--bg-base)] text-[var(--text-muted)] border border-[var(--bg-mantle)] cursor-not-allowed opacity-50"
-            disabled
-            title="Save not available yet (writeFile API required)"
-          >
-            Save
-          </button>
-        )}
+        {/* No Save button: the panel is a read-only viewer with a local-only
+            edit/scratch mode (changes are not persisted). A disabled "Save not
+            available yet" button read as unfinished; removed (NN5-T5-ALT).
+            Finishing persistence would require relaxing the CLAUDE.md-only
+            FS_WRITE_FILE allowlist (a renderer write-power expansion) — out of
+            scope for the read-only viewer the README documents. */}
       </div>
 
       {/* Body */}

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -31,6 +31,7 @@ import type { SessionData, PaneLeaf, Pane, Surface, Workspace } from '../../../s
 import { FIRST_RUN_REOPEN_EVENT } from '../../../shared/firstRun';
 import { isFileDrag } from '../../../shared/dragDrop';
 import { terminalRegistry } from '../../hooks/useTerminal';
+import { resolvePtyIdsToClear } from '../../hooks/reconcileWithReQuery';
 import { withDefaultShell } from '../../utils/ptyCreateOptions';
 import { serializeTerminalBuffer } from '../../utils/scrollbackDump';
 import { pastePtyChunked } from '../../utils/clipboardChunk';
@@ -442,7 +443,15 @@ export default function AppLayout() {
         // is now responsible for calling pty.reconnect AFTER its
         // pty.onData listener is registered, so the SessionPipe replay
         // always lands on an attached listener.
-        const reconcile = (pane: Pane, wsId: string) => {
+        // RCA A1/A9 — collect candidate ptyIds (present in the store but
+        // ABSENT from the first NON-EMPTY daemon snapshot) WITHOUT clearing.
+        // Live ptyIds stay in place (useTerminal mount reconnects). The
+        // partial-list case is the still-open hole the empty-list guard above
+        // does not cover: a single snapshot can be partial (daemon
+        // mid-rehydrate), so clearing on the first cycle could destroy a live
+        // session. We defer the destructive decision to a 2-strike re-query.
+        const absentCandidates: { paneId: string; surfaceId: string; ptyId: string }[] = [];
+        const collect = (pane: Pane) => {
           if (signal?.aborted) return;
           if (pane.type === 'leaf') {
             for (const surface of pane.surfaces) {
@@ -456,21 +465,13 @@ export default function AppLayout() {
                 console.log(`[AppLayout] Surface ${surface.id}: ptyId ${surface.ptyId} alive in daemon, Terminal will reconnect on mount`);
                 // Leave ptyId in place. useTerminal mount reconnects.
               } else {
-                // RCA A8 — this is a destructive decision (live ptyId → ''),
-                // logged at warn so it lands in the main log file (mirrored via
-                // the webContents console-message listener) and can be
-                // correlated with the daemon's pty.list count. Reached only
-                // when the daemon returned a NON-empty list that omits this
-                // ptyId (empty lists are preserved above), so this is a
-                // genuinely-absent session per the daemon's own snapshot.
-                console.warn(`[lifecycle] reconcile clearing ptyId=${surface.ptyId} surface=${surface.id} (absent from daemon's ${activeIds.size}-session list) → Terminal self-create`);
-                useStore.getState().updateSurfacePtyId(pane.id, surface.id, '');
+                absentCandidates.push({ paneId: pane.id, surfaceId: surface.id, ptyId: surface.ptyId });
               }
             }
           } else {
             for (const child of pane.children) {
               if (signal?.aborted) return;
-              reconcile(child, wsId);
+              collect(child);
             }
           }
         };
@@ -483,7 +484,35 @@ export default function AppLayout() {
         for (const ws of useStore.getState().workspaces) {
           if (signal?.aborted) return;
           console.log(`[AppLayout] Reconciling workspace: ${ws.name}`);
-          reconcile(ws.rootPane, ws.id);
+          collect(ws.rootPane);
+        }
+
+        // RCA A1/A9 — partial-list 2-strike guard. Before destructively
+        // clearing any live ptyId absent from the first non-empty snapshot,
+        // re-query the daemon ONCE (resolvePtyIdsToClear). It preserves
+        // everything on uncertainty (re-query fails or the run aborts) and
+        // returns only ptyIds absent from BOTH snapshots. RCA A8 — the actual
+        // clear is logged at warn so it lands in the main log file and can be
+        // correlated with the daemon's pty.list count.
+        if (absentCandidates.length > 0 && !signal?.aborted) {
+          const firstAbsent = absentCandidates.map((c) => c.ptyId);
+          const toClear = await resolvePtyIdsToClear(firstAbsent, {
+            reList: async () => {
+              const r = await ipcInvoke<{ id: string }[]>(() => window.electronAPI.pty.list());
+              return r.ok
+                ? { ok: true, ids: new Set(r.data.map((p: { id: string }) => p.id)) }
+                : { ok: false };
+            },
+            isCurrent: () => !signal?.aborted,
+            log: (level, message) => (level === 'warn' ? console.warn(message) : console.log(message)),
+          });
+          for (const c of absentCandidates) {
+            if (signal?.aborted) break;
+            if (toClear.has(c.ptyId)) {
+              console.warn(`[lifecycle] reconcile clearing ptyId=${c.ptyId} surface=${c.surfaceId} (absent from TWO daemon snapshots) → Terminal self-create`);
+              useStore.getState().updateSurfacePtyId(c.paneId, c.surfaceId, '');
+            }
+          }
         }
         console.log('[AppLayout] Reconciliation complete');
       } finally {

--- a/src/renderer/hooks/__tests__/reconcileWithReQuery.test.ts
+++ b/src/renderer/hooks/__tests__/reconcileWithReQuery.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolvePtyIdsToClear } from '../reconcileWithReQuery';
+
+// RCA A1/A9 partial-list reconcile guard. The bug: a single partial daemon
+// snapshot (mid-rehydrate) caused the reconcile to clear a live ptyId on the
+// FIRST cycle, destroying a live session. These tests lock in the 2-strike
+// contract: only clear ptyIds absent from BOTH snapshots, and PRESERVE
+// everything on any uncertainty (re-query fails/throws, or the run aborts).
+
+const noSleep = () => Promise.resolve();
+const alwaysCurrent = () => true;
+const noLog = () => { /* silent in tests */ };
+
+describe('resolvePtyIdsToClear (RCA A1/A9 partial-list 2-strike guard)', () => {
+  it('no candidates → returns empty set, never re-queries', async () => {
+    const reList = vi.fn();
+    const toClear = await resolvePtyIdsToClear([], { reList, sleep: noSleep, isCurrent: alwaysCurrent, log: noLog });
+    expect(toClear.size).toBe(0);
+    expect(reList).not.toHaveBeenCalled();
+  });
+
+  it('candidate reappears on re-query → NOT cleared (the whole point: live session survives a partial snapshot)', async () => {
+    const reList = vi.fn(async () => ({ ok: true, ids: new Set(['pty-live']) }));
+    const toClear = await resolvePtyIdsToClear(['pty-live'], { reList, sleep: noSleep, isCurrent: alwaysCurrent, log: noLog });
+    expect(reList).toHaveBeenCalledTimes(1);
+    expect(toClear.size).toBe(0);
+  });
+
+  it('candidate absent from BOTH snapshots → cleared exactly once', async () => {
+    const reList = vi.fn(async () => ({ ok: true, ids: new Set(['other-pty']) }));
+    const toClear = await resolvePtyIdsToClear(['pty-dead'], { reList, sleep: noSleep, isCurrent: alwaysCurrent, log: noLog });
+    expect(toClear.has('pty-dead')).toBe(true);
+    expect(toClear.size).toBe(1);
+  });
+
+  it('mixed — only ptyIds still absent on re-query are cleared; reappeared ones preserved', async () => {
+    const reList = vi.fn(async () => ({ ok: true, ids: new Set(['a', 'c']) })); // b,d still missing
+    const toClear = await resolvePtyIdsToClear(['a', 'b', 'c', 'd'], { reList, sleep: noSleep, isCurrent: alwaysCurrent, log: noLog });
+    expect([...toClear].sort()).toEqual(['b', 'd']);
+  });
+
+  it('re-query returns !ok → zero clears (preserve all on uncertainty)', async () => {
+    const reList = vi.fn(async () => ({ ok: false }));
+    const toClear = await resolvePtyIdsToClear(['pty-1', 'pty-2'], { reList, sleep: noSleep, isCurrent: alwaysCurrent, log: noLog });
+    expect(toClear.size).toBe(0);
+  });
+
+  it('re-query throws → zero clears (preserve all, no destructive decision on a thrown RPC)', async () => {
+    const reList = vi.fn(async () => { throw new Error('pipe not writable'); });
+    const toClear = await resolvePtyIdsToClear(['pty-1'], { reList, sleep: noSleep, isCurrent: alwaysCurrent, log: noLog });
+    expect(toClear.size).toBe(0);
+  });
+
+  it('aborted before strike 2 → zero clears, never re-queries', async () => {
+    const reList = vi.fn();
+    const toClear = await resolvePtyIdsToClear(['pty-1'], { reList, sleep: noSleep, isCurrent: () => false, log: noLog });
+    expect(toClear.size).toBe(0);
+    expect(reList).not.toHaveBeenCalled();
+  });
+
+  it('aborted DURING the backoff (between strikes) → zero clears, never re-queries', async () => {
+    const reList = vi.fn(async () => ({ ok: true, ids: new Set<string>() }));
+    let alive = true;
+    const sleep = vi.fn(async () => { alive = false; }); // torn down while backing off
+    const toClear = await resolvePtyIdsToClear(['pty-1'], { reList, sleep, isCurrent: () => alive, log: noLog });
+    expect(toClear.size).toBe(0);
+    expect(reList).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/hooks/reconcileWithReQuery.ts
+++ b/src/renderer/hooks/reconcileWithReQuery.ts
@@ -1,0 +1,97 @@
+/**
+ * RCA A1/A9 — partial-list reconcile "2-strike" guard.
+ *
+ * The empty-list case (daemon returns ZERO sessions) is already handled
+ * non-destructively by AppLayout's reconcile (preserve everything; the daemon
+ * is almost certainly mid-rehydrate). This helper closes the remaining hole:
+ * the PARTIAL-list case, where the daemon returns a NON-empty session list
+ * that happens to omit a live ptyId because the snapshot was taken mid-rehydrate
+ * (e.g. the daemon has reattached 2 of 3 sessions). The pre-fix code cleared
+ * that third surface's live ptyId on the FIRST cycle — destroying a live
+ * session, the exact class the v2.14.0 RCA flagged.
+ *
+ * Fix: before clearing any ptyId that was absent from the first non-empty
+ * snapshot, re-query the daemon ONCE after a short backoff. Only clear ptyIds
+ * that are absent from BOTH snapshots. On ANY uncertainty — the re-query RPC
+ * fails, or the view is torn down — preserve everything (return an empty set).
+ * Clearing a live ptyId is destructive; never do it on incomplete evidence.
+ *
+ * Extracted as a pure, dependency-injected function (no xterm / zustand /
+ * electron import) so the decision can be unit-tested in isolation, mirroring
+ * reconnectPtyWithRetry.ts.
+ */
+
+export interface ReListResult {
+  ok: boolean;
+  /** The set of ptyIds the daemon reports alive, when ok. */
+  ids?: Set<string>;
+}
+
+export interface ReconcileReQueryDeps {
+  /** Re-query the daemon's live session list (a second snapshot). */
+  reList: () => Promise<ReListResult>;
+  /** Sleep before the re-query. Injectable so tests don't wait real time. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Bail (preserve everything) the moment the reconcile is aborted/torn down. */
+  isCurrent?: () => boolean;
+  /** Optional structured logger. Defaults to console. */
+  log?: (level: 'warn' | 'log', message: string) => void;
+  /** Override the re-query backoff (default RECONCILE_REQUERY_BACKOFF_MS). */
+  backoffMs?: number;
+}
+
+/**
+ * Backoff before the second daemon snapshot. Kept well under
+ * RECONCILE_TIMEOUT_MS (DAEMON_RPC_TIMEOUT_MS + 5s = 15s) so one backoff plus
+ * a second pty.list round-trip still fits the reconcile budget.
+ */
+export const RECONCILE_REQUERY_BACKOFF_MS = 600;
+
+/**
+ * Given the ptyIds that were ABSENT from the first (non-empty) daemon snapshot,
+ * re-query once and return ONLY those still absent in the second snapshot — the
+ * safe-to-clear set. Returns an EMPTY set (preserve everything) if there are no
+ * candidates, the re-query fails, or the caller is no longer current.
+ */
+export async function resolvePtyIdsToClear(
+  firstAbsent: string[],
+  deps: ReconcileReQueryDeps,
+): Promise<Set<string>> {
+  const toClear = new Set<string>();
+  if (firstAbsent.length === 0) return toClear;
+
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const isCurrent = deps.isCurrent ?? (() => true);
+  const log = deps.log ?? ((level, message) => {
+    // eslint-disable-next-line no-console
+    console[level](message);
+  });
+
+  if (!isCurrent()) return toClear; // torn down before strike 2 — preserve all
+  await sleep(deps.backoffMs ?? RECONCILE_REQUERY_BACKOFF_MS);
+  if (!isCurrent()) return toClear; // torn down during backoff — preserve all
+
+  let second: ReListResult;
+  try {
+    second = await deps.reList();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log('warn', `[lifecycle] reconcile re-query threw (${msg}) — preserving ${firstAbsent.length} candidate ptyId(s), no destructive clear`);
+    return toClear; // empty = preserve all
+  }
+
+  if (!second.ok || !second.ids) {
+    log('warn', `[lifecycle] reconcile re-query failed — preserving ${firstAbsent.length} candidate ptyId(s), no destructive clear`);
+    return toClear; // empty = preserve all
+  }
+
+  const secondIds = second.ids;
+  for (const id of firstAbsent) {
+    if (!secondIds.has(id)) toClear.add(id);
+  }
+  log(
+    'warn',
+    `[lifecycle] reconcile 2-strike: ${toClear.size}/${firstAbsent.length} candidate ptyId(s) absent from BOTH daemon snapshots → clear; ${firstAbsent.length - toClear.size} reappeared on re-query → preserved`,
+  );
+  return toClear;
+}

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -21,6 +21,16 @@ import { reconnectPtyWithRetry as reconnectPtyWithRetryImpl } from './reconnectP
 const terminalRegistry = new Map<string, Terminal>();
 export { terminalRegistry };
 
+// RCA (2026-05-29 view-switch lag): when a terminal is hidden we DEFER WebGL
+// context dispose by this delay instead of tearing it down immediately. A
+// hidden terminal usually reappears within seconds (workspace switch back,
+// multiview<->single toggle); immediate dispose+reload thrashes GPU context
+// creation, which is the main source of the view-switch lag the user reported.
+// If the terminal becomes visible again before the timer fires, the dispose is
+// cancelled and the live context reused. Long-hidden panes still free their
+// context, bounding the simultaneous-context count under Chromium's ~16 limit.
+export const WEBGL_HIDDEN_DISPOSE_DELAY_MS = 10_000;
+
 // RCA A1 — reconnect-with-retry policy lives in its own module so it can be
 // unit-tested without xterm/zustand/electron. Bound to the live deps here.
 function reconnectPtyWithRetry(ptyId: string, isCurrent: () => boolean): Promise<void> {
@@ -141,6 +151,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
   const webglAddonRef = useRef<WebglAddon | null>(null);
   // loadWebgl closure ref — set by the main effect, called by visibility effect.
   const loadWebglRef = useRef<(() => void) | null>(null);
+  // Pending deferred-WebGL-dispose timer (see WEBGL_HIDDEN_DISPOSE_DELAY_MS).
+  const webglDisposeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { ptyId, isVisible = true, scrollbackFile, onFirstData, onContextMenu } = options;
   const ptyIdRef = useRef(ptyId);
   ptyIdRef.current = ptyId;
@@ -861,6 +873,10 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       removeDaemonConnectedForRestore?.();
       removeFlushListener?.();
       terminalRegistry.delete(ptyId);
+      if (webglDisposeTimerRef.current) {
+        clearTimeout(webglDisposeTimerRef.current);
+        webglDisposeTimerRef.current = null;
+      }
       webglAddonRef.current?.dispose();
       webglAddonRef.current = null;
       loadWebglRef.current = null;
@@ -907,6 +923,14 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
   // that was initialized while hidden displays at the correct size.
   useEffect(() => {
     if (isVisible) {
+      // Cancel any pending deferred WebGL dispose — the terminal is visible
+      // again (fast workspace switch / multiview<->single toggle), so reuse the
+      // still-live context instead of tearing it down and rebuilding. This is
+      // the de-thrash that removes the view-switch lag.
+      if (webglDisposeTimerRef.current) {
+        clearTimeout(webglDisposeTimerRef.current);
+        webglDisposeTimerRef.current = null;
+      }
       // Load WebGL for this terminal if not already loaded
       if (!webglAddonRef.current && loadWebglRef.current) {
         loadWebglRef.current();
@@ -926,10 +950,19 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       });
       return () => cancelAnimationFrame(id);
     } else {
-      // Dispose WebGL when hidden — free the context for other terminals
-      if (webglAddonRef.current) {
-        webglAddonRef.current.dispose();
-        webglAddonRef.current = null;
+      // DEFER WebGL dispose rather than tearing it down the instant the
+      // terminal is hidden (see WEBGL_HIDDEN_DISPOSE_DELAY_MS). A hidden
+      // terminal usually reappears within seconds; immediate dispose+reload
+      // is the view-switch lag. Only free the context if it stays hidden past
+      // the grace period, which still bounds simultaneous contexts.
+      if (webglAddonRef.current && !webglDisposeTimerRef.current) {
+        webglDisposeTimerRef.current = setTimeout(() => {
+          webglDisposeTimerRef.current = null;
+          if (webglAddonRef.current) {
+            webglAddonRef.current.dispose();
+            webglAddonRef.current = null;
+          }
+        }, WEBGL_HIDDEN_DISPOSE_DELAY_MS);
       }
     }
   }, [isVisible, fit]);

--- a/src/shared/security.ts
+++ b/src/shared/security.ts
@@ -7,6 +7,9 @@ import { execFileSync } from 'child_process';
  * grant Full control to ONLY the current user. Throws on failure (callers
  * decide whether that is fatal). Shared by the write path (secureWriteTokenFile)
  * and the re-harden path (reHardenTokenFileAcl).
+ *
+ * Backs the docs/SECURITY.md §1.2 + PROTOCOL.md §5 token-file ACL guarantee —
+ * keep the icacls argv (/inheritance:r /grant:r %USERNAME%:F) in sync with them.
  */
 function applyRestrictiveWindowsAcl(filePath: string): void {
   const icacls = `${process.env.SystemRoot || 'C:\\Windows'}\\System32\\icacls.exe`;


### PR DESCRIPTION
## What & why

Two tracks toward making wmux the **#1 AI-agent terminal for Windows** (the defensible category; "general #1 terminal" is conceded — see the strategy doc below):

1. **Launch non-negotiables** — the must-fix gaps that block a growth/launch push (funnel, signing-integrity, reliability, security-doc honesty, demo credibility).
2. **Runtime reliability/perf** — root-caused from real user dogfood logs (`bridge.log`, `main/daemon-*.log`): the hook-RPC timeout flood that froze the UI, view-switch lag, and a pane-death bug.

Strategy + work breakdown live in `plans/wmux-number-one-terminal-strategy-2026-05-29.md` and `plans/wmux-nonnegotiables-execution-plan-2026-05-29.md`.

**All 2060 tests pass. Codex-reviewed (one P2 found and fixed; re-review clean).**

---

## Part 1 — Launch non-negotiables

| Area | Change | Commit |
|---|---|---|
| **Reliability (safe-gate)** | Partial-list reconcile **2-strike guard** — re-query the daemon before destructively clearing a live ptyId absent from a non-empty snapshot; preserve on uncertainty. Closes the still-open arm of the v2.14.0 session-loss RCA (`reconcileWithReQuery.ts`, +8 tests). | `15548bb` |
| **Supply chain (safe-gate)** | Auto-updater was launching an **unverified** binary (`shell.openExternal`). Now **fail-closed**: fetch CI `update-manifest.json`, download Setup.exe, verify pinned SHA-256, then launch the local file (`verifyUpdate.ts`, +11 tests; `release.yml` publishes the manifest). | `815853c` |
| **Security docs (safe-gate)** | README claimed `RunAsNode disabled`; `forge.config.ts:178` sets it **true**. Corrected, plus full SECURITY.md/PROTOCOL.md reconciliation (token entropy 256→UUIDv4/122-bit, icacls wording, asar-integrity-off rationale, code cross-refs). | `db6c65e`, `4b4174a` |
| **Daemon resilience** | Control-pipe connect **retry + error classification** (ENOENT/ECONNREFUSED fast-fail, EPERM/ECONNRESET transient retry) — RCA A6 (`daemonConnectRetry.ts`, +8 tests). | `19afeef` |
| **Daemon resilience** | Health-probe tolerates a **busy daemon**: `daemon.ping` reports event-loop lag; thresholds 3/3s → 5/5s; a successful-but-slow ping never force-respawns — RCA A4 (+2 tests). | `66d52c7` |
| **Funnel** | `install.ps1` advertised "30-second install" but git-cloned + compiled from source. Now **downloads the prebuilt Setup.exe + verifies SHA-256** by default; build-from-source is opt-in (`-FromSource` / `WMUX_FROM_SOURCE=1`). | `b50a617` |
| **Demo credibility** | Removed the permanently-disabled "Save not available yet" EditorPanel button (read-only viewer, per README). | `3edca9d` |
| Docs | Strategy report + execution plan. | `545a5b3` |

## Part 2 — Runtime reliability/perf (user dogfood-log RCA)

| Issue | Root cause (source-verified) | Fix | Commit |
|---|---|---|---|
| **A1** UI freezes / "자꾸 터짐" | `hooks.signal` did a renderer `workspace.list` round-trip **per hook** (`sendToRenderer` 5s > bridge 2s). Tool-heavy turns + backgrounded window → ~11.6% of signals timed out; worst bursts blocked the daemon event loop → forced respawn. | 2s-TTL **cache + concurrent-coalesce + 1.5s fetch + stale-serve** (`createWorkspaceListCache`, +5 tests). Burst of N → ~1 round-trip / 2s. | `d033185` |
| **B** view-switch / multiview lag | xterm **WebGL context disposed on every hide** and reloaded on show → GPU context create/destroy thrash. | **Defer dispose 10s**; cancel on re-show (reuse live context). Long-hidden panes still freed. | `acdb7e7` |
| **A3** pane death | `SessionPipe.start()` single-shot `listen` → `EADDRINUSE` when a prior pipe hadn't released the name (reattach/reconnect). | **Retry EADDRINUSE 5×100ms backoff** (`listenOnce`). | `0d9ccfc` |
| **A2** connect-error drops | Bridge did a single connect attempt; 8 hooks dropped during a brief main-pipe restart window. | **Retry transient connect-errors** within the 2s budget; ENOENT (wmux not running) dropped fast; never double-fires. | `f947c07`, `57806e3` |
| **Observability** | Flood was only visible by hand-tallying `bridge.log`. | `HookFloodMeter`: 30s rolling summary in the main log, warns on ≥10% degraded `workspace.list` (+6 tests). | `6bfcae1` |

---

## Codex review

`codex review` of the A2 + observability diff found one **[P2]**: a reset/broken-pipe **after** the request was written still surfaced as `connect-error`, so `ECONNRESET`/`EPIPE` in the retry set could re-send a hook the server had already processed → duplicate notification. Fixed by tracking a `wrote` flag and tagging `retryable: !wrote` (`57806e3`). Re-review: *"did not find any discrete, actionable bugs in the diff."*

## Testing

- Full suite: **2060 passing (164 files), 0 failures.**
- New unit suites: `reconcileWithReQuery` (8), `verifyUpdate` (11), `daemonConnectRetry` (8/14), `DaemonRespawnController` (+2), `hooks.rpc.cache` (5), `HookFloodMeter` (6).
- `install.ps1` and `wmux-bridge.mjs` are validated via the PowerShell AST parser / `node --check` (JS-only, no vitest coverage).

## Not in this PR (owner / external / deferred)

- **Authenticode code signing** (NN2-T0/T1/T2) — needs an external code-signing cert (SignPath OSS / Azure Trusted Signing). SHA-256 pinning is the interim trust floor; SECURITY.md states signing is **not yet in place** (honest, no overclaim).
- **`install.ps1` end-to-end verification on a clean Windows VM** — AST-validated only; real install not yet exercised.
- **Font ligatures** (NN5-T1..T4) — the xterm ligatures addon may be WebGL-incompatible; needs a GUI runtime spike.
- **Funnel telemetry** (NN6) — growth instrumentation, not a launch safety gate; endpoint/retention/consent are owner decisions.
- **Daemon TCP fallback** (NN3-T6/T7), view-switch `performance.now` instrumentation, multiview WebGL-context cap — follow-ups.

## Caveats for reviewers

- The dogfood logs were from installed **v2.9.1 / 2.12.0** (older than `main`'s 2.14.0). Some symptoms may already be partly mitigated on 2.14.0; these fixes harden the current code regardless. Real validation = build this branch and re-dogfood under load, watching `bridge.log` timeout rate fall toward ~0.
- Large single PR by request; can be split by area (non-negotiables / dogfood fixes / docs) if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
