### PR TITLE
fix: gate CDP port disclosure

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,7 +23,7 @@ import { registerMetaRpc } from './pipe/handlers/meta.rpc';
 import { registerSystemRpc } from './pipe/handlers/system.rpc';
 import { registerHooksRpc } from './pipe/handlers/hooks.rpc';
 import { UsagePoller } from './claude/UsagePoller';
-import { IPC } from '../shared/constants';
+import { getCdpAccessTokenPath, IPC } from '../shared/constants';
 import { HookSignalRouter } from './hooks/HookSignalRouter';
 import { SignalLatencyMeter } from './hooks/SignalLatencyMeter';
 import { registerBrowserRpc } from './pipe/handlers/browser.rpc';
@@ -55,12 +55,23 @@ import { collectLegacyMetadata } from './metadata/legacyMigration';
 import { sessionManager, registerSessionHandlers } from './ipc/handlers/session.handler';
 import { eventBus } from './events/EventBus';
 import { initLogSink, logLine } from './util/logSink';
+import { secureWriteTokenFile } from '../shared/security';
 
 // Force English for Chromium internal messages to avoid encoding corruption
 // on non-ASCII locales (e.g. Korean Windows where cp949 garbles console output).
 app.commandLine.appendSwitch('lang', 'en-US');
 
 // CDP (Chrome DevTools Protocol) remote debugging
