### PR TITLE
fix(mcp): route terminal IO through verified identity, not the env hint (#163 Part 2)

### DIFF
--- a/src/main/pipe/handlers/__tests__/input.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/input.rpc.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
 import type { BrowserWindow } from 'electron';
 import { RpcRouter } from '../../RpcRouter';
 import { registerInputRpc } from '../input.rpc';
@@ -128,4 +130,29 @@ describe('input.readScreen — cross-workspace ownership (issue #163)', () => {
       expect.objectContaining({ workspaceId: 'ws-self' }),
     );
   });
+});
+
+// Source-level invariant lock (issue #163, requested in the issue). All four
+// terminal-IO RPC handlers must call assertWorkspaceOwnsPty before delegating
+// to the renderer. input.readScreen was the one that silently skipped it; this
+// pins parity so a future handler can't regress the same way. Keys off source
+// text rather than behavior so it catches a NEW handler that forgets the check.
+describe('input.rpc — assertWorkspaceOwnsPty parity (source invariant)', () => {
+  const rawSrc = fs.readFileSync(path.join(__dirname, '..', 'input.rpc.ts'), 'utf-8');
+  const src = rawSrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
+  // Slice a single router.register('name', ...) block, bounded by the next
+  // router.register( (or end of file for the last one).
+  function handlerBlock(method: string): string {
+    const start = src.indexOf(`router.register('${method}'`);
+    expect(start, `handler ${method} must exist`).toBeGreaterThan(0);
+    const next = src.indexOf('router.register(', start + method.length + 20);
+    return src.slice(start, next > start ? next : src.length);
+  }
+
+  for (const method of ['input.send', 'input.sendKey', 'input.readScreen', 'terminal.readEvents']) {
+    it(`${method} calls assertWorkspaceOwnsPty`, () => {
+      expect(handlerBlock(method)).toMatch(/assertWorkspaceOwnsPty\(/);
+    });
+  }
 });

--- a/src/mcp/__tests__/paneResolver.test.ts
+++ b/src/mcp/__tests__/paneResolver.test.ts
@@ -1,138 +1,118 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { resolveDefaultPtyId, __resetPaneResolverForTesting } from '../paneResolver';
-import type { PaneResolverDeps } from '../paneResolver';
+import {
+  claimPinnedRoute,
+  getPinnedRoute,
+  __resetPaneResolverForTesting,
+} from '../paneResolver';
+import type { ClaimDeps } from '../paneResolver';
 
-function makeDeps(overrides: Partial<PaneResolverDeps> = {}): PaneResolverDeps {
+function makeDeps(overrides: Partial<ClaimDeps> = {}): ClaimDeps {
   return {
     sendRpc: overrides.sendRpc ?? vi.fn(),
-    resolveWorkspaceId: overrides.resolveWorkspaceId ?? vi.fn().mockResolvedValue(''),
   };
 }
 
-describe('resolveDefaultPtyId', () => {
+describe('claimPinnedRoute / getPinnedRoute', () => {
   beforeEach(() => {
     __resetPaneResolverForTesting();
   });
 
-  it('returns null for internal callers so the main process falls through to the active pane', async () => {
-    // Internal callers can resolve their host workspace via the PID-tree walk.
-    const sendRpc = vi.fn();
-    const resolveWorkspaceId = vi.fn().mockResolvedValue('ws-123');
-    const deps = makeDeps({ sendRpc, resolveWorkspaceId });
-
-    const result = await resolveDefaultPtyId(deps);
-
-    expect(result).toBeNull();
-    // Internal callers must NOT claim a new workspace — that would spawn a
-    // surprise pane when the user just wanted to target their current one.
-    expect(sendRpc).not.toHaveBeenCalled();
+  it('returns null from getPinnedRoute before any claim', () => {
+    expect(getPinnedRoute()).toBeNull();
   });
 
-  it('claims a workspace and returns the new ptyId for external callers', async () => {
+  it('claims a dedicated workspace and pins BOTH ids', async () => {
     const sendRpc = vi.fn().mockResolvedValue({
       ptyId: 'pty-42',
       workspaceId: 'ws-new',
       workspaceName: 'MCP',
     });
-    const resolveWorkspaceId = vi.fn().mockResolvedValue('');
-    const deps = makeDeps({ sendRpc, resolveWorkspaceId });
+    const deps = makeDeps({ sendRpc });
 
-    const result = await resolveDefaultPtyId(deps);
+    const route = await claimPinnedRoute(deps);
 
-    expect(result).toBe('pty-42');
+    expect(route).toEqual({ ptyId: 'pty-42', workspaceId: 'ws-new' });
     expect(sendRpc).toHaveBeenCalledWith('mcp.claimWorkspace', { name: 'MCP' });
+    // The pin must carry the workspaceId so terminal RPCs have a verified id to
+    // assert against — never the spoofable env hint.
+    expect(getPinnedRoute()).toEqual({ ptyId: 'pty-42', workspaceId: 'ws-new' });
   });
 
-  it('pins the claimed ptyId so subsequent calls reuse it without a second RPC', async () => {
-    const sendRpc = vi.fn().mockResolvedValue({ ptyId: 'pty-7' });
-    const deps = makeDeps({
-      sendRpc,
-      resolveWorkspaceId: vi.fn().mockResolvedValue(''),
-    });
+  it('pins the claimed route so subsequent claims reuse it without a second RPC', async () => {
+    const sendRpc = vi.fn().mockResolvedValue({ ptyId: 'pty-7', workspaceId: 'ws-7' });
+    const deps = makeDeps({ sendRpc });
 
-    const first = await resolveDefaultPtyId(deps);
-    const second = await resolveDefaultPtyId(deps);
-    const third = await resolveDefaultPtyId(deps);
+    const first = await claimPinnedRoute(deps);
+    const second = await claimPinnedRoute(deps);
+    const third = await claimPinnedRoute(deps);
 
-    expect(first).toBe('pty-7');
-    expect(second).toBe('pty-7');
-    expect(third).toBe('pty-7');
-    // All three calls must share a single claim RPC — re-claiming on every
-    // tool call would spawn a new workspace each time and defeat the point.
+    expect(first).toEqual({ ptyId: 'pty-7', workspaceId: 'ws-7' });
+    expect(second).toEqual(first);
+    expect(third).toEqual(first);
+    // All three calls share a single claim RPC — re-claiming on every tool call
+    // would spawn a new workspace each time.
     expect(sendRpc).toHaveBeenCalledTimes(1);
   });
 
   it('de-duplicates concurrent first calls so only one claim RPC fires', async () => {
-    // Simulate an RPC that takes a moment — three terminal tools invoked in
-    // parallel on first startup must converge onto a single claim.
     let resolveRpc!: (value: unknown) => void;
     const sendRpc = vi.fn().mockImplementation(
       () => new Promise((r) => {
         resolveRpc = r;
       }),
     );
-    const deps = makeDeps({
-      sendRpc,
-      resolveWorkspaceId: vi.fn().mockResolvedValue(''),
-    });
+    const deps = makeDeps({ sendRpc });
 
-    const p1 = resolveDefaultPtyId(deps);
-    const p2 = resolveDefaultPtyId(deps);
-    const p3 = resolveDefaultPtyId(deps);
+    const p1 = claimPinnedRoute(deps);
+    const p2 = claimPinnedRoute(deps);
+    const p3 = claimPinnedRoute(deps);
 
-    // Only one inflight claim, not three.
     await Promise.resolve();
     await Promise.resolve();
     expect(sendRpc).toHaveBeenCalledTimes(1);
 
-    resolveRpc({ ptyId: 'pty-99' });
+    resolveRpc({ ptyId: 'pty-99', workspaceId: 'ws-99' });
 
-    await expect(p1).resolves.toBe('pty-99');
-    await expect(p2).resolves.toBe('pty-99');
-    await expect(p3).resolves.toBe('pty-99');
+    await expect(p1).resolves.toEqual({ ptyId: 'pty-99', workspaceId: 'ws-99' });
+    await expect(p2).resolves.toEqual({ ptyId: 'pty-99', workspaceId: 'ws-99' });
+    await expect(p3).resolves.toEqual({ ptyId: 'pty-99', workspaceId: 'ws-99' });
   });
 
   it('throws and does not pin when the claim RPC fails', async () => {
     const sendRpc = vi.fn().mockRejectedValueOnce(new Error('pipe closed'));
-    const deps = makeDeps({
-      sendRpc,
-      resolveWorkspaceId: vi.fn().mockResolvedValue(''),
-    });
+    const deps = makeDeps({ sendRpc });
 
-    await expect(resolveDefaultPtyId(deps)).rejects.toThrow(
+    await expect(claimPinnedRoute(deps)).rejects.toThrow(
       'Unable to claim a dedicated MCP terminal workspace: pipe closed',
     );
+    expect(getPinnedRoute()).toBeNull();
 
-    // Next call should retry — failures must not permanently disable the
-    // external caller's default-pane resolution.
-    sendRpc.mockResolvedValueOnce({ ptyId: 'pty-retry' });
-    const retry = await resolveDefaultPtyId(deps);
-    expect(retry).toBe('pty-retry');
+    // Next call should retry — failures must not permanently disable resolution.
+    sendRpc.mockResolvedValueOnce({ ptyId: 'pty-retry', workspaceId: 'ws-retry' });
+    const retry = await claimPinnedRoute(deps);
+    expect(retry).toEqual({ ptyId: 'pty-retry', workspaceId: 'ws-retry' });
     expect(sendRpc).toHaveBeenCalledTimes(2);
   });
 
-  it('throws when the claim RPC returns a malformed response', async () => {
-    const sendRpc = vi.fn().mockResolvedValue({ workspaceId: 'ws-1' }); // missing ptyId
-    const deps = makeDeps({
-      sendRpc,
-      resolveWorkspaceId: vi.fn().mockResolvedValue(''),
-    });
+  it('throws and does not pin when the claim response is missing ptyId', async () => {
+    const sendRpc = vi.fn().mockResolvedValue({ workspaceId: 'ws-1' }); // no ptyId
+    const deps = makeDeps({ sendRpc });
 
-    await expect(resolveDefaultPtyId(deps)).rejects.toThrow(
+    await expect(claimPinnedRoute(deps)).rejects.toThrow(
       'Unable to claim a dedicated MCP terminal workspace: mcp.claimWorkspace returned no ptyId',
     );
+    expect(getPinnedRoute()).toBeNull();
   });
 
-  it('does not treat unverified workspace identity as internal', async () => {
-    const sendRpc = vi.fn().mockResolvedValue({ ptyId: 'pty-claimed' });
-    const deps = makeDeps({
-      sendRpc,
-      resolveWorkspaceId: vi.fn().mockResolvedValue(''),
-    });
+  it('throws and does not pin when the claim response is missing workspaceId', async () => {
+    // Pinning a ptyId without its owning workspaceId would force terminal RPCs
+    // back onto the spoofable env hint — fail closed instead (issue #163).
+    const sendRpc = vi.fn().mockResolvedValue({ ptyId: 'pty-1' }); // no workspaceId
+    const deps = makeDeps({ sendRpc });
 
-    const result = await resolveDefaultPtyId(deps);
-
-    expect(result).toBe('pty-claimed');
-    expect(sendRpc).toHaveBeenCalledWith('mcp.claimWorkspace', { name: 'MCP' });
+    await expect(claimPinnedRoute(deps)).rejects.toThrow(
+      'Unable to claim a dedicated MCP terminal workspace: mcp.claimWorkspace returned no workspaceId',
+    );
+    expect(getPinnedRoute()).toBeNull();
   });
 });

--- a/src/mcp/__tests__/terminalRouting.test.ts
+++ b/src/mcp/__tests__/terminalRouting.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveTerminalRoute } from '../terminalRouting';
+import type { PidMapLookup, TerminalRoutingDeps } from '../terminalRouting';
+import type { PinnedRoute } from '../paneResolver';
+
+/**
+ * Build deps with sane defaults. `lookups` is a queue consumed one per call to
+ * lookupPidMapWorkspace (last entry repeats if the queue drains, so a single
+ * terminal status doesn't need padding). sleep is a no-op spy by default so
+ * grace loops don't actually wait.
+ */
+function makeDeps(
+  lookups: PidMapLookup[],
+  overrides: Partial<TerminalRoutingDeps> = {},
+): { deps: TerminalRoutingDeps; spies: Record<string, ReturnType<typeof vi.fn>> } {
+  const queue = [...lookups];
+  const lookupPidMapWorkspace = vi.fn(async () =>
+    queue.length > 1 ? (queue.shift() as PidMapLookup) : queue[0],
+  );
+  let cache = '';
+  const cacheVerifiedWorkspaceId = vi.fn((wsId: string) => {
+    cache = wsId;
+  });
+  const getCachedVerifiedWorkspaceId = vi.fn(() => cache);
+  const claimPinnedRoute = vi.fn(async (): Promise<PinnedRoute> => ({
+    ptyId: 'pty-claimed',
+    workspaceId: 'ws-claimed',
+  }));
+  const getPinnedRoute = vi.fn((): PinnedRoute | null => null);
+  const sleep = vi.fn(async () => undefined);
+
+  const deps: TerminalRoutingDeps = {
+    lookupPidMapWorkspace,
+    getCachedVerifiedWorkspaceId,
+    cacheVerifiedWorkspaceId,
+    getPinnedRoute,
+    claimPinnedRoute,
+    sleep,
+    graceDelayMs: 1,
+    ...overrides,
+  };
+  return {
+    deps,
+    spies: {
+      lookupPidMapWorkspace,
+      cacheVerifiedWorkspaceId,
+      getCachedVerifiedWorkspaceId,
+      claimPinnedRoute,
+      getPinnedRoute,
+      sleep,
+    },
+  };
+}
+
+describe('resolveTerminalRoute', () => {
+  it('① cache hit: uses cached ws, no lookup, no claim', async () => {
+    const { deps, spies } = makeDeps([{ status: 'miss' }], {
+      getCachedVerifiedWorkspaceId: () => 'ws-cached',
+    });
+    const route = await resolveTerminalRoute(deps);
+    expect(route).toEqual({ workspaceId: 'ws-cached', ptyId: undefined });
+    expect(spies.lookupPidMapWorkspace).not.toHaveBeenCalled();
+    expect(spies.claimPinnedRoute).not.toHaveBeenCalled();
+  });
+
+  it('cache hit preserves an explicit ptyId passthrough', async () => {
+    const { deps } = makeDeps([{ status: 'miss' }], {
+      getCachedVerifiedWorkspaceId: () => 'ws-cached',
+    });
+    const route = await resolveTerminalRoute(deps, 'pty-x');
+    expect(route).toEqual({ workspaceId: 'ws-cached', ptyId: 'pty-x' });
+  });
+
+  it('② first-party hit, ptyId omitted: returns ws and caches it', async () => {
+    const { deps, spies } = makeDeps([{ status: 'hit', wsId: 'ws-fp' }]);
+    const route = await resolveTerminalRoute(deps);
+    expect(route).toEqual({ workspaceId: 'ws-fp', ptyId: undefined });
+    expect(spies.cacheVerifiedWorkspaceId).toHaveBeenCalledWith('ws-fp');
+    expect(spies.claimPinnedRoute).not.toHaveBeenCalled();
+  });
+
+  it('③ first-party hit, explicit ptyId: passes ptyId through (main asserts)', async () => {
+    const { deps } = makeDeps([{ status: 'hit', wsId: 'ws-fp' }]);
+    const route = await resolveTerminalRoute(deps, 'pty-1');
+    expect(route).toEqual({ workspaceId: 'ws-fp', ptyId: 'pty-1' });
+  });
+
+  it('R2: a fresh hit beats an existing pin (bounds false-claim blast radius)', async () => {
+    const pin: PinnedRoute = { ptyId: 'pty-claimed', workspaceId: 'ws-claimed' };
+    const { deps, spies } = makeDeps([{ status: 'hit', wsId: 'ws-real' }], {
+      getPinnedRoute: () => pin,
+    });
+    const route = await resolveTerminalRoute(deps);
+    expect(route).toEqual({ workspaceId: 'ws-real', ptyId: undefined });
+    expect(spies.claimPinnedRoute).not.toHaveBeenCalled();
+  });
+
+  it('R1: stale cache (getter returns "") re-resolves via the PID map', async () => {
+    // Simulates callRpc → invalidateWorkspaceId clearing workspaceResolved: the
+    // getter returns '' even though a stale id lingers, so we must re-resolve.
+    const { deps, spies } = makeDeps([{ status: 'hit', wsId: 'ws-fresh' }], {
+      getCachedVerifiedWorkspaceId: () => '',
+    });
+    const route = await resolveTerminalRoute(deps);
+    expect(route.workspaceId).toBe('ws-fresh');
+    expect(spies.lookupPidMapWorkspace).toHaveBeenCalled();
+  });
+
+  it('④ external miss, ptyId omitted: claims a dedicated route', async () => {
+    const { deps, spies } = makeDeps([{ status: 'miss' }]);
+    const route = await resolveTerminalRoute(deps);
+    expect(route).toEqual({ workspaceId: 'ws-claimed', ptyId: 'pty-claimed' });
+    expect(spies.claimPinnedRoute).toHaveBeenCalledTimes(1);
+  });
+
+  it('④b external miss, ptyId omitted, pin exists: reuses pin without claiming', async () => {
+    const pin: PinnedRoute = { ptyId: 'pty-pinned', workspaceId: 'ws-pinned' };
+    const { deps, spies } = makeDeps([{ status: 'miss' }], {
+      getPinnedRoute: () => pin,
+    });
+    const route = await resolveTerminalRoute(deps);
+    expect(route).toEqual({ workspaceId: 'ws-pinned', ptyId: 'pty-pinned' });
+    expect(spies.claimPinnedRoute).not.toHaveBeenCalled();
+  });
+
+  it('⑤ external miss, explicit ptyId, pin exists: pinned ws + explicit ptyId, no claim', async () => {
+    // The foreign-ptyId attack lands here: pinned ws ≠ victim ws, so the
+    // main-side assert rejects the victim ptyId. A legit pane in the claimed
+    // ws passes.
+    const pin: PinnedRoute = { ptyId: 'pty-pinned', workspaceId: 'ws-pinned' };
+    const { deps, spies } = makeDeps([{ status: 'miss' }], {
+      getPinnedRoute: () => pin,
+    });
+    const route = await resolveTerminalRoute(deps, 'pty-victim');
+    expect(route).toEqual({ workspaceId: 'ws-pinned', ptyId: 'pty-victim' });
+    expect(spies.claimPinnedRoute).not.toHaveBeenCalled();
+  });
+
+  it('⑥ external miss, explicit ptyId, NO pin: fails closed without claiming', async () => {
+    const { deps, spies } = makeDeps([{ status: 'miss' }]);
+    await expect(resolveTerminalRoute(deps, 'pty-victim')).rejects.toThrow(
+      /cannot target an explicit ptyId before claiming/,
+    );
+    expect(spies.claimPinnedRoute).not.toHaveBeenCalled();
+  });
+
+  it('⑦ rpc-down twice then hit: grace recovers, no claim', async () => {
+    const { deps, spies } = makeDeps([
+      { status: 'rpc-down' },
+      { status: 'rpc-down' },
+      { status: 'hit', wsId: 'ws-recovered' },
+    ]);
+    const route = await resolveTerminalRoute(deps);
+    expect(route.workspaceId).toBe('ws-recovered');
+    expect(spies.sleep).toHaveBeenCalledTimes(2);
+    expect(spies.claimPinnedRoute).not.toHaveBeenCalled();
+  });
+
+  it('⑧ rpc-down exhausted: throws retryable, no claim', async () => {
+    const { deps, spies } = makeDeps([{ status: 'rpc-down' }], {
+      rpcDownGraceAttempts: 3,
+    });
+    await expect(resolveTerminalRoute(deps)).rejects.toThrow(
+      /not reachable.*[Rr]etry/,
+    );
+    expect(spies.claimPinnedRoute).not.toHaveBeenCalled();
+    // 3 attempts → 2 sleeps then throw on the 3rd.
+    expect(spies.sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it('⑨ empty-map exhausted, ptyId omitted: treated as external → claim', async () => {
+    const { deps, spies } = makeDeps([{ status: 'empty-map' }], {
+      emptyMapGraceAttempts: 2,
+    });
+    const route = await resolveTerminalRoute(deps);
+    expect(route).toEqual({ workspaceId: 'ws-claimed', ptyId: 'pty-claimed' });
+    expect(spies.claimPinnedRoute).toHaveBeenCalledTimes(1);
+  });
+
+  it('empty-map recovers to hit within grace: no claim', async () => {
+    const { deps, spies } = makeDeps([
+      { status: 'empty-map' },
+      { status: 'hit', wsId: 'ws-late' },
+    ]);
+    const route = await resolveTerminalRoute(deps);
+    expect(route.workspaceId).toBe('ws-late');
+    expect(spies.claimPinnedRoute).not.toHaveBeenCalled();
+  });
+
+  it('empty-map exhausted, explicit ptyId, no pin: fails closed (parity with ⑥)', async () => {
+    const { deps, spies } = makeDeps([{ status: 'empty-map' }], {
+      emptyMapGraceAttempts: 2,
+    });
+    await expect(resolveTerminalRoute(deps, 'pty-victim')).rejects.toThrow(
+      /cannot target an explicit ptyId before claiming/,
+    );
+    expect(spies.claimPinnedRoute).not.toHaveBeenCalled();
+  });
+
+  it('⑪ miss is decided immediately — lookup called exactly once, no sleep', async () => {
+    const { deps, spies } = makeDeps([{ status: 'miss' }]);
+    await resolveTerminalRoute(deps);
+    expect(spies.lookupPidMapWorkspace).toHaveBeenCalledTimes(1);
+    expect(spies.sleep).not.toHaveBeenCalled();
+  });
+
+  it('⑩ never returns an empty workspaceId (hit/claim/pin all non-empty)', async () => {
+    for (const scenario of [
+      { lookups: [{ status: 'hit', wsId: 'ws-a' }] as PidMapLookup[], pin: null, pty: undefined },
+      { lookups: [{ status: 'miss' }] as PidMapLookup[], pin: null, pty: undefined },
+      {
+        lookups: [{ status: 'miss' }] as PidMapLookup[],
+        pin: { ptyId: 'p', workspaceId: 'ws-pin' } as PinnedRoute,
+        pty: 'pe',
+      },
+    ]) {
+      const { deps } = makeDeps(scenario.lookups, {
+        getPinnedRoute: () => scenario.pin,
+      });
+      const route = await resolveTerminalRoute(deps, scenario.pty);
+      expect(route.workspaceId).toBeTruthy();
+      expect(typeof route.workspaceId).toBe('string');
+    }
+  });
+});

--- a/src/mcp/__tests__/workspaceRouting.test.ts
+++ b/src/mcp/__tests__/workspaceRouting.test.ts
@@ -49,9 +49,10 @@ describe('MCP workspace routing (source-level invariants)', () => {
     // requireWorkspaceId is the single sanctioned caller: it throws when the
     // resolver returns falsy. Any tool handler that calls resolveWorkspaceId()
     // directly can silently fall back to the active workspace on a miss — the
-    // exact bug. `resolveWorkspaceId` passed by REFERENCE (resolveDefaultPtyId
-    // deps) has no parens and is intentionally excluded by the `()` in the regex.
-    const directCalls = src.match(/resolveWorkspaceId\(\)/g) ?? [];
+    // exact bug. The `(?<!function )` lookbehind excludes the parameter-less
+    // declaration (`async function resolveWorkspaceId()`) so only call sites
+    // are counted.
+    const directCalls = src.match(/(?<!function )resolveWorkspaceId\(\)/g) ?? [];
     expect(directCalls).toHaveLength(1);
   });
 
@@ -61,11 +62,69 @@ describe('MCP workspace routing (source-level invariants)', () => {
     expect(block).not.toMatch(/resolveWorkspaceId\(\)/);
   });
 
-  it('terminal default routing uses verified identity, not the env-hint resolver', () => {
-    const start = src.indexOf('function resolveDefaultPtyId');
+  it('terminal default routing binds the verified router, not the weak resolver (#163 Part 2)', () => {
+    // resolveTerminalRouteBound wires resolveTerminalRoute to the verified
+    // PID-map lookup + claim pinning. The cache getter MUST honor
+    // workspaceResolved so an invalidated (stale) identity re-resolves instead
+    // of being served from cache — otherwise callRpc's self-heal is defeated.
+    const start = src.indexOf('function resolveTerminalRouteBound');
     expect(start).toBeGreaterThan(0);
-    const block = src.slice(start, src.indexOf('}', start) + 2);
-    expect(block).toContain('resolveDefaultPtyIdImpl({ sendRpc, resolveWorkspaceId: resolveVerifiedWorkspaceId })');
+    const block = src.slice(start, src.indexOf('\n}', start) + 2);
+    expect(block).toContain('resolveTerminalRoute(');
+    expect(block).toContain('lookupPidMapWorkspace');
+    expect(block).toContain('claimPinnedRoute');
+    // The verified-cache getter is gated on workspaceResolved (R1).
+    expect(block).toMatch(/workspaceResolved\s*\?\s*MY_WORKSPACE_ID\s*:\s*''/);
+  });
+
+  it('the env-hint resolver (verifiedOnly) is fully removed — terminal IO never reaches it', () => {
+    // resolveVerifiedWorkspaceId / the verifiedOnly opt were the old seam. They
+    // are gone; terminal routing now has its own verified path. If they ever
+    // reappear, terminal IO could regain the env-hint fallback.
+    expect(src).not.toContain('resolveVerifiedWorkspaceId');
+    expect(src).not.toContain('verifiedOnly');
+  });
+
+  it('every terminal IO tool routes through resolveTerminalRouteBound, never the workspaceId resolvers', () => {
+    for (const tool of [
+      'terminal_read',
+      'terminal_read_events',
+      'terminal_send',
+      'terminal_send_key',
+    ]) {
+      const block = toolBlock(tool);
+      expect(block, `${tool} must use resolveTerminalRouteBound`).toMatch(
+        /resolveTerminalRouteBound\(/,
+      );
+      // Must NOT resolve workspaceId via the weak/A2A resolvers — those accept
+      // the spoofable env hint.
+      expect(block, `${tool} must not call requireWorkspaceId`).not.toMatch(
+        /requireWorkspaceId\(\)/,
+      );
+      expect(block, `${tool} must not call resolveWorkspaceId`).not.toMatch(
+        /resolveWorkspaceId\(\)/,
+      );
+    }
+  });
+
+  it('terminal tools always send workspaceId — never a conditional spread that could drop it', () => {
+    // An absent/empty workspaceId makes the main-side assertWorkspaceOwnsPty
+    // treat the call as an internal caller and skip the ownership check — the
+    // exact bypass. workspaceId must come from route.workspaceId unconditionally.
+    for (const tool of [
+      'terminal_read',
+      'terminal_read_events',
+      'terminal_send',
+      'terminal_send_key',
+    ]) {
+      const block = toolBlock(tool);
+      expect(block, `${tool} must set workspaceId from route unconditionally`).toMatch(
+        /workspaceId:\s*route\.workspaceId/,
+      );
+      expect(block, `${tool} must not conditionally spread workspaceId`).not.toMatch(
+        /\.\.\.\(\s*workspaceId/,
+      );
+    }
   });
 
   it('browser_session_start is GLOBAL — carries no workspace identity (no resolver calls)', () => {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -4,7 +4,8 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import { clearClientIdentity, sendRpc, setClientIdentity } from './wmux-client';
 import type { RpcMethod } from '../shared/rpc';
-import { resolveDefaultPtyId as resolveDefaultPtyIdImpl } from './paneResolver';
+import { claimPinnedRoute, getPinnedRoute } from './paneResolver';
+import { resolveTerminalRoute, type PidMapLookup } from './terminalRouting';
 import { classifyWorkspaceListResult, type WorkspaceLiveness } from './workspaceIdentity';
 import { PlaywrightEngine } from './playwright/PlaywrightEngine';
 import { registerNavigationTools } from './playwright/tools/navigation';
@@ -82,65 +83,79 @@ function invalidateWorkspaceId(): void {
 }
 
 /**
- * Resolve workspace identity by:
- * 1. Getting PID→workspaceId mappings from the main process via RPC. The map
- *    is keyed by PID and resolved to the CURRENT owning workspace server-side,
- *    so it reflects live ownership rather than a frozen create-time value.
- * 2. Walking our process tree upward to find a matching PTY shell PID.
+ * Live PID→workspace lookup, classified so callers can tell apart a
+ * confirmed-external caller (map populated, our process chain absent) from a
+ * transient boot/respawn window (RPC down, or map momentarily empty).
  *
- * Process chain: MCP server → Claude Code → shell(PTY).
- *
- * The (stale-prone) env hint is used only as a last resort when the live map
- * cannot be obtained, and is NOT cached, so a later call retries live
- * resolution once the renderer / pid-map becomes available.
+ * Process chain: MCP server → Claude Code → shell(PTY). A `hit` is verified
+ * identity (our PID tree owns a live workspace); the env hint never reaches
+ * here. Shared by the weak resolveWorkspaceId() (A2A routing) and the verified
+ * terminal router (resolveTerminalRoute) so the walk lives in one place.
  */
-async function resolveWorkspaceId(opts?: { force?: boolean; verifiedOnly?: boolean }): Promise<string> {
-  if (workspaceResolved && MY_WORKSPACE_ID && !opts?.force) return MY_WORKSPACE_ID;
-
+async function lookupPidMapWorkspace(): Promise<PidMapLookup> {
+  let mappings: Record<string, string> | undefined;
   try {
-    // Get PID→(live)workspaceId mappings from main process
     const result = await sendRpc('a2a.resolve.identity' as RpcMethod, {});
-    const { mappings } = result as { mappings: Record<string, string> };
-    if (mappings && Object.keys(mappings).length > 0) {
-      const knownPids = new Map<number, string>();
-      for (const [pidStr, wsId] of Object.entries(mappings)) {
-        const pid = parseInt(pidStr, 10);
-        if (!isNaN(pid)) knownPids.set(pid, wsId);
-      }
+    mappings = (result as { mappings: Record<string, string> }).mappings;
+  } catch {
+    return { status: 'rpc-down' };
+  }
+  if (!mappings || Object.keys(mappings).length === 0) {
+    return { status: 'empty-map' };
+  }
 
-      // Walk process tree upward: MCP server → Claude Code → shell(PTY)
-      let currentPid = process.ppid;
-      for (let depth = 0; depth < 10; depth++) {
-        const wsId = knownPids.get(currentPid);
-        if (wsId) {
-          MY_WORKSPACE_ID = wsId;
-          workspaceResolved = true;
-          return MY_WORKSPACE_ID;
-        }
-        const parentPid = await getParentPid(currentPid);
-        if (!parentPid || parentPid === currentPid || parentPid <= 1) break;
-        currentPid = parentPid;
-      }
-    }
-  } catch { /* resolve failed, fall through to env hint */ }
+  const knownPids = new Map<number, string>();
+  for (const [pidStr, wsId] of Object.entries(mappings)) {
+    const pid = parseInt(pidStr, 10);
+    if (!isNaN(pid)) knownPids.set(pid, wsId);
+  }
+
+  // Walk process tree upward: MCP server → Claude Code → shell(PTY)
+  let currentPid = process.ppid;
+  for (let depth = 0; depth < 10; depth++) {
+    const wsId = knownPids.get(currentPid);
+    if (wsId) return { status: 'hit', wsId };
+    const parentPid = await getParentPid(currentPid);
+    if (!parentPid || parentPid === currentPid || parentPid <= 1) break;
+    currentPid = parentPid;
+  }
+  return { status: 'miss' };
+}
+
+/**
+ * Resolve workspace identity for A2A / non-terminal tools (the WEAK resolver):
+ * 1. Verified PID-map lookup (caches a hit).
+ * 2. Falls back to the unconfirmed env hint when no verified identity is
+ *    available — NOT cached, so a later call retries live resolution.
+ *
+ * Terminal IO does NOT use this — it routes through resolveTerminalRoute,
+ * which trusts only verified identity (issue #163 Part 2). The env-hint
+ * fallback below is the bypass that fix closes for terminal IO; it remains
+ * for A2A tools, which carry no PTY-ownership assertion.
+ */
+async function resolveWorkspaceId(): Promise<string> {
+  if (workspaceResolved && MY_WORKSPACE_ID) return MY_WORKSPACE_ID;
+
+  const lookup = await lookupPidMapWorkspace();
+  if (lookup.status === 'hit') {
+    MY_WORKSPACE_ID = lookup.wsId;
+    workspaceResolved = true;
+    return MY_WORKSPACE_ID;
+  }
 
   // Last resort: the unconfirmed (possibly stale) env hint. Not cached.
-  // Security-sensitive routing (terminal default-pane resolution) asks for a
-  // verified identity only; in that mode, never treat a user-supplied env var
-  // as proof that the MCP server is running inside a wmux PTY.
   //
-  // Even for non-verified callers the hint must still not name a CONFIRMED
-  // ghost. The PID-map walk above already fails closed once legacy "ws-" debris
-  // is pruned (a2a.resolve.identity); the hint is the only remaining path a
-  // re-minted ghost id can leak through. Drop it ONLY on positive proof it is
-  // gone ('absent'); on 'unknown' (workspace.list transiently unavailable
-  // during boot reconcile) keep trusting the hint, since this fallback exists
-  // precisely to carry the call through while the RPC layer is briefly down.
-  // Not cached, so a later call re-checks once the renderer is ready.
-  if (!opts?.verifiedOnly && ENV_WORKSPACE_HINT) {
+  // The hint must still not name a CONFIRMED ghost. The PID-map walk above
+  // already fails closed once legacy "ws-" debris is pruned; the hint is the
+  // only remaining path a re-minted ghost id can leak through. Drop it ONLY on
+  // positive proof it is gone ('absent'); on 'unknown' (workspace.list
+  // transiently unavailable during boot reconcile) keep trusting the hint,
+  // since this fallback exists precisely to carry the call through while the
+  // RPC layer is briefly down. Not cached, so a later call re-checks once the
+  // renderer is ready.
+  if (ENV_WORKSPACE_HINT) {
     if ((await isLiveWorkspace(ENV_WORKSPACE_HINT)) !== 'absent') return ENV_WORKSPACE_HINT;
   }
-  if (opts?.verifiedOnly) return '';
 
   // Last-resort cached identity. invalidateWorkspaceId() clears the
   // `workspaceResolved` flag but NOT MY_WORKSPACE_ID, so a re-minted/closed
@@ -154,10 +169,6 @@ async function resolveWorkspaceId(opts?: { force?: boolean; verifiedOnly?: boole
     workspaceResolved = false;
   }
   return MY_WORKSPACE_ID;
-}
-
-function resolveVerifiedWorkspaceId(): Promise<string> {
-  return resolveWorkspaceId({ force: true, verifiedOnly: true });
 }
 
 /**
@@ -219,13 +230,27 @@ async function requireWorkspaceId(): Promise<string> {
   return wsId;
 }
 
-// External-caller pane pinning — see src/mcp/paneResolver.ts for rationale.
-// Bind the resolver's deps to this module's sendRpc + verified identity
-// resolver. Unlike A2A tools, terminal defaults must not trust WMUX_WORKSPACE_ID
-// because an external launcher can spoof it and otherwise regain active-pane
-// fallback.
-function resolveDefaultPtyId(): Promise<string | null> {
-  return resolveDefaultPtyIdImpl({ sendRpc, resolveWorkspaceId: resolveVerifiedWorkspaceId });
+// Verified terminal routing — see src/mcp/terminalRouting.ts for the full
+// state machine. Binds the router's deps to this module's PID-map lookup,
+// verified-identity cache, and external-claim pinning. Unlike A2A tools,
+// terminal IO must not trust WMUX_WORKSPACE_ID: an external launcher can spoof
+// it to a victim workspace and read/write that workspace's terminal
+// (issue #163). The cache getter honors workspaceResolved so a stale identity
+// invalidated by callRpc re-resolves instead of being served from cache.
+function resolveTerminalRouteBound(explicitPtyId?: string) {
+  return resolveTerminalRoute(
+    {
+      lookupPidMapWorkspace,
+      getCachedVerifiedWorkspaceId: () => (workspaceResolved ? MY_WORKSPACE_ID : ''),
+      cacheVerifiedWorkspaceId: (wsId: string) => {
+        MY_WORKSPACE_ID = wsId;
+        workspaceResolved = true;
+      },
+      getPinnedRoute,
+      claimPinnedRoute: () => claimPinnedRoute({ sendRpc }),
+    },
+    explicitPtyId,
+  );
 }
 
 // === Browser tools (RPC-based: surface management stays in main process) ===
@@ -314,10 +339,9 @@ server.tool(
     tail_lines: z.number().int().positive().optional().describe('Return only the last N non-empty lines of the viewport. Omit to return everything the terminal buffer knows about.'),
   },
   async ({ ptyId, tail_lines }) => {
-    const workspaceId = await requireWorkspaceId();
-    const params: Record<string, unknown> = { workspaceId };
-    const effective = ptyId ?? (await resolveDefaultPtyId()) ?? undefined;
-    if (effective) params.ptyId = effective;
+    const route = await resolveTerminalRouteBound(ptyId);
+    const params: Record<string, unknown> = { workspaceId: route.workspaceId };
+    if (route.ptyId) params.ptyId = route.ptyId;
     if (tail_lines !== undefined) params.tail_lines = tail_lines;
     return callRpc('input.readScreen', params);
   },
@@ -333,10 +357,9 @@ server.tool(
     lastCommandOnly: z.boolean().optional().describe('Skip the events list and only return lastCompletedRange (the byte-offset range + exit code of the most recently finished command).'),
   },
   async ({ ptyId, limit, sinceOffset, lastCommandOnly }) => {
-    const workspaceId = await requireWorkspaceId();
-    const params: Record<string, unknown> = { workspaceId };
-    const effective = ptyId ?? (await resolveDefaultPtyId()) ?? undefined;
-    if (effective) params.ptyId = effective;
+    const route = await resolveTerminalRouteBound(ptyId);
+    const params: Record<string, unknown> = { workspaceId: route.workspaceId };
+    if (route.ptyId) params.ptyId = route.ptyId;
     if (limit !== undefined) params.limit = limit;
     if (sinceOffset !== undefined) params.sinceOffset = sinceOffset;
     if (lastCommandOnly) params.lastCommandOnly = true;
@@ -353,10 +376,9 @@ server.tool(
     submit: z.boolean().optional().describe('When true, append a carriage return (\\r) after the text so it is committed — equivalent to pressing Enter. Use this for shell commands and TUI chat prompts (e.g. Claude Code, REPLs). Default: false (text is written as-is; you must call terminal_send_key({ key: "enter" }) separately to commit).'),
   },
   async ({ text, ptyId, submit }) => {
-    const workspaceId = await requireWorkspaceId();
-    const effective = ptyId ?? (await resolveDefaultPtyId()) ?? undefined;
-    const base: Record<string, unknown> = { text, workspaceId };
-    if (effective) base.ptyId = effective;
+    const route = await resolveTerminalRouteBound(ptyId);
+    const base: Record<string, unknown> = { text, workspaceId: route.workspaceId };
+    if (route.ptyId) base.ptyId = route.ptyId;
     if (submit) base.submit = true;
     return callRpc('input.send', base);
   },
@@ -372,9 +394,10 @@ server.tool(
     ptyId: z.string().optional().describe('Target a specific terminal by PTY ID. Omit to use the active terminal. Get PTY IDs from surface_list().'),
   },
   async ({ key, ptyId }) => {
-    const workspaceId = await requireWorkspaceId();
-    const effective = ptyId ?? (await resolveDefaultPtyId()) ?? undefined;
-    return callRpc('input.sendKey', effective ? { key, ptyId: effective, workspaceId } : { key, workspaceId });
+    const route = await resolveTerminalRouteBound(ptyId);
+    const params: Record<string, unknown> = { key, workspaceId: route.workspaceId };
+    if (route.ptyId) params.ptyId = route.ptyId;
+    return callRpc('input.sendKey', params);
   },
 );
 

--- a/src/mcp/paneResolver.ts
+++ b/src/mcp/paneResolver.ts
@@ -9,58 +9,68 @@
  * Terminal / VS Code terminal) — there the user almost always has live
  * work in the focused pane and keystrokes would hijack it.
  *
- * This module holds a process-lifetime "pinned ptyId" that external
- * callers claim on first use via the mcp.claimWorkspace RPC. The pin
- * survives for the MCP server process only; when the external Claude Code
- * exits, the subprocess dies and the pin disappears. The claimed workspace
- * and its pane are left intact so the user can inspect output afterwards.
+ * This module holds a process-lifetime "pinned route" (ptyId + owning
+ * workspaceId) that external callers claim on first use via the
+ * mcp.claimWorkspace RPC. The pin survives for the MCP server process
+ * only; when the external Claude Code exits, the subprocess dies and the
+ * pin disappears. The claimed workspace and its pane are left intact so
+ * the user can inspect output afterwards.
+ *
+ * The workspaceId is pinned ALONGSIDE the ptyId (issue #163 Part 2): the
+ * terminal RPCs carry workspaceId so the main process can assert PTY
+ * ownership, and that id must come from the claim response — never from
+ * the spoofable WMUX_WORKSPACE_ID env hint. A pin without a workspaceId
+ * would force callers back onto the hint, reopening the bypass, so a
+ * claim response missing either id fails closed.
  */
 
 import type { RpcMethod } from '../shared/rpc';
 
-export interface PaneResolverDeps {
-  /** JSON-RPC sender (wmux-client.sendRpc, usually). */
-  sendRpc: (method: RpcMethod, params?: Record<string, unknown>) => Promise<unknown>;
-  /**
-   * Verified identity resolver. Must return empty string when the MCP server
-   * can't prove it is running inside a live wmux PTY. This resolver must not
-   * trust user-supplied environment hints such as WMUX_WORKSPACE_ID.
-   */
-  resolveWorkspaceId: () => Promise<string>;
+export interface PinnedRoute {
+  ptyId: string;
+  workspaceId: string;
 }
 
-let pinnedPtyId: string | null = null;
-let claimInFlight: Promise<string | null> | null = null;
+export interface ClaimDeps {
+  /** JSON-RPC sender (wmux-client.sendRpc, usually). */
+  sendRpc: (method: RpcMethod, params?: Record<string, unknown>) => Promise<unknown>;
+}
+
+let pinned: PinnedRoute | null = null;
+let claimInFlight: Promise<PinnedRoute> | null = null;
+
+/** The route claimed earlier in this process, or null before the first claim. */
+export function getPinnedRoute(): PinnedRoute | null {
+  return pinned;
+}
 
 /**
- * Resolve the default ptyId for terminal tools when the caller didn't
- * provide one explicitly.
- *
- * Returns:
- * - A pinned ptyId for external callers (first call triggers a claim RPC
- *   that creates a dedicated workspace + PTY).
- * - null for internal callers — signalling that the main process should
- *   fall back to the active pane (existing behavior).
+ * Claim a dedicated workspace + PTY for an external caller and pin both ids
+ * for the rest of this process's lifetime.
  *
  * Concurrent first calls de-dupe through claimInFlight so we don't race
- * and spawn multiple claim workspaces.
+ * and spawn multiple claim workspaces. Failures throw (fail-closed) and do
+ * NOT pin, so a later call retries instead of being permanently disabled.
  */
-export async function resolveDefaultPtyId(deps: PaneResolverDeps): Promise<string | null> {
-  if (pinnedPtyId) return pinnedPtyId;
+export async function claimPinnedRoute(deps: ClaimDeps): Promise<PinnedRoute> {
+  if (pinned) return pinned;
   if (claimInFlight) return claimInFlight;
 
   claimInFlight = (async () => {
-    const wsId = await deps.resolveWorkspaceId();
-    if (wsId) return null;
-
     try {
       const result = await deps.sendRpc('mcp.claimWorkspace', { name: 'MCP' });
       const ptyId = (result as { ptyId?: string } | null)?.ptyId;
-      if (typeof ptyId === 'string' && ptyId.length > 0) {
-        pinnedPtyId = ptyId;
-        return ptyId;
+      const workspaceId = (result as { workspaceId?: string } | null)?.workspaceId;
+      if (typeof ptyId !== 'string' || ptyId.length === 0) {
+        throw new Error('mcp.claimWorkspace returned no ptyId');
       }
-      throw new Error('mcp.claimWorkspace returned no ptyId');
+      if (typeof workspaceId !== 'string' || workspaceId.length === 0) {
+        // Pinning the ptyId without its owner would leave terminal RPCs with
+        // no trustworthy workspaceId to assert against — fail closed instead.
+        throw new Error('mcp.claimWorkspace returned no workspaceId');
+      }
+      pinned = { ptyId, workspaceId };
+      return pinned;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       console.error('[mcp] claimWorkspace failed:', message);
@@ -77,6 +87,6 @@ export async function resolveDefaultPtyId(deps: PaneResolverDeps): Promise<strin
 
 /** Test-only: clear module state so each test starts with an empty pin. */
 export function __resetPaneResolverForTesting(): void {
-  pinnedPtyId = null;
+  pinned = null;
   claimInFlight = null;
 }

--- a/src/mcp/terminalRouting.ts
+++ b/src/mcp/terminalRouting.ts
@@ -1,0 +1,184 @@
+/**
+ * Verified workspace routing for the wmux MCP terminal tools (issue #163 Part 2).
+ *
+ * The terminal tools (terminal_read, terminal_read_events, terminal_send,
+ * terminal_send_key) carry a `workspaceId` so the main process can assert that
+ * the target PTY actually belongs to the caller's workspace
+ * (assertWorkspaceOwnsPty). Before this module they resolved that id via the
+ * weak resolver, which falls back to the spoofable WMUX_WORKSPACE_ID env hint
+ * on a PID-map miss. An external caller could therefore set the hint to a
+ * victim workspace, pass that victim's ptyId, and the assert — which only
+ * checks "ptyId belongs to workspaceId", both attacker-supplied — would pass.
+ *
+ * This module resolves terminal routing from VERIFIED identity only:
+ *
+ *   ┌─ cache hit (verified PID-map result, still valid) ─→ use it
+ *   │
+ *   ├─ PID-map HIT (our process tree owns a live workspace) ─→ first-party,
+ *   │     use that ws; explicit ptyId passes through (main asserts ownership)
+ *   │
+ *   ├─ PID-map MISS (map populated, our chain absent) ─→ confirmed external:
+ *   │     • ptyId omitted  → reuse pinned route, else claim a dedicated ws
+ *   │     • explicit ptyId → use pinned ws if pinned (main rejects a foreign
+ *   │       ptyId), else FAIL CLOSED (no legitimate target before a claim)
+ *   │
+ *   └─ TRANSIENT (rpc-down / empty-map, e.g. daemon respawn) ─→ grace retry,
+ *         so a real first-party caller booting through a respawn isn't falsely
+ *         treated as external. On exhaust: rpc-down → retryable throw;
+ *         empty-map → treat as external (a live daemon with zero PTYs cannot
+ *         be hosting a first-party caller).
+ *
+ * INVARIANT: resolveTerminalRoute never returns an empty/undefined
+ * workspaceId. An empty workspaceId reaching the main process would make
+ * assertWorkspaceOwnsPty treat the call as an internal (CLI/UI) caller and
+ * skip the ownership check entirely — the exact bypass this fix closes.
+ */
+
+import type { PinnedRoute } from './paneResolver';
+
+export type PidMapLookup =
+  | { status: 'hit'; wsId: string }
+  | { status: 'miss' } // map non-empty but our process chain isn't in it → confirmed external
+  | { status: 'rpc-down' } // a2a.resolve.identity threw → transient (daemon unreachable)
+  | { status: 'empty-map' }; // RPC answered but mappings empty → boot/respawn reconcile window
+
+export interface TerminalRoute {
+  workspaceId: string;
+  ptyId?: string;
+}
+
+export interface TerminalRoutingDeps {
+  /** Live PID→workspace lookup. Distinguishes hit / miss / transient states. */
+  lookupPidMapWorkspace: () => Promise<PidMapLookup>;
+  /** Verified cached identity ('' when none / invalidated). Honors workspaceResolved. */
+  getCachedVerifiedWorkspaceId: () => string;
+  /** Persist a freshly-resolved verified identity into the cache. */
+  cacheVerifiedWorkspaceId: (wsId: string) => void;
+  /** Route pinned by an earlier external claim, or null. */
+  getPinnedRoute: () => PinnedRoute | null;
+  /** Claim (and pin) a dedicated workspace + PTY for an external caller. */
+  claimPinnedRoute: () => Promise<PinnedRoute>;
+  /** Injectable sleep for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Grace attempts for rpc-down. Default 4. */
+  rpcDownGraceAttempts?: number;
+  /** Grace attempts for empty-map (slightly longer — respawn reconcile). Default 6. */
+  emptyMapGraceAttempts?: number;
+  /** Delay between grace attempts, ms. Default 750. */
+  graceDelayMs?: number;
+}
+
+const DEFAULT_RPC_DOWN_ATTEMPTS = 4;
+const DEFAULT_EMPTY_MAP_ATTEMPTS = 6;
+const DEFAULT_GRACE_DELAY_MS = 750;
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Resolve the verified workspace (and possibly ptyId) for a terminal RPC.
+ * Throws on confirmed-external explicit-ptyId-without-pin and on rpc-down
+ * exhaustion. Never returns an empty workspaceId.
+ */
+export async function resolveTerminalRoute(
+  deps: TerminalRoutingDeps,
+  explicitPtyId?: string,
+): Promise<TerminalRoute> {
+  const route = await resolveInner(deps, explicitPtyId);
+  if (!route.workspaceId) {
+    // Defensive: no branch below should produce this, but an empty workspaceId
+    // silently disables the main-side ownership assert, so refuse it loudly.
+    throw new Error(
+      'resolveTerminalRoute: refusing to route a terminal RPC with no verified workspaceId',
+    );
+  }
+  return route;
+}
+
+async function resolveInner(
+  deps: TerminalRoutingDeps,
+  explicitPtyId?: string,
+): Promise<TerminalRoute> {
+  // 1. Verified cache fast-path. getCachedVerifiedWorkspaceId returns '' once
+  //    invalidateWorkspaceId() has cleared workspaceResolved, so a stale (re-
+  //    minted) workspace falls through to a fresh PID-map lookup and self-heals.
+  const cached = deps.getCachedVerifiedWorkspaceId();
+  if (cached) {
+    return { workspaceId: cached, ptyId: explicitPtyId };
+  }
+
+  const sleep = deps.sleep ?? defaultSleep;
+  const rpcDownAttempts = deps.rpcDownGraceAttempts ?? DEFAULT_RPC_DOWN_ATTEMPTS;
+  const emptyMapAttempts = deps.emptyMapGraceAttempts ?? DEFAULT_EMPTY_MAP_ATTEMPTS;
+  const delayMs = deps.graceDelayMs ?? DEFAULT_GRACE_DELAY_MS;
+
+  let rpcDownSeen = 0;
+  let emptyMapSeen = 0;
+
+  // 2. Grace loop. `hit` and `miss` are terminal (decided immediately — a miss
+  //    must not stall a confirmed-external caller). Only transient states retry.
+  for (;;) {
+    const lookup = await deps.lookupPidMapWorkspace();
+
+    if (lookup.status === 'hit') {
+      // First-party: cache so subsequent calls take the fast-path, then route.
+      // A fresh hit always beats an existing pin — this bounds the blast radius
+      // of any false claim (below) to a single self-healing call.
+      deps.cacheVerifiedWorkspaceId(lookup.wsId);
+      return { workspaceId: lookup.wsId, ptyId: explicitPtyId };
+    }
+
+    if (lookup.status === 'miss') {
+      return resolveExternal(deps, explicitPtyId);
+    }
+
+    if (lookup.status === 'rpc-down') {
+      rpcDownSeen += 1;
+      if (rpcDownSeen >= rpcDownAttempts) {
+        throw new Error(
+          'wmux main process is not reachable (it may be starting or restarting). ' +
+            'Retry the terminal operation in a few seconds.',
+        );
+      }
+      await sleep(delayMs);
+      continue;
+    }
+
+    // empty-map: a live daemon reporting zero PTYs. During a respawn reconcile
+    // window this can briefly be true for a first-party caller, so retry; on
+    // exhaust treat as external (a daemon with no PTYs can't host first-party).
+    emptyMapSeen += 1;
+    if (emptyMapSeen >= emptyMapAttempts) {
+      return resolveExternal(deps, explicitPtyId);
+    }
+    await sleep(delayMs);
+  }
+}
+
+/**
+ * Confirmed-external routing. ptyId omitted → reuse/claim a pinned dedicated
+ * route. Explicit ptyId → only valid against an existing pin (a foreign ptyId
+ * is then rejected by the main-side assert); without a pin there is no
+ * legitimate target, so fail closed rather than claim (claiming would spawn an
+ * empty "MCP" workspace the explicit ptyId can never belong to).
+ */
+async function resolveExternal(
+  deps: TerminalRoutingDeps,
+  explicitPtyId?: string,
+): Promise<TerminalRoute> {
+  const pin = deps.getPinnedRoute();
+
+  if (explicitPtyId) {
+    if (pin) {
+      return { workspaceId: pin.workspaceId, ptyId: explicitPtyId };
+    }
+    throw new Error(
+      'External MCP callers cannot target an explicit ptyId before claiming a ' +
+        'dedicated terminal. Omit ptyId to claim and use your own terminal.',
+    );
+  }
+
+  const route = pin ?? (await deps.claimPinnedRoute());
+  return { workspaceId: route.workspaceId, ptyId: route.ptyId };
+}


### PR DESCRIPTION
## Summary

Closes the root cause of #163: a token-holding external MCP client could spoof `WMUX_WORKSPACE_ID` to a victim workspace, pass that workspace''s ptyId, and read/write its terminal across the workspace-isolation boundary.

The terminal tools (`terminal_read`, `terminal_read_events`, `terminal_send`, `terminal_send_key`) resolved their `workspaceId` via the weak resolver, which falls back to the spoofable `WMUX_WORKSPACE_ID` env hint on a PID-map miss. The main-side `assertWorkspaceOwnsPty` only checks that the ptyId belongs to the workspaceId — and both were attacker-supplied — so the assert passed. Part 1 (#164) added the assert to `input.readScreen`; this **Part 2** removes the spoofable identity it asserts against.

## What changed

Terminal routing now goes through `resolveTerminalRoute` (new `src/mcp/terminalRouting.ts`), which trusts **only verified PID-map identity** — the env hint never reaches terminal IO:

- **PID-map hit** (our process tree owns a live workspace) → first-party, use it.
- **PID-map miss** (map populated, our chain absent) → confirmed external:
  - ptyId omitted → reuse / claim a dedicated workspace + PTY (pinned).
  - explicit ptyId without a pin → **fail closed** (no legitimate target before a claim).
- **Transient** (`rpc-down` / `empty-map`, e.g. daemon respawn) → grace retry, so a first-party caller booting through a respawn isn''t misclassified as external. On exhaust: `rpc-down` → retryable error; `empty-map` → treat as external.

Supporting changes:
- The verified-identity cache getter honors `workspaceResolved`, so an identity invalidated by `callRpc`''s stale-identity self-heal re-resolves instead of being served stale.
- `resolveTerminalRoute` never returns an empty `workspaceId` — an empty one would make the main-side assert treat the call as an internal caller and skip the ownership check (the exact bypass).
- `paneResolver` now pins the `workspaceId` alongside the `ptyId` (from the `mcp.claimWorkspace` response) and fails closed when either is missing; pinning a ptyId without its owner would force the env hint back into the path.
- The old `verifiedOnly` option / `resolveVerifiedWorkspaceId` / `resolveDefaultPtyId` seam is removed. The weak `resolveWorkspaceId` is unchanged for A2A tools, which carry no PTY-ownership assertion.

## Tests

- **`terminalRouting.test.ts`** — routing matrix: cache-hit, first-party hit, external miss (claim / pinned / fail-closed), transient grace recovery + exhaust, fresh-hit-beats-pin (bounds false-claim blast radius), stale-cache self-heal, and the never-empty-workspaceId invariant.
- **`paneResolver.test.ts`** — dual-id pinning, dedupe, fail-closed on missing ptyId **or** workspaceId.
- **`workspaceRouting.test.ts`** — source invariants: all four terminal tools bind the verified router with an unconditional `workspaceId`; the `verifiedOnly` seam is gone; the verified lookup never reads the env hint.
- **`input.rpc.test.ts`** — `assertWorkspaceOwnsPty` parity invariant across all four terminal-IO handlers, so a future handler can''t silently skip the check.

`src/mcp` + `input.rpc` suites: 128/128 green.

## Verification

- Compiled-module dynamic harness (`scripts/issue-163-part2-dynamic.mjs`) drives the real transpiled `terminalRouting` + `paneResolver` and an end-to-end process-boundary env-spoof check: 12/12 pass.
- Live dogfood against a dev wmux GUI + the real built `dist/mcp-bundle` server (external, non-wmux-PTY process), with a victim workspace holding a sentinel:
  - **spoofed `WMUX_WORKSPACE_ID` + explicit victim ptyId** → fail-closed error, sentinel never leaked.
  - **ptyId omitted** → a dedicated "MCP" workspace is claimed via the real renderer `mcp.claimWorkspace` handler; routing never lands on the spoofed victim.
  - **first-party** (PID-map hit, no env hint) → reads its own terminal with both explicit and omitted ptyId — no regression.

## Scope

- A2A / browser / pane tools are unchanged (they carry no PTY-ownership assertion, so the spoof grants no terminal access through them).
- Pinned-route invalidation when a claimed workspace is closed mid-session is a pre-existing limitation (also in the prior `resolveDefaultPtyId`), tracked in TODOS, not in scope here.