### PR TITLE
fix: memory-leak audit survivors — bound MCP capture, A2A GC hard cap, PTY listener cleanup

### DIFF
--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -172,20 +172,26 @@ export function registerPTYHandlers(
   // recoveredBytes=0 (cap-skipped session or fresh create) means the cache
   // is the best approximation and must be kept.
   // Single broadcast listener; the renderer filters by ptyId.
+  // Stored in a named variable (not an anonymous closure) so the cleanup function below
+  // can removeListener it, mirroring session:data / session:died. Without this, repeated
+  // handler swaps on the same surviving daemonClient (renderer-crash / unresponsive-reload
+  // recovery) accumulate flushComplete listeners → MaxListenersExceededWarning + duplicate
+  // PTY_FLUSH_COMPLETE sends.
+  let onDaemonFlushComplete:
+    | ((payload: { sessionId: string; recoveredBytes: number }) => void)
+    | null = null;
   if (useDaemon && daemonClient) {
-    daemonClient.on(
-      'session:flushComplete',
-      (payload: { sessionId: string; recoveredBytes: number }) => {
-        const win = getWindow?.();
-        if (win && !win.isDestroyed()) {
-          win.webContents.send(
-            IPC.PTY_FLUSH_COMPLETE,
-            payload.sessionId,
-            payload.recoveredBytes,
-          );
-        }
-      },
-    );
+    onDaemonFlushComplete = (payload: { sessionId: string; recoveredBytes: number }) => {
+      const win = getWindow?.();
+      if (win && !win.isDestroyed()) {
+        win.webContents.send(
+          IPC.PTY_FLUSH_COMPLETE,
+          payload.sessionId,
+          payload.recoveredBytes,
+        );
+      }
+    };
+    daemonClient.on('session:flushComplete', onDaemonFlushComplete);
   }
 
   // pty:create
@@ -597,6 +603,9 @@ export function registerPTYHandlers(
       daemonSessionListeners.clear();
       if (onDaemonSessionDied) {
         daemonClient.removeListener('session:died', onDaemonSessionDied);
+      }
+      if (onDaemonFlushComplete) {
+        daemonClient.removeListener('session:flushComplete', onDaemonFlushComplete);
       }
     }
   };

