### PR TITLE
feat: cross-platform release — macOS + Linux (opt-in)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,3 +180,130 @@ jobs:
           token: ${{ secrets.WINGET_TOKEN }}
         env:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+
+  # ── macOS build leg ──────────────────────────────────────────────────────
+  # OPT-IN: runs only when the repo variable ENABLE_CROSS_PLATFORM_RELEASE is
+  # 'true'. Until then this job is skipped and a tag push behaves EXACTLY like
+  # today (Windows-only). `needs: build` means it runs AFTER the `build` job has
+  # created the GitHub Release, so this job only APPENDS assets to it — it never
+  # creates the release. A macOS failure therefore cannot block the Windows
+  # release (which already shipped in `build`). Signing/notarization is gated on
+  # the Apple secrets being present (same no-op-when-empty contract as SignPath):
+  # with no secrets, Forge produces an unsigned/un-notarized .zip/.dmg that still
+  # uploads, so the pipeline structure can be validated before certs exist.
+  macos:
+    name: Build macOS (${{ matrix.os }})
+    needs: build
+    if: vars.ENABLE_CROSS_PLATFORM_RELEASE == 'true'
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    strategy:
+      # Keep both arches building so one regressing doesn't hide the other.
+      fail-fast: false
+      matrix:
+        os: [macos-14, macos-13]   # macos-14 = Apple Silicon (arm64), macos-13 = Intel (x64)
+    env:
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APPLE_CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
+      APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+      KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Import the Developer ID Application cert into a throwaway keychain so
+      # Forge's osxSign can discover it. No-op when the cert secret is empty.
+      - name: Import Apple Developer ID certificate
+        if: env.APPLE_CERT_P12_BASE64 != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/wmux-build.keychain-db"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          printf '%s' "$APPLE_CERT_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -P "$APPLE_CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain-db
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+          rm -f "$RUNNER_TEMP/cert.p12"
+
+      # Forge signs + notarizes inside `make` only when Apple creds are present
+      # (see macSignConfig in forge.config.ts); otherwise it builds unsigned.
+      - name: Build & Make
+        run: npm run make
+        timeout-minutes: 30
+
+      # Append the .zip/.dmg to the release the `build` job already created.
+      # continue-on-error: a macOS upload hiccup must not fail the whole release.
+      - name: Upload macOS artifacts to the release
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          FILES=$(find out/make -type f \( -name '*.dmg' -o -name '*.zip' \))
+          if [ -z "$FILES" ]; then echo "No macOS artifacts found — skipping upload"; exit 0; fi
+          printf 'Uploading:\n%s\n' "$FILES"
+          # Filenames carry no spaces (wmux-<ver>-<arch>.dmg); intentional word split.
+          # shellcheck disable=SC2086
+          gh release upload "${{ github.ref_name }}" $FILES --clobber
+
+      - name: Clean up temporary keychain
+        if: always() && env.APPLE_CERT_P12_BASE64 != ''
+        shell: bash
+        run: security delete-keychain "$RUNNER_TEMP/wmux-build.keychain-db" || true
+
+  # ── Linux build leg ──────────────────────────────────────────────────────
+  # OPT-IN (same flag) + needs: build → append-only, never blocks Windows.
+  # Linux has no in-app auto-update (users update via apt/dnf or re-download the
+  # AppImage), so no manifest is published here.
+  linux:
+    name: Build Linux
+    needs: build
+    if: vars.ENABLE_CROSS_PLATFORM_RELEASE == 'true'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # build-essential + libxss1 for node-pty/Electron (matches the baseline CI);
+      # rpm + fakeroot are required by @electron-forge/maker-rpm.
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libxss1 rpm fakeroot
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build & Make
+        run: npm run make
+        timeout-minutes: 30
+
+      - name: Upload Linux artifacts to the release
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          FILES=$(find out/make -type f \( -name '*.deb' -o -name '*.rpm' -o -name '*.AppImage' \))
+          if [ -z "$FILES" ]; then echo "No Linux artifacts found — skipping upload"; exit 0; fi
+          printf 'Uploading:\n%s\n' "$FILES"
+          # shellcheck disable=SC2086
+          gh release upload "${{ github.ref_name }}" $FILES --clobber

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Hardened-runtime entitlements for the notarized macOS build.
+
+  wmux ships with the Electron `RunAsNode` fuse enabled (forge.config.ts) because
+  the detached daemon is spawned from the app binary with ELECTRON_RUN_AS_NODE=1,
+  and it loads the node-pty native addon. Under the macOS hardened runtime
+  (required for notarization, macOS 10.15+) those operations are blocked unless
+  the corresponding entitlements are granted:
+
+    - allow-jit / allow-unsigned-executable-memory: V8 JIT + the writable+
+      executable memory Node/Chromium use. Without these the renderer/daemon
+      crash on launch under hardened runtime.
+    - allow-dyld-environment-variables: ELECTRON_RUN_AS_NODE (and other ELECTRON_*
+      / NODE_* vars) are dyld-relevant env vars; hardened runtime strips them
+      unless this is set, which would break the daemon spawn handshake.
+    - disable-library-validation: lets the process load the locally-built,
+      separately-signed node-pty .node addon (and any other unbundled native
+      module) without Apple rejecting the team-id mismatch.
+
+  Keep this in sync with the RunAsNode fuse + the daemon spawn path. If RunAsNode
+  is ever disabled, revisit whether allow-dyld-environment-variables is still
+  needed. Documented alongside docs/SECURITY.md §1.4 (Fuses).
+-->
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -1,6 +1,7 @@
 import type { ForgeConfig } from '@electron-forge/shared-types';
 import { MakerSquirrel } from '@electron-forge/maker-squirrel';
 import { MakerZIP } from '@electron-forge/maker-zip';
+import { MakerDMG } from '@electron-forge/maker-dmg';
 import { MakerDeb } from '@electron-forge/maker-deb';
 import { MakerRpm } from '@electron-forge/maker-rpm';
 import { VitePlugin } from '@electron-forge/plugin-vite';
@@ -30,6 +31,37 @@ function copyDirSync(src: string, dest: string): void {
   }
 }
 
