### PR TITLE
feat(terminal): keyboard zoom for terminal font size (Ctrl+= / Ctrl+- / Ctrl+0)

### DIFF
--- a/src/renderer/hooks/__tests__/useKeyboard.test.ts
+++ b/src/renderer/hooks/__tests__/useKeyboard.test.ts
@@ -24,6 +24,7 @@ import * as path from 'node:path';
 import {
   ctrlByteForKeyCode,
   createPrefixActions,
+  clampFontSize,
   type PrefixActionDeps,
 } from '../useKeyboard';
 import { DEFAULT_PREFIX_CONFIG } from '../../../shared/types';
@@ -418,5 +419,84 @@ describe('useKeyboard handler — inspect suppression (D-exclusive)', () => {
     // unconsumed so InspectOverlay's React onKeyDown handles exitInspect.
     const head = handlerHead();
     expect(head).not.toMatch(/Escape/);
+  });
+});
+
+// ─── Terminal font zoom (#171) ──────────────────────────────────────────────
+
+describe('clampFontSize', () => {
+  it('passes through values inside the [12, 24] range', () => {
+    expect(clampFontSize(14)).toBe(14);
+    expect(clampFontSize(12)).toBe(12);
+    expect(clampFontSize(24)).toBe(24);
+  });
+
+  it('clamps below the minimum up to 12', () => {
+    expect(clampFontSize(11)).toBe(12);
+    expect(clampFontSize(-5)).toBe(12);
+    expect(clampFontSize(0)).toBe(12);
+  });
+
+  it('clamps above the maximum down to 24', () => {
+    expect(clampFontSize(25)).toBe(24);
+    expect(clampFontSize(100)).toBe(24);
+  });
+});
+
+describe('useKeyboard handler — zoom shortcuts (#171)', () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, '..', 'useKeyboard.ts'),
+    'utf-8',
+  );
+
+  it('zoom range constants stay aligned with the Settings slider + store default', () => {
+    expect(src).toContain('const FONT_SIZE_MIN = 12;');
+    expect(src).toContain('const FONT_SIZE_MAX = 24;');
+    expect(src).toContain('const FONT_SIZE_DEFAULT = 14;');
+  });
+
+  it('zoom in matches both e.key and physical e.code (IME-safe), incl. numpad', () => {
+    // The combined zoom-in guard must accept '=' / '+' by key and Equal /
+    // NumpadAdd by code so a Hangul IME (e.key = composed glyph) still zooms.
+    expect(src).toMatch(/key === '=' \|\| key === '\+' \|\| code === 'Equal' \|\| code === 'NumpadAdd'/);
+  });
+
+  it('zoom out matches Ctrl+- by key and Minus / NumpadSubtract by code', () => {
+    expect(src).toMatch(/key === '-' \|\| key === '_' \|\| code === 'Minus' \|\| code === 'NumpadSubtract'/);
+  });
+
+  it('reset zoom (Ctrl+0) restores FONT_SIZE_DEFAULT and excludes Shift', () => {
+    const reset = src.indexOf("key === '0' || code === 'Digit0' || code === 'Numpad0'");
+    expect(reset, 'reset guard not found').toBeGreaterThan(-1);
+    // The reset guard line requires !shift so Ctrl+Shift+0 stays free.
+    const guardLineStart = src.lastIndexOf('if (', reset);
+    expect(src.slice(guardLineStart, reset)).toContain('!shift');
+    expect(src).toContain('store.getState().setTerminalFontSize(FONT_SIZE_DEFAULT);');
+  });
+
+  it('places the zoom guards AFTER the Ctrl+1~9 workspace switch (so Ctrl+0 is unambiguous)', () => {
+    const wsSwitch = src.indexOf("key >= '1' && key <= '9'");
+    const zoomIn = src.indexOf('Zoom in: Ctrl+= or Ctrl++');
+    expect(wsSwitch).toBeGreaterThan(-1);
+    expect(zoomIn).toBeGreaterThan(-1);
+    expect(zoomIn).toBeGreaterThan(wsSwitch);
+  });
+
+  it('zoom writes through setTerminalFontSize (runtime font effect, no re-create)', () => {
+    expect(src).toContain('store.getState().setTerminalFontSize(next)');
+  });
+});
+
+describe('useTerminal — zoom combos bubble past xterm (#171)', () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, '..', 'useTerminal.ts'),
+    'utf-8',
+  );
+
+  it('returns false (bubbles) for Ctrl+= / Ctrl+- / Ctrl+0 by key and code', () => {
+    // Without this, xterm would feed '=' / '-' / '0' to the PTY instead of
+    // letting useKeyboard zoom. Match the guard that lists the keys + codes.
+    expect(src).toMatch(/e\.key === '=' \|\| e\.key === '-' \|\| e\.key === '0'/);
+    expect(src).toMatch(/e\.code === 'Equal' \|\| e\.code === 'Minus' \|\| e\.code === 'Digit0'/);
   });
 });

