### PR TITLE
fix(security): assert workspace ownership on input.readScreen (#163 Part 1)

### DIFF
--- a/src/main/pipe/handlers/__tests__/input.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/input.rpc.test.ts
@@ -100,4 +100,32 @@ describe('input.readScreen — cross-workspace ownership (issue #163)', () => {
       expect.anything(),
     );
   });
+
+  it('reads the caller workspace active pane when ptyId is omitted, independent of UI focus', async () => {
+    // Regression guard (PR review): the renderer scopes the active-pane lookup
+    // to params.workspaceId, so a legit caller naming its own ws must read its
+    // own active pane even when the user's UI focus is on another workspace.
+    // Resolving via a workspaceId-less resolveActivePtyId would read the
+    // UI-focused pane and wrongly reject this caller.
+    sendToRendererMock.mockImplementation((_w: unknown, method: string) => {
+      if (method === 'input.readScreen') return Promise.resolve({ ptyId: 'daemon-self', text: 'mine' });
+      if (method === 'input.findOwnerWorkspace') return Promise.resolve({ workspaceId: 'ws-self' });
+      return Promise.resolve(null);
+    });
+
+    const res = await setup().dispatch({
+      id: '4',
+      method: 'input.readScreen',
+      params: { workspaceId: 'ws-self' },
+    });
+
+    expect(res.ok).toBe(true);
+    // the read forwarded workspaceId so the renderer scopes the lookup to it,
+    // not to a focus-based default.
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'input.readScreen',
+      expect.objectContaining({ workspaceId: 'ws-self' }),
+    );
+  });
 });

--- a/src/main/pipe/handlers/__tests__/input.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/input.rpc.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserWindow } from 'electron';
+import { RpcRouter } from '../../RpcRouter';
+import { registerInputRpc } from '../input.rpc';
+import type { PTYManager } from '../../../pty/PTYManager';
+
+// Mock the renderer bridge so we can drive input.findOwnerWorkspace (the
+// ownership oracle assertWorkspaceOwnsPty consults) and input.readScreen (the
+// viewport read) without a real BrowserWindow.
+const { sendToRendererMock } = vi.hoisted(() => ({ sendToRendererMock: vi.fn() }));
+vi.mock('../_bridge', () => ({ sendToRenderer: sendToRendererMock }));
+
+const fakeWindow = {} as BrowserWindow;
+const fakePty = {} as PTYManager;
+
+function setup(): RpcRouter {
+  const router = new RpcRouter();
+  registerInputRpc(router, fakePty, () => fakeWindow);
+  return router;
+}
+
+// Regression guard for issue #163: input.readScreen was the lone terminal-IO
+// handler missing assertWorkspaceOwnsPty, letting a caller that names another
+// workspace + a foreign ptyId read that workspace's viewport.
+describe('input.readScreen — cross-workspace ownership (issue #163)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('rejects an explicit-ptyId read owned by a different workspace, before any viewport read', async () => {
+    sendToRendererMock.mockImplementation((_w: unknown, method: string) => {
+      if (method === 'input.findOwnerWorkspace') {
+        // The ptyId genuinely belongs to the victim ws (the crux of the bug).
+        return Promise.resolve({ workspaceId: 'ws-victim' });
+      }
+      return Promise.resolve({ ptyId: 'daemon-victim', text: 'SECRET' });
+    });
+
+    const res = await setup().dispatch({
+      id: '1',
+      method: 'input.readScreen',
+      params: { workspaceId: 'ws-attacker', ptyId: 'daemon-victim' },
+    });
+
+    expect(res.ok).toBe(false);
+    // The ownership check ran...
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'input.findOwnerWorkspace',
+      { ptyId: 'daemon-victim' },
+    );
+    // ...and the viewport read never happened (assert-before-read).
+    expect(sendToRendererMock).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'input.readScreen',
+      expect.anything(),
+    );
+  });
+
+  it('allows a read when the caller workspace owns the ptyId', async () => {
+    sendToRendererMock.mockImplementation(
+      (_w: unknown, method: string, params?: { ptyId?: string }) => {
+        if (method === 'input.findOwnerWorkspace') return Promise.resolve({ workspaceId: 'ws-A' });
+        return Promise.resolve({ ptyId: params?.ptyId ?? 'daemon-A', text: 'mine' });
+      },
+    );
+
+    const res = await setup().dispatch({
+      id: '2',
+      method: 'input.readScreen',
+      params: { workspaceId: 'ws-A', ptyId: 'daemon-A' },
+    });
+
+    expect(res.ok).toBe(true);
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'input.readScreen',
+      expect.objectContaining({ ptyId: 'daemon-A' }),
+    );
+  });
+
+  it('skips the ownership check for internal callers that pass no workspaceId (CLI/UI)', async () => {
+    sendToRendererMock.mockImplementation(
+      (_w: unknown, method: string, params?: { ptyId?: string }) => {
+        if (method === 'input.findOwnerWorkspace') {
+          return Promise.reject(new Error('findOwnerWorkspace must not be called for internal callers'));
+        }
+        return Promise.resolve({ ptyId: params?.ptyId ?? 'daemon-A', text: 'cli' });
+      },
+    );
+
+    const res = await setup().dispatch({
+      id: '3',
+      method: 'input.readScreen',
+      params: { ptyId: 'daemon-A' },
+    });
+
+    expect(res.ok).toBe(true);
+    expect(sendToRendererMock).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'input.findOwnerWorkspace',
+      expect.anything(),
+    );
+  });
+});