+// macOS Developer ID signing + notarization, gated on the Apple credentials
+// being present — exactly like the SignPath no-op-when-empty pattern in
+// release.yml. With no creds (local dev, or CI before the secrets are set) this
+// returns {} so Forge produces a working UNSIGNED .app/.zip/.dmg and nothing
+// changes for Windows/Linux. With all three creds present, Forge signs with the
+// Developer ID Application identity it discovers in the keychain and notarizes
+// via notarytool. Signing happens in the package phase AFTER the postPackage
+// asar repack below, so the signature covers the repacked asar (keep
+// EnableEmbeddedAsarIntegrityValidation=false). The entitlements grant the
+// hardened-runtime exceptions RunAsNode + node-pty need (see
+// build/entitlements.mac.plist).
+function macSignConfig(): Pick<NonNullable<ForgeConfig['packagerConfig']>, 'osxSign' | 'osxNotarize'> {
+  const { APPLE_TEAM_ID, APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD } = process.env;
+  if (!APPLE_TEAM_ID || !APPLE_ID || !APPLE_APP_SPECIFIC_PASSWORD) {
+    return {};
+  }
+  return {
+    osxSign: {
+      optionsForFile: () => ({
+        hardenedRuntime: true,
+        entitlements: 'build/entitlements.mac.plist',
+      }),
+    },
+    osxNotarize: {
+      appleId: APPLE_ID,
+      appleIdPassword: APPLE_APP_SPECIFIC_PASSWORD,
+      teamId: APPLE_TEAM_ID,
+    },
+  };
+}
+
 const config: ForgeConfig = {
   packagerConfig: {
     asar: {
@@ -42,6 +74,8 @@ const config: ForgeConfig = {
     // (covering Chromium / V8 / Node) is emitted automatically by
     // electron-packager next to wmux.exe, so we don't duplicate it here.
     extraResource: ['./dist/mcp-bundle', './dist/daemon-bundle', './assets/icon.ico', './assets/icon.icns', './assets/icon.png', './LICENSE', './THIRD_PARTY_NOTICES', './src/main/pty/shell-hooks'],
+    // No-op on Windows/Linux and when Apple creds are absent (see macSignConfig).
+    ...macSignConfig(),
   },
   hooks: {
     postPackage: async (_config, packageResult) => {
@@ -127,7 +161,10 @@ const config: ForgeConfig = {
         ]
       : []),
     ...(process.platform === 'darwin'
-      ? [new MakerZIP({}, ['darwin'])]
+      // MakerZIP backs the update.electronjs.org/darwin/ discovery feed and the
+      // in-app ZIP self-update (Phase E); MakerDMG is the first-install download
+      // UX (drag to /Applications). Keep BOTH.
+      ? [new MakerZIP({}, ['darwin']), new MakerDMG({}, ['darwin'])]
       : []),
     ...(process.platform === 'linux'
       ? [

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -4,6 +4,7 @@ import { MakerZIP } from '@electron-forge/maker-zip';
 import { MakerDMG } from '@electron-forge/maker-dmg';
 import { MakerDeb } from '@electron-forge/maker-deb';
 import { MakerRpm } from '@electron-forge/maker-rpm';
+import { MakerAppImage } from '@reforged/maker-appimage';
 import { VitePlugin } from '@electron-forge/plugin-vite';
 import { AutoUnpackNativesPlugin } from '@electron-forge/plugin-auto-unpack-natives';
 import { FusesPlugin } from '@electron-forge/plugin-fuses';
@@ -180,6 +181,18 @@ const config: ForgeConfig = {
               name: 'wmux',
               productName: 'wmux',
               categories: ['Utility', 'Development'],
+            },
+          }),
+          // AppImage: distro-independent single-file portable binary (like the
+          // Windows .exe). @reforged/maker-appimage is a third-party maker
+          // (no official Forge AppImage maker). Linux-guarded, so Windows/macOS
+          // builds never instantiate it.
+          new MakerAppImage({
+            options: {
+              name: 'wmux',
+              productName: 'wmux',
+              categories: ['Utility', 'Development'],
+              icon: './assets/icon.png',
             },
           }),
         ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "2.15.0",
+      "version": "2.16.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -33,6 +33,7 @@
       "devDependencies": {
         "@electron-forge/cli": "^7.11.1",
         "@electron-forge/maker-deb": "^7.11.1",
+        "@electron-forge/maker-dmg": "^7.11.2",
         "@electron-forge/maker-rpm": "^7.11.1",
         "@electron-forge/maker-squirrel": "^7.11.1",
         "@electron-forge/maker-zip": "^7.11.1",
@@ -40,6 +41,7 @@
         "@electron-forge/plugin-fuses": "^7.11.1",
         "@electron-forge/plugin-vite": "^7.11.1",
         "@electron/fuses": "^1.8.0",
+        "@electron/notarize": "^3.1.1",
         "@types/electron-squirrel-startup": "^1.0.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -566,6 +568,68 @@
         "electron-installer-debian": "^3.2.0"
       }
     },
+    "node_modules/@electron-forge/maker-dmg": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-7.11.2.tgz",
+      "integrity": "sha512-vh8/mnu3xyMbRcz3S0TV1rB7ZyGhMK60Yz2f2R+Zmj1EbAivLEq5UAvzHdB+kLttr0Dpjp2FIX4TcZ9neD4Y9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/maker-base": "7.11.2",
+        "@electron-forge/shared-types": "7.11.2",
+        "fs-extra": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      },
+      "optionalDependencies": {
+        "electron-installer-dmg": "^5.0.1"
+      }
+    },
+    "node_modules/@electron-forge/maker-dmg/node_modules/@electron-forge/maker-base": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.11.2.tgz",
+      "integrity": "sha512-9934zYu9WVdgCYQXvtS+eL1oyLagsY8JlWhZmoK8yWTYftSAydH7jb3seVpfy6n85SYmY/yjcAy2lvOTy5dUwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/shared-types": "7.11.2",
+        "fs-extra": "^10.0.0",
+        "which": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      }
+    },
+    "node_modules/@electron-forge/maker-dmg/node_modules/@electron-forge/shared-types": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.11.2.tgz",
+      "integrity": "sha512-Tcles7y74xy3jN5dEC+Pt1duJYk4c7W2xu98tjWW8RewmfKD2uHkie6I1I3yifPFZXZ/QfTlaFOOoKIQ9ENZjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/tracer": "7.11.2",
+        "@electron/packager": "^18.3.5",
+        "@electron/rebuild": "^3.7.0",
+        "listr2": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      }
+    },
+    "node_modules/@electron-forge/maker-dmg/node_modules/@electron-forge/tracer": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.11.2.tgz",
+      "integrity": "sha512-U8j5Hyj2Zt7I5PciJvPJfmEv69Gb/Da9v+k655z3Jj1cuY0UnToEJ61IhXrzlTYqo+jUKC+fgAjDJ6vltJTS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chrome-trace-event": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 14.17.5"
+      }
+    },
     "node_modules/@electron-forge/maker-rpm": {
       "version": "7.11.1",
       "resolved": "https://registry.npmjs.org/@electron-forge/maker-rpm/-/maker-rpm-7.11.1.tgz",
@@ -1003,34 +1067,17 @@
       }
     },
     "node_modules/@electron/notarize": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
-      "integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-3.1.1.tgz",
+      "integrity": "sha512-uQQSlOiJnqRkTL1wlEBAxe90nVN/Fc/hEmk0bqpKk8nKjV1if/tXLHKUPePtv9Xsx90PtZU8aidx5lAiOpjkQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.1.1",
-        "fs-extra": "^9.0.1",
+        "debug": "^4.4.0",
         "promise-retry": "^2.0.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@electron/notarize/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">= 22.12.0"
       }
     },
     "node_modules/@electron/osx-sign": {
@@ -1092,6 +1139,37 @@
       },
       "funding": {
         "url": "https://github.com/electron/packager?sponsor=1"
+      }
+    },
+    "node_modules/@electron/packager/node_modules/@electron/notarize": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
+      "integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/packager/node_modules/@electron/notarize/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@electron/packager/node_modules/fs-extra": {
@@ -3237,6 +3315,17 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/@types/appdmg": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@types/appdmg/-/appdmg-0.5.5.tgz",
+      "integrity": "sha512-G+n6DgZTZFOteITE30LnWj+HRVIGr7wMlAiLWOO02uJFWVEitaPU9JVXm9wJokkgshBawb2O1OykdcsmkkZfgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4272,6 +4361,36 @@
         "node": ">= 8"
       }
     },
