### PR TITLE
feat(pane): pane.split honors explicit workspaceId for multi-agent targeting (#236)

### DIFF
--- a/plans/issue-236-followup-rpc-workspace-scoping-sweep.md
+++ b/plans/issue-236-followup-rpc-workspace-scoping-sweep.md
@@ -1,0 +1,56 @@
+# Follow-up: RPC workspaceId scoping sweep (siblings of #236)
+
+**Status:** tracked, deferred out of the #236 fix (scope discipline).
+**Parent:** #236 (`pane.split` ignored `workspaceId` → fixed: handler fail-closed +
+focus-scoping + background eager-spawn + main-side forward).
+
+## Why this is separate from #236
+
+The #236 expert panel (sweep agent) found `pane.split` is **not** the only RPC
+handler that ignores an explicit `workspaceId` and always acts on the
+globally-active workspace. The same `activeWorkspaceId`-fallback defect lives in
+several sibling handlers. They are deferred because — unlike `pane.split`, which
+is a pure "create in my ws" operation — the `*.focus` siblings **intentionally
+move the user's focus today**, so changing them is a UX-semantics decision that
+needs its own dogfood, not a drive-by bugfix bundled into #236.
+
+## Classification (current branch, post-#236)
+
+C-bucket = ignores `workspaceId` entirely (always active ws).
+B-bucket = reads `workspaceId` but silently falls back to active ws on miss.
+
+| Method | Renderer site | Daemon site | Bucket | Multi-agent impact |
+|---|---|---|---|---|
+| `pane.focus` | `useRpcBridge.ts` (`method === 'pane.focus'`) | `pane.rpc.ts` `pane.focus` (forwards only `id`) | **C** | external caller focuses the active ws's pane, not its own |
+| `surface.new` | `useRpcBridge.ts` (`method === 'surface.new'`) | `surface.rpc.ts` `surface.new` (drops params) | **C** | new terminal opens in the on-screen ws, not the caller's |
+| `surface.focus` | `useRpcBridge.ts` (`method === 'surface.focus'`) | `surface.rpc.ts` `surface.focus` (forwards only `id`) | **C** | focus moves in the active ws, not the caller's |
+| `browser.open` | `useRpcBridge.ts` (`browser.open`) | `browser.rpc.ts` | **B** | MCP-gated by `requireWorkspaceId()` upstream → low risk |
+| `browser.close` | `useRpcBridge.ts` (`browser.close`) | `browser.rpc.ts` | **B** | MCP-gated → low risk |
+
+(For contrast, the already-CORRECT handlers — `pane.list`, `surface.list`,
+`surface.close` — read `workspaceId` and either fail closed or search all
+workspaces by a globally-unique id. `pane.split` now joins them.)
+
+## Also surfaced, separate gap
+
+- **No `pane.close` / `pane.delete` RPC exists.** The store has
+  `closePane(paneId, workspaceId?)` but it is not registered on the pipe. An
+  external multi-agent caller that creates a worker pane (now possible via the
+  #236 fix) cannot clean it up over RPC — it has to `exit` the shell. Worth a
+  `pane.close` handler mirroring `surface.close`'s all-workspace, id-unambiguous
+  lookup.
+
+## Recommended approach for the sweep PR
+
+1. **`surface.new` first** — lowest UX risk (creating, not focusing) and #236
+   already did half the infra: `addSurface` now takes an optional `workspaceId`,
+   and the background eager-spawn pattern in the `pane.split` handler is the
+   template. Thread `workspaceId` (fail-closed) + eager-spawn for a background ws.
+2. **`pane.focus` / `surface.focus`** — these need a product decision: should a
+   remote focus move the *global* view or only the *target ws's* internal active
+   pane/surface? Likely the latter (don't yank the user's screen), mirroring the
+   #236 focus-scoping. Dogfood with two live workspaces.
+3. **`pane.close` RPC** — additive; mirror `surface.close`.
+4. Leave `browser.*` B-bucket as-is unless a concrete report lands (MCP-gated).
+
+Each gets a `workspaceRouting` / dogfood regression like #236's.

--- a/scripts/issue-236-pane-split-workspace-dogfood.mjs
+++ b/scripts/issue-236-pane-split-workspace-dogfood.mjs
@@ -1,0 +1,192 @@
+/*
+ * Live dogfood — issue #236: pane.split must honor an explicit workspaceId.
+ *
+ * Spawns an isolated packaged wmux (out/wmux-win32-x64/wmux.exe) with
+ * WMUX_DATA_SUFFIX isolation, then over the pure main-pipe RPC (clientName
+ * omitted → grandfather path, exactly how an external multi-agent CLI drives
+ * the daemon) verifies the root fix:
+ *
+ *   - With ws B globally active, `pane.split {workspaceId: wsA}` lands the new
+ *     pane in the BACKGROUND ws A (not the on-screen ws B) — the core bug.
+ *   - The split returns the new paneId, and that background pane gets a LIVE
+ *     PTY surface immediately (eager-spawn P0 closed).
+ *   - ws B is untouched and global focus does NOT move (no hijack).
+ *   - An explicit-but-unknown workspaceId is REJECTED (fail-closed), with no
+ *     tree mutation — never a silent active-ws fallback.
+ *   - Omitting workspaceId still splits the ACTIVE ws (human-path back-compat).
+ *
+ * Run (PowerShell): npm run package; node scripts/issue-236-pane-split-workspace-dogfood.mjs
+ */
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '..');
+const APP_EXE = path.join(REPO_ROOT, 'out', 'wmux-win32-x64', 'wmux.exe');
+const USERNAME = os.userInfo().username || 'default';
+
+const results = [];
+let app = null;
+function check(name, ok, detail = '') {
+  results.push({ name, ok: !!ok });
+  console.log(`  [${ok ? 'PASS' : 'FAIL'}] ${name}${detail ? ` — ${detail}` : ''}`);
+  return ok;
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+if (process.platform !== 'win32') { console.log('issue-236-dogfood: SKIP (win32-only)'); process.exit(0); }
+if (!fs.existsSync(APP_EXE)) { console.error(`packaged exe not found: ${APP_EXE} — run \`npm run package\` first`); process.exit(2); }
+
+const suffix = `-split236dog${process.pid}`;
+const home = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-split236-'));
+const env = {
+  ...process.env,
+  USERPROFILE: home, HOME: home,
+  APPDATA: path.join(home, 'AppData', 'Roaming'),
+  LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
+  WMUX_DATA_SUFFIX: suffix, WMUX_NO_DIALOG: '1',
+};
+delete env.HOMEDRIVE; delete env.HOMEPATH;
+fs.mkdirSync(env.APPDATA, { recursive: true });
+fs.mkdirSync(env.LOCALAPPDATA, { recursive: true });
+const userDataDir = path.join(env.APPDATA, `wmux${suffix}`);
+fs.mkdirSync(userDataDir, { recursive: true });
+fs.writeFileSync(path.join(userDataDir, '.first-run'), new Date().toISOString(), 'utf8');
+
+const mainPipe = `\\\\.\\pipe\\wmux${suffix}-${USERNAME}`;
+const authTokenPath = path.join(home, `.wmux${suffix}-auth-token`);
+
+function readMainToken() { try { return fs.readFileSync(authTokenPath, 'utf8').trim() || null; } catch { return null; } }
+
+function rpcCall(method, params = {}, { timeoutMs = 8000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const sock = net.createConnection(mainPipe);
+    let buf = ''; let settled = false; const id = randomUUID();
+    const finish = (fn) => { if (settled) return; settled = true; clearTimeout(timer); try { sock.destroy(); } catch { /* */ } fn(); };
+    const timer = setTimeout(() => finish(() => reject(new Error(`rpc timeout: ${method}`))), timeoutMs);
+    sock.setEncoding('utf8');
+    sock.once('connect', () => sock.write(JSON.stringify({ id, method, params, token: TOKEN }) + '\n'));
+    sock.once('error', (e) => finish(() => reject(e)));
+    sock.on('data', (chunk) => {
+      buf += chunk; let nl;
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl).trim(); buf = buf.slice(nl + 1);
+        if (!line) continue;
+        let msg; try { msg = JSON.parse(line); } catch { continue; }
+        if (msg.id !== id) continue;
+        finish(() => resolve(msg));
+        return;
+      }
+    });
+  });
+}
+const rpcResult = async (m, p, o) => { const r = await rpcCall(m, p, o); if (r && r.ok === false) throw new Error(typeof r.error === 'string' ? r.error : JSON.stringify(r.error)); return r?.result ?? r; };
+
+function spawnApp() {
+  const proc = spawn(APP_EXE, [], { cwd: REPO_ROOT, env, stdio: ['ignore', 'pipe', 'pipe'], detached: false });
+  proc.stdout.on('data', () => {}); proc.stderr.on('data', () => {});
+  return proc;
+}
+async function waitMainToken(timeoutMs) {
+  const dl = Date.now() + timeoutMs;
+  while (Date.now() < dl) { const t = readMainToken(); if (t) return t; await sleep(120); }
+  return null;
+}
+async function waitRendererReady(timeoutMs) {
+  const dl = Date.now() + timeoutMs; let last = '';
+  while (Date.now() < dl) {
+    try { const r = await rpcCall('workspace.list', {}, { timeoutMs: 4000 }); if (r && Array.isArray(r.result)) return r.result; }
+    catch (e) { last = e.message; }
+    await sleep(250);
+  }
+  throw new Error(`renderer not ready (${last})`);
+}
+const paneCount = async (wsId) => ((await rpcResult('pane.list', { workspaceId: wsId })).panes ?? []).length;
+
+let TOKEN = null;
+
+async function main() {
+  console.log(`issue-236-pane-split-workspace-dogfood — exe=${APP_EXE}`);
+  app = spawnApp();
+  TOKEN = await waitMainToken(20000);
+  if (!TOKEN) throw new Error('main token never appeared');
+  const wss = await waitRendererReady(30000);
+  check('renderer ready + default workspace exists', wss.length >= 1, `workspaces=${wss.length}`);
+  const wsA = wss[0].id; // default ws — the BACKGROUND split target
+
+  // Create ws B and make it the globally-active (on-screen) workspace, so wsA
+  // is a background workspace exactly like another agent's session.
+  const wsB = (await rpcResult('workspace.new', { name: 'focus-holder-B' })).id;
+  await sleep(700);
+  await rpcResult('workspace.focus', { id: wsB }).catch(() => {});
+  await sleep(400);
+  const curBefore = await rpcResult('workspace.current', {});
+  check('ws B is the globally-active workspace before the split', curBefore?.id === wsB, `current=${curBefore?.id}`);
+
+  const aBefore = await paneCount(wsA);
+  const bBefore = await paneCount(wsB);
+
+  // ── THE TEST: split ws A (background) while ws B is active ──────────────
+  const split = await rpcCall('pane.split', { direction: 'vertical', workspaceId: wsA });
+  const sres = split.result ?? split;
+  check('pane.split returned ok + a new paneId',
+    sres?.ok === true && typeof sres.paneId === 'string' && sres.paneId.length > 0,
+    JSON.stringify(sres));
+  const newPaneId = sres?.paneId;
+  await sleep(2000); // allow the eager-spawn PTY create to settle
+
+  const aPanes = (await rpcResult('pane.list', { workspaceId: wsA })).panes ?? [];
+  check('★ ws A gained exactly one pane (split landed in the TARGET ws, not the active one)',
+    aPanes.length === aBefore + 1, `before=${aBefore} after=${aPanes.length}`);
+  check('★ the returned paneId exists in ws A', !!aPanes.find((p) => p.id === newPaneId), `paneId=${newPaneId}`);
+
+  // The background pane has a live PTY surface (3a eager-spawn).
+  const aSurfaces = (await rpcResult('surface.list', { workspaceId: wsA }))
+    .filter((s) => s.surfaceType !== 'browser' && s.ptyId);
+  const newSurface = aSurfaces.find((s) => s.paneId === newPaneId);
+  check('★ the new background pane has a spawned PTY surface (eager-spawn closed the P0)',
+    !!newSurface?.ptyId, `surface=${JSON.stringify(newSurface ?? null)}`);
+
+  // ws B untouched + global focus did not move.
+  const bAfter = await paneCount(wsB);
+  check('★ ws B pane count unchanged (no collateral split into the active ws)',
+    bAfter === bBefore, `before=${bBefore} after=${bAfter}`);
+  const curAfter = await rpcResult('workspace.current', {});
+  check('★ global focus still on ws B after the background split (no focus hijack)',
+    curAfter?.id === wsB, `current=${curAfter?.id}`);
+
+  // ── Fail-closed: unknown workspaceId is rejected, no tree mutation ──────
+  const aPreBad = await paneCount(wsA);
+  const bad = await rpcCall('pane.split', { direction: 'vertical', workspaceId: 'ws-does-not-exist' });
+  const bres = bad.result ?? bad;
+  check('★ an explicit unknown workspaceId is REJECTED (fail-closed, not active-ws fallback)',
+    typeof bres?.error === 'string' && /not found/.test(bres.error), JSON.stringify(bres));
+  const aPostBad = await paneCount(wsA);
+  check('the rejected split did not mutate any workspace tree', aPostBad === aPreBad, `pre=${aPreBad} post=${aPostBad}`);
+
+  // ── Back-compat: no workspaceId → splits the ACTIVE ws (B) ──────────────
+  const bPre = await paneCount(wsB);
+  const compat = await rpcCall('pane.split', { direction: 'horizontal' }); // omit workspaceId
+  const cres = compat.result ?? compat;
+  check('no-workspaceId pane.split still succeeds', cres?.ok === true, JSON.stringify(cres));
+  await sleep(1500);
+  const bPost = await paneCount(wsB);
+  check('★ no-workspaceId split targets the ACTIVE ws (B) — back-compat preserved',
+    bPost === bPre + 1, `pre=${bPre} post=${bPost}`);
+}
+
+main()
+  .catch((e) => { console.error('FATAL', e); check('harness completed without fatal error', false, e.message); })
+  .finally(async () => {
+    try { await rpcResult('daemon.shutdown', {}).catch(() => {}); } catch { /* */ }
+    try { if (app) app.kill(); } catch { /* */ }
+    await sleep(800);
+    const passed = results.filter((r) => r.ok).length;
+    console.log(`\nissue-236-pane-split-workspace-dogfood: ${passed}/${results.length} passed`);
+    process.exit(passed === results.length && results.length > 0 ? 0 : 1);
+  });

