### PR TITLE
fix(terminal): clear xterm's hidden IME textarea when idle

### DIFF
--- a/docs/internal/substrate-perf.md
+++ b/docs/internal/substrate-perf.md
@@ -77,47 +77,45 @@ The bench prints a results table and emits machine-readable JSON both to `--json
 
 > Numbers below are from one bench run on the environment noted. They are environment-dependent (pipe IPC latency, CPU, disk — each write persists `metadata.json` synchronously); re-run on the target machine before quoting. Re-generate verbatim with the §2.4 command and lift the values from the `BENCH_JSON` block.
 
-Environment: `win32, Node v22.21.1, packaged app build 2.17.1 (out/wmux-win32-x64), --duration 10s, run 2026-06-09`
+Environment: `win32, Node v22.21.1, packaged app build 2.17.1 (out/wmux-win32-x64), --duration 10s, run 2026-06-10`
 
 ### B1 — metadata write throughput (single socket, paced under cap)
 
 | Metric | Value |
 |---|---|
-| writes/sec (single socket, paced under 50/s cap) | 31.35 — **below the ~48/s pace ceiling**, i.e. dispatch-cadence-bound (sequential await ≈ 5.7 ms + sleep-timer granularity ≈ 15 ms ⇒ ~32 ms/cycle), **not** the wire cap and not the store; see §2.3 |
-| write latency p50 / p95 / p99 | 5.688 ms / 9.295 ms / 10.636 ms |
-| ok writes / errors over the window | 314 / 0 |
-| version monotonic | PASS (final version = 314) |
+| writes/sec (single socket, paced under 50/s cap) | 37.23 — **below the ~48/s pace ceiling**, i.e. dispatch-cadence-bound (sequential await ≈ 5.1 ms + sleep-timer granularity ⇒ ~27 ms/cycle), **not** the wire cap and not the store; see §2.3 |
+| write latency p50 / p95 / p99 | 5.089 ms / 8.028 ms / 9.226 ms |
+| ok writes / errors over the window | 373 / 0 |
+| version monotonic | PASS (final version = 373) |
 
 ### B2 — `events.poll` round-trip latency by page size
 
 | `max` | p50 | p95 | events returned |
 |---|---|---|---|
-| 1 | 1.038 ms | 1.883 ms | 1 |
-| 32 | 1.349 ms | 1.991 ms | 32 |
-| 256 (`POLL_DEFAULT_MAX`) | 1.972 ms | 2.551 ms | 256 |
-| 1024 (`RING_CAPACITY`) | 2.115 ms | 3.637 ms | 314 |
+| 1 | 1.04 ms | 2.687 ms | 1 |
+| 32 | 0.969 ms | 2.24 ms | 32 |
+| 256 (`POLL_DEFAULT_MAX`) | 1.911 ms | 3.531 ms | 256 |
+| 1024 (`RING_CAPACITY`) | 2.506 ms | 5.079 ms | 373 |
 
 ### B3 — ring-overflow point + resync recovery
 
-> Counting caveat: in the run below the script counted *dispatched* writes and swallowed write errors without a counter (B1's `errors = 0` under the same caps makes silent B3 failures unlikely, but it was not proven). The script now counts only confirmed writes and reports `emit errors` separately — refresh this table on the next full run.
-
 | Metric | Value |
 |---|---|
-| events emitted | 1230 |
-| backlog at which `droppedCount` first appears | ≈ 720 events (first `droppedCount` = 9) |
-| final stale poll: `resync` / `droppedCount` | resync: true / 519 |
+| events emitted (confirmed writes; emit errors counted separately) | 1230 / 0 errors |
+| backlog at which `droppedCount` first appears | ≈ 650 events (first `droppedCount` = 3) |
+| final stale poll: `resync` / `droppedCount` | resync: true / 585 |
 | `bootId` stable across the burst | true |
-| recovered via `pane.list` (`asOfSeq` returned) | PASS (`asOfSeq` = 1547) |
+| recovered via `pane.list` (`asOfSeq` returned) | PASS (`asOfSeq` = 1613) |
 
 ### B4 — snapshot latency idle vs. mid-burst (m0 §8 Q5)
 
 | Metric | Value |
 |---|---|
 | pane count (this harness) | 1 |
-| `pane.list` idle p50 / p95 | 1.78 ms / 3.022 ms |
-| `pane.list` mid-burst p50 / p95 | 1.751 ms / 5.43 ms |
-| mid-burst / idle p95 ratio | 1.797x (no copy-on-write needed — see §4.3 caveat) |
-| concurrent writes completed during the burst | 253 |
+| `pane.list` idle p50 / p95 | 1.718 ms / 3.933 ms |
+| `pane.list` mid-burst p50 / p95 | 1.616 ms / 6.354 ms |
+| mid-burst / idle p95 ratio | 1.616x (no copy-on-write needed — see §4.3 caveat) |
+| concurrent writes completed during the burst | 306 |
 
 ---
 
@@ -140,7 +138,7 @@ The store can commit far more than 50 writes/s — a synchronous in-memory `Map.
 
 `MetadataStore.snapshot()` iterates the in-memory `Map`, clones each entry, and reads `eventBus.latestSeq()` + `eventBus.bootId` — all in-memory, all synchronous, no I/O (`src/main/metadata/MetadataStore.ts`). Because it is synchronous and the store map is in-memory, a snapshot cannot be *preempted* by a concurrent write, and a write cannot be preempted by a snapshot — single-threaded JS runs each to completion. The only interaction is that a `pane.list` and a `pane.setMetadata` queued at the same tick run back-to-back, each adding its own latency to the other's wait, not multiplying it.
 
