### PR TITLE
feat(cli): wmux doctor — one-command boot/daemon/log diagnostics

### DIFF
--- a/scripts/doctor-daemon-live.mjs
+++ b/scripts/doctor-daemon-live.mjs
@@ -1,0 +1,264 @@
+/**
+ * Live re-verification for the `wmux doctor` daemon-pipe fix.
+ *
+ * Boots the PACKAGED app (out/wmux-win32-x64/wmux.exe from the MAIN repo — the
+ * daemon binary is unchanged by this CLI-only fix) in a fully isolated env
+ * (fresh temp HOME + unique WMUX_DATA_SUFFIX), waits for the detached daemon to
+ * come up, then runs the WORKTREE's freshly built CLI bundle `doctor` against
+ * the same env and asserts:
+ *   - daemon section OK with real pid / uptime / sessions / eventLoopLagMs
+ *   - daemon bootTrace phase table (lock acquire / boot id / config load /
+ *     recovery / pipe start) rendered
+ *   - exit code 0
+ * Then shuts the daemon down and asserts doctor reports it down with exit 1.
+ * Cleans up (daemon shutdown, app kill, temp removal, pipe-gone + zombie check).
+ *
+ * Usage: node scripts/doctor-daemon-live.mjs
+ */
+import { spawn, execFile, execFileSync } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WORKTREE_ROOT = path.resolve(__dirname, '..');
+// The packaged app lives in the MAIN repo's out/ (the worktree shares no out/).
+const MAIN_REPO = 'D:\\wmux';
+const APP_EXE = path.join(MAIN_REPO, 'out', 'wmux-win32-x64', 'wmux.exe');
+const CLI_BUNDLE = path.join(WORKTREE_ROOT, 'dist', 'cli-bundle', 'index.js');
+const USERNAME = os.userInfo().username || 'default';
+const POWERSHELL_EXE = path.join(
+  process.env.SystemRoot ?? 'C:\\Windows',
+  'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe',
+);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+function pipeAlive(pipeName) {
+  return new Promise((resolve) => {
+    const sock = net.createConnection(pipeName);
+    const done = (v) => { try { sock.destroy(); } catch {} resolve(v); };
+    sock.once('connect', () => done(true));
+    sock.once('error', () => done(false));
+    setTimeout(() => done(false), 300);
+  });
+}
+function pidAlive(pid) { try { process.kill(pid, 0); return true; } catch { return false; } }
+async function waitFor(label, fn, timeoutMs, intervalMs = 200) {
+  const start = Date.now();
+  for (;;) {
+    try { const v = await fn(); if (v) return v; } catch {}
+    if (Date.now() - start >= timeoutMs) throw new Error(`timeout waiting for ${label} after ${timeoutMs}ms`);
+    await sleep(intervalMs);
+  }
+}
+
+// Minimal raw JSON-RPC client for the daemon pipe (shutdown only).
+class PipeClient {
+  constructor(pipeName, token) { this.pipeName = pipeName; this.token = token; this.sock = null; this.buf = ''; this.pending = new Map(); }
+  connect() {
+    return new Promise((resolve, reject) => {
+      const sock = net.createConnection(this.pipeName);
+      let settled = false;
+      sock.setEncoding('utf8');
+      sock.once('connect', () => { settled = true; this.sock = sock; resolve(); });
+      sock.once('error', (e) => { if (!settled) { settled = true; reject(e); } });
+      sock.on('data', (c) => this._onData(c));
+      sock.on('close', () => { for (const [, p] of this.pending) { clearTimeout(p.timer); p.reject(new Error('closed')); } this.pending.clear(); });
+    });
+  }
+  _onData(c) {
+    this.buf += c; let nl;
+    while ((nl = this.buf.indexOf('\n')) !== -1) {
+      const line = this.buf.slice(0, nl).trim(); this.buf = this.buf.slice(nl + 1);
+      if (!line) continue; let msg; try { msg = JSON.parse(line); } catch { continue; }
+      const p = this.pending.get(msg.id); if (!p) continue;
+      this.pending.delete(msg.id); clearTimeout(p.timer);
+      if (msg.ok === false) p.reject(new Error(String(msg.error))); else p.resolve(msg.result ?? msg);
+    }
+  }
+  call(method, params = {}, timeoutMs = 5000) {
+    return new Promise((resolve, reject) => {
+      if (!this.sock || this.sock.destroyed) return reject(new Error('not connected'));
+      const id = randomUUID();
+      const timer = setTimeout(() => { this.pending.delete(id); reject(new Error(`rpc timeout: ${method}`)); }, timeoutMs);
+      this.pending.set(id, { resolve, reject, timer });
+      this.sock.write(JSON.stringify({ id, method, params, token: this.token }) + '\n');
+    });
+  }
+  close() { try { this.sock?.destroy(); } catch {} }
+}
+
+function runDoctor(env, args = []) {
+  return new Promise((resolve) => {
+    execFile(process.execPath, [CLI_BUNDLE, 'doctor', ...args], { env, windowsHide: true, timeout: 30000 },
+      (err, stdout, stderr) => {
+        resolve({ code: err && typeof err.code === 'number' ? err.code : (err ? 1 : 0), stdout: stdout || '', stderr: stderr || '' });
+      });
+  });
+}
+
+function readDaemonPid(wmuxDir) {
+  try { const p = Number(fs.readFileSync(path.join(wmuxDir, 'daemon.pid'), 'utf8').trim()); return Number.isInteger(p) && p > 0 ? p : null; } catch { return null; }
+}
+function readDaemonPipe(wmuxDir, fallback) {
+  try { const n = fs.readFileSync(path.join(wmuxDir, 'daemon-pipe'), 'utf8').trim(); return n || fallback; } catch { return fallback; }
+}
+function readDaemonToken(home, wmuxDir) {
+  for (const p of [path.join(home, '.wmux', 'daemon-auth-token'), path.join(wmuxDir, 'daemon-auth-token')]) {
+    try { return fs.readFileSync(p, 'utf8').trim(); } catch {}
+  }
+  return null;
+}
+
+let FAILED = false;
+function assert(cond, msg) {
+  if (cond) { console.log(`  PASS: ${msg}`); } else { console.log(`  FAIL: ${msg}`); FAILED = true; }
+}
+
+async function main() {
+  if (!fs.existsSync(APP_EXE)) { console.error(`Missing app exe: ${APP_EXE}`); process.exit(2); }
+  if (!fs.existsSync(CLI_BUNDLE)) { console.error(`Missing CLI bundle: ${CLI_BUNDLE} (build it first)`); process.exit(2); }
+
+  const suffix = `-doctorlive${process.pid}`;
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-doctorlive-'));
+  const wmuxDir = path.join(home, `.wmux${suffix}`);
+  const env = {
+    ...process.env,
+    USERPROFILE: home, HOME: home, HOMEDRIVE: undefined, HOMEPATH: undefined,
+    APPDATA: path.join(home, 'AppData', 'Roaming'),
+    LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
+    WMUX_DATA_SUFFIX: suffix, WMUX_NO_DIALOG: '1',
+  };
+  fs.mkdirSync(env.APPDATA, { recursive: true });
+  fs.mkdirSync(env.LOCALAPPDATA, { recursive: true });
+  const userDataDir = path.join(env.APPDATA, `wmux${suffix}`);
+  fs.mkdirSync(userDataDir, { recursive: true });
+  fs.writeFileSync(path.join(userDataDir, '.first-run'), new Date().toISOString(), 'utf8');
+
+  const mainPipe = `\\\\.\\pipe\\wmux${suffix}-${USERNAME}`;
+  const daemonPipeFallback = `\\\\.\\pipe\\wmux-daemon${suffix}-${USERNAME}`;
+
+  console.log(`[setup] home=${home}`);
+  console.log(`[setup] suffix=${suffix}`);
+  console.log(`[setup] app=${APP_EXE}`);
+  console.log(`[setup] cli=${CLI_BUNDLE}`);
+
+  let proc = null;
+  try {
+    console.log('\n[boot] spawning app...');
+    proc = spawn(APP_EXE, [], { cwd: MAIN_REPO, env, stdio: ['ignore', 'pipe', 'pipe'], detached: false });
+    proc.stdout.on('data', () => {});
+    proc.stderr.on('data', () => {});
+    proc.on('exit', (c) => console.log(`[app] main process exited (code ${c})`));
+
+    // Wait for the daemon to be reachable: daemon-pipe file written + pipe alive.
+    await waitFor('daemon-pipe file', () => fs.existsSync(path.join(wmuxDir, 'daemon-pipe')), 45000, 200);
+    const daemonPipe = readDaemonPipe(wmuxDir, daemonPipeFallback);
+    console.log(`[boot] daemon-pipe = ${daemonPipe}`);
+    await waitFor('daemon pipe alive', () => pipeAlive(daemonPipe), 30000, 200);
+    const token = readDaemonToken(home, wmuxDir);
+    assert(!!token, 'daemon auth token present on disk');
+    // Confirm the daemon answers daemon.ping over its own pipe (ground truth).
+    await waitFor('daemon.ping ok', async () => {
+      try { const dc = new PipeClient(daemonPipe, token); await dc.connect(); const r = await dc.call('daemon.ping', {}, 3000); dc.close(); return r && r.status === 'ok'; } catch { return false; }
+    }, 30000, 250);
+    console.log('[boot] daemon is up and answering daemon.ping');
+
+    // === Scenario 1: daemon ALIVE → doctor must report OK + exit 0 ===
+    console.log('\n[test 1] doctor with daemon ALIVE');
+    const r1 = await runDoctor(env);
+    console.log('----- doctor (human) -----');
+    console.log(r1.stdout.trimEnd());
+    console.log('--------------------------');
+    if (r1.stderr.trim()) console.log(`[stderr] ${r1.stderr.trim()}`);
+
+    assert(r1.code === 0, `exit code 0 (got ${r1.code})`);
+    assert(/\[ OK \] daemon/.test(r1.stdout), 'daemon section is [ OK ]');
+    assert(/daemon: up \(pid \d+\)/.test(r1.stdout), 'daemon line shows up (pid N)');
+    assert(/uptime: /.test(r1.stdout), 'uptime line present');
+    assert(/sessions: \d+/.test(r1.stdout), 'sessions line present with a number');
+    assert(/event-loop lag: \d+ms/.test(r1.stdout), 'event-loop lag line present with ms value');
+    assert(/app \(main process\) pipe reachable: yes/.test(r1.stdout), 'app main-process pipe reachable: yes');
+    // bootTrace phase table — the lines that NEVER rendered under the old defect.
+    assert(/lock acquire\s+\d+ms/.test(r1.stdout), 'daemon bootTrace: lock acquire phase rendered');
+    assert(/boot id\s+\d+ms/.test(r1.stdout), 'daemon bootTrace: boot id phase rendered');
+    assert(/config load\s+\d+ms/.test(r1.stdout), 'daemon bootTrace: config load phase rendered');
+    assert(/recovery\s+\d+ms/.test(r1.stdout), 'daemon bootTrace: recovery phase rendered');
+    assert(/pipe start \/ token ACL\s+\d+ms/.test(r1.stdout), 'daemon bootTrace: pipe start phase rendered');
+    assert(/daemon \(ms since start\):/.test(r1.stdout), 'daemon anchor row rendered');
+    assert(!/Unknown method/.test(r1.stdout), 'no "Unknown method: daemon.ping" anywhere');
+
+    // JSON mode sanity — daemon verdict OK + bootTrace present.
+    const r1json = await runDoctor(env, ['--json']);
+    assert(r1json.code === 0, `--json exit code 0 (got ${r1json.code})`);
+    let parsed = null; try { parsed = JSON.parse(r1json.stdout); } catch {}
+    assert(parsed && parsed.daemon && parsed.daemon.verdict === 'OK', '--json daemon.verdict === OK');
+    assert(parsed && parsed.bootPhases && Array.isArray(parsed.bootPhases.daemon) && parsed.bootPhases.daemon.length >= 5, '--json bootPhases.daemon has >=5 phase rows');
+
+    // === Scenario 2: daemon DOWN → doctor must report down + exit 1 ===
+    console.log('\n[test 2] shutting daemon down, then doctor with daemon DOWN');
+    const daemonPid = readDaemonPid(wmuxDir);
+    // Kill the main app first so it cannot re-spawn the daemon, then shut the daemon.
+    if (proc && !proc.killed) { try { proc.kill(); } catch {} }
+    await sleep(1500);
+    try {
+      const dc = new PipeClient(daemonPipe, token);
+      await dc.connect();
+      await dc.call('daemon.shutdown', {}, 5000).catch(() => {});
+      dc.close();
+    } catch {}
+    // Wait until the daemon pipe is truly gone.
+    try { await waitFor('daemon pipe gone', async () => !(await pipeAlive(daemonPipe)), 12000, 250); } catch {}
+    if (daemonPid) { const dl = Date.now() + 6000; while (pidAlive(daemonPid) && Date.now() < dl) await sleep(150); if (pidAlive(daemonPid)) { try { process.kill(daemonPid); } catch {} } }
+
+    const r2 = await runDoctor(env);
+    console.log('----- doctor (daemon down) -----');
+    console.log(r2.stdout.trimEnd());
+    console.log('--------------------------------');
+    assert(r2.code === 1, `exit code 1 when daemon down (got ${r2.code})`);
+    assert(/\[FAIL\] daemon/.test(r2.stdout), 'daemon section is [FAIL] when down');
+    assert(/daemon: down/.test(r2.stdout), 'daemon line shows down');
+    assert(/recovery:/.test(r2.stdout), 'recovery steps rendered when down');
+    assert(/not running/.test(r2.stdout), 'down hint mentions "not running" (true connect failure, not Unknown method)');
+  } finally {
+    // === Cleanup ===
+    console.log('\n[cleanup]');
+    const daemonPid = readDaemonPid(wmuxDir);
+    const daemonPipe = readDaemonPipe(wmuxDir, daemonPipeFallback);
+    const token = readDaemonToken(home, wmuxDir);
+    if (token && await pipeAlive(daemonPipe)) {
+      try { const dc = new PipeClient(daemonPipe, token); await dc.connect(); await dc.call('daemon.shutdown', {}, 5000).catch(() => {}); dc.close(); } catch {}
+    }
+    if (daemonPid && pidAlive(daemonPid)) {
+      const dl = Date.now() + 6000; while (pidAlive(daemonPid) && Date.now() < dl) await sleep(150);
+      if (pidAlive(daemonPid)) { try { process.kill(daemonPid); } catch {} await sleep(300); if (pidAlive(daemonPid)) { try { process.kill(daemonPid, 'SIGKILL'); } catch {} } }
+    }
+    if (proc && proc.exitCode === null && !proc.killed) { try { proc.kill('SIGKILL'); } catch {} }
+    await sleep(500);
+    const mainGone = !(await pipeAlive(mainPipe));
+    const daemonGone = !(await pipeAlive(daemonPipe));
+    console.log(`  main pipe gone:   ${mainGone}`);
+    console.log(`  daemon pipe gone: ${daemonGone}`);
+    // Zombie check: any wmux/daemon process referencing our suffix still alive?
+    // Exclude PowerShell itself — the scan's OWN CommandLine contains the suffix
+    // string (self-match false positive), as do any shell wrappers around it.
+    let zombies = '';
+    try {
+      zombies = execFileSync(POWERSHELL_EXE, ['-NoProfile', '-NonInteractive', '-Command',
+        `Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*${suffix}*' -and $_.Name -notlike '*powershell*' -and $_.Name -notlike '*pwsh*' } | Select-Object ProcessId,Name | ConvertTo-Json -Compress`],
+        { windowsHide: true, timeout: 8000 }).toString().trim();
+    } catch {}
+    const zombieCount = zombies && zombies !== '' ? (zombies.startsWith('[') ? JSON.parse(zombies).length : 1) : 0;
+    console.log(`  suffix-tagged processes still alive: ${zombieCount}`);
+    assert(zombieCount === 0, 'zero zombie processes for our suffix');
+    try { fs.rmSync(home, { recursive: true, force: true }); console.log('  temp home removed'); } catch (e) { console.log(`  temp home removal warning: ${e.message}`); }
+  }
+
+  console.log(`\n=== ${FAILED ? 'LIVE VERIFICATION FAILED' : 'LIVE VERIFICATION PASSED'} ===`);
+  process.exit(FAILED ? 1 : 0);
+}
+
+main().catch((e) => { console.error('FATAL', e); process.exit(1); });