+// Separate one-process token that gates disclosure of the randomized raw CDP
+// port. The ordinary RPC auth token is intentionally insufficient to retrieve
+// the port from browser.cdp.info.
+const cdpAccessToken = crypto.randomUUID();
+try {
+  secureWriteTokenFile(getCdpAccessTokenPath(), cdpAccessToken);
+} catch (err) {
+  console.warn('[WinMux] Failed to persist CDP access token:', err);
+}
+
 let cdpPort = 0;
 if (process.env.WMUX_DISABLE_CDP !== 'true') {
   // Randomize port within range to prevent predictable scanning
@@ -391,7 +402,7 @@ registerInputRpc(rpcRouter, ptyManager, () => mainWindow, () => daemonClient);
 registerNotifyRpc(rpcRouter, () => mainWindow);
 registerMetaRpc(rpcRouter, () => mainWindow);
 registerSystemRpc(rpcRouter);
-registerBrowserRpc(rpcRouter, () => mainWindow, webviewCdpManager);
+registerBrowserRpc(rpcRouter, () => mainWindow, webviewCdpManager, { cdpAccessToken });
 registerA2aRpc(rpcRouter, () => mainWindow, claudeWorker);
 registerCompanyRpc(rpcRouter, () => mainWindow);
 registerEventsRpc(rpcRouter);

--- a/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
@@ -42,7 +42,10 @@ describe('registerBrowserRpc', () => {
     sendToRendererMock.mockResolvedValue({ ok: true });
   });
 
-  function register(getWindow: () => BrowserWindow | null = () => null): RpcRouter {
+  function register(
+    getWindow: () => BrowserWindow | null = () => null,
+    cdpAccessToken?: string,
+  ): RpcRouter {
     const router = new RpcRouter();
     const webviewCdpManager = {
       getTarget: vi.fn(() => ({ surfaceId: 'surface-1', webContentsId: 42, targetId: 'target-1', wsUrl: 'ws://127.0.0.1/devtools/page/target-1' })),
@@ -51,7 +54,7 @@ describe('registerBrowserRpc', () => {
       waitForTarget: vi.fn(),
     };
 
-    registerBrowserRpc(router, getWindow, webviewCdpManager as never);
+    registerBrowserRpc(router, getWindow, webviewCdpManager as never, { cdpAccessToken });
     return router;
   }
 
@@ -103,9 +106,32 @@ describe('registerBrowserRpc', () => {
     if (response.ok) {
       // No window (getWindow → null): shellUrl is omitted, not null.
       expect(response.result).toEqual({
-        cdpPort: 18800,
         targets: [{ surfaceId: 'surface-1', targetId: 'target-1' }],
       });
+    }
+  });
+
+  it('browser.cdp.info returns cdpPort only with the internal CDP access token', async () => {
+    const router = register(undefined, 'internal-cdp-token');
+
+    const publicResponse = await router.dispatch({
+      id: '3a-public',
+      method: 'browser.cdp.info',
+      params: {},
+    });
+    const internalResponse = await router.dispatch({
+      id: '3a-internal',
+      method: 'browser.cdp.info',
+      params: { cdpAccessToken: 'internal-cdp-token' },
+    });
+
+    expect(publicResponse.ok).toBe(true);
+    expect(internalResponse.ok).toBe(true);
+    if (publicResponse.ok) {
+      expect(publicResponse.result).not.toHaveProperty('cdpPort');
+    }
+    if (internalResponse.ok) {
+      expect(internalResponse.result).toMatchObject({ cdpPort: 18800 });
     }
   });
 
@@ -123,9 +149,9 @@ describe('registerBrowserRpc', () => {
     expect(response.ok).toBe(true);
     if (response.ok) {
       expect(response.result).toMatchObject({
-        cdpPort: 18800,
         shellUrl: 'file:///x/.vite/renderer/main_window/index.html',
       });
+      expect(response.result).not.toHaveProperty('cdpPort');
     }
   });
 

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -10,6 +10,10 @@ import { validateResolvedNavigationUrl } from '../../security/navigationPolicy';
 
 type GetWindow = () => BrowserWindow | null;
 
+interface BrowserRpcOptions {
+  cdpAccessToken?: string;
+}
+
 async function validateUrl(url: string, method: string): Promise<void> {
   const result = await validateResolvedNavigationUrl(url);
   if (!result.valid) {
@@ -28,7 +32,12 @@ const profileManager = new ProfileManager();
 const portAllocator = new PortAllocator();
 const humanBehavior = new HumanBehavior();
 
-export function registerBrowserRpc(router: RpcRouter, getWindow: GetWindow, webviewCdpManager: WebviewCdpManager): void {
+export function registerBrowserRpc(
+  router: RpcRouter,
+  getWindow: GetWindow,
+  webviewCdpManager: WebviewCdpManager,
+  options: BrowserRpcOptions = {},
+): void {
   const getActivePartition = (): string => profileManager.getActiveProfile().partition;
 
   /**
@@ -237,10 +246,16 @@ export function registerBrowserRpc(router: RpcRouter, getWindow: GetWindow, webv
 
   /**
    * browser.cdp.info
-   * Returns the CDP port and minimal target metadata required for Playwright attachment.
+   * Returns minimal target metadata required for Playwright attachment.
+   *
+   * The randomized raw CDP port is only included when the bundled MCP
+   * Playwright engine presents the separate CDP access token. Generic RPC
+   * callers authenticated with the normal wmux RPC token can still discover
+   * mediated browser target metadata, but cannot use this method to discover
+   * the unauthenticated Chromium debugging endpoint.
    * params: none
    */
-  router.register('browser.cdp.info', async () => {
+  router.register('browser.cdp.info', async (params) => {
     let targets = webviewCdpManager.listTargets();
 
     // If no targets yet, wait briefly for in-flight registrations to complete.
@@ -250,7 +265,12 @@ export function registerBrowserRpc(router: RpcRouter, getWindow: GetWindow, webv
       targets = webviewCdpManager.listTargets();
     }
 
-    const cdpPort: number = webviewCdpManager.getCdpPort();
+    const requestedCdpAccessToken =
+      typeof params['cdpAccessToken'] === 'string' ? params['cdpAccessToken'] : undefined;
+    const includeCdpPort =
+      typeof options.cdpAccessToken === 'string' &&
+      options.cdpAccessToken.length > 0 &&
+      requestedCdpAccessToken === options.cdpAccessToken;
 
     // Expose the actual runtime URL of the main-window webContents (the app
     // shell) so the Playwright engine can recognize the shell by exact-match
@@ -265,7 +285,7 @@ export function registerBrowserRpc(router: RpcRouter, getWindow: GetWindow, webv
     } catch { /* window destroyed — omit shellUrl */ }
 
     return {
-      cdpPort,
+      ...(includeCdpPort && { cdpPort: webviewCdpManager.getCdpPort() }),
       ...(shellUrl && { shellUrl }),
       targets: targets.map((t) => ({
         surfaceId: t.surfaceId,

--- a/src/mcp/playwright/PlaywrightEngine.ts
+++ b/src/mcp/playwright/PlaywrightEngine.ts
@@ -1,5 +1,5 @@
 import { chromium, type Browser, type BrowserContext, type Page, type CDPSession } from 'playwright-core';
-import { sendRpc } from '../wmux-client';
+import { readCdpAccessToken, sendRpc } from '../wmux-client';
 import { isMac } from '../../shared/platform';
 import { formatMacosError, MACOS_ERRORS } from '../../shared/errors/macos';
 
@@ -9,7 +9,7 @@ interface CdpTargetInfo {
 }
 
 interface CdpInfoResponse {
-  cdpPort: number;
+  cdpPort?: number;
   /**
    * The actual runtime URL of the main-window webContents (the app shell),
    * as reported by the main process. Optional: absent on older mains or when
@@ -28,6 +28,22 @@ const PAGE_FIND_DELAY_MS = 500;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function requestCdpInfo(options: { includePort?: boolean } = {}): Promise<CdpInfoResponse> {
+  const params: Record<string, unknown> = {};
+  if (options.includePort) {
+    const cdpAccessToken = readCdpAccessToken();
+    if (cdpAccessToken) params.cdpAccessToken = cdpAccessToken;
+  }
+  return (await sendRpc('browser.cdp.info', params)) as CdpInfoResponse;
+}
+
+function requireCdpPort(info: CdpInfoResponse): number {
+  if (typeof info.cdpPort !== 'number') {
+    throw new Error('browser.cdp.info did not return a CDP port for the Playwright engine');
+  }
+  return info.cdpPort;
 }
 
 /**
@@ -214,9 +230,9 @@ export class PlaywrightEngine {
     let lastError: unknown = null;
     for (let attempt = 1; attempt <= MAX_CONNECT_RETRIES; attempt++) {
       try {
-        const info = (await sendRpc('browser.cdp.info')) as CdpInfoResponse;
+        const info = await requestCdpInfo({ includePort: true });
         this.cacheShellUrl(info);
-        await this.connect(info.cdpPort);
+        await this.connect(requireCdpPort(info));
         return;
       } catch (err) {
         lastError = err;
@@ -405,7 +421,7 @@ export class PlaywrightEngine {
         console.error(`[PlaywrightEngine] CDP targets: ${targetInfos.map(t => `${t.type}:${t.url.substring(0, 40)}`).join(', ')}`);
 
         // Get registered wmux targets for matching
-        const info = (await sendRpc('browser.cdp.info')) as CdpInfoResponse;
+        const info = await requestCdpInfo();
         this.cacheShellUrl(info);
         const wmuxTarget = surfaceId
           ? info.targets.find((t) => t.surfaceId === surfaceId)
@@ -485,7 +501,7 @@ export class PlaywrightEngine {
       console.error(`[PlaywrightEngine] /json targets: ${targets.map(t => `${t.type}:${t.url.substring(0, 40)}`).join(', ')}`);
 
       // Get registered wmux targets
-      const info = (await sendRpc('browser.cdp.info')) as CdpInfoResponse;
+      const info = await requestCdpInfo();
       this.cacheShellUrl(info);
       const wmuxTarget = surfaceId
         ? info.targets.find((t) => t.surfaceId === surfaceId)

--- a/src/mcp/wmux-client.ts
+++ b/src/mcp/wmux-client.ts
@@ -2,7 +2,7 @@ import * as net from 'net';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
 import type { RpcMethod, RpcResponse } from '../shared/rpc';
-import { getPipeName, getAuthTokenPath, getTcpPortPath } from '../shared/constants';
+import { getPipeName, getAuthTokenPath, getTcpPortPath, getCdpAccessTokenPath } from '../shared/constants';
 
 const TIMEOUT_MS = 10000;
 const RETRY_COUNT = 3;
@@ -49,6 +49,15 @@ function readAuthToken(): string | undefined {
   // Env var fallback (when running inside wmux terminal)
   if (process.env.WMUX_AUTH_TOKEN) return process.env.WMUX_AUTH_TOKEN;
   return undefined;
+}
+
+export function readCdpAccessToken(): string | undefined {
+  try {
+    const token = fs.readFileSync(getCdpAccessTokenPath(), 'utf8').trim();
+    return token || undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function readTcpPort(): number | undefined {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -152,6 +152,16 @@ export function getAuthTokenPath(): string {
   return `${home}/.wmux-auth-token`;
 }
 
+// CDP access token path — written by wmux main process, read by the bundled
+// MCP Playwright engine when it needs the raw Chromium debugging port. This is
+// deliberately separate from the general RPC auth token so ordinary
+// token-bearing RPC clients cannot discover the randomized CDP port through
+// browser.cdp.info.
+export function getCdpAccessTokenPath(): string {
+  const home = process.env.USERPROFILE || process.env.HOME || '';
+  return `${home}/.wmux-cdp-access-token`;
+}
+
 // PID-to-workspace mapping directory — written by PTYManager, read by MCP server
 // to resolve workspace identity when env vars don't propagate through Claude Code
 export function getPidMapDir(): string {


### PR DESCRIPTION
### Motivation

- Prevent unauthorised disclosure of the randomized Chromium DevTools (CDP) port via the `browser.cdp.info` RPC while preserving Playwright's ability to connect for MCP automation.

### Description

- Add a separate per-process CDP access token and on-disk path (`getCdpAccessTokenPath`) and persist it securely from the main process so ordinary RPC clients cannot use the normal auth token to discover the raw CDP port.  
- Change the `browser.cdp.info` handler to omit `cdpPort` by default and only include it when the caller supplies the internal CDP access token that matches the one passed to `registerBrowserRpc`.  
- Teach the bundled MCP-side client to read the CDP access token (`readCdpAccessToken`) and update `PlaywrightEngine` to request `browser.cdp.info` with the token only when it needs the raw port, while continuing to use non-port metadata for normal discovery.  
- Update unit tests (`browser.rpc.test.ts`) to assert public responses omit `cdpPort` and that token-bearing internal requests still receive it.

### Testing

- Ran the test suite with `npm test -- --runInBand` and all tests passed (`2172` tests total).  
- Built MCP and daemon with `npm run build:mcp && npm run build:daemon` and both builds succeeded.  
- Type-check verified with `npx tsc --noEmit` (no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2289e63024832095eb096458f98303)