### PR TITLE
fix(mcp): allow the bundled first-party MCP server under enforce mode

### DIFF
--- a/plans/first-party-mcp-trust.md
+++ b/plans/first-party-mcp-trust.md
@@ -1,0 +1,258 @@
+# First-Party MCP Trust — production fix for the enforce-mode lockout
+
+Status: IMPLEMENTED (revised per codex adversarial review — see §0)
+Branch base: main (fix to be cut as its own branch)
+Author: investigate session 2026-06-06
+Severity: HIGH — every packaged release since v2.12.0 silently locks the bundled
+MCP server out of all capability-bearing RPCs.
+
+---
+
+## 0. IMPLEMENTED design (supersedes §5 A+C)
+
+Eng review + codex adversarial review killed the original A+C (token) plan. The
+decisive findings (all verified against code):
+
+- **C is an incomplete safety net.** The bundled server calls `surface.list`
+  and `company.a2a.*`, which map to `wmux.internal` in methodCapabilityMap.
+  `permissionGrammar` forbids `wmux.*` in any declaration, so declare/approve
+  (and pre-seed) can NEVER unblock those tools. Approach C alone leaves them
+  broken.
+- **`ctx.firstParty => allow` over-grants.** A blanket per-request bypass would
+  open `daemon.*`, `workspace.new`, `company.*`, `hooks.signal` on any token
+  leak — broader than pre-trusting the name.
+- **Token-in-args buys ~nothing.** `~/.claude.json` is plain-written (no ACL);
+  a same-user process that can read it can already read the daemon auth token
+  and call the pipe directly. Second bearer secret, worse location.
+
+**Implemented instead: name-recognized, scoped method allowlist in the enforcer.**
+
+- `src/main/mcp/firstParty.ts` (new): `FIRST_PARTY_CLIENT_NAMES = {'claude-code'}`
+  and `FIRST_PARTY_METHODS` = the exact RPC set the bundled server calls
+  (browser.* incl. CDP fallbacks, pane.*, meta.setSkills, input.*,
+  terminal.readEvents, events.poll, a2a.*, the `wmux.internal` company.a2a.* +
+  surface.list, workspace.list, mcp.*). `isFirstPartyClient()`.
+- `src/main/mcp/PermissionEnforcer.ts`: after the legacy/`!clientName` branch and
+  before the unconfirmed reject — `if (isFirstPartyClient(ctx.clientName) &&
+  trust?.status !== 'denied' && FIRST_PARTY_METHODS.has(method)) return allow`.
+  Denied still wins (escape hatch); non-allowlisted methods fall through to
+  normal enforcement (no silent widening).
+- **No wire-format change, no secret, no args injection, no McpRegistrar/
+  PipeServer/bundled-server change.** The bundled server already stamps
+  `clientName='claude-code'` (shipped in #71), so the enforcer change alone
+  fixes the lockout. ~2 files + 3 test files.
+
+Security posture (documented, matches the spec's "declared, not verified"
+stance): recognition is by self-asserted clientName. On a single-user OS this
+is no weaker than any local secret. What the *scoped* allowlist buys over a
+blanket bypass: even a clientName impersonator only reaches the curated method
+set — never daemon/ workspace-mutation/ company-mutation/ reserved surface.
+
+### Verification (dynamic, 2026-06-06)
+- `tsc -p tsconfig.json` clean. `build:daemon` + `build:mcp` clean (no bundle drift).
+- New tests 18/18: `firstParty.test.ts` (source-invariant — parses src/mcp/** so
+  the allowlist can't drift from the tools), `PermissionEnforcer.firstParty.test.ts`,
+  `RpcRouter.firstParty.enforce.test.ts` (real RpcRouter + real PluginTrustStore
+  dispatched in **enforce mode** — reproduces the exact live failure: claude-code
+  `unconfirmed` → browser.open/surface.list/company.a2a.whoami now pass; external
+  plugin + reserved methods still rejected; denied honored).
+- Full parallel lane: **2236/2236 pass**, zero regressions.
+- Remaining last-mile: relaunch the packaged app with this fix and call
+  `browser_open` from inside wmux (the enforcer runs in the Electron main
+  process, which the user must rebuild+restart — can't self-restart from inside).
+
+---
+
+## 1. Symptom
+
+In a packaged build, every wmux MCP tool fails with:
+
+```
+browser.open: plugin is unconfirmed; call mcp.identify + mcp.declarePermissions first
+```
+
+`a2a.whoami`, `pane.*`, `browser.*`, everything capability-bearing — all rejected.
+Host Claude Code restart does not help.
+
+## 2. Root cause (confirmed, code + live evidence)
+
+v2.12.0 (#71, commit `7b4d201`) shipped two things together:
+
+1. Production default `enforcementMode = 'enforce'`
+   (`src/main/mcp/enforcementMode.ts:33` → `isDev ? 'shadow' : 'enforce'`;
+   `src/main/index.ts:465` → `!app.isPackaged` ⇒ not dev ⇒ enforce).
+2. The bundled MCP server began stamping `clientName = 'claude-code'` on every
+   RPC envelope (`src/mcp/index.ts:704` `setClientIdentity`, `src/mcp/wmux-client.ts:70`).
+
+But the bundled server only ever calls `mcp.identify` (`src/mcp/index.ts:707`).
+It **never calls `mcp.declarePermissions`**, and there is **no first-party
+auto-trust path** anywhere.
+
+Consequence chain in enforce mode:
+- `mcp.identify` → `PluginTrustStore.upsertContact` → record with
+  `status:'unconfirmed'`, `declaredCapabilities: []`.
+- `browser.open` (cap `browser.navigate`) → `PermissionEnforcer.check`
+  (`src/main/mcp/PermissionEnforcer.ts:198`) → reject `identity-status / unconfirmed`.
+- The approval-dialog branch (`src/main/pipe/RpcRouter.ts:277-282`) requires
+  `trust.declaredCapabilities.length > 0` — it is empty, so **no dialog ever fires**.
+- `applyContact` never demotes and there is no auto-promote, so status stays
+  `unconfirmed` forever. **Permanent silent deadlock.**
+
+Live evidence on this machine (packaged build):
+- `~/.wmux/plugin-trust.json` → `"claude-code": { "status":"unconfirmed" }`,
+  no `declaredCapabilities`, never trusted since `firstSeen`.
+- `~/.wmux/shadow-rejections.log` → repeated
+  `{"clientName":"claude-code","method":"browser.open","rejection":{"status":"unconfirmed","capability":"browser.navigate"}}`.
+- `~/.wmux/config.json` has no `mcp.mode` override ⇒ enforce default applies.
+
+Why it stayed hidden: dev (`npm start`) defaults to **shadow** (allow + log), so
+all in-dev dogfooding worked. This is effectively the first packaged enforce-mode
+exercise of wmux's own MCP tools by the maintainer. Recent browser PRs
+(#104/#107/#108) touched browser internals only, not the enforcement gate — they
+did not cause this and their packaged smoke was pending.
+
+## 3. Why this is a design error, not just a missing call
+
+The enforcement layer exists to scope **external, third-party** MCP plugins and
+to give the user a consent surface for them. wmux's **own bundled MCP server**
+ships inside the app the user installed and launched; it is not a third party.
+Treating it as an untrusted plugin — with no way to ever become trusted — is the
+defect.
+
+## 4. Threat model / constraints (these bound the design)
+
+- **Shared daemon token.** Every pipe client (first-party or external) presents
+  the same `~/.wmux/daemon-auth-token` to talk to the daemon at all
+  (`PipeServer.ts:302` timing-safe compare). The token is an admission gate, not
+  a per-plugin identity.
+- **Declared, not verified identity.** `clientName` is self-asserted; the spec
+  says so explicitly (`src/shared/rpc.ts:14-18`: "declared identity, not a
+  verified one … any caller can self-name"). User approval is the root of trust.
+- **Single-user OS reality.** Any same-user process can read owner-only files and
+  another process's argv. No purely-local secret (env, args, file, compiled
+  constant) can cryptographically separate "wmux's bundled server" from a
+  determined same-user impersonator. A hostile same-user token-holder is already
+  out of scope (it can do anything the user can).
+- **Registration cannot use `env`.** `McpRegistrar` deliberately omits the `env`
+  field (`McpRegistrar.ts:147`) because Claude Code may *replace* (not merge) the
+  child environment and break PATH/USERPROFILE. **`args` are appended**, so args
+  are the only safe injection channel.
+- **Two bundled servers.** `wmux` and `wmux-a2a` are both registered
+  (`McpRegistrar.register`). Both are first-party. (Note: the a2a_* tools the
+  shadow log shows rejected come from the primary `wmux` server, `src/mcp/index.ts`;
+  the separate `wmux-a2a` registration must be confirmed/covered — see §8 open Q.)
+- **The approval machinery is fully wired** and only blocked by the empty
+  declaration: `ApprovalQueue` (`index.ts:469`) → IPC `PERMISSION_PROMPT_OPEN` →
+  `PermissionApprovalDialog.tsx` → `PERMISSION_PROMPT_RESOLVE` →
+  `setUserDecision('trusted')`. So enabling declarations re-activates an existing,
+  tested path.
+
+Design takeaway: the realistic goal is **strictly stronger than name-only trust,
+fail-safe (never a silent deadlock), zero-friction for first-party**, while
+accepting the inherent same-user limit (documented, not pretended-away).
+
+## 5. Recommended approach — A (verified first-party token) + C (declare safety net)
+
+### A. Per-connection verified first-party bypass (primary — makes it silent)
+
+1. **Secret.** Main process owns a stable per-install secret
+   `firstPartySecret` (32-byte random), persisted to `~/.wmux/first-party-secret`
+   with owner-only ACL via the existing `secureWriteTokenFile`, generated once and
+   reused thereafter (mirrors the auth-token reuse in `PipeServer.initAuthToken`,
+   so no per-boot churn / no args staleness).
+2. **Inject via args.** `McpRegistrar.register` appends the secret to BOTH bundled
+   server registrations: `args: [mcpScript, '--wmux-fp', firstPartySecret]`.
+   Stable secret ⇒ args don't churn ⇒ the existing "args changed → rewrite"
+   guard (`McpRegistrar.ts:206`) stays quiet after the one-time migration.
+3. **Present it.** The bundled server reads `--wmux-fp` from `process.argv` at
+   startup (`src/mcp/index.ts`) and `wmux-client.ts` adds `firstPartyToken` to
+   every RPC envelope (next to `clientName`).
+4. **Verify it.** `RpcRouter` gets an injected verifier
+   (`setFirstPartyVerifier(fn)`, mirroring `setTrustLookup`). In `dispatch`, after
+   building `ctx`, it constant-time-compares `request.firstPartyToken` to the
+   secret and sets `ctx.firstParty = true` on match. The compare lives in main,
+   which holds the secret in memory — no extra cross-process plumbing.
+5. **Honor it.** `PermissionEnforcer.check`: add at the top, right after the
+   totality guard — `if (input.ctx.firstParty) return { kind: 'allow' }`. Pure
+   function unchanged (ctx is already an input). **No trust-DB write** — first
+   party is a per-connection property, so a later `clientName:'claude-code'`
+   plugin without the secret inherits nothing.
+
+### C. Declaration safety net (built-in — makes failure recoverable, never silent)
+
+6. After `mcp.identify`, the bundled server also calls `mcp.declarePermissions`
+   with its full first-party capability set (the KNOWN_CAPABILITIES the bundled
+   tools actually use: `browser.*`, `a2a.*`, `pane.*`, `meta.*`, `terminal.*`,
+   `events.subscribe`, `workspace.read`, `workspace.claim`, `pane.search`).
+   Effect: if the token path ever fails (registration skew right after an upgrade,
+   missing secret, stripped arg), the server is `unconfirmed` **with a
+   declaration**, so the approval dialog **fires** (`RpcRouter.ts:280` satisfied)
+   and the user gets one "Allow wmux's tools?" click — degraded, not deadlocked.
+   On approve → `trusted` persists → silent thereafter even without the token.
+
+Net behavior:
+- Normal packaged run: token verified ⇒ **zero clicks**, everything works.
+- Token path broken for any reason: **one approval dialog**, then trusted.
+- Never a silent permanent lockout again.
+
+### Files touched (estimate)
+- `src/main/pipe/RpcRouter.ts` — `firstPartyVerifier` field + setter; ctx.firstParty.
+- `src/shared/rpc.ts` — `RpcRequest.firstPartyToken?`, `RpcContext.firstParty?`.
+- `src/main/mcp/PermissionEnforcer.ts` — one early allow branch.
+- `src/main/index.ts` — load/generate secret, `setFirstPartyVerifier`, pass secret to registrar.
+- `src/main/mcp/McpRegistrar.ts` — append `--wmux-fp` to both registrations; secret param.
+- `src/mcp/index.ts` — parse `--wmux-fp`; call `declarePermissions` after identify.
+- `src/mcp/wmux-client.ts` — stash fp token; add to envelope.
+- `src/shared/constants.ts` — `getFirstPartySecretPath()`.
+- Tests: enforcer first-party allow; RpcRouter verifier (match/mismatch/absent);
+  registrar args injection; envelope round-trip; e2e dynamic (bundled daemon +
+  RPC probe) proving browser.open passes with token and dialog-fires without.
+
+## 6. Alternatives considered
+
+- **B. McpRegistrar pre-seeds `claude-code: trusted` (+ declared caps) in
+  plugin-trust.json.** Simplest (no envelope/bundled-server change), but: pollutes
+  the name-keyed DB so ANY `clientName:'claude-code'` client inherits full trust;
+  crosses a concern boundary (registrar managing the trust DB); stale 'trusted'
+  row survives installs. Security-equivalent to A against same-user, weaker against
+  accidental name collision. Keep as fallback if A is deemed too big for a hotfix.
+- **C alone (declare only, no token).** Smallest diff; correct fail-safe; but costs
+  the user one approval click on first run / after any widened declaration. The
+  maintainer explicitly chose "automatic trust" (zero friction), so C-alone misses
+  intent — but C is retained as A's safety net.
+- **OS peer-credential verification (pipe client PID → image path/signature).**
+  The only truly-verified option, but the bundled server runs as `node.exe`
+  spawned by Claude Code (not by wmux), so PID→image can't distinguish it from any
+  other node process; fragile cross-platform. Rejected.
+
+## 7. Rollout
+
+- Cut `fix/first-party-mcp-trust` from `main` (not from the taskbar branch).
+- Land behind the existing enforce/shadow switch — dev stays shadow, so the token
+  path is exercised only where it matters (packaged/enforce) and dev keeps working
+  even mid-implementation.
+- Patch release (v2.16.x). CHANGELOG: "Fixed: wmux's own MCP tools (browser,
+  terminal, panes) were blocked in packaged builds under permission enforcement."
+- Dynamic verification in a bundled daemon subprocess (template:
+  `scripts/v281-dynamic-test.mjs`) BEFORE any release — this bug is invisible to
+  unit tests and to dev/shadow.
+
+## 8. Open questions for eng review
+
+1. Token transport: per-RPC envelope field (stateless verify, simplest) vs.
+   verify-once-on-identify and mark the connection (less data on the wire, but
+   the pipe is connection-per-request here — confirm there's no persistent
+   connection to pin to). Leaning per-RPC.
+2. Does the separate `wmux-a2a` registration share `wmux-client.ts`/argv parsing,
+   or does it need its own injection? Confirm the a2a bundle source path
+   (`dist/mcp/mcp/a2a/index.js`) and that the secret reaches it.
+3. Should the full first-party capability set be derived from a single source of
+   truth (e.g. `listKnownCapabilities()` minus reserved) so it can't drift from
+   the methods the bundled tools actually call?
+4. Secret lifecycle: stable-per-install (recommended, no staleness) vs. rotate on
+   `rotateAuthToken`. If we ever rotate, McpRegistrar must rewrite args AND the
+   user must restart Claude Code — the safety net covers the gap, but call it out.
+5. Is documenting the residual same-user impersonation risk in
+   `docs/api/mcp-plugin-spec.md` sufficient, or does the threat model need an
+   explicit "first-party is best-effort, not a security boundary against same-user
+   code" statement?

--- a/src/main/mcp/PermissionEnforcer.ts
+++ b/src/main/mcp/PermissionEnforcer.ts
@@ -54,6 +54,7 @@ import {
   parsePermission,
   type ParsedPermission,
 } from './permissionGrammar';
+import { FIRST_PARTY_METHODS, isFirstPartyClient } from './firstParty';
 
 export type EnforcerOutcome =
   | { kind: 'allow' }
@@ -161,6 +162,28 @@ export function check(input: EnforcerInput): EnforcerOutcome {
   // Legacy: caller didn't send a clientName envelope, RpcRouter is already
   // grandfathering them via the legacy recorder. Allow at this layer.
   if (!input.ctx.clientName) {
+    return { kind: 'allow' };
+  }
+
+  // First-party bundled wmux MCP server (recognised by the host clientName it
+  // reports). It ships inside wmux and never goes through the external-plugin
+  // declare/approve flow — and it couldn't if it tried, because several tools
+  // it exposes map to `wmux.internal` methods (surface.list, company.a2a.*)
+  // that the permission grammar forbids from any declaration. Grant exactly
+  // the method set it calls (firstParty.ts), nothing more, regardless of the
+  // trust-DB `unconfirmed` status that the bundled server is otherwise stuck
+  // in. Two guards keep this from becoming a blanket bypass:
+  //   - An explicit user `denied` still wins (operator escape hatch): fall
+  //     through to the `denied` branch below.
+  //   - A method outside the curated allowlist also falls through to normal
+  //     enforcement, so a coverage gap surfaces as a rejection instead of
+  //     silently widening first-party scope.
+  // See plans/first-party-mcp-trust.md and docs/api/mcp-plugin-spec.md.
+  if (
+    isFirstPartyClient(input.ctx.clientName) &&
+    input.trust?.status !== 'denied' &&
+    FIRST_PARTY_METHODS.has(input.method)
+  ) {
     return { kind: 'allow' };
   }
 

--- a/src/main/mcp/PermissionEnforcer.ts
+++ b/src/main/mcp/PermissionEnforcer.ts
@@ -71,6 +71,19 @@ export interface EnforcerInput {
   ctx: RpcContext;
   /** Trust record for `ctx.clientName`, or `undefined` if none exists. */
   trust: PluginIdentityRecord | undefined;
+  /**
+   * True when the trust-store lookup *threw* (corrupt DB / I/O error) instead
+   * of cleanly resolving to "no record". The two cases look identical at the
+   * `trust === undefined` level but must NOT be treated the same: a clean miss
+   * is a fresh first-party caller (grant the bypass), whereas a failed read
+   * means an operator `denied` row might exist but couldn't be loaded — so the
+   * first-party bypass declines on this unknown state and lets the caller fall
+   * through to the normal (fail-closed) ladder. Non-first-party callers already
+   * fail closed here regardless; this keeps first-party symmetric for the
+   * security-relevant `denied` case. Defaults to `false` when omitted (the
+   * common path and every unit test that doesn't exercise a lookup failure).
+   */
+  trustLookupFailed?: boolean;
 }
 
 /**
@@ -172,15 +185,21 @@ export function check(input: EnforcerInput): EnforcerOutcome {
   // that the permission grammar forbids from any declaration. Grant exactly
   // the method set it calls (firstParty.ts), nothing more, regardless of the
   // trust-DB `unconfirmed` status that the bundled server is otherwise stuck
-  // in. Two guards keep this from becoming a blanket bypass:
+  // in. Three guards keep this from becoming a blanket bypass:
   //   - An explicit user `denied` still wins (operator escape hatch): fall
   //     through to the `denied` branch below.
+  //   - A failed trust lookup (corrupt DB / I/O error, signalled by
+  //     `trustLookupFailed`) is an UNKNOWN state, not a clean miss: a `denied`
+  //     row may exist but be unreadable, so we decline the bypass and fall
+  //     through to fail-closed enforcement rather than honoring the bundled
+  //     server while an operator's `denied` couldn't be loaded.
   //   - A method outside the curated allowlist also falls through to normal
   //     enforcement, so a coverage gap surfaces as a rejection instead of
   //     silently widening first-party scope.
   // See plans/first-party-mcp-trust.md and docs/api/mcp-plugin-spec.md.
   if (
     isFirstPartyClient(input.ctx.clientName) &&
+    !input.trustLookupFailed &&
     input.trust?.status !== 'denied' &&
     FIRST_PARTY_METHODS.has(input.method)
   ) {

--- a/src/main/mcp/__tests__/PermissionEnforcer.firstParty.test.ts
+++ b/src/main/mcp/__tests__/PermissionEnforcer.firstParty.test.ts
@@ -130,4 +130,40 @@ describe('PermissionEnforcer.check — first-party allowlist', () => {
       expect(out.kind, `${method} must never be first-party-allowed`).toBe('reject');
     }
   });
+
+  it('SECURITY: declines the first-party bypass when the trust lookup FAILED (a denied row may be unreadable)', () => {
+    // A clean miss (trust=undefined, no failure) grants the bypass — see the
+    // "NO trust record" test above. But when the trust-store read THREW (corrupt
+    // DB / I/O), an operator `denied` row might exist and merely be unreadable.
+    // Honoring first-party here would silently bypass that escape hatch, so the
+    // enforcer must fall through to the fail-closed ladder instead. Symmetric
+    // with non-first-party callers, which already fail closed on undefined trust.
+    for (const method of SAMPLE_ALLOWED) {
+      const out = check({
+        method,
+        params: {},
+        ctx: ctx(FP),
+        trust: undefined,
+        trustLookupFailed: true,
+      });
+      expect(out.kind, `${method} must not be first-party-allowed on a failed lookup`).toBe(
+        'reject',
+      );
+    }
+  });
+
+  it('still grants the first-party bypass on a clean miss (trustLookupFailed=false)', () => {
+    // Regression guard for the live boot path: trust=undefined from a clean
+    // lookup is the fresh-identify case and MUST keep working unchanged.
+    for (const method of SAMPLE_ALLOWED) {
+      const out = check({
+        method,
+        params: {},
+        ctx: ctx(FP),
+        trust: undefined,
+        trustLookupFailed: false,
+      });
+      expect(out, `${method} should be allowed on a clean miss`).toEqual({ kind: 'allow' });
+    }
+  });
 });

--- a/src/main/mcp/__tests__/PermissionEnforcer.firstParty.test.ts
+++ b/src/main/mcp/__tests__/PermissionEnforcer.firstParty.test.ts
@@ -1,0 +1,133 @@
+// First-party scoped-allowlist behavior in the Phase 2.2 enforcer.
+//
+// These cover the production lockout fix (plans/first-party-mcp-trust.md): the
+// bundled wmux MCP server identifies as `claude-code` and is recorded
+// `unconfirmed` in the trust DB, but must still be allowed to call the method
+// set it actually uses — including `wmux.internal` methods (surface.list,
+// company.a2a.*) that can never be declared/approved.
+
+import { describe, expect, it } from 'vitest';
+import type { PluginIdentityRecord, RpcContext, RpcMethod } from '../../../shared/rpc';
+import { check } from '../PermissionEnforcer';
+import { FIRST_PARTY_METHODS } from '../firstParty';
+
+function trust(
+  overrides: Partial<PluginIdentityRecord> & Pick<PluginIdentityRecord, 'name' | 'status'>,
+): PluginIdentityRecord {
+  return { firstSeen: 1000, lastSeen: 2000, ...overrides };
+}
+function ctx(clientName?: string): RpcContext {
+  return clientName ? { clientName } : {};
+}
+
+const FP = 'claude-code';
+// A representative spread of the allowlist: a normal capability method, a
+// path-scoped one, and two that map to `wmux.internal` (the whole reason the
+// allowlist exists — these can never be granted via declaration).
+const SAMPLE_ALLOWED: RpcMethod[] = [
+  'browser.open',
+  'pane.setMetadata',
+  'surface.list',
+  'company.a2a.whoami',
+];
+
+describe('PermissionEnforcer.check — first-party allowlist', () => {
+  it('allows allowlisted methods for claude-code even when status=unconfirmed', () => {
+    for (const method of SAMPLE_ALLOWED) {
+      const out = check({
+        method,
+        params: {},
+        ctx: ctx(FP),
+        trust: trust({ name: FP, status: 'unconfirmed' }),
+      });
+      expect(out, `${method} should be allowed for first-party/unconfirmed`).toEqual({
+        kind: 'allow',
+      });
+    }
+  });
+
+  it('allows allowlisted methods for claude-code with NO trust record (fresh identify)', () => {
+    // The actual live scenario: claude-code called mcp.identify, then a tool
+    // RPC arrives before/without any declaration. trust may be undefined or a
+    // bare unconfirmed row — either way the bundled server must work.
+    const out = check({
+      method: 'surface.list',
+      params: {},
+      ctx: ctx(FP),
+      trust: undefined,
+    });
+    expect(out).toEqual({ kind: 'allow' });
+  });
+
+  it('allows wmux.internal methods (surface.list, company.a2a.*) that can never be declared', () => {
+    for (const method of ['surface.list', 'company.a2a.send', 'company.a2a.status'] as const) {
+      const out = check({
+        method,
+        params: {},
+        ctx: ctx(FP),
+        trust: trust({ name: FP, status: 'unconfirmed' }),
+      });
+      expect(out, `${method}`).toEqual({ kind: 'allow' });
+    }
+  });
+
+  it('honors an explicit denied as an operator escape hatch (denied wins over first-party)', () => {
+    const out = check({
+      method: 'browser.open',
+      params: {},
+      ctx: ctx(FP),
+      trust: trust({ name: FP, status: 'denied' }),
+    });
+    expect(out.kind).toBe('reject');
+    if (out.kind !== 'reject' || out.rejection.reason !== 'identity-status') {
+      throw new Error('expected identity-status rejection');
+    }
+    expect(out.rejection.status).toBe('denied');
+  });
+
+  it('does NOT widen scope: a non-allowlisted method falls through to normal enforcement', () => {
+    // daemon.shutdown / workspace.new are NOT in FIRST_PARTY_METHODS. Even for
+    // claude-code they must NOT be auto-allowed — they fall through to the
+    // unconfirmed/capability path and reject.
+    for (const method of ['workspace.new', 'daemon.shutdown'] as const) {
+      expect(FIRST_PARTY_METHODS.has(method)).toBe(false);
+      const out = check({
+        method,
+        params: {},
+        ctx: ctx(FP),
+        trust: trust({ name: FP, status: 'unconfirmed' }),
+      });
+      expect(out.kind, `${method} must not be auto-allowed for first-party`).toBe('reject');
+    }
+  });
+
+  it('SECURITY: a non-first-party clientName does NOT get the bypass for the same method', () => {
+    // The bypass keys on the exact first-party clientName. An external plugin
+    // reporting some other name hits the normal unconfirmed rejection — it
+    // cannot reach the allowlist by calling an allowlisted method.
+    for (const method of SAMPLE_ALLOWED) {
+      const out = check({
+        method,
+        params: {},
+        ctx: ctx('totally-not-claude-code'),
+        trust: trust({ name: 'totally-not-claude-code', status: 'unconfirmed' }),
+      });
+      expect(out.kind, `${method} must be rejected for a non-first-party caller`).toBe('reject');
+    }
+  });
+
+  it('SECURITY: even spoofing clientName="claude-code" only reaches the curated set, never reserved daemon methods', () => {
+    // Defense-in-depth assertion: the worst a clientName impersonator (who
+    // already needs the daemon auth token) can do via the first-party path is
+    // the allowlist — never daemon.shutdown/compact or company mutation.
+    for (const method of ['daemon.shutdown', 'daemon.compact', 'company.create'] as const) {
+      const out = check({
+        method,
+        params: {},
+        ctx: ctx(FP),
+        trust: trust({ name: FP, status: 'unconfirmed' }),
+      });
+      expect(out.kind, `${method} must never be first-party-allowed`).toBe('reject');
+    }
+  });
+});

--- a/src/main/mcp/__tests__/firstParty.test.ts
+++ b/src/main/mcp/__tests__/firstParty.test.ts
@@ -1,0 +1,105 @@
+// Source-invariant guard for FIRST_PARTY_METHODS.
+//
+// The first-party allowlist (firstParty.ts) must stay a superset of every RPC
+// method the bundled MCP server actually calls — otherwise a tool silently
+// breaks under enforce mode. Rather than trust a hand-maintained list, this
+// test parses the real bundled-server source (src/mcp/**) for every
+// callRpc/sendRpc method literal and fails if any valid RpcMethod is missing
+// from the allowlist. Add a tool that calls a new RPC → this test tells you to
+// allowlist it.
+
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { FIRST_PARTY_CLIENT_NAMES, FIRST_PARTY_METHODS, isFirstPartyClient } from '../firstParty';
+import { METHOD_CAPABILITY } from '../methodCapabilityMap';
+import type { RpcMethod } from '../../../shared/rpc';
+
+// src/main/mcp/__tests__ -> src/mcp
+const MCP_DIR = path.resolve(__dirname, '..', '..', '..', 'mcp');
+
+function collectTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+      out.push(...collectTsFiles(full));
+    } else if (
+      entry.name.endsWith('.ts') &&
+      !entry.name.endsWith('.test.ts') &&
+      !entry.name.endsWith('.d.ts')
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function extractCalledMethods(): Set<string> {
+  const called = new Set<string>();
+  const re = /\b(?:callRpc|sendRpc)\(\s*'([a-zA-Z0-9_.]+)'/g;
+  for (const file of collectTsFiles(MCP_DIR)) {
+    const src = fs.readFileSync(file, 'utf8');
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(src)) !== null) {
+      called.add(m[1]);
+    }
+  }
+  return called;
+}
+
+const VALID_METHODS = new Set<string>(Object.keys(METHOD_CAPABILITY));
+
+describe('FIRST_PARTY_METHODS source invariant', () => {
+  it('found a non-trivial set of bundled-server RPC calls (parser sanity)', () => {
+    const called = extractCalledMethods();
+    // If this drops near zero the regex/path broke and the invariant is vacuous.
+    expect(called.size).toBeGreaterThan(20);
+  });
+
+  it('covers every valid RpcMethod the bundled MCP server calls', () => {
+    const called = extractCalledMethods();
+    const missing = [...called]
+      .filter((m) => VALID_METHODS.has(m)) // drop event-topic strings (pane.closed, ...)
+      .filter((m) => !FIRST_PARTY_METHODS.has(m as RpcMethod))
+      .sort();
+    expect(
+      missing,
+      `These methods are called by src/mcp/** but missing from FIRST_PARTY_METHODS — ` +
+        `add them to firstParty.ts or the tool will break under enforce mode:\n  ${missing.join(
+          '\n  ',
+        )}`,
+    ).toEqual([]);
+  });
+
+  it('every entry in FIRST_PARTY_METHODS is a real RpcMethod (no typos / dead entries)', () => {
+    const bogus = [...FIRST_PARTY_METHODS].filter((m) => !VALID_METHODS.has(m)).sort();
+    expect(bogus, `FIRST_PARTY_METHODS contains non-RpcMethod entries`).toEqual([]);
+  });
+
+  it('does not allowlist reserved/destructive surface (least privilege)', () => {
+    // These must NEVER be first-party-granted; the bundled server does not call
+    // them and a clientName impersonator must not reach them.
+    for (const m of [
+      'daemon.shutdown',
+      'daemon.compact',
+      'workspace.new',
+      'workspace.close',
+      'company.create',
+      'company.destroy',
+    ] as const) {
+      expect(FIRST_PARTY_METHODS.has(m)).toBe(false);
+    }
+  });
+});
+
+describe('isFirstPartyClient', () => {
+  it('recognizes claude-code, rejects everything else', () => {
+    expect(isFirstPartyClient('claude-code')).toBe(true);
+    expect(FIRST_PARTY_CLIENT_NAMES.has('claude-code')).toBe(true);
+    for (const name of [undefined, '', 'claude', 'Claude-Code', 'evil', 'wmux-orchestrator-e2e']) {
+      expect(isFirstPartyClient(name as string | undefined)).toBe(false);
+    }
+  });
+});

--- a/src/main/mcp/firstParty.ts
+++ b/src/main/mcp/firstParty.ts
@@ -1,0 +1,117 @@
+// First-party MCP recognition for the Phase 2.2 permission enforcer.
+//
+// Why this exists
+// ---------------
+// wmux ships its own MCP server (`src/mcp/index.ts`, the `wmux` plugin Claude
+// Code talks to). In a packaged build the daemon runs the enforcer in
+// `enforce` mode (enforcementMode.ts), and the bundled server is recorded in
+// the trust DB as `unconfirmed` because it only ever calls `mcp.identify`,
+// never `mcp.declarePermissions`. That left every capability-bearing RPC it
+// makes (browser.*, pane.*, a2a.*, ...) rejected with no path to recover:
+// the approval dialog only fires for plugins that declared a non-empty
+// capability set, so the bundled server deadlocked permanently. See
+// `plans/first-party-mcp-trust.md`.
+//
+// It can't go through the normal declare/approve flow either: several tools
+// it exposes map to `wmux.internal` methods (surface.list, company.a2a.*)
+// which `permissionGrammar` deliberately forbids from ever appearing in a
+// declaration (RESERVED_PREFIXES = ['wmux.']). No amount of user approval can
+// grant those.
+//
+// The fix: recognise the bundled server by the host clientName it reports and
+// allow exactly the method set it actually calls — nothing more. This is a
+// scoped allowlist, NOT a blanket "first party can do anything" bypass: a
+// method outside the set falls through to normal enforcement, and an explicit
+// user `denied` still wins (see PermissionEnforcer.check).
+//
+// Threat model (matches the spec's "declared, not verified" stance, rpc.ts):
+// recognition is by self-asserted clientName. On a single-user OS this is no
+// weaker than any local secret — a same-user process that wanted to
+// impersonate the host already holds the daemon auth token and could call the
+// pipe directly. What the scoped allowlist buys over a blanket bypass is that
+// even an impersonator only reaches the curated method set, never daemon.*,
+// workspace.new, company mutation, or other reserved surface. Documented in
+// docs/api/mcp-plugin-spec.md.
+
+import type { RpcMethod } from '../../shared/rpc';
+
+// Host identities that own the bundled wmux MCP server. The server reports the
+// connecting MCP client's `clientInfo.name` (see wireClientIdentityHook in
+// src/mcp/index.ts); Claude Code reports `claude-code`. A Set so additional
+// first-party hosts (e.g. a future wmux-native CLI) can be added without
+// touching the enforcer. Exact match — `clientName` is already trimmed by
+// PipeServer when it builds RpcContext.
+export const FIRST_PARTY_CLIENT_NAMES: ReadonlySet<string> = new Set<string>([
+  'claude-code',
+]);
+
+// The exact RPC methods the bundled MCP server (src/mcp/index.ts and its
+// src/mcp/playwright/* helpers) invokes. Kept in lockstep with that surface by
+// `firstParty.test.ts`, which parses src/mcp/ for every callRpc/sendRpc method
+// literal and fails if any is missing here. Least privilege: methods the
+// bundled server does NOT call (e.g. daemon.shutdown, workspace.new,
+// company.create) are intentionally absent, so a clientName impersonator can
+// never reach them through the first-party path.
+export const FIRST_PARTY_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
+  // identity / workspace bootstrap
+  'mcp.identify',
+  'mcp.claimWorkspace',
+  'workspace.list',
+  'surface.list',
+  // panes + metadata
+  'pane.list',
+  'pane.search',
+  'pane.getMetadata',
+  'pane.setMetadata',
+  'meta.setSkills',
+  // terminal IO
+  'input.send',
+  'input.sendKey',
+  'input.readScreen',
+  'terminal.readEvents',
+  // events
+  'events.poll',
+  // browser (Playwright + packaged CDP/RPC fallbacks)
+  'browser.open',
+  'browser.navigate',
+  'browser.goBack',
+  'browser.close',
+  'browser.session.start',
+  'browser.session.stop',
+  'browser.session.status',
+  'browser.session.list',
+  'browser.screenshot',
+  'browser.evaluate',
+  'browser.cdp.info',
+  'browser.console.get',
+  'browser.network.get',
+  'browser.responseBody.get',
+  'browser.click.cdp',
+  'browser.type.cdp',
+  'browser.press.cdp',
+  // agent-to-agent
+  'a2a.resolve.identity',
+  'a2a.whoami',
+  'a2a.discover',
+  'a2a.task.send',
+  'a2a.task.query',
+  'a2a.task.update',
+  'a2a.task.cancel',
+  'a2a.broadcast',
+  // company mode (all wmux.internal — undeclarable, hence the need for this list)
+  'company.a2a.whoami',
+  'company.a2a.send',
+  'company.a2a.broadcast',
+  'company.a2a.inbox',
+  'company.a2a.ack',
+  'company.a2a.status',
+]);
+
+/**
+ * True when `clientName` identifies the bundled first-party wmux MCP server.
+ * `undefined` / unknown names are NOT first-party — envelope-less callers are
+ * already handled by the enforcer's `legacy` grandfather branch.
+ */
+export function isFirstPartyClient(clientName: string | undefined): boolean {
+  return typeof clientName === 'string' && FIRST_PARTY_CLIENT_NAMES.has(clientName);
+}

--- a/src/main/pipe/RpcRouter.ts
+++ b/src/main/pipe/RpcRouter.ts
@@ -235,14 +235,20 @@ export class RpcRouter {
     // enforce-mode flip (pre-commit 6) will gate handler invocation on
     // the outcome and convert rejections into RpcResponse failures.
     let trust: PluginIdentityRecord | undefined;
+    let trustLookupFailed = false;
     if (ctx.clientName && this.trustLookup) {
       try {
         trust = await this.trustLookup(ctx.clientName);
       } catch {
-        // Trust DB read errors fall through as undefined — the enforcer
-        // treats that as "self-named but not yet recorded" (unconfirmed),
-        // which in shadow mode just generates a log entry.
+        // Trust DB read error (corrupt file / I/O). This is NOT the same as a
+        // clean "no record" miss: flag it so the enforcer can distinguish them.
+        // For a normal plugin the outcome is identical (unconfirmed → reject in
+        // enforce mode), but for the first-party bypass it matters — an operator
+        // `denied` row that simply couldn't be read must not be silently
+        // bypassed. The enforcer declines the first-party bypass on this unknown
+        // state and falls through to the fail-closed ladder.
         trust = undefined;
+        trustLookupFailed = true;
       }
     }
     const outcome = enforcerCheck({
@@ -250,6 +256,7 @@ export class RpcRouter {
       params: request.params ?? {},
       ctx,
       trust,
+      trustLookupFailed,
     });
     if (outcome.kind !== 'allow' && this.shadowSink) {
       try {

--- a/src/main/pipe/__tests__/RpcRouter.firstParty.enforce.test.ts
+++ b/src/main/pipe/__tests__/RpcRouter.firstParty.enforce.test.ts
@@ -141,4 +141,24 @@ describe('enforce-mode dispatch — first-party bundled server (the lockout fix)
     });
     expect(res.ok).toBe(false); // confirms enforce mode blocks, not shadow
   });
+
+  it('SECURITY: a failing trust lookup denies the first-party bypass (a denied row could be unreadable)', async () => {
+    // Simulate a corrupt / unreadable trust DB by making the lookup throw
+    // instead of cleanly resolving. A clean miss grants the bypass (see the
+    // "NO trust record" case above), but a *failed* read is an unknown state:
+    // an operator `denied` row might exist and merely be unreadable, so
+    // first-party must fall through to fail-closed enforcement rather than
+    // silently honoring claude-code. Without trustLookupFailed plumbing this
+    // call would wrongly succeed.
+    router.setTrustLookup(async () => {
+      throw new Error('simulated corrupt plugin-trust.json');
+    });
+    const res = await router.dispatch({
+      id: 'fp-lookup-fail',
+      method: 'browser.open',
+      params: {},
+      clientName: CLAUDE,
+    });
+    expect(res.ok, 'first-party must not be allowed when the trust lookup throws').toBe(false);
+  });
 });

