### PR TITLE
fix(daemon): prefer PowerShell 7 over Windows PowerShell 5.1 in default-shell fallback

### DIFF
--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -541,9 +541,13 @@ export class DaemonSessionManager extends EventEmitter {
   private getDefaultShell(): string {
     if (process.platform === 'win32') {
       const fs = require('fs');
+      // PowerShell 7 first, then Windows PowerShell 5.1 — mirrors
+      // ShellDetector's priority so the daemon picks the same default as the
+      // main process (issue #176). 5.1 ships on every Windows box, so a
+      // 5.1-first order would mask an installed pwsh 7 forever.
       const candidates = [
-        `${process.env.SystemRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`,
         `${process.env.ProgramFiles}\\PowerShell\\7\\pwsh.exe`,
+        `${process.env.SystemRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`,
         'powershell.exe',
         'cmd.exe',
       ];

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
 
 // --- Mock node-pty -----------------------------------------------------------
 
@@ -560,6 +561,56 @@ describe('DaemonSessionManager', () => {
 
       expect(diedHandler).toHaveBeenCalledWith(expect.objectContaining({ id: 'rec-exit', exitCode: 2 }));
       expect(manager.getSession('rec-exit')?.meta.state).toBe('dead');
+    });
+  });
+
+  // The daemon's own default-shell fallback (getDefaultShell), used when a
+  // session is created with no explicit cmd, listed Windows PowerShell 5.1
+  // before PowerShell 7 — the same ordering bug #176/#178 fixed in the main
+  // process but left unfixed on the daemon path. Since 5.1 ships on every
+  // Windows box, a 5.1-first order masks an installed pwsh 7 forever.
+  describe('default shell fallback (Windows)', () => {
+    let origPlatform: PropertyDescriptor | undefined;
+    let origSystemRoot: string | undefined;
+    let origProgramFiles: string | undefined;
+    let existsSpy: ReturnType<typeof vi.spyOn>;
+
+    // getDefaultShell composes the candidate paths from these env vars via
+    // template literals, so pin them to fixed values: the test must match the
+    // source's exact string on any CI OS (where these vars are normally unset).
+    const PWSH7 = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe';
+    const PS5 = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+
+    beforeEach(() => {
+      origPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      origSystemRoot = process.env.SystemRoot;
+      origProgramFiles = process.env.ProgramFiles;
+      process.env.SystemRoot = 'C:\\Windows';
+      process.env.ProgramFiles = 'C:\\Program Files';
+      existsSpy = vi.spyOn(fs, 'existsSync');
+    });
+
+    afterEach(() => {
+      if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
+      if (origSystemRoot === undefined) delete process.env.SystemRoot;
+      else process.env.SystemRoot = origSystemRoot;
+      if (origProgramFiles === undefined) delete process.env.ProgramFiles;
+      else process.env.ProgramFiles = origProgramFiles;
+      existsSpy.mockRestore();
+    });
+
+    it('prefers PowerShell 7 over Windows PowerShell 5.1 when both exist', () => {
+      existsSpy.mockImplementation((p: fs.PathLike) => p === PWSH7 || p === PS5);
+      // Empty cmd is falsy → resolveShellPath returns null → getDefaultShell runs.
+      const session = manager.createSession({ id: 'def-pwsh7', cmd: '', cwd: '.' });
+      expect(session.cmd).toBe(PWSH7);
+    });
+
+    it('falls back to Windows PowerShell 5.1 when pwsh 7 is absent', () => {
+      existsSpy.mockImplementation((p: fs.PathLike) => p === PS5);
+      const session = manager.createSession({ id: 'def-ps5', cmd: '', cwd: '.' });
+      expect(session.cmd).toBe(PS5);
     });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #178 (issue #176). That PR consolidated the **main-process** default-shell selection onto `ShellDetector.getDefault()`, which prefers PowerShell 7. The **daemon process** has its own independent fallback — `DaemonSessionManager.getDefaultShell()` — that was left untouched and still listed Windows PowerShell 5.1 before PowerShell 7. This PR reorders the daemon's candidate list so pwsh 7 comes first.

Scope: this fixes **ordering only**. For a `Program Files` pwsh 7 install the daemon and the main process now pick the same default. It does **not** port #180's Store-build (`WindowsApps` App Execution Alias) detection/launch handling to the daemon — see Notes.

## Changes

- `src/daemon/DaemonSessionManager.ts` — `getDefaultShell()` Windows branch now lists `…\PowerShell\7\pwsh.exe` before `…\WindowsPowerShell\v1.0\powershell.exe`. This is the fallback used when a session is created with no explicit `cmd` (`resolveShellPath(params.cmd) || this.getDefaultShell()`).
- `src/daemon/__tests__/DaemonSessionManager.test.ts` — locks the daemon contract: pwsh 7 is chosen when both are present; 5.1 is chosen when pwsh 7 is absent.

## CHANGELOG entry

### Fixed

- The daemon's default-shell fallback (used when a session is created without an explicit command) no longer prefers Windows PowerShell 5.1 over PowerShell 7. It now mirrors the main process, so both pick PowerShell 7 when installed.

## Stability tier impact

- [x] No external surface touched (internal refactor / docs / tests / CI).
- [ ] Additive change to a `stable` surface (new optional param, new field, new event type).
- [ ] Breaking change to a `stable` surface (requires major bump — block until release planning is in scope).
- [ ] Change to an `experimental` surface (note in release notes).
- [ ] Change to an `internal` surface (no contract impact).

<!-- Default-shell selection is local behavior; no RPC/event/metadata contract changes. -->

## Substrate contract impact (Substrate 3.0)

n/a — no PaneMetadata, EventBus, permission, Named Pipe, or RPC/event surface is touched. Only the daemon's internal default-shell ordering changes.

## Test plan

- Unit tests added (`src/daemon/__tests__/DaemonSessionManager.test.ts`), driven red → green:
  - **red**: with the 5.1-first order, the "prefers PowerShell 7" test received the 5.1 path — reproducing the bug.
  - **green**: after the reorder, the daemon returns the pwsh 7 path; the 5.1-fallback test (pwsh 7 absent) stays green.
  - Tests stub `process.platform`, `SystemRoot`/`ProgramFiles`, and `fs.existsSync` so the Windows branch is exercised deterministically on any CI OS, and assert through `createSession({ cmd: '' })` (empty cmd falls through `resolveShellPath` to `getDefaultShell`).
- Full suite: `vitest run src/daemon/__tests__/DaemonSessionManager.test.ts` → 37 passing; `tsc --noEmit` clean.
- No manual daemon run: this fallback only fires on a `cmd`-less daemon RPC, which the main process never sends in normal operation (it resolves the shell first via `ShellDetector`). It is a latent path, verified by unit test rather than a contrived live repro.

## Related issues / PRs

Follow-up to #178 (issue #176). Surfaced during post-merge review of #178: the daemon carried a second, independent copy of the same 5.1-first ordering.

Related: #180 (issue #179) just landed Store-build (`WindowsApps` App Execution Alias) detection + launch handling in `ShellDetector`. That widens the gap between `ShellDetector` and the daemon's hand-rolled candidate list, which this PR does **not** close (see Notes).

> Note — what this PR does NOT fix:
> - **Store-only pwsh 7 on the daemon path.** The daemon's candidate list has no `WindowsApps` alias entry and does no alias resolution, so on a box where pwsh 7 exists only as a Store App Execution Alias the daemon fallback still picks 5.1 — the #179 symptom, unfixed on the daemon path. #180 fixed this for the main process only.
> - **The broader duplication.** Multiple `getDefaultShell` implementations and shell-path tables live across `DaemonSessionManager`, `daemon/config.ts`, and the MCP helpers. This PR is a surgical ordering fix mirroring #178; consolidating onto a single shared shell-resolution module (which would also bring #180's alias handling to the daemon for free) is a separate refactor.

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed. (n/a — no surface change)
- [x] Tests cover the new behavior and the regression case (if a bug fix).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.