-So the §8 Q5 question — "does a snapshot mid-burst block the main process noticeably?" — has a structural answer: **no copy-on-write is needed.** The snapshot is O(panes) in clone cost and O(1) in seq/bootId reads; it never awaits. B4 confirms this empirically, with the nuance the prediction anticipated: **mid-burst p50 is flat** (1.751 ms vs. 1.78 ms idle — the median snapshot is no slower under concurrent writes, exactly what "no blocking" predicts), while **p95 rises to 1.797x idle** (5.43 ms vs. 3.022 ms). That tail elevation is the IPC dispatch queue, not the store: both `pane.list` and the background writer share one main-process event loop, so a snapshot occasionally queues behind a write (and vice versa) and pays that one write's latency as added wait — they run back-to-back, not concurrently, so the tail widens while the median holds. A *store-blocking* failure would have moved the median too. The ratio scales with concurrent traffic and pane count, not with any shared lock — there is none.
+So the §8 Q5 question — "does a snapshot mid-burst block the main process noticeably?" — has a structural answer: **no copy-on-write is needed.** The snapshot is O(panes) in clone cost and O(1) in seq/bootId reads; it never awaits. B4 confirms this empirically, with the nuance the prediction anticipated: **mid-burst p50 is flat** (1.616 ms vs. 1.718 ms idle — the median snapshot is no slower under concurrent writes, exactly what "no blocking" predicts), while **p95 rises to 1.616x idle** (6.354 ms vs. 3.933 ms). That tail elevation is the IPC dispatch queue, not the store: both `pane.list` and the background writer share one main-process event loop, so a snapshot occasionally queues behind a write (and vice versa) and pays that one write's latency as added wait — they run back-to-back, not concurrently, so the tail widens while the median holds. A *store-blocking* failure would have moved the median too. The ratio scales with concurrent traffic and pane count, not with any shared lock — there is none.
 
 **Caveat on pane count.** This harness has one pane, so B4's snapshot cost is a floor, not a worst case. Snapshot clone cost is O(number of panes with metadata): `snapshot()` walks the whole map and clones each `metadata` object. A daemon with hundreds of metadata-bearing panes pays proportionally more per `pane.list`. That cost is still synchronous and non-blocking in the preemption sense, but it lengthens the single critical section. See §5.
 

