### PR TITLE
feat(daemon): configurable substrate 3.0 lifecycle thresholds

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -383,7 +383,7 @@ There are four resolution paths in the current implementation, in order of prefe
 | C | `mcp.claimWorkspace` (external-caller fallback) | When paths B and A both fail (typical for an MCP server launched from a non-wmux terminal such as `cmd`, Windows Terminal, or VS Code's integrated terminal), the first pane-targeted tool call invokes `mcp.claimWorkspace`. The daemon spawns a dedicated background workspace named `MCP`, creates a PTY pane inside it, restores the previously-active workspace so the user's focus is not stolen, and pins the new `ptyId` for the MCP server's lifetime. | First claim ≈ 100–400 ms (workspace + PTY spawn). Subsequent calls hit the pin. | Deterministic per MCP server process. |
 | D | `activeWorkspaceId` (renderer-side fallback) | A small number of legacy RPCs (notifications and some renderer-side surfaces) accept an optional `workspaceId` parameter; if omitted, the renderer falls back to `store.activeWorkspaceId`. This path predates `mcp.claimWorkspace` and survives in places that have not yet been migrated. | Instant. | **Non-deterministic — depends on whatever workspace the user is viewing at the moment of the call.** |
 
-Path B is the substrate-aligned answer: it anchors identity to the immutable `ptyId` and resolves the owning workspace live, so it survives workspace-id re-minting. Path A is now a stale-prone hint, demoted to a last resort behind B (it previously short-circuited resolution, which left agents permanently stuck on a dead workspace id after a respawn/restore — "no workspace found for ws-…"). Path C covers non-wmux terminals; path D is the only remaining footgun and is the substrate boundary documented in §7.
+Path B is the substrate-aligned answer: it anchors identity to the immutable `ptyId` and resolves the owning workspace live, so it survives workspace-id re-minting. Path A is now a stale-prone hint, demoted to a last resort behind B (it previously short-circuited resolution, which left agents permanently stuck on a dead workspace id after a respawn/restore — "no workspace found for ws-…"). Path C covers non-wmux terminals; path D is the only remaining footgun and is the substrate boundary documented in §8.
 
 **Substrate alignment notes:**
 
@@ -395,7 +395,50 @@ Path B is the substrate-aligned answer: it anchors identity to the immutable `pt
 
 ---
 
-## 7. Known limitations and v3.0 boundaries
+## 7. Daemon lifecycle & resource floors
+
+§§1–6 cover the state, event, and identity surfaces. This section covers the daemon **lifecycle** and the **config contract** that parameterises it.
+
+The governing principle mirrors the neutrality of the other surfaces. The substrate enforces **resource floors** — configurable, triggered by measured pressure or count, and resolved by *refusing* new work or *garbage-collecting* dead artifacts. It never evicts a *live* session because of idle-time or age. Idle/age eviction is workflow policy and lives in an outer layer (§8).
+
+### 7.1 Three tiers
+
+| Tier | Owner | Behaviour |
+|---|---|---|
+| **1 — Mechanism** | substrate, no knob | create / destroy / attach / detach; persist-across-detach + recover; **exit-empty** — the daemon exits after a grace window once *zero* live sessions remain. This fires on count == 0 (the daemon has nothing to hold), never on idle-time. |
+| **2 — Resource floor** | substrate, **configurable threshold** | `maxSessions` cap → refuse new with `RESOURCE_EXHAUSTED` (never evict existing); memory-pressure ladder → warn, then GC dead tombstones, then refuse new (never kill live); dead/suspended **tombstone GC** on a configurable TTL. |
+| **3 — Policy** | outer layer (GUI / plugin / operator), off by default | idle-session reaping, suspend-on-idle, age-based eviction of *live* sessions, "kill oldest to make room". The substrate's only role is to expose the facts and the `destroySession` mechanism; the decision lives here. **Not in the substrate.** |
+
+A Tier-2 floor is legitimate substrate only because its threshold is a knob, not a literal, and it reacts to measured pressure/count (or GCs an artifact with no live process behind it) — never to idle-time, age, or intent. Reaping a dead/suspended tombstone is garbage collection (no live process behind the retained metadata); reaping a *live* idle session would be eviction and belongs in Tier 3.
+
+### 7.2 Config contract
+
+The daemon reads `~/.wmux/config.json`. Lifecycle knobs and their defaults:
+
+| Key | Default | Floor / cap | Semantics |
+|---|---|---|---|
+| `daemon.idleShutdownMinutes` | `5` | `0` = off | exit-empty grace window (Tier 1). `0` keeps the daemon alive forever. |
+| `daemon.memWarnMb` | `500` | floor 128, cap = physical RAM | RSS ≥ this → log a warning (Tier 2). |
+| `daemon.memReapMb` | `750` | floor 192, cap = RAM | RSS ≥ this → GC DEAD tombstones. |
+| `daemon.memBlockMb` | `1024` | floor 256, cap = RAM | RSS ≥ this → refuse new sessions until RSS recovers. A value below the floor is clamped **and logged at startup** — a block threshold under normal idle RSS would silently brick session creation. |
+| `session.maxSessions` | `200` | floor 1, cap 10000 | hard cap on concurrent sessions; new-session creation throws `RESOURCE_EXHAUSTED` at the cap. Startup recovery derives its own soft cap as `min(maxSessions, 40)`, so a freshly lowered cap can never dead-mark persisted sessions. |
+| `session.suspendedTtlHours` | `168` (7d) | floor 1, cap 8760 (1y) | a SUSPENDED tombstone idle longer than this is GC'd on the next load. |
+| `session.deadSessionTtlHours` | `24` | — | a DEAD tombstone older than this is reaped. Captured **per session at create time**; a config change applies only to *new* sessions — existing tombstones keep their create-time value (no silent retroactive change). |
+
+Contract rules:
+
+- **Per-field backfill.** A config.json missing a lifecycle key gets that key filled from its default; a key with a garbage value is reset to its default **in isolation** — a single bad field never resets the whole file (whole-file reset stays reserved for core-structure breakage like a missing `pipeName`). `idleShutdownMinutes` is the one exception and keeps its pre-existing whole-reset-on-garbage validation.
+- **Floors have no "off".** `0`/negative on a floor (`maxSessions`, the memory triple, `suspendedTtlHours`) clamps to the floor; "permanent" retention is a large value, not `0`. Only `idleShutdownMinutes` treats `0` as off.
+- **Memory order invariant.** After per-field clamping the substrate enforces `memWarnMb ≤ memReapMb ≤ memBlockMb`, raising `reap`/`block` rather than lowering `warn`.
+- **Operator contract, not wire contract.** These keys are a daemon **config** contract, distinct from the §1–§3 pane/event/identity **wire** contract — but still a contract: renaming a key or changing a default is a compatibility concern.
+
+### 7.3 Lifecycle facts and events
+
+The daemon tracks `createdAt`, `lastActivity`, and `state` (`attached` / `detached` / `suspended` / `dead`) per session, surfaced to the wmux main process via the internal `daemon.listSessions` RPC. A **client-facing** idle surface on the external event bus — an `idleSince` fact plus a `session.idleThresholdExceeded` event (emit-only; the substrate would never act on it) — is deferred to v3.1: no Tier-3 consumer exists yet, and wiring an unused event into the contract would be a proxy-metric anti-pattern. v3.0 ships the floors and the config contract; it emits no idle event.
+
+---
+
+## 8. Known limitations and v3.0 boundaries
 
 Things external clients may run into that aren't bugs but are explicit substrate boundaries:
 
@@ -404,15 +447,17 @@ Things external clients may run into that aren't bugs but are explicit substrate
 - **Cursor evolution.** The opaque-cursor guarantee is a forward-compat hedge. If sharded rings ship in v3.x, the encoding may change; opaque-cursor clients are unaffected by design.
 - **Layered status precedence.** The substrate does not enforce precedence among writers of the top-level `status` field. Last writer wins. Tools that need precedence should coordinate via `custom.<tool>.status` and pick one tool to own the shared field.
 - **Cross-producer ordering.** `seq` is arrival order, not causal order. See §2.7.
+- **Lifecycle neutrality — the substrate enforces resource floors, never idle/age eviction.** The daemon refuses new sessions at `session.maxSessions` (`RESOURCE_EXHAUSTED`) and under memory pressure, and GCs dead/suspended tombstones on configurable TTLs — all count/pressure/GC-based. It never kills or suspends a *live* session because it has been idle or old. Idle-session reaping, age eviction, and "kill oldest to make room" are outer-layer policy (GUI app / plugin / operator): the substrate exposes the facts (`createdAt`, `lastActivity`, session `state`) and the `destroySession` mechanism, but the decision lives above it. See §7 for the tier model and config contract.
 
 ---
 
-## 8. Change history of this document
+## 9. Change history of this document
 
 | Version | Date | Notes |
 |---|---|---|
 | Draft 1 | 2026-05-12 | Phase 0 initial draft. Covers PaneMetadata layered status, mergeMode, version + expectedVersion, bootId, cursor opaqueness, snapshot envelope, permission enforcement (sketch), Named Pipe security model. Phase 1 M3 will expand. |
 | Draft 2 | 2026-05-16 | Phase 1 M4 — adds §6.1 `workspaceId` resolution paths (env / PID-tree walk / `mcp.claimWorkspace` / legacy `activeWorkspaceId` fallback). §7 limitation entry rewritten to point at §6.1 and to define the path-D removal as a Phase 2.1 work item rather than a v3.0 blocker. |
 | Draft 3 | 2026-05-18 | Phase 2.1 follow-up — §4.2 adds structured rejection result for `mcp.declarePermissions` (discriminated union with per-entry `errors`) and the trust-DB invariants subsection: capability-widening demotion, LRU eviction cap, transport-close identity clear. No method-dispatch enforcement yet. |
+| Draft 4 | 2026-06-01 | Substrate 3.0 lifecycle boundary — adds §7 (daemon lifecycle three-tier model, config contract for the 5 new lifecycle knobs, lifecycle facts/event deferral to v3.1) and the §8 "Lifecycle neutrality" boundary entry. Documents resource-floor neutrality: substrate refuses/GCs on pressure/count, never evicts a live session on idle/age (that is outer-layer policy). Renumbered prior §7/§8 → §8/§9. |
 
 This document evolves alongside the implementation. Changes that affect the wire contract require a major-version bump per [`api/versioning.md`](./api/versioning.md). Changes that clarify existing semantics ship in any release.

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -9,11 +9,11 @@ import { PromptEventLog } from './PromptEventLog';
 import { buildSpawnInjection } from './shell-integration';
 import { buildSafeChildEnv } from '../shared/envFilter';
 import { isMac } from '../shared/platform';
+import { createDefaultConfig } from './config';
 
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
 const DEFAULT_BUFFER_SIZE = 512 * 1024; // 512 KB
-const DEFAULT_DEAD_TTL_HOURS = 24;
 
 /**
  * Internal type: session metadata + runtime resources.
@@ -86,18 +86,22 @@ export class DaemonSessionManager extends EventEmitter {
       throw new Error(`Invalid session ID: must be 1-64 chars of [a-zA-Z0-9_-]`);
     }
 
+    // Resolve effective config once. The daemon main calls setConfig()
+    // before any createSession(); the createDefaultConfig() fallback only
+    // covers tests / early-boot paths and keeps the default SSOT in
+    // config.ts (createDefaultConfig) rather than re-hardcoding 200 / 24 here.
+    const cfg = this.config ?? createDefaultConfig();
+
     // Guard against resource exhaustion from unbounded session creation.
-    // The error message is user-facing — phrase it as an action the user
-    // can actually take so a cap lockout doesn't read as a generic toast.
-    //
-    // 50 → 200: the v2.8.1 soft cap (MAX_RECOVER_SESSIONS=40) only gates
-    // startup recovery. Detached sessions still accumulate at runtime
-    // because the daemon keeps them alive across X-closes, so 50 is too
-    // tight for multi-workspace users. Soft-cap policy unchanged.
-    const MAX_SESSIONS = 200;
-    if (this.sessions.size >= MAX_SESSIONS) {
+    // Substrate 3.0 Tier-2 floor: refuse the new session (RESOURCE_EXHAUSTED)
+    // — never evict an existing one to make room. The error message is
+    // user-facing, so phrase it as an action the user can actually take.
+    // The ceiling is configurable via session.maxSessions (default 200);
+    // startup recovery derives its own soft cap as min(maxSessions, 40).
+    const maxSessions = cfg.session.maxSessions;
+    if (this.sessions.size >= maxSessions) {
       throw new Error(
-        `Cannot create new terminal: ${MAX_SESSIONS} active sessions already running. ` +
+        `Cannot create new terminal: ${maxSessions} active sessions already running. ` +
           `Close some panes (or restart wmux) and try again.`,
       );
     }
@@ -167,7 +171,12 @@ export class DaemonSessionManager extends EventEmitter {
       env,
       cols,
       rows,
-      deadTtlHours: DEFAULT_DEAD_TTL_HOURS,
+      // Per-session snapshot of the dead-TTL config. codex #5: this is
+      // captured at create time and the reaper reads the per-session value,
+      // so a later config change applies only to NEW sessions — existing
+      // tombstones keep the value they were created with (no silent
+      // retroactive change to retention).
+      deadTtlHours: cfg.session.deadSessionTtlHours,
     };
     if (params.agent) {
       meta.agent = params.agent;

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -98,8 +98,19 @@ export class DaemonSessionManager extends EventEmitter {
     // user-facing, so phrase it as an action the user can actually take.
     // The ceiling is configurable via session.maxSessions (default 200);
     // startup recovery derives its own soft cap as min(maxSessions, 40).
+    //
+    // Count only LIVE PTYs (attached/detached). DEAD tombstones linger in the
+    // map until the TTL/memory reaper runs but hold no live PTY — counting
+    // them would wrongly reject a new session under a low maxSessions the
+    // moment a PTY dies (codex P2). `suspended` never sits in this runtime
+    // map (it is a disk-only state the shutdown path demotes live sessions to
+    // before persisting, and recovery re-creates them as `detached`).
     const maxSessions = cfg.session.maxSessions;
-    if (this.sessions.size >= maxSessions) {
+    let liveCount = 0;
+    for (const m of this.sessions.values()) {
+      if (m.meta.state === 'attached' || m.meta.state === 'detached') liveCount++;
+    }
+    if (liveCount >= maxSessions) {
       throw new Error(
         `Cannot create new terminal: ${maxSessions} active sessions already running. ` +
           `Close some panes (or restart wmux) and try again.`,

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -70,6 +70,13 @@ export class DaemonSessionManager extends EventEmitter {
     rows?: number;
     agent?: { role: string; teamId: string; displayName: string };
     createdAt?: string;
+    /**
+     * Recovery passes the session's persisted per-session dead-TTL so a
+     * recovered session keeps its create-time retention instead of being
+     * restamped from the current config (codex P2). Omitted for brand-new
+     * sessions, which take the config default.
+     */
+    deadTtlHours?: number;
     scrollbackData?: Buffer;
     /**
      * v2.8.1 hotfix: when true, the bridge starts muted so PTY output
@@ -182,12 +189,13 @@ export class DaemonSessionManager extends EventEmitter {
       env,
       cols,
       rows,
-      // Per-session snapshot of the dead-TTL config. codex #5: this is
-      // captured at create time and the reaper reads the per-session value,
-      // so a later config change applies only to NEW sessions — existing
-      // tombstones keep the value they were created with (no silent
-      // retroactive change to retention).
-      deadTtlHours: cfg.session.deadSessionTtlHours,
+      // Per-session dead-TTL. codex #5: captured at create time and the
+      // reaper reads the per-session value, so a later config change applies
+      // only to NEW sessions. Recovery passes the persisted value
+      // (params.deadTtlHours) so a recovered session keeps its create-time
+      // retention; a brand-new session takes the current config default
+      // (codex P2 — recovery must not silently restamp existing retention).
+      deadTtlHours: params.deadTtlHours ?? cfg.session.deadSessionTtlHours,
     };
     if (params.agent) {
       meta.agent = params.agent;

--- a/src/daemon/StateWriter.ts
+++ b/src/daemon/StateWriter.ts
@@ -13,17 +13,21 @@ import { AsyncQueue } from './util/AsyncQueue';
 const DEBOUNCE_MS = 30_000;
 const QUEUE_KEY = 'state';
 
-// Suspended sessions persist across daemon restarts so an interrupted
-// shell can be resumed. Without a TTL they accumulate indefinitely:
-// every X-button shutdown re-suspends every live session, the next
-// launch recovers them, and any panes the user adds before the next
-// shutdown ride along forever. v2.8.0 shipped without this bound and
-// users reached the 50-session hard cap after a few launches, at which
-// point recovery throws and new pane creation throws — wmux silently
-// becomes unusable. 7 days mirrors the dead-session pattern (24h × 7)
-// so a session you stopped touching a week ago is unlikely to be the
-// one you actually wanted to resume.
-const SUSPENDED_TTL_HOURS = 7 * 24;
+// Default suspended-session retention (hours). Suspended sessions persist
+// across daemon restarts so an interrupted shell can be resumed. Without a
+// TTL they accumulate indefinitely: every X-button shutdown re-suspends
+// every live session, the next launch recovers them, and any panes the
+// user adds before the next shutdown ride along forever. v2.8.0 shipped
+// without this bound and users reached the session hard cap after a few
+// launches, at which point recovery throws and new pane creation throws —
+// wmux silently becomes unusable. 7 days mirrors the dead-session pattern
+// (24h × 7) so a session you stopped touching a week ago is unlikely to be
+// the one you actually wanted to resume.
+//
+// Substrate 3.0: now configurable via config.session.suspendedTtlHours,
+// threaded through the constructor. This constant is only the fallback for
+// callers that don't pass config (see constructor).
+const SUSPENDED_TTL_HOURS_DEFAULT = 7 * 24;
 
 /**
  * Persists DaemonState (sessions.json) to disk using the shared
@@ -46,6 +50,7 @@ const SUSPENDED_TTL_HOURS = 7 * 24;
  */
 export class StateWriter {
   private filePath: string;
+  private readonly suspendedTtlHours: number;
   private debounceTimer: NodeJS.Timeout | null = null;
   private pendingState: DaemonState | null = null;
   private readonly queue = new AsyncQueue();
@@ -58,8 +63,15 @@ export class StateWriter {
   private immediateEpoch = 0;
   private lastImmediateState: DaemonState | null = null;
 
-  constructor(baseDir: string) {
+  constructor(baseDir: string, suspendedTtlHours: number = SUSPENDED_TTL_HOURS_DEFAULT) {
     this.filePath = path.join(baseDir, 'sessions.json');
+    // Substrate 3.0: suspended-tombstone GC retention. The daemon main
+    // threads config.session.suspendedTtlHours here (codex #2). The
+    // acquireLock() one-shot StateWriter omits it — it only reads bootId
+    // and discards the pruned sessions, so the default is harmless there;
+    // the authoritative prune runs on the main instance during recovery
+    // (codex #3 — both startup paths handled).
+    this.suspendedTtlHours = suspendedTtlHours;
 
     // Sync fallback used by `flushSync()` on emergency exit paths.
     // It writes whatever the latest pending snapshot is using the
@@ -193,8 +205,9 @@ export class StateWriter {
 
     // Prune expired sessions. Two paths:
     //   - dead: per-session TTL (s.deadTtlHours)
-    //   - suspended: global SUSPENDED_TTL_HOURS (v2.8.1 hotfix — see top
-    //     of this file for the accumulation incident this prevents).
+    //   - suspended: this.suspendedTtlHours (configurable, default 7d —
+    //     v2.8.1 hotfix; see top of this file for the accumulation incident
+    //     this prevents).
     //
     // detached/attached states are runtime-only and never reach disk —
     // shutdown demotes every live session to suspended before saving.
@@ -205,7 +218,7 @@ export class StateWriter {
         return sinceMs < s.deadTtlHours * 60 * 60 * 1000;
       }
       if (s.state === 'suspended') {
-        return sinceMs < SUSPENDED_TTL_HOURS * 60 * 60 * 1000;
+        return sinceMs < this.suspendedTtlHours * 60 * 60 * 1000;
       }
       return true;
     });

--- a/src/daemon/Watchdog.ts
+++ b/src/daemon/Watchdog.ts
@@ -36,10 +36,14 @@ export class Watchdog {
   private checkCount = 0;
   private idleShutdownFired = false;
 
-  // Escalation thresholds
-  private static readonly WARN_BYTES = 500 * 1024 * 1024;   // 500 MB — log warning
-  private static readonly REAP_BYTES = 750 * 1024 * 1024;   // 750 MB — reap dead sessions
-  private static readonly BLOCK_BYTES = 1024 * 1024 * 1024; // 1 GB — block new sessions
+  // Memory escalation thresholds (bytes). Instance-level (was static) so the
+  // daemon can thread config.daemon.mem{Warn,Reap,Block}Mb. The defaults
+  // preserve the historical 500/750/1024 MB ladder for callers that omit
+  // memConfig — which keeps every existing Watchdog escalation test locked
+  // to the same behaviour (substrate 3.0 regression #2).
+  private readonly warnBytes: number;
+  private readonly reapBytes: number;
+  private readonly blockBytes: number;
 
   /**
    * @param checkIntervalMs how often to poll health (default 30s)
@@ -47,6 +51,10 @@ export class Watchdog {
    *                        values to enable, set `idleTimeoutMs <= 0` to
    *                        keep the daemon alive forever (default behavior
    *                        before this knob existed)
+   * @param memConfig       memory-pressure escalation thresholds in MB. The
+   *                        daemon passes config.daemon.mem{Warn,Reap,Block}Mb
+   *                        (already clamped + ordered by loadConfig). Omit to
+   *                        get the default 500/750/1024 MB ladder.
    */
   constructor(
     private readonly checkIntervalMs: number = 30000,
@@ -55,7 +63,16 @@ export class Watchdog {
       graceMs: 60_000,
       startTime: Date.now(),
     },
-  ) {}
+    memConfig: { warnMb: number; reapMb: number; blockMb: number } = {
+      warnMb: 500,
+      reapMb: 750,
+      blockMb: 1024,
+    },
+  ) {
+    this.warnBytes = memConfig.warnMb * 1024 * 1024;
+    this.reapBytes = memConfig.reapMb * 1024 * 1024;
+    this.blockBytes = memConfig.blockMb * 1024 * 1024;
+  }
 
   setCallbacks(callbacks: WatchdogCallbacks): void {
     this.callbacks = callbacks;
@@ -75,30 +92,30 @@ export class Watchdog {
         const health = healthCheck();
         const memMB = (health.memory / 1024 / 1024).toFixed(1);
 
-        // Level 3: Block new sessions (>= 1GB)
-        if (health.memory >= Watchdog.BLOCK_BYTES) {
+        // Level 3: Block new sessions (>= block threshold)
+        if (health.memory >= this.blockBytes) {
           if (!this.sessionsBlocked) {
             this.sessionsBlocked = true;
             this.callbacks.onBlockNewSessions?.(true);
-            console.log(`[Watchdog] CRITICAL: Memory ${memMB}MB >= 1GB — blocking new sessions`);
+            console.log(`[Watchdog] CRITICAL: Memory ${memMB}MB >= ${Math.round(this.blockBytes / 1024 / 1024)}MB — blocking new sessions`);
           }
         }
 
-        // Level 2: Reap dead sessions (>= 750MB)
-        if (health.memory >= Watchdog.REAP_BYTES) {
+        // Level 2: Reap dead sessions (>= reap threshold)
+        if (health.memory >= this.reapBytes) {
           const reaped = this.callbacks.onReapDeadSessions?.() ?? 0;
           if (reaped > 0) {
-            console.log(`[Watchdog] WARNING: Memory ${memMB}MB >= 750MB — reaped ${reaped} dead sessions`);
+            console.log(`[Watchdog] WARNING: Memory ${memMB}MB >= ${Math.round(this.reapBytes / 1024 / 1024)}MB — reaped ${reaped} dead sessions`);
           }
         }
 
-        // Level 1: Warning (>= 500MB)
-        if (health.memory >= Watchdog.WARN_BYTES) {
-          console.log(`[Watchdog] WARNING: Memory ${memMB}MB exceeds 500MB threshold`);
+        // Level 1: Warning (>= warn threshold)
+        if (health.memory >= this.warnBytes) {
+          console.log(`[Watchdog] WARNING: Memory ${memMB}MB exceeds ${Math.round(this.warnBytes / 1024 / 1024)}MB threshold`);
         }
 
         // Recovery: unblock if memory drops below block threshold
-        if (this.sessionsBlocked && health.memory < Watchdog.BLOCK_BYTES) {
+        if (this.sessionsBlocked && health.memory < this.blockBytes) {
           this.sessionsBlocked = false;
           this.callbacks.onBlockNewSessions?.(false);
           console.log(`[Watchdog] Memory recovered to ${memMB}MB — unblocking new sessions`);

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -70,6 +70,7 @@ vi.mock('node-pty', () => ({
 
 // Import after mock is set up
 import { DaemonSessionManager } from '../DaemonSessionManager';
+import { createDefaultConfig } from '../config';
 
 describe('DaemonSessionManager', () => {
   let manager: DaemonSessionManager;
@@ -363,6 +364,34 @@ describe('DaemonSessionManager', () => {
     expect(() =>
       manager.createSession({ id: 'cap-201', cmd: 'cmd.exe', cwd: '.' }),
     ).toThrow(/Cannot create new terminal: 200 active sessions already running/);
+  });
+
+  // substrate 3.0: the session cap is configurable (was a 200 literal)
+  it('honours a custom session.maxSessions from setConfig', () => {
+    const cfg = createDefaultConfig();
+    cfg.session.maxSessions = 3;
+    manager.setConfig(cfg);
+    for (let i = 0; i < 3; i++) {
+      manager.createSession({ id: `cm-${i}`, cmd: 'cmd.exe', cwd: '.' });
+    }
+    // The cap is now 3, not the default 200 — and the message echoes it.
+    expect(() =>
+      manager.createSession({ id: 'cm-overflow', cmd: 'cmd.exe', cwd: '.' }),
+    ).toThrow(/Cannot create new terminal: 3 active sessions already running/);
+  });
+
+  // substrate 3.0: dead-TTL is stamped per session from config (codex #5)
+  it('stamps new sessions with deadSessionTtlHours from config', () => {
+    const cfg = createDefaultConfig();
+    cfg.session.deadSessionTtlHours = 48;
+    manager.setConfig(cfg);
+    const s = manager.createSession({ id: 'ttl-cfg', cmd: 'cmd.exe', cwd: '.' });
+    expect(s.deadTtlHours).toBe(48);
+  });
+
+  it('defaults deadTtlHours to 24 when no config is set (createDefaultConfig SSOT)', () => {
+    const s = manager.createSession({ id: 'ttl-def', cmd: 'cmd.exe', cwd: '.' });
+    expect(s.deadTtlHours).toBe(24);
   });
 
   // v2.8.1 hotfix: deferred output mode for recovered sessions (Bug 2)

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -412,6 +412,19 @@ describe('DaemonSessionManager', () => {
     expect(s.deadTtlHours).toBe(24);
   });
 
+  // codex P2: recovery passes the saved per-session value, which must win
+  // over the current config so a recovered session keeps its create-time
+  // retention instead of being silently restamped.
+  it('preserves a passed deadTtlHours over the config default (recovery path)', () => {
+    const cfg = createDefaultConfig();
+    cfg.session.deadSessionTtlHours = 48; // current config
+    manager.setConfig(cfg);
+    // Recovery hands back the value the session was created with (e.g. 12h
+    // from an older config), not the current 48h.
+    const s = manager.createSession({ id: 'rec-ttl', cmd: 'cmd.exe', cwd: '.', deadTtlHours: 12 });
+    expect(s.deadTtlHours).toBe(12);
+  });
+
   // v2.8.1 hotfix: deferred output mode for recovered sessions (Bug 2)
   describe('deferOutput (recovery mode)', () => {
     it('drops PTY data while deferred and the ring buffer stays clean', () => {

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -380,6 +380,24 @@ describe('DaemonSessionManager', () => {
     ).toThrow(/Cannot create new terminal: 3 active sessions already running/);
   });
 
+  // codex P2: DEAD tombstones must not occupy a cap slot
+  it('does not count DEAD tombstones against maxSessions', () => {
+    const cfg = createDefaultConfig();
+    cfg.session.maxSessions = 2;
+    manager.setConfig(cfg);
+    manager.createSession({ id: 'd1', cmd: 'cmd.exe', cwd: '.' });
+    const d1Pty = lastMockPty; // capture before d2 overwrites lastMockPty
+    manager.createSession({ id: 'd2', cmd: 'cmd.exe', cwd: '.' });
+    // d1's PTY exits → it becomes a DEAD tombstone still held in the map.
+    d1Pty?.simulateExit(0);
+    expect(manager.getSession('d1')?.meta.state).toBe('dead');
+    // 1 live (d2) + 1 dead (d1). Under cap=2 a new session must be allowed —
+    // the dead tombstone must not occupy a live slot.
+    expect(() =>
+      manager.createSession({ id: 'd3', cmd: 'cmd.exe', cwd: '.' }),
+    ).not.toThrow();
+  });
+
   // substrate 3.0: dead-TTL is stamped per session from config (codex #5)
   it('stamps new sessions with deadSessionTtlHours from config', () => {
     const cfg = createDefaultConfig();

--- a/src/daemon/__tests__/StateWriter.test.ts
+++ b/src/daemon/__tests__/StateWriter.test.ts
@@ -241,6 +241,42 @@ describe('StateWriter', () => {
     expect(loaded.sessions[0].id).toBe('suspended-with-tight-dead-ttl');
   });
 
+  it('honours a custom suspendedTtlHours from the constructor (substrate 3.0)', () => {
+    const now = Date.now();
+    const HOUR = 60 * 60 * 1000;
+    // A writer configured with a 48h suspended TTL instead of the 7d default.
+    const customWriter = new StateWriter(tmpDir, 48);
+    const stale = makeSession({
+      id: 'stale-3d',
+      state: 'suspended',
+      lastActivity: new Date(now - 3 * 24 * HOUR).toISOString(), // 72h > 48h → pruned
+    });
+    const fresh = makeSession({
+      id: 'fresh-1d',
+      state: 'suspended',
+      lastActivity: new Date(now - 24 * HOUR).toISOString(), // 24h < 48h → survives
+    });
+    customWriter.saveImmediate(makeState([stale, fresh]));
+
+    const ids = customWriter.load().sessions.map((s) => s.id);
+    expect(ids).not.toContain('stale-3d');
+    expect(ids).toContain('fresh-1d');
+  });
+
+  it('default constructor keeps the 7-day suspended TTL (no config passed)', () => {
+    const now = Date.now();
+    const HOUR = 60 * 60 * 1000;
+    // 3 days old: would be pruned under a 48h TTL, but kept under the 7d
+    // default — proves the default still applies when config is omitted.
+    const s = makeSession({
+      id: 'three-day-suspended',
+      state: 'suspended',
+      lastActivity: new Date(now - 3 * 24 * HOUR).toISOString(),
+    });
+    writer.saveImmediate(makeState([s]));
+    expect(writer.load().sessions.map((x) => x.id)).toContain('three-day-suspended');
+  });
+
   it('rejects prototype pollution keys in JSON', () => {
     const filePath = path.join(tmpDir, 'sessions.json');
     const poisoned = JSON.stringify({

--- a/src/daemon/__tests__/Watchdog.test.ts
+++ b/src/daemon/__tests__/Watchdog.test.ts
@@ -294,4 +294,56 @@ describe('Watchdog', () => {
 
     consoleSpy.mockRestore();
   });
+
+  describe('custom memory thresholds (substrate 3.0)', () => {
+    // Proves the escalation ladder is instance-driven (config.daemon.mem*Mb)
+    // rather than the old static constants. The pairing with the control
+    // case below is the actual evidence: 250 MB trips a custom 200 MB block
+    // but is a no-op under the 1 GB default.
+    it('blocks at a custom block threshold below the 1GB default', () => {
+      const wd = new Watchdog(1000, undefined, { warnMb: 100, reapMb: 150, blockMb: 200 });
+      const onBlock = vi.fn();
+      wd.setCallbacks({ onBlockNewSessions: onBlock });
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      wd.start(() => ({ sessions: 5, memory: 250 * 1024 * 1024, uptime: 100 }));
+      vi.advanceTimersByTime(1000);
+
+      expect(wd.isBlocked).toBe(true);
+      expect(onBlock).toHaveBeenCalledWith(true);
+      wd.stop();
+      consoleSpy.mockRestore();
+    });
+
+    it('default thresholds do NOT block at 250MB (control for the above)', () => {
+      const wd = new Watchdog(1000); // omit memConfig → default 500/750/1024
+      const onBlock = vi.fn();
+      wd.setCallbacks({ onBlockNewSessions: onBlock });
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      wd.start(() => ({ sessions: 5, memory: 250 * 1024 * 1024, uptime: 100 }));
+      vi.advanceTimersByTime(1000);
+
+      expect(wd.isBlocked).toBe(false);
+      expect(onBlock).not.toHaveBeenCalled();
+      wd.stop();
+      consoleSpy.mockRestore();
+    });
+
+    it('reaps dead sessions at a custom reap threshold', () => {
+      const wd = new Watchdog(1000, undefined, { warnMb: 100, reapMb: 150, blockMb: 200 });
+      const onReap = vi.fn(() => 2);
+      wd.setCallbacks({ onReapDeadSessions: onReap });
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      // 160MB: above custom reap(150), below custom block(200).
+      wd.start(() => ({ sessions: 3, memory: 160 * 1024 * 1024, uptime: 100 }));
+      vi.advanceTimersByTime(1000);
+
+      expect(onReap).toHaveBeenCalledTimes(1);
+      expect(wd.isBlocked).toBe(false);
+      wd.stop();
+      consoleSpy.mockRestore();
+    });
+  });
 });

--- a/src/daemon/__tests__/config.test.ts
+++ b/src/daemon/__tests__/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -111,5 +111,138 @@ describe('saveConfig', () => {
 
     const loaded = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(loaded.version).toBe(1);
+  });
+});
+
+// ── Substrate 3.0 lifecycle knobs ──────────────────────────────────────
+// maxSessions / suspendedTtlHours / memWarnMb / memReapMb / memBlockMb:
+// per-field backfill + clamp, never a whole-file reset on a single bad
+// field. See the clamp contract in config.ts (loadConfig).
+
+/** Write a raw (possibly partial / malformed) config object to disk. */
+function writeRawConfig(obj: unknown): void {
+  const wmuxDir = getWmuxDir();
+  fs.mkdirSync(wmuxDir, { recursive: true });
+  fs.writeFileSync(path.join(wmuxDir, 'config.json'), JSON.stringify(obj), 'utf-8');
+}
+
+describe('createDefaultConfig — lifecycle knobs', () => {
+  it('includes the substrate 3.0 lifecycle defaults', () => {
+    const c = createDefaultConfig();
+    expect(c.session.maxSessions).toBe(200);
+    expect(c.session.suspendedTtlHours).toBe(7 * 24);
+    expect(c.daemon.memWarnMb).toBe(500);
+    expect(c.daemon.memReapMb).toBe(750);
+    expect(c.daemon.memBlockMb).toBe(1024);
+  });
+});
+
+describe('loadConfig — lifecycle backfill + clamp', () => {
+  it('REGRESSION #1: old config.json (no lifecycle fields) → defaults backfilled, existing fields + idleShutdownMinutes preserved', () => {
+    // A v1 config from before substrate 3.0: structurally valid, no new
+    // knobs, plus a customised idleShutdownMinutes/logLevel/TTL the user
+    // must keep. This is the highest-priority regression.
+    writeRawConfig({
+      version: 1,
+      daemon: { pipeName: '\\\\.\\pipe\\custom', logLevel: 'debug', autoStart: false, idleShutdownMinutes: 12 },
+      session: {
+        defaultShell: '/bin/zsh', defaultCols: 100, defaultRows: 40,
+        bufferSizeMb: 8, bufferMaxMb: 64, deadSessionTtlHours: 48, deadSessionDumpBuffer: false,
+      },
+    });
+    const c = loadConfig();
+    // Existing fields preserved verbatim
+    expect(c.daemon.pipeName).toBe('\\\\.\\pipe\\custom');
+    expect(c.daemon.logLevel).toBe('debug');
+    expect(c.daemon.autoStart).toBe(false);
+    expect(c.daemon.idleShutdownMinutes).toBe(12);
+    expect(c.session.defaultShell).toBe('/bin/zsh');
+    expect(c.session.deadSessionTtlHours).toBe(48);
+    expect(c.session.deadSessionDumpBuffer).toBe(false);
+    // New fields backfilled to defaults
+    expect(c.session.maxSessions).toBe(200);
+    expect(c.session.suspendedTtlHours).toBe(7 * 24);
+    expect(c.daemon.memWarnMb).toBe(500);
+    expect(c.daemon.memReapMb).toBe(750);
+    expect(c.daemon.memBlockMb).toBe(1024);
+  });
+
+  it('preserves valid lifecycle values (passthrough)', () => {
+    const c0 = createDefaultConfig();
+    writeRawConfig({
+      ...c0,
+      session: { ...c0.session, maxSessions: 50, suspendedTtlHours: 48 },
+      daemon: { ...c0.daemon, memWarnMb: 300, memReapMb: 400, memBlockMb: 600 },
+    });
+    const c = loadConfig();
+    expect(c.session.maxSessions).toBe(50);
+    expect(c.session.suspendedTtlHours).toBe(48);
+    expect(c.daemon.memWarnMb).toBe(300);
+    expect(c.daemon.memReapMb).toBe(400);
+    expect(c.daemon.memBlockMb).toBe(600);
+  });
+
+  it('garbage in one lifecycle field backfills ONLY that field — no whole-file reset', () => {
+    const c0 = createDefaultConfig();
+    writeRawConfig({
+      ...c0,
+      daemon: { ...c0.daemon, pipeName: '\\\\.\\pipe\\keepme' },
+      session: { ...c0.session, maxSessions: 'abc' as unknown as number, suspendedTtlHours: 99 },
+    });
+    const c = loadConfig();
+    expect(c.daemon.pipeName).toBe('\\\\.\\pipe\\keepme'); // NOT reset to default
+    expect(c.session.maxSessions).toBe(200);               // garbage → backfilled
+    expect(c.session.suspendedTtlHours).toBe(99);          // sibling preserved
+  });
+
+  it('clamps ≤0 / negative to the floor (no "off" for floors)', () => {
+    const c0 = createDefaultConfig();
+    writeRawConfig({ ...c0, session: { ...c0.session, maxSessions: 0, suspendedTtlHours: -5 } });
+    const c = loadConfig();
+    expect(c.session.maxSessions).toBe(1);        // MAX_SESSIONS_FLOOR
+    expect(c.session.suspendedTtlHours).toBe(1);  // SUSPENDED_TTL_FLOOR_HOURS
+  });
+
+  it('clamps over-cap values to the cap', () => {
+    const c0 = createDefaultConfig();
+    writeRawConfig({ ...c0, session: { ...c0.session, maxSessions: 999999, suspendedTtlHours: 99999999 } });
+    const c = loadConfig();
+    expect(c.session.maxSessions).toBe(10_000);          // MAX_SESSIONS_CAP
+    expect(c.session.suspendedTtlHours).toBe(24 * 365);  // SUSPENDED_TTL_CAP_HOURS
+  });
+
+  it('caps memory thresholds at physical RAM (absolute upper cap)', () => {
+    const c0 = createDefaultConfig();
+    const totalMemMb = Math.floor(os.totalmem() / 1024 / 1024);
+    writeRawConfig({
+      ...c0,
+      daemon: { ...c0.daemon, memWarnMb: 9_999_999, memReapMb: 9_999_999, memBlockMb: 9_999_999 },
+    });
+    const c = loadConfig();
+    expect(c.daemon.memBlockMb).toBe(totalMemMb);
+    expect(c.daemon.memBlockMb).toBeLessThanOrEqual(totalMemMb);
+  });
+
+  it('REGRESSION #5: memBlockMb below the safe floor → clamped + startup warning (no silent brick)', () => {
+    const c0 = createDefaultConfig();
+    writeRawConfig({ ...c0, daemon: { ...c0.daemon, memWarnMb: 10, memReapMb: 20, memBlockMb: 30 } });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const c = loadConfig();
+    expect(c.daemon.memBlockMb).toBeGreaterThanOrEqual(256); // MEM_BLOCK_FLOOR_MB
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('below the safe floor'));
+    warnSpy.mockRestore();
+  });
+
+  it('corrects memory order inversion (warn > reap > block) after clamp', () => {
+    const c0 = createDefaultConfig();
+    // All above their floors so the floor clamp doesn't mask the inversion;
+    // the order-correction step must raise reap/block up to warn.
+    writeRawConfig({ ...c0, daemon: { ...c0.daemon, memWarnMb: 900, memReapMb: 500, memBlockMb: 300 } });
+    const c = loadConfig();
+    expect(c.daemon.memWarnMb).toBeLessThanOrEqual(c.daemon.memReapMb);
+    expect(c.daemon.memReapMb).toBeLessThanOrEqual(c.daemon.memBlockMb);
+    expect(c.daemon.memWarnMb).toBe(900);  // warn stays put
+    expect(c.daemon.memReapMb).toBe(900);  // raised to warn
+    expect(c.daemon.memBlockMb).toBe(900); // raised to reap
   });
 });

--- a/src/daemon/__tests__/recoverySelector.test.ts
+++ b/src/daemon/__tests__/recoverySelector.test.ts
@@ -80,6 +80,28 @@ describe('selectRecoverableSessions', () => {
     expect(cappedCount).toBe(0);
   });
 
+  it('REGRESSION #4: cap below the recoverable count keeps the overflow SUSPENDED, never dead (codex #4)', () => {
+    // When maxSessions is lowered below the persisted recoverable count, the
+    // daemon derives cap = min(maxSessions, 40) (see index.ts main()). The
+    // overflow must stay suspended: it lands in cappedCount, never in
+    // recoverableIds, so recoverSessions preserves it verbatim
+    // (buildState + preservedFromState) and never calls createSession for
+    // it — which means it can never trip the MAX_SESSIONS throw → catch →
+    // dead-mark path. cap ≤ maxSessions by construction also guarantees
+    // recovery itself can't exhaust the cap. This is the data-loss guard.
+    const sessions: DaemonSession[] = [];
+    for (let i = 0; i < 10; i++) {
+      const ts = new Date(2026, 4, 1, 0, 0, i).toISOString();
+      sessions.push(session(`s-${i}`, 'suspended', ts));
+    }
+    const maxSessions = 5;
+    const cap = Math.min(maxSessions, 40); // mirror index.ts main()
+    const { recoverableIds, cappedCount } = selectRecoverableSessions(sessions, cap);
+    expect(recoverableIds.size).toBe(5); // recover up to the cap
+    expect(cappedCount).toBe(5); // overflow stays suspended, NOT dead-marked
+    expect(recoverableIds.size).toBeLessThanOrEqual(maxSessions); // never exceeds the ceiling
+  });
+
   it('handles cap=0 by skipping every session', () => {
     // Defensive: a config that disables recovery should not throw.
     const sessions = [

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -56,8 +56,13 @@ const MEM_BLOCK_FLOOR_MB = 256;
  * `idleShutdownMinutes`).
  */
 function clampLifecycle(raw: unknown, def: number, min: number, max: number): number {
-  if (typeof raw !== 'number' || !Number.isFinite(raw)) return def;
-  return Math.min(Math.max(Math.floor(raw), min), max);
+  // Fall back to the default for an absent/non-numeric value, then clamp the
+  // RESULT — default included — to [min, max]. Clamping the fallback matters
+  // on a box with less RAM than a memory default: an omitted memBlockMb must
+  // still cap at physical RAM, not sit above it and silently disable the
+  // guard (codex P3).
+  const v = typeof raw === 'number' && Number.isFinite(raw) ? raw : def;
+  return Math.min(Math.max(Math.floor(v), min), max);
 }
 
 /** Build a DaemonConfig with all defaults */

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -30,6 +30,36 @@ function getDefaultPipeName(): string {
   return path.join(os.homedir(), '.wmux-daemon.sock');
 }
 
+/**
+ * Substrate 3.0 lifecycle clamp bounds. Tier-2 resource floors stay
+ * configurable, but can't be set to self-defeating values: a 0/negative
+ * threshold, or a memory threshold above physical RAM, would silently
+ * disable the protection (codex #9 — silent boot brick). Each knob clamps
+ * to `[floor, cap]`; an absent or non-numeric value falls back to the
+ * `createDefaultConfig` default PER-FIELD, without resetting the rest of
+ * the file (codex #13 — a maxSessions typo must not nuke pipeName).
+ */
+const MAX_SESSIONS_FLOOR = 1;
+const MAX_SESSIONS_CAP = 10_000;
+const SUSPENDED_TTL_FLOOR_HOURS = 1;
+const SUSPENDED_TTL_CAP_HOURS = 24 * 365; // 1 year — "permanent" = large, not 0
+const MEM_WARN_FLOOR_MB = 128;
+const MEM_REAP_FLOOR_MB = 192;
+const MEM_BLOCK_FLOOR_MB = 256;
+
+/**
+ * Coerce a lifecycle knob to a finite integer within `[min, max]`. An
+ * absent (`undefined`) or non-numeric/`NaN`/`Infinity` value falls back to
+ * `def` — this is the per-field backfill. A finite out-of-range value is
+ * clamped (floored toward `min`, capped at `max`); `0`/negative therefore
+ * lands on `min`, never "off" (these floors have no disable, unlike
+ * `idleShutdownMinutes`).
+ */
+function clampLifecycle(raw: unknown, def: number, min: number, max: number): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return def;
+  return Math.min(Math.max(Math.floor(raw), min), max);
+}
+
 /** Build a DaemonConfig with all defaults */
 export function createDefaultConfig(): DaemonConfig {
   return {
@@ -39,6 +69,9 @@ export function createDefaultConfig(): DaemonConfig {
       logLevel: 'info',
       autoStart: true,
       idleShutdownMinutes: 5,
+      memWarnMb: 500,
+      memReapMb: 750,
+      memBlockMb: 1024,
     },
     session: {
       defaultShell: getDefaultShell(),
@@ -48,6 +81,8 @@ export function createDefaultConfig(): DaemonConfig {
       bufferMaxMb: 64,
       deadSessionTtlHours: 24,
       deadSessionDumpBuffer: true,
+      maxSessions: 200,
+      suspendedTtlHours: 7 * 24,
     },
   };
 }
@@ -94,6 +129,53 @@ export function loadConfig(): DaemonConfig {
       console.warn(`[daemon/config] bufferSizeMb (${config.session.bufferSizeMb}) exceeds max (${effectiveMax}), capping`);
       config.session.bufferSizeMb = effectiveMax;
     }
+
+    // ── Substrate 3.0 lifecycle knobs: per-field backfill + clamp ──
+    // validateConfig deliberately ignores these fields, so a garbage value
+    // here can never trigger the whole-file reset above (that path stays
+    // reserved for core-structure breakage). Here: absent (old config.json)
+    // → default; out-of-range → clamped; valid → preserved. Defaults come
+    // from `defaults` (createDefaultConfig) — the single source of truth.
+    config.session.maxSessions = clampLifecycle(
+      config.session.maxSessions, defaults.session.maxSessions,
+      MAX_SESSIONS_FLOOR, MAX_SESSIONS_CAP,
+    );
+    config.session.suspendedTtlHours = clampLifecycle(
+      config.session.suspendedTtlHours, defaults.session.suspendedTtlHours,
+      SUSPENDED_TTL_FLOOR_HOURS, SUSPENDED_TTL_CAP_HOURS,
+    );
+
+    // Memory triple: floor + absolute upper cap (physical RAM). A threshold
+    // above total RAM can never trip, silently disabling the protection;
+    // clamp it to RAM. The cap never drops below the block floor so a tiny
+    // box (RAM < floor) still keeps the floor.
+    const totalMemMb = Math.floor(os.totalmem() / 1024 / 1024);
+    const memCap = Math.max(MEM_BLOCK_FLOOR_MB, totalMemMb);
+    // codex #9: a block threshold below the sane floor would permanently
+    // refuse new sessions on boot (RSS never drops under it) — and silently.
+    // Detect BEFORE clampLifecycle rewrites it, then warn loudly.
+    if (
+      typeof config.daemon.memBlockMb === 'number' &&
+      Number.isFinite(config.daemon.memBlockMb) &&
+      config.daemon.memBlockMb < MEM_BLOCK_FLOOR_MB
+    ) {
+      console.warn(
+        `[daemon/config] memBlockMb (${config.daemon.memBlockMb}MB) is below the safe floor ` +
+          `${MEM_BLOCK_FLOOR_MB}MB — clamping to ${MEM_BLOCK_FLOOR_MB}MB to avoid silently ` +
+          `bricking new-session creation.`,
+      );
+    }
+    const memWarn = clampLifecycle(config.daemon.memWarnMb, defaults.daemon.memWarnMb, MEM_WARN_FLOOR_MB, memCap);
+    let memReap = clampLifecycle(config.daemon.memReapMb, defaults.daemon.memReapMb, MEM_REAP_FLOOR_MB, memCap);
+    let memBlock = clampLifecycle(config.daemon.memBlockMb, defaults.daemon.memBlockMb, MEM_BLOCK_FLOOR_MB, memCap);
+    // Order invariant warn ≤ reap ≤ block, corrected AFTER per-field clamp
+    // (a per-field floor can invert a user's ordering). Raise reap/block to
+    // preserve the escalation ladder rather than lowering warn.
+    memReap = Math.max(memReap, memWarn);
+    memBlock = Math.max(memBlock, memReap);
+    config.daemon.memWarnMb = memWarn;
+    config.daemon.memReapMb = memReap;
+    config.daemon.memBlockMb = memBlock;
 
     return config;
   } catch (err) {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -376,6 +376,7 @@ async function recoverSessions(
               rows: session.rows,
               agent: session.agent,
               createdAt: session.createdAt,
+              deadTtlHours: session.deadTtlHours,
               scrollbackData,
               // v2.8.1: stay muted until the renderer's first resize so PTY
               // output produced at the saved geometry can't interleave with
@@ -452,6 +453,7 @@ async function recoverSessions(
             rows: session.rows,
             agent: session.agent,
             createdAt: session.createdAt,
+            deadTtlHours: session.deadTtlHours,
             scrollbackData,
             // v2.8.1: see deferOutput rationale above (Bug 2).
             deferOutput: true,
@@ -490,6 +492,7 @@ async function recoverSessions(
           rows: session.rows,
           agent: session.agent,
           createdAt: session.createdAt,
+          deadTtlHours: session.deadTtlHours,
           // v2.8.1: see deferOutput rationale above (Bug 2).
           deferOutput: true,
         });

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -33,13 +33,16 @@ eventLoopMonitor.enable();
 // lines land in ~/.wmux/logs/daemon-YYYY-MM-DD.log.
 initDaemonLogSink(wmuxDir);
 
-// Recovery soft cap. The hard PTY ceiling lives in DaemonSessionManager
-// (MAX_SESSIONS = 200). Recovery has its own lower bound so a state file
-// inflated by past v2.8.0 accumulation can't consume every slot before
-// the user creates their first new pane. Sessions beyond this cap stay
-// suspended in state.sessions and become recoverable on a subsequent
-// launch if the live count drops; SUSPENDED_TTL_HOURS reaps the truly
-// stale ones over time.
+// Recovery soft-cap ceiling. The hard PTY ceiling is now configurable
+// (config.session.maxSessions, default 200); recovery derives its own cap
+// as min(maxSessions, 40) in main(). This 40 is the startup-headroom
+// heuristic: even with a large maxSessions, recover at most 40 so a state
+// file inflated by past v2.8.0 accumulation can't consume every slot before
+// the user creates their first new pane. Deriving from maxSessions also
+// guarantees maxRecover ≤ maxSessions, so recovery can never trip the
+// createSession cap and dead-mark the overflow (codex #4). Sessions beyond
+// the cap stay suspended and become recoverable on a later launch, or get
+// reaped by the suspended TTL.
 const MAX_RECOVER_SESSIONS = 40;
 
 /** Get a unique identifier for the current OS boot session (async).
@@ -219,6 +222,13 @@ async function acquireLock(): Promise<boolean> {
           // Use bootId comparison as a fallback: if bootId matches the saved state,
           // the lock is truly stale (same boot, process gone).
           // If bootId differs, it's definitely stale (reboot happened).
+          //
+          // This one-shot StateWriter intentionally omits the suspended-TTL
+          // config — acquireLock() runs before loadConfig(), so it isn't
+          // available yet. Safe: we only read savedState.bootId here and
+          // discard the pruned session list; the authoritative, config-driven
+          // prune runs on the main StateWriter during recovery (codex #3 —
+          // both startup paths handled).
           const stateWriter = new StateWriter(wmuxDir);
           const savedState = stateWriter.load();
           const currentBoot = await getBootId();
@@ -279,6 +289,7 @@ async function recoverSessions(
   stateWriter: StateWriter,
   sessionManager: DaemonSessionManager,
   processMonitor: ProcessMonitor,
+  maxRecover: number,
 ): Promise<void> {
   const state = stateWriter.load();
   let changed = false;
@@ -299,7 +310,7 @@ async function recoverSessions(
   // to create new panes after a heavy session.
   const { recoverableIds, cappedCount } = selectRecoverableSessions(
     state.sessions,
-    MAX_RECOVER_SESSIONS,
+    maxRecover,
   );
   if (cappedCount > 0) {
     log(
@@ -1179,7 +1190,10 @@ async function main(): Promise<void> {
   log('info', `Config loaded (logLevel=${config.daemon.logLevel})`);
 
   // 3. Initialize modules
-  const stateWriter = new StateWriter(wmuxDir);
+  // Thread the configured suspended-tombstone TTL into the authoritative
+  // StateWriter (codex #2). The acquireLock() one-shot above runs pre-config
+  // and only reads bootId, so the default there is harmless.
+  const stateWriter = new StateWriter(wmuxDir, config.session.suspendedTtlHours);
   // A4 — sweep tmp dumps left behind by a previous crash. They are safe to
   // delete: tmp files only exist between the write and rename steps of an
   // atomic dump, so any tmp on disk now is from a daemon that died before
@@ -1220,7 +1234,11 @@ async function main(): Promise<void> {
   // (scripts/daemon-idle-shutdown-dynamic.mjs) drops this so it doesn't
   // have to wait a full tick after the idle window elapses.
   const watchdogTickMs = parsePositiveMs(process.env.WMUX_WATCHDOG_TICK_MS) ?? 30000;
-  const watchdog = new Watchdog(watchdogTickMs, idleConfig);
+  const watchdog = new Watchdog(watchdogTickMs, idleConfig, {
+    warnMb: config.daemon.memWarnMb,
+    reapMb: config.daemon.memReapMb,
+    blockMb: config.daemon.memBlockMb,
+  });
   const sessionPipes = new Map<string, SessionPipe>();
   const sessionDataListeners = new Map<string, { bridge: import('./DaemonPTYBridge').DaemonPTYBridge; listener: (data: Buffer) => void }>();
 
@@ -1229,8 +1247,13 @@ async function main(): Promise<void> {
   // immediate snapshot; the 30 s interval will still cover them.
   let runSnapshotOnceRef: (() => Promise<void>) | null = null;
 
-  // 4. Recover previous sessions
-  await recoverSessions(stateWriter, sessionManager, processMonitor);
+  // 4. Recover previous sessions. Derive the recovery soft cap from the
+  // configured session ceiling: min(maxSessions, 40). Capping at maxSessions
+  // guarantees recovery never trips the createSession limit and dead-marks
+  // the overflow — a freshly lowered maxSessions keeps the excess SUSPENDED
+  // instead of destroying it (codex #4).
+  const maxRecover = Math.min(config.session.maxSessions, MAX_RECOVER_SESSIONS);
+  await recoverSessions(stateWriter, sessionManager, processMonitor, maxRecover);
 
   // 5. Register RPC handlers
   registerRpcHandlers(

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -49,6 +49,24 @@ export interface DaemonConfig {
      * orphaned daemon would otherwise occupy RAM indefinitely.
      */
     idleShutdownMinutes?: number;
+    /**
+     * Memory-pressure escalation thresholds in MB, measured against the
+     * daemon process RSS. Substrate 3.0 lifecycle Tier-2 floors: as RSS
+     * climbs the daemon warns (`memWarnMb`), then GCs DEAD tombstones
+     * (`memReapMb`), then refuses new sessions (`memBlockMb`) — it never
+     * evicts a live session. `memWarnMb ≤ memReapMb ≤ memBlockMb` is
+     * enforced at load time; each has a sane floor and an absolute upper
+     * cap (a value above physical RAM can't silently disable protection),
+     * and a `memBlockMb` below the floor logs a startup warning rather than
+     * silently bricking session creation. Backfilled per-field from
+     * defaults when absent/garbage — see `loadConfig` in config.ts.
+     *
+     * Normalised by `loadConfig`, so they are always present at runtime;
+     * a raw config.json may omit them (old files) and gets backfilled.
+     */
+    memWarnMb: number;
+    memReapMb: number;
+    memBlockMb: number;
   };
   session: {
     defaultShell: string;
@@ -58,5 +76,22 @@ export interface DaemonConfig {
     bufferMaxMb: number;
     deadSessionTtlHours: number;
     deadSessionDumpBuffer: boolean;
+    /**
+     * Hard cap on concurrent sessions the daemon will hold. New-session
+     * creation throws RESOURCE_EXHAUSTED at this ceiling — the substrate
+     * refuses, it never evicts an existing session to make room (Tier-2
+     * floor, refuse-not-evict). Startup recovery derives its own soft cap
+     * as `min(maxSessions, 40)` so a freshly lowered cap can't dead-mark
+     * persisted sessions. Backfilled from the default when absent/garbage.
+     */
+    maxSessions: number;
+    /**
+     * TTL in hours after which an idle SUSPENDED session tombstone is
+     * garbage-collected on the next `StateWriter.load`. This is GC of a
+     * tombstone (no live PTY behind it), not eviction of a live session.
+     * "Permanent" retention = a large value, never 0. Backfilled from the
+     * default when absent/garbage.
+     */
+    suspendedTtlHours: number;
   };
 }


### PR DESCRIPTION
## Summary

Surfaces the daemon's hard-coded lifecycle floors as `config.json` knobs, per the substrate-3.0-lifecycle-boundary plan (#91, docs-only). Tier-2 resource floors stay in the substrate but become configurable; no live-session eviction is introduced and default behaviour is unchanged.

**5 new config knobs** (`createDefaultConfig` is the single default source):
- `session.maxSessions` (200) — was a literal in `DaemonSessionManager`
- `daemon.memWarnMb` / `memReapMb` / `memBlockMb` (500/750/1024) — were static in `Watchdog`
- `session.suspendedTtlHours` (168) — was a literal in `StateWriter`
- `session.deadSessionTtlHours` — de-duplicated (config is now the only source)

`maxRecoverSessions` is derived as `min(maxSessions, 40)`, never exposed as a knob.

`loadConfig` normalises the new fields per-field: absent/garbage backfills from the default in isolation (never a whole-file reset), 0/negative clamps to a floor, memory thresholds cap at physical RAM, `warn ≤ reap ≤ block` is enforced after clamping, and a `memBlockMb` below the floor is clamped + logged at startup (no silent session-creation brick).

Adds `PROTOCOL.md` §7 (lifecycle three-tier model + config contract) and the §8 lifecycle-neutrality boundary entry.

## Commits
- `c967930` feat — config knobs + per-field clamp/backfill + maxRecover derivation + PROTOCOL §7/§8
- `12f5870` fix — count only live sessions against maxSessions (codex R1 P2: dead tombstones occupied a slot under a low cap)
- `408bdcd` fix — preserve recovered session dead-TTL + clamp fallback memory defaults (codex R2 P2/P3)

## Test Coverage

~20 new tests across config / Watchdog / StateWriter / DaemonSessionManager / recoverySelector, covering the plan's 5 critical regressions:
1. Old config.json (no new fields) → defaults backfilled, existing fields + `idleShutdownMinutes` preserved
2. Watchdog static→instance: default 500/750/1024 escalation unchanged
3. maxSessions / suspendedTtl / recovery defaults unchanged
4. maxSessions < persisted recoverable → overflow stays SUSPENDED, none dead-marked
5. memBlockMb below floor → clamped + warning

Full suite: **2088 tests green** (165 files). daemon typecheck green, bundle build green (203 kb), changed-file lint clean.

## Review

**codex review — 3 rounds to convergence:**
- R1: P2 (maxSessions counted dead tombstones) → fixed `12f5870`
- R2: P2 (recovery restamped dead-TTL) + P3 (fallback default bypassed RAM cap) → fixed `408bdcd`
- R3: clean — "no discrete introduced bugs that would break existing behavior or the new lifecycle configuration paths"

## Verification

GUI dogfood was explicitly waived by the maintainer for this PR. Config-clamp behaviour is covered by the unit tests above; daemon-path correctness by codex 3R + typecheck. The plan flags daemon as the highest-risk area, so dynamic verification can still run post-merge if desired.

## Notes
- VERSION / CHANGELOG intentionally not bumped — this is a feature PR; the version/tag is handled in the release that bundles it.
- Plan lives in #91 (docs-only); this is the implementation PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)