### PR TITLE
fix(pty): emit OSC 7/7727 with [char]27 so the prompt hook works on PowerShell 5.1

### DIFF
--- a/src/main/pty/shell-hooks/pwsh.ps1
+++ b/src/main/pty/shell-hooks/pwsh.ps1
@@ -27,19 +27,31 @@ function prompt {
     $oscPrefix = ''
     if (-not $script:__wmux_skip_osc) {
         try {
+            # ESC / BEL as [char] codes, NOT the PowerShell `e / `a escapes.
+            # The `e escape (escape char) only exists in PowerShell 6+. Under
+            # Windows PowerShell 5.1 "`e" is the literal two-char string and
+            # collapses to "e", so the prompt would emit visible `e]7;...` text
+            # instead of a real OSC 7 sequence — a garbled prompt plus broken
+            # cwd reporting, and the stray glyphs throw off the cursor baseline
+            # that in-pane TUIs (codex, Claude Code) render against. [char]27 /
+            # [char]7 work on 5.1 and 7+, matching the OSC 133 hook in
+            # daemon/shell-integration.ts.
+            $esc = [char]27
+            $bel = [char]7
+
             # --- OSC 7: Current Working Directory ---
             $cwd = (Get-Location).ProviderPath
             $hostname = $env:COMPUTERNAME
             # file:// URI with forward slashes
             $uri = 'file://' + $hostname + '/' + ($cwd -replace '\\', '/')
-            $oscPrefix += "`e]7;$uri`a"
+            $oscPrefix += "$esc]7;$uri$bel"
 
             # --- OSC 7727: Git branch (best-effort) ---
             $gitExe = Get-Command git -ErrorAction SilentlyContinue
             if ($gitExe) {
                 $branch = & git rev-parse --abbrev-ref HEAD 2>$null
                 if ($LASTEXITCODE -eq 0 -and $branch) {
-                    $oscPrefix += "`e]7727;$branch`a"
+                    $oscPrefix += "$esc]7727;$branch$bel"
                 }
             }
         } catch {


### PR DESCRIPTION
## Problem

The PowerShell prompt-integration hook builds its **OSC 7** (cwd) and **OSC 7727** (git branch) sequences with the backtick-e (`` `e ``) / backtick-a escape-character escapes. Those only exist in PowerShell 6+.

Under **Windows PowerShell 5.1** — the default `powershell.exe` on Windows — `` `e `` is *not* an escape; it collapses to the literal string `e`. So instead of a real ESC-introduced OSC sequence, every prompt render emits visible text:

```
e]7;file://HOST/C:/Users/...
```

The stray glyphs corrupt the prompt and, worse, shift the cursor baseline that in-pane TUIs (codex, Claude Code) lay their UI against — so keystrokes like Ctrl+J / Backspace appear to make the cursor jump to the footer and back — and cwd reporting is broken (the URI never parses).

## Fix

Switch to `[char]27` / `[char]7`, which evaluate to ESC / BEL on **both** 5.1 and 7+, matching the OSC 133 hook in `daemon/shell-integration.ts`. Confirmed: under `powershell.exe` the emitted sequence now starts with byte 27, not 101 (`'e'`).

Scope: a single file — `src/main/pty/shell-hooks/pwsh.ps1` (no behavior change on PowerShell 7+, which already produced ESC from `` `e ``).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated PowerShell shell hook's internal signal transmission mechanism to use explicit control character encoding, improving terminal compatibility and reliability for directory and git branch information display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->