### PR TITLE
fix(pane): keep both sides visible in the terminal+browser split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Terminal + browser split no longer blanks the unfocused side ([#247](https://github.com/openwong2kim/wmux/pull/247)).** A pane holding both a terminal and a browser surface renders them in a side-by-side split, but each surface gated its visibility on the pane's single active-surface id — so focusing one side hid the other (`display:none`) and the unfocused pane went blank, toggling as you switched. Visibility is now decoupled from focus: both sides stay rendered, and the active-surface id only drives keyboard focus.
+
 ## [3.5.1] — 2026-06-17
 
 ### Fixed

--- a/src/renderer/components/Browser/BrowserPanel.tsx
+++ b/src/renderer/components/Browser/BrowserPanel.tsx
@@ -21,7 +21,12 @@ interface BrowserPanelProps {
   surfaceId: string;
   initialUrl: string;
   partition: string;
+  /** Focused surface (drives F12 devtools + toolbar active state). */
   isActive: boolean;
+  /** Rendered (display:flex) regardless of focus. The terminal+browser split
+   *  shows both sides at once, so visibility is decoupled from `isActive`.
+   *  Defaults to `isActive` (stacked/tab case: only the active tab renders). */
+  visible?: boolean;
   onClose: () => void;
 }
 
@@ -29,7 +34,7 @@ interface BrowserPanelProps {
 // Component
 // ---------------------------------------------------------------------------
 
-export default function BrowserPanel({ surfaceId, initialUrl, partition, isActive, onClose }: BrowserPanelProps) {
+export default function BrowserPanel({ surfaceId, initialUrl, partition, isActive, visible, onClose }: BrowserPanelProps) {
   const t = useT();
   const updateBrowserUrl = useStore((s) => s.updateBrowserUrl);
   const webviewRef = useRef<Electron.WebviewTag>(null);
@@ -324,7 +329,7 @@ export default function BrowserPanel({ surfaceId, initialUrl, partition, isActiv
       style={{
         position: 'absolute',
         inset: 0,
-        display: isActive ? 'flex' : 'none',
+        display: (visible ?? isActive) ? 'flex' : 'none',
       }}
     >
       {/* Title bar strip showing page title */}

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -67,6 +67,29 @@ export function composePaneClassName(opts: {
   return classes.join(' ');
 }
 
+/**
+ * Choose which terminal and which browser surface is SHOWN on each side of the
+ * terminal+browser split (`SplitSurfaceView` hasBoth). Both sides are laid out
+ * side by side and must stay visible, but a pane has a single `activeSurfaceId`,
+ * so visibility (what renders on each side) must be decoupled from focus (which
+ * side `activeSurfaceId` points at). Each side shows its active surface when the
+ * active surface is on that side, otherwise its first surface — so neither side
+ * ever blanks when the other is focused. (Bug: each surface gated `display` on
+ * `surface.id === activeSurfaceId`, so focusing one side display:none'd the other.)
+ *
+ * Pure so it is unit-testable without mounting the split (which pulls in xterm).
+ */
+export function pickSplitShownSurfaces(
+  terminals: ReadonlyArray<{ id: string }>,
+  browsers: ReadonlyArray<{ id: string }>,
+  activeSurfaceId: string,
+): { shownTerminalId: string | undefined; shownBrowserId: string | undefined } {
+  return {
+    shownTerminalId: terminals.find((s) => s.id === activeSurfaceId)?.id ?? terminals[0]?.id,
+    shownBrowserId: browsers.find((s) => s.id === activeSurfaceId)?.id ?? browsers[0]?.id,
+  };
+}
+
 export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVisible = true }: PaneProps) {
   const t = useT();
   const [flashing, setFlashing] = useState(false);
@@ -534,7 +557,11 @@ function SplitSurfaceView({
     );
   }
 
-  // Both terminals and browsers exist — resizable split
+  // Both terminals and browsers exist — resizable split. Both sides stay
+  // visible at once; visibility is decoupled from the pane's single
+  // activeSurfaceId (which now only drives focus), else focusing one side
+  // display:none'd the other (blank-pane bug).
+  const { shownTerminalId, shownBrowserId } = pickSplitShownSurfaces(terminals, browsers, activeSurfaceId);
   return (
     <div className="flex-1 relative overflow-hidden">
       <Group orientation="horizontal" className="h-full w-full" resizeTargetMinimumSize={{ coarse: 37, fine: 16 }}>
@@ -547,6 +574,7 @@ function SplitSurfaceView({
                 ptyId={surface.ptyId || undefined}
                 cwd={surface.cwd || undefined}
                 isActive={surface.id === activeSurfaceId}
+                visible={surface.id === shownTerminalId}
                 isWorkspaceVisible={isWorkspaceVisible}
                 onPtyCreated={(ptyId) => onPtyCreated(surface.id, ptyId)}
                 scrollbackFile={surface.scrollbackFile}
@@ -569,6 +597,7 @@ function SplitSurfaceView({
                 initialUrl={surface.browserUrl || 'https://google.com'}
                 partition={surface.browserPartition || 'persist:wmux-default'}
                 isActive={surface.id === activeSurfaceId}
+                visible={surface.id === shownBrowserId}
                 onClose={() => onCloseSurface(surface.id)}
               />
             ))}

--- a/src/renderer/components/Pane/__tests__/Pane.splitVisibility.test.tsx
+++ b/src/renderer/components/Pane/__tests__/Pane.splitVisibility.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Regression tests for the terminal+browser split blank-pane bug.
+ *
+ * Symptom: in a pane holding BOTH a terminal and a browser surface,
+ * `SplitSurfaceView` lays them out side by side but each surface gated its
+ * `display` on `surface.id === activeSurfaceId`. A pane has a single
+ * `activeSurfaceId`, so focusing one side display:none'd the other — the
+ * non-focused side went blank, toggling as the user switched.
+ *
+ * Fix: `pickSplitShownSurfaces` decouples visibility (what renders on each
+ * side) from focus (`activeSurfaceId`). Each side shows its active surface when
+ * the active surface is on that side, else its first surface — so neither side
+ * ever blanks. These tests pin that contract.
+ *
+ * Runs in the repo's node (no-JSDOM) vitest env — same pattern as
+ * Pane.notificationRing.test.tsx (the pure helper is the load-bearing piece).
+ */
+import { describe, it, expect } from 'vitest';
+import { pickSplitShownSurfaces } from '../Pane';
+
+const T = (id: string) => ({ id });
+
+describe('pickSplitShownSurfaces — split visibility decoupled from focus', () => {
+  it('common 1 terminal + 1 browser: BOTH sides shown when the terminal is focused', () => {
+    const r = pickSplitShownSurfaces([T('term-1')], [T('brow-1')], 'term-1');
+    expect(r.shownTerminalId).toBe('term-1');
+    // The regression: the browser side must STILL show its surface, not blank.
+    expect(r.shownBrowserId).toBe('brow-1');
+  });
+
+  it('common 1 terminal + 1 browser: BOTH sides shown when the browser is focused', () => {
+    const r = pickSplitShownSurfaces([T('term-1')], [T('brow-1')], 'brow-1');
+    // The regression in the other direction: the terminal side must not blank.
+    expect(r.shownTerminalId).toBe('term-1');
+    expect(r.shownBrowserId).toBe('brow-1');
+  });
+
+  it('neither side blanks for EITHER focus target (the core invariant)', () => {
+    const terminals = [T('term-1')];
+    const browsers = [T('brow-1')];
+    for (const active of ['term-1', 'brow-1']) {
+      const r = pickSplitShownSurfaces(terminals, browsers, active);
+      expect(r.shownTerminalId).toBeDefined();
+      expect(r.shownBrowserId).toBeDefined();
+    }
+  });
+
+  it('multiple terminal tabs: the FOCUSED terminal shows; browser side shows its first', () => {
+    const r = pickSplitShownSurfaces([T('term-1'), T('term-2')], [T('brow-1')], 'term-2');
+    expect(r.shownTerminalId).toBe('term-2'); // active tab on the terminal side
+    expect(r.shownBrowserId).toBe('brow-1'); // browser side keeps its first, never blank
+  });
+
+  it('multiple browser tabs: the FOCUSED browser shows; terminal side shows its first', () => {
+    const r = pickSplitShownSurfaces([T('term-1'), T('term-2')], [T('brow-1'), T('brow-2')], 'brow-2');
+    expect(r.shownTerminalId).toBe('term-1'); // terminal side falls back to first (active is a browser)
+    expect(r.shownBrowserId).toBe('brow-2'); // active browser tab
+  });
+
+  it('active surface absent from both lists: each side falls back to its first', () => {
+    const r = pickSplitShownSurfaces([T('term-1')], [T('brow-1')], 'stale-id');
+    expect(r.shownTerminalId).toBe('term-1');
+    expect(r.shownBrowserId).toBe('brow-1');
+  });
+
+  it('defensive: empty side yields undefined (no throw) without affecting the other', () => {
+    expect(pickSplitShownSurfaces([], [T('brow-1')], 'brow-1')).toEqual({
+      shownTerminalId: undefined,
+      shownBrowserId: 'brow-1',
+    });
+    expect(pickSplitShownSurfaces([T('term-1')], [], 'term-1')).toEqual({
+      shownTerminalId: 'term-1',
+      shownBrowserId: undefined,
+    });
+  });
+});

--- a/src/renderer/components/Terminal/Terminal.tsx
+++ b/src/renderer/components/Terminal/Terminal.tsx
@@ -21,8 +21,14 @@ interface TerminalProps {
   shell?: string;
   cwd?: string;
   onPtyCreated?: (ptyId: string) => void;
-  /** True when this surface tab is the selected tab inside its pane. */
+  /** True when this surface tab is the selected tab inside its pane (drives
+   *  keyboard focus, vi-copy mode, search bar). */
   isActive?: boolean;
+  /** True when this surface should be RENDERED (display:flex) regardless of
+   *  focus. The terminal+browser split shows both sides at once, so visibility
+   *  is decoupled from `isActive`. Defaults to `isActive` (stacked/tab case:
+   *  only the active tab renders). */
+  visible?: boolean;
   /** True when the parent workspace is the currently visible workspace.
    *  False when the workspace is hidden via display:none in AppLayout.
    *  Defaults to true so callers that don't use the all-workspaces rendering
@@ -39,7 +45,7 @@ interface TerminalProps {
   surfaceId?: string;
 }
 
-export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, onPtyCreated, isActive = true, isWorkspaceVisible = true, scrollbackFile, workspaceId: ownerWorkspaceId, surfaceId: ownerSurfaceId }: TerminalProps) {
+export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, onPtyCreated, isActive = true, visible, isWorkspaceVisible = true, scrollbackFile, workspaceId: ownerWorkspaceId, surfaceId: ownerSurfaceId }: TerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [ptyId, setPtyId] = useState<string | null>(externalPtyId || null);
   const creatingRef = useRef(false);
@@ -155,7 +161,12 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
     setCtxMenu(e);
   }, []);
 
-  const isVisible = isWorkspaceVisible && isActive;
+  // `visible` decouples render (display) from focus (`isActive`): the
+  // terminal+browser split shows both sides at once, so a visible-but-unfocused
+  // terminal must still render AND fit (else xterm stays blank). Falls back to
+  // `isActive` for the stacked/tab case (one tab visible at a time).
+  const shown = visible ?? isActive;
+  const isVisible = isWorkspaceVisible && shown;
   const { terminal: terminalRef, findNext, findPrevious, clearSearch } = useTerminal(containerRef, { ptyId, isVisible, scrollbackFile, onFirstData: scrollbackFile ? handleFirstData : undefined, onContextMenu: handleContextMenu });
 
   const showViCopyMode = viCopyModeActive && isActive && terminalRef.current !== null;
@@ -285,7 +296,7 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
   return (
     <div
       style={{
-        display: isActive ? 'flex' : 'none',
+        display: shown ? 'flex' : 'none',
         flexDirection: 'column',
         width: '100%',
         height: '100%',


### PR DESCRIPTION
## Problem
In a pane that holds **both** a terminal and a browser surface, `SplitSurfaceView`'s `hasBoth` branch lays them out in a side-by-side resizable split — but each surface gated its `display` on `surface.id === activeSurfaceId`. A pane has a single `activeSurfaceId`, so only one side was ever visible: focusing the terminal `display:none`'d the browser and vice versa. The unfocused side went blank, and the blank toggled as the user switched surfaces.

## Root cause
`isActive` conflated two concepts — **visibility** (which surface renders, correct for the stacked/tab case) and **focus** (keyboard / devtools / toolbar). In the side-by-side split both sides must stay visible, but the single-`activeSurfaceId` gate hid one. `Terminal.tsx` also tied `isVisible` (the xterm fit/render) to `isActive`, so even a shown-but-inactive terminal stayed blank.

## Fix
Decouple visibility from focus:
- `pickSplitShownSurfaces()` (pure, unit-tested) picks the shown surface per side — the active one if it is on that side, else the first — so neither side blanks.
- A new `visible` prop on `TerminalComponent` / `BrowserPanel` drives `display` (and the xterm fit) independently of `isActive`, which now only drives focus. It defaults to `isActive`, so the stacked/tab path is unchanged.

## Testing
- New `Pane.splitVisibility.test.tsx` — 7 cases pinning the invariant (focusing either side never blanks the other; multi-tab per side; stale/empty fallbacks).
- `tsc` clean · full suite **3484/3484** · no new lint findings.

## Notes
- Out of scope (separate latent bug, noted for follow-up): an `editor` surface coexisting with a terminal **and** a browser in one pane falls outside the `hasBoth` terminal/browser filters and is not rendered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed visibility behavior when a terminal and browser are displayed side-by-side in a split pane. Previously, switching focus between them would hide the unfocused surface. Now both surfaces remain fully visible and rendered, with only keyboard focus changing as you switch between the active surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->