### PR TITLE
fix(daemon): dispose PTYs on external workspace.close + surface background session count in tray

### DIFF
--- a/scripts/workspace-close-dispose-dynamic.mjs
+++ b/scripts/workspace-close-dispose-dynamic.mjs
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+/**
+ * Dynamic verification for PR #86 (fix/daemon-session-visibility).
+ *
+ * The PR's user-visible fix is renderer-side (useRpcBridge `workspace.close`
+ * disposes every pane PTY) and main-side (tray surfaces the live session
+ * count). Neither imports cleanly headless. What CAN be proven dynamically is
+ * the daemon-level MECHANISM the fix depends on — and that mechanism is the
+ * whole point: closing a workspace must actually terminate that workspace's
+ * shell processes (the original RAM-accumulation bug was that they did NOT
+ * die), while leaving other workspaces and the daemon untouched.
+ *
+ * Scenarios (against the BUNDLED daemon, real ConPTY, real PIDs):
+ *
+ *   WC1  Two "workspaces": A = [a1, a2], B = [b1]. Disposing A's sessions
+ *        (exactly what `workspace.close` triggers via collectAllPtyIds →
+ *        pty.dispose → daemon.destroySession) must:
+ *          - kill a1's and a2's real PTY processes,
+ *          - leave b1's PTY alive,
+ *          - leave the daemon alive,
+ *          - drop a1/a2 from listSessions while keeping b1.
+ *        This is the "the leak is actually fixed" proof.
+ *
+ *   WC2  Best-effort safety (supports the R2 `.catch` + best-effort claim):
+ *        destroySession on a bogus id, and a double-destroy of a real id,
+ *        must NOT crash the daemon — it stays alive and answers `daemon.ping`.
+ *        This is why workspace.close can fire dispose at sessions that may be
+ *        already-dead / mid-respawn without taking the daemon (or the close)
+ *        down with it.
+ *
+ * NOT covered here (renderer/Electron-only — covered by tsc + codex review):
+ *   - the `workspaces.length > 1` guard in useRpcBridge (renderer logic),
+ *   - the tray tooltip/menu count + monotonic refresh token (Electron main UI).
+ *
+ * Liveness signal: assertions use the daemon's authoritative RPC state
+ * (`daemon.listSessions` membership + `daemon.ping`) and the spawned daemon's
+ * own `exit` event — NOT OS process enumeration. `tasklist.exe`/WMI are
+ * unreliable in some sandboxed/loaded environments (they time out), and the
+ * OS-level PTY kill is already performed by destroySession→ptyProcess.kill
+ * (unit-tested). What we verify here is the disposal CONTRACT: a closed
+ * workspace's sessions leave the daemon's live set, others don't, daemon lives.
+ *
+ * Run: npm run build:daemon && node scripts/workspace-close-dispose-dynamic.mjs
+ */
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DAEMON_BUNDLE = path.join(REPO_ROOT, 'dist', 'daemon-bundle', 'index.js');
+
+if (!fs.existsSync(DAEMON_BUNDLE)) {
+  console.error('Daemon bundle missing — run `npm run build:daemon` first');
+  process.exit(2);
+}
+
+// --- harness helpers (mirrors persistence-dynamic.mjs) -----------------
+
+function makeTestHome() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-wc-dyn-'));
+  fs.mkdirSync(path.join(home, '.wmux'), { recursive: true });
+  return home;
+}
+
+function makePipeName(tag) {
+  if (process.platform === 'win32') return `\\\\.\\pipe\\wmux-test-${tag}`;
+  return path.join(os.tmpdir(), `wmux-test-${tag}.sock`);
+}
+
+function writeConfig(wmuxDir, pipeName, authToken) {
+  fs.writeFileSync(
+    path.join(wmuxDir, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      daemon: { pipeName, logLevel: 'warn', autoStart: true },
+      session: {
+        defaultShell: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
+        defaultCols: 80, defaultRows: 24, bufferSizeMb: 8, bufferMaxMb: 64,
+        deadSessionTtlHours: 24, deadSessionDumpBuffer: true,
+      },
+    }, null, 2),
+  );
+  fs.writeFileSync(path.join(wmuxDir, 'daemon-auth-token'), authToken, 'utf-8');
+}
+
+function spawnDaemon(testHome, extraEnv = {}) {
+  return spawn(process.execPath, [DAEMON_BUNDLE], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      USERPROFILE: testHome, HOME: testHome,
+      HOMEDRIVE: undefined, HOMEPATH: undefined,
+      ...extraEnv,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+async function waitForPipeFile(wmuxDir, timeoutMs = 10_000) {
+  const pipeFile = path.join(wmuxDir, 'daemon-pipe');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(pipeFile)) return fs.readFileSync(pipeFile, 'utf-8').trim();
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error('daemon-pipe did not appear within timeout');
+}
+
+function connectSocket(pipeName) {
+  return new Promise((resolve, reject) => {
+    const s = net.createConnection(pipeName, () => resolve(s));
+    s.on('error', reject);
+  });
+}
+
+function rpc(socket, method, params, authToken, timeoutMs = 30_000) {
+  return new Promise((resolve, reject) => {
+    const id = `req-${Math.random().toString(36).slice(2, 10)}`;
+    let buffer = '';
+    const handler = (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id === id) {
+            socket.removeListener('data', handler);
+            if (msg.ok) resolve(msg.result);
+            else reject(new Error(msg.error ?? 'rpc error'));
+            return;
+          }
+        } catch { /* ignore */ }
+      }
+    };
+    socket.on('data', handler);
+    socket.write(JSON.stringify({ id, method, params, token: authToken }) + '\n');
+    setTimeout(() => {
+      socket.removeListener('data', handler);
+      reject(new Error(`rpc timeout: ${method}`));
+    }, timeoutMs);
+  });
+}
+
+// Spawn a real PowerShell PTY (the shell from the bug report) with a full
+// inherited env so it boots cleanly in the temp home. Retries on the
+// occasional ConPTY error code 87 race.
+async function createPwshSession(socket, authToken, id, cwd, attempts = 5) {
+  const cmd = process.platform === 'win32'
+    ? path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe')
+    : '/bin/sh';
+  // Pass the real env (minus nothing) so PowerShell's runspace init has
+  // PSModulePath/TEMP/etc. — we are NOT trying to reproduce the low-resource
+  // InitialSessionState failure here, just a normal shell whose PID we can kill.
+  const env = {};
+  for (const [k, v] of Object.entries(process.env)) if (typeof v === 'string') env[k] = v;
+  let lastErr = null;
+  for (let i = 1; i <= attempts; i++) {
+    const sessionId = i === 1 ? id : `${id}-r${i}`;
+    try {
+      const result = await rpc(socket, 'daemon.createSession', {
+        id: sessionId, cmd, cwd, env, cols: 80, rows: 24,
+      }, authToken);
+      return { pid: result?.pid, sessionId };
+    } catch (err) {
+      lastErr = err;
+      if (!/error code: 87|ConPTY|Cannot create process/i.test(err?.message ?? '')) throw err;
+      await new Promise((r) => setTimeout(r, 800 * i));
+    }
+  }
+  throw lastErr ?? new Error('createSession failed after retries');
+}
+
+async function killDaemon(child) {
+  if (child.exitCode !== null) return;
+  child.kill('SIGTERM');
+  await new Promise((r) => setTimeout(r, 800));
+  if (child.exitCode === null) child.kill('SIGKILL');
+}
+
+// --- WC1: closing workspace A disposes A's PTYs, B + daemon survive ----
+
+async function runWC1(report) {
+  const testHome = makeTestHome();
+  const wmuxDir = path.join(testHome, '.wmux');
+  const pipeName = makePipeName(`WC1-${randomUUID().slice(0, 8)}`);
+  const authToken = randomUUID();
+  writeConfig(wmuxDir, pipeName, authToken);
+  const child = spawnDaemon(testHome); // default idle (won't fire; B keeps it alive)
+  let exited = false;
+  child.on('exit', () => { exited = true; });
+  let stderr = '';
+  child.stderr.on('data', (d) => { stderr += d.toString(); });
+
+  let entry = { scenario: 'WC1', pass: false };
+  try {
+    const resolvedPipe = await waitForPipeFile(wmuxDir);
+    const socket = await connectSocket(resolvedPipe);
+    await new Promise((r) => setTimeout(r, 1500)); // settle before ConPTY
+
+    // Workspace A = two panes, Workspace B = one pane.
+    const a1 = await createPwshSession(socket, authToken, `a1-${randomUUID().slice(0, 8)}`, wmuxDir);
+    const a2 = await createPwshSession(socket, authToken, `a2-${randomUUID().slice(0, 8)}`, wmuxDir);
+    const b1 = await createPwshSession(socket, authToken, `b1-${randomUUID().slice(0, 8)}`, wmuxDir);
+
+    // Sanity: all three sessions are present in the daemon's live set, each
+    // with a real PTY pid behind it (createSession returned them).
+    const haveAllPids = !!a1.pid && !!a2.pid && !!b1.pid;
+    const listBefore = await rpc(socket, 'daemon.listSessions', {}, authToken);
+    const idsBefore = new Set((listBefore ?? []).map((s) => s.id));
+    const allListedBefore =
+      idsBefore.has(a1.sessionId) && idsBefore.has(a2.sessionId) && idsBefore.has(b1.sessionId);
+
+    // Close workspace A: dispose each of A's PTYs (what useRpcBridge does on
+    // workspace.close — collectAllPtyIds(A) -> pty.dispose -> destroySession).
+    await rpc(socket, 'daemon.destroySession', { id: a1.sessionId }, authToken);
+    await rpc(socket, 'daemon.destroySession', { id: a2.sessionId }, authToken);
+    await new Promise((r) => setTimeout(r, 500));
+
+    // The daemon's authoritative view: A's sessions are gone, B remains.
+    // (destroySession both deletes the managed session AND ptyProcess.kill()s
+    // the shell; the kill itself is unit-tested. We assert the contract via
+    // RPC state because process enumeration is blocked in this environment.)
+    const listAfter = await rpc(socket, 'daemon.listSessions', {}, authToken);
+    const idsAfter = new Set((listAfter ?? []).map((s) => s.id));
+    const aDisposed = !idsAfter.has(a1.sessionId) && !idsAfter.has(a2.sessionId);
+    const bSurvived = idsAfter.has(b1.sessionId);
+    const daemonResponsive =
+      (!exited) && (await rpc(socket, 'daemon.ping', {}, authToken, 5000).then(() => true).catch(() => false));
+    socket.end();
+
+    entry = {
+      scenario: 'WC1',
+      sessions: { a1: a1.sessionId, a2: a2.sessionId, b1: b1.sessionId },
+      pids: { a1: a1.pid, a2: a2.pid, b1: b1.pid },
+      haveAllPids, allListedBefore, aDisposed, bSurvived, daemonResponsive,
+      pass: haveAllPids && allListedBefore && aDisposed && bSurvived && daemonResponsive,
+    };
+  } catch (err) {
+    entry = { scenario: 'WC1', pass: false, error: err.message, stderr: stderr.slice(-600) };
+  } finally {
+    await killDaemon(child);
+    try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  report.push(entry);
+}
+
+// --- WC2: best-effort dispose is daemon-safe (supports R2 .catch) ------
+
+async function runWC2(report) {
+  const testHome = makeTestHome();
+  const wmuxDir = path.join(testHome, '.wmux');
+  const pipeName = makePipeName(`WC2-${randomUUID().slice(0, 8)}`);
+  const authToken = randomUUID();
+  writeConfig(wmuxDir, pipeName, authToken);
+  const child = spawnDaemon(testHome);
+  let exited = false;
+  child.on('exit', () => { exited = true; });
+  let stderr = '';
+  child.stderr.on('data', (d) => { stderr += d.toString(); });
+
+  let entry = { scenario: 'WC2', pass: false };
+  try {
+    const resolvedPipe = await waitForPipeFile(wmuxDir);
+    const socket = await connectSocket(resolvedPipe);
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const s = await createPwshSession(socket, authToken, `wc2-${randomUUID().slice(0, 8)}`, wmuxDir);
+
+    // 1) destroy a session that does not exist (mid-respawn / already-gone).
+    let bogusThrew = false;
+    try { await rpc(socket, 'daemon.destroySession', { id: 'no-such-session' }, authToken); }
+    catch { bogusThrew = true; } // either resolves or rejects — both must leave daemon alive
+
+    // 2) double-destroy the real one (renderer could fire dispose twice).
+    await rpc(socket, 'daemon.destroySession', { id: s.sessionId }, authToken);
+    let doubleThrew = false;
+    try { await rpc(socket, 'daemon.destroySession', { id: s.sessionId }, authToken); }
+    catch { doubleThrew = true; }
+
+    // The hard requirement: daemon is still alive and responsive afterwards.
+    // `exited` is a direct signal — the daemon is our spawned child, so its
+    // 'exit' event fires for us with no process enumeration needed.
+    const ping = await rpc(socket, 'daemon.ping', {}, authToken, 5000).then(() => true).catch(() => false);
+    const daemonAlive = !exited;
+    socket.end();
+
+    entry = {
+      scenario: 'WC2',
+      bogusThrew, doubleThrew, pingOk: ping, daemonAlive,
+      pass: ping && daemonAlive, // tolerant of throw-or-resolve; what matters is survival
+    };
+  } catch (err) {
+    entry = { scenario: 'WC2', pass: false, error: err.message, stderr: stderr.slice(-600) };
+  } finally {
+    await killDaemon(child);
+    try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  report.push(entry);
+}
+
+// --- main --------------------------------------------------------------
+
+process.on('unhandledRejection', (reason) => {
+  console.error('[unhandledRejection]', reason instanceof Error ? reason.stack : String(reason));
+});
+
+const report = [];
+for (const [name, fn] of [['WC1', runWC1], ['WC2', runWC2]]) {
+  try { await fn(report); }
+  catch (err) { console.error(`[${name}] threw: ${err.message}`); report.push({ scenario: name, pass: false, error: err.message }); }
+}
+
+console.log('\n=== WORKSPACE-CLOSE DISPOSE REPORT ===');
+for (const entry of report) console.log(JSON.stringify(entry));
+
+const failed = report.filter((r) => r.pass === false);
+if (failed.length > 0) {
+  console.error(`\n[FAIL] ${failed.length}/${report.length} scenarios failed.`);
+  process.exit(1);
+}
+console.log(`\n[PASS] all ${report.length} scenarios met their post-conditions.`);
+process.exit(0);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -200,24 +200,32 @@ const claudeWorker = new ClaudeWorker(() => mainWindow);
 // Daemon client — initialized on app ready, used if daemon is available
 let daemonClient: DaemonClient | null = null;
 
+// Monotonic token guarding the async tray refresh. Bumped on every refresh
+// start and on window 'show', so a slow `daemon.listSessions` from an earlier
+// 'hide' can't land its now-stale count after the window is visible again (or
+// after a newer refresh superseded it). (codex review P3)
+let trayRefreshToken = 0;
+
 /**
  * Query the daemon for its live (attached + detached) session count and push
  * it to the tray's background-session nudge. Dead/suspended tombstones hold no
  * live process, so they're excluded. Best-effort and self-contained: any
  * failure (local-only mode, daemon mid-respawn, RPC timeout) clears the nudge
  * to `null` rather than surfacing an error — the count is a cosmetic hint.
+ * The result is only applied if no newer refresh/show has superseded this one.
  */
 async function refreshTraySessionCount(): Promise<void> {
+  const token = ++trayRefreshToken;
   if (!daemonClient) {
-    updateTraySessionCount(null);
+    if (token === trayRefreshToken) updateTraySessionCount(null);
     return;
   }
   try {
     const sessions = (await daemonClient.rpc('daemon.listSessions', {})) as Array<{ state: string }>;
     const live = sessions.filter((s) => s.state === 'attached' || s.state === 'detached').length;
-    updateTraySessionCount(live);
+    if (token === trayRefreshToken) updateTraySessionCount(live);
   } catch {
-    updateTraySessionCount(null);
+    if (token === trayRefreshToken) updateTraySessionCount(null);
   }
 }
 
@@ -582,7 +590,10 @@ app.on('ready', async () => {
   mainWindow.on('show', () => {
     usagePoller.setWindowVisible(true);
     // Window is visible again — the panes speak for themselves, so clear the
-    // background-session nudge back to the plain "wmux" tooltip/menu.
+    // background-session nudge back to the plain "wmux" tooltip/menu. Bump the
+    // refresh token first so a slow in-flight hide refresh can't overwrite this
+    // clear with a stale count after it resolves. (codex review P3)
+    trayRefreshToken++;
     updateTraySessionCount(null);
   });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -46,7 +46,7 @@ import { migrateScrollbackOnce } from './scrollback/legacyMigration';
 import { DaemonNotificationRouter } from './notification/DaemonNotificationRouter';
 import { ensureDaemon, killDaemonByPidFile } from './daemon/launcher';
 import { DaemonRespawnController } from './daemon/DaemonRespawnController';
-import { createTray, destroyTray } from './tray';
+import { createTray, destroyTray, updateTraySessionCount } from './tray';
 import { FirstRunOrchestrator } from './firstRun/FirstRunOrchestrator';
 import { registerFirstRunHandlers } from './firstRun';
 import { ProcessMonitor } from '../daemon/ProcessMonitor';
@@ -199,6 +199,28 @@ const claudeWorker = new ClaudeWorker(() => mainWindow);
 
 // Daemon client — initialized on app ready, used if daemon is available
 let daemonClient: DaemonClient | null = null;
+
+/**
+ * Query the daemon for its live (attached + detached) session count and push
+ * it to the tray's background-session nudge. Dead/suspended tombstones hold no
+ * live process, so they're excluded. Best-effort and self-contained: any
+ * failure (local-only mode, daemon mid-respawn, RPC timeout) clears the nudge
+ * to `null` rather than surfacing an error — the count is a cosmetic hint.
+ */
+async function refreshTraySessionCount(): Promise<void> {
+  if (!daemonClient) {
+    updateTraySessionCount(null);
+    return;
+  }
+  try {
+    const sessions = (await daemonClient.rpc('daemon.listSessions', {})) as Array<{ state: string }>;
+    const live = sessions.filter((s) => s.state === 'attached' || s.state === 'detached').length;
+    updateTraySessionCount(live);
+  } catch {
+    updateTraySessionCount(null);
+  }
+}
+
 // In daemon mode, this router bridges daemon-broadcast events (agent status,
 // activity transitions, critical actions) into the same IPC channels
 // PTYBridge writes to in local mode. Without it, daemon mode would render
@@ -548,8 +570,21 @@ app.on('ready', async () => {
   // as "user not looking" so the poller's 30-min skip threshold kicks in
   // and we don't burn Anthropic quota for a UI nobody sees. Show always
   // unpauses immediately and forces a catch-up fetch.
-  mainWindow.on('hide', () => { usagePoller.setWindowVisible(false); });
-  mainWindow.on('show', () => { usagePoller.setWindowVisible(true); });
+  mainWindow.on('hide', () => {
+    usagePoller.setWindowVisible(false);
+    // Quit-to-tray is the accumulation blind spot: the daemon keeps every
+    // live session (and any agent inside it) running with no visible UI.
+    // Refresh the tray's session-count nudge so the user can see how much is
+    // still alive in the background. Best-effort — a tray hint must never
+    // block window hide, and listSessions may reject mid daemon-respawn.
+    void refreshTraySessionCount();
+  });
+  mainWindow.on('show', () => {
+    usagePoller.setWindowVisible(true);
+    // Window is visible again — the panes speak for themselves, so clear the
+    // background-session nudge back to the plain "wmux" tooltip/menu.
+    updateTraySessionCount(null);
+  });
 
   // System tray — lets the app stay alive when window is closed.
   // Phase A — A3/A5 fix (codex review P1, session 019e2af8): the callback

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -4,6 +4,10 @@ import path from 'path';
 import { platformChoice } from '../shared/platform';
 
 let tray: Tray | null = null;
+// Retained so updateTraySessionCount() can rebuild the context menu (and so
+// the tooltip nudge stays in sync) without the caller re-passing them.
+let trayWindow: BrowserWindow | null = null;
+let trayCallbacks: TrayCallbacks | null = null;
 
 /**
  * Resolve a license-style file that ships in <exe>/resources/ when packaged
@@ -30,30 +34,19 @@ export interface TrayCallbacks {
   onShutdownAll: () => void;
 }
 
-export function createTray(mainWindow: BrowserWindow, callbacks: TrayCallbacks): Tray {
-  // In packaged app, extraResource files land in <exe_dir>/resources/
-  // In dev, assets are at project root: <__dirname>/../../assets/
-  //
-  // OS-aware extension: Windows -> .ico, macOS -> .icns, Linux/other -> .png.
-  // The actual non-Windows image files are produced by a separate asset pipeline
-  // (Phase 1.1 generate-icon.js). If the resolved file is missing on a given
-  // platform, Electron falls back to a default tray image rather than throwing.
-  const iconExt = platformChoice<string>({ win: 'ico', mac: 'icns', linux: 'png', default: 'png' });
-  const iconFile = `icon.${iconExt}`;
-  const iconPath = app.isPackaged
-    ? path.join(process.resourcesPath, iconFile)
-    : path.join(__dirname, '..', '..', 'assets', iconFile);
-
-  tray = new Tray(nativeImage.createFromPath(iconPath));
-  tray.setToolTip('wmux');
-
-  // License / About handlers — surface the MIT notice for wmux itself
-  // and the bundled THIRD_PARTY_NOTICES so users (and downstream
-  // distributors) can find the attribution that ships next to wmux.exe.
-  // `shell.openPath` opens the file in the user's default text app;
-  // failure (missing file in a stripped build, no associated app, etc.)
-  // falls back to revealing the containing folder so the file is still
-  // discoverable.
+/**
+ * Build the tray context menu. When `sessionCount` is a positive number we
+ * insert a disabled info row above the quit items so a user who has quit-to-
+ * tray can see, without opening the window, that the daemon is still holding
+ * N live sessions (each potentially a heavyweight agent process). This is the
+ * visibility half of the "don't auto-kill, make accumulation visible" fix —
+ * the user stays in control and reaches for "Shut down" when they see the count.
+ */
+function buildContextMenu(
+  mainWindow: BrowserWindow,
+  callbacks: TrayCallbacks,
+  sessionCount: number | null,
+): Menu {
   const openOrReveal = async (file: string | null): Promise<void> => {
     if (!file) {
       dialog.showErrorBox('wmux', 'License file is missing from this build.');
@@ -63,7 +56,7 @@ export function createTray(mainWindow: BrowserWindow, callbacks: TrayCallbacks):
     if (err) shell.showItemInFolder(file);
   };
 
-  const contextMenu = Menu.buildFromTemplate([
+  const template: Electron.MenuItemConstructorOptions[] = [
     {
       label: 'Open wmux',
       click: () => {
@@ -87,6 +80,16 @@ export function createTray(mainWindow: BrowserWindow, callbacks: TrayCallbacks):
       click: () => void openOrReveal(resolveResource('THIRD_PARTY_NOTICES')),
     },
     { type: 'separator' },
+  ];
+
+  if (typeof sessionCount === 'number' && sessionCount > 0) {
+    template.push({
+      label: `${sessionCount} background session${sessionCount === 1 ? '' : 's'} running`,
+      enabled: false,
+    });
+  }
+
+  template.push(
     {
       label: 'Quit (keep sessions running)',
       click: () => {
@@ -101,9 +104,54 @@ export function createTray(mainWindow: BrowserWindow, callbacks: TrayCallbacks):
         app.quit();
       },
     },
-  ]);
+  );
 
-  tray.setContextMenu(contextMenu);
+  return Menu.buildFromTemplate(template);
+}
+
+/**
+ * Update the tray to reflect how many live sessions the daemon is holding.
+ * Pass the count when hiding to tray (the accumulation blind spot) and `null`
+ * when the window is shown (the panes are visible, so no nudge needed). Safe
+ * no-op before the tray exists. Best-effort cosmetic surface — never throws.
+ */
+export function updateTraySessionCount(sessionCount: number | null): void {
+  if (!tray || !trayWindow || !trayCallbacks) return;
+  tray.setToolTip(
+    typeof sessionCount === 'number' && sessionCount > 0
+      ? `wmux — ${sessionCount} background session${sessionCount === 1 ? '' : 's'} running`
+      : 'wmux',
+  );
+  tray.setContextMenu(buildContextMenu(trayWindow, trayCallbacks, sessionCount));
+}
+
+export function createTray(mainWindow: BrowserWindow, callbacks: TrayCallbacks): Tray {
+  // In packaged app, extraResource files land in <exe_dir>/resources/
+  // In dev, assets are at project root: <__dirname>/../../assets/
+  //
+  // OS-aware extension: Windows -> .ico, macOS -> .icns, Linux/other -> .png.
+  // The actual non-Windows image files are produced by a separate asset pipeline
+  // (Phase 1.1 generate-icon.js). If the resolved file is missing on a given
+  // platform, Electron falls back to a default tray image rather than throwing.
+  const iconExt = platformChoice<string>({ win: 'ico', mac: 'icns', linux: 'png', default: 'png' });
+  const iconFile = `icon.${iconExt}`;
+  const iconPath = app.isPackaged
+    ? path.join(process.resourcesPath, iconFile)
+    : path.join(__dirname, '..', '..', 'assets', iconFile);
+
+  tray = new Tray(nativeImage.createFromPath(iconPath));
+  trayWindow = mainWindow;
+  trayCallbacks = callbacks;
+  tray.setToolTip('wmux');
+
+  // License / About handlers — surface the MIT notice for wmux itself
+  // and the bundled THIRD_PARTY_NOTICES so users (and downstream
+  // distributors) can find the attribution that ships next to wmux.exe.
+  // `shell.openPath` opens the file in the user's default text app;
+  // failure (missing file in a stripped build, no associated app, etc.)
+  // falls back to revealing the containing folder so the file is still
+  // discoverable. (See buildContextMenu for the menu template.)
+  tray.setContextMenu(buildContextMenu(mainWindow, callbacks, null));
 
   tray.on('double-click', () => {
     mainWindow.show();
@@ -118,4 +166,6 @@ export function destroyTray(): void {
     tray.destroy();
     tray = null;
   }
+  trayWindow = null;
+  trayCallbacks = null;
 }

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -257,7 +257,15 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     const ws = store.workspaces.find((w) => w.id === id);
     if (ws && store.workspaces.length > 1) {
       for (const ptyId of collectAllPtyIds(ws.rootPane)) {
-        try { window.electronAPI.pty.dispose(ptyId); } catch { /* best-effort */ }
+        // dispose() returns an IPC Promise, so a daemon-side failure (mid-
+        // respawn, session already dead) rejects asynchronously — a plain
+        // try/catch wouldn't catch it and workspace.close would emit an
+        // unhandled rejection while still reporting success. Swallow the
+        // rejection via .catch; the outer try guards a synchronous throw
+        // (e.g. electronAPI missing). Best-effort either way. (codex review P2)
+        try {
+          void window.electronAPI.pty.dispose(ptyId).catch(() => { /* best-effort */ });
+        } catch { /* best-effort */ }
       }
     }
     store.removeWorkspace(id);

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -240,6 +240,19 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
 
   if (method === 'workspace.close') {
     const id = String(params.id ?? '');
+    // Dispose the workspace's PTY sessions before dropping it from the UI.
+    // The UI close paths (Sidebar X, Ctrl+Shift+W, Settings reset) already
+    // dispose every surface's PTY; without the same step here an external
+    // CLI/MCP `workspace.close` would leave each pane's shell — and any agent
+    // process running inside it — alive in the daemon with no UI to reattach,
+    // accumulating until a full daemon shutdown. Best-effort: a failed dispose
+    // (session already dead, daemon mid-respawn) must not block the removal.
+    const ws = store.workspaces.find((w) => w.id === id);
+    if (ws) {
+      for (const ptyId of collectAllPtyIds(ws.rootPane)) {
+        try { window.electronAPI.pty.dispose(ptyId); } catch { /* best-effort */ }
+      }
+    }
     store.removeWorkspace(id);
     return { ok: true };
   }

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -247,8 +247,15 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // process running inside it — alive in the daemon with no UI to reattach,
     // accumulating until a full daemon shutdown. Best-effort: a failed dispose
     // (session already dead, daemon mid-respawn) must not block the removal.
+    //
+    // Guard on workspaces.length > 1: removeWorkspace refuses to drop the final
+    // workspace (the store always keeps at least one). Without this check the
+    // RPC would dispose the only workspace's PTYs — killing its shells and any
+    // agent inside them — while the workspace stays in the UI with dead
+    // surfaces. Mirror the slice's guard so dispose only runs when the removal
+    // will actually happen. (codex review P2)
     const ws = store.workspaces.find((w) => w.id === id);
-    if (ws) {
+    if (ws && store.workspaces.length > 1) {
       for (const ptyId of collectAllPtyIds(ws.rootPane)) {
         try { window.electronAPI.pty.dispose(ptyId); } catch { /* best-effort */ }
       }


### PR DESCRIPTION
## Problem

A user hit two symptoms that turned out to share one root cause:

1. **Intermittent Windows PowerShell crash** — freshly-spawned `powershell.exe` (5.1) dies at the .NET `System.Management.Automation.Runspaces.InitialSessionState` type initializer (exit `-65536` / `-1`), before any wmux init script runs. This is the documented low-resource signature of that failure.
2. **Claude Code processes piling up** — 15 `claude.exe` instances eating ~3.5 GB, ~2.3 GB of which was held by the wmux daemon (6 detached `powershell → claude` trees).

### Root cause

wmux's tmux-style persistence keeps **detached** sessions alive indefinitely (by design). Each pane can hold a heavyweight agent (Claude Code, ~400–550 MB). Quit-to-tray and window-close both **detach** rather than terminate, and `idle-shutdown` only fires when *zero* live sessions remain — so a single lingering detached session keeps the daemon (and everything in it) alive forever. Over a long daemon lifetime these accumulate, starve system memory, and new `powershell.exe` spawns intermittently fail their CLR runspace init.

The InitialSessionState crash is a **downstream symptom of memory pressure**, not a logic bug. The real gaps are an external-close leak and the *invisibility* of the accumulation.

## Changes

**1. `workspace.close` RPC disposes PTYs** (`useRpcBridge.ts`)
The UI close paths (Sidebar X, `Ctrl+Shift+W`, Settings reset) already dispose every surface's PTY before removing a workspace. The external CLI/MCP `workspace.close` RPC did not — it called `removeWorkspace` only, leaking every pane shell (and any agent inside it) in the daemon. Now it mirrors the UI paths via `collectAllPtyIds` → `pty.dispose`, with a `length > 1` guard (so it never disposes the un-removable last workspace) and async-rejection-safe best-effort disposal.

**2. Tray surfaces the live session count** (`tray.ts`, `index.ts`)
The accumulation blind spot is quit-to-tray: sessions keep running with no visible UI. On window `hide`, the tray now queries the daemon's live (attached+detached) session count and shows it — tooltip (`wmux — N background sessions running`) plus a disabled menu row above the quit items. On `show` it clears back to plain `wmux`. Event-driven, no polling, with a monotonic token guarding against stale async results.

### Explicitly NOT done: idle-session auto-reaping

Auto-killing idle detached sessions was considered and rejected: it breaks the tmux-style recovery promise, conflicts with substrate neutrality (no opinionated per-session lifecycle policy in the substrate), and "idle" is unreliable for awaiting-input agent sessions (no output ≠ done). The principle here is **surface the accumulation, let the user shut down** — the user stays in control. Closing a workspace kills only that workspace's shells; the daemon itself stays up (shared across workspaces) and only exits via idle-shutdown (zero sessions) or the explicit "Shut down wmux" tray item.

## Code review (codex, 4 rounds, converged)

| Round | Severity | Finding | Fix |
|-------|----------|---------|-----|
| R1 | P2 | dispose ran even when `removeWorkspace` no-ops on the last workspace → killed shells while workspace stayed in UI | `workspaces.length > 1` guard (`7886713`) |
| R2 | P2 | `pty.dispose()` returns an IPC Promise; sync try/catch couldn't catch async rejection → unhandled rejection | `.catch()` on the dispose promise (`331ccde`) |
| R3 | P3 | slow `listSessions` from `hide` could land a stale count after `show` cleared it | monotonic `trayRefreshToken` guard (`72c440b`) |
| R4 | — | clean, no findings | — |

## Test

- `tsc --noEmit`: clean.
- `vitest run`: 2055 passed. 2 failures in `ProcessMonitor.test.ts` are pre-existing and **unrelated** — `isAlive(process.pid)` returns false because the sandboxed test environment blocks the Windows tasklist/WMI liveness probe (independent of this diff; `ProcessMonitor` imports none of the changed files).

## Dynamic verification

`scripts/workspace-close-dispose-dynamic.mjs` (isolated bundled daemon, real PowerShell PTYs) — both scenarios **PASS**:

- **WC1** — closing workspace A (2 sessions) removes A from the daemons live set (\`aDisposed\`) while workspace B survives (\`bSurvived\`) and the daemon stays responsive. The disposal contract the fix depends on holds end-to-end.
- **WC2** — destroying a bogus id and double-destroying a real id never crash the daemon (still answers \`ping\`), backing the R2 \`.catch\` best-effort path.

Assertions use daemon RPC state + the spawned daemons exit event, not OS process enumeration (`tasklist`/WMI time out in this environment; the OS-level kill is unit-tested via `destroySession` → `ptyProcess.kill`).

Still GUI-only (manual dogfood): the tray tooltip/menu count (③) — run dev wmux, hide to tray, confirm `N background sessions running` appears.