### PR TITLE
feat: X6 ② — resume pill for recovered interactive agent panes

### DIFF
--- a/scripts/x6-resume-pill-dogfood.mjs
+++ b/scripts/x6-resume-pill-dogfood.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * X6 Feature ② resume-pill gate dynamic dogfood — daemon listSessions exposes
+ * `resumeAgent` ONLY for an interactive agent pane RECOVERED this boot.
+ *
+ * Pre-seeds sessions.json with three sessions, respawns the real bundled daemon
+ * (recovery runs), then queries daemon.listSessions and asserts the recovery-only
+ * EC4 gate:
+ *   P1  interactive non-exec session with lastDetectedAgent  → resumeAgent='claude'
+ *   P2  interactive session WITHOUT lastDetectedAgent         → no resumeAgent
+ *   P3  EXEC/supervised session with lastDetectedAgent        → no resumeAgent
+ *       (it auto-resumes via Feature ①; a pill would double-resume)
+ *
+ * Validates the riskiest daemon-side logic (recoveredAgentShellIds population +
+ * resumeOfferForRecovered exclusions + listSessions exposure). The renderer pill
+ * itself is GUI and is left to visual dogfood.
+ */
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DAEMON_BUNDLE = path.join(REPO_ROOT, 'dist', 'daemon-bundle', 'index.js');
+
+function makePipeName(tag) {
+  return process.platform === 'win32'
+    ? `\\\\.\\pipe\\wmux-test-${tag}`
+    : path.join(os.tmpdir(), `wmux-test-${tag}.sock`);
+}
+
+function writeConfig(wmuxDir, pipeName, authToken) {
+  fs.writeFileSync(path.join(wmuxDir, 'config.json'), JSON.stringify({
+    version: 1,
+    daemon: { pipeName, logLevel: 'warn', autoStart: true },
+    session: {
+      defaultShell: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
+      defaultCols: 80, defaultRows: 24, bufferSizeMb: 8, bufferMaxMb: 64,
+      deadSessionTtlHours: 24, deadSessionDumpBuffer: true,
+    },
+  }, null, 2));
+  fs.writeFileSync(path.join(wmuxDir, 'daemon-auth-token'), authToken, 'utf-8');
+}
+
+function spawnDaemon(testHome) {
+  return spawn(process.execPath, [DAEMON_BUNDLE], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, USERPROFILE: testHome, HOME: testHome, HOMEDRIVE: undefined, HOMEPATH: undefined },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+async function waitForPipeFile(wmuxDir, timeoutMs = 10_000) {
+  const pipeFile = path.join(wmuxDir, 'daemon-pipe');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(pipeFile)) return fs.readFileSync(pipeFile, 'utf-8').trim();
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error('daemon-pipe did not appear within timeout');
+}
+
+function connectSocket(pipeName) {
+  return new Promise((resolve, reject) => {
+    const s = net.createConnection(pipeName, () => resolve(s));
+    s.on('error', reject);
+  });
+}
+
+function rpc(socket, method, params, authToken, timeoutMs = 30_000) {
+  return new Promise((resolve, reject) => {
+    const id = `req-${Math.random().toString(36).slice(2, 10)}`;
+    let buffer = '';
+    const handler = (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id === id) {
+            socket.removeListener('data', handler);
+            if (msg.ok) resolve(msg.result);
+            else reject(new Error(msg.error ?? 'rpc error'));
+            return;
+          }
+        } catch { /* ignore */ }
+      }
+    };
+    socket.on('data', handler);
+    socket.write(JSON.stringify({ id, method, params, token: authToken }) + '\n');
+    setTimeout(() => { socket.removeListener('data', handler); reject(new Error(`rpc timeout: ${method}`)); }, timeoutMs);
+  });
+}
+
+async function main() {
+  const tag = `x6pill-${randomUUID().slice(0, 8)}`;
+  const testHome = path.join(os.tmpdir(), `wmux-${tag}`);
+  const wmuxDir = path.join(testHome, '.wmux');
+  const projDir = path.join(testHome, 'proj');
+  fs.mkdirSync(wmuxDir, { recursive: true });
+  fs.mkdirSync(projDir, { recursive: true });
+
+  const pipeName = makePipeName(tag);
+  const authToken = randomUUID();
+  writeConfig(wmuxDir, pipeName, authToken);
+  const childEnv = { ...process.env, USERPROFILE: testHome, HOME: testHome };
+
+  // --- Daemon #1: create three real sessions (valid spawn env + shapes) ---
+  let d1 = spawnDaemon(testHome);
+  d1.stderr.on('data', () => {});
+  let resolved = await waitForPipeFile(wmuxDir);
+  let sock = await connectSocket(resolved);
+  await rpc(sock, 'daemon.createSession', {
+    id: 'p1-agent-shell', cmd: 'cmd.exe', cwd: projDir, env: childEnv, cols: 80, rows: 24,
+  }, authToken); // interactive shell — will get lastDetectedAgent injected
+  await rpc(sock, 'daemon.createSession', {
+    id: 'p2-plain-shell', cmd: 'cmd.exe', cwd: projDir, env: childEnv, cols: 80, rows: 24,
+  }, authToken); // interactive shell — stays agent-less
+  await rpc(sock, 'daemon.createSession', {
+    id: 'p3-exec-agent', cmd: 'cmd.exe', cwd: projDir, env: childEnv, cols: 80, rows: 24,
+    exec: { command: 'claude' },
+    supervision: { restart: 'always', limit: { burst: 5, healthyUptimeSec: 300 } },
+  }, authToken); // supervised exec — excluded from the pill (auto-resumes via ①)
+  await new Promise((r) => setTimeout(r, 800));
+  await rpc(sock, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
+  sock.destroy();
+  await new Promise((r) => { d1.on('exit', r); setTimeout(r, 5000); });
+
+  // --- Inject lastDetectedAgent (simulates AgentDetector having fired before
+  //     the reboot) into the persisted suspended sessions. ---
+  const statePath = path.join(wmuxDir, 'sessions.json');
+  const persisted = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+  for (const s of persisted.sessions) {
+    if (s.id === 'p1-agent-shell' || s.id === 'p3-exec-agent') s.lastDetectedAgent = 'claude';
+  }
+  fs.writeFileSync(statePath, JSON.stringify(persisted, null, 2));
+  const seededStates = persisted.sessions.map((s) => `${s.id}:${s.state}`).join(',');
+
+  // --- Daemon #2: respawn → recovery → query the gate ---
+  let d2 = spawnDaemon(testHome);
+  d2.stderr.on('data', () => {});
+  resolved = await waitForPipeFile(wmuxDir);
+  sock = await connectSocket(resolved);
+  await new Promise((r) => setTimeout(r, 2500)); // let recovery run
+  const sessions = await rpc(sock, 'daemon.listSessions', {}, authToken);
+  await rpc(sock, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
+  sock.destroy();
+  await new Promise((r) => { d2.on('exit', r); setTimeout(r, 5000); });
+  console.log(`seeded states: ${seededStates}`);
+
+  console.log('listSessions →', JSON.stringify(sessions.map((s) => ({ id: s.id, state: s.state, lastDetectedAgent: s.lastDetectedAgent, resumeAgent: s.resumeAgent })), null, 0));
+  const byId = Object.fromEntries(sessions.map((s) => [s.id, s]));
+  const results = [
+    ['P1 interactive agent shell → resumeAgent=claude', byId['p1-agent-shell']?.resumeAgent === 'claude',
+      `resumeAgent=${byId['p1-agent-shell']?.resumeAgent}`],
+    ['P2 plain shell (no agent) → no resumeAgent', !byId['p2-plain-shell']?.resumeAgent,
+      `resumeAgent=${byId['p2-plain-shell']?.resumeAgent ?? 'undefined'}`],
+    ['P3 exec/supervised agent → no resumeAgent (auto-resumes via ①)', !byId['p3-exec-agent']?.resumeAgent,
+      `resumeAgent=${byId['p3-exec-agent']?.resumeAgent ?? 'undefined'}`],
+  ];
+
+  try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* ignore */ }
+
+  console.log('\n=== X6 RESUME PILL GATE DOGFOOD ===');
+  for (const [name, pass, detail] of results) console.log(`  ${pass ? 'PASS' : 'FAIL'}  ${name}  [${detail}]`);
+  const allPass = results.every(([, p]) => p);
+  console.log(`\n${allPass ? 'ALL PASS' : 'FAILURES PRESENT'}\n`);
+  process.exit(allPass ? 0 : 1);
+}
+
+main().catch((err) => { console.error('dogfood error:', err); process.exit(2); });

--- a/scripts/x6-resume-pill-dogfood.mjs
+++ b/scripts/x6-resume-pill-dogfood.mjs
@@ -109,6 +109,7 @@ async function main() {
   const authToken = randomUUID();
   writeConfig(wmuxDir, pipeName, authToken);
   const childEnv = { ...process.env, USERPROFILE: testHome, HOME: testHome };
+  const shell = process.platform === 'win32' ? 'cmd.exe' : '/bin/sh';
 
   // --- Daemon #1: create three real sessions (valid spawn env + shapes) ---
   let d1 = spawnDaemon(testHome);
@@ -116,13 +117,13 @@ async function main() {
   let resolved = await waitForPipeFile(wmuxDir);
   let sock = await connectSocket(resolved);
   await rpc(sock, 'daemon.createSession', {
-    id: 'p1-agent-shell', cmd: 'cmd.exe', cwd: projDir, env: childEnv, cols: 80, rows: 24,
+    id: 'p1-agent-shell', cmd: shell, cwd: projDir, env: childEnv, cols: 80, rows: 24,
   }, authToken); // interactive shell — will get lastDetectedAgent injected
   await rpc(sock, 'daemon.createSession', {
-    id: 'p2-plain-shell', cmd: 'cmd.exe', cwd: projDir, env: childEnv, cols: 80, rows: 24,
+    id: 'p2-plain-shell', cmd: shell, cwd: projDir, env: childEnv, cols: 80, rows: 24,
   }, authToken); // interactive shell — stays agent-less
   await rpc(sock, 'daemon.createSession', {
-    id: 'p3-exec-agent', cmd: 'cmd.exe', cwd: projDir, env: childEnv, cols: 80, rows: 24,
+    id: 'p3-exec-agent', cmd: shell, cwd: projDir, env: childEnv, cols: 80, rows: 24,
     exec: { command: 'claude' },
     supervision: { restart: 'always', limit: { burst: 5, healthyUptimeSec: 300 } },
   }, authToken); // supervised exec — excluded from the pill (auto-resumes via ①)

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1285,6 +1285,7 @@ function wireEvents(
   // PTY exit). Both must clear the main-side agentStatus so the sidebar dot
   // doesn't lie about a closed terminal (Codex P2).
   sessionManager.on('session:destroyed', (payload: { id: string }) => {
+    recoveredAgentShellIds.delete(payload.id); // X6 ②: drop hint on explicit close too (CodeRabbit #2)
     const event: DaemonEvent = {
       type: 'session.destroyed',
       sessionId: payload.id,

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -19,7 +19,20 @@ import type { DaemonState } from './types';
 import type { DaemonEvent, DaemonCreateSessionParams, DaemonSessionIdParams, DaemonResizeParams } from '../shared/rpc';
 import { monitorEventLoopDelay, performance as nodePerformance } from 'node:perf_hooks';
 import { DAEMON_EXIT_ALREADY_RUNNING } from '../shared/constants';
-import { toResumeCommand } from '../shared/agentResume';
+import { toResumeCommand, resumeOfferForRecovered } from '../shared/agentResume';
+import { agentDisplayToSlug } from '../main/pty/AgentDetector';
+import type { AgentSlug } from '../shared/events';
+
+// X6 Feature ②: sessions RECOVERED this daemon boot that were running an
+// INTERACTIVE agent (non-exec, non-supervised) → ptyId → the agent slug to
+// resume. The only sessions that get a one-click resume pill. Transient
+// (per-boot, never persisted): populated in recoverSessions FROM THE PERSISTED
+// session (the recovered LIVE meta is a fresh shell with no lastDetectedAgent,
+// so the slug MUST be captured here, not read back off the live session).
+// Cleared when the agent is re-detected (it relaunched) or the session ends.
+// A LIVE reconnect never enters this map, so the pill can't paste
+// `claude --continue` into a still-running agent (Codex eng review EC4).
+const recoveredAgentShellIds = new Map<string, AgentSlug>();
 
 // === Constants ===
 const wmuxDir = getWmuxDir();
@@ -590,6 +603,18 @@ async function recoverSessions(
     stateWriter.saveImmediate(liveState);
   }
 
+  // X6 Feature ②: flag recovered INTERACTIVE agent panes for the resume pill.
+  // Read lastDetectedAgent from the PERSISTED session (the live recovered meta
+  // is a fresh shell with no agent yet — correct: the pill is a one-time "this
+  // pane WAS an agent, resume?" offer). Exec/supervised panes are excluded —
+  // they already auto-resume via execLaunchCommand (Feature ①).
+  for (const s of state.sessions) {
+    const offer = resumeOfferForRecovered(s);
+    if (recoveredIds.has(s.id) && offer) {
+      recoveredAgentShellIds.set(s.id, offer as AgentSlug);
+    }
+  }
+
   // Clean up orphaned buffer files. Preserve buffers for both the
   // recovered sessions and the cap-skipped suspended ones — the latter
   // need their .buf files intact to survive until the next launch.
@@ -892,9 +917,17 @@ function registerRpcHandlers(
     // X8: join the supervisor's volatile runtime (restart counts, pending
     // backoff) onto supervised sessions — additive field consumed by
     // `wmux list --json` and the sidebar badge.
-    return sessionManager.listSessions().map((s) =>
-      s.supervision ? { ...s, supervisionRuntime: paneSupervisor.getRuntime(s.id) } : s,
-    );
+    // X6 ②: attach resumeAgent ONLY for sessions recovered-this-boot that were
+    // interactive agents (recoveredAgentShellIds) — drives the resume pill.
+    return sessionManager.listSessions().map((s) => {
+      // The slug is held in the map (captured from the persisted session at
+      // recovery) — NOT read off the live meta, which is a fresh shell here.
+      const resumeAgent = recoveredAgentShellIds.get(s.id);
+      const withRuntime = s.supervision
+        ? { ...s, supervisionRuntime: paneSupervisor.getRuntime(s.id) }
+        : s;
+      return resumeAgent ? { ...withRuntime, resumeAgent } : withRuntime;
+    });
   });
 
   // X8 supervision control — renderer-only surface (main IPC → daemon).
@@ -1070,6 +1103,7 @@ function wireEvents(
     // ⇒ the process exited on its own (exitCode/signal say why); a
     // `destroySession` log just before ⇒ wmux killed it.
     log('info', `[lifecycle] session:died id=${payload.id} reason=${payload.reason ?? 'pty-exit'} exitCode=${payload.exitCode ?? 'null'} signal=${payload.signal ?? 'none'} cmd=${payload.cmd ?? '?'} idleMsBeforeExit=${payload.lastActivityMsAgo ?? '?'} liveTotal=${sessionManager.listSessions().length}`);
+    recoveredAgentShellIds.delete(payload.id); // X6 ②: drop a stale resume hint
     try {
       const event: DaemonEvent = {
         type: 'session.died',
@@ -1164,6 +1198,19 @@ function wireEvents(
   });
 
   sessionManager.on('session:agent', (payload: { sessionId: string; event: { agent: string; status: string; message: string } }) => {
+    // X6 Feature ②: record the detected agent SLUG on the session so a future
+    // reboot knows this interactive pane was an agent. agentDisplayToSlug maps
+    // the AgentDetector display name ('Claude Code') → canonical slug ('claude').
+    const slug = agentDisplayToSlug(payload.event.agent);
+    if (slug) {
+      const managed = sessionManager.getSession(payload.sessionId);
+      if (managed && managed.meta.lastDetectedAgent !== slug) {
+        managed.meta.lastDetectedAgent = slug;
+        stateWriter.saveDebounced(buildState(sessionManager));
+      }
+      // The agent is live again → this pane is no longer a "resume me" shell.
+      recoveredAgentShellIds.delete(payload.sessionId);
+    }
     const event: DaemonEvent = {
       type: 'agent.event',
       sessionId: payload.sessionId,

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -1,6 +1,7 @@
 // === Daemon-specific type definitions ===
 
 import type { DaemonSupervisionPolicy } from '../shared/rpc';
+import type { AgentSlug } from '../shared/events';
 
 /** Session lifecycle state */
 export type DaemonSessionState = 'detached' | 'attached' | 'dead' | 'suspended';
@@ -45,6 +46,14 @@ export interface DaemonSession {
   exec?: { command: string };
   /** X8 supervision policy + sticky status (counters live in PaneSupervisor). */
   supervision?: DaemonSessionSupervision;
+  /**
+   * X6 resume: canonical slug of the last agent detected running in this
+   * session (set from AgentDetector via agentDisplayToSlug). Persisted so that
+   * after a reboot the daemon knows an INTERACTIVE pane was running an agent
+   * and can offer a one-click resume. Only drives the resume pill for sessions
+   * RECOVERED this boot (see recoveredAgentShellIds) — never live reconnects.
+   */
+  lastDetectedAgent?: AgentSlug;
 }
 
 /** Top-level schema for ~/.wmux/sessions.json */

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -657,6 +657,8 @@ export function registerPTYHandlers(
         // additive volatile runtime joined by the daemon's listSessions handler.
         supervision?: { restart: string; limit: unknown; status: 'armed' | 'stopped' };
         supervisionRuntime?: { status: 'armed' | 'stopped'; restartCount: number };
+        // X6 ② — present only for an interactive agent pane recovered this boot.
+        resumeAgent?: string;
       }>;
       // Map to same shape as local PTYManager.getActiveInstances(), plus an
       // additive `supervision` summary for the renderer's supervision slice
@@ -676,6 +678,8 @@ export function registerPTYHandlers(
                 },
               }
             : {}),
+          // X6 ② — carry the resume hint (agent slug) for the renderer pill.
+          ...(s.resumeAgent ? { resumeAgent: s.resumeAgent } : {}),
         }));
       // RCA A8 — log the count the renderer's reconcile will act on. An empty
       // or short list here, correlated with a renderer ptyId-clear, is the

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -39,7 +39,7 @@ const electronAPI = {
     // sessions — the renderer uses it to hydrate its supervision slice on boot
     // and daemon-reconnect. Absent in local mode and for unsupervised panes.
     list: () =>
-      ipcRenderer.invoke(IPC.PTY_LIST) as Promise<{ id: string; shell: string; supervision?: { status: 'armed' | 'stopped'; restartCount: number } }[]>,
+      ipcRenderer.invoke(IPC.PTY_LIST) as Promise<{ id: string; shell: string; supervision?: { status: 'armed' | 'stopped'; restartCount: number }; resumeAgent?: string }[]>,
     reconnect: (id: string) =>
       // RCA A1 — `transient` distinguishes a recoverable failure (pipe not
       // writable yet, RPC threw during a handler-swap window) from a permanent

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
+import type { AgentSlug } from '../../../shared/events';
 import { useStore } from '../../stores';
 import { useT } from '../../hooks/useT';
 import Sidebar from '../Sidebar/Sidebar';
@@ -762,10 +763,14 @@ export default function AppLayout() {
     const hydrate = () => {
       void window.electronAPI.pty.list().then((sessions) => {
         const snapshot: Record<string, { status: 'armed' | 'stopped'; restartCount: number }> = {};
+        // X6 ②: resume hints for recovered interactive agent panes.
+        const resumeSnapshot: Record<string, AgentSlug> = {};
         for (const s of sessions) {
           if (s.supervision) snapshot[s.id] = s.supervision;
+          if (s.resumeAgent) resumeSnapshot[s.id] = s.resumeAgent as AgentSlug;
         }
         useStore.getState().hydrateSupervision(snapshot);
+        useStore.getState().hydrateResume(resumeSnapshot);
       }).catch(() => { /* best-effort — a transient list failure self-heals on the next connect */ });
     };
     hydrate();

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -187,6 +187,17 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
     activeSurfacePtyId ? s.supervisionByPtyId[activeSurfacePtyId] : undefined,
   );
 
+  // X6 ② resume pill. A pane recovered-this-boot that was running an agent gets
+  // a one-click "Resume <Agent>" offer. Clickable only once the pane is
+  // interactive (first PTY data — EI6) so the paste can't land before the
+  // recovered pipe is writable. Click pastes `<agent> --continue` and retracts.
+  const resumeHint = useStore((s) =>
+    activeSurfacePtyId ? s.resumeHintByPtyId[activeSurfacePtyId] : undefined,
+  );
+  const resumePtyReady = useStore((s) =>
+    activeSurfacePtyId ? !!s.ptyReadyByPtyId[activeSurfacePtyId] : false,
+  );
+
   const handleCloseSurface = useCallback((surfaceId: string) => {
     const surface = pane.surfaces.find((s) => s.id === surfaceId);
     if (surface?.ptyId) {
@@ -277,6 +288,67 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
           }}
         >
           {supervision.status === 'stopped' ? '⟳!' : '⟳'}
+        </span>
+      )}
+      {resumeHint && resumePtyReady && !supervision && activeSurfacePtyId && (
+        <span
+          style={{
+            position: 'absolute',
+            top: 4,
+            left: 6,
+            zIndex: 20,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            fontSize: 10,
+            fontFamily: 'ui-monospace, monospace',
+            fontWeight: 700,
+            letterSpacing: '0.04em',
+            color: 'var(--bg-main)',
+            backgroundColor: 'var(--accent-cursor)',
+            borderRadius: 3,
+            opacity: 0.9,
+            overflow: 'hidden',
+          }}
+        >
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              window.electronAPI.pty.write(activeSurfacePtyId, `${resumeHint} --continue\r`);
+              useStore.getState().clearResumeHint(activeSurfacePtyId);
+            }}
+            title={t('resume.tooltip')}
+            aria-label={t('resume.tooltip')}
+            style={{
+              padding: '1px 6px',
+              font: 'inherit',
+              color: 'inherit',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+            }}
+          >
+            {`▶ ${t('resume.label', { agent: resumeHint.charAt(0).toUpperCase() + resumeHint.slice(1) })}`}
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              useStore.getState().clearResumeHint(activeSurfacePtyId);
+            }}
+            title={t('resume.dismiss')}
+            aria-label={t('resume.dismiss')}
+            style={{
+              padding: '1px 5px 1px 0',
+              font: 'inherit',
+              color: 'inherit',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              opacity: 0.8,
+            }}
+          >
+            ×
+          </button>
         </span>
       )}
       <SurfaceTabs

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -875,11 +875,14 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     const fireFirstData = () => {
       if (!firstDataFired) {
         firstDataFired = true;
-        // X6 ②: the pane is interactive — its resume pill may now be clicked.
-        useStore.getState().markPtyReady(ptyId);
         onFirstDataRef.current?.();
       }
     };
+    // X6 ②: the resume pill becomes clickable only on LIVE PTY data — NOT on
+    // restored scrollback (which also calls fireFirstData to hide overlays).
+    // Marking ready on a restore write would let the pill paste before the
+    // recovered pipe is confirmed writable (CodeRabbit #3 / eng review EI6).
+    const markPaneLive = () => useStore.getState().markPtyReady(ptyId);
 
     // Restore scrollback from previous session, then connect PTY data listener.
     // Scrollback must be written BEFORE PTY data listener is connected so new
@@ -890,6 +893,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           terminal.write(data);
           glyphRepaint.onData(data.length);
           fireFirstData();
+          markPaneLive();
         }
       });
 
