### PR TITLE
fix(terminal): send Esc under a CJK IME (keyCode 229)

### DIFF
--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -517,6 +517,24 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         return false;
       }
 
+      // IME-safe Escape (same class of bug as the Ctrl+J newline above).
+      // When a CJK IME is active, Windows/Chromium delivers the Escape
+      // keydown with `keyCode === 229` ("Process"). xterm's CompositionHelper
+      // drops EVERY keyCode-229 keydown (it returns false, so `_keyDown` bails
+      // before emitting), so no `\x1b` ever reaches the PTY — Esc silently does
+      // nothing inside in-pane TUIs (Claude Code's /status dialog, fzf, less, …)
+      // while Tab still works (Tab is keyCode 9, which the IME doesn't claim).
+      // We emit the ESC byte ourselves and bypass xterm. `keyCode === 229` is
+      // exactly the set xterm drops, so this never double-sends on the normal
+      // keyCode-27 path. `!isComposing` defers to the IME while a candidate
+      // window / preedit is open, where Escape legitimately cancels the
+      // composition rather than the foreground app (mirrors newlineKeys).
+      if (e.code === 'Escape' && !e.isComposing && e.keyCode === 229) {
+        e.preventDefault();
+        window.electronAPI.pty.write(ptyId, '\x1b');
+        return false;
+      }
+
       // Pass app shortcuts through to useKeyboard (don't let xterm consume them).
       // 'd' is the Ctrl+D split-right shortcut — without it xterm sends EOT (0x04)
       // to the PTY and PowerShell echoes it back as `^D` instead of triggering split.


### PR DESCRIPTION
## Problem

Inside an in-pane TUI, pressing **Esc does nothing** when a CJK IME (e.g. Microsoft Pinyin) is active. The clearest repro is Claude Code's `/status` dialog: the footer says "Esc to cancel", but Esc never closes it. The only escape hatch is Ctrl+C twice, which kills the whole session. `q` / Enter / Ctrl+[ also do nothing. **Tab still works** (it cycles the dialog's tabs), so the pane is responsive — the problem is specific to Esc.

This bites any in-pane TUI that uses a bare Esc to cancel — `fzf`, `less`, vim's insert→normal, etc.

## Root cause

When a CJK IME is active, Windows/Chromium delivers the Escape keydown with `keyCode === 229` (the IME "Process" code) instead of `27`.

xterm.js's `CompositionHelper.keydown` returns `false` for **every** keyCode-229 keydown:

```js
keydown(e){
  if(this._isComposing||this._isSendingComposition){ if(20===e.keyCode||229===e.keyCode)return false; ... }
  return 229!==e.keyCode || (this._handleAnyTextareaChanges(), false)
}
```

`_keyDown` then bails before emitting anything, so **no `\x1b` ever reaches the PTY**. Tab is unaffected because it arrives as keyCode 9, which the IME doesn't claim — which is exactly why Tab works and Esc doesn't.

This is the **same root cause** as the Ctrl+J newline fix (#153): xterm derives behavior from the deprecated `keyCode`, which a CJK IME mangles to 229. Native terminals (Windows Terminal / conhost) don't go through a browser textarea + composition events, so they're unaffected — this only shows up in the xterm.js-based renderer.

## Fix

Mirror the #153 approach in `attachCustomKeyEventHandler`: match the **physical** Escape key and emit the ESC byte ourselves, bypassing xterm.

```ts
if (e.code === 'Escape' && !e.isComposing && e.keyCode === 229) {
  e.preventDefault();
  window.electronAPI.pty.write(ptyId, '\x1b');
  return false;
}
```

- **`keyCode === 229`** targets *exactly* the set xterm drops, so the normal keyCode-27 path is untouched and we never double-send.
- **`!e.isComposing`** defers to the IME while a candidate window / preedit is open, where Esc legitimately cancels the composition rather than reaching the foreground app (same guard philosophy as `newlineKeys`).

One file, +18 lines, no behavior change on the working path.

## Verification

Driven against a **live renderer over CDP** (found the xterm instance via React fiber, fired synthetic keydowns at the pane textarea, spied on `term.onData`):

| keydown | `onData` emitted |
|---|---|
| `keyCode 27`, not composing (plain Esc) | `1b` ✅ |
| `keyCode 229`, not composing (IME active) | *nothing* ❌ |
| `keyCode 229`, composing (IME preedit) | *nothing* ❌ |

Separately, driving the real `claude.exe` under ConPTY confirmed a raw `\x1b` written to the PTY dismisses the `/status` dialog cleanly — so the missing byte was the entire problem, and the binding / PTY-write path were never at fault.

`tsc -p tsconfig.json --noEmit` passes. `eslint` on the file reports only two pre-existing `no-empty-function` errors (identical on `main`, just shifted by the insertion); the added block is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
