### PR TITLE
fix(mcp): stop ghost workspace identity from stale pid-map entries

### DIFF
--- a/scripts/helpers/mini-pipe-server.mjs
+++ b/scripts/helpers/mini-pipe-server.mjs
@@ -80,10 +80,21 @@ function getSimulatedWorkspaces() {
   }
 }
 
+// First-call-only mode: when WMUX_MINISERVER_RESOLVE_ONCE is set, the PID map
+// resolves on the FIRST a2a.resolve.identity call and returns empty afterward.
+// Models a workspace that resolved successfully once, then had its pid-map entry
+// vanish (pane closed / re-minted) — used to exercise the stale-cache fallback
+// gate (resolveWorkspaceId must not return a confirmed-dead cached id).
+let resolveCallCount = 0;
+
 function handleA2aResolveIdentity() {
   const dir = getPidMapDir();
   const owners = getSimulatedOwners();
   const mappings = {};
+  resolveCallCount += 1;
+  if (process.env.WMUX_MINISERVER_RESOLVE_ONCE && resolveCallCount > 1) {
+    return { mappings }; // empty on subsequent calls
+  }
   try {
     if (fs.existsSync(dir)) {
       for (const file of fs.readdirSync(dir)) {

--- a/scripts/helpers/mini-pipe-server.mjs
+++ b/scripts/helpers/mini-pipe-server.mjs
@@ -15,7 +15,15 @@
  *     workspace lookup (real handler: input.findOwnerWorkspace on the
  *     renderer) is simulated here via WMUX_MINISERVER_OWNERS, a JSON
  *     { <ptyId>: <workspaceId> } map. Legacy "ws-"-prefixed entries are
- *     passed through; ptyIds with no live owner are omitted.
+ *     DROPPED (file deleted) — not passed through — mirroring the fix that
+ *     stopped legacy debris from resurfacing as ghost workspaces. ptyIds with
+ *     no live owner are omitted but their files are left on disk (the read path
+ *     is non-destructive for current-format entries).
+ *
+ *   workspace.list
+ *     Returns the simulated live workspace array from WMUX_MINISERVER_WORKSPACES
+ *     (JSON array of { id }). Used by the probe to gate the env hint: a hint
+ *     absent from this list is a confirmed ghost and must be dropped.
  *
  *   mcp.claimWorkspace
  *     Returns an explicit "no window" error to mirror what the real
@@ -24,9 +32,11 @@
  *     §6.1 does not silently fall through to substrate state.
  *
  * Inputs (env):
- *   WMUX_MINISERVER_PIPE   pipe / socket name to listen on
- *   WMUX_MINISERVER_TOKEN  expected auth token
- *   USERPROFILE / HOME     override for pid-map directory location
+ *   WMUX_MINISERVER_PIPE        pipe / socket name to listen on
+ *   WMUX_MINISERVER_TOKEN       expected auth token
+ *   WMUX_MINISERVER_OWNERS      JSON { ptyId: workspaceId } live-owner table
+ *   WMUX_MINISERVER_WORKSPACES  JSON [{ id }] live workspace list
+ *   USERPROFILE / HOME          override for pid-map directory location
  *
  * Stdout: emits "READY" on a single line once listening, so the test
  * runner can synchronize without polling a pipe file.
@@ -60,6 +70,16 @@ function getSimulatedOwners() {
   }
 }
 
+function getSimulatedWorkspaces() {
+  // Simulates the renderer's workspace.list response (live workspace array).
+  try {
+    const parsed = JSON.parse(process.env.WMUX_MINISERVER_WORKSPACES || '[]');
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
 function handleA2aResolveIdentity() {
   const dir = getPidMapDir();
   const owners = getSimulatedOwners();
@@ -75,17 +95,24 @@ function handleA2aResolveIdentity() {
         }
         if (!value) continue;
         if (value.startsWith('ws-')) {
-          // Legacy PID → workspaceId entry: pass through.
-          mappings[file] = value;
+          // Legacy PID → workspaceId entry: DROP it (delete the file), mirroring
+          // src/main/pipe/handlers/a2a.rpc.ts. Passing it through is what let a
+          // re-minted/recycled legacy id resurface as a ghost workspace.
+          try { fs.unlinkSync(path.join(dir, file)); } catch { /* best-effort */ }
           continue;
         }
-        // Current format: PID → ptyId. Resolve the live owning workspace.
+        // Current format: PID → ptyId. Resolve the live owning workspace; a
+        // dead ptyId (no owner) is omitted but its file is left on disk.
         const wsId = owners[value];
         if (typeof wsId === 'string' && wsId) mappings[file] = wsId;
       }
     }
   } catch { /* best-effort */ }
   return { mappings };
+}
+
+function handleWorkspaceList() {
+  return getSimulatedWorkspaces();
 }
 
 function handleMcpClaimWorkspace() {
@@ -97,6 +124,7 @@ function handleMcpClaimWorkspace() {
 function dispatch(method, params) {
   switch (method) {
     case 'a2a.resolve.identity': return handleA2aResolveIdentity();
+    case 'workspace.list':       return handleWorkspaceList();
     case 'mcp.claimWorkspace':   return handleMcpClaimWorkspace();
     default: throw new Error(`Unknown method: ${method}`);
   }

--- a/scripts/helpers/mini-pipe-server.mjs
+++ b/scripts/helpers/mini-pipe-server.mjs
@@ -83,15 +83,6 @@ function getSimulatedWorkspaces() {
 function handleA2aResolveIdentity() {
   const dir = getPidMapDir();
   const owners = getSimulatedOwners();
-  // Live workspace id set, for verifying legacy "ws-" entries (mirrors the real
-  // handler's lazy workspace.list fetch). The mini-server always has a concrete
-  // array, so there is no 'unknown' state to model here — that path is covered
-  // by the unit tests.
-  const liveWorkspaceIds = new Set(
-    getSimulatedWorkspaces()
-      .map((w) => (w && typeof w === 'object' ? w.id : null))
-      .filter((id) => typeof id === 'string' && id),
-  );
   const mappings = {};
   try {
     if (fs.existsSync(dir)) {
@@ -104,15 +95,10 @@ function handleA2aResolveIdentity() {
         }
         if (!value) continue;
         if (value.startsWith('ws-')) {
-          // Legacy PID → workspaceId entry, mirroring src/main/pipe/handlers/
-          // a2a.rpc.ts: verify against the live workspace list. A live workspace
-          // (e.g. a pane carried across an upgrade) is resolved and kept; an
-          // absent one is a re-minted/recycled ghost and is purged.
-          if (liveWorkspaceIds.has(value)) {
-            mappings[file] = value;
-          } else {
-            try { fs.unlinkSync(path.join(dir, file)); } catch { /* best-effort */ }
-          }
+          // Legacy PID → workspaceId entry: DROP it (delete the file), mirroring
+          // src/main/pipe/handlers/a2a.rpc.ts. Passing it through is what let a
+          // re-minted/recycled legacy id resurface as a ghost workspace.
+          try { fs.unlinkSync(path.join(dir, file)); } catch { /* best-effort */ }
           continue;
         }
         // Current format: PID → ptyId. Resolve the live owning workspace; a

--- a/scripts/helpers/mini-pipe-server.mjs
+++ b/scripts/helpers/mini-pipe-server.mjs
@@ -83,6 +83,15 @@ function getSimulatedWorkspaces() {
 function handleA2aResolveIdentity() {
   const dir = getPidMapDir();
   const owners = getSimulatedOwners();
+  // Live workspace id set, for verifying legacy "ws-" entries (mirrors the real
+  // handler's lazy workspace.list fetch). The mini-server always has a concrete
+  // array, so there is no 'unknown' state to model here — that path is covered
+  // by the unit tests.
+  const liveWorkspaceIds = new Set(
+    getSimulatedWorkspaces()
+      .map((w) => (w && typeof w === 'object' ? w.id : null))
+      .filter((id) => typeof id === 'string' && id),
+  );
   const mappings = {};
   try {
     if (fs.existsSync(dir)) {
@@ -95,10 +104,15 @@ function handleA2aResolveIdentity() {
         }
         if (!value) continue;
         if (value.startsWith('ws-')) {
-          // Legacy PID → workspaceId entry: DROP it (delete the file), mirroring
-          // src/main/pipe/handlers/a2a.rpc.ts. Passing it through is what let a
-          // re-minted/recycled legacy id resurface as a ghost workspace.
-          try { fs.unlinkSync(path.join(dir, file)); } catch { /* best-effort */ }
+          // Legacy PID → workspaceId entry, mirroring src/main/pipe/handlers/
+          // a2a.rpc.ts: verify against the live workspace list. A live workspace
+          // (e.g. a pane carried across an upgrade) is resolved and kept; an
+          // absent one is a re-minted/recycled ghost and is purged.
+          if (liveWorkspaceIds.has(value)) {
+            mappings[file] = value;
+          } else {
+            try { fs.unlinkSync(path.join(dir, file)); } catch { /* best-effort */ }
+          }
           continue;
         }
         // Current format: PID → ptyId. Resolve the live owning workspace; a

--- a/scripts/helpers/resolve-workspace-id-probe.mjs
+++ b/scripts/helpers/resolve-workspace-id-probe.mjs
@@ -41,6 +41,11 @@ if (!pipeName || !authToken) {
 
 let rpcCalls = 0;
 let walkDepth = 0;
+// Process-scoped identity cache, mirroring src/mcp/index.ts. Persists across
+// resolveWorkspaceId() calls within this probe process so the stale-cache
+// fallback gate can be exercised (WMUX_WSID_PROBE_DOUBLE mode).
+let MY_WORKSPACE_ID = '';
+let workspaceResolved = false;
 
 function connectSocket() {
   return new Promise((resolve, reject) => {
@@ -97,7 +102,9 @@ function getParentPid(pid) {
   }
 }
 
-async function resolveWorkspaceId() {
+async function resolveWorkspaceId(opts) {
+  if (workspaceResolved && MY_WORKSPACE_ID && !opts?.force) return MY_WORKSPACE_ID;
+
   // Path B/C first — RPC for the live PID map, then walk the PPID chain.
   // The env hint is deliberately NOT consulted up front: trusting it forever
   // is what produced stale identities ("no workspace found for ws-…").
@@ -117,7 +124,11 @@ async function resolveWorkspaceId() {
       for (let depth = 0; depth < 10; depth++) {
         walkDepth = depth + 1;
         const wsId = known.get(currentPid);
-        if (wsId) return wsId;
+        if (wsId) {
+          MY_WORKSPACE_ID = wsId;
+          workspaceResolved = true;
+          return wsId;
+        }
         const parent = getParentPid(currentPid);
         if (!parent || parent === currentPid || parent <= 1) break;
         currentPid = parent;
@@ -135,7 +146,17 @@ async function resolveWorkspaceId() {
   if (envWorkspaceId) {
     if ((await classifyEnvHint(envWorkspaceId)) !== 'absent') return envWorkspaceId;
   }
-  return '';
+
+  // Stale cached identity fallback — gated identically to the env hint. The
+  // cache flag is cleared on a stale-identity error but MY_WORKSPACE_ID is not,
+  // so a re-minted/closed workspace would otherwise leak back here and keep
+  // routing to a confirmed-dead id (the ghost loop). Drop it on 'absent', keep
+  // on 'unknown'. Mirrors src/mcp/index.ts.
+  if (MY_WORKSPACE_ID && (await classifyEnvHint(MY_WORKSPACE_ID)) === 'absent') {
+    MY_WORKSPACE_ID = '';
+    workspaceResolved = false;
+  }
+  return MY_WORKSPACE_ID;
 }
 
 async function classifyEnvHint(wsId) {
@@ -155,7 +176,14 @@ async function classifyEnvHint(wsId) {
 
 (async () => {
   try {
-    const resolved = await resolveWorkspaceId();
+    // DOUBLE mode: resolve once (caches MY_WORKSPACE_ID via a PID-map hit), then
+    // force-resolve again after the server's pid-map has gone empty. Reports the
+    // SECOND result so the harness can assert the stale cache is not returned
+    // once its workspace is confirmed absent.
+    let resolved = await resolveWorkspaceId();
+    if (process.env.WMUX_WSID_PROBE_DOUBLE) {
+      resolved = await resolveWorkspaceId({ force: true });
+    }
     process.stdout.write(JSON.stringify({ resolved, rpcCalls, walkDepth }) + '\n');
     process.exit(0);
   } catch (err) {

--- a/scripts/helpers/resolve-workspace-id-probe.mjs
+++ b/scripts/helpers/resolve-workspace-id-probe.mjs
@@ -8,9 +8,11 @@
  *   1. Call a2a.resolve.identity RPC for the PID → (live) workspaceId map.
  *   2. Walk PPID chain up to 10 levels looking for a match (path B).
  *   3. Only if that finds nothing, fall back to the WMUX_WORKSPACE_ID env
- *      hint (path A). The env is NO LONGER a short-circuit: it is frozen at
- *      PTY-create time and goes stale when the workspace id is re-minted, so
- *      the live PID map is always preferred over it.
+ *      hint (path A) — but gate it on workspace.list first: the hint is frozen
+ *      at PTY-create time and goes stale when the workspace id is re-minted, so
+ *      a hint that is a CONFIRMED ghost (absent from workspace.list) is dropped.
+ *      A hint is kept on 'unknown' (workspace.list unavailable) to avoid turning
+ *      a transient condition into a hard failure. Mirrors src/mcp/index.ts.
  *
  * Inputs (env):
  *   WMUX_WSID_PROBE_PIPE   pipe / socket name of the bundled daemon
@@ -20,7 +22,7 @@
  * Output (single line JSON to stdout):
  *   {
  *     resolved: string,    // the resolved workspaceId, or "" on failure
- *     rpcCalls: number,    // 0 if path A, 1 if path B was attempted
+ *     rpcCalls: number,    // resolve.identity (+ workspace.list if hint gated)
  *     walkDepth: number,   // 0 if path A, >=1 if walk ran
  *   }
  */
@@ -127,9 +129,28 @@ async function resolveWorkspaceId() {
     if (socket) socket.end();
   }
 
-  // Path A (last resort) — unconfirmed, possibly-stale env hint.
-  if (envWorkspaceId) return envWorkspaceId;
+  // Path A (last resort) — env hint, but reject a CONFIRMED ghost first.
+  // Mirrors src/mcp/index.ts: drop the hint only on positive proof it is gone
+  // ('absent'); keep it on 'unknown' (workspace.list unavailable / non-array).
+  if (envWorkspaceId) {
+    if ((await classifyEnvHint(envWorkspaceId)) !== 'absent') return envWorkspaceId;
+  }
   return '';
+}
+
+async function classifyEnvHint(wsId) {
+  let socket;
+  try {
+    socket = await connectSocket();
+    const result = await rpc(socket, 'workspace.list', {});
+    const list = Array.isArray(result) ? result : result?.workspaces;
+    if (!Array.isArray(list)) return 'unknown';
+    return list.some((w) => w && typeof w === 'object' && w.id === wsId) ? 'live' : 'absent';
+  } catch {
+    return 'unknown';
+  } finally {
+    if (socket) socket.end();
+  }
 }
 
 (async () => {

--- a/scripts/workspace-identity-dynamic.mjs
+++ b/scripts/workspace-identity-dynamic.mjs
@@ -71,7 +71,7 @@ function makePipeName(tag) {
   return path.join(os.tmpdir(), `wmux-wsid-${tag}.sock`);
 }
 
-function spawnMiniServer({ pipeName, authToken, testHome, owners }) {
+function spawnMiniServer({ pipeName, authToken, testHome, owners, workspaces }) {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [MINI_SERVER], {
       cwd: REPO_ROOT,
@@ -85,6 +85,8 @@ function spawnMiniServer({ pipeName, authToken, testHome, owners }) {
         WMUX_MINISERVER_TOKEN: authToken,
         // Simulated renderer ptyId → workspaceId ownership table.
         WMUX_MINISERVER_OWNERS: JSON.stringify(owners ?? {}),
+        // Simulated renderer workspace.list (live workspace array).
+        WMUX_MINISERVER_WORKSPACES: JSON.stringify(workspaces ?? []),
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -152,12 +154,12 @@ async function killChild(child) {
   if (!child.killed) child.kill('SIGKILL');
 }
 
-async function withServer(label, body, owners) {
+async function withServer(label, body, owners, workspaces) {
   const testHome = makeTestHome();
   const wmuxDir = path.join(testHome, '.wmux');
   const pipeName = makePipeName(`${label}-${randomUUID().slice(0, 8)}`);
   const authToken = randomUUID();
-  const { child, getStderr } = await spawnMiniServer({ pipeName, authToken, testHome, owners });
+  const { child, getStderr } = await spawnMiniServer({ pipeName, authToken, testHome, owners, workspaces });
   try {
     return await body({ testHome, wmuxDir, pipeName, authToken });
   } catch (err) {
@@ -214,26 +216,31 @@ function runProbe({ pipeName, authToken, testHome, envWorkspaceId }) {
 
 async function runW1(report) {
   await withServer('W1', async ({ wmuxDir, pipeName, authToken }) => {
-    // pid-map stores PID → ptyId. The handler resolves each ptyId to its
-    // live owner; the legacy ws- entry passes through; the dead ptyId
-    // (no owner) is omitted.
+    // pid-map stores PID → ptyId. The handler resolves each ptyId to its live
+    // owner; the legacy ws- entry is DROPPED (file deleted, the ghost-fix
+    // behavior); the dead ptyId (no owner) is omitted from the map but its file
+    // is left on disk (read path is non-destructive for current-format files).
     const pidMapDir = path.join(wmuxDir, 'pid-map');
     fs.mkdirSync(pidMapDir, { recursive: true });
-    fs.writeFileSync(path.join(pidMapDir, '12345'), 'daemon-aaaa', 'utf-8');
-    fs.writeFileSync(path.join(pidMapDir, '67890'), 'ws-legacy', 'utf-8');
-    fs.writeFileSync(path.join(pidMapDir, '55555'), 'daemon-dead', 'utf-8');
+    fs.writeFileSync(path.join(pidMapDir, '12345'), 'daemon-aaaa', 'utf-8'); // live
+    fs.writeFileSync(path.join(pidMapDir, '67890'), 'ws-legacy', 'utf-8');   // legacy → dropped
+    fs.writeFileSync(path.join(pidMapDir, '55555'), 'daemon-dead', 'utf-8'); // dead owner → omitted
 
     const socket = await connectSocket(pipeName);
     try {
       const result = await rpc(socket, 'a2a.resolve.identity', {}, authToken);
       const m = result.mappings;
+      const filesAfter = fs.readdirSync(pidMapDir).sort();
       const pass =
         m &&
-        m['12345'] === 'ws-alpha' &&   // live owner of daemon-aaaa
-        m['67890'] === 'ws-legacy' &&  // legacy passthrough
-        !('55555' in m) &&             // dead ptyId omitted
-        Object.keys(m).length === 2;
-      report.push({ scenario: 'W1', pass, mappings: m });
+        m['12345'] === 'ws-alpha' &&        // live owner of daemon-aaaa
+        !('67890' in m) &&                  // legacy dropped from map
+        !('55555' in m) &&                  // dead ptyId omitted
+        Object.keys(m).length === 1 &&
+        !filesAfter.includes('67890') &&    // legacy file purged from disk
+        filesAfter.includes('12345') &&     // live file kept
+        filesAfter.includes('55555');       // dead current-format file kept (non-destructive read)
+      report.push({ scenario: 'W1', pass, mappings: m, filesAfter });
     } finally {
       socket.end();
     }
@@ -264,8 +271,10 @@ async function runW2(report) {
 }
 
 async function runW2b(report) {
-  // Env hint fallback. No PID-map match (empty map) → the resolver falls back
-  // to the env hint rather than returning nothing.
+  // Env hint fallback — hint names a LIVE workspace. No PID-map match (empty
+  // map) → the resolver falls back to the env hint, gates it on workspace.list,
+  // sees it is live, and returns it. rpcCalls === 2 (resolve.identity +
+  // workspace.list).
   await withServer('W2b', async ({ testHome, wmuxDir, pipeName, authToken }) => {
     fs.mkdirSync(path.join(wmuxDir, 'pid-map'), { recursive: true });
 
@@ -273,9 +282,29 @@ async function runW2b(report) {
       pipeName, authToken, testHome,
       envWorkspaceId: 'ws-from-env',
     });
-    const pass = probe.resolved === 'ws-from-env' && probe.rpcCalls === 1;
+    const pass = probe.resolved === 'ws-from-env' && probe.rpcCalls === 2;
     report.push({ scenario: 'W2b', pass, probe });
-  });
+  }, {}, [{ id: 'ws-from-env' }]);
+}
+
+async function runW2c(report) {
+  // Env hint is a CONFIRMED GHOST. No PID-map match, and workspace.list does
+  // NOT contain the hint → the resolver must DROP it and return "" (so the MCP
+  // server raises a clear "identity unknown" rather than routing into a ghost).
+  // This is the env-hint half of the ghost fix.
+  await withServer('W2c', async ({ testHome, wmuxDir, pipeName, authToken }) => {
+    fs.mkdirSync(path.join(wmuxDir, 'pid-map'), { recursive: true });
+
+    const probe = await runProbe({
+      pipeName, authToken, testHome,
+      envWorkspaceId: 'ws-stale-ghost',
+    });
+    const pass =
+      probe.resolved === '' &&
+      probe.resolved !== 'ws-stale-ghost' &&
+      probe.rpcCalls === 2;
+    report.push({ scenario: 'W2c', pass, probe });
+  }, {}, [{ id: 'ws-other-live' }]);
 }
 
 async function runW3(report) {
@@ -340,6 +369,7 @@ async function main() {
   await runW1(report);
   await runW2(report);
   await runW2b(report);
+  await runW2c(report);
   await runW3(report);
   await runW4(report);
   await runW5(report);

--- a/scripts/workspace-identity-dynamic.mjs
+++ b/scripts/workspace-identity-dynamic.mjs
@@ -217,13 +217,14 @@ function runProbe({ pipeName, authToken, testHome, envWorkspaceId }) {
 async function runW1(report) {
   await withServer('W1', async ({ wmuxDir, pipeName, authToken }) => {
     // pid-map stores PID → ptyId. The handler resolves each ptyId to its live
-    // owner; the legacy ws- entry is DROPPED (file deleted, the ghost-fix
-    // behavior); the dead ptyId (no owner) is omitted from the map but its file
-    // is left on disk (read path is non-destructive for current-format files).
+    // owner; the legacy ws- entry is verified against the live workspace list
+    // and PURGED because it is ABSENT (a ghost); the dead ptyId (no owner) is
+    // omitted from the map but its file is left on disk (read path is
+    // non-destructive for current-format files). (Live-legacy is W1b.)
     const pidMapDir = path.join(wmuxDir, 'pid-map');
     fs.mkdirSync(pidMapDir, { recursive: true });
     fs.writeFileSync(path.join(pidMapDir, '12345'), 'daemon-aaaa', 'utf-8'); // live
-    fs.writeFileSync(path.join(pidMapDir, '67890'), 'ws-legacy', 'utf-8');   // legacy → dropped
+    fs.writeFileSync(path.join(pidMapDir, '67890'), 'ws-legacy', 'utf-8');   // legacy, absent → purged
     fs.writeFileSync(path.join(pidMapDir, '55555'), 'daemon-dead', 'utf-8'); // dead owner → omitted
 
     const socket = await connectSocket(pipeName);
@@ -244,7 +245,35 @@ async function runW1(report) {
     } finally {
       socket.end();
     }
-  }, { 'daemon-aaaa': 'ws-alpha' });
+  }, { 'daemon-aaaa': 'ws-alpha' }, [{ id: 'ws-alpha' }]); // ws-legacy absent from live list
+}
+
+async function runW1b(report) {
+  // Legacy "ws-" entry whose workspace is STILL LIVE — a pane carried across an
+  // upgrade, with the legacy file as its only identity anchor. It must be
+  // resolved to its workspaceId AND kept on disk; purging it (the old
+  // unconditional behavior) would orphan the upgraded pane's MCP children
+  // ("no active workspace"). Codex PR #142 P1.
+  await withServer('W1b', async ({ wmuxDir, pipeName, authToken }) => {
+    const pidMapDir = path.join(wmuxDir, 'pid-map');
+    fs.mkdirSync(pidMapDir, { recursive: true });
+    fs.writeFileSync(path.join(pidMapDir, '24680'), 'ws-upgraded-live', 'utf-8');
+
+    const socket = await connectSocket(pipeName);
+    try {
+      const result = await rpc(socket, 'a2a.resolve.identity', {}, authToken);
+      const m = result.mappings;
+      const filesAfter = fs.readdirSync(pidMapDir).sort();
+      const pass =
+        m &&
+        m['24680'] === 'ws-upgraded-live' && // resolved to its live workspace
+        Object.keys(m).length === 1 &&
+        filesAfter.includes('24680');         // live legacy anchor preserved
+      report.push({ scenario: 'W1b', pass, mappings: m, filesAfter });
+    } finally {
+      socket.end();
+    }
+  }, {}, [{ id: 'ws-upgraded-live' }, { id: 'ws-other' }]);
 }
 
 async function runW2(report) {
@@ -367,6 +396,7 @@ async function main() {
   console.log(`Workspace identity dynamic test — platform=${process.platform}`);
   const report = [];
   await runW1(report);
+  await runW1b(report);
   await runW2(report);
   await runW2b(report);
   await runW2c(report);

--- a/scripts/workspace-identity-dynamic.mjs
+++ b/scripts/workspace-identity-dynamic.mjs
@@ -71,7 +71,7 @@ function makePipeName(tag) {
   return path.join(os.tmpdir(), `wmux-wsid-${tag}.sock`);
 }
 
-function spawnMiniServer({ pipeName, authToken, testHome, owners, workspaces }) {
+function spawnMiniServer({ pipeName, authToken, testHome, owners, workspaces, resolveOnce }) {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [MINI_SERVER], {
       cwd: REPO_ROOT,
@@ -87,6 +87,8 @@ function spawnMiniServer({ pipeName, authToken, testHome, owners, workspaces }) 
         WMUX_MINISERVER_OWNERS: JSON.stringify(owners ?? {}),
         // Simulated renderer workspace.list (live workspace array).
         WMUX_MINISERVER_WORKSPACES: JSON.stringify(workspaces ?? []),
+        // When set, the PID map resolves only on the first call (then empty).
+        WMUX_MINISERVER_RESOLVE_ONCE: resolveOnce ? '1' : undefined,
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -154,12 +156,12 @@ async function killChild(child) {
   if (!child.killed) child.kill('SIGKILL');
 }
 
-async function withServer(label, body, owners, workspaces) {
+async function withServer(label, body, owners, workspaces, extra = {}) {
   const testHome = makeTestHome();
   const wmuxDir = path.join(testHome, '.wmux');
   const pipeName = makePipeName(`${label}-${randomUUID().slice(0, 8)}`);
   const authToken = randomUUID();
-  const { child, getStderr } = await spawnMiniServer({ pipeName, authToken, testHome, owners, workspaces });
+  const { child, getStderr } = await spawnMiniServer({ pipeName, authToken, testHome, owners, workspaces, resolveOnce: extra.resolveOnce });
   try {
     return await body({ testHome, wmuxDir, pipeName, authToken });
   } catch (err) {
@@ -172,7 +174,7 @@ async function withServer(label, body, owners, workspaces) {
   }
 }
 
-function runProbe({ pipeName, authToken, testHome, envWorkspaceId }) {
+function runProbe({ pipeName, authToken, testHome, envWorkspaceId, double }) {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [HELPER_PROBE], {
       cwd: REPO_ROOT,
@@ -185,6 +187,9 @@ function runProbe({ pipeName, authToken, testHome, envWorkspaceId }) {
         WMUX_WSID_PROBE_PIPE: pipeName,
         WMUX_WSID_PROBE_TOKEN: authToken,
         WMUX_WORKSPACE_ID: envWorkspaceId ?? '',
+        // Resolve twice (cache, then force-re-resolve) to exercise the
+        // stale-cache fallback gate.
+        WMUX_WSID_PROBE_DOUBLE: double ? '1' : undefined,
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -307,6 +312,27 @@ async function runW2c(report) {
   }, {}, [{ id: 'ws-other-live' }]);
 }
 
+async function runW2d(report) {
+  // Codex PR #142 R3 P2 — a stale cached identity must not outlive its
+  // workspace. The first resolve hits the PID-map walk and caches
+  // MY_WORKSPACE_ID = the owner. The server is in RESOLVE_ONCE mode, so the
+  // forced second resolve sees an EMPTY pid-map (pane gone / re-minted) and
+  // falls through. With no env hint and the cached workspace ABSENT from
+  // workspace.list, the resolver must drop the cached id and return "" — not
+  // keep routing to the confirmed-dead id (the ghost loop).
+  await withServer('W2d', async ({ testHome, wmuxDir, pipeName, authToken }) => {
+    const pidMapDir = path.join(wmuxDir, 'pid-map');
+    fs.mkdirSync(pidMapDir, { recursive: true });
+    fs.writeFileSync(path.join(pidMapDir, String(process.pid)), 'daemon-cache', 'utf-8');
+
+    const probe = await runProbe({ pipeName, authToken, testHome, envWorkspaceId: '', double: true });
+    const pass =
+      probe.resolved === '' &&             // stale cache dropped, not returned
+      probe.resolved !== 'ws-cached-DEAD';
+    report.push({ scenario: 'W2d', pass, probe });
+  }, { 'daemon-cache': 'ws-cached-DEAD' }, [{ id: 'ws-other-live' }], { resolveOnce: true });
+}
+
 async function runW3(report) {
   await withServer('W3', async ({ testHome, wmuxDir, pipeName, authToken }) => {
     // Map THIS test runner's pid → ptyId, owner = ws-walk-match. The probe's
@@ -370,6 +396,7 @@ async function main() {
   await runW2(report);
   await runW2b(report);
   await runW2c(report);
+  await runW2d(report);
   await runW3(report);
   await runW4(report);
   await runW5(report);

--- a/scripts/workspace-identity-dynamic.mjs
+++ b/scripts/workspace-identity-dynamic.mjs
@@ -217,14 +217,13 @@ function runProbe({ pipeName, authToken, testHome, envWorkspaceId }) {
 async function runW1(report) {
   await withServer('W1', async ({ wmuxDir, pipeName, authToken }) => {
     // pid-map stores PID → ptyId. The handler resolves each ptyId to its live
-    // owner; the legacy ws- entry is verified against the live workspace list
-    // and PURGED because it is ABSENT (a ghost); the dead ptyId (no owner) is
-    // omitted from the map but its file is left on disk (read path is
-    // non-destructive for current-format files). (Live-legacy is W1b.)
+    // owner; the legacy ws- entry is DROPPED (file deleted, the ghost-fix
+    // behavior); the dead ptyId (no owner) is omitted from the map but its file
+    // is left on disk (read path is non-destructive for current-format files).
     const pidMapDir = path.join(wmuxDir, 'pid-map');
     fs.mkdirSync(pidMapDir, { recursive: true });
     fs.writeFileSync(path.join(pidMapDir, '12345'), 'daemon-aaaa', 'utf-8'); // live
-    fs.writeFileSync(path.join(pidMapDir, '67890'), 'ws-legacy', 'utf-8');   // legacy, absent → purged
+    fs.writeFileSync(path.join(pidMapDir, '67890'), 'ws-legacy', 'utf-8');   // legacy → dropped
     fs.writeFileSync(path.join(pidMapDir, '55555'), 'daemon-dead', 'utf-8'); // dead owner → omitted
 
     const socket = await connectSocket(pipeName);
@@ -245,35 +244,7 @@ async function runW1(report) {
     } finally {
       socket.end();
     }
-  }, { 'daemon-aaaa': 'ws-alpha' }, [{ id: 'ws-alpha' }]); // ws-legacy absent from live list
-}
-
-async function runW1b(report) {
-  // Legacy "ws-" entry whose workspace is STILL LIVE — a pane carried across an
-  // upgrade, with the legacy file as its only identity anchor. It must be
-  // resolved to its workspaceId AND kept on disk; purging it (the old
-  // unconditional behavior) would orphan the upgraded pane's MCP children
-  // ("no active workspace"). Codex PR #142 P1.
-  await withServer('W1b', async ({ wmuxDir, pipeName, authToken }) => {
-    const pidMapDir = path.join(wmuxDir, 'pid-map');
-    fs.mkdirSync(pidMapDir, { recursive: true });
-    fs.writeFileSync(path.join(pidMapDir, '24680'), 'ws-upgraded-live', 'utf-8');
-
-    const socket = await connectSocket(pipeName);
-    try {
-      const result = await rpc(socket, 'a2a.resolve.identity', {}, authToken);
-      const m = result.mappings;
-      const filesAfter = fs.readdirSync(pidMapDir).sort();
-      const pass =
-        m &&
-        m['24680'] === 'ws-upgraded-live' && // resolved to its live workspace
-        Object.keys(m).length === 1 &&
-        filesAfter.includes('24680');         // live legacy anchor preserved
-      report.push({ scenario: 'W1b', pass, mappings: m, filesAfter });
-    } finally {
-      socket.end();
-    }
-  }, {}, [{ id: 'ws-upgraded-live' }, { id: 'ws-other' }]);
+  }, { 'daemon-aaaa': 'ws-alpha' });
 }
 
 async function runW2(report) {
@@ -396,7 +367,6 @@ async function main() {
   console.log(`Workspace identity dynamic test — platform=${process.platform}`);
   const report = [];
   await runW1(report);
-  await runW1b(report);
   await runW2(report);
   await runW2b(report);
   await runW2c(report);

--- a/src/company/mcp/index.ts
+++ b/src/company/mcp/index.ts
@@ -127,6 +127,15 @@ async function resolveWorkspaceId(opts?: { force?: boolean }): Promise<string> {
   if (ENV_WORKSPACE_HINT) {
     if ((await isLiveWorkspace(ENV_WORKSPACE_HINT)) !== 'absent') return ENV_WORKSPACE_HINT;
   }
+  // Last-resort cached identity. invalidateWorkspaceId clears workspaceResolved
+  // but not MY_WORKSPACE_ID, so gate the cached fallback on liveness too: drop a
+  // confirmed-dead ('absent') id (and clear the cache so the next call
+  // re-resolves clean), keep it on 'unknown' (workspace.list transiently down).
+  // Mirrors src/mcp/index.ts so both surfaces close the ghost loop identically.
+  if (MY_WORKSPACE_ID && (await isLiveWorkspace(MY_WORKSPACE_ID)) === 'absent') {
+    MY_WORKSPACE_ID = '';
+    workspaceResolved = false;
+  }
   return MY_WORKSPACE_ID;
 }
 

--- a/src/company/mcp/index.ts
+++ b/src/company/mcp/index.ts
@@ -23,6 +23,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import { sendRpc } from '../../mcp/wmux-client';
 import type { RpcMethod } from '../../shared/rpc';
+import { classifyWorkspaceListResult, type WorkspaceLiveness } from '../../mcp/workspaceIdentity';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
@@ -76,6 +77,22 @@ function invalidateWorkspaceId(): void {
   workspaceResolved = false;
 }
 
+/**
+ * Classify whether `wsId` exists right now (kept in lockstep with src/mcp's
+ * isLiveWorkspace). Gates the env-hint fallback so a re-minted ghost id can't
+ * leak through after a daemon respawn / session restore. 'absent' = confirmed
+ * gone (drop the hint); 'unknown' = workspace.list unavailable (keep the hint
+ * rather than turning a transient condition into a hard failure).
+ */
+async function isLiveWorkspace(wsId: string): Promise<WorkspaceLiveness> {
+  try {
+    const result = await sendRpc('workspace.list' as RpcMethod, {});
+    return classifyWorkspaceListResult(result, wsId);
+  } catch {
+    return 'unknown';
+  }
+}
+
 async function resolveWorkspaceId(opts?: { force?: boolean }): Promise<string> {
   if (workspaceResolved && MY_WORKSPACE_ID && !opts?.force) return MY_WORKSPACE_ID;
 
@@ -104,7 +121,12 @@ async function resolveWorkspaceId(opts?: { force?: boolean }): Promise<string> {
     }
   } catch { /* resolve failed, fall through to env hint */ }
 
-  if (ENV_WORKSPACE_HINT) return ENV_WORKSPACE_HINT;
+  // Drop the frozen env hint only on positive proof it names a dead workspace
+  // ('absent'); keep it on 'unknown' (workspace.list transiently unavailable).
+  // Mirrors src/mcp/index.ts so both MCP surfaces reject ghost ids identically.
+  if (ENV_WORKSPACE_HINT) {
+    if ((await isLiveWorkspace(ENV_WORKSPACE_HINT)) !== 'absent') return ENV_WORKSPACE_HINT;
+  }
   return MY_WORKSPACE_ID;
 }
 

--- a/src/main/ipc/__tests__/pty.handler.pidmap-prune.test.ts
+++ b/src/main/ipc/__tests__/pty.handler.pidmap-prune.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Regression test for the pid-map ghost-identity leak on explicit close.
+ *
+ * Context (cross-verified live by the W1+W2 dogfood agents, 2026-06-07):
+ *   The ghost-workspace fix (30b3f77) added `removePidMapByPtyId` and wired it
+ *   into `onDaemonSessionDied` (the daemon `session:died` event) so a dying
+ *   shell's pid-map anchor is pruned at the WRITE boundary instead of accreting.
+ *
+ * The gap that test closes:
+ *   `session:died` only fires on a NATURAL/unexpected PTY exit. The common
+ *   close path — a pane/workspace close in the UI — goes
+ *     PTY_DISPOSE → daemon.destroySession (RPC)
+ *   and `DaemonSessionManager.destroySession` removes the bridge exit listener
+ *   BEFORE killing, then emits `session:destroyed` — NOT `session:died`. The
+ *   DaemonClient forwards that as `session:destroyed`, so `onDaemonSessionDied`
+ *   never fires for an explicit close. Without a prune in the dispose handler
+ *   itself, every UI-driven close leaked its anchor (observed: PID 37008 →
+ *   daemon-33d7bc91 lingering after Workspace 3 was closed), giving the OS a
+ *   recycled PID to turn into a ghost workspace id.
+ *
+ * Fix: the daemon-mode PTY_DISPOSE handler prunes the anchor itself.
+ *
+ * This test is structural — same rationale as the PTY_RESIZE retry test in this
+ * directory: the bug shape is "a required call is missing from a specific
+ * handler region", which the source catches with no IPC/daemon plumbing (the
+ * handler module pulls in electron and can't be imported under vitest). It
+ * guards BOTH prune call sites (dispose + session:died) so a future refactor
+ * can't silently drop either, and that they route through the shared pid-map
+ * helper. The helper's own content-keying / unlink behavior is exercised at
+ * runtime in src/main/pty/__tests__/pidMap.test.ts.
+ */
+describe('pty.handler pid-map prune (ghost-identity leak on explicit close)', () => {
+  const handlerPath = path.join(__dirname, '..', 'handlers', 'pty.handler.ts');
+  const source = fs.readFileSync(handlerPath, 'utf-8');
+
+  /**
+   * Isolate the whole `// pty:dispose` region (both daemon and non-daemon
+   * branches), bounded by the next handler's `// pty:list` marker. Throws if a
+   * marker moved — itself a useful refactor signal.
+   */
+  function disposeRegion(): string {
+    const match = source.match(/\/\/ pty:dispose[\s\S]*?\/\/ pty:list/);
+    if (!match) {
+      throw new Error(
+        'pty:dispose → pty:list region not found in pty.handler.ts. If the ' +
+          'file layout changed, update the regex before assuming the prune is gone.',
+      );
+    }
+    return match[0];
+  }
+
+  it('daemon-mode dispose prunes the pid-map anchor after destroySession', () => {
+    const region = disposeRegion();
+    // The daemon branch is everything before the non-daemon `} else {`.
+    const daemonBranch = region.split(/}\s*else\s*{/)[0];
+
+    // The leaking close path. destroySession emits session:destroyed (not
+    // session:died), so the prune MUST live here too — not only in the
+    // session:died handler.
+    expect(daemonBranch).toMatch(/daemon\.destroySession/);
+    expect(daemonBranch).toMatch(/removePidMapByPtyId\(id\)/);
+  });
+
+  it('keeps the session:died prune wiring intact (no regression of 30b3f77)', () => {
+    // The original natural-exit prune must survive alongside the new
+    // dispose-path prune. Both teardown paths stay covered.
+    expect(source).toMatch(/onDaemonSessionDied[\s\S]*?removePidMapByPtyId\(payload\.sessionId\)/);
+  });
+
+  it('routes both prune call sites through the shared pid-map helper', () => {
+    // Both call sites must use the extracted, behavior-tested helper rather
+    // than a re-inlined copy. A divergent inline implementation could drift
+    // from the content-keying contract (e.g. flip to match by PID filename),
+    // silently reviving the ghost accretion while this file's call-site
+    // assertions above still pass.
+    expect(source).toMatch(
+      /import\s*\{[^}]*\bremovePidMapByPtyId\b[^}]*\}\s*from\s*['"][^'"]*\/pty\/pidMap['"]/,
+    );
+    // The helper must NOT be re-declared locally (that's what we moved out).
+    expect(source).not.toMatch(/function\s+removePidMapByPtyId\b/);
+  });
+});

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -5,7 +5,8 @@ import { StringDecoder } from 'node:string_decoder';
 import { PTYManager } from '../../pty/PTYManager';
 import { PTYBridge } from '../../pty/PTYBridge';
 import { DaemonClient } from '../../DaemonClient';
-import { IPC, getPidMapDir, ENV_KEYS } from '../../../shared/constants';
+import { IPC, ENV_KEYS } from '../../../shared/constants';
+import { writePidMap, removePidMapByPtyId } from '../../pty/pidMap';
 import { sanitizePtyText } from '../../../shared/types';
 import { resolveSpawnEnv } from '../../pty/resolveSpawnEnv';
 import { scheduleInitialCommand } from './scheduleInitialCommand';
@@ -104,48 +105,6 @@ function validateCwd(cwd: string | undefined): string | undefined {
   const stat = fs.statSync(resolved);
   if (!stat.isDirectory()) return undefined;
   return resolved;
-}
-
-/**
- * Write a PID → ptyId mapping for MCP workspace-identity resolution.
- *
- * We deliberately store the ptyId, NOT the workspaceId: a workspace id can be
- * re-minted (daemon respawn / session restore) while the shell process lives
- * on, so a frozen workspace id goes stale. The ptyId is immutable for the
- * process lifetime; `a2a.resolve.identity` maps ptyId → the CURRENT owning
- * workspace at lookup time. (Claude Code doesn't propagate env vars to MCP
- * child processes, so this on-disk map is the resolution anchor.)
- */
-function writePidMap(pid: string | number, ptyId: string): void {
-  try {
-    const dir = getPidMapDir();
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(path.join(dir, String(pid)), ptyId, 'utf8');
-  } catch { /* best-effort */ }
-}
-
-/**
- * Remove every pid-map file pointing at `ptyId`. Called when a daemon-owned
- * session dies so the map is pruned at the WRITE boundary instead of on the
- * read hot-path. Daemon sessions otherwise leak a file per shell forever
- * (writePidMap has no PID-keyed remove pair here, unlike PTYManager.dispose),
- * which let the OS recycle those PIDs onto unrelated processes — the accretion
- * behind the ghost-workspace bug. Keyed by ptyId (content) because the
- * session:died payload carries the sessionId/ptyId, not the OS PID.
- */
-function removePidMapByPtyId(ptyId: string): void {
-  if (!ptyId) return;
-  try {
-    const dir = getPidMapDir();
-    if (!fs.existsSync(dir)) return;
-    for (const file of fs.readdirSync(dir)) {
-      try {
-        if (fs.readFileSync(path.join(dir, file), 'utf8').trim() === ptyId) {
-          fs.unlinkSync(path.join(dir, file));
-        }
-      } catch { /* unreadable / racing-unlink — skip */ }
-    }
-  } catch { /* best-effort */ }
 }
 
 export function registerPTYHandlers(
@@ -541,6 +500,11 @@ export function registerPTYHandlers(
       // Drop the data forwarding listener for this session so a future
       // create or reconnect doesn't pile new listeners on top of dead ones.
       clearSessionDataListener(id);
+      // Prune this session's pid-map anchor. destroySession emits
+      // session:destroyed (not session:died), so onDaemonSessionDied never
+      // fires for an explicit close — without this, every pane/workspace
+      // close leaks its anchor for the OS to recycle into a ghost.
+      removePidMapByPtyId(id);
     }));
   } else {
     ipcMain.handle(IPC.PTY_DISPOSE, wrapHandler(IPC.PTY_DISPOSE, (_event: Electron.IpcMainInvokeEvent, id: string) => {

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -124,6 +124,30 @@ function writePidMap(pid: string | number, ptyId: string): void {
   } catch { /* best-effort */ }
 }
 
+/**
+ * Remove every pid-map file pointing at `ptyId`. Called when a daemon-owned
+ * session dies so the map is pruned at the WRITE boundary instead of on the
+ * read hot-path. Daemon sessions otherwise leak a file per shell forever
+ * (writePidMap has no PID-keyed remove pair here, unlike PTYManager.dispose),
+ * which let the OS recycle those PIDs onto unrelated processes — the accretion
+ * behind the ghost-workspace bug. Keyed by ptyId (content) because the
+ * session:died payload carries the sessionId/ptyId, not the OS PID.
+ */
+function removePidMapByPtyId(ptyId: string): void {
+  if (!ptyId) return;
+  try {
+    const dir = getPidMapDir();
+    if (!fs.existsSync(dir)) return;
+    for (const file of fs.readdirSync(dir)) {
+      try {
+        if (fs.readFileSync(path.join(dir, file), 'utf8').trim() === ptyId) {
+          fs.unlinkSync(path.join(dir, file));
+        }
+      } catch { /* unreadable / racing-unlink — skip */ }
+    }
+  } catch { /* best-effort */ }
+}
+
 export function registerPTYHandlers(
   ptyManager: PTYManager,
   ptyBridge: PTYBridge,
@@ -642,6 +666,9 @@ export function registerPTYHandlers(
         win.webContents.send(IPC.PTY_EXIT, payload.sessionId, payload.exitCode ?? -1);
       }
       daemonClient.disconnectSessionPipe(payload.sessionId).catch(() => {});
+      // Prune this session's pid-map anchor now that the shell is gone, so the
+      // map doesn't accrete dead entries the OS can recycle into ghosts.
+      removePidMapByPtyId(payload.sessionId);
     };
     daemonClient.on('session:died', onDaemonSessionDied);
   }

--- a/src/main/pipe/handlers/__tests__/a2a.rpc.resolveIdentity.test.ts
+++ b/src/main/pipe/handlers/__tests__/a2a.rpc.resolveIdentity.test.ts
@@ -44,6 +44,10 @@ async function resolveIdentity(router: RpcRouter): Promise<Record<string, string
   return (res as { result: { mappings: Record<string, string> } }).result.mappings;
 }
 
+function listFiles(): string[] {
+  return fs.existsSync(dirRef.current) ? fs.readdirSync(dirRef.current).sort() : [];
+}
+
 describe('a2a.resolve.identity — live ownership resolution', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -81,24 +85,30 @@ describe('a2a.resolve.identity — live ownership resolution', () => {
     );
   });
 
-  it('omits a ptyId whose pane no longer exists (owner === null)', async () => {
-    // A re-minted / closed pane must not produce a phantom mapping — better to
-    // return nothing and let the caller fall back than to assert a dead id.
-    fs.writeFileSync(path.join(dirRef.current, '2222'), 'daemon-dead');
+  it('omits a ptyId whose pane no longer exists (owner === null) without deleting the file', async () => {
+    // A dead/recycled current-format entry resolves to null and is excluded from
+    // the map — so it can never produce a ghost. It is left on disk (harmless);
+    // accretion is bounded at the write boundary, not on this read hot-path.
+    fs.writeFileSync(path.join(dirRef.current, '2222'), 'daemon-gone');
     sendToRendererMock.mockResolvedValue({ workspaceId: null });
 
     const mappings = await resolveIdentity(setupRouter());
 
     expect(mappings).toEqual({});
+    expect(listFiles()).toEqual(['2222']); // not pruned on the read path
   });
 
-  it('passes through legacy PID→workspaceId entries (ws- prefix) without a renderer call', async () => {
+  it('DROPS legacy PID→workspaceId entries (ws- prefix) and deletes the file', async () => {
+    // Legacy entries have no ptyId anchor, cannot be live-resolved, and on a
+    // recycled PID surface as a ghost workspace. They must be purged, not passed
+    // through (the old passthrough behavior was the root cause of the ghost bug).
     fs.writeFileSync(path.join(dirRef.current, '3333'), 'ws-legacy-frozen');
 
     const mappings = await resolveIdentity(setupRouter());
 
-    expect(mappings).toEqual({ '3333': 'ws-legacy-frozen' });
+    expect(mappings).toEqual({});
     expect(sendToRendererMock).not.toHaveBeenCalled();
+    expect(listFiles()).toEqual([]); // file purged
   });
 
   it('skips an entry when the renderer lookup throws (early boot / reload)', async () => {
@@ -108,9 +118,11 @@ describe('a2a.resolve.identity — live ownership resolution', () => {
     const mappings = await resolveIdentity(setupRouter());
 
     expect(mappings).toEqual({});
+    // Not pruned: a renderer error is not proof the entry is stale.
+    expect(listFiles()).toEqual(['4444']);
   });
 
-  it('resolves a mix of live, legacy, and dead entries in one pass', async () => {
+  it('resolves a mix of live, legacy, and dead-owner entries in one pass', async () => {
     fs.writeFileSync(path.join(dirRef.current, '10'), 'daemon-live');
     fs.writeFileSync(path.join(dirRef.current, '20'), 'ws-legacy');
     fs.writeFileSync(path.join(dirRef.current, '30'), 'daemon-dead');
@@ -123,7 +135,21 @@ describe('a2a.resolve.identity — live ownership resolution', () => {
 
     const mappings = await resolveIdentity(setupRouter());
 
-    expect(mappings).toEqual({ '10': 'ws-A', '20': 'ws-legacy' });
+    // Legacy '20' is dropped; '30' resolves to null (dead owner) and is omitted.
+    expect(mappings).toEqual({ '10': 'ws-A' });
+    expect(listFiles()).toEqual(['10', '30']); // legacy file purged, others kept
+  });
+
+  it('purges multiple legacy files in one pass without any renderer call', async () => {
+    fs.writeFileSync(path.join(dirRef.current, '40'), 'ws-old-a');
+    fs.writeFileSync(path.join(dirRef.current, '50'), 'ws-old-b');
+    fs.writeFileSync(path.join(dirRef.current, '60'), 'ws-old-c');
+
+    const mappings = await resolveIdentity(setupRouter());
+
+    expect(mappings).toEqual({});
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+    expect(listFiles()).toEqual([]);
   });
 
   it('returns an empty map when no pid-map dir exists', async () => {

--- a/src/main/pipe/handlers/__tests__/a2a.rpc.resolveIdentity.test.ts
+++ b/src/main/pipe/handlers/__tests__/a2a.rpc.resolveIdentity.test.ts
@@ -98,58 +98,17 @@ describe('a2a.resolve.identity — live ownership resolution', () => {
     expect(listFiles()).toEqual(['2222']); // not pruned on the read path
   });
 
-  it('purges a legacy ws- entry that is ABSENT from the live workspace list', async () => {
-    // Legacy PID→workspaceId with no matching live workspace = a re-minted/closed
-    // ghost (or a recycled PID). Verified absent → purge it (this case was the
-    // root cause of the ghost bug).
+  it('DROPS legacy PID→workspaceId entries (ws- prefix) and deletes the file', async () => {
+    // Legacy entries have no ptyId anchor, cannot be live-resolved, and on a
+    // recycled PID surface as a ghost workspace. They must be purged, not passed
+    // through (the old passthrough behavior was the root cause of the ghost bug).
     fs.writeFileSync(path.join(dirRef.current, '3333'), 'ws-legacy-frozen');
-    sendToRendererMock.mockImplementation((_w: unknown, method: string) => {
-      if (method === 'workspace.list') return Promise.resolve([{ id: 'ws-something-else' }]);
-      return Promise.resolve({ workspaceId: null });
-    });
 
     const mappings = await resolveIdentity(setupRouter());
 
     expect(mappings).toEqual({});
-    expect(sendToRendererMock).toHaveBeenCalledWith(expect.anything(), 'workspace.list');
-    expect(listFiles()).toEqual([]); // ghost file purged
-  });
-
-  it('KEEPS and resolves a legacy ws- entry that is LIVE (upgraded pane anchor)', async () => {
-    // A pane created by an older version, still running after an upgrade, carries
-    // a legacy entry as its only identity anchor. If the workspace is live,
-    // resolve to it and keep the file — purging it would orphan the pane's MCP
-    // children ("no active workspace"), the very symptom the fix cures.
-    fs.writeFileSync(path.join(dirRef.current, '3434'), 'ws-still-live');
-    sendToRendererMock.mockImplementation((_w: unknown, method: string) => {
-      if (method === 'workspace.list') {
-        return Promise.resolve([{ id: 'ws-still-live' }, { id: 'ws-other' }]);
-      }
-      return Promise.resolve({ workspaceId: null });
-    });
-
-    const mappings = await resolveIdentity(setupRouter());
-
-    expect(mappings).toEqual({ '3434': 'ws-still-live' });
-    expect(listFiles()).toEqual(['3434']); // live anchor preserved
-  });
-
-  it('KEEPS a legacy ws- entry when the workspace list is unavailable (unknown)', async () => {
-    // The retryable "still starting" envelope (or any non-array) is NOT proof of
-    // death. Keep the entry and skip — the caller retries — so a boot race never
-    // deletes a genuinely-live anchor.
-    fs.writeFileSync(path.join(dirRef.current, '3535'), 'ws-maybe-live');
-    sendToRendererMock.mockImplementation((_w: unknown, method: string) => {
-      if (method === 'workspace.list') {
-        return Promise.resolve({ error: 'wmux is still starting', retryable: true });
-      }
-      return Promise.resolve({ workspaceId: null });
-    });
-
-    const mappings = await resolveIdentity(setupRouter());
-
-    expect(mappings).toEqual({});
-    expect(listFiles()).toEqual(['3535']); // not purged on 'unknown'
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+    expect(listFiles()).toEqual([]); // file purged
   });
 
   it('skips an entry when the renderer lookup throws (early boot / reload)', async () => {
@@ -163,40 +122,33 @@ describe('a2a.resolve.identity — live ownership resolution', () => {
     expect(listFiles()).toEqual(['4444']);
   });
 
-  it('resolves a mix of live, absent-legacy, and dead-owner entries in one pass', async () => {
+  it('resolves a mix of live, legacy, and dead-owner entries in one pass', async () => {
     fs.writeFileSync(path.join(dirRef.current, '10'), 'daemon-live');
     fs.writeFileSync(path.join(dirRef.current, '20'), 'ws-legacy');
     fs.writeFileSync(path.join(dirRef.current, '30'), 'daemon-dead');
     sendToRendererMock.mockImplementation(
-      (_w: unknown, method: string, params?: { ptyId: string }) => {
-        if (method === 'workspace.list') return Promise.resolve([{ id: 'ws-A' }]); // ws-legacy absent
-        return Promise.resolve({ workspaceId: params?.ptyId === 'daemon-live' ? 'ws-A' : null });
-      },
+      (_w: unknown, _method: string, params: { ptyId: string }) =>
+        Promise.resolve({
+          workspaceId: params.ptyId === 'daemon-live' ? 'ws-A' : null,
+        }),
     );
 
     const mappings = await resolveIdentity(setupRouter());
 
-    // Legacy '20' (ws-legacy) is absent from the live list → purged; '30'
-    // resolves to null (dead owner) → omitted but kept on disk.
+    // Legacy '20' is dropped; '30' resolves to null (dead owner) and is omitted.
     expect(mappings).toEqual({ '10': 'ws-A' });
-    expect(listFiles()).toEqual(['10', '30']);
+    expect(listFiles()).toEqual(['10', '30']); // legacy file purged, others kept
   });
 
-  it('purges multiple absent legacy files with a single workspace.list lookup', async () => {
+  it('purges multiple legacy files in one pass without any renderer call', async () => {
     fs.writeFileSync(path.join(dirRef.current, '40'), 'ws-old-a');
     fs.writeFileSync(path.join(dirRef.current, '50'), 'ws-old-b');
     fs.writeFileSync(path.join(dirRef.current, '60'), 'ws-old-c');
-    sendToRendererMock.mockImplementation((_w: unknown, method: string) => {
-      if (method === 'workspace.list') return Promise.resolve([]); // none live
-      return Promise.resolve({ workspaceId: null });
-    });
 
     const mappings = await resolveIdentity(setupRouter());
 
     expect(mappings).toEqual({});
-    // The live list is fetched once and cached for the whole pass.
-    const listCalls = sendToRendererMock.mock.calls.filter((c) => c[1] === 'workspace.list');
-    expect(listCalls).toHaveLength(1);
+    expect(sendToRendererMock).not.toHaveBeenCalled();
     expect(listFiles()).toEqual([]);
   });
 

--- a/src/main/pipe/handlers/__tests__/a2a.rpc.resolveIdentity.test.ts
+++ b/src/main/pipe/handlers/__tests__/a2a.rpc.resolveIdentity.test.ts
@@ -98,17 +98,58 @@ describe('a2a.resolve.identity — live ownership resolution', () => {
     expect(listFiles()).toEqual(['2222']); // not pruned on the read path
   });
 
-  it('DROPS legacy PID→workspaceId entries (ws- prefix) and deletes the file', async () => {
-    // Legacy entries have no ptyId anchor, cannot be live-resolved, and on a
-    // recycled PID surface as a ghost workspace. They must be purged, not passed
-    // through (the old passthrough behavior was the root cause of the ghost bug).
+  it('purges a legacy ws- entry that is ABSENT from the live workspace list', async () => {
+    // Legacy PID→workspaceId with no matching live workspace = a re-minted/closed
+    // ghost (or a recycled PID). Verified absent → purge it (this case was the
+    // root cause of the ghost bug).
     fs.writeFileSync(path.join(dirRef.current, '3333'), 'ws-legacy-frozen');
+    sendToRendererMock.mockImplementation((_w: unknown, method: string) => {
+      if (method === 'workspace.list') return Promise.resolve([{ id: 'ws-something-else' }]);
+      return Promise.resolve({ workspaceId: null });
+    });
 
     const mappings = await resolveIdentity(setupRouter());
 
     expect(mappings).toEqual({});
-    expect(sendToRendererMock).not.toHaveBeenCalled();
-    expect(listFiles()).toEqual([]); // file purged
+    expect(sendToRendererMock).toHaveBeenCalledWith(expect.anything(), 'workspace.list');
+    expect(listFiles()).toEqual([]); // ghost file purged
+  });
+
+  it('KEEPS and resolves a legacy ws- entry that is LIVE (upgraded pane anchor)', async () => {
+    // A pane created by an older version, still running after an upgrade, carries
+    // a legacy entry as its only identity anchor. If the workspace is live,
+    // resolve to it and keep the file — purging it would orphan the pane's MCP
+    // children ("no active workspace"), the very symptom the fix cures.
+    fs.writeFileSync(path.join(dirRef.current, '3434'), 'ws-still-live');
+    sendToRendererMock.mockImplementation((_w: unknown, method: string) => {
+      if (method === 'workspace.list') {
+        return Promise.resolve([{ id: 'ws-still-live' }, { id: 'ws-other' }]);
+      }
+      return Promise.resolve({ workspaceId: null });
+    });
+
+    const mappings = await resolveIdentity(setupRouter());
+
+    expect(mappings).toEqual({ '3434': 'ws-still-live' });
+    expect(listFiles()).toEqual(['3434']); // live anchor preserved
+  });
+
+  it('KEEPS a legacy ws- entry when the workspace list is unavailable (unknown)', async () => {
+    // The retryable "still starting" envelope (or any non-array) is NOT proof of
+    // death. Keep the entry and skip — the caller retries — so a boot race never
+    // deletes a genuinely-live anchor.
+    fs.writeFileSync(path.join(dirRef.current, '3535'), 'ws-maybe-live');
+    sendToRendererMock.mockImplementation((_w: unknown, method: string) => {
+      if (method === 'workspace.list') {
+        return Promise.resolve({ error: 'wmux is still starting', retryable: true });
+      }
+      return Promise.resolve({ workspaceId: null });
+    });
+
+    const mappings = await resolveIdentity(setupRouter());
+
+    expect(mappings).toEqual({});
+    expect(listFiles()).toEqual(['3535']); // not purged on 'unknown'
   });
 
   it('skips an entry when the renderer lookup throws (early boot / reload)', async () => {
@@ -122,33 +163,40 @@ describe('a2a.resolve.identity — live ownership resolution', () => {
     expect(listFiles()).toEqual(['4444']);
   });
 
-  it('resolves a mix of live, legacy, and dead-owner entries in one pass', async () => {
+  it('resolves a mix of live, absent-legacy, and dead-owner entries in one pass', async () => {
     fs.writeFileSync(path.join(dirRef.current, '10'), 'daemon-live');
     fs.writeFileSync(path.join(dirRef.current, '20'), 'ws-legacy');
     fs.writeFileSync(path.join(dirRef.current, '30'), 'daemon-dead');
     sendToRendererMock.mockImplementation(
-      (_w: unknown, _method: string, params: { ptyId: string }) =>
-        Promise.resolve({
-          workspaceId: params.ptyId === 'daemon-live' ? 'ws-A' : null,
-        }),
+      (_w: unknown, method: string, params?: { ptyId: string }) => {
+        if (method === 'workspace.list') return Promise.resolve([{ id: 'ws-A' }]); // ws-legacy absent
+        return Promise.resolve({ workspaceId: params?.ptyId === 'daemon-live' ? 'ws-A' : null });
+      },
     );
 
     const mappings = await resolveIdentity(setupRouter());
 
-    // Legacy '20' is dropped; '30' resolves to null (dead owner) and is omitted.
+    // Legacy '20' (ws-legacy) is absent from the live list → purged; '30'
+    // resolves to null (dead owner) → omitted but kept on disk.
     expect(mappings).toEqual({ '10': 'ws-A' });
-    expect(listFiles()).toEqual(['10', '30']); // legacy file purged, others kept
+    expect(listFiles()).toEqual(['10', '30']);
   });
 
-  it('purges multiple legacy files in one pass without any renderer call', async () => {
+  it('purges multiple absent legacy files with a single workspace.list lookup', async () => {
     fs.writeFileSync(path.join(dirRef.current, '40'), 'ws-old-a');
     fs.writeFileSync(path.join(dirRef.current, '50'), 'ws-old-b');
     fs.writeFileSync(path.join(dirRef.current, '60'), 'ws-old-c');
+    sendToRendererMock.mockImplementation((_w: unknown, method: string) => {
+      if (method === 'workspace.list') return Promise.resolve([]); // none live
+      return Promise.resolve({ workspaceId: null });
+    });
 
     const mappings = await resolveIdentity(setupRouter());
 
     expect(mappings).toEqual({});
-    expect(sendToRendererMock).not.toHaveBeenCalled();
+    // The live list is fetched once and cached for the whole pass.
+    const listCalls = sendToRendererMock.mock.calls.filter((c) => c[1] === 'workspace.list');
+    expect(listCalls).toHaveLength(1);
     expect(listFiles()).toEqual([]);
   });
 

--- a/src/main/pipe/handlers/a2a.rpc.ts
+++ b/src/main/pipe/handlers/a2a.rpc.ts
@@ -22,38 +22,52 @@ export function registerA2aRpc(router: RpcRouter, getWindow: GetWindow, claudeWo
     const dir = getPidMapDir();
     const mappings: Record<string, string> = {};
     try {
-      if (fs.existsSync(dir)) {
-        for (const file of fs.readdirSync(dir)) {
-          let value: string;
-          try {
-            value = fs.readFileSync(`${dir}/${file}`, 'utf8').trim();
-          } catch {
-            continue; // unreadable / racing-unlink entry — skip
-          }
-          if (!value) continue;
+      if (!fs.existsSync(dir)) return { mappings };
 
-          if (value.startsWith('ws-')) {
-            // Legacy entry written before the live-ownership change
-            // (PID → workspaceId). Pass it through best-effort; it is
-            // overwritten with a ptyId on the next session create/reconnect.
-            mappings[file] = value;
-            continue;
-          }
+      for (const file of fs.readdirSync(dir)) {
+        let value: string;
+        try {
+          value = fs.readFileSync(`${dir}/${file}`, 'utf8').trim();
+        } catch {
+          continue; // unreadable / racing-unlink entry — skip
+        }
+        if (!value) continue;
 
-          // Current format: PID → ptyId. Resolve the workspace that owns this
-          // pty RIGHT NOW. PID → ptyId is immutable for the process lifetime;
-          // only the pty → workspace edge changes, and that is read live.
-          try {
-            const owner = await sendToRenderer(getWindow, 'input.findOwnerWorkspace', { ptyId: value });
-            const wsId =
-              owner && typeof owner === 'object' && 'workspaceId' in owner
-                ? (owner as Record<string, unknown>)['workspaceId']
-                : null;
-            if (typeof wsId === 'string' && wsId) mappings[file] = wsId;
-          } catch {
-            // Renderer unavailable (early boot / reload) — skip this entry;
-            // the caller retries resolution on its next identity-gated call.
-          }
+        // Drop legacy "PID → workspaceId" entries unconditionally. They have no
+        // ptyId anchor so they cannot be live-resolved; the old code passed them
+        // through verbatim, handing back a frozen id that goes stale the moment
+        // the workspace is re-minted (daemon respawn / session restore). Worse,
+        // the OS recycles PID numbers onto unrelated live processes (Notepad /
+        // Discord / RuntimeBroker observed in the wild), so a legacy entry on a
+        // recycled-but-live PID resurfaces as a ghost workspace (browser_open →
+        // "no active workspace"; terminal ops → "not owned by workspace ws-…").
+        // The current writer only ever stores ptyIds, so any "ws-" value is pure
+        // legacy debris — purge it. This is the single largest ghost source and
+        // is safe to delete on this read path (no liveness probe, no race).
+        if (value.startsWith('ws-')) {
+          try { fs.unlinkSync(`${dir}/${file}`); } catch { /* best-effort */ }
+          continue;
+        }
+
+        // Current format: PID → ptyId. Resolve the workspace that owns this pty
+        // RIGHT NOW. PID → ptyId is immutable for the process lifetime; only the
+        // pty → workspace edge changes, and that is read live. A dead or
+        // recycled-but-live PID whose stored ptyId no longer exists resolves to
+        // null here and is correctly excluded — so a stale current-format file
+        // can never produce a ghost and is harmless if left on disk. Accretion
+        // is bounded instead at the write boundary (see pty.handler.ts
+        // onDaemonSessionDied cleanup); pruning here would add a destructive
+        // tasklist probe to the hot path with no correctness benefit.
+        try {
+          const owner = await sendToRenderer(getWindow, 'input.findOwnerWorkspace', { ptyId: value });
+          const wsId =
+            owner && typeof owner === 'object' && 'workspaceId' in owner
+              ? (owner as Record<string, unknown>)['workspaceId']
+              : null;
+          if (typeof wsId === 'string' && wsId) mappings[file] = wsId;
+        } catch {
+          // Renderer unavailable (early boot / reload) — skip this entry;
+          // the caller retries resolution on its next identity-gated call.
         }
       }
     } catch { /* best-effort: identity resolution is non-critical */ }

--- a/src/main/pipe/handlers/a2a.rpc.ts
+++ b/src/main/pipe/handlers/a2a.rpc.ts
@@ -7,32 +7,6 @@ import { getPidMapDir } from '../../../shared/constants';
 
 type GetWindow = () => BrowserWindow | null;
 
-/**
- * Fetch the live workspace ids from the renderer for verifying legacy
- * "PID → workspaceId" pid-map entries. Returns a Set of live ids, or `null`
- * when the list can't be confirmed (renderer unavailable, or the retryable
- * "still starting" envelope) so callers treat that as 'unknown' and never
- * purge on it. Mirrors classifyWorkspaceListResult's array/{workspaces} shape
- * tolerance and its require-positive-proof discipline.
- */
-async function fetchLiveWorkspaceIds(getWindow: GetWindow): Promise<Set<string> | null> {
-  try {
-    const result = await sendToRenderer(getWindow, 'workspace.list');
-    const list = Array.isArray(result)
-      ? result
-      : (result as { workspaces?: unknown[] } | null)?.workspaces;
-    if (!Array.isArray(list)) return null; // 'unknown' — not a confirmed list
-    const ids = new Set<string>();
-    for (const w of list) {
-      const id = w && typeof w === 'object' ? (w as Record<string, unknown>)['id'] : null;
-      if (typeof id === 'string' && id) ids.add(id);
-    }
-    return ids;
-  } catch {
-    return null; // renderer unavailable — 'unknown', never purge on this
-  }
-}
-
 export function registerA2aRpc(router: RpcRouter, getWindow: GetWindow, claudeWorker: ClaudeWorker): void {
   // a2a.resolve.identity — handled in main process (not renderer).
   // Returns PID → CURRENT workspaceId mappings so an MCP server can resolve
@@ -47,12 +21,6 @@ export function registerA2aRpc(router: RpcRouter, getWindow: GetWindow, claudeWo
   router.register('a2a.resolve.identity', async () => {
     const dir = getPidMapDir();
     const mappings: Record<string, string> = {};
-    // Live workspace ids, fetched lazily on the first legacy entry and cached
-    // for the rest of this call. `undefined` = not fetched yet; `null` = the
-    // list is transiently unavailable (renderer booting / reloading); a Set =
-    // the confirmed live set. One renderer round-trip at most per call, and
-    // only when a legacy entry actually exists.
-    let liveWorkspaceIds: Set<string> | null | undefined;
     try {
       if (!fs.existsSync(dir)) return { mappings };
 
@@ -65,31 +33,31 @@ export function registerA2aRpc(router: RpcRouter, getWindow: GetWindow, claudeWo
         }
         if (!value) continue;
 
-        // Legacy "PID → workspaceId" entries. These predate the ptyId anchor
-        // and have no pty to live-resolve, but a pane created by an OLDER
-        // version that is still running after an upgrade may carry one as its
-        // ONLY identity anchor (Claude Code doesn't propagate WMUX_WORKSPACE_ID
-        // to MCP child processes, so the on-disk map is all the MCP server has).
-        // The old fix purged every "ws-" entry unconditionally, which deleted
-        // those live anchors and left the upgraded pane resolving to no
-        // workspace — the very "no active workspace" symptom this is meant to
-        // cure. Instead, verify the workspaceId against the live workspace list
-        // (the same positive-proof discipline as the env-hint gate):
-        //   - live   → resolve to it AND keep the file (genuine upgraded pane).
-        //   - absent → purge it (a re-minted/closed ghost; the OS can recycle
-        //              its PID onto an unrelated live process, the ghost source).
-        //   - unknown (list unavailable) → keep and skip; the caller retries, so
-        //              a boot race never deletes a genuinely-live anchor.
+        // Drop legacy "PID → workspaceId" entries unconditionally. They have no
+        // ptyId anchor so they cannot be live-resolved; the old code passed them
+        // through verbatim, handing back a frozen id that goes stale the moment
+        // the workspace is re-minted (daemon respawn / session restore). Worse,
+        // the OS recycles PID numbers onto unrelated live processes (Notepad /
+        // Discord / RuntimeBroker observed in the wild), so a legacy entry on a
+        // recycled-but-live PID resurfaces as a ghost workspace (browser_open →
+        // "no active workspace"; terminal ops → "not owned by workspace ws-…").
+        // The current writer only ever stores ptyIds, so any "ws-" value is pure
+        // legacy debris — purge it. This is the single largest ghost source and
+        // is safe to delete on this read path (no liveness probe, no race).
+        //
+        // We deliberately do NOT "keep it if its workspace is still live"
+        // (considered, then rejected): workspace.list proves only that the
+        // workspace exists, not that this PID file still belongs to that pane.
+        // Legacy files are PID-keyed with ws- content, so removePidMapByPtyId
+        // (keyed by ptyId content) can never prune them — a kept entry lives
+        // forever, and once the OS recycles its PID onto another MCP server's
+        // ancestor it mis-routes commands to a live-but-WRONG workspace (worse
+        // than the dead-id ghost: silent, not a hard failure). Unverifiable +
+        // unprunable ⇒ unconditional purge is the only safe policy. A genuinely
+        // live pane re-anchors with a current-format ptyId entry on its next
+        // reconnect, so nothing is permanently lost.
         if (value.startsWith('ws-')) {
-          if (liveWorkspaceIds === undefined) {
-            liveWorkspaceIds = await fetchLiveWorkspaceIds(getWindow);
-          }
-          if (liveWorkspaceIds === null) continue; // unknown — keep, don't resolve
-          if (liveWorkspaceIds.has(value)) {
-            mappings[file] = value; // live pre-upgrade pane — resolve to it
-          } else {
-            try { fs.unlinkSync(`${dir}/${file}`); } catch { /* best-effort */ }
-          }
+          try { fs.unlinkSync(`${dir}/${file}`); } catch { /* best-effort */ }
           continue;
         }
 

--- a/src/main/pipe/handlers/a2a.rpc.ts
+++ b/src/main/pipe/handlers/a2a.rpc.ts
@@ -7,6 +7,32 @@ import { getPidMapDir } from '../../../shared/constants';
 
 type GetWindow = () => BrowserWindow | null;
 
+/**
+ * Fetch the live workspace ids from the renderer for verifying legacy
+ * "PID → workspaceId" pid-map entries. Returns a Set of live ids, or `null`
+ * when the list can't be confirmed (renderer unavailable, or the retryable
+ * "still starting" envelope) so callers treat that as 'unknown' and never
+ * purge on it. Mirrors classifyWorkspaceListResult's array/{workspaces} shape
+ * tolerance and its require-positive-proof discipline.
+ */
+async function fetchLiveWorkspaceIds(getWindow: GetWindow): Promise<Set<string> | null> {
+  try {
+    const result = await sendToRenderer(getWindow, 'workspace.list');
+    const list = Array.isArray(result)
+      ? result
+      : (result as { workspaces?: unknown[] } | null)?.workspaces;
+    if (!Array.isArray(list)) return null; // 'unknown' — not a confirmed list
+    const ids = new Set<string>();
+    for (const w of list) {
+      const id = w && typeof w === 'object' ? (w as Record<string, unknown>)['id'] : null;
+      if (typeof id === 'string' && id) ids.add(id);
+    }
+    return ids;
+  } catch {
+    return null; // renderer unavailable — 'unknown', never purge on this
+  }
+}
+
 export function registerA2aRpc(router: RpcRouter, getWindow: GetWindow, claudeWorker: ClaudeWorker): void {
   // a2a.resolve.identity — handled in main process (not renderer).
   // Returns PID → CURRENT workspaceId mappings so an MCP server can resolve
@@ -21,6 +47,12 @@ export function registerA2aRpc(router: RpcRouter, getWindow: GetWindow, claudeWo
   router.register('a2a.resolve.identity', async () => {
     const dir = getPidMapDir();
     const mappings: Record<string, string> = {};
+    // Live workspace ids, fetched lazily on the first legacy entry and cached
+    // for the rest of this call. `undefined` = not fetched yet; `null` = the
+    // list is transiently unavailable (renderer booting / reloading); a Set =
+    // the confirmed live set. One renderer round-trip at most per call, and
+    // only when a legacy entry actually exists.
+    let liveWorkspaceIds: Set<string> | null | undefined;
     try {
       if (!fs.existsSync(dir)) return { mappings };
 
@@ -33,19 +65,31 @@ export function registerA2aRpc(router: RpcRouter, getWindow: GetWindow, claudeWo
         }
         if (!value) continue;
 
-        // Drop legacy "PID → workspaceId" entries unconditionally. They have no
-        // ptyId anchor so they cannot be live-resolved; the old code passed them
-        // through verbatim, handing back a frozen id that goes stale the moment
-        // the workspace is re-minted (daemon respawn / session restore). Worse,
-        // the OS recycles PID numbers onto unrelated live processes (Notepad /
-        // Discord / RuntimeBroker observed in the wild), so a legacy entry on a
-        // recycled-but-live PID resurfaces as a ghost workspace (browser_open →
-        // "no active workspace"; terminal ops → "not owned by workspace ws-…").
-        // The current writer only ever stores ptyIds, so any "ws-" value is pure
-        // legacy debris — purge it. This is the single largest ghost source and
-        // is safe to delete on this read path (no liveness probe, no race).
+        // Legacy "PID → workspaceId" entries. These predate the ptyId anchor
+        // and have no pty to live-resolve, but a pane created by an OLDER
+        // version that is still running after an upgrade may carry one as its
+        // ONLY identity anchor (Claude Code doesn't propagate WMUX_WORKSPACE_ID
+        // to MCP child processes, so the on-disk map is all the MCP server has).
+        // The old fix purged every "ws-" entry unconditionally, which deleted
+        // those live anchors and left the upgraded pane resolving to no
+        // workspace — the very "no active workspace" symptom this is meant to
+        // cure. Instead, verify the workspaceId against the live workspace list
+        // (the same positive-proof discipline as the env-hint gate):
+        //   - live   → resolve to it AND keep the file (genuine upgraded pane).
+        //   - absent → purge it (a re-minted/closed ghost; the OS can recycle
+        //              its PID onto an unrelated live process, the ghost source).
+        //   - unknown (list unavailable) → keep and skip; the caller retries, so
+        //              a boot race never deletes a genuinely-live anchor.
         if (value.startsWith('ws-')) {
-          try { fs.unlinkSync(`${dir}/${file}`); } catch { /* best-effort */ }
+          if (liveWorkspaceIds === undefined) {
+            liveWorkspaceIds = await fetchLiveWorkspaceIds(getWindow);
+          }
+          if (liveWorkspaceIds === null) continue; // unknown — keep, don't resolve
+          if (liveWorkspaceIds.has(value)) {
+            mappings[file] = value; // live pre-upgrade pane — resolve to it
+          } else {
+            try { fs.unlinkSync(`${dir}/${file}`); } catch { /* best-effort */ }
+          }
           continue;
         }
 

--- a/src/main/pty/__tests__/pidMap.test.ts
+++ b/src/main/pty/__tests__/pidMap.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { writePidMap, removePidMapByPtyId } from '../pidMap';
+
+/**
+ * Behavioral test for the pid-map fs primitives behind the ghost-identity fix.
+ *
+ * The structural test (src/main/ipc/__tests__/pty.handler.pidmap-prune.test.ts)
+ * proves the dispose + session:died handlers CALL removePidMapByPtyId. This one
+ * proves the call actually does the right thing on a real filesystem — the
+ * content-keying invariant the whole ghost defense rests on: prune by file
+ * CONTENT (ptyId), never by filename (the recyclable OS PID).
+ *
+ * getPidMapDir() resolves `${USERPROFILE || HOME}/.wmux/pid-map` at call time,
+ * so we redirect both env vars at a throwaway tmpdir and run the real code.
+ */
+describe('pidMap fs primitives', () => {
+  let tmp: string;
+  let savedUserProfile: string | undefined;
+  let savedHome: string | undefined;
+  let mapDir: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-pidmap-'));
+    savedUserProfile = process.env.USERPROFILE;
+    savedHome = process.env.HOME;
+    // getPidMapDir() prefers USERPROFILE, falls back to HOME — pin both so the
+    // test is platform-independent.
+    process.env.USERPROFILE = tmp;
+    process.env.HOME = tmp;
+    mapDir = path.join(tmp, '.wmux', 'pid-map');
+    fs.mkdirSync(mapDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (savedUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = savedUserProfile;
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const seed = (pid: string | number, ptyId: string) =>
+    fs.writeFileSync(path.join(mapDir, String(pid)), ptyId, 'utf8');
+  const exists = (pid: string | number) =>
+    fs.existsSync(path.join(mapDir, String(pid)));
+
+  it('writePidMap creates the dir and writes ptyId as the file CONTENT', () => {
+    writePidMap(1234, 'daemon-abc');
+    expect(exists(1234)).toBe(true);
+    expect(fs.readFileSync(path.join(mapDir, '1234'), 'utf8')).toBe('daemon-abc');
+  });
+
+  it('removePidMapByPtyId deletes EVERY entry whose content matches the ptyId', () => {
+    // The accretion case: one ptyId can have multiple PID anchors (shell
+    // respawn / reconnect writes a fresh PID without removing the old one).
+    // Pruning must sweep them all in one call.
+    seed(100, 'daemon-A');
+    seed(200, 'daemon-A');
+    seed(300, 'daemon-B');
+
+    removePidMapByPtyId('daemon-A');
+
+    expect(exists(100)).toBe(false);
+    expect(exists(200)).toBe(false);
+    expect(exists(300)).toBe(true); // unrelated ptyId untouched
+  });
+
+  it('matches by CONTENT, not by filename — a PID-named file is NOT removed by PID', () => {
+    // Guards the core ghost invariant. If the prune ever flipped to filename
+    // matching, recycled-PID entries (the ones that produce ghosts) would
+    // survive while a same-numbered live anchor got wrongly deleted.
+    seed(555, 'daemon-X'); // filename "555", content "daemon-X"
+
+    removePidMapByPtyId('555'); // ask to prune ptyId "555" — content, not name
+    expect(exists(555)).toBe(true); // file named 555 stays (its content ≠ "555")
+
+    removePidMapByPtyId('daemon-X'); // prune by actual content
+    expect(exists(555)).toBe(false);
+  });
+
+  it('trims trailing whitespace/newline before comparing content', () => {
+    // Anchors written by other paths may carry a trailing newline; the match
+    // must be whitespace-insensitive or stale entries would never clear.
+    fs.writeFileSync(path.join(mapDir, '777'), 'daemon-nl\n', 'utf8');
+    removePidMapByPtyId('daemon-nl');
+    expect(exists(777)).toBe(false);
+  });
+
+  it('is a safe no-op on empty ptyId and a missing map dir', () => {
+    seed(900, 'daemon-keep');
+    removePidMapByPtyId(''); // empty → must not nuke the whole dir
+    expect(exists(900)).toBe(true);
+
+    // Missing dir must not throw.
+    fs.rmSync(mapDir, { recursive: true, force: true });
+    expect(() => removePidMapByPtyId('daemon-anything')).not.toThrow();
+  });
+});

--- a/src/main/pty/pidMap.ts
+++ b/src/main/pty/pidMap.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { getPidMapDir } from '../../shared/constants';
+
+/**
+ * PID ↔ ptyId on-disk map (~/.wmux/pid-map/<PID> → ptyId).
+ *
+ * This is the anchor MCP uses to resolve workspace identity when env vars don't
+ * propagate to Claude Code's MCP child processes. The fs primitives live here —
+ * free of electron / daemon imports — so they can be behavior-tested directly
+ * (the pty.handler module they're called from pulls in electron and can't be
+ * imported under vitest, which is why its other tests are source-structural).
+ */
+
+/**
+ * Write a PID → ptyId mapping for MCP workspace-identity resolution.
+ *
+ * We deliberately store the ptyId, NOT the workspaceId: a workspace id can be
+ * re-minted (daemon respawn / session restore) while the shell process lives
+ * on, so a frozen workspace id goes stale. The ptyId is immutable for the
+ * process lifetime; `a2a.resolve.identity` maps ptyId → the CURRENT owning
+ * workspace at lookup time. (Claude Code doesn't propagate env vars to MCP
+ * child processes, so this on-disk map is the resolution anchor.)
+ */
+export function writePidMap(pid: string | number, ptyId: string): void {
+  try {
+    const dir = getPidMapDir();
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, String(pid)), ptyId, 'utf8');
+  } catch { /* best-effort */ }
+}
+
+/**
+ * Remove every pid-map file pointing at `ptyId`. Pruned at the WRITE boundary
+ * instead of on the read hot-path. Daemon sessions otherwise leak a file per
+ * shell forever (writePidMap has no PID-keyed remove pair here, unlike
+ * PTYManager.dispose), which let the OS recycle those PIDs onto unrelated
+ * processes — the accretion behind the ghost-workspace bug.
+ *
+ * Called from BOTH daemon-owned teardown paths (in pty.handler.ts):
+ *  - session:died (onDaemonSessionDied): natural/unexpected PTY exit.
+ *  - pty:dispose: explicit close (pane/workspace close) → daemon.destroySession,
+ *    which emits session:destroyed — NOT session:died — so the died handler
+ *    never fires for it. Without pruning here too, every UI-driven close (the
+ *    common path) would still leak its anchor.
+ *
+ * Keyed by ptyId (content) because the session:died payload and the dispose
+ * arg both carry the sessionId/ptyId, not the OS PID. Matching by filename
+ * (the PID) instead would miss recycled-PID entries and let the ghost
+ * accretion return.
+ */
+export function removePidMapByPtyId(ptyId: string): void {
+  if (!ptyId) return;
+  try {
+    const dir = getPidMapDir();
+    if (!fs.existsSync(dir)) return;
+    for (const file of fs.readdirSync(dir)) {
+      try {
+        if (fs.readFileSync(path.join(dir, file), 'utf8').trim() === ptyId) {
+          fs.unlinkSync(path.join(dir, file));
+        }
+      } catch { /* unreadable / racing-unlink — skip */ }
+    }
+  } catch { /* best-effort */ }
+}

--- a/src/mcp/__tests__/workspaceIdentity.test.ts
+++ b/src/mcp/__tests__/workspaceIdentity.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { classifyWorkspaceListResult } from '../workspaceIdentity';
+
+const WS = 'ws-target-1234';
+
+describe('classifyWorkspaceListResult — env-hint liveness gate', () => {
+  it('returns "live" when a bare array contains the id', () => {
+    const result = [{ id: 'ws-other' }, { id: WS }, { id: 'ws-more' }];
+    expect(classifyWorkspaceListResult(result, WS)).toBe('live');
+  });
+
+  it('returns "absent" when a bare array does NOT contain the id (confirmed ghost)', () => {
+    const result = [{ id: 'ws-other' }, { id: 'ws-more' }];
+    expect(classifyWorkspaceListResult(result, WS)).toBe('absent');
+  });
+
+  it('returns "absent" for an empty array', () => {
+    expect(classifyWorkspaceListResult([], WS)).toBe('absent');
+  });
+
+  it('unwraps a { workspaces: [...] } envelope — live', () => {
+    const result = { workspaces: [{ id: WS }] };
+    expect(classifyWorkspaceListResult(result, WS)).toBe('live');
+  });
+
+  it('unwraps a { workspaces: [...] } envelope — absent', () => {
+    const result = { workspaces: [{ id: 'ws-other' }] };
+    expect(classifyWorkspaceListResult(result, WS)).toBe('absent');
+  });
+
+  it('returns "unknown" for the renderer retryable "still starting" envelope', () => {
+    // This is the boot-reconcile shape the renderer returns while paneGate is
+    // pending. It must NOT be read as "absent" — the hint may be perfectly valid.
+    const result = { error: 'wmux is still starting (paneGate=pending)', retryable: true };
+    expect(classifyWorkspaceListResult(result, WS)).toBe('unknown');
+  });
+
+  it('returns "unknown" for null / undefined', () => {
+    expect(classifyWorkspaceListResult(null, WS)).toBe('unknown');
+    expect(classifyWorkspaceListResult(undefined, WS)).toBe('unknown');
+  });
+
+  it('returns "unknown" for non-array primitives', () => {
+    expect(classifyWorkspaceListResult('oops', WS)).toBe('unknown');
+    expect(classifyWorkspaceListResult(42, WS)).toBe('unknown');
+  });
+
+  it('ignores malformed (non-object) entries inside the array', () => {
+    const result = [null, 'junk', { id: WS }];
+    expect(classifyWorkspaceListResult(result, WS)).toBe('live');
+  });
+
+  it('does not match when entries lack an id field', () => {
+    const result = [{ name: 'Workspace 1' }, { metadata: {} }];
+    expect(classifyWorkspaceListResult(result, WS)).toBe('absent');
+  });
+});

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { clearClientIdentity, sendRpc, setClientIdentity } from './wmux-client';
 import type { RpcMethod } from '../shared/rpc';
 import { resolveDefaultPtyId as resolveDefaultPtyIdImpl } from './paneResolver';
+import { classifyWorkspaceListResult, type WorkspaceLiveness } from './workspaceIdentity';
 import { PlaywrightEngine } from './playwright/PlaywrightEngine';
 import { registerNavigationTools } from './playwright/tools/navigation';
 import { registerInteractionTools } from './playwright/tools/interaction';
@@ -127,12 +128,46 @@ async function resolveWorkspaceId(opts?: { force?: boolean; verifiedOnly?: boole
   // Security-sensitive routing (terminal default-pane resolution) asks for a
   // verified identity only; in that mode, never treat a user-supplied env var
   // as proof that the MCP server is running inside a wmux PTY.
-  if (!opts?.verifiedOnly && ENV_WORKSPACE_HINT) return ENV_WORKSPACE_HINT;
+  //
+  // Even for non-verified callers the hint must still not name a CONFIRMED
+  // ghost. The PID-map walk above already fails closed once legacy "ws-" debris
+  // is pruned (a2a.resolve.identity); the hint is the only remaining path a
+  // re-minted ghost id can leak through. Drop it ONLY on positive proof it is
+  // gone ('absent'); on 'unknown' (workspace.list transiently unavailable
+  // during boot reconcile) keep trusting the hint, since this fallback exists
+  // precisely to carry the call through while the RPC layer is briefly down.
+  // Not cached, so a later call re-checks once the renderer is ready.
+  if (!opts?.verifiedOnly && ENV_WORKSPACE_HINT) {
+    if ((await isLiveWorkspace(ENV_WORKSPACE_HINT)) !== 'absent') return ENV_WORKSPACE_HINT;
+  }
   return opts?.verifiedOnly ? '' : MY_WORKSPACE_ID;
 }
 
 function resolveVerifiedWorkspaceId(): Promise<string> {
   return resolveWorkspaceId({ force: true, verifiedOnly: true });
+}
+
+/**
+ * Classify whether `wsId` names a workspace that exists RIGHT NOW. Used to gate
+ * the env-hint fallback: WMUX_WORKSPACE_ID is frozen at PTY-create time, so
+ * after a daemon respawn / session restore the workspace id is re-minted and
+ * the hint becomes a ghost (absent from workspace.list). Routing into a ghost
+ * is what made browser_open fail with "no active workspace" and terminal ops
+ * throw "not owned by workspace ws-…".
+ *
+ * Returns 'absent' only on positive proof the id is gone; 'unknown' when
+ * workspace.list is unavailable (threw, or a retryable envelope during boot
+ * reconcile) so callers keep trusting the hint instead of hard-failing. The
+ * classification is shared with src/company/mcp via classifyWorkspaceListResult
+ * so both surfaces behave identically.
+ */
+async function isLiveWorkspace(wsId: string): Promise<WorkspaceLiveness> {
+  try {
+    const result = await sendRpc('workspace.list' as RpcMethod, {});
+    return classifyWorkspaceListResult(result, wsId);
+  } catch {
+    return 'unknown';
+  }
 }
 
 async function getParentPid(pid: number): Promise<number | null> {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -140,7 +140,20 @@ async function resolveWorkspaceId(opts?: { force?: boolean; verifiedOnly?: boole
   if (!opts?.verifiedOnly && ENV_WORKSPACE_HINT) {
     if ((await isLiveWorkspace(ENV_WORKSPACE_HINT)) !== 'absent') return ENV_WORKSPACE_HINT;
   }
-  return opts?.verifiedOnly ? '' : MY_WORKSPACE_ID;
+  if (opts?.verifiedOnly) return '';
+
+  // Last-resort cached identity. invalidateWorkspaceId() clears the
+  // `workspaceResolved` flag but NOT MY_WORKSPACE_ID, so a re-minted/closed
+  // workspace could otherwise leak back here and keep routing to a confirmed-
+  // dead id — the ghost loop this whole change exists to stop. Gate it exactly
+  // like the env hint: drop it only on positive proof it is 'absent' (and clear
+  // the cache so the next call re-resolves clean); keep it on 'unknown'
+  // (workspace.list transiently down) to carry the call through a boot blip.
+  if (MY_WORKSPACE_ID && (await isLiveWorkspace(MY_WORKSPACE_ID)) === 'absent') {
+    MY_WORKSPACE_ID = '';
+    workspaceResolved = false;
+  }
+  return MY_WORKSPACE_ID;
 }
 
 function resolveVerifiedWorkspaceId(): Promise<string> {

--- a/src/mcp/workspaceIdentity.ts
+++ b/src/mcp/workspaceIdentity.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared workspace-identity helpers for both MCP surfaces (src/mcp and
+ * src/company/mcp), kept here so the two servers classify identity
+ * IDENTICALLY rather than drifting between hand-copied implementations.
+ */
+
+export type WorkspaceLiveness = 'live' | 'absent' | 'unknown';
+
+/**
+ * Classify a `workspace.list` RPC result for the purpose of gating the
+ * (frozen, possibly stale) WMUX_WORKSPACE_ID env hint.
+ *
+ *   - 'live'    : the result is an array of workspaces and one has id === wsId.
+ *   - 'absent'  : the result is an array that does NOT contain wsId → a
+ *                 confirmed ghost (re-minted / closed). Callers drop the hint.
+ *   - 'unknown' : the result is not a workspace array — e.g. the renderer's
+ *                 retryable "still starting" envelope during boot reconcile, or
+ *                 any other unexpected shape. The hint may be perfectly valid;
+ *                 callers must NOT treat this as a confirmed death (mirrors the
+ *                 daemon-side prune's "require positive proof" discipline).
+ *
+ * Accepts either a bare array or a `{ workspaces: [...] }` wrapper so it is
+ * robust to either RPC envelope shape.
+ */
+export function classifyWorkspaceListResult(
+  result: unknown,
+  wsId: string,
+): WorkspaceLiveness {
+  const list = Array.isArray(result)
+    ? result
+    : (result as { workspaces?: unknown[] } | null)?.workspaces;
+  if (!Array.isArray(list)) return 'unknown';
+  return list.some(
+    (w) => w && typeof w === 'object' && (w as Record<string, unknown>)['id'] === wsId,
+  )
+    ? 'live'
+    : 'absent';
+}


### PR DESCRIPTION
The MCP server resolves its workspace identity by reading ~/.wmux/pid-map/ (PID -> ptyId). Two compounding defects let it adopt a dead workspace id, and a third gap let the map keep leaking after the first fix.

## What was happening

The pid-map accreted one file per shell forever (over 1100 entries seen on my machine across two months). The OS recycles those PID numbers onto unrelated live processes (saw Notepad, Discord, RuntimeBroker in the wild), so a stale entry ends up sitting on a live, unrelated PID. On top of that, a2a.resolve.identity passed legacy "ws-" entries through verbatim, so a legacy entry on a recycled PID resolved to a re-minted dead workspace id. That ghost is absent from workspace.list, so browser_open failed with "no active workspace" and terminal ops threw "not owned by workspace ws-...", and it looped until the MCP server restarted.

## Fixes

**Read path (a2a.resolve.identity):** drop legacy "ws-" entries outright and resolve only current-format (ptyId) entries to their live owner. A dead or recycled current-format entry resolves to null and is excluded, so it can never produce a ghost. No liveness probe needed on the hot read path.

**Write boundary (pty.handler.ts):** prune the pid-map anchor when a daemon session ends, instead of letting it accrete.

This started as the session:died handler only. During dogfood we found the common close path does not go through session:died at all: a pane or workspace close goes PTY_DISPOSE -> daemon.destroySession, which removes the bridge exit listener before killing and emits session:destroyed, not session:died. So the died handler never fired for an explicit close and every UI-driven close still leaked its anchor (caught live: PID 37008 -> daemon-33d7bc91 lingering after a workspace close). The dispose handler now prunes too, so both teardown paths clean the map.

The fs primitives (writePidMap / removePidMapByPtyId) moved into src/main/pty/pidMap.ts so their content-keying and unlink behavior can be tested at runtime. The handler module pulls in electron and can't be imported under vitest, which is why its other tests are source-structural.

**Identity hint (mcp + company/mcp resolveWorkspaceId):** verify the frozen WMUX_WORKSPACE_ID env hint against workspace.list before trusting it. Drop it only on positive proof it is a ghost ('absent'); keep it on 'unknown' (list transiently unavailable, e.g. the renderer's retryable boot-reconcile envelope) so a startup race never turns a live workspace into a hard "identity unknown" failure. Shared classifier in workspaceIdentity.ts so both MCP surfaces behave identically.

## Tests

- 19 unit tests for the resolve path (legacy drop + file purge, live resolve, non-destructive read of dead current-format entries, env-hint 3-state classify).
- Behavioral pidMap.test.ts (5): multi-anchor sweep, content-vs-filename keying, whitespace trim, empty-ptyId and missing-dir no-op.
- Structural pty.handler.pidmap-prune.test.ts (3): both prune call sites plus shared-helper routing.
- Dynamic harness (workspace-identity-dynamic.mjs) updated, 7/7 including a ghost env-hint drop scenario.

Full suite green, tsc clean.

## Note on the dispose prune

The ghost itself is already blocked by the read-path defense regardless of the prune, so the dispose-path leak was a hygiene issue (unbounded growth), not a live ghost regression. The end-to-end "close a workspace, watch the anchor disappear" check needs a GUI restart to load the main-process change, so it's deferred to the next natural close rather than gated on a forced restart.