### PR TITLE
fix: bracket inter-agent PTY message delivery

### DIFF
--- a/src/company/core/MessageQueue.ts
+++ b/src/company/core/MessageQueue.ts
@@ -6,6 +6,7 @@
 import { generateId } from '../../shared/types';
 import type { MemberStatus } from '../types';
 import { formatMessage, formatBroadcast, type MessagePriority } from './messageTemplates';
+import { formatBracketedPastePayload, isMultilinePtyPayload } from '../../shared/ptyMessageDelivery';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -95,7 +96,10 @@ export class MessageQueue {
         ? formatBroadcast(msg.from, msg.message, msg.priority)
         : formatMessage(msg.from, msg.targetName, msg.message, msg.priority);
 
-      this.deliverFn(msg.targetPtyId, formatted + '\r');
+      this.deliverFn(msg.targetPtyId, formatBracketedPastePayload(formatted));
+      setTimeout(() => {
+        this.deliverFn(msg.targetPtyId, isMultilinePtyPayload(formatted) ? '\r\r' : '\r');
+      }, 100);
       msg.delivered = true;
     }
   }

--- a/src/company/renderer/rpcHandlers.ts
+++ b/src/company/renderer/rpcHandlers.ts
@@ -6,6 +6,7 @@ import { useStore } from '../../renderer/stores';
 import type { Company, TeamMember } from '../types';
 import { validateMessage } from '../../shared/types';
 import { formatMessage, formatBroadcast } from '../core/messageTemplates';
+import { submitBracketedPasteToPty } from '../../renderer/utils/ptyMessageDelivery';
 import { spawnCompany, spawnMember } from './provisioner';
 
 type Store = ReturnType<typeof useStore.getState>;
@@ -58,7 +59,7 @@ function deliverToCeo(store: Store, from: string, message: string): void {
     const surface = leaf.surfaces.find((s) => s.surfaceType !== 'browser' && s.ptyId);
     if (surface) {
       const formatted = formatMessage(from, 'CEO', message);
-      window.electronAPI.pty.write(surface.ptyId, formatted + '\r');
+      submitBracketedPasteToPty(surface.ptyId, formatted);
       break;
     }
   }
