### PR TITLE
chore(a2a): remove dead execute-gate code + extract/test the approval gate

### DIFF
--- a/src/renderer/components/FleetView/ApprovalInboxList.tsx
+++ b/src/renderer/components/FleetView/ApprovalInboxList.tsx
@@ -110,7 +110,7 @@ export default function ApprovalInboxList({ items, focusedIdx, onResolve }: Appr
                 </span>
               </div>
               {/* Who is asking + what they want — security context (subordinate,
-                  muted, mono). Uses the previously-dead from/to/a2aDesc keys. */}
+                  muted, mono). Uses the from/to/a2aDescRemote/a2aDescSameWorkspace keys. */}
               <div className="text-[10px] font-mono" style={{ color: 'var(--text-subtle)' }}>
                 {t('fleet.approvals.from')} {wsName(item.senderWorkspaceId)}
                 {' → '}

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -9,7 +9,7 @@ import { generateId } from '../../shared/types';
 import { handleCompanyRpc } from '../../company/renderer/rpcHandlers';
 import { formatA2aMessage, formatA2aBroadcast, sanitizeA2aName } from '../utils/a2aFormat';
 import type { A2aPriority } from '../utils/a2aFormat';
-import { resolveExecuteApproval, setExecuteApprovalResolver } from '../utils/executeApproval';
+import { requestExecuteApproval } from '../utils/executeApprovalGate';
 import { openUrlInBrowserPane } from '../utils/browserPaneActions';
 import { terminalRegistry } from './useTerminal';
 import { readPtyBufferLines } from '../utils/terminalTail';
@@ -107,43 +107,6 @@ function submitToPty(ptyId: string, text: string): void {
 
 type RpcParams = Record<string, unknown>;
 type RpcResult = unknown;
-
-const EXECUTE_APPROVAL_TIMEOUT_MS = 30_000;
-
-function requestExecuteApproval(input: {
-  taskId: string;
-  senderWorkspaceId: string;
-  receiverWorkspaceId: string;
-  messagePreview: string;
-  cwd: string | null;
-}): Promise<boolean> {
-  if (useStore.getState().a2aAutoApproveExecute) return Promise.resolve(true);
-
-  const approvalId = generateId('approval');
-  const expiresAt = Date.now() + EXECUTE_APPROVAL_TIMEOUT_MS;
-
-  return new Promise<boolean>((resolve) => {
-    let settled = false;
-    const settle = (approved: boolean) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      useStore.getState().removeExecuteApproval(approvalId);
-      resolve(approved);
-    };
-    const timer = setTimeout(() => resolveExecuteApproval(approvalId, false), EXECUTE_APPROVAL_TIMEOUT_MS);
-    setExecuteApprovalResolver(approvalId, settle);
-    useStore.getState().enqueueExecuteApproval({
-      approvalId,
-      taskId: input.taskId,
-      senderWorkspaceId: input.senderWorkspaceId,
-      receiverWorkspaceId: input.receiverWorkspaceId,
-      messagePreview: input.messagePreview,
-      cwd: input.cwd,
-      expiresAt,
-    });
-  });
-}
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -1202,20 +1165,6 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
   // -------------------------------------------------------------------------
   // a2a.*
   // -------------------------------------------------------------------------
