### PR TITLE
fix(build): drop the @electron/asar header cache after the postPackage repack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,12 +285,6 @@ jobs:
   linux:
     name: Build Linux
     needs: build
-    # Best-effort: @electron-forge/maker-deb currently throws a JSON parse error
-    # ("Unexpected token ... is not valid JSON") while building the .deb, which
-    # failed the whole leg. Linux artifacts are append-only and never block the
-    # Windows release, so a failure here must not red-flag the run. Tracked for a
-    # proper maker-deb fix; remove this once the deb build is green.
-    continue-on-error: true
     if: vars.ENABLE_CROSS_PLATFORM_RELEASE == 'true'
     runs-on: ubuntu-22.04
     permissions:

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -161,6 +161,27 @@ const config: ForgeConfig = {
         unpack: '**/node_modules/node-pty/prebuilds/**',
       });
 
+      // 3a. Invalidate @electron/asar's in-memory header cache for this archive.
+      //
+      // @electron/asar memoizes parsed archive headers in a module-level
+      // `filesystemCache` keyed by archive path. Step 1's `extractAll(asarPath)`
+      // populated that cache with the ORIGINAL (pre-repack) header. The in-place
+      // repack above overwrites app.asar on disk but does NOT refresh the cache,
+      // so the cached entry now carries stale file offsets.
+      //
+      // `electron-forge make` runs packaging and the makers in ONE process, and
+      // every `require('@electron/asar')` resolves to the same hoisted instance.
+      // So the Linux maker-deb / maker-rpm chain (electron-installer-common's
+      // readMetadata) later calls `asar.extractFile(asarPath, 'package.json')`
+      // against this same stale cache — reading at the old offset, which now
+      // lands inside the new archive's data section (bundled JS), and feeding
+      // non-JSON bytes to JSON.parse:
+      //   "Unexpected token ... is not valid JSON".
+      // Windows (Squirrel) and macOS (DMG/ZIP) makers never read app.asar this
+      // way, which is why the breakage was Linux-only (issue #159). Dropping the
+      // cache entry forces the next reader to re-parse the freshly written header.
+      asar.uncache(asarPath);
+
       // 4. Cleanup temp
       fs.rmSync(tempDir, { recursive: true });
       console.log('[postPackage] Done — node-pty bundled in asar.');

