### PR TITLE
feat(cli): X4 wmux CLI — verified self-pane identity, PATH shim install, command surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`wmux` CLI on your PATH, with verified self-pane identity (X4).** The installer now drops a `wmux` command onto the user PATH (regenerated on every update, removed on uninstall), so any shell — inside or outside wmux — can script the app: `wmux send "npm test" --submit`, `wmux read-screen`, `wmux notify "Done" "Build finished"`, `wmux open http://localhost:3000`, `wmux split`, `wmux list-workspaces --json`. Run inside a wmux pane, terminal commands target **the pane you typed them in** — identity is resolved by walking the CLI's own process tree against the PID map (the same verified identity the MCP terminal tools use, never the spoofable/stale env hint), and the zero-spawn fast path covers the common shell-direct case. `--pane <ptyId>` targets another pane explicitly, `--active` keeps the old UI-focused-pane behavior, and notifications/browser opens route to the calling workspace automatically. The CLI client also gained the TCP-localhost fallback for Windows named-pipe ACL edge cases.
+
+### Changed
+- **`a2a.resolve.identity` now returns pane-level `entries`** (`pid` + `ptyId` + `workspaceId`) alongside the existing `mappings` — additive; existing MCP clients are unaffected.
+
 ## [3.1.1] — 2026-06-12 — browser pane wired into the workflow, IME input self-healing
 
 Headline: the embedded browser pane is now reachable from where you actually work — terminal URLs route smartly, sidebar port badges open localhost in one click, and browser panes restore on the page you last visited. And the field-reported "keyboard input dies until you toggle multiview" IME failure on Korean Windows now self-heals: the suspect textarea-clearing is off by default and a storm guard detects the dead-input signature and resyncs the IME automatically.

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -108,7 +108,7 @@ const config: ForgeConfig = {
     // wmux itself and every bundled npm dep. Electron's own LICENSE
     // (covering Chromium / V8 / Node) is emitted automatically by
     // electron-packager next to wmux.exe, so we don't duplicate it here.
-    extraResource: ['./dist/mcp-bundle', './dist/daemon-bundle', './assets/icon.ico', './assets/icon.icns', './assets/icon.png', './LICENSE', './THIRD_PARTY_NOTICES', './src/main/pty/shell-hooks'],
+    extraResource: ['./dist/mcp-bundle', './dist/daemon-bundle', './dist/cli-bundle', './assets/icon.ico', './assets/icon.icns', './assets/icon.png', './LICENSE', './THIRD_PARTY_NOTICES', './src/main/pty/shell-hooks'],
     // macOS 서명/노타라이즈는 packagerConfig가 아니라 postPackage hook 끝에서
     // 수행한다(signMacAppIfConfigured 주석 참고). 여기서 서명하면 postPackage의
     // node-pty 복사가 서명을 깨뜨리기 때문이다.

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "postinstall": "node scripts/fix-node-pty.js",
     "start": "npm run build:daemon && npm run build:mcp && electron-forge start",
-    "package": "npm run build:daemon && npm run build:mcp && electron-forge package",
-    "make": "npm run build:daemon && npm run build:mcp && electron-forge make",
+    "package": "npm run build:daemon && npm run build:mcp && npm run build:cli && electron-forge package",
+    "make": "npm run build:daemon && npm run build:mcp && npm run build:cli && electron-forge make",
     "lint": "eslint --ext .ts,.tsx .",
     "build:daemon": "tsc -p tsconfig.daemon.json && esbuild dist/daemon/daemon/index.js --bundle --platform=node --outfile=dist/daemon-bundle/index.js --external:node-pty",
     "build:cli": "tsc -p tsconfig.cli.json && esbuild dist/cli/cli/index.js --bundle --platform=node --outfile=dist/cli-bundle/index.js",

--- a/src/cli/__tests__/identity.test.ts
+++ b/src/cli/__tests__/identity.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveSelfContext, parseIdentityEntries, type IdentityDeps } from '../identity';
+import type { RpcResponse } from '../../shared/rpc';
+
+function okResponse(result: unknown): RpcResponse {
+  return { id: 'r', ok: true, result };
+}
+
+function makeDeps(overrides: Partial<IdentityDeps>): IdentityDeps {
+  return {
+    sendRequest: vi.fn(async () => okResponse({ mappings: {}, entries: [] })),
+    env: {},
+    ppid: 1000,
+    getParentPid: vi.fn(async () => null),
+    ...overrides,
+  };
+}
+
+describe('parseIdentityEntries', () => {
+  it('prefers the entries array (pane-level identity)', () => {
+    const entries = parseIdentityEntries({
+      mappings: { '10': 'ws-a' },
+      entries: [{ pid: '10', ptyId: 'pty-1', workspaceId: 'ws-a' }],
+    });
+    expect(entries).toEqual([{ pid: '10', ptyId: 'pty-1', workspaceId: 'ws-a' }]);
+  });
+
+  it('falls back to mappings for older mains (workspace-only, empty ptyId)', () => {
+    const entries = parseIdentityEntries({ mappings: { '10': 'ws-a', '20': 'ws-b' } });
+    expect(entries).toEqual([
+      { pid: '10', ptyId: '', workspaceId: 'ws-a' },
+      { pid: '20', ptyId: '', workspaceId: 'ws-b' },
+    ]);
+  });
+
+  it('drops malformed entries and non-string mapping values', () => {
+    expect(
+      parseIdentityEntries({ entries: [{ pid: 5 }, null, { pid: '7', ptyId: 'p', workspaceId: 'w' }] }),
+    ).toEqual([{ pid: '7', ptyId: 'p', workspaceId: 'w' }]);
+    expect(parseIdentityEntries({ mappings: { '10': 42 } })).toEqual([]);
+    expect(parseIdentityEntries(null)).toEqual([]);
+    expect(parseIdentityEntries('nope')).toEqual([]);
+  });
+});
+
+describe('resolveSelfContext', () => {
+  it('resolves pane identity at depth 0 with zero getParentPid spawns', async () => {
+    const getParentPid = vi.fn(async () => null);
+    const deps = makeDeps({
+      sendRequest: vi.fn(async () =>
+        okResponse({ entries: [{ pid: '1000', ptyId: 'pty-self', workspaceId: 'ws-self' }] }),
+      ),
+      ppid: 1000,
+      getParentPid,
+    });
+    const ctx = await resolveSelfContext(deps);
+    expect(ctx).toEqual({ ptyId: 'pty-self', workspaceId: 'ws-self' });
+    expect(getParentPid).not.toHaveBeenCalled();
+  });
+
+  it('omits ptyId for workspace-only legacy entries', async () => {
+    const deps = makeDeps({
+      sendRequest: vi.fn(async () => okResponse({ mappings: { '1000': 'ws-legacy' } })),
+      ppid: 1000,
+    });
+    const ctx = await resolveSelfContext(deps);
+    expect(ctx).toEqual({ workspaceId: 'ws-legacy' });
+    expect(ctx.ptyId).toBeUndefined();
+  });
+
+  it('walks the parent chain only when the WMUX_WORKSPACE_ID hint is present', async () => {
+    // chain: ppid 1000 → 2000 → 3000 (mapped)
+    const chain: Record<number, number> = { 1000: 2000, 2000: 3000 };
+    const getParentPid = vi.fn(async (pid: number) => chain[pid] ?? null);
+    const entriesResult = okResponse({
+      entries: [{ pid: '3000', ptyId: 'pty-deep', workspaceId: 'ws-deep' }],
+    });
+
+    // without hint: depth-0 miss → give up immediately, no spawns
+    const noHint = await resolveSelfContext(
+      makeDeps({ sendRequest: vi.fn(async () => entriesResult), ppid: 1000, getParentPid }),
+    );
+    expect(noHint).toEqual({});
+    expect(getParentPid).not.toHaveBeenCalled();
+
+    // with hint: walk up and hit at depth 2
+    const withHint = await resolveSelfContext(
+      makeDeps({
+        sendRequest: vi.fn(async () => entriesResult),
+        env: { WMUX_WORKSPACE_ID: 'ws-hint-stale' },
+        ppid: 1000,
+        getParentPid,
+      }),
+    );
+    expect(withHint).toEqual({ ptyId: 'pty-deep', workspaceId: 'ws-deep' });
+    // NOTE: the stale env hint value itself is never returned — only the
+    // verified PID-map identity is.
+    expect(withHint.workspaceId).not.toBe('ws-hint-stale');
+  });
+
+  it('stops the walk at maxDepth / self-parent / pid<=1', async () => {
+    const getParentPid = vi.fn(async (pid: number) => (pid === 1000 ? 1000 : null));
+    const ctx = await resolveSelfContext(
+      makeDeps({
+        sendRequest: vi.fn(async () =>
+          okResponse({ entries: [{ pid: '9', ptyId: 'p', workspaceId: 'w' }] }),
+        ),
+        env: { WMUX_WORKSPACE_ID: 'ws' },
+        ppid: 1000,
+        getParentPid,
+      }),
+    );
+    expect(ctx).toEqual({});
+    expect(getParentPid).toHaveBeenCalledTimes(1); // self-parent loop detected
+  });
+
+  it('returns {} on RPC failure, error envelope, or empty map (never throws)', async () => {
+    expect(
+      await resolveSelfContext(
+        makeDeps({ sendRequest: vi.fn(async () => { throw new Error('down'); }) }),
+      ),
+    ).toEqual({});
+    expect(
+      await resolveSelfContext(
+        makeDeps({ sendRequest: vi.fn(async () => ({ id: 'r', ok: false, error: 'nope' }) as RpcResponse) }),
+      ),
+    ).toEqual({});
+    expect(
+      await resolveSelfContext(
+        makeDeps({ sendRequest: vi.fn(async () => okResponse({ mappings: {}, entries: [] })) }),
+      ),
+    ).toEqual({});
+  });
+});

