### PR TITLE
fix(pane): render prefix-mode Toggle Zoom (#182)

### DIFF
--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -174,6 +174,10 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
 
   const closePane = useStore((s) => s.closePane);
 
+  // Issue #182: zoomed badge. Without a visual cue, a zoomed pane reads as
+  // "all my other panes vanished" — mirror tmux's status-line Z marker.
+  const isZoomed = useStore((s) => s.zoomedPaneId === pane.id);
+
   const handleCloseSurface = useCallback((surfaceId: string) => {
     const surface = pane.surfaces.find((s) => s.id === surfaceId);
     if (surface?.ptyId) {
@@ -199,6 +203,35 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
       data-derived="accentCursor"
     >
       <ErrorBoundary name="pane">
+      {isZoomed && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            useStore.getState().togglePaneZoom(pane.id);
+          }}
+          title={t('settings.prefix.toggleZoom')}
+          aria-label={t('settings.prefix.toggleZoom')}
+          style={{
+            position: 'absolute',
+            top: 4,
+            right: 6,
+            zIndex: 20,
+            padding: '1px 6px',
+            fontSize: 10,
+            fontFamily: 'ui-monospace, monospace',
+            fontWeight: 700,
+            letterSpacing: '0.08em',
+            color: 'var(--bg-main)',
+            backgroundColor: 'var(--accent-cursor)',
+            border: 'none',
+            borderRadius: 3,
+            cursor: 'pointer',
+            opacity: 0.85,
+          }}
+        >
+          ZOOM
+        </button>
+      )}
       <SurfaceTabs
         surfaces={pane.surfaces}
         activeSurfaceId={pane.activeSurfaceId}

--- a/src/renderer/components/Pane/PaneContainer.tsx
+++ b/src/renderer/components/Pane/PaneContainer.tsx
@@ -2,6 +2,7 @@ import { Fragment, useCallback, useEffect, useRef } from 'react';
 import { Panel, Group, Separator, useGroupRef } from 'react-resizable-panels';
 import type { Layout } from 'react-resizable-panels';
 import type { Pane as PaneType, Workspace } from '../../../shared/types';
+import { findLeaf } from '../../../shared/paneUtils';
 import { useStore } from '../../stores';
 import PaneComponent from './Pane';
 
@@ -21,6 +22,15 @@ export default function PaneContainer({ pane, workspace, isWorkspaceVisible = tr
     const ws = s.workspaces.find((w) => w.id === s.activeWorkspaceId);
     return ws?.activePaneId || '';
   });
+
+  // Pane zoom (issue #182): when a leaf in THIS subtree is zoomed, hide every
+  // sibling Panel that is not on the path to the zoomed leaf. The library
+  // sizes panels with flexGrow over flexBasis:0, so once the off-path
+  // siblings (and separators) are display:none, the on-path panel is the only
+  // grow item left and naturally fills 100% — no layout state is touched, so
+  // un-zooming restores the exact previous split. All panes stay mounted
+  // (same hide-don't-unmount pattern as inactive workspaces in AppLayout).
+  const zoomedPaneId = useStore((s) => s.zoomedPaneId);
 
   const updatePaneSizes = useStore((s) => s.updatePaneSizes);
 
@@ -82,6 +92,10 @@ export default function PaneContainer({ pane, workspace, isWorkspaceVisible = tr
 
   const orientation = pane.direction === 'horizontal' ? 'horizontal' : 'vertical';
 
+  // Zoom only affects this branch when the zoomed leaf lives somewhere below
+  // it; a zoomed pane in another workspace (or none) leaves rendering as-is.
+  const zoomInSubtree = zoomedPaneId !== null && findLeaf(pane, zoomedPaneId) !== null;
+
   return (
     <Group
       groupRef={groupRef}
@@ -90,24 +104,34 @@ export default function PaneContainer({ pane, workspace, isWorkspaceVisible = tr
       resizeTargetMinimumSize={{ coarse: 37, fine: 16 }}
       onLayoutChanged={handleLayoutChanged}
     >
-      {pane.children.map((child, i) => (
-        <Fragment key={child.id}>
-          {i > 0 && (
-            <Separator
-              className={`${
-                orientation === 'horizontal' ? 'w-1.5' : 'h-1.5'
-              } bg-[var(--bg-surface)] hover:bg-[var(--accent-blue)] transition-colors`}
-            />
-          )}
-          <Panel
-            id={child.id}
-            defaultSize={pane.sizes?.[i] ?? 100 / pane.children.length}
-            minSize={10}
-          >
-            <PaneContainer pane={child} workspace={workspace} isWorkspaceVisible={isWorkspaceVisible} />
-          </Panel>
-        </Fragment>
-      ))}
+      {pane.children.map((child, i) => {
+        // Off the zoom path → hide (keep mounted). The data attribute is
+        // spread onto the Panel's OUTER flex-item div (className would land
+        // on the inner one), and the globals.css rule beats the library's
+        // inline display with !important.
+        const zoomHidden = zoomInSubtree && findLeaf(child, zoomedPaneId) === null;
+        return (
+          <Fragment key={child.id}>
+            {i > 0 && (
+              <Separator
+                className={`${
+                  orientation === 'horizontal' ? 'w-1.5' : 'h-1.5'
+                } bg-[var(--bg-surface)] hover:bg-[var(--accent-blue)] transition-colors ${
+                  zoomInSubtree ? 'wmux-zoom-hidden' : ''
+                }`}
+              />
+            )}
+            <Panel
+              id={child.id}
+              defaultSize={pane.sizes?.[i] ?? 100 / pane.children.length}
+              minSize={10}
+              {...(zoomHidden ? { 'data-wmux-zoom-hidden': true } : {})}
+            >
+              <PaneContainer pane={child} workspace={workspace} isWorkspaceVisible={isWorkspaceVisible} />
+            </Panel>
+          </Fragment>
+        );
+      })}
     </Group>
   );
 }

--- a/src/renderer/components/Pane/__tests__/PaneContainer.zoom.test.tsx
+++ b/src/renderer/components/Pane/__tests__/PaneContainer.zoom.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+//
+// Dynamic verification for issue #182 — prefix-mode Toggle Zoom.
+//
+// Mounts the REAL PaneContainer (real react-resizable-panels Group/Panel/
+// Separator) against the REAL zustand store, with only the leaf Pane
+// component mocked out (it would otherwise pull in xterm.js/electronAPI).
+// Asserts the rendering contract the fix relies on:
+//
+//   • zoom on  → every Panel NOT on the path to the zoomed leaf carries
+//     data-wmux-zoom-hidden (globals.css turns that into display:none
+//     !important), separators get .wmux-zoom-hidden, and the on-path
+//     panels stay visible.
+//   • zoom off → no hidden markers anywhere; the saved layout is intact
+//     because zoom never touches Panel layout state.
+//   • a zoom belonging to a different workspace's pane leaves this tree
+//     untouched.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+// Leaf Pane mock: PaneContainer only needs SOMETHING to render at leaves.
+vi.mock('../Pane', () => ({
+  default: ({ pane }: { pane: { id: string } }) =>
+    React.createElement('div', { 'data-testid': `leaf-${pane.id}` }),
+}));
+
+import PaneContainer from '../PaneContainer';
+import { useStore } from '../../../stores';
+import { getLeafPanes } from '../../../../shared/paneUtils';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// react-resizable-panels observes group elements; jsdom has no ResizeObserver.
+class ResizeObserverStub {
+  observe(): void {
+    /* layout reflow is irrelevant under jsdom */
+  }
+  unobserve(): void {
+    /* no-op */
+  }
+  disconnect(): void {
+    /* no-op */
+  }
+}
+(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver ??= ResizeObserverStub;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function mountActiveWorkspace(): void {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const ws = useStore
+    .getState()
+    .workspaces.find((w) => w.id === useStore.getState().activeWorkspaceId)!;
+  act(() => {
+    root.render(
+      React.createElement(PaneContainer, {
+        pane: ws.rootPane,
+        workspace: ws,
+        isWorkspaceVisible: true,
+      }),
+    );
+  });
+}
+
+function rerender(): void {
+  const ws = useStore
+    .getState()
+    .workspaces.find((w) => w.id === useStore.getState().activeWorkspaceId)!;
+  act(() => {
+    root.render(
+      React.createElement(PaneContainer, {
+        pane: ws.rootPane,
+        workspace: ws,
+        isWorkspaceVisible: true,
+      }),
+    );
+  });
+}
+
+const hiddenPanels = (): Element[] =>
+  Array.from(container.querySelectorAll('[data-panel][data-wmux-zoom-hidden]'));
+const hiddenSeparators = (): Element[] =>
+  Array.from(container.querySelectorAll('.wmux-zoom-hidden'));
+
+beforeEach(() => {
+  // Reset to a single fresh workspace, then build a 3-leaf tree:
+  // root(horizontal)[ A, branch(vertical)[ B, C ] ] via real splitPane.
+  const state = useStore.getState();
+  for (const w of [...state.workspaces]) state.removeWorkspace(w.id);
+  state.addWorkspace();
+  useStore.setState({ zoomedPaneId: null });
+
+  const ws = () =>
+    useStore.getState().workspaces.find((w) => w.id === useStore.getState().activeWorkspaceId)!;
+  const rootId = ws().rootPane.id;
+  useStore.getState().splitPane(rootId, 'horizontal');
+  // split the new active (right) pane vertically → 3 leaves
+  useStore.getState().splitPane(ws().activePaneId, 'vertical');
+  // splitPane clears zoom (tmux behavior) — start each test un-zoomed.
+  expect(useStore.getState().zoomedPaneId).toBeNull();
+
+  mountActiveWorkspace();
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function leafIds(): string[] {
+  const ws = useStore
+    .getState()
+    .workspaces.find((w) => w.id === useStore.getState().activeWorkspaceId)!;
+  return getLeafPanes(ws.rootPane).map((l) => l.id);
+}
+
+describe('PaneContainer zoom rendering (#182)', () => {
+  it('renders all 3 leaves with no hidden markers before zoom', () => {
+    expect(leafIds()).toHaveLength(3);
+    for (const id of leafIds()) {
+      expect(container.querySelector(`[data-testid="leaf-${id}"]`)).not.toBeNull();
+    }
+    expect(hiddenPanels()).toHaveLength(0);
+    expect(hiddenSeparators()).toHaveLength(0);
+  });
+
+  it('zooming a nested leaf hides every off-path panel and all separators, keeps panes mounted', () => {
+    const [a, b, c] = leafIds();
+    act(() => {
+      useStore.getState().togglePaneZoom(c);
+    });
+    rerender();
+
+    // Off-path: leaf A's panel (outer branch) and leaf B's panel (inner branch).
+    const hidden = hiddenPanels();
+    expect(hidden).toHaveLength(2);
+    const hiddenLeafIds = hidden.map((el) =>
+      el.querySelector('[data-testid^="leaf-"]')?.getAttribute('data-testid'),
+    );
+    expect(hiddenLeafIds).toContain(`leaf-${a}`);
+    expect(hiddenLeafIds).toContain(`leaf-${b}`);
+
+    // Both branches are on the zoom path → both separators hidden.
+    expect(hiddenSeparators()).toHaveLength(2);
+
+    // The zoomed leaf's panel chain carries no hidden marker.
+    const zoomedLeaf = container.querySelector(`[data-testid="leaf-${c}"]`)!;
+    expect(zoomedLeaf).not.toBeNull();
+    expect(zoomedLeaf.closest('[data-wmux-zoom-hidden]')).toBeNull();
+
+    // Hide-don't-unmount: all three leaves are still in the DOM.
+    for (const id of [a, b, c]) {
+      expect(container.querySelector(`[data-testid="leaf-${id}"]`)).not.toBeNull();
+    }
+  });
+
+  it('toggling again removes every hidden marker (un-zoom restores the tree)', () => {
+    const [, , c] = leafIds();
+    act(() => {
+      useStore.getState().togglePaneZoom(c);
+    });
+    rerender();
+    expect(hiddenPanels().length).toBeGreaterThan(0);
+
+    act(() => {
+      useStore.getState().togglePaneZoom(c);
+    });
+    rerender();
+    expect(hiddenPanels()).toHaveLength(0);
+    expect(hiddenSeparators()).toHaveLength(0);
+  });
+
+  it("a zoomed pane from another workspace leaves this tree untouched", () => {
+    act(() => {
+      useStore.getState().togglePaneZoom('pane-of-some-other-workspace');
+    });
+    rerender();
+    expect(hiddenPanels()).toHaveLength(0);
+    expect(hiddenSeparators()).toHaveLength(0);
+  });
+});

--- a/src/renderer/stores/slices/__tests__/paneSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneSlice.test.ts
@@ -11,6 +11,8 @@ type TestState = PaneSlice & {
   workspaces: Workspace[];
   activeWorkspaceId: string;
   pushToast: ReturnType<typeof vi.fn>;
+  // uiSlice field that splitPane/closePane mutate for zoom coherence (#182).
+  zoomedPaneId: string | null;
 };
 
 function createTestStore() {
@@ -20,6 +22,7 @@ function createTestStore() {
       workspaces: [ws],
       activeWorkspaceId: ws.id,
       pushToast: vi.fn(),
+      zoomedPaneId: null,
       // @ts-expect-error — minimal test store doesn't match full StoreState
       ...createPaneSlice(...args),
     }))
@@ -397,6 +400,53 @@ describe('PaneSlice', () => {
       store.getState().setSurfaceAgentStatus('pty-1', 'waiting');
       store.getState().setSurfaceAgentStatus('pty-1', 'complete');
       expect(store.getState().surfaceAgentStatus['pty-1']).toBe('complete');
+    });
+  });
+
+  // Issue #182: split/close must keep the zoom state coherent. zoomedPaneId
+  // lives in uiSlice; the pane mutations below clear it via the shared
+  // StoreState, so the test store injects it with setState.
+  describe('pane zoom coherence (issue #182)', () => {
+    it('splitPane un-zooms when the zoomed pane is in the target workspace', () => {
+      const ws = getActiveWorkspace(store);
+      const rootId = ws.rootPane.id;
+      store.setState({ zoomedPaneId: rootId });
+
+      store.getState().splitPane(rootId, 'horizontal');
+
+      expect(store.getState().zoomedPaneId).toBeNull();
+    });
+
+    it('splitPane keeps a zoom that belongs to a different workspace', () => {
+      const ws = getActiveWorkspace(store);
+      store.setState({ zoomedPaneId: 'pane-elsewhere' });
+
+      store.getState().splitPane(ws.rootPane.id, 'horizontal');
+
+      expect(store.getState().zoomedPaneId).toBe('pane-elsewhere');
+    });
+
+    it('closePane clears the zoom when closing the zoomed pane', () => {
+      const ws = getActiveWorkspace(store);
+      store.getState().splitPane(ws.rootPane.id, 'horizontal');
+      const leaves = getLeafPanes(getActiveWorkspace(store).rootPane);
+      const target = leaves[1].id;
+      store.setState({ zoomedPaneId: target });
+
+      store.getState().closePane(target);
+
+      expect(store.getState().zoomedPaneId).toBeNull();
+    });
+
+    it('closePane keeps the zoom when closing a different pane', () => {
+      const ws = getActiveWorkspace(store);
+      store.getState().splitPane(ws.rootPane.id, 'horizontal');
+      const leaves = getLeafPanes(getActiveWorkspace(store).rootPane);
+      store.setState({ zoomedPaneId: leaves[0].id });
+
+      store.getState().closePane(leaves[1].id);
+
+      expect(store.getState().zoomedPaneId).toBe(leaves[0].id);
     });
   });
 });

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -192,6 +192,13 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
       const previousActiveId = ws.activePaneId;
       ws.activePaneId = newPane.id;
 
+      // Issue #182: splitting while a pane in this workspace is zoomed must
+      // un-zoom (tmux behavior) — otherwise the freshly created sibling would
+      // be born hidden behind the zoom and look like the split did nothing.
+      if (state.zoomedPaneId !== null && findPane(ws.rootPane, state.zoomedPaneId)) {
+        state.zoomedPaneId = null;
+      }
+
       if (inheritedCwd) state.splitCwdSeed[newPane.id] = inheritedCwd;
 
       event = {
@@ -263,6 +270,11 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
       delete state.paneNotificationRing[paneId];
       // A pane closed before its PTY spawned would leave a dangling cwd seed.
       delete state.splitCwdSeed[paneId];
+      // Issue #182: closing the zoomed pane ends the zoom; a stale id would
+      // make the next toggle on another pane read as an un-zoom.
+      if (state.zoomedPaneId === paneId) {
+        state.zoomedPaneId = null;
+      }
 
       event = {
         wsId: ws.id,

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -402,3 +402,13 @@ html, body, #root {
     border-width: 2px !important;
   }
 }
+
+/* Pane zoom (issue #182): panels off the path to the zoomed leaf are hidden
+ * but stay mounted. The attribute lives on the Panel's outer flex-item div;
+ * !important is required to beat the library's inline display style. With the
+ * off-path siblings and separators gone, the on-path panel is the only
+ * flex-grow item left (flexBasis is 0) and fills the whole group. */
+[data-panel][data-wmux-zoom-hidden],
+.wmux-zoom-hidden {
+  display: none !important;
+}


### PR DESCRIPTION
## Problem

Toggle Zoom (prefix `Ctrl+B z`, or any rebound key) consumed the keypress but did nothing on screen, as reported in #182: the key is swallowed, no pane resizes, nothing reaches the terminal.

**Root cause:** the feature was only half-wired. The prefix action `toggleZoom` flips the store's `zoomedPaneId`, but **no rendering code anywhere read that value**. So the keypress matched a binding, prefix mode exited, and the layout never changed. `n` / `c` / `p` work because their actions are actually connected to rendering; zoom never was.

## Fix

Wire `zoomedPaneId` into the layout (tmux-style zoom):

- **`PaneContainer.tsx`** — panels *not* on the path to the zoomed leaf get a `data-wmux-zoom-hidden` attribute (and separators a hide class). `react-resizable-panels` sizes panels with `flexGrow` over `flexBasis: 0`, so once the off-path siblings are `display:none` the on-path panel is the only grow item left and fills the group. **No layout state is touched**, so un-zooming restores the exact previous split. All panes stay mounted (hide-don't-unmount), preserving terminal state.
- **`globals.css`** — the `display:none` rule, `!important` to beat the library's inline `display`.
- **`paneSlice.ts`** — keep zoom coherent: splitting while zoomed un-zooms (tmux behavior; otherwise the new sibling is born hidden), and closing the zoomed pane clears the zoom.
- **`Pane.tsx`** — a `ZOOM` badge on the zoomed pane (click to un-zoom) so it doesn't read as "my other panes vanished".

## Testing

- `tsc --noEmit` clean, ESLint clean, full suite **2652/2652**.
- New `PaneContainer.zoom.test.tsx` (jsdom) mounts the **real** `PaneContainer` over the **real** library and store, then asserts the hide markers appear on zoom and clear on un-zoom; new `paneSlice` tests lock the split/close coherence.
- **Live dogfood** over CDP driving the real `Ctrl+B z` on a 3-pane layout: zoom hides the off-path panels and the zoomed pane fills the workspace 100% (area 274451 → 553183), un-zoom restores it exactly (→ 274451), badge toggles correctly. 9/9 checks pass.

| before zoom | zoomed | restored |
|---|---|---|
| 3-pane split | active pane fills workspace + ZOOM badge | pixel-identical to before |

Reported by @Dzirik.