### PR TITLE
feat(hooks): notify on Claude Code AskUserQuestion (awaiting-input via PreToolUse)

### DIFF
--- a/docs/superpowers/plans/2026-06-12-askuserquestion-awaiting-input.md
+++ b/docs/superpowers/plans/2026-06-12-askuserquestion-awaiting-input.md
@@ -1,0 +1,312 @@
+# AskUserQuestion Awaiting-Input Hook Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When Claude Code shows an AskUserQuestion prompt in a wmux pane, fire the existing `awaiting_input` experience (yellow sidebar dot + notification sound), driven by a reliable `PreToolUse` hook instead of fragile regex.
+
+**Architecture:** Ride the existing Claude hook bridge → `hooks.signal` RPC → `HookSignalRouter` → `hooks.rpc.ts` fan-out. The `agent.awaiting_input` kind already exists in the signal union and in `titleFor`/`bodyFor`; we (1) let the validator accept it from hooks, (2) make the fan-out emit it AND light the sidebar dot, and (3) register the `PreToolUse`/AskUserQuestion hook in the bridge.
+
+**Tech Stack:** Node (self-contained bridge .mjs), TypeScript (main process), Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-askuserquestion-awaiting-input-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `integrations/shared/signal-types.ts` — `isAgentSignal()` accepts `agent.awaiting_input`; update stale comment.
+- **Modify** `src/main/pipe/handlers/hooks.rpc.ts` — add `agent.awaiting_input` to `isEmitKind`; broadcast `agentStatus: 'awaiting_input'` on emit.
+- **Modify** `integrations/claude/bin/wmux-bridge.mjs` — `HOOK_TO_KIND.PreToolUse = 'agent.awaiting_input'` + `tool_name` guard.
+- **Modify** `integrations/claude/hooks/hooks.json` — register `PreToolUse` matcher `"AskUserQuestion"`.
+- **Tests:** extend `integrations/shared/__tests__/signal-types.test.ts` and `src/main/pipe/handlers/__tests__/hooks.rpc.emit.test.ts`.
+
+---
+
+## Task 1: Validator accepts `agent.awaiting_input`
+
+**Files:**
+- Test: `integrations/shared/__tests__/signal-types.test.ts`
+- Modify: `integrations/shared/signal-types.ts:121-129` (and doc comment ~20-27)
+
+- [ ] **Step 1: Write the failing test**
+
+In `integrations/shared/__tests__/signal-types.test.ts`, add `'agent.awaiting_input'` to the existing `it.each([...])('accepts kind = %s', ...)` list (the array currently holds the four other kinds):
+
+```ts
+  it.each([
+    'agent.stop',
+    'agent.activity',
+    'agent.subagent_stop',
+    'agent.session_start',
+    'agent.awaiting_input',
+  ])('accepts kind = %s', (kind) => {
+    expect(isAgentSignal({ ...valid, kind })).toBe(true);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run integrations/shared/__tests__/signal-types.test.ts`
+Expected: FAIL on `accepts kind = agent.awaiting_input` (validator rejects it today).
+
+- [ ] **Step 3: Accept the kind in the validator**
+
+In `integrations/shared/signal-types.ts`, change the kind guard in `isAgentSignal` (lines ~124-129) to also allow `agent.awaiting_input`:
+
+```ts
+  if (
+    v['kind'] !== 'agent.stop' &&
+    v['kind'] !== 'agent.activity' &&
+    v['kind'] !== 'agent.subagent_stop' &&
+    v['kind'] !== 'agent.session_start' &&
+    v['kind'] !== 'agent.awaiting_input'
+  ) return false;
+```
+
+- [ ] **Step 4: Update the stale doc comment**
+
+In `integrations/shared/signal-types.ts`, in the `AgentSignalKind` doc block (~lines 20-27), replace the "Hook bridges are not expected to emit this kind today" sentence so it reflects that the Claude bridge now emits it on AskUserQuestion:
+
+```ts
+ * - agent.awaiting_input  — agent paused for input: a y/N or approval prompt
+ *                           (regex AgentDetector), OR Claude Code's
+ *                           AskUserQuestion tool (emitted by the Claude hook
+ *                           bridge via PreToolUse). Routed through the same
+ *                           HookSignalRouter ledger as agent.stop.
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run integrations/shared/__tests__/signal-types.test.ts`
+Expected: PASS (all kinds incl. `agent.awaiting_input`; `rejects unknown kind` still passes).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add integrations/shared/signal-types.ts integrations/shared/__tests__/signal-types.test.ts
+git commit -m "feat(signals): accept agent.awaiting_input from hook bridges"
+```
+
+---
+
+## Task 2: Fan out `awaiting_input` + light the sidebar dot
+
+**Files:**
+- Test: `src/main/pipe/handlers/__tests__/hooks.rpc.emit.test.ts`
+- Modify: `src/main/pipe/handlers/hooks.rpc.ts:179` and the emit block ~229-236 (+ import)
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/main/pipe/handlers/__tests__/hooks.rpc.emit.test.ts`, add a mock for the metadata handler near the other `vi.mock` calls (after line 24), plus a hoisted mock fn (extend the `vi.hoisted` block at line 13):
+
+```ts
+const { sendToRendererMock, sendNotificationMock, broadcastMetadataUpdateMock } = vi.hoisted(() => ({
+  sendToRendererMock: vi.fn(),
+  sendNotificationMock: vi.fn(),
+  broadcastMetadataUpdateMock: vi.fn(),
+}));
+```
+
+```ts
+vi.mock('../../../ipc/handlers/metadata.handler', () => ({
+  broadcastMetadataUpdate: broadcastMetadataUpdateMock,
+}));
+```
+
+Then add a test inside the `describe('hooks.signal — agent.lifecycle event tee', ...)` block:
+
+```ts
+  it('emits and lights the sidebar dot for agent.awaiting_input', async () => {
+    const stub = stubHookRouter();
+    stub.setDecision('emit');
+    const router = new RpcRouter();
+    registerHooksRpc(router, () => fakeWindow(), stub.router);
+
+    const res = await router.dispatch({
+      id: '8',
+      method: 'hooks.signal',
+      params: signal({ kind: 'agent.awaiting_input' }) as unknown as Record<string, unknown>,
+    });
+
+    expect(res.ok).toBe(true);
+    const events = pollLifecycle();
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('agent.awaiting_input');
+    // Sound/toast fires…
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+    // …and the sidebar dot is set to awaiting_input for the resolved pty.
+    expect(broadcastMetadataUpdateMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ptyId: 'pty-1', agentStatus: 'awaiting_input' }),
+    );
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/main/pipe/handlers/__tests__/hooks.rpc.emit.test.ts -t "lights the sidebar dot"`
+Expected: FAIL — `awaiting_input` is not an emit-kind, so no lifecycle event, no `sendNotification`, no `broadcastMetadataUpdate`.
+
+- [ ] **Step 3: Import the metadata broadcaster**
+
+In `src/main/pipe/handlers/hooks.rpc.ts`, add to the imports (near line 44, after the `sendNotification` import):
+
+```ts
+import { broadcastMetadataUpdate } from '../../ipc/handlers/metadata.handler';
+```
+
+- [ ] **Step 4: Add `awaiting_input` to the emit-kinds**
+
+In `hooks.rpc.ts`, change `isEmitKind` (line ~179):
+
+```ts
+    const isEmitKind = signal.kind === 'agent.stop'
+      || signal.kind === 'agent.subagent_stop'
+      || signal.kind === 'agent.awaiting_input';
+```
+
+- [ ] **Step 5: Light the dot on emit**
+
+In `hooks.rpc.ts`, in the final emit block (currently lines ~229-236), after the `sendNotification(...)` call and inside the `if (win)` guard, set the agent status for `awaiting_input`:
+
+```ts
+    const win = getWindow();
+    if (win) {
+      sendNotification(win, ptyId, {
+        type: 'agent',
+        title: titleFor(signal),
+        body: bodyFor(signal),
+      });
+      // Hook path (unlike the detector path in DaemonNotificationRouter) does
+      // not otherwise touch agentStatus. For awaiting_input, set it so the
+      // sidebar dot turns yellow — the part users see at a glance.
+      if (signal.kind === 'agent.awaiting_input') {
+        broadcastMetadataUpdate(win, { ptyId, agentStatus: 'awaiting_input' });
+      }
+    }
+    return { ok: true };
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `npx vitest run src/main/pipe/handlers/__tests__/hooks.rpc.emit.test.ts`
+Expected: PASS (new test + all existing regression tests in the file).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/pipe/handlers/hooks.rpc.ts src/main/pipe/handlers/__tests__/hooks.rpc.emit.test.ts
+git commit -m "feat(hooks): fan out agent.awaiting_input + set sidebar agentStatus"
+```
+
+---
+
+## Task 3: Bridge mapping + guard, and hook registration
+
+**Files:**
+- Modify: `integrations/claude/bin/wmux-bridge.mjs:52-57` and `main()` (~line 304)
+- Modify: `integrations/claude/hooks/hooks.json`
+
+- [ ] **Step 1: Map PreToolUse → awaiting_input**
+
+In `integrations/claude/bin/wmux-bridge.mjs`, extend `HOOK_TO_KIND` (lines 52-57):
+
+```js
+const HOOK_TO_KIND = {
+  PreToolUse: 'agent.awaiting_input',
+  PostToolUse: 'agent.activity',
+  Stop: 'agent.stop',
+  SubagentStop: 'agent.subagent_stop',
+  SessionStart: 'agent.session_start',
+};
+```
+
+- [ ] **Step 2: Guard PreToolUse to AskUserQuestion only**
+
+In `wmux-bridge.mjs`, in `main()`, after the empty-stdin check (the block ending ~line 322, right before the auth-token read) add a tool-name guard so only AskUserQuestion produces an awaiting_input signal:
+
+```js
+  // PreToolUse fires per tool call; we only treat AskUserQuestion as
+  // "awaiting input". A future broad PreToolUse matcher can never tunnel a
+  // spurious awaiting_input through here. (Other PreToolUse tools are dropped.)
+  if (hookName === 'PreToolUse'
+      && !(payload && payload.tool_name === 'AskUserQuestion')) {
+    logEvent('skip-pretooluse', { tool: payload && payload.tool_name });
+    return;
+  }
+```
+
+- [ ] **Step 3: Register the hook in hooks.json**
+
+In `integrations/claude/hooks/hooks.json`, add a `PreToolUse` entry to the `hooks` object (alongside `PostToolUse`/`Stop`/etc.), scoped by matcher so the bridge is only invoked for AskUserQuestion:
+
+```json
+    "PreToolUse": [
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/bin/wmux-bridge.mjs\" PreToolUse"
+          }
+        ]
+      }
+    ],
+```
+
+- [ ] **Step 4: Validate the JSON parses**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('integrations/claude/hooks/hooks.json','utf8')); console.log('hooks.json OK')"`
+Expected: prints `hooks.json OK`.
+
+- [ ] **Step 5: Sanity-run the bridge mapping (no wmux needed)**
+
+Run (simulates a non-matching PreToolUse — should skip, exit 0, write a skip log):
+```bash
+echo '{"tool_name":"Read","cwd":"/tmp","session_id":"s"}' | node integrations/claude/bin/wmux-bridge.mjs PreToolUse; echo "exit=$?"
+```
+Expected: `exit=0` (the guard drops it; no crash). A matching `tool_name:"AskUserQuestion"` would proceed to attempt the pipe RPC and fail-open if wmux isn't running — both are exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add integrations/claude/bin/wmux-bridge.mjs integrations/claude/hooks/hooks.json
+git commit -m "feat(claude-bridge): emit awaiting_input on AskUserQuestion PreToolUse"
+```
+
+---
+
+## Task 4: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full test suite**
+
+Run: `npx vitest run`
+Expected: PASS (the known daemon save-debounce flake may fail under parallel load — re-run that file in isolation to confirm it's unrelated).
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc -p tsconfig.json --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Lint touched TS files**
+
+Run:
+```bash
+npx eslint integrations/shared/signal-types.ts src/main/pipe/handlers/hooks.rpc.ts integrations/shared/__tests__/signal-types.test.ts src/main/pipe/handlers/__tests__/hooks.rpc.emit.test.ts
+```
+Expected: PASS for the changed code (pre-existing warnings elsewhere are out of scope).
+
+- [ ] **Step 4: Manual smoke (real app)**
+
+With the wmux Claude plugin installed, run Claude Code in a wmux pane and trigger an AskUserQuestion. Expect the pane's sidebar dot to turn yellow and the notification sound to play the moment the question appears; answering clears it as the agent resumes.
+
+---
+
+## Self-Review Notes (author checklist — completed)
+
+- **Spec coverage:** validator accepts kind (Task 1) ✓; fan-out emit + dot (Task 2) ✓; bridge map + tool_name guard (Task 3 Steps 1-2) ✓; hooks.json registration (Task 3 Step 3) ✓; tests (Tasks 1-2) ✓; non-goals respected (no new status/sound, no regex, no clear hook) ✓.
+- **Type consistency:** `agent.awaiting_input` kind string used identically across signal-types, hooks.rpc, bridge; `broadcastMetadataUpdate(win, { ptyId, agentStatus: 'awaiting_input' })` matches its `(window, MetadataUpdatePayload)` signature and the `AgentStatus` union.
+- **No placeholders:** every step has full code/commands with expected output.
+```