--- a/src/renderer/hooks/__tests__/useKeyboard.zoom.dynamic.test.tsx
+++ b/src/renderer/hooks/__tests__/useKeyboard.zoom.dynamic.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+//
+// Dynamic verification for #171 terminal font zoom.
+//
+// Unlike the source-invariant checks in useKeyboard.test.ts (which string-match
+// the handler), this suite mounts the REAL useKeyboard hook against the REAL
+// zustand store and dispatches REAL KeyboardEvents, then asserts the live
+// terminalFontSize moved. It is the automated stand-in for clicking around the
+// running app: key in → store out, through the actual capture-phase listener.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useKeyboard } from '../useKeyboard';
+import { useStore } from '../../stores';
+
+// React 19 logs a warning unless the test env flags act() support.
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function mount(): void {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  function Harness(): null {
+    useKeyboard();
+    return null;
+  }
+  act(() => {
+    root.render(React.createElement(Harness));
+  });
+}
+
+function unmount(): void {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+/** Dispatch a real keydown on window (capture-phase listener picks it up). */
+function press(init: KeyboardEventInit): void {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
+  });
+}
+
+const fontSize = (): number => useStore.getState().terminalFontSize;
+
+beforeEach(() => {
+  // Minimal electronAPI surface useKeyboard reads at mount + in adjacent paths.
+  // The zoom path itself only touches the store, but createPrefixActions and the
+  // platform read run on mount.
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    platform: 'win32',
+    window: { hide: vi.fn() },
+    pty: { dispose: vi.fn(), create: vi.fn(), write: vi.fn() },
+  };
+  // Deterministic starting point — store is a module singleton across tests.
+  act(() => {
+    useStore.getState().setTerminalFontSize(14);
+    useStore.getState().setPrefixMode(false);
+  });
+  mount();
+});
+
+afterEach(() => {
+  unmount();
+});
+
+describe('#171 zoom — real key events move the live font size', () => {
+  it('Ctrl+= zooms in one step (14 → 15)', () => {
+    press({ ctrlKey: true, key: '=', code: 'Equal' });
+    expect(fontSize()).toBe(15);
+  });
+
+  it('Ctrl+- zooms out one step (14 → 13)', () => {
+    press({ ctrlKey: true, key: '-', code: 'Minus' });
+    expect(fontSize()).toBe(13);
+  });
+
+  it('Ctrl+0 resets to the default (16 → 14)', () => {
+    act(() => useStore.getState().setTerminalFontSize(16));
+    press({ ctrlKey: true, key: '0', code: 'Digit0' });
+    expect(fontSize()).toBe(14);
+  });
+
+  it('Ctrl++ (Shift+=) also zooms in — no need to release Shift', () => {
+    press({ ctrlKey: true, shiftKey: true, key: '+', code: 'Equal' });
+    expect(fontSize()).toBe(15);
+  });
+
+  it('Numpad +/- zoom by physical code', () => {
+    press({ ctrlKey: true, key: '+', code: 'NumpadAdd' });
+    expect(fontSize()).toBe(15);
+    press({ ctrlKey: true, key: '-', code: 'NumpadSubtract' });
+    expect(fontSize()).toBe(14);
+  });
+
+  it('zooms under a Hangul IME (e.key = "Process", resolved by code)', () => {
+    // With an active IME e.key arrives as 'Process'; the handler falls back to
+    // the physical code so zoom still fires. This is the #171 regression guard.
+    press({ ctrlKey: true, key: 'Process', code: 'Equal' });
+    expect(fontSize()).toBe(15);
+  });
+
+  it('clamps at the maximum (24) — extra zoom-ins do not overshoot', () => {
+    for (let i = 0; i < 20; i++) press({ ctrlKey: true, key: '=', code: 'Equal' });
+    expect(fontSize()).toBe(24);
+  });
+
+  it('clamps at the minimum (12) — extra zoom-outs do not undershoot', () => {
+    for (let i = 0; i < 20; i++) press({ ctrlKey: true, key: '-', code: 'Minus' });
+    expect(fontSize()).toBe(12);
+  });
+
+  it('does not zoom without Ctrl (bare "=" is a normal keystroke)', () => {
+    press({ key: '=', code: 'Equal' });
+    expect(fontSize()).toBe(14);
+  });
+
+  it('Ctrl+1 stays a workspace switch — it must not change the font size', () => {
+    press({ ctrlKey: true, key: '1', code: 'Digit1' });
+    expect(fontSize()).toBe(14);
+  });
+});

