### PR TITLE
feat(lanlink): LanLinkServer core — net.Server + PIN-EKE + AEAD + allow-list router (PR-4)

### DIFF
--- a/src/daemon/__tests__/daemonExecuteWall.test.ts
+++ b/src/daemon/__tests__/daemonExecuteWall.test.ts
@@ -20,6 +20,14 @@ const FORBIDDEN: ReadonlyArray<{ pattern: RegExp; label: string }> = [
   { pattern: /from\s+['"][^'"]*\/RpcRouter['"]/, label: "import of RpcRouter" },
   { pattern: /from\s+['"][^'"]*a2a\.rpc['"]/, label: "import of a2a.rpc" },
   { pattern: /\bclaudeWorker\.execute\s*\(/, label: "call to claudeWorker.execute()" },
+  // LanLink PR-4 (C19): broaden the wall beyond the three named modules so the
+  // process boundary does not rest solely on the daemon tsconfig include list. The
+  // daemon legitimately imports pure helpers from src/main/pty (OSC/cwd/agent
+  // parsing), so a blanket src/main ban is impossible; instead we ban the execute
+  // MACHINERY trees — src/main/a2a (ClaudeWorker lives here) and src/main/pipe
+  // (RpcRouter + a2a.rpc live here). No daemon file imports from these today, and
+  // none ever should: that is exactly where a remote byte could reach execute.
+  { pattern: /from\s+['"][^'"]*\/main\/(a2a|pipe)\//, label: "import of src/main execute machinery (a2a/pipe)" },
 ];
 
 function collectTsFiles(dir: string): string[] {

--- a/src/daemon/__tests__/daemonExecuteWall.test.ts
+++ b/src/daemon/__tests__/daemonExecuteWall.test.ts
@@ -27,7 +27,10 @@ const FORBIDDEN: ReadonlyArray<{ pattern: RegExp; label: string }> = [
   // MACHINERY trees — src/main/a2a (ClaudeWorker lives here) and src/main/pipe
   // (RpcRouter + a2a.rpc live here). No daemon file imports from these today, and
   // none ever should: that is exactly where a remote byte could reach execute.
-  { pattern: /from\s+['"][^'"]*\/main\/(a2a|pipe)\//, label: "import of src/main execute machinery (a2a/pipe)" },
+  // Match both a deeper import (.../main/a2a/ClaudeWorker) AND a directory-index
+  // import (.../main/a2a) by requiring a2a/pipe to be followed by a slash OR the
+  // closing quote.
+  { pattern: /from\s+['"][^'"]*\/main\/(a2a|pipe)(\/|['"])/, label: "import of src/main execute machinery (a2a/pipe)" },
 ];
 
 function collectTsFiles(dir: string): string[] {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -9,6 +9,8 @@ import { SessionPipe } from './SessionPipe';
 import { StateWriter } from './StateWriter';
 import { LanLinkInbox } from './lanlink/inbox';
 import { LanLinkController } from './lanlink/controller';
+import { LanLinkServer } from './lanlink/server';
+import { PeerStore } from './lanlink/peers';
 import { coerceLanLinkPatch } from '../shared/lanlink';
 import { ProcessMonitor } from './ProcessMonitor';
 import { Watchdog } from './Watchdog';
@@ -967,6 +969,7 @@ function registerRpcHandlers(
   stateWriter: StateWriter,
   lanLinkInbox: LanLinkInbox,
   lanLinkController: LanLinkController,
+  lanLinkServer: LanLinkServer,
   sessionPipes: Map<string, SessionPipe>,
   processMonitor: ProcessMonitor,
   startTime: number,
@@ -1356,6 +1359,41 @@ function registerRpcHandlers(
   });
   pipeServer.onRpc('lanlink.configure', async (params) => {
     return lanLinkController.configure(coerceLanLinkPatch(params));
+  });
+
+  // LanLink PR-4 — pairing + peer control plane. Machine-local control-pipe RPCs
+  // (NOT origin-gated, NOT registered on the LAN net.Server, which carries framed
+  // bytes only). `pair.begin` mints a 6-digit PIN + arms the <=2min window;
+  // `pair.join`/`send` are the OUTBOUND initiator paths; `peers.remove` revokes a
+  // peer and destroys its live AEAD connection (C13). These are control-pipe RPCs,
+  // not RpcMethods — the renderer/Settings UI bridge for them is PR-5.
+  pipeServer.onRpc('lanlink.pair.begin', async () => lanLinkServer.beginPairing());
+  pipeServer.onRpc('lanlink.pair.status', async () => lanLinkServer.pairingStatus());
+  pipeServer.onRpc('lanlink.pair.cancel', async () => {
+    lanLinkServer.cancelPairing();
+    return { ok: true };
+  });
+  pipeServer.onRpc('lanlink.pair.join', async (params) => {
+    const host = typeof params['host'] === 'string' ? params['host'] : '';
+    const port = typeof params['port'] === 'number' ? params['port'] : 0;
+    const pin = typeof params['pin'] === 'string' ? params['pin'] : '';
+    if (!host || !port || !pin) throw new Error('lanlink.pair.join: host, port, and pin are required');
+    return lanLinkServer.joinPeer(host, port, pin);
+  });
+  pipeServer.onRpc('lanlink.send', async (params) => {
+    const host = typeof params['host'] === 'string' ? params['host'] : '';
+    const port = typeof params['port'] === 'number' ? params['port'] : 0;
+    const peerUuid = typeof params['peerUuid'] === 'string' ? params['peerUuid'] : '';
+    const text = typeof params['text'] === 'string' ? params['text'] : '';
+    if (!host || !port || !peerUuid) throw new Error('lanlink.send: host, port, and peerUuid are required');
+    await lanLinkServer.sendMessage(host, port, peerUuid, text);
+    return { ok: true };
+  });
+  pipeServer.onRpc('lanlink.peers.list', async () => ({ peers: lanLinkServer.listPeers() }));
+  pipeServer.onRpc('lanlink.peers.remove', async (params) => {
+    const peerUuid = typeof params['peerUuid'] === 'string' ? params['peerUuid'] : '';
+    if (peerUuid) lanLinkServer.revokePeer(peerUuid);
+    return { ok: true };
   });
 
   // __lanlink.inject — DEV/TEST ONLY synthetic inject (no real LAN peer). Gated
@@ -1792,6 +1830,9 @@ let disposeContextWatchers: (() => void) | null = null;
 
 /** X8: set in main(); shutdown() cancels pending supervised restarts through it. */
 let paneSupervisorRef: PaneSupervisor | null = null;
+// Module-level so the standalone shutdown() can dispose the LanLink listener
+// (close the net.Server, drop live connections, remove the firewall rules).
+let lanLinkServerRef: LanLinkServer | null = null;
 
 // === State builder ===
 
@@ -1874,6 +1915,10 @@ async function shutdown(
   // disposeAll. Policies stay persisted on the session meta; recovery
   // re-arms them on the next boot.
   try { paneSupervisorRef?.dispose(); } catch { /* best effort */ }
+
+  // LanLink PR-4: close the listener, drop live AEAD connections, remove firewall
+  // rules. Best-effort — must never block the shutdown path.
+  try { lanLinkServerRef?.dispose(); } catch { /* best effort */ }
   paneSupervisorRef = null;
 
   // Stop X1 context watchers (port poll timer + git fs.watch handles)
@@ -2011,6 +2056,32 @@ async function main(): Promise<void> {
   const pipeServer = new DaemonPipeServer(config.daemon.pipeName);
   const processMonitor = new ProcessMonitor();
 
+  // LanLink PR-4 — the network surface. An ISOLATED net.Server (its OWN admission
+  // counters, never the control pipe's = G1) bound to the configured NIC, with
+  // PIN-EKE pairing + AEAD + an allow-list router. `enabled` defaults OFF, so a
+  // listener exists only after the user opts in via Settings. Inbound messages
+  // decode -> sanitize -> LanLinkInbox.append (the PR-2 durable inbox) -> the SAME
+  // `lanlink.remote.received` nudge the dev __lanlink.inject fires. execute is
+  // physically impossible — the daemon imports 0 of the execute machinery
+  // (daemonExecuteWall.test.ts). The peer store's live-eviction guard reads back
+  // through the server lazily, to break the construction cycle.
+  const lanLinkPeers = new PeerStore(wmuxDir, {
+    isLive: (uuid) => lanLinkServerRef?.hasLiveConn(uuid) ?? false,
+  });
+  const lanLinkServer = new LanLinkServer({
+    inbox: lanLinkInbox,
+    controller: lanLinkController,
+    peers: lanLinkPeers,
+    selfName: os.hostname(),
+    nudge: (seq) =>
+      pipeServer.broadcast({
+        type: 'lanlink.remote.received',
+        sessionId: LANLINK_SENTINEL_SESSION_ID,
+        data: { seq },
+      }),
+  });
+  lanLinkServerRef = lanLinkServer;
+
   // Idle-shutdown config. Defaults: 5 min idle window + 60 s grace.
   // `WMUX_IDLE_SHUTDOWN_MS` and `WMUX_IDLE_GRACE_MS` env vars override
   // both — the dynamic test (scripts/daemon-idle-shutdown-dynamic.mjs)
@@ -2126,6 +2197,7 @@ async function main(): Promise<void> {
     stateWriter,
     lanLinkInbox,
     lanLinkController,
+    lanLinkServer,
     sessionPipes,
     processMonitor,
     startTime,

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1367,6 +1367,8 @@ function registerRpcHandlers(
   // `pair.join`/`send` are the OUTBOUND initiator paths; `peers.remove` revokes a
   // peer and destroys its live AEAD connection (C13). These are control-pipe RPCs,
   // not RpcMethods — the renderer/Settings UI bridge for them is PR-5.
+  const coercePort = (v: unknown): number =>
+    typeof v === 'number' && Number.isInteger(v) && v >= 1 && v <= 65535 ? v : 0;
   pipeServer.onRpc('lanlink.pair.begin', async () => lanLinkServer.beginPairing());
   pipeServer.onRpc('lanlink.pair.status', async () => lanLinkServer.pairingStatus());
   pipeServer.onRpc('lanlink.pair.cancel', async () => {
@@ -1375,14 +1377,14 @@ function registerRpcHandlers(
   });
   pipeServer.onRpc('lanlink.pair.join', async (params) => {
     const host = typeof params['host'] === 'string' ? params['host'] : '';
-    const port = typeof params['port'] === 'number' ? params['port'] : 0;
+    const port = coercePort(params['port']);
     const pin = typeof params['pin'] === 'string' ? params['pin'] : '';
     if (!host || !port || !pin) throw new Error('lanlink.pair.join: host, port, and pin are required');
     return lanLinkServer.joinPeer(host, port, pin);
   });
   pipeServer.onRpc('lanlink.send', async (params) => {
     const host = typeof params['host'] === 'string' ? params['host'] : '';
-    const port = typeof params['port'] === 'number' ? params['port'] : 0;
+    const port = coercePort(params['port']);
     const peerUuid = typeof params['peerUuid'] === 'string' ? params['peerUuid'] : '';
     const text = typeof params['text'] === 'string' ? params['text'] : '';
     if (!host || !port || !peerUuid) throw new Error('lanlink.send: host, port, and peerUuid are required');

--- a/src/daemon/lanlink/__tests__/aead.test.ts
+++ b/src/daemon/lanlink/__tests__/aead.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import crypto from 'node:crypto';
+import {
+  deriveSessionKeys,
+  AeadSealer,
+  AeadOpener,
+  AeadError,
+  AEAD_KEY_LEN,
+  AEAD_NONCE_LEN,
+} from '../aead';
+
+function mkSession() {
+  const longTerm = crypto.randomBytes(32);
+  const ee = crypto.randomBytes(32);
+  const helloNonce = crypto.randomBytes(16);
+  const respNonce = crypto.randomBytes(16);
+  return deriveSessionKeys(longTerm, ee, helloNonce, respNonce);
+}
+
+describe('aead — chacha20-poly1305 IETF channel', () => {
+  it('seal/open round-trips on the c2s direction', () => {
+    const { c2sKey } = mkSession();
+    const sealer = new AeadSealer(c2sKey, 1);
+    const opener = new AeadOpener(c2sKey, 1);
+    const pt = Buffer.from('hello over the lan', 'utf8');
+    const out = opener.open(sealer.seal(pt));
+    expect(out.equals(pt)).toBe(true);
+  });
+
+  it('rejects a tag-tampered record', () => {
+    const { c2sKey } = mkSession();
+    const rec = new AeadSealer(c2sKey, 1).seal(Buffer.from('x'));
+    rec[rec.length - 1] ^= 0x01; // flip a tag byte
+    expect(() => new AeadOpener(c2sKey, 1).open(rec)).toThrow(AeadError);
+  });
+
+  it('drops a replayed (non-increasing counter) record', () => {
+    const { c2sKey } = mkSession();
+    const sealer = new AeadSealer(c2sKey, 1);
+    const opener = new AeadOpener(c2sKey, 1);
+    const r1 = sealer.seal(Buffer.from('one'));
+    expect(opener.open(r1).toString()).toBe('one');
+    expect(() => opener.open(r1)).toThrow(/replay/i); // same counter again
+  });
+
+  it('a tag failure leaves lastCounter unchanged so the genuine next record opens (C17)', () => {
+    const { c2sKey } = mkSession();
+    const sealer = new AeadSealer(c2sKey, 1);
+    const opener = new AeadOpener(c2sKey, 1);
+    const r1 = sealer.seal(Buffer.from('a'));
+    const r2 = sealer.seal(Buffer.from('b'));
+    expect(opener.open(r1).toString()).toBe('a');
+    // forge a record at counter 2 with a bad tag -> AeadError, must NOT advance lastCounter
+    const forged = Buffer.from(r2);
+    forged[forged.length - 1] ^= 0xff;
+    expect(() => opener.open(forged)).toThrow(AeadError);
+    // the genuine counter-2 record still opens
+    expect(opener.open(r2).toString()).toBe('b');
+  });
+
+  it('separates keys by direction (c2s != s2c)', () => {
+    const s = mkSession();
+    expect(s.c2sKey.length).toBe(AEAD_KEY_LEN);
+    expect(s.s2cKey.length).toBe(AEAD_KEY_LEN);
+    expect(s.c2sKey.equals(s.s2cKey)).toBe(false);
+  });
+
+  it('deriveSessionKeys consumes ee — same (longTerm, nonces) yields DIFFERENT keys when ee differs (C2)', () => {
+    const longTerm = crypto.randomBytes(32);
+    const helloNonce = crypto.randomBytes(16);
+    const respNonce = crypto.randomBytes(16);
+    const a = deriveSessionKeys(longTerm, crypto.randomBytes(32), helloNonce, respNonce);
+    const b = deriveSessionKeys(longTerm, crypto.randomBytes(32), helloNonce, respNonce);
+    expect(a.c2sKey.equals(b.c2sKey)).toBe(false);
+  });
+
+  it('uses a 12-byte nonce space (record header is the 8-byte counter)', () => {
+    const { c2sKey } = mkSession();
+    const rec = new AeadSealer(c2sKey, 1).seal(Buffer.from('z'));
+    // record = [8B counter][ct][16B tag]; counter starts at 1
+    expect(rec.readBigUInt64BE(0)).toBe(1n);
+    expect(AEAD_NONCE_LEN).toBe(12);
+  });
+
+  it('rejects a too-short record', () => {
+    const { c2sKey } = mkSession();
+    expect(() => new AeadOpener(c2sKey, 1).open(Buffer.alloc(4))).toThrow(AeadError);
+  });
+});

--- a/src/daemon/lanlink/__tests__/dogfood.live.test.ts
+++ b/src/daemon/lanlink/__tests__/dogfood.live.test.ts
@@ -1,0 +1,163 @@
+// LIVE 1-machine real-net dogfood (gated on LANLINK_DOGFOOD_IP so CI skips it).
+// Runs a REAL net.Server bound to a REAL LAN IPv4 (C2 assertLanBindAddress must
+// actually pass) and drives it with the REAL net.connect client — exercising
+// PIN-EKE pairing, the AEAD channel, the allow-list router, durable inbox append,
+// and execute-impossibility over an actual TCP socket (not the in-memory fake).
+//
+//   LANLINK_DOGFOOD_IP=192.168.x.y npx vitest run src/daemon/lanlink/__tests__/dogfood.live.test.ts
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import net from 'node:net';
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+import { EventEmitter } from 'node:events';
+import { LanLinkServer } from '../server';
+import { pairWithPeer, sendToPeer } from '../client';
+import { PeerStore } from '../peers';
+import { LanLinkInbox } from '../inbox';
+import { ReconnectInitiator } from '../pairing';
+import { encodeFrame } from '../wire';
+import { AeadSealer } from '../aead';
+import type { PairResult } from '../pairing';
+
+const LAN_IP = process.env['LANLINK_DOGFOOD_IP'];
+const suite = LAN_IP ? describe : describe.skip;
+const PORT = 45000 + Math.floor(Math.random() * 1000);
+const PIN = '314159';
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const seam = { reHarden: () => true, secureWrite: (p: string, d: string) => fs.writeFileSync(p, d) };
+
+function mockController(nic: { name: string; mac: string }) {
+  return Object.assign(new EventEmitter(), {
+    getStatus: () => ({ enabled: true, nic, port: PORT, nics: [] }),
+  });
+}
+
+suite('LanLink LIVE real-net dogfood (1-machine, LAN IP)', () => {
+  let root: string;
+  let hostInboxDir: string;
+  let server: LanLinkServer;
+  let hostInbox: LanLinkInbox;
+  let hostPeers: PeerStore;
+  let joinPeers: PeerStore;
+  let nudges: number[];
+  let nic: { name: string; mac: string };
+
+  beforeAll(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'lanlink-live-'));
+    hostInboxDir = fs.mkdtempSync(path.join(root, 'host-'));
+    const ifs = os.networkInterfaces();
+    let found: { name: string; mac: string } | null = null;
+    for (const [name, addrs] of Object.entries(ifs)) {
+      for (const a of addrs || []) {
+        if (a.family === 'IPv4' && !a.internal && a.address === LAN_IP) found = { name, mac: a.mac };
+      }
+    }
+    if (!found) throw new Error(`LANLINK_DOGFOOD_IP ${LAN_IP} is not a live external IPv4`);
+    nic = found;
+    hostInbox = new LanLinkInbox(hostInboxDir);
+    hostPeers = new PeerStore(hostInboxDir, seam);
+    joinPeers = new PeerStore(fs.mkdtempSync(path.join(root, 'join-')), seam);
+    nudges = [];
+    server = new LanLinkServer({
+      inbox: hostInbox,
+      controller: mockController(nic) as never,
+      peers: hostPeers,
+      selfName: 'host-A',
+      nudge: (s) => nudges.push(s),
+      netCategory: () => 'Private',
+      firewall: { apply: async () => undefined, remove: async () => undefined },
+    });
+    await delay(80); // reconcile -> real listen on LAN_IP:PORT
+  });
+
+  afterAll(async () => {
+    server?.dispose();
+    await delay(50);
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  });
+
+  it('D7: the server is actually listening on the LAN IP (not loopback/wildcard)', () => {
+    const addr = server.boundAddress();
+    expect(addr).not.toBeNull();
+    expect(addr!.ip).toBe(LAN_IP);
+    expect(addr!.port).toBe(PORT);
+    expect(server.isListening()).toBe(true);
+  });
+
+  let paired: PairResult;
+  it('D1: pairs over a real TCP socket (PIN-EKE), both sides agree on the peer', async () => {
+    server.enterPairingMode(PIN);
+    paired = await pairWithPeer({ host: LAN_IP!, port: PORT, pin: PIN, selfName: 'joiner-B', peers: joinPeers });
+    expect(hostPeers.get(paired.peerUuid)).not.toBeNull();
+    expect(joinPeers.secretOf(paired.peerUuid)!.equals(hostPeers.secretOf(paired.peerUuid)!)).toBe(true);
+  });
+
+  it('D2: a read-only message lands in the durable inbox (origin:remote, sanitized) + nudge', async () => {
+    const before = hostInbox.size;
+    await sendToPeer({ host: LAN_IP!, port: PORT, peerUuid: paired.peerUuid, peers: joinPeers, selfName: 'joiner-B', text: 'live hello\x1b[31m!' });
+    await delay(60);
+    expect(hostInbox.size).toBe(before + 1);
+    const items = hostInbox.poll(before).items;
+    expect(items[0].origin).toBe('remote');
+    expect(items[0].text).toBe('live hello[31m!'); // ESC stripped
+    expect(nudges.length).toBeGreaterThan(0);
+  });
+
+  it('D7-persist: the inbox record survives a fresh LanLinkInbox load (daemon restart)', () => {
+    const reloaded = new LanLinkInbox(hostInboxDir);
+    expect(reloaded.size).toBeGreaterThan(0);
+    expect(reloaded.poll(0).items.some((r) => r.text.startsWith('live hello'))).toBe(true);
+  });
+
+  it('D5: an execute-kind message is rejected — never appended', async () => {
+    const before = hostInbox.size;
+    const secret = joinPeers.secretOf(paired.peerUuid)!;
+    const sock = net.connect({ host: LAN_IP!, port: PORT });
+    await new Promise<void>((res, rej) => {
+      sock.once('connect', () => res());
+      sock.once('error', rej);
+    });
+    const recon = new ReconnectInitiator(paired.peerUuid, secret);
+    const frames: Buffer[] = [];
+    sock.on('data', (c: Buffer) => frames.push(c));
+    sock.write(encodeFrame(0x04, recon.hello()));
+    await delay(80); // receive RECONNECT2
+    // parse the single RECONNECT2 frame
+    const buf = Buffer.concat(frames);
+    const len = buf.readUInt32BE(0);
+    const r2body = buf.subarray(5, 4 + len);
+    const keys = recon.onReconnect2(r2body);
+    const sealer = new AeadSealer(keys.c2sKey, 1);
+    const hostile = JSON.stringify({ kind: 'a2a.task.send', peerName: 'B', text: 'rm -rf /', senderSeq: 1, execute: true });
+    sock.write(encodeFrame(0x10, sealer.seal(Buffer.from(hostile))));
+    await delay(80);
+    sock.destroy();
+    expect(hostInbox.size).toBe(before); // execute kind never reached the inbox
+  });
+
+  it('D3: a wrong PIN is rejected over the real socket', async () => {
+    server.enterPairingMode(PIN);
+    await expect(
+      pairWithPeer({ host: LAN_IP!, port: PORT, pin: '000000', selfName: 'evil', peers: new PeerStore(fs.mkdtempSync(path.join(root, 'evil-')), seam) }),
+    ).rejects.toThrow();
+    expect(server.pairingStatus().failCount).toBeGreaterThan(0);
+  });
+
+  it('D8/G7: a first frame of 0x10 (no handshake) is dropped, inbox untouched', async () => {
+    const before = hostInbox.size;
+    const sock = net.connect({ host: LAN_IP!, port: PORT });
+    await new Promise<void>((res, rej) => {
+      sock.once('connect', () => res());
+      sock.once('error', rej);
+    });
+    sock.write(encodeFrame(0x10, Buffer.alloc(40)));
+    await delay(60);
+    sock.destroy();
+    expect(hostInbox.size).toBe(before);
+  });
+});

--- a/src/daemon/lanlink/__tests__/pairing.test.ts
+++ b/src/daemon/lanlink/__tests__/pairing.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { PairingInitiator, PairingResponder, deterministicPeerUuid } from '../pairing';
+import { AeadSealer, AeadOpener } from '../aead';
+
+async function runHandshake(joinPin: string, hostPin: string) {
+  const ini = new PairingInitiator(joinPin, 'B-joiner');
+  const res = new PairingResponder(hostPin, 'A-host');
+  const helloBody = ini.hello();
+  const pake2Body = await res.onHello(helloBody);
+  const { confirm, pending } = await ini.onPake2(pake2Body);
+  const r = res.onConfirm(confirm); // throws on wrong PIN
+  const iniResult = ini.verifyRespMac(r.respMac, pending);
+  return { ini, res, r, pending, iniResult };
+}
+
+describe('pairing — PIN-EKE double-masked handshake', () => {
+  it('correct PIN: both sides agree on longTermSecret, peerUuid, and session keys', async () => {
+    const { r, pending, iniResult } = await runHandshake('314159', '314159');
+    // shared long-term secret matches on both sides
+    expect(r.result.longTermSecret.equals(iniResult.longTermSecret)).toBe(true);
+    // peerUuid is deterministic and agreed by both sides
+    expect(r.result.peerUuid).toBe(iniResult.peerUuid);
+    // names crossed over
+    expect(r.result.peerName).toBe('B-joiner');
+    expect(iniResult.peerName).toBe('A-host');
+    // session keys agree across the two sides (so AEAD will interoperate)
+    expect(r.sessionKeys.c2sKey.equals(pending.sessionKeys.c2sKey)).toBe(true);
+    expect(r.sessionKeys.s2cKey.equals(pending.sessionKeys.s2cKey)).toBe(true);
+  });
+
+  it('the established AEAD session interoperates in both directions', async () => {
+    const { r, pending } = await runHandshake('271828', '271828');
+    // joiner -> host (c2s)
+    const c2sSeal = new AeadSealer(pending.sessionKeys.c2sKey, 1);
+    const c2sOpen = new AeadOpener(r.sessionKeys.c2sKey, 1);
+    expect(c2sOpen.open(c2sSeal.seal(Buffer.from('ping'))).toString()).toBe('ping');
+    // host -> joiner (s2c) — e.g. the respMac carrier
+    const s2cSeal = new AeadSealer(r.sessionKeys.s2cKey, 2);
+    const s2cOpen = new AeadOpener(pending.sessionKeys.s2cKey, 2);
+    expect(s2cOpen.open(s2cSeal.seal(r.respMac)).equals(r.respMac)).toBe(true);
+  });
+
+  it('wrong PIN: the handshake fails (no shared secret)', async () => {
+    await expect(runHandshake('000000', '999999')).rejects.toThrow();
+  });
+
+  it('PIN never appears in any wire frame', async () => {
+    const pin = '424242';
+    const ini = new PairingInitiator(pin, 'B');
+    const res = new PairingResponder(pin, 'A');
+    const helloBody = ini.hello();
+    const pake2Body = await res.onHello(helloBody);
+    const { confirm } = await ini.onPake2(pake2Body);
+    for (const frame of [helloBody, pake2Body, confirm]) {
+      expect(frame.toString('latin1')).not.toContain(pin);
+      // also check the raw bytes of the PIN's ascii form are not a contiguous run
+      expect(frame.includes(Buffer.from(pin, 'utf8'))).toBe(false);
+    }
+  });
+
+  it('deterministicPeerUuid is stable for a given pubkey and RFC4122-v5 shaped', () => {
+    const pub = Buffer.alloc(32, 7);
+    const u1 = deterministicPeerUuid(pub);
+    const u2 = deterministicPeerUuid(pub);
+    expect(u1).toBe(u2);
+    expect(u1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  it('tampering with PAKE2 breaks the confirm MAC', async () => {
+    const ini = new PairingInitiator('555555', 'B');
+    const res = new PairingResponder('555555', 'A');
+    const helloBody = ini.hello();
+    const pake2Body = await res.onHello(helloBody);
+    // flip a byte in the responder nonce region (offset 32..48) so the transcript differs
+    pake2Body[40] ^= 0xff;
+    await expect(
+      (async () => {
+        const { confirm } = await ini.onPake2(pake2Body);
+        res.onConfirm(confirm);
+      })(),
+    ).rejects.toThrow();
+  });
+});

--- a/src/daemon/lanlink/__tests__/peers.test.ts
+++ b/src/daemon/lanlink/__tests__/peers.test.ts
@@ -58,15 +58,22 @@ describe('peers — per-peer store', () => {
     expect(store().get('u1')).toBeNull();
   });
 
-  it('high-water persists; sendSeq is monotonic and persists (C8)', () => {
+  it('high-water persists; send seq peek/commit is monotonic + idempotent on retry (C8)', () => {
     const s = store();
     s.upsertPaired(mkResult('u1'));
     s.bumpHighWater('u1', 5);
     expect(s.highWater('u1')).toBe(5);
     expect(store().highWater('u1')).toBe(5);
-    expect(s.nextSendSeq('u1')).toBe(1);
-    expect(s.nextSendSeq('u1')).toBe(2);
-    expect(store().nextSendSeq('u1')).toBe(3);
+    // peek does NOT burn the seq — a failed/retried send reuses it
+    expect(s.peekSendSeq('u1') + 1).toBe(1);
+    expect(s.peekSendSeq('u1') + 1).toBe(1); // still 1 (not committed)
+    s.commitSendSeq('u1', 1);
+    expect(s.peekSendSeq('u1') + 1).toBe(2);
+    s.commitSendSeq('u1', 2);
+    expect(store().peekSendSeq('u1') + 1).toBe(3); // persisted
+    // committing a stale seq is a no-op
+    s.commitSendSeq('u1', 1);
+    expect(s.peekSendSeq('u1')).toBe(2);
   });
 
   it('get(__proto__) is null (Map-backed, C20)', () => {

--- a/src/daemon/lanlink/__tests__/peers.test.ts
+++ b/src/daemon/lanlink/__tests__/peers.test.ts
@@ -58,22 +58,16 @@ describe('peers — per-peer store', () => {
     expect(store().get('u1')).toBeNull();
   });
 
-  it('high-water persists; send seq peek/commit is monotonic + idempotent on retry (C8)', () => {
+  it('high-water persists; nextSendSeq reserves a DISTINCT monotonic seq per call (C8)', () => {
     const s = store();
     s.upsertPaired(mkResult('u1'));
     s.bumpHighWater('u1', 5);
     expect(s.highWater('u1')).toBe(5);
     expect(store().highWater('u1')).toBe(5);
-    // peek does NOT burn the seq — a failed/retried send reuses it
-    expect(s.peekSendSeq('u1') + 1).toBe(1);
-    expect(s.peekSendSeq('u1') + 1).toBe(1); // still 1 (not committed)
-    s.commitSendSeq('u1', 1);
-    expect(s.peekSendSeq('u1') + 1).toBe(2);
-    s.commitSendSeq('u1', 2);
-    expect(store().peekSendSeq('u1') + 1).toBe(3); // persisted
-    // committing a stale seq is a no-op
-    s.commitSendSeq('u1', 1);
-    expect(s.peekSendSeq('u1')).toBe(2);
+    // reserved immediately + distinct (concurrent sends never collide on one seq)
+    expect(s.nextSendSeq('u1')).toBe(1);
+    expect(s.nextSendSeq('u1')).toBe(2);
+    expect(store().nextSendSeq('u1')).toBe(3); // persisted across reload
   });
 
   it('get(__proto__) is null (Map-backed, C20)', () => {

--- a/src/daemon/lanlink/__tests__/peers.test.ts
+++ b/src/daemon/lanlink/__tests__/peers.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PeerStore, isPeerFile, PEER_BURN_THRESHOLD, PEER_CAP, type PeerStoreOptions } from '../peers';
+import type { PairResult } from '../pairing';
+
+// Test seam: skip the slow win32 PowerShell ACL shell-out.
+const seam: PeerStoreOptions = {
+  reHarden: () => true,
+  secureWrite: (p, d) => fs.writeFileSync(p, d),
+};
+
+function mkResult(uuid: string, secretByte = 1): PairResult {
+  return { peerUuid: uuid, peerName: 'P-' + uuid, longTermSecret: Buffer.alloc(32, secretByte) };
+}
+
+let dir: string;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lanlink-peers-'));
+});
+afterEach(() => {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+function store(): PeerStore {
+  return new PeerStore(dir, seam);
+}
+
+describe('peers — per-peer store', () => {
+  it('upsert + persist + reload preserves the record and secret', () => {
+    const s = store();
+    const res = mkResult('u1');
+    s.upsertPaired(res);
+    expect(s.get('u1')?.peerUuid).toBe('u1');
+    const s2 = store();
+    expect(s2.get('u1')?.peerUuid).toBe('u1');
+    expect(s2.secretOf('u1')!.equals(res.longTermSecret)).toBe(true);
+  });
+
+  it('burns after the threshold and stays burned across a reload', () => {
+    const s = store();
+    s.upsertPaired(mkResult('u1'));
+    for (let i = 0; i < PEER_BURN_THRESHOLD; i++) s.noteSteadyStateAuthFail('u1');
+    expect(s.get('u1')).toBeNull();
+    expect(store().get('u1')).toBeNull(); // survives restart (fsync'd)
+  });
+
+  it('revoke removes the peer durably', () => {
+    const s = store();
+    s.upsertPaired(mkResult('u1'));
+    s.revoke('u1');
+    expect(s.get('u1')).toBeNull();
+    expect(store().get('u1')).toBeNull();
+  });
+
+  it('high-water persists; sendSeq is monotonic and persists (C8)', () => {
+    const s = store();
+    s.upsertPaired(mkResult('u1'));
+    s.bumpHighWater('u1', 5);
+    expect(s.highWater('u1')).toBe(5);
+    expect(store().highWater('u1')).toBe(5);
+    expect(s.nextSendSeq('u1')).toBe(1);
+    expect(s.nextSendSeq('u1')).toBe(2);
+    expect(store().nextSendSeq('u1')).toBe(3);
+  });
+
+  it('get(__proto__) is null (Map-backed, C20)', () => {
+    expect(store().get('__proto__')).toBeNull();
+    expect(store().get('constructor')).toBeNull();
+  });
+
+  it('isPeerFile is Array.isArray-first and rejects extra/missing keys', () => {
+    expect(isPeerFile([])).toBe(false);
+    expect(isPeerFile({ version: 1, mac: 'x', peers: 'no' })).toBe(false);
+    expect(isPeerFile({ version: 1, mac: 'x', peers: [{ peerUuid: 'a' }] })).toBe(false); // missing keys
+    expect(isPeerFile({ version: 2, mac: 'x', peers: [] })).toBe(false);
+  });
+
+  it('rejects a file whose HMAC does not verify (planted/tampered) (C12)', () => {
+    const s = store();
+    s.upsertPaired(mkResult('u1'));
+    const fp = path.join(dir, 'lanlink', 'lanlink-peers.json');
+    const obj = JSON.parse(fs.readFileSync(fp, 'utf8'));
+    obj.mac = 'deadbeef';
+    fs.writeFileSync(fp, JSON.stringify(obj));
+    for (const ext of ['.bak', '.bak.1', '.bak.2', '.bak.3']) {
+      try {
+        fs.unlinkSync(fp + ext);
+      } catch {
+        /* none */
+      }
+    }
+    expect(store().get('u1')).toBeNull(); // HMAC failed -> fresh empty store
+  });
+
+  it('rejects a new pairing when the store is full and nothing is evictable (fail-closed)', () => {
+    const live = new Set<string>();
+    const s = new PeerStore(dir, { ...seam, isLive: (u) => live.has(u) });
+    for (let i = 0; i < PEER_CAP; i++) {
+      s.upsertPaired(mkResult('u' + i, (i % 250) + 1));
+      live.add('u' + i); // every paired peer holds a live connection
+    }
+    expect(() => s.upsertPaired(mkResult('uNEW'))).toThrow(/full/i);
+  });
+
+  it('LRU eviction at cap never drops a burned peer', () => {
+    const s = store();
+    s.upsertPaired(mkResult('u0'));
+    for (let i = 0; i < PEER_BURN_THRESHOLD; i++) s.noteSteadyStateAuthFail('u0');
+    for (let i = 1; i <= PEER_CAP + 5; i++) s.upsertPaired(mkResult('u' + i, (i % 250) + 1));
+    expect(store().list().some((p) => p.peerUuid === 'u0')).toBe(true);
+  });
+
+  it('list() never leaks the long-term secret', () => {
+    const s = store();
+    s.upsertPaired(mkResult('u1'));
+    const row = s.list()[0] as Record<string, unknown>;
+    expect('longTermSecret' in row).toBe(false);
+    expect(row['peerUuid']).toBe('u1');
+  });
+
+  it('a symlink at the store path leaves the pointee unmodified', () => {
+    const target = path.join(dir, 'secret.txt');
+    fs.writeFileSync(target, 'IMPORTANT');
+    fs.mkdirSync(path.join(dir, 'lanlink'), { recursive: true });
+    const link = path.join(dir, 'lanlink', 'lanlink-peers.json');
+    try {
+      fs.symlinkSync(target, link);
+    } catch {
+      return; // no symlink perms on this platform/run — skip
+    }
+    const s = new PeerStore(dir, seam);
+    s.upsertPaired(mkResult('u1'));
+    // atomicWrite renames a fresh tmp inode over the path, never writes through the link.
+    expect(fs.readFileSync(target, 'utf8')).toBe('IMPORTANT');
+  });
+});

--- a/src/daemon/lanlink/__tests__/router.test.ts
+++ b/src/daemon/lanlink/__tests__/router.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { ACCEPTED_KINDS, admitKind, isAcceptedKind, RouterError } from '../router';
+
+describe('router — inbound message-kind allow-list', () => {
+  it('accepts exactly msg.text and state.update', () => {
+    expect([...ACCEPTED_KINDS]).toEqual(['msg.text', 'state.update']);
+    expect(admitKind('msg.text')).toBe('msg.text');
+    expect(admitKind('state.update')).toBe('state.update');
+  });
+
+  it('rejects a2a.task.send, control methods, and any execute/spawn kind', () => {
+    for (const k of [
+      'a2a.task.send',
+      'a2a.task.update',
+      'execute',
+      'spawn',
+      'daemon.inbox.poll',
+      'lanlink.status',
+      'lanlink.configure',
+      'lanlink.pair.begin',
+      'lanlink.peers.remove',
+    ]) {
+      expect(() => admitKind(k)).toThrow(RouterError);
+    }
+  });
+
+  it('rejects prototype-chain keys (C20 — never an object-map index)', () => {
+    for (const k of ['__proto__', 'constructor', 'prototype', 'hasOwnProperty', 'toString', 'valueOf']) {
+      expect(isAcceptedKind(k)).toBe(false);
+      expect(() => admitKind(k)).toThrow(RouterError);
+    }
+  });
+
+  it('rejects non-strings', () => {
+    for (const k of [null, undefined, 1, {}, [], true]) {
+      expect(isAcceptedKind(k)).toBe(false);
+      expect(() => admitKind(k)).toThrow(RouterError);
+    }
+  });
+
+  it('drift-lock: no accepted kind carries an execute/spawn/send/task substring', () => {
+    for (const k of ACCEPTED_KINDS) {
+      expect(/execute|spawn|send|task|exec|run/i.test(k)).toBe(false);
+    }
+  });
+});

--- a/src/daemon/lanlink/__tests__/sanitize.test.ts
+++ b/src/daemon/lanlink/__tests__/sanitize.test.ts
@@ -60,7 +60,7 @@ describe('sanitize — ingress sanitizer (C16)', () => {
     expect(sanitizeRemoteText('ok' + ch(0xd800))).toBe('ok');
   });
 
-  it('never throws on 2000 fuzzed inputs (incl. lone surrogates / full BMP+)', () => {
+  it('never throws on 2000 fuzzed inputs (incl. lone surrogates, across the BMP)', () => {
     for (let i = 0; i < 2000; i++) {
       const n = i % 60;
       let s = '';

--- a/src/daemon/lanlink/__tests__/sanitize.test.ts
+++ b/src/daemon/lanlink/__tests__/sanitize.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeRemoteText, sanitizeRemotePeerName, hasResidualControl } from '../sanitize';
+
+// Build every control / invisible codepoint with String.fromCharCode so the
+// source file stays printable ASCII (no literal invisible characters).
+const ch = (...codes: number[]) => String.fromCharCode(...codes);
+const ESC = ch(0x1b);
+const BEL = ch(0x07);
+const TAB = ch(0x09);
+
+describe('sanitize — ingress sanitizer (C16)', () => {
+  it('normalizes CR/LF to a single space (no welding)', () => {
+    expect(sanitizeRemoteText('l1\nl2')).toBe('l1 l2');
+    expect(sanitizeRemoteText('a\r\nb')).toBe('a b');
+  });
+
+  it('normalizes U+2028/U+2029 line/paragraph separators to a space', () => {
+    expect(sanitizeRemoteText('a' + ch(0x2028) + 'b')).toBe('a b');
+    expect(sanitizeRemoteText('a' + ch(0x2029) + 'b')).toBe('a b');
+    expect(hasResidualControl('a' + ch(0x2028) + 'b')).toBe(true);
+  });
+
+  it('strips C0 except TAB', () => {
+    expect(sanitizeRemoteText('a' + ch(0x00) + 'b' + TAB + 'c')).toBe('ab' + TAB + 'c');
+    expect(sanitizeRemoteText('a' + ch(0x0b) + 'b' + ch(0x0c) + 'c')).toBe('abc');
+  });
+
+  it('strips DEL (0x7F)', () => {
+    expect(sanitizeRemoteText('a' + ch(0x7f) + 'b')).toBe('ab');
+  });
+
+  it('strips C1 including the 8-bit CSI 0x9B', () => {
+    expect(sanitizeRemoteText('a' + ch(0x9b) + '31mb')).toBe('a31mb');
+  });
+
+  it('strips a lone ESC', () => {
+    expect(sanitizeRemoteText('a' + ESC + 'b')).toBe('ab');
+  });
+
+  it('strips an OSC sequence (incl. its intro ESC)', () => {
+    expect(sanitizeRemoteText('a' + ESC + ']0;window-title' + BEL + 'b')).toBe('ab');
+  });
+
+  it('strips zero-width + bidi isolates (Trojan-Source U+2066-2069) + ALM U+061C', () => {
+    expect(sanitizeRemoteText('a' + ch(0x200b) + 'b' + ch(0x2066) + 'c' + ch(0x2069) + 'd' + ch(0x061c) + 'e')).toBe('abcde');
+    expect(sanitizeRemoteText('x' + ch(0x202e) + 'y')).toBe('xy');
+  });
+
+  it('strips invisible Hangul fillers', () => {
+    expect(sanitizeRemoteText('Alice' + ch(0x3164))).toBe('Alice');
+    expect(sanitizeRemoteText(ch(0x115f, 0x1160, 0xffa0) + 'z')).toBe('z');
+  });
+
+  it('clamps the body to 4000 and the name to 100, never throwing', () => {
+    expect(sanitizeRemoteText('x'.repeat(10000)).length).toBe(4000);
+    expect(sanitizeRemotePeerName('y'.repeat(500)).length).toBe(100);
+  });
+
+  it('drops a trailing lone high surrogate', () => {
+    expect(sanitizeRemoteText('ok' + ch(0xd800))).toBe('ok');
+  });
+
+  it('never throws on 2000 fuzzed inputs (incl. lone surrogates / full BMP+)', () => {
+    for (let i = 0; i < 2000; i++) {
+      const n = i % 60;
+      let s = '';
+      for (let j = 0; j < n; j++) s += ch((i * 7 + j * 13) % 0x11000);
+      expect(() => sanitizeRemoteText(s)).not.toThrow();
+      expect(() => sanitizeRemotePeerName(s)).not.toThrow();
+    }
+  });
+
+  it('hasResidualControl flags a planted isolate / ESC but passes clean text + TAB', () => {
+    expect(hasResidualControl('a' + ch(0x2066) + 'b')).toBe(true);
+    expect(hasResidualControl('a' + ESC + 'b')).toBe(true);
+    expect(hasResidualControl('clean text' + TAB + 'with tab')).toBe(false);
+  });
+});

--- a/src/daemon/lanlink/__tests__/server.test.ts
+++ b/src/daemon/lanlink/__tests__/server.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { LanLinkServer } from '../server';
+import { pairWithPeer, sendToPeer } from '../client';
+import { PeerStore } from '../peers';
+import { FrameReader, encodeFrame, type FrameType } from '../wire';
+import { ReconnectInitiator } from '../pairing';
+import { AeadSealer, AeadOpener } from '../aead';
+import type { InboxRecord } from '../../../shared/lanlink';
+
+// ── in-memory cross-wired socket pair ─────────────────────────────────────────
+class FakeSocket extends EventEmitter {
+  destroyed = false;
+  remoteAddress = '192.168.1.50';
+  peer: FakeSocket | null = null;
+  write(buf: Buffer): boolean {
+    const copy = Buffer.from(buf);
+    if (this.peer && !this.peer.destroyed) {
+      const p = this.peer;
+      setImmediate(() => {
+        if (!p.destroyed) p.emit('data', copy);
+      });
+    }
+    return true;
+  }
+  destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.emit('close');
+    if (this.peer && !this.peer.destroyed) this.peer.destroy();
+  }
+  setTimeout(): void {
+    /* no-op */
+  }
+  setEncoding(): void {
+    /* no-op */
+  }
+  setNoDelay(): void {
+    /* no-op */
+  }
+}
+function pair(): [FakeSocket, FakeSocket] {
+  const a = new FakeSocket();
+  const b = new FakeSocket();
+  a.peer = b;
+  b.peer = a;
+  return [a, b];
+}
+
+const MOCK_IFACES = () => ({
+  eth0: [
+    {
+      address: '192.168.1.10',
+      family: 'IPv4',
+      internal: false,
+      mac: 'aa:bb:cc:dd:ee:ff',
+      netmask: '255.255.255.0',
+      cidr: '192.168.1.10/24',
+      scopeid: 0,
+    },
+  ],
+}) as unknown as NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+
+const NIC = { name: 'eth0', mac: 'aa:bb:cc:dd:ee:ff' };
+
+function mockController(enabled: boolean) {
+  const ee = new EventEmitter();
+  return Object.assign(ee, {
+    getStatus: () => ({ enabled, nic: NIC, port: null, nics: [] }),
+  });
+}
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+let tmpRoot: string;
+function mkPeers(): PeerStore {
+  const dir = fs.mkdtempSync(path.join(tmpRoot, 'peers-'));
+  // Skip the slow win32 PowerShell owner-DACL shell-out so the handshake tests
+  // stay well under the default test timeout even under full-suite parallelism.
+  return new PeerStore(dir, { reHarden: () => true, secureWrite: (p, d) => fs.writeFileSync(p, d) });
+}
+
+interface Harness {
+  server: LanLinkServer;
+  onConn: (s: FakeSocket) => void;
+  serverPeers: PeerStore;
+  appended: Omit<InboxRecord, 'seq'>[];
+  nudges: number[];
+}
+
+async function makeServer(): Promise<Harness> {
+  const serverPeers = mkPeers();
+  const appended: Omit<InboxRecord, 'seq'>[] = [];
+  const nudges: number[] = [];
+  let seq = 0;
+  let onConn: ((s: FakeSocket) => void) | null = null;
+  const fakeNetServer = {
+    on() {
+      /* no-op */
+    },
+    listen() {
+      /* no-op */
+    },
+    close(cb?: () => void) {
+      cb?.();
+    },
+  };
+  const server = new LanLinkServer({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    inbox: { append: (rec: Omit<InboxRecord, 'seq'>) => { appended.push(rec); return { seq: ++seq }; } } as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    controller: mockController(true) as any,
+    nudge: (s: number) => nudges.push(s),
+    peers: serverPeers,
+    selfName: 'A-host',
+    ifaces: MOCK_IFACES,
+    netCategory: () => 'Private',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    createServer: (cb: (s: any) => void) => { onConn = cb as (s: FakeSocket) => void; return fakeNetServer as any; },
+    firewall: {
+      apply: async () => {
+        /* no-op */
+      },
+      remove: async () => {
+        /* no-op */
+      },
+    },
+  });
+  await delay(30); // let the reconcile chain create the server + capture onConn
+  return { server, onConn: (s) => onConn!(s), serverPeers, appended, nudges };
+}
+
+/** Drive a happy-path pairing from a fresh client against the armed server. */
+async function doPair(h: Harness, clientPeers: PeerStore, pin: string) {
+  const [clientSock, serverSock] = pair();
+  h.onConn(serverSock);
+  return pairWithPeer({ host: 'x', port: 1, pin, selfName: 'B-joiner', peers: clientPeers, connect: () => clientSock });
+}
+
+// minimal client-side frame collector for crafting hostile records
+class Collector {
+  private reader = new FrameReader();
+  private q: { type: FrameType; body: Buffer }[] = [];
+  private waiter: ((f: { type: FrameType; body: Buffer }) => void) | null = null;
+  constructor(sock: FakeSocket) {
+    sock.on('data', (c: Buffer) => {
+      this.reader.push(c);
+      let f;
+      while ((f = this.reader.next()) !== null) {
+        if (this.waiter) {
+          const w = this.waiter;
+          this.waiter = null;
+          w(f);
+        } else this.q.push(f);
+      }
+    });
+  }
+  next(): Promise<{ type: FrameType; body: Buffer }> {
+    const queued = this.q.shift();
+    if (queued) return Promise.resolve(queued);
+    return new Promise((res) => (this.waiter = res));
+  }
+}
+
+/** Reconnect manually and return a sealer/opener so a test can craft any record. */
+async function openAeadChannel(h: Harness, peerUuid: string, secret: Buffer) {
+  const [clientSock, serverSock] = pair();
+  h.onConn(serverSock);
+  const col = new Collector(clientSock);
+  const recon = new ReconnectInitiator(peerUuid, secret);
+  clientSock.write(encodeFrame(0x04, recon.hello()));
+  const r2 = await col.next();
+  const keys = recon.onReconnect2(r2.body);
+  return {
+    sealer: new AeadSealer(keys.c2sKey, 1),
+    opener: new AeadOpener(keys.s2cKey, 2),
+    sendRaw: (obj: unknown) => clientSock.write(encodeFrame(0x10, new AeadSealer(keys.c2sKey, 1).seal(Buffer.from(JSON.stringify(obj))))),
+    clientSock,
+    col,
+  };
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'lanlink-srv-'));
+});
+afterEach(() => {
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe('LanLinkServer — inbound responder state machine', () => {
+  it('pairs and both sides agree on the peer; secrets match', async () => {
+    const h = await makeServer();
+    h.server.enterPairingMode('123456');
+    const clientPeers = mkPeers();
+    const result = await doPair(h, clientPeers, '123456');
+    const onServer = h.serverPeers.get(result.peerUuid);
+    expect(onServer).not.toBeNull();
+    expect(h.serverPeers.secretOf(result.peerUuid)!.equals(result.longTermSecret)).toBe(true);
+    h.server.dispose();
+  });
+
+  it('delivers a message into the durable inbox as origin:remote, sanitized, with a deterministic id + nudge', async () => {
+    const h = await makeServer();
+    h.server.enterPairingMode('123456');
+    const clientPeers = mkPeers();
+    const result = await doPair(h, clientPeers, '123456');
+    await sendToPeer({ host: 'x', port: 1, peerUuid: result.peerUuid, peers: clientPeers, selfName: 'B', text: 'hi\x1b[31m there', connect: () => { const [c, s] = pair(); h.onConn(s); return c; } });
+    expect(h.appended.length).toBe(1);
+    const rec = h.appended[0];
+    expect(rec.origin).toBe('remote');
+    expect(rec.text).toBe('hi[31m there'); // ESC stripped, CSI body remains as text
+    expect(rec.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(h.nudges.length).toBe(1);
+    h.server.dispose();
+  });
+
+  it('REJECTS an execute-kind app message — never appended, peer burn-bounded (C1/router)', async () => {
+    const h = await makeServer();
+    h.server.enterPairingMode('123456');
+    const clientPeers = mkPeers();
+    const result = await doPair(h, clientPeers, '123456');
+    const ch = await openAeadChannel(h, result.peerUuid, clientPeers.secretOf(result.peerUuid)!);
+    ch.sendRaw({ kind: 'a2a.task.send', peerName: 'B', text: 'rm -rf', senderSeq: 1, execute: true });
+    await delay(40);
+    expect(h.appended.length).toBe(0); // never reaches the inbox
+    h.server.dispose();
+  });
+
+  it('REJECTS a file/data part (text-only subset) — never appended', async () => {
+    const h = await makeServer();
+    h.server.enterPairingMode('123456');
+    const clientPeers = mkPeers();
+    const result = await doPair(h, clientPeers, '123456');
+    const ch = await openAeadChannel(h, result.peerUuid, clientPeers.secretOf(result.peerUuid)!);
+    ch.sendRaw({ kind: 'msg.text', peerName: 'B', text: 'x', senderSeq: 1, file: { bytes: 'AAAA' } });
+    await delay(40);
+    expect(h.appended.length).toBe(0);
+    h.server.dispose();
+  });
+
+  it('drops a cross-connection replay (senderSeq <= highWater) — no duplicate inbox row (C8)', async () => {
+    const h = await makeServer();
+    h.server.enterPairingMode('123456');
+    const clientPeers = mkPeers();
+    const result = await doPair(h, clientPeers, '123456');
+    const secret = clientPeers.secretOf(result.peerUuid)!;
+    const ch1 = await openAeadChannel(h, result.peerUuid, secret);
+    ch1.sendRaw({ kind: 'msg.text', peerName: 'B', text: 'first', senderSeq: 1 });
+    await delay(40);
+    expect(h.appended.length).toBe(1);
+    // fresh connection, SAME senderSeq → dropped
+    const ch2 = await openAeadChannel(h, result.peerUuid, secret);
+    ch2.sendRaw({ kind: 'msg.text', peerName: 'B', text: 'replay', senderSeq: 1 });
+    await delay(40);
+    expect(h.appended.length).toBe(1); // still 1
+    h.server.dispose();
+  });
+
+  it('a first frame of 0x10 (no handshake) is destroyed before any inbox touch (G7)', async () => {
+    const h = await makeServer();
+    const [clientSock, serverSock] = pair();
+    h.onConn(serverSock);
+    clientSock.write(encodeFrame(0x10, Buffer.alloc(40)));
+    await delay(40);
+    expect(h.appended.length).toBe(0);
+    expect(serverSock.destroyed).toBe(true);
+    h.server.dispose();
+  });
+
+  it('revoke destroys the live connection and refuses the next reconnect (C13)', async () => {
+    const h = await makeServer();
+    h.server.enterPairingMode('123456');
+    const clientPeers = mkPeers();
+    const result = await doPair(h, clientPeers, '123456');
+    const secret = clientPeers.secretOf(result.peerUuid)!;
+    h.server.revokePeer(result.peerUuid);
+    // a reconnect with the (now revoked) peerUuid is refused before any AEAD
+    const [clientSock, serverSock] = pair();
+    h.onConn(serverSock);
+    const recon = new ReconnectInitiator(result.peerUuid, secret);
+    clientSock.write(encodeFrame(0x04, recon.hello()));
+    await delay(40);
+    expect(serverSock.destroyed).toBe(true);
+    h.server.dispose();
+  });
+
+  it('wrong PIN fails the join and increments the window fail count', async () => {
+    const h = await makeServer();
+    h.server.enterPairingMode('123456');
+    const clientPeers = mkPeers();
+    await expect(doPair(h, clientPeers, '000000')).rejects.toThrow();
+    expect(h.server.pairingStatus().failCount).toBe(1);
+    h.server.dispose();
+  });
+
+  it('a closed pairing window destroys a PAKE_HELLO before scrypt (no pairing)', async () => {
+    const h = await makeServer();
+    // window NOT armed
+    const clientPeers = mkPeers();
+    await expect(doPair(h, clientPeers, '123456')).rejects.toThrow();
+    expect(h.serverPeers.list().length).toBe(0);
+    h.server.dispose();
+  });
+});

--- a/src/daemon/lanlink/__tests__/wire.test.ts
+++ b/src/daemon/lanlink/__tests__/wire.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import {
+  FrameReader,
+  encodeFrame,
+  safeJsonParse,
+  decodeAppMessage,
+  WireError,
+  MAX_FRAME,
+  MAX_JSON_DEPTH,
+  LEN_BYTES,
+} from '../wire';
+
+describe('wire — framing', () => {
+  it('encodes and reads back a frame', () => {
+    const r = new FrameReader();
+    r.push(encodeFrame(0x10, Buffer.from('hello')));
+    const f = r.next();
+    expect(f?.type).toBe(0x10);
+    expect(f?.body.toString()).toBe('hello');
+    expect(r.next()).toBeNull();
+  });
+
+  it('reassembles a frame split across chunks', () => {
+    const frame = encodeFrame(0x01, Buffer.from('abc'));
+    const r = new FrameReader();
+    r.push(frame.subarray(0, 3));
+    expect(r.next()).toBeNull();
+    r.push(frame.subarray(3));
+    expect(r.next()?.body.toString()).toBe('abc');
+  });
+
+  it('rejects a declared length > MAX_FRAME (G1)', () => {
+    const r = new FrameReader();
+    const buf = Buffer.alloc(LEN_BYTES);
+    buf.writeUInt32BE(MAX_FRAME + 1, 0);
+    r.push(buf);
+    expect(() => r.next()).toThrow(WireError);
+  });
+
+  it('allows legitimate back-to-back frames but rejects a gross backlog overflow (G1)', () => {
+    const r = new FrameReader(64);
+    // back-to-back (a full frame plus the start of the next) is fine
+    expect(() => r.push(Buffer.alloc(64 + LEN_BYTES + 1))).not.toThrow();
+    // a gross overflow well past the hard ceiling (4 * maxFrame) is rejected
+    const r2 = new FrameReader(64);
+    expect(() => r2.push(Buffer.alloc(4 * 64 + 1))).toThrow(WireError);
+  });
+
+  it('rejects an unknown frame type', () => {
+    const body = Buffer.from('x');
+    const out = Buffer.alloc(LEN_BYTES + 1 + body.length);
+    out.writeUInt32BE(1 + body.length, 0);
+    out.writeUInt8(0x09, LEN_BYTES); // 0x09 is not a valid frame type
+    body.copy(out, LEN_BYTES + 1);
+    const r = new FrameReader();
+    r.push(out);
+    expect(() => r.next()).toThrow(WireError);
+  });
+});
+
+describe('wire — safeJsonParse', () => {
+  it('drops prototype-pollution keys', () => {
+    const v = safeJsonParse(Buffer.from('{"a":1,"__proto__":{"polluted":true}}')) as Record<string, unknown>;
+    expect(v['a']).toBe(1);
+    expect(Object.getPrototypeOf(v)).toBe(Object.prototype);
+    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+  });
+
+  it('rejects a deep-nesting bomb before JSON.parse (C11)', () => {
+    const depth = MAX_JSON_DEPTH + 5;
+    const bomb = '['.repeat(depth) + ']'.repeat(depth);
+    expect(() => safeJsonParse(Buffer.from(bomb))).toThrow(WireError);
+  });
+
+  it('rejects invalid JSON', () => {
+    expect(() => safeJsonParse(Buffer.from('{not json'))).toThrow(WireError);
+  });
+});
+
+describe('wire — decodeAppMessage (text-only restricted subset)', () => {
+  const base = { kind: 'msg.text', peerName: 'B', text: 'hi', senderSeq: 1 };
+
+  it('decodes a valid text message', () => {
+    const m = decodeAppMessage(Buffer.from(JSON.stringify(base)));
+    expect(m.kind).toBe('msg.text');
+    expect(m.text).toBe('hi');
+    expect(m.senderSeq).toBe(1);
+    expect(m.state).toBeUndefined();
+  });
+
+  it('rejects any disallowed key (file/data/parts/mimeType/bytes/execute)', () => {
+    for (const extra of [
+      { file: { bytes: 'AA' } },
+      { data: { x: 1 } },
+      { parts: [] },
+      { mimeType: 'image/png' },
+      { bytes: 'AA' },
+      { uri: 'http://x' },
+      { execute: true },
+      { metadata: {} },
+    ]) {
+      expect(() => decodeAppMessage(Buffer.from(JSON.stringify({ ...base, ...extra })))).toThrow(WireError);
+    }
+  });
+
+  it('rejects a non-object, non-string fields, and a bad senderSeq', () => {
+    expect(() => decodeAppMessage(Buffer.from('[]'))).toThrow(WireError);
+    expect(() => decodeAppMessage(Buffer.from(JSON.stringify({ ...base, text: 1 })))).toThrow(WireError);
+    expect(() => decodeAppMessage(Buffer.from(JSON.stringify({ ...base, peerName: null })))).toThrow(WireError);
+    expect(() => decodeAppMessage(Buffer.from(JSON.stringify({ ...base, senderSeq: -1 })))).toThrow(WireError);
+    expect(() => decodeAppMessage(Buffer.from(JSON.stringify({ ...base, senderSeq: 1.5 })))).toThrow(WireError);
+  });
+
+  it('drops an invalid state but attaches a valid TaskState (C10)', () => {
+    expect(decodeAppMessage(Buffer.from(JSON.stringify({ ...base, state: 'bogus' }))).state).toBeUndefined();
+    expect(decodeAppMessage(Buffer.from(JSON.stringify({ ...base, state: 'constructor' }))).state).toBeUndefined();
+    expect(decodeAppMessage(Buffer.from(JSON.stringify({ ...base, state: 'working' }))).state).toBe('working');
+  });
+});

--- a/src/daemon/lanlink/aead.ts
+++ b/src/daemon/lanlink/aead.ts
@@ -1,0 +1,152 @@
+// === LanLink AEAD channel (PR-4, chacha20-poly1305 IETF) ===
+//
+// Native node:crypto only. XChaCha20 (192-bit nonce) is NOT native — we use the
+// IETF chacha20-poly1305 (96-bit / 12-byte nonce, 16-byte tag, 32-byte key).
+//
+// THE CRUX (C2): session keys derive from a FRESH per-connection ephemeral X25519
+// DH (`ee`), never a pure function of (longTermSecret, nonces). With the counter
+// reset to 1 on every connection, a key that was a pure function of long-term
+// material + nonces would re-use (key, nonce=1) whenever the nonces collided —
+// a two-time pad + Poly1305-key disclosure. Binding fresh `ee` makes every
+// connection's key unique even if both nonces AND the RNG collide.
+
+import crypto from 'node:crypto';
+
+export const AEAD_KEY_LEN = 32;
+export const AEAD_NONCE_LEN = 12;
+export const AEAD_TAG_LEN = 16;
+export const COUNTER_MAX = 2n ** 63n; // C17 overflow ceiling (fits a signed-safe u64 window)
+
+const COUNTER_BYTES = 8;
+const HKDF_HASH = 'sha256';
+const AEAD_VERSION_BYTE = 1; // mirrors wire.WIRE_VERSION; part of the AEAD AAD
+const AEAD_CIPHER_BYTE = 1; // mirrors wire.CIPHER_ID; part of the AEAD AAD
+
+/** 1 = client->server (c2s), 2 = server->client (s2c). */
+export type Direction = 1 | 2;
+
+export interface SessionKeys {
+  c2sKey: Buffer;
+  s2cKey: Buffer;
+}
+
+export class AeadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AeadError';
+  }
+}
+
+/** HKDF-SHA256 returning a Buffer (hkdfSync yields an ArrayBuffer — MUST wrap). */
+function hkdf(ikm: Buffer, salt: Buffer, info: string, len: number): Buffer {
+  return Buffer.from(crypto.hkdfSync(HKDF_HASH, ikm, salt, info, len));
+}
+
+/**
+ * The ONLY factory for SessionKeys (C2 hard invariant). It CONSUMES the fresh
+ * per-connection ephemeral DH output `ee`, so a fresh AeadSealer/AeadOpener
+ * (counter reset to 1) is always backed by single-use key material. Direction
+ * separation is by KEY (distinct HKDF labels c2s/s2c), the load-bearing
+ * guarantee; the nonce direction tag is defense-in-depth.
+ */
+export function deriveSessionKeys(
+  longTermSecret: Buffer,
+  ee: Buffer,
+  helloNonce: Buffer,
+  respNonce: Buffer,
+): SessionKeys {
+  const sessionIkm = hkdf(
+    longTermSecret,
+    Buffer.concat([ee, helloNonce, respNonce]),
+    'wmux-lanlink/v1 session',
+    32,
+  );
+  return {
+    c2sKey: hkdf(sessionIkm, ee, 'wmux-lanlink/v1 c2s', AEAD_KEY_LEN),
+    s2cKey: hkdf(sessionIkm, ee, 'wmux-lanlink/v1 s2c', AEAD_KEY_LEN),
+  };
+}
+
+/** nonce(12B) = directionTag(u32be) || counter(u64be). */
+function nonceFor(direction: Direction, counter: bigint): Buffer {
+  const n = Buffer.alloc(AEAD_NONCE_LEN);
+  n.writeUInt32BE(direction, 0);
+  n.writeBigUInt64BE(counter, 4);
+  return n;
+}
+
+/** AAD binds version || cipherId || direction || counter (C17). */
+function aadFor(direction: Direction, counter: bigint): Buffer {
+  const aad = Buffer.alloc(3 + COUNTER_BYTES);
+  aad.writeUInt8(AEAD_VERSION_BYTE, 0);
+  aad.writeUInt8(AEAD_CIPHER_BYTE, 1);
+  aad.writeUInt8(direction, 2);
+  aad.writeBigUInt64BE(counter, 3);
+  return aad;
+}
+
+/** Outbound sealer. Counter starts at 1; record = [u64be counter][ct][16B tag]. */
+export class AeadSealer {
+  private counter = 0n;
+
+  constructor(private readonly key: Buffer, private readonly direction: Direction) {
+    if (key.length !== AEAD_KEY_LEN) throw new AeadError('AEAD seal key must be 32 bytes');
+  }
+
+  seal(plaintext: Buffer): Buffer {
+    const counter = this.counter + 1n;
+    if (counter > COUNTER_MAX) throw new AeadError('AEAD counter overflow'); // BEFORE nonce derive (C17)
+    const nonce = nonceFor(this.direction, counter);
+    const aad = aadFor(this.direction, counter);
+    const cipher = crypto.createCipheriv('chacha20-poly1305', this.key, nonce, {
+      authTagLength: AEAD_TAG_LEN,
+    });
+    cipher.setAAD(aad, { plaintextLength: plaintext.length });
+    const ct = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    this.counter = counter; // advance only after a successful seal
+    const header = Buffer.alloc(COUNTER_BYTES);
+    header.writeBigUInt64BE(counter, 0);
+    return Buffer.concat([header, ct, tag]);
+  }
+}
+
+/** Inbound opener. Drops a non-increasing counter (replay) BEFORE deciphering. */
+export class AeadOpener {
+  private lastCounter = 0n;
+
+  constructor(private readonly key: Buffer, private readonly direction: Direction) {
+    if (key.length !== AEAD_KEY_LEN) throw new AeadError('AEAD open key must be 32 bytes');
+  }
+
+  open(record: Buffer): Buffer {
+    if (record.length < COUNTER_BYTES + AEAD_TAG_LEN) {
+      throw new AeadError('AEAD record too short');
+    }
+    const counter = record.readBigUInt64BE(0);
+    // Replay defense: counter check BEFORE any decipher work, and lastCounter is
+    // advanced ONLY after final() succeeds (C17) — so a tag/AAD failure can never
+    // poison the high-water mark and let a real next record be wrongly dropped.
+    if (counter <= this.lastCounter) {
+      throw new AeadError('AEAD counter not strictly increasing (replay)');
+    }
+    if (counter > COUNTER_MAX) throw new AeadError('AEAD counter exceeds max');
+    const tag = record.subarray(record.length - AEAD_TAG_LEN);
+    const ct = record.subarray(COUNTER_BYTES, record.length - AEAD_TAG_LEN);
+    const nonce = nonceFor(this.direction, counter);
+    const aad = aadFor(this.direction, counter);
+    const decipher = crypto.createDecipheriv('chacha20-poly1305', this.key, nonce, {
+      authTagLength: AEAD_TAG_LEN,
+    });
+    decipher.setAAD(aad, { plaintextLength: ct.length });
+    decipher.setAuthTag(tag);
+    let pt: Buffer;
+    try {
+      pt = Buffer.concat([decipher.update(ct), decipher.final()]);
+    } catch {
+      throw new AeadError('AEAD tag verification failed'); // lastCounter UNCHANGED
+    }
+    this.lastCounter = counter;
+    return pt;
+  }
+}

--- a/src/daemon/lanlink/client.ts
+++ b/src/daemon/lanlink/client.ts
@@ -1,0 +1,161 @@
+// === LanLink outbound client (PR-4) — pairing-join + message-send ===
+//
+// The OUTBOUND half: connect to a peer daemon's LanLinkServer to JOIN a pairing
+// (initiator side of the PIN-EKE) or to SEND a read-only message (reconnect +
+// AEAD record). The crypto lives in pairing.ts/aead.ts; this is the net plumbing.
+// connect is injectable so the handshake can be exercised in-memory against a
+// LanLinkServer without a real socket (the bind guard forbids loopback).
+//
+// Imports node:net/stream + sibling lanlink files only — execute-wall clean.
+
+import net from 'node:net';
+import type { EventEmitter } from 'node:events';
+import { FrameReader, encodeFrame, type FrameType } from './wire';
+import { PairingInitiator, ReconnectInitiator, type PairResult } from './pairing';
+import { AeadSealer, AeadOpener } from './aead';
+import type { PeerStore } from './peers';
+import type { TaskState } from '../../shared/types';
+
+const HELLO: FrameType = 0x01;
+const PAKE2: FrameType = 0x02;
+const CONFIRM: FrameType = 0x03;
+const RECONNECT_HELLO: FrameType = 0x04;
+const RECONNECT2: FrameType = 0x05;
+const AEAD_RECORD: FrameType = 0x10;
+
+const FRAME_TIMEOUT_MS = 6_000;
+
+/** Minimal socket surface this client needs — satisfied by net.Socket and by an
+ *  in-memory fake in tests (the bind guard forbids real loopback). */
+export type LanLinkSocket = Pick<EventEmitter, 'on'> & {
+  write(data: Buffer): unknown;
+  destroy(): void;
+};
+export type ConnectFn = (host: string, port: number) => LanLinkSocket;
+
+const defaultConnect: ConnectFn = (host, port) => net.connect({ host, port });
+
+/** Ordered async frame reader over a socket, with timeout + error/close failure. */
+class FrameStream {
+  private reader = new FrameReader();
+  private queue: { type: FrameType; body: Buffer }[] = [];
+  private waiters: { resolve: (f: { type: FrameType; body: Buffer }) => void; reject: (e: Error) => void; timer: NodeJS.Timeout }[] = [];
+  private failed: Error | null = null;
+
+  constructor(socket: LanLinkSocket) {
+    socket.on('data', (chunk: Buffer) => {
+      try {
+        this.reader.push(chunk);
+        let f: { type: FrameType; body: Buffer } | null;
+        while ((f = this.reader.next()) !== null) {
+          const w = this.waiters.shift();
+          if (w) {
+            clearTimeout(w.timer);
+            w.resolve(f);
+          } else {
+            this.queue.push(f);
+          }
+        }
+      } catch (err) {
+        this.fail(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+    socket.on('error', (err) => this.fail(err instanceof Error ? err : new Error(String(err))));
+    socket.on('close', () => this.fail(new Error('connection closed')));
+  }
+
+  private fail(err: Error): void {
+    if (this.failed) return;
+    this.failed = err;
+    for (const w of this.waiters.splice(0)) {
+      clearTimeout(w.timer);
+      w.reject(err);
+    }
+  }
+
+  next(expected: FrameType): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const done = (f: { type: FrameType; body: Buffer }) => {
+        if (f.type !== expected) reject(new Error(`expected frame 0x${expected.toString(16)}, got 0x${f.type.toString(16)}`));
+        else resolve(f.body);
+      };
+      const queued = this.queue.shift();
+      if (queued) return done(queued);
+      if (this.failed) return reject(this.failed);
+      const timer = setTimeout(() => reject(new Error('LanLink client: frame timeout')), FRAME_TIMEOUT_MS);
+      this.waiters.push({ resolve: done, reject, timer });
+    });
+  }
+}
+
+export interface PairJoinOptions {
+  host: string;
+  port: number;
+  pin: string;
+  selfName: string;
+  peers: PeerStore;
+  connect?: ConnectFn;
+}
+
+/** JOIN a pairing the peer armed with `enterPairingMode`. Persists on success. */
+export async function pairWithPeer(opts: PairJoinOptions): Promise<PairResult> {
+  const socket = (opts.connect ?? defaultConnect)(opts.host, opts.port);
+  const stream = new FrameStream(socket);
+  try {
+    const ini = new PairingInitiator(opts.pin, opts.selfName);
+    socket.write(encodeFrame(HELLO, ini.hello()));
+    const pake2 = await stream.next(PAKE2);
+    const { confirm, pending } = await ini.onPake2(pake2);
+    socket.write(encodeFrame(CONFIRM, confirm));
+    const firstAead = await stream.next(AEAD_RECORD);
+    // Responder sends respMac via the s2c direction; joiner opens it as s2c.
+    const respMac = new AeadOpener(pending.sessionKeys.s2cKey, 2).open(firstAead);
+    const result = ini.verifyRespMac(respMac, pending);
+    opts.peers.upsertPaired(result);
+    return result;
+  } finally {
+    socket.destroy();
+  }
+}
+
+export interface SendOptions {
+  host: string;
+  port: number;
+  peerUuid: string;
+  peers: PeerStore;
+  selfName: string;
+  text: string;
+  kind?: 'msg.text' | 'state.update';
+  state?: TaskState;
+  connect?: ConnectFn;
+}
+
+/** Reconnect (no scrypt) + send one read-only AEAD record; await the app ACK. */
+export async function sendToPeer(opts: SendOptions): Promise<{ delivered: boolean }> {
+  const secret = opts.peers.secretOf(opts.peerUuid);
+  if (!secret) throw new Error(`sendToPeer: unknown or burned peer ${opts.peerUuid}`);
+  const socket = (opts.connect ?? defaultConnect)(opts.host, opts.port);
+  const stream = new FrameStream(socket);
+  try {
+    const recon = new ReconnectInitiator(opts.peerUuid, secret);
+    socket.write(encodeFrame(RECONNECT_HELLO, recon.hello()));
+    const r2 = await stream.next(RECONNECT2);
+    const keys = recon.onReconnect2(r2);
+    const sealer = new AeadSealer(keys.c2sKey, 1); // joiner -> host (c2s)
+    const opener = new AeadOpener(keys.s2cKey, 2);
+    const senderSeq = opts.peers.nextSendSeq(opts.peerUuid);
+    const appMsg = JSON.stringify({
+      kind: opts.kind ?? 'msg.text',
+      peerName: opts.selfName,
+      text: opts.text,
+      senderSeq,
+      ...(opts.state !== undefined ? { state: opts.state } : {}),
+    });
+    socket.write(encodeFrame(AEAD_RECORD, sealer.seal(Buffer.from(appMsg, 'utf8'))));
+    const ack = await stream.next(AEAD_RECORD);
+    opener.open(ack); // authenticate the ACK (throws on tamper)
+    return { delivered: true };
+  } finally {
+    socket.destroy();
+  }
+}

--- a/src/daemon/lanlink/client.ts
+++ b/src/daemon/lanlink/client.ts
@@ -11,7 +11,7 @@
 import net from 'node:net';
 import type { EventEmitter } from 'node:events';
 import { FrameReader, encodeFrame, type FrameType } from './wire';
-import { PairingInitiator, ReconnectInitiator, type PairResult } from './pairing';
+import { PairingInitiator, ReconnectInitiator, deterministicUuid, type PairResult } from './pairing';
 import { AeadSealer, AeadOpener } from './aead';
 import type { PeerStore } from './peers';
 import type { TaskState } from '../../shared/types';
@@ -156,7 +156,21 @@ export async function sendToPeer(opts: SendOptions): Promise<{ delivered: boolea
     });
     socket.write(encodeFrame(AEAD_RECORD, sealer.seal(Buffer.from(appMsg, 'utf8'))));
     const ack = await stream.next(AEAD_RECORD);
-    opener.open(ack); // authenticate the ACK (throws on tamper)
+    const ackPlain = opener.open(ack); // authenticate the ACK (throws on tamper/replay)
+    // Confirm the ACK is FOR THIS message, not just any authentic frame (codex): the
+    // server ACKs with { ack: deterministicUuid(peerUuid:senderSeq) }. Only commit
+    // the send seq when the id matches, so a stray/other frame can't mark a failed
+    // delivery as confirmed.
+    const expectedId = deterministicUuid(`${opts.peerUuid}:${senderSeq}`);
+    let ackObj: unknown;
+    try {
+      ackObj = JSON.parse(ackPlain.toString('utf8'));
+    } catch {
+      throw new Error('LanLink sendToPeer: malformed ACK');
+    }
+    if (typeof ackObj !== 'object' || ackObj === null || (ackObj as Record<string, unknown>)['ack'] !== expectedId) {
+      throw new Error('LanLink sendToPeer: ACK does not match the sent message');
+    }
     opts.peers.commitSendSeq(opts.peerUuid, senderSeq); // delivery confirmed -> commit
     return { delivered: true };
   } finally {

--- a/src/daemon/lanlink/client.ts
+++ b/src/daemon/lanlink/client.ts
@@ -143,7 +143,10 @@ export async function sendToPeer(opts: SendOptions): Promise<{ delivered: boolea
     const keys = recon.onReconnect2(r2);
     const sealer = new AeadSealer(keys.c2sKey, 1); // joiner -> host (c2s)
     const opener = new AeadOpener(keys.s2cKey, 2);
-    const senderSeq = opts.peers.nextSendSeq(opts.peerUuid);
+    // Peek the next senderSeq; commit it ONLY after the ACK confirms delivery, so a
+    // timeout/retry reuses the same senderSeq and the receiver's high-water dedup
+    // keeps the retry idempotent (no duplicate inbox row) (codex).
+    const senderSeq = opts.peers.peekSendSeq(opts.peerUuid) + 1;
     const appMsg = JSON.stringify({
       kind: opts.kind ?? 'msg.text',
       peerName: opts.selfName,
@@ -154,6 +157,7 @@ export async function sendToPeer(opts: SendOptions): Promise<{ delivered: boolea
     socket.write(encodeFrame(AEAD_RECORD, sealer.seal(Buffer.from(appMsg, 'utf8'))));
     const ack = await stream.next(AEAD_RECORD);
     opener.open(ack); // authenticate the ACK (throws on tamper)
+    opts.peers.commitSendSeq(opts.peerUuid, senderSeq); // delivery confirmed -> commit
     return { delivered: true };
   } finally {
     socket.destroy();

--- a/src/daemon/lanlink/client.ts
+++ b/src/daemon/lanlink/client.ts
@@ -143,10 +143,9 @@ export async function sendToPeer(opts: SendOptions): Promise<{ delivered: boolea
     const keys = recon.onReconnect2(r2);
     const sealer = new AeadSealer(keys.c2sKey, 1); // joiner -> host (c2s)
     const opener = new AeadOpener(keys.s2cKey, 2);
-    // Peek the next senderSeq; commit it ONLY after the ACK confirms delivery, so a
-    // timeout/retry reuses the same senderSeq and the receiver's high-water dedup
-    // keeps the retry idempotent (no duplicate inbox row) (codex).
-    const senderSeq = opts.peers.peekSendSeq(opts.peerUuid) + 1;
+    // Reserve the senderSeq immediately so two concurrent sends can't collide on
+    // one seq (which the receiver's dedup would silently drop) — codex P1.
+    const senderSeq = opts.peers.nextSendSeq(opts.peerUuid);
     const appMsg = JSON.stringify({
       kind: opts.kind ?? 'msg.text',
       peerName: opts.selfName,
@@ -171,7 +170,6 @@ export async function sendToPeer(opts: SendOptions): Promise<{ delivered: boolea
     if (typeof ackObj !== 'object' || ackObj === null || (ackObj as Record<string, unknown>)['ack'] !== expectedId) {
       throw new Error('LanLink sendToPeer: ACK does not match the sent message');
     }
-    opts.peers.commitSendSeq(opts.peerUuid, senderSeq); // delivery confirmed -> commit
     return { delivered: true };
   } finally {
     socket.destroy();

--- a/src/daemon/lanlink/deliver.ts
+++ b/src/daemon/lanlink/deliver.ts
@@ -1,0 +1,43 @@
+// === LanLink deliver() seam — DEFINE-ONLY (PR-4, roadmap §11) ===
+//
+// The shared delivery interface where the channels track (topology: who is in a
+// room) and the LanLink track (transport: how far a message reaches) converge
+// WITHOUT a code merge. channels U2 fanout calls deliver(msg, recipient); a local
+// recipient routes through the in-process pipe, a remote recipient routes through
+// the LanLink AEAD transport to the peer daemon's durable inbox. PR-4 DEFINES the
+// contract only — no implementation, no wiring — so #269 (channels) can target a
+// stable shape. The remote member identity is the LanLink per-peer UUID.
+//
+// Imports a shared type only; execute-wall clean.
+
+import type { TaskState } from '../../shared/types';
+
+/** Where a fanned-out message should land. */
+export type DeliveryRecipient =
+  | { transport: 'local'; workspaceId: string; paneId?: string }
+  | { transport: 'lanlink'; peerUuid: string };
+
+/** The text-only restricted message a room post fans out (mirrors the wire subset). */
+export interface DeliverableMessage {
+  kind: 'msg.text' | 'state.update';
+  peerName: string;
+  text: string;
+  state?: TaskState;
+}
+
+export interface DeliveryResult {
+  ok: boolean;
+  /** For a durable remote landing, the inbox seq (the durable ACK); absent on local. */
+  seq?: number;
+  error?: string;
+}
+
+/**
+ * The convergence seam. channels U2 fanout implements its room/membership logic
+ * and calls this for each recipient; a LanLink-backed Deliverer routes a
+ * `transport:'lanlink'` recipient over the AEAD channel and a `transport:'local'`
+ * recipient over the in-process pipe. DEFINE-ONLY in PR-4.
+ */
+export interface Deliverer {
+  deliver(msg: DeliverableMessage, recipient: DeliveryRecipient): Promise<DeliveryResult>;
+}

--- a/src/daemon/lanlink/firewall.ts
+++ b/src/daemon/lanlink/firewall.ts
@@ -22,7 +22,8 @@ function netshPath(): string {
 
 function run(file: string, args: string[]): Promise<boolean> {
   return new Promise((resolve) => {
-    execFile(file, args, { windowsHide: true }, (err) => {
+    // timeout so a hung netsh.exe cannot wedge the firewall op chain forever.
+    execFile(file, args, { windowsHide: true, timeout: 10_000 }, (err) => {
       if (err) {
         console.warn(`[lanlink-firewall] ${path.basename(file)} ${args.slice(0, 4).join(' ')} ... failed:`, err.message);
         resolve(false);

--- a/src/daemon/lanlink/firewall.ts
+++ b/src/daemon/lanlink/firewall.ts
@@ -1,0 +1,64 @@
+// === LanLink Windows firewall control (PR-4, C15) ===
+//
+// On enable+listen: an idempotent delete-then-add of two stable-named rules — a
+// Private-profile ALLOW and an explicit Public/Domain BLOCK. In Windows Firewall
+// a BLOCK rule takes precedence over an ALLOW, so a stray pre-existing Public
+// allow cannot win — the LAN port is reachable only on networks Windows marks
+// Private. Best-effort (needs the firewall service / sufficient rights); the
+// caller also refuses to listen on a Public-category NIC where it can tell, and
+// the pairing window further bounds exposure.
+//
+// win32-only; a no-op elsewhere. Imports node:child_process/os/path only.
+
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+
+const PRIVATE_RULE = 'wmux LanLink (Private)';
+const PUBLIC_DENY_RULE = 'wmux LanLink (Public deny)';
+
+function netshPath(): string {
+  return path.join(process.env['SystemRoot'] ?? 'C:\\Windows', 'System32', 'netsh.exe');
+}
+
+function run(file: string, args: string[]): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile(file, args, { windowsHide: true }, (err) => {
+      if (err) {
+        console.warn(`[lanlink-firewall] ${path.basename(file)} ${args.slice(0, 4).join(' ')} ... failed:`, err.message);
+        resolve(false);
+      } else {
+        resolve(true);
+      }
+    });
+  });
+}
+
+/** Apply the Private ALLOW + Public/Domain BLOCK rules (idempotent). win32-only. */
+export async function applyLanLinkFirewall(port: number, exe: string): Promise<void> {
+  if (process.platform !== 'win32') return;
+  const netsh = netshPath();
+  // delete-then-add so a port/exe change leaves no stale rule.
+  await run(netsh, ['advfirewall', 'firewall', 'delete', 'rule', `name=${PRIVATE_RULE}`]);
+  await run(netsh, ['advfirewall', 'firewall', 'delete', 'rule', `name=${PUBLIC_DENY_RULE}`]);
+  await run(netsh, [
+    'advfirewall', 'firewall', 'add', 'rule', `name=${PRIVATE_RULE}`,
+    'dir=in', 'action=allow', 'protocol=TCP', `localport=${port}`, 'profile=private', `program=${exe}`, 'enable=yes',
+  ]);
+  // The BLOCK is the rule that gates exposure (block precedence). If it fails, the
+  // caller's Public-category refusal + the pairing window are the remaining gates.
+  const denyOk = await run(netsh, [
+    'advfirewall', 'firewall', 'add', 'rule', `name=${PUBLIC_DENY_RULE}`,
+    'dir=in', 'action=block', 'protocol=TCP', `localport=${port}`, 'profile=public,domain', `program=${exe}`, 'enable=yes',
+  ]);
+  if (!denyOk) {
+    console.warn('[lanlink-firewall] Public/Domain BLOCK rule could not be applied — relying on Public-category refusal + pairing window');
+  }
+}
+
+/** Remove both LanLink firewall rules (idempotent). win32-only. */
+export async function removeLanLinkFirewall(): Promise<void> {
+  if (process.platform !== 'win32') return;
+  const netsh = netshPath();
+  await run(netsh, ['advfirewall', 'firewall', 'delete', 'rule', `name=${PRIVATE_RULE}`]);
+  await run(netsh, ['advfirewall', 'firewall', 'delete', 'rule', `name=${PUBLIC_DENY_RULE}`]);
+}

--- a/src/daemon/lanlink/pairing.ts
+++ b/src/daemon/lanlink/pairing.ts
@@ -1,0 +1,477 @@
+// === LanLink PIN-EKE pairing + reconnect key agreement (PR-4, C4/C5/C7/C9) ===
+//
+// Construction class: a DOUBLE-MASKED EKE — PIN-bound ephemeral X25519 with HKDF
+// key-binding and a mutual key-confirmation MAC. This is NOT SPAKE2/CPace: native
+// node:crypto X25519 exposes only scalar-mult (crypto.diffieHellman), not the
+// point addition those need. We are precise about the limit (see SECURITY notes
+// in the design doc): there is NO offline brute-force from a captured transcript;
+// an active same-LAN attacker gets ONE online guess per handshake, hard-bounded
+// by the window fail-burn (server-side), MAX_PAKE_IN_FLIGHT, and the <=2min TTL.
+//
+// The PIN NEVER travels: it appears only as scrypt(PIN) -> mask and in the confirm
+// MAC. The wire carries an unmasked ephemeral pubkey (jPub), a masked responder
+// pubkey, nonces, and a MAC — none reveal the PIN.
+//
+// Imports node:crypto + node:util + sibling wire/aead/sanitize only (execute-wall
+// clean). No literal control chars in source.
+
+import crypto from 'node:crypto';
+import { deriveSessionKeys, type SessionKeys } from './aead';
+import { sanitizeRemotePeerName } from './sanitize';
+
+export const PIN_LEN = 6;
+export const PAIR_TTL_MS = 120_000; // <=2 min (server enforces with a monotonic clock)
+export const PAIR_FAIL_BURN = 5; // window-scoped fail cap (server enforces)
+export const SCRYPT_PARAMS = Object.freeze({ N: 2 ** 15, r: 8, p: 1, maxmem: 64 * 1024 * 1024 });
+
+const NONCE_LEN = 16;
+const RAW_PUB_LEN = 32;
+const MAC_LEN = 32;
+const NAME_WIRE_MAX = 100;
+// Fixed 12-byte SPKI prefix for an X25519 raw public key (runtime-verified
+// constant). raw32 == export({type:'spki',format:'der'}).subarray(12).
+const SPKI_PREFIX = Buffer.from('302a300506032b656e032100', 'hex');
+// Deterministic-UUID namespace ("lanlink-peers-v5", 16 bytes). uuidv5 over the
+// joiner's ephemeral pubkey gives a stable PAIRING id (C9): re-pairing the same
+// device UPDATES its record rather than duplicating it.
+const LANLINK_NS = Buffer.from('6c616e6c696e6b2d70656572732d7635', 'hex');
+
+const WIRE_VERSION = 1;
+const CIPHER_ID = 1;
+
+export class PairError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PairError';
+  }
+}
+
+export interface PairResult {
+  /** Stable pairing id = uuidv5(joiner ephemeral pubkey). Symmetric: both sides compute the same value. */
+  peerUuid: string;
+  /** The OTHER party's display name (sanitized). */
+  peerName: string;
+  /** The shared long-term secret (32 bytes); persisted owner-DACL by both sides. */
+  longTermSecret: Buffer;
+}
+
+// ── crypto helpers ───────────────────────────────────────────────────────────
+
+function scryptAsync(password: Buffer, salt: Buffer, keylen: number): Promise<Buffer> {
+  // scrypt runs on the libuv threadpool (C5) — NEVER scryptSync, which would block
+  // the daemon event loop and the machine-local control pipe. maxmem MUST be set
+  // explicitly: N=2**15,r=8 needs exactly 32 MiB == the default maxmem and would
+  // otherwise throw ERR_CRYPTO_INVALID_SCRYPT_PARAMS.
+  return new Promise((resolve, reject) => {
+    crypto.scrypt(password, salt, keylen, SCRYPT_PARAMS, (err, dk) => {
+      if (err) reject(err);
+      else resolve(dk);
+    });
+  });
+}
+
+function hkdf(ikm: Buffer, salt: Buffer, info: Buffer | string, len: number): Buffer {
+  return Buffer.from(crypto.hkdfSync('sha256', ikm, salt, info, len));
+}
+
+function hmac(key: Buffer, data: Buffer): Buffer {
+  return crypto.createHmac('sha256', key).update(data).digest();
+}
+
+function rawPubOf(keyObject: crypto.KeyObject): Buffer {
+  return keyObject.export({ type: 'spki', format: 'der' }).subarray(SPKI_PREFIX.length);
+}
+
+function pubKeyFromRaw(raw32: Buffer): crypto.KeyObject {
+  return crypto.createPublicKey({
+    key: Buffer.concat([SPKI_PREFIX, raw32]),
+    format: 'der',
+    type: 'spki',
+  });
+}
+
+function isAllZero(b: Buffer): boolean {
+  for (let i = 0; i < b.length; i++) if (b[i] !== 0) return false;
+  return true;
+}
+
+/**
+ * X25519 shared secret with a contributory-behaviour check (C7). A small-order /
+ * low-order peer point yields an all-zero shared secret; Node's X25519 already
+ * throws on this, and we ALSO reject an all-zero result explicitly. Any failure
+ * (bad point, throw, all-zero) collapses to the SAME PairError so a wrong PIN and
+ * a malicious point are indistinguishable to the attacker (no oracle).
+ */
+function x25519Shared(privateKey: crypto.KeyObject, peerRawPub: Buffer): Buffer {
+  let shared: Buffer;
+  try {
+    const publicKey = pubKeyFromRaw(peerRawPub);
+    shared = crypto.diffieHellman({ privateKey, publicKey });
+  } catch {
+    throw new PairError('X25519 key agreement failed');
+  }
+  if (shared.length !== RAW_PUB_LEN || isAllZero(shared)) {
+    throw new PairError('degenerate X25519 shared secret');
+  }
+  return shared;
+}
+
+function xorInto(a: Buffer, b: Buffer): Buffer {
+  const out = Buffer.alloc(a.length);
+  for (let i = 0; i < a.length; i++) out[i] = a[i] ^ b[i];
+  return out;
+}
+
+/**
+ * Whiten bit 255 of a raw X25519 public key before it is PIN-masked (C-crypto
+ * fix). A raw X25519 u-coordinate always has bit 255 == 0 (u < 2^255-19); XOR-ing
+ * a uniform PIN-derived mask over a value with a deterministic top bit lets a
+ * PASSIVE eavesdropper distinguish the correct PIN's unmask (top bit always 0)
+ * from a wrong PIN's (top bit 0 only ~50%), leaking ~1 bit of the PIN offline. We
+ * OR a fresh random bit into position 255 of the PLAINTEXT key so the masked
+ * value is uniformly distributed; RFC7748 ignores bit 255 in the u-coordinate, so
+ * the receiver clears it (clearTopBit) before the DH and key agreement is exact.
+ */
+function whitenTopBit(raw32: Buffer): Buffer {
+  const out = Buffer.from(raw32);
+  out[31] = (out[31] & 0x7f) | (crypto.randomBytes(1)[0] & 0x80);
+  return out;
+}
+
+/** Clear bit 255 of a recovered raw X25519 pubkey before the DH (RFC7748-lossless). */
+function clearTopBit(raw32: Buffer): Buffer {
+  const out = Buffer.from(raw32);
+  out[31] &= 0x7f;
+  return out;
+}
+
+/** Deterministic RFC4122 v5 UUID over `name` in the LanLink namespace (no external dep). */
+export function deterministicUuid(name: Buffer | string): string {
+  const nameBuf = typeof name === 'string' ? Buffer.from(name, 'utf8') : name;
+  const h = crypto.createHash('sha1').update(LANLINK_NS).update(nameBuf).digest();
+  h[6] = (h[6] & 0x0f) | 0x50; // version 5
+  h[8] = (h[8] & 0x3f) | 0x80; // RFC4122 variant
+  const hex = h.subarray(0, 16).toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+/** The stable pairing id derived from the joiner's raw ephemeral pubkey (C9). */
+export function deterministicPeerUuid(rawJPub32: Buffer): string {
+  return deterministicUuid(rawJPub32);
+}
+
+// ── name <-> wire ────────────────────────────────────────────────────────────
+
+function nameToWire(name: string): Buffer {
+  let b = Buffer.from(name, 'utf8');
+  if (b.length > NAME_WIRE_MAX) b = b.subarray(0, NAME_WIRE_MAX);
+  return b;
+}
+
+function readName(body: Buffer, off: number): { name: string; end: number } {
+  if (off >= body.length) throw new PairError('pairing frame truncated (name length)');
+  const nameLen = body[off];
+  const start = off + 1;
+  const end = start + nameLen;
+  if (end > body.length) throw new PairError('pairing frame truncated (name)');
+  // sanitize on receipt (design §1): strip control/bidi + clamp.
+  const name = sanitizeRemotePeerName(body.subarray(start, end).toString('utf8'));
+  return { name, end };
+}
+
+// ── transcript / session derivation (shared by both roles) ───────────────────
+
+function buildTranscript(helloBody: Buffer, pake2Body: Buffer): Buffer {
+  return crypto.createHash('sha256').update(helloBody).update(pake2Body).digest();
+}
+
+function deriveSecrets(shared: Buffer, sessionSalt: Buffer, transcript: Buffer): {
+  masterSecret: Buffer;
+  confirmKey: Buffer;
+  longTermSecret: Buffer;
+} {
+  const masterSecret = hkdf(
+    shared,
+    sessionSalt,
+    Buffer.concat([Buffer.from('wmux-lanlink/v1 master'), transcript]),
+    32,
+  );
+  const confirmKey = hkdf(masterSecret, sessionSalt, 'wmux-lanlink/v1 confirm', 32);
+  const longTermSecret = hkdf(masterSecret, sessionSalt, 'wmux-lanlink/v1 longterm', 32);
+  return { masterSecret, confirmKey, longTermSecret };
+}
+
+function joinerMacOf(confirmKey: Buffer, transcript: Buffer): Buffer {
+  return hmac(confirmKey, Buffer.concat([Buffer.from('wmux-lanlink/v1 joiner'), transcript]));
+}
+
+function responderMacOf(confirmKey: Buffer, transcript: Buffer): Buffer {
+  return hmac(confirmKey, Buffer.concat([Buffer.from('wmux-lanlink/v1 responder'), transcript]));
+}
+
+// ── PAKE_HELLO / PAKE2 / CONFIRM body codecs ─────────────────────────────────
+
+function encodeHelloBody(jPub: Buffer, helloNonce: Buffer, selfName: string): Buffer {
+  const name = nameToWire(selfName);
+  return Buffer.concat([
+    Buffer.from([WIRE_VERSION, CIPHER_ID]),
+    jPub,
+    helloNonce,
+    Buffer.from([name.length]),
+    name,
+  ]);
+}
+
+function parseHelloBody(body: Buffer): { jPub: Buffer; helloNonce: Buffer; name: string } {
+  // version/cipher are the FIRST two byte reads (C18 downgrade gate) — reject
+  // before any crypto.
+  if (body.length < 2 + RAW_PUB_LEN + NONCE_LEN + 1) throw new PairError('PAKE_HELLO too short');
+  if (body[0] !== WIRE_VERSION) throw new PairError('PAKE_HELLO unsupported wire version');
+  if (body[1] !== CIPHER_ID) throw new PairError('PAKE_HELLO unsupported cipher');
+  const jPub = body.subarray(2, 2 + RAW_PUB_LEN);
+  const helloNonce = body.subarray(2 + RAW_PUB_LEN, 2 + RAW_PUB_LEN + NONCE_LEN);
+  const { name } = readName(body, 2 + RAW_PUB_LEN + NONCE_LEN);
+  return { jPub: Buffer.from(jPub), helloNonce: Buffer.from(helloNonce), name };
+}
+
+function encodePake2Body(respPubMasked: Buffer, respNonce: Buffer, selfName: string): Buffer {
+  const name = nameToWire(selfName);
+  return Buffer.concat([respPubMasked, respNonce, Buffer.from([name.length]), name]);
+}
+
+function parsePake2Body(body: Buffer): { respPubMasked: Buffer; respNonce: Buffer; name: string } {
+  if (body.length < RAW_PUB_LEN + NONCE_LEN + 1) throw new PairError('PAKE2 too short');
+  const respPubMasked = body.subarray(0, RAW_PUB_LEN);
+  const respNonce = body.subarray(RAW_PUB_LEN, RAW_PUB_LEN + NONCE_LEN);
+  const { name } = readName(body, RAW_PUB_LEN + NONCE_LEN);
+  return {
+    respPubMasked: Buffer.from(respPubMasked),
+    respNonce: Buffer.from(respNonce),
+    name,
+  };
+}
+
+// ── Responder (the listening side; A in "A shows PIN, B joins") ───────────────
+
+interface ResponderPending {
+  shared: Buffer;
+  sessionSalt: Buffer;
+  helloNonce: Buffer;
+  respNonce: Buffer;
+  jPubRaw: Buffer;
+  helloBody: Buffer;
+  pake2Body: Buffer;
+  joinerName: string;
+}
+
+export class PairingResponder {
+  private pending: ResponderPending | null = null;
+
+  constructor(private readonly pin: string, private readonly selfName: string) {}
+
+  /** Process PAKE_HELLO, return the PAKE2 body to send. scrypt runs async (C5). */
+  async onHello(helloBody: Buffer): Promise<Buffer> {
+    const { jPub, helloNonce, name } = parseHelloBody(helloBody);
+    const respEph = crypto.generateKeyPairSync('x25519');
+    const respNonce = crypto.randomBytes(NONCE_LEN);
+    const sessionSalt = crypto.createHash('sha256').update(helloNonce).update(respNonce).digest();
+    const pinKey = await scryptAsync(Buffer.from(this.pin, 'utf8'), sessionSalt, 32);
+    const mask = hkdf(pinKey, sessionSalt, 'wmux-lanlink/v1 mask', RAW_PUB_LEN);
+    // DH: any failure (bad/low-order point, all-zero) -> PairError, unified with a
+    // wrong-PIN failure by the server (C7).
+    const shared = x25519Shared(respEph.privateKey, jPub);
+    // Whiten the biased top bit BEFORE masking (no offline-distinguisher leak).
+    const rPubRaw = whitenTopBit(rawPubOf(respEph.publicKey));
+    const respPubMasked = xorInto(rPubRaw, mask);
+    const pake2Body = encodePake2Body(respPubMasked, respNonce, this.selfName);
+    this.pending = {
+      shared,
+      sessionSalt,
+      helloNonce,
+      respNonce,
+      jPubRaw: jPub,
+      helloBody: Buffer.from(helloBody),
+      pake2Body,
+      joinerName: name,
+    };
+    return pake2Body;
+  }
+
+  /**
+   * Verify the joiner's CONFIRM MAC. On success returns the PairResult, the
+   * responder's MAC (to send as the FIRST AEAD record plaintext, C18), and the
+   * material the server needs to build the AEAD session. THROWS PairError on a
+   * MAC mismatch (the server treats this identically to any handshake failure).
+   */
+  onConfirm(confirmBody: Buffer): {
+    result: PairResult;
+    respMac: Buffer;
+    sessionKeys: SessionKeys;
+    helloNonce: Buffer;
+    respNonce: Buffer;
+  } {
+    if (!this.pending) throw new PairError('CONFIRM before PAKE_HELLO');
+    if (confirmBody.length !== MAC_LEN) throw new PairError('CONFIRM wrong length');
+    const p = this.pending;
+    const transcript = buildTranscript(p.helloBody, p.pake2Body);
+    const { confirmKey, longTermSecret } = deriveSecrets(p.shared, p.sessionSalt, transcript);
+    const expected = joinerMacOf(confirmKey, transcript);
+    // length-check first (timingSafeEqual throws on unequal length), no structural
+    // short-circuit before the constant-time compare.
+    if (confirmBody.length !== expected.length || !crypto.timingSafeEqual(confirmBody, expected)) {
+      throw new PairError('CONFIRM MAC mismatch');
+    }
+    const respMac = responderMacOf(confirmKey, transcript);
+    // Pairing ephemerals double as the session ephemerals: ee = shared (C2/§5).
+    const sessionKeys = deriveSessionKeys(longTermSecret, p.shared, p.helloNonce, p.respNonce);
+    const result: PairResult = {
+      peerUuid: deterministicPeerUuid(p.jPubRaw),
+      peerName: p.joinerName,
+      longTermSecret,
+    };
+    return { result, respMac, sessionKeys, helloNonce: p.helloNonce, respNonce: p.respNonce };
+  }
+}
+
+// ── Initiator (the joining side; B enters PIN, connects to A) ─────────────────
+
+export interface PendingJoin {
+  jPriv: crypto.KeyObject;
+  jPubRaw: Buffer;
+  helloNonce: Buffer;
+  pin: string;
+  helloBody: Buffer;
+}
+
+export interface JoinPending2 {
+  longTermSecret: Buffer;
+  confirmKey: Buffer;
+  transcript: Buffer;
+  peerUuid: string;
+  peerName: string;
+  sessionKeys: SessionKeys;
+}
+
+export class PairingInitiator {
+  private j: PendingJoin | null = null;
+
+  constructor(private readonly pin: string, private readonly selfName: string) {}
+
+  /** Build PAKE_HELLO (jPub UNMASKED + helloNonce + name). */
+  hello(): Buffer {
+    const eph = crypto.generateKeyPairSync('x25519');
+    const jPubRaw = rawPubOf(eph.publicKey);
+    const helloNonce = crypto.randomBytes(NONCE_LEN);
+    const helloBody = encodeHelloBody(jPubRaw, helloNonce, this.selfName);
+    this.j = { jPriv: eph.privateKey, jPubRaw, helloNonce, pin: this.pin, helloBody };
+    return helloBody;
+  }
+
+  /** Process PAKE2, return the CONFIRM body + pending state for verifyRespMac. */
+  async onPake2(pake2Body: Buffer): Promise<{ confirm: Buffer; pending: JoinPending2 }> {
+    if (!this.j) throw new PairError('PAKE2 before PAKE_HELLO');
+    const j = this.j;
+    const { respPubMasked, respNonce, name } = parsePake2Body(pake2Body);
+    const sessionSalt = crypto.createHash('sha256').update(j.helloNonce).update(respNonce).digest();
+    const pinKey = await scryptAsync(Buffer.from(j.pin, 'utf8'), sessionSalt, 32);
+    const mask = hkdf(pinKey, sessionSalt, 'wmux-lanlink/v1 mask', RAW_PUB_LEN);
+    // Unmask, then clear the whitened top bit before the DH (RFC7748-lossless).
+    const rPubRaw = clearTopBit(xorInto(respPubMasked, mask));
+    const shared = x25519Shared(j.jPriv, rPubRaw); // wrong PIN -> wrong rPub -> degenerate/wrong shared
+    const transcript = buildTranscript(j.helloBody, pake2Body);
+    const { confirmKey, longTermSecret } = deriveSecrets(shared, sessionSalt, transcript);
+    const confirm = joinerMacOf(confirmKey, transcript);
+    const sessionKeys = deriveSessionKeys(longTermSecret, shared, j.helloNonce, respNonce);
+    const pending: JoinPending2 = {
+      longTermSecret,
+      confirmKey,
+      transcript,
+      peerUuid: deterministicPeerUuid(j.jPubRaw),
+      peerName: name,
+      sessionKeys,
+    };
+    return { confirm, pending };
+  }
+
+  /** Verify the responder's MAC (decrypted from the first AEAD record). */
+  verifyRespMac(plaintext: Buffer, pending: JoinPending2): PairResult {
+    const expected = responderMacOf(pending.confirmKey, pending.transcript);
+    if (plaintext.length !== expected.length || !crypto.timingSafeEqual(plaintext, expected)) {
+      throw new PairError('responder MAC mismatch');
+    }
+    return {
+      peerUuid: pending.peerUuid,
+      peerName: pending.peerName,
+      longTermSecret: pending.longTermSecret,
+    };
+  }
+}
+
+// ── Reconnect (known peer, ephemeral DH, NO scrypt — C3) ──────────────────────
+//
+// Like the PAKE codecs, these return the frame BODY only — the server wraps each
+// in encodeFrame(0x04 / 0x05). No scrypt, no PIN: a fresh ephemeral DH bound into
+// the stored long-term secret yields a unique session key per reconnect (C2).
+
+export function encodeReconnectHelloBody(peerUuid: string, ephPubRaw: Buffer, connNonce: Buffer): Buffer {
+  const uuidBytes = Buffer.from(peerUuid.replace(/-/g, ''), 'hex'); // 16 bytes
+  return Buffer.concat([Buffer.from([WIRE_VERSION, CIPHER_ID]), uuidBytes, ephPubRaw, connNonce]);
+}
+
+export function parseReconnectHello(body: Buffer): { peerUuid: string; ephPubRaw: Buffer; connNonce: Buffer } {
+  if (body.length < 2 + 16 + RAW_PUB_LEN + NONCE_LEN) throw new PairError('RECONNECT_HELLO too short');
+  if (body[0] !== WIRE_VERSION) throw new PairError('RECONNECT_HELLO unsupported wire version');
+  if (body[1] !== CIPHER_ID) throw new PairError('RECONNECT_HELLO unsupported cipher');
+  const uuidHex = body.subarray(2, 18).toString('hex');
+  const peerUuid = `${uuidHex.slice(0, 8)}-${uuidHex.slice(8, 12)}-${uuidHex.slice(12, 16)}-${uuidHex.slice(16, 20)}-${uuidHex.slice(20, 32)}`;
+  const ephPubRaw = Buffer.from(body.subarray(18, 18 + RAW_PUB_LEN));
+  const connNonce = Buffer.from(body.subarray(18 + RAW_PUB_LEN, 18 + RAW_PUB_LEN + NONCE_LEN));
+  return { peerUuid, ephPubRaw, connNonce };
+}
+
+export function encodeReconnect2Body(ephPubRaw: Buffer, respNonce: Buffer): Buffer {
+  return Buffer.concat([ephPubRaw, respNonce]);
+}
+
+export function parseReconnect2Body(body: Buffer): { ephPubRaw: Buffer; respNonce: Buffer } {
+  if (body.length < RAW_PUB_LEN + NONCE_LEN) throw new PairError('RECONNECT2 too short');
+  return {
+    ephPubRaw: Buffer.from(body.subarray(0, RAW_PUB_LEN)),
+    respNonce: Buffer.from(body.subarray(RAW_PUB_LEN, RAW_PUB_LEN + NONCE_LEN)),
+  };
+}
+
+/** Responder side of reconnect: fresh ephemeral DH (no scrypt) -> session keys. */
+export function reconnectResponder(
+  longTermSecret: Buffer,
+  peerEphPubRaw: Buffer,
+  connNonce: Buffer,
+): { sessionKeys: SessionKeys; reconnect2Body: Buffer } {
+  const eph = crypto.generateKeyPairSync('x25519');
+  const respNonce = crypto.randomBytes(NONCE_LEN);
+  const ee = x25519Shared(eph.privateKey, peerEphPubRaw);
+  const sessionKeys = deriveSessionKeys(longTermSecret, ee, connNonce, respNonce);
+  return { sessionKeys, reconnect2Body: encodeReconnect2Body(rawPubOf(eph.publicKey), respNonce) };
+}
+
+/** Initiator side of reconnect: build the hello body, then finish with RECONNECT2. */
+export class ReconnectInitiator {
+  private eph: { publicKey: crypto.KeyObject; privateKey: crypto.KeyObject } | null = null;
+  private connNonce: Buffer | null = null;
+
+  constructor(private readonly peerUuid: string, private readonly longTermSecret: Buffer) {}
+
+  hello(): Buffer {
+    const eph = crypto.generateKeyPairSync('x25519');
+    this.eph = eph;
+    this.connNonce = crypto.randomBytes(NONCE_LEN);
+    return encodeReconnectHelloBody(this.peerUuid, rawPubOf(eph.publicKey), this.connNonce);
+  }
+
+  onReconnect2(body: Buffer): SessionKeys {
+    if (!this.eph || !this.connNonce) throw new PairError('RECONNECT2 before hello');
+    const { ephPubRaw, respNonce } = parseReconnect2Body(body);
+    const ee = x25519Shared(this.eph.privateKey, ephPubRaw);
+    return deriveSessionKeys(this.longTermSecret, ee, this.connNonce, respNonce);
+  }
+}

--- a/src/daemon/lanlink/peers.ts
+++ b/src/daemon/lanlink/peers.ts
@@ -179,22 +179,21 @@ export class PeerStore {
     return rec;
   }
 
-  /** The last COMMITTED send sequence for a peer (sender side of C8 dedup). The
-   *  next message uses peekSendSeq()+1 and only commits it after delivery is ACKed
-   *  (commitSendSeq) — so a failed/retried send reuses the same senderSeq and the
-   *  receiver's high-water dedup makes the retry idempotent (codex). */
-  peekSendSeq(peerUuid: string): number {
-    return this.map.get(peerUuid)?.sendSeq ?? 0;
-  }
-
-  /** Commit a send sequence once its delivery was confirmed (monotonic, persisted). */
-  commitSendSeq(peerUuid: string, seq: number): void {
+  /**
+   * Reserve the next monotonic send sequence for a peer (sender side of C8 dedup).
+   * RESERVED IMMEDIATELY (not after an ACK) so two concurrent sends to the same
+   * peer get DISTINCT senderSeqs — otherwise the receiver's high-water dedup would
+   * silently drop the second message (codex P1: message loss is worse than a retry
+   * duplicate). A failed/retried send therefore takes a fresh seq (at-least-once);
+   * the receiver's high-water + the deterministic record id keep a genuine network
+   * replay idempotent.
+   */
+  nextSendSeq(peerUuid: string): number {
     const r = this.map.get(peerUuid);
-    if (!r) throw new Error(`commitSendSeq: unknown peer ${peerUuid}`);
-    if (seq > r.sendSeq) {
-      r.sendSeq = seq;
-      this.persist();
-    }
+    if (!r) throw new Error(`nextSendSeq: unknown peer ${peerUuid}`);
+    r.sendSeq += 1;
+    this.persist();
+    return r.sendSeq;
   }
 
   /** ++pinFailCount on an AEAD-authenticated failure; burn at the threshold (C6). */

--- a/src/daemon/lanlink/peers.ts
+++ b/src/daemon/lanlink/peers.ts
@@ -296,7 +296,9 @@ export class PeerStore {
   private loadOrCreateMachineKey(): Buffer {
     try {
       const existing = fs.readFileSync(this.keyPath, 'utf8').trim();
-      if (existing) {
+      // Require exactly 32 bytes of hex — a malformed/truncated key would silently
+      // weaken every peer-file HMAC, so a bad value is discarded + regenerated.
+      if (existing && /^[0-9a-fA-F]{64}$/.test(existing)) {
         const ok = this.reHarden(this.keyPath);
         // Fail closed (codex P2): if the integrity key cannot be locked to owner-only
         // ACLs on win32, do NOT trust a broad-readable key (an attacker who reads it

--- a/src/daemon/lanlink/peers.ts
+++ b/src/daemon/lanlink/peers.ts
@@ -179,13 +179,22 @@ export class PeerStore {
     return rec;
   }
 
-  /** Mint the next monotonic send sequence for a peer (sender side of C8 dedup). */
-  nextSendSeq(peerUuid: string): number {
+  /** The last COMMITTED send sequence for a peer (sender side of C8 dedup). The
+   *  next message uses peekSendSeq()+1 and only commits it after delivery is ACKed
+   *  (commitSendSeq) — so a failed/retried send reuses the same senderSeq and the
+   *  receiver's high-water dedup makes the retry idempotent (codex). */
+  peekSendSeq(peerUuid: string): number {
+    return this.map.get(peerUuid)?.sendSeq ?? 0;
+  }
+
+  /** Commit a send sequence once its delivery was confirmed (monotonic, persisted). */
+  commitSendSeq(peerUuid: string, seq: number): void {
     const r = this.map.get(peerUuid);
-    if (!r) throw new Error(`nextSendSeq: unknown peer ${peerUuid}`);
-    r.sendSeq += 1;
-    this.persist();
-    return r.sendSeq;
+    if (!r) throw new Error(`commitSendSeq: unknown peer ${peerUuid}`);
+    if (seq > r.sendSeq) {
+      r.sendSeq = seq;
+      this.persist();
+    }
   }
 
   /** ++pinFailCount on an AEAD-authenticated failure; burn at the threshold (C6). */

--- a/src/daemon/lanlink/peers.ts
+++ b/src/daemon/lanlink/peers.ts
@@ -1,0 +1,338 @@
+// === LanLink per-peer store (PR-4, C9/C12/C13) ===
+//
+// Persists paired-peer identities (the deterministic pairing peerUuid + the
+// shared long-term secret + a per-peer steady-state fail counter + a receive
+// high-water mark). Fail-closed owner-DACL, HMAC-bound to this host, atomic-write
+// + .bak recovery — mirrors the inbox/StateWriter persistence discipline.
+//
+// FAIL-CLOSED (C12): every persist does atomicWriteJSONSync THEN a synchronous
+// reHardenTokenFileAcl; on win32 if the ACL cannot be applied the file is
+// unlinked and the call throws (a long-term secret must NEVER sit broad-readable,
+// mirroring secureWriteTokenFile). HMAC-bound (C12): the file carries an HMAC over
+// its peers under a machine-local key, so a planted/divergent .bak from another
+// host is rejected on load.
+//
+// Imports node:fs/path/crypto + atomicWrite + shared/security (reHarden) only —
+// execute-wall clean, no src/main.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { atomicReadJSONSync, atomicWriteJSONSync } from '../util/atomicWrite';
+import { reHardenTokenFileAcl, secureWriteTokenFile } from '../../shared/security';
+import type { PairResult } from './pairing';
+
+export const PEER_CAP = 64;
+/** Per-peer steady-state (AEAD-authenticated) auth failures before the peer is burned. */
+export const PEER_BURN_THRESHOLD = 5;
+
+export interface PeerRecord {
+  peerUuid: string;
+  peerName: string;
+  /** base64 of the 32-byte shared long-term secret. */
+  longTermSecret: string;
+  pairedAt: number;
+  lastSeenAt: number;
+  /** Steady-state AEAD-authenticated failures ONLY (NEVER unauth/pairing — C6). */
+  pinFailCount: number;
+  burned: boolean;
+  /** Highest accepted senderSeq from this peer (C8 cross-connection dedup). */
+  recvHighWater: number;
+  /** Our own monotonic send counter TO this peer (C8 — the sender side of dedup). */
+  sendSeq: number;
+}
+
+export interface PeerFile {
+  version: 1;
+  /** HMAC-SHA256(machineLocalKey, canonical(peers)) — binds the file to this host (C12). */
+  mac: string;
+  peers: PeerRecord[];
+}
+
+const RECORD_KEYS: readonly (keyof PeerRecord)[] = [
+  'peerUuid',
+  'peerName',
+  'longTermSecret',
+  'pairedAt',
+  'lastSeenAt',
+  'pinFailCount',
+  'burned',
+  'recvHighWater',
+  'sendSeq',
+];
+
+/** Canonical, fixed-key-order projection used for the HMAC (deterministic bytes). */
+function canonical(peers: PeerRecord[]): string {
+  return JSON.stringify(
+    peers.map((r) => ({
+      peerUuid: r.peerUuid,
+      peerName: r.peerName,
+      longTermSecret: r.longTermSecret,
+      pairedAt: r.pairedAt,
+      lastSeenAt: r.lastSeenAt,
+      pinFailCount: r.pinFailCount,
+      burned: r.burned,
+      recvHighWater: r.recvHighWater,
+      sendSeq: r.sendSeq,
+    })),
+  );
+}
+
+/**
+ * STRUCTURE validator (Array.isArray-first, exact-own-keys, types). The HMAC is
+ * verified separately by PeerStore.load (it needs the machine-local key, which a
+ * free function can't hold) — so a planted .bak passes this shape check but fails
+ * the load-time HMAC and is skipped (C12).
+ */
+export function isPeerFile(v: unknown): v is PeerFile {
+  if (Array.isArray(v)) return false; // #269 lesson: an array is NOT a healthy object file
+  if (typeof v !== 'object' || v === null) return false;
+  const o = v as Record<string, unknown>;
+  if (o['version'] !== 1) return false;
+  if (typeof o['mac'] !== 'string' || o['mac'].length === 0) return false;
+  if (!Array.isArray(o['peers'])) return false;
+  for (const r of o['peers'] as unknown[]) {
+    if (typeof r !== 'object' || r === null || Array.isArray(r)) return false;
+    const rec = r as Record<string, unknown>;
+    const keys = Object.keys(rec);
+    if (keys.length !== RECORD_KEYS.length) return false; // reject extra keys (C20)
+    for (const k of RECORD_KEYS) {
+      if (!(k in rec)) return false;
+    }
+    if (typeof rec['peerUuid'] !== 'string' || rec['peerUuid'].length === 0) return false;
+    if (typeof rec['peerName'] !== 'string') return false;
+    if (typeof rec['longTermSecret'] !== 'string' || rec['longTermSecret'].length === 0) return false;
+    for (const numKey of ['pairedAt', 'lastSeenAt', 'pinFailCount', 'recvHighWater', 'sendSeq'] as const) {
+      const n = rec[numKey];
+      if (typeof n !== 'number' || !Number.isFinite(n)) return false;
+    }
+    if (typeof rec['burned'] !== 'boolean') return false;
+  }
+  return true;
+}
+
+export interface PeerStoreOptions {
+  /** Lets the server protect a peer with a live connection from LRU eviction. */
+  isLive?: (peerUuid: string) => boolean;
+  /** Test seam: override the (slow, win32 PowerShell) owner-DACL re-harden. */
+  reHarden?: (filePath: string) => boolean;
+  /** Test seam: override the secure (owner-DACL) machine-key write. */
+  secureWrite?: (filePath: string, data: string) => void;
+}
+
+export class PeerStore {
+  private readonly dir: string;
+  private readonly filePath: string;
+  private readonly keyPath: string;
+  private readonly machineKey: Buffer;
+  private readonly isLive: (peerUuid: string) => boolean;
+  private readonly reHarden: (filePath: string) => boolean;
+  private readonly secureWrite: (filePath: string, data: string) => void;
+  /** Map-backed (C20): lookups can never traverse the prototype chain. */
+  private map = new Map<string, PeerRecord>();
+
+  constructor(baseDir: string, opts: PeerStoreOptions = {}) {
+    this.dir = path.join(baseDir, 'lanlink');
+    this.filePath = path.join(this.dir, 'lanlink-peers.json');
+    this.keyPath = path.join(this.dir, 'peer-hmac-key');
+    this.isLive = opts.isLive ?? (() => false);
+    this.reHarden = opts.reHarden ?? reHardenTokenFileAcl;
+    this.secureWrite = opts.secureWrite ?? secureWriteTokenFile;
+    fs.mkdirSync(this.dir, { recursive: true });
+    this.machineKey = this.loadOrCreateMachineKey();
+    this.load();
+  }
+
+  /** A paired/active record, or null if missing OR burned. */
+  get(peerUuid: string): PeerRecord | null {
+    if (typeof peerUuid !== 'string') return null;
+    const r = this.map.get(peerUuid);
+    if (!r || r.burned) return null;
+    return r;
+  }
+
+  /** Insert/replace a paired peer (keyed by the deterministic pairing peerUuid). */
+  upsertPaired(r: PairResult): PeerRecord {
+    const now = nowMs();
+    const rec: PeerRecord = {
+      peerUuid: r.peerUuid,
+      peerName: r.peerName,
+      longTermSecret: r.longTermSecret.toString('base64'),
+      pairedAt: now,
+      lastSeenAt: now,
+      pinFailCount: 0,
+      burned: false,
+      recvHighWater: 0,
+      sendSeq: 0,
+    };
+    // Enforce the cap BEFORE committing a NEW peer (fail-closed): if the store is
+    // full and there is no evictable slot, REJECT the pairing rather than overflow.
+    if (!this.map.has(rec.peerUuid) && this.map.size >= PEER_CAP) {
+      const victim = this.pickEvictable(rec.peerUuid);
+      if (!victim) {
+        throw new Error('LanLink peer store is full — revoke a peer before pairing a new one');
+      }
+      this.map.delete(victim.peerUuid);
+    }
+    this.map.set(rec.peerUuid, rec);
+    this.persist();
+    return rec;
+  }
+
+  /** Mint the next monotonic send sequence for a peer (sender side of C8 dedup). */
+  nextSendSeq(peerUuid: string): number {
+    const r = this.map.get(peerUuid);
+    if (!r) throw new Error(`nextSendSeq: unknown peer ${peerUuid}`);
+    r.sendSeq += 1;
+    this.persist();
+    return r.sendSeq;
+  }
+
+  /** ++pinFailCount on an AEAD-authenticated failure; burn at the threshold (C6). */
+  noteSteadyStateAuthFail(peerUuid: string): void {
+    const r = this.map.get(peerUuid);
+    if (!r) return;
+    r.pinFailCount += 1;
+    if (r.pinFailCount >= PEER_BURN_THRESHOLD) r.burned = true;
+    this.persist();
+  }
+
+  noteSeen(peerUuid: string): void {
+    const r = this.map.get(peerUuid);
+    if (!r) return;
+    r.lastSeenAt = nowMs();
+    this.persist();
+  }
+
+  bumpHighWater(peerUuid: string, senderSeq: number): void {
+    const r = this.map.get(peerUuid);
+    if (!r) return;
+    if (senderSeq > r.recvHighWater) {
+      r.recvHighWater = senderSeq;
+      this.persist();
+    }
+  }
+
+  highWater(peerUuid: string): number {
+    return this.map.get(peerUuid)?.recvHighWater ?? 0;
+  }
+
+  /** Revoke: delete + persist. The server separately destroys live connections (C13). */
+  revoke(peerUuid: string): void {
+    if (this.map.delete(peerUuid)) this.persist();
+  }
+
+  /** No secrets — for lanlink.peers.list. */
+  list(): Array<Omit<PeerRecord, 'longTermSecret'>> {
+    return [...this.map.values()].map((r) => {
+      const { longTermSecret: _secret, ...rest } = r;
+      void _secret;
+      return rest;
+    });
+  }
+
+  /** The decoded 32-byte secret for an active peer (server use only). */
+  secretOf(peerUuid: string): Buffer | null {
+    const r = this.get(peerUuid);
+    return r ? Buffer.from(r.longTermSecret, 'base64') : null;
+  }
+
+  // ── internals ──────────────────────────────────────────────────────────────
+
+  /** LRU eviction candidate: NEVER a burned peer (can't reset a burn, C9), a peer
+   *  with a live connection, or the one being upserted. null if none evictable. */
+  private pickEvictable(keep: string): PeerRecord | null {
+    let victim: PeerRecord | null = null;
+    for (const r of this.map.values()) {
+      if (r.peerUuid === keep || r.burned || this.isLive(r.peerUuid)) continue;
+      if (!victim || r.lastSeenAt < victim.lastSeenAt) victim = r;
+    }
+    return victim;
+  }
+
+  private computeMac(peers: PeerRecord[]): string {
+    return crypto.createHmac('sha256', this.machineKey).update(canonical(peers)).digest('hex');
+  }
+
+  private verifyMac(file: PeerFile): boolean {
+    const expected = this.computeMac(file.peers);
+    const a = Buffer.from(file.mac, 'hex');
+    const b = Buffer.from(expected, 'hex');
+    return a.length === b.length && crypto.timingSafeEqual(a, b);
+  }
+
+  private persist(): void {
+    const peers = [...this.map.values()];
+    const file: PeerFile = { version: 1, mac: this.computeMac(peers), peers };
+    atomicWriteJSONSync(this.filePath, file, { validate: isPeerFile, rotationEnabled: true });
+    const ok = this.reHarden(this.filePath);
+    if (process.platform === 'win32' && !ok) {
+      // Fail closed: never leave the long-term secrets broad-readable.
+      try {
+        fs.unlinkSync(this.filePath);
+      } catch {
+        /* best-effort */
+      }
+      throw new Error('LanLink peer store: could not apply owner-only ACL — refusing to persist secrets');
+    }
+    this.fsyncBestEffort();
+  }
+
+  private load(): void {
+    this.map = new Map();
+    let loaded: PeerFile | null = null;
+    try {
+      loaded = atomicReadJSONSync<PeerFile>(this.filePath, {
+        validate: (v): v is PeerFile => isPeerFile(v) && this.verifyMac(v),
+      });
+    } catch (err) {
+      console.error('[LanLinkPeerStore] Failed to load peer store:', err);
+    }
+    if (loaded) {
+      for (const r of loaded.peers) this.map.set(r.peerUuid, r);
+    }
+  }
+
+  private loadOrCreateMachineKey(): Buffer {
+    try {
+      const existing = fs.readFileSync(this.keyPath, 'utf8').trim();
+      if (existing) {
+        const ok = this.reHarden(this.keyPath);
+        // Fail closed (codex P2): if the integrity key cannot be locked to owner-only
+        // ACLs on win32, do NOT trust a broad-readable key (an attacker who reads it
+        // could forge a planted peer file's HMAC). Discard it and fall through to
+        // regenerate a fresh key with a clean owner-DACL via secureWrite.
+        if (process.platform !== 'win32' || ok) {
+          return Buffer.from(existing, 'hex');
+        }
+        try {
+          fs.unlinkSync(this.keyPath);
+        } catch {
+          /* best-effort — secureWrite below overwrites + re-hardens anyway */
+        }
+      }
+    } catch {
+      /* missing — create below */
+    }
+    const key = crypto.randomBytes(32);
+    this.secureWrite(this.keyPath, key.toString('hex')); // 0o600 + owner DACL, fail-closed
+    return key;
+  }
+
+  private fsyncBestEffort(): void {
+    try {
+      const fd = fs.openSync(this.filePath, 'r+');
+      try {
+        fs.fsyncSync(fd);
+      } finally {
+        fs.closeSync(fd);
+      }
+    } catch {
+      /* best-effort — atomic rename already provides atomicity */
+    }
+  }
+}
+
+function nowMs(): number {
+  return Date.now();
+}

--- a/src/daemon/lanlink/router.ts
+++ b/src/daemon/lanlink/router.ts
@@ -1,0 +1,45 @@
+// === LanLink inbound message-kind allow-list (PR-4, C20) ===
+//
+// A POSITIVE allow-list over the KINDS of application message a paired peer may
+// send over the AEAD channel. This is NOT an RPC forwarder and shares NOTHING
+// with the daemon control pipe (DaemonPipeServer) or the main RpcRouter: it
+// never references a2a.task.send, daemon.inbox.poll, lanlink.status, or any
+// execute/spawn surface — so a remote peer's frame can only ever land read-only
+// in the durable inbox. (The drift-lock test asserts the accepted set excludes
+// all of those plus any execute/spawn/send substring.)
+//
+// Pollution-safe BY CONSTRUCTION (C20): admission is a `typeof === 'string'`
+// pre-check then `.includes` on a FROZEN ARRAY — never an object-map index — so
+// a crafted kind like '__proto__' / 'constructor' / 'hasOwnProperty' cannot
+// masquerade as admitted via a prototype-chain lookup.
+
+/** The only inbound application message kinds a paired peer may send. */
+export const ACCEPTED_KINDS = Object.freeze(['msg.text', 'state.update'] as const);
+export type AcceptedKind = (typeof ACCEPTED_KINDS)[number];
+
+export class RouterError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RouterError';
+  }
+}
+
+/** True iff `k` is an admitted inbound message kind (frozen-array membership). */
+export function isAcceptedKind(k: unknown): k is AcceptedKind {
+  if (typeof k !== 'string') return false;
+  return (ACCEPTED_KINDS as readonly string[]).includes(k);
+}
+
+/**
+ * Admit a kind or THROW RouterError. The dispatch counterpart to the structural
+ * import wall (daemonExecuteWall): an unregistered kind — including
+ * `a2a.task.send` or any execute-spawning kind — is refused before the message
+ * reaches the inbox.
+ */
+export function admitKind(k: unknown): AcceptedKind {
+  if (!isAcceptedKind(k)) {
+    const shown = typeof k === 'string' ? JSON.stringify(k) : typeof k;
+    throw new RouterError(`LanLinkRouter: rejected message kind ${shown}`);
+  }
+  return k;
+}

--- a/src/daemon/lanlink/sanitize.ts
+++ b/src/daemon/lanlink/sanitize.ts
@@ -1,0 +1,97 @@
+/* eslint-disable no-control-regex -- this sanitizer's entire purpose is to match
+   and strip C0/C1/DEL/ESC/OSC control characters from untrusted remote text. */
+// === LanLink ingress sanitizer (PR-4, C16) ===
+//
+// A NEW pure sanitizer for UNTRUSTED remote text — NOT shared/types.ts'
+// sanitizePtyText, which strips only NUL+C1 and deliberately PRESERVES ESC/CSI
+// for trusted PTY-bound output. Remote LAN text is rendered as React text (the
+// no-paste wall keeps it out of any PTY), but it is still control-char and
+// homograph sanitized here, before it reaches the durable inbox, so the renderer
+// never has to trust the bytes.
+//
+// ORDER MATTERS: CR/LF are normalized to a single space FIRST (so a stripped
+// newline cannot weld two lines together), THEN OSC is removed before lone-ESC
+// (so the OSC intro ESC is consumed as part of the OSC, not left as a bare ESC),
+// THEN the control / invisible / bidi classes, THEN the length clamp, THEN a
+// trailing lone surrogate is dropped (no malformed UTF-16 on disk).
+//
+// Pure + TOTAL: this NEVER throws on hostile input — a throw out of the accept
+// loop would be a DoS. A malformed / huge field simply degrades (clamp / strip).
+//
+// Every pattern below is built with `new RegExp(<ascii-escaped string>)` so the
+// source file contains ONLY printable ASCII escape sequences (\\xNN / \\uNNNN) —
+// never a literal invisible/control character, which would be unreviewable and
+// could silently corrupt the very patterns meant to strip it.
+
+import { BODY_MAX, PEER_NAME_MAX, clampText } from '../../shared/lanlink';
+
+// CR/LF + Unicode line/paragraph separators (U+2028/U+2029) -> single space (run
+// FIRST so the C0 strip below can't weld lines, and so a non-C0 separator can't
+// sneak an injected line break past the CR/LF normalization).
+const CRLF_RE = new RegExp('[\\r\\n\\u2028\\u2029]+', 'g');
+// OSC: ESC ] ... BEL (stripped before the lone-ESC pass). An unterminated OSC
+// (no BEL) consumes to end-of-string — the safe over-strip direction.
+const OSC_RE = new RegExp('\\x1B\\][^\\x07]*\\x07?', 'g');
+// C0 controls EXCEPT TAB (0x09); CR/LF already normalized away. Covers
+// 0x00-0x08 and 0x0B-0x1F (so 0x0B/0x0C and the lone ESC 0x1B are included).
+const C0_EXCEPT_TAB_RE = new RegExp('[\\x00-\\x08\\x0B-\\x1F]', 'g');
+// DEL.
+const DEL_RE = new RegExp('\\x7F', 'g');
+// C1 controls, including the 8-bit CSI 0x9B.
+const C1_RE = new RegExp('[\\x80-\\x9F]', 'g');
+// Zero-width / bidi incl. LRI/RLI/FSI/PDI isolates (U+2066-2069, Trojan-Source)
+// and the Arabic letter mark U+061C.
+const ZW_BIDI_RE = new RegExp(
+  '[\\u200B-\\u200F\\u202A-\\u202E\\u2060-\\u2064\\u2066-\\u2069\\u061C\\uFEFF\\u00AD]',
+  'g',
+);
+// Invisible filler homoglyphs (Hangul filler family + halfwidth Hangul filler).
+const FILLER_RE = new RegExp('[\\u115F\\u1160\\u3164\\uFFA0]', 'g');
+
+function strip(raw: string): string {
+  return raw
+    .replace(CRLF_RE, ' ')
+    .replace(OSC_RE, '')
+    .replace(C0_EXCEPT_TAB_RE, '')
+    .replace(DEL_RE, '')
+    .replace(C1_RE, '')
+    .replace(ZW_BIDI_RE, '')
+    .replace(FILLER_RE, '');
+}
+
+/** Drop a trailing high surrogate with no following low surrogate (malformed). */
+function dropTrailingLoneSurrogate(s: string): string {
+  if (s.length === 0) return s;
+  const last = s.charCodeAt(s.length - 1);
+  if (last >= 0xd800 && last <= 0xdbff) return s.slice(0, -1);
+  return s;
+}
+
+function sanitize(raw: string, max: number): string {
+  const stripped = strip(raw);
+  const clamped = clampText(stripped, max);
+  return dropTrailingLoneSurrogate(clamped);
+}
+
+/** Sanitize a remote message body (clamped to BODY_MAX). Never throws. */
+export function sanitizeRemoteText(raw: string): string {
+  return sanitize(raw, BODY_MAX);
+}
+
+/** Sanitize a remote peer display name (clamped to PEER_NAME_MAX). Never throws. */
+export function sanitizeRemotePeerName(raw: string): string {
+  return sanitize(raw, PEER_NAME_MAX);
+}
+
+// Defense-in-depth (C16): after sanitize, re-check for any residual stripped-class
+// codepoint. isInboxFile validates text/peerName only as strings, so this gives a
+// cheap "drop the record" backstop should a strip rule ever regress. TAB is
+// allowed (it is the one preserved C0).
+const RESIDUAL_RE = new RegExp(
+  '[\\x00-\\x08\\x0B-\\x1F\\x7F\\x80-\\x9F\\u2028\\u2029\\u200B-\\u200F\\u202A-\\u202E\\u2060-\\u2064\\u2066-\\u2069\\u061C\\uFEFF\\u00AD\\u115F\\u1160\\u3164\\uFFA0]',
+);
+
+/** True iff `s` still contains a stripped-class codepoint (=> drop the record). */
+export function hasResidualControl(s: string): boolean {
+  return RESIDUAL_RE.test(s);
+}

--- a/src/daemon/lanlink/server.ts
+++ b/src/daemon/lanlink/server.ts
@@ -1,0 +1,652 @@
+// === LanLinkServer — isolated net.Server + per-connection state machine (PR-4) ===
+//
+// The INBOUND network surface. An ISOLATED net.Server (its OWN admission counters,
+// NEVER shared with the control-pipe DaemonPipeServer — sharing would let an
+// unpaired attacker starve local control RPC, G1) bound to the configured NIC.
+// Per-connection lifecycle: ADMITTED -> HANDSHAKE (PAKE or reconnect) -> AEAD.
+// AEAD-GATES-ALL-BYTES (G7): zero app/router/inbox processing before the
+// handshake completes. Inbound app records terminate in the durable inbox
+// (decode -> router -> sanitize -> dedup -> inbox.append -> nudge); there is NO
+// RpcContext, NO RpcRouter, NO execute path — the daemon execute-wall (source
+// scan over src/daemon/**) proves it structurally.
+//
+// Imports node builtins + sibling lanlink files + shared types ONLY. No src/main.
+
+import net from 'node:net';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import { performance } from 'node:perf_hooks';
+import { LANLINK_CONFIG_CHANGED, type LanLinkController } from './controller';
+import { pairWithPeer, sendToPeer } from './client';
+import { assertLanBindAddress, enumerateNics } from './bindGuard';
+import type { LanLinkInbox } from './inbox';
+import { PeerStore } from './peers';
+import { FrameReader, encodeFrame, decodeAppMessage, type FrameType } from './wire';
+import { AeadSealer, AeadOpener, type Direction, type SessionKeys } from './aead';
+import {
+  PairingResponder,
+  reconnectResponder,
+  parseReconnectHello,
+  deterministicUuid,
+  PAIR_TTL_MS,
+  PAIR_FAIL_BURN,
+  PIN_LEN,
+} from './pairing';
+import { admitKind } from './router';
+import { sanitizeRemoteText, sanitizeRemotePeerName, hasResidualControl } from './sanitize';
+import { applyLanLinkFirewall, removeLanLinkFirewall } from './firewall';
+import type { InboxRecord, LanLinkNic, NicInfo } from '../../shared/lanlink';
+
+export const DEFAULT_PORT = 45651;
+
+const HANDSHAKE_TIMEOUT_MS = 5_000; // absolute, NOT reset by byte arrival (slow-loris)
+const IDLE_TIMEOUT_MS = 60_000;
+const MAX_CONNECTIONS_TOTAL = 8;
+const MAX_CONNECTIONS_PER_IP = 2;
+const MAX_NEW_CONN_PER_SEC = 10;
+const MAX_RECORDS_PER_SEC = 50; // post-AEAD per-connection record-rate cap (paired-peer flood)
+
+const PAKE_HELLO: FrameType = 0x01;
+const PAKE2: FrameType = 0x02;
+const CONFIRM: FrameType = 0x03;
+const RECONNECT_HELLO: FrameType = 0x04;
+const RECONNECT2: FrameType = 0x05;
+const AEAD_RECORD: FrameType = 0x10;
+
+export type NetCategory = 'Private' | 'Public' | 'Domain' | 'Unknown';
+
+export interface LanLinkServerDeps {
+  inbox: LanLinkInbox;
+  controller: LanLinkController;
+  nudge: (seq: number) => void;
+  peers: PeerStore;
+  selfName: string;
+  /** Injectable interface snapshot source (tests). Defaults to a live read. */
+  ifaces?: () => NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+  /** Injectable NLM lookup (C15). Default returns 'Unknown' (no sync shell-out); the
+   *  enforced exposure gate is the Windows Public/Domain BLOCK firewall rule. */
+  netCategory?: (ip: string) => NetCategory;
+  /** Injectable net.createServer (tests). */
+  createServer?: (onConn: (s: net.Socket) => void) => net.Server;
+  /** Injectable firewall apply/remove (tests). */
+  firewall?: {
+    apply: (port: number, exe: string) => Promise<void>;
+    remove: () => Promise<void>;
+  };
+}
+
+// 'handshake-reconnect' is intentionally absent: the reconnect path is fully
+// synchronous (no scrypt, no event-loop yield), so a connection never rests in an
+// intermediate reconnect state — onReconnectHello goes admitted -> aead in one tick.
+type ConnState = 'admitted' | 'handshake-pake' | 'aead' | 'dead';
+
+interface Conn {
+  socket: net.Socket;
+  ip: string;
+  state: ConnState;
+  reader: FrameReader;
+  pumping: boolean;
+  deadline: NodeJS.Timeout | null;
+  pairing: PairingResponder | null;
+  sealer: AeadSealer | null;
+  opener: AeadOpener | null;
+  peerUuid: string | null;
+  recordCount: number;
+  recordResetAt: number;
+}
+
+function monoNow(): number {
+  return performance.now();
+}
+
+export class LanLinkServer {
+  private readonly deps: LanLinkServerDeps;
+  private readonly ifaces: () => NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+  private readonly netCategory: (ip: string) => NetCategory;
+  private readonly createServer: (onConn: (s: net.Socket) => void) => net.Server;
+  private readonly fw: { apply: (port: number, exe: string) => Promise<void>; remove: () => Promise<void> };
+
+  private status: { enabled: boolean; nic: LanLinkNic | null; port: number | null };
+  private server: net.Server | null = null;
+  private boundIp: string | null = null;
+  private boundPort: number | null = null;
+  private livenessTimer: NodeJS.Timeout | null = null;
+  private reconcileChain: Promise<void> = Promise.resolve();
+  // Firewall mutations run on their OWN serialized chain so an async `apply`
+  // (netsh add) can NEVER land after a later `remove` and resurrect a stale rule
+  // with no listener behind it (C14 race fix).
+  private fwChain: Promise<void> = Promise.resolve();
+  private disposed = false;
+
+  // Admission (ISOLATED — never the control pipe's counters).
+  private readonly conns = new Set<Conn>();
+  private readonly connsByIp = new Map<string, number>();
+  private newConnWindow = { count: 0, resetAt: 0 };
+
+  // Pairing window (server-global; MAX_PAKE_IN_FLIGHT = 1).
+  private pairingPin: string | null = null;
+  private pairingDeadlineMono: number | null = null;
+  private windowFailCount = 0;
+  private pakeInFlight = false;
+
+  constructor(deps: LanLinkServerDeps) {
+    this.deps = deps;
+    this.ifaces = deps.ifaces ?? (() => os.networkInterfaces());
+    this.netCategory = deps.netCategory ?? (() => 'Unknown');
+    this.createServer = deps.createServer ?? ((onConn) => net.createServer(onConn));
+    this.fw = deps.firewall ?? { apply: applyLanLinkFirewall, remove: removeLanLinkFirewall };
+
+    const s = deps.controller.getStatus(); // 'changed' does NOT fire at boot — read initial state
+    this.status = { enabled: s.enabled, nic: s.nic, port: s.port };
+    deps.controller.on(LANLINK_CONFIG_CHANGED, (cfg: { enabled: boolean; nic: LanLinkNic | null; port?: number }) => {
+      this.status = { enabled: cfg.enabled, nic: cfg.nic, port: cfg.port ?? null };
+      this.scheduleReconcile();
+    });
+    if (this.status.enabled) this.scheduleReconcile();
+  }
+
+  // ── lifecycle (serialized, C14) ─────────────────────────────────────────────
+
+  private scheduleReconcile(): void {
+    this.reconcileChain = this.reconcileChain.then(() => this.doReconcile()).catch((err) => {
+      console.error('[LanLinkServer] reconcile failed:', err);
+    });
+  }
+
+  /** Serialize a firewall mutation so apply/remove can never reorder (C14). */
+  private queueFirewall(op: () => Promise<void>): void {
+    this.fwChain = this.fwChain.then(op).catch((err) => {
+      console.warn('[LanLinkServer] firewall op failed:', err instanceof Error ? err.message : err);
+    });
+  }
+
+  private async doReconcile(): Promise<void> {
+    if (this.disposed) {
+      await this.closeServer();
+      return;
+    }
+    if (!this.status.enabled) {
+      await this.closeServer();
+      this.queueFirewall(() => this.fw.remove());
+      return;
+    }
+    // Enabled: (re)bind. Always close first so a NIC/port change rebinds cleanly.
+    await this.closeServer();
+    try {
+      this.bindOrThrow();
+    } catch (err) {
+      // assertLanBindAddress / listen pre-conditions failed -> stay stopped (C2).
+      console.warn('[LanLinkServer] bind aborted, staying stopped:', err instanceof Error ? err.message : err);
+      await this.closeServer();
+    }
+  }
+
+  /** The ONLY place net.Server.listen() appears. One pinned ifaces snapshot (C14). */
+  private bindOrThrow(): void {
+    if (this.disposed) return; // never (re)bind after teardown, even if a reconcile was queued
+    const snap = this.ifaces();
+    const nic = this.status.nic;
+    if (!nic) return; // no NIC selected -> stay stopped
+    const ip = this.resolveIp(enumerateNics(snap), nic);
+    if (!ip) {
+      console.warn('[LanLinkServer] selected NIC has no live external IPv4 — staying stopped');
+      return;
+    }
+    if (this.netCategory(ip) === 'Public') {
+      console.warn('[LanLinkServer] refusing to listen on a Public-category network');
+      return;
+    }
+    assertLanBindAddress(ip, snap); // C2 fail-closed — throws to abort, caught by doReconcile
+    const port = this.status.port ?? DEFAULT_PORT;
+    const server = this.createServer((s) => this.onConn(s));
+    // OS-level accept throttle so libuv stops accepting past the cap BEFORE the
+    // app-level admission gate allocates a socket + runs onConn — mitigates an
+    // accept-flood that would otherwise churn the event loop (G1). Mirrors
+    // DaemonPipeServer.maxConnections.
+    server.maxConnections = MAX_CONNECTIONS_TOTAL;
+    server.on('error', (err) => {
+      // C14: wired BEFORE listen; any listen error -> stop, never wildcard/retry-loop.
+      console.warn('[LanLinkServer] listen error, staying stopped:', err.message);
+      void this.closeServer();
+    });
+    server.listen(port, ip);
+    this.server = server;
+    this.boundIp = ip;
+    this.boundPort = port;
+    this.queueFirewall(() => this.fw.apply(port, process.execPath));
+    this.startLiveness(nic, ip);
+  }
+
+  private resolveIp(nics: NicInfo[], nic: LanLinkNic): string | null {
+    const match = nics.find((n) => n.name === nic.name && n.mac === nic.mac);
+    if (!match) return null;
+    // Deterministic pick: exclude link-local 169.254/16, then lowest address — so
+    // the pairing-time and listen-time addresses agree.
+    const usable = match.addresses.filter((a) => !a.startsWith('169.254.')).sort();
+    return usable[0] ?? null;
+  }
+
+  private startLiveness(nic: LanLinkNic, boundIp: string): void {
+    this.clearLiveness();
+    this.livenessTimer = setInterval(() => {
+      const snap = this.ifaces();
+      const ip = this.resolveIp(enumerateNics(snap), nic);
+      if (ip !== boundIp) {
+        // The bound IP changed (DHCP renew) OR the NIC vanished. Reconcile rather
+        // than hard-stop: doReconcile closes the old listener and bindOrThrow
+        // re-resolves the NIC's live IPv4 — rebinding to the new address if the
+        // NIC still has one, or staying stopped if resolveIp returns null (NIC
+        // gone). Never a wildcard; bindOrThrow re-asserts the address (C2/C14).
+        console.warn('[LanLinkServer] bound NIC address changed — reconciling');
+        this.scheduleReconcile();
+      }
+    }, 10_000);
+    this.livenessTimer.unref?.();
+  }
+
+  private clearLiveness(): void {
+    if (this.livenessTimer) {
+      clearInterval(this.livenessTimer);
+      this.livenessTimer = null;
+    }
+  }
+
+  private closeServer(): Promise<void> {
+    this.clearLiveness();
+    for (const conn of [...this.conns]) this.destroy(conn);
+    const server = this.server;
+    this.server = null;
+    this.boundIp = null;
+    this.boundPort = null;
+    if (!server) return Promise.resolve();
+    return new Promise((resolve) => server.close(() => resolve()));
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.cancelPairing();
+    void this.closeServer();
+    this.queueFirewall(() => this.fw.remove());
+  }
+
+  // ── pairing window (C6) ─────────────────────────────────────────────────────
+
+  enterPairingMode(pin: string, ttlMs: number = PAIR_TTL_MS): void {
+    this.pairingPin = pin;
+    this.pairingDeadlineMono = monoNow() + ttlMs;
+    this.windowFailCount = 0;
+  }
+
+  cancelPairing(): void {
+    this.pairingPin = null;
+    this.pairingDeadlineMono = null;
+    this.windowFailCount = 0;
+  }
+
+  isPairingActive(): boolean {
+    return (
+      this.pairingPin !== null &&
+      this.pairingDeadlineMono !== null &&
+      monoNow() < this.pairingDeadlineMono &&
+      this.windowFailCount < PAIR_FAIL_BURN
+    );
+  }
+
+  pairingStatus(): { active: boolean; expiresInMs: number | null; failCount: number } {
+    const active = this.isPairingActive();
+    const expiresInMs =
+      active && this.pairingDeadlineMono !== null ? Math.max(0, Math.round(this.pairingDeadlineMono - monoNow())) : null;
+    return { active, expiresInMs, failCount: this.windowFailCount };
+  }
+
+  private noteWindowFailure(): void {
+    this.windowFailCount += 1;
+    if (this.windowFailCount >= PAIR_FAIL_BURN) this.cancelPairing(); // disarm entirely (C6)
+  }
+
+  /** Revoke + destroy live connections of that peer (C13). */
+  revokePeer(peerUuid: string): void {
+    this.deps.peers.revoke(peerUuid);
+    for (const conn of [...this.conns]) {
+      if (conn.peerUuid === peerUuid) this.destroy(conn);
+    }
+  }
+
+  // ── control surface (driven by the daemon control pipe) ─────────────────────
+
+  /** Mint a fresh 6-digit PIN and arm the pairing window. */
+  beginPairing(): { pin: string; expiresInMs: number | null } {
+    const pin = String(crypto.randomInt(0, 1_000_000)).padStart(PIN_LEN, '0');
+    this.enterPairingMode(pin);
+    return { pin, expiresInMs: this.pairingStatus().expiresInMs };
+  }
+
+  /** Paired peers, secrets stripped (for lanlink.peers.list). */
+  listPeers(): Array<{ peerUuid: string; peerName: string; pairedAt: number; lastSeenAt: number; burned: boolean }> {
+    return this.deps.peers.list().map((p) => ({
+      peerUuid: p.peerUuid,
+      peerName: p.peerName,
+      pairedAt: p.pairedAt,
+      lastSeenAt: p.lastSeenAt,
+      burned: p.burned,
+    }));
+  }
+
+  /** OUTBOUND: join a pairing the peer armed (initiator side). */
+  joinPeer(host: string, port: number, pin: string): Promise<{ peerUuid: string; peerName: string }> {
+    return pairWithPeer({ host, port, pin, selfName: this.deps.selfName, peers: this.deps.peers }).then((r) => ({
+      peerUuid: r.peerUuid,
+      peerName: r.peerName,
+    }));
+  }
+
+  /** OUTBOUND: send one read-only message to a paired peer (reconnect + AEAD). */
+  async sendMessage(host: string, port: number, peerUuid: string, text: string): Promise<void> {
+    await sendToPeer({ host, port, peerUuid, peers: this.deps.peers, selfName: this.deps.selfName, text });
+  }
+
+  // ── connection handling ─────────────────────────────────────────────────────
+
+  private onConn(socket: net.Socket): void {
+    const ip = socket.remoteAddress ?? 'unknown';
+    const now = Date.now();
+    if (now > this.newConnWindow.resetAt) this.newConnWindow = { count: 0, resetAt: now + 1000 };
+    this.newConnWindow.count += 1;
+    if (this.newConnWindow.count > MAX_NEW_CONN_PER_SEC) {
+      socket.destroy();
+      return;
+    }
+    if (this.conns.size >= MAX_CONNECTIONS_TOTAL) {
+      socket.destroy();
+      return;
+    }
+    if ((this.connsByIp.get(ip) ?? 0) >= MAX_CONNECTIONS_PER_IP) {
+      socket.destroy();
+      return;
+    }
+
+    const conn: Conn = {
+      socket,
+      ip,
+      state: 'admitted',
+      reader: new FrameReader(),
+      pumping: false,
+      deadline: null,
+      pairing: null,
+      sealer: null,
+      opener: null,
+      peerUuid: null,
+      recordCount: 0,
+      recordResetAt: 0,
+    };
+    this.conns.add(conn);
+    this.connsByIp.set(ip, (this.connsByIp.get(ip) ?? 0) + 1);
+    // ABSOLUTE handshake deadline — not reset by byte arrival (slow-loris, G1).
+    conn.deadline = setTimeout(() => this.destroy(conn), HANDSHAKE_TIMEOUT_MS);
+    conn.deadline.unref?.();
+
+    socket.on('data', (chunk: Buffer) => {
+      try {
+        conn.reader.push(chunk);
+      } catch {
+        this.destroy(conn); // backlog / frame-size violation (G1)
+        return;
+      }
+      void this.pump(conn);
+    });
+    socket.on('close', () => this.destroy(conn));
+    socket.on('error', () => this.destroy(conn));
+  }
+
+  /** Read conn.state through a function boundary so TS does not narrow the literal
+   *  across await points (destroy() can flip it to 'dead' during a scrypt await). */
+  private isDead(conn: Conn): boolean {
+    return conn.state === 'dead';
+  }
+
+  private async pump(conn: Conn): Promise<void> {
+    if (conn.pumping || this.isDead(conn)) return;
+    conn.pumping = true;
+    try {
+      let frame: { type: FrameType; body: Buffer } | null;
+      while (!this.isDead(conn) && (frame = conn.reader.next()) !== null) {
+        await this.handleFrame(conn, frame);
+      }
+    } catch {
+      // Broad wall (C11): WireError / any unexpected throw -> destroy, never crash.
+      this.destroy(conn);
+    } finally {
+      conn.pumping = false;
+    }
+  }
+
+  private async handleFrame(conn: Conn, frame: { type: FrameType; body: Buffer }): Promise<void> {
+    switch (conn.state) {
+      case 'admitted':
+        if (frame.type === PAKE_HELLO) return this.onPakeHello(conn, frame.body);
+        if (frame.type === RECONNECT_HELLO) return this.onReconnectHello(conn, frame.body);
+        this.destroy(conn); // G7: only handshake-init frames in ADMITTED
+        return;
+      case 'handshake-pake':
+        if (frame.type === CONFIRM) return this.onConfirm(conn, frame.body);
+        this.destroy(conn);
+        return;
+      case 'aead':
+        if (frame.type === AEAD_RECORD) return this.onAeadRecord(conn, frame.body);
+        this.destroy(conn); // G7: no cleartext handshake frame after AEAD
+        return;
+      default:
+        this.destroy(conn);
+    }
+  }
+
+  private async onPakeHello(conn: Conn, body: Buffer): Promise<void> {
+    // Window-gated BEFORE any crypto (C5/G7): no scrypt on unauthenticated bytes
+    // outside an armed window, and only one scrypt in flight.
+    if (!this.isPairingActive() || this.pakeInFlight) {
+      this.destroy(conn);
+      return;
+    }
+    // Hold pakeInFlight for the ENTIRE scrypt lifetime (C5 fix): a mid-scrypt
+    // socket close must NOT free the slot early, or an attacker could close-and-
+    // retry to pile unbounded concurrent scrypt jobs onto the libuv pool and
+    // starve the machine-local control pipe (G1). The slot is released only after
+    // the scrypt promise settles, below — never in destroy().
+    this.pakeInFlight = true;
+    conn.state = 'handshake-pake';
+    conn.pairing = new PairingResponder(this.pairingPin as string, this.deps.selfName);
+    let pake2: Buffer;
+    try {
+      pake2 = await conn.pairing.onHello(body); // scrypt runs here (async threadpool)
+    } catch {
+      // bad point / DH throw / malformed hello -> unified failure (window-burn).
+      this.pakeInFlight = false;
+      this.noteWindowFailure();
+      this.destroy(conn);
+      return;
+    }
+    this.pakeInFlight = false; // scrypt settled -> the next PAKE may start
+    if (this.isDead(conn)) {
+      // Closed mid-scrypt: count the abandoned handshake so churn burns the window.
+      this.noteWindowFailure();
+      return;
+    }
+    this.send(conn, PAKE2, pake2);
+  }
+
+  private onConfirm(conn: Conn, body: Buffer): void {
+    if (!conn.pairing) {
+      this.destroy(conn);
+      return;
+    }
+    let r: ReturnType<PairingResponder['onConfirm']>;
+    try {
+      r = conn.pairing.onConfirm(body);
+    } catch {
+      this.noteWindowFailure(); // wrong PIN / MAC mismatch
+      this.destroy(conn);
+      return;
+    }
+    // Success: persist the peer, establish AEAD, send respMac as the first record.
+    // (The PAKE slot was already released when onHello's scrypt settled.)
+    this.deps.peers.upsertPaired(r.result);
+    this.establishAead(conn, r.result.peerUuid, r.sessionKeys);
+    this.send(conn, AEAD_RECORD, conn.sealer!.seal(r.respMac));
+  }
+
+  private onReconnectHello(conn: Conn, body: Buffer): void {
+    let parsed: ReturnType<typeof parseReconnectHello>;
+    try {
+      parsed = parseReconnectHello(body);
+    } catch {
+      this.destroy(conn);
+      return;
+    }
+    const secret = this.deps.peers.secretOf(parsed.peerUuid); // null if missing/burned/revoked
+    if (!secret) {
+      this.destroy(conn); // before any crypto (C3)
+      return;
+    }
+    try {
+      const { sessionKeys, reconnect2Body } = reconnectResponder(secret, parsed.ephPubRaw, parsed.connNonce);
+      this.establishAead(conn, parsed.peerUuid, sessionKeys);
+      this.send(conn, RECONNECT2, reconnect2Body);
+    } catch {
+      this.destroy(conn);
+    }
+  }
+
+  private establishAead(conn: Conn, peerUuid: string, keys: SessionKeys): void {
+    // Responder: opens c2s (joiner->host), seals s2c (host->joiner).
+    const c2s: Direction = 1;
+    const s2c: Direction = 2;
+    conn.opener = new AeadOpener(keys.c2sKey, c2s);
+    conn.sealer = new AeadSealer(keys.s2cKey, s2c);
+    conn.peerUuid = peerUuid;
+    conn.state = 'aead';
+    if (conn.deadline) {
+      clearTimeout(conn.deadline);
+      conn.deadline = null;
+    }
+    conn.socket.setTimeout(IDLE_TIMEOUT_MS, () => this.destroy(conn));
+  }
+
+  private onAeadRecord(conn: Conn, body: Buffer): void {
+    // Post-AEAD per-connection record-rate cap: even an authenticated, paired peer
+    // cannot spin synchronous fsync'd inbox appends past this rate.
+    const now = Date.now();
+    if (now > conn.recordResetAt) {
+      conn.recordCount = 0;
+      conn.recordResetAt = now + 1000;
+    }
+    if (++conn.recordCount > MAX_RECORDS_PER_SEC) {
+      this.destroy(conn);
+      return;
+    }
+    const peerUuid = conn.peerUuid as string;
+    // C13 live-revoke gate: a peer revoked mid-stream stops delivering immediately.
+    if (!this.deps.peers.get(peerUuid)) {
+      this.destroy(conn);
+      return;
+    }
+    let pt: Buffer;
+    try {
+      pt = conn.opener!.open(body);
+    } catch {
+      // crypto failure (tag/replay/short) on an authenticated channel: drop the
+      // connection. NOT a per-peer burn — could be transient corruption, and a
+      // real peer must not be burned for it.
+      this.destroy(conn);
+      return;
+    }
+    let msg: ReturnType<typeof decodeAppMessage>;
+    let kind: string;
+    try {
+      msg = decodeAppMessage(pt);
+      kind = admitKind(msg.kind);
+    } catch {
+      // An AUTHENTICATED peer sent a disallowed/malformed app message -> misbehaving.
+      // Bounded by the per-peer steady-state burn (C6) so a paired-but-hostile peer
+      // cannot flood garbage indefinitely.
+      this.deps.peers.noteSteadyStateAuthFail(peerUuid);
+      this.destroy(conn);
+      return;
+    }
+    void kind; // admitted; the inbox stores text only, not the kind
+    const text = sanitizeRemoteText(msg.text);
+    const peerName = sanitizeRemotePeerName(msg.peerName);
+    if (hasResidualControl(text) || hasResidualControl(peerName)) {
+      return; // C16 defense-in-depth: drop the record, keep the connection
+    }
+    // C8 cross-connection dedup: drop a duplicate/replayed senderSeq (the AEAD
+    // counter is intra-connection only). Not an error — just don't re-deliver.
+    if (msg.senderSeq <= this.deps.peers.highWater(peerUuid)) return;
+    const id = deterministicUuid(`${peerUuid}:${msg.senderSeq}`);
+    const rec: Omit<InboxRecord, 'seq'> = {
+      id,
+      origin: 'remote',
+      peerName,
+      text,
+      receivedAt: Date.now(),
+      ...(msg.state !== undefined ? { state: msg.state } : {}),
+    };
+    // Ack ordering (non-negotiable): durable append+fsync BEFORE high-water bump,
+    // app-ACK, and nudge.
+    const { seq } = this.deps.inbox.append(rec);
+    this.deps.peers.bumpHighWater(peerUuid, msg.senderSeq);
+    this.deps.peers.noteSeen(peerUuid);
+    // App-level AEAD-sealed ACK (after the durable write).
+    this.send(conn, AEAD_RECORD, conn.sealer!.seal(Buffer.from(JSON.stringify({ ack: id }), 'utf8')));
+    this.deps.nudge(seq);
+  }
+
+  private send(conn: Conn, type: FrameType, body: Buffer): void {
+    if (conn.state === 'dead' || conn.socket.destroyed) return;
+    try {
+      conn.socket.write(encodeFrame(type, body));
+    } catch {
+      this.destroy(conn);
+    }
+  }
+
+  private destroy(conn: Conn): void {
+    if (conn.state === 'dead') return;
+    conn.state = 'dead';
+    // NOTE: destroy() deliberately does NOT touch pakeInFlight — the slot is owned
+    // by onPakeHello for the scrypt lifetime and released there (C5 fix). Freeing
+    // it here on a mid-scrypt close is exactly the close-and-retry starvation hole.
+    if (conn.deadline) {
+      clearTimeout(conn.deadline);
+      conn.deadline = null;
+    }
+    try {
+      conn.socket.destroy();
+    } catch {
+      /* ignore */
+    }
+    if (this.conns.delete(conn)) {
+      const n = (this.connsByIp.get(conn.ip) ?? 1) - 1;
+      if (n <= 0) this.connsByIp.delete(conn.ip);
+      else this.connsByIp.set(conn.ip, n);
+    }
+  }
+
+  /** True if a paired peer has a live AEAD connection (PeerStore eviction guard). */
+  hasLiveConn(peerUuid: string): boolean {
+    for (const c of this.conns) {
+      if (c.peerUuid === peerUuid && c.state === 'aead') return true;
+    }
+    return false;
+  }
+
+  // ── test/diagnostic accessors ───────────────────────────────────────────────
+
+  /** Whether the listener is currently bound (test/diagnostics). */
+  isListening(): boolean {
+    return this.server !== null;
+  }
+
+  boundAddress(): { ip: string; port: number } | null {
+    return this.boundIp && this.boundPort ? { ip: this.boundIp, port: this.boundPort } : null;
+  }
+}

--- a/src/daemon/lanlink/server.ts
+++ b/src/daemon/lanlink/server.ts
@@ -246,6 +246,14 @@ export class LanLinkServer {
         // gone). Never a wildcard; bindOrThrow re-asserts the address (C2/C14).
         console.warn('[LanLinkServer] bound NIC address changed — reconciling');
         this.scheduleReconcile();
+        return;
+      }
+      // Re-evaluate the network category too (codex): a NIC can be re-classified
+      // Private -> Public while keeping the same IP. Reconcile so bindOrThrow's
+      // Public refusal stops the listener + removes the firewall rule.
+      if (this.netCategory(boundIp) === 'Public') {
+        console.warn('[LanLinkServer] bound NIC became Public — reconciling (will stay stopped)');
+        this.scheduleReconcile();
       }
     }, 10_000);
     this.livenessTimer.unref?.();

--- a/src/daemon/lanlink/server.ts
+++ b/src/daemon/lanlink/server.ts
@@ -592,10 +592,14 @@ export class LanLinkServer {
     if (hasResidualControl(text) || hasResidualControl(peerName)) {
       return; // C16 defense-in-depth: drop the record, keep the connection
     }
-    // C8 cross-connection dedup: drop a duplicate/replayed senderSeq (the AEAD
-    // counter is intra-connection only). Not an error — just don't re-deliver.
-    if (msg.senderSeq <= this.deps.peers.highWater(peerUuid)) return;
     const id = deterministicUuid(`${peerUuid}:${msg.senderSeq}`);
+    // C8 cross-connection dedup: a duplicate/replayed senderSeq is not re-delivered
+    // (the AEAD counter is intra-connection only). Re-ACK with the SAME id so a
+    // retrying sender (who didn't get the first ACK) still commits — idempotent.
+    if (msg.senderSeq <= this.deps.peers.highWater(peerUuid)) {
+      this.send(conn, AEAD_RECORD, conn.sealer!.seal(Buffer.from(JSON.stringify({ ack: id }), 'utf8')));
+      return;
+    }
     const rec: Omit<InboxRecord, 'seq'> = {
       id,
       origin: 'remote',

--- a/src/daemon/lanlink/server.ts
+++ b/src/daemon/lanlink/server.ts
@@ -179,6 +179,12 @@ export class LanLinkServer {
       console.warn('[LanLinkServer] bind aborted, staying stopped:', err instanceof Error ? err.message : err);
       await this.closeServer();
     }
+    // If we ended up with NO listener while enabled (no NIC / no live IP / Public /
+    // assert threw), remove any firewall rule a previous successful bind left behind
+    // so a stale ALLOW never outlives the listener (CodeRabbit).
+    if (!this.server) {
+      this.queueFirewall(() => this.fw.remove());
+    }
   }
 
   /** The ONLY place net.Server.listen() appears. One pinned ifaces snapshot (C14). */
@@ -208,6 +214,7 @@ export class LanLinkServer {
       // C14: wired BEFORE listen; any listen error -> stop, never wildcard/retry-loop.
       console.warn('[LanLinkServer] listen error, staying stopped:', err.message);
       void this.closeServer();
+      this.queueFirewall(() => this.fw.remove()); // don't leave a rule with no listener
     });
     server.listen(port, ip);
     this.server = server;

--- a/src/daemon/lanlink/server.ts
+++ b/src/daemon/lanlink/server.ts
@@ -478,6 +478,13 @@ export class LanLinkServer {
       this.noteWindowFailure();
       return;
     }
+    // Re-check the window AFTER the async scrypt (codex): it may have expired (TTL)
+    // or been disarmed while scrypt ran — don't continue a handshake into a closed
+    // window.
+    if (!this.isPairingActive()) {
+      this.destroy(conn);
+      return;
+    }
     this.send(conn, PAKE2, pake2);
   }
 

--- a/src/daemon/lanlink/wire.ts
+++ b/src/daemon/lanlink/wire.ts
@@ -1,0 +1,180 @@
+// === LanLink wire codec + app-message decoder (PR-4, pure, state-free) ===
+//
+// Binary length-prefix framing for the AEAD channel. UNLIKE the control pipe
+// (DaemonPipeServer, newline-JSON TEXT framing), the LAN channel is BINARY:
+// [u32be length][u8 type][body]. The codec is STATE-FREE — it knows nothing
+// about connection state; rejecting an out-of-state frame type is the server's
+// job (C3). All caps here are pre-decrypt (G1) so an unpaired attacker cannot
+// exhaust memory before authentication.
+
+import { isTaskState, type TaskState } from '../../shared/types';
+
+export const WIRE_VERSION = 1;
+export const MIN_WIRE_VERSION = 1;
+export const CIPHER_ID = 1; // 1 == chacha20-poly1305 IETF (the ONLY accepted cipher)
+export const ACCEPTED_VERSIONS = Object.freeze([1] as const);
+export const ACCEPTED_CIPHERS = Object.freeze([1] as const);
+export const MAX_FRAME = 64 * 1024; // G1: pre-decrypt OOM cap on a single frame
+export const MAX_JSON_DEPTH = 64; // C11: pre-parse JSON-bomb guard
+export const LEN_BYTES = 4;
+
+export type FrameType =
+  | 0x01 // PAKE_HELLO      (unknown peer, window-gated)
+  | 0x02 // PAKE2           (responder -> joiner)
+  | 0x03 // CONFIRM         (joiner -> responder ONLY)
+  | 0x04 // RECONNECT_HELLO (known peer, ephemeral-DH, no scrypt)
+  | 0x05 // RECONNECT2      (responder -> joiner, ephemeral pub + nonce)
+  | 0x10; // AEAD_RECORD
+
+const VALID_FRAME_TYPES: ReadonlySet<number> = new Set([0x01, 0x02, 0x03, 0x04, 0x05, 0x10]);
+
+export class WireError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WireError';
+  }
+}
+
+/**
+ * Pulls complete length-prefixed frames out of a growing buffer. STATE-FREE.
+ * THROWS WireError on: a declared length > MAX_FRAME, a buffered backlog that
+ * exceeds one max frame (slow-loris memory, G1), or an unknown type byte.
+ */
+export class FrameReader {
+  private buf: Buffer = Buffer.alloc(0);
+  private readonly maxFrame: number;
+
+  constructor(maxFrame: number = MAX_FRAME) {
+    this.maxFrame = maxFrame;
+  }
+
+  push(chunk: Buffer): void {
+    // Append. The server drains complete frames immediately via next(), so the
+    // backlog normally holds only the in-flight partial frame plus any frames
+    // pipelined into the same TCP segment (legitimate back-to-back traffic — e.g.
+    // a near-max AEAD record split across segments followed by the next record).
+    // A hard ceiling well ABOVE a single max frame prevents pre-decrypt OOM (G1)
+    // without rejecting that legitimate pipelining; an oversized SINGLE frame is
+    // still rejected by next() (declared length > maxFrame), and a dribbled
+    // never-completing partial frame is killed by the server's handshake / idle
+    // timeout (slow-loris). The earlier `maxFrame + LEN_BYTES` cap wrongly
+    // rejected a valid record that arrived back-to-back with the next one.
+    if (this.buf.length + chunk.length > 4 * this.maxFrame) {
+      throw new WireError('LanLink frame backlog exceeds limit');
+    }
+    this.buf = this.buf.length === 0 ? Buffer.from(chunk) : Buffer.concat([this.buf, chunk]);
+  }
+
+  /** Returns the next complete frame, or null if more bytes are needed. */
+  next(): { type: FrameType; body: Buffer } | null {
+    if (this.buf.length < LEN_BYTES) return null;
+    const len = this.buf.readUInt32BE(0);
+    if (len < 1 || len > this.maxFrame) {
+      throw new WireError(`LanLink declared frame length ${len} out of range`);
+    }
+    if (this.buf.length < LEN_BYTES + len) return null; // incomplete — need more
+    const type = this.buf[LEN_BYTES];
+    if (!VALID_FRAME_TYPES.has(type)) {
+      throw new WireError(`LanLink unknown frame type 0x${type.toString(16)}`);
+    }
+    const body = Buffer.from(this.buf.subarray(LEN_BYTES + 1, LEN_BYTES + len));
+    this.buf = Buffer.from(this.buf.subarray(LEN_BYTES + len));
+    return { type: type as FrameType, body };
+  }
+}
+
+/** Encode a frame: [u32be (1 + body.length)][u8 type][body]. */
+export function encodeFrame(type: FrameType, body: Buffer): Buffer {
+  const len = 1 + body.length;
+  if (len > MAX_FRAME) throw new WireError('encodeFrame: body exceeds MAX_FRAME');
+  const out = Buffer.allocUnsafe(LEN_BYTES + len);
+  out.writeUInt32BE(len, 0);
+  out.writeUInt8(type, LEN_BYTES);
+  body.copy(out, LEN_BYTES + 1);
+  return out;
+}
+
+/**
+ * Parse DECRYPTED plaintext JSON with two hardenings (C11): a pre-parse nesting
+ * scan rejects a JSON bomb (> MAX_JSON_DEPTH nested `[`/`{`) BEFORE JSON.parse
+ * builds the tree, and a reviver drops `__proto__` / `constructor` / `prototype`
+ * keys so a crafted message can't pollute any object it lands in. THROWS
+ * WireError on a bomb or on invalid JSON.
+ */
+export function safeJsonParse(buf: Buffer): unknown {
+  const text = buf.toString('utf8');
+  let depth = 0;
+  let inStr = false;
+  let escaped = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inStr) {
+      if (escaped) escaped = false;
+      else if (c === '\\') escaped = true;
+      else if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '"') inStr = true;
+    else if (c === '[' || c === '{') {
+      depth++;
+      if (depth > MAX_JSON_DEPTH) throw new WireError('LanLink JSON nesting exceeds MAX_JSON_DEPTH');
+    } else if (c === ']' || c === '}') {
+      if (depth > 0) depth--;
+    }
+  }
+  try {
+    return JSON.parse(text, (key, value) => {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') return undefined;
+      return value;
+    });
+  } catch (err) {
+    throw new WireError(`LanLink invalid JSON: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export interface DecodedAppMessage {
+  /** Raw message kind — NOT yet admitted; the server calls router.admitKind. */
+  kind: string;
+  peerName: string;
+  text: string;
+  senderSeq: number; // C8 idempotency: monotonic per-peer
+  state?: TaskState; // C10: attached only when isTaskState
+}
+
+const ALLOWED_KEYS: ReadonlySet<string> = new Set(['kind', 'peerName', 'text', 'senderSeq', 'state']);
+
+/**
+ * Decode decrypted plaintext into the restricted TEXT-ONLY schema with a
+ * POSITIVE key allow-list. THROWS WireError on any extra key (incl. parts /
+ * file / data / mimeType / bytes / uri — a full Task is never deserialized),
+ * non-string text/peerName/kind, or a non-finite-int senderSeq. A `state` field
+ * present-but-not-a-valid-TaskState is DROPPED (the record proceeds without it,
+ * C10); the disk validator additionally rejects a present-and-invalid state.
+ */
+export function decodeAppMessage(plaintext: Buffer): DecodedAppMessage {
+  const parsed = safeJsonParse(plaintext);
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new WireError('LanLink app message must be a JSON object');
+  }
+  const o = parsed as Record<string, unknown>;
+  for (const k of Object.keys(o)) {
+    if (!ALLOWED_KEYS.has(k)) {
+      throw new WireError(`LanLink app message has disallowed key ${JSON.stringify(k)}`);
+    }
+  }
+  const kind = o['kind'];
+  if (typeof kind !== 'string') throw new WireError('LanLink app message kind must be a string');
+  const peerName = o['peerName'];
+  if (typeof peerName !== 'string') throw new WireError('LanLink app message peerName must be a string');
+  const text = o['text'];
+  if (typeof text !== 'string') throw new WireError('LanLink app message text must be a string');
+  const senderSeq = o['senderSeq'];
+  if (typeof senderSeq !== 'number' || !Number.isInteger(senderSeq) || senderSeq < 0) {
+    throw new WireError('LanLink app message senderSeq must be a non-negative integer');
+  }
+  const msg: DecodedAppMessage = { kind, peerName, text, senderSeq };
+  if ('state' in o && isTaskState(o['state'])) {
+    msg.state = o['state'];
+  }
+  return msg;
+}

--- a/src/shared/lanlink.ts
+++ b/src/shared/lanlink.ts
@@ -12,7 +12,7 @@
 // `origin: 'remote'` and is treated as untrusted (G3): it is rendered as React
 // text and NEVER pasted into a PTY or routed to the a2a execute path.
 
-import type { TaskState } from './types';
+import { isTaskState, type TaskState } from './types';
 
 /**
  * Fixed non-session sentinel for the `lanlink.remote.received` DaemonEvent.
@@ -322,10 +322,11 @@ export function isInboxFile(v: unknown): v is InboxFile {
     if ((rec['seq'] as number) <= prevSeq) return false;
     // seq can never exceed the persisted counter.
     if ((rec['seq'] as number) > (o['nextSeq'] as number)) return false;
-    // NOTE: rec['state'] is intentionally NOT validated — in PR-2 it is never
-    // materialized to the renderer (RemoteInboxItem has no `state` field), so an
-    // unvalidated value is inert. If a future PR forwards record.state to any
-    // consumer, add an isTaskState guard for it here.
+    // PR-4 (C10): the LAN listener now attaches `state` from an UNTRUSTED wire
+    // message. A present-but-invalid state must reject the whole record at the
+    // disk boundary so a hostile value can never become a VALID_TRANSITIONS[state]
+    // lookup key on any downstream consumer. Absent state stays valid (optional).
+    if ('state' in rec && !isTaskState(rec['state'])) return false;
     prevSeq = rec['seq'] as number;
   }
   return true;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -527,6 +527,27 @@ export interface Message {
 
 export type TaskState = 'submitted' | 'working' | 'input-required' | 'completed' | 'failed' | 'canceled';
 
+/** Every valid TaskState, in declaration order — the single source for isTaskState. */
+export const TASK_STATES: readonly TaskState[] = [
+  'submitted',
+  'working',
+  'input-required',
+  'completed',
+  'failed',
+  'canceled',
+];
+
+/**
+ * Runtime type guard for TaskState. Authored for LanLink PR-4 (C10): a `state`
+ * field decoded from an UNTRUSTED LAN wire message must be membership-validated
+ * before it is attached to a durable inbox record, so a hostile value can never
+ * become a `VALID_TRANSITIONS[state]` lookup key (prototype / type-confusion) on
+ * any downstream consumer. Rejects non-strings, objects, and `'constructor'` etc.
+ */
+export function isTaskState(v: unknown): v is TaskState {
+  return typeof v === 'string' && (TASK_STATES as readonly string[]).includes(v);
+}
+
 export interface TaskStatus {
   state: TaskState;
   message?: Message;


### PR DESCRIPTION
LanLink epic **PR-4**: the security-critical network surface in the daemon. An isolated `net.Server`, PIN-EKE pairing, an AEAD channel, an allow-list router, an ingress sanitizer, and a per-peer store — inbound messages terminate in the PR-2 durable inbox. `enabled` defaults **OFF**; **execute is physically impossible**.

## What's in it
- **server.ts** — isolated `net.Server` (own admission counters, never the control pipe's — G1), per-connection state machine `ADMITTED → HANDSHAKE → AEAD` (AEAD gates all app bytes, G7), single `bindOrThrow` choke-point (`assertLanBindAddress` fail-closed, `on('error')` before listen, `maxConnections`), liveness rebind on DHCP renew / stop on NIC vanish, serialized reconcile + firewall chains, broad per-record exception wall.
- **pairing.ts** — double-masked PIN-EKE (X25519 + `scrypt(PIN)` + HKDF), PIN never on the wire, **top-bit whitening** (a raw X25519 pubkey's bit 255 is always 0; whitening removes the passive offline PIN-bit distinguisher), mutual key-confirmation MAC, reconnect (fresh ephemeral DH, no scrypt), window-scoped fail-burn, `MAX_PAKE_IN_FLIGHT` held for the whole scrypt lifetime.
- **aead.ts** — native `chacha20-poly1305` IETF, per-connection **fresh ephemeral DH** keys, direction-separated keys, counter nonce + strictly-increasing replay drop + overflow guard + AAD binding.
- **router / sanitize / peers / wire / client** — frozen positive allow-list; Trojan-Source sanitizer; HMAC-bound fail-closed peer store with live revoke + app-level dedup; binary length-prefix framing with a positive key allow-list (text-only, rejects file/data/parts); outbound pairing-join / message-send.
- **index.ts** — constructs `LanLinkServer` alongside the inbox/controller; daemon control RPCs `lanlink.pair.*` / `send` / `peers.*` (renderer Settings UI is PR-5). `daemonExecuteWall` extended with a `/main/(a2a|pipe)/` import regex.

## execute is physically impossible (4-layer wall)
L1 daemon import scan (no `ClaudeWorker` / `RpcRouter` / `a2a.rpc` / `main/(a2a|pipe)`) · L2 router positive allow-list · L3 no `RpcContext` on the LAN path → inbox terminus · L4 main-side no-paste. Inbound flow: `AeadOpener.open` → `decodeAppMessage` (positive key allow-list) → `admitKind` → sanitize → dedup → `LanLinkInbox.append({origin:'remote'})` → nudge.

## Review
Adversarially reviewed (opus 8-dimension panel + codex cross-model): **execute-reach / downgrade-G7 / replay / sanitizer verdicts all hold**. Every must-fix folded in — mask top-bit whitening, scrypt-lifetime in-flight slot (close-during-scrypt can't pile concurrent scrypts), serialized firewall chain, accept-flood `maxConnections`, machine-key fail-closed.

## Verification
- `tsc` 4-config exit 0
- 100 unit + in-memory end-to-end server tests (execute-kind / file-part rejection, cross-connection replay drop, live revoke, first-frame-0x10 G7 — all proven)
- full vitest: no regression from this change
- execute-wall + api-reference drift guards green

## Not in this PR
- renderer remote-inbox card + Settings pairing UI (**PR-5**)
- **live 2-machine dogfood requires a physical second machine** — not yet run
- the PIN-EKE is a native-`node:crypto` construction (true SPAKE2/CPace needs point addition X25519 scalar-mult doesn't expose); no external crypto audit yet — the honest residual is documented in `plans/lanlink-pr4-design.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced LAN Link connectivity with PIN-based pairing, secure session-key establishment, and authenticated peer messaging.
  * Added durable peer persistence plus pairing/control capabilities (pairing window, peer list/join/send/revoke) and stricter inbound message acceptance with sanitized text.
  * Daemon now exposes LAN Link pairing/peer management via RPC and broadcasts delivery nudges; graceful shutdown disposes LAN Link listener.
  * Windows: automated LAN Link firewall rule management.
* **Tests**
  * Expanded LAN Link coverage across AEAD, replay protection, pairing, peer-store durability, wire framing/JSON hardening, router allow-lists, sanitization, and end-to-end server/client flows (optional live dogfood).
  * Added stricter source-invariant checks for daemon execute/dispatch imports.
* **Bug Fixes**
  * Hardened inbox `state` validation at the disk boundary so invalid `state` rejects the inbox file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->