### PR TITLE
feat(x6): resume the exact Claude session on every pane after a reboot

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -26,7 +26,7 @@ returns `EPERM`. Wire framing: newline-delimited JSON, one object per line.
 
 ## RPC methods
 
-Total: **99** methods (`ALL_RPC_METHODS` in
+Total: **100** methods (`ALL_RPC_METHODS` in
 `src/shared/rpc.ts`). Capability and risk class are read from
 `src/main/mcp/methodCapabilityMap.ts`:
 
@@ -208,6 +208,7 @@ Total: **99** methods (`ALL_RPC_METHODS` in
 | `daemon.compact` | `wmux.internal` |  |
 | `daemon.superviseRearm` | `wmux.internal` |  |
 | `daemon.superviseStop` | `wmux.internal` |  |
+| `daemon.setResumeBinding` | `wmux.internal` |  |
 
 ### `hooks`
 

--- a/integrations/claude/bin/wmux-bridge.mjs
+++ b/integrations/claude/bin/wmux-bridge.mjs
@@ -119,6 +119,13 @@ function spoolResumeBinding(record) {
     if (!safe) return;
     const dir = getResumeSpoolDir();
     const file = join(dir, `${safe}.json`);
+    // Deliberately a SHARED per-pane temp (not a unique name): a crashed bridge
+    // leaves at most ONE orphan `<pane>.json.tmp` that the next write overwrites,
+    // whereas unique temps would accumulate unboundedly. Two concurrent same-pane
+    // hooks (e.g. Stop + SubagentStop) can race here — last rename wins and the
+    // loser may log ENOENT — but the daemon ingest is the real ordering authority
+    // (it skips a spool whose session already matches or whose ts is older), so a
+    // racy spool is reconciled correctly, never mis-applied (codex P2).
     const tmp = join(dir, `${safe}.json.tmp`);
     writeFileSync(tmp, JSON.stringify(record), { encoding: 'utf8', mode: 0o600 });
     renameSync(tmp, file);

--- a/integrations/claude/bin/wmux-bridge.mjs
+++ b/integrations/claude/bin/wmux-bridge.mjs
@@ -19,7 +19,7 @@
 // Codex review 2026-05-22 P0 #2: bridges must be JS-only.
 // Codex review 2026-05-22 P0 #4: token is read from disk, not env.
 
-import { readFileSync, existsSync, mkdirSync, appendFileSync, statSync, openSync, readSync, closeSync } from 'node:fs';
+import { readFileSync, existsSync, mkdirSync, appendFileSync, statSync, openSync, readSync, closeSync, writeFileSync, renameSync } from 'node:fs';
 import { homedir, userInfo } from 'node:os';
 import { join } from 'node:path';
 import { createConnection } from 'node:net';
@@ -83,6 +83,49 @@ function getBridgeLogPath() {
     // upward from this script.
   }
   return join(dir, 'bridge.log');
+}
+
+// X6 ③ — durable resume-binding spool dir. When the hooks.signal RPC fails
+// (main pipe ENOENT because wmux is mid-boot / restarting, no-workspace-match,
+// timeout, …), the binding is otherwise lost forever. We instead drop a
+// self-describing capture record here; the DAEMON drains it on its next boot
+// (recovery) and reconnect, attributing each record to the EXACT pane by its
+// WMUX_PTY_ID. Pipe-free local file write, so it never depends on wmux being up.
+//
+// Path matches the bridge.log convention (~/.wmux, NO data-suffix): the bridge
+// cannot see WMUX_DATA_SUFFIX (a reserved WMUX_* var, stripped from the pane
+// env), so dev/prod-concurrent isolation falls back to cwd routing — same
+// pre-existing limitation as bridge.log. In production (no suffix) and in the
+// USERPROFILE-isolated dogfood, bridge and daemon resolve the same dir.
+function getResumeSpoolDir() {
+  const home = process.env.USERPROFILE || process.env.HOME || homedir();
+  const dir = join(home, '.wmux', 'resume-spool');
+  try {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+  } catch {
+    // Fall through; the writeFileSync below will throw and be swallowed.
+  }
+  return dir;
+}
+
+// Persist one capture record, keyed by ptyId (last-write-wins per pane — a
+// later Stop, whose agentSessionId is the #12235-safe transcript basename,
+// overwrites an earlier SessionStart whose id was the payload.session_id
+// fallback). Atomic via temp-then-rename. Never throws.
+function spoolResumeBinding(record) {
+  try {
+    if (!record || !record.ptyId || !record.sessionId) return;
+    const safe = String(record.ptyId).replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 80);
+    if (!safe) return;
+    const dir = getResumeSpoolDir();
+    const file = join(dir, `${safe}.json`);
+    const tmp = join(dir, `${safe}.json.tmp`);
+    writeFileSync(tmp, JSON.stringify(record), { encoding: 'utf8', mode: 0o600 });
+    renameSync(tmp, file);
+    logEvent('resume-spooled', { ptyId: record.ptyId, sessionId: record.sessionId });
+  } catch (err) {
+    logEvent('resume-spool-error', { error: String(err) });
+  }
 }
 
 // ----- Logging (best-effort, never throws) --------------------------------
@@ -463,6 +506,14 @@ async function main() {
     typeof process.env.WMUX_SURFACE_ID === 'string' && process.env.WMUX_SURFACE_ID.length > 0
       ? process.env.WMUX_SURFACE_ID
       : undefined;
+  // X6 ③: the EXACT pane this hook fired from. The daemon stamps WMUX_PTY_ID
+  // (its own session id) into every pane's env at spawn, so this is the
+  // strongest routing key — it pins the resume-binding capture to one pane even
+  // when several panes share a workspaceId/cwd. Also the spool's attribution key.
+  const envPtyId =
+    typeof process.env.WMUX_PTY_ID === 'string' && process.env.WMUX_PTY_ID.length > 0
+      ? process.env.WMUX_PTY_ID
+      : undefined;
 
   // Build the AgentSignal envelope. Schema mirrors
   // integrations/shared/signal-types.ts (kept in sync manually because
@@ -477,6 +528,7 @@ async function main() {
     ),
     workspaceId: envWorkspaceId,
     surfaceId: envSurfaceId,
+    ptyId: envPtyId,
     cwd: payloadCwd ?? process.cwd(),
     payload: {
       ...(payload ?? {}),
@@ -530,6 +582,28 @@ async function main() {
       hook: hookName,
       error: rpcResult?.error ?? 'unknown',
       detail: rpcResult?.detail, // connect-error code (ENOENT/EPERM/…) for diagnosis
+    });
+  }
+
+  // X6 ③: a session-lifecycle capture that did NOT durably reach wmux (anything
+  // but innerOk — ENOENT, no-workspace-match, timeout, internal-error) would be
+  // lost forever. Spool it so the daemon reconciles it on its next boot/connect
+  // and attributes it to the EXACT pane by ptyId. Gated on a real per-pane key
+  // (ptyId) + a resumable id. A SessionStart whose transcript doesn't exist yet
+  // still spools; a later Stop's spool overwrites it with the #12235-safe id.
+  const isLifecycle = envelope.kind === 'agent.session_start'
+    || envelope.kind === 'agent.stop'
+    || envelope.kind === 'agent.subagent_stop';
+  if (!innerOk && isLifecycle && envPtyId && envelope.agentSessionId) {
+    spoolResumeBinding({
+      ptyId: envPtyId,
+      agent: 'claude',
+      sessionId: envelope.agentSessionId,
+      cwd: envelope.cwd,
+      transcriptPath: transcriptPath ?? undefined,
+      permissionMode: permissionMode ?? undefined,
+      workspaceId: envWorkspaceId,
+      ts: envelope.ts,
     });
   }
 }

--- a/integrations/claude/bin/wmux-bridge.mjs
+++ b/integrations/claude/bin/wmux-bridge.mjs
@@ -19,7 +19,7 @@
 // Codex review 2026-05-22 P0 #2: bridges must be JS-only.
 // Codex review 2026-05-22 P0 #4: token is read from disk, not env.
 
-import { readFileSync, existsSync, mkdirSync, appendFileSync, statSync, openSync, readSync, closeSync, writeFileSync, renameSync } from 'node:fs';
+import { readFileSync, existsSync, mkdirSync, appendFileSync, statSync, openSync, readSync, closeSync, writeFileSync, renameSync, unlinkSync } from 'node:fs';
 import { homedir, userInfo } from 'node:os';
 import { join } from 'node:path';
 import { createConnection } from 'node:net';
@@ -119,15 +119,26 @@ function spoolResumeBinding(record) {
     if (!safe) return;
     const dir = getResumeSpoolDir();
     const file = join(dir, `${safe}.json`);
-    // Deliberately a SHARED per-pane temp (not a unique name): a crashed bridge
-    // leaves at most ONE orphan `<pane>.json.tmp` that the next write overwrites,
-    // whereas unique temps would accumulate unboundedly. Two concurrent same-pane
-    // hooks (e.g. Stop + SubagentStop) can race here — last rename wins and the
-    // loser may log ENOENT — but the daemon ingest is the real ordering authority
-    // (it skips a spool whose session already matches or whose ts is older), so a
-    // racy spool is reconciled correctly, never mis-applied (codex P2).
-    const tmp = join(dir, `${safe}.json.tmp`);
+    // UNIQUE temp per write (pid + uuid): two concurrent same-pane hook exits must
+    // not overwrite each other's in-flight temp and publish a stale payload — with
+    // a shared temp, a newer Stop's rename could end up publishing an older
+    // SessionStart's bytes (codex + CodeRabbit). The daemon prunes abandoned
+    // `*.json.tmp` on ingest so a crashed write can't accumulate.
+    const tmp = join(dir, `${safe}.${process.pid}.${randomUUID()}.json.tmp`);
     writeFileSync(tmp, JSON.stringify(record), { encoding: 'utf8', mode: 0o600 });
+    // Don't replace a spool file that already holds a NEWER capture — last-write
+    // by ts, not by rename order. (The daemon ingest re-applies the same ordering
+    // as a backstop; this just avoids publishing a known-stale record.) A corrupt
+    // existing file falls through and is replaced.
+    try {
+      if (existsSync(file)) {
+        const existing = JSON.parse(readFileSync(file, 'utf8'));
+        if (typeof existing?.ts === 'number' && existing.ts > record.ts) {
+          try { unlinkSync(tmp); } catch { /* ignore */ }
+          return;
+        }
+      }
+    } catch { /* replace a corrupt/unreadable existing spool */ }
     renameSync(tmp, file);
     logEvent('resume-spooled', { ptyId: record.ptyId, sessionId: record.sessionId });
   } catch (err) {

--- a/integrations/claude/bin/wmux-bridge.mjs
+++ b/integrations/claude/bin/wmux-bridge.mjs
@@ -164,6 +164,65 @@ function extractUsageFromTranscript(transcriptPath) {
   }
 }
 
