### PR TITLE
fix(terminal): self-heal orphaned keyboard focus (typing dead until view switch)

### DIFF
--- a/src/renderer/hooks/__tests__/useActivePaneFocus.test.ts
+++ b/src/renderer/hooks/__tests__/useActivePaneFocus.test.ts
@@ -11,7 +11,14 @@
  * same-pane surface (tab) switches, and must decline non-terminal surfaces.
  */
 import { describe, it, expect } from 'vitest';
-import { resolveActivePanePtyId, driveFocusToTerminal, type FocusDriverDeps } from '../useActivePaneFocus';
+import {
+  resolveActivePanePtyId,
+  driveFocusToTerminal,
+  isFocusOrphaned,
+  reassertFocusIfOrphaned,
+  type FocusDriverDeps,
+  type FocusReassertDeps,
+} from '../useActivePaneFocus';
 import type { Workspace, Pane, PaneLeaf, Surface } from '../../../shared/types';
 
 function surface(id: string, ptyId: string, surfaceType?: Surface['surfaceType']): Surface {
@@ -195,5 +202,100 @@ describe('driveFocusToTerminal', () => {
     h.register('pty-1');
     expect(h.focused).toEqual([]);
     expect(h.listenerCount()).toBe(0);
+  });
+});
+
+// ─── isFocusOrphaned ─────────────────────────────────────────────────────────
+// The guard that lets the self-heal RECLAIM abandoned focus without ever
+// STEALING focus the user placed on a real element.
+
+describe('isFocusOrphaned', () => {
+  const body = {} as Element;
+  const real = {} as Element;
+
+  it('true when nothing holds focus (activeElement null)', () => {
+    expect(isFocusOrphaned(null, body)).toBe(true);
+  });
+  it('true when <body> holds focus', () => {
+    expect(isFocusOrphaned(body, body)).toBe(true);
+  });
+  it('false when a real interactive element holds focus', () => {
+    expect(isFocusOrphaned(real, body)).toBe(false);
+  });
+});
+
+// ─── reassertFocusIfOrphaned ─────────────────────────────────────────────────
+// Pins the fix for the field bug "typing dies in the Claude pane until I toggle
+// multiview": an overlay closes, focus falls to <body>, and the terminal must
+// be re-focused — but only when focus is genuinely orphaned.
+
+/** Drives the heal with a controllable activeElement sequence + manual defer. */
+function makeReassertHarness(seq: Array<'body' | 'real' | 'null'>, target: string | null) {
+  const body = {} as Element;
+  const real = {} as Element;
+  const resolve = { body, real, null: null } as const;
+  const active = seq.map((s) => resolve[s]);
+  let i = 0;
+  const focused: string[] = [];
+  const healed: string[] = [];
+  const deferQueue: Array<() => void> = [];
+
+  const deps: FocusReassertDeps = {
+    resolveTarget: () => target,
+    // Each read advances the staged sequence, clamping at the last entry so a
+    // heal that reads activeElement twice (sync + deferred) sees both stages.
+    getActiveElement: () => active[Math.min(i++, active.length - 1)],
+    getBody: () => body,
+    focusTerminal: (id) => focused.push(id),
+    defer: (cb) => deferQueue.push(cb),
+    onHeal: (id) => healed.push(id),
+  };
+
+  return {
+    deps,
+    focused,
+    healed,
+    deferredCount: () => deferQueue.length,
+    drain: () => { while (deferQueue.length) { const cb = deferQueue.shift(); if (cb) cb(); } },
+  };
+}
+
+describe('reassertFocusIfOrphaned', () => {
+  it('focuses the active terminal when focus is orphaned to <body>', () => {
+    const h = makeReassertHarness(['body', 'body'], 'pty-1');
+    reassertFocusIfOrphaned(h.deps);
+    // Deferred — nothing focused synchronously.
+    expect(h.focused).toEqual([]);
+    h.drain();
+    expect(h.focused).toEqual(['pty-1']);
+    expect(h.healed).toEqual(['pty-1']);
+  });
+
+  it('fast-bails (schedules no defer) when a real element holds focus', () => {
+    const h = makeReassertHarness(['real'], 'pty-1');
+    reassertFocusIfOrphaned(h.deps);
+    expect(h.deferredCount()).toBe(0); // hot per-keystroke path stays cheap
+    h.drain();
+    expect(h.focused).toEqual([]);
+  });
+
+  it('does nothing when no terminal target resolves (browser/editor/empty)', () => {
+    const h = makeReassertHarness(['body', 'body'], null);
+    reassertFocusIfOrphaned(h.deps);
+    h.drain();
+    expect(h.focused).toEqual([]);
+    expect(h.healed).toEqual([]);
+  });
+
+  it('does NOT yank focus when a real element claims it before the deferred frame', () => {
+    // Orphaned at the synchronous check (body), but a legit element (palette
+    // input) takes focus by the time the deferred re-check runs — the user
+    // moved focus on purpose, so the heal must stand down.
+    const h = makeReassertHarness(['body', 'real'], 'pty-1');
+    reassertFocusIfOrphaned(h.deps);
+    expect(h.deferredCount()).toBe(1);
+    h.drain();
+    expect(h.focused).toEqual([]);
+    expect(h.healed).toEqual([]);
   });
 });

