### PR TITLE
perf(bench): RAM attribution by process category + scrollback A/B (S-A)

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -40,10 +40,37 @@ pre-announce targets."*
   (pre-JS → module eval → app-ready wait → plugin load → daemon bootstrap
   with spawn/pipe/ping sub-phases → ready tail). All fields are **additive
   and never gated** — they exist to attribute regressions, not to gate them.
+- **RAM attribution** (PR D) — each `ram` scenario carries an additive
+  `breakdown` field that splits the flat working-set / commit total across
+  per-process categories: `main` (Electron browser process), `renderer` (React
+  UI + every xterm), `gpu` (WebGL contexts), `utility` (network/audio/storage
+  services), `daemon` (the detached wmux daemon, matched by its pid file),
+  `conhost` (ConPTY hosts, one per shell), and `other` (user shells, crashpad,
+  …). Processes are bucketed from the Electron `--type=` command-line flag plus
+  image-name heuristics (pure classifier in `scripts/perf-process-classify.mjs`,
+  unit-tested in `scripts/__tests__/perfProcessClassify.test.mjs`). Each bucket
+  carries `{workingSetBytes, commitBytes, processCount}` and the buckets
+  reconcile exactly to the flat total. **Additive and never gated** — it exists
+  to locate the ~70 MB/pane cost (renderer V8 heap vs GPU vs daemon vs conhost)
+  before any diet PR is built. No product code is touched; the attribution is
+  derived entirely in the harness from a `Win32_Process` CIM snapshot.
+- **WebGL pool occupancy** (PR D, 8-pane state) — `ram.webglOccupancy8` records
+  an **approximation** of the live GPU-context count: `webglContextPool` is a
+  module-level singleton not exposed on `window` (and PR D deliberately adds no
+  debug hook to product code), so the harness counts `.xterm-screen canvas`
+  elements in the DOM and probes each for a live `webgl`/`webgl2` context. This
+  is a DOM proxy for `grantedCount()`, not the pool's own counter — it can
+  diverge during the 10s deferred-dispose window or right after an eviction. The
+  pool budget is `MAX_WEBGL_CONTEXTS=12`, so 8 panes sits below the cap (expect
+  up to 8 live canvases). Recorded automatically with the 8-pane RAM scenario;
+  `--webgl-occupancy` forces it on runs that skip RAM.
 
 The result schema (`schemaVersion: 1`) is documented inline in
 `scripts/perf-compare.mjs` (the gated dot-paths) and produced by
-`scripts/perf-bench.mjs`.
+`scripts/perf-bench.mjs`. The PR D `ram.breakdown` and `ram.webglOccupancy8`
+fields are **additive** — the gate iterates only the explicit dot-paths in
+`GATES`, so new fields never change PASS/FAIL or trigger a record-only run (same
+principle as the #210 boot-trace `marks` addition).
 
 ## Running locally
 
@@ -58,6 +85,34 @@ Scenarios can be partially skipped via harness flags (e.g. `--skip-cold`,
 scenario that the *baseline* measured but the *current* run skipped as a gate
 **FAILURE** — a silently dropped scenario must not pass. Skip a scenario on both
 sides (or run record-only) if you genuinely want it out of the gate.
+
+### Scrollback A/B (PR D — RAM diet go/no-go)
+
+To measure how much of the per-pane RAM is xterm scrollback, run the bench twice
+with different `--scrollback-lines` and diff the `ram` totals + `breakdown`:
+
+```sh
+node scripts/perf-bench.mjs --skip-cold --skip-input --scrollback-lines 10000 --json out/perf-sb-10000.json
+node scripts/perf-bench.mjs --skip-cold --skip-input --scrollback-lines 1000  --json out/perf-sb-1000.json
+```
+
+`--scrollback-lines N` pre-seeds a minimal `session.json` (one workspace, one
+empty-PTY pane) carrying `scrollbackLines: N` into each isolated instance's
+`userData`. The renderer's `loadSession` applies the preference **before any
+terminal mounts**, so every measured pane — the seeded pane and the 7 split
+children — allocates its xterm CircularBuffer at `N` lines. Both `idle1Pane` and
+`panes8` reflect the size, so the 8-pane delta between the two runs (where the
+per-pane cost is amplified ×8) is the scrollback's RAM contribution.
+
+> Why a `session.json` pre-seed and not a live CDP injection: `scrollbackLines`
+> is persisted in `SessionData`, but the zustand store is not exposed on
+> `window` (no post-boot setter handle) and `loadSession` early-returns on an
+> empty `workspaces` array (a preference-only seed is ignored). Seeding one
+> schema-valid workspace is the robust persisted-location path. See the
+> `buildScrollbackSeedSession` header in `scripts/perf-bench.mjs`.
+
+The `--scrollback-lines` run identity is recorded in `meta.config.scrollbackLines`
+so two result files are unambiguous.
 
 ## Isolation
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -101,9 +101,11 @@ node scripts/perf-bench.mjs --skip-cold --skip-input --scrollback-lines 1000  --
 empty-PTY pane) carrying `scrollbackLines: N` into each isolated instance's
 `userData`. The renderer's `loadSession` applies the preference **before any
 terminal mounts**, so every measured pane — the seeded pane and the 7 split
-children — allocates its xterm CircularBuffer at `N` lines. Both `idle1Pane` and
-`panes8` reflect the size, so the 8-pane delta between the two runs (where the
-per-pane cost is amplified ×8) is the scrollback's RAM contribution.
+children — gets an xterm CircularBuffer *configured* for `N` lines. Note the
+buffer is lazily populated: RAM only grows as scrollback actually fills, so on
+the near-empty terminals this scenario boots, the 8-pane delta between two runs
+bounds the *configured worst case*, not a guaranteed linear increase (see the
+measured verdict below, where the empty-buffer delta was ~0).
 
 > Why a `session.json` pre-seed and not a live CDP injection: `scrollbackLines`
 > is persisted in `SessionData`, but the zustand store is not exposed on

--- a/bench/README.md
+++ b/bench/README.md
@@ -115,6 +115,36 @@ per-pane cost is amplified ×8) is the scrollback's RAM contribution.
 The `--scrollback-lines` run identity is recorded in `meta.config.scrollbackLines`
 so two result files are unambiguous.
 
