### PR TITLE
fix(rpc): system.capabilities advertises only registered methods (LanLink review followup)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -223,3 +223,21 @@
 - **Depends on:** 구체적 적대 멀티에이전트 위협 리포트 발생 시.
 - **Priority:** P3
 
+## LanLink: expose effective pairing port + host address on the PIN (P2)
+- **What:** 페어링 PIN 발급 시 이 머신의 effective `host:port`를 함께 표시해 상대가 join 가능하게. 데몬 status에 `effectivePort`(persisted port 없으면 데몬 기본 listen 포트) 추가 + 렌더러 `LanLinkPairingView`가 선택 NIC IP + port를 PIN 옆에 노출. join 폼 port 기본값 `0`(invalid) 개선.
+- **Why:** codex review(PR-5 #275, codex#5). 현재 PIN만 표시 → 상대가 우리 IP/port를 몰라 join 불가. `status.port`는 persisted만(null이면 데몬 기본 = 렌더러가 모름).
+- **Pros:** 페어링 UX 완성(상대가 PIN 하나로 우리 접속정보 전부 획득).
+- **Cons:** 데몬 status 확장 필요(PR-5는 데몬 0줄 원칙 → follow-up은 데몬 변경 허용). NIC IP 계산(status.nics에서 선택 NIC 매칭).
+- **Context:** `src/daemon/lanlink/server.ts` getStatus + `src/shared/lanlink.ts` LanLinkStatus(+effectivePort) + `SettingsPanel.tsx` LanLinkPairingSection(status.port/nics 노출).
+- **Depends on:** —
+- **Priority:** P2
+
+## LanLink: unify the double daemon status probe (P3)
+- **What:** `LanLinkSection`(PR-3)과 `LanLinkPairingSection`(PR-5)이 각각 `lanlink.status`를 폴링 → LanLink 탭 열 때 status RPC 2회. 상위 컨테이너가 status를 한 번 읽어 둘에 props로 공유.
+- **Why:** codex review(PR-5 #275, codex P2). read-only minor지만 중복 probe.
+- **Pros:** status RPC 1회, enabled/nic 단일 SoT.
+- **Cons:** `LanLinkSection`을 props 받게 리팩터(PR-5 "LanLinkView 0편집" 원칙은 follow-up서 완화 가능).
+- **Context:** `SettingsPanel.tsx` activeTab==='lanlink' 렌더(`<LanLinkSection/><LanLinkPairingSection/>`) → 상위 LanLinkTab 컨테이너로 status lift.
+- **Depends on:** —
+- **Priority:** P3
+

--- a/src/main/pipe/RpcRouter.ts
+++ b/src/main/pipe/RpcRouter.ts
@@ -98,6 +98,17 @@ export class RpcRouter {
     this.handlers.set(method, handler);
   }
 
+  /**
+   * The methods actually wired into THIS router (i.e. reachable over the RPC
+   * wire). A subset of `ALL_RPC_METHODS`: control-pipe-only RPCs (daemon.* /
+   * lanlink.*) are dispatched by the daemon control pipe, never registered here,
+   * so `system.capabilities` advertises only what a caller can really invoke
+   * (codex review) rather than the full static list.
+   */
+  getRegisteredMethods(): RpcMethod[] {
+    return [...this.handlers.keys()];
+  }
+
   // Wire the trust-store side. main/index.ts injects a recorder backed by
   // PluginTrustStore.upsertLegacyContact; tests leave it unset for isolation.
   setLegacyContactRecorder(recorder: LegacyContactRecorder | undefined): void {

--- a/src/main/pipe/handlers/__tests__/system.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/system.rpc.test.ts
@@ -41,7 +41,15 @@ describe('system.rpc — system.capabilities', () => {
       };
     };
 
-    expect(result.methods).toEqual(ALL_RPC_METHODS);
+    // capabilities advertises ONLY methods registered on this router. The test
+    // router has just registerSystemRpc, so control-pipe-only RPCs (lanlink.* /
+    // daemon.*) and every other unregistered method are correctly excluded — a
+    // wire caller can't invoke them, so they shouldn't be advertised (codex review).
+    const registered = router.getRegisteredMethods();
+    expect(result.methods).toEqual(ALL_RPC_METHODS.filter((m) => registered.includes(m)));
+    expect(result.methods).toContain('system.capabilities');
+    expect(result.methods).not.toContain('lanlink.pair.begin');
+    expect(result.methods).not.toContain('daemon.inbox.poll');
     expect(result.features.events.types).toEqual(WMUX_EVENT_TYPES);
     expect(result.features.events.maxRingSize).toBe(RING_CAPACITY);
     expect(typeof result.features.events.bootId).toBe('string');

--- a/src/main/pipe/handlers/system.rpc.ts
+++ b/src/main/pipe/handlers/system.rpc.ts
@@ -39,12 +39,18 @@ export function registerSystemRpc(router: RpcRouter): void {
     // wrote `if (caps.features.paneMetadata)` keep working because a non-null
     // object is truthy. v2.9.0+ clients can feature-detect by reading the
     // fields directly.
+    // Advertise only methods actually registered on THIS router. Control-pipe-only
+    // RPCs (daemon.* / lanlink.*) are dispatched by the daemon pipe and are never
+    // registered here, so listing the full static ALL_RPC_METHODS would advertise
+    // methods a wire caller can't invoke (they'd get unknown-method). Filtering to
+    // the registered set keeps capabilities honest (codex review).
+    const registered = new Set(router.getRegisteredMethods());
     const paneMetadata: PaneMetadataCapabilities = {
       optimisticConcurrency: true,
       mergeModes: ['merge', 'replace', 'replaceShared'],
     };
     return Promise.resolve({
-      methods: ALL_RPC_METHODS,
+      methods: ALL_RPC_METHODS.filter((m) => registered.has(m)),
       features: {
         paneMetadata,
         events: {


### PR DESCRIPTION
## What

Follow-up to the codex review on **#275** (LanLink PR-5).

codex flagged that adding the 7 `lanlink.*` control-pipe RPCs to `ALL_RPC_METHODS` makes `system.capabilities` advertise methods a wire caller can't invoke — they're dispatched by the **daemon control pipe** and never registered on the `RpcRouter`. This was already true for `daemon.*` and the PR-3 `lanlink.status/configure`, so the fix is general:

- `RpcRouter.getRegisteredMethods()` returns the methods actually wired into the router.
- `system.capabilities` now returns `ALL_RPC_METHODS` **filtered to the registered set**, so control-pipe-only RPCs (`daemon.*` / `lanlink.*`) are correctly excluded.

**No external impact:** those methods were never callable over the RPC wire, so advertising them only invited an unknown-method error. `docs/api/reference.md` (the full static method catalog) is unchanged.

## Verification
- tsc 4-config · vitest **3861** · `system.rpc.test` extended (asserts `lanlink.pair.begin` / `daemon.inbox.poll` are NOT advertised, `system.capabilities` IS).

## Deferred (TODOS.md — need a daemon change / refactor, out of scope here)
- expose the effective pairing port + host address on the PIN (codex#5)
- unify the double `LanLinkSection`/`LanLinkPairingSection` status probe (codex P2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added method to expose registered RPC methods for the router instance.

* **Tests**
  * Updated system capability test to validate only registered RPC methods are reported.

* **Chores**
  * Added LanLink enhancement planning items (improved pairing experience and status polling optimization).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->