### PR TITLE
fix(terminal): defensive repaints for garbled glyph corruption (#166)

### DIFF
--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -190,6 +190,10 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
   const { ptyId, isVisible = true, scrollbackFile, onFirstData, onContextMenu } = options;
   const ptyIdRef = useRef(ptyId);
   ptyIdRef.current = ptyId;
+  // Live visibility for long-lived callbacks (the burst repaint below) — the
+  // closure value captured at mount would go stale across workspace switches.
+  const isVisibleRef = useRef(isVisible);
+  isVisibleRef.current = isVisible;
   const onFirstDataRef = useRef(onFirstData);
   onFirstDataRef.current = onFirstData;
   const onContextMenuRef = useRef(onContextMenu);
@@ -389,12 +393,21 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // Issue #166 — defensive repaints for the "garbled glyphs until resize"
     // corruption. Strategy and trigger rationale live in terminal/glyphRepaint.ts.
     // Cost split: focus/visible clear the WebGL texture atlas (repairs atlas
-    // corruption; rare, user-initiated) AND force a full refresh (repairs
-    // dirty-region desync); burst-settle only refreshes — clearing a CJK-heavy
-    // atlas after every agent output burst would be constant re-rasterisation.
+    // corruption; throttled — "focus" fires not just on mouse clicks but on
+    // every keyboard pane-nav / MCP pane.focus via useActivePaneFocus's
+    // term.focus(), so the throttle is load-bearing) AND force a full refresh
+    // (repairs dirty-region desync); burst-settle only refreshes — clearing a
+    // CJK-heavy atlas after every agent output burst would be constant
+    // re-rasterisation.
     const glyphRepaint = createGlyphRepaintScheduler({
       repaint: (reason) => {
         if (terminalRef.current !== terminal) return;
+        // A hidden pane (background workspace/tab, display:none) skips the
+        // burst refresh — nobody can see the staleness, and the `visible`
+        // repaint on re-show repairs it at the moment it matters. Without
+        // this gate, N background agent panes each schedule a full-range
+        // refresh after every output burst.
+        if (reason === 'burst' && !isVisibleRef.current) return;
         if (reason !== 'burst') {
           try {
             webglAddonRef.current?.clearTextureAtlas();

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -18,6 +18,7 @@ import { terminalFontFamilyCss } from '../utils/terminalFont';
 import { createPathLinkProvider } from '../terminal/pathLinkProvider';
 import { resolveNewlineKeyByte } from '../terminal/newlineKeys';
 import { webglContextPool } from '../terminal/webglContextPool';
+import { createGlyphRepaintScheduler, type GlyphRepaintScheduler } from '../terminal/glyphRepaint';
 import { reconnectPtyWithRetry as reconnectPtyWithRetryImpl } from './reconnectPtyWithRetry';
 
 // Module-level terminal registry for scrollback persistence
@@ -183,6 +184,9 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
   if (!webglTokenRef.current) webglTokenRef.current = `wgl-${++webglTokenSeq}`;
   // Pending deferred-WebGL-release timer (see WEBGL_HIDDEN_DISPOSE_DELAY_MS).
   const webglDisposeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Glyph-corruption repair scheduler (issue #166) — created by the main
+  // effect, also poked by the visibility effect on regain.
+  const glyphRepaintRef = useRef<GlyphRepaintScheduler | null>(null);
   const { ptyId, isVisible = true, scrollbackFile, onFirstData, onContextMenu } = options;
   const ptyIdRef = useRef(ptyId);
   ptyIdRef.current = ptyId;
@@ -381,6 +385,34 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       }
     }
     disposeWebglRef.current = disposeWebgl;
+
+    // Issue #166 — defensive repaints for the "garbled glyphs until resize"
+    // corruption. Strategy and trigger rationale live in terminal/glyphRepaint.ts.
+    // Cost split: focus/visible clear the WebGL texture atlas (repairs atlas
+    // corruption; rare, user-initiated) AND force a full refresh (repairs
+    // dirty-region desync); burst-settle only refreshes — clearing a CJK-heavy
+    // atlas after every agent output burst would be constant re-rasterisation.
+    const glyphRepaint = createGlyphRepaintScheduler({
+      repaint: (reason) => {
+        if (terminalRef.current !== terminal) return;
+        if (reason !== 'burst') {
+          try {
+            webglAddonRef.current?.clearTextureAtlas();
+          } catch {
+            // addon may be mid-dispose (pool eviction race) — refresh still runs
+          }
+        }
+        try {
+          terminal.refresh(0, terminal.rows - 1);
+        } catch {
+          // terminal may already be disposed
+        }
+      },
+    });
+    glyphRepaintRef.current = glyphRepaint;
+    const onTextareaFocus = () => glyphRepaint.onFocus();
+    // terminal.textarea exists once open() has run (above).
+    terminal.textarea?.addEventListener('focus', onTextareaFocus);
 
     // Only fit immediately if the container is actually visible (non-zero size).
     // If the workspace starts hidden (display:none), skip the initial fit so we
@@ -749,6 +781,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       removeDataListener = window.electronAPI.pty.onData((id, data) => {
         if (id === ptyId) {
           terminal.write(data);
+          glyphRepaint.onData(data.length);
           fireFirstData();
         }
       });
@@ -775,6 +808,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           return;
         }
         terminal.write(data);
+        glyphRepaint.onData(data.length);
         fireFirstData();
       });
 
@@ -972,6 +1006,9 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
 
     return () => {
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
+      terminal.textarea?.removeEventListener('focus', onTextareaFocus);
+      glyphRepaint.dispose();
+      glyphRepaintRef.current = null;
       autoCopy.dispose();
       selectionDisposable.dispose();
       pathLinkDisposable.dispose();
@@ -1112,6 +1149,14 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // ResizeObserver tick (after selection is released) handles the
       // deferred resize naturally.
       const id = requestAnimationFrame(() => {
+        // Issue #166 — repaint BEFORE the selection guard: neither the atlas
+        // clear nor refresh() touches the selection, and a stale pane must
+        // repair on view-switch-back even while a selection is live. Runs
+        // after the pool acquire above, so if a NEW addon was just created
+        // the atlas clear is a cheap no-op on a fresh atlas; the case this
+        // exists for is the fast switch where the old context (and its
+        // possibly stale atlas) was kept alive.
+        glyphRepaintRef.current?.onVisible();
         if (!shouldFitWhilePreservingSelection(terminalRef.current)) {
           console.debug('[Terminal] visibility fit skipped — active selection');
           return;

--- a/src/renderer/terminal/__tests__/glyphRepaint.test.ts
+++ b/src/renderer/terminal/__tests__/glyphRepaint.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createGlyphRepaintScheduler,
+  BURST_BYTES_DEFAULT,
+  BURST_QUIET_MS_DEFAULT,
+  FOCUS_THROTTLE_MS_DEFAULT,
+  type RepaintReason,
+} from '../glyphRepaint';
+
+describe('glyphRepaint scheduler', () => {
+  let repaints: RepaintReason[];
+  const repaint = (reason: RepaintReason) => repaints.push(reason);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    repaints = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('burst repaint', () => {
+    it('fires once after a qualifying burst settles', () => {
+      const s = createGlyphRepaintScheduler({ repaint });
+      s.onData(BURST_BYTES_DEFAULT);
+      expect(repaints).toEqual([]); // not before the quiet gap
+      vi.advanceTimersByTime(BURST_QUIET_MS_DEFAULT);
+      expect(repaints).toEqual(['burst']);
+    });
+
+    it('does not fire for a burst below the threshold', () => {
+      const s = createGlyphRepaintScheduler({ repaint });
+      s.onData(BURST_BYTES_DEFAULT - 1);
+      vi.advanceTimersByTime(BURST_QUIET_MS_DEFAULT * 2);
+      expect(repaints).toEqual([]);
+    });
+
+    it('accumulates chunks within one burst', () => {
+      const s = createGlyphRepaintScheduler({ repaint, burstBytes: 100, burstQuietMs: 50 });
+      s.onData(40);
+      vi.advanceTimersByTime(20); // still inside the quiet window
+      s.onData(40);
+      vi.advanceTimersByTime(20);
+      s.onData(40); // total 120 >= 100
+      vi.advanceTimersByTime(50);
+      expect(repaints).toEqual(['burst']);
+    });
+
+    it('keeps deferring while writes keep arriving, fires once at the end', () => {
+      const s = createGlyphRepaintScheduler({ repaint, burstBytes: 10, burstQuietMs: 50 });
+      for (let i = 0; i < 20; i++) {
+        s.onData(1000);
+        vi.advanceTimersByTime(49); // never quiet long enough
+      }
+      expect(repaints).toEqual([]);
+      vi.advanceTimersByTime(50);
+      expect(repaints).toEqual(['burst']);
+    });
+
+    it('resets accumulation between bursts — a slow trickle never qualifies', () => {
+      const s = createGlyphRepaintScheduler({ repaint, burstBytes: 100, burstQuietMs: 50 });
+      // 10 separate "bursts" of 60 each (each settles below threshold).
+      for (let i = 0; i < 10; i++) {
+        s.onData(60);
+        vi.advanceTimersByTime(51);
+      }
+      expect(repaints).toEqual([]);
+    });
+
+    it('fires again for a second qualifying burst', () => {
+      const s = createGlyphRepaintScheduler({ repaint, burstBytes: 100, burstQuietMs: 50 });
+      s.onData(150);
+      vi.advanceTimersByTime(50);
+      s.onData(150);
+      vi.advanceTimersByTime(50);
+      expect(repaints).toEqual(['burst', 'burst']);
+    });
+
+    it('ignores zero/negative sizes', () => {
+      const s = createGlyphRepaintScheduler({ repaint, burstBytes: 1, burstQuietMs: 50 });
+      s.onData(0);
+      s.onData(-5);
+      vi.advanceTimersByTime(100);
+      expect(repaints).toEqual([]);
+    });
+  });
+
+  describe('focus repaint', () => {
+    it('fires immediately on first focus', () => {
+      const t = 0;
+      const s = createGlyphRepaintScheduler({ repaint, now: () => t });
+      s.onFocus();
+      expect(repaints).toEqual(['focus']);
+    });
+
+    it('throttles rapid refocus', () => {
+      let t = 0;
+      const s = createGlyphRepaintScheduler({ repaint, now: () => t });
+      s.onFocus();
+      t += FOCUS_THROTTLE_MS_DEFAULT - 1;
+      s.onFocus(); // inside throttle window — dropped
+      expect(repaints).toEqual(['focus']);
+      t += 1; // exactly at the boundary
+      s.onFocus();
+      expect(repaints).toEqual(['focus', 'focus']);
+    });
+  });
+
+  describe('visible repaint', () => {
+    it('fires on every visibility regain (workspace switches are infrequent)', () => {
+      const s = createGlyphRepaintScheduler({ repaint });
+      s.onVisible();
+      s.onVisible();
+      expect(repaints).toEqual(['visible', 'visible']);
+    });
+  });
+
+  describe('dispose', () => {
+    it('cancels a pending burst repaint', () => {
+      const s = createGlyphRepaintScheduler({ repaint, burstBytes: 1, burstQuietMs: 50 });
+      s.onData(100);
+      s.dispose();
+      vi.advanceTimersByTime(100);
+      expect(repaints).toEqual([]);
+    });
+
+    it('turns all entry points into no-ops', () => {
+      const s = createGlyphRepaintScheduler({ repaint, burstBytes: 1, burstQuietMs: 50 });
+      s.dispose();
+      s.onData(100);
+      s.onFocus();
+      s.onVisible();
+      vi.advanceTimersByTime(100);
+      expect(repaints).toEqual([]);
+    });
+  });
+});

--- a/src/renderer/terminal/glyphRepaint.ts
+++ b/src/renderer/terminal/glyphRepaint.ts
@@ -1,0 +1,122 @@
+// Defensive repaint scheduling for the "garbled glyphs until resize" class of
+// rendering corruption (issue #166).
+//
+// Symptom: a pane's text renders as corrupted/mojibake glyphs after fast
+// output bursts (CJK + box-drawing heavy, several panes updating at once),
+// and stays corrupted until a pane-border drag forces a resize — which is the
+// only code path today that triggers a full xterm repaint. Two known
+// root-cause classes produce exactly this signature:
+//
+//   1. WebGL texture atlas corruption — the addon's glyph cache holds stale
+//      texture data; only `clearTextureAtlas()` (or addon recreate) repairs it.
+//   2. Dirty-region desync — xterm's incremental renderer thinks rows are
+//      clean when their on-screen pixels are stale; a full-range `refresh()`
+//      repairs it.
+//
+// The corruption is non-deterministic (driver/timing dependent), so instead of
+// chasing a single trigger we schedule cheap repaints at the moments a user
+// would notice staleness, covering both classes:
+//
+//   - `focus`   — the user clicked into the pane (throttled).
+//   - `visible` — the pane's workspace/tab became visible again. Matters for
+//                 fast view switches where the WebGL context pool kept the
+//                 (possibly stale) context alive instead of rebuilding it.
+//   - `burst`   — a contiguous run of PTY writes totalling >= burstBytes ended
+//                 (quiet for burstQuietMs). This is the "watching agent output
+//                 garble live" case where neither focus nor visibility changes.
+//
+// The caller decides repaint cost per reason: focus/visible clear the texture
+// atlas AND refresh (rare, user-initiated); burst only refreshes (frequent
+// under agent workloads — atlas re-rasterisation of a CJK-heavy screen on
+// every burst would be measurable GPU churn for no benefit in class 2).
+//
+// This module is pure scheduling logic (timers + counters) so it can be unit
+// tested without xterm; all rendering side effects live in the caller's
+// `repaint` callback.
+
+export type RepaintReason = 'focus' | 'visible' | 'burst';
+
+export interface GlyphRepaintScheduler {
+  /** Feed PTY write sizes; fires repaint('burst') when a large burst settles. */
+  onData(byteLength: number): void;
+  /** The terminal's textarea gained focus; throttled repaint('focus'). */
+  onFocus(): void;
+  /** The terminal became visible again; immediate repaint('visible'). */
+  onVisible(): void;
+  /** Cancel pending timers; all further calls become no-ops. */
+  dispose(): void;
+}
+
+export interface GlyphRepaintOptions {
+  repaint: (reason: RepaintReason) => void;
+  /** A burst must total at least this many UTF-16 code units to earn a
+   *  repaint when it settles. Small interactive echoes never qualify. */
+  burstBytes?: number;
+  /** Quiet gap that ends a burst. Writes closer together than this are the
+   *  same burst (one pending timer is re-armed per write). */
+  burstQuietMs?: number;
+  /** Minimum interval between focus-triggered repaints. Focus fires on every
+   *  click into the pane; the atlas clear behind it should not. */
+  focusThrottleMs?: number;
+  /** Injectable clock for tests. */
+  now?: () => number;
+}
+
+export const BURST_BYTES_DEFAULT = 32 * 1024;
+export const BURST_QUIET_MS_DEFAULT = 300;
+export const FOCUS_THROTTLE_MS_DEFAULT = 1000;
+
+export function createGlyphRepaintScheduler(
+  options: GlyphRepaintOptions,
+): GlyphRepaintScheduler {
+  const {
+    repaint,
+    burstBytes = BURST_BYTES_DEFAULT,
+    burstQuietMs = BURST_QUIET_MS_DEFAULT,
+    focusThrottleMs = FOCUS_THROTTLE_MS_DEFAULT,
+    now = Date.now,
+  } = options;
+
+  let disposed = false;
+  let burstAccum = 0;
+  let quietTimer: ReturnType<typeof setTimeout> | null = null;
+  let lastFocusRepaintAt = -Infinity;
+
+  return {
+    onData(byteLength: number): void {
+      if (disposed || byteLength <= 0) return;
+      burstAccum += byteLength;
+      if (quietTimer) clearTimeout(quietTimer);
+      quietTimer = setTimeout(() => {
+        quietTimer = null;
+        const qualified = burstAccum >= burstBytes;
+        // Always reset at burst end — a slow trickle must not accumulate
+        // across unrelated bursts into a spurious repaint.
+        burstAccum = 0;
+        if (qualified) repaint('burst');
+      }, burstQuietMs);
+    },
+
+    onFocus(): void {
+      if (disposed) return;
+      const t = now();
+      if (t - lastFocusRepaintAt < focusThrottleMs) return;
+      lastFocusRepaintAt = t;
+      repaint('focus');
+    },
+
+    onVisible(): void {
+      if (disposed) return;
+      repaint('visible');
+    },
+
+    dispose(): void {
+      disposed = true;
+      if (quietTimer) {
+        clearTimeout(quietTimer);
+        quietTimer = null;
+      }
+      burstAccum = 0;
+    },
+  };
+}

--- a/src/renderer/terminal/glyphRepaint.ts
+++ b/src/renderer/terminal/glyphRepaint.ts
@@ -17,7 +17,10 @@
 // chasing a single trigger we schedule cheap repaints at the moments a user
 // would notice staleness, covering both classes:
 //
-//   - `focus`   — the user clicked into the pane (throttled).
+//   - `focus`   — the pane became the focused pane: mouse click, keyboard
+//                 pane-nav, or the MCP pane.focus bridge (useActivePaneFocus
+//                 calls term.focus() for all of these). Throttled because
+//                 keyboard nav can cycle panes several times per second.
 //   - `visible` — the pane's workspace/tab became visible again. Matters for
 //                 fast view switches where the WebGL context pool kept the
 //                 (possibly stale) context alive instead of rebuilding it.


### PR DESCRIPTION
Fixes #166

## Problem

Panes intermittently render garbled/corrupted glyphs after fast output bursts (CJK + box-drawing heavy, several panes updating at once), and the corruption sticks until a pane-border drag forces a resize, which happens to be the only code path today that triggers a full repaint.

Two known root-cause classes produce exactly this signature, and the repro is non-deterministic (driver/timing dependent), so this fix covers both defensively rather than chasing a single trigger:

1. **WebGL texture atlas corruption** - the addon's glyph cache holds stale texture data; only `clearTextureAtlas()` repairs it. We load `@xterm/addon-webgl` but never call this anywhere.
2. **Dirty-region desync** - xterm's incremental renderer thinks rows are clean while their pixels are stale; a full-range `refresh()` repairs it.

## Fix

New `glyphRepaint` scheduler (pure timer/counter logic, unit-testable without xterm) wired into `useTerminal`, repainting at the moments staleness would be noticed:

| Trigger | Action | Rationale |
|---|---|---|
| textarea focus (throttled 1s) | `clearTextureAtlas()` + full `refresh()` | user clicked into the pane; rare and user-initiated, so the atlas clear is affordable |
| visibility regain | same | covers fast view switches where the WebGL context pool kept the (possibly stale) context alive instead of rebuilding it |
| PTY write burst settle (>=32KB total, 300ms quiet) | full `refresh()` only | the "watching agent output garble live" case; clearing a CJK-heavy atlas after every burst would be constant re-rasterisation for no benefit in class 2 |

The visibility repaint runs before the selection-preservation guard on purpose: neither the atlas clear nor `refresh()` touches the selection, and a stale pane must repair on switch-back even while a selection is live.

## Testing

- 12 new unit tests for the scheduler (burst accumulation/reset, trickle never qualifies, focus throttle boundary, dispose cancels pending work)
- `tsc --noEmit` clean, eslint clean on new files
- Full suite: failures seen in full-suite runs (`StateWriter`, `MetadataStore`) pass in isolation and vary between runs - pre-existing timing flakes under load, unrelated to this renderer-only change

Since the corruption is non-deterministic, the real verification is dogfood: when a pane garbles, clicking into it or switching workspaces back should now repair it without dragging a border. If it recurs past this, we reopen and go after the atlas path specifically (addon recreate instead of clear).