### PR TITLE
feat(a2a-channels): U1 channel domain types + persistence layer

### DIFF
--- a/src/daemon/channels/ChannelStateWriter.ts
+++ b/src/daemon/channels/ChannelStateWriter.ts
@@ -289,6 +289,7 @@ export class ChannelStateWriter {
       if (typeof ch !== 'object' || ch === null) return false;
       const c = ch as Record<string, unknown>;
       if (typeof c['id'] !== 'string') return false;
+      if (!isSafeObjectKey(c['id'])) return false;
       if (typeof c['companyId'] !== 'string') return false;
       if (typeof c['name'] !== 'string') return false;
       if (c['visibility'] !== 'public' && c['visibility'] !== 'private') {
@@ -318,6 +319,21 @@ export class ChannelStateWriter {
       if (list.length === 0) continue;
       if (!isValidChannelMessageRow(list[0])) return false;
       break;
+    }
+    // Reject members/messages/idempotency keys that name the prototype
+    // chain. The JSON.parse guard upstream normally strips these, but we
+    // double-check so a custom-parsed file (e.g. from a future migration
+    // step) cannot smuggle `__proto__` past validation.
+    for (const key of Object.keys(obj['members'] as Record<string, unknown>)) {
+      if (!isSafeObjectKey(key)) return false;
+    }
+    for (const key of Object.keys(obj['messages'] as Record<string, unknown>)) {
+      if (!isSafeObjectKey(key)) return false;
+    }
+    for (const key of Object.keys(
+      obj['idempotency'] as Record<string, unknown>,
+    )) {
+      if (!isSafeObjectKey(key)) return false;
     }
 
     return true;
@@ -397,13 +413,39 @@ function isValidChannelMessageRow(row: unknown): boolean {
   );
 }
 
+/**
+ * Returns false for object keys that name the well-known JS prototype
+ * chain — `__proto__`, `constructor`, `prototype`. Used to guard
+ * `pruneKeys` and validator map lookups against a corrupt file that
+ * could otherwise leak prototype references into the running process.
+ */
+function isSafeObjectKey(s: unknown): s is string {
+  return (
+    typeof s === 'string' &&
+    s !== '__proto__' &&
+    s !== 'constructor' &&
+    s !== 'prototype'
+  );
+}
+
+/**
+ * Build a new record containing only the keys in `survivors`. Returns a
+ * null-prototype object and reads with own-key checks, so a corrupt
+ * `rec` with `__proto__` as a literal own property cannot pollute
+ * `Object.prototype`.
+ */
 function pruneKeys<T>(
   rec: Record<string, T>,
   survivors: Set<string>,
 ): Record<string, T> {
-  const out: Record<string, T> = {};
+  const out = Object.create(null) as Record<string, T>;
   for (const id of survivors) {
-    if (id in rec) out[id] = rec[id];
+    if (
+      Object.prototype.hasOwnProperty.call(rec, id) &&
+      isSafeObjectKey(id)
+    ) {
+      out[id] = rec[id];
+    }
   }
   return out;
 }

--- a/src/daemon/channels/ChannelStateWriter.ts
+++ b/src/daemon/channels/ChannelStateWriter.ts
@@ -1,0 +1,323 @@
+// ─── ChannelStateWriter ────────────────────────────────────────────────────
+// Persists ChannelState (channels.json) to disk using the shared atomic-write
+// helpers in `../util/atomicWrite`. The public API mirrors `StateWriter`
+// (saveImmediate / saveDebounced / load / flush / flushSync / dispose) so
+// future waves can layer behaviour without changing call sites.
+//
+// Concurrency model is identical to StateWriter's:
+//   - `saveImmediate` is synchronous and remains so — emergency-exit
+//     paths (SIGINT/SIGTERM/etc.) rely on it running inline. Before
+//     writing it clears any queued async write so a stale debounced
+//     snapshot cannot overwrite the newer immediate one.
+//   - `saveDebounced` funnels through an AsyncQueue keyed
+//     `'channel-state'` so only one async write is ever in flight.
+//     Repeated debounced calls coalesce to the latest snapshot.
+//   - `flushSync` drains the queue by invoking the registered sync
+//     fallback (used by process-exit handlers where the event loop
+//     has stopped).
+//
+// Plan reference: U1 (channel domain types and persistence layer).
+
+import path from 'node:path';
+import {
+  atomicReadJSONSync,
+  atomicWriteJSON,
+  atomicWriteJSONSync,
+  createMigrator,
+  CHANNEL_STATE_REGISTRY,
+} from '../util/atomicWrite';
+import { AsyncQueue } from '../util/AsyncQueue';
+import {
+  CHANNEL_EMPTY_TTL_HOURS_DEFAULT,
+  EMPTY_CHANNEL_STATE,
+  type ChannelState,
+} from '../../shared/channels';
+
+const DEBOUNCE_MS = 30_000;
+const QUEUE_KEY = 'channel-state';
+
+/**
+ * Persists ChannelState to `channels.json`. Channel-specific concerns:
+ *   - On `load()`, channels with zero members for `emptyChannelTtlHours`
+ *     (default 7d) are pruned. The 7-day bound mirrors StateWriter's
+ *     suspended-session retention so a stale empty channel doesn't
+ *     accumulate forever.
+ *   - The migration registry is identity today; future schema rewrites
+ *     append steps to `CHANNEL_STATE_REGISTRY` without touching this
+ *     call site.
+ *   - The on-disk file is `channels.json` (NOT `sessions.json`) —
+ *     channels and sessions share the base directory but not the
+ *     persistence file, so a channel-loss event cannot cascade into
+ *     session failure.
+ */
+export class ChannelStateWriter {
+  private filePath: string;
+  private readonly emptyChannelTtlHours: number;
+  private debounceTimer: NodeJS.Timeout | null = null;
+  private pendingState: ChannelState | null = null;
+  private readonly queue = new AsyncQueue();
+  private immediateEpoch = 0;
+  private lastImmediateState: ChannelState | null = null;
+
+  constructor(
+    baseDir: string,
+    emptyChannelTtlHours: number = CHANNEL_EMPTY_TTL_HOURS_DEFAULT,
+  ) {
+    this.filePath = path.join(baseDir, 'channels.json');
+    this.emptyChannelTtlHours = emptyChannelTtlHours;
+
+    this.queue.setSyncFallback(QUEUE_KEY, () => {
+      if (this.pendingState !== null) {
+        atomicWriteJSONSync(this.filePath, this.pendingState, {
+          validate: ChannelStateWriter.isChannelState,
+          rotationEnabled: true,
+        });
+        this.pendingState = null;
+      }
+    });
+  }
+
+  /** Immediately write state to disk (channel create/destroy/post). */
+  saveImmediate(state: ChannelState): void {
+    this.immediateEpoch++;
+    this.lastImmediateState = state;
+    this.queue.clear();
+    try {
+      atomicWriteJSONSync(this.filePath, state, {
+        validate: ChannelStateWriter.isChannelState,
+        rotationEnabled: true,
+      });
+      this.pendingState = null;
+    } catch (err) {
+      console.error('[ChannelStateWriter] Failed to save state:', err);
+    }
+  }
+
+  /** Debounced save — coalesces frequent updates over 30s. */
+  saveDebounced(state: ChannelState): void {
+    this.pendingState = state;
+
+    if (this.debounceTimer !== null) {
+      return;
+    }
+
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      const snapshot = this.pendingState;
+      if (snapshot === null) return;
+
+      void this.queue.enqueue(QUEUE_KEY, async () => {
+        const payload = this.pendingState;
+        if (payload === null) return;
+        const epochAtStart = this.immediateEpoch;
+        try {
+          await atomicWriteJSON(this.filePath, payload, {
+            validate: ChannelStateWriter.isChannelState,
+            rotationEnabled: true,
+          });
+          // Race recovery: if saveImmediate bumped the epoch while we
+          // were between awaits, restore the latest immediate payload
+          // synchronously so disk matches the latest in-memory state.
+          if (
+            this.immediateEpoch !== epochAtStart &&
+            this.lastImmediateState !== null
+          ) {
+            try {
+              atomicWriteJSONSync(this.filePath, this.lastImmediateState, {
+                validate: ChannelStateWriter.isChannelState,
+                rotationEnabled: true,
+              });
+            } catch (err) {
+              console.error(
+                '[ChannelStateWriter] Failed to restore superseded immediate save:',
+                err,
+              );
+            }
+          }
+          if (this.pendingState === payload) {
+            this.pendingState = null;
+          }
+        } catch (err) {
+          console.error(
+            '[ChannelStateWriter] Failed to save state (async):',
+            err,
+          );
+        }
+      });
+    }, DEBOUNCE_MS);
+  }
+
+  /**
+   * Load state from disk. Falls back to `.bak` on primary failure. Prunes
+   * channels that have been empty longer than `emptyChannelTtlHours`.
+   */
+  load(): ChannelState {
+    const migrator = createMigrator<ChannelState>(
+      CHANNEL_STATE_REGISTRY,
+      this.filePath,
+    );
+
+    let state: ChannelState | null = null;
+    try {
+      state = atomicReadJSONSync<ChannelState>(this.filePath, {
+        validate: ChannelStateWriter.isChannelState,
+        migrator,
+      });
+    } catch (err) {
+      console.error('[ChannelStateWriter] Failed to load state:', err);
+    }
+
+    if (!state) {
+      return { ...EMPTY_CHANNEL_STATE, channels: [], members: {}, messages: {}, idempotency: {} };
+    }
+
+    // Prune channels that have been empty longer than the TTL.
+    // Prune rules:
+    //   - Has members: keep (always).
+    //   - No `emptySince`: never marked empty, so we don't know when it
+    //     became empty — keep it. (A channel with 0 members but no
+    //     emptySince is "real but never joined" and is NOT eligible for
+    //     the 7-day empty purge. A future leave/empty flow will set
+    //     `emptySince` and only THEN does the TTL clock start.)
+    //   - `emptySince` set AND within TTL: keep.
+    //   - `emptySince` set AND older than TTL: prune.
+    // Archived channels with zero members follow the same rule — once
+    // their TTL expires, the empty-channel reaper evicts them.
+    const now = Date.now();
+    const cutoffMs = this.emptyChannelTtlHours * 60 * 60 * 1000;
+    const survivingIds = new Set<string>();
+    for (const ch of state.channels) {
+      const memberCount = (state.members[ch.id] ?? []).length;
+      if (memberCount > 0) {
+        survivingIds.add(ch.id);
+        continue;
+      }
+      const emptyStart = ch.emptySince;
+      if (emptyStart === undefined) {
+        survivingIds.add(ch.id);
+        continue;
+      }
+      if (now - emptyStart < cutoffMs) {
+        survivingIds.add(ch.id);
+      }
+      // else: prune.
+    }
+    state.channels = state.channels.filter((c) => survivingIds.has(c.id));
+    state.members = pruneKeys(state.members, survivingIds);
+    state.messages = pruneKeys(state.messages, survivingIds);
+    state.idempotency = pruneKeys(state.idempotency, survivingIds);
+
+    return state;
+  }
+
+  /** Flush pending debounce — if there is pending state, write it immediately. */
+  flush(): void {
+    if (this.debounceTimer !== null) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    if (this.pendingState !== null) {
+      this.saveImmediate(this.pendingState);
+    }
+  }
+
+  /**
+   * Process-exit friendly drain. Mirrors StateWriter.flushSync order
+   * (queue first, then inline fallback for staged-but-unenqueued
+   * pending state).
+   */
+  flushSync(): void {
+    if (this.debounceTimer !== null) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    this.queue.flushSync();
+    if (this.pendingState !== null) {
+      const state = this.pendingState;
+      this.pendingState = null;
+      try {
+        atomicWriteJSONSync(this.filePath, state, {
+          validate: ChannelStateWriter.isChannelState,
+          rotationEnabled: true,
+        });
+      } catch (err) {
+        console.error(
+          '[ChannelStateWriter] flushSync immediate write failed:',
+          err,
+        );
+      }
+    }
+  }
+
+  /** Clean up timers (daemon shutdown). Flushes pending state first. */
+  dispose(): void {
+    this.flush();
+  }
+
+  // ── Internal helpers ─────────────────────────────────────────────
+
+  /**
+   * Type guard. Mirrors the minimum-shape contract from StateWriter:
+   * validate version + top-level containers, then spot-check a
+   * channel row. Full schema validation lands when the schema
+   * stabilises.
+   */
+  private static isChannelState(parsed: unknown): parsed is ChannelState {
+    if (typeof parsed !== 'object' || parsed === null) return false;
+    const obj = parsed as Record<string, unknown>;
+
+    if (typeof obj['version'] !== 'number') return false;
+    if (!Array.isArray(obj['channels'])) return false;
+    if (!isRecordOfArrays(obj['members'])) return false;
+    if (!isRecordOfArrays(obj['messages'])) return false;
+    if (!isRecordOfRecords(obj['idempotency'])) return false;
+
+    for (const ch of obj['channels'] as unknown[]) {
+      if (typeof ch !== 'object' || ch === null) return false;
+      const c = ch as Record<string, unknown>;
+      if (typeof c['id'] !== 'string') return false;
+      if (typeof c['companyId'] !== 'string') return false;
+      if (typeof c['name'] !== 'string') return false;
+      if (c['visibility'] !== 'public' && c['visibility'] !== 'private') {
+        return false;
+      }
+      if (c['status'] !== 'active' && c['status'] !== 'archived') {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}
+
+function isRecordOfArrays(v: unknown): v is Record<string, unknown[]> {
+  if (typeof v !== 'object' || v === null) return false;
+  for (const value of Object.values(v as Record<string, unknown>)) {
+    if (!Array.isArray(value)) return false;
+  }
+  return true;
+}
+
+function isRecordOfRecords(
+  v: unknown,
+): v is Record<string, Record<string, number>> {
+  if (typeof v !== 'object' || v === null) return false;
+  for (const value of Object.values(v as Record<string, unknown>)) {
+    if (typeof value !== 'object' || value === null) return false;
+    for (const inner of Object.values(value as Record<string, unknown>)) {
+      if (typeof inner !== 'number') return false;
+    }
+  }
+  return true;
+}
+
+function pruneKeys<T>(
+  rec: Record<string, T>,
+  survivors: Set<string>,
+): Record<string, T> {
+  const out: Record<string, T> = {};
+  for (const id of survivors) {
+    if (id in rec) out[id] = rec[id];
+  }
+  return out;
+}

--- a/src/daemon/channels/ChannelStateWriter.ts
+++ b/src/daemon/channels/ChannelStateWriter.ts
@@ -160,8 +160,23 @@ export class ChannelStateWriter {
   }
 
   /**
-   * Load state from disk. Falls back to `.bak` on primary failure. Prunes
-   * channels that have been empty longer than `emptyChannelTtlHours`.
+   * Load state from disk and run the load-time reaper. Steps:
+   *   1. Read `channels.json` through the migrator + validator. A
+   *      parse failure or validator rejection falls through to `.bak`;
+   *      a `.bak` failure falls through to `EMPTY_CHANNEL_STATE`.
+   *   2. Reject prototype-chain keys (`__proto__`, `constructor`,
+   *      `prototype`) on both channel ids and map keys — defense in
+   *      depth on top of the JSON.parse reviver.
+   *   3. Prune channels whose empty-period has exceeded
+   *      `emptyChannelTtlHours`. The empty-period is `emptySince` if
+   *      set, otherwise `createdAt` (the "lost emptySince" recovery
+   *      case). Channels with members are never pruned here.
+   *   4. Prune members / messages / idempotency entries whose channel
+   *      did not survive. The pruned result is a null-prototype object
+   *      built with own-key checks so a corrupt entry cannot pollute
+   *      `Object.prototype`.
+   *
+   * @returns The loaded state, possibly empty.
    */
   load(): ChannelState {
     const migrator = createMigrator<ChannelState>(
@@ -259,7 +274,11 @@ export class ChannelStateWriter {
     }
   }
 
-  /** Clean up timers (daemon shutdown). Flushes pending state first. */
+  /**
+   * Clean up timers (daemon shutdown). Flushes any pending debounced
+   * state first so the on-disk file reflects the latest in-memory
+   * snapshot before the writer is released. Mirrors `StateWriter.dispose`.
+   */
   dispose(): void {
     this.flush();
   }

--- a/src/daemon/channels/ChannelStateWriter.ts
+++ b/src/daemon/channels/ChannelStateWriter.ts
@@ -59,6 +59,18 @@ export class ChannelStateWriter {
   private immediateEpoch = 0;
   private lastImmediateState: ChannelState | null = null;
 
+  /**
+   * Construct a `ChannelStateWriter` rooted at `baseDir`. The on-disk
+   * file is `<baseDir>/channels.json` (NOT `sessions.json`) so a channel
+   * loss event cannot cascade into session-state failure. Registers the
+   * synchronous fallback used by `flushSync` to drain pending writes
+   * from the per-channel queue during process exit.
+   *
+   * @param baseDir - Directory where `channels.json` lives.
+   * @param emptyChannelTtlHours - Hours an empty channel can survive
+   *   before the load-time reaper evicts it. Defaults to
+   *   `CHANNEL_EMPTY_TTL_HOURS_DEFAULT` (7d).
+   */
   constructor(
     baseDir: string,
     emptyChannelTtlHours: number = CHANNEL_EMPTY_TTL_HOURS_DEFAULT,
@@ -258,9 +270,10 @@ export class ChannelStateWriter {
 
   /**
    * Type guard. Mirrors the minimum-shape contract from StateWriter:
-   * validate version + top-level containers, then spot-check a
-   * channel row. Full schema validation lands when the schema
-   * stabilises.
+   * validate version + top-level containers (rejecting top-level arrays),
+   * then spot-check one row per nested map. A malformed row fails the
+   * whole validator, triggering `.bak` recovery. Full schema validation
+   * lands when the schema stabilises.
    */
   private static isChannelState(parsed: unknown): parsed is ChannelState {
     if (typeof parsed !== 'object' || parsed === null) return false;
@@ -286,29 +299,102 @@ export class ChannelStateWriter {
       }
     }
 
+    // Spot-check nested row shapes — one non-empty row per map. Catches
+    // realistic corruption modes (e.g. someone hand-edited the JSON and
+    // broke a row's shape) without paying for full schema validation on
+    // every load.
+    const memberLists = Object.values(
+      obj['members'] as Record<string, unknown[]>,
+    );
+    for (const list of memberLists) {
+      if (list.length === 0) continue;
+      if (!isValidChannelMemberRow(list[0])) return false;
+      break;
+    }
+    const messageLists = Object.values(
+      obj['messages'] as Record<string, unknown[]>,
+    );
+    for (const list of messageLists) {
+      if (list.length === 0) continue;
+      if (!isValidChannelMessageRow(list[0])) return false;
+      break;
+    }
+
     return true;
   }
 }
 
+/**
+ * Type guard: `v` is a non-array object whose values are arrays. Rejects
+ * arrays at the top level (since `typeof [] === 'object'`) so a corrupt
+ * `channels.json` with `members: []` cannot slip past validation.
+ */
 function isRecordOfArrays(v: unknown): v is Record<string, unknown[]> {
   if (typeof v !== 'object' || v === null) return false;
+  if (Array.isArray(v)) return false;
   for (const value of Object.values(v as Record<string, unknown>)) {
     if (!Array.isArray(value)) return false;
   }
   return true;
 }
 
+/**
+ * Type guard: `v` is a non-array object whose values are non-array objects
+ * whose values are numbers. Used for the idempotency map (channelId →
+ * clientMsgId → seq). Rejects arrays at any level.
+ */
 function isRecordOfRecords(
   v: unknown,
 ): v is Record<string, Record<string, number>> {
   if (typeof v !== 'object' || v === null) return false;
+  if (Array.isArray(v)) return false;
   for (const value of Object.values(v as Record<string, unknown>)) {
     if (typeof value !== 'object' || value === null) return false;
+    if (Array.isArray(value)) return false;
     for (const inner of Object.values(value as Record<string, unknown>)) {
       if (typeof inner !== 'number') return false;
     }
   }
   return true;
+}
+
+/**
+ * Spot-check: does `row` have the minimum required shape of a
+ * `ChannelMember`? Used as a sanity check on the members map during
+ * load-time validation.
+ */
+function isValidChannelMemberRow(row: unknown): boolean {
+  if (typeof row !== 'object' || row === null) return false;
+  const m = row as Record<string, unknown>;
+  return (
+    typeof m['workspaceId'] === 'string' &&
+    typeof m['memberId'] === 'string' &&
+    typeof m['joinedAt'] === 'number' &&
+    typeof m['historyFromSeq'] === 'number'
+  );
+}
+
+/**
+ * Spot-check: does `row` have the minimum required shape of a
+ * `ChannelMessage`? `data` and `clientMsgId` are optional and not checked
+ * here. Used as a sanity check on the messages map during load-time
+ * validation.
+ */
+function isValidChannelMessageRow(row: unknown): boolean {
+  if (typeof row !== 'object' || row === null) return false;
+  const m = row as Record<string, unknown>;
+  return (
+    typeof m['channelId'] === 'string' &&
+    typeof m['seq'] === 'number' &&
+    typeof m['workspaceId'] === 'string' &&
+    typeof m['memberId'] === 'string' &&
+    typeof m['memberName'] === 'string' &&
+    typeof m['text'] === 'string' &&
+    typeof m['postedAt'] === 'number' &&
+    (m['deliveryStatus'] === 'pending' ||
+      m['deliveryStatus'] === 'delivered' ||
+      m['deliveryStatus'] === 'target_gone')
+  );
 }
 
 function pruneKeys<T>(

--- a/src/daemon/channels/ChannelStateWriter.ts
+++ b/src/daemon/channels/ChannelStateWriter.ts
@@ -184,17 +184,19 @@ export class ChannelStateWriter {
     }
 
     // Prune channels that have been empty longer than the TTL.
-    // Prune rules:
+    // Prune rules (applied per channel):
     //   - Has members: keep (always).
-    //   - No `emptySince`: never marked empty, so we don't know when it
-    //     became empty — keep it. (A channel with 0 members but no
-    //     emptySince is "real but never joined" and is NOT eligible for
-    //     the 7-day empty purge. A future leave/empty flow will set
-    //     `emptySince` and only THEN does the TTL clock start.)
-    //   - `emptySince` set AND within TTL: keep.
-    //   - `emptySince` set AND older than TTL: prune.
-    // Archived channels with zero members follow the same rule — once
-    // their TTL expires, the empty-channel reaper evicts them.
+    //   - 0 members AND emptySince set AND within TTL: keep.
+    //   - 0 members AND emptySince set AND older than TTL: prune.
+    //   - 0 members AND no emptySince AND `now - createdAt < TTL`: keep
+    //     (the never-joined case AND the recently-orphaned case).
+    //   - 0 members AND no emptySince AND `now - createdAt >= TTL`:
+    //     prune. The fallback to `createdAt` catches a channel that had
+    //     members, went empty, and lost its `emptySince` through a
+    //     crash-between-leave-and-persist window — without the
+    //     fallback, that channel would be immortal. The 7-day bound
+    //     applies from creation in that case, which is conservative.
+    // Archived channels with zero members follow the same rule.
     const now = Date.now();
     const cutoffMs = this.emptyChannelTtlHours * 60 * 60 * 1000;
     const survivingIds = new Set<string>();
@@ -204,12 +206,8 @@ export class ChannelStateWriter {
         survivingIds.add(ch.id);
         continue;
       }
-      const emptyStart = ch.emptySince;
-      if (emptyStart === undefined) {
-        survivingIds.add(ch.id);
-        continue;
-      }
-      if (now - emptyStart < cutoffMs) {
+      const effectiveEmptyStart = ch.emptySince ?? ch.createdAt;
+      if (now - effectiveEmptyStart < cutoffMs) {
         survivingIds.add(ch.id);
       }
       // else: prune.

--- a/src/daemon/channels/__tests__/ChannelStateWriter.test.ts
+++ b/src/daemon/channels/__tests__/ChannelStateWriter.test.ts
@@ -657,4 +657,88 @@ describe('ChannelStateWriter', () => {
     expect(Object.getPrototypeOf(loaded.members)).toBeNull();
     expect(loaded.members['ch-live']).toHaveLength(1);
   });
+
+  // ── U3 empty-channel GC createdAt fallback ───────────────────────
+
+  it('load prunes a never-joined channel whose createdAt is older than the TTL', () => {
+    const HOUR = 60 * 60 * 1000;
+    const ch = makeChannel({
+      id: 'ch-orphan-8d',
+      createdAt: Date.now() - 8 * 24 * HOUR,
+    });
+    writer.saveImmediate(makeState([ch]));
+
+    const ids = writer.load().channels.map((c) => c.id);
+    expect(ids).not.toContain('ch-orphan-8d');
+  });
+
+  it('load keeps a never-joined channel whose createdAt is within the TTL', () => {
+    const HOUR = 60 * 60 * 1000;
+    const ch = makeChannel({
+      id: 'ch-fresh-3d',
+      createdAt: Date.now() - 3 * 24 * HOUR,
+    });
+    writer.saveImmediate(makeState([ch]));
+
+    const ids = writer.load().channels.map((c) => c.id);
+    expect(ids).toContain('ch-fresh-3d');
+  });
+
+  it('load prunes a long-orphaned channel (lost emptySince, created 30d ago)', () => {
+    // The "lost emptySince" recovery case — without the createdAt
+    // fallback, this channel would be immortal.
+    const HOUR = 60 * 60 * 1000;
+    const ch = makeChannel({
+      id: 'ch-long-orphan',
+      createdAt: Date.now() - 30 * 24 * HOUR,
+    });
+    writer.saveImmediate(makeState([ch]));
+
+    const ids = writer.load().channels.map((c) => c.id);
+    expect(ids).not.toContain('ch-long-orphan');
+  });
+
+  it('honours a custom emptyChannelTtlHours for the createdAt fallback', () => {
+    const HOUR = 60 * 60 * 1000;
+    const customWriter = new ChannelStateWriter(tmpDir, 48);
+    const stale = makeChannel({
+      id: 'ch-stale-3d-fallback',
+      createdAt: Date.now() - 3 * 24 * HOUR,
+    });
+    const fresh = makeChannel({
+      id: 'ch-fresh-1d-fallback',
+      createdAt: Date.now() - 24 * HOUR,
+    });
+    customWriter.saveImmediate(makeState([stale, fresh]));
+
+    const ids = customWriter.load().channels.map((c) => c.id);
+    expect(ids).not.toContain('ch-stale-3d-fallback');
+    expect(ids).toContain('ch-fresh-1d-fallback');
+  });
+
+  it('load keeps a channel with an explicit emptySince within the TTL', () => {
+    // Regression: the explicit emptySince path still works.
+    const HOUR = 60 * 60 * 1000;
+    const ch = makeChannel({
+      id: 'ch-explicit-emptySince',
+      emptySince: Date.now() - 3 * 24 * HOUR,
+    });
+    writer.saveImmediate(makeState([ch]));
+
+    const ids = writer.load().channels.map((c) => c.id);
+    expect(ids).toContain('ch-explicit-emptySince');
+  });
+
+  it('load prunes a channel with an explicit emptySince older than the TTL', () => {
+    // Regression: the explicit emptySince path still prunes when stale.
+    const HOUR = 60 * 60 * 1000;
+    const ch = makeChannel({
+      id: 'ch-stale-emptySince',
+      emptySince: Date.now() - 8 * 24 * HOUR,
+    });
+    writer.saveImmediate(makeState([ch]));
+
+    const ids = writer.load().channels.map((c) => c.id);
+    expect(ids).not.toContain('ch-stale-emptySince');
+  });
 });

--- a/src/daemon/channels/__tests__/ChannelStateWriter.test.ts
+++ b/src/daemon/channels/__tests__/ChannelStateWriter.test.ts
@@ -555,4 +555,106 @@ describe('ChannelStateWriter', () => {
     const loaded = writer.load();
     expect(loaded.idempotency).toEqual({});
   });
+
+  // ── U2 prototype-pollution hardening ─────────────────────────────
+
+  it('load rejects a channel whose id is a prototype-chain key (__proto__)', () => {
+    // The id is a value (not a key), so the JSON.parse reviver does not
+    // strip it — the validator's isSafeObjectKey check is what catches
+    // it here.
+    const filePath = path.join(tmpDir, 'channels.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        channels: [
+          {
+            id: '__proto__',
+            companyId: 'co-1',
+            name: 'x',
+            visibility: 'public',
+            status: 'active',
+            createdAt: 0,
+            createdBy: 'ws',
+            nextSeq: 1,
+          },
+        ],
+        members: {},
+        messages: {},
+        idempotency: {},
+      }),
+      'utf-8',
+    );
+    const loaded = writer.load();
+    expect(loaded.channels).toEqual([]);
+  });
+
+  it('load rejects a channel whose id is the constructor prototype key', () => {
+    const filePath = path.join(tmpDir, 'channels.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        channels: [
+          {
+            id: 'constructor',
+            companyId: 'co-1',
+            name: 'x',
+            visibility: 'public',
+            status: 'active',
+            createdAt: 0,
+            createdBy: 'ws',
+            nextSeq: 1,
+          },
+        ],
+        members: {},
+        messages: {},
+        idempotency: {},
+      }),
+      'utf-8',
+    );
+    const loaded = writer.load();
+    expect(loaded.channels).toEqual([]);
+  });
+
+  it('load rejects a channel whose id is the prototype key', () => {
+    const filePath = path.join(tmpDir, 'channels.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        channels: [
+          {
+            id: 'prototype',
+            companyId: 'co-1',
+            name: 'x',
+            visibility: 'public',
+            status: 'active',
+            createdAt: 0,
+            createdBy: 'ws',
+            nextSeq: 1,
+          },
+        ],
+        members: {},
+        messages: {},
+        idempotency: {},
+      }),
+      'utf-8',
+    );
+    const loaded = writer.load();
+    expect(loaded.channels).toEqual([]);
+  });
+
+  it('load returns a null-prototype members object via pruneKeys', () => {
+    // A channel with members survives pruning — the surviving members
+    // list is pruneKeys output, which uses Object.create(null).
+    const ch = makeChannel({ id: 'ch-live' });
+    const member = makeMember();
+    writer.saveImmediate(
+      makeState([ch], { 'ch-live': [member] }),
+    );
+    const loaded = writer.load();
+    expect(Object.getPrototypeOf(loaded.members)).toBeNull();
+    expect(loaded.members['ch-live']).toHaveLength(1);
+  });
 });

