### PR TITLE
Harden WinGet release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.pkg.outputs.version }}
     env:
       # NN2-T1 — SignPath Foundation (OSS) code signing. EMPTY until the secret
       # is configured, which makes every signing step below no-op so unsigned
@@ -169,17 +171,24 @@ jobs:
         env:
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
 
+  winget:
+    name: Publish to WinGet
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+    steps:
       - name: Publish to winget
         if: env.WINGET_TOKEN != ''
         continue-on-error: true
-        uses: vedantmgoyal2009/winget-releaser@v2
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e
         with:
           identifier: openwong2kim.wmux
-          version: ${{ steps.pkg.outputs.version }}
+          version: ${{ needs.build.outputs.version }}
           installers-regex: '\.Setup\.exe$'
           token: ${{ secrets.WINGET_TOKEN }}
-        env:
-          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
 
   # ── macOS build leg ──────────────────────────────────────────────────────
   # OPT-IN: runs only when the repo variable ENABLE_CROSS_PLATFORM_RELEASE is


### PR DESCRIPTION
### Motivation
- The release workflow previously invoked a third-party WinGet action by a mutable tag while the job had `permissions.contents: write` and passed `secrets.WINGET_TOKEN`, creating a supply-chain risk of secret exfiltration and release tampering. 
- The change reduces the blast radius by running WinGet publishing in a separate, less-privileged job and by pinning the external action to an immutable reference. 
- The goal is to remediate the supply-chain exposure while preserving the existing publishing functionality and release versioning.

### Description
- Move the `Publish to winget` step out of the privileged Windows `build` job into a new `winget` job that `needs: build`, runs on `ubuntu-latest`, and sets `permissions.contents: read`.
- Add `outputs.version` to the `build` job and consume it in the `winget` job via `needs.build.outputs.version` so the published version remains unchanged.
- Replace the mutable `vedantmgoyal2009/winget-releaser@v2` usage with a pinned full-length commit SHA `vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e` and remove the duplicate step-level `WINGET_TOKEN` environment exposure while continuing to pass the token as the action input.

### Testing
- Ran a Python assertion that checks the workflow no longer references the mutable tag and confirms the `winget` job uses `contents: read`, and the assertion passed. 
- Parsed the workflow with a Ruby YAML load to validate structure and presence of the `winget` job, and the parse succeeded. 
- Executed `npm test` (Vitest unit and runtime suites) and all automated tests passed; a PyYAML-based YAML parse check was skipped because `PyYAML` was not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a226d121a7483209aaf607a7c766627)