### PR TITLE
feat(a2a): same-workspace multi-agent messaging + instance-suffix propagation

### DIFF
--- a/scripts/same-ws-a2a-dogfood.mjs
+++ b/scripts/same-ws-a2a-dogfood.mjs
@@ -1,0 +1,222 @@
+/*
+ * Live dogfood — same-workspace multi-agent A2A (Track 1).
+ *
+ * Proves the headline fix: two agent panes in the SAME workspace can now address
+ * each other via a2a_task_send (previously hard-rejected "cannot send to
+ * yourself"), while a true self-send (own pane) and an ambiguous no-address send
+ * are still rejected, and the cross-workspace fail-closed boundary is unchanged.
+ *
+ * Single ISOLATED packaged instance (out/wmux-win32-x64/wmux.exe + a unique
+ * WMUX_DATA_SUFFIX so it never touches the user's real wmux). Drives the pure
+ * main-pipe RPC (clientName omitted → grandfather), passing senderPtyId verbatim
+ * the way the MCP server would after a verified PID-map hit.
+ *
+ * Verifies over the main-pipe RPC:
+ *   - ws1 pane A → ws1 pane B (sibling surface_id + sibling senderPtyId) SUCCEEDS
+ *     and pins to.surfaceId; the task is same-ws (from.ws === to.ws).
+ *   - addressing your OWN pane (surface_id == sender, senderPtyId == that pty)
+ *     is REJECTED ("cannot send to your own pane").
+ *   - a same-ws send with NO pane address is REJECTED ("without addressing a
+ *     specific pane").
+ *   - same-ws sibling send with senderPtyId ABSENT still succeeds (silent
+ *     fallback — delivery suppressed, task persisted).
+ *   - cross-ws ws2 → ws1 paneB still SUCCEEDS (back-compat) and a cross-ws /
+ *     foreign surface_id is REJECTED (fail-closed #163).
+ *
+ * Run (PowerShell): npm run package; node scripts/same-ws-a2a-dogfood.mjs
+ */
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '..');
+const APP_EXE = path.join(REPO_ROOT, 'out', 'wmux-win32-x64', 'wmux.exe');
+const USERNAME = os.userInfo().username || 'default';
+
+const results = [];
+let app = null;
+function check(name, ok, detail = '') {
+  results.push({ name, ok: !!ok });
+  console.log(`  [${ok ? 'PASS' : 'FAIL'}] ${name}${detail ? ` — ${detail}` : ''}`);
+  return ok;
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+if (process.platform !== 'win32') { console.log('same-ws-a2a-dogfood: SKIP (win32-only)'); process.exit(0); }
+if (!fs.existsSync(APP_EXE)) { console.error(`packaged exe not found: ${APP_EXE} — run \`npm run package\` first`); process.exit(2); }
+
+const suffix = `-samewsdog${process.pid}`;
+const home = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-samewsdog-'));
+const env = {
+  ...process.env,
+  USERPROFILE: home, HOME: home,
+  APPDATA: path.join(home, 'AppData', 'Roaming'),
+  LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
+  WMUX_DATA_SUFFIX: suffix, WMUX_NO_DIALOG: '1',
+};
+delete env.HOMEDRIVE; delete env.HOMEPATH;
+fs.mkdirSync(env.APPDATA, { recursive: true });
+fs.mkdirSync(env.LOCALAPPDATA, { recursive: true });
+const userDataDir = path.join(env.APPDATA, `wmux${suffix}`);
+fs.mkdirSync(userDataDir, { recursive: true });
+fs.writeFileSync(path.join(userDataDir, '.first-run'), new Date().toISOString(), 'utf8');
+
+const mainPipe = `\\\\.\\pipe\\wmux${suffix}-${USERNAME}`;
+const authTokenPath = path.join(home, `.wmux${suffix}-auth-token`);
+
+function readMainToken() { try { return fs.readFileSync(authTokenPath, 'utf8').trim() || null; } catch { return null; } }
+
+function rpcCall(method, params = {}, { timeoutMs = 8000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const sock = net.createConnection(mainPipe);
+    let buf = ''; let settled = false; const id = randomUUID();
+    const finish = (fn) => { if (settled) return; settled = true; clearTimeout(timer); try { sock.destroy(); } catch { /* */ } fn(); };
+    const timer = setTimeout(() => finish(() => reject(new Error(`rpc timeout: ${method}`))), timeoutMs);
+    sock.setEncoding('utf8');
+    sock.once('connect', () => sock.write(JSON.stringify({ id, method, params, token: TOKEN }) + '\n'));
+    sock.once('error', (e) => finish(() => reject(e)));
+    sock.on('data', (chunk) => {
+      buf += chunk; let nl;
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl).trim(); buf = buf.slice(nl + 1);
+        if (!line) continue;
+        let msg; try { msg = JSON.parse(line); } catch { continue; }
+        if (msg.id !== id) continue;
+        finish(() => resolve(msg));
+        return;
+      }
+    });
+  });
+}
+const rpcResult = async (m, p, o) => { const r = await rpcCall(m, p, o); if (r && r.ok === false) throw new Error(typeof r.error === 'string' ? r.error : JSON.stringify(r.error)); return r?.result ?? r; };
+// Normalize a send response to { ok, taskId, error } from the HANDLER payload.
+// CRUCIAL: derive ok from the handler result (ok / error / taskId), NEVER the
+// transport-level envelope `ok` (which is true whenever the RPC didn't throw,
+// even when the handler returned { error } — that conflation would mis-read a
+// rejection as a success).
+const sendResp = (r) => {
+  const p = (r && typeof r === 'object' && r.result && typeof r.result === 'object') ? r.result : (r ?? {});
+  const error = typeof p.error === 'string' ? p.error : undefined;
+  const taskId = typeof p.taskId === 'string' ? p.taskId : undefined;
+  return { ok: !error && (p.ok === true || !!taskId), taskId, error };
+};
+
+function spawnApp() {
+  const proc = spawn(APP_EXE, [], { cwd: REPO_ROOT, env, stdio: ['ignore', 'pipe', 'pipe'], detached: false });
+  proc.stdout.on('data', () => {}); proc.stderr.on('data', () => {});
+  return proc;
+}
+async function waitMainToken(timeoutMs) {
+  const dl = Date.now() + timeoutMs;
+  while (Date.now() < dl) { const t = readMainToken(); if (t) return t; await sleep(120); }
+  return null;
+}
+async function waitRendererReady(timeoutMs) {
+  const dl = Date.now() + timeoutMs; let last = '';
+  while (Date.now() < dl) {
+    try { const r = await rpcCall('workspace.list', {}, { timeoutMs: 4000 }); if (r && Array.isArray(r.result)) return r.result; }
+    catch (e) { last = e.message; }
+    await sleep(250);
+  }
+  throw new Error(`renderer not ready (${last})`);
+}
+
+let TOKEN = null;
+
+async function main() {
+  console.log(`same-ws-a2a-dogfood — exe=${APP_EXE}`);
+  app = spawnApp();
+  TOKEN = await waitMainToken(20000);
+  if (!TOKEN) throw new Error('main token never appeared');
+  const wss = await waitRendererReady(30000);
+  check('renderer ready + default workspace exists', wss.length >= 1, `workspaces=${wss.length}`);
+  const ws1 = wss[0].id;
+
+  // ws1 is the only workspace at boot → active. Split its pane into two so the
+  // single workspace hosts two addressable terminal panes (A and B).
+  await rpcResult('pane.split', { direction: 'vertical' }).catch((e) => console.log('  (split note:', e.message, ')'));
+  await sleep(1500); // let the second pane auto-spawn its PTY
+
+  let surfaces = await rpcResult('surface.list', { workspaceId: ws1 });
+  surfaces = surfaces.filter((s) => s.surfaceType !== 'browser' && s.ptyId);
+  check('ws1 has two terminal surfaces after split', surfaces.length >= 2, `surfaces=${surfaces.length}`);
+  if (surfaces.length < 2) throw new Error('need two panes to test same-ws addressing');
+  const surfA = surfaces[0]; // sender pane
+  const surfB = surfaces[1]; // target sibling pane
+  console.log(`  paneA pty=${surfA.ptyId} surf=${surfA.id} | paneB pty=${surfB.ptyId} surf=${surfB.id}`);
+
+  // ── HEADLINE: same-ws A → B (sibling surface_id + sibling senderPtyId) ──
+  // This is the exact call that used to hard-fail "cannot send to yourself".
+  const t1 = sendResp(await rpcCall('a2a.task.send', {
+    workspaceId: ws1, to: ws1, surfaceId: surfB.id, senderPtyId: surfA.ptyId,
+    message: 'same-ws sibling hello', silent: true,
+  }));
+  check('★ same-ws A→B sibling send SUCCEEDS (was "cannot send to yourself")',
+    t1.ok && typeof t1.taskId === 'string' && t1.taskId.length > 0, JSON.stringify(t1));
+
+  // The task is genuinely same-workspace and pinned to pane B.
+  const q1 = await rpcResult('a2a.task.query', { workspaceId: ws1 });
+  const task1 = (q1.tasks || []).find((t) => t.id === t1.taskId);
+  check('★ same-ws task pinned to.surfaceId = pane B', task1?.metadata?.to?.surfaceId === surfB.id, `to.surfaceId=${task1?.metadata?.to?.surfaceId}`);
+  check('★ task is same-workspace (from.ws === to.ws === ws1)',
+    task1?.metadata?.from?.workspaceId === ws1 && task1?.metadata?.to?.workspaceId === ws1,
+    `from=${task1?.metadata?.from?.workspaceId} to=${task1?.metadata?.to?.workspaceId}`);
+
+  // ── true-self reject: addressing your OWN pane (surface == sender pty) ──
+  const t2 = sendResp(await rpcCall('a2a.task.send', {
+    workspaceId: ws1, to: ws1, surfaceId: surfA.id, senderPtyId: surfA.ptyId,
+    message: 'self loop attempt', silent: true,
+  }));
+  check('★ true self-send (own pane) is REJECTED',
+    !t2.ok && typeof t2.error === 'string' && /your own pane/.test(t2.error), `err=${t2.error}`);
+
+  // ── no-address reject: same-ws send without a pane address (ambiguous) ──
+  const t3 = sendResp(await rpcCall('a2a.task.send', {
+    workspaceId: ws1, to: ws1, senderPtyId: surfA.ptyId, message: 'ambiguous self', silent: true,
+  }));
+  check('★ same-ws send with NO pane address is REJECTED',
+    !t3.ok && typeof t3.error === 'string' && /without addressing a specific pane/.test(t3.error), `err=${t3.error}`);
+
+  // ── silent fallback: same-ws sibling send with senderPtyId ABSENT still ok ──
+  // (the MCP env-hint path supplies no senderPtyId → renderer delivers silently
+  // rather than rejecting; the task is still persisted + pollable.)
+  const t4 = sendResp(await rpcCall('a2a.task.send', {
+    workspaceId: ws1, to: ws1, surfaceId: surfB.id, message: 'no-sender-pty sibling', silent: false,
+  }));
+  check('same-ws sibling send WITHOUT senderPtyId still succeeds (silent fallback)',
+    t4.ok && typeof t4.taskId === 'string' && t4.taskId.length > 0, JSON.stringify(t4));
+
+  // ── back-compat + fail-closed: a second workspace as cross-ws sender ──
+  const ws2 = (await rpcResult('workspace.new', { name: 'sender-ws' })).id;
+  await sleep(500);
+  const ws2Surfaces = (await rpcResult('surface.list', { workspaceId: ws2 })).filter((s) => s.surfaceType !== 'browser' && s.ptyId);
+  const ws2Surf = ws2Surfaces[0];
+
+  const t5 = sendResp(await rpcCall('a2a.task.send', {
+    workspaceId: ws2, to: ws1, surfaceId: surfB.id, message: 'cross-ws hello', silent: true,
+  }));
+  check('cross-ws ws2 → ws1 paneB still SUCCEEDS (back-compat)',
+    t5.ok && typeof t5.taskId === 'string' && t5.taskId.length > 0, JSON.stringify(t5));
+
+  const t6 = sendResp(await rpcCall('a2a.task.send', {
+    workspaceId: ws2, to: ws1, surfaceId: ws2Surf?.id ?? 'nonexistent', message: 'should fail', silent: true,
+  }));
+  check('★ cross-ws / foreign surface_id is REJECTED (fail-closed #163)',
+    !t6.ok && typeof t6.error === 'string' && /not found in target workspace/.test(t6.error), `err=${t6.error}`);
+}
+
+main()
+  .catch((e) => { console.error('FATAL', e); check('harness completed without fatal error', false, e.message); })
+  .finally(async () => {
+    try { await rpcResult('daemon.shutdown', {}).catch(() => {}); } catch { /* */ }
+    try { if (app) app.kill(); } catch { /* */ }
+    await sleep(800);
+    const passed = results.filter((r) => r.ok).length;
+    console.log(`\nsame-ws-a2a-dogfood: ${passed}/${results.length} passed`);
+    process.exit(passed === results.length && results.length > 0 ? 0 : 1);
+  });

