### PR TITLE
fix(daemon): close the duplicate-daemon / split-brain bug (3-defect chain)

### DIFF
--- a/scripts/split-brain-dynamic.mjs
+++ b/scripts/split-brain-dynamic.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+/**
+ * Dynamic verification for the duplicate-daemon / split-brain fix
+ * (plans/duplicate-daemon-split-brain.md, Step ③).
+ *
+ * Spawns the BUNDLED daemon in an isolated state dir (USERPROFILE/HOME →
+ * tmpdir, unique pipe name) so it never touches the user's real ~/.wmux or
+ * the production daemon.
+ *
+ * SB1 — the split-brain trigger, end-to-end:
+ *   1. Spawn daemon A → it listens on the canonical pipe.
+ *   2. Confirm A answers daemon.ping.
+ *   3. Delete daemon.lock / daemon.pid / daemon-pipe — this reproduces what
+ *      the launcher does right before spawning a second daemon (it cleans
+ *      "stale" files, which is exactly how a redundant B gets past acquireLock).
+ *   4. Spawn daemon B against the SAME state dir + config (same canonical pipe).
+ *   5. Assert: B exits with DAEMON_EXIT_ALREADY_RUNNING (75) — it found A live
+ *      on the canonical pipe and yielded (Step ③ fail-fast), instead of taking
+ *      a `-1` suffix and becoming a second live daemon.
+ *   6. Assert: NO `<pipe>-1` daemon exists (connect is refused).
+ *   7. Assert: A is still alive (answers daemon.ping) — B did not kill it.
+ *
+ * SB2 — regression: a daemon on a CLEAN state dir starts normally on the
+ *   canonical pipe (no fail-fast, no `-1`).
+ */
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const DAEMON_BUNDLE = path.join(REPO_ROOT, 'dist', 'daemon-bundle', 'index.js');
+const DAEMON_EXIT_ALREADY_RUNNING = 75; // mirror src/shared/constants.ts
+
+if (!fs.existsSync(DAEMON_BUNDLE)) {
+  console.error('Daemon bundle missing — run `npm run build:daemon` first');
+  process.exit(2);
+}
+
+function makeTestHome() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-split-brain-'));
+  fs.mkdirSync(path.join(home, '.wmux'), { recursive: true });
+  return home;
+}
+
+function makePipeName(tag) {
+  if (process.platform === 'win32') return `\\\\.\\pipe\\wmux-test-${tag}`;
+  return path.join(os.tmpdir(), `wmux-test-${tag}.sock`);
+}
+
+function writeConfig(wmuxDir, pipeName, authToken) {
+  fs.writeFileSync(
+    path.join(wmuxDir, 'config.json'),
+    JSON.stringify(
+      {
+        version: 1,
+        daemon: { pipeName, logLevel: 'warn', autoStart: true },
+        session: {
+          defaultShell: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
+          defaultCols: 80, defaultRows: 24, bufferSizeMb: 8, bufferMaxMb: 64,
+          deadSessionTtlHours: 24, deadSessionDumpBuffer: true,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(path.join(wmuxDir, 'daemon-auth-token'), authToken, 'utf-8');
+}
+
+function spawnDaemon(testHome) {
+  return spawn(process.execPath, [DAEMON_BUNDLE], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, USERPROFILE: testHome, HOME: testHome, HOMEDRIVE: undefined, HOMEPATH: undefined },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+async function waitForPipeFile(wmuxDir, timeoutMs = 12_000) {
+  const pipeFile = path.join(wmuxDir, 'daemon-pipe');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(pipeFile)) return fs.readFileSync(pipeFile, 'utf-8').trim();
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error('daemon-pipe did not appear within timeout');
+}
+
+function connectSocket(pipeName) {
+  return new Promise((resolve, reject) => {
+    const s = net.createConnection(pipeName, () => resolve(s));
+    s.on('error', reject);
+  });
+}
+
+function rpc(socket, method, params, authToken, timeoutMs = 10_000) {
+  return new Promise((resolve, reject) => {
+    const id = `req-${Math.random().toString(36).slice(2, 10)}`;
+    let buffer = '';
+    const handler = (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id === id) {
+            socket.removeListener('data', handler);
+            if (msg.ok) resolve(msg.result ?? { status: 'ok' });
+            else reject(new Error(msg.error ?? 'rpc error'));
+            return;
+          }
+        } catch { /* ignore */ }
+      }
+    };
+    socket.on('data', handler);
+    socket.write(JSON.stringify({ id, method, params, token: authToken }) + '\n');
+    setTimeout(() => { socket.removeListener('data', handler); reject(new Error(`rpc timeout: ${method}`)); }, timeoutMs);
+  });
+}
+
+async function pingOnce(pipeName, authToken) {
+  let socket;
+  try {
+    socket = await connectSocket(pipeName);
+    await rpc(socket, 'daemon.ping', {}, authToken, 5000);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (socket) socket.end();
+  }
+}
+
+// connect refused (or any error) ⇒ no daemon owns that name.
+async function pipeHasOwner(pipeName) {
+  return new Promise((resolve) => {
+    const s = net.createConnection(pipeName, () => { s.destroy(); resolve(true); });
+    s.on('error', () => { s.destroy(); resolve(false); });
+    setTimeout(() => { s.destroy(); resolve(false); }, 2000);
+  });
+}
+
+async function killDaemon(child) {
+  if (!child || child.killed) return;
+  child.kill('SIGKILL');
+  await new Promise((r) => setTimeout(r, 500));
+}
+
+function exitOf(child) {
+  return new Promise((resolve) => {
+    let done = false;
+    child.on('exit', (code, signal) => { if (!done) { done = true; resolve({ code, signal }); } });
+    setTimeout(() => { if (!done) { done = true; resolve({ code: 'TIMEOUT', signal: null }); } }, 20_000);
+  });
+}
+
+// SB1 -------------------------------------------------------------------
+async function runSB1(report) {
+  const testHome = makeTestHome();
+  const wmuxDir = path.join(testHome, '.wmux');
+  const tag = `sb1-${randomUUID().slice(0, 8)}`;
+  const pipeName = makePipeName(tag);
+  const authToken = randomUUID();
+  writeConfig(wmuxDir, pipeName, authToken);
+
+  let childA;
+  let bStderr = '';
+  let bStdout = '';
+  try {
+    // 1-2. Daemon A up + answering ping.
+    childA = spawnDaemon(testHome);
+    await waitForPipeFile(wmuxDir);
+    await new Promise((r) => setTimeout(r, 800));
+    const aAliveBefore = await pingOnce(pipeName, authToken);
+
+    // 3. Reproduce the launcher's pre-spawn stale-file cleanup so B can pass
+    //    acquireLock (this is exactly how a redundant second daemon arises).
+    for (const f of ['daemon.lock', 'daemon.pid', 'daemon-pipe']) {
+      try { fs.unlinkSync(path.join(wmuxDir, f)); } catch { /* ignore */ }
+    }
+
+    // 4. Spawn daemon B against the same dir/config (same canonical pipe).
+    const childB = spawnDaemon(testHome);
+    childB.stderr.on('data', (d) => { bStderr += d.toString(); });
+    childB.stdout.on('data', (d) => { bStdout += d.toString(); });
+    const bExit = await exitOf(childB);
+
+    // 5-7. Assertions.
+    const noMinusOnePipe = !(await pipeHasOwner(`${pipeName}-1`));
+    const aAliveAfter = await pingOnce(pipeName, authToken);
+
+    const pass =
+      bExit.code === DAEMON_EXIT_ALREADY_RUNNING &&
+      noMinusOnePipe === true &&
+      aAliveBefore === true &&
+      aAliveAfter === true;
+
+    report.push({
+      scenario: 'SB1', pass,
+      aAliveBefore, bExitCode: bExit.code, bExitSignal: bExit.signal,
+      noMinusOnePipe, aAliveAfter,
+      bStdoutTail: pass ? undefined : bStdout.slice(-700).replace(/\s+/g, ' '),
+      bStderrTail: pass ? undefined : bStderr.slice(-500).replace(/\s+/g, ' '),
+    });
+  } catch (err) {
+    report.push({ scenario: 'SB1', pass: false, error: err.message, bStderrTail: bStderr.slice(-500) });
+  } finally {
+    await killDaemon(childA);
+    try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+}
+
+// SB2 (regression) ------------------------------------------------------
+async function runSB2(report) {
+  const testHome = makeTestHome();
+  const wmuxDir = path.join(testHome, '.wmux');
+  const tag = `sb2-${randomUUID().slice(0, 8)}`;
+  const pipeName = makePipeName(tag);
+  const authToken = randomUUID();
+  writeConfig(wmuxDir, pipeName, authToken);
+
+  let child;
+  try {
+    child = spawnDaemon(testHome);
+    const resolvedPipe = await waitForPipeFile(wmuxDir);
+    await new Promise((r) => setTimeout(r, 800));
+    const alive = await pingOnce(pipeName, authToken);
+    const onCanonical = resolvedPipe === pipeName;            // no -N fallback on a clean dir
+    const noMinusOne = !(await pipeHasOwner(`${pipeName}-1`));
+    const pass = alive && onCanonical && noMinusOne;
+    report.push({ scenario: 'SB2', pass, alive, resolvedPipe, onCanonical, noMinusOne });
+  } catch (err) {
+    report.push({ scenario: 'SB2', pass: false, error: err.message });
+  } finally {
+    await killDaemon(child);
+    try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+}
+
+process.on('unhandledRejection', (reason) => {
+  console.error('[unhandledRejection]', reason instanceof Error ? reason.stack : String(reason));
+});
+
+const report = [];
+await runSB2(report); // clean-start regression first
+await runSB1(report); // then the split-brain trigger
+
+console.log('\n=== SPLIT-BRAIN DYNAMIC REPORT ===');
+for (const entry of report) console.log(JSON.stringify(entry));
+
+const failed = report.filter((r) => r.pass === false);
+if (failed.length > 0) {
+  console.error(`\n[FAIL] ${failed.length} scenario(s) failed.`);
+  process.exit(1);
+}
+console.log('\n[PASS] split-brain fail-fast + reconnect invariants hold.');
+process.exit(0);

--- a/src/daemon/DaemonPipeServer.ts
+++ b/src/daemon/DaemonPipeServer.ts
@@ -10,6 +10,34 @@ const MAX_LINE_BUFFER = 1024 * 1024; // 1 MB — prevent OOM from malicious clie
 
 type RpcHandler = (params: Record<string, unknown>) => Promise<unknown>;
 
+/** Action a reclaim probe implies, distinguishing a live owner from a zombie. */
+export type ReclaimOutcome = 'live-owner' | 'reclaimed' | 'unreclaimable';
+
+/**
+ * Classify a reclaim-probe result into the action the pipe server should take.
+ * Pure, so the live-owner-vs-zombie decision is unit-testable without a real
+ * socket.
+ *   - connect succeeded         → 'live-owner'    (a live process owns the pipe)
+ *   - ECONNREFUSED/RESET/EPIPE   → 'reclaimed'     (zombie; probe released it)
+ *   - timeout / any other error  → 'unreclaimable' (ambiguous; do NOT claim live)
+ *
+ * The 'live-owner' vs 'unreclaimable' split is the split-brain fix (Defect 3):
+ * the OLD code folded both into "false" and then fell back to a `-N` suffix,
+ * spawning a second LIVE daemon on the canonical pipe. Only a confirmed live
+ * owner must make `start()` yield; an ambiguous probe keeps the legacy retry.
+ */
+export function classifyReclaimProbe(
+  event: 'connect' | 'error' | 'timeout',
+  errCode?: string,
+): ReclaimOutcome {
+  if (event === 'connect') return 'live-owner';
+  if (event === 'timeout') return 'unreclaimable';
+  if (errCode === 'ECONNREFUSED' || errCode === 'ECONNRESET' || errCode === 'EPIPE') {
+    return 'reclaimed';
+  }
+  return 'unreclaimable';
+}
+
 /**
  * Daemon Control Pipe server.
  * Listens on a Named Pipe (Windows) or Unix domain socket for JSON-RPC requests.
@@ -123,10 +151,17 @@ export class DaemonPipeServer {
           throw err;
         }
 
-        // Attempt to reclaim the zombie pipe before falling back
+        // Attempt to reclaim the pipe before falling back. Distinguish a LIVE
+        // owner from a genuine zombie: a live owner on the CANONICAL pipe
+        // (attempt 0) means we are a redundant second daemon — the split-brain
+        // trigger (Defect 3). We must NOT fall back to the `-N` suffix (that
+        // produces two live daemons racing for the session pipes); fail fast so
+        // the entrypoint exits cleanly and the launcher reconnects to the
+        // existing daemon. The `-N` suffix stays only for the genuine-zombie
+        // and ambiguous cases.
         if (process.platform === 'win32' && code === 'EADDRINUSE') {
-          const reclaimed = await this.tryReclaimPipe(candidateName);
-          if (reclaimed) {
+          const outcome = await this.tryReclaimPipe(candidateName);
+          if (outcome === 'reclaimed') {
             try {
               await this.tryListen(candidateName);
               this.activePipeName = candidateName;
@@ -134,7 +169,16 @@ export class DaemonPipeServer {
             } catch {
               // Reclaim succeeded but listen still failed — fall through
             }
+          } else if (outcome === 'live-owner' && attempt === 0) {
+            const e = new Error(
+              `[daemon] canonical control pipe ${candidateName} is owned by a live daemon — refusing to start a redundant second daemon`,
+            ) as NodeJS.ErrnoException;
+            e.code = 'EDAEMON_ALREADY_RUNNING';
+            throw e;
           }
+          // 'unreclaimable', or a live-owner on a `-N` attempt: fall through to
+          // the next suffix (legacy behavior for the genuinely ambiguous or
+          // multi-daemon-cleanup case).
         }
 
         if (attempt === maxAttempts - 1) {
@@ -146,40 +190,40 @@ export class DaemonPipeServer {
   }
 
   /**
-   * Attempt to reclaim a zombie Windows named pipe.
-   *
-   * When a process crashes without closing its pipe handle, Windows keeps the
-   * pipe object alive until all handles are closed.  We probe the pipe:
-   *   - If connect succeeds → a live process owns it, cannot reclaim.
-   *   - If connect gets ECONNREFUSED/ECONNRESET → zombie pipe. Connecting
-   *     and immediately destroying the socket releases the last handle,
-   *     freeing the pipe name for reuse.
+   * Probe a Windows named pipe to decide whether it can be reclaimed. Returns
+   * a three-state outcome (see `classifyReclaimProbe`):
+   *   - 'live-owner': connect succeeded → a live process owns it. start() must
+   *     yield rather than fall back to a `-N` suffix (the split-brain fix).
+   *   - 'reclaimed': connect refused/reset → zombie; the probe released the
+   *     last handle, the name is free to retry.
+   *   - 'unreclaimable': timeout / unexpected error → ambiguous; neither claim
+   *     a live owner nor assume the name is free.
    */
-  private tryReclaimPipe(name: string): Promise<boolean> {
+  private tryReclaimPipe(name: string): Promise<ReclaimOutcome> {
     return new Promise((resolve) => {
       const probe = net.connect(name);
       const timer = setTimeout(() => {
         probe.destroy();
-        resolve(false);
+        resolve(classifyReclaimProbe('timeout'));
       }, 2000);
       timer.unref();
 
       probe.on('connect', () => {
-        // Pipe is owned by a live process — cannot reclaim
         clearTimeout(timer);
         probe.destroy();
-        resolve(false);
+        resolve(classifyReclaimProbe('connect'));
       });
 
       probe.on('error', (err: NodeJS.ErrnoException) => {
         clearTimeout(timer);
         probe.destroy();
-        if (err.code === 'ECONNREFUSED' || err.code === 'ECONNRESET' || err.code === 'EPIPE') {
-          // Zombie pipe — the connect attempt released the handle
-          // Wait briefly for Windows to clean up the pipe name
-          setTimeout(() => resolve(true), 200);
+        const outcome = classifyReclaimProbe('error', err.code);
+        if (outcome === 'reclaimed') {
+          // The connect attempt released the zombie handle — wait briefly for
+          // Windows to clean up the pipe name before the caller retries listen.
+          setTimeout(() => resolve('reclaimed'), 200);
         } else {
-          resolve(false);
+          resolve(outcome);
         }
       });
     });

--- a/src/daemon/__tests__/DaemonPipeServer.reclaim.test.ts
+++ b/src/daemon/__tests__/DaemonPipeServer.reclaim.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { classifyReclaimProbe } from '../DaemonPipeServer';
+
+// Step ③ of the duplicate-daemon / split-brain fix
+// (plans/duplicate-daemon-split-brain.md). Defect 3: when a freshly spawned
+// second daemon hits EADDRINUSE on the canonical control pipe, the OLD probe
+// folded "a live process owns it" and "the probe was inconclusive" into a
+// single `false`, then fell back to a `-N` suffix — producing TWO live daemons.
+// classifyReclaimProbe splits those cases so only a CONFIRMED live owner makes
+// start() yield (fail-fast), while ambiguous probes keep the legacy retry.
+
+describe('classifyReclaimProbe (Step ③ live-owner vs zombie)', () => {
+  it('connect succeeded → live-owner (must NOT take the -N fallback)', () => {
+    expect(classifyReclaimProbe('connect')).toBe('live-owner');
+  });
+
+  it('ECONNREFUSED → reclaimed (genuine zombie, probe released the handle)', () => {
+    expect(classifyReclaimProbe('error', 'ECONNREFUSED')).toBe('reclaimed');
+  });
+
+  it('ECONNRESET → reclaimed', () => {
+    expect(classifyReclaimProbe('error', 'ECONNRESET')).toBe('reclaimed');
+  });
+
+  it('EPIPE → reclaimed', () => {
+    expect(classifyReclaimProbe('error', 'EPIPE')).toBe('reclaimed');
+  });
+
+  it('timeout → unreclaimable (ambiguous — do NOT claim a live owner)', () => {
+    expect(classifyReclaimProbe('timeout')).toBe('unreclaimable');
+  });
+
+  it('an unexpected error code → unreclaimable, NOT live-owner', () => {
+    // The split-brain-relevant guarantee: a weird probe error must not be
+    // mistaken for a confirmed live owner (which would wrongly fail-fast),
+    // nor for a reclaimable zombie (which would wrongly steal the pipe).
+    expect(classifyReclaimProbe('error', 'EACCES')).toBe('unreclaimable');
+    expect(classifyReclaimProbe('error', 'ETIMEDOUT')).toBe('unreclaimable');
+  });
+
+  it('an error with no code → unreclaimable', () => {
+    expect(classifyReclaimProbe('error', undefined)).toBe('unreclaimable');
+  });
+});

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -15,6 +15,7 @@ import { initDaemonLogSink } from './util/logSink';
 import type { DaemonState } from './types';
 import type { DaemonEvent, DaemonCreateSessionParams, DaemonSessionIdParams, DaemonResizeParams } from '../shared/rpc';
 import { monitorEventLoopDelay } from 'node:perf_hooks';
+import { DAEMON_EXIT_ALREADY_RUNNING } from '../shared/constants';
 
 // === Constants ===
 const wmuxDir = getWmuxDir();
@@ -1486,6 +1487,19 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  if (code === 'EDAEMON_ALREADY_RUNNING') {
+    // Another LIVE daemon already owns the canonical control pipe — we are a
+    // redundant second daemon the launcher spawned over a daemon it failed to
+    // detect (split-brain Defect 3 / Step ③). Exit with a DISTINCT code so the
+    // launcher reconnects to the existing daemon instead of treating this as a
+    // generic startup failure. releaseLock() clears the daemon.pid that
+    // acquireLock() wrote for us; the launcher reconnects via the canonical
+    // pipe name, not the pid file.
+    log('warn', 'another live daemon owns the control pipe — exiting cleanly (EDAEMON_ALREADY_RUNNING)');
+    releaseLock();
+    process.exit(DAEMON_EXIT_ALREADY_RUNNING);
+  }
   log('error', 'Fatal error during startup:', err);
   releaseLock();
   process.exit(1);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -798,7 +798,9 @@ function registerRpcHandlers(
     const meanNs = eventLoopMonitor.mean;
     const eventLoopLagMs = Number.isFinite(meanNs) ? Math.round(meanNs / 1e6) : 0;
     eventLoopMonitor.reset();
-    return { status: 'ok', uptime, sessions: sessions.length, eventLoopLagMs };
+    // `pid` lets the launcher restore daemon.pid after a Step ③ reconnect
+    // (the redundant-daemon path cleaned the pid file). Log-only otherwise.
+    return { status: 'ok', pid: process.pid, uptime, sessions: sessions.length, eventLoopLagMs };
   });
 
   // daemon.shutdown — gracefully terminate the daemon process. A2 makes

--- a/src/main/daemon/__tests__/launcher.liveness.test.ts
+++ b/src/main/daemon/__tests__/launcher.liveness.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { classifyTasklistOutput, classifyKillOutcome } from '../launcher';
+
+// Step ① of the duplicate-daemon / split-brain fix
+// (plans/duplicate-daemon-split-brain.md). The bug's upstream trigger
+// (Defect 1) was a probe TIMEOUT being coerced to "dead", so ensureDaemon
+// skipped ping/reuse and spawned a second daemon over the live one. These
+// tests pin the three-state classification so a timeout can never again read
+// as `dead`.
+
+describe('classifyTasklistOutput (win32 liveness)', () => {
+  it('null stdout (probe timeout / exec error) → unknown, never dead', () => {
+    // This is the exact regression guard for Defect 1: a tasklist stall
+    // under Defender/CPU pressure must be `unknown`, not `dead`.
+    expect(classifyTasklistOutput(1234, null)).toBe('unknown');
+  });
+
+  it('stdout carrying the PID row → alive', () => {
+    expect(
+      classifyTasklistOutput(1234, '"node.exe","1234","Console","1","50,000 K"\r\n'),
+    ).toBe('alive');
+  });
+
+  it('authoritative empty listing (exec ok, PID absent) → dead', () => {
+    expect(classifyTasklistOutput(1234, '')).toBe('dead');
+  });
+
+  it('real tasklist absent-PID output (INFO line, no data row) → dead', () => {
+    // What tasklist actually prints to stdout (exit 0) for an absent PID —
+    // the realistic 'dead' input, distinct from the phantom empty string.
+    expect(
+      classifyTasklistOutput(
+        1234,
+        'INFO: No tasks are running which match the specified criteria.\r\n',
+      ),
+    ).toBe('dead');
+  });
+
+  it('listing for a different PID only → dead', () => {
+    expect(
+      classifyTasklistOutput(1234, '"other.exe","9999","Console","1","10,000 K"\r\n'),
+    ).toBe('dead');
+  });
+});
+
+describe('classifyKillOutcome (POSIX liveness)', () => {
+  it('no error (signal delivered to a live process) → alive', () => {
+    expect(classifyKillOutcome(undefined)).toBe('alive');
+  });
+
+  it('ESRCH (no such process) → dead', () => {
+    expect(classifyKillOutcome('ESRCH')).toBe('dead');
+  });
+
+  it('EPERM (process exists but not permitted to signal) → alive', () => {
+    expect(classifyKillOutcome('EPERM')).toBe('alive');
+  });
+
+  it('any other error (timeout, EINVAL, ...) → unknown', () => {
+    expect(classifyKillOutcome('ETIMEDOUT')).toBe('unknown');
+    expect(classifyKillOutcome('EINVAL')).toBe('unknown');
+  });
+});

--- a/src/main/daemon/__tests__/launcher.reping.test.ts
+++ b/src/main/daemon/__tests__/launcher.reping.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { tryEscalatedReping } from '../launcher';
+
+// Step ② of the duplicate-daemon / split-brain fix
+// (plans/duplicate-daemon-split-brain.md). When a verified-but-unresponsive
+// daemon misses the two short startup pings, the OLD code went straight to
+// SIGKILL — destroying the sessions the user chose to keep (Defect 2). The
+// escalated re-ping gives a busy-but-alive daemon a longer budget so it is
+// reused instead of killed. These tests pin the reuse-vs-kill decision via
+// injected ping/sleep (no live daemon needed).
+
+const noSleep = (): Promise<void> => Promise.resolve();
+
+describe('tryEscalatedReping (Step ② escalating re-ping)', () => {
+  it('reuses (true) as soon as an escalated ping succeeds, stopping early', async () => {
+    const seen: number[] = [];
+    const ping = (t: number): Promise<boolean> => {
+      seen.push(t);
+      return Promise.resolve(t === 1000); // first (500ms) fails, second (1000ms) succeeds
+    };
+    const ok = await tryEscalatedReping(ping, [500, 1000], 0, noSleep);
+    expect(ok).toBe(true);
+    expect(seen).toEqual([500, 1000]);
+  });
+
+  it('returns true on the very first escalated ping if it succeeds (no further pings)', async () => {
+    const seen: number[] = [];
+    const ping = (t: number): Promise<boolean> => {
+      seen.push(t);
+      return Promise.resolve(true);
+    };
+    const ok = await tryEscalatedReping(ping, [500, 1000], 0, noSleep);
+    expect(ok).toBe(true);
+    expect(seen).toEqual([500]); // stopped after the first success — no kill considered yet
+  });
+
+  it('returns false (→ proceed to kill) only when every escalated ping fails', async () => {
+    const seen: number[] = [];
+    const ping = (t: number): Promise<boolean> => {
+      seen.push(t);
+      return Promise.resolve(false);
+    };
+    const ok = await tryEscalatedReping(ping, [500, 1000], 0, noSleep);
+    expect(ok).toBe(false);
+    expect(seen).toEqual([500, 1000]);
+  });
+
+  it('backs off before each ping (escalating budget, not a tight loop)', async () => {
+    const sleeps: number[] = [];
+    const sleep = (ms: number): Promise<void> => {
+      sleeps.push(ms);
+      return Promise.resolve();
+    };
+    await tryEscalatedReping(() => Promise.resolve(false), [500, 1000], 200, sleep);
+    expect(sleeps).toEqual([200, 200]);
+  });
+
+  it('an empty timeout list performs no pings and returns false', async () => {
+    let pings = 0;
+    await tryEscalatedReping(
+      () => {
+        pings += 1;
+        return Promise.resolve(true);
+      },
+      [],
+      0,
+      noSleep,
+    );
+    expect(pings).toBe(0);
+  });
+});

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -228,14 +228,33 @@ function getProcessCommandLine(pid: number): string | null {
   } catch { return null; }
 }
 
-function pingDaemon(pipeName: string, token: string, timeoutMs = 3000): Promise<boolean> {
+interface DaemonPingResult {
+  status?: string;
+  pid?: number;
+  uptime?: number;
+  sessions?: number;
+  eventLoopLagMs?: number;
+}
+
+/**
+ * Send `daemon.ping` and return the daemon's reported result (which carries
+ * `pid` since the Step ③ follow-up), or `null` on timeout / error / refusal.
+ * `pingDaemon` is the boolean wrapper most callers use; the reconnect path
+ * uses the result's `pid` to restore daemon.pid.
+ */
+function daemonPing(pipeName: string, token: string, timeoutMs = 3000): Promise<DaemonPingResult | null> {
   return new Promise((resolve) => {
     const socket = net.connect(pipeName);
     let settled = false;
+    const finish = (value: DaemonPingResult | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(value);
+    };
 
-    const timer = setTimeout(() => {
-      if (!settled) { settled = true; socket.destroy(); resolve(false); }
-    }, timeoutMs);
+    const timer = setTimeout(() => finish(null), timeoutMs);
     timer.unref();
 
     socket.on('connect', () => {
@@ -253,20 +272,19 @@ function pingDaemon(pipeName: string, token: string, timeoutMs = 3000): Promise<
         try {
           const resp = JSON.parse(line.trim());
           if (resp.ok || (resp.result && resp.result.status === 'ok')) {
-            settled = true;
-            clearTimeout(timer);
-            socket.destroy();
-            resolve(true);
+            finish((resp.result as DaemonPingResult) ?? { status: 'ok' });
             return;
           }
         } catch {}
       }
     });
 
-    socket.on('error', () => {
-      if (!settled) { settled = true; clearTimeout(timer); resolve(false); }
-    });
+    socket.on('error', () => finish(null));
   });
+}
+
+function pingDaemon(pipeName: string, token: string, timeoutMs = 3000): Promise<boolean> {
+  return daemonPing(pipeName, token, timeoutMs).then((r) => r !== null);
 }
 
 /**
@@ -670,20 +688,32 @@ export async function ensureDaemon(): Promise<DaemonInfo> {
       // canonical pipe (split-brain avoided — no second live daemon, no `-N`
       // pipe). Reconnect to the existing daemon instead of looping into another
       // spawn. The pipe file was cleaned with the stale files above, so resolve
-      // the canonical name deterministically. (DaemonInfo.pid is log-only
-      // downstream, so a best-effort pid is fine.)
+      // the canonical name deterministically.
       const canonicalPipe = getDaemonPipeName();
       const reconnectToken = readDaemonAuthToken();
-      if (reconnectToken && (await pingDaemon(canonicalPipe, reconnectToken))) {
-        console.log(
-          '[launcher] spawned daemon yielded to a live daemon — reconnected to the existing daemon',
-        );
-        return {
-          pid: existingPid ?? 0,
-          authToken: reconnectToken,
-          pipeName: canonicalPipe,
-          spawned: false,
-        };
+      if (reconnectToken) {
+        const pong = await daemonPing(canonicalPipe, reconnectToken);
+        if (pong) {
+          // Restore daemon.pid (the stale-file cleanup above deleted it) to the
+          // live daemon's reported pid, so the NEXT launch hits the cheap reuse
+          // branch (existingPid → ping → reuse) instead of repeating this
+          // spawn-yield-reconnect dance every launch.
+          const livePid = typeof pong.pid === 'number' && pong.pid > 0 ? pong.pid : (existingPid ?? 0);
+          if (livePid > 0) {
+            try {
+              fs.writeFileSync(pidFile, String(livePid), { encoding: 'utf-8', mode: 0o600 });
+            } catch { /* best effort — reconnect still succeeds without it */ }
+          }
+          console.log(
+            '[launcher] spawned daemon yielded to a live daemon — reconnected to the existing daemon',
+          );
+          return {
+            pid: livePid,
+            authToken: reconnectToken,
+            pipeName: canonicalPipe,
+            spawned: false,
+          };
+        }
       }
     }
     throw err;

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -268,6 +268,28 @@ function pingDaemon(pipeName: string, token: string, timeoutMs = 3000): Promise<
   });
 }
 
