### PR TITLE
fix(browser): route browser.close/surface.close by caller workspace, not UI-active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **`a2a.resolve.identity` now returns pane-level `entries`** (`pid` + `ptyId` + `workspaceId`) alongside the existing `mappings` — additive; existing MCP clients are unaffected.
 
+### Fixed
+- **`browser_close` / `wmux browser close` can no longer tear down a browser pane the user is viewing in another workspace.** `browser.open` was pinned to the caller's workspace in #193, but `browser.close` kept resolving "the browser pane" inside the UI-active workspace — an agent in workspace A issuing a close took down whatever browser the user happened to be looking at in workspace B, or got a spurious "not found" when B had none. Close now routes the same way open does: MCP resolves the calling workspace (fail-closed), the CLI uses its verified self-pane identity (with a `--workspace` override), and an explicit `surfaceId` — which is globally unique — is found across all workspaces. `surface.close` with an explicit id likewise no longer fails with "surface not found" when the surface lives outside the active workspace. Callers that pass no workspace at all keep the active-workspace behavior.
+
 ## [3.1.1] — 2026-06-12 — browser pane wired into the workflow, IME input self-healing
 
 Headline: the embedded browser pane is now reachable from where you actually work — terminal URLs route smartly, sidebar port badges open localhost in one click, and browser panes restore on the page you last visited. And the field-reported "keyboard input dies until you toggle multiview" IME failure on Korean Windows now self-heals: the suspect textarea-clearing is off by default and a storm guard detects the dead-input signature and resyncs the IME automatically.

--- a/src/cli/commands/browser.ts
+++ b/src/cli/commands/browser.ts
@@ -48,7 +48,8 @@ USAGE
 
 SUBCOMMANDS
   navigate <url>                  Navigate the active browser surface to a URL
-  close                           Close the browser panel
+  close [--workspace <id>]        Close the browser panel (defaults to your own
+                                  workspace when run inside a wmux pane)
   session start [--profile <name>]  Start a browser session
   session stop                      Stop the active browser session
   session status                    Show active session status
@@ -94,9 +95,27 @@ export async function handleBrowser(
       break;
     }
 
-    // ── browser close ────────────────────────────────────────────────────────
+    // ── browser close [--workspace <id>] ─────────────────────────────────────
     case 'close': {
-      response = await sendRequest('browser.close', {});
+      // Mirror `wmux open`: inside a wmux pane the close targets the caller's
+      // own workspace via verified PID-map identity, so it can never tear down
+      // a browser the user is viewing in another workspace. Outside a pane the
+      // identity resolves to nothing and the active workspace is used (the
+      // pre-fix behavior).
+      let workspaceId = parseFlag(rest, '--workspace');
+      if (!workspaceId) {
+        const ctx = await resolveSelfContext({
+          sendRequest,
+          env: process.env,
+          ppid: process.ppid,
+          getParentPid: getParentPidDefault,
+        });
+        workspaceId = ctx.workspaceId;
+      }
+      const params: Record<string, unknown> = {};
+      if (workspaceId) params.workspaceId = workspaceId;
+
+      response = await sendRequest('browser.close', params);
       if (jsonMode) {
         printResult(response);
       } else {

--- a/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
@@ -200,6 +200,33 @@ describe('registerBrowserRpc', () => {
     });
   });
 
