### PR TITLE
fix(mcp): remove the empty pane left by browser_close

### DIFF
--- a/src/renderer/hooks/__tests__/useRpcBridge.browserClose.test.ts
+++ b/src/renderer/hooks/__tests__/useRpcBridge.browserClose.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Regression test for issue #143: MCP browser_close left an empty pane that
+ * AppLayout backfilled with a fresh terminal.
+ *
+ * Root cause: the UI close path (Pane.tsx handleCloseSurface) removes the pane
+ * when its last surface is closed (closeSurface then closePane), but the MCP
+ * mirror (browser.close in useRpcBridge.ts) only called closeSurface, leaving a
+ * surfaces.length === 0 leaf that the "auto-create initial surface for empty
+ * leaf panes" effect then filled with a terminal. browser_open/close in a loop
+ * accreted blank terminals.
+ *
+ * Fix: the handler snapshots whether this was the last surface BEFORE closing,
+ * then cascades into closePane — mirroring the UI path. (Root panes are a no-op
+ * in closePane by design, so a browser that is a workspace's only pane still
+ * gets an auto-terminal on both paths; only the non-root asymmetry was a bug.)
+ *
+ * This is a source-structural test: handleRpcMethod is not exported and pulls in
+ * the whole store, so it can't be imported under vitest — the same reason the
+ * pty.handler tests scan source. It fails if a refactor drops the cascade or
+ * reorders it so the last-surface decision is made AFTER the surface is gone.
+ */
+describe('useRpcBridge browser.close cascade (issue #143)', () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, '..', 'useRpcBridge.ts'),
+    'utf-8',
+  );
+
+  /** Isolate the browser.close handler region so assertions can't match elsewhere. */
+  function closeBlock(): string {
+    const match = src.match(
+      /method === 'browser\.close'[\s\S]*?method === 'browser\.navigate'/,
+    );
+    if (!match) {
+      throw new Error(
+        "browser.close -> browser.navigate handler region not found in " +
+          'useRpcBridge.ts. Update the regex if the layout changed.',
+      );
+    }
+    return match[0];
+  }
+
+  it('cascades into closePane when the last surface is closed', () => {
+    const block = closeBlock();
+    expect(block).toMatch(/store\.closeSurface\(/);
+    // The empty-pane cleanup that issue #143 was missing.
+    expect(block).toMatch(/store\.closePane\(targetLeaf\.id\)/);
+  });
+
+  it('decides last-surface BEFORE closeSurface (no off-by-one on the snapshot)', () => {
+    const block = closeBlock();
+    // The pre-close snapshot must exist and gate the closePane call.
+    expect(block).toMatch(/const\s+wasLastSurface\s*=\s*targetLeaf\.surfaces\.length\s*<=\s*1/);
+    expect(block).toMatch(/if\s*\(\s*wasLastSurface\s*\)/);
+
+    // Ordering: the length is captured before the surface is spliced out, or the
+    // decision would be off-by-one (length already decremented).
+    const snapAt = block.indexOf('wasLastSurface =');
+    const closeAt = block.indexOf('store.closeSurface(');
+    expect(snapAt).toBeGreaterThanOrEqual(0);
+    expect(closeAt).toBeGreaterThan(snapAt);
+  });
+});

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -899,7 +899,38 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       return { error: 'browser.close: no browser surface found' };
     }
 
+    // Snapshot whether this was the pane's last surface BEFORE removing it, so
+    // the decision matches Pane.tsx handleCloseSurface (which reads
+    // pane.surfaces.length at call time, pre-close) regardless of how the store
+    // applies the mutation.
+    const wasLastSurface = targetLeaf.surfaces.length <= 1;
+
     store.closeSurface(targetLeaf.id, targetSurfaceId);
+
+    // Mirror the UI close path's cascade: when the closed surface was the
+    // pane's last one, remove the now-empty leaf too. Without this, AppLayout's
+    // "auto-create initial surface for empty leaf panes" effect backfills the
+    // empty leaf with a fresh terminal, so MCP browser_close would accrete
+    // blank terminals where the UI path leaves nothing. A browser sharing a
+    // split pane with a terminal has surfaces.length > 1, so only the surface
+    // is removed and the pane stays.
+    //
+    // Root-pane edge: closePane is a no-op on the root pane ("can't close root
+    // pane"), so a browser that is a workspace's ONLY pane leaves an empty root
+    // that AppLayout backfills with a terminal. That is intended (a workspace
+    // can't have zero panes) and the UI path behaves identically, so it is not
+    // an asymmetry — only the non-root case was leaking.
+    //
+    // Safety note: closeSurface and closePane are two separate set() calls, so
+    // there is a transient "empty leaf" state between them. They run
+    // synchronously with no await in between, so zustand batches them and React
+    // never re-renders on the intermediate state — the empty-leaf auto-terminal
+    // effect only ever sees the final state (pane removed) and stays dormant.
+    // Keep these two calls synchronous and adjacent; an await between them would
+    // expose the empty leaf to the effect and reintroduce the backfill.
+    if (wasLastSurface) {
+      store.closePane(targetLeaf.id);
+    }
     return { ok: true };
   }
 


### PR DESCRIPTION
Closes #143

Closing a browser through the MCP `browser_close` tool removed the browser surface but left its pane behind, and the empty pane was then backfilled with a fresh PowerShell terminal. Repeating `browser_open` then `browser_close` accreted blank terminals.

## Cause

The MCP path was missing the cascade the UI path runs. `Pane.tsx` `handleCloseSurface` closes the surface and then, when it was the pane's last one, closes the pane too. The `browser.close` handler in `useRpcBridge.ts` only called `store.closeSurface`, leaving a `surfaces.length === 0` leaf that AppLayout's "auto-create initial surface for empty leaf panes" effect filled with a terminal. Same shape as the #142 pid-map leak: a teardown cascade present in the UI path but absent from its RPC mirror.

## Fix

Mirror the cascade in the handler. Snapshot whether this is the pane's last surface BEFORE closing it (so the decision matches `Pane.tsx`, which reads the count pre-close), then `closePane` when it was. A browser sharing a split pane with a terminal has `surfaces.length > 1`, so only the surface is removed and the pane stays.

`closeSurface` and `closePane` are two synchronous `set()` calls; zustand batches them so React never renders the intermediate empty-leaf state and the auto-terminal effect stays dormant. There's a comment marking that the two calls must stay synchronous and adjacent.

## Scope note (root pane)

`closePane` is a no-op on the root pane by design (a workspace can't have zero panes), so a browser that is a workspace's only pane still gets an auto-terminal. The UI path behaves identically there, so it's consistent, not an asymmetry. Only the non-root case was leaking, and that's what this fixes.

## Tests

Source-structural test (handleRpcMethod can't be imported under vitest, same constraint as the pty.handler tests): asserts the cascade is present and that the last-surface decision is taken before the surface is removed. 303 renderer tests green, tsc clean.

## Follow-up

The #143 issue also tracks a non-blocking efficiency cleanup carried over from the #142 review (resolveWorkspaceId can issue two `workspace.list` calls on a rare fallback path).