### PR TITLE
fix(mcp): CDP fallback for browser_wait in packaged builds (#114)

### DIFF
--- a/src/mcp/playwright/__tests__/wait.fallback.test.ts
+++ b/src/mcp/playwright/__tests__/wait.fallback.test.ts
@@ -105,6 +105,38 @@ describe('browser_wait RPC fallback', () => {
     expect(res.content[0].text).toContain('Timed out');
   });
 
+  it('matches zero path segments for a double-star URL glob (**/ is optional subpath)', async () => {
+    // `**/settings` must also match the zero-segment case `/settings`, like waitForURL.
+    mockSendRpc.mockImplementation(evalRouter({
+      'location.href': 'https://site.test/settings',
+      'document.readyState': 'complete',
+    }));
+    const res = await wait({ url: 'https://site.test/**/settings', timeout: 1000 });
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0].text).toContain('URL matched');
+  });
+
+  it('calls a function-expression predicate instead of testing the function object', async () => {
+    mockSendRpc.mockResolvedValue({ value: true });
+    const res = await wait({ fn: '() => window.ready' });
+    expect(res.content[0].text).toContain('custom predicate satisfied');
+    const expr = (mockSendRpc.mock.calls[0][1] as { expression: string }).expression;
+    // The arrow function is invoked, not coerced to a (truthy) function object.
+    expect(expr).toBe('!!((() => window.ready)())');
+  });
+
+  it('treats timeout:0 as an unbounded wait, not an instant timeout', async () => {
+    // First poll false, second true: with a 0ms deadline the old code would time
+    // out immediately; now it keeps polling until the condition holds.
+    mockSendRpc
+      .mockResolvedValueOnce({ value: false })
+      .mockResolvedValue({ value: true });
+    const res = await wait({ selector: '#eventual', timeout: 0 });
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0].text).toContain('selector "#eventual" found');
+    expect(mockSendRpc.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
   it('approximates networkidle with document.readyState', async () => {
     mockSendRpc.mockResolvedValue({ value: 'complete' });
     const res = await wait({});

--- a/src/mcp/playwright/__tests__/wait.fallback.test.ts
+++ b/src/mcp/playwright/__tests__/wait.fallback.test.ts
@@ -34,6 +34,15 @@ function collectTools(): Map<string, ToolHandler> {
 
 const wait = collectTools().get('browser_wait')!;
 
+/** Resolve common page reads (href/readyState) and let each test override the
+ *  predicate-defining expression via `truthy`. */
+function evalRouter(map: Record<string, unknown>, fallback: unknown = false) {
+  return (_method: string, params: { expression: string }) => {
+    if (params.expression in map) return Promise.resolve({ value: map[params.expression] });
+    return Promise.resolve({ value: fallback });
+  };
+}
+
 beforeEach(() => {
   mockSendRpc.mockReset();
   getPage.mockReset();
@@ -41,14 +50,17 @@ beforeEach(() => {
 });
 
 describe('browser_wait RPC fallback', () => {
-  it('polls selector presence over browser.evaluate', async () => {
+  it('polls selector presence AND visibility over browser.evaluate', async () => {
     mockSendRpc.mockResolvedValue({ value: true });
     const res = await wait({ selector: '#app', surfaceId: 's1' });
     expect(res.isError).toBeUndefined();
     expect(res.content[0].text).toContain('selector "#app" found');
     const [method, params] = mockSendRpc.mock.calls[0] as [string, { expression: string; surfaceId?: string }];
     expect(method).toBe('browser.evaluate');
-    expect(params.expression).toBe('!!document.querySelector("#app")');
+    // Mirrors Playwright's default state:'visible' — attachment + visible box.
+    expect(params.expression).toContain('querySelector("#app")');
+    expect(params.expression).toContain('getBoundingClientRect');
+    expect(params.expression).toContain('visibility');
     expect(params.surfaceId).toBe('s1');
   });
 
@@ -60,19 +72,37 @@ describe('browser_wait RPC fallback', () => {
     expect(expr).toContain('document.body.innerText.includes("Ready")');
   });
 
-  it('evaluates a custom predicate expression', async () => {
+  it('coerces the custom predicate to a boolean in the page (truthy objects survive RPC)', async () => {
     mockSendRpc.mockResolvedValue({ value: true });
-    const res = await wait({ fn: "window.__ready === 'yes'" });
+    const res = await wait({ fn: "document.querySelector('#app')" });
     expect(res.content[0].text).toContain('custom predicate satisfied');
     const expr = (mockSendRpc.mock.calls[0][1] as { expression: string }).expression;
-    expect(expr).toBe("(window.__ready === 'yes')");
+    // !! wrapper means a truthy DOM node serializes as `true`, not `null`.
+    expect(expr).toBe("!!(document.querySelector('#app'))");
   });
 
-  it('matches a URL glob against location.href', async () => {
-    mockSendRpc.mockResolvedValue({ value: 'https://example.com/dashboard/42' });
+  it('matches a URL glob and waits for the load state (readyState complete)', async () => {
+    mockSendRpc.mockImplementation(evalRouter({
+      'location.href': 'https://example.com/dashboard/42',
+      'document.readyState': 'complete',
+    }));
     const res = await wait({ url: '**/dashboard/**' });
+    expect(res.isError).toBeUndefined();
     expect(res.content[0].text).toContain('URL matched "**/dashboard/**"');
-    expect((mockSendRpc.mock.calls[0][1] as { expression: string }).expression).toBe('location.href');
+    const exprs = mockSendRpc.mock.calls.map((c) => (c[1] as { expression: string }).expression);
+    expect(exprs).toContain('location.href');
+    expect(exprs).toContain('document.readyState');
+  });
+
+  it('confines a single * to one path segment (glob parity with waitForURL)', async () => {
+    // href has an extra segment, so single-* must NOT match -> times out.
+    mockSendRpc.mockImplementation(evalRouter({
+      'location.href': 'https://site.test/a/b/settings',
+      'document.readyState': 'complete',
+    }));
+    const res = await wait({ url: 'https://site.test/*/settings', timeout: 60 });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('Timed out');
   });
 
   it('approximates networkidle with document.readyState', async () => {
@@ -98,6 +128,15 @@ describe('browser_wait RPC fallback', () => {
     expect(res.isError).toBeUndefined();
     expect(res.content[0].text).toContain('selector "#late" found');
     expect(mockSendRpc.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('surfaces a setup error immediately instead of timing out', async () => {
+    mockSendRpc.mockRejectedValue(new Error('browser.evaluate: no webview target registered'));
+    const res = await wait({ selector: '#app', timeout: 30000 });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('no webview target registered');
+    // Failed fast — did not burn the 30s deadline polling.
+    expect(mockSendRpc.mock.calls.length).toBe(1);
   });
 
   it('uses the Playwright Page when one exists (no RPC)', async () => {

--- a/src/mcp/playwright/__tests__/wait.fallback.test.ts
+++ b/src/mcp/playwright/__tests__/wait.fallback.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Packaged RPC fallback coverage for browser_wait (#114). On packaged builds
+// engine.getPage() returns null and the tool must poll the condition over the
+// browser.evaluate RPC channel instead of throwing "No browser page available".
+
+vi.mock('../../wmux-client', () => ({ sendRpc: vi.fn() }));
+
+const getPage = vi.fn();
+vi.mock('../PlaywrightEngine', () => ({
+  PlaywrightEngine: { getInstance: () => ({ getPage }) },
+}));
+
+import { sendRpc } from '../../wmux-client';
+import { registerWaitTools } from '../tools/wait';
+
+const mockSendRpc = sendRpc as unknown as ReturnType<typeof vi.fn>;
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: { type: 'text'; text: string }[];
+  isError?: boolean;
+}>;
+
+function collectTools(): Map<string, ToolHandler> {
+  const tools = new Map<string, ToolHandler>();
+  const server = {
+    tool: (name: string, _desc: string, _schema: unknown, handler: ToolHandler) => {
+      tools.set(name, handler);
+    },
+  };
+  registerWaitTools(server as never);
+  return tools;
+}
+
+const wait = collectTools().get('browser_wait')!;
+
+beforeEach(() => {
+  mockSendRpc.mockReset();
+  getPage.mockReset();
+  getPage.mockResolvedValue(null); // default: packaged (no Playwright Page)
+});
+
+describe('browser_wait RPC fallback', () => {
+  it('polls selector presence over browser.evaluate', async () => {
+    mockSendRpc.mockResolvedValue({ value: true });
+    const res = await wait({ selector: '#app', surfaceId: 's1' });
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0].text).toContain('selector "#app" found');
+    const [method, params] = mockSendRpc.mock.calls[0] as [string, { expression: string; surfaceId?: string }];
+    expect(method).toBe('browser.evaluate');
+    expect(params.expression).toBe('!!document.querySelector("#app")');
+    expect(params.surfaceId).toBe('s1');
+  });
+
+  it('polls text content over browser.evaluate', async () => {
+    mockSendRpc.mockResolvedValue({ value: true });
+    const res = await wait({ text: 'Ready' });
+    expect(res.content[0].text).toContain('text "Ready" found');
+    const expr = (mockSendRpc.mock.calls[0][1] as { expression: string }).expression;
+    expect(expr).toContain('document.body.innerText.includes("Ready")');
+  });
+
+  it('evaluates a custom predicate expression', async () => {
+    mockSendRpc.mockResolvedValue({ value: true });
+    const res = await wait({ fn: "window.__ready === 'yes'" });
+    expect(res.content[0].text).toContain('custom predicate satisfied');
+    const expr = (mockSendRpc.mock.calls[0][1] as { expression: string }).expression;
+    expect(expr).toBe("(window.__ready === 'yes')");
+  });
+
+  it('matches a URL glob against location.href', async () => {
+    mockSendRpc.mockResolvedValue({ value: 'https://example.com/dashboard/42' });
+    const res = await wait({ url: '**/dashboard/**' });
+    expect(res.content[0].text).toContain('URL matched "**/dashboard/**"');
+    expect((mockSendRpc.mock.calls[0][1] as { expression: string }).expression).toBe('location.href');
+  });
+
+  it('approximates networkidle with document.readyState', async () => {
+    mockSendRpc.mockResolvedValue({ value: 'complete' });
+    const res = await wait({});
+    expect(res.content[0].text).toContain('network idle');
+    expect((mockSendRpc.mock.calls[0][1] as { expression: string }).expression).toBe('document.readyState');
+  });
+
+  it('times out with a clear message when the condition never holds', async () => {
+    mockSendRpc.mockResolvedValue({ value: false });
+    const res = await wait({ selector: '#never', timeout: 60 });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('Timed out after 60ms');
+    expect(res.content[0].text).toContain('selector "#never"');
+  });
+
+  it('keeps polling through a transient evaluate error, then succeeds', async () => {
+    mockSendRpc
+      .mockRejectedValueOnce(new Error('Cannot read properties of null'))
+      .mockResolvedValue({ value: true });
+    const res = await wait({ selector: '#late', timeout: 2000 });
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0].text).toContain('selector "#late" found');
+    expect(mockSendRpc.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('uses the Playwright Page when one exists (no RPC)', async () => {
+    const waitForSelector = vi.fn().mockResolvedValue(undefined);
+    getPage.mockResolvedValue({ waitForSelector });
+    const res = await wait({ selector: '#app' });
+    expect(waitForSelector).toHaveBeenCalledWith('#app', { timeout: 30000 });
+    expect(mockSendRpc).not.toHaveBeenCalled();
+    expect(res.content[0].text).toContain('selector "#app" found');
+  });
+});

--- a/src/mcp/playwright/tools/wait.ts
+++ b/src/mcp/playwright/tools/wait.ts
@@ -18,15 +18,29 @@ const optionalSurfaceId = z
 // Playwright Page, so engine.getPage() returns null and page.waitFor* is
 // unavailable. browser_wait then polls the condition over the main-process CDP
 // channel (browser.evaluate), the same route the state/extraction tools use
-// (#105/#106/#111).
+// (#105/#106/#111). Each predicate mirrors the Playwright path's semantics as
+// closely as the transport allows.
 
 /**
- * Convert a Playwright-style URL glob to an anchored RegExp. `*` and `**` both
- * match any run of characters; every other regex metacharacter is escaped.
+ * Convert a Playwright-style URL glob to an anchored RegExp, matching
+ * `waitForURL` glob semantics: `**` spans path separators (`.*`), while a single
+ * `*` is confined to one path segment (`[^/]*`). Every other regex metacharacter
+ * is escaped first.
  */
 function urlGlobToRegExp(glob: string): RegExp {
-  const escaped = glob.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  const DOUBLE = String.fromCharCode(0); // placeholder so ** survives the single-* pass
+  const escaped = glob
+    .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, DOUBLE)
+    .replace(/\*/g, '[^/]*')
+    .replace(new RegExp(DOUBLE, 'g'), '.*');
   return new RegExp(`^${escaped}$`);
+}
+
+/** Setup errors (no target / dead WebContents) are not transient navigation
+ *  races — re-raise them immediately instead of polling until the deadline. */
+function isSetupError(message: string): boolean {
+  return /no webview target registered|WebContents unavailable/i.test(message);
 }
 
 function sleep(ms: number): Promise<void> {
@@ -89,13 +103,26 @@ export function registerWaitTools(server: McpServer): void {
           // Playwright path below).
           if (url) {
             const re = urlGlobToRegExp(url);
+            // waitForURL waits for the load state (default 'load') after the URL
+            // matches, so require document.readyState === 'complete' too — without
+            // it the fallback could complete against a partially loaded page.
             predicate = async () => {
               const href = await evaluate('location.href');
-              return typeof href === 'string' && (href === url || re.test(href));
+              if (!(typeof href === 'string' && (href === url || re.test(href)))) return false;
+              return (await evaluate('document.readyState')) === 'complete';
             };
             label = `URL matched "${url}"`;
           } else if (selector) {
-            const expr = `!!document.querySelector(${JSON.stringify(selector)})`;
+            // waitForSelector defaults to state 'visible', so match attachment AND
+            // visibility (non-empty box, not display:none/visibility:hidden) rather
+            // than mere DOM presence.
+            const expr =
+              `(() => { const el = document.querySelector(${JSON.stringify(selector)});` +
+              ` if (!el) return false;` +
+              ` const s = window.getComputedStyle(el);` +
+              ` if (s.visibility === 'hidden' || s.display === 'none') return false;` +
+              ` const r = el.getBoundingClientRect();` +
+              ` return r.width > 0 && r.height > 0; })()`;
             predicate = async () => Boolean(await evaluate(expr));
             label = `selector "${selector}" found`;
           } else if (text) {
@@ -108,9 +135,12 @@ export function registerWaitTools(server: McpServer): void {
               console.warn(`[browser_wait] Dangerous patterns in fn: ${warnings.join(', ')}`);
               warningPrefix = `⚠ Security warning: fn contains potentially dangerous patterns: ${warnings.join(', ')}.\n`;
             }
-            // fn is a JS predicate expression evaluated in page context, matching
-            // Playwright's waitForFunction(string) semantics.
-            predicate = async () => Boolean(await evaluate(`(${fn})`));
+            // fn is a JS predicate expression evaluated in page context (Playwright
+            // waitForFunction(string) semantics). Coerce to a boolean IN the page:
+            // browser.evaluate returns only the CDP result.value, so a truthy but
+            // non-serializable result (e.g. a DOM node from querySelector) would
+            // otherwise come back as null and never satisfy the wait.
+            predicate = async () => Boolean(await evaluate(`!!(${fn})`));
             label = 'custom predicate satisfied';
           } else {
             // networkidle has no page-target debugger equivalent over this
@@ -124,9 +154,13 @@ export function registerWaitTools(server: McpServer): void {
             let ok = false;
             try {
               ok = await predicate();
-            } catch {
-              // Transient evaluate error mid-navigation (e.g. body not ready);
-              // keep polling until the deadline.
+            } catch (error) {
+              // A missing target / dead WebContents is a setup error, not a
+              // transient navigation race — surface it immediately so the caller
+              // gets an actionable message instead of a timeout.
+              const message = error instanceof Error ? error.message : String(error);
+              if (isSetupError(message)) throw error;
+              // Otherwise transient (e.g. body not ready mid-navigation): keep polling.
             }
             if (ok) {
               return {
@@ -173,7 +207,7 @@ export function registerWaitTools(server: McpServer): void {
           }
           await page.waitForFunction(fn, undefined, { timeout: resolvedTimeout });
           const warningPrefix = warnings.length > 0
-            ? `\u26A0 Security warning: fn contains potentially dangerous patterns: ${warnings.join(', ')}.\n`
+            ? `⚠ Security warning: fn contains potentially dangerous patterns: ${warnings.join(', ')}.\n`
             : '';
           return {
             content: [{ type: 'text' as const, text: warningPrefix + 'Wait completed: custom predicate satisfied' }],

--- a/src/mcp/playwright/tools/wait.ts
+++ b/src/mcp/playwright/tools/wait.ts
@@ -22,19 +22,58 @@ const optionalSurfaceId = z
 // closely as the transport allows.
 
 /**
- * Convert a Playwright-style URL glob to an anchored RegExp, matching
- * `waitForURL` glob semantics: `**` spans path separators (`.*`), while a single
- * `*` is confined to one path segment (`[^/]*`). Every other regex metacharacter
- * is escaped first.
+ * Convert a Playwright-style URL glob to an anchored RegExp, ported from
+ * playwright-core's `globToRegexPattern` so packaged builds match `waitForURL`
+ * exactly:
+ *   - a single `*` is confined to one path segment (`[^/]*`);
+ *   - a "deep" `**` bounded by `/` or the string edge spans zero or more whole
+ *     segments and absorbs the following slash, so `/**​/settings` also matches
+ *     `/settings` (zero segments), not just `/a/b/settings`.
+ * Every other character is escaped to a regex literal.
  */
 function urlGlobToRegExp(glob: string): RegExp {
-  const DOUBLE = String.fromCharCode(0); // placeholder so ** survives the single-* pass
-  const escaped = glob
-    .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
-    .replace(/\*\*/g, DOUBLE)
-    .replace(/\*/g, '[^/]*')
-    .replace(new RegExp(DOUBLE, 'g'), '.*');
-  return new RegExp(`^${escaped}$`);
+  const tokens = ['^'];
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === '*') {
+      const beforeDeep = glob[i - 1];
+      let starCount = 1;
+      while (glob[i + 1] === '*') {
+        starCount++;
+        i++;
+      }
+      const afterDeep = glob[i + 1];
+      const isDeep =
+        starCount > 1 &&
+        (beforeDeep === '/' || beforeDeep === undefined) &&
+        (afterDeep === '/' || afterDeep === undefined);
+      if (isDeep) {
+        tokens.push('((?:[^/]*(?:/|$))*)');
+        i++; // consume the trailing slash that the deep wildcard already spans
+      } else {
+        tokens.push('([^/]*)');
+      }
+    } else {
+      tokens.push(c.replace(/[.+?^${}()|[\]\\]/g, '\\$&'));
+    }
+  }
+  tokens.push('$');
+  return new RegExp(tokens.join(''));
+}
+
+/**
+ * Whether a JS string looks like a function expression (arrow or classic) rather
+ * than a bare predicate expression. `page.waitForFunction(string)` invokes a
+ * function-looking string on each poll, so the fallback must call it too — a bare
+ * `() => cond` would otherwise be a truthy function object and satisfy the wait
+ * immediately. Mirrors that branch over the CDP transport.
+ */
+function isFunctionExpression(source: string): boolean {
+  const s = source.trim();
+  return (
+    /^(async\s+)?function\b/.test(s) ||
+    /^(async\s+)?(\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>/.test(s)
+  );
 }
 
 /** Setup errors (no target / dead WebContents) are not transient navigation
@@ -135,12 +174,15 @@ export function registerWaitTools(server: McpServer): void {
               console.warn(`[browser_wait] Dangerous patterns in fn: ${warnings.join(', ')}`);
               warningPrefix = `⚠ Security warning: fn contains potentially dangerous patterns: ${warnings.join(', ')}.\n`;
             }
-            // fn is a JS predicate expression evaluated in page context (Playwright
-            // waitForFunction(string) semantics). Coerce to a boolean IN the page:
-            // browser.evaluate returns only the CDP result.value, so a truthy but
-            // non-serializable result (e.g. a DOM node from querySelector) would
-            // otherwise come back as null and never satisfy the wait.
-            predicate = async () => Boolean(await evaluate(`!!(${fn})`));
+            // fn is a JS predicate evaluated in page context (Playwright
+            // waitForFunction(string) semantics). A function-looking string is
+            // *called* each poll; a bare expression is evaluated as-is. Then
+            // coerce to a boolean IN the page: browser.evaluate returns only the
+            // CDP result.value, so a truthy but non-serializable result (e.g. a
+            // DOM node from querySelector) would otherwise come back as null and
+            // never satisfy the wait.
+            const expr = isFunctionExpression(fn) ? `!!((${fn})())` : `!!(${fn})`;
+            predicate = async () => Boolean(await evaluate(expr));
             label = 'custom predicate satisfied';
           } else {
             // networkidle has no page-target debugger equivalent over this
@@ -149,6 +191,9 @@ export function registerWaitTools(server: McpServer): void {
             label = 'network idle (approximated by document.readyState === "complete" over the CDP fallback)';
           }
 
+          // Playwright treats timeout:0 as "wait forever"; mirror that by polling
+          // with no deadline rather than expiring on the first miss.
+          const hasDeadline = resolvedTimeout > 0;
           const deadline = Date.now() + resolvedTimeout;
           for (;;) {
             let ok = false;
@@ -167,10 +212,10 @@ export function registerWaitTools(server: McpServer): void {
                 content: [{ type: 'text' as const, text: warningPrefix + `Wait completed: ${label}` }],
               };
             }
-            if (Date.now() >= deadline) {
+            if (hasDeadline && Date.now() >= deadline) {
               throw new Error(`Timeout ${resolvedTimeout}ms exceeded`);
             }
-            await sleep(Math.min(250, Math.max(0, deadline - Date.now())));
+            await sleep(hasDeadline ? Math.min(250, Math.max(0, deadline - Date.now())) : 250);
           }
         }
 

--- a/src/mcp/playwright/tools/wait.ts
+++ b/src/mcp/playwright/tools/wait.ts
@@ -2,12 +2,36 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { PlaywrightEngine } from '../PlaywrightEngine';
 import { detectDangerousPatterns } from '../security';
+import { rpcEvaluator } from '../page-eval';
 
 // Optional surfaceId schema reused across tools
 const optionalSurfaceId = z
   .string()
   .optional()
   .describe('Target a specific surface by ID. Omit to use the active surface.');
+
+// ---------------------------------------------------------------------------
+// Packaged RPC fallback helpers (#114)
+// ---------------------------------------------------------------------------
+//
+// On packaged builds playwright-core cannot surface the guest <webview> as a
+// Playwright Page, so engine.getPage() returns null and page.waitFor* is
+// unavailable. browser_wait then polls the condition over the main-process CDP
+// channel (browser.evaluate), the same route the state/extraction tools use
+// (#105/#106/#111).
+
+/**
+ * Convert a Playwright-style URL glob to an anchored RegExp. `*` and `**` both
+ * match any run of characters; every other regex metacharacter is escaped.
+ */
+function urlGlobToRegExp(glob: string): RegExp {
+  const escaped = glob.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 /**
  * Register wait-related MCP tools on the given server.
@@ -51,9 +75,69 @@ export function registerWaitTools(server: McpServer): void {
       const resolvedTimeout = timeout ?? 30000;
 
       try {
-        const page = await engine.getPage(surfaceId);
+        const page = await engine.getPage(surfaceId).catch(() => null);
+
+        // Packaged RPC fallback (#114): no Playwright Page, so poll the condition
+        // over the CDP channel until it holds or the timeout elapses.
         if (!page) {
-          throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
+          const evaluate = rpcEvaluator(surfaceId);
+          let predicate: () => Promise<boolean>;
+          let label: string;
+          let warningPrefix = '';
+
+          // Priority: url > selector > text > fn > networkidle (mirrors the
+          // Playwright path below).
+          if (url) {
+            const re = urlGlobToRegExp(url);
+            predicate = async () => {
+              const href = await evaluate('location.href');
+              return typeof href === 'string' && (href === url || re.test(href));
+            };
+            label = `URL matched "${url}"`;
+          } else if (selector) {
+            const expr = `!!document.querySelector(${JSON.stringify(selector)})`;
+            predicate = async () => Boolean(await evaluate(expr));
+            label = `selector "${selector}" found`;
+          } else if (text) {
+            const expr = `!!(document.body && document.body.innerText.includes(${JSON.stringify(text)}))`;
+            predicate = async () => Boolean(await evaluate(expr));
+            label = `text "${text}" found`;
+          } else if (fn) {
+            const warnings = detectDangerousPatterns(fn);
+            if (warnings.length > 0) {
+              console.warn(`[browser_wait] Dangerous patterns in fn: ${warnings.join(', ')}`);
+              warningPrefix = `⚠ Security warning: fn contains potentially dangerous patterns: ${warnings.join(', ')}.\n`;
+            }
+            // fn is a JS predicate expression evaluated in page context, matching
+            // Playwright's waitForFunction(string) semantics.
+            predicate = async () => Boolean(await evaluate(`(${fn})`));
+            label = 'custom predicate satisfied';
+          } else {
+            // networkidle has no page-target debugger equivalent over this
+            // transport; approximate with document.readyState === 'complete'.
+            predicate = async () => (await evaluate('document.readyState')) === 'complete';
+            label = 'network idle (approximated by document.readyState === "complete" over the CDP fallback)';
+          }
+
+          const deadline = Date.now() + resolvedTimeout;
+          for (;;) {
+            let ok = false;
+            try {
+              ok = await predicate();
+            } catch {
+              // Transient evaluate error mid-navigation (e.g. body not ready);
+              // keep polling until the deadline.
+            }
+            if (ok) {
+              return {
+                content: [{ type: 'text' as const, text: warningPrefix + `Wait completed: ${label}` }],
+              };
+            }
+            if (Date.now() >= deadline) {
+              throw new Error(`Timeout ${resolvedTimeout}ms exceeded`);
+            }
+            await sleep(Math.min(250, Math.max(0, deadline - Date.now())));
+          }
         }
 
         // Priority: url > selector > text > fn > networkidle


### PR DESCRIPTION
Closes #114.

`browser_wait` was the last browser tool with no packaged fallback. It only used the Playwright Page API (`waitForURL` / `waitForSelector` / `waitForFunction` / `waitForLoadState`), so on packaged builds — where `engine.getPage()` returns null because playwright-core can't surface the guest `<webview>` as a Page — it threw `No browser page available` instead of waiting. Surfaced during the #112 geo verification, where every other browser tool worked but `browser_wait` errored out.

## Change

Same shape as the #105/#106/#111 fallbacks: try the Playwright Page first, and when none is available poll the condition over the main-process CDP channel (`browser.evaluate`) until it holds or the timeout elapses.

| condition | fallback |
|-----------|----------|
| `url` | match `location.href` against the glob (anchored regex; `*` and `**` both match any run of characters) |
| `selector` | `!!document.querySelector(sel)` |
| `text` | `document.body.innerText.includes(text)`, guarded for a null body |
| `fn` | evaluate the predicate expression (Playwright `waitForFunction(string)` semantics); the dangerous-pattern warning is preserved |
| `networkidle` | approximated by `document.readyState === "complete"` — the page-target debugger has no network-idle signal over this transport, and the completion message says so |

Transient evaluate errors mid-navigation are swallowed so polling continues; a deadline miss throws a `Timeout` error that flows into the existing timeout messaging. The Playwright (dev) path is unchanged.

## Tests

`wait.fallback.test.ts` — 8 cases (selector/text/fn/url/networkidle success, timeout messaging, transient-error retry, and the Playwright-Page-present no-RPC path). Full suite 2263 green, mcp tsc clean.

## Not covered

Packaged smoke (real CDP round-trip) is not in this PR — the unit tests mock the RPC. Worth a quick dogfood in a packaged build before release, the same way the geo fix was verified.