--- a/scripts/doctor-daemon-live.mjs
+++ b/scripts/doctor-daemon-live.mjs
@@ -25,9 +25,11 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const WORKTREE_ROOT = path.resolve(__dirname, '..');
-// The packaged app lives in the MAIN repo's out/ (the worktree shares no out/).
-const MAIN_REPO = 'D:\\wmux';
-const APP_EXE = path.join(MAIN_REPO, 'out', 'wmux-win32-x64', 'wmux.exe');
+// The packaged app normally lives in this checkout's own out/. When running
+// from a git worktree (which shares no out/ with the main checkout), point
+// WMUX_APP_ROOT at the checkout that ran `npm run package`.
+const APP_ROOT = process.env.WMUX_APP_ROOT || WORKTREE_ROOT;
+const APP_EXE = path.join(APP_ROOT, 'out', 'wmux-win32-x64', 'wmux.exe');
 const CLI_BUNDLE = path.join(WORKTREE_ROOT, 'dist', 'cli-bundle', 'index.js');
 const USERNAME = os.userInfo().username || 'default';
 const POWERSHELL_EXE = path.join(

--- a/src/cli/__tests__/client.daemonPipe.test.ts
+++ b/src/cli/__tests__/client.daemonPipe.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Daemon control-pipe resolution for `wmux doctor`.
+ *
+ * Regression guard for the doctor "down — Unknown method: daemon.ping" defect:
+ * the doctor used to ping the daemon via the MAIN process pipe, where
+ * `daemon.ping` is not registered. The fix routes the ping to the DAEMON pipe,
+ * resolved by these helpers. These tests pin the four resolution cases the live
+ * dogfood exercised:
+ *   1. daemon-pipe hint file present → use its value (authoritative name)
+ *   2. hint file absent              → fall back to the derived convention
+ *   3. daemon auth token present     → returned trimmed
+ *   4. daemon auth token absent      → undefined
+ *
+ * `fs` and `os` are mocked so the test is hermetic (no real ~/.wmux access).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock fs/os BEFORE importing the module under test (hoisted by Vitest).
+vi.mock('fs');
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: vi.fn(), userInfo: vi.fn() };
+});
+
+import * as fs from 'fs';
+import * as os from 'os';
+import {
+  getDaemonPipeName,
+  resolveDaemonPipeName,
+  resolveDaemonAuthToken,
+} from '../client';
+
+const readFileSyncMock = fs.readFileSync as unknown as ReturnType<typeof vi.fn>;
+const homedirMock = os.homedir as unknown as ReturnType<typeof vi.fn>;
+const userInfoMock = os.userInfo as unknown as ReturnType<typeof vi.fn>;
+
+const ORIGINAL_PLATFORM = process.platform;
+const ORIGINAL_SUFFIX = process.env.WMUX_DATA_SUFFIX;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  homedirMock.mockReturnValue('/home/u');
+  userInfoMock.mockReturnValue({ username: 'tester' } as os.UserInfo<string>);
+  delete process.env.WMUX_DATA_SUFFIX;
+});
+
+afterEach(() => {
+  setPlatform(ORIGINAL_PLATFORM);
+  if (ORIGINAL_SUFFIX === undefined) delete process.env.WMUX_DATA_SUFFIX;
+  else process.env.WMUX_DATA_SUFFIX = ORIGINAL_SUFFIX;
+});
+
+describe('getDaemonPipeName', () => {
+  it('derives the win32 daemon pipe name (suffix + username)', () => {
+    setPlatform('win32');
+    expect(getDaemonPipeName()).toBe('\\\\.\\pipe\\wmux-daemon-tester');
+  });
+
+  it('applies WMUX_DATA_SUFFIX to the win32 daemon pipe name', () => {
+    setPlatform('win32');
+    process.env.WMUX_DATA_SUFFIX = '-dev';
+    expect(getDaemonPipeName()).toBe('\\\\.\\pipe\\wmux-daemon-dev-tester');
+  });
+
+  it('derives the unix daemon socket path under the home dir', () => {
+    setPlatform('linux');
+    // path.join uses the host separator (the test host is Windows), so assert
+    // the segments rather than a hardcoded forward-slash literal. The real code
+    // mirrors src/main/DaemonClient.ts getDaemonPipeName (path.join on unix).
+    const result = getDaemonPipeName();
+    expect(result).toContain('home');
+    expect(result).toContain('.wmux-daemon.sock');
+  });
+});
+
+describe('resolveDaemonPipeName', () => {
+  it('prefers the daemon-pipe hint file when present (authoritative name)', () => {
+    setPlatform('win32');
+    // The daemon may have fallen back to a renamed pipe; the hint file is the
+    // source of truth, so its value must win over the derived convention.
+    readFileSyncMock.mockReturnValue('\\\\.\\pipe\\wmux-daemon-fallback-xyz\n');
+    expect(resolveDaemonPipeName()).toBe('\\\\.\\pipe\\wmux-daemon-fallback-xyz');
+    // It read from the suffix-aware ~/.wmux<suffix>/daemon-pipe path.
+    const readPath = String(readFileSyncMock.mock.calls[0][0]);
+    expect(readPath).toContain('.wmux');
+    expect(readPath).toContain('daemon-pipe');
+  });
+
+  it('falls back to the derived name when the hint file is absent', () => {
+    setPlatform('win32');
+    readFileSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    expect(resolveDaemonPipeName()).toBe('\\\\.\\pipe\\wmux-daemon-tester');
+  });
+
+  it('falls back to the derived name when the hint file is empty/whitespace', () => {
+    setPlatform('win32');
+    readFileSyncMock.mockReturnValue('   \n');
+    expect(resolveDaemonPipeName()).toBe('\\\\.\\pipe\\wmux-daemon-tester');
+  });
+});
+
+describe('resolveDaemonAuthToken', () => {
+  it('returns the trimmed token from ~/.wmux/daemon-auth-token', () => {
+    readFileSyncMock.mockReturnValue('  SECRET123\n');
+    expect(resolveDaemonAuthToken()).toBe('SECRET123');
+    // NOTE: the daemon token path is NOT suffix-aware (hardcoded ~/.wmux).
+    const readPath = String(readFileSyncMock.mock.calls[0][0]);
+    expect(readPath).toContain('.wmux');
+    expect(readPath).toContain('daemon-auth-token');
+  });
+
+  it('returns undefined when the token file is absent', () => {
+    readFileSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    expect(resolveDaemonAuthToken()).toBeUndefined();
+  });
+
+  it('returns undefined for an empty token file', () => {
+    readFileSyncMock.mockReturnValue('\n');
+    expect(resolveDaemonAuthToken()).toBeUndefined();
+  });
+});

--- a/src/cli/client.ts
+++ b/src/cli/client.ts
@@ -1,8 +1,16 @@
 import * as net from 'net';
 import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import * as crypto from 'crypto';
 import type { RpcRequest, RpcResponse, RpcMethod } from '../shared/rpc';
-import { getPipeName, getAuthTokenPath, getTcpPortPath } from '../shared/constants';
+import {
+  getPipeName,
+  getAuthTokenPath,
+  getTcpPortPath,
+  getWmuxHomeDir,
+  dataSuffix,
+} from '../shared/constants';
 
 // 서버(PipeServer)와 동일한 경로 해석을 사용한다. 과거에는 '/tmp/wmux.sock'을
 // 하드코딩해 macOS/Linux에서 서버('~/.wmux.sock')와 어긋나 항상 "not running"이
@@ -155,4 +163,115 @@ export async function sendRequest(
   }
 
   throw lastError instanceof Error ? lastError : new Error('wmux is not running. Start the app first.');
+}
+
+// ---------------------------------------------------------------------------
+// Daemon control-pipe access (direct, NOT proxied through the main process).
+//
+// The main process pipe (getPipeName) and the daemon control pipe are two
+// SEPARATE servers with disjoint RPC method tables. `daemon.ping` is only
+// registered on the DAEMON pipe (src/daemon/index.ts onRpc('daemon.ping')),
+// so a caller that needs daemon liveness/bootTrace must connect to the daemon
+// pipe directly — going through getPipeName() returns "Unknown method".
+//
+// `wmux doctor` is the consumer: it must diagnose the daemon EVEN WHEN the
+// main process is dead (the app crashed but the detached daemon is still up,
+// or vice versa), so it cannot rely on a main-pipe proxy. The helpers below
+// resolve the daemon pipe + token exactly the way the launcher does.
+//
+// Single source of truth: these mirror, for the CLI build (which cannot import
+// the Electron-adjacent src/main/DaemonClient.ts), the canonical resolvers
+//   - daemon pipe file  → src/main/daemon/launcher.ts readPipeNameFromFile
+//                          (reads `${getWmuxDir()}/daemon-pipe`)
+//   - daemon pipe name  → src/main/DaemonClient.ts getDaemonPipeName
+//   - daemon auth token → src/main/DaemonClient.ts readDaemonAuthToken
+//                          (and src/daemon/DaemonPipeServer.ts getTokenPath)
+// Keep these in lockstep with those modules if the daemon transport changes.
+// ---------------------------------------------------------------------------
+
+/**
+ * The daemon's default control-pipe name for this platform/user, derived from
+ * the same convention as src/main/DaemonClient.ts `getDaemonPipeName` and
+ * src/daemon/config.ts `getDefaultPipeName` (suffix-aware via dataSuffix()).
+ * Used as the fallback when the `daemon-pipe` hint file is absent.
+ */
+export function getDaemonPipeName(): string {
+  const username = os.userInfo().username || 'default';
+  if (process.platform === 'win32') {
+    return `\\\\.\\pipe\\wmux-daemon${dataSuffix()}-${username}`;
+  }
+  return path.join(os.homedir(), `.wmux-daemon${dataSuffix()}.sock`);
+}
+
+/**
+ * Resolve the daemon control pipe. Prefers the live `daemon-pipe` hint file
+ * the daemon writes at boot (`${getWmuxHomeDir()}/daemon-pipe` — suffix-aware,
+ * the authoritative name even after a fallback rename), and falls back to the
+ * derived convention when that file is missing (daemon never started, or an
+ * older daemon that predates the hint file). Mirrors launcher.ts
+ * `readPipeNameFromFile(wmuxDir) || getDaemonPipeName()`.
+ */
+export function resolveDaemonPipeName(): string {
+  try {
+    const fromFile = fs
+      .readFileSync(path.join(getWmuxHomeDir(), 'daemon-pipe'), 'utf-8')
+      .trim();
+    if (fromFile) return fromFile;
+  } catch {
+    // hint file absent/unreadable — fall through to the derived name
+  }
+  return getDaemonPipeName();
+}
+
+/**
+ * Read the daemon auth token. NOTE: unlike the main-pipe token
+ * (getAuthTokenPath, suffix-aware), the daemon token path is NOT suffix-aware
+ * — both the daemon (src/daemon/DaemonPipeServer.ts getTokenPath) and the
+ * launcher (src/main/DaemonClient.ts readDaemonAuthToken) hardcode
+ * `~/.wmux/daemon-auth-token`. Returns undefined if absent.
+ */
+export function resolveDaemonAuthToken(): string | undefined {
+  try {
+    const fromFile = fs
+      .readFileSync(path.join(os.homedir(), '.wmux', 'daemon-auth-token'), 'utf8')
+      .trim();
+    if (fromFile) return fromFile;
+  } catch {
+    // file absent/unreadable
+  }
+  return undefined;
+}
+
+/**
+ * Send a single JSON-RPC request to an explicit pipe with an explicit token —
+ * the transport primitive `sendRequest` is built on, exposed so callers that
+ * must target the daemon pipe (or any non-default pipe) can reuse the same
+ * newline-delimited framing without the main-pipe/TCP fallback chain. A
+ * connect-level failure (ENOENT/ECONNREFUSED) rejects with the wrapped
+ * "not running" error, exactly as the per-attempt path does.
+ */
+export function sendRequestToPipe(
+  pipeName: string,
+  method: RpcMethod,
+  params: Record<string, unknown> = {},
+  token: string | undefined,
+): Promise<RpcResponse> {
+  return attemptRequest(pipeName, method, params, token);
+}
+
+/**
+ * Ping the daemon over its OWN control pipe (not the main process pipe).
+ * Resolves the daemon pipe + token, then issues `daemon.ping`. Rejects if the
+ * daemon is unreachable — the caller (doctor) maps that to the "down" verdict.
+ */
+export function sendDaemonRequest(
+  method: RpcMethod,
+  params: Record<string, unknown> = {},
+): Promise<RpcResponse> {
+  return sendRequestToPipe(
+    resolveDaemonPipeName(),
+    method,
+    params,
+    resolveDaemonAuthToken(),
+  );
 }

