### PR TITLE
fix(rpc): scope pane.focus/surface.focus to the owning workspace (#236 follow-up)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -196,3 +196,30 @@
 - **Depends on:** 없음.
 - **Priority:** P3
 
+## (security) Unscoped plugin events.poll leaks cross-workspace lifecycle events (P2)
+- **What:** `PluginFrame.tsx:89`가 `events.poll`을 `{}`(workspaceId 없음)로 호출 → `events.rpc.ts:97` `caller ? e.workspaceId===caller : true`가 unscoped 호출에 **전 워크스페이스**의 `pane.created/closed/focused/process.*`를 통과시킴. `events.subscribe` capability를 declare한 플러그인이 다른 ws의 lifecycle을 관측 가능. `a2a.task`만 unscoped서 fail-closed.
+- **Why:** substrate 격리 원칙 위반. `a2a.task`의 `!!caller &&` fail-closed 절이 lifecycle 타입엔 없음. focus-rpc 리뷰(plan-eng-review, security 전문가)서 발견 — 선재 버그이며 focus 픽스가 만든 게 아니지만 EMIT이 약간 넓힘.
+- **Pros:** 플러그인 샌드박스의 cross-ws 관측 차단.
+- **Cons:** 둘 중 택1 — (a) `PluginFrame`이 호스트 프레임의 workspaceId를 poll에 실어보냄, 또는 (b) unscoped poll에서 lifecycle 타입도 fail-closed(`a2a.task`처럼). (a)가 깔끔하나 플러그인이 여러 ws를 의도적으로 보는 합법 케이스가 있는지 확인 필요.
+- **Context:** `src/main/pipe/handlers/events.rpc.ts:93-104`(post-filter), `src/renderer/plugins/PluginFrame.tsx:88-89`(unscoped poll). 시작점=poll params에 workspaceId 주입 vs 필터 fail-closed 결정.
+- **Depends on:** 없음 (focus 픽스와 독립).
+- **Priority:** P2 (보안 격리)
+
+## surface.focus capability를 pane.read로 통일 (P3)
+- **What:** `methodCapabilityMap.ts:181` `surface.focus` = `wmux.internal` → `pane.read`로(sibling `pane.focus:186`과 일치). first-party MCP에 surface.focus 도구 노출 + 서드파티 declarable.
+- **Why:** 동일 blast radius(focus 마커 이동)인 두 메서드가 다른 capability 클래스. security 전문가: 방어 가능(grandfather 경로 + self-asserted clientName이라 wmux.internal 라벨이 same-user 대상 보안 이득 0)하나 coherence 결함.
+- **Pros:** capability 대칭, surface.focus가 sibling처럼 first-party/declarable.
+- **Cons:** capability 정책 변경 = 별도 검토. focus ws-scoping 픽스에 묶지 말 것(orthogonal).
+- **Context:** focus-rpc 리뷰서 식별. `src/main/mcp/methodCapabilityMap.ts:181/186`, `firstParty.ts` allowlist.
+- **Depends on:** focus ws-scoping 픽스 ship 후.
+- **Priority:** P3
+
+## Per-target ownership authz for focus/close family (P3)
+- **What:** globally-unique id 해석 메서드(`pane.focus`/`surface.focus`/`pane.close`/`surface.close`)에 호출자 ws 소유권 게이트 추가 — 공유 `resolvePaneOwner(id)` 헬퍼를 authz 지점으로.
+- **Why:** id 보유 시 어느 ws의 pane이든 focus/close 가능. ids는 unguessable + `pane_list`/`surface_list`는 ws-scoped라 열거 불가지만, 적대적 멀티에이전트면 per-target authz가 정답. security 전문가: focus는 close(#256, pane 파괴)보다 약하므로 close-family부터.
+- **Pros:** 진짜 적대적 멀티에이전트 격리.
+- **Cons:** id-as-capability 모델을 owner-gate로 바꾸는 건 #256 close까지 소급 = 넓은 변경. 현 위협모델(single-user)에선 과함.
+- **Context:** focus-rpc 리뷰서 식별. close-family부터 게이트, focus를 같은 패스에. 시작점=`useRpcBridge.ts:550` all-ws scan을 `resolvePaneOwner`로 추출 후 caller-ws 비교.
+- **Depends on:** 구체적 적대 멀티에이전트 위협 리포트 발생 시.
+- **Priority:** P3
+

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -408,6 +408,8 @@ There are four resolution paths in the current implementation, in order of prefe
 
 Path B is the substrate-aligned answer: it anchors identity to the immutable `ptyId` and resolves the owning workspace live, so it survives workspace-id re-minting. Path A is now a stale-prone hint, demoted to a last resort behind B (it previously short-circuited resolution, which left agents permanently stuck on a dead workspace id after a respawn/restore — "no workspace found for ws-…"). Path C covers non-wmux terminals; path D is the only remaining footgun and is the substrate boundary documented in §8.
 
+The address-resolution methods that target an existing node by its globally-unique id — `pane.focus`, `surface.focus`, `pane.close`, `surface.close` — sidestep path D entirely: they resolve the owning workspace by scanning every workspace for that `paneId`/`surfaceId` and never read or mutate `activeWorkspaceId`, so a caller in a background workspace addresses its own pane without the resolution depending on (or disturbing) whichever workspace the user is viewing. Focusing a pane is therefore non-yank — bringing a workspace on-screen is the separate `workspace.focus` RPC.
+
 **Substrate alignment notes:**
 
 - Identity is anchored to `ptyId`, not `workspaceId`. The on-disk PID map (`~/.wmux/pid-map/<pid>`) stores the ptyId, which never changes for a process's lifetime; the pty → workspace edge is resolved live in `a2a.resolve.identity`. This is what keeps identity correct across a daemon respawn or session restore that re-mints the workspace id. The map is (re)written at PTY create and on reconnect.

--- a/src/renderer/hooks/__tests__/useRpcBridge.focus.test.ts
+++ b/src/renderer/hooks/__tests__/useRpcBridge.focus.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Workspace-scoping wiring for the address-resolution focus paths
+ * (issue #236 follow-up — the last sibling after surface.new / pane.close).
+ *
+ * pane.focus / surface.focus used to act on the UI-ACTIVE workspace only:
+ *   - pane.focus called store.setActivePane(id) directly, which silently no-ops
+ *     for any non-active workspace yet still returned {ok:true} (false success);
+ *   - surface.focus searched store.activeWorkspaceId only → "surface not found"
+ *     for a background workspace.
+ * Both now resolve the globally-unique id across ALL workspaces (mirroring the
+ * #256 pane.close / surface.close handlers) and delegate the mutation to the
+ * dedicated, non-yank focusPaneSurface store action — so an external agent can
+ * focus its own background pane/surface without stealing the user's screen.
+ *
+ * The behavioural assertions (activePaneId moves, activeWorkspaceId UNCHANGED,
+ * emit on real change, no mutation/emit on a branch id) live in
+ * paneSlice.events.test.ts against focusPaneSurface — the action holds all the
+ * mutation logic. handleRpcMethod is not exported and pulls in the store/window,
+ * so it can't be imported under vitest (same constraint as
+ * useRpcBridge.browserClose.test.ts / useRpcBridge.a2aPaneIdentity.test.ts);
+ * these are source-structural guards that the handlers stay wired to the all-ws
+ * resolver + focusPaneSurface and keep the {error}-on-miss contract.
+ */
+describe('useRpcBridge — focus-path workspace scoping (#236 follow-up)', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'useRpcBridge.ts'), 'utf-8');
+
+  function region(start: string, end: string): string {
+    const m = src.match(new RegExp(`${start}[\\s\\S]*?${end}`));
+    if (!m) {
+      throw new Error(
+        `region ${start} → ${end} not found in useRpcBridge.ts. ` +
+          'Update the regex if the handler layout changed.',
+      );
+    }
+    return m[0];
+  }
+
+  describe('pure resolver helpers', () => {
+    it('defines findOwningWorkspace as an all-workspaces scan by paneId', () => {
+      const block = region('function findOwningWorkspace\\(', 'function findOwningWorkspaceBySurface');
+      expect(block).toMatch(/for \(const ws of workspaces\)/);
+      expect(block).toMatch(/findPaneById\(ws\.rootPane, paneId\)/);
+    });
+
+    it('defines findOwningWorkspaceBySurface returning the owning ws + leaf', () => {
+      const block = region('function findOwningWorkspaceBySurface\\(', '// ----');
+      expect(block).toMatch(/for \(const ws of workspaces\)/);
+      expect(block).toMatch(/findLeafBySurfaceId\(ws\.rootPane, surfaceId\)/);
+      expect(block).toMatch(/return \{ ws, leaf \}/);
+    });
+  });
+
+  describe('pane.focus', () => {
+    function block(): string {
+      return region("method === 'pane\\.focus'", "method === 'pane\\.split'");
+    }
+
+    it('resolves the owning workspace across ALL workspaces (not activeWorkspaceId)', () => {
+      const b = block();
+      expect(b).toMatch(/findOwningWorkspace\(store\.workspaces, paneId\)/);
+      // The resolver, not the active workspace, decides the target → no
+      // store.activeWorkspaceId read in this handler (non-yank by construction).
+      expect(b).not.toMatch(/store\.activeWorkspaceId/);
+    });
+
+    it('returns {error} when the pane belongs to no workspace (false-ok removed)', () => {
+      const b = block();
+      expect(b).toMatch(/if \(!ownerWs\) return \{ error:/);
+      // The old direct no-op call is gone.
+      expect(b).not.toMatch(/store\.setActivePane\(paneId\)/);
+    });
+
+    it('delegates to focusPaneSurface(ownerWs.id, paneId) and {error}s a non-leaf', () => {
+      const b = block();
+      expect(b).toMatch(/store\.focusPaneSurface\(ownerWs\.id, paneId\)/);
+      // focusPaneSurface returns false for a branch/missing id → surfaced as error.
+      expect(b).toMatch(/if \(!ok\) return \{ error:/);
+    });
+  });
+
+  describe('surface.focus', () => {
+    function block(): string {
+      return region("method === 'surface\\.focus'", "method === 'pane\\.close'");
+    }
+
+    it('resolves the owning workspace + leaf across ALL workspaces (not activeWorkspaceId)', () => {
+      const b = block();
+      expect(b).toMatch(/findOwningWorkspaceBySurface\(store\.workspaces, surfaceId\)/);
+      // No active-workspace lookup → non-yank, and no "no active workspace" path.
+      expect(b).not.toMatch(/store\.activeWorkspaceId/);
+      expect(b).not.toMatch(/no active workspace/);
+    });
+
+    it('returns {error} when the surface belongs to no workspace', () => {
+      const b = block();
+      expect(b).toMatch(/if \(!owner\) return \{ error:/);
+    });
+
+    it('delegates the active pane + surface set to focusPaneSurface in one call', () => {
+      const b = block();
+      expect(b).toMatch(/store\.focusPaneSurface\(owner\.ws\.id, owner\.leaf\.id, surfaceId\)/);
+      // The two-write setActivePane + setActiveSurface pair is replaced by the
+      // single atomic action.
+      expect(b).not.toMatch(/store\.setActivePane\(/);
+      expect(b).not.toMatch(/store\.setActiveSurface\(/);
+    });
+  });
+});

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -90,6 +90,35 @@ function findLeafBySurfaceId(root: Pane, surfaceId: string): PaneLeaf | null {
   return leaves.find((l) => l.surfaces.some((s) => s.id === surfaceId)) ?? null;
 }
 
+/**
+ * Find the workspace whose pane tree contains `paneId` (paneIds are globally
+ * unique). Used by the address-resolution focus handlers — the counterpart to
+ * the all-ws scan in `pane.close` — so an external caller can focus a pane in
+ * its own background workspace by id alone. Returns the first owner or null.
+ */
+function findOwningWorkspace(workspaces: Workspace[], paneId: string): Workspace | null {
+  for (const ws of workspaces) {
+    if (findPaneById(ws.rootPane, paneId)) return ws;
+  }
+  return null;
+}
+
+/**
+ * Find the workspace + leaf owning `surfaceId` (surfaceIds are globally unique).
+ * The surface counterpart to findOwningWorkspace, mirroring `surface.close`'s
+ * all-ws scan. Returns `{ ws, leaf }` for the first owner or null.
+ */
+function findOwningWorkspaceBySurface(
+  workspaces: Workspace[],
+  surfaceId: string,
+): { ws: Workspace; leaf: PaneLeaf } | null {
+  for (const ws of workspaces) {
+    const leaf = findLeafBySurfaceId(ws.rootPane, surfaceId);
+    if (leaf) return { ws, leaf };
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // PTY submit helper — paste structured inter-agent messages through bracketed
 // paste before submitting, so receiver-controlled shells/readline prompts treat
@@ -527,15 +556,15 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
   }
 
   if (method === 'surface.focus') {
+    // surfaceIds are globally unique → resolve across ALL workspaces (mirrors
+    // surface.close / pane.focus below), never the UI-active one. focusPaneSurface
+    // sets the owning ws's active pane + surface atomically and is non-yank
+    // (activeWorkspaceId is untouched), so a background agent can focus its own
+    // surface without stealing the user's screen.
     const surfaceId = String(params.id ?? '');
-    const ws = store.workspaces.find((w) => w.id === store.activeWorkspaceId);
-    if (!ws) return { error: 'no active workspace' };
-
-    const targetLeaf = findLeafBySurfaceId(ws.rootPane, surfaceId);
-    if (!targetLeaf) return { error: `surface ${surfaceId} not found` };
-
-    store.setActivePane(targetLeaf.id);
-    store.setActiveSurface(targetLeaf.id, surfaceId);
+    const owner = findOwningWorkspaceBySurface(store.workspaces, surfaceId);
+    if (!owner) return { error: `surface.focus: surface ${surfaceId} not found` };
+    store.focusPaneSurface(owner.ws.id, owner.leaf.id, surfaceId);
     return { ok: true };
   }
 
@@ -646,8 +675,17 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
   }
 
   if (method === 'pane.focus') {
+    // paneIds are globally unique → resolve across ALL workspaces (mirrors
+    // pane.close), never the UI-active one. focusPaneSurface is non-yank
+    // (activeWorkspaceId untouched) so an external agent can focus a pane in its
+    // own background workspace. The old direct setActivePane call silently
+    // no-op'd for any non-active workspace yet still returned {ok:true} (false
+    // success); resolve-then-error surfaces the miss via getResultError.
     const paneId = String(params.id ?? '');
-    store.setActivePane(paneId);
+    const ownerWs = findOwningWorkspace(store.workspaces, paneId);
+    if (!ownerWs) return { error: `pane.focus: pane ${paneId} not found` };
+    const ok = store.focusPaneSurface(ownerWs.id, paneId);
+    if (!ok) return { error: `pane.focus: pane ${paneId} is not a focusable leaf` };
     return { ok: true };
   }
 

--- a/src/renderer/stores/slices/__tests__/paneSlice.events.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneSlice.events.test.ts
@@ -127,6 +127,149 @@ describe('paneSlice — event publication', () => {
     });
   });
 
+  describe('focusPaneSurface (#236 follow-up)', () => {
+    // A second, BACKGROUND workspace whose leaf carries a couple of surfaces so
+    // the surfaceId path can be exercised. ws1 (rootPaneId) stays active so every
+    // assertion here is about focusing a non-active workspace.
+    let bgWsId: string;
+    let bgPaneId: string;
+    let bgSurfaceA: string;
+    let bgSurfaceB: string;
+
+    beforeEach(() => {
+      const bg = createWorkspace('Background');
+      bgWsId = bg.id;
+      bgPaneId = bg.rootPane.id;
+      bgSurfaceA = 'surf-a';
+      bgSurfaceB = 'surf-b';
+      store.setState((s) => {
+        // The background leaf needs ≥2 surfaces, with A active, so a switch to B
+        // is a real change.
+        const root = bg.rootPane;
+        if (root.type !== 'leaf') throw new Error('expected fresh leaf root');
+        root.surfaces = [
+          { id: bgSurfaceA, title: 'A', surfaceType: 'terminal', shell: 'pwsh', cwd: '', ptyId: 'pty-a' },
+          { id: bgSurfaceB, title: 'B', surfaceType: 'terminal', shell: 'pwsh', cwd: '', ptyId: 'pty-b' },
+        ];
+        root.activeSurfaceId = bgSurfaceA;
+        s.workspaces.push(bg);
+      });
+      publishCalls.length = 0;
+    });
+
+    function bgWorkspace(): Workspace {
+      return store.getState().workspaces.find((w) => w.id === bgWsId)!;
+    }
+
+    it('focuses a leaf in a BACKGROUND workspace and emits pane.focused carrying that ws id', () => {
+      // Pre-condition: split the background leaf so it has a second leaf to make
+      // bgPaneId not already the only focus target, then re-point active away.
+      store.getState().splitPane(bgPaneId, 'horizontal', bgWsId);
+      const branch = bgWorkspace().rootPane;
+      if (branch.type !== 'branch') throw new Error('expected branch after bg split');
+      const otherLeafId = branch.children.find((c) => c.id !== bgPaneId)!.id;
+      // A background split must NOT have moved the bg active pane off the original.
+      expect(bgWorkspace().activePaneId).toBe(bgPaneId);
+      publishCalls.length = 0;
+
+      const ok = store.getState().focusPaneSurface(bgWsId, otherLeafId);
+      expect(ok).toBe(true);
+      expect(bgWorkspace().activePaneId).toBe(otherLeafId);
+
+      const focused = publishCalls.filter((c) => c.fn === 'pane.focused');
+      expect(focused).toHaveLength(1);
+      // (wsId, newActiveId, previousActiveId) — wsId is the BACKGROUND ws.
+      expect(focused[0].args[0]).toBe(bgWsId);
+      expect(focused[0].args[1]).toBe(otherLeafId);
+      expect(focused[0].args[2]).toBe(bgPaneId);
+    });
+
+    it('does NOT mutate the active workspace id (non-yank)', () => {
+      const activeBefore = store.getState().activeWorkspaceId;
+      store.getState().splitPane(bgPaneId, 'horizontal', bgWsId);
+      const branch = bgWorkspace().rootPane;
+      if (branch.type !== 'branch') throw new Error('expected branch after bg split');
+      const otherLeafId = branch.children.find((c) => c.id !== bgPaneId)!.id;
+
+      store.getState().focusPaneSurface(bgWsId, otherLeafId);
+
+      expect(store.getState().activeWorkspaceId).toBe(activeBefore);
+    });
+
+    it('sets activeSurfaceId atomically when surfaceId is provided', () => {
+      const ok = store.getState().focusPaneSurface(bgWsId, bgPaneId, bgSurfaceB);
+      expect(ok).toBe(true);
+      const leaf = bgWorkspace().rootPane;
+      if (leaf.type !== 'leaf') throw new Error('expected leaf');
+      expect(leaf.activeSurfaceId).toBe(bgSurfaceB);
+      // bgPaneId was already the bg active pane → no pane change → no emit, even
+      // though the surface changed (pane.focused is a pane event).
+      expect(publishCalls.filter((c) => c.fn === 'pane.focused')).toHaveLength(0);
+    });
+
+    it('ignores an unknown surfaceId (pane still focuses, surface unchanged)', () => {
+      store.getState().splitPane(bgPaneId, 'horizontal', bgWsId);
+      const branch = bgWorkspace().rootPane;
+      if (branch.type !== 'branch') throw new Error('expected branch after bg split');
+      const otherLeafId = branch.children.find((c) => c.id !== bgPaneId)!.id;
+
+      const ok = store.getState().focusPaneSurface(bgWsId, otherLeafId, 'no-such-surface');
+      expect(ok).toBe(true);
+      expect(bgWorkspace().activePaneId).toBe(otherLeafId);
+    });
+
+    it('returns false with no mutation/emit for a non-leaf (branch) id', () => {
+      store.getState().splitPane(bgPaneId, 'horizontal', bgWsId);
+      const branch = bgWorkspace().rootPane;
+      if (branch.type !== 'branch') throw new Error('expected branch after bg split');
+      const branchId = branch.id;
+      const activePaneBefore = bgWorkspace().activePaneId;
+      publishCalls.length = 0;
+
+      const ok = store.getState().focusPaneSurface(bgWsId, branchId);
+      expect(ok).toBe(false);
+      expect(bgWorkspace().activePaneId).toBe(activePaneBefore);
+      expect(publishCalls.filter((c) => c.fn === 'pane.focused')).toHaveLength(0);
+    });
+
+    it('returns false for an unknown workspace', () => {
+      const ok = store.getState().focusPaneSurface('ws-does-not-exist', bgPaneId);
+      expect(ok).toBe(false);
+      expect(publishCalls.filter((c) => c.fn === 'pane.focused')).toHaveLength(0);
+    });
+
+    it('returns false for a pane id that is not in the named workspace', () => {
+      // rootPaneId belongs to ws1, not bgWs → not found in bgWs's tree.
+      const ok = store.getState().focusPaneSurface(bgWsId, rootPaneId);
+      expect(ok).toBe(false);
+      expect(publishCalls.filter((c) => c.fn === 'pane.focused')).toHaveLength(0);
+    });
+
+    it('returns true but does NOT emit when the pane is already active (idempotent)', () => {
+      // bgPaneId is the bg active pane already.
+      const ok = store.getState().focusPaneSurface(bgWsId, bgPaneId);
+      expect(ok).toBe(true);
+      expect(publishCalls.filter((c) => c.fn === 'pane.focused')).toHaveLength(0);
+    });
+
+    it('regression: setActivePane(bgPaneId) with NO ws arg still no-ops (browserPane invariant intact)', () => {
+      // setActivePane is active-ws-scoped: bgPaneId lives in a background ws, so
+      // it must NOT move that ws's active pane nor emit. This is the contract
+      // browserPane.ts:240 relies on — focusPaneSurface must not have changed it.
+      store.getState().splitPane(bgPaneId, 'horizontal', bgWsId);
+      const branch = bgWorkspace().rootPane;
+      if (branch.type !== 'branch') throw new Error('expected branch after bg split');
+      const otherLeafId = branch.children.find((c) => c.id !== bgPaneId)!.id;
+      const bgActiveBefore = bgWorkspace().activePaneId;
+      publishCalls.length = 0;
+
+      store.getState().setActivePane(otherLeafId);
+
+      expect(bgWorkspace().activePaneId).toBe(bgActiveBefore); // unchanged
+      expect(publishCalls.filter((c) => c.fn === 'pane.focused')).toHaveLength(0);
+    });
+  });
+
   describe('cyclePane', () => {
     it('publishes pane.focused with previous active pane id', () => {
       store.getState().splitPane(rootPaneId, 'horizontal');

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -39,6 +39,27 @@ export interface PaneSlice {
    * unchanged). */
   closePane: (paneId: string, workspaceId?: string) => void;
   setActivePane: (paneId: string) => void;
+  /**
+   * Focus a leaf pane (and optionally one of its surfaces) in an EXPLICIT
+   * workspace — the address-resolution counterpart to `setActivePane`, used by
+   * the `pane.focus` / `surface.focus` RPC so an external agent that owns a
+   * BACKGROUND workspace can focus its own pane without the active-workspace
+   * scoping `setActivePane` enforces.
+   *
+   * Resolves `workspaceId` exactly (no self-search, no `activeWorkspaceId`
+   * fallback) and NEVER mutates `activeWorkspaceId` — bringing a workspace
+   * on-screen is the separate `workspace.focus` RPC, so this is inherently
+   * non-yank. Sets `activePaneId` and (when `surfaceId` is supplied and present
+   * on the leaf) `activeSurfaceId` in ONE transaction. Emits `pane.focused`
+   * when — and only when — the active pane actually changed (a surface-only
+   * change on the already-active pane does not, since `pane.focused` is a pane
+   * event); the emit is NOT gated on `activeWorkspaceId`, so a real focus change
+   * in a background/multiview workspace is reported honestly.
+   *
+   * Returns `false` (no mutation, no emit) when the workspace is unknown or the
+   * pane is missing / not a leaf (a branch); `true` otherwise.
+   */
+  focusPaneSurface: (workspaceId: string, paneId: string, surfaceId?: string) => boolean;
   focusPaneDirection: (direction: 'up' | 'down' | 'left' | 'right') => void;
   cyclePane: (direction: 'next' | 'prev') => void;
   updatePaneSizes: (branchId: string, sizes: number[]) => void;
@@ -418,6 +439,50 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
       const e = event as { wsId: string; paneId: string; previousActiveId: string };
       publishPaneFocused(e.wsId, e.paneId, e.previousActiveId);
     }
+  },
+
+  focusPaneSurface: (workspaceId, paneId, surfaceId) => {
+    // Mirrors setActivePane's capture-outside-set / publish-after-set shape, but
+    // resolves the workspace by EXPLICIT id (the RPC bridge already located the
+    // owning workspace by globally-unique pane/surface id) instead of the
+    // active one, and emits even for a background workspace (#236 follow-up).
+    let event: { wsId: string; paneId: string; previousActiveId: string } | null = null;
+    let ok = false;
+    set((state: StoreState) => {
+      const ws = state.workspaces.find((w: Workspace) => w.id === workspaceId);
+      if (!ws) return; // unknown workspace → false, no mutation, no emit.
+
+      // Only a leaf is focusable: a branch id (or a missing id) must not move the
+      // active selection. findPane returns the node of either type, so assert leaf.
+      const target = findPane(ws.rootPane, paneId);
+      if (!target || target.type !== 'leaf') return;
+
+      const previousActiveId = ws.activePaneId;
+      const paneChanged = previousActiveId !== target.id;
+
+      // Atomic: set the active pane and (when asked + present) the active surface
+      // in the SAME producer, so an observer never sees the new pane with a stale
+      // active surface (the two-write race the dedicated action exists to avoid).
+      ws.activePaneId = target.id;
+      if (surfaceId && target.surfaces.some((s) => s.id === surfaceId)) {
+        target.activeSurfaceId = surfaceId;
+      }
+
+      ok = true;
+      // pane.focused is a PANE event: emit only when the active pane actually
+      // changed. A surface-only change on the already-active pane is a no-emit.
+      // No activeWorkspaceId gate — a real focus change in a background/multiview
+      // workspace is honest to report, and events are ws-scoped so there is no
+      // cross-workspace leak.
+      if (paneChanged) {
+        event = { wsId: ws.id, paneId: target.id, previousActiveId };
+      }
+    });
+    if (event) {
+      const e = event as { wsId: string; paneId: string; previousActiveId: string };
+      publishPaneFocused(e.wsId, e.paneId, e.previousActiveId);
+    }
+    return ok;
   },
 
   updatePaneSizes: (branchId, sizes) => set((state: StoreState) => {


### PR DESCRIPTION
## Summary

`pane.focus` and `surface.focus` only acted on the on-screen workspace, so an external agent working in a **background** workspace could not focus its own pane/surface:
- `pane.focus` silently no-op'd yet returned `{ok:true}` (false success)
- `surface.focus` errored `"not found"`

Last sibling of the #236 RPC workspace-scoping sweep, after `surface.new`/`pane.close` (#256).

## Approach

New dedicated store action `focusPaneSurface(workspaceId, paneId, surfaceId?)`:
- resolves the workspace by **explicit** id (no self-search, no `activeWorkspaceId` fallback)
- rejects non-leaf panes (returns `false`, no mutation/emit)
- sets the active pane and (when supplied + present) the active surface in **one** transaction (atomic)
- emits `pane.focused` on a **real pane change**, NOT gated on `activeWorkspaceId` — so a background or multiview workspace's focus change is reported honestly (events are ws-scoped, no cross-workspace leak)

The bridge handlers resolve the target across **all** workspaces by its globally-unique id (mirroring #256 `pane.close`/`surface.close`) and surface a real `{error}` on a miss, removing the false `{ok:true}`.

`setActivePane`/`setActiveSurface` and the daemon handlers are **untouched**, so the `browserPane` background no-op invariant and the **non-yank** guarantee (bringing a workspace on-screen stays the separate `workspace.focus` RPC) both hold.

## Design notes

Resolved via a multi-expert plan review + cross-model (codex) check. Key catch: an earlier draft suppressed `pane.focused` for background focus, but **multiview** (multiple workspaces rendered simultaneously) makes `activeWorkspaceId` a poor visibility gate, so the event is emitted for every real focus change. `pane.focus`/`surface.focus` resolve by globally-unique id (the address-an-existing-node family) rather than taking a `workspaceId` (the create family); `docs/PROTOCOL.md` §6.1 documents the contract.

## Tests

- 9 behavioral cases against `focusPaneSurface` (EMIT-on-background carrying the ws id, non-yank, atomic surface set, non-leaf → false, unknown ws/pane → false, idempotent no-emit, + a regression locking `setActivePane`'s background no-op so the `browserPane` invariant holds)
- structural bridge guards (`handleRpcMethod` is un-exported, matching the `browserClose`/`a2aPaneIdentity` precedent)
- full suite green (3638), `tsc` clean, lint 0 errors

## Out of scope (filed to TODOS.md)

- unscoped plugin `events.poll` cross-workspace lifecycle leak (pre-existing)
- unify `surface.focus` capability (`wmux.internal` → `pane.read`)
- per-target ownership authz for the focus/close family


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new pane and surface focus capabilities with improved cross-workspace handling.

* **Bug Fixes**
  * Focus operations now correctly target panes and surfaces in background workspaces without unintentionally switching the active workspace.

* **Documentation**
  * Clarified protocol documentation for address-resolution RPC operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->