### PR TITLE
i18n(settings): translate Claude integration + first-run setup tab bodies (21 locales)

### DIFF
--- a/src/renderer/i18n/locales/ar.ts
+++ b/src/renderer/i18n/locales/ar.ts
@@ -240,7 +240,55 @@ export const ar = {
   'firstRun.autoUpdateMessage': 'هل تريد أن يتحقق WMUX من التحديثات تلقائياً؟ يمكنك تغيير ذلك لاحقاً في الإعدادات.',
   'firstRun.enable': 'تفعيل',
   'firstRun.disable': 'لا، شكراً',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'إعداد التشغيل الأول',
+  'settings.firstRunSetupDesc':
+    'أعد فتح معالج الترحيب أو اعرض ورقة اختصارات لوحة المفاتيح مرة أخرى.',
+  'settings.firstRunSetup.lastCompleted': 'آخر اكتمال: {date}',
+  'settings.firstRunSetup.notCompleted': 'لم يكتمل بعد',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP: {status}',
+  'settings.firstRunSetup.statusDetected': 'مكتشف',
+  'settings.firstRunSetup.statusNotDetected': 'غير مكتشف',
+  'settings.firstRunSetup.statusRegistered': 'مسجَّل',
+  'settings.firstRunSetup.statusNotRegistered': 'غير مسجَّل',
+  'settings.firstRunSetup.openWizard': 'فتح معالج الإعداد',
+  'settings.firstRunSetup.showCheatSheet': 'عرض ورقة اختصارات لوحة المفاتيح',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'تكامل Claude',
+  'claudeIntegration.signalHealth.title': 'سلامة إشارة الإضافة',
+  'claudeIntegration.signalHealth.unknownBody':
+    'حالة الإضافة: لم تُرصد بعد. ثبِّتها باستخدام الأمر أدناه في Claude Code. يؤكد wmux الكشف بمجرد تشغيل أول خطّاف.',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'آخر إشارة {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'زمن الاستجابة P50 {p50}ms · P95 {p95}ms · {count} عيّنة',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'تطابق مساحة العمل: {matched}/{total} خطّاف تم ربطه بجزء wmux',
+  'claudeIntegration.signalHealth.staleBody':
+    'حالة الإضافة: قديمة. وصل آخر خطّاف {rel} — ربما توقفت الإضافة عن العمل أو أن Claude Code خامل.',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'نسخ أمر التثبيت',
+  'claudeIntegration.signalHealth.copySuccess': 'تم النسخ — الصقه في Claude Code',
+  'claudeIntegration.signalHealth.copyError': 'فشل النسخ — الحافظة مقفلة',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'عدّاد استخدام Anthropic (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'يقرأ رمز OAuth الخاص بـ Claude Code من التخزين المحلي، ويفحص Anthropic بطلب Haiku بحجم 1-token لقراءة ترويسات حد المعدل. يُحتسب الفحص على حصتك الخاصة (≈ لا يُذكر). لا يُعاد كتابة الرمز أبداً، ولا يُسجَّل أبداً، ويُرسَل فقط إلى api.anthropic.com.',
+  'claudeIntegration.usage.enableLabel': 'عرض استخدام 5h / 7d في شريط الحالة',
+  'claudeIntegration.usage.refreshButton': 'تحديث الآن',
+  'claudeIntegration.usage.refreshCooldown': 'التحديث متاح خلال {seconds} ث',
+  'claudeIntegration.usage.subscription': 'الخطة: {tier}',
+  'claudeIntegration.usage.lastFetched': 'آخر جلب: {ago}',
+  'claudeIntegration.usage.justNow': 'الآن',
+  'claudeIntegration.usage.minutesAgo': 'قبل {n} د',
+  'claudeIntegration.usage.hoursAgo': 'قبل {n} س',
+  'claudeIntegration.usage.daysAgo': 'قبل {n} ي',
+  'claudeIntegration.usage.status.token-missing': 'لم يتم تسجيل الدخول إلى Claude Code',
+  'claudeIntegration.usage.status.unauthorized':
+    'انتهت صلاحية الرمز — سجّل الدخول إلى Claude Code مرة أخرى',
+  'claudeIntegration.usage.status.http-error': 'خطأ في واجهة Anthropic API',
+  'claudeIntegration.usage.status.network-error': 'خطأ في الشبكة',
+  'claudeIntegration.usage.status.read-error': 'خطأ في قراءة بيانات الاعتماد',
 } as const;