+#### First measured verdict (2026-06-13, dev machine i5-13420H) — diet NO-GO
+
+The A/B above was run on the C1+Step-1 build. Buckets reconciled exactly to
+the flat total in all four samples; `commandLineNullCount` was 0; WebGL
+occupancy at 8 panes was 8/12 (cap never hit).
+
+| 8-pane bucket | working set |
+|---|---|
+| other (user shells ×8 + unclassified Chromium) | **~632 MB (≈48%)** |
+| gpu (one process, same at idle) | ~186 MB |
+| renderer | ~146 MB |
+| daemon | ~120 MB |
+| main | ~106 MB |
+| conhost (×8) | ~66 MB |
+
+- **Half the 8-pane footprint is the user's own shells** (PowerShell ≈80 MB
+  each) — not reachable by any wmux code change.
+- **Scrollback A/B delta ≈ 0** (renderer −5 MB, inside noise): xterm's
+  CircularBuffer is lazily populated, so on near-empty terminals the
+  configured line count costs nothing. A future fill-the-scrollback scenario
+  would be needed to measure the *populated* cost; on the diet question the
+  empty-buffer result already kills the "cap scrollback by default" idea.
+- gpu is a single fixed-cost process (identical at idle and 8 panes) — not a
+  per-pane lever either.
+
+Per the plan gate (renderer attribution >60% AND A/B delta >100 MB → build a
+scrollback-cap PR): **both conditions failed → no RAM-diet code work.** The
+remaining footprint is Chromium/V8/shell tax; this section is the
+documentation-closure the plan called for.
+
 ## Isolation
 
 The bench spawns the **packaged exe** with a `WMUX_DATA_SUFFIX` so it runs in an

--- a/bench/README.md
+++ b/bench/README.md
@@ -45,8 +45,9 @@ pre-announce targets."*
   per-process categories: `main` (Electron browser process), `renderer` (React
   UI + every xterm), `gpu` (WebGL contexts), `utility` (network/audio/storage
   services), `daemon` (the detached wmux daemon, matched by its pid file),
-  `conhost` (ConPTY hosts, one per shell), and `other` (user shells, crashpad,
-  …). Processes are bucketed from the Electron `--type=` command-line flag plus
+  `conhost` (ConPTY hosts, one per shell), and `other` (user shells +
+  unclassified Chromium child types such as zygote, crashpad-handler, …).
+  Processes are bucketed from the Electron `--type=` command-line flag plus
   image-name heuristics (pure classifier in `scripts/perf-process-classify.mjs`,
   unit-tested in `scripts/__tests__/perfProcessClassify.test.mjs`). Each bucket
   carries `{workingSetBytes, commitBytes, processCount}` and the buckets

--- a/scripts/__tests__/perfProcessClassify.test.mjs
+++ b/scripts/__tests__/perfProcessClassify.test.mjs
@@ -1,0 +1,144 @@
+// Pure-logic tests for the A1 RAM-attribution classifier
+// (scripts/perf-process-classify.mjs, PR D). No packaged app, no CIM, no
+// pipes — collected by `npm test` via scripts/__tests__/**/*.test.mjs and safe
+// on CI. Mirrors the perfCompare.test.mjs convention: import the pure module,
+// feed it mock rows, assert the bucketing.
+import { describe, it, expect } from 'vitest';
+import {
+  classifyProcess,
+  accumulateBreakdown,
+  RAM_CATEGORIES,
+} from '../perf-process-classify.mjs';
+
+// Realistic command-line shapes Electron/Chromium produce on Windows. The
+// classifier reads the --type= token, not the whole string, so the noisy
+// flag tails are deliberately preserved here.
+const MAIN_CMD = '"C:\\path\\out\\wmux-win32-x64\\wmux.exe"';
+const RENDERER_CMD = '"C:\\path\\wmux.exe" --type=renderer --user-data-dir="C:\\u" --lang=en-US';
+const GPU_CMD = '"C:\\path\\wmux.exe" --type=gpu-process --gpu-preferences=xyz';
+const UTILITY_CMD = '"C:\\path\\wmux.exe" --type=utility --utility-sub-type=network.mojom.NetworkService';
+const QUOTED_GPU_CMD = '"C:\\path\\wmux.exe" --type="gpu-process"';
+
+describe('classifyProcess — Electron child types', () => {
+  it('buckets a typeless wmux.exe as main', () => {
+    expect(classifyProcess({ name: 'wmux.exe', commandLine: MAIN_CMD })).toBe('main');
+  });
+
+  it('buckets --type=renderer as renderer', () => {
+    expect(classifyProcess({ name: 'wmux.exe', commandLine: RENDERER_CMD })).toBe('renderer');
+  });
+
+  it('buckets --type=gpu-process as gpu', () => {
+    expect(classifyProcess({ name: 'wmux.exe', commandLine: GPU_CMD })).toBe('gpu');
+  });
+
+  it('buckets --type=utility as utility', () => {
+    expect(classifyProcess({ name: 'wmux.exe', commandLine: UTILITY_CMD })).toBe('utility');
+  });
+
+  it('tolerates a quoted --type value', () => {
+    expect(classifyProcess({ name: 'wmux.exe', commandLine: QUOTED_GPU_CMD })).toBe('gpu');
+  });
+
+  it('does NOT mis-bucket a path that merely contains "renderer"', () => {
+    // No --type flag → still main, even though the path has the word renderer.
+    const cmd = '"C:\\renderer-tools\\wmux.exe"';
+    expect(classifyProcess({ name: 'wmux.exe', commandLine: cmd })).toBe('main');
+  });
+});
+
+describe('classifyProcess — daemon vs main (shared wmux.exe image)', () => {
+  it('buckets the daemon by authoritative pid match, not by name', () => {
+    // Same image + no --type as the main process; only the pid distinguishes.
+    expect(
+      classifyProcess(
+        { name: 'wmux.exe', commandLine: MAIN_CMD },
+        { pid: 4242, mainPid: 1000, daemonPid: 4242 },
+      ),
+    ).toBe('daemon');
+  });
+
+  it('still buckets the main process as main when the daemon pid differs', () => {
+    expect(
+      classifyProcess(
+        { name: 'wmux.exe', commandLine: MAIN_CMD },
+        { pid: 1000, mainPid: 1000, daemonPid: 4242 },
+      ),
+    ).toBe('main');
+  });
+
+  it('daemon pid match wins even over a --type flag (defensive ordering)', () => {
+    // A daemon should never carry --type, but if a recycled pid ever did, the
+    // pid-file identity must still win.
+    expect(
+      classifyProcess(
+        { name: 'wmux.exe', commandLine: RENDERER_CMD },
+        { pid: 4242, daemonPid: 4242 },
+      ),
+    ).toBe('daemon');
+  });
+});
+
+describe('classifyProcess — conhost and fallback', () => {
+  it('buckets conhost.exe as conhost (ConPTY host)', () => {
+    expect(classifyProcess({ name: 'conhost.exe', commandLine: null })).toBe('conhost');
+  });
+
+  it('buckets a user shell as other', () => {
+    expect(classifyProcess({ name: 'powershell.exe', commandLine: 'powershell.exe -NoLogo' })).toBe('other');
+  });
+
+  it('buckets an unknown process with a null command line as other', () => {
+    expect(classifyProcess({ name: 'crashpad_handler.exe', commandLine: null })).toBe('other');
+  });
+
+  it('treats a typeless electron.exe (dev build) as main', () => {
+    expect(classifyProcess({ name: 'electron.exe', commandLine: '"C:\\electron.exe"' })).toBe('main');
+  });
+
+  it('handles a missing/empty row without throwing', () => {
+    expect(classifyProcess({})).toBe('other');
+    expect(classifyProcess({ name: undefined, commandLine: undefined })).toBe('other');
+  });
+});
+
+describe('accumulateBreakdown — folding rows into category totals', () => {
+  const rows = [
+    { pid: 1000, name: 'wmux.exe', commandLine: MAIN_CMD, workingSetBytes: 100, commitBytes: 50 },
+    { pid: 1001, name: 'wmux.exe', commandLine: RENDERER_CMD, workingSetBytes: 200, commitBytes: 80 },
+    { pid: 1002, name: 'wmux.exe', commandLine: RENDERER_CMD, workingSetBytes: 210, commitBytes: 90 },
+    { pid: 1003, name: 'wmux.exe', commandLine: GPU_CMD, workingSetBytes: 300, commitBytes: 120 },
+    { pid: 1004, name: 'wmux.exe', commandLine: UTILITY_CMD, workingSetBytes: 40, commitBytes: 20 },
+    { pid: 4242, name: 'wmux.exe', commandLine: MAIN_CMD, workingSetBytes: 60, commitBytes: 30 },
+    { pid: 5000, name: 'conhost.exe', commandLine: null, workingSetBytes: 25, commitBytes: 10 },
+    { pid: 6000, name: 'powershell.exe', commandLine: 'powershell.exe', workingSetBytes: 70, commitBytes: 35 },
+  ];
+
+  it('produces every category key (zeroed when empty) for a stable JSON shape', () => {
+    const b = accumulateBreakdown([], {});
+    for (const cat of RAM_CATEGORIES) {
+      expect(b[cat]).toEqual({ workingSetBytes: 0, commitBytes: 0, processCount: 0 });
+    }
+  });
+
+  it('attributes working set + commit + count per category', () => {
+    const b = accumulateBreakdown(rows, { mainPid: 1000, daemonPid: 4242 });
+    expect(b.main).toEqual({ workingSetBytes: 100, commitBytes: 50, processCount: 1 });
+    expect(b.renderer).toEqual({ workingSetBytes: 410, commitBytes: 170, processCount: 2 });
+    expect(b.gpu).toEqual({ workingSetBytes: 300, commitBytes: 120, processCount: 1 });
+    expect(b.utility).toEqual({ workingSetBytes: 40, commitBytes: 20, processCount: 1 });
+    expect(b.daemon).toEqual({ workingSetBytes: 60, commitBytes: 30, processCount: 1 });
+    expect(b.conhost).toEqual({ workingSetBytes: 25, commitBytes: 10, processCount: 1 });
+    expect(b.other).toEqual({ workingSetBytes: 70, commitBytes: 35, processCount: 1 });
+  });
+
+  it('reconciles exactly to the flat working-set / commit totals', () => {
+    const b = accumulateBreakdown(rows, { mainPid: 1000, daemonPid: 4242 });
+    const flatWs = rows.reduce((a, r) => a + r.workingSetBytes, 0);
+    const flatCommit = rows.reduce((a, r) => a + r.commitBytes, 0);
+    const sumWs = RAM_CATEGORIES.reduce((a, c) => a + b[c].workingSetBytes, 0);
+    const sumCommit = RAM_CATEGORIES.reduce((a, c) => a + b[c].commitBytes, 0);
+    expect(sumWs).toBe(flatWs);
+    expect(sumCommit).toBe(flatCommit);
+  });
+});

