### PR TITLE
Disable packaged CDP by default and bind debug to loopback

### DIFF
--- a/src/main/browser-session/__tests__/cdpConfig.test.ts
+++ b/src/main/browser-session/__tests__/cdpConfig.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCdpRemoteDebuggingConfig } from '../cdpConfig';
+
+describe('resolveCdpRemoteDebuggingConfig', () => {
+  it('disables CDP by default in packaged builds', () => {
+    expect(resolveCdpRemoteDebuggingConfig({ env: {}, isPackaged: true })).toMatchObject({
+      enabled: false,
+      port: 0,
+    });
+  });
+
+  it('allows an explicit CDP opt-in for packaged builds on a randomized loopback port', () => {
+    expect(
+      resolveCdpRemoteDebuggingConfig({
+        env: { WMUX_ENABLE_CDP: 'true' },
+        isPackaged: true,
+        randomInt: () => 42,
+      }),
+    ).toEqual({ enabled: true, port: 18842 });
+  });
+
+  it('honors an explicit CDP port only after CDP is enabled', () => {
+    expect(
+      resolveCdpRemoteDebuggingConfig({
+        env: { WMUX_ENABLE_CDP: 'true', WMUX_CDP_PORT: '18850' },
+        isPackaged: true,
+      }),
+    ).toEqual({ enabled: true, port: 18850 });
+  });
+
+  it('lets WMUX_DISABLE_CDP override all other settings', () => {
+    expect(
+      resolveCdpRemoteDebuggingConfig({
+        env: { WMUX_DISABLE_CDP: 'true', WMUX_ENABLE_CDP: 'true', WMUX_CDP_PORT: '18850' },
+        isPackaged: true,
+      }),
+    ).toMatchObject({ enabled: false, port: 0 });
+  });
+
+  it('keeps development builds debuggable without exposing a fixed port', () => {
+    expect(
+      resolveCdpRemoteDebuggingConfig({
+        env: {},
+        isPackaged: false,
+        randomInt: () => 7,
+      }),
+    ).toEqual({ enabled: true, port: 18807 });
+  });
+
+  it('rejects out-of-range explicit ports', () => {
+    expect(() =>
+      resolveCdpRemoteDebuggingConfig({
+        env: { WMUX_ENABLE_CDP: 'true', WMUX_CDP_PORT: '18799' },
+        isPackaged: true,
+      }),
+    ).toThrow('WMUX_CDP_PORT must be an integer in the range 18800-18899');
+  });
+});

