### PR TITLE
feat(rpc): require origin on RpcContext, positive-allow the a2a execute gate (LanLink PR-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Hardened the A2A execute path against off-machine callers.** Every internal RPC now carries a required trust-origin tag (`local` vs `remote`), and the agent-spawning `a2a.task.send` path only runs when the call provably came from this machine, a positive-allow gate that fails closed for anything else. A source-level test pins that the background daemon can never even import the code that spawns agents. Nothing changes for same-machine multi-agent use today; this is the foundation for cross-PC A2A where remote agents can exchange messages but never execute commands.
+
 ## [3.7.0] — 2026-06-20 — A2A execute approval hardened, and remote RPC that lands in the right workspace
 
 Headline: the A2A execute gate — the path that lets a remote agent spawn a `bypassPermissions` Claude CLI in your workspace — is reworked into a renderer-driven approval flow with `execute` as its own dedicated capability (no longer bundled with ordinary send), an `executeApproved` receipt the worker can't forge, fail-closed YOLO hydration, and a queue so concurrent requests don't clobber each other. Alongside it, the #236 RPC workspace-scoping sweep is finished: `surface.new`, `pane.close`, `pane.focus`, and `surface.focus` now all act on the workspace the caller names instead of whatever happens to be on screen — so a multi-agent orchestrator's "do this in MY workspace" finally lands where it should. Plus a per-pane activity line on Fleet View cards, and a browser-pane keyboard-focus fix.

--- a/src/daemon/__tests__/daemonExecuteWall.test.ts
+++ b/src/daemon/__tests__/daemonExecuteWall.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Source-level invariant: the daemon process must NEVER import the execute
+// machinery. This is the PRIMARY, strongest layer of "remote A2A messages can
+// never reach claudeWorker.execute()" (LanLink C1). The daemon is a separate OS
+// process; if it cannot even import ClaudeWorker / RpcRouter / a2a.rpc, then a
+// remote LAN listener that lives in the daemon (future LanLink PR) has no code
+// path to spawn an agent — no matter how the dispatch logic above it evolves.
+//
+// This mirrors the repo's established source-invariant pattern (see
+// squirrelWiring.test.ts): we assert over source text because importing the
+// modules for a runtime check would defeat the "daemon never loads this" point.
+
+const DAEMON_DIR = path.join(__dirname, '..');
+
+const FORBIDDEN: ReadonlyArray<{ pattern: RegExp; label: string }> = [
+  { pattern: /from\s+['"][^'"]*ClaudeWorker['"]/, label: "import of ClaudeWorker" },
+  { pattern: /from\s+['"][^'"]*\/RpcRouter['"]/, label: "import of RpcRouter" },
+  { pattern: /from\s+['"][^'"]*a2a\.rpc['"]/, label: "import of a2a.rpc" },
+  { pattern: /\bclaudeWorker\.execute\s*\(/, label: "call to claudeWorker.execute()" },
+];
+
+function collectTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+      out.push(...collectTsFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('daemon execute-wall — process-boundary invariant (LanLink C1)', () => {
+  const files = collectTsFiles(DAEMON_DIR);
+
+  it('finds daemon source files to scan', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('no daemon source imports ClaudeWorker / RpcRouter / a2a.rpc, nor calls claudeWorker.execute()', () => {
+    const violations: string[] = [];
+    for (const file of files) {
+      const src = fs.readFileSync(file, 'utf-8');
+      for (const { pattern, label } of FORBIDDEN) {
+        if (pattern.test(src)) {
+          violations.push(`${path.relative(DAEMON_DIR, file)} — ${label}`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/src/main/mcp/__tests__/PermissionEnforcer.firstParty.test.ts
+++ b/src/main/mcp/__tests__/PermissionEnforcer.firstParty.test.ts
@@ -17,7 +17,7 @@ function trust(
   return { firstSeen: 1000, lastSeen: 2000, ...overrides };
 }
 function ctx(clientName?: string): RpcContext {
-  return clientName ? { clientName } : {};
+  return clientName ? { origin: 'local', clientName } : { origin: 'local' };
 }
 
 const FP = 'claude-code';

--- a/src/main/mcp/__tests__/PermissionEnforcer.test.ts
+++ b/src/main/mcp/__tests__/PermissionEnforcer.test.ts
@@ -13,7 +13,7 @@ function trust(
 }
 
 function ctx(clientName?: string): RpcContext {
-  return clientName ? { clientName } : {};
+  return clientName ? { origin: 'local', clientName } : { origin: 'local' };
 }
 
 describe('PermissionEnforcer.check — identity bootstrap', () => {

--- a/src/main/pipe/RpcRouter.ts
+++ b/src/main/pipe/RpcRouter.ts
@@ -177,6 +177,11 @@ export class RpcRouter {
     // Lift the optional identity envelope into the per-request context so
     // handlers don't reach back into PipeServer internals.
     const ctx: RpcContext = {
+      // This router serves only the machine-local named pipe + loopback TCP, so
+      // every request it dispatches is local by construction. The LanLink LAN
+      // listener is a SEPARATE router that sets origin:'remote' (future PR), and
+      // origin is REQUIRED on RpcContext so that listener can't forget to.
+      origin: 'local',
       clientName:
         typeof request.clientName === 'string' && request.clientName.trim().length > 0
           ? request.clientName.trim()

--- a/src/main/pipe/__tests__/RpcRouter.test.ts
+++ b/src/main/pipe/__tests__/RpcRouter.test.ts
@@ -25,6 +25,17 @@ function makeRouter() {
 }
 
 describe('RpcRouter dispatch envelope', () => {
+  it('stamps origin=local on the dispatched context (LanLink PR-1)', async () => {
+    const router = new RpcRouter();
+    const handler = vi.fn<HandlerSig>(async () => 'ok');
+    router.register('pane.list', handler);
+    await router.dispatch({ id: 'r-origin', method: 'pane.list', params: {} });
+    const [, ctx] = handler.mock.calls[0];
+    // The local pipe / loopback router is local by construction; a future
+    // LanLink listener is the only path that should ever stamp 'remote'.
+    expect(ctx?.origin).toBe('local');
+  });
+
   it('lifts clientName / clientVersion into the handler context', async () => {
     const router = new RpcRouter();
     const handler = vi.fn<HandlerSig>(async () => 'ok');

--- a/src/main/pipe/handlers/__tests__/a2a.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/a2a.rpc.test.ts
@@ -3,6 +3,7 @@ import type { BrowserWindow } from 'electron';
 import { RpcRouter } from '../../RpcRouter';
 import { registerA2aRpc } from '../a2a.rpc';
 import type { ClaudeWorker } from '../../../a2a/ClaudeWorker';
+import type { RpcContext } from '../../../../shared/rpc';
 
 const { sendToRendererMock } = vi.hoisted(() => ({
   sendToRendererMock: vi.fn(),
@@ -31,6 +32,23 @@ function setupRouter(worker: ClaudeWorker): RpcRouter {
   const router = new RpcRouter();
   registerA2aRpc(router, () => fakeWindow, worker);
   return router;
+}
+
+// remote/undefined-origin cases can't go through router.dispatch (it hard-codes
+// origin:'local' at RpcRouter), so capture the registered a2a.task.send handler
+// and invoke it directly with a synthetic context.
+type TaskSendHandler = (params: Record<string, unknown>, ctx?: RpcContext) => Promise<unknown>;
+
+function captureTaskSend(worker: ClaudeWorker): TaskSendHandler {
+  let handler: TaskSendHandler | undefined;
+  const capturing = {
+    register: (method: string, fn: TaskSendHandler) => {
+      if (method === 'a2a.task.send') handler = fn;
+    },
+  };
+  registerA2aRpc(capturing as unknown as RpcRouter, () => fakeWindow, worker);
+  if (!handler) throw new Error('a2a.task.send handler was not registered');
+  return handler;
 }
 
 describe('a2a.rpc — execute confirmation gate', () => {
@@ -134,6 +152,32 @@ describe('a2a.rpc — execute confirmation gate', () => {
       method: 'a2a.task.send',
       params: { workspaceId: 'ws-from', to: 'ws-to', message: 'do not execute', execute: 'true' },
     });
+
+    expect(worker.execute).not.toHaveBeenCalled();
+  });
+
+  it('does NOT spawn for a remote-origin call even when approved (LanLink PR-1)', async () => {
+    sendToRendererMock.mockResolvedValueOnce({ ok: true, taskId: 'task-remote', toWorkspaceId: 'ws-to', executeApproved: true });
+    const worker = makeWorker();
+    const handler = captureTaskSend(worker);
+
+    await handler(
+      { workspaceId: 'ws-from', to: 'ws-to', message: 'remote run', execute: true },
+      { origin: 'remote' },
+    );
+
+    expect(worker.execute).not.toHaveBeenCalled();
+  });
+
+  it('does NOT spawn when the origin context is absent (fail-closed)', async () => {
+    sendToRendererMock.mockResolvedValueOnce({ ok: true, taskId: 'task-noctx', toWorkspaceId: 'ws-to', executeApproved: true });
+    const worker = makeWorker();
+    const handler = captureTaskSend(worker);
+
+    await handler(
+      { workspaceId: 'ws-from', to: 'ws-to', message: 'no ctx', execute: true },
+      undefined,
+    );
 
     expect(worker.execute).not.toHaveBeenCalled();
   });

--- a/src/main/pipe/handlers/a2a.rpc.ts
+++ b/src/main/pipe/handlers/a2a.rpc.ts
@@ -105,10 +105,17 @@ export function registerA2aRpc(router: RpcRouter, getWindow: GetWindow, claudeWo
   // task.send: renderer validates, approval-gates execute:true, then stores +
   // delivers. Main only spawns the background worker after renderer reports that
   // the pre-create execute approval succeeded.
-  router.register('a2a.task.send', async (params) => {
+  router.register('a2a.task.send', async (params, ctx) => {
     const result = await sendToRenderer(getWindow, 'a2a.task.send', params);
 
-    if (params.execute === true && !params.taskId) {
+    // execute → origin decision (LanLink PR-1, positive-allow):
+    //   local  + execute + !taskId + approved → claudeWorker.execute()  ← only spawn
+    //   remote / undefined / unknown          → drop (fail-closed; blocks remote RCE)
+    //   local  + (no execute | taskId | !approved) → message-only
+    // origin is a REQUIRED RpcContext field, so a future remote transport cannot
+    // silently inherit execute. The renderer-returned executeApproved is
+    // origin-blind, so it is only consulted once we know origin is local.
+    if (ctx?.origin === 'local' && params.execute === true && !params.taskId) {
       const record = result as Record<string, unknown> | null;
       const taskId = typeof record?.taskId === 'string' ? record.taskId : '';
       const receiverWsId = typeof record?.toWorkspaceId === 'string' ? record.toWorkspaceId : '';

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -29,6 +29,15 @@ export interface RpcRequest {
  * argument so legacy handlers `(params) => ...` keep compiling.
  */
 export interface RpcContext {
+  /**
+   * Trust boundary the request entered through. REQUIRED (no `?`) so any new
+   * transport that constructs a context MUST classify it — a forgotten origin
+   * is a tsc error, never a silent default. `'remote'` = off-machine (LAN),
+   * gated out of every local-only capability (e.g. the a2a execute spawn).
+   * Today the only constructor is RpcRouter (named pipe + loopback TCP) →
+   * always `'local'`; the LanLink LAN listener (future PR) sets `'remote'`.
+   */
+  origin: 'local' | 'remote';
   clientName?: string;
   clientVersion?: string;
 }


### PR DESCRIPTION
## Summary
LanLink groundwork (PR-1): harden the A2A execute path against off-machine callers, with **zero network code**. Execute becomes a provably local-only capability, enforced by the type system and a process-boundary invariant.

- `RpcContext.origin` is now a **required** `'local' | 'remote'` field (`src/shared/rpc.ts`). A forgotten origin is a tsc error, not a silent default, so a future LAN transport can't inherit execute by omission.
- `RpcRouter` (named pipe + loopback TCP) stamps `origin: 'local'` (`RpcRouter.ts:179`) — it's machine-local by construction.
- `a2a.task.send` flips from deny-list to **positive-allow** (`a2a.rpc.ts`): `claudeWorker.execute()` spawns only when `ctx.origin === 'local'`, fail-closed for `remote` / `undefined`.
- New source-scan invariant test (`daemonExecuteWall.test.ts`): the daemon process can never import `ClaudeWorker` / `RpcRouter` / `a2a.rpc` — the structural "execute physically impossible at the daemon boundary" wall.

First PR of the LanLink epic (cross-PC A2A messaging). Ships value standalone even if no LAN feature ever lands.

## Test Coverage
- `rpc.ts` origin: type-only, tsc-enforced across all 4 configs.
- `RpcRouter.test.ts`: asserts dispatch stamps `origin: 'local'`.
- `a2a.rpc.test.ts`: existing 6 execute-gate tests pass **unchanged** (real `router.dispatch` injects `'local'`); +2 new — remote-origin and absent-origin both fail closed (`worker.execute` not called).
- `daemonExecuteWall.test.ts`: source-scan invariant (daemon import-0).
- **tsc 4/4 exit 0**, **vitest full suite green** (test:parallel + test:runtime).

## Reviews
- `/plan-eng-review`: CLEARED (5 refinements folded, 0 critical gaps).
- `/codex review`: **PASS** — "no discrete actionable regressions; origin consistently wired through router and tests; execute gate aligned, no production call site broken."

## NOT in scope (deferred)
- ClaudeWorker-internal origin rejection (defense layer 4) → PR-4 (when remote tasks exist).
- LAN listener / PAKE / AEAD / durable inbox / renderer card → PR-2..5.

## Test plan
- [x] `tsc --noEmit` across tsconfig.{json,daemon,mcp,cli} — exit 0
- [x] vitest full suite — green
- [x] `codex review --uncommitted` — PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Improvements**
  * Hardened agent task execution by restricting command spawning to authenticated local machine calls, preventing remote callers from triggering agent execution.
  * Established trust boundary framework for future multi-machine agent communication.

* **Tests**
  * Added enforcement tests to validate security boundaries and prevent execution vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->