--- a/scripts/__tests__/perfProcessClassify.test.mjs
+++ b/scripts/__tests__/perfProcessClassify.test.mjs
@@ -142,3 +142,75 @@ describe('accumulateBreakdown — folding rows into category totals', () => {
     expect(sumCommit).toBe(flatCommit);
   });
 });
+
+describe('accumulateBreakdown — commandLineNullCount (P2-1 skew signal)', () => {
+  // All command lines readable: main + two renderers + a conhost.
+  const readableRows = [
+    { pid: 1000, name: 'wmux.exe', commandLine: MAIN_CMD, workingSetBytes: 100, commitBytes: 50 },
+    { pid: 1001, name: 'wmux.exe', commandLine: RENDERER_CMD, workingSetBytes: 200, commitBytes: 80 },
+    { pid: 1002, name: 'wmux.exe', commandLine: RENDERER_CMD, workingSetBytes: 210, commitBytes: 90 },
+    { pid: 5000, name: 'conhost.exe', commandLine: null, workingSetBytes: 25, commitBytes: 10 },
+  ];
+
+  it('exposes the field as 0 for an all-readable tree', () => {
+    const b = accumulateBreakdown(readableRows, { mainPid: 1000, daemonPid: 4242 });
+    expect(b.commandLineNullCount).toBe(0);
+  });
+
+  it('exposes the field as 0 on an empty tree (stable JSON shape)', () => {
+    expect(accumulateBreakdown([], {}).commandLineNullCount).toBe(0);
+  });
+
+  it('counts a typeless wmux.exe child whose CommandLine CIM could not read', () => {
+    // CIM null CommandLine → no --type token → silently folded into `main`.
+    // The count surfaces that the main attribution may be inflated.
+    const skewed = [
+      { pid: 1000, name: 'wmux.exe', commandLine: MAIN_CMD, workingSetBytes: 100, commitBytes: 50 },
+      { pid: 2000, name: 'wmux.exe', commandLine: null, workingSetBytes: 180, commitBytes: 70 },
+      { pid: 2001, name: 'wmux.exe', commandLine: undefined, workingSetBytes: 150, commitBytes: 60 },
+      { pid: 2002, name: 'wmux.exe', commandLine: '   ', workingSetBytes: 90, commitBytes: 40 },
+    ];
+    const b = accumulateBreakdown(skewed, { mainPid: 1000 });
+    // All three unreadable rows fall into `main` alongside the genuine main.
+    expect(b.main.processCount).toBe(4);
+    expect(b.commandLineNullCount).toBe(3);
+  });
+
+  it('does NOT count the daemon — its null command line is pinned by pid', () => {
+    // The daemon shares the wmux.exe image with a null/typeless command line,
+    // but it is bucketed authoritatively by pid, so it is not a skew risk.
+    const withDaemon = [
+      { pid: 1000, name: 'wmux.exe', commandLine: MAIN_CMD, workingSetBytes: 100, commitBytes: 50 },
+      { pid: 4242, name: 'wmux.exe', commandLine: null, workingSetBytes: 60, commitBytes: 30 },
+    ];
+    const b = accumulateBreakdown(withDaemon, { mainPid: 1000, daemonPid: 4242 });
+    expect(b.daemon.processCount).toBe(1);
+    expect(b.commandLineNullCount).toBe(0);
+  });
+
+  it('does NOT count a non-wmux process with a null command line', () => {
+    // A null command line on conhost/crashpad is bucketed by name, not skew.
+    const b = accumulateBreakdown(
+      [{ pid: 5000, name: 'conhost.exe', commandLine: null, workingSetBytes: 25, commitBytes: 10 }],
+      {},
+    );
+    expect(b.commandLineNullCount).toBe(0);
+  });
+
+  it('keeps the bucket-sum invariant intact even with the additive count present', () => {
+    // commandLineNullCount must not participate in the working-set/commit sums.
+    const skewed = [
+      { pid: 1000, name: 'wmux.exe', commandLine: MAIN_CMD, workingSetBytes: 100, commitBytes: 50 },
+      { pid: 2000, name: 'wmux.exe', commandLine: null, workingSetBytes: 180, commitBytes: 70 },
+      { pid: 5000, name: 'conhost.exe', commandLine: null, workingSetBytes: 25, commitBytes: 10 },
+    ];
+    const b = accumulateBreakdown(skewed, { mainPid: 1000 });
+    const flatWs = skewed.reduce((a, r) => a + r.workingSetBytes, 0);
+    const flatCommit = skewed.reduce((a, r) => a + r.commitBytes, 0);
+    const sumWs = RAM_CATEGORIES.reduce((a, c) => a + b[c].workingSetBytes, 0);
+    const sumCommit = RAM_CATEGORIES.reduce((a, c) => a + b[c].commitBytes, 0);
+    expect(sumWs).toBe(flatWs);
+    expect(sumCommit).toBe(flatCommit);
+    expect(b.commandLineNullCount).toBe(1);
+  });
+});

