### PR TITLE
perf: cold-start boot-phase instrumentation (S-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Cold-start boot-phase instrumentation (S-A).** The main process now emits one cheap `[boot-trace]` line per boot milestone (process spawn → module eval → app-ready → plugin load → daemon bootstrap with spawn/pipe/ping sub-phases → ready end), plus a JSON summary that lands in the daily log file; the daemon exposes its own boot marks through `daemon.ping`. The perf bench collects both and prints a derived phase-attribution table, so a cold-start regression now points at the guilty phase instead of a single opaque number. First run of the new table immediately attributed ~70% of the measured cold start to the auth-token ACL hardening's synchronous PowerShell shell-outs (one in the main process, one in the daemon) — the optimization target for the follow-up PR. Zero telemetry: stderr and local log files only.
+
 ## [3.2.0] — 2026-06-12 — wmux CLI on your PATH, wmux.json project config, click-to-jump notifications, perf gate
 
 Headline: every shell — inside or outside wmux — gets a `wmux` command with verified self-pane identity; a repo-root `wmux.json` turns "open this repo" into a fully arranged workspace (custom commands + declarative pane layout) behind a byte-exact trust gate; clicking a desktop toast now jumps straight to the pane that fired it; and a benchmark harness with a CI regression gate puts real numbers behind the performance story (echo p95 29.2 ms, no degradation at 8 panes). Plus cross-workspace browser-close routing, a multi-image paste fix, and Smart App Control install guidance.

--- a/bench/README.md
+++ b/bench/README.md
@@ -30,6 +30,16 @@ pre-announce targets."*
 - **RAM** — working-set bytes of the **full process tree**, including the
   detached daemon, at two states: idle with 1 pane (`idle1Pane`) and 8 panes
   (`panes8`). `appMetricsRaw` is captured for context but is **never gated**.
+- **Boot-phase attribution** (S-A) — the main process emits one
+  `[boot-trace] mark=<name> epoch=<ms>` stderr line per boot milestone
+  (`src/main/util/bootTrace.ts`), and the daemon exposes its own marks via the
+  `daemon.ping` response (`bootTrace` field). The harness re-bases both onto
+  the spawn timeline and records them per run (`runs[i].marks`,
+  `runs[i].daemonBoot`) plus medians (`coldStart.medianMarks`,
+  `coldStart.medianDaemonMarks`), and prints a derived phase table
+  (pre-JS → module eval → app-ready wait → plugin load → daemon bootstrap
+  with spawn/pipe/ping sub-phases → ready tail). All fields are **additive
+  and never gated** — they exist to attribute regressions, not to gate them.
 
 The result schema (`schemaVersion: 1`) is documented inline in
 `scripts/perf-compare.mjs` (the gated dot-paths) and produced by
@@ -111,6 +121,17 @@ regression first.
 - CI runners are shared and use software GL, so absolute numbers there are
   noisier and slower than real hardware. The CI gate thresholds are
   intentionally loose for exactly this reason.
+- **Antivirus tax on cold start**: real-time scanning (Windows Defender) can
+  dominate local cold-start numbers — the same commit measures ~2.4x slower on
+  a Defender-active dev machine than on CI. To attribute it, compare the
+  boot-phase table local vs CI: AV cost concentrates in `pre-JS`, module eval,
+  and the `daemon-spawned → daemon-pipe-file-seen` span (a second exe image
+  scan), while genuine code cost inflates phases uniformly. For a one-off
+  LOCAL diagnosis you can temporarily add a Defender exclusion for
+  `out\wmux-win32-x64` plus the bench temp root via the Windows Security UI,
+  re-run `--skip-input --skip-ram --cold-runs 3`, diff the phase tables, and
+  **remove the exclusions afterwards**. Never automate or ship exclusions —
+  this is a diagnostic procedure only.
 - `baseline-local.json` is the sensitive one — the dev machine is stable, so its
   thresholds are the meaningful guardrail for everyday work.
 - frame numbers depend on the compositor; trust `echoMs` first when a run looks

--- a/scripts/perf-bench.mjs
+++ b/scripts/perf-bench.mjs
@@ -352,6 +352,9 @@ function spawnInstance(inst) {
   // Boot-trace mark collector (S-A). Separate listener from the CDP matcher
   // above: that one early-returns once the port is found, while marks keep
   // arriving until ready-end. Line-buffered because chunks can split lines.
+  // STDERR ONLY: bootTrace.ts emits marks via process.stderr.write, and a
+  // single buffer shared across both streams could interleave stdout chunks
+  // into the middle of a stderr line and corrupt the parse.
   // Marks are emitted as absolute epochs by src/main/util/bootTrace.ts and
   // re-based here onto the bench timeline (same machine clock as t0).
   {
@@ -370,7 +373,6 @@ function spawnInstance(inst) {
       // Cap a pathological lineless tail (binary noise) — marks always end in \n.
       if (traceBuf.length > 65536) traceBuf = traceBuf.slice(-4096);
     };
-    inst.proc.stdout.on('data', onTraceChunk);
     inst.proc.stderr.on('data', onTraceChunk);
   }
   // Surface app errors to the harness log without flooding it.

--- a/scripts/perf-bench.mjs
+++ b/scripts/perf-bench.mjs
@@ -316,6 +316,8 @@ function makeInstance() {
     wmuxDir: path.join(home, `.wmux${suffix}`),
     t0: null,
     milestones: {},
+    bootMarks: {},   // [boot-trace] mark lines from the app, ms relative to t0
+    daemonBoot: null, // daemon.ping bootTrace (marks re-based to t0), or null
   };
 }
 
@@ -347,6 +349,30 @@ function spawnInstance(inst) {
     inst.proc.on('exit', (code) => reject(new Error(`app exited early (code ${code}) before CDP line`)));
     setTimeout(() => reject(new Error('timeout waiting for CDP port line (20s)')), 20000);
   });
