### PR TITLE
fix(terminal): stop non-selected panes garbling on pane-selection switch (#191)

### DIFF
--- a/src/renderer/hooks/__tests__/useTerminal.atlasClear.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.atlasClear.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// #191 regression lock (source-level).
+//
+// The focus/visible glyph repaint must NEVER clearTextureAtlas. xterm shares
+// one glyph texture atlas across every same-config terminal (CharAtlasCache),
+// so clearing it from one pane empties it for all of them — the non-focused
+// siblings then sample an emptied/repositioned atlas and render garbled or
+// blank glyphs. The repaint repairs only the dirty-region desync, via a
+// full-range refresh, which does not touch the shared atlas.
+//
+// This is the kind of "must not reintroduce X" invariant a future contributor
+// chasing a glyph artifact would naturally break by reaching for
+// clearTextureAtlas. The repaint is an xterm-bound side effect that can't be
+// asserted without a real WebGL context, so the invariant is pinned at the
+// source level (matching the Fix D / A6 regression-lock tests in
+// src/renderer/hooks/__tests__).
+describe('#191 — repaint must not clear the shared texture atlas (source-level)', () => {
+  const hookPath = path.join(__dirname, '..', 'useTerminal.ts');
+  const src = fs.readFileSync(hookPath, 'utf-8');
+
+  // Slice the glyphRepaint scheduler's repaint callback: from the
+  // createGlyphRepaintScheduler call to where the scheduler ref is assigned.
+  const start = src.indexOf('const glyphRepaint = createGlyphRepaintScheduler({');
+  const end = src.indexOf('glyphRepaintRef.current = glyphRepaint;', start);
+  const repaintBlock = src.slice(start, end);
+
+  it('locates the repaint scheduler block', () => {
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+  });
+
+  it('does not call clearTextureAtlas in the repaint path', () => {
+    expect(repaintBlock).not.toMatch(/clearTextureAtlas\(/);
+  });
+
+  it('repairs staleness with a full-range refresh instead', () => {
+    expect(repaintBlock).toMatch(/terminal\.refresh\(0, terminal\.rows - 1\)/);
+  });
+});

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -407,15 +407,14 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     }
     disposeWebglRef.current = disposeWebgl;
 
-    // Issue #166 — defensive repaints for the "garbled glyphs until resize"
-    // corruption. Strategy and trigger rationale live in terminal/glyphRepaint.ts.
-    // Cost split: focus/visible clear the WebGL texture atlas (repairs atlas
-    // corruption; throttled — "focus" fires not just on mouse clicks but on
+    // Issue #166 — defensive full-range repaint for the "garbled glyphs until
+    // resize" corruption (dirty-region desync). Strategy and trigger rationale
+    // live in terminal/glyphRepaint.ts. Every reason (focus / visible / burst)
+    // does a plain full-range refresh; "focus" is throttled because it fires on
     // every keyboard pane-nav / MCP pane.focus via useActivePaneFocus's
-    // term.focus(), so the throttle is load-bearing) AND force a full refresh
-    // (repairs dirty-region desync); burst-settle only refreshes — clearing a
-    // CJK-heavy atlas after every agent output burst would be constant
-    // re-rasterisation.
+    // term.focus(), not just mouse clicks, so the throttle is load-bearing. The
+    // repaint must NOT clearTextureAtlas (see the repaint body): xterm shares one
+    // glyph atlas across same-config panes, so clearing it corrupts the others.
     const glyphRepaint = createGlyphRepaintScheduler({
       repaint: (reason) => {
         if (terminalRef.current !== terminal) return;
@@ -425,13 +424,12 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         // this gate, N background agent panes each schedule a full-range
         // refresh after every output burst.
         if (reason === 'burst' && !isVisibleRef.current) return;
-        if (reason !== 'burst') {
-          try {
-            webglAddonRef.current?.clearTextureAtlas();
-          } catch {
-            // addon may be mid-dispose (pool eviction race) — refresh still runs
-          }
-        }
+        // Do NOT clearTextureAtlas here (#191). xterm shares ONE glyph atlas
+        // across every same-config terminal (CharAtlasCache); clearing it from
+        // one pane empties it for all of them, and siblings that do not rebuild
+        // their model on a focus event then sample an emptied/repositioned atlas
+        // and render garbled or blank glyphs. A full-range refresh repairs only
+        // this pane's dirty-region staleness without mutating the shared atlas.
         try {
           terminal.refresh(0, terminal.rows - 1);
         } catch {
@@ -1210,13 +1208,11 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // ResizeObserver tick (after selection is released) handles the
       // deferred resize naturally.
       const id = requestAnimationFrame(() => {
-        // Issue #166 — repaint BEFORE the selection guard: neither the atlas
-        // clear nor refresh() touches the selection, and a stale pane must
-        // repair on view-switch-back even while a selection is live. Runs
-        // after the pool acquire above, so if a NEW addon was just created
-        // the atlas clear is a cheap no-op on a fresh atlas; the case this
-        // exists for is the fast switch where the old context (and its
-        // possibly stale atlas) was kept alive.
+        // Issue #166 — repaint BEFORE the selection guard: refresh() does not
+        // touch the selection, and a stale pane must repair on view-switch-back
+        // even while a selection is live. This matters most on a fast switch
+        // where the pool kept the old (possibly stale) context alive instead of
+        // rebuilding it.
         glyphRepaintRef.current?.onVisible();
         if (!shouldFitWhilePreservingSelection(terminalRef.current)) {
           console.debug('[Terminal] visibility fit skipped — active selection');

--- a/src/renderer/terminal/glyphRepaint.ts
+++ b/src/renderer/terminal/glyphRepaint.ts
@@ -4,18 +4,16 @@
 // Symptom: a pane's text renders as corrupted/mojibake glyphs after fast
 // output bursts (CJK + box-drawing heavy, several panes updating at once),
 // and stays corrupted until a pane-border drag forces a resize — which is the
-// only code path today that triggers a full xterm repaint. Two known
-// root-cause classes produce exactly this signature:
-//
-//   1. WebGL texture atlas corruption — the addon's glyph cache holds stale
-//      texture data; only `clearTextureAtlas()` (or addon recreate) repairs it.
-//   2. Dirty-region desync — xterm's incremental renderer thinks rows are
-//      clean when their on-screen pixels are stale; a full-range `refresh()`
-//      repairs it.
+// only code path today that triggers a full xterm repaint. This module repairs
+// the dirty-region desync — xterm's incremental renderer treats rows as clean
+// when their on-screen pixels are stale — with a full-range `refresh()`. It
+// does NOT clear the WebGL texture atlas: xterm shares one glyph atlas across
+// same-config terminals (CharAtlasCache), so clearing it from one pane corrupts
+// the others; atlas-level staleness is left to xterm's own page management.
 //
 // The corruption is non-deterministic (driver/timing dependent), so instead of
 // chasing a single trigger we schedule cheap repaints at the moments a user
-// would notice staleness, covering both classes:
+// would notice staleness:
 //
 //   - `focus`   — the pane became the focused pane: mouse click, keyboard
 //                 pane-nav, or the MCP pane.focus bridge (useActivePaneFocus
@@ -28,10 +26,10 @@
 //                 (quiet for burstQuietMs). This is the "watching agent output
 //                 garble live" case where neither focus nor visibility changes.
 //
-// The caller decides repaint cost per reason: focus/visible clear the texture
-// atlas AND refresh (rare, user-initiated); burst only refreshes (frequent
-// under agent workloads — atlas re-rasterisation of a CJK-heavy screen on
-// every burst would be measurable GPU churn for no benefit in class 2).
+// All three reasons run the same full-range refresh; the caller does not vary
+// repaint cost per reason. The refresh never mutates the shared glyph atlas
+// (#191), so it cannot corrupt sibling panes — the burst-visibility gate aside,
+// the only per-reason difference is the throttle on `focus`.
 //
 // This module is pure scheduling logic (timers + counters) so it can be unit
 // tested without xterm; all rendering side effects live in the caller's


### PR DESCRIPTION
## Summary

Switching pane selection no longer garbles the non-selected panes. The focus/visible defensive repaint cleared the WebGL glyph atlas that xterm shares across same-config terminals, which corrupted the sibling panes; it now repairs only the focused pane without touching the shared atlas.

## Changes

- Remove the `clearTextureAtlas()` call from the focus/visible glyph repaint in `useTerminal.ts`. All repaint reasons (focus / visible / burst) now do a full-range `terminal.refresh()` only.
- Update the `#166` / `onVisible` comments in `useTerminal.ts` and the `glyphRepaint.ts` header to describe the refresh-only behavior (they previously documented the now-removed atlas clear).
- Add a source-level regression lock (`useTerminal.atlasClear.test.ts`) asserting the repaint never calls `clearTextureAtlas` again.

## CHANGELOG entry

### Fixed

- Non-selected panes no longer render garbled or blank glyphs when switching pane selection after long use with content-heavy panes (#191).

## Stability tier impact

- [x] No external surface touched (internal refactor / docs / tests / CI).
- [ ] Additive change to a `stable` surface (new optional param, new field, new event type).
- [ ] Breaking change to a `stable` surface (requires major bump — block until release planning is in scope).
- [ ] Change to an `experimental` surface (note in release notes).
- [ ] Change to an `internal` surface (no contract impact).

## Substrate contract impact (Substrate 3.0)

n/a — renderer-only rendering fix; no PaneMetadata, EventBus, permission, Named Pipe, or RPC/event surface touched.

## Test plan

- Unit tests added / updated: `src/renderer/hooks/__tests__/useTerminal.atlasClear.test.ts` — source-level regression lock that the glyph-repaint callback never calls `clearTextureAtlas` (and still does the full-range refresh). Matches the existing `useTerminal.daemonReattach` / A6 source-level lock pattern, since the repaint is an xterm-bound side effect that can't be asserted without a real WebGL context.
- Existing `glyphRepaint` and `webglContextPool` unit tests unchanged and passing.
- Manual verification: ran the dev build, split into content-heavy panes, switched pane selection repeatedly. Confirmed via an A/B toggle (fixed build vs. the pre-fix build that still calls `clearTextureAtlas`) that the garble reproduces only with the atlas clear present and is gone without it.
- `tsc --noEmit` clean; renderer test suite passing (223 tests).

## Related issues / PRs

Closes #191

Root cause: xterm's WebGL addon shares one glyph texture atlas across every terminal with the same render config (font / theme / DPR) via the module-global `CharAtlasCache`. The #166 focus/visible repaint called `WebglAddon.clearTextureAtlas()`, which empties that **shared** atlas and re-rasterises only the newly-focused pane's glyphs at fresh positions; the other (non-focused) panes do not rebuild their render model on a focus event, so they keep stale per-cell texture coordinates and render against a repositioned/emptied atlas — appearing garbled or blank. Dropping the focus/visible clear leaves the shared atlas untouched; the `#166` "garbled glyphs after a burst" case is still covered by the burst-path `refresh()`, which never cleared the atlas.

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed. (n/a — no surface change)
- [x] Tests cover the new behavior and the regression case (if a bug fix).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.
