### PR TITLE
fix(terminal): yield right-click paste to the app when it owns the mouse

### DIFF
--- a/src/renderer/hooks/__tests__/useTerminal.rightClickPasteMouseMode.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.rightClickPasteMouseMode.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Source-level regression lock: right-click paste must yield to the foreground
+ * app's mouse mode.
+ *
+ * When a TUI enables mouse tracking (xterm mouseTrackingMode x10/vt200/drag/any,
+ * i.e. DECSET 9/1000/1002/1003 — vim `:set mouse=a`, htop, tmux, lazygit), a
+ * plain right-click is already delivered to it as a mouse event. wmux's
+ * `contextmenu` handler must therefore NOT also paste, or the single click is
+ * handled twice — the reported right-click double-paste. Shift+right-click
+ * forces wmux's own paste, matching Windows Terminal's Shift-override.
+ *
+ * The contextmenu handler runs against a real xterm Terminal plus DOM events
+ * that jsdom can't faithfully drive, so the invariant is pinned at the source
+ * level (matching the atlasClear / webglTeardown regression locks in this dir).
+ * Assertions are scoped to the contextmenu handler slice so unrelated paste
+ * sites (the Ctrl+V / Ctrl+Shift+V handlers) can't satisfy them by accident.
+ */
+
+const SRC = readFileSync(
+  path.resolve(process.cwd(), 'src/renderer/hooks/useTerminal.ts'),
+  'utf8',
+);
+
+// Slice just the contextmenu handler: from its registration to the catch that
+// logs '[wmux:clipboard] right-click error:'.
+const handlerStart = SRC.indexOf("addEventListener('contextmenu'");
+const handlerEnd = SRC.indexOf('right-click error:', handlerStart);
+const HANDLER = SRC.slice(handlerStart, handlerEnd);
+
+describe('useTerminal right-click paste yields to mouse mode (source-level lock)', () => {
+  it('locates the contextmenu handler', () => {
+    expect(handlerStart).toBeGreaterThan(-1);
+    expect(handlerEnd).toBeGreaterThan(handlerStart);
+  });
+
+  it('reads the foreground app mouse mode in the contextmenu handler', () => {
+    expect(HANDLER).toMatch(/modes\?\.mouseTrackingMode/);
+  });
+
+  it('bails out of the paste when mouse mode is on and Shift is not held', () => {
+    expect(HANDLER).toMatch(
+      /if\s*\(\s*mouseMode\s*!==\s*['"]none['"]\s*&&\s*!e\.shiftKey\s*\)\s*\{\s*return;/,
+    );
+  });
+
+  it('keeps Shift+right-click a true override of the post-copy suppression window', () => {
+    expect(HANDLER).toMatch(
+      /if\s*\(\s*!e\.shiftKey\s*&&\s*Date\.now\(\)\s*-\s*lastRightClickCopyAt\s*<\s*RIGHT_CLICK_PASTE_SUPPRESS_MS\s*\)/,
+    );
+  });
+
+  it('guards only the no-selection paste — after the selection-copy branch, before the paste write', () => {
+    const idxCopyBranch = HANDLER.indexOf('lastRightClickCopyAt = Date.now()');
+    const idxGuard = HANDLER.indexOf('mouseTrackingMode');
+    const idxPaste = HANDLER.indexOf('pastePtyChunked(');
+
+    expect(idxCopyBranch).toBeGreaterThan(-1);
+    // Guard sits AFTER the selection→copy branch, so selecting + right-clicking
+    // still copies (the guard never runs for that path).
+    expect(idxGuard).toBeGreaterThan(idxCopyBranch);
+    // Guard sits BEFORE the paste write, so it can suppress it.
+    expect(idxPaste).toBeGreaterThan(idxGuard);
+  });
+});

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -754,13 +754,26 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         return;
       }
 
+      // Foreground app owns the mouse (xterm mouseTrackingMode is non-'none' —
+      // x10/vt200/drag/any, i.e. DECSET 9/1000/1002/1003): a plain right-click
+      // already reaches the app as a mouse event, so wmux must NOT also paste —
+      // that double-handling is the reported right-click double-paste.
+      // Shift+right-click forces wmux's own paste (the suppression guard below
+      // honours Shift too), matching Windows Terminal's Shift-override.
+      const mouseMode = (terminal as unknown as { modes?: { mouseTrackingMode?: string } })
+        .modes?.mouseTrackingMode ?? 'none';
+      if (mouseMode !== 'none' && !e.shiftKey) {
+        return;
+      }
+
       // No selection, no link → paste immediately (text or image). Guard:
       // if a right-click copy just happened, this contextmenu is almost
       // certainly a stray repeat of the copy gesture (double right-click, or
       // the selection got wiped by incoming PTY data between two intentional
       // clicks). Suppressing the paste here is what kills the reported
-      // copy↔paste collision.
-      if (Date.now() - lastRightClickCopyAt < RIGHT_CLICK_PASTE_SUPPRESS_MS) {
+      // copy↔paste collision. A held Shift is a deliberate paste, so it
+      // bypasses this suppression — keeping Shift+right-click a true override.
+      if (!e.shiftKey && Date.now() - lastRightClickCopyAt < RIGHT_CLICK_PASTE_SUPPRESS_MS) {
         return;
       }
       void (async () => {


### PR DESCRIPTION
## Summary

In a pane whose foreground app has enabled mouse tracking (`vim :set mouse=a`, `htop`, `tmux`, `lazygit`), a plain right-click pasted the clipboard **twice** — once via the app's own mouse handling, once via wmux's `contextmenu` paste. This makes wmux yield the right-click to the app when it owns the mouse; **Shift+right-click** forces wmux's own paste (matching Windows Terminal).

## Changes

- `useTerminal.ts`: in the `contextmenu` no-selection paste branch, bail when `terminal.modes.mouseTrackingMode !== 'none'` and Shift is not held — the app already received the right-click as a mouse event, so wmux must not also paste.
- Make Shift a true override: the pre-existing post-copy suppression window now also honours Shift (`!e.shiftKey && …`), so a deliberate Shift+right-click is never swallowed.
- Add a source-level regression lock scoped to the `contextmenu` handler, matching the `atlasClear` / `webglTeardown` locks in the same dir (the handler runs against a real xterm `Terminal` + DOM events jsdom can't faithfully drive).

## CHANGELOG entry

### Changed

- In a pane where the foreground app has mouse tracking enabled, a plain right-click no longer pastes — use **Shift+right-click** to paste (matches Windows Terminal).

### Fixed

- Right-click no longer pastes the clipboard twice in panes whose foreground app owns the mouse (`vim :set mouse=a`, `htop`, `tmux`, `lazygit`).

## Stability tier impact

- [x] No external surface touched (internal refactor / docs / tests / CI).

Renderer-only terminal UI behavior; no RPC / protocol / API surface changes.

## Substrate contract impact (Substrate 3.0)

n/a — no PaneMetadata / EventBus / permission / Named Pipe / RPC changes.

## Test plan

- **Unit test added:** `src/renderer/hooks/__tests__/useTerminal.rightClickPasteMouseMode.test.ts` — a source-level regression lock asserting (a) the contextmenu handler reads `mouseTrackingMode`, (b) it bails when mouse mode is on and Shift is not held, (c) Shift overrides the post-copy suppression window, and (d) the guard sits after the selection→copy branch and before the paste write (so selection-copy is unaffected).
- **Full suite:** `npm run test:parallel` → 270 files / 3412 tests passed locally. `tsc --noEmit` clean; ESLint introduces no new issues.
- **Manual:** in a pane running `vim` with `:set mouse=a`, confirmed a plain right-click no longer double-pastes; **Shift+right-click** pastes; a plain PowerShell pane (no mouse mode) still right-click-pastes exactly as before. Selection + right-click still copies.

## Related issues / PRs

n/a

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed. (n/a — no surface change)
- [x] Tests cover the new behavior and the regression case (if a bug fix).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed right-click paste behavior in the terminal when mouse tracking is enabled. Shift+right-click now provides a consistent paste override option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->