### PR TITLE
fix(mcp): fail-closed default PTY resolution and verify workspace identity

### DIFF
--- a/src/mcp/__tests__/paneResolver.test.ts
+++ b/src/mcp/__tests__/paneResolver.test.ts
@@ -92,15 +92,16 @@ describe('resolveDefaultPtyId', () => {
     await expect(p3).resolves.toBe('pty-99');
   });
 
-  it('returns null and does not pin when the claim RPC fails', async () => {
-    const sendRpc = vi.fn().mockRejectedValue(new Error('pipe closed'));
+  it('throws and does not pin when the claim RPC fails', async () => {
+    const sendRpc = vi.fn().mockRejectedValueOnce(new Error('pipe closed'));
     const deps = makeDeps({
       sendRpc,
       resolveWorkspaceId: vi.fn().mockResolvedValue(''),
     });
 
-    const result = await resolveDefaultPtyId(deps);
-    expect(result).toBeNull();
+    await expect(resolveDefaultPtyId(deps)).rejects.toThrow(
+      'Unable to claim a dedicated MCP terminal workspace: pipe closed',
+    );
 
     // Next call should retry — failures must not permanently disable the
     // external caller's default-pane resolution.
@@ -110,14 +111,28 @@ describe('resolveDefaultPtyId', () => {
     expect(sendRpc).toHaveBeenCalledTimes(2);
   });
 
-  it('returns null when the claim RPC returns a malformed response', async () => {
+  it('throws when the claim RPC returns a malformed response', async () => {
     const sendRpc = vi.fn().mockResolvedValue({ workspaceId: 'ws-1' }); // missing ptyId
     const deps = makeDeps({
       sendRpc,
       resolveWorkspaceId: vi.fn().mockResolvedValue(''),
     });
 
+    await expect(resolveDefaultPtyId(deps)).rejects.toThrow(
+      'Unable to claim a dedicated MCP terminal workspace: mcp.claimWorkspace returned no ptyId',
+    );
+  });
+
+  it('does not treat unverified workspace identity as internal', async () => {
+    const sendRpc = vi.fn().mockResolvedValue({ ptyId: 'pty-claimed' });
+    const deps = makeDeps({
+      sendRpc,
+      resolveWorkspaceId: vi.fn().mockResolvedValue(''),
+    });
+
     const result = await resolveDefaultPtyId(deps);
-    expect(result).toBeNull();
+
+    expect(result).toBe('pty-claimed');
+    expect(sendRpc).toHaveBeenCalledWith('mcp.claimWorkspace', { name: 'MCP' });
   });
 });

--- a/src/mcp/__tests__/workspaceRouting.test.ts
+++ b/src/mcp/__tests__/workspaceRouting.test.ts
@@ -61,6 +61,13 @@ describe('MCP workspace routing (source-level invariants)', () => {
     expect(block).not.toMatch(/resolveWorkspaceId\(\)/);
   });
 
+  it('terminal default routing uses verified identity, not the env-hint resolver', () => {
+    const start = src.indexOf('function resolveDefaultPtyId');
+    expect(start).toBeGreaterThan(0);
+    const block = src.slice(start, src.indexOf('}', start) + 2);
+    expect(block).toContain('resolveDefaultPtyIdImpl({ sendRpc, resolveWorkspaceId: resolveVerifiedWorkspaceId })');
+  });
+
   it('browser_session_start is GLOBAL — carries no workspace identity (no resolver calls)', () => {
     // Session start manages a single global profile + CDP port; the RPC handler
     // ignores workspaceId. Requiring identity here would protect no routing and

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -93,7 +93,7 @@ function invalidateWorkspaceId(): void {
  * cannot be obtained, and is NOT cached, so a later call retries live
  * resolution once the renderer / pid-map becomes available.
  */
-async function resolveWorkspaceId(opts?: { force?: boolean }): Promise<string> {
+async function resolveWorkspaceId(opts?: { force?: boolean; verifiedOnly?: boolean }): Promise<string> {
   if (workspaceResolved && MY_WORKSPACE_ID && !opts?.force) return MY_WORKSPACE_ID;
 
   try {
@@ -124,8 +124,15 @@ async function resolveWorkspaceId(opts?: { force?: boolean }): Promise<string> {
   } catch { /* resolve failed, fall through to env hint */ }
 
   // Last resort: the unconfirmed (possibly stale) env hint. Not cached.
-  if (ENV_WORKSPACE_HINT) return ENV_WORKSPACE_HINT;
-  return MY_WORKSPACE_ID;
+  // Security-sensitive routing (terminal default-pane resolution) asks for a
+  // verified identity only; in that mode, never treat a user-supplied env var
+  // as proof that the MCP server is running inside a wmux PTY.
+  if (!opts?.verifiedOnly && ENV_WORKSPACE_HINT) return ENV_WORKSPACE_HINT;
+  return opts?.verifiedOnly ? '' : MY_WORKSPACE_ID;
+}
+
+function resolveVerifiedWorkspaceId(): Promise<string> {
+  return resolveWorkspaceId({ force: true, verifiedOnly: true });
 }
 
 async function getParentPid(pid: number): Promise<number | null> {
@@ -165,9 +172,12 @@ async function requireWorkspaceId(): Promise<string> {
 }
 
 // External-caller pane pinning — see src/mcp/paneResolver.ts for rationale.
-// Bind the resolver's deps to this module's sendRpc + resolveWorkspaceId.
+// Bind the resolver's deps to this module's sendRpc + verified identity
+// resolver. Unlike A2A tools, terminal defaults must not trust WMUX_WORKSPACE_ID
+// because an external launcher can spoof it and otherwise regain active-pane
+// fallback.
 function resolveDefaultPtyId(): Promise<string | null> {
-  return resolveDefaultPtyIdImpl({ sendRpc, resolveWorkspaceId });
+  return resolveDefaultPtyIdImpl({ sendRpc, resolveWorkspaceId: resolveVerifiedWorkspaceId });
 }
 
 // === Browser tools (RPC-based: surface management stays in main process) ===

--- a/src/mcp/paneResolver.ts
+++ b/src/mcp/paneResolver.ts
@@ -22,8 +22,9 @@ export interface PaneResolverDeps {
   /** JSON-RPC sender (wmux-client.sendRpc, usually). */
   sendRpc: (method: RpcMethod, params?: Record<string, unknown>) => Promise<unknown>;
   /**
-   * Identity resolver. Must return empty string when the MCP server can't
-   * locate a host workspace (i.e. it's running outside any wmux PTY).
+   * Verified identity resolver. Must return empty string when the MCP server
+   * can't prove it is running inside a live wmux PTY. This resolver must not
+   * trust user-supplied environment hints such as WMUX_WORKSPACE_ID.
    */
   resolveWorkspaceId: () => Promise<string>;
 }
@@ -59,10 +60,12 @@ export async function resolveDefaultPtyId(deps: PaneResolverDeps): Promise<strin
         pinnedPtyId = ptyId;
         return ptyId;
       }
+      throw new Error('mcp.claimWorkspace returned no ptyId');
     } catch (err) {
-      console.error('[mcp] claimWorkspace failed:', err instanceof Error ? err.message : String(err));
+      const message = err instanceof Error ? err.message : String(err);
+      console.error('[mcp] claimWorkspace failed:', message);
+      throw new Error(`Unable to claim a dedicated MCP terminal workspace: ${message}`);
     }
-    return null;
   })();
 
   try {


### PR DESCRIPTION
### Motivation
- The default-pane resolver could "fail open": a spoofable `WMUX_WORKSPACE_ID` hint or a failed/malformed `mcp.claimWorkspace` response caused tools to omit `ptyId` and fall back to the user's active pane, enabling cross-process keystroke injection and reads. 
- Terminal-default routing must instead require a verified PID-mapped workspace identity and fail closed if claiming a dedicated workspace cannot be proven.

### Description
- Add a `verifiedOnly` mode to `resolveWorkspaceId` and a helper `resolveVerifiedWorkspaceId()` so callers can request an identity that does not fall back to the untrusted `WMUX_WORKSPACE_ID` env hint (changes in `src/mcp/index.ts`).
- Wire the terminal default resolver to the verified identity by calling `resolveDefaultPtyIdImpl({ sendRpc, resolveWorkspaceId: resolveVerifiedWorkspaceId })` so env hints cannot classify an external MCP server as internal (changes in `src/mcp/index.ts`).
- Change `resolveDefaultPtyId` behavior to throw on `mcp.claimWorkspace` failures or when the claim returns no `ptyId`, turning the previous `null`/omit behavior into a fail-closed error path and preventing active-pane fallback (changes in `src/mcp/paneResolver.ts`).
- Update unit tests in `src/mcp/__tests__/paneResolver.test.ts` and `src/mcp/__tests__/workspaceRouting.test.ts` to cover claim RPC failure, malformed responses, and the verified-identity binding.

### Testing
- Ran targeted unit tests with `npx vitest run src/mcp/__tests__/paneResolver.test.ts src/mcp/__tests__/workspaceRouting.test.ts --reporter=verbose`, and they passed.
- Built the MCP bundle with `npm run build:mcp`, which completed successfully.
- Ran the full test suite with `npm test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a226dc91dac8320985c2fcb1718ceda)