### PR TITLE
fix(security): rotate session pipe tokens

### DIFF
--- a/src/daemon/DaemonPipeServer.ts
+++ b/src/daemon/DaemonPipeServer.ts
@@ -9,6 +9,7 @@ import { secureWriteTokenFile, reHardenTokenFileAcl } from '../shared/security';
 const MAX_LINE_BUFFER = 1024 * 1024; // 1 MB — prevent OOM from malicious clients
 
 type RpcHandler = (params: Record<string, unknown>) => Promise<unknown>;
+type TokenRotationHandler = (newToken: string) => void;
 
 /** Action a reclaim probe implies, distinguishing a live owner from a zombie. */
 export type ReclaimOutcome = 'live-owner' | 'reclaimed' | 'unreclaimable';
@@ -45,8 +46,9 @@ export function classifyReclaimProbe(
  */
 export class DaemonPipeServer {
   private server: net.Server | null = null;
-  private authToken: string = '';
+  private authToken = '';
   private readonly handlers = new Map<string, RpcHandler>();
+  private readonly tokenRotationHandlers = new Set<TokenRotationHandler>();
   private readonly connectedSockets = new Set<net.Socket>();
   private readonly rateLimits = new Map<net.Socket, { count: number; resetAt: number }>();
   private globalRate = { count: 0, resetAt: 0 };
@@ -327,6 +329,14 @@ export class DaemonPipeServer {
     return this.authToken;
   }
 
+  /** Register a handler that runs after the daemon auth token rotates. */
+  onTokenRotated(handler: TokenRotationHandler): () => void {
+    this.tokenRotationHandlers.add(handler);
+    return () => {
+      this.tokenRotationHandlers.delete(handler);
+    };
+  }
+
   /** For testing: set token directly without file I/O. */
   setAuthToken(token: string): void {
     this.authToken = token;
@@ -346,6 +356,9 @@ export class DaemonPipeServer {
     }
     this.connectedSockets.clear();
     this.rateLimits.clear();
+    for (const handler of this.tokenRotationHandlers) {
+      handler(newToken);
+    }
     // Forced drop-to-zero — keep idle-window accounting consistent.
     this.lastDisconnectAt = Date.now();
     return newToken;

--- a/src/daemon/SessionPipe.ts
+++ b/src/daemon/SessionPipe.ts
@@ -29,11 +29,15 @@ export class SessionPipe {
   // Anything above this cap in a 1-second window is brute-force / scanner traffic.
   private static readonly MAX_NEW_CONNECTIONS_PER_SEC = 10;
 
+  private readonly authTokenProvider: () => string;
+
   constructor(
     private readonly sessionId: string,
     private readonly ringBuffer: RingBuffer,
-    private readonly authToken: string,
-  ) {}
+    authToken: string | (() => string),
+  ) {
+    this.authTokenProvider = typeof authToken === 'function' ? authToken : () => authToken;
+  }
 
   /** Get the platform-specific pipe name for this session. */
   getPipeName(): string {
@@ -183,6 +187,16 @@ export class SessionPipe {
     return this.client !== null && !this.client.destroyed;
   }
 
+  /** Disconnect any authenticated client after daemon token rotation. */
+  handleAuthTokenRotated(): void {
+    if (this.client) {
+      this.client.destroy();
+      this.client = null;
+    }
+    this.flushed = false;
+    this.connectionRate = { count: 0, resetAt: 0 };
+  }
+
   private handleClient(socket: net.Socket): void {
     // Auth handshake: client must send TOKEN\n within 5 seconds
     let authBuffer = Buffer.alloc(0);
@@ -218,7 +232,7 @@ export class SessionPipe {
 
       clearTimeout(authTimeout);
       const clientToken = authBuffer.subarray(0, newlineIndex);
-      const expectedToken = Buffer.from(this.authToken);
+      const expectedToken = Buffer.from(this.authTokenProvider());
 
       if (clientToken.length !== expectedToken.length ||
           !crypto.timingSafeEqual(clientToken, expectedToken)) {

--- a/src/daemon/__tests__/DaemonPipeServer.test.ts
+++ b/src/daemon/__tests__/DaemonPipeServer.test.ts
@@ -523,6 +523,80 @@ describe('SessionPipe', () => {
     expect(allInput).toBe('user input');
   });
 
+  it('should reject stale session tokens and drop clients after daemon token rotation', async () => {
+    const tmpTokenPath = path.join(os.tmpdir(), `wmux-test-token-${crypto.randomUUID().slice(0, 8)}`);
+    const daemon = new DaemonPipeServer(testPipeName('session-rotate-ctrl'));
+    daemon.setAuthToken('old-session-token');
+    daemon.setTokenPathForTest(tmpTokenPath);
+
+    ringBuffer.write(Buffer.from('buffered output'));
+    sessionPipe = new SessionPipe(sessionId + '-rotate', ringBuffer, () => daemon.getAuthToken());
+    daemon.onTokenRotated(() => sessionPipe.handleAuthTokenRotated());
+    await sessionPipe.start();
+    const pipeName = sessionPipe.getPipeName();
+
+    try {
+      const liveClient = net.createConnection(pipeName);
+      const liveClosed = new Promise<void>((resolve) => liveClient.on('close', () => resolve()));
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('timeout')), 3000);
+        const chunks: Buffer[] = [];
+        liveClient.on('connect', () => {
+          liveClient.write('old-session-token\n');
+        });
+        liveClient.on('data', (chunk: Buffer) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+          if (Buffer.concat(chunks).indexOf(FLUSH_DONE_MARKER) !== -1) {
+            clearTimeout(timeout);
+            resolve();
+          }
+        });
+        liveClient.on('error', reject);
+      });
+      expect(sessionPipe.isConnected).toBe(true);
+
+      const newToken = daemon.rotateToken();
+      expect(newToken).not.toBe('old-session-token');
+      await liveClosed;
+      expect(sessionPipe.isConnected).toBe(false);
+
+      const staleResult = await new Promise<string>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        const client = net.createConnection(pipeName, () => {
+          client.write('old-session-token\n');
+        });
+        client.on('data', (chunk: Buffer) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+        client.on('close', () => resolve(Buffer.concat(chunks).toString()));
+        client.on('error', reject);
+        setTimeout(() => reject(new Error('timeout')), 3000);
+      });
+      expect(staleResult).toContain('AUTH_FAILED');
+
+      const newResult = await new Promise<Buffer>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        const client = net.createConnection(pipeName, () => {
+          client.write(newToken + '\n');
+        });
+        client.on('data', (chunk: Buffer) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+          const combined = Buffer.concat(chunks);
+          if (combined.indexOf(FLUSH_DONE_MARKER) !== -1) {
+            client.destroy();
+            resolve(combined);
+          }
+        });
+        client.on('error', reject);
+        setTimeout(() => reject(new Error('timeout')), 3000);
+      });
+      expect(newResult.indexOf(FLUSH_DONE_MARKER)).not.toBe(-1);
+    } finally {
+      await daemon.stop();
+      try { fs.unlinkSync(tmpTokenPath); } catch { /* ignore */ }
+    }
+  });
+
   it('should report isConnected correctly', async () => {
     sessionPipe = new SessionPipe(sessionId + '-d', ringBuffer, SESSION_AUTH_TOKEN);
     await sessionPipe.start();

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -655,7 +655,7 @@ function registerRpcHandlers(
         sessionPipes.delete(p.id);
       }
 
-      const pipe = new SessionPipe(p.id, managed.ringBuffer, pipeServer.getAuthToken());
+      const pipe = new SessionPipe(p.id, managed.ringBuffer, () => pipeServer.getAuthToken());
       sessionPipes.set(p.id, pipe);
 
       // Forward PTY output to session pipe
@@ -1247,6 +1247,11 @@ async function main(): Promise<void> {
   });
   const sessionPipes = new Map<string, SessionPipe>();
   const sessionDataListeners = new Map<string, { bridge: import('./DaemonPTYBridge').DaemonPTYBridge; listener: (data: Buffer) => void }>();
+  pipeServer.onTokenRotated(() => {
+    for (const pipe of sessionPipes.values()) {
+      pipe.handleAuthTokenRotated();
+    }
+  });
 
   // Forward reference — initialised at step 8c after the snapshot runner is
   // wired. RPC handlers that fire before initialisation simply skip the


### PR DESCRIPTION
### Motivation
- Token rotation previously only updated the daemon control-pipe token and dropped control sockets, leaving per-session `SessionPipe` instances authenticated with a stale token and allowing attackers holding an old token to continue accessing active sessions.
- The change ensures daemon token rotation immediately invalidates session pipes and closes any authenticated session clients.

### Description
- Add a token-rotation subscription mechanism on `DaemonPipeServer` with `onTokenRotated()` and invoke subscribers from `rotateToken()` after the new token is persisted to disk.
- Change `SessionPipe` to accept an auth-token provider (`() => string`) instead of a creation-time snapshot and validate incoming clients against `authTokenProvider()` so it observes current daemon token state.
- Add `SessionPipe.handleAuthTokenRotated()` to disconnect any authenticated client and reset local state when the daemon token rotates.
- Wire the daemon (`src/daemon/index.ts`) to construct session pipes with a token provider and register a `pipeServer.onTokenRotated()` handler that calls `handleAuthTokenRotated()` for every active session pipe.
- Add a regression test in `src/daemon/__tests__/DaemonPipeServer.test.ts` proving that a pre-existing session pipe accepts the old token, is dropped on rotation, then rejects the old token and accepts the newly issued token.

### Testing
- Ran `npx vitest run src/daemon/__tests__/DaemonPipeServer.test.ts --reporter verbose` and all tests in that file passed (`18 passed`).
- Ran `npx tsc -p tsconfig.daemon.json --noEmit` to validate types and it succeeded.
- Ran `git diff --check` which reported no problems for the modified files.
- Ran targeted `eslint` checks; `eslint` reported existing repository baseline issues in other files unrelated to this patch (these are pre-existing and not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a226e6ae7d083208fb568b722af2aec)