+  // Boot-trace mark collector (S-A). Separate listener from the CDP matcher
+  // above: that one early-returns once the port is found, while marks keep
+  // arriving until ready-end. Line-buffered because chunks can split lines.
+  // Marks are emitted as absolute epochs by src/main/util/bootTrace.ts and
+  // re-based here onto the bench timeline (same machine clock as t0).
+  {
+    let traceBuf = '';
+    const onTraceChunk = (b) => {
+      traceBuf += b.toString('utf8');
+      let nl;
+      while ((nl = traceBuf.indexOf('\n')) !== -1) {
+        const line = traceBuf.slice(0, nl);
+        traceBuf = traceBuf.slice(nl + 1);
+        const m = line.match(/\[boot-trace\] mark=([\w-]+) epoch=(\d+)/);
+        if (m && !(m[1] in inst.bootMarks)) {
+          inst.bootMarks[m[1]] = Number(m[2]) - inst.t0;
+        }
+      }
+      // Cap a pathological lineless tail (binary noise) — marks always end in \n.
+      if (traceBuf.length > 65536) traceBuf = traceBuf.slice(-4096);
+    };
+    inst.proc.stdout.on('data', onTraceChunk);
+    inst.proc.stderr.on('data', onTraceChunk);
+  }
   // Surface app errors to the harness log without flooding it.
   inst.proc.on('exit', (code) => {
     if (liveInstances.has(inst)) console.error(`[app#${inst.seq}] exited (code ${code})`);
@@ -535,6 +561,28 @@ async function bootInstance(inst) {
     });
     inst.milestones.fcpMs = fcpEpoch != null ? round(fcpEpoch - inst.t0) : null;
   } catch { inst.milestones.fcpMs = null; }
+
+  // Daemon-side boot breakdown (S-A): daemon.ping carries `bootTrace`
+  // (additive field). Best-effort — a local-PTY-fallback boot has no daemon.
+  try {
+    const token = readDaemonToken(inst);
+    const daemonPipe = readDaemonPipeName(inst);
+    if (token && await pipeAlive(daemonPipe)) {
+      const dc = new PipeClient(daemonPipe, token);
+      await dc.connect();
+      const pong = await dc.call('daemon.ping', {}, 3000);
+      dc.close();
+      if (pong?.bootTrace?.marks) {
+        const rebase = (epoch) => round(epoch - inst.t0);
+        inst.daemonBoot = {
+          jsStartMs: rebase(pong.bootTrace.jsStartEpochMs),
+          marks: Object.fromEntries(
+            Object.entries(pong.bootTrace.marks).map(([k, v]) => [k, rebase(v)]),
+          ),
+        };
+      }
+    }
+  } catch { inst.daemonBoot = null; }
 
   return inst;
 }
@@ -856,6 +904,10 @@ process.on('exit', () => {
         rendererReadyMs: m.rendererReadyMs ?? null,
         firstPtyDataMs: m.firstPtyDataMs ?? null,
         fcpMs: m.fcpMs ?? null,
+        // S-A boot-phase attribution (additive — perf-compare gates only by
+        // explicit dot-paths, so these fields never affect the gate).
+        marks: { ...inst.bootMarks },
+        daemonBoot: inst.daemonBoot,
       });
       console.log(`    cdp=${m.cdpReadyMs}ms pipe=${m.pipeReadyMs}ms renderer=${m.rendererReadyMs}ms firstPty=${m.firstPtyDataMs}ms fcp=${m.fcpMs}ms`);
       if (i < ARGS.coldRuns - 1) await shutdownInstance(inst);