+/**
+ * Escalating re-ping. After the two short startup pings (250+250 ms) fail,
+ * give a busy-but-alive daemon a longer budget before treating it as wedged
+ * and SIGKILLing it — which would destroy the sessions the user chose to keep
+ * (split-brain Defect 2). Injectable (`ping`/`sleep` passed in) so the
+ * reuse-vs-kill decision is unit-testable without a live daemon. Returns true
+ * as soon as any escalated ping succeeds (→ reuse, do not kill); stops at the
+ * first success.
+ */
+export async function tryEscalatedReping(
+  ping: (timeoutMs: number) => Promise<boolean>,
+  timeouts: number[],
+  backoffMs: number,
+  sleep: (ms: number) => Promise<void>,
+): Promise<boolean> {
+  for (const timeoutMs of timeouts) {
+    await sleep(backoffMs);
+    if (await ping(timeoutMs)) return true;
+  }
+  return false;
+}
+
 function findNodePath(): string {
   // Prefer Electron's bundled node (via ELECTRON_RUN_AS_NODE) — it's a GUI
   // subsystem executable, so it won't flash a console window on Windows.
@@ -544,9 +566,39 @@ export async function ensureDaemon(): Promise<DaemonInfo> {
               `[launcher] PID ${existingPid} image matches but cmdline does not reference daemon script — stale-PID reuse by sibling Electron app, cleaning + spawning fresh`,
             );
           } else {
+            // (a) Verified wmux daemon (image+cmdline match) that missed the
+            //     two-shot (250+250 ms) ping. Before the DESTRUCTIVE SIGKILL —
+            //     which nukes the very sessions the user chose to keep
+            //     (Defect 2) — escalate the ping budget. A busy-but-alive
+            //     daemon (big sessions.json recovery, ConPTY cold-init,
+            //     Defender realtime scan) can stall past the short pings while
+            //     fully alive and still owning its PTYs. Only a daemon that
+            //     ALSO fails the escalated ping is treated as genuinely wedged.
+            //     The escalating budget (~1.9 s worst case) stays well inside
+            //     the 15 s spawn budget.
+            //
+            //     A graceful shutdown RPC is intentionally NOT attempted: a
+            //     daemon that can't answer a ping can't answer an RPC either,
+            //     so escalated re-ping (→ reuse) is the only thing that
+            //     actually preserves kept sessions. A confirmed-wedged daemon
+            //     leaves SIGKILL+respawn as the single-daemon recovery.
+            if (token) {
+              const recovered = await tryEscalatedReping(
+                (timeoutMs) => pingDaemon(pipeName, token, timeoutMs),
+                [500, 1000],
+                200,
+                (ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
+              );
+              if (recovered) {
+                console.log(
+                  `[launcher] Daemon (PID ${existingPid}) recovered on escalated re-ping — reusing, no kill`,
+                );
+                return { pid: existingPid, authToken: token, pipeName, spawned: false };
+              }
+            }
             // (a) Verified wmux daemon → kill before respawning.
             console.warn(
-              `[launcher] PID ${existingPid} verified wmux daemon (image+cmdline) but unresponsive — terminating before respawn`,
+              `[launcher] PID ${existingPid} verified wmux daemon (image+cmdline) but unresponsive${token ? ' after escalated re-ping' : ' (no auth token to ping)'} — terminating before respawn`,
             );
             let killSucceeded = true;
             try {

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -61,19 +61,63 @@ function askUserToRecoverFromStalePid(opts: {
   return choice === 0;
 }
 
-function isProcessAlive(pid: number): boolean {
+export type ProcessLiveness = 'alive' | 'dead' | 'unknown';
+
+/**
+ * Classify a Windows `tasklist` probe result. `stdout === null` means the
+ * probe itself failed (timeout under Defender realtime scan, CPU/WMI
+ * pressure, exec error) — that is `unknown`, NOT `dead`. Only an
+ * authoritative empty listing (exec succeeded, PID absent) is `dead`.
+ */
+export function classifyTasklistOutput(pid: number, stdout: string | null): ProcessLiveness {
+  if (stdout === null) return 'unknown';
+  return stdout.includes(`"${pid}"`) ? 'alive' : 'dead';
+}
+
+/**
+ * Classify a POSIX `process.kill(pid, 0)` outcome. No error → the signal
+ * reached a live process (`alive`). `ESRCH` → authoritative "no such
+ * process" (`dead`). `EPERM` → the process exists but we may not signal it
+ * (`alive`). Anything else → `unknown`.
+ */
+export function classifyKillOutcome(code: string | undefined): ProcessLiveness {
+  if (code === undefined) return 'alive';
+  if (code === 'ESRCH') return 'dead';
+  if (code === 'EPERM') return 'alive';
+  return 'unknown';
+}
+
+/**
+ * Three-state liveness probe. A probe FAILURE (timeout / exec error) is
+ * `unknown`, never `dead` — mirroring `ProcessMonitor.isDefinitelyDead`
+ * (PR #87). Only positive confirmation of death (`dead`) may authorize a
+ * destructive / spawn-over branch; callers must treat `unknown` as "assume
+ * alive, do not spawn over it." Reading a probe timeout as "process absent"
+ * was the upstream trigger of the duplicate-daemon / split-brain bug
+ * (Defect 1): tasklist stalls on a loaded box → false "dead" → ensureDaemon
+ * skips ping/reuse and spawns a second daemon over the live one.
+ */
+function checkProcessLiveness(pid: number): ProcessLiveness {
   if (process.platform === 'win32') {
+    let stdout: string | null = null;
     try {
       const { execFileSync } = require('child_process');
       const systemRoot = process.env.SystemRoot || 'C:\\Windows';
       const tasklist = path.join(systemRoot, 'System32', 'tasklist.exe');
-      const result = execFileSync(tasklist, ['/fi', `PID eq ${pid}`, '/fo', 'csv', '/nh'], {
+      stdout = execFileSync(tasklist, ['/fi', `PID eq ${pid}`, '/fo', 'csv', '/nh'], {
         encoding: 'utf-8', timeout: 3000, windowsHide: true,
       });
-      return result.includes(`"${pid}"`);
-    } catch { return false; }
+    } catch {
+      stdout = null; // timeout / exec failure → unknown (NOT dead)
+    }
+    return classifyTasklistOutput(pid, stdout);
   }
-  try { process.kill(pid, 0); return true; } catch { return false; }
+  try {
+    process.kill(pid, 0);
+    return classifyKillOutcome(undefined);
+  } catch (err: unknown) {
+    return classifyKillOutcome((err as NodeJS.ErrnoException | undefined)?.code);
+  }
 }
 
 /**
@@ -360,8 +404,10 @@ export async function ensureDaemon(): Promise<DaemonInfo> {
     existingPid = parseInt(pidStr, 10);
   } catch {}
 
-  // 2. If PID exists and process alive, try to ping
-  if (existingPid && isProcessAlive(existingPid)) {
+  // 2. If the PID is alive OR its liveness is unknown (a probe timeout must
+  //    NOT be read as "dead" — Defect 1), enter the ping/reuse path. Only a
+  //    confirmed-dead PID skips straight to spawn over a possibly-live daemon.
+  if (existingPid && checkProcessLiveness(existingPid) !== 'dead') {
     const token = readDaemonAuthToken();
     const pipeName = readPipeNameFromFile(wmuxDir) || getDaemonPipeName();
 
@@ -508,7 +554,7 @@ export async function ensureDaemon(): Promise<DaemonInfo> {
             } catch (err: unknown) {
               const code = (err as NodeJS.ErrnoException | undefined)?.code;
               if (code === 'ESRCH') {
-                // ESRCH = process died between isProcessAlive and kill.
+                // ESRCH = process died between the liveness check and kill.
                 // Benign race — we wanted it gone and it is.
               } else {
                 // EPERM (Windows: Access Denied), EINVAL, anything else:
@@ -584,7 +630,11 @@ export function killDaemonByPidFile(): boolean {
     const pidStr = fs.readFileSync(path.join(wmuxDir, 'daemon.pid'), 'utf8').trim();
     const pid = parseInt(pidStr, 10);
     if (!Number.isFinite(pid) || pid <= 0 || pid === process.pid) return false;
-    if (!isProcessAlive(pid)) return false;
+    // Only a confirmed-dead PID skips the kill (already gone). `unknown`
+    // proceeds — this backstop runs seconds after we were talking to the
+    // daemon, so an orphan is the worse outcome; the image/cmdline guards
+    // below still prevent killing an unrelated PID-reuse victim.
+    if (checkProcessLiveness(pid) === 'dead') return false;
 
     const expectedImage = path.basename(process.execPath);
     const image = getProcessImageName(pid);

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -6,6 +6,7 @@ import * as crypto from 'crypto';
 import { app, dialog } from 'electron';
 import { getWmuxDir } from '../../daemon/config';
 import { getDaemonPipeName, readDaemonAuthToken } from '../DaemonClient';
+import { DAEMON_EXIT_ALREADY_RUNNING } from '../../shared/constants';
 
 export interface DaemonInfo {
   pid: number;
@@ -404,6 +405,23 @@ function spawnDaemon(): Promise<number> {
         reject(new Error('Daemon spawned but not responding after 15 seconds'));
       }
     }, 200);
+
+    // A redundant second daemon (spawned over a daemon the launcher failed to
+    // detect) yields the canonical pipe to the live owner and exits with
+    // DAEMON_EXIT_ALREADY_RUNNING (split-brain Defect 3). Surface that as a
+    // distinct error so ensureDaemon reconnects to the existing daemon instead
+    // of treating it as a spawn failure. Other early exits fall through to the
+    // poll's own 15s timeout.
+    child.on('exit', (code) => {
+      if (code === DAEMON_EXIT_ALREADY_RUNNING) {
+        clearInterval(poll);
+        const e = new Error(
+          'daemon yielded: another daemon already owns the canonical control pipe',
+        ) as NodeJS.ErrnoException;
+        e.code = 'EDAEMON_ALREADY_RUNNING';
+        reject(e);
+      }
+    });
   });
 }
 
@@ -643,7 +661,33 @@ export async function ensureDaemon(): Promise<DaemonInfo> {
     try { fs.unlinkSync(path.join(wmuxDir, name)); } catch { /* ignore */ }
   }
 
-  const pid = await spawnDaemon();
+  let pid: number;
+  try {
+    pid = await spawnDaemon();
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | undefined)?.code === 'EDAEMON_ALREADY_RUNNING') {
+      // The daemon we spawned yielded to a live daemon already owning the
+      // canonical pipe (split-brain avoided — no second live daemon, no `-N`
+      // pipe). Reconnect to the existing daemon instead of looping into another
+      // spawn. The pipe file was cleaned with the stale files above, so resolve
+      // the canonical name deterministically. (DaemonInfo.pid is log-only
+      // downstream, so a best-effort pid is fine.)
+      const canonicalPipe = getDaemonPipeName();
+      const reconnectToken = readDaemonAuthToken();
+      if (reconnectToken && (await pingDaemon(canonicalPipe, reconnectToken))) {
+        console.log(
+          '[launcher] spawned daemon yielded to a live daemon — reconnected to the existing daemon',
+        );
+        return {
+          pid: existingPid ?? 0,
+          authToken: reconnectToken,
+          pipeName: canonicalPipe,
+          spawned: false,
+        };
+      }
+    }
+    throw err;
+  }
 
   // Read connection info after spawn
   const token = readDaemonAuthToken();

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -115,6 +115,14 @@ export const IPC = {
   FIRST_RUN_SAMPLE_TASK_TIMEOUT: 'first-run:sample-task-timeout',
 } as const;
 
+// Daemon process exit codes. A spawned daemon that finds the canonical control
+// pipe already owned by a LIVE daemon exits with this distinct code (rather than
+// a generic failure) so the launcher reconnects to the existing daemon instead
+// of looping into another spawn — the duplicate-daemon / split-brain fix
+// (Defect 3 / Step ③). 75 mirrors sysexits.h EX_TEMPFAIL: "try again", and is
+// well clear of Node's own 1/2/9-ish fatal codes.
+export const DAEMON_EXIT_ALREADY_RUNNING = 75;
+
 // Named Pipe / Unix socket path for wmux API
 // Fixed name so MCP clients (e.g. Claude Code) can reconnect across wmux restarts
 export function getPipeName(): string {


### PR DESCRIPTION
## Problem

"Quit (keep sessions running)" leaves the daemon + its PTYs alive (the persistence design). On the next relaunch the terminal came up **reset** (fresh sessions) with a **second daemon** running and a `-1`-suffixed pipe — persistence broken, RAM wasted on the orphaned first daemon, per-session pipes colliding (`EADDRINUSE`). Root cause is a three-defect chain in the daemon/launcher lifecycle (grounded in `plans/duplicate-daemon-split-brain.md`).

## The 3-defect chain + fix

**Defect 1 — `isProcessAlive` coerced a probe TIMEOUT to "dead"** (Step 1, `7905719`)
On a loaded box (Defender scan, CPU/WMI pressure) `tasklist`/`ps` times out → old `catch { return false }` → `ensureDaemon` reads the live daemon as absent → skips ping/reuse → spawns over it. Replaced with `checkProcessLiveness` → `alive | dead | unknown`; only an authoritative "no such PID" is `dead`, any probe failure is `unknown` ("assume alive, do not spawn over it"). Mirrors `ProcessMonitor.isDefinitelyDead` (PR #87).

**Defect 2 — verified-but-unresponsive daemon was SIGKILLed immediately** (Step 2, `a9ec2d6`)
A busy-but-alive daemon (big `sessions.json` recovery, ConPTY cold-init) that missed the two-shot ping was killed — destroying the very sessions the user chose to keep. Now escalates the ping `[500, 1000]ms` (`tryEscalatedReping`) before any kill; only a daemon that ALSO fails the escalated ping is treated as wedged.

**Defect 3 — `-N` pipe fallback couldn't tell a live owner from a zombie** (Step 3, `8b1f611`)
When a redundant second daemon hit `EADDRINUSE` on the canonical pipe, `tryReclaimPipe` folded "live owner" and "inconclusive probe" into one `false`, then took a `-1` suffix → two live daemons. Now a 3-state outcome (`classifyReclaimProbe`): a live owner on the canonical pipe fails fast (`EDAEMON_ALREADY_RUNNING` → `exit 75`); the launcher catches the exit and **reconnects to the existing daemon** instead of spawning again. The `-N` suffix stays only for genuine zombies / ambiguous probes.

**Follow-up — restore `daemon.pid` on reconnect** (`3e08b81`)
`daemon.ping` now reports `pid`; on reconnect the launcher rewrites `daemon.pid` so the next launch hits the cheap `existingPid → ping → reuse` path instead of repeating spawn-yield-reconnect every launch.

## Verification

- **Unit**: the 3-state classifiers (`classifyTasklistOutput` / `classifyKillOutcome`, `tryEscalatedReping`, `classifyReclaimProbe`) are pure + injectable + fully covered.
- **Dynamic** (`scripts/split-brain-dynamic.mjs`): spawns the real bundled daemon in an isolated state dir (USERPROFILE/HOME → tmpdir, unique pipe), reproduces the trigger (daemon A holds canonical pipe → stale cleanup → daemon B spawned over A) and asserts **B exits 75, no `-1` pipe, A survives + still answers `daemon.ping`**. SB1 + SB2 (clean-start regression) both PASS.
- **Review**: 4 rounds of opus adversarial review (codex unavailable on this account), all SHIP.
- Typecheck clean; daemon + launcher unit suites green.

## Not covered (honest)

- **GUI dogfood was skipped by explicit maintainer choice for this PR.** The launcher-side reconnect (`exit 75 → ensureDaemon` reconnect) and the real-environment Quit/relaunch regression are Electron-coupled — verified by code review + the daemon-half dynamic test, not by a live GUI run.
- A separate, pre-existing bug surfaced during this work: **orphan daemons (session 0, client 0) are not idle-reaped and accumulate** (a 5/30 daemon was found alive 3 days later). Tracked separately — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