--- a/scripts/issue-167-ime-wipe-dynamic.mjs
+++ b/scripts/issue-167-ime-wipe-dynamic.mjs
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+// Dynamic verification for issue #167 — AutoGLM voice/IME injection wipes the
+// already-typed line.
+//
+// Hypothesis under test (two-part):
+//   1. ENABLER — xterm.js's hidden textarea retains IME-composed text after it
+//      has been sent to the PTY (it is only cleared on blur / paste). So after
+//      typing "abc" through an IME, textarea.value === "abc" even though the
+//      shell already has those bytes.
+//   2. TRIGGER — an external injector (AutoGLM voice) treats that textarea as
+//      a populated edit field and "replaces" its content. Depending on how it
+//      replaces (backspace keystrokes / programmatic value swap + keyCode 229 /
+//      TSF range-replace composition), xterm emits destructive bytes (\x7f)
+//      or drops/mangles the inserted text.
+//
+// The suspect code is entirely in xterm.js's browser input layer
+// (CompositionHelper + CoreBrowserTerminal textarea handlers), so we test the
+// REAL @xterm/xterm 6.0 bundle in a real Chromium page and treat term.onData
+// as ground truth — those bytes are exactly what wmux forwards to the PTY.
+// A local line model applies the bytes like a shell echo line so "the typed
+// line got wiped" is directly observable.
+//
+// IME synthesis: CDP Input.imeSetComposition / Input.insertText (Chromium's
+// real IME pipeline). If the environment doesn't deliver composition events
+// (some headless builds), falls back to synthesized DOM CompositionEvents,
+// which exercise the same xterm handlers.
+//
+// Run: node scripts/issue-167-ime-wipe-dynamic.mjs
+
+import { createRequire } from 'module';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import http from 'http';
+
+const require = createRequire(import.meta.url);
+const { chromium } = require('playwright-core');
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const xtermJs = readFileSync(join(root, 'node_modules/@xterm/xterm/lib/xterm.js'), 'utf8');
+const xtermCss = readFileSync(join(root, 'node_modules/@xterm/xterm/css/xterm.css'), 'utf8');
+
+const PAGE = `<!doctype html>
+<meta charset="utf-8"><title>wmux-167</title>
+<style>${xtermCss}</style>
+<body><div id="t" style="width:800px;height:300px"></div>
+<script>${xtermJs}<\/script>
+<script>
+  window.__bytes = [];   // raw onData chunks (what wmux would write to the PTY)
+  window.__events = [];  // textarea event trace
+  window.__line = '';    // shell-line model: printable appends, \\x7f erases
+
+  const term = new Terminal({ cols: 80, rows: 10 });
+  term.open(document.getElementById('t'));
+  term.onData((d) => {
+    window.__bytes.push(d);
+    for (const ch of d) {
+      if (ch === '\\x7f' || ch === '\\b') window.__line = window.__line.slice(0, -1);
+      else if (ch >= ' ') window.__line += ch;
+    }
+  });
+  term.focus();
+
+  const ta = document.querySelector('.xterm-helper-textarea');
+  for (const type of ['keydown','keyup','compositionstart','compositionupdate','compositionend','beforeinput','input']) {
+    ta.addEventListener(type, (e) => {
+      window.__events.push({
+        type,
+        data: e.data ?? null,
+        inputType: e.inputType ?? null,
+        key: e.key ?? null,
+        keyCode: e.keyCode ?? null,
+        isComposing: e.isComposing ?? null,
+        value: ta.value,
+      });
+    }, true);
+  }
+
+  window.__ta = ta;
+  window.__reset = () => { window.__bytes = []; window.__events = []; window.__line = ''; ta.value = ''; term.focus(); };
+  // DOM-synthesis fallback: emulate an IME commit (compositionstart/update,
+  // textarea mutation, compositionend) without Chromium's IME pipeline.
+  window.__domCompose = (text) => {
+    ta.dispatchEvent(new CompositionEvent('compositionstart', { data: '' }));
+    ta.dispatchEvent(new CompositionEvent('compositionupdate', { data: text }));
+    ta.value += text;
+    ta.dispatchEvent(new CompositionEvent('compositionend', { data: text }));
+  };
+<\/script>`;
+
+const results = [];
+function check(name, ok, detail = '') {
+  results.push({ name, ok, detail });
+  console.log(`  [${ok ? 'PASS' : 'FAIL'}] ${name}${detail ? ` — ${detail}` : ''}`);
+}
+const show = (s) => JSON.stringify(s);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const server = http.createServer((_req, res) => {
+  res.setHeader('Content-Type', 'text/html');
+  res.end(PAGE);
+});
+
+let browser;
+try {
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const origin = `http://127.0.0.1:${server.address().port}`;
+
+  browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto(origin);
+  await page.waitForFunction(() => !!window.__ta);
+  const cdp = await page.context().newCDPSession(page);
+
+  const state = () =>
+    page.evaluate(() => ({
+      bytes: window.__bytes,
+      line: window.__line,
+      taValue: window.__ta.value,
+      events: window.__events.map((e) => `${e.type}(${e.inputType ?? e.key ?? e.data ?? ''})${e.isComposing ? '*' : ''}`),
+    }));
+  const reset = () => page.evaluate(() => window.__reset());
+
+  // Compose text via CDP IME pipeline; falls back to DOM synthesis when the
+  // environment doesn't deliver composition events to the page.
+  let useDomFallback = false;
+  async function imeCommit(text) {
+    if (useDomFallback) {
+      await page.evaluate((t) => window.__domCompose(t), text);
+    } else {
+      for (let i = 1; i <= text.length; i++) {
+        await cdp.send('Input.imeSetComposition', { text: text.slice(0, i), selectionStart: i, selectionEnd: i });
+      }
+      await cdp.send('Input.insertText', { text });
+    }
+    await sleep(80); // CompositionHelper finalizes in setTimeout(0)
+  }
+
+  // ── T0: plain (non-IME) typing leaves no residue ──────────────────────────
+  console.log('T0: plain keystrokes (baseline)');
+  for (const ch of 'abc') {
+    await cdp.send('Input.dispatchKeyEvent', { type: 'keyDown', key: ch, code: 'Key' + ch.toUpperCase(), text: ch, windowsVirtualKeyCode: ch.toUpperCase().charCodeAt(0) });
+    await cdp.send('Input.dispatchKeyEvent', { type: 'keyUp', key: ch, code: 'Key' + ch.toUpperCase(), windowsVirtualKeyCode: ch.toUpperCase().charCodeAt(0) });
+  }
+  await sleep(80);
+  {
+    const s = await state();
+    check('T0 bytes are "abc"', s.bytes.join('') === 'abc', show(s.bytes.join('')));
+    check('T0 textarea has NO residue', s.taValue === '', `value=${show(s.taValue)}`);
+  }
+
+  // ── T1: IME-composed typing leaves residue (ENABLER) ──────────────────────
+  console.log('T1: IME composition "abc" (the enabler)');
+  await reset();
+  await imeCommit('abc');
+  {
+    const s = await state();
+    const sawComposition = s.events.some((e) => e.startsWith('compositionstart'));
+    if (!sawComposition) {
+      useDomFallback = true;
+      console.log('  (CDP IME events not delivered — switching to DOM-synthesis fallback)');
+      await reset();
+      await imeCommit('abc');
+    }
+  }
+  {
+    const s = await state();
+    check('T1 bytes are "abc" (sent to PTY once)', s.bytes.join('') === 'abc', show(s.bytes.join('')));
+    check('T1 textarea RETAINS "abc" after send', s.taValue === 'abc', `value=${show(s.taValue)} — residue enables external "replace field" behavior`);
+    console.log(`  trace: ${s.events.join(' → ')}`);
+  }
+
+  // Helper: seed the canonical repro state — shell line "abc", textarea "abc" —
+  // then clear the byte tape so each scenario asserts only the injection's bytes.
+  async function seed() {
+    await reset();
+    await imeCommit('abc');
+    await page.evaluate(() => { window.__bytes = []; });
+  }
+
+  // ── T2: injector clears the "field" with backspace keys, then inserts ─────
+  console.log('T2: backspace-clear + voice insert (S1: SendInput VK_BACK style)');
+  await seed();
+  for (let i = 0; i < 3; i++) {
+    await cdp.send('Input.dispatchKeyEvent', { type: 'rawKeyDown', key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8 });
+    await cdp.send('Input.dispatchKeyEvent', { type: 'keyUp', key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8 });
+  }
+  await sleep(50);
+  await imeCommit('voice');
+  {
+    const s = await state();
+    const dels = (s.bytes.join('').match(/\x7f/g) || []).length;
+    check('T2 xterm forwarded 3 destructive DEL bytes', dels === 3, `DEL count=${dels}`);
+    check('T2 WIPE REPRODUCED: typed "abc" erased from line', s.line === 'voice', `line=${show(s.line)} (expected "voice" if wiped, "abcvoice" if appended)`);
+    console.log(`  bytes: ${show(s.bytes.join(''))}  textarea after: ${show(s.taValue)}`);
+  }
+
+
+  // ── T3: programmatic value replace + keyCode 229 (S2: DEL diff path) ──────
+  console.log('T3: keydown 229 + programmatic shorter replace (S2: _handleAnyTextareaChanges)');
+  await seed();
+  await page.evaluate(() => {
+    const ta = window.__ta;
+    ta.dispatchEvent(new KeyboardEvent('keydown', { key: 'Process', keyCode: 229 }));
+    ta.value = 'xy'; // injector swaps field content with shorter recognized text
+  });
+  await sleep(80);
+  {
+    const s = await state();
+    const bytes = s.bytes.join('');
+    check('T3 xterm emitted a lone destructive DEL', bytes === '\x7f', `bytes=${show(bytes)} — one char of the typed line erased`);
+    check('T3 replacement text LOST (never sent) and line damaged', s.line === 'ab' && !bytes.includes('xy'), `line=${show(s.line)} (was "abc") — "xy" never reached the PTY`);
+  }
+
+  // ── T4: TSF range-replace composition (S3) ────────────────────────────────
+  console.log('T4: composition with replacement range 0..3 (S3: TSF replace)');
+  await seed();
+  if (!useDomFallback) {
+    await cdp.send('Input.imeSetComposition', { text: 'voice', selectionStart: 5, selectionEnd: 5, replacementStart: 0, replacementEnd: 3 });
+    await cdp.send('Input.insertText', { text: 'voice' });
+    await sleep(80);
+    const s = await state();
+    const bytes = s.bytes.join('');
+    check('T4 commit MANGLED by stale composition position', bytes !== 'voice' && bytes.length < 'voice'.length, `bytes=${show(bytes)} — substring(start=3) of replaced value, not the full text`);
+    console.log(`  line=${show(s.line)} textarea=${show(s.taValue)}`);
+  } else {
+    console.log('  (skipped — requires CDP IME pipeline)');
+  }
+
+  // ── T5: fix direction — idle-cleared textarea removes the hazard ──────────
+  console.log('T5: same injection against an idle-cleared textarea (fix preview)');
+  await seed();
+  await page.evaluate(() => { window.__ta.value = ''; }); // what an idle-clear guard would do post-send
+  await page.evaluate(() => { window.__bytes = []; window.__line = 'abc'; }); // keep shell line, clear tape
+  await imeCommit('voice');
+  {
+    const s = await state();
+    check('T5 voice text APPENDS cleanly (no wipe) once residue is gone', s.line === 'abcvoice' && !s.bytes.join('').includes('\x7f'), `line=${show(s.line)} bytes=${show(s.bytes.join(''))}`);
+  }
+
+  // ── T6: the wmux fix (imeResidueGuard) against the real IME pipeline ──────
+  // Mirrors src/renderer/terminal/imeResidueGuard.ts (same event scheme:
+  // compositionstart cancels, compositionend/keydown/onData re-arm a debounced
+  // clear). Validates the race-safety design against real Chromium event
+  // ordering: normal IME typing must be unaffected, back-to-back compositions
+  // must not lose text to the timer, and the residue must be gone once idle.
+  console.log('T6: imeResidueGuard scheme — normal IME typing intact, residue cleared when idle');
+  await reset();
+  await page.evaluate(() => {
+    const ta = window.__ta;
+    const DELAY = 150;
+    let composing = false;
+    let timer = null;
+    const cancel = () => { if (timer !== null) { clearTimeout(timer); timer = null; } };
+    const schedule = () => {
+      cancel();
+      timer = setTimeout(() => {
+        timer = null;
+        if (composing) return;
+        if (ta.selectionStart !== ta.selectionEnd) return;
+        if (ta.value.length === 0) return;
+        ta.value = '';
+      }, DELAY);
+    };
+    ta.addEventListener('compositionstart', () => { composing = true; cancel(); });
+    ta.addEventListener('compositionend', () => { composing = false; schedule(); });
+    ta.addEventListener('keydown', () => { if (!composing) schedule(); });
+  });
+  await imeCommit('abc');
+  await imeCommit('def'); // back-to-back: second composition starts within the debounce window
+  {
+    const s = await state();
+    check('T6 back-to-back IME commits both reach the PTY', s.bytes.join('') === 'abcdef', `bytes=${show(s.bytes.join(''))}`);
+  }
+  await sleep(300); // let the guard go idle
+  {
+    const s = await state();
+    check('T6 residue cleared once idle', s.taValue === '', `value=${show(s.taValue)}`);
+  }
+  await imeCommit('ghi'); // typing again after a clear must still work
+  {
+    const s = await state();
+    check('T6 IME typing after a clear still works', s.bytes.join('') === 'abcdefghi', `bytes=${show(s.bytes.join(''))}`);
+  }
+  // Replay the T2 injector against the guarded terminal: a field-replacing
+  // tool sends one Backspace per char it READS in the field. Idle guard has
+  // emptied it, so it sends zero backspaces and just commits.
+  await sleep(300);
+  {
+    const n = await page.evaluate(() => window.__ta.value.length);
+    for (let i = 0; i < n; i++) {
+      await cdp.send('Input.dispatchKeyEvent', { type: 'rawKeyDown', key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8 });
+      await cdp.send('Input.dispatchKeyEvent', { type: 'keyUp', key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8 });
+    }
+    await imeCommit('voice');
+    const s = await state();
+    check('T6 injection with guard: appends cleanly, NO wipe', s.line === 'abcdefghivoice' && !s.bytes.join('').includes('\x7f'), `line=${show(s.line)}`);
+  }
+
+  console.log('');
+  const fails = results.filter((r) => !r.ok);
+  console.log(`${results.length - fails.length}/${results.length} checks passed${fails.length ? ` — FAILURES: ${fails.map((f) => f.name).join('; ')}` : ''}`);
+  process.exitCode = fails.length ? 1 : 0;
+} finally {
+  await browser?.close();
+  server.close();
+}

