### PR TITLE
fix(sidebar): mirror the hide/expand controls when docked on the right

### DIFF
--- a/src/renderer/components/Sidebar/MiniSidebar.tsx
+++ b/src/renderer/components/Sidebar/MiniSidebar.tsx
@@ -3,6 +3,7 @@ import { useStore } from '../../stores';
 import { useT } from '../../hooks/useT';
 import { AGENT_STATUS_ICON } from './agentStatusIcon';
 import { tokenAttrs } from '../../themes';
+import { expandGlyph } from './sidebarGlyphs';
 
 export default function MiniSidebar() {
   const t = useT();
@@ -174,7 +175,7 @@ export default function MiniSidebar() {
           onClick={toggleSidebar}
           title={t('sidebar.expandTooltip')}
         >
-          ▶
+          {expandGlyph(sidebarPosition)}
         </button>
       </div>
     </div>

--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -6,6 +6,7 @@ import type { Pane } from '../../../shared/types';
 import { useT } from '../../hooks/useT';
 import { buildWorkspaceMarkdown } from '../../utils/sessionInfoMarkdown';
 import { tokenAttrs } from '../../themes';
+import { collapseGlyph } from './sidebarGlyphs';
 
 // Pane 트리에서 모든 leaf의 PTY를 dispose
 function disposeAllPtys(pane: Pane) {
@@ -127,15 +128,16 @@ export default function Sidebar() {
         ))}
       </div>
 
-      {/* Footer */}
-      <div className="flex items-center justify-between px-4 py-2 border-t border-[var(--bg-surface)] text-[10px] font-mono text-[var(--text-muted)]" {...tokenAttrs('textMuted', 'text')}>
+      {/* Footer — when docked right, mirror the row so the collapse arrow sits
+          on the inner edge facing the content area (issue #151). */}
+      <div className={`flex items-center justify-between px-4 py-2 border-t border-[var(--bg-surface)] text-[10px] font-mono text-[var(--text-muted)] ${sidebarPosition === 'right' ? 'flex-row-reverse' : ''}`} {...tokenAttrs('textMuted', 'text')}>
         <span>{workspaces.length} {t('sidebar.workspaces')}</span>
         <button
           className="text-[var(--text-muted)] hover:text-[var(--text-main)] transition-colors"
           onClick={() => useStore.getState().toggleSidebar()}
           title={t('sidebar.hideTooltip')}
         >
-          ◀
+          {collapseGlyph(sidebarPosition)}
         </button>
       </div>
     </div>

--- a/src/renderer/components/Sidebar/__tests__/sidebarGlyphs.test.ts
+++ b/src/renderer/components/Sidebar/__tests__/sidebarGlyphs.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression for issue #151: the sidebar hide/expand button glyphs must follow
+ * the sidebar's physical position. Left-docked points one way, right-docked
+ * mirrors it. Tested as a pure helper because vitest runs in the node env with
+ * no DOM (same constraint as the SettingsPanel suites).
+ */
+import { describe, it, expect } from 'vitest';
+import { collapseGlyph, expandGlyph } from '../sidebarGlyphs';
+
+describe('sidebar glyphs (issue #151)', () => {
+  it('collapse arrow points toward the docked edge', () => {
+    // Left sidebar collapses toward the left edge; right toward the right edge.
+    expect(collapseGlyph('left')).toBe('◀');
+    expect(collapseGlyph('right')).toBe('▶');
+  });
+
+  it('expand arrow points inward toward the content area', () => {
+    // Mini sidebar on the left expands rightward; on the right expands leftward.
+    expect(expandGlyph('left')).toBe('▶');
+    expect(expandGlyph('right')).toBe('◀');
+  });
+
+  it('collapse and expand always point in opposite directions', () => {
+    // The two buttons swap places visually, so their arrows must never match.
+    for (const pos of ['left', 'right'] as const) {
+      expect(collapseGlyph(pos)).not.toBe(expandGlyph(pos));
+    }
+  });
+
+  it('flipping the position mirrors both glyphs', () => {
+    expect(collapseGlyph('left')).toBe(expandGlyph('right'));
+    expect(collapseGlyph('right')).toBe(expandGlyph('left'));
+  });
+});

--- a/src/renderer/components/Sidebar/sidebarGlyphs.ts
+++ b/src/renderer/components/Sidebar/sidebarGlyphs.ts
@@ -1,0 +1,28 @@
+/**
+ * Direction glyphs for the sidebar hide/expand buttons.
+ *
+ * The arrows must follow the sidebar's physical position (issue #151): a
+ * left-docked sidebar collapses toward the left edge and expands rightward into
+ * the content area, while a right-docked sidebar is mirrored. Hard-coding the
+ * glyphs left them pointing the wrong way once the sidebar moved to the right.
+ *
+ * Single-sourced here so both Sidebar (full) and MiniSidebar (collapsed) stay
+ * consistent and the direction logic is unit-testable in the node test env.
+ */
+export type SidebarPosition = 'left' | 'right';
+
+/**
+ * Glyph for the "hide/collapse" button shown in the full sidebar. Points toward
+ * the screen edge the sidebar is docked to — the direction it collapses into.
+ */
+export function collapseGlyph(position: SidebarPosition): string {
+  return position === 'right' ? '▶' : '◀';
+}
+
+/**
+ * Glyph for the "expand/show" button shown in the mini sidebar. Points inward
+ * toward the content area — the direction the sidebar expands into.
+ */
+export function expandGlyph(position: SidebarPosition): string {
+  return position === 'right' ? '◀' : '▶';
+}


### PR DESCRIPTION
Closes #151.

When the sidebar is docked on the right, the hide/expand buttons pointed the wrong way, and the collapse button stayed on the far edge instead of the inner edge facing the content.

## What changed
- New `sidebarGlyphs` helper that derives the arrow glyph from `sidebarPosition`, used by both the full Sidebar (hide) and the MiniSidebar (expand). Left-docked keeps the original `◀` / `▶`; right-docked mirrors to `▶` / `◀`.
- The full sidebar footer row flips to `flex-row-reverse` when docked right, so the collapse arrow sits on the inner edge next to the content area, matching the left-docked layout.
- Unit test covering both orientations plus the opposite-direction invariant.

## Testing
- `vitest run` on the new glyph suite (4 passing)
- `tsc --noEmit` clean, eslint clean (no new warnings)
- Dogfooded in the dev build: switched the sidebar to the right and confirmed both the arrow direction and the footer order are correct when hidden and expanded.