### PR TITLE
fix(company): authorize A2A sender identity

### DIFF
--- a/src/company/mcp/index.ts
+++ b/src/company/mcp/index.ts
@@ -161,20 +161,11 @@ server.tool(
   {
     to: z.string().describe('Target agent name, department name, or "CEO"'),
     message: z.string().describe('Message content'),
-    from: z.string().optional().describe('Sender name (auto-detected if omitted)'),
     priority: z.enum(['low', 'normal', 'high']).optional().describe('Message priority (default: normal)'),
   },
-  async ({ to, message, from, priority }) => {
+  async ({ to, message, priority }) => {
     const wsId = await requireWorkspaceId();
-    let senderName = from;
-    if (!senderName) {
-      try {
-        const whoami = await sendRpc('company.a2a.whoami', { workspaceId: wsId }) as { name?: string } | null;
-        senderName = whoami?.name;
-      } catch { /* use fallback */ }
-    }
     return callRpc('company.a2a.send', {
-      from: senderName || 'Agent',
       to,
       message,
       priority: priority || 'normal',
@@ -190,20 +181,11 @@ server.tool(
   'Broadcast a message to ALL agents in the company. Use sparingly.',
   {
     message: z.string().describe('Broadcast message content'),
-    from: z.string().optional().describe('Sender name (auto-detected if omitted)'),
     priority: z.enum(['low', 'normal', 'high']).optional().describe('Message priority'),
   },
-  async ({ message, from, priority }) => {
+  async ({ message, priority }) => {
     const wsId = await requireWorkspaceId();
-    let senderName = from;
-    if (!senderName) {
-      try {
-        const whoami = await sendRpc('company.a2a.whoami', { workspaceId: wsId }) as { name?: string } | null;
-        senderName = whoami?.name;
-      } catch { /* use fallback */ }
-    }
     return callRpc('company.a2a.broadcast', {
-      from: senderName || 'Agent',
       message,
       priority: priority || 'normal',
       workspaceId: wsId,

--- a/src/company/renderer/__tests__/rpcHandlers.a2a.test.ts
+++ b/src/company/renderer/__tests__/rpcHandlers.a2a.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleCompanyRpc } from '../rpcHandlers';
+import type { Company } from '../../types';
+
+const ptyWrite = vi.fn();
+
+function createStore() {
+  const company: Company = {
+    id: 'company-1',
+    name: 'Acme',
+    ceoWorkspaceId: 'ceo-ws',
+    createdAt: 1,
+    departments: [
+      {
+        id: 'dept-1',
+        name: 'Engineering',
+        leadId: 'alice-id',
+        members: [
+          {
+            id: 'alice-id',
+            name: 'Alice',
+            preset: 'frontend-developer',
+            workspaceId: 'alice-ws',
+            ptyId: 'alice-pty',
+            status: 'idle',
+          },
+          {
+            id: 'bob-id',
+            name: 'Bob',
+            preset: 'backend-architect',
+            workspaceId: 'bob-ws',
+            ptyId: 'bob-pty',
+            status: 'idle',
+          },
+        ],
+      },
+    ],
+  };
+
+  return {
+    company,
+    workspaces: [],
+    addFeedEntry: vi.fn(),
+    addToInbox: vi.fn(),
+    enqueueMessage: vi.fn(),
+  };
+}
+
+describe('company A2A RPC sender authorization', () => {
+  beforeEach(() => {
+    ptyWrite.mockReset();
+    vi.stubGlobal('window', { electronAPI: { pty: { write: ptyWrite } } });
+  });
+
+  it('rejects send and broadcast calls from workspaces outside the company', async () => {
+    const store = createStore();
+
+    await expect(handleCompanyRpc('company.a2a.send', {
+      workspaceId: 'outsider-ws',
+      from: 'CEO',
+      to: 'Bob',
+      message: 'spoofed',
+    }, store as any)).resolves.toMatchObject({ error: 'no company sender for workspace outsider-ws' });
+
+    await expect(handleCompanyRpc('company.a2a.broadcast', {
+      workspaceId: 'outsider-ws',
+      from: 'CEO',
+      message: 'spoofed',
+    }, store as any)).resolves.toMatchObject({ error: 'no company sender for workspace outsider-ws' });
+
+    expect(store.addFeedEntry).not.toHaveBeenCalled();
+    expect(store.addToInbox).not.toHaveBeenCalled();
+    expect(ptyWrite).not.toHaveBeenCalled();
+  });
+
+  it('derives the sender from workspaceId and ignores caller-controlled from values', async () => {
+    const store = createStore();
+
+    await expect(handleCompanyRpc('company.a2a.send', {
+      workspaceId: 'alice-ws',
+      from: 'CEO',
+      to: 'Bob',
+      message: 'hello',
+      priority: 'high',
+    }, store as any)).resolves.toMatchObject({ ok: true, delivered: 1, queued: 0, targetCount: 1 });
+
+    expect(store.addFeedEntry).toHaveBeenCalledWith({ from: 'Alice', to: 'Bob', message: 'hello', tag: 'message' });
+    expect(store.addToInbox).toHaveBeenCalledWith('bob-id', { from: 'Alice', to: 'Bob', message: 'hello', priority: 'high' });
+    expect(ptyWrite.mock.calls[0][1]).toContain('Alice');
+    expect(ptyWrite.mock.calls[0][1]).not.toContain('CEO');
+  });
+
+  it('allows the CEO workspace and derives sender as CEO', async () => {
+    const store = createStore();
+
+    await expect(handleCompanyRpc('company.a2a.broadcast', {
+      workspaceId: 'ceo-ws',
+      from: 'Mallory',
+      message: 'all hands',
+    }, store as any)).resolves.toMatchObject({ ok: true, sent: 2 });
+
+    expect(store.addFeedEntry).toHaveBeenCalledWith({ from: 'CEO', to: 'All', message: 'all hands', tag: 'broadcast' });
+    expect(store.addToInbox).toHaveBeenCalledWith('alice-id', { from: 'CEO', to: 'All', message: 'all hands', priority: 'normal' });
+    expect(store.addToInbox).toHaveBeenCalledWith('bob-id', { from: 'CEO', to: 'All', message: 'all hands', priority: 'normal' });
+    expect(ptyWrite.mock.calls.every(([, data]) => String(data).includes('CEO'))).toBe(true);
+    expect(ptyWrite.mock.calls.every(([, data]) => !String(data).includes('Mallory'))).toBe(true);
+  });
+});

--- a/src/company/renderer/rpcHandlers.ts
+++ b/src/company/renderer/rpcHandlers.ts
@@ -48,6 +48,14 @@ function resolveTargetMembers(
   return partialMatches.length === 1 ? partialMatches : [];
 }
 
+function getCompanyActorName(company: Company, workspaceId: string): string | null {
+  const allMembers = company.departments.flatMap((d) => d.members);
+  const member = allMembers.find((m) => m.workspaceId === workspaceId);
+  if (member) return member.name;
+  if (company.ceoWorkspaceId === workspaceId) return 'CEO';
+  return null;
+}
+
 function deliverToCeo(store: Store, from: string, message: string): void {
   const c = store.company;
   if (!c?.ceoWorkspaceId) return;
@@ -294,16 +302,18 @@ export async function handleCompanyRpc(
 
   if (method === 'company.a2a.send') {
     const rawMessage = typeof params.message === 'string' ? params.message : '';
-    const from = typeof params.from === 'string' ? params.from : '';
+    const workspaceId = typeof params.workspaceId === 'string' ? params.workspaceId : '';
     const to = typeof params.to === 'string' ? params.to : '';
     const priority = typeof params.priority === 'string' ? params.priority : 'normal';
-    if (!from || !to || !rawMessage) return { error: 'company.a2a.send: missing params' };
+    if (!workspaceId || !to || !rawMessage) return { error: 'company.a2a.send: missing params' };
     let message: string;
     try { message = validateMessage(rawMessage); } catch (e) {
       return { error: `company.a2a.send: ${e instanceof Error ? e.message : 'invalid'}` };
     }
     const c = store.company;
     if (!c) return { error: 'no company active' };
+    const from = getCompanyActorName(c, workspaceId);
+    if (!from) return { error: `no company sender for workspace ${workspaceId}` };
     store.addFeedEntry({ from, to, message, tag: 'message' });
     if (to.trim().toLowerCase() === 'ceo' && c.ceoWorkspaceId) {
       deliverToCeo(store, from, message);
@@ -327,15 +337,17 @@ export async function handleCompanyRpc(
 
   if (method === 'company.a2a.broadcast') {
     const rawMessage = typeof params.message === 'string' ? params.message : '';
-    const from = typeof params.from === 'string' ? params.from : '';
+    const workspaceId = typeof params.workspaceId === 'string' ? params.workspaceId : '';
     const priority = typeof params.priority === 'string' ? params.priority : 'normal';
-    if (!from || !rawMessage) return { error: 'company.a2a.broadcast: missing params' };
+    if (!workspaceId || !rawMessage) return { error: 'company.a2a.broadcast: missing params' };
     let message: string;
     try { message = validateMessage(rawMessage); } catch (e) {
       return { error: `company.a2a.broadcast: ${e instanceof Error ? e.message : 'invalid'}` };
     }
     const c = store.company;
     if (!c) return { error: 'no company active' };
+    const from = getCompanyActorName(c, workspaceId);
+    if (!from) return { error: `no company sender for workspace ${workspaceId}` };
     store.addFeedEntry({ from, to: 'All', message, tag: 'broadcast' });
     let sent = 0;
     for (const member of c.departments.flatMap((d) => d.members)) {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -604,20 +604,11 @@ server.tool(
   {
     to: z.string().describe('Target agent name, department name, or "CEO"'),
     message: z.string().describe('Message content'),
-    from: z.string().optional().describe('Sender name (auto-detected if omitted)'),
     priority: z.enum(['low', 'normal', 'high']).optional().describe('Message priority (default: normal)'),
   },
-  async ({ to, message, from, priority }) => {
+  async ({ to, message, priority }) => {
     const wsId = await requireWorkspaceId();
-    let senderName = from;
-    if (!senderName) {
-      try {
-        const whoami = await sendRpc('company.a2a.whoami', { workspaceId: wsId }) as { name?: string } | null;
-        senderName = whoami?.name;
-      } catch { /* use fallback */ }
-    }
     return callRpc('company.a2a.send', {
-      from: senderName || 'Agent',
       to,
       message,
       priority: priority || 'normal',
@@ -631,20 +622,11 @@ server.tool(
   'Company mode: broadcast a message to ALL agents in the company. Use sparingly. For workspace-wide broadcast (not company members), use a2a_broadcast.',
   {
     message: z.string().describe('Broadcast message content'),
-    from: z.string().optional().describe('Sender name (auto-detected if omitted)'),
     priority: z.enum(['low', 'normal', 'high']).optional().describe('Message priority'),
   },
-  async ({ message, from, priority }) => {
+  async ({ message, priority }) => {
     const wsId = await requireWorkspaceId();
-    let senderName = from;
-    if (!senderName) {
-      try {
-        const whoami = await sendRpc('company.a2a.whoami', { workspaceId: wsId }) as { name?: string } | null;
-        senderName = whoami?.name;
-      } catch { /* use fallback */ }
-    }
     return callRpc('company.a2a.broadcast', {
-      from: senderName || 'Agent',
       message,
       priority: priority || 'normal',
       workspaceId: wsId,


### PR DESCRIPTION
### Motivation
- The main MCP re-exposed company A2A send/broadcast but accepted a caller-controlled `from` and forwarded it to the renderer without verifying that the caller's `workspaceId` is a company member, enabling sender spoofing and PTY injection.

### Description
- Removed the caller-supplied `from` parameter from the `company_a2a_send` and `company_a2a_broadcast` MCP tool schemas and stopped forwarding any user-provided sender strings in `src/mcp/index.ts` and `src/company/mcp/index.ts`.
- Enforced sender authorization in the renderer RPC sink by deriving the sender name from the provided `workspaceId` (member name or `CEO`) and rejecting requests from workspaces not in the company in `src/company/renderer/rpcHandlers.ts` (added `getCompanyActorName` helper and replaced trusted `params.from` with derived sender).
- Ensured all inbox/feed/PTY delivery and enqueue paths use the derived, authorized sender name rather than a caller-controlled string.
- Added regression tests `src/company/renderer/__tests__/rpcHandlers.a2a.test.ts` that cover outsider rejection, suppression of spoofed `from` values, and CEO sender derivation.

### Testing
- Built the MCP surface with `npm run build:mcp` which completed successfully.
- Ran the new targeted tests with `npx vitest run src/company/renderer/__tests__/rpcHandlers.a2a.test.ts` and observed the new test file passing (3 tests passed).
- Ran the full test suite with `npm test` and observed the test run complete successfully (all automated tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a226f65af38832094bd84feb6ddaec4)