### PR TITLE
macOS support: substrate를 Windows 수준으로 (focus/CLI/격리/zsh OSC133/agent detection)

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -314,7 +314,13 @@ const config: ForgeConfig = {
       // multiplexer that already executes arbitrary shell commands.
       // Documented in README §6 + docs/SECURITY.md §1.4 — keep in sync.
       [FuseV1Options.RunAsNode]: true,
-      [FuseV1Options.EnableCookieEncryption]: true,
+      // 서명된 빌드에서만 쿠키 암호화를 켠다. macOS os_crypt는 keychain에서 암호화
+      // 키를 읽는데, 미서명(로컬 dev/UNSIGNED) 바이너리는 hardened runtime 자격이
+      // 없어 keychain 접근이 거부된다(errSecAuthFailed -25293, 매 실행 콘솔 에러).
+      // Apple 자격증명 3개가 모두 있는 정식 빌드에서만 활성화한다.
+      [FuseV1Options.EnableCookieEncryption]: Boolean(
+        process.env.APPLE_TEAM_ID && process.env.APPLE_ID && process.env.APPLE_APP_SPECIFIC_PASSWORD,
+      ),
       [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
       [FuseV1Options.EnableNodeCliInspectArguments]: false,
       // Disabled: postPackage hook repacks asar (for node-pty), which changes the hash.

--- a/src/cli/client.ts
+++ b/src/cli/client.ts
@@ -1,10 +1,30 @@
 #!/usr/bin/env node
 import * as net from 'net';
+import * as fs from 'fs';
 import * as crypto from 'crypto';
 import type { RpcRequest, RpcResponse, RpcMethod } from '../shared/rpc';
+import { getPipeName, getAuthTokenPath } from '../shared/constants';
 
-const PIPE_NAME = process.env.WMUX_SOCKET_PATH || (process.platform === 'win32' ? '\\\\.\\pipe\\wmux' : '/tmp/wmux.sock');
+// 서버(PipeServer)와 동일한 경로 해석을 사용한다. 과거에는 '/tmp/wmux.sock'을
+// 하드코딩해 macOS/Linux에서 서버('~/.wmux.sock')와 어긋나 항상 "not running"이
+// 떴고, Windows에서도 username 없는 '\\.\pipe\wmux'로 빗나갔다. getPipeName()이
+// win32/unix·username을 모두 처리한다. WMUX_SOCKET_PATH로 오버라이드 가능.
+const PIPE_NAME = process.env.WMUX_SOCKET_PATH || getPipeName();
 const TIMEOUT_MS = 5000;
+
+// 인증 토큰: 서버는 토큰을 ~/.wmux-auth-token 파일에 쓴다. CLI가 이 파일을
+// 자동으로 읽지 않아 매번 WMUX_AUTH_TOKEN을 수동 주입해야 했다(인증 실패).
+// env 우선, 없으면 토큰 파일에서 읽는다.
+function resolveAuthToken(): string | undefined {
+  if (process.env.WMUX_AUTH_TOKEN) return process.env.WMUX_AUTH_TOKEN;
+  try {
+    const fromFile = fs.readFileSync(getAuthTokenPath(), 'utf8').trim();
+    if (fromFile) return fromFile;
+  } catch {
+    // 파일 없음/권한 없음 — 토큰 없이 진행(서버가 거부하면 호출부에서 처리)
+  }
+  return undefined;
+}
 
 export function sendRequest(
   method: RpcMethod,
@@ -12,7 +32,7 @@ export function sendRequest(
 ): Promise<RpcResponse> {
   return new Promise((resolve, reject) => {
     const id = crypto.randomUUID();
-    const token = process.env.WMUX_AUTH_TOKEN;
+    const token = resolveAuthToken();
     const request: RpcRequest = { id, method, params, token };
 
     const socket = net.connect(PIPE_NAME);

--- a/src/cli/commands/pane.ts
+++ b/src/cli/commands/pane.ts
@@ -4,28 +4,32 @@ import type { RpcResponse } from '../../shared/rpc';
 
 interface PaneInfo {
   id: string;
-  type: 'leaf' | 'branch';
-  direction?: string;
-  activeSurfaceId?: string;
+  surfaceCount?: number;
+  active?: boolean;
+  cwd?: string;
 }
 
 function formatPaneList(result: unknown): void {
-  const list = result as PaneInfo[];
-  if (!Array.isArray(list) || list.length === 0) {
+  // pane.list RPC는 { asOfSeq, bootId, panes: [...] } 형태를 반환한다. 과거엔
+  // result 자체를 PaneInfo[]로 캐스트해 Array.isArray가 항상 false → 팬이
+  // 있어도 "No panes found"로 표시되던 버그가 있었다(--json은 정상). panes를
+  // 추출해서 렌더한다.
+  const panes = (result as { panes?: unknown } | null)?.panes;
+  const list = Array.isArray(panes) ? (panes as PaneInfo[]) : [];
+  if (list.length === 0) {
     console.log('No panes found.');
     return;
   }
   const maxId = Math.max(...list.map((p) => p.id.length));
-  console.log('ID'.padEnd(maxId + 2) + 'TYPE'.padEnd(8) + 'DETAILS');
-  console.log('-'.repeat(maxId + 30));
+  console.log('ID'.padEnd(maxId + 2) + 'SURFACES'.padEnd(10) + 'ACTIVE'.padEnd(8) + 'CWD');
+  console.log('-'.repeat(maxId + 40));
   for (const p of list) {
-    let details = '';
-    if (p.type === 'leaf' && p.activeSurfaceId) {
-      details = `active surface: ${p.activeSurfaceId}`;
-    } else if (p.type === 'branch' && p.direction) {
-      details = `direction: ${p.direction}`;
-    }
-    console.log(p.id.padEnd(maxId + 2) + p.type.padEnd(8) + details);
+    console.log(
+      p.id.padEnd(maxId + 2) +
+        String(p.surfaceCount ?? '').padEnd(10) +
+        (p.active ? 'yes' : 'no').padEnd(8) +
+        (p.cwd ?? ''),
+    );
   }
 }
 

--- a/src/daemon/DaemonPTYBridge.ts
+++ b/src/daemon/DaemonPTYBridge.ts
@@ -183,6 +183,16 @@ export class DaemonPTYBridge extends EventEmitter {
     this.muted = muted;
   }
 
+  /**
+   * gate로 확정된 에이전트 표시명(없으면 null). daemon 프로세스 안의
+   * AgentDetector가 배너를 직접 feed받아 설정하므로, main으로의 1회성
+   * session:agent emit 전파(타이밍 race)와 무관하게 권위 있는 값을 준다.
+   * renderer의 detection pull이 이 값을 직접 조회한다.
+   */
+  getLastAgent(): string | null {
+    return this.agentDetector?.getLastAgent() ?? null;
+  }
+
   /** Whether the bridge is currently dropping PTY output. */
   get isMuted(): boolean {
     return this.muted;

--- a/src/daemon/DaemonPTYBridge.ts
+++ b/src/daemon/DaemonPTYBridge.ts
@@ -79,7 +79,12 @@ export class DaemonPTYBridge extends EventEmitter {
     // reach into them the way local-mode PTYBridge does (Codex P1).
     this.activeUnsubscribe = activityMonitor.onActive((ptyId) => {
       this.agentDetector?.resetEmissionState();
-      this.emit('active', { sessionId: ptyId });
+      // gate로 확정된 에이전트 이름을 active 이벤트에 함께 싣는다. main의
+      // DaemonNotificationRouter는 daemon AgentDetector에 직접 닿지 못하지만,
+      // 같은 daemon 프로세스인 여기서는 getLastAgent()가 닿는다. 이게 있어야
+      // idle prompt 패턴이 안 잡히는 에이전트(Claude Code v2.1.x 등)도 running
+      // 상태에서 agentName이 채워진다.
+      this.emit('active', { sessionId: ptyId, agentName: this.agentDetector?.getLastAgent() ?? undefined });
     });
 
     // OSC events → cwd (OSC 7) and prompt/command markers (OSC 133)

--- a/src/daemon/DaemonPTYBridge.ts
+++ b/src/daemon/DaemonPTYBridge.ts
@@ -114,6 +114,18 @@ export class DaemonPTYBridge extends EventEmitter {
 
     // PTY data handler
     const onDataDisposable = ptyProcess.onData((data: string) => {
+      // AgentDetector는 순수 텍스트 분석(side effect 없음)이라 muted 구간에서도
+      // 돌려야 한다. recovery 세션은 첫 resize 전까지 muted인데, 그 사이에
+      // 에이전트 시작 배너("Claude Code vX" 등)가 출력되면 gate 정규식이 영구
+      // 미활성화되어 이후 모든 status 감지가 죽는다(daemon mode agent detection
+      // 갭). feed만 muted 체크 앞으로 끌어올리고, ring buffer write·emit 등
+      // side effect는 여전히 muted로 차단해 geometry mismatch 오염은 막는다.
+      try {
+        agentDetector.feed(data);
+      } catch {
+        // detection 실패가 데이터 포워딩을 막아선 안 된다.
+      }
+
       // Muted: drop the chunk before any side effect. Recovery sessions
       // run muted until their first resize so the geometry mismatch
       // window (Bug 2 in v2.8.0) doesn't pollute the ring buffer.
@@ -123,7 +135,6 @@ export class DaemonPTYBridge extends EventEmitter {
         ringBuffer.write(buf);
         activityMonitor.feed(sessionId, buf.length);
         oscParser.process(data);
-        agentDetector.feed(data);
 
         // Prompt-based CWD detection
         promptBuffer += data;

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -8,7 +8,7 @@ import type { DaemonSession, DaemonSessionState, DaemonConfig } from './types';
 import { RingBuffer } from './RingBuffer';
 import { DaemonPTYBridge } from './DaemonPTYBridge';
 import { PromptEventLog } from './PromptEventLog';
-import { buildSpawnInjection } from './shell-integration';
+import { buildSpawnInjection, classifyShell } from './shell-integration';
 import { buildSafeChildEnv } from '../shared/envFilter';
 import { isMac } from '../shared/platform';
 import { getWindowsDefaultShell, resolveBareShellName, resolveLaunchableWindowsExe } from '../shared/shellResolution';
@@ -220,6 +220,13 @@ export class DaemonSessionManager extends EventEmitter {
     try {
       const injection = buildSpawnInjection(cmd);
       if (injection) {
+        // zsh ZDOTDIR 가로채기: injection이 ZDOTDIR을 wmux 디렉토리로 덮어쓰기
+        // 전에, 사용자의 원래 ZDOTDIR(없으면 HOME)을 WMUX_USER_ZDOTDIR로 보존한다.
+        // stub .zshenv/.zshrc가 이 값으로 사용자 설정을 복원하므로, 보존을
+        // 빠뜨리면 사용자 .zshrc(PATH/alias 등)가 통째로 날아간다.
+        if (classifyShell(cmd) === 'zsh' && !env['WMUX_USER_ZDOTDIR']) {
+          env['WMUX_USER_ZDOTDIR'] = env['ZDOTDIR'] || env['HOME'] || os.homedir();
+        }
         spawnArgs = injection.args;
         for (const [k, v] of Object.entries(injection.env)) {
           env[k] = v;

--- a/src/daemon/__tests__/shellIntegration.test.ts
+++ b/src/daemon/__tests__/shellIntegration.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { classifyShell, buildSpawnInjection } from '../shell-integration';
+
+// zsh 지원(macOS 기본 셸) — ZDOTDIR 가로채기 방식의 핵심 불변식 검증.
+describe('classifyShell', () => {
+  it('zsh를 분류한다 (경로/이름/로그인 셸 형태)', () => {
+    expect(classifyShell('/bin/zsh')).toBe('zsh');
+    expect(classifyShell('zsh')).toBe('zsh');
+    expect(classifyShell('-zsh')).toBe('zsh'); // 로그인 셸은 argv[0]에 '-' 접두
+  });
+
+  it('기존 셸 분류는 그대로 유지한다', () => {
+    expect(classifyShell('/bin/bash')).toBe('bash');
+    expect(classifyShell('pwsh')).toBe('pwsh');
+    expect(classifyShell('powershell.exe')).toBe('pwsh');
+    expect(classifyShell('/usr/bin/fish')).toBeNull();
+    expect(classifyShell('')).toBeNull();
+  });
+});
+
+describe('buildSpawnInjection — zsh', () => {
+  it('zsh는 ZDOTDIR을 wmux zsh 디렉토리로 설정한다', () => {
+    const inj = buildSpawnInjection('/bin/zsh');
+    expect(inj).not.toBeNull();
+    // ZDOTDIR 가로채기: wmux 디렉토리를 가리켜야 OSC 133 stub이 로드된다.
+    expect(inj?.env.ZDOTDIR).toMatch(/shell-integration[\\/]zsh$/);
+    expect(inj?.env.WMUX_SHELL_INTEGRATION).toBe('1');
+    expect(inj?.args).toContain('-i');
+  });
+
+  it('알 수 없는 셸은 injection이 없다(일반 spawn)', () => {
+    expect(buildSpawnInjection('/usr/bin/fish')).toBeNull();
+    expect(buildSpawnInjection('cmd.exe')).toBeNull();
+  });
+});

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -3,10 +3,11 @@ import path from 'node:path';
 import os from 'node:os';
 import type { DaemonConfig } from './types';
 import { getWindowsDefaultShell } from '../shared/shellResolution';
+import { dataSuffix } from '../shared/constants';
 
-/** ~/.wmux directory */
+/** ~/.wmux directory (인스턴스 격리 suffix 반영 — main에서 상속된 WMUX_DATA_SUFFIX) */
 export function getWmuxDir(): string {
-  return path.join(os.homedir(), '.wmux');
+  return path.join(os.homedir(), `.wmux${dataSuffix()}`);
 }
 
 /** Path to daemon config file */
@@ -24,13 +25,13 @@ function getDefaultShell(): string {
   return process.env.SHELL || '/bin/sh';
 }
 
-/** Generate default pipe name for current platform */
+/** Generate default pipe name for current platform (격리 suffix 반영) */
 function getDefaultPipeName(): string {
   const username = os.userInfo().username || 'default';
   if (process.platform === 'win32') {
-    return `\\\\.\\pipe\\wmux-daemon-${username}`;
+    return `\\\\.\\pipe\\wmux-daemon${dataSuffix()}-${username}`;
   }
-  return path.join(os.homedir(), '.wmux-daemon.sock');
+  return path.join(os.homedir(), `.wmux-daemon${dataSuffix()}.sock`);
 }
 
 /**

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -964,11 +964,14 @@ function wireEvents(
     pipeServer.broadcast(event);
   });
 
-  sessionManager.on('session:active', (payload: { sessionId: string }) => {
+  sessionManager.on('session:active', (payload: { sessionId: string; agentName?: string }) => {
     const event: DaemonEvent = {
       type: 'activity.active',
       sessionId: payload.sessionId,
-      data: null,
+      // gate로 확정된 에이전트 이름을 data에 실어 main으로 전달한다(없으면 null).
+      // daemon mode running 상태에 agentName을 채우는 경로(local mode는
+      // PTYBridge가 getLastAgent로 직접 처리).
+      data: payload.agentName ?? null,
     };
     pipeServer.broadcast(event);
   });

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -741,6 +741,15 @@ function registerRpcHandlers(
     return sessionManager.listSessions();
   });
 
+  // daemon.getAgentName — daemon AgentDetector가 gate로 확정한 에이전트 표시명을
+  // 직접 조회한다. renderer detection pull의 권위 소스: main으로의 session:agent
+  // emit 전파(타이밍 race)를 우회해, 배너 매칭이 됐다면 항상 정답을 준다.
+  pipeServer.onRpc('daemon.getAgentName', async (params) => {
+    const id = typeof params['id'] === 'string' ? params['id'] : '';
+    const session = id ? sessionManager.getSession(id) : undefined;
+    return { agentName: session?.bridge.getLastAgent() ?? null };
+  });
+
   // daemon.readPromptEvents — read structured OSC 133 prompt/command events
   // from a session's PromptEventLog. Falls back to an empty response when the
   // session doesn't exist so callers can degrade gracefully.

--- a/src/daemon/shell-integration.ts
+++ b/src/daemon/shell-integration.ts
@@ -12,13 +12,14 @@ import { getWmuxDir } from './config';
  * Coverage:
  *   - PowerShell 5.1 / 7+  (powershell.exe, pwsh.exe)
  *   - Bash 4.4+            (Git Bash, WSL)
+ *   - zsh 5.x              (macOS 기본 셸 — ZDOTDIR 가로채기 방식)
  *
  * Explicitly NOT covered:
  *   - cmd.exe              (no prompt hook, OSC 133 is a no-op there)
- *   - zsh / fish           (v3 roadmap)
+ *   - fish                 (v3 roadmap)
  */
 
-const INTEGRATION_VERSION = 3;
+const INTEGRATION_VERSION = 4;
 const VERSION_FILE = '.version';
 
 // -----------------------------------------------------------------------
@@ -156,6 +157,77 @@ esac
 `;
 
 // -----------------------------------------------------------------------
+// zsh 5.x (macOS 기본 셸) — ZDOTDIR 가로채기 방식.
+//
+// zsh는 bash의 --rcfile 같은 옵션이 없다. 대신 시작 시 $ZDOTDIR(미설정 시
+// $HOME)의 .zshenv → .zprofile → .zshrc → .zlogin을 로드한다. 그래서 wmux는
+// ZDOTDIR을 자기 디렉토리로 바꿔 띄우고, 그 안의 stub들이 사용자의 원래 zsh
+// 파일을 먼저 source한 뒤(WMUX_USER_ZDOTDIR로 원래 위치 전달) .zshrc에서만
+// OSC 133 hook을 추가한다. VS Code / iTerm2와 동일한 표준 기법.
+//
+// 핵심 안전장치: 사용자 설정을 절대 잃지 않도록 4개 파일 모두 원래 것을
+// source하고, .zshrc 끝에서 ZDOTDIR을 사용자 값으로 복원해 이후 셸 동작이
+// 평소와 동일하게 유지되게 한다.
+// -----------------------------------------------------------------------
+
+// 공통: 원래 ZDOTDIR(없으면 HOME) 위임. <hook>은 파일별 OSC 133 추가분.
+const ZSH_ENV = `# wmux shell integration — zsh .zshenv stub (v${INTEGRATION_VERSION})
+__wmux_uzd="\${WMUX_USER_ZDOTDIR:-$HOME}"
+[ -r "$__wmux_uzd/.zshenv" ] && source "$__wmux_uzd/.zshenv"
+`;
+
+const ZSH_PROFILE = `# wmux shell integration — zsh .zprofile stub (v${INTEGRATION_VERSION})
+__wmux_uzd="\${WMUX_USER_ZDOTDIR:-$HOME}"
+[ -r "$__wmux_uzd/.zprofile" ] && source "$__wmux_uzd/.zprofile"
+`;
+
+const ZSH_LOGIN = `# wmux shell integration — zsh .zlogin stub (v${INTEGRATION_VERSION})
+__wmux_uzd="\${WMUX_USER_ZDOTDIR:-$HOME}"
+[ -r "$__wmux_uzd/.zlogin" ] && source "$__wmux_uzd/.zlogin"
+`;
+
+const ZSH_RC = `# wmux shell integration — OSC 133 semantic markers (zsh, v${INTEGRATION_VERSION})
+# Emits prompt/command boundaries so wmux's daemon can index command output.
+
+__wmux_uzd="\${WMUX_USER_ZDOTDIR:-$HOME}"
+
+# 사용자의 실제 .zshrc를 먼저 로드해 alias/PATH/테마(oh-my-zsh 등)를 보존한다.
+[ -r "$__wmux_uzd/.zshrc" ] && source "$__wmux_uzd/.zshrc"
+
+# ZDOTDIR을 사용자 값으로 되돌린다. 이후 서브셸/재로드가 평소처럼 동작하도록.
+if [ "$__wmux_uzd" = "$HOME" ]; then
+  unset ZDOTDIR
+else
+  export ZDOTDIR="$__wmux_uzd"
+fi
+
+# 옵트아웃: WMUX_SHELL_INTEGRATION=0 이면 OSC 133 markers를 달지 않는다.
+if [ "\${WMUX_SHELL_INTEGRATION:-1}" = "0" ]; then
+  return 0 2>/dev/null
+fi
+
+# preexec: 명령 실행 직전 → C (command start)
+__wmux_preexec() { printf '\\033]133;C\\a'; }
+# precmd: 프롬프트 출력 직전 → D;<exit> (이전 명령 종료) + A (프롬프트 시작)
+__wmux_precmd() { local __ec=$?; printf '\\033]133;D;%d\\a\\033]133;A\\a' "$__ec"; }
+
+autoload -Uz add-zsh-hook 2>/dev/null
+if (( \${+functions[add-zsh-hook]} )); then
+  add-zsh-hook preexec __wmux_preexec
+  add-zsh-hook precmd __wmux_precmd
+else
+  typeset -ga preexec_functions precmd_functions
+  preexec_functions+=(__wmux_preexec)
+  precmd_functions+=(__wmux_precmd)
+fi
+
+# B (프롬프트 끝 / 사용자 입력 시작)을 PROMPT 끝에 한 번만 추가.
+if [[ "$PROMPT" != *"133;B"* ]]; then
+  PROMPT="\${PROMPT}"$'\\033]133;B\\a'
+fi
+`;
+
+// -----------------------------------------------------------------------
 // Installer
 // -----------------------------------------------------------------------
 
@@ -166,6 +238,8 @@ export function getShellIntegrationDir(): string {
 export interface ShellIntegrationPaths {
   pwsh: string;
   bash: string;
+  /** zsh ZDOTDIR로 쓸 디렉토리 (.zshenv/.zprofile/.zlogin/.zshrc 포함). */
+  zshDir: string;
 }
 
 /**
@@ -176,6 +250,7 @@ export function installShellIntegration(): ShellIntegrationPaths {
   const dir = getShellIntegrationDir();
   const pwshPath = path.join(dir, 'wmux-shell-init.ps1');
   const bashPath = path.join(dir, 'wmux-shell-init.bash');
+  const zshDir = path.join(dir, 'zsh');
   const versionPath = path.join(dir, VERSION_FILE);
 
   if (!fs.existsSync(dir)) {
@@ -184,7 +259,12 @@ export function installShellIntegration(): ShellIntegrationPaths {
 
   let needsWrite = true;
   try {
-    if (fs.existsSync(versionPath) && fs.existsSync(pwshPath) && fs.existsSync(bashPath)) {
+    if (
+      fs.existsSync(versionPath) &&
+      fs.existsSync(pwshPath) &&
+      fs.existsSync(bashPath) &&
+      fs.existsSync(path.join(zshDir, '.zshrc'))
+    ) {
       const existing = fs.readFileSync(versionPath, 'utf-8').trim();
       if (existing === String(INTEGRATION_VERSION)) {
         needsWrite = false;
@@ -197,21 +277,31 @@ export function installShellIntegration(): ShellIntegrationPaths {
   if (needsWrite) {
     fs.writeFileSync(pwshPath, PWSH_INIT, { encoding: 'utf-8', mode: 0o600 });
     fs.writeFileSync(bashPath, BASH_INIT, { encoding: 'utf-8', mode: 0o600 });
+    // zsh: ZDOTDIR 디렉토리에 4개 stub 작성 (사용자 설정 위임 + .zshrc만 OSC 133).
+    if (!fs.existsSync(zshDir)) {
+      fs.mkdirSync(zshDir, { recursive: true });
+    }
+    fs.writeFileSync(path.join(zshDir, '.zshenv'), ZSH_ENV, { encoding: 'utf-8', mode: 0o600 });
+    fs.writeFileSync(path.join(zshDir, '.zprofile'), ZSH_PROFILE, { encoding: 'utf-8', mode: 0o600 });
+    fs.writeFileSync(path.join(zshDir, '.zlogin'), ZSH_LOGIN, { encoding: 'utf-8', mode: 0o600 });
+    fs.writeFileSync(path.join(zshDir, '.zshrc'), ZSH_RC, { encoding: 'utf-8', mode: 0o600 });
     fs.writeFileSync(versionPath, String(INTEGRATION_VERSION), { encoding: 'utf-8', mode: 0o600 });
   }
 
-  return { pwsh: pwshPath, bash: bashPath };
+  return { pwsh: pwshPath, bash: bashPath, zshDir };
 }
 
 /**
  * Classify a shell executable path into one of the integration families.
  * Returns null when no known integration exists (e.g. cmd.exe, zsh today).
  */
-export function classifyShell(shellPath: string): 'pwsh' | 'bash' | null {
+export function classifyShell(shellPath: string): 'pwsh' | 'bash' | 'zsh' | null {
   if (!shellPath) return null;
-  const base = path.basename(shellPath).toLowerCase();
+  // 로그인 셸은 argv[0]가 '-zsh'처럼 앞에 '-'가 붙는다.
+  const base = path.basename(shellPath).toLowerCase().replace(/^-/, '');
   if (base === 'powershell.exe' || base === 'pwsh.exe' || base === 'pwsh') return 'pwsh';
   if (base === 'bash.exe' || base === 'bash') return 'bash';
+  if (base === 'zsh') return 'zsh';
   return null;
 }
 
@@ -237,6 +327,16 @@ export function buildSpawnInjection(shellPath: string): SpawnInjection | null {
     return {
       args: ['-NoLogo', '-NoExit', '-Command', `. '${paths.pwsh.replace(/'/g, "''")}'`],
       env: { WMUX_SHELL_INTEGRATION: '1' },
+    };
+  }
+
+  if (kind === 'zsh') {
+    // zsh: ZDOTDIR을 wmux zsh 디렉토리로 바꿔 OSC 133 stub들이 로드되게 한다.
+    // 원래 ZDOTDIR(사용자 .zshrc 위치)은 DaemonSessionManager가 spawn 직전에
+    // WMUX_USER_ZDOTDIR로 보존하므로, stub들이 사용자 설정을 먼저 source한다.
+    return {
+      args: ['-i'],
+      env: { WMUX_SHELL_INTEGRATION: '1', ZDOTDIR: paths.zshDir },
     };
   }
 

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -308,6 +308,20 @@ export class DaemonClient extends EventEmitter {
     };
   }
 
+  /**
+   * daemon AgentDetector가 gate로 확정한 에이전트 표시명을 조회한다(없으면 null).
+   * renderer detection pull의 권위 소스 — session:agent emit 전파 race를 우회한다.
+   */
+  async getAgentName(sessionId: string): Promise<string | null> {
+    try {
+      const result = await this.rpc('daemon.getAgentName', { id: sessionId });
+      const name = (result as { agentName?: unknown })?.agentName;
+      return typeof name === 'string' && name ? name : null;
+    } catch {
+      return null;
+    }
+  }
+
   /** Whether the daemon control pipe is connected. */
   get isConnected(): boolean {
     return this.connected;

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -413,7 +413,11 @@ export class DaemonClient extends EventEmitter {
           this.emit('session:idle', { sessionId: event.sessionId });
           break;
         case 'activity.active':
-          this.emit('session:active', { sessionId: event.sessionId });
+          // data에 실린 gate 확정 agentName(없으면 null)을 함께 전달.
+          this.emit('session:active', {
+            sessionId: event.sessionId,
+            agentName: typeof event.data === 'string' ? event.data : undefined,
+          });
           break;
         case 'agent.event':
           this.emit('session:agent', { sessionId: event.sessionId, event: event.data });

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -4,6 +4,7 @@ import crypto from 'node:crypto';
 import type { RpcResponse, DaemonEvent } from '../shared/rpc';
 import { FLUSH_DONE_MARKER } from '../daemon/SessionPipe';
 import { DAEMON_RPC_TIMEOUT_MS } from '../shared/timeouts';
+import { dataSuffix } from '../shared/constants';
 import { connectWithRetry, type ConnectAttemptResult } from './daemonConnectRetry';
 
 // RCA A2 — single source of truth in shared/timeouts.ts so the renderer's
@@ -521,9 +522,9 @@ export function getDaemonPipeName(): string {
   const path = require('path');
   const username = os.userInfo().username || 'default';
   if (process.platform === 'win32') {
-    return `\\\\.\\pipe\\wmux-daemon-${username}`;
+    return `\\\\.\\pipe\\wmux-daemon${dataSuffix()}-${username}`;
   }
-  return path.join(os.homedir(), '.wmux-daemon.sock');
+  return path.join(os.homedir(), `.wmux-daemon${dataSuffix()}.sock`);
 }
 
 /** Read the daemon auth token from disk. Returns empty string if not found. */

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -163,6 +163,23 @@ appInit();
 
 function appInit(): void {
 
+// 인스턴스 격리: dev 빌드(!app.isPackaged)는 packaged 빌드 및 다른 체크아웃의
+// 빌드와 SingletonLock·userData·소켓·~/.wmux를 공유해 충돌한다(둘 다 productName
+// "wmux"). dev일 때 WMUX_DATA_SUFFIX='-dev'를 박아 모든 경로(소켓/토큰/데몬/홈)를
+// 격리하고, userData도 분리한다. daemon은 spawn 시 이 env를 상속받아 같은 suffix
+// 경로를 쓴다. packaged 기본은 suffix 빈 문자열이라 기존 경로와 100% 동일.
+// setPath('userData')는 app ready 전에 호출해야 효력이 있으므로 lock 체크보다 먼저 둔다.
+if (!app.isPackaged && !process.env.WMUX_DATA_SUFFIX) {
+  process.env.WMUX_DATA_SUFFIX = '-dev';
+}
+if (process.env.WMUX_DATA_SUFFIX) {
+  try {
+    app.setPath('userData', app.getPath('userData') + process.env.WMUX_DATA_SUFFIX);
+  } catch (err) {
+    console.error('[Main] userData 격리 setPath 실패:', err);
+  }
+}
+
 let isQuitting = false;
 // tmux-style persistence: a normal Quit (window-close intercept / tray
 // "Quit (keep sessions running)") only DETACHES from the daemon — live PTY
@@ -842,13 +859,26 @@ app.on('ready', async () => {
   mainWindow.on('closed', () => {
     mainWindow = null;
   });
+  // dev에서 Vite dev server가 아직 준비 전이거나(포트 점유로 5174 지연) 죽었을 때
+  // did-fail-load가 발생한다. 기존엔 2초 고정 간격으로 무한 reload해 콘솔을
+  // ERR_CONNECTION_REFUSED로 도배했다. 지수 백오프 + 재시도 상한으로 교체한다.
+  let didFailLoadCount = 0;
   mainWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription) => {
+    // ERR_ABORTED(-3): 새 내비게이션이 이전 로드를 정상 취소한 경우 — 재시도 불필요.
+    if (errorCode === -3) return;
     console.error('[Main] Page failed to load:', errorCode, errorDescription);
+    didFailLoadCount += 1;
+    if (didFailLoadCount > 10) {
+      console.error('[Main] did-fail-load 10회 초과 — 자동 reload 중단. dev server(npm start)나 빌드 자산을 확인하세요.');
+      return;
+    }
+    const delay = Math.min(500 * 2 ** (didFailLoadCount - 1), 30_000);
     setTimeout(() => {
       if (mainWindow && !mainWindow.isDestroyed()) mainWindow.reload();
-    }, 2000);
+    }, delay);
   });
   mainWindow.webContents.on('did-finish-load', () => {
+    didFailLoadCount = 0; // 로드 성공 — 백오프 카운터 리셋
     console.log('[Main] Page loaded successfully');
   });
   // M0-e — hydrate MetadataStore from disk, then wire the persist callback

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -292,6 +292,17 @@ function markDaemonReady(): void {
 // live `daemonClient` value via closure, which means a renderer that
 // reloaded after a mid-session daemon disconnect still gets a truthful
 // answer instead of a cached stale one.
+// renderer가 agentStatus='running'을 받았는데 그 ptyId의 agentName이 아직
+// 비어 있을 때 호출한다(1회성 session:agent emit을 매핑 준비 전에 놓친 경우).
+// daemon AgentDetector를 직접 조회한다 — router 캐시(lastAgentNameByPty)는
+// session:agent emit 도착에 의존해 같은 race를 타므로 쓰지 않는다. daemon은
+// 배너를 직접 feed받아 lastAgent를 설정하므로 전파 race와 무관한 권위 소스다.
+ipcMain.handle('detection:resolveAgent', async (_e, ptyId: string) => {
+  const id = typeof ptyId === 'string' ? ptyId : '';
+  if (!id) return null;
+  return (await daemonClient?.getAgentName(id)) ?? null;
+});
+
 ipcMain.handle('daemon:get-ready-state', async () => {
   if (!daemonReadyDecided) {
     await new Promise<void>((resolve) => {

--- a/src/main/ipc/__tests__/wrapHandler.test.ts
+++ b/src/main/ipc/__tests__/wrapHandler.test.ts
@@ -93,6 +93,17 @@ describe('wrapHandler', () => {
     expect(entry.error_code).toBe('RESOURCE_EXHAUSTED' satisfies IpcErrorCode);
   });
 
+  it('classifies a daemon "rate limited" error as RESOURCE_EXHAUSTED', async () => {
+    // DaemonPipeServer rate-limit. 분류 없이는 UNKNOWN → '알 수 없는 오류'
+    // 토스트/콘솔 도배가 된다(리사이즈 burst 등).
+    const wrapped = wrapHandler('pty:create', (_event: unknown) => {
+      throw new Error('rate limited');
+    });
+    await expect(wrapped({} as never)).rejects.toThrow();
+    const entry = parseLoggedEntry(writtenLines[0]);
+    expect(entry.error_code).toBe('RESOURCE_EXHAUSTED' satisfies IpcErrorCode);
+  });
+
   it('stamps the RESOURCE_EXHAUSTED code into the message prefix', async () => {
     const err = new Error(
       'Cannot create new terminal: 200 active sessions already running. ' +

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -464,6 +464,12 @@ export function registerPTYHandlers(
           return;
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);
+          // 데몬 rate-limit(DaemonPipeServer)은 창 리사이즈 burst 중 일시적으로
+          // 발생한다. pty:resize는 연속 이벤트라 이번 것을 조용히 흘려도 곧 다음
+          // resize가 정확한 크기를 싣고 온다(리사이즈 종료 시 빈도가 떨어져
+          // 마지막 이벤트는 통과). 재시도하면 부하만 가중되고, throw하면
+          // '[UNKNOWN] rate limited'가 콘솔을 도배한다 — graceful swallow.
+          if (msg.toLowerCase().includes('rate limit')) return;
           const isNotFound = msg.includes('not found') || msg.includes('not exist');
           if (!isNotFound) throw err;
           if (attempt === RESIZE_RETRY_ATTEMPTS - 1) {

--- a/src/main/ipc/wrapHandler.ts
+++ b/src/main/ipc/wrapHandler.ts
@@ -111,6 +111,13 @@ function classifyError(err: unknown): IpcErrorCode {
     return 'RESOURCE_EXHAUSTED';
   }
 
+  // 데몬 rate-limit(DaemonPipeServer PER_SOCKET/GLOBAL_RATE_LIMIT). 리사이즈
+  // burst 등 일시적 부하 신호다. UNKNOWN으로 두면 콘솔/토스트가 '알 수 없는
+  // 오류'로 도배되므로 RESOURCE_EXHAUSTED로 분류한다.
+  if (lower.includes('rate limit')) {
+    return 'RESOURCE_EXHAUSTED';
+  }
+
   return 'UNKNOWN';
 }
 

--- a/src/main/notification/DaemonNotificationRouter.ts
+++ b/src/main/notification/DaemonNotificationRouter.ts
@@ -307,18 +307,17 @@ export class DaemonNotificationRouter {
       }
     };
 
-    const onActive = (payload: { sessionId: string }) => {
+    const onActive = (payload: { sessionId: string; agentName?: string }) => {
       try {
-        // Intentionally omit `agentName`: the daemon's AgentDetector owns
-        // the last-agent name, and we can't reach into it from main. If we
-        // emitted `agentName: ''` here, the renderer's Object.assign would
-        // clobber the legitimate name set by the previous session:agent
-        // event, making the sidebar label flicker to blank on every burst.
-        // Leaving the field out preserves the prior name; the next
-        // session:agent event will refresh it.
+        // daemon이 active 이벤트에 gate로 확정한 agentName을 실어 보낸다(있으면).
+        // 이게 있어야 idle prompt 패턴이 안 잡히는 에이전트(Claude Code v2.1.x:
+        // 입력대기 hint가 "❯"만 남음)도 running 상태에서 agentName이 채워진다.
+        // 없으면 필드를 생략해 이전 이름을 보존한다 — 빈 문자열로 덮으면 renderer의
+        // Object.assign이 정당한 이름을 지워 사이드바 라벨이 매 버스트마다 깜빡인다.
         broadcastMetadataUpdate(this.getWindow(), {
           ptyId: payload.sessionId,
           agentStatus: 'running',
+          ...(payload.agentName ? { agentName: payload.agentName } : {}),
         });
       } catch (err) {
         console.warn('[DaemonNotificationRouter] session:active error:', err);

--- a/src/main/pipe/handlers/pane.rpc.ts
+++ b/src/main/pipe/handlers/pane.rpc.ts
@@ -69,6 +69,19 @@ export function registerPaneRpc(
       Record<string, unknown> & { id?: unknown; metadata?: unknown }
     >;
 
+    // renderer가 paneGate 미준비(부팅 중) 등으로 배열 대신 { error, retryable }
+    // 객체를 반환할 수 있다. 그대로 .map()을 돌리면 TypeError로 핸들러가 죽고
+    // 클라이언트엔 의미 없는 에러가 간다. 명시적으로 검사해 retryable 사유를
+    // 그대로 전파한다(클라이언트가 재시도 판단 가능).
+    if (!Array.isArray(panes)) {
+      const errObj = panes as { error?: unknown; retryable?: unknown } | null;
+      const reason =
+        errObj && typeof errObj.error === 'string'
+          ? errObj.error
+          : 'pane.list: renderer returned a non-array response';
+      throw new Error(reason);
+    }
+
     // 2. THEN snapshot the metadata store. asOfSeq is anchored to the pane
     //    tree we just received: any event with seq > asOfSeq describes a
     //    delta relative to the panes[] the client is about to read.

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -107,7 +107,10 @@ const AGENT_PATTERNS: AgentPattern[] = [
   {
     agent: 'Claude Code',
     slug: 'claude',
-    gate: /Claude Code|claude-code|╭.*Claude/,
+    // \s* — Claude Code TUI는 배너 "Claude Code"를 셀 단위 커서 이동으로 그려,
+    // ANSI strip 후 "Claude"와 "Code" 사이 공백이 사라진 "ClaudeCode"가 된다.
+    // 공백을 선택적으로 둬야 daemon mode에서도 gate가 매칭된다(핵심 race 원인).
+    gate: /Claude\s*Code|claude-code|╭.*Claude/,
     patterns: [
       // Waiting — Claude Code's unique idle prompt fragments.
       //
@@ -324,6 +327,32 @@ export class AgentDetector {
     for (const line of lines) {
       this.processLine(line);
     }
+
+    // 미완성 라인(아직 개행이 안 온 redraw)의 gate도 미리 검사한다. claude처럼
+    // 시작 배너를 개행 없이 커서 이동으로 그리는 TUI는 "Claude Code vX"가
+    // lineBuffer에 갇혀 라인 완성이 영영 안 될 수 있고, 그러면 gate가 chunk
+    // 타이밍에 따라 가끔만 매칭돼 agentName 감지가 불안정해진다. patterns는
+    // 라인 완성 후에만 검사하지만(부분 매칭 오탐 방지), gate는 활성화 신호일
+    // 뿐이라 미완성 라인에서 미리 봐도 안전하다.
+    const tail = this.lineBuffer.replace(ANSI_STRIP, '').trim();
+    if (tail) this.checkGates(tail);
+  }
+
+  /**
+   * gate 매칭 → 에이전트 활성화 + 'running' 시작 이벤트 1회 emit + lastAgent
+   * 설정. 라인 완성 여부와 무관하게 호출할 수 있도록 분리(feed의 미완성 라인
+   * 검사와 processLine 양쪽에서 사용). activeAgents 가드로 세션당 1회만 발화.
+   */
+  private checkGates(clean: string): void {
+    for (const ap of AGENT_PATTERNS) {
+      if (ap.gate && !this.activeAgents.has(ap.agent) && ap.gate.test(clean)) {
+        this.activeAgents.add(ap.agent);
+        this.lastAgent = ap.agent;
+        for (const cb of this.callbacks) {
+          cb({ agent: ap.agent, status: 'running', message: 'Agent started' });
+        }
+      }
+    }
   }
 
   private processLine(line: string): void {
@@ -345,20 +374,11 @@ export class AgentDetector {
     }
 
     // Check agent gates — activate agents when their gate pattern matches.
-    // gate가 처음 매칭되는 순간 'running'으로 한 번 emit한다. 이렇게 하면
-    // 에이전트별 idle prompt 패턴(Claude의 "bypass permissions on" 등)이
-    // 버전에 따라 사라져도(예: Claude Code v2.1.x는 입력대기 hint가 "❯"만
-    // 남음) 시작 배너(gate)만으로 agentName이 확정된다 — detection이 patterns
-    // 유지보수에 덜 의존하게 된다. activeAgents 가드로 세션당 1회만 발화한다.
-    for (const ap of AGENT_PATTERNS) {
-      if (ap.gate && !this.activeAgents.has(ap.agent) && ap.gate.test(clean)) {
-        this.activeAgents.add(ap.agent);
-        this.lastAgent = ap.agent;
-        for (const cb of this.callbacks) {
-          cb({ agent: ap.agent, status: 'running', message: 'Agent started' });
-        }
-      }
-    }
+    // gate가 처음 매칭되는 순간 'running'으로 한 번 emit한다(checkGates). idle
+    // prompt 패턴(Claude의 "bypass permissions on" 등)이 버전에 따라 사라져도
+    // (Claude Code v2.1.x는 입력대기 hint가 "❯"만 남음) 시작 배너(gate)만으로
+    // agentName이 확정된다.
+    this.checkGates(clean);
 
     // Only check patterns for agents that are confirmed active (gate matched)
     for (const ap of AGENT_PATTERNS) {

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -344,10 +344,19 @@ export class AgentDetector {
       }
     }
 
-    // Check agent gates — activate agents when their gate pattern matches
+    // Check agent gates — activate agents when their gate pattern matches.
+    // gate가 처음 매칭되는 순간 'running'으로 한 번 emit한다. 이렇게 하면
+    // 에이전트별 idle prompt 패턴(Claude의 "bypass permissions on" 등)이
+    // 버전에 따라 사라져도(예: Claude Code v2.1.x는 입력대기 hint가 "❯"만
+    // 남음) 시작 배너(gate)만으로 agentName이 확정된다 — detection이 patterns
+    // 유지보수에 덜 의존하게 된다. activeAgents 가드로 세션당 1회만 발화한다.
     for (const ap of AGENT_PATTERNS) {
       if (ap.gate && !this.activeAgents.has(ap.agent) && ap.gate.test(clean)) {
         this.activeAgents.add(ap.agent);
+        this.lastAgent = ap.agent;
+        for (const cb of this.callbacks) {
+          cb({ agent: ap.agent, status: 'running', message: 'Agent started' });
+        }
       }
     }
 

--- a/src/main/pty/__tests__/AgentDetector.test.ts
+++ b/src/main/pty/__tests__/AgentDetector.test.ts
@@ -3,12 +3,28 @@ import { AgentDetector } from '../AgentDetector';
 
 describe('AgentDetector', () => {
   describe('agent status emission', () => {
+    it('gate 매칭 시 "running" 시작 이벤트를 1회 emit한다 (배너만으로 agentName 확정)', () => {
+      // Claude Code v2.1.x처럼 idle prompt hint가 "❯"만 남아 patterns가
+      // 매칭되지 않아도, 시작 배너(gate)만으로 detection이 활성화돼야 한다.
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('Claude Code v2.1.172\n');
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb.mock.calls[0][0]).toMatchObject({ agent: 'Claude Code', status: 'running' });
+      expect(det.getLastAgent()).toBe('Claude Code');
+      // 같은 세션에서 배너가 다시 나와도 재발화하지 않는다 (activeAgents 가드).
+      det.feed('Claude Code v2.1.172\n');
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
     it('emits "waiting" for "shift+tab to cycle" Claude prompt', () => {
       const det = new AgentDetector();
       const cb = vi.fn();
       det.onEvent(cb);
-      // gate first
+      // gate first — gate 매칭은 'running' 시작 이벤트를 발화하므로 분리해 무시
       det.feed('Claude Code starting up\n');
+      cb.mockClear();
       det.feed('  shift+tab to cycle modes\n');
       expect(cb).toHaveBeenCalledTimes(1);
       expect(cb.mock.calls[0][0]).toMatchObject({ agent: 'Claude Code', status: 'waiting' });
@@ -19,6 +35,7 @@ describe('AgentDetector', () => {
       const cb = vi.fn();
       det.onEvent(cb);
       det.feed('Claude Code starting up\n');
+      cb.mockClear(); // gate 'running' 무시 — esc 라인 자체는 emit하면 안 된다
       det.feed('press esc to interrupt\n');
       // Previously this falsely emitted 'waiting'. After the fix, no agent
       // event should fire for this line.
@@ -56,6 +73,7 @@ describe('AgentDetector', () => {
       const cb = vi.fn();
       const unsub = det.onEvent(cb);
       det.feed('Claude Code starting up\n');
+      cb.mockClear(); // gate 'running' 분리
       det.feed('  shift+tab to cycle\n');
       expect(cb).toHaveBeenCalledTimes(1);
 
@@ -73,6 +91,7 @@ describe('AgentDetector', () => {
       det.onEvent(b);
       unsubA();
       det.feed('Claude Code\n');
+      b.mockClear(); // gate 'running' 분리 (a는 이미 unsub됨)
       det.feed('  shift+tab to cycle\n');
       expect(a).not.toHaveBeenCalled();
       expect(b).toHaveBeenCalledTimes(1);
@@ -85,6 +104,7 @@ describe('AgentDetector', () => {
       const cb = vi.fn();
       det.onEvent(cb);
       det.feed('Claude Code\n');
+      cb.mockClear(); // gate 'running' 분리
       det.feed('  shift+tab to cycle\n');
       det.feed('  shift+tab to cycle\n');
       det.feed('  shift+tab to cycle\n');
@@ -96,6 +116,7 @@ describe('AgentDetector', () => {
       const cb = vi.fn();
       det.onEvent(cb);
       det.feed('Claude Code\n');
+      cb.mockClear(); // gate 'running' 분리
       det.feed('  shift+tab to cycle\n');
       expect(cb).toHaveBeenCalledTimes(1);
 
@@ -109,6 +130,7 @@ describe('AgentDetector', () => {
       const cb = vi.fn();
       det.onEvent(cb);
       det.feed('aider v0.50.0\n');
+      cb.mockClear(); // gate 'running' 분리
       det.feed('aider>\n');
       det.feed('Applied edit to src/foo.ts\n');
       expect(cb).toHaveBeenCalledTimes(2);
@@ -123,7 +145,8 @@ describe('AgentDetector', () => {
       const cb = vi.fn();
       det.onEvent(cb);
       det.feed('Claude Code\n  shift+tab to cycle\n');
-      expect(cb).toHaveBeenCalledTimes(1);
+      // gate 'running' + 패턴 'waiting' = 2 emit. 분리되지 않았다면 0이다.
+      expect(cb).toHaveBeenCalledTimes(2);
     });
 
     it('splits on lone \\r (carriage return redraw)', () => {
@@ -134,7 +157,7 @@ describe('AgentDetector', () => {
       const cb = vi.fn();
       det.onEvent(cb);
       det.feed('Claude Code\r  shift+tab to cycle\r');
-      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenCalledTimes(2); // gate 'running' + 'waiting'
     });
 
     it('keeps \\r\\n intact (no double-split)', () => {
@@ -142,7 +165,7 @@ describe('AgentDetector', () => {
       const cb = vi.fn();
       det.onEvent(cb);
       det.feed('Claude Code\r\n  shift+tab to cycle\r\n');
-      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenCalledTimes(2); // gate 'running' + 'waiting'
     });
   });
 
@@ -155,6 +178,7 @@ describe('AgentDetector', () => {
       const cb = vi.fn();
       det.onEvent(cb);
       det.feed('\x1b[?25hClaude Code starting\n');
+      cb.mockClear(); // gate 'running' 분리
       det.feed('\x1b[?25l  shift+tab to cycle\n');
       expect(cb).toHaveBeenCalledTimes(1);
     });

--- a/src/main/pty/__tests__/AgentDetector.test.ts
+++ b/src/main/pty/__tests__/AgentDetector.test.ts
@@ -18,6 +18,18 @@ describe('AgentDetector', () => {
       expect(cb).toHaveBeenCalledTimes(1);
     });
 
+    it('개행 없이 미완성 라인에 머무는 시작 배너도 gate 매칭한다 (claude TUI 대응)', () => {
+      // claude는 시작 배너를 개행 없이 커서 이동으로 그려 "Claude Code vX"가
+      // lineBuffer에 갇혀 라인 완성이 안 될 수 있다. 그래도 gate는 검사돼야 한다.
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('Claude Code v2.1.172'); // 개행 없음
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb.mock.calls[0][0]).toMatchObject({ agent: 'Claude Code', status: 'running' });
+      expect(det.getLastAgent()).toBe('Claude Code');
+    });
+
     it('emits "waiting" for "shift+tab to cycle" Claude prompt', () => {
       const det = new AgentDetector();
       const cb = vi.fn();

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -136,6 +136,10 @@ const electronAPI = {
       ipcRenderer.on(IPC.METADATA_UPDATE, listener);
       return () => { ipcRenderer.removeListener(IPC.METADATA_UPDATE, listener); };
     },
+    // gate로 확정된 agentName을 main 캐시에서 pull. running 수신 시 agentName이
+    // 비어 있으면 호출해, 매핑 준비 전에 놓친 1회성 session:agent emit을 메운다.
+    resolveAgent: (ptyId: string) =>
+      ipcRenderer.invoke('detection:resolveAgent', ptyId) as Promise<string | null>,
   },
   rpc: {
     onCommand: (

--- a/src/renderer/hooks/useNotificationListener.ts
+++ b/src/renderer/hooks/useNotificationListener.ts
@@ -325,6 +325,18 @@ export function useNotificationListener() {
             // Only update CWD from the active pane's active surface to prevent
             // stale PTYs from overwriting the current directory.
             applyToWorkspace(ws.id, !isActivePtySurface(ws, ptyId));
+            // agentStatus='running'은 주기적으로 오지만 agentName(session:agent
+            // gate emit)은 1회성이라, ptyId↔surface 매핑이 준비되기 전에 발화하면
+            // 영영 유실된다. 매핑이 생긴 지금(running 수신 + agentName 비어 있음)
+            // main의 lastAgentNameByPty 캐시에서 race-free하게 pull해 메운다.
+            if (rest.agentStatus === 'running' && !ws.metadata?.agentName) {
+              const targetWsId = ws.id;
+              void window.electronAPI.metadata.resolveAgent(ptyId).then((name) => {
+                if (name) {
+                  useStore.getState().updateWorkspaceMetadata(targetWsId, { agentName: name });
+                }
+              });
+            }
             break;
           }
         }

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -281,7 +281,11 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // spurious row-change events on resize; the dedicated reflow logic
       // suppresses them, which in turn keeps SelectionService from
       // unconditionally clearing the user's selection mid-drag.
-      windowsPty: { backend: 'conpty', buildNumber: 21376 },
+      // macOS/Linux PTY는 ConPTY가 아니므로 이 reflow 경로를 켜면 오히려
+      // focus/resize 시 줄바꿈이 어긋나 글자가 깨진다(좌측 팬 garble). win32 한정.
+      ...(window.electronAPI.platform === 'win32'
+        ? { windowsPty: { backend: 'conpty' as const, buildNumber: 21376 } }
+        : {}),
     });
 
     const fitAddon = new FitAddon();

--- a/src/shared/__tests__/constants.test.ts
+++ b/src/shared/__tests__/constants.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  dataSuffix,
+  getPipeName,
+  getAuthTokenPath,
+  getWmuxHomeDir,
+  getPidMapDir,
+  getTcpPortPath,
+} from '../constants';
+
+// WMUX_DATA_SUFFIX 기반 인스턴스 격리. dev 빌드와 packaged 빌드(또는 다른
+// 체크아웃의 빌드)가 같은 소켓·토큰·~/.wmux를 두고 충돌하던 문제를 막는다.
+describe('dataSuffix 인스턴스 격리', () => {
+  const orig = process.env.WMUX_DATA_SUFFIX;
+  afterEach(() => {
+    if (orig === undefined) delete process.env.WMUX_DATA_SUFFIX;
+    else process.env.WMUX_DATA_SUFFIX = orig;
+  });
+
+  it('suffix 미설정(packaged 기본) 시 기존 경로를 그대로 유지한다', () => {
+    delete process.env.WMUX_DATA_SUFFIX;
+    expect(dataSuffix()).toBe('');
+    expect(getAuthTokenPath()).toMatch(/\.wmux-auth-token$/);
+    expect(getWmuxHomeDir()).toMatch(/\.wmux$/);
+    expect(getPidMapDir()).toMatch(/\.wmux[\\/]pid-map$/);
+    if (process.platform !== 'win32') {
+      expect(getPipeName()).toMatch(/\.wmux\.sock$/);
+    }
+  });
+
+  it('suffix 설정 시 모든 경로(소켓/토큰/홈/pid-map/tcp)에 격리가 반영된다', () => {
+    process.env.WMUX_DATA_SUFFIX = '-dev';
+    expect(dataSuffix()).toBe('-dev');
+    expect(getAuthTokenPath()).toMatch(/\.wmux-dev-auth-token$/);
+    expect(getWmuxHomeDir()).toMatch(/\.wmux-dev$/);
+    expect(getPidMapDir()).toMatch(/\.wmux-dev[\\/]pid-map$/);
+    expect(getTcpPortPath()).toMatch(/\.wmux-dev-tcp-port$/);
+    if (process.platform === 'win32') {
+      expect(getPipeName()).toContain('wmux-dev-');
+    } else {
+      expect(getPipeName()).toMatch(/\.wmux-dev\.sock$/);
+    }
+  });
+
+  it('핵심 불변식: packaged 경로와 dev 경로는 절대 겹치지 않는다', () => {
+    delete process.env.WMUX_DATA_SUFFIX;
+    const packagedPipe = getPipeName();
+    const packagedHome = getWmuxHomeDir();
+    const packagedToken = getAuthTokenPath();
+
+    process.env.WMUX_DATA_SUFFIX = '-dev';
+    expect(getPipeName()).not.toBe(packagedPipe);
+    expect(getWmuxHomeDir()).not.toBe(packagedHome);
+    expect(getAuthTokenPath()).not.toBe(packagedToken);
+  });
+});

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -124,6 +124,15 @@ export const IPC = {
 // well clear of Node's own 1/2/9-ish fatal codes.
 export const DAEMON_EXIT_ALREADY_RUNNING = 75;
 
+// 인스턴스 격리용 경로 suffix. main 프로세스가 dev 빌드(!app.isPackaged)에서
+// WMUX_DATA_SUFFIX='-dev'를 설정하고, daemon은 spawn 시 env로 이를 상속한다.
+// 이 헬퍼를 모든 소켓/토큰/디렉토리 경로에 적용해, dev 빌드와 packaged 빌드(또는
+// 다른 체크아웃의 빌드)가 같은 SingletonLock·소켓·~/.wmux를 두고 충돌하지 않게
+// 한다. 미설정(packaged 기본) 시 빈 문자열이라 기존 경로와 100% 동일.
+export function dataSuffix(): string {
+  return process.env.WMUX_DATA_SUFFIX || '';
+}
+
 // Named Pipe / Unix socket path for wmux API
 // Fixed name so MCP clients (e.g. Claude Code) can reconnect across wmux restarts
 export function getPipeName(): string {
@@ -131,10 +140,10 @@ export function getPipeName(): string {
     // Use os.userInfo() instead of process.env.USERNAME — env vars may not
     // be inherited by MCP subprocesses spawned by Claude Code
     const username = require('os').userInfo().username || 'default';
-    return `\\\\.\\pipe\\wmux-${username}`;
+    return `\\\\.\\pipe\\wmux${dataSuffix()}-${username}`;
   }
   const home = require('os').homedir() || '/tmp';
-  return `${home}/.wmux.sock`;
+  return `${home}/.wmux${dataSuffix()}.sock`;
 }
 
 // Environment variable names injected into PTY sessions
@@ -150,21 +159,20 @@ export const ENV_KEYS = {
 // Auth token file path — written by wmux main process, read by MCP server
 export function getAuthTokenPath(): string {
   const home = process.env.USERPROFILE || process.env.HOME || '';
-  return `${home}/.wmux-auth-token`;
+  return `${home}/.wmux${dataSuffix()}-auth-token`;
 }
 
 // PID-to-workspace mapping directory — written by PTYManager, read by MCP server
 // to resolve workspace identity when env vars don't propagate through Claude Code
 export function getPidMapDir(): string {
-  const home = process.env.USERPROFILE || process.env.HOME || '';
-  return `${home}/.wmux/pid-map`;
+  return `${getWmuxHomeDir()}/pid-map`;
 }
 
 // TCP port file path — written by PipeServer, read by MCP clients as fallback
 // when Windows named pipe EPERM blocks direct pipe connections
 export function getTcpPortPath(): string {
   const home = process.env.USERPROFILE || process.env.HOME || '';
-  return `${home}/.wmux-tcp-port`;
+  return `${home}/.wmux${dataSuffix()}-tcp-port`;
 }
 
 // wmux user home directory — root for plugin-trust.json, pid-map/, and other
@@ -172,7 +180,7 @@ export function getTcpPortPath(): string {
 // of truth so callers don't reimplement the USERPROFILE/HOME dance.
 export function getWmuxHomeDir(): string {
   const home = process.env.USERPROFILE || process.env.HOME || '';
-  return `${home}/.wmux`;
+  return `${home}/.wmux${dataSuffix()}`;
 }
 
 // Plugin trust database — see `docs/api/mcp-plugin-spec.md`. Written by main


### PR DESCRIPTION
## 요약

wmux를 macOS(arm64)에서 클론·빌드·dogfood하며 발견한 **macOS 버그 7건을 수정**하고, substrate("LSP-for-terminals") 핵심 기능을 Windows와 동등하게 동작시켰습니다. 모든 수정은 packaged 빌드에서 실측 검증 + 단위 테스트(누적 580+ 통과)를 거쳤습니다.

> 배경: README는 "native Windows / ConPTY"라 하지만 실체는 Electron + node-pty(darwin-arm64 prebuilt 포함)라 macOS에서 그대로 구동됩니다. 다만 Windows 가정이 곳곳에 박혀 substrate가 조용히 깨져 있었습니다.

## 커밋별 수정

| 영역 | 내용 | 검증 |
|---|---|---|
| focus 글자 깨짐 + CLI 연결 | `windowsPty`(ConPTY reflow)를 win32 한정 분기 / CLI 소켓·토큰 자동 해석 | 스크린샷 비교, env 없이 CLI 동작 |
| 인스턴스 격리 + keychain + did-fail-load | `WMUX_DATA_SUFFIX`로 dev/packaged 경로 격리 / Fuse 조건부 / 백오프 | A·B 인스턴스 공존, keychain 에러 소멸 |
| resize rate-limit + pane.list | resize rate-limit graceful swallow / pane.list 타입·CLI 표시 버그 | 콘솔 도배 0건, list-panes 정상 |
| agent detection (muted) | daemon mode에서 `agentDetector.feed`를 muted 체크 앞으로 | agentStatus idle→running |
| **zsh OSC 133** | ZDOTDIR 가로채기로 zsh shell integration (macOS 기본 셸) | osc133 이벤트 0→7건, exitCode 캡처, 사용자 PATH 보존 |
| agent detection (배너 활성화) | gate 매칭 시 emit + lastAgent 설정 | — |
| **agentName race 완전 해결** | gate 공백 선택적(`\s*`) + daemon 직접 pull | claude 7회 연속 agentName='Claude Code' (수정 전 비결정적) |

## Substrate dogfood 결과 (raw RPC)

- ✅ pane metadata **atomic claim** (`VERSION_CONFLICT`로 동시 claim 거부)
- ✅ events.poll (seq 기반 이벤트 스트림)
- ✅ A2A (whoami/broadcast)
- ✅ **Claude Code 실행 + 감지** (wmux PTY에서 v2.1.172 부팅, agentStatus='running' + agentName='Claude Code')
- ✅ **OSC 133 시맨틱 명령 경계** (zsh 지원 추가 — 이전엔 macOS 기본 셸에서 무용)

## agentName race 근본 원인 (참고)

Claude Code TUI가 시작 배너 "Claude Code"를 셀 단위 커서 이동으로 그려, ANSI strip 후 공백이 사라진 "ClaudeCode"가 됩니다. gate `/Claude Code/`가 공백을 강제해 daemon AgentDetector가 매칭에 실패했고(lastAgent=null), 그 위의 모든 detection 경로가 무용이었습니다. 공백을 `\s*`로 바꾸고, renderer가 running 수신 시 daemon AgentDetector를 직접 pull(emit 전파 race 우회)하도록 해 결정적으로 해결했습니다.