### PR TITLE
fix(rpc): scope surface.new to an explicit workspace + add pane.close (#236 follow-up)

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -26,7 +26,7 @@ returns `EPERM`. Wire framing: newline-delimited JSON, one object per line.
 
 ## RPC methods
 
-Total: **100** methods (`ALL_RPC_METHODS` in
+Total: **101** methods (`ALL_RPC_METHODS` in
 `src/shared/rpc.ts`). Capability and risk class are read from
 `src/main/mcp/methodCapabilityMap.ts`:
 
@@ -63,6 +63,7 @@ Total: **100** methods (`ALL_RPC_METHODS` in
 | `pane.list` | `pane.read` | `pane-lifecycle` |
 | `pane.focus` | `pane.read` | `pane-lifecycle` |
 | `pane.split` | `pane.create` | `pane-lifecycle` |
+| `pane.close` | `pane.create` | `pane-lifecycle` |
 | `pane.setMetadata` | `meta.write` | `metadata` |
 | `pane.getMetadata` | `meta.read` | `metadata` |
 | `pane.clearMetadata` | `meta.write` | `metadata` |

--- a/src/main/mcp/methodCapabilityMap.ts
+++ b/src/main/mcp/methodCapabilityMap.ts
@@ -185,6 +185,7 @@ export const METHOD_CAPABILITY: Record<RpcMethod, RequiredCapability> = {
   'pane.list':   { capability: 'pane.read', riskClass: 'pane-lifecycle' },
   'pane.focus':  { capability: 'pane.read', riskClass: 'pane-lifecycle' },
   'pane.split':  { capability: 'pane.create', riskClass: 'pane-lifecycle' },
+  'pane.close':  { capability: 'pane.create', riskClass: 'pane-lifecycle' },
   'pane.search': { capability: 'pane.search', riskClass: 'terminal-content' },
 
   // --- Metadata (spec §3.4) ---

--- a/src/main/pipe/handlers/__tests__/pane.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/pane.rpc.test.ts
@@ -1478,3 +1478,44 @@ describe('pane.rpc — pane.split workspaceId forwarding (#236)', () => {
     expect(sendToRendererMock).not.toHaveBeenCalled();
   });
 });
+
+describe('pane.rpc — pane.close (#236 follow-up)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sendToRendererMock.mockResolvedValue({ ok: true });
+  });
+
+  it('forwards the paneId to the renderer', async () => {
+    const router = register();
+    const res = await router.dispatch({
+      id: 'c1',
+      method: 'pane.close',
+      params: { id: 'pane-7' },
+    });
+    expect(res.ok).toBe(true);
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      'pane.close',
+      { id: 'pane-7' },
+    );
+  });
+
+  it('rejects a missing id before any renderer call', async () => {
+    const router = register();
+    const res = await router.dispatch({ id: 'c2', method: 'pane.close', params: {} });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/id/);
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-string id', async () => {
+    const router = register();
+    const res = await router.dispatch({
+      id: 'c3',
+      method: 'pane.close',
+      params: { id: 42 as unknown as string },
+    });
+    expect(res.ok).toBe(false);
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/pipe/handlers/__tests__/surface.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/surface.rpc.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserWindow } from 'electron';
+import { RpcRouter } from '../../RpcRouter';
+import { registerSurfaceRpc } from '../surface.rpc';
+
+const { sendToRendererMock } = vi.hoisted(() => ({
+  sendToRendererMock: vi.fn(),
+}));
+
+vi.mock('../_bridge', () => ({
+  sendToRenderer: sendToRendererMock,
+}));
+
+function register(): RpcRouter {
+  const router = new RpcRouter();
+  registerSurfaceRpc(router, (() => null) as () => BrowserWindow | null);
+  return router;
+}
+
+// #236 follow-up — surface.new previously dropped params entirely, scoping
+// every caller to the on-screen workspace. The handler must now forward an
+// explicit workspaceId/shell/cwd so a multi-agent caller targets its OWN
+// workspace (renderer fails closed on an unknown explicit id; covered by dogfood).
+describe('surface.rpc — new (workspaceId scoping)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sendToRendererMock.mockResolvedValue({ ptyId: 'pty-1' });
+  });
+
+  it('forwards an explicit workspaceId / shell / cwd to the renderer', async () => {
+    const router = register();
+    const r = await router.dispatch({
+      id: '1',
+      method: 'surface.new',
+      params: { workspaceId: 'ws-2', shell: 'pwsh', cwd: '/tmp/x' },
+    });
+    expect(r.ok).toBe(true);
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      'surface.new',
+      { workspaceId: 'ws-2', shell: 'pwsh', cwd: '/tmp/x' },
+    );
+  });
+
+  it('omits workspaceId when not provided (renderer falls back to active ws)', async () => {
+    const router = register();
+    await router.dispatch({ id: '2', method: 'surface.new', params: {} });
+    expect(sendToRendererMock).toHaveBeenCalledWith(expect.any(Function), 'surface.new', {});
+  });
+
+  it('rejects a non-string workspaceId', async () => {
+    const router = register();
+    const r = await router.dispatch({
+      id: '3',
+      method: 'surface.new',
+      params: { workspaceId: 123 },
+    });
+    expect(r.ok).toBe(false);
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('surface.rpc — focus/close forward the surface id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sendToRendererMock.mockResolvedValue({ ok: true });
+  });
+
+  it('surface.focus forwards { id }', async () => {
+    const router = register();
+    await router.dispatch({ id: '1', method: 'surface.focus', params: { id: 's-1' } });
+    expect(sendToRendererMock).toHaveBeenCalledWith(expect.any(Function), 'surface.focus', { id: 's-1' });
+  });
+
+  it('surface.close forwards { id }', async () => {
+    const router = register();
+    await router.dispatch({ id: '2', method: 'surface.close', params: { id: 's-2' } });
+    expect(sendToRendererMock).toHaveBeenCalledWith(expect.any(Function), 'surface.close', { id: 's-2' });
+  });
+
+  it('surface.focus rejects a missing id', async () => {
+    const router = register();
+    const r = await router.dispatch({ id: '3', method: 'surface.focus', params: {} });
+    expect(r.ok).toBe(false);
+  });
+});