--- a/src/cli/commands/__tests__/doctor.test.ts
+++ b/src/cli/commands/__tests__/doctor.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildDoctorReport,
+  worst,
+  countErrorWarn,
+  renderReport,
+  EVENT_LOOP_LAG_WARN_MS,
+  AV_TAX_PHASE_WARN_MS,
+  type DoctorDeps,
+  type DaemonPingResult,
+} from '../doctor';
+import type { RpcResponse } from '../../../shared/rpc';
+
+// ---- fixtures ----------------------------------------------------------------
+
+// A realistic main `[boot-trace] summary` line. preJsMs is small (healthy);
+// the heavy-AV variant below pushes daemon-boot past the threshold.
+function mainSummaryLine(overrides: Record<string, number> = {}, preJsMs = 300): string {
+  const marks: Record<string, number> = {
+    'js-start': 0,
+    'imports-done': 80,
+    'module-eval-end': 160,
+    'construction-start': 120,
+    'pre-pipe-server-ctor': 140,
+    'pipe-server-ctor-done': 150,
+    'ready-fired': 400,
+    'plugins-loaded': 460,
+    'window-created': 480,
+    'daemon-bootstrap-start': 490,
+    'daemon-ensure-start': 491,
+    'daemon-spawned': 520,
+    'daemon-pipe-file-seen': 700,
+    'daemon-first-ping-ok': 760,
+    'daemon-bootstrap-end': 800,
+    'renderer-load-triggered': 810,
+    'ready-end': 1200,
+    ...overrides,
+  };
+  return (
+    '[2026-06-13T09:00:00.000Z] [info] [main] [boot-trace] summary=' +
+    JSON.stringify({ procCreateEpochMs: 1000, jsStartEpochMs: 1300, preJsMs, marks })
+  );
+}
+
+function okPing(result: DaemonPingResult): RpcResponse {
+  return { id: 'x', ok: true, result };
+}
+
+function healthyPing(): DaemonPingResult {
+  const jsStart = 50_000;
+  return {
+    status: 'ok',
+    pid: 4242,
+    uptime: 3725, // 1h 2m 5s
+    sessions: 3,
+    eventLoopLagMs: 12,
+    bootTrace: {
+      jsStartEpochMs: jsStart,
+      marks: {
+        'main-start': jsStart + 0,
+        'lock-acquired': jsStart + 30,
+        'bootid-done': jsStart + 35,
+        'config-loaded': jsStart + 60,
+        'recovery-done': jsStart + 120,
+        'pre-pipe-start': jsStart + 130,
+        'pipe-listening': jsStart + 170,
+        ready: jsStart + 200,
+      },
+    },
+  };
+}
+
+function makeDeps(overrides: Partial<DoctorDeps> = {}): DoctorDeps {
+  const files: Record<string, string> = {
+    '/logs/main-2026-06-13.log': mainSummaryLine(),
+    '/auth-token': 'TOKEN123',
+    '/logs/daemon-2026-06-13.log': '[info] daemon up\n',
+  };
+  return {
+    ping: vi.fn().mockResolvedValue(okPing(healthyPing())),
+    version: '3.2.0',
+    platform: 'win32',
+    pipeName: '\\\\.\\pipe\\wmux-user',
+    authTokenPath: '/auth-token',
+    mainLogPath: '/logs/main-2026-06-13.log',
+    daemonLogPath: '/logs/daemon-2026-06-13.log',
+    readTextFile: vi.fn((p: string) => files[p] ?? null),
+    env: {},
+    ...overrides,
+  };
+}
+
+// ---- worst() algebra ---------------------------------------------------------
+
+describe('worst', () => {
+  it('returns OK for an empty list', () => {
+    expect(worst([])).toBe('OK');
+  });
+  it('FAIL dominates everything', () => {
+    expect(worst(['OK', 'WARN', 'SKIP', 'FAIL'])).toBe('FAIL');
+  });
+  it('WARN beats SKIP and OK', () => {
+    expect(worst(['OK', 'SKIP', 'WARN'])).toBe('WARN');
+  });
+  it('SKIP beats OK but is not a failure', () => {
+    expect(worst(['OK', 'SKIP', 'OK'])).toBe('SKIP');
+  });
+  it('all OK stays OK', () => {
+    expect(worst(['OK', 'OK'])).toBe('OK');
+  });
+});
+
+// ---- countErrorWarn ----------------------------------------------------------
+
+describe('countErrorWarn', () => {
+  it('counts [error] and [warn] lines (logSink format)', () => {
+    const text = [
+      '[2026-06-13T00:00:00.000Z] [info] [x] hi',
+      '[2026-06-13T00:00:01.000Z] [warn] [x] careful',
+      '[2026-06-13T00:00:02.000Z] [error] [x] boom',
+      '[2026-06-13T00:00:03.000Z] [error] [x] boom again',
+    ].join('\n');
+    expect(countErrorWarn(text)).toEqual({ errors: 2, warns: 1 });
+  });
+  it('does not double-count an error line as a warn', () => {
+    expect(countErrorWarn('[error] only')).toEqual({ errors: 1, warns: 0 });
+  });
+  it('returns zeros for clean text', () => {
+    expect(countErrorWarn('[info] all good')).toEqual({ errors: 0, warns: 0 });
+  });
+});
+
+// ---- environment section -----------------------------------------------------
+
+describe('environment section', () => {
+  it('reports OK with token present and no suffix', async () => {
+    const r = await buildDoctorReport(makeDeps());
+    expect(r.environment.verdict).toBe('OK');
+    const labels = r.environment.lines.map((l) => l.label);
+    expect(labels).toContain('app version');
+    expect(labels).toContain('platform');
+    expect(labels).toContain('control pipe');
+    expect(labels).toContain('auth token file');
+    expect(labels).toContain('WMUX_DATA_SUFFIX');
+  });
+
+  it('WARNs when the auth token file is missing', async () => {
+    const deps = makeDeps({ readTextFile: vi.fn(() => null) });
+    const r = await buildDoctorReport(deps);
+    const token = r.environment.lines.find((l) => l.label === 'auth token file');
+    expect(token?.verdict).toBe('WARN');
+    expect(r.environment.verdict).toBe('WARN');
+  });
+
+  it('surfaces WMUX_DATA_SUFFIX when set', async () => {
+    const r = await buildDoctorReport(makeDeps({ env: { WMUX_DATA_SUFFIX: '-dev' } }));
+    const line = r.environment.lines.find((l) => l.label === 'WMUX_DATA_SUFFIX');
+    expect(line?.value).toContain('-dev');
+  });
+});
+
+// ---- daemon section ----------------------------------------------------------
+
+describe('daemon section', () => {
+  it('reports OK when the daemon is up and responsive', async () => {
+    const r = await buildDoctorReport(makeDeps());
+    expect(r.daemon.verdict).toBe('OK');
+    expect(r.daemon.recovery).toEqual([]);
+    const up = r.daemon.lines.find((l) => l.label === 'daemon');
+    expect(up?.value).toContain('pid 4242');
+    expect(r.daemon.lines.find((l) => l.label === 'uptime')?.value).toBe('1h 2m 5s');
+    expect(r.daemon.lines.find((l) => l.label === 'sessions')?.value).toBe('3');
+  });
+
+  it('WARNs when eventLoopLagMs exceeds the threshold (boundary)', async () => {
+    const ping = healthyPing();
+    ping.eventLoopLagMs = EVENT_LOOP_LAG_WARN_MS + 1;
+    const r = await buildDoctorReport(makeDeps({ ping: vi.fn().mockResolvedValue(okPing(ping)) }));
+    const lag = r.daemon.lines.find((l) => l.label === 'event-loop lag');
+    expect(lag?.verdict).toBe('WARN');
+    expect(r.daemon.verdict).toBe('WARN');
+  });
+
+  it('does NOT warn exactly at the threshold', async () => {
+    const ping = healthyPing();
+    ping.eventLoopLagMs = EVENT_LOOP_LAG_WARN_MS; // == 100, not > 100
+    const r = await buildDoctorReport(makeDeps({ ping: vi.fn().mockResolvedValue(okPing(ping)) }));
+    const lag = r.daemon.lines.find((l) => l.label === 'event-loop lag');
+    expect(lag?.verdict).toBe('OK');
+  });
+
+  it('FAILs with recovery steps when the daemon ping rejects (down)', async () => {
+    const deps = makeDeps({
+      ping: vi.fn().mockRejectedValue(new Error('wmux is not running. Start the app first.')),
+    });
+    const r = await buildDoctorReport(deps);
+    expect(r.daemon.verdict).toBe('FAIL');
+    expect(r.daemon.recovery.length).toBeGreaterThan(0);
+    expect(r.overall).toBe('FAIL');
+    const line = r.daemon.lines.find((l) => l.label === 'daemon');
+    expect(line?.value).toBe('down');
+    expect(line?.hint).toContain('not running');
+  });
+
+  it('FAILs when ping returns an error envelope', async () => {
+    const deps = makeDeps({
+      ping: vi.fn().mockResolvedValue({ id: 'x', ok: false, error: 'boom' } as RpcResponse),
+    });
+    const r = await buildDoctorReport(deps);
+    expect(r.daemon.verdict).toBe('FAIL');
+    expect(r.daemon.lines[0].hint).toBe('boom');
+  });
+
+  it('still builds env + log sections when the daemon is down', async () => {
+    const deps = makeDeps({ ping: vi.fn().mockRejectedValue(new Error('down')) });
+    const r = await buildDoctorReport(deps);
+    // env/log sections do not depend on the daemon.
+    expect(r.environment.lines.length).toBeGreaterThan(0);
+    expect(r.logs.lines.length).toBe(2);
+  });
+});
+
+// ---- boot-phase section ------------------------------------------------------
+
+describe('boot-phase section', () => {
+  it('builds the main + daemon phase tables when both are present', async () => {
+    const r = await buildDoctorReport(makeDeps());
+    expect(r.bootPhases.verdict).toBe('OK');
+    const mainRows = r.bootPhases.main;
+    const daemonRows = r.bootPhases.daemon;
+    const anchors = r.bootPhases.daemonAnchors;
+    expect(mainRows).not.toBeNull();
+    expect(daemonRows).not.toBeNull();
+    expect(anchors).not.toBeNull();
+    expect(r.bootPhases.preJsMs).toBe(300);
+    if (!mainRows || !daemonRows || !anchors) throw new Error('phase tables missing');
+
+    const imports = mainRows.find((p) => p.label === 'module imports');
+    expect(imports?.ms).toBe(80); // imports-done(80) - js-start(0)
+    const daemonBoot = mainRows.find((p) => p.label === 'daemon boot');
+    expect(daemonBoot?.ms).toBe(180); // pipe-file-seen(700) - spawned(520)
+
+    // Daemon rebased: lock-acquired(30) - main-start(0) = 30.
+    const lockAcq = daemonRows.find((p) => p.label === 'lock acquire');
+    expect(lockAcq?.ms).toBe(30);
+    // Anchor row carries every ordered mark, rebased.
+    const ready = anchors.find((a) => a.name === 'ready');
+    expect(ready?.ms).toBe(200);
+  });
+
+  it('SKIPs the main table when the log has no summary line', async () => {
+    const deps = makeDeps({
+      readTextFile: vi.fn((p: string) =>
+        p.includes('main') ? '[info] no summary here\n' : '[info] daemon\n',
+      ),
+    });
+    const r = await buildDoctorReport(deps);
+    expect(r.bootPhases.main).toBeNull();
+    expect(r.bootPhases.note).toBeDefined();
+    // Daemon table still present from the live ping → section not pure SKIP.
+    expect(r.bootPhases.daemon).not.toBeNull();
+    expect(r.bootPhases.verdict).toBe('OK');
+  });
+
+  it('SKIPs the whole section when neither main summary nor daemon bootTrace exists', async () => {
+    const deps = makeDeps({
+      readTextFile: vi.fn(() => '[info] nothing useful\n'),
+      ping: vi.fn().mockResolvedValue(okPing({ status: 'ok', pid: 1, uptime: 1, sessions: 0, eventLoopLagMs: 0 })),
+    });
+    const r = await buildDoctorReport(deps);
+    expect(r.bootPhases.main).toBeNull();
+    expect(r.bootPhases.daemon).toBeNull();
+    expect(r.bootPhases.verdict).toBe('SKIP');
+  });
+});
+
+// ---- AV-tax hint -------------------------------------------------------------
+
+describe('AV-tax hint', () => {
+  it('stays OK when boot phases are normal', async () => {
+    const r = await buildDoctorReport(makeDeps());
+    expect(r.avHint.verdict).toBe('OK');
+  });
+
+  it('WARNs when a daemon-boot phase exceeds the AV threshold', async () => {
+    // Push daemon-spawned→pipe-file-seen well past AV_TAX_PHASE_WARN_MS.
+    const line = mainSummaryLine({
+      'daemon-spawned': 520,
+      'daemon-pipe-file-seen': 520 + AV_TAX_PHASE_WARN_MS + 200,
+      'daemon-bootstrap-end': 520 + AV_TAX_PHASE_WARN_MS + 400,
+      'renderer-load-triggered': 520 + AV_TAX_PHASE_WARN_MS + 410,
+      'ready-end': 520 + AV_TAX_PHASE_WARN_MS + 800,
+    });
+    const deps = makeDeps({
+      readTextFile: vi.fn((p: string) => (p.includes('main') ? line : '[info] daemon\n')),
+    });
+    const r = await buildDoctorReport(deps);
+    expect(r.avHint.verdict).toBe('WARN');
+    expect(r.avHint.lines[0].hint).toContain('bench/README.md');
+  });
+
+  it('WARNs when pre-JS itself is abnormally large', async () => {
+    const line = mainSummaryLine({}, AV_TAX_PHASE_WARN_MS + 500);
+    const deps = makeDeps({
+      readTextFile: vi.fn((p: string) => (p.includes('main') ? line : '[info] daemon\n')),
+    });
+    const r = await buildDoctorReport(deps);
+    expect(r.avHint.verdict).toBe('WARN');
+    expect(r.avHint.lines[0].value).toContain('pre-JS');
+  });
+});
+
+// ---- logs section ------------------------------------------------------------
+
+describe('logs section', () => {
+  it('reports both log paths and OK counts when clean', async () => {
+    const r = await buildDoctorReport(makeDeps());
+    expect(r.logs.lines).toHaveLength(2);
+    expect(r.logs.verdict).toBe('OK');
+    expect(r.logs.lines[0].value).toContain('0 error');
+  });
+
+  it('SKIPs a log line when the file is absent', async () => {
+    const deps = makeDeps({
+      readTextFile: vi.fn((p: string) => (p.includes('daemon') ? null : mainSummaryLine())),
+    });
+    const r = await buildDoctorReport(deps);
+    const daemonLog = r.logs.lines.find((l) => l.label === 'daemon log');
+    expect(daemonLog?.verdict).toBe('SKIP');
+    expect(daemonLog?.value).toContain('not found');
+  });
+
+  it('WARNs when today\'s log has error lines', async () => {
+    const deps = makeDeps({
+      readTextFile: vi.fn((p: string) => {
+        if (p.includes('main')) return mainSummaryLine();
+        return '[2026-06-13T00:00:00.000Z] [error] [daemon] spawn failed\n';
+      }),
+    });
+    const r = await buildDoctorReport(deps);
+    const daemonLog = r.logs.lines.find((l) => l.label === 'daemon log');
+    expect(daemonLog?.verdict).toBe('WARN');
+    expect(daemonLog?.value).toContain('1 error');
+  });
+});
+
+// ---- overall + rendering -----------------------------------------------------
+
+describe('overall verdict + rendering', () => {
+  it('overall is OK on a fully healthy install', async () => {
+    const r = await buildDoctorReport(makeDeps());
+    expect(r.overall).toBe('OK');
+  });
+
+  it('renders a non-empty human report without throwing', async () => {
+    const r = await buildDoctorReport(makeDeps());
+    const text = renderReport(r);
+    expect(text).toContain('wmux doctor');
+    expect(text).toContain('environment');
+    expect(text).toContain('daemon');
+    expect(text).toContain('boot phases');
+    expect(text).toContain('logs');
+  });
+
+  it('renders recovery steps when the daemon is down', async () => {
+    const deps = makeDeps({ ping: vi.fn().mockRejectedValue(new Error('down')) });
+    const r = await buildDoctorReport(deps);
+    const text = renderReport(r);
+    expect(text).toContain('recovery:');
+    expect(text).toContain('[FAIL]');
+  });
+});

