### PR TITLE
chore(community): issue templates + contributor onramp + honest i18n status

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,124 @@
+name: Bug report
+description: Something in wmux is broken or behaves unexpectedly.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. wmux is a native Windows
+        terminal multiplexer — please include enough detail for us to reproduce
+        it on a clean machine. Search [existing issues](https://github.com/openwong2kim/wmux/issues?q=is%3Aissue)
+        first; if you find a match, add a 👍 or a comment instead of opening a new one.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: A clear, concise description of the bug — what you saw versus what you expected.
+      placeholder: When I split a pane with Ctrl+D, the new pane renders blank until I click it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Number the exact steps so we can follow along. Include any `wmux.json` or layout that matters.
+      placeholder: |
+        1. Launch wmux
+        2. Open a workspace and run `claude`
+        3. Press Ctrl+D to split right
+        4. Observe the right pane is blank
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: input
+    id: wmux-version
+    attributes:
+      label: wmux version
+      description: "Found in Settings → About, or run `wmux --version`."
+      placeholder: e.g. 3.6.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: How did you install wmux?
+      options:
+        - winget
+        - Chocolatey
+        - Setup.exe (direct download)
+        - Built from source
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: shell
+    attributes:
+      label: Shell in the affected pane
+      description: Which shell was running in the pane where the bug occurred?
+      options:
+        - PowerShell 7+ (pwsh)
+        - Windows PowerShell 5.1
+        - Command Prompt (cmd)
+        - WSL / other
+        - Not applicable
+    validations:
+      required: true
+
+  - type: input
+    id: windows-version
+    attributes:
+      label: Windows version
+      description: "Run `winver`, or Settings → System → About. Include the build number."
+      placeholder: e.g. Windows 11 23H2 (build 22631.3737)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: agent
+    attributes:
+      label: AI agent involved (if any)
+      description: Was a coding agent running in the pane when this happened?
+      options:
+        - None / not relevant
+        - Claude Code
+        - Codex CLI
+        - Gemini CLI
+        - Other agent
+      default: 0
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, screenshots, or recordings
+      description: |
+        Attach anything that helps. Daemon and renderer logs live under
+        `%APPDATA%\wmux\logs`. Drag-and-drop images or paste a short clip.
+        Code and logs are rendered automatically — no backticks needed.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: I am on Windows 10 or 11 (wmux is Windows-only).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & ideas (Discussions)
+    url: https://github.com/openwong2kim/wmux/discussions
+    about: Ask a question, share a setup, or float an open-ended idea before it becomes an issue.
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/openwong2kim/wmux/security/advisories/new
+    about: Please report security issues privately here — do not open a public issue.
+  - name: 📖 Documentation
+    url: https://github.com/openwong2kim/wmux#readme
+    about: Installation, keyboard shortcuts, and the full feature list live in the README.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature request
+description: Suggest an idea or improvement for wmux.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping shape wmux. Search [existing issues](https://github.com/openwong2kim/wmux/issues?q=is%3Aissue)
+        and [Discussions](https://github.com/openwong2kim/wmux/discussions) first —
+        if your idea is open-ended, a Discussion is often a better home for it.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem are you trying to solve? What's frustrating or missing today?
+      placeholder: I run four agents across two workspaces and can't tell at a glance which one is blocked on an approval.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the feature or behavior you'd like. Be as concrete as you can.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches, workarounds you currently use, or how similar tools (tmux, cmux, Windows Terminal) handle this.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, screenshots, links, or anything else that helps explain the request.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues and Discussions and this is not a duplicate.
+          required: true

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ winget install openwong2kim.wmux
 - 🔀 **Multiview** — several workspaces side by side · layout templates · drag-to-reorder sidebar
 - 🧩 **Plugin host** — sandboxed iframe plugins with an explicit permission model
 - 🛡️ **Token-authed IPC**, SSRF guard, PTY input sanitization, randomized CDP port, Electron Fuses
-- 🎨 Catppuccin Mocha · Monochrome · Sandstone &nbsp;·&nbsp; 🌏 English · 한국어 · 日本語 · 中文
+- 🎨 Catppuccin Mocha · Monochrome · Sandstone &nbsp;·&nbsp; 🌏 **23 locales scaffolded** — English & 한국어 complete, 日本語 / 中文 in progress — **[translations welcome](https://github.com/openwong2kim/wmux/labels/good%20first%20issue)**
 
 > 💡 **Tip:** point Claude Code at the MCP tools (`browser_open`, `terminal_read`, `pane_list`, `a2a_task_send`) or script the `wmux` CLI (`wmux send` / `read-screen` / `list-panes --json`) to orchestrate panes programmatically.
 
@@ -172,6 +172,8 @@ Requires Node 18+, Python 3.x, and VS Build Tools (C++ workload). `WMUX_FROM_SOU
 ---
 
 ## 🙌 Contributors
+
+New here? Grab a [**good first issue**](https://github.com/openwong2kim/wmux/labels/good%20first%20issue), help translate a locale, or read [**CONTRIBUTING.md**](CONTRIBUTING.md) — PRs welcome.
 
 [![Contributors](https://contrib.rocks/image?repo=openwong2kim/wmux)](https://github.com/openwong2kim/wmux/graphs/contributors)
 


### PR DESCRIPTION
## What

Lower the barrier for new contributors. The real M2 gap from the adoption review: open issues sat at 0, so newcomers had no entry point — even though the repo already has 8 external contributors and a `good first issue` label.

## Changes (docs/community only, no code, no version bump)

**Issue templates** (`.github/ISSUE_TEMPLATE/`, new) — GitHub issue forms:
- `bug_report.yml` — wmux version, install method (winget/Choco/Setup.exe/source), shell (pwsh7/5.1/cmd), Windows build, AI agent involved, repro steps, expected vs actual, log path hint
- `feature_request.yml` — problem / proposal / alternatives / context
- `config.yml` — disables blank issues; links Discussions, private security advisory, and docs

**README** — two honest, minimal edits:
- **i18n line:** replaced the overstated `English · 한국어 · 日本語 · 中文` with the true tier — **23 locales scaffolded, en/ko complete, ja/zh in progress, translations welcome** (links the good-first-issue label). Only en/ko are fully translated; the other 21 fall back to English. Honest, and turns the gap into a contribution invite.
- **Contributors section:** a one-line onramp (good first issue / translate a locale / CONTRIBUTING.md).

Follow-up (separate, with maintainer approval): publish ~5 good-first-issues so the label links above resolve to real work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated highlights with locale progress information for internationalization
  * Expanded contributor section with welcoming invitation for new contributors

* **Chores**
  * Added structured bug report and feature request issue templates
  * Configured issue settings to disable blank issues and provide contact links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->