### PR TITLE
feat: X6 — resume agent conversation on supervised restart/reboot

### DIFF
--- a/scripts/x6-resume-dogfood.mjs
+++ b/scripts/x6-resume-dogfood.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+/**
+ * X6 resume dynamic dogfood — supervised agent pane resumes on RECOVERY.
+ *
+ * Spawns the BUNDLED daemon (dist/daemon-bundle/index.js) in an isolated HOME,
+ * creates a SUPERVISED exec unit whose command is `claude` (a recording shim on
+ * PATH, NOT the real CLI — we are verifying the daemon's spawn rewrite, not the
+ * Claude API; the spike already proved `claude --continue` resumes a real
+ * conversation), then shuts the daemon down and respawns it so recoverSessions
+ * replays the unit. The shim records its argv + cwd on every launch.
+ *
+ * PASS criteria (the headline "reboot survival of the conversation" path):
+ *   L1  first launch (fresh createSession) runs `claude` with NO --continue
+ *   L2  recovery replay runs `claude --continue` (X6 resume rewrite) ...
+ *   L3  ... in the SAME cwd (resume is cwd-scoped; the rewrite is gated on it)
+ *
+ * Exercises the real recoverSessions suspended branch + resumeLaunchCommand +
+ * the non-persisted execLaunchCommand channel in createSession. The supervisor
+ * RESTART path shares the same helper and is covered by unit tests.
+ */
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DAEMON_BUNDLE = path.join(REPO_ROOT, 'dist', 'daemon-bundle', 'index.js');
+
+function makePipeName(tag) {
+  return process.platform === 'win32'
+    ? `\\\\.\\pipe\\wmux-test-${tag}`
+    : path.join(os.tmpdir(), `wmux-test-${tag}.sock`);
+}
+
+function writeConfig(wmuxDir, pipeName, authToken) {
+  fs.writeFileSync(
+    path.join(wmuxDir, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      daemon: { pipeName, logLevel: 'warn', autoStart: true },
+      session: {
+        defaultShell: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
+        defaultCols: 80, defaultRows: 24, bufferSizeMb: 8, bufferMaxMb: 64,
+        deadSessionTtlHours: 24, deadSessionDumpBuffer: true,
+      },
+    }, null, 2),
+  );
+  fs.writeFileSync(path.join(wmuxDir, 'daemon-auth-token'), authToken, 'utf-8');
+}
+
+function spawnDaemon(testHome) {
+  return spawn(process.execPath, [DAEMON_BUNDLE], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, USERPROFILE: testHome, HOME: testHome, HOMEDRIVE: undefined, HOMEPATH: undefined },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+async function waitForPipeFile(wmuxDir, timeoutMs = 10_000) {
+  const pipeFile = path.join(wmuxDir, 'daemon-pipe');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(pipeFile)) return fs.readFileSync(pipeFile, 'utf-8').trim();
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error('daemon-pipe did not appear within timeout');
+}
+
+function connectSocket(pipeName) {
+  return new Promise((resolve, reject) => {
+    const s = net.createConnection(pipeName, () => resolve(s));
+    s.on('error', reject);
+  });
+}
+
+function rpc(socket, method, params, authToken, timeoutMs = 30_000) {
+  return new Promise((resolve, reject) => {
+    const id = `req-${Math.random().toString(36).slice(2, 10)}`;
+    let buffer = '';
+    const handler = (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id === id) {
+            socket.removeListener('data', handler);
+            if (msg.ok) resolve(msg.result);
+            else reject(new Error(msg.error ?? 'rpc error'));
+            return;
+          }
+        } catch { /* ignore */ }
+      }
+    };
+    socket.on('data', handler);
+    socket.write(JSON.stringify({ id, method, params, token: authToken }) + '\n');
+    setTimeout(() => { socket.removeListener('data', handler); reject(new Error(`rpc timeout: ${method}`)); }, timeoutMs);
+  });
+}
+
+function readShimLog(logPath) {
+  if (!fs.existsSync(logPath)) return [];
+  return fs.readFileSync(logPath, 'utf-8').split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+
+async function main() {
+  const tag = `x6-${randomUUID().slice(0, 8)}`;
+  const testHome = path.join(os.tmpdir(), `wmux-${tag}`);
+  const wmuxDir = path.join(testHome, '.wmux');
+  const shimDir = path.join(testHome, 'shim');
+  const projDir = path.join(testHome, 'proj');
+  fs.mkdirSync(wmuxDir, { recursive: true });
+  fs.mkdirSync(shimDir, { recursive: true });
+  fs.mkdirSync(projDir, { recursive: true });
+
+  // `claude` shim: record argv+cwd, then stay alive so the supervised unit is
+  // "live" at shutdown (→ suspended → recovered). Invoked as `claude` by the
+  // exec wrapper; resolved from PATH (shimDir prepended).
+  const shimLog = path.join(testHome, 'shim.log');
+  fs.writeFileSync(path.join(shimDir, 'claude-shim.mjs'),
+    `import fs from 'node:fs';\n` +
+    `fs.appendFileSync(process.env.X6_SHIM_LOG, JSON.stringify({argv: process.argv.slice(2), cwd: process.cwd(), ts: Date.now()})+'\\n');\n` +
+    `setInterval(() => {}, 1 << 30);\n`);
+  if (process.platform === 'win32') {
+    fs.writeFileSync(path.join(shimDir, 'claude.cmd'), `@echo off\r\nnode "%~dp0claude-shim.mjs" %*\r\n`);
+  } else {
+    const sh = path.join(shimDir, 'claude');
+    fs.writeFileSync(sh, `#!/bin/sh\nnode "$(dirname "$0")/claude-shim.mjs" "$@"\n`);
+    fs.chmodSync(sh, 0o755);
+  }
+
+  const pipeName = makePipeName(tag);
+  const authToken = randomUUID();
+  writeConfig(wmuxDir, pipeName, authToken);
+
+  const childEnv = {
+    ...process.env,
+    PATH: shimDir + path.delimiter + (process.env.PATH ?? ''),
+    Path: shimDir + path.delimiter + (process.env.Path ?? process.env.PATH ?? ''),
+    X6_SHIM_LOG: shimLog,
+  };
+
+  const results = [];
+  const sessionId = `x6sess`;
+
+  // --- Daemon #1: create the supervised agent unit (FRESH launch) ---
+  let d1 = spawnDaemon(testHome);
+  d1.stderr.on('data', () => {});
+  let resolved = await waitForPipeFile(wmuxDir);
+  let sock = await connectSocket(resolved);
+  await rpc(sock, 'daemon.createSession', {
+    id: sessionId,
+    cmd: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
+    cwd: projDir,
+    env: childEnv,
+    cols: 80, rows: 24,
+    exec: { command: 'claude' },
+    supervision: { restart: 'always', limit: { burst: 5, healthyUptimeSec: 300 } },
+  }, authToken);
+  await new Promise((r) => setTimeout(r, 2000)); // let the shim launch + record
+  await rpc(sock, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
+  sock.destroy();
+  await new Promise((r) => { d1.on('exit', r); setTimeout(r, 5000); });
+
+  const afterFresh = readShimLog(shimLog);
+
+  // --- Daemon #2: respawn → recoverSessions replays the unit (RESUME) ---
+  let d2 = spawnDaemon(testHome);
+  d2.stderr.on('data', () => {});
+  resolved = await waitForPipeFile(wmuxDir);
+  sock = await connectSocket(resolved);
+  await new Promise((r) => setTimeout(r, 2500)); // let recovery replay + shim record
+  await rpc(sock, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
+  sock.destroy();
+  await new Promise((r) => { d2.on('exit', r); setTimeout(r, 5000); });
+
+  const afterRecovery = readShimLog(shimLog);
+
+  // --- Assertions ---
+  const L1 = afterFresh.length >= 1 && !afterFresh[0].argv.includes('--continue');
+  results.push(['L1 fresh launch has NO --continue', L1, JSON.stringify(afterFresh[0]?.argv ?? null)]);
+
+  const recoveryLaunch = afterRecovery[afterFresh.length]; // the launch added by recovery
+  const L2 = !!recoveryLaunch && recoveryLaunch.argv.includes('--continue');
+  results.push(['L2 recovery replay runs claude --continue', L2, JSON.stringify(recoveryLaunch?.argv ?? null)]);
+
+  // cwd preserved across recovery = the resume targets the same project as the
+  // original launch (resume is cwd-scoped; this is what makes --continue resolve
+  // the right session). Compare against the fresh launch's recorded cwd to avoid
+  // realpath/case normalization noise.
+  const L3 = !!recoveryLaunch && !!afterFresh[0] && recoveryLaunch.cwd === afterFresh[0].cwd;
+  results.push(['L3 recovery resumes in the SAME cwd as fresh launch', L3,
+    `fresh=${afterFresh[0]?.cwd} recovery=${recoveryLaunch?.cwd}`]);
+
+  // cleanup
+  try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* ignore */ }
+
+  console.log('\n=== X6 RESUME DOGFOOD ===');
+  for (const [name, pass, detail] of results) {
+    console.log(`  ${pass ? 'PASS' : 'FAIL'}  ${name}  [${detail}]`);
+  }
+  const allPass = results.every(([, p]) => p);
+  console.log(`\n${allPass ? 'ALL PASS' : 'FAILURES PRESENT'}\n`);
+  process.exit(allPass ? 0 : 1);
+}
+
+main().catch((err) => { console.error('dogfood error:', err); process.exit(2); });

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -148,6 +148,16 @@ export class DaemonSessionManager extends EventEmitter {
      */
     exec?: { command: string };
     /**
+     * X6 resume: a NON-persisted launch command used ONLY to spawn this
+     * replay. When set (replay paths whose agent should resume — see
+     * agentResume.toResumeCommand), buildExecArgs runs THIS command (e.g.
+     * `claude --continue`) while `meta.exec.command` still stores the ORIGINAL
+     * (`claude`). So first launch stays fresh, the badge/`wmux list` show the
+     * launch command, and a restart/reboot revives the conversation. Ignored
+     * unless `exec` is also set. Defaults to `exec.command`.
+     */
+    execLaunchCommand?: string;
+    /**
      * X8 supervision policy + sticky status. Fresh creates pass
      * status:'armed'; recovery replays the persisted value so a
      * runaway-guard 'stopped' survives reboots.
@@ -235,10 +245,15 @@ export class DaemonSessionManager extends EventEmitter {
       // and injection args would collide with the wrapper argv). When the
       // resolved shell's family is unknown we swap to a known-good platform
       // shell rather than guess argv for it.
-      let execArgs = buildExecArgs(cmd, params.exec.command);
+      //
+      // X6: spawn the (possibly resume-rewritten) launch command, but persist
+      // the ORIGINAL below (meta.exec.command). Replay-only callers set
+      // execLaunchCommand; brand-new sessions omit it → spawn === persisted.
+      const launchCommand = params.execLaunchCommand ?? params.exec.command;
+      let execArgs = buildExecArgs(cmd, launchCommand);
       if (!execArgs) {
         cmd = this.resolveExecFallbackShell();
-        execArgs = buildExecArgs(cmd, params.exec.command);
+        execArgs = buildExecArgs(cmd, launchCommand);
       }
       if (!execArgs) {
         throw new Error(`No usable wrapper shell for exec session (resolved: ${cmd})`);

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -718,6 +718,43 @@ describe('DaemonSessionManager', () => {
       expect(session.exec).toEqual({ command: 'claude /loop' });
     });
 
+    // X6: a non-persisted execLaunchCommand spawns the resume-rewritten command
+    // (used by recovery/restart replays) while meta.exec.command stays original.
+    it('spawns execLaunchCommand but persists the ORIGINAL exec.command (X6 resume replay)', () => {
+      const session = manager.createSession({
+        id: 'x6-replay',
+        cmd: 'pwsh.exe',
+        cwd: '.',
+        exec: { command: 'claude' },
+        execLaunchCommand: 'claude --continue',
+      });
+      // Spawned argv carries the resume form...
+      expect(lastMockPty?.spawnArgs).toEqual([
+        '-NoLogo',
+        '-NoProfile',
+        '-Command',
+        `claude --continue${PWSH_EXIT_TAIL}`,
+      ]);
+      // ...but the persisted unit command is the ORIGINAL (badge / future
+      // first-launch semantics / no drift across repeated replays).
+      expect(session.exec).toEqual({ command: 'claude' });
+    });
+
+    it('without execLaunchCommand, spawns the original exec.command (first launch unchanged)', () => {
+      manager.createSession({
+        id: 'x6-fresh',
+        cmd: 'pwsh.exe',
+        cwd: '.',
+        exec: { command: 'claude' },
+      });
+      expect(lastMockPty?.spawnArgs).toEqual([
+        '-NoLogo',
+        '-NoProfile',
+        '-Command',
+        `claude${PWSH_EXIT_TAIL}`,
+      ]);
+    });
+
     it('stores supervision meta as an owned copy (no caller aliasing)', () => {
       const limit = { burst: 5, healthyUptimeSec: 300 };
       const session = manager.createSession({

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -19,6 +19,7 @@ import type { DaemonState } from './types';
 import type { DaemonEvent, DaemonCreateSessionParams, DaemonSessionIdParams, DaemonResizeParams } from '../shared/rpc';
 import { monitorEventLoopDelay, performance as nodePerformance } from 'node:perf_hooks';
 import { DAEMON_EXIT_ALREADY_RUNNING } from '../shared/constants';
+import { toResumeCommand } from '../shared/agentResume';
 
 // === Constants ===
 const wmuxDir = getWmuxDir();
@@ -146,6 +147,26 @@ const LOCK_FILE = path.join(wmuxDir, 'daemon.lock');
 function log(level: string, msg: string, ...args: unknown[]): void {
   const ts = new Date().toISOString();
   console.log(`[${ts}] [daemon/${level}] ${msg}`, ...args);
+}
+
+// === X6 resume on replay ===
+// Compute the NON-persisted launch command for a supervised exec session being
+// REPLAYED (recovery or supervisor restart). Returns the resume-rewritten
+// command (e.g. `claude --continue`) only when:
+//   - the session is an exec unit (has `exec`), AND
+//   - its ORIGINAL cwd still exists — resume is cwd-scoped, so a homedir
+//     fallback would resume an unrelated/empty session (run fresh instead), AND
+//   - the launch command is a known agent launcher (toResumeCommand rewrites it).
+// Otherwise returns undefined → createSession spawns the original command.
+// The persisted meta.exec.command is never affected; first launch is never
+// touched (brand-new createSession callers don't call this).
+function resumeLaunchCommand(session: { id: string; exec?: { command: string }; cwd: string }): string | undefined {
+  if (!session.exec) return undefined;
+  if (!fs.existsSync(session.cwd)) return undefined; // cwd gone → fresh, not wrong-target resume
+  const rewritten = toResumeCommand(session.exec.command);
+  if (rewritten === session.exec.command) return undefined; // not a known agent launcher / already resuming
+  log('info', `X6 resume: replaying session ${session.id} as resume form in ${session.cwd}`);
+  return rewritten;
 }
 
 // === PID / Lock helpers ===
@@ -403,6 +424,9 @@ async function recoverSessions(
               // session this relaunches the supervised command itself (the
               // reboot-survival story), not an empty shell.
               exec: session.exec,
+              // X6: if the exec unit is an agent, resume its conversation
+              // (non-persisted launch command; meta.exec.command stays original).
+              execLaunchCommand: resumeLaunchCommand(session),
               supervision: session.supervision,
               scrollbackData,
               // v2.8.1: stay muted until the renderer's first resize so PTY
@@ -483,6 +507,8 @@ async function recoverSessions(
             deadTtlHours: session.deadTtlHours,
             // X8: replay exec unit + supervision (see suspended path above).
             exec: session.exec,
+            // X6: resume the agent conversation on replay (see suspended path).
+            execLaunchCommand: resumeLaunchCommand(session),
             supervision: session.supervision,
             scrollbackData,
             // v2.8.1: see deferOutput rationale above (Bug 2).
@@ -525,6 +551,8 @@ async function recoverSessions(
           deadTtlHours: session.deadTtlHours,
           // X8: replay exec unit + supervision (see suspended path above).
           exec: session.exec,
+          // X6: resume the agent conversation on replay (see suspended path).
+          execLaunchCommand: resumeLaunchCommand(session),
           supervision: session.supervision,
           // v2.8.1: see deferOutput rationale above (Bug 2).
           deferOutput: true,
@@ -618,6 +646,9 @@ function restartSupervisedSession(
     createdAt: meta.createdAt,
     deadTtlHours: meta.deadTtlHours,
     exec: meta.exec,
+    // X6: a supervised agent that crashed resumes its conversation on restart
+    // (non-persisted launch command; meta.exec.command stays original).
+    execLaunchCommand: resumeLaunchCommand(meta),
     supervision: meta.supervision,
   };
 

--- a/src/shared/__tests__/agentResume.test.ts
+++ b/src/shared/__tests__/agentResume.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { toResumeCommand, isResumableLaunchCommand } from '../agentResume';
+
+describe('toResumeCommand (X6)', () => {
+  describe('rewrites known agent launchers', () => {
+    it('claude → claude --continue', () => {
+      expect(toResumeCommand('claude')).toBe('claude --continue');
+    });
+
+    it('preserves trailing args after the launcher', () => {
+      expect(toResumeCommand('claude --dangerously-skip-permissions')).toBe(
+        'claude --continue --dangerously-skip-permissions',
+      );
+    });
+
+    it('preserves a quoted prompt argument verbatim', () => {
+      expect(toResumeCommand('claude "do the thing"')).toBe('claude --continue "do the thing"');
+    });
+
+    it('matches a Windows .exe / .cmd basename', () => {
+      expect(toResumeCommand('claude.cmd')).toBe('claude.cmd --continue');
+      expect(toResumeCommand('claude.exe --foo')).toBe('claude.exe --continue --foo');
+    });
+
+    it('matches a quoted absolute path launcher', () => {
+      expect(toResumeCommand('"C:\\tools\\claude\\claude.exe" --foo')).toBe(
+        '"C:\\tools\\claude\\claude.exe" --continue --foo',
+      );
+    });
+
+    it('normalizes a POSIX absolute path launcher', () => {
+      expect(toResumeCommand('/usr/local/bin/claude')).toBe('/usr/local/bin/claude --continue');
+    });
+
+    it('tolerates leading whitespace (preserved verbatim)', () => {
+      expect(toResumeCommand('  claude')).toBe('  claude --continue');
+    });
+  });
+
+  describe('idempotency — never double-adds / leaves resume+oneshot unchanged', () => {
+    it('already --continue → unchanged', () => {
+      const c = 'claude --continue';
+      expect(toResumeCommand(c)).toBe(c);
+    });
+    it('re-applying is a fixpoint', () => {
+      const once = toResumeCommand('claude --foo');
+      expect(toResumeCommand(once)).toBe(once);
+    });
+    it('--resume <id> → unchanged (would double-resume)', () => {
+      const c = 'claude --resume abc-123';
+      expect(toResumeCommand(c)).toBe(c);
+    });
+    it('-c → unchanged', () => {
+      expect(toResumeCommand('claude -c')).toBe('claude -c');
+    });
+    it('-p / --print one-shot → unchanged (semantics differ)', () => {
+      expect(toResumeCommand('claude -p "hi"')).toBe('claude -p "hi"');
+      expect(toResumeCommand('claude --print "hi"')).toBe('claude --print "hi"');
+    });
+    it('short-flag cluster containing c/r/p → unchanged', () => {
+      expect(toResumeCommand('claude -cp')).toBe('claude -cp');
+    });
+    it('a flag inside a QUOTED prompt is NOT treated as a resume flag', () => {
+      // The prompt mentions --continue but the command itself is fresh.
+      expect(toResumeCommand('claude "explain the --continue flag"')).toBe(
+        'claude --continue "explain the --continue flag"',
+      );
+    });
+  });
+
+  describe('leaves non-agent / ambiguous commands unchanged', () => {
+    it('unknown launcher (node, bash) → unchanged', () => {
+      expect(toResumeCommand('node server.js')).toBe('node server.js');
+      expect(toResumeCommand('bash -lc "loop.sh"')).toBe('bash -lc "loop.sh"');
+    });
+    it('false-positive prefix (claude-foo) → unchanged', () => {
+      expect(toResumeCommand('claude-foo')).toBe('claude-foo');
+      expect(toResumeCommand('claudette')).toBe('claudette');
+    });
+    it('env-assignment prefix → unchanged', () => {
+      expect(toResumeCommand('FOO=claude claude')).toBe('FOO=claude claude');
+    });
+    it('empty / whitespace → unchanged', () => {
+      expect(toResumeCommand('')).toBe('');
+      expect(toResumeCommand('   ')).toBe('   ');
+    });
+  });
+
+  describe('isResumableLaunchCommand', () => {
+    it('true for a fresh claude launch', () => {
+      expect(isResumableLaunchCommand('claude')).toBe(true);
+    });
+    it('false for already-resuming or non-agent', () => {
+      expect(isResumableLaunchCommand('claude --continue')).toBe(false);
+      expect(isResumableLaunchCommand('node x.js')).toBe(false);
+    });
+  });
+});

--- a/src/shared/agentResume.ts
+++ b/src/shared/agentResume.ts
@@ -1,0 +1,140 @@
+/**
+ * X6 — agent session resume on supervised restart/recovery.
+ *
+ * Pure transform: given the launch command of a supervised exec unit, return
+ * the command rewritten to RESUME the agent's previous session instead of
+ * starting a fresh one, so a daemon restart / OS reboot revives the agent
+ * CONVERSATION (not just the process — that is X8's job).
+ *
+ * Only applied on REPLAY paths (recovery + supervisor restart), never on first
+ * launch — the persisted `meta.exec.command` always stays the original, and the
+ * replay sites pass the rewritten string as a NON-persisted launch command
+ * (see DaemonSessionManager.createSession `execLaunchCommand`).
+ *
+ * Mechanism, per agent: append the agent's "continue latest session in this
+ * cwd" flag. For Claude Code that is `--continue` (verified 2026-06-13: it
+ * resumes the latest session for the cwd with zero captured state, and is a
+ * graceful fresh start when there is nothing to continue). Resume is
+ * cwd-scoped, so the caller MUST only apply this when the original cwd still
+ * exists — otherwise it would resume an unrelated homedir session.
+ *
+ * v1 covers `claude` only. cmux supports 16 agents; codex/opencode/gemini
+ * resume forms are a deliberate follow-up (their resume ergonomics differ and
+ * none is needed for the reboot-survival headline).
+ *
+ * This module lives in src/shared so the daemon (tsconfig.daemon.json scopes
+ * to src/daemon + src/shared) can import it WITHOUT reaching into
+ * integrations/shared (out of the daemon's tsconfig).
+ */
+
+/** Agent launcher executable stems we know how to resume → the resume flag. */
+const RESUME_FLAG_BY_LAUNCHER: Readonly<Record<string, string>> = {
+  claude: '--continue',
+};
+
+/**
+ * Unquoted tokens that mean "already resuming" or "not a resumable run" →
+ * leave the command unchanged. `--continue`/`--resume`/`-c`/`-r` already
+ * resume; `-p`/`--print` is a non-interactive one-shot (rewriting it to
+ * `--continue` would change its semantics and, under `restart: always`, could
+ * re-run a print loop). We err toward NOT rewriting: a missed resume just
+ * starts fresh, a wrong rewrite changes behavior.
+ */
+const SKIP_TOKENS: ReadonlySet<string> = new Set([
+  '--continue',
+  '--resume',
+  '--print',
+  '-c',
+  '-r',
+  '-p',
+]);
+
+interface Token {
+  /** Literal value with surrounding quotes stripped. */
+  value: string;
+  /** True if any part of the token was quoted (so flags inside a prompt
+   *  string like `claude "explain --continue"` are NOT treated as flags). */
+  quoted: boolean;
+  /** Index in the source string just past this token (for splice insertion). */
+  end: number;
+}
+
+/**
+ * Minimal POSIX-ish tokenizer: splits on unquoted whitespace, respects single
+ * and double quotes (a quoted span contributes to the current token and marks
+ * it `quoted`). Good enough for launch commands; not a full shell parser.
+ */
+function tokenize(command: string): Token[] {
+  const tokens: Token[] = [];
+  const n = command.length;
+  let i = 0;
+  while (i < n) {
+    while (i < n && /\s/.test(command[i])) i++;
+    if (i >= n) break;
+    let value = '';
+    let quoted = false;
+    while (i < n && !/\s/.test(command[i])) {
+      const c = command[i];
+      if (c === '"' || c === "'") {
+        quoted = true;
+        const q = c;
+        i++;
+        while (i < n && command[i] !== q) {
+          value += command[i];
+          i++;
+        }
+        if (i < n) i++; // consume closing quote
+      } else {
+        value += c;
+        i++;
+      }
+    }
+    tokens.push({ value, quoted, end: i });
+  }
+  return tokens;
+}
+
+/** Launcher executable stem: basename, drop a Windows executable extension,
+ *  lowercase. `"C:\\tools\\claude.cmd"` → `claude`; `claude-foo` → `claude-foo`. */
+function launcherStem(firstToken: string): string {
+  const base = firstToken.split(/[\\/]/).pop() ?? '';
+  return base.toLowerCase().replace(/\.(exe|cmd|bat|ps1)$/, '');
+}
+
+/**
+ * Return `command` rewritten to resume the agent's previous session, or the
+ * command UNCHANGED when it is not a known single-agent launcher, when it is
+ * already a resume/one-shot, or when it uses syntax we won't touch (env
+ * assignment, pipeline — anything whose first token is not a bare launcher).
+ *
+ * Idempotent: re-applying never double-adds the flag.
+ */
+export function toResumeCommand(command: string): string {
+  const tokens = tokenize(command);
+  if (tokens.length === 0) return command;
+
+  // The launcher must be a bare command (its first token's stem). An env
+  // assignment (`FOO=bar`) or a path that doesn't basename to a known launcher
+  // falls through unchanged.
+  const stem = launcherStem(tokens[0].value);
+  const resumeFlag = RESUME_FLAG_BY_LAUNCHER[stem];
+  if (!resumeFlag) return command;
+
+  // Already resuming / one-shot? Check UNQUOTED tokens only, exact match plus
+  // short-flag clusters that contain c/r/p (e.g. `-cp`). Errs toward skipping.
+  for (const t of tokens) {
+    if (t.quoted) continue;
+    if (SKIP_TOKENS.has(t.value)) return command;
+    if (/^-[a-z]*[crp][a-z]*$/.test(t.value)) return command;
+  }
+
+  // Insert the resume flag immediately after the launcher token, preserving the
+  // rest of the command (and its spacing/quoting) verbatim.
+  const at = tokens[0].end;
+  return `${command.slice(0, at)} ${resumeFlag}${command.slice(at)}`;
+}
+
+/** Whether a launch command would be rewritten by {@link toResumeCommand}. */
+export function isResumableLaunchCommand(command: string): boolean {
+  return toResumeCommand(command) !== command;
+}


### PR DESCRIPTION
## What

A supervised agent pane (a `wmux.json` leaf with `restart`) now **resumes its previous conversation** when the daemon restarts the process or recovers it after a reboot, instead of relaunching the agent fresh.

This pairs with X8 (#220): X8 revives the **process**, X6 revives the **conversation**. Together they make the reboot-survival story real — a structural capability cmux (no daemon) and MS Intelligent Terminal (no daemon) cannot match.

## How

No session-id capture, no new config surface. On the **replay paths only** (recovery + supervisor restart), the launch command of a known agent launcher is rewritten to its native "continue latest session" form:

```
claude  →  claude --continue
```

`claude --continue` resumes the latest session for a cwd with zero captured state, and degrades to a graceful fresh start when there is nothing to continue (verified live).

- **`src/shared/agentResume.ts`** — pure `toResumeCommand(command)`. Quote-aware tokenizer; basename launcher detection (no `claude-foo` / absolute-path false positives); idempotent (skips commands already resuming, and `-p`/`--print` one-shots). Lives in `src/shared` so the daemon tsconfig can import it.
- **`DaemonSessionManager.createSession`** — new **non-persisted** `execLaunchCommand`: `buildExecArgs` runs it, while `meta.exec.command` keeps the **original**. So the badge / `wmux list` show the launch command, first launch stays fresh, and repeated replays never drift.
- **`daemon/index.ts`** — `resumeLaunchCommand()` wired at all **four** replay sites (three `recoverSessions` branches + `restartSupervisedSession`). Gated on the original cwd still existing, since `--continue` is cwd-scoped.

## Scope

Claude only (v1). The interactive-pane resume pill and multi-session-per-cwd disambiguation (`--resume <id>`) are deliberate follow-ups.

## Verification

- **Unit**: `agentResume` (20 — tokenizer / idempotency / false-positive edges) + `DaemonSessionManager` (+2 — spawn uses launch command, persists original, fresh without it). Daemon + shared suites green. Root `tsc --noEmit` clean.
- **Live dogfood** (`scripts/x6-resume-dogfood.mjs`, 3/3 stable): drives the real bundled daemon in an isolated HOME with a recording `claude` shim → create supervised exec unit → daemon shutdown → respawn → recovery replay. Asserts fresh launch = `claude` (no `--continue`), **recovery replay = `claude --continue`**, same cwd preserved.
- The resume mechanism itself (`claude --continue` actually recalling the conversation) was verified separately against the real Claude CLI.

### Honest scope of proof
The reboot-survival chain is proven in two halves that meet on the same code path: the daemon rewrites to `--continue` on recovery (live, real daemon), and `--continue` resumes a real conversation (verified, real CLI). A single integrated run (real agent in a GUI pane + actual OS reboot + visual reattach) is left to GUI dogfood. Conversation *context* resumes; whether an unattended loop self-issues its next turn depends on the agent's loop driver, which X6 does not own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for resuming supervised agent sessions during daemon recovery. Suspended sessions now automatically continue from their previous state instead of starting fresh, preserving workflow continuity across daemon restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->