--- a/src/main/pipe/__tests__/RpcRouter.firstParty.enforce.test.ts
+++ b/src/main/pipe/__tests__/RpcRouter.firstParty.enforce.test.ts
@@ -1,0 +1,144 @@
+// Dynamic verification of the first-party lockout fix through the REAL
+// enforce-mode dispatch pipeline.
+//
+// This reproduces the exact production scenario that was broken
+// (plans/first-party-mcp-trust.md): a packaged build runs the enforcer in
+// `enforce` mode, the bundled MCP server identifies as `claude-code` and is
+// recorded `unconfirmed`, and every capability-bearing RPC it makes was
+// rejected with no recovery path. We wire the production objects (real
+// RpcRouter + real PluginTrustStore on an isolated tmpdir + the real enforcer)
+// exactly like src/main/index.ts, flip enforce mode on, and assert the bundled
+// server's calls now pass while an impersonator and reserved methods do not.
+//
+// Per-module unit tests can't catch a regression in this wiring — only
+// dispatching through the assembled pipeline can.
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { RpcRouter } from '../RpcRouter';
+import { PluginTrustStore } from '../../mcp/PluginTrustStore';
+import { registerMcpPluginRpc } from '../handlers/mcp.rpc';
+
+let tmpDir = '';
+let store: PluginTrustStore;
+let router: RpcRouter;
+
+function wireEnforced(): void {
+  registerMcpPluginRpc(router, store);
+  // Stub handlers for the methods under test (handler bodies are irrelevant —
+  // we assert on whether the enforcer let dispatch REACH them).
+  router.register('browser.open', async () => ({ ok: true, opened: true }));
+  router.register('surface.list', async () => ({ surfaces: [] }));
+  router.register('company.a2a.whoami', async () => ({ name: 'agent' }));
+  router.register('pane.setMetadata', async () => ({
+    ok: true,
+    paneId: 'p1',
+    metadata: { custom: {} },
+    version: 1,
+  }));
+  router.register('workspace.new', async () => ({ ok: true, id: 'ws-2' }));
+  router.setTrustLookup(async (name) => store.get(name));
+  router.setEnforcementMode('enforce');
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-fp-enforce-'));
+  store = new PluginTrustStore(path.join(tmpDir, 'plugin-trust.json'));
+  router = new RpcRouter();
+  wireEnforced();
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+const CLAUDE = 'claude-code';
+
+describe('enforce-mode dispatch — first-party bundled server (the lockout fix)', () => {
+  it('allows browser.open / surface.list / company.a2a.whoami for claude-code recorded unconfirmed', async () => {
+    // Mirror the live trust DB: mcp.identify recorded claude-code unconfirmed,
+    // no declaration. This is the exact state ~/.wmux/plugin-trust.json showed.
+    await store.upsertContact(CLAUDE, '2.1.167');
+    expect((await store.get(CLAUDE))?.status).toBe('unconfirmed');
+
+    for (const method of ['browser.open', 'surface.list', 'company.a2a.whoami'] as const) {
+      const res = await router.dispatch({
+        id: `fp-${method}`,
+        method,
+        params: {},
+        clientName: CLAUDE,
+        clientVersion: '2.1.167',
+      });
+      expect(res.ok, `${method} should pass enforce-mode dispatch for first-party`).toBe(true);
+    }
+  });
+
+  it('allows even with NO trust record at all (tool call racing ahead of identify)', async () => {
+    const res = await router.dispatch({
+      id: 'fp-norecord',
+      method: 'surface.list',
+      params: {},
+      clientName: CLAUDE,
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('REGRESSION GUARD: an external unconfirmed plugin is still rejected for the same methods', async () => {
+    await store.upsertContact('evil-plugin');
+    for (const method of ['browser.open', 'surface.list', 'company.a2a.whoami'] as const) {
+      const res = await router.dispatch({
+        id: `evil-${method}`,
+        method,
+        params: {},
+        clientName: 'evil-plugin',
+      });
+      expect(res.ok, `${method} must be rejected for a non-first-party plugin`).toBe(false);
+      if (!res.ok) {
+        expect(res.error).toMatch(/unconfirmed/);
+      }
+    }
+  });
+
+  it('does NOT widen scope: claude-code is still rejected for a non-allowlisted method', async () => {
+    await store.upsertContact(CLAUDE);
+    const res = await router.dispatch({
+      id: 'fp-widen',
+      method: 'workspace.new', // wmux.internal, NOT in FIRST_PARTY_METHODS
+      params: {},
+      clientName: CLAUDE,
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it('honors an explicit denied for claude-code (operator escape hatch)', async () => {
+    await store.upsertContact(CLAUDE);
+    await store.setUserDecision(CLAUDE, 'denied');
+    const res = await router.dispatch({
+      id: 'fp-denied',
+      method: 'browser.open',
+      params: {},
+      clientName: CLAUDE,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/denied/);
+  });
+
+  it('control: without the fix path, the same first-party call would have been rejected (sanity on enforce wiring)', async () => {
+    // Prove enforce mode is actually ON: a path-scoped method NOT in the
+    // allowlist, from an unconfirmed external plugin, must hard-fail here.
+    await store.upsertContact('some-plugin');
+    const res = await router.dispatch({
+      id: 'enforce-on',
+      method: 'pane.setMetadata',
+      params: { custom: { 'x.y': 'z' } },
+      clientName: 'some-plugin',
+    });
+    expect(res.ok).toBe(false); // confirms enforce mode blocks, not shadow
+  });
+});


### PR DESCRIPTION
## What's broken

Every wmux MCP tool (`browser_*`, `pane_*`, `a2a_*`, `surface_list`, `company_a2a_*`) fails in packaged builds with:

```
browser.open: plugin is unconfirmed; call mcp.identify + mcp.declarePermissions first
```

This has shipped in every release since v2.12.0 (#71). Dev builds default to shadow mode, so nobody hit it in development. It surfaces the first time the bundled MCP tools are actually used in a packaged enforce-mode build.

## Root cause

Production defaults the permission enforcer to `enforce` (`enforcementMode.ts`). The bundled MCP server stamps `clientName=claude-code` and calls `mcp.identify`, but never `mcp.declarePermissions`, so it sits in the trust DB as `unconfirmed` with no declared capabilities. The enforcer rejects every capability-bearing RPC, and the approval dialog never fires because it requires a non-empty declaration. Permanent silent deadlock, no recovery path.

The declare/approve flow can't fix it anyway: `surface_list` and `company_a2a_*` map to `wmux.internal`, which the permission grammar deliberately forbids from any declaration. No amount of user approval can grant those.

## Fix

Recognize the bundled first-party server by the host clientName and allow exactly the method set it calls (`src/main/mcp/firstParty.ts`), checked in the enforcer. Scoped allowlist, not a blanket bypass:

- a method outside the list falls through to normal enforcement (no silent widening)
- an explicit `denied` still wins (operator escape hatch)
- no wire-format change, no secret, no registrar/transport change. The bundled server already reports its clientName, so the enforcer is the only thing that changes.

An earlier token-based approach was dropped after review: a blanket bypass over-grants `daemon.*`/`workspace.new`/`company.*`, and a token stashed in `~/.claude.json` args is no stronger than the name on a single-user machine (a same-user process that can read the args can already read the daemon auth token).

## Tests

- `RpcRouter.firstParty.enforce.test.ts` — dispatches the real router + trust store in **enforce mode**, reproduces the live failure (`claude-code` unconfirmed), and proves `browser.open` / `surface.list` / `company.a2a.whoami` now pass while an external plugin and reserved methods stay rejected. `denied` is honored.
- `firstParty.test.ts` — source invariant: parses `src/mcp/**` for every `callRpc`/`sendRpc` method and fails if the allowlist drifts from the tools the server actually uses.
- `PermissionEnforcer.firstParty.test.ts` — allow / deny / non-first-party / no-widening.
- Full parallel suite green (2236).

## Still to verify

The enforcer runs in the Electron main process, so the final confirmation needs a packaged rebuild: launch the built app and call `browser_open` from inside wmux. The dynamic test above covers the decision path, but the live end-to-end smoke is the last step before release.
