### PR TITLE
fix(daemon): prevent reconnect ping token disclosure

### DIFF
--- a/src/daemon/DaemonPipeServer.ts
+++ b/src/daemon/DaemonPipeServer.ts
@@ -7,6 +7,11 @@ import type { RpcRequest, RpcResponse } from '../shared/rpc';
 import { secureWriteTokenFile, reHardenTokenFileAcl } from '../shared/security';
 
 const MAX_LINE_BUFFER = 1024 * 1024; // 1 MB — prevent OOM from malicious clients
+const AUTH_CHALLENGE_METHOD = 'daemon.authChallenge';
+
+function signAuthProof(token: string, payload: string): string {
+  return crypto.createHmac('sha256', token).update(payload).digest('hex');
+}
 
 type RpcHandler = (params: Record<string, unknown>) => Promise<unknown>;
 
@@ -48,6 +53,7 @@ export class DaemonPipeServer {
   private authToken: string = '';
   private readonly handlers = new Map<string, RpcHandler>();
   private readonly connectedSockets = new Set<net.Socket>();
+  private readonly authChallenges = new WeakMap<net.Socket, string>();
   private readonly rateLimits = new Map<net.Socket, { count: number; resetAt: number }>();
   private globalRate = { count: 0, resetAt: 0 };
   private connectionRate = { count: 0, resetAt: 0 };
@@ -252,6 +258,7 @@ export class DaemonPipeServer {
         this.connectedSockets.add(socket);
         socket.on('close', () => {
           this.connectedSockets.delete(socket);
+          this.authChallenges.delete(socket);
           this.rateLimits.delete(socket);
           // Record the moment we dropped to zero clients so the Watchdog
           // idle-shutdown timer has an anchor. We re-stamp on every drop
@@ -422,11 +429,23 @@ export class DaemonPipeServer {
       return;
     }
 
-    // Authenticate before rate limit check (prevents DoS via rate exhaustion)
-    // Use timing-safe comparison to prevent timing attacks
-    const tokenBuf = Buffer.from(request.token || '');
-    const authBuf = Buffer.from(this.authToken);
-    if (tokenBuf.length !== authBuf.length || !crypto.timingSafeEqual(tokenBuf, authBuf)) {
+    if (request.method === AUTH_CHALLENGE_METHOD) {
+      const nonce = crypto.randomUUID();
+      this.authChallenges.set(socket, nonce);
+      socket.write(JSON.stringify({
+        id: request.id,
+        ok: true,
+        result: { nonce, algorithm: 'hmac-sha256' },
+      }) + '\n');
+      return;
+    }
+
+    // Authenticate before rate limit check (prevents DoS via rate exhaustion).
+    // Legacy callers can still send the token directly, but sensitive liveness
+    // probes use the challenge/HMAC path so an untrusted named-pipe owner never
+    // receives the daemon secret in plaintext.
+    const proofNonce = this.verifyRequestAuth(socket, request);
+    if (proofNonce === false) {
       const res = JSON.stringify({ id: request.id, ok: false, error: 'unauthorized' });
       socket.write(res + '\n');
       // Close the socket so brute-force must pay the per-second connection cap
@@ -464,7 +483,16 @@ export class DaemonPipeServer {
     this.dispatch(request)
       .then((response) => {
         if (!socket.destroyed) {
-          socket.write(JSON.stringify(response) + '\n');
+          const signedResponse = proofNonce
+            ? {
+                ...response,
+                authProof: signAuthProof(
+                  this.authToken,
+                  `${proofNonce}:${request.id}:response:${JSON.stringify(response.ok ? response.result : response.error)}`,
+                ),
+              }
+            : response;
+          socket.write(JSON.stringify(signedResponse) + '\n');
         }
       })
       .catch(() => {
@@ -473,6 +501,30 @@ export class DaemonPipeServer {
           socket.write(res + '\n');
         }
       });
+  }
+
+
+  private verifyRequestAuth(socket: net.Socket, request: RpcRequest): string | false {
+    const authProof = (request as RpcRequest & { authProof?: unknown }).authProof;
+    const authNonce = (request as RpcRequest & { authNonce?: unknown }).authNonce;
+    if (typeof authProof === 'string' && typeof authNonce === 'string') {
+      const expectedNonce = this.authChallenges.get(socket);
+      this.authChallenges.delete(socket);
+      if (expectedNonce !== authNonce) return false;
+      const expected = signAuthProof(this.authToken, `${authNonce}:${request.id}:${request.method}`);
+      const proofBuf = Buffer.from(authProof);
+      const expectedBuf = Buffer.from(expected);
+      return proofBuf.length === expectedBuf.length && crypto.timingSafeEqual(proofBuf, expectedBuf)
+        ? authNonce
+        : false;
+    }
+
+    // Use timing-safe comparison to prevent timing attacks.
+    const tokenBuf = Buffer.from(request.token || '');
+    const authBuf = Buffer.from(this.authToken);
+    return tokenBuf.length === authBuf.length && crypto.timingSafeEqual(tokenBuf, authBuf)
+      ? ''
+      : false;
   }
 
   private async dispatch(request: RpcRequest): Promise<RpcResponse> {

--- a/src/daemon/__tests__/DaemonPipeServer.test.ts
+++ b/src/daemon/__tests__/DaemonPipeServer.test.ts
@@ -20,8 +20,15 @@ function testPipeName(suffix: string): string {
 // Helper: connect to pipe and send a JSON-RPC request, return parsed response
 function sendRpc(
   pipeName: string,
-  req: { id: string; method: string; params?: Record<string, unknown>; token?: string },
-): Promise<{ id: string; ok: boolean; result?: unknown; error?: string }> {
+  req: {
+    id: string;
+    method: string;
+    params?: Record<string, unknown>;
+    token?: string;
+    authNonce?: string;
+    authProof?: string;
+  },
+): Promise<{ id: string; ok: boolean; result?: unknown; error?: string; authProof?: string }> {
   return new Promise((resolve, reject) => {
     const client = net.createConnection(pipeName, () => {
       client.write(JSON.stringify(req) + '\n');
@@ -111,6 +118,67 @@ describe('DaemonPipeServer', () => {
 
     expect(res.ok).toBe(true);
     expect(res.result).toEqual({ created: 'sess-1' });
+  });
+
+  it('should authenticate ping through challenge proof without disclosing the token', async () => {
+    server.onRpc('daemon.ping', async () => ({ status: 'ok' }));
+    await server.start();
+
+    const seenWrites: string[] = [];
+    const responses = await new Promise<Array<{ id: string; ok: boolean; result?: unknown; authProof?: string }>>((resolve, reject) => {
+      const client = net.createConnection(pipeName, () => {
+        const request = JSON.stringify({ id: 'challenge-1', method: 'daemon.authChallenge', params: {} }) + '\n';
+        seenWrites.push(request);
+        client.write(request);
+      });
+      const parsedResponses: Array<{ id: string; ok: boolean; result?: unknown; authProof?: string }> = [];
+      let buf = '';
+      client.setEncoding('utf8');
+      client.on('data', (chunk: string) => {
+        buf += chunk;
+        const lines = buf.split('\n');
+        buf = lines.pop() ?? '';
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          const parsed = JSON.parse(trimmed);
+          parsedResponses.push(parsed);
+          if (parsedResponses.length === 1) {
+            const nonce = parsed?.result?.nonce;
+            const id = 'ping-1';
+            const authProof = crypto
+              .createHmac('sha256', 'test-token-123')
+              .update(`${nonce}:${id}:daemon.ping`)
+              .digest('hex');
+            const request = JSON.stringify({
+              id,
+              method: 'daemon.ping',
+              params: {},
+              authNonce: nonce,
+              authProof,
+            }) + '\n';
+            seenWrites.push(request);
+            client.write(request);
+          } else {
+            client.destroy();
+            resolve(parsedResponses);
+          }
+        }
+      });
+      client.on('error', reject);
+    });
+
+    const [challenge, res] = responses;
+    expect(challenge.ok).toBe(true);
+    expect(res.ok).toBe(true);
+    expect(res.result).toEqual({ status: 'ok' });
+    expect(res.authProof).toBe(
+      crypto
+        .createHmac('sha256', 'test-token-123')
+        .update(`${(challenge.result as { nonce: string }).nonce}:ping-1:response:${JSON.stringify(res.result)}`)
+        .digest('hex'),
+    );
+    expect(seenWrites.join('')).not.toContain('test-token-123');
   });
 
   it('should reject requests with invalid token', async () => {

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -228,6 +228,17 @@ function getProcessCommandLine(pid: number): string | null {
   } catch { return null; }
 }
 
+
+function signDaemonAuthProof(token: string, payload: string): string {
+  return crypto.createHmac('sha256', token).update(payload).digest('hex');
+}
+
+function timingSafeEqualHex(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a);
+  const bBuf = Buffer.from(b);
+  return aBuf.length === bBuf.length && crypto.timingSafeEqual(aBuf, bBuf);
+}
+
 interface DaemonPingResult {
   status?: string;
   pid?: number;
@@ -246,6 +257,8 @@ function daemonPing(pipeName: string, token: string, timeoutMs = 3000): Promise<
   return new Promise((resolve) => {
     const socket = net.connect(pipeName);
     let settled = false;
+    let challengeNonce = '';
+    let pingRequestId = '';
     const finish = (value: DaemonPingResult | null) => {
       if (settled) return;
       settled = true;
@@ -259,7 +272,7 @@ function daemonPing(pipeName: string, token: string, timeoutMs = 3000): Promise<
 
     socket.on('connect', () => {
       const id = crypto.randomUUID();
-      socket.write(JSON.stringify({ id, method: 'daemon.ping', params: {}, token }) + '\n');
+      socket.write(JSON.stringify({ id, method: 'daemon.authChallenge', params: {} }) + '\n');
     });
 
     let buffer = '';
@@ -267,14 +280,47 @@ function daemonPing(pipeName: string, token: string, timeoutMs = 3000): Promise<
       if (settled) return;
       buffer += chunk.toString('utf8');
       const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
       for (const line of lines) {
         if (!line.trim()) continue;
         try {
           const resp = JSON.parse(line.trim());
-          if (resp.ok || (resp.result && resp.result.status === 'ok')) {
-            finish((resp.result as DaemonPingResult) ?? { status: 'ok' });
+          if (!challengeNonce) {
+            const nonce = resp?.result?.nonce;
+            if (!resp.ok || typeof nonce !== 'string' || nonce.length === 0) {
+              finish(null);
+              return;
+            }
+            challengeNonce = nonce;
+            pingRequestId = crypto.randomUUID();
+            const authProof = signDaemonAuthProof(token, `${challengeNonce}:${pingRequestId}:daemon.ping`);
+            socket.write(JSON.stringify({
+              id: pingRequestId,
+              method: 'daemon.ping',
+              params: {},
+              authNonce: challengeNonce,
+              authProof,
+            }) + '\n');
+            continue;
+          }
+
+          const result = resp.result as DaemonPingResult | undefined;
+          const expectedProof = signDaemonAuthProof(
+            token,
+            `${challengeNonce}:${pingRequestId}:response:${JSON.stringify(resp.ok ? result : resp.error)}`,
+          );
+          if (
+            resp.ok &&
+            result &&
+            result.status === 'ok' &&
+            typeof resp.authProof === 'string' &&
+            timingSafeEqualHex(resp.authProof, expectedProof)
+          ) {
+            finish(result);
             return;
           }
+          finish(null);
+          return;
         } catch {}
       }
     });

--- a/src/main/mcp/methodCapabilityMap.ts
+++ b/src/main/mcp/methodCapabilityMap.ts
@@ -252,6 +252,7 @@ export const METHOD_CAPABILITY: Record<RpcMethod, RequiredCapability> = {
   'daemon.resizeSession':    { capability: 'wmux.internal' },
   'daemon.listSessions':     { capability: 'wmux.internal' },
   'daemon.readPromptEvents': { capability: 'wmux.internal' },
+  'daemon.authChallenge':    { capability: 'wmux.internal' },
   'daemon.ping':             { capability: 'wmux.internal' },
   'daemon.shutdown':         { capability: 'wmux.internal' },
   'daemon.compact':          { capability: 'wmux.internal' },

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -129,6 +129,7 @@ export type RpcMethod =
   | 'daemon.resizeSession'
   | 'daemon.listSessions'
   | 'daemon.readPromptEvents'
+  | 'daemon.authChallenge'
   | 'daemon.ping'
   | 'daemon.shutdown'
   | 'daemon.compact'
@@ -222,6 +223,7 @@ export const ALL_RPC_METHODS = [
   'daemon.resizeSession',
   'daemon.listSessions',
   'daemon.readPromptEvents',
+  'daemon.authChallenge',
   'daemon.ping',
   'daemon.shutdown',
   'daemon.compact',


### PR DESCRIPTION
### Motivation
- A Windows reconnect path treated any successful connect to the canonical named pipe as a trusted daemon and had the launcher send the plaintext daemon auth token to that pipe, allowing a local pipe squatter to steal the token. 
- The goal is to prevent disclosure of the daemon token during liveness/reconnect probes while preserving the split‑brain avoidance and fallback behavior.

### Description
- Add a `daemon.authChallenge` RPC that returns a per-connection nonce so peers can prove possession of the token via an HMAC instead of receiving the token in cleartext (`src/daemon/DaemonPipeServer.ts`, `src/shared/rpc.ts`).
- Implement HMAC signing/verification on the daemon (`signAuthProof`, `verifyRequestAuth`) and emit an `authProof` on RPC responses when the request was authenticated via a challenge (preserves legacy direct-token callers). 
- Update the launcher `daemonPing` to perform the challenge/HMAC flow (request challenge → send HMACed `daemon.ping` → verify server `authProof`) instead of sending the token directly (`src/main/daemon/launcher.ts`).
- Register `daemon.authChallenge` in the RPC metadata and capability map so it is recognized by the permission subsystem (`src/main/mcp/methodCapabilityMap.ts`).
- Add a regression test that exercises the challenge+proof flow and asserts the plaintext token is never written to the socket (`src/daemon/__tests__/DaemonPipeServer.test.ts`).

### Testing
- Ran the focused unit tests covering the pipe server and launcher ping logic with `npx vitest run src/daemon/__tests__/DaemonPipeServer.test.ts src/daemon/__tests__/DaemonPipeServer.reclaim.test.ts src/main/daemon/__tests__/launcher.liveness.test.ts src/main/daemon/__tests__/launcher.reping.test.ts --reporter=verbose` and the new test passed.
- Type-checked the project with `npx tsc --noEmit` and the full test suite with `npm test`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a225912bb5c832085a714194bc3e34e)