### PR TITLE
chore(mcp): remove dead wmux-a2a server registration

### DIFF
--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -30,12 +30,12 @@ USAGE
   wmux mcp <subcommand> [--target <id>] [--json]
 
 SUBCOMMANDS
-  check        Show whether wmux + wmux-a2a are registered in each agent config.
-  register     Add wmux + wmux-a2a entries to each installed agent's config.
+  check        Show whether the wmux MCP server is registered in each agent config.
+  register     Add the wmux entry to each installed agent's config.
                Note: written paths point at this CLI's own bundle layout — for a
                GUI re-register that uses the running app's resolved paths, use
                Settings → General → MCP → Re-register.
-  unregister   Remove the wmux + wmux-a2a keys from each agent config.
+  unregister   Remove the wmux key from each agent config.
                Other entries are left untouched.
 
 OPTIONS
@@ -81,22 +81,26 @@ function printCheck(statuses: TargetRegStatus[], jsonMode: boolean): void {
     }
     const fmt = (srv: { registered: boolean; path: string | null }) =>
       srv.registered ? `registered → ${srv.path}` : 'NOT REGISTERED';
-    console.log(`  wmux:     ${fmt(s.wmux)}`);
-    console.log(`  wmux-a2a: ${fmt(s.wmuxA2a)}`);
-    console.log(`  config:   ${s.configPath} (${formatModified(s.configModified)})`);
+    console.log(`  wmux:   ${fmt(s.wmux)}`);
+    console.log(`  config: ${s.configPath} (${formatModified(s.configModified)})`);
   }
 }
 
 /**
- * Find the bundled MCP scripts when this CLI is invoked from a packaged
+ * Find the bundled wmux MCP script when this CLI is invoked from a packaged
  * install. The CLI bundle lives in `dist/cli-bundle/index.js` next to
  * `dist/mcp-bundle/index.js` (or the legacy `dist/mcp/mcp/index.js` layout).
- * Returns null when neither candidate exists.
+ * Returns null when no candidate exists.
  */
-function findScript(candidateRelative: string[]): string | null {
+function resolveWmuxScript(): string | null {
+  const candidates = [
+    path.join('mcp-bundle', 'index.js'),
+    path.join('dist', 'mcp-bundle', 'index.js'),
+    path.join('dist', 'mcp', 'mcp', 'index.js'),
+  ];
   let dir = __dirname;
   for (let i = 0; i < 6; i++) {
-    for (const rel of candidateRelative) {
+    for (const rel of candidates) {
       const candidate = path.join(dir, rel);
       if (fs.existsSync(candidate)) return candidate;
     }
@@ -105,21 +109,6 @@ function findScript(candidateRelative: string[]): string | null {
     dir = parent;
   }
   return null;
-}
-
-function resolveScripts(): { wmux: string | null; a2a: string | null } {
-  return {
-    wmux: findScript([
-      path.join('mcp-bundle', 'index.js'),
-      path.join('dist', 'mcp-bundle', 'index.js'),
-      path.join('dist', 'mcp', 'mcp', 'index.js'),
-    ]),
-    a2a: findScript([
-      path.join('a2a-bundle', 'index.js'),
-      path.join('dist', 'a2a-bundle', 'index.js'),
-      path.join('dist', 'mcp', 'mcp', 'a2a', 'index.js'),
-    ]),
-  };
 }
 
 export async function handleMcp(args: string[], jsonMode: boolean): Promise<void> {
@@ -149,11 +138,9 @@ export async function handleMcp(args: string[], jsonMode: boolean): Promise<void
     }
 
     case 'register': {
-      const scripts = resolveScripts();
-      // The core `wmux` MCP script is REQUIRED — registering the optional
-      // `wmux-a2a` server alone is an incoherent partial state (the primary
-      // tool surface would be missing). Bail if the main bundle isn't found.
-      if (!scripts.wmux) {
+      const wmuxScript = resolveWmuxScript();
+      // The wmux MCP script is required; bail if the bundle can't be found.
+      if (!wmuxScript) {
         const warning =
           'Could not locate the wmux MCP bundle next to this CLI. Open the wmux app once and use Settings → General → MCP → Re-register, or reinstall wmux.';
         if (jsonMode) console.log(JSON.stringify({ error: warning }, null, 2));
@@ -161,18 +148,15 @@ export async function handleMcp(args: string[], jsonMode: boolean): Promise<void
         process.exit(1);
         return;
       }
-      if (!scripts.a2a) {
-        console.warn('Note: the optional wmux-a2a bundle was not found — registering wmux only.');
-      }
       // registerTarget propagates write/permission errors (only parse/edit
       // issues are 'malformed'); capture them per-target so one failure neither
       // aborts the rest nor is silently swallowed.
       const results = targets.map((t) => {
-        try { return { target: t, result: registerTarget(t, home, scripts), error: null as string | null }; }
+        try { return { target: t, result: registerTarget(t, home, wmuxScript), error: null as string | null }; }
         catch (e) { return { target: t, result: null, error: e instanceof Error ? e.message : String(e) }; }
       });
       if (jsonMode) {
-        console.log(JSON.stringify({ scripts, results: results.map((r) => ({ id: r.target.id, error: r.error, ...(r.result ?? {}) })) }, null, 2));
+        console.log(JSON.stringify({ scripts: { wmux: wmuxScript }, results: results.map((r) => ({ id: r.target.id, error: r.error, ...(r.result ?? {}) })) }, null, 2));
         if (results.some((r) => r.error)) process.exit(1);
         return;
       }
@@ -202,9 +186,8 @@ export async function handleMcp(args: string[], jsonMode: boolean): Promise<void
           console.warn(`  left foreign key(s) ${result.foreign.join(', ')} untouched`);
         }
       }
-      if (scripts.wmux) console.log(`  wmux     → ${scripts.wmux}`);
-      if (scripts.a2a) console.log(`  wmux-a2a → ${scripts.a2a}`);
-      if (wroteAny) console.log('Restart the affected agent(s) to pick up the new servers.');
+      console.log(`  wmux → ${wmuxScript}`);
+      if (wroteAny) console.log('Restart the affected agent(s) to pick up the new server.');
       if (failed) process.exit(1);
       return;
     }

--- a/src/main/firstRun/__tests__/FirstRunOrchestrator.test.ts
+++ b/src/main/firstRun/__tests__/FirstRunOrchestrator.test.ts
@@ -149,7 +149,6 @@ function makeMcpRegistrar(opts?: {
           configModified: new Date(),
           verified: true,
           wmux: { registered: opts?.registered ?? true, path: '/some/path' },
-          wmuxA2a: { registered: false, path: null },
         },
       ],
     })),