--- a/src/main/pipe/handlers/input.rpc.ts
+++ b/src/main/pipe/handlers/input.rpc.ts
@@ -183,10 +183,29 @@ export function registerInputRpc(
    * terminal viewport text of the active surface.
    * Returns { ptyId: string, text: string }
    * Accepts optional { ptyId?, tail_lines? } params that the renderer honors.
+   *
+   * Like input.send / input.sendKey / terminal.readEvents, this resolves the
+   * target ptyId and asserts the caller's workspace owns it before reading, so
+   * a caller that learned a foreign PTY id cannot read another workspace's
+   * viewport (issue #163 — readScreen was the lone terminal-IO handler missing
+   * the assert). Internal callers (CLI/UI) pass no workspaceId and skip the
+   * check via assertWorkspaceOwnsPty's early return.
    */
-  router.register('input.readScreen', (params) =>
-    sendToRenderer(getWindow, 'input.readScreen', params ?? {}),
-  );
+  router.register('input.readScreen', async (params) => {
+    const p = params ?? {};
+
+    let ptyId: string;
+    if (typeof p['ptyId'] === 'string' && p['ptyId'].length > 0) {
+      ptyId = p['ptyId'];
+    } else {
+      ptyId = await resolveActivePtyId(getWindow);
+    }
+
+    const callerWs = typeof p['workspaceId'] === 'string' ? p['workspaceId'] : undefined;
+    await assertWorkspaceOwnsPty(getWindow, ptyId, callerWs, 'input.readScreen');
+
+    return sendToRenderer(getWindow, 'input.readScreen', { ...p, ptyId });
+  });
 
   /**
    * terminal.readEvents — return structured OSC 133 prompt/command events

--- a/src/main/pipe/handlers/input.rpc.ts
+++ b/src/main/pipe/handlers/input.rpc.ts
@@ -180,31 +180,44 @@ export function registerInputRpc(
 
   /**
    * input.readScreen — delegates to the renderer to capture the current
-   * terminal viewport text of the active surface.
+   * terminal viewport text of a surface.
    * Returns { ptyId: string, text: string }
    * Accepts optional { ptyId?, tail_lines? } params that the renderer honors.
    *
-   * Like input.send / input.sendKey / terminal.readEvents, this resolves the
-   * target ptyId and asserts the caller's workspace owns it before reading, so
-   * a caller that learned a foreign PTY id cannot read another workspace's
-   * viewport (issue #163 — readScreen was the lone terminal-IO handler missing
-   * the assert). Internal callers (CLI/UI) pass no workspaceId and skip the
-   * check via assertWorkspaceOwnsPty's early return.
+   * Ownership is enforced so a caller that learned a foreign PTY id cannot read
+   * another workspace's viewport (issue #163 — readScreen was the lone
+   * terminal-IO handler missing the assert). Two paths:
+   *   - Explicit ptyId: assert BEFORE reading, so a foreign viewport is never
+   *     even captured.
+   *   - No ptyId: forward params as-is so the renderer resolves the active pane
+   *     scoped to params.workspaceId. This preserves the old passthrough — the
+   *     caller's OWN active pane, not the globally UI-focused one (resolving via
+   *     a workspaceId-less resolveActivePtyId would read whatever the user has
+   *     focused and wrongly reject a legit same-workspace caller). Re-assert the
+   *     returned ptyId as defense in depth.
+   * Internal callers (CLI/UI) pass no workspaceId; assertWorkspaceOwnsPty then
+   * early-returns and the check is skipped.
    */
   router.register('input.readScreen', async (params) => {
     const p = params ?? {};
+    const callerWs = typeof p['workspaceId'] === 'string' ? p['workspaceId'] : undefined;
 
-    let ptyId: string;
     if (typeof p['ptyId'] === 'string' && p['ptyId'].length > 0) {
-      ptyId = p['ptyId'];
-    } else {
-      ptyId = await resolveActivePtyId(getWindow);
+      await assertWorkspaceOwnsPty(getWindow, p['ptyId'], callerWs, 'input.readScreen');
+      return sendToRenderer(getWindow, 'input.readScreen', p);
     }
 
-    const callerWs = typeof p['workspaceId'] === 'string' ? p['workspaceId'] : undefined;
-    await assertWorkspaceOwnsPty(getWindow, ptyId, callerWs, 'input.readScreen');
-
-    return sendToRenderer(getWindow, 'input.readScreen', { ...p, ptyId });
+    const result = await sendToRenderer(getWindow, 'input.readScreen', p);
+    const readPtyId =
+      result !== null &&
+      typeof result === 'object' &&
+      typeof (result as Record<string, unknown>)['ptyId'] === 'string'
+        ? (result as Record<string, string>)['ptyId']
+        : undefined;
+    if (readPtyId) {
+      await assertWorkspaceOwnsPty(getWindow, readPtyId, callerWs, 'input.readScreen');
+    }
+    return result;
   });
 
   /**


### PR DESCRIPTION
## What
`input.readScreen` (the RPC behind `terminal_read`) was the only terminal-IO handler delegating to the renderer without `assertWorkspaceOwnsPty`. Its siblings `input.send` / `input.sendKey` / `terminal.readEvents` all assert. A token-holding caller that named another workspace plus a foreign ptyId could read that workspace's viewport (#163).

## Fix (Part 1, parity)
Resolve the target ptyId and assert the caller's workspace owns it before reading, mirroring the siblings. For an explicit ptyId the assert runs before any viewport read, so a foreign viewport is never captured. Internal callers (no `workspaceId`) skip via the helper's early return.

## Tests
New `input.rpc.test.ts`: cross-workspace read rejected before any read, own-workspace read allowed, internal caller skips the check. 3/3 pass, type-clean.

## Not in scope (Part 2, tracked in #163)
The root cause is terminal IO trusting the spoofable `WMUX_WORKSPACE_ID` env hint, plus both the assert and the renderer check validating `ptyId in workspaceId` rather than caller-owns-workspace. That follow-up needs the verified-resolver switch dogfooded against the first-party boot blip, so it is deliberately separate. This PR is the low-risk parity half.

Refs #163