--- a/src/renderer/hooks/useActivePaneFocus.ts
+++ b/src/renderer/hooks/useActivePaneFocus.ts
@@ -105,6 +105,64 @@ export function driveFocusToTerminal(ptyId: string, deps: FocusDriverDeps): () =
 }
 
 /**
+ * Is DOM focus "orphaned" — sitting on <body> or nowhere — rather than on a
+ * real interactive element?
+ *
+ * This is the load-bearing guard for the focus self-heal below. The heal may
+ * ONLY reclaim abandoned focus, never STEAL focus the user has placed: when a
+ * palette input, the agent-toolbar textarea, another pane's xterm, or a browser
+ * webview legitimately holds focus, `document.activeElement` is THAT element
+ * (not body), so this returns false and the heal stands down. It is exactly
+ * what lets the heal coexist with `driveFocusToTerminal`'s deliberately
+ * one-shot disarm (see its doc): that disarm stops focus being re-grabbed on a
+ * remount; this only ever fires when nobody owns focus at all.
+ */
+export function isFocusOrphaned(active: Element | null, body: Element | null): boolean {
+  return active === null || active === body;
+}
+
+export interface FocusReassertDeps {
+  /** The ptyId that SHOULD hold focus, or null (browser/editor/empty/no-ws). */
+  resolveTarget: () => string | null;
+  getActiveElement: () => Element | null;
+  getBody: () => Element | null;
+  /** Pull DOM focus onto a terminal's xterm by ptyId. No-op if unregistered. */
+  focusTerminal: (ptyId: string) => void;
+  /** Defer one frame so we read activeElement AFTER the focus change settles. */
+  defer: (cb: () => void) => void;
+  /** Instrumentation: called with the ptyId whenever a heal actually fires. */
+  onHeal?: (ptyId: string) => void;
+}
+
+/**
+ * Reclaim DOM focus onto the active terminal when it has been orphaned to
+ * <body>. This closes the structural hole behind the field bug "typing dies in
+ * the Claude pane until I toggle multiview": every transient overlay (Ctrl+F
+ * search bar, Ctrl+K palette, notification panel, agent-toolbar RichInput)
+ * focuses its OWN field and, on dismiss, UNMOUNTS — dropping DOM focus to
+ * <body>. Those overlays toggle via store flags that are NOT part of
+ * `useActivePaneFocus`'s focusKey, so the one-shot driver never re-runs and the
+ * terminal stays deaf. A multiview toggle "recovers" only because it remounts
+ * the whole workspace subtree and re-runs focus resolution from scratch.
+ *
+ * Two-stage check: a synchronous fast-bail keeps the per-keystroke path cheap
+ * (when a real element holds focus we never even touch the defer), and a
+ * deferred re-check absorbs the transient `<body>` window during a LEGIT focus
+ * move (terminal → palette input) so we don't yank focus back out from under
+ * the user mid-transition.
+ */
+export function reassertFocusIfOrphaned(deps: FocusReassertDeps): void {
+  if (!isFocusOrphaned(deps.getActiveElement(), deps.getBody())) return;
+  deps.defer(() => {
+    if (!isFocusOrphaned(deps.getActiveElement(), deps.getBody())) return;
+    const ptyId = deps.resolveTarget();
+    if (!ptyId) return;
+    deps.focusTerminal(ptyId);
+    deps.onHeal?.(ptyId);
+  });
+}
+
+/**
  * Keyboard pane/surface navigation moves the *visual* active marker (the red
  * pane border, driven by `ws.activePaneId` in the store) but does NOT move DOM
  * focus. xterm routes keystrokes from whichever textarea currently holds DOM
@@ -146,4 +204,36 @@ export function useActivePaneFocus(): void {
       caf: (handle) => cancelAnimationFrame(handle),
     });
   }, [focusKey]);
+
+  // Self-heal: reclaim focus when an overlay (search bar / command palette /
+  // notification panel / agent-toolbar RichInput) closes and drops DOM focus to
+  // <body>. The primary effect above only fires when the focus TARGET changes;
+  // these triggers cover the "target unchanged, focus abandoned" hole that left
+  // the terminal deaf until a multiview remount. Mounted once (this hook lives
+  // at AppLayout) and never re-armed per target, so it is independent of
+  // focusKey. The `isFocusOrphaned` guard inside means a real element holding
+  // focus (palette, toolbar, another pane, browser webview) is never disturbed.
+  useEffect(() => {
+    const onSignal = (): void => reassertFocusIfOrphaned({
+      resolveTarget: () => resolveActivePanePtyId(useStore.getState()),
+      getActiveElement: () => document.activeElement,
+      getBody: () => document.body,
+      focusTerminal: (id) => terminalRegistry.get(id)?.focus(),
+      defer: (cb) => requestAnimationFrame(cb),
+      onHeal: (id) => console.debug(`[useActivePaneFocus] reclaimed orphaned focus → pty=${id}`),
+    });
+    // window 'focus': OS focus returns (alt-tab back) onto <body>.
+    // 'focusout': an element (overlay input) just relinquished / was unmounted;
+    //   bubbles to document, unlike 'blur'.
+    // 'keydown': safety net — a key reached <body> because nothing is focused
+    //   (the literal dead-input moment); re-assert so the NEXT key lands.
+    window.addEventListener('focus', onSignal);
+    document.addEventListener('focusout', onSignal);
+    document.addEventListener('keydown', onSignal);
+    return () => {
+      window.removeEventListener('focus', onSignal);
+      document.removeEventListener('focusout', onSignal);
+      document.removeEventListener('keydown', onSignal);
+    };
+  }, []);
 }

--- a/src/renderer/hooks/useActivePaneFocus.ts
+++ b/src/renderer/hooks/useActivePaneFocus.ts
@@ -214,12 +214,19 @@ export function useActivePaneFocus(): void {
   // focusKey. The `isFocusOrphaned` guard inside means a real element holding
   // focus (palette, toolbar, another pane, browser webview) is never disturbed.
   useEffect(() => {
+    // Track deferred frames so cleanup fully disarms the heal: a focusout /
+    // keydown landing right before unmount could otherwise leave a queued rAF
+    // that refocuses a terminal from a torn-down effect instance.
+    const pending = new Set<number>();
     const onSignal = (): void => reassertFocusIfOrphaned({
       resolveTarget: () => resolveActivePanePtyId(useStore.getState()),
       getActiveElement: () => document.activeElement,
       getBody: () => document.body,
       focusTerminal: (id) => terminalRegistry.get(id)?.focus(),
-      defer: (cb) => requestAnimationFrame(cb),
+      defer: (cb) => {
+        const handle = requestAnimationFrame(() => { pending.delete(handle); cb(); });
+        pending.add(handle);
+      },
       onHeal: (id) => console.debug(`[useActivePaneFocus] reclaimed orphaned focus → pty=${id}`),
     });
     // window 'focus': OS focus returns (alt-tab back) onto <body>.
@@ -234,6 +241,8 @@ export function useActivePaneFocus(): void {
       window.removeEventListener('focus', onSignal);
       document.removeEventListener('focusout', onSignal);
       document.removeEventListener('keydown', onSignal);
+      for (const handle of pending) cancelAnimationFrame(handle);
+      pending.clear();
     };
   }, []);
 }


### PR DESCRIPTION
## Problem
Typing sometimes goes dead in a pane — reported as *"the Claude pane won't type until I toggle multiview, and it's not only Korean/IME."* The root cause is DOM **focus loss**, not the IME:

`useActivePaneFocus` pulls keyboard focus onto the active terminal **only when the focus target key** (workspace + pane + surface + pty) **changes**, and its late-registration subscription is one-shot. Every transient overlay — Ctrl+F search bar, Ctrl+K command palette, notification panel, agent-toolbar RichInput — focuses its own input and, on dismiss, **unmounts**, dropping DOM focus to `<body>`. Those overlays toggle via store flags that aren't part of the focus key, so the terminal stays deaf until the target changes again — which only a multiview remount forces.

## Fix
A central self-heal in `useActivePaneFocus`: `window` `focus` / `document` `focusout` / `keydown` listeners re-pull focus onto the active terminal, but **only when `document.activeElement` is `<body>`** (orphaned). That guard means it can only *reclaim abandoned* focus, never *steal* focus a real element (palette, toolbar, another pane, browser webview) legitimately holds — preserving the existing one-shot "don't yank focus" design.

- Pure `isFocusOrphaned` + `reassertFocusIfOrphaned` (deps-injected), unit-tested: orphan detection, a synchronous fast-bail on the hot keystroke path, a deferred re-check that stands down when a legit element claims focus mid-transition, and a no-target no-op.
- `console.debug` instrumentation logs each heal.

## Verification
- 23/23 `useActivePaneFocus` unit tests · tsc 0 · eslint 0 · full suite green.
- **Live CDP dogfood**: in the running app, focus falling to `<body>` fired the heal (logged once) and restored focus to the xterm helper textarea.

Closes the "can't type in a newly-focused pane until I click" class of report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an automatic focus recovery (“focus self-heal”) mechanism that detects when DOM focus is unexpectedly lost (or attached to the page) and restores focus to the active pane’s terminal for more reliable keyboard navigation.

* **Tests**
  * Expanded unit test coverage for focus orphan detection and the deferred focus reassertion behavior, including cases where focus should not be stolen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->