@@ -879,6 +931,49 @@ process.on('exit', () => {
     }
     const med = RESULTS.scenarios.coldStart.median;
     console.log(`coldStart median: firstPtyData=${med.firstPtyDataMs}ms renderer=${med.rendererReadyMs}ms`);
+
+    // ---- boot-phase attribution (S-A) ----
+    // Median across runs for every mark seen in any run (key union — the
+    // reuse path emits daemon-reused, the spawn path emits spawn marks).
+    const medianMarkMap = (pick) => {
+      const keys = new Set(runs.flatMap((r) => Object.keys(pick(r) ?? {})));
+      const out = {};
+      for (const k of keys) out[k] = median(runs.map((r) => pick(r)?.[k] ?? null));
+      return out;
+    };
+    const medianMarks = medianMarkMap((r) => r.marks);
+    const medianDaemonMarks = medianMarkMap((r) => r.daemonBoot?.marks);
+    RESULTS.scenarios.coldStart.medianMarks = medianMarks;
+    RESULTS.scenarios.coldStart.medianDaemonMarks = medianDaemonMarks;
+
+    const span = (marks, a, b) => {
+      const va = a === 'spawn' ? 0 : marks[a];
+      const vb = marks[b];
+      return typeof va === 'number' && typeof vb === 'number' ? Math.round(vb - va) : null;
+    };
+    const fmt = (v) => (v == null ? 'n/a' : `${v}ms`);
+    console.log('boot-phase breakdown (median, ms since spawn):');
+    console.log(`  pre-JS (spawn→js-start)                       ${fmt(span(medianMarks, 'spawn', 'js-start'))}`);
+    console.log(`  module imports (js-start→imports-done)        ${fmt(span(medianMarks, 'js-start', 'imports-done'))}`);
+    console.log(`  app init (imports-done→module-eval-end)       ${fmt(span(medianMarks, 'imports-done', 'module-eval-end'))}`);
+    console.log(`    pty managers (construction-start→pre-pipe-server-ctor) ${fmt(span(medianMarks, 'construction-start', 'pre-pipe-server-ctor'))}`);
+    console.log(`    PipeServer ctor / token ACL (pre→ctor-done) ${fmt(span(medianMarks, 'pre-pipe-server-ctor', 'pipe-server-ctor-done'))}`);
+    console.log(`    handler registration (ctor-done→eval-end)   ${fmt(span(medianMarks, 'pipe-server-ctor-done', 'module-eval-end'))}`);
+    console.log(`  ready wait (module-eval-end→ready-fired)      ${fmt(span(medianMarks, 'module-eval-end', 'ready-fired'))}`);
+    console.log(`  plugin load (ready-fired→plugins-loaded)      ${fmt(span(medianMarks, 'ready-fired', 'plugins-loaded'))}`);
+    console.log(`  window create (plugins-loaded→window-created) ${fmt(span(medianMarks, 'plugins-loaded', 'window-created'))}`);
+    console.log(`  daemon bootstrap (start→end)                  ${fmt(span(medianMarks, 'daemon-bootstrap-start', 'daemon-bootstrap-end'))}`);
+    console.log(`    spawn call (ensure-start→spawned)           ${fmt(span(medianMarks, 'daemon-ensure-start', 'daemon-spawned'))}`);
+    console.log(`    daemon boot (spawned→pipe-file-seen)        ${fmt(span(medianMarks, 'daemon-spawned', 'daemon-pipe-file-seen'))}`);
+    console.log(`    ping latency (pipe-file-seen→first-ping-ok) ${fmt(span(medianMarks, 'daemon-pipe-file-seen', 'daemon-first-ping-ok'))}`);
+    console.log(`  ready tail (renderer-load-triggered→ready-end) ${fmt(span(medianMarks, 'renderer-load-triggered', 'ready-end'))}`);
+    if (Object.keys(medianDaemonMarks).length > 0) {
+      const d = medianDaemonMarks;
+      console.log('  daemon internal (ms since spawn): '
+        + ['main-start', 'lock-acquired', 'bootid-done', 'config-loaded', 'recovery-done', 'pre-pipe-start', 'pipe-listening', 'ready']
+          .map((k) => `${k}=${d[k] ?? 'n/a'}`).join(' '));
+      console.log(`    daemon pipe start / token ACL (pre-pipe-start→pipe-listening) ${fmt(span(medianDaemonMarks, 'pre-pipe-start', 'pipe-listening'))}`);
+    }
   }
 
   if (!lastInst && (ARGS.diag || !ARGS.skipInput || !ARGS.skipRam)) {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -16,11 +16,29 @@ import { PortWatcher } from '../main/pty/portWatch';
 import { initDaemonLogSink } from './util/logSink';
 import type { DaemonState } from './types';
 import type { DaemonEvent, DaemonCreateSessionParams, DaemonSessionIdParams, DaemonResizeParams } from '../shared/rpc';
-import { monitorEventLoopDelay } from 'node:perf_hooks';
+import { monitorEventLoopDelay, performance as nodePerformance } from 'node:perf_hooks';
 import { DAEMON_EXIT_ALREADY_RUNNING } from '../shared/constants';
 
 // === Constants ===
 const wmuxDir = getWmuxDir();
+
+// Boot-phase trace (S-A). The launcher spawns this process with
+// `stdio: 'ignore'`, so unlike the main process we cannot stream marks over
+// stderr — instead marks accumulate here and are exposed two ways:
+//  - `daemon.ping` response carries `bootTrace` (additive field; the bench
+//    reads it, the launcher/respawn-controller only read status/pid)
+//  - one `[boot-trace] summary=` log line at the end of main() lands in
+//    ~/.wmux/logs/daemon-YYYY-MM-DD.log for postmortems.
+// Marks are absolute Date.now() epochs so the bench can place them on the
+// same timeline as the main-process marks (same machine, same clock).
+const DAEMON_BOOT: { jsStartEpochMs: number; marks: Record<string, number> } = {
+  jsStartEpochMs: Date.now(),
+  marks: {},
+};
+function markDaemonBoot(name: string): void {
+  if (name in DAEMON_BOOT.marks) return; // first-occurrence-wins
+  DAEMON_BOOT.marks[name] = Date.now();
+}
 
 // RCA A4 — event-loop lag monitor. Enabled once at module load; daemon.ping
 // reports the mean lag (ms) since the previous ping so the main-side health
@@ -811,7 +829,16 @@ function registerRpcHandlers(
     eventLoopMonitor.reset();
     // `pid` lets the launcher restore daemon.pid after a Step ③ reconnect
     // (the redundant-daemon path cleaned the pid file). Log-only otherwise.
-    return { status: 'ok', pid: process.pid, uptime, sessions: sessions.length, eventLoopLagMs };
+    // `bootTrace` is additive (S-A cold-start instrumentation): the perf
+    // bench reads it; launcher/respawn-controller only read status/pid.
+    return {
+      status: 'ok',
+      pid: process.pid,
+      uptime,
+      sessions: sessions.length,
+      eventLoopLagMs,
+      bootTrace: { jsStartEpochMs: DAEMON_BOOT.jsStartEpochMs, marks: DAEMON_BOOT.marks },
+    };
   });
 
   // daemon.shutdown — gracefully terminate the daemon process. A2 makes
