### PR TITLE
security: parse whoami SID field for ACL grants

### DIFF
--- a/src/shared/__tests__/security.test.ts
+++ b/src/shared/__tests__/security.test.ts
@@ -29,7 +29,7 @@ vi.mock('child_process', () => ({
 function stubWhoamiSid(sid: string): void {
   execFileSyncMock.mockImplementation((cmd: unknown) =>
     typeof cmd === 'string' && cmd.toLowerCase().includes('whoami')
-      ? Buffer.from(`\nUser Name        SID\n=============== ${'='.repeat(40)}\nmachine\\user    ${sid}\n`)
+      ? Buffer.from(`\nUSER INFORMATION\n----------------\nUser Name: machine\\user\nSID:       ${sid}\n`)
       : Buffer.from(''),
   );
 }
@@ -90,6 +90,33 @@ describe('secureWriteTokenFile', () => {
       '*S-1-5-21-1-2-3-1001:F',
       '/inheritance:r',
     ]);
+  });
+
+  it('parses the SID field instead of SID-like text in the account name', async () => {
+    vi.stubEnv('USERNAME', 'victim');
+    vi.stubEnv('SystemRoot', 'C:\\Windows');
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    execFileSyncMock.mockImplementation((cmd: unknown) =>
+      typeof cmd === 'string' && cmd.toLowerCase().includes('whoami')
+        ? Buffer.from(
+            '\nUSER INFORMATION\n----------------\n' +
+              'User Name: S-1-1-0\\victim\n' +
+              'SID:       S-1-5-21-1111111111-2222222222-3333333333-1001\n',
+          )
+        : Buffer.from(''),
+    );
+
+    const { secureWriteTokenFile } = await import('../security');
+    const tokenPath = path.join('C:', 'Users', 'victim', '.wmux-auth-token');
+    secureWriteTokenFile(tokenPath, 'secret-token');
+
+    expect(icaclsArgs()).toEqual([
+      tokenPath,
+      '/grant:r',
+      '*S-1-5-21-1111111111-2222222222-3333333333-1001:F',
+      '/inheritance:r',
+    ]);
+    expect(icaclsArgs()?.[2]).not.toBe('*S-1-1-0:F');
   });
 
   // Regression: a non-ASCII (Korean) profile name passed verbatim to icacls is
@@ -176,7 +203,7 @@ describe('secureWriteTokenFile', () => {
     // whoami resolves fine; icacls is the step that fails.
     execFileSyncMock.mockImplementation((cmd: unknown) => {
       if (typeof cmd === 'string' && cmd.toLowerCase().includes('whoami')) {
-        return Buffer.from('user S-1-5-21-1-2-3-1001\n');
+        return Buffer.from('User Name: machine\\user\nSID:       S-1-5-21-1-2-3-1001\n');
       }
       throw new Error('icacls failed');
     });
@@ -268,7 +295,7 @@ describe('reHardenTokenFileAcl', () => {
     execFileSyncMock.mockImplementation((cmd: unknown) => {
       // whoami succeeds; icacls denies — hardening must still fail soft.
       if (typeof cmd === 'string' && cmd.toLowerCase().includes('whoami')) {
-        return Buffer.from('user S-1-5-21-1-2-3-1001\n');
+        return Buffer.from('User Name: machine\\user\nSID:       S-1-5-21-1-2-3-1001\n');
       }
       throw new Error('icacls denied');
     });

--- a/src/shared/security.ts
+++ b/src/shared/security.ts
@@ -25,8 +25,8 @@ function getCurrentUserSid(): string | null {
     const out = execFileSync(whoami, ['/user', '/fo', 'list'], {
       windowsHide: true,
     }).toString('utf8');
-    const match = out.match(/S-1-[0-9-]+/);
-    return match ? match[0] : null;
+    const match = out.match(/^\s*SID\s*:\s*(S-\d-(?:\d+|0x[0-9a-fA-F]+)(?:-\d+)+)\s*$/im);
+    return match ? match[1] : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
### Motivation
- Fix a fragile SID resolver that previously matched the first SID-shaped substring anywhere in `whoami /user` output, which could grant the token ACL to the wrong principal (e.g. `S-1-1-0` in the account/machine name). 
- Preserve the non-ASCII username hardening design by keeping SID-based ASCII grants codepage-proof while retaining a safe ASCII-only fallback.

### Description
- Change `getCurrentUserSid()` to parse the explicit `SID:` field from `whoami /user /fo list` output with a targeted regex instead of matching the first SID-like substring. (file: `src/shared/security.ts`).
- Update Windows-focused tests to mock the list-format `whoami` output and add a regression test that ensures a SID-like account name (e.g. `S-1-1-0\victim`) does not override the real `SID:` field. (file: `src/shared/__tests__/security.test.ts`).
- Preserve existing behavior for ACL application ordering and the ASCII-only `USERNAME` fallback guard; no other functional changes were made.

### Testing
- Ran `npx vitest run src/shared/__tests__/security.test.ts --reporter=dot`, and the test file passed (`11` tests passed).
- Ran `npx eslint src/shared/security.ts src/shared/__tests__/security.test.ts`, which reported no issues for the changed files.
- Ran `npm run lint` (repo-wide) and observed failures due to existing, unrelated lint errors elsewhere in the repository, not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2258bed5308320a09b3e26d1d96279)