+  it('browser.close forwards surfaceId and workspaceId to the renderer (caller-ws routing)', async () => {
+    const router = register();
+
+    await router.dispatch({
+      id: '5b',
+      method: 'browser.close',
+      params: { surfaceId: 'surface-9', workspaceId: 'ws-caller' },
+    });
+
+    expect(sendToRendererMock).toHaveBeenCalledWith(expect.any(Function), 'browser.close', {
+      surfaceId: 'surface-9',
+      workspaceId: 'ws-caller',
+    });
+  });
+
+  it('browser.close omits absent ids (renderer falls back to the active workspace)', async () => {
+    const router = register();
+
+    await router.dispatch({
+      id: '5c',
+      method: 'browser.close',
+      params: {},
+    });
+
+    expect(sendToRendererMock).toHaveBeenCalledWith(expect.any(Function), 'browser.close', {});
+  });
+
   it('browser.session.start applies only the default partition to renderer browser surfaces', async () => {
     const router = register();
 

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -78,12 +78,18 @@ export function registerBrowserRpc(router: RpcRouter, getWindow: GetWindow, webv
   /**
    * browser.close
    * Closes the browser panel.
-   * params: { surfaceId?: string }
+   * params: { surfaceId?: string, workspaceId?: string }
    */
   router.register('browser.close', (params) => {
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
+    const workspaceId = typeof params['workspaceId'] === 'string' ? params['workspaceId'] : undefined;
     return sendToRenderer(getWindow, 'browser.close', {
       ...(surfaceId && { surfaceId }),
+      // Same caller-workspace routing contract as browser.open above: absent
+      // workspaceId falls back to the UI-active workspace in the renderer.
+      // MCP/CLI callers pass an explicit id so a close issued from workspace A
+      // can never tear down the browser the user is viewing in workspace B.
+      ...(workspaceId && { workspaceId }),
     });
   });
 

--- a/src/mcp/__tests__/workspaceRouting.test.ts
+++ b/src/mcp/__tests__/workspaceRouting.test.ts
@@ -62,6 +62,15 @@ describe('MCP workspace routing (source-level invariants)', () => {
     expect(block).not.toMatch(/resolveWorkspaceId\(\)/);
   });
 
+  it('browser_close routes through requireWorkspaceId, never the weak resolver', () => {
+    // The close mirror of invariant 2: a surfaceId-less browser_close used to
+    // fall back to the UI-active workspace and tore down whatever browser the
+    // user was looking at — the same #190-class misroute browser_open had.
+    const block = toolBlock('browser_close');
+    expect(block).toMatch(/requireWorkspaceId\(\)/);
+    expect(block).not.toMatch(/resolveWorkspaceId\(\)/);
+  });
+
   it('terminal default routing binds the verified router, not the weak resolver (#163 Part 2)', () => {
     // resolveTerminalRouteBound wires resolveTerminalRoute to the verified
     // PID-map lookup + claim pinning. The cache getter MUST honor

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -281,11 +281,21 @@ server.tool(
 
 server.tool(
   'browser_close',
-  'Close the browser panel in the active pane',
+  'Close the browser panel in the calling workspace',
   {
-    surfaceId: z.string().optional().describe('Target a specific surface by ID. Omit to use the active surface.'),
+    surfaceId: z.string().optional().describe('Target a specific surface by ID (searched across all workspaces). Omit to close the browser surface in the calling workspace.'),
   },
-  async ({ surfaceId }) => callRpc('browser.close', surfaceId ? { surfaceId } : {}),
+  async ({ surfaceId }) => {
+    // Same fail-closed identity rule as browser_open: without an explicit
+    // workspaceId the renderer falls back to the UI-active workspace, so a
+    // surfaceId-less close issued here would tear down whatever browser the
+    // user is currently looking at — possibly in a different workspace.
+    // An explicit surfaceId is unambiguous (renderer searches all
+    // workspaces), but requireWorkspaceId is kept unconditional so both
+    // shapes share one identity contract.
+    const workspaceId = await requireWorkspaceId();
+    return callRpc('browser.close', { ...(surfaceId && { surfaceId }), workspaceId });
+  },
 );
 
 // === Playwright browser tools ===

--- a/src/renderer/hooks/__tests__/useRpcBridge.browserClose.test.ts
+++ b/src/renderer/hooks/__tests__/useRpcBridge.browserClose.test.ts
@@ -47,7 +47,7 @@ describe('useRpcBridge browser.close cascade (issue #143)', () => {
     const block = closeBlock();
     expect(block).toMatch(/store\.closeSurface\(/);
     // The empty-pane cleanup that issue #143 was missing.
-    expect(block).toMatch(/store\.closePane\(targetLeaf\.id\)/);
+    expect(block).toMatch(/store\.closePane\(targetLeaf\.id,\s*targetWs\.id\)/);
   });
 
   it('decides last-surface BEFORE closeSurface (no off-by-one on the snapshot)', () => {
@@ -62,5 +62,57 @@ describe('useRpcBridge browser.close cascade (issue #143)', () => {
     const closeAt = block.indexOf('store.closeSurface(');
     expect(snapAt).toBeGreaterThanOrEqual(0);
     expect(closeAt).toBeGreaterThan(snapAt);
+  });
+});
+
+/**
+ * Workspace-routing invariants for the close paths (X4 follow-up).
+ *
+ * browser.close used to resolve "the browser pane" inside the UI-ACTIVE
+ * workspace only, while browser.open had been fixed (#193) to honor the
+ * caller's workspaceId. The asymmetry meant an agent in workspace A issuing
+ * a surfaceId-less close tore down whatever browser the user was viewing in
+ * workspace B — or got a spurious "not found" when B had none.
+ *
+ * surface.close had the sibling false-negative: an explicit (globally unique)
+ * surface id outside the active workspace returned "surface not found".
+ */
+describe('useRpcBridge close-path workspace routing', () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, '..', 'useRpcBridge.ts'),
+    'utf-8',
+  );
+
+  function blockBetween(startMarker: string, endMarker: string): string {
+    const match = src.match(
+      new RegExp(`${startMarker}[\\s\\S]*?${endMarker}`),
+    );
+    if (!match) {
+      throw new Error(
+        `${startMarker} -> ${endMarker} handler region not found in ` +
+          'useRpcBridge.ts. Update the regex if the layout changed.',
+      );
+    }
+    return match[0];
+  }
+
+  it('browser.close honors params.workspaceId with an active-workspace fallback (mirrors browser.open)', () => {
+    const block = blockBetween("method === 'browser\\.close'", "method === 'browser\\.navigate'");
+    expect(block).toMatch(/params\.workspaceId/);
+    expect(block).toMatch(/store\.activeWorkspaceId/);
+    // The store mutations must be pinned to the RESOLVED workspace, or the
+    // slice-level active-workspace default silently no-ops on background ones.
+    expect(block).toMatch(/store\.closeSurface\(targetLeaf\.id,\s*targetSurfaceId,\s*targetWs\.id\)/);
+  });
+
+  it('browser.close with an explicit surfaceId searches every workspace (unambiguous target)', () => {
+    const block = blockBetween("method === 'browser\\.close'", "method === 'browser\\.navigate'");
+    expect(block).toMatch(/for \(const ws of store\.workspaces\)/);
+  });
+
+  it('surface.close resolves an explicit surface id across all workspaces', () => {
+    const block = blockBetween("method === 'surface\\.close'", "method === 'pane\\.list'");
+    expect(block).toMatch(/for \(const ws of store\.workspaces\)/);
+    expect(block).toMatch(/store\.closeSurface\(targetLeaf\.id,\s*surfaceId,\s*targetWs\.id\)/);
   });
 });

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useStore } from '../stores';
 import { withDefaultShell, withWorkspaceProfile } from '../utils/ptyCreateOptions';
-import type { Pane, PaneLeaf, Surface } from '../../shared/types';
+import type { Pane, PaneLeaf, Surface, Workspace } from '../../shared/types';
 import { validateMessage } from '../../shared/types';
 import type { Message, Part, TaskState, Artifact, AgentSkill } from '../../shared/types';
 import type { PaneSearchResult, PaneSearchResponse } from '../../shared/types';
@@ -421,16 +421,27 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
 
   if (method === 'surface.close') {
     const surfaceId = String(params.id ?? '');
-    const ws = store.workspaces.find((w) => w.id === store.activeWorkspaceId);
-    if (!ws) return { error: 'no active workspace' };
 
-    const targetLeaf = findLeafBySurfaceId(ws.rootPane, surfaceId);
-    if (!targetLeaf) return { error: `surface ${surfaceId} not found` };
+    // Surface ids are globally unique, so an explicit id is an unambiguous
+    // target — search every workspace, not just the UI-active one. The old
+    // active-only lookup made CLI/MCP closes of a background workspace's
+    // surface fail with "surface not found" (see cli/utils.ts).
+    let targetWs: Workspace | null = null;
+    let targetLeaf: PaneLeaf | null = null;
+    for (const ws of store.workspaces) {
+      const leaf = findLeafBySurfaceId(ws.rootPane, surfaceId);
+      if (leaf) {
+        targetWs = ws;
+        targetLeaf = leaf;
+        break;
+      }
+    }
+    if (!targetWs || !targetLeaf) return { error: `surface ${surfaceId} not found` };
 
     const surface = targetLeaf.surfaces.find((s) => s.id === surfaceId);
     const ptyId = surface?.ptyId;
 
-    store.closeSurface(targetLeaf.id, surfaceId);
+    store.closeSurface(targetLeaf.id, surfaceId, targetWs.id);
 
     if (ptyId) {
       try {
@@ -835,31 +846,46 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
   }
 
   if (method === 'browser.close') {
-    const ws = store.workspaces.find((w) => w.id === store.activeWorkspaceId);
-    if (!ws) return { error: 'no active workspace' };
-
     const surfaceId = typeof params.surfaceId === 'string' ? params.surfaceId : undefined;
+    // Workspace routing mirrors browser.open (lines above): an explicit
+    // workspaceId (MCP requireWorkspaceId / CLI verified identity) pins the
+    // close to the CALLER's workspace; absent, fall back to the UI-active one.
+    // Without this, an agent in workspace A issuing browser_close closed
+    // whatever browser the USER happened to be looking at in workspace B —
+    // the open path was fixed in #193, close kept the asymmetry.
+    const targetWsId = typeof params.workspaceId === 'string'
+      ? params.workspaceId
+      : store.activeWorkspaceId;
 
-    // Find the browser surface to close — by surfaceId or the active one
-    const leaves = findLeafPanes(ws.rootPane);
+    let targetWs: Workspace | null = null;
     let targetLeaf: PaneLeaf | null = null;
     let targetSurfaceId: string | null = null;
 
     if (surfaceId) {
-      // Find the specific browser surface
-      for (const leaf of leaves) {
-        const surface = leaf.surfaces.find((s) => s.id === surfaceId && s.surfaceType === 'browser');
-        if (surface) {
-          targetLeaf = leaf;
-          targetSurfaceId = surface.id;
-          break;
+      // Explicit surface id — unambiguous target, so search EVERY workspace.
+      // Scoping an explicit id to one workspace only manufactures false
+      // "not found" errors (the surface.close lesson — see cli/utils.ts).
+      for (const ws of store.workspaces) {
+        for (const leaf of findLeafPanes(ws.rootPane)) {
+          const surface = leaf.surfaces.find((s) => s.id === surfaceId && s.surfaceType === 'browser');
+          if (surface) {
+            targetWs = ws;
+            targetLeaf = leaf;
+            targetSurfaceId = surface.id;
+            break;
+          }
         }
+        if (targetLeaf) break;
       }
     } else {
-      // Find any active browser surface
-      for (const leaf of leaves) {
+      // No surface id — "the browser pane" is ambiguous, so resolve it inside
+      // the routed workspace only. Never reach into other workspaces here.
+      const ws = store.workspaces.find((w) => w.id === targetWsId);
+      if (!ws) return { error: 'browser.close: workspace not found' };
+      for (const leaf of findLeafPanes(ws.rootPane)) {
         const surface = leaf.surfaces.find((s) => s.surfaceType === 'browser');
         if (surface) {
+          targetWs = ws;
           targetLeaf = leaf;
           targetSurfaceId = surface.id;
           break;
@@ -867,7 +893,7 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       }
     }
 
-    if (!targetLeaf || !targetSurfaceId) {
+    if (!targetWs || !targetLeaf || !targetSurfaceId) {
       return { error: 'browser.close: no browser surface found' };
     }
 
@@ -877,7 +903,7 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // applies the mutation.
     const wasLastSurface = targetLeaf.surfaces.length <= 1;
 
-    store.closeSurface(targetLeaf.id, targetSurfaceId);
+    store.closeSurface(targetLeaf.id, targetSurfaceId, targetWs.id);
 
     // Mirror the UI close path's cascade: when the closed surface was the
     // pane's last one, remove the now-empty leaf too. Without this, AppLayout's
@@ -901,7 +927,7 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // Keep these two calls synchronous and adjacent; an await between them would
     // expose the empty leaf to the effect and reintroduce the backfill.
     if (wasLastSurface) {
-      store.closePane(targetLeaf.id);
+      store.closePane(targetLeaf.id, targetWs.id);
     }
     return { ok: true };
   }

--- a/src/renderer/stores/slices/__tests__/paneSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneSlice.test.ts
@@ -188,6 +188,48 @@ describe('PaneSlice', () => {
   });
 
   describe('closePane', () => {
+    it('closes a pane in a non-active workspace via the workspaceId parameter', () => {
+      const ws1 = getActiveWorkspace(store);
+      const ws2 = createWorkspace('Other');
+      store.setState((s) => { s.workspaces.push(ws2); });
+
+      // Build a 2-pane tree inside ws2 (splitPane operates on the active
+      // workspace), then return focus to ws1 so ws2 is a background workspace.
+      store.setState((s) => { s.activeWorkspaceId = ws2.id; });
+      store.getState().splitPane(ws2.rootPane.id, 'horizontal');
+      store.setState((s) => { s.activeWorkspaceId = ws1.id; });
+
+      const ws2Split = store.getState().workspaces.find((w) => w.id === ws2.id)!;
+      expect(ws2Split.rootPane.type).toBe('branch');
+      if (ws2Split.rootPane.type !== 'branch') return;
+      const childId = ws2Split.rootPane.children[0].id;
+
+      store.getState().closePane(childId, ws2.id);
+
+      const ws2After = store.getState().workspaces.find((w) => w.id === ws2.id)!;
+      expect(ws2After.rootPane.type).toBe('leaf');
+      // The active workspace must be untouched.
+      expect(store.getState().activeWorkspaceId).toBe(ws1.id);
+      expect(getActiveWorkspace(store).rootPane.type).toBe('leaf');
+    });
+
+    it('without workspaceId, a non-active workspace pane is a no-op (the asymmetry guard)', () => {
+      const ws1 = getActiveWorkspace(store);
+      const ws2 = createWorkspace('Other');
+      store.setState((s) => { s.workspaces.push(ws2); });
+      store.setState((s) => { s.activeWorkspaceId = ws2.id; });
+      store.getState().splitPane(ws2.rootPane.id, 'horizontal');
+      store.setState((s) => { s.activeWorkspaceId = ws1.id; });
+
+      const ws2Split = store.getState().workspaces.find((w) => w.id === ws2.id)!;
+      if (ws2Split.rootPane.type !== 'branch') throw new Error('expected branch');
+
+      store.getState().closePane(ws2Split.rootPane.children[0].id);
+
+      const ws2After = store.getState().workspaces.find((w) => w.id === ws2.id)!;
+      expect(ws2After.rootPane.type).toBe('branch');
+    });
+
     it('removes a leaf and collapses the parent branch', () => {
       const ws = getActiveWorkspace(store);
       const originalLeafId = ws.rootPane.id;

--- a/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
@@ -149,6 +149,54 @@ describe('surfaceSlice.setActiveSurface', () => {
   });
 });
 
+describe('surfaceSlice.closeSurface', () => {
+  it('targets the active workspace when no workspaceId is given', () => {
+    const { state, slice } = createHarness();
+    const paneId = state.workspaces[0].rootPane.id;
+    slice.addSurface(paneId, 'pty-1', 'pwsh', '');
+    slice.addSurface(paneId, 'pty-2', 'pwsh', '');
+    const pane = state.workspaces[0].rootPane;
+    if (pane.type !== 'leaf') throw new Error('expected leaf pane');
+    const firstId = pane.surfaces[0].id;
+
+    slice.closeSurface(paneId, firstId);
+
+    expect(pane.surfaces).toHaveLength(1);
+    expect(pane.surfaces.find((s) => s.id === firstId)).toBeUndefined();
+  });
+
+  it('targets a non-active workspace via the workspaceId parameter', () => {
+    const { state, slice } = createHarness();
+    const other = createWorkspace('Other');
+    state.workspaces.push(other);
+    slice.addBrowserSurface(other.rootPane.id, 'https://x.example', undefined, other.id);
+    const pane = other.rootPane;
+    if (pane.type !== 'leaf') throw new Error('expected leaf pane');
+    const surfaceId = pane.surfaces[0].id;
+
+    slice.closeSurface(pane.id, surfaceId, other.id);
+
+    expect(pane.surfaces).toHaveLength(0);
+    expect(state.activeWorkspaceId).not.toBe(other.id);
+  });
+
+  it('is a no-op for a non-active workspace pane without the workspaceId parameter', () => {
+    // Documents WHY callers must thread workspaceId: the pane lookup runs
+    // inside one workspace tree, so a background-workspace pane silently
+    // no-ops instead of closing (the browser.close asymmetry).
+    const { state, slice } = createHarness();
+    const other = createWorkspace('Other');
+    state.workspaces.push(other);
+    slice.addBrowserSurface(other.rootPane.id, 'https://x.example', undefined, other.id);
+    const pane = other.rootPane;
+    if (pane.type !== 'leaf') throw new Error('expected leaf pane');
+
+    slice.closeSurface(pane.id, pane.surfaces[0].id);
+
+    expect(pane.surfaces).toHaveLength(1);
+  });
+});
+
 describe('surfaceSlice browser partition state', () => {
   it('stores the provided partition on new browser surfaces', () => {
     const { state, slice } = createHarness();

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -34,7 +34,10 @@ export interface PaneSlice {
    * the still-active original pane).
    */
   splitPane: (paneId: string, direction: 'horizontal' | 'vertical', workspaceId?: string, position?: 'before' | 'after') => boolean;
-  closePane: (paneId: string) => void;
+  /** Close a leaf pane. `workspaceId` lets RPC/CLI callers target a
+   * non-active workspace (defaults to the active one — existing callers are
+   * unchanged). */
+  closePane: (paneId: string, workspaceId?: string) => void;
   setActivePane: (paneId: string) => void;
   focusPaneDirection: (direction: 'up' | 'down' | 'left' | 'right') => void;
   cyclePane: (direction: 'next' | 'prev') => void;
@@ -246,10 +249,10 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
     return created;
   },
 
-  closePane: (paneId) => {
+  closePane: (paneId, workspaceId) => {
     let event: { wsId: string; closedPaneId: string; previousActiveId: string; newActiveId: string | null } | null = null;
     set((state: StoreState) => {
-      const ws = state.workspaces.find((w: Workspace) => w.id === state.activeWorkspaceId);
+      const ws = state.workspaces.find((w: Workspace) => w.id === (workspaceId || state.activeWorkspaceId));
       if (!ws) return;
 
       const parent = findParent(ws.rootPane, paneId);

--- a/src/renderer/stores/slices/surfaceSlice.ts
+++ b/src/renderer/stores/slices/surfaceSlice.ts
@@ -8,7 +8,10 @@ export interface SurfaceSlice {
   addSurface: (paneId: string, ptyId: string, shell: string, cwd: string) => void;
   addBrowserSurface: (paneId: string, url?: string, partition?: string, workspaceId?: string) => void;
   addEditorSurface: (paneId: string, filePath: string) => void;
-  closeSurface: (paneId: string, surfaceId: string) => void;
+  /** Close a surface tab. `workspaceId` lets RPC/CLI callers target a
+   * non-active workspace (defaults to the active one — existing callers are
+   * unchanged). */
+  closeSurface: (paneId: string, surfaceId: string, workspaceId?: string) => void;
   /** Activate a surface tab. `workspaceId` lets RPC/helper callers target a
    * non-active workspace (defaults to the active one — existing callers are
    * unchanged). */
@@ -106,8 +109,8 @@ export const createSurfaceSlice: StateCreator<StoreState, [['zustand/immer', nev
     pane.activeSurfaceId = surface.id;
   }),
 
-  closeSurface: (paneId, surfaceId) => set((state: StoreState) => {
-    const ws = state.workspaces.find((w: Workspace) => w.id === state.activeWorkspaceId);
+  closeSurface: (paneId, surfaceId, workspaceId) => set((state: StoreState) => {
+    const ws = state.workspaces.find((w: Workspace) => w.id === (workspaceId || state.activeWorkspaceId));
     if (!ws) return;
     const pane = findLeafPane(ws.rootPane, paneId);
     if (!pane) return;


### PR DESCRIPTION
## Problem

`browser.open` was pinned to the caller's workspace in #193, but `browser.close` kept resolving "the browser pane" inside the **UI-active** workspace. Two failure modes, both hit by agents/CLI callers running in a background workspace:

- **Misfire**: an agent in workspace A issuing a surfaceId-less `browser_close` / `wmux browser close` tore down whatever browser the user was viewing in workspace B.
- **False negative**: when the active workspace had no browser, the close failed with "no browser surface found" even though the caller's workspace had one.

`surface.close` had the sibling false negative: an explicit (globally unique) surface id outside the active workspace returned "surface not found".

## Fix

Close now routes symmetrically with open, through every layer:

- **renderer (`useRpcBridge.ts`)**: `browser.close` honors `params.workspaceId` with the documented active-workspace fallback; an explicit `surfaceId` is searched across **all** workspaces (an explicit id is an unambiguous target — scoping it only manufactures false "not found"s). `surface.close` resolves its explicit id across all workspaces.
- **store slices**: `closeSurface` / `closePane` accept an optional `workspaceId` (same pattern as `setActiveSurface`). Without this the handler fix is moot — the slice-level active-workspace default silently no-ops on background workspaces.
- **main (`browser.rpc.ts`)**: forwards `workspaceId`, same contract as `browser.open`.
- **MCP**: `browser_close` resolves the calling workspace via `requireWorkspaceId` (fail-closed), matching `browser_open`. Locked into the #193 source-level invariant suite.
- **CLI**: `wmux browser close` uses verified self-pane identity inside a pane, with a `--workspace` override; outside a pane the active-workspace behavior is preserved.

## Verification

- vitest green incl. new coverage: slice-level workspace targeting (unit), main handler forwarding (unit), MCP routing invariant, renderer close-path structural invariants.
- **Live dogfood on a dev build, 5/5 PASS** (driven through the real CLI against the running app):
  1. UI focused on B, `close --workspace A` → A's browser closed, B's untouched (pre-fix: B's would close)
  2. Active workspace has no browser → background-workspace close succeeds (pre-fix: "no browser surface found")
  3. `close-surface <id>` for a background workspace's surface succeeds (pre-fix: "surface not found")
  4. No workspaceId from an external caller → active-workspace fallback unchanged
  5. No browser anywhere in target workspace → clean error, exit 1

Follow-up noted in #202; remaining X4 follow-ups (dev-suffix PTY propagation, tmux mapping doc, packaged PATH install dogfood) are deferred separately.