--- a/scripts/substrate-bench.mjs
+++ b/scripts/substrate-bench.mjs
@@ -489,6 +489,8 @@ function line(s) { lines.push(s); console.log(s); }
     let emitted = 0;      // successful writes (each is exactly one ring event)
     let emitErrors = 0;   // failed writes — must NOT count toward the backlog
     let emitSeq = 0;
+    let firstDropAtBacklog = null;
+    let firstDropCount = null;
     const emitOne = (c, tag) => c.call('pane.setMetadata', {
       paneId, workspaceId: wsId,
       custom: { [`bench.b3.${tag}`]: String(++emitSeq) },

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -17,6 +17,7 @@ import { createAutoSelectionCopy } from '../utils/autoSelectionCopy';
 import { terminalFontFamilyCss } from '../utils/terminalFont';
 import { createPathLinkProvider } from '../terminal/pathLinkProvider';
 import { resolveNewlineKeyByte } from '../terminal/newlineKeys';
+import { attachImeResidueGuard } from '../terminal/imeResidueGuard';
 import { webglContextPool } from '../terminal/webglContextPool';
 import { createGlyphRepaintScheduler, type GlyphRepaintScheduler } from '../terminal/glyphRepaint';
 import { reconnectPtyWithRetry as reconnectPtyWithRetryImpl } from './reconnectPtyWithRetry';
@@ -327,6 +328,18 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // positioning (Claude Code, vim, etc.) collide frames over Korean text.
     terminal.unicode.activeVersion = '11';
     terminal.open(container);
+
+    // Issue #167: keep the hidden IME textarea empty while idle. xterm only
+    // clears it on blur, so IME-committed text accumulates there after it was
+    // already sent to the PTY, and external field-replacing injectors (voice
+    // IME like AutoGLM) "replace" that residue with destructive results — the
+    // forwarded DELs wipe the user's already-typed line. Upstream:
+    // xtermjs/xterm.js#6012. Gated off under screenReaderMode, where xterm
+    // intentionally retains the text until blur for announcement (wmux never
+    // enables that option today).
+    const imeResidueGuard = terminal.options.screenReaderMode
+      ? null
+      : attachImeResidueGuard(terminal);
 
     // Paint the container backdrop with the xterm theme background so the 4px
     // padding (and the sub-cell rounding gap xterm leaves around its grid) fades
@@ -1022,6 +1035,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       terminal.textarea?.removeEventListener('focus', onTextareaFocus);
       glyphRepaint.dispose();
       glyphRepaintRef.current = null;
+      imeResidueGuard?.dispose();
       autoCopy.dispose();
       selectionDisposable.dispose();
       pathLinkDisposable.dispose();

--- a/src/renderer/terminal/__tests__/imeResidueGuard.test.ts
+++ b/src/renderer/terminal/__tests__/imeResidueGuard.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  attachImeResidueGuard,
+  IME_RESIDUE_CLEAR_DELAY_MS,
+  type ImeResidueGuardTextarea,
+  type ImeResidueGuardTerminal,
+} from '../imeResidueGuard';
+
+const DELAY = IME_RESIDUE_CLEAR_DELAY_MS;
+
+class FakeTextarea implements ImeResidueGuardTextarea {
+  value = '';
+  selectionStart = 0;
+  selectionEnd = 0;
+  listeners = new Map<string, Set<() => void>>();
+
+  addEventListener(type: string, listener: () => void): void {
+    const set = this.listeners.get(type) ?? new Set<() => void>();
+    set.add(listener);
+    this.listeners.set(type, set);
+  }
+  removeEventListener(type: string, listener: () => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+  fire(type: string): void {
+    for (const l of this.listeners.get(type) ?? []) l();
+  }
+  listenerCount(): number {
+    let n = 0;
+    for (const set of this.listeners.values()) n += set.size;
+    return n;
+  }
+}
+
+function makeTerminal(textarea: FakeTextarea | undefined): {
+  terminal: ImeResidueGuardTerminal;
+  emitData: (data: string) => void;
+  dataHandlerCount: () => number;
+} {
+  const handlers = new Set<(data: string) => void>();
+  return {
+    terminal: {
+      textarea,
+      onData(handler: (data: string) => void) {
+        handlers.add(handler);
+        return { dispose: () => handlers.delete(handler) };
+      },
+    },
+    emitData: (data: string) => {
+      for (const h of handlers) h(data);
+    },
+    dataHandlerCount: () => handlers.size,
+  };
+}
+
+describe('attachImeResidueGuard', () => {
+  let ta: FakeTextarea;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    ta = new FakeTextarea();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clears IME residue after the terminal goes idle (onData trigger)', () => {
+    const { terminal, emitData } = makeTerminal(ta);
+    attachImeResidueGuard(terminal);
+
+    // IME-committed text was sent to the PTY but lingers in the textarea.
+    ta.value = 'abc';
+    emitData('abc');
+
+    vi.advanceTimersByTime(DELAY - 1);
+    expect(ta.value).toBe('abc');
+    vi.advanceTimersByTime(1);
+    expect(ta.value).toBe('');
+  });
+
+  it('clears residue after compositionend + idle delay', () => {
+    const { terminal } = makeTerminal(ta);
+    attachImeResidueGuard(terminal);
+
+    ta.fire('compositionstart');
+    ta.value = '한글';
+    ta.fire('compositionend');
+
+    vi.advanceTimersByTime(DELAY);
+    expect(ta.value).toBe('');
+  });
+
+  it('never clears while a composition is active', () => {
+    const { terminal, emitData } = makeTerminal(ta);
+    attachImeResidueGuard(terminal);
+
+    ta.value = 'abc';
+    emitData('abc'); // pending clear armed
+    ta.fire('compositionstart'); // new composition cancels it
+    ta.value = 'abc한';
+
+    // Even far past the delay, an active composition must not be touched —
+    // CompositionHelper reads textarea.value to finalize it.
+    vi.advanceTimersByTime(DELAY * 10);
+    expect(ta.value).toBe('abc한');
+  });
+
+  it('keydown re-arms a pending clear (cannot fire inside the 229 diff window)', () => {
+    const { terminal, emitData } = makeTerminal(ta);
+    attachImeResidueGuard(terminal);
+
+    ta.value = 'abc';
+    emitData('abc'); // clear due at t=DELAY
+
+    vi.advanceTimersByTime(DELAY - 10);
+    ta.fire('keydown'); // e.g. keyCode 229 — xterm will diff value at setTimeout(0)
+
+    // The old deadline passes without a clear…
+    vi.advanceTimersByTime(10);
+    expect(ta.value).toBe('abc');
+    // …and the re-armed timer fires a full delay after the keydown.
+    vi.advanceTimersByTime(DELAY - 10);
+    expect(ta.value).toBe('');
+  });
+
+  it('skips the clear while the textarea holds a selection (right-click copy)', () => {
+    const { terminal, emitData } = makeTerminal(ta);
+    attachImeResidueGuard(terminal);
+
+    ta.value = 'selected text';
+    ta.selectionStart = 0;
+    ta.selectionEnd = ta.value.length;
+    emitData('x');
+
+    vi.advanceTimersByTime(DELAY);
+    expect(ta.value).toBe('selected text');
+  });
+
+  it('is a no-op when the textarea is already empty', () => {
+    const { terminal, emitData } = makeTerminal(ta);
+    attachImeResidueGuard(terminal);
+
+    emitData('a');
+    vi.advanceTimersByTime(DELAY);
+    expect(ta.value).toBe('');
+  });
+
+  it('dispose removes all listeners and cancels the pending timer', () => {
+    const { terminal, emitData, dataHandlerCount } = makeTerminal(ta);
+    const guard = attachImeResidueGuard(terminal);
+
+    ta.value = 'abc';
+    emitData('abc');
+    guard.dispose();
+
+    vi.advanceTimersByTime(DELAY * 2);
+    expect(ta.value).toBe('abc'); // pending clear was cancelled
+    expect(ta.listenerCount()).toBe(0);
+    expect(dataHandlerCount()).toBe(0);
+  });
+
+  it('tolerates a terminal without a textarea', () => {
+    const { terminal } = makeTerminal(undefined);
+    const guard = attachImeResidueGuard(terminal);
+    expect(() => guard.dispose()).not.toThrow();
+  });
+});

