### PR TITLE
feat(lanlink): expose effective pairing port + show this machine's address on the PIN

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -223,15 +223,6 @@
 - **Depends on:** 구체적 적대 멀티에이전트 위협 리포트 발생 시.
 - **Priority:** P3
 
-## LanLink: expose effective pairing port + host address on the PIN (P2)
-- **What:** 페어링 PIN 발급 시 이 머신의 effective `host:port`를 함께 표시해 상대가 join 가능하게. 데몬 status에 `effectivePort`(persisted port 없으면 데몬 기본 listen 포트) 추가 + 렌더러 `LanLinkPairingView`가 선택 NIC IP + port를 PIN 옆에 노출. join 폼 port 기본값 `0`(invalid) 개선.
-- **Why:** codex review(PR-5 #275, codex#5). 현재 PIN만 표시 → 상대가 우리 IP/port를 몰라 join 불가. `status.port`는 persisted만(null이면 데몬 기본 = 렌더러가 모름).
-- **Pros:** 페어링 UX 완성(상대가 PIN 하나로 우리 접속정보 전부 획득).
-- **Cons:** 데몬 status 확장 필요(PR-5는 데몬 0줄 원칙 → follow-up은 데몬 변경 허용). NIC IP 계산(status.nics에서 선택 NIC 매칭).
-- **Context:** `src/daemon/lanlink/server.ts` getStatus + `src/shared/lanlink.ts` LanLinkStatus(+effectivePort) + `SettingsPanel.tsx` LanLinkPairingSection(status.port/nics 노출).
-- **Depends on:** —
-- **Priority:** P2
-
 ## LanLink: unify the double daemon status probe (P3)
 - **What:** `LanLinkSection`(PR-3)과 `LanLinkPairingSection`(PR-5)이 각각 `lanlink.status`를 폴링 → LanLink 탭 열 때 status RPC 2회. 상위 컨테이너가 status를 한 번 읽어 둘에 props로 공유.
 - **Why:** codex review(PR-5 #275, codex P2). read-only minor지만 중복 probe.

--- a/scripts/lanlink-pr5-dogfood.mjs
+++ b/scripts/lanlink-pr5-dogfood.mjs
@@ -122,7 +122,8 @@ async function main() {
   const nic = s0.nics[0] ? { name: s0.nics[0].name, mac: s0.nics[0].mac } : null;
   const s1 = await rpc('lanlink.configure', nic ? { enabled: true, nic } : { enabled: true });
   assert(s1.enabled === true, 'configure: LanLink enabled');
-  console.log(`    NIC: ${nic ? nic.name : '(none — enable-only)'}`);
+  assert(typeof s1.effectivePort === 'number' && s1.effectivePort > 0, `status exposes effectivePort (${s1.effectivePort}) — peer's join target (codex#5)`);
+  console.log(`    NIC: ${nic ? nic.name : '(none — enable-only)'}  effectivePort: ${s1.effectivePort}`);
 
   // 1. pair.begin — mints a 6-digit PIN + arms the window.
   const pb = await rpc('lanlink.pair.begin', {});

--- a/src/daemon/lanlink/__tests__/controller.test.ts
+++ b/src/daemon/lanlink/__tests__/controller.test.ts
@@ -31,6 +31,7 @@ describe('LanLinkController', () => {
     expect(status.enabled).toBe(false);
     expect(status.nic).toBeNull();
     expect(status.port).toBeNull();
+    expect(status.effectivePort).toBe(45651); // LANLINK_DEFAULT_PORT when none persisted (codex#5)
     expect(status.nics.map((n) => n.name)).toEqual(['Ethernet']); // loopback excluded
   });
 
@@ -90,6 +91,7 @@ describe('LanLinkController', () => {
     const { config, controller } = makeController();
     const status = controller.configure({ port: 41234 });
     expect(status.port).toBe(41234);
+    expect(status.effectivePort).toBe(41234); // persisted port wins over the default (codex#5)
     expect(config.lanlink?.port).toBe(41234);
   });
 });

--- a/src/daemon/lanlink/controller.ts
+++ b/src/daemon/lanlink/controller.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import type { DaemonConfig } from '../types';
 import {
   defaultLanLinkConfig,
+  LANLINK_DEFAULT_PORT,
   type LanLinkConfig,
   type LanLinkConfigurePatch,
   type LanLinkStatus,
@@ -68,6 +69,7 @@ export class LanLinkController extends EventEmitter {
       enabled: cur.enabled,
       nic: cur.nic,
       port: cur.port ?? null,
+      effectivePort: cur.port ?? LANLINK_DEFAULT_PORT,
       nics: enumerateNics(this.ifaces()),
     };
   }

--- a/src/daemon/lanlink/server.ts
+++ b/src/daemon/lanlink/server.ts
@@ -35,9 +35,9 @@ import {
 import { admitKind } from './router';
 import { sanitizeRemoteText, sanitizeRemotePeerName, hasResidualControl } from './sanitize';
 import { applyLanLinkFirewall, removeLanLinkFirewall } from './firewall';
-import type { InboxRecord, LanLinkNic, NicInfo } from '../../shared/lanlink';
+import { LANLINK_DEFAULT_PORT, type InboxRecord, type LanLinkNic, type NicInfo } from '../../shared/lanlink';
 
-export const DEFAULT_PORT = 45651;
+export const DEFAULT_PORT = LANLINK_DEFAULT_PORT;
 
 const HANDSHAKE_TIMEOUT_MS = 5_000; // absolute, NOT reset by byte arrival (slow-loris)
 const IDLE_TIMEOUT_MS = 60_000;

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -1002,6 +1002,8 @@ function LanLinkSection() {
 
 export interface LanLinkPairingViewProps {
   enabled: boolean;
+  /** This machine's host:port for a peer's Join form (null until a NIC resolves). */
+  selfAddress: string | null;
   // pair this machine
   pin: string | null;
   countdownSec: number | null;
@@ -1031,7 +1033,7 @@ export interface LanLinkPairingViewProps {
 
 export function LanLinkPairingView(props: LanLinkPairingViewProps) {
   const {
-    enabled, pin, countdownSec, failCount, pairBusy, onBeginPair, onCancelPair,
+    enabled, selfAddress, pin, countdownSec, failCount, pairBusy, onBeginPair, onCancelPair,
     joinHost, joinPort, joinPin, onJoinHost, onJoinPort, onJoinPin, onJoin, joinBusy,
     peers, confirmingRevoke, onAskRevoke, onConfirmRevoke, onCancelRevoke, error, t,
   } = props;
@@ -1081,6 +1083,11 @@ export function LanLinkPairingView(props: LanLinkPairingViewProps) {
           </Button>
         )}
       </SettingRow>
+      {pin && selfAddress && (
+        <p data-testid="lanlink-pair-self" className="text-[10px] font-mono px-1" style={{ color: 'var(--text-subtle)' }}>
+          {t('settings.lanlinkPairSelfAddress', { address: selfAddress })}
+        </p>
+      )}
       {failCount > 0 && (
         <p className="text-[10px] font-mono px-1" style={{ color: 'var(--accent-yellow)' }}>
           {t('settings.lanlinkPairFailCount', { count: failCount })}
@@ -1181,6 +1188,8 @@ function LanLinkPairingSection() {
 
   const [enabled, setEnabled] = useState<boolean | null>(null);
   const [nic, setNic] = useState<LanLinkNic | null>(null);
+  const [effectivePort, setEffectivePort] = useState<number | null>(null);
+  const [nics, setNics] = useState<NicInfo[]>([]);
   const [unavailable, setUnavailable] = useState(false);
   const [pin, setPin] = useState<string | null>(null);
   const [deadline, setDeadline] = useState<number | null>(null);
@@ -1204,8 +1213,11 @@ function LanLinkPairingSection() {
   const refreshStatus = useCallback(async () => {
     if (!api?.status) { setUnavailable(true); return; }
     const r = await ipcInvoke(() => api.status());
-    if (r.ok) { setEnabled(r.data.enabled); setNic(r.data.nic); setUnavailable(false); }
-    else setUnavailable(true);
+    if (r.ok) {
+      setEnabled(r.data.enabled); setNic(r.data.nic);
+      setEffectivePort(r.data.effectivePort); setNics(r.data.nics);
+      setUnavailable(false);
+    } else setUnavailable(true);
   }, [api, ipcInvoke]);
 
   const refreshPairStatus = useCallback(async () => {
@@ -1311,11 +1323,22 @@ function LanLinkPairingSection() {
     );
   }
 
+  // This machine's reachable address for a peer to enter on their "Join" form: the
+  // selected NIC's IP + the daemon's effective listen port. Shown next to the PIN so
+  // the peer knows the full host:port, not just the code (codex#5).
+  const selfAddress = (() => {
+    if (!nic || effectivePort == null) return null;
+    const match = nics.find((n) => n.name === nic.name && n.mac === nic.mac);
+    const ip = match?.addresses[0];
+    return ip ? `${ip}:${effectivePort}` : null;
+  })();
+
   const countdownSec = deadline != null ? Math.max(0, Math.ceil((deadline - now) / 1000)) : null;
 
   return (
     <LanLinkPairingView
       enabled={enabled === true && nic !== null}
+      selfAddress={selfAddress}
       pin={pin}
       countdownSec={countdownSec}
       failCount={failCount}

--- a/src/renderer/components/Settings/__tests__/LanLinkSection.test.tsx
+++ b/src/renderer/components/Settings/__tests__/LanLinkSection.test.tsx
@@ -115,6 +115,7 @@ describe('LanLinkView — onChange wiring', () => {
 function makePairProps(overrides: Partial<LanLinkPairingViewProps> = {}): LanLinkPairingViewProps {
   return {
     enabled: true,
+    selfAddress: null,
     pin: null,
     countdownSec: null,
     failCount: 0,
@@ -160,6 +161,21 @@ describe('LanLinkPairingView — markup', () => {
     expect(html).toContain('lanlink-pair-pin');
     expect(html).toContain('123456');
     expect(html).toContain('settings.lanlinkPairCountdown');
+  });
+
+  it('shows this machine host:port next to the PIN when available (codex#5)', () => {
+    // tStub returns the key (no {address} interpolation), so assert the self line
+    // renders; the actual host:port value is exercised by the CDP dogfood.
+    const withAddr = renderToStaticMarkup(
+      createElement(LanLinkPairingView, makePairProps({ pin: '123456', selfAddress: '192.168.1.5:45651' })),
+    );
+    expect(withAddr).toContain('lanlink-pair-self');
+    expect(withAddr).toContain('settings.lanlinkPairSelfAddress');
+    // No self line before a PIN is minted (nothing to share yet).
+    const noPin = renderToStaticMarkup(
+      createElement(LanLinkPairingView, makePairProps({ pin: null, selfAddress: '192.168.1.5:45651' })),
+    );
+    expect(noPin).not.toContain('lanlink-pair-self');
   });
 
   it('renders a peer row with the "remote peer" badge and a revoke control', () => {

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -281,6 +281,7 @@ export const en = {
   'settings.lanlinkPairStart': 'Pair this machine',
   'settings.lanlinkPairStartDesc': 'Generate a one-time PIN, then enter it on the other machine within 2 minutes.',
   'settings.lanlinkPairStartButton': 'Generate PIN',
+  'settings.lanlinkPairSelfAddress': 'On this machine: {address} — give this address and the PIN to the other machine.',
   'settings.lanlinkPairCountdown': 'expires in {seconds}s',
   'settings.lanlinkPairExpired': 'expired',
   'settings.lanlinkPairCancel': 'Cancel',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -228,6 +228,7 @@ export const ko = {
   'settings.lanlinkPairStart': '이 머신 페어링',
   'settings.lanlinkPairStartDesc': '일회용 PIN을 생성한 뒤 2분 안에 다른 머신에 입력하세요.',
   'settings.lanlinkPairStartButton': 'PIN 생성',
+  'settings.lanlinkPairSelfAddress': '이 머신: {address} — 이 주소와 PIN을 다른 머신에 알려주세요.',
   'settings.lanlinkPairCountdown': '{seconds}초 후 만료',
   'settings.lanlinkPairExpired': '만료됨',
   'settings.lanlinkPairCancel': '취소',

--- a/src/shared/lanlink.ts
+++ b/src/shared/lanlink.ts
@@ -143,6 +143,9 @@ export const LANLINK_PORT_MIN = 1024;
 /** Highest valid LanLink listen port. */
 export const LANLINK_PORT_MAX = 65535;
 
+/** Default LanLink listen port when none is persisted (the daemon's DEFAULT_PORT). */
+export const LANLINK_DEFAULT_PORT = 45651;
+
 /**
  * Persisted NIC identity. NOT a raw IP — the interface display name plus MAC, so
  * the same physical NIC is re-resolvable across reboots / DHCP renewals (C2). The
@@ -179,7 +182,11 @@ export interface LanLinkConfig {
 export interface LanLinkStatus {
   enabled: boolean;
   nic: LanLinkNic | null;
+  /** Persisted port override; `null` means "use the default". */
   port: number | null;
+  /** The port the daemon actually listens on (`port ?? LANLINK_DEFAULT_PORT`). The
+   *  Settings pairing UI shows this so a peer knows which port to join. */
+  effectivePort: number;
   /** Live LAN-capable NICs (re-enumerated each call); drives the Settings dropdown. */
   nics: NicInfo[];
 }


### PR DESCRIPTION
## What

LanLink review follow-up (**codex#5**, from #275).

When you mint a pairing PIN, the other machine needs your **host:port** to join — but the UI only showed the PIN, and `status.port` is the *persisted override* (null when the daemon uses its default), so a peer had no way to know which port to enter.

- **daemon:** `LanLinkStatus` gains `effectivePort` (= `port ?? LANLINK_DEFAULT_PORT`), the port the listener actually binds. `DEFAULT_PORT` is lifted to shared as `LANLINK_DEFAULT_PORT` so controller + server share one source (no duplicated literal).
- **renderer:** the pairing section derives this machine's `host:port` (selected NIC's IP + `effectivePort`) and shows it next to the PIN, so the peer can fill in their Join form from one screen.

## Verification
- tsc 4-config · vitest **3862** · controller test asserts `effectivePort` (default 45651 + persisted), `LanLinkPairingView` SSR asserts the self-address line.
- daemon dogfood **20/20** — `effectivePort` exposed live (`status exposes effectivePort (45651)`).

## Still deferred (TODOS.md)
- unify the double `LanLinkSection`/`LanLinkPairingSection` status probe (codex P2) — a `LanLinkTab` merge refactor; perf-minor, not worth the regression risk now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LanLink pairing PIN now displays the self address (host:port) so peers can easily connect to this machine.
  * Daemon status now exposes the effective listening port being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->