+    "node_modules/appdmg": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/appdmg/-/appdmg-0.6.6.tgz",
+      "integrity": "sha512-GRmFKlCG+PWbcYF4LUNonTYmy0GjguDy6Jh9WP8mpd0T6j80XIJyXBiWlD0U+MLNhqV9Nhx49Gl9GpVToulpLg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "async": "^1.4.2",
+        "ds-store": "^0.1.5",
+        "execa": "^1.0.0",
+        "fs-temp": "^1.0.0",
+        "fs-xattr": "^0.3.0",
+        "image-size": "^0.7.4",
+        "is-my-json-valid": "^2.20.0",
+        "minimist": "^1.1.3",
+        "parse-color": "^1.0.0",
+        "path-exists": "^4.0.0",
+        "repeat-string": "^1.5.4"
+      },
+      "bin": {
+        "appdmg": "bin/appdmg.js"
+      },
+      "engines": {
+        "node": ">=8.5"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -4428,6 +4547,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -4517,6 +4644,17 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base32-encode": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.2.0.tgz",
+      "integrity": "sha512-cHFU8XeRyx0GgmoWi5qHMCVRiqU6J3MHWxVgun7jggCBUpVzm1Ir7M9dYr2whjSNc3tFeXfQ/oZjQu/4u55h9A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "to-data-view": "^1.1.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -4632,6 +4770,17 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/bplist-creator": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
+      "integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "stream-buffers": "~2.2.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -5607,6 +5756,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/ds-store": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ds-store/-/ds-store-0.1.6.tgz",
+      "integrity": "sha512-kY21M6Lz+76OS3bnCzjdsJSF7LBpLYGCVfavW8TgQD2XkcqIZ86W0y9qUDZu6fp7SIZzqosMDW2zi7zVFfv4hw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bplist-creator": "~0.0.3",
+        "macos-alias": "~0.2.5",
+        "tn1150": "^0.1.0"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -5887,6 +6049,28 @@
       "optional": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/electron-installer-dmg": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/electron-installer-dmg/-/electron-installer-dmg-5.0.1.tgz",
+      "integrity": "sha512-qOa1aAQdX57C+vzhDk3549dd/PRlNL4F8y736MTD1a43qptD+PvHY97Bo9gSf+OZ8iUWE7BrYSpk/FgLUe40EA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@types/appdmg": "^0.5.5",
+        "debug": "^4.3.2",
+        "minimist": "^1.2.7"
+      },
+      "bin": {
+        "electron-installer-dmg": "dist/electron-installer-dmg-bin.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "optionalDependencies": {
+        "appdmg": "^0.6.4"
       }
     },
     "node_modules/electron-installer-redhat": {
@@ -6236,6 +6420,14 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encode-utf8": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
+      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -7377,6 +7569,17 @@
         "node": ">= 12"
       }
     },
+    "node_modules/fmix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
+      "integrity": "sha512-Y6hyofImk9JdzU8k5INtTXX1cu8LDlePWDFU5sftm9H+zKCr5SGrVjdhkvsim646cw5zD0nADj8oHyXMZmCZ9w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "imul": "^1.0.0"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -7451,6 +7654,32 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/fs-temp": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fs-temp/-/fs-temp-1.2.1.tgz",
+      "integrity": "sha512-okTwLB7/Qsq82G6iN5zZJFsOfZtx2/pqrA7Hk/9fvy+c+eJS9CvgGXT2uNxwnI14BDY9L/jQPkaBgSvlKfSW9w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "random-path": "^0.1.0"
+      }
+    },
+    "node_modules/fs-xattr": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/fs-xattr/-/fs-xattr-0.3.1.tgz",
+      "integrity": "sha512-UVqkrEW0GfDabw4C3HOrFlxKfx0eeigfRne69FxSBdHIP8Qt5Sq6Pu3RM9KmMlkygtC4pPKkj5CiPO5USnj2GA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "!win32"
+      ],
+      "engines": {
+        "node": ">=8.6.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -7538,6 +7767,28 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-property": "^1.0.0"
+      }
     },
     "node_modules/generator-function": {
       "version": "2.0.1",
@@ -8104,6 +8355,20 @@
         "node": ">= 4"
       }
     },
+    "node_modules/image-size": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
+      "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/immer": {
       "version": "11.1.4",
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
@@ -8129,6 +8394,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imul": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
+      "integrity": "sha512-WFAgfwPLAjU66EKt6vRdTlKj4nAgIDQzh29JonLa4Bqtl6D8JrIMvWjCnx7xEjVNmP3U0fM5o8ZObk7d0f62bA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/imurmurhash": {
@@ -8486,6 +8762,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-my-ip-valid": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
+      "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/is-my-json-valid": {
+      "version": "2.20.6",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
+      "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^5.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -8541,6 +8840,14 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -8885,6 +9192,17 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/junk": {
@@ -9374,6 +9692,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/macos-alias": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.12.tgz",
+      "integrity": "sha512-yiLHa7cfJcGRFq4FrR4tMlpNHb4Vy4mWnpajlSSIFM5k4Lv8/7BbbDLzCAVogWNl0LlLhizRp1drXv0hK9h0Yw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "nan": "^2.4.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -9697,6 +10030,19 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/murmur-32": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/murmur-32/-/murmur-32-0.2.0.tgz",
+      "integrity": "sha512-ZkcWZudylwF+ir3Ld1n7gL6bI2mQAzXvSobPwVtu8aYi2sbXeipeSkdcanRLzIofLcM5F53lGaKm2dk7orBi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "encode-utf8": "^1.0.3",
+        "fmix": "^0.1.0",
+        "imul": "^1.0.0"
+      }
+    },
     "node_modules/mute-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
@@ -9718,6 +10064,14 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -10312,6 +10666,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/parse-color": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
+      "integrity": "sha512-fuDHYgFHJGbpGMgw9skY/bj3HL/Jrn4l/5rSspy00DoT4RyLnDcRvPxdZ+r6OFwIsgAuhDh4I09tAId4mI12bw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "~0.5.0"
+      }
+    },
+    "node_modules/parse-color/node_modules/color-convert": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+      "integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -10854,6 +11226,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/random-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/random-path/-/random-path-0.1.2.tgz",
+      "integrity": "sha512-4jY0yoEaQ5v9StCl5kZbNIQlg1QheIDBrdkDn53EynpPb9FgO6//p3X/tgMnrC45XN6QZCzU1Xz/+pSSsJBpRw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base32-encode": "^0.1.0 || ^1.0.0",
+        "murmur-32": "^0.1.0 || ^0.2.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -11146,6 +11530,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/require-directory": {
@@ -12078,6 +12473,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/stream-buffers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+      "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
+      "dev": true,
+      "license": "Unlicense",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -12678,6 +13084,28 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/tn1150": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tn1150/-/tn1150-0.1.0.tgz",
+      "integrity": "sha512-DbplOfQFkqG5IHcDyyrs/lkvSr3mPUVsFf/RbDppOshs22yTPnSJWEe6FkYd1txAwU/zcnR905ar2fi4kwF29w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "unorm": "^1.4.1"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/to-data-view": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
+      "integrity": "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -12990,6 +13418,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unorm": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
+      "dev": true,
+      "license": "MIT or GPL-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/unpipe": {
@@ -14107,6 +14546,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@electron-forge/plugin-vite": "^7.11.1",
         "@electron/fuses": "^1.8.0",
         "@electron/notarize": "^3.1.1",
+        "@reforged/maker-appimage": "^5.2.0",
         "@types/electron-squirrel-startup": "^1.0.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -2634,6 +2635,37 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@reforged/maker-appimage": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@reforged/maker-appimage/-/maker-appimage-5.2.0.tgz",
+      "integrity": "sha512-5u7spsDMyMfwqAnTRsSipVgTIy+DW+wlfhceaRghCuTvyY8Sti8/tFhVKj4vb+dYTqPvS7m30Gl0InGv22J8RQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@electron-forge/maker-base": "^6.0.0 || ^7.0.0",
+        "@reforged/maker-types": "^2.1.0",
+        "@spacingbat3/lss": "^1.0.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=19.0.0 || ^18.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/SpacingBat3/ReForged?sponsor=1"
+      }
+    },
+    "node_modules/@reforged/maker-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@reforged/maker-types/-/maker-types-2.1.0.tgz",
+      "integrity": "sha512-gNMAFO6mxqGwuUov0CzXGTHUMfAawlM6v/uYrqVnKeMwmceaLBt3HtfPcuNapDSH4br6D4EZ14WuWbgefmDfOQ==",
+      "dev": true,
+      "license": "ISC",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/SpacingBat3/ReForged?sponsor=1"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.10",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
@@ -3265,6 +3297,13 @@
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
+    },
+    "node_modules/@spacingbat3/lss": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@spacingbat3/lss/-/lss-1.2.0.tgz",
+      "integrity": "sha512-aywhxHNb6l7COooF3m439eT/6QN8E/RSl5IVboSKthMHcp0GlZYMSoS7546rqDLmFRxTD8f1tu/NIS9vtDwYAg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@electron-forge/plugin-vite": "^7.11.1",
     "@electron/fuses": "^1.8.0",
     "@electron/notarize": "^3.1.1",
+    "@reforged/maker-appimage": "^5.2.0",
     "@types/electron-squirrel-startup": "^1.0.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@electron-forge/cli": "^7.11.1",
     "@electron-forge/maker-deb": "^7.11.1",
