### PR TITLE
fix(profile): allowlist path-pointer credential vars; non-destructive load (follow-up to #101)

### DIFF
--- a/docs/workspace-profiles.md
+++ b/docs/workspace-profiles.md
@@ -40,9 +40,10 @@ Consequences worth internalizing:
   restart).
 - **No cross-workspace leakage.** A pane only ever sees its own workspace's
   profile.
-- **Identity is protected.** `WMUX_WORKSPACE_ID`, `WMUX_SURFACE_ID`, and
-  `WMUX_SOCKET_PATH` are forced last; a profile cannot override them. Any
-  `WMUX_*` key you type is rejected.
+- **Identity is protected.** The wmux identity vars are forced last, so a
+  profile cannot override them, and any `WMUX_*` key you type is rejected.
+  (`WMUX_WORKSPACE_ID` / `WMUX_SURFACE_ID` in both modes; `WMUX_SOCKET_PATH`
+  in local mode only — see the mental-model note above.)
 - **Profile env overwrites, it does not append.** If you set `PATH` in a
   profile it *replaces* the inherited `PATH` — almost never what you want. Set
   tool-specific vars (config-dir pointers), not `PATH`.
@@ -173,9 +174,12 @@ That keeps each account's tokens in its own `<CODEX_HOME>\auth.json`.
 The same pattern works for any CLI whose account/config is selectable via an
 environment variable or config-dir pointer — e.g. `GIT_SSH_COMMAND` for an SSH
 key wrapper, `AWS_CONFIG_FILE` / `AWS_SHARED_CREDENTIALS_FILE`,