--- a/scripts/perf-bench.mjs
+++ b/scripts/perf-bench.mjs
@@ -20,7 +20,16 @@
  *   ram            Working set + commit charge summed over the FULL process
  *                  tree: main exe + Chromium children + the detached daemon
  *                  (read from its pid file) + its ConPTY/conhost children.
- *                  Sampled at idle-1-pane and at 8 panes.
+ *                  Sampled at idle-1-pane and at 8 panes. PR D adds an additive
+ *                  `breakdown` field that attributes that flat total to per-
+ *                  process categories (main / renderer / gpu / utility / daemon
+ *                  / conhost / other) via the Electron `--type=` flag, so a
+ *                  diet candidate (scrollback cap, V8 heap, GPU release) can be
+ *                  located before it is built. With --scrollback-lines N the
+ *                  bench pre-seeds session.json so EVERY measured pane mounts at
+ *                  that scrollback size (clean A/B at both idle1Pane and 8
+ *                  panes — see buildScrollbackSeedSession). With
+ *                  --webgl-occupancy it logs the 8-pane WebGL-canvas count.
  *
  * ISOLATION MODEL
  * ---------------
@@ -56,6 +65,8 @@
  *                          ci: 3 /80/40)
  *        --json <path>     write machine-readable results
  *        --cold-runs N --samples N --samples8 N   explicit overrides
+ *        --scrollback-lines N   inject scrollback=N into measured panes (A/B)
+ *        --webgl-occupancy      log the 8-pane WebGL canvas count (DOM approx)
  *        --skip-cold | --skip-input | --skip-ram
  *        --keep-app        leave the last instance running (debugging)
  */