+    "@electron-forge/maker-dmg": "^7.11.2",
     "@electron-forge/maker-rpm": "^7.11.1",
     "@electron-forge/maker-squirrel": "^7.11.1",
     "@electron-forge/maker-zip": "^7.11.1",
@@ -55,6 +56,7 @@
     "@electron-forge/plugin-fuses": "^7.11.1",
     "@electron-forge/plugin-vite": "^7.11.1",
     "@electron/fuses": "^1.8.0",
+    "@electron/notarize": "^3.1.1",
     "@types/electron-squirrel-startup": "^1.0.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/plans/cross-platform-release.md
+++ b/plans/cross-platform-release.md
@@ -1,0 +1,314 @@
+# Cross-Platform Release Plan (macOS + Linux)
+
+Status: DRAFT — awaiting user confirmation before implementation
+Date: 2026-05-31
+Base: main @ v2.16.0
+Decision inputs: user (macOS + Linux simultaneously, plan-first), Apple Developer account available.
+Validation: multi-agent workflow `xplat-understand-design` (9 agents) — 5-area map + 2 design
+decisions, each adversarially reviewed by a skeptic agent (both verdicts: "risky" with concrete
+fixes, folded into this plan). Cross-checked against direct reads of AutoUpdater.ts,
+verifyUpdate.ts, forge.config.ts, release.yml, ci-cross-platform-baseline.yml, install.ps1,
+package.json.
+
+---
+
+## 0. Headline decisions
+
+1. **Single repo.** wmux is Electron 41 + node-pty. Keep one codebase; branch builds per-OS.
+   Splitting the repo buys nothing and creates 3-way fork drift. The repo is ALREADY built for
+   this: `src/shared/platform.ts` (`platformChoice<T>`), `forge.config.ts` per-OS maker guards,
+   3-OS CI baseline. The only thing that should live in its own repo is the future Homebrew tap.
+
+2. **Auto-updater = Option C** (extend the existing custom updater; do NOT migrate to
+   electron-updater or a hosted feed). The electron `autoUpdater` import is dead code; the real
+   flow is a custom SHA-256-pinned `net.request` + `shell.openPath` pipeline that is already
+   platform-portable. Add a `darwin` branch (ZIP self-update, after signing); **Linux has NO
+   in-app auto-update in v1 — no check, no notification** (user-decided). Linux users update via
+   their package manager (apt/dnf) or by re-downloading the AppImage. AutoUpdater is fully inert
+   on Linux.
+
+3. **Release pipeline = per-OS jobs, but Windows ALWAYS ships.** Reject any `needs:[win,mac,linux]`
+   hard gate. macOS/Linux build legs are opt-in (`vars.ENABLE_CROSS_PLATFORM_RELEASE`) and
+   best-effort; a macOS/Linux build failure must never block the Windows release.
+
+4. **Integrity pin is non-negotiable.** The NN2-T4 SHA-256 manifest pin (verifyUpdate.ts) stays on
+   every platform path. This is why Option B (hosted feed, can't carry a hash) is rejected.
+
+5. **macOS signing is the real critical path** and gates the in-app macOS updater. Until Apple
+   creds + notarization + hardened-runtime entitlements are green, the darwin updater stays
+   notify-only (same as Linux).
+
+---
+
+## 1. Confirmed current state (from map + direct reads)
+
+### Auto-updater (`src/main/updater/`)
+- `AutoUpdater.ts:20` — `UPDATE_SERVER` hardcodes `update.electronjs.org/<repo>/win32/<ver>`.
+- `AutoUpdater.ts:170` — temp installer name hardcodes `.Setup.exe`.
+- `AutoUpdater.ts:257` — install = `shell.openPath(tempPath)` (cross-platform call, win-shaped arg).
+- `AutoUpdater.ts:11` — electron `autoUpdater` is imported but **never called** (dead). The custom
+  net.request flow exists because Squirrel's .NET updater is broken vs GitHub 302/TLS (documented
+  AutoUpdater.ts:7-8). DO NOT wire electron autoUpdater in.
+- `verifyUpdate.ts` — pure, fail-closed, unit-tested. `UpdateManifest = {version,setupExe,sha256,url}`
+  (Windows-shaped field names). `isAllowedDownloadUrl` = github.com only (DMG/ZIP are GH assets too,
+  so no allowlist change needed).
+- `AutoUpdater` has **zero** `process.platform` branching and **zero** platform mock tests today.
+- Consumers of `update-manifest.json`: in-app AutoUpdater AND `install.ps1:228-232` (reads
+  top-level `.sha256`; graceful-skips if absent). Chocolatey uses its own injected checksum (safe).
+
+### CI / Release
+- `release.yml` — single `runs-on: windows-latest` job: Build&Make → SignPath (env-gated no-op) →
+  checksum → write `update-manifest.json` → GitHub Release → Choco → winget. 100% PowerShell.
+- `ci.yml` — windows-only PR gate (tsc/test/lint, no build).
+- `ci-cross-platform-baseline.yml` — 3-OS matrix (windows-latest, macos-14, ubuntu-22.04), runs
+  `npm ci` + tsc + eslint + **full vitest**, but **NOT `npm run make`** → packaging is unverified
+  on mac/linux. Informational, fail-fast:false, NOT a release gate. Linux installs build-essential
+  + libxss1; macOS verifies Xcode CLT.
+
+### Build / packaging (`forge.config.ts`, `package.json`)
+- Makers per-OS guarded: win→Squirrel, darwin→`MakerZIP(['darwin'])` ONLY, linux→Deb+Rpm.
+- `package.json` has maker-squirrel/zip/deb/rpm; **missing `@electron-forge/maker-dmg`,
+  `@electron/notarize`, any AppImage maker.**
+- `packagerConfig` has **no** `osxSign`/`osxNotarize`. No entitlements plist anywhere.
+- `postPackage` hook (46-111) runs unconditionally: extracts+repacks asar to inject node-pty
+  (changes asar hash); `.ps1` cleanup is win32-guarded.
+- Fuses: `RunAsNode=true` (daemon spawns via `ELECTRON_RUN_AS_NODE=1`),
+  `EnableEmbeddedAsarIntegrityValidation=false` (because repack changes the hash),
+  `OnlyLoadAppFromAsar=true`.
+- Icons: `assets/icon.{ico,icns,png,svg}` all present; `createWindow.ts` already uses
+  `platformChoice` for the icon extension.
+- Electron 41.0.3 → SMAppService available (Phase 1.7 autostart research conclusion holds).
+
+### Phase 1 code residuals (Unix correctness gaps)
+- **No `autostart.ts`** / no `app.setLoginItemSettings`. Windows uses registry (index.ts:99-121);
+  macOS (LaunchAgent / `setLoginItemSettings`) + Linux (`~/.config/autostart/*.desktop`) absent.
+- **PTY spawn has no try/catch**: `DaemonSessionManager.ts:139`, `PTYManager.ts:155` call
+  `pty.spawn()` raw. `MACOS_ERRORS.nodePtyBuildFailed` is defined but never surfaced.
+- `src/shared/errors/macos.ts` — 5 templates; only `mcpPermissionDenied` is wired (McpRegistrar.ts).
+  `gatekeeperBlocked`, `nodePtyBuildFailed`, `brewTapNotFound`, `playwrightChromiumQuarantine`
+  defined but never thrown.
+- **Shell integration**: `shell-integration.ts` integrates pwsh + bash only; zsh/fish marked "v3
+  roadmap". `PTYManager.detectShellType()` returns 'unknown' for zsh/fish. → macOS default zsh
+  users get NO OSC 133 prompt markers (agent.lifecycle / awaiting_input degraded on macOS).
+- `metadata.handler.ts:58` — `/proc/PID/cwd` is Linux-only; macOS has no live-CWD fallback.
+- `PTYManager.getDefaultShell()` trusts `$SHELL` without bash-path resolution (DaemonSessionManager
+  does resolve). `claudeCredential.ts` handles darwin Keychain / win / linux-JSON (documented; Linux
+  has no libsecret — acceptable).
+
+### Tests
+- 164 test files; baseline runs full vitest on 3 OSes. Most platform logic uses `vi` platform mocks
+  (ShellDetector/ToastManager are exemplars) → cross-platform safe.
+- **CORRECTION (verified 2026-05-31):** the 3-OS `ci-cross-platform-baseline` is ALREADY GREEN —
+  last 5 runs on main + feature branches all `success`. The map agent's "pwshHook.test.ts will
+  ENOENT-fail on mac/linux" was WRONG: `src/main/pty/shell-hooks/pwsh.ps1` is a checked-in source
+  file present after checkout on every OS, and vitest runs from repo root, so the test PASSES
+  cross-platform. The CI header's "first runs expected to fail (45 win32 branches)" is stale — those
+  unix branches now pass tsc+eslint+vitest. ⇒ **A3 skip guard is NOT needed.** Only `npm run make`
+  (packaging) and runtime remain unverified on mac/linux.
+
+---
+
+## 2. Design decision 1 — Auto-updater cross-platform path
+
+**Chosen: Option C** — extend the existing custom updater behind a `platformChoice` seam.
+Win32 arm stays byte-for-byte identical. macOS adds a `darwin` branch. Linux = notify-only v1.
+
+Rejected: A (electron-updater/NSIS — max blast radius on the only shipping platform, drops the SHA
+pin, breaks Squirrel/Choco/winget/SignPath). B (hosted feed — can't carry the hash field, regresses
+the NN2-T4 supply-chain pin, risks resurrecting the broken Squirrel-on-GitHub updater on Windows).
+
+### Skeptic-mandated corrections (folded in)
+- **C-FIX-1 (feed semantics):** `update.electronjs.org/darwin/` only recognizes a **`.zip`** asset
+  named `*-mac/-darwin/-osx` — it does NOT serve `.dmg`. So: treat the `/darwin/` feed as a
+  **version-discovery ping** backed by a published `-mac.zip` (keep `MakerZIP`, ADD `MakerDMG` — do
+  not replace). The integrity-pinned self-update artifact is the **ZIP** (electron-idiomatic: the
+  app bundle drops straight into /Applications and supports relaunch). DMG is for first-install
+  download UX only. Do NOT describe the feed as "serving the DMG".
+- **C-FIX-2 (relaunch semantics):** DMG mount does not install or relaunch. The ZIP self-update path
+  must define relaunch behavior; the `beforeunload`/session-save dance (AutoUpdater.ts:225-240)
+  assumes installer-replaces-then-relaunches and is wrong for a bare mount — guard/skip it on darwin
+  for the v1 notify-only stage.
+- **C-FIX-3 (entitlements):** `RunAsNode=true` + notarization REQUIRES hardened runtime with
+  entitlements (`com.apple.security.cs.allow-jit`,
+  `com.apple.security.cs.allow-unsigned-executable-memory`,
+  `com.apple.security.cs.disable-library-validation` as needed for `ELECTRON_RUN_AS_NODE` daemon
+  spawn). Without the entitlements plist a notarized build will fail to spawn the daemon at runtime.
+  This is a hard prerequisite, not optional.
+- **C-FIX-4 (manifest back-compat):** evolving the manifest to a per-platform map MUST keep the
+  legacy top-level `{version,setupExe,sha256,url}` as a win32 alias for ≥1 release, because BOTH
+  older in-app clients AND `install.ps1:232` read top-level `.sha256`. Update install.ps1 in
+  lockstep + add a release-time assertion that the manifest parses under both readers.
+- **C-FIX-5 (TDD first):** AutoUpdater has no platform tests. Write the `process.platform` mock test
+  asserting win32 resolves the byte-identical URL+filename BEFORE introducing `platformChoice`.
+
+### Manifest schema (target, additive)
+```jsonc
+{
+  "version": "x.y.z",
+  // legacy win32 alias — keep for ≥1 release (in-app old clients + install.ps1)
+  "setupExe": "wmux-x.y.z.Setup.exe",
+  "sha256": "<win32 setup.exe sha256>",
+  "url": "https://github.com/.../wmux-x.y.z.Setup.exe",
+  "platforms": {
+    "win32":  { "file": "...Setup.exe", "sha256": "...", "url": "..." },
+    "darwin": { "file": "wmux-x.y.z-mac.zip", "sha256": "...", "url": "..." }
+    // no linux entry — notify-only, package-manager-owned
+  }
+}
+```
+
+---
+
+## 3. Design decision 2 — release.yml restructure
+
+**Chosen: per-OS jobs, Windows self-contained + always-ships.** NOT a hard coordinator gate.
+
+### Skeptic-mandated corrections (folded in)
+- **R-FIX-1 (no hard gate — FATAL otherwise):** Keep the GitHub Release **created inside the
+  `windows` job** exactly as today. macOS/Linux jobs **append** their assets via
+  `gh release upload v$VERSION <files> --clobber` with `continue-on-error: true`. Windows ships even
+  if cross-platform builds fail. (Alternative: a coordinator `needs:[windows]` only — but
+  append-from-each-OS keeps the Windows job a byte-for-byte superset of today, lowest risk.)
+- **R-FIX-2 (opt-in flag):** `macos`/`linux` jobs run only `if: vars.ENABLE_CROSS_PLATFORM_RELEASE
+  == 'true'`. Until flipped, tag push behaves exactly like today (Windows-only). Mirrors the
+  SignPath/CHOCO/WINGET no-op-when-empty pattern.
+- **R-FIX-3 (sequencing):** Land forge maker plumbing (§4 Phase B/C) and prove `npm run make` emits
+  darwin/linux artifacts on a throwaway fork tag BEFORE flipping the flag. Use
+  `if-no-files-found: warn` (not `error`) on mac/linux uploads during transition.
+- **R-FIX-4 (winget ordering):** winget-releaser reads the GH Release by version. Since it must run
+  AFTER the release exists and the Windows job creates the release, winget stays in the `windows`
+  job AFTER the create-release step (unchanged from today). `choco push` → push.chocolatey.org (no
+  release dependency) stays in `windows`.
+- **R-FIX-5 (updater correctness on multi-OS release — do FIRST, see Phase A):** A Windows-only
+  manifest on a release that now carries mac/linux assets makes a macOS client download+launch a
+  `.Setup.exe`. Ship the AutoUpdater `process.platform !== 'win32'` early-return (Phase A) BEFORE
+  any mac/linux asset reaches a release.
+- **R-FIX-6 (notarization latency/flake):** osxNotarize calls Apple's notary service synchronously
+  inside `npm run make`; set a generous job timeout and treat notary failure as `continue-on-error`
+  on the macOS leg so an Apple outage can't block the (decoupled) Windows release.
+
+### Job shape
+```
+job windows  (runs-on: windows-latest)  — TODAY's job, UNCHANGED (incl. Create Release, Choco, winget)
+job macos    (if ENABLE; matrix: macos-14 arm64, macos-13 x64) — make, keychain import (env-gated),
+             sign+notarize (env-gated), then `gh release upload --clobber` (continue-on-error)
+job linux    (if ENABLE; ubuntu-22.04) — apt deps (+rpm,fakeroot), make, `gh release upload` (c-o-e)
+```
+
+---
+
+## 4. Implementation phases & PR sequence
+
+Ordering is dependency-driven. **Branch + PR per phase** (cross-platform branch policy: feature
+branch, CI green before main, avoid main-fail mail noise).
+
+### Phase A — Updater safety guards (Windows-only risk: ZERO) — **PR1**
+- A1. `AutoUpdater`: introduce `isUpdaterSupported = process.platform === 'win32'` (darwin added in
+  Phase E once signed). On non-win32: register IPC handlers for UI consistency but DO NOT schedule
+  the auto-check timer, `UPDATE_CHECK` returns `not-available`, `UPDATE_INSTALL` is a no-op (log
+  only). Guarantees macOS/Linux clients NEVER download/launch a `.Setup.exe` even once multi-OS
+  assets land on the release. win32 path is byte-identical (flag is true → existing flow). (R-FIX-5)
+  Linux stays fully inert permanently (user decision); darwin flips on in Phase E.
+- A2. Add `AutoUpdater` platform mock test (electron mocked, vi platform mock à la ToastManager):
+  win32 → timer scheduled + check runs + UPDATE_SERVER is byte-identical
+  `update.electronjs.org/<repo>/win32/<ver>`; darwin/linux → no timer, check=not-available,
+  install=no-op. (C-FIX-5 — TDD invariant before the Phase E platformChoice refactor.)
+- ~~A3. pwshHook.test.ts skip guard~~ — DROPPED. Verified 2026-05-31: baseline is already green;
+  pwsh.ps1 is checked in and the test passes on all OSes. No fix needed.
+- Net: hardens Windows (no behavior change on win32). Shippable alone. The 3-OS suite is already
+  green, so this only ADDS the new AutoUpdater platform test.
+
+### Phase B — macOS build/sign plumbing (forge) — **PR2**
+- B1. devDeps: `@electron-forge/maker-dmg`, `@electron/notarize`.
+- B2. `forge.config.ts` darwin arm: keep `MakerZIP(['darwin'])` (feed + self-update artifact), ADD
+  `MakerDMG` (first-install UX). (C-FIX-1)
+- B3. `packagerConfig.osxSign` + `osxNotarize`, both built only when `process.env.APPLE_TEAM_ID` /
+  `APPLE_ID` present (no-op otherwise — unsigned local builds still work).
+- B4. **`build/entitlements.mac.plist`** with hardened-runtime + RunAsNode entitlements; wire into
+  osxSign. (C-FIX-3) ← do not skip.
+- B5. Verify signing runs AFTER postPackage asar repack (Forge package phase is post-postPackage →
+  correct; assert, don't enable asar integrity).
+- Verify on a fork throwaway tag before relying on it.
+
+### Phase C — Linux build plumbing — **PR3**
+- C1. AppImage: evaluate `@reforged/maker-appimage` (no official Forge AppImage maker). If included,
+  add maker; else deb/rpm only for v1 (acceptable).
+- C2. Linux release deps: `rpm`, `fakeroot` (rpm maker needs them) on top of build-essential+libxss1.
+- Verify `npm run make` emits .deb/.rpm(/.AppImage) on ubuntu fork tag.
+
+### Phase D — release.yml restructure (HIGH CARE) — **PR4**
+- D1. Keep `windows` job byte-for-byte (incl. Create Release, Choco, winget). Add job-level Apple
+  secret env block (no-op when empty).
+- D2. Add `macos` job (2-arch matrix, env-gated keychain import + sign/notarize, `gh release upload
+  --clobber` continue-on-error, `if: always()` keychain cleanup, `if: vars.ENABLE_...`). (R-FIX-1/2/6)
+- D3. Add `linux` job (apt deps, make, upload append). (R-FIX-1/2)
+- D4. Per-platform manifest: extend the Windows "Write update manifest" step to emit `platforms.win32`
+  + keep top-level alias; merge darwin zip sha256 (computed in macos job, passed as job output) only
+  once macOS signing is green. Until then manifest stays win32-only. (C-FIX-4)
+- D5. Add `ci-cross-platform-baseline` `npm run make` smoke on macos-14 + ubuntu (make it a gate for
+  updater/forge files). (closes the "packaging unverified" gap)
+
+### Phase E — macOS in-app updater darwin branch (AFTER signing green) — **PR5**
+- E1. Evolve `verifyUpdate.UpdateManifest` to per-platform map + `validateManifestForPlatform`,
+  keep legacy top-level alias + tests. Update `install.ps1` lockstep. (C-FIX-4)
+- E2. `AutoUpdater` UPDATE_SERVER / temp filename via `platformChoice` (win32 arm byte-identical,
+  enforced by A2 test).
+- E3. darwin self-update = download+pin the **ZIP**, replace app bundle, define relaunch; DMG is
+  download-only. Guard the beforeunload/session-save flow appropriately. (C-FIX-1/2)
+- E4. Wire `MACOS_ERRORS.gatekeeperBlocked` into the darwin install-failure catch.
+- Flip darwin from notify-only → real self-update only when notarized build + daemon-spawn smoke pass.
+
+### Phase F — Phase 1 code completeness (parallelizable) — **PR6+**
+- F1. PTY spawn try/catch → surface `nodePtyBuildFailed` (DaemonSessionManager.ts:139,
+  PTYManager.ts:155). Keep error handling daemon-local (don't make process.on('error') global).
+- F2. Wire remaining `macos.ts` errors at their catch sites.
+- F3. **zsh shell integration** (macOS default) — OSC 133 markers for zsh; extend
+  `detectShellType` + `buildHookInjection` + `shell-integration.ts`. Higher value than autostart;
+  own batch (touches the OSC 133 handshake — reuse the SampleTaskRunner mangle-guard learnings).
+- F4. `autostart.ts`: `app.setLoginItemSettings({openAtLogin})` (mac) + `~/.config/autostart/
+  wmux.desktop` (linux); keep Windows registry path guarded.
+- F5. `metadata.handler` macOS live-CWD fallback (no /proc on macOS).
+
+### Phase G — docs/marketing drift — **PRn**
+- README/package.json description say "cmux for Windows" / keyword "windows" — update at macOS GA.
+- Add docs/MACOS.md + docs/LINUX.md (Phase 2/3 backlog from the 16-week plan).
+
+### User-provided (out of band, blocks Phase D macOS leg going live)
+- GitHub repo secrets: `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`,
+  `APPLE_CERT_P12_BASE64`, `APPLE_CERT_PASSWORD`, `KEYCHAIN_PASSWORD`.
+- Decide AppImage in/out for v1.
+- (Later) Homebrew tap repo + PAT for `brew install`.
+
+---
+
+## 5. Windows regression invariants (must hold across every PR)
+1. `AutoUpdater` win32 UPDATE_SERVER == `https://update.electronjs.org/openwong2kim/wmux/win32/<ver>`
+   character-identical (A2 test enforces).
+2. win32 temp installer name stays `wmux-update-<ver>-<pid>.Setup.exe`.
+3. `verifyUpdate.validateManifest` keeps accepting the legacy top-level shape (install.ps1 + old
+   clients) for ≥1 release.
+4. `windows` release job byte-for-byte: Build&Make, SignPath env-gating (release.yml:12-21,42,50,63),
+   checksum AFTER signed-replace, manifest, Choco, winget regex `\.Setup\.exe$`. No matrix
+   conditionals inside it.
+5. `forge.config.ts`: SQUIRREL_SETUP_EXE name, win32 `.ps1` cleanup guard, asar repack, Fuses
+   (RunAsNode true, asar-integrity false) all unchanged. maker-dmg additive only.
+6. `index.ts:84-146` Squirrel events + HKCU Run registry remain reachable, unchanged; mac/linux
+   autostart is additive behind its own guard.
+7. Choco/winget stay `continue-on-error` — never fail the release.
+8. Manual Windows lifecycle re-test before any updater/release merge: install (shortcuts + Run key)
+   → in-app update (win32 feed → manifest → SHA match → openPath → relaunch) → uninstall.
+
+## 6. Verification strategy
+- Unit: AutoUpdater platform mock (A2), manifest dual-reader (E1), per-platform validate.
+- CI: 3-OS baseline + `npm run make` smoke (D5) as a gate for forge/updater files.
+- Dynamic: fork throwaway tag to exercise the macos/linux release legs before flipping
+  `ENABLE_CROSS_PLATFORM_RELEASE` (no main-fail mail noise).
+- macOS runtime smoke: notarized build must spawn the daemon (proves entitlements correct) before
+  darwin updater goes from notify-only → real.
+- User dogfood gate before any ship (no PR/release proposal until user verifies).
+
+## 7. Open questions for the user
+- AppImage for Linux v1, or deb/rpm only?
+- macOS distribution: DMG (drag-to-Applications) as the primary download + ZIP for self-update, or
+  ZIP only?
+- Linux auto-update philosophy v1: notify-only + "copy this apt/dnf command" — confirmed acceptable?

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -135,15 +135,25 @@ export class DaemonSessionManager extends EventEmitter {
       console.warn('[DaemonSessionManager] shell integration unavailable:', err);
     }
 
-    // Spawn ConPTY
-    const ptyProcess = pty.spawn(cmd, spawnArgs, {
-      name: 'xterm-256color',
-      cols,
-      rows,
-      cwd,
-      env,
-      useConpty: true,
-    });
+    // Spawn the PTY. node-pty throws synchronously on a missing/invalid shell
+    // binary or an unreadable cwd — common on macOS/Linux where the resolved
+    // shell path differs from Windows. Surface an actionable message instead of
+    // letting the raw node-pty error propagate as an opaque session-create
+    // failure. (useConpty is a Windows-only hint; node-pty ignores it elsewhere.)
+    let ptyProcess: IPty;
+    try {
+      ptyProcess = pty.spawn(cmd, spawnArgs, {
+        name: 'xterm-256color',
+        cols,
+        rows,
+        cwd,
+        env,
+        useConpty: true,
+      });
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to start shell "${cmd}" in "${cwd}": ${detail}`);
+    }
 
     const now = new Date().toISOString();
     const meta: DaemonSession = {

--- a/src/main/pty/PTYManager.ts
+++ b/src/main/pty/PTYManager.ts
@@ -152,14 +152,24 @@ export class PTYManager {
     const shellType = this.detectShellType(shell);
     const hookInjection = this.buildHookInjection(shellType, env);
 
-    const ptyProcess = pty.spawn(shell, hookInjection.args, {
-      name: 'xterm-256color',
-      cols: options?.cols || 80,
-      rows: options?.rows || 24,
-      cwd,
-      env: hookInjection.env,
-      useConpty: true,
-    });
+    // node-pty throws synchronously on a missing/invalid shell binary or an
+    // unreadable cwd (common on macOS/Linux where the shell path differs from
+    // Windows). Surface an actionable error instead of the raw node-pty throw.
+    // (useConpty is a Windows-only hint; node-pty ignores it elsewhere.)
+    let ptyProcess: ReturnType<typeof pty.spawn>;
+    try {
+      ptyProcess = pty.spawn(shell, hookInjection.args, {
+        name: 'xterm-256color',
+        cols: options?.cols || 80,
+        rows: options?.rows || 24,
+        cwd,
+        env: hookInjection.env,
+        useConpty: true,
+      });
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to start shell "${shell}" in "${cwd}": ${detail}`);
+    }
 
     const instance: PTYInstance = {
       id,

--- a/src/main/updater/AutoUpdater.ts
+++ b/src/main/updater/AutoUpdater.ts
@@ -26,6 +26,15 @@ const MANIFEST_URL = `https://github.com/${REPO}/releases/latest/download/update
 // 업데이트 자동 확인 간격 (30분)
 const CHECK_INTERVAL_MS = 30 * 60 * 1000;
 
+// In-app auto-update is Windows-only today. The update-server URL (line above),
+// the temp installer filename, and the launch verb in this class are all
+// Squirrel.Windows-shaped: macOS gains a signed-ZIP self-update path in a later
+// phase, and Linux updates via the system package manager (no in-app updater).
+// Gate every network/install action on this constant so a macOS/Linux client can
+// NEVER fetch a manifest, download, or launch a Windows `.Setup.exe` — not even
+// once all three OSes share a single GitHub release's assets.
+const isUpdaterSupported = process.platform === 'win32';
+
 interface UpdateInfo {
   name: string;
   notes: string;
@@ -44,9 +53,17 @@ export class AutoUpdater {
   }
 
   start(): void {
+    // Register IPC handlers on every platform so the renderer's "check for
+    // updates" UI resolves cleanly (it gets a not-available reply off win32),
+    // but only schedule background checks on a supported platform.
     this.registerIpcHandlers();
 
     if (process.env.NODE_ENV === 'development') {
+      return;
+    }
+
+    if (!isUpdaterSupported) {
+      console.log(`[AutoUpdater] In-app updates are not supported on ${process.platform}; skipping auto-check (update via your package manager).`);
       return;
     }
 
@@ -73,6 +90,9 @@ export class AutoUpdater {
   }
 
   private async check(): Promise<void> {
+    // Defense in depth: never poll the win32-only update feed off Windows, even
+    // if a caller invokes check() directly.
+    if (!isUpdaterSupported) return;
     if (!this.enabled || this.isChecking) return;
     this.isChecking = true;
     this.sendToRenderer(IPC.UPDATE_CHECK, { status: 'checking' });
@@ -214,7 +234,7 @@ export class AutoUpdater {
     });
 
     ipcMain.handle(IPC.UPDATE_CHECK, async () => {
-      if (process.env.NODE_ENV === 'development') {
+      if (process.env.NODE_ENV === 'development' || !isUpdaterSupported) {
         return { status: 'not-available' };
       }
       // Don't await — fire and forget, results come via IPC events
@@ -223,6 +243,13 @@ export class AutoUpdater {
     });
 
     ipcMain.handle(IPC.UPDATE_INSTALL, async () => {
+      if (!isUpdaterSupported) {
+        // No in-app installer on this platform — never download/launch a
+        // Windows .Setup.exe on macOS/Linux. The win32 install path below is
+        // unreachable here.
+        console.log(`[AutoUpdater] UPDATE_INSTALL ignored on ${process.platform} — no in-app installer for this platform.`);
+        return;
+      }
       const pending = this.pendingUpdate;
       if (!pending) return;
 

--- a/src/main/updater/__tests__/AutoUpdater.platform.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.platform.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Phase A (cross-platform) — platform invariants for AutoUpdater.
+ *
+ * The in-app updater is Windows-only today: the feed URL, the temp installer
+ * filename, and the launch verb are all Squirrel.Windows-shaped. This suite
+ * pins two invariants BEFORE the later (Phase E) platformChoice refactor:
+ *
+ *   1. win32 is byte-for-byte unchanged — start() schedules a check that hits
+ *      the EXACT update.electronjs.org/<repo>/win32/<version> feed URL.
+ *   2. off win32 the updater is inert — no auto-check timer, UPDATE_CHECK
+ *      resolves not-available, and UPDATE_INSTALL never touches the network
+ *      (so a macOS/Linux client can never download/launch a .Setup.exe even
+ *      when all OSes share one GitHub release's assets).
+ *
+ * AutoUpdater is electron-heavy, so we mock 'electron' and re-import the module
+ * per platform (à la ToastManager.test.ts) with process.platform overridden.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { IPC } from '../../../shared/constants';
+
+const FAKE_VERSION = '9.9.9';
+const EXPECTED_WIN32_FEED = `https://update.electronjs.org/openwong2kim/wmux/win32/${FAKE_VERSION}`;
+
+const realPlatform = process.platform;
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true });
+  vi.resetModules();
+  vi.useRealTimers();
+});
+
+/**
+ * (Re)load AutoUpdater with process.platform overridden and electron mocked.
+ * Returns the class plus probes: every net.request URL, and the captured
+ * ipcMain handlers so tests can invoke UPDATE_CHECK / UPDATE_INSTALL directly.
+ */
+async function loadForPlatform(platform: NodeJS.Platform) {
+  vi.resetModules();
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+
+  const requestUrls: string[] = [];
+  const ipcHandlers = new Map<string, (...args: unknown[]) => unknown>();
+  const ipcListeners = new Map<string, (...args: unknown[]) => unknown>();
+
+  // Minimal net.request that records the URL and emits a 204 (no update).
+  const request = vi.fn((url: string) => {
+    requestUrls.push(url);
+    const cbs: Record<string, (arg: unknown) => void> = {};
+    const req = {
+      on(ev: string, cb: (arg: unknown) => void) { cbs[ev] = cb; return req; },
+      end() {
+        // Async 204 response so check()'s promise settles like the real path.
+        Promise.resolve().then(() => {
+          const resp = { statusCode: 204, on: () => resp };
+          cbs['response']?.(resp);
+        });
+      },
+    };
+    return req;
+  });
+
+  vi.doMock('electron', () => ({
+    autoUpdater: {},
+    app: { getVersion: () => FAKE_VERSION, getPath: () => '/tmp' },
+    ipcMain: {
+      on: (ch: string, cb: (...a: unknown[]) => unknown) => { ipcListeners.set(ch, cb); },
+      handle: (ch: string, cb: (...a: unknown[]) => unknown) => { ipcHandlers.set(ch, cb); },
+      removeAllListeners: vi.fn(),
+      removeHandler: vi.fn(),
+    },
+    net: { request },
+    shell: { openPath: vi.fn(), openExternal: vi.fn() },
+  }));
+
+  const mod = await import('../AutoUpdater');
+  return { AutoUpdater: mod.AutoUpdater, requestUrls, ipcHandlers, ipcListeners, request };
+}
+
+describe('AutoUpdater platform gating', () => {
+  it('win32: start() schedules a check that hits the exact win32 feed URL (byte-identical)', async () => {
+    vi.useFakeTimers();
+    const { AutoUpdater, requestUrls } = await loadForPlatform('win32');
+
+    const updater = new AutoUpdater(() => null);
+    updater.start();
+
+    // First check fires 15s after start.
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(requestUrls).toContain(EXPECTED_WIN32_FEED);
+    updater.stop();
+  });
+
+  it('win32: periodic timer keeps polling the win32 feed', async () => {
+    vi.useFakeTimers();
+    const { AutoUpdater, requestUrls } = await loadForPlatform('win32');
+
+    const updater = new AutoUpdater(() => null);
+    updater.start();
+    await vi.advanceTimersByTimeAsync(15_000); // first check
+    const afterFirst = requestUrls.length;
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000); // one interval
+    expect(requestUrls.length).toBeGreaterThan(afterFirst);
+    expect(requestUrls.every((u) => u === EXPECTED_WIN32_FEED)).toBe(true);
+    updater.stop();
+  });
+
+  it.each(['darwin', 'linux'] as const)(
+    '%s: start() never schedules a check and never touches the network',
+    async (platform) => {
+      vi.useFakeTimers();
+      const { AutoUpdater, requestUrls } = await loadForPlatform(platform);
+
+      const updater = new AutoUpdater(() => null);
+      updater.start();
+
+      // Advance well past the first-check delay AND a full interval.
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+
+      expect(requestUrls).toHaveLength(0);
+      updater.stop();
+    },
+  );
+
+  it.each(['darwin', 'linux'] as const)(
+    '%s: UPDATE_CHECK resolves not-available and UPDATE_INSTALL is an inert no-op',
+    async (platform) => {
+      const { AutoUpdater, ipcHandlers, requestUrls } = await loadForPlatform(platform);
+
+      const updater = new AutoUpdater(() => null);
+      updater.start();
+
+      const checkHandler = ipcHandlers.get(IPC.UPDATE_CHECK);
+      const installHandler = ipcHandlers.get(IPC.UPDATE_INSTALL);
+      if (typeof checkHandler !== 'function' || typeof installHandler !== 'function') {
+        throw new Error('UPDATE_CHECK / UPDATE_INSTALL handlers were not registered');
+      }
+
+      await expect(checkHandler()).resolves.toEqual({ status: 'not-available' });
+
+      // Install must not fetch a manifest or download anything off win32.
+      await installHandler();
+      expect(requestUrls).toHaveLength(0);
+
+      updater.stop();
+    },
+  );
+
+  it('win32: UPDATE_CHECK reports checking (updater is active)', async () => {
+    vi.useFakeTimers();
+    const { AutoUpdater, ipcHandlers } = await loadForPlatform('win32');
+
+    const updater = new AutoUpdater(() => null);
+    updater.start();
+
+    const checkHandler = ipcHandlers.get(IPC.UPDATE_CHECK);
+    if (typeof checkHandler !== 'function') throw new Error('UPDATE_CHECK handler was not registered');
+    await expect(checkHandler()).resolves.toEqual({ status: 'checking' });
+
+    updater.stop();
+  });
+});


