### PR TITLE
fix(pty): detect AND launch Store-build PowerShell 7 App Execution Alias (#179)

### DIFF
--- a/src/main/pty/ShellDetector.ts
+++ b/src/main/pty/ShellDetector.ts
@@ -18,6 +18,36 @@ export class ShellDetector {
     });
   }
 
+  /**
+   * Resolve a Windows shell candidate to a path that node-pty can actually
+   * spawn, or null if it is not launchable (#179).
+   *
+   * A regular file launches as-is. The WindowsApps pwsh.exe installed via the
+   * Microsoft Store, however, is an App Execution Alias — a 0-byte
+   * IO_REPARSE_TAG_APPEXECLINK reparse point. fs.existsSync() does not follow
+   * it (so existsSync-only detection misses it entirely), AND node-pty's
+   * CreateProcess cannot launch the alias stub directly — it silently falls
+   * back to Windows PowerShell 5.1 (dogfood 2026-06-10: declaring the alias as
+   * the shell spawned 5.1, not pwsh 7). So we must hand back the *resolved*
+   * package target (readlink, the same path libuv would resolve), which spawns
+   * pwsh 7 correctly. Requiring the resolved target to exist also filters out a
+   * dead alias stub left by an uninstalled package.
+   */
+  private resolveLaunchableWindowsExe(p: string): string | null {
+    if (!p) return null;
+    try {
+      if (fs.existsSync(p)) return p;
+      if (!fs.lstatSync(p).isSymbolicLink()) return null;
+      const target = fs.readlinkSync(p);
+      // win32 semantics explicitly: this helper only runs for Windows paths,
+      // but unit tests exercise it on POSIX hosts too.
+      const resolved = path.win32.isAbsolute(target) ? target : path.resolve(path.dirname(p), target);
+      return fs.existsSync(resolved) ? resolved : null;
+    } catch {
+      return null;
+    }
+  }
+
   private detectWindows(): ShellInfo[] {
     const shells: ShellInfo[] = [];
 
@@ -27,8 +57,9 @@ export class ShellDetector {
       path.join(process.env.LOCALAPPDATA || '', 'Microsoft\\WindowsApps\\pwsh.exe'),
     ];
     for (const p of pwshPaths) {
-      if (fs.existsSync(p)) {
-        shells.push({ name: 'PowerShell 7', path: p });
+      const launchable = this.resolveLaunchableWindowsExe(p);
+      if (launchable) {
+        shells.push({ name: 'PowerShell 7', path: launchable });
         break;
       }
     }

--- a/src/main/pty/__tests__/ShellDetector.test.ts
+++ b/src/main/pty/__tests__/ShellDetector.test.ts
@@ -173,6 +173,82 @@ describe('ShellDetector', () => {
       expect(detector.getDefault()).toBe(pwsh7);
     });
 
+    // Issue #179: Store-installed pwsh 7 lives behind an App Execution Alias
+    // (a reparse-point symlink) that fs.existsSync() does not follow, so an
+    // existsSync-only gate misses it and 5.1 wins despite pwsh being usable.
+    // Dogfood found a second trap: node-pty cannot spawn the alias stub
+    // directly (it falls back to 5.1), so the detector must hand back the
+    // RESOLVED package target, not the alias path itself.
+    describe('Store-build pwsh App Execution Alias (#179)', () => {
+      const aliasPath = path.join('C:\\Users\\test\\AppData\\Local', 'Microsoft\\WindowsApps\\pwsh.exe');
+      const aliasTarget = 'C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.5.0.0_x64__8wekyb3d8bbwe\\pwsh.exe';
+      const ps5 = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32\\WindowsPowerShell\\v1.0\\powershell.exe');
+      let originalLocalAppData: string | undefined;
+      let lstatSpy: ReturnType<typeof vi.spyOn>;
+      let readlinkSpy: ReturnType<typeof vi.spyOn>;
+
+      beforeEach(() => {
+        originalLocalAppData = process.env.LOCALAPPDATA;
+        process.env.LOCALAPPDATA = 'C:\\Users\\test\\AppData\\Local';
+        lstatSpy = vi.spyOn(fs, 'lstatSync');
+        readlinkSpy = vi.spyOn(fs, 'readlinkSync');
+      });
+
+      afterEach(() => {
+        lstatSpy.mockRestore();
+        readlinkSpy.mockRestore();
+        if (originalLocalAppData === undefined) delete process.env.LOCALAPPDATA;
+        else process.env.LOCALAPPDATA = originalLocalAppData;
+      });
+
+      it('resolves the alias to its package target (not the alias path) so node-pty can spawn it', () => {
+        existsSpy.mockImplementation((p: fs.PathLike) => p === aliasTarget || p === ps5);
+        lstatSpy.mockImplementation((p: fs.PathLike) => {
+          if (p === aliasPath) return { isSymbolicLink: () => true } as fs.Stats;
+          throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        });
+        readlinkSpy.mockImplementation((p: fs.PathLike) => {
+          if (p === aliasPath) return aliasTarget;
+          throw Object.assign(new Error('EINVAL'), { code: 'EINVAL' });
+        });
+        const detector = new ShellDetector();
+        const shells = detector.detect();
+        const pwsh = shells.find((s) => s.name === 'PowerShell 7');
+        // The resolved target, NOT the alias — the alias stub is unspawnable.
+        expect(pwsh?.path).toBe(aliasTarget);
+        expect(detector.getDefault()).toBe(aliasTarget);
+      });
+
+      it('skips a dead alias stub whose target package is gone', () => {
+        existsSpy.mockImplementation((p: fs.PathLike) => p === ps5);
+        lstatSpy.mockImplementation((p: fs.PathLike) => {
+          if (p === aliasPath) return { isSymbolicLink: () => true } as fs.Stats;
+          throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        });
+        readlinkSpy.mockImplementation((p: fs.PathLike) => {
+          if (p === aliasPath) return aliasTarget;
+          throw Object.assign(new Error('EINVAL'), { code: 'EINVAL' });
+        });
+        const detector = new ShellDetector();
+        const shells = detector.detect();
+        expect(shells.find((s) => s.name === 'PowerShell 7')).toBeUndefined();
+        expect(detector.getDefault()).toBe(ps5);
+      });
+
+      it('skips the alias path when readlink fails', () => {
+        existsSpy.mockImplementation((p: fs.PathLike) => p === ps5);
+        lstatSpy.mockImplementation((p: fs.PathLike) => {
+          if (p === aliasPath) return { isSymbolicLink: () => true } as fs.Stats;
+          throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        });
+        readlinkSpy.mockImplementation(() => {
+          throw Object.assign(new Error('EINVAL'), { code: 'EINVAL' });
+        });
+        const detector = new ShellDetector();
+        expect(detector.getDefault()).toBe(ps5);
+      });
+    });
+
     it('getDefault falls back to Windows PowerShell 5.1 when pwsh 7 is absent', () => {
       const ps5 = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32\\WindowsPowerShell\\v1.0\\powershell.exe');
       existsSpy.mockImplementation((p: fs.PathLike) => p === ps5);


### PR DESCRIPTION
## Summary

Fixes #179. On a box where PowerShell 7 is installed **only** via the Microsoft Store, the default shell fell back to Windows PowerShell 5.1 even though `pwsh` works fine from any terminal.

The Store launcher at `%LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe` is an **App Execution Alias** — a 0-byte `IO_REPARSE_TAG_APPEXECLINK` reparse-point symlink. It had **two** distinct traps, both fixed here:

1. **Detection** — `fs.existsSync()` does not follow the reparse point, so `detectWindows()` skipped the candidate entirely (the symptom reported in #179).
2. **Launch** — even once detected, node-pty's `CreateProcess` cannot spawn the alias stub directly; it silently falls back to 5.1. (Found during dogfood: declaring the alias path as the shell still spawned `powershell.exe` 5.1, not pwsh 7.)

## Fix

`resolveLaunchableWindowsExe()` returns a path node-pty can actually spawn:
- a regular file launches as-is;
- an alias is resolved via `readlink` to its real package target (the same path libuv resolves), and the detector hands back **that resolved target** — which spawns pwsh 7 correctly.

Requiring the resolved target to exist also filters out a dead alias stub left by an uninstalled package (the `#179` "verify it actually launches" caveat).

## Verification

- **Unit**: ShellDetector 13/13 (alias→target resolution, dead-stub skip, readlink-failure skip), full suite green, lint clean.
- **Dynamic dogfood** (Store-only pwsh box, dev wmux over CDP):
  - Before: a shell-unspecified `pty.create` declared the alias path but the live session reported `$PSVersionTable.PSVersion = 5.1.26100.8457`.
  - After: same call resolves to the package target and the live session reports **7.6.2**, `LIVE_EXE` under `Program Files\WindowsApps\...\pwsh.exe`.

## Notes

This is a different root cause from #176/#178 (which fixed priority-ordering between already-detected shells); this is about pwsh 7 not being detected/launchable at all when it is a Store install.