### PR TITLE
feat(zoom): make the pane restore button minimal, matching the maximize button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The zoom restore button is now a quiet, minimal control that matches the maximize button.** When a pane is zoomed, the toggle that returns it to the grid was a bold red `ZOOM` badge — it reused the cursor accent color, which is a strong red in several themes. It's now styled identically to the hover-revealed `⤢` maximize button (neutral surface background, subtle border) and uses a `⤡` restore glyph, so the maximize and restore controls read as a matched pair instead of the restore button drawing the eye. It still stays visible while zoomed so the way back out is always obvious ([#258](https://github.com/openwong2kim/wmux/pull/258) follow-up).
+
 - **Hardened the A2A execute path against off-machine callers.** Every internal RPC now carries a required trust-origin tag (`local` vs `remote`), and the agent-spawning `a2a.task.send` path only runs when the call provably came from this machine, a positive-allow gate that fails closed for anything else. A source-level test pins that the background daemon can never even import the code that spawns agents. Nothing changes for same-machine multi-agent use today; this is the foundation for cross-PC A2A where remote agents can exchange messages but never execute commands.
 
 ## [3.7.0] — 2026-06-20 — A2A execute approval hardened, and remote RPC that lands in the right workspace

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -276,20 +276,19 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
             top: 4,
             right: 6,
             zIndex: 20,
-            padding: '1px 6px',
-            fontSize: 10,
+            padding: '0 5px',
+            height: 16,
+            fontSize: 12,
+            lineHeight: '16px',
             fontFamily: 'ui-monospace, monospace',
-            fontWeight: 700,
-            letterSpacing: '0.08em',
-            color: 'var(--bg-main)',
-            backgroundColor: 'var(--accent-cursor)',
-            border: 'none',
+            color: 'var(--text-main)',
+            backgroundColor: 'var(--bg-surface)',
+            border: '1px solid var(--bg-surface0, rgba(255,255,255,0.12))',
             borderRadius: 3,
             cursor: 'pointer',
-            opacity: 0.85,
           }}
         >
-          ZOOM
+          ⤡
         </button>
       )}
       {/* Issue #182 discoverability: an un-zoomed pane exposes a quiet maximize


### PR DESCRIPTION
## Summary

When a pane is zoomed, the control that returns it to the grid was a bold red `ZOOM` badge. It reused the cursor accent color (`--accent-cursor`), which is a strong red in several themes (e.g. `#BC002D` in the default theme), so it drew the eye and felt out of place next to the quiet, hover-revealed `⤢` maximize button.

This restyles the restore toggle to match the maximize button exactly — neutral `--bg-surface` background, subtle border, same dimensions — and swaps the `ZOOM` text for a `⤡` restore glyph, so maximize (`⤢`) and restore (`⤡`) read as a matched pair instead of the restore control shouting for attention. The button stays always-visible while zoomed (unlike the hover-only maximize button) so the way back out of zoom is always obvious. `--accent-cursor` is no longer used here.

Single file: `src/renderer/components/Pane/Pane.tsx` (the `isZoomed` toggle block). No behavior change — the click still calls `togglePaneZoom(pane.id)`.

## Test plan
- [x] Renderer typecheck passes (`tsc --noEmit -p tsconfig.json`, exit 0)
- [x] Pane + zoom suites pass (52 tests: `Pane` + `useKeyboard.zoom.dynamic`)
- [x] No new code paths (pure inline-style + glyph change); no test changes needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * The zoom restore control has been redesigned with a minimal, quiet appearance that pairs with the maximize button. It now displays a restore icon instead of a text badge, improving visual consistency while remaining visible for easy zoom restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->