### PR DESCRIPTION
## Summary
Extends wmux from Windows-only to a single-repo cross-platform release (macOS + Linux) while keeping the Windows release path **byte-identical**. Implements phases A–D plus spawn hardening (F1). macOS in-app self-update (E) and remaining runtime polish (F) are deferred to a macOS-dogfood follow-up.

## What's included
- **Phase A — AutoUpdater win32 gate.** macOS/Linux clients never schedule a check, fetch the manifest, or launch a `.Setup.exe` (inert off win32) — prevents mis-installing the Windows installer once all OSes share one release's assets. Adds a platform mock test pinning the win32 byte-identical feed-URL invariant.
- **Phase B — macOS packaging.** `@electron-forge/maker-dmg` + `@electron/notarize`; env-gated `osxSign`/`osxNotarize` (no-op when Apple creds absent); `build/entitlements.mac.plist` granting the hardened-runtime exceptions RunAsNode (`ELECTRON_RUN_AS_NODE` daemon spawn) + node-pty need. Ships ZIP (feed/self-update) **and** DMG (first-install).
- **Phase C — Linux AppImage** maker via `@reforged/maker-appimage`, alongside deb/rpm.
- **Phase D — release.yml 3-OS matrix.** Adds `macos` (macos-14 arm64 + macos-13 x64) and `linux` (ubuntu) jobs that build + append artifacts to the release. The `build` (windows) job is **byte-identical**; new legs are `needs: build` + append-only (`gh release upload --clobber`, continue-on-error) + `if: vars.ENABLE_CROSS_PLATFORM_RELEASE`.
- **Phase F1 — PTY spawn hardening.** `DaemonSessionManager` + `PTYManager` wrap `pty.spawn()` in try/catch and surface an actionable error (shell path + cwd) instead of an opaque node-pty throw.

