### PR TITLE
fix(mcp): walk the identity PID tree with async execFile, not blocking execFileSync (#194)

### DIFF
--- a/src/mcp/__tests__/pidWalkNonblocking.test.ts
+++ b/src/mcp/__tests__/pidWalkNonblocking.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Source-level invariant lock for the MCP identity PID walk (#194).
+//
+// getParentPid() spawns a child process per hop to walk the PID tree
+// (PowerShell Get-CimInstance on Windows, `ps` elsewhere) up to depth 10, each
+// hop bounded by a multi-second timeout. It runs on the workspace-identity hot
+// path — reached by resolveWorkspaceId/requireWorkspaceId for A2A and browser
+// auto-open, and by resolveTerminalRoute for terminal IO. Using the SYNCHRONOUS
+// execFileSync blocks the Node event loop for the whole walk, freezing every
+// other MCP operation (and, inside PlaywrightEngine's getPageLock, serializing
+// all browser tools behind one slow auto-open). The walk must therefore use the
+// ASYNC execFile so the event loop stays free while each child process runs.
+describe('MCP PID walk is non-blocking (source-level invariant, #194)', () => {
+  const indexPath = path.join(__dirname, '..', 'index.ts');
+  const rawSrc = fs.readFileSync(indexPath, 'utf-8');
+
+  // Strip block + line comments so prose that merely mentions a primitive by
+  // name (e.g. a comment explaining why execFileSync was dropped) never trips
+  // the invariant — only real call sites count.
+  function stripComments(s: string): string {
+    return s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+  }
+  const src = stripComments(rawSrc);
+
+  it('never uses the synchronous execFileSync on the identity hot path', () => {
+    // execFileSync blocks the event loop until the spawned process exits — up to
+    // the per-hop timeout × depth. The PID walk must not use it.
+    expect(src).not.toMatch(/execFileSync/);
+  });
+
+  it('walks the PID tree with the async execFile (promisified)', () => {
+    // The async replacement: import execFile and await a promisified call, so
+    // each child process runs without parking the event loop.
+    expect(src).toMatch(/\bexecFile\b/);
+    expect(src).toMatch(/\bpromisify\b/);
+  });
+});

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -196,19 +196,26 @@ async function isLiveWorkspace(wsId: string): Promise<WorkspaceLiveness> {
 
 async function getParentPid(pid: number): Promise<number | null> {
   try {
-    const { execFileSync } = await import('child_process');
+    // Async execFile (not execFileSync): this walk runs per hop on the
+    // workspace-identity hot path, so a synchronous spawn would park the Node
+    // event loop for the child's whole lifetime — up to the per-hop timeout ×
+    // depth — freezing every other MCP operation. Awaiting a promisified
+    // execFile keeps the loop free while each child process runs.
+    const { execFile } = await import('child_process');
+    const { promisify } = await import('util');
+    const execFileAsync = promisify(execFile);
     if (process.platform === 'win32') {
       const path = await import('path');
       const ps = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
-      const out = execFileSync(ps, [
+      const { stdout } = await execFileAsync(ps, [
         '-NoProfile', '-Command',
         `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}").ParentProcessId`,
       ], { encoding: 'utf8', windowsHide: true, timeout: 5000 });
-      const parsed = parseInt(out.trim(), 10);
+      const parsed = parseInt(stdout.trim(), 10);
       return isNaN(parsed) ? null : parsed;
     } else {
-      const out = execFileSync('ps', ['-o', 'ppid=', '-p', String(pid)], { encoding: 'utf8', timeout: 3000 });
-      return parseInt(out.trim(), 10) || null;
+      const { stdout } = await execFileAsync('ps', ['-o', 'ppid=', '-p', String(pid)], { encoding: 'utf8', timeout: 3000 });
+      return parseInt(stdout.trim(), 10) || null;
     }
   } catch {
     return null;


### PR DESCRIPTION
## Summary

`getParentPid` walked the PID tree with the synchronous `execFileSync`, which parked the Node event loop for the whole walk (a child process per hop — PowerShell `Get-CimInstance` on Windows, `ps` elsewhere — up to depth 10, each bounded by a multi-second timeout). Because this runs on the workspace-identity hot path, a slow walk froze every other MCP operation. Switch to an awaited, promisified `execFile` so the loop stays free while each child process runs.

## Changes

- `getParentPid` (`src/mcp/index.ts`) now awaits a promisified `execFile` instead of calling `execFileSync`. Timeouts, encoding, and the fail-to-`null` behavior are unchanged — only the blocking changes.
- Source-level invariant test locks the contract: the identity PID walk must not use `execFileSync` and must use the async `execFile`.

## CHANGELOG entry

### Fixed

- Workspace-identity resolution (PID-tree walk) no longer blocks the MCP server's event loop while spawning per-hop child processes, so a slow walk on Windows can't freeze unrelated MCP operations. (#194)

## Stability tier impact

- [x] Change to an `internal` surface (no contract impact).

No RPC method, tool signature, or wire shape changes. `getParentPid` is an internal helper; only its blocking characteristic changes (sync → async), with identical observable behavior.

## Substrate contract impact (Substrate 3.0)

n/a — no PaneMetadata/EventBus/wire-shape change, no new RPC method or event type, no change to permission enforcement points. This is an internal implementation change to a private helper.

## Test plan

- **Unit test added** (`src/mcp/__tests__/pidWalkNonblocking.test.ts`): source-level invariant asserting the identity walk does not use `execFileSync` and does use the async `execFile` (promisified). Mirrors the repo's existing source-invariant pattern for `index.ts` (`workspaceRouting.test.ts`), which is testing-via-source because `index.ts` has import-time side effects (it constructs the MCP server).
- **TDD**: RED — both assertions failed against the `execFileSync` implementation; GREEN — pass after the conversion.
- **Suite**: `npm run test:parallel` → identity/routing tests pass (`pidWalkNonblocking`, `workspaceRouting`, `terminalRouting`). The single suite failure (`security.test.ts > secureWriteTokenFile`) is a pre-existing, environment-specific Windows ACL case (non-ASCII `USERNAME`) unrelated to this change. `tsc -p tsconfig.mcp.json` clean; no new lint violations.

## Related issues / PRs

- Closes #194
- Follow-up from #190 (the #190 PR is independent — this branch is cut from `main`, not stacked on it). The remaining "bound the auto-open resolver / move it outside `getPageLock`" idea from #194 is moot once the walk is non-blocking: the `getPageLock` serialization is intended behavior and is bounded by the resolver's own per-hop timeouts.

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed. (n/a — no surface change.)
- [x] Tests cover the new behavior and the regression case (if a bug fix).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
