### PR TITLE
test(daemon): lock orphan idle-reap robustness + idle-eval observability

### DIFF
--- a/scripts/daemon-orphan-idle-dynamic.mjs
+++ b/scripts/daemon-orphan-idle-dynamic.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * Orphan-daemon idle-reap reproduction. Covers the two idle-shutdown
+ * paths the existing daemon-idle-shutdown-dynamic.mjs never exercises:
+ *
+ *   S1 — a daemon that boots and NEVER sees a client connect. The idle
+ *        anchor must fall back to startTime (getLastDisconnectAt() is
+ *        null). This is the closest analogue to orphan PID 31396, whose
+ *        parent died before a client ever attached, yet which lived for
+ *        3 days instead of self-terminating.
+ *
+ *   S2 — a daemon with one live session whose PTY is killed out from
+ *        under it (parent crash leaves the PTY; the PTY later exits).
+ *        The ProcessMonitor death->'dead' transition must drop
+ *        listLiveSessions() to 0 so idle-shutdown can fire. If the dead
+ *        transition never happens, the session stays `detached` forever
+ *        and the daemon never reaps itself — the orphan-accumulation bug.
+ *
+ * Exit 0 only if BOTH daemons self-terminate within the idle window.
+ *
+ * Usage:  node scripts/daemon-orphan-idle-dynamic.mjs
+ */
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const DAEMON_BUNDLE = path.join(REPO_ROOT, 'dist', 'daemon-bundle', 'index.js');
+const WIN = process.platform === 'win32';
+
+if (!fs.existsSync(DAEMON_BUNDLE)) {
+  console.error('Daemon bundle missing — run `npm run build:daemon` first');
+  process.exit(2);
+}
+
+// Idle config turned down so the verification finishes in seconds.
+const IDLE_MS = 3_000;
+const GRACE_MS = 1_500;
+const TICK_MS = 500;
+
+function rpc(socket, method, params, token) {
+  return new Promise((resolve, reject) => {
+    const id = `req-${Math.random().toString(36).slice(2, 10)}`;
+    let buffer = '';
+    const handler = (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id === id) {
+            socket.removeListener('data', handler);
+            if (msg.ok) resolve(msg.result);
+            else reject(new Error(msg.error ?? 'rpc error'));
+            return;
+          }
+        } catch { /* ignore */ }
+      }
+    };
+    socket.on('data', handler);
+    socket.write(JSON.stringify({ id, method, params, token }) + '\n');
+    setTimeout(() => {
+      socket.removeListener('data', handler);
+      reject(new Error(`rpc timeout: ${method}`));
+    }, 5000);
+  });
+}
+
+function connectSocket(pipeName) {
+  return new Promise((resolve, reject) => {
+    const s = net.connect(pipeName);
+    const t = setTimeout(() => { s.destroy(); reject(new Error('connect timeout')); }, 5000);
+    s.once('connect', () => { clearTimeout(t); resolve(s); });
+    s.once('error', (e) => { clearTimeout(t); reject(e); });
+  });
+}
+
+function waitForPipeFile(wmuxDir, timeoutMs = 10_000) {
+  const pipeFile = path.join(wmuxDir, 'daemon-pipe');
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const tick = () => {
+      if (fs.existsSync(pipeFile)) {
+        resolve(fs.readFileSync(pipeFile, 'utf-8').trim());
+        return;
+      }
+      if (Date.now() >= deadline) { reject(new Error('pipe file timeout')); return; }
+      setTimeout(tick, 100);
+    };
+    tick();
+  });
+}
+
+async function runScenario(name, opts) {
+  const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), `wmux-orphan-${name}-`));
+  const TEST_WMUX = path.join(TEST_HOME, '.wmux');
+  fs.mkdirSync(TEST_WMUX, { recursive: true });
+  const PIPE = WIN
+    ? `\\\\.\\pipe\\wmux-test-${name}-${randomUUID().slice(0, 8)}`
+    : path.join(TEST_HOME, `s-${randomUUID().slice(0, 8)}.sock`);
+  const TOKEN = randomUUID();
+
+  fs.writeFileSync(
+    path.join(TEST_WMUX, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      daemon: { pipeName: PIPE, logLevel: 'info', autoStart: true, idleShutdownMinutes: 5 },
+      session: {
+        defaultShell: WIN ? 'cmd.exe' : '/bin/sh',
+        defaultCols: 120, defaultRows: 30, bufferSizeMb: 8, bufferMaxMb: 64,
+        deadSessionTtlHours: 24, deadSessionDumpBuffer: true,
+      },
+    }, null, 2),
+  );
+  fs.writeFileSync(path.join(TEST_WMUX, 'daemon-auth-token'), TOKEN, 'utf-8');
+
+  const child = spawn(process.execPath, [DAEMON_BUNDLE], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      USERPROFILE: TEST_HOME, HOME: TEST_HOME, HOMEDRIVE: undefined, HOMEPATH: undefined,
+      WMUX_IDLE_SHUTDOWN_MS: String(IDLE_MS),
+      WMUX_IDLE_GRACE_MS: String(GRACE_MS),
+      WMUX_WATCHDOG_TICK_MS: String(TICK_MS),
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let out = '';
+  child.stdout.on('data', (d) => { out += d.toString(); process.stdout.write(`[${name}] ${d}`); });
+  child.stderr.on('data', (d) => { out += d.toString(); process.stderr.write(`[${name}-err] ${d}`); });
+  const exitPromise = new Promise((res) => child.once('exit', (code, sig) => res({ code, sig })));
+
+  try {
+    const pipeName = await waitForPipeFile(TEST_WMUX);
+    console.log(`[${name}] daemon up on ${pipeName}`);
+
+    if (opts.createAndKill) {
+      const socket = await connectSocket(pipeName);
+      const ping = await rpc(socket, 'daemon.ping', {}, TOKEN);
+      if (!ping || ping.status !== 'ok') throw new Error(`bad ping: ${JSON.stringify(ping)}`);
+      const sess = await rpc(socket, 'daemon.createSession',
+        { id: 'orphan1', cmd: WIN ? 'cmd.exe' : '/bin/sh', cwd: TEST_HOME, cols: 120, rows: 30 }, TOKEN);
+      console.log(`[${name}] created session pid=${sess.pid} state=${sess.state}`);
+      // Kill the PTY child out from under the daemon — simulates the PTY
+      // exiting after the parent UI already crashed. ProcessMonitor must
+      // notice and flip the session to 'dead'.
+      try { process.kill(sess.pid); console.log(`[${name}] killed PTY pid=${sess.pid}`); }
+      catch (e) { console.log(`[${name}] kill failed (already gone?): ${e.message}`); }
+      // Disconnect — drop to 0 clients so only the (now-dead) session
+      // could keep the daemon alive.
+      socket.end(); socket.destroy();
+      console.log(`[${name}] client disconnected`);
+    } else {
+      // S1: deliberately NEVER connect. lastDisconnectAt stays null.
+      console.log(`[${name}] no client will ever connect (idle anchor = startTime)`);
+    }
+
+    const deadlineMs = opts.createAndKill
+      ? GRACE_MS + IDLE_MS + 18_000   // + ProcessMonitor 5s detect + margin
+      : GRACE_MS + IDLE_MS + 6_000;
+    console.log(`[${name}] waiting up to ${deadlineMs}ms for self-terminate`);
+
+    const result = await Promise.race([
+      exitPromise,
+      new Promise((_, rej) => setTimeout(
+        () => rej(new Error(`did NOT self-terminate within ${deadlineMs}ms`)), deadlineMs)),
+    ]);
+
+    if (!/idle\.timeout/.test(out)) throw new Error('missing [shutdown.phase] idle.timeout breadcrumb');
+    if (result.code !== 0) throw new Error(`exited non-zero code=${result.code}`);
+    console.log(`[${name}] PASS — self-terminated code=${result.code}`);
+    return true;
+  } catch (err) {
+    console.error(`[${name}] FAIL — ${err?.message ?? err}`);
+    return false;
+  } finally {
+    try { if (!child.killed) child.kill('SIGKILL'); } catch { /* ignore */ }
+    try { fs.rmSync(TEST_HOME, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+}
+
+const s1 = await runScenario('S1-no-client', { createAndKill: false });
+const s2 = await runScenario('S2-pty-killed', { createAndKill: true });
+
+console.log(`\n=== RESULT: S1(no-client)=${s1 ? 'PASS' : 'FAIL'}  S2(pty-killed)=${s2 ? 'PASS' : 'FAIL'} ===`);
+process.exit(s1 && s2 ? 0 : 1);

--- a/src/daemon/Watchdog.ts
+++ b/src/daemon/Watchdog.ts
@@ -173,11 +173,36 @@ export class Watchdog {
 
     const info = this.callbacks.onIdleCheck?.();
     if (!info) return; // wiring missing — refuse to act
-    if (info.connections > 0 || info.sessions > 0) return;
+
+    // Observability (orphan-reap diagnosis): when the daemon is NOT
+    // idle-eligible, periodically log WHICH signal is holding it alive. An
+    // orphan daemon that never self-reaps (parent UI dead, no client, but a
+    // lingering `detached` session) could previously only be diagnosed by
+    // inspecting the live process; now the reason lands in the daemon log
+    // next to the `[Watchdog] Health:` lines. Gated to every 5th health tick
+    // to match the Health cadence; `checkCount === 0` for direct
+    // `evaluateIdle()` unit calls, so the unit suite stays log-silent.
+    const traceIdle = this.checkCount > 0 && this.checkCount % 5 === 0;
+
+    if (info.connections > 0 || info.sessions > 0) {
+      if (traceIdle) {
+        console.log(
+          `[Watchdog] idle-eval: held alive by connections=${info.connections} liveSessions=${info.sessions} (pid=${process.pid})`,
+        );
+      }
+      return;
+    }
 
     const lastActivityAt = info.lastDisconnectAt ?? startTime;
     const idleMs = now - lastActivityAt;
-    if (idleMs < idleTimeoutMs) return;
+    if (idleMs < idleTimeoutMs) {
+      if (traceIdle) {
+        console.log(
+          `[Watchdog] idle-eval: empty but counting down idleMs=${idleMs}/${idleTimeoutMs} (pid=${process.pid})`,
+        );
+      }
+      return;
+    }
 
     this.idleShutdownFired = true;
     this.callbacks.onIdleShutdown?.(idleMs);

--- a/src/daemon/__tests__/Watchdog.test.ts
+++ b/src/daemon/__tests__/Watchdog.test.ts
@@ -272,6 +272,33 @@ describe('Watchdog', () => {
       wd.evaluateIdle();
       expect(onIdleShutdown).not.toHaveBeenCalled();
     });
+
+    it('logs which signal holds it alive on the 5th idle tick (orphan diagnosis)', () => {
+      // Regression lock for the orphan-reap observability. A daemon held
+      // alive past grace by a live session must periodically log WHY, so a
+      // future orphan that never reaps is diagnosable from the daemon log
+      // instead of a live-process inspection. Driven via start() rather than
+      // a direct evaluateIdle() call because the trace is gated on the
+      // health-tick counter (checkCount), which only advances under start().
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const wd = new Watchdog(1000, {
+        idleTimeoutMs: 60_000,
+        graceMs: 1,
+        startTime: Date.now() - 10 * 60_000,
+      });
+      wd.setCallbacks({
+        onIdleCheck: () => ({ connections: 0, sessions: 1, lastDisconnectAt: null }),
+        onIdleShutdown: vi.fn(),
+      });
+      wd.start(() => ({ sessions: 1, memory: 1024, uptime: 600 }));
+      vi.advanceTimersByTime(5000); // 5 ticks → checkCount hits 5 → trace fires
+      const heldLogs = consoleSpy.mock.calls.filter(
+        (a) => typeof a[0] === 'string' && a[0].includes('idle-eval: held alive'),
+      );
+      expect(heldLogs.length).toBeGreaterThanOrEqual(1);
+      wd.stop();
+      consoleSpy.mockRestore();
+    });
   });
 
   it('logs health every 5th check', () => {

--- a/src/daemon/__tests__/idleShutdown.test.ts
+++ b/src/daemon/__tests__/idleShutdown.test.ts
@@ -70,4 +70,19 @@ describe('Daemon idle shutdown (source-level invariants)', () => {
     expect(setCallbacksIdx).toBeGreaterThan(0);
     expect(doShutdownIdx).toBeLessThan(setCallbacksIdx);
   });
+
+  it('watches every spawned/recovered PTY so a dead process can reap the session (S2 orphan path)', () => {
+    // idle-shutdown can only fire once listLiveSessions() reaches 0. A
+    // session leaves the live set only when its PTY death transitions it to
+    // 'dead', and that transition is driven by processMonitor.watch's onDead
+    // callback. If any PTY-spawning path (the create RPC, or one of the three
+    // recovery branches: suspended / snapshot / no-scrollback) forgets to
+    // watch, an orphan daemon whose parent UI has died would hold that
+    // 'detached' session forever and never self-reap — the orphan-
+    // accumulation symptom this lock guards. Pin that every spawn path is
+    // paired with a watch, and that a watch callback can mark a session dead.
+    const watchCalls = src.match(/processMonitor\.watch\(/g) ?? [];
+    expect(watchCalls.length).toBeGreaterThanOrEqual(4);
+    expect(src).toMatch(/processMonitor\.watch\([\s\S]{0,500}?state = 'dead'/);
+  });
 });


### PR DESCRIPTION
## Summary

The orphan-daemon idle-reap investigation found that **current `main` already reaps empty daemons correctly** — a daemon with 0 sessions and 0 clients self-terminates in ~3s. There is no behavioral bug to fix. This PR locks that robustness against regression and adds diagnostics for the next time an orphan is suspected.

## Why no code fix?

`shutdown()` always terminates once called (`process.exit(0)` at the end + a 10s hard-timeout force-exit), so any idle-shutdown bug reduces to **`evaluateIdle()` never firing**. The S1/S2 reproductions below show the current fire conditions work. The observed orphan (PID 31396) ran v2.16.0, whose idle code is functionally identical to current `main` (`git show 8639904`), and that process is gone + daemon logs do not identify it per-PID — so its exact internal state is unrecoverable. Most likely a split-brain second daemon, already closed by #93.

Killing a daemon that still holds `detached` sessions would break tmux persistence, so that path is intentionally left alone.

## Changes

- **`Watchdog.evaluateIdle`** — observability logging: when the daemon is NOT idle-eligible, log which signal holds it alive (`connections` / `liveSessions`) or that it is counting down, with pid, every 5th health tick. Gated on `checkCount > 0` so direct `evaluateIdle()` unit calls stay log-silent. **Behavior unchanged — logging only.**
- **`idleShutdown.test.ts`** — S2 wiring lock: every PTY-spawning path (create RPC + 3 recovery branches) must `processMonitor.watch`, and the callback must be able to flip the session to `dead`. Guards a future refactor from letting an orphan hold a `detached` session forever.
- **`Watchdog.test.ts`** — behavioral lock for the new idle-eval observability.
- **`scripts/daemon-orphan-idle-dynamic.mjs`** — new dynamic repro covering the two paths the existing `daemon-idle-shutdown-dynamic.mjs` never exercised:
  - **S1** — client never connects (idle anchor falls back to `startTime`)
  - **S2** — live session PTY killed -> ProcessMonitor death -> `dead` -> `listLiveSessions()=0` -> reap

## Testing

- Changed-file tests: **30/30 pass**
- Dynamic repro: **S1 + S2 PASS** (self-terminate ~3s, `idle.timeout` breadcrumb confirmed)
- The daemon suite shows 2 ConPTY-concurrency flakes (`shellIntegration.runtime` etc.) that **reproduce on baseline without these changes** — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)