+// X6 ③: the permission mode the session is CURRENTLY in, read from the
+// transcript. Claude Code stamps `"permissionMode"` on every USER turn
+// (F5, verified live 2026-06-14). Walk lines from the END for the most
+// recent user turn — that's the live mode. Mirrors extractUsageFromTranscript's
+// parse-tolerant tail read (last 64KB). Returns one of the four known modes,
+// or null (file absent, no user turn yet, or an unrecognized value).
+const VALID_PERMISSION_MODES = new Set(['bypassPermissions', 'acceptEdits', 'plan', 'default']);
+function extractPermissionModeFromTranscript(transcriptPath) {
+  try {
+    if (!existsSync(transcriptPath)) return null;
+    const stat = statSync(transcriptPath);
+    const TAIL_BYTES = 64 * 1024;
+    const readBytes = Math.min(TAIL_BYTES, stat.size);
+    const offset = stat.size - readBytes;
+    const buf = Buffer.alloc(readBytes);
+    const fd = openSync(transcriptPath, 'r');
+    try {
+      readSync(fd, buf, 0, readBytes, offset);
+    } finally {
+      closeSync(fd);
+    }
+    const tail = buf.toString('utf8');
+    // Trim leading partial line if we landed mid-line (offset > 0).
+    const start = offset > 0 ? tail.indexOf('\n') + 1 : 0;
+    const lines = tail.slice(start).split('\n').filter((l) => l.trim().length > 0);
+
+    for (let i = lines.length - 1; i >= 0; i--) {
+      let entry;
+      try {
+        entry = JSON.parse(lines[i]);
+      } catch {
+        continue;
+      }
+      if (entry && entry.type === 'user' && typeof entry.permissionMode === 'string'
+          && VALID_PERMISSION_MODES.has(entry.permissionMode)) {
+        return entry.permissionMode;
+      }
+    }
+    return null;
+  } catch (err) {
+    logEvent('transcript-permission-read-error', { error: String(err) });
+    return null;
+  }
+}
+
+// X6 ③ (#12235-safe): the origin session id is the transcript FILENAME without
+// its .jsonl extension. `claude --resume <id>` mints a NEW session_id on the
+// hook payload but APPENDS to the SAME transcript file (F3), so the filename is
+// the only stable handle on the origin conversation. Falls back to the passed
+// session_id when no transcript path is available.
+function sessionIdFromTranscript(transcriptPath, fallback) {
+  if (typeof transcriptPath === 'string' && transcriptPath.length > 0) {
+    const base = transcriptPath.split(/[\\/]/).pop() ?? '';
+    const id = base.replace(/\.jsonl$/i, '');
+    if (id) return id;
+  }
+  return fallback;
+}
+
 // ----- stdin reader -------------------------------------------------------
 
 async function readStdin() {
@@ -366,10 +425,27 @@ async function main() {
   // We only do this for stop-class kinds. PostToolUse / SessionStart
   // do not carry final usage and the cost of the read isn't justified
   // per tool call.
+  const transcriptPath = (payload && typeof payload.transcript_path === 'string' && payload.transcript_path.length > 0)
+    ? payload.transcript_path
+    : null;
+
   let usage = null;
   const isStopClass = hookName === 'Stop' || hookName === 'SubagentStop';
-  if (isStopClass && payload && typeof payload.transcript_path === 'string') {
-    usage = extractUsageFromTranscript(payload.transcript_path);
+  if (isStopClass && transcriptPath) {
+    usage = extractUsageFromTranscript(transcriptPath);
+  }
+
+  // X6 ③: capture the permission mode LIVE — on SessionStart and on every
+  // Stop/SubagentStop while the session is still alive. This is deliberately
+  // NOT a teardown/exit hook: a real reboot is SIGKILL, so no exit hook fires;
+  // the resume binding must already be persisted from the last live hook (the
+  // X6 ② SIGKILL-survival lesson). On SessionStart the transcript may not exist
+  // yet (F9 — it appears on the first turn), so this is null until the first
+  // turn lands; the next Stop fills it in.
+  let permissionMode;
+  const isSessionStart = hookName === 'SessionStart';
+  if ((isSessionStart || isStopClass) && transcriptPath) {
+    permissionMode = extractPermissionModeFromTranscript(transcriptPath) ?? undefined;
   }
 
   // Env-first routing identifiers. When Claude Code runs inside a wmux
@@ -394,11 +470,19 @@ async function main() {
   const envelope = {
     kind: HOOK_TO_KIND[hookName],
     agent: 'claude',
-    agentSessionId: (payload && typeof payload.session_id === 'string') ? payload.session_id : undefined,
+    // #12235-safe: derive from the transcript filename, NOT payload.session_id.
+    agentSessionId: sessionIdFromTranscript(
+      transcriptPath,
+      (payload && typeof payload.session_id === 'string') ? payload.session_id : undefined,
+    ),
     workspaceId: envWorkspaceId,
     surfaceId: envSurfaceId,
     cwd: payloadCwd ?? process.cwd(),
-    payload: { ...(payload ?? {}), ...(usage ? { usage } : {}) },
+    payload: {
+      ...(payload ?? {}),
+      ...(usage ? { usage } : {}),
+      ...(permissionMode ? { permissionMode } : {}),
+    },
     ts: Date.now(),
   };
 
@@ -409,8 +493,11 @@ async function main() {
   if (process.env.WMUX_BRIDGE_DEBUG === '1') {
     const { payload: envelopePayload, ...envelopeMeta } = envelope;
     const usageOnly = envelopePayload && envelopePayload.usage ? { usage: envelopePayload.usage } : {};
+    const permOnly = envelopePayload && envelopePayload.permissionMode
+      ? { permissionMode: envelopePayload.permissionMode }
+      : {};
     process.stderr.write(
-      `WMUX_BRIDGE_DEBUG_ENVELOPE=${JSON.stringify({ ...envelopeMeta, payloadKeys: Object.keys(envelopePayload ?? {}), ...usageOnly })}\n`,
+      `WMUX_BRIDGE_DEBUG_ENVELOPE=${JSON.stringify({ ...envelopeMeta, payloadKeys: Object.keys(envelopePayload ?? {}), ...usageOnly, ...permOnly })}\n`,
     );
   }
 

--- a/integrations/shared/__tests__/signal-types.test.ts
+++ b/integrations/shared/__tests__/signal-types.test.ts
@@ -86,4 +86,19 @@ describe('isAgentSignal', () => {
     expect(isAgentSignal({ ...valid, workspaceId: 42 })).toBe(false);
     expect(isAgentSignal({ ...valid, surfaceId: { id: 'x' } })).toBe(false);
   });
+
+  // X6 ③: per-pane routing key (WMUX_PTY_ID env).
+  it('accepts a valid ptyId', () => {
+    expect(isAgentSignal({ ...valid, ptyId: 'daemon-978b497a' })).toBe(true);
+  });
+
+  it('rejects empty / non-string ptyId', () => {
+    expect(isAgentSignal({ ...valid, ptyId: '' })).toBe(false);
+    expect(isAgentSignal({ ...valid, ptyId: 42 })).toBe(false);
+    expect(isAgentSignal({ ...valid, ptyId: { id: 'x' } })).toBe(false);
+  });
+
+  it('a hook with no ptyId is still valid (older bridges / standalone claude)', () => {
+    expect(isAgentSignal(valid)).toBe(true);
+  });
 });

--- a/integrations/shared/signal-types.ts
+++ b/integrations/shared/signal-types.ts
@@ -48,18 +48,24 @@ export type AgentSlug = 'claude' | 'codex' | 'gemini' | 'aider' | 'opencode' | '
 /**
  * Canonical envelope. All fields are required UNLESS marked optional.
  *
- * Routing priority (daemon-side, `resolvePtyIdForSignal`):
- *   1. `workspaceId` (from WMUX_WORKSPACE_ID env, set by wmux PTYManager)
- *      — strongest signal. When the user runs Claude inside a wmux pane,
+ * Routing priority (main-side, `resolvePtyIdForSignal`):
+ *   1. `ptyId` (from WMUX_PTY_ID env, injected by the daemon at spawn) —
+ *      EXACT per-pane key. Trusted only when it still maps to a live
+ *      workspace pane. Resolves the multi-pane-in-one-workspace and
+ *      shared-cwd cases that workspaceId+cwd alone collapse (every pane's
+ *      hook would otherwise route to the workspace's active surface).
+ *   2. `workspaceId` (from WMUX_WORKSPACE_ID env, set by wmux PTYManager)
+ *      — strong signal. When the user runs Claude inside a wmux pane,
  *      the env propagates through Claude Code's subprocess spawn and
- *      lands here. Routing is deterministic regardless of cwd overlap
- *      between workspaces.
- *   2. `surfaceId` (from WMUX_SURFACE_ID env) — refines workspaceId when
- *      a workspace has multiple surfaces. Optional even when workspaceId
- *      is present.
+ *      lands here. Deterministic regardless of cwd overlap between
+ *      workspaces, but resolves only to the workspace's active surface.
  *   3. `cwd` — fallback for sessions started outside a wmux pane, OR
  *      for older bridges that don't fill the env fields. Resolved via
  *      exact + longest-prefix match against `workspace.metadata.cwd`.
+ *
+ * `surfaceId` is carried for forensic continuity but is NOT a routing key:
+ * the renderer mints a surface only AFTER pty.create returns, so WMUX_SURFACE_ID
+ * is never actually injected into the pane env. WMUX_PTY_ID supersedes it.
  *
  * Bridges MUST set `cwd` (workflow user expects), MAY set `workspaceId` /
  * `surfaceId` when the env is available. Codex round 1 P1 #7 + user
@@ -83,6 +89,15 @@ export interface AgentSignal {
   workspaceId?: string;
   /** WMUX_SURFACE_ID env value. Refines workspaceId for multi-surface workspaces. */
   surfaceId?: string;
+  /**
+   * X6 ③: WMUX_PTY_ID env value — the EXACT daemon session id of the pane the
+   * hook fired from, injected by the daemon at spawn. The strongest routing key:
+   * when present and still live, it pins the capture to the exact pane, fixing
+   * the split-workspace / shared-cwd collapse where workspaceId+cwd alone route
+   * every pane's hook to the workspace's active surface. (surfaceId is never set
+   * in practice — the renderer mints a surface only AFTER pty.create returns.)
+   */
+  ptyId?: string;
   cwd: string;
   payload: Record<string, unknown>;
   ts: number;
@@ -140,5 +155,6 @@ export function isAgentSignal(value: unknown): value is AgentSignal {
   // by sending an obviously-bad workspaceId.
   if (v['workspaceId'] !== undefined && (typeof v['workspaceId'] !== 'string' || v['workspaceId'].length === 0)) return false;
   if (v['surfaceId'] !== undefined && (typeof v['surfaceId'] !== 'string' || v['surfaceId'].length === 0)) return false;
+  if (v['ptyId'] !== undefined && (typeof v['ptyId'] !== 'string' || v['ptyId'].length === 0)) return false;
   return true;
 }

--- a/scripts/verify-bridge-resume-capture.mjs
+++ b/scripts/verify-bridge-resume-capture.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// Dynamic verification for X6 ③ (resume-by-id) bridge capture:
+//   - agentSessionId is derived from basename(transcript_path) WITHOUT the
+//     .jsonl extension, NOT payload.session_id (upstream #12235: `--resume`
+//     mints a new session_id but appends to the same transcript file, so the
+//     filename is the only stable handle on the ORIGIN conversation).
+//   - permissionMode is extracted from the LAST user turn of the transcript
+//     (F5), for Stop AND SessionStart kinds (live capture, not teardown).
+//   - SessionStart before the transcript exists (F9) still yields the id, with
+//     permissionMode absent until the first turn lands.
+//
+// Strategy mirrors verify-bridge-env-capture.mjs: spawn the bridge with
+// WMUX_BRIDGE_DEBUG=1, feed a hook JSON on stdin, parse the
+// WMUX_BRIDGE_DEBUG_ENVELOPE=... line from stderr. The envelope dump happens
+// before the RPC, so no daemon is required. Exits 0 on all passing, 1 on any
+// mismatch.
+
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, basename, join } from 'node:path';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BRIDGE = resolve(__dirname, '..', 'integrations', 'claude', 'bin', 'wmux-bridge.mjs');
+
+const tmpHome = mkdtempSync(join(tmpdir(), 'wmux-bridge-resume-'));
+writeFileSync(join(tmpHome, '.wmux-auth-token'), 'fake-verification-token');
+
+// A transcript JSONL line for a user turn stamped with a permission mode (F5).
+const userLine = (mode) =>
+  JSON.stringify({
+    type: 'user',
+    message: { role: 'user', content: 'hi' },
+    permissionMode: mode,
+    cwd: 'C:\\fake',
+    version: '2.1.177',
+    gitBranch: 'main',
+  });
+const assistantLine = () =>
+  JSON.stringify({ type: 'assistant', message: { role: 'assistant', usage: { input_tokens: 1, output_tokens: 1 } } });
+
+function writeTranscript(name, lines) {
+  const p = join(tmpHome, name);
+  writeFileSync(p, lines.join('\n') + '\n');
+  return p;
+}
+
+const ORIGIN_ID = '86b7e519-aaaa-bbbb-cccc-000000000001';
+const bypassTranscript = writeTranscript(`${ORIGIN_ID}.jsonl`, [userLine('bypassPermissions'), assistantLine()]);
+// Last user turn wins: starts in bypass, switches to acceptEdits.
+const switchTranscript = writeTranscript('switch-mode-session.jsonl', [
+  userLine('bypassPermissions'),
+  assistantLine(),
+  userLine('acceptEdits'),
+]);
+const nonexistentTranscript = join(tmpHome, 'never-written-yet-session.jsonl');
+
+const cases = [
+  {
+    name: '#12235: id = transcript basename, NOT payload.session_id',
+    hook: 'Stop',
+    payload: { session_id: 'DRIFTED-on-resume-9999', transcript_path: bypassTranscript, cwd: 'C:\\fake' },
+    expect: { agentSessionId: ORIGIN_ID, permissionMode: 'bypassPermissions' },
+  },
+  {
+    name: 'permissionMode = last user turn (acceptEdits overrides earlier bypass)',
+    hook: 'Stop',
+    payload: { session_id: 's2', transcript_path: switchTranscript, cwd: 'C:\\fake' },
+    expect: { agentSessionId: 'switch-mode-session', permissionMode: 'acceptEdits' },
+  },
+  {
+    name: 'SessionStart also captures (id + mode)',
+    hook: 'SessionStart',
+    payload: { session_id: 's3', transcript_path: bypassTranscript, cwd: 'C:\\fake' },
+    expect: { agentSessionId: ORIGIN_ID, permissionMode: 'bypassPermissions' },
+  },
+  {
+    name: 'F9: SessionStart before transcript exists → id present, mode absent',
+    hook: 'SessionStart',
+    payload: { session_id: 's4', transcript_path: nonexistentTranscript, cwd: 'C:\\fake' },
+    expect: { agentSessionId: basename(nonexistentTranscript).replace(/\.jsonl$/, ''), permissionMode: undefined },
+  },
+];
+
+let failures = 0;
+for (const tc of cases) {
+  const childEnv = { PATH: process.env.PATH, USERPROFILE: tmpHome, HOME: tmpHome, WMUX_BRIDGE_DEBUG: '1' };
+  const proc = spawn(process.execPath, [BRIDGE, tc.hook], { env: childEnv, stdio: ['pipe', 'pipe', 'pipe'] });
+  proc.stdin.write(JSON.stringify(tc.payload));
+  proc.stdin.end();
+  let stderr = '';
+  proc.stderr.on('data', (b) => { stderr += b.toString(); });
+  // eslint-disable-next-line no-await-in-loop
+  await new Promise((res) => proc.on('close', res));
+  const match = /WMUX_BRIDGE_DEBUG_ENVELOPE=(.+)/.exec(stderr);
+  if (!match) {
+    console.error(`FAIL [${tc.name}] — no debug envelope. stderr:\n${stderr.slice(0, 400)}`);
+    failures += 1;
+    continue;
+  }
+  let envelope;
+  try {
+    envelope = JSON.parse(match[1]);
+  } catch (err) {
+    console.error(`FAIL [${tc.name}] — bad envelope JSON: ${String(err)}`);
+    failures += 1;
+    continue;
+  }
+  const checks = Object.entries(tc.expect).map(([k, v]) => ({ k, expected: v, actual: envelope[k], ok: envelope[k] === v }));
+  if (checks.every((c) => c.ok)) {
+    console.log(`PASS [${tc.name}] — agentSessionId=${envelope.agentSessionId}, permissionMode=${envelope.permissionMode ?? 'undef'}`);
+  } else {
+    failures += 1;
+    console.error(`FAIL [${tc.name}]`);
+    for (const c of checks) if (!c.ok) console.error(`  - ${c.k}: expected ${JSON.stringify(c.expected)}, got ${JSON.stringify(c.actual)}`);
+  }
+}
+
+rmSync(tmpHome, { recursive: true, force: true });
+if (failures > 0) {
+  console.error(`\n${failures} case(s) failed.`);
+  process.exit(1);
+}
+console.log('\nAll bridge resume-capture cases passed.');

--- a/scripts/x6-multipane-resume-dogfood.mjs
+++ b/scripts/x6-multipane-resume-dogfood.mjs
@@ -1,0 +1,410 @@
+#!/usr/bin/env node
+/**
+ * X6 ③ ALL-PANE resume reliability — daemon KILL-REAL dogfood.
+ *
+ * The existing x6-resume-binding-dogfood.mjs proves the SINGLE-session happy
+ * path: a live banner sets lastDetectedAgent and a manual setResumeBinding is
+ * captured. It cannot reproduce the ACTUAL reported bug — "only the first
+ * workspace's pill survives a reboot" — because it seeds the capture it is
+ * meant to verify. This harness drives the real bundled daemon through the two
+ * dominant failure modes the eng-review found, in isolated HOMEs:
+ *
+ *   A. Rung 0 — the daemon stamps WMUX_PTY_ID into each pane's env (the per-pane
+ *      routing key the hook bridge echoes back; surfaceId is never injected).
+ *   B. Rung 1 — a pane whose live banner was NEVER detected (silent shell) but
+ *      whose setResumeBinding hook lands STILL gets lastDetectedAgent='claude',
+ *      so the pill appears after reboot with the EXACT binding. (Pre-fix: no
+ *      banner -> no pill, even though the exact uuid was captured.)
+ *   C. Rung 3 — TWO panes in the SAME cwd, each with a spool record (simulating
+ *      a failed live RPC: main pipe down at capture) keyed by its EXACT ptyId
+ *      with a DIFFERENT uuid. After reboot each pane resumes its OWN uuid — pane
+ *      B never inherits pane A's conversation. The headline shared-cwd
+ *      correctness that cwd-only inference cannot achieve.
+ *   D. Rung 3 guard — a spool record OLDER than a live binding does NOT clobber
+ *      it (a stale spool can't overwrite a fresher live capture).
+ *   E. Rung 3 guards — a spool record whose transcript is purged (D5) or whose
+ *      cwd mismatches the pane (F7) is dropped, never surfaced as a bad --resume.
+ *
+ * PASS on all = the all-pane reliability rungs hold on the real bundle.
+ */
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DAEMON_BUNDLE = path.join(REPO_ROOT, 'dist', 'daemon-bundle', 'index.js');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function makePipeName(tag) {
+  return process.platform === 'win32'
+    ? `\\\\.\\pipe\\wmux-test-${tag}`
+    : path.join(os.tmpdir(), `wmux-test-${tag}.sock`);
+}
+
+function writeConfig(wmuxDir, pipeName, authToken) {
+  fs.writeFileSync(path.join(wmuxDir, 'config.json'), JSON.stringify({
+    version: 1,
+    daemon: { pipeName, logLevel: 'warn', autoStart: true },
+    session: {
+      defaultShell: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
+      defaultCols: 80, defaultRows: 24, bufferSizeMb: 8, bufferMaxMb: 64,
+      deadSessionTtlHours: 24, deadSessionDumpBuffer: true,
+    },
+  }, null, 2));
+  fs.writeFileSync(path.join(wmuxDir, 'daemon-auth-token'), authToken, 'utf-8');
+}
+
+function spawnDaemon(testHome) {
+  return spawn(process.execPath, [DAEMON_BUNDLE], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, USERPROFILE: testHome, HOME: testHome, HOMEDRIVE: undefined, HOMEPATH: undefined },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+async function waitForPipeFile(wmuxDir, timeoutMs = 12_000) {
+  const pipeFile = path.join(wmuxDir, 'daemon-pipe');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(pipeFile)) return fs.readFileSync(pipeFile, 'utf-8').trim();
+    await sleep(100);
+  }
+  throw new Error('daemon-pipe did not appear');
+}
+
+async function connectSocket(pipeName, retries = 40) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      return await new Promise((resolve, reject) => {
+        const s = net.createConnection(pipeName, () => resolve(s));
+        s.on('error', reject);
+      });
+    } catch (e) { if (i === retries - 1) throw e; await sleep(250); }
+  }
+}
+
+function rpc(socket, method, params, authToken, timeoutMs = 30_000) {
+  return new Promise((resolve, reject) => {
+    const id = `req-${Math.random().toString(36).slice(2, 10)}`;
+    let buffer = '';
+    const handler = (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const m = JSON.parse(line);
+          if (m.id === id) {
+            socket.removeListener('data', handler);
+            m.ok ? resolve(m.result) : reject(new Error(m.error ?? 'rpc error'));
+            return;
+          }
+        } catch { /* ignore */ }
+      }
+    };
+    socket.on('data', handler);
+    socket.write(JSON.stringify({ id, method, params, token: authToken }) + '\n');
+    setTimeout(() => { socket.removeListener('data', handler); reject(new Error(`rpc timeout: ${method}`)); }, timeoutMs);
+  });
+}
+
+function readSessions(wmuxDir) {
+  const f = path.join(wmuxDir, 'sessions.json');
+  if (!fs.existsSync(f)) return [];
+  const j = JSON.parse(fs.readFileSync(f, 'utf-8'));
+  return Array.isArray(j) ? j : (j.sessions || []);
+}
+
+function markPidDeadAndClearPipe(wmuxDir, sessionIds) {
+  // A real reboot kills every process; here we SIGKILL only the daemon, so the
+  // orphaned shim children stay alive and the next daemon would RECONNECT, not
+  // RECOVER. Force the recovery branch by marking each pid dead, and remove the
+  // stale daemon-pipe so the next daemon's fresh pipe is picked up.
+  try {
+    const f = path.join(wmuxDir, 'sessions.json');
+    const j = JSON.parse(fs.readFileSync(f, 'utf-8'));
+    const arr = Array.isArray(j) ? j : (j.sessions || []);
+    for (const id of sessionIds) {
+      const t = arr.find((s) => s && s.id === id);
+      if (t) t.pid = 999999;
+    }
+    fs.writeFileSync(f, JSON.stringify(j, null, 2));
+  } catch { /* ignore */ }
+  try { fs.unlinkSync(path.join(wmuxDir, 'daemon-pipe')); } catch { /* ignore */ }
+}
+
+// Idle shell: NEVER prints a claude banner. The whole point of cases B/C is that
+// the live AgentDetector gate never fires, so lastDetectedAgent must come from a
+// hook (Rung 1) or the spool (Rung 3), not the banner.
+function writeSilentShim(shimDir) {
+  let shimCmd;
+  if (process.platform === 'win32') {
+    shimCmd = path.join(shimDir, 'silent.cmd');
+    fs.writeFileSync(shimCmd, `@echo off\r\n:loop\r\nping -n 3600 127.0.0.1 >nul\r\ngoto loop\r\n`);
+  } else {
+    shimCmd = path.join(shimDir, 'silent.sh');
+    fs.writeFileSync(shimCmd, `#!/bin/sh\nwhile true; do sleep 3600; done\n`);
+    fs.chmodSync(shimCmd, 0o755);
+  }
+  return shimCmd;
+}
+
+async function killDaemon(d) {
+  d.kill('SIGKILL');
+  await new Promise((r) => { d.on('exit', r); setTimeout(r, 6000); });
+  await sleep(400);
+}
+
+let testHomes = [];
+function makeHome(tag) {
+  const testHome = path.join(os.tmpdir(), `wmux-mp-${tag}`);
+  const wmuxDir = path.join(testHome, '.wmux');
+  const shimDir = path.join(testHome, 'shim');
+  const projDir = path.join(testHome, 'proj');
+  const tx = path.join(testHome, 'transcripts');
+  for (const d of [wmuxDir, shimDir, projDir, tx]) fs.mkdirSync(d, { recursive: true });
+  testHomes.push(testHome);
+  return { testHome, wmuxDir, shimDir, projDir, tx };
+}
+
+function writeTranscript(txDir, name, mode = 'bypassPermissions') {
+  const p = path.join(txDir, name);
+  fs.writeFileSync(p, JSON.stringify({ type: 'user', permissionMode: mode }) + '\n');
+  return p;
+}
+
+// Write a bridge-shaped spool record (what wmux-bridge.mjs drops on a failed RPC).
+function writeSpool(wmuxDir, record) {
+  const dir = path.join(wmuxDir, 'resume-spool');
+  fs.mkdirSync(dir, { recursive: true });
+  const safe = String(record.ptyId).replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 80);
+  fs.writeFileSync(path.join(dir, `${safe}.json`), JSON.stringify(record));
+}
+
+const results = [];
+const record = (name, pass, detail) => {
+  results.push({ name, pass });
+  console.log(`  ${pass ? 'PASS' : 'FAIL'} — ${name}${detail ? `  (${detail})` : ''}`);
+};
+
+async function bootDaemon(h, tag) {
+  const d = spawnDaemon(h.testHome);
+  const resolved = await waitForPipeFile(h.wmuxDir);
+  const sock = await connectSocket(resolved);
+  return { d, sock };
+}
+
+async function recover(h) {
+  const d = spawnDaemon(h.testHome);
+  const resolved = await waitForPipeFile(h.wmuxDir);
+  const sock = await connectSocket(resolved);
+  await sleep(3500); // recoverSessions + spool ingest
+  return { d, sock };
+}
+
+function findSession(list, id) {
+  const arr = Array.isArray(list) ? list : (list?.sessions || []);
+  return arr.find((s) => s && s.id === id);
+}
+
+async function shutdown(sock, d, authToken) {
+  await rpc(sock, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
+  sock.destroy();
+  await new Promise((r) => { d.on('exit', r); setTimeout(r, 5000); });
+}
+
+async function main() {
+  if (!fs.existsSync(DAEMON_BUNDLE)) {
+    console.log('FAIL — daemon bundle missing; run npm run build:daemon');
+    process.exit(2);
+  }
+  console.log('\n=== X6 ③ MULTI-PANE / MISSED-CAPTURE RESUME DOGFOOD (real bundle) ===\n');
+
+  // ---- Case A: Rung 0 — WMUX_PTY_ID stamped into the pane env ----
+  {
+    const tag = `A-${randomUUID().slice(0, 4)}`;
+    const h = makeHome(tag);
+    const shim = writeSilentShim(h.shimDir);
+    const authToken = randomUUID();
+    writeConfig(h.wmuxDir, makePipeName(tag), authToken);
+    const id = `mpA-${tag}`;
+    const { d, sock } = await bootDaemon(h, tag);
+    await rpc(sock, 'daemon.createSession', { id, cmd: shim, cwd: h.projDir, cols: 80, rows: 24 }, authToken);
+    await sleep(800);
+    const onDisk = findSession(readSessions(h.wmuxDir), id);
+    const stamped = onDisk?.env?.WMUX_PTY_ID;
+    record('A  daemon stamps WMUX_PTY_ID = session id into the pane env (Rung 0)',
+      stamped === id, `env.WMUX_PTY_ID=${stamped ?? '<absent>'} expected=${id}`);
+    await shutdown(sock, d, authToken);
+  }
+
+  // ---- Case B: Rung 1 — hook arms the pill gate with NO live banner ----
+  {
+    const tag = `B-${randomUUID().slice(0, 4)}`;
+    const h = makeHome(tag);
+    const shim = writeSilentShim(h.shimDir);
+    const authToken = randomUUID();
+    writeConfig(h.wmuxDir, makePipeName(tag), authToken);
+    const id = `mpB-${tag}`;
+    const uuid = randomUUID();
+    const tx = writeTranscript(h.tx, 'B-origin.jsonl');
+    const { d, sock } = await bootDaemon(h, tag);
+    await rpc(sock, 'daemon.createSession', { id, cmd: shim, cwd: h.projDir, cols: 80, rows: 24 }, authToken);
+    await sleep(1500); // silent shell — the banner gate NEVER fires
+    const before = findSession(readSessions(h.wmuxDir), id);
+    const noBanner = !before?.lastDetectedAgent;
+    // The hook lands (live capture path) even though no banner was seen.
+    await rpc(sock, 'daemon.setResumeBinding', {
+      id,
+      resumeBinding: { agent: 'claude', sessionId: uuid, cwd: h.projDir, permissionMode: 'bypassPermissions', transcriptPath: tx, ts: Date.now() },
+    }, authToken);
+    await sleep(400);
+    const after = findSession(readSessions(h.wmuxDir), id);
+    record('B1 no live banner → lastDetectedAgent unset until the hook lands',
+      noBanner, `before.lastDetectedAgent=${before?.lastDetectedAgent ?? '<unset>'}`);
+    record('B2 setResumeBinding ALSO arms lastDetectedAgent (Rung 1, pill 2nd writer)',
+      after?.lastDetectedAgent === 'claude', `after.lastDetectedAgent=${after?.lastDetectedAgent ?? '<unset>'}`);
+
+    sock.destroy();
+    await killDaemon(d);
+    markPidDeadAndClearPipe(h.wmuxDir, [id]);
+    const r = await recover(h);
+    const list = await rpc(r.sock, 'daemon.listSessions', {}, authToken).catch((e) => ({ err: e.message }));
+    const got = findSession(list, id);
+    record('B3 after reboot the pill + EXACT binding surface for a banner-less pane',
+      got?.resumeAgent === 'claude' && got?.resumeBinding?.sessionId === uuid,
+      `resumeAgent=${got?.resumeAgent}, id=${got?.resumeBinding?.sessionId?.slice(0, 8)}`);
+    await shutdown(r.sock, r.d, authToken);
+  }
+
+  // ---- Case C: Rung 3 — two panes, SAME cwd, spool → each its OWN uuid ----
+  {
+    const tag = `C-${randomUUID().slice(0, 4)}`;
+    const h = makeHome(tag);
+    const shim = writeSilentShim(h.shimDir);
+    const authToken = randomUUID();
+    writeConfig(h.wmuxDir, makePipeName(tag), authToken);
+    const idA = `mpC-A-${tag}`;
+    const idB = `mpC-B-${tag}`;
+    const uuidA = randomUUID();
+    const uuidB = randomUUID();
+    const txA = writeTranscript(h.tx, 'C-A.jsonl');
+    const txB = writeTranscript(h.tx, 'C-B.jsonl');
+    const { d, sock } = await bootDaemon(h, tag);
+    // BOTH panes in the SAME cwd (h.projDir) — the exact shared-cwd scenario.
+    await rpc(sock, 'daemon.createSession', { id: idA, cmd: shim, cwd: h.projDir, cols: 80, rows: 24 }, authToken);
+    await rpc(sock, 'daemon.createSession', { id: idB, cmd: shim, cwd: h.projDir, cols: 80, rows: 24 }, authToken);
+    await sleep(800);
+    // NO live setResumeBinding — simulate both panes losing the live RPC (main
+    // pipe down at capture). The bridge instead spooled, keyed by exact ptyId.
+    writeSpool(h.wmuxDir, { ptyId: idA, agent: 'claude', sessionId: uuidA, cwd: h.projDir, transcriptPath: txA, permissionMode: 'bypassPermissions', ts: Date.now() });
+    writeSpool(h.wmuxDir, { ptyId: idB, agent: 'claude', sessionId: uuidB, cwd: h.projDir, transcriptPath: txB, permissionMode: 'plan', ts: Date.now() });
+
+    sock.destroy();
+    await killDaemon(d);
+    markPidDeadAndClearPipe(h.wmuxDir, [idA, idB]);
+    const r = await recover(h);
+    const list = await rpc(r.sock, 'daemon.listSessions', {}, authToken).catch((e) => ({ err: e.message }));
+    const gotA = findSession(list, idA);
+    const gotB = findSession(list, idB);
+    record('C1 pane A resumes its OWN uuid from the spool (per-pane attribution)',
+      gotA?.resumeAgent === 'claude' && gotA?.resumeBinding?.sessionId === uuidA,
+      `A.id=${gotA?.resumeBinding?.sessionId?.slice(0, 8)} expected=${uuidA.slice(0, 8)}`);
+    record('C2 pane B resumes its OWN uuid (NOT pane A\'s) under the SAME cwd',
+      gotB?.resumeAgent === 'claude' && gotB?.resumeBinding?.sessionId === uuidB
+        && gotB?.resumeBinding?.sessionId !== uuidA,
+      `B.id=${gotB?.resumeBinding?.sessionId?.slice(0, 8)} expected=${uuidB.slice(0, 8)}`);
+    record('C3 each pane kept its own permission mode through the spool',
+      gotA?.resumeBinding?.permissionMode === 'bypassPermissions' && gotB?.resumeBinding?.permissionMode === 'plan',
+      `A=${gotA?.resumeBinding?.permissionMode}, B=${gotB?.resumeBinding?.permissionMode}`);
+    const spoolDir = path.join(h.wmuxDir, 'resume-spool');
+    const leftover = fs.existsSync(spoolDir) ? fs.readdirSync(spoolDir).filter((f) => f.endsWith('.json')).length : 0;
+    record('C4 consumed spool records are deleted after ingest',
+      leftover === 0, `leftover=${leftover}`);
+    await shutdown(r.sock, r.d, authToken);
+  }
+
+  // ---- Case D: Rung 3 guard — a stale spool does NOT clobber a newer live binding ----
+  {
+    const tag = `D-${randomUUID().slice(0, 4)}`;
+    const h = makeHome(tag);
+    const shim = writeSilentShim(h.shimDir);
+    const authToken = randomUUID();
+    writeConfig(h.wmuxDir, makePipeName(tag), authToken);
+    const id = `mpD-${tag}`;
+    const liveUuid = randomUUID();
+    const staleUuid = randomUUID();
+    const txLive = writeTranscript(h.tx, 'D-live.jsonl');
+    const txStale = writeTranscript(h.tx, 'D-stale.jsonl');
+    const { d, sock } = await bootDaemon(h, tag);
+    await rpc(sock, 'daemon.createSession', { id, cmd: shim, cwd: h.projDir, cols: 80, rows: 24 }, authToken);
+    await sleep(600);
+    const NOW = Date.now();
+    // Live capture is the FRESH one.
+    await rpc(sock, 'daemon.setResumeBinding', {
+      id, resumeBinding: { agent: 'claude', sessionId: liveUuid, cwd: h.projDir, permissionMode: 'bypassPermissions', transcriptPath: txLive, ts: NOW },
+    }, authToken);
+    await sleep(300);
+    // An OLDER spool record (a capture from before the live one) must NOT win.
+    writeSpool(h.wmuxDir, { ptyId: id, agent: 'claude', sessionId: staleUuid, cwd: h.projDir, transcriptPath: txStale, permissionMode: 'plan', ts: NOW - 60_000 });
+
+    sock.destroy();
+    await killDaemon(d);
+    markPidDeadAndClearPipe(h.wmuxDir, [id]);
+    const r = await recover(h);
+    const list = await rpc(r.sock, 'daemon.listSessions', {}, authToken).catch((e) => ({ err: e.message }));
+    const got = findSession(list, id);
+    record('D  a stale spool does NOT clobber a newer live binding',
+      got?.resumeBinding?.sessionId === liveUuid,
+      `surfaced=${got?.resumeBinding?.sessionId?.slice(0, 8)} expected-live=${liveUuid.slice(0, 8)}`);
+    await shutdown(r.sock, r.d, authToken);
+  }
+
+  // ---- Case E: Rung 3 guards — purged transcript (D5) + cwd mismatch (F7) dropped ----
+  {
+    const tag = `E-${randomUUID().slice(0, 4)}`;
+    const h = makeHome(tag);
+    const shim = writeSilentShim(h.shimDir);
+    const authToken = randomUUID();
+    writeConfig(h.wmuxDir, makePipeName(tag), authToken);
+    const idPurged = `mpE-P-${tag}`;
+    const idCwd = `mpE-C-${tag}`;
+    const { d, sock } = await bootDaemon(h, tag);
+    await rpc(sock, 'daemon.createSession', { id: idPurged, cmd: shim, cwd: h.projDir, cols: 80, rows: 24 }, authToken);
+    await rpc(sock, 'daemon.createSession', { id: idCwd, cmd: shim, cwd: h.projDir, cols: 80, rows: 24 }, authToken);
+    await sleep(800);
+    // D5: transcriptPath points at a file that does NOT exist.
+    writeSpool(h.wmuxDir, { ptyId: idPurged, agent: 'claude', sessionId: randomUUID(), cwd: h.projDir, transcriptPath: path.join(h.tx, 'gone.jsonl'), ts: Date.now() });
+    // F7: cwd does not match the pane's cwd.
+    const txOk = writeTranscript(h.tx, 'E-ok.jsonl');
+    writeSpool(h.wmuxDir, { ptyId: idCwd, agent: 'claude', sessionId: randomUUID(), cwd: path.join(os.tmpdir(), 'some-other-dir'), transcriptPath: txOk, ts: Date.now() });
+
+    sock.destroy();
+    await killDaemon(d);
+    markPidDeadAndClearPipe(h.wmuxDir, [idPurged, idCwd]);
+    const r = await recover(h);
+    const list = await rpc(r.sock, 'daemon.listSessions', {}, authToken).catch((e) => ({ err: e.message }));
+    const gotP = findSession(list, idPurged);
+    const gotC = findSession(list, idCwd);
+    record('E1 spool with a purged transcript is NOT applied (D5)',
+      !gotP?.resumeBinding, `resumeBinding=${gotP?.resumeBinding ? 'PRESENT(bad)' : 'withheld'}`);
+    record('E2 spool with a mismatched cwd is NOT applied (F7)',
+      !gotC?.resumeBinding, `resumeBinding=${gotC?.resumeBinding ? 'PRESENT(bad)' : 'withheld'}`);
+    await shutdown(r.sock, r.d, authToken);
+  }
+
+  // cleanup
+  if (process.platform === 'win32') { try { spawn('taskkill', ['/F', '/IM', 'PING.EXE', '/T'], { stdio: 'ignore' }); } catch { /* ignore */ } }
+  for (const home of testHomes) { try { fs.rmSync(home, { recursive: true, force: true }); } catch { /* ignore */ } }
+
+  const passed = results.filter((r) => r.pass).length;
+  console.log(`\n=== ${passed}/${results.length} PASS ===`);
+  process.exit(passed === results.length ? 0 : 1);
+}
+
+main().catch((e) => { console.error('ERROR', e); process.exit(2); });

--- a/scripts/x6-multipane-resume-dogfood.mjs
+++ b/scripts/x6-multipane-resume-dogfood.mjs
@@ -154,9 +154,23 @@ function writeSilentShim(shimDir) {
   return shimCmd;
 }
 
+// Wait for a child to actually exit; on timeout force-SIGKILL so we never proceed
+// with an orphan daemon still holding the pipe (which would make later cases
+// nondeterministic — CodeRabbit). A short grace after the kill guarantees we don't
+// hang if the 'exit' event is missed.
+async function waitForExitOrKill(proc, timeoutMs = 6000) {
+  if (proc.exitCode !== null) return;
+  await new Promise((resolve) => {
+    let settled = false;
+    const done = () => { if (!settled) { settled = true; resolve(); } };
+    const hard = setTimeout(() => { try { proc.kill('SIGKILL'); } catch { /* already dead */ } setTimeout(done, 1500); }, timeoutMs);
+    proc.once('exit', () => { clearTimeout(hard); done(); });
+  });
+}
+
 async function killDaemon(d) {
   d.kill('SIGKILL');
-  await new Promise((r) => { d.on('exit', r); setTimeout(r, 6000); });
+  await waitForExitOrKill(d, 6000);
   await sleep(400);
 }
 
@@ -215,7 +229,7 @@ function findSession(list, id) {
 async function shutdown(sock, d, authToken) {
   await rpc(sock, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
   sock.destroy();
-  await new Promise((r) => { d.on('exit', r); setTimeout(r, 5000); });
+  await waitForExitOrKill(d, 5000);
 }
 
 async function main() {

--- a/scripts/x6-resume-binding-dogfood.mjs
+++ b/scripts/x6-resume-binding-dogfood.mjs
@@ -153,9 +153,23 @@ function writeShim(shimDir, marker) {
   return shimCmd;
 }
 
+// Wait for a child to actually exit; on timeout force-SIGKILL so we never proceed
+// with an orphan daemon still holding the pipe (which would make later cases
+// nondeterministic — CodeRabbit). A short grace after the kill avoids hanging if
+// the 'exit' event is missed.
+async function waitForExitOrKill(proc, timeoutMs = 6000) {
+  if (proc.exitCode !== null) return;
+  await new Promise((resolve) => {
+    let settled = false;
+    const done = () => { if (!settled) { settled = true; resolve(); } };
+    const hard = setTimeout(() => { try { proc.kill('SIGKILL'); } catch { /* already dead */ } setTimeout(done, 1500); }, timeoutMs);
+    proc.once('exit', () => { clearTimeout(hard); done(); });
+  });
+}
+
 async function killDaemon(d) {
   d.kill('SIGKILL');
-  await new Promise((r) => { d.on('exit', r); setTimeout(r, 6000); });
+  await waitForExitOrKill(d, 6000);
   await sleep(400);
 }
 
@@ -253,7 +267,7 @@ async function main() {
       `disk-after-recover1.permissionMode=${onDisk2?.resumeBinding?.permissionMode ?? '<absent>'}, surfaced=${got3?.resumeBinding?.permissionMode ?? '<absent>'}`);
     await rpc(r3.sock, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
     r3.sock.destroy();
-    await new Promise((r) => { r3.d.on('exit', r); setTimeout(r, 5000); });
+    await waitForExitOrKill(r3.d, 5000);
   }
 
   // ---- Case C: sticky permissionMode (codex #1) ----
@@ -292,7 +306,7 @@ async function main() {
       `resumeAgent=${got2?.resumeAgent}, resumeBinding=${got2?.resumeBinding ? 'PRESENT(bad)' : 'withheld'}`);
     await rpc(r2.sock, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
     r2.sock.destroy();
-    await new Promise((r) => { r2.d.on('exit', r); setTimeout(r, 5000); });
+    await waitForExitOrKill(r2.d, 5000);
   }
 
   // ---- Case E: cwd-guard (F7) — binding.cwd ≠ session.cwd → not surfaced ----
@@ -310,7 +324,7 @@ async function main() {
       `resumeBinding=${got2?.resumeBinding ? 'PRESENT(bad)' : 'withheld'}`);
     await rpc(r2.sock, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
     r2.sock.destroy();
-    await new Promise((r) => { r2.d.on('exit', r); setTimeout(r, 5000); });
+    await waitForExitOrKill(r2.d, 5000);
   }
 
   // cleanup

--- a/scripts/x6-resume-binding-dogfood.mjs
+++ b/scripts/x6-resume-binding-dogfood.mjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+/**
+ * X6 ③ resume-by-id — daemon KILL-REAL dogfood (the deterministic half).
+ *
+ * Drives the REAL bundled daemon through the resume-binding capture → persist →
+ * SIGKILL(reboot) → recover path, exercising the parts print-mode can't and the
+ * two codex review fixes. Five cases, each in an isolated HOME:
+ *
+ *   A. CAPTURE+SURVIVE — createSession (shim prints `claude-code` →
+ *      lastDetectedAgent), daemon.setResumeBinding(bypass + a real transcript),
+ *      SIGKILL, recover → listSessions reports resumeAgent='claude' AND
+ *      resumeBinding with the right sessionId/permissionMode/cwd/transcriptPath.
+ *   B. 2ND-REBOOT DURABILITY (codex P2 #3) — after A's recovery, SIGKILL the
+ *      recovered daemon AGAIN with NO fresh hook, recover once more → the binding
+ *      MUST still be present (carry-forward into recovered meta before the
+ *      recovery save; without the fix it's dropped on the first recovery save).
+ *   C. STICKY permissionMode (codex P2 #1) — setResumeBinding(bypass) then
+ *      setResumeBinding(NO mode, the 64KB-tail-miss case) → on-disk meta MUST
+ *      still be bypass (a null capture must not wipe a known mode).
+ *   D. EXISTENCE-PROBE (D5) — binding with a transcript that is DELETED before
+ *      recovery → resumeBinding MUST NOT be surfaced (dead id ⇒ fall back).
+ *   E. CWD-GUARD (F7) — binding.cwd ≠ session.cwd → resumeBinding MUST NOT be
+ *      surfaced.
+ *
+ * PASS on all = the daemon half of the resume-by-id dogfood gate holds on the
+ * real bundle. The bridge envelope is covered by verify-bridge-resume-capture.mjs;
+ * the GUI pill render is the CDP layer.
+ */
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DAEMON_BUNDLE = path.join(REPO_ROOT, 'dist', 'daemon-bundle', 'index.js');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function makePipeName(tag) {
+  return process.platform === 'win32'
+    ? `\\\\.\\pipe\\wmux-test-${tag}`
+    : path.join(os.tmpdir(), `wmux-test-${tag}.sock`);
+}
+
+function writeConfig(wmuxDir, pipeName, authToken) {
+  fs.writeFileSync(path.join(wmuxDir, 'config.json'), JSON.stringify({
+    version: 1,
+    daemon: { pipeName, logLevel: 'warn', autoStart: true },
+    session: {
+      defaultShell: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
+      defaultCols: 80, defaultRows: 24, bufferSizeMb: 8, bufferMaxMb: 64,
+      deadSessionTtlHours: 24, deadSessionDumpBuffer: true,
+    },
+  }, null, 2));
+  fs.writeFileSync(path.join(wmuxDir, 'daemon-auth-token'), authToken, 'utf-8');
+}
+
+function spawnDaemon(testHome, sink) {
+  const d = spawn(process.execPath, [DAEMON_BUNDLE], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, USERPROFILE: testHome, HOME: testHome, HOMEDRIVE: undefined, HOMEPATH: undefined },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  d.stdout.on('data', (b) => sink && sink.push(b.toString()));
+  d.stderr.on('data', (b) => sink && sink.push(b.toString()));
+  return d;
+}
+
+async function waitForPipeFile(wmuxDir, timeoutMs = 12_000) {
+  const pipeFile = path.join(wmuxDir, 'daemon-pipe');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(pipeFile)) return fs.readFileSync(pipeFile, 'utf-8').trim();
+    await sleep(100);
+  }
+  throw new Error('daemon-pipe did not appear');
+}
+
+async function connectSocket(pipeName, retries = 40) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      return await new Promise((resolve, reject) => {
+        const s = net.createConnection(pipeName, () => resolve(s));
+        s.on('error', reject);
+      });
+    } catch (e) { if (i === retries - 1) throw e; await sleep(250); }
+  }
+}
+
+function rpc(socket, method, params, authToken, timeoutMs = 30_000) {
+  return new Promise((resolve, reject) => {
+    const id = `req-${Math.random().toString(36).slice(2, 10)}`;
+    let buffer = '';
+    const handler = (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const m = JSON.parse(line);
+          if (m.id === id) {
+            socket.removeListener('data', handler);
+            m.ok ? resolve(m.result) : reject(new Error(m.error ?? 'rpc error'));
+            return;
+          }
+        } catch { /* ignore */ }
+      }
+    };
+    socket.on('data', handler);
+    socket.write(JSON.stringify({ id, method, params, token: authToken }) + '\n');
+    setTimeout(() => { socket.removeListener('data', handler); reject(new Error(`rpc timeout: ${method}`)); }, timeoutMs);
+  });
+}
+
+function readSessions(wmuxDir) {
+  const f = path.join(wmuxDir, 'sessions.json');
+  if (!fs.existsSync(f)) return [];
+  const j = JSON.parse(fs.readFileSync(f, 'utf-8'));
+  return Array.isArray(j) ? j : (j.sessions || []);
+}
+
+function markPidDeadAndClearPipe(wmuxDir, sessionId) {
+  // A real reboot kills every process; here we only SIGKILL'd the daemon, so the
+  // orphaned shim child stays alive and the next daemon would RECONNECT, not
+  // RECOVER. Force the recovery branch by marking the pid dead, and remove the
+  // stale daemon-pipe so the next daemon's fresh pipe is picked up.
+  try {
+    const f = path.join(wmuxDir, 'sessions.json');
+    const j = JSON.parse(fs.readFileSync(f, 'utf-8'));
+    const arr = Array.isArray(j) ? j : (j.sessions || []);
+    const t = arr.find((s) => s && s.id === sessionId);
+    if (t) t.pid = 999999;
+    fs.writeFileSync(f, JSON.stringify(j, null, 2));
+  } catch { /* ignore */ }
+  try { fs.unlinkSync(path.join(wmuxDir, 'daemon-pipe')); } catch { /* ignore */ }
+}
+
+function writeShim(shimDir, marker) {
+  let shimCmd;
+  if (process.platform === 'win32') {
+    shimCmd = path.join(shimDir, 'agentshell.cmd');
+    fs.writeFileSync(shimCmd,
+      `@echo off\r\nif exist "${marker}" goto loop\r\necho claude-code\r\ntype nul > "${marker}"\r\n:loop\r\nping -n 3600 127.0.0.1 >nul\r\ngoto loop\r\n`);
+  } else {
+    shimCmd = path.join(shimDir, 'agentshell.sh');
+    fs.writeFileSync(shimCmd,
+      `#!/bin/sh\nif [ ! -f "${marker}" ]; then echo claude-code; : > "${marker}"; fi\nwhile true; do sleep 3600; done\n`);
+    fs.chmodSync(shimCmd, 0o755);
+  }
+  return shimCmd;
+}
+
+async function killDaemon(d) {
+  d.kill('SIGKILL');
+  await new Promise((r) => { d.on('exit', r); setTimeout(r, 6000); });
+  await sleep(400);
+}
+
+let testHomes = [];
+function makeHome(tag) {
+  const testHome = path.join(os.tmpdir(), `wmux-${tag}`);
+  const wmuxDir = path.join(testHome, '.wmux');
+  const shimDir = path.join(testHome, 'shim');
+  const projDir = path.join(testHome, 'proj');
+  const tx = path.join(testHome, 'transcripts');
+  for (const d of [wmuxDir, shimDir, projDir, tx]) fs.mkdirSync(d, { recursive: true });
+  testHomes.push(testHome);
+  return { testHome, wmuxDir, shimDir, projDir, tx };
+}
+
+const results = [];
+const record = (name, pass, detail) => { results.push({ name, pass, detail }); console.log(`  ${pass ? 'PASS' : 'FAIL'} — ${name}${detail ? `  (${detail})` : ''}`); };
+
+async function setup(tag, { bindingCwd, transcriptName = 'origin-abc.jsonl', mode = 'bypassPermissions', createTranscript = true } = {}) {
+  const h = makeHome(tag);
+  const marker = path.join(h.testHome, 'shim-ran.marker');
+  const shimCmd = writeShim(h.shimDir, marker);
+  const pipeName = makePipeName(tag);
+  const authToken = randomUUID();
+  writeConfig(h.wmuxDir, pipeName, authToken);
+  const sessionId = `x6bind-${tag}`;
+  const childEnv = { ...process.env, USERPROFILE: h.testHome, HOME: h.testHome };
+  const transcriptPath = path.join(h.tx, transcriptName);
+  if (createTranscript) {
+    fs.writeFileSync(transcriptPath, JSON.stringify({ type: 'user', permissionMode: mode }) + '\n');
+  }
+  const sink = [];
+  const d1 = spawnDaemon(h.testHome, sink);
+  let resolved = await waitForPipeFile(h.wmuxDir);
+  let sock = await connectSocket(resolved);
+  await rpc(sock, 'daemon.createSession', { id: sessionId, cmd: shimCmd, cwd: h.projDir, env: childEnv, cols: 80, rows: 24 }, authToken);
+  await sleep(2500); // shim prints claude-code → lastDetectedAgent persists
+  const sessionId_origin = randomUUID();
+  const binding = {
+    agent: 'claude',
+    sessionId: sessionId_origin,
+    cwd: bindingCwd ?? h.projDir,
+    permissionMode: mode,
+    transcriptPath,
+    ts: 1700000000000,
+  };
+  await rpc(sock, 'daemon.setResumeBinding', { id: sessionId, resumeBinding: binding }, authToken);
+  await sleep(300);
+  return { h, sock, d1, authToken, sessionId, binding, sink };
+}
+
+async function recover(h, tag) {
+  const d = spawnDaemon(h.testHome, []);
+  const resolved = await waitForPipeFile(h.wmuxDir);
+  const sock = await connectSocket(resolved);
+  await sleep(3000); // recoverSessions
+  return { d, sock };
+}
+
+async function main() {
+  if (!fs.existsSync(DAEMON_BUNDLE)) { console.log('FAIL — daemon bundle missing; run npm run build:daemon'); process.exit(2); }
+  console.log('\n=== X6 ③ RESUME-BINDING DAEMON DOGFOOD (real bundle, SIGKILL recover) ===\n');
+
+  // ---- Case A + B: capture, survive a reboot, then a SECOND reboot ----
+  {
+    const tag = `A-${randomUUID().slice(0, 4)}`;
+    const { h, sock, d1, authToken, sessionId, binding } = await setup(tag);
+    const onDisk = readSessions(h.wmuxDir).find((s) => s.id === sessionId);
+    record('A0 binding persisted to disk before kill', !!onDisk?.resumeBinding && onDisk.resumeBinding.permissionMode === 'bypassPermissions',
+      `disk.permissionMode=${onDisk?.resumeBinding?.permissionMode ?? '<absent>'}`);
+    sock.destroy();
+    await killDaemon(d1);
+    markPidDeadAndClearPipe(h.wmuxDir, sessionId);
+
+    const r2 = await recover(h, tag);
+    const list2 = await rpc(r2.sock, 'daemon.listSessions', {}, authToken).catch((e) => ({ err: e.message }));
+    const got2 = (Array.isArray(list2) ? list2 : list2?.sessions || []).find((s) => s && s.id === sessionId);
+    const a = got2?.resumeAgent === 'claude'
+      && got2?.resumeBinding?.sessionId === binding.sessionId
+      && got2?.resumeBinding?.permissionMode === 'bypassPermissions'
+      && got2?.resumeBinding?.cwd === binding.cwd;
+    record('A  capture survives reboot #1 (resumeAgent + resumeBinding correct)', a,
+      `resumeAgent=${got2?.resumeAgent}, id=${got2?.resumeBinding?.sessionId?.slice(0, 8)}, mode=${got2?.resumeBinding?.permissionMode}`);
+
+    // Case B: SECOND reboot, no fresh hook — durability fix (codex #3)
+    r2.sock.destroy();
+    await killDaemon(r2.d);
+    markPidDeadAndClearPipe(h.wmuxDir, sessionId);
+    const onDisk2 = readSessions(h.wmuxDir).find((s) => s.id === sessionId);
+    const r3 = await recover(h, tag);
+    const list3 = await rpc(r3.sock, 'daemon.listSessions', {}, authToken).catch((e) => ({ err: e.message }));
+    const got3 = (Array.isArray(list3) ? list3 : list3?.sessions || []).find((s) => s && s.id === sessionId);
+    record('B  binding survives a SECOND reboot w/ no fresh hook (codex #3 durability)',
+      got3?.resumeBinding?.sessionId === binding.sessionId && got3?.resumeBinding?.permissionMode === 'bypassPermissions',
+      `disk-after-recover1.permissionMode=${onDisk2?.resumeBinding?.permissionMode ?? '<absent>'}, surfaced=${got3?.resumeBinding?.permissionMode ?? '<absent>'}`);
+    await rpc(r3.sock, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
+    r3.sock.destroy();
+    await new Promise((r) => { r3.d.on('exit', r); setTimeout(r, 5000); });
+  }
+
+  // ---- Case C: sticky permissionMode (codex #1) ----
+  {
+    const tag = `C-${randomUUID().slice(0, 4)}`;
+    const { h, sock, d1, authToken, sessionId, binding } = await setup(tag);
+    // A later Stop whose 64KB tail missed the user line → no permissionMode.
+    await rpc(sock, 'daemon.setResumeBinding', {
+      id: sessionId,
+      resumeBinding: { agent: 'claude', sessionId: binding.sessionId, cwd: binding.cwd, transcriptPath: binding.transcriptPath, ts: 1700000009999 },
+    }, authToken);
+    await sleep(300);
+    const onDisk = readSessions(h.wmuxDir).find((s) => s.id === sessionId);
+    record('C  sticky permissionMode — a null capture does NOT wipe bypass (codex #1)',
+      onDisk?.resumeBinding?.permissionMode === 'bypassPermissions',
+      `disk.permissionMode=${onDisk?.resumeBinding?.permissionMode ?? '<absent>'}`);
+    await rpc(sock, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
+    sock.destroy();
+    await killDaemon(d1);
+  }
+
+  // ---- Case D: existence-probe (D5) — purged transcript → not surfaced ----
+  {
+    const tag = `D-${randomUUID().slice(0, 4)}`;
+    const { h, sock, d1, authToken, sessionId, binding } = await setup(tag);
+    sock.destroy();
+    await killDaemon(d1);
+    markPidDeadAndClearPipe(h.wmuxDir, sessionId);
+    fs.unlinkSync(binding.transcriptPath); // purge the origin transcript
+    const r2 = await recover(h, tag);
+    const list2 = await rpc(r2.sock, 'daemon.listSessions', {}, authToken).catch((e) => ({ err: e.message }));
+    const got2 = (Array.isArray(list2) ? list2 : list2?.sessions || []).find((s) => s && s.id === sessionId);
+    // Pill still offered (resumeAgent present), but the EXACT-session binding is withheld → falls back to --continue.
+    record('D  existence-probe hides a purged binding but keeps the pill (D5)',
+      got2?.resumeAgent === 'claude' && !got2?.resumeBinding,
+      `resumeAgent=${got2?.resumeAgent}, resumeBinding=${got2?.resumeBinding ? 'PRESENT(bad)' : 'withheld'}`);
+    await rpc(r2.sock, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
+    r2.sock.destroy();
+    await new Promise((r) => { r2.d.on('exit', r); setTimeout(r, 5000); });
+  }
+
+  // ---- Case E: cwd-guard (F7) — binding.cwd ≠ session.cwd → not surfaced ----
+  {
+    const tag = `E-${randomUUID().slice(0, 4)}`;
+    const { h, sock, d1, authToken, sessionId } = await setup(tag, { bindingCwd: path.join(os.tmpdir(), 'some-other-dir') });
+    sock.destroy();
+    await killDaemon(d1);
+    markPidDeadAndClearPipe(h.wmuxDir, sessionId);
+    const r2 = await recover(h, tag);
+    const list2 = await rpc(r2.sock, 'daemon.listSessions', {}, authToken).catch((e) => ({ err: e.message }));
+    const got2 = (Array.isArray(list2) ? list2 : list2?.sessions || []).find((s) => s && s.id === sessionId);
+    record('E  cwd-guard withholds a mismatched-cwd binding (F7)',
+      got2?.resumeAgent === 'claude' && !got2?.resumeBinding,
+      `resumeBinding=${got2?.resumeBinding ? 'PRESENT(bad)' : 'withheld'}`);
+    await rpc(r2.sock, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
+    r2.sock.destroy();
+    await new Promise((r) => { r2.d.on('exit', r); setTimeout(r, 5000); });
+  }
+
+  // cleanup
+  if (process.platform === 'win32') { try { spawn('taskkill', ['/F', '/IM', 'PING.EXE', '/T'], { stdio: 'ignore' }); } catch { /* ignore */ } }
+  for (const home of testHomes) { try { fs.rmSync(home, { recursive: true, force: true }); } catch { /* ignore */ } }
+
+  const passed = results.filter((r) => r.pass).length;
+  console.log(`\n=== ${passed}/${results.length} PASS ===`);
+  process.exit(passed === results.length ? 0 : 1);
+}
+
+main().catch((e) => { console.error('ERROR', e); process.exit(2); });

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -13,6 +13,7 @@ import { buildExecArgs } from './execWrapper';
 import { buildSafeChildEnv } from '../shared/envFilter';
 import { isMac } from '../shared/platform';
 import { getWindowsDefaultShell, resolveBareShellName, resolveLaunchableWindowsExe } from '../shared/shellResolution';
+import { ENV_KEYS } from '../shared/constants';
 import { createDefaultConfig } from './config';
 
 const DEFAULT_COLS = 80;
@@ -237,6 +238,16 @@ export class DaemonSessionManager extends EventEmitter {
     const env = params.env
       ? stripReservedAuth(params.env)
       : stripReservedNamespace(buildSafeChildEnv(globalThis.process.env));
+
+    // X6 ③: stamp the pane's own daemon session id into its env so the Claude
+    // hook bridge can attribute its resume-binding capture to the EXACT pane
+    // (per-pane routing). The daemon is the only layer that knows this id at
+    // spawn time — the renderer cannot supply a surfaceId at pty.create because
+    // a surface is minted only AFTER the pty exists, so WMUX_SURFACE_ID never
+    // reaches the shell. Set AFTER the reserved-namespace strip so it survives;
+    // recovery replays meta.env (and re-stamps the same id), keeping it stable
+    // across reboot. This is the join key the spool ingest matches on.
+    env[ENV_KEYS.PTY_ID] = params.id;
 
     let spawnArgs: string[] = [];
     if (params.exec) {

--- a/src/daemon/__tests__/x6ResumeDurability.test.ts
+++ b/src/daemon/__tests__/x6ResumeDurability.test.ts
@@ -147,4 +147,58 @@ describe('X6 ② reboot-survival durability', () => {
     // Same cwd must early-return before mutating meta / emitting / persisting.
     expect(body).toMatch(/if \(meta\.cwd === payload\.cwd\) return;/);
   });
+
+  // --- X6 ③ all-pane reliability guards (Rung 0/1/3) ------------------------
+
+  it('Rung 1: setResumeBinding ALSO arms lastDetectedAgent (pill 2nd writer)', () => {
+    // The pill must not be hostage to the once-per-session live banner. A
+    // captured hook binding proves the pane ran claude, so it sets the pill gate
+    // too — otherwise a banner-missed-but-hook-landed pane holds the exact uuid
+    // yet shows NO pill after reboot. Lock the write into the handler.
+    const src = fs.readFileSync(daemonIndexPath, 'utf-8');
+    const idx = src.indexOf("onRpc('daemon.setResumeBinding'");
+    expect(idx).toBeGreaterThan(-1);
+    const body = src.slice(idx, idx + 1600);
+    expect(body).toMatch(/lastDetectedAgent\s*=\s*next\.agent/);
+    expect(body).toMatch(/KNOWN_AGENT_SLUGS/);
+  });
+
+  it('Rung 0: the daemon stamps WMUX_PTY_ID into each pane env (per-pane routing key)', () => {
+    // surfaceId is never injected (the renderer mints a surface after pty.create),
+    // so the daemon's own session id is the one reliable per-pane key the hook
+    // bridge can echo back. Without it, every split-pane hook collapses to the
+    // workspace's active surface and bindings clobber each other.
+    const mgrPath = path.join(__dirname, '..', 'DaemonSessionManager.ts');
+    const src = fs.readFileSync(mgrPath, 'utf-8');
+    expect(src).toMatch(/env\[ENV_KEYS\.PTY_ID\]\s*=\s*params\.id/);
+  });
+
+  it('Rung 3: recoverSessions drains the resume-binding spool before surfacing the pill', () => {
+    const src = fs.readFileSync(daemonIndexPath, 'utf-8');
+    // The ingest must run inside recovery so a binding lost to a failed live RPC
+    // (main pipe down at capture) is reconciled and drives an EXACT-session pill.
+    const recIdx = src.indexOf('async function recoverSessions');
+    expect(recIdx).toBeGreaterThan(-1);
+    const recEnd = src.indexOf('\n}', src.indexOf('cleanOrphanedBuffers', recIdx));
+    const recBody = src.slice(recIdx, recEnd);
+    expect(recBody).toMatch(/ingestResumeSpool\(sessionManager, stateWriter\)/);
+    // And the pill markers are read off the LIVE recovered meta (which reflects
+    // carry-forward + spool ingest + Rung-1 gate), not the stale persisted record.
+    expect(recBody).toMatch(/for \(const recoveredId of recoveredIds\)/);
+  });
+
+  it('Rung 3: spool ingest guards — F7 cwd-match, D5 existence-probe, no stale clobber', () => {
+    const src = fs.readFileSync(daemonIndexPath, 'utf-8');
+    const idx = src.indexOf('function ingestResumeSpool');
+    expect(idx).toBeGreaterThan(-1);
+    const body = src.slice(idx, idx + 4200);
+    // Attribute by EXACT pane id, not cwd guessing.
+    expect(body).toMatch(/sessionManager\.getSession\(ptyId\)/);
+    // F7: origin cwd must match the recovered pane cwd.
+    expect(body).toMatch(/cwd !== managed\.meta\.cwd/);
+    // Never let an older spooled capture overwrite a newer live one.
+    expect(body).toMatch(/prev\.ts >= recTs/);
+    // D5: purged transcript → drop, never offer a dead --resume.
+    expect(body).toMatch(/bindingTranscriptLives\(binding\)/);
+  });
 });

--- a/src/daemon/__tests__/x6ResumeDurability.test.ts
+++ b/src/daemon/__tests__/x6ResumeDurability.test.ts
@@ -158,7 +158,7 @@ describe('X6 ② reboot-survival durability', () => {
     const src = fs.readFileSync(daemonIndexPath, 'utf-8');
     const idx = src.indexOf("onRpc('daemon.setResumeBinding'");
     expect(idx).toBeGreaterThan(-1);
-    const body = src.slice(idx, idx + 1600);
+    const body = src.slice(idx, idx + 2400);
     expect(body).toMatch(/lastDetectedAgent\s*=\s*next\.agent/);
     expect(body).toMatch(/KNOWN_AGENT_SLUGS/);
   });
@@ -185,6 +185,10 @@ describe('X6 ② reboot-survival durability', () => {
     // And the pill markers are read off the LIVE recovered meta (which reflects
     // carry-forward + spool ingest + Rung-1 gate), not the stale persisted record.
     expect(recBody).toMatch(/for \(const recoveredId of recoveredIds\)/);
+    // CodeRabbit: a spool-only binding must reach the exec REPLAY launch (which
+    // runs before ingest), so resumeLaunchCommand consults the pre-read spool map.
+    expect(recBody).toMatch(/readResumeSpoolMap\(\)/);
+    expect(recBody).toMatch(/resumeLaunchCommand\(session, spoolBindings\.get\(session\.id\)\)/);
   });
 
   it('Rung 3: spool ingest guards — F7 cwd-match, D5 existence-probe, no stale clobber', () => {
@@ -195,9 +199,11 @@ describe('X6 ② reboot-survival durability', () => {
     // Attribute by EXACT pane id, not cwd guessing.
     expect(body).toMatch(/sessionManager\.getSession\(ptyId\)/);
     // F7: origin cwd must match the recovered pane cwd.
-    expect(body).toMatch(/cwd !== managed\.meta\.cwd/);
-    // Never let an older spooled capture overwrite a newer live one.
-    expect(body).toMatch(/prev\.ts >= recTs/);
+    expect(body).toMatch(/binding\.cwd !== managed\.meta\.cwd/);
+    // Never let an older spooled capture overwrite a newer live one, and skip a
+    // same-conversation spool (codex P2).
+    expect(body).toMatch(/prev\.ts >= binding\.ts/);
+    expect(body).toMatch(/prev\.sessionId === binding\.sessionId/);
     // D5: purged transcript → drop, never offer a dead --resume.
     expect(body).toMatch(/bindingTranscriptLives\(binding\)/);
   });

--- a/src/daemon/__tests__/x6ResumeDurability.test.ts
+++ b/src/daemon/__tests__/x6ResumeDurability.test.ts
@@ -158,7 +158,7 @@ describe('X6 ② reboot-survival durability', () => {
     const src = fs.readFileSync(daemonIndexPath, 'utf-8');
     const idx = src.indexOf("onRpc('daemon.setResumeBinding'");
     expect(idx).toBeGreaterThan(-1);
-    const body = src.slice(idx, idx + 2400);
+    const body = src.slice(idx, idx + 3400);
     expect(body).toMatch(/lastDetectedAgent\s*=\s*next\.agent/);
     expect(body).toMatch(/KNOWN_AGENT_SLUGS/);
   });
@@ -198,8 +198,8 @@ describe('X6 ② reboot-survival durability', () => {
     const body = src.slice(idx, idx + 4200);
     // Attribute by EXACT pane id, not cwd guessing.
     expect(body).toMatch(/sessionManager\.getSession\(ptyId\)/);
-    // F7: origin cwd must match the recovered pane cwd.
-    expect(body).toMatch(/binding\.cwd !== managed\.meta\.cwd/);
+    // F7: origin cwd must match the recovered pane cwd (normalized — codex P2).
+    expect(body).toMatch(/normalizeResumeCwd\(binding\.cwd\) !== normalizeResumeCwd\(managed\.meta\.cwd\)/);
     // Never let an older spooled capture overwrite a newer live one, and skip a
     // same-conversation spool (codex P2).
     expect(body).toMatch(/prev\.ts >= binding\.ts/);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -979,11 +979,21 @@ function registerRpcHandlers(
       // recovery) — NOT read off the live meta, which is a fresh shell here.
       const resumeAgent = recoveredAgentShellIds.get(s.id);
       // X6 ③: the captured binding for the EXACT-session resume, also recovery-
-      // only (same transient-map reasoning as resumeAgent).
+      // only (same transient-map reasoning as resumeAgent) and guarded by the
+      // cwd-match + transcript existence-probe at recovery time.
       const resumeBinding = recoveredResumeBindings.get(s.id);
-      const withRuntime = s.supervision
-        ? { ...s, supervisionRuntime: paneSupervisor.getRuntime(s.id) }
-        : s;
+      // meta.resumeBinding is an INTERNAL durability field — it is persisted
+      // (and carried forward across consecutive recoveries) so the EXACT-session
+      // resume survives multiple reboots, but it must NOT leak to clients raw:
+      // the pill only ever gets the recovery-SURFACED binding (which passed the
+      // cwd + existence guards). Strip the meta field, then re-attach the
+      // guarded transient one. Without this strip, the carry-forward would
+      // bypass the D5/F7 guards (caught by x6-resume-binding-dogfood D/E).
+      const base = { ...s };
+      delete base.resumeBinding;
+      const withRuntime = base.supervision
+        ? { ...base, supervisionRuntime: paneSupervisor.getRuntime(s.id) }
+        : base;
       const withAgent = resumeAgent ? { ...withRuntime, resumeAgent } : withRuntime;
       return resumeBinding ? { ...withAgent, resumeBinding } : withAgent;
     });

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -209,11 +209,25 @@ function bindingTranscriptLives(binding: ResumeBinding | undefined): boolean {
   return fs.existsSync(binding.transcriptPath);
 }
 
-function resumeLaunchCommand(session: { id: string; exec?: { command: string }; cwd: string; resumeBinding?: ResumeBinding }): string | undefined {
+function resumeLaunchCommand(
+  session: { id: string; exec?: { command: string }; cwd: string; resumeBinding?: ResumeBinding },
+  spoolBinding?: ResumeBinding,
+): string | undefined {
   if (!session.exec) return undefined;
   if (!fs.existsSync(session.cwd)) return undefined; // cwd gone → fresh, not wrong-target resume
+  // Prefer the persisted binding; fall back to a spool-captured one (the live
+  // capture RPC failed, so the exact id only survived in the spool) so an exec
+  // agent pane replays as `--resume <id>` instead of an ambiguous `--continue`.
+  // The spool ingest runs AFTER this replay, so without consulting it here the
+  // exec pane would launch with --continue before the binding lands (CodeRabbit).
+  // Pick the fresher of the two by ts; toResumeCommand still applies the F7
+  // cwd-match guard, and bindingTranscriptLives is the D5 probe.
+  let binding = session.resumeBinding;
+  if (spoolBinding && (!binding || (spoolBinding.ts ?? 0) > (binding.ts ?? 0))) {
+    binding = spoolBinding;
+  }
   // D5: drop to `--continue` when the exact transcript is gone (pass no binding).
-  const usableBinding = bindingTranscriptLives(session.resumeBinding) ? session.resumeBinding : undefined;
+  const usableBinding = bindingTranscriptLives(binding) ? binding : undefined;
   const rewritten = toResumeCommand(session.exec.command, usableBinding, session.cwd);
   if (rewritten === session.exec.command) return undefined; // not a known agent launcher / already resuming
   log('info', `X6 resume: replaying session ${session.id} as resume form in ${session.cwd}`);
@@ -237,6 +251,57 @@ const KNOWN_PERMISSION_MODES: ReadonlySet<string> = new Set([
   'bypassPermissions', 'acceptEdits', 'plan', 'default',
 ]);
 
+// Validate one spool record into a {ptyId, binding} pair, or null when it is
+// malformed or names an unknown agent (a hostile / stale spool file). Shared by
+// the recovery-replay pre-read (readResumeSpoolMap) and the durable ingest.
+function spoolRecordToBinding(rec: Record<string, unknown>): { ptyId: string; binding: ResumeBinding } | null {
+  const ptyId = typeof rec.ptyId === 'string' ? rec.ptyId : null;
+  const sessionId = typeof rec.sessionId === 'string' ? rec.sessionId : null;
+  const cwd = typeof rec.cwd === 'string' ? rec.cwd : null;
+  const agent = typeof rec.agent === 'string' ? rec.agent : 'claude';
+  if (!ptyId || !sessionId || !cwd || !KNOWN_AGENT_SLUGS.has(agent)) return null;
+  const permissionMode = typeof rec.permissionMode === 'string' && KNOWN_PERMISSION_MODES.has(rec.permissionMode)
+    ? (rec.permissionMode as ResumeBinding['permissionMode'])
+    : undefined;
+  return {
+    ptyId,
+    binding: {
+      agent,
+      sessionId,
+      cwd,
+      ...(permissionMode ? { permissionMode } : {}),
+      ...(typeof rec.transcriptPath === 'string' ? { transcriptPath: rec.transcriptPath } : {}),
+      ts: typeof rec.ts === 'number' && Number.isFinite(rec.ts) ? rec.ts : 0,
+    },
+  };
+}
+
+// Read the spool into a ptyId→binding map WITHOUT consuming it (the post-recovery
+// ingestResumeSpool does the durable apply + delete). Used to feed an exec /
+// supervised pane's replay launch (resumeLaunchCommand) BEFORE ingest runs, so a
+// spool-only binding still produces `--resume <id>` instead of an ambiguous
+// `--continue` (CodeRabbit). cwd-match + D5 are applied by resumeLaunchCommand.
+function readResumeSpoolMap(): Map<string, ResumeBinding> {
+  const out = new Map<string, ResumeBinding>();
+  const dir = path.join(wmuxDir, 'resume-spool');
+  let names: string[];
+  try {
+    if (!fs.existsSync(dir)) return out;
+    names = fs.readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of names) {
+    if (!name.endsWith('.json')) continue; // skips *.json.tmp (ends with .tmp)
+    try {
+      const rec = JSON.parse(fs.readFileSync(path.join(dir, name), 'utf-8')) as Record<string, unknown>;
+      const parsed = spoolRecordToBinding(rec);
+      if (parsed) out.set(parsed.ptyId, parsed.binding);
+    } catch { /* skip corrupt — ingestResumeSpool drops it on its pass */ }
+  }
+  return out;
+}
+
 function ingestResumeSpool(
   sessionManager: DaemonSessionManager,
   stateWriter: StateWriter,
@@ -251,6 +316,17 @@ function ingestResumeSpool(
   }
   let applied = 0;
   for (const name of names) {
+    // Prune an abandoned temp from a crashed bridge write. The bridge now uses a
+    // UNIQUE temp name (pid+uuid) so a crash leaks one orphan that nothing
+    // overwrites; spool writes are atomic and instant, so anything older than a
+    // minute is dead (CodeRabbit).
+    if (name.endsWith('.json.tmp')) {
+      try {
+        const tmpPath = path.join(dir, name);
+        if (Date.now() - fs.statSync(tmpPath).mtimeMs > 60_000) fs.unlinkSync(tmpPath);
+      } catch { /* ignore */ }
+      continue;
+    }
     if (!name.endsWith('.json')) continue;
     const file = path.join(dir, name);
     const drop = (): void => { try { fs.unlinkSync(file); } catch { /* ignore */ } };
@@ -263,15 +339,11 @@ function ingestResumeSpool(
       drop(); // corrupt / partial write — never let it wedge the drain
       continue;
     }
-    const ptyId = typeof rec.ptyId === 'string' ? rec.ptyId : null;
-    const sessionId = typeof rec.sessionId === 'string' ? rec.sessionId : null;
-    const cwd = typeof rec.cwd === 'string' ? rec.cwd : null;
-    const agent = typeof rec.agent === 'string' ? rec.agent : 'claude';
-    if (!ptyId || !sessionId || !cwd) { drop(); continue; }
-    // Never persist a binding for an unknown agent (a malformed/hostile spool
-    // file). The pill gate is already bounded to KNOWN_AGENT_SLUGS; bound the
-    // durable binding the same way so downstream never sees a bogus slug (codex P2).
-    if (!KNOWN_AGENT_SLUGS.has(agent)) { drop(); continue; }
+    // Validate + bound unknown agents (codex P2): a malformed / hostile record
+    // never becomes a durable binding.
+    const parsed = spoolRecordToBinding(rec);
+    if (!parsed) { drop(); continue; }
+    const { ptyId, binding } = parsed;
 
     const managed = sessionManager.getSession(ptyId);
     if (!managed) {
@@ -282,8 +354,7 @@ function ingestResumeSpool(
     }
     // F7: `--resume` is cwd-scoped, so the capture's origin cwd must match the
     // recovered pane's cwd; a mismatch would dead-end (offer --continue instead).
-    if (cwd !== managed.meta.cwd) { drop(); continue; }
-    const recTs = typeof rec.ts === 'number' && Number.isFinite(rec.ts) ? rec.ts : 0;
+    if (binding.cwd !== managed.meta.cwd) { drop(); continue; }
     const prev = managed.meta.resumeBinding;
     // Never clobber: for a DIFFERENT conversation, only a strictly-newer spool
     // wins (ts tiebreak). For the SAME conversation the spool is redundant — its
@@ -291,33 +362,22 @@ function ingestResumeSpool(
     // keeps permissionMode sticky), and setResumeBinding's durable-change check
     // omits ts, so the persisted ts can lag a same-session live update; skipping
     // by sessionId avoids an older spool overwriting it (codex P2).
-    if (prev && (prev.sessionId === sessionId || prev.ts >= recTs)) { drop(); continue; }
+    if (prev && (prev.sessionId === binding.sessionId || prev.ts >= binding.ts)) { drop(); continue; }
 
-    const permissionMode = typeof rec.permissionMode === 'string'
-      && KNOWN_PERMISSION_MODES.has(rec.permissionMode)
-      ? (rec.permissionMode as ResumeBinding['permissionMode'])
-      : undefined;
-    const binding: ResumeBinding = {
-      agent,
-      sessionId,
-      cwd,
-      ...(permissionMode ? { permissionMode } : {}),
-      ...(typeof rec.transcriptPath === 'string' ? { transcriptPath: rec.transcriptPath } : {}),
-      ts: recTs,
-    };
     // D5: a purged origin transcript makes `--resume` a silent "No conversation
     // found." — drop the record (the pill can still degrade to --continue).
     if (!bindingTranscriptLives(binding)) { drop(); continue; }
 
     managed.meta.resumeBinding = mergeResumeBinding(prev, binding);
     // Rung 1 parity: a spooled capture also proves the pane ran claude, so it
-    // arms the pill gate even if no live banner was ever detected.
-    if (!managed.meta.lastDetectedAgent && KNOWN_AGENT_SLUGS.has(agent)) {
-      managed.meta.lastDetectedAgent = agent as AgentSlug;
+    // arms the pill gate even if no live banner was ever detected. (binding.agent
+    // is already a KNOWN_AGENT_SLUG — validated in spoolRecordToBinding.)
+    if (!managed.meta.lastDetectedAgent) {
+      managed.meta.lastDetectedAgent = binding.agent as AgentSlug;
     }
     drop();
     applied++;
-    log('info', `X6 resume-spool: ingested binding for ${ptyId} (session ${sessionId.slice(0, 8)})`);
+    log('info', `X6 resume-spool: ingested binding for ${ptyId} (session ${binding.sessionId.slice(0, 8)})`);
   }
   if (applied > 0) stateWriter.saveImmediate(buildState(sessionManager));
   return applied;
@@ -491,6 +551,11 @@ async function recoverSessions(
   const state = stateWriter.load();
   let changed = false;
   const recoveredIds = new Set<string>();
+  // X6 ③ (CodeRabbit): pre-read the spool (no consume) so an exec/supervised agent
+  // pane whose exact binding only exists in the spool replays as `--resume <id>`,
+  // not `--continue`. The post-recovery ingestResumeSpool still does the durable
+  // apply + cleanup; this just makes the binding available at replay-launch time.
+  const spoolBindings = readResumeSpoolMap();
 
   // Detect reboot: if bootId changed, all old PIDs are stale — skip kill attempts
   const currentBootId = await getBootId();
@@ -580,7 +645,7 @@ async function recoverSessions(
               exec: session.exec,
               // X6: if the exec unit is an agent, resume its conversation
               // (non-persisted launch command; meta.exec.command stays original).
-              execLaunchCommand: resumeLaunchCommand(session),
+              execLaunchCommand: resumeLaunchCommand(session, spoolBindings.get(session.id)),
               supervision: session.supervision,
               scrollbackData,
               // v2.8.1: stay muted until the renderer's first resize so PTY
@@ -662,7 +727,7 @@ async function recoverSessions(
             // X8: replay exec unit + supervision (see suspended path above).
             exec: session.exec,
             // X6: resume the agent conversation on replay (see suspended path).
-            execLaunchCommand: resumeLaunchCommand(session),
+            execLaunchCommand: resumeLaunchCommand(session, spoolBindings.get(session.id)),
             supervision: session.supervision,
             scrollbackData,
             // v2.8.1: see deferOutput rationale above (Bug 2).
@@ -706,7 +771,7 @@ async function recoverSessions(
           // X8: replay exec unit + supervision (see suspended path above).
           exec: session.exec,
           // X6: resume the agent conversation on replay (see suspended path).
-          execLaunchCommand: resumeLaunchCommand(session),
+          execLaunchCommand: resumeLaunchCommand(session, spoolBindings.get(session.id)),
           supervision: session.supervision,
           // v2.8.1: see deferOutput rationale above (Bug 2).
           deferOutput: true,
@@ -1150,8 +1215,15 @@ function registerRpcHandlers(
     const next = mergeResumeBinding(prev, p.resumeBinding);
     let durableChange = !prev
       || prev.sessionId !== next.sessionId
+      || prev.agent !== next.agent
       || prev.permissionMode !== next.permissionMode
-      || prev.cwd !== next.cwd;
+      || prev.cwd !== next.cwd
+      // transcriptPath is the D5 liveness-probe input. A SessionStart persists a
+      // binding without it (the .jsonl doesn't exist yet, F9); the first Stop
+      // fills it in with the same sessionId/cwd — without this the fill is not
+      // saveImmediate'd and a reboot loses the probe path (CodeRabbit). It only
+      // transitions once (absent → present), so no per-turn write amplification.
+      || prev.transcriptPath !== next.transcriptPath;
     managed.meta.resumeBinding = next;
     // X6 ③ (Rung 1): a captured binding PROVES claude ran in this pane, so the
     // hook is a SECOND, independent writer of the pill gate (lastDetectedAgent) —
@@ -1331,6 +1403,7 @@ function wireEvents(
     // `destroySession` log just before ⇒ wmux killed it.
     log('info', `[lifecycle] session:died id=${payload.id} reason=${payload.reason ?? 'pty-exit'} exitCode=${payload.exitCode ?? 'null'} signal=${payload.signal ?? 'none'} cmd=${payload.cmd ?? '?'} idleMsBeforeExit=${payload.lastActivityMsAgo ?? '?'} liveTotal=${sessionManager.listSessions().length}`);
     recoveredAgentShellIds.delete(payload.id); // X6 ②: drop a stale resume hint
+    recoveredResumeBindings.delete(payload.id); // X6 ③: ...and its exact binding (id reuse, CodeRabbit)
     try {
       const event: DaemonEvent = {
         type: 'session.died',
@@ -1530,6 +1603,7 @@ function wireEvents(
   // doesn't lie about a closed terminal (Codex P2).
   sessionManager.on('session:destroyed', (payload: { id: string }) => {
     recoveredAgentShellIds.delete(payload.id); // X6 ②: drop hint on explicit close too (CodeRabbit #2)
+    recoveredResumeBindings.delete(payload.id); // X6 ③: drop the exact binding too (id reuse, CodeRabbit)
     const event: DaemonEvent = {
       type: 'session.destroyed',
       sessionId: payload.id,

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -16,14 +16,13 @@ import { GitContextWatcher } from '../main/pty/gitContextWatch';
 import { PortWatcher } from '../main/pty/portWatch';
 import { initDaemonLogSink } from './util/logSink';
 import type { DaemonState } from './types';
-import type { DaemonEvent, DaemonCreateSessionParams, DaemonSessionIdParams, DaemonResizeParams } from '../shared/rpc';
+import type { DaemonEvent, DaemonCreateSessionParams, DaemonSessionIdParams, DaemonResizeParams, DaemonSetResumeBindingParams } from '../shared/rpc';
 import { monitorEventLoopDelay, performance as nodePerformance } from 'node:perf_hooks';
 import { DAEMON_EXIT_ALREADY_RUNNING } from '../shared/constants';
 import { toResumeCommand, resumeOfferForRecovered } from '../shared/agentResume';
 import type { ResumeBinding } from '../shared/agentResume';
 import { agentDisplayToSlug } from '../main/pty/AgentDetector';
 import type { AgentSlug } from '../shared/events';
-import type { DaemonSetResumeBindingParams } from '../shared/rpc';
 
 // X6 Feature ②: sessions RECOVERED this daemon boot that were running an
 // INTERACTIVE agent (non-exec, non-supervised) → ptyId → the agent slug to
@@ -630,8 +629,13 @@ async function recoverSessions(
     if (recoveredIds.has(s.id) && offer) {
       recoveredAgentShellIds.set(s.id, offer as AgentSlug);
       // X6 ③: carry the persisted binding alongside the slug so the pill can
-      // resume the EXACT session (and the cwd-match guard can run renderer-side).
-      if (s.resumeBinding) recoveredResumeBindings.set(s.id, s.resumeBinding);
+      // resume the EXACT session. Surface it ONLY when its captured cwd still
+      // matches the recovered session's cwd — `--resume` is cwd-scoped (F7), so
+      // a mismatch must not offer an id-resume; the pill then falls back to the
+      // cwd-relative `--continue`.
+      if (s.resumeBinding && s.resumeBinding.cwd === s.cwd) {
+        recoveredResumeBindings.set(s.id, s.resumeBinding);
+      }
     }
   }
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -20,8 +20,10 @@ import type { DaemonEvent, DaemonCreateSessionParams, DaemonSessionIdParams, Dae
 import { monitorEventLoopDelay, performance as nodePerformance } from 'node:perf_hooks';
 import { DAEMON_EXIT_ALREADY_RUNNING } from '../shared/constants';
 import { toResumeCommand, resumeOfferForRecovered } from '../shared/agentResume';
+import type { ResumeBinding } from '../shared/agentResume';
 import { agentDisplayToSlug } from '../main/pty/AgentDetector';
 import type { AgentSlug } from '../shared/events';
+import type { DaemonSetResumeBindingParams } from '../shared/rpc';
 
 // X6 Feature ②: sessions RECOVERED this daemon boot that were running an
 // INTERACTIVE agent (non-exec, non-supervised) → ptyId → the agent slug to
@@ -33,6 +35,13 @@ import type { AgentSlug } from '../shared/events';
 // A LIVE reconnect never enters this map, so the pill can't paste
 // `claude --continue` into a still-running agent (Codex eng review EC4).
 const recoveredAgentShellIds = new Map<string, AgentSlug>();
+
+// X6 ③: parallel to recoveredAgentShellIds — the captured resume binding for a
+// pane recovered this boot, read FROM THE PERSISTED session at recovery (the
+// live recovered meta has none yet). Surfaced on listSessions so the resume
+// pill can build `--resume <id>` for the EXACT conversation; cleared when the
+// agent relaunches (live again → no pill).
+const recoveredResumeBindings = new Map<string, ResumeBinding>();
 
 // === Constants ===
 const wmuxDir = getWmuxDir();
@@ -165,7 +174,7 @@ function log(level: string, msg: string, ...args: unknown[]): void {
 // === X6 resume on replay ===
 // Compute the NON-persisted launch command for a supervised exec session being
 // REPLAYED (recovery or supervisor restart). Returns the resume-rewritten
-// command (e.g. `claude --continue`) only when:
+// command only when:
 //   - the session is an exec unit (has `exec`), AND
 //   - its ORIGINAL cwd still exists — resume is cwd-scoped, so a homedir
 //     fallback would resume an unrelated/empty session (run fresh instead), AND
@@ -173,10 +182,18 @@ function log(level: string, msg: string, ...args: unknown[]): void {
 // Otherwise returns undefined → createSession spawns the original command.
 // The persisted meta.exec.command is never affected; first launch is never
 // touched (brand-new createSession callers don't call this).
-function resumeLaunchCommand(session: { id: string; exec?: { command: string }; cwd: string }): string | undefined {
+//
+// X6 ③: with a captured resumeBinding whose cwd still matches, the rewrite
+// targets the EXACT session (`claude --resume <id>`); otherwise it falls back to
+// `--continue` (latest-in-cwd). The permission mode is deliberately NOT restored
+// here — supervised auto-run has no human in the loop, so re-granting
+// `--dangerously-skip-permissions` silently every reboot is unsafe (D6
+// fail-safe). Permission restore happens ONLY on the pill path (explicit user
+// Enter); the trust-gated supervised auto-restore is a deferred follow-up.
+function resumeLaunchCommand(session: { id: string; exec?: { command: string }; cwd: string; resumeBinding?: ResumeBinding }): string | undefined {
   if (!session.exec) return undefined;
   if (!fs.existsSync(session.cwd)) return undefined; // cwd gone → fresh, not wrong-target resume
-  const rewritten = toResumeCommand(session.exec.command);
+  const rewritten = toResumeCommand(session.exec.command, session.resumeBinding, session.cwd);
   if (rewritten === session.exec.command) return undefined; // not a known agent launcher / already resuming
   log('info', `X6 resume: replaying session ${session.id} as resume form in ${session.cwd}`);
   return rewritten;
@@ -612,6 +629,9 @@ async function recoverSessions(
     const offer = resumeOfferForRecovered(s);
     if (recoveredIds.has(s.id) && offer) {
       recoveredAgentShellIds.set(s.id, offer as AgentSlug);
+      // X6 ③: carry the persisted binding alongside the slug so the pill can
+      // resume the EXACT session (and the cwd-match guard can run renderer-side).
+      if (s.resumeBinding) recoveredResumeBindings.set(s.id, s.resumeBinding);
     }
   }
 
@@ -923,10 +943,14 @@ function registerRpcHandlers(
       // The slug is held in the map (captured from the persisted session at
       // recovery) — NOT read off the live meta, which is a fresh shell here.
       const resumeAgent = recoveredAgentShellIds.get(s.id);
+      // X6 ③: the captured binding for the EXACT-session resume, also recovery-
+      // only (same transient-map reasoning as resumeAgent).
+      const resumeBinding = recoveredResumeBindings.get(s.id);
       const withRuntime = s.supervision
         ? { ...s, supervisionRuntime: paneSupervisor.getRuntime(s.id) }
         : s;
-      return resumeAgent ? { ...withRuntime, resumeAgent } : withRuntime;
+      const withAgent = resumeAgent ? { ...withRuntime, resumeAgent } : withRuntime;
+      return resumeBinding ? { ...withAgent, resumeBinding } : withAgent;
     });
   });
 
@@ -941,6 +965,30 @@ function registerRpcHandlers(
   pipeServer.onRpc('daemon.superviseStop', async (params) => {
     const p = params as unknown as DaemonSessionIdParams;
     return { ok: paneSupervisor.stop(p.id) };
+  });
+
+  // X6 ③: persist the resume binding captured live from the claude hook (main
+  // forwards it after env-first ptyId resolution). Always refresh the in-memory
+  // meta (ts freshness), but only saveImmediate when a DURABLE field changes
+  // (sessionId / permissionMode / cwd) — bounding sync writes to ~once per
+  // permission-mode transition, exactly like lastDetectedAgent (X6 ②). The
+  // SIGKILL-survival rule is the whole point: the binding must be on disk before
+  // a reboot, and a reboot fires no exit hook.
+  pipeServer.onRpc('daemon.setResumeBinding', async (params) => {
+    const p = params as unknown as DaemonSetResumeBindingParams;
+    const managed = sessionManager.getSession(p.id);
+    if (!managed || !p.resumeBinding || !p.resumeBinding.sessionId) return { ok: false };
+    const prev = managed.meta.resumeBinding;
+    const next = p.resumeBinding;
+    const durableChange = !prev
+      || prev.sessionId !== next.sessionId
+      || prev.permissionMode !== next.permissionMode
+      || prev.cwd !== next.cwd;
+    managed.meta.resumeBinding = next;
+    if (durableChange) {
+      stateWriter.saveImmediate(buildState(sessionManager));
+    }
+    return { ok: true };
   });
 
   // daemon.getAgentName — daemon AgentDetector가 gate로 확정한 에이전트 표시명을
@@ -1219,6 +1267,7 @@ function wireEvents(
       }
       // The agent is live again → this pane is no longer a "resume me" shell.
       recoveredAgentShellIds.delete(payload.sessionId);
+      recoveredResumeBindings.delete(payload.sessionId);
     }
     const event: DaemonEvent = {
       type: 'agent.event',

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -19,7 +19,7 @@ import type { DaemonState } from './types';
 import type { DaemonEvent, DaemonCreateSessionParams, DaemonSessionIdParams, DaemonResizeParams, DaemonSetResumeBindingParams } from '../shared/rpc';
 import { monitorEventLoopDelay, performance as nodePerformance } from 'node:perf_hooks';
 import { DAEMON_EXIT_ALREADY_RUNNING } from '../shared/constants';
-import { toResumeCommand, resumeOfferForRecovered, mergeResumeBinding } from '../shared/agentResume';
+import { toResumeCommand, resumeOfferForRecovered, mergeResumeBinding, normalizeResumeCwd } from '../shared/agentResume';
 import type { ResumeBinding } from '../shared/agentResume';
 import { agentDisplayToSlug } from '../main/pty/AgentDetector';
 import type { AgentSlug } from '../shared/events';
@@ -354,7 +354,8 @@ function ingestResumeSpool(
     }
     // F7: `--resume` is cwd-scoped, so the capture's origin cwd must match the
     // recovered pane's cwd; a mismatch would dead-end (offer --continue instead).
-    if (binding.cwd !== managed.meta.cwd) { drop(); continue; }
+    // Normalized compare so a drive-case / trailing-slash diff isn't a false miss.
+    if (normalizeResumeCwd(binding.cwd) !== normalizeResumeCwd(managed.meta.cwd)) { drop(); continue; }
     const prev = managed.meta.resumeBinding;
     // Never clobber: for a DIFFERENT conversation, only a strictly-newer spool
     // wins (ts tiebreak). For the SAME conversation the spool is redundant — its
@@ -362,7 +363,11 @@ function ingestResumeSpool(
     // keeps permissionMode sticky), and setResumeBinding's durable-change check
     // omits ts, so the persisted ts can lag a same-session live update; skipping
     // by sessionId avoids an older spool overwriting it (codex P2).
-    if (prev && (prev.sessionId === binding.sessionId || prev.ts >= binding.ts)) { drop(); continue; }
+    // ...and never let a provisional (no-transcript) spool replace an existing
+    // transcript-derived binding for a different session (codex P2, mirrors the
+    // live setResumeBinding guard).
+    if (prev && (prev.sessionId === binding.sessionId || prev.ts >= binding.ts
+        || (prev.transcriptPath && !binding.transcriptPath))) { drop(); continue; }
 
     // D5: a purged origin transcript makes `--resume` a silent "No conversation
     // found." — drop the record (the pill can still degrade to --continue).
@@ -851,7 +856,7 @@ async function recoverSessions(
     // the recovered session's cwd (F7 — `--resume` is cwd-scoped) AND its origin
     // transcript still exists (D5 — a purged id is a dead-end). Either miss drops
     // the pill to the cwd-relative `--continue`.
-    if (m.resumeBinding && m.resumeBinding.cwd === m.cwd && bindingTranscriptLives(m.resumeBinding)) {
+    if (m.resumeBinding && normalizeResumeCwd(m.resumeBinding.cwd) === normalizeResumeCwd(m.cwd) && bindingTranscriptLives(m.resumeBinding)) {
       recoveredResumeBindings.set(recoveredId, m.resumeBinding);
     }
   }
@@ -925,6 +930,16 @@ function restartSupervisedSession(
   } catch (err) {
     sessionManager.reinsertSession(managed);
     throw err;
+  }
+
+  // Carry the resume markers onto the recreated session meta. createSession builds
+  // FRESH metadata, so without this the saveImmediate below drops the exact binding
+  // (and the pill gate), and a second crash/reboot before another hook lands falls
+  // back to ambiguous --continue (codex P2). Mirrors the recovery carry-forward.
+  const fresh = sessionManager.getSession(recovered.id);
+  if (fresh) {
+    if (meta.resumeBinding && !fresh.meta.resumeBinding) fresh.meta.resumeBinding = meta.resumeBinding;
+    if (meta.lastDetectedAgent && !fresh.meta.lastDetectedAgent) fresh.meta.lastDetectedAgent = meta.lastDetectedAgent;
   }
 
   // Same external-death safety net as the create/recovery paths.
@@ -1210,6 +1225,22 @@ function registerRpcHandlers(
     const managed = sessionManager.getSession(p.id);
     if (!managed || !p.resumeBinding || !p.resumeBinding.sessionId) return { ok: false };
     const prev = managed.meta.resumeBinding;
+    // codex P2: ignore a STALE capture — an older hook RPC (a delayed Stop /
+    // SessionStart from a prior turn) reaching the daemon after a newer one must
+    // not replace the durable exact id. The spool ingest already does this; mirror
+    // it on the live path so a reboot can't resume the wrong conversation.
+    if (prev && typeof p.resumeBinding.ts === 'number' && p.resumeBinding.ts < prev.ts) {
+      return { ok: true };
+    }
+    // codex P2: a SessionStart fired before its transcript exists (F9) sends the
+    // #12235-UNSAFE payload.session_id as the id and carries NO transcriptPath.
+    // Don't let that provisional capture overwrite an existing transcript-derived
+    // (authoritative) binding for a DIFFERENT session — a reboot in between would
+    // then `--resume <wrong id>`.
+    if (prev && prev.transcriptPath && !p.resumeBinding.transcriptPath
+        && prev.sessionId !== p.resumeBinding.sessionId) {
+      return { ok: true };
+    }
     // Sticky-merge: a capture that couldn't read permissionMode (transcript tail
     // miss) must not wipe a previously-captured mode (codex review 2026-06-14).
     const next = mergeResumeBinding(prev, p.resumeBinding);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -189,10 +189,24 @@ function log(level: string, msg: string, ...args: unknown[]): void {
 // `--dangerously-skip-permissions` silently every reboot is unsafe (D6
 // fail-safe). Permission restore happens ONLY on the pill path (explicit user
 // Enter); the trust-gated supervised auto-restore is a deferred follow-up.
+// X6 ③ (D5): a binding is usable for an EXACT-session resume only when its
+// origin transcript still exists. A purged id turns `--resume` into a silent
+// "No conversation found." (F8 — exit 0, so no exit-code fallback). We probe the
+// exact stored path (slug-rule-free). Bindings with no transcriptPath (older
+// captures) are treated as usable — we can't prove them dead, and `--resume`
+// degrades gracefully if so.
+function bindingTranscriptLives(binding: ResumeBinding | undefined): boolean {
+  if (!binding) return false;
+  if (!binding.transcriptPath) return true;
+  return fs.existsSync(binding.transcriptPath);
+}
+
 function resumeLaunchCommand(session: { id: string; exec?: { command: string }; cwd: string; resumeBinding?: ResumeBinding }): string | undefined {
   if (!session.exec) return undefined;
   if (!fs.existsSync(session.cwd)) return undefined; // cwd gone → fresh, not wrong-target resume
-  const rewritten = toResumeCommand(session.exec.command, session.resumeBinding, session.cwd);
+  // D5: drop to `--continue` when the exact transcript is gone (pass no binding).
+  const usableBinding = bindingTranscriptLives(session.resumeBinding) ? session.resumeBinding : undefined;
+  const rewritten = toResumeCommand(session.exec.command, usableBinding, session.cwd);
   if (rewritten === session.exec.command) return undefined; // not a known agent launcher / already resuming
   log('info', `X6 resume: replaying session ${session.id} as resume form in ${session.cwd}`);
   return rewritten;
@@ -630,10 +644,10 @@ async function recoverSessions(
       recoveredAgentShellIds.set(s.id, offer as AgentSlug);
       // X6 ③: carry the persisted binding alongside the slug so the pill can
       // resume the EXACT session. Surface it ONLY when its captured cwd still
-      // matches the recovered session's cwd — `--resume` is cwd-scoped (F7), so
-      // a mismatch must not offer an id-resume; the pill then falls back to the
-      // cwd-relative `--continue`.
-      if (s.resumeBinding && s.resumeBinding.cwd === s.cwd) {
+      // matches the recovered session's cwd (F7 — `--resume` is cwd-scoped) AND
+      // its origin transcript still exists (D5 — a purged id is a dead-end).
+      // Either miss drops the pill to the cwd-relative `--continue`.
+      if (s.resumeBinding && s.resumeBinding.cwd === s.cwd && bindingTranscriptLives(s.resumeBinding)) {
         recoveredResumeBindings.set(s.id, s.resumeBinding);
       }
     }

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -268,6 +268,10 @@ function ingestResumeSpool(
     const cwd = typeof rec.cwd === 'string' ? rec.cwd : null;
     const agent = typeof rec.agent === 'string' ? rec.agent : 'claude';
     if (!ptyId || !sessionId || !cwd) { drop(); continue; }
+    // Never persist a binding for an unknown agent (a malformed/hostile spool
+    // file). The pill gate is already bounded to KNOWN_AGENT_SLUGS; bound the
+    // durable binding the same way so downstream never sees a bogus slug (codex P2).
+    if (!KNOWN_AGENT_SLUGS.has(agent)) { drop(); continue; }
 
     const managed = sessionManager.getSession(ptyId);
     if (!managed) {
@@ -281,7 +285,13 @@ function ingestResumeSpool(
     if (cwd !== managed.meta.cwd) { drop(); continue; }
     const recTs = typeof rec.ts === 'number' && Number.isFinite(rec.ts) ? rec.ts : 0;
     const prev = managed.meta.resumeBinding;
-    if (prev && prev.ts >= recTs) { drop(); continue; } // never clobber a newer capture
+    // Never clobber: for a DIFFERENT conversation, only a strictly-newer spool
+    // wins (ts tiebreak). For the SAME conversation the spool is redundant — its
+    // durable fields can only be staler than the live one (mergeResumeBinding
+    // keeps permissionMode sticky), and setResumeBinding's durable-change check
+    // omits ts, so the persisted ts can lag a same-session live update; skipping
+    // by sessionId avoids an older spool overwriting it (codex P2).
+    if (prev && (prev.sessionId === sessionId || prev.ts >= recTs)) { drop(); continue; }
 
     const permissionMode = typeof rec.permissionMode === 'string'
       && KNOWN_PERMISSION_MODES.has(rec.permissionMode)

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -42,6 +42,14 @@ const recoveredAgentShellIds = new Map<string, AgentSlug>();
 // agent relaunches (live again → no pill).
 const recoveredResumeBindings = new Map<string, ResumeBinding>();
 
+// X6 ③: closed set of resumable agent slugs, used to validate a hook-supplied
+// binding agent before it is written to `lastDetectedAgent` (an AgentSlug). Keep
+// in sync with AgentSlug in src/shared/events.ts and ALLOWED_AGENT_SLUGS in
+// integrations/shared/signal-types.ts.
+const KNOWN_AGENT_SLUGS: ReadonlySet<string> = new Set([
+  'claude', 'codex', 'gemini', 'aider', 'opencode', 'copilot',
+]);
+
 // === Constants ===
 const wmuxDir = getWmuxDir();
 
@@ -210,6 +218,99 @@ function resumeLaunchCommand(session: { id: string; exec?: { command: string }; 
   if (rewritten === session.exec.command) return undefined; // not a known agent launcher / already resuming
   log('info', `X6 resume: replaying session ${session.id} as resume form in ${session.cwd}`);
   return rewritten;
+}
+
+// === X6 ③ resume-binding spool ingest (Rung 3) ===
+// Drain the durable spool the Claude hook bridge writes (~/.wmux/resume-spool/)
+// when its capture RPC to wmux fails (main pipe absent during boot/restart,
+// no-workspace-match, timeout). Each record is self-describing and keyed by the
+// EXACT pane — WMUX_PTY_ID, the daemon session id — so we attribute it to a live
+// session by id with NO cwd guessing (the per-pane correctness the live hook
+// path also relies on). Applied through the same merge + F7 cwd guard + D5
+// existence probe as the live capture, and ONLY when at least as fresh as any
+// binding already on the session, so a stale spool can never clobber a newer
+// live capture. Consumed / dead / aged records are deleted. Best-effort: never
+// throws (a corrupt spool file must not fail the recovery path). Returns the
+// number of bindings applied so the caller can skip the save when nothing changed.
+const RESUME_SPOOL_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // prune orphans after 7d
+const KNOWN_PERMISSION_MODES: ReadonlySet<string> = new Set([
+  'bypassPermissions', 'acceptEdits', 'plan', 'default',
+]);
+
+function ingestResumeSpool(
+  sessionManager: DaemonSessionManager,
+  stateWriter: StateWriter,
+): number {
+  const dir = path.join(wmuxDir, 'resume-spool');
+  let names: string[];
+  try {
+    if (!fs.existsSync(dir)) return 0;
+    names = fs.readdirSync(dir);
+  } catch {
+    return 0;
+  }
+  let applied = 0;
+  for (const name of names) {
+    if (!name.endsWith('.json')) continue;
+    const file = path.join(dir, name);
+    const drop = (): void => { try { fs.unlinkSync(file); } catch { /* ignore */ } };
+    let rec: Record<string, unknown>;
+    let mtimeMs = 0;
+    try {
+      rec = JSON.parse(fs.readFileSync(file, 'utf-8')) as Record<string, unknown>;
+      try { mtimeMs = fs.statSync(file).mtimeMs; } catch { /* ignore */ }
+    } catch {
+      drop(); // corrupt / partial write — never let it wedge the drain
+      continue;
+    }
+    const ptyId = typeof rec.ptyId === 'string' ? rec.ptyId : null;
+    const sessionId = typeof rec.sessionId === 'string' ? rec.sessionId : null;
+    const cwd = typeof rec.cwd === 'string' ? rec.cwd : null;
+    const agent = typeof rec.agent === 'string' ? rec.agent : 'claude';
+    if (!ptyId || !sessionId || !cwd) { drop(); continue; }
+
+    const managed = sessionManager.getSession(ptyId);
+    if (!managed) {
+      // No live session owns this ptyId yet — a cap-skipped / not-yet-recovered
+      // pane. Keep the record until it ages out so a later launch can use it.
+      if (Date.now() - mtimeMs > RESUME_SPOOL_MAX_AGE_MS) drop();
+      continue;
+    }
+    // F7: `--resume` is cwd-scoped, so the capture's origin cwd must match the
+    // recovered pane's cwd; a mismatch would dead-end (offer --continue instead).
+    if (cwd !== managed.meta.cwd) { drop(); continue; }
+    const recTs = typeof rec.ts === 'number' && Number.isFinite(rec.ts) ? rec.ts : 0;
+    const prev = managed.meta.resumeBinding;
+    if (prev && prev.ts >= recTs) { drop(); continue; } // never clobber a newer capture
+
+    const permissionMode = typeof rec.permissionMode === 'string'
+      && KNOWN_PERMISSION_MODES.has(rec.permissionMode)
+      ? (rec.permissionMode as ResumeBinding['permissionMode'])
+      : undefined;
+    const binding: ResumeBinding = {
+      agent,
+      sessionId,
+      cwd,
+      ...(permissionMode ? { permissionMode } : {}),
+      ...(typeof rec.transcriptPath === 'string' ? { transcriptPath: rec.transcriptPath } : {}),
+      ts: recTs,
+    };
+    // D5: a purged origin transcript makes `--resume` a silent "No conversation
+    // found." — drop the record (the pill can still degrade to --continue).
+    if (!bindingTranscriptLives(binding)) { drop(); continue; }
+
+    managed.meta.resumeBinding = mergeResumeBinding(prev, binding);
+    // Rung 1 parity: a spooled capture also proves the pane ran claude, so it
+    // arms the pill gate even if no live banner was ever detected.
+    if (!managed.meta.lastDetectedAgent && KNOWN_AGENT_SLUGS.has(agent)) {
+      managed.meta.lastDetectedAgent = agent as AgentSlug;
+    }
+    drop();
+    applied++;
+    log('info', `X6 resume-spool: ingested binding for ${ptyId} (session ${sessionId.slice(0, 8)})`);
+  }
+  if (applied > 0) stateWriter.saveImmediate(buildState(sessionManager));
+  return applied;
 }
 
 // === PID / Lock helpers ===
@@ -650,23 +751,33 @@ async function recoverSessions(
     stateWriter.saveImmediate(liveState);
   }
 
-  // X6 Feature ②: flag recovered INTERACTIVE agent panes for the resume pill.
-  // Read lastDetectedAgent from the PERSISTED session (the live recovered meta
-  // is a fresh shell with no agent yet — correct: the pill is a one-time "this
-  // pane WAS an agent, resume?" offer). Exec/supervised panes are excluded —
-  // they already auto-resume via execLaunchCommand (Feature ①).
-  for (const s of state.sessions) {
-    const offer = resumeOfferForRecovered(s);
-    if (recoveredIds.has(s.id) && offer) {
-      recoveredAgentShellIds.set(s.id, offer as AgentSlug);
-      // X6 ③: carry the persisted binding alongside the slug so the pill can
-      // resume the EXACT session. Surface it ONLY when its captured cwd still
-      // matches the recovered session's cwd (F7 — `--resume` is cwd-scoped) AND
-      // its origin transcript still exists (D5 — a purged id is a dead-end).
-      // Either miss drops the pill to the cwd-relative `--continue`.
-      if (s.resumeBinding && s.resumeBinding.cwd === s.cwd && bindingTranscriptLives(s.resumeBinding)) {
-        recoveredResumeBindings.set(s.id, s.resumeBinding);
-      }
+  // X6 ③ (Rung 3): reconcile the durable hook spool onto the recovered sessions
+  // BEFORE surfacing the pill, so a binding lost to a failed live RPC (main pipe
+  // down at capture time — the dominant ENOENT case in the bug report) still
+  // drives an EXACT-session resume. Keyed by WMUX_PTY_ID, so attribution is
+  // per-pane with no cwd guessing. Writes the binding + (Rung 1) lastDetectedAgent
+  // onto the live meta and persists, so the loop below surfaces it like any other.
+  ingestResumeSpool(sessionManager, stateWriter);
+
+  // X6 Feature ②/③: flag recovered INTERACTIVE agent panes for the resume pill.
+  // Read off the LIVE recovered meta (not the persisted record): the carry-forward
+  // above, the spool ingest, and the Rung-1 hook-sourced gate ALL write their
+  // markers onto managed.meta, so the live meta is the single source that reflects
+  // every capture path. Exec/supervised panes are excluded — they already
+  // auto-resume via execLaunchCommand (Feature ①).
+  for (const recoveredId of recoveredIds) {
+    const managed = sessionManager.getSession(recoveredId);
+    if (!managed) continue;
+    const m = managed.meta;
+    const offer = resumeOfferForRecovered(m);
+    if (!offer) continue;
+    recoveredAgentShellIds.set(recoveredId, offer as AgentSlug);
+    // Surface the EXACT-session binding ONLY when its captured cwd still matches
+    // the recovered session's cwd (F7 — `--resume` is cwd-scoped) AND its origin
+    // transcript still exists (D5 — a purged id is a dead-end). Either miss drops
+    // the pill to the cwd-relative `--continue`.
+    if (m.resumeBinding && m.resumeBinding.cwd === m.cwd && bindingTranscriptLives(m.resumeBinding)) {
+      recoveredResumeBindings.set(recoveredId, m.resumeBinding);
     }
   }
 
@@ -1027,11 +1138,22 @@ function registerRpcHandlers(
     // Sticky-merge: a capture that couldn't read permissionMode (transcript tail
     // miss) must not wipe a previously-captured mode (codex review 2026-06-14).
     const next = mergeResumeBinding(prev, p.resumeBinding);
-    const durableChange = !prev
+    let durableChange = !prev
       || prev.sessionId !== next.sessionId
       || prev.permissionMode !== next.permissionMode
       || prev.cwd !== next.cwd;
     managed.meta.resumeBinding = next;
+    // X6 ③ (Rung 1): a captured binding PROVES claude ran in this pane, so the
+    // hook is a SECOND, independent writer of the pill gate (lastDetectedAgent) —
+    // the live AgentDetector banner is once-per-session and is never re-armed from
+    // restored scrollback, so a pane whose banner was missed but whose hook landed
+    // would otherwise hold the exact uuid yet show NO pill after a reboot. Bounded
+    // to a known slug and a one-time set (the !lastDetectedAgent guard) so it costs
+    // at most one extra sync write per pane, exactly like the banner path.
+    if (!managed.meta.lastDetectedAgent && KNOWN_AGENT_SLUGS.has(next.agent)) {
+      managed.meta.lastDetectedAgent = next.agent as AgentSlug;
+      durableChange = true;
+    }
     if (durableChange) {
       stateWriter.saveImmediate(buildState(sessionManager));
     }
@@ -1778,6 +1900,23 @@ async function main(): Promise<void> {
   const maxRecover = Math.min(config.session.maxSessions, MAX_RECOVER_SESSIONS);
   await recoverSessions(stateWriter, sessionManager, processMonitor, maxRecover);
   markDaemonBoot('recovery-done');
+
+  // X6 ③ (Rung 3): recoverSessions drains the hook spool once at boot (the reboot
+  // headline). Also drain on a low-frequency timer so a capture spooled while the
+  // MAIN process was restarting — but the daemon stayed alive (dev HMR, a main
+  // crash) — is reconciled within the interval instead of waiting for the next
+  // reboot. ingestResumeSpool is a no-op (single readdir, no write) when the spool
+  // dir is empty, so the steady-state cost is negligible. Unref'd: never holds the
+  // process open.
+  const RESUME_SPOOL_DRAIN_INTERVAL_MS = 60_000;
+  const resumeSpoolTimer = setInterval(() => {
+    try {
+      ingestResumeSpool(sessionManager, stateWriter);
+    } catch (err) {
+      log('warn', 'resume-spool drain failed:', err);
+    }
+  }, RESUME_SPOOL_DRAIN_INTERVAL_MS);
+  resumeSpoolTimer.unref?.();
 
   // X8: re-arm supervision for recovered sessions. The policy + sticky
   // status live on the persisted meta, so this is a pure replay — a

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -19,7 +19,7 @@ import type { DaemonState } from './types';
 import type { DaemonEvent, DaemonCreateSessionParams, DaemonSessionIdParams, DaemonResizeParams, DaemonSetResumeBindingParams } from '../shared/rpc';
 import { monitorEventLoopDelay, performance as nodePerformance } from 'node:perf_hooks';
 import { DAEMON_EXIT_ALREADY_RUNNING } from '../shared/constants';
-import { toResumeCommand, resumeOfferForRecovered } from '../shared/agentResume';
+import { toResumeCommand, resumeOfferForRecovered, mergeResumeBinding } from '../shared/agentResume';
 import type { ResumeBinding } from '../shared/agentResume';
 import { agentDisplayToSlug } from '../main/pty/AgentDetector';
 import type { AgentSlug } from '../shared/events';
@@ -622,6 +622,23 @@ async function recoverSessions(
   }
 
   if (changed) {
+    // X6 ②/③ (codex review 2026-06-14): createSession does NOT replay the
+    // persisted resume markers (lastDetectedAgent / resumeBinding) into the
+    // fresh recovered meta — so the recovery save below would DROP them, and a
+    // SECOND reboot before the agent re-runs (and re-emits them) would lose the
+    // resume offer / exact-session binding. Carry them forward onto the live
+    // meta first so buildState persists them durably across consecutive reboots.
+    for (const persisted of state.sessions) {
+      if (!recoveredIds.has(persisted.id)) continue;
+      const managed = sessionManager.getSession(persisted.id);
+      if (!managed) continue;
+      if (persisted.lastDetectedAgent && !managed.meta.lastDetectedAgent) {
+        managed.meta.lastDetectedAgent = persisted.lastDetectedAgent;
+      }
+      if (persisted.resumeBinding && !managed.meta.resumeBinding) {
+        managed.meta.resumeBinding = persisted.resumeBinding;
+      }
+    }
     // Build combined state: recovered (live) sessions + everything we
     // intentionally left untouched (originally-dead within TTL, plus
     // any session the recovery cap excluded — which stays suspended).
@@ -997,7 +1014,9 @@ function registerRpcHandlers(
     const managed = sessionManager.getSession(p.id);
     if (!managed || !p.resumeBinding || !p.resumeBinding.sessionId) return { ok: false };
     const prev = managed.meta.resumeBinding;
-    const next = p.resumeBinding;
+    // Sticky-merge: a capture that couldn't read permissionMode (transcript tail
+    // miss) must not wipe a previously-captured mode (codex review 2026-06-14).
+    const next = mergeResumeBinding(prev, p.resumeBinding);
     const durableChange = !prev
       || prev.sessionId !== next.sessionId
       || prev.permissionMode !== next.permissionMode

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -2,6 +2,7 @@
 
 import type { DaemonSupervisionPolicy } from '../shared/rpc';
 import type { AgentSlug } from '../shared/events';
+import type { ResumeBinding } from '../shared/agentResume';
 
 /** Session lifecycle state */
 export type DaemonSessionState = 'detached' | 'attached' | 'dead' | 'suspended';
@@ -54,6 +55,14 @@ export interface DaemonSession {
    * RECOVERED this boot (see recoveredAgentShellIds) — never live reconnects.
    */
   lastDetectedAgent?: AgentSlug;
+  /**
+   * X6 ③ resume-by-id: the captured handle on this pane's agent conversation
+   * (origin session id + cwd + last permission mode), set live from the claude
+   * hook via daemon.setResumeBinding and persisted IMMEDIATELY (saveImmediate —
+   * same SIGKILL-survival rule as lastDetectedAgent). Drives the EXACT-session
+   * resume (`--resume <id>`) on both the recovery pill and the supervised replay.
+   */
+  resumeBinding?: ResumeBinding;
 }
 
 /** Top-level schema for ~/.wmux/sessions.json */

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -492,7 +492,7 @@ registerPluginHostHandlers(rpcRouter, () => pluginHostLoader, () => approvalQueu
 registerProjectConfigHandlers();
 // Returns an unsubscribe for the signal-health push subscription. Called from
 // before-quit so HMR reload / shutdown does not leak the listener.
-const disposeHooksRpc = registerHooksRpc(rpcRouter, () => mainWindow, hookSignalRouter);
+const disposeHooksRpc = registerHooksRpc(rpcRouter, () => mainWindow, hookSignalRouter, () => daemonClient);
 
 // ─── Phase 2 — Anthropic 5h/7d usage meter ──────────────────────────────────
 // Opt-in. Stays idle until the renderer sends IPC.USAGE_TOGGLE with `true`.

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -25,6 +25,7 @@ import {
   PROJECT_SUPERVISION_HEALTHY_UPTIME_SEC_MAX,
 } from '../../../shared/wmuxProjectConfig';
 import type { DaemonSupervisionPolicy } from '../../../shared/rpc';
+import type { ResumeBinding } from '../../../shared/agentResume';
 
 /**
  * Allowed shell basenames (compared case-insensitively).
@@ -659,6 +660,9 @@ export function registerPTYHandlers(
         supervisionRuntime?: { status: 'armed' | 'stopped'; restartCount: number };
         // X6 ② — present only for an interactive agent pane recovered this boot.
         resumeAgent?: string;
+        // X6 ③ — the captured resume binding (origin id + cwd + permission mode),
+        // surfaced alongside resumeAgent (recovery-only, cwd-matched) for the pill.
+        resumeBinding?: ResumeBinding;
       }>;
       // Map to same shape as local PTYManager.getActiveInstances(), plus an
       // additive `supervision` summary for the renderer's supervision slice
@@ -680,6 +684,8 @@ export function registerPTYHandlers(
             : {}),
           // X6 ② — carry the resume hint (agent slug) for the renderer pill.
           ...(s.resumeAgent ? { resumeAgent: s.resumeAgent } : {}),
+          // X6 ③ — carry the binding so the pill can build `--resume <id>`.
+          ...(s.resumeBinding ? { resumeBinding: s.resumeBinding } : {}),
         }));
       // RCA A8 — log the count the renderer's reconcile will act on. An empty
       // or short list here, correlated with a renderer ptyId-clear, is the

--- a/src/main/mcp/methodCapabilityMap.ts
+++ b/src/main/mcp/methodCapabilityMap.ts
@@ -284,6 +284,10 @@ export const METHOD_CAPABILITY: Record<RpcMethod, RequiredCapability> = {
   // same posture as project-trust ops.
   'daemon.superviseRearm':   { capability: 'wmux.internal' },
   'daemon.superviseStop':    { capability: 'wmux.internal' },
+  // X6 ③: resume-binding persistence is forwarded ONLY by main (the hooks.signal
+  // handler) after env-first ptyId resolution. External clients must never set a
+  // pane's resume binding — same internal-only posture as supervision control.
+  'daemon.setResumeBinding': { capability: 'wmux.internal' },
 
   // --- A2A (agent-to-agent) ---
   'a2a.resolve.identity': { capability: 'a2a.read',    riskClass: 'a2a' },

--- a/src/main/pipe/handlers/__tests__/hooks.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/hooks.rpc.test.ts
@@ -222,6 +222,18 @@ describe('resolvePtyIdForSignal — X6 ③ per-pane WMUX_PTY_ID routing', () => 
     );
     expect(got).toBe('p-active'); // cwd exact match → workspace's activePtyId
   });
+
+  it('a live ptyId is NOT trusted when it belongs to a DIFFERENT claimed workspace (anti-spoof)', () => {
+    // p-bg is a real live pane in ws-1, but the hook claims ws-evil. A pane-env
+    // -controlled WMUX_PTY_ID must not let an authenticated hook hijack another
+    // workspace's pane — the workspace cross-check rejects it and routing falls
+    // back to the (unknown) workspaceId → cwd.
+    const got = resolvePtyIdForSignal(
+      signal({ ptyId: 'p-bg', workspaceId: 'ws-evil', cwd: '/repo' }),
+      workspaces,
+    );
+    expect(got).toBe('p-active'); // NOT p-bg — the spoofed cross-workspace target
+  });
 });
 
 describe('isAgentSignal (re-export check)', () => {

--- a/src/main/pipe/handlers/__tests__/hooks.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/hooks.rpc.test.ts
@@ -177,6 +177,53 @@ describe('resolvePtyIdForSignal — env-first routing (Codex P1 #7 fix)', () => 
   });
 });
 
+describe('resolvePtyIdForSignal — X6 ③ per-pane WMUX_PTY_ID routing', () => {
+  // One workspace, TWO panes (split). cwd is shared. activePtyId is p-active.
+  // Pre-fix, every hook collapsed to p-active; the non-active pane's binding
+  // was clobbered. With ptyId routing each pane keeps its own attribution.
+  const workspaces = [
+    {
+      id: 'ws-1',
+      name: 'Split',
+      metadata: { cwd: '/repo' },
+      activePtyId: 'p-active',
+      ptyIds: ['p-active', 'p-bg'],
+    },
+  ];
+
+  it('exact ptyId wins over workspace activePtyId for a non-active split pane', () => {
+    const got = resolvePtyIdForSignal(
+      signal({ ptyId: 'p-bg', workspaceId: 'ws-1', cwd: '/repo' }),
+      workspaces,
+    );
+    expect(got).toBe('p-bg'); // NOT p-active — the collapse is fixed
+  });
+
+  it('exact ptyId also pins the active pane (no regression)', () => {
+    const got = resolvePtyIdForSignal(
+      signal({ ptyId: 'p-active', workspaceId: 'ws-1', cwd: '/repo' }),
+      workspaces,
+    );
+    expect(got).toBe('p-active');
+  });
+
+  it('a stale/unknown ptyId is NOT trusted — falls back to workspaceId routing', () => {
+    const got = resolvePtyIdForSignal(
+      signal({ ptyId: 'p-closed', workspaceId: 'ws-1', cwd: '/repo' }),
+      workspaces,
+    );
+    expect(got).toBe('p-active'); // unknown id ignored, workspace fallback wins
+  });
+
+  it('a stale ptyId with no other signal falls through to cwd', () => {
+    const got = resolvePtyIdForSignal(
+      signal({ ptyId: 'p-gone', cwd: '/repo' }),
+      workspaces,
+    );
+    expect(got).toBe('p-active'); // cwd exact match → workspace's activePtyId
+  });
+});
+
 describe('isAgentSignal (re-export check)', () => {
   // Smoke-imported separately to keep this file focused; full validation
   // tests live next to signal-types.ts spec if needed. Here we just make

--- a/src/main/pipe/handlers/hooks.rpc.ts
+++ b/src/main/pipe/handlers/hooks.rpc.ts
@@ -46,9 +46,12 @@ import { broadcastMetadataUpdate } from '../../ipc/handlers/metadata.handler';
 import type { HookSignalRouter } from '../../hooks/HookSignalRouter';
 import { HookFloodMeter, describeHookFlood } from '../../hooks/HookFloodMeter';
 import { eventBus } from '../../events/EventBus';
-import { IPC } from '../../../shared/constants';
+import { IPC, dataSuffix } from '../../../shared/constants';
 import type { DaemonClient } from '../../DaemonClient';
 import type { ResumeBinding, PermissionMode } from '../../../shared/agentResume';
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
 import {
   isAgentSignal,
   type AgentSignal,
@@ -68,6 +71,48 @@ const VALID_PERMISSION_MODES: ReadonlySet<string> = new Set([
 function readPermissionMode(payload: Record<string, unknown>): PermissionMode | undefined {
   const m = payload?.permissionMode;
   return typeof m === 'string' && VALID_PERMISSION_MODES.has(m) ? (m as PermissionMode) : undefined;
+}
+
+/**
+ * X6 ③ (codex P2): durable spool written by MAIN when the daemon.setResumeBinding
+ * relay can't land (daemon down / restarting). The bridge already spools when the
+ * MAIN pipe is down; this closes the symmetric hole where main is up and resolved
+ * the pane but the daemon isn't reachable. Same record shape + ptyId key + atomic
+ * temp→rename + don't-replace-newer rule the daemon's ingest expects. Writes under
+ * the suffix-aware ~/.wmux dir the daemon actually reads (main owns WMUX_DATA_SUFFIX,
+ * unlike the bridge). Best-effort: never throws into the hook path.
+ */
+function writeMainResumeSpool(ptyId: string, binding: ResumeBinding): void {
+  try {
+    const dir = path.join(os.homedir(), `.wmux${dataSuffix()}`, 'resume-spool');
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    const safe = String(ptyId).replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 80);
+    if (!safe) return;
+    const file = path.join(dir, `${safe}.json`);
+    const tmp = path.join(dir, `${safe}.${process.pid}.${Date.now()}.json.tmp`);
+    const record = {
+      ptyId,
+      agent: binding.agent,
+      sessionId: binding.sessionId,
+      cwd: binding.cwd,
+      ts: binding.ts,
+      ...(binding.permissionMode ? { permissionMode: binding.permissionMode } : {}),
+      ...(binding.transcriptPath ? { transcriptPath: binding.transcriptPath } : {}),
+    };
+    fs.writeFileSync(tmp, JSON.stringify(record), { encoding: 'utf8', mode: 0o600 });
+    try {
+      if (fs.existsSync(file)) {
+        const existing = JSON.parse(fs.readFileSync(file, 'utf8'));
+        if (typeof existing?.ts === 'number' && existing.ts > record.ts) {
+          try { fs.unlinkSync(tmp); } catch { /* ignore */ }
+          return;
+        }
+      }
+    } catch { /* replace a corrupt existing spool */ }
+    fs.renameSync(tmp, file);
+  } catch (err) {
+    console.warn(`[hooks.signal] main resume-spool write failed: ${String(err)}`);
+  }
 }
 
 interface WorkspaceListEntry {
@@ -195,23 +240,32 @@ export function registerHooksRpc(
         || signal.kind === 'agent.subagent_stop')
       && signal.agentSessionId
     ) {
+      const permissionMode = readPermissionMode(signal.payload);
+      const transcriptPath = typeof signal.payload?.transcript_path === 'string'
+        ? signal.payload.transcript_path
+        : undefined;
+      const resumeBinding: ResumeBinding = {
+        agent: signal.agent,
+        sessionId: signal.agentSessionId,
+        cwd: signal.cwd,
+        ...(permissionMode ? { permissionMode } : {}),
+        ...(transcriptPath ? { transcriptPath } : {}),
+        ts: signal.ts,
+      };
       const client = getDaemonClient?.();
       if (client) {
-        const permissionMode = readPermissionMode(signal.payload);
-        const transcriptPath = typeof signal.payload?.transcript_path === 'string'
-          ? signal.payload.transcript_path
-          : undefined;
-        const resumeBinding: ResumeBinding = {
-          agent: signal.agent,
-          sessionId: signal.agentSessionId,
-          cwd: signal.cwd,
-          ...(permissionMode ? { permissionMode } : {}),
-          ...(transcriptPath ? { transcriptPath } : {}),
-          ts: signal.ts,
-        };
         client
           .rpc('daemon.setResumeBinding', { id: ptyId, resumeBinding }, { timeoutMs: WORKSPACE_LIST_FETCH_TIMEOUT_MS })
-          .catch((err) => console.warn(`[hooks.signal] setResumeBinding failed: ${String(err)}`));
+          // codex P2: the relay is fire-and-forget, so a daemon down/restarting
+          // here would lose the capture entirely (the bridge already saw ok). Spool
+          // it from main so the daemon reconciles it on its next boot/connect.
+          .catch((err) => {
+            console.warn(`[hooks.signal] setResumeBinding failed, spooling: ${String(err)}`);
+            writeMainResumeSpool(ptyId, resumeBinding);
+          });
+      } else {
+        // No daemon client (daemon down / not yet connected) — spool directly.
+        writeMainResumeSpool(ptyId, resumeBinding);
       }
     }
 

--- a/src/main/pipe/handlers/hooks.rpc.ts
+++ b/src/main/pipe/handlers/hooks.rpc.ts
@@ -47,6 +47,8 @@ import type { HookSignalRouter } from '../../hooks/HookSignalRouter';
 import { HookFloodMeter, describeHookFlood } from '../../hooks/HookFloodMeter';
 import { eventBus } from '../../events/EventBus';
 import { IPC } from '../../../shared/constants';
+import type { DaemonClient } from '../../DaemonClient';
+import type { ResumeBinding, PermissionMode } from '../../../shared/agentResume';
 import {
   isAgentSignal,
   type AgentSignal,
@@ -54,6 +56,19 @@ import {
 } from '../../../../integrations/shared/signal-types';
 
 type GetWindow = () => BrowserWindow | null;
+
+/** X6 ③: known permission modes, for validating the bridge's payload field. */
+const VALID_PERMISSION_MODES: ReadonlySet<string> = new Set([
+  'bypassPermissions',
+  'acceptEdits',
+  'plan',
+  'default',
+]);
+
+function readPermissionMode(payload: Record<string, unknown>): PermissionMode | undefined {
+  const m = payload?.permissionMode;
+  return typeof m === 'string' && VALID_PERMISSION_MODES.has(m) ? (m as PermissionMode) : undefined;
+}
 
 interface WorkspaceListEntry {
   id: string;
@@ -105,6 +120,7 @@ export function registerHooksRpc(
   router: RpcRouter,
   getWindow: GetWindow,
   hookRouter: HookSignalRouter,
+  getDaemonClient?: () => DaemonClient | null,
 ): () => void {
   const meter = hookRouter.getLatencyMeter();
   // Short-TTL, coalescing cache so a burst of hooks in one turn collapses to
@@ -164,6 +180,35 @@ export function registerHooksRpc(
       // This is expected when Claude is used standalone; we just drop
       // the per-pane notification. Signal health (above) still records.
       return { ok: false, reason: 'no-workspace-match' };
+    }
+
+    // X6 ③: persist the resume binding for session-LIFECYCLE kinds. This runs
+    // BEFORE the isEmitKind gate below, which drops SessionStart for the
+    // notification path — but SessionStart is a key live-capture point (the
+    // earliest the origin id is known). Fire-and-forget: the daemon does the
+    // durable saveImmediate, and the hook's 2s budget must never block on it.
+    // agentSessionId is the #12235-safe origin id (transcript basename) the
+    // bridge derived; cwd + permissionMode complete the binding (F5/F7).
+    if (
+      (signal.kind === 'agent.session_start'
+        || signal.kind === 'agent.stop'
+        || signal.kind === 'agent.subagent_stop')
+      && signal.agentSessionId
+    ) {
+      const client = getDaemonClient?.();
+      if (client) {
+        const permissionMode = readPermissionMode(signal.payload);
+        const resumeBinding: ResumeBinding = {
+          agent: signal.agent,
+          sessionId: signal.agentSessionId,
+          cwd: signal.cwd,
+          ...(permissionMode ? { permissionMode } : {}),
+          ts: signal.ts,
+        };
+        client
+          .rpc('daemon.setResumeBinding', { id: ptyId, resumeBinding }, { timeoutMs: WORKSPACE_LIST_FETCH_TIMEOUT_MS })
+          .catch((err) => console.warn(`[hooks.signal] setResumeBinding failed: ${String(err)}`));
+      }
     }
 
     // (Per-pane token usage forwarding was removed in B6: the StatusBar token

--- a/src/main/pipe/handlers/hooks.rpc.ts
+++ b/src/main/pipe/handlers/hooks.rpc.ts
@@ -198,11 +198,15 @@ export function registerHooksRpc(
       const client = getDaemonClient?.();
       if (client) {
         const permissionMode = readPermissionMode(signal.payload);
+        const transcriptPath = typeof signal.payload?.transcript_path === 'string'
+          ? signal.payload.transcript_path
+          : undefined;
         const resumeBinding: ResumeBinding = {
           agent: signal.agent,
           sessionId: signal.agentSessionId,
           cwd: signal.cwd,
           ...(permissionMode ? { permissionMode } : {}),
+          ...(transcriptPath ? { transcriptPath } : {}),
           ts: signal.ts,
         };
         client

--- a/src/main/pipe/handlers/hooks.rpc.ts
+++ b/src/main/pipe/handlers/hooks.rpc.ts
@@ -477,6 +477,17 @@ export function resolvePtyIdForSignal(
   signal: AgentSignal,
   workspaces: WorkspaceListEntry[],
 ): string | null {
+  // X6 ③: EXACT per-pane routing. The daemon stamps WMUX_PTY_ID (its own session
+  // id) into every pane's env, so a hook carries the precise ptyId it fired from.
+  // Trust it ONLY when it still maps to a live workspace pane — that bounds a
+  // stale/spoofed id to a currently-open pane (the auth-gated hooks path is
+  // lower-trust than the MCP terminal-IO resolver, so an unverified id must never
+  // target a session). This resolves the split-workspace / shared-cwd collapse
+  // where every pane's hook would otherwise land on the workspace's ACTIVE
+  // surface — the dominant cross-pane resume-binding clobber.
+  if (signal.ptyId && findWorkspaceIdForPty(signal.ptyId, workspaces)) {
+    return signal.ptyId;
+  }
   if (signal.workspaceId) {
     const match = workspaces.find((w) => w.id === signal.workspaceId);
     if (match) {

--- a/src/main/pipe/handlers/hooks.rpc.ts
+++ b/src/main/pipe/handlers/hooks.rpc.ts
@@ -485,8 +485,16 @@ export function resolvePtyIdForSignal(
   // target a session). This resolves the split-workspace / shared-cwd collapse
   // where every pane's hook would otherwise land on the workspace's ACTIVE
   // surface — the dominant cross-pane resume-binding clobber.
-  if (signal.ptyId && findWorkspaceIdForPty(signal.ptyId, workspaces)) {
-    return signal.ptyId;
+  if (signal.ptyId) {
+    const ptyWorkspaceId = findWorkspaceIdForPty(signal.ptyId, workspaces);
+    // Trust the exact ptyId only when it maps to a LIVE pane AND — when the hook
+    // also carries a workspaceId — that pane belongs to the CLAIMED workspace.
+    // WMUX_PTY_ID is pane-env-controlled, so without the workspace cross-check an
+    // authenticated hook could target another live pane by id (codex P2). A hook
+    // with no workspaceId (older bridge / standalone) still trusts a live ptyId.
+    if (ptyWorkspaceId && (!signal.workspaceId || ptyWorkspaceId === signal.workspaceId)) {
+      return signal.ptyId;
+    }
   }
   if (signal.workspaceId) {
     const match = workspaces.find((w) => w.id === signal.workspaceId);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -6,6 +6,7 @@ import type {
   SampleTaskStartPayload,
 } from '../shared/firstRun';
 import { isFileDrag } from '../shared/dragDrop';
+import type { ResumeBinding } from '../shared/agentResume';
 
 /** Mirrors {@link McpStatusPayload} in src/main/ipc/handlers/mcp.handler.ts. */
 interface McpStatusPayload {
@@ -39,7 +40,7 @@ const electronAPI = {
     // sessions — the renderer uses it to hydrate its supervision slice on boot
     // and daemon-reconnect. Absent in local mode and for unsupervised panes.
     list: () =>
-      ipcRenderer.invoke(IPC.PTY_LIST) as Promise<{ id: string; shell: string; supervision?: { status: 'armed' | 'stopped'; restartCount: number }; resumeAgent?: string }[]>,
+      ipcRenderer.invoke(IPC.PTY_LIST) as Promise<{ id: string; shell: string; supervision?: { status: 'armed' | 'stopped'; restartCount: number }; resumeAgent?: string; resumeBinding?: ResumeBinding }[]>,
     reconnect: (id: string) =>
       // RCA A1 — `transient` distinguishes a recoverable failure (pipe not
       // writable yet, RPC threw during a handler-swap window) from a permanent

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import type { AgentSlug } from '../../../shared/events';
+import type { ResumeBinding } from '../../../shared/agentResume';
 import { useStore } from '../../stores';
 import { useT } from '../../hooks/useT';
 import Sidebar from '../Sidebar/Sidebar';
@@ -765,12 +766,16 @@ export default function AppLayout() {
         const snapshot: Record<string, { status: 'armed' | 'stopped'; restartCount: number }> = {};
         // X6 ②: resume hints for recovered interactive agent panes.
         const resumeSnapshot: Record<string, AgentSlug> = {};
+        // X6 ③: the captured binding (id + cwd + permission mode) for the pill.
+        const resumeBindingSnapshot: Record<string, ResumeBinding> = {};
         for (const s of sessions) {
           if (s.supervision) snapshot[s.id] = s.supervision;
           if (s.resumeAgent) resumeSnapshot[s.id] = s.resumeAgent as AgentSlug;
+          if (s.resumeBinding) resumeBindingSnapshot[s.id] = s.resumeBinding;
         }
         useStore.getState().hydrateSupervision(snapshot);
         useStore.getState().hydrateResume(resumeSnapshot);
+        useStore.getState().hydrateResumeBindings(resumeBindingSnapshot);
       }).catch(() => { /* best-effort — a transient list failure self-heals on the next connect */ });
     };
     hydrate();

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -308,8 +308,17 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
         const ptyId = activeSurfacePtyId;
         const launcher = resumeHint; // slug doubles as the launcher stem ('claude')
         const agentName = launcher.charAt(0).toUpperCase() + launcher.slice(1);
-        const sessionId = resumeBinding?.sessionId;
-        const permFlag = permissionFlagFor(resumeBinding?.permissionMode);
+        // cwd-match guard (F7): `--resume <id>` is cwd-scoped, so only offer the
+        // exact-session resume when the binding's origin cwd still matches the
+        // pane's LIVE cwd. The daemon checks this at recovery, but the shell can
+        // `cd` afterwards (OSC 7 updates surface.cwd) — re-validate here so a
+        // post-recovery cd drops to the cwd-relative `--continue` (plan line 220).
+        const normCwd = (p: string | undefined) =>
+          (p ?? '').replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+        const paneCwd = pane.surfaces.find((s) => s.id === pane.activeSurfaceId)?.cwd;
+        const cwdMatches = !!(resumeBinding && paneCwd && normCwd(resumeBinding.cwd) === normCwd(paneCwd));
+        const sessionId = cwdMatches ? resumeBinding?.sessionId : undefined;
+        const permFlag = cwdMatches ? permissionFlagFor(resumeBinding?.permissionMode) : '';
 
         // Paste WITHOUT a trailing \r. The user presses Enter to run — so bypass
         // is re-granted only by an explicit keystroke, never automatically (D6).

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -10,6 +10,7 @@ import EditorPanel from '../Editor/EditorPanel';
 import SurfaceTabs from './SurfaceTabs';
 import { ErrorBoundary } from '../ErrorBoundary';
 import { resolveStartupCwd, withDefaultShell, withWorkspaceProfile } from '../../utils/ptyCreateOptions';
+import { permissionFlagFor } from '../../../shared/agentResume';
 import { tokenAttrs } from '../../themes';
 import PaneDecorations from '../../plugins/PaneDecorations';
 
@@ -187,16 +188,29 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
     activeSurfacePtyId ? s.supervisionByPtyId[activeSurfacePtyId] : undefined,
   );
 
-  // X6 ② resume pill. A pane recovered-this-boot that was running an agent gets
-  // a one-click "Resume <Agent>" offer. Clickable only once the pane is
-  // interactive (first PTY data — EI6) so the paste can't land before the
-  // recovered pipe is writable. Click pastes `<agent> --continue` and retracts.
+  // X6 ②/③ resume pill. A pane recovered-this-boot that was running an agent
+  // gets a resume offer. Clickable only once the pane is interactive (first PTY
+  // data — EI6) so the paste can't land before the recovered pipe is writable.
+  // X6 ③: the pill TYPES the command (no Enter) and assembles progressively —
+  // click 1 restores the permission mode, an optional click 2 appends
+  // `--resume <id>` for the EXACT session; the user presses Enter to run. With
+  // no binding it falls back to cwd-relative `--continue`.
   const resumeHint = useStore((s) =>
     activeSurfacePtyId ? s.resumeHintByPtyId[activeSurfacePtyId] : undefined,
+  );
+  const resumeBinding = useStore((s) =>
+    activeSurfacePtyId ? s.resumeBindingByPtyId[activeSurfacePtyId] : undefined,
   );
   const resumePtyReady = useStore((s) =>
     activeSurfacePtyId ? !!s.ptyReadyByPtyId[activeSurfacePtyId] : false,
   );
+  // Progressive-assembly stage: 0 = nothing typed; 1 = base command (permission
+  // flag) typed, awaiting an optional second click to append the session resume.
+  const [resumeStage, setResumeStage] = useState(0);
+  // Never carry a stale stage across panes or a re-offer.
+  useEffect(() => {
+    setResumeStage(0);
+  }, [activeSurfacePtyId, resumeHint]);
 
   const handleCloseSurface = useCallback((surfaceId: string) => {
     const surface = pane.surfaces.find((s) => s.id === surfaceId);
@@ -290,67 +304,111 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
           {supervision.status === 'stopped' ? '⟳!' : '⟳'}
         </span>
       )}
-      {resumeHint && resumePtyReady && !supervision && activeSurfacePtyId && (
-        <span
-          style={{
-            position: 'absolute',
-            top: 4,
-            left: 6,
-            zIndex: 20,
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 6,
-            fontSize: 10,
-            fontFamily: 'ui-monospace, monospace',
-            fontWeight: 700,
-            letterSpacing: '0.04em',
-            color: 'var(--bg-main)',
-            backgroundColor: 'var(--accent-cursor)',
-            borderRadius: 3,
-            opacity: 0.9,
-            overflow: 'hidden',
-          }}
-        >
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              window.electronAPI.pty.write(activeSurfacePtyId, `${resumeHint} --continue\r`);
-              useStore.getState().clearResumeHint(activeSurfacePtyId);
-            }}
-            title={t('resume.tooltip')}
-            aria-label={t('resume.tooltip')}
+      {resumeHint && resumePtyReady && !supervision && activeSurfacePtyId && (() => {
+        const ptyId = activeSurfacePtyId;
+        const launcher = resumeHint; // slug doubles as the launcher stem ('claude')
+        const agentName = launcher.charAt(0).toUpperCase() + launcher.slice(1);
+        const sessionId = resumeBinding?.sessionId;
+        const permFlag = permissionFlagFor(resumeBinding?.permissionMode);
+
+        // Paste WITHOUT a trailing \r. The user presses Enter to run — so bypass
+        // is re-granted only by an explicit keystroke, never automatically (D6).
+        const type = (text: string) => window.electronAPI.pty.write(ptyId, text);
+        const typeAndClear = (text: string) => {
+          type(text);
+          useStore.getState().clearResumeHint(ptyId);
+        };
+
+        const onPrimary = (e: React.MouseEvent) => {
+          e.stopPropagation();
+          if (!sessionId) {
+            // No binding (hook absent / purged / cwd mismatch) → cwd-relative
+            // --continue (today's behavior, minus the auto-submit).
+            typeAndClear(`${launcher} --continue`);
+            return;
+          }
+          if (resumeStage === 0 && permFlag) {
+            // Click 1: permission-restore only. Stop + Enter = a fresh session in
+            // the restored mode; click again to also resume the exact session.
+            // The two flags MUST land on ONE line (F6) — that's why we don't
+            // submit between clicks.
+            type(`${launcher} ${permFlag}`);
+            setResumeStage(1);
+            return;
+          }
+          if (resumeStage === 0) {
+            // Default mode (no permission flag) → one click types the full
+            // id-resume; no pointless permission-only stop.
+            typeAndClear(`${launcher} --resume ${sessionId}`);
+          } else {
+            // Click 2: append the session resume to the already-typed base.
+            typeAndClear(` --resume ${sessionId}`);
+          }
+        };
+
+        const primaryLabel = resumeStage === 1
+          ? `+ ${t('resume.addSession')}`
+          : `▶ ${t('resume.label', { agent: agentName })}`;
+        const primaryTooltip = resumeStage === 1 ? t('resume.addSessionTooltip') : t('resume.tooltip');
+
+        return (
+          <span
             style={{
-              padding: '1px 6px',
-              font: 'inherit',
-              color: 'inherit',
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
+              position: 'absolute',
+              top: 4,
+              left: 6,
+              zIndex: 20,
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              fontSize: 10,
+              fontFamily: 'ui-monospace, monospace',
+              fontWeight: 700,
+              letterSpacing: '0.04em',
+              color: 'var(--bg-main)',
+              backgroundColor: 'var(--accent-cursor)',
+              borderRadius: 3,
+              opacity: 0.9,
+              overflow: 'hidden',
             }}
           >
-            {`▶ ${t('resume.label', { agent: resumeHint.charAt(0).toUpperCase() + resumeHint.slice(1) })}`}
-          </button>
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              useStore.getState().clearResumeHint(activeSurfacePtyId);
-            }}
-            title={t('resume.dismiss')}
-            aria-label={t('resume.dismiss')}
-            style={{
-              padding: '1px 5px 1px 0',
-              font: 'inherit',
-              color: 'inherit',
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              opacity: 0.8,
-            }}
-          >
-            ×
-          </button>
-        </span>
-      )}
+            <button
+              onClick={onPrimary}
+              title={primaryTooltip}
+              aria-label={primaryTooltip}
+              style={{
+                padding: '1px 6px',
+                font: 'inherit',
+                color: 'inherit',
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+              }}
+            >
+              {primaryLabel}
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                useStore.getState().clearResumeHint(ptyId);
+              }}
+              title={t('resume.dismiss')}
+              aria-label={t('resume.dismiss')}
+              style={{
+                padding: '1px 5px 1px 0',
+                font: 'inherit',
+                color: 'inherit',
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                opacity: 0.8,
+              }}
+            >
+              ×
+            </button>
+          </span>
+        );
+      })()}
       <SurfaceTabs
         surfaces={pane.surfaces}
         activeSurfaceId={pane.activeSurfaceId}

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -313,8 +313,15 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
         // pane's LIVE cwd. The daemon checks this at recovery, but the shell can
         // `cd` afterwards (OSC 7 updates surface.cwd) — re-validate here so a
         // post-recovery cd drops to the cwd-relative `--continue` (plan line 220).
-        const normCwd = (p: string | undefined) =>
-          (p ?? '').replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+        const normCwd = (p: string | undefined) => {
+          // Lowercase ONLY a leading Windows drive letter — drive letters are
+          // case-insensitive, but POSIX paths are fully case-sensitive, so a blanket
+          // toLowerCase() would treat `/Foo` and `/foo` as equal and wrongly allow
+          // `--resume` (CodeRabbit). Mirrors the daemon's normalizeCwd.
+          let out = (p ?? '').replace(/\\/g, '/').replace(/\/+$/, '');
+          if (/^[A-Za-z]:\//.test(out)) out = out[0].toLowerCase() + out.slice(1);
+          return out;
+        };
         const paneCwd = pane.surfaces.find((s) => s.id === pane.activeSurfaceId)?.cwd;
         const cwdMatches = !!(resumeBinding && paneCwd && normCwd(resumeBinding.cwd) === normCwd(paneCwd));
         const sessionId = cwdMatches ? resumeBinding?.sessionId : undefined;

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -324,8 +324,15 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
         };
         const paneCwd = pane.surfaces.find((s) => s.id === pane.activeSurfaceId)?.cwd;
         const cwdMatches = !!(resumeBinding && paneCwd && normCwd(resumeBinding.cwd) === normCwd(paneCwd));
-        const sessionId = cwdMatches ? resumeBinding?.sessionId : undefined;
-        const permFlag = cwdMatches ? permissionFlagFor(resumeBinding?.permissionMode) : '';
+        // The binding must be for THIS launcher's agent. The pill's slug
+        // (resumeHint) and the binding are surfaced independently, and the daemon
+        // only fills lastDetectedAgent when empty — so a stale hint for one agent
+        // could pair with a binding for another, typing `codex --resume <claude-id>`
+        // (codex P2). Gate the exact-session path on an agent match too.
+        const agentMatches = resumeBinding?.agent === launcher;
+        const exactOk = cwdMatches && agentMatches;
+        const sessionId = exactOk ? resumeBinding?.sessionId : undefined;
+        const permFlag = exactOk ? permissionFlagFor(resumeBinding?.permissionMode) : '';
 
         // Paste WITHOUT a trailing \r. The user presses Enter to run — so bypass
         // is re-granted only by an explicit keystroke, never automatically (D6).

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -180,6 +180,11 @@ export const en = {
   'resume.label': 'Resume {agent}',
   'resume.tooltip': 'Resume the previous agent conversation in this pane',
   'resume.dismiss': 'Dismiss',
+  // X6 ③ — progressive assembly: the first click restores the permission mode
+  // (types the command, no Enter); this second click appends the exact-session
+  // resume. The user presses Enter to run.
+  'resume.addSession': 'resume this session',
+  'resume.addSessionTooltip': 'Also resume the exact previous conversation (--resume <id>); press Enter to run',
 
   // Browser
   'browser.urlPlaceholder': 'Enter URL...',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -128,6 +128,10 @@ export const ko = {
   'resume.label': '{agent} 이어가기',
   'resume.tooltip': '이 pane의 이전 에이전트 대화를 이어갑니다',
   'resume.dismiss': '닫기',
+  // X6 ③ — 점진 조립: 첫 클릭은 권한 모드를 복원(명령만 입력, Enter 없음),
+  // 이 두 번째 클릭은 정확한 세션 복원을 덧붙입니다. 실행은 사용자가 Enter.
+  'resume.addSession': '이 세션 복원',
+  'resume.addSessionTooltip': '이전 대화를 정확히 이어가기 (--resume <id>); 실행하려면 Enter',
 
   // Browser
   'browser.urlPlaceholder': 'URL 입력...',

--- a/src/renderer/stores/slices/__tests__/resumeSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/resumeSlice.test.ts
@@ -5,8 +5,17 @@ import { useStore } from '../../index';
 describe('resumeSlice', () => {
   beforeEach(() => {
     useStore.getState().hydrateResume({});
+    useStore.getState().hydrateResumeBindings({});
     // clear readiness by re-hydrating is not enough (separate map) — mark fresh
     // ptys ready explicitly per test.
+  });
+
+  const binding = (sessionId: string, cwd = 'D:\\wmux') => ({
+    agent: 'claude' as const,
+    sessionId,
+    cwd,
+    permissionMode: 'bypassPermissions' as const,
+    ts: 1,
   });
 
   it('starts empty', () => {
@@ -43,6 +52,30 @@ describe('resumeSlice', () => {
       useStore.getState().setResumeHint('pty-a', 'claude');
       useStore.getState().hydrateResume({});
       expect(useStore.getState().resumeHintByPtyId).toEqual({});
+    });
+  });
+
+  describe('X6 ③ — resume binding (id + permission mode)', () => {
+    it('starts empty', () => {
+      expect(useStore.getState().resumeBindingByPtyId).toEqual({});
+    });
+
+    it('hydrateResumeBindings replaces the whole map', () => {
+      useStore.getState().hydrateResumeBindings({ 'pty-a': binding('s-1') });
+      expect(useStore.getState().resumeBindingByPtyId['pty-a']?.sessionId).toBe('s-1');
+      useStore.getState().hydrateResumeBindings({ 'pty-b': binding('s-2') });
+      expect(useStore.getState().resumeBindingByPtyId['pty-a']).toBeUndefined();
+      expect(useStore.getState().resumeBindingByPtyId['pty-b']?.sessionId).toBe('s-2');
+    });
+
+    it('clearResumeHint clears the binding together with the hint (pill is one unit)', () => {
+      useStore.getState().setResumeHint('pty-a', 'claude');
+      useStore.getState().hydrateResumeBindings({ 'pty-a': binding('s-1'), 'pty-b': binding('s-2') });
+      useStore.getState().clearResumeHint('pty-a');
+      expect(useStore.getState().resumeHintByPtyId['pty-a']).toBeUndefined();
+      expect(useStore.getState().resumeBindingByPtyId['pty-a']).toBeUndefined();
+      // untouched sibling
+      expect(useStore.getState().resumeBindingByPtyId['pty-b']?.sessionId).toBe('s-2');
     });
   });
 

--- a/src/renderer/stores/slices/resumeSlice.ts
+++ b/src/renderer/stores/slices/resumeSlice.ts
@@ -12,10 +12,20 @@
 import type { StateCreator } from 'zustand';
 import type { StoreState } from '../index';
 import type { AgentSlug } from '../../../shared/events';
+import type { ResumeBinding } from '../../../shared/agentResume';
 
 export interface ResumeSlice {
   /** Per-ptyId resume hint (agent slug). Absent key = no pill for this pane. */
   resumeHintByPtyId: Record<string, AgentSlug>;
+
+  /**
+   * X6 ③: per-ptyId resume binding (origin session id + cwd + permission mode),
+   * surfaced alongside the slug for panes recovered-this-boot whose captured cwd
+   * still matches (the daemon enforces that guard). Present → the pill can build
+   * `--resume <id>` for the EXACT conversation; absent → the pill falls back to
+   * cwd-relative `--continue`.
+   */
+  resumeBindingByPtyId: Record<string, ResumeBinding>;
 
   /** Ptys that have emitted their first data (shell prompt drawn) since mount.
    *  The resume pill is only clickable once its pane is here — guards against
@@ -41,6 +51,9 @@ export interface ResumeSlice {
    * then detected live.
    */
   hydrateResume: (snapshot: Record<string, AgentSlug>) => void;
+
+  /** Replace the binding map from a `pty.list` snapshot (parallel to hydrateResume). */
+  hydrateResumeBindings: (snapshot: Record<string, ResumeBinding>) => void;
 }
 
 export const createResumeSlice: StateCreator<
@@ -50,6 +63,7 @@ export const createResumeSlice: StateCreator<
   ResumeSlice
 > = (set) => ({
   resumeHintByPtyId: {},
+  resumeBindingByPtyId: {},
   ptyReadyByPtyId: {},
 
   markPtyReady: (ptyId) => set((draft: StoreState) => {
@@ -61,10 +75,17 @@ export const createResumeSlice: StateCreator<
   }),
 
   clearResumeHint: (ptyId) => set((draft: StoreState) => {
+    // Clear the binding together with the hint — the pill goes away as a unit
+    // (clicked, dismissed, typed-into, or agent relaunched).
     if (draft.resumeHintByPtyId[ptyId]) delete draft.resumeHintByPtyId[ptyId];
+    if (draft.resumeBindingByPtyId[ptyId]) delete draft.resumeBindingByPtyId[ptyId];
   }),
 
   hydrateResume: (snapshot) => set((draft: StoreState) => {
     draft.resumeHintByPtyId = { ...snapshot };
+  }),
+
+  hydrateResumeBindings: (snapshot) => set((draft: StoreState) => {
+    draft.resumeBindingByPtyId = { ...snapshot };
   }),
 });

--- a/src/shared/__tests__/agentResume.test.ts
+++ b/src/shared/__tests__/agentResume.test.ts
@@ -143,6 +143,12 @@ describe('toResumeCommand (X6)', () => {
       const once = toResumeCommand('claude --model opus', binding(), CWD);
       expect(toResumeCommand(once, binding(), CWD)).toBe(once);
     });
+
+    it('transcriptPath is carried metadata (D5 probe) — never enters the command', () => {
+      expect(
+        toResumeCommand('claude', binding({ transcriptPath: 'C:\\u\\.claude\\projects\\x\\abc-123.jsonl' }), CWD),
+      ).toBe('claude --resume abc-123');
+    });
   });
 
   describe('X6 ③ — opt-in permission-mode restore (restorePermissionMode)', () => {

--- a/src/shared/__tests__/agentResume.test.ts
+++ b/src/shared/__tests__/agentResume.test.ts
@@ -226,6 +226,17 @@ describe('toResumeCommand (X6)', () => {
       const next = binding({ permissionMode: 'plan' });
       expect(mergeResumeBinding(undefined, next)).toEqual(next);
     });
+
+    it('does NOT carry sticky fields to a DIFFERENT conversation (CodeRabbit)', () => {
+      // A fresh SessionStart in a reused pane (new sessionId, no tail data yet)
+      // must not inherit the prior conversation's bypassPermissions / transcript.
+      const prev = binding({ sessionId: 'old', permissionMode: 'bypassPermissions', transcriptPath: 'C:\\t\\old.jsonl' });
+      const next = binding({ sessionId: 'new', permissionMode: undefined, transcriptPath: undefined, ts: 9 });
+      const m = mergeResumeBinding(prev, next);
+      expect(m.permissionMode).toBeUndefined();
+      expect(m.transcriptPath).toBeUndefined();
+      expect(m.sessionId).toBe('new');
+    });
   });
 
   describe('permissionFlagFor (pill helper) — the 4-mode mapping', () => {

--- a/src/shared/__tests__/agentResume.test.ts
+++ b/src/shared/__tests__/agentResume.test.ts
@@ -5,6 +5,7 @@ import {
   resumeOfferForRecovered,
   permissionFlagFor,
   mergeResumeBinding,
+  normalizeResumeCwd,
   PERMISSION_FLAG,
   type ResumeBinding,
   type PermissionMode,
@@ -225,6 +226,18 @@ describe('toResumeCommand (X6)', () => {
     it('no prior → returns the new binding unchanged', () => {
       const next = binding({ permissionMode: 'plan' });
       expect(mergeResumeBinding(undefined, next)).toEqual(next);
+    });
+
+    it('normalizeResumeCwd: drive-case + trailing slash compare equal; POSIX stays case-sensitive (codex P2)', () => {
+      expect(normalizeResumeCwd('D:\\repo')).toBe(normalizeResumeCwd('d:/repo/'));
+      expect(normalizeResumeCwd('C:\\Users\\rizz\\')).toBe(normalizeResumeCwd('c:/Users/rizz'));
+      expect(normalizeResumeCwd('/Foo')).not.toBe(normalizeResumeCwd('/foo'));
+    });
+
+    it('toResumeCommand resumes the EXACT id when the binding cwd differs only by format (codex P2)', () => {
+      const b = binding({ sessionId: 'sess-xyz', cwd: 'D:\\repo' });
+      // paneCwd reported as forward-slash / trailing-slash — same dir, must still --resume.
+      expect(toResumeCommand('claude', b, 'd:/repo/')).toContain('--resume sess-xyz');
     });
 
     it('does NOT carry sticky fields to a DIFFERENT conversation (CodeRabbit)', () => {

--- a/src/shared/__tests__/agentResume.test.ts
+++ b/src/shared/__tests__/agentResume.test.ts
@@ -4,6 +4,7 @@ import {
   isResumableLaunchCommand,
   resumeOfferForRecovered,
   permissionFlagFor,
+  mergeResumeBinding,
   PERMISSION_FLAG,
   type ResumeBinding,
   type PermissionMode,
@@ -192,6 +193,38 @@ describe('toResumeCommand (X6)', () => {
       expect(toResumeCommand('claude', binding({ permissionMode: 'bypassPermissions' }), CWD)).toBe(
         'claude --resume abc-123',
       );
+    });
+  });
+
+  describe('mergeResumeBinding — sticky permissionMode / transcriptPath (codex P2)', () => {
+    it('keeps a prior permissionMode when the new capture lacks one (tail miss)', () => {
+      const prev = binding({ permissionMode: 'bypassPermissions' });
+      const next = binding({ permissionMode: undefined, ts: 2 });
+      expect(mergeResumeBinding(prev, next).permissionMode).toBe('bypassPermissions');
+    });
+
+    it('a real mode change still overrides the prior (not blindly sticky)', () => {
+      const prev = binding({ permissionMode: 'bypassPermissions' });
+      const next = binding({ permissionMode: 'acceptEdits', ts: 2 });
+      expect(mergeResumeBinding(prev, next).permissionMode).toBe('acceptEdits');
+    });
+
+    it('keeps a prior transcriptPath when the new capture omits it', () => {
+      const prev = binding({ transcriptPath: 'C:\\t\\abc.jsonl' });
+      const next = binding({ transcriptPath: undefined, ts: 2 });
+      expect(mergeResumeBinding(prev, next).transcriptPath).toBe('C:\\t\\abc.jsonl');
+    });
+
+    it('takes the latest sessionId/cwd/ts (stable fields are not sticky)', () => {
+      const prev = binding({ sessionId: 'old', cwd: 'C:\\a', ts: 1 });
+      const next = binding({ sessionId: 'new', cwd: 'C:\\b', ts: 9 });
+      const m = mergeResumeBinding(prev, next);
+      expect([m.sessionId, m.cwd, m.ts]).toEqual(['new', 'C:\\b', 9]);
+    });
+
+    it('no prior → returns the new binding unchanged', () => {
+      const next = binding({ permissionMode: 'plan' });
+      expect(mergeResumeBinding(undefined, next)).toEqual(next);
     });
   });
 

--- a/src/shared/__tests__/agentResume.test.ts
+++ b/src/shared/__tests__/agentResume.test.ts
@@ -1,5 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { toResumeCommand, isResumableLaunchCommand, resumeOfferForRecovered } from '../agentResume';
+import {
+  toResumeCommand,
+  isResumableLaunchCommand,
+  resumeOfferForRecovered,
+  permissionFlagFor,
+  PERMISSION_FLAG,
+  type ResumeBinding,
+  type PermissionMode,
+} from '../agentResume';
+
+const CWD = 'D:\\wmux';
+const binding = (over: Partial<ResumeBinding> = {}): ResumeBinding => ({
+  agent: 'claude',
+  sessionId: 'abc-123',
+  cwd: CWD,
+  ts: 1,
+  ...over,
+});
 
 describe('toResumeCommand (X6)', () => {
   describe('rewrites known agent launchers', () => {
@@ -83,6 +100,109 @@ describe('toResumeCommand (X6)', () => {
     it('empty / whitespace → unchanged', () => {
       expect(toResumeCommand('')).toBe('');
       expect(toResumeCommand('   ')).toBe('   ');
+    });
+  });
+
+  describe('X6 ③ — id-aware resume with a binding', () => {
+    it('binding + cwd match → --resume <id> (no permFlag by default, D6 fail-safe)', () => {
+      expect(toResumeCommand('claude', binding(), CWD)).toBe('claude --resume abc-123');
+    });
+
+    it('preserves trailing args after the inserted --resume', () => {
+      expect(toResumeCommand('claude --model opus', binding(), CWD)).toBe(
+        'claude --resume abc-123 --model opus',
+      );
+    });
+
+    it('cwd MISMATCH → falls back to --continue (F7: --resume is cwd-scoped)', () => {
+      expect(toResumeCommand('claude', binding({ cwd: 'C:\\other' }), CWD)).toBe('claude --continue');
+    });
+
+    it('no paneCwd provided → cannot prove cwd match → --continue', () => {
+      expect(toResumeCommand('claude', binding())).toBe('claude --continue');
+    });
+
+    it('binding for a DIFFERENT agent slug → --continue', () => {
+      expect(toResumeCommand('claude', binding({ agent: 'codex' }), CWD)).toBe('claude --continue');
+    });
+
+    it('binding with an empty sessionId → --continue', () => {
+      expect(toResumeCommand('claude', binding({ sessionId: '' }), CWD)).toBe('claude --continue');
+    });
+
+    it('undefined binding → --continue (today’s behavior, unchanged)', () => {
+      expect(toResumeCommand('claude', undefined, CWD)).toBe('claude --continue');
+    });
+
+    it('already --resume <id> → unchanged even with a binding (no double-resume)', () => {
+      const c = 'claude --resume zzz-999';
+      expect(toResumeCommand(c, binding(), CWD)).toBe(c);
+    });
+
+    it('idempotent: re-applying the id-aware build is a fixpoint', () => {
+      const once = toResumeCommand('claude --model opus', binding(), CWD);
+      expect(toResumeCommand(once, binding(), CWD)).toBe(once);
+    });
+  });
+
+  describe('X6 ③ — opt-in permission-mode restore (restorePermissionMode)', () => {
+    const opt = { restorePermissionMode: true };
+
+    it('bypassPermissions → --resume <id> --dangerously-skip-permissions', () => {
+      expect(toResumeCommand('claude', binding({ permissionMode: 'bypassPermissions' }), CWD, opt)).toBe(
+        'claude --resume abc-123 --dangerously-skip-permissions',
+      );
+    });
+
+    it('acceptEdits → --resume <id> --permission-mode acceptEdits', () => {
+      expect(toResumeCommand('claude', binding({ permissionMode: 'acceptEdits' }), CWD, opt)).toBe(
+        'claude --resume abc-123 --permission-mode acceptEdits',
+      );
+    });
+
+    it('plan → --resume <id> --permission-mode plan', () => {
+      expect(toResumeCommand('claude', binding({ permissionMode: 'plan' }), CWD, opt)).toBe(
+        'claude --resume abc-123 --permission-mode plan',
+      );
+    });
+
+    it('default → --resume <id> (no flag, even when opted in)', () => {
+      expect(toResumeCommand('claude', binding({ permissionMode: 'default' }), CWD, opt)).toBe(
+        'claude --resume abc-123',
+      );
+    });
+
+    it('no permissionMode captured → --resume <id> only', () => {
+      expect(toResumeCommand('claude', binding(), CWD, opt)).toBe('claude --resume abc-123');
+    });
+
+    it('opt-in has NO effect on the --continue fallback (cwd mismatch)', () => {
+      expect(
+        toResumeCommand('claude', binding({ cwd: 'C:\\other', permissionMode: 'bypassPermissions' }), CWD, opt),
+      ).toBe('claude --continue');
+    });
+
+    it('default OFF: bypass binding does NOT auto-add the flag (D6 fail-safe)', () => {
+      expect(toResumeCommand('claude', binding({ permissionMode: 'bypassPermissions' }), CWD)).toBe(
+        'claude --resume abc-123',
+      );
+    });
+  });
+
+  describe('permissionFlagFor (pill helper) — the 4-mode mapping', () => {
+    it('maps every mode', () => {
+      expect(permissionFlagFor('bypassPermissions')).toBe('--dangerously-skip-permissions');
+      expect(permissionFlagFor('acceptEdits')).toBe('--permission-mode acceptEdits');
+      expect(permissionFlagFor('plan')).toBe('--permission-mode plan');
+      expect(permissionFlagFor('default')).toBe('');
+    });
+    it('undefined → empty string', () => {
+      expect(permissionFlagFor(undefined)).toBe('');
+    });
+    it('PERMISSION_FLAG table covers exactly the 4 modes', () => {
+      expect(Object.keys(PERMISSION_FLAG).sort()).toEqual(
+        (['acceptEdits', 'bypassPermissions', 'default', 'plan'] as PermissionMode[]).sort(),
+      );
     });
   });
 

--- a/src/shared/agentResume.ts
+++ b/src/shared/agentResume.ts
@@ -176,8 +176,17 @@ export function mergeResumeBinding(
   next: ResumeBinding,
 ): ResumeBinding {
   const merged: ResumeBinding = { ...next };
-  if (!merged.permissionMode && prev?.permissionMode) merged.permissionMode = prev.permissionMode;
-  if (!merged.transcriptPath && prev?.transcriptPath) merged.transcriptPath = prev.transcriptPath;
+  // Sticky fields are only valid for the SAME conversation. When next points at
+  // a different session/cwd/agent (e.g. a fresh SessionStart in a reused pane),
+  // carrying prev's permissionMode/transcriptPath forward would leak the old
+  // pane's bypassPermissions or run the D5 liveness probe against the wrong file
+  // (CodeRabbit). Gate the carry-forward on conversation identity.
+  const sameConversation =
+    prev?.agent === next.agent &&
+    prev?.sessionId === next.sessionId &&
+    prev?.cwd === next.cwd;
+  if (sameConversation && !merged.permissionMode && prev?.permissionMode) merged.permissionMode = prev.permissionMode;
+  if (sameConversation && !merged.transcriptPath && prev?.transcriptPath) merged.transcriptPath = prev.transcriptPath;
   return merged;
 }
 

--- a/src/shared/agentResume.ts
+++ b/src/shared/agentResume.ts
@@ -163,6 +163,25 @@ function launcherStem(firstToken: string): string {
 }
 
 /**
+ * X6 ③: merge a freshly-captured binding over the previously-persisted one,
+ * keeping `permissionMode` and `transcriptPath` STICKY. The bridge reads
+ * permissionMode from the transcript's last 64KB; a turn that writes >64KB after
+ * the last user line makes that read miss and return undefined (codex review
+ * 2026-06-14). A capture that couldn't observe the mode must NOT wipe a mode we
+ * already captured — so undefined fields fall back to the prior binding's value.
+ * `sessionId`/`cwd` always take the latest (they come from stable fields).
+ */
+export function mergeResumeBinding(
+  prev: ResumeBinding | undefined,
+  next: ResumeBinding,
+): ResumeBinding {
+  const merged: ResumeBinding = { ...next };
+  if (!merged.permissionMode && prev?.permissionMode) merged.permissionMode = prev.permissionMode;
+  if (!merged.transcriptPath && prev?.transcriptPath) merged.transcriptPath = prev.transcriptPath;
+  return merged;
+}
+
+/**
  * Decide what to insert after the launcher token: an id-aware
  * `--resume <id> [permFlag]` when a valid binding exists for THIS launcher and
  * its origin cwd still matches the pane (F7: `--resume` is cwd-scoped), or the

--- a/src/shared/agentResume.ts
+++ b/src/shared/agentResume.ts
@@ -81,6 +81,14 @@ export interface ResumeBinding {
   cwd: string;
   /** Last-observed permission mode (F5). Restored only on explicit user intent. */
   permissionMode?: PermissionMode;
+  /**
+   * Absolute path to the origin transcript `.jsonl`. Stored so staleness can be
+   * decided by an `fs.existsSync` probe (D5) — a purged id makes `--resume` a
+   * "No conversation found." dead-end (F8 — it exits 0, so no exit-code signal).
+   * Storing the exact path keeps the probe slug-rule-free (claude's cwd→slug
+   * mapping is version-drift-prone; capture deliberately avoided depending on it).
+   */
+  transcriptPath?: string;
   /** Capture time (ms). Staleness is decided by existence-probe, not a TTL. */
   ts: number;
 }

--- a/src/shared/agentResume.ts
+++ b/src/shared/agentResume.ts
@@ -64,6 +64,22 @@ export function permissionFlagFor(mode: PermissionMode | undefined): string {
 }
 
 /**
+ * Normalize a cwd for resume-binding equality: backslashes → forward slashes,
+ * lowercase a leading Windows drive letter, strip a trailing separator. POSIX
+ * paths stay case-sensitive. So `D:\repo` and `d:/repo/` compare equal but
+ * `/Foo` and `/foo` do not. Shared by the resume builder, the daemon recovery /
+ * spool guards, and the renderer pill so all agree on "same directory" — a raw
+ * `===` rejected harmless formatting diffs and dropped a valid exact resume to
+ * `--continue` (codex P2).
+ */
+export function normalizeResumeCwd(p: string): string {
+  let out = p.replace(/\\/g, '/');
+  if (/^[A-Za-z]:\//.test(out)) out = out[0].toLowerCase() + out.slice(1);
+  if (out.length > 1 && out.endsWith('/')) out = out.slice(0, -1);
+  return out;
+}
+
+/**
  * X6 ③: a per-session resume binding, captured live from the claude hook and
  * persisted on the daemon session record so it survives a SIGKILL/reboot.
  *
@@ -215,7 +231,7 @@ function resumeInsertion(
     binding.sessionId &&
     binding.cwd &&
     paneCwd &&
-    binding.cwd === paneCwd
+    normalizeResumeCwd(binding.cwd) === normalizeResumeCwd(paneCwd)
   ) {
     const parts = ['--resume', binding.sessionId];
     if (options?.restorePermissionMode) {

--- a/src/shared/agentResume.ts
+++ b/src/shared/agentResume.ts
@@ -33,6 +33,59 @@ const RESUME_FLAG_BY_LAUNCHER: Readonly<Record<string, string>> = {
 };
 
 /**
+ * X6 ③: Claude Code's per-invocation permission mode, as stamped on every user
+ * turn in the `.jsonl` transcript (`"permissionMode":"bypassPermissions"`, etc.).
+ * Permission mode is NOT restored state — it must be RE-APPLIED as a launch flag
+ * on resume, or a `--dangerously-skip-permissions` workflow drops back to prompts
+ * after a reboot.
+ */
+export type PermissionMode = 'bypassPermissions' | 'acceptEdits' | 'plan' | 'default';
+
+/**
+ * permissionMode → the launch flag that re-enables it. `default` maps to no flag
+ * (Claude's normal prompting). Verified 2026-06-14 (live): `--resume <id>` and
+ * `--dangerously-skip-permissions` coexist (F6).
+ */
+export const PERMISSION_FLAG: Readonly<Record<PermissionMode, string>> = {
+  bypassPermissions: '--dangerously-skip-permissions',
+  acceptEdits: '--permission-mode acceptEdits',
+  plan: '--permission-mode plan',
+  default: '',
+};
+
+/**
+ * The launch flag(s) that re-apply `mode`, or '' when none is needed (default
+ * mode, unknown mode, or no mode captured). Exported for the resume pill, which
+ * assembles its command progressively rather than via {@link toResumeCommand}.
+ */
+export function permissionFlagFor(mode: PermissionMode | undefined): string {
+  if (!mode) return '';
+  return PERMISSION_FLAG[mode] ?? '';
+}
+
+/**
+ * X6 ③: a per-session resume binding, captured live from the claude hook and
+ * persisted on the daemon session record so it survives a SIGKILL/reboot.
+ *
+ * `sessionId` is the ORIGIN conversation id — derived from the transcript
+ * filename, NOT the hook's `payload.session_id` (which mints a NEW uuid on
+ * resume, upstream #12235; the transcript file is appended in place so its
+ * basename always points at the origin).
+ */
+export interface ResumeBinding {
+  /** Agent launcher slug. 'claude' in v1. */
+  agent: string;
+  /** `--resume` argument: the origin session id (basename of the transcript). */
+  sessionId: string;
+  /** Origin cwd — hard cwd-match guard, since `--resume` is cwd-scoped (F7). */
+  cwd: string;
+  /** Last-observed permission mode (F5). Restored only on explicit user intent. */
+  permissionMode?: PermissionMode;
+  /** Capture time (ms). Staleness is decided by existence-probe, not a TTL. */
+  ts: number;
+}
+
+/**
  * Unquoted tokens that mean "already resuming" or "not a resumable run" →
  * leave the command unchanged. `--continue`/`--resume`/`-c`/`-r` already
  * resume; `-p`/`--print` is a non-interactive one-shot (rewriting it to
@@ -102,14 +155,62 @@ function launcherStem(firstToken: string): string {
 }
 
 /**
+ * Decide what to insert after the launcher token: an id-aware
+ * `--resume <id> [permFlag]` when a valid binding exists for THIS launcher and
+ * its origin cwd still matches the pane (F7: `--resume` is cwd-scoped), or the
+ * launcher's plain `--continue` fallback otherwise.
+ *
+ * The permission flag is OPT-IN (`options.restorePermissionMode`) and OFF by
+ * default. The only auto-run consumer is the supervised replay path, which must
+ * be fail-safe per D6 — never silently re-grant `--dangerously-skip-permissions`
+ * with no human in the loop. The resume pill (explicit user Enter) opts in via
+ * {@link permissionFlagFor} instead of this builder.
+ */
+function resumeInsertion(
+  stem: string,
+  resumeFlag: string,
+  binding: ResumeBinding | undefined,
+  paneCwd: string | undefined,
+  options: { restorePermissionMode?: boolean } | undefined,
+): string {
+  if (
+    binding &&
+    binding.agent === stem &&
+    binding.sessionId &&
+    binding.cwd &&
+    paneCwd &&
+    binding.cwd === paneCwd
+  ) {
+    const parts = ['--resume', binding.sessionId];
+    if (options?.restorePermissionMode) {
+      const permFlag = permissionFlagFor(binding.permissionMode);
+      if (permFlag) parts.push(permFlag);
+    }
+    return parts.join(' ');
+  }
+  return resumeFlag;
+}
+
+/**
  * Return `command` rewritten to resume the agent's previous session, or the
  * command UNCHANGED when it is not a known single-agent launcher, when it is
  * already a resume/one-shot, or when it uses syntax we won't touch (env
  * assignment, pipeline — anything whose first token is not a bare launcher).
  *
- * Idempotent: re-applying never double-adds the flag.
+ * With a valid `binding` whose cwd matches `paneCwd`, resumes the EXACT session
+ * (`--resume <id>`); otherwise falls back to `--continue` (latest-in-cwd, still
+ * correct for the single-session case). Permission-mode restore is opt-in via
+ * `options.restorePermissionMode` (default OFF — D6 fail-safe).
+ *
+ * Idempotent: re-applying never double-adds the flag (`--resume`/`--continue`
+ * are both skip tokens).
  */
-export function toResumeCommand(command: string): string {
+export function toResumeCommand(
+  command: string,
+  binding?: ResumeBinding,
+  paneCwd?: string,
+  options?: { restorePermissionMode?: boolean },
+): string {
   const tokens = tokenize(command);
   if (tokens.length === 0) return command;
 
@@ -128,10 +229,11 @@ export function toResumeCommand(command: string): string {
     if (/^-[a-z]*[crp][a-z]*$/.test(t.value)) return command;
   }
 
-  // Insert the resume flag immediately after the launcher token, preserving the
-  // rest of the command (and its spacing/quoting) verbatim.
+  // Insert the resume tokens immediately after the launcher token, preserving
+  // the rest of the command (and its spacing/quoting) verbatim.
+  const insert = resumeInsertion(stem, resumeFlag, binding, paneCwd, options);
   const at = tokens[0].end;
-  return `${command.slice(0, at)} ${resumeFlag}${command.slice(at)}`;
+  return `${command.slice(0, at)} ${insert}${command.slice(at)}`;
 }
 
 /** Whether a launch command would be rewritten by {@link toResumeCommand}. */

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -189,6 +189,14 @@ export function getPipeName(): string {
 export const ENV_KEYS = {
   WORKSPACE_ID: 'WMUX_WORKSPACE_ID',
   SURFACE_ID: 'WMUX_SURFACE_ID',
+  // X6 ③: the daemon session id of the pane, injected by the daemon at spawn
+  // (DaemonSessionManager.createSession). Unlike SURFACE_ID — which the renderer
+  // never supplies at pty.create time because a surface is minted AFTER the pty
+  // exists — the daemon always knows its own session id, so this is the one
+  // per-pane identifier that reliably reaches the child shell (and the Claude
+  // hook bridge). Lets a hook attribute its capture to the EXACT pane instead of
+  // collapsing to the workspace's active surface (split-pane / shared-cwd fix).
+  PTY_ID: 'WMUX_PTY_ID',
   SOCKET_PATH: 'WMUX_SOCKET_PATH',
   AUTH_TOKEN: 'WMUX_AUTH_TOKEN',
   SHELL_HOOK: 'WMUX_SHELL_HOOK',

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -1,5 +1,7 @@
 // === JSON-RPC Protocol Types ===
 
+import type { ResumeBinding } from './agentResume';
+
 export interface RpcRequest {
   id: string;
   method: RpcMethod;
@@ -141,6 +143,7 @@ export type RpcMethod =
   | 'daemon.compact'
   | 'daemon.superviseRearm'
   | 'daemon.superviseStop'
+  | 'daemon.setResumeBinding'
   | 'a2a.resolve.identity'
   | 'a2a.whoami'
   | 'a2a.discover'
@@ -243,6 +246,7 @@ export const ALL_RPC_METHODS = [
   'daemon.compact',
   'daemon.superviseRearm',
   'daemon.superviseStop',
+  'daemon.setResumeBinding',
   'a2a.resolve.identity',
   'a2a.whoami',
   'a2a.discover',
@@ -394,6 +398,16 @@ export interface SupervisionRuntime {
 
 export interface DaemonSessionIdParams {
   id: string;
+}
+
+/**
+ * X6 ③: persist a resume binding on a session (daemon-side, saveImmediate).
+ * `id` is the daemon session id (== ptyId); `resumeBinding.sessionId` is the
+ * claude conversation id captured from the hook (transcript basename).
+ */
+export interface DaemonSetResumeBindingParams {
+  id: string;
+  resumeBinding: ResumeBinding;
 }
 
 export interface DaemonResizeParams {


### PR DESCRIPTION
## What

X6 ③ — resume-by-id. After a daemon restart or OS reboot, wmux revives the
*exact* Claude conversation that was running in each pane (`claude --resume <id>`,
with the captured permission mode), not a fresh shell or a fuzzy `--continue`. And
it now works for **every** pane that ran Claude, not only the one whose live
startup banner happened to be caught.

## Why

The reboot-resume "▶ Resume Claude" pill reliably appeared on only one pane. An
eng-review found the data model (`ptyId` as the join key) and the display path are
sound — this was purely a *capture* problem with two independent fragilities:

1. The pill's sole gate, `lastDetectedAgent`, is written only when the live
   `AgentDetector` catches Claude's startup banner. That is once-per-session and
   restored scrollback is never re-fed, so a pane whose banner streamed before the
   daemon attached never re-arms it after a reboot.
2. The exact-uuid `resumeBinding` had no durable fallback, and its hook routing
   collapsed every pane in a workspace to the active surface (`WMUX_SURFACE_ID` is
   never injected — the renderer mints a surface only *after* `pty.create`). Split
   / shared-cwd panes clobbered each other's binding.

## How

The `ptyId` join key is unchanged. Three capture-reliability rungs:

- **Per-pane routing.** The daemon stamps `WMUX_PTY_ID` (its own session id) into
  each pane's env at spawn — the one per-pane key that reliably reaches the child
  shell and the hook bridge. The bridge echoes it; `resolvePtyIdForSignal` trusts
  `signal.ptyId` when it maps to a live pane *and* belongs to the claimed
  workspace, falling back to workspaceId/cwd otherwise.
- **Second pill writer.** `daemon.setResumeBinding` also arms `lastDetectedAgent`
  (a captured hook proves the pane ran Claude), so a banner-missed-but-hook-landed
  pane shows the pill with its exact binding instead of nothing.
- **Durable spool.** On a failed capture RPC (main pipe down at boot,
  no-workspace-match, timeout) the bridge appends a self-describing record to
  `~/.wmux/resume-spool/<ptyId>.json` (pipe-free, last-write-wins). The daemon
  ingests it on recovery and a 60s timer, attributing by exact `ptyId` with the F7
  cwd-match, D5 transcript-existence, and a stale-clobber guard. Disk
  cwd-inference is deliberately *not* used — it mis-attributes under a shared cwd.

This branch also contains the earlier X6 ③ steps: the id-aware resume builder +
permission-mode mapping, the hook → main → daemon binding capture across the
SIGKILL-survival path, the progressive resume pill, and the D5 existence-probe.

## Verification

- `tsc` daemon/root/cli/mcp clean; full unit suite **3256** (+12 new).
- New `scripts/x6-multipane-resume-dogfood.mjs` **11/11** on the real daemon
  bundle — two shared-cwd panes each resume their **own** uuid via the spool (pane
  B never inherits pane A's conversation); a banner-less pane still gets the pill;
  the D5 / F7 / stale-clobber guards hold.
- Existing `scripts/x6-resume-binding-dogfood.mjs` **6/6** (no regression).
- Bridge resume-capture 4/4 + env-capture 4/4 + spool producer.
- Codex review: **PASS** (no P1); 4 P2 hardenings applied and re-reviewed clean.

## Remaining

Deterministic verification is complete. The live packaged-build reboot visual
check (the "▶ Resume Claude" pixels rendering across all workspaces) is the one
manual step left, since a packaged renderer cannot be store-injected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Resume now persists exact session bindings for more reliable recovery, including optional permission-mode restoration.
  * Multi-pane resume routing is improved with per-pane identifiers to reduce mix-ups in shared/cwd scenarios.
  * The resume pill now follows a progressive, permission-aware flow and can offer exact `--resume <id>` when context matches.

* **Documentation**
  * API reference updated to include the new `daemon.setResumeBinding` RPC method.

* **Tests**
  * Added/expanded automated coverage and verification scripts for resume binding durability, routing guards, and replay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->