### PR TITLE
fix: Ctrl+Enter newline in TUIs + discoverable pane maximize (Reddit feedback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **A pane now has a discoverable maximize button.** Hovering an un-zoomed pane reveals a quiet `⤢` button in its top-right corner; clicking it zooms that pane to fill the window — the same toggle as the tmux-style prefix + `z`, which was previously keyboard-only and undocumented. The keyboard cheat sheet (`?` in prefix mode) gained a **Maximize pane** entry. Surfaced after Reddit feedback that there was no visible fullscreen/maximize control to find ([#182](https://github.com/openwong2kim/wmux/issues/182) follow-up).
+
+### Fixed
+- **Ctrl+Enter now inserts a newline instead of submitting, inside in-pane TUIs like Claude Code and codex.** xterm sends a bare carriage return for Ctrl+Enter — byte-identical to plain Enter — so a TUI couldn't tell the two apart and treated Ctrl+Enter as submit. wmux now emits a line feed for the Ctrl+Enter chord, matching the existing Shift+Enter and Ctrl+J newline keys. Surfaced after Reddit feedback.
+
 ## [3.6.0] — 2026-06-17 — A reply finds the exact agent that asked
 
 Headline: same-workspace agents now reply to the *exact* pane that asked. A task's reply returns to its originating pane instead of the workspace's active one, same-workspace history finally tells the two agents apart (sender vs receiver, per pane), and a status update is restricted to the addressed pane — completing the pane-level multi-agent mesh that #239 and #242 began. Plus a fix for the terminal+browser split that blanked its unfocused side.

--- a/src/renderer/components/KeyboardCheatSheet.tsx
+++ b/src/renderer/components/KeyboardCheatSheet.tsx
@@ -87,6 +87,13 @@ export function buildShortcuts(platform: string | undefined): CheatSheetEntry[] 
     // tmux prefix is always literal Ctrl+B (wmux convention, D1 / useKeyboard.ts).
     // TODO(T1): wire i18n key for cheat sheet "tmux prefix" entry.
     { label: 'tmux prefix', combo: 'Ctrl+B', literal: true },
+    // Maximize / zoom the focused pane to fill the window (tmux prefix then z;
+    // press again to restore). Surfaced here because there is no always-visible
+    // button — the pane only reveals a maximize affordance on hover — so the
+    // "no fullscreen button" gap is at least discoverable via the cheat sheet.
+    // literal: the prefix is Ctrl+B on every OS, so the combo can't use ⌘.
+    // TODO(T1): wire i18n key for cheat sheet "Maximize pane" entry.
+    { label: 'Maximize pane', combo: 'Ctrl+B Z', literal: true },
     // Bookmark is always literal Ctrl+M (matches useKeyboard.ts:448).
     // TODO(T1): wire i18n key for cheat sheet "Bookmark line" entry.
     { label: 'Bookmark line', combo: 'Ctrl+M', literal: true },

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -256,6 +256,7 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
       }}
       onClick={handleClick}
       data-onboarding-target="pane-area"
+      data-wmux-pane-root
       {...tokenAttrs('accent', 'border')}
       data-derived="accentCursor"
     >
@@ -289,6 +290,41 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
           }}
         >
           ZOOM
