### PR TITLE
release(v2.16.1): daemon false-death fix + pty:resize console-spam fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.16.1] — 2026-06-01 — daemon false-death fix, resize console-spam fix
+
+A stability patch. The headline: on slow or loaded machines the daemon's process monitor could mistake a probe timeout for a dead process and reap a session that was actually alive, so sessions appeared to close on their own. That's fixed. It also quiets an `Uncaught (in promise)` console flood on relaunch and adds session-death logging so future "why did my session close" reports are diagnosable.
+
+### Fixed
+- **Live sessions are no longer killed on a probe timeout.** ProcessMonitor treated a slow or timed-out `tasklist` probe as proof the process had died and reaped the still-alive session — the cause behind sessions closing by themselves under CPU contention or a Defender scan. It now reaps only on positive confirmation of death; a probe that fails or times out defers instead of killing.
+- **No more `Uncaught (in promise)` flood on relaunch.** A burst of terminal resizes during reconnect could exceed the daemon's per-socket rate limit, and the renderer never caught the rejection, spamming the console. Resize calls now swallow the transient rejection and re-send the live geometry once after the rate window clears, so a resize dropped during the burst self-heals instead of leaving the terminal stuck at the wrong size.
+
+### Added
+- **PTY session-death logging.** When a session dies the daemon now logs its exit code, signal, and idle time, so an unexpected session close can be diagnosed from the log instead of guessed at.
+
 ## [2.16.0] — 2026-05-30 — tmux-style persistence, blank-relaunch fix, multiline-paste fix, stability batch
 
 Bundles everything merged since v2.15.0 (#81, #84). The headline is tmux-style persistence — closing the window now keeps your daemon and sessions alive and reattaches them on next launch — plus the fix for recovered sessions rendering blank on relaunch, a multiline-paste fix for PowerShell, and a batch of dogfood-driven stability and UX changes.

--- a/TODOS.md
+++ b/TODOS.md
@@ -8,13 +8,10 @@
 - **Context:** `src/main/index.ts` before-quit에서 daemon.shutdown RPC를 보내는데, 트레이 모드에서는 이걸 skip하게 변경 예정. 하지만 edge case(강제 종료, 데몬 크래시 후 재시작)에서는 여전히 reconnect가 필요.
 - **Depends on:** 트레이 아이콘 구현
 
-## Pane split max depth/count guard
-- **What:** splitPane에 max leaf count 가드 추가 (예: 20개)
-- **Why:** 무한 split 시 xterm.js 인스턴스 폭증 → 메모리 목표(200MB for 10 panes) 초과 가능
-- **Pros:** 안정성 + 메모리 보호. 1줄 가드.
-- **Cons:** 사용자에게 에러 메시지 표시 필요
-- **Context:** `src/renderer/stores/slices/paneSlice.ts:46` splitPane 함수 시작 부분에 leaf count 체크 추가.
-- **Depends on:** 없음 (즉시 가능)
+<!-- Pane split max depth/count guard — RESOLVED. paneSlice.ts now declares
+     MAX_PANES_PER_WORKSPACE=20 and splitPane() returns false (blockedAtCap)
+     when collectLeafIds(ws.rootPane).length >= the cap. Guard + boolean
+     return contract are complete. -->
 
 ## DESIGN.md 작성
 - **What:** 디자인 시스템 문서 생성 (CSS 변수 목록, 스페이싱 스케일, 폰트, 컴포넌트 패턴)
@@ -24,21 +21,15 @@
 - **Context:** /design-consultation 스킬로 자동 생성 가능. 기존 themes.ts의 CSS 변수, StatusBar/Sidebar의 스타일 패턴에서 추출.
 - **Depends on:** v1.0 출시 후
 
-## destroyCompanyWithCleanup race condition
-- **What:** PTY dispose가 완료되기 전에 store.destroyCompany()가 호출되는 레이스 컨디션 수정
-- **Why:** dispose 중 UI 리렌더가 company === null을 만나 에러 가능성. 기존 inline 코드에도 동일한 문제가 있었음.
-- **Pros:** company mode 종료 시 안정성 향상
-- **Cons:** async/await 변환 필요
-- **Context:** `src/company/renderer/provisioner.ts` destroyCompanyWithCleanup. await Promise.all(disposePromises) 후 destroyCompany() 호출하도록 변경.
-- **Depends on:** 없음
+<!-- destroyCompanyWithCleanup race condition (#4) — RESOLVED. provisioner.ts
+     destroyCompanyWithCleanup() now `await Promise.all(ptyIds.map(dispose))`
+     BEFORE state.destroyCompany(), so the store is never cleared while a
+     dispose Promise is mid-flight. -->
 
-## Member workspace PTY leak on company destroy
-- **What:** company destroy 시 member workspace 내 분할된 pane의 PTY가 정리되지 않는 문제
-- **Why:** m.ptyId만 dispose하고 workspace 내 다른 surface의 PTY는 무시됨
-- **Pros:** 메모리 누수 방지
-- **Cons:** collectLeafSurfaces로 workspace별 PTY 수집 로직 필요
-- **Context:** `src/company/renderer/provisioner.ts` 및 기존 CompanyPanel.tsx의 destroy 로직
-- **Depends on:** 없음
+<!-- Member workspace PTY leak on company destroy (#5) — RESOLVED.
+     destroyCompanyWithCleanup() sweeps every member workspace AND the CEO
+     workspace via collectLeafSurfaces(rootPane), de-duping ptyIds before
+     dispose. No split-pane PTY survives a company destroy. -->
 
 ## (E3) Agent status dot transient flash on completed/waiting
 - **What:** `agentStatusIcon.ts`/`MiniSidebar` dot animation을 `completed`/`waiting` 전환 시점에 한 번만 발화 (예: 2s flash). 현재 `running`만 `animate-pulse`이고 나머지는 정적.
@@ -88,34 +79,18 @@
   signal materializes within 4 weeks of merge, downgrade back to P3 idea.
 - **Priority:** P1 (after measurement gate)
 
-## (P3) CLI notify command
-- **What:** `wmux notify --title X --body Y` CLI surface that triggers an
-  in-app notification. External scripts can signal wmux directly.
-- **Why:** Power-user request from external-advice-26-concepts review. MCP
-  `send_message` partially covers this, but a one-liner CLI is more ergonomic
-  for ad-hoc shell scripts.
-- **Pros:** No new infrastructure — existing `sendNotification` helper +
-  IPC route already exist. The CLI just shells into the daemon's named pipe.
-- **Cons:** Yet another surface to maintain. Demand unproven.
-- **Context:** Pattern matches existing `wmux` CLI subcommands. Hook into
-  daemon RPC routes. CC ~20 min if scoped tight.
-- **Depends on:** None.
-- **Priority:** P3 (defer until user demand surfaces)
+<!-- (P3) CLI notify command — RESOLVED. src/cli/commands/notify.ts implements
+     `wmux notify --title X --body Y` (parses both flags, sends the `notify`
+     RPC over the daemon pipe); src/main/pipe/handlers/notify.rpc.ts handles
+     it; `wmux notify` is listed in the CLI help. -->
 
-## (P3) findSurfaceByPtyId / findActiveLeaf dedup inside useNotificationListener
-- **What:** `findSurfaceByPtyId` is defined twice and `findActiveLeaf` twice
-  inside `src/renderer/hooks/useNotificationListener.ts` (lines 17, 32, 74,
-  ~311 from quick scan). Extract to a single utility.
-- **Why:** Minor DRY violation introduced during T8 refactor. The duplicates
-  are identical closures; they exist because the file evolved without a
-  cleanup pass.
-- **Pros:** Easier maintenance. Small file size reduction.
-- **Cons:** Touching the listener at all carries regression risk; isolated
-  refactor + green test suite is required.
-- **Context:** Extract to `src/renderer/utils/paneTraversal.ts`. The functions
-  are pure and have no React/store dependencies. CC ~10 min.
-- **Depends on:** None.
-- **Priority:** P3 (purely a maintenance nit)
+<!-- (P3) findSurfaceByPtyId / findActiveLeaf dedup — RESOLVED (this session).
+     Both helpers extracted to src/renderer/utils/paneTraversal.ts (pure, no
+     React/store deps). useNotificationListener now imports them; the two
+     inline findActiveLeaf closures (isActivePtySurface / resolveNotificationTarget)
+     are gone. Regression-locked listener tests (19) + full suite (2057) green.
+     NOTE: findSurfaceByPtyId was already de-duplicated to a single module-level
+     fn before this pass — only findActiveLeaf was still duplicated. -->
 
 <!-- (P3) Pre-existing daemon ProcessMonitor flake — RESOLVED 2026-05-22.
      Root cause: watch() relied on the CHECK_INTERVAL_MS setInterval tick
@@ -124,4 +99,56 @@
      Fix: watch() now triggers an immediate first runBatchCheck (production
      code) AND the test's outer it() timeout is bumped to 20s with a 15s
      vi.waitFor budget. Verified stable across 5 consecutive full-suite runs. -->
+
+## Duplicate-daemon / split-brain on "Quit (keep sessions)" → relaunch (P1)
+- **What:** "Quit (keep sessions running)" 후 `npm start` 재실행 시 둘째 데몬이 `wmux-daemon-rizz-1` 폴백 파이프로 기동 → 첫 데몬의 세션 파이프 EADDRINUSE → reattach 실패 → 새 세션 → 터미널 초기화. persistence가 깨짐 + 데몬 중복(RAM 낭비).
+- **Why:** (1) `ensureDaemon`이 살아있는 데몬에 재접속 안 하고 spawn. 유력 가설: 느린 OS probe(tasklist/WMI 타임아웃 머신)로 verify-ping 타임아웃→"데몬 없음" 오판 (false-death PR #87과 같은 근원 패턴). (2) `DaemonPipeServer.start()`(`src/daemon/DaemonPipeServer.ts:108-145`)의 `-N` 폴백이 *크래시 zombie*용인데 *살아있는 owner*와 구분 못 해 split-brain 허용.
+- **Pros:** 영속성(핵심 기능) 정상화 + 중복 데몬 제거.
+- **Cons:** 데몬 lifecycle = 최고위험 영역(여러 라운드 하드닝, issue #54). 성급한 패치 금지.
+- **Context:** 별도 plan + codex 반복 리뷰. 순서: ① verify-timeout 동작 확인(launcher/DaemonRespawnController) → ② ensureDaemon이 live 데몬 확실히 재사용(timeout≠부재) → ③ `-N` 폴백이 live owner면 abort/양보. 메모리 project_duplicate_daemon_split_brain 참조.
+- **Plan (grounded):** `plans/duplicate-daemon-split-brain.md` — 코드 대조로 3-defect
+  체인 확정. **Defect 1 = `launcher.ts:64-77` `isProcessAlive`의 `tasklist timeout →
+  catch → false`** (느린 머신서 live 데몬을 dead로 오판 → spawn). PR #87 ProcessMonitor와
+  동일 안티패턴. ② kill+spawn은 keep-sessions 의도와 모순(켜둔 세션 파괴)이라 escalating
+  re-ping + graceful 재사용으로 교체. ③ `-N` 폴백은 live-owner면 fail-fast→launcher 재접속.
+  Step별 codex 리뷰 게이트. 미구현(코드 미변경).
+- **Depends on:** 없음 (PR #87와 독립)
+- **Priority:** P1 (persistence 깨짐)
+
+## pty:resize "[UNKNOWN] rate limited" 폭주 + uncaught promise (P2 → renderer fix shipped)
+- **Status:** Renderer side FIXED (this session, option (a) — minimal form). All
+  three `useTerminal` resize call sites now route through a `sendResize` helper
+  that `.catch()`es the RPC, so a "rate limited" / "not found" reject can no
+  longer float as `Uncaught (in promise)`. On a "rate limited" reject it re-sends
+  the *live* geometry once after the per-socket window clears (~1.1 s), so a
+  resize dropped during a reconnect burst self-heals instead of stranding the PTY
+  at a stale size (callers update lastSentCols/Rows *before* the send, so an
+  identical re-fit was otherwise suppressed and never retried). tsc + full suite
+  (2057) green. **Verify via GUI dogfood** (clean-daemon relaunch with many panes,
+  watch console for the spam + confirm TUI geometry is correct).
+- **Deferred (optional, needs codex review):** the *transport-layer* mitigations —
+  (b) cross-terminal resize coalesce/debounce, or (c) exempting `pty:resize` from
+  the `DaemonPipeServer` per-socket limit (`DaemonPipeServer.ts:413`,
+  PER_SOCKET_RATE_LIMIT=50/s). These touch the security-sensitive rate limiter
+  and were intentionally NOT done here; the renderer fix removes the symptom
+  without altering the DoS guard. Revisit only if dogfood still shows dropped
+  resizes under extreme pane counts (>50 simultaneous).
+- **Dead-ptyId resize note:** a resize aimed at a swapped/disposed session returns
+  "not found", which the main `pty:resize` handler already retries-then-logs and
+  the new `sendResize` swallows — no uncaught reject, no infinite re-fire (the
+  ResizeObserver disconnects on unmount).
+- **Priority:** P2 (renderer symptom resolved; transport-layer option deferred)
+
+## Cross-platform liveness/probe 신뢰성 일반화 (P3, follow-up of PR #87)
+- **What:** Windows OS probe(tasklist/WMI)가 타임아웃하는 머신에서 "probe 실패=부재/죽음" 오해 패턴을 코드 전반에서 제거. PR #87이 ProcessMonitor kill 게이트는 고침. 같은 안티패턴이 남아있는지 audit(특히 데몬 verify, launcher PID 체크 — split-brain와 연결).
+- **Why:** 동일 근원 버그(느린 probe→오판)가 여러 곳에 잠복. 원칙: probe 실패는 "unknown"이지 "absent/dead"가 아님.
+- **Pros:** 느린/부하 머신에서 전반적 안정성.
+- **Cons:** audit 범위 넓음.
+- **Context:** `isAlive` catch→false 패턴 grep, launcher의 daemon verify 타임아웃 처리 확인. 메모리 project_processmonitor_false_death 참조.
+- **Audit done (2026-06-01):** `plans/duplicate-daemon-split-brain.md` §"Cross-platform
+  liveness/probe audit"에 사이트 표 작성. 확정 BAD 1건 = `launcher.ts:74` `isProcessAlive`
+  `catch→false` (split-brain Defect 1로 승격). `getProcessImage` null→category(c) throw는
+  안전, `ProcessMonitor`는 PR #87로 이미 정답. 원칙: timeout/예외 = `unknown`, 절대 `dead` 아님.
+- **Depends on:** split-brain plan과 함께 진행 (Step ①이 이 항목을 흡수)
+- **Priority:** P3 (P1 split-brain 작업 중 자연히 일부 커버됨)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",

--- a/plans/duplicate-daemon-split-brain.md
+++ b/plans/duplicate-daemon-split-brain.md
@@ -1,0 +1,132 @@
+# Plan: Duplicate-daemon / split-brain on "Quit (keep sessions)" → relaunch (P1)
+
+## Status
+Design / plan-level. **No code changed.** High-risk daemon-lifecycle area
+(issue #54 required 5 rounds of codex hardening). This doc grounds the fix in
+the real code so a future session can implement it behind iterative codex
+review. Folds in the P3 "cross-platform liveness/probe generalization" audit
+(TODOS.md) — same root cause, same files.
+
+## Symptom
+"Quit (keep sessions running)" leaves the daemon + its PTYs alive. On the next
+`npm start` / relaunch the terminal comes up **reset** (fresh sessions), and a
+**second daemon** is running. Persistence (the headline feature) is broken and
+RAM is wasted on the orphaned first daemon.
+
+## Root cause — a three-defect chain (all code-confirmed)
+
+Relaunch path is `ensureDaemon()` (`src/main/daemon/launcher.ts:352`). On a
+slow / loaded machine (the exact condition PR #87 fixed for ProcessMonitor) the
+chain is:
+
+### Defect 1 — `isProcessAlive` coerces a probe TIMEOUT to "dead"
+`launcher.ts:64-77`. On Windows it runs `tasklist.exe … { timeout: 3000 }` and
+`catch { return false; }`. If `tasklist` is slow (Defender realtime scan, CPU
+contention, WMI/Win32 pressure) it **throws on timeout → returns `false` →
+"process absent"** even though the daemon is alive. This is the **identical
+anti-pattern** PR #87 (commit c36b62b) removed from `ProcessMonitor`
+(`isDefinitelyDead` positive-confirmation gate). A `false` here makes
+`ensureDaemon` skip the ping/reuse branch entirely (the `if (existingPid &&
+isProcessAlive(existingPid))` guard at line 364 is false) → straight to "clean
+stale files + spawn".
+
+### Defect 2 — `pingDaemon` double-timeout also reads as "absent"
+`launcher.ts:186` (`timeout 3000 → resolve(false)`), called two-shot with a
+250 ms gap (lines 376-380). The two-shot retry is good, but on a genuinely slow
+box both shots can time out while the daemon is alive-but-busy. The fall-through
+then enters the **kill-verify gate** (lines 387-438): if the PID is image-verified
+as a wmux daemon (category a) it **SIGKILLs the live daemon and spawns** — which
+**destroys the very sessions the user chose to keep**. (Category c — unverifiable
+live — correctly throws; that path is already safe.)
+
+### Defect 3 — `DaemonPipeServer` `-N` fallback can't tell a LIVE owner from a zombie
+`src/daemon/DaemonPipeServer.ts:108-145`. When the freshly-spawned second daemon
+tries to `listen` on the canonical pipe and gets `EADDRINUSE`, `tryReclaimPipe`
+(line 158) probes it: **connect succeeds ⇒ a live process owns it ⇒ cannot
+reclaim** → it falls through to the suffixed name `wmux-daemon-rizz-1`
+(`attempt → ${pipeName}-${attempt}`, line 112-114). That fallback exists for
+**crash zombies**, but here the owner is the *live first daemon*. Result:
+**two daemons**, the second writes its `-1` pipe name to the `daemon-pipe` file,
+the new renderer connects to the empty second daemon (→ terminal reset), and the
+per-session pipes collide (`EADDRINUSE` on reattach).
+
+> The TODO's two suspected causes are both real; Defect 1 is the upstream
+> trigger that the original write-up under-weighted (it lumped the false-death
+> into "slow OS probe" generally — it is specifically `isProcessAlive`'s
+> `catch→false`, mirroring PR #87).
+
+## Fix design (ordered — implement + codex-review each step before the next)
+
+Guiding principle (same as PR #87): **a probe failure is `unknown`, never
+`absent`/`dead`.** "Keep the live daemon" must always win ties.
+
+### Step ① — `isProcessAlive` must not return `false` on a probe error
+Split the result into `alive | dead | unknown`. A `tasklist`/`ps` **timeout or
+exec error → `unknown`**, only an authoritative "no such PID" → `dead`. Callers
+that gate "should I spawn?" must treat `unknown` as **"assume alive, do not
+spawn over it."** (Mirror `ProcessMonitor.isDefinitelyDead`: only positive
+confirmation of death authorizes the destructive branch.)
+- Touch: `launcher.ts:64-77` (+ its callers at line 364 and the kill gate).
+- Lowest-risk shape: return a 3-state enum; map old `true`→alive,
+  old `false`(real "not listed")→dead, old `catch`→unknown.
+
+### Step ② — `ensureDaemon` reuses a live-but-unreachable daemon instead of killing it
+When the PID is `alive`/`unknown` **and** image-verified as a daemon, but the
+two-shot ping failed:
+- Do **NOT** SIGKILL + spawn (that nukes kept sessions). Instead **back off and
+  re-ping** with a longer budget (e.g. escalating 250 → 500 → 1000 ms, total a
+  few seconds — still inside the spawn budget) before considering any kill.
+- Only after the *escalated* ping still fails AND the process is image-verified
+  do we consider the daemon genuinely wedged. Even then, prefer a **graceful
+  shutdown RPC / detach-preserving restart** over blind SIGKILL so kept sessions
+  survive, or surface the failure via `DaemonRespawnController`'s budget + IPC
+  rather than spawning a racing second daemon.
+- Touch: `launcher.ts:376-438`, coordinate with `DaemonRespawnController`.
+
+### Step ③ — `-N` fallback yields to a live owner (zombie-only reclaim)
+In `DaemonPipeServer.start()`: when `EADDRINUSE` and `tryReclaimPipe` reports a
+**LIVE owner** (connect succeeded), do **not** take `-1`. Instead **fail fast**
+with a distinct error (e.g. `EDAEMON_ALREADY_RUNNING`) so the spawning daemon
+**exits cleanly** and the launcher **reconnects to the existing daemon** rather
+than treating `-1` as success. The `-N` suffix path stays ONLY for the
+genuine-zombie case (connect refused/reset → reclaim → retry canonical name).
+- Touch: `DaemonPipeServer.ts:108-145` + the spawn/handshake reader in
+  `launcher.ts` (must interpret the new "already running, reconnect" signal and
+  re-enter the reuse path, not loop into another spawn).
+- This is the most delicate step: the daemon entrypoint and the launcher
+  handshake must agree on the new exit semantics. Codex-review in isolation.
+
+## Cross-platform liveness/probe audit (folds in the P3 TODO)
+Sites where a probe failure is (or risks being) read as absent/dead:
+| Site | File:line | Current | Verdict |
+|---|---|---|---|
+| `isProcessAlive` | `launcher.ts:74` | `catch → false` | **BAD** — Defect 1, fix in Step ① |
+| `pingDaemon` | `launcher.ts:192` | `timeout → resolve(false)` | **Caller-dependent** — fine as a reachability signal; the *decision* on a timeout (Step ②) is what must change |
+| `getProcessImage` (`/proc`, `ps`) | `launcher.ts:171,183` | `catch → null` | OK — `null` flows to category (c) "unverifiable" which **throws** (refuses to act). Safe. |
+| `ProcessMonitor` | (PR #87) | `isDefinitelyDead` gate | **Already correct** — the template to copy. |
+Principle to enforce repo-wide: **only positive confirmation of death may
+authorize a destructive/spawn branch; every timeout/exception is `unknown`.**
+
+## Test strategy
+- **Unit:** `isProcessAlive` 3-state (mock a timing-out `tasklist`/`ps` →
+  `unknown`, a clean "no PID" → `dead`, a hit → `alive`). `ensureDaemon` with a
+  live daemon whose first two pings time out → asserts **reuse, no spawn, no
+  kill**. `DaemonPipeServer.start()` against a live-owner pipe → asserts
+  fail-fast (no `-1`), against a zombie pipe → asserts reclaim+retry.
+- **Dynamic** (bundled daemon subprocess + RPC probe, see
+  `reference_dynamic_test_pattern`): start daemon A, simulate a slow
+  `isProcessAlive`, run the launcher reuse path, assert **one** daemon and the
+  original sessions reattach. Then a real zombie-pipe case asserts `-1` reclaim
+  still works.
+- **Dogfood (required before any ship):** Quit (keep sessions) → relaunch on the
+  user's actual machine; confirm: exactly one daemon process
+  (`Get-CimInstance` child count, see `reference_stale_pid_in_sessions_json`),
+  sessions reattach with scrollback, no `-1` pipe, no terminal reset.
+
+## Constraints / process
+- **No push / PR until user GUI dogfood passes** (project policy).
+- Implement Step ① → codex review → Step ② → codex review → Step ③ → codex
+  review. Do **not** batch all three; issue #54 proved this area needs
+  incremental adversarial review (`reference_iterative_codex_review`).
+- Independent of PR #87 (already shipped on `fix/daemon-exit-observability`) and
+  of the `pty:resize` renderer fix; can branch from the same base.

--- a/scripts/resize-ratelimit-repro.cjs
+++ b/scripts/resize-ratelimit-repro.cjs
@@ -1,0 +1,257 @@
+/**
+ * Dynamic repro for the `pty:resize` rate-limit flood + uncaught-promise bug
+ * and the `sendResize` fix (TODOS "pty:resize '[UNKNOWN] rate limited' 폭주").
+ *
+ * Forces the exact daemon condition behind the bug — a resize burst on a
+ * single RPC socket exceeding DaemonPipeServer.PER_SOCKET_RATE_LIMIT (50/s) —
+ * against the REAL bundled daemon, then proves both halves of the fix:
+ *
+ *   R1  Burst of 70 resizes on one socket → some come back "rate limited".
+ *       (The trigger exists: a reconnect burst overruns the per-socket cap.)
+ *
+ *   R2  OLD renderer path — fire resizes with NO .catch (mimics
+ *       `window.electronAPI.pty.resize(...)`). The rate-limited rejections
+ *       float → Node emits `unhandledRejection`. This is the reported
+ *       "Uncaught (in promise)" console spam.
+ *
+ *   R3  NEW `sendResize` path — same burst, but each call is `.catch`ed and a
+ *       "rate limited" reject schedules ONE re-send of the live geometry after
+ *       the 1.1 s window clears. Asserts: ZERO unhandledRejection AND the
+ *       *target* geometry (137x42), which was rate-limited during the burst,
+ *       self-heals onto the daemon session (verified via daemon.listSessions).
+ *
+ * Run with Electron's node ABI so the spawned daemon can load node-pty:
+ *   $env:ELECTRON_RUN_AS_NODE=1; npx electron scripts/resize-ratelimit-repro.cjs
+ */
+const { spawn } = require('child_process');
+const net = require('net');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { randomUUID } = require('crypto');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const DAEMON_BUNDLE = path.join(REPO_ROOT, 'dist', 'daemon-bundle', 'index.js');
+const PER_SOCKET_LIMIT = 50; // DaemonPipeServer.PER_SOCKET_RATE_LIMIT
+const BURST = 70;            // > limit so the tail of the burst is rate-limited
+const TARGET = { cols: 137, rows: 42 }; // distinctive geometry for the self-heal
+
+if (!fs.existsSync(DAEMON_BUNDLE)) {
+  console.error('Daemon bundle missing — run `npm run build:daemon` first');
+  process.exit(2);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// A permanent listener so the INTENTIONAL floats in R2 don't crash the
+// process; a per-scenario counter is toggled via `countUnhandled`.
+let unhandledCount = 0;
+let counting = false;
+process.on('unhandledRejection', () => { if (counting) unhandledCount++; });
+process.on('uncaughtException', (err) => { console.error('[uncaughtException]', err.stack || err.message); });
+
+function makeTestHome() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-resize-rl-'));
+  fs.mkdirSync(path.join(home, '.wmux'), { recursive: true });
+  return home;
+}
+function makePipeName(tag) {
+  return process.platform === 'win32'
+    ? `\\\\.\\pipe\\wmux-test-${tag}`
+    : path.join(os.tmpdir(), `wmux-test-${tag}.sock`);
+}
+function writeConfig(wmuxDir, pipeName, authToken) {
+  fs.writeFileSync(path.join(wmuxDir, 'config.json'), JSON.stringify({
+    version: 1,
+    daemon: { pipeName, logLevel: 'warn', autoStart: true },
+    session: {
+      defaultShell: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
+      defaultCols: 80, defaultRows: 24, bufferSizeMb: 8, bufferMaxMb: 64,
+      deadSessionTtlHours: 24, deadSessionDumpBuffer: true,
+    },
+  }, null, 2));
+  fs.writeFileSync(path.join(wmuxDir, 'daemon-auth-token'), authToken, 'utf-8');
+}
+function spawnDaemon(testHome) {
+  return spawn(process.execPath, [DAEMON_BUNDLE], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, USERPROFILE: testHome, HOME: testHome, HOMEDRIVE: undefined, HOMEPATH: undefined },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+async function waitForPipeFile(wmuxDir, timeoutMs = 10_000) {
+  const pipeFile = path.join(wmuxDir, 'daemon-pipe');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(pipeFile)) return fs.readFileSync(pipeFile, 'utf-8').trim();
+    await sleep(100);
+  }
+  throw new Error('daemon-pipe did not appear within timeout');
+}
+function connectSocket(pipeName) {
+  return new Promise((resolve, reject) => {
+    const s = net.createConnection(pipeName, () => resolve(s));
+    s.on('error', reject);
+  });
+}
+function rpc(socket, method, params, authToken, timeoutMs = 15_000) {
+  return new Promise((resolve, reject) => {
+    const id = `req-${Math.random().toString(36).slice(2, 10)}`;
+    let buffer = '';
+    const handler = (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id === id) {
+            socket.removeListener('data', handler);
+            if (msg.ok) resolve(msg.result);
+            else reject(new Error(msg.error ?? 'rpc error'));
+            return;
+          }
+        } catch { /* ignore */ }
+      }
+    };
+    socket.on('data', handler);
+    socket.write(JSON.stringify({ id, method, params, token: authToken }) + '\n');
+    setTimeout(() => { socket.removeListener('data', handler); reject(new Error(`rpc timeout: ${method}`)); }, timeoutMs);
+  });
+}
+async function createSessionWithRetry(socket, authToken, base, cwd, attempts = 6) {
+  let lastErr = null;
+  for (let i = 1; i <= attempts; i++) {
+    const sessionId = i === 1 ? base : `${base}-r${i}`;
+    try {
+      await rpc(socket, 'daemon.createSession', {
+        id: sessionId, cmd: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
+        cwd, env: {}, cols: 80, rows: 24,
+      }, authToken);
+      return sessionId;
+    } catch (err) {
+      lastErr = err;
+      if (!/error code: 87|ConPTY|Cannot create process/i.test(err.message || '')) throw err;
+      await sleep(800 * i);
+    }
+  }
+  throw lastErr ?? new Error('createSession failed');
+}
+async function getSize(socket, sid, authToken) {
+  const list = await rpc(socket, 'daemon.listSessions', {}, authToken);
+  const s = Array.isArray(list) ? list.find((x) => x.id === sid) : null;
+  return s ? { cols: s.cols, rows: s.rows } : null;
+}
+
+// The fix under test, reproduced faithfully from useTerminal.ts `sendResize`.
+function sendResize(socket, sid, cols, rows, authToken) {
+  rpc(socket, 'daemon.resizeSession', { id: sid, cols, rows }, authToken).catch((err) => {
+    const msg = err && err.message ? err.message : String(err);
+    if (!msg.includes('rate limited')) return; // not-found / other handled upstream
+    setTimeout(() => {
+      // "live geometry" — here the latest intended (cols, rows).
+      rpc(socket, 'daemon.resizeSession', { id: sid, cols, rows }, authToken).catch(() => {});
+    }, 1100);
+  });
+}
+
+async function main() {
+  const testHome = makeTestHome();
+  const wmuxDir = path.join(testHome, '.wmux');
+  const tag = `resize-rl-${randomUUID().slice(0, 8)}`;
+  const pipeName = makePipeName(tag);
+  const authToken = randomUUID();
+  writeConfig(wmuxDir, pipeName, authToken);
+
+  const child = spawnDaemon(testHome);
+  let stderr = '';
+  child.stderr.on('data', (d) => { stderr += d.toString(); });
+
+  const report = [];
+  let socket;
+  try {
+    const resolvedPipe = await waitForPipeFile(wmuxDir);
+    socket = await connectSocket(resolvedPipe);
+    socket.setMaxListeners(0); // we fan out BURST concurrent rpc() data listeners
+    await sleep(1500);
+    const sid = await createSessionWithRetry(socket, authToken, `rl-${randomUUID().slice(0, 8)}`, wmuxDir);
+    await sleep(1300); // fresh rate window before R1
+
+    // ── R1: burst overruns the per-socket cap ─────────────────────────────
+    const r1 = await Promise.allSettled(
+      Array.from({ length: BURST }, (_, i) =>
+        rpc(socket, 'daemon.resizeSession', { id: sid, cols: 80 + (i % 10), rows: 24 }, authToken)),
+    );
+    const ok = r1.filter((r) => r.status === 'fulfilled').length;
+    const rl = r1.filter((r) => r.status === 'rejected' && /rate limited/.test(r.reason.message)).length;
+    const other = r1.filter((r) => r.status === 'rejected' && !/rate limited/.test(r.reason.message)).length;
+    report.push({ scenario: 'R1 burst→rate-limit', burst: BURST, ok, rateLimited: rl, other, pass: rl > 0 && ok > 0 });
+
+    await sleep(1300); // reset window
+
+    // ── R2: OLD path (no .catch) leaks unhandledRejection ─────────────────
+    unhandledCount = 0; counting = true;
+    for (let i = 0; i < BURST; i++) {
+      // No await, no .catch — exactly like the pre-fix renderer call.
+      rpc(socket, 'daemon.resizeSession', { id: sid, cols: 80 + (i % 10), rows: 24 }, authToken);
+    }
+    await sleep(700); // let the rejected promises surface as unhandledRejection
+    counting = false;
+    const r2Unhandled = unhandledCount;
+    report.push({ scenario: 'R2 old-path uncaught', unhandledRejections: r2Unhandled, pass: r2Unhandled > 0 });
+
+    await sleep(1300); // reset window
+
+    // ── R3: NEW sendResize → no unhandled + target geometry self-heals ────
+    // Baseline in a fresh window: pin the session to a known NON-target size.
+    await rpc(socket, 'daemon.resizeSession', { id: sid, cols: 80, rows: 24 }, authToken);
+    const baseline = await getSize(socket, sid, authToken); // expect 80x24, != TARGET
+    await sleep(1300); // fresh window for the burst
+
+    unhandledCount = 0; counting = true;
+    for (let i = 0; i < BURST; i++) {
+      // Put the distinctive TARGET geometry at the tail so it lands in the
+      // rate-limited zone (after the first ~50 consume the window) — the
+      // resize that gets DROPPED and must be recovered by the self-heal.
+      const geo = i >= BURST - 5 ? TARGET : { cols: 80 + (i % 10), rows: 24 };
+      sendResize(socket, sid, geo.cols, geo.rows, authToken);
+    }
+    // The ~20 rate-limited resizes each schedule a re-send at +1.1s (in the
+    // NEXT, un-saturated window). Wait well past that AND past the rate
+    // window so the verification listSessions runs clean.
+    await sleep(2600);
+    counting = false;
+    const sizeAfterHeal = await getSize(socket, sid, authToken);
+    const healed = !!sizeAfterHeal && sizeAfterHeal.cols === TARGET.cols && sizeAfterHeal.rows === TARGET.rows;
+    const baselineWasNonTarget = !!baseline && !(baseline.cols === TARGET.cols && baseline.rows === TARGET.rows);
+    report.push({
+      scenario: 'R3 sendResize fix',
+      unhandledRejections: unhandledCount,
+      baseline, sizeAfterHeal, target: TARGET,
+      baselineWasNonTarget, selfHealed: healed,
+      pass: unhandledCount === 0 && healed && baselineWasNonTarget,
+    });
+  } catch (err) {
+    if (stderr) console.error(`daemon stderr tail:\n${stderr.slice(-1500)}`);
+    report.push({ scenario: 'SETUP', pass: false, error: err.message });
+  } finally {
+    try { if (socket) socket.end(); } catch { /* ignore */ }
+    try { child.kill('SIGTERM'); } catch { /* ignore */ }
+    await sleep(600);
+    try { if (!child.killed) child.kill('SIGKILL'); } catch { /* ignore */ }
+    try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+
+  console.log('\n=== RESIZE RATE-LIMIT REPRO REPORT ===');
+  for (const e of report) console.log(JSON.stringify(e));
+  const failed = report.filter((r) => r.pass === false);
+  if (failed.length) {
+    console.error(`\n[FAIL] ${failed.length} scenario(s) failed.`);
+    process.exit(1);
+  }
+  console.log('\n[PASS] R1 reproduces the rate-limit burst; R2 reproduces the uncaught-promise leak; R3 proves sendResize swallows it AND self-heals the dropped geometry.');
+  process.exit(0);
+}
+
+main().catch((err) => { console.error('REPRO CRASHED:', err.stack || err.message); process.exit(1); });

--- a/src/daemon/DaemonPTYBridge.ts
+++ b/src/daemon/DaemonPTYBridge.ts
@@ -17,7 +17,7 @@ import { PromptEventLog, parseOsc133Payload } from './PromptEventLog';
  *  - 'critical' → { sessionId: string, event: CriticalEvent }
  *  - 'active'   → { sessionId: string }                — onActive cycle start
  *  - 'idle'     → { sessionId: string }                — onActiveToIdle
- *  - 'exit'     → { sessionId: string, exitCode }
+ *  - 'exit'     → { sessionId: string, exitCode, signal }
  */
 export class DaemonPTYBridge extends EventEmitter {
   private oscParser: OscParser | null = null;
@@ -146,9 +146,13 @@ export class DaemonPTYBridge extends EventEmitter {
     });
     this.dataDisposable = () => onDataDisposable.dispose();
 
-    // PTY exit handler
-    const onExitDisposable = ptyProcess.onExit(({ exitCode }) => {
-      this.emit('exit', { sessionId, exitCode });
+    // PTY exit handler. Capture `signal` alongside exitCode: a clean shell
+    // exit carries a numeric exitCode and no signal, whereas a terminated
+    // process (ConPTY torn down, killed) shows up as a signal or a null
+    // exitCode. That distinction is what the silent-death investigation needs
+    // to tell "the shell exited on its own" from "something killed it".
+    const onExitDisposable = ptyProcess.onExit(({ exitCode, signal }) => {
+      this.emit('exit', { sessionId, exitCode, signal });
     });
     this.exitDisposable = () => onExitDisposable.dispose();
   }

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -231,12 +231,23 @@ export class DaemonSessionManager extends EventEmitter {
       meta.lastActivity = new Date().toISOString();
     });
 
-    bridge.on('exit', (payload: { sessionId: string; exitCode: number | null }) => {
+    bridge.on('exit', (payload: { sessionId: string; exitCode: number | null; signal?: number }) => {
       meta.state = 'dead';
       meta.exitCode = payload.exitCode;
       // Clean up bridge timers/listeners to prevent leaks when sessions die naturally
       managed.bridge.cleanup();
-      this.emit('session:died', { id: params.id, exitCode: payload.exitCode });
+      // Enrich the death event with forensics so the daemon can log WHY a PTY
+      // exited: code/signal, the shell, and how long it had been idle before
+      // dying. Silent PTY deaths (no log, no recorded exitCode) made the
+      // "powershell exits -1 under claude" report undiagnosable.
+      const lastActivityMsAgo = Date.now() - new Date(meta.lastActivity).getTime();
+      this.emit('session:died', {
+        id: params.id,
+        exitCode: payload.exitCode,
+        signal: payload.signal,
+        cmd: meta.cmd,
+        lastActivityMsAgo,
+      });
       this.emit('session:stateChanged', { id: params.id, state: 'dead' as DaemonSessionState });
     });
 

--- a/src/daemon/ProcessMonitor.ts
+++ b/src/daemon/ProcessMonitor.ts
@@ -43,6 +43,47 @@ export class ProcessMonitor {
   }
 
   /**
+   * Positively confirm a PID is dead. Returns true ONLY when the liveness
+   * probe SUCCEEDS and reports the PID absent. THROWS when the probe itself
+   * fails (tasklist timeout/error) so the caller can tell "confirmed dead"
+   * from "couldn't check" and defer rather than kill.
+   *
+   * This is the critical distinction `isAlive` collapses: `isAlive` returns
+   * `false` on a probe error, conflating an unreachable/slow tasklist with a
+   * genuinely dead process. On machines where tasklist intermittently times
+   * out, that false negative makes the watch loop fire onDead for LIVE
+   * sessions (observed: powershell panes "exit -1" with exitCode=null while
+   * the process is still running). The kill gate must require positive proof.
+   */
+  static async isDefinitelyDead(pid: number): Promise<boolean> {
+    if (process.platform === 'win32') {
+      const { execFile } = require('child_process');
+      const { promisify } = require('util');
+      const execFileAsync = promisify(execFile);
+      const pathMod = require('path');
+      const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+      const tasklist = pathMod.join(systemRoot, 'System32', 'tasklist.exe');
+      // No catch: a timeout/error rejects, and the caller treats a rejection
+      // as "unknown — do not kill". A clean run that lacks the PID is the only
+      // path to a confirmed death.
+      const { stdout } = await execFileAsync(
+        tasklist,
+        ['/fi', `PID eq ${pid}`, '/fo', 'csv', '/nh'],
+        { encoding: 'utf-8', timeout: 3000, windowsHide: true },
+      );
+      return !(stdout as string).includes(`"${pid}"`);
+    }
+    // POSIX: kill(pid, 0) is reliable. ESRCH ⇒ dead; EPERM ⇒ alive (not ours).
+    try {
+      process.kill(pid, 0);
+      return false; // signal delivered ⇒ alive
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ESRCH') return true; // no such process
+      return false; // EPERM or other ⇒ exists / can't prove dead
+    }
+  }
+
+  /**
    * Batch-check all given PIDs in a single tasklist call (Windows).
    * Returns the set of PIDs that are alive.
    */
@@ -179,12 +220,19 @@ export class ProcessMonitor {
 
           let confirmedDead = false;
           try {
-            confirmedDead = !(await ProcessMonitor.isAlive(pid));
+            // Require POSITIVE proof of death. isDefinitelyDead throws when the
+            // probe itself fails (tasklist timeout), so a slow/unreachable
+            // tasklist can NEVER be read as "dead" — it falls into the catch
+            // and defers. (Previously this used `!isAlive(pid)`, which returns
+            // false on a probe error and thus mis-fired onDead for live
+            // sessions whenever tasklist timed out — the "powershell exit -1 /
+            // exitCode=null" false death.)
+            confirmedDead = await ProcessMonitor.isDefinitelyDead(pid);
           } catch {
-            // If the per-PID check itself errors, defer the decision to the
-            // next batch cycle rather than firing onDead. Better to leave a
-            // watcher in place for one extra tick than to mass-kill live
-            // sessions when the OS is having a bad five seconds.
+            // Probe failed (timeout/error): cannot confirm death. Defer to the
+            // next cycle rather than killing a possibly-live session. Better to
+            // leave a watcher in place for one extra tick than to mass-kill
+            // live sessions when the OS is having a bad five seconds.
             confirmedDead = false;
           }
 

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -272,7 +272,9 @@ describe('DaemonSessionManager', () => {
     // Simulate exit on the mock PTY
     lastMockPty?.simulateExit(1);
 
-    expect(diedHandler).toHaveBeenCalledWith({ id: 'die', exitCode: 1 });
+    // Payload also carries forensic fields (signal/cmd/lastActivityMsAgo) used
+    // by the daemon's death logging; assert the contract fields, tolerate extras.
+    expect(diedHandler).toHaveBeenCalledWith(expect.objectContaining({ id: 'die', exitCode: 1 }));
     const session = manager.getSession('die');
     expect(session?.meta.state).toBe('dead');
   });
@@ -460,7 +462,7 @@ describe('DaemonSessionManager', () => {
 
       lastMockPty?.simulateExit(2);
 
-      expect(diedHandler).toHaveBeenCalledWith({ id: 'rec-exit', exitCode: 2 });
+      expect(diedHandler).toHaveBeenCalledWith(expect.objectContaining({ id: 'rec-exit', exitCode: 2 }));
       expect(manager.getSession('rec-exit')?.meta.state).toBe('dead');
     });
   });

--- a/src/daemon/__tests__/ProcessMonitor.test.ts
+++ b/src/daemon/__tests__/ProcessMonitor.test.ts
@@ -149,17 +149,17 @@ describe('ProcessMonitor', () => {
   // for every watched session. The user-visible bug was "한번 터지면 모든
   // 터미널이 동시에 종료" — caused by tasklist returning unparseable output
   // once, which made aliveSet empty, which marked every PID dead in one tick.
-  // The fix re-verifies each apparent-dead PID via individual isAlive() before
+  // The fix re-verifies each apparent-dead PID via isDefinitelyDead() before
   // firing onDead.
   it('does not cascade-fire onDead when batch returns empty set but PIDs are alive', async () => {
     monitor = new ProcessMonitor();
     const batchSpy = vi.spyOn(ProcessMonitor, 'batchCheckAlive');
-    const isAliveSpy = vi.spyOn(ProcessMonitor, 'isAlive');
+    const deadSpy = vi.spyOn(ProcessMonitor, 'isDefinitelyDead');
 
     // Simulate the failure mode: batch reports nobody alive (parse failure),
-    // but per-PID isAlive correctly reports them alive.
+    // but the per-PID re-verify confirms they are NOT dead (still alive).
     batchSpy.mockResolvedValue(new Set<number>());
-    isAliveSpy.mockResolvedValue(true);
+    deadSpy.mockResolvedValue(false);
 
     const origInterval = (ProcessMonitor as any).CHECK_INTERVAL_MS;
     Object.defineProperty(ProcessMonitor, 'CHECK_INTERVAL_MS', { value: 50, configurable: true });
@@ -175,7 +175,7 @@ describe('ProcessMonitor', () => {
       // Wait for batch check + per-PID re-verify to complete
       await vi.waitFor(() => {
         expect(batchSpy).toHaveBeenCalled();
-        expect(isAliveSpy).toHaveBeenCalled();
+        expect(deadSpy).toHaveBeenCalled();
       }, { timeout: 2000 });
 
       // Give re-verify a chance to finish for all three
@@ -188,18 +188,18 @@ describe('ProcessMonitor', () => {
     } finally {
       Object.defineProperty(ProcessMonitor, 'CHECK_INTERVAL_MS', { value: origInterval, configurable: true });
       batchSpy.mockRestore();
-      isAliveSpy.mockRestore();
+      deadSpy.mockRestore();
     }
   });
 
   it('still fires onDead when both batch and per-PID confirm death', async () => {
     monitor = new ProcessMonitor();
     const batchSpy = vi.spyOn(ProcessMonitor, 'batchCheckAlive');
-    const isAliveSpy = vi.spyOn(ProcessMonitor, 'isAlive');
+    const deadSpy = vi.spyOn(ProcessMonitor, 'isDefinitelyDead');
 
     // Both layers agree this PID is gone — fire onDead.
     batchSpy.mockResolvedValue(new Set<number>());
-    isAliveSpy.mockResolvedValue(false);
+    deadSpy.mockResolvedValue(true);
 
     const origInterval = (ProcessMonitor as any).CHECK_INTERVAL_MS;
     Object.defineProperty(ProcessMonitor, 'CHECK_INTERVAL_MS', { value: 50, configurable: true });
@@ -214,50 +214,55 @@ describe('ProcessMonitor', () => {
     } finally {
       Object.defineProperty(ProcessMonitor, 'CHECK_INTERVAL_MS', { value: origInterval, configurable: true });
       batchSpy.mockRestore();
-      isAliveSpy.mockRestore();
+      deadSpy.mockRestore();
     }
   });
 
-  it('defers decision when per-PID isAlive itself errors', async () => {
+  // PRIMARY REGRESSION for the "powershell exits -1 / exitCode=null" false
+  // death: when the liveness probe itself fails (tasklist times out), the
+  // re-verify must NOT read that as death. The old gate used `!isAlive(pid)`,
+  // and isAlive returns false on a probe error — so a slow tasklist killed
+  // LIVE sessions. isDefinitelyDead throws on probe failure; the gate must
+  // catch that and defer, never firing onDead.
+  it('does NOT fire onDead when the death probe times out (live session survives a slow tasklist)', async () => {
     monitor = new ProcessMonitor();
     const batchSpy = vi.spyOn(ProcessMonitor, 'batchCheckAlive');
-    const isAliveSpy = vi.spyOn(ProcessMonitor, 'isAlive');
+    const deadSpy = vi.spyOn(ProcessMonitor, 'isDefinitelyDead');
 
-    // Batch reports dead, per-PID check throws. Defer rather than cascade-fire.
+    // Batch can't see the PID (timed out → empty), and the per-PID confirm
+    // probe also fails (tasklist timeout). The process is actually ALIVE.
     batchSpy.mockResolvedValue(new Set<number>());
-    isAliveSpy.mockRejectedValue(new Error('tasklist OS-level failure'));
+    deadSpy.mockRejectedValue(Object.assign(new Error('tasklist ETIMEDOUT'), { code: 'ETIMEDOUT' }));
 
     const origInterval = (ProcessMonitor as any).CHECK_INTERVAL_MS;
     Object.defineProperty(ProcessMonitor, 'CHECK_INTERVAL_MS', { value: 50, configurable: true });
 
     try {
       const onDead = vi.fn();
-      monitor.watch('sess-uncertain', 55555, onDead);
+      monitor.watch('sess-alive-but-probe-slow', 55555, onDead);
 
-      // Give batch + isAlive (rejected) time to run
       await vi.waitFor(() => {
-        expect(isAliveSpy).toHaveBeenCalled();
+        expect(deadSpy).toHaveBeenCalled();
       }, { timeout: 2000 });
-      await new Promise((r) => setTimeout(r, 100));
+      await new Promise((r) => setTimeout(r, 150));
 
-      // onDead must not fire on uncertainty — better to leak a watcher
-      // for one tick than to falsely kill a live session.
+      // The whole point: a probe timeout must never be read as a death.
       expect(onDead).not.toHaveBeenCalled();
     } finally {
       Object.defineProperty(ProcessMonitor, 'CHECK_INTERVAL_MS', { value: origInterval, configurable: true });
       batchSpy.mockRestore();
-      isAliveSpy.mockRestore();
+      deadSpy.mockRestore();
     }
   });
 
   it('only re-verifies the apparent-dead subset, not the whole watch list', async () => {
     monitor = new ProcessMonitor();
     const batchSpy = vi.spyOn(ProcessMonitor, 'batchCheckAlive');
-    const isAliveSpy = vi.spyOn(ProcessMonitor, 'isAlive');
+    const deadSpy = vi.spyOn(ProcessMonitor, 'isDefinitelyDead');
 
     // Three watched, one missing from batch result.
     batchSpy.mockResolvedValue(new Set<number>([11111, 22222]));
-    isAliveSpy.mockResolvedValue(false);
+    deadSpy.mockResolvedValue(true);
 
     const origInterval = (ProcessMonitor as any).CHECK_INTERVAL_MS;
     Object.defineProperty(ProcessMonitor, 'CHECK_INTERVAL_MS', { value: 50, configurable: true });
@@ -275,14 +280,14 @@ describe('ProcessMonitor', () => {
       }, { timeout: 2000 });
 
       // Only the missing one should have been re-verified
-      expect(isAliveSpy).toHaveBeenCalledTimes(1);
-      expect(isAliveSpy).toHaveBeenCalledWith(33333);
+      expect(deadSpy).toHaveBeenCalledTimes(1);
+      expect(deadSpy).toHaveBeenCalledWith(33333);
       expect(onDead1).not.toHaveBeenCalled();
       expect(onDead2).not.toHaveBeenCalled();
     } finally {
       Object.defineProperty(ProcessMonitor, 'CHECK_INTERVAL_MS', { value: origInterval, configurable: true });
       batchSpy.mockRestore();
-      isAliveSpy.mockRestore();
+      deadSpy.mockRestore();
     }
   });
 });

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -397,7 +397,7 @@ async function recoverSessions(
           const managed = sessionManager.getSession(recovered.id);
           if (managed && managed.meta.state !== 'dead') {
             managed.meta.state = 'dead';
-            sessionManager.emit('session:died', { id: recovered.id, exitCode: null });
+            sessionManager.emit('session:died', { id: recovered.id, exitCode: null, reason: 'recovery' });
           }
         });
 
@@ -450,7 +450,7 @@ async function recoverSessions(
             const managed = sessionManager.getSession(recovered.id);
             if (managed && managed.meta.state !== 'dead') {
               managed.meta.state = 'dead';
-              sessionManager.emit('session:died', { id: recovered.id, exitCode: null });
+              sessionManager.emit('session:died', { id: recovered.id, exitCode: null, reason: 'recovery' });
             }
           });
 
@@ -487,7 +487,7 @@ async function recoverSessions(
           const managed = sessionManager.getSession(recovered.id);
           if (managed && managed.meta.state !== 'dead') {
             managed.meta.state = 'dead';
-            sessionManager.emit('session:died', { id: recovered.id, exitCode: null });
+            sessionManager.emit('session:died', { id: recovered.id, exitCode: null, reason: 'recovery' });
           }
         });
 
@@ -566,7 +566,7 @@ function registerRpcHandlers(
       const managed = sessionManager.getSession(session.id);
       if (managed && managed.meta.state !== 'dead') {
         managed.meta.state = 'dead';
-        sessionManager.emit('session:died', { id: session.id, exitCode: null });
+        sessionManager.emit('session:died', { id: session.id, exitCode: null, reason: 'process-monitor' });
       }
     });
 
@@ -858,14 +858,14 @@ function wireEvents(
   // repeats as fatal and shuts the whole daemon down, killing every other
   // session as collateral damage. Per-step isolation ensures one session's
   // exit can't cascade into a mass kill.
-  sessionManager.on('session:died', (payload: { id: string; exitCode: number | null; signal?: number; cmd?: string; lastActivityMsAgo?: number }) => {
+  sessionManager.on('session:died', (payload: { id: string; exitCode: number | null; signal?: number; cmd?: string; lastActivityMsAgo?: number; reason?: string }) => {
     // OBSERVABILITY: PTY deaths were previously unlogged — a session could
     // vanish (e.g. powershell exiting -1 under a TUI like claude) with zero
     // trace in the daemon log, making root-cause impossible. Log the forensics
     // on every death. Read it as: NO preceding `destroySession` log for this id
     // ⇒ the process exited on its own (exitCode/signal say why); a
     // `destroySession` log just before ⇒ wmux killed it.
-    log('info', `[lifecycle] session:died id=${payload.id} exitCode=${payload.exitCode ?? 'null'} signal=${payload.signal ?? 'none'} cmd=${payload.cmd ?? '?'} idleMsBeforeExit=${payload.lastActivityMsAgo ?? '?'} liveTotal=${sessionManager.listSessions().length}`);
+    log('info', `[lifecycle] session:died id=${payload.id} reason=${payload.reason ?? 'pty-exit'} exitCode=${payload.exitCode ?? 'null'} signal=${payload.signal ?? 'none'} cmd=${payload.cmd ?? '?'} idleMsBeforeExit=${payload.lastActivityMsAgo ?? '?'} liveTotal=${sessionManager.listSessions().length}`);
     try {
       const event: DaemonEvent = {
         type: 'session.died',

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -585,6 +585,9 @@ function registerRpcHandlers(
   // daemon.destroySession
   pipeServer.onRpc('daemon.destroySession', async (params) => {
     const p = params as unknown as DaemonSessionIdParams;
+    // OBSERVABILITY: log wmux-initiated kills (pane/workspace close, reset) so
+    // they can be told apart from a process self-exit in the session:died log.
+    log('info', `[lifecycle] destroySession id=${p.id} reason=rpc`);
 
     // Remove data listener to prevent leak
     const tracked = sessionDataListeners.get(p.id);
@@ -855,7 +858,14 @@ function wireEvents(
   // repeats as fatal and shuts the whole daemon down, killing every other
   // session as collateral damage. Per-step isolation ensures one session's
   // exit can't cascade into a mass kill.
-  sessionManager.on('session:died', (payload: { id: string; exitCode: number | null }) => {
+  sessionManager.on('session:died', (payload: { id: string; exitCode: number | null; signal?: number; cmd?: string; lastActivityMsAgo?: number }) => {
+    // OBSERVABILITY: PTY deaths were previously unlogged — a session could
+    // vanish (e.g. powershell exiting -1 under a TUI like claude) with zero
+    // trace in the daemon log, making root-cause impossible. Log the forensics
+    // on every death. Read it as: NO preceding `destroySession` log for this id
+    // ⇒ the process exited on its own (exitCode/signal say why); a
+    // `destroySession` log just before ⇒ wmux killed it.
+    log('info', `[lifecycle] session:died id=${payload.id} exitCode=${payload.exitCode ?? 'null'} signal=${payload.signal ?? 'none'} cmd=${payload.cmd ?? '?'} idleMsBeforeExit=${payload.lastActivityMsAgo ?? '?'} liveTotal=${sessionManager.listSessions().length}`);
     try {
       const event: DaemonEvent = {
         type: 'session.died',

--- a/src/renderer/hooks/useNotificationListener.ts
+++ b/src/renderer/hooks/useNotificationListener.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useStore } from '../stores';
-import type { AgentStatus, NotificationType, Pane, PaneLeaf, Workspace } from '../../shared/types';
+import type { AgentStatus, NotificationType, Pane, Workspace } from '../../shared/types';
 import { playNotificationSound } from './useNotificationSound';
 import { createThrottler, type Throttler } from '../utils/createThrottler';
 import {
@@ -8,36 +8,18 @@ import {
   type NotifPayload,
   type PolicyContext,
 } from './useNotificationPolicy';
+import { findSurfaceByPtyId, findActiveLeaf } from '../utils/paneTraversal';
 
 // ─── Target resolution helpers (regression-locked, unchanged from pre-T8) ───
-// These two helpers were verified by the integration tests below (R1-R4)
-// to behave identically to the previous implementation. Any change here
-// would shift workspace resolution semantics and break callers.
-
-function findSurfaceByPtyId(root: Pane, ptyId: string): { surfaceId: string; paneId: string } | null {
-  if (root.type === 'leaf') {
-    const surface = root.surfaces.find((s) => s.ptyId === ptyId);
-    if (surface) return { surfaceId: surface.id, paneId: root.id };
-    return null;
-  }
-  for (const child of root.children) {
-    const found = findSurfaceByPtyId(child, ptyId);
-    if (found) return found;
-  }
-  return null;
-}
+// `findSurfaceByPtyId` / `findActiveLeaf` now live in ../utils/paneTraversal
+// (extracted to kill the in-file duplicates). They were verified by the
+// integration tests below (R1-R4) to behave identically to the previous
+// implementation. Any change there would shift workspace resolution semantics
+// and break callers.
 
 /** Check if a ptyId belongs to the active pane's active surface in a workspace */
 function isActivePtySurface(ws: { rootPane: Pane; activePaneId: string }, ptyId: string): boolean {
-  const findActiveLeaf = (pane: Pane): PaneLeaf | null => {
-    if (pane.type === 'leaf') return pane.id === ws.activePaneId ? pane : null;
-    for (const child of pane.children) {
-      const found = findActiveLeaf(child);
-      if (found) return found;
-    }
-    return null;
-  };
-  const leaf = findActiveLeaf(ws.rootPane);
+  const leaf = findActiveLeaf(ws.rootPane, ws.activePaneId);
   if (!leaf) return false;
   const activeSurface = leaf.surfaces.find((s) => s.id === leaf.activeSurfaceId);
   return activeSurface?.ptyId === ptyId;
@@ -71,15 +53,7 @@ export function resolveNotificationTarget(
   if (!ws) return null;
   // Best-effort active surface lookup. If no active leaf, the notification
   // is still recorded at the workspace level with no surfaceId / paneId.
-  const findActiveLeaf = (pane: Pane): PaneLeaf | null => {
-    if (pane.type === 'leaf') return pane.id === ws.activePaneId ? pane : null;
-    for (const child of pane.children) {
-      const found = findActiveLeaf(child);
-      if (found) return found;
-    }
-    return null;
-  };
-  const leaf = findActiveLeaf(ws.rootPane);
+  const leaf = findActiveLeaf(ws.rootPane, ws.activePaneId);
   const surfaceId = leaf?.surfaces.find((s) => s.id === leaf.activeSurfaceId)?.id;
   return { workspaceId: ws.id, surfaceId, paneId: leaf?.id };
 }

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -204,6 +204,33 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
   // enforcement) to preserve intentionally subtle dimmed text.
   const minimumContrastRatio = xtermTheme.background && isLight(xtermTheme.background) ? 4.5 : 1;
 
+  // Resize the daemon PTY without letting a rejected RPC float as an
+  // "Uncaught (in promise)". Two transient daemon errors are expected here and
+  // are both benign to the UI:
+  //   • "rate limited" — a reconnect burst (many panes recreating at once)
+  //     momentarily exceeds the daemon's per-socket cap (50 RPC/s, 1 s window).
+  //     The dropped resize would otherwise strand the PTY at a stale geometry
+  //     (callers update lastSentCols/Rows *before* the send, so an identical
+  //     re-fit is suppressed and never retries). Re-send the *live* geometry
+  //     once after the window clears (~1.1 s) so the size self-heals.
+  //   • "not found" — the session was swapped/disposed mid-resize; the main
+  //     pty:resize handler already retries-then-logs this, so we swallow it.
+  const sendResize = useCallback((targetPtyId: string, cols: number, rows: number) => {
+    window.electronAPI.pty.resize(targetPtyId, cols, rows).catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!msg.includes('rate limited')) return; // not-found / other: handled upstream
+      window.setTimeout(() => {
+        const term = terminalRef.current;
+        // Bail if the terminal was disposed or the pane swapped PTYs meanwhile.
+        if (!term || ptyIdRef.current !== targetPtyId) return;
+        const { cols: c, rows: r } = term;
+        if (c > 0 && r > 0) {
+          window.electronAPI.pty.resize(targetPtyId, c, r).catch(() => { /* give up quietly */ });
+        }
+      }, 1100);
+    });
+  }, []);
+
   const fit = useCallback(() => {
     const container = containerRef.current;
     if (!fitAddonRef.current || !terminalRef.current || !container) return;
@@ -218,7 +245,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         const { cols, rows } = terminalRef.current;
         // Never send 0-size resize to PTY — that corrupts the terminal buffer.
         if (cols > 0 && rows > 0) {
-          window.electronAPI.pty.resize(currentPtyId, cols, rows);
+          sendResize(currentPtyId, cols, rows);
         }
       }
     } catch {
@@ -857,7 +884,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     if (cols > 0 && rows > 0) {
       lastSentCols = cols;
       lastSentRows = rows;
-      window.electronAPI.pty.resize(ptyId, cols, rows);
+      sendResize(ptyId, cols, rows);
     }
 
     // Terminal registry registration is now per-branch above:
@@ -912,7 +939,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
             if (currentPtyId && cols > 0 && rows > 0 && (cols !== lastSentCols || rows !== lastSentRows)) {
               lastSentCols = cols;
               lastSentRows = rows;
-              window.electronAPI.pty.resize(currentPtyId, cols, rows);
+              sendResize(currentPtyId, cols, rows);
             }
           } catch {
             // ignore fit errors during unmount

--- a/src/renderer/utils/paneTraversal.ts
+++ b/src/renderer/utils/paneTraversal.ts
@@ -1,0 +1,44 @@
+// ─── Pane-tree traversal helpers (pure) ──────────────────────────────────────
+// Extracted from useNotificationListener.ts (TODOS "findSurfaceByPtyId /
+// findActiveLeaf dedup"). These are pure functions over the Pane tree with no
+// React / store dependencies, so they live here and are shared by every
+// notification/metadata routing path. Behavior is byte-for-byte identical to
+// the previous in-file copies — the listener's regression tests (R1-R4) lock
+// the routing semantics, so any change here must preserve them exactly.
+
+import type { Pane, PaneLeaf } from '../../shared/types';
+
+/**
+ * Locate the surface that owns a given ptyId anywhere in a pane tree.
+ * Returns the owning surface id + the leaf pane id, or null if no surface in
+ * the tree is bound to `ptyId`.
+ */
+export function findSurfaceByPtyId(
+  root: Pane,
+  ptyId: string,
+): { surfaceId: string; paneId: string } | null {
+  if (root.type === 'leaf') {
+    const surface = root.surfaces.find((s) => s.ptyId === ptyId);
+    if (surface) return { surfaceId: surface.id, paneId: root.id };
+    return null;
+  }
+  for (const child of root.children) {
+    const found = findSurfaceByPtyId(child, ptyId);
+    if (found) return found;
+  }
+  return null;
+}
+
+/**
+ * Find the active leaf pane in a tree — the leaf whose id matches
+ * `activePaneId`. Returns null when the active pane is not a leaf in this tree
+ * (or the tree has no such id).
+ */
+export function findActiveLeaf(pane: Pane, activePaneId: string): PaneLeaf | null {
+  if (pane.type === 'leaf') return pane.id === activePaneId ? pane : null;
+  for (const child of pane.children) {
+    const found = findActiveLeaf(child, activePaneId);
+    if (found) return found;
+  }
+  return null;
+}


### PR DESCRIPTION
## This PR ships **v2.16.1** (stability patch)

Originally opened for the daemon false-death fix; it now bundles the full v2.16.1
release. Three substantive changes plus docs:

1. **Daemon false-death fix** (`4a0f3ef` + `c36b62b`) — ProcessMonitor no longer reaps
   a live session when a `tasklist` probe times out. *(full root-cause writeup below)*
2. **`pty:resize` console-spam fix** (`fe9965a`) — renderer no longer leaks
   `Uncaught (in promise)` on a reconnect resize burst, and a dropped resize self-heals.
3. **Pane-traversal dedup** (`9b4d728`) — pure-function extraction, zero behaviour change.
4. **Docs** (`540600f`) — TODOS cleanup + a grounded plan for the (still-deferred) P1
   duplicate-daemon split-brain bug.

`vitest run`: **2057 passed** on the merged branch. Version bumped to `2.16.1`.

---

## Daemon false-death fix

### Root cause

Reproducible bug: a wmux pane running `claude` (or any TUI) would show
`[프로세스가 코드 -1로 종료됨]` and reset — the shell appeared to exit while it
was still running. Reported for months as "intermittent Windows PowerShell exit
(-1 / -65536)" and previously mis-attributed to memory pressure / the .NET
`InitialSessionState` initializer. Both were wrong.

`ProcessMonitor` checks PID liveness on Windows via `tasklist`, and
`isAlive()` returns `false` on ANY probe error — including a `tasklist` timeout.
On a loaded/slow machine `tasklist` times out (observed: even the current
process's own PID probe returned `ETIMEDOUT` at the 3s cap). The watch loop then
read a LIVE powershell as dead and fired `onDead` → the daemon marked the
session dead and emitted `session:died{exitCode:null}` → the renderer showed the
exit banner while the process was still alive (false death + orphaned process,
which also fed the background-RAM accumulation). The existing batch+re-verify
guard didn't help: both layers route through `isAlive`, which swallows a timeout
as "dead". This 5s loop meant every session was a false-death waiting to happen,
which is exactly why it read as "intermittent".

### How it was found

Added daemon-side death instrumentation (`4a0f3ef`): `session:died` now carries
`signal`/`cmd`/idle-before-exit and is logged, and every emit is tagged with a
`reason`. The reproduction logged `session:died ... exitCode=null cmd=?` — `cmd=?`
proved it did NOT come from a real PTY exit (that path sets `cmd`), pinning it to
the ProcessMonitor watch-callback emit.

### Fix (`c36b62b`)

The kill gate now requires POSITIVE proof of death:
- New `ProcessMonitor.isDefinitelyDead(pid)`: true only when the probe SUCCEEDS
  and reports the PID absent; THROWS on probe failure (timeout/error).
- The re-verify gate calls it instead of `!isAlive(pid)`; a thrown probe error is
  caught and DEFERS to the next cycle, so a slow/unreachable `tasklist` can never
  be read as a death. `isAlive` is unchanged (other callers keep their contract).
- Every `session:died` emit tagged with `reason` (process-monitor / recovery /
  pty-exit) and logged, so a death's origin is visible in the daemon log.

### Dogfood — verified

User confirmed ("이제 잘된다"). Daemon log evidence: since the fixed daemon
started, **zero** `session:died` events and the `claude` session stayed attached
and alive (previously it died within ~16s to a tasklist-timeout false death).

---

## `pty:resize` console-spam fix (`fe9965a`)

On a clean-daemon relaunch the saved-session reconnect→recreate burst fires many
`pty:resize` RPCs on one socket, exceeding the daemon's per-socket rate limit
(`DaemonPipeServer` `PER_SOCKET_RATE_LIMIT=50`/s). The three renderer resize call
sites in `useTerminal.ts` were fire-and-forget, so the `rate limited` rejection
floated as `Uncaught (in promise)` — console spam, and (because callers update
`lastSentCols/Rows` *before* the send) the dropped resize was never retried, so the
PTY could stay stuck at a stale geometry.

Fix: a `sendResize` helper `.catch()`es the resize RPC. A `not found` / other reject
is swallowed (the main `pty:resize` handler already retries-then-logs not-found). A
`rate limited` reject re-sends the **live** geometry once after the 1.1s rate window
clears, guarded by `!term || ptyIdRef.current !== targetPtyId`, so it can't fire on a
disposed terminal or a swapped PTY, and the re-send uses the raw RPC (no recursion →
no compounding loop).

### Verification (forced, headless)

`scripts/resize-ratelimit-repro.cjs` (bundled-daemon subprocess, run via
`ELECTRON_RUN_AS_NODE=1 npx electron`) reproduces the exact condition and proves both
halves, deterministically:

| Scenario | Result |
|---|---|
| R1 burst of 70 resizes on one socket | **50 ok / 20 rate-limited** (cap=50 confirmed) |
| R2 old no-`catch` path | **20 `unhandledRejection`** (the bug, reproduced) |
| R3 new `sendResize` | **0 `unhandledRejection`** + baseline 80×24 → self-heal 137×42 |

---

## Pane-traversal dedup (`9b4d728`)

`findSurfaceByPtyId` + `findActiveLeaf` extracted to `src/renderer/utils/paneTraversal.ts`
as pure functions; `useNotificationListener`'s two inline `findActiveLeaf` closures
removed. An independent adversarial review confirmed the extracted functions are
**byte-for-byte identical** to both originals; the R1-R4 notification-routing
regression tests stay green.

---

## Test plan

- [x] `vitest run` — **164 files / 2057 tests passed** (merged branch, re-run).
- [x] `tsc --noEmit` clean for the renderer changes.
- [x] `eslint` — lint-neutral (no new findings; the 6 pre-existing warnings/errors are
  in untouched code).
- [x] Resize fix proven by the headless `resize-ratelimit-repro.cjs` (R1/R2/R3).
- [x] Independent adversarial review of the renderer diff → **NO ISSUES**.
- [x] Daemon false-death fix dogfood-verified by the maintainer.
- [ ] **GUI dogfood for the resize fix (A) was explicitly SKIPPED by the maintainer as
  a knowing policy exception.** The mechanism is verified by unit tests + the dynamic
  repro + adversarial review, but the real `useTerminal` wiring + visual TUI geometry
  were not eyeballed in the running app before this release. Recorded here honestly.

## Follow-up (separate, deferred)

- **Duplicate-daemon / split-brain (P1)** — after "Quit (keep sessions running)",
  relaunch can spawn a second daemon on a `-N` fallback pipe → `EADDRINUSE` on the
  first daemon's session pipes → reattach fails → terminal resets. The exposed-by-
  persistence bug now has a grounded plan: `plans/duplicate-daemon-split-brain.md`
  (3-defect chain; **Defect 1 = `launcher.ts:74` `isProcessAlive` `tasklist` timeout
  → `catch → false`**, the same anti-pattern as this PR's ProcessMonitor fix). High-risk
  daemon-lifecycle area — implementation is step-by-step behind codex review, not in
  this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