@@ -67,6 +78,7 @@ import os from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { chromium } from 'playwright-core';
+import { accumulateBreakdown, RAM_CATEGORIES } from './perf-process-classify.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
@@ -85,6 +97,12 @@ function parseArgs(argv) {
     mode: 'local', json: null, help: false, keepApp: false,
     coldRuns: null, samples: null, samples8: null,
     skipCold: false, skipInput: false, skipRam: false, diag: false,
+    // PR D — RAM attribution. scrollbackLines: null leaves the app default
+    // (10000) untouched; a number injects that scrollback into the panes the
+    // bench measures so two runs (e.g. 10000 vs 1000) form an A/B for the
+    // scrollback-cap go/no-go. webglOccupancy: log the 8-pane WebGL-canvas
+    // count (approximation; see measureWebglOccupancy).
+    scrollbackLines: null, webglOccupancy: false,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -94,6 +112,8 @@ function parseArgs(argv) {
     else if (a === '--cold-runs') out.coldRuns = Math.max(1, Number(argv[++i]) || 0);
     else if (a === '--samples') out.samples = Math.max(5, Number(argv[++i]) || 0);
     else if (a === '--samples8') out.samples8 = Math.max(5, Number(argv[++i]) || 0);
+    else if (a === '--scrollback-lines') out.scrollbackLines = Math.max(0, Number(argv[++i]) || 0);
+    else if (a === '--webgl-occupancy') out.webglOccupancy = true;
     else if (a === '--skip-cold') out.skipCold = true;
     else if (a === '--skip-input') out.skipInput = true;
     else if (a === '--skip-ram') out.skipRam = true;
@@ -118,7 +138,14 @@ Usage (PowerShell, package first):
 
 Scenarios: coldStart (N isolated boots, warmup discarded), inputLatency
 (key→echo / key→frame in-renderer, 1 pane and 8 panes), ram (process-tree
-working set at idle-1-pane / 8 panes). See bench/README.md.`);
+working set at idle-1-pane / 8 panes). See bench/README.md.
+
+RAM-attribution flags (PR D):
+  --scrollback-lines N   inject scrollback=N into the panes the bench creates
+                         (run twice, e.g. 10000 vs 1000, for a scrollback A/B).
+  --webgl-occupancy      log the 8-pane WebGL canvas count (DOM approximation).
+ram results carry an additive ram.breakdown (per-process-category working set:
+main / renderer / gpu / utility / daemon / conhost / other) — never gated.`);
   process.exit(0);
 }
 if (!fs.existsSync(APP_EXE)) {
@@ -308,6 +335,17 @@ function makeInstance() {
   const userDataDir = path.join(env.APPDATA, `wmux${suffix}`);
   fs.mkdirSync(userDataDir, { recursive: true });
   fs.writeFileSync(path.join(userDataDir, '.first-run'), new Date().toISOString(), 'utf8');
+  // PR D scrollback A/B: pre-seed session.json so loadSession applies the
+  // scrollbackLines preference BEFORE any terminal mounts (see
+  // buildScrollbackSeedSession for why this beats CDP store-injection). Only
+  // when --scrollback-lines is supplied; otherwise the app boots untouched.
+  if (ARGS.scrollbackLines != null) {
+    fs.writeFileSync(
+      path.join(userDataDir, 'session.json'),
+      JSON.stringify(buildScrollbackSeedSession(ARGS.scrollbackLines)),
+      'utf8',
+    );
+  }
   return {
     seq, suffix, home, env,
     proc: null, cdpPort: null, browser: null, page: null,
@@ -775,7 +813,11 @@ const POWERSHELL_EXE = path.join(
 ); // absolute path — bare 'powershell.exe' is ENOENT under some shells (git-bash PATH)
 function snapshotProcesses() {
   return new Promise((resolve, reject) => {
-    const ps = 'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,WorkingSetSize,PageFileUsage | ConvertTo-Json -Compress';
+    // PR D: Name + CommandLine are added so measureRam() can attribute the flat
+    // total to per-process categories (the Electron `--type=` flag lives on the
+    // command line). CommandLine is null for processes the bench user can't read
+    // — the classifier tolerates that and buckets them by image name / fallback.
+    const ps = 'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine,WorkingSetSize,PageFileUsage | ConvertTo-Json -Compress';
     execFile(POWERSHELL_EXE, ['-NoProfile', '-NonInteractive', '-Command', ps],
       { maxBuffer: 64 * 1024 * 1024, windowsHide: true }, (err, stdout) => {
         if (err) return reject(err);
@@ -805,18 +847,142 @@ async function measureRam(inst, label) {
   }
   let workingSetBytes = 0;
   let commitBytes = 0;
+  // PR D: collect the normalized per-process rows over the SAME tree the flat
+  // sum walks, so the breakdown reconciles exactly to workingSetBytes below.
+  const treeRows = [];
   for (const pid of seen) {
     const p = byPid.get(pid);
-    workingSetBytes += Number(p.WorkingSetSize) || 0;
-    commitBytes += (Number(p.PageFileUsage) || 0) * 1024; // PageFileUsage is KB
+    const ws = Number(p.WorkingSetSize) || 0;
+    const commit = (Number(p.PageFileUsage) || 0) * 1024; // PageFileUsage is KB
+    workingSetBytes += ws;
+    commitBytes += commit;
+    treeRows.push({
+      pid: p.ProcessId,
+      name: p.Name,
+      commandLine: p.CommandLine,
+      workingSetBytes: ws,
+      commitBytes: commit,
+    });
   }
+  // Additive RAM attribution (PR D). Pure classifier in perf-process-classify
+  // .mjs; never gated (perf-compare.mjs gates only explicit dot-paths).
+  const breakdown = accumulateBreakdown(treeRows, { mainPid: inst.proc.pid, daemonPid });
   let appMetricsRaw = null;
   try {
     appMetricsRaw = await inst.page.evaluate(() =>
       window.electronAPI?.system?.getMemoryUsage ? window.electronAPI.system.getMemoryUsage() : null);
   } catch { /* informational only */ }
   console.log(`[${label}] workingSet=${(workingSetBytes / 1048576).toFixed(1)}MB commit=${(commitBytes / 1048576).toFixed(1)}MB procs=${seen.size}${daemonPid ? '' : ' (daemon pid missing!)'}`);
-  return { workingSetBytes, commitBytes, processCount: seen.size, appMetricsRaw };
+  // Per-category working-set line (MB), only the non-empty buckets.
+  const breakdownLine = RAM_CATEGORIES
+    .filter((c) => breakdown[c].processCount > 0)
+    .map((c) => `${c}=${(breakdown[c].workingSetBytes / 1048576).toFixed(1)}MB×${breakdown[c].processCount}`)
+    .join(' ');
+  console.log(`[${label}] breakdown: ${breakdownLine}`);
+  return { workingSetBytes, commitBytes, processCount: seen.size, breakdown, appMetricsRaw };
+}
+
+// === Scrollback A/B seed (PR D) ===
+//
+// HOW scrollbackLines is persisted (investigation result):
+//   It rides SessionData — written by AppLayout.buildSessionData into
+//   session.json (<userData>/session.json, SessionManager) and read back by
+//   workspaceSlice.loadSession on boot, which sets uiSlice.scrollbackLines
+//   (default 10000). useTerminal then constructs every xterm with
+//   `scrollback: scrollbackLines`. Two product facts shaped the seeding choice:
+//     1. The zustand store is NOT exposed on window, so a post-boot CDP
+//        `setScrollbackLines()` injection has no handle to call (verified —
+//        no window.useStore / __wmuxStore in src/renderer). Driving the
+//        Settings UI by CDP is possible but brittle (i18n labels, DOM shape).
+//     2. loadSession EARLY-RETURNS on an empty `workspaces` array
+//        (`if (!data.workspaces || data.workspaces.length === 0) return;`),
+//        so a preference-only session.json is silently ignored.
+//   => We pre-seed a session.json carrying ONE minimal, schema-valid workspace
+//      (a single leaf pane with one empty-ptyId surface — exactly the shape a
+//      fresh boot self-creates, so Terminal.tsx takes its self-create path and
+//      spawns a real PTY on mount) PLUS scrollbackLines. loadSession applies
+//      the preference BEFORE any terminal mounts, so every measured pane (the
+//      seeded pane and the 7 split children) allocates its CircularBuffer at
+//      the seeded size — a clean, uniform A/B at both idle1Pane and 8 panes.
+//      This is the persisted-location pre-seed the plan asked for; the store
+//      not being on window is why the CDP-inject alternative was rejected.
+//
+// The seed is only written when --scrollback-lines is supplied; otherwise the
+// app boots its normal default-workspace path untouched.
+function buildScrollbackSeedSession(lines) {
+  const id = (prefix) => `${prefix}-${randomUUID()}`;
+  const surfaceId = id('surface');
+  const paneId = id('pane');
+  const wsId = id('ws');
+  return {
+    workspaces: [
+      {
+        id: wsId,
+        name: 'Workspace 1',
+        rootPane: {
+          id: paneId,
+          type: 'leaf',
+          // Empty ptyId → Terminal.tsx self-creates a fresh PTY on mount (the
+          // well-tested path), so this seeded pane behaves like a normal first
+          // pane — no stale-session reconnect, no scrollback file to replay.
+          surfaces: [
+            { id: surfaceId, ptyId: '', title: 'powershell', shell: 'powershell', cwd: '' },
+          ],
+          activeSurfaceId: surfaceId,
+        },
+        activePaneId: paneId,
+      },
+    ],
+    activeWorkspaceId: wsId,
+    sidebarVisible: true,
+    // The field under test.
+    scrollbackLines: lines,
+    // Match the bench's regular-boot assumptions: skip onboarding / first-run
+    // overlays that would otherwise steal the pane-focus click.
+    onboardingCompleted: true,
+    firstRunCompleted: true,
+  };
+}
+
+// === WebGL pool occupancy (PR D) ===
+//
+// webglContextPool is a module-level singleton in
+// src/renderer/terminal/webglContextPool.ts and is intentionally NOT exposed on
+// window. Per PR D we must NOT add a debug window export to product code, so we
+// approximate the live GPU-context count from the DOM: xterm's WebglAddon
+// appends a <canvas> to each accelerated terminal's `.xterm-screen`, whereas the
+// DOM-renderer fallback (panes the pool evicted) has no canvas. We count
+// `.xterm-screen canvas` elements and, defensively, probe each canvas for a live
+// webgl/webgl2 context so a stray 2D canvas can't inflate the number.
+//
+// LIMITATIONS (reported in the JSON + log):
+//   - This is a DOM proxy, not the pool's own grantedCount(). It can diverge
+//     during the 10s deferred-dispose window (a hidden pane still holds a
+//     canvas) or right after an eviction before xterm tears the canvas down.
+//   - It cannot see the pool's LRU ordering or its MAX_WEBGL_CONTEXTS budget
+//     directly; it only observes the realized canvas count, which is the thing
+//     that actually consumes GPU memory — adequate for the occupancy question.
+async function measureWebglOccupancy(page) {
+  return page.evaluate(() => {
+    const screens = [...document.querySelectorAll('.xterm-screen')];
+    const canvases = [...document.querySelectorAll('.xterm-screen canvas')];
+    let liveWebglContexts = 0;
+    for (const c of canvases) {
+      try {
+        // Reuse the existing context if xterm already created one (getContext
+        // returns the same object for the same type); this does NOT allocate a
+        // new context.
+        if (c.getContext('webgl2') || c.getContext('webgl')) liveWebglContexts++;
+      } catch { /* tainted/!canvas — ignore */ }
+    }
+    return {
+      method: 'dom-canvas-approximation',
+      xtermScreens: screens.length,
+      webglCanvases: canvases.length,
+      liveWebglContexts,
+      note: 'DOM proxy for webglContextPool.grantedCount(); pool is not exposed on window (no product debug hook added per PR D). May diverge during the 10s deferred-dispose window.',
+    };
+  });
 }
 
 // === Results ===
@@ -840,7 +1006,15 @@ const RESULTS = {
     totalMemBytes: os.totalmem(),
     osRelease: os.release(),
     nodeVersion: process.version,
-    config: { coldRuns: ARGS.coldRuns, inputSamples: ARGS.samples, inputSamples8: ARGS.samples8 },
+    config: {
+      coldRuns: ARGS.coldRuns,
+      inputSamples: ARGS.samples,
+      inputSamples8: ARGS.samples8,
+      // PR D: which scrollback A/B leg this run is (null = app default 10000,
+      // not seeded). Records the run's identity so two result files can be
+      // diffed unambiguously.
+      scrollbackLines: ARGS.scrollbackLines,
+    },
   },
   scenarios: {},
 };
@@ -885,6 +1059,9 @@ process.on('exit', () => {
 
   console.log(`exe: ${APP_EXE}`);
   console.log(`mode: ${ARGS.mode}  coldRuns=${ARGS.coldRuns} samples=${ARGS.samples} samples8=${ARGS.samples8}`);
+  if (ARGS.scrollbackLines != null) {
+    console.log(`[scrollback A/B] seeding session.json scrollbackLines=${ARGS.scrollbackLines} into every fresh instance (panes mount at this size). idle1Pane and 8-pane RAM reflect it; compare two runs (e.g. 10000 vs 1000).`);
+  }
 
   let lastInst = null;
 
@@ -1095,6 +1272,23 @@ process.on('exit', () => {
     console.log('--- ram: 8 panes (5s settle) ---');
     await sleep(5000);
     RESULTS.scenarios.ram.panes8 = await measureRam(lastInst, 'ram panes8');
+  }
+
+  // ---------- WebGL pool occupancy at 8 panes (PR D) ----------
+  // Always recorded when the 8-pane state exists (additive, near-zero cost);
+  // --webgl-occupancy is the explicit knob for runs that skip RAM. The pool
+  // budget is MAX_WEBGL_CONTEXTS=12, so 8 panes sits below the cap — we expect
+  // up to 8 live canvases here. See measureWebglOccupancy for the DOM-proxy
+  // caveat (it is not the pool's own grantedCount()).
+  if ((!ARGS.skipInput || !ARGS.skipRam) && (ARGS.webglOccupancy || !ARGS.skipRam)) {
+    try {
+      const occ = await measureWebglOccupancy(lastInst.page);
+      RESULTS.scenarios.ram = RESULTS.scenarios.ram ?? {};
+      RESULTS.scenarios.ram.webglOccupancy8 = occ;
+      console.log(`[webgl occupancy 8-pane] screens=${occ.xtermScreens} canvases=${occ.webglCanvases} liveContexts=${occ.liveWebglContexts} (DOM approximation)`);
+    } catch (e) {
+      console.error(`[webgl occupancy] measurement failed (continuing): ${e.message}`);
+    }
   }
 
   // ---------- inputLatency: 8 panes (focused pane) ----------

--- a/scripts/perf-bench.mjs
+++ b/scripts/perf-bench.mjs
@@ -879,6 +879,12 @@ async function measureRam(inst, label) {
     .map((c) => `${c}=${(breakdown[c].workingSetBytes / 1048576).toFixed(1)}MB×${breakdown[c].processCount}`)
     .join(' ');
   console.log(`[${label}] breakdown: ${breakdownLine}`);
+  // PR D review P2-1: a wmux.exe child whose CommandLine CIM could not read
+  // carries no --type= token and silently falls into the `main` bucket. Surface
+  // it so a skewed attribution is never silent (additive count is in the JSON).
+  if (breakdown.commandLineNullCount > 0) {
+    console.error(`[${label}] attribution may be skewed: ${breakdown.commandLineNullCount} wmux processes had unreadable CommandLine`);
+  }
   return { workingSetBytes, commitBytes, processCount: seen.size, breakdown, appMetricsRaw };
 }
 
@@ -970,8 +976,11 @@ async function measureWebglOccupancy(page) {
     for (const c of canvases) {
       try {
         // Reuse the existing context if xterm already created one (getContext
-        // returns the same object for the same type); this does NOT allocate a
-        // new context.
+        // returns the same object for the same type). On a canvas that already
+        // has a live context this does NOT allocate a new one; on a canvas
+        // whose context was just lost, getContext CAN re-allocate. We run this
+        // probe in a steady state (after panes settle), so in practice it only
+        // observes contexts xterm already holds and does not perturb the count.
         if (c.getContext('webgl2') || c.getContext('webgl')) liveWebglContexts++;
       } catch { /* tainted/!canvas — ignore */ }
     }

--- a/scripts/perf-bench.mjs
+++ b/scripts/perf-bench.mjs
@@ -112,7 +112,18 @@ function parseArgs(argv) {
     else if (a === '--cold-runs') out.coldRuns = Math.max(1, Number(argv[++i]) || 0);
     else if (a === '--samples') out.samples = Math.max(5, Number(argv[++i]) || 0);
     else if (a === '--samples8') out.samples8 = Math.max(5, Number(argv[++i]) || 0);
-    else if (a === '--scrollback-lines') out.scrollbackLines = Math.max(0, Number(argv[++i]) || 0);
+    else if (a === '--scrollback-lines') {
+      // Reject garbage instead of coercing to 0 — a silently-zeroed seed
+      // would measure "scrollback disabled" while the runner believes they
+      // asked for N lines, poisoning the A/B comparison.
+      const n = Number(argv[++i]);
+      if (!Number.isInteger(n) || n < 1) {
+        console.error(`--scrollback-lines expects a positive integer, got: ${argv[i]}`);
+        out.help = true;
+      } else {
+        out.scrollbackLines = n;
+      }
+    }
     else if (a === '--webgl-occupancy') out.webglOccupancy = true;
     else if (a === '--skip-cold') out.skipCold = true;
     else if (a === '--skip-input') out.skipInput = true;

--- a/scripts/perf-process-classify.mjs
+++ b/scripts/perf-process-classify.mjs
@@ -1,0 +1,140 @@
+// Pure process-classification helpers for the A1 RAM-attribution breakdown
+// (perf-bench.mjs PR D). Split into its own module — with NO shebang — so it
+// can be imported by both perf-bench.mjs and a vitest test
+// (scripts/__tests__/perfProcessClassify.test.mjs). A leading shebang makes
+// the Windows-CI vitest loader throw a SyntaxError (known repo gotcha — see
+// the same note atop perf-compare.mjs), so this file must stay shebang-free.
+//
+// The bench sums working-set + commit over the FULL wmux process tree, but a
+// flat total can't tell us WHERE the ~70 MB/pane lives (renderer V8 heap vs
+// GPU process vs daemon vs ConPTY conhost). This module maps each CIM
+// Win32_Process row to one attribution bucket using Electron's child-process
+// `--type=` command-line flag plus image-name heuristics, so measureRam() can
+// emit an additive `ram.breakdown` field without touching product code.
+
+/**
+ * Attribution categories. Order is the display order in the bench log.
+ *   main     — the Electron main/browser process (the root wmux.exe, no --type)
+ *   renderer — Chromium renderer processes (--type=renderer): the React UI +
+ *              every xterm. This is the bucket the scrollback/DOM diet targets.
+ *   gpu      — the GPU process (--type=gpu-process): WebGL contexts live here.
+ *   utility  — Chromium utility/network/audio processes (--type=utility and the
+ *              older --type=network/audio/storage service splits).
+ *   daemon   — the detached wmux daemon (runs the bundled daemon entry; NOT an
+ *              Electron child of the main exe, identified by its pid file).
+ *   conhost  — ConPTY's conhost.exe instances backing each shell (one per PTY).
+ *   other    — anything in the tree we could not confidently bucket (e.g. the
+ *              user's shells themselves, or a crashpad handler). Kept explicit
+ *              so the breakdown always reconciles to the flat total.
+ */
+export const RAM_CATEGORIES = [
+  'main',
+  'renderer',
+  'gpu',
+  'utility',
+  'daemon',
+  'conhost',
+  'other',
+];
+
+// Electron/Chromium tags its children with `--type=<role>` on the command
+// line. We read the role token after the flag rather than substring-matching
+// the whole command line, so an unrelated path component that happens to
+// contain "renderer" can't mis-bucket the main process.
+function extractChromiumType(commandLine) {
+  if (!commandLine) return null;
+  // Match --type=renderer, --type="gpu-process", --type=utility, etc. The
+  // value runs until whitespace or a quote.
+  const m = /--type=(?:"|')?([a-z-]+)/i.exec(commandLine);
+  return m ? m[1].toLowerCase() : null;
+}
+
+/**
+ * Classify one process row into a RAM_CATEGORIES bucket.
+ *
+ * @param {object} row
+ * @param {string} [row.name]        Win32_Process.Name (image file name).
+ * @param {string} [row.commandLine] Win32_Process.CommandLine (may be null —
+ *                                   CIM returns null for processes the bench
+ *                                   user can't read the command line of).
+ * @param {object} [opts]
+ * @param {number} [opts.pid]        This process's pid (for daemon/main match).
+ * @param {number} [opts.mainPid]    The Electron main exe's pid. A child whose
+ *                                   image is wmux.exe with no --type is a main
+ *                                   process; Electron spawns no other typeless
+ *                                   wmux.exe, so name+no-type is a safe "main"
+ *                                   signal even when the pid is not supplied.
+ * @param {number} [opts.daemonPid]  The detached daemon's pid (read from the
+ *                                   daemon.pid file). Authoritative — the
+ *                                   daemon shares the wmux.exe image, so the
+ *                                   pid is the only reliable discriminator.
+ * @returns {string} one of RAM_CATEGORIES.
+ */
+export function classifyProcess(row, opts = {}) {
+  const name = String(row?.name ?? '').toLowerCase();
+  const commandLine = row?.commandLine ?? '';
+  const { pid, mainPid, daemonPid } = opts;
+
+  // 1. Daemon: authoritative pid match wins over every name/flag heuristic,
+  //    because the daemon runs the same wmux.exe image with no --type and
+  //    would otherwise be mis-bucketed as "main".
+  if (daemonPid != null && pid != null && pid === daemonPid) return 'daemon';
+
+  // 2. conhost.exe — ConPTY's pseudo-console host backing each shell PTY.
+  if (name === 'conhost.exe' || name.startsWith('conhost')) return 'conhost';
+
+  // 3. Electron children carry an explicit --type= role.
+  const type = extractChromiumType(commandLine);
+  if (type === 'renderer') return 'renderer';
+  if (type === 'gpu-process' || type === 'gpu') return 'gpu';
+  if (
+    type === 'utility' ||
+    type === 'network' ||
+    type === 'audio' ||
+    type === 'storage' ||
+    type === 'broker'
+  ) {
+    return 'utility';
+  }
+
+  // 4. The Electron main/browser process: the wmux.exe image with no --type.
+  //    (The daemon was already peeled off by the pid match above, so any
+  //    remaining typeless wmux.exe is the main process.)
+  const isWmuxImage = name.includes('wmux') || (mainPid != null && pid === mainPid);
+  if (isWmuxImage && !type) return 'main';
+
+  // 5. Some dev builds name the Electron main image electron.exe — treat a
+  //    typeless electron.exe as main too.
+  if (name === 'electron.exe' && !type) return 'main';
+
+  // 6. Everything else in the tree (user shells, crashpad, etc.).
+  return 'other';
+}
+
+/**
+ * Fold a list of process rows into a per-category {workingSetBytes,
+ * commitBytes, processCount} breakdown. Every category in RAM_CATEGORIES is
+ * present in the output (zeroed when empty) so the JSON shape stays stable
+ * across runs. The summed totals reconcile exactly to the flat working-set /
+ * commit the bench already reports.
+ *
+ * @param {Array<{pid:number,name:string,commandLine:string,
+ *                workingSetBytes:number,commitBytes:number}>} rows
+ * @param {{mainPid?:number, daemonPid?:number}} opts
+ */
+export function accumulateBreakdown(rows, opts = {}) {
+  const out = {};
+  for (const cat of RAM_CATEGORIES) {
+    out[cat] = { workingSetBytes: 0, commitBytes: 0, processCount: 0 };
+  }
+  for (const row of rows) {
+    const cat = classifyProcess(
+      { name: row.name, commandLine: row.commandLine },
+      { pid: row.pid, mainPid: opts.mainPid, daemonPid: opts.daemonPid },
+    );
+    out[cat].workingSetBytes += Number(row.workingSetBytes) || 0;
+    out[cat].commitBytes += Number(row.commitBytes) || 0;
+    out[cat].processCount += 1;
+  }
+  return out;
+}

--- a/scripts/perf-process-classify.mjs
+++ b/scripts/perf-process-classify.mjs
@@ -23,9 +23,12 @@
  *   daemon   — the detached wmux daemon (runs the bundled daemon entry; NOT an
  *              Electron child of the main exe, identified by its pid file).
  *   conhost  — ConPTY's conhost.exe instances backing each shell (one per PTY).
- *   other    — anything in the tree we could not confidently bucket (e.g. the
- *              user's shells themselves, or a crashpad handler). Kept explicit
- *              so the breakdown always reconciles to the flat total.
+ *   other    — user shells plus any unclassified Chromium child types. The
+ *              utility bucket only matches the --type= roles we enumerate
+ *              (utility/network/audio/storage/broker); other Chromium child
+ *              types (e.g. zygote, crashpad-handler) land here, as do the
+ *              user's own shells. Kept explicit so the breakdown always
+ *              reconciles to the flat total.
  */
 export const RAM_CATEGORIES = [
   'main',
@@ -107,8 +110,36 @@ export function classifyProcess(row, opts = {}) {
   //    typeless electron.exe as main too.
   if (name === 'electron.exe' && !type) return 'main';
 
-  // 6. Everything else in the tree (user shells, crashpad, etc.).
+  // 6. Everything else in the tree: user shells plus any Chromium child type
+  //    we don't enumerate in step 3 (e.g. zygote, crashpad-handler).
   return 'other';
+}
+
+/**
+ * True when a row is a wmux.exe child whose CommandLine CIM could not read
+ * (null/empty) AND whose identity isn't otherwise pinned by pid. Such a row
+ * carries no `--type=` token, so extractChromiumType returns null and
+ * classifyProcess silently folds it into the `main` bucket — even though it may
+ * really be a renderer/gpu/utility child. We can't fix the attribution without
+ * the command line, but we CAN surface how often it happens so a skewed
+ * breakdown is never silent.
+ *
+ * Excluded on purpose: (a) a typeless wmux.exe WITH a real command line is a
+ * genuine main process, and (b) the daemon shares the wmux.exe image and also
+ * has a null/typeless command line, but it is bucketed authoritatively by its
+ * pid-file match — so a null command line there is expected, not a skew risk.
+ */
+function isUnreadableWmuxCommandLine(row, opts = {}) {
+  const name = String(row?.name ?? '').toLowerCase();
+  const { pid, mainPid, daemonPid } = opts;
+  // The daemon is pinned by pid; its null command line never skews `main`.
+  if (daemonPid != null && pid != null && pid === daemonPid) return false;
+  const isWmuxImage = name.includes('wmux') || (mainPid != null && pid === mainPid);
+  if (!isWmuxImage) return false;
+  const commandLine = row?.commandLine;
+  // CIM returns null (or, defensively, an empty string) when the bench user
+  // lacks read access to the target process's command line.
+  return commandLine == null || String(commandLine).trim() === '';
 }
 
 /**
@@ -117,6 +148,13 @@ export function classifyProcess(row, opts = {}) {
  * present in the output (zeroed when empty) so the JSON shape stays stable
  * across runs. The summed totals reconcile exactly to the flat working-set /
  * commit the bench already reports.
+ *
+ * The result also carries an additive `commandLineNullCount`: the number of
+ * wmux.exe rows whose CommandLine was unreadable. These rows fall back into the
+ * `main` bucket for lack of a `--type=` token, so a non-zero count means the
+ * main attribution may be inflated by hidden renderer/gpu/utility children. The
+ * field sits alongside the category keys (which stay the canonical
+ * RAM_CATEGORIES set) and does NOT participate in the bucket-sum invariant.
  *
  * @param {Array<{pid:number,name:string,commandLine:string,
  *                workingSetBytes:number,commitBytes:number}>} rows
@@ -127,6 +165,7 @@ export function accumulateBreakdown(rows, opts = {}) {
   for (const cat of RAM_CATEGORIES) {
     out[cat] = { workingSetBytes: 0, commitBytes: 0, processCount: 0 };
   }
+  let commandLineNullCount = 0;
   for (const row of rows) {
     const cat = classifyProcess(
       { name: row.name, commandLine: row.commandLine },
@@ -135,6 +174,10 @@ export function accumulateBreakdown(rows, opts = {}) {
     out[cat].workingSetBytes += Number(row.workingSetBytes) || 0;
     out[cat].commitBytes += Number(row.commitBytes) || 0;
     out[cat].processCount += 1;
+    if (isUnreadableWmuxCommandLine(row, { pid: row.pid, mainPid: opts.mainPid, daemonPid: opts.daemonPid })) {
+      commandLineNullCount += 1;
+    }
   }
+  out.commandLineNullCount = commandLineNullCount;
   return out;
 }


### PR DESCRIPTION
## What

Extends the bench harness (zero product-code changes) so the flat RAM number can answer "what is the 70 MB/pane actually made of":

- **`ram.breakdown`** (additive field, schemaVersion unchanged): every process in the measured tree is classified `main / renderer / gpu / utility / daemon / conhost / other` via the Electron `--type=` flag + image/pid heuristics (daemon matched authoritatively by its pid file since it shares the wmux.exe image). Buckets reconcile **exactly** to the flat total — a tested invariant. Unreadable CommandLines surface as `commandLineNullCount` + a stderr skew warning instead of silently mis-bucketing (review P2-1).
- **`--scrollback-lines N`**: pre-seeds a schema-valid `session.json` into each isolated instance so every measured pane allocates its xterm buffer at N lines — a clean A/B for the scrollback-cap question. (CDP injection is impossible: the store isn''t exposed on `window`, and `loadSession` ignores preference-only seeds.)
- **`ram.webglOccupancy8`**: DOM-canvas approximation of WebGL context count at 8 panes (no product debug hook added; limitation documented).

## First verdict from the data (now in bench/README.md): RAM diet NO-GO

| 8-pane bucket | working set |
|---|---|
| other = user shells x8 + unclassified Chromium | **~632 MB (~48%)** |
| gpu (single fixed-cost process, same at idle) | ~186 MB |
| renderer | ~146 MB |
| daemon / main / conhost | ~120 / ~106 / ~66 MB |

- Half the 8-pane footprint is the user''s own PowerShells (~80 MB each) — unreachable by wmux code.
- Scrollback A/B delta ~= 0 (renderer -5 MB): xterm''s CircularBuffer is lazily populated, so the configured cap costs nothing on near-empty terminals — kills the "cap scrollback by default" diet idea. A fill-the-scrollback scenario is the future follow-up if populated cost ever matters.
- Plan gate (renderer >60% AND A/B >100 MB -> build diet PR): **both failed -> no diet code work.** The instrumentation paid for itself by cancelling a sprint item with data.

## Verification

- Buckets == flat total in all four live samples (10000/1000 x idle/8-pane); `commandLineNullCount` 0; WebGL occupancy 8/12 (cap never hit); seed identity recorded in `meta.config.scrollbackLines`
- perf-compare gate safety: RAM gates PASS against the freshly blessed baseline with the new additive fields present; no gated dot-path references them; no record-only trip
- 23 unit tests on the pure classifier (incl. null-CommandLine fallback + reconcile invariant); full vitest parallel green; `node --check` clean; no shebang in vitest-imported .mjs
- Adversarial review: P2-1 (silent null-CommandLine skew) and P2-2 (''other'' bucket doc) fixed; P3 comment scoped; P3-2/3/4 accepted as-is

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded perf bench: per-process RAM attribution, scrollback A/B seeding, and 8-pane WebGL occupancy measurement.
  * Bench records scrollback config in run metadata and captures per-category RAM totals and process counts.

* **Documentation**
  * Added bench README with new metrics, scrollback A/B instructions, example verdict table, and conclusions.

* **Tests**
  * Added tests validating RAM attribution classification and per-category aggregation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->