### PR TITLE
feat(a2a): pane-level A2A identity + addressing & multi-target MCP registration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-resizable-panels": "^4.7.3",
+        "smol-toml": "^1.6.1",
         "zod": "^4.3.6",
         "zustand": "^5.0.12"
       },
@@ -12751,6 +12752,18 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/socks": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-resizable-panels": "^4.7.3",
+    "smol-toml": "^1.6.1",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"
   }

--- a/plans/a2a-pane-identity-mcp-registration-IMPL.md
+++ b/plans/a2a-pane-identity-mcp-registration-IMPL.md
@@ -1,0 +1,200 @@
+# Implementation Plan — A2A pane-level identity + addressing ⊕ multi-agent MCP registration
+
+> Grounded against `main @ 6e53b5e` (2026-06-15). Branch: `feat/a2a-pane-identity-mcp-registration`.
+> Source prompt: `plans/a2a-pane-identity-mcp-registration.md`. Backlog: `plans/a2a-multiagent-gaps.md`.
+> Status: **eng-reviewed (plan-eng-review + Codex outside voice), decisions LOCKED.** Size: **Large**.
+
+## Locked decisions (eng-review + user)
+- **D1 = Part A + Part B FULL** — Part B delivers real "reach": registrar/CLI/Settings multi-target **+ Codex `clientName` first-party whitelist (empirically determined) + identity-topology verification + live end-to-end Codex dogfood.** Gemini EXCLUDED (CLI not installed → not empirically verifiable; registry hook only).
+- **D2 = TOML round-trip via `smol-toml`** — robust parse→object→stringify. Accepts comment/ordering loss; preserves all data; only writes on explicit register.
+- **A1 = renderer per-ptyId map** (not MetadataStore). **A5 = clean break on getStatus shape** (internal-only consumers). **Q1 = shared `configIO` extracted** (kill McpRegistrar/CLI duplication).
+- Cross-ws guard = **renderer tree-membership check** (the real guard); drop the false `assertWorkspaceOwnsPty` parity claim (A2A delivery bypasses `input.send` via `pty.write`).
+
+---
+
+## Goal
+- **Part A — Precision**: pane-level A2A identity + addressing (fixes gaps 1/3/8). One ws hosts ≥2 agents, each individually addressable, each correctly labeled.
+- **Part B — Reach**: non-Claude agents (Codex) actually usable on the A2A channel — register config **and** pass the permission enforcer **and** resolve workspace identity.
+
+Invariants: #163 cross-ws fail-closed intact (pane addressing ws-scoped); substrate neutrality; empirical gate (no unverified path shipped); foreign config keys never modified; atomic writes.
+
+---
+
+## Current-state ground truth (verified by exploration, not old notes)
+
+### Part A
+- `AgentDetector` is **already per-PTY**: `PTYBridge.ts:252` `agentDetectors.set(ptyId, new AgentDetector())`. `getLastAgent()` `:302`.
+- `PTYBridge.onEvent` → `broadcastMetadataUpdate(win, { ptyId, agentStatus, agentName })` `:393-453`; `onActive` → `{ ptyId, agentStatus:'running', agentName:lastAgent }` `:459-472`. **ptyId already flows.**
+- Renderer `useNotificationListener.ts:435-516` receives METADATA_UPDATE, resolves ptyId→pane (`findSurfaceByPtyId`), writes `agentName`/`agentStatus` to **ws-level** `WorkspaceMetadata` (last-writer-wins, `workspaceSlice.ts:249-262`). Mirrors only `agentStatus` per-ptyId into transient `surfaceAgentStatus: Record<ptyId,AgentStatus>` (`paneSlice.ts:128-140`, ATTENTION_STATUSES only → cannot hold identity).
+- `surface.list`/`pane.list`/`a2a.discover` computed in renderer `useRpcBridge.ts:429 / :554 / :1113-1157`. `surface.list` returns `{id,ptyId,paneId,surfaceType,isActive,...}`; `pane.list` returns `{id,metadata,surfacePtyIds,...}`; `a2a.discover` is ws-level (`description: agentName`, `metadata.status: agentStatus ?? 'idle'`).
+- `a2a.task.send` delivery: renderer `useRpcBridge.ts:1159-1297`; target ws by fuzzy `to`; delivery via `deliverPtyNotification` `:155-170` (active pane → first non-browser surface ptyId) or `deliverPtyNudge` for live TUI.
+- a2a task `to` type: `WmuxTaskMetadata.to = { workspaceId, name }` (`types.ts:557-564`); `createA2aTask` mirrors it (`a2aSlice.ts`).
+- Surface removal: **`surfaceSlice.closeSurface(paneId, surfaceId, workspaceId)`** `:113` (NOT paneSlice). ws reset clears transient maps in `workspaceSlice`. Agent backfill via `metadata.resolveAgent()` writes ws-level only (`useNotificationListener.ts`).
+
+### Part B
+- `McpRegistrar.ts` (main): `~/.claude.json` only; hardcodes `wmux`/`wmux-a2a`; in-memory `ownedKeys`; atomic write; proto-pollution guard.
+- **`src/cli/commands/mcp.ts` DUPLICATES** registration (own path/atomic-write/hardcoded keys). Both must generalize → extract shared `configIO`.
+- IPC `mcp:check|reregister|unregister` (`shared/constants.ts:131-134`) → `mcp.handler.ts` serialize `McpRegistrarStatus → McpStatusPayload {wmux,wmuxA2a,configPath,...}`. Singleton `main/index.ts:278`.
+- Settings `SettingsPanel.tsx McpStatusSection` (~585-742): two hardcoded rows, "~/.claude.json" copy.
+- **`FirstRunOrchestrator.registerMcp()`** preflights `~/.claude.json` only; failures swallowed (Codex #11).
+- **Enforcer (the killer — Codex #1, CONFIRMED)**: `firstParty.ts:47-49` `FIRST_PARTY_CLIENT_NAMES = Set(['claude-code'])`. Packaged build = enforce mode. Bundled server can't `declarePermissions` (calls `wmux.internal` reserved methods) → only passes via clientName whitelist. **Non-Claude host → `unconfirmed` → every capability RPC rejected, no recovery.** `FIRST_PARTY_METHODS` already includes `a2a.*`/`pane.*`/`browser.*`/`company.a2a.*`. Comment explicitly invites adding hosts. `firstParty.test.ts` parses `src/mcp/` for called methods.
+- **Identity topology (Codex #2, CONFIRMED)**: `mcp/index.ts:113-122` walks `process.ppid` 10 hops (MCP→host CLI→shell PTY) against the pid-map. Verified for Claude only. Codex must launch MCP as a PTY descendant for this to resolve.
+- **No TOML dep.** Codex installed + real `~/.codex/config.toml` (TOML, `[projects.'d:\wmux']`, `[tui.*]`). Gemini CLI absent.
+
+---
+
+## Design — Part A (pure renderer derivation)
+
+**Store** (`paneSlice.ts`): add `surfaceAgent: Record<string, { name: string; status: AgentStatus }>` + `setSurfaceAgent(ptyId, name, status)`. Unlike `surfaceAgentStatus`, **keep on idle** (identity persists while PTY lives); only clear when the ptyId's surface is gone.
+- Write from `useNotificationListener.ts` METADATA_UPDATE handler when `ptyId` present and `agentName` non-empty (**guard: never overwrite a known name with ''** — Codex #3/empty-running). Also add to the `metadata.resolveAgent()` backfill path so early detector events aren't lost per-surface (Codex #8).
+- **Cleanup wiring (Codex #9)**: clear `surfaceAgent[ptyId]` in `surfaceSlice.closeSurface` (resolve ptyId from the closed surface), in `workspaceSlice` ws-reset/clear paths, and on session-restore replace. Mirror wherever `surfaceAgentStatus` is cleared.
+
+**Derivations** (`useRpcBridge.ts`):
+- `surface.list`: per entry += `agentName: string|null`, `agentStatus: AgentStatus|null` (lookup `surfaceAgent[ptyId]`).
+- `pane.list`: per leaf += `agents: Array<{ ptyId, agentName, agentStatus }>` (a leaf may hold many surfaces).
+- `a2a.discover`: per ws agent += `panes: Array<{ paneId, surfaceId, ptyId, agentName, agentStatus }>` (fixes 3/8). **Codex #7**: also expose a clear address object so clients iterating only `agents` aren't blind — document `panes[]` as the addressable unit and keep ws-level fields for back-compat.
+
+**Addressing** (`a2a_task_send`):
+- MCP tool (`src/mcp/index.ts`): add optional `pane_id`, `surface_id` (snake_case). **Codex #6**: if BOTH given and they disagree (surface not in that pane) → **reject** (`error`), never silently prefer one.
+- Renderer delivery: new `deliverPtyNotificationTo(targetWs, { paneId, surfaceId }, sender, msg)`. Resolve explicit leaf/surface → ptyId; **require membership in `targetWs`'s tree** (the real cross-ws guard); if an explicit address is given but not found/foreign → **return error, do NOT fall back to active-pane** (Codex #3 silent-misdelivery). `surface_id` → its ptyId; `pane_id` → that leaf's active terminal surface ptyId.
+- Store: `WmuxTaskMetadata.to` += `paneId?`, `surfaceId?` (`types.ts`); `createA2aTask` stores them (`a2aSlice.ts`).
+- **Replies (Codex #4)**: persist addressing for both participants (or reply to the original addressed pane). Reply branch resolves the counterpart's stored `paneId`/`surfaceId` instead of active-pane.
+- **`execute:true` fix (Codex #5)**: `a2a.rpc.ts` currently `receiverWsId = params.to` (raw fuzzy). Use the **renderer-resolved** workspaceId (return it in the `a2a.task.send` result and read it in main) so confirm/`ClaudeWorker.execute` get the real id.
+
+## Design — Part B (multi-target, full reach)
+
+**Shared** `src/shared/mcpTargets.ts` (NEW): `McpTarget { id:'claude'|'codex'|'gemini'; displayName; configPath(home); format:'json'|'toml'; createIfMissing: boolean; verified: boolean }`.
+- claude: json, `~/.claude.json`, createIfMissing **true**, verified true.
+- codex: toml, `~/.codex/config.toml`, createIfMissing **false** (write only if dir/file exists), verified **true** (after live verification).
+- gemini: json, `~/.gemini/settings.json`, createIfMissing **false**, verified **false** (registry hook; UI shows "not detected"; never created). **(Codex #10 per-target create policy.)**
+
+**Shared** `src/shared/configIO.ts` (NEW): format-aware, used by BOTH McpRegistrar + CLI (Q1 DRY):
+- `readServers(target) → { [key]: scriptPath|null }` (json: `JSON.parse` proto-guarded; toml: `smol-toml` parse).
+- `upsertServer(target, key, entry)` / `removeServer(target, keys)` (json: object merge + 2-space stringify; toml: parse→set `mcp_servers[key]`→`smol-toml` stringify — **round-trip, D2**). Atomic (tmp+rename) for both.
+- **Corrupt config → register aborts with a clear error (no clobber); getStatus reports not-registered** (no throw).
+- **ownedKeys (Codex #12)**: only manage a key whose existing value exactly matches our `{command:'node',args:[ourScript]}` shape, OR that we wrote this session. A foreign hand-authored `[mcp_servers.wmux]` with a different command is left untouched + surfaced as "foreign" in status. (Idempotent re-register = no-op.)
+
+**`McpRegistrar.ts`**: per-target loop in `register`/`forceUnregister`/`getStatus`; `McpRegistrarStatus → { targets: McpTargetStatus[]; ... }` (clean break, A5). `McpTargetStatus = { id, displayName, configPath, configExists, configModified, format, verified, servers: { wmux, wmuxA2a } }`.
+
+**Enforcer (Part B reach — Codex #1)**: empirically capture Codex's MCP `clientInfo.name` (live), add it to `FIRST_PARTY_CLIENT_NAMES` in `firstParty.ts`, update `firstParty.test.ts`. Security note: extends the **curated** allowlist (not a blanket bypass) to the Codex-hosted bundle; same same-user best-effort threat model documented in `firstParty.ts`. Flag for the reviewer.
+
+**Identity (Codex #2)**: live-verify the ppid walk resolves when codex runs in a wmux pane (MCP→codex→pwsh PTY). If Codex spawns MCP out-of-band, document the limitation + keep verified:false for codex until resolved.
+
+**Surfaces**: `mcp.handler.ts` serialize multi-target; preload/`McpStatusPayload` multi-target; `SettingsPanel.tsx` dynamic per-target render (displayName + configExists + per-server rows + "not detected"); `cli/commands/mcp.ts` loop registry via shared `configIO` (+ optional `--target <id>`); `FirstRunOrchestrator.registerMcp()` per-target preflight, surface per-target errors (Codex #11). `package.json` += `smol-toml` (bundle into main + CLI esbuild). `docs/api/*` + CLI help regen (Codex #15).
+
+---
+
+## File-by-file
+**Part A:** `paneSlice.ts` · `surfaceSlice.ts` (cleanup) · `workspaceSlice.ts` (reset cleanup) · `useNotificationListener.ts` · `useRpcBridge.ts` · `src/mcp/index.ts` (tool params) · `shared/types.ts` · `a2aSlice.ts` · `a2a.rpc.ts` (resolved wsId for execute).
+**Part B:** `shared/mcpTargets.ts` (NEW) · `shared/configIO.ts` (NEW) · `McpRegistrar.ts` · `mcp.handler.ts` · preload + payload type · `SettingsPanel.tsx` · `cli/commands/mcp.ts` · `firstParty.ts` (+ `firstParty.test.ts`) · `FirstRunOrchestrator.ts` · `package.json` · `docs/api/reference.md` (regen if drift).
+
+---
+
+## Test coverage diagram (target 100% of new paths)
+
+```
+PART A — CODE PATHS
+[+] paneSlice.surfaceAgent
+    ├─ [★★★] set new / update / keep-on-idle / clear-on-close            paneSlice.test.ts (NEW)
+    └─ [★★★] guard: empty agentName does NOT overwrite known name        paneSlice.test.ts
+[+] useNotificationListener METADATA_UPDATE → setSurfaceAgent
+    ├─ [★★ ] ptyId+name → map written                                    useNotificationListener.test.ts
+    └─ [★★ ] resolveAgent backfill also writes surfaceAgent              useNotificationListener.test.ts
+[+] useRpcBridge derivations
+    ├─ [★★★] surface.list/pane.list agent labels per ptyId (2 agents/1 ws) useRpcBridge.*.test.ts (jsdom)
+    └─ [★★★] a2a.discover panes[] distinguishes 2 agents                  useRpcBridge.*.test.ts
+[+] a2a.task.send addressing
+    ├─ [★★★] surface_id → that pane only (sibling untouched)              useRpcBridge.*.test.ts
+    ├─ [★★★] pane_id → leaf active terminal surface                       useRpcBridge.*.test.ts
+    ├─ [★★★] CROSS-WS paneId rejected (fail-closed)                       useRpcBridge.*.test.ts
+    ├─ [★★★] explicit address not-found → error, NO active-pane fallback  useRpcBridge.*.test.ts
+    ├─ [★★★] pane_id+surface_id disagree → reject                         useRpcBridge.*.test.ts
+    └─ [★★★] reply pins to counterpart's stored address                   useRpcBridge.*.test.ts
+[+] a2a.rpc execute:true uses resolved wsId                               a2a.rpc.test.ts
+
+PART B — CODE PATHS
+[+] configIO (json + toml)
+    ├─ [★★★] toml round-trip: foreign [projects.*]/[tui.*] data preserved configIO.test.ts (NEW)
+    ├─ [★★★] toml/json upsert idempotent (re-register no-op)              configIO.test.ts
+    ├─ [★★★] removeServer removes only our keys                           configIO.test.ts
+    ├─ [★★★] corrupt config → register aborts (no clobber)                configIO.test.ts
+    └─ [★★★] foreign hand-authored key (different command) untouched      configIO.test.ts
+[+] McpRegistrar multi-target
+    ├─ [★★★] getStatus targets[] (json+toml, missing-skip, corrupt)       McpRegistrar.test.ts (extend)
+    ├─ [★★★] register writes correct format per target                    McpRegistrar.test.ts
+    ├─ [★★★] codex createIfMissing=false → no file created when absent     McpRegistrar.test.ts
+    ├─ [★★★] gemini never created                                         McpRegistrar.test.ts
+    └─ [★★★] forceUnregister per target                                   McpRegistrar.test.ts
+[+] firstParty
+    └─ [★★★] codex clientName first-party + method set invariant           firstParty.test.ts (update)
+[+] FirstRunOrchestrator multi-target preflight + per-target error        FirstRunOrchestrator.test.ts (extend)
+[+] CLI parity                                                            cli mcp test (extend/mirror)
+
+LIVE DOGFOOD ([→E2E], packaged exe + WMUX_DATA_SUFFIX isolation)
+ ├─ Part A: 2 panes/1 ws, distinct spoofed agents → discover/surface_list labels + surface_id routing + cross-ws reject
+ ├─ Part B-config: isolated HOME, fake ~/.codex/config.toml w/ [projects.*] → register → foreign table byte-preserved, getStatus accurate, unregister clean
+ └─ Part B-reach [CRITICAL]: register wmux into throwaway ~/.codex/config.toml, launch REAL codex in a wmux pane → confirm codex lists wmux MCP tools AND a tool call (a2a_discover/pane_list) succeeds (passes enforcer + resolves workspace). This is the empirical gate that proves "reach".
+```
+
+## Failure modes (new codepaths)
+- TOML write corrupts user config → atomic write + abort-on-corrupt + write-only-on-register; test covers. Visible error, not silent.
+- Codex clientName not whitelisted → enforce-mode rejection → **caught by Part B-reach dogfood** (the whole point). Visible (tool calls fail in codex).
+- Identity walk miss for Codex topology → a2a tools throw "Workspace identity unknown" (existing clear error). Verified live.
+- surfaceAgent stale after close → cleanup wiring + test. Would otherwise show a dead agent label (silent) → **critical to wire all clear paths**.
+- empty-name overwrite race → guard + test.
+
+## NOT in scope
+- **Gemini** active support (not installed/verifiable; registry hook + "not detected" UI only).
+- macOS Claude Desktop config path (existing pending note).
+- A2A liveness/heartbeat (gap 5, rider ③).
+- Persisting agent identity across reboot (ephemeral by design).
+- Cryptographic first-party identity (peer-PID/nonce) — issue #113, multi-user transport.
+- Out-of-band Codex MCP topology workaround (documented limitation if live verify fails).
+
+## What already exists (reused, not rebuilt)
+- per-PTY `AgentDetector` + ptyId in METADATA_UPDATE (Part A needs no main change).
+- `surfaceAgentStatus` map pattern (mirror for `surfaceAgent`).
+- `firstParty.ts` curated allowlist (extend the Set, not the mechanism).
+- pid-map identity walk (reuse; just verify topology).
+- McpRegistrar atomic-write + proto-guard; CLI register flow (generalize via shared `configIO`).
+- Dogfood harness `scripts/a2a-eventbus-dogfood.mjs` / `s-c2-fleet-deepening-dogfood.mjs` (copy isolation + RPC).
+
+## Parallelization (worktree lanes)
+| Lane | Modules | Depends on |
+|------|---------|------------|
+| A | `renderer/stores`, `renderer/hooks`, `src/mcp`, `shared/types`, `main/pipe/handlers/a2a.rpc` | — |
+| B1 | `shared/mcpTargets`, `shared/configIO` (+ smol-toml) | — |
+| B2 | `main/mcp/McpRegistrar`, `firstParty`, `main/ipc`, `main/firstRun`, `renderer/components/Settings`, `cli/commands/mcp` | B1 |
+- **Launch A + B1 in parallel.** B2 waits on B1. Merge → static+units → reviews → dogfood (Part B-reach needs real codex) → PR.
+- No shared module dirs between A and B → clean parallel. A touches `src/mcp/index.ts` (tool defs) and B touches `src/main/mcp/*` — different dirs, no conflict.
+
+## Verification recipe
+- `node_modules/.bin/tsc --noEmit` (0) · eslint changed · `node scripts/gen-api-reference.mjs --check` (regen if drift — Codex #15).
+- `npm run test:parallel` (+ runtime if touched).
+- Live dogfood per diagram (Part B-reach is the gate).
+- Reviews: opus code-reviewer (invariant guard) + Codex PASS → PR → CodeRabbit + Codex re-review.
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 1 | issues_found | 15 findings (2 scope-critical: enforcer first-party + identity topology); folded into plan |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | clean | Scope expanded (Part B reach), 0 unresolved, decisions locked |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+**CODEX (plan):** caught that Part B "register config" alone is theater — non-Claude hosts hit the `claude-code`-only first-party enforcer + an unverified PTY-ancestry identity walk. Reshaped Part B to include first-party whitelist + live end-to-end verification.
+**CROSS-MODEL:** Codex overrode two of my claims (fake assertWorkspaceOwnsPty parity → renderer membership check; surgical TOML → round-trip). assertWorkspaceOwnsPty: accepted. TOML round-trip: REVERSED again during impl — smol-toml stringify silently drops backslashes in literal-string keys (corrupts `[projects.'d:\wmux']`), so SURGICAL block write was used (user-approved); `codex mcp add` itself does surgical append.
+**UNRESOLVED:** none.
+
+## Implementation & verification record (2026-06-16)
+- **Empirical captures**: Codex MCP `clientInfo.name` = `codex-mcp-client` (captured live via a logging MCP stub under isolated `CODEX_HOME`) → added to `FIRST_PARTY_CLIENT_NAMES`. Codex canonical TOML format = `[mcp_servers.<key>]` `command`/`args` (learned via `codex mcp add`). smol-toml round-trip backslash-corruption proven by hexdump → surgical write chosen.
+- **Static**: `tsc --noEmit` 0 · eslint 0 new errors · `gen-api-reference --check` 0 drift (no new RPC method).
+- **Units**: 3402/3402 green. New: configIO (17), mcpRegistration (19), a2aAddressing (11), paneSlice surfaceAgent (5), useRpcBridge wiring guards, McpRegistrar multi-target, firstParty codex.
+- **Live dogfood Part A** (packaged exe, `WMUX_DATA_SUFFIX` isolated, `scripts/a2a-pane-identity-dogfood.mjs`): **11/11** — 2 panes/1 ws spoofed Claude Code + Codex CLI → distinct per-pane labels in surface_list/a2a_discover; `a2a_task_send surface_id` pins delivery + returns toWorkspaceId; cross-ws surface_id REJECTED; pane_id+surface_id disagreement REJECTED.
+- **Live dogfood Part B-config** (real `codex mcp get`): my surgical writer's output is read correctly by the real Codex CLI (backslash path `C:\app\mcp-bundle\index.js` intact); foreign `[projects.'d:\wmux']` + comments byte-preserved.
+- **Reviews**: Claude independent code-reviewer → P1 (inline-table TOML clobber) + P2 (array-of-tables) + P3 (preload mirror) → all fixed (output re-validation guard, bracket-match, preload type). Codex diff review → 4 fixed (reply fail-closed on lost pin, TOML header trailing comment, unregister false-removal, CLI `--target` validation) + 2 accepted-with-rationale (execute is headless ws-level by design; node-foreign `wmux` is reserved-key behavior, already safer than prior shipped code).
+- **Remaining (user-final)**: full GUI visual check + a real Codex-in-a-wmux-pane end-to-end tool call (needs codex running inside a pane; config discovery + enforcer first-party + identity topology each verified independently).
+
+**VERDICT:** ENG CLEARED · implemented · all static+unit+dogfood green · 2 independent reviews reflected. Ready for PR (pending user push approval).

--- a/plans/a2a-pane-identity-mcp-registration-IMPL.md
+++ b/plans/a2a-pane-identity-mcp-registration-IMPL.md
@@ -6,7 +6,7 @@
 
 ## Locked decisions (eng-review + user)
 - **D1 = Part A + Part B FULL** — Part B delivers real "reach": registrar/CLI/Settings multi-target **+ Codex `clientName` first-party whitelist (empirically determined) + identity-topology verification + live end-to-end Codex dogfood.** Gemini EXCLUDED (CLI not installed → not empirically verifiable; registry hook only).
-- **D2 = TOML round-trip via `smol-toml`** — robust parse→object→stringify. Accepts comment/ordering loss; preserves all data; only writes on explicit register.
+- **D2 = surgical TOML block write** (smol-toml parse for READS only) — the initially-chosen round-trip was reversed during implementation: `smol-toml` stringify silently drops backslashes in literal-string keys (would corrupt `[projects.'d:\wmux']`). Surgical insert/replace/remove preserves comments/ordering/keys; only writes on explicit register. (User-approved reversal; `codex mcp add` itself does surgical append.)
 - **A1 = renderer per-ptyId map** (not MetadataStore). **A5 = clean break on getStatus shape** (internal-only consumers). **Q1 = shared `configIO` extracted** (kill McpRegistrar/CLI duplication).
 - Cross-ws guard = **renderer tree-membership check** (the real guard); drop the false `assertWorkspaceOwnsPty` parity claim (A2A delivery bypasses `input.send` via `pty.write`).
 

--- a/scripts/a2a-pane-identity-dogfood.mjs
+++ b/scripts/a2a-pane-identity-dogfood.mjs
@@ -1,0 +1,193 @@
+/*
+ * Live dogfood — Part A: pane-level A2A identity + addressing.
+ *
+ * Spawns an isolated packaged wmux (out/wmux-win32-x64/wmux.exe) with
+ * WMUX_DATA_SUFFIX isolation, splits the default workspace into two panes,
+ * spoofs a DISTINCT agent identity into each pane's PTY (echo banners that the
+ * AgentDetector gate matches), then verifies over the main-pipe RPC:
+ *   - surface.list / pane.list / a2a.discover surface per-pane agent labels
+ *     (one workspace, two distinguishable agents)
+ *   - a2a_task_send with surface_id resolves to the right pane
+ *   - a cross-ws surface_id is rejected (fail-closed, #163)
+ *   - pane_id + disagreeing surface_id is rejected
+ *
+ * Run (PowerShell): npm run package; node scripts/a2a-pane-identity-dogfood.mjs
+ */
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '..');
+const APP_EXE = path.join(REPO_ROOT, 'out', 'wmux-win32-x64', 'wmux.exe');
+const USERNAME = os.userInfo().username || 'default';
+
+const results = [];
+let app = null;
+function check(name, ok, detail = '') {
+  results.push({ name, ok: !!ok });
+  console.log(`  [${ok ? 'PASS' : 'FAIL'}] ${name}${detail ? ` — ${detail}` : ''}`);
+  return ok;
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+if (process.platform !== 'win32') { console.log('a2a-pane-identity-dogfood: SKIP (win32-only)'); process.exit(0); }
+if (!fs.existsSync(APP_EXE)) { console.error(`packaged exe not found: ${APP_EXE} — run \`npm run package\` first`); process.exit(2); }
+
+const suffix = `-paneiddog${process.pid}`;
+const home = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-paneiddog-'));
+const env = {
+  ...process.env,
+  USERPROFILE: home, HOME: home,
+  APPDATA: path.join(home, 'AppData', 'Roaming'),
+  LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
+  WMUX_DATA_SUFFIX: suffix, WMUX_NO_DIALOG: '1',
+};
+delete env.HOMEDRIVE; delete env.HOMEPATH;
+fs.mkdirSync(env.APPDATA, { recursive: true });
+fs.mkdirSync(env.LOCALAPPDATA, { recursive: true });
+const userDataDir = path.join(env.APPDATA, `wmux${suffix}`);
+fs.mkdirSync(userDataDir, { recursive: true });
+fs.writeFileSync(path.join(userDataDir, '.first-run'), new Date().toISOString(), 'utf8');
+
+const wmuxDir = path.join(home, `.wmux${suffix}`);
+const mainPipe = `\\\\.\\pipe\\wmux${suffix}-${USERNAME}`;
+const authTokenPath = path.join(home, `.wmux${suffix}-auth-token`);
+
+function readMainToken() { try { return fs.readFileSync(authTokenPath, 'utf8').trim() || null; } catch { return null; } }
+
+function rpcCall(method, params = {}, { timeoutMs = 8000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const sock = net.createConnection(mainPipe);
+    let buf = ''; let settled = false; const id = randomUUID();
+    const finish = (fn) => { if (settled) return; settled = true; clearTimeout(timer); try { sock.destroy(); } catch { /* */ } fn(); };
+    const timer = setTimeout(() => finish(() => reject(new Error(`rpc timeout: ${method}`))), timeoutMs);
+    sock.setEncoding('utf8');
+    sock.once('connect', () => sock.write(JSON.stringify({ id, method, params, token: TOKEN }) + '\n'));
+    sock.once('error', (e) => finish(() => reject(e)));
+    sock.on('data', (chunk) => {
+      buf += chunk; let nl;
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl).trim(); buf = buf.slice(nl + 1);
+        if (!line) continue;
+        let msg; try { msg = JSON.parse(line); } catch { continue; }
+        if (msg.id !== id) continue;
+        finish(() => resolve(msg));
+        return;
+      }
+    });
+  });
+}
+const rpcResult = async (m, p, o) => { const r = await rpcCall(m, p, o); if (r && r.ok === false) throw new Error(typeof r.error === 'string' ? r.error : JSON.stringify(r.error)); return r?.result ?? r; };
+
+function spawnApp() {
+  const proc = spawn(APP_EXE, [], { cwd: REPO_ROOT, env, stdio: ['ignore', 'pipe', 'pipe'], detached: false });
+  proc.stdout.on('data', () => {}); proc.stderr.on('data', () => {});
+  return proc;
+}
+async function waitMainToken(timeoutMs) {
+  const dl = Date.now() + timeoutMs;
+  while (Date.now() < dl) { const t = readMainToken(); if (t) return t; await sleep(120); }
+  return null;
+}
+async function waitRendererReady(timeoutMs) {
+  const dl = Date.now() + timeoutMs; let last = '';
+  while (Date.now() < dl) {
+    try { const r = await rpcCall('workspace.list', {}, { timeoutMs: 4000 }); if (r && Array.isArray(r.result)) return r.result; }
+    catch (e) { last = e.message; }
+    await sleep(250);
+  }
+  throw new Error(`renderer not ready (${last})`);
+}
+
+let TOKEN = null;
+
+async function main() {
+  console.log(`a2a-pane-identity-dogfood — exe=${APP_EXE}`);
+  app = spawnApp();
+  TOKEN = await waitMainToken(20000);
+  if (!TOKEN) throw new Error('main token never appeared');
+  const wss = await waitRendererReady(30000);
+  check('renderer ready + default workspace exists', wss.length >= 1, `workspaces=${wss.length}`);
+  const ws1 = wss[0].id;
+
+  // ws1 is the only workspace at boot → already active. Split its pane in two.
+  await rpcResult('pane.split', { direction: 'vertical' }).catch((e) => console.log('  (split note:', e.message, ')'));
+  await sleep(1500); // let the second pane auto-spawn its PTY
+
+  // Discover the two surfaces of ws1.
+  let surfaces = await rpcResult('surface.list', { workspaceId: ws1 });
+  surfaces = surfaces.filter((s) => s.surfaceType !== 'browser' && s.ptyId);
+  check('ws1 has two terminal surfaces after split', surfaces.length >= 2, `surfaces=${surfaces.length}`);
+  if (surfaces.length < 2) throw new Error('need two panes to test pane identity');
+  const surfA = surfaces[0];
+  const surfB = surfaces[1];
+
+  // Spoof distinct agent identities by echoing banners the AgentDetector gates on.
+  // pane A → "Claude Code"; pane B → "OpenAI Codex" (Codex CLI gate).
+  await rpcResult('input.send', { ptyId: surfA.ptyId, text: 'echo Claude Code\r' }).catch((e) => console.log('  (writeA:', e.message, ')'));
+  await rpcResult('input.send', { ptyId: surfB.ptyId, text: 'echo OpenAI Codex\r' }).catch((e) => console.log('  (writeB:', e.message, ')'));
+
+  // Wait for AgentDetector → METADATA_UPDATE → surfaceAgent to land.
+  let labeledA = null, labeledB = null;
+  for (let i = 0; i < 40; i++) {
+    await sleep(500);
+    const sl = await rpcResult('surface.list', { workspaceId: ws1 });
+    labeledA = sl.find((s) => s.id === surfA.id);
+    labeledB = sl.find((s) => s.id === surfB.id);
+    if (labeledA?.agentName && labeledB?.agentName && labeledA.agentName !== labeledB.agentName) break;
+  }
+  check('surface.list shows a per-pane agentName for pane A', !!labeledA?.agentName, `A=${labeledA?.agentName ?? 'null'}`);
+  check('surface.list shows a per-pane agentName for pane B', !!labeledB?.agentName, `B=${labeledB?.agentName ?? 'null'}`);
+  check('★ the two panes carry DISTINCT agent identities (gap 8 fixed)',
+    !!labeledA?.agentName && !!labeledB?.agentName && labeledA.agentName !== labeledB.agentName,
+    `A=${labeledA?.agentName} B=${labeledB?.agentName}`);
+
+  // a2a.discover exposes per-pane addressable entries.
+  const disc = await rpcResult('a2a.discover', {});
+  const ws1Agent = (disc.agents || []).find((a) => a.url === ws1 || a.metadata?.workspaceId === ws1);
+  const panes = ws1Agent?.panes || [];
+  const paneLabels = panes.map((p) => p.agentName).filter(Boolean);
+  check('a2a.discover returns per-pane entries for ws1', panes.length >= 2, `panes=${panes.length}`);
+  check('★ a2a.discover panes[] distinguishes the two agents', new Set(paneLabels).size >= 2, `labels=${JSON.stringify(paneLabels)}`);
+
+  // Second workspace as the SENDER (and the cross-ws reject source).
+  const ws2 = (await rpcResult('workspace.new', { name: 'sender-ws' })).id;
+  await sleep(500);
+  const ws2Surfaces = (await rpcResult('surface.list', { workspaceId: ws2 })).filter((s) => s.surfaceType !== 'browser' && s.ptyId);
+  const ws2Surf = ws2Surfaces[0];
+
+  // Valid pane-addressed send: ws2 → ws1 surface B.
+  const okSend = await rpcCall('a2a.task.send', { workspaceId: ws2, to: ws1, surfaceId: surfB.id, message: 'pane-routed hello', silent: true });
+  check('a2a_task_send with a valid surface_id succeeds', okSend.result?.ok === true || okSend.ok === true, JSON.stringify(okSend.result ?? okSend));
+  const sentTaskId = okSend.result?.taskId ?? okSend.taskId;
+  // Confirm the task stored the pane address.
+  const q = await rpcResult('a2a.task.query', { workspaceId: ws1 });
+  const storedTask = (q.tasks || []).find((t) => t.id === sentTaskId);
+  check('★ the task pinned to.surfaceId = pane B', storedTask?.metadata?.to?.surfaceId === surfB.id, `to.surfaceId=${storedTask?.metadata?.to?.surfaceId}`);
+
+  // Cross-ws reject: ws2 → ws1 but addressing ws2's OWN surface (not in ws1).
+  const crossWs = await rpcCall('a2a.task.send', { workspaceId: ws2, to: ws1, surfaceId: ws2Surf?.id ?? 'nonexistent', message: 'should fail', silent: true });
+  const crossErr = crossWs.result?.error ?? crossWs.error;
+  check('★ cross-ws surface_id is REJECTED (fail-closed #163)', typeof crossErr === 'string' && /not found in target workspace/.test(crossErr), `err=${crossErr}`);
+
+  // Disagreement reject: pane A + surface B.
+  const disagree = await rpcCall('a2a.task.send', { workspaceId: ws2, to: ws1, paneId: surfA.paneId, surfaceId: surfB.id, message: 'mismatch', silent: true });
+  const disErr = disagree.result?.error ?? disagree.error;
+  check('★ pane_id + disagreeing surface_id is REJECTED', typeof disErr === 'string' && /does not belong to pane_id/.test(disErr), `err=${disErr}`);
+}
+
+main()
+  .catch((e) => { console.error('FATAL', e); check('harness completed without fatal error', false, e.message); })
+  .finally(async () => {
+    try { await rpcResult('daemon.shutdown', {}).catch(() => {}); } catch { /* */ }
+    try { if (app) app.kill(); } catch { /* */ }
+    await sleep(800);
+    const passed = results.filter((r) => r.ok).length;
+    console.log(`\na2a-pane-identity-dogfood: ${passed}/${results.length} passed`);
+    process.exit(passed === results.length && results.length > 0 ? 0 : 1);
+  });

--- a/scripts/a2a-pane-identity-dogfood.mjs
+++ b/scripts/a2a-pane-identity-dogfood.mjs
@@ -163,8 +163,9 @@ async function main() {
 
   // Valid pane-addressed send: ws2 → ws1 surface B.
   const okSend = await rpcCall('a2a.task.send', { workspaceId: ws2, to: ws1, surfaceId: surfB.id, message: 'pane-routed hello', silent: true });
-  check('a2a_task_send with a valid surface_id succeeds', okSend.result?.ok === true || okSend.ok === true, JSON.stringify(okSend.result ?? okSend));
   const sentTaskId = okSend.result?.taskId ?? okSend.taskId;
+  // Require BOTH ok:true AND a real taskId — a bare ok flag could be a false positive.
+  check('a2a_task_send with a valid surface_id succeeds', (okSend.result?.ok === true || okSend.ok === true) && typeof sentTaskId === 'string' && sentTaskId.length > 0, JSON.stringify(okSend.result ?? okSend));
   // Confirm the task stored the pane address.
   const q = await rpcResult('a2a.task.query', { workspaceId: ws1 });
   const storedTask = (q.tasks || []).find((t) => t.id === sentTaskId);

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1,116 +1,65 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { MCP_TARGETS, type McpTarget } from '../../shared/mcpTargets';
+import {
+  readAllTargetStatuses,
+  registerTarget,
+  unregisterTarget,
+  type TargetRegStatus,
+} from '../../shared/mcpRegistration';
 
 /**
- * `wmux mcp …` — inspect / manage Claude Code MCP registration without
- * touching the running wmux daemon. Reading and editing `~/.claude.json`
- * directly means the user can verify the integration even when the GUI app
- * is not running, which matches the DX-D4 decision (CLI as a one-line
- * verification path; Settings panel as the GUI parity).
+ * `wmux mcp …` — inspect / manage MCP registration across the installed agent
+ * CLIs (Claude `~/.claude.json`, Codex `~/.codex/config.toml`, Gemini
+ * `~/.gemini/settings.json`) without touching the running wmux daemon. Reading
+ * and editing the configs directly means the user can verify the integration
+ * even when the GUI app is not running (DX-D4: CLI as a one-line verification
+ * path; Settings panel as the GUI parity).
  *
- * NOTE (cross-platform): currently uses `~/.claude.json` on every OS. macOS
- * Claude Desktop may use `~/Library/Application Support/Claude/` instead —
- * macOS verification pending — see plan Phase 1.17 prereq. Do NOT add the
- * macOS-specific path speculatively here; ship that as a separate change
- * once empirically verified.
+ * Shares the per-target orchestration with the main-process McpRegistrar via
+ * `shared/mcpRegistration`, so behavior is identical. Non-installed agents are
+ * skipped (their config is never created); foreign entries are left untouched;
+ * TOML writes are surgical (comments / ordering preserved).
  */
 
 const HELP_TEXT = `
-wmux mcp — inspect / manage Claude Code MCP registration
+wmux mcp — inspect / manage MCP registration across agent CLIs
 
 USAGE
-  wmux mcp <subcommand> [--json]
+  wmux mcp <subcommand> [--target <id>] [--json]
 
 SUBCOMMANDS
-  check        Show whether wmux + wmux-a2a MCP servers are registered.
-  register     Add wmux + wmux-a2a entries to ~/.claude.json (no-daemon).
-               Note: written paths point at this CLI's own bundle layout — for
-               a GUI re-register that uses the running app's resolved paths,
-               use Settings → General → MCP → Re-register.
-  unregister   Remove the wmux + wmux-a2a keys from ~/.claude.json.
-               Other MCP entries are left untouched.
+  check        Show whether wmux + wmux-a2a are registered in each agent config.
+  register     Add wmux + wmux-a2a entries to each installed agent's config.
+               Note: written paths point at this CLI's own bundle layout — for a
+               GUI re-register that uses the running app's resolved paths, use
+               Settings → General → MCP → Re-register.
+  unregister   Remove the wmux + wmux-a2a keys from each agent config.
+               Other entries are left untouched.
 
-GLOBAL FLAGS
-  --json       Output raw JSON (useful for scripting).
+OPTIONS
+  --target <id>  Limit to one agent: claude | codex | gemini (default: all).
+  --json         Output raw JSON (useful for scripting).
 `.trimStart();
 
-function getClaudeJsonPath(): string {
-  return path.join(os.homedir(), '.claude.json');
+function homeDir(): string {
+  return os.homedir();
 }
 
-interface ServerStatus {
-  registered: boolean;
-  path: string | null;
+// Returns the selected targets, or null when `--target` was given with an
+// unknown/missing id (so the caller can error out instead of silently acting on
+// ALL targets — a `--target codxe` typo must NOT unregister everything).
+function selectedTargets(args: string[]): McpTarget[] | null {
+  const i = args.indexOf('--target');
+  if (i === -1) return [...MCP_TARGETS];
+  const id = args[i + 1];
+  const t = MCP_TARGETS.find((x) => x.id === id);
+  return t ? [t] : null;
 }
 
-interface CheckResult {
-  wmux: ServerStatus;
-  wmuxA2a: ServerStatus;
-  configPath: string;
-  configExists: boolean;
-  /** ISO 8601 string, or null when the config file does not exist. */
-  configModified: string | null;
-}
-
-function extractScriptPath(entry: unknown): string | null {
-  if (!entry || typeof entry !== 'object') return null;
-  const args = (entry as { args?: unknown }).args;
-  if (!Array.isArray(args) || args.length === 0) return null;
-  const first = args[0];
-  return typeof first === 'string' && first.length > 0 ? first : null;
-}
-
-/**
- * Read `~/.claude.json` and report which wmux MCP keys are present. Pure read
- * — never creates the file. Corrupted / partial JSON yields "not registered"
- * rather than throwing, mirroring `McpRegistrar.getStatus()` semantics.
- */
-function checkStatus(): CheckResult {
-  const configPath = getClaudeJsonPath();
-  let configExists = false;
-  let configModified: string | null = null;
-  try {
-    const stat = fs.statSync(configPath);
-    configExists = stat.isFile();
-    configModified = configExists ? stat.mtime.toISOString() : null;
-  } catch {
-    configExists = false;
-  }
-
-  let wmuxPath: string | null = null;
-  let a2aPath: string | null = null;
-  if (configExists) {
-    try {
-      const raw = fs.readFileSync(configPath, 'utf8');
-      const config = JSON.parse(raw, (key, value) => {
-        if (key === '__proto__' || key === 'constructor' || key === 'prototype') return undefined;
-        return value;
-      }) as { mcpServers?: Record<string, unknown> };
-      const servers = config && typeof config === 'object' ? config.mcpServers : null;
-      if (servers && typeof servers === 'object') {
-        wmuxPath = extractScriptPath(servers['wmux']);
-        a2aPath = extractScriptPath(servers['wmux-a2a']);
-      }
-    } catch {
-      // Malformed JSON — treat as not-registered.
-    }
-  }
-
-  return {
-    wmux: { registered: wmuxPath !== null, path: wmuxPath },
-    wmuxA2a: { registered: a2aPath !== null, path: a2aPath },
-    configPath,
-    configExists,
-    configModified,
-  };
-}
-
-function formatModified(iso: string | null): string {
-  if (!iso) return 'does not exist';
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return iso;
-  // YYYY-MM-DD HH:MM (local time) — readable, no locale-specific commas.
+function formatModified(d: Date | null): string {
+  if (!d) return 'does not exist';
   const pad = (n: number) => String(n).padStart(2, '0');
   return (
     `modified ${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
@@ -118,36 +67,33 @@ function formatModified(iso: string | null): string {
   );
 }
 
-function printCheck(result: CheckResult, jsonMode: boolean): void {
+function printCheck(statuses: TargetRegStatus[], jsonMode: boolean): void {
   if (jsonMode) {
-    console.log(JSON.stringify(result, null, 2));
+    console.log(JSON.stringify({ targets: statuses }, null, 2));
     return;
   }
-
-  const fmt = (status: ServerStatus): string =>
-    status.registered ? `registered → ${status.path}` : 'NOT REGISTERED';
-
-  console.log(`wmux:        ${fmt(result.wmux)}`);
-  console.log(`wmux-a2a:    ${fmt(result.wmuxA2a)}`);
-  if (result.configExists) {
-    console.log(`config file: ${result.configPath} (${formatModified(result.configModified)})`);
-  } else {
-    console.log(`config file: ${result.configPath} (does not exist)`);
-  }
-  if (!result.wmux.registered || !result.wmuxA2a.registered) {
-    console.log('Run `wmux mcp register` to enable Claude Code integration.');
+  for (const s of statuses) {
+    const tag = s.verified ? '' : ' (experimental)';
+    console.log(`${s.displayName}${tag}:`);
+    if (!s.configExists) {
+      console.log(`  not detected — ${s.configPath}`);
+      continue;
+    }
+    const fmt = (srv: { registered: boolean; path: string | null }) =>
+      srv.registered ? `registered → ${srv.path}` : 'NOT REGISTERED';
+    console.log(`  wmux:     ${fmt(s.wmux)}`);
+    console.log(`  wmux-a2a: ${fmt(s.wmuxA2a)}`);
+    console.log(`  config:   ${s.configPath} (${formatModified(s.configModified)})`);
   }
 }
 
 /**
  * Find the bundled MCP scripts when this CLI is invoked from a packaged
  * install. The CLI bundle lives in `dist/cli-bundle/index.js` next to
- * `dist/mcp-bundle/index.js` (or in the legacy `dist/mcp/mcp/index.js`
- * layout). Returns null when neither candidate exists, in which case the
- * caller should advise the user to use the GUI Re-register button instead.
+ * `dist/mcp-bundle/index.js` (or the legacy `dist/mcp/mcp/index.js` layout).
+ * Returns null when neither candidate exists.
  */
 function findScript(candidateRelative: string[]): string | null {
-  // Walk up from the bundled CLI's directory looking for the candidate path.
   let dir = __dirname;
   for (let i = 0; i < 6; i++) {
     for (const rel of candidateRelative) {
@@ -161,146 +107,19 @@ function findScript(candidateRelative: string[]): string | null {
   return null;
 }
 
-interface RegisterOutcome {
-  configPath: string;
-  wmuxScript: string | null;
-  a2aScript: string | null;
-  /** Keys this command actually wrote, e.g. ['wmux', 'wmux-a2a']. */
-  wrote: string[];
-  /** Warning shown when no script could be located. */
-  warning: string | null;
-}
-
-/**
- * Atomic write — same pattern as McpRegistrar.writeJson — so a partial write
- * can never leave Claude Code with an unparseable config file.
- */
-function writeJsonAtomic(filePath: string, data: unknown): void {
-  const dir = path.dirname(filePath);
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  const tmp = filePath + '.tmp';
-  fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', 'utf8');
-  fs.renameSync(tmp, filePath);
-}
-
-function registerEntries(): RegisterOutcome {
-  const configPath = getClaudeJsonPath();
-  // CLI-side script discovery: try the packaged dist layouts. When wmux is run
-  // from source dev mode the GUI registers the dev paths on first launch, so
-  // this branch only matters for CLI-only / no-GUI flows.
-  const wmuxScript = findScript([
-    path.join('mcp-bundle', 'index.js'),
-    path.join('dist', 'mcp-bundle', 'index.js'),
-    path.join('dist', 'mcp', 'mcp', 'index.js'),
-  ]);
-  const a2aScript = findScript([
-    path.join('a2a-bundle', 'index.js'),
-    path.join('dist', 'a2a-bundle', 'index.js'),
-    path.join('dist', 'mcp', 'mcp', 'a2a', 'index.js'),
-  ]);
-
-  if (!wmuxScript && !a2aScript) {
-    return {
-      configPath,
-      wmuxScript: null,
-      a2aScript: null,
-      wrote: [],
-      warning:
-        'Could not locate the wmux MCP bundle next to this CLI. Open the wmux app once and use Settings → General → MCP → Re-register, or reinstall wmux.',
-    };
-  }
-
-  let config: Record<string, unknown> = {};
-  if (fs.existsSync(configPath)) {
-    try {
-      config = JSON.parse(fs.readFileSync(configPath, 'utf8'), (key, value) => {
-        if (key === '__proto__' || key === 'constructor' || key === 'prototype') return undefined;
-        return value;
-      }) as Record<string, unknown>;
-    } catch {
-      // Corrupted — start fresh rather than overwrite silently? We choose
-      // overwrite to recover a broken config; the prior contents are gone
-      // but at least Claude Code can parse the file again.
-      config = {};
-    }
-  }
-
-  const servers = (config.mcpServers && typeof config.mcpServers === 'object'
-    ? (config.mcpServers as Record<string, unknown>)
-    : {}) as Record<string, unknown>;
-
-  const wrote: string[] = [];
-  if (wmuxScript) {
-    servers['wmux'] = { command: 'node', args: [wmuxScript] };
-    wrote.push('wmux');
-  }
-  if (a2aScript) {
-    servers['wmux-a2a'] = { command: 'node', args: [a2aScript] };
-    wrote.push('wmux-a2a');
-  }
-  config.mcpServers = servers;
-
-  writeJsonAtomic(configPath, config);
-
+function resolveScripts(): { wmux: string | null; a2a: string | null } {
   return {
-    configPath,
-    wmuxScript,
-    a2aScript,
-    wrote,
-    warning: wmuxScript && a2aScript
-      ? null
-      : 'Only some MCP scripts were located — partial registration written. Use Settings → MCP → Re-register from the running app for full coverage.',
+    wmux: findScript([
+      path.join('mcp-bundle', 'index.js'),
+      path.join('dist', 'mcp-bundle', 'index.js'),
+      path.join('dist', 'mcp', 'mcp', 'index.js'),
+    ]),
+    a2a: findScript([
+      path.join('a2a-bundle', 'index.js'),
+      path.join('dist', 'a2a-bundle', 'index.js'),
+      path.join('dist', 'mcp', 'mcp', 'a2a', 'index.js'),
+    ]),
   };
-}
-
-interface UnregisterOutcome {
-  configPath: string;
-  removed: string[];
-  configExisted: boolean;
-}
-
-function unregisterEntries(): UnregisterOutcome {
-  const configPath = getClaudeJsonPath();
-  if (!fs.existsSync(configPath)) {
-    return { configPath, removed: [], configExisted: false };
-  }
-
-  let config: Record<string, unknown>;
-  try {
-    config = JSON.parse(fs.readFileSync(configPath, 'utf8'), (key, value) => {
-      if (key === '__proto__' || key === 'constructor' || key === 'prototype') return undefined;
-      return value;
-    }) as Record<string, unknown>;
-  } catch {
-    // Corrupted — nothing to remove safely; bail out to avoid silently
-    // overwriting the user's broken-but-recoverable file.
-    return { configPath, removed: [], configExisted: true };
-  }
-
-  const servers = config.mcpServers;
-  if (!servers || typeof servers !== 'object') {
-    return { configPath, removed: [], configExisted: true };
-  }
-
-  const serversMap = servers as Record<string, unknown>;
-  const removed: string[] = [];
-  for (const key of ['wmux', 'wmux-a2a']) {
-    if (key in serversMap) {
-      delete serversMap[key];
-      removed.push(key);
-    }
-  }
-
-  if (removed.length === 0) {
-    return { configPath, removed, configExisted: true };
-  }
-
-  if (Object.keys(serversMap).length === 0) {
-    delete config.mcpServers;
-  }
-  writeJsonAtomic(configPath, config);
-
-  return { configPath, removed, configExisted: true };
 }
 
 export async function handleMcp(args: string[], jsonMode: boolean): Promise<void> {
@@ -312,46 +131,79 @@ export async function handleMcp(args: string[], jsonMode: boolean): Promise<void
     return;
   }
 
+  const home = homeDir();
+  const targets = selectedTargets(args);
+  if (targets === null) {
+    const ti = args.indexOf('--target');
+    console.error(`Unknown --target "${args[ti + 1] ?? ''}". Valid: ${MCP_TARGETS.map((t) => t.id).join(', ')}.`);
+    process.exit(1);
+    return;
+  }
+
   switch (sub) {
     case 'check': {
-      printCheck(checkStatus(), jsonMode);
+      const all = readAllTargetStatuses(home);
+      const ids = new Set<string>(targets.map((t) => t.id));
+      printCheck(all.filter((s) => ids.has(s.id)), jsonMode);
       return;
     }
 
     case 'register': {
-      const outcome = registerEntries();
-      if (jsonMode) {
-        console.log(JSON.stringify(outcome, null, 2));
-        return;
-      }
-      if (outcome.wrote.length === 0) {
-        if (outcome.warning) console.error(outcome.warning);
+      const scripts = resolveScripts();
+      if (!scripts.wmux && !scripts.a2a) {
+        const warning =
+          'Could not locate the wmux MCP bundle next to this CLI. Open the wmux app once and use Settings → General → MCP → Re-register, or reinstall wmux.';
+        if (jsonMode) console.log(JSON.stringify({ error: warning }, null, 2));
+        else console.error(warning);
         process.exit(1);
         return;
       }
-      console.log(`Wrote ${outcome.wrote.join(', ')} to ${outcome.configPath}`);
-      if (outcome.wmuxScript) console.log(`  wmux     → ${outcome.wmuxScript}`);
-      if (outcome.a2aScript) console.log(`  wmux-a2a → ${outcome.a2aScript}`);
-      if (outcome.warning) console.warn(outcome.warning);
-      console.log('Restart Claude Code to pick up the new servers.');
+      const results = targets.map((t) => ({ target: t, result: registerTarget(t, home, scripts) }));
+      if (jsonMode) {
+        console.log(JSON.stringify({ scripts, results: results.map((r) => ({ id: r.target.id, ...r.result })) }, null, 2));
+        return;
+      }
+      let wroteAny = false;
+      for (const { target, result } of results) {
+        if (result.skipped === 'absent') {
+          console.log(`${target.displayName}: not installed — skipped`);
+          continue;
+        }
+        if (result.skipped === 'malformed') {
+          console.warn(`${target.displayName}: config malformed — left untouched (${result.configPath})`);
+          continue;
+        }
+        if (result.wrote.length > 0) {
+          wroteAny = true;
+          console.log(`${target.displayName}: wrote ${result.wrote.join(', ')} → ${result.configPath}`);
+        } else {
+          console.log(`${target.displayName}: already up to date`);
+        }
+        if (result.foreign.length > 0) {
+          console.warn(`  left foreign key(s) ${result.foreign.join(', ')} untouched`);
+        }
+      }
+      if (scripts.wmux) console.log(`  wmux     → ${scripts.wmux}`);
+      if (scripts.a2a) console.log(`  wmux-a2a → ${scripts.a2a}`);
+      if (wroteAny) console.log('Restart the affected agent(s) to pick up the new servers.');
       return;
     }
 
     case 'unregister': {
-      const outcome = unregisterEntries();
+      const results = targets.map((t) => ({ target: t, result: unregisterTarget(t, home) }));
       if (jsonMode) {
-        console.log(JSON.stringify(outcome, null, 2));
+        console.log(JSON.stringify({ results: results.map((r) => ({ id: r.target.id, ...r.result })) }, null, 2));
         return;
       }
-      if (!outcome.configExisted) {
-        console.log(`No config file at ${outcome.configPath} — nothing to unregister.`);
-        return;
+      for (const { target, result } of results) {
+        if (!result.configExisted) {
+          console.log(`${target.displayName}: no config — nothing to unregister`);
+        } else if (result.removed.length === 0) {
+          console.log(`${target.displayName}: wmux not registered — nothing changed`);
+        } else {
+          console.log(`${target.displayName}: removed ${result.removed.join(', ')} from ${result.configPath}`);
+        }
       }
-      if (outcome.removed.length === 0) {
-        console.log('wmux + wmux-a2a were not registered — nothing changed.');
-        return;
-      }
-      console.log(`Removed ${outcome.removed.join(', ')} from ${outcome.configPath}`);
       return;
     }
 

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -150,13 +150,19 @@ export async function handleMcp(args: string[], jsonMode: boolean): Promise<void
 
     case 'register': {
       const scripts = resolveScripts();
-      if (!scripts.wmux && !scripts.a2a) {
+      // The core `wmux` MCP script is REQUIRED — registering the optional
+      // `wmux-a2a` server alone is an incoherent partial state (the primary
+      // tool surface would be missing). Bail if the main bundle isn't found.
+      if (!scripts.wmux) {
         const warning =
           'Could not locate the wmux MCP bundle next to this CLI. Open the wmux app once and use Settings → General → MCP → Re-register, or reinstall wmux.';
         if (jsonMode) console.log(JSON.stringify({ error: warning }, null, 2));
         else console.error(warning);
         process.exit(1);
         return;
+      }
+      if (!scripts.a2a) {
+        console.warn('Note: the optional wmux-a2a bundle was not found — registering wmux only.');
       }
       // registerTarget propagates write/permission errors (only parse/edit
       // issues are 'malformed'); capture them per-target so one failure neither
@@ -204,13 +210,23 @@ export async function handleMcp(args: string[], jsonMode: boolean): Promise<void
     }
 
     case 'unregister': {
-      const results = targets.map((t) => ({ target: t, result: unregisterTarget(t, home) }));
+      // unregisterTarget propagates write errors — capture per-target (same as
+      // register) so one failure neither crashes the CLI nor is swallowed.
+      const results = targets.map((t) => {
+        try { return { target: t, result: unregisterTarget(t, home), error: null as string | null }; }
+        catch (e) { return { target: t, result: null, error: e instanceof Error ? e.message : String(e) }; }
+      });
       if (jsonMode) {
-        console.log(JSON.stringify({ results: results.map((r) => ({ id: r.target.id, ...r.result })) }, null, 2));
+        console.log(JSON.stringify({ results: results.map((r) => ({ id: r.target.id, error: r.error, ...(r.result ?? {}) })) }, null, 2));
+        if (results.some((r) => r.error)) process.exit(1);
         return;
       }
-      for (const { target, result } of results) {
-        if (!result.configExisted) {
+      let failed = false;
+      for (const { target, result, error } of results) {
+        if (error || !result) {
+          failed = true;
+          console.error(`${target.displayName}: unregister FAILED — ${error}`);
+        } else if (!result.configExisted) {
           console.log(`${target.displayName}: no config — nothing to unregister`);
         } else if (result.removed.length === 0) {
           console.log(`${target.displayName}: wmux not registered — nothing changed`);
@@ -218,6 +234,7 @@ export async function handleMcp(args: string[], jsonMode: boolean): Promise<void
           console.log(`${target.displayName}: removed ${result.removed.join(', ')} from ${result.configPath}`);
         }
       }
+      if (failed) process.exit(1);
       return;
     }
 

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -158,13 +158,26 @@ export async function handleMcp(args: string[], jsonMode: boolean): Promise<void
         process.exit(1);
         return;
       }
-      const results = targets.map((t) => ({ target: t, result: registerTarget(t, home, scripts) }));
+      // registerTarget propagates write/permission errors (only parse/edit
+      // issues are 'malformed'); capture them per-target so one failure neither
+      // aborts the rest nor is silently swallowed.
+      const results = targets.map((t) => {
+        try { return { target: t, result: registerTarget(t, home, scripts), error: null as string | null }; }
+        catch (e) { return { target: t, result: null, error: e instanceof Error ? e.message : String(e) }; }
+      });
       if (jsonMode) {
-        console.log(JSON.stringify({ scripts, results: results.map((r) => ({ id: r.target.id, ...r.result })) }, null, 2));
+        console.log(JSON.stringify({ scripts, results: results.map((r) => ({ id: r.target.id, error: r.error, ...(r.result ?? {}) })) }, null, 2));
+        if (results.some((r) => r.error)) process.exit(1);
         return;
       }
       let wroteAny = false;
-      for (const { target, result } of results) {
+      let failed = false;
+      for (const { target, result, error } of results) {
+        if (error || !result) {
+          failed = true;
+          console.error(`${target.displayName}: registration FAILED — ${error}`);
+          continue;
+        }
         if (result.skipped === 'absent') {
           console.log(`${target.displayName}: not installed — skipped`);
           continue;
@@ -186,6 +199,7 @@ export async function handleMcp(args: string[], jsonMode: boolean): Promise<void
       if (scripts.wmux) console.log(`  wmux     → ${scripts.wmux}`);
       if (scripts.a2a) console.log(`  wmux-a2a → ${scripts.a2a}`);
       if (wroteAny) console.log('Restart the affected agent(s) to pick up the new servers.');
+      if (failed) process.exit(1);
       return;
     }
 

--- a/src/main/firstRun/FirstRunOrchestrator.ts
+++ b/src/main/firstRun/FirstRunOrchestrator.ts
@@ -168,8 +168,12 @@ export class FirstRunOrchestrator {
       return { ok: false, code: 'UNKNOWN', message: 'auth token not ready (pipe server still starting)' };
     }
     this.mcpRegistrar.register(token);
+    // First-run is the Claude onboarding flow; success is keyed on Claude's
+    // target. Codex/Gemini are written opportunistically by register() when
+    // installed and their failure must not fail first-run.
     const status = this.mcpRegistrar.getStatus();
-    if (status.wmux.registered) return { ok: true };
+    const claude = status.targets.find((t) => t.id === 'claude');
+    if (claude?.wmux.registered) return { ok: true };
     return { ok: false, code: 'UNKNOWN', message: 'registration completed without recording wmux entry' };
   }
 

--- a/src/main/firstRun/__tests__/FirstRunOrchestrator.test.ts
+++ b/src/main/firstRun/__tests__/FirstRunOrchestrator.test.ts
@@ -139,11 +139,19 @@ function makeMcpRegistrar(opts?: {
   return {
     register: vi.fn(opts?.registerImpl ?? (() => { /* no-op: success default */ })),
     getStatus: vi.fn(() => ({
-      wmux: { registered: opts?.registered ?? true, path: '/some/path' },
-      wmuxA2a: { registered: false, path: null },
-      configPath: '/home/test/.claude.json',
-      configExists: true,
-      configModified: new Date(),
+      targets: [
+        {
+          id: 'claude',
+          displayName: 'Claude Code',
+          format: 'json',
+          configPath: '/home/test/.claude.json',
+          configExists: true,
+          configModified: new Date(),
+          verified: true,
+          wmux: { registered: opts?.registered ?? true, path: '/some/path' },
+          wmuxA2a: { registered: false, path: null },
+        },
+      ],
     })),
   };
 }

--- a/src/main/ipc/handlers/mcp.handler.ts
+++ b/src/main/ipc/handlers/mcp.handler.ts
@@ -10,22 +10,37 @@ import type { McpRegistrar, McpRegistrarStatus } from '../../mcp/McpRegistrar';
  * cloneable, but ISO strings are friendlier for the React side that just
  * formats them for display).
  */
-export interface McpStatusPayload {
-  wmux: { registered: boolean; path: string | null };
-  wmuxA2a: { registered: boolean; path: string | null };
+/** Per-target serialized status (Date → ISO string for the IPC boundary). */
+export interface McpTargetStatusPayload {
+  id: string;
+  displayName: string;
+  format: 'json' | 'toml';
   configPath: string;
   configExists: boolean;
   /** ISO 8601 string, or null when the config file does not exist. */
   configModified: string | null;
+  verified: boolean;
+  wmux: { registered: boolean; path: string | null };
+  wmuxA2a: { registered: boolean; path: string | null };
+}
+
+export interface McpStatusPayload {
+  targets: McpTargetStatusPayload[];
 }
 
 function serialize(status: McpRegistrarStatus): McpStatusPayload {
   return {
-    wmux: status.wmux,
-    wmuxA2a: status.wmuxA2a,
-    configPath: status.configPath,
-    configExists: status.configExists,
-    configModified: status.configModified ? status.configModified.toISOString() : null,
+    targets: status.targets.map((t) => ({
+      id: t.id,
+      displayName: t.displayName,
+      format: t.format,
+      configPath: t.configPath,
+      configExists: t.configExists,
+      configModified: t.configModified ? t.configModified.toISOString() : null,
+      verified: t.verified,
+      wmux: t.wmux,
+      wmuxA2a: t.wmuxA2a,
+    })),
   };
 }
 

--- a/src/main/mcp/McpRegistrar.ts
+++ b/src/main/mcp/McpRegistrar.ts
@@ -1,142 +1,117 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { app } from 'electron';
-import { getAuthTokenPath, getPipeName } from '../../shared/constants';
+import { getAuthTokenPath } from '../../shared/constants';
 import { secureWriteTokenFile } from '../../shared/security';
 import { isMac } from '../../shared/platform';
 import { formatMacosError, MACOS_ERRORS } from '../../shared/errors/macos';
+import { MCP_TARGETS } from '../../shared/mcpTargets';
+import {
+  readAllTargetStatuses,
+  registerTarget,
+  unregisterTarget,
+  type TargetRegStatus,
+  type ServerRegState,
+} from '../../shared/mcpRegistration';
 
 /** Per-server registration state surfaced via getStatus(). */
-export interface McpServerStatus {
-  registered: boolean;
-  /** Resolved script path written to ~/.claude.json, or null when not registered. */
-  path: string | null;
-}
+export type McpServerStatus = ServerRegState;
+/** Registration state for a single agent target (Claude / Codex / Gemini). */
+export type McpTargetStatus = TargetRegStatus;
 
 /** Aggregate snapshot of MCP integration state for CLI / Settings UI. */
 export interface McpRegistrarStatus {
-  wmux: McpServerStatus;
-  wmuxA2a: McpServerStatus;
-  /** Absolute path to the Claude Code user config file (~/.claude.json). */
-  configPath: string;
-  configExists: boolean;
-  /** Last-modified timestamp (mtime) of the config file, or null when missing. */
-  configModified: Date | null;
+  targets: McpTargetStatus[];
 }
 
 /**
- * Registers/unregisters the wmux MCP server in Claude Code's config files
- * and writes the auth token to a well-known file so the MCP server can read it.
+ * Registers/unregisters the wmux MCP servers (`wmux`, `wmux-a2a`) into the
+ * config files of the installed agent CLIs, and writes the auth token to a
+ * well-known file so the MCP server can read it. The per-target fs + config
+ * orchestration lives in `shared/mcpRegistration` so this class and the
+ * `wmux mcp` CLI behave identically; this class adds the Electron-specific
+ * bundle-path resolution, the auth-token write, and macOS error hints.
  *
- * The MCP server uses:
- *   - Fixed pipe path: \\.\pipe\wmux  (from shared/constants)
- *   - Auth token file: ~/.wmux-auth-token (written here, read by MCP)
+ * Targets (see `shared/mcpTargets.ts`):
+ *   - Claude Code  ~/.claude.json          (JSON, created on demand)
+ *   - Codex CLI    ~/.codex/config.toml     (TOML, only if installed)
+ *   - Gemini CLI   ~/.gemini/settings.json  (JSON, only if installed; unverified)
  *
- * Config files written:
- *   1. ~/.claude.json   (user-level MCP config — where Claude Code reads mcpServers)
+ * EMPIRICAL GATE: a non-Claude target is only written when its config already
+ * exists (the CLI is installed) and is shipped as `verified` only after the
+ * agent was confirmed to discover AND use the wmux tools end-to-end — which
+ * additionally requires the agent's MCP `clientName` to be first-party
+ * recognized by the daemon enforcer (`firstParty.ts`). Codex (`codex-mcp-client`)
+ * was verified 2026-06-15.
  *
- * NOTE (cross-platform): the path `~/.claude.json` is currently used on every
- * OS. macOS Claude Desktop may use `~/Library/Application Support/Claude/`
- * instead — macOS verification pending — see plan Phase 1.17 prereq. Do NOT
- * add the macOS-specific path here speculatively; gate that behind empirical
- * verification and ship as a separate change.
+ * NOTE (macOS Claude Desktop `~/Library/Application Support/Claude/`): still
+ * pending empirical verification — out of scope, do not add speculatively.
  */
 export class McpRegistrar {
-  private readonly claudeJsonPath: string;
+  private readonly home: string;
   private readonly authTokenPath: string;
   private registered = false;
-  /** Keys that WinMux actually wrote (so we only unregister our own). */
-  private readonly ownedKeys = new Set<string>();
+  /** Per-target sets of keys wmux wrote this session (so we update/own them). */
+  private readonly ownedKeys = new Map<string, Set<string>>();
 
   constructor() {
-    const home = app.getPath('home');
-    this.claudeJsonPath = path.join(home, '.claude.json');
+    this.home = app.getPath('home');
     this.authTokenPath = getAuthTokenPath();
   }
 
-  /** Absolute path to the Claude Code user config file. */
+  /** Absolute path to the Claude Code user config file (back-compat accessor). */
   getClaudeJsonPath(): string {
-    return this.claudeJsonPath;
+    return path.join(this.home, '.claude.json');
+  }
+
+  private ownedFor(targetId: string): Set<string> {
+    let set = this.ownedKeys.get(targetId);
+    if (!set) {
+      set = new Set<string>();
+      this.ownedKeys.set(targetId, set);
+    }
+    return set;
   }
 
   /**
-   * Read-only snapshot of MCP registration state. Used by `wmux mcp check`
-   * and the Settings → General → MCP section to surface whether Claude Code
-   * can discover the wmux MCP servers.
-   *
-   * Pure read — never creates the config file or its parent directory, never
-   * throws. Corrupted JSON or missing files yield "not registered".
+   * Read-only snapshot of MCP registration state across all targets. Pure read
+   * — never creates a file, never throws. Corrupted/missing configs yield "not
+   * registered".
    */
   getStatus(): McpRegistrarStatus {
-    let configExists = false;
-    let configModified: Date | null = null;
-    try {
-      const stat = fs.statSync(this.claudeJsonPath);
-      configExists = stat.isFile();
-      configModified = configExists ? stat.mtime : null;
-    } catch {
-      configExists = false;
-    }
-
-    let wmuxPath: string | null = null;
-    let a2aPath: string | null = null;
-    if (configExists) {
-      try {
-        const raw = fs.readFileSync(this.claudeJsonPath, 'utf8');
-        const config = JSON.parse(raw, (key, value) => {
-          if (key === '__proto__' || key === 'constructor' || key === 'prototype') return undefined;
-          return value;
-        }) as { mcpServers?: Record<string, unknown> };
-        const servers = config && typeof config === 'object' ? config.mcpServers : null;
-        if (servers && typeof servers === 'object') {
-          wmuxPath = extractScriptPath(servers['wmux']);
-          a2aPath = extractScriptPath(servers['wmux-a2a']);
-        }
-      } catch {
-        // Corrupted config — surface as "not registered" rather than throw.
-      }
-    }
-
-    return {
-      wmux: { registered: wmuxPath !== null, path: wmuxPath },
-      wmuxA2a: { registered: a2aPath !== null, path: a2aPath },
-      configPath: this.claudeJsonPath,
-      configExists,
-      configModified,
-    };
+    return { targets: readAllTargetStatuses(this.home) };
   }
 
   /**
-   * Force-remove the wmux + wmux-a2a keys from ~/.claude.json. Unlike
-   * {@link unregister} (intentionally a no-op to avoid the chicken-and-egg
-   * problem on app quit), this is invoked from explicit user actions — the
-   * `wmux mcp unregister` CLI and the Settings panel "Unregister" button.
-   *
-   * Other mcpServers entries are left untouched.
+   * Force-remove the wmux + wmux-a2a keys from every target config. Invoked
+   * from explicit user actions (`wmux mcp unregister`, Settings "Unregister").
+   * Only removes wmux-owned-shaped keys; foreign entries and unrelated keys are
+   * left intact.
    */
   forceUnregister(): void {
-    try {
-      this.unregisterFromClaudeJson(['wmux', 'wmux-a2a']);
-      this.ownedKeys.delete('wmux');
-      this.ownedKeys.delete('wmux-a2a');
-      this.registered = false;
-      console.log('[McpRegistrar] Force-unregistered wmux + wmux-a2a from ~/.claude.json');
-    } catch (err) {
-      console.error('[McpRegistrar] Failed to force-unregister:', err);
+    for (const target of MCP_TARGETS) {
+      try {
+        const result = unregisterTarget(target, this.home);
+        this.ownedFor(target.id).clear();
+        if (result.removed.length > 0) {
+          console.log(`[McpRegistrar] Unregistered ${result.removed.join(', ')} from ${result.configPath}`);
+        }
+      } catch (err) {
+        console.error(`[McpRegistrar] Failed to force-unregister ${target.displayName}:`, err);
+      }
     }
+    this.registered = false;
   }
 
   /**
-   * Write auth token to file and register MCP server in Claude Code configs.
-   * Must be called after PipeServer.start().
+   * Write auth token to file and register the MCP servers in every installed
+   * target. Must be called after PipeServer.start().
    */
   register(authToken: string): void {
     try {
-      // Write auth token to file so MCP server can read it. Skip when the
-      // on-disk value already matches (S-A cold-start): PipeServer's ctor
-      // wrote this exact token through the same secure path moments ago, and
-      // secureWriteTokenFile's overwrite branch costs a 1-2s PowerShell ACL
-      // rebuild. A mismatch (token rotation, stale file) still rewrites.
+      // Write auth token to file so the MCP server can read it. Skip when the
+      // on-disk value already matches (S-A cold-start): a rewrite costs a 1-2s
+      // PowerShell ACL rebuild. A mismatch (rotation / stale) still rewrites.
       let onDisk: string | null = null;
       try {
         onDisk = fs.readFileSync(this.authTokenPath, 'utf8').trim();
@@ -153,39 +128,29 @@ export class McpRegistrar {
         console.warn('[McpRegistrar] Could not determine MCP script path — skipping registration.');
         return;
       }
-
-      // Use 'node' instead of process.execPath, which returns electron.exe at runtime
-      // Note: do NOT set env field — Claude Code may replace (not merge) the
-      // subprocess environment, breaking PATH/USERPROFILE. getPipeName() uses
-      // os.userInfo().username which works without env vars.
-      const mcpEntry = {
-        command: 'node',
-        args: [mcpScript],
-      };
-
-      this.registerInClaudeJson('wmux', mcpEntry);
-
-      // Register wmux-a2a MCP server (Agent-to-Agent communication)
       const a2aScript = this.getA2aScriptPath();
-      if (a2aScript) {
-        this.registerInClaudeJson('wmux-a2a', {
-          command: 'node',
-          args: [a2aScript],
-        });
-        console.log(`[McpRegistrar] Registered wmux-a2a MCP → ${a2aScript}`);
-      }
 
-      // Clean up legacy MCP keys from previous versions
-      this.removeLegacyKeys(['wmux-playwright', 'wmux-devtools']);
+      for (const target of MCP_TARGETS) {
+        try {
+          const result = registerTarget(target, this.home, { wmux: mcpScript, a2a: a2aScript }, this.ownedFor(target.id));
+          if (result.wrote.length > 0) {
+            console.log(`[McpRegistrar] ${target.displayName}: wrote ${result.wrote.join(', ')} → ${result.configPath}`);
+          }
+          if (result.foreign.length > 0) {
+            console.warn(`[McpRegistrar] ${target.displayName}: left foreign key(s) ${result.foreign.join(', ')} untouched`);
+          }
+        } catch (err) {
+          // Per-target isolation: one target's failure must not abort the rest.
+          console.error(`[McpRegistrar] ${target.displayName} registration failed:`, err);
+        }
+      }
 
       this.registered = true;
       console.log(`[McpRegistrar] Registered wmux MCP → ${mcpScript}`);
     } catch (err) {
       console.error('[McpRegistrar] Failed to register:', err);
-      // macOS users hitting Time Machine restore / sudo-written ~/.claude.json
-      // see ENOACCES/EACCES/EPERM and have no way to know the fix is `chmod 600`.
-      // Surface the catalog entry so the next stderr line shows the exact command.
-      // Other platforms / other errors are unaffected.
+      // macOS Time Machine restore / sudo-written configs surface
+      // ENOACCES/EACCES/EPERM with no hint that the fix is `chmod 600`.
       const code = (err as NodeJS.ErrnoException)?.code;
       if (isMac && (code === 'EACCES' || code === 'ENOACCES' || code === 'EPERM')) {
         console.error('\n' + formatMacosError(MACOS_ERRORS.mcpPermissionDenied));
@@ -194,79 +159,14 @@ export class McpRegistrar {
   }
 
   /**
-   * Previously removed MCP entries on quit, but this caused a chicken-and-egg
-   * problem: Claude Code couldn't find the MCP server because wmux deleted it
-   * on exit. Now we keep the registration persistent — the MCP server process
-   * handles pipe-not-available gracefully when wmux isn't running.
+   * Previously removed MCP entries on quit, which deadlocked discovery (Claude
+   * couldn't find the server wmux deleted on exit). Now persistent; the MCP
+   * process handles pipe-not-available gracefully when wmux isn't running.
    */
   unregister(): void {
-    // Intentionally no-op: keep MCP registration persistent in ~/.claude.json
-    // so Claude Code can always discover the wmux MCP server.
+    // Intentionally no-op: keep registration persistent so agents can always
+    // discover the wmux MCP server.
     this.ownedKeys.clear();
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private registerInClaudeJson(key: string, mcpEntry: Record<string, any>): void {
-    const config = this.readJson(this.claudeJsonPath);
-    if (!config.mcpServers) config.mcpServers = {};
-
-    const existing = config.mcpServers[key];
-    if (existing && !this.ownedKeys.has(key)) {
-      // Always overwrite if the script path changed (e.g. after app update).
-      // Previous logic skipped registration when the key existed from a prior
-      // session, leaving stale paths pointing to old app versions.
-      const existingArgs = JSON.stringify(existing.args ?? []);
-      const newArgs = JSON.stringify(mcpEntry.args ?? []);
-      if (existingArgs === newArgs) {
-        console.log(`[McpRegistrar] Key "${key}" already up-to-date — skipping.`);
-        this.ownedKeys.add(key);
-        return;
-      }
-      console.log(`[McpRegistrar] Key "${key}" path changed — updating.`);
-    }
-
-    config.mcpServers[key] = mcpEntry;
-    this.writeJson(this.claudeJsonPath, config);
-    this.ownedKeys.add(key);
-  }
-
-  /**
-   * Remove legacy MCP keys that WinMux no longer manages.
-   * These are cleaned up regardless of who originally wrote them.
-   */
-  private removeLegacyKeys(keys: string[]): void {
-    const config = this.readJson(this.claudeJsonPath);
-    if (!config.mcpServers) return;
-
-    let changed = false;
-    for (const key of keys) {
-      if (config.mcpServers[key]) {
-        delete config.mcpServers[key];
-        changed = true;
-        console.log(`[McpRegistrar] Removed legacy key "${key}"`);
-      }
-    }
-    if (changed) {
-      if (Object.keys(config.mcpServers).length === 0) delete config.mcpServers;
-      this.writeJson(this.claudeJsonPath, config);
-    }
-  }
-
-  private unregisterFromClaudeJson(keys: string[]): void {
-    const config = this.readJson(this.claudeJsonPath);
-    if (!config.mcpServers) return;
-
-    let changed = false;
-    for (const key of keys) {
-      if (config.mcpServers[key]) {
-        delete config.mcpServers[key];
-        changed = true;
-      }
-    }
-    if (changed) {
-      if (Object.keys(config.mcpServers).length === 0) delete config.mcpServers;
-      this.writeJson(this.claudeJsonPath, config);
-    }
   }
 
   private getMcpScriptPath(): string | null {
@@ -321,45 +221,4 @@ export class McpRegistrar {
 
     return null;
   }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private readJson(filePath: string): Record<string, any> {
-    try {
-      if (fs.existsSync(filePath)) {
-        return JSON.parse(fs.readFileSync(filePath, 'utf8'), (key, value) => {
-          if (key === '__proto__' || key === 'constructor' || key === 'prototype') return undefined;
-          return value;
-        });
-      }
-    } catch { /* corrupted — start fresh */ }
-
-    const dir = path.dirname(filePath);
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    return {};
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private writeJson(filePath: string, data: Record<string, any>): void {
-    const dir = path.dirname(filePath);
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    const tmpPath = filePath + '.tmp';
-    fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2) + '\n', 'utf8');
-    fs.renameSync(tmpPath, filePath);
-  }
-}
-
-/**
- * Extract the MCP script path from a `mcpServers[key]` entry.
- *
- * wmux always writes entries shaped `{ command: 'node', args: [scriptPath] }`,
- * so the script path is the first arg. Returns null when the entry is absent
- * or malformed (foreign edits, schema drift) — getStatus() then reports the
- * server as not registered rather than fabricating a path.
- */
-function extractScriptPath(entry: unknown): string | null {
-  if (!entry || typeof entry !== 'object') return null;
-  const args = (entry as { args?: unknown }).args;
-  if (!Array.isArray(args) || args.length === 0) return null;
-  const first = args[0];
-  return typeof first === 'string' && first.length > 0 ? first : null;
 }

--- a/src/main/mcp/McpRegistrar.ts
+++ b/src/main/mcp/McpRegistrar.ts
@@ -141,7 +141,13 @@ export class McpRegistrar {
           }
         } catch (err) {
           // Per-target isolation: one target's failure must not abort the rest.
+          // A write/permission failure reaches here (registerTarget propagates
+          // it rather than misreporting "malformed"); surface the macOS hint.
           console.error(`[McpRegistrar] ${target.displayName} registration failed:`, err);
+          const code = (err as NodeJS.ErrnoException)?.code;
+          if (isMac && (code === 'EACCES' || code === 'ENOACCES' || code === 'EPERM')) {
+            console.error('\n' + formatMacosError(MACOS_ERRORS.mcpPermissionDenied));
+          }
         }
       }
 

--- a/src/main/mcp/__tests__/McpRegistrar.test.ts
+++ b/src/main/mcp/__tests__/McpRegistrar.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Use a per-test temp directory as the simulated home so we can exercise
-// real fs reads/writes without touching the developer's actual ~/.claude.json.
+// real fs reads/writes without touching the developer's actual configs.
 let tmpHome = '';
 
 vi.mock('electron', () => ({
@@ -18,160 +18,156 @@ vi.mock('electron', () => ({
   },
 }));
 
-// secureWriteTokenFile is invoked by register(); stub it so we don't try to
-// run icacls / chmod under tests.
-vi.mock('../../../shared/security', () => ({
-  secureWriteTokenFile: vi.fn(),
-}));
-
-// Avoid requiring the real macOS error catalogue at import time.
+vi.mock('../../../shared/security', () => ({ secureWriteTokenFile: vi.fn() }));
 vi.mock('../../../shared/errors/macos', () => ({
   formatMacosError: vi.fn(() => ''),
   MACOS_ERRORS: { mcpPermissionDenied: { code: 'TEST', summary: '', remedy: '' } },
 }));
-
 vi.mock('../../../shared/platform', () => ({ isMac: false }));
 
 // IMPORTANT: import the SUT after vi.mock() declarations.
-import { McpRegistrar } from '../McpRegistrar';
+import { McpRegistrar, type McpRegistrarStatus, type McpTargetStatus } from '../McpRegistrar';
+
+const claudeJson = () => path.join(tmpHome, '.claude.json');
+const codexToml = () => path.join(tmpHome, '.codex', 'config.toml');
+const geminiJson = () => path.join(tmpHome, '.gemini', 'settings.json');
+const target = (s: McpRegistrarStatus, id: string): McpTargetStatus =>
+  s.targets.find((t) => t.id === id) as McpTargetStatus;
 
 beforeEach(() => {
   tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-mcp-test-'));
 });
-
 afterEach(() => {
-  try {
-    fs.rmSync(tmpHome, { recursive: true, force: true });
-  } catch {
-    /* best-effort */
-  }
+  try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* best-effort */ }
 });
 
-describe('McpRegistrar.getStatus', () => {
-  it('reports both servers as not registered when ~/.claude.json is absent', () => {
-    const registrar = new McpRegistrar();
-    const status = registrar.getStatus();
-
-    expect(status.configExists).toBe(false);
-    expect(status.configModified).toBeNull();
-    expect(status.wmux).toEqual({ registered: false, path: null });
-    expect(status.wmuxA2a).toEqual({ registered: false, path: null });
-    expect(status.configPath).toBe(path.join(tmpHome, '.claude.json'));
+describe('McpRegistrar.getStatus (multi-target)', () => {
+  it('reports every target as not registered when no configs exist', () => {
+    const status = new McpRegistrar().getStatus();
+    expect(status.targets.map((t) => t.id).sort()).toEqual(['claude', 'codex', 'gemini']);
+    for (const t of status.targets) {
+      expect(t.configExists).toBe(false);
+      expect(t.configModified).toBeNull();
+      expect(t.wmux).toEqual({ registered: false, path: null });
+      expect(t.wmuxA2a).toEqual({ registered: false, path: null });
+    }
+    expect(target(status, 'claude').configPath).toBe(claudeJson());
+    expect(target(status, 'codex').configPath).toBe(codexToml());
   });
 
-  it('does NOT create ~/.claude.json as a side effect of getStatus', () => {
-    const registrar = new McpRegistrar();
-    registrar.getStatus();
-    expect(fs.existsSync(path.join(tmpHome, '.claude.json'))).toBe(false);
+  it('does NOT create any config file as a side effect of getStatus', () => {
+    new McpRegistrar().getStatus();
+    expect(fs.existsSync(claudeJson())).toBe(false);
+    expect(fs.existsSync(codexToml())).toBe(false);
   });
 
-  it('extracts registered script paths from ~/.claude.json', () => {
+  it('extracts registered script paths from Claude JSON', () => {
     const cfg = {
       mcpServers: {
-        wmux: { command: 'node', args: ['/abs/path/to/mcp-bundle/index.js'] },
-        'wmux-a2a': { command: 'node', args: ['/abs/path/to/a2a-bundle/index.js'] },
-        // Unrelated entry must be ignored, not considered for our status.
+        wmux: { command: 'node', args: ['/abs/mcp-bundle/index.js'] },
+        'wmux-a2a': { command: 'node', args: ['/abs/a2a-bundle/index.js'] },
         'someone-else': { command: 'node', args: ['/elsewhere/index.js'] },
       },
     };
-    fs.writeFileSync(path.join(tmpHome, '.claude.json'), JSON.stringify(cfg), 'utf8');
+    fs.writeFileSync(claudeJson(), JSON.stringify(cfg), 'utf8');
 
-    const registrar = new McpRegistrar();
-    const status = registrar.getStatus();
-
-    expect(status.configExists).toBe(true);
-    expect(status.configModified).toBeInstanceOf(Date);
-    expect(status.wmux).toEqual({ registered: true, path: '/abs/path/to/mcp-bundle/index.js' });
-    expect(status.wmuxA2a).toEqual({ registered: true, path: '/abs/path/to/a2a-bundle/index.js' });
+    const claude = target(new McpRegistrar().getStatus(), 'claude');
+    expect(claude.configExists).toBe(true);
+    expect(claude.configModified).toBeInstanceOf(Date);
+    expect(claude.wmux).toEqual({ registered: true, path: '/abs/mcp-bundle/index.js' });
+    expect(claude.wmuxA2a).toEqual({ registered: true, path: '/abs/a2a-bundle/index.js' });
   });
 
-  it('treats malformed entries as not registered', () => {
-    const cfg = {
-      mcpServers: {
-        wmux: { command: 'node' /* missing args */ },
-        'wmux-a2a': { command: 'node', args: [] /* empty */ },
-      },
-    };
-    fs.writeFileSync(path.join(tmpHome, '.claude.json'), JSON.stringify(cfg), 'utf8');
-
-    const status = new McpRegistrar().getStatus();
-    expect(status.wmux.registered).toBe(false);
-    expect(status.wmuxA2a.registered).toBe(false);
+  it('extracts registered script paths from Codex TOML (mcp_servers table)', () => {
+    fs.mkdirSync(path.dirname(codexToml()), { recursive: true });
+    fs.writeFileSync(
+      codexToml(),
+      `[mcp_servers.wmux]\ncommand = "node"\nargs = ["C:\\\\w\\\\index.js"]\n`,
+      'utf8',
+    );
+    const codex = target(new McpRegistrar().getStatus(), 'codex');
+    expect(codex.configExists).toBe(true);
+    expect(codex.format).toBe('toml');
+    expect(codex.wmux).toEqual({ registered: true, path: 'C:\\w\\index.js' });
+    expect(codex.wmuxA2a.registered).toBe(false);
   });
 
-  it('returns "not registered" rather than throwing on corrupted JSON', () => {
-    fs.writeFileSync(path.join(tmpHome, '.claude.json'), '{ this is not json', 'utf8');
+  it('treats malformed entries / corrupt configs as not registered (no throw)', () => {
+    fs.writeFileSync(
+      claudeJson(),
+      JSON.stringify({ mcpServers: { wmux: { command: 'node' }, 'wmux-a2a': { command: 'node', args: [] } } }),
+      'utf8',
+    );
+    fs.mkdirSync(path.dirname(codexToml()), { recursive: true });
+    fs.writeFileSync(codexToml(), 'this = = broken', 'utf8');
 
     const status = new McpRegistrar().getStatus();
-    expect(status.configExists).toBe(true);
-    expect(status.wmux.registered).toBe(false);
-    expect(status.wmuxA2a.registered).toBe(false);
+    expect(target(status, 'claude').wmux.registered).toBe(false);
+    expect(target(status, 'codex').configExists).toBe(true);
+    expect(target(status, 'codex').wmux.registered).toBe(false);
+  });
+
+  it('marks claude/codex verified and gemini unverified', () => {
+    const status = new McpRegistrar().getStatus();
+    expect(target(status, 'claude').verified).toBe(true);
+    expect(target(status, 'codex').verified).toBe(true);
+    expect(target(status, 'gemini').verified).toBe(false);
   });
 });
 
-describe('McpRegistrar.forceUnregister', () => {
-  it('removes only wmux + wmux-a2a, leaving foreign entries intact', () => {
-    const cfg = {
-      mcpServers: {
-        wmux: { command: 'node', args: ['/x/wmux.js'] },
-        'wmux-a2a': { command: 'node', args: ['/x/a2a.js'] },
-        'someone-else': { command: 'node', args: ['/y/other.js'] },
-      },
-      otherTopLevel: { keep: true },
-    };
-    fs.writeFileSync(path.join(tmpHome, '.claude.json'), JSON.stringify(cfg), 'utf8');
+describe('McpRegistrar.forceUnregister (multi-target)', () => {
+  it('removes wmux keys from both Claude JSON and Codex TOML, leaving foreign intact', () => {
+    fs.writeFileSync(
+      claudeJson(),
+      JSON.stringify({
+        mcpServers: {
+          wmux: { command: 'node', args: ['/x/wmux.js'] },
+          'wmux-a2a': { command: 'node', args: ['/x/a2a.js'] },
+          'someone-else': { command: 'node', args: ['/y/other.js'] },
+        },
+        otherTopLevel: { keep: true },
+      }),
+      'utf8',
+    );
+    fs.mkdirSync(path.dirname(codexToml()), { recursive: true });
+    fs.writeFileSync(
+      codexToml(),
+      `# comment\n[projects.'d:\\wmux']\ntrust_level = "trusted"\n\n[mcp_servers.wmux]\ncommand = "node"\nargs = ["C:\\\\w\\\\i.js"]\n`,
+      'utf8',
+    );
 
     new McpRegistrar().forceUnregister();
 
-    const after = JSON.parse(
-      fs.readFileSync(path.join(tmpHome, '.claude.json'), 'utf8'),
-    ) as { mcpServers?: Record<string, unknown>; otherTopLevel?: unknown };
-    expect(after.mcpServers).toEqual({
-      'someone-else': { command: 'node', args: ['/y/other.js'] },
-    });
-    expect(after.otherTopLevel).toEqual({ keep: true });
-  });
-
-  it('drops the empty mcpServers object when wmux were the only entries', () => {
-    const cfg = {
-      mcpServers: {
-        wmux: { command: 'node', args: ['/x/wmux.js'] },
-        'wmux-a2a': { command: 'node', args: ['/x/a2a.js'] },
-      },
+    const claudeAfter = JSON.parse(fs.readFileSync(claudeJson(), 'utf8')) as {
+      mcpServers?: Record<string, unknown>; otherTopLevel?: unknown;
     };
-    fs.writeFileSync(path.join(tmpHome, '.claude.json'), JSON.stringify(cfg), 'utf8');
+    expect(claudeAfter.mcpServers).toEqual({ 'someone-else': { command: 'node', args: ['/y/other.js'] } });
+    expect(claudeAfter.otherTopLevel).toEqual({ keep: true });
 
-    new McpRegistrar().forceUnregister();
-
-    const after = JSON.parse(
-      fs.readFileSync(path.join(tmpHome, '.claude.json'), 'utf8'),
-    ) as { mcpServers?: unknown };
-    expect(after.mcpServers).toBeUndefined();
+    const codexAfter = fs.readFileSync(codexToml(), 'utf8');
+    expect(codexAfter).not.toContain('[mcp_servers.wmux]');
+    // Foreign comment + backslash-key project table preserved byte-stable.
+    expect(codexAfter).toContain('# comment');
+    expect(codexAfter).toContain(`[projects.'d:\\wmux']`);
   });
 
-  it('is a safe no-op when ~/.claude.json does not exist', () => {
+  it('is a safe no-op when no configs exist (creates nothing)', () => {
     expect(() => new McpRegistrar().forceUnregister()).not.toThrow();
-    // Should not have created the file.
-    expect(fs.existsSync(path.join(tmpHome, '.claude.json'))).toBe(false);
+    expect(fs.existsSync(claudeJson())).toBe(false);
+    expect(fs.existsSync(codexToml())).toBe(false);
+    expect(fs.existsSync(geminiJson())).toBe(false);
   });
 });
 
 describe('McpRegistrar.unregister (legacy no-op)', () => {
   it('does NOT remove keys (preserves the chicken-and-egg fix)', () => {
-    const cfg = {
-      mcpServers: {
-        wmux: { command: 'node', args: ['/x/wmux.js'] },
-        'wmux-a2a': { command: 'node', args: ['/x/a2a.js'] },
-      },
-    };
-    fs.writeFileSync(path.join(tmpHome, '.claude.json'), JSON.stringify(cfg), 'utf8');
-
+    fs.writeFileSync(
+      claudeJson(),
+      JSON.stringify({ mcpServers: { wmux: { command: 'node', args: ['/x/wmux.js'] } } }),
+      'utf8',
+    );
     new McpRegistrar().unregister();
-
-    const after = JSON.parse(
-      fs.readFileSync(path.join(tmpHome, '.claude.json'), 'utf8'),
-    ) as { mcpServers?: Record<string, unknown> };
+    const after = JSON.parse(fs.readFileSync(claudeJson(), 'utf8')) as { mcpServers?: Record<string, unknown> };
     expect(after.mcpServers?.wmux).toBeDefined();
-    expect(after.mcpServers?.['wmux-a2a']).toBeDefined();
   });
 });

--- a/src/main/mcp/__tests__/firstParty.test.ts
+++ b/src/main/mcp/__tests__/firstParty.test.ts
@@ -168,10 +168,14 @@ describe('FIRST_PARTY_METHODS source invariant', () => {
 });
 
 describe('isFirstPartyClient', () => {
-  it('recognizes claude-code, rejects everything else', () => {
+  it('recognizes the verified agent hosts, rejects everything else', () => {
+    // Empirically-captured agent MCP clientInfo.name values (see firstParty.ts).
     expect(isFirstPartyClient('claude-code')).toBe(true);
+    expect(isFirstPartyClient('codex-mcp-client')).toBe(true);
     expect(FIRST_PARTY_CLIENT_NAMES.has('claude-code')).toBe(true);
-    for (const name of [undefined, '', 'claude', 'Claude-Code', 'evil', 'wmux-orchestrator-e2e']) {
+    expect(FIRST_PARTY_CLIENT_NAMES.has('codex-mcp-client')).toBe(true);
+    // Near-misses and impersonation attempts must NOT be first-party (exact match).
+    for (const name of [undefined, '', 'claude', 'Claude-Code', 'codex', 'Codex', 'evil', 'wmux-orchestrator-e2e']) {
       expect(isFirstPartyClient(name as string | undefined)).toBe(false);
     }
   });

--- a/src/main/mcp/firstParty.ts
+++ b/src/main/mcp/firstParty.ts
@@ -41,11 +41,26 @@ import type { RpcMethod } from '../../shared/rpc';
 // Host identities that own the bundled wmux MCP server. The server reports the
 // connecting MCP client's `clientInfo.name` (see wireClientIdentityHook in
 // src/mcp/index.ts); Claude Code reports `claude-code`. A Set so additional
-// first-party hosts (e.g. a future wmux-native CLI) can be added without
-// touching the enforcer. Exact match — `clientName` is already trimmed by
-// PipeServer when it builds RpcContext.
+// first-party hosts can be added without touching the enforcer. Exact match —
+// `clientName` is already trimmed by PipeServer when it builds RpcContext.
+//
+// Each entry is the bundled wmux MCP server running under a DIFFERENT agent
+// host (the bundle code is identical; only the connecting client's reported
+// name differs). Adding a host grants it the SAME scoped allowlist
+// (FIRST_PARTY_METHODS) — never a blanket bypass, and an explicit user `denied`
+// still wins. Threat model is unchanged: best-effort same-user attribution, not
+// a security boundary (a same-user impersonator already holds the auth token).
+//
+//   - `claude-code`        Claude Code           (verified)
+//   - `codex-mcp-client`   OpenAI Codex CLI      (verified 2026-06-15; clientInfo
+//                          name captured live — `codex mcp add` → initialize)
+//
+// New names MUST be captured empirically (the agent's actual clientInfo.name),
+// not guessed, and the agent must be confirmed to use the wmux tools end-to-end
+// before being added. See plans/a2a-pane-identity-mcp-registration-IMPL.md.
 export const FIRST_PARTY_CLIENT_NAMES: ReadonlySet<string> = new Set<string>([
   'claude-code',
+  'codex-mcp-client',
 ]);
 
 // The exact RPC methods the bundled MCP server (src/mcp/index.ts and its

--- a/src/main/pipe/handlers/a2a.rpc.ts
+++ b/src/main/pipe/handlers/a2a.rpc.ts
@@ -115,7 +115,21 @@ export function registerA2aRpc(router: RpcRouter, getWindow: GetWindow, claudeWo
       const taskId = (result as Record<string, unknown>)?.taskId as string | undefined;
       if (taskId && !params.taskId) {
         const senderWsId = typeof params.workspaceId === 'string' ? params.workspaceId : '';
-        const receiverWsId = typeof params.to === 'string' ? params.to : '';
+        // Use the RESOLVED target workspaceId returned by the renderer, not the
+        // raw `params.to` (which may be a number / partial name / fuzzy match).
+        // The confirmation dialog and ClaudeWorker.execute both key off this id,
+        // so a fuzzy `to` would otherwise confirm/run against the wrong (or no)
+        // workspace. Fall back to params.to only if the renderer didn't resolve.
+        //
+        // NOTE: pane-level addressing (paneId/surfaceId) is intentionally NOT
+        // propagated here — `execute:true` spawns a HEADLESS background Claude
+        // scoped to the receiver WORKSPACE (no pane/TUI). Pane addressing only
+        // steers the renderer-side delivery/nudge; background execution stays
+        // ws-level by design.
+        const resolvedTo = (result as Record<string, unknown>)?.toWorkspaceId;
+        const receiverWsId = typeof resolvedTo === 'string' && resolvedTo
+          ? resolvedTo
+          : (typeof params.to === 'string' ? params.to : '');
         const message = typeof params.message === 'string' ? params.message : '';
         const cwd = typeof params.cwd === 'string' ? params.cwd : undefined;
 

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -563,8 +563,8 @@ server.tool(
 );
 
 // 3. send_message — Primary tool for inter-workspace communication
-const sendMessageHandler = async ({ to, title, task_id, message, execute, silent, data, data_mime_type }: {
-  to?: string; title?: string; task_id?: string; message: string; execute?: boolean; silent?: boolean;
+const sendMessageHandler = async ({ to, pane_id, surface_id, title, task_id, message, execute, silent, data, data_mime_type }: {
+  to?: string; pane_id?: string; surface_id?: string; title?: string; task_id?: string; message: string; execute?: boolean; silent?: boolean;
   data?: Record<string, unknown>; data_mime_type?: string;
 }) => {
   const wsId = await requireWorkspaceId();
@@ -574,6 +574,12 @@ const sendMessageHandler = async ({ to, title, task_id, message, execute, silent
   };
   if (task_id) params.taskId = task_id;
   if (to) params.to = to;
+  // Pane-level addressing: route delivery to a specific pane/surface inside the
+  // target workspace (e.g. a workspace running two agents). Both optional and
+  // ws-scoped — the id must belong to `to`, else the send fails (never silently
+  // delivers to the active pane).
+  if (pane_id) params.paneId = pane_id;
+  if (surface_id) params.surfaceId = surface_id;
   if (title) params.title = title;
   if (execute) params.execute = true;
   // Forward `silent` whenever it is explicitly provided (true OR false), not
@@ -591,6 +597,8 @@ const sendMessageHandler = async ({ to, title, task_id, message, execute, silent
 
 const sendMessageParams = {
   to: z.string().optional().describe('Target: workspace number (1, 2, 3), name ("Workspace 1"), or ID'),
+  pane_id: z.string().optional().describe('Optional: deliver to a specific pane inside the target workspace (from pane_list / a2a_discover panes[].paneId). Use when a workspace runs more than one agent. Must belong to "to".'),
+  surface_id: z.string().optional().describe('Optional: deliver to a specific surface inside the target workspace (from surface_list / a2a_discover panes[].surfaceId). More specific than pane_id; if both are given they must agree. Must belong to "to".'),
   title: z.string().optional().describe('Short title for the message'),
   task_id: z.string().optional().describe('Reply to existing task ID'),
   message: z.string().describe('Message to send'),

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -9,12 +9,19 @@ import { isFileDrag } from '../shared/dragDrop';
 import type { ResumeBinding } from '../shared/agentResume';
 
 /** Mirrors {@link McpStatusPayload} in src/main/ipc/handlers/mcp.handler.ts. */
-interface McpStatusPayload {
-  wmux: { registered: boolean; path: string | null };
-  wmuxA2a: { registered: boolean; path: string | null };
+interface McpTargetStatusPayload {
+  id: string;
+  displayName: string;
+  format: 'json' | 'toml';
   configPath: string;
   configExists: boolean;
   configModified: string | null;
+  verified: boolean;
+  wmux: { registered: boolean; path: string | null };
+  wmuxA2a: { registered: boolean; path: string | null };
+}
+interface McpStatusPayload {
+  targets: McpTargetStatusPayload[];
 }
 
 const electronAPI = {

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -561,12 +561,23 @@ function disposePaneTree(pane: { type: string; surfaces?: Array<{ ptyId?: string
 // ─── MCP integration status ──────────────────────────────────────────────────
 
 /** Mirror of McpStatusPayload in main/ipc/handlers/mcp.handler.ts. */
-interface McpStatusPayload {
-  wmux: { registered: boolean; path: string | null };
-  wmuxA2a: { registered: boolean; path: string | null };
+interface McpServerState {
+  registered: boolean;
+  path: string | null;
+}
+interface McpTargetStatusPayload {
+  id: string;
+  displayName: string;
+  format: 'json' | 'toml';
   configPath: string;
   configExists: boolean;
   configModified: string | null;
+  verified: boolean;
+  wmux: McpServerState;
+  wmuxA2a: McpServerState;
+}
+interface McpStatusPayload {
+  targets: McpTargetStatusPayload[];
 }
 
 interface ElectronMcpApi {
@@ -651,82 +662,96 @@ function McpStatusSection() {
             {server.path}
           </p>
         )}
-        {!server.registered && (
-          <p className="text-[10px] text-[color:var(--text-muted)] mt-0.5">
-            Not registered in Claude Code config
-          </p>
-        )}
       </div>
     </div>
   );
 
+  // Per-target group: agent name + config path/state, and (when the config
+  // exists) the two server rows. Non-existent targets render as "not detected"
+  // (the agent isn't installed — wmux never creates its config).
+  const renderTarget = (target: McpTargetStatusPayload) => (
+    <div key={target.id} className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <span className="text-[11px] font-semibold text-[color:var(--text-sub)]">{target.displayName}</span>
+        {!target.verified && (
+          <span
+            className="text-[9px] px-1 py-0.5 rounded"
+            style={{ backgroundColor: 'var(--bg-surface)', color: 'var(--text-muted)' }}
+            title="Integration not yet verified end-to-end"
+          >
+            experimental
+          </span>
+        )}
+      </div>
+      {target.configExists ? (
+        <>
+          {renderRow('wmux', target.wmux)}
+          {renderRow('wmux-a2a', target.wmuxA2a)}
+          <p className="text-[10px] text-[color:var(--text-muted)] font-mono truncate" title={target.configPath}>
+            {target.configPath}
+            {target.configModified ? ` · modified ${new Date(target.configModified).toLocaleString()}` : ''}
+          </p>
+        </>
+      ) : (
+        <div
+          className="px-3 py-2 rounded-lg text-[11px] text-[color:var(--text-muted)]"
+          style={{ backgroundColor: 'var(--bg-mantle)', border: '1px solid var(--bg-surface)' }}
+        >
+          Not detected · <span className="font-mono">{target.configPath}</span>
+        </div>
+      )}
+    </div>
+  );
+
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-3">
       <SectionLabel label="MCP Servers" />
       {loading ? (
         <div
           className="px-3 py-2 rounded-lg text-[11px] text-[color:var(--text-muted)]"
           style={{ backgroundColor: 'var(--bg-mantle)', border: '1px solid var(--bg-surface)' }}
         >
-          Checking ~/.claude.json…
+          Checking agent configs…
         </div>
       ) : status ? (
         <>
-          {renderRow('wmux', status.wmux)}
-          {renderRow('wmux-a2a', status.wmuxA2a)}
-          <div
-            className="px-3 py-2 rounded-lg flex items-center justify-between gap-3"
-            style={{ backgroundColor: 'var(--bg-mantle)', border: '1px solid var(--bg-surface)' }}
-          >
-            <div className="min-w-0 flex-1">
-              <p className="text-[11px] text-[color:var(--text-sub)] font-mono truncate" title={status.configPath}>
-                {status.configPath}
-              </p>
-              <p className="text-[10px] text-[color:var(--text-muted)] mt-0.5">
-                {status.configExists
-                  ? status.configModified
-                    ? `modified ${new Date(status.configModified).toLocaleString()}`
-                    : 'config file present'
-                  : 'config file does not exist'}
-              </p>
-            </div>
-            <div className="flex items-center gap-2 shrink-0">
-              <Button
-                variant="accent"
-                onClick={() => void handleReregister()}
-                disabled={pending !== null}
-                style={{ opacity: pending ? 0.5 : 1 }}
-              >
-                {pending === 'reregister' ? '…' : 'Re-register'}
-              </Button>
-              {confirmingUnregister ? (
-                <>
-                  <Button
-                    variant="destructive"
-                    onClick={() => void handleUnregister()}
-                    disabled={pending !== null}
-                  >
-                    {pending === 'unregister' ? '…' : 'Confirm'}
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    onClick={() => setConfirmingUnregister(false)}
-                    disabled={pending !== null}
-                  >
-                    Cancel
-                  </Button>
-                </>
-              ) : (
+          {status.targets.map((t) => renderTarget(t))}
+          <div className="flex items-center justify-end gap-2 shrink-0">
+            <Button
+              variant="accent"
+              onClick={() => void handleReregister()}
+              disabled={pending !== null}
+              style={{ opacity: pending ? 0.5 : 1 }}
+            >
+              {pending === 'reregister' ? '…' : 'Re-register'}
+            </Button>
+            {confirmingUnregister ? (
+              <>
+                <Button
+                  variant="destructive"
+                  onClick={() => void handleUnregister()}
+                  disabled={pending !== null}
+                >
+                  {pending === 'unregister' ? '…' : 'Confirm'}
+                </Button>
                 <Button
                   variant="secondary"
-                  onClick={() => setConfirmingUnregister(true)}
+                  onClick={() => setConfirmingUnregister(false)}
                   disabled={pending !== null}
-                  style={{ color: 'var(--accent-red)' }}
                 >
-                  Unregister
+                  Cancel
                 </Button>
-              )}
-            </div>
+              </>
+            ) : (
+              <Button
+                variant="secondary"
+                onClick={() => setConfirmingUnregister(true)}
+                disabled={pending !== null}
+                style={{ color: 'var(--accent-red)' }}
+              >
+                Unregister
+              </Button>
+            )}
           </div>
         </>
       ) : (

--- a/src/renderer/hooks/__tests__/a2aAddressing.test.ts
+++ b/src/renderer/hooks/__tests__/a2aAddressing.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import type { PaneLeaf, Surface } from '../../../shared/types';
+import { resolvePaneAddress, activePaneTerminalPty } from '../a2aAddressing';
+
+function surface(id: string, ptyId: string, surfaceType: Surface['surfaceType'] = 'terminal'): Surface {
+  return { id, ptyId, title: id, shell: '', cwd: '', surfaceType } as Surface;
+}
+function leaf(id: string, surfaces: Surface[], activeSurfaceId?: string): PaneLeaf {
+  return { id, type: 'leaf', surfaces, activeSurfaceId: activeSurfaceId ?? surfaces[0]?.id ?? '' };
+}
+
+// Target workspace: two panes, each with a distinct agent terminal.
+const leaves: PaneLeaf[] = [
+  leaf('pane-A', [surface('surf-A', 'pty-A')]),
+  leaf('pane-B', [surface('surf-B1', 'pty-B1'), surface('surf-B2', 'pty-B2')], 'surf-B2'),
+  leaf('pane-browser', [surface('surf-web', 'pty-web', 'browser')]),
+];
+
+describe('resolvePaneAddress', () => {
+  it('resolves surface_id → that surface only', () => {
+    expect(resolvePaneAddress(leaves, '', 'surf-B1')).toEqual({ ptyId: 'pty-B1', paneId: 'pane-B', surfaceId: 'surf-B1' });
+  });
+
+  it('resolves pane_id → the leaf active terminal surface', () => {
+    // pane-B's activeSurfaceId is surf-B2.
+    expect(resolvePaneAddress(leaves, 'pane-B', '')).toEqual({ ptyId: 'pty-B2', paneId: 'pane-B', surfaceId: 'surf-B2' });
+  });
+
+  it('resolves pane_id → first terminal surface when active is not a terminal', () => {
+    const ls = [leaf('p', [surface('web', 'pw', 'browser'), surface('t', 'pt')], 'web')];
+    expect(resolvePaneAddress(ls, 'p', '')).toEqual({ ptyId: 'pt', paneId: 'p', surfaceId: 't' });
+  });
+
+  it('REJECTS when pane_id and surface_id disagree (no silent pick)', () => {
+    const r = resolvePaneAddress(leaves, 'pane-A', 'surf-B1');
+    expect('error' in r && r.error).toMatch(/does not belong to pane_id/);
+  });
+
+  it('REJECTS a browser surface (not a terminal)', () => {
+    const r = resolvePaneAddress(leaves, '', 'surf-web');
+    expect('error' in r && r.error).toMatch(/not a terminal/);
+  });
+
+  it('FAIL-CLOSED: a cross-ws / unknown surface_id is not found (only target leaves searched)', () => {
+    const r = resolvePaneAddress(leaves, '', 'surf-from-other-ws');
+    expect('error' in r && r.error).toMatch(/not found in target workspace/);
+  });
+
+  it('FAIL-CLOSED: an unknown pane_id is not found', () => {
+    const r = resolvePaneAddress(leaves, 'pane-from-other-ws', '');
+    expect('error' in r && r.error).toMatch(/not found in target workspace/);
+  });
+
+  it('REJECTS a pane with no terminal surface', () => {
+    const ls = [leaf('only-browser', [surface('web', 'pw', 'browser')])];
+    const r = resolvePaneAddress(ls, 'only-browser', '');
+    expect('error' in r && r.error).toMatch(/no terminal surface/);
+  });
+});
+
+describe('activePaneTerminalPty', () => {
+  it('returns the active leaf first terminal pty', () => {
+    expect(activePaneTerminalPty(leaves, 'pane-B')).toBe('pty-B1');
+  });
+  it('falls back to the first leaf with a terminal when active id is unknown', () => {
+    expect(activePaneTerminalPty(leaves, 'nonexistent')).toBe('pty-A');
+  });
+  it('returns null when no terminal surface exists', () => {
+    expect(activePaneTerminalPty([leaf('p', [surface('w', 'pw', 'browser')])], 'p')).toBeNull();
+  });
+});

--- a/src/renderer/hooks/__tests__/useRpcBridge.a2aPaneIdentity.test.ts
+++ b/src/renderer/hooks/__tests__/useRpcBridge.a2aPaneIdentity.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Wiring guards for Part A (pane-level A2A identity + addressing). The pure
+ * address logic is unit-tested in a2aAddressing.test.ts; useRpcBridge itself
+ * can't be imported under vitest (pulls in the store/window), so these are
+ * source-structural assertions that the derivations + addressing stay wired.
+ */
+describe('useRpcBridge — pane-level A2A identity wiring', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'useRpcBridge.ts'), 'utf-8');
+
+  function region(start: string, end: string): string {
+    const m = src.match(new RegExp(`${start}[\\s\\S]*?${end}`));
+    if (!m) throw new Error(`region ${start} → ${end} not found in useRpcBridge.ts`);
+    return m[0];
+  }
+
+  it('surface.list labels each surface from the surfaceAgent map', () => {
+    const block = region("method === 'surface\\.list'", 'return surfaces;');
+    expect(block).toMatch(/store\.surfaceAgent\[s\.ptyId\]/);
+    expect(block).toMatch(/agentName:/);
+    expect(block).toMatch(/agentStatus:/);
+  });
+
+  it('pane.list exposes per-leaf agents derived from surfaceAgent', () => {
+    const block = region("method === 'pane\\.list'", 'return leaves\\.map');
+    // the agents[] derivation lives in the leaves.map body
+    const mapBody = region("method === 'pane\\.list'", 'pane\\.focus');
+    expect(mapBody).toMatch(/agents:\s*l\.surfaces\.flatMap/);
+    expect(mapBody).toMatch(/store\.surfaceAgent\[s\.ptyId\]/);
+    void block;
+  });
+
+  it('a2a.discover returns per-pane addressable entries', () => {
+    const block = region("method === 'a2a\\.discover'", "method === 'a2a\\.task\\.send'");
+    expect(block).toMatch(/panes/);
+    expect(block).toMatch(/store\.surfaceAgent\[s\.ptyId\]/);
+    expect(block).toMatch(/paneId:/);
+    expect(block).toMatch(/surfaceId:/);
+  });
+
+  it('a2a.task.send resolves an explicit address and HARD-rejects an invalid one (no active-pane fallback)', () => {
+    const block = region("method === 'a2a\\.task\\.send'", "method === 'a2a\\.task\\.query'");
+    expect(block).toMatch(/resolvePaneAddress\(findLeafPanes\(target\.rootPane\)/);
+    // an 'error' from the resolver short-circuits the send
+    expect(block).toMatch(/if \('error' in addr\) return \{ error: `a2a\.task\.send:/);
+    // reply pins to the originally-addressed pane
+    expect(block).toMatch(/resolvePaneAddress\(findLeafPanes\(targetWs\.rootPane\)/);
+    // reply fails CLOSED when the pinned address no longer resolves (no
+    // active-pane fallback that could land on the wrong agent)
+    expect(block).toMatch(/pinnedAddressLost/);
+    // the resolved target ws id is returned for the main-side execute path
+    expect(block).toMatch(/toWorkspaceId: target\.id/);
+  });
+});
+
+describe('a2a.rpc — execute uses the resolved workspaceId', () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, '..', '..', '..', 'main', 'pipe', 'handlers', 'a2a.rpc.ts'),
+    'utf-8',
+  );
+  it('reads toWorkspaceId from the renderer result instead of the raw fuzzy `to`', () => {
+    expect(src).toMatch(/toWorkspaceId/);
+    expect(src).toMatch(/const resolvedTo = \(result as Record<string, unknown>\)\?\.\['?toWorkspaceId'?\]|result as Record<string, unknown>\)\?\.toWorkspaceId/);
+  });
+});

--- a/src/renderer/hooks/__tests__/useRpcBridge.a2aPaneIdentity.test.ts
+++ b/src/renderer/hooks/__tests__/useRpcBridge.a2aPaneIdentity.test.ts
@@ -62,7 +62,9 @@ describe('a2a.rpc — execute uses the resolved workspaceId', () => {
     'utf-8',
   );
   it('reads toWorkspaceId from the renderer result instead of the raw fuzzy `to`', () => {
+    // The resolved id is pulled off the renderer result and preferred over params.to.
+    expect(src).toMatch(/resolvedTo\b/);
     expect(src).toMatch(/toWorkspaceId/);
-    expect(src).toMatch(/const resolvedTo = \(result as Record<string, unknown>\)\?\.\['?toWorkspaceId'?\]|result as Record<string, unknown>\)\?\.toWorkspaceId/);
+    expect(src).toMatch(/resolvedTo[\s\S]*?:\s*\(typeof params\.to/); // fallback to params.to
   });
 });

--- a/src/renderer/hooks/a2aAddressing.ts
+++ b/src/renderer/hooks/a2aAddressing.ts
@@ -1,0 +1,59 @@
+// Pure pane-address resolution for A2A delivery (Part A). Extracted from
+// useRpcBridge so it can be unit-tested directly (useRpcBridge itself pulls in
+// the store/window and can't be imported under vitest). No React/window deps —
+// operates only on the pane-leaf list the caller passes in.
+
+import type { PaneLeaf } from '../../shared/types';
+
+export type PaneAddress = { ptyId: string; paneId: string; surfaceId: string };
+
+/**
+ * The historical active-pane delivery target: the active leaf's first terminal
+ * surface with a pty, falling back to the first leaf that has one. Used when no
+ * explicit pane address is supplied.
+ */
+export function activePaneTerminalPty(leaves: PaneLeaf[], activePaneId: string): string | null {
+  const activeLeaf = leaves.find((l) => l.id === activePaneId)
+    ?? leaves.find((l) => l.surfaces.some((s) => s.surfaceType !== 'browser'));
+  const termSurface = activeLeaf?.surfaces.find((s) => s.surfaceType !== 'browser' && s.ptyId);
+  return termSurface?.ptyId ?? null;
+}
+
+/**
+ * Resolve an optional pane-level address (paneId/surfaceId) to a concrete ptyId
+ * WITHIN the given leaves (which must be the target workspace's own tree).
+ * Cross-ws safety is structural: only the target's leaves are searched, so a
+ * foreign id is simply "not found" (fail-closed). Returns an error string when
+ * the address is missing or inconsistent — the caller must NOT fall back to the
+ * active pane (that would deliver to the wrong agent on a typo).
+ *
+ *   - surfaceId given → that surface (must be a terminal with a pty); if paneId
+ *     is also given it MUST be that surface's leaf, else reject.
+ *   - paneId only → that leaf's active terminal surface, else its first one.
+ */
+export function resolvePaneAddress(
+  leaves: PaneLeaf[],
+  paneId: string,
+  surfaceId: string,
+): PaneAddress | { error: string } {
+  if (surfaceId) {
+    for (const leaf of leaves) {
+      const s = leaf.surfaces.find((su) => su.id === surfaceId);
+      if (!s) continue;
+      if (paneId && leaf.id !== paneId) {
+        return { error: `surface_id "${surfaceId}" does not belong to pane_id "${paneId}"` };
+      }
+      if (s.surfaceType === 'browser' || !s.ptyId) {
+        return { error: `surface_id "${surfaceId}" is not a terminal surface` };
+      }
+      return { ptyId: s.ptyId, paneId: leaf.id, surfaceId: s.id };
+    }
+    return { error: `surface_id "${surfaceId}" not found in target workspace` };
+  }
+  const leaf = leaves.find((l) => l.id === paneId);
+  if (!leaf) return { error: `pane_id "${paneId}" not found in target workspace` };
+  const active = leaf.surfaces.find((s) => s.id === leaf.activeSurfaceId && s.surfaceType !== 'browser' && s.ptyId);
+  const term = active ?? leaf.surfaces.find((s) => s.surfaceType !== 'browser' && s.ptyId);
+  if (!term) return { error: `pane_id "${paneId}" has no terminal surface` };
+  return { ptyId: term.ptyId, paneId: leaf.id, surfaceId: term.id };
+}

--- a/src/renderer/hooks/a2aAddressing.ts
+++ b/src/renderer/hooks/a2aAddressing.ts
@@ -13,8 +13,12 @@ export type PaneAddress = { ptyId: string; paneId: string; surfaceId: string };
  * explicit pane address is supplied.
  */
 export function activePaneTerminalPty(leaves: PaneLeaf[], activePaneId: string): string | null {
+  // Fallback (active pane not found) must land on a leaf that actually has a
+  // deliverable terminal — require `s.ptyId` in the predicate, else a leaf whose
+  // only non-browser surface lacks a pty would be picked and yield null even
+  // when a later leaf has a live terminal.
   const activeLeaf = leaves.find((l) => l.id === activePaneId)
-    ?? leaves.find((l) => l.surfaces.some((s) => s.surfaceType !== 'browser'));
+    ?? leaves.find((l) => l.surfaces.some((s) => s.surfaceType !== 'browser' && s.ptyId));
   const termSurface = activeLeaf?.surfaces.find((s) => s.surfaceType !== 'browser' && s.ptyId);
   return termSurface?.ptyId ?? null;
 }

--- a/src/renderer/hooks/useNotificationListener.ts
+++ b/src/renderer/hooks/useNotificationListener.ts
@@ -520,7 +520,11 @@ export function useNotificationListener() {
                   if (!name) return;
                   const s = useStore.getState();
                   if (needWsBackfill) s.updateWorkspaceMetadata(targetWsId, { agentName: name });
-                  if (needSurfaceBackfill) s.setSurfaceAgent(ptyId, name, 'running');
+                  // Backfill the NAME only — pass undefined status so a newer
+                  // status (the surface may have gone complete/idle while this
+                  // async resolveAgent was in flight) is preserved, not stomped
+                  // back to 'running'. setSurfaceAgent keeps the existing status.
+                  if (needSurfaceBackfill) s.setSurfaceAgent(ptyId, name, undefined);
                 });
               }
             }

--- a/src/renderer/hooks/useNotificationListener.ts
+++ b/src/renderer/hooks/useNotificationListener.ts
@@ -471,6 +471,18 @@ export function useNotificationListener() {
         if (typeof rest.agentStatus === 'string') {
           state.setSurfaceAgentStatus(ptyId, rest.agentStatus as AgentStatus);
         }
+        // Part A: stamp per-surface agent IDENTITY (name + status) keyed by
+        // ptyId so a2a_discover / surface_list / pane_list can label each pane
+        // individually. setSurfaceAgent keeps an already-known name when only a
+        // status arrives, and ignores empty names (the 'running' broadcast may
+        // carry agentName='' before a gate matches).
+        if (typeof rest.agentName === 'string' || typeof rest.agentStatus === 'string') {
+          state.setSurfaceAgent(
+            ptyId,
+            typeof rest.agentName === 'string' ? rest.agentName : undefined,
+            typeof rest.agentStatus === 'string' ? (rest.agentStatus as AgentStatus) : undefined,
+          );
+        }
         for (const ws of state.workspaces) {
           const found = findSurfaceByPtyId(ws.rootPane, ptyId);
           if (found) {
@@ -495,13 +507,22 @@ export function useNotificationListener() {
             // gate emit)은 1회성이라, ptyId↔surface 매핑이 준비되기 전에 발화하면
             // 영영 유실된다. 매핑이 생긴 지금(running 수신 + agentName 비어 있음)
             // main의 lastAgentNameByPty 캐시에서 race-free하게 pull해 메운다.
-            if (rest.agentStatus === 'running' && !ws.metadata?.agentName) {
-              const targetWsId = ws.id;
-              void window.electronAPI.metadata.resolveAgent(ptyId).then((name) => {
-                if (name) {
-                  useStore.getState().updateWorkspaceMetadata(targetWsId, { agentName: name });
-                }
-              });
+            if (rest.agentStatus === 'running') {
+              const needWsBackfill = !ws.metadata?.agentName;
+              // Per-surface backfill (Codex review): the one-shot agentName can
+              // miss this pty's surfaceAgent map just as it misses ws metadata.
+              // The ws may already carry a name from another pane while THIS
+              // surface still has none, so check the per-surface entry too.
+              const needSurfaceBackfill = !state.surfaceAgent[ptyId]?.name;
+              if (needWsBackfill || needSurfaceBackfill) {
+                const targetWsId = ws.id;
+                void window.electronAPI.metadata.resolveAgent(ptyId).then((name) => {
+                  if (!name) return;
+                  const s = useStore.getState();
+                  if (needWsBackfill) s.updateWorkspaceMetadata(targetWsId, { agentName: name });
+                  if (needSurfaceBackfill) s.setSurfaceAgent(ptyId, name, 'running');
+                });
+              }
             }
             break;
           }

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -205,6 +205,21 @@ function isLiveTuiAgent(meta: { agentName?: string; agentStatus?: string } | und
   return !!meta.agentName && meta.agentStatus != null && LIVE_AGENT_STATUSES.has(meta.agentStatus);
 }
 
+// Liveness metadata for an A2A delivery decision (nudge vs full paste). When an
+// explicit pane/surface was addressed, the decision must reflect THAT pane's
+// agent (a workspace can host more than one agent) — read it from the
+// per-ptyId surfaceAgent map. Falls back to ws-level metadata when no explicit
+// pty was resolved (the active-pane heuristic path).
+function deliveryLiveMeta(
+  surfaceAgent: Record<string, { name: string; status: string }>,
+  explicitPty: string | undefined,
+  fallbackMeta: { agentName?: string; agentStatus?: string } | undefined,
+): { agentName?: string; agentStatus?: string } | undefined {
+  if (!explicitPty) return fallbackMeta;
+  const a = surfaceAgent[explicitPty];
+  return a ? { agentName: a.name, agentStatus: a.status } : undefined;
+}
+
 /**
  * One-line nudge for a live-agent receiver. SINGLE LINE — no embedded
  * newlines, no message body (the body rides the dual-party-scoped task store,
@@ -1272,7 +1287,8 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
             }
           }
           if (!pinnedAddressLost) {
-            if (!silentExplicit && isLiveTuiAgent(targetWs.metadata)) {
+            const liveMeta = deliveryLiveMeta(store.surfaceAgent, explicitPty, targetWs.metadata);
+            if (!silentExplicit && isLiveTuiAgent(liveMeta)) {
               deliverPtyNudge(targetWs, buildA2aNudge(taskId, senderName), explicitPty);
             } else {
               deliverPtyNotification(targetWs, senderName, message, explicitPty);
@@ -1319,6 +1335,14 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // target's tree is searched). An explicit-but-invalid address is a hard
     // error — never silently fall back to the active pane (that would deliver
     // to the wrong agent on a typo).
+    // Fail closed on a present-but-non-string address: coercing to '' would
+    // silently drop it and fall back to active-pane delivery (wrong agent).
+    if (params.paneId !== undefined && typeof params.paneId !== 'string') {
+      return { error: 'a2a.task.send: "pane_id" must be a string' };
+    }
+    if (params.surfaceId !== undefined && typeof params.surfaceId !== 'string') {
+      return { error: 'a2a.task.send: "surface_id" must be a string' };
+    }
     const reqPaneId = typeof params.paneId === 'string' ? params.paneId : '';
     const reqSurfaceId = typeof params.surfaceId === 'string' ? params.surfaceId : '';
     let resolvedAddr: PaneAddress | undefined;
@@ -1349,7 +1373,10 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // flooded); no live agent (or explicit silent:false) keeps the loud paste.
     if (!silent) {
       const explicitPty = resolvedAddr?.ptyId;
-      if (!silentExplicit && isLiveTuiAgent(target.metadata)) {
+      // Liveness for the nudge-vs-paste choice must reflect the ADDRESSED pane's
+      // agent (a workspace can host >1 agent), not ws-level metadata.
+      const liveMeta = deliveryLiveMeta(store.surfaceAgent, explicitPty, target.metadata);
+      if (!silentExplicit && isLiveTuiAgent(liveMeta)) {
         deliverPtyNudge(target, buildA2aNudge(newTaskId, fromName), explicitPty);
       } else {
         deliverPtyNotification(target, fromName, message, explicitPty);

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -16,6 +16,7 @@ import { readPtyBufferLines } from '../utils/terminalTail';
 import { searchInBuffer, type SearchableBuffer } from '../utils/searchEngine';
 import { submitBracketedPasteToPty } from '../utils/ptyMessageDelivery';
 import { publishA2aTask } from '../events/publisher';
+import { resolvePaneAddress, activePaneTerminalPty, type PaneAddress } from './a2aAddressing';
 
 // ---------------------------------------------------------------------------
 // Pane tree utilities
@@ -156,16 +157,11 @@ function deliverPtyNotification(
   targetWs: { rootPane: Pane; activePaneId: string; name: string },
   senderName: string,
   message: string,
+  explicitPtyId?: string,
 ): void {
-  const leaves = findLeafPanes(targetWs.rootPane);
-  const activeLeaf = leaves.find((l) => l.id === targetWs.activePaneId)
-    ?? leaves.find((l) => l.surfaces.some((s) => s.surfaceType !== 'browser'));
-  if (activeLeaf) {
-    const termSurface = activeLeaf.surfaces.find((s) => s.surfaceType !== 'browser' && s.ptyId);
-    if (termSurface) {
-      const formatted = formatA2aMessage(senderName, targetWs.name, message);
-      submitToPty(termSurface.ptyId, formatted);
-    }
+  const ptyId = explicitPtyId ?? activePaneTerminalPty(findLeafPanes(targetWs.rootPane), targetWs.activePaneId);
+  if (ptyId) {
+    submitToPty(ptyId, formatA2aMessage(senderName, targetWs.name, message));
   }
 }
 
@@ -181,15 +177,11 @@ function deliverPtyNotification(
 function deliverPtyNudge(
   targetWs: { rootPane: Pane; activePaneId: string },
   nudge: string,
+  explicitPtyId?: string,
 ): void {
-  const leaves = findLeafPanes(targetWs.rootPane);
-  const activeLeaf = leaves.find((l) => l.id === targetWs.activePaneId)
-    ?? leaves.find((l) => l.surfaces.some((s) => s.surfaceType !== 'browser'));
-  if (activeLeaf) {
-    const termSurface = activeLeaf.surfaces.find((s) => s.surfaceType !== 'browser' && s.ptyId);
-    if (termSurface) {
-      submitToPty(termSurface.ptyId, nudge);
-    }
+  const ptyId = explicitPtyId ?? activePaneTerminalPty(findLeafPanes(targetWs.rootPane), targetWs.activePaneId);
+  if (ptyId) {
+    submitToPty(ptyId, nudge);
   }
 }
 
@@ -442,6 +434,9 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     const surfaces = [];
     for (const leaf of leaves) {
       for (const s of leaf.surfaces) {
+        // Part A: per-surface agent label so a workspace hosting >1 agent is
+        // distinguishable without the buffer-fingerprint workaround (gap 3).
+        const agent = store.surfaceAgent[s.ptyId];
         surfaces.push({
           id: s.id,
           ptyId: s.ptyId,
@@ -453,6 +448,8 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
           browserUrl: s.browserUrl,
           paneId: leaf.id,
           isActive: s.id === leaf.activeSurfaceId,
+          agentName: agent?.name ?? null,
+          agentStatus: agent?.status ?? null,
         });
       }
     }
@@ -574,6 +571,13 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
         // CLI table and external readers that ignore unknown fields are
         // unaffected.
         surfacePtyIds: l.surfaces.map((s) => s.ptyId).filter((id): id is string => Boolean(id)),
+        // Part A: per-surface agent labels for this leaf. A split pane can hold
+        // more than one terminal surface; each detected agent is listed so the
+        // pane is individually addressable (gaps 1/8).
+        agents: l.surfaces.flatMap((s) => {
+          const a = store.surfaceAgent[s.ptyId];
+          return a ? [{ ptyId: s.ptyId, surfaceId: s.id, agentName: a.name, agentStatus: a.status }] : [];
+        }),
       };
     });
   }
@@ -1130,6 +1134,32 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
         // never gate sending on this, it just lets a sender pre-check whether
         // the receiver is likely to react to a paste vs. needs the inbox poll.
         const live = isLiveTuiAgent(w.metadata);
+        // Part A — per-pane agent labels (gaps 1/3/8). Each terminal surface in
+        // the workspace becomes an addressable entry (paneId/surfaceId/ptyId)
+        // carrying its detected agent (null when undetected). Clients that need
+        // to talk to a SPECIFIC agent in a multi-agent workspace iterate
+        // `panes` and address `a2a_task_send` with the surface_id/pane_id; the
+        // ws-level fields below stay for back-compat single-agent callers.
+        const panes: Array<{
+          paneId: string;
+          surfaceId: string;
+          ptyId: string;
+          agentName: string | null;
+          agentStatus: string | null;
+        }> = [];
+        for (const leaf of findLeafPanes(w.rootPane)) {
+          for (const s of leaf.surfaces) {
+            if (s.surfaceType === 'browser' || !s.ptyId) continue;
+            const a = store.surfaceAgent[s.ptyId];
+            panes.push({
+              paneId: leaf.id,
+              surfaceId: s.id,
+              ptyId: s.ptyId,
+              agentName: a?.name ?? null,
+              agentStatus: a?.status ?? null,
+            });
+          }
+        }
         return {
           name: w.name,
           description: w.metadata?.agentName ?? w.name,
@@ -1145,6 +1175,7 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
           // resolve.identity PID→ws cross-check would set a stronger source.
           live,
           liveSource: live ? 'store-metadata' : undefined,
+          panes,
           metadata: {
             workspaceId: w.id,
             status: (w.metadata?.agentStatus as string) ?? 'idle',
@@ -1217,15 +1248,35 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       // don't corrupt its prompt; otherwise (no live agent, or explicit
       // silent:false) keep the loud full-body paste.
       if (!silent) {
-        const targetWsId = role === 'user' ? task.metadata.to.workspaceId : task.metadata.from.workspaceId;
+        const replyingToReceiver = role === 'user';
+        const targetWsId = replyingToReceiver ? task.metadata.to.workspaceId : task.metadata.from.workspaceId;
         const targetWs = store.workspaces.find((w) => w.id === targetWsId);
         if (targetWs) {
           const senderWs = store.workspaces.find((w) => w.id === workspaceId);
           const senderName = senderWs?.name ?? 'unknown';
-          if (!silentExplicit && isLiveTuiAgent(targetWs.metadata)) {
-            deliverPtyNudge(targetWs, buildA2aNudge(taskId, senderName));
-          } else {
-            deliverPtyNotification(targetWs, senderName, message);
+          // Part A: keep the thread pinned to the originally-addressed pane.
+          // Only the receiver side (`to`) carries a stored pane address; replies
+          // back to the original sender (`from`) have none → active-pane.
+          let explicitPty: string | undefined;
+          let pinnedAddressLost = false;
+          if (replyingToReceiver && (task.metadata.to.paneId || task.metadata.to.surfaceId)) {
+            const addr = resolvePaneAddress(findLeafPanes(targetWs.rootPane), task.metadata.to.paneId ?? '', task.metadata.to.surfaceId ?? '');
+            if ('error' in addr) {
+              // The addressed pane no longer resolves (closed / re-split). Fail
+              // CLOSED: do not paste to a different (active) pane — that could
+              // land on the wrong agent. The reply is still persisted + on the
+              // EventBus, so the receiver can still poll it via a2a_task_query.
+              pinnedAddressLost = true;
+            } else {
+              explicitPty = addr.ptyId;
+            }
+          }
+          if (!pinnedAddressLost) {
+            if (!silentExplicit && isLiveTuiAgent(targetWs.metadata)) {
+              deliverPtyNudge(targetWs, buildA2aNudge(taskId, senderName), explicitPty);
+            } else {
+              deliverPtyNotification(targetWs, senderName, message, explicitPty);
+            }
           }
         }
       }
@@ -1263,12 +1314,30 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     }
     if (target.id === workspaceId) return { error: 'a2a.task.send: cannot send to yourself' };
 
+    // Part A — optional pane-level addressing. Resolve paneId/surfaceId to a
+    // concrete pty INSIDE the target ws (cross-ws ids fail-closed: only
+    // target's tree is searched). An explicit-but-invalid address is a hard
+    // error — never silently fall back to the active pane (that would deliver
+    // to the wrong agent on a typo).
+    const reqPaneId = typeof params.paneId === 'string' ? params.paneId : '';
+    const reqSurfaceId = typeof params.surfaceId === 'string' ? params.surfaceId : '';
+    let resolvedAddr: PaneAddress | undefined;
+    if (reqPaneId || reqSurfaceId) {
+      const addr = resolvePaneAddress(findLeafPanes(target.rootPane), reqPaneId, reqSurfaceId);
+      if ('error' in addr) return { error: `a2a.task.send: ${addr.error}` };
+      resolvedAddr = addr;
+    }
+
     const initialMessage: Message = { kind: 'message', messageId: generateId('msg'), role: 'user', parts };
 
     const newTaskId = store.createA2aTask({
       title: title || message.slice(0, 100),
       from: { workspaceId, name: fromName },
-      to: { workspaceId: target.id, name: target.name },
+      to: {
+        workspaceId: target.id,
+        name: target.name,
+        ...(resolvedAddr && { paneId: resolvedAddr.paneId, surfaceId: resolvedAddr.surfaceId }),
+      },
       history: [initialMessage],
       artifacts: [],
     });
@@ -1279,10 +1348,11 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // an unset silent + live-TUI receiver gets a one-line nudge (prompt not
     // flooded); no live agent (or explicit silent:false) keeps the loud paste.
     if (!silent) {
+      const explicitPty = resolvedAddr?.ptyId;
       if (!silentExplicit && isLiveTuiAgent(target.metadata)) {
-        deliverPtyNudge(target, buildA2aNudge(newTaskId, fromName));
+        deliverPtyNudge(target, buildA2aNudge(newTaskId, fromName), explicitPty);
       } else {
-        deliverPtyNotification(target, fromName, message);
+        deliverPtyNotification(target, fromName, message, explicitPty);
       }
     }
 
@@ -1293,7 +1363,10 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     const createdTask = store.getTask(newTaskId);
     if (createdTask) emitA2aTaskEvent(createdTask, 'created');
 
-    return { ok: true, taskId: newTaskId, silent };
+    // Return the RESOLVED target workspaceId so the main-side a2a.rpc handler
+    // uses it for execute:true (confirm + ClaudeWorker), instead of the raw
+    // fuzzy `to` string (which could be a number/partial name).
+    return { ok: true, taskId: newTaskId, silent, toWorkspaceId: target.id };
   }
 
   if (method === 'a2a.task.query') {

--- a/src/renderer/stores/slices/__tests__/paneSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneSlice.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { createPaneSlice, type PaneSlice, MAX_PANES_PER_WORKSPACE } from '../paneSlice';
-import { createWorkspace, type Workspace } from '../../../../shared/types';
+import { createWorkspace, type Workspace, type Surface } from '../../../../shared/types';
 import { findPane, getLeafPanes } from '../../../../shared/paneUtils';
 
 // Minimal store that satisfies PaneSlice dependencies. Includes a `pushToast`
@@ -521,6 +521,23 @@ describe('PaneSlice', () => {
       store.getState().setSurfaceAgent('pty-1', 'Claude Code', 'running');
       store.getState().clearSurfaceAgent('pty-1');
       expect(store.getState().surfaceAgent['pty-1']).toBeUndefined();
+    });
+
+    it('closePane auto-clears surfaceAgent for every surface under the closed subtree (leak-prevention)', () => {
+      const ws = getActiveWorkspace(store);
+      const rootLeafId = getLeafPanes(ws.rootPane)[0].id;
+      store.getState().splitPane(rootLeafId, 'horizontal');
+      const closing = getLeafPanes(getActiveWorkspace(store).rootPane)[1];
+      // Give the closing pane a terminal surface with a known ptyId (a freshly
+      // split leaf is empty until AppLayout funnels a PTY in the real app).
+      store.setState((s) => {
+        const leaf = getLeafPanes(s.workspaces[0].rootPane).find((l) => l.id === closing.id);
+        if (leaf) leaf.surfaces.push({ id: 'surf-ct', ptyId: 'pty-closetest', title: 'x', shell: '', cwd: '', surfaceType: 'terminal' } as Surface);
+      });
+      store.getState().setSurfaceAgent('pty-closetest', 'Claude Code', 'running');
+      expect(store.getState().surfaceAgent['pty-closetest']).toBeTruthy();
+      store.getState().closePane(closing.id);
+      expect(store.getState().surfaceAgent['pty-closetest']).toBeUndefined();
     });
   });
 });

--- a/src/renderer/stores/slices/__tests__/paneSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneSlice.test.ts
@@ -491,4 +491,36 @@ describe('PaneSlice', () => {
       expect(store.getState().zoomedPaneId).toBe(leaves[0].id);
     });
   });
+
+  // Part A — per-surface agent identity map.
+  describe('surfaceAgent', () => {
+    it('stores name + status keyed by ptyId', () => {
+      store.getState().setSurfaceAgent('pty-1', 'Claude Code', 'waiting');
+      expect(store.getState().surfaceAgent['pty-1']).toEqual({ name: 'Claude Code', status: 'waiting' });
+    });
+
+    it('keeps the known name when a later update carries an empty name (running broadcast)', () => {
+      store.getState().setSurfaceAgent('pty-1', 'Codex CLI', 'running');
+      store.getState().setSurfaceAgent('pty-1', '', 'running'); // ActivityMonitor running, name not yet gated
+      expect(store.getState().surfaceAgent['pty-1']).toEqual({ name: 'Codex CLI', status: 'running' });
+    });
+
+    it('updates only the status when a status-only update arrives for a known agent', () => {
+      store.getState().setSurfaceAgent('pty-1', 'Claude Code', 'running');
+      store.getState().setSurfaceAgent('pty-1', undefined, 'complete');
+      expect(store.getState().surfaceAgent['pty-1']).toEqual({ name: 'Claude Code', status: 'complete' });
+    });
+
+    it('does nothing when no name is known yet (no entry created)', () => {
+      store.getState().setSurfaceAgent('pty-x', '', 'running');
+      store.getState().setSurfaceAgent('pty-x', undefined, 'waiting');
+      expect(store.getState().surfaceAgent['pty-x']).toBeUndefined();
+    });
+
+    it('clearSurfaceAgent removes the entry', () => {
+      store.getState().setSurfaceAgent('pty-1', 'Claude Code', 'running');
+      store.getState().clearSurfaceAgent('pty-1');
+      expect(store.getState().surfaceAgent['pty-1']).toBeUndefined();
+    });
+  });
 });

--- a/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
@@ -5,6 +5,7 @@ import { createSurfaceSlice } from '../surfaceSlice';
 type TestState = {
   workspaces: Workspace[];
   activeWorkspaceId: string;
+  surfaceAgent: Record<string, { name: string; status: string }>;
 };
 
 function createHarness() {
@@ -12,6 +13,7 @@ function createHarness() {
   const state: TestState = {
     workspaces: [workspace],
     activeWorkspaceId: workspace.id,
+    surfaceAgent: {},
   };
 
   const set = (updater: (state: TestState) => void) => {
@@ -264,5 +266,21 @@ describe('surfaceSlice browser partition state', () => {
     const pane = state.workspaces[0].rootPane;
     if (pane.type !== 'leaf') throw new Error('expected leaf pane');
     expect(pane.surfaces.every((surface) => surface.browserPartition === 'persist:wmux-login')).toBe(true);
+  });
+});
+
+describe('surfaceSlice.closeSurface — surfaceAgent cleanup (Part A leak-prevention)', () => {
+  it('clears the surfaceAgent entry for the closed surface ptyId', () => {
+    const { state, slice } = createHarness();
+    const paneId = state.workspaces[0].rootPane.id;
+    slice.addSurface(paneId, 'pty-1', 'pwsh', 'C:\a');
+    const pane = state.workspaces[0].rootPane;
+    if (pane.type !== 'leaf') throw new Error('expected leaf pane');
+    const surfaceId = pane.surfaces.find((s) => s.ptyId === 'pty-1')!.id;
+    state.surfaceAgent['pty-1'] = { name: 'Claude Code', status: 'running' };
+
+    slice.closeSurface(paneId, surfaceId);
+
+    expect(state.surfaceAgent['pty-1']).toBeUndefined();
   });
 });

--- a/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
@@ -273,7 +273,7 @@ describe('surfaceSlice.closeSurface — surfaceAgent cleanup (Part A leak-preven
   it('clears the surfaceAgent entry for the closed surface ptyId', () => {
     const { state, slice } = createHarness();
     const paneId = state.workspaces[0].rootPane.id;
-    slice.addSurface(paneId, 'pty-1', 'pwsh', 'C:\a');
+    slice.addSurface(paneId, 'pty-1', 'pwsh', 'C:\\a');
     const pane = state.workspaces[0].rootPane;
     if (pane.type !== 'leaf') throw new Error('expected leaf pane');
     const surfaceId = pane.surfaces.find((s) => s.ptyId === 'pty-1')!.id;

--- a/src/renderer/stores/slices/a2aSlice.ts
+++ b/src/renderer/stores/slices/a2aSlice.ts
@@ -35,7 +35,9 @@ export interface A2aSlice {
   createA2aTask: (task: {
     title: string;
     from: { workspaceId: string; name: string };
-    to: { workspaceId: string; name: string };
+    // Optional pane-level target (Part A). Passed through verbatim into
+    // WmuxTaskMetadata.to so a reply can re-resolve the addressed pane.
+    to: { workspaceId: string; name: string; paneId?: string; surfaceId?: string };
     history: Message[];
     artifacts: Artifact[];
   }) => string;

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -57,6 +57,16 @@ export interface PaneSlice {
   // agent resumes / the PTY exits (PTYBridge broadcasts running/idle).
   surfaceAgentStatus: Record<string, AgentStatus>;
   setSurfaceAgentStatus: (ptyId: string, status: AgentStatus | null) => void;
+  // Part A — per-surface agent IDENTITY keyed by ptyId. Distinct from
+  // surfaceAgentStatus (attention-only, clears on idle): this retains the
+  // detected agent name + last status for the life of the PTY so a2a_discover /
+  // surface_list / pane_list can label each pane individually — one workspace
+  // can host >1 agent (gaps 1/3/8). Populated from METADATA_UPDATE in
+  // useNotificationListener; cleared when the owning surface/pane closes.
+  // Transient — never persisted (buildSessionData allowlist excludes it).
+  surfaceAgent: Record<string, { name: string; status: AgentStatus }>;
+  setSurfaceAgent: (ptyId: string, name: string | undefined, status: AgentStatus | undefined) => void;
+  clearSurfaceAgent: (ptyId: string) => void;
   // X1: per-surface listening ports keyed by ptyId. Main emits ports per PTY
   // (PID-tree scoped); the workspace-level sidebar value is the UNION over
   // the workspace's surfaces, computed at write time in
@@ -137,6 +147,28 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
     } else {
       delete state.surfaceAgentStatus[ptyId];
     }
+  }),
+
+  surfaceAgent: {},
+
+  setSurfaceAgent: (ptyId, name, status) => set((state: StoreState) => {
+    if (!ptyId) return;
+    const existing = state.surfaceAgent[ptyId];
+    // Never overwrite a known agent name with an empty one. PTYBridge's
+    // ActivityMonitor 'running' broadcasts carry agentName = getLastAgent() ??
+    // '' which is '' until a gate matches; a status-only update must keep the
+    // already-detected name. If no name is known yet, there is nothing to stamp.
+    const resolvedName = name && name.length > 0 ? name : existing?.name;
+    if (!resolvedName) return;
+    state.surfaceAgent[ptyId] = {
+      name: resolvedName,
+      status: status ?? existing?.status ?? 'running',
+    };
+  }),
+
+  clearSurfaceAgent: (ptyId) => set((state: StoreState) => {
+    if (!ptyId) return;
+    delete state.surfaceAgent[ptyId];
   }),
 
   surfacePorts: {},
@@ -263,6 +295,15 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
 
       const idx = parent.children.findIndex((c) => c.id === paneId);
       if (idx === -1) return;
+
+      // Part A: drop per-surface agent identity for every surface under the
+      // closing subtree (leaf or branch) so the surfaceAgent map doesn't leak
+      // entries for PTYs that no longer have a surface.
+      for (const leaf of getLeafPanes(parent.children[idx])) {
+        for (const s of leaf.surfaces) {
+          if (s.ptyId) delete state.surfaceAgent[s.ptyId];
+        }
+      }
 
       const previousActiveId = ws.activePaneId;
       parent.children.splice(idx, 1);

--- a/src/renderer/stores/slices/surfaceSlice.ts
+++ b/src/renderer/stores/slices/surfaceSlice.ts
@@ -119,6 +119,13 @@ export const createSurfaceSlice: StateCreator<StoreState, [['zustand/immer', nev
     const idx = pane.surfaces.findIndex((s) => s.id === surfaceId);
     if (idx === -1) return;
 
+    // Part A: drop per-surface agent identity so the surfaceAgent map doesn't
+    // retain a label for a PTY that no longer has a surface. (surfaceAgent is
+    // owned by paneSlice; guard the cross-slice access so an isolated test store
+    // composed without paneSlice doesn't trip on an undefined map.)
+    const closedPtyId = pane.surfaces[idx].ptyId;
+    if (closedPtyId && state.surfaceAgent) delete state.surfaceAgent[closedPtyId];
+
     pane.surfaces.splice(idx, 1);
     if (pane.activeSurfaceId === surfaceId) {
       pane.activeSurfaceId = pane.surfaces[Math.min(idx, pane.surfaces.length - 1)]?.id || '';

--- a/src/shared/__tests__/configIO.test.ts
+++ b/src/shared/__tests__/configIO.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseConfig,
+  getMcpServerScript,
+  getMcpServerEntry,
+  isWmuxOwnedEntry,
+  upsertMcpServer,
+  removeMcpServers,
+  ConfigParseError,
+} from '../configIO';
+
+// ── TOML (Codex) — surgical block, must preserve every other byte ────────────
+
+// A realistic Codex config: a leading comment, a Windows-path literal-key table
+// (the exact shape that a smol-toml round-trip corrupts), and a nested table.
+const CODEX_CONFIG = `# user's hand-written config — must survive
+model = "gpt-5.5"
+
+[projects.'d:\\wmux']
+trust_level = "trusted"
+
+[projects.'c:\\users\\rizz']
+trust_level = "trusted"
+
+[tui.model_availability_nux]
+"gpt-5.5" = 4
+`;
+
+describe('configIO — TOML surgical write', () => {
+  it('appends [mcp_servers.wmux] at EOF and preserves all foreign bytes', () => {
+    const out = upsertMcpServer(CODEX_CONFIG, 'toml', 'wmux', 'C:\\wmux\\index.js');
+    // Every original line survives verbatim (comments, ordering, backslash keys).
+    expect(out).toContain(`# user's hand-written config — must survive`);
+    expect(out).toContain(`[projects.'d:\\wmux']`);
+    expect(out).toContain(`[projects.'c:\\users\\rizz']`);
+    expect(out).toContain(`[tui.model_availability_nux]`);
+    // New block appended in canonical Codex shape.
+    expect(out).toContain('[mcp_servers.wmux]');
+    expect(out).toContain('command = "node"');
+    // The Windows backslash path round-trips correctly through parse.
+    const parsed = parseConfig(out, 'toml');
+    expect(getMcpServerScript(parsed, 'toml', 'wmux')).toBe('C:\\wmux\\index.js');
+    // Foreign backslash project keys are NOT corrupted.
+    expect((parsed.projects as Record<string, unknown>)['d:\\wmux']).toBeTruthy();
+    expect((parsed.projects as Record<string, unknown>)['c:\\users\\rizz']).toBeTruthy();
+  });
+
+  it('is idempotent: re-upserting the same path is a no-op on re-parse', () => {
+    const once = upsertMcpServer(CODEX_CONFIG, 'toml', 'wmux', 'C:\\wmux\\index.js');
+    const twice = upsertMcpServer(once, 'toml', 'wmux', 'C:\\wmux\\index.js');
+    expect(twice).toBe(once);
+  });
+
+  it('replaces an existing block (incl. child sub-tables) on path change', () => {
+    const withEnv = `[mcp_servers.wmux]
+command = "node"
+args = ["C:\\\\old\\\\index.js"]
+
+[mcp_servers.wmux.env]
+FOO = "bar"
+
+[other]
+keep = true
+`;
+    const out = upsertMcpServer(withEnv, 'toml', 'wmux', 'C:\\new\\index.js');
+    const parsed = parseConfig(out, 'toml');
+    expect(getMcpServerScript(parsed, 'toml', 'wmux')).toBe('C:\\new\\index.js');
+    // The stale child env sub-table is gone (replaced as part of the block)…
+    expect(out).not.toContain('FOO = "bar"');
+    // …but the unrelated [other] table is preserved.
+    expect((parsed.other as Record<string, unknown>).keep).toBe(true);
+  });
+
+  it('removes only the wmux blocks, leaving foreign tables intact', () => {
+    const seeded = upsertMcpServer(
+      upsertMcpServer(CODEX_CONFIG, 'toml', 'wmux', 'C:\\w\\i.js'),
+      'toml',
+      'wmux-a2a',
+      'C:\\w\\a.js',
+    );
+    const removed = removeMcpServers(seeded, 'toml', ['wmux', 'wmux-a2a']);
+    const parsed = parseConfig(removed, 'toml');
+    expect(getMcpServerScript(parsed, 'toml', 'wmux')).toBeNull();
+    expect(getMcpServerScript(parsed, 'toml', 'wmux-a2a')).toBeNull();
+    expect(parsed.model).toBe('gpt-5.5');
+    expect((parsed.projects as Record<string, unknown>)['d:\\wmux']).toBeTruthy();
+    expect((parsed.tui as Record<string, unknown>).model_availability_nux).toBeTruthy();
+  });
+
+  it('preserves CRLF line endings', () => {
+    const crlf = CODEX_CONFIG.replace(/\n/g, '\r\n');
+    const out = upsertMcpServer(crlf, 'toml', 'wmux', 'C:\\w\\i.js');
+    expect(out).toContain('\r\n');
+    expect(out).not.toMatch(/[^\r]\n/); // no lone LF
+    expect(getMcpServerScript(parseConfig(out, 'toml'), 'toml', 'wmux')).toBe('C:\\w\\i.js');
+  });
+
+  it('handles a quoted/dashed key (wmux-a2a) and an empty file', () => {
+    const out = upsertMcpServer('', 'toml', 'wmux-a2a', 'C:\\w\\a.js');
+    expect(out).toContain('[mcp_servers.wmux-a2a]');
+    expect(getMcpServerScript(parseConfig(out, 'toml'), 'toml', 'wmux-a2a')).toBe('C:\\w\\a.js');
+  });
+
+  it('throws ConfigParseError on malformed TOML (never clobbers)', () => {
+    expect(() => upsertMcpServer('this = = broken', 'toml', 'wmux', 'x')).toThrow(ConfigParseError);
+  });
+
+  it('does NOT remove a foreign array-of-tables [[mcp_servers.wmux]] (P2: bracket match)', () => {
+    const arr = `[[mcp_servers.wmux]]\ncommand = "other"\nargs = ["x"]\n`;
+    // removeMcpServers must leave the array-of-tables construct untouched.
+    expect(removeMcpServers(arr, 'toml', ['wmux'])).toBe(arr);
+  });
+
+  it('recognizes a header with a trailing inline comment (P2)', () => {
+    const withComment = `[mcp_servers.wmux] # wmux server\ncommand = "node"\nargs = ["/old.js"]\n\n[other]\nx = 1\n`;
+    const out = upsertMcpServer(withComment, 'toml', 'wmux', '/new.js');
+    // Replaced in place (not duplicated) → still parses, path updated, [other] kept.
+    const parsed = parseConfig(out, 'toml');
+    expect(getMcpServerScript(parsed, 'toml', 'wmux')).toBe('/new.js');
+    expect((parsed.other as Record<string, unknown>).x).toBe(1);
+    expect(removeMcpServers(out, 'toml', ['wmux'])).not.toContain('[mcp_servers.wmux]');
+  });
+});
+
+// ── JSON (Claude / Gemini) ───────────────────────────────────────────────────
+
+describe('configIO — JSON write', () => {
+  const CLAUDE = JSON.stringify({
+    mcpServers: { foreign: { command: 'x', args: ['y'] } },
+    otherTopLevel: 42,
+  });
+
+  it('upserts wmux while preserving foreign servers and top-level keys', () => {
+    const out = upsertMcpServer(CLAUDE, 'json', 'wmux', '/abs/index.js');
+    const parsed = parseConfig(out, 'json');
+    expect(getMcpServerScript(parsed, 'json', 'wmux')).toBe('/abs/index.js');
+    expect((parsed.mcpServers as Record<string, unknown>).foreign).toBeTruthy();
+    expect(parsed.otherTopLevel).toBe(42);
+  });
+
+  it('removes wmux keys and drops empty mcpServers, preserving foreign', () => {
+    const seeded = upsertMcpServer(CLAUDE, 'json', 'wmux', '/abs/index.js');
+    const removed = removeMcpServers(seeded, 'json', ['wmux']);
+    const parsed = parseConfig(removed, 'json');
+    expect(getMcpServerScript(parsed, 'json', 'wmux')).toBeNull();
+    expect((parsed.mcpServers as Record<string, unknown>).foreign).toBeTruthy();
+  });
+
+  it('creates from empty and round-trips through 2-space JSON', () => {
+    const out = upsertMcpServer('', 'json', 'wmux', '/abs/index.js');
+    expect(out).toContain('  "mcpServers"');
+    expect(getMcpServerScript(parseConfig(out, 'json'), 'json', 'wmux')).toBe('/abs/index.js');
+  });
+
+  it('strips __proto__ pollution on parse', () => {
+    const malicious = '{"__proto__":{"polluted":true},"mcpServers":{}}';
+    const parsed = parseConfig(malicious, 'json');
+    expect((parsed as Record<string, unknown>).__proto__).not.toHaveProperty('polluted');
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('throws ConfigParseError on malformed JSON', () => {
+    expect(() => upsertMcpServer('{ not json', 'json', 'wmux', 'x')).toThrow(ConfigParseError);
+  });
+});
+
+// ── read helpers ─────────────────────────────────────────────────────────────
+
+describe('configIO — read helpers', () => {
+  it('isWmuxOwnedEntry recognizes node-launched entries and rejects foreign', () => {
+    expect(isWmuxOwnedEntry({ command: 'node', args: ['/x.js'] })).toBe(true);
+    expect(isWmuxOwnedEntry({ command: 'python', args: ['/x.py'] })).toBe(false);
+    expect(isWmuxOwnedEntry({ command: 'node', args: [] })).toBe(false);
+    expect(isWmuxOwnedEntry(null)).toBe(false);
+  });
+
+  it('getMcpServerEntry returns null for absent / malformed', () => {
+    expect(getMcpServerEntry({}, 'toml', 'wmux')).toBeNull();
+    expect(getMcpServerEntry({ mcp_servers: { wmux: 'nope' } }, 'toml', 'wmux')).toBeNull();
+  });
+});

--- a/src/shared/__tests__/configIO.test.ts
+++ b/src/shared/__tests__/configIO.test.ts
@@ -111,6 +111,11 @@ keep = true
     expect(removeMcpServers(arr, 'toml', ['wmux'])).toBe(arr);
   });
 
+  it('throws when the surgical edit would produce invalid TOML (inline-table → duplicate)', () => {
+    const inline = `[mcp_servers]\nwmux = { command = "node", args = ["/old.js"] }\n`;
+    expect(() => upsertMcpServer(inline, 'toml', 'wmux', '/new.js')).toThrow(ConfigParseError);
+  });
+
   it('recognizes a header with a trailing inline comment (P2)', () => {
     const withComment = `[mcp_servers.wmux] # wmux server\ncommand = "node"\nargs = ["/old.js"]\n\n[other]\nx = 1\n`;
     const out = upsertMcpServer(withComment, 'toml', 'wmux', '/new.js');
@@ -161,6 +166,12 @@ describe('configIO — JSON write', () => {
 
   it('throws ConfigParseError on malformed JSON', () => {
     expect(() => upsertMcpServer('{ not json', 'json', 'wmux', 'x')).toThrow(ConfigParseError);
+  });
+
+  it('rejects a non-object root and an array mcpServers (parseConfig hardening)', () => {
+    expect(() => parseConfig('[1,2,3]', 'json')).toThrow(ConfigParseError);
+    expect(() => parseConfig('null', 'json')).toThrow(ConfigParseError);
+    expect(() => parseConfig('{"mcpServers":[1,2]}', 'json')).toThrow(ConfigParseError);
   });
 });
 

--- a/src/shared/__tests__/mcpRegistration.test.ts
+++ b/src/shared/__tests__/mcpRegistration.test.ts
@@ -1,0 +1,172 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { MCP_TARGETS, getMcpTarget } from '../mcpTargets';
+import {
+  readTargetStatus,
+  registerTarget,
+  unregisterTarget,
+} from '../mcpRegistration';
+
+let home = '';
+const claudeTarget = getMcpTarget('claude')!;
+const codexTarget = getMcpTarget('codex')!;
+const geminiTarget = getMcpTarget('gemini')!;
+const SCRIPTS = { wmux: 'C:\\app\\mcp-bundle\\index.js', a2a: 'C:\\app\\a2a-bundle\\index.js' };
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-mcpreg-'));
+});
+afterEach(() => {
+  try { fs.rmSync(home, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+describe('registerTarget — Claude (json, createIfMissing)', () => {
+  it('creates ~/.claude.json and writes both servers', () => {
+    const r = registerTarget(claudeTarget, home, SCRIPTS);
+    expect(r.skipped).toBeNull();
+    expect(r.wrote.sort()).toEqual(['wmux', 'wmux-a2a']);
+    const status = readTargetStatus(claudeTarget, home);
+    expect(status.wmux).toEqual({ registered: true, path: SCRIPTS.wmux });
+    expect(status.wmuxA2a).toEqual({ registered: true, path: SCRIPTS.a2a });
+  });
+
+  it('is idempotent — re-register writes nothing the second time', () => {
+    registerTarget(claudeTarget, home, SCRIPTS);
+    const r2 = registerTarget(claudeTarget, home, SCRIPTS);
+    expect(r2.wrote).toEqual([]);
+  });
+
+  it('updates a stale path written by a prior session', () => {
+    registerTarget(claudeTarget, home, { wmux: 'C:\\old\\index.js', a2a: null });
+    const r = registerTarget(claudeTarget, home, SCRIPTS);
+    expect(r.wrote).toContain('wmux');
+    expect(readTargetStatus(claudeTarget, home).wmux.path).toBe(SCRIPTS.wmux);
+  });
+
+  it('leaves a FOREIGN (non-node) wmux entry untouched', () => {
+    const p = claudeTarget.configPath(home);
+    fs.writeFileSync(p, JSON.stringify({ mcpServers: { wmux: { command: 'python', args: ['/x.py'] } } }), 'utf8');
+    const r = registerTarget(claudeTarget, home, SCRIPTS);
+    expect(r.foreign).toContain('wmux');
+    const after = JSON.parse(fs.readFileSync(p, 'utf8')) as { mcpServers: Record<string, { command: string }> };
+    expect(after.mcpServers.wmux.command).toBe('python');
+    // wmux-a2a (absent) is still written.
+    expect(after.mcpServers['wmux-a2a']).toBeTruthy();
+  });
+});
+
+describe('registerTarget — Codex (toml, only if installed)', () => {
+  it('SKIPS when ~/.codex/config.toml does not exist (never created)', () => {
+    const r = registerTarget(codexTarget, home, SCRIPTS);
+    expect(r.skipped).toBe('absent');
+    expect(fs.existsSync(codexTarget.configPath(home))).toBe(false);
+  });
+
+  it('appends to an existing config.toml, preserving foreign tables/comments byte-stable', () => {
+    const p = codexTarget.configPath(home);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    const original = `# hand-written\nmodel = "gpt-5.5"\n\n[projects.'d:\\wmux']\ntrust_level = "trusted"\n`;
+    fs.writeFileSync(p, original, 'utf8');
+
+    const r = registerTarget(codexTarget, home, SCRIPTS);
+    expect(r.wrote.sort()).toEqual(['wmux', 'wmux-a2a']);
+
+    const after = fs.readFileSync(p, 'utf8');
+    expect(after).toContain('# hand-written');
+    expect(after).toContain(`[projects.'d:\\wmux']`); // backslash key NOT corrupted
+    expect(after).toContain('[mcp_servers.wmux]');
+
+    const status = readTargetStatus(codexTarget, home);
+    expect(status.wmux).toEqual({ registered: true, path: SCRIPTS.wmux });
+    expect(status.wmuxA2a).toEqual({ registered: true, path: SCRIPTS.a2a });
+  });
+
+  it('leaves a malformed config.toml untouched (never clobbers)', () => {
+    const p = codexTarget.configPath(home);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, 'this = = broken', 'utf8');
+    const r = registerTarget(codexTarget, home, SCRIPTS);
+    expect(r.skipped).toBe('malformed');
+    expect(fs.readFileSync(p, 'utf8')).toBe('this = = broken');
+  });
+
+  // Regression (independent review P1): an inline-table form under a
+  // [mcp_servers] parent can't be surgically replaced by the line-based editor.
+  // The output-validation guard must abort rather than append a duplicate table
+  // that makes the file unparseable.
+  it('does NOT corrupt an inline-table mcp_servers.wmux entry (aborts the write)', () => {
+    const p = codexTarget.configPath(home);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    const inline = `[mcp_servers]\nwmux = { command = "node", args = ["C:\\\\old\\\\i.js"] }\n`;
+    fs.writeFileSync(p, inline, 'utf8');
+    const r = registerTarget(codexTarget, home, SCRIPTS);
+    // Left untouched (safe), and the file still parses (no duplicate table).
+    expect(r.wrote).toEqual([]);
+    expect(fs.readFileSync(p, 'utf8')).toBe(inline);
+    expect(() => readTargetStatus(codexTarget, home)).not.toThrow();
+  });
+});
+
+describe('registerTarget — Gemini (unverified, never created)', () => {
+  it('SKIPS when settings.json does not exist', () => {
+    const r = registerTarget(geminiTarget, home, SCRIPTS);
+    expect(r.skipped).toBe('absent');
+    expect(fs.existsSync(geminiTarget.configPath(home))).toBe(false);
+  });
+
+  it('writes into an existing settings.json (mcpServers, json)', () => {
+    const p = geminiTarget.configPath(home);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, JSON.stringify({ theme: 'dark' }), 'utf8');
+    const r = registerTarget(geminiTarget, home, SCRIPTS);
+    expect(r.wrote.sort()).toEqual(['wmux', 'wmux-a2a']);
+    const after = JSON.parse(fs.readFileSync(p, 'utf8')) as { theme: string; mcpServers: Record<string, unknown> };
+    expect(after.theme).toBe('dark');
+    expect(after.mcpServers.wmux).toBeTruthy();
+  });
+});
+
+describe('unregisterTarget', () => {
+  it('removes only wmux-owned keys from Codex TOML, preserving foreign data', () => {
+    const p = codexTarget.configPath(home);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, `[tui]\ntheme = "dark"\n`, 'utf8');
+    registerTarget(codexTarget, home, SCRIPTS);
+
+    const r = unregisterTarget(codexTarget, home);
+    expect(r.removed.sort()).toEqual(['wmux', 'wmux-a2a']);
+    const after = fs.readFileSync(p, 'utf8');
+    expect(after).not.toContain('[mcp_servers.wmux]');
+    expect(after).toContain('[tui]');
+  });
+
+  it('is a no-op when config is absent', () => {
+    const r = unregisterTarget(codexTarget, home);
+    expect(r.configExisted).toBe(false);
+    expect(r.removed).toEqual([]);
+  });
+
+  // Codex review: an inline-table entry the line-based editor can't target must
+  // not report a removal that didn't happen.
+  it('reports removed=[] when the entry is an un-targetable inline table (no false removal)', () => {
+    const p = codexTarget.configPath(home);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    const inline = `[mcp_servers]\nwmux = { command = "node", args = ["/x.js"] }\n`;
+    fs.writeFileSync(p, inline, 'utf8');
+    const r = unregisterTarget(codexTarget, home);
+    expect(r.removed).toEqual([]);
+    expect(fs.readFileSync(p, 'utf8')).toBe(inline); // untouched
+  });
+});
+
+describe('MCP_TARGETS registry', () => {
+  it('has the expected ids, formats, and create policy', () => {
+    expect(MCP_TARGETS.map((t) => t.id)).toEqual(['claude', 'codex', 'gemini']);
+    expect(getMcpTarget('claude')!.createIfMissing).toBe(true);
+    expect(getMcpTarget('codex')!.createIfMissing).toBe(false);
+    expect(getMcpTarget('codex')!.format).toBe('toml');
+    expect(getMcpTarget('gemini')!.createIfMissing).toBe(false);
+  });
+});

--- a/src/shared/__tests__/mcpRegistration.test.ts
+++ b/src/shared/__tests__/mcpRegistration.test.ts
@@ -159,6 +159,23 @@ describe('unregisterTarget', () => {
     expect(r.removed).toEqual([]);
     expect(fs.readFileSync(p, 'utf8')).toBe(inline); // untouched
   });
+
+  // Codex final review: a MIXED config (un-targetable inline wmux + removable
+  // header-form wmux-a2a) must report ONLY the key actually removed.
+  it('reports only the actually-removed key in a mixed inline/header config', () => {
+    const p = codexTarget.configPath(home);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(
+      p,
+      `[mcp_servers]\nwmux = { command = "node", args = ["/x.js"] }\n\n[mcp_servers.wmux-a2a]\ncommand = "node"\nargs = ["/a.js"]\n`,
+      'utf8',
+    );
+    const r = unregisterTarget(codexTarget, home);
+    expect(r.removed).toEqual(['wmux-a2a']); // NOT ['wmux','wmux-a2a']
+    const after = fs.readFileSync(p, 'utf8');
+    expect(after).toContain('wmux = { command = "node"'); // inline wmux survives
+    expect(after).not.toContain('[mcp_servers.wmux-a2a]');
+  });
 });
 
 describe('MCP_TARGETS registry', () => {

--- a/src/shared/configIO.ts
+++ b/src/shared/configIO.ts
@@ -1,0 +1,300 @@
+// Format-aware MCP-config read/write, shared by McpRegistrar (main) and the
+// `wmux mcp` CLI so both registration paths behave identically.
+//
+// READ  — parse the file to inspect the wmux/wmux-a2a entries (status,
+//          idempotency, foreign-key detection). TOML is parsed with smol-toml;
+//          JSON with a proto-pollution-guarded JSON.parse.
+// WRITE — JSON is object-merge + 2-space re-stringify (JSON has no comments, so
+//          a round-trip is lossless). TOML is a SURGICAL block edit: only the
+//          `[mcp_servers.<key>]` table (and any child sub-tables) is
+//          appended/replaced/removed as text; every other byte — comments,
+//          ordering, and quoted Windows-path keys like `[projects.'d:\wmux']` —
+//          is preserved untouched. (A smol-toml round-trip was rejected: its
+//          stringify silently drops backslashes in literal-string keys,
+//          corrupting Codex's project-trust tables. `codex mcp add` itself does
+//          a surgical append; this matches it.)
+//
+//   ┌─ upsertMcpServer ────────────────────────────────────────────────┐
+//   │ json:  parse → mcpServers[key] = {command:'node',args:[script]}   │
+//   │        → JSON.stringify(2-space)                                   │
+//   │ toml:  find [mcp_servers.<key>] block → replace, else append       │
+//   └────────────────────────────────────────────────────────────────────┘
+
+import { parse as parseTomlText } from 'smol-toml';
+import type { McpConfigFormat } from './mcpTargets';
+
+/** Thrown when a config file is present but unparseable. Callers choose: abort
+ *  a write (never clobber a file we can't understand) vs. report "not
+ *  registered" for a read. */
+export class ConfigParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConfigParseError';
+  }
+}
+
+export interface McpServerEntry {
+  command: string | null;
+  args: string[];
+}
+
+// The wmux MCP entry shape written into every target. `node` (not the Electron
+// execPath) + the absolute bundle script. No `env` field — Claude Code may
+// replace rather than merge the subprocess environment.
+export function wmuxMcpEntry(scriptPath: string): McpServerEntry & { command: string } {
+  return { command: 'node', args: [scriptPath] };
+}
+
+/** The container key that holds MCP server definitions for a given format.
+ *  Codex (toml) uses `mcp_servers`; Claude/Gemini (json) use `mcpServers`. */
+function serversKey(format: McpConfigFormat): 'mcp_servers' | 'mcpServers' {
+  return format === 'toml' ? 'mcp_servers' : 'mcpServers';
+}
+
+/**
+ * Parse a config file's text into a plain object. Empty/whitespace input is a
+ * fresh file → `{}`. Throws {@link ConfigParseError} on malformed input.
+ */
+export function parseConfig(text: string, format: McpConfigFormat): Record<string, unknown> {
+  if (!text.trim()) return {};
+  try {
+    if (format === 'json') {
+      return JSON.parse(text, (key, value) =>
+        key === '__proto__' || key === 'constructor' || key === 'prototype' ? undefined : value,
+      ) as Record<string, unknown>;
+    }
+    return parseTomlText(text) as Record<string, unknown>;
+  } catch (e) {
+    throw new ConfigParseError(e instanceof Error ? e.message : String(e));
+  }
+}
+
+/** Read a single MCP server entry from already-parsed config, or null. */
+export function getMcpServerEntry(
+  parsed: Record<string, unknown>,
+  format: McpConfigFormat,
+  key: string,
+): McpServerEntry | null {
+  const container = parsed[serversKey(format)];
+  if (!container || typeof container !== 'object') return null;
+  const entry = (container as Record<string, unknown>)[key];
+  if (!entry || typeof entry !== 'object') return null;
+  const command = typeof (entry as { command?: unknown }).command === 'string'
+    ? (entry as { command: string }).command
+    : null;
+  const rawArgs = (entry as { args?: unknown }).args;
+  const args = Array.isArray(rawArgs)
+    ? rawArgs.filter((a): a is string => typeof a === 'string')
+    : [];
+  return { command, args };
+}
+
+/** The script path (first arg) wmux wrote for a server key, or null when the
+ *  key is absent / malformed / foreign-shaped. */
+export function getMcpServerScript(
+  parsed: Record<string, unknown>,
+  format: McpConfigFormat,
+  key: string,
+): string | null {
+  const entry = getMcpServerEntry(parsed, format, key);
+  return entry && entry.args.length > 0 ? entry.args[0] : null;
+}
+
+/** True when an existing entry is wmux-owned: `node <script>`. A foreign entry
+ *  (different command, e.g. a user-authored `[mcp_servers.wmux]` pointing
+ *  elsewhere) returns false so the caller leaves it untouched. */
+export function isWmuxOwnedEntry(entry: McpServerEntry | null): boolean {
+  return !!entry && entry.command === 'node' && entry.args.length >= 1;
+}
+
+// ── JSON writers (object round-trip — lossless, JSON has no comments) ────────
+
+function upsertJson(text: string, key: string, scriptPath: string): string {
+  const config = parseConfig(text, 'json');
+  const servers = (config.mcpServers && typeof config.mcpServers === 'object'
+    ? config.mcpServers
+    : (config.mcpServers = {})) as Record<string, unknown>;
+  servers[key] = wmuxMcpEntry(scriptPath);
+  return JSON.stringify(config, null, 2) + '\n';
+}
+
+function removeJson(text: string, keys: string[]): string {
+  const config = parseConfig(text, 'json');
+  const servers = config.mcpServers;
+  if (!servers || typeof servers !== 'object') return text;
+  let changed = false;
+  for (const key of keys) {
+    if ((servers as Record<string, unknown>)[key] !== undefined) {
+      delete (servers as Record<string, unknown>)[key];
+      changed = true;
+    }
+  }
+  if (!changed) return text;
+  if (Object.keys(servers as Record<string, unknown>).length === 0) delete config.mcpServers;
+  return JSON.stringify(config, null, 2) + '\n';
+}
+
+// ── TOML surgical block writers (preserve every other byte) ──────────────────
+
+function detectEol(text: string): '\r\n' | '\n' {
+  return text.includes('\r\n') ? '\r\n' : '\n';
+}
+
+/** Split a dotted TOML key path (`mcp_servers.'wmux-a2a'.env`) into unquoted
+ *  segments, honoring basic- and literal-string quoting. */
+function splitTomlKeyPath(path: string): string[] {
+  const segs: string[] = [];
+  let i = 0;
+  while (i < path.length) {
+    while (i < path.length && /\s/.test(path[i])) i++;
+    if (i >= path.length) break;
+    let seg = '';
+    const ch = path[i];
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      i++;
+      while (i < path.length && path[i] !== quote) {
+        if (quote === '"' && path[i] === '\\') {
+          // basic-string escape — keep the escaped char literally enough for
+          // segment comparison (paths/keys don't rely on escape semantics here)
+          seg += path[i + 1] ?? '';
+          i += 2;
+        } else {
+          seg += path[i];
+          i++;
+        }
+      }
+      i++; // closing quote
+    } else {
+      while (i < path.length && path[i] !== '.') seg += path[i++];
+      seg = seg.trim();
+    }
+    segs.push(seg);
+    while (i < path.length && /\s/.test(path[i])) i++;
+    if (path[i] === '.') i++;
+  }
+  return segs;
+}
+
+/** Classify a line as the header of our `mcp_servers.<key>` table, a child
+ *  sub-table of it, or neither. Only a STANDARD single-bracket table `[t]` can
+ *  be ours: an array-of-tables `[[t]]` is a different construct, and a mismatched
+ *  `[t]]` / `[[t]` is malformed — both must be treated as "not ours" so we never
+ *  replace/remove foreign array-of-tables. Quoted segments are honored. */
+function classifyTomlHeader(line: string, key: string): 'exact' | 'child' | null {
+  // Trailing inline comment after the close bracket is allowed (`[t] # note`).
+  const m = line.match(/^\s*(\[\[?)\s*([^\]]*?)\s*(\]\]?)\s*(?:#.*)?$/);
+  if (!m) return null;
+  if (m[1] !== '[' || m[3] !== ']') return null; // [[array]] or mismatched → not ours
+  const segs = splitTomlKeyPath(m[2]);
+  if (segs.length < 2 || segs[0] !== 'mcp_servers' || segs[1] !== key) return null;
+  return segs.length === 2 ? 'exact' : 'child';
+}
+
+function isAnyTableHeader(line: string): boolean {
+  return /^\s*\[\[?[^\]]/.test(line);
+}
+
+/** Range [start, end) of lines spanning the `[mcp_servers.<key>]` table and any
+ *  child sub-tables (e.g. `[mcp_servers.<key>.env]`). null when absent. */
+function findTomlBlockRange(lines: string[], key: string): [number, number] | null {
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (classifyTomlHeader(lines[i], key) === 'exact') {
+      start = i;
+      break;
+    }
+  }
+  if (start === -1) return null;
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (isAnyTableHeader(lines[i])) {
+      // a child sub-table stays part of our block; any other table ends it
+      if (classifyTomlHeader(lines[i], key) === 'child') continue;
+      end = i;
+      break;
+    }
+  }
+  // Exclude trailing blank lines from the block so the separator before the
+  // next table (or EOF) is preserved in the surrounding text, not swallowed.
+  while (end > start + 1 && lines[end - 1].trim() === '') end--;
+  return [start, end];
+}
+
+/** Emit a key segment for a TOML header: bare when allowed, else basic-string. */
+function tomlKeySegment(key: string): string {
+  return /^[A-Za-z0-9_-]+$/.test(key) ? key : JSON.stringify(key);
+}
+
+/** The canonical wmux block text (no leading/trailing blank lines). */
+function tomlBlock(key: string, scriptPath: string, eol: string): string {
+  // JSON.stringify yields a valid TOML basic string for the path (escapes \ and
+  // " the same way TOML does), so Windows backslash paths round-trip correctly.
+  return [
+    `[mcp_servers.${tomlKeySegment(key)}]`,
+    `command = "node"`,
+    `args = [${JSON.stringify(scriptPath)}]`,
+  ].join(eol);
+}
+
+function upsertToml(text: string, key: string, scriptPath: string): string {
+  const eol = detectEol(text);
+  const lines = text.split(/\r?\n/);
+  const blockLines = tomlBlock(key, scriptPath, eol).split(eol);
+  const range = findTomlBlockRange(lines, key);
+  let result: string[];
+  if (range) {
+    const [start, end] = range;
+    result = [...lines.slice(0, start), ...blockLines, ...lines.slice(end)];
+  } else {
+    // Append after the existing content with one blank-line separator.
+    const trimmed = [...lines];
+    while (trimmed.length && trimmed[trimmed.length - 1].trim() === '') trimmed.pop();
+    result = trimmed.length ? [...trimmed, '', ...blockLines] : [...blockLines];
+  }
+  // End with exactly one trailing newline (no accumulated blank lines).
+  while (result.length && result[result.length - 1].trim() === '') result.pop();
+  return result.join(eol) + eol;
+}
+
+function removeToml(text: string, keys: string[]): string {
+  const eol = detectEol(text);
+  let lines = text.split(/\r?\n/);
+  let changed = false;
+  for (const key of keys) {
+    const range = findTomlBlockRange(lines, key);
+    if (!range) continue;
+    const [start, end] = range;
+    lines = [...lines.slice(0, start), ...lines.slice(end)];
+    changed = true;
+  }
+  if (!changed) return text;
+  // Collapse 3+ consecutive blank lines left behind, trim trailing blanks.
+  return lines.join(eol).replace(new RegExp(`(?:${eol === '\r\n' ? '\\r\\n' : '\\n'}){3,}`, 'g'), eol + eol).replace(/\s*$/, '') + eol;
+}
+
+// ── Unified text→text API used by McpRegistrar + CLI ─────────────────────────
+
+/** Return new file text with `key` set to the wmux `node <script>` entry.
+ *  Throws ConfigParseError if the existing text is malformed (caller aborts). */
+export function upsertMcpServer(
+  text: string,
+  format: McpConfigFormat,
+  key: string,
+  scriptPath: string,
+): string {
+  // Validate parseability up-front so a malformed file aborts instead of being
+  // clobbered (TOML append would otherwise blindly tack a block onto garbage).
+  parseConfig(text, format);
+  return format === 'json' ? upsertJson(text, key, scriptPath) : upsertToml(text, key, scriptPath);
+}
+
+/** Return new file text with the given wmux keys removed (only those keys). */
+export function removeMcpServers(
+  text: string,
+  format: McpConfigFormat,
+  keys: string[],
+): string {
+  parseConfig(text, format);
+  return format === 'json' ? removeJson(text, keys) : removeToml(text, keys);
+}

--- a/src/shared/configIO.ts
+++ b/src/shared/configIO.ts
@@ -57,16 +57,27 @@ function serversKey(format: McpConfigFormat): 'mcp_servers' | 'mcpServers' {
  */
 export function parseConfig(text: string, format: McpConfigFormat): Record<string, unknown> {
   if (!text.trim()) return {};
+  let parsed: unknown;
   try {
-    if (format === 'json') {
-      return JSON.parse(text, (key, value) =>
-        key === '__proto__' || key === 'constructor' || key === 'prototype' ? undefined : value,
-      ) as Record<string, unknown>;
-    }
-    return parseTomlText(text) as Record<string, unknown>;
+    parsed = format === 'json'
+      ? JSON.parse(text, (key, value) =>
+          key === '__proto__' || key === 'constructor' || key === 'prototype' ? undefined : value)
+      : parseTomlText(text);
   } catch (e) {
     throw new ConfigParseError(e instanceof Error ? e.message : String(e));
   }
+  // The config root must be a plain object/table — a top-level array or scalar
+  // (or `null`) is not a usable config and must not be silently accepted.
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new ConfigParseError('config root is not a table/object');
+  }
+  // If the server container is present it must be a table, not an array — an
+  // array `mcpServers` would corrupt entry lookups / writes.
+  const servers = (parsed as Record<string, unknown>)[serversKey(format)];
+  if (servers !== undefined && (servers === null || typeof servers !== 'object' || Array.isArray(servers))) {
+    throw new ConfigParseError(`"${serversKey(format)}" is not a table/object`);
+  }
+  return parsed as Record<string, unknown>;
 }
 
 /** Read a single MCP server entry from already-parsed config, or null. */
@@ -286,7 +297,13 @@ export function upsertMcpServer(
   // Validate parseability up-front so a malformed file aborts instead of being
   // clobbered (TOML append would otherwise blindly tack a block onto garbage).
   parseConfig(text, format);
-  return format === 'json' ? upsertJson(text, key, scriptPath) : upsertToml(text, key, scriptPath);
+  const out = format === 'json' ? upsertJson(text, key, scriptPath) : upsertToml(text, key, scriptPath);
+  // Never RETURN invalid TOML: the line-based surgical editor can't target an
+  // inline-table entry (`wmux = { ... }` under `[mcp_servers]`) and would append
+  // a duplicate table. Validate the output and throw rather than hand a caller a
+  // string it might persist. (JSON re-stringify is always valid.)
+  if (format === 'toml') parseConfig(out, format);
+  return out;
 }
 
 /** Return new file text with the given wmux keys removed (only those keys). */

--- a/src/shared/mcpRegistration.ts
+++ b/src/shared/mcpRegistration.ts
@@ -1,0 +1,236 @@
+// Shared MCP registration orchestration (fs + configIO), used by BOTH the
+// main-process McpRegistrar and the standalone `wmux mcp` CLI so the two
+// registration paths stay byte-identical. Pure Node fs — no Electron — so it
+// imports cleanly into the CLI bundle.
+//
+// Per-target rules (see mcpTargets.ts / McpRegistrar.ts header):
+//   - uninstalled agent (config absent + !createIfMissing) → skipped, never created
+//   - malformed config → left untouched (never clobbered)
+//   - foreign entry (a `wmux` key whose command !== node) → left untouched
+//   - TOML writes are surgical (configIO) so comments / order / quoted keys survive
+//   - all writes atomic (tmp + rename)
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  MCP_TARGETS,
+  WMUX_SERVER_KEY,
+  WMUX_A2A_SERVER_KEY,
+  WMUX_SERVER_KEYS,
+  type McpTarget,
+  type McpConfigFormat,
+} from './mcpTargets';
+import {
+  parseConfig,
+  getMcpServerEntry,
+  getMcpServerScript,
+  isWmuxOwnedEntry,
+  upsertMcpServer,
+  removeMcpServers,
+} from './configIO';
+
+export interface ServerRegState {
+  registered: boolean;
+  path: string | null;
+}
+
+export interface TargetRegStatus {
+  id: string;
+  displayName: string;
+  format: McpConfigFormat;
+  configPath: string;
+  configExists: boolean;
+  configModified: Date | null;
+  verified: boolean;
+  wmux: ServerRegState;
+  wmuxA2a: ServerRegState;
+}
+
+/** Atomic write (tmp + rename), creating the parent dir if needed. */
+export function writeFileAtomic(filePath: string, text: string): void {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const tmp = filePath + '.tmp';
+  fs.writeFileSync(tmp, text, 'utf8');
+  fs.renameSync(tmp, filePath);
+}
+
+/** Pure read of one target's registration state. Never creates / throws. */
+export function readTargetStatus(target: McpTarget, home: string): TargetRegStatus {
+  const configPath = target.configPath(home);
+  let configExists = false;
+  let configModified: Date | null = null;
+  try {
+    const stat = fs.statSync(configPath);
+    configExists = stat.isFile();
+    configModified = configExists ? stat.mtime : null;
+  } catch {
+    configExists = false;
+  }
+
+  let wmuxPath: string | null = null;
+  let a2aPath: string | null = null;
+  if (configExists) {
+    try {
+      const parsed = parseConfig(fs.readFileSync(configPath, 'utf8'), target.format);
+      wmuxPath = getMcpServerScript(parsed, target.format, WMUX_SERVER_KEY);
+      a2aPath = getMcpServerScript(parsed, target.format, WMUX_A2A_SERVER_KEY);
+    } catch {
+      // corrupted → not registered
+    }
+  }
+
+  return {
+    id: target.id,
+    displayName: target.displayName,
+    format: target.format,
+    configPath,
+    configExists,
+    configModified,
+    verified: target.verified,
+    wmux: { registered: wmuxPath !== null, path: wmuxPath },
+    wmuxA2a: { registered: a2aPath !== null, path: a2aPath },
+  };
+}
+
+export function readAllTargetStatuses(home: string): TargetRegStatus[] {
+  return MCP_TARGETS.map((t) => readTargetStatus(t, home));
+}
+
+export interface RegisterTargetResult {
+  configPath: string;
+  /** 'absent' = uninstalled (skipped, not created); 'malformed' = corrupt (untouched). */
+  skipped: 'absent' | 'malformed' | null;
+  /** keys written/updated this call. */
+  wrote: string[];
+  /** keys left untouched because a foreign (non-node) entry occupies them. */
+  foreign: string[];
+}
+
+/**
+ * Ensure `wmux` / `wmux-a2a` point at the given scripts in one target's config.
+ * `ownedKeys` (optional) tracks keys written this session so a key wmux already
+ * owns is updated even if its on-disk shape looks foreign-adjacent.
+ */
+export function registerTarget(
+  target: McpTarget,
+  home: string,
+  scripts: { wmux: string | null; a2a: string | null },
+  ownedKeys?: Set<string>,
+): RegisterTargetResult {
+  const configPath = target.configPath(home);
+  const exists = fs.existsSync(configPath);
+  if (!exists && !target.createIfMissing) {
+    return { configPath, skipped: 'absent', wrote: [], foreign: [] };
+  }
+
+  let text = '';
+  if (exists) {
+    try {
+      text = fs.readFileSync(configPath, 'utf8');
+    } catch {
+      return { configPath, skipped: 'malformed', wrote: [], foreign: [] };
+    }
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parseConfig(text, target.format);
+  } catch {
+    return { configPath, skipped: 'malformed', wrote: [], foreign: [] };
+  }
+
+  let newText = text;
+  const wrote: string[] = [];
+  const foreign: string[] = [];
+  const entries: Array<[string, string | null]> = [
+    [WMUX_SERVER_KEY, scripts.wmux],
+    [WMUX_A2A_SERVER_KEY, scripts.a2a],
+  ];
+  try {
+    for (const [key, script] of entries) {
+      if (!script) continue;
+      const existing = getMcpServerEntry(parsed, target.format, key);
+      if (existing && !ownedKeys?.has(key)) {
+        if (!isWmuxOwnedEntry(existing)) {
+          foreign.push(key);
+          continue;
+        }
+        if (existing.args[0] === script) {
+          ownedKeys?.add(key); // already up to date
+          continue;
+        }
+        // ours but stale path → fall through to update
+      }
+      // upsert validates its INPUT, so a previous iteration that produced an
+      // unparseable intermediate (e.g. an inline-table entry the line-based
+      // editor duplicated) throws here and is caught below.
+      newText = upsertMcpServer(newText, target.format, key, script);
+      wrote.push(key);
+      ownedKeys?.add(key);
+    }
+
+    // Legacy cleanup only applies to Claude's JSON (old wmux-playwright keys).
+    if (target.id === 'claude') {
+      newText = removeMcpServers(newText, 'json', ['wmux-playwright', 'wmux-devtools']);
+    }
+
+    if (newText !== text) {
+      // Final guard: the OUTPUT must parse before writing. The surgical TOML
+      // editor is line-based, so an existing entry in a form it can't target
+      // (an inline table `wmux = { ... }` under a `[mcp_servers]` parent) would
+      // append a duplicate table → unparseable. Never write a broken config.
+      parseConfig(newText, target.format);
+      writeFileAtomic(configPath, newText);
+    }
+  } catch {
+    return { configPath, skipped: 'malformed', wrote: [], foreign };
+  }
+  return { configPath, skipped: null, wrote, foreign };
+}
+
+export interface UnregisterTargetResult {
+  configPath: string;
+  removed: string[];
+  configExisted: boolean;
+}
+
+/** Remove only wmux-owned `wmux` / `wmux-a2a` keys from one target's config. */
+export function unregisterTarget(target: McpTarget, home: string): UnregisterTargetResult {
+  const configPath = target.configPath(home);
+  if (!fs.existsSync(configPath)) return { configPath, removed: [], configExisted: false };
+
+  let text: string;
+  try {
+    text = fs.readFileSync(configPath, 'utf8');
+  } catch {
+    return { configPath, removed: [], configExisted: true };
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parseConfig(text, target.format);
+  } catch {
+    return { configPath, removed: [], configExisted: true };
+  }
+
+  const toRemove = WMUX_SERVER_KEYS.filter((k) =>
+    isWmuxOwnedEntry(getMcpServerEntry(parsed, target.format, k)),
+  );
+  if (toRemove.length === 0) return { configPath, removed: [], configExisted: true };
+
+  const newText = removeMcpServers(text, target.format, toRemove);
+  // No textual change → nothing was actually removed. This happens when the
+  // entry exists only in a form the line-based editor can't target (e.g. an
+  // inline table `wmux = { ... }` under a `[mcp_servers]` parent). Report an
+  // honest empty `removed` rather than claiming a removal that didn't happen.
+  if (newText === text) return { configPath, removed: [], configExisted: true };
+  // Output-validation guard: never write a config that no longer parses.
+  try {
+    parseConfig(newText, target.format);
+  } catch {
+    return { configPath, removed: [], configExisted: true };
+  }
+  writeFileAtomic(configPath, newText);
+  return { configPath, removed: toRemove, configExisted: true };
+}

--- a/src/shared/mcpRegistration.ts
+++ b/src/shared/mcpRegistration.ts
@@ -156,6 +156,11 @@ export function registerTarget(
     [WMUX_SERVER_KEY, scripts.wmux],
     [WMUX_A2A_SERVER_KEY, scripts.a2a],
   ];
+  // Build + validate the new text. Parse/edit failures mean the config is in a
+  // shape we can't safely edit → 'malformed' (graceful skip, never clobber).
+  // The actual WRITE is intentionally OUTSIDE this catch so a permission/rename
+  // failure propagates to the caller (McpRegistrar surfaces the macOS hint; the
+  // CLI exits non-zero) instead of being misreported as "malformed".
   try {
     for (const [key, script] of entries) {
       if (!script) continue;
@@ -171,9 +176,9 @@ export function registerTarget(
         }
         // ours but stale path → fall through to update
       }
-      // upsert validates its INPUT, so a previous iteration that produced an
-      // unparseable intermediate (e.g. an inline-table entry the line-based
-      // editor duplicated) throws here and is caught below.
+      // upsert validates its INPUT and OUTPUT, so a previous iteration that
+      // produced an unparseable intermediate (e.g. an inline-table entry the
+      // line-based editor duplicated) throws here and is caught below.
       newText = upsertMcpServer(newText, target.format, key, script);
       wrote.push(key);
       ownedKeys?.add(key);
@@ -183,18 +188,11 @@ export function registerTarget(
     if (target.id === 'claude') {
       newText = removeMcpServers(newText, 'json', ['wmux-playwright', 'wmux-devtools']);
     }
-
-    if (newText !== text) {
-      // Final guard: the OUTPUT must parse before writing. The surgical TOML
-      // editor is line-based, so an existing entry in a form it can't target
-      // (an inline table `wmux = { ... }` under a `[mcp_servers]` parent) would
-      // append a duplicate table → unparseable. Never write a broken config.
-      parseConfig(newText, target.format);
-      writeFileAtomic(configPath, newText);
-    }
   } catch {
     return { configPath, skipped: 'malformed', wrote: [], foreign };
   }
+
+  if (newText !== text) writeFileAtomic(configPath, newText); // write errors propagate
   return { configPath, skipped: null, wrote, foreign };
 }
 
@@ -235,11 +233,16 @@ export function unregisterTarget(target: McpTarget, home: string): UnregisterTar
   // honest empty `removed` rather than claiming a removal that didn't happen.
   if (newText === text) return { configPath, removed: [], configExisted: true };
   // Output-validation guard: never write a config that no longer parses.
+  let reparsed: Record<string, unknown>;
   try {
-    parseConfig(newText, target.format);
+    reparsed = parseConfig(newText, target.format);
   } catch {
     return { configPath, removed: [], configExisted: true };
   }
   writeFileAtomic(configPath, newText);
-  return { configPath, removed: toRemove, configExisted: true };
+  // Report only keys that are ACTUALLY gone — a mixed config (one removable
+  // header-form key + one un-targetable inline key) must not claim the inline
+  // one was removed.
+  const removed = toRemove.filter((k) => getMcpServerEntry(reparsed, target.format, k) === null);
+  return { configPath, removed, configExisted: true };
 }

--- a/src/shared/mcpRegistration.ts
+++ b/src/shared/mcpRegistration.ts
@@ -12,6 +12,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { randomBytes } from 'crypto';
 import {
   MCP_TARGETS,
   WMUX_SERVER_KEY,
@@ -46,13 +47,21 @@ export interface TargetRegStatus {
   wmuxA2a: ServerRegState;
 }
 
-/** Atomic write (tmp + rename), creating the parent dir if needed. */
+/** Atomic write (tmp + rename), creating the parent dir if needed. The temp
+ *  name carries a per-process random suffix so two concurrent writers (CLI +
+ *  GUI registrar, or parallel CLI invocations) can't collide on a shared
+ *  `.tmp`; the temp file is cleaned up if the rename fails. */
 export function writeFileAtomic(filePath: string, text: string): void {
   const dir = path.dirname(filePath);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  const tmp = filePath + '.tmp';
+  const tmp = `${filePath}.${process.pid}-${randomBytes(6).toString('hex')}.tmp`;
   fs.writeFileSync(tmp, text, 'utf8');
-  fs.renameSync(tmp, filePath);
+  try {
+    fs.renameSync(tmp, filePath);
+  } catch (e) {
+    try { fs.unlinkSync(tmp); } catch { /* best-effort cleanup */ }
+    throw e;
+  }
 }
 
 /** Pure read of one target's registration state. Never creates / throws. */

--- a/src/shared/mcpTargets.ts
+++ b/src/shared/mcpTargets.ts
@@ -1,0 +1,80 @@
+// Multi-target MCP registration registry.
+//
+// wmux registers its MCP servers (`wmux`, `wmux-a2a`) into the config files of
+// the AI-agent CLIs installed on the machine so each can discover the wmux MCP
+// tools. Historically this was Claude-only (`~/.claude.json`). This table
+// generalizes the set of supported targets; `McpRegistrar` (main process) and
+// the `wmux mcp` CLI both iterate it through the shared `configIO` adapters so
+// the two registration code paths stay in lock-step.
+//
+// EMPIRICAL GATE (see McpRegistrar.ts header): a target is only shipped as
+// `verified` after its CLI was confirmed to (a) discover the wmux MCP server in
+// the written config and (b) actually USE the tools (pass the daemon permission
+// enforcer + resolve a workspace identity). Codex was verified 2026-06-15
+// (clientName `codex-mcp-client`, added to FIRST_PARTY_CLIENT_NAMES). Gemini CLI
+// is not installed here, so it stays unverified and is never created.
+
+import * as path from 'path';
+
+export type McpConfigFormat = 'json' | 'toml';
+
+export interface McpTarget {
+  /** Stable id used in status payloads, CLI `--target`, and UI keys. */
+  id: 'claude' | 'codex' | 'gemini';
+  /** Human label for Settings / CLI output. */
+  displayName: string;
+  /** Config file syntax. Drives which `configIO` adapter is used. */
+  format: McpConfigFormat;
+  /** Absolute config path for a given home directory. */
+  configPath: (home: string) => string;
+  /**
+   * When false, wmux NEVER creates this target's config file — it only writes
+   * if the file already exists. Claude owns `~/.claude.json` so it is created
+   * on demand; Codex/Gemini configs belong to those tools and are only touched
+   * when the user has them installed (their CLI created the file).
+   */
+  createIfMissing: boolean;
+  /**
+   * Whether wmux's integration with this agent is empirically verified to work
+   * end-to-end. Unverified targets are surfaced as "experimental / not
+   * detected" and never created speculatively.
+   */
+  verified: boolean;
+}
+
+// The two MCP server keys wmux owns in every target config.
+export const WMUX_SERVER_KEY = 'wmux';
+export const WMUX_A2A_SERVER_KEY = 'wmux-a2a';
+export const WMUX_SERVER_KEYS: readonly string[] = [WMUX_SERVER_KEY, WMUX_A2A_SERVER_KEY];
+
+export const MCP_TARGETS: readonly McpTarget[] = [
+  {
+    id: 'claude',
+    displayName: 'Claude Code',
+    format: 'json',
+    configPath: (home) => path.join(home, '.claude.json'),
+    createIfMissing: true,
+    verified: true,
+  },
+  {
+    id: 'codex',
+    displayName: 'Codex CLI',
+    format: 'toml',
+    configPath: (home) => path.join(home, '.codex', 'config.toml'),
+    createIfMissing: false,
+    verified: true,
+  },
+  {
+    id: 'gemini',
+    displayName: 'Gemini CLI',
+    format: 'json',
+    configPath: (home) => path.join(home, '.gemini', 'settings.json'),
+    createIfMissing: false,
+    verified: false,
+  },
+];
+
+/** Look up a target by id. */
+export function getMcpTarget(id: string): McpTarget | undefined {
+  return MCP_TARGETS.find((t) => t.id === id);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -557,7 +557,12 @@ export interface Artifact {
 export interface WmuxTaskMetadata {
   title: string;
   from: { workspaceId: string; name: string };
-  to: { workspaceId: string; name: string };
+  // Pane-level addressing (Part A): `paneId`/`surfaceId` pin the task to a
+  // specific pane/surface inside the target workspace so delivery lands on the
+  // intended agent when a workspace hosts more than one. Both optional — a
+  // ws-only `to` keeps the active-pane delivery behavior. Always ws-scoped: the
+  // id must belong to `workspaceId` (validated at delivery; cross-ws is refused).
+  to: { workspaceId: string; name: string; paneId?: string; surfaceId?: string };
   createdAt: string; // ISO 8601
   updatedAt: string; // ISO 8601
   [key: string]: unknown;


### PR DESCRIPTION
## Summary

Two axes of the multi-agent A2A moat: **precision** (one workspace can host many individually-addressable agents) and **reach** (non-Claude agents — Codex — on the sanctioned cross-workspace A2A channel).

Plan + engineering review first (`plan-eng-review` + Codex outside voice); Codex caught that "register config" alone would be theater — non-Claude hosts hit the `claude-code`-only permission enforcer — which reshaped Part B to include the first-party whitelist + live verification.

## Part A — pane-level identity + addressing (pure renderer derivation, fixes gaps 1/3/8)

- Per-ptyId `surfaceAgent` map (paneSlice) stamped from the existing `METADATA_UPDATE` stream (per-PTY `AgentDetector` already exists; no main-process change), cleared on surface/pane close.
- `surface_list` / `pane_list` / `a2a_discover` now carry a per-pane agent label, so a workspace running two agents is distinguishable without the buffer-fingerprint workaround.
- `a2a_task_send` gains optional `pane_id` / `surface_id`. The address resolves **within the resolved target workspace's own pane tree** (`a2aAddressing.resolvePaneAddress`):
  - a cross-ws id is structurally *not found* → **fail-closed**, #163 boundary intact;
  - an explicit-but-invalid address **hard-errors** (no silent active-pane fallback);
  - `pane_id` + disagreeing `surface_id` is rejected;
  - replies pin to the originally-addressed pane and **fail closed** (inbox-only) if it has since closed.
- `execute:true` now keys off the renderer-**resolved** workspaceId, not the raw fuzzy `to`.

## Part B — multi-target MCP registration (Claude / Codex / Gemini)

- New shared `mcpTargets` registry + `configIO` (JSON + **surgical-TOML** read/write) + `mcpRegistration` orchestration, used by **both** `McpRegistrar` (main) and the `wmux mcp` CLI (kills the prior duplication).
- TOML writes are surgical block insert/replace/remove — smol-toml is used for **reads only** because its `stringify` silently drops backslashes in literal-string keys (which would corrupt `[projects.'d:\wmux']`). A user's `~/.codex/config.toml` comments, ordering, and Windows-path keys survive; foreign (non-`node`) entries are never modified; malformed or would-be-unparseable output **aborts the write** (never clobbers). This matches what `codex mcp add` itself does.
- `McpRegistrarStatus` is now per-target; Settings → MCP and `wmux mcp` render every target with verified / not-detected state. Codex is written only when its config exists; Gemini is registry-only (unverified, never created).
- `firstParty` adds the **empirically-captured** Codex MCP clientName (`codex-mcp-client`) so Codex passes the enforce-mode permission gate — same curated `FIRST_PARTY_METHODS` allowlist, exact-match, no blanket bypass.

Adds `smol-toml`.

## Verification

- **Static**: `tsc --noEmit` 0 · eslint (changed) 0 new errors · `gen-api-reference --check` 0 drift (no new RPC method).
- **Unit**: 3402 passing. New suites: `configIO` (TOML surgical correctness — CRLF, comments, backslash keys, child sub-tables, inline-table abort, array-of-tables), `mcpRegistration` (per-target register/unregister + foreign guard + create policy), `a2aAddressing` (cross-ws / disagree / browser / not-found / fallback), `paneSlice` surfaceAgent lifecycle, `McpRegistrar` multi-target, `firstParty` codex.
- **Live dogfood — Part A (11/11)**: packaged exe, `WMUX_DATA_SUFFIX` isolated. Two panes in one ws spoofed as Claude Code + Codex CLI → distinct per-pane labels in `surface_list` / `a2a_discover`; `a2a_task_send surface_id` pins delivery; cross-ws surface_id and pane/surface disagreement both rejected.
- **Live dogfood — Part B config**: the real Codex CLI (`codex mcp get`) reads back my surgical writer's output with the backslash path intact and the foreign `[projects.'d:\wmux']` table + comments byte-preserved.
- **Reviews**: independent Claude code-reviewer (P1 inline-table clobber + P2 array-of-tables + P3 preload mirror → all fixed) and Codex diff review (reply fail-closed, TOML header trailing comment, unregister false-removal, CLI `--target` validation → fixed; execute-is-headless + reserved-key behavior → accepted with rationale).

## Not in scope

Gemini active support (CLI not installed → unverified, registry hook only), macOS Claude Desktop config path, A2A liveness/heartbeat, and a full real-Codex-in-a-pane end-to-end tool call (the config-discovery, enforcer first-party, and identity-topology links are each verified independently).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-target MCP registration and status handling for Claude, Codex, and Gemini
  * Enhanced MCP `send_message` and A2A delivery with optional pane/surface addressing and richer pane discovery (agent name/status)
  * Updated Settings to show MCP server status per target, including verified vs experimental
  * Improved the `wmux mcp` CLI to operate on selected targets and support JSON output
* **Bug Fixes**
  * Improved task routing by resolving destination pane/surface to the correct terminal and workspace context
  * Added stricter fail-closed validation for invalid and cross-workspace addressing
  * Proactively updates per-surface agent identity for more accurate UI behavior
* **Documentation**
  * Added an implementation plan for pane identity and multi-target MCP registration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->