--- a/docs/superpowers/specs/2026-06-12-askuserquestion-awaiting-input-design.md
+++ b/docs/superpowers/specs/2026-06-12-askuserquestion-awaiting-input-design.md
@@ -1,0 +1,156 @@
+# Notify on Claude Code AskUserQuestion (awaiting-input via PreToolUse hook)
+
+**Date:** 2026-06-12
+**Status:** Approved design, ready for implementation plan
+**Area:** `integrations/claude`, `integrations/shared`, `src/main/pipe/handlers`
+
+## Problem
+
+When Claude Code (running in a wmux pane) uses its interactive **AskUserQuestion**
+tool, wmux gives the user no signal — no sound, no sidebar dot — so a user who
+looked away never learns Claude is blocked waiting on them. wmux *does* notify on
+replies (`Stop`) and on the single-line permission prompt (`Do you want to
+proceed?`), but not on AskUserQuestion.
+
+### Root cause
+
+wmux detects "awaiting input" only via **AgentDetector regex** on terminal
+output, anchored to single-line prompts (`Do you want to proceed?`, `Allow tool
+use for X`). AskUserQuestion renders a **multi-line boxed** header + option list,
+so no pattern matches → the `awaiting_input` agent status (which already maps to a
+yellow sidebar dot + sound) never fires.
+
+The robust fix is signal-based, not regex-based. Authoritative Claude Code docs
+confirm: the **Notification hook does NOT fire** for AskUserQuestion, but
+**`PreToolUse` with matcher `"AskUserQuestion"` DOES** — firing the instant Claude
+is about to show the question, with `tool_name: "AskUserQuestion"`. wmux already
+runs a Claude Code **hook bridge** (`wmux-bridge.mjs`) for `Stop`/`PostToolUse`/
+`SubagentStop`/`SessionStart`; we add one more hook to it.
+
+## Goal
+
+When Claude Code shows an AskUserQuestion prompt in a wmux pane, fire the existing
+`awaiting_input` experience: the **sidebar dot turns yellow** and the
+**notification sound/toast** plays — same as the regex path already does for
+permission prompts, but driven by a reliable hook.
+
+## Non-goals (YAGNI)
+
+- No new agent status, sound, or sidebar styling — reuse the existing
+  `awaiting_input` status, yellow dot, and `type: 'agent'` notification.
+- No regex pattern for AskUserQuestion (fragile; the hook is authoritative).
+- No enriched notification body (the question text) — `bodyFor` already returns a
+  sensible "Approval requested"; question-aware body is a possible follow-up.
+- No explicit "clear" hook — answering resumes the agent, whose next
+  `session:active` / `Stop` already updates the status away from `awaiting_input`.
+
+## Architecture
+
+Ride the existing bridge → `hooks.signal` RPC → `HookSignalRouter` dedup →
+`hooks.rpc.ts` fan-out. The `agent.awaiting_input` kind already exists in the
+signal union and in `titleFor`/`bodyFor`; three boundaries currently drop it, and
+the fan-out doesn't light the dot. Close exactly those gaps.
+
+```
+Claude Code shows AskUserQuestion
+  → PreToolUse hook (matcher "AskUserQuestion")
+    → wmux-bridge.mjs PreToolUse  (guard: tool_name === "AskUserQuestion")
+      → RPC hooks.signal { kind: 'agent.awaiting_input', ... }
+        → isAgentSignal() must ACCEPT awaiting_input        [gap 3]
+        → resolve cwd/env → ptyId
+        → isEmitKind must INCLUDE awaiting_input            [gap 4a]
+          → sendNotification(type:'agent')  → sound + toast (existing)
+          → broadcastMetadataUpdate({ptyId, agentStatus:'awaiting_input'}) → yellow dot  [gap 4b]
+```
+
+## Components & changes
+
+### 1. `integrations/claude/hooks/hooks.json` — register the hook (gap 1)
+
+Add a `PreToolUse` entry whose matcher is scoped to the tool, so the bridge is
+invoked only for AskUserQuestion (not every tool call):
+
+```json
+"PreToolUse": [
+  {
+    "matcher": "AskUserQuestion",
+    "hooks": [
+      { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/bin/wmux-bridge.mjs\" PreToolUse" }
+    ]
+  }
+]
+```
+
+### 2. `integrations/claude/bin/wmux-bridge.mjs` — map + guard (gap 2)
+
+- Add `PreToolUse: 'agent.awaiting_input'` to `HOOK_TO_KIND`.
+- Defense in depth: for `PreToolUse`, only emit when the payload's `tool_name`
+  is `AskUserQuestion`; otherwise log and exit 0 (so a future broad `PreToolUse`
+  matcher can never tunnel a spurious awaiting_input). This is a small guard in
+  `main()` after the payload is read.
+
+### 3. `integrations/shared/signal-types.ts` — accept the kind (gap 3)
+
+- `isAgentSignal()` currently accepts only `agent.stop` / `agent.activity` /
+  `agent.subagent_stop` / `agent.session_start` and rejects everything else. Add
+  `agent.awaiting_input` to the accepted set.
+- Update the now-stale doc comment that says "Hook bridges are not expected to
+  emit this kind today."
+
+### 4. `src/main/pipe/handlers/hooks.rpc.ts` — fan out + dot (gap 4)
+
+- `isEmitKind` (currently `agent.stop || agent.subagent_stop`) must also include
+  `agent.awaiting_input`, so it runs the dedup ledger and fans out a
+  notification. `titleFor`/`bodyFor` already cover the kind.
+- On an **emit** decision for `agent.awaiting_input`, additionally call
+  `broadcastMetadataUpdate(win, { ptyId, agentStatus: 'awaiting_input' })` so the
+  sidebar dot turns yellow (the hook path sends notifications but, unlike the
+  detector path in `DaemonNotificationRouter`, does not currently touch
+  `agentStatus`). Import `broadcastMetadataUpdate` from the metadata handler.
+
+## Data flow & dedup
+
+`agent.awaiting_input` is an emit-kind, so it flows through `HookSignalRouter`
+exactly like `agent.stop`: if the regex detector *also* fired for the same
+(agent, pty, kind) within 10 s, the hook is deduped (no double toast) but latency
+is still recorded. For AskUserQuestion the detector never matches, so the hook is
+the sole emitter — which is the whole point.
+
+## Error handling
+
+- Bridge: unchanged fail-open posture — any error logs to `~/.wmux/bridge.log`
+  and exits 0, never slowing or breaking Claude. The `tool_name` guard simply
+  drops non-matching PreToolUse calls.
+- RPC: a malformed or unmatched-cwd signal returns the existing
+  `invalid-envelope` / `no-workspace-match` reasons; no behavior change for other
+  kinds.
+
+## Testing
+
+- **`integrations/shared/__tests__/signal-types.test.ts`:** `isAgentSignal`
+  accepts a well-formed `agent.awaiting_input` envelope (currently it would
+  reject it), and still rejects unknown kinds.
+- **`src/main/pipe/handlers/__tests__/hooks.rpc.*` (extend or add):** a
+  `hooks.signal` with `kind: 'agent.awaiting_input'` resolved to a known pty
+  produces (a) a `sendNotification` call and (b) a `broadcastMetadataUpdate` with
+  `agentStatus: 'awaiting_input'`. Reuse the existing handler-test harness/mocks
+  if present; otherwise assert via the injected `getWindow`/sendNotification
+  seam.
+- **Bridge mapping:** the `.mjs` is a self-contained script (hard to unit-test in
+  the vitest TS suite). Cover the mapping decision by asserting `HOOK_TO_KIND`
+  semantics indirectly through the signal-types + rpc tests; manual smoke
+  verifies the end-to-end.
+
+## Manual verification (end to end)
+
+With the wmux Claude plugin installed (the user already gets `Stop`
+notifications, so the bridge is live): run Claude Code in a wmux pane, trigger a
+`/`-flow or any turn that calls AskUserQuestion. Expect: the pane's sidebar dot
+turns **yellow** and the notification **sound** plays the moment the question
+appears; answering it clears the dot as the agent resumes.
+
+## Dependency note
+
+This works only when the Claude Code hook bridge is installed/active (wmux's
+plugin). That is already true for any user who gets wmux notifications when Claude
+finishes a turn. No new install step is introduced.

