### PR TITLE
fix(win): stop --squirrel-firstrun from becoming a never-quitting zombie

### DIFF
--- a/src/main/__tests__/squirrel.test.ts
+++ b/src/main/__tests__/squirrel.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { isSquirrelInstallerEvent, SQUIRREL_INSTALLER_EVENTS } from '../squirrel';
+
+// Pure classifier (no electron, no app bootstrap), exercised directly.
+//
+// Regression context: a prior `startsWith('--squirrel-')` guard in index.ts
+// treated '--squirrel-firstrun' as an installer event, set isSquirrelEvent,
+// matched no handler, never quit, and skipped appInit() — leaving an invisible
+// main process that lazily spawned its own gpu/network subprocesses (duplicate
+// GPU process → UI stutter). firstrun MUST classify as "not an installer event"
+// so it falls through to the normal single-instance-locked app init path.
+
+describe('isSquirrelInstallerEvent', () => {
+  it('returns true for each of the four installer lifecycle events', () => {
+    for (const ev of SQUIRREL_INSTALLER_EVENTS) {
+      expect(isSquirrelInstallerEvent(ev)).toBe(true);
+    }
+  });
+
+  it('exposes exactly the four installer events (no firstrun in the list)', () => {
+    expect([...SQUIRREL_INSTALLER_EVENTS]).toEqual([
+      '--squirrel-install',
+      '--squirrel-updated',
+      '--squirrel-uninstall',
+      '--squirrel-obsolete',
+    ]);
+    expect([...SQUIRREL_INSTALLER_EVENTS]).not.toContain('--squirrel-firstrun');
+  });
+
+  it('returns false for --squirrel-firstrun (the regression guard)', () => {
+    // firstrun is a normal launch, not an installer hook — must run the app.
+    expect(isSquirrelInstallerEvent('--squirrel-firstrun')).toBe(false);
+  });
+
+  it('returns false for an unknown --squirrel-* arg', () => {
+    // Defensive: any future/unknown squirrel arg runs normally rather than
+    // becoming a never-quit zombie.
+    expect(isSquirrelInstallerEvent('--squirrel-frobnicate')).toBe(false);
+  });
+
+  it('returns false for a normal launch with no flag (argv[1] undefined)', () => {
+    expect(isSquirrelInstallerEvent(undefined)).toBe(false);
+  });
+
+  it('returns false for an empty string', () => {
+    expect(isSquirrelInstallerEvent('')).toBe(false);
+  });
+
+  it('returns false for a real exe/script path (dev `electron .`)', () => {
+    expect(isSquirrelInstallerEvent('C:\\Users\\me\\wmux\\app.exe')).toBe(false);
+    expect(isSquirrelInstallerEvent('.')).toBe(false);
+  });
+
+  it('does not partial-match a prefix or substring', () => {
+    expect(isSquirrelInstallerEvent('--squirrel-')).toBe(false);
+    expect(isSquirrelInstallerEvent('--squirrel-install-extra')).toBe(false);
+    expect(isSquirrelInstallerEvent('squirrel-install')).toBe(false);
+  });
+});