--- a/src/daemon/channels/__tests__/ChannelStateWriter.test.ts
+++ b/src/daemon/channels/__tests__/ChannelStateWriter.test.ts
@@ -411,4 +411,148 @@ describe('ChannelStateWriter', () => {
     expect(EMPTY_CHANNEL_STATE.messages).toEqual({});
     expect(EMPTY_CHANNEL_STATE.idempotency).toEqual({});
   });
+
+  // ── U1 validator hardening ──────────────────────────────────────
+
+  it('load rejects channels.json where members is a top-level array', () => {
+    // typeof [] === 'object', so without the Array.isArray guard the
+    // validator would silently accept a corrupt file.
+    const filePath = path.join(tmpDir, 'channels.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        channels: [],
+        members: [],
+        messages: {},
+        idempotency: {},
+      }),
+      'utf-8',
+    );
+    const loaded = writer.load();
+    expect(loaded.channels).toEqual([]);
+    expect(loaded.members).toEqual({});
+  });
+
+  it('load rejects channels.json where messages is a top-level array', () => {
+    const filePath = path.join(tmpDir, 'channels.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        channels: [],
+        members: {},
+        messages: [],
+        idempotency: {},
+      }),
+      'utf-8',
+    );
+    const loaded = writer.load();
+    expect(loaded.messages).toEqual({});
+  });
+
+  it('load rejects channels.json where idempotency is a top-level array', () => {
+    const filePath = path.join(tmpDir, 'channels.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        channels: [],
+        members: {},
+        messages: {},
+        idempotency: [],
+      }),
+      'utf-8',
+    );
+    const loaded = writer.load();
+    expect(loaded.idempotency).toEqual({});
+  });
+
+  it('load rejects channels.json with a malformed member row (workspaceId wrong type)', () => {
+    // Spot-check on the first non-empty member row catches uniform row
+    // corruption even though the channel list itself is valid.
+    const filePath = path.join(tmpDir, 'channels.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        channels: [
+          {
+            id: 'ch-x',
+            companyId: 'co-1',
+            name: 'x',
+            visibility: 'public',
+            status: 'active',
+            createdAt: 0,
+            createdBy: 'ws',
+            nextSeq: 1,
+          },
+        ],
+        members: { 'ch-x': [{ workspaceId: 1, memberId: 'm-1', joinedAt: 0, historyFromSeq: 0 }] },
+        messages: {},
+        idempotency: {},
+      }),
+      'utf-8',
+    );
+    const loaded = writer.load();
+    expect(loaded.channels).toEqual([]);
+  });
+
+  it('load rejects channels.json with a malformed message row (bad deliveryStatus)', () => {
+    const filePath = path.join(tmpDir, 'channels.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        channels: [
+          {
+            id: 'ch-x',
+            companyId: 'co-1',
+            name: 'x',
+            visibility: 'public',
+            status: 'active',
+            createdAt: 0,
+            createdBy: 'ws',
+            nextSeq: 1,
+          },
+        ],
+        members: {},
+        messages: {
+          'ch-x': [
+            {
+              channelId: 'ch-x',
+              seq: 1,
+              workspaceId: 'ws-1',
+              memberId: 'm-1',
+              memberName: 'Alice',
+              text: 'hi',
+              postedAt: 0,
+              deliveryStatus: 'weird',
+            },
+          ],
+        },
+        idempotency: {},
+      }),
+      'utf-8',
+    );
+    const loaded = writer.load();
+    expect(loaded.channels).toEqual([]);
+  });
+
+  it('load rejects channels.json where idempotency value is not a number', () => {
+    const filePath = path.join(tmpDir, 'channels.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        channels: [],
+        members: {},
+        messages: {},
+        idempotency: { 'ch-x': { 'k': 'not-a-number' } },
+      }),
+      'utf-8',
+    );
+    const loaded = writer.load();
+    expect(loaded.idempotency).toEqual({});
+  });
 });