--- a/scripts/same-ws-a2a-dogfood.mjs
+++ b/scripts/same-ws-a2a-dogfood.mjs
@@ -108,7 +108,8 @@ const sendResp = (r) => {
 
 function spawnApp() {
   const proc = spawn(APP_EXE, [], { cwd: REPO_ROOT, env, stdio: ['ignore', 'pipe', 'pipe'], detached: false });
-  proc.stdout.on('data', () => {}); proc.stderr.on('data', () => {});
+  const drain = () => undefined; // keep the pipes flowing without buffering
+  proc.stdout.on('data', drain); proc.stderr.on('data', drain);
   return proc;
 }
 async function waitMainToken(timeoutMs) {
@@ -140,10 +141,15 @@ async function main() {
   // ws1 is the only workspace at boot → active. Split its pane into two so the
   // single workspace hosts two addressable terminal panes (A and B).
   await rpcResult('pane.split', { direction: 'vertical' }).catch((e) => console.log('  (split note:', e.message, ')'));
-  await sleep(1500); // let the second pane auto-spawn its PTY
 
-  let surfaces = await rpcResult('surface.list', { workspaceId: ws1 });
-  surfaces = surfaces.filter((s) => s.surfaceType !== 'browser' && s.ptyId);
+  // Poll until the second pane has auto-spawned its PTY (bounded), rather than a
+  // fixed sleep that flakes on slower hosts.
+  let surfaces = [];
+  for (let i = 0; i < 40; i++) {
+    surfaces = (await rpcResult('surface.list', { workspaceId: ws1 })).filter((s) => s.surfaceType !== 'browser' && s.ptyId);
+    if (surfaces.length >= 2) break;
+    await sleep(250);
+  }
   check('ws1 has two terminal surfaces after split', surfaces.length >= 2, `surfaces=${surfaces.length}`);
   if (surfaces.length < 2) throw new Error('need two panes to test same-ws addressing');
   const surfA = surfaces[0]; // sender pane
@@ -213,7 +219,7 @@ async function main() {
 main()
   .catch((e) => { console.error('FATAL', e); check('harness completed without fatal error', false, e.message); })
   .finally(async () => {
-    try { await rpcResult('daemon.shutdown', {}).catch(() => {}); } catch { /* */ }
+    try { await rpcResult('daemon.shutdown', {}).catch(() => undefined); } catch { /* */ }
     try { if (app) app.kill(); } catch { /* */ }
     await sleep(800);
     const passed = results.filter((r) => r.ok).length;

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -249,6 +249,22 @@ export class DaemonSessionManager extends EventEmitter {
     // across reboot. This is the join key the spool ingest matches on.
     env[ENV_KEYS.PTY_ID] = params.id;
 
+    // Instance-isolation suffix: force the child onto THIS daemon's instance (its
+    // own inherited WMUX_DATA_SUFFIX), overriding whatever a replayed session.env
+    // blob carried. The recovery path above runs stripReservedAuth, which strips
+    // only WMUX_AUTH* — so a persisted (or hand-edited) WMUX_DATA_SUFFIX would
+    // otherwise survive verbatim and could point a recovered pane at a DIFFERENT
+    // instance's control pipe. Sourced ONLY from the daemon's own process.env (the
+    // authoritative instance key, inherited from main at spawn), never a child-
+    // supplied value. The delete branch is the security-critical half: a
+    // production daemon (no suffix) recovering a '-dev'-tainted blob must SCRUB the
+    // key, not leave the child on the dev pipe.
+    if (globalThis.process.env[ENV_KEYS.DATA_SUFFIX]) {
+      env[ENV_KEYS.DATA_SUFFIX] = globalThis.process.env[ENV_KEYS.DATA_SUFFIX] as string;
+    } else {
+      delete env[ENV_KEYS.DATA_SUFFIX];
+    }
+
     let spawnArgs: string[] = [];
     if (params.exec) {
       // X8 exec unit: the command IS the pane process — no interactive

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -259,10 +259,15 @@ export class DaemonSessionManager extends EventEmitter {
     // supplied value. The delete branch is the security-critical half: a
     // production daemon (no suffix) recovering a '-dev'-tainted blob must SCRUB the
     // key, not leave the child on the dev pipe.
+    // Scrub ANY case-variant first (a replayed / hand-edited blob may carry
+    // `wmux_data_suffix` or mixed case; Windows process env is case-insensitive,
+    // so a stray variant would otherwise reach the child even after we set the
+    // canonical key). Then apply the daemon's own value, or leave it absent.
+    for (const k of Object.keys(env)) {
+      if (k.toUpperCase() === ENV_KEYS.DATA_SUFFIX) delete env[k];
+    }
     if (globalThis.process.env[ENV_KEYS.DATA_SUFFIX]) {
       env[ENV_KEYS.DATA_SUFFIX] = globalThis.process.env[ENV_KEYS.DATA_SUFFIX] as string;
-    } else {
-      delete env[ENV_KEYS.DATA_SUFFIX];
     }
 
     let spawnArgs: string[] = [];

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -144,6 +144,57 @@ describe('DaemonSessionManager', () => {
     expect(lastMockPty?.spawnEnv?.WMUX_AUTH_TOKEN).toBeUndefined();
   });
 
+  // Instance-isolation suffix (WMUX_DATA_SUFFIX) must always reflect THIS
+  // daemon's own instance, never a value carried in a replayed/persisted env
+  // blob — otherwise a recovered pane could be pointed at a DIFFERENT instance's
+  // control pipe. stripReservedAuth keeps non-auth WMUX_* from a supplied env, so
+  // the daemon forces its own inherited suffix over the blob (and scrubs it when
+  // the daemon itself has none).
+  it("forces the daemon's own WMUX_DATA_SUFFIX over a replayed env blob", () => {
+    const prev = process.env.WMUX_DATA_SUFFIX;
+    process.env.WMUX_DATA_SUFFIX = '-rc35';
+    try {
+      manager.createSession({
+        id: 'suffix-override',
+        cmd: 'cmd.exe',
+        cwd: '.',
+        env: { WMUX_DATA_SUFFIX: '-attacker', FOO: 'bar' },
+      });
+      expect(lastMockPty?.spawnEnv?.WMUX_DATA_SUFFIX).toBe('-rc35'); // blob value overwritten
+      expect(lastMockPty?.spawnEnv?.FOO).toBe('bar');
+    } finally {
+      if (prev === undefined) delete process.env.WMUX_DATA_SUFFIX; else process.env.WMUX_DATA_SUFFIX = prev;
+    }
+  });
+
+  it('scrubs a stale WMUX_DATA_SUFFIX from a replayed blob when the daemon has none (prod)', () => {
+    const prev = process.env.WMUX_DATA_SUFFIX;
+    delete process.env.WMUX_DATA_SUFFIX; // production daemon: no suffix
+    try {
+      manager.createSession({
+        id: 'suffix-scrub',
+        cmd: 'cmd.exe',
+        cwd: '.',
+        env: { WMUX_DATA_SUFFIX: '-dev', FOO: 'bar' },
+      });
+      expect(lastMockPty?.spawnEnv?.WMUX_DATA_SUFFIX).toBeUndefined(); // not left on the '-dev' pipe
+      expect(lastMockPty?.spawnEnv?.FOO).toBe('bar');
+    } finally {
+      if (prev === undefined) delete process.env.WMUX_DATA_SUFFIX; else process.env.WMUX_DATA_SUFFIX = prev;
+    }
+  });
+
+  it("propagates the daemon's own suffix in the process.env fallback (no supplied env)", () => {
+    const prev = process.env.WMUX_DATA_SUFFIX;
+    process.env.WMUX_DATA_SUFFIX = '-rc35';
+    try {
+      manager.createSession({ id: 'suffix-fallback', cmd: 'cmd.exe', cwd: '.' }); // no env
+      expect(lastMockPty?.spawnEnv?.WMUX_DATA_SUFFIX).toBe('-rc35');
+    } finally {
+      if (prev === undefined) delete process.env.WMUX_DATA_SUFFIX; else process.env.WMUX_DATA_SUFFIX = prev;
+    }
+  });
+
   it('emits session:created event', () => {
     const handler = vi.fn();
     manager.on('session:created', handler);

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -184,6 +184,25 @@ describe('DaemonSessionManager', () => {
     }
   });
 
+  it('scrubs a CASE-VARIANT WMUX_DATA_SUFFIX from a replayed blob (Windows env is case-insensitive)', () => {
+    const prev = process.env.WMUX_DATA_SUFFIX;
+    delete process.env.WMUX_DATA_SUFFIX; // production daemon: no suffix
+    try {
+      manager.createSession({
+        id: 'suffix-case',
+        cmd: 'cmd.exe',
+        cwd: '.',
+        env: { wmux_data_suffix: '-stale', FOO: 'bar' }, // lowercase variant survives stripReservedAuth
+      });
+      const spawned = lastMockPty?.spawnEnv ?? {};
+      const anyVariant = Object.keys(spawned).some((k) => k.toUpperCase() === 'WMUX_DATA_SUFFIX');
+      expect(anyVariant).toBe(false); // no case-variant reaches the child
+      expect(spawned.FOO).toBe('bar');
+    } finally {
+      if (prev === undefined) delete process.env.WMUX_DATA_SUFFIX; else process.env.WMUX_DATA_SUFFIX = prev;
+    }
+  });
+
   it("propagates the daemon's own suffix in the process.env fallback (no supplied env)", () => {
     const prev = process.env.WMUX_DATA_SUFFIX;
     process.env.WMUX_DATA_SUFFIX = '-rc35';

--- a/src/main/pty/__tests__/resolveSpawnEnv.test.ts
+++ b/src/main/pty/__tests__/resolveSpawnEnv.test.ts
@@ -77,4 +77,34 @@ describe('resolveSpawnEnv', () => {
     expect(env.wmux_socket_path).toBeUndefined();
     expect(env.PATH).toBe('/p');
   });
+
+  it('propagates the instance-isolation suffix from the spawning env (dogfood pipe, not prod)', () => {
+    // WMUX_DATA_SUFFIX selects which instance a child joins; unlike identity it
+    // must SURVIVE the WMUX_* strip, else an isolated pane's agent/MCP/CLI
+    // computes an empty suffix and connects to the PRODUCTION control pipe.
+    const env = resolveSpawnEnv(
+      { PATH: '/usr/bin', WMUX_DATA_SUFFIX: '-rc35' },
+      undefined,
+      { WMUX_WORKSPACE_ID: 'child-ws' },
+    );
+    expect(env.WMUX_DATA_SUFFIX).toBe('-rc35'); // re-keyed onto THIS instance
+    expect(env.WMUX_WORKSPACE_ID).toBe('child-ws');
+  });
+
+  it('never lets a profile set the isolation suffix (only the spawning env)', () => {
+    // A profile cannot redirect a child onto another instance's pipe:
+    // applyProfileEnv skips reserved WMUX_*, and the suffix is re-applied ONLY
+    // from baseEnv (the spawning process's real env).
+    const env = resolveSpawnEnv(
+      { PATH: '/usr/bin' },              // real env has NO suffix
+      { WMUX_DATA_SUFFIX: '-attacker' }, // profile tries to inject one
+      {},
+    );
+    expect(env.WMUX_DATA_SUFFIX).toBeUndefined();
+  });
+
+  it('omits the suffix when the spawning env has none (production child stays on the prod pipe)', () => {
+    const env = resolveSpawnEnv({ PATH: '/usr/bin' }, undefined, {});
+    expect(env.WMUX_DATA_SUFFIX).toBeUndefined();
+  });
 });

--- a/src/main/pty/resolveSpawnEnv.ts
+++ b/src/main/pty/resolveSpawnEnv.ts
@@ -1,5 +1,6 @@
 import { buildSafeChildEnv } from '../../shared/envFilter';
 import { applyProfileEnv } from '../../shared/workspaceProfile';
+import { ENV_KEYS } from '../../shared/constants';
 
 /**
  * Resolve the environment for a NEW child PTY, in the single canonical order
@@ -30,6 +31,15 @@ export function resolveSpawnEnv(
   identity: Record<string, string>,
 ): Record<string, string> {
   const env = buildSafeChildEnv(baseEnv);
+  // Capture the instance-isolation suffix from the SPAWNING process's own env
+  // BEFORE the blanket WMUX_* strip below, and re-apply it last (like identity).
+  // It is NOT an ownership claim — it only selects which instance a child joins —
+  // so unlike WORKSPACE_ID/SURFACE_ID/SOCKET_PATH it must SURVIVE: without it an
+  // isolated (dev / dogfood) pane's agent/MCP/CLI computes an empty suffix and
+  // connects to the PRODUCTION control pipe, where it can drive the user's real
+  // workspaces. Sourced ONLY from baseEnv (main/daemon's own env), never from
+  // profileEnv — so it isolates without being a spoofable identity.
+  const dataSuffix = baseEnv[ENV_KEYS.DATA_SUFFIX];
   // Drop the ENTIRE reserved WMUX_* namespace from the baseline before we
   // overlay or force anything. buildSafeChildEnv only strips WMUX_AUTH*, so a
   // wmux launched from inside a wmux pane (e.g. `npm start` while dogfooding)
@@ -48,5 +58,11 @@ export function resolveSpawnEnv(
   for (const [k, v] of Object.entries(identity)) {
     if (typeof v === 'string') env[k] = v;
   }
+  // Re-apply the captured suffix AFTER identity (same "forced last, unspoofable"
+  // discipline). A profile can never set it (applyProfileEnv skips WMUX_*); only
+  // the spawning process's real suffix survives. baseEnv here is always the live
+  // process.env (never a persisted blob), so a simple presence check is enough —
+  // the daemon recovery path scrubs a stale blob suffix separately.
+  if (typeof dataSuffix === 'string' && dataSuffix) env[ENV_KEYS.DATA_SUFFIX] = dataSuffix;
   return env;
 }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -133,7 +133,15 @@ async function lookupPidMapWorkspace(): Promise<PidMapLookup> {
   let currentPid = process.ppid;
   for (let depth = 0; depth < 10; depth++) {
     const match = knownPids.get(currentPid);
-    if (match) return { status: 'hit', wsId: match.wsId, ptyId: match.ptyId };
+    if (match) {
+      // Capture our OWN pane anchor on EVERY verified hit — including when a
+      // terminal tool warms this lookup before any A2A call. resolveWorkspaceId's
+      // cache fast-path returns without re-running this walk, so setting MY_PTY_ID
+      // only there would leave it empty whenever a terminal op resolved identity
+      // first (senderPtyId would then be silently absent on the next send).
+      MY_PTY_ID = match.ptyId ?? '';
+      return { status: 'hit', wsId: match.wsId, ptyId: match.ptyId };
+    }
     const parentPid = await getParentPid(currentPid);
     if (!parentPid || parentPid === currentPid || parentPid <= 1) break;
     currentPid = parentPid;
@@ -158,7 +166,8 @@ async function resolveWorkspaceId(): Promise<string> {
   const lookup = await lookupPidMapWorkspace();
   if (lookup.status === 'hit') {
     MY_WORKSPACE_ID = lookup.wsId;
-    MY_PTY_ID = lookup.ptyId ?? ''; // our own pane anchor for the A2A self-send guard
+    // MY_PTY_ID is set inside lookupPidMapWorkspace on the hit (so the
+    // terminal-route warm path populates it too — see there).
     workspaceResolved = true;
     return MY_WORKSPACE_ID;
   }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -40,6 +40,12 @@ function getVersion(): string {
 // fall back to the env hint only when the live map is unavailable.
 const ENV_WORKSPACE_HINT = process.env.WMUX_WORKSPACE_ID || '';
 let MY_WORKSPACE_ID = '';
+// Our OWN pane anchor (ptyId), captured alongside MY_WORKSPACE_ID on a verified
+// PID-map hit. Threaded to a2a.task.send as `senderPtyId` so the renderer can
+// reject a true self-send (addressing our own pane). Empty when identity came
+// from the env-hint fallback (no PID match) — the renderer then fails closed by
+// suppressing the same-ws paste rather than trusting an absent guard.
+let MY_PTY_ID = '';
 let workspaceResolved = false;
 
 const server = new McpServer({
@@ -94,9 +100,11 @@ function invalidateWorkspaceId(): void {
  */
 async function lookupPidMapWorkspace(): Promise<PidMapLookup> {
   let mappings: Record<string, string> | undefined;
+  let entries: Array<{ pid: string; ptyId: string; workspaceId: string }> | undefined;
   try {
     const result = await sendRpc('a2a.resolve.identity' as RpcMethod, {});
     mappings = (result as { mappings: Record<string, string> }).mappings;
+    entries = (result as { entries?: Array<{ pid: string; ptyId: string; workspaceId: string }> }).entries;
   } catch {
     return { status: 'rpc-down' };
   }
@@ -104,17 +112,28 @@ async function lookupPidMapWorkspace(): Promise<PidMapLookup> {
     return { status: 'empty-map' };
   }
 
-  const knownPids = new Map<number, string>();
-  for (const [pidStr, wsId] of Object.entries(mappings)) {
-    const pid = parseInt(pidStr, 10);
-    if (!isNaN(pid)) knownPids.set(pid, wsId);
+  // Prefer entries[] — it carries the immutable ptyId anchor per PID, so a
+  // verified hit can also surface the caller's OWN ptyId (used by A2A send to
+  // reject a true self-send). Fall back to mappings (pid→wsId, no ptyId) if an
+  // older main omits entries; the wsId resolution is identical either way.
+  const knownPids = new Map<number, { wsId: string; ptyId?: string }>();
+  if (entries && entries.length > 0) {
+    for (const e of entries) {
+      const pid = parseInt(e.pid, 10);
+      if (!isNaN(pid)) knownPids.set(pid, { wsId: e.workspaceId, ptyId: e.ptyId });
+    }
+  } else {
+    for (const [pidStr, wsId] of Object.entries(mappings)) {
+      const pid = parseInt(pidStr, 10);
+      if (!isNaN(pid)) knownPids.set(pid, { wsId });
+    }
   }
 
   // Walk process tree upward: MCP server → Claude Code → shell(PTY)
   let currentPid = process.ppid;
   for (let depth = 0; depth < 10; depth++) {
-    const wsId = knownPids.get(currentPid);
-    if (wsId) return { status: 'hit', wsId };
+    const match = knownPids.get(currentPid);
+    if (match) return { status: 'hit', wsId: match.wsId, ptyId: match.ptyId };
     const parentPid = await getParentPid(currentPid);
     if (!parentPid || parentPid === currentPid || parentPid <= 1) break;
     currentPid = parentPid;
@@ -139,6 +158,7 @@ async function resolveWorkspaceId(): Promise<string> {
   const lookup = await lookupPidMapWorkspace();
   if (lookup.status === 'hit') {
     MY_WORKSPACE_ID = lookup.wsId;
+    MY_PTY_ID = lookup.ptyId ?? ''; // our own pane anchor for the A2A self-send guard
     workspaceResolved = true;
     return MY_WORKSPACE_ID;
   }
@@ -166,6 +186,7 @@ async function resolveWorkspaceId(): Promise<string> {
   // (workspace.list transiently down) to carry the call through a boot blip.
   if (MY_WORKSPACE_ID && (await isLiveWorkspace(MY_WORKSPACE_ID)) === 'absent') {
     MY_WORKSPACE_ID = '';
+    MY_PTY_ID = '';
     workspaceResolved = false;
   }
   return MY_WORKSPACE_ID;
@@ -572,6 +593,12 @@ const sendMessageHandler = async ({ to, pane_id, surface_id, title, task_id, mes
     workspaceId: wsId,
     message,
   };
+  // KS-1 (true self-send guard): include our OWN verified ptyId so the renderer
+  // can reject addressing our own pane (bracket-paste + forced submit into our
+  // own prompt = loop) and can safely allow a loud same-ws sibling paste.
+  // Best-effort: only present on a verified PID-map hit; absent on the env-hint
+  // fallback, where the renderer fails closed by suppressing the same-ws paste.
+  if (MY_PTY_ID) params.senderPtyId = MY_PTY_ID;
   if (task_id) params.taskId = task_id;
   if (to) params.to = to;
   // Pane-level addressing: route delivery to a specific pane/surface inside the

--- a/src/mcp/terminalRouting.ts
+++ b/src/mcp/terminalRouting.ts
@@ -37,7 +37,7 @@
 import type { PinnedRoute } from './paneResolver';
 
 export type PidMapLookup =
-  | { status: 'hit'; wsId: string }
+  | { status: 'hit'; wsId: string; ptyId?: string } // ptyId = the caller's OWN pane anchor (A2A self-send guard); terminal routing ignores it
   | { status: 'miss' } // map non-empty but our process chain isn't in it → confirmed external
   | { status: 'rpc-down' } // a2a.resolve.identity threw → transient (daemon unreachable)
   | { status: 'empty-map' }; // RPC answered but mappings empty → boot/respawn reconcile window

--- a/src/renderer/components/A2a/ExecuteApprovalDialog.tsx
+++ b/src/renderer/components/A2a/ExecuteApprovalDialog.tsx
@@ -22,6 +22,11 @@ export default function ExecuteApprovalDialog() {
 
   const senderName = workspaces.find((w) => w.id === approval.senderWorkspaceId)?.name ?? approval.senderWorkspaceId ?? 'unknown sender';
   const receiverName = workspaces.find((w) => w.id === approval.receiverWorkspaceId)?.name ?? approval.receiverWorkspaceId ?? 'unknown receiver';
+  // Same-workspace execute (an agent asking to spawn an autonomous agent in its
+  // OWN workspace). The default "remote A2A caller … in this workspace" wording
+  // implies an inter-workspace handoff and reads as harmless; be explicit so the
+  // user isn't social-engineered into waving through a self-spawned bypass agent.
+  const sameWs = !!approval.senderWorkspaceId && approval.senderWorkspaceId === approval.receiverWorkspaceId;
   const remainingMs = Math.max(0, approval.expiresAt - now);
   const remainingSec = Math.ceil(remainingMs / 1000);
 
@@ -53,8 +58,18 @@ export default function ExecuteApprovalDialog() {
           </p>
         </div>
         <p className="text-xs" style={{ color: 'var(--text-sub)' }}>
-          A remote A2A caller wants to spawn a Claude CLI with{' '}
-          <span style={{ color: 'var(--accent-red)' }}>bypassPermissions</span> in this workspace.
+          {sameWs ? (
+            <>
+              An agent in <span style={{ color: 'var(--accent-red)' }}>this workspace</span> wants to spawn
+              another autonomous Claude CLI with{' '}
+              <span style={{ color: 'var(--accent-red)' }}>bypassPermissions</span> in the same workspace.
+            </>
+          ) : (
+            <>
+              A remote A2A caller wants to spawn a Claude CLI with{' '}
+              <span style={{ color: 'var(--accent-red)' }}>bypassPermissions</span> in this workspace.
+            </>
+          )}
         </p>
         <div
           className="text-xs font-mono flex flex-col gap-1 p-3 rounded-md"

--- a/src/renderer/hooks/__tests__/a2aAddressing.test.ts
+++ b/src/renderer/hooks/__tests__/a2aAddressing.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { PaneLeaf, Surface } from '../../../shared/types';
-import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend } from '../a2aAddressing';
+import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, isTerminalPtyInLeaves } from '../a2aAddressing';
 
 function surface(id: string, ptyId: string, surfaceType: Surface['surfaceType'] = 'terminal'): Surface {
   return { id, ptyId, title: id, shell: '', cwd: '', surfaceType } as Surface;
@@ -97,5 +97,19 @@ describe('decideSameWsSend', () => {
     // Common pid-map-miss / env-hint case: we cannot prove the target isn't self,
     // so suppress the paste (task still persisted + pollable) — never a loop.
     expect(decideSameWsSend(true, 'pty-sibling', '')).toEqual({ kind: 'deliver', suppressPaste: true });
+  });
+});
+
+describe('isTerminalPtyInLeaves', () => {
+  it('accepts a real terminal pty in the tree', () => {
+    expect(isTerminalPtyInLeaves(leaves, 'pty-A')).toBe(true);
+    expect(isTerminalPtyInLeaves(leaves, 'pty-B2')).toBe(true);
+  });
+  it('rejects a browser-surface pty (not a terminal)', () => {
+    expect(isTerminalPtyInLeaves(leaves, 'pty-web')).toBe(false);
+  });
+  it('rejects a foreign/unknown pty and the empty string', () => {
+    expect(isTerminalPtyInLeaves(leaves, 'pty-from-other-ws')).toBe(false);
+    expect(isTerminalPtyInLeaves(leaves, '')).toBe(false);
   });
 });

--- a/src/renderer/hooks/__tests__/a2aAddressing.test.ts
+++ b/src/renderer/hooks/__tests__/a2aAddressing.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { PaneLeaf, Surface } from '../../../shared/types';
-import { resolvePaneAddress, activePaneTerminalPty } from '../a2aAddressing';
+import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend } from '../a2aAddressing';
 
 function surface(id: string, ptyId: string, surfaceType: Surface['surfaceType'] = 'terminal'): Surface {
   return { id, ptyId, title: id, shell: '', cwd: '', surfaceType } as Surface;
@@ -67,5 +67,35 @@ describe('activePaneTerminalPty', () => {
   });
   it('returns null when no terminal surface exists', () => {
     expect(activePaneTerminalPty([leaf('p', [surface('w', 'pw', 'browser')])], 'p')).toBeNull();
+  });
+});
+
+describe('decideSameWsSend', () => {
+  it('cross-workspace send always delivers loud (path unchanged)', () => {
+    expect(decideSameWsSend(false, 'pty-X', '')).toEqual({ kind: 'deliver', suppressPaste: false });
+    expect(decideSameWsSend(false, undefined, 'pty-self')).toEqual({ kind: 'deliver', suppressPaste: false });
+  });
+
+  it('same-ws with NO resolved address is rejected (ambiguous → would loop to self)', () => {
+    const r = decideSameWsSend(true, undefined, 'pty-self');
+    expect(r.kind).toBe('reject');
+    expect(r.kind === 'reject' && r.error).toMatch(/without addressing a specific pane/);
+  });
+
+  it('same-ws addressing the sender\'s OWN pane is rejected (true self-send loop)', () => {
+    const r = decideSameWsSend(true, 'pty-self', 'pty-self');
+    expect(r.kind).toBe('reject');
+    expect(r.kind === 'reject' && r.error).toMatch(/your own pane/);
+  });
+
+  it('same-ws sibling pane with a VERIFIED sender pty delivers loud', () => {
+    // senderPtyId present and ≠ target → proven not-self → loud paste allowed.
+    expect(decideSameWsSend(true, 'pty-sibling', 'pty-self')).toEqual({ kind: 'deliver', suppressPaste: false });
+  });
+
+  it('same-ws sibling pane with an ABSENT sender pty delivers SILENT (fail-closed paste)', () => {
+    // Common pid-map-miss / env-hint case: we cannot prove the target isn't self,
+    // so suppress the paste (task still persisted + pollable) — never a loop.
+    expect(decideSameWsSend(true, 'pty-sibling', '')).toEqual({ kind: 'deliver', suppressPaste: true });
   });
 });

--- a/src/renderer/hooks/__tests__/useRpcBridge.a2aPaneIdentity.test.ts
+++ b/src/renderer/hooks/__tests__/useRpcBridge.a2aPaneIdentity.test.ts
@@ -61,7 +61,7 @@ describe('useRpcBridge — pane-level A2A identity wiring', () => {
     expect(block).not.toMatch(/cannot send to yourself/);
     // the relocated guard runs AFTER address resolution, keyed on the sender's
     // own verified ptyId (threaded from the MCP server as params.senderPtyId)
-    expect(block).toMatch(/const senderPtyId = typeof params\.senderPtyId === 'string'/);
+    expect(block).toMatch(/const rawSenderPtyId = typeof params\.senderPtyId === 'string'/);
     expect(block).toMatch(/decideSameWsSend\(target\.id === workspaceId, resolvedAddr\?\.ptyId, senderPtyId\)/);
     expect(block).toMatch(/sameWsDecision\.kind === 'reject'/);
     // delivery is gated by suppressPaste (silent OR same-ws-can't-prove-non-self)
@@ -71,6 +71,18 @@ describe('useRpcBridge — pane-level A2A identity wiring', () => {
     expect(block).toMatch(/const sameWsTask = task\.metadata\.from\.workspaceId === task\.metadata\.to\.workspaceId/);
     expect(block).toMatch(/if \(!silent && !sameWsTask\)/);
   });
+
+  it('a2a.task.send validates senderPtyId provenance against the sender workspace', () => {
+    const block = region("method === 'a2a\\.task\\.send'", "method === 'a2a\\.task\\.query'");
+    // a foreign/bogus senderPtyId is treated as absent (→ safe silent fallback)
+    expect(block).toMatch(/isTerminalPtyInLeaves\(findLeafPanes\(sender\.rootPane\), rawSenderPtyId\)/);
+  });
+
+  it('a2a.task.update suppresses the PTY paste for same-ws tasks (no active-pane loop)', () => {
+    const block = region("method === 'a2a\\.task\\.update'", 'addTaskArtifact');
+    expect(block).toMatch(/const sameWsTask = task\.metadata\.from\.workspaceId === task\.metadata\.to\.workspaceId/);
+    expect(block).toMatch(/if \(targetWs && !sameWsTask\)/);
+  });
 });
 
 describe('mcp — A2A send threads the caller\'s own ptyId (KS-1 self-send guard)', () => {
@@ -79,8 +91,9 @@ describe('mcp — A2A send threads the caller\'s own ptyId (KS-1 self-send guard
     'utf-8',
   );
   it('captures MY_PTY_ID on a verified hit and forwards it as senderPtyId', () => {
-    // hit path records the caller's own pane anchor …
-    expect(src).toMatch(/MY_PTY_ID = lookup\.ptyId/);
+    // hit path records the caller's own pane anchor inside the PID-map walk, so
+    // the terminal-route warm path populates it too …
+    expect(src).toMatch(/MY_PTY_ID = match\.ptyId/);
     // … and the send handler forwards it (best-effort: only when present).
     expect(src).toMatch(/if \(MY_PTY_ID\) params\.senderPtyId = MY_PTY_ID/);
   });

--- a/src/renderer/hooks/__tests__/useRpcBridge.a2aPaneIdentity.test.ts
+++ b/src/renderer/hooks/__tests__/useRpcBridge.a2aPaneIdentity.test.ts
@@ -54,6 +54,36 @@ describe('useRpcBridge — pane-level A2A identity wiring', () => {
     // the resolved target ws id is returned for the main-side execute path
     expect(block).toMatch(/toWorkspaceId: target\.id/);
   });
+
+  it('a2a.task.send replaces the whole-ws self-guard with per-pane decideSameWsSend', () => {
+    const block = region("method === 'a2a\\.task\\.send'", "method === 'a2a\\.task\\.query'");
+    // the old workspace-granular guard is gone (it blocked legitimate sibling sends)
+    expect(block).not.toMatch(/cannot send to yourself/);
+    // the relocated guard runs AFTER address resolution, keyed on the sender's
+    // own verified ptyId (threaded from the MCP server as params.senderPtyId)
+    expect(block).toMatch(/const senderPtyId = typeof params\.senderPtyId === 'string'/);
+    expect(block).toMatch(/decideSameWsSend\(target\.id === workspaceId, resolvedAddr\?\.ptyId, senderPtyId\)/);
+    expect(block).toMatch(/sameWsDecision\.kind === 'reject'/);
+    // delivery is gated by suppressPaste (silent OR same-ws-can't-prove-non-self)
+    expect(block).toMatch(/const suppressPaste = silent \|\| sameWsDecision\.suppressPaste/);
+    expect(block).toMatch(/if \(!suppressPaste\)/);
+    // same-ws task replies suppress the PTY paste (no active-pane loop)
+    expect(block).toMatch(/const sameWsTask = task\.metadata\.from\.workspaceId === task\.metadata\.to\.workspaceId/);
+    expect(block).toMatch(/if \(!silent && !sameWsTask\)/);
+  });
+});
+
+describe('mcp — A2A send threads the caller\'s own ptyId (KS-1 self-send guard)', () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, '..', '..', '..', 'mcp', 'index.ts'),
+    'utf-8',
+  );
+  it('captures MY_PTY_ID on a verified hit and forwards it as senderPtyId', () => {
+    // hit path records the caller's own pane anchor …
+    expect(src).toMatch(/MY_PTY_ID = lookup\.ptyId/);
+    // … and the send handler forwards it (best-effort: only when present).
+    expect(src).toMatch(/if \(MY_PTY_ID\) params\.senderPtyId = MY_PTY_ID/);
+  });
 });
 
 describe('a2a.rpc — execute uses the resolved workspaceId', () => {

--- a/src/renderer/hooks/a2aAddressing.ts
+++ b/src/renderer/hooks/a2aAddressing.ts
@@ -61,3 +61,53 @@ export function resolvePaneAddress(
   if (!term) return { error: `pane_id "${paneId}" has no terminal surface` };
   return { ptyId: term.ptyId, paneId: leaf.id, surfaceId: term.id };
 }
+
+export type SameWsSendDecision =
+  | { kind: 'reject'; error: string }
+  | { kind: 'deliver'; suppressPaste: boolean };
+
+/**
+ * Decide whether an A2A NEW-TASK send is allowed and whether its PTY paste must
+ * be suppressed, once same-workspace pane-to-pane sends are permitted. Pure so
+ * it is unit-testable (useRpcBridge can't be imported under vitest).
+ *
+ * The historical guard rejected ANY same-workspace send ("cannot send to
+ * yourself"), which also blocked legitimate sibling-pane delivery. Now the rule
+ * is per-pane:
+ *
+ *  - Different workspace → always deliver (cross-ws path unchanged).
+ *  - Same workspace, NO resolved pane address → REJECT: ambiguous; a bare
+ *    same-ws send would fall back to the sender's own active pane and loop.
+ *  - Same workspace, resolved address == sender's OWN pty (only knowable when
+ *    senderPtyId is present) → REJECT: true self-send = bracket-paste + forced
+ *    submit into your own prompt = loop.
+ *  - Same workspace, resolved SIBLING address, senderPtyId VERIFIED (present and
+ *    ≠ target) → deliver with a loud paste (we proved it isn't self).
+ *  - Same workspace, resolved address but senderPtyId ABSENT → deliver but
+ *    SUPPRESS the paste. Absent senderPtyId is the common case (PID-map miss →
+ *    env-hint identity), so we cannot prove the target isn't the sender's own
+ *    pane; fail closed on the PASTE only. The task is still persisted + teed onto
+ *    the EventBus, so a sibling still receives it (pollable via a2a_task_query)
+ *    and a self-addressed send is at worst a no-op pointer — never a loop.
+ */
+export function decideSameWsSend(
+  targetIsSelfWorkspace: boolean,
+  resolvedPtyId: string | undefined,
+  senderPtyId: string,
+): SameWsSendDecision {
+  if (!targetIsSelfWorkspace) return { kind: 'deliver', suppressPaste: false };
+  if (!resolvedPtyId) {
+    return {
+      kind: 'reject',
+      error:
+        'cannot send to your own workspace without addressing a specific pane ' +
+        '(pass pane_id or surface_id of a sibling pane)',
+    };
+  }
+  if (senderPtyId && resolvedPtyId === senderPtyId) {
+    return { kind: 'reject', error: 'cannot send to your own pane' };
+  }
+  // Verified sibling (senderPtyId present and ≠ target) → loud paste; otherwise
+  // (senderPtyId absent) deliver silently so an unprovable self-send can't loop.
+  return { kind: 'deliver', suppressPaste: !senderPtyId };
+}

--- a/src/renderer/hooks/a2aAddressing.ts
+++ b/src/renderer/hooks/a2aAddressing.ts
@@ -62,6 +62,17 @@ export function resolvePaneAddress(
   return { ptyId: term.ptyId, paneId: leaf.id, surfaceId: term.id };
 }
 
+/**
+ * True iff `ptyId` is a live TERMINAL surface's pty within `leaves`. Used to
+ * validate a caller-supplied senderPtyId against the sender's own workspace tree
+ * before trusting it (a bogus / foreign value is treated as absent → the safe
+ * silent fallback). Empty ptyId is never a member.
+ */
+export function isTerminalPtyInLeaves(leaves: PaneLeaf[], ptyId: string): boolean {
+  if (!ptyId) return false;
+  return leaves.some((l) => l.surfaces.some((s) => s.surfaceType !== 'browser' && s.ptyId === ptyId));
+}
+
 export type SameWsSendDecision =
   | { kind: 'reject'; error: string }
   | { kind: 'deliver'; suppressPaste: boolean };

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -16,7 +16,7 @@ import { readPtyBufferLines } from '../utils/terminalTail';
 import { searchInBuffer, type SearchableBuffer } from '../utils/searchEngine';
 import { submitBracketedPasteToPty } from '../utils/ptyMessageDelivery';
 import { publishA2aTask } from '../events/publisher';
-import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, type PaneAddress } from './a2aAddressing';
+import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, isTerminalPtyInLeaves, type PaneAddress } from './a2aAddressing';
 
 // ---------------------------------------------------------------------------
 // Pane tree utilities
@@ -1351,6 +1351,11 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       if (task.metadata.from.workspaceId !== workspaceId && task.metadata.to.workspaceId !== workspaceId) {
         return { error: 'a2a.task.send: not authorized to reply to this task' };
       }
+      // NOTE: for a SAME-workspace task (from.ws === to.ws) this collapses to
+      // 'user' for either party — the sender/receiver distinction needs per-pane
+      // identity, deferred to the from.ptyId model (S-C2). Delivery for same-ws
+      // tasks is suppressed below, so the only residual effect is the stored
+      // history role; documented interim limitation, not a cross-ws regression.
       const role = task.metadata.from.workspaceId === workspaceId ? 'user' : 'agent';
       const msg: Message = { kind: 'message', messageId: generateId('msg'), role, parts };
       store.addTaskMessage(taskId, msg);
@@ -1465,8 +1470,12 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // Same-workspace send policy (relocated self-guard + KS-1 true-self guard).
     // senderPtyId is the caller's OWN pane anchor, supplied by the MCP server on
     // a verified PID-map hit (absent on the env-hint fallback → fail closed on
-    // the paste, see suppressPaste below).
-    const senderPtyId = typeof params.senderPtyId === 'string' ? params.senderPtyId : '';
+    // the paste, see suppressPaste below). It is NOT an agent-settable tool param;
+    // as defense-in-depth for the main-pipe/token path, only trust it if it
+    // resolves to a real terminal pty in the SENDER's own workspace — a bogus /
+    // foreign value is treated as ABSENT (→ silent), never as a loud-paste enabler.
+    const rawSenderPtyId = typeof params.senderPtyId === 'string' ? params.senderPtyId : '';
+    const senderPtyId = (sender && isTerminalPtyInLeaves(findLeafPanes(sender.rootPane), rawSenderPtyId)) ? rawSenderPtyId : '';
     const sameWsDecision = decideSameWsSend(target.id === workspaceId, resolvedAddr?.ptyId, senderPtyId);
     if (sameWsDecision.kind === 'reject') return { error: `a2a.task.send: ${sameWsDecision.error}` };
 
@@ -1576,6 +1585,10 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       if (task.metadata.from.workspaceId !== workspaceId && task.metadata.to.workspaceId !== workspaceId) {
         return { error: 'a2a.task.update: not authorized' };
       }
+      // Same-ws role collapses to 'user' for either party (see the a2a.task.send
+      // reply branch) — per-pane role needs the from.ptyId model (S-C2). Delivery
+      // is suppressed for same-ws below, so only the stored history role is
+      // affected; documented interim limitation.
       const role = task.metadata.from.workspaceId === workspaceId ? 'user' : 'agent';
 
       const parts: Part[] = [{ kind: 'text', text: message }];
@@ -1587,9 +1600,15 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       // (its prompt is not corrupted); a receiver with no live agent keeps the
       // loud paste. Mirrors the a2a.task.send reply branch so EVERY delivery
       // path honors the live-agent protection, not just the initial send.
+      // Same-ws task: suppress the PTY paste (mirrors the a2a.task.send reply
+      // branch). A same-ws update has no reliable per-pane reply address and
+      // would paste to the ws active pane — risking a loop into the caller's own
+      // or an uninvolved pane. The update is still persisted + teed onto the bus,
+      // so the other pane sees it via a2a_task_query.
+      const sameWsTask = task.metadata.from.workspaceId === task.metadata.to.workspaceId;
       const targetWsId = role === 'user' ? task.metadata.to.workspaceId : task.metadata.from.workspaceId;
       const targetWs = store.workspaces.find((w) => w.id === targetWsId);
-      if (targetWs) {
+      if (targetWs && !sameWsTask) {
         const callerWs = store.workspaces.find((w) => w.id === workspaceId);
         const callerName = callerWs?.name ?? 'unknown';
         if (isLiveTuiAgent(targetWs.metadata)) {

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -16,7 +16,7 @@ import { readPtyBufferLines } from '../utils/terminalTail';
 import { searchInBuffer, type SearchableBuffer } from '../utils/searchEngine';
 import { submitBracketedPasteToPty } from '../utils/ptyMessageDelivery';
 import { publishA2aTask } from '../events/publisher';
-import { resolvePaneAddress, activePaneTerminalPty, type PaneAddress } from './a2aAddressing';
+import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, type PaneAddress } from './a2aAddressing';
 
 // ---------------------------------------------------------------------------
 // Pane tree utilities
@@ -1360,7 +1360,16 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       // a live TUI agent, send a one-line nudge instead of the full body so we
       // don't corrupt its prompt; otherwise (no live agent, or explicit
       // silent:false) keep the loud full-body paste.
-      if (!silent) {
+      // Same-ws task reply safety: a task whose from/to are the SAME workspace
+      // has no reliable per-pane reply address (the `from` side carries none), so
+      // the active-pane delivery below could paste back into the sender's own
+      // pane (loop) or an uninvolved pane. Suppress the paste for same-ws tasks;
+      // the reply is still persisted (addTaskMessage above) + queryable via
+      // a2a_task_query. NOTE: same-ws reply/status authz stays workspace-granular
+      // (any pane in the ws can reply) pending the per-pane `from.ptyId` model
+      // (S-C2 follow-up) — a documented limitation, not a cross-ws regression.
+      const sameWsTask = task.metadata.from.workspaceId === task.metadata.to.workspaceId;
+      if (!silent && !sameWsTask) {
         const replyingToReceiver = role === 'user';
         const targetWsId = replyingToReceiver ? task.metadata.to.workspaceId : task.metadata.from.workspaceId;
         const targetWs = store.workspaces.find((w) => w.id === targetWsId);
@@ -1426,7 +1435,10 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       const available = store.workspaces.map((w) => w.name).join(', ');
       return { error: `a2a.task.send: target "${to}" not found. Available: ${available}` };
     }
-    if (target.id === workspaceId) return { error: 'a2a.task.send: cannot send to yourself' };
+    // The same-workspace self-guard moved BELOW pane-address resolution (see
+    // decideSameWsSend) so a precise sibling-pane address is honored. A same-ws
+    // send is now rejected only when it has NO address (ambiguous) or resolves to
+    // the sender's OWN pane (true self). Cross-ws sends are unaffected.
 
     // Part A — optional pane-level addressing. Resolve paneId/surfaceId to a
     // concrete pty INSIDE the target ws (cross-ws ids fail-closed: only
@@ -1450,6 +1462,14 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       resolvedAddr = addr;
     }
 
+    // Same-workspace send policy (relocated self-guard + KS-1 true-self guard).
+    // senderPtyId is the caller's OWN pane anchor, supplied by the MCP server on
+    // a verified PID-map hit (absent on the env-hint fallback → fail closed on
+    // the paste, see suppressPaste below).
+    const senderPtyId = typeof params.senderPtyId === 'string' ? params.senderPtyId : '';
+    const sameWsDecision = decideSameWsSend(target.id === workspaceId, resolvedAddr?.ptyId, senderPtyId);
+    if (sameWsDecision.kind === 'reject') return { error: `a2a.task.send: ${sameWsDecision.error}` };
+
     const initialMessage: Message = { kind: 'message', messageId: generateId('msg'), role: 'user', parts };
 
     const newTaskId = store.createA2aTask({
@@ -1469,7 +1489,12 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // receiver must poll via a2a_task_query to discover it. silent-default:
     // an unset silent + live-TUI receiver gets a one-line nudge (prompt not
     // flooded); no live agent (or explicit silent:false) keeps the loud paste.
-    if (!silent) {
+    // Suppress the PTY paste when the user asked (silent) OR when a same-ws send
+    // can't be proven non-self (decideSameWsSend → suppressPaste). The task is
+    // still created + teed onto the EventBus below, so a sibling can poll it via
+    // a2a_task_query — only the loud prompt injection is withheld.
+    const suppressPaste = silent || sameWsDecision.suppressPaste;
+    if (!suppressPaste) {
       const explicitPty = resolvedAddr?.ptyId;
       // Liveness for the nudge-vs-paste choice must reflect the ADDRESSED pane's
       // agent (a workspace can host >1 agent), not ws-level metadata.

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -204,6 +204,13 @@ export const ENV_KEYS = {
   // hook bridge). Lets a hook attribute its capture to the EXACT pane instead of
   // collapsing to the workspace's active surface (split-pane / shared-cwd fix).
   PTY_ID: 'WMUX_PTY_ID',
+  // Instance-isolation suffix (dev / dogfood vs prod). Re-keys the control pipe
+  // + data dir — see dataSuffix() / getPipeName(). Unlike the identity vars it is
+  // NOT an ownership claim; it only selects WHICH instance a child joins, so it
+  // is deliberately PROPAGATED to child PTYs (forced from the spawning process's
+  // OWN env, never a child/profile value) so an agent/MCP/CLI inside a pane
+  // re-keys onto THIS instance's pipe instead of silently leaking onto production.
+  DATA_SUFFIX: 'WMUX_DATA_SUFFIX',
   SOCKET_PATH: 'WMUX_SOCKET_PATH',
   AUTH_TOKEN: 'WMUX_AUTH_TOKEN',
   SHELL_HOOK: 'WMUX_SHELL_HOOK',


### PR DESCRIPTION
## Why

A wmux workspace can **display** N collaborating agents (split panes, Fleet, Agent Teams) but they could not **address one another**. Every same-workspace path was closed:

- `a2a_task_send` to the same workspace → hard-rejected `cannot send to yourself` at *workspace* granularity, **before** the pane-level addressing PR #235 added. The exact "one workspace, many agents" case `pane_id`/`surface_id` were built for was reachable only **across** workspaces — the feature's own contract, dead on arrival.
- `terminal_send` with a sibling `ptyId` → fail-closed by the #163 hardening (correct as a security boundary, but it left zero sanctioned intra-workspace channels).

This is a CORE dependency for S-C2 (Agent Teams / multi-model compare-execute), which is *by definition* same-workspace-multi-pane. Found during live v3.5.0 dogfood (4 agents in one workspace, no working path to greet each other).

## What

Two tracks, two commits.

### Track 2 — `WMUX_DATA_SUFFIX` propagation (`fix(pty)`)
A child PTY (pane shell + any agent/MCP/CLI it spawns) did not inherit `WMUX_DATA_SUFFIX`, so it computed `getPipeName()` with an **empty** suffix and connected to the **production** control pipe — even inside an isolated dev/dogfood instance. A dogfood agent could drive the user's **real** workspaces. The blanket `WMUX_*` strip (built to stop identity spoofing) took the isolation suffix as collateral.

- `resolveSpawnEnv`: capture the suffix from the **spawning process's own env** before the strip, re-apply last (like identity). Covers local PTYManager **and** the daemon-via-main path.
- `DaemonSessionManager`: force the child's suffix to the **daemon's own** suffix, with a **delete-on-unset** branch — closes the recovery-replay vector where a persisted/hand-edited `session.env` suffix survives `stripReservedAuth` and points a recovered pane at a different instance's pipe.

Net **security-positive**: closes a sandbox→prod leak rather than opening one.

### Track 1 — same-workspace pane-to-pane A2A (`feat(a2a)`)
The self-guard was workspace-granular; it should mean "same **pane**", not "same **workspace**", once addressing exists.

- `a2aAddressing.decideSameWsSend` (pure, unit-tested): cross-ws unchanged · same-ws **no address** → reject (ambiguous, would loop to own active pane) · same-ws resolving to the sender's **own pty** → reject (true self-send = bracket-paste + forced submit into your own prompt = loop) · same-ws sibling with a **verified** sender pty → loud paste · same-ws sibling with an **absent** sender pty → deliver but **suppress** the paste.
- MCP self-pty capture (KS-1): `lookupPidMapWorkspace` reads the ptyId anchor from `a2a.resolve.identity` `entries[]`, cached on a verified hit and threaded as `senderPtyId`. It is **absent on the env-hint fallback — the common case** — which is precisely why the renderer fails closed on the *paste* (silent delivery) instead of trusting an absent guard. The task is still persisted + on the EventBus, so a sibling gets it via `a2a_task_query`; a self-addressed send is at worst a no-op pointer, never a loop.
- KS-2: same-ws task **replies** also suppress the paste (reply-to-`from` has no pane address → active-pane delivery could loop). Same-ws reply/status authz stays workspace-granular pending the per-pane `from.ptyId` model — documented, not a cross-ws regression.
- KS-3: the execute-approval dialog is **honest** when sender ws == receiver ws (an agent spawning an autonomous `bypassPermissions` agent in its own workspace).

The cross-workspace **fail-closed boundary (#163) is untouched**: `resolvePaneAddress` only ever searches the target's own tree, and the cross-ws path skips the same-ws gate entirely.

## Design provenance
Two independent adversarial reviews (Opus 4.8) hardened the design before implementation:
1. **senderPtyId is absent in the dominant pid-map-miss/env-hint path** → the guard can't be the only defense; the same-ws silent-delivery default is what actually closes the loop.
2. **Recovery replay survives a forged suffix** (`stripReservedAuth` keeps non-auth `WMUX_*`) → the daemon force **with the delete-on-unset branch** is required, not defensive garnish.

## Out of scope (S-C2 follow-up)
The full per-pane `from.ptyId` model: symmetric reply pinning, role-per-pane, pane-granular reply/status authz.

## Verification
- `tsc --noEmit` (main/daemon/mcp) = 0 · full unit suite **3432 + 16 runtime** green · API reference drift none · lint clean (pre-existing baseline only).
- **Live dogfood 10/10** in a single isolated packaged instance (`scripts/same-ws-a2a-dogfood.mjs`): same-ws A→B sibling send succeeds + pins to pane B (same-ws task) · true self-send + no-address rejected · senderPtyId-absent sibling falls back to silent · cross-ws back-compat + foreign-id fail-closed.

> Merge gate: pending the author's **GUI dogfood** with real Claude/Codex agent panes (exercises the MCP process-tree `senderPtyId` capture, which the RPC harness injects directly).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced same-workspace multi-agent communication with safer pane/surface addressing and improved “silent” handling.

* **Bug Fixes**
  * Strengthened self-send detection to prevent agent-to-agent loops.
  * Improved instance isolation for development and dogfood runs.
  * Updated the execution approval dialog to clearly describe same-workspace spawn scenarios.

* **Tests**
  * Added/expanded coverage for same-workspace addressing decisions, pane identity, and spawn environment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->