### PR TITLE
feat(settings): replace dated unicode tab glyphs with SVG line icons

### DIFF
--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
+import { useEffect, useMemo, useRef, useState, useCallback, type ReactNode } from 'react';
 import { useStore } from '../../stores';
 import { LOCALE_OPTIONS, type Locale } from '../../i18n';
 import { useT } from '../../hooks/useT';
@@ -39,6 +39,79 @@ function IconRefresh() {
     <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M1.5 7a5.5 5.5 0 1 0 1.1-3.3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
       <polyline points="1.5,2 1.5,4.5 4,4.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+// ─── Tab icons (stroke line icons — 14px, currentColor) ───────────────────────
+
+function IconGeneral() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <line x1="2" y1="3.5" x2="12" y2="3.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      <line x1="2" y1="7" x2="12" y2="7" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      <line x1="2" y1="10.5" x2="12" y2="10.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      <circle cx="4.5" cy="3.5" r="1.6" fill="currentColor" />
+      <circle cx="9.5" cy="7" r="1.6" fill="currentColor" />
+      <circle cx="5.5" cy="10.5" r="1.6" fill="currentColor" />
+    </svg>
+  );
+}
+
+function IconAppearance() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="7" cy="7" r="5" stroke="currentColor" strokeWidth="1.3" />
+      <path d="M7 2a5 5 0 0 1 0 10z" fill="currentColor" />
+    </svg>
+  );
+}
+
+function IconNotifications() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M3.5 9.5c.7-.7.9-1.7.9-2.9a2.6 2.6 0 0 1 5.2 0c0 1.2.2 2.2.9 2.9z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" />
+      <path d="M5.9 11.2a1.2 1.2 0 0 0 2.2 0" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function IconShortcuts() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="1.5" y="3.5" width="11" height="7" rx="1.5" stroke="currentColor" strokeWidth="1.3" />
+      <line x1="3.7" y1="5.9" x2="3.7" y2="5.9" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      <line x1="5.7" y1="5.9" x2="5.7" y2="5.9" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      <line x1="7.7" y1="5.9" x2="7.7" y2="5.9" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      <line x1="9.7" y1="5.9" x2="9.7" y2="5.9" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      <line x1="4.5" y1="8.3" x2="9.5" y2="8.3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function IconClaude() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M7 1.5 8.3 5.7 12.5 7 8.3 8.3 7 12.5 5.7 8.3 1.5 7 5.7 5.7Z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function IconFirstRun() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <line x1="3.5" y1="1.8" x2="3.5" y2="12.2" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      <path d="M3.5 2.5h6.7l-1.7 2.3 1.7 2.3H3.5z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function IconAbout() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="7" cy="7" r="5" stroke="currentColor" strokeWidth="1.3" />
+      <line x1="7" y1="6.4" x2="7" y2="9.8" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      <line x1="7" y1="4.3" x2="7" y2="4.3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
     </svg>
   );
 }
