### PR TITLE
feat(lanlink): durable inbound inbox + cursor-pull delivery backbone (PR-2)

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -26,7 +26,7 @@ returns `EPERM`. Wire framing: newline-delimited JSON, one object per line.
 
 ## RPC methods
 
-Total: **101** methods (`ALL_RPC_METHODS` in
+Total: **102** methods (`ALL_RPC_METHODS` in
 `src/shared/rpc.ts`). Capability and risk class are read from
 `src/main/mcp/methodCapabilityMap.ts`:
 
@@ -210,6 +210,7 @@ Total: **101** methods (`ALL_RPC_METHODS` in
 | `daemon.superviseRearm` | `wmux.internal` |  |
 | `daemon.superviseStop` | `wmux.internal` |  |
 | `daemon.setResumeBinding` | `wmux.internal` |  |
+| `daemon.inbox.poll` | `wmux.internal` |  |
 
 ### `hooks`
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -7,6 +7,7 @@ import { PaneSupervisor } from './PaneSupervisor';
 import { DaemonPipeServer } from './DaemonPipeServer';
 import { SessionPipe } from './SessionPipe';
 import { StateWriter } from './StateWriter';
+import { LanLinkInbox } from './lanlink/inbox';
 import { ProcessMonitor } from './ProcessMonitor';
 import { Watchdog } from './Watchdog';
 import { selectRecoverableSessions } from './recoverySelector';
@@ -23,6 +24,7 @@ import { toResumeCommand, resumeOfferForRecovered, mergeResumeBinding, normalize
 import type { ResumeBinding } from '../shared/agentResume';
 import { agentDisplayToSlug } from '../main/pty/AgentDetector';
 import type { AgentSlug } from '../shared/events';
+import { LANLINK_SENTINEL_SESSION_ID } from '../shared/lanlink';
 
 // X6 Feature ②: sessions RECOVERED this daemon boot that were running an
 // INTERACTIVE agent (non-exec, non-supervised) → ptyId → the agent slug to
@@ -961,6 +963,7 @@ function registerRpcHandlers(
   pipeServer: DaemonPipeServer,
   sessionManager: DaemonSessionManager,
   stateWriter: StateWriter,
+  lanLinkInbox: LanLinkInbox,
   sessionPipes: Map<string, SessionPipe>,
   processMonitor: ProcessMonitor,
   startTime: number,
@@ -1327,6 +1330,50 @@ function registerRpcHandlers(
       sessionFound: true,
     };
   });
+
+  // daemon.inbox.poll — LanLink PR-2 cursor-pull. Returns every inbox record
+  // with seq > cursor (the DELIVERY guarantee; the lanlink.remote.received
+  // broadcast is only a re-pull nudge). The store degrades gracefully (typed
+  // empty) on a bogus cursor. No origin gating — the daemon control pipe is
+  // machine-local; remote bytes never reach here (they land in the inbox via
+  // the PR-4 LAN listener, which this PR does not build).
+  pipeServer.onRpc('daemon.inbox.poll', async (params) => {
+    const cursor = typeof params['cursor'] === 'number' ? params['cursor'] : 0;
+    return lanLinkInbox.poll(cursor);
+  });
+
+  // __lanlink.inject — DEV/TEST ONLY synthetic inject (no real LAN peer). Gated
+  // so it never registers in a production build. Lets PR-2 be exercised end to
+  // end (durable append → nudge → main cursor-pull → renderer) independently of
+  // the PR-4 LAN transport. The future PR-4 receive path and the channels
+  // deliver() remote endpoint call the SAME LanLinkInbox.append() under the hood.
+  // Positive dev-detection (matches enforcementMode.detectIsDev). This codebase
+  // does NOT set NODE_ENV='production' for packaged builds — it judges prod via
+  // app.isPackaged — so a `!== 'production'` gate would WRONGLY register this in
+  // packaged production (NODE_ENV is unset there). Allowlist dev/test/explicit
+  // opt-in only, so the inject RPC is absent in a shipped build.
+  if (
+    process.env.NODE_ENV === 'development' ||
+    process.env.NODE_ENV === 'test' ||
+    process.env.WMUX_LANLINK_INJECT === '1'
+  ) {
+    pipeServer.onRpc('__lanlink.inject', async (params) => {
+      const { seq } = lanLinkInbox.injectSynthetic({
+        id: typeof params['id'] === 'string' ? params['id'] : undefined,
+        peerName: typeof params['peerName'] === 'string' ? params['peerName'] : 'peer',
+        text: typeof params['text'] === 'string' ? params['text'] : '',
+      });
+      // The durable write already completed (append is synchronous) BEFORE we
+      // broadcast — the nudge is best-effort and may be dropped; the cursor-pull
+      // is the delivery guarantee.
+      pipeServer.broadcast({
+        type: 'lanlink.remote.received',
+        sessionId: LANLINK_SENTINEL_SESSION_ID,
+        data: { seq },
+      });
+      return { ok: true, seq };
+    });
+  }
 
   // daemon.ping
   pipeServer.onRpc('daemon.ping', async () => {
@@ -1926,6 +1973,10 @@ async function main(): Promise<void> {
   // StateWriter (codex #2). The acquireLock() one-shot above runs pre-config
   // and only reads bootId, so the default there is harmless.
   const stateWriter = new StateWriter(wmuxDir, config.session.suspendedTtlHours);
+  // LanLink PR-2 — durable inbound inbox (remote peer messages). Daemon-owned
+  // so it survives main/renderer death (C3). Lives next to sessions.json under
+  // the same suffix-aware wmuxDir; every append is synchronous + fsync'd.
+  const lanLinkInbox = new LanLinkInbox(wmuxDir);
   // A4 — sweep tmp dumps left behind by a previous crash. They are safe to
   // delete: tmp files only exist between the write and rename steps of an
   // atomic dump, so any tmp on disk now is from a daemon that died before
@@ -2052,6 +2103,7 @@ async function main(): Promise<void> {
     pipeServer,
     sessionManager,
     stateWriter,
+    lanLinkInbox,
     sessionPipes,
     processMonitor,
     startTime,

--- a/src/daemon/lanlink/__tests__/inbox.runtime.test.ts
+++ b/src/daemon/lanlink/__tests__/inbox.runtime.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { LanLinkInbox } from '../inbox';
+import * as atomicWrite from '../../util/atomicWrite';
+import { INBOX_CAP, isInboxFile } from '../../../shared/lanlink';
+
+// Disk-IO tests → `.runtime.test.ts` so they run serially (vitest.runtime.config
+// sets fileParallelism:false) and temp-file rotations don't race.
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lanlink-inbox-'));
+});
+afterEach(() => {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+const file = (): string => path.join(dir, 'lanlink-inbox.json');
+
+describe('LanLinkInbox — durable store', () => {
+  it('U2: cursor monotonic — poll returns seq>cursor; nextCursor never rewinds', () => {
+    const ib = new LanLinkInbox(dir);
+    ib.injectSynthetic({ peerName: 'A', text: 'm1' });
+    ib.injectSynthetic({ peerName: 'A', text: 'm2' });
+    ib.injectSynthetic({ peerName: 'A', text: 'm3' });
+
+    const all = ib.poll(0);
+    expect(all.items.map((r) => r.seq)).toEqual([1, 2, 3]);
+    expect(all.nextCursor).toBe(3);
+
+    const tail = ib.poll(2);
+    expect(tail.items.map((r) => r.seq)).toEqual([3]);
+    expect(tail.nextCursor).toBe(3);
+
+    // poll past the end echoes the cursor (never rewinds, no throw)
+    const none = ib.poll(3);
+    expect(none.items).toEqual([]);
+    expect(none.nextCursor).toBe(3);
+
+    // a bogus cursor degrades gracefully
+    expect(ib.poll(-5).items.map((r) => r.seq)).toEqual([1, 2, 3]);
+    expect(ib.poll(NaN).nextCursor).toBe(3);
+  });
+
+  it('U5: append is durable BEFORE it returns — a fresh instance sees it immediately (no flush)', () => {
+    const ib = new LanLinkInbox(dir);
+    const { seq } = ib.injectSynthetic({ id: 'fixed-1', peerName: 'A', text: 'durable' });
+    expect(seq).toBe(1);
+    // No flushSync/dispose — the synchronous atomic write already completed
+    // before append returned its seq (the ACK), so a brand-new instance reading
+    // the same path observes the record. This is the ack-after-durable proof.
+    const reopened = new LanLinkInbox(dir);
+    const got = reopened.poll(0);
+    expect(got.items).toHaveLength(1);
+    expect(got.items[0].id).toBe('fixed-1');
+    expect(got.items[0].text).toBe('durable');
+  });
+
+  it('seq + nextSeq survive a daemon restart (monotonic across reopen, never reset)', () => {
+    const ib = new LanLinkInbox(dir);
+    ib.injectSynthetic({ peerName: 'A', text: 'm1' });
+    ib.injectSynthetic({ peerName: 'A', text: 'm2' });
+    const reopened = new LanLinkInbox(dir);
+    const { seq } = reopened.injectSynthetic({ peerName: 'A', text: 'm3' });
+    expect(seq).toBe(3);
+  });
+
+  it('length-clamps peerName and body on inject', () => {
+    const ib = new LanLinkInbox(dir);
+    ib.injectSynthetic({ peerName: 'P'.repeat(500), text: 'B'.repeat(10_000) });
+    const [r] = ib.poll(0).items;
+    expect(r.peerName.length).toBe(100); // PEER_NAME_MAX
+    expect(r.text.length).toBe(4000); // BODY_MAX
+  });
+
+  it('U1: a corrupt (non-JSON) primary falls back to the .bak last-good on load', () => {
+    const ib = new LanLinkInbox(dir);
+    ib.injectSynthetic({ peerName: 'A', text: 'first' }); // writes primary
+    ib.injectSynthetic({ peerName: 'A', text: 'second' }); // rotates primary→.bak, new primary
+    fs.writeFileSync(file(), '{ this is not valid json');
+    const reopened = new LanLinkInbox(dir);
+    const got = reopened.poll(0);
+    expect(got.items.length).toBeGreaterThanOrEqual(1);
+    expect(got.items[0].text).toBe('first'); // recovered from .bak
+  });
+
+  it('U3: an ARRAY-shaped (corrupt) primary fails the validator and falls back to .bak', () => {
+    const ib = new LanLinkInbox(dir);
+    ib.injectSynthetic({ peerName: 'A', text: 'first' });
+    ib.injectSynthetic({ peerName: 'A', text: 'second' });
+    // Overwrite the primary with a JSON ARRAY — valid JSON, NOT a healthy inbox
+    // file (#269 trap). isInboxFile must reject it → .bak recovery.
+    fs.writeFileSync(
+      file(),
+      JSON.stringify([{ id: 'x', seq: 1, origin: 'remote', peerName: 'P', text: 'x', receivedAt: 1 }]),
+    );
+    const reopened = new LanLinkInbox(dir);
+    const got = reopened.poll(0);
+    expect(got.items[0].text).toBe('first'); // recovered from .bak, not the array
+  });
+
+  it('U6: FIFO bound at INBOX_CAP — oldest evicted, seq keeps climbing (never reused)', () => {
+    const ib = new LanLinkInbox(dir);
+    for (let i = 0; i < INBOX_CAP + 3; i++) ib.injectSynthetic({ peerName: 'A', text: `m${i}` });
+    expect(ib.size).toBe(INBOX_CAP);
+    const items = ib.poll(0).items;
+    // oldest 3 evicted → first surviving seq is 4, last is INBOX_CAP+3
+    expect(items[0].seq).toBe(4);
+    expect(items[items.length - 1].seq).toBe(INBOX_CAP + 3);
+  });
+
+  it('never persists a file it cannot load (own validator passes on the on-disk bytes)', () => {
+    const ib = new LanLinkInbox(dir);
+    ib.injectSynthetic({ peerName: 'A', text: 'm' });
+    const onDisk = JSON.parse(fs.readFileSync(file(), 'utf8'));
+    expect(isInboxFile(onDisk)).toBe(true);
+  });
+
+  it('append write throw leaves in-memory state unchanged (snapshot-then-commit, no phantom)', () => {
+    const ib = new LanLinkInbox(dir);
+    ib.injectSynthetic({ peerName: 'A', text: 'first' }); // seq 1, durable
+    // Force the next durable write to throw (ENOSPC/EACCES/Windows-lock class).
+    const spy = vi
+      .spyOn(atomicWrite, 'atomicWriteJSONSync')
+      .mockImplementationOnce(() => {
+        throw new Error('simulated write failure');
+      });
+    expect(() => ib.injectSynthetic({ peerName: 'A', text: 'second' })).toThrow();
+    spy.mockRestore();
+    // Snapshot-then-commit: this.file (poll/size/nextSeq) stays byte-identical to
+    // the last durable state — no phantom record is pollable, no seq is leaked.
+    expect(ib.size).toBe(1);
+    expect(ib.poll(0).items.map((r) => r.seq)).toEqual([1]);
+    // nextSeq was NOT consumed by the failed append — the next success reuses 2.
+    const { seq } = ib.injectSynthetic({ peerName: 'A', text: 'third' });
+    expect(seq).toBe(2);
+    expect(ib.poll(0).items.map((r) => r.text)).toEqual(['first', 'third']);
+  });
+});

--- a/src/daemon/lanlink/__tests__/inbox.runtime.test.ts
+++ b/src/daemon/lanlink/__tests__/inbox.runtime.test.ts
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { LanLinkInbox } from '../inbox';
 import * as atomicWrite from '../../util/atomicWrite';
-import { INBOX_CAP, isInboxFile } from '../../../shared/lanlink';
+import { isInboxFile } from '../../../shared/lanlink';
 
 // Disk-IO tests → `.runtime.test.ts` so they run serially (vitest.runtime.config
 // sets fileParallelism:false) and temp-file rotations don't race.
@@ -106,14 +106,18 @@ describe('LanLinkInbox — durable store', () => {
     expect(got.items[0].text).toBe('first'); // recovered from .bak, not the array
   });
 
-  it('U6: FIFO bound at INBOX_CAP — oldest evicted, seq keeps climbing (never reused)', () => {
-    const ib = new LanLinkInbox(dir);
-    for (let i = 0; i < INBOX_CAP + 3; i++) ib.injectSynthetic({ peerName: 'A', text: `m${i}` });
-    expect(ib.size).toBe(INBOX_CAP);
+  it('U6: FIFO bound — oldest evicted, seq keeps climbing (never reused)', () => {
+    // Inject a small cap so the FIFO invariant is exercised without thousands of
+    // synchronous disk writes (515 appends timed out CI's 5s default). The prod
+    // cap is INBOX_CAP=512; the eviction logic under test is cap-agnostic.
+    const cap = 5;
+    const ib = new LanLinkInbox(dir, cap);
+    for (let i = 0; i < cap + 3; i++) ib.injectSynthetic({ peerName: 'A', text: `m${i}` });
+    expect(ib.size).toBe(cap);
     const items = ib.poll(0).items;
-    // oldest 3 evicted → first surviving seq is 4, last is INBOX_CAP+3
+    // oldest 3 (seq 1,2,3) evicted → first surviving seq is 4, last is cap+3
     expect(items[0].seq).toBe(4);
-    expect(items[items.length - 1].seq).toBe(INBOX_CAP + 3);
+    expect(items[items.length - 1].seq).toBe(cap + 3);
   });
 
   it('never persists a file it cannot load (own validator passes on the on-disk bytes)', () => {

--- a/src/daemon/lanlink/__tests__/inbox.test.ts
+++ b/src/daemon/lanlink/__tests__/inbox.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { isInboxFile, type InboxFile } from '../../../shared/lanlink';
+
+function validFile(): InboxFile {
+  return {
+    version: 1,
+    nextSeq: 2,
+    records: [
+      { id: 'a', seq: 1, origin: 'remote', peerName: 'P', text: 'hi', receivedAt: 1 },
+      { id: 'b', seq: 2, origin: 'remote', peerName: 'P', text: 'yo', receivedAt: 2 },
+    ],
+  };
+}
+
+describe('isInboxFile — #269 array-reject + row validation', () => {
+  it('accepts a well-formed inbox file', () => {
+    expect(isInboxFile(validFile())).toBe(true);
+  });
+
+  it('accepts an empty inbox', () => {
+    expect(isInboxFile({ version: 1, nextSeq: 0, records: [] })).toBe(true);
+  });
+
+  it('rejects an ARRAY container (the #269 bug: typeof [] === "object")', () => {
+    // A JSON array is valid JSON but NOT a healthy inbox file; passing it would
+    // defeat .bak recovery. This is the exact codex P1 trap from #269.
+    expect(isInboxFile([])).toBe(false);
+    expect(
+      isInboxFile([
+        { id: 'a', seq: 1, origin: 'remote', peerName: 'P', text: 'x', receivedAt: 1 },
+      ]),
+    ).toBe(false);
+  });
+
+  it('rejects null / non-object / wrong version', () => {
+    expect(isInboxFile(null)).toBe(false);
+    expect(isInboxFile('nope')).toBe(false);
+    expect(isInboxFile(42)).toBe(false);
+    expect(isInboxFile({ version: 2, nextSeq: 0, records: [] })).toBe(false);
+  });
+
+  it('rejects a bad nextSeq (negative / non-integer / non-number)', () => {
+    expect(isInboxFile({ version: 1, nextSeq: -1, records: [] })).toBe(false);
+    expect(isInboxFile({ version: 1, nextSeq: 1.5, records: [] })).toBe(false);
+    expect(isInboxFile({ version: 1, nextSeq: 'x', records: [] })).toBe(false);
+  });
+
+  it('rejects when records is not an array', () => {
+    expect(isInboxFile({ version: 1, nextSeq: 0, records: {} })).toBe(false);
+  });
+
+  it('rejects a malformed record row', () => {
+    const f = validFile();
+    // wrong origin
+    expect(isInboxFile({ ...f, records: [{ ...f.records[0], origin: 'local' }] })).toBe(false);
+    // missing id
+    expect(
+      isInboxFile({
+        ...f,
+        nextSeq: 1,
+        records: [{ seq: 1, origin: 'remote', peerName: 'P', text: 'x', receivedAt: 1 }],
+      }),
+    ).toBe(false);
+    // non-string text
+    expect(isInboxFile({ ...f, records: [{ ...f.records[0], text: 123 }] })).toBe(false);
+    // empty id
+    expect(isInboxFile({ ...f, nextSeq: 1, records: [{ ...f.records[0], id: '' }] })).toBe(false);
+  });
+
+  it('rejects a rewound / duplicate seq (replay defense)', () => {
+    const f = validFile();
+    expect(isInboxFile({ ...f, records: [f.records[0], { ...f.records[1], seq: 1 }] })).toBe(false);
+  });
+
+  it('rejects a seq greater than nextSeq', () => {
+    const f = validFile();
+    expect(
+      isInboxFile({ ...f, nextSeq: 1, records: [f.records[0], { ...f.records[1], seq: 5 }] }),
+    ).toBe(false);
+  });
+});

--- a/src/daemon/lanlink/inbox.ts
+++ b/src/daemon/lanlink/inbox.ts
@@ -51,7 +51,14 @@ export class LanLinkInbox {
   /** In-memory authoritative copy, loaded at construction. */
   private file: InboxFile;
 
-  constructor(baseDir: string) {
+  /**
+   * @param baseDir suffix-aware wmux dir (the sessions.json sibling).
+   * @param cap     FIFO bound on retained records. Defaults to INBOX_CAP (512).
+   *                Tests inject a small cap so the FIFO-eviction invariant can be
+   *                exercised without thousands of synchronous disk writes — the
+   *                eviction logic itself is cap-agnostic.
+   */
+  constructor(baseDir: string, private readonly cap: number = INBOX_CAP) {
     this.filePath = path.join(baseDir, 'lanlink-inbox.json');
     this.file = this.load();
   }
@@ -65,8 +72,8 @@ export class LanLinkInbox {
     const seq = this.file.nextSeq + 1;
     const records = [...this.file.records, { ...rec, seq }];
     // FIFO bound. nextSeq keeps climbing so an evicted seq is never reused.
-    if (records.length > INBOX_CAP) {
-      records.splice(0, records.length - INBOX_CAP);
+    if (records.length > this.cap) {
+      records.splice(0, records.length - this.cap);
     }
     const next: InboxFile = { version: 1, nextSeq: seq, records };
     // SYNC atomic write (rename-atomic durability + `.bak` rotation) against the

--- a/src/daemon/lanlink/inbox.ts
+++ b/src/daemon/lanlink/inbox.ts
@@ -1,0 +1,176 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import {
+  atomicReadJSONSync,
+  atomicWriteJSONSync,
+  createMigrator,
+  type MigrationRegistry,
+} from '../util/atomicWrite';
+import {
+  BODY_MAX,
+  clampText,
+  INBOX_CAP,
+  isInboxFile,
+  PEER_NAME_MAX,
+  type InboxFile,
+  type InboxRecord,
+  type LanLinkInboxPollResult,
+  type SyntheticInjectInput,
+} from '../../shared/lanlink';
+
+// Identity migration registry (v1, no steps) — behaviour-neutral today, but the
+// hook means a future inbox schema change lands without touching `load()`.
+// Mirrors DAEMON_STATE_REGISTRY (StateWriter.ts:9 / migrate.ts:300).
+const LANLINK_INBOX_REGISTRY: MigrationRegistry = { currentVersion: 1, steps: [] };
+
+/**
+ * LanLink durable inbound inbox (PR-2). The single source of truth for remote
+ * peer messages, owned by the DAEMON process so it survives main/renderer death
+ * (C3). Append-only, monotonic `seq`, FIFO-bounded, atomic-write + `.bak`
+ * recovery.
+ *
+ * Mirrors `StateWriter`'s persistence shape with one deliberate correction:
+ * `StateWriter.saveDebounced` COALESCES same-key writes through `AsyncQueue`
+ * (only the latest snapshot matters), which would silently DROP a message that
+ * arrived just before a crash. An inbox must persist EVERY append, so `append()`
+ * follows the `saveImmediate` discipline — a synchronous atomic write on every
+ * record — and there is no debounce/coalesce path.
+ *
+ * **ACK ordering (non-negotiable):** the caller learns a record's `seq` ONLY
+ * after the durable write completes. `append()` returns `{seq}` physically after
+ * `atomicWriteJSONSync` + a best-effort `fsync`, so there is no code path where
+ * an "acked" message is not yet on stable storage (no ack-before-durable race).
+ *
+ * **Execute wall:** this module imports 0 of ClaudeWorker / RpcRouter / a2a.rpc
+ * — enforced by `daemonExecuteWall.test.ts`, which auto-scans `src/daemon/**`
+ * (the strongest, structural layer of "remote messages can never execute").
+ */
+export class LanLinkInbox {
+  private readonly filePath: string;
+  /** In-memory authoritative copy, loaded at construction. */
+  private file: InboxFile;
+
+  constructor(baseDir: string) {
+    this.filePath = path.join(baseDir, 'lanlink-inbox.json');
+    this.file = this.load();
+  }
+
+  /**
+   * Append a remote record durably and return its assigned `seq`. SYNCHRONOUS:
+   * the atomic write (and a best-effort fsync) complete before this returns, so
+   * the return value IS the durable ACK.
+   */
+  append(rec: Omit<InboxRecord, 'seq'>): { seq: number } {
+    const seq = this.file.nextSeq + 1;
+    const records = [...this.file.records, { ...rec, seq }];
+    // FIFO bound. nextSeq keeps climbing so an evicted seq is never reused.
+    if (records.length > INBOX_CAP) {
+      records.splice(0, records.length - INBOX_CAP);
+    }
+    const next: InboxFile = { version: 1, nextSeq: seq, records };
+    // SYNC atomic write (rename-atomic durability + `.bak` rotation) against the
+    // CANDIDATE snapshot — this.file is NOT mutated yet. The validator guards our
+    // own write too, so a logic bug can't persist a file that would later fail
+    // to load.
+    atomicWriteJSONSync(this.filePath, next, {
+      validate: isInboxFile,
+      rotationEnabled: true,
+    });
+    // Belt-and-suspenders: flush the renamed file to stable storage before we
+    // ACK, closing the ack-before-durable window against the OS write-back cache
+    // (atomicWrite relies on rename atomicity and does not fsync). The C3 threat
+    // model — main process kill, daemon alive — is already covered by the sync
+    // rename; this additionally hardens against a daemon-host crash.
+    this.fsyncBestEffort();
+    // Commit in-memory state ONLY after the durable write succeeded. If the
+    // write throws, this.file (and thus poll()/nextSeq) stays byte-identical to
+    // the last persisted state — no phantom record can be polled, no consumed-
+    // but-unpersisted seq leaks, and a record the caller was told failed is
+    // never resurrected by the next append.
+    this.file = next;
+    return { seq };
+  }
+
+  /**
+   * Inject a synthetic record (test/dev). Validates + length-clamps, then calls
+   * the SAME `append()` the future PR-4 LAN listener (and the channels
+   * `deliver()` remote endpoint) will call — the shared seam (roadmap §11).
+   */
+  injectSynthetic(input: SyntheticInjectInput): { seq: number } {
+    const rec: Omit<InboxRecord, 'seq'> = {
+      id: input.id ?? randomUUID(),
+      origin: 'remote',
+      peerName: clampText(input.peerName, PEER_NAME_MAX),
+      text: clampText(input.text, BODY_MAX),
+      receivedAt: Date.now(),
+      ...(input.state ? { state: input.state } : {}),
+    };
+    return this.append(rec);
+  }
+
+  /**
+   * Return every record with `seq > cursor`, oldest-first (the cursor-pull read
+   * shape, mirroring `PromptEventLog.since`). `nextCursor` never rewinds — even
+   * on an empty result it echoes the caller's cursor. Degrades gracefully (no
+   * throw) on a bogus cursor.
+   */
+  poll(cursor: number): LanLinkInboxPollResult {
+    const c = Number.isFinite(cursor) ? Math.max(0, Math.floor(cursor)) : 0;
+    const items = this.file.records.filter((r) => r.seq > c);
+    const highest = items.length > 0 ? items[items.length - 1].seq : c;
+    return { items, nextCursor: Math.max(c, highest) };
+  }
+
+  /** Current record count (test/diagnostics aid). */
+  get size(): number {
+    return this.file.records.length;
+  }
+
+  /**
+   * Process-exit drain. `append()` is synchronous + fsync'd, so there is never
+   * unflushed pending state — this is a no-op kept for symmetry with
+   * `StateWriter.flushSync` and as a forward hook if a write fast-path is added.
+   */
+  flushSync(): void {
+    /* intentionally empty — every append is already durable */
+  }
+
+  dispose(): void {
+    /* no timers/handles to release */
+  }
+
+  // ── Internal ──────────────────────────────────────────────────────────────
+
+  private load(): InboxFile {
+    const empty: InboxFile = { version: 1, nextSeq: 0, records: [] };
+    try {
+      const migrator = createMigrator<InboxFile>(LANLINK_INBOX_REGISTRY, this.filePath);
+      const loaded = atomicReadJSONSync<InboxFile>(this.filePath, {
+        validate: isInboxFile,
+        migrator,
+      });
+      // A corrupt/array-shaped/torn primary fails `isInboxFile` inside the
+      // atomic read, which walks the `.bak` chain; a total miss returns null.
+      if (loaded) return loaded;
+    } catch (err) {
+      console.error('[LanLinkInbox] Failed to load inbox:', err);
+    }
+    return empty;
+  }
+
+  /** Reopen the renamed primary and fsync it. Best-effort: a failure (e.g. a
+   *  platform that rejects the open) leaves us relying on rename atomicity. */
+  private fsyncBestEffort(): void {
+    try {
+      const fd = fs.openSync(this.filePath, 'r+');
+      try {
+        fs.fsyncSync(fd);
+      } finally {
+        fs.closeSync(fd);
+      }
+    } catch {
+      /* best-effort — the sync atomic rename already provides atomicity */
+    }
+  }
+}

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -2,6 +2,7 @@ import net from 'node:net';
 import { EventEmitter } from 'node:events';
 import crypto from 'node:crypto';
 import type { RpcResponse, DaemonEvent } from '../shared/rpc';
+import type { LanLinkInboxPollResult } from '../shared/lanlink';
 import { FLUSH_DONE_MARKER } from '../daemon/SessionPipe';
 import { DAEMON_RPC_TIMEOUT_MS } from '../shared/timeouts';
 import { dataSuffix } from '../shared/constants';
@@ -309,6 +310,17 @@ export class DaemonClient extends EventEmitter {
   }
 
   /**
+   * LanLink PR-2 — cursor-pull the daemon's durable inbox. Returns every record
+   * with seq > cursor; `nextCursor` never rewinds. RemoteInboxBridge advances
+   * its retained cursor only after the pulled items are materialized, so a
+   * reconnect replay is exactly-once on the read side.
+   */
+  async inboxPoll(cursor: number): Promise<LanLinkInboxPollResult> {
+    const result = await this.rpc('daemon.inbox.poll', { cursor });
+    return result as LanLinkInboxPollResult;
+  }
+
+  /**
    * daemon AgentDetector가 gate로 확정한 에이전트 표시명을 조회한다(없으면 null).
    * renderer detection pull의 권위 소스 — session:agent emit 전파 race를 우회한다.
    */
@@ -513,6 +525,16 @@ export class DaemonClient extends EventEmitter {
           // X1 — PID-tree-scoped listening ports (10 s daemon poll).
           this.emit('session:ports', { sessionId: event.sessionId, data: event.data });
           break;
+        case 'lanlink.remote.received': {
+          // LanLink PR-2 — a remote message landed in the daemon's durable
+          // inbox. This broadcast is a FIRE-AND-FORGET NUDGE only ("re-pull"),
+          // NOT delivery. RemoteInboxBridge listens for 'lanlink:nudge' and
+          // pulls via daemon.inbox.poll — the cursor-pull is the guarantee, so a
+          // dropped nudge is recovered by the bridge's interval/reconnect pull.
+          const data = event.data as { seq?: number } | null;
+          this.emit('lanlink:nudge', { seq: data?.seq ?? 0 });
+          break;
+        }
         default:
           break;
       }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -55,6 +55,7 @@ import { DaemonClient, getDaemonPipeName, readDaemonAuthToken } from './DaemonCl
 import { raceDaemonShutdown } from './daemonShutdownRace';
 import { migrateScrollbackOnce } from './scrollback/legacyMigration';
 import { DaemonNotificationRouter } from './notification/DaemonNotificationRouter';
+import { RemoteInboxBridge } from './lanlink/RemoteInboxBridge';
 import { WorkspaceContextRouter } from './metadata/WorkspaceContextRouter';
 import { ensureDaemon, killDaemonByPidFile } from './daemon/launcher';
 import { DaemonRespawnController } from './daemon/DaemonRespawnController';
@@ -335,6 +336,7 @@ async function refreshTraySessionCount(): Promise<void> {
 // PTYBridge writes to in local mode. Without it, daemon mode would render
 // the notification pipeline 100% inert (Codex 2nd review #1).
 let daemonNotificationRouter: DaemonNotificationRouter | null = null;
+let remoteInboxBridge: RemoteInboxBridge | null = null;
 // X1 — folds daemon context.git/context.ports broadcasts into the sidebar
 // metadata channel (and drives the gh PR cache). Same lifecycle as the
 // notification router above.
@@ -535,6 +537,15 @@ const disposeUsagePollerListener = usagePoller.onStateChange((state) => {
     win.webContents.send(IPC.USAGE_UPDATE, state);
   }
 });
+// LanLink PR-2 — renderer requests a full inbox replay on mount (cold start /
+// reload). Reset the bridge cursor to 0 and re-pull so the (possibly just-
+// reloaded, empty) renderer re-materializes every live record; isNew dedups.
+// No-op when no daemon bridge is mounted yet (the bridge's own start() pull
+// will deliver once it connects).
+ipcMain.on(IPC.LANLINK_RESYNC, () => {
+  remoteInboxBridge?.resync();
+});
+
 ipcMain.on(IPC.USAGE_TOGGLE, (_event, enabled: unknown) => {
   if (enabled === true) {
     usagePoller.start();
@@ -798,6 +809,14 @@ app.on('ready', async () => {
       daemonNotificationRouter?.stop();
       daemonNotificationRouter = new DaemonNotificationRouter(client, () => mainWindow, () => hookSignalRouter);
       daemonNotificationRouter.start();
+      // LanLink PR-2 — mount the remote-inbox cursor-pull bridge. On every
+      // (re)connect it pulls the daemon's durable inbox from its retained cursor
+      // and materializes read-only remote items to the renderer over a dedicated
+      // IPC channel (never the PTY paste / a2a execute path). Re-created per
+      // install like the notification router; the cursor lives in module scope.
+      remoteInboxBridge?.stop();
+      remoteInboxBridge = new RemoteInboxBridge(() => mainWindow);
+      remoteInboxBridge.start(client);
       // X1 — context fold (git branch / worktree / ports / PR badge).
       workspaceContextRouter?.stop();
       workspaceContextRouter = new WorkspaceContextRouter(client, () => mainWindow);
@@ -831,6 +850,8 @@ app.on('ready', async () => {
       console.warn('[Main] Daemon disconnected, falling back to local PTY');
       daemonNotificationRouter?.stop();
       daemonNotificationRouter = null;
+      remoteInboxBridge?.stop();
+      remoteInboxBridge = null;
       workspaceContextRouter?.stop();
       workspaceContextRouter = null;
       daemonClient = null;

--- a/src/main/lanlink/RemoteInboxBridge.ts
+++ b/src/main/lanlink/RemoteInboxBridge.ts
@@ -1,0 +1,175 @@
+import type { BrowserWindow } from 'electron';
+import type { DaemonClient } from '../DaemonClient';
+import { IPC } from '../../shared/constants';
+import {
+  BODY_MAX,
+  clampText,
+  PEER_NAME_MAX,
+  type InboxRecord,
+  type RemoteInboxItem,
+} from '../../shared/lanlink';
+
+// Backstop interval (ms). The nudge (lanlink:nudge) is the fast path; this
+// interval recovers a dropped nudge. Short enough to feel live, long enough to
+// be negligible against the named-pipe RPC cost.
+const POLL_INTERVAL_MS = 3_000;
+
+// Main-side delivery cursor, retained ACROSS onInstall router re-creation
+// (reconnect/respawn). The bridge instance is disposable; the cursor is the
+// durable delivery position, so it lives in module scope.
+//
+// The cursor ALONE is not sufficient for exactly-once to the RENDERER, for two
+// reasons the cursor-pull guarantee (which is about the daemon↔main seam) does
+// not cover:
+//   (1) RENDERER reload — crash recovery / unresponsive recovery call
+//       mainWindow.reload() (main/index.ts), which wipes the renderer zustand
+//       store but leaves main (and this module-scope cursor) alive, so a plain
+//       pull returns nothing and the UI stays empty.
+//   (2) COLD START — start()'s first pull can run before useRemoteInboxBridge
+//       installs its onRemote listener, so that batch is sent into the void.
+// Both are recovered by the renderer-driven `resync()` handshake: the renderer
+// calls it on mount (AFTER its listener is installed); resync resets the cursor
+// to 0 and re-pulls the full live inbox, and the renderer's isNew guard makes
+// the replay idempotent. A full MAIN restart also resets this to 0 (module
+// re-eval) and is likewise safe.
+let lanlinkCursor = 0;
+
+/** Test-only: reset the module-scope cursor between cases. */
+export function __resetLanlinkCursorForTest(): void {
+  lanlinkCursor = 0;
+}
+
+/** Test-only: read the module-scope cursor. */
+export function __getLanlinkCursorForTest(): number {
+  return lanlinkCursor;
+}
+
+/**
+ * LanLink PR-2 — main-process cursor-pull bridge. Owns the pull loop and the
+ * read-only materialization tee. Triggers: connect (start → immediate pull),
+ * nudge ('lanlink:nudge' Node event from DaemonClient), and a short interval
+ * backstop. The daemon cannot emit to the renderer (the EventBus is main-only),
+ * so delivery starts in the daemon, crosses the broadcast/cursor-pull seam, and
+ * this bridge re-emits to the renderer over a DEDICATED IPC channel.
+ *
+ * **No-paste wall (the security crux):** the ONLY exit is
+ * `win.webContents.send(IPC.LANLINK_REMOTE, item)`. This module imports 0 of
+ * useRpcBridge / submitToPty / deliverPty* / _bridge / a2a.rpc — enforced by
+ * the source-scan test `remoteInboxNoPaste.test.ts`. An `origin:'remote'` item
+ * is therefore structurally read-only: it can never reach a terminal paste or
+ * the a2a execute path.
+ */
+export class RemoteInboxBridge {
+  private inFlight = false;
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private cleanups: Array<() => void> = [];
+  private client: DaemonClient | null = null;
+
+  constructor(private getWindow: () => BrowserWindow | null) {}
+
+  start(client: DaemonClient): void {
+    this.client = client;
+    const onNudge = (): void => {
+      void this.runPull();
+    };
+    client.on('lanlink:nudge', onNudge);
+    this.cleanups.push(() => client.off('lanlink:nudge', onNudge));
+    this.interval = setInterval(() => {
+      void this.runPull();
+    }, POLL_INTERVAL_MS);
+    // Pull immediately on (re)connect to replay anything that landed on disk
+    // while main was disconnected (C3 reconnect replay). The renderer's own
+    // resync() on mount covers the case where this first pull beats the
+    // renderer's listener.
+    void this.runPull();
+  }
+
+  /**
+   * Renderer-driven replay. useRemoteInboxBridge calls this on mount, AFTER its
+   * onRemote listener is installed. Resets the delivery cursor to 0 and re-pulls
+   * the full live inbox so a reloaded/just-mounted renderer re-materializes
+   * every record it is missing; the renderer's isNew guard dedups, so it is safe
+   * to call repeatedly. This is the fix for both the renderer-reload gap (store
+   * wiped while main+cursor survive) and the cold-start race (first pull before
+   * the listener exists).
+   */
+  resync(): void {
+    lanlinkCursor = 0;
+    void this.runPull();
+  }
+
+  stop(): void {
+    if (this.interval) clearInterval(this.interval);
+    this.interval = null;
+    for (const off of this.cleanups) {
+      try {
+        off();
+      } catch {
+        /* defensive — a cleanup must never throw out of stop() */
+      }
+    }
+    this.cleanups = [];
+    this.client = null;
+  }
+
+  private async runPull(): Promise<void> {
+    const client = this.client;
+    if (!client || !client.isConnected) return; // avoid RPC on a dead client
+    // Resolve the renderer BEFORE advancing the cursor: with no window to
+    // deliver to, we must not consume records — leave the cursor and retry on
+    // the next nudge/interval (the disk inbox keeps them).
+    const win = this.getWindow();
+    if (!win || win.isDestroyed()) return;
+    if (this.inFlight) return; // single concurrent pull
+    this.inFlight = true;
+    try {
+      const { items } = await client.inboxPoll(lanlinkCursor);
+      // Advance the cursor only past records the renderer ACTUALLY received.
+      // `materialize` returns false when the send was dropped (window destroyed
+      // or a mid-reload throw); we stop at the first failure so the undelivered
+      // tail is re-pulled on the next nudge/interval. Coupling cursor-advance to
+      // delivery success is what makes the renderer side exactly-once: a
+      // transient renderer outage can no longer silently skip a record.
+      let delivered = lanlinkCursor;
+      for (const rec of items) {
+        if (!this.materialize(win, rec)) break;
+        delivered = rec.seq;
+      }
+      if (delivered > lanlinkCursor) lanlinkCursor = delivered;
+    } catch {
+      // Swallow — the next nudge/interval retries (health-probe pattern). A
+      // failed pull leaves the cursor untouched so nothing is skipped.
+    } finally {
+      this.inFlight = false;
+    }
+  }
+
+  /**
+   * Materialize a durable record into a read-only renderer item and push it over
+   * the dedicated IPC.LANLINK_REMOTE channel. Returns true if the send was
+   * handed to a live renderer, false if it was dropped (destroyed window or a
+   * mid-reload throw) — the caller holds the cursor at the last delivered seq so
+   * a dropped record is re-pulled, never silently skipped. Length-clamped again
+   * defensively (the daemon already clamped on inject). NEVER touches
+   * submitToPty / deliverPty* / sendToRenderer('a2a.task.*').
+   */
+  private materialize(win: BrowserWindow, rec: InboxRecord): boolean {
+    if (win.isDestroyed()) return false;
+    const item: RemoteInboxItem = {
+      recordId: rec.id,
+      origin: 'remote',
+      peerName: clampText(rec.peerName, PEER_NAME_MAX),
+      text: clampText(rec.text, BODY_MAX),
+      seq: rec.seq,
+      receivedAt: rec.receivedAt,
+    };
+    try {
+      win.webContents.send(IPC.LANLINK_REMOTE, item);
+      return true;
+    } catch {
+      // renderer mid-reload: hold the cursor here; the next pull re-delivers and
+      // the renderer's isNew guard dedups any overlap.
+      return false;
+    }
+  }
+}

--- a/src/main/lanlink/__tests__/RemoteInboxBridge.test.ts
+++ b/src/main/lanlink/__tests__/RemoteInboxBridge.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import {
+  RemoteInboxBridge,
+  __resetLanlinkCursorForTest,
+  __getLanlinkCursorForTest,
+} from '../RemoteInboxBridge';
+import { IPC } from '../../../shared/constants';
+import type { InboxRecord } from '../../../shared/lanlink';
+import type { DaemonClient } from '../../DaemonClient';
+import type { BrowserWindow } from 'electron';
+
+function rec(seq: number, id = `id-${seq}`): InboxRecord {
+  return { id, seq, origin: 'remote', peerName: 'Peer', text: `msg ${seq}`, receivedAt: seq };
+}
+
+/** Minimal DaemonClient stand-in: an EventEmitter + isConnected + inboxPoll. */
+type MockClient = DaemonClient & { _connected: boolean; inboxPoll: ReturnType<typeof vi.fn> };
+function makeClient(): MockClient {
+  const ee = new EventEmitter() as EventEmitter & {
+    _connected: boolean;
+    inboxPoll: ReturnType<typeof vi.fn>;
+  };
+  ee._connected = true;
+  Object.defineProperty(ee, 'isConnected', { get: () => ee._connected });
+  ee.inboxPoll = vi.fn(async (cursor: number) => ({ items: [] as InboxRecord[], nextCursor: cursor }));
+  return ee as unknown as MockClient;
+}
+
+function makeWindow() {
+  const send = vi.fn();
+  const win = { isDestroyed: () => false, webContents: { send } } as unknown as BrowserWindow;
+  return { win, send };
+}
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+describe('RemoteInboxBridge', () => {
+  let bridges: RemoteInboxBridge[] = [];
+  beforeEach(() => {
+    __resetLanlinkCursorForTest();
+    bridges = [];
+  });
+  afterEach(() => {
+    for (const b of bridges) b.stop();
+  });
+  function track(b: RemoteInboxBridge): RemoteInboxBridge {
+    bridges.push(b);
+    return b;
+  }
+
+  it('M1: materializes pulled items over IPC.LANLINK_REMOTE and advances the cursor', async () => {
+    const client = makeClient();
+    client.inboxPoll = vi.fn(async (cursor: number) =>
+      cursor < 2 ? { items: [rec(1), rec(2)], nextCursor: 2 } : { items: [], nextCursor: cursor },
+    );
+    const { win, send } = makeWindow();
+    const bridge = track(new RemoteInboxBridge(() => win));
+    bridge.start(client);
+    await flush();
+
+    const lanlinkSends = send.mock.calls.filter((c) => c[0] === IPC.LANLINK_REMOTE);
+    expect(lanlinkSends).toHaveLength(2);
+    expect(lanlinkSends[0][1].recordId).toBe('id-1');
+    expect(lanlinkSends[0][1].origin).toBe('remote');
+    expect(lanlinkSends[1][1].seq).toBe(2);
+    expect(__getLanlinkCursorForTest()).toBe(2);
+    // NEVER the RPC_COMMAND paste path
+    expect(send.mock.calls.some((c) => c[0] === IPC.RPC_COMMAND)).toBe(false);
+  });
+
+  it('M1b: a re-pull of an already-acked cursor returns empty → no duplicate send (dup-0)', async () => {
+    const client = makeClient();
+    client.inboxPoll = vi.fn(async (cursor: number) =>
+      cursor < 1 ? { items: [rec(1)], nextCursor: 1 } : { items: [], nextCursor: cursor },
+    );
+    const { win, send } = makeWindow();
+    const bridge = track(new RemoteInboxBridge(() => win));
+    bridge.start(client);
+    await flush();
+    // A nudge re-pulls from cursor=1 → empty → no second materialize.
+    client.emit('lanlink:nudge', { seq: 1 });
+    await flush();
+    const lanlinkSends = send.mock.calls.filter((c) => c[0] === IPC.LANLINK_REMOTE);
+    expect(lanlinkSends).toHaveLength(1);
+  });
+
+  it('M2: concurrent pulls are guarded — only one inboxPoll in flight', async () => {
+    const client = makeClient();
+    let release!: (v: { items: InboxRecord[]; nextCursor: number }) => void;
+    client.inboxPoll = vi.fn(
+      () => new Promise<{ items: InboxRecord[]; nextCursor: number }>((r) => { release = r; }),
+    );
+    const { win } = makeWindow();
+    const bridge = track(new RemoteInboxBridge(() => win));
+    bridge.start(client); // immediate pull → inFlight
+    // Fire nudges while the first pull is pending — they must be dropped.
+    client.emit('lanlink:nudge', { seq: 1 });
+    client.emit('lanlink:nudge', { seq: 1 });
+    expect(client.inboxPoll).toHaveBeenCalledTimes(1);
+    release({ items: [], nextCursor: 0 });
+    await flush();
+  });
+
+  it('M5: a disconnected client is never polled', async () => {
+    const client = makeClient();
+    client._connected = false;
+    const { win } = makeWindow();
+    const bridge = track(new RemoteInboxBridge(() => win));
+    bridge.start(client);
+    await flush();
+    expect(client.inboxPoll).not.toHaveBeenCalled();
+  });
+
+  it('M5b: a missing window is never polled — cursor stays put for a later retry', async () => {
+    const client = makeClient();
+    client.inboxPoll = vi.fn(async () => ({ items: [rec(1)], nextCursor: 1 }));
+    const bridge = track(new RemoteInboxBridge(() => null));
+    bridge.start(client);
+    await flush();
+    expect(client.inboxPoll).not.toHaveBeenCalled();
+    expect(__getLanlinkCursorForTest()).toBe(0);
+  });
+
+  it('stop() unsubscribes the nudge listener (no pull after stop)', async () => {
+    const client = makeClient();
+    const { win } = makeWindow();
+    const bridge = new RemoteInboxBridge(() => win);
+    bridge.start(client);
+    await flush();
+    const before = client.inboxPoll.mock.calls.length;
+    bridge.stop();
+    client.emit('lanlink:nudge', { seq: 1 });
+    await flush();
+    expect(client.inboxPoll.mock.calls.length).toBe(before);
+  });
+
+  it('resync() resets the cursor to 0 and re-materializes the full inbox (renderer reload / cold start)', async () => {
+    const client = makeClient();
+    const all = [rec(1), rec(2), rec(3)];
+    client.inboxPoll = vi.fn(async (cursor: number) => ({
+      items: all.filter((r) => r.seq > cursor),
+      nextCursor: all.length ? all[all.length - 1].seq : cursor,
+    }));
+    const { win, send } = makeWindow();
+    const bridge = track(new RemoteInboxBridge(() => win));
+    bridge.start(client);
+    await flush();
+    expect(send.mock.calls.filter((c) => c[0] === IPC.LANLINK_REMOTE)).toHaveLength(3);
+    expect(__getLanlinkCursorForTest()).toBe(3);
+
+    // Simulate a renderer reload: the store is wiped, the renderer re-mounts and
+    // calls requestResync → bridge.resync(). The cursor resets and all 3 records
+    // re-materialize (the slice's isNew guard would dedup in the real renderer).
+    send.mockClear();
+    bridge.resync();
+    await flush();
+    const resent = send.mock.calls.filter((c) => c[0] === IPC.LANLINK_REMOTE);
+    expect(resent).toHaveLength(3);
+    expect(resent.map((c) => c[1].seq)).toEqual([1, 2, 3]);
+  });
+
+  it('a mid-batch send failure holds the cursor at the last delivered seq (no skip)', async () => {
+    const client = makeClient();
+    const batch = [rec(1), rec(2), rec(3)];
+    client.inboxPoll = vi.fn(async (cursor: number) => ({
+      items: batch.filter((r) => r.seq > cursor),
+      nextCursor: 3,
+    }));
+    let sends = 0;
+    const send = vi.fn(() => {
+      sends++;
+      if (sends === 2) throw new Error('Render frame was disposed'); // seq 2 drops
+    });
+    const win = { isDestroyed: () => false, webContents: { send } } as unknown as BrowserWindow;
+    const bridge = track(new RemoteInboxBridge(() => win));
+    bridge.start(client);
+    await flush();
+    // seq 1 delivered, seq 2 threw → loop breaks → cursor held at 1 (NOT advanced
+    // past the undelivered seq 2/3). They are re-pulled on the next nudge/interval.
+    expect(__getLanlinkCursorForTest()).toBe(1);
+    expect(send).toHaveBeenCalledTimes(2); // attempted 1 and 2, stopped before 3
+  });
+});

--- a/src/main/lanlink/__tests__/remoteInboxNoPaste.test.ts
+++ b/src/main/lanlink/__tests__/remoteInboxNoPaste.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Structural no-PTY-paste invariant (LanLink C5 / G3). The main-side remote-inbox
+// bridge must NEVER import the terminal-paste / execute machinery. A remote,
+// untrusted message is materialized as a read-only renderer item over a
+// DEDICATED IPC channel; if the bridge source cannot even reference submitToPty /
+// deliverPty* / useRpcBridge / a2a.rpc / the pipe _bridge, then an
+// origin:'remote' item has no code path to a terminal paste or the execute
+// funnel — no matter how the bridge evolves.
+//
+// Mirrors daemonExecuteWall.test.ts: a source-text assertion (importing the
+// modules for a runtime check would defeat the "can never reach this" point).
+
+const LANLINK_DIR = path.join(__dirname, '..');
+
+const FORBIDDEN: ReadonlyArray<{ pattern: RegExp; label: string }> = [
+  { pattern: /from\s+['"][^'"]*useRpcBridge['"]/, label: 'import of useRpcBridge' },
+  { pattern: /from\s+['"][^'"]*a2a\.rpc['"]/, label: 'import of a2a.rpc' },
+  { pattern: /from\s+['"][^'"]*\/_bridge['"]/, label: 'import of pipe _bridge (sendToRenderer)' },
+  // Call-form (not bare word), mirroring daemonExecuteWall's `execute\(` idiom:
+  // a doc-comment that NAMES these helpers as forbidden must not trip the scan.
+  // What we forbid is an actual call — and an import of their host module
+  // (useRpcBridge / pipe _bridge) is already caught by the `from` patterns above.
+  { pattern: /\bsubmitToPty\s*\(/, label: 'call to submitToPty' },
+  { pattern: /\bdeliverPtyNotification\s*\(/, label: 'call to deliverPtyNotification' },
+  { pattern: /\bdeliverPtyNudge\s*\(/, label: 'call to deliverPtyNudge' },
+];
+
+function collectTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+      out.push(...collectTsFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('remote-inbox no-PTY-paste wall (LanLink C5/G3)', () => {
+  const files = collectTsFiles(LANLINK_DIR);
+
+  it('finds main/lanlink source files to scan', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('no main/lanlink source imports the PTY-paste / execute machinery', () => {
+    const violations: string[] = [];
+    for (const f of files) {
+      const src = fs.readFileSync(f, 'utf-8');
+      for (const { pattern, label } of FORBIDDEN) {
+        if (pattern.test(src)) violations.push(`${path.relative(LANLINK_DIR, f)} — ${label}`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/src/main/mcp/methodCapabilityMap.ts
+++ b/src/main/mcp/methodCapabilityMap.ts
@@ -301,6 +301,9 @@ export const METHOD_CAPABILITY: Record<RpcMethod, RequiredCapability> = {
   // handler) after env-first ptyId resolution. External clients must never set a
   // pane's resume binding — same internal-only posture as supervision control.
   'daemon.setResumeBinding': { capability: 'wmux.internal' },
+  // LanLink PR-2 — cursor-pull of the durable remote inbox. main↔daemon only
+  // (DaemonClient → daemon control pipe); never an external MCP surface.
+  'daemon.inbox.poll':       { capability: 'wmux.internal' },
 
   // --- A2A (agent-to-agent) ---
   'a2a.resolve.identity': { capability: 'a2a.read',    riskClass: 'a2a' },

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -7,6 +7,7 @@ import type {
 } from '../shared/firstRun';
 import { isFileDrag } from '../shared/dragDrop';
 import type { ResumeBinding } from '../shared/agentResume';
+import type { RemoteInboxItem } from '../shared/lanlink';
 
 /** Mirrors {@link McpStatusPayload} in src/main/ipc/handlers/mcp.handler.ts. */
 export interface McpTargetStatusPayload {
@@ -551,6 +552,27 @@ document.addEventListener('DOMContentLoaded', () => {
     return () => {
       ipcRenderer.removeListener(IPC.PERMISSION_PROMPT_CLOSED, listener);
     };
+  },
+};
+
+// LanLink PR-2 — dedicated channel for materialized read-only REMOTE inbox
+// items. Mirrors the permissionPrompt bridge: main pushes over IPC.LANLINK_REMOTE
+// and the renderer's useRemoteInboxBridge projects into the remoteInbox slice.
+// A dedicated channel (NOT RPC_COMMAND) keeps a remote message structurally
+// unable to reach submitToPty / the a2a execute funnel.
+(electronAPI as Record<string, unknown>).lanlink = {
+  onRemote: (callback: (item: RemoteInboxItem) => void) => {
+    const listener = (_event: unknown, item: RemoteInboxItem) => callback(item);
+    ipcRenderer.on(IPC.LANLINK_REMOTE, listener);
+    return () => {
+      ipcRenderer.removeListener(IPC.LANLINK_REMOTE, listener);
+    };
+  },
+  // Renderer → main replay request. Fire AFTER the onRemote listener is
+  // installed so main re-pulls the full inbox from cursor 0 (reload / cold-start
+  // recovery; the renderer's isNew guard dedups).
+  requestResync: () => {
+    ipcRenderer.send(IPC.LANLINK_RESYNC);
   },
 };
 

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -31,6 +31,7 @@ import { useNotificationListener } from '../../hooks/useNotificationListener';
 import { useRpcBridge } from '../../hooks/useRpcBridge';
 import { useResizeGuard } from '../../hooks/useResizeGuard';
 import { useApprovalInboxBridge } from '../../hooks/useApprovalInboxBridge';
+import { useRemoteInboxBridge } from '../../hooks/useRemoteInboxBridge';
 import { usePaneDecorationChannel } from '../../plugins/usePaneDecorationChannel';
 import { useIpc } from '../../hooks/useIpc';
 import type { SessionData, PaneLeaf, Pane, Surface, Workspace } from '../../../shared/types';
@@ -296,6 +297,9 @@ export default function AppLayout() {
   // onClosed (guard #2). Always-on (not gated on fleetViewVisible) so MCP
   // prompts accumulate in the store before the cockpit's Approvals tab opens.
   useApprovalInboxBridge();
+  // LanLink PR-2 — own the remote-inbox subscription (always-on, mounted once)
+  // so remote peer messages accumulate in the store before any surface opens.
+  useRemoteInboxBridge();
   // Plugin host (B-1): ui.decoratePane push → uiSlice pane decorations.
   usePaneDecorationChannel();
   const { invoke: ipcInvoke } = useIpc();

--- a/src/renderer/hooks/useRemoteInboxBridge.ts
+++ b/src/renderer/hooks/useRemoteInboxBridge.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useStore } from '../stores';
+
+// ─── LanLink PR-2 Remote Inbox bridge ────────────────────────────────────────
+//
+// The SINGLE owner of the `lanlink.onRemote` subscription. Mounted ONCE in
+// AppLayout, always-on (NOT gated on any view), so remote peer messages
+// accumulate in the store regardless of which surface is visible.
+//
+// The action is read via useStore.getState() rather than a selector
+// subscription so the effect deps stay [] — the subscription is established
+// exactly once per renderer lifetime and torn down on unmount. Mirrors
+// useApprovalInboxBridge.
+export function useRemoteInboxBridge(): void {
+  useEffect(() => {
+    const api = window.electronAPI.lanlink;
+    if (!api) return; // older preload bundles may not expose this channel
+    const off = api.onRemote((item) => {
+      useStore.getState().addRemoteItem(item);
+    });
+    // Request a full replay AFTER the listener is installed. Re-materializes the
+    // inbox on a renderer reload (store wiped while main + cursor survive) and on
+    // cold start (main may have pulled before this listener existed). Idempotent
+    // — the slice's isNew guard dedups any overlap.
+    api.requestResync?.();
+    return off;
+  }, []);
+}

--- a/src/renderer/stores/index.ts
+++ b/src/renderer/stores/index.ts
@@ -14,8 +14,9 @@ import { createProjectConfigSlice, type ProjectConfigSlice } from './slices/proj
 import { createSupervisionSlice, type SupervisionSlice } from './slices/supervisionSlice';
 import { createResumeSlice, type ResumeSlice } from './slices/resumeSlice';
 import { createAgentToolbarSlice, type AgentToolbarSlice } from './slices/agentToolbarSlice';
+import { createRemoteInboxSlice, type RemoteInboxSlice } from './slices/remoteInboxSlice';
 
-export type StoreState = WorkspaceSlice & PaneSlice & SurfaceSlice & UISlice & NotificationSlice & A2aSlice & ApprovalInboxSlice & CompanySlice & ToastSlice & SearchSlice & ProjectConfigSlice & SupervisionSlice & ResumeSlice & AgentToolbarSlice;
+export type StoreState = WorkspaceSlice & PaneSlice & SurfaceSlice & UISlice & NotificationSlice & A2aSlice & ApprovalInboxSlice & CompanySlice & ToastSlice & SearchSlice & ProjectConfigSlice & SupervisionSlice & ResumeSlice & AgentToolbarSlice & RemoteInboxSlice;
 
 export const useStore = create<StoreState>()(
   immer((...args) => ({
@@ -33,5 +34,6 @@ export const useStore = create<StoreState>()(
     ...createSupervisionSlice(...args),
     ...createResumeSlice(...args),
     ...createAgentToolbarSlice(...args),
+    ...createRemoteInboxSlice(...args),
   }))
 );

--- a/src/renderer/stores/selectors/remoteInbox.ts
+++ b/src/renderer/stores/selectors/remoteInbox.ts
@@ -1,0 +1,24 @@
+import type { StoreState } from '../index';
+import type { RemoteInboxItem } from '../../../shared/lanlink';
+
+// ─── LanLink PR-2 Remote Inbox — render list ──────────────────────────────────
+//
+// Pure derivation (mirrors selectors/approvalInbox.ts): fold the recordId order
+// array into a render list, skipping any id missing from the record map. The
+// order array and record map are written together (addRemoteItem), but a torn
+// intermediate state must never crash a surface — so the skip-missing guard is
+// required. PR-5 builds the visual "remote peer" card on top of this list;
+// PR-2 stops at state + selector.
+
+/** Minimal store surface the selector reads — keeps the subscription narrow. */
+export type RemoteInboxState = Pick<StoreState, 'remoteItems' | 'remoteItemOrder'>;
+
+export function selectRemoteInbox(state: RemoteInboxState): RemoteInboxItem[] {
+  const out: RemoteInboxItem[] = [];
+  for (const id of state.remoteItemOrder) {
+    const item = state.remoteItems[id];
+    if (!item) continue; // torn-state guard — never crash on a missing record
+    out.push(item);
+  }
+  return out;
+}

--- a/src/renderer/stores/slices/__tests__/remoteInboxSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/remoteInboxSlice.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { createRemoteInboxSlice, type RemoteInboxSlice } from '../remoteInboxSlice';
+import { selectRemoteInbox } from '../../selectors/remoteInbox';
+import type { RemoteInboxItem } from '../../../../shared/lanlink';
+
+type TestState = RemoteInboxSlice;
+
+function createTestStore() {
+  return create<TestState>()(
+    immer((...args) => ({
+      // @ts-expect-error — minimal test store doesn't match full StoreState
+      ...createRemoteInboxSlice(...args),
+    })),
+  );
+}
+
+function makeItem(recordId: string, overrides: Partial<RemoteInboxItem> = {}): RemoteInboxItem {
+  return {
+    recordId,
+    origin: 'remote',
+    peerName: 'Peer',
+    text: 'hello',
+    seq: 1,
+    receivedAt: 1,
+    ...overrides,
+  };
+}
+
+describe('remoteInboxSlice', () => {
+  let store: ReturnType<typeof createTestStore>;
+  beforeEach(() => {
+    store = createTestStore();
+  });
+
+  it('starts empty', () => {
+    expect(store.getState().remoteItems).toEqual({});
+    expect(store.getState().remoteItemOrder).toEqual([]);
+  });
+
+  it('R1: addRemoteItem records + appends to order; idempotent on recordId (dup-0, latest-wins)', () => {
+    store.getState().addRemoteItem(makeItem('r1', { text: 'first' }));
+    store.getState().addRemoteItem(makeItem('r2'));
+    expect(store.getState().remoteItemOrder).toEqual(['r1', 'r2']);
+
+    // Re-pull the SAME recordId with newer text → no duplicate row, latest wins.
+    store.getState().addRemoteItem(makeItem('r1', { text: 'second' }));
+    expect(store.getState().remoteItemOrder).toEqual(['r1', 'r2']);
+    expect(store.getState().remoteItems['r1'].text).toBe('second');
+  });
+
+  it('R2: selectRemoteInbox folds order→items and skips a missing record (torn state)', () => {
+    store.getState().addRemoteItem(makeItem('r1'));
+    store.getState().addRemoteItem(makeItem('r2'));
+    expect(selectRemoteInbox(store.getState()).map((i) => i.recordId)).toEqual(['r1', 'r2']);
+
+    // Torn state: an order id with no record — the selector skips, never throws.
+    const torn = {
+      remoteItems: store.getState().remoteItems,
+      remoteItemOrder: ['r1', 'ghost', 'r2'],
+    };
+    expect(() => selectRemoteInbox(torn)).not.toThrow();
+    expect(selectRemoteInbox(torn).map((i) => i.recordId)).toEqual(['r1', 'r2']);
+  });
+});

--- a/src/renderer/stores/slices/remoteInboxSlice.ts
+++ b/src/renderer/stores/slices/remoteInboxSlice.ts
@@ -1,0 +1,49 @@
+import type { StateCreator } from 'zustand';
+import type { StoreState } from '../index';
+import type { RemoteInboxItem } from '../../../shared/lanlink';
+
+// ─── LanLink PR-2 Remote Inbox — renderer-aggregated remote peer messages ─────
+//
+// Off-machine peer messages arrive over the dedicated `lanlink.onRemote` IPC
+// channel (RemoteInboxBridge → preload), one materialized read-only item at a
+// time. This slice is the single renderer-side copy of "which remote messages
+// have arrived"; the bridge hook (useRemoteInboxBridge) owns the subscription
+// and dispatches addRemoteItem here. The selector (selectRemoteInbox) derives
+// the render list.
+//
+// Mirrors approvalInboxSlice: a parallel-pair (record map keyed by stable id +
+// an insertion-order array) with an `isNew` guard so a re-pull — reconnect or a
+// nudge-storm — never produces a duplicate row. `origin:'remote'` items are
+// UNTRUSTED: they are rendered as text, never pasted into a terminal (PR-5
+// builds the visual card; PR-2 stops at state).
+
+export interface RemoteInboxSlice {
+  /** recordId -> item. The authoritative record for each remote message. */
+  remoteItems: Record<string, RemoteInboxItem>;
+  /** Insertion order of recordIds; drives the list render order. */
+  remoteItemOrder: string[];
+
+  /** Idempotent on recordId: overwrites the item, appends to order only once. */
+  addRemoteItem: (item: RemoteInboxItem) => void;
+}
+
+export const createRemoteInboxSlice: StateCreator<
+  StoreState,
+  [['zustand/immer', never]],
+  [],
+  RemoteInboxSlice
+> = (set) => ({
+  remoteItems: {},
+  remoteItemOrder: [],
+
+  addRemoteItem: (item) => set((state: StoreState) => {
+    const isNew = !(item.recordId in state.remoteItems);
+    // Overwrite either way — an append-only record re-pulled on reconnect is
+    // byte-identical, so this is a harmless no-op; the order push is guarded so
+    // a duplicate id never produces a second row (dup-0).
+    state.remoteItems[item.recordId] = item;
+    if (isNew) {
+      state.remoteItemOrder.push(item.recordId);
+    }
+  }),
+});

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -75,6 +75,20 @@ export const IPC = {
   // the pluginHost deadlock-break, or a coalesced sibling). Lets the renderer
   // approval-inbox remove the row. Payload: { promptId }.
   PERMISSION_PROMPT_CLOSED: 'permission:prompt-closed',
+  // LanLink PR-2 — main → renderer push of a materialized read-only REMOTE
+  // inbox item (origin:'remote', off-machine peer). RemoteInboxBridge sends it
+  // after a daemon.inbox.poll; the renderer's useRemoteInboxBridge projects it
+  // into the remoteInbox slice. Deliberately a DEDICATED channel (like
+  // permissionPrompt) — never the RPC_COMMAND path — so a remote message is
+  // structurally incapable of reaching submitToPty / the a2a execute funnel.
+  // Payload: RemoteInboxItem.
+  LANLINK_REMOTE: 'lanlink:remote',
+  // LanLink PR-2 — renderer → main replay request. Fired by useRemoteInboxBridge
+  // on mount (AFTER its onRemote listener is installed). Main resets the
+  // RemoteInboxBridge delivery cursor to 0 and re-pulls, so a reloaded or
+  // just-mounted renderer re-materializes the full live inbox (isNew dedups).
+  // Closes the renderer-reload / cold-start delivery gap.
+  LANLINK_RESYNC: 'lanlink:resync',
   // Shell
   SHELL_OPEN_EXTERNAL: 'shell:open-external',
   // Open an absolute filesystem path in the OS default app / explorer.

--- a/src/shared/electron.d.ts
+++ b/src/shared/electron.d.ts
@@ -1,4 +1,5 @@
 import type { ElectronAPI, McpTargetStatusPayload } from '../preload/preload';
+import type { RemoteInboxItem } from './lanlink';
 import type {
   FirstRunCheckResult,
   RegisterMcpResult,
@@ -53,6 +54,18 @@ declare global {
         onClosed: (
           callback: (payload: { promptId: string }) => void,
         ) => () => void;
+      };
+      /**
+       * LanLink PR-2 — subscribe to materialized read-only REMOTE inbox items
+       * (origin:'remote', off-machine peer messages). Dedicated channel
+       * (mirrors permissionPrompt) so a remote message is structurally
+       * incapable of reaching the RPC_COMMAND → submitToPty paste path.
+       * Returns an unsubscribe fn.
+       */
+      lanlink?: {
+        onRemote: (callback: (item: RemoteInboxItem) => void) => () => void;
+        /** Renderer → main replay request; fire on mount after onRemote is set. */
+        requestResync: () => void;
       };
     };
     clipboardAPI: {

--- a/src/shared/lanlink.ts
+++ b/src/shared/lanlink.ts
@@ -1,0 +1,177 @@
+// === LanLink shared types (PR-2: inbound durable inbox + cursor-pull) ===
+//
+// Lives in `src/shared` so the daemon (lanlink/inbox.ts), the main process
+// (DaemonClient, RemoteInboxBridge) and the renderer (remoteInboxSlice) all
+// bind the SAME wire shapes without crossing a process boundary — and so the
+// daemon's tsconfig.daemon.json (rootDir: src, include src/daemon + src/shared)
+// keeps compiling without ever reaching into src/main.
+//
+// **No network code in PR-2.** These shapes describe a remote message AFTER it
+// has been synthetically injected (PR-2 test/dev path) or, in a future PR,
+// decoded + sanitized off the LAN transport (PR-4). The message is ALWAYS
+// `origin: 'remote'` and is treated as untrusted (G3): it is rendered as React
+// text and NEVER pasted into a PTY or routed to the a2a execute path.
+
+import type { TaskState } from './types';
+
+/**
+ * Fixed non-session sentinel for the `lanlink.remote.received` DaemonEvent.
+ * A remote message is not backed by any PTY session, but `DaemonEvent.sessionId`
+ * is a required string — so the daemon stamps this constant and the main-side
+ * DaemonClient `case` ignores it, reading only `data.seq`.
+ */
+export const LANLINK_SENTINEL_SESSION_ID = 'lanlink';
+
+/** Hard length clamp for a peer's display name (mirrors validateName default). */
+export const PEER_NAME_MAX = 100;
+/** Hard length clamp for a message body (the inbox holds the full text, not a preview). */
+export const BODY_MAX = 4000;
+/** FIFO bound on the on-disk inbox (PromptEventLog cap-256 precedent, doubled). */
+export const INBOX_CAP = 512;
+
+/**
+ * Durable, append-only inbox record (the on-disk + cursor-pull unit).
+ *
+ * `id` vs `seq` are deliberately distinct:
+ *   - `id`  — stable record id, the renderer's DEDUP key. PR-2: supplied by the
+ *             synthetic inject (a uuid). PR-4 transport assigns it at receipt.
+ *             NEVER derived from content, so a re-pull yields a byte-identical
+ *             id and projection stays idempotent.
+ *   - `seq` — daemon-assigned monotonic DELIVERY cursor. seq >= 1, strictly
+ *             increasing, never reused (even after FIFO eviction), never rewound.
+ */
+export interface InboxRecord {
+  id: string;
+  seq: number;
+  /** Always 'remote' in PR-2 — off-machine peer messages, untrusted (G3). */
+  origin: 'remote';
+  /** Sending peer's display name. Length-clamped to PEER_NAME_MAX. */
+  peerName: string;
+  /**
+   * Message body. TEXT ONLY (PR-2 scope) and length-clamped to BODY_MAX. It is
+   * NOT control-char sanitized in PR-2 (inject is text-only by assumption); the
+   * full ingress sanitizer is PR-4. Any surface that renders it MUST treat it as
+   * plain text (never paste it into a terminal).
+   */
+  text: string;
+  /** Receipt time (epoch ms), daemon-assigned. */
+  receivedAt: number;
+  /**
+   * Optional A2A-reuse: the conceptual task state for status rendering without
+   * execute. Reuses `TaskState` from shared/types.ts as the CONCEPTUAL model
+   * only — the inbox stores a text-only subset, never a full `Task` (whose
+   * open-ended metadata would over-widen the deserialization surface). PR-2
+   * inject defaults this to undefined; it is not required for delivery.
+   */
+  state?: TaskState;
+}
+
+/**
+ * On-disk inbox file shape. `nextSeq` is the monotonic counter persisted WITH
+ * the records so seq never resets across a daemon restart and is never reused.
+ */
+export interface InboxFile {
+  version: 1;
+  nextSeq: number;
+  /** Append-only, oldest-first. FIFO-evicted at INBOX_CAP. */
+  records: InboxRecord[];
+}
+
+/** Result of `LanLinkInbox.poll(cursor)` / `daemon.inbox.poll`. */
+export interface LanLinkInboxPollResult {
+  /** Records with `seq > cursor`, oldest-first. */
+  items: InboxRecord[];
+  /** `max(cursor, highest seq returned)` — never rewinds, even on empty. */
+  nextCursor: number;
+}
+
+/**
+ * Input to `LanLinkInbox.injectSynthetic`. The future PR-4 LAN receive path and
+ * the channels `deliver()` remote endpoint (roadmap §11) BOTH bottleneck on the
+ * same `LanLinkInbox.append()` — this synthetic input is merely the dev/test
+ * wrapper that fabricates the same record without a real peer.
+ */
+export interface SyntheticInjectInput {
+  /** Stable id; a uuid is minted when omitted. */
+  id?: string;
+  peerName: string;
+  text: string;
+  state?: TaskState;
+}
+
+/**
+ * Renderer-facing materialized item pushed over `IPC.LANLINK_REMOTE`. Distinct
+ * from `InboxRecord` (the durable wire/disk shape): the renderer only needs the
+ * display fields, and `recordId` is the slice dedup key.
+ */
+export interface RemoteInboxItem {
+  recordId: string;
+  origin: 'remote';
+  peerName: string;
+  text: string;
+  seq: number;
+  receivedAt: number;
+}
+
+/**
+ * Payload of the `lanlink.remote.received` DaemonEvent. FIRE-AND-FORGET NUDGE
+ * ONLY ("a remote message landed, re-pull"); it is NOT a delivery guarantee.
+ * Durability + exactly-once come from the disk inbox + `daemon.inbox.poll`
+ * cursor-pull, so a message that arrives while main is dead survives on disk
+ * and replays on reconnect.
+ */
+export interface LanLinkRemoteReceivedData {
+  seq: number;
+}
+
+/** Truncate `s` to at most `max` chars. Length clamp only (no content sanitize). */
+export function clampText(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) : s;
+}
+
+/**
+ * Load-time validator / type guard for the inbox file.
+ *
+ * #269 lesson (codex P1): a naive `typeof v === 'object'` map-check passes an
+ * ARRAY (`typeof [] === 'object'`), letting a corrupt/array-shaped file load as
+ * "healthy" and defeating the `.bak` recovery chain. So we **reject
+ * `Array.isArray(v)` FIRST**, then validate the object shape AND each record
+ * row (including strictly-increasing seq and `seq <= nextSeq`). A torn file with
+ * a rewound/duplicate seq, an array container, or a malformed row fails the
+ * guard → `atomicReadJSON*` falls through to `.bak`/`.bak.1..3`.
+ */
+export function isInboxFile(v: unknown): v is InboxFile {
+  if (Array.isArray(v)) return false; // #269 fix: an array is NOT a healthy file
+  if (typeof v !== 'object' || v === null) return false;
+  const o = v as Record<string, unknown>;
+  if (o['version'] !== 1) return false;
+  if (
+    typeof o['nextSeq'] !== 'number' ||
+    !Number.isInteger(o['nextSeq']) ||
+    (o['nextSeq'] as number) < 0
+  ) {
+    return false;
+  }
+  if (!Array.isArray(o['records'])) return false;
+  let prevSeq = 0;
+  for (const r of o['records'] as unknown[]) {
+    if (typeof r !== 'object' || r === null) return false;
+    const rec = r as Record<string, unknown>;
+    if (typeof rec['id'] !== 'string' || rec['id'].length === 0) return false;
+    if (typeof rec['seq'] !== 'number' || !Number.isInteger(rec['seq'])) return false;
+    if (rec['origin'] !== 'remote') return false;
+    if (typeof rec['peerName'] !== 'string') return false;
+    if (typeof rec['text'] !== 'string') return false;
+    if (typeof rec['receivedAt'] !== 'number' || !Number.isFinite(rec['receivedAt'])) return false;
+    // Strictly-increasing seq — drops a rewound/duplicate seq (replay defense).
+    if ((rec['seq'] as number) <= prevSeq) return false;
+    // seq can never exceed the persisted counter.
+    if ((rec['seq'] as number) > (o['nextSeq'] as number)) return false;
+    // NOTE: rec['state'] is intentionally NOT validated — in PR-2 it is never
+    // materialized to the renderer (RemoteInboxItem has no `state` field), so an
+    // unvalidated value is inert. If a future PR forwards record.state to any
+    // consumer, add an isTaskState guard for it here.
+    prevSeq = rec['seq'] as number;
+  }
+  return true;
+}

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -154,6 +154,7 @@ export type RpcMethod =
   | 'daemon.superviseRearm'
   | 'daemon.superviseStop'
   | 'daemon.setResumeBinding'
+  | 'daemon.inbox.poll'
   | 'a2a.resolve.identity'
   | 'a2a.whoami'
   | 'a2a.discover'
@@ -258,6 +259,7 @@ export const ALL_RPC_METHODS = [
   'daemon.superviseRearm',
   'daemon.superviseStop',
   'daemon.setResumeBinding',
+  'daemon.inbox.poll',
   'a2a.resolve.identity',
   'a2a.whoami',
   'a2a.discover',
@@ -339,7 +341,16 @@ export interface DaemonEvent {
     //   context.git   → { branch: string | null, isWorktree: boolean }
     //   context.ports → { ports: Array<{ port: number, pid: number }> }
     | 'context.git'
-    | 'context.ports';
+    | 'context.ports'
+    // LanLink PR-2 inbound durable inbox. FIRE-AND-FORGET NUDGE ONLY — the
+    // broadcast says "a remote message landed, re-pull"; it is NOT a delivery
+    // guarantee. Durability + exactly-once come from the disk inbox +
+    // daemon.inbox.poll cursor-pull (a message that arrives while main is dead
+    // survives on disk and replays on reconnect). `data` is
+    // LanLinkRemoteReceivedData ({ seq }); `sessionId` is the
+    // LANLINK_SENTINEL_SESSION_ID — no PTY session backs a remote message.
+    //   lanlink.remote.received → { seq: number }
+    | 'lanlink.remote.received';
   sessionId: string;
   data: unknown;
 }


### PR DESCRIPTION
## LanLink PR-2 — durable inbound inbox + cursor-pull backbone

Epic의 PR-2. 원격 peer 메시지가 main/렌더러가 죽어도 디스크에 살아남고 재연결 시 **정확히 한 번** 전달되는 뼈대. **네트워크 코드 0** — synthetic inject로 끝까지 테스트(LAN 전송/PAKE/AEAD는 PR-4, 비주얼 카드는 PR-5).

### 무엇을 만드나
- **daemon `LanLinkInbox`** (`src/daemon/lanlink/inbox.ts`) — append-only + monotonic `seq` + FIFO-bound + atomic write + `.bak` 복구 + **snapshot-then-commit**(in-memory 상태는 durable write 성공 후에만 갱신 → write throw 시 phantom record 0). validator는 `Array.isArray` 먼저 거부(#269 `.bak`-무력화 교훈) + strict row / strictly-increasing-seq / `seq<=nextSeq`.
- **`daemon.inbox.poll` RPC** = 전달 보증. **`lanlink.remote.received` broadcast** = fire-and-forget re-pull nudge일 뿐(replay 0).
- **main `RemoteInboxBridge`** — connect/nudge/interval pull → read-only `origin:'remote'` 아이템을 **전용 IPC 채널**(`lanlink.onRemote`, EventBus/RPC_COMMAND 아님)로 materialize. `submitToPty`/`deliverPty*`/a2a execute에 **구조적 도달 불가**(소스스캔 테스트). cursor는 렌더러가 실제 받은 record까지만 전진(드롭된 send는 재pull, skip 0).
- **renderer resync handshake** — `useRemoteInboxBridge`가 mount 시(리스너 설치 후) full replay 요청 → 렌더러 reload / cold-start서 inbox 재materialize(slice `isNew` dedup).
- **`__lanlink.inject`** dev/test 전용 RPC, positive NODE_ENV allowlist(`detectIsDev` 컨벤션) — packaged 빌드 미등록.
- **execute wall**: `src/daemon/lanlink/**` 가 ClaudeWorker/RpcRouter/a2a.rpc import 0(기존 `daemonExecuteWall` 자동 스캔).

### 검증
- tsc 4-config(json/daemon/mcp/cli) clean · vitest 풀스위트 green · **LanLink 유닛 31개**(durability / `.bak` 복구 / cursor monotonic / dup-0 / no-paste 소스스캔 / resync replay / snapshot-commit write-throw).
- 적대 **opus 패널**(6차원, 각 finding 독립 REFUTE) + **codex cross-model 게이트** → P1/P2 전부 수정: renderer-reload/cold-start replay 갭, dev-gate NODE_ENV 역전, cursor-vs-delivery 결합, append phantom record, receivedAt 비유한.

### 남은 것 (이 PR 밖)
- C3 durability **라이브 dogfood**(synthetic inject → main kill+restart → 재연결 cursor-pull replay → dup 0 / execute·PTY-paste 0): packaged exe + `WMUX_DATA_SUFFIX` 격리 필요.
- outbound `deliver()` 전송 인터페이스(channels U2 fanout 타깃) = PR-4-near.

플랜: `plans/lanlink-roadmap-2026-06-21.md` §4/§6, `plans/lanlink-p0-implementation-plan.md` §2.6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LANLink PR-2 remote inbox delivery with cursor-based polling, automatic notifications, and renderer resynchronization on reload/cold start.
* **Tests**
  * Added comprehensive Vitest coverage for durable inbox persistence, cursor behavior, IPC delivery, idempotent replay, and failure/retry scenarios.
* **Documentation**
  * Updated the generated API reference to include the new daemon inbox poll RPC method and method count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->