--- a/src/renderer/hooks/useKeyboard.ts
+++ b/src/renderer/hooks/useKeyboard.ts
@@ -44,6 +44,20 @@ const PREFIX_TIMEOUT_MS = 2000;
 /** How long to show "Unknown: [key]" error */
 const PREFIX_ERROR_DISPLAY_MS = 500;
 
+// Terminal font-size zoom bounds. Kept in lockstep with the Appearance tab's
+// font-size slider (SettingsPanel TabAppearance: min 12 / max 24) and the
+// store default (uiSlice terminalFontSize: 14) so keyboard zoom and the slider
+// never disagree on the reachable range. One-px steps mirror the slider grain.
+const FONT_SIZE_MIN = 12;
+const FONT_SIZE_MAX = 24;
+const FONT_SIZE_DEFAULT = 14;
+const FONT_SIZE_STEP = 1;
+
+/** Clamp a candidate terminal font size into the [MIN, MAX] zoom range. */
+export function clampFontSize(n: number): number {
+  return Math.max(FONT_SIZE_MIN, Math.min(FONT_SIZE_MAX, n));
+}
+
 /**
  * Map a `Key<X>` `e.code` to the matching ASCII control byte (Ctrl+X).
  *
@@ -377,6 +391,47 @@ export function useKeyboard() {
         const idx = key === '9' ? workspaces.length - 1 : parseInt(key) - 1;
         if (idx >= 0 && idx < workspaces.length) {
           store.getState().setActiveWorkspace(workspaces[idx].id);
+        }
+        return;
+      }
+
+      // ─── Terminal font zoom (Ctrl+= / Ctrl+- / Ctrl+0) ─────────────────
+      // Matches the Windows Terminal / VS Code / browser convention. We match
+      // both e.key and the physical e.code: '=' and '-' sit on the same keys
+      // across Latin layouts, but resolving by code as well keeps zoom working
+      // under a Hangul / non-Latin IME (where e.key can be a composed glyph or
+      // 'Process'), mirroring the IME-safe split/prefix handling elsewhere in
+      // this file. Numpad +/-/0 are accepted too. Ctrl+1~9 above already
+      // returned, so '0' here is unambiguous (digit 0 is not a workspace key).
+      //
+      // The zoom step writes through setTerminalFontSize, so xterm picks it up
+      // via the runtime font effect in useTerminal (no terminal re-creation,
+      // scrollback preserved). For these to reach this handler while a terminal
+      // is focused, useTerminal's attachCustomKeyEventHandler must let the combo
+      // bubble (it does — see the zoom pass-through there).
+      const zoomFont = (delta: number) => {
+        const cur = store.getState().terminalFontSize;
+        const next = clampFontSize(cur + delta);
+        if (next !== cur) store.getState().setTerminalFontSize(next);
+      };
+      // Zoom in: Ctrl+= or Ctrl++ (Shift+=) — accept either so users needn't
+      // reach for Shift. NumpadAdd covers the numeric keypad.
+      if (cmdOrCtrl && !alt && (key === '=' || key === '+' || code === 'Equal' || code === 'NumpadAdd')) {
+        e.preventDefault();
+        zoomFont(FONT_SIZE_STEP);
+        return;
+      }
+      // Zoom out: Ctrl+- (Shift produces '_', accepted for symmetry).
+      if (cmdOrCtrl && !alt && (key === '-' || key === '_' || code === 'Minus' || code === 'NumpadSubtract')) {
+        e.preventDefault();
+        zoomFont(-FONT_SIZE_STEP);
+        return;
+      }
+      // Reset zoom: Ctrl+0 → back to the default font size.
+      if (cmdOrCtrl && !shift && !alt && (key === '0' || code === 'Digit0' || code === 'Numpad0')) {
+        e.preventDefault();
+        if (store.getState().terminalFontSize !== FONT_SIZE_DEFAULT) {
+          store.getState().setTerminalFontSize(FONT_SIZE_DEFAULT);
         }
         return;
       }

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -534,6 +534,18 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       if (e.ctrlKey && !e.shiftKey && e.code === 'Backquote') {
         return false;
       }
+      // Terminal font zoom: Ctrl+= / Ctrl+- / Ctrl+0 (#171). Let these bubble to
+      // useKeyboard instead of feeding '=' / '-' / '0' bytes to the PTY. Match by
+      // physical code as well so zoom survives a Hangul / non-Latin IME. The
+      // Ctrl++ (Shift+=) and numpad variants are already covered: the Ctrl+Shift
+      // catch-all below bubbles the former, and useKeyboard maps NumpadAdd etc.
+      if (e.ctrlKey && !e.shiftKey && (
+        e.key === '=' || e.key === '-' || e.key === '0' ||
+        e.code === 'Equal' || e.code === 'Minus' || e.code === 'Digit0' ||
+        e.code === 'NumpadAdd' || e.code === 'NumpadSubtract' || e.code === 'Numpad0'
+      )) {
+        return false; // let DOM bubble to useKeyboard's zoom handlers
+      }
       if (e.ctrlKey && e.shiftKey) {
         return false; // all Ctrl+Shift combos → app shortcuts
       }


### PR DESCRIPTION
Closes #171.

## Problem

wmux had no keyboard shortcut to change the terminal font size — it was only reachable through the Appearance settings slider. Users coming from Windows Terminal / VS Code / the browser expect `Ctrl+=` to zoom in, so the combo silently did nothing (the `=` byte just went to the shell). Reported on Windows 11, wmux 2.18.

## Change

Add the standard zoom shortcuts to the global keyboard handler:

| Shortcut | Action |
|----------|--------|
| `Ctrl+=` / `Ctrl++` | zoom in (1px step) |
| `Ctrl+-` | zoom out (1px step) |
| `Ctrl+0` | reset to default (14px) |

Details:
- Clamp to `[12, 24]` to stay in lockstep with the Appearance slider and the `uiSlice` default, so keyboard zoom and the slider never disagree.
- Match both `e.key` and the physical `e.code` (Equal/Minus/Digit0 + numpad) so zoom survives a Hangul / non-Latin IME, where `e.key` arrives as a composed glyph or `Process` — mirrors the IME-safe split/prefix paths already in this file.
- Placed after the `Ctrl+1~9` workspace switch so `Ctrl+0` is unambiguous.
- Writes through `setTerminalFontSize`, so `useTerminal`'s runtime font effect picks it up without re-creating the terminal (scrollback preserved).
- `useTerminal`'s `attachCustomKeyEventHandler` now lets `Ctrl+=/-/0` bubble to `useKeyboard` instead of feeding the byte to the PTY.

## Tests

- `clampFontSize` unit + source-invariant guards in `useKeyboard.test.ts`.
- New jsdom dynamic suite (`useKeyboard.zoom.dynamic.test.tsx`) that mounts the real hook and dispatches real `KeyboardEvent`s, asserting the live font size moves — including the IME `e.key='Process'` regression guard and the min/max clamps.
- Full suite green (2586 tests).

## Verification

Dogfooded against the running dev app over its CDP endpoint with real keystrokes: the rendered xterm glyph went 14 → 17 (`Ctrl+= ×3`) → 16 (`Ctrl+-`) → 14 (`Ctrl+0`), a single `Ctrl+=` gave 15, and hammering zoom-in clamped at 24. No `=`/`0` leaked into the shell while the terminal was focused.