@@ -2230,14 +2303,14 @@ export default function SettingsPanel() {
   const [activeTab, setActiveTab] = useState<TabId>('general');
   const panelRef = useRef<HTMLDivElement>(null);
 
-  const tabs: { id: TabId; label: string; icon: string }[] = [
-    { id: 'general',            label: t('settings.tabGeneral'),         icon: '⚙' },
-    { id: 'appearance',         label: t('settings.tabAppearance'),      icon: '◑' },
-    { id: 'notifications',      label: t('settings.tabNotifications'),   icon: '◎' },
-    { id: 'shortcuts',          label: t('settings.tabShortcuts'),       icon: '⌨' },
-    { id: 'claude-integration', label: t('claudeIntegration.tab'),       icon: '◈' },
-    { id: 'first-run-setup',    label: t('settings.firstRunSetup'),      icon: '◇' },
-    { id: 'about',              label: t('settings.tabAbout'),           icon: 'ℹ' },
+  const tabs: { id: TabId; label: string; icon: ReactNode }[] = [
+    { id: 'general',            label: t('settings.tabGeneral'),         icon: <IconGeneral /> },
+    { id: 'appearance',         label: t('settings.tabAppearance'),      icon: <IconAppearance /> },
+    { id: 'notifications',      label: t('settings.tabNotifications'),   icon: <IconNotifications /> },
+    { id: 'shortcuts',          label: t('settings.tabShortcuts'),       icon: <IconShortcuts /> },
+    { id: 'claude-integration', label: t('claudeIntegration.tab'),       icon: <IconClaude /> },
+    { id: 'first-run-setup',    label: t('settings.firstRunSetup'),      icon: <IconFirstRun /> },
+    { id: 'about',              label: t('settings.tabAbout'),           icon: <IconAbout /> },
   ];
 
   // Close on Escape
@@ -2316,7 +2389,7 @@ export default function SettingsPanel() {
                     fontWeight: isActive ? 600 : 400,
                   }}
                 >
-                  <span className="text-[13px] leading-none" style={{ color: isActive ? 'var(--accent-blue)' : 'var(--text-muted)' }}>
+                  <span className="inline-flex items-center leading-none" style={{ color: isActive ? 'var(--accent-blue)' : 'var(--text-muted)' }}>
                     {tab.icon}
                   </span>
                   {tab.label}


### PR DESCRIPTION
<img width="220" height="422" alt="image" src="https://github.com/user-attachments/assets/567a3c7a-8395-4c84-bfdf-12dd31d74dfd" />

The settings tab icons were Unicode geometric glyphs (the abstract circle/diamond shapes) rendered by the system font, so stroke weight and alignment varied per tab and the shapes read as dated.

Replace them with inline stroke SVG icon components matching the existing IconX/IconRefresh style (14px viewBox, currentColor, 1.3 stroke, rounded caps): 
- sliders
- half-filled circle
- bell
- keyboard
- sparkle
- flag
- info circle

All tabs now share one visual weight and pick up the active/muted theme colors via currentColor.

🇰🇷
설정 탭 아이콘은 시스템 폰트로 렌더링되는 유니코드 기하 글리프(추상적인 원/다이아몬드 도형)였습니다. 그래서 탭마다 선 굵기와 정렬이 제각각이고 도형이 낡아 보였습니다. 

이를 기존 IconX/IconRefresh 스타일(14px viewBox, currentColor, 1.3 stroke, 둥근 캡)에 맞춘 다음의 인라인 stroke SVG 아이콘 컴포넌트로 교체합니다:
- sliders
- half-filled circle
- bell
- keyboard
- sparkle
- flag
- info circle

이제 모든 탭이 하나의 시각적 굵기를 공유하고 currentColor로 active/muted 테마 색을 따릅니다.

<!--
Thanks for contributing to wmux. Fill the template out — reviewers use it as the
landing checklist. Sections that don't apply: write "n/a" rather than deleting
the header, so reviewers know you considered them.
-->

## Summary

<!-- One or two sentences. What changed and why. -->

Replace the Settings panel's Unicode tab glyphs with inline stroke-SVG icons that match the panel's existing `IconX`/`IconRefresh` system, so every tab shares one visual weight and follows the active/muted theme colors.

🇰🇷
설정 패널의 유니코드 탭 글리프를 패널의 기존 `IconX`/`IconRefresh` 체계에 맞춘 인라인 stroke-SVG 아이콘으로 교체합니다. 모든 탭이 동일한 시각적 굵기를 갖고 active/muted 테마 색을 따릅니다.

## Changes

<!--
Bulleted list of substantive changes. Keep it tight; the diff is the source of
truth, this is the index.
-->

- Add seven stroke-SVG tab-icon components (`IconGeneral`, `IconAppearance`, `IconNotifications`, `IconShortcuts`, `IconClaude`, `IconFirstRun`, `IconAbout`) in the existing icon style — 14px viewBox, `currentColor`, 1.3 stroke, rounded caps.
- Switch the `tabs` array's `icon` field from `string` (Unicode glyph) to `ReactNode` (SVG component).
- Change the tab-nav icon wrapper `<span>` from `text-[13px]` to `inline-flex items-center`, so the SVG aligns by its box instead of the text baseline.

🇰🇷
- 기존 아이콘 스타일(14px viewBox, `currentColor`, 1.3 stroke, 둥근 캡)을 따르는 stroke-SVG 탭 아이콘 컴포넌트 7개 추가 (`IconGeneral`, `IconAppearance`, `IconNotifications`, `IconShortcuts`, `IconClaude`, `IconFirstRun`, `IconAbout`).
- `tabs` 배열의 `icon` 필드 타입을 `string`(유니코드 글리프)에서 `ReactNode`(SVG 컴포넌트)로 변경.
- 탭 내비 아이콘 래퍼 `<span>`을 `text-[13px]`에서 `inline-flex items-center`로 변경. SVG가 텍스트 baseline이 아니라 자신의 box 기준으로 정렬되도록 함.

## CHANGELOG entry

<!--
Required for every PR that touches user-visible behavior or the external
substrate surface. Skip ONLY for internal-only refactors (with a note saying
"no CHANGELOG — internal only" below).

Use the Keep-a-Changelog sections. Pick the ones that apply; delete the rest.
The release writer will copy this verbatim into CHANGELOG.md.
-->

### Changed

- Settings panel tabs now use consistent SVG line icons in place of the previous Unicode glyphs.

🇰🇷
- 설정 패널 탭이 기존 유니코드 글리프 대신 일관된 SVG 라인 아이콘을 사용합니다.

## Stability tier impact

<!--
Check one. Definitions in docs/api/versioning.md.

- [ ] No external surface touched (internal refactor / docs / tests / CI).
- [ ] Additive change to a `stable` surface (new optional param, new field, new event type).
- [ ] Breaking change to a `stable` surface (requires major bump — block until release planning is in scope).
- [ ] Change to an `experimental` surface (note in release notes).
- [ ] Change to an `internal` surface (no contract impact).
-->

- [x] No external surface touched (internal refactor / docs / tests / CI).

Renderer-only visual change; no RPC, event, or protocol surface is involved.

## Substrate contract impact (Substrate 3.0)

<!--
If this PR touches any of these, link to the relevant docs section that needs
updating in the same PR or in a follow-up:

- PaneMetadata wire shape, mergeMode, version semantics → docs/PROTOCOL.md §1
- EventBus envelope, cursor semantics, bootId → docs/PROTOCOL.md §2, §3
- Permission enforcement points → docs/PROTOCOL.md §4
- Named Pipe security → docs/PROTOCOL.md §5
- New RPC method / event type → docs/api/inventory.md + docs/api/stability.md

Write "n/a" if nothing here applies.
-->

n/a — no PaneMetadata, EventBus, permission, Named Pipe, or RPC/event surface is touched.

## Test plan

<!--
- Unit tests added / updated: which paths.
- Integration / dynamic tests: link the script or describe the harness.
- Manual verification: what you did locally, especially for UI/UX changes.

CI must pass before merge — don't ship if you haven't run the full suite locally.
-->

- Unit: `npx vitest run src/renderer/components/Settings` → 47/47 pass. No new test added — this is a presentational icon swap with no behavioral branch; existing Settings render tests still exercise the panel.
- Full suite: `npm run test:parallel` → 2358 passed, 1 failed. The lone failure is in `src/shared/__tests__/security.test.ts` and is unrelated to this change — it fails identically on `main`. Root cause: that test's happy-path case isn't hermetic (it doesn't stub `process.platform` / `process.env.USERNAME`), so on a dev machine whose OS account name is non-ASCII it takes the real Windows-ACL branch and the production code *correctly* refuses to apply a mangling-prone ACL (the #90 lock-out guard). Green in CI and on ASCII-account machines; a pre-existing test-isolation gap, not a product bug.
- Static: `tsc -p tsconfig.json --noEmit` clean; `eslint` on the file adds 0 new findings (baseline unchanged; the pre-existing `IconRefresh` unused warning is untouched).
- Manual: rendered the real component in an isolated dev Electron instance (`--user-data-dir` + isolated `USERPROFILE`, leaving the running app and its MCP bridge untouched); all seven icons render at 14px with uniform weight and correct active (`--accent-blue`) / muted (`--text-muted`) colors.

## Related issues / PRs

<!-- e.g. Closes #123, Tracks #18, Stacked on #16 -->

Closes #145

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed. — surface unchanged; nothing to update.
- [x] Tests cover the new behavior and the regression case (if a bug fix). — visual-only change; covered by existing Settings render tests plus a manual render. No new assertion added (see Test plan).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries. — single-file `.tsx` change.