--- a/src/renderer/terminal/imeResidueGuard.ts
+++ b/src/renderer/terminal/imeResidueGuard.ts
@@ -1,0 +1,128 @@
+/**
+ * Idle clearing for xterm's hidden IME textarea (issue #167).
+ *
+ * Why this exists:
+ *   xterm.js only clears its hidden helper textarea on blur (and on paste).
+ *   Text committed through an IME composition therefore stays in
+ *   `textarea.value` after it has already been sent to the PTY: type `abc`
+ *   through an IME and the shell has `abc`, but the textarea still says
+ *   `abc` for as long as the pane keeps focus.
+ *
+ *   External input tools that treat the focused element as an ordinary edit
+ *   field then "replace" that residue instead of inserting at the caret —
+ *   AutoGLM's voice input does this — and every replacement style is
+ *   destructive (verified dynamically in scripts/issue-167-ime-wipe-dynamic.mjs
+ *   against the real xterm 6.0 bundle; reported upstream as
+ *   xtermjs/xterm.js#6012):
+ *     • backspace-clear: xterm forwards one DEL (\x7f) per leftover char,
+ *       erasing the user's already-typed line (the reported symptom),
+ *     • programmatic value swap + keyCode 229: CompositionHelper's diff path
+ *       emits a stray DEL and silently drops the new text,
+ *     • TSF replacement-range composition: the stale composition start
+ *       position slices the committed text.
+ *
+ *   Keeping the textarea empty while no composition is active removes the
+ *   residue, so a field-replacing injector sees nothing to replace and its
+ *   text simply inserts.
+ *
+ * Race safety — xterm reads `textarea.value` in two `setTimeout(0)` paths,
+ * and clearing inside either window would corrupt input, so the clear is
+ * debounced and re-armed by the events that open those windows:
+ *   1. CompositionHelper finalize (compositionend → setTimeout(0) → read):
+ *      `compositionstart` cancels any pending clear, and the clear scheduled
+ *      by `compositionend` fires a full delay after the finalize read.
+ *   2. CompositionHelper._handleAnyTextareaChanges (keydown 229 → captures
+ *      oldValue → setTimeout(0) → diffs newValue): every keydown re-arms the
+ *      timer, so no clear can fire between a keydown and its 0ms diff.
+ *   3. Right-click copy parks the selection text in the textarea and selects
+ *      it for the context menu; a non-collapsed selection skips the clear.
+ *
+ * NOT attached when screenReaderMode is enabled — xterm intentionally
+ * retains the textarea text until blur so screen readers can announce it
+ * (see CoreBrowserTerminal._handleTextAreaBlur). The call site gates this.
+ */
+
+/** Structural subset of HTMLTextAreaElement the guard touches (node-testable). */
+export interface ImeResidueGuardTextarea {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+  addEventListener(type: string, listener: () => void): void;
+  removeEventListener(type: string, listener: () => void): void;
+}
+
+/** Structural subset of xterm's Terminal the guard needs. */
+export interface ImeResidueGuardTerminal {
+  textarea: ImeResidueGuardTextarea | undefined;
+  onData(handler: (data: string) => void): { dispose(): void };
+}
+
+/**
+ * Idle delay before clearing. Must comfortably exceed xterm's internal
+ * setTimeout(0) reads (see "Race safety" above); beyond that the exact value
+ * only bounds how soon after the last input an external injector observes an
+ * empty field. Voice input always arrives seconds after typing stops.
+ */
+export const IME_RESIDUE_CLEAR_DELAY_MS = 150;
+
+export function attachImeResidueGuard(
+  terminal: ImeResidueGuardTerminal,
+  delayMs: number = IME_RESIDUE_CLEAR_DELAY_MS,
+): { dispose(): void } {
+  const textarea = terminal.textarea;
+  if (!textarea) {
+    return { dispose: () => undefined };
+  }
+
+  let composing = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const cancel = (): void => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const schedule = (): void => {
+    cancel();
+    timer = setTimeout(() => {
+      timer = null;
+      if (composing) return;
+      if (textarea.selectionStart !== textarea.selectionEnd) return;
+      if (textarea.value.length === 0) return;
+      textarea.value = '';
+    }, delayMs);
+  };
+
+  const onCompositionStart = (): void => {
+    composing = true;
+    cancel();
+  };
+  const onCompositionEnd = (): void => {
+    composing = false;
+    schedule();
+  };
+  // Re-arm on every keydown so a pending clear can never fire inside the
+  // keydown→setTimeout(0) window of CompositionHelper's 229 diff path.
+  const onKeyDown = (): void => {
+    if (!composing) schedule();
+  };
+
+  textarea.addEventListener('compositionstart', onCompositionStart);
+  textarea.addEventListener('compositionend', onCompositionEnd);
+  textarea.addEventListener('keydown', onKeyDown);
+  const dataDisposable = terminal.onData(() => {
+    if (!composing) schedule();
+  });
+
+  return {
+    dispose: (): void => {
+      cancel();
+      textarea.removeEventListener('compositionstart', onCompositionStart);
+      textarea.removeEventListener('compositionend', onCompositionEnd);
+      textarea.removeEventListener('keydown', onKeyDown);
+      dataDisposable.dispose();
+    },
+  };
+}


