### PR TITLE
fix(install): fail closed when checksum manifest missing or invalid

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -221,32 +221,40 @@ if (-not $FromSource) {
         return
     }
 
-    # Integrity: verify SHA-256 against the published manifest when available.
+    # Integrity: require SHA-256 verification against the published manifest.
     # TODO(NN2): once Authenticode signing lands, also verify
     # (Get-AuthenticodeSignature $tempExe).Status -eq 'Valid' and the publisher.
-    $expectedSha = $null
-    if ($manifestAsset) {
-        try {
-            $manifest = Invoke-RestMethod $manifestAsset.browser_download_url `
-                -Headers @{ 'User-Agent' = 'wmux-installer' } -TimeoutSec 15
-            $expectedSha = $manifest.sha256
-        } catch {
-            Write-Host "  [*] Could not fetch update-manifest.json ($($_.Exception.Message))" -ForegroundColor Yellow
-        }
+    if (-not $manifestAsset) {
+        Remove-Item $tempExe -Force -ErrorAction SilentlyContinue
+        Write-Host "  [!] No checksum manifest for this release. Aborting." -ForegroundColor Red
+        return
     }
-    if ($expectedSha) {
-        $actualSha = (Get-FileHash $tempExe -Algorithm SHA256).Hash
-        if ($actualSha.ToLower() -ne $expectedSha.ToLower()) {
-            Remove-Item $tempExe -Force -ErrorAction SilentlyContinue
-            Write-Host "  [!] SHA-256 mismatch — download may be corrupt or tampered. Aborting." -ForegroundColor Red
-            Write-Host "       expected $($expectedSha.ToLower())" -ForegroundColor Red
-            Write-Host "       actual   $($actualSha.ToLower())" -ForegroundColor Red
-            return
-        }
-        Write-Host "  [2/3] Verified SHA-256" -ForegroundColor Green
-    } else {
-        Write-Host "  [2/3] No checksum manifest for this release — skipping SHA-256 verification" -ForegroundColor Yellow
+
+    try {
+        $manifest = Invoke-RestMethod $manifestAsset.browser_download_url `
+            -Headers @{ 'User-Agent' = 'wmux-installer' } -TimeoutSec 15
+        $expectedSha = [string]$manifest.sha256
+    } catch {
+        Remove-Item $tempExe -Force -ErrorAction SilentlyContinue
+        Write-Host "  [!] Could not fetch update-manifest.json ($($_.Exception.Message)). Aborting." -ForegroundColor Red
+        return
     }
+
+    if ($expectedSha -notmatch '^[A-Fa-f0-9]{64}$') {
+        Remove-Item $tempExe -Force -ErrorAction SilentlyContinue
+        Write-Host "  [!] update-manifest.json is missing a valid SHA-256 checksum. Aborting." -ForegroundColor Red
+        return
+    }
+
+    $actualSha = (Get-FileHash $tempExe -Algorithm SHA256).Hash
+    if ($actualSha.ToLower() -ne $expectedSha.ToLower()) {
+        Remove-Item $tempExe -Force -ErrorAction SilentlyContinue
+        Write-Host "  [!] SHA-256 mismatch — download may be corrupt or tampered. Aborting." -ForegroundColor Red
+        Write-Host "       expected $($expectedSha.ToLower())" -ForegroundColor Red
+        Write-Host "       actual   $($actualSha.ToLower())" -ForegroundColor Red
+        return
+    }
+    Write-Host "  [2/3] Verified SHA-256" -ForegroundColor Green
 
     Write-Host "  [3/3] Launching installer..." -ForegroundColor Green
     Start-Process -FilePath $tempExe


### PR DESCRIPTION
### Motivation
- The installer previously downloaded and launched the prebuilt `Setup.exe` even when `update-manifest.json` was missing, malformed, or lacked a SHA-256, creating a fail-open integrity check and enabling arbitrary code execution risks.  
- The change enforces a fail-closed policy so the installer will not run an unverifiable binary and matches the README claim that SHA-256 is verified before launch.

### Description
- Require the presence of an `update-manifest.json` release asset before launching the downloaded `Setup.exe`, and abort if it is missing.  
- Abort and remove the downloaded installer if the manifest cannot be fetched or parsed, with an explicit error message.  
- Require the manifest to contain a valid 64-hex-character SHA-256 string and abort if the value is absent or invalid.  
- Compute `Get-FileHash -Algorithm SHA256` on the downloaded file and abort (and remove the temp file) if the hash does not match, otherwise proceed to `Start-Process` to launch the installer.

### Testing
- Ran `git diff --check` to ensure no whitespace/merge issues and it succeeded.  
- Executed a `python3` semantic check that verified the presence of the manifest requirement, SHA-256 format validation, hash comparison, and absence of a skip-verification path, and it succeeded.  
- Attempted to run the PowerShell AST parser command (`pwsh -NoProfile -Command ...`) but it could not be executed in the container because `pwsh` is not installed (skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a225b8291348320a135ee64fe79c4d6)