## Windows safety
- `build` job unchanged — diff is **pure additions** (0 modified/deleted lines).
- macOS/Linux release legs are **opt-in**: with `ENABLE_CROSS_PLATFORM_RELEASE` unset, a tag push behaves exactly like today (Windows-only).
- AutoUpdater win32 path byte-identical (enforced by the new platform mock test).
- Verified on Windows: `tsc` clean, `electron-forge package` succeeds, 499 changed-area tests pass. (The local Squirrel `Setup.exe` failure is a pre-existing electron-winstaller/SharpCompress env issue that reproduces on `main` too — unrelated; CI windows-latest builds it fine, as v2.16.0 shipped.)

## To activate the macOS/Linux release (after merge)
1. Add GitHub Secrets: `APPLE_CERT_P12_BASE64`, `APPLE_CERT_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`, `KEYCHAIN_PASSWORD`.
2. Set repo variable `ENABLE_CROSS_PLATFORM_RELEASE = true`.
3. Tag push → signed+notarized macOS DMG/ZIP + Linux deb/rpm/AppImage append to the GitHub Release.

Until then, builds are unsigned (no-op-when-empty), so the pipeline structure can be validated before certs exist.

## Not in this PR (follow-up, needs macOS env)
- **Phase E**: macOS in-app ZIP self-update (per-platform manifest with a win32 top-level alias + `install.ps1` lockstep, after the notarized build is green).
- **Phase F rest**: `macos.ts` error wiring, macOS live-CWD fallback, zsh OSC133 markers, autostart.

## Notes
- Plan: `plans/cross-platform-release.md` (multi-agent workflow analysis + adversarial skeptic review).
- Key skeptic catches folded in: darwin feed serves `.zip` not `.dmg` (keep both makers); RunAsNode needs hardened-runtime entitlements; `install.ps1` also consumes the manifest top-level sha256; no `needs:[win,mac,linux]` hard gate (Windows always ships); node-pty build failure is import-time (not spawn-time).
- User decisions: macOS DMG+ZIP, Linux deb+rpm+AppImage, Linux has no in-app auto-update, Apple secrets later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)