### PR TITLE
fix(mcp): browser DOM tools read app shell instead of webview in packaged builds

### DIFF
--- a/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
@@ -42,7 +42,7 @@ describe('registerBrowserRpc', () => {
     sendToRendererMock.mockResolvedValue({ ok: true });
   });
 
-  function register(): RpcRouter {
+  function register(getWindow: () => BrowserWindow | null = () => null): RpcRouter {
     const router = new RpcRouter();
     const webviewCdpManager = {
       getTarget: vi.fn(() => ({ surfaceId: 'surface-1', webContentsId: 42, targetId: 'target-1', wsUrl: 'ws://127.0.0.1/devtools/page/target-1' })),
@@ -51,8 +51,14 @@ describe('registerBrowserRpc', () => {
       waitForTarget: vi.fn(),
     };
 
-    registerBrowserRpc(router, (() => null) as () => BrowserWindow | null, webviewCdpManager as never);
+    registerBrowserRpc(router, getWindow, webviewCdpManager as never);
     return router;
+  }
+
+  /** Build a fake main window whose webContents.getURL() returns `url`. */
+  function windowWithUrl(url: string | (() => string)): () => BrowserWindow {
+    const getURL = typeof url === 'function' ? url : () => url;
+    return () => ({ webContents: { getURL } }) as unknown as BrowserWindow;
   }
 
   it('does not expose browser.cdp.send through the RPC router', async () => {
@@ -95,10 +101,61 @@ describe('registerBrowserRpc', () => {
 
     expect(response.ok).toBe(true);
     if (response.ok) {
+      // No window (getWindow → null): shellUrl is omitted, not null.
       expect(response.result).toEqual({
         cdpPort: 18800,
         targets: [{ surfaceId: 'surface-1', targetId: 'target-1' }],
       });
+    }
+  });
+
+  it('browser.cdp.info exposes the main-window URL as shellUrl', async () => {
+    const router = register(
+      windowWithUrl('file:///x/.vite/renderer/main_window/index.html'),
+    );
+
+    const response = await router.dispatch({
+      id: '3b',
+      method: 'browser.cdp.info',
+      params: {},
+    });
+
+    expect(response.ok).toBe(true);
+    if (response.ok) {
+      expect(response.result).toMatchObject({
+        cdpPort: 18800,
+        shellUrl: 'file:///x/.vite/renderer/main_window/index.html',
+      });
+    }
+  });
+
+  it('browser.cdp.info omits shellUrl when the URL is empty (mid-load)', async () => {
+    const router = register(windowWithUrl(''));
+
+    const response = await router.dispatch({
+      id: '3c',
+      method: 'browser.cdp.info',
+      params: {},
+    });
+
+    expect(response.ok).toBe(true);
+    if (response.ok) {
+      expect(response.result).not.toHaveProperty('shellUrl');
+    }
+  });
+
+  it('browser.cdp.info omits shellUrl when getURL throws (window destroyed)', async () => {
+    const router = register(windowWithUrl(() => { throw new Error('destroyed'); }));
+
+    const response = await router.dispatch({
+      id: '3d',
+      method: 'browser.cdp.info',
+      params: {},
+    });
+
+    expect(response.ok).toBe(true);
+    if (response.ok) {
+      expect(response.result).not.toHaveProperty('shellUrl');
     }
   });
 

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -246,8 +246,22 @@ export function registerBrowserRpc(router: RpcRouter, getWindow: GetWindow, webv
     }
 
     const cdpPort: number = webviewCdpManager.getCdpPort();
+
+    // Expose the actual runtime URL of the main-window webContents (the app
+    // shell) so the Playwright engine can recognize the shell by exact-match
+    // instead of guessing from build-path shape. dev → http://localhost:..,
+    // packaged → file:///.../.vite/renderer/main_window/index.html. The guest
+    // <webview> is a separate webContents and never appears here. Suppress an
+    // empty URL (window still mid-load) so the engine keeps any prior value.
+    let shellUrl: string | undefined;
+    try {
+      const url = getWindow()?.webContents.getURL();
+      if (url && url.length > 0) shellUrl = url;
+    } catch { /* window destroyed — omit shellUrl */ }
+
     return {
       cdpPort,
+      ...(shellUrl && { shellUrl }),
       targets: targets.map((t) => ({
         surfaceId: t.surfaceId,
         targetId: t.targetId,

--- a/src/mcp/playwright/PlaywrightEngine.ts
+++ b/src/mcp/playwright/PlaywrightEngine.ts
@@ -10,6 +10,14 @@ interface CdpTargetInfo {
 
 interface CdpInfoResponse {
   cdpPort: number;
+  /**
+   * The actual runtime URL of the main-window webContents (the app shell),
+   * as reported by the main process. Optional: absent on older mains or when
+   * the window is mid-load (empty URL is suppressed). When present it is the
+   * authoritative shell identifier; when absent we fall back to the static
+   * isElectronShellUrl() heuristic. See browser.cdp.info handler.
+   */
+  shellUrl?: string;
   targets: CdpTargetInfo[];
 }
 
@@ -23,15 +31,65 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Returns true if the URL belongs to the Electron main renderer window.
+ * Returns true if the URL belongs to the Electron main renderer window
+ * (the wmux app shell), which must never be mistaken for a guest <webview>
+ * page when discovering the page to drive.
+ *
+ * Two shapes exist depending on build:
+ *  - dev:       the Vite dev server, e.g. http://localhost:5173/ (or 127.0.0.1)
+ *  - packaged:  loadFile() of the bundled renderer, i.e. a file:// URL ending
+ *               in `.../renderer/main_window/index.html` (see
+ *               src/main/window/createWindow.ts loadMainRenderer + the
+ *               `main_window` renderer entry in forge.config.ts).
+ *
+ * The packaged file:// shell was previously NOT excluded, so getPage()'s
+ * "first non-shell page" heuristic returned the app shell instead of the real
+ * page DOM. We match ONLY the app's own renderer entry path so that a
+ * legitimate user-opened file:// page (the thing being browsed) is still
+ * reachable.
  */
-function isElectronShellUrl(url: string): boolean {
-  return (
+export function isElectronShellUrl(url: string): boolean {
+  if (
     url.startsWith('http://localhost:') ||
     url.startsWith('http://127.0.0.1:') ||
     url.startsWith('devtools://') ||
     url.startsWith('chrome://')
-  );
+  ) {
+    return true;
+  }
+  if (url.startsWith('file://')) {
+    return isAppShellFileUrl(url);
+  }
+  return false;
+}
+
+/**
+ * Matches the packaged app shell's renderer entry.
+ *
+ * The shell is loaded via `loadFile(path.join(__dirname, '../renderer/
+ * main_window/index.html'))` (src/main/window/createWindow.ts). In a packaged
+ * build `__dirname` is `.vite/build`, so the resulting file path always ends
+ * with `.vite/renderer/main_window/index.html` (forge's `main_window`
+ * renderer entry). asar packaging only prepends `.../app.asar/` to that, so
+ * the `.vite/renderer/main_window/index.html` suffix is the stable, specific
+ * identifier.
+ *
+ * We deliberately require the `.vite/renderer/` segment rather than just
+ * `main_window/index.html`: a user could legitimately open their OWN project's
+ * `file:///.../main_window/index.html` as the page being browsed, and that
+ * must stay drivable. Only wmux's own build-output layout is excluded.
+ */
+function isAppShellFileUrl(url: string): boolean {
+  let pathname: string;
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    // Fall back to the raw URL minus any query/hash if URL parsing fails.
+    pathname = url.split(/[?#]/)[0];
+  }
+  // Normalize Windows backslashes that may survive the raw-URL fallback.
+  pathname = pathname.replace(/\\/g, '/');
+  return /\.vite\/renderer\/main_window\/index\.html$/i.test(pathname);
 }
 
 /**
@@ -57,6 +115,14 @@ export class PlaywrightEngine {
    * Playwright's internal connection map and leak memory over time.
    */
   private autoAttachSession: CDPSession | null = null;
+  /**
+   * The actual runtime URL of the app-shell main window, as reported by the
+   * main process via browser.cdp.info (`shellUrl`). When set, this is the
+   * authoritative way to recognize the shell page — exact-match against a
+   * page's URL — so getPage() never has to guess from build-path shape.
+   * Refreshed on every browser.cdp.info response and cleared on disconnect.
+   */
+  private shellUrl: string | null = null;
 
   private constructor() {}
 
@@ -65,6 +131,35 @@ export class PlaywrightEngine {
       PlaywrightEngine.instance = new PlaywrightEngine();
     }
     return PlaywrightEngine.instance;
+  }
+
+  /**
+   * Update the cached app-shell URL from a browser.cdp.info response. Ignores
+   * empty/missing values so a window that is still mid-load (empty getURL())
+   * doesn't clobber a previously-known good shell URL.
+   */
+  private cacheShellUrl(info: CdpInfoResponse): void {
+    if (info.shellUrl && info.shellUrl.length > 0) {
+      this.shellUrl = info.shellUrl;
+    }
+  }
+
+  /**
+   * Returns true if `url` is the wmux app shell (the main renderer window),
+   * which must never be returned as the page-to-drive.
+   *
+   * Primary signal: exact-match against the runtime shell URL reported by the
+   * main process (this.shellUrl). This reflects the real loaded document, so
+   * it is immune to build-tool/forge path changes.
+   *
+   * Defense-in-depth fallback: when the runtime URL hasn't been obtained yet
+   * (older main, or a mid-load race), fall back to the static
+   * isElectronShellUrl() heuristic so a shell page is still never mistaken
+   * for the guest webview.
+   */
+  private isShellPage(url: string): boolean {
+    if (this.shellUrl && url === this.shellUrl) return true;
+    return isElectronShellUrl(url);
   }
 
   async connect(cdpPort: number): Promise<void> {
@@ -99,6 +194,9 @@ export class PlaywrightEngine {
     this.browser = null;
     this.cdpPort = null;
     this.autoAttachSession = null;
+    // Drop the cached shell URL — a reconnect may target a different window
+    // (different port) whose shell URL must be re-fetched, not reused.
+    this.shellUrl = null;
     if (s) {
       await s.detach().catch(() => { /* session may already be gone */ });
     }
@@ -117,6 +215,7 @@ export class PlaywrightEngine {
     for (let attempt = 1; attempt <= MAX_CONNECT_RETRIES; attempt++) {
       try {
         const info = (await sendRpc('browser.cdp.info')) as CdpInfoResponse;
+        this.cacheShellUrl(info);
         await this.connect(info.cdpPort);
         return;
       } catch (err) {
@@ -195,20 +294,27 @@ export class PlaywrightEngine {
 
     for (let attempt = 1; attempt <= PAGE_FIND_RETRIES; attempt++) {
       try {
-        // Strategy 1: Check existing pages
-        const allPages = this.getAllPages();
-        console.error(`[PlaywrightEngine] Attempt ${attempt}: ${allPages.length} pages in ${this.browser?.contexts().length ?? 0} contexts`);
-
-        const safePage = allPages.find((p) => !isElectronShellUrl(p.url()));
-        if (safePage) {
-          console.error(`[PlaywrightEngine] Found page via contexts: ${safePage.url()}`);
-          return safePage;
-        }
-
-        // Strategy 2: Use CDP Target.getTargets to find webview targets
+        // Strategy 1 (was 2): positive identification via the registered
+        // targetId from WebviewCdpManager. This is the authoritative match —
+        // it pins the exact guest webview by id — so it runs FIRST, before the
+        // negative "any non-shell page" heuristic, to avoid ever returning the
+        // shell when the shell happens to slip past URL classification.
         if (this.browser) {
           const page = await this.findViaTargetDomain(surfaceId);
           if (page) return page;
+        }
+
+        // Strategy 2 (was 1): fall back to the first existing page that isn't
+        // the app shell. Used when positive targetId matching didn't yield a
+        // page (e.g. target not registered yet). isShellPage() prefers the
+        // runtime shell URL and falls back to the static heuristic.
+        const allPages = this.getAllPages();
+        console.error(`[PlaywrightEngine] Attempt ${attempt}: ${allPages.length} pages in ${this.browser?.contexts().length ?? 0} contexts`);
+
+        const safePage = allPages.find((p) => !this.isShellPage(p.url()));
+        if (safePage) {
+          console.error(`[PlaywrightEngine] Found page via contexts: ${safePage.url()}`);
+          return safePage;
         }
 
         // Strategy 3: Use /json endpoint + match registered targets
@@ -300,6 +406,7 @@ export class PlaywrightEngine {
 
         // Get registered wmux targets for matching
         const info = (await sendRpc('browser.cdp.info')) as CdpInfoResponse;
+        this.cacheShellUrl(info);
         const wmuxTarget = surfaceId
           ? info.targets.find((t) => t.surfaceId === surfaceId)
           : info.targets[0];
@@ -312,7 +419,7 @@ export class PlaywrightEngine {
         // Fallback: find any page target that isn't the Electron shell
         if (!webviewTarget) {
           webviewTarget = targetInfos.find(
-            (t) => t.type === 'page' && !isElectronShellUrl(t.url) && t.url !== 'about:blank',
+            (t) => t.type === 'page' && !this.isShellPage(t.url) && t.url !== 'about:blank',
           );
         }
 
@@ -338,7 +445,7 @@ export class PlaywrightEngine {
         const newPages = this.getAllPages();
         console.error(`[PlaywrightEngine] After attach: ${newPages.length} pages`);
 
-        const matchedPage = newPages.find((p) => !isElectronShellUrl(p.url()));
+        const matchedPage = newPages.find((p) => !this.isShellPage(p.url()));
         if (matchedPage) {
           console.error(`[PlaywrightEngine] Found page after attach: ${matchedPage.url()}`);
           return matchedPage;
@@ -379,6 +486,7 @@ export class PlaywrightEngine {
 
       // Get registered wmux targets
       const info = (await sendRpc('browser.cdp.info')) as CdpInfoResponse;
+      this.cacheShellUrl(info);
       const wmuxTarget = surfaceId
         ? info.targets.find((t) => t.surfaceId === surfaceId)
         : info.targets[0];
@@ -390,7 +498,7 @@ export class PlaywrightEngine {
 
       if (!jsonTarget) {
         jsonTarget = targets.find(
-          (t) => t.type === 'page' && !isElectronShellUrl(t.url) && t.url !== 'about:blank',
+          (t) => t.type === 'page' && !this.isShellPage(t.url) && t.url !== 'about:blank',
         );
       }
 
@@ -421,7 +529,7 @@ export class PlaywrightEngine {
         const pages = this.getAllPages();
         console.error(`[PlaywrightEngine] After /json attach: ${pages.length} pages`);
 
-        const matchedPage = pages.find((p) => !isElectronShellUrl(p.url()));
+        const matchedPage = pages.find((p) => !this.isShellPage(p.url()));
         if (matchedPage) {
           console.error(`[PlaywrightEngine] Found page via /json attach: ${matchedPage.url()}`);
           return matchedPage;

--- a/src/mcp/playwright/__tests__/PlaywrightEngine.test.ts
+++ b/src/mcp/playwright/__tests__/PlaywrightEngine.test.ts
@@ -15,7 +15,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  */
 
 const mockSendRpc = vi.fn();
-vi.mock('../wmux-client', () => ({
+// NOTE: path is relative to THIS test file. PlaywrightEngine.ts lives one
+// directory up and imports '../wmux-client' (= src/mcp/wmux-client), so from
+// src/mcp/playwright/__tests__/ the same module is '../../wmux-client'. The
+// previous '../wmux-client' resolved to a non-existent module and silently
+// failed to mock sendRpc — only unnoticed because earlier tests never drove a
+// code path that called it.
+vi.mock('../../wmux-client', () => ({
   sendRpc: (...args: unknown[]) => mockSendRpc(...args),
 }));
 
@@ -27,7 +33,81 @@ vi.mock('playwright-core', () => ({
 }));
 
 // Import after mocks are declared.
-import { PlaywrightEngine } from '../PlaywrightEngine';
+import { PlaywrightEngine, isElectronShellUrl } from '../PlaywrightEngine';
+
+/*
+ * Regression tests for app-shell URL detection.
+ *
+ * Background: getPage() picks the "first page whose URL is not the Electron
+ * shell" as the page to drive. In packaged builds the main window is loaded
+ * via loadFile() of the bundled renderer, producing a file:// URL ending in
+ * `.../renderer/main_window/index.html`. The original isElectronShellUrl()
+ * only excluded http://localhost, http://127.0.0.1, devtools://, chrome:// —
+ * so the packaged file:// shell slipped through and was returned instead of
+ * the real <webview> page. Dev builds (Vite dev server on http://localhost)
+ * were unaffected, which is why the bug only reproduced in production.
+ */
+describe('isElectronShellUrl', () => {
+  it('treats the dev-server shell origins as the shell', () => {
+    expect(isElectronShellUrl('http://localhost:5173/')).toBe(true);
+    expect(isElectronShellUrl('http://127.0.0.1:5173/index.html')).toBe(true);
+    expect(isElectronShellUrl('devtools://devtools/bundled/inspector.html')).toBe(true);
+    expect(isElectronShellUrl('chrome://gpu/')).toBe(true);
+  });
+
+  it('treats the packaged file:// renderer entry as the shell', () => {
+    // Windows asar-packed path with a percent-encoded directory.
+    expect(
+      isElectronShellUrl(
+        'file:///C:/Program%20Files/wmux/resources/app.asar/.vite/renderer/main_window/index.html',
+      ),
+    ).toBe(true);
+    // POSIX asar-packed path.
+    expect(
+      isElectronShellUrl('file:///opt/wmux/resources/app.asar/.vite/renderer/main_window/index.html'),
+    ).toBe(true);
+    // Unpacked (asar disabled) packaged path.
+    expect(
+      isElectronShellUrl('file:///opt/wmux/resources/app/.vite/renderer/main_window/index.html'),
+    ).toBe(true);
+    // Tolerate a trailing query/hash appended by the renderer.
+    expect(
+      isElectronShellUrl('file:///x/.vite/renderer/main_window/index.html?foo=1#bar'),
+    ).toBe(true);
+    // Case-insensitive (Windows filesystems are case-insensitive).
+    expect(
+      isElectronShellUrl('file:///X/.vite/renderer/main_window/INDEX.HTML'),
+    ).toBe(true);
+  });
+
+  it('does NOT misclassify a user project that merely ends in main_window/index.html', () => {
+    // The key false-positive risk: a user opening their OWN project's
+    // main_window/index.html as the page being browsed. Without the
+    // `.vite/renderer/` qualifier this would be dropped as the app shell.
+    expect(isElectronShellUrl('file:///C:/myproj/main_window/index.html')).toBe(false);
+    expect(isElectronShellUrl('file:///home/user/app/src/main_window/index.html')).toBe(false);
+    // Even a renderer/main_window/index.html without the `.vite` segment is a
+    // user page, not wmux's build output.
+    expect(isElectronShellUrl('file:///home/user/renderer/main_window/index.html')).toBe(false);
+  });
+
+  it('does NOT exclude other legitimate user-opened file:// pages', () => {
+    expect(isElectronShellUrl('file:///home/user/report.html')).toBe(false);
+    expect(isElectronShellUrl('file:///C:/docs/index.html')).toBe(false);
+    expect(isElectronShellUrl('file:///some/other_window/index.html')).toBe(false);
+    // A directory URL (trailing slash) is not the shell entry file.
+    expect(isElectronShellUrl('file:///x/.vite/renderer/main_window/')).toBe(false);
+  });
+
+  it('does NOT exclude real remote page URLs', () => {
+    // A remote page that coincidentally mirrors the shell path is still a page.
+    expect(
+      isElectronShellUrl('https://example.com/.vite/renderer/main_window/index.html'),
+    ).toBe(false);
+    expect(isElectronShellUrl('https://example.com/')).toBe(false);
+    expect(isElectronShellUrl('about:blank')).toBe(false);
+  });
+});
 
 interface FakeSession {
   send: ReturnType<typeof vi.fn>;
@@ -118,5 +198,140 @@ describe('PlaywrightEngine CDP session lifecycle', () => {
 
     await expect(engine.disconnect()).resolves.toBeUndefined();
     expect(sessions[0].detach).toHaveBeenCalledTimes(1);
+  });
+});
+
+/*
+ * Tests for the runtime shell-URL hardening (Option B + reorder).
+ *
+ * The engine learns the app shell's real URL from the browser.cdp.info RPC
+ * (`shellUrl`) and uses an exact-match against it to recognize the shell —
+ * instead of guessing from build-path shape. The static isElectronShellUrl()
+ * heuristic remains as a defense-in-depth fallback for when the runtime URL
+ * isn't available yet. getPage() also tries positive targetId matching before
+ * the negative "first non-shell page" filter so it never returns the shell.
+ */
+
+// Minimal access to the engine's private shell-URL surface for unit testing.
+interface ShellUrlInternals {
+  shellUrl: string | null;
+  cacheShellUrl(info: { cdpPort: number; shellUrl?: string; targets: unknown[] }): void;
+  isShellPage(url: string): boolean;
+}
+function priv(engine: PlaywrightEngine): ShellUrlInternals {
+  return engine as unknown as ShellUrlInternals;
+}
+
+interface FakePage {
+  url: ReturnType<typeof vi.fn>;
+  context: ReturnType<typeof vi.fn>;
+}
+
+describe('PlaywrightEngine runtime shell-URL handling (B)', () => {
+  beforeEach(() => {
+    (PlaywrightEngine as unknown as { instance: PlaywrightEngine | null }).instance = null;
+    mockSendRpc.mockReset();
+    mockConnectOverCDP.mockReset();
+  });
+
+  it('caches shellUrl from cdp.info and exact-matches it as the shell', () => {
+    const engine = PlaywrightEngine.getInstance();
+    priv(engine).cacheShellUrl({ cdpPort: 1, shellUrl: 'https://app.internal/shell', targets: [] });
+
+    expect(priv(engine).shellUrl).toBe('https://app.internal/shell');
+    expect(priv(engine).isShellPage('https://app.internal/shell')).toBe(true);
+    // A different page (the real webview) is NOT the shell.
+    expect(priv(engine).isShellPage('https://example.com/page')).toBe(false);
+  });
+
+  it('ignores empty/missing shellUrl so a known-good value is not clobbered', () => {
+    const engine = PlaywrightEngine.getInstance();
+    const good = 'file:///real/.vite/renderer/main_window/index.html';
+    priv(engine).cacheShellUrl({ cdpPort: 1, shellUrl: good, targets: [] });
+    priv(engine).cacheShellUrl({ cdpPort: 1, targets: [] });            // missing
+    priv(engine).cacheShellUrl({ cdpPort: 1, shellUrl: '', targets: [] }); // empty
+
+    expect(priv(engine).shellUrl).toBe(good);
+  });
+
+  it('falls back to the static heuristic when no runtime shellUrl is known', () => {
+    const engine = PlaywrightEngine.getInstance();
+    expect(priv(engine).shellUrl).toBeNull();
+
+    // Heuristic still catches the packaged + dev shell shapes...
+    expect(priv(engine).isShellPage('file:///x/.vite/renderer/main_window/index.html')).toBe(true);
+    expect(priv(engine).isShellPage('http://localhost:5173/')).toBe(true);
+    // ...but does not over-exclude a user-opened file:// page.
+    expect(priv(engine).isShellPage('file:///home/user/main_window/index.html')).toBe(false);
+  });
+
+  it('exact-match excludes only the shell, even for a dev-server shell URL', () => {
+    const engine = PlaywrightEngine.getInstance();
+    priv(engine).cacheShellUrl({ cdpPort: 1, shellUrl: 'http://localhost:5173/', targets: [] });
+
+    expect(priv(engine).isShellPage('http://localhost:5173/')).toBe(true);
+    // A real remote webview is reachable.
+    expect(priv(engine).isShellPage('https://example.com/')).toBe(false);
+  });
+
+  it('clears the cached shellUrl on disconnect', async () => {
+    const sessions: FakeSession[] = [];
+    mockConnectOverCDP.mockResolvedValue(makeFakeBrowser(sessions));
+
+    const engine = PlaywrightEngine.getInstance();
+    await engine.connect(9222);
+    priv(engine).cacheShellUrl({ cdpPort: 9222, shellUrl: 'file:///x/.vite/renderer/main_window/index.html', targets: [] });
+    expect(priv(engine).shellUrl).not.toBeNull();
+
+    await engine.disconnect();
+    expect(priv(engine).shellUrl).toBeNull();
+  });
+
+  it('getPage returns the guest webview, not the exact-match app shell', async () => {
+    const shellUrl = 'file:///app/.vite/renderer/main_window/index.html';
+
+    const makePage = (u: string): FakePage => {
+      const page: FakePage = {
+        url: vi.fn().mockReturnValue(u),
+        context: vi.fn(),
+      };
+      return page;
+    };
+    const shellPage = makePage(shellUrl);
+    const webviewPage = makePage('https://example.com/');
+
+    // A context whose pages() exposes both the shell and the webview.
+    const ctx = {
+      pages: vi.fn().mockReturnValue([shellPage, webviewPage]),
+      newCDPSession: vi.fn().mockImplementation(async () => makeFakeSession()),
+    };
+    shellPage.context.mockReturnValue(ctx);
+    webviewPage.context.mockReturnValue(ctx);
+
+    const browser = {
+      isConnected: vi.fn().mockReturnValue(true),
+      newBrowserCDPSession: vi.fn().mockImplementation(async () => makeFakeSession()),
+      contexts: vi.fn().mockReturnValue([ctx]),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    mockConnectOverCDP.mockResolvedValue(browser);
+
+    // cdp.info advertises the shell URL and no registered webview target, so
+    // positive targetId matching yields nothing and the negative filter runs —
+    // which must skip the exact-match shell page and pick the webview.
+    mockSendRpc.mockImplementation((method: string) => {
+      if (method === 'browser.cdp.info') {
+        return Promise.resolve({ cdpPort: 9222, shellUrl, targets: [] });
+      }
+      return Promise.resolve({});
+    });
+
+    const engine = PlaywrightEngine.getInstance();
+    await engine.connect(9222);
+
+    const page = await engine.getPage();
+    expect(page).toBe(webviewPage);
+    // The shell URL was learned from cdp.info during discovery.
+    expect(priv(engine).shellUrl).toBe(shellUrl);
   });
 });


### PR DESCRIPTION
## Summary

In packaged (production) builds, the MCP browser DOM tools
(`browser_evaluate` / `browser_snapshot` / `browser_extract_text` /
`browser_smart_snapshot`) read the wmux **app shell** (main window) DOM instead
of the embedded `<webview>`'s real page DOM, so page content extraction
silently failed. Dev builds were unaffected. Root cause: `PlaywrightEngine`
recognized the shell only by dev-server/devtools/chrome URLs, so the packaged
shell — a `file:///.../.vite/renderer/main_window/index.html` URL — slipped
past `getPage()`'s "first non-shell page" filter and was returned as if it were
the webview. (`navigate`/`screenshot` were fine because they go through the
`webviewCdpManager` RPC path, which targets the guest `webContentsId`
directly.)

This PR hardens shell detection using the main process's **actual runtime shell
URL** and reorders `getPage()` to prefer **positive** webview identification
(registered `targetId`) over URL-based negative filtering.

## Changes

- **`browser.cdp.info` (main, `browser.rpc.ts`)**: expose an optional
  `shellUrl` = `getWindow().webContents.getURL()` — the real main-window URL
  (dev: `http://localhost…`, packaged:
  `file:///.../.vite/renderer/main_window/index.html`). Empty (mid-load) or
  throwing (window destroyed) URLs are omitted so the engine keeps any prior
  value. The guest `<webview>` is a separate `webContents` and never appears
  here.
- **`PlaywrightEngine.ts`**:
  - Cache `shellUrl` from every `browser.cdp.info` response; clear on
    `disconnect()`.
  - New `isShellPage()` — exact-match against the runtime `shellUrl`, with the
    static `isElectronShellUrl()` heuristic retained as a **secondary
    defense-in-depth fallback** when the runtime URL isn't known yet. All four
    negative-filter sites now route through `isShellPage()`.
  - `getPage()` reorder: run `findViaTargetDomain()` (positive `targetId`
    match) **before** the "first non-shell page" filter, so the shell is never
    returned when a registered target exists.
  - The static `file://` heuristic itself was narrowed earlier in this branch
    to `.vite/renderer/main_window/index.html` so a user-opened
    `…/main_window/index.html` page stays drivable.
- **Tests**: +9 cases across `PlaywrightEngine.test.ts` (shellUrl
  caching/exact-match, empty-ignore, heuristic fallback, dev-shell,
  disconnect-reset, and a `getPage()` integration test that returns the webview
  not the shell) and `browser.rpc.test.ts` (shellUrl exposed / omitted on
  empty / omitted on throw). Also fixes a latent test-mock path bug:
  `vi.mock('../wmux-client')` resolved to a non-existent module from the
  `__tests__/` dir → corrected to `'../../wmux-client'` (previously unnoticed
  because no prior test drove a `getPage()` path that calls `sendRpc`).

## CHANGELOG entry

### Fixed

- MCP browser DOM tools (`browser_evaluate`, `browser_snapshot`,
  `browser_extract_text`, `browser_smart_snapshot`) now read the embedded
  page's DOM instead of the wmux app-shell DOM in packaged builds.

## Stability tier impact

- [x] Change to an `experimental` surface (note in release notes).

`browser.cdp.info` is classified `experimental` in `docs/api/inventory.md`
(line 111). The change is additive — a new optional `shellUrl` field on the
response — and backward compatible (older engines ignore it; the field is
omitted when unavailable).

## Substrate contract impact (Substrate 3.0)

New optional field on an existing experimental RPC response (`browser.cdp.info`
→ `shellUrl`). No change to PaneMetadata, EventBus, permission enforcement
(`browser.read` gate unchanged), or Named Pipe security. No new RPC method or
event type. `docs/api/inventory.md` already lists `browser.cdp.info` with a
"various" shape; an explicit field note there is an optional follow-up since
the surface is experimental.

## Test plan

- **Unit/integration tests added (+9)**:
  - `src/mcp/playwright/__tests__/PlaywrightEngine.test.ts` — shellUrl
    cache/exact-match, empty/missing ignore, heuristic fallback, dev-server
    shell, disconnect reset, and `getPage()` returns the webview over the
    exact-match shell.
  - `src/main/pipe/handlers/__tests__/browser.rpc.test.ts` — `shellUrl` exposed
    from `getURL()`; omitted when empty (mid-load) or when `getURL()` throws
    (destroyed).
- **Full suite**: `npx vitest run` → **2081 passed / 1 failed (2082 total)**.
  The single failure is environment-specific (see Reviewer notes), not a
  regression.
- **Typecheck/build**: `tsc -p tsconfig.mcp.json --noEmit` ✅, `npm run
  build:mcp` ✅.
- **Lint (changed files)**: no new issues. Two pre-existing warnings/errors in
  `PlaywrightEngine.ts` (`BrowserContext` unused import, empty constructor)
  predate this branch and are unrelated.
- **Manual verification**: not run in a packaged build this cycle (see
  Limitations). The fix is covered by the unit/integration tests above.

## Related issues / PRs

n/a

## Reviewer checklist

- [x] CHANGELOG entry above is filled in.
- [x] Stability tier impact is correctly classified (experimental, additive).
- [x] Substrate contract docs: experimental surface; inventory note optional
      follow-up.
- [x] Tests cover the new behavior and the regression case.
- [x] No secrets/tokens/.env/large binaries committed.

---

### Reviewer notes (limitations, risks, trade-offs)

**Limitations**
- No packaged-build manual verification this cycle; correctness rests on the
  unit/integration tests. A quick prod smoke test (`browser_extract_text` on a
  real page) before/after is the highest-value manual check if a reviewer can
  run it.
- The extraction tools (`smart_snapshot`/`extract_text`/`extract_data`) still
  have **no RPC fallback** — they depend on `getPage()` returning the real
  webview. This PR makes that reliable but does not add a fallback for them
  (that was the larger "route DOM tools through `browser.rpc`" option, scoped
  out to avoid reimplementing extraction as injected JS and losing Playwright
  features).

**Risks / trade-offs**
- **Extra CDP round-trip on the common path**: `getPage()` now runs
  `findViaTargetDomain()` (which issues `Target.getTargets` + a
  `browser.cdp.info` RPC) *before* the cheap in-memory page filter. This adds a
  small, bounded latency to the hot path in exchange for never returning the
  shell. The negative filter remains as the immediate next step, so behavior
  degrades gracefully if positive matching yields nothing.
- **`shellUrl` exact-match depends on the runtime URL**: if the main process
  doesn't supply it (older main, or `getURL()` empty mid-load), detection falls
  back to the static `file://` heuristic (A). This is intentional
  defense-in-depth — two independent mechanisms must both fail to regress — but
  it does mean the exact-match guarantee is "best-effort, with a heuristic
  floor."
- **Heuristic floor is still build-path-coupled**: the retained `A` fallback
  matches `.vite/renderer/main_window/index.html`. If forge/vite output layout
  changes *and* the runtime `shellUrl` is simultaneously unavailable, the
  fallback could go stale — but the primary runtime-URL path is immune to that,
  so this only matters in the double-failure case.

**Environment-specific test failure (not a regression)**
- The one failing test is `src/shared/__tests__/security.test.ts >
  secureWriteTokenFile`. It fails because this dev machine's `USERNAME` is
  **non-ASCII (Korean)**, which the token-file ACL hardening (commit #90)
  deliberately refuses. Verified via `git stash` that it fails identically on
  `main` without this branch's changes — so it is pre-existing and unrelated to
  this PR. CI (ASCII runner usernames) should be green.