--- a/src/renderer/i18n/locales/bs.ts
+++ b/src/renderer/i18n/locales/bs.ts
@@ -240,7 +240,54 @@ export const bs = {
   'firstRun.autoUpdateMessage': 'Želite li da WMUX automatski provjerava ažuriranja? Možete to promijeniti kasnije u Postavkama.',
   'firstRun.enable': 'Omogući',
   'firstRun.disable': 'Ne, hvala',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'Početno postavljanje',
+  'settings.firstRunSetupDesc':
+    'Ponovo otvori čarobnjak dobrodošlice ili ponovo prikaži pregled tipkovničkih prečica.',
+  'settings.firstRunSetup.lastCompleted': 'Posljednji put završeno: {date}',
+  'settings.firstRunSetup.notCompleted': 'Još nije završeno',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP: {status}',
+  'settings.firstRunSetup.statusDetected': 'otkriveno',
+  'settings.firstRunSetup.statusNotDetected': 'nije otkriveno',
+  'settings.firstRunSetup.statusRegistered': 'registrirano',
+  'settings.firstRunSetup.statusNotRegistered': 'nije registrirano',
+  'settings.firstRunSetup.openWizard': 'Otvori čarobnjak za postavljanje',
+  'settings.firstRunSetup.showCheatSheet': 'Prikaži pregled tipkovničkih prečica',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Claude integracija',
+  'claudeIntegration.signalHealth.title': 'Stanje signala dodatka',
+  'claudeIntegration.signalHealth.unknownBody':
+    'Status dodatka: još nije zabilježen. Instaliraj komandom ispod u Claude Code. wmux potvrđuje otkrivanje čim se okine prvi hook.',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'Posljednji signal {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'Latencija P50 {p50}ms · P95 {p95}ms · {count} uzoraka',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'Podudaranje radnog prostora: {matched}/{total} hookova razriješeno na wmux panel',
+  'claudeIntegration.signalHealth.staleBody':
+    'Status dodatka: zastario. Posljednji hook stigao {rel} — dodatak je možda prestao okidati ili Claude Code miruje.',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'Kopiraj komandu za instalaciju',
+  'claudeIntegration.signalHealth.copySuccess': 'Kopirano — zalijepi u Claude Code',
+  'claudeIntegration.signalHealth.copyError': 'Kopiranje neuspjelo — međuspremnik zaključan',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Mjerač korištenja Anthropic (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'Čita tvoj Claude Code OAuth token iz lokalnog spremišta i ispituje Anthropic s 1-token Haiku zahtjevom kako bi pročitao zaglavlja ograničenja brzine. Ispitivanje se naplaćuje s tvoje vlastite kvote (≈ zanemarivo). Token se nikada ne upisuje natrag, nikada se ne bilježi, šalje se samo na api.anthropic.com.',
+  'claudeIntegration.usage.enableLabel': 'Prikaži iskorištenost 5h / 7d u statusnoj traci',
+  'claudeIntegration.usage.refreshButton': 'Osvježi sada',
+  'claudeIntegration.usage.refreshCooldown': 'Osvježavanje dostupno za {seconds}s',
+  'claudeIntegration.usage.subscription': 'Plan: {tier}',
+  'claudeIntegration.usage.lastFetched': 'Posljednje dohvaćeno: {ago}',
+  'claudeIntegration.usage.justNow': 'upravo sada',
+  'claudeIntegration.usage.minutesAgo': 'prije {n}m',
+  'claudeIntegration.usage.hoursAgo': 'prije {n}h',
+  'claudeIntegration.usage.daysAgo': 'prije {n}d',
+  'claudeIntegration.usage.status.token-missing': 'Nisi prijavljen u Claude Code',
+  'claudeIntegration.usage.status.unauthorized': 'Token istekao — ponovo se prijavi u Claude Code',
+  'claudeIntegration.usage.status.http-error': 'Greška Anthropic API-ja',
+  'claudeIntegration.usage.status.network-error': 'Mrežna greška',
+  'claudeIntegration.usage.status.read-error': 'Greška čitanja vjerodajnica',
 } as const;

--- a/src/renderer/i18n/locales/da.ts
+++ b/src/renderer/i18n/locales/da.ts
@@ -240,7 +240,53 @@ export const da = {
   'firstRun.autoUpdateMessage': 'Vil du have WMUX til at tjekke for opdateringer automatisk? Du kan ændre dette senere i Indstillinger.',
   'firstRun.enable': 'Aktiver',
   'firstRun.disable': 'Nej tak',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'Førstegangsopsætning',
+  'settings.firstRunSetupDesc': 'Genåbn velkomstguiden, eller vis tastaturgenvejsoversigten igen.',
+  'settings.firstRunSetup.lastCompleted': 'Sidst fuldført: {date}',
+  'settings.firstRunSetup.notCompleted': 'Ikke fuldført endnu',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP: {status}',
+  'settings.firstRunSetup.statusDetected': 'fundet',
+  'settings.firstRunSetup.statusNotDetected': 'ikke fundet',
+  'settings.firstRunSetup.statusRegistered': 'registreret',
+  'settings.firstRunSetup.statusNotRegistered': 'ikke registreret',
+  'settings.firstRunSetup.openWizard': 'Åbn opsætningsguide',
+  'settings.firstRunSetup.showCheatSheet': 'Vis tastaturgenvejsoversigt',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Claude-integration',
+  'claudeIntegration.signalHealth.title': 'Plugin-signaltilstand',
+  'claudeIntegration.signalHealth.unknownBody':
+    'Plugin-status: endnu ikke observeret. Installer med kommandoen nedenfor i Claude Code. wmux bekræfter registrering, når den første hook udløses.',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'Seneste signal {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'Latenstid P50 {p50}ms · P95 {p95}ms · {count} målinger',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'Arbejdsområde-match: {matched}/{total} hooks knyttet til et wmux-panel',
+  'claudeIntegration.signalHealth.staleBody':
+    'Plugin-status: forældet. Seneste hook ankom {rel} — pluginnet er måske holdt op med at udløse, eller Claude Code er inaktiv.',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'Kopiér installationskommando',
+  'claudeIntegration.signalHealth.copySuccess': 'Kopieret — indsæt i Claude Code',
+  'claudeIntegration.signalHealth.copyError': 'Kopiering mislykkedes — udklipsholderen er låst',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Anthropic-forbrugsmåler (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'Læser dit Claude Code OAuth-token fra lokal lagring og prober Anthropic med en 1-token Haiku-forespørgsel for at læse rate-limit-headerne. Proben afregnes på din egen kvote (≈ ubetydeligt). Tokenet skrives aldrig tilbage, logges aldrig og sendes kun til api.anthropic.com.',
+  'claudeIntegration.usage.enableLabel': 'Vis 5h / 7d-udnyttelse i statuslinjen',
+  'claudeIntegration.usage.refreshButton': 'Opdater nu',
+  'claudeIntegration.usage.refreshCooldown': 'Opdatering tilgængelig om {seconds}s',
+  'claudeIntegration.usage.subscription': 'Plan: {tier}',
+  'claudeIntegration.usage.lastFetched': 'Sidst hentet: {ago}',
+  'claudeIntegration.usage.justNow': 'lige nu',
+  'claudeIntegration.usage.minutesAgo': 'for {n}m siden',
+  'claudeIntegration.usage.hoursAgo': 'for {n}h siden',
+  'claudeIntegration.usage.daysAgo': 'for {n}d siden',
+  'claudeIntegration.usage.status.token-missing': 'Ikke logget ind i Claude Code',
+  'claudeIntegration.usage.status.unauthorized': 'Token udløbet — log ind i Claude Code igen',
+  'claudeIntegration.usage.status.http-error': 'Anthropic API-fejl',
+  'claudeIntegration.usage.status.network-error': 'Netværksfejl',
+  'claudeIntegration.usage.status.read-error': 'Fejl ved læsning af loginoplysninger',
 } as const;

--- a/src/renderer/i18n/locales/de.ts
+++ b/src/renderer/i18n/locales/de.ts
@@ -240,7 +240,55 @@ export const de = {
   'firstRun.autoUpdateMessage': 'Soll WMUX automatisch nach Updates suchen? Sie können dies später in den Einstellungen ändern.',
   'firstRun.enable': 'Aktivieren',
   'firstRun.disable': 'Nein danke',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'Ersteinrichtung',
+  'settings.firstRunSetupDesc':
+    'Öffnen Sie den Willkommens-Assistenten erneut oder zeigen Sie die Tastatur-Kurzübersicht wieder an.',
+  'settings.firstRunSetup.lastCompleted': 'Zuletzt abgeschlossen: {date}',
+  'settings.firstRunSetup.notCompleted': 'Noch nicht abgeschlossen',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP: {status}',
+  'settings.firstRunSetup.statusDetected': 'erkannt',
+  'settings.firstRunSetup.statusNotDetected': 'nicht erkannt',
+  'settings.firstRunSetup.statusRegistered': 'registriert',
+  'settings.firstRunSetup.statusNotRegistered': 'nicht registriert',
+  'settings.firstRunSetup.openWizard': 'Einrichtungs-Assistenten öffnen',
+  'settings.firstRunSetup.showCheatSheet': 'Tastatur-Kurzübersicht anzeigen',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Claude-Integration',
+  'claudeIntegration.signalHealth.title': 'Plugin-Signalzustand',
+  'claudeIntegration.signalHealth.unknownBody':
+    'Plugin-Status: noch kein Signal empfangen. Installieren Sie es mit dem untenstehenden Befehl in Claude Code. wmux bestätigt die Erkennung, sobald der erste Hook ausgelöst wird.',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'Letztes Signal {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'Latenz P50 {p50}ms · P95 {p95}ms · {count} Messwerte',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'Arbeitsbereich-Zuordnung: {matched}/{total} Hooks wurden einem wmux-Bereich zugeordnet',
+  'claudeIntegration.signalHealth.staleBody':
+    'Plugin-Status: veraltet. Letzter Hook traf {rel} ein — das Plugin sendet möglicherweise keine Signale mehr oder Claude Code ist inaktiv.',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'Installationsbefehl kopieren',
+  'claudeIntegration.signalHealth.copySuccess': 'Kopiert — in Claude Code einfügen',
+  'claudeIntegration.signalHealth.copyError': 'Kopieren fehlgeschlagen — Zwischenablage gesperrt',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Anthropic-Nutzungsanzeige (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'Liest Ihr Claude Code OAuth-Token aus dem lokalen Speicher und fragt Anthropic mit einer 1-token Haiku-Anfrage ab, um die Rate-Limit-Header auszulesen. Die Abfrage wird Ihrem eigenen Kontingent berechnet (≈ vernachlässigbar). Das Token wird nie zurückgeschrieben, nie protokolliert und nur an api.anthropic.com gesendet.',
+  'claudeIntegration.usage.enableLabel': '5h / 7d Auslastung in der Statusleiste anzeigen',
+  'claudeIntegration.usage.refreshButton': 'Jetzt aktualisieren',
+  'claudeIntegration.usage.refreshCooldown': 'Aktualisierung verfügbar in {seconds}s',
+  'claudeIntegration.usage.subscription': 'Tarif: {tier}',
+  'claudeIntegration.usage.lastFetched': 'Zuletzt abgerufen: {ago}',
+  'claudeIntegration.usage.justNow': 'gerade eben',
+  'claudeIntegration.usage.minutesAgo': 'vor {n}m',
+  'claudeIntegration.usage.hoursAgo': 'vor {n}h',
+  'claudeIntegration.usage.daysAgo': 'vor {n}d',
+  'claudeIntegration.usage.status.token-missing': 'Nicht in Claude Code angemeldet',
+  'claudeIntegration.usage.status.unauthorized':
+    'Token abgelaufen — erneut in Claude Code anmelden',
+  'claudeIntegration.usage.status.http-error': 'Anthropic-API-Fehler',
+  'claudeIntegration.usage.status.network-error': 'Netzwerkfehler',
+  'claudeIntegration.usage.status.read-error': 'Fehler beim Lesen der Anmeldedaten',
 } as const;

--- a/src/renderer/i18n/locales/es.ts
+++ b/src/renderer/i18n/locales/es.ts
@@ -240,7 +240,55 @@ export const es = {
   'firstRun.autoUpdateMessage': '¿Quieres que WMUX busque actualizaciones automáticamente? Puedes cambiarlo más tarde en Ajustes.',
   'firstRun.enable': 'Activar',
   'firstRun.disable': 'No, gracias',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'Configuración inicial',
+  'settings.firstRunSetupDesc':
+    'Vuelve a abrir el asistente de bienvenida o muestra de nuevo la chuleta de atajos de teclado.',
+  'settings.firstRunSetup.lastCompleted': 'Completada por última vez: {date}',
+  'settings.firstRunSetup.notCompleted': 'Aún no completada',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP: {status}',
+  'settings.firstRunSetup.statusDetected': 'detectado',
+  'settings.firstRunSetup.statusNotDetected': 'no detectado',
+  'settings.firstRunSetup.statusRegistered': 'registrado',
+  'settings.firstRunSetup.statusNotRegistered': 'no registrado',
+  'settings.firstRunSetup.openWizard': 'Abrir asistente de configuración',
+  'settings.firstRunSetup.showCheatSheet': 'Mostrar chuleta de atajos de teclado',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Integración con Claude',
+  'claudeIntegration.signalHealth.title': 'Estado de la señal del plugin',
+  'claudeIntegration.signalHealth.unknownBody':
+    'Estado del plugin: aún no observado. Instálalo con el comando de abajo en Claude Code. wmux confirma la detección en cuanto se dispara el primer hook.',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'Última señal {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'Latencia P50 {p50}ms · P95 {p95}ms · {count} muestras',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'Coincidencia de espacio de trabajo: {matched}/{total} hooks resueltos a un panel de wmux',
+  'claudeIntegration.signalHealth.staleBody':
+    'Estado del plugin: obsoleto. El último hook llegó {rel} — puede que el plugin haya dejado de dispararse o que Claude Code esté inactivo.',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'Copiar comando de instalación',
+  'claudeIntegration.signalHealth.copySuccess': 'Copiado — pégalo en Claude Code',
+  'claudeIntegration.signalHealth.copyError': 'Error al copiar — portapapeles bloqueado',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Medidor de uso de Anthropic (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'Lee tu token OAuth de Claude Code del almacenamiento local y consulta a Anthropic con una petición Haiku de 1-token para leer las cabeceras de límite de frecuencia. La consulta se factura a tu propia cuota (≈ insignificante). El token nunca se vuelve a escribir, nunca se registra y solo se envía a api.anthropic.com.',
+  'claudeIntegration.usage.enableLabel': 'Mostrar uso de 5h / 7d en la barra de estado',
+  'claudeIntegration.usage.refreshButton': 'Actualizar ahora',
+  'claudeIntegration.usage.refreshCooldown': 'Podrás actualizar en {seconds}s',
+  'claudeIntegration.usage.subscription': 'Plan: {tier}',
+  'claudeIntegration.usage.lastFetched': 'Última obtención: {ago}',
+  'claudeIntegration.usage.justNow': 'justo ahora',
+  'claudeIntegration.usage.minutesAgo': 'hace {n}min',
+  'claudeIntegration.usage.hoursAgo': 'hace {n}h',
+  'claudeIntegration.usage.daysAgo': 'hace {n}d',
+  'claudeIntegration.usage.status.token-missing': 'No has iniciado sesión en Claude Code',
+  'claudeIntegration.usage.status.unauthorized':
+    'Token caducado — inicia sesión de nuevo en Claude Code',
+  'claudeIntegration.usage.status.http-error': 'Error de la API de Anthropic',
+  'claudeIntegration.usage.status.network-error': 'Error de red',
+  'claudeIntegration.usage.status.read-error': 'Error al leer las credenciales',
 } as const;

--- a/src/renderer/i18n/locales/fr.ts
+++ b/src/renderer/i18n/locales/fr.ts
@@ -240,7 +240,54 @@ export const fr = {
   'firstRun.autoUpdateMessage': 'Voulez-vous que WMUX vérifie automatiquement les mises à jour ? Vous pourrez le modifier plus tard dans les paramètres.',
   'firstRun.enable': 'Activer',
   'firstRun.disable': 'Non merci',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'Configuration initiale',
+  'settings.firstRunSetupDesc':
+    'Rouvrir l\'assistant de bienvenue ou réafficher l\'aide-mémoire des raccourcis clavier.',
+  'settings.firstRunSetup.lastCompleted': 'Dernière exécution : {date}',
+  'settings.firstRunSetup.notCompleted': 'Pas encore terminée',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code : {status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP : {status}',
+  'settings.firstRunSetup.statusDetected': 'détecté',
+  'settings.firstRunSetup.statusNotDetected': 'non détecté',
+  'settings.firstRunSetup.statusRegistered': 'enregistré',
+  'settings.firstRunSetup.statusNotRegistered': 'non enregistré',
+  'settings.firstRunSetup.openWizard': 'Ouvrir l\'assistant de configuration',
+  'settings.firstRunSetup.showCheatSheet': 'Afficher l\'aide-mémoire des raccourcis',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Intégration Claude',
+  'claudeIntegration.signalHealth.title': 'État du signal du plugin',
+  'claudeIntegration.signalHealth.unknownBody':
+    'État du plugin : pas encore observé. Installez-le avec la commande ci-dessous dans Claude Code. wmux confirme la détection dès le déclenchement du premier hook.',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'Dernier signal {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'Latence P50 {p50}ms · P95 {p95}ms · {count} échantillons',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'Correspondance d\'espace de travail : {matched}/{total} hooks associés à un panneau wmux',
+  'claudeIntegration.signalHealth.staleBody':
+    'État du plugin : obsolète. Le dernier hook est arrivé {rel} — le plugin a peut-être cessé de se déclencher ou Claude Code est inactif.',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'Copier la commande d\'installation',
+  'claudeIntegration.signalHealth.copySuccess': 'Copié — collez dans Claude Code',
+  'claudeIntegration.signalHealth.copyError': 'Échec de la copie — presse-papiers verrouillé',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Indicateur d\'utilisation Anthropic (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'Lit votre jeton OAuth Claude Code depuis le stockage local et interroge Anthropic avec une requête Haiku à 1-token pour lire les en-têtes de limite de débit. La sonde est facturée sur votre propre quota (≈ négligeable). Le jeton n\'est jamais réécrit, jamais journalisé, et envoyé uniquement à api.anthropic.com.',
+  'claudeIntegration.usage.enableLabel': 'Afficher l\'utilisation 5h / 7d dans la barre d\'état',
+  'claudeIntegration.usage.refreshButton': 'Actualiser maintenant',
+  'claudeIntegration.usage.refreshCooldown': 'Actualisation possible dans {seconds}s',
+  'claudeIntegration.usage.subscription': 'Forfait : {tier}',
+  'claudeIntegration.usage.lastFetched': 'Dernière récupération : {ago}',
+  'claudeIntegration.usage.justNow': 'à l\'instant',
+  'claudeIntegration.usage.minutesAgo': 'il y a {n}min',
+  'claudeIntegration.usage.hoursAgo': 'il y a {n}h',
+  'claudeIntegration.usage.daysAgo': 'il y a {n}j',
+  'claudeIntegration.usage.status.token-missing': 'Claude Code non connecté',
+  'claudeIntegration.usage.status.unauthorized': 'Jeton expiré — reconnectez-vous à Claude Code',
+  'claudeIntegration.usage.status.http-error': 'Erreur de l\'API Anthropic',
+  'claudeIntegration.usage.status.network-error': 'Erreur réseau',
+  'claudeIntegration.usage.status.read-error': 'Erreur de lecture des identifiants',
 } as const;

--- a/src/renderer/i18n/locales/hi.ts
+++ b/src/renderer/i18n/locales/hi.ts
@@ -240,7 +240,54 @@ export const hi = {
   'firstRun.autoUpdateMessage': 'क्या आप चाहते हैं कि WMUX स्वचालित रूप से अपडेट जाँचे? आप इसे बाद में सेटिंग्स में बदल सकते हैं।',
   'firstRun.enable': 'सक्षम करें',
   'firstRun.disable': 'नहीं, धन्यवाद',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'पहली बार सेटअप',
+  'settings.firstRunSetupDesc': 'वेलकम विज़ार्ड फिर से खोलें या कीबोर्ड चीट शीट दोबारा दिखाएँ।',
+  'settings.firstRunSetup.lastCompleted': 'अंतिम बार पूरा हुआ: {date}',
+  'settings.firstRunSetup.notCompleted': 'अभी तक पूरा नहीं हुआ',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP: {status}',
+  'settings.firstRunSetup.statusDetected': 'पता चला',
+  'settings.firstRunSetup.statusNotDetected': 'पता नहीं चला',
+  'settings.firstRunSetup.statusRegistered': 'पंजीकृत',
+  'settings.firstRunSetup.statusNotRegistered': 'पंजीकृत नहीं',
+  'settings.firstRunSetup.openWizard': 'सेटअप विज़ार्ड खोलें',
+  'settings.firstRunSetup.showCheatSheet': 'कीबोर्ड चीट शीट दिखाएँ',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Claude एकीकरण',
+  'claudeIntegration.signalHealth.title': 'प्लगइन सिग्नल स्थिति',
+  'claudeIntegration.signalHealth.unknownBody':
+    'प्लगइन स्थिति: अभी तक नहीं देखा गया। Claude Code में नीचे दिए गए कमांड से इंस्टॉल करें। पहला हुक चलते ही wmux पता लगने की पुष्टि कर देता है।',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'अंतिम सिग्नल {rel}।',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'विलंबता P50 {p50}ms · P95 {p95}ms · {count} नमूने',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'वर्कस्पेस मिलान: {matched}/{total} हुक किसी wmux पेन से मैप हुए',
+  'claudeIntegration.signalHealth.staleBody':
+    'प्लगइन स्थिति: पुरानी। अंतिम हुक {rel} आया — हो सकता है प्लगइन ने चलना बंद कर दिया हो या Claude Code निष्क्रिय हो।',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'इंस्टॉल कमांड कॉपी करें',
+  'claudeIntegration.signalHealth.copySuccess': 'कॉपी हो गया — Claude Code में पेस्ट करें',
+  'claudeIntegration.signalHealth.copyError': 'कॉपी विफल — क्लिपबोर्ड लॉक है',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Anthropic उपयोग मीटर (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'लोकल स्टोरेज से आपका Claude Code OAuth टोकन पढ़ता है और रेट-लिमिट हेडर पढ़ने के लिए 1-token Haiku अनुरोध भेजकर Anthropic की जाँच करता है। यह जाँच आपके अपने कोटे से बिल होती है (≈ नगण्य)। टोकन कभी वापस नहीं लिखा जाता, कभी लॉग नहीं होता, केवल api.anthropic.com को भेजा जाता है।',
+  'claudeIntegration.usage.enableLabel': 'स्टेटस बार में 5h / 7d उपयोग दिखाएँ',
+  'claudeIntegration.usage.refreshButton': 'अभी रिफ्रेश करें',
+  'claudeIntegration.usage.refreshCooldown': 'रिफ्रेश {seconds}s में उपलब्ध होगा',
+  'claudeIntegration.usage.subscription': 'प्लान: {tier}',
+  'claudeIntegration.usage.lastFetched': 'अंतिम बार लाया गया: {ago}',
+  'claudeIntegration.usage.justNow': 'अभी-अभी',
+  'claudeIntegration.usage.minutesAgo': '{n} मिनट पहले',
+  'claudeIntegration.usage.hoursAgo': '{n} घंटे पहले',
+  'claudeIntegration.usage.daysAgo': '{n} दिन पहले',
+  'claudeIntegration.usage.status.token-missing': 'Claude Code में लॉग इन नहीं है',
+  'claudeIntegration.usage.status.unauthorized':
+    'टोकन समाप्त हो गया — Claude Code में फिर से लॉग इन करें',
+  'claudeIntegration.usage.status.http-error': 'Anthropic API त्रुटि',
+  'claudeIntegration.usage.status.network-error': 'नेटवर्क त्रुटि',
+  'claudeIntegration.usage.status.read-error': 'क्रेडेंशियल पढ़ने में त्रुटि',
 } as const;

--- a/src/renderer/i18n/locales/id.ts
+++ b/src/renderer/i18n/locales/id.ts
@@ -240,7 +240,54 @@ export const id = {
   'firstRun.autoUpdateMessage': 'Apakah Anda ingin WMUX memeriksa pembaruan secara otomatis? Anda dapat mengubahnya nanti di Pengaturan.',
   'firstRun.enable': 'Aktifkan',
   'firstRun.disable': 'Tidak, terima kasih',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'Penyiapan awal',
+  'settings.firstRunSetupDesc':
+    'Buka kembali wizard selamat datang atau tampilkan lagi lembar contekan keyboard.',
+  'settings.firstRunSetup.lastCompleted': 'Terakhir diselesaikan: {date}',
+  'settings.firstRunSetup.notCompleted': 'Belum diselesaikan',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP: {status}',
+  'settings.firstRunSetup.statusDetected': 'terdeteksi',
+  'settings.firstRunSetup.statusNotDetected': 'tidak terdeteksi',
+  'settings.firstRunSetup.statusRegistered': 'terdaftar',
+  'settings.firstRunSetup.statusNotRegistered': 'tidak terdaftar',
+  'settings.firstRunSetup.openWizard': 'Buka wizard penyiapan',
+  'settings.firstRunSetup.showCheatSheet': 'Tampilkan lembar contekan keyboard',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Integrasi Claude',
+  'claudeIntegration.signalHealth.title': 'Kesehatan sinyal plugin',
+  'claudeIntegration.signalHealth.unknownBody':
+    'Status plugin: belum teramati. Pasang dengan perintah di bawah ini di Claude Code. wmux mengonfirmasi deteksi setelah hook pertama terpicu.',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'Sinyal terakhir {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'Latensi P50 {p50}ms · P95 {p95}ms · {count} sampel',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'Kecocokan ruang kerja: {matched}/{total} hook cocok dengan panel wmux',
+  'claudeIntegration.signalHealth.staleBody':
+    'Status plugin: usang. Hook terakhir tiba {rel} — plugin mungkin berhenti terpicu atau Claude Code sedang menganggur.',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'Salin perintah pemasangan',
+  'claudeIntegration.signalHealth.copySuccess': 'Tersalin — tempel ke Claude Code',
+  'claudeIntegration.signalHealth.copyError': 'Gagal menyalin — papan klip terkunci',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Pengukur penggunaan Anthropic (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'Membaca token OAuth Claude Code Anda dari penyimpanan lokal dan mengirim probe ke Anthropic dengan permintaan Haiku 1-token untuk membaca header batas laju. Probe ditagihkan ke kuota Anda sendiri (≈ dapat diabaikan). Token tidak pernah ditulis kembali, tidak pernah dicatat, hanya dikirim ke api.anthropic.com.',
+  'claudeIntegration.usage.enableLabel': 'Tampilkan utilisasi 5h / 7d di bilah status',
+  'claudeIntegration.usage.refreshButton': 'Segarkan sekarang',
+  'claudeIntegration.usage.refreshCooldown': 'Penyegaran tersedia dalam {seconds} dtk',
+  'claudeIntegration.usage.subscription': 'Paket: {tier}',
+  'claudeIntegration.usage.lastFetched': 'Terakhir diambil: {ago}',
+  'claudeIntegration.usage.justNow': 'baru saja',
+  'claudeIntegration.usage.minutesAgo': '{n} mnt lalu',
+  'claudeIntegration.usage.hoursAgo': '{n} jam lalu',
+  'claudeIntegration.usage.daysAgo': '{n} hr lalu',
+  'claudeIntegration.usage.status.token-missing': 'Belum masuk ke Claude Code',
+  'claudeIntegration.usage.status.unauthorized': 'Token kedaluwarsa — masuk lagi ke Claude Code',
+  'claudeIntegration.usage.status.http-error': 'Kesalahan API Anthropic',
+  'claudeIntegration.usage.status.network-error': 'Kesalahan jaringan',
+  'claudeIntegration.usage.status.read-error': 'Kesalahan baca kredensial',
 } as const;

--- a/src/renderer/i18n/locales/it.ts
+++ b/src/renderer/i18n/locales/it.ts
@@ -240,7 +240,54 @@ export const it = {
   'firstRun.autoUpdateMessage': 'Vuoi che WMUX verifichi automaticamente gli aggiornamenti? Puoi modificarlo più tardi nelle Impostazioni.',
   'firstRun.enable': 'Abilita',
   'firstRun.disable': 'No, grazie',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'Configurazione iniziale',
+  'settings.firstRunSetupDesc':
+    'Riapri la procedura guidata di benvenuto o mostra di nuovo l\'elenco delle scorciatoie da tastiera.',
+  'settings.firstRunSetup.lastCompleted': 'Ultimo completamento: {date}',
+  'settings.firstRunSetup.notCompleted': 'Non ancora completata',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'MCP wmux: {status}',
+  'settings.firstRunSetup.statusDetected': 'rilevato',
+  'settings.firstRunSetup.statusNotDetected': 'non rilevato',
+  'settings.firstRunSetup.statusRegistered': 'registrato',
+  'settings.firstRunSetup.statusNotRegistered': 'non registrato',
+  'settings.firstRunSetup.openWizard': 'Apri la procedura guidata di configurazione',
+  'settings.firstRunSetup.showCheatSheet': 'Mostra l\'elenco delle scorciatoie da tastiera',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Integrazione Claude',
+  'claudeIntegration.signalHealth.title': 'Stato del segnale del plugin',
+  'claudeIntegration.signalHealth.unknownBody':
+    'Stato del plugin: non ancora osservato. Installalo con il comando qui sotto in Claude Code. wmux conferma il rilevamento al primo hook attivato.',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'Ultimo segnale {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'Latenza P50 {p50}ms · P95 {p95}ms · {count} campioni',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'Corrispondenza area di lavoro: {matched}/{total} hook associati a un pannello wmux',
+  'claudeIntegration.signalHealth.staleBody':
+    'Stato del plugin: obsoleto. L\'ultimo hook è arrivato {rel} — il plugin potrebbe aver smesso di attivarsi oppure Claude Code è inattivo.',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'Copia il comando di installazione',
+  'claudeIntegration.signalHealth.copySuccess': 'Copiato — incolla in Claude Code',
+  'claudeIntegration.signalHealth.copyError': 'Copia non riuscita — appunti bloccati',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Misuratore di utilizzo Anthropic (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'Legge il tuo token OAuth di Claude Code dall\'archiviazione locale e interroga Anthropic con una richiesta Haiku da 1-token per leggere le intestazioni del limite di frequenza. La richiesta viene addebitata sulla tua quota (≈ trascurabile). Il token non viene mai riscritto né registrato, ma inviato solo a api.anthropic.com.',
+  'claudeIntegration.usage.enableLabel': 'Mostra l\'utilizzo 5h / 7d nella barra di stato',
+  'claudeIntegration.usage.refreshButton': 'Aggiorna ora',
+  'claudeIntegration.usage.refreshCooldown': 'Aggiornamento disponibile tra {seconds}s',
+  'claudeIntegration.usage.subscription': 'Piano: {tier}',
+  'claudeIntegration.usage.lastFetched': 'Ultimo recupero: {ago}',
+  'claudeIntegration.usage.justNow': 'proprio ora',
+  'claudeIntegration.usage.minutesAgo': '{n} min fa',
+  'claudeIntegration.usage.hoursAgo': '{n} h fa',
+  'claudeIntegration.usage.daysAgo': '{n} g fa',
+  'claudeIntegration.usage.status.token-missing': 'Accesso a Claude Code non effettuato',
+  'claudeIntegration.usage.status.unauthorized': 'Token scaduto — accedi di nuovo a Claude Code',
+  'claudeIntegration.usage.status.http-error': 'Errore dell\'API Anthropic',
+  'claudeIntegration.usage.status.network-error': 'Errore di rete',
+  'claudeIntegration.usage.status.read-error': 'Errore di lettura delle credenziali',
 } as const;

--- a/src/renderer/i18n/locales/ja.ts
+++ b/src/renderer/i18n/locales/ja.ts
@@ -283,7 +283,53 @@ export const ja = {
   'firstRun.autoUpdateMessage': 'WMUXが自動的にアップデートを確認するようにしますか？後で設定から変更できます。',
   'firstRun.enable': '有効にする',
   'firstRun.disable': 'いいえ',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': '初回設定',
+  'settings.firstRunSetupDesc': 'ようこそ画面のウィザードをもう一度開いたり、キーボードショートカット一覧を再表示したりできます。',
+  'settings.firstRunSetup.lastCompleted': '最終完了: {date}',
+  'settings.firstRunSetup.notCompleted': 'まだ完了していません',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP: {status}',
+  'settings.firstRunSetup.statusDetected': '検出済み',
+  'settings.firstRunSetup.statusNotDetected': '未検出',
+  'settings.firstRunSetup.statusRegistered': '登録済み',
+  'settings.firstRunSetup.statusNotRegistered': '未登録',
+  'settings.firstRunSetup.openWizard': 'セットアップウィザードを開く',
+  'settings.firstRunSetup.showCheatSheet': 'キーボードショートカット一覧を表示',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Claude 連携',
+  'claudeIntegration.signalHealth.title': 'プラグインのシグナル状態',
+  'claudeIntegration.signalHealth.unknownBody':
+    'プラグインの状態: まだ検出されていません。Claude Code で下記のコマンドを実行してインストールしてください。最初のフックが発火すると、wmux が検出を確認します。',
+  'claudeIntegration.signalHealth.detectedLastReceived': '最後のシグナル: {rel}',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'レイテンシ P50 {p50}ms · P95 {p95}ms · サンプル {count} 件',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'ワークスペースの一致: {matched}/{total} 件のフックが wmux のペインに対応付けられました',
+  'claudeIntegration.signalHealth.staleBody':
+    'プラグインの状態: 古くなっています。最後のフックが届いたのは {rel} です — プラグインの発火が止まったか、Claude Code がアイドル状態の可能性があります。',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'インストールコマンドをコピー',
+  'claudeIntegration.signalHealth.copySuccess': 'コピーしました — Claude Code に貼り付けてください',
+  'claudeIntegration.signalHealth.copyError': 'コピーに失敗しました — クリップボードがロックされています',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Anthropic 使用量メーター (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'ローカルストレージから Claude Code の OAuth トークンを読み取り、1-token の Haiku リクエストで Anthropic にプローブしてレート制限ヘッダーを取得します。プローブの料金はご自身のクォータに課金されます (≈ ごくわずか)。トークンは書き戻されることもログに記録されることもなく、api.anthropic.com にのみ送信されます。',
+  'claudeIntegration.usage.enableLabel': 'ステータスバーに 5h / 7d の使用率を表示',
+  'claudeIntegration.usage.refreshButton': '今すぐ更新',
+  'claudeIntegration.usage.refreshCooldown': '{seconds} 秒後に更新できます',
+  'claudeIntegration.usage.subscription': 'プラン: {tier}',
+  'claudeIntegration.usage.lastFetched': '最終取得: {ago}',
+  'claudeIntegration.usage.justNow': 'たった今',
+  'claudeIntegration.usage.minutesAgo': '{n} 分前',
+  'claudeIntegration.usage.hoursAgo': '{n} 時間前',
+  'claudeIntegration.usage.daysAgo': '{n} 日前',
+  'claudeIntegration.usage.status.token-missing': 'Claude Code にログインしていません',
+  'claudeIntegration.usage.status.unauthorized': 'トークンの有効期限が切れました — Claude Code に再度ログインしてください',
+  'claudeIntegration.usage.status.http-error': 'Anthropic API エラー',
+  'claudeIntegration.usage.status.network-error': 'ネットワークエラー',
+  'claudeIntegration.usage.status.read-error': '認証情報の読み取りエラー',
 } as const;

--- a/src/renderer/i18n/locales/ms.ts
+++ b/src/renderer/i18n/locales/ms.ts
@@ -240,7 +240,55 @@ export const ms = {
   'firstRun.autoUpdateMessage': 'Adakah anda mahu WMUX memeriksa kemas kini secara automatik? Anda boleh ubah ini kemudian di Tetapan.',
   'firstRun.enable': 'Dayakan',
   'firstRun.disable': 'Tidak, terima kasih',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'Persediaan kali pertama',
+  'settings.firstRunSetupDesc':
+    'Buka semula bestari alu-aluan atau tunjukkan helaian pintasan papan kekunci sekali lagi.',
+  'settings.firstRunSetup.lastCompleted': 'Terakhir diselesaikan: {date}',
+  'settings.firstRunSetup.notCompleted': 'Belum diselesaikan lagi',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP: {status}',
+  'settings.firstRunSetup.statusDetected': 'dikesan',
+  'settings.firstRunSetup.statusNotDetected': 'tidak dikesan',
+  'settings.firstRunSetup.statusRegistered': 'didaftarkan',
+  'settings.firstRunSetup.statusNotRegistered': 'tidak didaftarkan',
+  'settings.firstRunSetup.openWizard': 'Buka bestari persediaan',
+  'settings.firstRunSetup.showCheatSheet': 'Tunjukkan helaian pintasan papan kekunci',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Penyepaduan Claude',
+  'claudeIntegration.signalHealth.title': 'Kesihatan isyarat pemalam',
+  'claudeIntegration.signalHealth.unknownBody':
+    'Status pemalam: belum diperhatikan. Pasang dengan arahan di bawah dalam Claude Code. wmux akan mengesahkan pengesanan sebaik sahaja hook pertama dicetuskan.',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'Isyarat terakhir {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'Kependaman P50 {p50}ms · P95 {p95}ms · {count} sampel',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'Padanan ruang kerja: {matched}/{total} hook dipadankan ke panel wmux',
+  'claudeIntegration.signalHealth.staleBody':
+    'Status pemalam: basi. Hook terakhir tiba {rel} — pemalam mungkin telah berhenti dicetuskan atau Claude Code sedang tidak aktif.',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'Salin arahan pemasangan',
+  'claudeIntegration.signalHealth.copySuccess': 'Disalin — tampal ke dalam Claude Code',
+  'claudeIntegration.signalHealth.copyError': 'Gagal menyalin — papan keratan dikunci',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Meter penggunaan Anthropic (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'Membaca token OAuth Claude Code anda daripada storan tempatan dan menguji Anthropic dengan permintaan Haiku 1-token untuk membaca pengepala had kadar. Ujian ini dicajkan kepada kuota anda sendiri (≈ boleh diabaikan). Token tidak pernah ditulis semula, tidak pernah dilog, hanya dihantar ke api.anthropic.com.',
+  'claudeIntegration.usage.enableLabel': 'Tunjukkan penggunaan 5h / 7d dalam bar status',
+  'claudeIntegration.usage.refreshButton': 'Segar semula sekarang',
+  'claudeIntegration.usage.refreshCooldown': 'Segar semula tersedia dalam {seconds}s',
+  'claudeIntegration.usage.subscription': 'Pelan: {tier}',
+  'claudeIntegration.usage.lastFetched': 'Terakhir diambil: {ago}',
+  'claudeIntegration.usage.justNow': 'sebentar tadi',
+  'claudeIntegration.usage.minutesAgo': '{n}m lalu',
+  'claudeIntegration.usage.hoursAgo': '{n}h lalu',
+  'claudeIntegration.usage.daysAgo': '{n}d lalu',
+  'claudeIntegration.usage.status.token-missing': 'Claude Code belum log masuk',
+  'claudeIntegration.usage.status.unauthorized':
+    'Token tamat tempoh — log masuk ke Claude Code semula',
+  'claudeIntegration.usage.status.http-error': 'Ralat API Anthropic',
+  'claudeIntegration.usage.status.network-error': 'Ralat rangkaian',
+  'claudeIntegration.usage.status.read-error': 'Ralat membaca kelayakan',
 } as const;

--- a/src/renderer/i18n/locales/nb.ts
+++ b/src/renderer/i18n/locales/nb.ts
@@ -240,7 +240,54 @@ export const nb = {
   'firstRun.autoUpdateMessage': 'Vil du at WMUX skal se etter oppdateringer automatisk? Du kan endre dette senere i Innstillinger.',
   'firstRun.enable': 'Aktiver',
   'firstRun.disable': 'Nei takk',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'Førstegangsoppsett',
+  'settings.firstRunSetupDesc':
+    'Åpne velkomstveiviseren på nytt, eller vis hurtigtastoversikten igjen.',
+  'settings.firstRunSetup.lastCompleted': 'Sist fullført: {date}',
+  'settings.firstRunSetup.notCompleted': 'Ikke fullført ennå',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP: {status}',
+  'settings.firstRunSetup.statusDetected': 'oppdaget',
+  'settings.firstRunSetup.statusNotDetected': 'ikke oppdaget',
+  'settings.firstRunSetup.statusRegistered': 'registrert',
+  'settings.firstRunSetup.statusNotRegistered': 'ikke registrert',
+  'settings.firstRunSetup.openWizard': 'Åpne oppsettsveiviser',
+  'settings.firstRunSetup.showCheatSheet': 'Vis hurtigtastoversikt',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Claude-integrasjon',
+  'claudeIntegration.signalHealth.title': 'Signaltilstand for programtillegg',
+  'claudeIntegration.signalHealth.unknownBody':
+    'Status for programtillegg: ikke observert ennå. Installer med kommandoen nedenfor i Claude Code. wmux bekrefter oppdagelse så snart den første kroken utløses.',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'Siste signal {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'Forsinkelse P50 {p50}ms · P95 {p95}ms · {count} prøver',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'Treff på arbeidsområde: {matched}/{total} kroker løst til et wmux-panel',
+  'claudeIntegration.signalHealth.staleBody':
+    'Status for programtillegg: foreldet. Siste krok kom {rel} — programtillegget kan ha sluttet å utløses, eller Claude Code er inaktiv.',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'Kopier installasjonskommando',
+  'claudeIntegration.signalHealth.copySuccess': 'Kopiert — lim inn i Claude Code',
+  'claudeIntegration.signalHealth.copyError': 'Kopiering mislyktes — utklippstavlen er låst',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Anthropic-bruksmåler (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'Leser Claude Code-OAuth-tokenet ditt fra lokal lagring og sonderer Anthropic med en Haiku-forespørsel på 1-token for å lese rategrense-hodene. Sonderingen belastes din egen kvote (≈ ubetydelig). Tokenet skrives aldri tilbake, logges aldri, og sendes bare til api.anthropic.com.',
+  'claudeIntegration.usage.enableLabel': 'Vis 5h / 7d-utnyttelse i statuslinjen',
+  'claudeIntegration.usage.refreshButton': 'Oppdater nå',
+  'claudeIntegration.usage.refreshCooldown': 'Oppdatering tilgjengelig om {seconds}s',
+  'claudeIntegration.usage.subscription': 'Abonnement: {tier}',
+  'claudeIntegration.usage.lastFetched': 'Sist hentet: {ago}',
+  'claudeIntegration.usage.justNow': 'akkurat nå',
+  'claudeIntegration.usage.minutesAgo': 'for {n}m siden',
+  'claudeIntegration.usage.hoursAgo': 'for {n}t siden',
+  'claudeIntegration.usage.daysAgo': 'for {n}d siden',
+  'claudeIntegration.usage.status.token-missing': 'Ikke logget på Claude Code',
+  'claudeIntegration.usage.status.unauthorized': 'Tokenet er utløpt — logg på Claude Code igjen',
+  'claudeIntegration.usage.status.http-error': 'Feil i Anthropic-API-et',
+  'claudeIntegration.usage.status.network-error': 'Nettverksfeil',
+  'claudeIntegration.usage.status.read-error': 'Feil ved lesing av påloggingsinformasjon',
 } as const;

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -240,7 +240,55 @@ export const pl = {
   'firstRun.autoUpdateMessage': 'Czy chcesz, aby WMUX automatycznie sprawdzał aktualizacje? Możesz zmienić to później w ustawieniach.',
   'firstRun.enable': 'Włącz',
   'firstRun.disable': 'Nie, dziękuję',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'Konfiguracja początkowa',
+  'settings.firstRunSetupDesc':
+    'Otwórz ponownie kreatora powitalnego lub pokaż ponownie ściągę klawiszy.',
+  'settings.firstRunSetup.lastCompleted': 'Ostatnio ukończono: {date}',
+  'settings.firstRunSetup.notCompleted': 'Jeszcze nie ukończono',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP: {status}',
+  'settings.firstRunSetup.statusDetected': 'wykryto',
+  'settings.firstRunSetup.statusNotDetected': 'nie wykryto',
+  'settings.firstRunSetup.statusRegistered': 'zarejestrowano',
+  'settings.firstRunSetup.statusNotRegistered': 'nie zarejestrowano',
+  'settings.firstRunSetup.openWizard': 'Otwórz kreatora konfiguracji',
+  'settings.firstRunSetup.showCheatSheet': 'Pokaż ściągę klawiszy',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Integracja z Claude',
+  'claudeIntegration.signalHealth.title': 'Kondycja sygnału wtyczki',
+  'claudeIntegration.signalHealth.unknownBody':
+    'Status wtyczki: jeszcze nieobserwowany. Zainstaluj poniższym poleceniem w Claude Code. wmux potwierdzi wykrycie, gdy zadziała pierwszy hook.',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'Ostatni sygnał {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'Opóźnienie P50 {p50}ms · P95 {p95}ms · {count} próbek',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'Dopasowanie obszaru roboczego: {matched}/{total} hooków przypisano do panelu wmux',
+  'claudeIntegration.signalHealth.staleBody':
+    'Status wtyczki: nieaktualny. Ostatni hook dotarł {rel} — wtyczka mogła przestać działać lub Claude Code jest bezczynny.',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'Kopiuj polecenie instalacji',
+  'claudeIntegration.signalHealth.copySuccess': 'Skopiowano — wklej w Claude Code',
+  'claudeIntegration.signalHealth.copyError': 'Kopiowanie nie powiodło się — schowek zablokowany',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Miernik zużycia Anthropic (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'Odczytuje token OAuth Claude Code z lokalnej pamięci i odpytuje Anthropic żądaniem Haiku o wielkości 1-token, aby odczytać nagłówki limitu zapytań. Odpytanie jest rozliczane z Twojego własnego limitu (≈ pomijalne). Token nigdy nie jest zapisywany z powrotem ani logowany, jest wysyłany wyłącznie do api.anthropic.com.',
+  'claudeIntegration.usage.enableLabel': 'Pokaż wykorzystanie 5h / 7d na pasku stanu',
+  'claudeIntegration.usage.refreshButton': 'Odśwież teraz',
+  'claudeIntegration.usage.refreshCooldown': 'Odświeżenie dostępne za {seconds}s',
+  'claudeIntegration.usage.subscription': 'Plan: {tier}',
+  'claudeIntegration.usage.lastFetched': 'Ostatnio pobrano: {ago}',
+  'claudeIntegration.usage.justNow': 'przed chwilą',
+  'claudeIntegration.usage.minutesAgo': '{n} min temu',
+  'claudeIntegration.usage.hoursAgo': '{n} godz. temu',
+  'claudeIntegration.usage.daysAgo': '{n} dni temu',
+  'claudeIntegration.usage.status.token-missing': 'Brak logowania do Claude Code',
+  'claudeIntegration.usage.status.unauthorized':
+    'Token wygasł — zaloguj się ponownie do Claude Code',
+  'claudeIntegration.usage.status.http-error': 'Błąd API Anthropic',
+  'claudeIntegration.usage.status.network-error': 'Błąd sieci',
+  'claudeIntegration.usage.status.read-error': 'Błąd odczytu poświadczeń',
 } as const;

--- a/src/renderer/i18n/locales/pt-BR.ts
+++ b/src/renderer/i18n/locales/pt-BR.ts
@@ -240,7 +240,55 @@ export const ptBR = {
   'firstRun.autoUpdateMessage': 'Deseja que o WMUX verifique atualizações automaticamente? Você pode alterar isso depois em Configurações.',
   'firstRun.enable': 'Ativar',
   'firstRun.disable': 'Não, obrigado',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'Configuração inicial',
+  'settings.firstRunSetupDesc':
+    'Reabra o assistente de boas-vindas ou exiba novamente a folha de atalhos do teclado.',
+  'settings.firstRunSetup.lastCompleted': 'Concluído pela última vez: {date}',
+  'settings.firstRunSetup.notCompleted': 'Ainda não concluído',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'MCP do wmux: {status}',
+  'settings.firstRunSetup.statusDetected': 'detectado',
+  'settings.firstRunSetup.statusNotDetected': 'não detectado',
+  'settings.firstRunSetup.statusRegistered': 'registrado',
+  'settings.firstRunSetup.statusNotRegistered': 'não registrado',
+  'settings.firstRunSetup.openWizard': 'Abrir assistente de configuração',
+  'settings.firstRunSetup.showCheatSheet': 'Mostrar folha de atalhos do teclado',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Integração com Claude',
+  'claudeIntegration.signalHealth.title': 'Integridade do sinal do plugin',
+  'claudeIntegration.signalHealth.unknownBody':
+    'Status do plugin: ainda não observado. Instale com o comando abaixo no Claude Code. O wmux confirma a detecção assim que o primeiro hook é disparado.',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'Último sinal {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'Latência P50 {p50}ms · P95 {p95}ms · {count} amostras',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'Correspondência de espaço de trabalho: {matched}/{total} hooks resolvidos para um painel do wmux',
+  'claudeIntegration.signalHealth.staleBody':
+    'Status do plugin: desatualizado. O último hook chegou {rel} — o plugin pode ter parado de disparar ou o Claude Code está ocioso.',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'Copiar comando de instalação',
+  'claudeIntegration.signalHealth.copySuccess': 'Copiado — cole no Claude Code',
+  'claudeIntegration.signalHealth.copyError': 'Falha ao copiar — área de transferência bloqueada',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Medidor de uso da Anthropic (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'Lê seu token OAuth do Claude Code do armazenamento local e sonda a Anthropic com uma requisição Haiku de 1-token para ler os cabeçalhos de limite de taxa. A sondagem é cobrada da sua própria cota (≈ insignificante). O token nunca é gravado de volta, nunca é registrado, apenas enviado para api.anthropic.com.',
+  'claudeIntegration.usage.enableLabel': 'Mostrar utilização de 5h / 7d na barra de status',
+  'claudeIntegration.usage.refreshButton': 'Atualizar agora',
+  'claudeIntegration.usage.refreshCooldown': 'Atualização disponível em {seconds}s',
+  'claudeIntegration.usage.subscription': 'Plano: {tier}',
+  'claudeIntegration.usage.lastFetched': 'Última atualização: {ago}',
+  'claudeIntegration.usage.justNow': 'agora mesmo',
+  'claudeIntegration.usage.minutesAgo': 'há {n}min',
+  'claudeIntegration.usage.hoursAgo': 'há {n}h',
+  'claudeIntegration.usage.daysAgo': 'há {n}d',
+  'claudeIntegration.usage.status.token-missing': 'Não conectado ao Claude Code',
+  'claudeIntegration.usage.status.unauthorized':
+    'Token expirado — conecte-se ao Claude Code novamente',
+  'claudeIntegration.usage.status.http-error': 'Erro da API da Anthropic',
+  'claudeIntegration.usage.status.network-error': 'Erro de rede',
+  'claudeIntegration.usage.status.read-error': 'Erro ao ler credencial',
 } as const;

--- a/src/renderer/i18n/locales/ru.ts
+++ b/src/renderer/i18n/locales/ru.ts
@@ -240,7 +240,55 @@ export const ru = {
   'firstRun.autoUpdateMessage': 'Разрешить WMUX автоматически проверять обновления? Это можно изменить позже в настройках.',
   'firstRun.enable': 'Включить',
   'firstRun.disable': 'Нет, спасибо',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'Первоначальная настройка',
+  'settings.firstRunSetupDesc':
+    'Снова откройте мастер первоначальной настройки или покажите шпаргалку по сочетаниям клавиш.',
+  'settings.firstRunSetup.lastCompleted': 'Последнее завершение: {date}',
+  'settings.firstRunSetup.notCompleted': 'Ещё не завершено',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP: {status}',
+  'settings.firstRunSetup.statusDetected': 'обнаружен',
+  'settings.firstRunSetup.statusNotDetected': 'не обнаружен',
+  'settings.firstRunSetup.statusRegistered': 'зарегистрирован',
+  'settings.firstRunSetup.statusNotRegistered': 'не зарегистрирован',
+  'settings.firstRunSetup.openWizard': 'Открыть мастер настройки',
+  'settings.firstRunSetup.showCheatSheet': 'Показать шпаргалку по клавишам',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Интеграция с Claude',
+  'claudeIntegration.signalHealth.title': 'Состояние сигнала плагина',
+  'claudeIntegration.signalHealth.unknownBody':
+    'Статус плагина: ещё не зафиксирован. Установите его командой ниже в Claude Code. wmux подтвердит обнаружение, как только сработает первый хук.',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'Последний сигнал {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'Задержка P50 {p50}ms · P95 {p95}ms · {count} измерений',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'Совпадение рабочих пространств: {matched}/{total} хуков сопоставлены с панелью wmux',
+  'claudeIntegration.signalHealth.staleBody':
+    'Статус плагина: устарел. Последний хук пришёл {rel} — возможно, плагин перестал срабатывать или Claude Code простаивает.',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'Копировать команду установки',
+  'claudeIntegration.signalHealth.copySuccess': 'Скопировано — вставьте в Claude Code',
+  'claudeIntegration.signalHealth.copyError': 'Не удалось скопировать — буфер обмена заблокирован',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Счётчик использования Anthropic (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'Считывает ваш OAuth-токен Claude Code из локального хранилища и опрашивает Anthropic запросом к Haiku на 1 токен (1-token), чтобы прочитать заголовки лимита запросов. Запрос списывается с вашей собственной квоты (≈ незначительно). Токен никогда не записывается обратно, никогда не логируется и отправляется только на api.anthropic.com.',
+  'claudeIntegration.usage.enableLabel': 'Показывать использование 5h / 7d в строке состояния',
+  'claudeIntegration.usage.refreshButton': 'Обновить сейчас',
+  'claudeIntegration.usage.refreshCooldown': 'Обновление будет доступно через {seconds} с',
+  'claudeIntegration.usage.subscription': 'Тариф: {tier}',
+  'claudeIntegration.usage.lastFetched': 'Последнее обновление: {ago}',
+  'claudeIntegration.usage.justNow': 'только что',
+  'claudeIntegration.usage.minutesAgo': '{n} мин назад',
+  'claudeIntegration.usage.hoursAgo': '{n} ч назад',
+  'claudeIntegration.usage.daysAgo': '{n} дн назад',
+  'claudeIntegration.usage.status.token-missing': 'Вход в Claude Code не выполнен',
+  'claudeIntegration.usage.status.unauthorized':
+    'Срок действия токена истёк — войдите в Claude Code снова',
+  'claudeIntegration.usage.status.http-error': 'Ошибка API Anthropic',
+  'claudeIntegration.usage.status.network-error': 'Ошибка сети',
+  'claudeIntegration.usage.status.read-error': 'Ошибка чтения учётных данных',
 } as const;

--- a/src/renderer/i18n/locales/th.ts
+++ b/src/renderer/i18n/locales/th.ts
@@ -240,7 +240,53 @@ export const th = {
   'firstRun.autoUpdateMessage': 'ต้องการให้ WMUX ตรวจสอบการอัปเดตโดยอัตโนมัติหรือไม่? คุณสามารถเปลี่ยนแปลงได้ในภายหลังในการตั้งค่า',
   'firstRun.enable': 'เปิดใช้งาน',
   'firstRun.disable': 'ไม่ ขอบคุณ',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'การตั้งค่าครั้งแรก',
+  'settings.firstRunSetupDesc': 'เปิดตัวช่วยต้อนรับอีกครั้ง หรือแสดงสรุปแป้นพิมพ์ลัดอีกครั้ง',
+  'settings.firstRunSetup.lastCompleted': 'ทำเสร็จครั้งล่าสุด: {date}',
+  'settings.firstRunSetup.notCompleted': 'ยังทำไม่เสร็จ',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP: {status}',
+  'settings.firstRunSetup.statusDetected': 'ตรวจพบแล้ว',
+  'settings.firstRunSetup.statusNotDetected': 'ไม่พบ',
+  'settings.firstRunSetup.statusRegistered': 'ลงทะเบียนแล้ว',
+  'settings.firstRunSetup.statusNotRegistered': 'ยังไม่ลงทะเบียน',
+  'settings.firstRunSetup.openWizard': 'เปิดตัวช่วยตั้งค่า',
+  'settings.firstRunSetup.showCheatSheet': 'แสดงสรุปแป้นพิมพ์ลัด',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'การเชื่อมต่อ Claude',
+  'claudeIntegration.signalHealth.title': 'สถานะสัญญาณปลั๊กอิน',
+  'claudeIntegration.signalHealth.unknownBody':
+    'สถานะปลั๊กอิน: ยังไม่พบสัญญาณ ติดตั้งโดยใช้คำสั่งด้านล่างนี้ใน Claude Code แล้ว wmux จะยืนยันการตรวจพบเมื่อ hook แรกทำงาน',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'สัญญาณล่าสุดเมื่อ {rel}',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'ความหน่วง P50 {p50}ms · P95 {p95}ms · {count} ตัวอย่าง',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'การจับคู่พื้นที่ทำงาน: {matched}/{total} hook เชื่อมโยงกับพาเนลของ wmux',
+  'claudeIntegration.signalHealth.staleBody':
+    'สถานะปลั๊กอิน: ค้าง hook ล่าสุดมาถึงเมื่อ {rel} — ปลั๊กอินอาจหยุดส่งสัญญาณ หรือ Claude Code กำลังว่างอยู่',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'คัดลอกคำสั่งติดตั้ง',
+  'claudeIntegration.signalHealth.copySuccess': 'คัดลอกแล้ว — วางลงใน Claude Code',
+  'claudeIntegration.signalHealth.copyError': 'คัดลอกไม่สำเร็จ — คลิปบอร์ดถูกล็อก',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'มาตรวัดการใช้งาน Anthropic (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'อ่านโทเค็น OAuth ของ Claude Code จากที่จัดเก็บภายในเครื่อง แล้วส่งคำขอ Haiku แบบ 1-token ไปยัง Anthropic เพื่ออ่านส่วนหัวขีดจำกัดอัตรา การส่งคำขอนี้จะคิดค่าใช้จ่ายจากโควตาของคุณเอง (≈ น้อยมาก) โทเค็นจะไม่ถูกเขียนกลับ ไม่ถูกบันทึก และส่งไปยัง api.anthropic.com เท่านั้น',
+  'claudeIntegration.usage.enableLabel': 'แสดงการใช้งาน 5h / 7d ในแถบสถานะ',
+  'claudeIntegration.usage.refreshButton': 'รีเฟรชเดี๋ยวนี้',
+  'claudeIntegration.usage.refreshCooldown': 'รีเฟรชได้ในอีก {seconds} วินาที',
+  'claudeIntegration.usage.subscription': 'แผน: {tier}',
+  'claudeIntegration.usage.lastFetched': 'ดึงข้อมูลล่าสุด: {ago}',
+  'claudeIntegration.usage.justNow': 'เมื่อสักครู่',
+  'claudeIntegration.usage.minutesAgo': '{n} นาทีที่แล้ว',
+  'claudeIntegration.usage.hoursAgo': '{n} ชั่วโมงที่แล้ว',
+  'claudeIntegration.usage.daysAgo': '{n} วันที่แล้ว',
+  'claudeIntegration.usage.status.token-missing': 'ยังไม่ได้เข้าสู่ระบบ Claude Code',
+  'claudeIntegration.usage.status.unauthorized': 'โทเค็นหมดอายุ — เข้าสู่ระบบ Claude Code อีกครั้ง',
+  'claudeIntegration.usage.status.http-error': 'ข้อผิดพลาดของ Anthropic API',
+  'claudeIntegration.usage.status.network-error': 'ข้อผิดพลาดของเครือข่าย',
+  'claudeIntegration.usage.status.read-error': 'อ่านข้อมูลรับรองผิดพลาด',
 } as const;

--- a/src/renderer/i18n/locales/tr.ts
+++ b/src/renderer/i18n/locales/tr.ts
@@ -240,7 +240,55 @@ export const tr = {
   'firstRun.autoUpdateMessage': 'WMUX güncellemeleri otomatik denetlemesin mi? Bunu daha sonra Ayarlar\'dan değiştirebilirsiniz.',
   'firstRun.enable': 'Etkinleştir',
   'firstRun.disable': 'Hayır, teşekkürler',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'İlk kurulum',
+  'settings.firstRunSetupDesc':
+    'Karşılama sihirbazını yeniden açın veya klavye kısayolları kartını tekrar gösterin.',
+  'settings.firstRunSetup.lastCompleted': 'Son tamamlanma: {date}',
+  'settings.firstRunSetup.notCompleted': 'henüz tamamlanmadı',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP: {status}',
+  'settings.firstRunSetup.statusDetected': 'algılandı',
+  'settings.firstRunSetup.statusNotDetected': 'algılanmadı',
+  'settings.firstRunSetup.statusRegistered': 'kayıtlı',
+  'settings.firstRunSetup.statusNotRegistered': 'kayıtlı değil',
+  'settings.firstRunSetup.openWizard': 'Kurulum sihirbazını aç',
+  'settings.firstRunSetup.showCheatSheet': 'Klavye kısayolları kartını göster',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Claude entegrasyonu',
+  'claudeIntegration.signalHealth.title': 'Eklenti sinyal durumu',
+  'claudeIntegration.signalHealth.unknownBody':
+    'Eklenti durumu: henüz gözlemlenmedi. Claude Code içinde aşağıdaki komutla yükleyin. İlk kanca tetiklendiğinde wmux algılamayı onaylar.',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'Son sinyal {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'Gecikme P50 {p50}ms · P95 {p95}ms · {count} örnek',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'Çalışma alanı eşleşmesi: {matched}/{total} kanca bir wmux bölmesine çözümlendi',
+  'claudeIntegration.signalHealth.staleBody':
+    'Eklenti durumu: eski. Son kanca {rel} geldi — eklenti tetiklemeyi durdurmuş olabilir ya da Claude Code boşta.',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'Yükleme komutunu kopyala',
+  'claudeIntegration.signalHealth.copySuccess': 'Kopyalandı — Claude Code içine yapıştırın',
+  'claudeIntegration.signalHealth.copyError': 'Kopyalama başarısız — pano kilitli',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Anthropic kullanım ölçer (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'Claude Code OAuth jetonunuzu yerel depolamadan okur ve hız sınırı başlıklarını okumak için Anthropic\'i 1-token Haiku isteğiyle yoklar. Yoklama kendi kotanıza faturalanır (≈ ihmal edilebilir). Jeton asla geri yazılmaz, asla günlüğe kaydedilmez, yalnızca api.anthropic.com adresine gönderilir.',
+  'claudeIntegration.usage.enableLabel': 'Durum çubuğunda 5h / 7d kullanımını göster',
+  'claudeIntegration.usage.refreshButton': 'Şimdi yenile',
+  'claudeIntegration.usage.refreshCooldown': 'Yenileme {seconds}sn içinde kullanılabilir',
+  'claudeIntegration.usage.subscription': 'Plan: {tier}',
+  'claudeIntegration.usage.lastFetched': 'Son alınma: {ago}',
+  'claudeIntegration.usage.justNow': 'az önce',
+  'claudeIntegration.usage.minutesAgo': '{n}dk önce',
+  'claudeIntegration.usage.hoursAgo': '{n}sa önce',
+  'claudeIntegration.usage.daysAgo': '{n}g önce',
+  'claudeIntegration.usage.status.token-missing': 'Claude Code\'da oturum açılmamış',
+  'claudeIntegration.usage.status.unauthorized':
+    'Jeton süresi doldu — Claude Code\'da tekrar oturum açın',
+  'claudeIntegration.usage.status.http-error': 'Anthropic API hatası',
+  'claudeIntegration.usage.status.network-error': 'Ağ hatası',
+  'claudeIntegration.usage.status.read-error': 'Kimlik bilgisi okuma hatası',
 } as const;

--- a/src/renderer/i18n/locales/uk.ts
+++ b/src/renderer/i18n/locales/uk.ts
@@ -240,7 +240,55 @@ export const uk = {
   'firstRun.autoUpdateMessage': 'Дозволити WMUX автоматично перевіряти оновлення? Це можна змінити пізніше в налаштуваннях.',
   'firstRun.enable': 'Увімкнути',
   'firstRun.disable': 'Ні, дякую',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'Початкове налаштування',
+  'settings.firstRunSetupDesc':
+    'Знову відкрити майстер привітання або ще раз показати шпаргалку клавіш.',
+  'settings.firstRunSetup.lastCompleted': 'Востаннє завершено: {date}',
+  'settings.firstRunSetup.notCompleted': 'Ще не завершено',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP: {status}',
+  'settings.firstRunSetup.statusDetected': 'виявлено',
+  'settings.firstRunSetup.statusNotDetected': 'не виявлено',
+  'settings.firstRunSetup.statusRegistered': 'зареєстровано',
+  'settings.firstRunSetup.statusNotRegistered': 'не зареєстровано',
+  'settings.firstRunSetup.openWizard': 'Відкрити майстер налаштування',
+  'settings.firstRunSetup.showCheatSheet': 'Показати шпаргалку клавіш',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Інтеграція з Claude',
+  'claudeIntegration.signalHealth.title': 'Стан сигналу плагіна',
+  'claudeIntegration.signalHealth.unknownBody':
+    'Стан плагіна: ще не зафіксовано. Установіть його за допомогою наведеної нижче команди в Claude Code. wmux підтвердить виявлення, щойно спрацює перший хук.',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'Останній сигнал {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'Затримка P50 {p50}ms · P95 {p95}ms · {count} зразків',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'Збіг робочого простору: {matched}/{total} хуків зіставлено з панеллю wmux',
+  'claudeIntegration.signalHealth.staleBody':
+    'Стан плагіна: застарілий. Останній хук надійшов {rel} — можливо, плагін перестав спрацьовувати або Claude Code простоює.',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'Скопіювати команду встановлення',
+  'claudeIntegration.signalHealth.copySuccess': 'Скопійовано — вставте в Claude Code',
+  'claudeIntegration.signalHealth.copyError': 'Не вдалося скопіювати — буфер обміну заблоковано',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Лічильник використання Anthropic (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'Зчитує ваш OAuth-токен Claude Code з локального сховища та надсилає до Anthropic запит Haiku на 1-token, щоб прочитати заголовки обмеження частоти. Запит списується з вашої власної квоти (≈ незначно). Токен ніколи не записується назад, ніколи не логується, а лише надсилається до api.anthropic.com.',
+  'claudeIntegration.usage.enableLabel': 'Показувати використання 5h / 7d у рядку стану',
+  'claudeIntegration.usage.refreshButton': 'Оновити зараз',
+  'claudeIntegration.usage.refreshCooldown': 'Оновлення буде доступне через {seconds} с',
+  'claudeIntegration.usage.subscription': 'Тариф: {tier}',
+  'claudeIntegration.usage.lastFetched': 'Востаннє отримано: {ago}',
+  'claudeIntegration.usage.justNow': 'щойно',
+  'claudeIntegration.usage.minutesAgo': '{n} хв тому',
+  'claudeIntegration.usage.hoursAgo': '{n} год тому',
+  'claudeIntegration.usage.daysAgo': '{n} дн тому',
+  'claudeIntegration.usage.status.token-missing': 'Не виконано вхід у Claude Code',
+  'claudeIntegration.usage.status.unauthorized':
+    'Термін дії токена минув — увійдіть у Claude Code знову',
+  'claudeIntegration.usage.status.http-error': 'Помилка API Anthropic',
+  'claudeIntegration.usage.status.network-error': 'Помилка мережі',
+  'claudeIntegration.usage.status.read-error': 'Помилка читання облікових даних',
 } as const;

--- a/src/renderer/i18n/locales/vi.ts
+++ b/src/renderer/i18n/locales/vi.ts
@@ -240,7 +240,53 @@ export const vi = {
   'firstRun.autoUpdateMessage': 'Bạn có muốn WMUX tự động kiểm tra cập nhật? Bạn có thể đổi sau trong Cài đặt.',
   'firstRun.enable': 'Bật',
   'firstRun.disable': 'Không, cảm ơn',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': 'Thiết lập lần đầu',
+  'settings.firstRunSetupDesc': 'Mở lại trình hướng dẫn chào mừng hoặc xem lại bảng phím tắt.',
+  'settings.firstRunSetup.lastCompleted': 'Hoàn tất lần cuối: {date}',
+  'settings.firstRunSetup.notCompleted': 'Chưa hoàn tất',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code: {status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP: {status}',
+  'settings.firstRunSetup.statusDetected': 'đã phát hiện',
+  'settings.firstRunSetup.statusNotDetected': 'chưa phát hiện',
+  'settings.firstRunSetup.statusRegistered': 'đã đăng ký',
+  'settings.firstRunSetup.statusNotRegistered': 'chưa đăng ký',
+  'settings.firstRunSetup.openWizard': 'Mở trình hướng dẫn thiết lập',
+  'settings.firstRunSetup.showCheatSheet': 'Hiện bảng phím tắt',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Tích hợp Claude',
+  'claudeIntegration.signalHealth.title': 'Tình trạng tín hiệu plugin',
+  'claudeIntegration.signalHealth.unknownBody':
+    'Trạng thái plugin: chưa quan sát được. Hãy cài đặt bằng lệnh bên dưới trong Claude Code. wmux sẽ xác nhận phát hiện khi hook đầu tiên kích hoạt.',
+  'claudeIntegration.signalHealth.detectedLastReceived': 'Tín hiệu cuối {rel}.',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    'Độ trễ P50 {p50}ms · P95 {p95}ms · {count} mẫu',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    'Khớp không gian làm việc: {matched}/{total} hook đã phân giải về một khung wmux',
+  'claudeIntegration.signalHealth.staleBody':
+    'Trạng thái plugin: đã cũ. Hook cuối đến {rel} — plugin có thể đã ngừng kích hoạt hoặc Claude Code đang nhàn rỗi.',
+  'claudeIntegration.signalHealth.copyInstallCommand': 'Sao chép lệnh cài đặt',
+  'claudeIntegration.signalHealth.copySuccess': 'Đã sao chép — dán vào Claude Code',
+  'claudeIntegration.signalHealth.copyError': 'Sao chép thất bại — bộ nhớ tạm bị khoá',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Đồng hồ sử dụng Anthropic (5h / 7d)',
+  'claudeIntegration.usage.description':
+    'Đọc token OAuth Claude Code của bạn từ bộ nhớ cục bộ và thăm dò Anthropic bằng một yêu cầu Haiku 1-token để đọc các header giới hạn tốc độ. Lần thăm dò được tính vào hạn mức của chính bạn (≈ không đáng kể). Token không bao giờ được ghi ngược lại, không bao giờ được ghi log, chỉ gửi tới api.anthropic.com.',
+  'claudeIntegration.usage.enableLabel': 'Hiện mức sử dụng 5h / 7d trên thanh trạng thái',
+  'claudeIntegration.usage.refreshButton': 'Làm mới ngay',
+  'claudeIntegration.usage.refreshCooldown': 'Có thể làm mới sau {seconds}s',
+  'claudeIntegration.usage.subscription': 'Gói: {tier}',
+  'claudeIntegration.usage.lastFetched': 'Lấy lần cuối: {ago}',
+  'claudeIntegration.usage.justNow': 'vừa xong',
+  'claudeIntegration.usage.minutesAgo': '{n} phút trước',
+  'claudeIntegration.usage.hoursAgo': '{n} giờ trước',
+  'claudeIntegration.usage.daysAgo': '{n} ngày trước',
+  'claudeIntegration.usage.status.token-missing': 'Chưa đăng nhập Claude Code',
+  'claudeIntegration.usage.status.unauthorized': 'Token đã hết hạn — đăng nhập lại Claude Code',
+  'claudeIntegration.usage.status.http-error': 'Lỗi API Anthropic',
+  'claudeIntegration.usage.status.network-error': 'Lỗi mạng',
+  'claudeIntegration.usage.status.read-error': 'Lỗi đọc thông tin xác thực',
 } as const;

--- a/src/renderer/i18n/locales/zh-TW.ts
+++ b/src/renderer/i18n/locales/zh-TW.ts
@@ -240,7 +240,53 @@ export const zhTW = {
   'firstRun.autoUpdateMessage': '要讓 WMUX 自動檢查更新嗎? 您之後可以在設定中變更。',
   'firstRun.enable': '啟用',
   'firstRun.disable': '不用了',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': '首次執行設定',
+  'settings.firstRunSetupDesc': '重新開啟歡迎精靈，或再次顯示鍵盤速查表。',
+  'settings.firstRunSetup.lastCompleted': '上次完成：{date}',
+  'settings.firstRunSetup.notCompleted': '尚未完成',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code：{status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP：{status}',
+  'settings.firstRunSetup.statusDetected': '已偵測到',
+  'settings.firstRunSetup.statusNotDetected': '未偵測到',
+  'settings.firstRunSetup.statusRegistered': '已註冊',
+  'settings.firstRunSetup.statusNotRegistered': '未註冊',
+  'settings.firstRunSetup.openWizard': '開啟設定精靈',
+  'settings.firstRunSetup.showCheatSheet': '顯示鍵盤速查表',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Claude 整合',
+  'claudeIntegration.signalHealth.title': '外掛訊號健康狀態',
+  'claudeIntegration.signalHealth.unknownBody':
+    '外掛狀態：尚未偵測到。請在 Claude Code 中使用下方指令安裝。第一個 hook 觸發後，wmux 即會確認偵測結果。',
+  'claudeIntegration.signalHealth.detectedLastReceived': '上次收到訊號：{rel}。',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    '延遲 P50 {p50}ms · P95 {p95}ms · {count} 個樣本',
+  'claudeIntegration.signalHealth.workspaceMatchFormat':
+    '工作區比對：{matched}/{total} 個 hook 對應到 wmux 面板',
+  'claudeIntegration.signalHealth.staleBody':
+    '外掛狀態：已停滯。上次 hook 於 {rel} 送達 — 外掛可能已停止觸發，或 Claude Code 處於閒置狀態。',
+  'claudeIntegration.signalHealth.copyInstallCommand': '複製安裝指令',
+  'claudeIntegration.signalHealth.copySuccess': '已複製 — 貼到 Claude Code',
+  'claudeIntegration.signalHealth.copyError': '複製失敗 — 剪貼簿已鎖定',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Anthropic 用量計 (5h / 7d)',
+  'claudeIntegration.usage.description':
+    '從本機儲存讀取你的 Claude Code OAuth 權杖，並以 1-token Haiku 請求向 Anthropic 探測，藉此讀取速率限制標頭。此探測會計入你自己的配額（≈ 微不足道）。權杖絕不會回寫、絕不會記錄，只會傳送至 api.anthropic.com。',
+  'claudeIntegration.usage.enableLabel': '在狀態列顯示 5h / 7d 使用率',
+  'claudeIntegration.usage.refreshButton': '立即重新整理',
+  'claudeIntegration.usage.refreshCooldown': '{seconds} 秒後可重新整理',
+  'claudeIntegration.usage.subscription': '方案：{tier}',
+  'claudeIntegration.usage.lastFetched': '上次擷取：{ago}',
+  'claudeIntegration.usage.justNow': '剛剛',
+  'claudeIntegration.usage.minutesAgo': '{n} 分鐘前',
+  'claudeIntegration.usage.hoursAgo': '{n} 小時前',
+  'claudeIntegration.usage.daysAgo': '{n} 天前',
+  'claudeIntegration.usage.status.token-missing': 'Claude Code 尚未登入',
+  'claudeIntegration.usage.status.unauthorized': '權杖已過期 — 請重新登入 Claude Code',
+  'claudeIntegration.usage.status.http-error': 'Anthropic API 錯誤',
+  'claudeIntegration.usage.status.network-error': '網路錯誤',
+  'claudeIntegration.usage.status.read-error': '憑證讀取錯誤',
 } as const;

--- a/src/renderer/i18n/locales/zh.ts
+++ b/src/renderer/i18n/locales/zh.ts
@@ -283,7 +283,52 @@ export const zh = {
   'firstRun.autoUpdateMessage': '是否让 WMUX 自动检查更新？您可以稍后在设置中更改。',
   'firstRun.enable': '启用',
   'firstRun.disable': '不需要',
-  // Settings tabs (#145 follow-up — labels missing from non-en/ko locales)
+
+  // Settings — First-run setup section (D7-C4)
   'settings.firstRunSetup': '首次运行设置',
+  'settings.firstRunSetupDesc': '重新打开欢迎向导，或再次显示键盘速查表。',
+  'settings.firstRunSetup.lastCompleted': '上次完成：{date}',
+  'settings.firstRunSetup.notCompleted': '尚未完成',
+  'settings.firstRunSetup.claudeStatus': 'Claude Code：{status}',
+  'settings.firstRunSetup.mcpStatus': 'wmux MCP：{status}',
+  'settings.firstRunSetup.statusDetected': '已检测到',
+  'settings.firstRunSetup.statusNotDetected': '未检测到',
+  'settings.firstRunSetup.statusRegistered': '已注册',
+  'settings.firstRunSetup.statusNotRegistered': '未注册',
+  'settings.firstRunSetup.openWizard': '打开设置向导',
+  'settings.firstRunSetup.showCheatSheet': '显示键盘速查表',
+
+  // Settings — Claude integration (Phase 1.5 signal-health card)
   'claudeIntegration.tab': 'Claude 集成',
+  'claudeIntegration.signalHealth.title': '插件信号健康状况',
+  'claudeIntegration.signalHealth.unknownBody':
+    '插件状态：尚未观测到。请在 Claude Code 中使用下方命令安装。首个钩子触发后，wmux 即会确认检测到插件。',
+  'claudeIntegration.signalHealth.detectedLastReceived': '上次信号：{rel}。',
+  'claudeIntegration.signalHealth.detectedLatencyFormat':
+    '延迟 P50 {p50}ms · P95 {p95}ms · {count} 个样本',
+  'claudeIntegration.signalHealth.workspaceMatchFormat': '工作区匹配：{matched}/{total} 个钩子已解析到 wmux 面板',
+  'claudeIntegration.signalHealth.staleBody':
+    '插件状态：已过期。最近一个钩子在 {rel}到达 — 插件可能已停止触发，或 Claude Code 处于空闲状态。',
+  'claudeIntegration.signalHealth.copyInstallCommand': '复制安装命令',
+  'claudeIntegration.signalHealth.copySuccess': '已复制 — 粘贴到 Claude Code 中',
+  'claudeIntegration.signalHealth.copyError': '复制失败 — 剪贴板已锁定',
+
+  // Phase 2 — Anthropic 5h/7d usage meter
+  'claudeIntegration.usage.title': 'Anthropic 用量表（5h / 7d）',
+  'claudeIntegration.usage.description':
+    '从本地存储读取你的 Claude Code OAuth 令牌，并以 1-token 的 Haiku 请求探测 Anthropic，以读取速率限制响应头。该探测会计入你自己的配额（≈ 可忽略不计）。令牌绝不会被写回、绝不会被记录，仅发送至 api.anthropic.com。',
+  'claudeIntegration.usage.enableLabel': '在状态栏显示 5h / 7d 用量',
+  'claudeIntegration.usage.refreshButton': '立即刷新',
+  'claudeIntegration.usage.refreshCooldown': '{seconds} 秒后可刷新',
+  'claudeIntegration.usage.subscription': '套餐：{tier}',
+  'claudeIntegration.usage.lastFetched': '上次获取：{ago}',
+  'claudeIntegration.usage.justNow': '刚刚',
+  'claudeIntegration.usage.minutesAgo': '{n} 分钟前',
+  'claudeIntegration.usage.hoursAgo': '{n} 小时前',
+  'claudeIntegration.usage.daysAgo': '{n} 天前',
+  'claudeIntegration.usage.status.token-missing': 'Claude Code 未登录',
+  'claudeIntegration.usage.status.unauthorized': '令牌已过期 — 请重新登录 Claude Code',
+  'claudeIntegration.usage.status.http-error': 'Anthropic API 错误',
+  'claudeIntegration.usage.status.network-error': '网络错误',
+  'claudeIntegration.usage.status.read-error': '凭据读取错误',
 } as const;


### PR DESCRIPTION
Closes #149.

The two newest Settings tabs (Claude integration, First-run setup) only had
their body strings in `en` and `ko`. Every other locale showed the translated
tab label but fell back to English the moment you opened the tab. It was the
largest remaining i18n gap in the app.

## What changed

36 body strings per locale, across the 21 locales that were missing them (ja,
zh, zh-TW, ar, bs, da, de, es, fr, hi, id, it, ms, nb, pl, pt-BR, ru, th, tr,
uk, vi):

- `settings.firstRunSetup.*` (11): description, status rows, wizard and
  cheat-sheet buttons
- `claudeIntegration.signalHealth.*` (9): plugin signal-health card
- `claudeIntegration.usage.*` (16): Anthropic 5h / 7d usage meter

The tab labels themselves (`settings.firstRunSetup`, `claudeIntegration.tab`)
were already translated in #150 and are reused verbatim; only the bodies are
new. 756 strings total. `en` and `ko` were already complete and are untouched.

## Correctness

Each interpolation placeholder and technical token is preserved verbatim in
every locale:

- placeholders: `{rel}`, `{p50}`/`{p95}`/`{count}`, `{matched}`/`{total}`,
  `{seconds}`, `{tier}`, `{ago}`, `{n}`, `{date}`, `{status}`
- tokens kept in Latin even in RTL / CJK / Cyrillic / Devanagari locales:
  `wmux`, `Claude Code`, `MCP`, `Anthropic`, `Haiku`, `OAuth`,
  `api.anthropic.com`, `P50`/`P95`, `5h / 7d`

Verified locally:

- key audit: 0 missing across all 23 locales (was 756 missing on these two families)
- no duplicate keys; both tab labels present exactly once per file
- placeholder sets match the `en` source for all 13 interpolated keys
- `tsc --noEmit`: clean
- renderer test suite: green

This is a renderer-only, additive string change; no code paths change.