### PR DESCRIPTION
Fixes #167. Upstream report: xtermjs/xterm.js#6012.

## Problem

xterm.js only clears its hidden helper textarea on blur, so text committed through an IME stays in `textarea.value` after it has already been sent to the PTY. Type `abc` through an IME and the shell has `abc`, but the textarea still says `abc` for as long as the pane keeps focus.

Input tools that treat the focused element as an ordinary edit field then "replace" that residue instead of inserting at the caret. AutoGLM's voice input does this, and the user's already-typed line gets wiped (#167). I verified all three plausible replacement styles against the stock xterm 6.0 bundle through Chromium's real IME pipeline, and every one corrupts input:

- backspace-clearing forwards one `\x7f` per leftover char, erasing the typed line (the reported symptom)
- a programmatic value swap plus a keyCode 229 keydown emits a stray `\x7f` and silently drops the new text
- a TSF replacement-range composition slices the commit against a stale `_compositionPosition.start` (`voice` arrives as `ce`)

## Fix

`imeResidueGuard` keeps the textarea empty while no composition is active. With the residue gone, a field-replacing injector sees nothing to replace and its text simply inserts.

The clear is debounced (150ms) and the timing is the careful part. xterm reads `textarea.value` in two `setTimeout(0)` paths, and clearing inside either window would corrupt input, so:

- `compositionstart` cancels any pending clear; the clear scheduled by `compositionend` fires well after CompositionHelper's finalize read
- every keydown re-arms the timer, so a clear can never land between a keyCode-229 keydown and its 0ms textarea diff
- a non-collapsed selection skips the clear (right-click copy parks the selection text in the textarea)
- not attached under `screenReaderMode`, where xterm retains the text until blur on purpose

## Verification

- `scripts/issue-167-ime-wipe-dynamic.mjs`: drives the real lib bundle in Chromium via CDP `Input.imeSetComposition` / `Input.insertText`. 14/14 checks. T1 proves the residue, T2-T4 reproduce the three corruption styles (T2 is the exact #167 symptom), T6 runs the guard scheme against the same pipeline: back-to-back IME commits lose nothing, the residue clears once idle, and the same injection appends cleanly with no wipe.
- Unit tests (8) cover the race cases: no clear during an active composition, keydown re-arm, selection skip, cancel on dispose.
- Full suite: 2478 passing. The 3 failing files fail identically on main (locally broken transitive deps, `@alloc/quick-lru` / `@asamuzakjp/css-color`), unrelated to this change.

Real-world regression check for the risky path: everyday Korean IME typing exercises the composition flow this touches; dogfooding before release as usual.