### PR TITLE
perf(daemon): adaptive readiness-poll cadence after daemon spawn (S-A C1)

### DIFF
--- a/src/main/daemon/__tests__/launcher.pollCadence.test.ts
+++ b/src/main/daemon/__tests__/launcher.pollCadence.test.ts
@@ -125,10 +125,12 @@ describe('pollDaemonReady', () => {
   it('never overlaps checks while a slow ping is in flight', async () => {
     let inFlight = 0;
     let maxInFlight = 0;
+    let calls = 0;
     const state = observe(
       startPoll({
         ping: () =>
           new Promise<boolean>((resolve) => {
+            calls++;
             inFlight++;
             maxInFlight = Math.max(maxInFlight, inFlight);
             setTimeout(() => {
@@ -136,14 +138,39 @@ describe('pollDaemonReady', () => {
               resolve(false);
             }, 1_000); // slower than many dense ticks
           }),
-        budgetMs: 3_000,
+        budgetMs: 10_000,
       }).promise,
     );
 
     await vi.advanceTimersByTimeAsync(2_500);
     expect(maxInFlight).toBe(1);
+    // The chain must not queue extra ticks while a ping is in flight: each
+    // 1 s ping is followed by exactly one scheduled delay before the next
+    // check. In 2 500 ms that is ping(0–1000) → 40 ms → ping(1040–2040) →
+    // 200 ms → ping(2240–…) = 3 calls. A fixed-interval loop that kept
+    // ticking behind the in-flight guard would not hold this bound.
+    expect(calls).toBe(3);
     expect(state.resolved).toBe(false);
     expect(state.rejected).toBeNull();
+  });
+
+  it('treats a rejecting ping as a failed attempt (no unhandled rejection)', async () => {
+    let calls = 0;
+    const state = observe(
+      startPoll({
+        ping: async () => {
+          calls++;
+          if (calls === 1) throw new Error('pipe write EPIPE');
+          return true;
+        },
+      }).promise,
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(state.resolved).toBe(false); // first attempt rejected → retry
+    await vi.advanceTimersByTimeAsync(40);
+    expect(state.resolved).toBe(true);
+    expect(calls).toBe(2);
   });
 
   it('rejects with the pipe-file message when the budget runs out', async () => {

--- a/src/main/daemon/__tests__/launcher.pollCadence.test.ts
+++ b/src/main/daemon/__tests__/launcher.pollCadence.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { nextPollDelayMs, pollDaemonReady } from '../launcher';
+
+// S-A C1 — adaptive readiness-poll cadence. The old loop was a fixed
+// 200 ms setInterval, which quantized the (typically fast) daemon-spawned →
+// first-ping-ok span by +0–200 ms. These tests pin the extracted chain:
+// immediate first check, dense early cadence, 200 ms long-tail backoff,
+// wall-clock budget, and the cancel path used by the
+// DAEMON_EXIT_ALREADY_RUNNING child-exit handler.
+
+describe('nextPollDelayMs', () => {
+  it('polls densely (40 ms) during the first 2 s', () => {
+    expect(nextPollDelayMs(0)).toBe(40);
+    expect(nextPollDelayMs(1_999)).toBe(40);
+  });
+
+  it('backs off to the original 200 ms after 2 s', () => {
+    expect(nextPollDelayMs(2_000)).toBe(200);
+    expect(nextPollDelayMs(14_000)).toBe(200);
+  });
+});
+
+describe('pollDaemonReady', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  interface Overrides {
+    budgetMs?: number;
+    readPipeName?: () => string | null;
+    readToken?: () => string | null;
+    ping?: (pipeName: string, token: string) => Promise<boolean>;
+    onPipeFileSeen?: () => void;
+    onPingOk?: () => void;
+  }
+
+  function startPoll(overrides: Overrides = {}) {
+    return pollDaemonReady({
+      budgetMs: 15_000,
+      readPipeName: () => 'pipe-x',
+      readToken: () => 'token-x',
+      ping: async () => true,
+      ...overrides,
+    });
+  }
+
+  /** Attach a state probe — fake timers make bare await-on-promise hang. */
+  function observe(promise: Promise<void>) {
+    const state = { resolved: false, rejected: null as Error | null };
+    promise.then(
+      () => {
+        state.resolved = true;
+      },
+      (err: Error) => {
+        state.rejected = err;
+      },
+    );
+    return state;
+  }
+
+  it('resolves on the immediate first check without waiting one interval', async () => {
+    const onPingOk = vi.fn();
+    const state = observe(startPoll({ onPingOk }).promise);
+
+    // No timer advance at all — only microtask flush.
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(state.resolved).toBe(true);
+    expect(onPingOk).toHaveBeenCalledTimes(1);
+  });
+
+  it('detects a late pipe file on the dense 40 ms cadence', async () => {
+    let pipeName: string | null = null;
+    const state = observe(startPoll({ readPipeName: () => pipeName }).promise);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(state.resolved).toBe(false);
+
+    pipeName = 'pipe-x';
+    // One dense tick (40 ms) must pick it up — well under the old 200 ms.
+    await vi.advanceTimersByTimeAsync(40);
+    expect(state.resolved).toBe(true);
+  });
+
+  it('fires onPipeFileSeen exactly once across repeated checks', async () => {
+    const onPipeFileSeen = vi.fn();
+    let alive = false;
+    const state = observe(
+      startPoll({
+        onPipeFileSeen,
+        ping: async () => alive,
+      }).promise,
+    );
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(onPipeFileSeen).toHaveBeenCalledTimes(1);
+
+    alive = true;
+    await vi.advanceTimersByTimeAsync(200);
+    expect(state.resolved).toBe(true);
+    expect(onPipeFileSeen).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a failing ping and resolves once it answers', async () => {
+    let calls = 0;
+    const state = observe(
+      startPoll({
+        ping: async () => {
+          calls++;
+          return calls >= 3;
+        },
+      }).promise,
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(state.resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(state.resolved).toBe(true);
+    expect(calls).toBe(3);
+  });
+
+  it('never overlaps checks while a slow ping is in flight', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const state = observe(
+      startPoll({
+        ping: () =>
+          new Promise<boolean>((resolve) => {
+            inFlight++;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            setTimeout(() => {
+              inFlight--;
+              resolve(false);
+            }, 1_000); // slower than many dense ticks
+          }),
+        budgetMs: 3_000,
+      }).promise,
+    );
+
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(maxInFlight).toBe(1);
+    expect(state.resolved).toBe(false);
+    expect(state.rejected).toBeNull();
+  });
+
+  it('rejects with the pipe-file message when the budget runs out', async () => {
+    const state = observe(
+      startPoll({ readPipeName: () => null, budgetMs: 15_000 }).promise,
+    );
+
+    await vi.advanceTimersByTimeAsync(15_500);
+    expect(state.rejected?.message).toBe(
+      'Daemon spawned but pipe name file not created after 15 seconds',
+    );
+  });
+
+  it('rejects with the auth-token message when the budget runs out', async () => {
+    const state = observe(
+      startPoll({ readToken: () => null, budgetMs: 15_000 }).promise,
+    );
+
+    await vi.advanceTimersByTimeAsync(15_500);
+    expect(state.rejected?.message).toBe(
+      'Daemon spawned but auth token not found after 15 seconds',
+    );
+  });
+
+  it('rejects with the not-responding message when pings never answer', async () => {
+    const state = observe(
+      startPoll({ ping: async () => false, budgetMs: 15_000 }).promise,
+    );
+
+    await vi.advanceTimersByTimeAsync(15_500);
+    expect(state.rejected?.message).toBe(
+      'Daemon spawned but not responding after 15 seconds',
+    );
+  });
+
+  it('cancel() settles with the given error and stops further checks', async () => {
+    let calls = 0;
+    const poll = startPoll({
+      ping: async () => {
+        calls++;
+        return false;
+      },
+    });
+    const state = observe(poll.promise);
+
+    await vi.advanceTimersByTimeAsync(100);
+    const callsAtCancel = calls;
+    const err = new Error('daemon yielded');
+    poll.cancel(err);
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(state.rejected).toBe(err);
+    expect(calls).toBe(callsAtCancel);
+  });
+
+  it('discards a ping that resolves after cancel (no double settle)', async () => {
+    let resolvePing!: (alive: boolean) => void;
+    const onPingOk = vi.fn();
+    const poll = startPoll({
+      ping: () =>
+        new Promise<boolean>((res) => {
+          resolvePing = res;
+        }),
+      onPingOk,
+    });
+    const state = observe(poll.promise);
+
+    await vi.advanceTimersByTimeAsync(0); // first check now awaiting ping
+    const err = new Error('daemon yielded');
+    poll.cancel(err);
+    resolvePing(true); // late success must be ignored
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(state.rejected).toBe(err);
+    expect(onPingOk).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -416,7 +416,16 @@ export function pollDaemonReady(
       return;
     }
 
-    const alive = await opts.ping(pipeName, token);
+    // Defensive: the real pingDaemon never rejects (errors resolve false),
+    // but the injected contract only promises Promise<boolean> — treat a
+    // rejection as a failed ping instead of leaking an unhandled rejection
+    // out of the void-returning chain.
+    let alive: boolean;
+    try {
+      alive = await opts.ping(pipeName, token);
+    } catch {
+      alive = false;
+    }
     if (settled) return; // cancelled while the ping was in flight
 
     if (alive) {
@@ -425,6 +434,9 @@ export function pollDaemonReady(
       return;
     }
 
+    // Budget is evaluated after the ping returns, so a ping started just
+    // inside the budget can settle up to one ping-timeout past it — same
+    // property as the old attempt-count loop, intentional.
     if (overBudget()) {
       finish(() => rejectFn(new Error(`Daemon spawned but not responding after ${budgetLabel}`)));
       return;
@@ -512,7 +524,7 @@ function spawnDaemon(): Promise<number> {
     // guard live in pollDaemonReady (extracted so the chain is unit-testable
     // with fake timers).
     const readiness = pollDaemonReady({
-      budgetMs: 15_000, // same wall-clock budget as the old 75 × 200 ms loop
+      budgetMs: 15_000, // wall-clock 15 s (the old loop's 75 × 200 ms ceiling, now measured directly)
       readPipeName: () => readPipeNameFromFile(getWmuxDir()),
       readToken: readDaemonAuthToken,
       ping: (pipeName, token) => pingDaemon(pipeName, token, 2000),

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -310,6 +310,137 @@ export async function tryEscalatedReping(
   return false;
 }
 
+/**
+ * Poll cadence for the freshly-spawned daemon readiness loop.
+ *
+ * The daemon typically writes its pipe file and answers its first ping
+ * within a few hundred ms on a warm machine, so the old fixed 200 ms
+ * interval quantized that wait by +0–200 ms (~+100 ms median, visible in
+ * the daemon-spawned → daemon-first-ping-ok boot-trace span). Poll densely
+ * (40 ms) for the first 2 s to catch the common fast path with minimal
+ * latency, then back off to the original 200 ms for the long tail
+ * (Defender cold-scan, ConPTY cold-init) where poll resolution no longer
+ * matters and cheap-but-nonzero pipe probes shouldn't pile onto a machine
+ * that is already struggling.
+ */
+export function nextPollDelayMs(elapsedMs: number): number {
+  return elapsedMs < 2_000 ? 40 : 200;
+}
+
+export interface DaemonReadinessPollOptions {
+  budgetMs: number;
+  readPipeName: () => string | null;
+  readToken: () => string | null;
+  ping: (pipeName: string, token: string) => Promise<boolean>;
+  onPipeFileSeen?: () => void;
+  onPingOk?: () => void;
+}
+
+/**
+ * Wait for a freshly-spawned daemon to become reachable: pipe-name file
+ * written → auth token readable → first ping answered.
+ *
+ * Self-scheduling timeout chain (not setInterval): each check runs to
+ * completion — including the up-to-2 s ping — before the next one is
+ * scheduled, so checks can never overlap and the old `pinging` in-flight
+ * guard is structural now. The budget is wall-clock from poll start rather
+ * than an attempt count because the cadence is adaptive (nextPollDelayMs).
+ *
+ * The pipe-file gate is preserved from the original loop: pinging before
+ * the daemon writes its pipe name would connect to a zombie Windows named
+ * pipe left by a crashed predecessor and burn 1 s timeouts.
+ *
+ * `cancel(err)` settles the poll with `err` (used when the child exits
+ * with DAEMON_EXIT_ALREADY_RUNNING mid-poll); a ping already in flight is
+ * discarded on return.
+ */
+export function pollDaemonReady(
+  opts: DaemonReadinessPollOptions,
+): { promise: Promise<void>; cancel: (err: Error) => void } {
+  let settled = false;
+  let timer: NodeJS.Timeout | null = null;
+  let pipeFileSeen = false;
+  let resolveFn!: () => void;
+  let rejectFn!: (err: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolveFn = res;
+    rejectFn = rej;
+  });
+  const start = Date.now();
+  const budgetLabel = `${Math.round(opts.budgetMs / 1000)} seconds`;
+
+  const finish = (fn: () => void): void => {
+    if (settled) return;
+    settled = true;
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    fn();
+  };
+
+  const schedule = (): void => {
+    if (settled) return;
+    timer = setTimeout(() => {
+      void check();
+    }, nextPollDelayMs(Date.now() - start));
+  };
+
+  const overBudget = (): boolean => Date.now() - start >= opts.budgetMs;
+
+  const check = async (): Promise<void> => {
+    if (settled) return;
+
+    // Wait for daemon to write its pipe name file before attempting ping
+    const pipeName = opts.readPipeName();
+    if (!pipeName) {
+      if (overBudget()) {
+        finish(() => rejectFn(new Error(`Daemon spawned but pipe name file not created after ${budgetLabel}`)));
+      } else {
+        schedule();
+      }
+      return;
+    }
+    if (!pipeFileSeen) {
+      pipeFileSeen = true;
+      opts.onPipeFileSeen?.();
+    }
+
+    const token = opts.readToken();
+    if (!token) {
+      if (overBudget()) {
+        finish(() => rejectFn(new Error(`Daemon spawned but auth token not found after ${budgetLabel}`)));
+      } else {
+        schedule();
+      }
+      return;
+    }
+
+    const alive = await opts.ping(pipeName, token);
+    if (settled) return; // cancelled while the ping was in flight
+
+    if (alive) {
+      opts.onPingOk?.();
+      finish(() => resolveFn());
+      return;
+    }
+
+    if (overBudget()) {
+      finish(() => rejectFn(new Error(`Daemon spawned but not responding after ${budgetLabel}`)));
+      return;
+    }
+    schedule();
+  };
+
+  // First check immediately rather than after one interval: on a warm
+  // machine the pipe file can already exist within tens of ms of spawn,
+  // and the old fixed setInterval burned a guaranteed 200 ms before even
+  // looking.
+  void check();
+
+  return { promise, cancel: (err: Error) => finish(() => rejectFn(err)) };
+}
+
 function findNodePath(): string {
   // Prefer Electron's bundled node (via ELECTRON_RUN_AS_NODE) — it's a GUI
   // subsystem executable, so it won't flash a console window on Windows.
@@ -377,57 +508,18 @@ function spawnDaemon(): Promise<number> {
     markBoot('daemon-spawned');
     console.log(`[launcher] Daemon spawned with PID: ${child.pid}`);
 
-    // Wait for daemon to be ready.
-    // Only ping once the daemon-pipe file exists — this means the daemon has
-    // finished starting its pipe server and written the actual pipe name.
-    // Without this guard, early polls connect to a zombie Windows named pipe
-    // left by a crashed predecessor, wasting time on 1s timeouts.
-    let attempts = 0;
-    const maxAttempts = 75; // 75 * 200ms = 15 seconds
-    let pinging = false; // prevent concurrent pings
-
-    const poll = setInterval(async () => {
-      attempts++;
-      if (pinging) return; // previous ping still in-flight
-
-      const wmuxDir = getWmuxDir();
-      const pipeName = readPipeNameFromFile(wmuxDir);
-
-      // Wait for daemon to write its pipe name file before attempting ping
-      if (!pipeName) {
-        if (attempts >= maxAttempts) {
-          clearInterval(poll);
-          reject(new Error('Daemon spawned but pipe name file not created after 15 seconds'));
-        }
-        return;
-      }
-      markBoot('daemon-pipe-file-seen');
-
-      const token = readDaemonAuthToken();
-      if (!token) {
-        if (attempts >= maxAttempts) {
-          clearInterval(poll);
-          reject(new Error('Daemon spawned but auth token not found after 15 seconds'));
-        }
-        return;
-      }
-
-      pinging = true;
-      const alive = await pingDaemon(pipeName, token, 2000);
-      pinging = false;
-
-      if (alive) {
-        markBoot('daemon-first-ping-ok');
-        clearInterval(poll);
-        resolve(child.pid!);
-        return;
-      }
-
-      if (attempts >= maxAttempts) {
-        clearInterval(poll);
-        reject(new Error('Daemon spawned but not responding after 15 seconds'));
-      }
-    }, 200);
+    // Wait for daemon to be ready. Adaptive cadence + the pipe-file zombie
+    // guard live in pollDaemonReady (extracted so the chain is unit-testable
+    // with fake timers).
+    const readiness = pollDaemonReady({
+      budgetMs: 15_000, // same wall-clock budget as the old 75 × 200 ms loop
+      readPipeName: () => readPipeNameFromFile(getWmuxDir()),
+      readToken: readDaemonAuthToken,
+      ping: (pipeName, token) => pingDaemon(pipeName, token, 2000),
+      onPipeFileSeen: () => markBoot('daemon-pipe-file-seen'),
+      onPingOk: () => markBoot('daemon-first-ping-ok'),
+    });
+    readiness.promise.then(() => resolve(child.pid!), reject);
 
     // A redundant second daemon (spawned over a daemon the launcher failed to
     // detect) yields the canonical pipe to the live owner and exits with
@@ -437,12 +529,11 @@ function spawnDaemon(): Promise<number> {
     // poll's own 15s timeout.
     child.on('exit', (code) => {
       if (code === DAEMON_EXIT_ALREADY_RUNNING) {
-        clearInterval(poll);
         const e = new Error(
           'daemon yielded: another daemon already owns the canonical control pipe',
         ) as NodeJS.ErrnoException;
         e.code = 'EDAEMON_ALREADY_RUNNING';
-        reject(e);
+        readiness.cancel(e);
       }
     });
   });


### PR DESCRIPTION
## What

Replaces the fixed 200 ms `setInterval` readiness poll after a fresh daemon spawn with an adaptive self-scheduling timeout chain, extracted as a dependency-injected `pollDaemonReady()` helper:

- **Immediate first check** (the old loop burned a guaranteed 200 ms before even looking)
- **40 ms dense cadence for the first 2 s** (the common fast path)
- **200 ms backoff for the long tail** (Defender cold-scan, ConPTY cold-init)
- Budget switches from attempt-count to **wall-clock 15 s** (same envelope; the old loop could actually exceed 15 s under slow pings)

## Why

#210 boot-trace instrumentation showed the `daemon-pipe-file-written -> daemon-pipe-file-seen` span carrying ~93-199 ms of pure poll quantization on every cold start (gate condition "median >100 ms" from the S-A plan fired).

## Measured (packaged build, 5 cold runs each)

| span | baseline | this PR |
|---|---|---|
| pipe-file-written -> pipe-file-seen (per-run) | 93-199 ms | **6-44 ms** |
| pipe-file-seen -> first-ping-ok | 4-8 ms | 5-10 ms (unchanged) |

Note: absolute `firstPtyDataMs` comparison was load-contaminated in this session (parallel agent workloads); the targeted span comparison above is per-run and clean. Local/CI baseline re-bless follows in the renderer-parallel PR with cumulative numbers.

## Semantics preserved

- Pipe-file zombie guard (never ping before the daemon writes its pipe name — avoids 1 s timeouts against a crashed predecessor's named pipe)
- Auth-token gate, all three budget-exhausted error messages (byte-identical)
- `DAEMON_EXIT_ALREADY_RUNNING` child-exit path now routes through `readiness.cancel()` (same reject surface for `ensureDaemon`)
- Checks run to completion before the next is scheduled, so the old `pinging` in-flight guard is structural

## Verification

- 13 new fake-timer unit tests (immediate resolve, dense-tick pickup, no-overlap call-count bound, ping retry, rejecting-ping self-defense, all three budget messages, cancel mid-poll, late-ping discard after cancel)
- Full vitest suite green (one pre-existing load-sensitive flake in StateWriter.test.ts, passes standalone)
- Adversarial review: PASS, zero P1; P2/P3 findings folded in (rejecting-ping hardening, no-overlap test strengthened, comment accuracy)
- Live dogfood 15/15 (isolated packaged boot x2): fresh-spawn marks monotonic, adaptive span 9-10 ms, echo round-trip through the daemon OK, reuse path unaffected (`daemon-reused` present, no spawn marks), zero zombie processes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added extensive test coverage for daemon startup and readiness detection, validating polling behavior, transient failure recovery, promise settlement under cancellation, and budget exhaustion scenarios.

* **Refactor**
  * Optimized daemon initialization with refined polling strategy, enhanced error handling during startup failures, and support for cancelling readiness checks when the spawned process exits unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->