### PR TITLE
fix(company): disable remote SOUL prompt loading

### DIFF
--- a/src/company/core/SoulLoader.ts
+++ b/src/company/core/SoulLoader.ts
@@ -1,18 +1,16 @@
 // ─── Soul Loader ──────────────────────────────────────────────────────────────
-// Loads agent SOUL files from GitHub (agency-agents repo) with in-memory caching.
+// Maintains the agent SOUL API while preventing runtime third-party prompt downloads.
 // Designed to work in the Electron renderer process (no Node.js fs required).
-// Souls are fetched once per session and cached in memory.
 
 import { SOUL_MAPPING } from './soulMapping';
 
-const GITHUB_RAW_BASE =
-  'https://raw.githubusercontent.com/msitarzewski/agency-agents/main';
-
+// Remote SOUL prompt downloads are disabled by default. The previous
+// implementation fetched mutable third-party markdown from GitHub and
+// installed it as Claude instructions, which made company spawning depend on
+// unaudited command-capable prompts. Keep the loader shape for callers, but do
+// not make network requests or cache remote prompt text.
 /** In-memory cache: presetId -> raw markdown content */
 const soulCache = new Map<string, string>();
-
-/** Track in-flight fetches to avoid duplicate requests */
-const pendingFetches = new Map<string, Promise<string | null>>();
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 
@@ -31,42 +29,15 @@ export function loadSoulSync(presetId: string): string | null {
 }
 
 /**
- * Fetch a SOUL file from GitHub and cache it in memory.
- * Returns the raw content, or null if fetch fails or no mapping exists.
- * Deduplicates concurrent requests for the same preset.
+ * Runtime network fetching is intentionally disabled for SOUL files.
+ * Returns null so callers fall back to built-in wmux role prompts.
  */
