### PR TITLE
fix(mcp): RPC fallback for browser extraction/snapshot tools in packaged builds (#105)

### DIFF
--- a/plans/issue-105-browser-extraction-rpc-fallback.md
+++ b/plans/issue-105-browser-extraction-rpc-fallback.md
@@ -1,0 +1,288 @@
+# Issue #105 — Browser extraction/snapshot tools: RPC fallback for packaged builds
+
+**Status:** PLAN (pre-implementation)
+**Base:** `origin/main` @ `2808f38` (includes #104)
+**Branch:** `fix/mcp-browser-extraction-rpc-fallback`
+
+## Problem
+
+In a packaged build, `connectOverCDP` (playwright-core) does not surface the
+Electron `<webview>` guest as a Playwright `Page`. After #104 made
+`PlaywrightEngine.getPage()` correctly refuse the app shell, the affected tools
+get `null` from `getPage()` and — having **no fallback** — throw
+`No browser page available`. Before #104 they silently returned the shell's DOM,
+so the breakage was masked. #104 made the failure honest; #105 makes the tools
+actually work.
+
+`browser_evaluate`, `browser_snapshot`, and `browser_screenshot` already keep
+working because they fall back to `sendRpc('browser.evaluate' | 'browser.screenshot')`,
+which drives the guest `webContents` directly in the main process
+(`browser.rpc.ts`). The RPC route reaches the webview fine; the Playwright-`Page`
+route doesn't.
+
+## Affected tools (current `getPage()`-only, no fallback → throw)
+
+| Tool | File | In-page work | Reroutable via `browser.evaluate`? |
+|---|---|---|---|
+| `browser_extract_text` | extraction.ts | `extractMarkdown` → `page.evaluate(<string>)` returns JSON tree, converted in Node | **Yes, cleanly** — script is already a string |
+| `browser_extract_data` | extraction.ts | `extractStructuredData` → 3× `page.evaluate(fn, {fieldNames})`, pure DOM, JSON return | **Yes** — wrap fn+arg as a string expression |
+| `browser_smart_snapshot` | extraction.ts | `getSmartSnapshot` → CDP `Accessibility.getFullAXTree` + `innerText` | **Partial** — AX tree needs CDP; use DOM-based fallback over evaluate |
+| `browser_highlight` | inspection.ts | `resolveRef` + `el.evaluate(style=...)` | **Yes** — resolve via `[data-wmux-ref]`, set style |
+| `browser_console` | inspection.ts | `page.on('console')` streaming listener | **No** — needs main-process CDP event capture (out of scope) |
+| `browser_network` | inspection.ts | `page.on('request'/'response')` streaming listener | **No** — same (out of scope) |
+| `browser_response_body` | inspection.ts | depends on network listener buffer | **No** — same (out of scope) |
+
+`browser_snapshot` / `browser_screenshot` / `browser_evaluate` already have
+fallbacks → **untouched**.
+
+## Goals
+
+1. `browser_extract_text`, `browser_extract_data`, `browser_smart_snapshot`,
+   `browser_highlight` work in packaged builds (page-null path) by rerouting
+   through the proven `browser.evaluate` RPC channel.
+2. **Zero behavior change on the Playwright path** (dev / when `getPage()`
+   returns a real page). Extraction output must be byte-identical.
+3. No new RPC method, no new IPC surface, no new permission gate — reuse
+   `browser.evaluate` (already classified, already proven in packaged builds via
+   `browser_evaluate`).
+4. RPC-mode refs stay consistent with the existing `data-wmux-ref` system so
+   `browser_click` / `browser_type` etc. resolve smart-snapshot refs.
+
+## Non-goals (explicitly out of scope, documented as follow-up)
+
+- `browser_console`, `browser_network`, `browser_response_body`. These rely on
+  Playwright's **event-subscription** model (`page.on(...)`). A one-shot
+  `browser.evaluate` cannot stream console/network events. Supporting them in
+  packaged builds requires a **main-process CDP event-capture subsystem**
+  (`Runtime.consoleAPICalled`, `Network.*` listeners buffered on the guest
+  `webContents`, drained via new RPC) — a separate feature, not "the same
+  fallback evaluate has." They keep their current honest error in RPC mode.
+  → File as follow-up issue after #105.
+
+## Design
+
+### Decisions locked (eng review, 2026-06-05)
+
+1. **console/network/response_body → OUT** + file a follow-up issue. They need a
+   main-process CDP event-capture subsystem (an ocean, not a lake).
+2. **smart_snapshot ref consistency → share the selector constant (option c).**
+   Extract the interactive-element selector into a shared
+   `INTERACTIVE_SELECTOR` constant; both `browser_snapshot`'s fallback script
+   and `getSmartSnapshotViaEval` use it (plus the same `.slice(0,100)` cap and
+   `data-wmux-ref=<i>` tagging convention) so the two tools assign identical ref
+   indices in RPC mode. `browser_snapshot`'s output stays byte-identical (only
+   the inline selector string is replaced by the constant).
+3. **extract_data → keep the Playwright path native (option b).** dev path stays
+   `page.evaluate(fn, arg)` (zero behavior change, risk isolated); only the RPC
+   fallback stringifies via `(${fn.toString()})(${JSON.stringify(arg)})`
+   (`.toString()` verified safe: `build-mcp.js` esbuild has no `minify`, and the
+   3 functions reference only browser globals + their arg).
+
+### Core abstractions — `src/mcp/playwright/page-eval.ts` (NEW)
+
+Two small transport helpers, both genuinely used:
+
+```ts
+export type JsonEvaluator = (expression: string) => Promise<unknown>;
+
+export function pageEvaluator(page: Page): JsonEvaluator {
+  return (expression) => page.evaluate(expression);   // page.evaluate(string)
+}
+export function rpcEvaluator(surfaceId?: string): JsonEvaluator {
+  return async (expression) => {
+    const r = await sendRpc('browser.evaluate', {
+      expression, ...(surfaceId && { surfaceId }),
+    }) as { value: unknown };
+    return r.value;
+  };
+}
+/** String-script tools (extract_text, smart_snapshot RPC path). Playwright
+ *  page if available, else RPC. extract_text's dev path was ALREADY string-based
+ *  (buildSerialiseScript), so this is a zero-behavior-change unification. */
+export async function resolveEvaluator(
+  engine: PlaywrightEngine, surfaceId?: string,
+): Promise<JsonEvaluator> {
+  const page = await engine.getPage(surfaceId).catch(() => null);
+  return page ? pageEvaluator(page) : rpcEvaluator(surfaceId);
+}
+
+/** Function+arg tools (extract_data, decision b): native page.evaluate(fn,arg)
+ *  when a page exists, else stringify the fn for the RPC channel. */
+export async function evalFunctionOrRpc<A, R>(
+  page: Page | null, fn: (arg: A) => R, arg: A, surfaceId?: string,
+): Promise<R> {
+  if (page) return (await page.evaluate(fn, arg)) as R;
+  const expression = `(${fn.toString()})(${JSON.stringify(arg)})`;
+  const r = await sendRpc('browser.evaluate', {
+    expression, ...(surfaceId && { surfaceId }),
+  }) as { value: R };
+  return r.value;
+}
+```
+
+### Per-tool plan
+
+**`browser_extract_text`** — refactor `markdown-extractor.ts`:
+- Split `extractMarkdown(page, opts)` into:
+  - `buildSerialiseScript(...)` (already exists, returns string) — unchanged.
+  - `treeToMarkdown(tree, opts)` (NEW pure Node fn) — the existing
+    `convertNode` + `cleanMarkdown` body, extracted.
+  - `extractMarkdown(evaluate: JsonEvaluator, opts)` — `const tree = await
+    evaluate(script); return treeToMarkdown(tree, opts)`.
+- Tool: `const evaluate = await resolveEvaluator(engine, surfaceId); const md =
+  await extractMarkdown(evaluate, {...})`. Drop the `if (!page) throw`.
+- Fidelity: identical — conversion was always Node-side; in-page part was always
+  a string.
+
+**`browser_extract_data`** — refactor `markdown-extractor.ts` (decision b):
+- Keep the 3 in-page functions (`extractFromTables/Lists/RepeatedElements`) as
+  real functions. Route each through `evalFunctionOrRpc(page, fn, {fieldNames},
+  surfaceId)`: dev path runs `page.evaluate(fn, arg)` **unchanged**; RPC path
+  stringifies `(${fn.toString()})(${JSON.stringify(arg)})`.
+  - **Security:** `fieldNames` is user-supplied (`Object.keys(fields)`). It is
+    embedded **only** via `JSON.stringify` (data literal, cannot break out to
+    code). No template interpolation of raw values. No fetch/cookie/storage in
+    the scripts → no `detectDangerousPatterns` concern (the RPC handler doesn't
+    gate; the gate is at the `browser_evaluate` tool layer for user expressions).
+- `extractStructuredData(page, surfaceId, goal, fields)` — signature gains
+  `page: Page | null` + `surfaceId`; runs the 3 strategies, first non-empty wins
+  (unchanged order).
+- Tool: `const page = await engine.getPage(surfaceId).catch(()=>null); const
+  records = await extractStructuredData(page, surfaceId, goal, fields);`
+
+**`browser_smart_snapshot`** — branch in the tool, add to `dom-intelligence.ts`:
+- Keep `getSmartSnapshot(page, opts)` (CDP AX tree) for the Playwright path —
+  **unchanged**, preserves full accessibility fidelity in dev.
+- Add `getSmartSnapshotViaEval(evaluate, opts)` (NEW): one injected script that
+  tags interactive elements with `data-wmux-ref="<i>"` and returns
+  `{ url, title, content, elements:[{ref, role, name, value?, description?}] }`.
+  Refs are the `data-wmux-ref` indices, so `browser_click({smartRef})`'s RPC
+  fallback (`[data-wmux-ref="<n>"]`) resolves them. Lower role fidelity than the
+  AX tree (tag/role heuristic), the accepted packaged-mode degradation.
+- Tool: `const page = await engine.getPage(surfaceId).catch(()=>null); const
+  snap = page ? await getSmartSnapshot(page, o) : await
+  getSmartSnapshotViaEval(rpcEvaluator(surfaceId), o);` then the existing
+  formatter.
+- **Ref-consistency (locked: option c, corrected by codex):** extract the
+  interactive-element selector to a shared `INTERACTIVE_SELECTOR` constant
+  (exported from `dom-intelligence.ts`). `browser_snapshot`'s fallback script
+  interpolates the constant (output byte-identical); `getSmartSnapshotViaEval`
+  reuses it (same `.slice(0,100)` cap). We share **only the selector** (which
+  elements are interactive) — **NOT the numbering base.** `getSmartSnapshot` is
+  **1-based** (`dom-intelligence.ts:123`, `getLocatorByRef` does `ref-1`);
+  `browser_snapshot` tags `data-wmux-ref` **0-based**. So `getSmartSnapshotViaEval`
+  stays **1-based** and tags `data-wmux-ref="<ref>"` with the SAME 1-based number
+  (do NOT copy browser_snapshot's 0-based tagging). Refs do not align across the
+  two tools (separate `ref` vs `smartRef` namespaces, ephemeral per the
+  "re-snapshot for current refs" model) — that's fine.
+- **elementCache MUST be populated (codex finding 1):** `browser_click({smartRef})`
+  uses `getLocatorByRef(smartRef)` **whenever a page exists**
+  (`interaction.ts:113-121`) and only falls to `[data-wmux-ref]` when page is null
+  (`:141-143`). `getPage()` can flip null→page within a session (`playwrightFailed`
+  resets, `PlaywrightEngine.ts:363`). So a snapshot taken in RPC mode whose click
+  lands after recovery would miss the cache. Fix: `getSmartSnapshotViaEval` sets
+  `elementCache = elements` with each `locator = '[data-wmux-ref="<ref>"]'`. That
+  selector resolves in BOTH modes — page path: `page.locator('[data-wmux-ref="<ref>"]')`
+  (the RPC snapshot's attributes persist in the same webview DOM); RPC path:
+  `String(smartRef)` → `[data-wmux-ref="<ref>"]`. 1-based throughout, consistent.
+
+**`browser_highlight`** — add RPC fallback in `inspection.ts` mirroring
+`browser_hover`'s existing fallback:
+- `page` path unchanged. Else: `sanitizeRef(ref)` → `sendRpc('browser.evaluate',
+  { expression: querySelector('[data-wmux-ref="<ref>"]') + set outline })`,
+  map `not_found` → `refNotFound`-style error.
+- **`sanitizeRef` is currently private to `interaction.ts` (codex finding 6).**
+  Export it from `interaction.ts` and import in `inspection.ts` (one-way edge,
+  no cycle — verified neither imports the other today). Highlight MUST sanitize
+  (the ref is interpolated into a CSS selector inside injected JS).
+
+**Drive-by hardening (codex finding 6a):** `browser_scroll`'s RPC fallback
+(`interaction.ts:559-560`) interpolates `ref` raw into the selector — the lone
+sibling that skips `sanitizeRef` (hover/drag/select/scroll_into_view all
+sanitize). 1-line fix to match its siblings, same `sanitizeRef` pattern this PR
+formalizes. Documented as drive-by in the PR; trivially droppable if unwanted.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `src/mcp/playwright/page-eval.ts` | **NEW** — `JsonEvaluator`, `pageEvaluator`, `rpcEvaluator`, `resolveEvaluator` |
+| `src/mcp/playwright/markdown-extractor.ts` | refactor to `JsonEvaluator`; extract `treeToMarkdown`; string-script builders for structured data |
+| `src/mcp/playwright/dom-intelligence.ts` | export `INTERACTIVE_SELECTOR`; add `getSmartSnapshotViaEval` (1-based, populates `elementCache`) |
+| `src/mcp/playwright/tools/extraction.ts` | extract_text → `resolveEvaluator`; extract_data → `evalFunctionOrRpc`; smart_snapshot → page?AX:eval branch; drop throws |
+| `src/mcp/playwright/tools/inspection.ts` | `browser_highlight` RPC fallback (uses `sanitizeRef`); `browser_snapshot` uses shared `INTERACTIVE_SELECTOR` |
+| `src/mcp/playwright/tools/interaction.ts` | export `sanitizeRef`; harden `browser_scroll` RPC fallback with it (drive-by) |
+| `src/mcp/playwright/__tests__/markdown-extractor.test.ts` | **NEW** unit tests (mock evaluator) |
+| `src/mcp/playwright/__tests__/page-eval.test.ts` | **NEW** unit tests (mock `sendRpc` / page) |
+| `src/mcp/playwright/__tests__/dom-intelligence.test.ts` | **NEW** unit tests for `getSmartSnapshotViaEval` |
+
+## Test strategy
+
+No real browser needed — the Node-side logic is isolated behind `JsonEvaluator`:
+- `markdown-extractor.test.ts`: feed a canned `SerializedNode` tree → assert
+  markdown (headings, links, tables, truncation). Feed canned table/list/
+  repeated results → assert `extractStructuredData` picks the right strategy and
+  shapes records.
+- `page-eval.test.ts`: `rpcEvaluator` calls `sendRpc('browser.evaluate', {...})`
+  and unwraps `.value`; passes `surfaceId` only when set. `pageEvaluator`
+  delegates to `page.evaluate`.
+- `dom-intelligence.test.ts`: `getSmartSnapshotViaEval` with a mock evaluator
+  returning a canned payload → assert SmartSnapshot shape + ref indexing.
+- Full suite: `npx vitest run` must stay green (one pre-existing failure,
+  `security.test.ts > secureWriteTokenFile`, is environment-specific — non-ASCII
+  dev username — and unrelated; CI is green).
+- Typecheck/build: `tsc -p tsconfig.mcp.json --noEmit` + `npm run build:mcp`.
+
+## Risks / trade-offs
+
+- **`smart_snapshot` RPC degradation:** roles come from tag/`role`-attr heuristic,
+  not the CDP AX tree. Acceptable — only on the page-null (packaged) path; dev
+  keeps full fidelity. Documented in the tool output is unnecessary; behavior is
+  a superset of "throw".
+- **No new RPC method:** intentionally reuses `browser.evaluate`. Means
+  `browser.evaluate` RPC must be available — it is, and is the exact channel
+  #104's verification proved working in packaged builds.
+- **extract_data dev path stays native (decision b):** Playwright keeps
+  `page.evaluate(fn, arg)` (zero behavior change). Only the RPC fallback uses
+  `(${fn.toString()})(${JSON.stringify(arg)})`. `.toString()` is safe here:
+  esbuild (`build-mcp.js`) sets no `minify`, and the 3 functions reference only
+  browser globals (`document`, `Map`, `CSS`) + their arg (no module refs/closures).
+- **RPC 10s timeout on huge pages (codex finding 3):** `extractMarkdown`
+  transfers the full serialized DOM tree before Node-side truncation, and the RPC
+  client has a hard 10s timeout (`wmux-client.ts:7`) the Playwright/CDP path does
+  not. On a pathological multi-MB DOM the RPC path may time out where Playwright
+  would survive. Accepted: the common case works and "times out" is still better
+  than the current "always throws"; the dev path is unaffected. Future hardening:
+  a node-count/depth cap inside `buildSerialiseScript` (deferred — it would alter
+  the dev path's output, which decision b protects).
+- **`browser_snapshot` RPC fallback ignores `format` (codex finding 4):** the
+  existing fallback always returns the custom DOM summary, never the ARIA tree
+  (`format:'aria'` only honored on the Playwright path). Pre-existing, NOT
+  introduced here; #105 only swaps its inline selector for the shared constant.
+  Noted as a possible follow-up, out of scope.
+- **`clear`-buffer tools untouched:** console/network/response_body still throw
+  in RPC mode (documented non-goal → follow-up issue).
+
+## Verification (packaged)
+
+The fix rides the `browser.evaluate` RPC path that `browser_evaluate` already
+exercises successfully in packaged builds (junbeom09, #104). Unit tests cover
+the Node-side conversion. A full packaged smoke test (`browser_extract_text` /
+`browser_smart_snapshot` on a real page in a `npm run make` bundle with a fresh
+daemon) is the highest-value manual check — request from @junbeom09 (has the
+setup) or run locally before merge. **Do not merge before that packaged
+verification.**
+
+## Review record
+
+- **Eng review (plan-eng-review):** Step 0 scope challenge + Architecture / Code
+  Quality / Tests / Performance. 3 decisions surfaced + locked (console/network
+  scope-out, ref-consistency option c, extract_data option b). No critical
+  architecture gaps.
+- **Codex review (gpt-5.5, read-only, high reasoning):** 6 findings, all
+  incorporated — (1) smart_snapshot elementCache mode-flip bug → populate cache;
+  (2) 1-based vs 0-based ref numbering → keep 1-based, share selector only;
+  (3) RPC 10s timeout on huge pages → documented; (4) browser_snapshot fallback
+  ignores `format` → pre-existing, noted; (5) plan self-contradiction on dev path
+  → fixed; (6) `sanitizeRef` private + `browser_scroll` raw interpolation →
+  export + drive-by harden. Security (fieldNames via JSON.stringify) confirmed safe.

--- a/src/mcp/playwright/__tests__/dom-intelligence.test.ts
+++ b/src/mcp/playwright/__tests__/dom-intelligence.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getSmartSnapshotViaEval,
+  getLocatorByRef,
+  clearElementCache,
+  INTERACTIVE_SELECTOR,
+} from '../dom-intelligence';
+
+describe('INTERACTIVE_SELECTOR', () => {
+  it('is a non-empty selector shared with browser_snapshot', () => {
+    expect(typeof INTERACTIVE_SELECTOR).toBe('string');
+    expect(INTERACTIVE_SELECTOR).toContain('button');
+    expect(INTERACTIVE_SELECTOR).toContain('[contenteditable="true"]');
+  });
+});
+
+describe('getSmartSnapshotViaEval', () => {
+  it('maps the evaluator payload into a SmartSnapshot with data-wmux-ref locators', async () => {
+    const evaluate = vi.fn().mockResolvedValue({
+      url: 'https://x.test/',
+      title: 'X',
+      content: 'hello',
+      elements: [
+        { ref: 1, role: 'button', name: 'OK' },
+        { ref: 2, role: 'textbox', name: 'Search', value: 'q', description: 'main search' },
+      ],
+    });
+
+    const snap = await getSmartSnapshotViaEval(evaluate, { maxContentLength: 100 });
+
+    expect(snap.url).toBe('https://x.test/');
+    expect(snap.title).toBe('X');
+    expect(snap.content).toBe('hello');
+    expect(snap.elements).toEqual([
+      { ref: 1, role: 'button', name: 'OK', locator: '[data-wmux-ref="1"]' },
+      {
+        ref: 2,
+        role: 'textbox',
+        name: 'Search',
+        value: 'q',
+        description: 'main search',
+        locator: '[data-wmux-ref="2"]',
+      },
+    ]);
+  });
+
+  it('injects a 1-based, data-wmux-ref-tagging script using the shared selector', async () => {
+    const evaluate = vi.fn().mockResolvedValue({ url: '', title: '', content: '', elements: [] });
+    await getSmartSnapshotViaEval(evaluate);
+    const script = evaluate.mock.calls[0][0] as string;
+    expect(script).toContain('data-wmux-ref');
+    expect(script).toContain('i + 1'); // 1-based, matches getSmartSnapshot / getLocatorByRef
+    expect(script).toContain('button'); // INTERACTIVE_SELECTOR embedded
+    expect(script).toContain('slice(0, 100)');
+  });
+
+  it('populates elementCache so getLocatorByRef resolves after a null->page flip', async () => {
+    clearElementCache();
+    const evaluate = vi.fn().mockResolvedValue({
+      url: 'u',
+      title: 't',
+      content: 'c',
+      elements: [{ ref: 1, role: 'link', name: 'Home' }],
+    });
+    await getSmartSnapshotViaEval(evaluate);
+    // The cache must hold a CSS-selector locator that page.locator() can resolve
+    // against the data-wmux-ref attributes the snapshot left in the DOM.
+    expect(getLocatorByRef(1)).toBe('[data-wmux-ref="1"]');
+    expect(getLocatorByRef(2)).toBeNull();
+  });
+
+  it('tolerates a null / element-less payload', async () => {
+    const evaluate = vi.fn().mockResolvedValue(null);
+    const snap = await getSmartSnapshotViaEval(evaluate);
+    expect(snap).toEqual({ url: '', title: '', elements: [], content: '' });
+  });
+});

--- a/src/mcp/playwright/__tests__/markdown-extractor.test.ts
+++ b/src/mcp/playwright/__tests__/markdown-extractor.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import {
+  treeToMarkdown,
+  extractMarkdown,
+  extractStructuredData,
+} from '../markdown-extractor';
+
+vi.mock('../../wmux-client', () => ({
+  sendRpc: vi.fn(),
+}));
+import { sendRpc } from '../../wmux-client';
+const mockSendRpc = sendRpc as unknown as ReturnType<typeof vi.fn>;
+
+// SerializedNode-shaped helpers (type 1 = element, 3 = text). SerializedNode is
+// internal to markdown-extractor, so we mirror its structure with a local type.
+type SNode = {
+  type: number;
+  tag?: string;
+  attrs?: Record<string, string>;
+  text?: string;
+  children?: SNode[];
+};
+const text = (t: string): SNode => ({ type: 3, text: t });
+const el = (tag: string, children: SNode[] = [], attrs: Record<string, string> = {}): SNode => ({
+  type: 1,
+  tag,
+  attrs,
+  children,
+});
+
+describe('treeToMarkdown', () => {
+  it('returns empty string for a null tree', () => {
+    expect(treeToMarkdown(null)).toBe('');
+  });
+
+  it('converts headings and paragraphs', () => {
+    const tree = el('DIV', [
+      el('H1', [text('Title')]),
+      el('P', [text('Body text')]),
+    ]);
+    const md = treeToMarkdown(tree);
+    expect(md).toContain('# Title');
+    expect(md).toContain('Body text');
+  });
+
+  it('honors includeLinks', () => {
+    const tree = el('P', [
+      text('see '),
+      el('A', [text('here')], { href: 'https://x.test' }),
+    ]);
+    expect(treeToMarkdown(tree, { includeLinks: true })).toContain('[here](https://x.test)');
+    const plain = treeToMarkdown(tree, { includeLinks: false });
+    expect(plain).toContain('here');
+    expect(plain).not.toContain('https://x.test');
+  });
+
+  it('renders tables', () => {
+    const tree = el('TABLE', [
+      el('TR', [el('TH', [text('A')]), el('TH', [text('B')])]),
+      el('TR', [el('TD', [text('1')]), el('TD', [text('2')])]),
+    ]);
+    const md = treeToMarkdown(tree);
+    expect(md).toContain('| A | B |');
+    expect(md).toContain('| --- | --- |');
+    expect(md).toContain('| 1 | 2 |');
+  });
+
+  it('truncates at maxLength', () => {
+    const tree = el('P', [text('x'.repeat(100))]);
+    const md = treeToMarkdown(tree, { maxLength: 20 });
+    expect(md).toContain('... (truncated)');
+    // body slice (20) + suffix
+    expect(md.length).toBeLessThan(60);
+  });
+});
+
+describe('extractMarkdown', () => {
+  it('runs the serialise script through the evaluator and converts the tree', async () => {
+    const tree = el('H1', [text('Hello')]);
+    const evaluate = vi.fn().mockResolvedValue(tree);
+    const md = await extractMarkdown(evaluate, {});
+    // the injected script is a string that strips noise + serialises the DOM
+    const script = evaluate.mock.calls[0][0] as string;
+    expect(typeof script).toBe('string');
+    expect(script).toContain('serialise');
+    expect(md).toContain('# Hello');
+  });
+
+  it('returns empty string when the evaluator yields null (no root)', async () => {
+    const evaluate = vi.fn().mockResolvedValue(null);
+    expect(await extractMarkdown(evaluate, {})).toBe('');
+  });
+});
+
+describe('extractStructuredData', () => {
+  beforeEach(() => mockSendRpc.mockReset());
+
+  it('returns [] for empty fields without touching the page', async () => {
+    const page = { evaluate: vi.fn() };
+    const out = await extractStructuredData(page as never, undefined, 'goal', {});
+    expect(out).toEqual([]);
+    expect(page.evaluate).not.toHaveBeenCalled();
+  });
+
+  it('returns table data (strategy 1) from the native page path', async () => {
+    const rows = [{ name: 'a', price: '1' }];
+    const page = { evaluate: vi.fn().mockResolvedValueOnce(rows) };
+    const out = await extractStructuredData(page as never, undefined, 'goal', {
+      name: 'string',
+      price: 'number',
+    });
+    expect(out).toEqual(rows);
+    expect(page.evaluate).toHaveBeenCalledTimes(1); // stopped at first non-empty
+  });
+
+  it('falls through table -> list -> repeated until a strategy yields data', async () => {
+    const repeated = [{ title: 'card' }];
+    const page = {
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce([]) // tables
+        .mockResolvedValueOnce([]) // lists
+        .mockResolvedValueOnce(repeated), // repeated
+    };
+    const out = await extractStructuredData(page as never, undefined, 'goal', { title: 'string' });
+    expect(out).toEqual(repeated);
+    expect(page.evaluate).toHaveBeenCalledTimes(3);
+  });
+
+  it('uses the RPC fallback when no page is available', async () => {
+    mockSendRpc.mockResolvedValueOnce({ value: [{ name: 'rpc' }] });
+    const out = await extractStructuredData(null, 'surf', 'goal', { name: 'string' });
+    expect(out).toEqual([{ name: 'rpc' }]);
+    const [method, params] = mockSendRpc.mock.calls[0];
+    expect(method).toBe('browser.evaluate');
+    expect(params.surfaceId).toBe('surf');
+    expect(params.expression).toContain('querySelectorAll'); // stringified table fn
+  });
+});

--- a/src/mcp/playwright/__tests__/page-eval.test.ts
+++ b/src/mcp/playwright/__tests__/page-eval.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import {
+  pageEvaluator,
+  rpcEvaluator,
+  resolveEvaluator,
+  evalFunctionOrRpc,
+} from '../page-eval';
+
+// Mock the RPC transport. Path is relative to THIS test file:
+// __tests__/ -> playwright/ -> mcp/, so ../../wmux-client === src/mcp/wmux-client.
+vi.mock('../../wmux-client', () => ({
+  sendRpc: vi.fn(),
+}));
+
+import { sendRpc } from '../../wmux-client';
+
+const mockSendRpc = sendRpc as unknown as ReturnType<typeof vi.fn>;
+
+describe('page-eval', () => {
+  beforeEach(() => {
+    mockSendRpc.mockReset();
+  });
+
+  describe('pageEvaluator', () => {
+    it('delegates the expression to page.evaluate', async () => {
+      const page = { evaluate: vi.fn().mockResolvedValue('result') };
+      const evaluate = pageEvaluator(page as never);
+      const out = await evaluate('1 + 1');
+      expect(page.evaluate).toHaveBeenCalledWith('1 + 1');
+      expect(out).toBe('result');
+    });
+  });
+
+  describe('rpcEvaluator', () => {
+    it('calls browser.evaluate and unwraps .value', async () => {
+      mockSendRpc.mockResolvedValue({ value: 42 });
+      const evaluate = rpcEvaluator('surface-1');
+      const out = await evaluate('expr');
+      expect(mockSendRpc).toHaveBeenCalledWith('browser.evaluate', {
+        expression: 'expr',
+        surfaceId: 'surface-1',
+      });
+      expect(out).toBe(42);
+    });
+
+    it('omits surfaceId when not provided', async () => {
+      mockSendRpc.mockResolvedValue({ value: null });
+      const evaluate = rpcEvaluator();
+      await evaluate('expr');
+      expect(mockSendRpc).toHaveBeenCalledWith('browser.evaluate', {
+        expression: 'expr',
+      });
+    });
+  });
+
+  describe('resolveEvaluator', () => {
+    it('returns a page-backed evaluator when getPage resolves a page', async () => {
+      const page = { evaluate: vi.fn().mockResolvedValue('via-page') };
+      const engine = { getPage: vi.fn().mockResolvedValue(page) };
+      const evaluate = await resolveEvaluator(engine as never, 's');
+      const out = await evaluate('x');
+      expect(page.evaluate).toHaveBeenCalledWith('x');
+      expect(out).toBe('via-page');
+      expect(mockSendRpc).not.toHaveBeenCalled();
+    });
+
+    it('returns an RPC-backed evaluator when getPage resolves null', async () => {
+      mockSendRpc.mockResolvedValue({ value: 'via-rpc' });
+      const engine = { getPage: vi.fn().mockResolvedValue(null) };
+      const evaluate = await resolveEvaluator(engine as never, 's');
+      const out = await evaluate('x');
+      expect(mockSendRpc).toHaveBeenCalledWith('browser.evaluate', {
+        expression: 'x',
+        surfaceId: 's',
+      });
+      expect(out).toBe('via-rpc');
+    });
+
+    it('falls back to RPC when getPage rejects', async () => {
+      mockSendRpc.mockResolvedValue({ value: 'via-rpc' });
+      const engine = { getPage: vi.fn().mockRejectedValue(new Error('boom')) };
+      const evaluate = await resolveEvaluator(engine as never);
+      const out = await evaluate('x');
+      expect(out).toBe('via-rpc');
+    });
+  });
+
+  describe('evalFunctionOrRpc', () => {
+    const fn = ({ n }: { n: number }) => n * 2;
+
+    it('runs the function natively on the page when one exists', async () => {
+      const page = { evaluate: vi.fn().mockResolvedValue(20) };
+      const out = await evalFunctionOrRpc(page as never, fn, { n: 10 }, 's');
+      // native page.evaluate(fn, arg) — dev path unchanged
+      expect(page.evaluate).toHaveBeenCalledTimes(1);
+      expect(page.evaluate.mock.calls[0][1]).toEqual({ n: 10 });
+      expect(out).toBe(20);
+      expect(mockSendRpc).not.toHaveBeenCalled();
+    });
+
+    it('stringifies the function for RPC when no page exists', async () => {
+      mockSendRpc.mockResolvedValue({ value: 20 });
+      const out = await evalFunctionOrRpc(null, fn, { n: 10 }, 's');
+      expect(mockSendRpc).toHaveBeenCalledTimes(1);
+      const [method, params] = mockSendRpc.mock.calls[0];
+      expect(method).toBe('browser.evaluate');
+      // expression = (fn.toString())(JSON.stringify(arg))
+      expect(params.expression).toContain('n * 2');
+      expect(params.expression).toContain('{"n":10}');
+      expect(params.surfaceId).toBe('s');
+      expect(out).toBe(20);
+    });
+
+    it('embeds arg via JSON.stringify (no code injection from values)', async () => {
+      mockSendRpc.mockResolvedValue({ value: [] });
+      const evilFn = ({ fieldNames }: { fieldNames: string[] }) => fieldNames;
+      await evalFunctionOrRpc(
+        null,
+        evilFn,
+        { fieldNames: ['"); globalThis.hacked = 1; ("'] },
+        undefined,
+      );
+      const expr = mockSendRpc.mock.calls[0][1].expression as string;
+      // The dangerous payload is a JSON string literal, never bare code.
+      expect(expr).toContain('globalThis.hacked = 1');
+      expect(expr).toContain('\\"); globalThis.hacked = 1; (\\"');
+    });
+  });
+});

--- a/src/mcp/playwright/dom-intelligence.ts
+++ b/src/mcp/playwright/dom-intelligence.ts
@@ -1,4 +1,20 @@
 import type { Page } from 'playwright-core';
+import type { JsonEvaluator } from './page-eval';
+
+// ---------------------------------------------------------------------------
+// Shared interactive-element selector
+// ---------------------------------------------------------------------------
+
+/**
+ * CSS selector for "interactive" elements that get a ref number in DOM-based
+ * (RPC) snapshots. Shared between browser_snapshot's RPC fallback (inspection.ts)
+ * and getSmartSnapshotViaEval so both tools tag the SAME elements with
+ * data-wmux-ref. The numbering BASE differs by design (browser_snapshot is
+ * 0-based; smart snapshot is 1-based to match getSmartSnapshot / getLocatorByRef),
+ * so refs are not interchangeable across the two tools — only the element set is.
+ */
+export const INTERACTIVE_SELECTOR =
+  'a[href], button, input:not([type="hidden"]), textarea, select, [role="button"], [role="link"], [role="textbox"], [role="checkbox"], [role="radio"], [role="combobox"], [role="searchbox"], [role="tab"], [contenteditable="true"]';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -219,6 +235,105 @@ export async function getSmartSnapshot(
   elementCache = elements;
 
   return { url, title, elements, content };
+}
+
+/**
+ * DOM-based smart snapshot for the packaged-build RPC fallback (issue #105).
+ *
+ * When PlaywrightEngine.getPage() returns null, the CDP accessibility tree used
+ * by getSmartSnapshot() is unavailable, so this derives the same SmartSnapshot
+ * shape from a single injected DOM script over the RPC `browser.evaluate`
+ * channel. Lower role fidelity than the AX tree (tag/role heuristic) — the
+ * accepted packaged-mode degradation; the dev path keeps full fidelity.
+ *
+ * Refs are 1-based to match getSmartSnapshot() and getLocatorByRef()'s `ref-1`
+ * lookup. Each interactive element is tagged `data-wmux-ref="<ref>"` with the
+ * SAME 1-based number, so:
+ *   - RPC-mode click: browser_click({smartRef}) -> [data-wmux-ref="<smartRef>"].
+ *   - page-mode click after getPage() recovers: getLocatorByRef returns
+ *     `[data-wmux-ref="<ref>"]`, which page.locator() resolves against the
+ *     attributes this snapshot left in the (same) webview DOM.
+ * elementCache is populated for exactly that second case.
+ */
+export async function getSmartSnapshotViaEval(
+  evaluate: JsonEvaluator,
+  options?: SmartSnapshotOptions,
+): Promise<SmartSnapshot> {
+  const maxContentLength = Math.max(
+    0,
+    Math.floor(options?.maxContentLength ?? DEFAULT_MAX_CONTENT_LENGTH),
+  );
+
+  // Note: the selector + .slice(0, 100) cap + data-wmux-ref tagging mirror
+  // browser_snapshot's RPC fallback (inspection.ts) via INTERACTIVE_SELECTOR.
+  const script = `(() => {
+    const sel = ${JSON.stringify(INTERACTIVE_SELECTOR)};
+    const max = ${maxContentLength};
+    const els = [...document.querySelectorAll(sel)].slice(0, 100);
+    const roleFor = (el) => {
+      const explicit = el.getAttribute('role');
+      if (explicit) return explicit;
+      const tag = el.tagName.toLowerCase();
+      if (tag === 'a') return 'link';
+      if (tag === 'button') return 'button';
+      if (tag === 'select') return 'combobox';
+      if (tag === 'textarea') return 'textbox';
+      if (tag === 'input') {
+        const t = (el.getAttribute('type') || 'text').toLowerCase();
+        if (t === 'checkbox') return 'checkbox';
+        if (t === 'radio') return 'radio';
+        if (t === 'button' || t === 'submit' || t === 'reset') return 'button';
+        return 'textbox';
+      }
+      if (el.getAttribute('contenteditable') === 'true') return 'textbox';
+      return 'generic';
+    };
+    const elements = els.map((el, i) => {
+      const ref = i + 1; // 1-based — matches getSmartSnapshot / getLocatorByRef
+      el.setAttribute('data-wmux-ref', String(ref));
+      const name = (el.getAttribute('aria-label')
+        || (el.textContent || '').trim()
+        || el.getAttribute('placeholder')
+        || el.getAttribute('name')
+        || '').substring(0, 120);
+      const out = { ref, role: roleFor(el), name };
+      const val = el.value;
+      if (typeof val === 'string' && val) out.value = val;
+      const desc = el.getAttribute('aria-description');
+      if (desc) out.description = desc;
+      return out;
+    });
+    let content = (document.body && document.body.innerText) || '';
+    if (content.length > max) content = content.slice(0, max) + '\\n... (truncated)';
+    return { url: location.href, title: document.title, content, elements };
+  })()`;
+
+  const raw = (await evaluate(script)) as {
+    url?: string;
+    title?: string;
+    content?: string;
+    elements?: Array<{ ref: number; role: string; name: string; value?: string; description?: string }>;
+  } | null;
+
+  const elements: IndexedElement[] = (raw?.elements ?? []).map((e) => ({
+    ref: e.ref,
+    role: e.role,
+    name: e.name,
+    ...(e.value !== undefined && { value: e.value }),
+    ...(e.description !== undefined && { description: e.description }),
+    locator: `[data-wmux-ref="${e.ref}"]`,
+  }));
+
+  // Cache so browser_click({smartRef}) resolves via getLocatorByRef even if
+  // getPage() flips null->page between this snapshot and the click.
+  elementCache = elements;
+
+  return {
+    url: raw?.url ?? '',
+    title: raw?.title ?? '',
+    elements,
+    content: raw?.content ?? '',
+  };
 }
 
 /**

--- a/src/mcp/playwright/markdown-extractor.ts
+++ b/src/mcp/playwright/markdown-extractor.ts
@@ -1,4 +1,6 @@
 import type { Page } from 'playwright-core';
+import type { JsonEvaluator } from './page-eval';
+import { evalFunctionOrRpc } from './page-eval';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -341,18 +343,34 @@ function buildSerialiseScript(
  *
  * Strips navigation, footer, ad, and other non-content elements, then
  * converts the remaining HTML structure into readable markdown text.
+ *
+ * Takes a JsonEvaluator rather than a Page so the same logic serves both the
+ * Playwright transport and the packaged-build RPC fallback (issue #105). The
+ * in-page work is a string script (buildSerialiseScript), so neither transport
+ * changes behavior.
  */
 export async function extractMarkdown(
-  page: Page,
+  evaluate: JsonEvaluator,
   options?: ExtractionOptions,
 ): Promise<string> {
+  const selector = options?.selector ?? null;
+  const script = buildSerialiseScript(selector, NOISE_SELECTORS);
+  const tree = (await evaluate(script)) as SerializedNode | null;
+  return treeToMarkdown(tree, options);
+}
+
+/**
+ * Convert a serialised DOM tree (the output of buildSerialiseScript) into clean
+ * markdown. Pure Node-side logic — split out from extractMarkdown so it can be
+ * unit-tested against a canned tree without a browser.
+ */
+export function treeToMarkdown(
+  tree: SerializedNode | null,
+  options?: ExtractionOptions,
+): string {
   const maxLength = options?.maxLength ?? DEFAULT_MAX_LENGTH;
   const includeLinks = options?.includeLinks ?? true;
   const includeImages = options?.includeImages ?? false;
-  const selector = options?.selector ?? null;
-
-  const script = buildSerialiseScript(selector, NOISE_SELECTORS);
-  const tree = await page.evaluate(script) as SerializedNode | null;
 
   if (!tree) {
     return '';
@@ -374,31 +392,34 @@ export async function extractMarkdown(
  * such as tables, lists, or repeated elements and maps them to the
  * requested fields.
  *
- * @param page     Playwright Page instance
- * @param goal     Human-readable description of what to extract (used to
- *                 narrow scope when multiple data regions exist)
- * @param fields   Mapping of field names to human descriptions, e.g.
- *                 `{ title: "product name", price: "price in USD" }`
- * @returns        Array of objects with keys matching `fields`
+ * @param page      Playwright Page, or null to use the RPC fallback (issue #105)
+ * @param surfaceId Optional surface to target on the RPC path
+ * @param goal      Human-readable description of what to extract (reserved;
+ *                  not yet used to narrow scope)
+ * @param fields    Mapping of field names to human descriptions, e.g.
+ *                  `{ title: "product name", price: "price in USD" }`
+ * @returns         Array of objects with keys matching `fields`
  */
 export async function extractStructuredData(
-  page: Page,
+  page: Page | null,
+  surfaceId: string | undefined,
   goal: string,
   fields: Record<string, string>,
 ): Promise<Record<string, unknown>[]> {
+  void goal; // reserved for future scope-narrowing; not yet used
   const fieldNames = Object.keys(fields);
   if (fieldNames.length === 0) return [];
 
   // Strategy 1: Try to extract from <table> elements
-  const tableData = await extractFromTables(page, fieldNames);
+  const tableData = await extractFromTables(page, surfaceId, fieldNames);
   if (tableData.length > 0) return tableData;
 
   // Strategy 2: Try to extract from repeated list items
-  const listData = await extractFromLists(page, fieldNames);
+  const listData = await extractFromLists(page, surfaceId, fieldNames);
   if (listData.length > 0) return listData;
 
   // Strategy 3: Try to find repeated element patterns (grids, cards, etc.)
-  const repeatedData = await extractFromRepeatedElements(page, fieldNames);
+  const repeatedData = await extractFromRepeatedElements(page, surfaceId, fieldNames);
   if (repeatedData.length > 0) return repeatedData;
 
   return [];
@@ -409,11 +430,13 @@ export async function extractStructuredData(
 // ---------------------------------------------------------------------------
 
 async function extractFromTables(
-  page: Page,
+  page: Page | null,
+  surfaceId: string | undefined,
   fieldNames: string[],
 ): Promise<Record<string, unknown>[]> {
-  return await page.evaluate(
-    ({ fieldNames: names }) => {
+  return await evalFunctionOrRpc(
+    page,
+    ({ fieldNames: names }: { fieldNames: string[] }) => {
       const tables = document.querySelectorAll('table');
       if (tables.length === 0) return [];
 
@@ -476,6 +499,7 @@ async function extractFromTables(
       return [];
     },
     { fieldNames },
+    surfaceId,
   );
 }
 
@@ -484,11 +508,13 @@ async function extractFromTables(
 // ---------------------------------------------------------------------------
 
 async function extractFromLists(
-  page: Page,
+  page: Page | null,
+  surfaceId: string | undefined,
   fieldNames: string[],
 ): Promise<Record<string, unknown>[]> {
-  return await page.evaluate(
-    ({ fieldNames: names }) => {
+  return await evalFunctionOrRpc(
+    page,
+    ({ fieldNames: names }: { fieldNames: string[] }) => {
       const lists = document.querySelectorAll('ul, ol');
       if (lists.length === 0) return [];
 
@@ -547,6 +573,7 @@ async function extractFromLists(
       return results;
     },
     { fieldNames },
+    surfaceId,
   );
 }
 
@@ -555,11 +582,13 @@ async function extractFromLists(
 // ---------------------------------------------------------------------------
 
 async function extractFromRepeatedElements(
-  page: Page,
+  page: Page | null,
+  surfaceId: string | undefined,
   fieldNames: string[],
 ): Promise<Record<string, unknown>[]> {
-  return await page.evaluate(
-    ({ fieldNames: names }) => {
+  return await evalFunctionOrRpc(
+    page,
+    ({ fieldNames: names }: { fieldNames: string[] }) => {
       // Find class names that appear 3+ times, suggesting repeated items
       const classCount = new Map<string, number>();
       const allElements = document.querySelectorAll('div, li, article, section');
@@ -661,5 +690,6 @@ async function extractFromRepeatedElements(
       return [];
     },
     { fieldNames },
+    surfaceId,
   );
 }

--- a/src/mcp/playwright/page-eval.ts
+++ b/src/mcp/playwright/page-eval.ts
@@ -1,0 +1,94 @@
+import type { Page } from 'playwright-core';
+import type { PlaywrightEngine } from './PlaywrightEngine';
+import { sendRpc } from '../wmux-client';
+
+// ---------------------------------------------------------------------------
+// Transport abstraction for DOM-extraction tools (issue #105)
+// ---------------------------------------------------------------------------
+//
+// In a packaged build, playwright-core's connectOverCDP does not surface the
+// Electron <webview> guest as a Playwright Page, so PlaywrightEngine.getPage()
+// returns null. Tools that need to read the DOM must then fall back to the
+// main-process RPC channel (browser.evaluate -> guest webContents), the same
+// route browser_evaluate / browser_snapshot already use successfully.
+//
+// These helpers unify "evaluate a string expression, get a JSON value back"
+// across both transports so extraction tools have a single code path that works
+// whether or not a Playwright Page is available.
+
+/** Evaluate a JS expression string and resolve its JSON-serialisable value. */
+export type JsonEvaluator = (expression: string) => Promise<unknown>;
+
+/** Evaluator backed by a live Playwright Page (dev / when getPage succeeds). */
+export function pageEvaluator(page: Page): JsonEvaluator {
+  return (expression) => page.evaluate(expression);
+}
+
+/**
+ * Evaluator backed by the main-process RPC channel. Drives the guest webview's
+ * webContents via browser.evaluate (CDP Runtime.evaluate, returnByValue), so it
+ * works in packaged builds where the Playwright Page route does not.
+ */
+export function rpcEvaluator(surfaceId?: string): JsonEvaluator {
+  return async (expression) => {
+    const result = (await sendRpc('browser.evaluate', {
+      expression,
+      ...(surfaceId && { surfaceId }),
+    })) as { value: unknown };
+    return result.value;
+  };
+}
+
+/**
+ * Resolve the best evaluator for string-script tools (browser_extract_text and
+ * the browser_smart_snapshot RPC path): a Playwright Page if one is available,
+ * otherwise the RPC channel.
+ *
+ * Note: browser_extract_text's Playwright path was ALREADY string-based
+ * (page.evaluate(buildSerialiseScript())), so routing it through pageEvaluator
+ * is a zero-behavior-change unification — not a switch from function to string.
+ */
+export async function resolveEvaluator(
+  engine: PlaywrightEngine,
+  surfaceId?: string,
+): Promise<JsonEvaluator> {
+  const page = await engine.getPage(surfaceId).catch(() => null);
+  return page ? pageEvaluator(page) : rpcEvaluator(surfaceId);
+}
+
+/**
+ * Run a Playwright-style page function (`fn(arg)`) and resolve its JSON value.
+ *
+ * Used by browser_extract_data (issue #105 decision b): when a Page exists the
+ * function runs natively via page.evaluate(fn, arg) — IDENTICAL to the prior
+ * behavior, so the dev path cannot regress. When no Page is available it
+ * stringifies the function for the RPC channel.
+ *
+ * `.toString()` is safe for the extraction functions because the MCP bundle
+ * (scripts/build-mcp.js) runs esbuild WITHOUT minify and the functions are
+ * self-contained — they reference only browser globals (document, Map, CSS) and
+ * their single argument, never a module-level binding or closure variable.
+ *
+ * Security: `arg` is embedded only via JSON.stringify (a data literal that
+ * cannot break out into executable code), so user-supplied values inside `arg`
+ * (e.g. extract_data field names) cannot inject script.
+ */
+export async function evalFunctionOrRpc<A, R>(
+  page: Page | null,
+  fn: (arg: A) => R,
+  arg: A,
+  surfaceId?: string,
+): Promise<R> {
+  if (page) {
+    // Playwright types page.evaluate's function param as PageFunction<Unboxed<A>, R>,
+    // which a free generic A cannot satisfy. The function is correct at runtime
+    // (it ran identically before #105 via the same call), so cast at this boundary.
+    return (await page.evaluate(fn as (a: unknown) => R, arg)) as R;
+  }
+  const expression = `(${fn.toString()})(${JSON.stringify(arg)})`;
+  const result = (await sendRpc('browser.evaluate', {
+    expression,
+    ...(surfaceId && { surfaceId }),
+  })) as { value: R };
+  return result.value;
+}

--- a/src/mcp/playwright/tools/extraction.ts
+++ b/src/mcp/playwright/tools/extraction.ts
@@ -1,8 +1,9 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { PlaywrightEngine } from '../PlaywrightEngine';
-import { getSmartSnapshot } from '../dom-intelligence';
+import { getSmartSnapshot, getSmartSnapshotViaEval } from '../dom-intelligence';
 import { extractMarkdown, extractStructuredData } from '../markdown-extractor';
+import { resolveEvaluator, rpcEvaluator } from '../page-eval';
 
 // Optional surfaceId schema reused across tools
 const optionalSurfaceId = z
@@ -36,19 +37,18 @@ export function registerExtractionTools(server: McpServer): void {
     },
     async ({ maxContentLength, surfaceId }) => {
       try {
-        const page = await engine.getPage(surfaceId);
-        if (!page) {
-          throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
-        }
-
-        const snapshot = await getSmartSnapshot(page, {
-          maxContentLength: maxContentLength ?? 3000,
-        });
+        // Playwright path uses the CDP accessibility tree; when no Page is
+        // available (packaged builds, issue #105) fall back to a DOM-based
+        // snapshot over the RPC channel.
+        const page = await engine.getPage(surfaceId).catch(() => null);
+        const snapshot = page
+          ? await getSmartSnapshot(page, { maxContentLength: maxContentLength ?? 3000 })
+          : await getSmartSnapshotViaEval(rpcEvaluator(surfaceId), { maxContentLength: maxContentLength ?? 3000 });
 
         // Format the snapshot output: indexed elements + content summary
         const lines: string[] = [];
 
-        lines.push(`Page: ${snapshot.title ?? page.url()}`);
+        lines.push(`Page: ${snapshot.title ?? snapshot.url}`);
         lines.push('');
 
         if (snapshot.elements && snapshot.elements.length > 0) {
@@ -100,12 +100,12 @@ export function registerExtractionTools(server: McpServer): void {
     },
     async ({ selector, maxLength, includeLinks, surfaceId }) => {
       try {
-        const page = await engine.getPage(surfaceId);
-        if (!page) {
-          throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
-        }
+        // resolveEvaluator picks the Playwright page when available, else the
+        // RPC channel (packaged builds, issue #105). extract_text's in-page work
+        // is a string script, so both transports produce identical output.
+        const evaluate = await resolveEvaluator(engine, surfaceId);
 
-        const markdown = await extractMarkdown(page, {
+        const markdown = await extractMarkdown(evaluate, {
           selector,
           maxLength,
           includeLinks,
@@ -141,12 +141,11 @@ export function registerExtractionTools(server: McpServer): void {
     },
     async ({ goal, fields, surfaceId }) => {
       try {
-        const page = await engine.getPage(surfaceId);
-        if (!page) {
-          throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
-        }
+        // Native page.evaluate(fn, arg) when a Page exists (unchanged dev path);
+        // RPC fallback when not (packaged builds, issue #105).
+        const page = await engine.getPage(surfaceId).catch(() => null);
 
-        const records = await extractStructuredData(page, goal, fields);
+        const records = await extractStructuredData(page, surfaceId, goal, fields);
 
         return {
           content: [

--- a/src/mcp/playwright/tools/inspection.ts
+++ b/src/mcp/playwright/tools/inspection.ts
@@ -3,8 +3,10 @@ import type { Page } from 'playwright-core';
 import { z } from 'zod';
 import { PlaywrightEngine } from '../PlaywrightEngine';
 import { generateSnapshot, resolveRef } from '../snapshot';
+import { INTERACTIVE_SELECTOR } from '../dom-intelligence';
 import { evaluateWithGesture } from '../anti-detection';
 import { detectDangerousPatterns } from '../security';
+import { sanitizeRef } from './interaction';
 import { sendRpc } from '../../wmux-client';
 
 // Optional surfaceId schema reused across tools
@@ -222,7 +224,7 @@ export function registerInspectionTools(server: McpServer): void {
         // Tags interactive elements with data-wmux-ref so interaction tools can resolve them
         const result = await sendRpc('browser.evaluate', {
           expression: `(() => {
-            const sel = 'a[href], button, input:not([type="hidden"]), textarea, select, [role="button"], [role="link"], [role="textbox"], [role="checkbox"], [role="radio"], [role="combobox"], [role="searchbox"], [role="tab"], [contenteditable="true"]';
+            const sel = ${JSON.stringify(INTERACTIVE_SELECTOR)};
             const interactives = [...document.querySelectorAll(sel)].slice(0, 100);
             interactives.forEach((el, i) => el.setAttribute('data-wmux-ref', String(i)));
             const title = document.title;
@@ -583,22 +585,38 @@ export function registerInspectionTools(server: McpServer): void {
     },
     async ({ ref, surfaceId }) => {
       try {
-        const page = await engine.getPage(surfaceId);
-        if (!page) {
-          throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
-        }
+        const page = await engine.getPage(surfaceId).catch(() => null);
 
-        const el = await resolveRef(page, ref);
-        if (!el) {
-          throw new Error(`Could not resolve ref="${ref}" to an element.`);
-        }
+        if (page) {
+          const el = await resolveRef(page, ref);
+          if (!el) {
+            throw new Error(`Could not resolve ref="${ref}" to an element.`);
+          }
 
-        await el.evaluate(
-          (element: Element) => {
-            (element as HTMLElement).style.outline = '3px solid red';
-            (element as HTMLElement).style.outlineOffset = '2px';
-          },
-        );
+          await el.evaluate(
+            (element: Element) => {
+              (element as HTMLElement).style.outline = '3px solid red';
+              (element as HTMLElement).style.outlineOffset = '2px';
+            },
+          );
+        } else {
+          // RPC fallback (packaged builds): resolve via the data-wmux-ref tag set
+          // by browser_snapshot / browser_smart_snapshot and set the outline inline.
+          const safeRef = sanitizeRef(ref);
+          const result = await sendRpc('browser.evaluate', {
+            expression: `(() => {
+              const el = document.querySelector('[data-wmux-ref="${safeRef}"]');
+              if (!el) return 'not_found';
+              el.style.outline = '3px solid red';
+              el.style.outlineOffset = '2px';
+              return 'ok';
+            })()`,
+            ...(surfaceId && { surfaceId }),
+          }) as { value: string };
+          if (result.value === 'not_found') {
+            throw new Error(`Could not resolve ref="${ref}" to an element.`);
+          }
+        }
 
         return {
           content: [{ type: 'text' as const, text: 'Element highlighted' }],

--- a/src/mcp/playwright/tools/interaction.ts
+++ b/src/mcp/playwright/tools/interaction.ts
@@ -32,8 +32,12 @@ async function rpcEval(expression: string, surfaceId?: string): Promise<string> 
   return result.value;
 }
 
-/** Sanitize ref to prevent injection in CSS selectors / JS template literals. */
-function sanitizeRef(ref: string): string {
+/**
+ * Sanitize ref to prevent injection in CSS selectors / JS template literals.
+ * Exported so other tool modules that interpolate a ref into injected JS
+ * (e.g. browser_highlight in inspection.ts) reuse the same guard.
+ */
+export function sanitizeRef(ref: string): string {
   if (!/^[a-zA-Z0-9_-]+$/.test(ref)) throw new Error(`Invalid ref: "${ref}"`);
   return ref;
 }
@@ -556,8 +560,9 @@ export function registerInteractionTools(server: McpServer): void {
         } else {
           // RPC fallback
           if (ref) {
+            const safeRef = sanitizeRef(ref);
             await rpcEval(`(() => {
-              const el = document.querySelector('[data-wmux-ref="${ref}"]');
+              const el = document.querySelector('[data-wmux-ref="${safeRef}"]');
               if (!el) return 'not_found';
               el.scrollBy(${deltaX}, ${deltaY});
               return 'ok';


### PR DESCRIPTION
## Summary

After #104, `PlaywrightEngine.getPage()` correctly refuses the app shell. In a
packaged build `connectOverCDP` doesn't surface the Electron `<webview>` guest
as a Playwright `Page` either, so `getPage()` returns null — and the tools that
needed a real `Page` with **no fallback** started throwing `No browser page
available`. Before #104 they silently returned the app shell's DOM, so the
breakage was masked; #104 made it honest, this PR makes the tools actually work.

`browser_evaluate` / `browser_snapshot` / `browser_screenshot` already keep
working because they fall back to the main-process RPC channel
(`browser.evaluate` / `browser.screenshot`, which drive the guest `webContents`
directly). This PR extends the **same proven channel** to the extraction and
snapshot tools. No new RPC method, no new IPC surface, no new permission gate.

Fixes the second problem @junbeom09 surfaced while verifying #104 in a packaged
build (`browser_extract_text` returned `No browser page available` there).

## Changes

- **`browser_extract_text`** — `extractMarkdown` now takes a `JsonEvaluator`
  (Playwright page when available, else RPC). The in-page work was already a
  string script, so dev output is unchanged. Pure conversion split into
  `treeToMarkdown` for unit testing.
- **`browser_extract_data`** — the three strategy functions run through
  `evalFunctionOrRpc`. The Playwright path stays native `page.evaluate(fn, arg)`
  (zero dev change, risk isolated); only the RPC path stringifies the function.
  Safe: `build-mcp.js` esbuild has no `minify` and the functions reference only
  browser globals + their arg. User field names are embedded via `JSON.stringify`
  only — a data literal that can't break out into code.
- **`browser_smart_snapshot`** — keeps the CDP accessibility-tree path for dev;
  adds a DOM-based `getSmartSnapshotViaEval` fallback over RPC. Refs are 1-based
  (matching `getSmartSnapshot` / `getLocatorByRef`) and tagged `data-wmux-ref`
  with the same number; it populates `elementCache` so `browser_click({smartRef})`
  resolves even if `getPage()` recovers (null -> page) between snapshot and click.
  Shares the interactive-element selector with `browser_snapshot` via a new
  `INTERACTIVE_SELECTOR` constant.
- **`browser_highlight`** — adds an RPC fallback resolving the element via
  `data-wmux-ref`. `sanitizeRef` is now exported from `interaction.ts` for reuse.
- **Drive-by hardening** — `browser_scroll`'s RPC fallback now runs `ref` through
  `sanitizeRef` (it was the one sibling interpolating `ref` raw into the selector).
- **New** `src/mcp/playwright/page-eval.ts` — `JsonEvaluator`, `pageEvaluator`,
  `rpcEvaluator`, `resolveEvaluator`, `evalFunctionOrRpc`.

### Out of scope (tracked in #106)

`browser_console` / `browser_network` / `browser_response_body` rely on Playwright
event subscriptions (`page.on(...)`), which a one-shot `browser.evaluate` can't
provide. Supporting them needs a main-process CDP event-capture subsystem — a
separate feature, not a fallback. They keep their honest error in packaged builds.

## CHANGELOG entry

### Fixed

- MCP browser tools `browser_extract_text`, `browser_extract_data`,
  `browser_smart_snapshot`, and `browser_highlight` now work in packaged builds
  instead of erroring with "No browser page available" (they fall back to the
  `browser.evaluate` RPC channel when no Playwright page is available).

## Stability tier impact

- [x] Reuses the existing `experimental` `browser.evaluate` RPC; no new method,
  event, or response field. Tool behavior changes from "throws in packaged mode"
  to "works", which is strictly additive.

## Substrate contract impact (Substrate 3.0)

No change to PaneMetadata, EventBus, permission enforcement, or Named Pipe
security. No new RPC method or event type.

## Test plan

- **Unit (new, +25):** `page-eval.test.ts` (transport selection, RPC unwrap,
  `JSON.stringify` arg embedding / no injection), `markdown-extractor.test.ts`
  (`treeToMarkdown` headings/links/tables/truncation, strategy fall-through,
  RPC fallback), `dom-intelligence.test.ts` (`getSmartSnapshotViaEval` shape,
  1-based `data-wmux-ref`, `elementCache` population for the mode-flip case).
- **Full suite:** `npx vitest run` -> 2212 passed (0 failed).
- **Typecheck/build:** `tsc -p tsconfig.mcp.json` + `npm run build:mcp` green.
- **Lint:** no new findings (2 pre-existing warnings unrelated to this change).
- **Packaged smoke test: PENDING.** This only reproduces in a packaged build, so
  the real check is `browser_extract_text` / `browser_smart_snapshot` on a real
  page in an `npm run make` bundle with a fresh daemon. The fix rides the
  `browser.evaluate` RPC path that `browser_evaluate` already exercises
  successfully in packaged builds (#104), and unit tests cover the Node-side
  logic — but please do not merge before a packaged run. @junbeom09 has the setup.

## Reviewer notes (limitations / trade-offs)

- **`smart_snapshot` RPC fidelity:** roles come from a tag/`role`-attr heuristic,
  not the CDP accessibility tree. Only on the packaged (page-null) path; dev keeps
  full fidelity.
- **RPC 10s timeout on huge pages:** `extractMarkdown` transfers the full
  serialized DOM tree before Node-side truncation, and the RPC client has a hard
  10s timeout the CDP path doesn't. On a pathological multi-MB DOM the RPC path
  could time out where Playwright would survive. Accepted — common pages work and
  "times out" still beats "always throws". A node-count cap in the serialise
  script is a possible future hardening (deferred; it would alter the dev output).
- **`browser_snapshot` RPC fallback ignores `format`** (`aria` only honored on
  the Playwright path). Pre-existing, not introduced here; this PR only swaps its
  inline selector for the shared constant. Possible follow-up.

Closes #105. Follow-up: #106. Context: #104.