### PR TITLE
feat(workspace): add Rename to right-click context menu

### DIFF
--- a/src/renderer/components/Sidebar/WorkspaceItem.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceItem.tsx
@@ -353,6 +353,13 @@ export default function WorkspaceItem({ workspace, isActive, isMultiview, index,
           <button
             className="w-full text-left px-3 py-1.5 text-xs transition-colors hover:bg-[var(--bg-overlay)]"
             style={{ color: 'var(--text-main)' }}
+            onClick={() => { setMenuPos(null); setEditName(workspace.name); setEditing(true); }}
+          >
+            {t('workspace.rename')}
+          </button>
+          <button
+            className="w-full text-left px-3 py-1.5 text-xs transition-colors hover:bg-[var(--bg-overlay)]"
+            style={{ color: 'var(--text-main)' }}
             onClick={() => { setMenuPos(null); setProfileModalOpen(true); }}
           >
             {t('workspace.configureProfile')}

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -20,6 +20,7 @@ export const en = {
   'workspace.close': 'Close workspace',
   'workspace.copyInfo': 'Copy session info',
   'workspace.copied': 'Copied!',
+  'workspace.rename': 'Rename workspace',
   'workspace.configureProfile': 'Configure profile…',
   'workspace.duplicate': 'Duplicate workspace',
   'workspace.workingDirs': 'Working directories',


### PR DESCRIPTION
## What

Adds a **Rename workspace** item to the top of the workspace right-click context menu in the sidebar.

## Why

wmux already supports renaming a workspace via:
- double-click on the workspace name
- `Ctrl+Shift+R`
- tmux prefix + `,`

…but the right-click context menu had no rename entry, which is the first place many users look. As a daily user I kept right-clicking expecting to find it. This adds that missing, most-discoverable entry point.

## How

The rename machinery (inline editor, `renameWorkspace` store action, session persistence) already exists. This change only wires a new menu button to the existing flow: clicking **Rename workspace** closes the menu and enters the inline editor (`setEditing(true)`), exactly like double-click does.

## Changes
- `src/renderer/components/Sidebar/WorkspaceItem.tsx` — new context-menu button as the first item, before *Configure profile…*
- `src/renderer/i18n/locales/en.ts` — new `workspace.rename` label (other locales fall back to `en`, consistent with the sibling menu items `configureProfile`/`duplicate` which are also en-only)

## Testing
- `npx tsc --noEmit -p tsconfig.json` passes clean
- Verified the menu item opens the existing inline rename editor and commits via Enter

🤖 Generated with [Claude Code](https://claude.com/claude-code)