@@ -1320,18 +1347,22 @@ async function shutdown(
 
 async function main(): Promise<void> {
   const startTime = Date.now();
+  markDaemonBoot('main-start');
   log('info', `wmux-daemon starting (PID ${process.pid})`);
 
   // 1. Single-instance check
   if (!(await acquireLock())) {
     process.exit(1);
   }
+  markDaemonBoot('lock-acquired');
 
   // Cache boot ID early (async) so buildState() never needs to block
   await initBootId();
+  markDaemonBoot('bootid-done');
 
   // 2. Load configuration
   const config = loadConfig();
+  markDaemonBoot('config-loaded');
   log('info', `Config loaded (logLevel=${config.daemon.logLevel})`);
 
   // 3. Initialize modules
@@ -1399,6 +1430,7 @@ async function main(): Promise<void> {
   // instead of destroying it (codex #4).
   const maxRecover = Math.min(config.session.maxSessions, MAX_RECOVER_SESSIONS);
   await recoverSessions(stateWriter, sessionManager, processMonitor, maxRecover);
+  markDaemonBoot('recovery-done');
 
   // 5. Register RPC handlers
   registerRpcHandlers(
@@ -1422,7 +1454,9 @@ async function main(): Promise<void> {
   disposeContextWatchers = wireContextWatchers(sessionManager, pipeServer);
 
   // 7. Start control pipe
+  markDaemonBoot('pre-pipe-start');
   await pipeServer.start();
+  markDaemonBoot('pipe-listening');
 
   // Write active pipe name so clients know which pipe to connect to
   const activePipeName = pipeServer.getActivePipeName();
@@ -1432,6 +1466,7 @@ async function main(): Promise<void> {
   } catch (err) {
     log('warn', 'Failed to write pipe name file:', err);
   }
+  markDaemonBoot('pipe-file-written');
 
   // doShutdown is hoisted ahead of `setCallbacks` so the idle-shutdown
   // callback can route through the same termination path used by
@@ -1627,7 +1662,18 @@ async function main(): Promise<void> {
     log('error', 'Unhandled rejection:', reason);
   });
 
+  markDaemonBoot('ready');
   log('info', `Daemon ready — pipe: ${activePipeName}`);
+  // Boot summary for postmortems. nodeTiming gives the Node/V8 startup split
+  // for free (all values are ms relative to nodeTiming's own timeOrigin).
+  try {
+    const nt = nodePerformance.nodeTiming;
+    log('info', `[boot-trace] summary=${JSON.stringify({
+      jsStartEpochMs: DAEMON_BOOT.jsStartEpochMs,
+      marks: DAEMON_BOOT.marks,
+      nodeTiming: { nodeStart: nt.nodeStart, v8Start: nt.v8Start, bootstrapComplete: nt.bootstrapComplete, environment: nt.environment },
+    })}`);
+  } catch { /* tracing must never break boot */ }
 }
 
 main().catch((err) => {

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -7,6 +7,7 @@ import { app, dialog } from 'electron';
 import { getWmuxDir } from '../../daemon/config';
 import { getDaemonPipeName, readDaemonAuthToken } from '../DaemonClient';
 import { DAEMON_EXIT_ALREADY_RUNNING } from '../../shared/constants';
+import { markBoot } from '../util/bootTrace';
 
 export interface DaemonInfo {
   pid: number;
@@ -318,6 +319,7 @@ function findNodePath(): string {
 }
 
 function spawnDaemon(): Promise<number> {
+  markBoot('daemon-spawn-start');
   return new Promise((resolve, reject) => {
     // Find daemon script
     // In dev: app.getAppPath() = project root → dist/daemon/daemon/index.js
@@ -372,6 +374,7 @@ function spawnDaemon(): Promise<number> {
       return;
     }
 
+    markBoot('daemon-spawned');
     console.log(`[launcher] Daemon spawned with PID: ${child.pid}`);
 
     // Wait for daemon to be ready.
@@ -398,6 +401,7 @@ function spawnDaemon(): Promise<number> {
         }
         return;
       }
+      markBoot('daemon-pipe-file-seen');
 
       const token = readDaemonAuthToken();
       if (!token) {
@@ -413,6 +417,7 @@ function spawnDaemon(): Promise<number> {
       pinging = false;
 
       if (alive) {
+        markBoot('daemon-first-ping-ok');
         clearInterval(poll);
         resolve(child.pid!);
         return;
@@ -452,6 +457,7 @@ function readPipeNameFromFile(wmuxDir: string): string | null {
 }
 
 export async function ensureDaemon(): Promise<DaemonInfo> {
+  markBoot('daemon-ensure-start');
   const wmuxDir = getWmuxDir();
   const pidFile = path.join(wmuxDir, 'daemon.pid');
 
@@ -465,7 +471,11 @@ export async function ensureDaemon(): Promise<DaemonInfo> {
   // 2. If the PID is alive OR its liveness is unknown (a probe timeout must
   //    NOT be read as "dead" — Defect 1), enter the ping/reuse path. Only a
   //    confirmed-dead PID skips straight to spawn over a possibly-live daemon.
-  if (existingPid && checkProcessLiveness(existingPid) !== 'dead') {
+  const livenessOnBoot = existingPid ? checkProcessLiveness(existingPid) : null;
+  // Boot-trace only (first-occurrence-wins): isolates the tasklist.exe cost
+  // on machines where AV slows process probes. No-op on respawn re-entry.
+  markBoot('daemon-liveness-checked');
+  if (existingPid && livenessOnBoot !== 'dead') {
     const token = readDaemonAuthToken();
     const pipeName = readPipeNameFromFile(wmuxDir) || getDaemonPipeName();
 
@@ -483,6 +493,7 @@ export async function ensureDaemon(): Promise<DaemonInfo> {
         alive = await pingDaemon(pipeName, token);
       }
       if (alive) {
+        markBoot('daemon-reused');
         console.log(`[launcher] Daemon already running (PID: ${existingPid})`);
         return { pid: existingPid, authToken: token, pipeName, spawned: false };
       }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,11 @@ process.on('uncaughtException', (err) => {
   console.error('[Main] Uncaught exception:', err);
 });
 
+// MUST stay the first import: ESM import hoisting means evaluation order ==
+// import order, and bootTrace's module body stamps `js-start` (the first JS
+// the main process runs). Moving it below another import skews every boot
+// phase measurement by that import's eval cost.
+import { markBoot, emitBootSummary } from './util/bootTrace';
 import * as crypto from 'crypto';
 import * as path from 'path';
 import { app, BrowserWindow, dialog, ipcMain, powerMonitor } from 'electron';
@@ -62,6 +67,8 @@ import { collectLegacyMetadata } from './metadata/legacyMigration';
 import { sessionManager, registerSessionHandlers } from './ipc/handlers/session.handler';
 import { eventBus } from './events/EventBus';
 import { initLogSink, logLine } from './util/logSink';
+
+markBoot('imports-done');
 
 // Force English for Chromium internal messages to avoid encoding corruption
 // on non-ASCII locales (e.g. Korean Windows where cp949 garbles console output).
@@ -176,6 +183,10 @@ if (process.platform === 'win32') {
 // Squirrel handlers above already called process.exit() in their callbacks.
 if (!isSquirrelEvent) {
 appInit();
+// All module-level construction is done (PTYManager, PipeServer ctor's sync
+// token-file read, handler registration). ready-fired minus this mark =
+// pure Electron app-ready wait.
+markBoot('module-eval-end');
 }
 
 function appInit(): void {
@@ -208,6 +219,7 @@ let fullShutdownRequested = false;
 
 // Prevent multiple instances — focus existing window instead
 const gotLock = app.requestSingleInstanceLock();
+markBoot('lock-acquired');
 console.log(`[DEBUG] gotLock = ${gotLock}`);
 if (!gotLock) {
   console.log('[DEBUG] failed to get single instance lock, quitting');
@@ -224,6 +236,7 @@ if (!gotLock) {
   });
 }
 
+markBoot('construction-start');
 const ptyManager = new PTYManager();
 let mainWindow: BrowserWindow | null = null;
 // Forward-declared: PTYBridge captures this binding by reference and reads it
@@ -235,7 +248,12 @@ const ptyBridge = new PTYBridge(ptyManager, () => mainWindow, () => hookSignalRo
 const autoUpdater = new AutoUpdater(() => mainWindow);
 
 const rpcRouter = new RpcRouter();
+markBoot('pre-pipe-server-ctor');
 const pipeServer = new PipeServer(rpcRouter);
+// Isolates the PipeServer constructor: its loadOrCreateToken() shells out to
+// PowerShell for token-file ACL hardening (secureWriteTokenFile /
+// reHardenTokenFileAcl) — a prime cold-start suspect.
+markBoot('pipe-server-ctor-done');
 
 // Plugin host (B-1). Scheme privileges MUST be registered before app
 // 'ready'; the loader itself is constructed inside the ready handler (it
@@ -580,6 +598,7 @@ ipcMain.handle('browser:register-webview', async (_event, surfaceId: string, web
 
 console.log('[DEBUG] registering app.on(ready)');
 app.on('ready', async () => {
+  markBoot('ready-fired');
   // Persistent log sink — must come first so every subsequent stderr write
   // and explicit logLine() call lands on disk for postmortem analysis.
   // Path: %APPDATA%\wmux\logs\main-YYYY-MM-DD.log (Windows default).
@@ -633,8 +652,10 @@ app.on('ready', async () => {
     logLine('warn', 'main', `plugin host load failed: ${err instanceof Error ? err.message : String(err)}`);
   }
   registerPluginProtocolHandler(() => pluginHostLoader);
+  markBoot('plugins-loaded');
 
   mainWindow = createWindow({ deferLoad: true });
+  markBoot('window-created');
   console.log(`[Main] Window created (renderer load deferred): ${!!mainWindow}`);
   logLine('info', 'main', `window created (deferred): present=${!!mainWindow}`);
 
@@ -827,11 +848,13 @@ app.on('ready', async () => {
       error: (msg) => { logLine('error', 'daemon-respawn', msg); },
     },
   });
+  markBoot('daemon-bootstrap-start');
   try {
     await daemonRespawnController.bootstrap();
   } catch (err) {
     console.warn('[Main] Daemon auto-start failed, using local PTY:', err);
   }
+  markBoot('daemon-bootstrap-end');
 
   // v2.8.1 hotfix (Bug 3): unblock any renderer that already invoked
   // `daemon:get-ready-state`. From this point on the handler answers
@@ -855,6 +878,7 @@ app.on('ready', async () => {
   // the `createWindow({ deferLoad: true })` call.
   if (mainWindow && !mainWindow.isDestroyed()) {
     loadMainRenderer(mainWindow);
+    markBoot('renderer-load-triggered');
     logLine('info', 'main', 'renderer load triggered after daemon bootstrap');
   }
 
@@ -1040,6 +1064,10 @@ app.on('ready', async () => {
   mcpRegistrar.register(authToken);
   pipeServer.start();
   autoUpdater.start();
+  markBoot('ready-end');
+  // Log sink is up by now, so the summary line (unlike the early per-mark
+  // stderr lines) is durably teed into the daily log file for postmortems.
+  emitBootSummary();
 });
 
 // Browser-pane popup policy (X3). The BrowserPanel webview sets allowpopups

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -219,13 +219,15 @@ let fullShutdownRequested = false;
 
 // Prevent multiple instances — focus existing window instead
 const gotLock = app.requestSingleInstanceLock();
-markBoot('lock-acquired');
 console.log(`[DEBUG] gotLock = ${gotLock}`);
 if (!gotLock) {
   console.log('[DEBUG] failed to get single instance lock, quitting');
   app.quit();
   return;
 } else {
+  // Mark only on the success path — the duplicate-instance branch quits and
+  // must not leave a "lock-acquired" lie in the boot trace.
+  markBoot('lock-acquired');
   app.on('second-instance', () => {
     if (isQuitting) return;
     if (mainWindow) {

--- a/src/main/util/bootTrace.ts
+++ b/src/main/util/bootTrace.ts
@@ -1,0 +1,111 @@
+/**
+ * Boot-phase timing trace for the main process.
+ *
+ * Why this exists: cold start (spawn → first PTY data) was a single opaque
+ * number — the bench (scripts/perf-bench.mjs) could see WHEN the app became
+ * ready but not WHERE the time went (module eval vs app-ready wait vs plugin
+ * scan vs daemon bootstrap). This module emits one cheap, always-on stderr
+ * line per boot milestone so the bench (and a future `wmux doctor`) can
+ * attribute every millisecond of the boot critical path.
+ *
+ * Design constraints:
+ *  - ZERO imports. This module must be the FIRST import of src/main/index.ts
+ *    so its module body evaluates before every other LOCAL module body
+ *    (Vite/Rollup ESM import hoisting means import order == evaluation
+ *    order). Importing anything here would evaluate that dependency first
+ *    and skew `js-start`. Note: Rollup hoists EXTERNAL `require()` calls
+ *    (electron, node-pty, …) above all module bodies in the flattened
+ *    bundle, so `js-start` means "external native modules loaded, first
+ *    local code running" — external load cost lands in the pre-JS span
+ *    (procCreate → js-start), by design.
+ *  - Raw process.stderr.write, never logLine(): marks fire before the log
+ *    sink exists. The sink tees stderr to the daily log file once installed,
+ *    so post-ready marks land on disk automatically; `emitBootSummary()`
+ *    re-emits the full picture after the sink is up so the early marks are
+ *    durably captured too.
+ *  - Zero telemetry: stderr + local log file only, nothing leaves the machine.
+ *
+ * Line format (parsed by scripts/perf-bench.mjs — keep stable):
+ *   [boot-trace] mark=<name> epoch=<Date.now() ms>
+ *   [boot-trace] summary=<json>
+ */
+
+/** Process creation time (ms epoch) — Electron extends `process` with this.
+ *  `js-start` minus this value = pre-JS tax: exe mapping, Chromium early
+ *  init, and any AV scan of the binary before our first line runs. */
+const PROC_CREATE_EPOCH_MS: number | null =
+  typeof (process as NodeJS.Process & { getCreationTime?: () => number | null })
+    .getCreationTime === 'function'
+    ? (process as NodeJS.Process & { getCreationTime: () => number | null }).getCreationTime()
+    : null;
+
+const JS_START_EPOCH_MS = Date.now();
+
+/** First-occurrence-wins mark store. Respawn paths re-enter ensureDaemon()
+ *  long after boot; the trace must describe the BOOT, not the latest retry. */
+const marks: Record<string, number> = {};
+
+function emitLine(line: string): void {
+  try {
+    process.stderr.write(line + '\n');
+  } catch {
+    /* never break boot for tracing */
+  }
+}
+
+/**
+ * Record a boot milestone and emit it immediately. Idempotent per name —
+ * only the first call sticks (and only the first call emits a line).
+ */
+export function markBoot(name: string): void {
+  if (name in marks) return;
+  const epoch = Date.now();
+  marks[name] = epoch;
+  emitLine(`[boot-trace] mark=${name} epoch=${epoch}`);
+}
+
+/** Marks as deltas (ms) from js-start — the human-readable view. */
+function marksAsDeltas(): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const [name, epoch] of Object.entries(marks)) {
+    out[name] = epoch - JS_START_EPOCH_MS;
+  }
+  return out;
+}
+
+/**
+ * Emit the one-line JSON summary. Call at ready-handler end: the log sink
+ * tee is installed by then, so this line (unlike the early per-mark lines)
+ * lands in %APPDATA%\wmux\logs\main-YYYY-MM-DD.log for postmortems.
+ */
+export function emitBootSummary(): void {
+  try {
+    const summary = {
+      procCreateEpochMs: PROC_CREATE_EPOCH_MS,
+      jsStartEpochMs: JS_START_EPOCH_MS,
+      preJsMs: PROC_CREATE_EPOCH_MS != null ? JS_START_EPOCH_MS - PROC_CREATE_EPOCH_MS : null,
+      marks: marksAsDeltas(),
+    };
+    emitLine(`[boot-trace] summary=${JSON.stringify(summary)}`);
+  } catch {
+    /* never break boot for tracing */
+  }
+}
+
+/** Accessor for future surfaces (`wmux doctor`, diagnostics RPC). */
+export function getBootTrace(): {
+  procCreateEpochMs: number | null;
+  jsStartEpochMs: number;
+  marks: Record<string, number>;
+} {
+  return {
+    procCreateEpochMs: PROC_CREATE_EPOCH_MS,
+    jsStartEpochMs: JS_START_EPOCH_MS,
+    marks: { ...marks },
+  };
+}
+
+// Record js-start as a mark too so the bench's mark parser sees the anchor
+// without special-casing the summary line. Emitted at module eval — i.e. the
+// first JS the main process runs (this module is index.ts's first import).
+markBoot('js-start');

--- a/src/main/util/bootTrace.ts
+++ b/src/main/util/bootTrace.ts
@@ -56,10 +56,13 @@ function emitLine(line: string): void {
 /**
  * Record a boot milestone and emit it immediately. Idempotent per name —
  * only the first call sticks (and only the first call emits a line).
+ * `epochOverride` lets a mark carry a timestamp captured earlier than the
+ * call itself (used for js-start, whose moment is the module-level
+ * JS_START_EPOCH_MS capture, not the markBoot call at the end of this file).
  */
-export function markBoot(name: string): void {
+export function markBoot(name: string, epochOverride?: number): void {
   if (name in marks) return;
-  const epoch = Date.now();
+  const epoch = epochOverride ?? Date.now();
   marks[name] = epoch;
   emitLine(`[boot-trace] mark=${name} epoch=${epoch}`);
 }
@@ -106,6 +109,7 @@ export function getBootTrace(): {
 }
 
 // Record js-start as a mark too so the bench's mark parser sees the anchor
-// without special-casing the summary line. Emitted at module eval — i.e. the
-// first JS the main process runs (this module is index.ts's first import).
-markBoot('js-start');
+// without special-casing the summary line. The epoch is the module-level
+// JS_START_EPOCH_MS capture (the first JS the main process runs — this module
+// is index.ts's first import), not this call's own Date.now().
+markBoot('js-start', JS_START_EPOCH_MS);

--- a/src/shared/security.ts
+++ b/src/shared/security.ts
@@ -196,6 +196,21 @@ function applyRestrictiveAclViaIcacls(filePath: string, principal: string): void
  * name rather than re-introduce the icacls codepage mangle.
  */
 function applyRestrictiveWindowsAcl(filePath: string): void {
+  // Boot-phase diagnostics (S-A): this function shells out synchronously to
+  // whoami.exe + powershell.exe (or icacls) and runs on EVERY cold start in
+  // both the main process (PipeServer ctor → loadOrCreateToken) and the
+  // daemon (DaemonPipeServer.start → loadOrCreateToken). PowerShell process
+  // start under AV is a known multi-second tax — log the duration so boot
+  // traces can attribute it.
+  const aclStart = Date.now();
+  try {
+    applyRestrictiveWindowsAclInner(filePath);
+  } finally {
+    console.log(`[security] token ACL harden took ${Date.now() - aclStart}ms (${path.basename(filePath)})`);
+  }
+}
+
+function applyRestrictiveWindowsAclInner(filePath: string): void {
   const { sid, username } = resolveOwnerIdentity(filePath);
 
   // PRIMARY: DACL-only rebuild via .NET FileInfo.SetAccessControl. The target


### PR DESCRIPTION
## Summary

Cold start (process spawn -> first PTY data at the renderer) was a single opaque number: the A1 bench (#207) could see WHEN the app became ready but not WHERE the time went. This PR adds a permanent, zero-telemetry boot trace across all three processes and teaches the bench to attribute every phase.

- **`src/main/util/bootTrace.ts` (new, zero-dep, deliberately the first import of main)**: stamps `js-start` at module eval (anchored against `process.getCreationTime()` for the pre-JS tax), emits one cheap stderr line per milestone, and a JSON summary at ready-end that the log-sink tee lands in the daily log file for postmortems.
- **Main marks**: imports-done / lock-acquired / construction (isolating the PipeServer ctor) / module-eval-end / ready-fired / plugins-loaded / window-created / daemon-bootstrap start+end / renderer-load-triggered / ready-end.
- **Launcher marks**: ensure / liveness / spawn / pipe-file-seen / first-ping-ok (first-occurrence-wins, so respawn re-entry never overwrites the boot record).
- **Daemon**: in-memory marks exposed via an additive `bootTrace` field on `daemon.ping` plus a summary log line with `performance.nodeTiming` (its stdio is `ignore`, so stderr was not an option).
- **`shared/security.ts`**: logs the duration of every token-ACL hardening shell-out.
- **perf-bench**: collects marks from app stderr and `daemon.ping`, re-bases them onto the spawn timeline (`runs[i].marks`, `runs[i].daemonBoot`, `coldStart.medianMarks` / `medianDaemonMarks` -- all additive; gated metrics and `schemaVersion` untouched, verified perf-compare still gates normally), and prints a derived phase table.

## What the first run found

The table immediately attributed **~70% of the measured cold start to the auth-token ACL hardening's synchronous PowerShell shell-outs** (median 2015ms in the main PipeServer ctor + 3465ms inside `DaemonPipeServer.start()`, directly on the launcher-polled path). Every other suspected phase -- module eval (4ms), plugin scan (15ms), handler registration (7ms), daemon recovery (5ms) -- measured in single-digit ms. The follow-up PR (#stacked on this one) targets that path.

## Verification

- tsc (main + daemon), eslint (no new findings), vitest 2983/2983
- 3 bench runs (2 smoke + 1 full local); perf-compare gate PASS against baseline-local (no record-only fallback -> schema compat confirmed)
- Boot-trace summary lines confirmed in both `main-*.log` and `daemon-*.log` of an isolated packaged instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced cold-start diagnostics: per-boot milestone traces and a JSON summary are recorded, and benchmarks now produce a detailed phase-attribution breakdown (including daemon marks) to pinpoint regressions.
  * Runtime logs now capture timing for security-related token ACL hardening.

* **Documentation**
  * Updated bench docs with boot-phase attribution methodology and a Windows Defender caveat plus one-off exclusion guidance.
* **Privacy**
  * Tracing uses stderr/local logs only; no telemetry is collected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->