### PR TITLE
fix(browser): focus webview when its pane is active so keyboard input works (#252)

### DIFF
--- a/src/renderer/components/Browser/BrowserPanel.tsx
+++ b/src/renderer/components/Browser/BrowserPanel.tsx
@@ -140,6 +140,23 @@ export default function BrowserPanel({ surfaceId, initialUrl, partition, isActiv
     return () => window.removeEventListener('keydown', handler);
   }, [isActive]);
 
+  // Pull DOM keyboard focus onto the webview when this surface is the active
+  // one. useActivePaneFocus deliberately skips browser/editor surfaces (they
+  // have no xterm to focus), so without this the keyboard focus stays on the
+  // previously focused terminal / <body> and every keystroke in the page is
+  // dropped — mouse works (Electron handles pointer natively) but typing does
+  // nothing (#252, pre-existing since #75).
+  //
+  // Gated on `isActive` (focus), NOT `visible` (display): in a terminal+browser
+  // split BOTH sides are visible but only one is active, and focus must follow
+  // the active surface so the browser never steals focus from the terminal
+  // side. `isReady` ensures the guest webContents exists before we focus it.
+  // DOM focus is singular, so webview.focus() moves focus off the prior xterm.
+  useEffect(() => {
+    if (!isActive || !(visible ?? isActive) || !isReady) return;
+    webviewRef.current?.focus();
+  }, [isActive, visible, isReady]);
+
   const handleNavigate = useCallback((url: string) => {
     if (!isSafeBrowserUrl(url)) return;
     const wv = webviewRef.current;
@@ -326,6 +343,12 @@ export default function BrowserPanel({ surfaceId, initialUrl, partition, isActiv
   return (
     <div
       className="flex flex-col h-full w-full overflow-hidden"
+      // Clicking the toolbar / title strip / page chrome (anywhere in the
+      // pane) pulls keyboard focus onto the webview. Clicking *inside* page
+      // content already focuses the guest natively, but pane-switch clicks and
+      // clicks on our own chrome do not — without this, keyboard input stays
+      // dead after such a click (#252).
+      onClick={() => webviewRef.current?.focus()}
       style={{
         position: 'absolute',
         inset: 0,

--- a/src/renderer/components/Browser/__tests__/BrowserPanel.focus.dynamic.test.tsx
+++ b/src/renderer/components/Browser/__tests__/BrowserPanel.focus.dynamic.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+//
+// #252 — BrowserPanel keyboard-focus DYNAMIC harness.
+//
+// Symptom: in a browser pane the mouse works but no keyboard input reaches the
+// page. useActivePaneFocus deliberately skips browser/editor surfaces (they
+// have no xterm), so DOM keyboard focus is never moved onto the <webview>; it
+// stays on the previously focused terminal / <body> and every keystroke is
+// dropped. The fix gives BrowserPanel its own focus path:
+//   1. a useEffect that calls webviewRef.current.focus() when the surface is
+//      active AND visible AND the webview is dom-ready, and
+//   2. an onClick on the pane container that focuses the webview (so toolbar /
+//      chrome / pane-switch clicks focus it too).
+//
+// This mounts the REAL <BrowserPanel/> via react-dom/client createRoot so its
+// effects run, drives `dom-ready` to flip the internal `isReady` state, and
+// asserts webview.focus() is (or is not) called. End-to-end keystroke delivery
+// in a live Electron <webview> cannot be exercised in jsdom — the load-bearing
+// proof here is that .focus() is invoked under exactly the right conditions.
+//
+// jsdom renders <webview> as an HTMLUnknownElement which still carries the
+// HTMLElement.focus() method; we replace that element's own `focus` with a
+// vi.fn() spy AFTER mount (so the spy is in place before the state change that
+// should trigger it) and assert on the call count. Electron-only webview APIs
+// (getWebContentsId, canGoBack, …) are absent in jsdom; the component already
+// guards them with optional chaining / try-catch, so dom-ready is a no-op
+// beyond setting isReady.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as React from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import BrowserPanel from '../BrowserPanel';
+import { useStore } from '../../../stores';
+
+// React 19 ships act() from the package root.
+const act = React.act;
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// ─── Mount lifecycle ────────────────────────────────────────────────────────
+
+let container: HTMLDivElement;
+let root: Root;
+
+interface MountProps {
+  isActive: boolean;
+  visible?: boolean;
+  surfaceId?: string;
+}
+
+function mount(props: MountProps): void {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(
+      React.createElement(BrowserPanel, {
+        surfaceId: props.surfaceId ?? 'surf-1',
+        initialUrl: 'https://example.com',
+        partition: 'persist:test',
+        isActive: props.isActive,
+        visible: props.visible,
+        onClose: () => {},
+      }),
+    );
+  });
+}
+
+function unmount(): void {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+/** The rendered <webview> intrinsic (HTMLUnknownElement in jsdom). */
+function webviewEl(surfaceId = 'surf-1'): HTMLElement {
+  const el = document.querySelector<HTMLElement>(`webview[data-surface-id="${surfaceId}"]`);
+  if (!el) throw new Error('webview element not rendered');
+  return el;
+}
+
+/** Replace the webview's own focus() with a spy (after mount, before trigger). */
+function spyWebviewFocus(surfaceId = 'surf-1'): ReturnType<typeof vi.fn> {
+  const el = webviewEl(surfaceId);
+  const fn = vi.fn();
+  el.focus = fn;
+  return fn;
+}
+
+/** Flip the component's internal isReady by firing the webview's dom-ready. */
+function fireDomReady(surfaceId = 'surf-1'): void {
+  const el = webviewEl(surfaceId);
+  act(() => {
+    el.dispatchEvent(new Event('dom-ready'));
+  });
+}
+
+/** The outer pane container that carries the click-to-focus handler. */
+function paneContainer(): HTMLElement {
+  const el = container.firstElementChild as HTMLElement | null;
+  if (!el) throw new Error('pane container not rendered');
+  return el;
+}
+
+beforeEach(() => {
+  // The component subscribes to `locale` (useT) and calls updateBrowserUrl on
+  // navigation; a clean known store keeps both deterministic.
+  act(() => {
+    useStore.setState({ locale: 'en' });
+  });
+});
+
+afterEach(() => {
+  try {
+    unmount();
+  } catch {
+    /* some tests unmount themselves */
+  }
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('BrowserPanel — webview keyboard focus (#252)', () => {
+  it('focuses the webview once it becomes dom-ready while active', () => {
+    mount({ isActive: true });
+    // Before dom-ready: isReady is false, so the focus effect must not fire.
+    const focus = spyWebviewFocus();
+    expect(focus).not.toHaveBeenCalled();
+
+    fireDomReady();
+
+    // dom-ready flips isReady → the active surface grabs DOM focus.
+    expect(focus).toHaveBeenCalled();
+  });
+
+  it('does NOT focus the webview when the surface is not active (split background side)', () => {
+    // A terminal+browser split: this browser is rendered (visible) but the
+    // terminal side holds focus (isActive=false). It must not steal focus.
+    mount({ isActive: false, visible: true });
+    const focus = spyWebviewFocus();
+
+    fireDomReady();
+
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it('does NOT focus the webview when active but not yet ready', () => {
+    mount({ isActive: true });
+    const focus = spyWebviewFocus();
+    // No dom-ready fired → guest webContents not up yet → no focus.
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it('focuses the webview when the pane container is clicked', () => {
+    // Even an inactive/not-ready surface should focus on an explicit click —
+    // this is the toolbar / chrome / pane-switch click path.
+    mount({ isActive: false, visible: true });
+    const focus = spyWebviewFocus();
+
+    act(() => {
+      paneContainer().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  it('focuses on click independently of the active-surface effect', () => {
+    mount({ isActive: true });
+    const focus = spyWebviewFocus();
+    // Click before dom-ready: the effect has not fired, so the only call is the
+    // click handler's — proving the click path stands on its own.
+    act(() => {
+      paneContainer().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  it('focuses when becoming active after already being ready (active toggles last)', () => {
+    // Start visible but inactive and let it become ready (no focus yet), then
+    // make it the active surface — focus must follow the active flip.
+    mount({ isActive: false, visible: true });
+    fireDomReady();
+    const focus = spyWebviewFocus();
+    expect(focus).not.toHaveBeenCalled();
+
+    act(() => {
+      root.render(
+        React.createElement(BrowserPanel, {
+          surfaceId: 'surf-1',
+          initialUrl: 'https://example.com',
+          partition: 'persist:test',
+          isActive: true,
+          visible: true,
+          onClose: () => {},
+        }),
+      );
+    });
+
+    expect(focus).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Fix #252 — keyboard input did not work in the **browser pane** (all keys; mouse worked fine).

## Root cause
The browser `<webview>` never received DOM keyboard focus. `useActivePaneFocus` (the hook that pulls focus onto the active pane) explicitly skips browser/editor surfaces (`useActivePaneFocus.ts:34`, no xterm to focus) and leaves focus on the previously-focused terminal / `<body>`. `BrowserPanel` had a `webviewRef` but never called `.focus()` and had no click-to-focus.

**Pre-existing since #75** (not a #247 regression) — CDP dogfooding masked it because automation focuses the webview directly. Mouse worked because Electron's webview handles pointer events natively; keyboard needs persistent DOM focus that never moved to the webview.

## Fix (minimal, BrowserPanel-owned focus)
- **Focus-on-active effect:** `webview.focus()` when the surface is `isActive` + `visible` + `isReady` (deps `[isActive, visible, isReady]`).
- **Container `onClick`** → `webview.focus()` (toolbar / chrome / pane-switch clicks; clicking inside page content already focuses natively).
- `useActivePaneFocus` left as-is (its browser skip is correct).

## #247 split safety
Focus follows `isActive` (focus), NOT `visible` (display). In a terminal+browser split both are visible but only one is active, so the background browser never steals focus from the terminal. Covered by a test.

## Tests
New `BrowserPanel.focus.dynamic.test.tsx` (6 cases: active+ready → focus; inactive → no focus; not-ready → no focus; click → focus; ready-after-active → focus follows). Renderer 1244 / full suite **3598 passed**, tsc 0.

## ⚠️ GUI verification needed before merge
Actual keystroke delivery into a real Electron webview can't be exercised in jsdom — the unit proof is that `.focus()` is called under the right conditions. Please confirm in a live browser pane that typing now works.

## Follow-up (not in this PR)
Clicking an *inactive* browser side in a split focuses its webview but doesn't update the store's active marker (click-to-activate not wired in BrowserPanel). Minor; separate change.

Closes #252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard focus handling in the browser panel. The panel now actively manages focus to prevent keystrokes from being lost when users click on toolbars or other interface elements. Focus is automatically restored to the browser surface when appropriate.

* **Tests**
  * Added test suite for browser panel focus behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->