### PR TITLE
feat(channels): right-side channel dock, decoupled from Company mode

### DIFF
--- a/scripts/channel-dock-dogfood.mjs
+++ b/scripts/channel-dock-dogfood.mjs
@@ -1,0 +1,129 @@
+// Live CDP dogfood for the right-side channel dock (Approach A).
+//
+// The headline claim is "the dock REFLOWS the terminals instead of the old
+// fixed overlay that COVERED them." We prove it by comparing bounding boxes:
+// with the dock open, the visible terminal area must NOT overlap the dock's
+// x-range (they sit side by side). Plus: default-collapsed, StatusBar toggle
+// opens/closes, collapse button closes, opposite edge from the sidebar.
+//
+// Run: node scripts/channel-dock-dogfood.mjs   (dev wmux must be running)
+import { chromium } from 'playwright-core';
+import http from 'node:http';
+import fs from 'node:fs';
+
+const OUT = 'D:/wmux/out-dogfood';
+fs.mkdirSync(OUT, { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+function httpGet(url) { return new Promise((res) => { const q = http.get(url, (r) => { let b = ''; r.on('data', (c) => (b += c)); r.on('end', () => res(b)); }); q.on('error', () => res(null)); q.setTimeout(800, () => { q.destroy(); res(null); }); }); }
+async function findPort() { for (let p = 18800; p < 18900; p++) { const b = await httpGet(`http://127.0.0.1:${p}/json/version`); if (b && b.includes('webSocketDebuggerUrl')) return p; } return null; }
+async function findRenderer(ctx) { for (let i = 0; i < 60; i++) { for (const p of ctx.pages()) { try { if (await p.evaluate(() => !!document.querySelector('.xterm'))) return p; } catch { /* nav */ } } await sleep(1000); } return null; }
+// NOTE: this dogfood is intentionally DOM-only — a direct store-drive via
+// `import('/src/renderer/stores/index.ts')` resolves to a SEPARATE Vite module
+// instance after repeated reloads and won't reflect into the app's React tree.
+// All setup + assertions go through real DOM interactions instead.
+
+// Rect of the dock and the visible terminal screen.
+const rects = (page) => page.evaluate(() => {
+  const r = (el) => { if (!el) return null; const b = el.getBoundingClientRect(); return { x: Math.round(b.x), right: Math.round(b.right), w: Math.round(b.width), h: Math.round(b.height) }; };
+  const dock = document.querySelector('[data-channel-dock]');
+  const screens = Array.from(document.querySelectorAll('.xterm-screen'));
+  const vis = screens.find((el) => el.getBoundingClientRect().width > 0) || screens[0];
+  return { dock: r(dock), term: r(vis), statusToggle: !!document.querySelector('[data-statusbar-channels]') };
+});
+
+async function main() {
+  const results = [];
+  const pass = (id, cond, detail) => { results.push({ id, ok: !!cond, detail }); console.log(`${cond ? 'PASS' : 'FAIL'} ${id} — ${detail}`); };
+
+  const port = await findPort();
+  if (!port) { console.log('RESULT: FAIL — no dev CDP endpoint'); process.exit(2); }
+  console.log('CDP port:', port);
+  const browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`);
+  const ctx = browser.contexts()[0];
+  let page = await findRenderer(ctx);
+  if (!page) { console.log('RESULT: FAIL — no renderer'); await browser.close(); process.exit(2); }
+
+  // Reload so Vite serves the dock modules, then wait for re-mount.
+  await page.reload({ waitUntil: 'domcontentloaded' }).catch(() => {});
+  for (let i = 0; i < 30; i++) { await sleep(700); try { if (await page.evaluate(() => !!document.querySelector('.xterm'))) break; } catch { /* loading */ } }
+  await page.keyboard.press('Escape').catch(() => {});
+  await sleep(300);
+
+  // Clean baseline DOM-only: a direct store-drive hits a duplicate Vite module
+  // instance after repeated reloads and won't reflect into the app, so we close
+  // the dock through its own collapse button instead.
+  for (let i = 0; i < 4; i++) {
+    const open = await page.evaluate(() => !!document.querySelector('[data-channel-dock]'));
+    if (!open) break;
+    await page.click('[data-channel-dock-collapse]').catch(() => {});
+    await sleep(400);
+  }
+
+  // D1 — default collapsed: dock absent, StatusBar toggle present.
+  let r = await rects(page);
+  pass('D1-default-collapsed', !r.dock && r.statusToggle,
+    `dock absent by default, StatusBar toggle present=${r.statusToggle}`);
+
+  // D2 — StatusBar toggle opens the dock.
+  await page.click('[data-statusbar-channels]');
+  await sleep(500);
+  r = await rects(page);
+  pass('D2-toggle-opens', !!r.dock, `clicking StatusBar # opens the dock (dock rect=${JSON.stringify(r.dock)})`);
+  await page.screenshot({ path: `${OUT}/dock-open.png` }).catch(() => {});
+
+  // D3 — THE headline: dock REFLOWS, does not cover the terminals. The visible
+  // terminal screen must not overlap the dock's x-range.
+  if (r.dock && r.term) {
+    const noOverlap = r.term.right <= r.dock.x + 4 || r.dock.right <= r.term.x + 4;
+    pass('D3-reflow-not-overlay', noOverlap,
+      `terminal[x=${r.term.x},right=${r.term.right}] vs dock[x=${r.dock.x},right=${r.dock.right}] — side by side=${noOverlap}`);
+  } else {
+    pass('D3-reflow-not-overlay', false, `missing rects (dock=${!!r.dock} term=${!!r.term})`);
+  }
+
+  // D4 — dock sits opposite the (left) workspace sidebar → on the right half.
+  if (r.dock) {
+    const vw = await page.evaluate(() => window.innerWidth);
+    pass('D4-opposite-edge', r.dock.x > vw / 2, `dock on the right half (dock.x=${r.dock.x}, vw=${vw})`);
+  } else { pass('D4-opposite-edge', false, 'no dock'); }
+
+  // D5 — collapse button closes the dock.
+  await page.click('[data-channel-dock-collapse]').catch(() => {});
+  await sleep(400);
+  r = await rects(page);
+  pass('D5-collapse-closes', !r.dock, `collapse button hides the dock (present=${!!r.dock})`);
+
+  // D6 — REAL user path (DOM only; a direct store-drive hits a duplicate Vite
+  // module instance and won't reflect into the app's React tree): open the dock
+  // via the StatusBar toggle, click a channel row in the list, and confirm the
+  // conversation surface renders. (Channels are hydrated from the daemon on
+  // mount, so the -dogfood profile's catalog populates the list.)
+  await page.click('[data-statusbar-channels]'); // open the dock
+  await sleep(600);
+  const chRow = await page.$('[data-channel-dock] [data-channel-id]');
+  if (chRow) {
+    await chRow.click();
+    await sleep(600);
+    const conv = await page.evaluate(() => !!document.querySelector('[data-channel-view]'));
+    pass('D6-click-channel-shows-conversation', conv,
+      `clicking a channel row in the dock renders the conversation=${conv}`);
+    await page.screenshot({ path: `${OUT}/dock-conversation.png` }).catch(() => {});
+  } else {
+    pass('D6-click-channel-shows-conversation', false,
+      'no channel rows in the dock to click (empty hydrated catalog)');
+  }
+  await page.screenshot({ path: `${OUT}/dock-conversation.png` }).catch(() => {});
+
+  // Cleanup
+  await drive(page, async (useStore) => {
+    const s = useStore.getState();
+    s.setActiveChannel(null);
+    s.setChannelDockVisible(false);
+  });
+
+  const passed = results.filter((x) => x.ok).length;
+  console.log(`\nRESULT: ${passed}/${results.length} passed`);
+  await browser.close();
+  process.exit(passed === results.length ? 0 : 1);
+}
+main().catch((e) => { console.error('DOGFOOD ERROR:', e); process.exit(3); });

--- a/scripts/channels-company-dogfood.mjs
+++ b/scripts/channels-company-dogfood.mjs
@@ -1,0 +1,265 @@
+// Live CDP dogfood for two fixes (uncommitted working tree):
+//   1) Company-mode UI wiring — Ctrl+K "Company:" commands were "visible but
+//      no reaction" because sidebarMode='company' had no renderer consumer and
+//      CompanyPanel was orphaned. Fix: Sidebar renders CompanyPanel on
+//      sidebarMode==='company' + a header toggle (entry/exit).
+//   2) Channels decouple + hydration — channels were gated on in-app Company
+//      mode and the renderer never hydrated the daemon catalog.
+//
+// dev wmux exposes CDP on a random port in [18800,18900). We connect
+// playwright-core, drive the LIVE renderer (real click for the toggle; store
+// actions for the palette-command effects), and assert the visible result.
+//
+// Run: node scripts/channels-company-dogfood.mjs   (dev wmux must be running)
+import { chromium } from 'playwright-core';
+import http from 'node:http';
+import fs from 'node:fs';
+
+const OUT = 'D:/wmux/out-dogfood';
+fs.mkdirSync(OUT, { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function httpGet(url, timeoutMs = 800) {
+  return new Promise((resolve) => {
+    const req = http.get(url, (res) => {
+      let body = ''; res.on('data', (c) => (body += c)); res.on('end', () => resolve(body));
+    });
+    req.on('error', () => resolve(null));
+    req.setTimeout(timeoutMs, () => { req.destroy(); resolve(null); });
+  });
+}
+async function findCdpPort() {
+  for (let port = 18800; port < 18900; port++) {
+    const body = await httpGet(`http://127.0.0.1:${port}/json/version`);
+    if (body && body.includes('webSocketDebuggerUrl')) return port;
+  }
+  return null;
+}
+async function findRenderer(ctx) {
+  for (let i = 0; i < 60; i++) {
+    for (const p of ctx.pages()) {
+      try { if (await p.evaluate(() => !!document.querySelector('.xterm'))) return p; } catch { /* navigating */ }
+    }
+    await sleep(1000);
+  }
+  return null;
+}
+
+// All store mutations go through the Vite module URL (dev). Returns plain JSON.
+// Extra args after `fn` are forwarded to the evaluated function (after useStore).
+const drive = (page, fn, ...args) => page.evaluate(async ({ src, args }) => {
+  const { useStore } = await import('/src/renderer/stores/index.ts');
+  // eslint-disable-next-line no-eval
+  const f = eval('(' + src + ')');
+  return await f(useStore, ...args);
+}, { src: fn.toString(), args });
+
+const readSidebar = (page) => page.evaluate(() => {
+  const panel = document.querySelector('[data-channels-panel]');
+  const toggle = document.querySelector('[data-company-toggle]');
+  return {
+    companyToggle: !!toggle,
+    togglePressed: toggle ? toggle.getAttribute('aria-pressed') : null,
+    channelsPanel: !!panel,
+    companyState: panel ? panel.getAttribute('data-company-state') : null,
+    channelCount: panel ? panel.getAttribute('data-channel-count') : null,
+    channelIds: Array.from(document.querySelectorAll('[data-channel-id]')).map((e) => e.getAttribute('data-channel-id')),
+    workspaceRows: document.querySelectorAll('.sidebar-row').length,
+    noCompanyPrompt: document.body.textContent.includes('No company created yet'),
+    hasDogfoodCo: document.body.textContent.includes('Dogfood Co'),
+    hasDogfoodChan: document.body.textContent.includes('dogfood-chan'),
+  };
+});
+
+async function main() {
+  const results = [];
+  const pass = (id, cond, detail, opts = {}) => { results.push({ id, ok: !!cond, besteffort: !!opts.besteffort, detail }); console.log(`${cond ? 'PASS' : (opts.besteffort ? 'WARN' : 'FAIL')} ${id} — ${detail}`); };
+
+  const port = await findCdpPort();
+  if (!port) { console.log('RESULT: FAIL — no dev wmux CDP endpoint. Is the dev app running?'); process.exit(2); }
+  console.log('CDP port:', port);
+  const browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`);
+  const ctx = browser.contexts()[0];
+  const page = await findRenderer(ctx);
+  if (!page) { console.log('RESULT: FAIL — no renderer with .xterm in 60s'); await browser.close(); process.exit(2); }
+  console.log('renderer:', page.url());
+  await page.keyboard.press('Escape').catch(() => {});
+  await sleep(300);
+
+  // Clean known baseline: workspaces mode, no company, no dogfood channel.
+  await drive(page, async (useStore) => {
+    const s = useStore.getState();
+    if (s.company) s.destroyCompany();
+    s.setSidebarMode('workspaces');
+  });
+  await sleep(400);
+
+  // ── Company-mode fix ────────────────────────────────────────────────
+  let sb = await readSidebar(page);
+  pass('C1-toggle-present', sb.companyToggle && sb.togglePressed === 'false',
+    `company toggle present in workspaces mode (pressed=${sb.togglePressed})`);
+  pass('C1-channels-decoupled', sb.channelsPanel,
+    `channels panel renders without a company (company-state=${sb.companyState})`);
+
+  // C2 — REAL user click on the toggle → CompanyPanel must mount (was orphaned).
+  await page.click('[data-company-toggle]');
+  await sleep(500);
+  sb = await readSidebar(page);
+  pass('C2-toggle-enters-company', sb.togglePressed === 'true' && sb.noCompanyPrompt,
+    `clicking toggle shows CompanyPanel empty state ("No company created yet"=${sb.noCompanyPrompt})`);
+  await page.screenshot({ path: `${OUT}/company-empty.png` }).catch(() => {});
+
+  // C3 — the palette "Company: Create …" command effect: createCompany + mode.
+  await drive(page, async (useStore) => {
+    const s = useStore.getState();
+    s.createCompany('Dogfood Co');
+    useStore.getState().setSidebarMode('company');
+  });
+  await sleep(500);
+  sb = await readSidebar(page);
+  pass('C3-company-tree-visible', sb.hasDogfoodCo && !sb.noCompanyPrompt,
+    `created company renders in the sidebar (hasDogfoodCo=${sb.hasDogfoodCo})`);
+  await page.screenshot({ path: `${OUT}/company-tree.png` }).catch(() => {});
+
+  // C4 — toggle back to workspaces.
+  await page.click('[data-company-toggle]');
+  await sleep(400);
+  sb = await readSidebar(page);
+  pass('C4-toggle-exits-company', sb.togglePressed === 'false' && sb.workspaceRows > 0,
+    `toggle returns to workspaces (rows=${sb.workspaceRows})`);
+
+  // ── Channels decouple + hydration ───────────────────────────────────
+  // Unique channel name per run — the daemon persists channels in the -dogfood
+  // profile, so a fixed name would collide (INVALID_NAME) on re-run.
+  const chan = 'dogfood-' + Date.now().toString(36);
+  const bodyHas = (text) => page.evaluate((t) => document.body.textContent.includes(t), text);
+
+  await drive(page, async (useStore) => {
+    const s = useStore.getState();
+    if (s.company) s.destroyCompany();
+    s.setSidebarMode('workspaces');
+  });
+  await sleep(400);
+  sb = await readSidebar(page);
+  pass('CH1-panel-no-company', sb.channelsPanel && sb.companyState === 'absent',
+    `channels panel present with NO company (not a dead-end), state=${sb.companyState}`);
+
+  // CH2 — create a channel without a company (active-workspace identity).
+  const created = await drive(page, async (useStore, name) => {
+    const s = useStore.getState();
+    const ws = s.activeWorkspaceId;
+    const companyId = s.company?.id ?? 'co-default';
+    const self = s.company?.ceoWorkspaceId ?? ws;
+    const channel = {
+      id: `ch-local-${Date.now().toString(36)}`, companyId, name,
+      visibility: 'public', status: 'active', createdAt: Date.now(), createdBy: 'local-ui', nextSeq: 1,
+    };
+    const r = await s.createChannelDaemon({
+      name, visibility: 'public',
+      createdBy: { workspaceId: self, memberId: 'local-ui', memberName: 'local-ui' }, channel,
+    });
+    return { ok: r.ok, err: r.ok ? null : r.error, self };
+  }, chan);
+  await sleep(500);
+  const ch2Visible = await bodyHas(chan);
+  pass('CH2-create-without-company', created.ok && ch2Visible,
+    `channel "${chan}" created w/o company (daemon ok=${created.ok}${created.err ? ' err=' + JSON.stringify(created.err) : ''}) and visible in sidebar=${ch2Visible}`);
+  await page.screenshot({ path: `${OUT}/channels-no-company.png` }).catch(() => {});
+
+  // CH3 — hydration: wipe the renderer catalog (simulate fresh start) then run
+  // the exact list→getMembers→setChannels path useChannelsHydration uses,
+  // including the { id, ok, result } transport-envelope unwrap.
+  const hydrated = await drive(page, async (useStore) => {
+    const unwrap = (r) => (r && typeof r === 'object' && r.result && typeof r.result === 'object') ? r.result : r;
+    const s = useStore.getState();
+    useStore.setState((st) => { st.channels = {}; st.channelMembers = {}; });
+    const beforeCount = Object.keys(useStore.getState().channels).length;
+    const ws = s.activeWorkspaceId;
+    const self = s.company?.ceoWorkspaceId ?? ws;
+    const bridge = window.__wmuxChannelsRpc;
+    if (!bridge) return { beforeCount, error: 'no bridge' };
+    const listEnv = unwrap(await bridge.rpc('a2a.channel.list', { workspaceId: self, verifiedWorkspaceId: self }));
+    const channels = (listEnv && listEnv.ok && Array.isArray(listEnv.channels)) ? listEnv.channels : [];
+    const members = {};
+    for (const ch of channels) {
+      const mEnv = unwrap(await bridge.rpc('a2a.channel.getMembers', { channelId: ch.id, workspaceId: self, verifiedWorkspaceId: self }));
+      if (mEnv && mEnv.ok && Array.isArray(mEnv.members)) members[ch.id] = mEnv.members;
+    }
+    useStore.getState().setChannels(channels, members);
+    return { beforeCount, listedNames: channels.map((c) => c.name), afterCount: Object.keys(useStore.getState().channels).length };
+  });
+  await sleep(400);
+  const ch3Visible = await bodyHas(chan);
+  const hydOk = hydrated.beforeCount === 0 && (hydrated.listedNames || []).includes(chan) && ch3Visible;
+  pass('CH3-hydration-from-daemon', hydOk,
+    `wiped catalog (before=${hydrated.beforeCount}) → hydrated ${(hydrated.listedNames || []).length} channel(s) from daemon → "${chan}" visible=${ch3Visible}`);
+  await page.screenshot({ path: `${OUT}/channels-hydrated.png` }).catch(() => {});
+
+  // CH4 — DEPLOYED hook end-to-end: reload the renderer (Vite serves the FIXED
+  // modules) and assert useChannelsHydration auto-populates from the daemon on
+  // mount, with NO manual bridge calls. This is the real proof the shipped hook
+  // (not just the inline pattern) works.
+  await page.reload({ waitUntil: 'domcontentloaded' }).catch(() => {});
+  // wait for the renderer to re-mount (.xterm) then for hydration to land.
+  let remounted = false;
+  for (let i = 0; i < 30; i++) { await sleep(700); try { if (await page.evaluate(() => !!document.querySelector('.xterm'))) { remounted = true; break; } } catch { /* loading */ } }
+  let ch4Visible = false;
+  if (remounted) {
+    for (let i = 0; i < 12; i++) { await sleep(700); if (await bodyHas(chan)) { ch4Visible = true; break; } }
+  }
+  pass('CH4-deployed-hydration-on-reload', ch4Visible,
+    `after reload, the shipped useChannelsHydration auto-loaded "${chan}" from the daemon=${ch4Visible} (remounted=${remounted})`);
+  await page.screenshot({ path: `${OUT}/channels-reload-hydrated.png` }).catch(() => {});
+
+  // CH5 — DEPLOYED event subscription (best-effort, timing-sensitive): post a
+  // message via the raw daemon path (NO optimistic insert) and confirm it
+  // arrives through the 1 Hz events.poll. Pre-fix this silently delivered
+  // nothing (read one level too shallow). Isolated from optimistic insert by
+  // clearing the local message cache before posting.
+  const posted = ch4Visible ? await drive(page, async (useStore, name) => {
+    const s = useStore.getState();
+    const self = s.company?.ceoWorkspaceId ?? s.activeWorkspaceId;
+    const ch = Object.values(useStore.getState().channels).find((c) => c.name === name);
+    if (!ch) return { ok: false, error: 'channel not hydrated' };
+    useStore.getState().setActiveChannel(ch.id);
+    useStore.setState((st) => { st.channelMessages[ch.id] = []; });
+    const text = 'live-evt-' + Date.now().toString(36);
+    const raw = await window.__wmuxChannelsRpc.mutateLocal('a2a.channel.post', {
+      channelId: ch.id, text,
+      sender: { workspaceId: self, memberId: 'local-ui', memberName: 'local-ui' },
+      verifiedWorkspaceId: self, clientMsgId: 'cmid-' + text,
+    });
+    const ok = !!(raw && (raw.ok === true || (raw.result && raw.result.ok === true)));
+    return { ok, text, chId: ch.id };
+  }, chan) : { ok: false, error: 'skipped (no hydration)' };
+  let ch5 = false;
+  if (posted.ok) {
+    for (let i = 0; i < 7; i++) {
+      await sleep(800);
+      const seen = await drive(page, async (useStore, payload) => {
+        const msgs = useStore.getState().channelMessages[payload.chId] || [];
+        return msgs.some((m) => m.text === payload.text);
+      }, posted);
+      if (seen) { ch5 = true; break; }
+    }
+  }
+  pass('CH5-live-event-delivery', ch5,
+    `posted "${posted.text || '?'}" via daemon (no optimistic) → arrived through events.poll=${ch5}${posted.error ? ' (' + posted.error + ')' : ''}`,
+    { besteffort: true });
+
+  // Cleanup the dogfood channel + company so we don't pollute the dev profile.
+  await drive(page, async (useStore) => {
+    const s = useStore.getState();
+    if (s.company) s.destroyCompany();
+    s.setSidebarMode('workspaces');
+  });
+
+  const hard = results.filter((r) => !r.besteffort);
+  const passed = hard.filter((r) => r.ok).length;
+  const be = results.filter((r) => r.besteffort);
+  const bePassed = be.filter((r) => r.ok).length;
+  console.log(`\nRESULT: ${passed}/${hard.length} hard passed` + (be.length ? ` (+ ${bePassed}/${be.length} best-effort)` : ''));
+  await browser.close();
+  process.exit(passed === hard.length ? 0 : 1);
+}
+main().catch((e) => { console.error('DOGFOOD ERROR:', e); process.exit(3); });

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -13,6 +13,7 @@ import { LanLinkServer } from './lanlink/server';
 import { PeerStore } from './lanlink/peers';
 import { coerceLanLinkPatch } from '../shared/lanlink';
 import { ChannelService, ChannelStateWriter, wrapChannelMessageEnvelope } from './channels';
+import { DEFAULT_COMPANY_ID } from '../shared/channels';
 import { ProcessMonitor } from './ProcessMonitor';
 import { Watchdog } from './Watchdog';
 import { selectRecoverableSessions } from './recoverySelector';
@@ -2234,13 +2235,15 @@ async function main(): Promise<void> {
   // cannot cascade into session-state failure. The service receives
   // `pipeServer.broadcast` as its emit sink so a successful post is
   // fanned out to every connected client before the next RPC turn.
-  // Company id is hardcoded to `'co-default'` until the company-mode
+  // Company id is the shared `DEFAULT_COMPANY_ID` until the company-mode
   // config key lands; the channel state format already supports
-  // multi-company, so this is a single line to swap.
+  // multi-company, so this is a single line to swap. The renderer uses the
+  // SAME constant when it has no in-app Company, so optimistic rows and the
+  // daemon's authoritative rows share one companyId.
   const channelStateWriter = new ChannelStateWriter(wmuxDir);
   const channelService = new ChannelService({
     writer: channelStateWriter,
-    companyId: 'co-default',
+    companyId: DEFAULT_COMPANY_ID,
     // U5 archive-authz (KTD-F): the CEO override is gated on this field.
     // The renderer owns `Company.ceoWorkspaceId` today; the daemon does
     // not have a copy, so we pass `undefined` (creator-only archive)

--- a/src/renderer/components/Channels/ChannelDock.tsx
+++ b/src/renderer/components/Channels/ChannelDock.tsx
@@ -1,0 +1,82 @@
+// ─── Right-side channel dock (Approach A) ────────────────────────────────
+//
+// A collapsible flex column on the OPPOSITE edge from the workspace sidebar.
+// Holds the channel list (ChannelsPanel) at the top and the active
+// conversation (ChannelView) below. This replaces the old `position: fixed`
+// ChannelView overlay that covered the terminals — the dock is a flex sibling
+// in AppLayout's root row, so it reflows the panes instead of floating over
+// them. Mounted only when `channelDockVisible` (uiSlice); auto-opens when a
+// channel is selected (channelsSlice.setActiveChannel), collapses via the
+// header button, and reopens from the StatusBar channel toggle.
+//
+// Edge mirroring: the workspace Sidebar sits on `sidebarPosition`; the dock
+// sits opposite. AppLayout's root uses `flex-row-reverse` when the sidebar is
+// docked right, so placing the dock as the last flex child puts it on the
+// correct (opposite) edge automatically — we only flip the inner border side.
+
+import { useStore } from '../../stores';
+import { useT } from '../../hooks/useT';
+import { tokenAttrs } from '../../themes';
+import { FOCUS_RING } from '../focusRing';
+import { IconChevronDir } from '../icons';
+import { ChannelsPanel } from './ChannelsPanel';
+import { ChannelView } from './ChannelView';
+
+export default function ChannelDock(): React.ReactElement {
+  const t = useT();
+  const sidebarPosition = useStore((s) => s.sidebarPosition);
+  const setChannelDockVisible = useStore((s) => s.setChannelDockVisible);
+
+  // Workspace sidebar is on `sidebarPosition`; the dock is on the opposite
+  // edge. When the sidebar is on the LEFT (default), the dock is on the RIGHT,
+  // so its content border faces left (border-l) and the collapse chevron
+  // points right (toward the screen edge it tucks into).
+  const dockOnRight = sidebarPosition !== 'right';
+
+  return (
+    <div
+      className={`flex flex-col h-full bg-[var(--bg-mantle)] ${dockOnRight ? 'border-l' : 'border-r'} border-[var(--bg-surface)]`}
+      style={{ width: 320, borderColor: 'var(--border-soft)' }}
+      data-channel-dock
+      {...tokenAttrs('bgMantle', 'bg')}
+      {...tokenAttrs('bgSurface', 'border')}
+    >
+      {/* Slim header — collapse affordance on the inner edge (mirrors the
+          Sidebar footer collapse). The "Channels" section title + unread total
+          live in ChannelsPanel's own header just below. */}
+      <div
+        className={`flex items-center justify-between px-3 py-1.5 border-b border-[var(--bg-surface)] shrink-0 ${dockOnRight ? '' : 'flex-row-reverse'}`}
+        style={{ borderColor: 'var(--border-soft)' }}
+        {...tokenAttrs('bgSurface', 'border')}
+      >
+        <span
+          className="text-[10px] font-mono tracking-widest uppercase text-[var(--text-muted)]"
+          {...tokenAttrs('textMuted', 'text')}
+        >
+          {t('channels.dockTitle') || 'Channels'}
+        </span>
+        <button
+          type="button"
+          className={`flex items-center justify-center w-5 h-5 rounded text-[var(--text-muted)] hover:text-[var(--text-main)] hover:bg-[rgba(var(--bg-surface-rgb),0.6)] transition-colors duration-150 ${FOCUS_RING}`}
+          onClick={() => setChannelDockVisible(false)}
+          title={t('channels.dockCollapse') || 'Collapse channels'}
+          aria-label={t('channels.dockCollapse') || 'Collapse channels'}
+          data-channel-dock-collapse
+        >
+          {/* Chevron points toward the edge the dock tucks into. */}
+          <IconChevronDir dir={dockOnRight ? 'right' : 'left'} />
+        </button>
+      </div>
+
+      {/* Channel list — capped so a long catalog can't crowd out the
+          conversation; scrolls within its share. */}
+      <div className="shrink-0 max-h-[45%] overflow-y-auto">
+        <ChannelsPanel />
+      </div>
+
+      {/* Active conversation — fills the remaining height. Renders null when no
+          channel is active (you still see the list above). */}
+      <ChannelView />
+    </div>
+  );
+}

--- a/src/renderer/components/Channels/ChannelView.tsx
+++ b/src/renderer/components/Channels/ChannelView.tsx
@@ -291,32 +291,28 @@ export function ChannelView(): React.ReactElement | null {
     return null;
   }
 
+  // Dock content (not a fixed overlay anymore). The ChannelDock owns width +
+  // positioning; ChannelView fills the dock's remaining height below the list.
   return (
-    <div
-      className="fixed top-0 right-0 h-screen pointer-events-none"
-      style={{ width: 360, zIndex: 40 }}
-      data-channel-view-wrapper
-    >
-      <div className="h-full pointer-events-auto">
-        <ChannelViewContent
-          channel={channel}
-          messages={messages}
-          viewer={viewer}
-          onClose={handleClose}
-          composerSlot={
-            channel.status === 'archived' ? (
-              <div
-                data-channel-archived-composer
-                className="px-4 py-2 text-[10px] font-mono text-[var(--text-muted)]"
-              >
-                {t('channels.archivedReadOnly') || 'Archived channels are read-only.'}
-              </div>
-            ) : (
-              <Composer channelId={channel.id} onError={pushToast} />
-            )
-          }
-        />
-      </div>
+    <div className="flex flex-col flex-1 min-h-0" data-channel-view-wrapper>
+      <ChannelViewContent
+        channel={channel}
+        messages={messages}
+        viewer={viewer}
+        onClose={handleClose}
+        composerSlot={
+          channel.status === 'archived' ? (
+            <div
+              data-channel-archived-composer
+              className="px-4 py-2 text-[10px] font-mono text-[var(--text-muted)]"
+            >
+              {t('channels.archivedReadOnly') || 'Archived channels are read-only.'}
+            </div>
+          ) : (
+            <Composer channelId={channel.id} onError={pushToast} />
+          )
+        }
+      />
     </div>
   );
 }

--- a/src/renderer/components/Channels/ChannelView.tsx
+++ b/src/renderer/components/Channels/ChannelView.tsx
@@ -247,6 +247,10 @@ export function ChannelView(): React.ReactElement | null {
     activeChannelId ? s.channelMembers[activeChannelId] ?? EMPTY_MEMBERS : EMPTY_MEMBERS,
   );
   const company = useStore((s) => s.company);
+  // Channels are decoupled from in-app Company mode: the active workspace is
+  // the renderer's "self" identity when no company is set (mirrors
+  // useChannelsHydration / ChannelsPanel).
+  const activeWorkspaceId = useStore((s) => s.activeWorkspaceId);
   const setActiveChannel = useStore((s) => s.setActiveChannel);
   const pushToast = useStore((s) => s.pushToast);
 
@@ -270,13 +274,13 @@ export function ChannelView(): React.ReactElement | null {
   // return makes the hook order stable across renders.
   const viewer = useMemo<ChannelMember | null>(() => {
     if (members.length === 0) return null;
-    const ownWorkspaceId = company?.ceoWorkspaceId;
-    if (ownWorkspaceId !== undefined) {
+    const ownWorkspaceId = company?.ceoWorkspaceId ?? activeWorkspaceId;
+    if (ownWorkspaceId) {
       const own = members.find((m) => m.workspaceId === ownWorkspaceId);
       if (own) return own;
     }
     return members[0] ?? null;
-  }, [members, company?.ceoWorkspaceId]);
+  }, [members, company?.ceoWorkspaceId, activeWorkspaceId]);
 
   if (!activeChannelId || !channel) {
     // The activeChannelId-but-channel-undefined case can fire on a

--- a/src/renderer/components/Channels/ChannelsPanel.tsx
+++ b/src/renderer/components/Channels/ChannelsPanel.tsx
@@ -22,12 +22,19 @@
 //     shown inside a collapsible disclosure (collapsed by default —
 //     archived rooms are read-only and rarely useful in the sidebar).
 //
-// Empty states:
-//   - When `state.company === null`, channels are company-bounded by
-//     design, so we render a one-line prompt rather than an empty list.
-//   - When the company exists but the channel catalog is empty, we
-//     render a friendlier "no channels yet" prompt with the same
-//     `+ New channel` action.
+// Company decoupling:
+//   - Channels are NOT gated on in-app Company mode. The daemon scopes
+//     every channel to `DEFAULT_COMPANY_ID` until multi-company lands, and
+//     the renderer mirrors that catalog (hydrated by useChannelsHydration)
+//     regardless of `state.company`. When no in-app company exists, the
+//     active workspace stands in as the creator identity so `+ New channel`
+//     still works. `data-company-state` is a diagnostic attribute, not a
+//     render gate.
+//
+// Empty state:
+//   - When the channel catalog is empty, we render a friendly "no channels
+//     yet" prompt with the same `+ New channel` action (whether or not an
+//     in-app company exists).
 //
 // New-channel flow:
 //   - Clicking `+ New channel` opens the inline `CreateChannelModal`
@@ -47,6 +54,7 @@ import {
   canonicalizeChannelName,
   isValidChannelName,
   CHANNEL_NAME_MAX,
+  DEFAULT_COMPANY_ID,
 } from '../../../shared/channels';
 import type { Company } from '../../../company/types';
 import { useStore } from '../../stores';
@@ -304,25 +312,16 @@ export function ChannelsPanelView(props: ChannelsPanelViewProps): React.ReactEle
     [channelUnread],
   );
 
-  // R20/R29: company-bounded empty state.
-  if (!company) {
-    return (
-      <div
-        data-channels-panel
-        data-company-state="absent"
-        className="border-t border-[var(--bg-surface)] px-3 py-2 text-[10px] font-mono text-[var(--text-muted)]"
-        style={{ borderColor: 'var(--border-soft)' }}
-        {...tokenAttrs('textMuted', 'text')}
-      >
-        {t('channels.emptyCompany') ?? 'Channels are company-scoped — start a company to use them.'}
-      </div>
-    );
-  }
-
+  // Channels are decoupled from in-app Company mode (the daemon scopes every
+  // channel to DEFAULT_COMPANY_ID until multi-company lands). The panel always
+  // renders so the daemon's authoritative catalog is visible and the `+`
+  // affordance works without a company — `data-company-state` is now a
+  // diagnostic attribute, not a render gate. Empty catalog falls through to the
+  // friendly empty prompt below.
   return (
     <div
       data-channels-panel
-      data-company-state="present"
+      data-company-state={company ? 'present' : 'absent'}
       data-channel-count={channelList.length}
       data-total-unread={totalUnread}
       className="border-t border-[var(--bg-surface)] py-2"
@@ -442,35 +441,41 @@ export function ChannelsPanel(): React.ReactElement {
   const channelUnread = useStore((s) => s.channelUnread);
   const activeChannelId = useStore((s) => s.activeChannelId);
   const company = useStore((s) => s.company);
+  // Channels are decoupled from in-app Company mode: when no company is set,
+  // the active workspace stands in as the creator identity so the `+` button
+  // works without one (mirrors useChannelsHydration's identity resolution).
+  const activeWorkspaceId = useStore((s) => s.activeWorkspaceId);
   const setActiveChannel = useStore((s) => s.setActiveChannel);
   const createChannelDaemon = useStore((s) => s.createChannelDaemon);
 
   const handleCreate = useCallback(
     async (params: { name: string; visibility: ChannelVisibility }) => {
-      if (!company) return false;
+      // companyId matches the daemon's DEFAULT_COMPANY_ID when no in-app
+      // company exists, so the optimistic row's companyId agrees with the
+      // daemon's authoritative row (the daemon ignores any client companyId
+      // and stamps its own — keeping them equal avoids a flicker on refresh).
+      const companyId = company?.id ?? DEFAULT_COMPANY_ID;
+      // Sender identity: the CEO workspace when Company mode is active, else
+      // the active workspace. The daemon pins `createdBy` to the verified
+      // (renderer-supplied, process-boundary-trusted) workspace anyway; this
+      // is the value it pins to. Bail only if there is no workspace at all.
+      const selfWorkspaceId = company?.ceoWorkspaceId ?? activeWorkspaceId;
+      if (!selfWorkspaceId) return false;
       // Synthesize the row the slice would use as the optimistic
       // insert. The `*Daemon` thunk will overwrite this with the
       // daemon's authoritative row on success — the synthesized row
       // is only used as the input shape so the thunk can call the
       // matching `*Optimistic` primitive with the right field set.
       const channel = synthesizeChannel({
-        companyId: company.id,
+        companyId,
         name: params.name,
         visibility: params.visibility,
       });
-      // The slice's `*Daemon` thunks need a sender address. v1 has
-      // no concept of "the current renderer identity" — the U7 UI
-      // is company-scoped but workspace-agnostic. The CEO workspace
-      // (or the first workspace in the company, if CEO is not set)
-      // is used as a stable stand-in. The authoritative row that
-      // arrives from the daemon will overwrite the auto-member with
-      // the real creator's id.
-      const ceoWorkspaceId = company.ceoWorkspaceId ?? 'unknown-workspace';
       const result = await createChannelDaemon({
         name: params.name,
         visibility: params.visibility,
         createdBy: {
-          workspaceId: ceoWorkspaceId,
+          workspaceId: selfWorkspaceId,
           memberId: 'local-ui',
           memberName: 'local-ui',
         },

--- a/src/renderer/components/Channels/Composer.tsx
+++ b/src/renderer/components/Channels/Composer.tsx
@@ -195,18 +195,26 @@ export interface ComposerProps {
 export function Composer({ channelId, onError }: ComposerProps): React.ReactElement {
   const t = useT();
   const company = useStore((s) => s.company);
+  // Channels are decoupled from in-app Company mode: the active workspace
+  // stands in as the sender identity when no company is set (mirrors
+  // ChannelsPanel / ChannelView / useChannelsHydration).
+  const activeWorkspaceId = useStore((s) => s.activeWorkspaceId);
   const channel = useStore((s) => s.channels[channelId]);
   const postMessageDaemon = useStore((s) => s.postMessageDaemon);
 
   const handlePost = useCallback(
     async (text: string) => {
-      if (!company || !channel) {
-        return { ok: false, errorCode: 'UNKNOWN', errorMessage: 'No active company' };
+      // Sender identity: the CEO workspace when Company mode is active, else
+      // the active workspace. The daemon's post path requires
+      // sender.workspaceId === verifiedWorkspaceId AND membership; posting
+      // succeeds on channels this identity is a member of (e.g. ones it
+      // created here). A channel created by another client requires a join
+      // first — that is the daemon's membership rule (NOT_A_MEMBER), not a
+      // company gate.
+      const selfWorkspaceId = company?.ceoWorkspaceId ?? activeWorkspaceId;
+      if (!channel || !selfWorkspaceId) {
+        return { ok: false, errorCode: 'UNKNOWN', errorMessage: 'No channel or workspace identity' };
       }
-      // The CEO-workspace stand-in is the same stand-in U7 uses for
-      // channel create; the authoritative row from the daemon will
-      // overwrite the auto-member with the real creator's id.
-      const ceoWorkspaceId = company.ceoWorkspaceId ?? 'unknown-workspace';
       // R11 idempotency: `clientMsgId` is the per-post idempotency
       // key. The daemon returns the original `seq` on a repeat hit
       // instead of appending a duplicate; we generate the key here
@@ -218,7 +226,7 @@ export function Composer({ channelId, onError }: ComposerProps): React.ReactElem
         channelId,
         seq: nextSeq,
         text,
-        senderWorkspaceId: ceoWorkspaceId,
+        senderWorkspaceId: selfWorkspaceId,
         senderMemberId: 'local-ui',
         senderMemberName: 'local-ui',
         clientMsgId,
@@ -226,7 +234,7 @@ export function Composer({ channelId, onError }: ComposerProps): React.ReactElem
       const result = await postMessageDaemon(channelId, {
         text,
         sender: {
-          workspaceId: ceoWorkspaceId,
+          workspaceId: selfWorkspaceId,
           memberId: 'local-ui',
           memberName: 'local-ui',
         },

--- a/src/renderer/components/Channels/__tests__/ChannelDock.test.tsx
+++ b/src/renderer/components/Channels/__tests__/ChannelDock.test.tsx
@@ -1,0 +1,54 @@
+// ─── Regression guard: right-side channel dock wiring (Approach A) ───────────
+//
+// The dock replaced the old `position: fixed` ChannelView overlay (which COVERED
+// the terminals) with a flex sibling that REFLOWS them. The behavioral proof is
+// the live CDP dogfood (scripts/channel-dock-dogfood.mjs, 6/6). Store-connected
+// chrome can't be seeded under the node-env renderToStaticMarkup harness, so
+// this pins the wiring in source (same lockstep pattern as Sidebar.companyMode)
+// to stop a silent regression back to the covering overlay or an orphaned panel.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = resolve(process.cwd(), 'src/renderer');
+const read = (p: string) => readFileSync(resolve(SRC, p), 'utf8');
+
+const dock = read('components/Channels/ChannelDock.tsx');
+const channelView = read('components/Channels/ChannelView.tsx');
+const appLayout = read('components/Layout/AppLayout.tsx');
+const sidebar = read('components/Sidebar/Sidebar.tsx');
+const uiSlice = read('stores/slices/uiSlice.ts');
+
+describe('channel dock — wiring regression guard', () => {
+  it('ChannelDock renders the list + the conversation', () => {
+    expect(dock).toMatch(/<ChannelsPanel\s*\/>/);
+    expect(dock).toMatch(/<ChannelView\s*\/>/);
+    expect(dock).toContain('data-channel-dock');
+  });
+
+  it('ChannelView is dock content, NOT a fixed covering overlay', () => {
+    // The old overlay used `fixed top-0 right-0 ... pointer-events-none`. The
+    // dock content must be a flex column instead.
+    expect(channelView).not.toMatch(/fixed\s+top-0\s+right-0/);
+    expect(channelView).not.toContain('pointer-events-none');
+    expect(channelView).toMatch(/data-channel-view-wrapper/);
+  });
+
+  it('AppLayout mounts ChannelDock gated on channelDockVisible (not the old overlay)', () => {
+    expect(appLayout).toMatch(/import ChannelDock from '\.\.\/Channels\/ChannelDock'/);
+    expect(appLayout).toContain('channelDockVisible && (');
+    expect(appLayout).toMatch(/<ChannelDock\s*\/>/);
+    // The old always-mounted overlay <ChannelView /> must be gone from AppLayout.
+    expect(appLayout).not.toMatch(/^\s*<ChannelView\s*\/>/m);
+  });
+
+  it('Sidebar no longer mounts ChannelsPanel (it moved to the dock)', () => {
+    expect(sidebar).not.toMatch(/<ChannelsPanel\s*\/>/);
+  });
+
+  it('uiSlice owns the persisted channelDockVisible flag + toggle', () => {
+    expect(uiSlice).toContain('channelDockVisible');
+    expect(uiSlice).toMatch(/toggleChannelDock/);
+  });
+});

--- a/src/renderer/components/Channels/__tests__/ChannelsPanel.test.tsx
+++ b/src/renderer/components/Channels/__tests__/ChannelsPanel.test.tsx
@@ -23,6 +23,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { Channel } from '../../../../shared/channels';
+import { DEFAULT_COMPANY_ID } from '../../../../shared/channels';
 import { useStore } from '../../../stores';
 import {
   ChannelsPanelView,
@@ -328,10 +329,26 @@ beforeEach(() => {
 });
 
 describe('ChannelsPanelView', () => {
-  it('renders the company-absent empty state when company is null', () => {
+  it('renders the full panel (not a dead-end) when company is null — channels are decoupled from Company mode', () => {
     const html = renderPanel({ company: null });
+    // Decoupled: `data-company-state` is now a diagnostic attribute, not a
+    // render gate. The panel renders its normal body so the daemon catalog is
+    // visible and the `+` affordance works without a company.
     expect(html).toContain('data-company-state="absent"');
     expect(html).toContain('data-channels-panel');
+    expect(html).toContain('data-channels-new');
+    // Empty catalog → friendly empty prompt (NOT the old company-scoped dead-end).
+    expect(html).toContain('data-channels-empty');
+  });
+
+  it('shows the daemon catalog when company is null but channels exist (gate relaxed)', () => {
+    const html = renderPanel({
+      company: null,
+      channels: { 'ch-1': makeChannel({ id: 'ch-1', name: 'general' }) },
+    });
+    expect(html).toContain('data-company-state="absent"');
+    expect(html).toContain('data-channel-count="1"');
+    expect(html).toContain('data-channel-id="ch-1"');
   });
 
   it('renders the empty-catalog prompt when company is set but no channels exist', () => {
@@ -466,11 +483,32 @@ describe('ChannelsPanel — createChannelOptimistic wiring', () => {
     expect(after.channelMessages[channel.id]).toEqual([]);
   });
 
-  it('does not add a channel when state.company is null (handleCreate short-circuits)', () => {
-    useStore.setState({ company: null });
-    // The panel's handleCreate returns false when company is null —
-    // mirroring the behavior, we simulate the early return by NOT
-    // calling createChannelOptimistic. The catalog stays empty.
-    expect(Object.keys(useStore.getState().channels)).toHaveLength(0);
+  it('adds a channel when state.company is null using the active-workspace identity (decoupled)', () => {
+    // New behavior: channels work without in-app Company mode. handleCreate
+    // resolves companyId → DEFAULT_COMPANY_ID and the creator workspace →
+    // active workspace. We mirror that resolution here (handleCreate itself
+    // needs the bridge; the slice round-trip is what we assert).
+    useStore.setState({ company: null, activeWorkspaceId: 'ws-active' });
+    const channel = synthesizeChannel({
+      companyId: DEFAULT_COMPANY_ID,
+      name: 'general',
+      visibility: 'public',
+    });
+    const result = useStore.getState().createChannelOptimistic({
+      name: 'general',
+      visibility: 'public',
+      createdBy: {
+        workspaceId: 'ws-active',
+        memberId: 'local-ui',
+        memberName: 'local-ui',
+      },
+      channel,
+    });
+
+    expect(result.ok).toBe(true);
+    const after = useStore.getState();
+    expect(after.channels[channel.id]).toBeDefined();
+    expect(after.channels[channel.id].companyId).toBe(DEFAULT_COMPANY_ID);
+    expect(after.channelMembers[channel.id]).toHaveLength(1);
   });
 });

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -24,7 +24,7 @@ import KeyboardCheatSheet from '../KeyboardCheatSheet';
 import ToastContainer from '../Toast/ToastContainer';
 import FloatingPane from '../Terminal/FloatingPane';
 import SearchResultsPanel from '../Search/SearchResultsPanel';
-import { ChannelView } from '../Channels/ChannelView';
+import ChannelDock from '../Channels/ChannelDock';
 import { ErrorBoundary } from '../ErrorBoundary';
 import { useKeyboard } from '../../hooks/useKeyboard';
 import { useActivePaneFocus } from '../../hooks/useActivePaneFocus';
@@ -186,6 +186,7 @@ function buildSessionData(dumped: Map<string, boolean>): SessionData {
     })),
     activeWorkspaceId: state.activeWorkspaceId,
     sidebarVisible: state.sidebarVisible,
+    channelDockVisible: state.channelDockVisible,
     sidebarMode: state.sidebarMode,
     company: companySafe,
     memberCosts: state.memberCosts,
@@ -233,6 +234,7 @@ export default function AppLayout() {
   // Global guard: blocks webview pointer capture during panel separator drag
   useResizeGuard();
   const sidebarVisible = useStore((s) => s.sidebarVisible);
+  const channelDockVisible = useStore((s) => s.channelDockVisible);
   const sidebarPosition = useStore((s) => s.sidebarPosition);
   const fileTreeVisible = useStore((s) => s.fileTreeVisible);
   const companyViewVisible = useStore((s) => s.companyViewVisible);
@@ -1172,6 +1174,16 @@ export default function AppLayout() {
         )}
       </div>
       </ErrorBoundary>
+      {/* A2A channel dock (Approach A). A flex sibling on the OPPOSITE edge
+          from the workspace sidebar — the root row's flex-row-reverse (when
+          the sidebar is docked right) puts this on the correct edge, so it
+          reflows the panes instead of the old fixed overlay that covered them.
+          Holds the channel list + active conversation; collapsible. */}
+      {channelDockVisible && (
+        <ErrorBoundary name="ChannelDock">
+          <ChannelDock />
+        </ErrorBoundary>
+      )}
       {fileTreeVisible && (
         <ErrorBoundary name="FileTree">
           <FileTreePanel position={sidebarPosition === 'left' ? 'right' : 'left'} />
@@ -1179,15 +1191,6 @@ export default function AppLayout() {
       )}
       <NotificationPanel />
       <MessageFeedPanel />
-      {/* A2A channel view (U8). Always mounted; returns null when no
-          channel is active, so the gate is internal (matches the
-          NotificationPanel pattern). The view docks to the right
-          edge of the main area when a channel is active. The wrapper
-          uses a fixed-position overlay so it stacks above the panes
-          but does not disturb the workspace layout — the panes
-          remain fully interactive when the channel view is hidden
-          (pointer-events: none on the wrapper). */}
-      <ChannelView />
       {/* Cross-pane search results panel (T-F). Mount-gated on
           searchPanelOpen at this level (I3) so the panel's 6-field zustand
           subscriptions don't run when closed. */}

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -34,6 +34,7 @@ import { useResizeGuard } from '../../hooks/useResizeGuard';
 import { useApprovalInboxBridge } from '../../hooks/useApprovalInboxBridge';
 import { useRemoteInboxBridge } from '../../hooks/useRemoteInboxBridge';
 import { useChannelsEventSubscription } from '../../hooks/useChannelsEventSubscription';
+import { useChannelsHydration } from '../../hooks/useChannelsHydration';
 import { usePaneDecorationChannel } from '../../plugins/usePaneDecorationChannel';
 import { useIpc } from '../../hooks/useIpc';
 import type { SessionData, PaneLeaf, Pane, Surface, Workspace } from '../../../shared/types';
@@ -307,6 +308,12 @@ export default function AppLayout() {
   // panel visibility) so the unread badge stays accurate while the
   // sidebar is collapsed.
   useChannelsEventSubscription();
+  // U6 follow-up — hydrate the channel catalog from the daemon's authoritative
+  // list on mount + daemon (re)connect. Without this the sidebar only ever
+  // showed channels created in THIS renderer session; channels created by MCP
+  // agents or persisted across restart were invisible. Decoupled from in-app
+  // Company mode (falls back to the active workspace for identity).
+  useChannelsHydration();
   // Plugin host (B-1): ui.decoratePane push → uiSlice pane decorations.
   usePaneDecorationChannel();
   const { invoke: ipcInvoke } = useIpc();

--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -11,6 +11,7 @@ import { IconPlus, IconChevronDir } from '../icons';
 import { FOCUS_RING } from '../focusRing';
 import PluginPanels from '../../plugins/PluginPanels';
 import { ChannelsPanel } from '../Channels/ChannelsPanel';
+import CompanyPanel from './CompanyPanel';
 
 // Pane 트리에서 모든 leaf의 PTY를 dispose
 function disposeAllPtys(pane: Pane) {
@@ -39,6 +40,13 @@ export default function Sidebar() {
   const toggleFileTree = useStore((s) => s.toggleFileTree);
   const fileTreeVisible = useStore((s) => s.fileTreeVisible);
   const company = useStore((s) => s.company);
+  // sidebarMode toggles the sidebar's central content between the workspace
+  // list and the company tree (CompanyPanel). The palette's "Company: …"
+  // commands flip this to 'company'; without a consumer here the flip was a
+  // no-op (the bug: company commands appeared to do nothing). The header
+  // toggle below is the UI entry/exit point.
+  const sidebarMode = useStore((s) => s.sidebarMode);
+  const setSidebarMode = useStore((s) => s.setSidebarMode);
 
   const [pickerOpen, setPickerOpen] = useState(false);
   const togglePicker = useCallback(() => setPickerOpen((v) => !v), []);
@@ -81,6 +89,36 @@ export default function Sidebar() {
       <div className="relative flex items-center justify-between px-4 py-3 border-b border-[var(--bg-surface)]" style={{ borderColor: 'var(--border-soft)' }}>
         <span className="text-sm font-bold text-[var(--text-main)] tracking-widest font-mono" {...tokenAttrs('textMain', 'text')}>WMUX</span>
         <div className="flex items-center gap-1.5">
+          {/* Workspaces ⇄ Company toggle. Entry/exit for company mode — the
+              palette commands set sidebarMode but there was no UI affordance
+              to flip it back (or discover it). */}
+          <button
+            className={`flex items-center justify-center w-6 h-6 rounded-md transition-colors duration-150 hover:bg-[rgba(var(--bg-surface-rgb),0.6)] ${FOCUS_RING} ${
+              sidebarMode === 'company'
+                ? 'text-[var(--accent-blue)]'
+                : 'text-[var(--text-subtle)] hover:text-[var(--accent-blue)]'
+            }`}
+            onClick={() => setSidebarMode(sidebarMode === 'company' ? 'workspaces' : 'company')}
+            title={
+              sidebarMode === 'company'
+                ? (t('sidebar.showWorkspaces') || 'Show workspaces')
+                : (t('sidebar.showCompany') || 'Show company')
+            }
+            aria-label={
+              sidebarMode === 'company'
+                ? (t('sidebar.showWorkspaces') || 'Show workspaces')
+                : (t('sidebar.showCompany') || 'Show company')
+            }
+            aria-pressed={sidebarMode === 'company'}
+            data-company-toggle
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <circle cx="5.5" cy="5" r="2" />
+              <circle cx="11" cy="6" r="1.5" />
+              <path d="M2 13c0-2 1.6-3.3 3.5-3.3S9 11 9 13" />
+              <path d="M10 13c0-1.7.8-2.7 2-2.7s2 1 2 2.3" />
+            </svg>
+          </button>
           {/* File tree button hidden - feature unstable
           <button
             className={`text-sm leading-none transition-colors ${fileTreeVisible ? 'text-[var(--accent-blue)]' : 'text-[var(--text-subtle)] hover:text-[var(--accent-green)]'}`}
@@ -106,11 +144,17 @@ export default function Sidebar() {
         {pickerOpen && <PresetPicker onClose={closePicker} />}
       </div>
 
-      {/* Workspace list */}
-      {/* The list container absorbs dragover for sidebar-internal reorder
+      {/* Central content: company tree when in company mode, else the
+          workspace list. This is the consumer of `sidebarMode` that was
+          missing — CompanyPanel was orphaned (never rendered) so the
+          palette's company commands had no visible surface. */}
+      {sidebarMode === 'company' ? (
+        <CompanyPanel />
+      ) : (
+      /* The list container absorbs dragover for sidebar-internal reorder
           drags so the gaps between WorkspaceItem rows (and the empty area
           below the last row) don't paint a 🚫 cursor mid-drag. External
-          drags hover-through the container untouched. */}
+          drags hover-through the container untouched. */
       <div
         className="flex-1 overflow-y-auto py-2 space-y-0.5"
         onDragOver={(e) => {
@@ -136,6 +180,7 @@ export default function Sidebar() {
           />
         ))}
       </div>
+      )}
 
       {/* Plugin sidebar panels (B-1 ui.sidebar contribution point) */}
       <PluginPanels />

--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -10,7 +10,6 @@ import { collapseDirection } from './sidebarGlyphs';
 import { IconPlus, IconChevronDir } from '../icons';
 import { FOCUS_RING } from '../focusRing';
 import PluginPanels from '../../plugins/PluginPanels';
-import { ChannelsPanel } from '../Channels/ChannelsPanel';
 import CompanyPanel from './CompanyPanel';
 
 // Pane 트리에서 모든 leaf의 PTY를 dispose
@@ -185,10 +184,8 @@ export default function Sidebar() {
       {/* Plugin sidebar panels (B-1 ui.sidebar contribution point) */}
       <PluginPanels />
 
-      {/* A2A channels panel — always-on, company-bounded. Mounted
-          between the workspace list and the footer so it sits at the
-          bottom of the sidebar like a permanent dock (U7). */}
-      <ChannelsPanel />
+      {/* Channels moved to the right-side ChannelDock (Approach A) — the list
+          + conversation now live together opposite the workspace sidebar. */}
 
       {/* Footer — when docked right, mirror the row so the collapse arrow sits
           on the inner edge facing the content area (issue #151). */}

--- a/src/renderer/components/Sidebar/__tests__/Sidebar.companyMode.test.tsx
+++ b/src/renderer/components/Sidebar/__tests__/Sidebar.companyMode.test.tsx
@@ -1,0 +1,49 @@
+// ─── Regression guard: Sidebar must consume sidebarMode → render CompanyPanel ─
+//
+// Bug: the palette's "Company: …" commands set `sidebarMode = 'company'`, but
+// NOTHING in the renderer read `sidebarMode` to swap the sidebar content — the
+// `CompanyPanel` component was never rendered (orphaned). So company commands
+// mutated state with no visible effect ("보이는데 눌러도 무반응").
+//
+// The store-connected <Sidebar /> can't be behavior-tested in this repo's
+// node-env harness (renderToStaticMarkup doesn't run effects, and the store
+// can't be seeded reliably without a mount — the same reason AppLayout/Sidebar
+// have no render fixtures). So this is a SOURCE-SCAN lockstep guard (the same
+// pattern as firstParty.test.ts scanning src/mcp): it pins the wiring in source
+// so the consumer can't silently regress to orphaned again.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// vitest runs from the repo root — resolve sources from cwd (avoids
+// import.meta, which tsconfig's module target rejects).
+const SIDEBAR_DIR = resolve(process.cwd(), 'src/renderer/components/Sidebar');
+const sidebarSrc = readFileSync(resolve(SIDEBAR_DIR, 'Sidebar.tsx'), 'utf8');
+const companyPanelSrc = readFileSync(resolve(SIDEBAR_DIR, 'CompanyPanel.tsx'), 'utf8');
+
+describe('Sidebar — company mode wiring (regression guard)', () => {
+  it('imports CompanyPanel', () => {
+    expect(sidebarSrc).toMatch(/import\s+CompanyPanel\s+from\s+['"]\.\/CompanyPanel['"]/);
+  });
+
+  it('reads sidebarMode from the store', () => {
+    expect(sidebarSrc).toMatch(/useStore\(\(s\)\s*=>\s*s\.sidebarMode\)/);
+  });
+
+  it("renders <CompanyPanel /> gated on sidebarMode === 'company'", () => {
+    // The conditional must reference company mode AND mount CompanyPanel.
+    expect(sidebarSrc).toContain("sidebarMode === 'company'");
+    expect(sidebarSrc).toMatch(/<CompanyPanel\s*\/>/);
+  });
+
+  it('provides a UI affordance to toggle modes (entry + exit)', () => {
+    // Without a toggle the only entry was the palette and there was no exit.
+    expect(sidebarSrc).toContain('data-company-toggle');
+    expect(sidebarSrc).toMatch(/setSidebarMode\(\s*sidebarMode === 'company'\s*\?\s*'workspaces'\s*:\s*'company'\s*\)/);
+  });
+
+  it('CompanyPanel still exposes its no-company empty state (the surface that was invisible)', () => {
+    expect(companyPanelSrc).toContain('No company created yet');
+  });
+});

--- a/src/renderer/components/StatusBar/StatusBar.tsx
+++ b/src/renderer/components/StatusBar/StatusBar.tsx
@@ -5,6 +5,7 @@ import type { Notification, Workspace } from '../../../shared/types';
 import { UsageWidgetView } from './UsageWidget';
 import { tokenAttrs } from '../../themes';
 import PluginStatusBarWidgets from '../../plugins/PluginStatusBarWidgets';
+import { sumUnread } from '../Channels/ChannelsPanel';
 
 /**
  * Compute the unread notification count, excluding notifications whose
@@ -94,6 +95,14 @@ export default function StatusBar() {
   );
   const toggleNotificationPanel = useStore((s) => s.toggleNotificationPanel);
   const toggleSettingsPanel = useStore((s) => s.toggleSettingsPanel);
+
+  // Channel dock toggle + aggregate unread. The dock is the only home of the
+  // channel list now, so this StatusBar control is the reopen affordance when
+  // it's collapsed (and a quick toggle otherwise).
+  const channelUnread = useStore((s) => s.channelUnread);
+  const channelDockVisible = useStore((s) => s.channelDockVisible);
+  const toggleChannelDock = useStore((s) => s.toggleChannelDock);
+  const channelUnreadTotal = useMemo(() => sumUnread(channelUnread), [channelUnread]);
 
   // Prefix mode (tmux-style Ctrl+B)
   const prefixMode = useStore((s) => s.prefixMode);
@@ -194,6 +203,22 @@ export default function StatusBar() {
         />
         {/* Plugin status-bar widgets (B-1 ui.statusbar, right-aligned) */}
         <PluginStatusBarWidgets alignment="right" />
+        <button
+          type="button"
+          onClick={toggleChannelDock}
+          className={`flex items-center gap-1 transition-colors ${channelDockVisible ? 'text-[var(--accent-blue)]' : 'text-[var(--text-muted)] hover:text-[var(--text-main)]'}`}
+          title={t('statusBar.channelsTooltip') || 'Toggle channels'}
+          aria-label={t('statusBar.channelsTooltip') || 'Toggle channels'}
+          aria-pressed={channelDockVisible}
+          data-statusbar-channels
+        >
+          <span aria-hidden="true" className="font-mono">#</span>
+          {channelUnreadTotal > 0 && (
+            <span className="text-[var(--accent-blue)]" data-statusbar-channel-unread {...tokenAttrs('accent', 'text')}>
+              {channelUnreadTotal > 99 ? '99+' : channelUnreadTotal}
+            </span>
+          )}
+        </button>
         <NotificationBellBadgeView unreadCount={unreadCount} onActivate={toggleNotificationPanel} />
         {memUsage && <span>{memUsage}</span>}
         <span>{timeStr}</span>

--- a/src/renderer/hooks/__tests__/useChannelsHydration.test.ts
+++ b/src/renderer/hooks/__tests__/useChannelsHydration.test.ts
@@ -1,0 +1,183 @@
+// ─── Tests for hydrateChannelsCatalog (channel catalog hydration core) ───────
+//
+// The hook `useChannelsHydration` runs a React effect that can't be exercised
+// under the repo's node-env vitest (renderToStaticMarkup doesn't run effects),
+// so the list→getMembers→setChannels logic is extracted into the pure
+// `hydrateChannelsCatalog` (the same extract-for-test pattern as
+// `createLateReconcileOnConnect` / `resolvePtyIdsToClear`). These tests drive
+// it with a mock `rpc` bridge and a spy `setChannels`.
+
+import { describe, it, expect, vi } from 'vitest';
+import { hydrateChannelsCatalog } from '../useChannelsHydration';
+import type { Channel, ChannelMember } from '../../../shared/channels';
+
+function makeChannel(overrides: Partial<Channel> = {}): Channel {
+  return {
+    id: 'ch-1',
+    companyId: 'co-default',
+    name: 'general',
+    visibility: 'public',
+    status: 'active',
+    createdAt: 1,
+    createdBy: 'ws-1',
+    nextSeq: 1,
+    ...overrides,
+  };
+}
+
+function makeMember(overrides: Partial<ChannelMember> = {}): ChannelMember {
+  return { workspaceId: 'ws-1', memberId: 'm-1', joinedAt: 1, historyFromSeq: 0, ...overrides };
+}
+
+/** Build a mock `rpc` that routes by method, with per-method handlers.
+ *  The real renderer `rpc` bridge (electronAPI.rpc.invoke → pipe RpcRouter)
+ *  wraps the daemon reply in the transport envelope `{ id, ok, result }` —
+ *  confirmed via live CDP. The mock MUST reproduce that wrapping, otherwise the
+ *  test validates a shape that never occurs in production (the original bug:
+ *  hydration read `.channels` one level too shallow and always got nothing). */
+function wrap(daemonReply: unknown) {
+  return { id: 'test', ok: true, result: daemonReply };
+}
+function makeRpc(handlers: {
+  list?: (params: Record<string, unknown>) => unknown;
+  getMembers?: (params: Record<string, unknown>) => unknown;
+}) {
+  return vi.fn(async (method: string, params: Record<string, unknown>) => {
+    if (method === 'a2a.channel.list') {
+      return wrap(handlers.list ? handlers.list(params) : { ok: true, channels: [] });
+    }
+    if (method === 'a2a.channel.getMembers') {
+      return wrap(handlers.getMembers ? handlers.getMembers(params) : { ok: true, members: [] });
+    }
+    throw new Error(`unexpected method ${method}`);
+  });
+}
+
+describe('hydrateChannelsCatalog', () => {
+  it('lists channels, fetches members per channel, and dispatches setChannels', async () => {
+    const channels = [
+      makeChannel({ id: 'ch-1', name: 'general' }),
+      makeChannel({ id: 'ch-2', name: 'design' }),
+    ];
+    const rpc = makeRpc({
+      list: () => ({ ok: true, channels }),
+      getMembers: (p) => ({
+        ok: true,
+        members: [makeMember({ memberId: `m-${String(p.channelId)}` })],
+      }),
+    });
+    const setChannels = vi.fn();
+
+    const n = await hydrateChannelsCatalog({ rpc, workspaceId: 'ws-self', setChannels });
+
+    expect(n).toBe(2);
+    expect(setChannels).toHaveBeenCalledTimes(1);
+    const [dispatchedChannels, dispatchedMembers] = setChannels.mock.calls[0];
+    expect(dispatchedChannels).toEqual(channels);
+    expect(Object.keys(dispatchedMembers).sort()).toEqual(['ch-1', 'ch-2']);
+    expect(dispatchedMembers['ch-1'][0].memberId).toBe('m-ch-1');
+  });
+
+  it('also accepts an already-unwrapped daemon reply (defensive — no transport envelope)', async () => {
+    // If the bridge ever returns the daemon reply directly (no { id, ok, result }
+    // wrapper), unwrapRpc must fall back to the value itself.
+    const rpc = vi.fn(async (method: string) => {
+      if (method === 'a2a.channel.list') return { ok: true, channels: [makeChannel({ id: 'ch-1' })] };
+      return { ok: true, members: [makeMember()] };
+    });
+    const setChannels = vi.fn();
+    const n = await hydrateChannelsCatalog({ rpc, workspaceId: 'ws-self', setChannels });
+    expect(n).toBe(1);
+    expect(setChannels).toHaveBeenCalledTimes(1);
+    const [chs, mem] = setChannels.mock.calls[0];
+    expect(chs).toHaveLength(1);
+    expect(mem['ch-1']).toHaveLength(1);
+  });
+
+  it('passes the self workspace as BOTH workspaceId and verifiedWorkspaceId on every read', async () => {
+    const rpc = makeRpc({
+      list: () => ({ ok: true, channels: [makeChannel({ id: 'ch-1' })] }),
+      getMembers: () => ({ ok: true, members: [] }),
+    });
+    await hydrateChannelsCatalog({ rpc, workspaceId: 'ws-self', setChannels: vi.fn() });
+
+    expect(rpc).toHaveBeenCalledWith('a2a.channel.list', {
+      workspaceId: 'ws-self',
+      verifiedWorkspaceId: 'ws-self',
+    });
+    expect(rpc).toHaveBeenCalledWith('a2a.channel.getMembers', {
+      channelId: 'ch-1',
+      workspaceId: 'ws-self',
+      verifiedWorkspaceId: 'ws-self',
+    });
+  });
+
+  it('no-ops (no rpc, no dispatch) when workspaceId is empty', async () => {
+    const rpc = makeRpc({});
+    const setChannels = vi.fn();
+    const n = await hydrateChannelsCatalog({ rpc, workspaceId: '', setChannels });
+    expect(n).toBe(0);
+    expect(rpc).not.toHaveBeenCalled();
+    expect(setChannels).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch when the list RPC returns ok:false', async () => {
+    const rpc = makeRpc({ list: () => ({ ok: false, error: { code: 'NOT_AUTHORIZED', message: 'x' } }) });
+    const setChannels = vi.fn();
+    const n = await hydrateChannelsCatalog({ rpc, workspaceId: 'ws-self', setChannels });
+    expect(n).toBe(0);
+    expect(setChannels).not.toHaveBeenCalled();
+    // getMembers must not be probed once the list failed.
+    expect(rpc).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not dispatch when the list RPC throws', async () => {
+    const rpc = vi.fn(async (method: string) => {
+      if (method === 'a2a.channel.list') throw new Error('DaemonClient not connected');
+      return { ok: true, members: [] };
+    });
+    const setChannels = vi.fn();
+    const n = await hydrateChannelsCatalog({ rpc, workspaceId: 'ws-self', setChannels });
+    expect(n).toBe(0);
+    expect(setChannels).not.toHaveBeenCalled();
+  });
+
+  it('treats a malformed list payload (channels not an array) as empty and does not dispatch', async () => {
+    const rpc = makeRpc({ list: () => ({ ok: true, channels: 'nope' }) });
+    const setChannels = vi.fn();
+    const n = await hydrateChannelsCatalog({ rpc, workspaceId: 'ws-self', setChannels });
+    expect(n).toBe(0);
+    expect(setChannels).not.toHaveBeenCalled();
+  });
+
+  it('still dispatches when one channel getMembers fails — that channel hydrates with no member entry', async () => {
+    const channels = [makeChannel({ id: 'ch-ok' }), makeChannel({ id: 'ch-bad' })];
+    const rpc = makeRpc({
+      list: () => ({ ok: true, channels }),
+      getMembers: (p) => {
+        if (p.channelId === 'ch-bad') throw new Error('boom');
+        return { ok: true, members: [makeMember()] };
+      },
+    });
+    const setChannels = vi.fn();
+    const n = await hydrateChannelsCatalog({ rpc, workspaceId: 'ws-self', setChannels });
+    expect(n).toBe(2);
+    expect(setChannels).toHaveBeenCalledTimes(1);
+    const [, dispatchedMembers] = setChannels.mock.calls[0];
+    expect(dispatchedMembers['ch-ok']).toHaveLength(1);
+    expect(dispatchedMembers['ch-bad']).toBeUndefined();
+  });
+
+  it('skips dispatch when the liveness guard reports disposed after the list resolves', async () => {
+    const rpc = makeRpc({ list: () => ({ ok: true, channels: [makeChannel()] }) });
+    const setChannels = vi.fn();
+    const n = await hydrateChannelsCatalog({
+      rpc,
+      workspaceId: 'ws-self',
+      setChannels,
+      isCurrent: () => false,
+    });
+    expect(n).toBe(0);
+    expect(setChannels).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/hooks/useChannelsEventSubscription.ts
+++ b/src/renderer/hooks/useChannelsEventSubscription.ts
@@ -71,13 +71,26 @@ interface EventsPollBridge {
     types: ['channel.message'];
     max?: number;
     workspaceId: string;
-  }): Promise<EventsPollResponse | null>;
+  }): Promise<EventsPollEnvelope | null>;
 }
 
 interface EventsPollResponse {
   events: WmuxEvent[];
   nextCursor: number;
   resync?: boolean;
+}
+
+/**
+ * The renderer rpc bridge (electronAPI.rpc.invoke → pipe RpcRouter) wraps the
+ * daemon reply in the RPC protocol envelope `{ id, ok, result }`, where
+ * `result` is the events.poll payload. Reading `result.events` directly (one
+ * level too shallow) silently dispatched NOTHING — the cursor stayed 0 and the
+ * `for…of` ran over `undefined`, swallowed by the catch. PluginFrame's
+ * forwardEvents loop reads `resp.result.events` correctly; we mirror it.
+ */
+interface EventsPollEnvelope {
+  ok?: boolean;
+  result?: EventsPollResponse;
 }
 
 interface BridgeWindow {
@@ -117,21 +130,20 @@ export function useChannelsEventSubscription(): void {
 
     // Per-recipient scoping (plan U3, R3): the daemon's per-workspace
     // filter at `events.rpc.ts:115-124` requires the caller to identify
-    // its own workspace or it silently drops every event. The
-    // renderer-side identity source is `company.ceoWorkspaceId` (the
-    // company workspace that owns the renderer instance — see
-    // `ChannelsPanel.tsx`). On a non-company render the field is
-    // undefined: send a literal `'unknown-workspace'` is NOT an option
-    // because the strict filter would silently drop every event and the
-    // UI would look identical to a healthy empty stream, so we skip the
-    // tick and warn once. Multi-workspace renderers (FIX-MULTI-WS
-    // follow-up) will iterate `company.departments[].members[].ptyId`
-    // here; for v1 the company CEO workspace is the only one we poll.
-    const company = useStore.getState().company;
-    const workspaceId = company?.ceoWorkspaceId;
+    // its own workspace or it silently drops every event. Channels are
+    // decoupled from in-app Company mode, so the identity source is the
+    // company CEO workspace when Company mode is active, else the active
+    // workspace (mirrors useChannelsHydration / ChannelsPanel). Sending a
+    // literal `'unknown-workspace'` is NOT an option — the strict filter
+    // would silently drop every event and the UI would look identical to a
+    // healthy empty stream — so we skip + warn only when there is no
+    // workspace at all. Multi-workspace renderers (FIX-MULTI-WS follow-up)
+    // will iterate every member workspace here; for v1 we poll one.
+    const state = useStore.getState();
+    const workspaceId = state.company?.ceoWorkspaceId ?? state.activeWorkspaceId;
     if (!workspaceId) {
       console.warn(
-        '[useChannelsEventSubscription] no company.ceoWorkspaceId — channel events will not auto-update (FIX-MULTI-WS follow-up)',
+        '[useChannelsEventSubscription] no resolvable workspace (no company + no active workspace) — channel events will not auto-update',
       );
       return;
     }
@@ -144,8 +156,13 @@ export function useChannelsEventSubscription(): void {
       if (disposed || inFlight) return;
       inFlight = true;
       bridge({ cursor, types: ['channel.message'], max: EVENT_POLL_MAX, workspaceId })
-        .then((result) => {
-          if (disposed || !result) return;
+        .then((raw) => {
+          if (disposed || !raw) return;
+          // Peel the RPC transport envelope { id, ok, result }. The daemon's
+          // events.poll payload lives at `.result` — reading the top level
+          // gave undefined and dispatched nothing.
+          if (raw.ok !== true || !raw.result) return;
+          const result = raw.result;
           cursor = result.nextCursor;
           if (result.resync) {
             // Drift past the ring window — drop the local message

--- a/src/renderer/hooks/useChannelsHydration.ts
+++ b/src/renderer/hooks/useChannelsHydration.ts
@@ -1,0 +1,194 @@
+// ─── Renderer-side channel catalog hydration ─────────────────────────────
+//
+// The renderer's channel mirror (`channelsSlice.channels` / `channelMembers`)
+// was previously populated ONLY by local optimistic creates and message
+// events — there was no path that read the daemon's authoritative catalog.
+// That left the sidebar empty on a fresh launch even when the daemon had
+// persisted channels on disk, and made channels created by OTHER clients
+// (MCP agents via `channel_create`) invisible to the human in the UI. This
+// hook closes that gap: it calls `a2a.channel.list` + `a2a.channel.getMembers`
+// and dispatches the result into `setChannels`.
+//
+// Identity: channels are decoupled from in-app Company mode. The "self"
+// workspace is the Company CEO workspace when Company mode is active, else
+// the active workspace — so channels hydrate (and stay visible) without a
+// company. Reads ride the `rpc` bridge (the pipe RpcRouter); the main-side
+// `a2a.channel.*` read handler accepts a caller-supplied workspace for a
+// no-senderPtyId renderer caller (process-boundary trust — see the header of
+// `src/main/pipe/handlers/a2a.channel.rpc.ts`). Only the unforgeable D5 pin
+// (senderPtyId resolution on the pipe/MCP path) gates writes, and this hook
+// performs no writes.
+//
+// Triggers (all best-effort, idempotent — `setChannels` replaces the catalog
+// wholesale while preserving per-channel message caches):
+//   1. mount — covers the reload case where the daemon was already connected.
+//   2. `daemon.whenReady()` — covers the cold-boot case where the daemon
+//      finishes connecting shortly after the renderer mounts.
+//   3. `daemon.onConnected` — covers respawn/reconnect after the first
+//      hydration already ran.
+//
+// Scope note (FIX-MULTI-WS): the daemon's `list(verifiedWorkspaceId)` returns
+// every PUBLIC channel plus PRIVATE channels the passed workspace is a member
+// of. With a single self-workspace, private channels owned by a different
+// workspace stay hidden until the multi-workspace identity follow-up lands.
+// Public channels (the create modal's default) always hydrate.
+//
+// The core list→getMembers→setChannels logic is extracted into the pure
+// `hydrateChannelsCatalog` (mirroring the `createLateReconcileOnConnect` /
+// `reconcileWithReQuery` extract-for-test pattern) so it can be unit-tested
+// with a mock bridge without rendering a React tree.
+
+import { useEffect } from 'react';
+import { useStore } from '../stores';
+import type { Channel, ChannelMember } from '../../shared/channels';
+
+/** Dependencies for the pure hydration routine. */
+export interface ChannelHydrationDeps {
+  /** Read RPC bridge (`__wmuxChannelsRpc.rpc`). Returns the daemon's raw
+   *  `{ ok, ... }` envelope (see preload `rpc.invoke`). */
+  rpc: (method: string, params: Record<string, unknown>) => Promise<unknown>;
+  /** The renderer's resolved "self" workspace. Empty string ⇒ no identity. */
+  workspaceId: string;
+  /** Catalog setter (`channelsSlice.setChannels`). */
+  setChannels: (channels: Channel[], members: Record<string, ChannelMember[]>) => void;
+  /** Liveness guard. When it returns false the routine bails before
+   *  dispatching (the hook passes `() => !disposed`). Defaults to always-live
+   *  for tests. */
+  isCurrent?: () => boolean;
+}
+
+function isOkObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && (v as { ok?: unknown }).ok === true;
+}
+
+/**
+ * The renderer `rpc` bridge (electronAPI.rpc.invoke → pipe RpcRouter) wraps
+ * the daemon reply in the RPC protocol envelope `{ id, ok, result }`, where
+ * `result` is the daemon's own `{ ok, channels }` / `{ ok, members }` reply.
+ * (Confirmed via live CDP; PluginFrame's events.poll loop reads `resp.result`
+ * the same way.) Peel the transport envelope so callers see the daemon reply.
+ * Falls back to the value itself if it's already unwrapped (defensive).
+ */
+function unwrapRpc(res: unknown): unknown {
+  if (
+    res !== null &&
+    typeof res === 'object' &&
+    'result' in res &&
+    (res as { result?: unknown }).result !== null &&
+    typeof (res as { result?: unknown }).result === 'object'
+  ) {
+    return (res as { result: unknown }).result;
+  }
+  return res;
+}
+
+/**
+ * Pure hydration: `a2a.channel.list` → per-channel `a2a.channel.getMembers`
+ * → `setChannels`. Best-effort throughout — any RPC error, non-ok envelope,
+ * malformed shape, missing identity, or a disposed guard short-circuits to a
+ * no-op (no partial dispatch). Returns the number of channels hydrated (0 on
+ * any early bail) so callers/tests can assert progress.
+ */
+export async function hydrateChannelsCatalog(deps: ChannelHydrationDeps): Promise<number> {
+  const { rpc, workspaceId, setChannels } = deps;
+  const isCurrent = deps.isCurrent ?? (() => true);
+  if (!workspaceId) return 0;
+
+  let listRes: unknown;
+  try {
+    listRes = await rpc('a2a.channel.list', { workspaceId, verifiedWorkspaceId: workspaceId });
+  } catch {
+    // Daemon not connected yet / transient pipe failure — a later trigger retries.
+    return 0;
+  }
+  if (!isCurrent()) return 0;
+  const listEnv = unwrapRpc(listRes);
+  if (!isOkObject(listEnv)) return 0;
+  const rawChannels = (listEnv as { channels?: unknown }).channels;
+  if (!Array.isArray(rawChannels)) return 0;
+  const channels = rawChannels as Channel[];
+
+  // Fetch members per channel in parallel (best-effort — a channel whose
+  // getMembers fails hydrates with no member entry and is reconciled on the
+  // next trigger).
+  const members: Record<string, ChannelMember[]> = {};
+  await Promise.all(
+    channels.map(async (ch) => {
+      try {
+        const mRes = await rpc('a2a.channel.getMembers', {
+          channelId: ch.id,
+          workspaceId,
+          verifiedWorkspaceId: workspaceId,
+        });
+        const mEnv = unwrapRpc(mRes);
+        if (isOkObject(mEnv)) {
+          const raw = (mEnv as { members?: unknown }).members;
+          if (Array.isArray(raw)) members[ch.id] = raw as ChannelMember[];
+        }
+      } catch {
+        /* best-effort per channel */
+      }
+    }),
+  );
+  if (!isCurrent()) return 0;
+  setChannels(channels, members);
+  return channels.length;
+}
+
+/** Single-method facade over the channels bridge `useRpcBridge` installs.
+ *  Only the read `rpc` method is needed here. */
+interface ChannelsRpcBridge {
+  rpc: (method: string, params: Record<string, unknown>) => Promise<unknown>;
+}
+
+interface ChannelsBridgeWindow {
+  __wmuxChannelsRpc?: ChannelsRpcBridge;
+}
+
+function readChannelsRpc(): ChannelsRpcBridge | undefined {
+  return (window as unknown as ChannelsBridgeWindow).__wmuxChannelsRpc;
+}
+
+/** Resolve the renderer's "self" workspace for channel reads. Prefer the
+ *  in-app Company CEO workspace when Company mode is active; otherwise fall
+ *  back to the active workspace so channels work without a company. Empty
+ *  string means "no resolvable identity yet" — the caller skips the cycle. */
+function resolveSelfWorkspaceId(): string {
+  const s = useStore.getState();
+  return s.company?.ceoWorkspaceId ?? s.activeWorkspaceId ?? '';
+}
+
+/**
+ * Mount once in AppLayout (parallel to `useChannelsEventSubscription`).
+ * Owns nothing in React state — it dispatches into the store and tears down
+ * its daemon listener on unmount.
+ */
+export function useChannelsHydration(): void {
+  useEffect(() => {
+    let disposed = false;
+
+    const hydrate = (): void => {
+      const bridge = readChannelsRpc();
+      if (!bridge) return; // useRpcBridge installs this first (hook order); a miss self-heals on the next trigger.
+      void hydrateChannelsCatalog({
+        rpc: bridge.rpc,
+        workspaceId: resolveSelfWorkspaceId(),
+        setChannels: useStore.getState().setChannels,
+        isCurrent: () => !disposed,
+      });
+    };
+
+    hydrate();
+    void window.electronAPI.daemon.whenReady().then(() => {
+      if (!disposed) hydrate();
+    });
+    const offConnected = window.electronAPI.daemon.onConnected(() => {
+      if (!disposed) hydrate();
+    });
+
+    return () => {
+      disposed = true;
+      offConnected();
+    };
+  }, []);
+}

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -243,6 +243,7 @@ export const en = {
   'statusBar.company': 'COMPANY',
   'statusBar.session': 'Session: {min}m',
   'statusBar.settingsTooltip': 'Settings (Ctrl+,)',
+  'statusBar.channelsTooltip': 'Toggle channels',
 
   // Settings
   'settings.title': 'Settings',
@@ -638,6 +639,8 @@ export const en = {
 
   // Channels (a2a.channel.* RPC UI surface)
   'channels.title': 'Channels',
+  'channels.dockTitle': 'Channels',
+  'channels.dockCollapse': 'Collapse channels',
   'channels.archived': 'archived',
   'channels.empty': 'No channels yet — click + to create one.',
   'channels.emptyCompany': 'Channels are company-scoped — start a company to use them.',

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -7,6 +7,8 @@ export const en = {
   'sidebar.newWorkspace': 'New workspace',
   'sidebar.newWorkspaceTooltip': 'New workspace (Ctrl+N)',
   'sidebar.hideTooltip': 'Hide sidebar (Ctrl+B)',
+  'sidebar.showCompany': 'Show company',
+  'sidebar.showWorkspaces': 'Show workspaces',
   'sidebar.expandTooltip': 'Expand sidebar (Ctrl+B)',
   'sidebar.unreadCount': '{count} unread',
 

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -7,6 +7,8 @@ export const ko = {
   'sidebar.newWorkspace': '새 워크스페이스',
   'sidebar.newWorkspaceTooltip': '새 워크스페이스 (Ctrl+N)',
   'sidebar.hideTooltip': '사이드바 숨기기 (Ctrl+B)',
+  'sidebar.showCompany': '회사 보기',
+  'sidebar.showWorkspaces': '워크스페이스 보기',
   'sidebar.expandTooltip': '사이드바 펼치기 (Ctrl+B)',
   'sidebar.unreadCount': '읽지 않음 {count}개',
 

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -190,6 +190,7 @@ export const ko = {
   'statusBar.company': '회사',
   'statusBar.session': '세션: {min}분',
   'statusBar.settingsTooltip': '설정 (Ctrl+,)',
+  'statusBar.channelsTooltip': '채널 토글',
 
   // Settings
   'settings.title': '설정',
@@ -566,6 +567,8 @@ export const ko = {
 
   // Channels (a2a.channel.* RPC UI surface)
   'channels.title': '채널',
+  'channels.dockTitle': '채널',
+  'channels.dockCollapse': '채널 접기',
   'channels.archived': '보관됨',
   'channels.empty': '아직 채널이 없습니다 — + 버튼으로 새로 만드세요.',
   'channels.emptyCompany': '채널은 회사 범위입니다 — 회사를 시작해 사용하세요.',

--- a/src/renderer/stores/slices/channelsSlice.ts
+++ b/src/renderer/stores/slices/channelsSlice.ts
@@ -229,6 +229,9 @@ export const createChannelsSlice: StateCreator<
       // here means a single source of truth (no double-bookkeeping).
       if (channelId !== null) {
         state.channelUnread[channelId] = 0;
+        // Auto-open the right channel dock so clicking a channel reveals the
+        // conversation (the dock is collapsed by default — uiSlice).
+        state.channelDockVisible = true;
       }
     }),
 

--- a/src/renderer/stores/slices/uiSlice.ts
+++ b/src/renderer/stores/slices/uiSlice.ts
@@ -55,6 +55,13 @@ export interface UISlice {
   toggleSidebar: () => void;
   setSidebarVisible: (visible: boolean) => void;
 
+  // Right-side channel dock (opposite the workspace sidebar). Default off so
+  // users without channels pay no screen width; auto-opens on first channel
+  // select/create (setActiveChannel) and is collapsible. Persisted.
+  channelDockVisible: boolean;
+  toggleChannelDock: () => void;
+  setChannelDockVisible: (visible: boolean) => void;
+
   notificationPanelVisible: boolean;
   toggleNotificationPanel: () => void;
   setNotificationPanelVisible: (visible: boolean) => void;
@@ -534,6 +541,16 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
 
   setSidebarVisible: (visible) => set((state) => {
     state.sidebarVisible = visible;
+  }),
+
+  channelDockVisible: false,
+
+  toggleChannelDock: () => set((state) => {
+    state.channelDockVisible = !state.channelDockVisible;
+  }),
+
+  setChannelDockVisible: (visible) => set((state) => {
+    state.channelDockVisible = visible;
   }),
 
   // ─── Notification panel ──────────────────────────────────────────────────

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -447,6 +447,7 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
         window.electronAPI.settings.setAutoUpdateEnabled(data.autoUpdateEnabled);
       }
       if (data.sidebarMode) state.sidebarMode = data.sidebarMode;
+      if (data.channelDockVisible != null) state.channelDockVisible = data.channelDockVisible;
       if (data.company !== undefined) state.company = data.company ?? null;
       if (data.memberCosts) state.memberCosts = data.memberCosts;
       if (data.sessionStartTime != null) state.sessionStartTime = data.sessionStartTime;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -170,6 +170,20 @@ export const EMPTY_CHANNEL_STATE: ChannelState = {
   idempotency: {},
 };
 
+/**
+ * The single company every channel belongs to until in-app Company mode
+ * provides a real company id. The daemon's ChannelService is constructed
+ * with this id (it stamps every channel's `companyId`), so the renderer
+ * MUST use the same value when it synthesizes an optimistic row or resolves
+ * a "self" company context without an in-app Company — otherwise the
+ * optimistic row's companyId would disagree with the daemon's authoritative
+ * row. Channels are intentionally decoupled from in-app Company mode: they
+ * are always available, scoped to this default company, and the daemon is
+ * the authoritative catalog. When multi-company lands, this becomes a
+ * fallback rather than the only value.
+ */
+export const DEFAULT_COMPANY_ID = 'co-default';
+
 /** Channel name length bounds. `CHANNEL_NAME_MIN` is the empty-length
  *  floor; the regex below requires at least 1 character. */
 export const CHANNEL_NAME_MIN = 1;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -385,6 +385,9 @@ export interface SessionData {
   workspaces: Workspace[];
   activeWorkspaceId: string;
   sidebarVisible: boolean;
+  /** Right-side channel dock visibility. Optional for backward-compat with
+   *  pre-dock sessions (defaults to false on load). */
+  channelDockVisible?: boolean;
   // User preferences (persisted across restarts)
   theme?: string;
   locale?: string;


### PR DESCRIPTION
## Summary

Channels felt unstable and Company mode's Ctrl+K commands appeared dead. Root-caused both and reworked the channel UI into a right-side dock. Three commits:

**`fix(channels)` — work without Company mode + hydrate from the daemon**
- Channels were gated on in-app Company mode while the daemon always scopes them to a single default company, and the renderer never read the daemon's channel catalog. So the sidebar only showed channels created in the current session; MCP-created and persisted channels were invisible.
- New `DEFAULT_COMPANY_ID` shared const. New `useChannelsHydration` hook (list + getMembers → `setChannels` on mount, daemon ready, reconnect). Identity falls back to the active workspace when no company exists. Peeled the `{id,ok,result}` rpc transport envelope in hydration + the events.poll subscription (both read one level too shallow).

**`fix(company)` — render the orphaned CompanyPanel via sidebarMode**
- The palette's "Company:" commands set `sidebarMode='company'` but nothing consumed it — `CompanyPanel` was never mounted. Sidebar now renders it on `sidebarMode==='company'` with a header toggle.

**`feat(channels)` — right-side channel dock**
- The conversation was a `position:fixed` overlay that covered the terminals; the list was cramped bottom-left. Both now live in one collapsible dock on the opposite edge from the workspace sidebar (workspaces left, channels right), reflowing the panes. `channelDockVisible` (persisted, auto-opens on select), StatusBar `#` toggle with unread badge, collapse button.

## Verification
- tsc clean (renderer + daemon). Full suite **4128 passed** / 7 skipped.
- Tests: `useChannelsHydration` unit (rpc-envelope unwrap), source-scan guards for the company-mode + dock wiring.
- Live CDP dogfood: channels **9/9 hard** (`channels-company-dogfood.mjs`), dock **6/6** (`channel-dock-dogfood.mjs` — reflow not cover, opposite edge, collapse, click→conversation).

## UX review → drag-to-join pulled (deferred, done right next)
A drag-workspace-onto-channel "join" gesture was prototyped on this branch, then **removed** after a 3-expert UX panel (accessibility / usability / interaction architecture) unanimously flagged it as not-ready:
- **Accessibility:** mouse-only, no keyboard/SR path → WCAG 2.1.1 (Level A) failure.
- **Reversibility:** add-only, no remove UI and no member roster → a one-way trap.
- **Discoverability ~0** + gesture overload (the same workspace drag also reorders the sidebar AND pastes into a terminal).
- **Conceptual:** membership keys on `(workspaceId, memberId)` for per-agent addressing, but the renderer collapses identity to `memberId:'local-ui'` — joining a workspace ≠ joining an agent.

The right sequence (follow-up PR): build a **channel members roster** in the ChannelView header (gives `leave` a home + makes membership legible), settle the member-identity model, ship a conventional "+ member" affordance + keyboard path, then layer drag back as an accelerator.

## Follow-ups
- Channel members roster + leave + "+ member" + keyboard/a11y path, then drag-to-join (above).
- **Channel live-message delivery (pre-existing):** a posted `channel.message` doesn't reach the `events.poll` ring scoped to the caller, so real-time updates don't arrive (messages appear on next hydration). The renderer-side unwrap fix here is necessary but not sufficient — the daemon→events-ring path needs a separate fix.
- Dock polish: resizable width, a collapsed mini-rail for unread, focus management on open/collapse (UX panel P2s).

## Notes
- No VERSION/CHANGELOG bump — release PR does that, per repo convention. [Unreleased].

## Test plan
- [x] tsc renderer + daemon: 0 errors
- [x] Full vitest suite: 4128 passed
- [x] Live CDP dogfood: channels 9/9, dock 6/6
- [ ] Maintainer visual spot-check of the dock on a real window size