--- a/src/main/pipe/handlers/__tests__/pane.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/pane.rpc.test.ts
@@ -1424,3 +1424,57 @@ describe('pane.rpc — pane.list supervision join (X8)', () => {
     }
   });
 });
+
+describe('pane.rpc — pane.split workspaceId forwarding (#236)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sendToRendererMock.mockResolvedValue({ ok: true, paneId: 'pane-new' });
+  });
+
+  it('forwards an explicit workspaceId to the renderer', async () => {
+    const router = register();
+    const res = await router.dispatch({
+      id: 's1',
+      method: 'pane.split',
+      params: { direction: 'vertical', workspaceId: 'ws-bg' },
+    });
+    expect(res.ok).toBe(true);
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      'pane.split',
+      { direction: 'vertical', workspaceId: 'ws-bg' },
+    );
+  });
+
+  it('omits workspaceId from the forwarded payload when the caller did not provide it', async () => {
+    const router = register();
+    await router.dispatch({ id: 's2', method: 'pane.split', params: { direction: 'horizontal' } });
+    const payload = sendToRendererMock.mock.calls[0][2] as Record<string, unknown>;
+    expect(payload).toEqual({ direction: 'horizontal' });
+    expect('workspaceId' in payload).toBe(false);
+  });
+
+  it('rejects a non-string workspaceId before any renderer call', async () => {
+    const router = register();
+    const res = await router.dispatch({
+      id: 's3',
+      method: 'pane.split',
+      params: { direction: 'vertical', workspaceId: 42 as unknown as string },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/string/);
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+  });
+
+  it('still rejects an invalid direction (regression)', async () => {
+    const router = register();
+    const res = await router.dispatch({
+      id: 's4',
+      method: 'pane.split',
+      params: { direction: 'sideways' },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/horizontal.*vertical/);
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/pipe/handlers/pane.rpc.ts
+++ b/src/main/pipe/handlers/pane.rpc.ts
@@ -199,7 +199,21 @@ export function registerPaneRpc(
         new Error('pane.split: "direction" must be "horizontal" or "vertical"'),
       );
     }
-    return sendToRenderer(getWindow, 'pane.split', { direction });
+    // #236: forward an explicit workspaceId so an external multi-agent caller
+    // can split inside ITS OWN workspace rather than whichever workspace the
+    // user is currently viewing. Omitted → the renderer falls back to the
+    // active workspace (unchanged human-keybind / first-party CLI behavior).
+    // Mirrors the pane.search forwarding guard above.
+    const workspaceId = params['workspaceId'];
+    if (workspaceId !== undefined && typeof workspaceId !== 'string') {
+      return Promise.reject(
+        new Error('pane.split: "workspaceId" must be a string if provided'),
+      );
+    }
+    return sendToRenderer(getWindow, 'pane.split', {
+      direction,
+      ...(workspaceId !== undefined && { workspaceId }),
+    });
   });
 
   /**

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -39,7 +39,7 @@ import { isFileDrag } from '../../../shared/dragDrop';
 import { terminalRegistry } from '../../hooks/useTerminal';
 import { resolvePtyIdsToClear } from '../../hooks/reconcileWithReQuery';
 import { createLateReconcileOnConnect } from '../../hooks/lateReconcileOnConnect';
-import { resolveStartupCwd, withDefaultShell, withWorkspaceProfile } from '../../utils/ptyCreateOptions';
+import { resolveStartupCwd, shellDisplayName, withDefaultShell, withWorkspaceProfile } from '../../utils/ptyCreateOptions';
 import ProjectConfigDialog from '../Project/ProjectConfigDialog';
 import { probeProjectConfig, maybeAutoApplyProjectLayout, workspaceProbeCwd } from '../../utils/projectConfigProbe';
 import {
@@ -95,21 +95,6 @@ import AgentToolbar from '../AgentToolbar/AgentToolbar';
  * that answered pty.list in 6–9s under load still lost the race and the
  * startup catch wiped every live session via clearAllPtyState().
  */
-
-/** Map shell executable path to a human-readable display name. */
-function shellDisplayName(shellPath: string): string {
-  const base = shellPath.replace(/\\/g, '/').split('/').pop()?.toLowerCase() || '';
-  if (base.includes('pwsh')) return 'PowerShell 7';
-  if (base.includes('powershell')) return 'PowerShell';
-  if (base.includes('bash')) return 'Bash';
-  if (base.includes('wsl')) return 'WSL';
-  if (base.includes('cmd')) return 'CMD';
-  if (base.includes('zsh')) return 'Zsh';
-  if (base.includes('fish')) return 'Fish';
-  // Strip extension and capitalize
-  const name = base.replace(/\.exe$/i, '');
-  return name.charAt(0).toUpperCase() + name.slice(1);
-}
 
 /** Collect all terminal surfaces from a pane tree */
 function collectTerminalSurfaces(pane: Pane): Surface[] {

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useStore } from '../stores';
-import { withDefaultShell, withWorkspaceProfile } from '../utils/ptyCreateOptions';
+import { resolveStartupCwd, shellDisplayName, withDefaultShell, withWorkspaceProfile } from '../utils/ptyCreateOptions';
 import type { Pane, PaneLeaf, Surface, Workspace } from '../../shared/types';
 import { validateMessage } from '../../shared/types';
 import type { Message, Part, TaskState, Artifact, AgentSkill, Task } from '../../shared/types';
@@ -604,13 +604,111 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
   }
 
   if (method === 'pane.split') {
-    const ws = store.workspaces.find((w) => w.id === store.activeWorkspaceId);
-    if (!ws) return { error: 'no active workspace' };
+    // ─── Workspace scope + fail-closed (#236, mirrors pane.search) ───────
+    // An external multi-agent caller passes `workspaceId` so the split lands
+    // in the CALLING workspace, not whichever the user is currently viewing.
+    // The human keybind / first-party CLI omit it → active workspace.
+    const requestedWsId =
+      typeof params.workspaceId === 'string' && params.workspaceId.length > 0
+        ? params.workspaceId
+        : store.activeWorkspaceId;
+    const ws = store.workspaces.find((w) => w.id === requestedWsId);
+    if (!ws) {
+      // Fail CLOSED on an explicit-but-unknown workspaceId — never silently
+      // fall back to the active ws (that would split the wrong agent's
+      // workspace, the exact #236 bug). Unlike browser.open this method has no
+      // requireWorkspaceId() MCP guard upstream, so the check lives here.
+      if (typeof params.workspaceId === 'string' && params.workspaceId.length > 0) {
+        return { error: `pane.split: workspace "${requestedWsId}" not found` };
+      }
+      return { error: 'pane.split: no active workspace' };
+    }
+
     const direction =
       params.direction === 'vertical' ? 'vertical' : 'horizontal';
-    const ok = store.splitPane(ws.activePaneId, direction);
-    if (!ok) return { error: 'pane cap reached (max 20 per workspace)' };
-    return { ok: true };
+
+    // Snapshot this workspace's empty leaves BEFORE the split so the freshly
+    // created (always-empty) leaf can be identified afterwards — without
+    // widening splitPane's boolean return, which would ripple to ~30 keybind /
+    // palette / test callsites.
+    const emptyBefore = new Set(
+      findLeafPanes(ws.rootPane).filter((l) => l.surfaces.length === 0).map((l) => l.id),
+    );
+
+    const ok = store.splitPane(ws.activePaneId, direction, ws.id);
+    if (!ok) return { error: 'pane.split: pane cap reached (max 20 per workspace)' };
+
+    // Locate the new leaf: the one empty leaf that was not empty-listed before.
+    const afterSplit = useStore.getState();
+    const splitWs = afterSplit.workspaces.find((w) => w.id === ws.id);
+    if (!splitWs) return { ok: true }; // ws vanished in the async gap; split still happened
+    const newLeaf = findLeafPanes(splitWs.rootPane).find(
+      (l) => l.surfaces.length === 0 && !emptyBefore.has(l.id),
+    );
+    const newPaneId = newLeaf?.id;
+
+    // Active-ws split: the AppLayout empty-leaf funnel owns PTY creation (it
+    // carries the full startup-cwd / project-seed / X8-supervision chain), so
+    // we do NOT duplicate it here. The ptyId is only known after that async
+    // create, hence it is omitted from the return for the active-ws path.
+    if (splitWs.id === afterSplit.activeWorkspaceId) {
+      return { ok: true, paneId: newPaneId };
+    }
+
+    // ─── Background-ws split: eager-spawn the PTY (#236 P0) ──────────────
+    // The funnel is gated on the ACTIVE workspace (AppLayout effect dep =
+    // activeWorkspace.id), so a pane split into a background ws would stay
+    // surface-less — no terminal — until the user activates that workspace. An
+    // external agent that splits-then-sends needs a live PTY immediately, so
+    // spawn it here, mirroring surface.new's create + orphan-guard + adopt.
+    if (!newPaneId) return { ok: true }; // couldn't locate the new leaf; tree split still ok
+
+    // Same cwd precedence the funnel applies (split-inherited > profile
+    // startupCwd > global startupDirectory > main-side homedir). Consume the
+    // seed so a later activation's funnel can't double-create on this pane.
+    const startupCwd = resolveStartupCwd({
+      splitSeed: afterSplit.splitCwdSeed[newPaneId],
+      splitInheritsCwd: afterSplit.splitInheritsCwd,
+      profile: splitWs.profile,
+      startupDirectory: afterSplit.startupDirectory,
+    });
+    if (afterSplit.splitCwdSeed[newPaneId]) afterSplit.clearSplitCwdSeed(newPaneId);
+
+    let created: { id: string; shell?: string; cwd?: string };
+    try {
+      created = await window.electronAPI.pty.create(
+        withWorkspaceProfile(
+          withDefaultShell(
+            { workspaceId: splitWs.id, cwd: startupCwd || undefined },
+            useStore.getState().defaultShell,
+          ),
+          splitWs.profile,
+        ),
+      );
+    } catch (err) {
+      // The tree split already succeeded and is valid — surface the PTY failure
+      // but do NOT roll back (the agent asked for the pane; the funnel will
+      // backfill it if the ws is later activated).
+      return {
+        ok: true,
+        paneId: newPaneId,
+        ptyWarning: `pane.split: PTY create failed — ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    // Orphan guard (mirror surface.new / funnel): adopt the PTY only if the
+    // pane still exists AND is still empty. If the user switched to the ws
+    // mid-create and the funnel already filled it, dispose ours.
+    const afterPty = useStore.getState();
+    const freshWs = afterPty.workspaces.find((w) => w.id === splitWs.id);
+    const livePane = freshWs ? findPaneById(freshWs.rootPane, newPaneId) : null;
+    if (!livePane || livePane.type !== 'leaf' || livePane.surfaces.length > 0) {
+      try { await window.electronAPI.pty.dispose(created.id); } catch { /* best-effort */ }
+      return { ok: true, paneId: newPaneId };
+    }
+    const shellName = created.shell ? shellDisplayName(created.shell) : 'Terminal';
+    afterPty.addSurface(newPaneId, created.id, shellName, created.cwd || '', splitWs.id);
+    return { ok: true, paneId: newPaneId, ptyId: created.id };
   }
 
   if (method === 'pane.resolveActiveLeaf') {

--- a/src/renderer/stores/slices/__tests__/paneSlice.events.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneSlice.events.test.ts
@@ -61,6 +61,21 @@ describe('paneSlice — event publication', () => {
       expect(focused?.args[0]).toBe(wsId);
       expect(focused?.args[2]).toBe(rootPaneId);
     });
+
+    it('background-ws split emits pane.created but NOT pane.focused (#236 focus-scoping)', () => {
+      const ws2 = createWorkspace('Background');
+      store.setState((s) => { s.workspaces.push(ws2); });
+      publishCalls.length = 0;
+
+      // ws1 (rootPaneId) is active; split ws2 explicitly via its workspaceId.
+      store.getState().splitPane(ws2.rootPane.id, 'horizontal', ws2.id);
+
+      const created = publishCalls.filter((c) => c.fn === 'pane.created');
+      const focused = publishCalls.filter((c) => c.fn === 'pane.focused');
+      expect(created).toHaveLength(1);
+      expect(created[0].args[0]).toBe(ws2.id); // pane.created scoped to ws2
+      expect(focused).toHaveLength(0);          // no focus event for a background pane
+    });
   });
 
   describe('closePane', () => {

--- a/src/renderer/stores/slices/__tests__/paneSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneSlice.test.ts
@@ -187,6 +187,73 @@ describe('PaneSlice', () => {
     });
   });
 
+  describe('splitPane — background workspace targeting (#236)', () => {
+    // ws1 stays active; ws2 is split DIRECTLY via the workspaceId arg without
+    // ever being activated — exactly what the pane.split RPC does for an
+    // external multi-agent caller whose workspace isn't the one on screen.
+    function twoWorkspaces() {
+      const ws1 = getActiveWorkspace(store);
+      const ws2 = createWorkspace('Background');
+      store.setState((s) => { s.workspaces.push(ws2); });
+      return { ws1, ws2 };
+    }
+
+    it('splits the explicit background workspace while another ws stays active', () => {
+      const { ws1, ws2 } = twoWorkspaces();
+      const ok = store.getState().splitPane(ws2.rootPane.id, 'horizontal', ws2.id);
+      expect(ok).toBe(true);
+
+      const ws2After = store.getState().workspaces.find((w) => w.id === ws2.id)!;
+      expect(ws2After.rootPane.type).toBe('branch'); // ws2 got the split
+      const ws1After = store.getState().workspaces.find((w) => w.id === ws1.id)!;
+      expect(ws1After.rootPane.type).toBe('leaf');    // ws1 untouched
+      expect(store.getState().activeWorkspaceId).toBe(ws1.id); // global focus didn't move
+    });
+
+    it('does NOT change the active ws activePaneId when splitting a background ws', () => {
+      const { ws1, ws2 } = twoWorkspaces();
+      const activeBefore = ws1.activePaneId;
+      store.getState().splitPane(ws2.rootPane.id, 'horizontal', ws2.id);
+      const ws1After = store.getState().workspaces.find((w) => w.id === ws1.id)!;
+      expect(ws1After.activePaneId).toBe(activeBefore);
+    });
+
+    it('leaves the background ws own activePaneId untouched (focus-scoping); new empty leaf is locatable', () => {
+      const { ws2 } = twoWorkspaces();
+      const ws2ActiveBefore = ws2.activePaneId;
+      store.getState().splitPane(ws2.rootPane.id, 'horizontal', ws2.id);
+      const ws2After = store.getState().workspaces.find((w) => w.id === ws2.id)!;
+      // The RPC handler locates the fresh empty leaf structurally, so the slice
+      // does not need to (and must not) move the background ws's selection.
+      expect(ws2After.activePaneId).toBe(ws2ActiveBefore);
+      const emptyLeaves = getLeafPanes(ws2After.rootPane).filter((l) => l.surfaces.length === 0);
+      expect(emptyLeaves.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('still records the splitCwdSeed for a background split (the PTY funnel / eager-spawn needs it)', () => {
+      const { ws2 } = twoWorkspaces();
+      store.setState((s) => {
+        const w = s.workspaces.find((x) => x.id === ws2.id)!;
+        if (w.rootPane.type !== 'leaf') throw new Error('expected leaf');
+        w.rootPane.surfaces.push({ id: 's-bg', ptyId: 'pty-bg', title: 't', shell: 'pwsh', cwd: 'D:\\bg' });
+        w.rootPane.activeSurfaceId = 's-bg';
+      });
+      store.getState().splitPane(ws2.rootPane.id, 'horizontal', ws2.id);
+      const ws2After = store.getState().workspaces.find((w) => w.id === ws2.id)!;
+      const newLeaf = getLeafPanes(ws2After.rootPane).find((l) => l.surfaces.length === 0)!;
+      expect(store.getState().splitCwdSeed[newLeaf.id]).toBe('D:\\bg');
+    });
+
+    it('no-workspaceId split still targets the active ws (human-path regression guard)', () => {
+      const { ws1, ws2 } = twoWorkspaces();
+      store.getState().splitPane(ws1.activePaneId, 'horizontal'); // omit workspaceId
+      const ws1After = store.getState().workspaces.find((w) => w.id === ws1.id)!;
+      const ws2After = store.getState().workspaces.find((w) => w.id === ws2.id)!;
+      expect(ws1After.rootPane.type).toBe('branch'); // active ws split
+      expect(ws2After.rootPane.type).toBe('leaf');    // background untouched
+    });
+  });
+
   describe('closePane', () => {
     it('closes a pane in a non-active workspace via the workspaceId parameter', () => {
       const ws1 = getActiveWorkspace(store);

--- a/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
@@ -24,6 +24,37 @@ function createHarness() {
   return { state, slice };
 }
 
+describe('surfaceSlice.addSurface — workspace targeting (#236)', () => {
+  it('lands the surface in a background workspace when workspaceId is given', () => {
+    const { state, slice } = createHarness();
+    const ws1 = state.workspaces[0];
+    const ws2 = createWorkspace('Background');
+    state.workspaces.push(ws2);
+
+    slice.addSurface(ws2.rootPane.id, 'pty-bg', 'pwsh', 'D:\\bg', ws2.id);
+
+    const ws2Pane = state.workspaces.find((w) => w.id === ws2.id)!.rootPane;
+    if (ws2Pane.type !== 'leaf') throw new Error('expected leaf');
+    expect(ws2Pane.surfaces).toHaveLength(1);
+    expect(ws2Pane.surfaces[0].ptyId).toBe('pty-bg');
+
+    // ws1 (the active ws) must NOT receive the surface.
+    const ws1Pane = ws1.rootPane;
+    if (ws1Pane.type !== 'leaf') throw new Error('expected leaf');
+    expect(ws1Pane.surfaces).toHaveLength(0);
+    expect(state.activeWorkspaceId).toBe(ws1.id);
+  });
+
+  it('defaults to the active workspace when workspaceId is omitted (back-compat)', () => {
+    const { state, slice } = createHarness();
+    slice.addSurface(state.workspaces[0].rootPane.id, 'pty-1', 'pwsh', 'C:\\a');
+    const pane = state.workspaces[0].rootPane;
+    if (pane.type !== 'leaf') throw new Error('expected leaf');
+    expect(pane.surfaces).toHaveLength(1);
+    expect(pane.surfaces[0].ptyId).toBe('pty-1');
+  });
+});
+
 describe('surfaceSlice.updateSurfaceCwd', () => {
   it('updates the cwd of the surface bound to a ptyId', () => {
     const { state, slice } = createHarness();

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -189,7 +189,7 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
   }),
 
   splitPane: (paneId, direction, workspaceId, position = 'after') => {
-    let event: { wsId: string; newPaneId: string; branchId: string; previousActiveId: string } | null = null;
+    let event: { wsId: string; newPaneId: string; branchId: string; previousActiveId: string; focusMoved: boolean } | null = null;
     let blockedAtCap = false;
     let created = false;
     set((state: StoreState) => {
@@ -245,13 +245,26 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
       }
 
       const previousActiveId = ws.activePaneId;
-      ws.activePaneId = newPane.id;
+      // Focus-scoping (#236): only move the active selection + emit pane.focused
+      // when the split targets the GLOBALLY-active workspace. A background-ws
+      // split (an external agent owns ws B while the user looks at ws A) must
+      // NOT hijack ws A's focus or fire a focus event for a pane the user can't
+      // see. The pane.created emit and the splitCwdSeed write below stay
+      // UNCONDITIONAL — the pane really was created, and its PTY (the AppLayout
+      // funnel, or the eager-spawn in the pane.split RPC handler) needs the
+      // inherited cwd regardless of which workspace is active.
+      const isActiveWsSplit = targetWsId === state.activeWorkspaceId;
+      if (isActiveWsSplit) {
+        ws.activePaneId = newPane.id;
 
-      // Issue #182: splitting while a pane in this workspace is zoomed must
-      // un-zoom (tmux behavior) — otherwise the freshly created sibling would
-      // be born hidden behind the zoom and look like the split did nothing.
-      if (state.zoomedPaneId !== null && findPane(ws.rootPane, state.zoomedPaneId)) {
-        state.zoomedPaneId = null;
+        // Issue #182: splitting while a pane in this workspace is zoomed must
+        // un-zoom (tmux behavior) — otherwise the freshly created sibling would
+        // be born hidden behind the zoom and look like the split did nothing.
+        // zoomedPaneId is a single global view-state field that only ever holds
+        // a pane in the active workspace, so gating it here is correct.
+        if (state.zoomedPaneId !== null && findPane(ws.rootPane, state.zoomedPaneId)) {
+          state.zoomedPaneId = null;
+        }
       }
 
       if (inheritedCwd) state.splitCwdSeed[newPane.id] = inheritedCwd;
@@ -261,12 +274,17 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
         newPaneId: newPane.id,
         branchId: branch.id,
         previousActiveId,
+        focusMoved: isActiveWsSplit,
       };
     });
     if (event) {
-      const e = event as { wsId: string; newPaneId: string; branchId: string; previousActiveId: string };
+      const e = event as { wsId: string; newPaneId: string; branchId: string; previousActiveId: string; focusMoved: boolean };
       publishPaneCreated(e.wsId, e.newPaneId, e.branchId);
-      if (e.previousActiveId !== e.newPaneId) {
+      // pane.focused only when the active selection actually moved (active-ws
+      // split). A background split leaves the active ws's activePaneId
+      // untouched, so emitting a focus event would misreport the user's current
+      // pane to external EventBus pollers.
+      if (e.focusMoved && e.previousActiveId !== e.newPaneId) {
         publishPaneFocused(e.wsId, e.newPaneId, e.previousActiveId);
       }
     }

--- a/src/renderer/stores/slices/surfaceSlice.ts
+++ b/src/renderer/stores/slices/surfaceSlice.ts
@@ -5,7 +5,11 @@ import { createSurface, generateId } from '../../../shared/types';
 import { isSafeBrowserUrl } from '../../utils/browserPane';
 
 export interface SurfaceSlice {
-  addSurface: (paneId: string, ptyId: string, shell: string, cwd: string) => void;
+  /** Add a terminal surface to a pane. `workspaceId` lets RPC / eager-spawn
+   * callers (e.g. the pane.split background-workspace path, #236) target a
+   * non-active workspace — defaults to the active one, so existing positional
+   * callers are unchanged. */
+  addSurface: (paneId: string, ptyId: string, shell: string, cwd: string, workspaceId?: string) => void;
   addBrowserSurface: (paneId: string, url?: string, partition?: string, workspaceId?: string) => void;
   addEditorSurface: (paneId: string, filePath: string) => void;
   /** Close a surface tab. `workspaceId` lets RPC/CLI callers target a
@@ -55,8 +59,9 @@ function findLeafPane(root: Pane, id: string): PaneLeaf | null {
 }
 
 export const createSurfaceSlice: StateCreator<StoreState, [['zustand/immer', never]], [], SurfaceSlice> = (set) => ({
-  addSurface: (paneId, ptyId, shell, cwd) => set((state: StoreState) => {
-    const ws = state.workspaces.find((w: Workspace) => w.id === state.activeWorkspaceId);
+  addSurface: (paneId, ptyId, shell, cwd, workspaceId) => set((state: StoreState) => {
+    const targetWsId = workspaceId || state.activeWorkspaceId;
+    const ws = state.workspaces.find((w: Workspace) => w.id === targetWsId);
     if (!ws) return;
     const pane = findLeafPane(ws.rootPane, paneId);
     if (!pane) return;

--- a/src/renderer/utils/ptyCreateOptions.ts
+++ b/src/renderer/utils/ptyCreateOptions.ts
@@ -98,3 +98,24 @@ export function resolveStartupCwd(args: {
   if (args.startupDirectory && args.startupDirectory.trim().length > 0) return args.startupDirectory.trim();
   return undefined;
 }
+
+/**
+ * Human-readable shell label derived from an executable path
+ * (e.g. `C:\\…\\pwsh.exe` → "PowerShell 7"). Used for the surface tab title
+ * when a PTY is adopted. Lifted out of AppLayout so the eager-spawn path in
+ * the `pane.split` RPC handler (background-workspace split, #236) produces the
+ * exact same labels as the empty-leaf PTY funnel.
+ */
+export function shellDisplayName(shellPath: string): string {
+  const base = shellPath.replace(/\\/g, '/').split('/').pop()?.toLowerCase() || '';
+  if (base.includes('pwsh')) return 'PowerShell 7';
+  if (base.includes('powershell')) return 'PowerShell';
+  if (base.includes('bash')) return 'Bash';
+  if (base.includes('wsl')) return 'WSL';
+  if (base.includes('cmd')) return 'CMD';
+  if (base.includes('zsh')) return 'Zsh';
+  if (base.includes('fish')) return 'Fish';
+  // Strip extension and capitalize
+  const name = base.replace(/\.exe$/i, '');
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}


### PR DESCRIPTION
## Problem

`pane.split` over the daemon RPC ignored an explicit `workspaceId` and always split the **globally-active** workspace. For external multi-agent tooling — several agents each owning a workspace (the README multi-agent use case) — there was no way to "split a pane in *my* workspace": a split landed in whichever workspace had focus, i.e. another agent's session. The reporter (@zhenzoo) hit this live — a worker pane landed in `bot-arch` instead of `bot-default` and disrupted a running worker. Same `activeWorkspaceId`-fallback class that #96/#190 fixed for browser surfaces, now for panes.

## Root fix (not just threading the param)

An expert review found the naive "thread `workspaceId`" fix incomplete on three axes, all addressed here:

1. **Fail-closed addressing** — the `useRpcBridge` `pane.split` handler reads `params.workspaceId` and **errors on an explicit-but-unknown id** instead of silently falling back to the active ws (this method has no `requireWorkspaceId` MCP guard upstream, unlike `browser.open`). It returns the new `paneId` (and `ptyId` for the eager-spawn path) so a caller can address the pane it just created.
2. **Focus-scoping** — `paneSlice.splitPane` only moves `activePaneId` / emits `pane.focused` when the split targets the active workspace, so a background-ws split never hijacks another agent's focus. `pane.created` and the `splitCwdSeed` write stay unconditional.
3. **Background eager-spawn (the hidden P0)** — the AppLayout empty-leaf PTY funnel is gated on the *active* workspace, so a pane split into a background ws would stay **surface-less (no terminal)** until that ws is activated — useless for an agent that splits-then-sends. The handler now spawns the PTY eagerly (mirroring `mcp.claimWorkspace`), which required an optional `workspaceId` on `addSurface`. cwd precedence matches the funnel via `resolveStartupCwd`.

Also: `pane.rpc.ts` now forwards `workspaceId` (it was dropped main-side too), and `shellDisplayName` was lifted into `ptyCreateOptions` so the eager-spawn path labels surfaces identically to the funnel.

## Verification

- **Unit** — background placement, focus-scoping (`pane.created` without `pane.focused`), fail-closed, back-compat, `addSurface` workspace targeting, `pane.rpc` forwarding. Full suite green (tsc + lint clean).
- **Live multi-agent dogfood 12/12** (`scripts/issue-236-pane-split-workspace-dogfood.mjs`): with ws B active, `pane.split {workspaceId: wsA}` lands the new pane in background ws A **with a live PTY surface**, ws B is untouched, global focus does not move, an unknown `workspaceId` is rejected, and a no-`workspaceId` split still targets the active ws.

## Scope

Sibling handlers (`pane.focus` / `surface.new` / `surface.focus`) share the same defect but are **tracked separately** (`plans/issue-236-followup-rpc-workspace-scoping-sweep.md`) — their focus semantics are a UX decision that needs its own dogfood. This keeps the fix's blast radius tight.

Backward compatible: omitting `workspaceId` preserves today's active-workspace behavior (human keybind, first-party CLI).

Closes #236.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pane splitting now supports targeting non-active workspaces with optional workspace parameter
  * Surface operations can be scoped to specific workspaces while maintaining correct workspace focus
  * Background workspace pane operations no longer change active workspace state

* **Tests**
  * Added test coverage for workspace-scoped pane splitting and surface operations

* **Documentation**
  * Added planning documentation for workspace-scoping follow-up work

<!-- end of auto-generated comment: release notes by coderabbit.ai -->