### PR TITLE
fix: avoid daemon token disclosure during discovery

### DIFF
--- a/src/daemon/DaemonPipeServer.ts
+++ b/src/daemon/DaemonPipeServer.ts
@@ -422,6 +422,11 @@ export class DaemonPipeServer {
       return;
     }
 
+    if (request?.method === 'daemon.identify') {
+      this.handleIdentify(socket, request);
+      return;
+    }
+
     // Authenticate before rate limit check (prevents DoS via rate exhaustion)
     // Use timing-safe comparison to prevent timing attacks
     const tokenBuf = Buffer.from(request.token || '');
@@ -473,6 +478,31 @@ export class DaemonPipeServer {
           socket.write(res + '\n');
         }
       });
+  }
+
+
+  private handleIdentify(socket: net.Socket, request: RpcRequest): void {
+    const params = request.params ?? {};
+    const clientNonce = typeof params.clientNonce === 'string' ? params.clientNonce : '';
+    if (typeof request.id !== 'string' || clientNonce.length < 16 || clientNonce.length > 256) {
+      socket.write(JSON.stringify({ id: request.id || '', ok: false, error: 'Invalid identify request' }) + '\n');
+      return;
+    }
+
+    const proof = crypto
+      .createHmac('sha256', this.authToken)
+      .update(clientNonce)
+      .digest('hex');
+    socket.write(JSON.stringify({
+      id: request.id,
+      ok: true,
+      result: {
+        status: 'ok',
+        pid: process.pid,
+        proof,
+        algorithm: 'hmac-sha256',
+      },
+    }) + '\n');
   }
 
   private async dispatch(request: RpcRequest): Promise<RpcResponse> {

--- a/src/daemon/__tests__/DaemonPipeServer.test.ts
+++ b/src/daemon/__tests__/DaemonPipeServer.test.ts
@@ -142,6 +142,31 @@ describe('DaemonPipeServer', () => {
     expect(res.error).toBe('unauthorized');
   });
 
+  it('should prove daemon identity without requiring or echoing the auth token', async () => {
+    await server.start();
+    const clientNonce = crypto.randomBytes(32).toString('hex');
+
+    const res = await sendRpc(pipeName, {
+      id: 'identify-1',
+      method: 'daemon.identify',
+      params: { clientNonce },
+    });
+
+    const expectedProof = crypto
+      .createHmac('sha256', 'test-token-123')
+      .update(clientNonce)
+      .digest('hex');
+    expect(res.ok).toBe(true);
+    expect(res.id).toBe('identify-1');
+    expect(res.result).toMatchObject({
+      status: 'ok',
+      pid: process.pid,
+      proof: expectedProof,
+      algorithm: 'hmac-sha256',
+    });
+    expect(JSON.stringify(res)).not.toContain('test-token-123');
+  });
+
   it('should return error for unknown method', async () => {
     await server.start();
 

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -236,16 +236,31 @@ interface DaemonPingResult {
   eventLoopLagMs?: number;
 }
 
+interface DaemonIdentifyResult extends DaemonPingResult {
+  proof?: string;
+  algorithm?: string;
+}
+
+function verifyDaemonProof(token: string, clientNonce: string, proof: unknown): boolean {
+  if (typeof proof !== 'string') return false;
+  const expected = crypto.createHmac('sha256', token).update(clientNonce).digest('hex');
+  const proofBuf = Buffer.from(proof, 'hex');
+  const expectedBuf = Buffer.from(expected, 'hex');
+  return proofBuf.length === expectedBuf.length && crypto.timingSafeEqual(proofBuf, expectedBuf);
+}
+
 /**
- * Send `daemon.ping` and return the daemon's reported result (which carries
- * `pid` since the Step ③ follow-up), or `null` on timeout / error / refusal.
- * `pingDaemon` is the boolean wrapper most callers use; the reconnect path
- * uses the result's `pid` to restore daemon.pid.
+ * Prove daemon identity without disclosing the auth token to the endpoint. The
+ * daemon returns an HMAC over a fresh launcher nonce; pipe squatters that do
+ * not already know the token cannot forge it, so startup discovery no longer
+ * leaks the bearer token to a predictable/stale pipe.
  */
 function daemonPing(pipeName: string, token: string, timeoutMs = 3000): Promise<DaemonPingResult | null> {
   return new Promise((resolve) => {
     const socket = net.connect(pipeName);
     let settled = false;
+    const requestId = crypto.randomUUID();
+    const clientNonce = crypto.randomBytes(32).toString('hex');
     const finish = (value: DaemonPingResult | null) => {
       if (settled) return;
       settled = true;
@@ -258,8 +273,11 @@ function daemonPing(pipeName: string, token: string, timeoutMs = 3000): Promise<
     timer.unref();
 
     socket.on('connect', () => {
-      const id = crypto.randomUUID();
-      socket.write(JSON.stringify({ id, method: 'daemon.ping', params: {}, token }) + '\n');
+      socket.write(JSON.stringify({
+        id: requestId,
+        method: 'daemon.identify',
+        params: { clientNonce },
+      }) + '\n');
     });
 
     let buffer = '';
@@ -271,8 +289,21 @@ function daemonPing(pipeName: string, token: string, timeoutMs = 3000): Promise<
         if (!line.trim()) continue;
         try {
           const resp = JSON.parse(line.trim());
-          if (resp.ok || (resp.result && resp.result.status === 'ok')) {
-            finish((resp.result as DaemonPingResult) ?? { status: 'ok' });
+          const result = resp.result as DaemonIdentifyResult | undefined;
+          if (
+            resp.id === requestId
+            && resp.ok === true
+            && result?.status === 'ok'
+            && result.algorithm === 'hmac-sha256'
+            && verifyDaemonProof(token, clientNonce, result.proof)
+          ) {
+            finish({
+              status: result.status,
+              pid: result.pid,
+              uptime: result.uptime,
+              sessions: result.sessions,
+              eventLoopLagMs: result.eventLoopLagMs,
+            });
             return;
           }
         } catch {}
@@ -467,9 +498,9 @@ export async function ensureDaemon(): Promise<DaemonInfo> {
   //    confirmed-dead PID skips straight to spawn over a possibly-live daemon.
   if (existingPid && checkProcessLiveness(existingPid) !== 'dead') {
     const token = readDaemonAuthToken();
-    const pipeName = readPipeNameFromFile(wmuxDir) || getDaemonPipeName();
+    const pipeName = readPipeNameFromFile(wmuxDir);
 
-    if (token) {
+    if (token && pipeName) {
       // Two-shot ping: a freshly spawned daemon can briefly miss the ping
       // window while its event loop is busy on startup (recovery loop on
       // big sessions.json, Defender realtime scan on cold ASAR, ConPTY
@@ -618,7 +649,7 @@ export async function ensureDaemon(): Promise<DaemonInfo> {
             //     so escalated re-ping (→ reuse) is the only thing that
             //     actually preserves kept sessions. A confirmed-wedged daemon
             //     leaves SIGKILL+respawn as the single-daemon recovery.
-            if (token) {
+            if (token && pipeName) {
               const recovered = await tryEscalatedReping(
                 (timeoutMs) => pingDaemon(pipeName, token, timeoutMs),
                 [500, 1000],
@@ -684,47 +715,25 @@ export async function ensureDaemon(): Promise<DaemonInfo> {
     pid = await spawnDaemon();
   } catch (err) {
     if ((err as NodeJS.ErrnoException | undefined)?.code === 'EDAEMON_ALREADY_RUNNING') {
-      // The daemon we spawned yielded to a live daemon already owning the
-      // canonical pipe (split-brain avoided — no second live daemon, no `-N`
-      // pipe). Reconnect to the existing daemon instead of looping into another
-      // spawn. The pipe file was cleaned with the stale files above, so resolve
-      // the canonical name deterministically.
-      const canonicalPipe = getDaemonPipeName();
-      const reconnectToken = readDaemonAuthToken();
-      if (reconnectToken) {
-        const pong = await daemonPing(canonicalPipe, reconnectToken);
-        if (pong) {
-          // Restore daemon.pid (the stale-file cleanup above deleted it) to the
-          // live daemon's reported pid, so the NEXT launch hits the cheap reuse
-          // branch (existingPid → ping → reuse) instead of repeating this
-          // spawn-yield-reconnect dance every launch.
-          const livePid = typeof pong.pid === 'number' && pong.pid > 0 ? pong.pid : (existingPid ?? 0);
-          if (livePid > 0) {
-            try {
-              fs.writeFileSync(pidFile, String(livePid), { encoding: 'utf-8', mode: 0o600 });
-            } catch { /* best effort — reconnect still succeeds without it */ }
-          }
-          console.log(
-            '[launcher] spawned daemon yielded to a live daemon — reconnected to the existing daemon',
-          );
-          return {
-            pid: livePid,
-            authToken: reconnectToken,
-            pipeName: canonicalPipe,
-            spawned: false,
-          };
-        }
-      }
+      // A live owner on the predictable canonical pipe may be either a real
+      // daemon or a pipe squatter. Do not send the bearer token to that name
+      // during recovery; fall back to local PTY instead of risking disclosure.
+      throw new Error(
+        '[launcher] canonical daemon pipe is already owned but no trusted daemon-pipe file is available; refusing token-bearing reconnect',
+      );
     }
     throw err;
   }
 
   // Read connection info after spawn
   const token = readDaemonAuthToken();
-  const pipeName = readPipeNameFromFile(wmuxDir) || getDaemonPipeName();
+  const pipeName = readPipeNameFromFile(wmuxDir);
 
   if (!token) {
     throw new Error('Daemon spawned but auth token not found');
+  }
+  if (!pipeName) {
+    throw new Error('Daemon spawned but trusted pipe name not found');
   }
 
   return { pid, authToken: token, pipeName, spawned: true };

--- a/src/main/mcp/methodCapabilityMap.ts
+++ b/src/main/mcp/methodCapabilityMap.ts
@@ -253,6 +253,7 @@ export const METHOD_CAPABILITY: Record<RpcMethod, RequiredCapability> = {
   'daemon.listSessions':     { capability: 'wmux.internal' },
   'daemon.readPromptEvents': { capability: 'wmux.internal' },
   'daemon.ping':             { capability: 'wmux.internal' },
+  'daemon.identify':         { capability: 'wmux.internal' },
   'daemon.shutdown':         { capability: 'wmux.internal' },
   'daemon.compact':          { capability: 'wmux.internal' },
 

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -130,6 +130,7 @@ export type RpcMethod =
   | 'daemon.listSessions'
   | 'daemon.readPromptEvents'
   | 'daemon.ping'
+  | 'daemon.identify'
   | 'daemon.shutdown'
   | 'daemon.compact'
   | 'a2a.resolve.identity'
@@ -223,6 +224,7 @@ export const ALL_RPC_METHODS = [
   'daemon.listSessions',
   'daemon.readPromptEvents',
   'daemon.ping',
+  'daemon.identify',
   'daemon.shutdown',
   'daemon.compact',
   'a2a.resolve.identity',


### PR DESCRIPTION
### Motivation
- Prevent the launcher from disclosing the daemon bearer token to an arbitrary/local endpoint during startup discovery and reuse probes. 
- Provide a way for the launcher to verify the daemon identity without sending the token to a potentially attacker-controlled pipe.

### Description
- Add an unauthenticated `daemon.identify` RPC handler in `DaemonPipeServer` that returns an HMAC proof (over a client nonce) instead of echoing the auth token. 
- Change launcher probing in `src/main/daemon/launcher.ts` to send `daemon.identify` with a fresh `clientNonce`, verify the response `id`, `status`, `algorithm`, and HMAC proof with `crypto.timingSafeEqual`, and only accept endpoints that present a valid proof. 
- Stop using the predictable default pipe as a fallback when there is no trusted `daemon-pipe` file, and refuse the `EDAEMON_ALREADY_RUNNING` reconnect path when a trusted pipe name is not available to avoid token-bearing reconnects. 
- Wire `daemon.identify` into RPC metadata (`src/shared/rpc.ts` and `methodCapabilityMap`) and add a unit test proving the identity endpoint returns a proof without exposing the token (`src/daemon/__tests__/DaemonPipeServer.test.ts`).

### Testing
- Ran `npm run build:daemon` and the daemon bundle built successfully. (passed)
- Ran targeted unit tests `npx vitest run src/daemon/__tests__/DaemonPipeServer.test.ts src/main/daemon/__tests__/launcher.reping.test.ts src/main/mcp/__tests__/methodCapabilityMap.test.ts` and all tests passed. (passed)
- Ran `npx vitest run src/main/mcp/__tests__/phase-2-2-dynamic.test.ts` and it passed. (passed)
- Ran the full parallel suite `npm run test:parallel` and the full test suite passed (`171` test files, `2172` tests). (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a228e08d7608320a10e844d303e7fda)