+        </button>
+      )}
+      {/* Issue #182 discoverability: an un-zoomed pane exposes a quiet maximize
+          button (hover-revealed via .wmux-pane-maximize-btn in globals.css) so
+          the zoom feature isn't keyboard-only. Clicking it zooms the pane; once
+          zoomed, the always-visible ZOOM badge above takes over as the toggle. */}
+      {!isZoomed && (
+        <button
+          className="wmux-pane-maximize-btn"
+          onClick={(e) => {
+            e.stopPropagation();
+            useStore.getState().togglePaneZoom(pane.id);
+          }}
+          title={t('settings.prefix.toggleZoom')}
+          aria-label={t('settings.prefix.toggleZoom')}
+          style={{
+            position: 'absolute',
+            top: 4,
+            // Sit left of the supervision badge when present (it owns right:6 on
+            // an un-zoomed pane); otherwise take the corner.
+            right: supervision ? 32 : 6,
+            zIndex: 20,
+            padding: '0 5px',
+            height: 16,
+            fontSize: 12,
+            lineHeight: '16px',
+            fontFamily: 'ui-monospace, monospace',
+            color: 'var(--text-main)',
+            backgroundColor: 'var(--bg-surface)',
+            border: '1px solid var(--bg-surface0, rgba(255,255,255,0.12))',
+            borderRadius: 3,
+            cursor: 'pointer',
+          }}
+        >
+          ⤢
         </button>
       )}
       {supervision && (

--- a/src/renderer/components/__tests__/KeyboardCheatSheet.test.tsx
+++ b/src/renderer/components/__tests__/KeyboardCheatSheet.test.tsx
@@ -96,9 +96,17 @@ describe('buildShortcuts', () => {
     expect(winList.find((e) => e.label === 'cheatSheet.toggleSidebar')?.combo).toBe('Ctrl+Shift+B');
   });
 
-  it('returns 11 shortcut entries', () => {
-    expect(buildShortcuts('darwin').length).toBe(11);
-    expect(buildShortcuts('win32').length).toBe(11);
+  it('returns 12 shortcut entries', () => {
+    expect(buildShortcuts('darwin').length).toBe(12);
+    expect(buildShortcuts('win32').length).toBe(12);
+  });
+
+  it('includes the Maximize pane entry (literal "Ctrl+B Z" on every platform)', () => {
+    const macList = buildShortcuts('darwin');
+    const winList = buildShortcuts('win32');
+    expect(macList.find((e) => e.label === 'Maximize pane')?.combo).toBe('Ctrl+B Z');
+    expect(winList.find((e) => e.label === 'Maximize pane')?.combo).toBe('Ctrl+B Z');
+    expect(macList.find((e) => e.label === 'Maximize pane')?.literal).toBe(true);
   });
 
   it('includes the Ctrl+Shift+Arrow move-focus entry (literal Ctrl on every platform)', () => {
@@ -224,12 +232,12 @@ describe('KeyboardCheatSheetView (renderToStaticMarkup)', () => {
     expect(renderView({ progress: 5 })).toMatch(/style="width:\s*100%/);
   });
 
-  it('renders all 11 shortcut entries in the list', () => {
+  it('renders all 12 shortcut entries in the list', () => {
     const html = renderView({ shortcuts: buildShortcuts('win32') });
     // Each shortcut entry is rendered inside a <li>; count occurrences of the
-    // opening <li tag inside the list to verify all 11 made it.
+    // opening <li tag inside the list to verify all 12 made it.
     const liMatches = html.match(/<li/g) ?? [];
-    expect(liMatches.length).toBe(11);
+    expect(liMatches.length).toBe(12);
   });
 });
 

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -413,6 +413,28 @@ html, body, #root {
   display: none !important;
 }
 
+/* Pane maximize affordance (issue #182 discoverability): the per-pane maximize
+ * button stays invisible until the pane is hovered, then fades in — keeps the
+ * terminal surface clean while giving a discoverable click target alongside the
+ * keyboard path (prefix + z) and the cheat-sheet entry. A zoomed pane keeps its
+ * always-visible ZOOM badge instead (rendered separately in Pane.tsx). */
+.wmux-pane-maximize-btn {
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+[data-wmux-pane-root]:hover .wmux-pane-maximize-btn {
+  opacity: 0.85;
+}
+.wmux-pane-maximize-btn:hover,
+.wmux-pane-maximize-btn:focus-visible {
+  opacity: 1 !important;
+}
+@media (prefers-reduced-motion: reduce) {
+  .wmux-pane-maximize-btn {
+    transition: none;
+  }
+}
+
 /* ─── Sidebar polish: depth + motion (refined-terminal pass) ────────────────
  * Depth on the active row comes from token-derived color-mix values, so all
  * built-in and custom themes work: the gradient/highlight lean toward

--- a/src/renderer/terminal/__tests__/newlineKeys.test.ts
+++ b/src/renderer/terminal/__tests__/newlineKeys.test.ts
@@ -78,3 +78,30 @@ describe('resolveNewlineKeyByte — Shift+Enter (preserved behavior)', () => {
     expect(resolveNewlineKeyByte(ev({ key: 'Enter', shiftKey: true, ctrlKey: true }))).toBeNull();
   });
 });
+
+describe('resolveNewlineKeyByte — Ctrl+Enter', () => {
+  it('emits LF for Ctrl+Enter so an in-pane TUI inserts a newline instead of submitting', () => {
+    expect(resolveNewlineKeyByte(ev({ key: 'Enter', code: 'Enter', ctrlKey: true }))).toBe('\n');
+  });
+
+  it('emits LF for Ctrl+Enter on the numeric keypad (NumpadEnter still reports key "Enter")', () => {
+    expect(resolveNewlineKeyByte(ev({ key: 'Enter', code: 'NumpadEnter', ctrlKey: true }))).toBe('\n');
+  });
+
+  it('ignores Ctrl+Shift+Enter (Shift+Enter already owns its CSI u path)', () => {
+    expect(resolveNewlineKeyByte(ev({ key: 'Enter', ctrlKey: true, shiftKey: true }))).toBeNull();
+  });
+
+  it('ignores Ctrl+Alt+Enter and Ctrl+Meta+Enter', () => {
+    expect(resolveNewlineKeyByte(ev({ key: 'Enter', ctrlKey: true, altKey: true }))).toBeNull();
+    expect(resolveNewlineKeyByte(ev({ key: 'Enter', ctrlKey: true, metaKey: true }))).toBeNull();
+  });
+
+  it('defers during an active IME composition so a preedit is not split', () => {
+    expect(resolveNewlineKeyByte(ev({ key: 'Enter', ctrlKey: true, isComposing: true }))).toBeNull();
+  });
+
+  it('ignores a bare Enter (no Ctrl) — plain submit is unchanged', () => {
+    expect(resolveNewlineKeyByte(ev({ key: 'Enter' }))).toBeNull();
+  });
+});

--- a/src/renderer/terminal/newlineKeys.ts
+++ b/src/renderer/terminal/newlineKeys.ts
@@ -21,6 +21,11 @@
  *   - Shift+Enter → CSI u (`ESC [ 13 ; 2 u`): Claude Code / kitty-protocol
  *     apps insert a newline instead of submitting. (Pre-existing behavior,
  *     moved here verbatim.)
+ *   - Ctrl+Enter → LF (`\n`): same intent as Ctrl+J. With no extended keyboard
+ *     protocol enabled, xterm sends a bare CR for Ctrl+Enter — byte-identical
+ *     to plain Enter — so an in-pane TUI submits instead of inserting a
+ *     newline. Many users reach for Ctrl+Enter expecting a newline; we emit LF
+ *     so it behaves like Ctrl+J / Shift+Enter.
  *   - Ctrl+J → LF (`\n`, U+000A): the canonical "insert newline, do not
  *     submit" byte that codex / Claude Code / readline editors expect. This
  *     is exactly what xterm would emit in its legacy path — we just emit it
@@ -61,6 +66,26 @@ export function resolveNewlineKeyByte(
   // constrained — preserves the original inline handler's exact predicate.)
   if (e.key === 'Enter' && e.shiftKey && !e.ctrlKey && !e.altKey) {
     return '\x1b[13;2u';
+  }
+
+  // Ctrl+Enter → LF, same intent as Ctrl+J: insert a newline without
+  // submitting. xterm has no extended keyboard protocol enabled, so it sends a
+  // bare CR (\r) for Ctrl+Enter — indistinguishable from plain Enter — and an
+  // in-pane TUI (Claude Code, codex) submits instead of adding a line. Emitting
+  // LF ourselves gives the editor the "newline, don't submit" byte it expects.
+  // Keyed on `key === 'Enter'` to mirror the Shift+Enter predicate above
+  // (NumpadEnter also reports key 'Enter'). The other modifiers are excluded so
+  // only the pure Ctrl+Enter chord matches, and `!isComposing` defers to an
+  // active IME preedit exactly like the Ctrl+J path below.
+  if (
+    e.key === 'Enter' &&
+    e.ctrlKey &&
+    !e.shiftKey &&
+    !e.altKey &&
+    !e.metaKey &&
+    !e.isComposing
+  ) {
+    return '\n';
   }
 
   // Ctrl+J → LF. Match the physical key so it survives a CJK IME where


### PR DESCRIPTION
## Summary
Two small fixes surfaced by Reddit feedback on wmux:

**Ctrl+Enter newline (fix).** Pressing Ctrl+Enter inside an in-pane TUI (Claude Code, codex) submitted the prompt instead of inserting a newline. xterm sends a bare CR for Ctrl+Enter, byte-identical to plain Enter, so the app can't distinguish them. `resolveNewlineKeyByte` now emits LF for the pure Ctrl+Enter chord, matching the existing Shift+Enter (CSI u) and Ctrl+J (LF) newline keys. Those two already worked — Ctrl+Enter was the missing chord.

**Pane maximize discoverability (feat).** Pane zoom ([#182](https://github.com/openwong2kim/wmux/issues/182)) was keyboard-only (tmux prefix + z) with no visible button and no cheat-sheet entry, so users couldn't find how to maximize a pane (a recurring "no fullscreen button" report). Each un-zoomed pane now shows a quiet maximize button (⤢) on hover that zooms via the same `togglePaneZoom` path as the ZOOM badge, and the cheat sheet gained a **Maximize pane** entry.

## Test Coverage
- `newlineKeys.test.ts`: +6 cases — Ctrl+Enter → LF, NumpadEnter, Shift/Alt/Meta rejected, IME-composition defer, bare Enter unchanged.
- `KeyboardCheatSheet.test.tsx`: Maximize pane entry + count 11 → 12.
- Static: `tsc` 0 errors, eslint 0, vitest 85 passed (relevant suites).

## Verification
- **Ctrl+Enter:** unit-verified; the transport path is shared with Ctrl+J / Shift+Enter (already in production). A live CDP byte-probe isn't possible — wmux's xterm WebGL renderer keeps terminal output out of the DOM.
- **Maximize button:** CDP dogfood in an isolated dev instance — button renders (⤢ glyph), hidden at rest (opacity 0), forced `:hover` reveals at 0.85, click → zoom (hidden sibling + ZOOM badge), restore. Visibility was tuned (0.55 → 0.85, `--text-main`/`--bg-surface`/border) after the first screenshot showed it too faint on the light theme.

## Notes
- No VERSION bump — unreleased, logged under CHANGELOG `[Unreleased]` per repo convention.
- Frontend-only (renderer + globals.css). No daemon/main changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a maximize pane button (⤢) that appears on hover for easy access to pane zoom control.
  * Ctrl+Enter now inserts a newline in in-pane TUIs (e.g., Claude Code) instead of submitting.
  * Keyboard cheat sheet now includes the maximize pane shortcut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->