--- a/integrations/claude/bin/wmux-bridge.mjs
+++ b/integrations/claude/bin/wmux-bridge.mjs
@@ -50,6 +50,7 @@ const MAX_STDIN_BYTES = 1 * 1024 * 1024;
 // ----- Hook name → AgentSignal kind ---------------------------------------
 
 const HOOK_TO_KIND = {
+  PreToolUse: 'agent.awaiting_input',
   PostToolUse: 'agent.activity',
   Stop: 'agent.stop',
   SubagentStop: 'agent.subagent_stop',
@@ -318,6 +319,15 @@ async function main() {
   // Empty stdin is allowed for SessionStart per Claude Code spec.
   if (payload === null && hookName !== 'SessionStart') {
     logEvent('empty-stdin', { hook: hookName });
+    return;
+  }
+
+  // PreToolUse fires per tool call; we only treat AskUserQuestion as
+  // "awaiting input". A future broad PreToolUse matcher can never tunnel a
+  // spurious awaiting_input through here — other PreToolUse tools are dropped.
+  if (hookName === 'PreToolUse'
+      && !(payload && payload.tool_name === 'AskUserQuestion')) {
+    logEvent('skip-pretooluse', { tool: payload && payload.tool_name });
     return;
   }
 

--- a/integrations/claude/hooks/hooks.json
+++ b/integrations/claude/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/bin/wmux-bridge.mjs\" PreToolUse"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "",

--- a/integrations/shared/__tests__/signal-types.test.ts
+++ b/integrations/shared/__tests__/signal-types.test.ts
@@ -23,6 +23,7 @@ describe('isAgentSignal', () => {
     'agent.activity',
     'agent.subagent_stop',
     'agent.session_start',
+    'agent.awaiting_input',
   ])('accepts kind = %s', (kind) => {
     expect(isAgentSignal({ ...valid, kind })).toBe(true);
   });

--- a/integrations/shared/signal-types.ts
+++ b/integrations/shared/signal-types.ts
@@ -17,14 +17,13 @@
  * - agent.activity        — per-tool-call activity ping (optional, may be dropped if too noisy).
  * - agent.subagent_stop   — subagent finished (e.g. /team mode coordinator).
  * - agent.session_start   — agent session began. Used to clear stale metadata.
- * - agent.awaiting_input  — agent paused mid-turn for a y/N or approval prompt.
- *                           Detector-only kind in v2.13.0: emitted by the
- *                           regex-based AgentDetector when a confirmation
- *                           pattern matches on a previously-gated agent. Hook
- *                           bridges are not expected to emit this kind today;
- *                           it is included in the union so HookSignalRouter
- *                           can dedup detector signals through the same ledger
- *                           shape used for `agent.stop`.
+ * - agent.awaiting_input  — agent paused for input. Two emitters: the regex
+ *                           AgentDetector (single-line y/N or approval prompts),
+ *                           AND the Claude Code hook bridge, which maps a
+ *                           PreToolUse hook on the AskUserQuestion tool to this
+ *                           kind (the boxed multi-line question UI never matched
+ *                           a detector regex). Both route through the same
+ *                           HookSignalRouter ledger shape used for `agent.stop`.
  */
 export type AgentSignalKind =
   | 'agent.stop'
@@ -125,7 +124,8 @@ export function isAgentSignal(value: unknown): value is AgentSignal {
     v['kind'] !== 'agent.stop' &&
     v['kind'] !== 'agent.activity' &&
     v['kind'] !== 'agent.subagent_stop' &&
-    v['kind'] !== 'agent.session_start'
+    v['kind'] !== 'agent.session_start' &&
+    v['kind'] !== 'agent.awaiting_input'
   ) return false;
   if (typeof v['agent'] !== 'string' || !ALLOWED_AGENT_SLUGS.has(v['agent'])) return false;
   if (typeof v['cwd'] !== 'string' || v['cwd'].length === 0) return false;

--- a/src/main/pipe/handlers/__tests__/hooks.rpc.emit.test.ts
+++ b/src/main/pipe/handlers/__tests__/hooks.rpc.emit.test.ts
@@ -10,9 +10,10 @@ import { eventBus } from '../../../events/EventBus';
 import type { HookSignalRouter } from '../../../hooks/HookSignalRouter';
 import type { AgentSignal } from '../../../../../integrations/shared/signal-types';
 
-const { sendToRendererMock, sendNotificationMock } = vi.hoisted(() => ({
+const { sendToRendererMock, sendNotificationMock, broadcastMetadataUpdateMock } = vi.hoisted(() => ({
   sendToRendererMock: vi.fn(),
   sendNotificationMock: vi.fn(),
+  broadcastMetadataUpdateMock: vi.fn(),
 }));
 
 vi.mock('../_bridge', () => ({
@@ -21,6 +22,10 @@ vi.mock('../_bridge', () => ({
 
 vi.mock('../../../notification/sendNotification', () => ({
   sendNotification: sendNotificationMock,
+}));
+
+vi.mock('../../../ipc/handlers/metadata.handler', () => ({
+  broadcastMetadataUpdate: broadcastMetadataUpdateMock,
 }));
 
 // Static import — vi.mock declarations are hoisted, so the module-under-test
@@ -128,6 +133,31 @@ describe('hooks.signal — agent.lifecycle event tee', () => {
     });
     // Regression: sendNotification still fires when decision=emit.
     expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits and lights the sidebar dot for agent.awaiting_input', async () => {
+    const stub = stubHookRouter();
+    stub.setDecision('emit');
+    const router = new RpcRouter();
+    registerHooksRpc(router, () => fakeWindow(), stub.router);
+
+    const res = await router.dispatch({
+      id: '8',
+      method: 'hooks.signal',
+      params: signal({ kind: 'agent.awaiting_input' }) as unknown as Record<string, unknown>,
+    });
+
+    expect(res.ok).toBe(true);
+    const events = pollLifecycle();
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('agent.awaiting_input');
+    // Sound/toast fires…
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+    // …and the sidebar dot is set to awaiting_input for the resolved pty.
+    expect(broadcastMetadataUpdateMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ptyId: 'pty-1', agentStatus: 'awaiting_input' }),
+    );
   });
 
   it('emits agent.lifecycle on dedup decision but skips sendNotification', async () => {

--- a/src/main/pipe/handlers/hooks.rpc.ts
+++ b/src/main/pipe/handlers/hooks.rpc.ts
@@ -42,6 +42,7 @@ import type { BrowserWindow } from 'electron';
 import type { RpcRouter } from '../RpcRouter';
 import { sendToRenderer } from './_bridge';
 import { sendNotification } from '../../notification/sendNotification';
+import { broadcastMetadataUpdate } from '../../ipc/handlers/metadata.handler';
 import type { HookSignalRouter } from '../../hooks/HookSignalRouter';
 import { HookFloodMeter, describeHookFlood } from '../../hooks/HookFloodMeter';
 import { eventBus } from '../../events/EventBus';
@@ -176,7 +177,9 @@ export function registerHooksRpc(
     //    P2 #6) because a no-emit ledger entry would silently block
     //    a same-kind detector emission for 10s with no benefit. Only
     //    emit-class kinds participate in dedup.
-    const isEmitKind = signal.kind === 'agent.stop' || signal.kind === 'agent.subagent_stop';
+    const isEmitKind = signal.kind === 'agent.stop'
+      || signal.kind === 'agent.subagent_stop'
+      || signal.kind === 'agent.awaiting_input';
     if (!isEmitKind) {
       return { ok: true };
     }
@@ -233,6 +236,12 @@ export function registerHooksRpc(
         title: titleFor(signal),
         body: bodyFor(signal),
       });
+      // Hook path (unlike the detector path in DaemonNotificationRouter) does
+      // not otherwise touch agentStatus. For awaiting_input, set it so the
+      // sidebar dot turns yellow — the part users see at a glance.
+      if (signal.kind === 'agent.awaiting_input') {
+        broadcastMetadataUpdate(win, { ptyId, agentStatus: 'awaiting_input' });
+      }
     }
     return { ok: true };
   });


### PR DESCRIPTION
## Summary

When Claude Code (in a wmux pane) shows its **AskUserQuestion** prompt, wmux gave no signal — no sound, no sidebar dot — so a user who looked away never knew Claude was blocked on them. wmux notifies on `Stop`/replies and on the single-line permission prompt, but **not** on AskUserQuestion.

**Root cause:** "awaiting input" was detected only by **AgentDetector regex**, anchored to single-line prompts (`Do you want to proceed?`). AskUserQuestion renders a multi-line boxed UI that matches nothing → the existing `awaiting_input` status (yellow dot + sound) never fired.

**Fix (signal-based, not regex):** Per Claude Code docs, the Notification hook does *not* fire for AskUserQuestion, but **`PreToolUse` with matcher `"AskUserQuestion"` does**. wmux already runs a Claude hook bridge — we add this one hook and close the three boundaries that dropped the signal.

## Changes
- **`integrations/claude/hooks/hooks.json`** — register `PreToolUse` matcher `"AskUserQuestion"`.
- **`integrations/claude/bin/wmux-bridge.mjs`** — map `PreToolUse → agent.awaiting_input`, guarded on `tool_name === "AskUserQuestion"` (a broad PreToolUse matcher can't tunnel spurious signals).
- **`integrations/shared/signal-types.ts`** — `isAgentSignal()` now accepts `agent.awaiting_input` from hooks (it was rejected); doc comment updated.
- **`src/main/pipe/handlers/hooks.rpc.ts`** — treat `awaiting_input` as an emit-kind (sound/toast via the existing dedup ledger) **and** `broadcastMetadataUpdate({ agentStatus: 'awaiting_input' })` so the **sidebar dot** turns yellow. `titleFor`/`bodyFor` already covered the kind.

Reuses the existing `awaiting_input` status, sound, and yellow dot — no new UI. Clearing is automatic (answering resumes the agent → `running`).

## Test Plan
- [x] `npx vitest run integrations/shared/__tests__/signal-types.test.ts` — validator accepts `agent.awaiting_input`
- [x] `npx vitest run src/main/pipe/handlers/__tests__/hooks.rpc.emit.test.ts` — `awaiting_input` fans out a notification **and** broadcasts `agentStatus: 'awaiting_input'`; existing dedup/regression tests still green
- [x] Bridge guard verified: non-AskUserQuestion `PreToolUse` is dropped (exit 0, `skip-pretooluse` logged); a matching call reached a live wmux and was accepted by the envelope validator (rejected only at workspace-match) — confirms the path end-to-end
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx vitest run` — 2929 passing (3 failures are a pre-existing daemon save-debounce timing flake; green in isolation)
- [ ] Manual: trigger AskUserQuestion in a wmux pane → yellow sidebar dot + sound the moment the question appears

Design spec: \`docs/superpowers/specs/2026-06-12-askuserquestion-awaiting-input-design.md\`
Plan: \`docs/superpowers/plans/2026-06-12-askuserquestion-awaiting-input.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved detection and notification for Claude Code awaiting user input. When Claude Code requires input during operations, the app now displays a visual sidebar indicator and sends notifications, ensuring you're always aware when the agent is waiting for your response to continue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->