@@ -168,7 +169,7 @@ export async function handleCompanyRpc(
     for (const member of c.departments.flatMap((d) => d.members)) {
       if (!member.ptyId) continue;
       if (member.status === 'idle') {
-        window.electronAPI.pty.write(member.ptyId, formatBroadcast(from, message) + '\r');
+        submitBracketedPasteToPty(member.ptyId, formatBroadcast(from, message));
         sentImmediate++;
       } else {
         store.enqueueMessage(member.id, member.ptyId, member.name, message, from, true);
@@ -195,7 +196,7 @@ export async function handleCompanyRpc(
     for (const member of dept.members) {
       if (!member.ptyId) continue;
       if (member.status === 'idle') {
-        window.electronAPI.pty.write(member.ptyId, formatMessage(from, member.name, message) + '\r');
+        submitBracketedPasteToPty(member.ptyId, formatMessage(from, member.name, message));
         sentImmediate++;
       } else {
         store.enqueueMessage(member.id, member.ptyId, member.name, message, from, false);
@@ -222,7 +223,7 @@ export async function handleCompanyRpc(
     const member = dept.members.find((m) => m.id === memberId);
     if (!member?.ptyId) return { error: `member not found or no PTY` };
     if (member.status === 'idle') {
-      window.electronAPI.pty.write(member.ptyId, formatMessage(from, member.name, message) + '\r');
+      submitBracketedPasteToPty(member.ptyId, formatMessage(from, member.name, message));
       return { ok: true, sentImmediate: 1, queued: 0 };
     } else {
       store.enqueueMessage(member.id, member.ptyId, member.name, message, from, false);
@@ -249,7 +250,7 @@ export async function handleCompanyRpc(
       for (const member of c.departments.flatMap((d) => d.members)) {
         if (!member.ptyId) continue;
         if (member.status === 'idle') {
-          window.electronAPI.pty.write(member.ptyId, formatBroadcast(from, message) + '\r');
+          submitBracketedPasteToPty(member.ptyId, formatBroadcast(from, message));
         } else {
           store.enqueueMessage(member.id, member.ptyId, member.name, message, from, true);
         }
@@ -267,7 +268,7 @@ export async function handleCompanyRpc(
     for (const member of targets) {
       if (!member.ptyId) continue;
       if (member.status === 'idle') {
-        window.electronAPI.pty.write(member.ptyId, formatMessage(from, member.name, message) + '\r');
+        submitBracketedPasteToPty(member.ptyId, formatMessage(from, member.name, message));
       } else {
         store.enqueueMessage(member.id, member.ptyId, member.name, message, from, false);
       }
@@ -315,7 +316,7 @@ export async function handleCompanyRpc(
       store.addToInbox(member.id, { from, to: member.name, message, priority });
       if (!member.ptyId) continue;
       if (member.status === 'idle') {
-        window.electronAPI.pty.write(member.ptyId, formatMessage(from, member.name, message, priority as MessagePriority) + '\r');
+        submitBracketedPasteToPty(member.ptyId, formatMessage(from, member.name, message, priority as MessagePriority));
         delivered++;
       } else {
         store.enqueueMessage(member.id, member.ptyId, member.name, message, from, false);
@@ -342,7 +343,7 @@ export async function handleCompanyRpc(
       store.addToInbox(member.id, { from, to: 'All', message, priority });
       if (!member.ptyId) continue;
       if (member.status === 'idle') {
-        window.electronAPI.pty.write(member.ptyId, formatBroadcast(from, message, priority as MessagePriority) + '\r');
+        submitBracketedPasteToPty(member.ptyId, formatBroadcast(from, message, priority as MessagePriority));
       } else {
         store.enqueueMessage(member.id, member.ptyId, member.name, message, from, true);
       }

--- a/src/renderer/company/MessageQueue.ts
+++ b/src/renderer/company/MessageQueue.ts
@@ -6,6 +6,7 @@
 import { generateId } from '../../shared/types';
 import type { MemberStatus } from '../../shared/types';
 import { formatMessage, formatBroadcast, type MessagePriority } from './messageTemplates';
+import { formatBracketedPastePayload, isMultilinePtyPayload } from '../../shared/ptyMessageDelivery';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -95,7 +96,10 @@ export class MessageQueue {
         ? formatBroadcast(msg.from, msg.message, msg.priority)
         : formatMessage(msg.from, msg.targetName, msg.message, msg.priority);
 
-      this.deliverFn(msg.targetPtyId, formatted + '\r');
+      this.deliverFn(msg.targetPtyId, formatBracketedPastePayload(formatted));
+      setTimeout(() => {
+        this.deliverFn(msg.targetPtyId, isMultilinePtyPayload(formatted) ? '\r\r' : '\r');
+      }, 100);
       msg.delivered = true;
     }
   }

--- a/src/renderer/company/messageTemplates.ts
+++ b/src/renderer/company/messageTemplates.ts
@@ -8,13 +8,32 @@ export type MessagePriority = 'low' | 'normal' | 'high';
 /**
  * Strip control characters from names/message content that will be
  * embedded into PTY-bound text to prevent injection of extra commands.
+ *
+ * `sanitizePtyText` preserves CR/LF/TAB/ESC for ordinary terminal writes.
+ * Inter-agent envelopes are different: sender-controlled CR/LF can split the
+ * envelope into extra PTY input lines, and raw ESC can forge terminal control
+ * sequences or bracketed-paste boundaries. The envelope's own separators are
+ * added after these helpers run, so message structure remains intact.
  */
+// eslint-disable-next-line no-control-regex
+const ESC_CSI_RE = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+// eslint-disable-next-line no-control-regex
+const ESC_OTHER_RE = /\x1b[@-_]/g;
+
+function stripEscapes(input: string): string {
+  return input.replace(ESC_CSI_RE, '').replace(ESC_OTHER_RE, '');
+}
+
 function safeName(name: string): string {
-  return sanitizePtyText(name).slice(0, 100);
+  return stripEscapes(sanitizePtyText(name))
+    .replace(/[\r\n\t]/g, ' ')
+    .slice(0, 100);
 }
 
 function safeBody(message: string): string {
-  return sanitizePtyText(message);
+  return stripEscapes(sanitizePtyText(message))
+    .replace(/\r/g, '')
+    .replace(/\n/g, '\u2424');
 }
 
 /**

--- a/src/renderer/hooks/companyRpcHandlers.ts
+++ b/src/renderer/hooks/companyRpcHandlers.ts
@@ -6,6 +6,7 @@ import { useStore } from '../stores';
 import type { Company, TeamMember, CompanyTemplate } from '../../shared/types';
 import { validateMessage } from '../../shared/types';
 import { formatMessage, formatBroadcast } from '../company/messageTemplates';
+import { submitBracketedPasteToPty } from '../utils/ptyMessageDelivery';
 
 type Store = ReturnType<typeof useStore.getState>;
 
@@ -57,7 +58,7 @@ function deliverToCeo(store: Store, from: string, message: string): void {
     const surface = leaf.surfaces.find((s) => s.surfaceType !== 'browser' && s.ptyId);
     if (surface) {
       const formatted = formatMessage(from, 'CEO', message);
-      window.electronAPI.pty.write(surface.ptyId, formatted + '\r');
+      submitBracketedPasteToPty(surface.ptyId, formatted);
       break;
     }
   }
@@ -167,7 +168,7 @@ export async function handleCompanyRpc(
     for (const member of c.departments.flatMap((d) => d.members)) {
       if (!member.ptyId) continue;
       if (member.status === 'idle') {
-        window.electronAPI.pty.write(member.ptyId, formatBroadcast(from, message) + '\r');
+        submitBracketedPasteToPty(member.ptyId, formatBroadcast(from, message));
         sentImmediate++;
       } else {
         store.enqueueMessage(member.id, member.ptyId, member.name, message, from, true);
@@ -194,7 +195,7 @@ export async function handleCompanyRpc(
     for (const member of dept.members) {
       if (!member.ptyId) continue;
       if (member.status === 'idle') {
-        window.electronAPI.pty.write(member.ptyId, formatMessage(from, member.name, message) + '\r');
+        submitBracketedPasteToPty(member.ptyId, formatMessage(from, member.name, message));
         sentImmediate++;
       } else {
         store.enqueueMessage(member.id, member.ptyId, member.name, message, from, false);
@@ -221,7 +222,7 @@ export async function handleCompanyRpc(
     const member = dept.members.find((m) => m.id === memberId);
     if (!member?.ptyId) return { error: `member not found or no PTY` };
     if (member.status === 'idle') {
-      window.electronAPI.pty.write(member.ptyId, formatMessage(from, member.name, message) + '\r');
+      submitBracketedPasteToPty(member.ptyId, formatMessage(from, member.name, message));
       return { ok: true, sentImmediate: 1, queued: 0 };
     } else {
       store.enqueueMessage(member.id, member.ptyId, member.name, message, from, false);
@@ -248,7 +249,7 @@ export async function handleCompanyRpc(
       for (const member of c.departments.flatMap((d) => d.members)) {
         if (!member.ptyId) continue;
         if (member.status === 'idle') {
-          window.electronAPI.pty.write(member.ptyId, formatBroadcast(from, message) + '\r');
+          submitBracketedPasteToPty(member.ptyId, formatBroadcast(from, message));
         } else {
           store.enqueueMessage(member.id, member.ptyId, member.name, message, from, true);
         }
@@ -266,7 +267,7 @@ export async function handleCompanyRpc(
     for (const member of targets) {
       if (!member.ptyId) continue;
       if (member.status === 'idle') {
-        window.electronAPI.pty.write(member.ptyId, formatMessage(from, member.name, message) + '\r');
+        submitBracketedPasteToPty(member.ptyId, formatMessage(from, member.name, message));
       } else {
         store.enqueueMessage(member.id, member.ptyId, member.name, message, from, false);
       }
@@ -314,7 +315,7 @@ export async function handleCompanyRpc(
       store.addToInbox(member.id, { from, to: member.name, message, priority });
       if (!member.ptyId) continue;
       if (member.status === 'idle') {
-        window.electronAPI.pty.write(member.ptyId, formatMessage(from, member.name, message, priority as MessagePriority) + '\r');
+        submitBracketedPasteToPty(member.ptyId, formatMessage(from, member.name, message, priority as MessagePriority));
         delivered++;
       } else {
         store.enqueueMessage(member.id, member.ptyId, member.name, message, from, false);
@@ -341,7 +342,7 @@ export async function handleCompanyRpc(
       store.addToInbox(member.id, { from, to: 'All', message, priority });
       if (!member.ptyId) continue;
       if (member.status === 'idle') {
-        window.electronAPI.pty.write(member.ptyId, formatBroadcast(from, message, priority as MessagePriority) + '\r');
+        submitBracketedPasteToPty(member.ptyId, formatBroadcast(from, message, priority as MessagePriority));
       } else {
         store.enqueueMessage(member.id, member.ptyId, member.name, message, from, true);
       }

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -12,6 +12,7 @@ import type { A2aPriority } from '../utils/a2aFormat';
 import { setExecuteApprovalResolver } from '../utils/executeApproval';
 import { terminalRegistry } from './useTerminal';
 import { searchInBuffer, type SearchableBuffer } from '../utils/searchEngine';
+import { submitBracketedPasteToPty } from '../utils/ptyMessageDelivery';
 
 // ---------------------------------------------------------------------------
 // Pane tree utilities
@@ -85,27 +86,14 @@ function findLeafBySurfaceId(root: Pane, surfaceId: string): PaneLeaf | null {
 }
 
 // ---------------------------------------------------------------------------
-// PTY submit helper — paste text then press Enter after a short delay
-// so Claude Code (and similar TUI apps) process the paste before submit.
-//
-// Two-write split (paste then \r) instead of a single `text + '\r'` write:
-//   1. PSReadLine (PowerShell) buffers the body as a multi-line composition.
-//      An immediate trailing \r in the same write lands inside that
-//      composition and reads as line continuation — the prompt sits filled
-//      but never commits. A 100ms gap lets ConPTY drain the paste into
-//      PSReadLine's buffer before the commit arrives.
-//   2. Multi-line bodies need a second \r to close PSReadLine's
-//      continuation buffer. Single-line bodies get exactly one \r so TUI
-//      chat prompts (Claude Code, REPLs) don't see a stray empty-Enter
-//      follow-up that submits a blank message.
+// PTY submit helper — paste structured inter-agent messages through bracketed
+// paste before submitting, so receiver-controlled shells/readline prompts treat
+// the envelope as pasted data instead of executing embedded line breaks as
+// individual keystrokes.
 // ---------------------------------------------------------------------------
 
 function submitToPty(ptyId: string, text: string): void {
-  const isMultiLine = text.includes('\n');
-  window.electronAPI.pty.write(ptyId, text);
-  setTimeout(() => {
-    window.electronAPI.pty.write(ptyId, isMultiLine ? '\r\r' : '\r');
-  }, 100);
+  submitBracketedPasteToPty(ptyId, text);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/renderer/utils/__tests__/a2aFormat.security.test.ts
+++ b/src/renderer/utils/__tests__/a2aFormat.security.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { formatA2aMessage } from '../a2aFormat';
+import { formatMessage } from '../../company/messageTemplates';
+
+const ATTACK = 'hello\nprintf VULNERABLE\r\n\x1b[201~printf ESCAPED';
+
+describe('inter-agent PTY message formatting', () => {
+  it('neutralizes CR/LF and ESC in A2A message bodies before PTY delivery', () => {
+    const formatted = formatA2aMessage('sender\nspoof', 'target\tname', ATTACK);
+
+    expect(formatted).not.toContain('hello\nprintf VULNERABLE');
+    expect(formatted).not.toContain('\r');
+    expect(formatted).not.toContain('\x1b');
+    expect(formatted).toContain('hello␤printf VULNERABLE␤printf ESCAPED');
+    expect(formatted).toContain('From: sender spoof');
+    expect(formatted).toContain('To: target name');
+  });
+
+  it('neutralizes CR/LF and ESC in company message bodies before PTY delivery', () => {
+    const formatted = formatMessage('CEO\nspoof', 'agent\tname', ATTACK, 'high');
+
+    expect(formatted).not.toContain('hello\nprintf VULNERABLE');
+    expect(formatted).not.toContain('\r');
+    expect(formatted).not.toContain('\x1b');
+    expect(formatted).toContain('hello␤printf VULNERABLE␤printf ESCAPED');
+    expect(formatted).toContain('From: CEO spoof');
+    expect(formatted).toContain('To: agent name');
+  });
+});

--- a/src/renderer/utils/__tests__/ptyMessageDelivery.test.ts
+++ b/src/renderer/utils/__tests__/ptyMessageDelivery.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import { formatBracketedPastePayload, submitBracketedPasteToPty } from '../ptyMessageDelivery';
+
+describe('PTY message delivery', () => {
+  it('wraps inter-agent messages in bracketed paste and neutralizes ESC bytes', () => {
+    const payload = formatBracketedPastePayload('line 1\n\x1b[201~printf ESCAPED');
+
+    expect(payload).toBe('\x1b[200~line 1\n␛[201~printf ESCAPED\x1b[201~');
+  });
+
+  it('submits bracketed paste separately from Enter', () => {
+    vi.useFakeTimers();
+    const writes: Array<[string, string]> = [];
+
+    submitBracketedPasteToPty('pty-1', 'line 1\nline 2', (ptyId, data) => {
+      writes.push([ptyId, data]);
+    });
+
+    expect(writes).toEqual([['pty-1', '\x1b[200~line 1\nline 2\x1b[201~']]);
+    vi.advanceTimersByTime(100);
+    expect(writes).toEqual([
+      ['pty-1', '\x1b[200~line 1\nline 2\x1b[201~'],
+      ['pty-1', '\r\r'],
+    ]);
+    vi.useRealTimers();
+  });
+});

--- a/src/renderer/utils/a2aFormat.ts
+++ b/src/renderer/utils/a2aFormat.ts
@@ -2,12 +2,35 @@ import { sanitizePtyText } from '../../shared/types';
 
 export type A2aPriority = 'low' | 'normal' | 'high';
 
+/**
+ * Strip control characters from names/message content that will be
+ * embedded into PTY-bound text to prevent injection of extra commands.
+ *
+ * `sanitizePtyText` preserves CR/LF/TAB/ESC for ordinary terminal writes.
+ * Inter-agent envelopes are different: sender-controlled CR/LF can split the
+ * envelope into extra PTY input lines, and raw ESC can forge terminal control
+ * sequences or bracketed-paste boundaries. The envelope's own separators are
+ * added after these helpers run, so message structure remains intact.
+ */
+// eslint-disable-next-line no-control-regex
+const ESC_CSI_RE = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+// eslint-disable-next-line no-control-regex
+const ESC_OTHER_RE = /\x1b[@-_]/g;
+
+function stripEscapes(input: string): string {
+  return input.replace(ESC_CSI_RE, '').replace(ESC_OTHER_RE, '');
+}
+
 function safeName(name: string): string {
-  return sanitizePtyText(name).slice(0, 100);
+  return stripEscapes(sanitizePtyText(name))
+    .replace(/[\r\n\t]/g, ' ')
+    .slice(0, 100);
 }
 
 function safeBody(message: string): string {
-  return sanitizePtyText(message);
+  return stripEscapes(sanitizePtyText(message))
+    .replace(/\r/g, '')
+    .replace(/\n/g, '\u2424');
 }
 
 /**

--- a/src/renderer/utils/ptyMessageDelivery.ts
+++ b/src/renderer/utils/ptyMessageDelivery.ts
@@ -1,0 +1,30 @@
+/**
+ * Helpers for delivering structured inter-agent messages to PTYs.
+ *
+ * A2A/company notifications are not typed by the local user; they can include
+ * sender-controlled text and are delivered across workspace boundaries. Always
+ * bracket them as terminal paste data so embedded line breaks are inserted into
+ * paste-aware prompts instead of being interpreted as individual keystrokes.
+ */
+
+import {
+  formatBracketedPastePayload,
+  isMultilinePtyPayload,
+  sanitizeBracketedPastePayload,
+} from '../../shared/ptyMessageDelivery';
+
+export { formatBracketedPastePayload, sanitizeBracketedPastePayload };
+
+const DEFAULT_SUBMIT_DELAY_MS = 100;
+
+export function submitBracketedPasteToPty(
+  ptyId: string,
+  text: string,
+  write: (ptyId: string, data: string) => void = window.electronAPI.pty.write,
+): void {
+  const isMultiLine = isMultilinePtyPayload(text);
+  write(ptyId, formatBracketedPastePayload(text));
+  setTimeout(() => {
+    write(ptyId, isMultiLine ? '\r\r' : '\r');
+  }, DEFAULT_SUBMIT_DELAY_MS);
+}

--- a/src/shared/ptyMessageDelivery.ts
+++ b/src/shared/ptyMessageDelivery.ts
@@ -1,0 +1,22 @@
+/** Utilities for safe PTY delivery of structured inter-agent messages. */
+
+const BRACKETED_PASTE_START = '\x1b[200~';
+const BRACKETED_PASTE_END = '\x1b[201~';
+const VISIBLE_ESCAPE = '␛';
+
+/**
+ * Escape raw ESC bytes before wrapping a bracketed paste payload. Otherwise a
+ * malicious body could include ESC [ 201 ~ to close the bracketed paste early.
+ */
+export function sanitizeBracketedPastePayload(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1b/g, VISIBLE_ESCAPE);
+}
+
+export function formatBracketedPastePayload(text: string): string {
+  return `${BRACKETED_PASTE_START}${sanitizeBracketedPastePayload(text)}${BRACKETED_PASTE_END}`;
+}
+
+export function isMultilinePtyPayload(text: string): boolean {
+  return text.includes('\n') || text.includes('\r');
+}


### PR DESCRIPTION
### Motivation
- Prevent A2A/company messages from being interpreted as keystrokes in peer PTYs which allowed sender-controlled CR/LF/ESC bytes to execute commands in another workspace's terminal. 
- Restore the previous safety model (bracketed paste + delayed Enter) for any non-user-originated PTY delivery so paste-aware shells/readline treat the envelope as pasted data rather than individual typed lines. 

### Description
- Add a small shared delivery helper `src/shared/ptyMessageDelivery.ts` and a renderer wrapper `src/renderer/utils/ptyMessageDelivery.ts` that produce a bracketed-paste payload and neutralize raw ESC bytes, and submit Enter separately via `submitBracketedPasteToPty` instead of `text + '\r'`.
- Harden A2A/company envelope formatting by neutralizing CR/LF/TAB/ESC before assembly in `src/renderer/utils/a2aFormat.ts` and `src/renderer/company/messageTemplates.ts` (use `stripEscapes` + replace newline with visible symbol U+2424 where appropriate).
- Replace direct `window.electronAPI.pty.write(..., formatted + '\r')` or `submitToPty` raw writes with the bracketed-paste helper in renderer and company handlers, message queues, and RPC delivery paths (`useRpcBridge`, company RPC handlers, and both renderer/core `MessageQueue` implementations).
- Add unit tests to assert envelope sanitization and bracketed-paste submission behavior (`src/renderer/utils/__tests__/a2aFormat.security.test.ts` and `src/renderer/utils/__tests__/ptyMessageDelivery.test.ts`).

### Testing
- Ran the focused unit tests with `npx vitest run src/renderer/utils/__tests__/a2aFormat.security.test.ts src/renderer/utils/__tests__/ptyMessageDelivery.test.ts --reporter verbose` and all tests passed (4 tests total).
- Performed type-checking with `npx tsc --noEmit`, which completed successfully.
- Ran `npx eslint --ext .ts,.tsx` on the changed files which exited successfully and reported only pre-existing warnings in unrelated modules (`useRpcBridge.ts` / `companyRpcHandlers.ts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a227bfc2c5c83208dd3f64741c0bfa0)