### PR TITLE
fix(mcp): scoped read resolver for surface_list/pane_list (codex P2, #243)

### DIFF
--- a/src/mcp/__tests__/workspaceRouting.test.ts
+++ b/src/mcp/__tests__/workspaceRouting.test.ts
@@ -45,25 +45,40 @@ describe('MCP workspace routing (source-level invariants)', () => {
     return src.slice(start, next > start ? next : start + 800);
   }
 
-  it('only requireWorkspaceId() and the two fail-soft READ tools call the weak resolveWorkspaceId() — exactly three call sites', () => {
+  it('the weak resolveWorkspaceId() is called only by requireWorkspaceId and the fail-soft read resolver — exactly three call sites', () => {
     // requireWorkspaceId is the sanctioned caller for WRITE/identity tools: it
     // throws when the resolver returns falsy, so a write (browser_open, a2a_*,
     // terminal routing) never silently lands on the UI-active workspace — the
-    // exact bug this invariant guards.
+    // exact bug this invariant guards. It calls the weak resolver ONCE.
     //
-    // surface_list and pane_list are READ tools that deliberately call the weak
-    // resolver directly: caller-scoped when identity resolves (converging with
-    // a2a_whoami so a multi-agent workspace's surfaces are the CALLER's, not the
-    // GUI-focused ones), and a fail-soft active fallback on a genuine miss — a
-    // read must not throw during the boot reconcile window. They forward an
-    // explicit workspaceId once resolved, so the fallback only fires on a true
-    // identity miss. Any NEW direct call site must be reviewed against this
-    // read-vs-write split — hence the exact count.
+    // resolveScopedReadWorkspaceId is the fail-soft read resolver behind
+    // surface_list/pane_list. It calls the weak resolver TWICE: once normally,
+    // then again after invalidating a stale cached id (#243 P2-1). No tool
+    // handler calls the weak resolver directly anymore — reads route through
+    // resolveScopedReadWorkspaceId, writes through requireWorkspaceId — so any NEW
+    // direct call site must be reviewed against this read-vs-write split. Hence
+    // the exact count: 1 (requireWorkspaceId) + 2 (resolveScopedReadWorkspaceId).
     //
     // The `(?<!function )` lookbehind excludes the parameter-less declaration
     // (`async function resolveWorkspaceId()`) so only call sites are counted.
     const directCalls = src.match(/(?<!function )resolveWorkspaceId\(\)/g) ?? [];
     expect(directCalls).toHaveLength(3);
+  });
+
+  it('surface_list/pane_list route through resolveScopedReadWorkspaceId, not the weak resolver (#243)', () => {
+    for (const tool of ['surface_list', 'pane_list']) {
+      const block = toolBlock(tool);
+      expect(block, `${tool} should resolve via resolveScopedReadWorkspaceId`).toMatch(/resolveScopedReadWorkspaceId\(\)/);
+    }
+  });
+
+  it('resolveScopedReadWorkspaceId revalidates a stale id and prefers the pin (#243 P2-1/P2-2)', () => {
+    const start = src.indexOf('async function resolveScopedReadWorkspaceId');
+    expect(start).toBeGreaterThan(0);
+    const block = src.slice(start, start + 600);
+    expect(block, 'P2-1: must revalidate liveness').toMatch(/isLiveWorkspace/);
+    expect(block, 'P2-1: must invalidate a stale cached id').toMatch(/invalidateWorkspaceId/);
+    expect(block, 'P2-2: must prefer the external pin').toMatch(/getPinnedRoute/);
   });
 
   it('browser_open routes through requireWorkspaceId, never the weak resolver', () => {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -267,6 +267,34 @@ async function requireWorkspaceId(): Promise<string> {
   return wsId;
 }
 
+/**
+ * Resolve the caller's workspace for fail-soft READ tools (surface_list /
+ * pane_list). Hardens the omitted-workspace path beyond the weak
+ * resolveWorkspaceId (codex P2 follow-ups, #243):
+ *   - Staleness (P2-1): the resolveWorkspaceId fast path can return a cached id
+ *     that is no longer live after a workspace re-mint (daemon respawn / session
+ *     restore). For a fail-soft read that would otherwise keep reporting an empty
+ *     list, revalidate the id and re-resolve clean once it is proven gone.
+ *   - External pin (P2-2): a confirmed-external caller has no PID/env identity but
+ *     may have claimed a dedicated workspace via terminal_read. Prefer that pin
+ *     over the renderer's UI-active fallback so the read reports the caller's OWN
+ *     workspace, not whatever the user has focused.
+ * Still degrades to '' (renderer active-ws fallback) on a true miss — a read must
+ * never throw.
+ */
+async function resolveScopedReadWorkspaceId(): Promise<string> {
+  let wsId = await resolveWorkspaceId();
+  if (wsId && (await isLiveWorkspace(wsId)) === 'absent') {
+    invalidateWorkspaceId();
+    wsId = await resolveWorkspaceId();
+  }
+  if (!wsId) {
+    const pin = getPinnedRoute();
+    if (pin?.workspaceId) wsId = pin.workspaceId;
+  }
+  return wsId;
+}
+
 // Verified terminal routing — see src/mcp/terminalRouting.ts for the full
 // state machine. Binds the router's deps to this module's PID-map lookup,
 // verified-identity cache, and external-claim pinning. Unlike A2A tools,
@@ -480,11 +508,12 @@ server.tool(
   },
   async ({ workspaceId }) => {
     // Scope to the CALLER's own workspace when omitted, not the GUI-focused one
-    // (the a2a_whoami-vs-surface_list divergence). resolveWorkspaceId is
-    // fail-soft (returns '' on identity miss, never throws — unlike a write tool,
-    // a read must not hard-fail); an empty resolution falls back to the
-    // renderer's active-ws default, preserving the old behavior.
-    const resolved = workspaceId || (await resolveWorkspaceId());
+    // (the a2a_whoami-vs-surface_list divergence). resolveScopedReadWorkspaceId
+    // is fail-soft (returns '' on identity miss, never throws — unlike a write
+    // tool, a read must not hard-fail), revalidates a stale cached id, and
+    // prefers an external caller's pin (#243); an empty resolution falls back to
+    // the renderer's active-ws default, preserving the old behavior.
+    const resolved = workspaceId || (await resolveScopedReadWorkspaceId());
     return callRpc('surface.list', resolved ? { workspaceId: resolved } : {});
   },
 );
@@ -497,8 +526,8 @@ server.tool(
   },
   async ({ workspaceId }) => {
     // Caller-scoped when omitted (see surface_list) — fail-soft via
-    // resolveWorkspaceId so a read never throws on identity miss.
-    const resolved = workspaceId || (await resolveWorkspaceId());
+    // resolveScopedReadWorkspaceId so a read never throws on identity miss.
+    const resolved = workspaceId || (await resolveScopedReadWorkspaceId());
     return callRpc('pane.list', resolved ? { workspaceId: resolved } : {});
   },
 );


### PR DESCRIPTION
## codex P2 hardening (#243) — for v3.5.1

Follow-up to the codex review on #242. v3.5.0 shipped with these as a tracked follow-up (#243); pulling them forward as a hotfix.

`surface_list`/`pane_list` now resolve the caller's workspace through `resolveScopedReadWorkspaceId`:

- **P2-1 (stale cache).** After a workspace re-mint (daemon respawn / session restore), the `resolveWorkspaceId` fast path could return a stale cached id, and the renderer's `[]` for an unknown workspace never invalidated it — so a fail-soft read kept reporting an empty list until some other op happened to recover. The helper now revalidates via `isLiveWorkspace` and re-resolves clean once the id is proven gone.
- **P2-2 (external pin).** A confirmed-external caller (no PID/env identity) that claimed a workspace via `terminal_read` now has that pin preferred over the renderer's UI-active fallback, so `surface_list` reports the caller's OWN workspace, not whatever the user has focused.

Still fail-soft — degrades to `''` (renderer active-ws) on a true miss, never throws. **a2a/write tools are unchanged** (they keep `requireWorkspaceId`), so the a2a identity path cannot regress.

Closes #243.

### Verification
- `tsc --noEmit` 0
- full unit suite **3477** passed (no regression)
- workspaceRouting invariant + P2 source assertions (`isLiveWorkspace` / `invalidateWorkspaceId` / `getPinnedRoute`) — 11/11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced workspace routing test coverage with more precise validation checks for read tool behavior.

* **Bug Fixes**
  * Improved workspace reference resolution reliability with better stale detection and external pinning support for read operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->