### PR TITLE
fix(mcp): authenticate first-party allowlist

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -193,6 +193,7 @@ const autoUpdater = new AutoUpdater(() => mainWindow);
 const rpcRouter = new RpcRouter();
 const pipeServer = new PipeServer(rpcRouter);
 const mcpRegistrar = new McpRegistrar();
+rpcRouter.setFirstPartyToken(mcpRegistrar.getFirstPartyToken());
 const webviewCdpManager = new WebviewCdpManager(cdpPort);
 
 const claudeWorker = new ClaudeWorker(() => mainWindow);

--- a/src/main/mcp/McpRegistrar.ts
+++ b/src/main/mcp/McpRegistrar.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as crypto from 'crypto';
 import { app } from 'electron';
-import { getAuthTokenPath, getPipeName } from '../../shared/constants';
+import { getAuthTokenPath, getFirstPartyTokenPath, getPipeName } from '../../shared/constants';
 import { secureWriteTokenFile } from '../../shared/security';
 import { isMac } from '../../shared/platform';
 import { formatMacosError, MACOS_ERRORS } from '../../shared/errors/macos';
@@ -44,6 +45,8 @@ export interface McpRegistrarStatus {
 export class McpRegistrar {
   private readonly claudeJsonPath: string;
   private readonly authTokenPath: string;
+  private readonly firstPartyTokenPath: string;
+  private readonly firstPartyToken: string;
   private registered = false;
   /** Keys that WinMux actually wrote (so we only unregister our own). */
   private readonly ownedKeys = new Set<string>();
@@ -52,6 +55,24 @@ export class McpRegistrar {
     const home = app.getPath('home');
     this.claudeJsonPath = path.join(home, '.claude.json');
     this.authTokenPath = getAuthTokenPath();
+    this.firstPartyTokenPath = getFirstPartyTokenPath();
+    this.firstPartyToken = this.loadOrCreateFirstPartyToken();
+  }
+
+  getFirstPartyToken(): string {
+    return this.firstPartyToken;
+  }
+
+  private loadOrCreateFirstPartyToken(): string {
+    try {
+      const existing = fs.readFileSync(this.firstPartyTokenPath, 'utf8').trim();
+      if (existing) return existing;
+    } catch {
+      // Missing on first run; create below.
+    }
+    const token = crypto.randomUUID();
+    secureWriteTokenFile(this.firstPartyTokenPath, token);
+    return token;
   }
 
   /** Absolute path to the Claude Code user config file. */
@@ -132,8 +153,11 @@ export class McpRegistrar {
    */
   register(authToken: string): void {
     try {
-      // Write auth token to file so MCP server can read it
+      // Write auth token to file so MCP server can read it. Also refresh the
+      // first-party token file in case ACL hardening or a previous cleanup
+      // removed it after this registrar was constructed.
       secureWriteTokenFile(this.authTokenPath, authToken);
+      secureWriteTokenFile(this.firstPartyTokenPath, this.firstPartyToken);
       console.log(`[McpRegistrar] Auth token written to ${this.authTokenPath}`);
 
       const mcpScript = this.getMcpScriptPath();

--- a/src/main/mcp/PermissionEnforcer.ts
+++ b/src/main/mcp/PermissionEnforcer.ts
@@ -74,14 +74,10 @@ export interface EnforcerInput {
   /**
    * True when the trust-store lookup *threw* (corrupt DB / I/O error) instead
    * of cleanly resolving to "no record". The two cases look identical at the
-   * `trust === undefined` level but must NOT be treated the same: a clean miss
-   * is a fresh first-party caller (grant the bypass), whereas a failed read
-   * means an operator `denied` row might exist but couldn't be loaded — so the
-   * first-party bypass declines on this unknown state and lets the caller fall
-   * through to the normal (fail-closed) ladder. Non-first-party callers already
-   * fail closed here regardless; this keeps first-party symmetric for the
-   * security-relevant `denied` case. Defaults to `false` when omitted (the
-   * common path and every unit test that doesn't exercise a lookup failure).
+   * `trust === undefined` level. A failed read must still fail closed because it
+   * might be hiding an operator `denied` row. Defaults to `false` when omitted
+   * (the common path and every unit test that doesn't exercise a lookup
+   * failure).
    */
   trustLookupFailed?: boolean;
 }
@@ -178,27 +174,15 @@ export function check(input: EnforcerInput): EnforcerOutcome {
     return { kind: 'allow' };
   }
 
-  // First-party bundled wmux MCP server (recognised by the host clientName it
-  // reports). It ships inside wmux and never goes through the external-plugin
-  // declare/approve flow — and it couldn't if it tried, because several tools
-  // it exposes map to `wmux.internal` methods (surface.list, company.a2a.*)
-  // that the permission grammar forbids from any declaration. Grant exactly
-  // the method set it calls (firstParty.ts), nothing more, regardless of the
-  // trust-DB `unconfirmed` status that the bundled server is otherwise stuck
-  // in. Three guards keep this from becoming a blanket bypass:
-  //   - An explicit user `denied` still wins (operator escape hatch): fall
-  //     through to the `denied` branch below.
-  //   - A failed trust lookup (corrupt DB / I/O error, signalled by
-  //     `trustLookupFailed`) is an UNKNOWN state, not a clean miss: a `denied`
-  //     row may exist but be unreadable, so we decline the bypass and fall
-  //     through to fail-closed enforcement rather than honoring the bundled
-  //     server while an operator's `denied` couldn't be loaded.
-  //   - A method outside the curated allowlist also falls through to normal
-  //     enforcement, so a coverage gap surfaces as a rejection instead of
-  //     silently widening first-party scope.
-  // See plans/first-party-mcp-trust.md and docs/api/mcp-plugin-spec.md.
+  // First-party bundled wmux MCP server. `clientName` is self-declared (see
+  // shared/rpc.ts), so a caller-controlled name must never grant privileges on
+  // its own. The router must also verify the private first-party bearer token
+  // before the curated method set can bypass declaration/approval. Denied rows,
+  // failed trust lookups, unauthenticated first-party claims, and methods
+  // outside the list all fall through to the normal fail-closed ladder below.
   if (
     isFirstPartyClient(input.ctx.clientName) &&
+    input.ctx.firstPartyAuthenticated === true &&
     !input.trustLookupFailed &&
     input.trust?.status !== 'denied' &&
     FIRST_PARTY_METHODS.has(input.method)

--- a/src/main/mcp/__tests__/PermissionEnforcer.firstParty.test.ts
+++ b/src/main/mcp/__tests__/PermissionEnforcer.firstParty.test.ts
@@ -1,10 +1,7 @@
 // First-party scoped-allowlist behavior in the Phase 2.2 enforcer.
 //
-// These cover the production lockout fix (plans/first-party-mcp-trust.md): the
-// bundled wmux MCP server identifies as `claude-code` and is recorded
-// `unconfirmed` in the trust DB, but must still be allowed to call the method
-// set it actually uses — including `wmux.internal` methods (surface.list,
-// company.a2a.*) that can never be declared/approved.
+// `clientName` is self-declared, so the first-party allowlist is only reachable
+// when RpcRouter has verified the private first-party bearer credential.
 
 import { describe, expect, it } from 'vitest';
 import type { PluginIdentityRecord, RpcContext, RpcMethod } from '../../../shared/rpc';
@@ -16,8 +13,8 @@ function trust(
 ): PluginIdentityRecord {
   return { firstSeen: 1000, lastSeen: 2000, ...overrides };
 }
-function ctx(clientName?: string): RpcContext {
-  return clientName ? { clientName } : {};
+function ctx(clientName?: string, firstPartyAuthenticated = false): RpcContext {
+  return clientName ? { clientName, firstPartyAuthenticated } : {};
 }
 
 const FP = 'claude-code';
@@ -32,29 +29,36 @@ const SAMPLE_ALLOWED: RpcMethod[] = [
 ];
 
 describe('PermissionEnforcer.check — first-party allowlist', () => {
-  it('allows allowlisted methods for claude-code even when status=unconfirmed', () => {
+  it('allows allowlisted methods for claude-code when the first-party token is verified', () => {
     for (const method of SAMPLE_ALLOWED) {
       const out = check({
         method,
         params: {},
-        ctx: ctx(FP),
+        ctx: ctx(FP, true),
         trust: trust({ name: FP, status: 'unconfirmed' }),
       });
-      expect(out, `${method} should be allowed for first-party/unconfirmed`).toEqual({
+      expect(out, `${method} should be allowed for token-authenticated first-party`).toEqual({
         kind: 'allow',
       });
     }
   });
 
-  it('allows allowlisted methods for claude-code with NO trust record (fresh identify)', () => {
-    // The actual live scenario: claude-code called mcp.identify, then a tool
-    // RPC arrives before/without any declaration. trust may be undefined or a
-    // bare unconfirmed row — either way the bundled server must work.
+  it('rejects claude-code with NO trust record when the first-party token is absent', () => {
     const out = check({
       method: 'surface.list',
       params: {},
       ctx: ctx(FP),
       trust: undefined,
+    });
+    expect(out.kind).toBe('reject');
+  });
+
+  it('allows claude-code with an unconfirmed trust record when the first-party token is verified', () => {
+    const out = check({
+      method: 'surface.list',
+      params: {},
+      ctx: ctx(FP, true),
+      trust: trust({ name: FP, status: 'unconfirmed' }),
     });
     expect(out).toEqual({ kind: 'allow' });
   });
@@ -64,7 +68,7 @@ describe('PermissionEnforcer.check — first-party allowlist', () => {
       const out = check({
         method,
         params: {},
-        ctx: ctx(FP),
+        ctx: ctx(FP, true),
         trust: trust({ name: FP, status: 'unconfirmed' }),
       });
       expect(out, `${method}`).toEqual({ kind: 'allow' });
@@ -75,7 +79,7 @@ describe('PermissionEnforcer.check — first-party allowlist', () => {
     const out = check({
       method: 'browser.open',
       params: {},
-      ctx: ctx(FP),
+      ctx: ctx(FP, true),
       trust: trust({ name: FP, status: 'denied' }),
     });
     expect(out.kind).toBe('reject');
@@ -94,7 +98,7 @@ describe('PermissionEnforcer.check — first-party allowlist', () => {
       const out = check({
         method,
         params: {},
-        ctx: ctx(FP),
+        ctx: ctx(FP, true),
         trust: trust({ name: FP, status: 'unconfirmed' }),
       });
       expect(out.kind, `${method} must not be auto-allowed for first-party`).toBe('reject');
@@ -116,10 +120,9 @@ describe('PermissionEnforcer.check — first-party allowlist', () => {
     }
   });
 
-  it('SECURITY: even spoofing clientName="claude-code" only reaches the curated set, never reserved daemon methods', () => {
-    // Defense-in-depth assertion: the worst a clientName impersonator (who
-    // already needs the daemon auth token) can do via the first-party path is
-    // the allowlist — never daemon.shutdown/compact or company mutation.
+  it('SECURITY: untrusted spoofing clientName="claude-code" cannot reach reserved daemon methods', () => {
+    // Defense-in-depth assertion: an unconfirmed clientName impersonator never
+    // reaches daemon.shutdown/compact or company mutation.
     for (const method of ['daemon.shutdown', 'daemon.compact', 'company.create'] as const) {
       const out = check({
         method,
@@ -132,17 +135,14 @@ describe('PermissionEnforcer.check — first-party allowlist', () => {
   });
 
   it('SECURITY: declines the first-party bypass when the trust lookup FAILED (a denied row may be unreadable)', () => {
-    // A clean miss (trust=undefined, no failure) grants the bypass — see the
-    // "NO trust record" test above. But when the trust-store read THREW (corrupt
-    // DB / I/O), an operator `denied` row might exist and merely be unreadable.
-    // Honoring first-party here would silently bypass that escape hatch, so the
-    // enforcer must fall through to the fail-closed ladder instead. Symmetric
-    // with non-first-party callers, which already fail closed on undefined trust.
+    // When the trust-store read THREW (corrupt DB / I/O), an operator `denied`
+    // row might exist and merely be unreadable. The enforcer must fall through
+    // to the fail-closed ladder instead.
     for (const method of SAMPLE_ALLOWED) {
       const out = check({
         method,
         params: {},
-        ctx: ctx(FP),
+        ctx: ctx(FP, true),
         trust: undefined,
         trustLookupFailed: true,
       });
@@ -152,18 +152,20 @@ describe('PermissionEnforcer.check — first-party allowlist', () => {
     }
   });
 
-  it('still grants the first-party bypass on a clean miss (trustLookupFailed=false)', () => {
-    // Regression guard for the live boot path: trust=undefined from a clean
-    // lookup is the fresh-identify case and MUST keep working unchanged.
+  it('allows the first-party bypass on a clean miss only when the token is verified', () => {
+    // A clean miss is safe only when paired with the private first-party token;
+    // clientName alone is covered by the NO trust record rejection above.
     for (const method of SAMPLE_ALLOWED) {
       const out = check({
         method,
         params: {},
-        ctx: ctx(FP),
+        ctx: ctx(FP, true),
         trust: undefined,
         trustLookupFailed: false,
       });
-      expect(out, `${method} should be allowed on a clean miss`).toEqual({ kind: 'allow' });
+      expect(out, `${method} should allow on a token-verified clean miss`).toEqual({
+        kind: 'allow',
+      });
     }
   });
 });

--- a/src/main/mcp/firstParty.ts
+++ b/src/main/mcp/firstParty.ts
@@ -18,29 +18,20 @@
 // declaration (RESERVED_PREFIXES = ['wmux.']). No amount of user approval can
 // grant those.
 //
-// The fix: recognise the bundled server by the host clientName it reports and
-// allow exactly the method set it actually calls — nothing more. This is a
-// scoped allowlist, NOT a blanket "first party can do anything" bypass: a
-// method outside the set falls through to normal enforcement, and an explicit
-// user `denied` still wins (see PermissionEnforcer.check).
-//
-// Threat model (matches the spec's "declared, not verified" stance, rpc.ts):
-// recognition is by self-asserted clientName. On a single-user OS this is no
-// weaker than any local secret — a same-user process that wanted to
-// impersonate the host already holds the daemon auth token and could call the
-// pipe directly. What the scoped allowlist buys over a blanket bypass is that
-// even an impersonator only reaches the curated method set, never daemon.*,
-// workspace.new, company mutation, or other reserved surface. Documented in
-// docs/api/mcp-plugin-spec.md.
+// The fix: pair the bundled server's host clientName with a private
+// first-party bearer credential before allowing exactly the method set it
+// actually calls — nothing more. `clientName` is self-declared (rpc.ts), so a
+// clean missing or unconfirmed row cannot grant first-party privileges by
+// itself. A method outside the set falls through to normal enforcement, and an
+// explicit user `denied` still wins (see PermissionEnforcer.check).
 
 import type { RpcMethod } from '../../shared/rpc';
 
-// Host identities that own the bundled wmux MCP server. The server reports the
-// connecting MCP client's `clientInfo.name` (see wireClientIdentityHook in
-// src/mcp/index.ts); Claude Code reports `claude-code`. A Set so additional
-// first-party hosts (e.g. a future wmux-native CLI) can be added without
-// touching the enforcer. Exact match — `clientName` is already trimmed by
-// PipeServer when it builds RpcContext.
+// Host identities that may own the bundled wmux MCP server once the request
+// also carries the private first-party token. The server reports the connecting
+// MCP client's `clientInfo.name` (see wireClientIdentityHook in src/mcp/index.ts);
+// Claude Code reports `claude-code`. Exact match — `clientName` is already
+// trimmed by PipeServer when it builds RpcContext.
 export const FIRST_PARTY_CLIENT_NAMES: ReadonlySet<string> = new Set<string>([
   'claude-code',
 ]);
@@ -50,8 +41,7 @@ export const FIRST_PARTY_CLIENT_NAMES: ReadonlySet<string> = new Set<string>([
 // `firstParty.test.ts`, which parses src/mcp/ for every callRpc/sendRpc method
 // literal and fails if any is missing here. Least privilege: methods the
 // bundled server does NOT call (e.g. daemon.shutdown, workspace.new,
-// company.create) are intentionally absent, so a clientName impersonator can
-// never reach them through the first-party path.
+// company.create) are intentionally absent.
 export const FIRST_PARTY_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
   // identity / workspace bootstrap
   'mcp.identify',

--- a/src/main/pipe/RpcRouter.ts
+++ b/src/main/pipe/RpcRouter.ts
@@ -73,6 +73,7 @@ export class RpcRouter {
   private legacyTrafficCounter: LegacyTrafficCounter | undefined;
   private trustLookup: TrustLookup | undefined;
   private shadowSink: ShadowRejectionSink | undefined;
+  private firstPartyToken: string | undefined;
   /**
    * Phase 2.2 pre-commit 6: enforcement mode. Default is `shadow` so a
    * router that was never explicitly set up (unit tests, transitional
@@ -137,6 +138,17 @@ export class RpcRouter {
   }
 
   /**
+   * Configure the private bearer credential accepted for the bundled wmux MCP
+   * bridge. The clientName remains self-declared; this token is the provenance
+   * check that prevents a normal authenticated RPC caller from spoofing
+   * clientName="claude-code" into the first-party allowlist.
+   */
+  setFirstPartyToken(token: string | undefined): void {
+    const trimmed = typeof token === 'string' ? token.trim() : '';
+    this.firstPartyToken = trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  /**
    * Phase 2.2 pre-commit 6: switch between shadow (log + proceed) and
    * enforce (log + return rejection). The mode is read from
    * `~/.wmux/config.json` at main/index.ts boot time.
@@ -185,6 +197,11 @@ export class RpcRouter {
         typeof request.clientVersion === 'string' && request.clientVersion.trim().length > 0
           ? request.clientVersion.trim()
           : undefined,
+      firstPartyAuthenticated:
+        typeof request.firstPartyToken === 'string' &&
+        this.firstPartyToken !== undefined &&
+        request.firstPartyToken.length === this.firstPartyToken.length &&
+        request.firstPartyToken === this.firstPartyToken,
     };
 
     // Spec §2.2: requests without `clientName` are recorded as `legacy`.

--- a/src/main/pipe/__tests__/RpcRouter.firstParty.enforce.test.ts
+++ b/src/main/pipe/__tests__/RpcRouter.firstParty.enforce.test.ts
@@ -1,14 +1,9 @@
-// Dynamic verification of the first-party lockout fix through the REAL
-// enforce-mode dispatch pipeline.
-//
-// This reproduces the exact production scenario that was broken
-// (plans/first-party-mcp-trust.md): a packaged build runs the enforcer in
-// `enforce` mode, the bundled MCP server identifies as `claude-code` and is
-// recorded `unconfirmed`, and every capability-bearing RPC it makes was
-// rejected with no recovery path. We wire the production objects (real
+// Dynamic verification of first-party enforcement through the REAL enforce-mode
+// dispatch pipeline. These are deliberately higher-level than
+// PermissionEnforcer.firstParty.test.ts: they wire the production objects (real
 // RpcRouter + real PluginTrustStore on an isolated tmpdir + the real enforcer)
 // exactly like src/main/index.ts, flip enforce mode on, and assert the bundled
-// server's calls now pass while an impersonator and reserved methods do not.
+// server allowlist only works after the private first-party token is verified.
 //
 // Per-module unit tests can't catch a regression in this wiring — only
 // dispatching through the assembled pipeline can.
@@ -24,6 +19,7 @@ import { registerMcpPluginRpc } from '../handlers/mcp.rpc';
 let tmpDir = '';
 let store: PluginTrustStore;
 let router: RpcRouter;
+const FIRST_PARTY_TOKEN = 'test-first-party-token';
 
 function wireEnforced(): void {
   registerMcpPluginRpc(router, store);
@@ -47,6 +43,7 @@ beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-fp-enforce-'));
   store = new PluginTrustStore(path.join(tmpDir, 'plugin-trust.json'));
   router = new RpcRouter();
+  router.setFirstPartyToken(FIRST_PARTY_TOKEN);
   wireEnforced();
 });
 
@@ -60,10 +57,8 @@ afterEach(() => {
 
 const CLAUDE = 'claude-code';
 
-describe('enforce-mode dispatch — first-party bundled server (the lockout fix)', () => {
-  it('allows browser.open / surface.list / company.a2a.whoami for claude-code recorded unconfirmed', async () => {
-    // Mirror the live trust DB: mcp.identify recorded claude-code unconfirmed,
-    // no declaration. This is the exact state ~/.wmux/plugin-trust.json showed.
+describe('enforce-mode dispatch — first-party bundled server', () => {
+  it('allows browser.open / surface.list / company.a2a.whoami for claude-code only with the first-party token', async () => {
     await store.upsertContact(CLAUDE, '2.1.167');
     expect((await store.get(CLAUDE))?.status).toBe('unconfirmed');
 
@@ -74,17 +69,46 @@ describe('enforce-mode dispatch — first-party bundled server (the lockout fix)
         params: {},
         clientName: CLAUDE,
         clientVersion: '2.1.167',
+        firstPartyToken: FIRST_PARTY_TOKEN,
       });
-      expect(res.ok, `${method} should pass enforce-mode dispatch for first-party`).toBe(true);
+      expect(
+        res.ok,
+        `${method} should pass enforce-mode dispatch for token-authenticated first-party`,
+      ).toBe(true);
     }
   });
 
-  it('allows even with NO trust record at all (tool call racing ahead of identify)', async () => {
+  it('rejects claude-code with NO trust record at all (spoofed clean miss)', async () => {
     const res = await router.dispatch({
       id: 'fp-norecord',
       method: 'surface.list',
       params: {},
       clientName: CLAUDE,
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it('allows claude-code with NO trust record when token is verified (fresh identify race)', async () => {
+    const res = await router.dispatch({
+      id: 'fp-token-norecord',
+      method: 'surface.list',
+      params: {},
+      clientName: CLAUDE,
+      firstPartyToken: FIRST_PARTY_TOKEN,
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('allows claude-code while only recorded as unconfirmed when token is verified', async () => {
+    await store.upsertContact(CLAUDE, '2.1.167');
+    expect((await store.get(CLAUDE))?.status).toBe('unconfirmed');
+    const res = await router.dispatch({
+      id: 'fp-unconfirmed',
+      method: 'surface.list',
+      params: {},
+      clientName: CLAUDE,
+      clientVersion: '2.1.167',
+      firstPartyToken: FIRST_PARTY_TOKEN,
     });
     expect(res.ok).toBe(true);
   });
@@ -112,6 +136,7 @@ describe('enforce-mode dispatch — first-party bundled server (the lockout fix)
       method: 'workspace.new', // wmux.internal, NOT in FIRST_PARTY_METHODS
       params: {},
       clientName: CLAUDE,
+      firstPartyToken: FIRST_PARTY_TOKEN,
     });
     expect(res.ok).toBe(false);
   });
@@ -124,6 +149,7 @@ describe('enforce-mode dispatch — first-party bundled server (the lockout fix)
       method: 'browser.open',
       params: {},
       clientName: CLAUDE,
+      firstPartyToken: FIRST_PARTY_TOKEN,
     });
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error).toMatch(/denied/);
@@ -144,12 +170,10 @@ describe('enforce-mode dispatch — first-party bundled server (the lockout fix)
 
   it('SECURITY: a failing trust lookup denies the first-party bypass (a denied row could be unreadable)', async () => {
     // Simulate a corrupt / unreadable trust DB by making the lookup throw
-    // instead of cleanly resolving. A clean miss grants the bypass (see the
-    // "NO trust record" case above), but a *failed* read is an unknown state:
-    // an operator `denied` row might exist and merely be unreadable, so
+    // instead of cleanly resolving. A failed read is an unknown state: an
+    // operator `denied` row might exist and merely be unreadable, so
     // first-party must fall through to fail-closed enforcement rather than
-    // silently honoring claude-code. Without trustLookupFailed plumbing this
-    // call would wrongly succeed.
+    // silently honoring claude-code.
     router.setTrustLookup(async () => {
       throw new Error('simulated corrupt plugin-trust.json');
     });
@@ -158,7 +182,10 @@ describe('enforce-mode dispatch — first-party bundled server (the lockout fix)
       method: 'browser.open',
       params: {},
       clientName: CLAUDE,
+      firstPartyToken: FIRST_PARTY_TOKEN,
     });
-    expect(res.ok, 'first-party must not be allowed when the trust lookup throws').toBe(false);
+    expect(res.ok, 'first-party must not be allowed when the trust lookup throws').toBe(
+      false,
+    );
   });
 });

--- a/src/mcp/wmux-client.ts
+++ b/src/mcp/wmux-client.ts
@@ -2,7 +2,7 @@ import * as net from 'net';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
 import type { RpcMethod, RpcResponse } from '../shared/rpc';
-import { getPipeName, getAuthTokenPath, getTcpPortPath } from '../shared/constants';
+import { getPipeName, getAuthTokenPath, getFirstPartyTokenPath, getTcpPortPath } from '../shared/constants';
 
 const TIMEOUT_MS = 10000;
 const RETRY_COUNT = 3;
@@ -51,6 +51,14 @@ function readAuthToken(): string | undefined {
   return undefined;
 }
 
+function readFirstPartyToken(): string | undefined {
+  try {
+    const fromFile = fs.readFileSync(getFirstPartyTokenPath(), 'utf8').trim();
+    if (fromFile) return fromFile;
+  } catch { /* file doesn't exist */ }
+  return undefined;
+}
+
 function readTcpPort(): number | undefined {
   try {
     const port = parseInt(fs.readFileSync(getTcpPortPath(), 'utf8').trim(), 10);
@@ -61,12 +69,14 @@ function readTcpPort(): number | undefined {
 function attemptRpc(
   target: string | { host: string; port: number },
   token: string,
+  firstPartyToken: string | undefined,
   method: RpcMethod,
   params: Record<string, unknown>,
 ): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const id = crypto.randomUUID();
     const envelope: Record<string, unknown> = { id, method, params, token };
+    if (firstPartyToken) envelope.firstPartyToken = firstPartyToken;
     if (CLIENT_NAME) envelope.clientName = CLIENT_NAME;
     if (CLIENT_VERSION) envelope.clientVersion = CLIENT_VERSION;
     const request = JSON.stringify(envelope) + '\n';
@@ -148,6 +158,8 @@ export async function sendRpc(
     throw new Error('wmux auth token not found. Is wmux running?');
   }
 
+  const firstPartyToken = readFirstPartyToken();
+
   // Try WMUX_SOCKET_PATH first (if set), then fall back to getPipeName().
   // Claude Code may cache a stale WMUX_SOCKET_PATH from a previous session,
   // so we must fall back to the derived name if the env path fails.
@@ -163,7 +175,7 @@ export async function sendRpc(
   for (const pipePath of pipePaths) {
     for (let attempt = 0; attempt < RETRY_COUNT; attempt++) {
       try {
-        return await attemptRpc(pipePath, token, method, params);
+        return await attemptRpc(pipePath, token, firstPartyToken, method, params);
       } catch (err) {
         lastError = err as Error;
         const msg = lastError.message;
@@ -185,7 +197,13 @@ export async function sendRpc(
   // TCP localhost fallback — bypasses Windows named pipe ACL issues
   if (tcpPort) {
     try {
-      return await attemptRpc({ host: '127.0.0.1', port: tcpPort }, token, method, params);
+      return await attemptRpc(
+        { host: '127.0.0.1', port: tcpPort },
+        token,
+        firstPartyToken,
+        method,
+        params,
+      );
     } catch { /* fall through */ }
   }
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -152,6 +152,15 @@ export function getAuthTokenPath(): string {
   return `${home}/.wmux-auth-token`;
 }
 
+// Separate bearer credential for the bundled first-party MCP bridge. This must
+// not be accepted as the general RPC auth token; it only proves that a request
+// came from the wmux-registered MCP script rather than a caller spoofing
+// clientName="claude-code" over an already-authenticated pipe.
+export function getFirstPartyTokenPath(): string {
+  const home = process.env.USERPROFILE || process.env.HOME || '';
+  return `${home}/.wmux-first-party-token`;
+}
+
 // PID-to-workspace mapping directory — written by PTYManager, read by MCP server
 // to resolve workspace identity when env vars don't propagate through Claude Code
 export function getPidMapDir(): string {

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -5,6 +5,8 @@ export interface RpcRequest {
   method: RpcMethod;
   params: Record<string, unknown>;
   token?: string;
+  /** Optional first-party bearer credential for the bundled wmux MCP bridge. */
+  firstPartyToken?: string;
   /**
    * v2.10.0+ — declared plugin identity. Carries the MCP `clientInfo.name`
    * (and version) from the MCP server stdio handshake so handlers can attribute
@@ -29,6 +31,8 @@ export interface RpcRequest {
 export interface RpcContext {
   clientName?: string;
   clientVersion?: string;
+  /** True only when RpcRouter verified the request's first-party credential. */
+  firstPartyAuthenticated?: boolean;
 }
 
 export type RpcResponse =


### PR DESCRIPTION
### Motivation
- The first-party allowlist previously relied only on the caller-supplied `clientName` (e.g. `claude-code`), which a malicious authenticated local client could spoof to bypass normal permission checks. 
- The goal is to ensure the bundled MCP bridge can still function without reworking the declaration/approval UX while preventing a spoofed `clientName` from gaining sensitive capabilities.

### Description
- Introduce a separate, on-disk first-party bearer credential and path (`getFirstPartyTokenPath`) and persist a per-install token alongside the normal RPC auth token via `McpRegistrar`.
- Wire the registrar token into the router with `RpcRouter.setFirstPartyToken(...)` and stamp `RpcContext.firstPartyAuthenticated` when an incoming request carries the verified `firstPartyToken` envelope field.
- Require `ctx.firstPartyAuthenticated === true` in `PermissionEnforcer.check` before applying the scoped `FIRST_PARTY_METHODS` bypass, while preserving fail-closed behavior for denied records and lookup failures.
- Make the bundled MCP client (`src/mcp/wmux-client.ts`) read and attach the first-party token to outbound RPC envelopes and update tests to assert that spoofed `clientName` is rejected unless the private token is present.

### Testing
- Ran unit tests: `npx vitest run src/main/mcp/__tests__/PermissionEnforcer.firstParty.test.ts src/main/pipe/__tests__/RpcRouter.firstParty.enforce.test.ts src/main/mcp/__tests__/firstParty.test.ts` and all modified tests passed (24 tests across the changed suites passed).
- Exercised the high-level router dispatch tests with `npx vitest run src/main/pipe/__tests__/RpcRouter.firstParty.enforce.test.ts` and they passed.
- Type-checked the repo with `npx tsc --noEmit -p tsconfig.json` and built the MCP bundle via `npm run build:mcp` with no errors.
- Ran linting (`npm run lint`) which reports pre-existing repository-wide lint issues unrelated to this change (lint failures are not new regressions introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a24182fa6888320a1bbcc00f901ff74)