-export async function fetchSoul(presetId: string): Promise<string | null> {
-  // Return from cache if available
-  const cached = soulCache.get(presetId);
-  if (cached) return cached;
-
-  const repoPath = SOUL_MAPPING[presetId as keyof typeof SOUL_MAPPING];
-  if (!repoPath) return null;
-
-  // Deduplicate in-flight fetches
-  const pending = pendingFetches.get(presetId);
-  if (pending) return pending;
-
-  const fetchPromise = (async (): Promise<string | null> => {
-    const url = `${GITHUB_RAW_BASE}/${repoPath}`;
-    try {
-      const response = await fetch(url);
-      if (!response.ok) return null;
-      const content = await response.text();
-
-      // Cache in memory
-      soulCache.set(presetId, content);
-      return content;
-    } catch {
-      // Network error — return null, caller uses base persona
-      return null;
-    } finally {
-      pendingFetches.delete(presetId);
-    }
-  })();
-
-  pendingFetches.set(presetId, fetchPromise);
-  return fetchPromise;
+export async function fetchSoul(_presetId: string): Promise<string | null> {
+  void _presetId;
+  // Intentionally do not fetch third-party prompt/instruction files at runtime.
+  // Callers fall back to the built-in wmux role prompts when no cached SOUL is
+  // available, avoiding a supply-chain prompt-injection path into Claude PTYs.
+  return null;
 }
 
 /**
@@ -79,16 +50,13 @@ export async function loadSoul(presetId: string): Promise<string | null> {
 }
 
 /**
- * Pre-fetch all souls for a list of preset IDs in parallel.
- * Useful before spawning a company to warm the cache.
- * Returns count of successfully loaded souls.
+ * Runtime network fetching is disabled, so no SOULs are prefetched.
+ * Returns the count of successfully loaded souls (always zero).
  */
-export async function prefetchSouls(presetIds: string[]): Promise<number> {
-  const unique = [...new Set(presetIds.filter((id) => hasSoul(id)))];
-  const results = await Promise.allSettled(unique.map((id) => fetchSoul(id)));
-  return results.filter(
-    (r) => r.status === 'fulfilled' && r.value !== null,
-  ).length;
+export async function prefetchSouls(_presetIds: string[]): Promise<number> {
+  void _presetIds;
+  // Runtime remote SOUL loading is disabled; there is nothing to prefetch.
+  return 0;
 }
 
 // ─── Soul Condensing ─────────────────────────────────────────────────────────
@@ -155,26 +123,14 @@ export function condenseSoul(raw: string): string {
 }
 
 /**
- * Write the SOUL as .claude/CLAUDE.md via the main-process fs IPC.
- *
- * Previously this built a POSIX shell heredoc and piped it through the PTY,
- * which introduced three defects: (1) supply-chain RCE via the fixed heredoc
- * delimiter when upstream markdown contained `WMUX_SOUL_EOF`, (2) silent
- * failure on Windows PowerShell (no `mkdir -p`, `&&`, or heredoc), and
- * (3) corruption of every apostrophe into `'\''` because the inline-quote
- * escape was applied inside a quoted heredoc where no expansion happens.
- *
- * Writing via the main process eliminates the shell round-trip entirely.
- * Returns true on success, false otherwise.
+ * Do not write third-party SOUL content into .claude/CLAUDE.md.
+ * Returns false so company spawning continues with the built-in role prompt.
  */
-export async function writeSoulToFile(presetId: string, workDir: string): Promise<boolean> {
-  if (!hasSoul(presetId)) return false;
-  const raw = await loadSoul(presetId);
-  if (!raw) return false;
-  const fs = window.electronAPI.fs;
-  if (!fs) return false;
-  const filePath = `${workDir}/.claude/CLAUDE.md`;
-  return fs.writeFile(filePath, raw);
+export async function writeSoulToFile(_presetId: string, _workDir: string): Promise<boolean> {
+  void _presetId;
+  void _workDir;
+  // Do not install remotely sourced SOUL files as Claude instruction files.
+  return false;
 }
 
 /**

--- a/src/company/core/__tests__/SoulLoader.security.test.ts
+++ b/src/company/core/__tests__/SoulLoader.security.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchSoul, loadSoul, prefetchSouls, writeSoulToFile } from '../SoulLoader';
+
+describe('SoulLoader remote prompt hardening', () => {
+  it('does not fetch third-party SOUL prompt content at runtime', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchSoul('security-engineer')).resolves.toBeNull();
+    await expect(loadSoul('security-engineer')).resolves.toBeNull();
+    await expect(prefetchSouls(['security-engineer', 'frontend-developer'])).resolves.toBe(0);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('does not install third-party SOUL content as Claude instructions', async () => {
+    const writeFile = vi.fn();
+    vi.stubGlobal('window', {
+      electronAPI: {
+        fs: { writeFile },
+      },
+    });
+
+    await expect(writeSoulToFile('security-engineer', '/tmp/wmux')).resolves.toBe(false);
+
+    expect(writeFile).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent runtime supply-chain prompt-injection by stopping automatic fetch and installation of third-party SOUL markdown into command-capable agent prompts and PTYs.
- Preserve the public SOUL loader API shape while removing the unsafe network-backed trust path used during company spawning.

### Description
- Disabled runtime fetching by making `fetchSoul` always return `null` and no-op `prefetchSouls`, so callers fall back to built-in wmux role prompts instead of downloading mutable remote content.
- Prevented installation of remote SOUL files by making `writeSoulToFile` return `false` and not write `.claude/CLAUDE.md` from third-party content.
- Kept `condenseSoul` and public API (`hasSoul`, `loadSoul`, `loadSoulSync`, `clearSoulCache`) intact so behavior is unchanged when cached content is available.
- Added a regression test `src/company/core/__tests__/SoulLoader.security.test.ts` that asserts `fetch` is not called, `prefetchSouls` returns `0`, and `writeSoulToFile` does not invoke `window.electronAPI.fs.writeFile`.

### Testing
- Ran the new unit tests with `./node_modules/.bin/vitest run src/company/core/__tests__/SoulLoader.security.test.ts --reporter=verbose --no-color`, and both tests passed.
- Type-checked the project with `npx tsc --noEmit -p tsconfig.json`, which completed successfully for this change.
- Linted the modified files with `./node_modules/.bin/eslint --ext .ts,.tsx src/company/core/SoulLoader.ts src/company/core/__tests__/SoulLoader.security.test.ts`, which passed for the changed files (only pre-existing warnings remain in unchanged `condenseSoul` code).
- Running repository-wide `npm run lint -- --quiet` surfaced unrelated, pre-existing lint errors elsewhere in the repo (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a227ad7a2688320a690410ab8278f5c)