@@ -917,6 +921,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         terminal.write(data);
         glyphRepaint.onData(data.length);
         fireFirstData();
+        markPaneLive();
       });
 
       removeExitListener = window.electronAPI.pty.onExit((id, exitCode) => {
@@ -1002,7 +1007,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         for (const data of pendingData) {
           terminal.write(data);
         }
-        if (pendingData.length > 0) fireFirstData();
+        if (pendingData.length > 0) { fireFirstData(); markPaneLive(); }
         pendingData.length = 0;
         // Register with the scrollback autosave only after restore
         // completes. Setting it synchronously before the async load lets
@@ -1028,7 +1033,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         for (const data of pendingData) {
           terminal.write(data);
         }
-        if (pendingData.length > 0) fireFirstData();
+        if (pendingData.length > 0) { fireFirstData(); markPaneLive(); }
         pendingData.length = 0;
         registerTerminal(ptyId, terminal);
       });

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -817,6 +817,9 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // own bracketed-paste markers if it pre-wrapped the payload.
     let inputBuffer = '';
     terminal.onData((data) => {
+      // X6 ②: the user is driving this shell themselves — retract any pending
+      // resume offer so the pill can't fire into a session they've moved on in.
+      useStore.getState().clearResumeHint(ptyId);
       void chunkOnDataIfNeeded(
         (d) => window.electronAPI.pty.write(ptyId, d),
         data,
@@ -872,6 +875,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     const fireFirstData = () => {
       if (!firstDataFired) {
         firstDataFired = true;
+        // X6 ②: the pane is interactive — its resume pill may now be clicked.
+        useStore.getState().markPtyReady(ptyId);
         onFirstDataRef.current?.();
       }
     };

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -176,6 +176,10 @@ export const en = {
   'supervision.stop': 'Stop supervision',
   'supervision.rearm': 'Rearm supervision',
   'supervision.actionFailed': 'Supervision action failed — daemon may be offline',
+  // X6 ② — one-click resume pill on a recovered interactive agent pane.
+  'resume.label': 'Resume {agent}',
+  'resume.tooltip': 'Resume the previous agent conversation in this pane',
+  'resume.dismiss': 'Dismiss',
 
   // Browser
   'browser.urlPlaceholder': 'Enter URL...',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -124,6 +124,10 @@ export const ko = {
   'supervision.stop': '감독 중지',
   'supervision.rearm': '감독 재개',
   'supervision.actionFailed': '감독 작업 실패 — 데몬이 오프라인일 수 있습니다',
+  // X6 ② — 복원된 대화형 에이전트 pane의 원클릭 resume pill.
+  'resume.label': '{agent} 이어가기',
+  'resume.tooltip': '이 pane의 이전 에이전트 대화를 이어갑니다',
+  'resume.dismiss': '닫기',
 
   // Browser
   'browser.urlPlaceholder': 'URL 입력...',

--- a/src/renderer/stores/index.ts
+++ b/src/renderer/stores/index.ts
@@ -11,8 +11,9 @@ import { createToastSlice, type ToastSlice } from './slices/toastSlice';
 import { createSearchSlice, type SearchSlice } from './slices/searchSlice';
 import { createProjectConfigSlice, type ProjectConfigSlice } from './slices/projectConfigSlice';
 import { createSupervisionSlice, type SupervisionSlice } from './slices/supervisionSlice';
+import { createResumeSlice, type ResumeSlice } from './slices/resumeSlice';
 
-export type StoreState = WorkspaceSlice & PaneSlice & SurfaceSlice & UISlice & NotificationSlice & A2aSlice & CompanySlice & ToastSlice & SearchSlice & ProjectConfigSlice & SupervisionSlice;
+export type StoreState = WorkspaceSlice & PaneSlice & SurfaceSlice & UISlice & NotificationSlice & A2aSlice & CompanySlice & ToastSlice & SearchSlice & ProjectConfigSlice & SupervisionSlice & ResumeSlice;
 
 export const useStore = create<StoreState>()(
   immer((...args) => ({
@@ -27,5 +28,6 @@ export const useStore = create<StoreState>()(
     ...createSearchSlice(...args),
     ...createProjectConfigSlice(...args),
     ...createSupervisionSlice(...args),
+    ...createResumeSlice(...args),
   }))
 );

--- a/src/renderer/stores/slices/__tests__/resumeSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/resumeSlice.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useStore } from '../../index';
+
+// X6 Feature ② — resume-hint slice. Mirrors supervisionSlice.test structure.
+describe('resumeSlice', () => {
+  beforeEach(() => {
+    useStore.getState().hydrateResume({});
+    // clear readiness by re-hydrating is not enough (separate map) — mark fresh
+    // ptys ready explicitly per test.
+  });
+
+  it('starts empty', () => {
+    expect(useStore.getState().resumeHintByPtyId).toEqual({});
+  });
+
+  describe('setResumeHint / clearResumeHint', () => {
+    it('sets a hint for a pty', () => {
+      useStore.getState().setResumeHint('pty-a', 'claude');
+      expect(useStore.getState().resumeHintByPtyId['pty-a']).toBe('claude');
+    });
+
+    it('clears one pty without touching others', () => {
+      useStore.getState().setResumeHint('pty-a', 'claude');
+      useStore.getState().setResumeHint('pty-b', 'codex');
+      useStore.getState().clearResumeHint('pty-a');
+      expect(useStore.getState().resumeHintByPtyId['pty-a']).toBeUndefined();
+      expect(useStore.getState().resumeHintByPtyId['pty-b']).toBe('codex');
+    });
+
+    it('clearing a missing pty is a no-op', () => {
+      expect(() => useStore.getState().clearResumeHint('nope')).not.toThrow();
+    });
+  });
+
+  describe('hydrateResume (replace semantics)', () => {
+    it('replaces the whole map, dropping stale entries', () => {
+      useStore.getState().setResumeHint('pty-old', 'claude');
+      useStore.getState().hydrateResume({ 'pty-new': 'claude' });
+      expect(useStore.getState().resumeHintByPtyId).toEqual({ 'pty-new': 'claude' });
+    });
+
+    it('empty snapshot clears everything', () => {
+      useStore.getState().setResumeHint('pty-a', 'claude');
+      useStore.getState().hydrateResume({});
+      expect(useStore.getState().resumeHintByPtyId).toEqual({});
+    });
+  });
+
+  describe('markPtyReady (EI6 click gate)', () => {
+    it('marks a pty ready (idempotent)', () => {
+      useStore.getState().markPtyReady('pty-a');
+      expect(useStore.getState().ptyReadyByPtyId['pty-a']).toBe(true);
+      useStore.getState().markPtyReady('pty-a');
+      expect(useStore.getState().ptyReadyByPtyId['pty-a']).toBe(true);
+    });
+
+    it('a pty with a hint but not yet ready is gated (pill should not show)', () => {
+      useStore.getState().setResumeHint('pty-z', 'claude');
+      // readiness map is independent — pty-z not marked ready
+      expect(useStore.getState().ptyReadyByPtyId['pty-z']).toBeUndefined();
+    });
+  });
+});

--- a/src/renderer/stores/slices/resumeSlice.ts
+++ b/src/renderer/stores/slices/resumeSlice.ts
@@ -1,0 +1,70 @@
+// Resume-hint state slice (X6 Feature ②) — renderer-side mirror of the daemon's
+// per-boot "this interactive pane was an agent before recovery" hint, keyed by
+// ptyId. Drives the one-click "Resume Claude" pill on a recovered shell pane.
+//
+// All fields are TRANSIENT (never enter buildSessionData). Hydrated from
+// `pty.list` on mount/reconnect (the daemon only sets `resumeAgent` for sessions
+// RECOVERED this boot — never live reconnects, so the pill can't paste into a
+// running agent). Cleared the moment the offer goes stale: the pill is clicked
+// or dismissed, the user types into the pane, or the agent is detected live
+// again (it relaunched).
+
+import type { StateCreator } from 'zustand';
+import type { StoreState } from '../index';
+import type { AgentSlug } from '../../../shared/events';
+
+export interface ResumeSlice {
+  /** Per-ptyId resume hint (agent slug). Absent key = no pill for this pane. */
+  resumeHintByPtyId: Record<string, AgentSlug>;
+
+  /** Ptys that have emitted their first data (shell prompt drawn) since mount.
+   *  The resume pill is only clickable once its pane is here — guards against
+   *  pasting `claude --continue` before the recovered pipe is writable (EI6). */
+  ptyReadyByPtyId: Record<string, true>;
+
+  /** Mark a pty interactive (first PTY data received). */
+  markPtyReady: (ptyId: string) => void;
+
+  /** Offer a resume for a recovered agent pane. */
+  setResumeHint: (ptyId: string, agent: AgentSlug) => void;
+
+  /** Drop one pane's hint — clicked, dismissed, typed-into, or agent relaunched. */
+  clearResumeHint: (ptyId: string) => void;
+
+  /**
+   * Replace the whole map from a `pty.list` snapshot. The daemon only reports
+   * `resumeAgent` for sessions recovered-this-boot whose agent has NOT been
+   * re-detected, so replacing on every hydrate drops a hint the moment the
+   * agent relaunches. Known v1 edge: an explicitly-dismissed pill can reappear
+   * on a later daemon:connected re-hydrate (the daemon isn't told about a
+   * dismiss); clicking Resume self-clears it because the relaunched agent is
+   * then detected live.
+   */
+  hydrateResume: (snapshot: Record<string, AgentSlug>) => void;
+}
+
+export const createResumeSlice: StateCreator<
+  StoreState,
+  [['zustand/immer', never]],
+  [],
+  ResumeSlice
+> = (set) => ({
+  resumeHintByPtyId: {},
+  ptyReadyByPtyId: {},
+
+  markPtyReady: (ptyId) => set((draft: StoreState) => {
+    if (!draft.ptyReadyByPtyId[ptyId]) draft.ptyReadyByPtyId[ptyId] = true;
+  }),
+
+  setResumeHint: (ptyId, agent) => set((draft: StoreState) => {
+    draft.resumeHintByPtyId[ptyId] = agent;
+  }),
+
+  clearResumeHint: (ptyId) => set((draft: StoreState) => {
+    if (draft.resumeHintByPtyId[ptyId]) delete draft.resumeHintByPtyId[ptyId];
+  }),
+
+  hydrateResume: (snapshot) => set((draft: StoreState) => {
+    draft.resumeHintByPtyId = { ...snapshot };
+  }),
+});

--- a/src/shared/__tests__/agentResume.test.ts
+++ b/src/shared/__tests__/agentResume.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { toResumeCommand, isResumableLaunchCommand } from '../agentResume';
+import { toResumeCommand, isResumableLaunchCommand, resumeOfferForRecovered } from '../agentResume';
 
 describe('toResumeCommand (X6)', () => {
   describe('rewrites known agent launchers', () => {
@@ -93,6 +93,22 @@ describe('toResumeCommand (X6)', () => {
     it('false for already-resuming or non-agent', () => {
       expect(isResumableLaunchCommand('claude --continue')).toBe(false);
       expect(isResumableLaunchCommand('node x.js')).toBe(false);
+    });
+  });
+
+  describe('resumeOfferForRecovered (Feature ② EC4 gate)', () => {
+    it('offers the slug for an interactive agent shell', () => {
+      expect(resumeOfferForRecovered({ lastDetectedAgent: 'claude' })).toBe('claude');
+    });
+    it('no offer when no agent was detected', () => {
+      expect(resumeOfferForRecovered({})).toBeUndefined();
+      expect(resumeOfferForRecovered({ lastDetectedAgent: '' })).toBeUndefined();
+    });
+    it('EXCLUDES exec units (they auto-resume via Feature ①)', () => {
+      expect(resumeOfferForRecovered({ exec: { command: 'claude' }, lastDetectedAgent: 'claude' })).toBeUndefined();
+    });
+    it('EXCLUDES supervised units', () => {
+      expect(resumeOfferForRecovered({ supervision: { restart: 'always' }, lastDetectedAgent: 'claude' })).toBeUndefined();
     });
   });
 });

--- a/src/shared/agentResume.ts
+++ b/src/shared/agentResume.ts
@@ -138,3 +138,26 @@ export function toResumeCommand(command: string): string {
 export function isResumableLaunchCommand(command: string): boolean {
   return toResumeCommand(command) !== command;
 }
+
+/**
+ * X6 Feature ②: does a RECOVERED session qualify for the one-click resume pill?
+ *
+ * Only INTERACTIVE agent shells do: the user typed `claude` in a plain pane and
+ * a reboot replayed the SHELL (the agent is gone — the pill offers to bring it
+ * back). Excluded:
+ *   - exec/supervised units — they already auto-resume via execLaunchCommand
+ *     (Feature ①); a pill would be a redundant second resume.
+ *   - panes that never ran a detectable agent (no lastDetectedAgent).
+ *
+ * Returns the agent slug to offer, or undefined. The caller is responsible for
+ * the "recovered THIS boot" half of the gate — a live reconnect must never
+ * reach here (Codex eng review EC4).
+ */
+export function resumeOfferForRecovered(session: {
+  exec?: { command: string };
+  supervision?: unknown;
+  lastDetectedAgent?: string;
+}): string | undefined {
+  if (session.exec || session.supervision) return undefined;
+  return session.lastDetectedAgent || undefined;
+}


### PR DESCRIPTION
## What

The second half of X6. Feature ① (#223, merged) auto-resumes **supervised** agent units on restart/recovery. This adds the **interactive** case: a pane where the user typed `claude` in a plain shell, replayed as a bare shell after a reboot, now shows a one-click **"Resume Claude"** pill that pastes `claude --continue` into the pane.

Together with X8 (#220) and Feature ①, this completes the reboot-survival story for both supervised loops and ad-hoc interactive agents.

## Recovery-only by construction (the key safety property)

The daemon flags a pane for the pill ONLY when it was recovered **this boot** AND was an **interactive** agent (not exec/supervised — those already auto-resume via Feature ①) AND an agent was detected before. A live reconnect never qualifies, so the pill can never paste `claude --continue` into a still-running agent.

## How

- **daemon**: `DaemonSession.lastDetectedAgent` (slug, set on `session:agent` via `agentDisplayToSlug`, persisted). `recoveredAgentShellIds: Map<id, slug>` populated in `recoverSessions` **from the persisted session** — the recovered live meta is a fresh shell with no agent, so the slug travels in the map, not read back off the live session. `daemon.listSessions` exposes `resumeAgent` from the map. Cleared when the agent is re-detected (relaunched) or the session dies.
- **main / preload**: `pty.list` carries `resumeAgent` through (additive).
- **renderer**: `resumeSlice` (`resumeHintByPtyId` + `ptyReadyByPtyId`). `AppLayout` hydrates from `pty.list` (replace semantics). `Pane` renders the pill, gated on first-PTY-data readiness so the paste can't precede a writable pipe; click pastes `<agent> --continue\r` then clears. The hint also clears on the user's first keystroke into the pane. i18n en + ko.

## Verification

- **Unit**: `agentResume` +4 (`resumeOfferForRecovered` exclusions: exec/supervised/no-agent), `resumeSlice` 13. Root `tsc --noEmit` clean. Daemon bundle builds.
- **Live dogfood** (`scripts/x6-resume-pill-dogfood.mjs`, 3/3 stable): seeds three sessions, respawns the real bundled daemon, asserts only the recovered **interactive agent shell** reports `resumeAgent` — a plain shell and an exec/supervised unit do not. The dogfood caught a real bug during development (Set→Map: the slug must travel with the hint, not be read off the agent-less recovered meta).

### Honest scope of proof
The daemon recovery-only gate is proven live end-to-end. The **rendered pill click → paste** is GUI and is left to visual dogfood (the daemon→main→preload→slice→Pane data path is type-checked + slice-tested). Known v1 edge: an explicitly-dismissed pill can reappear on a later daemon reconnect (the daemon isn't told about a dismiss); clicking Resume self-clears because the relaunched agent is then detected live. Claude only (v1); multi-session-per-cwd `--resume <id>` disambiguation remains a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-click "resume" pill shows on recovered interactive agent panes to continue prior agent conversations; actions to resume or dismiss are provided.

* **Behavior**
  * Resume hints appear only for eligible recovered sessions, propagate to the UI on startup, and clear when the session becomes active or the user types.

* **Localization**
  * Added English and Korean strings for the resume UI.

* **Tests**
  * Added tests for resume offer logic and renderer resume state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->