### PR TITLE
fix(mcp): pin Playwright auto-open to the calling session's workspace (#190)

### DIFF
--- a/src/mcp/__tests__/workspaceRouting.test.ts
+++ b/src/mcp/__tests__/workspaceRouting.test.ts
@@ -130,11 +130,9 @@ describe('MCP workspace routing (source-level invariants)', () => {
   it('PlaywrightEngine auto-open is wired to requireWorkspaceId (#190)', () => {
     // getPage()'s auto-open issues browser.open OUTSIDE any tool handler, so
     // the per-tool requireWorkspaceId() guard (invariant 2) cannot cover it.
-    // index.ts must inject the strict resolver into the engine; the engine
-    // fails closed (skips auto-open) on a resolve miss. Without this wiring a
-    // workspace-less browser.open reaches the renderer, which binds the new
-    // surface to the UI-active workspace at IPC-handling time — the wrong
-    // workspace whenever the user switches during the open attempt.
+    // index.ts injects the strict resolver into the engine so auto-open is
+    // pinned to the calling session and fails closed (skips auto-open) on a
+    // resolve miss, never reaching the renderer's active-workspace fallback.
     expect(src).toMatch(/setWorkspaceIdResolver\(\s*requireWorkspaceId\s*\)/);
   });
 

--- a/src/mcp/__tests__/workspaceRouting.test.ts
+++ b/src/mcp/__tests__/workspaceRouting.test.ts
@@ -127,6 +127,17 @@ describe('MCP workspace routing (source-level invariants)', () => {
     }
   });
 
+  it('PlaywrightEngine auto-open is wired to requireWorkspaceId (#190)', () => {
+    // getPage()'s auto-open issues browser.open OUTSIDE any tool handler, so
+    // the per-tool requireWorkspaceId() guard (invariant 2) cannot cover it.
+    // index.ts must inject the strict resolver into the engine; the engine
+    // fails closed (skips auto-open) on a resolve miss. Without this wiring a
+    // workspace-less browser.open reaches the renderer, which binds the new
+    // surface to the UI-active workspace at IPC-handling time — the wrong
+    // workspace whenever the user switches during the open attempt.
+    expect(src).toMatch(/setWorkspaceIdResolver\(\s*requireWorkspaceId\s*\)/);
+  });
+
   it('browser_session_start is GLOBAL — carries no workspace identity (no resolver calls)', () => {
     // Session start manages a single global profile + CDP port; the RPC handler
     // ignores workspaceId. Requiring identity here would protect no routing and

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -291,6 +291,14 @@ registerFileTools(server);
 registerUtilityTools(server);
 registerExtractionTools(server);
 
+// The engine's auto-open (getPage Strategy 4) issues browser.open outside any
+// tool handler, so it cannot rely on the per-tool requireWorkspaceId() guard
+// above (#190). Inject the strict resolver so the auto-opened surface is
+// pinned to this session's workspace; on a resolve miss the engine fails
+// closed (skips auto-open) instead of sending a workspace-less browser.open,
+// which the renderer would bind to the UI-active workspace.
+PlaywrightEngine.getInstance().setWorkspaceIdResolver(requireWorkspaceId);
+
 // === Browser session tools ===
 
 server.tool(

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -293,10 +293,9 @@ registerExtractionTools(server);
 
 // The engine's auto-open (getPage Strategy 4) issues browser.open outside any
 // tool handler, so it cannot rely on the per-tool requireWorkspaceId() guard
-// above (#190). Inject the strict resolver so the auto-opened surface is
-// pinned to this session's workspace; on a resolve miss the engine fails
-// closed (skips auto-open) instead of sending a workspace-less browser.open,
-// which the renderer would bind to the UI-active workspace.
+// above. Inject the strict resolver so the auto-opened surface is pinned to
+// this session's workspace; on a resolve miss the engine fails closed (skips
+// auto-open) rather than opening in an unspecified workspace.
 PlaywrightEngine.getInstance().setWorkspaceIdResolver(requireWorkspaceId);
 
 // === Browser session tools ===

--- a/src/mcp/playwright/PlaywrightEngine.ts
+++ b/src/mcp/playwright/PlaywrightEngine.ts
@@ -124,13 +124,12 @@ export class PlaywrightEngine {
    */
   private shellUrl: string | null = null;
   /**
-   * Resolves the calling session's workspace id for auto-open (#190). Wired
-   * by src/mcp/index.ts to requireWorkspaceId(). Auto-open issues browser.open
-   * outside any MCP tool handler, so the per-tool requireWorkspaceId() guard
-   * cannot cover it; without this resolver the RPC would carry no workspaceId
-   * and the renderer would bind the new surface to the UI-active workspace at
-   * IPC-handling time — the wrong workspace whenever the user switches while
-   * the open attempt is in flight.
+   * Resolves the calling session's workspace id for auto-open. Wired by
+   * src/mcp/index.ts to requireWorkspaceId(). Auto-open issues browser.open
+   * outside any MCP tool handler, so it cannot use the per-tool
+   * requireWorkspaceId() guard and carries the resolved id explicitly instead.
+   * null means no resolver is wired, in which case auto-open is skipped (fail
+   * closed) rather than opening in an unspecified workspace.
    */
   private workspaceIdResolver: (() => Promise<string>) | null = null;
 
@@ -341,9 +340,12 @@ export class PlaywrightEngine {
         // This eliminates the requirement for callers to call browser_open first.
         if (attempt === 1 && !this.autoOpenAttempted) {
           console.error('[PlaywrightEngine] No page found — auto-opening browser surface');
-          this.autoOpenAttempted = true;
           try {
             if (await this.attemptAutoOpen()) {
+              // Latch only once the RPC actually went out, so a fail-closed
+              // skip (no resolver / unresolved identity) leaves a later call
+              // free to retry instead of spending the one-shot attempt.
+              this.autoOpenAttempted = true;
               // Wait for the webview to register its CDP target
               await sleep(2000);
               await this.disconnect();

--- a/src/mcp/playwright/PlaywrightEngine.ts
+++ b/src/mcp/playwright/PlaywrightEngine.ts
@@ -123,8 +123,22 @@ export class PlaywrightEngine {
    * Refreshed on every browser.cdp.info response and cleared on disconnect.
    */
   private shellUrl: string | null = null;
+  /**
+   * Resolves the calling session's workspace id for auto-open (#190). Wired
+   * by src/mcp/index.ts to requireWorkspaceId(). Auto-open issues browser.open
+   * outside any MCP tool handler, so the per-tool requireWorkspaceId() guard
+   * cannot cover it; without this resolver the RPC would carry no workspaceId
+   * and the renderer would bind the new surface to the UI-active workspace at
+   * IPC-handling time — the wrong workspace whenever the user switches while
+   * the open attempt is in flight.
+   */
+  private workspaceIdResolver: (() => Promise<string>) | null = null;
 
   private constructor() {}
+
+  setWorkspaceIdResolver(resolver: () => Promise<string>): void {
+    this.workspaceIdResolver = resolver;
+  }
 
   static getInstance(): PlaywrightEngine {
     if (!PlaywrightEngine.instance) {
@@ -329,12 +343,13 @@ export class PlaywrightEngine {
           console.error('[PlaywrightEngine] No page found — auto-opening browser surface');
           this.autoOpenAttempted = true;
           try {
-            await sendRpc('browser.open', {});
-            // Wait for the webview to register its CDP target
-            await sleep(2000);
-            await this.disconnect();
-            await this.ensureConnected();
-            continue; // retry page discovery
+            if (await this.attemptAutoOpen()) {
+              // Wait for the webview to register its CDP target
+              await sleep(2000);
+              await this.disconnect();
+              await this.ensureConnected();
+              continue; // retry page discovery
+            }
           } catch (openErr) {
             console.error('[PlaywrightEngine] Auto-open failed:', openErr instanceof Error ? openErr.message : String(openErr));
           }
@@ -365,6 +380,37 @@ export class PlaywrightEngine {
     // Without this, one early failure permanently blocks all Playwright page discovery.
     setTimeout(() => { this.playwrightFailed = false; this.autoOpenAttempted = false; }, 10_000);
     return null;
+  }
+
+  /**
+   * Issue the auto-open browser.open RPC, pinned to the calling session's
+   * workspace. Fails closed: when no resolver is wired or identity cannot be
+   * resolved, NO RPC is sent (returns false) — a workspace-less browser.open
+   * would let the renderer fall back to the UI-active workspace (#190). The
+   * caller then proceeds to the normal "no page" retry/error path, surfacing
+   * the existing "Call browser_open first" guidance to the user.
+   */
+  private async attemptAutoOpen(): Promise<boolean> {
+    if (!this.workspaceIdResolver) {
+      console.error('[PlaywrightEngine] Auto-open skipped: no workspace resolver wired');
+      return false;
+    }
+    let workspaceId: string;
+    try {
+      workspaceId = await this.workspaceIdResolver();
+    } catch (err) {
+      console.error(
+        '[PlaywrightEngine] Auto-open skipped: workspace identity unresolved:',
+        err instanceof Error ? err.message : String(err),
+      );
+      return false;
+    }
+    if (!workspaceId) {
+      console.error('[PlaywrightEngine] Auto-open skipped: empty workspace id');
+      return false;
+    }
+    await sendRpc('browser.open', { workspaceId });
+    return true;
   }
 
   /**

--- a/src/mcp/playwright/__tests__/PlaywrightEngine.test.ts
+++ b/src/mcp/playwright/__tests__/PlaywrightEngine.test.ts
@@ -335,3 +335,96 @@ describe('PlaywrightEngine runtime shell-URL handling (B)', () => {
     expect(priv(engine).shellUrl).toBe(shellUrl);
   });
 });
+
+/*
+ * Regression tests for auto-open workspace routing (#190).
+ *
+ * Background: when getPage() finds no CDP-discoverable page, Strategy 4
+ * auto-opens a browser surface via the browser.open RPC. A workspace-less
+ * browser.open is bound by the renderer (useRpcBridge.ts) to
+ * store.activeWorkspaceId AT IPC-HANDLING TIME — so if the user switches
+ * workspaces while the open attempt is in flight, the surface lands in the
+ * newly active workspace instead of the calling session's. The engine must
+ * therefore send the session's workspaceId (resolved via the strict resolver
+ * wired by src/mcp/index.ts), and must fail closed — issue NO browser.open at
+ * all — when identity cannot be resolved.
+ */
+
+// Minimal access to the engine's auto-open surface. setWorkspaceIdResolver is
+// public API; attemptAutoOpen is private and reached the same way the
+// shell-URL tests reach their internals.
+interface AutoOpenInternals {
+  setWorkspaceIdResolver(resolver: () => Promise<string>): void;
+  attemptAutoOpen(): Promise<boolean>;
+}
+function autoOpen(engine: PlaywrightEngine): AutoOpenInternals {
+  return engine as unknown as AutoOpenInternals;
+}
+
+describe('PlaywrightEngine auto-open workspace routing (#190)', () => {
+  beforeEach(() => {
+    (PlaywrightEngine as unknown as { instance: PlaywrightEngine | null }).instance = null;
+    mockSendRpc.mockReset();
+    mockConnectOverCDP.mockReset();
+  });
+
+  it('sends browser.open with the workspaceId from the wired resolver', async () => {
+    const engine = PlaywrightEngine.getInstance();
+    autoOpen(engine).setWorkspaceIdResolver(async () => 'ws-caller-1');
+    mockSendRpc.mockResolvedValue({});
+
+    await expect(autoOpen(engine).attemptAutoOpen()).resolves.toBe(true);
+
+    expect(mockSendRpc).toHaveBeenCalledWith('browser.open', { workspaceId: 'ws-caller-1' });
+  });
+
+  it('fails closed — no browser.open RPC — when the resolver throws', async () => {
+    const engine = PlaywrightEngine.getInstance();
+    autoOpen(engine).setWorkspaceIdResolver(async () => {
+      throw new Error('Workspace identity unknown');
+    });
+
+    await expect(autoOpen(engine).attemptAutoOpen()).resolves.toBe(false);
+
+    expect(mockSendRpc).not.toHaveBeenCalledWith('browser.open', expect.anything());
+  });
+
+  it('fails closed when the resolver returns an empty id', async () => {
+    const engine = PlaywrightEngine.getInstance();
+    autoOpen(engine).setWorkspaceIdResolver(async () => '');
+
+    await expect(autoOpen(engine).attemptAutoOpen()).resolves.toBe(false);
+
+    expect(mockSendRpc).not.toHaveBeenCalledWith('browser.open', expect.anything());
+  });
+
+  it('fails closed when no resolver is wired', async () => {
+    const engine = PlaywrightEngine.getInstance();
+
+    await expect(autoOpen(engine).attemptAutoOpen()).resolves.toBe(false);
+
+    expect(mockSendRpc).not.toHaveBeenCalledWith('browser.open', expect.anything());
+  });
+
+  it('getPage never issues a workspace-less browser.open when identity is unavailable', async () => {
+    // End-to-end through the page-discovery loop: no page exists anywhere and
+    // no resolver is wired. The misrouting shape is browser.open carrying no
+    // workspaceId — the renderer then falls back to the UI-active workspace.
+    // The engine must skip auto-open entirely (fail closed) and give up.
+    const sessions: FakeSession[] = [];
+    mockConnectOverCDP.mockImplementation(async () => makeFakeBrowser(sessions));
+    mockSendRpc.mockImplementation((method: string) => {
+      if (method === 'browser.cdp.info') {
+        return Promise.resolve({ cdpPort: 59222, targets: [] });
+      }
+      return Promise.resolve({});
+    });
+
+    const engine = PlaywrightEngine.getInstance();
+    const page = await engine.getPage();
+
+    expect(page).toBeNull();
+    const browserOpenCalls = mockSendRpc.mock.calls.filter((c) => c[0] === 'browser.open');
+    expect(browserOpenCalls).toHaveLength(0);
+  }, 15_000);
+});

--- a/src/mcp/playwright/__tests__/PlaywrightEngine.test.ts
+++ b/src/mcp/playwright/__tests__/PlaywrightEngine.test.ts
@@ -337,17 +337,16 @@ describe('PlaywrightEngine runtime shell-URL handling (B)', () => {
 });
 
 /*
- * Regression tests for auto-open workspace routing (#190).
+ * Auto-open workspace routing invariants (#190).
  *
- * Background: when getPage() finds no CDP-discoverable page, Strategy 4
- * auto-opens a browser surface via the browser.open RPC. A workspace-less
- * browser.open is bound by the renderer (useRpcBridge.ts) to
- * store.activeWorkspaceId AT IPC-HANDLING TIME — so if the user switches
- * workspaces while the open attempt is in flight, the surface lands in the
- * newly active workspace instead of the calling session's. The engine must
- * therefore send the session's workspaceId (resolved via the strict resolver
- * wired by src/mcp/index.ts), and must fail closed — issue NO browser.open at
- * all — when identity cannot be resolved.
+ * When getPage() finds no CDP-discoverable page, Strategy 4 auto-opens a
+ * browser surface via the browser.open RPC. The renderer (useRpcBridge.ts)
+ * binds a workspace-less browser.open to store.activeWorkspaceId at
+ * IPC-handling time, so auto-open must carry the calling session's workspaceId
+ * (resolved via the strict resolver wired by src/mcp/index.ts) to pin the
+ * surface to the right workspace, and must fail closed — issue no browser.open
+ * at all — when identity cannot be resolved, rather than open in an
+ * unspecified workspace.
  */
 
 // Minimal access to the engine's auto-open surface. setWorkspaceIdResolver is
@@ -386,7 +385,7 @@ describe('PlaywrightEngine auto-open workspace routing (#190)', () => {
 
     await expect(autoOpen(engine).attemptAutoOpen()).resolves.toBe(false);
 
-    expect(mockSendRpc).not.toHaveBeenCalledWith('browser.open', expect.anything());
+    expect(mockSendRpc.mock.calls.filter((c) => c[0] === 'browser.open')).toHaveLength(0);
   });
 
   it('fails closed when the resolver returns an empty id', async () => {
@@ -395,7 +394,7 @@ describe('PlaywrightEngine auto-open workspace routing (#190)', () => {
 
     await expect(autoOpen(engine).attemptAutoOpen()).resolves.toBe(false);
 
-    expect(mockSendRpc).not.toHaveBeenCalledWith('browser.open', expect.anything());
+    expect(mockSendRpc.mock.calls.filter((c) => c[0] === 'browser.open')).toHaveLength(0);
   });
 
   it('fails closed when no resolver is wired', async () => {
@@ -403,7 +402,7 @@ describe('PlaywrightEngine auto-open workspace routing (#190)', () => {
 
     await expect(autoOpen(engine).attemptAutoOpen()).resolves.toBe(false);
 
-    expect(mockSendRpc).not.toHaveBeenCalledWith('browser.open', expect.anything());
+    expect(mockSendRpc.mock.calls.filter((c) => c[0] === 'browser.open')).toHaveLength(0);
   });
 
   it('getPage never issues a workspace-less browser.open when identity is unavailable', async () => {
@@ -426,5 +425,51 @@ describe('PlaywrightEngine auto-open workspace routing (#190)', () => {
     expect(page).toBeNull();
     const browserOpenCalls = mockSendRpc.mock.calls.filter((c) => c[0] === 'browser.open');
     expect(browserOpenCalls).toHaveLength(0);
+  }, 15_000);
+
+  it('getPage auto-opens with the session workspaceId, then returns the new webview', async () => {
+    // Full loop: no page on the first pass, so Strategy 4 auto-opens. The
+    // browser.open must carry the wired session id; after it lands, the webview
+    // surfaces and getPage returns it. This is the only test that exercises the
+    // id flowing through _getPageImpl -> attemptAutoOpen -> browser.open and on
+    // to a returned page, so a regression that dropped the id would fail here.
+    const shellUrl = 'file:///app/.vite/renderer/main_window/index.html';
+    let opened = false;
+
+    const webviewPage: FakePage = {
+      url: vi.fn().mockReturnValue('https://example.com/'),
+      context: vi.fn(),
+    };
+    const ctx = {
+      pages: vi.fn().mockImplementation(() => (opened ? [webviewPage] : [])),
+      newCDPSession: vi.fn().mockImplementation(async () => makeFakeSession()),
+    };
+    webviewPage.context.mockReturnValue(ctx);
+
+    const browser = {
+      isConnected: vi.fn().mockReturnValue(true),
+      newBrowserCDPSession: vi.fn().mockImplementation(async () => makeFakeSession()),
+      contexts: vi.fn().mockImplementation(() => (opened ? [ctx] : [])),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    mockConnectOverCDP.mockResolvedValue(browser);
+    mockSendRpc.mockImplementation((method: string) => {
+      if (method === 'browser.cdp.info') {
+        return Promise.resolve({ cdpPort: 9222, shellUrl, targets: [] });
+      }
+      if (method === 'browser.open') {
+        opened = true;
+        return Promise.resolve({ ok: true });
+      }
+      return Promise.resolve({});
+    });
+
+    const engine = PlaywrightEngine.getInstance();
+    autoOpen(engine).setWorkspaceIdResolver(async () => 'ws-caller-1');
+
+    const page = await engine.getPage();
+
+    expect(page).toBe(webviewPage);
+    expect(mockSendRpc).toHaveBeenCalledWith('browser.open', { workspaceId: 'ws-caller-1' });
   }, 15_000);
 });


### PR DESCRIPTION
## Summary

`PlaywrightEngine.getPage()` Strategy-4 auto-open issued the `browser.open` RPC with no `workspaceId`, so the renderer bound the new browser surface to `store.activeWorkspaceId` at IPC-handling time — opening the browser in whichever workspace the user switched to during the (multi-second) open attempt, rather than the calling session's workspace. This pins auto-open to the session's workspace and fails closed when identity can't be resolved.

## Changes

- Inject a workspace resolver into the `PlaywrightEngine` singleton (`setWorkspaceIdResolver`), wired in `src/mcp/index.ts` to `requireWorkspaceId` — the same strict resolver the explicit `browser_open` tool already uses.
- `attemptAutoOpen()` resolves the session's `workspaceId` and sends it with `browser.open`; it **fails closed** (sends no RPC) when no resolver is wired, the resolver throws, or it returns an empty id — falling through to the existing "Call browser_open first" path instead of misrouting.
- Latch `autoOpenAttempted` only once the RPC actually goes out, so a fail-closed skip leaves a later `getPage()` call free to retry within the 10s window.
- Tests: 5 unit/e2e cases for auto-open routing (happy path through the full `getPage` loop + 4 fail-closed paths) and a source-level invariant locking the `index.ts` wiring.

## CHANGELOG entry

### Fixed

- Browser surfaces opened by Playwright tools (`browser_snapshot`, `browser_click`, etc.) when no browser exists yet now open in the requesting agent session's workspace instead of whichever workspace is currently active in the UI. (#190)

## Stability tier impact

- [x] Change to an `internal` surface (no contract impact).

No MCP tool signature or RPC wire shape changes — `browser.open` already accepted `workspaceId`. Only internal auto-open routing behavior is corrected; the workspace-resolver injection is internal plumbing.

## Substrate contract impact (Substrate 3.0)

n/a — no PaneMetadata/EventBus/wire-shape change, no new RPC method or event type, and no change to permission enforcement points (`browser.open` carries no ownership assertion, unchanged). The fix only supplies an existing optional field (`workspaceId`) on an existing RPC.

## Test plan

- **Unit tests added** (`src/mcp/playwright/__tests__/PlaywrightEngine.test.ts`): `attemptAutoOpen` sends `browser.open` with the wired `workspaceId`; fails closed on resolver-throw, empty-id, and no-resolver; full-loop e2e (resolver wired → auto-open → webview returned with the id carried through); `getPage` never issues a workspace-less `browser.open` when identity is unavailable.
- **Source invariant** (`src/mcp/__tests__/workspaceRouting.test.ts`): locks `setWorkspaceIdResolver(requireWorkspaceId)` wiring so a future change can't silently drop it — closing the gap that let #96's per-tool guard miss this engine-level caller.
- **Suite**: `npm run test:parallel` → 2666 passed. The single failure (`security.test.ts > secureWriteTokenFile`) is a pre-existing, environment-specific Windows ACL case (non-ASCII `USERNAME`) unrelated to this change. `tsc -p tsconfig.mcp.json` clean; no new lint violations.

## Related issues / PRs

- Closes #190
- Follow-up (not in this PR, to keep it surgical): #194 — the resolver's blocking PID walk (`getParentPid` `execFileSync`, `src/mcp/index.ts`) runs inside `getPageLock`; converting it to async and bounding the resolver are tracked there.

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed. (n/a — no surface change.)
- [x] Tests cover the new behavior and the regression case (if a bug fix).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