--- a/src/main/pipe/handlers/pane.rpc.ts
+++ b/src/main/pipe/handlers/pane.rpc.ts
@@ -217,6 +217,22 @@ export function registerPaneRpc(
   });
 
   /**
+   * pane.close — closes a leaf pane and disposes its surfaces' PTYs.
+   * params: { id: string }
+   *
+   * paneIds are globally unique, so the renderer resolves the target across
+   * ALL workspaces (mirrors surface.close) rather than the UI-active one. This
+   * lets an external multi-agent caller clean up a worker pane it created via
+   * pane.split in its own background workspace. No active-ws fallback.
+   */
+  router.register('pane.close', (params) => {
+    if (typeof params['id'] !== 'string') {
+      return Promise.reject(new Error('pane.close: missing required param "id"'));
+    }
+    return sendToRenderer(getWindow, 'pane.close', { id: params['id'] });
+  });
+
+  /**
    * Resolves the target pane for a metadata RPC. Two paths:
    *
    *   - `paneId` provided: ask the renderer to confirm the paneId actually

--- a/src/main/pipe/handlers/surface.rpc.ts
+++ b/src/main/pipe/handlers/surface.rpc.ts
@@ -20,11 +20,26 @@ export function registerSurfaceRpc(router: RpcRouter, getWindow: GetWindow): voi
   );
 
   /**
-   * surface.new — creates a new surface in the active pane
+   * surface.new — creates a new surface in the active pane of a workspace.
+   * params: { workspaceId?, shell?, cwd? } — omitted workspaceId ⇒ active ws.
+   *
+   * Earlier this dropped params entirely, so an explicit workspaceId/shell/cwd
+   * was silently ignored and every surface opened in the on-screen workspace
+   * (the #236 family of bugs). Forward them so a multi-agent caller can open a
+   * terminal in ITS OWN workspace; the renderer fails closed on an unknown
+   * explicit workspaceId.
    */
