### PR TITLE
fix(daemon): re-wire DaemonNotificationRouter after reconnect (rpc:invoke handler leak)

### DIFF
--- a/scripts/ch-2party-delivery.mjs
+++ b/scripts/ch-2party-delivery.mjs
@@ -1,0 +1,82 @@
+// 2-party live delivery test. A creates a PUBLIC channel; B joins; A posts;
+// we poll events.poll SCOPED TO B (a member that is NOT the sender). If A's
+// message reaches B's scoped poll, live delivery to a non-sender member works
+// (the actual "human receives an agent's channel message" path). Uses the
+// renderer mutateLocal bridge (stamps supplied verifiedWorkspaceId = models two
+// same-machine callers) + events.poll via rpc.invoke (reads the main eventBus).
+import { chromium } from 'playwright-core';
+import http from 'node:http';
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+function httpGet(url){return new Promise((res)=>{const q=http.get(url,(r)=>{let b='';r.on('data',c=>b+=c);r.on('end',()=>res(b));});q.on('error',()=>res(null));q.setTimeout(800,()=>{q.destroy();res(null);});});}
+async function findPort(){for(let p=18800;p<18900;p++){const b=await httpGet(`http://127.0.0.1:${p}/json/version`);if(b&&b.includes('webSocketDebuggerUrl'))return p;}return null;}
+const port = process.env.CDP_PORT ? Number(process.env.CDP_PORT) : await findPort();
+if (!port) { console.log('NO CDP'); process.exit(2); }
+console.log('CDP port:', port);
+const browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`);
+const ctx = browser.contexts()[0];
+let page = null;
+for (const p of ctx.pages()) { try { if (await p.evaluate(() => !!document.querySelector('.xterm'))) { page = p; break; } } catch {} }
+if (!page) { console.log('NO RENDERER'); await browser.close(); process.exit(2); }
+
+const result = await page.evaluate(async () => {
+  const m = window.__wmuxChannelsRpc?.mutateLocal;
+  const inv = (method, params) => window.electronAPI.rpc.invoke(method, params);
+  if (!m) return { err: 'no mutateLocal' };
+  const A = 'live-A', B = 'live-B';
+  const name = 'live2p-' + Math.floor(performance.now());
+  const marker = 'msg-' + Math.floor(performance.now());
+
+  // A creates a PUBLIC channel.
+  const create = await m('a2a.channel.create', {
+    name, visibility: 'public',
+    createdBy: { workspaceId: A, memberId: 'a', memberName: 'A' },
+    verifiedWorkspaceId: A,
+  });
+  const channelId = create?.channel?.id;
+  if (!channelId) return { step: 'create', create };
+
+  // B joins (now a member → in recipientWorkspaceIds for future posts).
+  const join = await m('a2a.channel.join', {
+    channelId, member: { workspaceId: B, memberId: 'b', memberName: 'B' }, verifiedWorkspaceId: B,
+  });
+
+  // Baseline head BEFORE A posts.
+  const head0 = (await inv('events.poll', { cursor: 0, max: 1024 }))?.result?.nextCursor ?? 0;
+
+  // A posts.
+  const post = await m('a2a.channel.post', {
+    channelId, text: marker,
+    sender: { workspaceId: A, memberId: 'a', memberName: 'A' },
+    verifiedWorkspaceId: A,
+  });
+
+  // Poll SCOPED TO B (non-sender member) for the marker, with retries.
+  let bScoped = null, unscoped = null;
+  for (let i = 0; i < 10; i++) {
+    await new Promise((r) => setTimeout(r, 500));
+    const rb = await inv('events.poll', { cursor: head0, types: ['channel.message'], workspaceId: B });
+    const evb = rb?.result?.events ?? [];
+    bScoped = evb.find((e) => e.message?.text === marker) ? 'FOUND' : (evb.length ? `other(${evb.length})` : 'empty');
+    const ru = await inv('events.poll', { cursor: head0, max: 1024 });
+    const evu = (ru?.result?.events ?? []).filter((e) => e.type === 'channel.message');
+    unscoped = evu.find((e) => e.message?.text === marker) ? 'FOUND' : (evu.length ? `other(${evu.length})` : 'empty');
+    if (bScoped === 'FOUND') break;
+  }
+
+  // Cleanup.
+  await m('a2a.channel.archive', { channelId, verifiedWorkspaceId: A }).catch(() => {});
+
+  return {
+    channelId, join: join?.ok, post: post?.ok,
+    bScopedDelivery: bScoped,      // FOUND = live delivery to non-sender member B
+    unscopedRing: unscoped,        // FOUND = channel.message reached the main eventBus at all
+  };
+});
+
+console.log(JSON.stringify(result, null, 2));
+const ok = result.bScopedDelivery === 'FOUND';
+console.log(ok
+  ? '\n>>> LIVE DELIVERY CONFIRMED: A’s post reached non-sender member B’s scoped events.poll.'
+  : `\n>>> NOT delivered to B (bScoped=${result.bScopedDelivery}, unscopedRing=${result.unscopedRing}). ${result.unscopedRing === 'empty' ? 'channel.message never reached the main eventBus (tee gap or instance tangle).' : 'reached ring but not B’s scope (scope bug).'}`);
+await browser.close();
+process.exit(ok ? 0 : 1);

--- a/src/main/ipc/__tests__/registerHandlers.rpcInvoke.test.ts
+++ b/src/main/ipc/__tests__/registerHandlers.rpcInvoke.test.ts
@@ -1,0 +1,40 @@
+// Regression guard: the RPC_INVOKE ipcMain handler must be cleared with
+// removeHandler(), NOT removeAllListeners().
+//
+// Why this matters (the bug this guards against):
+//   `ipcMain.handle(channel, fn)` registers a HANDLE handler, which is removed
+//   only by `ipcMain.removeHandler(channel)`. `ipcMain.removeAllListeners(channel)`
+//   removes `.on()` listeners and is a NO-OP for a handle handler. The original
+//   code pre-cleared RPC_INVOKE with removeAllListeners, so the SECOND
+//   registerAllHandlers() (fired on every daemon reconnect/respawn) threw
+//   "Attempted to register a second handler for 'rpc:invoke'". That throw
+//   aborted the connect bootstrap BEFORE it re-wired DaemonNotificationRouter
+//   onto the new DaemonClient — silently killing every daemon→main EventBus tee
+//   (channel.message live delivery, agent.lifecycle, …) until an app restart.
+//
+// Source-scan (the file pulls in the full Electron main graph, which the
+// node-env vitest can't import), mirroring wrapHandler.rollout.test.ts.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = readFileSync(resolve(process.cwd(), 'src/main/ipc/registerHandlers.ts'), 'utf8');
+
+describe('registerHandlers — RPC_INVOKE handler is reconnect-safe', () => {
+  it('clears RPC_INVOKE with removeHandler before (re)registering the handle', () => {
+    // The register site must removeHandler first so a second registerAllHandlers
+    // (daemon reconnect) does not throw "second handler".
+    expect(SRC).toMatch(/removeHandler\(IPC\.RPC_INVOKE\)[\s\S]{0,120}handle\(IPC\.RPC_INVOKE/);
+  });
+
+  it('never uses removeAllListeners on RPC_INVOKE (no-op for a handle handler)', () => {
+    expect(SRC).not.toMatch(/removeAllListeners\(IPC\.RPC_INVOKE\)/);
+  });
+
+  it('the cleanup teardown also removes the RPC_INVOKE handle', () => {
+    // Two occurrences: the register-site pre-clear + the cleanup teardown.
+    const count = (SRC.match(/removeHandler\(IPC\.RPC_INVOKE\)/g) ?? []).length;
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/main/ipc/registerHandlers.ts
+++ b/src/main/ipc/registerHandlers.ts
@@ -242,7 +242,15 @@ export function registerAllHandlers(
     }
     return options.invokeRendererRpc(method, safeParams);
   };
-  ipcMain.removeAllListeners(IPC.RPC_INVOKE);
+  // RPC_INVOKE is an ipcMain.handle() handler, NOT an .on() listener — it must
+  // be cleared with removeHandler(), not removeAllListeners() (which is a no-op
+  // for handle handlers). Without this, the SECOND registerAllHandlers() (on a
+  // daemon reconnect/respawn) threw "Attempted to register a second handler for
+  // 'rpc:invoke'", which aborted the connect bootstrap BEFORE it re-wired the
+  // DaemonNotificationRouter onto the new DaemonClient — silently killing every
+  // daemon→main EventBus tee (channel.message live delivery, agent.lifecycle, …)
+  // until an app restart.
+  ipcMain.removeHandler(IPC.RPC_INVOKE);
   ipcMain.handle(IPC.RPC_INVOKE, onRpcInvoke);
 
   return () => {
@@ -257,6 +265,9 @@ export function registerAllHandlers(
     cleanupToolbar();
     if (cleanupMcp) cleanupMcp();
     if (cleanupLanLink) cleanupLanLink();
+    // Mirror the register-side removeHandler so a teardown leaves no stale
+    // handle behind (handle handlers are not .on listeners — see above).
+    ipcMain.removeHandler(IPC.RPC_INVOKE);
     ipcMain.removeAllListeners(IPC.TOAST_ENABLED);
     ipcMain.removeAllListeners(IPC.WINDOW_HIDE);
     ipcMain.removeAllListeners(IPC.WINDOW_FLASH_FRAME);


### PR DESCRIPTION
## The bug
On a daemon reconnect/respawn, the connect bootstrap re-runs `registerAllHandlers`, which pre-cleared the `RPC_INVOKE` ipcMain handler with **`removeAllListeners()`** — a no-op for a `handle()` handler (those are removed only by `removeHandler()`). So the second `ipcMain.handle(RPC_INVOKE)` threw:

```
Attempted to register a second handler for 'rpc:invoke'
```

That throw aborted the connect handler **before** it re-created and started the `DaemonNotificationRouter` on the new `DaemonClient` (the router (re)wire is later in the same connect block).

## The effect (why channels never updated live)
After any daemon reconnect, the new `DaemonClient` had **zero** listeners on `'channel:message'` (and the other daemon→main tees). Every daemon-broadcast EventBus tee silently stopped:
- `channel.message` live delivery (channels only updated on the next hydration/refresh, never live)
- `agent.lifecycle`, and the other `DaemonNotificationRouter` projections

…until an app restart. This is the root cause of "channel messages don't arrive live."

## The fix
Clear `RPC_INVOKE` with `removeHandler()` at the register site (so re-registration is idempotent) and in the cleanup teardown. Reconnect now completes the bootstrap and re-wires the router. (The neighboring `removeAllListeners` calls are correct — those channels are `.on()` listeners, not `.handle()` handlers.)

## Verification (live)
Reproduced + fixed on a clean isolated instance via CDP, with a temporary `[CHDBG]` trace:
- **Before:** `main rx channel.message broadcast … listeners= 0` → router never ran → a non-sender member's scoped `events.poll` was empty.
- **After:** `listeners= 1` → `router teed channel.message to eventBus` → the member's scoped `events.poll` receives the post in **real time**.

`scripts/ch-2party-delivery.mjs` (A creates a public channel, B joins, A posts, B's scoped poll receives it) goes from empty → `DELIVERY CONFIRMED`.

- tsc clean (renderer + daemon). Full suite **4111 passed**.
- New regression guard: `registerHandlers.rpcInvoke.test.ts` (removeHandler used, removeAllListeners forbidden on RPC_INVOKE, cleanup removes it).

## Impact / relation
This is an independent main-process infra fix (off `main`). It's what makes the channels work land for real — the dock (#287) and members roster (#289) are correct but their live delivery was dead after the first daemon reconnect until this fix. Recommend merging this first.

## Notes
- No VERSION/CHANGELOG bump — release PR does it. [Unreleased].

## Test plan
- [x] tsc renderer + daemon: 0 errors
- [x] Full vitest suite: 4111 passed
- [x] Live CDP: 2-party channel delivery (empty → confirmed) after the fix
- [ ] Maintainer spot-check: trigger a daemon respawn, confirm notifications + channel live updates survive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPC handler reconnection reliability by properly clearing existing handlers before re-registration.

* **Tests**
  * Added regression tests for IPC handler reconnection safety.
  * Added automated delivery verification tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->