--- a/src/main/browser-session/cdpConfig.ts
+++ b/src/main/browser-session/cdpConfig.ts
@@ -1,0 +1,53 @@
+import * as crypto from 'crypto';
+
+export const CDP_PORT_MIN = 18800;
+export const CDP_PORT_MAX = 18899;
+
+export interface CdpRemoteDebuggingConfig {
+  enabled: boolean;
+  port: number;
+  reason?: string;
+}
+
+interface ResolveCdpRemoteDebuggingOptions {
+  env?: NodeJS.ProcessEnv;
+  isPackaged: boolean;
+  randomInt?: (max: number) => number;
+}
+
+function parseExplicitPort(value: string | undefined): number | null {
+  if (!value) return null;
+
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < CDP_PORT_MIN || port > CDP_PORT_MAX) {
+    throw new Error(
+      `WMUX_CDP_PORT must be an integer in the range ${CDP_PORT_MIN}-${CDP_PORT_MAX}`,
+    );
+  }
+
+  return port;
+}
+
+/**
+ * Resolve whether Electron's unauthenticated Chromium remote debugging endpoint
+ * should be exposed. Production builds require an explicit opt-in so arbitrary
+ * web content loaded in a wmux <webview> cannot rely on a default CDP listener
+ * to reach privileged renderer APIs.
+ */
+export function resolveCdpRemoteDebuggingConfig({
+  env = process.env,
+  isPackaged,
+  randomInt = crypto.randomInt,
+}: ResolveCdpRemoteDebuggingOptions): CdpRemoteDebuggingConfig {
+  if (env.WMUX_DISABLE_CDP === 'true') {
+    return { enabled: false, port: 0, reason: 'disabled by WMUX_DISABLE_CDP' };
+  }
+
+  if (isPackaged && env.WMUX_ENABLE_CDP !== 'true') {
+    return { enabled: false, port: 0, reason: 'disabled by default in packaged builds' };
+  }
+
+  const explicitPort = parseExplicitPort(env.WMUX_CDP_PORT);
+  const port = explicitPort ?? CDP_PORT_MIN + randomInt(CDP_PORT_MAX - CDP_PORT_MIN + 1);
+  return { enabled: true, port };
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,7 +5,6 @@ process.on('uncaughtException', (err) => {
   console.error('[Main] Uncaught exception:', err);
 });
 
-import * as crypto from 'crypto';
 import * as path from 'path';
 import { app, BrowserWindow, dialog, ipcMain, powerMonitor } from 'electron';
 import { createWindow, loadMainRenderer } from './window/createWindow';
@@ -40,6 +39,7 @@ import { ClaudeWorker } from './a2a/ClaudeWorker';
 import { AutoUpdater } from './updater/AutoUpdater';
 import { McpRegistrar } from './mcp/McpRegistrar';
 import { WebviewCdpManager } from './browser-session/WebviewCdpManager';
+import { resolveCdpRemoteDebuggingConfig } from './browser-session/cdpConfig';
 import { DaemonClient, getDaemonPipeName, readDaemonAuthToken } from './DaemonClient';
 import { raceDaemonShutdown } from './daemonShutdownRace';
 import { migrateScrollbackOnce } from './scrollback/legacyMigration';
@@ -60,15 +60,20 @@ import { initLogSink, logLine } from './util/logSink';
 // on non-ASCII locales (e.g. Korean Windows where cp949 garbles console output).
 app.commandLine.appendSwitch('lang', 'en-US');
 
-// CDP (Chrome DevTools Protocol) remote debugging
-let cdpPort = 0;
-if (process.env.WMUX_DISABLE_CDP !== 'true') {
-  // Randomize port within range to prevent predictable scanning
-  const basePort = 18800;
-  const range = 100;
-  cdpPort = basePort + crypto.randomInt(range);
+// CDP (Chrome DevTools Protocol) remote debugging. Packaged builds keep
+// Electron's unauthenticated debugging endpoint closed unless the operator
+// explicitly opts in for a debugging session.
+const cdpConfig = resolveCdpRemoteDebuggingConfig({
+  env: process.env,
+  isPackaged: app.isPackaged,
+});
+const cdpPort = cdpConfig.port;
+if (cdpConfig.enabled) {
+  app.commandLine.appendSwitch('remote-debugging-address', '127.0.0.1');
   app.commandLine.appendSwitch('remote-debugging-port', cdpPort.toString());
-  console.log(`[WinMux] CDP enabled on port ${cdpPort}`);
+  console.log(`[WinMux] CDP enabled on 127.0.0.1:${cdpPort}`);
+} else {
+  console.log(`[WinMux] CDP disabled (${cdpConfig.reason ?? 'not enabled'})`);
 }
 
 // Handle Squirrel installer events.


### PR DESCRIPTION
### Motivation
- Prevent exposure of an unauthenticated, predictable Chrome DevTools Protocol (CDP) endpoint in production builds that could be reached by untrusted webview content. 
- Require an explicit operator opt-in for enabling CDP in packaged apps to reduce the attack surface for remote `Runtime.evaluate` targeting privileged preload APIs. 
- Ensure any enabled CDP sessions are bound to loopback and use a randomized port (or validated explicit port) to make accidental exposure harder.

### Description
- Add a centralized resolver `src/main/browser-session/cdpConfig.ts` that decides whether CDP should be enabled, validates `WMUX_CDP_PORT`, supports `WMUX_DISABLE_CDP`, and requires `WMUX_ENABLE_CDP=true` to opt-in for packaged builds. 
- Update main process startup in `src/main/index.ts` to use the resolver and only append `remote-debugging-address`/`remote-debugging-port` when CDP is explicitly enabled, otherwise CDP remains disabled. 
- Bind enabled CDP sessions to `127.0.0.1` and select a randomized port within the configured range when no explicit port is provided. 
- Add unit tests in `src/main/browser-session/__tests__/cdpConfig.test.ts` covering default packaged behavior, explicit opt-in, explicit port handling, disable override, development randomization, and out-of-range port rejection.

### Testing
- Ran the new unit tests with `npm run test:parallel -- src/main/browser-session/__tests__/cdpConfig.test.ts` and all tests passed. 
- Ran type-checking with `npx tsc -p tsconfig.json --noEmit` and it completed successfully. 
- Linted the new files with `npx eslint src/main/browser-session/cdpConfig.ts src/main/browser-session/__tests__/cdpConfig.test.ts` and no new lint errors were introduced. 
- Running the repository-wide `npm run lint` surfaced pre-existing lint errors unrelated to this change and did not block this targeted fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a228d077dac8320b522aa86c9f401d2)