-  router.register('surface.new', (_params) =>
-    sendToRenderer(getWindow, 'surface.new'),
-  );
+  router.register('surface.new', (params) => {
+    const workspaceId = params['workspaceId'];
+    if (workspaceId !== undefined && typeof workspaceId !== 'string') {
+      return Promise.reject(new Error('surface.new: "workspaceId" must be a string if provided'));
+    }
+    return sendToRenderer(getWindow, 'surface.new', {
+      ...(workspaceId !== undefined && { workspaceId }),
+      ...(typeof params['shell'] === 'string' && { shell: params['shell'] }),
+      ...(typeof params['cwd'] === 'string' && { cwd: params['cwd'] }),
+    });
+  });
 
   /**
    * surface.focus — focuses a specific surface

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -552,12 +552,17 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     }
     if (!targetWs) return { error: `pane.close: pane ${paneId} not found` };
 
-    // Dispose every PTY owned by the pane's surfaces (all leaves under it),
-    // mirroring surface.close's explicit pty.dispose.
+    // Only leaf panes are closable, and never the root: closePane is a no-op for
+    // the root pane (findParent returns null), so disposing its PTYs would orphan
+    // live surfaces with dead PTYs (CodeRabbit). Reject non-leaf / root up front.
     const pane = findPaneById(targetWs.rootPane, paneId);
-    const ptyIds = pane
-      ? findLeafPanes(pane).flatMap((l) => l.surfaces.map((s) => s.ptyId).filter((p): p is string => !!p))
-      : [];
+    if (!pane || pane.type !== 'leaf') {
+      return { error: `pane.close: pane ${paneId} is not a closable leaf` };
+    }
+    if (paneId === targetWs.rootPane.id) {
+      return { error: 'pane.close: cannot close the root pane' };
+    }
+    const ptyIds = pane.surfaces.map((s) => s.ptyId).filter((p): p is string => !!p);
 
     store.closePane(paneId, targetWs.id);
 

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -473,8 +473,21 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
   }
 
   if (method === 'surface.new') {
-    const ws = store.workspaces.find((w) => w.id === store.activeWorkspaceId);
-    if (!ws) return { error: 'no active workspace' };
+    // #236 family: honor an explicit workspaceId so a multi-agent caller opens
+    // the surface in ITS OWN workspace, not whichever the user is viewing.
+    // Fail CLOSED on an explicit-but-unknown id (never fall back to active —
+    // that would open the terminal in the wrong agent's workspace).
+    const requestedWsId =
+      typeof params.workspaceId === 'string' && params.workspaceId.length > 0
+        ? params.workspaceId
+        : store.activeWorkspaceId;
+    const ws = store.workspaces.find((w) => w.id === requestedWsId);
+    if (!ws) {
+      if (typeof params.workspaceId === 'string' && params.workspaceId.length > 0) {
+        return { error: `surface.new: workspace "${requestedWsId}" not found` };
+      }
+      return { error: 'surface.new: no active workspace' };
+    }
 
     const paneId = ws.activePaneId;
     const shell = typeof params.shell === 'string' ? params.shell : '';
@@ -491,18 +504,19 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       ),
     );
 
-    // Re-read state after async gap — paneId may have been removed.
+    // Re-read state after async gap — the pane may have been removed. Look up
+    // the SAME workspace by id (NOT the active one, which may have changed).
     const freshAfterCreate = useStore.getState();
-    const freshWsAfterCreate = freshAfterCreate.workspaces.find((w) => w.id === freshAfterCreate.activeWorkspaceId);
+    const freshWsAfterCreate = freshAfterCreate.workspaces.find((w) => w.id === ws.id);
     if (!freshWsAfterCreate || !findPaneById(freshWsAfterCreate.rootPane, paneId)) {
       // Pane was removed during async gap — dispose the orphaned PTY
       try { await window.electronAPI.pty.dispose(ptyId); } catch { /* best-effort */ }
       return { error: 'pane was removed during PTY creation' };
     }
-    freshAfterCreate.addSurface(paneId, ptyId, shell, cwd);
+    freshAfterCreate.addSurface(paneId, ptyId, shell, cwd, ws.id);
 
     const fresh = useStore.getState();
-    const freshWs = fresh.workspaces.find((w) => w.id === fresh.activeWorkspaceId);
+    const freshWs = fresh.workspaces.find((w) => w.id === ws.id);
     if (!freshWs) return { ptyId };
     const pane = findPaneById(freshWs.rootPane, paneId);
     if (!pane || pane.type !== 'leaf') return { ptyId };
@@ -522,6 +536,34 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
 
     store.setActivePane(targetLeaf.id);
     store.setActiveSurface(targetLeaf.id, surfaceId);
