### PR TITLE
feat(mcp): CLI clientName + scoped enforcer allowlist (grandfather deprecation Stage 2)

### DIFF
--- a/src/cli/client.ts
+++ b/src/cli/client.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as crypto from 'crypto';
 import type { RpcRequest, RpcResponse, RpcMethod } from '../shared/rpc';
+import { WMUX_CLI_CLIENT_NAME } from '../shared/rpc';
 import {
   getPipeName,
   getAuthTokenPath,
@@ -50,7 +51,11 @@ function attemptRequest(
 ): Promise<RpcResponse> {
   return new Promise((resolve, reject) => {
     const id = crypto.randomUUID();
-    const request: RpcRequest = { id, method, params, token };
+    // Report a stable clientName so the main-pipe enforcer grants the CLI its
+    // curated allowlist (internalCli.ts) instead of the envelope-less legacy
+    // grandfather (trust-root plan Stage 2). Harmless on the daemon control
+    // pipe, which is token-only and ignores the field.
+    const request: RpcRequest = { id, method, params, token, clientName: WMUX_CLI_CLIENT_NAME };
 
     const socket =
       typeof target === 'string' ? net.connect(target) : net.connect(target.port, target.host);

--- a/src/main/mcp/PermissionEnforcer.ts
+++ b/src/main/mcp/PermissionEnforcer.ts
@@ -56,6 +56,7 @@ import {
   type ParsedPermission,
 } from './permissionGrammar';
 import { FIRST_PARTY_METHODS, isFirstPartyClient } from './firstParty';
+import { WMUX_CLI_METHODS, isInternalCliClient } from './internalCli';
 
 export type EnforcerOutcome =
   | { kind: 'allow' }
@@ -205,6 +206,24 @@ export function check(input: EnforcerInput): EnforcerOutcome {
     !input.trustLookupFailed &&
     input.trust?.status !== 'denied' &&
     FIRST_PARTY_METHODS.has(input.method)
+  ) {
+    return { kind: 'allow' };
+  }
+
+  // Internal first-party CLI (`wmux <command>`, clientName 'wmux-cli'). The CLI
+  // ships inside wmux and is the one steady-state envelope-less mutating caller;
+  // Stage 2 of the grandfather deprecation gives it a stable clientName so the
+  // legacy grandfather can later be closed without breaking it. Grant exactly
+  // its curated method set (internalCli.ts), nothing more — a separate, narrower
+  // allowlist than FIRST_PARTY_METHODS. Same three guards as the first-party
+  // tier above: an explicit user `denied` wins, a failed trust lookup declines
+  // (fall through to fail-closed), and a method outside the curated set falls
+  // through to normal enforcement rather than silently widening CLI scope.
+  if (
+    isInternalCliClient(input.ctx.clientName) &&
+    !input.trustLookupFailed &&
+    input.trust?.status !== 'denied' &&
+    WMUX_CLI_METHODS.has(input.method)
   ) {
     return { kind: 'allow' };
   }

--- a/src/main/mcp/__tests__/PermissionEnforcer.internalCli.test.ts
+++ b/src/main/mcp/__tests__/PermissionEnforcer.internalCli.test.ts
@@ -1,0 +1,122 @@
+// Internal-CLI scoped-allowlist behavior in the permission enforcer.
+//
+// Mirrors PermissionEnforcer.firstParty.test.ts for the `wmux-cli` tier added in
+// Stage 2 of the grandfather deprecation: the CLI reports clientName 'wmux-cli'
+// and gets EXACTLY its curated method set (internalCli.ts) — a separate, narrower
+// allowlist than the bundled-MCP FIRST_PARTY_METHODS — with the same guards
+// (denied wins, failed-lookup declines, out-of-set falls through).
+
+import { describe, expect, it } from 'vitest';
+import type { PluginIdentityRecord, RpcContext, RpcMethod } from '../../../shared/rpc';
+import { check } from '../PermissionEnforcer';
+import { WMUX_CLI_METHODS, WMUX_CLI_CLIENT_NAME } from '../internalCli';
+
+function trust(
+  overrides: Partial<PluginIdentityRecord> & Pick<PluginIdentityRecord, 'name' | 'status'>,
+): PluginIdentityRecord {
+  return { firstSeen: 1000, lastSeen: 2000, ...overrides };
+}
+function ctx(clientName?: string): RpcContext {
+  return clientName ? { origin: 'local', clientName } : { origin: 'local' };
+}
+
+const CLI = WMUX_CLI_CLIENT_NAME;
+// A representative spread of the CLI allowlist: a normal capability method, and
+// three reserved `wmux.internal` ones (lifecycle + notify) that can never be
+// granted via declaration — name-recognition is the only path that reaches them.
+const SAMPLE_ALLOWED: RpcMethod[] = ['input.send', 'workspace.new', 'surface.list', 'notify'];
+
+describe('PermissionEnforcer.check — wmux-cli allowlist', () => {
+  it('allows allowlisted methods for wmux-cli even when status=unconfirmed', () => {
+    for (const method of SAMPLE_ALLOWED) {
+      const out = check({
+        method,
+        params: {},
+        ctx: ctx(CLI),
+        trust: trust({ name: CLI, status: 'unconfirmed' }),
+      });
+      expect(out, `${method} should be allowed for wmux-cli/unconfirmed`).toEqual({ kind: 'allow' });
+    }
+  });
+
+  it('allows allowlisted methods for wmux-cli with NO trust record (clean miss)', () => {
+    const out = check({ method: 'workspace.new', params: {}, ctx: ctx(CLI), trust: undefined });
+    expect(out).toEqual({ kind: 'allow' });
+  });
+
+  it('allows reserved wmux.internal methods the CLI drives (surface/workspace lifecycle, notify)', () => {
+    for (const method of ['surface.list', 'surface.new', 'workspace.close', 'notify'] as const) {
+      const out = check({
+        method,
+        params: {},
+        ctx: ctx(CLI),
+        trust: trust({ name: CLI, status: 'unconfirmed' }),
+      });
+      expect(out, `${method}`).toEqual({ kind: 'allow' });
+    }
+  });
+
+  it('honors an explicit denied as an operator escape hatch (denied wins over wmux-cli)', () => {
+    const out = check({
+      method: 'input.send',
+      params: {},
+      ctx: ctx(CLI),
+      trust: trust({ name: CLI, status: 'denied' }),
+    });
+    expect(out.kind).toBe('reject');
+  });
+
+  it('does NOT widen scope: a gated method the CLI never calls falls through to reject', () => {
+    // pane.setMetadata is a real gated method the bundled MCP calls but the CLI
+    // does NOT — wmux-cli must not reach it. daemon.shutdown / company.create are
+    // destructive and likewise absent from WMUX_CLI_METHODS.
+    for (const method of ['pane.setMetadata', 'daemon.shutdown', 'company.create'] as const) {
+      expect(WMUX_CLI_METHODS.has(method as RpcMethod)).toBe(false);
+      const out = check({
+        method,
+        params: {},
+        ctx: ctx(CLI),
+        trust: trust({ name: CLI, status: 'unconfirmed' }),
+      });
+      expect(out.kind, `${method} must not be auto-allowed for wmux-cli`).toBe('reject');
+    }
+  });
+
+  it('SECURITY: a different clientName does NOT get the wmux-cli bypass for a CLI method', () => {
+    for (const method of SAMPLE_ALLOWED) {
+      const out = check({
+        method,
+        params: {},
+        ctx: ctx('not-wmux-cli'),
+        trust: trust({ name: 'not-wmux-cli', status: 'unconfirmed' }),
+      });
+      expect(out.kind, `${method} must be rejected for a non-CLI caller`).toBe('reject');
+    }
+  });
+
+  it('SECURITY: declines the wmux-cli bypass when the trust lookup FAILED (a denied row may be unreadable)', () => {
+    for (const method of SAMPLE_ALLOWED) {
+      const out = check({
+        method,
+        params: {},
+        ctx: ctx(CLI),
+        trust: undefined,
+        trustLookupFailed: true,
+      });
+      expect(out.kind, `${method} must not be wmux-cli-allowed on a failed lookup`).toBe('reject');
+    }
+  });
+
+  it('still grants the wmux-cli bypass on a clean miss (trustLookupFailed=false)', () => {
+    for (const method of SAMPLE_ALLOWED) {
+      const out = check({
+        method,
+        params: {},
+        ctx: ctx(CLI),
+        trust: undefined,
+        trustLookupFailed: false,
+      });
+      expect(out, `${method} should be allowed on a clean miss`).toEqual({ kind: 'allow' });
+    }
+  });
+});

--- a/src/main/mcp/__tests__/internalCli.test.ts
+++ b/src/main/mcp/__tests__/internalCli.test.ts
@@ -1,0 +1,156 @@
+// Source-invariant guard for WMUX_CLI_METHODS (mirrors firstParty.test.ts).
+//
+// The internal-CLI allowlist (internalCli.ts) must stay a superset of every
+// MAIN-PIPE RPC method `wmux <command>` actually calls — otherwise, once the
+// legacy grandfather is closed (trust-root plan Stage 3), that CLI command
+// silently breaks under enforce mode. Rather than trust a hand-maintained list,
+// this test parses the real CLI source (src/cli/**) for every `sendRequest(...)`
+// method literal and fails if any valid RpcMethod is missing from the allowlist.
+//
+// Daemon-control-pipe calls are EXCLUDED: the CLI reaches the daemon pipe via
+// `sendDaemonRequest` / `sendRequestToPipe(daemonPipe, method, ...)` (the method
+// is the SECOND arg), which this `\bsendRequest\(` regex deliberately does not
+// match — those go to the DaemonPipeServer, which has no enforcer.
+
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { WMUX_CLI_METHODS, WMUX_CLI_CLIENT_NAME, isInternalCliClient } from '../internalCli';
+import { METHOD_CAPABILITY, resolveRequiredCapability } from '../methodCapabilityMap';
+import type { RpcMethod } from '../../../shared/rpc';
+
+// src/main/mcp/__tests__ -> src/cli
+const CLI_DIR = path.resolve(__dirname, '..', '..', '..', 'cli');
+
+function collectTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+      out.push(...collectTsFiles(full));
+    } else if (
+      entry.name.endsWith('.ts') &&
+      !entry.name.endsWith('.test.ts') &&
+      !entry.name.endsWith('.d.ts')
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// Match `sendRequest('method'` and `sendRequest<T>('method'` — the main-pipe
+// call. Deliberately NOT `sendRequestToPipe(` / `sendDaemonRequest(`: those put
+// the method in a later arg and target the daemon control pipe.
+function extractCalledMethods(): Set<string> {
+  const called = new Set<string>();
+  const re = /\bsendRequest(?:<[^>]*>)?\(\s*'([a-zA-Z0-9_.]+)'/g;
+  for (const file of collectTsFiles(CLI_DIR)) {
+    const src = fs.readFileSync(file, 'utf8');
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(src)) !== null) {
+      called.add(m[1]);
+    }
+  }
+  return called;
+}
+
+const VALID_METHODS = new Set<string>(Object.keys(METHOD_CAPABILITY));
+
+describe('WMUX_CLI_METHODS source invariant', () => {
+  it('found a non-trivial set of CLI RPC calls (parser sanity)', () => {
+    const called = extractCalledMethods();
+    expect(called.size).toBeGreaterThan(10);
+  });
+
+  it('covers every valid main-pipe RpcMethod the CLI calls', () => {
+    const called = extractCalledMethods();
+    const missing = [...called]
+      .filter((m) => VALID_METHODS.has(m)) // drop non-RPC literals (file names, etc.)
+      .filter((m) => !m.startsWith('daemon.') && !m.startsWith('lanlink.')) // daemon-pipe, no enforcer
+      .filter((m) => !WMUX_CLI_METHODS.has(m as RpcMethod))
+      .sort();
+    expect(
+      missing,
+      `These methods are called via sendRequest() in src/cli/** but are missing ` +
+        `from WMUX_CLI_METHODS — add them to internalCli.ts or the CLI command ` +
+        `breaks once the grandfather closes:\n  ${missing.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('every entry in WMUX_CLI_METHODS is a real RpcMethod (no typos / dead entries)', () => {
+    const bogus = [...WMUX_CLI_METHODS].filter((m) => !VALID_METHODS.has(m)).sort();
+    expect(bogus, `WMUX_CLI_METHODS contains non-RpcMethod entries`).toEqual([]);
+  });
+
+  it('does not allowlist destructive control surface the CLI never calls (least privilege)', () => {
+    // The CLI legitimately does workspace/surface lifecycle (wmux workspace new,
+    // wmux surface close), so those ARE allowed — but daemon control and company
+    // mutation must never be reachable through the wmux-cli tier.
+    for (const m of [
+      'daemon.shutdown',
+      'daemon.compact',
+      'company.create',
+      'company.destroy',
+    ] as const) {
+      expect(WMUX_CLI_METHODS.has(m as RpcMethod)).toBe(false);
+    }
+  });
+
+  it('the reserved (wmux.internal) methods it grants are exactly the ones the CLI calls', () => {
+    const reserved = (Object.keys(METHOD_CAPABILITY) as RpcMethod[]).filter(
+      (m) => resolveRequiredCapability(METHOD_CAPABILITY[m], {}) === 'wmux.internal',
+    );
+    // The CLI is a user-driven first-party tool, so unlike the bundled MCP server
+    // it legitimately drives workspace/surface LIFECYCLE + notify (all reserved,
+    // hence undeclarable — name-recognition is the only path that reaches them).
+    const ALLOWED_RESERVED_CLI = new Set<RpcMethod>([
+      'workspace.new',
+      'workspace.focus',
+      'workspace.close',
+      'surface.list',
+      'surface.new',
+      'surface.focus',
+      'surface.close',
+      'notify',
+    ]);
+    const leaked = reserved
+      .filter((m) => WMUX_CLI_METHODS.has(m))
+      .filter((m) => !ALLOWED_RESERVED_CLI.has(m))
+      .sort();
+    expect(
+      leaked,
+      `WMUX_CLI_METHODS grants reserved wmux.internal methods beyond the curated ` +
+        `CLI set. Either the CLI should not call these, or widen ` +
+        `ALLOWED_RESERVED_CLI here with explicit security review:\n  ${leaked.join('\n  ')}`,
+    ).toEqual([]);
+
+    // Keep the exception set honest: every entry must still be reserved AND still
+    // be granted (else it is stale).
+    for (const m of ALLOWED_RESERVED_CLI) {
+      expect(reserved.includes(m), `${m} is no longer wmux.internal — re-review`).toBe(true);
+      expect(WMUX_CLI_METHODS.has(m), `${m} was dropped from WMUX_CLI_METHODS`).toBe(true);
+    }
+
+    // Least-privilege direction: a reserved grant is only justified while the CLI
+    // actually calls the method.
+    const called = extractCalledMethods();
+    const stale = [...ALLOWED_RESERVED_CLI].filter((m) => !called.has(m)).sort();
+    expect(
+      stale,
+      `These reserved methods are granted but no longer called by src/cli/** — ` +
+        `prune them (least privilege):\n  ${stale.join('\n  ')}`,
+    ).toEqual([]);
+  });
+});
+
+describe('isInternalCliClient', () => {
+  it('recognizes only the exact wmux-cli clientName', () => {
+    expect(isInternalCliClient(WMUX_CLI_CLIENT_NAME)).toBe(true);
+    expect(WMUX_CLI_CLIENT_NAME).toBe('wmux-cli');
+    for (const name of [undefined, '', 'wmux', 'wmux-CLI', 'WMUX-CLI', 'claude-code', 'evil']) {
+      expect(isInternalCliClient(name as string | undefined)).toBe(false);
+    }
+  });
+});

--- a/src/main/mcp/internalCli.ts
+++ b/src/main/mcp/internalCli.ts
@@ -1,0 +1,87 @@
+// Internal first-party CLI recognition for the permission enforcer.
+//
+// Why this exists
+// ---------------
+// `wmux <command>` (src/cli) is the one steady-state, envelope-less, MUTATING
+// caller on the main pipe: it builds bare `{ id, method, params, token }`
+// requests and historically rode the legacy grandfather in the enforcer
+// (`if (!clientName) return allow`). To let the grandfather be CLOSED later
+// (trust-root plan Stage 3) WITHOUT breaking the CLI, the CLI now reports a
+// stable `clientName` (`WMUX_CLI_CLIENT_NAME`) and the enforcer grants it
+// EXACTLY the curated method set it invokes — a SEPARATE, narrower allowlist
+// than the bundled-MCP `FIRST_PARTY_METHODS` (this deliberately does NOT widen
+// that set).
+//
+// Threat model (identical to firstParty.ts): recognition is by self-asserted
+// `clientName` — best-effort same-user attribution, NOT a security boundary
+// against same-user code (a same-user process already holds the auth token and
+// can hit the pipe directly). What the scoped allowlist buys over the blanket
+// grandfather is that even an impersonator using this name reaches ONLY the
+// CLI's curated surface — never `daemon.*`, `company.*` mutation,
+// `workspace.new`'s neighbours it doesn't use, etc.
+//
+// Kept in lockstep with the real CLI surface by internalCli.test.ts, which
+// parses src/cli/** for every `sendRequest`/`sendRequestToPipe` method literal
+// and fails if a main-pipe method is missing here (so a new CLI command that
+// calls a new RPC can't silently break under enforce mode once the grandfather
+// closes).
+
+import type { RpcMethod } from '../../shared/rpc';
+import { WMUX_CLI_CLIENT_NAME } from '../../shared/rpc';
+
+export { WMUX_CLI_CLIENT_NAME };
+
+// The exact MAIN-PIPE RPC methods `wmux <command>` (src/cli/**) invokes via
+// `sendRequest`. Daemon-control-pipe methods (`daemon.*`) are intentionally
+// EXCLUDED — they target the DaemonPipeServer, which has no enforcer, so they
+// never reach this tier. Least privilege: methods the CLI does not call are
+// absent, so a `wmux-cli` impersonator can never reach them through this path.
+export const WMUX_CLI_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
+  // identity / capabilities (capability:null bootstrap; allowed before this
+  // tier anyway, listed so the source-lockstep test stays exhaustive)
+  'system.identify',
+  'system.capabilities',
+  // workspace lifecycle/read (the CLI's `wmux workspace ...` verbs)
+  'workspace.list',
+  'workspace.current',
+  'workspace.focus',
+  'workspace.new',
+  'workspace.close',
+  // surface + pane (`wmux surface ...` / `wmux pane ...`)
+  'surface.list',
+  'surface.new',
+  'surface.focus',
+  'surface.close',
+  'pane.list',
+  'pane.split',
+  'pane.focus',
+  // terminal IO (`wmux input ...`)
+  'input.send',
+  'input.sendKey',
+  'input.readScreen',
+  // metadata (`wmux` status/progress reporting)
+  'meta.setStatus',
+  'meta.setProgress',
+  // notification (`wmux notify`)
+  'notify',
+  // a2a identity resolution (`wmux` resolves its own pane identity)
+  'a2a.resolve.identity',
+  // browser control (`wmux browser ...`)
+  'browser.open',
+  'browser.navigate',
+  'browser.close',
+  'browser.session.start',
+  'browser.session.stop',
+  'browser.session.status',
+  'browser.session.list',
+]);
+
+/**
+ * True when `clientName` identifies the bundled first-party wmux CLI. Exact
+ * match — `clientName` is already trimmed by RpcRouter when it builds the
+ * RpcContext. `undefined` / unknown names are NOT the CLI (they fall through to
+ * the legacy grandfather / normal enforcement).
+ */
+export function isInternalCliClient(clientName: string | undefined): boolean {
+  return clientName === WMUX_CLI_CLIENT_NAME;
+}

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -24,6 +24,16 @@ export interface RpcRequest {
 }
 
 /**
+ * Stable `clientName` reported by the bundled wmux CLI (`wmux <command>`,
+ * src/cli) so the permission enforcer can grant it a curated allowlist
+ * (src/main/mcp/internalCli.ts) instead of the envelope-less legacy grandfather.
+ * Defined in shared so the CLI (its own build) and the main-process enforcer
+ * agree on the exact string without a cross-build import. See the trust-root
+ * grandfather-deprecation plan (Stage 2).
+ */
+export const WMUX_CLI_CLIENT_NAME = 'wmux-cli';
+
+/**
  * Per-request context surfaced to RPC handlers — populated by PipeServer
  * from RpcRequest fields. Handlers receive this as an optional second
  * argument so legacy handlers `(params) => ...` keep compiling.


### PR DESCRIPTION
## What

The bundled CLI (`wmux <command>`) is the one steady-state, envelope-less, **mutating** caller riding the permission enforcer's legacy grandfather (`if (!clientName) return allow` → a token-holder reaches every method). To let that grandfather be **closed** later (trust-root epic Stage 3) without breaking the CLI, this gives the CLI a stable identity and a scoped allowlist now.

- `shared/rpc.ts` — `WMUX_CLI_CLIENT_NAME` (shared so the CLI and main agree without a cross-build import).
- `main/mcp/internalCli.ts` — `WMUX_CLI_METHODS` (the CLI's main-pipe surface, least privilege) + `isInternalCliClient`, mirroring `firstParty.ts`. A **separate, narrower** allowlist than `FIRST_PARTY_METHODS` (it is NOT widened).
- `main/mcp/PermissionEnforcer.ts` — a parallel `wmux-cli` tier after the first-party tier, same three guards (explicit `denied` wins, failed trust lookup declines, out-of-set falls through).
- `cli/client.ts` — stamp `clientName='wmux-cli'` on every request (harmless on the token-only daemon control pipe).
- `internalCli.test.ts` — **source-lockstep guard**: parses `src/cli/**` for every `sendRequest` method literal and fails if a main-pipe method is missing, so a new CLI command can't silently break once the grandfather closes.

## What this is NOT

**Additive.** It does **not** close the grandfather — that is Stage 3, behind the existing `enforcementMode` shadow→enforce flip with a release deprecation cadence. Here the CLI simply stops *riding* the grandfather.

## Verification

- tsc ×4, vitest **4092 pass**, lint clean. Lockstep test proves `WMUX_CLI_METHODS` is complete against the real CLI source.
- **Live dogfood in ENFORCE mode** (`mcp.mode=enforce`, isolated instance):
  - raw RPC 5/5 — `wmux-cli` + allowlisted → allow; **`wmux-cli` + `pane.setMetadata` (out-of-set) → REJECT** (proves the tier is scoped, not riding the grandfather); impersonator name → reject; no-clientName grandfather → still allow (additive).
  - real CLI 3/3 — `list-surfaces` / `current-workspace` / `list-workspaces` exit 0 via the tier.

Refs: trust-root security epic (P1 grandfather deprecation, Stage 2). Follow-up: Stage 3 closes the grandfather once the legacy-traffic counter is clean for all first-party callers (MCP + CLI + doctor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now includes identifying information in requests for enhanced permission management.
  * Implemented scoped authorization tier for CLI with curated method allowlist.

* **Tests**
  * Added comprehensive test coverage for CLI authorization enforcement and method allowlisting.
  * Added source-level invariant tests to ensure CLI method calls align with authorization allowlist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->