### PR TITLE
fix(mcp): bind approvals to capability snapshot

### DIFF
--- a/src/main/mcp/ApprovalQueue.ts
+++ b/src/main/mcp/ApprovalQueue.ts
@@ -16,9 +16,10 @@
 // When the user resolves it, every coalesced caller gets the same answer.
 //
 // Persistence: on resolve, the queue writes the user's decision through
-// PluginTrustStore.setUserDecision so the next prompt for the same plugin
-// reads the persisted state (and the enforcer can short-circuit denied
-// plugins without ever surfacing another modal).
+// PluginTrustStore.setUserDecision with the exact capability snapshot that
+// appeared in the prompt. That prevents a plugin from widening its stored
+// declaration while a prompt is pending and having the wider set become
+// trusted when the user approves the older prompt.
 
 import { createHash } from 'node:crypto';
 import type { PluginIdentityRecord } from '../../shared/rpc';
@@ -196,6 +197,7 @@ export class ApprovalQueue {
       identity = await this.trustStore.setUserDecision(
         pending.clientName,
         approved ? 'trusted' : 'denied',
+        approved ? pending.declaredCapabilities : undefined,
       );
     } catch {
       // Trust-DB write failed — still resolve the waiters so they don't

--- a/src/main/mcp/PluginTrustStore.ts
+++ b/src/main/mcp/PluginTrustStore.ts
@@ -258,31 +258,43 @@ export class PluginTrustStore {
    * `(clientName, declaredCapabilities)` pair; that decision MUST stick:
    *
    *   - 'trusted' — bypasses applyContact/applyDeclaration's auto-demotion
-   *     since the user explicitly approved the current declaration. If no
-   *     record exists yet (a prompt that fired before mcp.identify
-   *     landed), seed a minimal trusted entry.
+   *     since the user explicitly approved the prompt's declaration. When
+   *     the prompt passes an approved capability snapshot, persist that exact
+   *     snapshot rather than whatever the plugin has redeclared since the
+   *     prompt opened. If no record exists yet (a prompt that fired before
+   *     mcp.identify landed), seed a minimal trusted entry.
    *   - 'denied' — spec §4.3 "denied never regresses". The next
    *     applyContact or applyDeclaration call will read this status and
    *     refuse to upgrade away from it.
    *
-   * `lastSeen` advances. `declaredCapabilities` are NOT overwritten — the
-   * decision applies to whatever set was active when the user clicked.
+   * `lastSeen` advances. When `approvedCapabilities` is provided,
+   * `declaredCapabilities` is rebound to that reviewed snapshot.
    */
   async setUserDecision(
     name: string,
     status: 'trusted' | 'denied',
+    approvedCapabilities?: readonly string[],
   ): Promise<PluginIdentityRecord> {
     const safeName = clampName(name);
     return this.mutate((db) => {
       const existing = ownPlugin(db, safeName);
       const t = Date.now();
+      const declaredCapabilities = approvedCapabilities
+        ? [...approvedCapabilities]
+        : undefined;
       const next: PluginIdentityRecord = existing
-        ? { ...existing, status, lastSeen: t }
+        ? {
+            ...existing,
+            ...(declaredCapabilities ? { declaredCapabilities } : {}),
+            status,
+            lastSeen: t,
+          }
         : {
             name: safeName,
             status,
             firstSeen: t,
             lastSeen: t,
+            ...(declaredCapabilities ? { declaredCapabilities } : {}),
           };
       db.plugins[safeName] = next;
       return next;

--- a/src/main/mcp/__tests__/ApprovalQueue.test.ts
+++ b/src/main/mcp/__tests__/ApprovalQueue.test.ts
@@ -69,6 +69,25 @@ describe('ApprovalQueue.requestApproval', () => {
     expect(result.identity?.name).toBe('plugin-a');
   });
 
+  it('trusts the prompt snapshot if capabilities change before approval', async () => {
+    const queue = makeQueue();
+    await store.upsertDeclaration('plugin-race', ['pane.read']);
+    const handle = queue.requestApproval({
+      clientName: 'plugin-race',
+      declaredCapabilities: ['pane.read'],
+    });
+
+    await store.upsertDeclaration('plugin-race', ['terminal.send']);
+    await queue.resolvePrompt(handle.promptId, true);
+    const result = await handle.resolution;
+
+    expect(result.identity?.status).toBe('trusted');
+    expect(result.identity?.declaredCapabilities).toEqual(['pane.read']);
+    expect((await store.get('plugin-race'))?.declaredCapabilities).toEqual([
+      'pane.read',
+    ]);
+  });
+
   it('persists denied status (spec §4.3)', async () => {
     const queue = makeQueue();
     const handle = queue.requestApproval({

--- a/src/main/mcp/__tests__/PluginTrustStore.test.ts
+++ b/src/main/mcp/__tests__/PluginTrustStore.test.ts
@@ -335,6 +335,20 @@ describe('PluginTrustStore.setUserDecision (Phase 2.2 pre-commit 5)', () => {
     expect((await store.get('p1'))?.declaredCapabilities).toEqual(['pane.read']);
   });
 
+  it('can bind a trusted decision to the reviewed capability snapshot', async () => {
+    const store = new PluginTrustStore(dbPath);
+    await store.upsertDeclaration('p-race', ['pane.read']);
+    await store.upsertDeclaration('p-race', ['terminal.send']);
+
+    const rec = await store.setUserDecision('p-race', 'trusted', ['pane.read']);
+
+    expect(rec.status).toBe('trusted');
+    expect(rec.declaredCapabilities).toEqual(['pane.read']);
+    expect((await store.get('p-race'))?.declaredCapabilities).toEqual([
+      'pane.read',
+    ]);
+  });
+
   it('clamps oversized plugin names like every other write path', async () => {
     const store = new PluginTrustStore(dbPath);
     const huge = 'X'.repeat(MAX_PLUGIN_NAME_LEN + 100);

--- a/src/main/mcp/__tests__/phase-2-2-dynamic.test.ts
+++ b/src/main/mcp/__tests__/phase-2-2-dynamic.test.ts
@@ -473,6 +473,68 @@ describe('phase 2.2 dynamic — enforce mode (pre-commit 6)', () => {
     expect(r2.ok).toBe(true);
   });
 
+  it('does not trust capabilities redeclared while an approval prompt is pending', async () => {
+    let inputSendRan = false;
+    router.register('input.send', async () => {
+      inputSendRan = true;
+      return { ok: true };
+    });
+
+    await router.dispatch({
+      id: 'race-identify',
+      method: 'mcp.identify',
+      params: {},
+      clientName: 'p-race',
+    });
+    await router.dispatch({
+      id: 'race-declare-benign',
+      method: 'mcp.declarePermissions',
+      params: { permissions: ['pane.read'] },
+      clientName: 'p-race',
+    });
+
+    const rejected = await router.dispatch({
+      id: 'race-trigger-prompt',
+      method: 'pane.list',
+      params: {},
+      clientName: 'p-race',
+    });
+    expect(rejected.ok).toBe(false);
+    if (rejected.ok) throw new Error('expected failure');
+    const promptId = (rejected.rejection as RpcRejection & { reason: 'identity-status' })
+      .pendingApproval?.promptId;
+    expect(promptId).toBeDefined();
+    expect(opened).toHaveLength(1);
+    expect(opened[0].declaredCapabilities).toEqual(['pane.read']);
+
+    await router.dispatch({
+      id: 'race-redeclare-dangerous',
+      method: 'mcp.declarePermissions',
+      params: { permissions: ['terminal.send'] },
+      clientName: 'p-race',
+    });
+
+    await approvalQueue.resolvePrompt(promptId as string, true);
+    store.invalidateCache();
+    await settle();
+
+    expect((await store.get('p-race'))?.status).toBe('trusted');
+    expect((await store.get('p-race'))?.declaredCapabilities).toEqual([
+      'pane.read',
+    ]);
+
+    const dangerous = await router.dispatch({
+      id: 'race-dangerous-call',
+      method: 'input.send',
+      params: { text: 'whoami' },
+      clientName: 'p-race',
+    });
+    expect(inputSendRan).toBe(false);
+    expect(dangerous.ok).toBe(false);
+    if (dangerous.ok) throw new Error('expected failure');
+    expect(dangerous.rejection?.reason).toBe('capability-not-declared');
+  });
+
   it('still allows identity-bootstrap RPCs in enforce mode (mcp.identify + mcp.declarePermissions)', async () => {
     const r = await router.dispatch({
       id: 'boot-1',


### PR DESCRIPTION
### Motivation

- A race allowed a plugin to redeclare broader capabilities while an approval prompt was pending, and an approve action would trust whatever was currently stored rather than the snapshot the user reviewed. 
- The change ensures the user decision is applied only to the exact capability snapshot shown in the prompt so an attacker cannot escalate privileges during the pending window.

### Description

- `ApprovalQueue.resolvePrompt` now passes the prompt's `declaredCapabilities` snapshot into `PluginTrustStore.setUserDecision` so the persisted trust decision can be bound to the reviewed set. (file: `src/main/mcp/ApprovalQueue.ts`)
- `PluginTrustStore.setUserDecision` signature was extended to accept an optional `approvedCapabilities` snapshot and, when provided, rebinding the trusted record's `declaredCapabilities` to that snapshot. (file: `src/main/mcp/PluginTrustStore.ts`)
- Added regression tests that exercise the approval race at the queue/store unit level and end-to-end in enforce-mode so a redeclaration to `terminal.send` during a pending `pane.read` prompt cannot become trusted. (files: `src/main/mcp/__tests__/ApprovalQueue.test.ts`, `src/main/mcp/__tests__/PluginTrustStore.test.ts`, `src/main/mcp/__tests__/phase-2-2-dynamic.test.ts`)
- Updated comments and small docs in the affected modules to explain the snapshot binding behaviour.

### Testing

- Ran the focused test suite with `npx vitest run src/main/mcp/__tests__/ApprovalQueue.test.ts src/main/mcp/__tests__/PluginTrustStore.test.ts src/main/mcp/__tests__/phase-2-2-dynamic.test.ts` and all tests passed.
- Type-checking with `npx tsc --noEmit` returned clean results for the change set.
- Ran `npx eslint` against the modified files and the targeted lint invocation exited without errors for those files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a225eee597c8320a81e0c8dfcdd4153)