--- a/src/main/ipc/handlers/mcp.handler.ts
+++ b/src/main/ipc/handlers/mcp.handler.ts
@@ -21,7 +21,6 @@ export interface McpTargetStatusPayload {
   configModified: string | null;
   verified: boolean;
   wmux: { registered: boolean; path: string | null };
-  wmuxA2a: { registered: boolean; path: string | null };
 }
 
 export interface McpStatusPayload {
@@ -39,7 +38,6 @@ function serialize(status: McpRegistrarStatus): McpStatusPayload {
       configModified: t.configModified ? t.configModified.toISOString() : null,
       verified: t.verified,
       wmux: t.wmux,
-      wmuxA2a: t.wmuxA2a,
     })),
   };
 }

--- a/src/main/mcp/McpRegistrar.ts
+++ b/src/main/mcp/McpRegistrar.ts
@@ -25,8 +25,8 @@ export interface McpRegistrarStatus {
 }
 
 /**
- * Registers/unregisters the wmux MCP servers (`wmux`, `wmux-a2a`) into the
- * config files of the installed agent CLIs, and writes the auth token to a
+ * Registers/unregisters the wmux MCP server (`wmux`) into the config files of
+ * the installed agent CLIs, and writes the auth token to a
  * well-known file so the MCP server can read it. The per-target fs + config
  * orchestration lives in `shared/mcpRegistration` so this class and the
  * `wmux mcp` CLI behave identically; this class adds the Electron-specific
@@ -83,7 +83,7 @@ export class McpRegistrar {
   }
 
   /**
-   * Force-remove the wmux + wmux-a2a keys from every target config. Invoked
+   * Force-remove the wmux key from every target config. Invoked
    * from explicit user actions (`wmux mcp unregister`, Settings "Unregister").
    * Only removes wmux-owned-shaped keys; foreign entries and unrelated keys are
    * left intact.
@@ -128,11 +128,10 @@ export class McpRegistrar {
         console.warn('[McpRegistrar] Could not determine MCP script path — skipping registration.');
         return;
       }
-      const a2aScript = this.getA2aScriptPath();
 
       for (const target of MCP_TARGETS) {
         try {
-          const result = registerTarget(target, this.home, { wmux: mcpScript, a2a: a2aScript }, this.ownedFor(target.id));
+          const result = registerTarget(target, this.home, mcpScript, this.ownedFor(target.id));
           if (result.wrote.length > 0) {
             console.log(`[McpRegistrar] ${target.displayName}: wrote ${result.wrote.join(', ')} → ${result.configPath}`);
           }
@@ -198,29 +197,6 @@ export class McpRegistrar {
       const parent = path.resolve(current, '..');
       if (parent === current) break;
       const candidate = path.join(parent, 'dist', 'mcp', 'mcp', 'index.js');
-      if (fs.existsSync(candidate)) return candidate;
-      current = parent;
-    }
-
-    return null;
-  }
-
-  private getA2aScriptPath(): string | null {
-    if (app.isPackaged) {
-      const bundlePath = path.join(process.resourcesPath, 'a2a-bundle', 'index.js');
-      if (fs.existsSync(bundlePath)) return bundlePath;
-      return null;
-    }
-
-    const appPath = app.getAppPath();
-    const devPath = path.join(appPath, 'dist', 'mcp', 'mcp', 'a2a', 'index.js');
-    if (fs.existsSync(devPath)) return devPath;
-
-    let current = appPath;
-    for (let i = 0; i < 5; i++) {
-      const parent = path.resolve(current, '..');
-      if (parent === current) break;
-      const candidate = path.join(parent, 'dist', 'mcp', 'mcp', 'a2a', 'index.js');
       if (fs.existsSync(candidate)) return candidate;
       current = parent;
     }

--- a/src/main/mcp/__tests__/McpRegistrar.test.ts
+++ b/src/main/mcp/__tests__/McpRegistrar.test.ts
@@ -49,7 +49,6 @@ describe('McpRegistrar.getStatus (multi-target)', () => {
       expect(t.configExists).toBe(false);
       expect(t.configModified).toBeNull();
       expect(t.wmux).toEqual({ registered: false, path: null });
-      expect(t.wmuxA2a).toEqual({ registered: false, path: null });
     }
     expect(target(status, 'claude').configPath).toBe(claudeJson());
     expect(target(status, 'codex').configPath).toBe(codexToml());
@@ -65,7 +64,6 @@ describe('McpRegistrar.getStatus (multi-target)', () => {
     const cfg = {
       mcpServers: {
         wmux: { command: 'node', args: ['/abs/mcp-bundle/index.js'] },
-        'wmux-a2a': { command: 'node', args: ['/abs/a2a-bundle/index.js'] },
         'someone-else': { command: 'node', args: ['/elsewhere/index.js'] },
       },
     };
@@ -75,7 +73,6 @@ describe('McpRegistrar.getStatus (multi-target)', () => {
     expect(claude.configExists).toBe(true);
     expect(claude.configModified).toBeInstanceOf(Date);
     expect(claude.wmux).toEqual({ registered: true, path: '/abs/mcp-bundle/index.js' });
-    expect(claude.wmuxA2a).toEqual({ registered: true, path: '/abs/a2a-bundle/index.js' });
   });
 
   it('extracts registered script paths from Codex TOML (mcp_servers table)', () => {
@@ -89,7 +86,6 @@ describe('McpRegistrar.getStatus (multi-target)', () => {
     expect(codex.configExists).toBe(true);
     expect(codex.format).toBe('toml');
     expect(codex.wmux).toEqual({ registered: true, path: 'C:\\w\\index.js' });
-    expect(codex.wmuxA2a.registered).toBe(false);
   });
 
   it('treats malformed entries / corrupt configs as not registered (no throw)', () => {
@@ -116,13 +112,12 @@ describe('McpRegistrar.getStatus (multi-target)', () => {
 });
 
 describe('McpRegistrar.forceUnregister (multi-target)', () => {
-  it('removes wmux keys from both Claude JSON and Codex TOML, leaving foreign intact', () => {
+  it('removes the wmux key from both Claude JSON and Codex TOML, leaving foreign intact', () => {
     fs.writeFileSync(
       claudeJson(),
       JSON.stringify({
         mcpServers: {
           wmux: { command: 'node', args: ['/x/wmux.js'] },
-          'wmux-a2a': { command: 'node', args: ['/x/a2a.js'] },
           'someone-else': { command: 'node', args: ['/y/other.js'] },
         },
         otherTopLevel: { keep: true },

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -9,7 +9,7 @@ import { isFileDrag } from '../shared/dragDrop';
 import type { ResumeBinding } from '../shared/agentResume';
 
 /** Mirrors {@link McpStatusPayload} in src/main/ipc/handlers/mcp.handler.ts. */