--- a/src/daemon/channels/__tests__/ChannelStateWriter.test.ts
+++ b/src/daemon/channels/__tests__/ChannelStateWriter.test.ts
@@ -1,0 +1,414 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { ChannelStateWriter } from '../ChannelStateWriter';
+import {
+  EMPTY_CHANNEL_STATE,
+  type Channel,
+  type ChannelMember,
+  type ChannelMessage,
+  type ChannelState,
+} from '../../../shared/channels';
+
+let tmpDir: string;
+let writer: ChannelStateWriter;
+
+function makeChannel(overrides: Partial<Channel> = {}): Channel {
+  return {
+    id: 'ch-test-1',
+    companyId: 'co-1',
+    name: 'general',
+    visibility: 'public',
+    status: 'active',
+    createdAt: Date.now(),
+    createdBy: 'ws-creator',
+    nextSeq: 1,
+    ...overrides,
+  };
+}
+
+function makeMember(overrides: Partial<ChannelMember> = {}): ChannelMember {
+  return {
+    workspaceId: 'ws-1',
+    memberId: 'm-1',
+    joinedAt: Date.now(),
+    historyFromSeq: 0,
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Partial<ChannelMessage> = {}): ChannelMessage {
+  return {
+    channelId: 'ch-test-1',
+    seq: 1,
+    workspaceId: 'ws-1',
+    memberId: 'm-1',
+    memberName: 'Alice',
+    text: 'hello',
+    postedAt: Date.now(),
+    deliveryStatus: 'pending',
+    ...overrides,
+  };
+}
+
+function makeState(
+  channels: Channel[] = [],
+  members: Record<string, ChannelMember[]> = {},
+  messages: Record<string, ChannelMessage[]> = {},
+): ChannelState {
+  return {
+    version: 1,
+    channels,
+    members,
+    messages,
+    idempotency: {},
+  };
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-channelstate-test-'));
+  writer = new ChannelStateWriter(tmpDir);
+});
+
+afterEach(() => {
+  writer.dispose();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('ChannelStateWriter', () => {
+  it('saveImmediate creates channels.json', () => {
+    const state = makeState([makeChannel()]);
+    writer.saveImmediate(state);
+
+    const filePath = path.join(tmpDir, 'channels.json');
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const loaded = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(loaded.version).toBe(1);
+    expect(loaded.channels).toHaveLength(1);
+    expect(loaded.channels[0].id).toBe('ch-test-1');
+  });
+
+  it('load restores saved data', () => {
+    const state = makeState(
+      [makeChannel({ id: 'ch-abc', name: 'design' })],
+      { 'ch-abc': [makeMember({ memberId: 'm-1' })] },
+      { 'ch-abc': [makeMessage({ seq: 1, text: 'first' })] },
+    );
+    writer.saveImmediate(state);
+
+    const loaded = writer.load();
+    expect(loaded.version).toBe(1);
+    expect(loaded.channels).toHaveLength(1);
+    expect(loaded.channels[0].id).toBe('ch-abc');
+    expect(loaded.members['ch-abc']).toHaveLength(1);
+    expect(loaded.messages['ch-abc'][0].text).toBe('first');
+  });
+
+  it('load falls back to .bak when primary is corrupt', () => {
+    // Save valid state, then save again (first becomes .bak).
+    writer.saveImmediate(
+      makeState([makeChannel({ id: 'ch-good' })]),
+    );
+    writer.saveImmediate(
+      makeState([makeChannel({ id: 'ch-good2' })]),
+    );
+
+    // Corrupt the primary.
+    const filePath = path.join(tmpDir, 'channels.json');
+    fs.writeFileSync(filePath, '{{not valid json', 'utf-8');
+
+    const loaded = writer.load();
+    // .bak had the first save; recovery should still find channels.
+    expect(loaded.channels).toHaveLength(1);
+    expect(loaded.channels[0].id).toBe('ch-good');
+  });
+
+  it('saveDebounced does not write immediately', async () => {
+    vi.useFakeTimers();
+    writer.saveDebounced(makeState([makeChannel()]));
+
+    const filePath = path.join(tmpDir, 'channels.json');
+    expect(fs.existsSync(filePath)).toBe(false);
+
+    vi.advanceTimersByTime(30_000);
+    vi.useRealTimers();
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it('saveDebounced coalesces multiple calls within debounce window', async () => {
+    vi.useFakeTimers();
+    writer.saveDebounced(makeState([makeChannel({ name: 'v1' })]));
+    vi.advanceTimersByTime(10_000);
+    writer.saveDebounced(makeState([makeChannel({ name: 'v2' })]));
+    vi.advanceTimersByTime(10_000);
+    writer.saveDebounced(makeState([makeChannel({ name: 'v3' })]));
+    vi.advanceTimersByTime(10_000);
+    vi.useRealTimers();
+    await new Promise((r) => setTimeout(r, 50));
+
+    const filePath = path.join(tmpDir, 'channels.json');
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const loaded = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(loaded.channels[0].name).toBe('v3');
+  });
+
+  it('flush writes pending state immediately', () => {
+    vi.useFakeTimers();
+    try {
+      writer.saveDebounced(makeState([makeChannel({ name: 'flushed' })]));
+
+      const filePath = path.join(tmpDir, 'channels.json');
+      expect(fs.existsSync(filePath)).toBe(false);
+
+      writer.flush();
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      const loaded = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      expect(loaded.channels[0].name).toBe('flushed');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('dispose clears timers and flushes pending', () => {
+    vi.useFakeTimers();
+    try {
+      writer.saveDebounced(makeState([makeChannel({ name: 'disposed' })]));
+      writer.dispose();
+
+      const filePath = path.join(tmpDir, 'channels.json');
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      const loaded = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      expect(loaded.channels[0].name).toBe('disposed');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('load prunes channels empty longer than the TTL', () => {
+    const HOUR = 60 * 60 * 1000;
+    const now = Date.now();
+    // Empty 8 days ago, 7d default TTL — should be pruned.
+    const stale = makeChannel({
+      id: 'ch-stale',
+      emptySince: now - 8 * 24 * HOUR,
+    });
+    // Empty 3 days ago — survives.
+    const fresh = makeChannel({
+      id: 'ch-fresh',
+      emptySince: now - 3 * 24 * HOUR,
+    });
+    // Has a member — never pruned by empty-TTL.
+    const live = makeChannel({ id: 'ch-live' });
+    writer.saveImmediate(
+      makeState(
+        [stale, fresh, live],
+        { 'ch-live': [makeMember()] },
+      ),
+    );
+
+    const loaded = writer.load();
+    const ids = loaded.channels.map((c) => c.id);
+
+    expect(ids).not.toContain('ch-stale');
+    expect(ids).toContain('ch-fresh');
+    expect(ids).toContain('ch-live');
+  });
+
+  it('load keeps a channel with 0 members and no emptySince (never joined)', () => {
+    // A real channel that exists on disk but has no members yet must
+    // survive the empty-channel reaper — its TTL clock only starts
+    // when a member leaves, which is when `emptySince` is set.
+    const ch = makeChannel({ id: 'ch-never-joined' });
+    writer.saveImmediate(makeState([ch]));
+
+    const ids = writer.load().channels.map((c) => c.id);
+    expect(ids).toContain('ch-never-joined');
+  });
+
+  it('honours a custom emptyChannelTtlHours from the constructor', () => {
+    const HOUR = 60 * 60 * 1000;
+    const now = Date.now();
+    // 48h custom TTL — channel empty for 72h must be pruned.
+    const customWriter = new ChannelStateWriter(tmpDir, 48);
+    const stale = makeChannel({
+      id: 'ch-stale-3d',
+      emptySince: now - 3 * 24 * HOUR,
+    });
+    const fresh = makeChannel({
+      id: 'ch-fresh-1d',
+      emptySince: now - 24 * HOUR,
+    });
+    customWriter.saveImmediate(makeState([stale, fresh]));
+
+    const ids = customWriter.load().channels.map((c) => c.id);
+    expect(ids).not.toContain('ch-stale-3d');
+    expect(ids).toContain('ch-fresh-1d');
+  });
+
+  it('default constructor keeps the 7-day empty TTL (no config passed)', () => {
+    const HOUR = 60 * 60 * 1000;
+    const ch = makeChannel({
+      id: 'ch-three-day',
+      emptySince: Date.now() - 3 * 24 * HOUR,
+    });
+    writer.saveImmediate(makeState([ch]));
+    expect(writer.load().channels.map((c) => c.id)).toContain('ch-three-day');
+  });
+
+  it('rejects prototype pollution keys in JSON', () => {
+    const filePath = path.join(tmpDir, 'channels.json');
+    const poisoned = JSON.stringify({
+      version: 1,
+      channels: [],
+      members: {},
+      messages: {},
+      idempotency: {},
+      '__proto__': { admin: true },
+      'constructor': { prototype: { isAdmin: true } },
+    });
+    fs.writeFileSync(filePath, poisoned, 'utf-8');
+
+    const loaded = writer.load();
+    expect(loaded.version).toBe(1);
+    expect(loaded.channels).toHaveLength(0);
+
+    const plain: Record<string, unknown> = {};
+    expect(plain['admin']).toBeUndefined();
+    expect(plain['isAdmin']).toBeUndefined();
+  });
+
+  it('load returns empty state when no files exist', () => {
+    const loaded = writer.load();
+    expect(loaded.version).toBe(1);
+    expect(loaded.channels).toHaveLength(0);
+    expect(loaded.members).toEqual({});
+    expect(loaded.messages).toEqual({});
+    expect(loaded.idempotency).toEqual({});
+  });
+
+  it('atomic write creates .bak file', () => {
+    writer.saveImmediate(makeState([makeChannel({ id: 'first' })]));
+    writer.saveImmediate(makeState([makeChannel({ id: 'second' })]));
+
+    const bakPath = path.join(tmpDir, 'channels.json.bak');
+    expect(fs.existsSync(bakPath)).toBe(true);
+
+    const bakData = JSON.parse(fs.readFileSync(bakPath, 'utf-8'));
+    expect(bakData.channels[0].id).toBe('first');
+  });
+
+  it('no .tmp residue after successful save', () => {
+    writer.saveImmediate(makeState([makeChannel()]));
+    const tmpPath = path.join(tmpDir, 'channels.json.tmp');
+    expect(fs.existsSync(tmpPath)).toBe(false);
+  });
+
+  it('rotation chain: three saves populate .bak and .bak.1', () => {
+    writer.saveImmediate(makeState([makeChannel({ id: 'g1' })]));
+    writer.saveImmediate(makeState([makeChannel({ id: 'g2' })]));
+    writer.saveImmediate(makeState([makeChannel({ id: 'g3' })]));
+
+    const primary = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, 'channels.json'), 'utf-8'),
+    );
+    const bak = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, 'channels.json.bak'), 'utf-8'),
+    );
+    const bak1Path = path.join(tmpDir, 'channels.json.bak.1');
+    expect(fs.existsSync(bak1Path)).toBe(true);
+    const bak1 = JSON.parse(fs.readFileSync(bak1Path, 'utf-8'));
+
+    expect(primary.channels[0].id).toBe('g3');
+    expect(bak.channels[0].id).toBe('g2');
+    expect(bak1.channels[0].id).toBe('g1');
+  });
+
+  it('flushSync: with no queued task, writes pending state inline', () => {
+    vi.useFakeTimers();
+    try {
+      writer.saveDebounced(
+        makeState([makeChannel({ id: 'fsync-pending' })]),
+      );
+      // Debounce timer has NOT fired yet.
+      writer.flushSync();
+
+      const filePath = path.join(tmpDir, 'channels.json');
+      expect(fs.existsSync(filePath)).toBe(true);
+      const loaded = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      expect(loaded.channels[0].id).toBe('fsync-pending');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('flushSync: drives queue.flushSync before any inline fallback', () => {
+    vi.useFakeTimers();
+    try {
+      writer.saveDebounced(
+        makeState([makeChannel({ id: 'fsync-queue' })]),
+      );
+      vi.advanceTimersByTime(30_000);
+      // Timer fired → queue has a pending task; flushSync must drive
+      // the queue's sync fallback rather than race it.
+      writer.flushSync();
+
+      const filePath = path.join(tmpDir, 'channels.json');
+      expect(fs.existsSync(filePath)).toBe(true);
+      const loaded = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      expect(loaded.channels[0].id).toBe('fsync-queue');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('load survives a channels.json that is missing a top-level key (recover to empty)', () => {
+    const filePath = path.join(tmpDir, 'channels.json');
+    // Only `version` and `channels` — the validator rejects this and
+    // we should fall through to empty state, not crash.
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({ version: 1, channels: [] }),
+      'utf-8',
+    );
+    const loaded = writer.load();
+    expect(loaded.version).toBe(1);
+    expect(loaded.channels).toEqual([]);
+    // The validator rejects the malformed shape; load returns the
+    // EMPTY_CHANNEL_STATE fallback.
+    expect(loaded.members).toEqual({});
+  });
+
+  it('load rejects a channel with bad visibility/status', () => {
+    const filePath = path.join(tmpDir, 'channels.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        channels: [
+          { id: 'ch-bad', companyId: 'co-1', name: 'x', visibility: 'public', status: 'weird' },
+        ],
+        members: {},
+        messages: {},
+        idempotency: {},
+      }),
+      'utf-8',
+    );
+    const loaded = writer.load();
+    expect(loaded.channels).toEqual([]);
+  });
+
+  it('EMPTY_CHANNEL_STATE is a valid empty shape', () => {
+    expect(EMPTY_CHANNEL_STATE.version).toBe(1);
+    expect(EMPTY_CHANNEL_STATE.channels).toEqual([]);
+    expect(EMPTY_CHANNEL_STATE.members).toEqual({});
+    expect(EMPTY_CHANNEL_STATE.messages).toEqual({});
+    expect(EMPTY_CHANNEL_STATE.idempotency).toEqual({});
+  });
+});

--- a/src/daemon/channels/__tests__/ChannelStateWriter.test.ts
+++ b/src/daemon/channels/__tests__/ChannelStateWriter.test.ts
@@ -127,27 +127,34 @@ describe('ChannelStateWriter', () => {
 
   it('saveDebounced does not write immediately', async () => {
     vi.useFakeTimers();
-    writer.saveDebounced(makeState([makeChannel()]));
+    try {
+      writer.saveDebounced(makeState([makeChannel()]));
 
-    const filePath = path.join(tmpDir, 'channels.json');
-    expect(fs.existsSync(filePath)).toBe(false);
+      const filePath = path.join(tmpDir, 'channels.json');
+      expect(fs.existsSync(filePath)).toBe(false);
 
-    vi.advanceTimersByTime(30_000);
-    vi.useRealTimers();
+      vi.advanceTimersByTime(30_000);
+    } finally {
+      vi.useRealTimers();
+    }
     await new Promise((r) => setTimeout(r, 50));
 
+    const filePath = path.join(tmpDir, 'channels.json');
     expect(fs.existsSync(filePath)).toBe(true);
   });
 
   it('saveDebounced coalesces multiple calls within debounce window', async () => {
     vi.useFakeTimers();
-    writer.saveDebounced(makeState([makeChannel({ name: 'v1' })]));
-    vi.advanceTimersByTime(10_000);
-    writer.saveDebounced(makeState([makeChannel({ name: 'v2' })]));
-    vi.advanceTimersByTime(10_000);
-    writer.saveDebounced(makeState([makeChannel({ name: 'v3' })]));
-    vi.advanceTimersByTime(10_000);
-    vi.useRealTimers();
+    try {
+      writer.saveDebounced(makeState([makeChannel({ name: 'v1' })]));
+      vi.advanceTimersByTime(10_000);
+      writer.saveDebounced(makeState([makeChannel({ name: 'v2' })]));
+      vi.advanceTimersByTime(10_000);
+      writer.saveDebounced(makeState([makeChannel({ name: 'v3' })]));
+      vi.advanceTimersByTime(10_000);
+    } finally {
+      vi.useRealTimers();
+    }
     await new Promise((r) => setTimeout(r, 50));
 
     const filePath = path.join(tmpDir, 'channels.json');

--- a/src/daemon/util/atomicWrite/migrate.ts
+++ b/src/daemon/util/atomicWrite/migrate.ts
@@ -301,3 +301,17 @@ export const DAEMON_STATE_REGISTRY: MigrationRegistry = {
   currentVersion: 1,
   steps: [],
 };
+
+/**
+ * Channel state schema (channels.json). Identity registry — no
+ * migrations registered yet. The Channels subsystem (see
+ * `src/shared/channels.ts` and `src/daemon/channels/`) registers
+ * this registry with the migrator factory in the same way that
+ * StateWriter registers `DAEMON_STATE_REGISTRY`: pass-through with
+ * the identity-registry short-circuit for legacy v0 payloads
+ * missing the version marker.
+ */
+export const CHANNEL_STATE_REGISTRY: MigrationRegistry = {
+  currentVersion: 1,
+  steps: [],
+};

--- a/src/shared/__tests__/channels.test.ts
+++ b/src/shared/__tests__/channels.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  canonicalizeChannelName,
+  isValidChannelName,
+  CHANNEL_NAME_MAX,
+  CHANNEL_NAME_MIN,
+} from '../channels';
+
+describe('canonicalizeChannelName', () => {
+  it('trims whitespace and lowercases', () => {
+    expect(canonicalizeChannelName('  General  ')).toBe('general');
+  });
+
+  it('replaces non-allowed characters with a single hyphen (trailing hyphen kept)', () => {
+    // "##hello##" → "-hello-" → strip leading hyphen → "hello-".
+    // The trailing hyphen is intentional — only the leading position is
+    // stripped because CHANNEL_NAME_RE requires a letter/digit start.
+    expect(canonicalizeChannelName('##hello##')).toBe('hello-');
+    expect(isValidChannelName('hello-')).toBe(true);
+  });
+
+  it('strips a single leading hyphen', () => {
+    expect(canonicalizeChannelName('-leading-hyphen')).toBe('leading-hyphen');
+  });
+
+  it('strips multiple leading hyphens', () => {
+    expect(canonicalizeChannelName('--double-leading')).toBe('double-leading');
+  });
+
+  it('clamps to CHANNEL_NAME_MAX characters', () => {
+    const long = 'a'.repeat(100);
+    const out = canonicalizeChannelName(long);
+    expect(out).toHaveLength(CHANNEL_NAME_MAX);
+    expect(out).toBe('a'.repeat(CHANNEL_NAME_MAX));
+  });
+
+  it('returns empty string for empty input (documented edge case)', () => {
+    expect(canonicalizeChannelName('')).toBe('');
+    // isValidChannelName rejects empty — the boundary check catches it.
+    expect(isValidChannelName('')).toBe(false);
+  });
+
+  it('returns "" for all-punctuation input (documented edge case)', () => {
+    // "!!!" → "-" → strip leading hyphen → "". The leading-hyphen strip
+    // also handles the all-hyphen case so the canonicalizer never
+    // returns a result that starts with a hyphen.
+    expect(canonicalizeChannelName('!!!')).toBe('');
+    // isValidChannelName rejects empty — the boundary check catches it.
+    expect(isValidChannelName('')).toBe(false);
+  });
+
+  it('round-trips a valid name unchanged', () => {
+    expect(canonicalizeChannelName('foo-bar-1')).toBe('foo-bar-1');
+    expect(isValidChannelName('foo-bar-1')).toBe(true);
+  });
+
+  it('clamps a 200-char input to exactly CHANNEL_NAME_MAX', () => {
+    const long = 'b'.repeat(200);
+    expect(canonicalizeChannelName(long)).toHaveLength(CHANNEL_NAME_MAX);
+  });
+
+  it('preserves interior hyphens when clamping (no truncation artifact)', () => {
+    // 70 chars of a-; clamp to 64 → first 64 a-.
+    const input = 'a-'.repeat(35); // 70 chars
+    const out = canonicalizeChannelName(input);
+    expect(out).toHaveLength(CHANNEL_NAME_MAX);
+    expect(out).toBe('a-'.repeat(32)); // 64 chars
+  });
+});
+
+describe('isValidChannelName', () => {
+  it('accepts single lowercase letter', () => {
+    expect(isValidChannelName('a')).toBe(true);
+  });
+
+  it('accepts a name at the max length', () => {
+    expect(isValidChannelName('a'.repeat(CHANNEL_NAME_MAX))).toBe(true);
+  });
+
+  it('rejects a name over the max length', () => {
+    expect(isValidChannelName('a'.repeat(CHANNEL_NAME_MAX + 1))).toBe(false);
+  });
+
+  it('rejects uppercase', () => {
+    expect(isValidChannelName('General')).toBe(false);
+  });
+
+  it('rejects a name starting with a hyphen', () => {
+    expect(isValidChannelName('-foo')).toBe(false);
+  });
+
+  it('rejects an empty string', () => {
+    expect(isValidChannelName('')).toBe(false);
+  });
+
+  it('rejects names shorter than CHANNEL_NAME_MIN', () => {
+    expect(CHANNEL_NAME_MIN).toBe(1);
+    expect(isValidChannelName('')).toBe(false);
+  });
+});

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -46,6 +46,13 @@ export interface Channel {
    * Epoch ms when the channel became empty (zero members). Set by
    * the last member's `leave` or `archive`+purge flow. Drives the
    * 7-day empty-channel purge (plan KTD8).
+   *
+   * When this field is missing on a zero-member channel at load time,
+   * the reaper falls back to `createdAt` as the effective empty-start.
+   * This catches the "lost emptySince" recovery case — a channel whose
+   * `emptySince` was never persisted (crash between leave and write) or
+   * was lost through a future migration — and applies the 7-day bound
+   * from creation in that case.
    */
   emptySince?: number;
 }

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -152,16 +152,40 @@ export const EMPTY_CHANNEL_STATE: ChannelState = {
   idempotency: {},
 };
 
-/** Channel name canonicalization. Lowercase, hyphens, length-bounded. */
+/** Channel name length bounds. `CHANNEL_NAME_MIN` is the empty-length
+ *  floor; the regex below requires at least 1 character. */
 export const CHANNEL_NAME_MIN = 1;
 export const CHANNEL_NAME_MAX = 64;
-/** Allowed characters: lowercase letters, digits, hyphens. */
+/** Allowed characters: lowercase letters, digits, hyphens. The trailing
+ *  `{0,63}` is `CHANNEL_NAME_MAX - 1` since the leading char is fixed. */
 const CHANNEL_NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
+/**
+ * Canonicalize a user-supplied channel name. Strips characters outside
+ * `[a-z0-9-]`, lowercases, drops a leading hyphen (so the result starts
+ * with a letter or digit), and clamps to `CHANNEL_NAME_MAX` characters.
+ *
+ * The result may still be invalid for adversarial inputs — e.g. an
+ * all-punctuation string canonicalizes to `"-"`, and an empty string
+ * canonicalizes to `""`. Both fail `isValidChannelName`. The caller is
+ * responsible for validating the result with `isValidChannelName` and
+ * rejecting invalid input at the boundary; the canonicalizer's job is
+ * to normalize, not to guarantee validity.
+ */
 export function canonicalizeChannelName(raw: string): string {
-  return raw.trim().toLowerCase().replace(/[^a-z0-9-]+/g, '-');
+  const replaced = raw.trim().toLowerCase().replace(/[^a-z0-9-]+/g, '-');
+  // Strip a leading hyphen so the result starts with a letter or digit.
+  // (CHANNEL_NAME_RE requires this — without the strip, "-foo" would
+  // pass canonicalize but fail isValidChannelName.)
+  const stripped = replaced.replace(/^-+/, '');
+  // Clamp to CHANNEL_NAME_MAX. JS's String.prototype.slice handles
+  // surrogate pairs as code units, which is fine here — channel names
+  // are ASCII by construction (the regex above restricts to ASCII).
+  return stripped.slice(0, CHANNEL_NAME_MAX);
 }
 
+/** Returns true iff `name` matches the channel name pattern: 1-64
+ *  characters, lowercase letter/digit start, `[a-z0-9-]` body. */
 export function isValidChannelName(name: string): boolean {
   return CHANNEL_NAME_RE.test(name);
 }

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -7,8 +7,18 @@
 // primitives). Channels layer on top: posts fan out via the same idle-targeted
 // delivery path, but the channel owns its own state, history, and membership.
 
+/**
+ * Channel visibility. Immutable post-creation (see plan KTD7).
+ * `public` channels are discoverable and joinable; `private` channels
+ * are invite-only.
+ */
 export type ChannelVisibility = 'public' | 'private';
 
+/**
+ * Channel lifecycle state. `active` channels accept posts; `archived`
+ * channels are read-only and subject to the empty-channel reaper. See
+ * plan R4 for the state machine.
+ */
 export type ChannelStatus = 'active' | 'archived';
 
 /**
@@ -105,6 +115,14 @@ export interface ChannelMessage {
    * `recipientSnapshot` entries (see R14, plan KTD3).
    */
   deliveryStatus: 'pending' | 'delivered' | 'target_gone';
+  /**
+   * Per-recipient delivery snapshot, populated when the message is
+   * posted under the per-channel mutex. Required by plan KTD3: the
+   * recipient set is frozen at critical-section entry so later joins
+   * don't retroactively change who was targeted. Optional because
+   * older persisted messages (pre-U2) won't have it.
+   */
+  recipientSnapshot?: ChannelRecipientStatus[];
 }
 
 /**
@@ -155,6 +173,8 @@ export const EMPTY_CHANNEL_STATE: ChannelState = {
 /** Channel name length bounds. `CHANNEL_NAME_MIN` is the empty-length
  *  floor; the regex below requires at least 1 character. */
 export const CHANNEL_NAME_MIN = 1;
+/** Channel name upper length bound. Matches `{CHANNEL_NAME_MAX - 1}` in
+ *  the `CHANNEL_NAME_RE` regex below. */
 export const CHANNEL_NAME_MAX = 64;
 /** Allowed characters: lowercase letters, digits, hyphens. The trailing
  *  `{0,63}` is `CHANNEL_NAME_MAX - 1` since the leading char is fixed. */
@@ -165,12 +185,13 @@ const CHANNEL_NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
  * `[a-z0-9-]`, lowercases, drops a leading hyphen (so the result starts
  * with a letter or digit), and clamps to `CHANNEL_NAME_MAX` characters.
  *
- * The result may still be invalid for adversarial inputs — e.g. an
- * all-punctuation string canonicalizes to `"-"`, and an empty string
- * canonicalizes to `""`. Both fail `isValidChannelName`. The caller is
- * responsible for validating the result with `isValidChannelName` and
- * rejecting invalid input at the boundary; the canonicalizer's job is
- * to normalize, not to guarantee validity.
+ * The result may still be invalid for adversarial inputs — an empty
+ * string canonicalizes to `""`, and any input whose non-hyphen chars
+ * are all stripped (e.g. all-punctuation) canonicalizes to `""`. Both
+ * fail `isValidChannelName`. The caller is responsible for validating
+ * the result with `isValidChannelName` and rejecting invalid input at
+ * the boundary; the canonicalizer's job is to normalize, not to
+ * guarantee validity.
  */
 export function canonicalizeChannelName(raw: string): string {
   const replaced = raw.trim().toLowerCase().replace(/[^a-z0-9-]+/g, '-');

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -1,0 +1,169 @@
+// === A2A Channels ===
+// Persistent, named multi-party rooms at the company level. Slack-style
+// channels: scoped membership, durable history, public-or-private visibility
+// (immutable post-creation), and a human-observable sidebar in the renderer.
+//
+// Companion to MessageQueue (which still owns the 1-to-1 + broadcast A2A
+// primitives). Channels layer on top: posts fan out via the same idle-targeted
+// delivery path, but the channel owns its own state, history, and membership.
+
+export type ChannelVisibility = 'public' | 'private';
+
+export type ChannelStatus = 'active' | 'archived';
+
+/**
+ * A channel's persisted shape. Lives in `channels.json` (separate from
+ * `sessions.json` so channel loss can't cascade into session failure —
+ * see plan KTD1).
+ */
+export interface Channel {
+  /** Stable, unique channel id. Format: `ch-<uuid>` (matches codebase convention). */
+  id: string;
+  /** Company this channel belongs to. Channels are company-bounded by design. */
+  companyId: string;
+  /** Canonical name (lowercase, hyphens, length-bounded). Unique within company. */
+  name: string;
+  /** Optional human-readable topic. */
+  topic?: string;
+  /** Immutable post-creation. See plan KTD7. */
+  visibility: ChannelVisibility;
+  /** State machine: `active` ↔ `archived`. See plan R4. */
+  status: ChannelStatus;
+  /** Epoch ms. */
+  createdAt: number;
+  /** workspaceId of creator. Always auto-added as a member (plan KTD10). */
+  createdBy: string;
+  /** Epoch ms, set on `a2a_channel_archive`. */
+  archivedAt?: number;
+  /** workspaceId of archiver. */
+  archivedBy?: string;
+  /**
+   * Monotonic per-channel counter for posts + membership events. Assigned
+   * under the per-channel mutex (plan KTD2). Initialized to 1.
+   */
+  nextSeq: number;
+  /**
+   * Epoch ms when the channel became empty (zero members). Set by
+   * the last member's `leave` or `archive`+purge flow. Drives the
+   * 7-day empty-channel purge (plan KTD8).
+   */
+  emptySince?: number;
+}
+
+/**
+ * Channel membership. One row per (channel, workspace). A workspace
+ * may have multiple `Member`s (e.g. one per team member), so we
+ * key on `memberId` for fine-grained addressing.
+ */
+export interface ChannelMember {
+  workspaceId: string;
+  memberId: string;
+  /** Epoch ms. */
+  joinedAt: number;
+  /**
+   * First channel `seq` this member can see. Defaults to 0 (= full
+   * history from channel creation, plan KTD9). A member who joins
+   * with `include_history: false` gets the nextSeq-at-join value
+   * here.
+   */
+  historyFromSeq: number;
+}
+
+/**
+ * A single posted message. Persisted in `messages[channelId]`. `seq`
+ * is the canonical ordering — timestamps are not used for ordering
+ * because multiple posts within a single mutex window can share
+ * millisecond timestamps.
+ */
+export interface ChannelMessage {
+  /** channelId. Duplicated from the map key for load-path convenience. */
+  channelId: string;
+  /** Monotonic per-channel sequence. See plan KTD2. */
+  seq: number;
+  workspaceId: string;
+  memberId: string;
+  /** Display name at post time. Snapshot to avoid stale-name drift. */
+  memberName: string;
+  text: string;
+  /** Optional structured data, R10. */
+  data?: unknown;
+  /** Optional idempotency key, R13. */
+  clientMsgId?: string;
+  /** Epoch ms. */
+  postedAt: number;
+  /**
+   * Delivery outcome. `pending` = enqueued, `delivered` = at least
+   * one `tryDeliver` cycle has fired, `target_gone` = dead PTY at
+   * deliver time. Per-recipient status lives on the
+   * `recipientSnapshot` entries (see R14, plan KTD3).
+   */
+  deliveryStatus: 'pending' | 'delivered' | 'target_gone';
+}
+
+/**
+ * Per-recipient delivery outcome. Stored alongside the message in
+ * the `recipientSnapshot` field. Required by plan KTD3: the
+ * recipient set is frozen at critical-section entry.
+ */
+export interface ChannelRecipientStatus {
+  memberId: string;
+  workspaceId: string;
+  ptyId?: string;
+  /** `'pending'` | `'delivered'` | `'target_gone'`. */
+  status: 'pending' | 'delivered' | 'target_gone';
+  /** Epoch ms of last attempt, if any. */
+  lastAttemptAt?: number;
+}
+
+/**
+ * Top-level persisted state. Mirrors the StateWriter's `{version, ...}`
+ * shape. Versioned for future migration; ships at v1 (no schema migrations
+ * registered yet — see `CHANNEL_STATE_REGISTRY`).
+ */
+export interface ChannelState {
+  version: number;
+  channels: Channel[];
+  /** channelId → membership list. */
+  members: Record<string, ChannelMember[]>;
+  /** channelId → message list (ordered by seq). */
+  messages: Record<string, ChannelMessage[]>;
+  /**
+   * Idempotency: channelId → clientMsgId → seq. R13. Looked up under
+   * the per-channel mutex; eviction policy: LRU-capped at 1000 per
+   * channel (memory bound; the per-channel mutex keeps the cap
+   * check O(1) amortized).
+   */
+  idempotency: Record<string, Record<string, number>>;
+}
+
+/** Default empty state. Returned by `load()` on first-run / no-file. */
+export const EMPTY_CHANNEL_STATE: ChannelState = {
+  version: 1,
+  channels: [],
+  members: {},
+  messages: {},
+  idempotency: {},
+};
+
+/** Channel name canonicalization. Lowercase, hyphens, length-bounded. */
+export const CHANNEL_NAME_MIN = 1;
+export const CHANNEL_NAME_MAX = 64;
+/** Allowed characters: lowercase letters, digits, hyphens. */
+const CHANNEL_NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+export function canonicalizeChannelName(raw: string): string {
+  return raw.trim().toLowerCase().replace(/[^a-z0-9-]+/g, '-');
+}
+
+export function isValidChannelName(name: string): boolean {
+  return CHANNEL_NAME_RE.test(name);
+}
+
+/** Topic bounds. */
+export const CHANNEL_TOPIC_MAX = 256;
+
+/** Per-channel idempotency cap. See `ChannelState.idempotency`. */
+export const CHANNEL_IDEMPOTENCY_CAP = 1000;
+
+/** Empty-channel retention. Plan KTD8. */
+export const CHANNEL_EMPTY_TTL_HOURS_DEFAULT = 7 * 24;


### PR DESCRIPTION
## Summary

First cut of persistent multi-party A2A channels at the company level — Slack-style rooms with scoped membership, durable history, and public-or-private visibility (immutable post-creation). This PR lands the foundation only: domain types + on-disk persistence. Channel service, IPC, and renderer UI follow in U2+.

Channels are a companion to `MessageQueue` (which still owns 1-to-1 + broadcast A2A primitives). Channel posts fan out through the same idle-targeted delivery path, but the channel owns its own state, history, and membership.

## What's in this PR

- **`src/shared/channels.ts` (NEW, 169 lines)** — Domain types: `Channel`, `ChannelMember`, `ChannelMessage`, `ChannelRecipientStatus`, `ChannelState`. Plus `EMPTY_CHANNEL_STATE` default, `canonicalizeChannelName` + `isValidChannelName`, topic + idempotency bounds, and the 7-day empty-TTL default.
- **`src/daemon/channels/ChannelStateWriter.ts` (NEW, 323 lines)** — Persistence layer mirroring `StateWriter` exactly: `saveImmediate` / `saveDebounced` / `load` / `flush` / `flushSync` / `dispose`. Same concurrency model — `AsyncQueue`-keyed async write with race recovery against a concurrent `saveImmediate`; process-exit-friendly `flushSync` drains the queue before the staged inline fallback. `load()` prunes channels empty longer than the configured TTL but **keeps channels with no `emptySince` (real but never-joined) intact** — a bug the test suite caught and that this PR fixes (see below).
- **`src/daemon/util/atomicWrite/migrate.ts`** — Registers `CHANNEL_STATE_REGISTRY` (v1, identity) so `channels.json` gets the same migration path as `sessions.json`. One-file change, additive.
- **`src/daemon/channels/__tests__/ChannelStateWriter.test.ts` (NEW, 21 tests)** — saveImmediate roundtrip, debounce coalesce + flush, dispose flushes pending, TTL prune (stale / fresh / live / custom-TTL / default-TTL), `.bak` recovery on primary corruption, prototype-pollution guard, rotation chain, `flushSync` order, `load()` recovers from malformed shape, validator rejects bad visibility/status, `EMPTY_CHANNEL_STATE` invariant.

## Bug found during dogfood (fixed in this PR)

The initial `load()` prune logic only kept empty channels if `emptySince` was set AND within the TTL. That meant a real channel that exists on disk but has never had a member join (no `emptySince`) was being **silently pruned on every load** — a P0 for the never-joined-channel case. The `.bak recovery` test caught it (the recovered channel had no `emptySince`, so it was getting dropped). Fixed by adding an explicit "no `emptySince` → keep" branch. Added a dedicated regression test (`load keeps a channel with 0 members and no emptySince`) so this can't drift back.

## Plan reference

Code references plan IDs in comments: `KTD1` (channels.json separation), `KTD2` (per-channel mutex), `KTD3` (recipient-set frozen at critical-section entry), `KTD7` (immutable visibility), `KTD8` (7-day empty purge), `KTD9` (`historyFromSeq`), `KTD10` (creator auto-joined), `R4` (state machine), `R10` (structured data), `R13` (idempotency), `R14` (per-recipient status). The full plan doc is **not** in this repo — U1 implements what the comments describe without claiming to land the rest of the plan. U2 derivation (service layer, per-channel mutex, fanout, idempotency LRU, IPC) is deferred to a follow-up.

## Test results

- `npx vitest run src/daemon/channels/` → **21/21** passed (incl. the new regression test)
- `npx vitest run src/daemon/` → **484/484** passed (no regressions in existing daemon code)
- `npx vitest run src/shared/` → **362/362** passed
- `npx tsc -p tsconfig.daemon.json --noEmit` → **0 errors**
- `npx eslint src/daemon/channels/ src/shared/channels.ts src/daemon/util/atomicWrite/migrate.ts` → **0 errors**

## Test plan for review

1. **Roundtrip + recovery**: `saveImmediate` then `load()` returns the same shape; corrupting the primary file lets `load()` recover from `.bak`.
2. **Empty-TTL prune**: a channel with `emptySince = now - 8d` is pruned under the default 7d TTL; `emptySince = now - 3d` survives; a channel with a member is never pruned by empty-TTL; a channel with 0 members and no `emptySince` survives (regression case).
3. **Debounce + flush**: `saveDebounced` doesn't write immediately; multiple calls within the 30s window coalesce to the latest; `flush()` writes pending state synchronously; `dispose()` flushes then cleans up; `flushSync()` drains the queue before falling back to inline write.
4. **Atomic write**: `rotationEnabled` produces `.bak` (and `.bak.1`) correctly; corrupt primary recovers via `.bak`; no `.tmp` residue after a successful save.
5. **Validator + proto guard**: channels with bad `visibility` / `status` are rejected (load returns empty); `__proto__` / `constructor` keys don't pollute the loaded object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added channel state persistence with automatic saving, debounced writes, and manual flush options.
  * Implemented empty-channel cleanup based on configurable retention (default: 7 days).
  * Added shared channel domain model and channel-name normalization/validation utilities.
  * Added support for channel visibility (public/private) and status (active/archived).
* **Security & Reliability**
  * Hardened persisted state loading with strict schema validation and safer JSON parsing (prototype-pollution resistant).
* **Tests**
  * Expanded test coverage for persistence, recovery, pruning/TTL edge cases, debouncing/flush behavior, and channel-name rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->