### PR TITLE
fix: restrict terminal text drops to wmux drags

### DIFF
--- a/src/renderer/components/FileTree/FileTreePanel.tsx
+++ b/src/renderer/components/FileTree/FileTreePanel.tsx
@@ -215,9 +215,16 @@ function TreeItem({
     }
   };
 
+  const setTerminalTextDropDragActive = useStore((s) => s.setTerminalTextDropDragActive);
+
   const handleDragStart = (e: React.DragEvent) => {
     e.dataTransfer.setData('text/plain', node.path);
     e.dataTransfer.effectAllowed = 'copy';
+    setTerminalTextDropDragActive(true);
+  };
+
+  const handleDragEnd = () => {
+    setTerminalTextDropDragActive(false);
   };
 
   return (
@@ -229,6 +236,7 @@ function TreeItem({
         title={node.path}
         draggable={!node.isDirectory}
         onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
       >
         <span className="mr-1 shrink-0 text-[11px]">{icon}</span>
         <span className="truncate">{node.name}</span>

--- a/src/renderer/components/Pane/SurfaceTabs.tsx
+++ b/src/renderer/components/Pane/SurfaceTabs.tsx
@@ -43,6 +43,7 @@ export default function SurfaceTabs({
   // completed agent is discoverable even when its tab isn't on top. The
   // active surface's completion is conveyed by the pane border blink instead.
   const surfaceAgentStatus = useStore((s) => s.surfaceAgentStatus);
+  const setTerminalTextDropDragActive = useStore((s) => s.setTerminalTextDropDragActive);
 
   // Always render the strip — even for a single surface — so the X button is
   // reachable. Pane.tsx's handleCloseSurface cascades into closePane when the
@@ -67,6 +68,7 @@ export default function SurfaceTabs({
     const md = buildPaneMarkdown(workspace, paneId);
     e.dataTransfer.setData('text/plain', md);
     e.dataTransfer.effectAllowed = 'copy';
+    setTerminalTextDropDragActive(true);
   };
 
   const handleTabClick = (surfaceId: string) => {
@@ -83,6 +85,7 @@ export default function SurfaceTabs({
           key={s.id}
           draggable
           onDragStart={handleDragStart}
+          onDragEnd={() => setTerminalTextDropDragActive(false)}
           className={`group flex items-center gap-1 px-3 h-full cursor-pointer text-xs border-r border-[var(--bg-surface)] transition-colors ${
             s.id === activeSurfaceId
               ? 'bg-[var(--bg-base)] text-[var(--text-main)]'

--- a/src/renderer/components/Sidebar/WorkspaceItem.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceItem.tsx
@@ -56,6 +56,7 @@ export default function WorkspaceItem({ workspace, isActive, isMultiview, index,
   // Sidebar reorder source index lives in the store, not in dataTransfer.
   // See uiSlice.draggedWorkspaceIndex for why this is out-of-band.
   const setDraggedWorkspaceIndex = useStore((s) => s.setDraggedWorkspaceIndex);
+  const setTerminalTextDropDragActive = useStore((s) => s.setTerminalTextDropDragActive);
 
   const metadata = workspace.metadata;
 
@@ -98,6 +99,7 @@ export default function WorkspaceItem({ workspace, isActive, isMultiview, index,
     // accept the 'copy' half of 'copyMove' just as well.
     e.dataTransfer.effectAllowed = 'copyMove';
     setDraggedWorkspaceIndex(index);
+    setTerminalTextDropDragActive(true);
     // Apply the "being dragged" visual synchronously by mutating the
     // element's inline style. The previous setTimeout(setIsDragging) +
     // className toggle caused a React re-render right after dragstart
@@ -111,6 +113,7 @@ export default function WorkspaceItem({ workspace, isActive, isMultiview, index,
   const handleDragEnd = (e: React.DragEvent<HTMLDivElement>) => {
     e.currentTarget.style.opacity = '';
     setDropIndicator(null);
+    setTerminalTextDropDragActive(false);
     // Always clear, including the "drag dropped outside any drop target"
     // path. dragend always fires, drop does not.
     setDraggedWorkspaceIndex(null);

--- a/src/renderer/components/Terminal/Terminal.tsx
+++ b/src/renderer/components/Terminal/Terminal.tsx
@@ -205,16 +205,19 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
     })();
   }, [ptyId, terminalRef]);
 
-  // Accept text/plain drops (workspace/pane markdown from sidebar + tabs,
-  // file paths from the file tree) and route them through the same chunked
-  // paste path the clipboard handler uses. Native file drags carry the
-  // 'Files' DataTransfer type and are owned by AppLayout's onFileDrop —
-  // bail early so we don't double-handle them. xterm.js does not surface a
-  // drop event of its own, so without this handler the OS accepts the drop
-  // visually (no 🚫) but no text ever reaches the PTY.
+  // Accept text/plain drops only from wmux-owned drag sources (workspace/pane
+  // markdown from sidebar + tabs, file paths from the file tree) and route
+  // them through the same chunked paste path the clipboard handler uses.
+  // DataTransfer text from external apps or embedded web pages is untrusted:
+  // a benign visible drag label can hide shell commands in text/plain, and
+  // pastePtyChunked normalizes newlines to Enter for non-bracketed prompts.
+  // The in-memory store flag below is set during wmux dragstart and is never
+  // exposed through DataTransfer, so Terminal remains an internal-only text
+  // drop target while native file drags stay owned by AppLayout.onFileDrop.
   const handleTerminalDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
     if (!ptyId) return;
     if (isFileDrag(e.dataTransfer)) return;
+    if (!useStore.getState().terminalTextDropDragActive) return;
     if (!e.dataTransfer.types.includes('text/plain')) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = 'copy';
@@ -223,6 +226,7 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
   const handleTerminalDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
     if (!ptyId) return;
     if (isFileDrag(e.dataTransfer)) return;
+    if (!useStore.getState().terminalTextDropDragActive) return;
     const text = e.dataTransfer.getData('text/plain');
     if (!text) return;
     e.preventDefault();

--- a/src/renderer/stores/slices/__tests__/uiSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/uiSlice.test.ts
@@ -415,3 +415,23 @@ describe('UISlice — multiview', () => {
     expect(store.getState().multiviewIds).toEqual(['A', 'B', 'C']);
   });
 });
+
+describe('UISlice — terminal text-drop trust boundary', () => {
+  let store: ReturnType<typeof createTestStore>;
+
+  beforeEach(() => {
+    store = createTestStore();
+  });
+
+  it('terminalTextDropDragActive defaults to false', () => {
+    expect(store.getState().terminalTextDropDragActive).toBe(false);
+  });
+
+  it('setTerminalTextDropDragActive toggles the internal drag marker', () => {
+    store.getState().setTerminalTextDropDragActive(true);
+    expect(store.getState().terminalTextDropDragActive).toBe(true);
+
+    store.getState().setTerminalTextDropDragActive(false);
+    expect(store.getState().terminalTextDropDragActive).toBe(false);
+  });
+});

--- a/src/renderer/stores/slices/uiSlice.ts
+++ b/src/renderer/stores/slices/uiSlice.ts
@@ -247,6 +247,15 @@ export interface UISlice {
   draggedWorkspaceIndex: number | null;
   setDraggedWorkspaceIndex: (index: number | null) => void;
 
+  // ─── Terminal text-drop trust boundary ────────────────────────────────
+  // Browser/Electron DataTransfer text is attacker-controlled across app and
+  // web boundaries. Terminal.tsx only accepts text/plain drops while this
+  // in-memory flag is set by a wmux-owned drag source (sidebar, surface tabs,
+  // or file tree), preserving internal drag-paste without accepting external
+  // page/application payloads.
+  terminalTextDropDragActive: boolean;
+  setTerminalTextDropDragActive: (active: boolean) => void;
+
   // ─── Custom keybindings ──────────────────────────────────────────────
   customKeybindings: CustomKeybinding[];
   addKeybinding: (kb: Omit<CustomKeybinding, 'id'>) => void;
@@ -691,6 +700,11 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
   draggedWorkspaceIndex: null as number | null,
   setDraggedWorkspaceIndex: (index) => set((state) => {
     state.draggedWorkspaceIndex = index;
+  }),
+
+  terminalTextDropDragActive: false,
+  setTerminalTextDropDragActive: (active) => set((state) => {
+    state.terminalTextDropDragActive = active;
   }),
 
   // ─── Custom keybindings ──────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Prevent untrusted `text/plain` DataTransfer payloads from external pages/apps being pasted directly into the PTY and potentially executing commands.
- Preserve the existing internal drag-paste UX for workspace/pane/file drags while closing the trust boundary to foreign drags.

### Description
- Add a renderer-local trust marker `terminalTextDropDragActive` to the UI slice and expose `setTerminalTextDropDragActive` to toggle it. (`src/renderer/stores/slices/uiSlice.ts`)
- Gate terminal drop handlers in `Terminal.tsx` so `onDragOver`/`onDrop` only accept text drops when the in-memory `terminalTextDropDragActive` flag is set and the drag is not a file drag. (`src/renderer/components/Terminal/Terminal.tsx`)
- Mark internal drag sources as trusted for the duration of the drag by setting/clearing `terminalTextDropDragActive` in the sidebar workspace item, pane surface tabs, and file tree drag handlers. (`src/renderer/components/Sidebar/WorkspaceItem.tsx`, `src/renderer/components/Pane/SurfaceTabs.tsx`, `src/renderer/components/FileTree/FileTreePanel.tsx`)
- Add tests that exercise the new UI-slice flag default and setter behavior. (`src/renderer/stores/slices/__tests__/uiSlice.test.ts`)

### Testing
- Ran unit tests: `npx vitest run src/renderer/stores/slices/__tests__/uiSlice.test.ts` — passed.
- Ran targeted linter: `npx eslint` on modified files (Terminal/WorkspaceItem/SurfaceTabs/FileTree/uiSlice/test) — completed (warnings only for these files).
- Type check: `npx tsc --noEmit -p tsconfig.json` — passed.
- Note: `npm run lint` (repo-wide) still reports unrelated, pre-existing lint errors in other parts of the repo; these are outside the scope of this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2261a527b483208d0ddd814b570a21)