### PR TITLE
perf: lighter idle footprint (RAM + CPU + package size)

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -145,9 +145,17 @@ const config: ForgeConfig = {
       const asar = require('@electron/asar');
       const outputPath = packageResult.outputPaths[0];
       // Build target — prune node-pty prebuilds to this platform/arch only.
-      // Fall back to the host triple if forge doesn't surface them.
-      const targetPlatform = (packageResult as { platform?: string }).platform ?? process.platform;
-      const targetArch = (packageResult as { arch?: string }).arch ?? process.arch;
+      // Use forge's packageResult triple (the actual build target, correct even
+      // under cross-compilation). If forge doesn't surface it, skip pruning
+      // entirely rather than fall back to the host triple — pruning against the
+      // wrong target could delete the only loadable prebuild. A larger build
+      // beats a broken one.
+      const targetPlatform = (packageResult as { platform?: string }).platform;
+      const targetArch = (packageResult as { arch?: string }).arch;
+      const canPrune = Boolean(targetPlatform && targetArch);
+      if (!canPrune) {
+        console.warn('[postPackage] packageResult platform/arch unavailable — skipping node-pty prebuild pruning.');
+      }
       // macOS는 .app 번들이라 리소스가 <app>.app/Contents/Resources에,
       // Windows/Linux는 <output>/resources에 위치한다. .app 이름은
       // productName에 따라 달라지므로 디렉토리에서 직접 찾는다.
@@ -169,7 +177,7 @@ const config: ForgeConfig = {
       const destNodePty = path.join(tempDir, 'node_modules', 'node-pty');
       console.log(`[postPackage] Copying node-pty...`);
       copyDirSync(path.join(__dirname, 'node_modules', 'node-pty'), destNodePty);
-      pruneForeignPrebuilds(destNodePty, targetPlatform, targetArch);
+      if (canPrune) pruneForeignPrebuilds(destNodePty, targetPlatform!, targetArch!);
       const srcAddonApi = path.join(__dirname, 'node_modules', 'node-addon-api');
       if (fs.existsSync(srcAddonApi)) {
         copyDirSync(srcAddonApi, path.join(tempDir, 'node_modules', 'node-addon-api'));
@@ -224,7 +232,7 @@ const config: ForgeConfig = {
         const daemonNodePty = path.join(daemonBundleDir, 'node_modules', 'node-pty');
         console.log('[postPackage] Copying node-pty for daemon-bundle...');
         copyDirSync(path.join(__dirname, 'node_modules', 'node-pty'), daemonNodePty);
-        pruneForeignPrebuilds(daemonNodePty, targetPlatform, targetArch);
+        if (canPrune) pruneForeignPrebuilds(daemonNodePty, targetPlatform!, targetArch!);
         console.log('[postPackage] Done — node-pty available for daemon.');
       }
 

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -32,6 +32,33 @@ function copyDirSync(src: string, dest: string): void {
   }
 }
 
+// node-pty ships prebuilt native binaries for every platform/arch under
+// prebuilds/<platform>-<arch>/. The Windows ConPTY prebuilds are ~30 MB EACH
+// (win32-x64 + win32-arm64 ≈ 58 MB), so shipping the non-target architectures
+// bloats both the app.asar.unpacked AND the daemon-bundle copy for binaries the
+// build can never load (a win32-x64 build will never dlopen a win32-arm64 or
+// darwin .node). Delete every prebuild dir that doesn't match the build target.
+//
+// Keyed on the ACTUAL packaged platform/arch (not the host) so cross-arch makes
+// keep the right one. Defensive: if the target dir is somehow missing we keep
+// everything rather than emit a build with no loadable PTY binary.
+function pruneForeignPrebuilds(nodePtyDir: string, platform: string, arch: string): void {
+  const prebuildsDir = path.join(nodePtyDir, 'prebuilds');
+  if (!fs.existsSync(prebuildsDir)) return;
+  const keep = `${platform}-${arch}`;
+  const entries = fs.readdirSync(prebuildsDir, { withFileTypes: true });
+  if (!entries.some((e) => e.isDirectory() && e.name === keep)) {
+    console.warn(`[postPackage] node-pty prebuild '${keep}' not found — keeping all prebuilds.`);
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory() && entry.name !== keep) {
+      fs.rmSync(path.join(prebuildsDir, entry.name), { recursive: true, force: true });
+      console.log(`[postPackage] Pruned foreign node-pty prebuild: ${entry.name}`);
+    }
+  }
+}
+
 // node-pty의 spawn-helper(macOS에서 셸을 fork/exec하는 바이너리)는 npm prebuild가
 // 실행권한 없이(rw-r--r--) 풀려서, +x를 직접 부여하지 않으면 posix_spawnp가
 // 셸을 띄우지 못한다("posix_spawnp failed"). 반드시 코드 서명 "전"에 호출해야
@@ -117,6 +144,10 @@ const config: ForgeConfig = {
     postPackage: async (_config, packageResult) => {
       const asar = require('@electron/asar');
       const outputPath = packageResult.outputPaths[0];
+      // Build target — prune node-pty prebuilds to this platform/arch only.
+      // Fall back to the host triple if forge doesn't surface them.
+      const targetPlatform = (packageResult as { platform?: string }).platform ?? process.platform;
+      const targetArch = (packageResult as { arch?: string }).arch ?? process.arch;
       // macOS는 .app 번들이라 리소스가 <app>.app/Contents/Resources에,
       // Windows/Linux는 <output>/resources에 위치한다. .app 이름은
       // productName에 따라 달라지므로 디렉토리에서 직접 찾는다.
@@ -138,6 +169,7 @@ const config: ForgeConfig = {
       const destNodePty = path.join(tempDir, 'node_modules', 'node-pty');
       console.log(`[postPackage] Copying node-pty...`);
       copyDirSync(path.join(__dirname, 'node_modules', 'node-pty'), destNodePty);
+      pruneForeignPrebuilds(destNodePty, targetPlatform, targetArch);
       const srcAddonApi = path.join(__dirname, 'node_modules', 'node-addon-api');
       if (fs.existsSync(srcAddonApi)) {
         copyDirSync(srcAddonApi, path.join(tempDir, 'node_modules', 'node-addon-api'));
@@ -192,6 +224,7 @@ const config: ForgeConfig = {
         const daemonNodePty = path.join(daemonBundleDir, 'node_modules', 'node-pty');
         console.log('[postPackage] Copying node-pty for daemon-bundle...');
         copyDirSync(path.join(__dirname, 'node_modules', 'node-pty'), daemonNodePty);
+        pruneForeignPrebuilds(daemonNodePty, targetPlatform, targetArch);
         console.log('[postPackage] Done — node-pty available for daemon.');
       }
 

--- a/src/daemon/RingBuffer.ts
+++ b/src/daemon/RingBuffer.ts
@@ -19,11 +19,21 @@ const TMP_SUFFIX_RE = /\.tmp\.[0-9a-f]+$/;
  * Preserves raw bytes including ANSI escape sequences without any filtering.
  * When the buffer is full, the oldest data is overwritten.
  */
+/**
+ * Initial physical allocation for a new buffer. The ring grows from here by
+ * doubling, up to its configured ceiling, so an idle session that prints
+ * little holds only ~64 KB instead of the full multi-MB ceiling (the default
+ * is 8 MB/session). Buffers whose ceiling is already ≤ this value allocate
+ * their ceiling outright and behave as a classic fixed ring.
+ */
+const INITIAL_PHYSICAL_BYTES = 64 * 1024;
+
 export class RingBuffer {
   private buffer: Buffer;
-  private readonly capacity: number;
-  private writePos: number;   // next write position (0..capacity-1)
-  private length: number;     // bytes currently stored (<= capacity)
+  private readonly capacity: number;  // logical ceiling — the max this ring will ever hold
+  private physical: number;           // bytes currently allocated (<= capacity), grown on demand
+  private writePos: number;   // next write position (0..physical-1)
+  private length: number;     // bytes currently stored (<= physical)
   private totalWritten: number; // monotonic lifetime count (used as byte offset for PromptEventLog)
 
   constructor(capacityBytes: number) {
@@ -31,10 +41,35 @@ export class RingBuffer {
       throw new Error('capacityBytes must be a positive integer');
     }
     this.capacity = capacityBytes;
-    this.buffer = Buffer.alloc(capacityBytes);
+    this.physical = Math.min(INITIAL_PHYSICAL_BYTES, capacityBytes);
+    this.buffer = Buffer.alloc(this.physical);
     this.writePos = 0;
     this.length = 0;
     this.totalWritten = 0;
+  }
+
+  /**
+   * Grow the physical allocation so it can hold at least `needed` bytes
+   * linearly, doubling each step and clamping at the ceiling. No-op once the
+   * allocation already covers `needed` or has reached the ceiling. Existing
+   * contents are copied in logical order (oldest→newest) into the new buffer,
+   * which also un-wraps the ring (writePos = length) — safe because after a
+   * grow the stored length is strictly below the new physical size.
+   */
+  private ensureCapacity(needed: number): void {
+    if (this.physical >= this.capacity || needed <= this.physical) return;
+    let next = this.physical;
+    while (next < needed && next < this.capacity) next *= 2;
+    next = Math.min(next, this.capacity);
+    if (next === this.physical) return;
+
+    const existing = this.readAll(); // oldest→newest, exactly `length` bytes
+    const grown = Buffer.alloc(next);
+    existing.copy(grown, 0);
+    this.buffer = grown;
+    this.physical = next;
+    this.writePos = existing.length; // length < next, so no wrap
+    this.length = existing.length;
   }
 
   /**
@@ -47,17 +82,21 @@ export class RingBuffer {
 
     this.totalWritten += dataLen;
 
-    // If incoming data is larger than capacity, only keep the tail
-    if (dataLen >= this.capacity) {
-      const offset = dataLen - this.capacity;
+    // Grow toward the ceiling so this write lands without prematurely
+    // overwriting still-young data. Once at the ceiling the ring wraps.
+    this.ensureCapacity(this.length + dataLen);
+
+    // If incoming data is larger than the current allocation, only keep the tail
+    if (dataLen >= this.physical) {
+      const offset = dataLen - this.physical;
       data.copy(this.buffer, 0, offset, dataLen);
       this.writePos = 0;
-      this.length = this.capacity;
+      this.length = this.physical;
       return;
     }
 
     // How much space from writePos to end of buffer
-    const spaceToEnd = this.capacity - this.writePos;
+    const spaceToEnd = this.physical - this.writePos;
 
     if (dataLen <= spaceToEnd) {
       // Fits without wrapping
@@ -68,8 +107,8 @@ export class RingBuffer {
       data.copy(this.buffer, 0, spaceToEnd, dataLen);
     }
 
-    this.writePos = (this.writePos + dataLen) % this.capacity;
-    this.length = Math.min(this.length + dataLen, this.capacity);
+    this.writePos = (this.writePos + dataLen) % this.physical;
+    this.length = Math.min(this.length + dataLen, this.physical);
   }
 
   /**
@@ -89,15 +128,15 @@ export class RingBuffer {
       return Buffer.alloc(0);
     }
 
-    if (this.length < this.capacity) {
+    if (this.length < this.physical) {
       // Buffer has not wrapped yet; data is at [0..length)
       return Buffer.from(this.buffer.subarray(0, this.length));
     }
 
     // Buffer is full and has wrapped.
     // writePos points to the oldest byte (it's where the next write will go).
-    // Order: [writePos..capacity) + [0..writePos)
-    const tail = this.buffer.subarray(this.writePos, this.capacity);
+    // Order: [writePos..physical) + [0..writePos)
+    const tail = this.buffer.subarray(this.writePos, this.physical);
     const head = this.buffer.subarray(0, this.writePos);
     return Buffer.concat([tail, head]);
   }
@@ -117,9 +156,14 @@ export class RingBuffer {
     return this.length;
   }
 
-  /** Total buffer capacity in bytes. */
+  /** Logical ceiling in bytes — the most this ring will ever store. */
   get totalCapacity(): number {
     return this.capacity;
+  }
+
+  /** Bytes currently committed for backing storage (grows on demand toward the ceiling). */
+  get allocatedBytes(): number {
+    return this.physical;
   }
 
   /**

--- a/src/daemon/__tests__/RingBuffer.test.ts
+++ b/src/daemon/__tests__/RingBuffer.test.ts
@@ -185,6 +185,72 @@ describe('RingBuffer', () => {
     expect(restored.size).toBe(8);
   });
 
+  // ── Lazy growth (idle-memory optimization) ──
+
+  // A large-capacity buffer must NOT commit its full ceiling upfront.
+  it('allocates far below the ceiling for a large empty buffer', () => {
+    const eightMb = 8 * 1024 * 1024;
+    const rb = new RingBuffer(eightMb);
+    // Ceiling is reported as the configured capacity...
+    expect(rb.totalCapacity).toBe(eightMb);
+    // ...but actual committed memory starts tiny (well under 1 MB).
+    expect(rb.allocatedBytes).toBeLessThan(1024 * 1024);
+    expect(rb.size).toBe(0);
+  });
+
+  // Growth kicks in only as data demands it, and never exceeds the ceiling.
+  it('grows allocation on demand up to but not beyond the ceiling', () => {
+    const cap = 1024 * 1024; // 1 MB ceiling
+    const rb = new RingBuffer(cap);
+    const initial = rb.allocatedBytes;
+    expect(initial).toBeLessThan(cap);
+
+    // Write 300 KB — should force at least one growth step.
+    rb.write(Buffer.alloc(300 * 1024, 0x41));
+    expect(rb.allocatedBytes).toBeGreaterThan(initial);
+    expect(rb.allocatedBytes).toBeLessThanOrEqual(cap);
+    expect(rb.size).toBe(300 * 1024);
+
+    // Fill past the ceiling — allocation caps at the ceiling, ring wraps.
+    rb.write(Buffer.alloc(cap, 0x42));
+    expect(rb.allocatedBytes).toBe(cap);
+    expect(rb.size).toBe(cap);
+  });
+
+  // Growth must preserve byte order across the reallocation boundary.
+  it('preserves data order and content across a growth reallocation', () => {
+    const rb = new RingBuffer(1024 * 1024);
+    // First chunk fits in the initial allocation.
+    rb.write(Buffer.from('HEAD'));
+    // Force growth with a chunk larger than the initial allocation.
+    const big = Buffer.alloc(200 * 1024, 0x5a); // 'Z' * 200K
+    rb.write(big);
+    rb.write(Buffer.from('TAIL'));
+
+    const all = rb.readAll();
+    expect(all.subarray(0, 4).toString()).toBe('HEAD');
+    expect(all.subarray(all.length - 4).toString()).toBe('TAIL');
+    expect(all.length).toBe(4 + big.length + 4);
+    // Middle is all 'Z'.
+    expect(all.subarray(4, 4 + big.length).every((b) => b === 0x5a)).toBe(true);
+  });
+
+  // A grown buffer still round-trips through dump → load correctly.
+  it('dump/load round-trips a grown buffer by logical contents', async () => {
+    const rb = new RingBuffer(1024 * 1024);
+    const payload = Buffer.alloc(250 * 1024, 0x37); // '7' * 250K
+    rb.write(payload);
+    expect(rb.allocatedBytes).toBeGreaterThan(64 * 1024);
+
+    const tmpFile = path.join(os.tmpdir(), `wmux-rb-grow-${Date.now()}.bin`);
+    tempFiles.push(tmpFile);
+    await rb.dumpToFile(tmpFile);
+
+    const restored = RingBuffer.loadFromFile(tmpFile, 1024 * 1024);
+    expect(restored.size).toBe(payload.length);
+    expect(restored.readAll().equals(payload)).toBe(true);
+  });
+
   // loadFromFile: empty file produces empty buffer
   it('loadFromFile with empty file produces empty buffer', () => {
     const tmpFile = path.join(os.tmpdir(), `wmux-rb-load-empty-${Date.now()}.bin`);

--- a/src/main/ipc/handlers/__tests__/metadata.visibility.test.ts
+++ b/src/main/ipc/handlers/__tests__/metadata.visibility.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { BrowserWindow } from 'electron';
+import { shouldPollMetadata } from '../metadata.handler';
+
+vi.mock('electron', () => ({
+  ipcMain: { removeHandler: vi.fn(), handle: vi.fn() },
+  BrowserWindow: {},
+}));
+
+/** Build a fake BrowserWindow with overridable visibility predicates. */
+function fakeWindow(overrides: Partial<{
+  destroyed: boolean;
+  loading: boolean;
+  visible: boolean;
+  minimized: boolean;
+}> = {}): BrowserWindow {
+  const o = { destroyed: false, loading: false, visible: true, minimized: false, ...overrides };
+  return {
+    isDestroyed: () => o.destroyed,
+    isVisible: () => o.visible,
+    isMinimized: () => o.minimized,
+    webContents: { isLoading: () => o.loading },
+  } as unknown as BrowserWindow;
+}
+
+describe('shouldPollMetadata', () => {
+  it('polls when the window is visible, loaded, and not minimized', () => {
+    expect(shouldPollMetadata(fakeWindow())).toBe(true);
+  });
+
+  it('skips when the window is hidden to tray', () => {
+    expect(shouldPollMetadata(fakeWindow({ visible: false }))).toBe(false);
+  });
+
+  it('skips when the window is minimized', () => {
+    expect(shouldPollMetadata(fakeWindow({ minimized: true }))).toBe(false);
+  });
+
+  it('skips while the renderer is still loading', () => {
+    expect(shouldPollMetadata(fakeWindow({ loading: true }))).toBe(false);
+  });
+
+  it('skips when the window is destroyed', () => {
+    expect(shouldPollMetadata(fakeWindow({ destroyed: true }))).toBe(false);
+  });
+});

--- a/src/main/ipc/handlers/metadata.handler.ts
+++ b/src/main/ipc/handlers/metadata.handler.ts
@@ -21,6 +21,24 @@ export function broadcastMetadataUpdate(
   window.webContents.send(IPC.METADATA_UPDATE, payload);
 }
 
+/**
+ * Whether the 5 s metadata poll should run for this window right now.
+ *
+ * Metadata (git branch, listening ports, PR badge) is purely cosmetic and
+ * only matters for a UI the user can actually see. When the window is hidden
+ * to tray or minimized, the per-PTY git / `gh` / `/proc` work the poll drives
+ * is the dominant idle cost on the main process for a UI nobody is looking at.
+ * Skipping it then makes a backgrounded wmux go quiet; the next visible tick
+ * (≤5 s after the window returns) refreshes everything, so staleness is
+ * bounded. Mirrors UsagePoller's hidden-window cost control.
+ */
+export function shouldPollMetadata(win: BrowserWindow): boolean {
+  if (win.isDestroyed()) return false;
+  if (win.webContents.isLoading()) return false;
+  if (!win.isVisible() || win.isMinimized()) return false;
+  return true;
+}
+
 const collector = new MetadataCollector();
 
 // Track CWD per ptyId (updated via OSC 7, prompt detection, or initial registration)
@@ -99,8 +117,7 @@ export function registerMetadataHandlers(
   // Periodic metadata polling (every 5 seconds)
   const pollingInterval = setInterval(async () => {
     const win = getWindow();
-    if (!win || win.isDestroyed()) return;
-    if (win.webContents.isLoading()) return;
+    if (!win || !shouldPollMetadata(win)) return;
 
     for (const [ptyId] of cwdMap) {
       const instance = ptyManager.get(ptyId);


### PR DESCRIPTION
## Summary
Three independent reductions to wmux's idle/background footprint:
- **daemon RAM** — `RingBuffer` now allocates 64 KB up front and doubles toward the configured ceiling (default 8 MB) on demand, instead of committing the full ceiling per session. Idle/quiet sessions hold ~64 KB; chatty ones still grow to the ceiling with no scrollback lost. Transparent to all consumers.
- **main-process CPU** — the 5 s metadata poll (per-PTY git / `gh` / `/proc` work for purely cosmetic UI) is now gated on `shouldPollMetadata()` and skipped while the window is destroyed/loading/hidden/minimized. Next visible tick refreshes within ≤5 s, so staleness is bounded.
- **package size** — `postPackage` prunes non-target `node-pty` prebuilds (win32-x64/arm64 ConPTY binaries are ~30 MB each), reclaiming ~28 MB+ per build across both node-pty copies. Defensive: keeps everything if the target dir is missing.

## Test Plan
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx vitest run` — 2930 passed (241 files)
- [ ] Package a build, confirm only the target prebuild ships and PTY still launches
- [ ] Background the window, confirm metadata polling pauses and resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metadata polling now pauses when the app window is hidden, minimized, destroyed, or still loading, resuming when visible.

* **Improvements**
  * On-demand memory allocation for internal buffers to reduce runtime memory usage.
  * Smaller packaged installs on non-target platforms by pruning unnecessary native prebuilds.

* **Tests**
  * Added tests for lazy buffer allocation and metadata polling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->