--- a/src/cli/client.ts
+++ b/src/cli/client.ts
@@ -1,41 +1,51 @@
-#!/usr/bin/env node
 import * as net from 'net';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
 import type { RpcRequest, RpcResponse, RpcMethod } from '../shared/rpc';
-import { getPipeName, getAuthTokenPath } from '../shared/constants';
+import { getPipeName, getAuthTokenPath, getTcpPortPath } from '../shared/constants';
 
 // 서버(PipeServer)와 동일한 경로 해석을 사용한다. 과거에는 '/tmp/wmux.sock'을
 // 하드코딩해 macOS/Linux에서 서버('~/.wmux.sock')와 어긋나 항상 "not running"이
 // 떴고, Windows에서도 username 없는 '\\.\pipe\wmux'로 빗나갔다. getPipeName()이
-// win32/unix·username을 모두 처리한다. WMUX_SOCKET_PATH로 오버라이드 가능.
-const PIPE_NAME = process.env.WMUX_SOCKET_PATH || getPipeName();
+// win32/unix·username을 모두 처리한다. WMUX_SOCKET_PATH로 오버라이드 가능하되,
+// PTY env는 세션 생성 시점에 동결되므로 env 경로 실패 시 파생 경로로 재시도한다.
 const TIMEOUT_MS = 5000;
 
 // 인증 토큰: 서버는 토큰을 ~/.wmux-auth-token 파일에 쓴다. CLI가 이 파일을
 // 자동으로 읽지 않아 매번 WMUX_AUTH_TOKEN을 수동 주입해야 했다(인증 실패).
-// env 우선, 없으면 토큰 파일에서 읽는다.
+// 파일 우선 — PTY env의 토큰은 PipeServer.rotateToken() 이후 stale일 수 있다.
 function resolveAuthToken(): string | undefined {
-  if (process.env.WMUX_AUTH_TOKEN) return process.env.WMUX_AUTH_TOKEN;
   try {
     const fromFile = fs.readFileSync(getAuthTokenPath(), 'utf8').trim();
     if (fromFile) return fromFile;
   } catch {
-    // 파일 없음/권한 없음 — 토큰 없이 진행(서버가 거부하면 호출부에서 처리)
+    // 파일 없음/권한 없음 — env로 폴백
   }
+  if (process.env.WMUX_AUTH_TOKEN) return process.env.WMUX_AUTH_TOKEN;
   return undefined;
 }
 