--- a/src/mcp/playwright/tools/inspection.ts
+++ b/src/mcp/playwright/tools/inspection.ts
@@ -35,11 +35,42 @@ interface NetworkEntry {
 const consoleMessages = new Map<string, ConsoleEntry[]>();
 const networkRequests = new Map<string, NetworkEntry[]>();
 
+// Bound the per-surface capture arrays so a long-lived MCP server process does not
+// grow without limit on a chatty / polling page. Oldest entries are dropped first.
+const MAX_CAPTURE_ENTRIES = 1000;
+// Cap each retained response body so a single large payload cannot pin unbounded RAM.
+const MAX_RESPONSE_BODY_BYTES = 256 * 1024;
+
 // Track which pages already have listeners attached
 const attachedConsolePages = new WeakSet<Page>();
 const attachedNetworkPages = new WeakSet<Page>();
+const cleanupBoundPages = new WeakSet<Page>();
+
+/** Append to a capped ring: drop the oldest entries once MAX_CAPTURE_ENTRIES is exceeded. */
+function pushCapped<T>(entries: T[], item: T): void {
+  entries.push(item);
+  if (entries.length > MAX_CAPTURE_ENTRIES) {
+    entries.splice(0, entries.length - MAX_CAPTURE_ENTRIES);
+  }
+}
+
+/**
+ * Delete a surface's capture buffers when its page closes, so a closed surface does not
+ * strand its arrays (and any retained response bodies) under a dead key for the rest of
+ * the MCP process lifetime. Bound once per page via cleanupBoundPages.
+ */
+function ensurePageCloseCleanup(page: Page, surfaceKey: string): void {
+  if (cleanupBoundPages.has(page)) return;
+  cleanupBoundPages.add(page);
+
+  page.on('close', () => {
+    consoleMessages.delete(surfaceKey);
+    networkRequests.delete(surfaceKey);
+  });
+}
 
 function ensureConsoleListener(page: Page, surfaceKey: string): void {
+  ensurePageCloseCleanup(page, surfaceKey);
   if (attachedConsolePages.has(page)) return;
   attachedConsolePages.add(page);
 
@@ -50,12 +81,13 @@ function ensureConsoleListener(page: Page, surfaceKey: string): void {
   page.on('console', (msg) => {
     const entries = consoleMessages.get(surfaceKey);
     if (entries) {
-      entries.push({ level: msg.type(), text: msg.text() });
+      pushCapped(entries, { level: msg.type(), text: msg.text() });
     }
   });
 }
 
 function ensureNetworkListener(page: Page, surfaceKey: string): void {
+  ensurePageCloseCleanup(page, surfaceKey);
   if (attachedNetworkPages.has(page)) return;
   attachedNetworkPages.add(page);
 
@@ -66,7 +98,7 @@ function ensureNetworkListener(page: Page, surfaceKey: string): void {
   page.on('request', (request) => {
     const entries = networkRequests.get(surfaceKey);
     if (entries) {
-      entries.push({
+      pushCapped(entries, {
         url: request.url(),
         method: request.method(),
       });
@@ -81,10 +113,14 @@ function ensureNetworkListener(page: Page, surfaceKey: string): void {
     // Find the matching request entry (last one with same URL and no status yet)
     for (let i = entries.length - 1; i >= 0; i--) {
       if (entries[i].url === url && entries[i].status === undefined) {
-        entries[i].status = response.status();
+        // Capture a stable reference to the entry object: the capture array is a
+        // capped ring (pushCapped), so positional indices can shift while the async
+        // response.text() below is in flight.
+        const entry = entries[i];
+        entry.status = response.status();
         // Store response headers for later body retrieval
         const headers = response.headers();
-        entries[i].response = { headers };
+        entry.response = { headers };
         // Only eagerly capture body for text-based content types
         const contentType = headers['content-type'] ?? '';
         const isTextual =
@@ -98,8 +134,12 @@ function ensureNetworkListener(page: Page, surfaceKey: string): void {
           response
             .text()
             .then((body) => {
-              if (entries[i].response) {
-                entries[i].response!.body = body;
+              if (entry.response) {
+                entry.response.body =
+                  body.length > MAX_RESPONSE_BODY_BYTES
+                    ? body.slice(0, MAX_RESPONSE_BODY_BYTES) +
+                      `\n... [truncated ${body.length - MAX_RESPONSE_BODY_BYTES} chars]`
+                    : body;
               }
             })
             .catch(() => {
@@ -413,15 +453,19 @@ export function registerInspectionTools(server: McpServer): void {
   // -----------------------------------------------------------------------
   server.tool(
     'browser_network',
-    'Retrieve network requests collected from the browser page. Requests are accumulated over time. Use a URL glob pattern to filter.',
+    'Retrieve network requests collected from the browser page. Requests are accumulated over time; use clear=true to reset. Use a URL glob pattern to filter.',
     {
       filter: z
         .string()
         .optional()
         .describe('URL glob pattern to filter requests (e.g. "*api*", "*.json").'),
+      clear: z
+        .boolean()
+        .optional()
+        .describe('Clear collected requests (and any retained response bodies) after returning them.'),
       surfaceId: optionalSurfaceId,
     },
-    async ({ filter, surfaceId }) => {
+    async ({ filter, clear, surfaceId }) => {
       try {
         const page = await engine.getPage(surfaceId);
         if (!page) {
@@ -447,6 +491,10 @@ export function registerInspectionTools(server: McpServer): void {
           summary.length === 0
             ? 'No network requests collected.'
             : JSON.stringify(summary, null, 2);
+
+        if (clear) {
+          networkRequests.set(key, []);
+        }
 
         return {
           content: [{ type: 'text' as const, text }],

--- a/src/mcp/playwright/tools/inspection.ts
+++ b/src/mcp/playwright/tools/inspection.ts
@@ -32,34 +32,25 @@ interface NetworkEntry {
   };
 }
 
-const consoleMessages = new Map<string, ConsoleEntry[]>();
-const networkRequests = new Map<string, NetworkEntry[]>();
+// Capture buffers are keyed by the Page object itself, not by surfaceId. A Page is the
+// true identity: an omitted surfaceId and an explicit surfaceId can resolve to the SAME
+// Page (one buffer, no stranding), and two DISTINCT Pages never collide on an alias key
+// like '__default__' (so closing one page cannot delete another's data). WeakMap also
+// lets a closed/GC'd Page drop its buffers automatically.
+const consoleMessages = new WeakMap<Page, ConsoleEntry[]>();
+const networkRequests = new WeakMap<Page, NetworkEntry[]>();
 
-// Bound the per-surface capture arrays so a long-lived MCP server process does not
-// grow without limit on a chatty / polling page. Oldest entries are dropped first.
+// Bound the per-page capture arrays so a long-lived MCP server process does not grow
+// without limit on a chatty / polling page. Oldest entries are dropped first.
 const MAX_CAPTURE_ENTRIES = 1000;
 // Cap each retained response body so a single large payload cannot pin unbounded RAM.
 const MAX_RESPONSE_BODY_BYTES = 256 * 1024;
 
-// Track which pages already have listeners attached
+// Track which pages already have listeners attached. Keyed by the Page object so a
+// closed/GC'd page drops its guard automatically.
 const attachedConsolePages = new WeakSet<Page>();
 const attachedNetworkPages = new WeakSet<Page>();
 const cleanupBoundPages = new WeakSet<Page>();
-
-// A single physical Page can be reached under more than one surfaceKey (e.g. an
-// omitted surfaceId resolves to '__default__' while an explicit surfaceId names the
-// same active page). The per-Page listener guards below would early-return on the
-// second key, stranding its data under the first key and leaving cleanup to delete
-// only the first key. Pin each Page to the FIRST surfaceKey it is seen with so every
-// access, listener, and the close cleanup all agree on one canonical key.
-const pageCanonicalKey = new WeakMap<Page, string>();
-
-function resolveCanonicalKey(page: Page, surfaceKey: string): string {
-  const existing = pageCanonicalKey.get(page);
-  if (existing !== undefined) return existing;
-  pageCanonicalKey.set(page, surfaceKey);
-  return surfaceKey;
-}
 
 /** Append to a capped ring: drop the oldest entries once MAX_CAPTURE_ENTRIES is exceeded. */
 function pushCapped<T>(entries: T[], item: T): void {
@@ -70,54 +61,49 @@ function pushCapped<T>(entries: T[], item: T): void {
 }
 
 /**
- * Delete a page's capture buffers when it closes, so a closed surface does not strand
- * its arrays (and any retained response bodies) under a dead key for the rest of the
- * MCP process lifetime. Bound once per page; the key is the page's canonical key.
+ * Eagerly drop a page's capture buffers when it closes. The WeakMap would reclaim them
+ * once the Page is GC'd, but the engine may retain the Page object past close, so we
+ * delete on 'close' to free the (potentially large) retained response bodies promptly.
+ * Bound once per page.
  */
-function ensurePageCloseCleanup(page: Page, canonicalKey: string): void {
+function ensurePageCloseCleanup(page: Page): void {
   if (cleanupBoundPages.has(page)) return;
   cleanupBoundPages.add(page);
 
   page.on('close', () => {
-    consoleMessages.delete(canonicalKey);
-    networkRequests.delete(canonicalKey);
+    consoleMessages.delete(page);
+    networkRequests.delete(page);
   });
 }
 
-/** Attach the console listener (idempotent per page) and return the canonical key to use. */
-function ensureConsoleListener(page: Page, surfaceKey: string): string {
-  const key = resolveCanonicalKey(page, surfaceKey);
-  ensurePageCloseCleanup(page, key);
-  if (attachedConsolePages.has(page)) return key;
+function ensureConsoleListener(page: Page): void {
+  ensurePageCloseCleanup(page);
+  if (attachedConsolePages.has(page)) return;
   attachedConsolePages.add(page);
 
-  if (!consoleMessages.has(key)) {
-    consoleMessages.set(key, []);
+  if (!consoleMessages.has(page)) {
+    consoleMessages.set(page, []);
   }
 
   page.on('console', (msg) => {
-    const entries = consoleMessages.get(key);
+    const entries = consoleMessages.get(page);
     if (entries) {
       pushCapped(entries, { level: msg.type(), text: msg.text() });
     }
   });
-
-  return key;
 }
 
-/** Attach the network listeners (idempotent per page) and return the canonical key to use. */
-function ensureNetworkListener(page: Page, surfaceKey: string): string {
-  const key = resolveCanonicalKey(page, surfaceKey);
-  ensurePageCloseCleanup(page, key);
-  if (attachedNetworkPages.has(page)) return key;
+function ensureNetworkListener(page: Page): void {
+  ensurePageCloseCleanup(page);
+  if (attachedNetworkPages.has(page)) return;
   attachedNetworkPages.add(page);
 
-  if (!networkRequests.has(key)) {
-    networkRequests.set(key, []);
+  if (!networkRequests.has(page)) {
+    networkRequests.set(page, []);
   }
 
   page.on('request', (request) => {
-    const entries = networkRequests.get(key);
+    const entries = networkRequests.get(page);
     if (entries) {
       pushCapped(entries, {
         url: request.url(),
@@ -127,7 +113,7 @@ function ensureNetworkListener(page: Page, surfaceKey: string): string {
   });
 
   page.on('response', (response) => {
-    const entries = networkRequests.get(key);
+    const entries = networkRequests.get(page);
     if (!entries) return;
 
     const url = response.url();
@@ -171,12 +157,6 @@ function ensureNetworkListener(page: Page, surfaceKey: string): string {
       }
     }
   });
-
-  return key;
-}
-
-function surfaceKey(surfaceId?: string): string {
-  return surfaceId ?? '__default__';
 }
 
 /**
@@ -433,9 +413,9 @@ export function registerInspectionTools(server: McpServer): void {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }
 
-        const key = ensureConsoleListener(page, surfaceKey(surfaceId));
+        ensureConsoleListener(page);
 
-        const entries = consoleMessages.get(key) ?? [];
+        const entries = consoleMessages.get(page) ?? [];
 
         const filterLevel = level ?? 'all';
         const filtered =
@@ -454,7 +434,7 @@ export function registerInspectionTools(server: McpServer): void {
             : filtered.map((e) => `[${e.level}] ${e.text}`).join('\n');
 
         if (clear) {
-          consoleMessages.set(key, []);
+          consoleMessages.set(page, []);
         }
 
         return {
@@ -494,9 +474,9 @@ export function registerInspectionTools(server: McpServer): void {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }
 
-        const key = ensureNetworkListener(page, surfaceKey(surfaceId));
+        ensureNetworkListener(page);
 
-        const entries = networkRequests.get(key) ?? [];
+        const entries = networkRequests.get(page) ?? [];
 
         const filtered = filter
           ? entries.filter((e) => matchesGlob(e.url, filter))
@@ -514,7 +494,7 @@ export function registerInspectionTools(server: McpServer): void {
             : JSON.stringify(summary, null, 2);
 
         if (clear) {
-          networkRequests.set(key, []);
+          networkRequests.set(page, []);
         }
 
         return {
@@ -549,9 +529,9 @@ export function registerInspectionTools(server: McpServer): void {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }
 
-        const key = ensureNetworkListener(page, surfaceKey(surfaceId));
+        ensureNetworkListener(page);
 
-        const entries = networkRequests.get(key) ?? [];
+        const entries = networkRequests.get(page) ?? [];
 
         // Find the last matching entry with a captured body
         let matchedEntry: NetworkEntry | undefined;

--- a/src/mcp/playwright/tools/inspection.ts
+++ b/src/mcp/playwright/tools/inspection.ts
@@ -46,6 +46,21 @@ const attachedConsolePages = new WeakSet<Page>();
 const attachedNetworkPages = new WeakSet<Page>();
 const cleanupBoundPages = new WeakSet<Page>();
 
+// A single physical Page can be reached under more than one surfaceKey (e.g. an
+// omitted surfaceId resolves to '__default__' while an explicit surfaceId names the
+// same active page). The per-Page listener guards below would early-return on the
+// second key, stranding its data under the first key and leaving cleanup to delete
+// only the first key. Pin each Page to the FIRST surfaceKey it is seen with so every
+// access, listener, and the close cleanup all agree on one canonical key.
+const pageCanonicalKey = new WeakMap<Page, string>();
+
+function resolveCanonicalKey(page: Page, surfaceKey: string): string {
+  const existing = pageCanonicalKey.get(page);
+  if (existing !== undefined) return existing;
+  pageCanonicalKey.set(page, surfaceKey);
+  return surfaceKey;
+}
+
 /** Append to a capped ring: drop the oldest entries once MAX_CAPTURE_ENTRIES is exceeded. */
 function pushCapped<T>(entries: T[], item: T): void {
   entries.push(item);
@@ -55,48 +70,54 @@ function pushCapped<T>(entries: T[], item: T): void {
 }
 
 /**
- * Delete a surface's capture buffers when its page closes, so a closed surface does not
- * strand its arrays (and any retained response bodies) under a dead key for the rest of
- * the MCP process lifetime. Bound once per page via cleanupBoundPages.
+ * Delete a page's capture buffers when it closes, so a closed surface does not strand
+ * its arrays (and any retained response bodies) under a dead key for the rest of the
+ * MCP process lifetime. Bound once per page; the key is the page's canonical key.
  */
-function ensurePageCloseCleanup(page: Page, surfaceKey: string): void {
+function ensurePageCloseCleanup(page: Page, canonicalKey: string): void {
   if (cleanupBoundPages.has(page)) return;
   cleanupBoundPages.add(page);
 
   page.on('close', () => {
-    consoleMessages.delete(surfaceKey);
-    networkRequests.delete(surfaceKey);
+    consoleMessages.delete(canonicalKey);
+    networkRequests.delete(canonicalKey);
   });
 }
 
-function ensureConsoleListener(page: Page, surfaceKey: string): void {
-  ensurePageCloseCleanup(page, surfaceKey);
-  if (attachedConsolePages.has(page)) return;
+/** Attach the console listener (idempotent per page) and return the canonical key to use. */
+function ensureConsoleListener(page: Page, surfaceKey: string): string {
+  const key = resolveCanonicalKey(page, surfaceKey);
+  ensurePageCloseCleanup(page, key);
+  if (attachedConsolePages.has(page)) return key;
   attachedConsolePages.add(page);
 
-  if (!consoleMessages.has(surfaceKey)) {
-    consoleMessages.set(surfaceKey, []);
+  if (!consoleMessages.has(key)) {
+    consoleMessages.set(key, []);
   }
 
   page.on('console', (msg) => {
-    const entries = consoleMessages.get(surfaceKey);
+    const entries = consoleMessages.get(key);
     if (entries) {
       pushCapped(entries, { level: msg.type(), text: msg.text() });
     }
   });
+
+  return key;
 }
 
-function ensureNetworkListener(page: Page, surfaceKey: string): void {
-  ensurePageCloseCleanup(page, surfaceKey);
-  if (attachedNetworkPages.has(page)) return;
+/** Attach the network listeners (idempotent per page) and return the canonical key to use. */
+function ensureNetworkListener(page: Page, surfaceKey: string): string {
+  const key = resolveCanonicalKey(page, surfaceKey);
+  ensurePageCloseCleanup(page, key);
+  if (attachedNetworkPages.has(page)) return key;
   attachedNetworkPages.add(page);
 
-  if (!networkRequests.has(surfaceKey)) {
-    networkRequests.set(surfaceKey, []);
+  if (!networkRequests.has(key)) {
+    networkRequests.set(key, []);
   }
 
   page.on('request', (request) => {
-    const entries = networkRequests.get(surfaceKey);
+    const entries = networkRequests.get(key);
     if (entries) {
       pushCapped(entries, {
         url: request.url(),
@@ -106,7 +127,7 @@ function ensureNetworkListener(page: Page, surfaceKey: string): void {
   });
 
   page.on('response', (response) => {
-    const entries = networkRequests.get(surfaceKey);
+    const entries = networkRequests.get(key);
     if (!entries) return;
 
     const url = response.url();
@@ -150,6 +171,8 @@ function ensureNetworkListener(page: Page, surfaceKey: string): void {
       }
     }
   });
+
+  return key;
 }
 
 function surfaceKey(surfaceId?: string): string {
@@ -410,8 +433,7 @@ export function registerInspectionTools(server: McpServer): void {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }
 
-        const key = surfaceKey(surfaceId);
-        ensureConsoleListener(page, key);
+        const key = ensureConsoleListener(page, surfaceKey(surfaceId));
 
         const entries = consoleMessages.get(key) ?? [];
 
@@ -472,8 +494,7 @@ export function registerInspectionTools(server: McpServer): void {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }
 
-        const key = surfaceKey(surfaceId);
-        ensureNetworkListener(page, key);
+        const key = ensureNetworkListener(page, surfaceKey(surfaceId));
 
         const entries = networkRequests.get(key) ?? [];
 
@@ -528,8 +549,7 @@ export function registerInspectionTools(server: McpServer): void {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }
 
-        const key = surfaceKey(surfaceId);
-        ensureNetworkListener(page, key);
+        const key = ensureNetworkListener(page, surfaceKey(surfaceId));
 
         const entries = networkRequests.get(key) ?? [];
 

--- a/src/renderer/stores/slices/__tests__/a2aSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/a2aSlice.test.ts
@@ -60,6 +60,67 @@ describe('a2aSlice — cancelTask permissions', () => {
   });
 });
 
+describe('a2aSlice — gcTerminalTasks hard cap (issue #99)', () => {
+  // Mirrors the GC_MAX_TASKS constant in a2aSlice.ts (not exported).
+  const GC_MAX_TASKS = 500;
+
+  function seedTasks(store: ReturnType<typeof createTestStore>, count: number): string[] {
+    const ids: string[] = [];
+    for (let i = 0; i < count; i++) {
+      ids.push(
+        store.getState().createA2aTask({
+          title: `Task ${i}`,
+          from: { workspaceId: 'ws-sender', name: 'Sender' },
+          to: { workspaceId: 'ws-receiver', name: 'Receiver' },
+          history: [makeMessage(`task ${i}`)],
+          artifacts: [],
+        }),
+      );
+    }
+    return ids;
+  }
+
+  it('enforces GC_MAX_TASKS as a TRUE hard bound even when every task is non-terminal', () => {
+    const store = createTestStore();
+    const overflow = 10;
+    seedTasks(store, GC_MAX_TASKS + overflow); // all 'submitted' (non-terminal)
+    expect(Object.keys(store.getState().a2aTasks).length).toBe(GC_MAX_TASKS + overflow);
+
+    store.getState().gcTerminalTasks();
+
+    // Before the fix, the overflow branch only evicted terminal tasks, so a pile of
+    // stuck non-terminal tasks could never be reclaimed. Now the cap is absolute.
+    expect(Object.keys(store.getState().a2aTasks).length).toBe(GC_MAX_TASKS);
+  });
+
+  it('evicts terminal tasks before non-terminal ones when over the cap', () => {
+    const store = createTestStore();
+    const overflow = 10;
+    const ids = seedTasks(store, GC_MAX_TASKS + overflow);
+
+    // Cancel the first 5 → terminal ('canceled'). updatedAt is "now", so the 30-min
+    // age prune does not touch them; only the overflow branch runs.
+    const canceledIds = ids.slice(0, 5);
+    for (const id of canceledIds) {
+      const result = store.getState().cancelTask(id, 'ws-sender');
+      expect(result.ok).toBe(true);
+    }
+
+    store.getState().gcTerminalTasks();
+
+    const remaining = store.getState().a2aTasks;
+    expect(Object.keys(remaining).length).toBe(GC_MAX_TASKS);
+    // All 5 terminal tasks must be gone (evicted first), plus 5 oldest non-terminal.
+    for (const id of canceledIds) {
+      expect(remaining[id]).toBeUndefined();
+    }
+    const stillTerminal = Object.values(remaining).filter((t) =>
+      ['completed', 'failed', 'canceled'].includes(t.status.state),
+    );
+    expect(stillTerminal.length).toBe(0);
+  });
+});
+
 describe('a2aSlice — pendingExecuteApproval', () => {
   it('starts null and round-trips through setter', () => {
     const store = createTestStore();

--- a/src/renderer/stores/slices/a2aSlice.ts
+++ b/src/renderer/stores/slices/a2aSlice.ts
@@ -194,15 +194,25 @@ export const createA2aSlice: StateCreator<StoreState, [['zustand/immer', never]]
       }
     }
 
-    // If still over limit, remove oldest terminal tasks first
+    // If still over the hard cap, evict oldest tasks. Prefer terminal tasks (their data
+    // is safe to drop), but fall back to evicting the oldest non-terminal tasks so
+    // GC_MAX_TASKS is a TRUE hard bound: a peer that creates tasks and never drives them
+    // to a terminal state would otherwise grow a2aTasks without limit, since the
+    // age-based prune above only removes terminal tasks.
     const remaining = Object.values(state.a2aTasks);
     if (remaining.length > GC_MAX_TASKS) {
-      const terminalTasks = remaining
-        .filter((t) => (TERMINAL_STATES as readonly string[]).includes(t.status.state))
-        .sort((a, b) => new Date(a.metadata.updatedAt).getTime() - new Date(b.metadata.updatedAt).getTime());
-
       let toRemove = remaining.length - GC_MAX_TASKS;
-      for (const task of terminalTasks) {
+      const oldestFirst = [...remaining].sort(
+        (a, b) => new Date(a.metadata.updatedAt).getTime() - new Date(b.metadata.updatedAt).getTime(),
+      );
+      const isTerminal = (t: (typeof remaining)[number]) =>
+        (TERMINAL_STATES as readonly string[]).includes(t.status.state);
+      // Terminal tasks first (oldest-first), then non-terminal oldest-first as a backstop.
+      const evictionOrder = [
+        ...oldestFirst.filter(isTerminal),
+        ...oldestFirst.filter((t) => !isTerminal(t)),
+      ];
+      for (const task of evictionOrder) {
         if (toRemove <= 0) break;
         delete state.a2aTasks[task.id];
         toRemove--;


### PR DESCRIPTION
## Summary

Fixes three memory issues surfaced by an adversarial RAM/memory-leak audit (10 domain
experts → per-finding refutation → 2nd-pass verification). 16 of 20 candidate findings
were rejected as fixed-overhead or intended tmux-style persistence (all bounded); these
are the survivors that were real and actionable.

Closes #98, #99, #100.

## Fixes

### #98 — MCP browser inspection capture buffers (P2 leak)
`src/mcp/playwright/tools/inspection.ts`
- Console/network capture arrays were module-level with no cap, no ring buffer, no
  eviction; the response handler stored full response bodies forever; `browser_network`
  had no clear path. A long-lived MCP server grew RSS without bound on a polling page.
- **Ring cap** (`MAX_CAPTURE_ENTRIES=1000`, oldest dropped) for console + network.
- **Response body cap** (`MAX_RESPONSE_BODY_BYTES=256KB`, truncated).
- **Page-close cleanup** frees a closed surface's buffers promptly.
- **`clear` param** added to `browser_network` (parity with `browser_console`).
- Capture buffers are keyed by the **Page object** (`WeakMap<Page, …>`), not a
  surfaceId alias — so omitted vs explicit surfaceId for the same page share one buffer
  (no stranding), and two distinct pages never collide on `__default__` (no cross-page
  deletion). This also fixed a pre-existing bug where the explicit-surfaceId path
  reported empty data. (Two codex review rounds drove this from per-key → canonical-key
  → Page-keyed.)

### #99 — A2A task GC hard cap (P2 leak, conditional)
`src/renderer/stores/slices/a2aSlice.ts`
- `gcTerminalTasks()` gated both deletion paths on `TERMINAL_STATES`, so tasks stuck
  non-terminal were never reclaimed and `GC_MAX_TASKS=500` was not a real hard bound.
- The overflow branch now evicts oldest-first, preferring terminal tasks and falling
  back to oldest non-terminal as a backstop, making 500 an absolute cap.
- Regression tests: hard-cap holds with all-non-terminal tasks; terminal evicted first.

### #100 — PTY flushComplete listener cleanup (P3 hygiene)
`src/main/ipc/handlers/pty.handler.ts`
- The `session:flushComplete` listener was an anonymous closure the cleanup function
  could not remove, so renderer-crash / unresponsive-reload recoveries on the same
  daemonClient accumulated listeners (MaxListenersExceededWarning + duplicate IPC).
- Stored in a named variable and removed in cleanup, mirroring `session:data` /
  `session:died`. (RAM impact is negligible; this is a correctness/hygiene fix.)

## Test plan

- `npx tsc --noEmit` + `npx tsc -p tsconfig.mcp.json --noEmit` — clean
- `npm test` — 2100 parallel + 16 runtime tests passing (incl. 2 new A2A hard-cap tests)
- **codex review**: 3 adversarial rounds. R1 and R2 each found a real defect in the
  MCP fix (data stranded under wrong key, then cross-page deletion on shared alias);
  both fixed. R3 CLEAN across all three fixes.

## Stability tier impact

- [x] Additive change to a `stable` surface — `browser_network` gains an optional
  `clear` param (backward compatible). Otherwise internal bounds/cleanup, no contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