--- a/src/main/__tests__/squirrelWiring.test.ts
+++ b/src/main/__tests__/squirrelWiring.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { SQUIRREL_INSTALLER_EVENTS } from '../squirrel';
+
+// Source-level WIRING invariants for the Squirrel firstrun zombie fix.
+//
+// The original zombie was a *wiring* bug in index.ts, not a logic bug in the
+// predicate: a bare `startsWith('--squirrel-')` guard set isSquirrelEvent=true
+// for '--squirrel-firstrun', matched none of the install/updated/uninstall/
+// obsolete handlers (so never quit), and then `if (!isSquirrelEvent) appInit()`
+// skipped init — an invisible, never-quitting main process that lazily spawned
+// its own gpu-process + network utility (duplicate GPU -> UI stutter).
+//
+// squirrel.test.ts proves the PREDICATE is correct, but a green predicate test
+// would NOT catch a regression where index.ts stops calling it, reverts to
+// startsWith, or moves the single-instance lock below subprocess construction.
+// These invariants pin the wiring. index.ts can't be imported (it runs appInit()
+// at module load), so we assert over its source text — the repo's established
+// source-invariant pattern (see beforeQuitDisconnectRace.test.ts).
+
+describe('Squirrel firstrun fix — index.ts wiring invariants', () => {
+  const indexPath = path.join(__dirname, '..', 'index.ts');
+  const indexSrc = fs.readFileSync(indexPath, 'utf-8');
+
+  it('classifies the Squirrel arg via isSquirrelInstallerEvent, not a bare startsWith', () => {
+    // The predicate must be the gate that sets isSquirrelEvent.
+    expect(indexSrc).toMatch(/if\s*\(\s*isSquirrelInstallerEvent\(\s*squirrelCmd\s*\)\s*\)\s*\{/);
+    // Regression lock: the exact original shape — a startsWith('--squirrel-')
+    // guard that swallows firstrun by setting the flag — must not come back.
+    const startsWithSwallowsFirstrun =
+      /startsWith\(\s*['"]--squirrel-['"]\s*\)\s*\)\s*\{\s*isSquirrelEvent\s*=\s*true/;
+    expect(indexSrc).not.toMatch(startsWithSwallowsFirstrun);
+  });
+
+  it('gates appInit() on !isSquirrelEvent so firstrun (predicate=false) falls through', () => {
+    expect(indexSrc).toMatch(/if\s*\(\s*!isSquirrelEvent\s*\)\s*\{\s*appInit\(\)/);
+  });
+
+  it('takes the single-instance lock BEFORE registering the ready handler (the real GPU gate)', () => {
+    // The duplicate gpu-process + network.mojom utility (the actual reported
+    // symptom) spawn from Chromium's runtime gated on app.on('ready') / window
+    // creation — NOT from PTYManager/PipeServer. So the invariant that actually
+    // prevents the zombie's subprocesses is: the lock loser returns before the
+    // ready handler is even registered. Pin that ordering directly.
+    const lockPos = indexSrc.indexOf('app.requestSingleInstanceLock()');
+    const readyPos = indexSrc.indexOf("app.on('ready'");
+    expect(lockPos).toBeGreaterThan(0);
+    expect(readyPos).toBeGreaterThan(lockPos);
+  });
+
+  it('takes the single-instance lock BEFORE constructing any subprocess/IPC owner', () => {
+    // Secondary: PTYManager / PipeServer (pipe + pty-host children) must also
+    // come after the lock so the loser leaks none of them either.
+    const lockPos = indexSrc.indexOf('app.requestSingleInstanceLock()');
+    const ptyPos = indexSrc.indexOf('new PTYManager(');
+    const pipePos = indexSrc.indexOf('new PipeServer(');
+    expect(ptyPos).toBeGreaterThan(lockPos);
+    expect(pipePos).toBeGreaterThan(lockPos);
+  });
+
+  it('calls appInit() exactly once (no unconditional or duplicate init)', () => {
+    // The !isSquirrelEvent gate is worthless if a second, ungated appInit() call
+    // exists. Pin the call-site count (the `function appInit()` declaration is
+    // `appInit(): void` and does not match the `appInit();` call form).
+    const callSites = indexSrc.match(/appInit\(\);/g) || [];
+    expect(callSites.length).toBe(1);
+  });
+
+  it('the lock loser quits and returns before any heavy init', () => {
+    // !gotLock -> app.quit(); return — the early-out that prevents the zombie.
+    const start = indexSrc.indexOf('const gotLock');
+    expect(start).toBeGreaterThan(0);
+    const guard = indexSrc.slice(start, start + 400);
+    expect(guard).toMatch(/if\s*\(\s*!gotLock\s*\)\s*\{[\s\S]*app\.quit\(\)[\s\S]*return/);
+  });
+
+  it('does not list --squirrel-firstrun as an installer event', () => {
+    expect([...SQUIRREL_INSTALLER_EVENTS]).not.toContain('--squirrel-firstrun');
+  });
+
+  it('the predicate classifies by exact membership, never a startsWith prefix', () => {
+    // The most realistic regression is moving the logic into squirrel.ts and
+    // using `startsWith('--squirrel-')` there — which would re-swallow firstrun.
+    // The index.ts source lock can't see that (wrong file), so pin squirrel.ts
+    // directly: exact-match membership, no prefix matching. (squirrel.test.ts
+    // already catches this behaviourally; this is the cheap source-level twin.)
+    const squirrelSrc = fs.readFileSync(path.join(__dirname, '..', 'squirrel.ts'), 'utf-8');
+    expect(squirrelSrc).toMatch(/\.includes\(\s*argv1\s*\)/);
+    expect(squirrelSrc).not.toMatch(/startsWith/);
+  });
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -49,6 +49,7 @@ import { DaemonRespawnController } from './daemon/DaemonRespawnController';
 import { createTray, destroyTray, updateTraySessionCount } from './tray';
 import { FirstRunOrchestrator } from './firstRun/FirstRunOrchestrator';
 import { registerFirstRunHandlers } from './firstRun';
+import { isSquirrelInstallerEvent } from './squirrel';
 import { ProcessMonitor } from '../daemon/ProcessMonitor';
 import { metadataStore } from './metadata/MetadataStore';
 import { collectLegacyMetadata } from './metadata/legacyMigration';
@@ -80,10 +81,19 @@ if (process.env.WMUX_DISABLE_CDP !== 'true') {
 // IMPORTANT: Set a flag so the rest of the app initialization is skipped
 // during Squirrel events. Without this, PTYManager/PipeServer/etc.
 // initialize and the before-quit handler tries cleanup — causing errors.
+//
+// Only the four INSTALLER lifecycle events (install/updated/uninstall/obsolete)
+// are handled-and-exited here. '--squirrel-firstrun' is NOT an installer hook —
+// Squirrel passes it on the first normal launch, so it must fall through to
+// appInit() where the single-instance lock dedupes it against the clean instance
+// auto-launched from --squirrel-install. (A bare startsWith('--squirrel-') guard
+// used to catch firstrun, set the flag, match no handler, never quit, and skip
+// appInit() — leaving an invisible zombie that spawned its own gpu/network procs.
+// See isSquirrelInstallerEvent + src/main/squirrel.ts.)
 let isSquirrelEvent = false;
 if (process.platform === 'win32') {
   const squirrelCmd = process.argv[1];
-  if (squirrelCmd?.startsWith('--squirrel-')) {
+  if (isSquirrelInstallerEvent(squirrelCmd)) {
     isSquirrelEvent = true;
     const path = require('path');
     const { spawn } = require('child_process');

--- a/src/main/squirrel.ts
+++ b/src/main/squirrel.ts
@@ -1,0 +1,42 @@
+/**
+ * Squirrel.Windows installer-event classification.
+ *
+ * Squirrel relaunches the app with a CLI flag at each point in the install
+ * lifecycle. Four of those are *installer hooks* — the app must do its
+ * shortcut/registry work and exit immediately, before any BrowserWindow or
+ * Chromium subprocess spins up:
+ *
+ *   --squirrel-install     first install
+ *   --squirrel-updated     in-place update
+ *   --squirrel-uninstall   removal
+ *   --squirrel-obsolete    old version being superseded
+ *
+ * '--squirrel-firstrun' is deliberately NOT in this list. It is NOT an
+ * installer hook — Squirrel passes it on the very first *normal* launch after
+ * install (electron-squirrel-startup returns false for it, i.e. "keep running
+ * normally"). It must fall through to the regular app init path so the
+ * single-instance lock can dedupe it against the clean instance auto-launched
+ * from the --squirrel-install handler. Misclassifying it as an installer event
+ * leaves a main process that never quits and never inits — an invisible zombie
+ * that lazily spawns its own gpu-process and network utility, contending with
+ * the real window (the bug this module exists to prevent).
+ *
+ * Pure + side-effect-free so it can be unit-tested directly; index.ts cannot be
+ * imported in tests because it runs appInit() at module load.
+ */
+export const SQUIRREL_INSTALLER_EVENTS = [
+  '--squirrel-install',
+  '--squirrel-updated',
+  '--squirrel-uninstall',
+  '--squirrel-obsolete',
+] as const;
+
+/**
+ * True only for the four installer lifecycle events that must handle-and-exit.
+ * Everything else — '--squirrel-firstrun', unknown '--squirrel-*' args, a normal
+ * launch with no flag, dev's exe path — returns false and runs the app normally.
+ */
+export function isSquirrelInstallerEvent(argv1: string | undefined): boolean {
+  return argv1 !== undefined
+    && (SQUIRREL_INSTALLER_EVENTS as readonly string[]).includes(argv1);
+}


### PR DESCRIPTION
## What was wrong

After a Squirrel reinstall on Windows, a `wmux.exe --squirrel-firstrun` process (parented by the installer) stayed alive indefinitely alongside the real app — one report had it running ~6.5h. It had no window or renderer of its own, but it lazily spawned its own `gpu-process` and `network.mojom.NetworkService` utility. Two GPU processes alive at once meant compositing contention and persistent UI stutter. Because it was invisible, the only way to clear it was killing the tree by hand.

## Root cause

The Squirrel block in `src/main/index.ts` gated on a bare prefix check:

```js
if (squirrelCmd?.startsWith('--squirrel-')) {
  isSquirrelEvent = true;
  if (squirrelCmd === '--squirrel-install')        { ... app.quit(); }
  else if (squirrelCmd === '--squirrel-updated')   { ... }
  else if (squirrelCmd === '--squirrel-uninstall') { ... }
  else if (squirrelCmd === '--squirrel-obsolete')  { process.exit(0); }
  // no branch for --squirrel-firstrun
}
if (!isSquirrelEvent) { appInit(); }
```

`--squirrel-firstrun` matched the prefix and set `isSquirrelEvent = true`, but it is not one of the four installer events, so no handler ran and the process never called `app.quit()` / `process.exit()`. Then `if (!isSquirrelEvent)` was false, so `appInit()` was skipped too. The result: a main process that neither initialized nor exited, just sitting there while Chromium spun up its gpu/network children.

`--squirrel-firstrun` is not an installer hook. Squirrel passes it on the first normal launch after install (electron-squirrel-startup returns false for it). It is supposed to run the app normally.

## The fix

Classify the Squirrel arg with a pure predicate that returns true only for the four real installer lifecycle events:

```ts
// src/main/squirrel.ts
export const SQUIRREL_INSTALLER_EVENTS = [
  '--squirrel-install', '--squirrel-updated',
  '--squirrel-uninstall', '--squirrel-obsolete',
] as const;
export function isSquirrelInstallerEvent(argv1: string | undefined): boolean {
  return argv1 !== undefined && (SQUIRREL_INSTALLER_EVENTS as readonly string[]).includes(argv1);
}
```

`index.ts` now gates on `isSquirrelInstallerEvent(squirrelCmd)`. firstrun (and any unknown `--squirrel-*` arg) falls through to `appInit()`, where the single-instance lock dedupes it against the clean instance the `--squirrel-install` handler auto-launches. The lock loser hits `app.quit()` and returns before `app.on('ready')` is registered, so it never spawns a window, GPU, or network process.

The predicate lives in its own module because `index.ts` runs `appInit()` at module load and can't be imported in a test.

## Tests

- `squirrel.test.ts` — the predicate: 4 installer events true; firstrun, unknown, undefined, empty, exe path, and partial matches all false.
- `squirrelWiring.test.ts` — source invariants that pin the wiring the regression actually broke: index.ts classifies via `isSquirrelInstallerEvent` (not a `startsWith` guard that swallows firstrun), `appInit()` is called exactly once under the `!isSquirrelEvent` gate, `requestSingleInstanceLock()` precedes both `app.on('ready')` (the real gpu/network gate) and `PTYManager`/`PipeServer` construction, and `squirrel.ts` classifies by exact membership rather than a prefix.

## Verified dynamically (packaged builds, before/after)

Ran the packaged `wmux.exe` with `--squirrel-firstrun` and watched the process tree:

| | firstrun process | still alive | gpu/network children |
|---|---|---|---|
| before (fix absent) | standalone | yes (7s+) | `gpu-process` + `network.mojom.NetworkService` |
| after (lock loser) | deduped | no, quits | none |

The "after" run used a separate `--user-data-dir` so a clean instance held the lock and the firstrun instance lost it — the same shape as the real install race. The loser exited with zero children, confirming it quits before any Chromium subprocess spawns.

## Not in scope

The `--squirrel-install` handler still auto-launches a clean instance while Squirrel also fires firstrun, so every fresh install briefly runs two mains that race for the lock (one wins, one quits immediately). That double-launch predates this change and is harmless now that the loser exits cleanly. Collapsing it to a single launch is a separate cleanup — it touches the install path and wants a real-install smoke test first.

win32-only path; non-win32 is unaffected.
