### PR TITLE
Terminal render/scrollback restore + workspace-scoped pane creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Logs
 logs
 *.log
+*.log.err
+wmux-restart.log*
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -98,6 +98,9 @@ async function signMacAppIfConfigured(appPath: string): Promise<void> {
 }
 
 const config: ForgeConfig = {
+  rebuildConfig: {
+    ignoreModules: ['node-pty'],
+  },
   packagerConfig: {
     asar: {
       unpack: '**/node_modules/node-pty/**',

--- a/src/main/ipc/handlers/__tests__/session.handler.daemonModeNoop.test.ts
+++ b/src/main/ipc/handlers/__tests__/session.handler.daemonModeNoop.test.ts
@@ -2,44 +2,53 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 
-// Phase A — A6. session.handler must short-circuit scrollback:dump AND
-// scrollback:load when the live `isDaemonConnected` getter returns true.
-// We verify the contract at the source level — actually exercising the
-// handler requires Electron's ipcMain and a real BrowserWindow, which a
-// vitest process cannot bootstrap.
-describe('A6 — session.handler daemon-mode short-circuit (source-level)', () => {
+// Daemon scrollback restore (commit "Fix daemon scrollback restore for TUI
+// redraws"). The earlier A6 design short-circuited scrollback:dump AND
+// scrollback:load whenever the live `isDaemonConnected` getter returned true,
+// leaving daemon RingBuffer replay as the sole restore path. Dogfooding showed
+// raw daemon bytes do not reliably repaint full-screen TUIs (Codex, Claude
+// Code, vim), so the rendered snapshot is now the UI recovery source and the
+// daemon replay is the fallback. These source-level assertions lock the
+// short-circuit OUT so it cannot silently return — actually exercising the
+// handler needs Electron's ipcMain + a real BrowserWindow, which a vitest
+// process cannot bootstrap.
+describe('session.handler daemon-mode scrollback (short-circuit removed)', () => {
   const handlerPath = path.join(__dirname, '..', 'session.handler.ts');
   const src = fs.readFileSync(handlerPath, 'utf-8');
 
-  it('registerSessionHandlers accepts an isDaemonConnected getter parameter', () => {
+  it('keeps the daemon getter param for register-site compatibility but leaves it unused', () => {
+    // The param is retained so callers in main/index.ts need no change, but it
+    // is underscore-prefixed to mark it intentionally unused.
     expect(src).toMatch(
-      /export function registerSessionHandlers\(\s*isDaemonConnected:\s*\(\s*\)\s*=>\s*boolean/,
+      /export function registerSessionHandlers\(\s*_isDaemonConnected:\s*\(\s*\)\s*=>\s*boolean/,
     );
   });
 
-  it('parameter defaults to () => false so local-only callers stay safe', () => {
-    expect(src).toMatch(/isDaemonConnected:\s*\(\s*\)\s*=>\s*boolean\s*=\s*\(\s*\)\s*=>\s*false/);
+  it('param defaults to () => false so local-only callers stay safe', () => {
+    expect(src).toMatch(/_isDaemonConnected:\s*\(\s*\)\s*=>\s*boolean\s*=\s*\(\s*\)\s*=>\s*false/);
   });
 
-  it('scrollback:dump handler short-circuits when daemon is connected', () => {
-    // Slice the dump handler body. The marker `// scrollback:dump` opens
-    // the registration. The body extends until the next `// scrollback:load`
-    // marker comment.
+  it('scrollback:dump no longer short-circuits when daemon is connected', () => {
     const start = src.indexOf('// scrollback:dump');
     const end = src.indexOf('// scrollback:load');
     expect(start).toBeGreaterThan(0);
     expect(end).toBeGreaterThan(start);
     const body = src.slice(start, end);
-    // Guard must be the first behavioural branch (before validation, write).
-    expect(body).toMatch(/if\s*\(\s*isDaemonConnected\(\)\s*\)\s*\{[\s\S]*?return\s*\{\s*success:\s*true[\s\S]*?skipped:\s*true/);
+    // No daemon-mode bail-out: the snapshot must still be written so the
+    // rendered transcript survives across restarts.
+    expect(body).not.toMatch(/if\s*\(\s*isDaemonConnected\(\)\s*\)/);
+    expect(body).not.toMatch(/skipped:\s*true/);
+    // First behavioural branch is the path-traversal guard on surfaceId.
+    expect(body).toMatch(/if\s*\(!\/\^\[a-zA-Z0-9-\]\+\$\/\.test\(surfaceId\)\)\s*return\s*\{\s*success:\s*false/);
   });
 
-  it('scrollback:load handler returns null when daemon is connected', () => {
+  it('scrollback:load no longer returns null when daemon is connected', () => {
     const start = src.indexOf('// scrollback:load');
     expect(start).toBeGreaterThan(0);
     const body = src.slice(start);
-    // The first guard in the load handler returns null on daemon mode so
-    // the renderer skips its .txt restore branch.
-    expect(body).toMatch(/if\s*\(\s*isDaemonConnected\(\)\s*\)\s*\{[\s\S]*?return\s+null/);
+    // No daemon-mode bail-out: the load handler must surface the rendered
+    // snapshot so the renderer can repaint TUIs from it.
+    expect(body).not.toMatch(/if\s*\(\s*isDaemonConnected\(\)\s*\)\s*\{[\s\S]*?return\s+null/);
+    expect(body).toMatch(/if\s*\(!\/\^\[a-zA-Z0-9-\]\+\$\/\.test\(surfaceId\)\)\s*return\s*null/);
   });
 });

--- a/src/main/ipc/handlers/session.handler.ts
+++ b/src/main/ipc/handlers/session.handler.ts
@@ -32,18 +32,13 @@ function scrollbackFilePath(surfaceId: string): string {
 }
 
 /**
- * Phase A — A6. Live getter for daemon-connected state. The handlers gate
- * scrollback:dump + scrollback:load on this; in daemon mode the renderer
- * .txt fallback path is short-circuited so the rotation chain hazard
- * (4-minute self-destruction of good backups) cannot fire while the daemon
- * is the source of truth. Local mode (getter returns false) keeps the
- * existing .txt path verbatim.
- *
- * Passed as a callback rather than a snapshot so connect/disconnect
- * transitions during the renderer's lifetime are reflected immediately.
+ * Live getter kept for register-site compatibility. Scrollback dump/load is
+ * intentionally no longer gated on daemon state: rendered snapshots are the
+ * UI recovery source for repainting TUIs, while daemon raw bytes are a
+ * fallback when no snapshot exists.
  */
 export function registerSessionHandlers(
-  isDaemonConnected: () => boolean = () => false,
+  _isDaemonConnected: () => boolean = () => false,
 ): () => void {
   // Instrumentation: scrollback restore race investigation. This function is
   // called from `registerAllHandlers`, which is invoked both at module load
@@ -79,14 +74,6 @@ export function registerSessionHandlers(
   //     guard in `serializeTerminalBuffer` is the primary fix.
   ipcMain.removeHandler(IPC.SCROLLBACK_DUMP);
   ipcMain.handle(IPC.SCROLLBACK_DUMP, wrapHandler(IPC.SCROLLBACK_DUMP, (_event: Electron.IpcMainInvokeEvent, surfaceId: string, content: string) => {
-    // Phase A — A6. Daemon mode: skip the .txt write entirely. The daemon
-    // RingBuffer is authoritative for scrollback; persisting the .txt at
-    // the same time would compose two restore paths in the renderer
-    // (`.txt` autoload + daemon SessionPipe flush) and the rotation chain
-    // would still self-destruct on idle terminals.
-    if (isDaemonConnected()) {
-      return { success: true, skipped: true };
-    }
     // Validate surfaceId (alphanumeric + hyphens only, prevent path traversal)
     if (!/^[a-zA-Z0-9-]+$/.test(surfaceId)) return { success: false };
 
@@ -131,14 +118,6 @@ export function registerSessionHandlers(
   //     the next good content on the next 5s tick.
   ipcMain.removeHandler(IPC.SCROLLBACK_LOAD);
   ipcMain.handle(IPC.SCROLLBACK_LOAD, wrapHandler(IPC.SCROLLBACK_LOAD, (_event: Electron.IpcMainInvokeEvent, surfaceId: string) => {
-    // Phase A — A6. Daemon mode: return null so the renderer skips its
-    // .txt restore branch and relies entirely on the daemon SessionPipe
-    // flush. Returning even a valid old .txt here would race the daemon
-    // replay and the renderer would compose them with a separator
-    // (codex review Layer C corruption path).
-    if (isDaemonConnected()) {
-      return null;
-    }
     if (!/^[a-zA-Z0-9-]+$/.test(surfaceId)) return null;
     const filePath = scrollbackFilePath(surfaceId);
     try {

--- a/src/main/pipe/handlers/__tests__/pane.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/pane.rpc.test.ts
@@ -226,6 +226,22 @@ describe('pane.rpc — search', () => {
     expect(sendToRendererMock).not.toHaveBeenCalled();
   });
 
+  it('forwards workspaceId when splitting a pane', async () => {
+    const router = register();
+    const response = await router.dispatch({
+      id: '14',
+      method: 'pane.split',
+      params: { direction: 'horizontal', workspaceId: 'ws-caller' },
+    });
+
+    expect(response.ok).toBe(true);
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      'pane.split',
+      { direction: 'horizontal', workspaceId: 'ws-caller' },
+    );
+  });
+
   it('returns the renderer response payload to the caller', async () => {
     const router = register();
     const fakeResponse = {

--- a/src/main/pipe/handlers/__tests__/surface.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/surface.rpc.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserWindow } from 'electron';
+import { RpcRouter } from '../../RpcRouter';
+import { registerSurfaceRpc } from '../surface.rpc';
+
+const { sendToRendererMock } = vi.hoisted(() => ({
+  sendToRendererMock: vi.fn(),
+}));
+
+vi.mock('../_bridge', () => ({
+  sendToRenderer: sendToRendererMock,
+}));
+
+function register(): RpcRouter {
+  const router = new RpcRouter();
+  registerSurfaceRpc(router, (() => null) as () => BrowserWindow | null);
+  return router;
+}
+
+describe('surface.rpc', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sendToRendererMock.mockResolvedValue({ ok: true });
+  });
+
+  it('forwards workspaceId, shell, and cwd to the renderer when creating a surface', async () => {
+    const router = register();
+
+    const response = await router.dispatch({
+      id: '1',
+      method: 'surface.new',
+      params: {
+        workspaceId: 'ws-caller',
+        shell: 'powershell.exe',
+        cwd: 'C:\\Users\\LORD',
+      },
+    });
+
+    expect(response.ok).toBe(true);
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      'surface.new',
+      {
+        workspaceId: 'ws-caller',
+        shell: 'powershell.exe',
+        cwd: 'C:\\Users\\LORD',
+      },
+    );
+  });
+});

--- a/src/main/pipe/handlers/pane.rpc.ts
+++ b/src/main/pipe/handlers/pane.rpc.ts
@@ -128,7 +128,11 @@ export function registerPaneRpc(
         new Error('pane.split: "direction" must be "horizontal" or "vertical"'),
       );
     }
-    return sendToRenderer(getWindow, 'pane.split', { direction });
+    const workspaceId = typeof params['workspaceId'] === 'string' ? params['workspaceId'] : undefined;
+    return sendToRenderer(getWindow, 'pane.split', {
+      direction,
+      ...(workspaceId !== undefined && { workspaceId }),
+    });
   });
 
   /**

--- a/src/main/pipe/handlers/surface.rpc.ts
+++ b/src/main/pipe/handlers/surface.rpc.ts
@@ -22,8 +22,12 @@ export function registerSurfaceRpc(router: RpcRouter, getWindow: GetWindow): voi
   /**
    * surface.new — creates a new surface in the active pane
    */
-  router.register('surface.new', (_params) =>
-    sendToRenderer(getWindow, 'surface.new'),
+  router.register('surface.new', (params) =>
+    sendToRenderer(getWindow, 'surface.new', {
+      ...(typeof params['workspaceId'] === 'string' && { workspaceId: params['workspaceId'] }),
+      ...(typeof params['shell'] === 'string' && { shell: params['shell'] }),
+      ...(typeof params['cwd'] === 'string' && { cwd: params['cwd'] }),
+    }),
   );
 
   /**

--- a/src/main/updater/__tests__/AutoUpdater.platform.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.platform.test.ts
@@ -27,6 +27,7 @@ afterEach(() => {
   Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true });
   vi.resetModules();
   vi.useRealTimers();
+  vi.unstubAllEnvs();
 });
 
 /**
@@ -36,6 +37,10 @@ afterEach(() => {
  */
 async function loadForPlatform(platform: NodeJS.Platform) {
   vi.resetModules();
+  // start() bails early when NODE_ENV === 'development', so pin a non-dev value.
+  // Otherwise these win32 invariants silently no-op when the suite is run from a
+  // shell that exports NODE_ENV=development (e.g. inside wmux's own dev session).
+  vi.stubEnv('NODE_ENV', 'production');
   Object.defineProperty(process, 'platform', { value: platform, configurable: true });
 
   const requestUrls: string[] = [];

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -117,16 +117,6 @@ function collectTerminalSurfaces(pane: Pane): Surface[] {
  *  instead of mutating surfaces directly. */
 /** Sync version — fire-and-forget for beforeunload (cannot await). */
 function dumpScrollbackBuffersSync(): Map<string, boolean> {
-  // Phase A — A6. In daemon mode the daemon RingBuffer is the single source
-  // of truth for scrollback. Skip the helper entirely so the corresponding
-  // scrollback:dump IPC is never invoked and the rotation chain cannot
-  // self-destruct while daemon is healthy. The returned empty map flows
-  // through cloneWithScrollback so no `scrollbackFile` field is stamped
-  // onto session data, preventing a future restore from picking up a stale
-  // entry from a session that ran in local mode.
-  if (isDaemonModeActive()) {
-    return new Map();
-  }
   const dumped = new Map<string, boolean>();
   const state = useStore.getState();
   for (const ws of state.workspaces) {
@@ -146,23 +136,18 @@ function dumpScrollbackBuffersSync(): Map<string, boolean> {
 
 /** Deep-clone pane tree, setting scrollbackFile on dumped surfaces.
  *
- * Phase A — A6 follow-up (codex review P2, session 019e2af8). When daemon
- * mode is active and dumped is empty, the previous logic preserved every
- * surface's existing `scrollbackFile` field. A session saved in local
- * mode therefore carried its stale `.txt` reference forward; if the
- * renderer ever reloaded before daemon readiness (or after a failed A7
- * migration), it would try to restore from the stale `.txt` despite the
- * IPC-level gate. Clear the field outright in daemon mode so session
- * data round-trips with the gates' intent.
+ * Preserve the last known rendered snapshot reference when a terminal is
+ * temporarily unmounted or ineligible to dump. In daemon mode this snapshot
+ * is the UI recovery source; raw daemon bytes remain the fallback when no
+ * snapshot exists.
  */
 function cloneWithScrollback(pane: Pane, dumped: Map<string, boolean>): Pane {
-  const daemonMode = isDaemonModeActive();
   if (pane.type === 'leaf') {
     return {
       ...pane,
       surfaces: pane.surfaces.map((s) => ({
         ...s,
-        scrollbackFile: dumped.has(s.id) ? s.id : (daemonMode ? undefined : s.scrollbackFile),
+        scrollbackFile: dumped.has(s.id) ? s.id : s.scrollbackFile,
       })),
     };
   }

--- a/src/renderer/components/Layout/__tests__/dumpScrollbackHelper.daemonMode.test.ts
+++ b/src/renderer/components/Layout/__tests__/dumpScrollbackHelper.daemonMode.test.ts
@@ -2,15 +2,15 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 
-// Phase A — A6. The renderer helper that drives 5s autosave + beforeunload
-// session save must skip its entire body in daemon mode so the
-// scrollback:dump IPC is never invoked and `cloneWithScrollback` receives
-// an empty Map (no stale scrollbackFile stamps onto session data).
+// Rendered scrollback snapshots must continue in daemon mode. Raw daemon
+// RingBuffer replay is not a stable UI transcript for repainting TUIs such as
+// Codex; restore uses the rendered snapshot when present and raw replay only
+// as fallback.
 //
 // Source-level only — running the helper requires Zustand + xterm
 // instances inside a JSDOM React tree, which is heavy and orthogonal to
 // the actual invariant under test (the daemon-mode gate).
-describe('A6 — dumpScrollbackBuffersSync daemon-mode skip (source-level)', () => {
+describe('daemon-mode rendered scrollback snapshots (source-level)', () => {
   const appLayoutPath = path.join(__dirname, '..', 'AppLayout.tsx');
   const src = fs.readFileSync(appLayoutPath, 'utf-8');
 
@@ -20,12 +20,12 @@ describe('A6 — dumpScrollbackBuffersSync daemon-mode skip (source-level)', () 
     );
   });
 
-  it('dumpScrollbackBuffersSync returns an empty Map when daemon is active', () => {
+  it('dumpScrollbackBuffersSync does not short-circuit when daemon is active', () => {
     const fnIdx = src.indexOf('function dumpScrollbackBuffersSync(');
     expect(fnIdx).toBeGreaterThan(0);
     const body = src.slice(fnIdx, fnIdx + 2000);
-    // The very first behavioural statement must be the daemon-mode guard.
-    expect(body).toMatch(/if\s*\(\s*isDaemonModeActive\(\)\s*\)\s*\{[\s\S]*?return\s+new\s+Map\(\)/);
+    expect(body).not.toMatch(/if\s*\(\s*isDaemonModeActive\(\)\s*\)\s*\{[\s\S]*?return\s+new\s+Map\(\)/);
+    expect(body).toMatch(/serializeTerminalBuffer\(/);
   });
 
   it('AppLayout subscribes to daemon onConnected + onDisconnected to keep the flag in sync', () => {
@@ -36,16 +36,11 @@ describe('A6 — dumpScrollbackBuffersSync daemon-mode skip (source-level)', () 
     expect(src).toMatch(/whenReady\(\)\.then[\s\S]*?setDaemonModeActive/);
   });
 
-  // Codex review P2 #1 (stale scrollback reference). cloneWithScrollback
-  // must zero out s.scrollbackFile in daemon mode so a session saved
-  // before v2.9.1 / before daemon-readiness does not carry its stale
-  // .txt file path forward into the next session restore cycle.
-  it('cloneWithScrollback clears stale scrollbackFile in daemon mode', () => {
+  it('cloneWithScrollback preserves the last rendered snapshot reference', () => {
     const fnIdx = src.indexOf('function cloneWithScrollback(');
     expect(fnIdx).toBeGreaterThan(0);
     const body = src.slice(fnIdx, fnIdx + 1500);
-    // The daemon-mode branch resolves to undefined rather than preserving
-    // the stale s.scrollbackFile.
-    expect(body).toMatch(/daemonMode\s*\?\s*undefined\s*:\s*s\.scrollbackFile/);
+    expect(body).toMatch(/scrollbackFile:\s*dumped\.has\(s\.id\)\s*\?\s*s\.id\s*:\s*s\.scrollbackFile/);
+    expect(body).not.toMatch(/daemonMode\s*\?\s*undefined\s*:\s*s\.scrollbackFile/);
   });
 });

--- a/src/renderer/hooks/__tests__/useTerminal.daemonModeRaceCancel.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.daemonModeRaceCancel.test.ts
@@ -2,18 +2,16 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 
-// Phase A — A6. The async scrollback.load() in useTerminal can resolve
-// AFTER daemon mode becomes active. Writing the stale .txt content into
-// the terminal at that point would compose with the daemon SessionPipe
-// flush via the \r\n\x1b[0m\r\n divider and produce visibly broken
-// scrollback (codex review Layer C corruption path).
+// Rendered scrollback snapshots are the UI recovery source for repainting
+// TUIs. When daemon replay arrives during snapshot restore, useTerminal must
+// drop the old replay bytes and keep only live bytes after the flush marker.
 //
 // useTerminal is a 700-line React hook with xterm dependencies that are
 // awkward to bootstrap in vitest, so we verify the race cancel at the
 // source level. The integration assertion (daemon connects mid-load →
 // terminal shows daemon flush only) is part of the manual Windows
 // checklist in docs/upgrade-v2.9.1.md.
-describe('A6 — useTerminal async restore race cancel (source-level)', () => {
+describe('daemon-mode snapshot restore (source-level)', () => {
   const hookPath = path.join(__dirname, '..', 'useTerminal.ts');
   const src = fs.readFileSync(hookPath, 'utf-8');
 
@@ -23,36 +21,35 @@ describe('A6 — useTerminal async restore race cancel (source-level)', () => {
     );
   });
 
-  it('scrollback.load().then(content) guards on isDaemonModeActive() before writing', () => {
+  it('writes loaded snapshots even when daemon mode is active', () => {
     const loadIdx = src.indexOf('scrollback.load(scrollbackFile)');
     expect(loadIdx).toBeGreaterThan(0);
-    // Slice forward enough lines to capture the then handler body.
     const body = src.slice(loadIdx, loadIdx + 4000);
-    // The guard substitutes the .txt content with null when daemon-mode
-    // activated during the IPC round-trip.
-    expect(body).toMatch(/isDaemonModeActive\(\)\s*\?\s*null\s*:\s*content/);
-    // The write call must use the guarded value, not the raw `content`.
+    expect(body).toMatch(/const\s+restored\s*=\s*content/);
     expect(body).toMatch(/terminal\.write\(\s*restored\s*\)/);
   });
 
-  it('still flushes pending PTY data after the daemon-mode skip', () => {
+  it('splits replay bytes from live bytes while scrollback is loading', () => {
     const loadIdx = src.indexOf('scrollback.load(scrollbackFile)');
     const body = src.slice(loadIdx, loadIdx + 4000);
-    // pendingData.length > 0 check happens whether or not restored ran.
-    expect(body).toMatch(/scrollbackLoaded\s*=\s*true/);
-    expect(body).toMatch(/for\s*\(\s*const\s+data\s+of\s+pendingData/);
+    expect(body).toMatch(/pendingReplayData/);
+    expect(body).toMatch(/pendingLiveData/);
+    expect(body).toMatch(/daemonFlushComplete/);
   });
 
-  // Codex review P2 #2 (cold-start race): if `.txt` restore lands before
-  // daemon mode flips, the renderer must clear the terminal on the
-  // subsequent daemon:connected event so the SessionPipe replay does not
-  // compose with the stale text.
-  it('arms a daemon.onConnected listener that clears the terminal after .txt restore', () => {
+  it('drops old daemon replay when a rendered snapshot exists', () => {
+    const loadIdx = src.indexOf('scrollback.load(scrollbackFile)');
+    const body = src.slice(loadIdx, loadIdx + 5000);
+    expect(body).toMatch(/restoreBeatsDaemonReplay/);
+    expect(body).toMatch(/dropDaemonReplayUntilFlush\s*=\s*!daemonFlushComplete/);
+    expect(body).toMatch(/scrollbackLoaded\s*=\s*true/);
+    expect(body).toMatch(/const\s+replayData\s*=\s*restoreBeatsDaemonReplay\s*\?\s*\[\]\s*:\s*pendingReplayData/);
+  });
+
+  it('keeps the legacy late-daemon reset fallback for non-daemon restores', () => {
     // Module-scope flag declared at the top of the effect.
     expect(src).toMatch(/let\s+didRestoreTxt\s*=\s*false/);
-    // Cleanup slot reserved.
     expect(src).toMatch(/let\s+removeDaemonConnectedForRestore/);
-    // Inside the restore branch, the flag flips true and the listener arms.
     const loadIdx = src.indexOf('scrollback.load(scrollbackFile)');
     const body = src.slice(loadIdx, loadIdx + 4000);
     expect(body).toMatch(/didRestoreTxt\s*=\s*true/);

--- a/src/renderer/hooks/__tests__/useTerminal.webglFallback.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.webglFallback.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Codex TUI render regression lock.
+//
+// WebGL can leave upper rows unpainted while lower status rows still update,
+// which makes tool output look missing even though the daemon buffer contains
+// the bytes. Keep the default renderer on xterm's DOM path until WebGL is
+// proven safe for full-screen TUI redraws.
+describe('useTerminal WebGL fallback', () => {
+  const hookPath = path.join(__dirname, '..', 'useTerminal.ts');
+  const src = fs.readFileSync(hookPath, 'utf-8');
+
+  it('keeps the WebGL renderer disabled by default', () => {
+    expect(src).toMatch(/const\s+XTERM_WEBGL_ENABLED\s*=\s*false/);
+  });
+
+  it('does not acquire a WebGL context when the fallback is disabled', () => {
+    expect(src).toMatch(/if\s*\(\s*!XTERM_WEBGL_ENABLED\s*\)\s*return;/);
+    expect(src).toMatch(/if\s*\(\s*!XTERM_WEBGL_ENABLED\s*\)\s*{[\s\S]*?requestAnimationFrame/);
+  });
+});

--- a/src/renderer/hooks/__tests__/useTerminal.wheelScroll.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.wheelScroll.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Codex TUI wheel-scroll regression lock.
+//
+// The terminal hook must route wheel input into xterm scrollback explicitly
+// instead of relying on the default wheel path. Otherwise hosted terminals
+// can feel stuck even though the buffer contains scrollback.
+describe('useTerminal wheel scroll handling (source-level)', () => {
+  const hookPath = path.join(__dirname, '..', 'useTerminal.ts');
+  const src = fs.readFileSync(hookPath, 'utf-8');
+
+  it('attaches a custom wheel handler on the terminal', () => {
+    expect(src).toMatch(/attachCustomWheelEventHandler\(/);
+  });
+
+  it('routes wheel input into terminal scrollback when available', () => {
+    expect(src).toMatch(/if\s*\(\s*terminal\.buffer\.active\.type\s*!==\s*['"]normal['"]\s*\)\s*return true;/);
+    expect(src).toMatch(/terminal\.scrollLines\(/);
+    expect(src).toMatch(/ev\.preventDefault\(\);/);
+  });
+});

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -365,8 +365,11 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
   }
 
   if (method === 'surface.new') {
-    const ws = store.workspaces.find((w) => w.id === store.activeWorkspaceId);
-    if (!ws) return { error: 'no active workspace' };
+    const workspaceId = typeof params.workspaceId === 'string' && params.workspaceId.length > 0
+      ? params.workspaceId
+      : store.activeWorkspaceId;
+    const ws = store.workspaces.find((w) => w.id === workspaceId);
+    if (!ws) return { error: `no workspace found for ${workspaceId}` };
 
     const paneId = ws.activePaneId;
     const shell = typeof params.shell === 'string' ? params.shell : '';
@@ -380,7 +383,7 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
 
     // Re-read state after async gap — paneId may have been removed.
     const freshAfterCreate = useStore.getState();
-    const freshWsAfterCreate = freshAfterCreate.workspaces.find((w) => w.id === freshAfterCreate.activeWorkspaceId);
+    const freshWsAfterCreate = freshAfterCreate.workspaces.find((w) => w.id === workspaceId);
     if (!freshWsAfterCreate || !findPaneById(freshWsAfterCreate.rootPane, paneId)) {
       // Pane was removed during async gap — dispose the orphaned PTY
       try { await window.electronAPI.pty.dispose(ptyId); } catch { /* best-effort */ }
@@ -389,7 +392,7 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     freshAfterCreate.addSurface(paneId, ptyId, shell, cwd);
 
     const fresh = useStore.getState();
-    const freshWs = fresh.workspaces.find((w) => w.id === fresh.activeWorkspaceId);
+    const freshWs = fresh.workspaces.find((w) => w.id === workspaceId);
     if (!freshWs) return { ptyId };
     const pane = findPaneById(freshWs.rootPane, paneId);
     if (!pane || pane.type !== 'leaf') return { ptyId };
@@ -468,11 +471,14 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
   }
 
   if (method === 'pane.split') {
-    const ws = store.workspaces.find((w) => w.id === store.activeWorkspaceId);
-    if (!ws) return { error: 'no active workspace' };
+    const workspaceId = typeof params.workspaceId === 'string' && params.workspaceId.length > 0
+      ? params.workspaceId
+      : store.activeWorkspaceId;
+    const ws = store.workspaces.find((w) => w.id === workspaceId);
+    if (!ws) return { error: `no workspace found for ${workspaceId}` };
     const direction =
       params.direction === 'vertical' ? 'vertical' : 'horizontal';
-    const ok = store.splitPane(ws.activePaneId, direction);
+    const ok = store.splitPane(ws.activePaneId, direction, workspaceId);
     if (!ok) return { error: 'pane cap reached (max 20 per workspace)' };
     return { ok: true };
   }

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -389,7 +389,7 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       try { await window.electronAPI.pty.dispose(ptyId); } catch { /* best-effort */ }
       return { error: 'pane was removed during PTY creation' };
     }
-    freshAfterCreate.addSurface(paneId, ptyId, shell, cwd);
+    freshAfterCreate.addSurface(paneId, ptyId, shell, cwd, workspaceId);
 
     const fresh = useStore.getState();
     const freshWs = fresh.workspaces.find((w) => w.id === workspaceId);

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -39,6 +39,12 @@ let webglTokenSeq = 0;
 // Chromium's ~16 cap); this timer is only the no-pressure cleanup.
 export const WEBGL_HIDDEN_DISPOSE_DELAY_MS = 10_000;
 
+// Keep xterm on the DOM renderer by default. Dogfooding with Codex TUI showed
+// the WebGL addon can leave upper rows unpainted while the daemon buffer and
+// bottom status rows are correct, making tool output look missing even though
+// PTY bytes arrived. DOM rendering is slower but is the reliable path.
+const XTERM_WEBGL_ENABLED = false;
+
 // RCA A1 — reconnect-with-retry policy lives in its own module so it can be
 // unit-tested without xterm/zustand/electron. Bound to the live deps here.
 function reconnectPtyWithRetry(ptyId: string, isCurrent: () => boolean): Promise<void> {
@@ -347,6 +353,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // count without any pane going blank. loadWebgl is the pool's "acquire"
     // callback; disposeWebgl is its "evict" callback (reverts to DOM renderer).
     function loadWebgl() {
+      if (!XTERM_WEBGL_ENABLED) return;
       if (webglAddonRef.current) return; // already loaded
       try {
         const addon = new WebglAddon();
@@ -1081,6 +1088,17 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
   // to free the WebGL context for other terminals.  Also re-fit so a terminal
   // that was initialized while hidden displays at the correct size.
   useEffect(() => {
+    if (!XTERM_WEBGL_ENABLED) {
+      const id = requestAnimationFrame(() => {
+        if (!shouldFitWhilePreservingSelection(terminalRef.current)) {
+          console.debug('[Terminal] visibility fit skipped — active selection');
+          return;
+        }
+        fit();
+      });
+      return () => cancelAnimationFrame(id);
+    }
+
     const token = webglTokenRef.current;
     if (isVisible) {
       // Cancel any pending deferred release — the terminal is visible again

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -316,6 +316,27 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // width. Without this, xterm defaults to v6 and TUI apps that use cursor
     // positioning (Claude Code, vim, etc.) collide frames over Korean text.
     terminal.unicode.activeVersion = '11';
+
+    // Wheel handling: xterm's default wheel path will hand off to the app in
+    // some buffer states. That leaves hosted shells with scrollback feeling
+    // dead under the mouse wheel in wmux even though the buffer exists.
+    // Explicitly route wheel deltas into terminal scrollback when it is
+    // available, and let xterm keep its app-side wheel behavior only when
+    // there is no scrollback to show.
+    const wheelHandler = (ev: WheelEvent) => {
+      if (terminal.buffer.active.type !== 'normal') return true;
+      const sensitivity = terminal.options.scrollSensitivity ?? 1;
+      const unit = ev.deltaMode === WheelEvent.DOM_DELTA_PAGE
+        ? terminal.rows
+        : ev.deltaMode === WheelEvent.DOM_DELTA_PIXEL
+          ? 40
+          : 1;
+      const deltaLines = Math.max(1, Math.round((Math.abs(ev.deltaY) / unit) * sensitivity));
+      terminal.scrollLines(ev.deltaY > 0 ? deltaLines : -deltaLines);
+      ev.preventDefault();
+      return false;
+    };
+    terminal.attachCustomWheelEventHandler(wheelHandler);
     terminal.open(container);
 
     // WebGL addon loading — driven by the shared webglContextPool, NOT called

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -772,13 +772,23 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // scrollback.load() is async (IPC round-trip). If PTY sends data before it
       // resolves, connectPty() would not yet be called and data would be lost.
       // Instead, buffer incoming data and flush after scrollback is written.
-      const pendingData: string[] = [];
+      const pendingReplayData: string[] = [];
+      const pendingLiveData: string[] = [];
       let scrollbackLoaded = false;
+      let daemonFlushComplete = !isDaemonModeActive();
+      let dropDaemonReplayUntilFlush = false;
 
       removeDataListener = window.electronAPI.pty.onData((id, data) => {
         if (id !== ptyId) return;
+        if (dropDaemonReplayUntilFlush && !daemonFlushComplete) {
+          return;
+        }
         if (!scrollbackLoaded) {
-          pendingData.push(data);
+          if (!daemonFlushComplete) {
+            pendingReplayData.push(data);
+          } else {
+            pendingLiveData.push(data);
+          }
           return;
         }
         terminal.write(data);
@@ -799,6 +809,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       removeFlushListener = window.electronAPI.pty.onFlushComplete((id, recoveredBytes) => {
         if (id !== ptyId) return;
         if (terminalRef.current !== terminal) return;
+        daemonFlushComplete = true;
+        dropDaemonReplayUntilFlush = false;
         lastFlushRecoveredBytes = recoveredBytes;
         if (pendingFlushReset) {
           pendingFlushReset = false;
@@ -822,13 +834,9 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         // would write into a torn-down terminal on fast unmount + remount
         // (e.g. workspace switch mid-restore).
         if (terminalRef.current !== terminal) return;
-        // Phase A — A6. Race cancel: if daemon mode activated between the
-        // scrollback.load() call and now, discard the .txt content. The
-        // daemon SessionPipe replay will provide authoritative scrollback
-        // and writing the stale .txt here would compose it with that
-        // replay (via the divider below), producing visibly broken output.
-        // Pending PTY data still flushes through unchanged.
-        const restored = isDaemonModeActive() ? null : content;
+        const restored = content;
+        const restoreBeatsDaemonReplay =
+          !!restored && isDaemonModeActive() && (lastFlushRecoveredBytes ?? 1) > 0;
         if (restored) {
           terminal.write(restored);
           // Whitespace + ANSI reset boundary so restored scrollback doesn't
@@ -841,35 +849,42 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           // output.
           terminal.write('\r\n\x1b[0m\r\n');
           fireFirstData();
-          didRestoreTxt = true;
-          // Arm the late-connect clear. If daemon mode activates after this
-          // moment, the reset only fires when the daemon actually has
-          // authoritative scrollback to replay (recoveredBytes > 0).
-          // Two race outcomes are handled:
-          //   1. Flush already arrived (lastFlushRecoveredBytes != null):
-          //      apply its verdict immediately.
-          //   2. Flush hasn't arrived: set pendingFlushReset so the
-          //      flush-complete listener applies the verdict later.
-          // recoveredBytes=0 (cap-skipped session or fresh create) leaves
-          // the .txt cache on screen — degraded gracefully instead of
-          // wiping to a blank prompt.
-          removeDaemonConnectedForRestore = window.electronAPI.daemon.onConnected(() => {
-            if (!didRestoreTxt) return;
-            if (terminalRef.current !== terminal) return;
-            didRestoreTxt = false;
-            if (lastFlushRecoveredBytes !== null) {
-              if (lastFlushRecoveredBytes > 0) terminal.reset();
-            } else {
-              pendingFlushReset = true;
-            }
-          });
+          if (restoreBeatsDaemonReplay) {
+            dropDaemonReplayUntilFlush = !daemonFlushComplete;
+          } else {
+            didRestoreTxt = true;
+            // Arm the late-connect clear. If daemon mode activates after this
+            // moment, the reset only fires when the daemon actually has
+            // authoritative scrollback to replay (recoveredBytes > 0).
+            // Two race outcomes are handled:
+            //   1. Flush already arrived (lastFlushRecoveredBytes != null):
+            //      apply its verdict immediately.
+            //   2. Flush hasn't arrived: set pendingFlushReset so the
+            //      flush-complete listener applies the verdict later.
+            // recoveredBytes=0 (cap-skipped session or fresh create) leaves
+            // the .txt cache on screen — degraded gracefully instead of
+            // wiping to a blank prompt.
+            removeDaemonConnectedForRestore = window.electronAPI.daemon.onConnected(() => {
+              if (!didRestoreTxt) return;
+              if (terminalRef.current !== terminal) return;
+              didRestoreTxt = false;
+              if (lastFlushRecoveredBytes !== null) {
+                if (lastFlushRecoveredBytes > 0) terminal.reset();
+              } else {
+                pendingFlushReset = true;
+              }
+            });
+          }
         }
         scrollbackLoaded = true;
-        for (const data of pendingData) {
+        const replayData = restoreBeatsDaemonReplay ? [] : pendingReplayData;
+        const flushData = [...replayData, ...pendingLiveData];
+        for (const data of flushData) {
           terminal.write(data);
         }
-        if (pendingData.length > 0) fireFirstData();
-        pendingData.length = 0;
+        if (flushData.length > 0) fireFirstData();
+        pendingReplayData.length = 0;
+        pendingLiveData.length = 0;
         // Register with the scrollback autosave only after restore
         // completes. Setting it synchronously before the async load lets
         // the 5s autosave tick dump an empty/partial buffer over the
@@ -891,11 +906,13 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         console.error(`[useTerminal] scrollback.load FAILED surfaceFile=${scrollbackFile} ptyId=${ptyId} err=${msg}`);
         if (terminalRef.current !== terminal) return;
         scrollbackLoaded = true;
-        for (const data of pendingData) {
+        const flushData = [...pendingReplayData, ...pendingLiveData];
+        for (const data of flushData) {
           terminal.write(data);
         }
-        if (pendingData.length > 0) fireFirstData();
-        pendingData.length = 0;
+        if (flushData.length > 0) fireFirstData();
+        pendingReplayData.length = 0;
+        pendingLiveData.length = 0;
         terminalRegistry.set(ptyId, terminal);
       });
     } else {

--- a/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
@@ -9,8 +9,9 @@ type TestState = {
 
 function createHarness() {
   const workspace = createWorkspace('Test');
+  const otherWorkspace = createWorkspace('Other');
   const state: TestState = {
-    workspaces: [workspace],
+    workspaces: [workspace, otherWorkspace],
     activeWorkspaceId: workspace.id,
   };
 
@@ -23,6 +24,23 @@ function createHarness() {
 }
 
 describe('surfaceSlice browser partition state', () => {
+  it('adds terminal surfaces to an explicit workspace even when another workspace is active', () => {
+    const { state, slice } = createHarness();
+    const targetWorkspace = state.workspaces[1];
+    const paneId = targetWorkspace.rootPane.id;
+
+    slice.addSurface(paneId, 'pty-explicit', 'powershell.exe', 'C:\\Users\\LORD', targetWorkspace.id);
+
+    const activePane = state.workspaces[0].rootPane;
+    const targetPane = targetWorkspace.rootPane;
+    if (activePane.type !== 'leaf' || targetPane.type !== 'leaf') {
+      throw new Error('expected leaf panes');
+    }
+    expect(activePane.surfaces).toHaveLength(0);
+    expect(targetPane.surfaces).toHaveLength(1);
+    expect(targetPane.surfaces[0].ptyId).toBe('pty-explicit');
+  });
+
   it('stores the provided partition on new browser surfaces', () => {
     const { state, slice } = createHarness();
     const paneId = state.workspaces[0].rootPane.id;

--- a/src/renderer/stores/slices/surfaceSlice.ts
+++ b/src/renderer/stores/slices/surfaceSlice.ts
@@ -4,7 +4,7 @@ import type { Pane, PaneLeaf, Surface, Workspace } from '../../../shared/types';
 import { createSurface, generateId } from '../../../shared/types';
 
 export interface SurfaceSlice {
-  addSurface: (paneId: string, ptyId: string, shell: string, cwd: string) => void;
+  addSurface: (paneId: string, ptyId: string, shell: string, cwd: string, workspaceId?: string) => void;
   addBrowserSurface: (paneId: string, url?: string, partition?: string, workspaceId?: string) => void;
   addEditorSurface: (paneId: string, filePath: string) => void;
   closeSurface: (paneId: string, surfaceId: string) => void;
@@ -28,8 +28,9 @@ function findLeafPane(root: Pane, id: string): PaneLeaf | null {
 }
 
 export const createSurfaceSlice: StateCreator<StoreState, [['zustand/immer', never]], [], SurfaceSlice> = (set) => ({
-  addSurface: (paneId, ptyId, shell, cwd) => set((state: StoreState) => {
-    const ws = state.workspaces.find((w: Workspace) => w.id === state.activeWorkspaceId);
+  addSurface: (paneId, ptyId, shell, cwd, workspaceId) => set((state: StoreState) => {
+    const targetWsId = workspaceId || state.activeWorkspaceId;
+    const ws = state.workspaces.find((w: Workspace) => w.id === targetWsId);
     if (!ws) return;
     const pane = findLeafPane(ws.rootPane, paneId);
     if (!pane) return;

--- a/src/shared/__tests__/security.test.ts
+++ b/src/shared/__tests__/security.test.ts
@@ -225,6 +225,34 @@ describe('reHardenTokenFileAcl', () => {
     expect(fsMock.writeFileSync).not.toHaveBeenCalled();
   });
 
+  it('retries transient Windows ACL access-denied failures before warning', async () => {
+    vi.stubEnv('USERNAME', 'tester');
+    vi.stubEnv('SystemRoot', 'C:\\Windows');
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+
+    let icaclsAttempts = 0;
+    execFileSyncMock.mockImplementation((cmd: unknown) => {
+      if (typeof cmd === 'string' && cmd.toLowerCase().includes('whoami')) {
+        return Buffer.from('user S-1-5-21-1-2-3-1001\n');
+      }
+      icaclsAttempts += 1;
+      if (icaclsAttempts === 1) {
+        throw new Error('Command failed: icacls Access is denied.');
+      }
+      return Buffer.from('');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { reHardenTokenFileAcl } = await import('../security');
+    const tokenPath = path.join('C:', 'Users', 'tester', '.wmux-auth-token');
+
+    expect(reHardenTokenFileAcl(tokenPath)).toBe(true);
+    expect(icaclsAttempts).toBe(2);
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
   it('chmods to 0600 on POSIX and returns true', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
 

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -316,6 +316,17 @@ export interface DaemonResizeParams {
   rows: number;
 }
 
+export interface PaneSplitParams {
+  direction: 'horizontal' | 'vertical';
+  workspaceId?: string;
+}
+
+export interface SurfaceNewParams {
+  shell?: string;
+  cwd?: string;
+  workspaceId?: string;
+}
+
 // === Pane Metadata RPC types (M0-f) ===
 //
 // Wire-format spec for the metadata RPC surface. Lifted out of the handler

--- a/src/shared/security.ts
+++ b/src/shared/security.ts
@@ -2,6 +2,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
 
+function sleepMs(ms: number): void {
+  const sab = new SharedArrayBuffer(4);
+  const view = new Int32Array(sab);
+  Atomics.wait(view, 0, 0, ms);
+}
+
 /**
  * Resolve the current user's SID (e.g. `S-1-5-21-...-1001`) so the ACL grant can
  * name the owner by SID instead of by SAM account name. Returns the bare SID
@@ -135,16 +141,33 @@ export function secureWriteTokenFile(filePath: string, token: string): void {
  * restrictive ACL/mode was successfully (re)applied.
  */
 export function reHardenTokenFileAcl(filePath: string): boolean {
-  try {
-    if (process.platform === 'win32') {
-      applyRestrictiveWindowsAcl(filePath);
-    } else {
-      // POSIX: ensure owner-only read/write on the existing file.
-      fs.chmodSync(filePath, 0o600);
+  const attempts = process.platform === 'win32' ? 3 : 1;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      if (process.platform === 'win32') {
+        applyRestrictiveWindowsAcl(filePath);
+      } else {
+        // POSIX: ensure owner-only read/write on the existing file.
+        fs.chmodSync(filePath, 0o600);
+      }
+      return true;
+    } catch (err) {
+      const message = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+      const isTransientWindowsAclError =
+        process.platform === 'win32' &&
+        attempt < attempts &&
+        /access is denied|eperm|eacces|busy|sharing violation/i.test(message);
+
+      if (isTransientWindowsAclError) {
+        sleepMs(75 * attempt);
+        continue;
+      }
+
+      console.warn(`[reHardenTokenFileAcl] could not re-harden ${filePath}:`, err);
+      return false;
     }
-    return true;
-  } catch (err) {
-    console.warn(`[reHardenTokenFileAcl] could not re-harden ${filePath}:`, err);
-    return false;
   }
+
+  return false;
 }


### PR DESCRIPTION
## Summary

Five terminal-rendering / session-restore / workspace fixes surfaced while dogfooding wmux with full-screen TUI agents (Codex, Claude Code). Each is independent and additive; the branch is cut from current `main` (includes #93) and cherry-picks cleanly with **zero file overlap** with the daemon split-brain work.

## What's here

- **Fix daemon scrollback restore for TUI redraws** — the load-bearing change. Raw daemon `RingBuffer` byte-replay does not reliably repaint full-screen TUIs (cursor-addressed apps assume a screen state the replay doesn't reconstruct), so tool output could look "missing" after a restore even though the bytes arrived. Restore now prefers the **rendered xterm snapshot** as the UI transcript, with daemon replay as the fallback when no snapshot exists. A race guard (`restoreBeatsDaemonReplay` / `dropDaemonReplayUntilFlush`, split replay-vs-live pending buffers) prevents the snapshot and the daemon flush from composing into corrupted scrollback.

- **Fix workspace scoping for pane creation** — `surface.new` / `pane.split` now thread an optional `workspaceId` end-to-end (RPC handlers → `useRpcBridge` → `splitPane`/`addSurface`), so an orchestrator can create terminals in a *specific* workspace instead of always the active one. Falls back to the active workspace when omitted.

- **Fix terminal scroll and startup warning cleanup** — custom xterm wheel handler so the mouse wheel drives scrollback in hosted shells (handing off to the app only when there's no scrollback); retry transient Windows ACL re-harden failures (access-denied / sharing-violation) before warning; `forge` ignores `node-pty` on rebuild.

- **Disable WebGL terminal renderer by default** — *precautionary.* WebGL has a track record here (context exhaustion, eviction lag, CJK garbling) and under context pressure a lost/evicted context can leave upper rows unpainted while the buffer is correct. The DOM renderer is slower but reliable. **Open question:** the scrollback-restore fix above is the more likely root cause of the "missing output" symptom; this WebGL default could be revisited once that's confirmed in the field (flip one const: `XTERM_WEBGL_ENABLED`).

- **test: realign scrollback + updater tests** — locks the new no-short-circuit scrollback contract at the IPC-handler level, and pins `NODE_ENV` in the win32 `AutoUpdater` tests so they stop silently no-op'ing when run from a `NODE_ENV=development` shell (e.g. inside wmux's own dev session).

## Verification

- `tsc` clean: main / daemon / mcp
- Full suite **2118/2118** (`vitest run`, `NODE_ENV=test`), run on top of current `main`
- Source-level regression locks added for the wheel handler, WebGL-off default, and the daemon-mode scrollback contract

## Notes

- The split-brain / duplicate-daemon hardening from the same local branch is **intentionally excluded** — #93 already fixes that bug, and the two approaches touch the same files. This PR is only the rendering / restore / workspace work, which is orthogonal.
- The WebGL default is the one change I'd flag for a second opinion (see open question above); happy to drop or gate it if you'd prefer to keep the GPU renderer on.