--- a/src/main/__tests__/makerDebAsarCache.test.ts
+++ b/src/main/__tests__/makerDebAsarCache.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Source-level WIRING invariants for the maker-deb / maker-rpm ".deb JSON parse"
+// fix (issue #159).
+//
+// @electron/asar memoizes parsed archive headers in a module-level
+// `filesystemCache` keyed by archive path. The postPackage hook in forge.config.ts
+//   1. `asar.extractAll(asarPath, …)`   -> caches the ORIGINAL header for asarPath
+//   2. …copies node-pty in…
+//   3. `asar.createPackageWithOptions(…, asarPath, …)` -> rewrites the file on disk
+//      but does NOT refresh the cache, so the cached offsets are now stale.
+// `electron-forge make` runs packaging and the makers in ONE process sharing the
+// same hoisted @electron/asar instance. On Linux the maker-deb / maker-rpm chain
+// (electron-installer-common's readMetadata) then calls
+// `asar.extractFile(asarPath, 'package.json')`, reads at the stale offset, lands
+// inside bundled JS, and feeds non-JSON bytes to JSON.parse ->
+// "Unexpected token … is not valid JSON". Windows (Squirrel) and macOS (DMG/ZIP)
+// makers never read app.asar this way, so the break was Linux-only.
+//
+// The fix is `asar.uncache(asarPath)` AFTER the repack. forge.config.ts can't be
+// imported and exercised in a unit test (postPackage needs a real packaged app
+// tree on disk), so we pin the wiring over its source text — the repo's
+// established source-invariant pattern (see squirrelWiring.test.ts). The dynamic
+// FAIL->OK proof lives in the reproduction run captured on the PR.
+
+describe('maker-deb fix — forge.config.ts postPackage asar-cache invariants', () => {
+  const forgeConfigPath = path.join(__dirname, '..', '..', '..', 'forge.config.ts');
+  const src = fs.readFileSync(forgeConfigPath, 'utf-8');
+
+  it('drops the @electron/asar header cache for the repacked archive', () => {
+    // The fix itself: the stale cache entry for the rewritten app.asar must be
+    // evicted. Accept the precise path-scoped form or a whole-cache flush.
+    const uncachesArchive = /asar\.uncache\(\s*asarPath\s*\)/.test(src);
+    const uncachesAll = /asar\.uncacheAll\(\s*\)/.test(src);
+    expect(uncachesArchive || uncachesAll).toBe(true);
+  });
+
+  it('evicts the cache AFTER the in-place repack, not before (else it is a no-op)', () => {
+    // Uncaching before createPackageWithOptions rewrites the file would re-cache
+    // nothing useful; the eviction only defeats staleness if it runs after the
+    // repack that introduced it.
+    const repackPos = src.search(/asar\.createPackageWithOptions\(\s*tempDir\s*,\s*asarPath/);
+    const uncachePos = src.search(/asar\.uncache(All)?\(/);
+    expect(repackPos).toBeGreaterThan(-1);
+    expect(uncachePos).toBeGreaterThan(repackPos);
+  });
+
+  it('still extracts then repacks the SAME archive path (the scenario that staled the cache)', () => {
+    // Anchors WHY the eviction is required: a read of asarPath (extractAll)
+    // followed by an in-place rewrite of the same asarPath. If this stops being
+    // true the invariant above is moot, but pinning it documents the hazard.
+    const extractPos = src.search(/asar\.extractAll\(\s*asarPath/);
+    const repackPos = src.search(/asar\.createPackageWithOptions\(\s*tempDir\s*,\s*asarPath/);
+    expect(extractPos).toBeGreaterThan(-1);
+    expect(repackPos).toBeGreaterThan(extractPos);
+  });
+});


### PR DESCRIPTION
## What

The Linux `.deb` build has been failing in the release pipeline with a maker-deb JSON parse error, so no `.deb` has shipped since v2.16.1:

```
✖ Making a deb distributable for linux/x64 [FAILED: Unexpected token 'm', "m "name"'}"... is not valid JSON]
SyntaxError: Unexpected token 'm', "m "name"'}"... is not valid JSON
```

## Root cause

It's not actually `maker-deb` that's broken — it's our `postPackage` hook leaving `@electron/asar` with a stale cache.

`@electron/asar` memoizes parsed archive headers in a module-level `filesystemCache` keyed by archive path. The `postPackage` hook in `forge.config.ts`:

1. `asar.extractAll(asarPath, …)` — caches the **original** header for `app.asar`
2. copies node-pty into the tree
3. `asar.createPackageWithOptions(…, asarPath, …)` — rewrites `app.asar` on disk, but **does not refresh the cache**, so the cached file offsets are now stale.

`electron-forge make` runs packaging and the makers in **one process**, and every `require('@electron/asar')` resolves to the same hoisted instance. So on Linux the maker-deb / maker-rpm chain (`electron-installer-common`'s `readMetadata`) calls `asar.extractFile(asarPath, 'package.json')` against that stale cache, reads at the old offset, lands inside the new archive's bundled JS, and feeds non-JSON bytes to `JSON.parse`. The `"m "name"'}"` in the error is literally a slice of a bundled string (`company.create: missing param "name"`), not our `package.json`.

Windows (Squirrel) and macOS (DMG/ZIP) makers never read `app.asar` this way, which is exactly why only the Linux leg broke.

## Fix

Call `asar.uncache(asarPath)` right after the in-place repack so the next reader re-parses the freshly written header. One line; the rest of the diff is comments and a test.

Also drops the `continue-on-error: true` workaround on the Linux release leg, now that the deb build is unblocked.

## Verification

Reproduced and fixed on real Linux (WSL + Docker, `@electron/asar` 3.4.1), driving the **exact** failing line through the real forge sequence (`extractAll` → in-place repack → `extractFile`) in a single process:

```
[no fix  ]  FAIL: Unexpected token ',', ",\n    Inst"...  | first40=",\n    InstanceMethod<&[ClassName]::Func2"
[with fix]  JSON.parse OK -> wmux@2.17.1
```

- A full `npm run make` on Linux runs the patched `postPackage` (repack + uncache) and produces **no** JSON parse error.
- New source-invariant test (`src/main/__tests__/makerDebAsarCache.test.ts`) pins the cache eviction and its ordering (must run after the repack); passes under vitest.

Closes #159