+    return { ok: true };
+  }
+
+  if (method === 'pane.close') {
+    // paneIds are globally unique → resolve across ALL workspaces (mirrors
+    // surface.close), so an external caller can close a worker pane it created
+    // (via pane.split) in its own background workspace. No active-ws fallback.
+    const paneId = String(params.id ?? '');
+    if (!paneId) return { error: 'pane.close: missing required param "id"' };
+
+    let targetWs: Workspace | null = null;
+    for (const ws of store.workspaces) {
+      if (findPaneById(ws.rootPane, paneId)) { targetWs = ws; break; }
+    }
+    if (!targetWs) return { error: `pane.close: pane ${paneId} not found` };
+
+    // Dispose every PTY owned by the pane's surfaces (all leaves under it),
+    // mirroring surface.close's explicit pty.dispose.
+    const pane = findPaneById(targetWs.rootPane, paneId);
+    const ptyIds = pane
+      ? findLeafPanes(pane).flatMap((l) => l.surfaces.map((s) => s.ptyId).filter((p): p is string => !!p))
+      : [];
+
+    store.closePane(paneId, targetWs.id);
+
+    for (const ptyId of ptyIds) {
+      try { await window.electronAPI.pty.dispose(ptyId); } catch { /* best-effort */ }
+    }
     return { ok: true };
   }
 

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -91,6 +91,7 @@ export type RpcMethod =
   | 'pane.list'
   | 'pane.focus'
   | 'pane.split'
+  | 'pane.close'
   | 'pane.setMetadata'
   | 'pane.getMetadata'
   | 'pane.clearMetadata'
@@ -194,6 +195,7 @@ export const ALL_RPC_METHODS = [
   'pane.list',
   'pane.focus',
   'pane.split',
+  'pane.close',
   'pane.setMetadata',
   'pane.getMetadata',
   'pane.clearMetadata',


### PR DESCRIPTION
## Summary

Follow-up to #236, which fixed `pane.split` ignoring `workspaceId`. The #236
expert sweep found the same active-workspace-fallback defect in sibling handlers.
This PR fixes the two low-risk, unambiguous ones and adds the missing `pane.close`.

## Changes

- **`surface.new`** — previously dropped all params main-side and pinned the
  renderer to the active workspace, so a multi-agent caller's "open a terminal in
  MY workspace" always landed in whichever workspace the user was viewing. Now:
  main forwards `workspaceId`/`shell`/`cwd`; the renderer honors `workspaceId`,
  **fails closed** on an explicit-but-unknown id (no active-ws fallback), and
  eager-spawns into the target ws's active pane.
- **`pane.close`** — new RPC. A worker pane created via `pane.split` (possible
  since #236) had no RPC to clean it up. `paneId`s are globally unique, so the
  renderer resolves the target across **all** workspaces (mirrors `surface.close`)
  and disposes every PTY under the pane. Capability `pane.create`
  (pane-lifecycle), same as `pane.split`.

## Deferred (product decision)

`pane.focus` / `surface.focus` also ignore `workspaceId`, but changing remote
focus is a "should it yank the user's screen?" UX decision that needs its own
dogfood. Left as-is, tracked in
`plans/issue-236-followup-rpc-workspace-scoping-sweep.md`. `browser.*` is
MCP-gated (`requireWorkspaceId()`) → low risk, left as-is.

## Test plan

- `tsc --noEmit` clean, `eslint` clean
- Full suite green (3621 parallel + 16 runtime)
- New unit tests: `surface.rpc` (forward workspaceId/shell/cwd, reject
  non-string, focus/close id forward), `pane.rpc` (pane.close forward + reject),
  capability map covers `pane.close`
- `docs/api/reference.md` regenerated
- **Packaged-build live dogfood 20/20** (isolated instance, zombie 0):
  - S1: `surface.new {workspaceId: bg}` → surface lands in the background ws
    (count 1→2), active ws unchanged (no screen yank)
  - S2: `surface.new {workspaceId: unknown}` → `workspace "..." not found`
    (fail-closed, active ws unchanged)
  - S3: `pane.split {bg}` → `pane.close {id}` → pane count back to baseline,
    closed paneId gone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `pane.close` RPC method to close panes by globally unique ID (with appropriate validation).
* **Bug Fixes**
  * Fixed `surface.new` so provided workspace configuration (workspace selection plus shell/cwd) is correctly forwarded and validated.
  * Improved routing so surface creation honors an explicit workspace choice when supplied.
* **Documentation**
  * Updated the API reference to include `pane.close` in the RPC inventory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->