### PR TITLE
fix(pty): prefer PowerShell 7 over Windows PowerShell 5.1 as default shell

### DIFF
--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { StringDecoder } from 'node:string_decoder';
 import { PTYManager } from '../../pty/PTYManager';
 import { PTYBridge } from '../../pty/PTYBridge';
+import { ShellDetector } from '../../pty/ShellDetector';
 import { DaemonClient } from '../../DaemonClient';
 import { IPC, ENV_KEYS } from '../../../shared/constants';
 import { writePidMap, removePidMapByPtyId } from '../../pty/pidMap';
@@ -209,7 +210,10 @@ export function registerPTYHandlers(
 
       const safeCwd = validateCwd(options?.cwd);
       const effectiveCwd = safeCwd ?? require('os').homedir();
-      const shell = options?.shell || (process.platform === 'win32' ? 'powershell.exe' : (process.env.SHELL || '/bin/bash'));
+      // Daemon-mode default shell. On Windows prefer PowerShell 7 over 5.1 via
+      // ShellDetector (issue #176) — mirrors PTYManager.getDefaultShell() so
+      // both modes pick the same default.
+      const shell = options?.shell || (process.platform === 'win32' ? new ShellDetector().getDefault() : (process.env.SHELL || '/bin/bash'));
 
       // Generate a unique session ID
       const crypto = require('crypto');

--- a/src/main/pty/PTYManager.ts
+++ b/src/main/pty/PTYManager.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { getPipeName, ENV_KEYS, getPidMapDir } from '../../shared/constants';
 import { resolveSpawnEnv } from './resolveSpawnEnv';
 import { isWindows } from '../../shared/platform';
+import { ShellDetector } from './ShellDetector';
 
 export type ShellType = 'powershell' | 'bash' | 'cmd' | 'unknown';
 
@@ -259,18 +260,11 @@ export class PTYManager {
 
   private getDefaultShell(): string {
     if (process.platform === 'win32') {
-      // Try PowerShell paths in order — basename alone may fail
-      // if Electron's PATH is limited (e.g. installed via install.ps1)
-      const candidates = [
-        `${process.env.SystemRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`,
-        `${process.env.ProgramFiles}\\PowerShell\\7\\pwsh.exe`,
-        'powershell.exe',
-        'cmd.exe',
-      ];
-      for (const s of candidates) {
-        try { if (fs.existsSync(s)) return s; } catch { /* skip */ }
-      }
-      return 'cmd.exe';
+      // Single source of truth for shell preference: ShellDetector lists
+      // PowerShell 7 before Windows PowerShell 5.1, so pwsh 7 is the default
+      // when installed (issue #176). 5.1 is the fallback — present on every
+      // Windows box, and absolute paths sidestep a limited Electron PATH.
+      return new ShellDetector().getDefault();
     }
     return process.env.SHELL || '/bin/bash';
   }

--- a/src/main/pty/__tests__/ShellDetector.test.ts
+++ b/src/main/pty/__tests__/ShellDetector.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
+import path from 'node:path';
 
 // Hoisted mutable state shared between the vi.mock factory and the tests.
 const platformState = vi.hoisted(() => {
@@ -151,6 +152,32 @@ describe('ShellDetector', () => {
         expect(s.path).not.toBe('/bin/zsh');
         expect(s.path).not.toBe('/usr/bin/fish');
       }
+    });
+
+    // Issue #176: when both PowerShell 7 and Windows PowerShell 5.1 are
+    // installed, the default must be PowerShell 7. 5.1 is present on every
+    // Windows box, so a 5.1-first ordering would mask pwsh 7 forever.
+    it('lists PowerShell 7 before Windows PowerShell 5.1 and picks it as default', () => {
+      const pwsh7 = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe';
+      // Build the 5.1 path exactly as detectWindows does (path.join), so the
+      // mock matches on POSIX CI runners too — a template literal diverges from
+      // path.posix.join's separator handling and the path would never match.
+      const ps5 = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32\\WindowsPowerShell\\v1.0\\powershell.exe');
+      existsSpy.mockImplementation((p: fs.PathLike) => p === pwsh7 || p === ps5);
+      const detector = new ShellDetector();
+      const shells = detector.detect();
+      const i7 = shells.findIndex((s) => s.path === pwsh7);
+      const i5 = shells.findIndex((s) => s.path === ps5);
+      expect(i7).toBeGreaterThanOrEqual(0);
+      expect(i5).toBeGreaterThan(i7);
+      expect(detector.getDefault()).toBe(pwsh7);
+    });
+
+    it('getDefault falls back to Windows PowerShell 5.1 when pwsh 7 is absent', () => {
+      const ps5 = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32\\WindowsPowerShell\\v1.0\\powershell.exe');
+      existsSpy.mockImplementation((p: fs.PathLike) => p === ps5);
+      const detector = new ShellDetector();
+      expect(detector.getDefault()).toBe(ps5);
     });
   });
 });


### PR DESCRIPTION
## Summary

On Windows the auto-selected default shell always resolved to Windows PowerShell 5.1 even when PowerShell 7 was installed. Both default-shell paths now delegate to `ShellDetector.getDefault()`, which prefers pwsh 7 (5.1 remains the fallback).

## Changes

- `src/main/pty/PTYManager.ts` — `getDefaultShell()` Windows branch now delegates to `ShellDetector.getDefault()` instead of its own candidate array that listed 5.1 first. Removes the duplicated, conflicting ordering.
- `src/main/ipc/handlers/pty.handler.ts` — daemon-mode default shell also uses `ShellDetector.getDefault()` on Windows instead of a bare `"powershell.exe"`, so local and daemon modes pick the same default.
- `src/main/pty/__tests__/ShellDetector.test.ts` — locks the Windows contract: pwsh 7 is listed before 5.1 and chosen by `getDefault()`; falls back to 5.1 when pwsh 7 is absent.

## CHANGELOG entry

### Changed

- On Windows, PowerShell 7 is now preferred as the default shell when installed (Windows PowerShell 5.1 remains the fallback).

### Fixed

- New terminals no longer always launched Windows PowerShell 5.1 when PowerShell 7 was available.

## Stability tier impact

- [x] No external surface touched (internal refactor / docs / tests / CI).
- [ ] Additive change to a `stable` surface (new optional param, new field, new event type).
- [ ] Breaking change to a `stable` surface (requires major bump — block until release planning is in scope).
- [ ] Change to an `experimental` surface (note in release notes).
- [ ] Change to an `internal` surface (no contract impact).

<!-- Default-shell selection is local behavior; no RPC/event/metadata contract changes. -->

## Substrate contract impact (Substrate 3.0)

n/a — no PaneMetadata, EventBus, permission, Named Pipe, or RPC/event surface is touched.

## Test plan

- Unit tests added: `src/main/pty/__tests__/ShellDetector.test.ts` — Windows pwsh-7-over-5.1 ordering + `getDefault()` selection, and the 5.1 fallback when pwsh 7 is absent.
- Suite run locally: `vitest run src/main/pty src/main/ipc/handlers` → 183 passing; `tsc --noEmit` clean.
- Manual verification: launched a fresh-profile dev instance with no explicit shell setting; the new pane's default shell was created as PowerShell 7 (`session.json` recorded `"shell": "PowerShell 7"`). Before the fix the same conditions produced 5.1.

## Related issues / PRs

Closes #176

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed. (n/a — no surface change)
- [x] Tests cover the new behavior and the regression case (if a bug fix).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.