-
-  if (method === 'a2a.confirmExecute') {
-    // Compatibility path for older main flows. New a2a.task.send requests gate
-    // execute inside the renderer before task creation.
-    const taskId = typeof params.taskId === 'string' ? params.taskId : '';
-    if (!taskId) return { approved: false };
-
-    const senderWorkspaceId = typeof params.senderWorkspaceId === 'string' ? params.senderWorkspaceId : '';
-    const receiverWorkspaceId = typeof params.receiverWorkspaceId === 'string' ? params.receiverWorkspaceId : '';
-    const messagePreview = typeof params.messagePreview === 'string' ? params.messagePreview : '';
-    const cwd = typeof params.cwd === 'string' ? params.cwd : null;
-    const approved = await requestExecuteApproval({ taskId, senderWorkspaceId, receiverWorkspaceId, messagePreview, cwd });
-    return { approved };
-  }
 
   if (method === 'a2a.resolve.identity') {
     // Resolve workspace from PTY workspace ID passed via env var

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -137,7 +137,6 @@ export const en = {
   'fleet.approvals.deny': 'Deny',
   'fleet.approvals.critical': 'Critical',
   'fleet.approvals.a2aTitle': 'Background execution',
-  'fleet.approvals.a2aDesc': 'A remote A2A caller wants to spawn a Claude CLI with bypassPermissions.',
   'fleet.approvals.a2aDescRemote': 'A remote A2A caller wants to spawn a Claude CLI with bypassPermissions.',
   'fleet.approvals.a2aDescSameWorkspace': 'An agent in this workspace wants to spawn another Claude CLI with bypassPermissions.',
   'fleet.approvals.a2aAutoApprove': 'Auto-approve future A2A execute requests',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -92,7 +92,6 @@ export const ko = {
   'fleet.approvals.deny': '거부',
   'fleet.approvals.critical': '위험',
   'fleet.approvals.a2aTitle': '백그라운드 실행',
-  'fleet.approvals.a2aDesc': '원격 A2A 호출자가 bypassPermissions로 Claude CLI를 실행하려 합니다.',
   'fleet.approvals.a2aDescRemote': '원격 A2A 호출자가 bypassPermissions로 Claude CLI를 실행하려 합니다.',
   'fleet.approvals.a2aDescSameWorkspace': '이 workspace의 에이전트가 같은 workspace에 bypassPermissions Claude CLI를 추가로 실행하려 합니다.',
   'fleet.approvals.a2aAutoApprove': '앞으로 A2A execute 자동 승인',

--- a/src/renderer/stores/slices/a2aSlice.ts
+++ b/src/renderer/stores/slices/a2aSlice.ts
@@ -65,7 +65,6 @@ export interface A2aSlice {
   getAgentSkills: (workspaceId: string) => AgentSkill[] | null;
   enqueueExecuteApproval: (approval: PendingExecuteApproval) => void;
   removeExecuteApproval: (approvalId: string) => void;
-  setPendingExecuteApproval: (approval: PendingExecuteApproval | null) => void;
   setA2aAutoApproveExecute: (enabled: boolean) => void;
 
   // GC
@@ -93,16 +92,6 @@ export const createA2aSlice: StateCreator<StoreState, [['zustand/immer', never]]
     state.pendingExecuteApprovalOrder = state.pendingExecuteApprovalOrder.filter((id) => id !== approvalId);
     const firstId = state.pendingExecuteApprovalOrder[0];
     state.pendingExecuteApproval = firstId ? state.pendingExecuteApprovals[firstId] ?? null : null;
-  }),
-
-  setPendingExecuteApproval: (approval) => set((state: StoreState) => {
-    state.pendingExecuteApprovals = {};
-    state.pendingExecuteApprovalOrder = [];
-    if (approval) {
-      state.pendingExecuteApprovals[approval.approvalId] = approval;
-      state.pendingExecuteApprovalOrder = [approval.approvalId];
-    }
-    state.pendingExecuteApproval = approval;
   }),
 
   setA2aAutoApproveExecute: (enabled) => set((state: StoreState) => {

--- a/src/renderer/utils/__tests__/executeApprovalGate.test.ts
+++ b/src/renderer/utils/__tests__/executeApprovalGate.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+//
+// Runtime coverage for the renderer-side execute approval gate. The
+// useRpcBridge.a2aPaneIdentity test is structural (source-regex); this drives
+// the actual Promise/queue/timer behavior so the gate's security-critical paths
+// (YOLO short-circuit, approve, deny, 30s auto-deny, concurrent independence)
+// are exercised end-to-end.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { requestExecuteApproval } from '../executeApprovalGate';
+import { useStore } from '../../stores';
+import { resolveExecuteApproval, hasPendingExecuteApproval } from '../executeApproval';
+
+const INPUT = {
+  taskId: 'task-1',
+  senderWorkspaceId: 'ws-from',
+  receiverWorkspaceId: 'ws-to',
+  messagePreview: 'run the build',
+  cwd: null,
+};
+
+function resetGate() {
+  const s = useStore.getState();
+  s.setA2aAutoApproveExecute(false);
+  for (const id of [...s.pendingExecuteApprovalOrder]) s.removeExecuteApproval(id);
+}
+
+describe('requestExecuteApproval (renderer execute gate)', () => {
+  beforeEach(resetGate);
+
+  it('short-circuits to approved when YOLO is on, enqueuing nothing', async () => {
+    useStore.getState().setA2aAutoApproveExecute(true);
+    await expect(requestExecuteApproval(INPUT)).resolves.toBe(true);
+    expect(useStore.getState().pendingExecuteApprovalOrder).toHaveLength(0);
+  });
+
+  it('enqueues a prompt and resolves true when the user approves', async () => {
+    const p = requestExecuteApproval(INPUT);
+    const order = useStore.getState().pendingExecuteApprovalOrder;
+    expect(order).toHaveLength(1);
+    const approvalId = order[0];
+    expect(hasPendingExecuteApproval(approvalId)).toBe(true);
+
+    resolveExecuteApproval(approvalId, true);
+    await expect(p).resolves.toBe(true);
+    // settle() clears both the queue row and the parked resolver.
+    expect(useStore.getState().pendingExecuteApprovalOrder).toHaveLength(0);
+    expect(hasPendingExecuteApproval(approvalId)).toBe(false);
+  });
+
+  it('resolves false when the user denies', async () => {
+    const p = requestExecuteApproval(INPUT);
+    const approvalId = useStore.getState().pendingExecuteApprovalOrder[0];
+    resolveExecuteApproval(approvalId, false);
+    await expect(p).resolves.toBe(false);
+    expect(useStore.getState().pendingExecuteApprovalOrder).toHaveLength(0);
+  });
+
+  it('auto-denies after the 30s timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const p = requestExecuteApproval(INPUT);
+      expect(useStore.getState().pendingExecuteApprovalOrder).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(30_000);
+      await expect(p).resolves.toBe(false);
+      expect(useStore.getState().pendingExecuteApprovalOrder).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps two concurrent requests independent', async () => {
+    const p1 = requestExecuteApproval({ ...INPUT, taskId: 'task-1' });
+    const p2 = requestExecuteApproval({ ...INPUT, taskId: 'task-2' });
+    const order = [...useStore.getState().pendingExecuteApprovalOrder];
+    expect(order).toHaveLength(2);
+
+    // Approve the second, deny the first — identities must not cross.
+    resolveExecuteApproval(order[1], true);
+    resolveExecuteApproval(order[0], false);
+    await expect(p2).resolves.toBe(true);
+    await expect(p1).resolves.toBe(false);
+    expect(useStore.getState().pendingExecuteApprovalOrder).toHaveLength(0);
+  });
+});

--- a/src/renderer/utils/executeApproval.ts
+++ b/src/renderer/utils/executeApproval.ts
@@ -14,10 +14,6 @@ export function setExecuteApprovalResolver(approvalId: string, resolver: Resolve
   pendingResolvers.set(approvalId, resolver);
 }
 
-export function clearExecuteApprovalResolver(approvalId: string): void {
-  pendingResolvers.delete(approvalId);
-}
-
 export function resolveExecuteApproval(approvalId: string, approved: boolean): void {
   const resolver = pendingResolvers.get(approvalId);
   pendingResolvers.delete(approvalId);

--- a/src/renderer/utils/executeApprovalGate.ts
+++ b/src/renderer/utils/executeApprovalGate.ts
@@ -1,0 +1,49 @@
+/**
+ * Renderer-side gate for A2A `execute:true` requests.
+ *
+ * Spawning a background Claude in `--permission-mode bypassPermissions` is the
+ * highest-risk A2A action, so every NEW execute request is parked here until
+ * the user approves — unless the global YOLO auto-approve is on, or the 30s
+ * timer auto-denies. Extracted from useRpcBridge so it can be unit-tested
+ * without importing the full RPC bridge (and its xterm/canvas dependencies).
+ */
+import { useStore } from '../stores';
+import { generateId } from '../../shared/types';
+import { resolveExecuteApproval, setExecuteApprovalResolver } from './executeApproval';
+
+const EXECUTE_APPROVAL_TIMEOUT_MS = 30_000;
+
+export function requestExecuteApproval(input: {
+  taskId: string;
+  senderWorkspaceId: string;
+  receiverWorkspaceId: string;
+  messagePreview: string;
+  cwd: string | null;
+}): Promise<boolean> {
+  if (useStore.getState().a2aAutoApproveExecute) return Promise.resolve(true);
+
+  const approvalId = generateId('approval');
+  const expiresAt = Date.now() + EXECUTE_APPROVAL_TIMEOUT_MS;
+
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const settle = (approved: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      useStore.getState().removeExecuteApproval(approvalId);
+      resolve(approved);
+    };
+    const timer = setTimeout(() => resolveExecuteApproval(approvalId, false), EXECUTE_APPROVAL_TIMEOUT_MS);
+    setExecuteApprovalResolver(approvalId, settle);
+    useStore.getState().enqueueExecuteApproval({
+      approvalId,
+      taskId: input.taskId,
+      senderWorkspaceId: input.senderWorkspaceId,
+      receiverWorkspaceId: input.receiverWorkspaceId,
+      messagePreview: input.messagePreview,
+      cwd: input.cwd,
+      expiresAt,
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Follow-up cleanup for the renderer-side A2A execute gate (#254). Removes dead
code left after the gate rework and extracts `requestExecuteApproval` into a
focused module so its security-critical paths get real runtime coverage.

## Dead code removed (no remaining call sites)

- `a2aSlice.setPendingExecuteApproval` — the prompt queue is driven entirely by
  `enqueue`/`removeExecuteApproval`; the single-slot setter was orphaned and, if
  ever called, would have wiped the whole queue.
- `executeApproval.clearExecuteApprovalResolver` — unused export.
- `useRpcBridge` `a2a.confirmExecute` handler — the main process no longer sends
  this RPC (the gate now runs in the renderer before task creation).
- `fleet.approvals.a2aDesc` i18n key — superseded by `a2aDescRemote` /
  `a2aDescSameWorkspace` (en/ko only; no other locale carried it).

## Refactor + tests

- Extract `requestExecuteApproval` into `utils/executeApprovalGate.ts`. Importing
  the full `useRpcBridge` into a test pulls in xterm/canvas (jsdom `getContext`
  noise); the focused module is testable in isolation.
- Add runtime tests for the gate: YOLO short-circuit (nothing enqueued), approve,
  deny, 30s auto-deny, and concurrent-request independence.

## Test plan

- `tsc --noEmit` clean
- `eslint` clean on changed files
- Full suite green (3612 parallel + 16 runtime)
- New `executeApprovalGate.test.ts` drives the gate end-to-end (queue + parked
  Promise + timer), complementing the structural `useRpcBridge.a2aPaneIdentity`
  test.

## Notes

Pure cleanup + test coverage — no behavior change to the execute gate itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * A2A approval prompts now display context-specific descriptions, distinguishing between remote callers and same-workspace agents for clearer decision-making.
  * Approval request handling enhanced with automatic timeout after 30 seconds of inactivity and improved state management for pending requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->