-export function sendRequest(
+function readTcpPort(): number | undefined {
+  try {
+    const port = parseInt(fs.readFileSync(getTcpPortPath(), 'utf8').trim(), 10);
+    return Number.isFinite(port) ? port : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function attemptRequest(
+  target: string | { host: string; port: number },
   method: RpcMethod,
-  params: Record<string, unknown> = {}
+  params: Record<string, unknown>,
+  token: string | undefined,
 ): Promise<RpcResponse> {
   return new Promise((resolve, reject) => {
     const id = crypto.randomUUID();
-    const token = resolveAuthToken();
     const request: RpcRequest = { id, method, params, token };
 
-    const socket = net.connect(PIPE_NAME);
+    const socket =
+      typeof target === 'string' ? net.connect(target) : net.connect(target.port, target.host);
     let buffer = '';
     let settled = false;
 
@@ -77,11 +87,13 @@ export function sendRequest(
       if (!settled) {
         settled = true;
         clearTimeout(timer);
-        if (err.code === 'ENOENT' || err.code === 'ECONNREFUSED') {
-          reject(new Error('wmux is not running. Start the app first.'));
-        } else {
-          reject(new Error(`Connection error: ${err.message}`));
-        }
+        const wrapped = new Error(
+          err.code === 'ENOENT' || err.code === 'ECONNREFUSED'
+            ? 'wmux is not running. Start the app first.'
+            : `Connection error: ${err.message}`,
+        ) as Error & { code?: string };
+        wrapped.code = err.code;
+        reject(wrapped);
       }
     });
 
@@ -93,4 +105,54 @@ export function sendRequest(
       }
     });
   });
+}
+
+/**
+ * Only connection-level failures trigger the next transport in the fallback
+ * chain. A TIMEOUT deliberately does NOT: by then the request bytes may have
+ * reached the server (connect succeeded), so replaying it over TCP could
+ * double-apply a non-idempotent call — `input.send` would type the text into
+ * the terminal twice. Timeouts fail hard instead.
+ */
+function isConnectFailure(err: unknown): boolean {
+  const code = (err as { code?: string })?.code;
+  return code === 'ENOENT' || code === 'ECONNREFUSED' || code === 'EPERM';
+}
+
+export async function sendRequest(
+  method: RpcMethod,
+  params: Record<string, unknown> = {},
+): Promise<RpcResponse> {
+  const token = resolveAuthToken();
+
+  // env 경로(WMUX_SOCKET_PATH)는 stale할 수 있으므로(데이터 suffix 변경 등),
+  // 실패 시 파생 경로로 폴백한다. wmux-client.ts(MCP)와 동일 전략.
+  const envPath = process.env.WMUX_SOCKET_PATH;
+  const derivedPath = getPipeName();
+  const pipePaths = envPath && envPath !== derivedPath ? [envPath, derivedPath] : [derivedPath];
+
+  let lastError: unknown;
+  for (const pipePath of pipePaths) {
+    try {
+      return await attemptRequest(pipePath, method, params, token);
+    } catch (err) {
+      lastError = err;
+      if (!isConnectFailure(err)) throw err;
+    }
+  }
+
+  // TCP localhost 폴백 — Windows named pipe EPERM/ACL 이슈 우회 (서버가
+  // 127.0.0.1 랜덤 포트를 열고 포트를 ~/.wmux-tcp-port에 기록한다).
+  if (process.platform === 'win32') {
+    const tcpPort = readTcpPort();
+    if (tcpPort) {
+      try {
+        return await attemptRequest({ host: '127.0.0.1', port: tcpPort }, method, params, token);
+      } catch {
+        // fall through to the pipe error — it names the real failure
+      }
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error('wmux is not running. Start the app first.');
 }

--- a/src/cli/commands/browser.ts
+++ b/src/cli/commands/browser.ts
@@ -1,6 +1,44 @@
 import { sendRequest } from '../client';
-import { printResult, printError } from '../utils';
+import { printResult, ensureOk, parseFlag } from '../utils';
+import { resolveSelfContext, getParentPidDefault } from '../identity';
 import type { RpcResponse } from '../../shared/rpc';
+
+/**
+ * wmux open <url> [--workspace <id>]
+ *
+ * Opens (or reuses — X3 semantics) a browser pane and navigates it to <url>.
+ * Inside a wmux pane the browser opens in the caller's own workspace via
+ * verified PID-map identity; otherwise the active workspace is used.
+ */
+export async function handleOpen(args: string[], jsonMode: boolean): Promise<void> {
+  const url = args.find((a) => !a.startsWith('--'));
+  if (!url) {
+    console.error('Error: open requires <url> — e.g. `wmux open http://localhost:3000`');
+    process.exit(1);
+  }
+
+  let workspaceId = parseFlag(args, '--workspace');
+  if (!workspaceId) {
+    const ctx = await resolveSelfContext({
+      sendRequest,
+      env: process.env,
+      ppid: process.ppid,
+      getParentPid: getParentPidDefault,
+    });
+    workspaceId = ctx.workspaceId;
+  }
+
+  const params: Record<string, unknown> = { url };
+  if (workspaceId) params.workspaceId = workspaceId;
+
+  const response = await sendRequest('browser.open', params);
+  if (jsonMode) {
+    printResult(response);
+  } else {
+    ensureOk(response);
+    console.log(`Opened in browser pane: ${url}`);
+  }
+}
 
 const BROWSER_HELP = `
 wmux browser — Browser Commands
@@ -50,7 +88,7 @@ export async function handleBrowser(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         console.log(`Navigated to: ${url}`);
       }
       break;
@@ -62,7 +100,7 @@ export async function handleBrowser(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         console.log('Browser panel closed.');
       }
       break;
@@ -86,7 +124,7 @@ export async function handleBrowser(
           if (jsonMode) {
             printResult(response);
           } else {
-            if (!response.ok) { printError(response); return; }
+            ensureOk(response);
             const r = response.result as Record<string, unknown>;
             console.log(`Session started with profile: ${r['profile'] ?? 'default'}`);
           }
@@ -97,7 +135,7 @@ export async function handleBrowser(
           if (jsonMode) {
             printResult(response);
           } else {
-            if (!response.ok) { printError(response); return; }
+            ensureOk(response);
             console.log('Session stopped.');
           }
           break;
@@ -107,7 +145,7 @@ export async function handleBrowser(
           if (jsonMode) {
             printResult(response);
           } else {
-            if (!response.ok) { printError(response); return; }
+            ensureOk(response);
             const r = response.result as Record<string, unknown>;
             console.log(`Active profile: ${r['profile'] ?? 'none'}`);
             console.log(`CDP port: ${r['port'] ?? 'none'}`);
@@ -119,7 +157,7 @@ export async function handleBrowser(
           if (jsonMode) {
             printResult(response);
           } else {
-            if (!response.ok) { printError(response); return; }
+            ensureOk(response);
             const profiles = (response.result as Record<string, unknown>)['profiles'] as Array<Record<string, unknown>>;
             if (!profiles || profiles.length === 0) {
               console.log('No profiles found.');

--- a/src/cli/commands/input.ts
+++ b/src/cli/commands/input.ts
@@ -1,6 +1,66 @@
 import { sendRequest } from '../client';
-import { printResult, printError } from '../utils';
+import { printResult, ensureOk, parseFlag, hasFlag } from '../utils';
+import { resolveSelfContext, getParentPidDefault, type SelfContext } from '../identity';
 import type { RpcResponse } from '../../shared/rpc';
+
+/**
+ * Resolve the routing params for a terminal-IO command.
+ *
+ *   --pane <ptyId>  → explicit target (no identity lookup)
+ *   --active        → legacy behavior: whatever pane is focused in the UI
+ *   (default)       → self-targeting: the pane whose shell spawned this CLI,
+ *                     resolved via the verified PID-map walk. Falls back to
+ *                     active-pane when not inside a wmux pane.
+ *
+ * Returned params carry workspaceId alongside ptyId so the main process
+ * asserts ownership (assertWorkspaceOwnsPty) — self-targeting can never
+ * write into a foreign workspace even if the map were wrong.
+ *
+ * `mode` handles the workspace-only identity case (older main that returns
+ * `mappings` without pane-level `entries`):
+ *   - 'require-pty' (send/send-key): a workspaceId WITHOUT a ptyId would make
+ *     the server resolve the globally focused pane and then hard-fail the
+ *     ownership assert whenever the user is viewing another workspace — worse
+ *     than the pre-X4 CLI. Drop the identity entirely → pure active-pane.
+ *   - 'workspace-scope-ok' (read-screen): the server forwards workspaceId to
+ *     the renderer, which resolves the CALLER's own active pane scoped to
+ *     that workspace — workspace-only identity is an improvement there.
+ */
+export async function resolveTargetParams(
+  args: string[],
+  mode: 'require-pty' | 'workspace-scope-ok',
+): Promise<Record<string, unknown>> {
+  const explicitPane = parseFlag(args, '--pane');
+  if (explicitPane) return { ptyId: explicitPane };
+  if (hasFlag(args, '--active')) return {};
+
+  const ctx: SelfContext = await resolveSelfContext({
+    sendRequest,
+    env: process.env,
+    ppid: process.ppid,
+    getParentPid: getParentPidDefault,
+  });
+  if (mode === 'require-pty' && !ctx.ptyId) return {};
+  const params: Record<string, unknown> = {};
+  if (ctx.ptyId) params.ptyId = ctx.ptyId;
+  if (ctx.workspaceId) params.workspaceId = ctx.workspaceId;
+  return params;
+}
+
+/** Strip routing/option flags so the remaining args are the text payload. */
+export function stripInputFlags(args: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--pane') {
+      i++; // skip value
+      continue;
+    }
+    if (a === '--active' || a === '--submit' || a === '--raw') continue;
+    out.push(a);
+  }
+  return out;
+}
 
 export async function handleInput(
   cmd: string,
@@ -11,43 +71,54 @@ export async function handleInput(
 
   switch (cmd) {
     case 'send': {
-      const text = args.join(' ');
+      const text = stripInputFlags(args).join(' ');
       if (!text) {
         console.error('Error: send requires <text>');
         process.exit(1);
       }
-      response = await sendRequest('input.send', { text });
+      const target = await resolveTargetParams(args, 'require-pty');
+      const params: Record<string, unknown> = { text, ...target };
+      if (hasFlag(args, '--submit')) params.submit = true;
+      if (hasFlag(args, '--raw')) params.raw = true;
+      response = await sendRequest('input.send', params);
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
-        console.log('Text sent.');
+        ensureOk(response);
+        console.log(params.submit ? 'Text sent and submitted.' : 'Text sent.');
       }
       break;
     }
 
     case 'send-key': {
-      const key = args[0];
+      const key = stripInputFlags(args)[0];
       if (!key) {
         console.error('Error: send-key requires <keystroke>');
         process.exit(1);
       }
-      response = await sendRequest('input.sendKey', { key });
+      const target = await resolveTargetParams(args, 'require-pty');
+      response = await sendRequest('input.sendKey', { key, ...target });
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         console.log(`Key sent: ${key}`);
       }
       break;
     }
 
     case 'read-screen': {
-      response = await sendRequest('input.readScreen', {});
+      const target = await resolveTargetParams(args, 'workspace-scope-ok');
+      const params: Record<string, unknown> = { ...target };
+      const tail = parseFlag(args, '--tail');
+      if (tail && Number.isFinite(parseInt(tail, 10))) {
+        params.tail_lines = parseInt(tail, 10);
+      }
+      response = await sendRequest('input.readScreen', params);
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         // server returns { text: string } object or plain string
         const result = response.result as { text?: string } | string;
         let screen: string;

--- a/src/cli/commands/notify.ts
+++ b/src/cli/commands/notify.ts
@@ -1,29 +1,75 @@
 import { sendRequest } from '../client';
-import { printResult, printError, parseFlag } from '../utils';
+import { printResult, ensureOk, parseFlag } from '../utils';
+import { resolveSelfContext, getParentPidDefault } from '../identity';
 import type { RpcResponse } from '../../shared/rpc';
 
+const VALID_TYPES = new Set(['info', 'warning', 'error', 'agent']);
+
+/**
+ * wmux notify <title> [body]            — positional shorthand
+ * wmux notify --title <t> --body <b>    — explicit flags (legacy)
+ * Options: --type info|warning|error|agent, --workspace <id>
+ *
+ * When run inside a wmux pane the notification is routed to the caller's own
+ * workspace (verified PID-map identity) so scripts in background workspaces
+ * notify the right place instead of whichever workspace the user is viewing.
+ */
 export async function handleNotify(
   args: string[],
   jsonMode: boolean
 ): Promise<void> {
-  const title = parseFlag(args, '--title');
-  const body = parseFlag(args, '--body');
+  const flagTitle = parseFlag(args, '--title');
+  const flagBody = parseFlag(args, '--body');
+  const type = parseFlag(args, '--type');
+  const explicitWorkspace = parseFlag(args, '--workspace');
+
+  // Positional form: args minus all flag pairs.
+  const positionals: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--title' || a === '--body' || a === '--type' || a === '--workspace') {
+      i++; // skip flag value
+      continue;
+    }
+    if (a.startsWith('--')) continue;
+    positionals.push(a);
+  }
+
+  const title = flagTitle ?? positionals[0];
+  // When --title is given, ALL positionals are the body (joined) — slicing
+  // only the first would silently drop the rest.
+  const body = flagBody ?? (flagTitle ? positionals.join(' ') : positionals.slice(1).join(' '));
 
   if (!title) {
-    console.error('Error: notify requires --title <text>');
+    console.error('Error: notify requires a title — `wmux notify "Done" "Build finished"` or --title/--body');
     process.exit(1);
   }
-  if (!body) {
-    console.error('Error: notify requires --body <text>');
+  if (type && !VALID_TYPES.has(type)) {
+    console.error(`Error: --type must be one of: ${[...VALID_TYPES].join(', ')}`);
     process.exit(1);
   }
 
-  const response: RpcResponse = await sendRequest('notify', { title, body });
+  let workspaceId = explicitWorkspace;
+  if (!workspaceId) {
+    const ctx = await resolveSelfContext({
+      sendRequest,
+      env: process.env,
+      ppid: process.ppid,
+      getParentPid: getParentPidDefault,
+    });
+    workspaceId = ctx.workspaceId;
+  }
+
+  const params: Record<string, unknown> = { title, body };
+  if (type) params.type = type;
+  if (workspaceId) params.workspaceId = workspaceId;
+
+  const response: RpcResponse = await sendRequest('notify', params);
 
   if (jsonMode) {
     printResult(response);
   } else {
-    if (!response.ok) { printError(response); return; }
+    ensureOk(response);
     console.log(`Notification sent: "${title}"`);
   }
 }

--- a/src/cli/commands/pane.ts
+++ b/src/cli/commands/pane.ts
@@ -1,5 +1,5 @@
 import { sendRequest } from '../client';
-import { printResult, printError, parseFlag } from '../utils';
+import { printResult, ensureOk, parseFlag } from '../utils';
 import type { RpcResponse } from '../../shared/rpc';
 
 interface PaneInfo {
@@ -46,7 +46,7 @@ export async function handlePane(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         formatPaneList(response.result);
       }
       break;
@@ -62,7 +62,7 @@ export async function handlePane(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         console.log(`Focused pane: ${id}`);
       }
       break;
@@ -81,7 +81,7 @@ export async function handlePane(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         console.log(`Split pane ${direction}.`);
       }
       break;

--- a/src/cli/commands/surface.ts
+++ b/src/cli/commands/surface.ts
@@ -1,5 +1,5 @@
 import { sendRequest } from '../client';
-import { printResult, printError } from '../utils';
+import { printResult, ensureOk } from '../utils';
 import type { RpcResponse } from '../../shared/rpc';
 
 interface SurfaceInfo {
@@ -45,7 +45,7 @@ export async function handleSurface(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         formatSurfaceList(response.result);
       }
       break;
@@ -56,7 +56,7 @@ export async function handleSurface(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         const s = response.result as SurfaceInfo;
         console.log(`Created surface: ${s?.id ?? '(unknown)'}`);
       }
@@ -73,7 +73,7 @@ export async function handleSurface(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         console.log(`Focused surface: ${id}`);
       }
       break;
@@ -89,7 +89,7 @@ export async function handleSurface(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         console.log(`Closed surface: ${id}`);
       }
       break;

--- a/src/cli/commands/system.ts
+++ b/src/cli/commands/system.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { sendRequest } from '../client';
-import { printResult, printError } from '../utils';
+import { printResult, ensureOk } from '../utils';
 import type { RpcResponse } from '../../shared/rpc';
 
 function getFallbackVersion(): string {
@@ -32,7 +32,7 @@ export async function handleSystem(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         const info = response.result as IdentifyResult;
         console.log(`app:      ${info?.app ?? 'wmux'}`);
         console.log(`version:  ${info?.version ?? getFallbackVersion()}`);
@@ -46,7 +46,7 @@ export async function handleSystem(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         // server may return { methods: string[] } or string[] directly
         const result = response.result as { methods?: string[] } | string[];
         const methods = Array.isArray(result) ? result : (result?.methods || []);
@@ -72,7 +72,7 @@ export async function handleSystem(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         console.log(`Status set: "${text}"`);
       }
       break;
@@ -93,7 +93,7 @@ export async function handleSystem(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         console.log(`Progress set: ${value}%`);
       }
       break;

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -1,5 +1,5 @@
 import { sendRequest } from '../client';
-import { printResult, printError, parseFlag } from '../utils';
+import { printResult, ensureOk, parseFlag } from '../utils';
 import type { RpcResponse } from '../../shared/rpc';
 
 interface WorkspaceInfo {
@@ -47,7 +47,7 @@ export async function handleWorkspace(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         formatWorkspaceList(response.result);
       }
       break;
@@ -59,7 +59,7 @@ export async function handleWorkspace(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         const ws = response.result as WorkspaceInfo;
         console.log(`Created workspace: ${ws?.name ?? name} (${ws?.id ?? ''})`);
       }
@@ -76,7 +76,7 @@ export async function handleWorkspace(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         console.log(`Focused workspace: ${id}`);
       }
       break;
@@ -92,7 +92,7 @@ export async function handleWorkspace(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         console.log(`Closed workspace: ${id}`);
       }
       break;
@@ -103,7 +103,7 @@ export async function handleWorkspace(
       if (jsonMode) {
         printResult(response);
       } else {
-        if (!response.ok) { printError(response); return; }
+        ensureOk(response);
         formatWorkspaceCurrent(response.result);
       }
       break;

--- a/src/cli/identity.ts
+++ b/src/cli/identity.ts
@@ -1,0 +1,173 @@
+/**
+ * Self-identity resolution for the `wmux` CLI (X4).
+ *
+ * When the CLI runs inside a wmux pane, its parent process chain leads to the
+ * shell that wmux spawned for that pane. The main process keeps an on-disk
+ * pid-map (PID → ptyId, resolved live to the owning workspace via
+ * `a2a.resolve.identity`), so walking our own PPID chain against that map
+ * yields VERIFIED pane-level identity: { ptyId, workspaceId }.
+ *
+ * Design constraints:
+ *  - The common case (CLI spawned directly by the pane shell) must resolve
+ *    with ZERO process spawns: `process.ppid` is free and is usually the
+ *    mapped shell PID itself.
+ *  - Walking further up requires one PowerShell/ps spawn per hop (slow), so
+ *    the deep walk only runs when the WMUX_WORKSPACE_ID env hint says we are
+ *    nominally inside wmux. Outside wmux the CLI falls back to active-pane
+ *    semantics immediately instead of burning seconds on a doomed walk.
+ *  - Env hints (WMUX_WORKSPACE_ID / WMUX_SURFACE_ID) are NEVER trusted as
+ *    routing identity — they are frozen at PTY create time and go stale when
+ *    a daemon respawn re-mints workspace ids (issue #163). They only gate
+ *    how hard we try to verify.
+ *
+ * Resolution outcome:
+ *  - verified hit  → commands target the caller's own pane (ptyId +
+ *    workspaceId; main asserts ownership server-side).
+ *  - miss / transient / outside → `{}` — commands keep today's active-pane
+ *    behavior, which is never worse than the pre-X4 CLI.
+ */
+
+import type { RpcMethod, RpcResponse } from '../shared/rpc';
+
+export interface SelfContext {
+  /** Verified ptyId of the pane whose shell spawned this CLI process. */
+  ptyId?: string;
+  /** Verified workspace that owns that pane (live ownership, not the frozen env hint). */
+  workspaceId?: string;
+}
+
+export interface IdentityEntry {
+  pid: string;
+  ptyId: string;
+  workspaceId: string;
+}
+
+export interface IdentityDeps {
+  /** RPC transport — the CLI's sendRequest. */
+  sendRequest: (method: RpcMethod, params?: Record<string, unknown>) => Promise<RpcResponse>;
+  /** Environment (injectable for tests). */
+  env: Record<string, string | undefined>;
+  /** Our parent PID (injectable for tests). */
+  ppid: number;
+  /** PPID lookup for one hop up the tree. Spawns a process — used sparingly. */
+  getParentPid: (pid: number) => Promise<number | null>;
+  /** Max hops above process.ppid when the env hint says we're inside wmux. */
+  maxDepth?: number;
+}
+
+const DEFAULT_MAX_DEPTH = 6;
+
+/**
+ * Parse the a2a.resolve.identity result into pane-level entries.
+ * Falls back to workspace-only entries (ptyId='') for older mains that
+ * return `mappings` without `entries`.
+ */
+export function parseIdentityEntries(result: unknown): IdentityEntry[] {
+  if (result === null || typeof result !== 'object') return [];
+  const obj = result as Record<string, unknown>;
+  if (Array.isArray(obj.entries)) {
+    return obj.entries.filter(
+      (e): e is IdentityEntry =>
+        e !== null &&
+        typeof e === 'object' &&
+        typeof (e as IdentityEntry).pid === 'string' &&
+        typeof (e as IdentityEntry).ptyId === 'string' &&
+        typeof (e as IdentityEntry).workspaceId === 'string',
+    );
+  }
+  const mappings = obj.mappings;
+  if (mappings !== null && typeof mappings === 'object') {
+    return Object.entries(mappings as Record<string, unknown>)
+      .filter((pair): pair is [string, string] => typeof pair[1] === 'string')
+      .map(([pid, workspaceId]) => ({ pid, ptyId: '', workspaceId }));
+  }
+  return [];
+}
+
+/**
+ * Resolve the CLI's own pane identity. Never throws — identity is an
+ * enhancement, not a gate; on any failure the caller proceeds with
+ * active-pane semantics.
+ */
+export async function resolveSelfContext(deps: IdentityDeps): Promise<SelfContext> {
+  const insideWmuxHint = Boolean(deps.env['WMUX_WORKSPACE_ID']);
+
+  let entries: IdentityEntry[];
+  try {
+    const response = await deps.sendRequest('a2a.resolve.identity' as RpcMethod, {});
+    if (!response.ok) return {};
+    entries = parseIdentityEntries(response.result);
+  } catch {
+    return {};
+  }
+  if (entries.length === 0) return {};
+
+  const byPid = new Map<number, IdentityEntry>();
+  for (const entry of entries) {
+    const pid = parseInt(entry.pid, 10);
+    if (!Number.isNaN(pid)) byPid.set(pid, entry);
+  }
+
+  // Depth 0 — our direct parent. Free (no spawn); covers `wmux …` typed
+  // straight into a pane shell.
+  const direct = byPid.get(deps.ppid);
+  if (direct) return toContext(direct);
+
+  // Deeper walk costs one spawn per hop — only worth it when the env hint
+  // says a wmux pane is somewhere above us (nested shells, scripts).
+  if (!insideWmuxHint) return {};
+
+  const maxDepth = deps.maxDepth ?? DEFAULT_MAX_DEPTH;
+  let currentPid = deps.ppid;
+  for (let depth = 1; depth <= maxDepth; depth++) {
+    const parentPid = await deps.getParentPid(currentPid);
+    if (!parentPid || parentPid === currentPid || parentPid <= 1) break;
+    currentPid = parentPid;
+    const hit = byPid.get(currentPid);
+    if (hit) return toContext(hit);
+  }
+  return {};
+}
+
+function toContext(entry: IdentityEntry): SelfContext {
+  const ctx: SelfContext = { workspaceId: entry.workspaceId };
+  if (entry.ptyId) ctx.ptyId = entry.ptyId;
+  return ctx;
+}
+
+/**
+ * One-hop parent PID lookup. Windows uses the absolute WindowsPowerShell
+ * path (bare `powershell.exe` can ENOENT under stripped PATH — see the
+ * pwsh ENOENT dogfood lesson); unix uses `ps`.
+ */
+export async function getParentPidDefault(pid: number): Promise<number | null> {
+  try {
+    const { execFile } = await import('child_process');
+    const { promisify } = await import('util');
+    const execFileAsync = promisify(execFile);
+    if (process.platform === 'win32') {
+      const path = await import('path');
+      const ps = path.join(
+        process.env.SystemRoot || 'C:\\Windows',
+        'System32',
+        'WindowsPowerShell',
+        'v1.0',
+        'powershell.exe',
+      );
+      const { stdout } = await execFileAsync(
+        ps,
+        ['-NoProfile', '-Command', `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}").ParentProcessId`],
+        { encoding: 'utf8', windowsHide: true, timeout: 5000 },
+      );
+      const parsed = parseInt(stdout.trim(), 10);
+      return Number.isNaN(parsed) ? null : parsed;
+    }
+    const { stdout } = await execFileAsync('ps', ['-o', 'ppid=', '-p', String(pid)], {
+      encoding: 'utf8',
+      timeout: 3000,
+    });
+    return parseInt(stdout.trim(), 10) || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,7 +11,7 @@ import { handlePane } from './commands/pane';
 import { handleInput } from './commands/input';
 import { handleNotify } from './commands/notify';
 import { handleSystem } from './commands/system';