-`KUBECONFIG`, `GOOGLE_APPLICATION_CREDENTIALS`, etc. If the tool keys off the
-OS keyring or a hardcoded path, profile env alone won't isolate it (same class
-of caveat as Codex's `auto` mode).
+`KUBECONFIG`, `GOOGLE_APPLICATION_CREDENTIALS`, etc. These name a *path* (a
+reference, not the secret itself), so they're allowed even though some match
+the secret-name policy — `GOOGLE_APPLICATION_CREDENTIALS` and
+`AWS_SHARED_CREDENTIALS_FILE` are on the path-pointer allowlist. If the tool
+keys off the OS keyring or a hardcoded path, profile env alone won't isolate it
+(same class of caveat as Codex's `auto` mode).
 
 ---
 

--- a/src/main/pty/__tests__/resolveSpawnEnv.test.ts
+++ b/src/main/pty/__tests__/resolveSpawnEnv.test.ts
@@ -14,13 +14,18 @@ describe('resolveSpawnEnv', () => {
     expect(env.WMUX_AUTH_TOKEN).toBeUndefined();
   });
 
-  it('keeps an intentional profile *_KEY that the baseline denylist would strip', () => {
+  it('applies any profile key verbatim (spawn mechanism — policy is one layer up)', () => {
+    // resolveSpawnEnv applies whatever the profile contains; it does NOT re-run
+    // the denylist on profile keys. WHICH keys a profile may contain is decided
+    // by the editor policy (workspaceProfile: secret-named keys dropped on
+    // save), tested separately. Here we only assert the mechanism: a key that
+    // reaches this layer survives even if its name matches the baseline denylist.
     const env = resolveSpawnEnv(
       { PATH: '/usr/bin' },
-      { GEMINI_API_KEY: 'intentional', CLAUDE_CONFIG_DIR: 'C:/a' },
+      { GEMINI_API_KEY: 'x', CLAUDE_CONFIG_DIR: 'C:/a' },
       {},
     );
-    expect(env.GEMINI_API_KEY).toBe('intentional');
+    expect(env.GEMINI_API_KEY).toBe('x');
     expect(env.CLAUDE_CONFIG_DIR).toBe('C:/a');
   });
 

--- a/src/main/pty/resolveSpawnEnv.ts
+++ b/src/main/pty/resolveSpawnEnv.ts
@@ -10,8 +10,12 @@ import { applyProfileEnv } from '../../shared/workspaceProfile';
  *   1. buildSafeChildEnv(baseEnv) — strip the control process's own inherited
  *      secrets / build-tooling vars from the child baseline.
  *   2. applyProfileEnv(...)       — overlay the workspace profile AFTER the
- *      denylist (so an intentional *_KEY/*_TOKEN survives) and skipping
- *      reserved WMUX_* keys.
+ *      denylist, so a configured profile key is applied verbatim and not
+ *      re-stripped; reserved WMUX_* keys are skipped. NOTE: this is the spawn
+ *      MECHANISM — it applies whatever the profile contains. WHICH keys a
+ *      profile may contain is decided one layer up by the editor's policy
+ *      (shared/workspaceProfile: reserved + secret-named keys are dropped on
+ *      save), not here.
  *   3. identity                   — forced LAST, so a profile can never spoof
  *      WMUX_WORKSPACE_ID / WMUX_SURFACE_ID / WMUX_SOCKET_PATH. The caller
  *      decides which identity vars apply (local mode also sets the socket

--- a/src/renderer/components/Sidebar/WorkspaceProfileModal.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceProfileModal.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { Workspace } from '../../../shared/types';
-import { isSecretLikeEnvKey, isValidEnvKey, normalizeWorkspaceProfile } from '../../../shared/workspaceProfile';
+import { isSecretLikeEnvKey, isValidEnvKey } from '../../../shared/workspaceProfile';
 import { useStore } from '../../stores';
 import { useT } from '../../hooks/useT';
 
@@ -73,10 +73,10 @@ export default function WorkspaceProfileModal({ workspace, onClose }: WorkspaceP
       if (key === '') continue;
       env[key] = row.value;
     }
-    // normalizeWorkspaceProfile drops invalid/reserved keys and collapses an
-    // empty profile to undefined (which clears it).
-    const profile = normalizeWorkspaceProfile({ env, defaultPaneCommand: command });
-    setWorkspaceProfile(workspace.id, profile);
+    // setWorkspaceProfile normalizes (drops invalid/reserved AND secret-named
+    // keys, collapses an empty profile to undefined) — it is the single
+    // enforcing boundary, so we just hand it the raw rows.
+    setWorkspaceProfile(workspace.id, { env, defaultPaneCommand: command });
     onClose();
   }, [rows, command, setWorkspaceProfile, workspace.id, onClose]);
 

--- a/src/renderer/stores/slices/__tests__/workspaceSlice.profile.test.ts
+++ b/src/renderer/stores/slices/__tests__/workspaceSlice.profile.test.ts
@@ -41,12 +41,21 @@ describe('workspaceSlice — setWorkspaceProfile', () => {
     expect(ws?.profile).toEqual({ env: { CLAUDE_CONFIG_DIR: 'C:/a' }, defaultPaneCommand: 'claude' });
   });
 
-  it('drops invalid env keys and reserved WMUX_* keys', () => {
+  it('drops invalid, reserved, and secret-named keys on save', () => {
     store.getState().setWorkspaceProfile(wsId, {
-      env: { CLAUDE_CONFIG_DIR: 'C:/a', '1BAD': 'x', WMUX_WORKSPACE_ID: 'spoof' },
+      env: {
+        CLAUDE_CONFIG_DIR: 'C:/a',
+        '1BAD': 'x',
+        WMUX_WORKSPACE_ID: 'spoof',
+        OPENAI_API_KEY: 'sk-leak',
+        GOOGLE_APPLICATION_CREDENTIALS: 'C:/gcp.json', // allowlisted path pointer — kept
+      },
     });
     const ws = store.getState().workspaces.find((w) => w.id === wsId);
-    expect(ws?.profile?.env).toEqual({ CLAUDE_CONFIG_DIR: 'C:/a' });
+    expect(ws?.profile?.env).toEqual({
+      CLAUDE_CONFIG_DIR: 'C:/a',
+      GOOGLE_APPLICATION_CREDENTIALS: 'C:/gcp.json',
+    });
   });
 
   it('clears the profile when given an empty profile', () => {
@@ -94,6 +103,16 @@ describe('workspaceSlice — loadSession profile sanitization', () => {
     );
     const ws = store.getState().workspaces[0];
     expect(ws.profile).toEqual({ env: { CLAUDE_CONFIG_DIR: 'C:/a' }, defaultPaneCommand: 'go' });
+  });
+
+  it('PRESERVES a secret-named key on load (non-destructive for legacy sessions)', () => {
+    // A session.json saved before the secret-name policy must keep working —
+    // load does not drop secret keys (only the editor save path does).
+    store.getState().loadSession(
+      sessionWith({ env: { CLAUDE_CONFIG_DIR: 'C:/a', LEGACY_TOKEN: 'keep-me' } }),
+    );
+    const ws = store.getState().workspaces[0];
+    expect(ws.profile?.env).toEqual({ CLAUDE_CONFIG_DIR: 'C:/a', LEGACY_TOKEN: 'keep-me' });
   });
 
   it('drops an empty/invalid profile on load', () => {

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -191,9 +191,10 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
     setWorkspaceProfile: (id, profile) => set((state: StoreState) => {
       const ws = state.workspaces.find((w: Workspace) => w.id === id);
       if (!ws) return;
-      // Normalize defensively even though the UI pre-validates — drops invalid
-      // entries / reserved keys and collapses an empty profile to undefined.
-      const normalized = normalizeWorkspaceProfile(profile);
+      // This is the editor/save boundary, so enforce the secret-name policy
+      // (dropSecretKeys) in addition to dropping invalid/reserved entries. Load
+      // is intentionally NOT dropSecretKeys (non-destructive — see loadSession).
+      const normalized = normalizeWorkspaceProfile(profile, { dropSecretKeys: true });
       if (normalized) {
         ws.profile = normalized;
       } else {
@@ -282,7 +283,11 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
 
       // Sanitize each workspace profile from the (untrusted) saved session:
       // drop invalid env keys/values, reserved WMUX_* keys, and collapse an
-      // empty profile so it doesn't linger as `{ env: {} }`.
+      // empty profile so it doesn't linger as `{ env: {} }`. Deliberately NOT
+      // dropSecretKeys — load is non-destructive, so a secret-named key saved
+      // before the policy keeps working until the user re-saves the profile
+      // (the editor flags it and drops it on save). Dropping here would
+      // silently delete working config without un-storing the plaintext value.
       for (const ws of data.workspaces) {
         if (ws.profile === undefined) continue;
         const normalized = normalizeWorkspaceProfile(ws.profile);

--- a/src/shared/__tests__/workspaceProfile.test.ts
+++ b/src/shared/__tests__/workspaceProfile.test.ts
@@ -55,16 +55,33 @@ describe('isSecretLikeEnvKey', () => {
     expect(isSecretLikeEnvKey('GIT_SSH_COMMAND')).toBe(false);
     expect(isSecretLikeEnvKey('SSH_AUTH_SOCK')).toBe(false); // safe-passthrough
   });
+
+  it('does NOT flag path-pointer credential vars on the allowlist', () => {
+    // These match the denylist by name but hold a PATH (reference over secret),
+    // which is exactly the supported pattern — must not be dropped.
+    expect(isSecretLikeEnvKey('GOOGLE_APPLICATION_CREDENTIALS')).toBe(false);
+    expect(isSecretLikeEnvKey('google_application_credentials')).toBe(false);
+    expect(isSecretLikeEnvKey('AWS_SHARED_CREDENTIALS_FILE')).toBe(false);
+  });
 });
 
 describe('normalizeEnv', () => {
-  it('drops secret-NAMED keys by policy (not persisted in plaintext)', () => {
-    const env = normalizeEnv({
-      CLAUDE_CONFIG_DIR: 'C:/a',
-      OPENAI_API_KEY: 'sk-leak',
-      github_token: 'ghp_leak',
+  it('drops secret-NAMED keys only when dropSecretKeys is set (save boundary)', () => {
+    const input = { CLAUDE_CONFIG_DIR: 'C:/a', OPENAI_API_KEY: 'sk-leak', github_token: 'ghp_leak' };
+    // Save path: drop secrets.
+    expect(normalizeEnv(input, true)).toEqual({ CLAUDE_CONFIG_DIR: 'C:/a' });
+    // Load path (default): preserve — non-destructive for legacy session.json.
+    expect(normalizeEnv(input)).toEqual({
+      CLAUDE_CONFIG_DIR: 'C:/a', OPENAI_API_KEY: 'sk-leak', github_token: 'ghp_leak',
     });
-    expect(env).toEqual({ CLAUDE_CONFIG_DIR: 'C:/a' });
+  });
+
+  it('keeps GOOGLE_APPLICATION_CREDENTIALS even with dropSecretKeys (allowlist)', () => {
+    const env = normalizeEnv(
+      { GOOGLE_APPLICATION_CREDENTIALS: 'C:/gcp/sa.json', OPENAI_API_KEY: 'sk-x' },
+      true,
+    );
+    expect(env).toEqual({ GOOGLE_APPLICATION_CREDENTIALS: 'C:/gcp/sa.json' });
   });
 
   it('keeps valid string entries and drops invalid ones', () => {
@@ -122,12 +139,14 @@ describe('applyProfileEnv', () => {
     expect(target).toEqual({ PATH: '/custom', CLAUDE_CONFIG_DIR: 'C:/a' });
   });
 
-  it('preserves an intentional *_KEY/*_TOKEN that the env denylist would strip', () => {
-    // The whole point of the separate overlay: a user-set secret-shaped key
-    // survives because applyProfileEnv runs AFTER buildSafeChildEnv.
+  it('applies any key verbatim — does not re-run the denylist (mechanism)', () => {
+    // applyProfileEnv is the spawn mechanism: it applies whatever it's given,
+    // so a key that reaches this layer is not re-stripped. WHICH keys a profile
+    // may contain is decided one layer up by the editor policy (normalizeEnv
+    // drops secret-named keys on save) — see the normalizeEnv tests.
     const target: Record<string, string> = {};
-    applyProfileEnv(target, { GEMINI_API_KEY: 'user-set', SOME_TOKEN: 't' });
-    expect(target.GEMINI_API_KEY).toBe('user-set');
+    applyProfileEnv(target, { GEMINI_API_KEY: 'x', SOME_TOKEN: 't' });
+    expect(target.GEMINI_API_KEY).toBe('x');
     expect(target.SOME_TOKEN).toBe('t');
   });
 

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -303,8 +303,8 @@ export interface DaemonCreateSessionParams {
   /**
    * The fully-resolved child environment. Main builds this (resolveSpawnEnv:
    * buildSafeChildEnv + workspace-profile overlay + forced WMUX identity) and
-   * the daemon replays it verbatim — NOT re-filtered daemon-side, so an
-   * intentional *_KEY/*_TOKEN survives and recovery reproduces the create-time
+   * the daemon replays it verbatim — NOT re-filtered daemon-side, so any key
+   * main placed here is applied as-is and recovery reproduces the create-time
    * env. Trusted-env contract: the caller is responsible for filtering. The
    * daemon's one unconditional guard is that it strips its own WMUX_AUTH*
    * namespace from any supplied env, so its RPC token can never reach a child.

--- a/src/shared/workspaceProfile.ts
+++ b/src/shared/workspaceProfile.ts
@@ -49,17 +49,31 @@ export function isReservedEnvKey(key: string): boolean {
 }
 
 /**
- * True when `key` looks like a raw credential (e.g. *_KEY, *_TOKEN, *_SECRET).
+ * Credential-NAMED keys whose value is a PATH/reference, not a secret — the
+ * "reference over secret" pattern we actively encourage. These match the
+ * inherited-env denylist by name but must NOT be treated as raw secrets by the
+ * profile policy (dropping them would break documented cloud/SSH use cases).
+ * Compared case-insensitively.
+ */
+const SECRET_KEY_ALLOWLIST: ReadonlySet<string> = new Set([
+  'GOOGLE_APPLICATION_CREDENTIALS', // path to a service-account JSON
+  'AWS_SHARED_CREDENTIALS_FILE',    // path to an AWS credentials file
+]);
+
+/**
+ * True when `key` looks like a raw credential (e.g. *_KEY, *_TOKEN, *_SECRET)
+ * AND is not a known path-pointer (SECRET_KEY_ALLOWLIST).
  *
  * Profiles are stored in plaintext in the session file, so by policy we do NOT
- * persist secret-NAMED env vars — the supported pattern is to point at a config
- * directory (CLAUDE_CONFIG_DIR, CODEX_HOME) that holds the real credential,
- * not to paste the credential itself. `normalizeEnv` drops these keys, and the
- * editor flags them. Case-insensitive (env names are conventionally uppercase,
- * but a user might type `openai_api_key`), reusing the inherited-env denylist
- * so the two stay in lockstep.
+ * accept secret-NAMED env vars from the editor — the supported pattern is to
+ * point at a config directory/file (CLAUDE_CONFIG_DIR, CODEX_HOME,
+ * GOOGLE_APPLICATION_CREDENTIALS) that holds the real credential, not to paste
+ * the credential itself. Case-insensitive (env names are conventionally
+ * uppercase, but a user might type `openai_api_key`), reusing the inherited-env
+ * denylist so the two stay in lockstep.
  */
 export function isSecretLikeEnvKey(key: string): boolean {
+  if (SECRET_KEY_ALLOWLIST.has(key.toUpperCase())) return false;
   return isSensitiveEnvKey(key.toUpperCase());
 }
 
@@ -67,18 +81,23 @@ export function isSecretLikeEnvKey(key: string): boolean {
  * Normalize an arbitrary value into a clean env map. Invalid keys/values are
  * dropped; the result is capped at WORKSPACE_PROFILE_MAX_ENV_ENTRIES, keeping
  * the first valid entries in insertion order.
+ *
+ * `dropSecretKeys` enforces the secret-name policy. It is applied only at the
+ * editor/save boundary (setWorkspaceProfile), NOT on load: load-time
+ * sanitization must be non-destructive so an existing session.json that
+ * predates this policy keeps working until the user actively edits it (the
+ * editor then flags the key and drops it on save). Dropping on load would
+ * silently delete a user's working config without un-storing the already-
+ * persisted value.
  */
-export function normalizeEnv(input: unknown): Record<string, string> {
+export function normalizeEnv(input: unknown, dropSecretKeys = false): Record<string, string> {
   const out: Record<string, string> = {};
   if (input === null || typeof input !== 'object' || Array.isArray(input)) return out;
   let count = 0;
   for (const [rawKey, rawValue] of Object.entries(input as Record<string, unknown>)) {
     if (count >= WORKSPACE_PROFILE_MAX_ENV_ENTRIES) break;
     if (!isValidEnvKey(rawKey)) continue;
-    // Policy: never persist a secret-NAMED key in plaintext (point at a config
-    // directory instead). Dropped here so both UI-save and load-time sanitize
-    // enforce it uniformly.
-    if (isSecretLikeEnvKey(rawKey)) continue;
+    if (dropSecretKeys && isSecretLikeEnvKey(rawKey)) continue;
     if (typeof rawValue !== 'string') continue;
     if (rawValue.length > WORKSPACE_PROFILE_ENV_VALUE_MAX) continue;
     out[rawKey] = rawValue;
@@ -120,11 +139,14 @@ export function normalizeCommand(input: unknown): string | undefined {
  * result would be empty. `env` is omitted when it has no valid entries so an
  * empty profile never persists as `{ env: {} }`.
  */
-export function normalizeWorkspaceProfile(input: unknown): WorkspaceProfile | undefined {
+export function normalizeWorkspaceProfile(
+  input: unknown,
+  opts: { dropSecretKeys?: boolean } = {},
+): WorkspaceProfile | undefined {
   if (input === null || typeof input !== 'object' || Array.isArray(input)) return undefined;
   const src = input as { env?: unknown; defaultPaneCommand?: unknown };
 
-  const env = normalizeEnv(src.env);
+  const env = normalizeEnv(src.env, opts.dropSecretKeys ?? false);
   const command = normalizeCommand(src.defaultPaneCommand);
 
   const profile: WorkspaceProfile = {};


### PR DESCRIPTION
Follow-up to #101. Two corrections to the secret-name policy, surfaced by a post-merge review pass, plus two doc/comment nits.

## Fixes

**1. `GOOGLE_APPLICATION_CREDENTIALS` was being dropped (major).** It matches the `*_CREDENTIALS` denylist by name, but its value is a *path* to a service-account JSON — the "reference over secret" pattern we encourage, and it's listed as supported in `docs/workspace-profiles.md`. Added a small `SECRET_KEY_ALLOWLIST` (`GOOGLE_APPLICATION_CREDENTIALS`, `AWS_SHARED_CREDENTIALS_FILE`) so path-pointer credential vars aren't treated as raw secrets.

**2. Load-time silent data loss (major).** The policy dropped secret-named keys on both save *and* load, so a `session.json` written before #101 would silently lose a working key (or the whole profile) on next load — without un-storing the already-persisted plaintext value. The drop now applies **only at the editor/save boundary** (`setWorkspaceProfile` passes `dropSecretKeys`); load is non-destructive. A legacy key keeps working until the user re-saves the profile, at which point the editor flags it and drops it. `normalizeEnv` / `normalizeWorkspaceProfile` gained a `dropSecretKeys` flag (default `false` = preserve).

## Nits

- Docs contradicted themselves on `WMUX_SOCKET_PATH` (the mental model says daemon-mode doesn't force it; the identity bullet said it always did). Corrected: `WORKSPACE_ID`/`SURFACE_ID` in both modes, `SOCKET_PATH` local-only.
- Clarified in comments/tests that the spawn layer (`resolveSpawnEnv` / `applyProfileEnv`) applies whatever profile keys it's given — the editor policy is the layer that decides which keys may be configured. They now differ, so the old "intentional `*_KEY` survives" wording was misleading.

## Tests

`npm test` green (2157 parallel + runtime). New coverage: allowlist exemption, save-drops-but-load-preserves, and a load-time legacy-key-preserved regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)