### PR TITLE
fix(ci): avoid release tag shell injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,6 +250,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           FILES=$(find out/make -type f \( -name '*.dmg' -o -name '*.zip' \))
@@ -257,7 +258,7 @@ jobs:
           printf 'Uploading:\n%s\n' "$FILES"
           # Filenames carry no spaces (wmux-<ver>-<arch>.dmg); intentional word split.
           # shellcheck disable=SC2086
-          gh release upload "${{ github.ref_name }}" $FILES --clobber
+          gh release upload "$RELEASE_TAG" $FILES --clobber
 
       - name: Clean up temporary keychain
         if: always() && env.APPLE_CERT_P12_BASE64 != ''
@@ -300,10 +301,11 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           FILES=$(find out/make -type f \( -name '*.deb' -o -name '*.rpm' -o -name '*.AppImage' \))
           if [ -z "$FILES" ]; then echo "No Linux artifacts found — skipping upload"; exit 0; fi
           printf 'Uploading:\n%s\n' "$FILES"
           # shellcheck disable=SC2086
-          gh release upload "${{ github.ref_name }}" $FILES --clobber
+          gh release upload "$RELEASE_TAG" $FILES --clobber


### PR DESCRIPTION
### Motivation
- The macOS and Linux release upload steps interpolated `${{ github.ref_name }}` directly into a bash `run:` block, which allows shell command substitution from a malicious tag and can leak CI secrets.

### Description
- Change `.github/workflows/release.yml` upload steps to export `RELEASE_TAG: ${{ github.ref_name }}` and use `gh release upload "$RELEASE_TAG"` instead of embedding `${{ github.ref_name }}` directly in the shell command for both macOS and Linux upload steps.

### Testing
- Ran `git diff --check` which produced no issues and passed. 
- Verified with `rg` that no direct `github.ref_name` interpolation remains in `gh release upload`, which passed. 
- Executed Python assertions that both upload steps define `RELEASE_TAG` and use `$RELEASE_TAG`, and those assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a22591851208320b6ab77e8b61c954d)