-import { handleBrowser } from './commands/browser';
+import { handleBrowser, handleOpen } from './commands/browser';
 import { handleMcp } from './commands/mcp';
 
 const HELP_TEXT = `
@@ -39,12 +39,20 @@ PANE COMMANDS
   split [--direction right|down]    Split the active pane (default: right)
 
 INPUT COMMANDS
-  send <text>                       Send text to the active terminal
+  send <text> [--submit]            Send text to your own pane (--submit presses Enter)
   send-key <keystroke>              Send a key (e.g. Enter, ctrl-c, Tab)
-  read-screen                       Read the current terminal screen content
+  read-screen [--tail <n>]          Read the current terminal screen content
+
+  Inside a wmux pane these target the pane you ran the command from
+  (verified PID-map identity). Options: --pane <ptyId> to target another
+  pane explicitly, --active to target the UI-focused pane instead.
+
+BROWSER PANE
+  open <url> [--workspace <id>]     Open/reuse a browser pane at <url>
 
 NOTIFICATION COMMANDS
-  notify --title <title> --body <body>   Show a notification in wmux
+  notify <title> [body]             Show a notification in wmux
+         [--type info|warning|error|agent] [--workspace <id>]
 
 SYSTEM COMMANDS
   set-status <text>                 Set a status message on the active workspace
@@ -72,8 +80,9 @@ GLOBAL FLAGS
 EXAMPLES
   wmux list-workspaces
   wmux new-workspace --name dev
-  wmux send "echo hello"
-  wmux notify --title "Done" --body "Build finished"
+  wmux send "echo hello" --submit
+  wmux notify "Done" "Build finished"
+  wmux open http://localhost:3000
   wmux identify --json
   wmux browser navigate "https://example.com"
   wmux browser close
@@ -135,6 +144,8 @@ async function main(): Promise<void> {
       await handleNotify(rest, jsonMode);
     } else if (SYSTEM_CMDS.has(cmd)) {
       await handleSystem(cmd, rest, jsonMode);
+    } else if (cmd === 'open') {
+      await handleOpen(rest, jsonMode);
     } else if (cmd === 'browser') {
       await handleBrowser(rest, jsonMode);
     } else if (cmd === 'mcp') {

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -1,9 +1,50 @@
 import type { RpcResponse } from '../shared/rpc';
 
 /**
+ * Extract the application-level error from an RPC response.
+ *
+ * Renderer-bridge handlers often report failure as `{ error: '...' }` INSIDE
+ * the result payload while the RPC envelope stays `ok: true` (the dispatch
+ * itself succeeded). Checking only `response.ok` masks those failures — e.g.
+ * `surface.close` on a surface outside the active workspace returned
+ * `{ error: 'surface not found' }` and the CLI printed "Closed surface: …".
+ * Returns undefined when the call genuinely succeeded.
+ */
+export function getResultError(response: RpcResponse): string | undefined {
+  if (!response.ok) return response.error;
+  const r = response.result;
+  if (
+    r !== null &&
+    typeof r === 'object' &&
+    typeof (r as Record<string, unknown>)['error'] === 'string'
+  ) {
+    return (r as Record<string, string>)['error'];
+  }
+  return undefined;
+}
+
+/**
+ * Guard for human-readable command paths: prints the (envelope- or
+ * payload-level) error to stderr and exits 1; returns silently on success.
+ * Declared as an assertion so callers keep the `response.result` narrowing
+ * the old `if (!response.ok) return` guard provided.
+ */
+export function ensureOk(
+  response: RpcResponse,
+): asserts response is Extract<RpcResponse, { ok: true }> {
+  const err = getResultError(response);
+  if (err !== undefined) {
+    console.error(`Error: ${err}`);
+    process.exit(1);
+  }
+}
+
+/**
  * Print the result field of a successful RPC response as JSON.
  * If the response contains an error, the error is printed to stderr and
- * the process exits with code 1.
+ * the process exits with code 1. A payload-level `result.error` keeps the
+ * machine-readable JSON on stdout but still exits 1 so scripts can rely on
+ * the exit code.
  */
 export function printResult(response: RpcResponse): void {
   if (!response.ok) {
@@ -11,6 +52,9 @@ export function printResult(response: RpcResponse): void {
     return;
   }
   console.log(JSON.stringify(response.result, null, 2));
+  if (getResultError(response) !== undefined) {
+    process.exit(1);
+  }
 }
 
 /**

--- a/src/main/__tests__/cliShim.test.ts
+++ b/src/main/__tests__/cliShim.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { buildShimCmd, buildPathEditScript, deriveShimPaths } from '../cliShim';
+
+describe('buildShimCmd', () => {
+  it('quotes paths, scopes ELECTRON_RUN_AS_NODE, and forwards args + exit code', () => {
+    const cmd = buildShimCmd(
+      'C:\\Users\\u\\AppData\\Local\\wmux\\app-3.2.0\\wmux.exe',
+      'C:\\Users\\u\\AppData\\Local\\wmux\\app-3.2.0\\resources\\cli-bundle\\index.js',
+    );
+    expect(cmd).toContain('setlocal');
+    expect(cmd).toContain('set "ELECTRON_RUN_AS_NODE=1"');
+    expect(cmd).toContain(
+      'call "C:\\Users\\u\\AppData\\Local\\wmux\\app-3.2.0\\wmux.exe" "C:\\Users\\u\\AppData\\Local\\wmux\\app-3.2.0\\resources\\cli-bundle\\index.js" %*',
+    );
+    expect(cmd).toContain('endlocal & exit /b %ERRORLEVEL%');
+    // CRLF line endings — cmd.exe is picky about bare LF in some contexts
+    expect(cmd.includes('\r\n')).toBe(true);
+    // No delayed expansion — a literal `!` in a path must survive
+    expect(cmd).not.toContain('enabledelayedexpansion');
+  });
+});
+
+describe('buildPathEditScript', () => {
+  it('add: reads raw (unexpanded) registry value and writes back as ExpandString', () => {
+    const script = buildPathEditScript('C:\\Users\\u\\AppData\\Local\\wmux\\bin', 'add');
+    // %VAR% entries must NOT be expanded-and-baked-in on rewrite
+    expect(script).toContain('DoNotExpandEnvironmentNames');
+    // REG_EXPAND_SZ must be preserved (SetEnvironmentVariable demotes to REG_SZ)
+    expect(script).toContain('-Type ExpandString');
+    // New shells must learn about the change without relogin
+    expect(script).toContain('SendMessageTimeout');
+    expect(script).toContain("'Environment'");
+    // Idempotency: only writes when membership actually changes
+    expect(script).toContain('if (-not $hit) { $parts += $bin; $changed = $true }');
+    expect(script).toContain('if ($changed) {');
+  });
+
+  it('remove: filters only the exact bin entry', () => {
+    const script = buildPathEditScript('C:\\wmux\\bin', 'remove');
+    expect(script).toContain('if ($hit) {');
+    expect(script).toContain('Where-Object');
+    expect(script).toContain('-ne $bin');
+  });
+
+  it('escapes single quotes in the bin dir for the PowerShell literal', () => {
+    const script = buildPathEditScript("C:\\odd'name\\bin", 'add');
+    expect(script).toContain("$bin = 'C:\\odd''name\\bin'");
+  });
+
+  it('never uses setx or [Environment]::SetEnvironmentVariable', () => {
+    for (const op of ['add', 'remove'] as const) {
+      const script = buildPathEditScript('C:\\wmux\\bin', op);
+      expect(script).not.toContain('setx');
+      expect(script).not.toContain('SetEnvironmentVariable');
+    }
+  });
+});
+
+describe('deriveShimPaths', () => {
+  it('derives version-independent bin dir + versioned cli-bundle path', () => {
+    const { binDir, cliJsPath } = deriveShimPaths(
+      'C:\\Users\\u\\AppData\\Local\\wmux\\app-3.2.0\\wmux.exe',
+    );
+    expect(binDir).toBe('C:\\Users\\u\\AppData\\Local\\wmux\\bin');
+    expect(cliJsPath).toBe(
+      'C:\\Users\\u\\AppData\\Local\\wmux\\app-3.2.0\\resources\\cli-bundle\\index.js',
+    );
+  });
+});

--- a/src/main/cliShim.ts
+++ b/src/main/cliShim.ts
@@ -1,0 +1,145 @@
+/**
+ * X4 — `wmux` CLI shim installation (Windows / Squirrel).
+ *
+ * The packaged app ships the bundled CLI at `<app>/resources/cli-bundle/index.js`.
+ * To make `wmux` callable from any shell we drop a tiny `wmux.cmd` shim into
+ * `<squirrelRoot>/bin` (a version-independent directory next to Update.exe)
+ * and register that directory on the USER Path.
+ *
+ * Why regenerate on every install/update instead of locating `app-*` at
+ * runtime: during `--squirrel-install` / `--squirrel-updated` the running
+ * process IS the freshly installed version, so `process.execPath` is the
+ * correct absolute target. A static absolute path keeps the shim trivial and
+ * avoids fragile `dir /b /o-n` latest-version discovery in batch.
+ *
+ * PATH editing runs as ONE PowerShell invocation per operation (Squirrel
+ * event handlers must not stall on serial spawns) and goes through the raw
+ * registry, not [Environment]::Get/SetEnvironmentVariable:
+ *   - read with GetValue(..., DoNotExpandEnvironmentNames) so existing
+ *     `%VAR%` entries are NOT expanded-and-baked-in on rewrite,
+ *   - write with Set-ItemProperty -Type ExpandString so REG_EXPAND_SZ is
+ *     preserved (SetEnvironmentVariable demotes to REG_SZ),
+ *   - broadcast WM_SETTINGCHANGE so newly opened shells see the change
+ *     (a bare registry write never notifies Explorer).
+ * `setx` is avoided entirely — it truncates values over 1024 chars.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+
+/** Batch shim content. `setlocal` keeps ELECTRON_RUN_AS_NODE out of the calling shell. */
+export function buildShimCmd(exePath: string, cliJsPath: string): string {
+  return [
+    '@echo off',
+    'setlocal',
+    'set "ELECTRON_RUN_AS_NODE=1"',
+    `call "${exePath}" "${cliJsPath}" %*`,
+    'endlocal & exit /b %ERRORLEVEL%',
+    '',
+  ].join('\r\n');
+}
+
+/**
+ * One-shot PowerShell script that adds/removes `binDir` on the user Path.
+ *
+ * The membership test is an exact, case-insensitive string match (PowerShell
+ * `-eq` on strings is case-insensitive): install and uninstall always pass
+ * the identical literal from deriveShimPaths, so no normalization beyond
+ * trailing-separator trim is needed — and entries we did NOT add are passed
+ * through byte-for-byte (quotes, `%VAR%` tokens and all).
+ */
+export function buildPathEditScript(binDir: string, op: 'add' | 'remove'): string {
+  const escaped = binDir.replace(/'/g, "''");
+  const mutate =
+    op === 'add'
+      ? `if (-not $hit) { $parts += $bin; $changed = $true }`
+      : `if ($hit) { $parts = @($parts | Where-Object { $_.TrimEnd('\\','/') -ne $bin }); $changed = $true }`;
+  return [
+    `$bin = '${escaped}'.TrimEnd('\\','/')`,
+    // Raw (unexpanded) read — keeps %VAR% entries intact across the rewrite.
+    `$key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)`,
+    `$cur = [string]$key.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)`,
+    `$parts = @($cur -split ';' | Where-Object { $_.Trim().Length -gt 0 })`,
+    `$hit = [bool]($parts | Where-Object { $_.TrimEnd('\\','/') -eq $bin })`,
+    `$changed = $false`,
+    mutate,
+    `if ($changed) {`,
+    // ExpandString == REG_EXPAND_SZ — SetEnvironmentVariable would demote to REG_SZ.
+    `  Set-ItemProperty -Path 'HKCU:\\Environment' -Name 'Path' -Value ($parts -join ';') -Type ExpandString`,
+    // WM_SETTINGCHANGE broadcast so new shells pick the change up without relogin.
+    `  $sig = '[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)] public static extern System.IntPtr SendMessageTimeout(System.IntPtr hWnd, uint Msg, System.UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out System.UIntPtr lpdwResult);'`,
+    `  $w = Add-Type -MemberDefinition $sig -Name 'Win32SendMessageTimeout' -Namespace 'Wmux' -PassThru`,
+    `  [System.UIntPtr]$res = [System.UIntPtr]::Zero`,
+    `  $null = $w::SendMessageTimeout([System.IntPtr]0xffff, 0x1A, [System.UIntPtr]::Zero, 'Environment', 2, 5000, [ref]$res)`,
+    `}`,
+  ].join('\n');
+}
+
+function powershellExe(): string {
+  return path.join(
+    process.env.SystemRoot || 'C:\\Windows',
+    'System32',
+    'WindowsPowerShell',
+    'v1.0',
+    'powershell.exe',
+  );
+}
+
+function runPathEdit(binDir: string, op: 'add' | 'remove'): void {
+  execFileSync(
+    powershellExe(),
+    ['-NoProfile', '-NonInteractive', '-Command', buildPathEditScript(binDir, op)],
+    { encoding: 'utf8', windowsHide: true, timeout: 20000 },
+  );
+}
+
+export interface ShimPaths {
+  /** Version-independent dir that receives wmux.cmd — `<squirrelRoot>/bin`. */
+  binDir: string;
+  /** Bundled CLI entry inside the current version's resources. */
+  cliJsPath: string;
+}
+
+/** Derive shim locations from the current executable (squirrel layout). */
+export function deriveShimPaths(execPath: string): ShimPaths {
+  const appDir = path.dirname(execPath); // …\wmux\app-X.Y.Z
+  const rootDir = path.resolve(appDir, '..'); // …\wmux (Update.exe lives here)
+  return {
+    binDir: path.join(rootDir, 'bin'),
+    cliJsPath: path.join(appDir, 'resources', 'cli-bundle', 'index.js'),
+  };
+}
+
+/**
+ * Install/refresh the CLI shim and register the bin dir on the user PATH.
+ * Best-effort: callers run this inside Squirrel event handlers where a
+ * failure must never block install/update — throws are caught and logged.
+ */
+export function installCliShim(execPath: string): void {
+  try {
+    const { binDir, cliJsPath } = deriveShimPaths(execPath);
+    if (!fs.existsSync(cliJsPath)) {
+      console.warn(`[cliShim] cli-bundle missing at ${cliJsPath} — skipping shim install`);
+      return;
+    }
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, 'wmux.cmd'), buildShimCmd(execPath, cliJsPath), 'utf8');
+    runPathEdit(binDir, 'add');
+  } catch (err) {
+    console.warn('[cliShim] shim install failed (non-fatal):', err);
+  }
+}
+
+/** Remove the shim and strip the bin dir from the user PATH. Best-effort. */
+export function uninstallCliShim(execPath: string): void {
+  try {
+    const { binDir } = deriveShimPaths(execPath);
+    try {
+      fs.rmSync(binDir, { recursive: true, force: true });
+    } catch { /* best-effort */ }
+    runPathEdit(binDir, 'remove');
+  } catch (err) {
+    console.warn('[cliShim] shim uninstall failed (non-fatal):', err);
+  }
+}

--- a/src/main/cliShim.ts
+++ b/src/main/cliShim.ts
@@ -101,13 +101,18 @@ export interface ShimPaths {
   cliJsPath: string;
 }
 
-/** Derive shim locations from the current executable (squirrel layout). */
+/**
+ * Derive shim locations from the current executable (squirrel layout).
+ * Uses path.win32 explicitly: the shim is Windows-only (Squirrel), and the
+ * POSIX path module would treat a `C:\…` execPath as one relative segment —
+ * which is also why the unit test must pass on the macOS/Linux CI baseline.
+ */
 export function deriveShimPaths(execPath: string): ShimPaths {
-  const appDir = path.dirname(execPath); // …\wmux\app-X.Y.Z
-  const rootDir = path.resolve(appDir, '..'); // …\wmux (Update.exe lives here)
+  const appDir = path.win32.dirname(execPath); // …\wmux\app-X.Y.Z
+  const rootDir = path.win32.resolve(appDir, '..'); // …\wmux (Update.exe lives here)
   return {
-    binDir: path.join(rootDir, 'bin'),
-    cliJsPath: path.join(appDir, 'resources', 'cli-bundle', 'index.js'),
+    binDir: path.win32.join(rootDir, 'bin'),
+    cliJsPath: path.win32.join(appDir, 'resources', 'cli-bundle', 'index.js'),
   };
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -117,6 +117,10 @@ if (process.platform === 'win32') {
         ], { windowsHide: true });
       } catch { /* best-effort */ }
 
+      // X4: drop the `wmux` CLI shim into <root>\bin and register it on the
+      // user PATH. Internally best-effort — never blocks the install.
+      try { require('./cliShim').installCliShim(process.execPath); } catch { /* best-effort */ }
+
       spawn(updateExe, ['--createShortcut', target, '--shortcut-locations', 'Desktop,StartMenu'], { detached: true, windowsHide: true })
         .on('close', () => {
           // Auto-launch app after install
@@ -136,6 +140,10 @@ if (process.platform === 'win32') {
         ], { windowsHide: true });
       } catch { /* best-effort */ }
 
+      // X4: regenerate the CLI shim — it embeds the absolute app-X.Y.Z path,
+      // which changes on every update.
+      try { require('./cliShim').installCliShim(process.execPath); } catch { /* best-effort */ }
+
       spawn(updateExe, ['--createShortcut', target], { detached: true, windowsHide: true })
         .on('close', () => process.exit(0));
       app.quit();
@@ -150,6 +158,9 @@ if (process.platform === 'win32') {
           '/v', 'wmux', '/f',
         ], { windowsHide: true });
       } catch { /* best-effort */ }
+
+      // X4: remove the CLI shim + strip <root>\bin from the user PATH.
+      try { require('./cliShim').uninstallCliShim(process.execPath); } catch { /* best-effort */ }
 
       spawn(updateExe, ['--removeShortcut', target], { detached: true, windowsHide: true })
         .on('close', () => process.exit(0));

--- a/src/main/pipe/handlers/__tests__/a2a.rpc.resolveIdentity.test.ts
+++ b/src/main/pipe/handlers/__tests__/a2a.rpc.resolveIdentity.test.ts
@@ -159,4 +159,40 @@ describe('a2a.resolve.identity — live ownership resolution', () => {
 
     expect(mappings).toEqual({});
   });
+
+  it('exposes pane-level entries (pid + ptyId + workspaceId) alongside mappings — X4 CLI', async () => {
+    fs.writeFileSync(path.join(dirRef.current, '70'), 'daemon-pane');
+    fs.writeFileSync(path.join(dirRef.current, '80'), 'daemon-dead');
+    sendToRendererMock.mockImplementation(
+      (_w: unknown, _method: string, params: { ptyId: string }) =>
+        Promise.resolve({
+          workspaceId: params.ptyId === 'daemon-pane' ? 'ws-X' : null,
+        }),
+    );
+
+    const res = await setupRouter().dispatch({
+      id: 'r2',
+      method: 'a2a.resolve.identity',
+      params: {},
+    });
+    expect(res.ok).toBe(true);
+    const result = (res as { result: { mappings: Record<string, string>; entries: unknown } }).result;
+
+    // mappings stays verbatim for existing MCP clients (additive change)
+    expect(result.mappings).toEqual({ '70': 'ws-X' });
+    // entries carries the immutable ptyId anchor; dead-owner entries excluded
+    expect(result.entries).toEqual([{ pid: '70', ptyId: 'daemon-pane', workspaceId: 'ws-X' }]);
+  });
+
+  it('returns empty entries alongside empty mappings when the dir is missing', async () => {
+    fs.rmSync(dirRef.current, { recursive: true, force: true });
+
+    const res = await setupRouter().dispatch({
+      id: 'r3',
+      method: 'a2a.resolve.identity',
+      params: {},
+    });
+    expect(res.ok).toBe(true);
+    expect((res as { result: { entries: unknown } }).result.entries).toEqual([]);
+  });
 });

--- a/src/main/pipe/handlers/a2a.rpc.ts
+++ b/src/main/pipe/handlers/a2a.rpc.ts
@@ -21,8 +21,13 @@ export function registerA2aRpc(router: RpcRouter, getWindow: GetWindow, claudeWo
   router.register('a2a.resolve.identity', async () => {
     const dir = getPidMapDir();
     const mappings: Record<string, string> = {};
+    // Additive (X4 CLI): per-PID detail including the immutable ptyId anchor,
+    // so a caller that finds its own shell PID here gets pane-level identity
+    // (ptyId) and not just the owning workspace. `mappings` is kept verbatim
+    // for existing MCP clients.
+    const entries: Array<{ pid: string; ptyId: string; workspaceId: string }> = [];
     try {
-      if (!fs.existsSync(dir)) return { mappings };
+      if (!fs.existsSync(dir)) return { mappings, entries };
 
       for (const file of fs.readdirSync(dir)) {
         let value: string;
@@ -76,14 +81,17 @@ export function registerA2aRpc(router: RpcRouter, getWindow: GetWindow, claudeWo
             owner && typeof owner === 'object' && 'workspaceId' in owner
               ? (owner as Record<string, unknown>)['workspaceId']
               : null;
-          if (typeof wsId === 'string' && wsId) mappings[file] = wsId;
+          if (typeof wsId === 'string' && wsId) {
+            mappings[file] = wsId;
+            entries.push({ pid: file, ptyId: value, workspaceId: wsId });
+          }
         } catch {
           // Renderer unavailable (early boot / reload) — skip this entry;
           // the caller retries resolution on its next identity-gated call.
         }
       }
     } catch { /* best-effort: identity resolution is non-critical */ }
-    return { mappings };
+    return { mappings, entries };
   });
 
   // A2A protocol — passthrough to renderer

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -16,5 +16,8 @@
     "src/shared/rpc.ts",
     "src/shared/constants.ts",
     "src/shared/types.ts"
+  ],
+  "exclude": [
+    "src/cli/__tests__/**"
   ]
 }


### PR DESCRIPTION
## Summary

X4 from the S-X sprint: makes the `wmux` CLI a first-class automation entry point — on the user PATH after install, and aware of **which pane it was invoked from**.

### Verified self-pane identity
- `a2a.resolve.identity` now additionally returns pane-level `entries` (`pid` + `ptyId` + `workspaceId`) alongside the existing `mappings` (additive; existing MCP clients unaffected).
- Inside a wmux pane, `send` / `send-key` / `read-screen` target **the pane the command was typed in**: the CLI walks its own PPID chain against the PID map — the same verified identity the MCP terminal tools use (#163) — never the spoofable/stale env hint, which only gates the deep walk. The common shell-direct case resolves with zero process spawns.
- Server-side `assertWorkspaceOwnsPty` still re-verifies ownership, so self-targeting can never write into a foreign workspace even if the map were wrong.
- With a legacy main (`mappings` only), `send`/`send-key` drop the workspace-only identity and fall back to active-pane semantics — never worse than the pre-X4 CLI; `read-screen` keeps the workspace scope (the renderer resolves the caller's own pane there).
- `--pane <ptyId>` targets another pane explicitly; `--active` keeps the old UI-focused behavior.

### Installer PATH integration (Windows / Squirrel)
- install/update drops a `wmux.cmd` shim (`ELECTRON_RUN_AS_NODE`, setlocal-scoped) into the version-independent `<root>\bin` and registers it on the user PATH; uninstall removes both. The shim embeds the absolute current-version path and is regenerated on every update.
- PATH editing is a single PowerShell invocation that reads the registry **raw** (`DoNotExpandEnvironmentNames`) and writes back as **ExpandString** with a `WM_SETTINGCHANGE` broadcast — avoiding `setx` 1024-char truncation, REG_EXPAND_SZ→REG_SZ demotion, and `%VAR%` literalization. Verified against the real registry with an add → idempotent-add → remove cycle (non-empty entries restored byte-identical).
- `dist/cli-bundle` ships via `extraResource`; `package`/`make` build it.

### Command surface
- New `wmux open <url>` — opens/reuses a browser pane (X3 semantics) in the **caller's** workspace.
- `send <text> [--submit] [--raw]`, `read-screen [--tail <n>]`, `notify <title> [body] [--type] [--workspace]` with caller-workspace routing.
- Pipe client gains the TCP-localhost fallback and stale `WMUX_SOCKET_PATH` fallback. Timeouts deliberately do **not** retry on another transport — the request may have been applied, and replaying `input.send` would type the text twice.

### Fixed while dogfooding
- Renderer-bridge handlers report failures as `{ error }` inside an `ok: true` envelope; the CLI printed success for them (e.g. `close-surface` on a foreign-workspace surface printed "Closed surface"). `ensureOk`/`getResultError` now surface payload-level errors on stderr with exit 1; `--json` keeps machine-readable output on stdout and still exits 1.

## Verification
- vitest 2852+ green incl. new suites (identity 8, cliShim 14, a2a entries 2); tsc / strict lint / api-reference drift clean.
- Adversarial review: no P1; all four P2 findings addressed in this diff.
- Live dogfood on a dev build, 7/7 scenarios PASS — decisive case: with UI focus on a *different* workspace, an in-pane `wmux send "echo X4SELF" --submit` echoed only in the invoking pane.

## Follow-ups (out of scope)
- `browser close` / `surface.close` only search the active workspace (asymmetric with `open`'s caller-workspace resolution) — needs workspaceId plumbing through the renderer bridge.
- Dev-only: #163 env stripping removes `WMUX_DATA_SUFFIX` from PTY env, so in-pane CLI against a dev instance needs the suffix set manually.
- tmux `send-keys` migration table in docs; packaged-installer PATH dogfood at release time.