--- a/src/cli/commands/__tests__/doctor.test.ts
+++ b/src/cli/commands/__tests__/doctor.test.ts
@@ -46,6 +46,15 @@ function okPing(result: DaemonPingResult): RpcResponse {
   return { id: 'x', ok: true, result };
 }
 
+// A reachable main process pipe (system.identify success envelope).
+function okIdentify(): RpcResponse {
+  return {
+    id: 'x',
+    ok: true,
+    result: { app: 'wmux', version: '3.2.0', platform: 'win32', electronVersion: '30' },
+  };
+}
+
 function healthyPing(): DaemonPingResult {
   const jsStart = 50_000;
   return {
@@ -78,6 +87,7 @@ function makeDeps(overrides: Partial<DoctorDeps> = {}): DoctorDeps {
   };
   const deps: DoctorDeps = {
     ping: vi.fn().mockResolvedValue(okPing(healthyPing())),
+    appPipeReachable: vi.fn().mockResolvedValue(okIdentify()),
     version: '3.2.0',
     platform: 'win32',
     pipeName: '\\\\.\\pipe\\wmux-user',
@@ -181,7 +191,46 @@ describe('environment section', () => {
     expect(labels).toContain('platform');
     expect(labels).toContain('control pipe');
     expect(labels).toContain('auth token file');
+    expect(labels).toContain('app (main process) pipe reachable');
     expect(labels).toContain('WMUX_DATA_SUFFIX');
+  });
+
+  it('reports the app pipe as reachable (OK) when system.identify answers', async () => {
+    const r = await buildDoctorReport(makeDeps());
+    const line = r.environment.lines.find(
+      (l) => l.label === 'app (main process) pipe reachable',
+    );
+    expect(line?.value).toBe('yes');
+    expect(line?.verdict).toBe('OK');
+  });
+
+  it('WARNs (informational) when the app pipe is unreachable but does not FAIL', async () => {
+    // main process down (pipe probe rejects), daemon still alive (default ping).
+    const deps = makeDeps({
+      appPipeReachable: vi.fn().mockRejectedValue(new Error('wmux is not running.')),
+    });
+    const r = await buildDoctorReport(deps);
+    const line = r.environment.lines.find(
+      (l) => l.label === 'app (main process) pipe reachable',
+    );
+    expect(line?.value).toBe('no');
+    expect(line?.verdict).toBe('WARN');
+    // A closed app is not a doctor FAIL when the daemon answers.
+    expect(r.daemon.verdict).toBe('OK');
+    expect(r.overall).not.toBe('FAIL');
+  });
+
+  it('treats an app-pipe error envelope (ok:false) as unreachable', async () => {
+    const deps = makeDeps({
+      appPipeReachable: vi
+        .fn()
+        .mockResolvedValue({ id: 'x', ok: false, error: 'boom' } as RpcResponse),
+    });
+    const r = await buildDoctorReport(deps);
+    const line = r.environment.lines.find(
+      (l) => l.label === 'app (main process) pipe reachable',
+    );
+    expect(line?.verdict).toBe('WARN');
   });
 
   it('WARNs when the auth token file is missing', async () => {

--- a/src/cli/commands/__tests__/doctor.test.ts
+++ b/src/cli/commands/__tests__/doctor.test.ts
@@ -76,7 +76,7 @@ function makeDeps(overrides: Partial<DoctorDeps> = {}): DoctorDeps {
     '/auth-token': 'TOKEN123',
     '/logs/daemon-2026-06-13.log': '[info] daemon up\n',
   };
-  return {
+  const deps: DoctorDeps = {
     ping: vi.fn().mockResolvedValue(okPing(healthyPing())),
     version: '3.2.0',
     platform: 'win32',
@@ -85,9 +85,21 @@ function makeDeps(overrides: Partial<DoctorDeps> = {}): DoctorDeps {
     mainLogPath: '/logs/main-2026-06-13.log',
     daemonLogPath: '/logs/daemon-2026-06-13.log',
     readTextFile: vi.fn((p: string) => files[p] ?? null),
+    // Default tail reader delegates to the (possibly overridden) readTextFile so
+    // log/boot reads honor a test's readTextFile override; the production code
+    // reads only the trailing bytes from disk, but for in-memory fixtures the
+    // full text is well under the window. Callers may override either.
+    tailReadTextFile: vi.fn(),
     env: {},
     ...overrides,
   };
+  // Wire the default tail reader AFTER overrides so it captures the final
+  // readTextFile (overridden or not). If the caller supplied its own
+  // tailReadTextFile, leave it in place.
+  if (!overrides.tailReadTextFile) {
+    deps.tailReadTextFile = vi.fn((p: string) => deps.readTextFile(p));
+  }
+  return deps;
 }
 
 // ---- worst() algebra ---------------------------------------------------------
@@ -113,20 +125,48 @@ describe('worst', () => {
 // ---- countErrorWarn ----------------------------------------------------------
 
 describe('countErrorWarn', () => {
-  it('counts [error] and [warn] lines (logSink format)', () => {
+  it('counts main logSink format `[<iso>] [<level>] [<source>] msg`', () => {
     const text = [
-      '[2026-06-13T00:00:00.000Z] [info] [x] hi',
-      '[2026-06-13T00:00:01.000Z] [warn] [x] careful',
-      '[2026-06-13T00:00:02.000Z] [error] [x] boom',
-      '[2026-06-13T00:00:03.000Z] [error] [x] boom again',
+      '[2026-06-13T00:00:00.000Z] [info] [main] hi',
+      '[2026-06-13T00:00:01.000Z] [warn] [main] careful',
+      '[2026-06-13T00:00:02.000Z] [error] [main] boom',
+      '[2026-06-13T00:00:03.000Z] [error] [main] boom again',
     ].join('\n');
     expect(countErrorWarn(text)).toEqual({ errors: 2, warns: 1 });
   });
-  it('does not double-count an error line as a warn', () => {
-    expect(countErrorWarn('[error] only')).toEqual({ errors: 1, warns: 0 });
+
+  it('counts daemon format `[<iso>] [daemon/<level>] msg` (P2 regression guard)', () => {
+    // Ground truth: src/daemon/index.ts log() → `[${ts}] [daemon/${level}] ${msg}`.
+    // The level word carries a `daemon/` source prefix inside the bracket, which
+    // the original `/\[error\]/` pattern missed (always counted 0).
+    const text = [
+      '[2026-06-13T00:00:00.000Z] [daemon/info] daemon up',
+      '[2026-06-13T00:00:01.000Z] [daemon/warn] retrying',
+      '[2026-06-13T00:00:02.000Z] [daemon/error] spawn failed',
+      '[2026-06-13T00:00:03.000Z] [daemon/error] lock contended',
+    ].join('\n');
+    expect(countErrorWarn(text)).toEqual({ errors: 2, warns: 1 });
   });
+
+  it('counts a mix of main and daemon formats in one buffer', () => {
+    const text = [
+      '[2026-06-13T00:00:00.000Z] [error] [main] main boom',
+      '[2026-06-13T00:00:01.000Z] [daemon/error] daemon boom',
+      '[2026-06-13T00:00:02.000Z] [warn] [main] main warn',
+      '[2026-06-13T00:00:03.000Z] [daemon/warn] daemon warn',
+      '[2026-06-13T00:00:04.000Z] [info] [main] noise',
+    ].join('\n');
+    expect(countErrorWarn(text)).toEqual({ errors: 2, warns: 2 });
+  });
+
+  it('does not double-count an error line as a warn (both formats)', () => {
+    expect(countErrorWarn('[error] only')).toEqual({ errors: 1, warns: 0 });
+    expect(countErrorWarn('[daemon/error] only')).toEqual({ errors: 1, warns: 0 });
+  });
+
   it('returns zeros for clean text', () => {
     expect(countErrorWarn('[info] all good')).toEqual({ errors: 0, warns: 0 });
+    expect(countErrorWarn('[daemon/info] all good')).toEqual({ errors: 0, warns: 0 });
   });
 });
 
@@ -330,11 +370,35 @@ describe('logs section', () => {
     expect(daemonLog?.value).toContain('not found');
   });
 
-  it('WARNs when today\'s log has error lines', async () => {
+  it('reads log + boot data via the bounded tail reader, not the full slurp', async () => {
+    // P3-d: doctor must tail-read logs (runaway-log OOM guard). Both the boot
+    // summary and the error/warn scan go through tailReadTextFile; readTextFile
+    // is reserved for the auth-token check.
+    const tail = vi.fn((p: string) => {
+      if (p.includes('main')) return mainSummaryLine();
+      return '[2026-06-13T00:00:00.000Z] [daemon/error] boom\n';
+    });
+    const read = vi.fn((p: string) => (p.includes('auth') ? 'TOKEN' : null));
+    const r = await buildDoctorReport(makeDeps({ tailReadTextFile: tail, readTextFile: read }));
+    // Both log paths were tail-read (main for boot summary + count, daemon for count).
+    const paths = tail.mock.calls.map((c) => c[0]);
+    expect(paths).toContain('/logs/main-2026-06-13.log');
+    expect(paths).toContain('/logs/daemon-2026-06-13.log');
+    // Boot summary parsed from the tail read, and the daemon error surfaced.
+    expect(r.bootPhases.main).not.toBeNull();
+    expect(r.logs.lines.find((l) => l.label === 'daemon log')?.value).toContain('1 error');
+    // The auth-token line still uses the full reader (it is not a log file).
+    expect(read.mock.calls.some((c) => String(c[0]).includes('auth'))).toBe(true);
+  });
+
+  it('WARNs when today\'s daemon log has error lines (real daemon format)', async () => {
+    // Ground truth: the daemon logger writes `[<iso>] [daemon/<level>] <msg>`
+    // (src/daemon/index.ts log()), NOT `[error] [daemon] ...`. This fixture
+    // pins the actual on-disk format so the [daemon/error] match cannot regress.
     const deps = makeDeps({
       readTextFile: vi.fn((p: string) => {
         if (p.includes('main')) return mainSummaryLine();
-        return '[2026-06-13T00:00:00.000Z] [error] [daemon] spawn failed\n';
+        return '[2026-06-13T00:00:00.000Z] [daemon/error] spawn failed\n';
       }),
     });
     const r = await buildDoctorReport(deps);

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,0 +1,556 @@
+/**
+ * `wmux doctor [--json]` — one-shot diagnostic for a wmux install.
+ *
+ * Prints section-by-section health (OK / WARN / FAIL / SKIP) covering the
+ * environment, daemon liveness, the boot-phase breakdown, an antivirus-tax
+ * hint, and pointers to the on-disk logs. Designed to run even when the
+ * daemon is dead: the environment and log sections need no RPC, so a user
+ * whose app won't start still gets actionable output.
+ *
+ * Testability: `buildDoctorReport()` is a pure function over an injected
+ * `DoctorDeps` bundle (RPC sender, file readers, path resolvers, env, clock).
+ * The CLI entry point `handleDoctor()` wires the real implementations and
+ * renders the result. Unit tests construct deps with `vi.fn` mocks and assert
+ * the section verdicts without spawning a daemon or touching the real FS.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import * as os from 'os';
+import { sendRequest } from '../client';
+import {
+  getPipeName,
+  getAuthTokenPath,
+  getWmuxHomeDir,
+  dataSuffix,
+} from '../../shared/constants';
+import {
+  span,
+  parseBootSummary,
+  rebaseDaemonMarks,
+  MAIN_PHASES,
+  DAEMON_PHASES,
+  DAEMON_MARK_ORDER,
+  type BootSummary,
+  type PhaseDef,
+} from '../../shared/bootPhases';
+import type { RpcResponse } from '../../shared/rpc';
+
+// --- public report model -----------------------------------------------------
+
+export type Verdict = 'OK' | 'WARN' | 'FAIL' | 'SKIP';
+
+export interface CheckLine {
+  /** Short label printed left of the value, e.g. "auth token file". */
+  label: string;
+  /** Human value, e.g. "present" / "127ms" / "down". */
+  value: string;
+  /** Per-line verdict; section verdict is the worst of its lines. */
+  verdict: Verdict;
+  /** Optional remediation / context line printed under the value. */
+  hint?: string;
+}
+
+export interface PhaseRow {
+  label: string;
+  ms: number | null;
+  indent: 0 | 1 | 2;
+}
+
+export interface DoctorReport {
+  /** Overall verdict — the worst section verdict. */
+  overall: Verdict;
+  environment: { verdict: Verdict; lines: CheckLine[] };
+  daemon: {
+    verdict: Verdict;
+    lines: CheckLine[];
+    /** Recovery steps, only populated when the daemon is down. */
+    recovery: string[];
+  };
+  bootPhases: {
+    verdict: Verdict;
+    /** null when no summary was found (SKIP). */
+    main: PhaseRow[] | null;
+    /** null when the daemon is down or carried no bootTrace. */
+    daemon: PhaseRow[] | null;
+    /** Compact "ms since start" daemon anchor row, name=value pairs. */
+    daemonAnchors: Array<{ name: string; ms: number | null }> | null;
+    preJsMs: number | null;
+    note?: string;
+  };
+  avHint: { verdict: Verdict; lines: CheckLine[] };
+  logs: { verdict: Verdict; lines: CheckLine[] };
+}
+
+// --- injected dependencies (the seam unit tests substitute) ------------------
+
+export interface DaemonPingResult {
+  status?: string;
+  pid?: number;
+  uptime?: number;
+  sessions?: number;
+  eventLoopLagMs?: number;
+  bootTrace?: { jsStartEpochMs: number; marks: Record<string, number> };
+}
+
+export interface DoctorDeps {
+  /** Resolves to the daemon.ping result, or rejects if the daemon is down. */
+  ping: () => Promise<RpcResponse>;
+  /** App version (from package.json), already resolved. */
+  version: string;
+  platform: string;
+  pipeName: string;
+  authTokenPath: string;
+  /** Resolved absolute path to today's main log file. */
+  mainLogPath: string;
+  /** Resolved absolute path to today's daemon log file. */
+  daemonLogPath: string;
+  /** Reads a file's full text, or returns null if it does not exist / errors. */
+  readTextFile: (path: string) => string | null;
+  /** Process env snapshot — only WMUX_DATA_SUFFIX is consulted today. */
+  env: Record<string, string | undefined>;
+}
+
+// --- thresholds (single source so tests assert the exact boundary) -----------
+
+/** daemon.ping eventLoopLagMs above this → WARN (busy/contended event loop). */
+export const EVENT_LOOP_LAG_WARN_MS = 100;
+/** A single daemon-boot phase above this → AV-tax hint (cold image rescan). */
+export const AV_TAX_PHASE_WARN_MS = 1500;
+
+// --- verdict algebra ---------------------------------------------------------
+
+const RANK: Record<Verdict, number> = { OK: 0, SKIP: 1, WARN: 2, FAIL: 3 };
+
+/** Worst verdict wins. SKIP is "absent, not broken" — ranks below WARN/FAIL
+ *  but above OK so a section that is entirely skipped surfaces as SKIP, while
+ *  a section mixing OK + SKIP stays OK. */
+export function worst(verdicts: Verdict[]): Verdict {
+  if (verdicts.length === 0) return 'OK';
+  return verdicts.reduce((acc, v) => (RANK[v] > RANK[acc] ? v : acc), 'OK' as Verdict);
+}
+
+// --- report builder (pure) ---------------------------------------------------
+
+export async function buildDoctorReport(deps: DoctorDeps): Promise<DoctorReport> {
+  const environment = buildEnvironment(deps);
+
+  // Ping the daemon once; reuse the result for the daemon + boot-phase sections.
+  let ping: DaemonPingResult | null = null;
+  let pingError: string | null = null;
+  try {
+    const resp = await deps.ping();
+    if (resp.ok) {
+      ping = resp.result as DaemonPingResult;
+    } else {
+      pingError = resp.error;
+    }
+  } catch (err) {
+    pingError = err instanceof Error ? err.message : String(err);
+  }
+
+  const daemon = buildDaemon(ping, pingError);
+  const bootPhases = buildBootPhases(deps, ping);
+  const avHint = buildAvHint(bootPhases);
+  const logs = buildLogs(deps);
+
+  const overall = worst([
+    environment.verdict,
+    daemon.verdict,
+    bootPhases.verdict,
+    avHint.verdict,
+    logs.verdict,
+  ]);
+
+  return { overall, environment, daemon, bootPhases, avHint, logs };
+}
+
+function buildEnvironment(deps: DoctorDeps): DoctorReport['environment'] {
+  const lines: CheckLine[] = [];
+
+  lines.push({ label: 'app version', value: deps.version, verdict: 'OK' });
+  lines.push({ label: 'platform', value: deps.platform, verdict: 'OK' });
+  lines.push({ label: 'control pipe', value: deps.pipeName, verdict: 'OK' });
+
+  const tokenPresent = deps.readTextFile(deps.authTokenPath) !== null;
+  lines.push({
+    label: 'auth token file',
+    value: tokenPresent ? `present (${deps.authTokenPath})` : 'missing',
+    // Absent token is expected when the app has never run; not a hard failure
+    // because the daemon section reports the actual connection result.
+    verdict: tokenPresent ? 'OK' : 'WARN',
+    hint: tokenPresent
+      ? undefined
+      : 'No auth token on disk — wmux has not run yet, or its state dir was cleared.',
+  });
+
+  const suffix = deps.env.WMUX_DATA_SUFFIX;
+  lines.push({
+    label: 'WMUX_DATA_SUFFIX',
+    value: suffix ? suffix : '(unset — packaged default)',
+    verdict: 'OK',
+    hint: suffix
+      ? 'Instance-isolation suffix is set; this is a dev/isolated build, not the packaged install.'
+      : undefined,
+  });
+
+  return { verdict: worst(lines.map((l) => l.verdict)), lines };
+}
+
+function buildDaemon(
+  ping: DaemonPingResult | null,
+  pingError: string | null,
+): DoctorReport['daemon'] {
+  if (!ping) {
+    const lines: CheckLine[] = [
+      {
+        label: 'daemon',
+        value: 'down',
+        verdict: 'FAIL',
+        hint: pingError ?? 'daemon.ping did not return a result',
+      },
+    ];
+    return {
+      verdict: 'FAIL',
+      lines,
+      recovery: [
+        'Start (or restart) the wmux app — the daemon is spawned on launch.',
+        'If the app is already running, fully quit it (tray → Shut down wmux) and relaunch.',
+        'Check the daemon log (see the logs section below) for a spawn/lock error.',
+        'If a stale lock is suspected, removing ~/.wmux*/daemon.lock and relaunching is safe — live sessions are re-recovered.',
+      ],
+    };
+  }
+
+  const lines: CheckLine[] = [];
+  lines.push({
+    label: 'daemon',
+    value: `up (pid ${ping.pid ?? '?'})`,
+    verdict: 'OK',
+  });
+  lines.push({
+    label: 'uptime',
+    value: formatUptime(ping.uptime),
+    verdict: 'OK',
+  });
+  lines.push({
+    label: 'sessions',
+    value: String(ping.sessions ?? 0),
+    verdict: 'OK',
+  });
+
+  const lag = ping.eventLoopLagMs;
+  if (typeof lag === 'number') {
+    const lagWarn = lag > EVENT_LOOP_LAG_WARN_MS;
+    lines.push({
+      label: 'event-loop lag',
+      value: `${lag}ms`,
+      verdict: lagWarn ? 'WARN' : 'OK',
+      hint: lagWarn
+        ? `Lag exceeds ${EVENT_LOOP_LAG_WARN_MS}ms — the daemon event loop is contended (heavy I/O, many sessions, or CPU pressure).`
+        : undefined,
+    });
+  }
+
+  return { verdict: worst(lines.map((l) => l.verdict)), lines, recovery: [] };
+}
+
+function buildBootPhases(
+  deps: DoctorDeps,
+  ping: DaemonPingResult | null,
+): DoctorReport['bootPhases'] {
+  // --- main process: parse the last summary line from today's main log ---
+  const mainLogText = deps.readTextFile(deps.mainLogPath);
+  const summary: BootSummary | null = mainLogText ? parseBootSummary(mainLogText) : null;
+
+  let main: PhaseRow[] | null = null;
+  let preJsMs: number | null = null;
+  if (summary) {
+    main = phaseRows(MAIN_PHASES, summary.marks);
+    preJsMs = summary.preJsMs;
+  }
+
+  // --- daemon: rebase ping bootTrace marks, build the same phase table ---
+  let daemonRows: PhaseRow[] | null = null;
+  let daemonAnchors: Array<{ name: string; ms: number | null }> | null = null;
+  if (ping?.bootTrace?.marks && typeof ping.bootTrace.jsStartEpochMs === 'number') {
+    const rebased = rebaseDaemonMarks(ping.bootTrace.marks, ping.bootTrace.jsStartEpochMs);
+    daemonRows = phaseRows(DAEMON_PHASES, rebased);
+    daemonAnchors = DAEMON_MARK_ORDER.map((name) => ({
+      name,
+      ms: typeof rebased[name] === 'number' ? rebased[name] : null,
+    }));
+  }
+
+  // SKIP (not FAIL) when we have nothing to show — a missing summary means the
+  // app predates the instrumentation or never reached emitBootSummary, which
+  // is informational, not a defect.
+  const verdict: Verdict = main === null && daemonRows === null ? 'SKIP' : 'OK';
+  const note =
+    main === null
+      ? 'No [boot-trace] summary in today\'s main log — boot-phase table for the main process is unavailable.'
+      : undefined;
+
+  return { verdict, main, daemon: daemonRows, daemonAnchors, preJsMs, note };
+}
+
+function buildAvHint(bootPhases: DoctorReport['bootPhases']): DoctorReport['avHint'] {
+  // The AV tax concentrates in the cold image-scan phases: pre-JS, module
+  // imports/eval, and (for the daemon) the spawn→pipe-file span. We look for
+  // any single daemon-boot phase that blew past the threshold.
+  const candidates: Array<{ label: string; ms: number | null }> = [];
+  if (bootPhases.preJsMs != null) candidates.push({ label: 'pre-JS', ms: bootPhases.preJsMs });
+  for (const row of bootPhases.main ?? []) {
+    if (row.label === 'daemon boot' || row.label === 'module imports') {
+      candidates.push({ label: row.label, ms: row.ms });
+    }
+  }
+
+  const hot = candidates.filter((c) => c.ms != null && c.ms > AV_TAX_PHASE_WARN_MS);
+
+  if (hot.length === 0) {
+    return {
+      verdict: 'OK',
+      lines: [
+        {
+          label: 'antivirus tax',
+          value: 'no abnormal boot phases',
+          verdict: 'OK',
+        },
+      ],
+    };
+  }
+
+  const worstPhase = hot.reduce((a, b) => ((b.ms ?? 0) > (a.ms ?? 0) ? b : a));
+  return {
+    verdict: 'WARN',
+    lines: [
+      {
+        label: 'antivirus tax',
+        value: `${worstPhase.label} = ${worstPhase.ms}ms (> ${AV_TAX_PHASE_WARN_MS}ms)`,
+        verdict: 'WARN',
+        hint:
+          'A boot phase dominated by cold image scanning suggests Windows Defender real-time ' +
+          'scanning is taxing startup. For a one-off LOCAL diagnosis you can temporarily add a ' +
+          'Defender exclusion for the install dir, re-measure, then remove it. See ' +
+          'bench/README.md → "Antivirus tax on cold start". Never ship or automate exclusions.',
+      },
+    ],
+  };
+}
+
+function buildLogs(deps: DoctorDeps): DoctorReport['logs'] {
+  const lines: CheckLine[] = [];
+
+  for (const [label, path] of [
+    ['main log', deps.mainLogPath],
+    ['daemon log', deps.daemonLogPath],
+  ] as const) {
+    const text = deps.readTextFile(path);
+    if (text === null) {
+      lines.push({
+        label,
+        value: `${path} (not found)`,
+        verdict: 'SKIP',
+      });
+      continue;
+    }
+    const { errors, warns } = countErrorWarn(text);
+    lines.push({
+      label,
+      value: `${path} — ${errors} error / ${warns} warn`,
+      verdict: errors > 0 ? 'WARN' : 'OK',
+      hint: errors > 0 ? `${errors} error line(s) in today's log — inspect the tail for the cause.` : undefined,
+    });
+  }
+
+  return { verdict: worst(lines.map((l) => l.verdict)), lines };
+}
+
+// --- helpers -----------------------------------------------------------------
+
+function phaseRows(defs: readonly PhaseDef[], marks: Record<string, number>): PhaseRow[] {
+  return defs.map((d) => ({ label: d.label, ms: span(marks, d.from, d.to), indent: d.indent }));
+}
+
+/** Count `[error]` / `[warn]` level lines, matching the logSink line format
+ *  `[<iso>] [<level>] [<source>] <message>`. Case-insensitive on the level. */
+export function countErrorWarn(text: string): { errors: number; warns: number } {
+  let errors = 0;
+  let warns = 0;
+  for (const line of text.split('\n')) {
+    if (/\[error\]/i.test(line)) errors++;
+    else if (/\[warn(?:ing)?\]/i.test(line)) warns++;
+  }
+  return { errors, warns };
+}
+
+function formatUptime(seconds: number | undefined): string {
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds)) return 'unknown';
+  const s = Math.max(0, Math.floor(seconds));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  if (h > 0) return `${h}h ${m}m ${sec}s`;
+  if (m > 0) return `${m}m ${sec}s`;
+  return `${sec}s`;
+}
+
+// --- path resolution (real deps) ---------------------------------------------
+
+function getFallbackVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8'));
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+/**
+ * Resolve today's main-process log file path WITHOUT Electron (`app` is not
+ * available in the CLI process). Mirrors `app.getPath('logs')`:
+ *   - Windows: %APPDATA%\<appName><suffix>\logs\main-YYYY-MM-DD.log
+ *     (logs default to userData/logs, and userData = APPDATA\appName; the
+ *     WMUX_DATA_SUFFIX isolation appends the suffix to userData — see
+ *     src/main/index.ts setPath('userData')).
+ *   - macOS:   ~/Library/Logs/<appName>/main-YYYY-MM-DD.log
+ *   - Linux:   ~/.config/<appName><suffix>/logs/main-YYYY-MM-DD.log
+ * The Windows path is the dogfood-verified one; the others are best-effort.
+ */
+export function resolveMainLogPath(date: string): string {
+  const appName = 'wmux';
+  const suffix = dataSuffix();
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA || join(os.homedir(), 'AppData', 'Roaming');
+    return join(appData, `${appName}${suffix}`, 'logs', `main-${date}.log`);
+  }
+  if (process.platform === 'darwin') {
+    // macOS derives the logs path from the app name, not userData, so the
+    // suffix does not apply here.
+    return join(os.homedir(), 'Library', 'Logs', appName, `main-${date}.log`);
+  }
+  const configHome = process.env.XDG_CONFIG_HOME || join(os.homedir(), '.config');
+  return join(configHome, `${appName}${suffix}`, 'logs', `main-${date}.log`);
+}
+
+/** Today's daemon log file: <wmuxHome>/logs/daemon-YYYY-MM-DD.log.
+ *  The daemon writes to `getWmuxDir()/logs` (= ~/.wmux<suffix>/logs), which
+ *  `getWmuxHomeDir()` resolves identically. */
+export function resolveDaemonLogPath(date: string): string {
+  return join(getWmuxHomeDir(), 'logs', `daemon-${date}.log`);
+}
+
+/** UTC date in YYYY-MM-DD — matches logSink's `todayUtc()`. */
+export function todayUtc(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+function readTextFileSafe(path: string): string | null {
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+// --- rendering ---------------------------------------------------------------
+
+const VERDICT_TAG: Record<Verdict, string> = {
+  OK: '[ OK ]',
+  WARN: '[WARN]',
+  FAIL: '[FAIL]',
+  SKIP: '[SKIP]',
+};
+
+function fmtMs(ms: number | null): string {
+  return ms == null ? 'n/a' : `${ms}ms`;
+}
+
+export function renderReport(report: DoctorReport): string {
+  const out: string[] = [];
+  out.push(`wmux doctor — overall ${VERDICT_TAG[report.overall]}`);
+  out.push('');
+
+  const section = (title: string, verdict: Verdict, lines: CheckLine[]) => {
+    out.push(`${VERDICT_TAG[verdict]} ${title}`);
+    for (const l of lines) {
+      out.push(`  ${VERDICT_TAG[l.verdict]} ${l.label}: ${l.value}`);
+      if (l.hint) out.push(`         ${l.hint}`);
+    }
+    out.push('');
+  };
+
+  section('environment', report.environment.verdict, report.environment.lines);
+
+  section('daemon', report.daemon.verdict, report.daemon.lines);
+  if (report.daemon.recovery.length > 0) {
+    out.push('  recovery:');
+    for (const step of report.daemon.recovery) out.push(`    - ${step}`);
+    out.push('');
+  }
+
+  // boot phases
+  out.push(`${VERDICT_TAG[report.bootPhases.verdict]} boot phases`);
+  if (report.bootPhases.note) out.push(`  ${report.bootPhases.note}`);
+  if (report.bootPhases.preJsMs != null) {
+    out.push(`  pre-JS (spawn→js-start)                ${fmtMs(report.bootPhases.preJsMs)}`);
+  }
+  if (report.bootPhases.main) {
+    out.push('  main process:');
+    for (const row of report.bootPhases.main) {
+      const pad = '  '.repeat(row.indent + 1);
+      out.push(`${pad}${row.label.padEnd(34 - row.indent * 2)} ${fmtMs(row.ms)}`);
+    }
+  }
+  if (report.bootPhases.daemonAnchors) {
+    out.push('  daemon (ms since start): ' +
+      report.bootPhases.daemonAnchors.map((a) => `${a.name}=${a.ms == null ? 'n/a' : a.ms}`).join(' '));
+  }
+  if (report.bootPhases.daemon) {
+    for (const row of report.bootPhases.daemon) {
+      const pad = '  '.repeat(row.indent + 1);
+      out.push(`${pad}${row.label.padEnd(34 - row.indent * 2)} ${fmtMs(row.ms)}`);
+    }
+  }
+  out.push('');
+
+  section('antivirus tax hint', report.avHint.verdict, report.avHint.lines);
+  section('logs', report.logs.verdict, report.logs.lines);
+
+  return out.join('\n').replace(/\n+$/, '\n');
+}
+
+// --- CLI entry point ---------------------------------------------------------
+
+export async function handleDoctor(_args: string[], jsonMode: boolean): Promise<void> {
+  const date = todayUtc();
+
+  // Resolve the app version: prefer a live daemon.identify-equivalent (the ping
+  // does not carry version), so fall back to package.json. Cheap + offline.
+  const version = getFallbackVersion();
+
+  const deps: DoctorDeps = {
+    ping: () => sendRequest('daemon.ping', {}),
+    version,
+    platform: process.platform,
+    pipeName: getPipeName(),
+    authTokenPath: getAuthTokenPath(),
+    mainLogPath: resolveMainLogPath(date),
+    daemonLogPath: resolveDaemonLogPath(date),
+    readTextFile: readTextFileSafe,
+    env: process.env,
+  };
+
+  const report = await buildDoctorReport(deps);
+
+  if (jsonMode) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(renderReport(report));
+  }
+
+  // Exit code reflects health so scripts can gate on it. FAIL → 1; WARN/SKIP/OK
+  // stay 0 (a warning is informational, not a failure of the command itself).
+  if (report.overall === 'FAIL') process.exit(1);
+}

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -17,7 +17,7 @@
 import { readFileSync, openSync, fstatSync, readSync, closeSync } from 'fs';
 import { join } from 'path';
 import * as os from 'os';
-import { sendRequest } from '../client';
+import { sendRequest, sendDaemonRequest } from '../client';
 import {
   getPipeName,
   getAuthTokenPath,
@@ -94,8 +94,25 @@ export interface DaemonPingResult {
 }
 
 export interface DoctorDeps {
-  /** Resolves to the daemon.ping result, or rejects if the daemon is down. */
+  /**
+   * Resolves to the `daemon.ping` result, or rejects if the daemon is down.
+   *
+   * MUST connect to the DAEMON control pipe directly, not proxy through the
+   * main process pipe: `daemon.ping` is only registered on the daemon pipe
+   * (src/daemon/index.ts), so a main-pipe proxy always returns "Unknown
+   * method" and reports a live daemon as down. A direct connect also lets the
+   * doctor diagnose the daemon when the main process is dead. The real wiring
+   * is `sendDaemonRequest('daemon.ping', {})` (src/cli/client.ts).
+   */
   ping: () => Promise<RpcResponse>;
+  /**
+   * Probe the MAIN process pipe (`system.identify`) once. Resolves to the
+   * raw RPC response on a reachable main process, rejects when the pipe is
+   * unreachable. Lets the report distinguish "main down + daemon alive" from
+   * "both down" — informational only (a dead main process is not a doctor
+   * failure when the daemon answers).
+   */
+  appPipeReachable: () => Promise<RpcResponse>;
   /** App version (from package.json), already resolved. */
   version: string;
   platform: string;
@@ -145,7 +162,18 @@ export function worst(verdicts: Verdict[]): Verdict {
 // --- report builder (pure) ---------------------------------------------------
 
 export async function buildDoctorReport(deps: DoctorDeps): Promise<DoctorReport> {
-  const environment = buildEnvironment(deps);
+  // Probe the main process pipe once (system.identify). This is independent of
+  // the daemon ping below — the two are SEPARATE servers — so a dead main
+  // process is reported as an informational WARN without masking a live daemon.
+  let appPipeReachable = false;
+  try {
+    const resp = await deps.appPipeReachable();
+    appPipeReachable = resp.ok;
+  } catch {
+    appPipeReachable = false;
+  }
+
+  const environment = buildEnvironment(deps, appPipeReachable);
 
   // Ping the daemon once; reuse the result for the daemon + boot-phase sections.
   let ping: DaemonPingResult | null = null;
@@ -177,12 +205,30 @@ export async function buildDoctorReport(deps: DoctorDeps): Promise<DoctorReport>
   return { overall, environment, daemon, bootPhases, avHint, logs };
 }
 
-function buildEnvironment(deps: DoctorDeps): DoctorReport['environment'] {
+function buildEnvironment(
+  deps: DoctorDeps,
+  appPipeReachable: boolean,
+): DoctorReport['environment'] {
   const lines: CheckLine[] = [];
 
   lines.push({ label: 'app version', value: deps.version, verdict: 'OK' });
   lines.push({ label: 'platform', value: deps.platform, verdict: 'OK' });
   lines.push({ label: 'control pipe', value: deps.pipeName, verdict: 'OK' });
+
+  // Liveness of the MAIN process pipe, separate from the daemon. A reachable
+  // app pipe is OK; an unreachable one is an informational WARN, not a FAIL —
+  // the daemon section below carries the real health gate, and the daemon can
+  // be alive while the app window is closed (or vice versa). This line is what
+  // lets a user tell "app down, daemon up" apart from "everything down".
+  lines.push({
+    label: 'app (main process) pipe reachable',
+    value: appPipeReachable ? 'yes' : 'no',
+    verdict: appPipeReachable ? 'OK' : 'WARN',
+    hint: appPipeReachable
+      ? undefined
+      : 'The wmux app (main process) is not answering on its control pipe — it may be closed. ' +
+        'The daemon is diagnosed independently below.',
+  });
 
   const tokenPresent = deps.readTextFile(deps.authTokenPath) !== null;
   lines.push({
@@ -593,7 +639,14 @@ export async function handleDoctor(_args: string[], jsonMode: boolean): Promise<
   const version = getFallbackVersion();
 
   const deps: DoctorDeps = {
-    ping: () => sendRequest('daemon.ping', {}),
+    // Direct daemon-pipe connection — `daemon.ping` lives ONLY on the daemon
+    // pipe, and a direct connect lets the doctor diagnose the daemon even when
+    // the main process is dead. NOT `sendRequest` (that targets the main pipe,
+    // which returns "Unknown method: daemon.ping").
+    ping: () => sendDaemonRequest('daemon.ping', {}),
+    // Main-pipe liveness probe — system.identify is registered on the main
+    // pipe and is always permitted (null capability).
+    appPipeReachable: () => sendRequest('system.identify', {}),
     version,
     platform: process.platform,
     pipeName: getPipeName(),

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -14,7 +14,7 @@
  * the section verdicts without spawning a daemon or touching the real FS.
  */
 
-import { readFileSync } from 'fs';
+import { readFileSync, openSync, fstatSync, readSync, closeSync } from 'fs';
 import { join } from 'path';
 import * as os from 'os';
 import { sendRequest } from '../client';
@@ -107,6 +107,13 @@ export interface DoctorDeps {
   daemonLogPath: string;
   /** Reads a file's full text, or returns null if it does not exist / errors. */
   readTextFile: (path: string) => string | null;
+  /** Reads at most the trailing `maxBytes` of a file as UTF-8 text (or null if
+   *  it does not exist / errors). Used for log files, which can grow unbounded
+   *  (a log-flood incident produced a 692MB main log) — the boot summary and
+   *  the recent error/warn lines live near the tail, so a bounded tail read is
+   *  both sufficient and safe against OOM on a runaway log. The first returned
+   *  line may be a partial fragment when the file exceeds `maxBytes`. */
+  tailReadTextFile: (path: string, maxBytes: number) => string | null;
   /** Process env snapshot — only WMUX_DATA_SUFFIX is consulted today. */
   env: Record<string, string | undefined>;
 }
@@ -117,6 +124,11 @@ export interface DoctorDeps {
 export const EVENT_LOOP_LAG_WARN_MS = 100;
 /** A single daemon-boot phase above this → AV-tax hint (cold image rescan). */
 export const AV_TAX_PHASE_WARN_MS = 1500;
+/** Bytes of trailing log to read for the boot-summary + error/warn scan. The
+ *  `[boot-trace] summary=` line is emitted at ready-end (near the file tail),
+ *  and error/warn counts only need recency, so 256KB is ample while capping
+ *  memory against a runaway log (cf. the 692MB log-flood incident). */
+export const MAIN_LOG_TAIL_BYTES = 256 * 1024;
 
 // --- verdict algebra ---------------------------------------------------------
 
@@ -260,7 +272,11 @@ function buildBootPhases(
   ping: DaemonPingResult | null,
 ): DoctorReport['bootPhases'] {
   // --- main process: parse the last summary line from today's main log ---
-  const mainLogText = deps.readTextFile(deps.mainLogPath);
+  // Tail-read only the trailing window: the summary line is emitted at
+  // ready-end so it lives near the file end, and bounding the read protects
+  // against a runaway log. parseBootSummary already tolerates a truncated
+  // leading line (JSON.parse failure on a partial fragment → skip).
+  const mainLogText = deps.tailReadTextFile(deps.mainLogPath, MAIN_LOG_TAIL_BYTES);
   const summary: BootSummary | null = mainLogText ? parseBootSummary(mainLogText) : null;
 
   let main: PhaseRow[] | null = null;
@@ -346,7 +362,9 @@ function buildLogs(deps: DoctorDeps): DoctorReport['logs'] {
     ['main log', deps.mainLogPath],
     ['daemon log', deps.daemonLogPath],
   ] as const) {
-    const text = deps.readTextFile(path);
+    // Tail-read: the error/warn count only needs recent lines, and a bounded
+    // read guards against a runaway log (cf. the 692MB log-flood incident).
+    const text = deps.tailReadTextFile(path, MAIN_LOG_TAIL_BYTES);
     if (text === null) {
       lines.push({
         label,
@@ -373,14 +391,18 @@ function phaseRows(defs: readonly PhaseDef[], marks: Record<string, number>): Ph
   return defs.map((d) => ({ label: d.label, ms: span(marks, d.from, d.to), indent: d.indent }));
 }
 
-/** Count `[error]` / `[warn]` level lines, matching the logSink line format
- *  `[<iso>] [<level>] [<source>] <message>`. Case-insensitive on the level. */
+/** Count `[error]` / `[warn]` level lines across BOTH log line formats:
+ *   - main logSink:  `[<iso>] [<level>] [<source>] <message>`  → `[error]`
+ *   - daemon logger: `[<iso>] [daemon/<level>] <message>`      → `[daemon/error]`
+ *     (see src/daemon/index.ts `log()` — `[${ts}] [daemon/${level}] ${msg}`).
+ *  The level token may carry an optional `<source>/` prefix; we match the level
+ *  word as the final segment inside the bracket. Case-insensitive on the level. */
 export function countErrorWarn(text: string): { errors: number; warns: number } {
   let errors = 0;
   let warns = 0;
   for (const line of text.split('\n')) {
-    if (/\[error\]/i.test(line)) errors++;
-    else if (/\[warn(?:ing)?\]/i.test(line)) warns++;
+    if (/\[(?:[^\][/]*\/)?error\]/i.test(line)) errors++;
+    else if (/\[(?:[^\][/]*\/)?warn(?:ing)?\]/i.test(line)) warns++;
   }
   return { errors, warns };
 }
@@ -451,6 +473,46 @@ function readTextFileSafe(path: string): string | null {
     return readFileSync(path, 'utf-8');
   } catch {
     return null;
+  }
+}
+
+/**
+ * Read at most the trailing `maxBytes` of a file as UTF-8 text, without
+ * loading the whole file. Returns null if the file is absent / unreadable.
+ *
+ * Reads from `max(0, size - maxBytes)` to EOF so a multi-hundred-MB runaway
+ * log never lands fully in memory (the 692MB log-flood incident). When the
+ * file exceeds the window, the first decoded line is a partial fragment — that
+ * is acceptable for both consumers: `parseBootSummary` skips lines whose JSON
+ * fails to parse, and the error/warn scanner only over/under-counts a single
+ * boundary line at worst.
+ */
+function tailReadTextFileSafe(path: string, maxBytes: number): string | null {
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, 'r');
+    const size = fstatSync(fd).size;
+    const readLen = Math.min(size, Math.max(0, maxBytes));
+    if (readLen === 0) return '';
+    const start = size - readLen;
+    const buf = Buffer.allocUnsafe(readLen);
+    let got = 0;
+    while (got < readLen) {
+      const n = readSync(fd, buf, got, readLen - got, start + got);
+      if (n <= 0) break;
+      got += n;
+    }
+    return buf.toString('utf-8', 0, got);
+  } catch {
+    return null;
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+        // best-effort close
+      }
+    }
   }
 }
 
@@ -539,6 +601,7 @@ export async function handleDoctor(_args: string[], jsonMode: boolean): Promise<
     mainLogPath: resolveMainLogPath(date),
     daemonLogPath: resolveDaemonLogPath(date),
     readTextFile: readTextFileSafe,
+    tailReadTextFile: tailReadTextFileSafe,
     env: process.env,
   };
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,6 +14,7 @@ import { handleSystem } from './commands/system';
 import { handleBrowser, handleOpen } from './commands/browser';
 import { handleMcp } from './commands/mcp';
 import { handleSetupHooks } from './commands/setupHooks';
+import { handleDoctor } from './commands/doctor';
 
 const HELP_TEXT = `
 wmux CLI
@@ -61,6 +62,11 @@ SYSTEM COMMANDS
   identify                          Show wmux app info
   capabilities                      List all supported RPC methods
 
+DIAGNOSTICS
+  doctor                            Run health checks (env, daemon, boot phases,
+                                    AV-tax hint, log pointers). Works even when
+                                    the daemon is down.
+
 BROWSER COMMANDS
   browser navigate <url>            Navigate the browser surface to a URL
   browser close                     Close the browser panel
@@ -92,6 +98,8 @@ EXAMPLES
   wmux identify --json
   wmux browser navigate "https://example.com"
   wmux browser close
+  wmux doctor
+  wmux doctor --json
 `.trimStart();
 
 const WORKSPACE_CMDS = new Set([
@@ -158,6 +166,8 @@ async function main(): Promise<void> {
       await handleMcp(rest, jsonMode);
     } else if (cmd === 'setup-hooks') {
       await handleSetupHooks(rest, jsonMode);
+    } else if (cmd === 'doctor') {
+      await handleDoctor(rest, jsonMode);
     } else {
       console.error(`Unknown command: "${cmd}". Run 'wmux --help' for usage.`);
       process.exit(1);

--- a/src/shared/__tests__/bootPhases.test.ts
+++ b/src/shared/__tests__/bootPhases.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  span,
+  parseBootSummary,
+  rebaseDaemonMarks,
+  MAIN_PHASES,
+  DAEMON_PHASES,
+  DAEMON_MARK_ORDER,
+} from '../bootPhases';
+
+describe('span', () => {
+  it('computes the delta between two marks', () => {
+    expect(span({ a: 100, b: 350 }, 'a', 'b')).toBe(250);
+  });
+
+  it('treats the sentinel "spawn" as zero origin', () => {
+    expect(span({ 'js-start': 120 }, 'spawn', 'js-start')).toBe(120);
+  });
+
+  it('returns null when the start mark is missing', () => {
+    expect(span({ b: 350 }, 'a', 'b')).toBeNull();
+  });
+
+  it('returns null when the end mark is missing', () => {
+    expect(span({ a: 100 }, 'a', 'b')).toBeNull();
+  });
+
+  it('rounds fractional deltas', () => {
+    expect(span({ a: 100.2, b: 350.9 }, 'a', 'b')).toBe(251);
+  });
+
+  it('matches the perf-bench inline span semantics for spawn→end', () => {
+    // perf-bench: span(marks, 'spawn', X) == marks[X] (origin 0).
+    expect(span({ 'imports-done': 42 }, 'spawn', 'imports-done')).toBe(42);
+  });
+});
+
+describe('parseBootSummary', () => {
+  // The exact line format emitted by src/main/util/bootTrace.ts emitBootSummary.
+  const realSummary =
+    '[2026-06-13T09:00:00.000Z] [info] [main] [boot-trace] summary=' +
+    JSON.stringify({
+      procCreateEpochMs: 1000,
+      jsStartEpochMs: 1400,
+      preJsMs: 400,
+      marks: { 'js-start': 0, 'imports-done': 60, 'module-eval-end': 120, 'ready-end': 900 },
+    });
+
+  it('parses a real-format summary line', () => {
+    const s = parseBootSummary(`some noise\n${realSummary}\nmore noise`);
+    expect(s).not.toBeNull();
+    expect(s?.jsStartEpochMs).toBe(1400);
+    expect(s?.preJsMs).toBe(400);
+    expect(s?.marks['imports-done']).toBe(60);
+  });
+
+  it('returns null when no summary line is present', () => {
+    expect(parseBootSummary('[info] just a log line\nanother line')).toBeNull();
+  });
+
+  it('returns null for empty text', () => {
+    expect(parseBootSummary('')).toBeNull();
+  });
+
+  it('picks the LAST summary when a log spans multiple boots', () => {
+    const older =
+      '[boot-trace] summary=' +
+      JSON.stringify({ procCreateEpochMs: 1, jsStartEpochMs: 1, preJsMs: 0, marks: { 'js-start': 0 } });
+    const newer =
+      '[boot-trace] summary=' +
+      JSON.stringify({ procCreateEpochMs: 2, jsStartEpochMs: 5000, preJsMs: 999, marks: { 'js-start': 0 } });
+    const s = parseBootSummary(`${older}\n${newer}`);
+    expect(s?.jsStartEpochMs).toBe(5000);
+    expect(s?.preJsMs).toBe(999);
+  });
+
+  it('falls through a corrupt latest line to the previous valid one', () => {
+    const good =
+      '[boot-trace] summary=' +
+      JSON.stringify({ procCreateEpochMs: 1, jsStartEpochMs: 7, preJsMs: 1, marks: { 'js-start': 0 } });
+    const corrupt = '[boot-trace] summary={not valid json';
+    const s = parseBootSummary(`${good}\n${corrupt}`);
+    expect(s?.jsStartEpochMs).toBe(7);
+  });
+
+  it('rejects a summary missing required fields', () => {
+    // No jsStartEpochMs / marks → not a usable summary.
+    const bad = '[boot-trace] summary=' + JSON.stringify({ foo: 'bar' });
+    expect(parseBootSummary(bad)).toBeNull();
+  });
+
+  it('tolerates a null preJsMs (procCreateTime unavailable)', () => {
+    const line =
+      '[boot-trace] summary=' +
+      JSON.stringify({ procCreateEpochMs: null, jsStartEpochMs: 100, preJsMs: null, marks: { 'js-start': 0 } });
+    const s = parseBootSummary(line);
+    expect(s?.preJsMs).toBeNull();
+    expect(s?.procCreateEpochMs).toBeNull();
+  });
+});
+
+describe('rebaseDaemonMarks', () => {
+  it('rebases absolute epoch marks to deltas from js-start', () => {
+    const rebased = rebaseDaemonMarks(
+      { 'main-start': 10_000, 'lock-acquired': 10_050, ready: 10_300 },
+      10_000,
+    );
+    expect(rebased['main-start']).toBe(0);
+    expect(rebased['lock-acquired']).toBe(50);
+    expect(rebased['ready']).toBe(300);
+  });
+
+  it('produces a marks map that span() consumes directly', () => {
+    const rebased = rebaseDaemonMarks(
+      { 'pre-pipe-start': 5_100, 'pipe-listening': 5_180 },
+      5_000,
+    );
+    expect(span(rebased, 'pre-pipe-start', 'pipe-listening')).toBe(80);
+  });
+});
+
+describe('phase tables', () => {
+  it('MAIN_PHASES mark names exist in the documented boot-trace vocabulary', () => {
+    // Guards against a typo silently producing all-n/a rows. These names are
+    // the markBoot() call sites in src/main (index.ts + daemon/launcher.ts).
+    const known = new Set([
+      'js-start', 'imports-done', 'module-eval-end', 'construction-start',
+      'pre-pipe-server-ctor', 'pipe-server-ctor-done', 'ready-fired',
+      'plugins-loaded', 'window-created', 'daemon-bootstrap-start',
+      'daemon-bootstrap-end', 'daemon-ensure-start', 'daemon-spawned',
+      'daemon-pipe-file-seen', 'daemon-first-ping-ok', 'renderer-load-triggered',
+      'ready-end',
+    ]);
+    for (const p of MAIN_PHASES) {
+      expect(known.has(p.from), `from=${p.from}`).toBe(true);
+      expect(known.has(p.to), `to=${p.to}`).toBe(true);
+    }
+  });
+
+  it('DAEMON_PHASES mark names are a subset of DAEMON_MARK_ORDER', () => {
+    const known = new Set(DAEMON_MARK_ORDER);
+    for (const p of DAEMON_PHASES) {
+      expect(known.has(p.from), `from=${p.from}`).toBe(true);
+      expect(known.has(p.to), `to=${p.to}`).toBe(true);
+    }
+  });
+});

--- a/src/shared/bootPhases.ts
+++ b/src/shared/bootPhases.ts
@@ -8,9 +8,21 @@
  * each named phase) were duplicated there inline (perf-bench.mjs:958-977).
  * `wmux doctor` needs the identical phase decomposition so its output matches
  * the bench. This module owns the canonical pair table; perf-bench can be
- * migrated onto it in a follow-up, but for now the two MUST agree mark-for-mark
- * or the doctor table would silently disagree with the bench. The pair labels
- * and mark names here are copied verbatim from perf-bench's console lines.
+ * migrated onto it in a follow-up, but for now the two MUST agree on the
+ * phase *spans* (the from→to deltas) or the doctor table would silently
+ * disagree with the bench. The pair labels and mark names here are copied
+ * verbatim from perf-bench's console lines.
+ *
+ * What "agree" does and does NOT cover: spans are origin-invariant — a phase's
+ * duration is `to − from`, so any shared timeline origin yields the same span.
+ * That is the guarantee. The ABSOLUTE anchor values are NOT guaranteed equal,
+ * because the two callers rebase the daemon's epoch marks against different
+ * origins: perf-bench rebases against the app-side spawn time `inst.t0` (its
+ * daemon anchor row reads "ms since spawn", so `main-start` is the non-zero
+ * spawn→main-start gap), whereas doctor rebases against the daemon's own
+ * `bootTrace.jsStartEpochMs` (so its `main-start` clamps to ~0). The daemon
+ * anchor rows therefore differ row-for-row by a constant spawn-overhead offset
+ * even though every span between two daemon marks matches.
  *
  * Mark-coordinate contract: `span(marks, a, b)` treats marks as numbers on a
  * single monotonic timeline (any common origin works — the caller normalizes).

--- a/src/shared/bootPhases.ts
+++ b/src/shared/bootPhases.ts
@@ -1,0 +1,175 @@
+/**
+ * Boot-phase span computation — shared single source of truth for the
+ * mark-pair table used by both `scripts/perf-bench.mjs` (cold-start
+ * breakdown) and `wmux doctor` (the phase table section).
+ *
+ * Why this exists: perf-bench is a `.mjs` script and cannot be imported from
+ * the TypeScript CLI. The mark-pair definitions (which two boot marks bound
+ * each named phase) were duplicated there inline (perf-bench.mjs:958-977).
+ * `wmux doctor` needs the identical phase decomposition so its output matches
+ * the bench. This module owns the canonical pair table; perf-bench can be
+ * migrated onto it in a follow-up, but for now the two MUST agree mark-for-mark
+ * or the doctor table would silently disagree with the bench. The pair labels
+ * and mark names here are copied verbatim from perf-bench's console lines.
+ *
+ * Mark-coordinate contract: `span(marks, a, b)` treats marks as numbers on a
+ * single monotonic timeline (any common origin works — the caller normalizes).
+ *  - Main marks come from the `[boot-trace] summary=` log line, where every
+ *    mark is already a delta in ms from `js-start` (see
+ *    src/main/util/bootTrace.ts `marksAsDeltas`). `js-start` is therefore 0.
+ *  - Daemon marks come from `daemon.ping` `bootTrace.marks`, which are absolute
+ *    epoch ms; the caller rebases them against `bootTrace.jsStartEpochMs`
+ *    first so `main-start` is ~0.
+ * The sentinel mark name `'spawn'` resolves to 0 (mirrors perf-bench), letting
+ * a phase anchor at process spawn when the caller's origin is spawn time.
+ */
+
+/** A named boot phase bounded by two marks. `from`/`to` are mark names; the
+ *  special name 'spawn' resolves to 0. `indent` controls table nesting depth
+ *  (0 = top-level phase, 1 = sub-phase) so the renderer can indent without
+ *  re-deriving the hierarchy. */
+export interface PhaseDef {
+  label: string;
+  from: string;
+  to: string;
+  indent: 0 | 1 | 2;
+}
+
+/**
+ * Compute the duration (ms) of the span between mark `a` and mark `b`.
+ * Returns null when either endpoint is missing (mark never fired, e.g. the
+ * daemon-reuse path skips spawn marks) so callers render "n/a" / "—" rather
+ * than a misleading 0 or NaN. The name 'spawn' is the zero origin.
+ *
+ * Mirrors `scripts/perf-bench.mjs`'s inline `span()` exactly so the doctor
+ * table and the bench table never diverge.
+ */
+export function span(
+  marks: Record<string, number>,
+  a: string,
+  b: string,
+): number | null {
+  const va = a === 'spawn' ? 0 : marks[a];
+  const vb = b === 'spawn' ? 0 : marks[b];
+  return typeof va === 'number' && typeof vb === 'number'
+    ? Math.round(vb - va)
+    : null;
+}
+
+/**
+ * Main-process boot phases. Labels + mark names lifted verbatim from
+ * perf-bench.mjs:958-971. Operates on the main `[boot-trace] summary` marks
+ * (deltas from js-start). The 'spawn'→'js-start' pre-JS span is intentionally
+ * NOT here because the summary stores pre-JS separately (`preJsMs`); the
+ * doctor renders it from that field directly.
+ */
+export const MAIN_PHASES: readonly PhaseDef[] = [
+  { label: 'module imports', from: 'js-start', to: 'imports-done', indent: 0 },
+  { label: 'app init', from: 'imports-done', to: 'module-eval-end', indent: 0 },
+  { label: 'pty managers', from: 'construction-start', to: 'pre-pipe-server-ctor', indent: 1 },
+  { label: 'PipeServer ctor / token ACL', from: 'pre-pipe-server-ctor', to: 'pipe-server-ctor-done', indent: 1 },
+  { label: 'handler registration', from: 'pipe-server-ctor-done', to: 'module-eval-end', indent: 1 },
+  { label: 'ready wait', from: 'module-eval-end', to: 'ready-fired', indent: 0 },
+  { label: 'plugin load', from: 'ready-fired', to: 'plugins-loaded', indent: 0 },
+  { label: 'window create', from: 'plugins-loaded', to: 'window-created', indent: 0 },
+  { label: 'daemon bootstrap', from: 'daemon-bootstrap-start', to: 'daemon-bootstrap-end', indent: 0 },
+  { label: 'spawn call', from: 'daemon-ensure-start', to: 'daemon-spawned', indent: 1 },
+  { label: 'daemon boot', from: 'daemon-spawned', to: 'daemon-pipe-file-seen', indent: 1 },
+  { label: 'ping latency', from: 'daemon-pipe-file-seen', to: 'daemon-first-ping-ok', indent: 1 },
+  { label: 'ready tail', from: 'renderer-load-triggered', to: 'ready-end', indent: 0 },
+] as const;
+
+/**
+ * Daemon-internal boot phases. Mirrors perf-bench.mjs:975-977 — the daemon's
+ * own mark timeline (main-start … ready). Operates on `daemon.ping`
+ * bootTrace.marks AFTER the caller rebases them against jsStartEpochMs.
+ */
+export const DAEMON_PHASES: readonly PhaseDef[] = [
+  { label: 'lock acquire', from: 'main-start', to: 'lock-acquired', indent: 0 },
+  { label: 'boot id', from: 'lock-acquired', to: 'bootid-done', indent: 0 },
+  { label: 'config load', from: 'bootid-done', to: 'config-loaded', indent: 0 },
+  { label: 'recovery', from: 'config-loaded', to: 'recovery-done', indent: 0 },
+  { label: 'pipe start / token ACL', from: 'pre-pipe-start', to: 'pipe-listening', indent: 0 },
+] as const;
+
+/**
+ * Ordered list of daemon mark names for the compact "ms since start" line —
+ * matches perf-bench.mjs:975. Exposed so the doctor prints the same anchor row.
+ */
+export const DAEMON_MARK_ORDER: readonly string[] = [
+  'main-start',
+  'lock-acquired',
+  'bootid-done',
+  'config-loaded',
+  'recovery-done',
+  'pre-pipe-start',
+  'pipe-listening',
+  'ready',
+] as const;
+
+/** Shape of the JSON carried by a `[boot-trace] summary=<json>` log line.
+ *  See src/main/util/bootTrace.ts `emitBootSummary`. */
+export interface BootSummary {
+  procCreateEpochMs: number | null;
+  jsStartEpochMs: number;
+  preJsMs: number | null;
+  /** Each value is a delta in ms from js-start. */
+  marks: Record<string, number>;
+}
+
+/**
+ * Parse the LAST `[boot-trace] summary=<json>` line out of a main log file's
+ * text. Returns null when no summary line is present (the app may have logged
+ * per-mark lines but never reached `emitBootSummary`, or the file predates the
+ * instrumentation) — callers render this as SKIP, not FAIL.
+ *
+ * Scans bottom-up so the freshest boot wins when a log file spans multiple
+ * launches in one day. Malformed JSON on the latest matching line falls
+ * through to the next-newest candidate rather than throwing.
+ */
+export function parseBootSummary(logText: string): BootSummary | null {
+  const marker = '[boot-trace] summary=';
+  const lines = logText.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    const idx = line.indexOf(marker);
+    if (idx === -1) continue;
+    const json = line.slice(idx + marker.length).trim();
+    try {
+      const parsed = JSON.parse(json) as Partial<BootSummary>;
+      // Minimal shape validation: jsStartEpochMs + marks must be present and
+      // the right types, else this isn't a usable summary.
+      if (
+        typeof parsed.jsStartEpochMs === 'number' &&
+        parsed.marks !== null &&
+        typeof parsed.marks === 'object'
+      ) {
+        return {
+          procCreateEpochMs:
+            typeof parsed.procCreateEpochMs === 'number' ? parsed.procCreateEpochMs : null,
+          jsStartEpochMs: parsed.jsStartEpochMs,
+          preJsMs: typeof parsed.preJsMs === 'number' ? parsed.preJsMs : null,
+          marks: parsed.marks as Record<string, number>,
+        };
+      }
+    } catch {
+      // Truncated/corrupt line — keep scanning older lines.
+    }
+  }
+  return null;
+}
+
+/**
+ * Rebase absolute-epoch daemon marks (from `daemon.ping` bootTrace.marks)
+ * to deltas from the daemon's js-start. Marks at or before jsStart clamp to 0.
+ */
+export function rebaseDaemonMarks(
+  marks: Record<string, number>,
+  jsStartEpochMs: number,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const [name, epoch] of Object.entries(marks)) {
+    if (typeof epoch === 'number') out[name] = Math.round(epoch - jsStartEpochMs);
+  }
+  return out;
+}

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -15,7 +15,8 @@
     "src/cli/**/*",
     "src/shared/rpc.ts",
     "src/shared/constants.ts",
-    "src/shared/types.ts"
+    "src/shared/types.ts",
+    "src/shared/bootPhases.ts"
   ],
   "exclude": [
     "src/cli/__tests__/**"


### PR DESCRIPTION
## What

`wmux doctor [--json]` — a single diagnostic command that turns the S-A boot-trace instrumentation (#210) into a user-facing surface. Sections, each with OK / WARN / FAIL / SKIP verdicts:

- **environment** — app version, platform, control pipe, auth-token presence, `WMUX_DATA_SUFFIX`, and an "app (main process) pipe reachable" probe so "main down + daemon alive" is distinguishable from "both down"
- **daemon** — pings the daemon over **its own control pipe** (pipe name from the suffix-aware `daemon-pipe` hint file, falling back to the derived convention) so the daemon is diagnosable even when the main process is dead; reports pid / uptime / sessions / event-loop lag (>100 ms WARN); a down daemon gets FAIL + concrete recovery steps and exit 1
- **boot phases** — parses the last `[boot-trace] summary=` line from the daily main log (bounded 256 KB tail read — this repo has a documented 692 MB log-runaway incident) plus the daemon''s `daemon.ping` bootTrace, and renders the same phase table as `perf-bench` (pre-JS / app init / PipeServer ctor / daemon bootstrap with spawn-boot-ping sub-phases / daemon-internal lock-bootid-config-recovery-pipe rows). Missing summary renders SKIP, not FAIL
- **AV tax hint** — flags cold-image-rescan phases >1500 ms with a Defender-exclusion pointer to `bench/README.md`
- **logs** — main + daemon log paths and today''s error/warn counts (both sink formats: `[error] [main]` and `[daemon/error]`)

The phase mark-pair table lives in a new shared module (`src/shared/bootPhases.ts`, zero imports) copied mark-for-mark from perf-bench; the doc scopes the agreement guarantee to spans (anchor origins differ by design). perf-bench migration onto it is a follow-up.

## Review + dogfood trail

- Adversarial review: P2 (daemon log `[daemon/error]` lines never counted — the test pinned a format that doesn''t exist) fixed with both real formats pinned; P3s folded in (doc overclaim scoped, bounded tail read)
- **Live dogfood caught a merge-blocker the unit tests and review both missed**: `daemon.ping` was sent over the *main* pipe, where the method isn''t registered — a healthy daemon always reported "down — Unknown method: daemon.ping", exit 1. Root-caused with live pipe probes; fixed by connecting to the daemon control pipe directly (rationale: doctor must diagnose the daemon independently of a dead main). Re-verified live: daemon section OK with real pid/uptime/sessions/lag, full daemon phase table, exit 0; post-shutdown FAIL path exit 1; zero zombies. Repeatable harness committed (`scripts/doctor-daemon-live.mjs`)
- Tests: 44 doctor/client cases + 17 bootPhases cases; full vitest parallel 3069/3069; `tsc --noEmit -p tsconfig.cli.json` clean; eslint clean

## Notes

- daemon auth token path is deliberately not suffix-aware (`~/.wmux/daemon-auth-token`) — replicates the daemon/launcher asymmetry exactly, with a comment flagging it
- exit codes: FAIL → 1, WARN/SKIP → 0 (script-friendly: a warning is informational, not a failure)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `wmux doctor` command for diagnostics with optional `--json` output — reports daemon health, boot-phase timings, AV-tax hints, and log error/warn analysis.

* **Tests**
  * Added comprehensive unit and end-to-end tests covering diagnostics, boot-phase parsing, daemon pipe resolution, auth handling, and report rendering.
  * Added a Windows live verification script to exercise daemon up/down scenarios and validate doctor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->