-interface McpTargetStatusPayload {
+export interface McpTargetStatusPayload {
   id: string;
   displayName: string;
   format: 'json' | 'toml';
@@ -18,7 +18,6 @@ interface McpTargetStatusPayload {
   configModified: string | null;
   verified: boolean;
   wmux: { registered: boolean; path: string | null };
-  wmuxA2a: { registered: boolean; path: string | null };
 }
 interface McpStatusPayload {
   targets: McpTargetStatusPayload[];

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -574,7 +574,6 @@ interface McpTargetStatusPayload {
   configModified: string | null;
   verified: boolean;
   wmux: McpServerState;
-  wmuxA2a: McpServerState;
 }
 interface McpStatusPayload {
   targets: McpTargetStatusPayload[];
@@ -587,8 +586,8 @@ interface ElectronMcpApi {
 }
 
 /**
- * MCP servers panel in Settings → General. Surfaces whether `~/.claude.json`
- * has the wmux + wmux-a2a MCP entries, plus Re-register / Unregister buttons.
+ * MCP servers panel in Settings → General. Surfaces whether each agent config
+ * has the wmux MCP entry, plus Re-register / Unregister buttons.
  *
  * Mirrors the `wmux mcp check` CLI output so users have a one-stop way to
  * verify Claude Code can discover the wmux MCP bridge — DX D4 decision.
@@ -686,7 +685,6 @@ function McpStatusSection() {
       {target.configExists ? (
         <>
           {renderRow('wmux', target.wmux)}
-          {renderRow('wmux-a2a', target.wmuxA2a)}
           <p className="text-[10px] text-[color:var(--text-muted)] font-mono truncate" title={target.configPath}>
             {target.configPath}
             {target.configModified ? ` · modified ${new Date(target.configModified).toLocaleString()}` : ''}

--- a/src/shared/__tests__/configIO.test.ts
+++ b/src/shared/__tests__/configIO.test.ts
@@ -71,17 +71,17 @@ keep = true
     expect((parsed.other as Record<string, unknown>).keep).toBe(true);
   });
 
-  it('removes only the wmux blocks, leaving foreign tables intact', () => {
+  it('removes multiple named blocks, leaving foreign tables intact', () => {
     const seeded = upsertMcpServer(
       upsertMcpServer(CODEX_CONFIG, 'toml', 'wmux', 'C:\\w\\i.js'),
       'toml',
-      'wmux-a2a',
+      'wmux-extra',
       'C:\\w\\a.js',
     );
-    const removed = removeMcpServers(seeded, 'toml', ['wmux', 'wmux-a2a']);
+    const removed = removeMcpServers(seeded, 'toml', ['wmux', 'wmux-extra']);
     const parsed = parseConfig(removed, 'toml');
     expect(getMcpServerScript(parsed, 'toml', 'wmux')).toBeNull();
-    expect(getMcpServerScript(parsed, 'toml', 'wmux-a2a')).toBeNull();
+    expect(getMcpServerScript(parsed, 'toml', 'wmux-extra')).toBeNull();
     expect(parsed.model).toBe('gpt-5.5');
     expect((parsed.projects as Record<string, unknown>)['d:\\wmux']).toBeTruthy();
     expect((parsed.tui as Record<string, unknown>).model_availability_nux).toBeTruthy();
@@ -95,10 +95,10 @@ keep = true
     expect(getMcpServerScript(parseConfig(out, 'toml'), 'toml', 'wmux')).toBe('C:\\w\\i.js');
   });
 
-  it('handles a quoted/dashed key (wmux-a2a) and an empty file', () => {
-    const out = upsertMcpServer('', 'toml', 'wmux-a2a', 'C:\\w\\a.js');
-    expect(out).toContain('[mcp_servers.wmux-a2a]');
-    expect(getMcpServerScript(parseConfig(out, 'toml'), 'toml', 'wmux-a2a')).toBe('C:\\w\\a.js');
+  it('handles a quoted/dashed key (wmux-extra) and an empty file', () => {
+    const out = upsertMcpServer('', 'toml', 'wmux-extra', 'C:\\w\\a.js');
+    expect(out).toContain('[mcp_servers.wmux-extra]');
+    expect(getMcpServerScript(parseConfig(out, 'toml'), 'toml', 'wmux-extra')).toBe('C:\\w\\a.js');
   });
 
   it('throws ConfigParseError on malformed TOML (never clobbers)', () => {

--- a/src/shared/__tests__/mcpRegistration.test.ts
+++ b/src/shared/__tests__/mcpRegistration.test.ts
@@ -13,7 +13,7 @@ let home = '';
 const claudeTarget = getMcpTarget('claude')!;
 const codexTarget = getMcpTarget('codex')!;
 const geminiTarget = getMcpTarget('gemini')!;
-const SCRIPTS = { wmux: 'C:\\app\\mcp-bundle\\index.js', a2a: 'C:\\app\\a2a-bundle\\index.js' };
+const WMUX_SCRIPT = 'C:\\app\\mcp-bundle\\index.js';
 
 beforeEach(() => {
   home = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-mcpreg-'));
@@ -23,43 +23,49 @@ afterEach(() => {
 });
 
 describe('registerTarget — Claude (json, createIfMissing)', () => {
-  it('creates ~/.claude.json and writes both servers', () => {
-    const r = registerTarget(claudeTarget, home, SCRIPTS);
+  it('creates ~/.claude.json and writes the wmux server', () => {
+    const r = registerTarget(claudeTarget, home, WMUX_SCRIPT);
     expect(r.skipped).toBeNull();
-    expect(r.wrote.sort()).toEqual(['wmux', 'wmux-a2a']);
-    const status = readTargetStatus(claudeTarget, home);
-    expect(status.wmux).toEqual({ registered: true, path: SCRIPTS.wmux });
-    expect(status.wmuxA2a).toEqual({ registered: true, path: SCRIPTS.a2a });
+    expect(r.wrote).toEqual(['wmux']);
+    expect(readTargetStatus(claudeTarget, home).wmux).toEqual({ registered: true, path: WMUX_SCRIPT });
   });
 
   it('is idempotent — re-register writes nothing the second time', () => {
-    registerTarget(claudeTarget, home, SCRIPTS);
-    const r2 = registerTarget(claudeTarget, home, SCRIPTS);
+    registerTarget(claudeTarget, home, WMUX_SCRIPT);
+    const r2 = registerTarget(claudeTarget, home, WMUX_SCRIPT);
     expect(r2.wrote).toEqual([]);
   });
 
   it('updates a stale path written by a prior session', () => {
-    registerTarget(claudeTarget, home, { wmux: 'C:\\old\\index.js', a2a: null });
-    const r = registerTarget(claudeTarget, home, SCRIPTS);
+    registerTarget(claudeTarget, home, 'C:\\old\\index.js');
+    const r = registerTarget(claudeTarget, home, WMUX_SCRIPT);
     expect(r.wrote).toContain('wmux');
-    expect(readTargetStatus(claudeTarget, home).wmux.path).toBe(SCRIPTS.wmux);
+    expect(readTargetStatus(claudeTarget, home).wmux.path).toBe(WMUX_SCRIPT);
   });
 
   it('leaves a FOREIGN (non-node) wmux entry untouched', () => {
     const p = claudeTarget.configPath(home);
     fs.writeFileSync(p, JSON.stringify({ mcpServers: { wmux: { command: 'python', args: ['/x.py'] } } }), 'utf8');
-    const r = registerTarget(claudeTarget, home, SCRIPTS);
+    const r = registerTarget(claudeTarget, home, WMUX_SCRIPT);
     expect(r.foreign).toContain('wmux');
+    expect(r.wrote).toEqual([]);
     const after = JSON.parse(fs.readFileSync(p, 'utf8')) as { mcpServers: Record<string, { command: string }> };
     expect(after.mcpServers.wmux.command).toBe('python');
-    // wmux-a2a (absent) is still written.
-    expect(after.mcpServers['wmux-a2a']).toBeTruthy();
+  });
+
+  it('drops a historical stray wmux-a2a key from Claude JSON (dead-server cleanup)', () => {
+    const p = claudeTarget.configPath(home);
+    fs.writeFileSync(p, JSON.stringify({ mcpServers: { 'wmux-a2a': { command: 'node', args: ['/old/a2a.js'] } } }), 'utf8');
+    registerTarget(claudeTarget, home, WMUX_SCRIPT);
+    const after = JSON.parse(fs.readFileSync(p, 'utf8')) as { mcpServers: Record<string, unknown> };
+    expect(after.mcpServers['wmux-a2a']).toBeUndefined();
+    expect(after.mcpServers.wmux).toBeTruthy();
   });
 });
 
 describe('registerTarget — Codex (toml, only if installed)', () => {
   it('SKIPS when ~/.codex/config.toml does not exist (never created)', () => {
-    const r = registerTarget(codexTarget, home, SCRIPTS);
+    const r = registerTarget(codexTarget, home, WMUX_SCRIPT);
     expect(r.skipped).toBe('absent');
     expect(fs.existsSync(codexTarget.configPath(home))).toBe(false);
   });
@@ -70,39 +76,34 @@ describe('registerTarget — Codex (toml, only if installed)', () => {
     const original = `# hand-written\nmodel = "gpt-5.5"\n\n[projects.'d:\\wmux']\ntrust_level = "trusted"\n`;
     fs.writeFileSync(p, original, 'utf8');
 
-    const r = registerTarget(codexTarget, home, SCRIPTS);
-    expect(r.wrote.sort()).toEqual(['wmux', 'wmux-a2a']);
+    const r = registerTarget(codexTarget, home, WMUX_SCRIPT);
+    expect(r.wrote).toEqual(['wmux']);
 
     const after = fs.readFileSync(p, 'utf8');
     expect(after).toContain('# hand-written');
     expect(after).toContain(`[projects.'d:\\wmux']`); // backslash key NOT corrupted
     expect(after).toContain('[mcp_servers.wmux]');
-
-    const status = readTargetStatus(codexTarget, home);
-    expect(status.wmux).toEqual({ registered: true, path: SCRIPTS.wmux });
-    expect(status.wmuxA2a).toEqual({ registered: true, path: SCRIPTS.a2a });
+    expect(readTargetStatus(codexTarget, home).wmux).toEqual({ registered: true, path: WMUX_SCRIPT });
   });
 
   it('leaves a malformed config.toml untouched (never clobbers)', () => {
     const p = codexTarget.configPath(home);
     fs.mkdirSync(path.dirname(p), { recursive: true });
     fs.writeFileSync(p, 'this = = broken', 'utf8');
-    const r = registerTarget(codexTarget, home, SCRIPTS);
+    const r = registerTarget(codexTarget, home, WMUX_SCRIPT);
     expect(r.skipped).toBe('malformed');
     expect(fs.readFileSync(p, 'utf8')).toBe('this = = broken');
   });
 
-  // Regression (independent review P1): an inline-table form under a
-  // [mcp_servers] parent can't be surgically replaced by the line-based editor.
-  // The output-validation guard must abort rather than append a duplicate table
-  // that makes the file unparseable.
+  // Regression (independent review): an inline-table form under a [mcp_servers]
+  // parent can't be surgically replaced by the line-based editor. The
+  // output-validation guard must abort rather than append a duplicate table.
   it('does NOT corrupt an inline-table mcp_servers.wmux entry (aborts the write)', () => {
     const p = codexTarget.configPath(home);
     fs.mkdirSync(path.dirname(p), { recursive: true });
     const inline = `[mcp_servers]\nwmux = { command = "node", args = ["C:\\\\old\\\\i.js"] }\n`;
     fs.writeFileSync(p, inline, 'utf8');
-    const r = registerTarget(codexTarget, home, SCRIPTS);
-    // Left untouched (safe), and the file still parses (no duplicate table).
+    const r = registerTarget(codexTarget, home, WMUX_SCRIPT);
     expect(r.wrote).toEqual([]);
     expect(fs.readFileSync(p, 'utf8')).toBe(inline);
     expect(() => readTargetStatus(codexTarget, home)).not.toThrow();
@@ -111,7 +112,7 @@ describe('registerTarget — Codex (toml, only if installed)', () => {
 
 describe('registerTarget — Gemini (unverified, never created)', () => {
   it('SKIPS when settings.json does not exist', () => {
-    const r = registerTarget(geminiTarget, home, SCRIPTS);
+    const r = registerTarget(geminiTarget, home, WMUX_SCRIPT);
     expect(r.skipped).toBe('absent');
     expect(fs.existsSync(geminiTarget.configPath(home))).toBe(false);
   });
@@ -120,8 +121,8 @@ describe('registerTarget — Gemini (unverified, never created)', () => {
     const p = geminiTarget.configPath(home);
     fs.mkdirSync(path.dirname(p), { recursive: true });
     fs.writeFileSync(p, JSON.stringify({ theme: 'dark' }), 'utf8');
-    const r = registerTarget(geminiTarget, home, SCRIPTS);
-    expect(r.wrote.sort()).toEqual(['wmux', 'wmux-a2a']);
+    const r = registerTarget(geminiTarget, home, WMUX_SCRIPT);
+    expect(r.wrote).toEqual(['wmux']);
     const after = JSON.parse(fs.readFileSync(p, 'utf8')) as { theme: string; mcpServers: Record<string, unknown> };
     expect(after.theme).toBe('dark');
     expect(after.mcpServers.wmux).toBeTruthy();
@@ -129,14 +130,14 @@ describe('registerTarget — Gemini (unverified, never created)', () => {
 });
 
 describe('unregisterTarget', () => {
-  it('removes only wmux-owned keys from Codex TOML, preserving foreign data', () => {
+  it('removes the wmux key from Codex TOML, preserving foreign data', () => {
     const p = codexTarget.configPath(home);
     fs.mkdirSync(path.dirname(p), { recursive: true });
     fs.writeFileSync(p, `[tui]\ntheme = "dark"\n`, 'utf8');
-    registerTarget(codexTarget, home, SCRIPTS);
+    registerTarget(codexTarget, home, WMUX_SCRIPT);
 
     const r = unregisterTarget(codexTarget, home);
-    expect(r.removed.sort()).toEqual(['wmux', 'wmux-a2a']);
+    expect(r.removed).toEqual(['wmux']);
     const after = fs.readFileSync(p, 'utf8');
     expect(after).not.toContain('[mcp_servers.wmux]');
     expect(after).toContain('[tui]');
@@ -158,23 +159,6 @@ describe('unregisterTarget', () => {
     const r = unregisterTarget(codexTarget, home);
     expect(r.removed).toEqual([]);
     expect(fs.readFileSync(p, 'utf8')).toBe(inline); // untouched
-  });
-
-  // Codex final review: a MIXED config (un-targetable inline wmux + removable
-  // header-form wmux-a2a) must report ONLY the key actually removed.
-  it('reports only the actually-removed key in a mixed inline/header config', () => {
-    const p = codexTarget.configPath(home);
-    fs.mkdirSync(path.dirname(p), { recursive: true });
-    fs.writeFileSync(
-      p,
-      `[mcp_servers]\nwmux = { command = "node", args = ["/x.js"] }\n\n[mcp_servers.wmux-a2a]\ncommand = "node"\nargs = ["/a.js"]\n`,
-      'utf8',
-    );
-    const r = unregisterTarget(codexTarget, home);
-    expect(r.removed).toEqual(['wmux-a2a']); // NOT ['wmux','wmux-a2a']
-    const after = fs.readFileSync(p, 'utf8');
-    expect(after).toContain('wmux = { command = "node"'); // inline wmux survives
-    expect(after).not.toContain('[mcp_servers.wmux-a2a]');
   });
 });
 

--- a/src/shared/configIO.ts
+++ b/src/shared/configIO.ts
@@ -1,7 +1,7 @@
 // Format-aware MCP-config read/write, shared by McpRegistrar (main) and the
 // `wmux mcp` CLI so both registration paths behave identically.
 //
-// READ  — parse the file to inspect the wmux/wmux-a2a entries (status,
+// READ  — parse the file to inspect the wmux entry (status,
 //          idempotency, foreign-key detection). TOML is parsed with smol-toml;
 //          JSON with a proto-pollution-guarded JSON.parse.
 // WRITE — JSON is object-merge + 2-space re-stringify (JSON has no comments, so
@@ -151,7 +151,7 @@ function detectEol(text: string): '\r\n' | '\n' {
   return text.includes('\r\n') ? '\r\n' : '\n';
 }
 
-/** Split a dotted TOML key path (`mcp_servers.'wmux-a2a'.env`) into unquoted
+/** Split a dotted TOML key path (`mcp_servers.'my-server'.env`) into unquoted
  *  segments, honoring basic- and literal-string quoting. */
 function splitTomlKeyPath(path: string): string[] {
   const segs: string[] = [];

--- a/src/shared/electron.d.ts
+++ b/src/shared/electron.d.ts
@@ -1,4 +1,4 @@
-import type { ElectronAPI } from '../preload/preload';
+import type { ElectronAPI, McpTargetStatusPayload } from '../preload/preload';
 import type {
   FirstRunCheckResult,
   RegisterMcpResult,
@@ -18,27 +18,9 @@ declare global {
         onChanged: (callback: (dirPath: string) => void) => () => void;
       };
       mcp?: {
-        check: () => Promise<{
-          wmux: { registered: boolean; path: string | null };
-          wmuxA2a: { registered: boolean; path: string | null };
-          configPath: string;
-          configExists: boolean;
-          configModified: string | null;
-        }>;
-        reregister: () => Promise<{
-          wmux: { registered: boolean; path: string | null };
-          wmuxA2a: { registered: boolean; path: string | null };
-          configPath: string;
-          configExists: boolean;
-          configModified: string | null;
-        }>;
-        unregister: () => Promise<{
-          wmux: { registered: boolean; path: string | null };
-          wmuxA2a: { registered: boolean; path: string | null };
-          configPath: string;
-          configExists: boolean;
-          configModified: string | null;
-        }>;
+        check: () => Promise<{ targets: McpTargetStatusPayload[] }>;
+        reregister: () => Promise<{ targets: McpTargetStatusPayload[] }>;
+        unregister: () => Promise<{ targets: McpTargetStatusPayload[] }>;
       };
       firstRun?: {
         check: () => Promise<FirstRunCheckResult>;

--- a/src/shared/mcpRegistration.ts
+++ b/src/shared/mcpRegistration.ts
@@ -16,7 +16,6 @@ import { randomBytes } from 'crypto';
 import {
   MCP_TARGETS,
   WMUX_SERVER_KEY,
-  WMUX_A2A_SERVER_KEY,
   WMUX_SERVER_KEYS,
   type McpTarget,
   type McpConfigFormat,
@@ -44,7 +43,6 @@ export interface TargetRegStatus {
   configModified: Date | null;
   verified: boolean;
   wmux: ServerRegState;
-  wmuxA2a: ServerRegState;
 }
 
 /** Atomic write (tmp + rename), creating the parent dir if needed. The temp
@@ -78,12 +76,10 @@ export function readTargetStatus(target: McpTarget, home: string): TargetRegStat
   }
 
   let wmuxPath: string | null = null;
-  let a2aPath: string | null = null;
   if (configExists) {
     try {
       const parsed = parseConfig(fs.readFileSync(configPath, 'utf8'), target.format);
       wmuxPath = getMcpServerScript(parsed, target.format, WMUX_SERVER_KEY);
-      a2aPath = getMcpServerScript(parsed, target.format, WMUX_A2A_SERVER_KEY);
     } catch {
       // corrupted → not registered
     }
@@ -98,7 +94,6 @@ export function readTargetStatus(target: McpTarget, home: string): TargetRegStat
     configModified,
     verified: target.verified,
     wmux: { registered: wmuxPath !== null, path: wmuxPath },
-    wmuxA2a: { registered: a2aPath !== null, path: a2aPath },
   };
 }
 
@@ -117,14 +112,14 @@ export interface RegisterTargetResult {
 }
 
 /**
- * Ensure `wmux` / `wmux-a2a` point at the given scripts in one target's config.
+ * Ensure the `wmux` MCP server points at `wmuxScript` in one target's config.
  * `ownedKeys` (optional) tracks keys written this session so a key wmux already
  * owns is updated even if its on-disk shape looks foreign-adjacent.
  */
 export function registerTarget(
   target: McpTarget,
   home: string,
-  scripts: { wmux: string | null; a2a: string | null },
+  wmuxScript: string,
   ownedKeys?: Set<string>,
 ): RegisterTargetResult {
   const configPath = target.configPath(home);
@@ -152,41 +147,36 @@ export function registerTarget(
   let newText = text;
   const wrote: string[] = [];
   const foreign: string[] = [];
-  const entries: Array<[string, string | null]> = [
-    [WMUX_SERVER_KEY, scripts.wmux],
-    [WMUX_A2A_SERVER_KEY, scripts.a2a],
-  ];
   // Build + validate the new text. Parse/edit failures mean the config is in a
   // shape we can't safely edit → 'malformed' (graceful skip, never clobber).
   // The actual WRITE is intentionally OUTSIDE this catch so a permission/rename
   // failure propagates to the caller (McpRegistrar surfaces the macOS hint; the
   // CLI exits non-zero) instead of being misreported as "malformed".
   try {
-    for (const [key, script] of entries) {
-      if (!script) continue;
-      const existing = getMcpServerEntry(parsed, target.format, key);
-      if (existing && !ownedKeys?.has(key)) {
-        if (!isWmuxOwnedEntry(existing)) {
-          foreign.push(key);
-          continue;
-        }
-        if (existing.args[0] === script) {
-          ownedKeys?.add(key); // already up to date
-          continue;
-        }
-        // ours but stale path → fall through to update
+    const existing = getMcpServerEntry(parsed, target.format, WMUX_SERVER_KEY);
+    let skip = false;
+    if (existing && !ownedKeys?.has(WMUX_SERVER_KEY)) {
+      if (!isWmuxOwnedEntry(existing)) {
+        foreign.push(WMUX_SERVER_KEY); // foreign hand-authored entry — never modify
+        skip = true;
+      } else if (existing.args[0] === wmuxScript) {
+        ownedKeys?.add(WMUX_SERVER_KEY); // already up to date
+        skip = true;
       }
-      // upsert validates its INPUT and OUTPUT, so a previous iteration that
-      // produced an unparseable intermediate (e.g. an inline-table entry the
-      // line-based editor duplicated) throws here and is caught below.
-      newText = upsertMcpServer(newText, target.format, key, script);
-      wrote.push(key);
-      ownedKeys?.add(key);
+      // else: ours but stale path → update below
+    }
+    if (!skip) {
+      // upsert validates its INPUT and OUTPUT, so an inline-table entry the
+      // line-based editor can't target (which would duplicate) throws here.
+      newText = upsertMcpServer(newText, target.format, WMUX_SERVER_KEY, wmuxScript);
+      wrote.push(WMUX_SERVER_KEY);
+      ownedKeys?.add(WMUX_SERVER_KEY);
     }
 
-    // Legacy cleanup only applies to Claude's JSON (old wmux-playwright keys).
+    // Legacy cleanup only applies to Claude's JSON (old wmux-playwright keys
+    // plus the removed wmux-a2a server, in case a historical stray exists).
     if (target.id === 'claude') {
-      newText = removeMcpServers(newText, 'json', ['wmux-playwright', 'wmux-devtools']);
+      newText = removeMcpServers(newText, 'json', ['wmux-playwright', 'wmux-devtools', 'wmux-a2a']);
     }
   } catch {
     return { configPath, skipped: 'malformed', wrote: [], foreign };
@@ -202,7 +192,7 @@ export interface UnregisterTargetResult {
   configExisted: boolean;
 }
 
-/** Remove only wmux-owned `wmux` / `wmux-a2a` keys from one target's config. */
+/** Remove the wmux-owned `wmux` key from one target's config. */
 export function unregisterTarget(target: McpTarget, home: string): UnregisterTargetResult {
   const configPath = target.configPath(home);
   if (!fs.existsSync(configPath)) return { configPath, removed: [], configExisted: false };

--- a/src/shared/mcpTargets.ts
+++ b/src/shared/mcpTargets.ts
@@ -1,7 +1,7 @@
 // Multi-target MCP registration registry.
 //
-// wmux registers its MCP servers (`wmux`, `wmux-a2a`) into the config files of
-// the AI-agent CLIs installed on the machine so each can discover the wmux MCP
+// wmux registers its MCP server (`wmux`) into the config files of the AI-agent
+// CLIs installed on the machine so each can discover the wmux MCP
 // tools. Historically this was Claude-only (`~/.claude.json`). This table
 // generalizes the set of supported targets; `McpRegistrar` (main process) and
 // the `wmux mcp` CLI both iterate it through the shared `configIO` adapters so
@@ -42,10 +42,12 @@ export interface McpTarget {
   verified: boolean;
 }
 
-// The two MCP server keys wmux owns in every target config.
+// The MCP server key wmux owns in every target config. (A formerly-paired
+// `wmux-a2a` server was removed as dead code: no a2a bundle was ever built or
+// packaged, so it never registered — the A2A tools live in the main `wmux`
+// server.) Kept as an array so unregister can sweep any historical strays.
 export const WMUX_SERVER_KEY = 'wmux';
-export const WMUX_A2A_SERVER_KEY = 'wmux-a2a';
-export const WMUX_SERVER_KEYS: readonly string[] = [WMUX_SERVER_KEY, WMUX_A2A_SERVER_KEY];
+export const WMUX_SERVER_KEYS: readonly string[] = [WMUX_SERVER_KEY];
 
 export const MCP_TARGETS: readonly McpTarget[] = [
   {


### PR DESCRIPTION
## Summary

Removes the dead `wmux-a2a` MCP server key. It was never functional: `getA2aScriptPath()` always returned `null` (no a2a server source exists, `build:mcp` never produced an `a2a-bundle`, and it isn't in `forge.config.ts` `extraResource`), so `wmux-a2a` was never registered since it was added in #71. The actual A2A tools (`a2a_task_send` / `a2a_discover` / `a2a_broadcast` / events poll) are hosted by the main `wmux` MCP server — built, registered, and working. (The `wmux-a2a ✗` row in Settings → MCP was this dead code surfacing as a permanent red X.)

## Changes
- Drop `getA2aScriptPath`, `WMUX_A2A_SERVER_KEY`, and the `wmuxA2a` status field across `mcpTargets` / `configIO` / `mcpRegistration` / `McpRegistrar` / IPC payload / preload / Settings UI / `wmux mcp` CLI.
- `registerTarget` now takes a single `wmuxScript` (was a `{ wmux, a2a }` pair) — same foreign-guard / idempotency / malformed-config behavior, just one key.
- Settings → MCP renders one server row per target; `wmux mcp` drops the `wmux-a2a` output (`register --json` keeps the `scripts.wmux` shape).
- Register-time legacy cleanup additionally sweeps a historical stray `wmux-a2a` key out of Claude JSON.
- Fix `electron.d.ts`: the `mcp` payload type still carried the pre-multi-target single-target shape (a consumer #235 missed) — now `{ targets }`.

Net −94 lines.

## Verification
tsc 0 · eslint clean (0 new) · `gen-api-reference --check` 0 drift · 3407 unit tests. Independent Codex review confirmed the removal is complete and behavior-preserving (foreign-guard / idempotency / malformed handling on `wmux` unchanged; `electron.d.ts` now correct).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Streamlined MCP server management to handle only the wmux server
  * Removed wmux-a2a support from registration commands, status checks, and settings panel display
  * Simplified registration, unregistration, and MCP configuration workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->