### PR TITLE
fix(channels): fail-closed visibility gate on daemon join() (#288)

### DIFF
--- a/plans/issue-288-channel-join-visibility-gate.md
+++ b/plans/issue-288-channel-join-visibility-gate.md
@@ -1,0 +1,192 @@
+# Plan: issue #288 — daemon `join()` visibility gate (fail-closed private join)
+
+Status: IMPLEMENTED — all static gates green (daemon tsc 0 · root tsc 0 · eslint 0 · vitest 4148 passed / channels 295). Awaiting live-dogfood + commit/PR decision.
+Owner: maintainer (REPO_MODE solo)
+Date: 2026-06-23
+Issue: #288 — "channel: join() has no visibility gate — any same-machine caller can join a private channel"
+Related: `plans/channel-membership-v1-design.md` (Security note L24-25, Open Question L91) · trust-root epic F1 (same-user ceiling)
+
+## ENG REVIEW outcome (3 independent reviewers, 2026-06-23) — confirmations + corrections
+
+Three independent reviewers (security / architecture / regression-trace) read the plan + source + tests.
+Strong convergence. Net decisions that OVERRIDE the draft below:
+
+- **Design SOUND, unanimous:** single choke point (`ChannelService.join()`) covers MCP/pipe, renderer
+  mutate-local, and daemon-direct — no 4th path. D1 (`isVisibleTo` reuse) is correct and can never
+  *allow* a join that should be denied. D3 (placement after NOT_FOUND, before DUPLICATE) correct.
+  No TOCTOU (gate runs inside the per-channel lock, before any mutation/persist). D4 (archived OOS) agreed.
+- **D2 → `CHANNEL_NOT_FOUND` (CHANGED from draft's NOT_AUTHORIZED; user-confirmed).** Returning a distinct
+  `NOT_AUTHORIZED` while `get()` returns null for the same (private, non-member) tuple creates an existence
+  ORACLE ("get→nothing, join→forbidden" reveals the id is a real private channel). Use `CHANNEL_NOT_FOUND`
+  with the SAME message bytes as a missing channel → symmetric with `get`/`getMembers`/`getMessages`,
+  maximal fail-closed, no oracle.
+- **Threat model under-claim (fix wording):** the escalation grants not just history but **live fan-out**
+  (the attacker ws lands in every future post's `recipientSnapshot` + receives the `channel.message`
+  event) **and roster presence** (appears to legit members). State this in the PR.
+- **MUST-FIX regression — the draft's test audit was wrong.** The draft suspected `D5 join pin wins`
+  (L1211) and `U7 join rollback` — both are SAFE (public channels / member re-join). The ACTUAL breakers
+  are two tests that encode the vulnerability by self-joining a stranger into a private channel:
+  - `U6 › list lets a non-creator member of a private channel see it` (L711-729) — asserts `list('ws-2')`
+    after a stranger self-join → fix: seed ws-2 via `create({members:[…]})`, drop the join.
+  - `U6 › getMessages … historyFromSeq floor` (L782-825) — asserts `joinRes.ok===true` for a stranger
+    private join → see correction below.
+- **CORRECTION to reviewers' "second-agent preserves private late-floor" suggestion — it does NOT.**
+  `getMessages` finds the viewer by `workspaceId` only (first match, `ChannelService.ts:322`). A 2nd agent
+  of an already-member ws is found AFTER the create-seeded agent (floor 0), so the late floor is never
+  observed. Conclusion: **after the gate, a private-channel member with `historyFromSeq>0` is unreachable
+  via the public API** (create-seed ⇒ floor 0; the only `includeHistory:false` join that passes the gate
+  is a 2nd agent of an already-member ws, whose floor is masked by the ws's first member). The
+  `getMessages` floor-apply branch (L319-333) stays as defensive code for a future invite model but is
+  not reachable for private channels now. L782 is therefore rewritten to "a create-seeded private member
+  sees full history" (floor 0); the SET side of historyFromSeq remains covered by the public test at L247.
+
+## Problem
+
+`ChannelService.join()` (`src/daemon/channels/ChannelService.ts:512-554`) checks only
+`CHANNEL_NOT_FOUND` and `DUPLICATE_MEMBER`. It never inspects `channel.visibility` or calls
+`isVisibleTo`. Every READ path (`list` / `get` / `getMembers` / `getMessages`) IS
+membership-/visibility-scoped via `isVisibleTo` (L339-343) — so **join is the privilege
+escalation**: a same-machine pipe/MCP caller that knows a private channel's id can `join` it
+and thereby unlock its full history + live feed, even though it was never invited.
+
+PoC `scripts/ch-privatejoin-repro.mjs` confirms: a non-member (`repro-B`) joins `repro-A`'s
+private channel and gets `{ok:true}`.
+
+## Root cause (confirmed by reading the code)
+
+- Reads gate on `isVisibleTo(channel, verifiedWorkspaceId)`: public ⇒ always visible; private ⇒
+  caller's workspace must be in the member list.
+- `join()` has no such gate. Because D5 pins the joining member's workspace to the
+  server-resolved `verifiedWorkspaceId` (L540), join is always a **self-join** — but with no
+  visibility check, self-join into a private channel makes the caller a member, after which
+  every read gate passes.
+
+## Blast-radius analysis (what a fix touches)
+
+Single choke point. Every mutating path funnels into `ChannelService.join()`:
+
+| Caller | Path | Verified-ws anchor |
+|---|---|---|
+| MCP tool `channel_join` | `a2a.channel.join` pipe RPC → `forward()` → daemon | senderPtyId (unforgeable) |
+| pipe/CLI client | `a2a.channel.join` → `forward()` → daemon | senderPtyId; mutating fails closed w/o it |
+| in-app GUI | `channels:mutate-local` IPC → daemon | renderer-supplied (process-boundary trust) |
+| daemon RPC handler | `daemon/index.ts:1594-1603` → `channelService.join(p)` | — |
+
+Confirmed NON-impacts (fix is safe):
+- **GUI is already public-only.** `ChannelMembers.tsx:199-200`:
+  `canJoin = channel.visibility === 'public' && status !== 'archived' && !!selfWorkspaceId`.
+  The "+ member" picker never offers private channels → no GUI regression.
+- **MCP tool already documents private join as unexposed** (`channels.ts:197`). This fix makes
+  the daemon enforce what the surface already claims.
+- **`create` is unaffected.** Creator auto-membership and the optional `members[]` initial
+  members are added INSIDE `create()` (L417-447), never through `join()`. So a private channel's
+  legitimate members are still established at create time; only post-hoc self-join is gated.
+
+## Threat model / ceiling (no overclaiming)
+
+- This is bounded by the **same-user OS ceiling** (trust-root F1): a same-user process can already
+  read workspace tokens. The fix restores the *per-channel privacy expectation within the
+  agent-to-agent model* on one machine — it is NOT a remote RCE fix.
+- **Not reachable via LanLink remote**: remote peers only append inbox notes; the wire layer
+  exposes message fields, not channel RPCs. So this is a same-machine hardening, fail-closed.
+
+## Design decisions (for ENG REVIEW)
+
+### D1 — Gate predicate: reuse `isVisibleTo` (RECOMMENDED) vs. `visibility === 'private'` direct
+- **Reuse `isVisibleTo`** so "you may join a channel iff you may see it" is one invariant shared
+  with the read paths. Behavior:
+  - public ⇒ visible ⇒ join allowed (normal self-join). ✓
+  - private + caller's ws already a member ⇒ visible ⇒ falls through to `DUPLICATE_MEMBER`
+    (accurate error). ✓
+  - private + caller's ws NOT a member ⇒ not visible ⇒ rejected. ✓
+- This also matches read **workspace-level** semantics: if ws W already has an agent member in a
+  private channel, W's other agents may already READ it (getMessages finds a viewer by
+  `workspaceId`), so letting W's second agent join is consistent — not a new hole. The direct
+  `visibility==='private'` variant would reject that case, creating a read-yes/join-no asymmetry.
+- **Recommendation: reuse `isVisibleTo`.**
+
+### D2 — Error code: `NOT_AUTHORIZED` vs `CHANNEL_NOT_FOUND` (existence non-disclosure)
+- `get()` returns `null` (≈ not-found) for private+non-member to avoid leaking existence.
+- The issue text explicitly suggests `NOT_AUTHORIZED`. Trade-off:
+  - `NOT_AUTHORIZED`: honest about a deliberate action; easy for MCP callers to branch on; the
+    caller already had to know the (random-UUID) channelId to call join, so existence disclosure
+    is marginal.
+  - `CHANNEL_NOT_FOUND`: maximal fail-closed; symmetric with `get()`'s existence-hiding.
+- **Recommendation: `NOT_AUTHORIZED`** (matches issue + honest action error). Open for the panel
+  to flip to `CHANNEL_NOT_FOUND` if existence non-disclosure is judged to outweigh clarity.
+- Note: `ChannelErrorCode` already includes both `NOT_AUTHORIZED` and `CHANNEL_NOT_FOUND` — no
+  type change needed either way.
+
+### D3 — Gate placement
+Inside `join()`'s critical section, AFTER the `CHANNEL_NOT_FOUND` lookup and BEFORE the
+`DUPLICATE_MEMBER` check, so:
+- a non-member of a private channel is rejected by the gate, and
+- an existing member re-joining a private channel still gets the precise `DUPLICATE_MEMBER`.
+
+### D4 — Archived channels — OUT OF SCOPE
+`join`/`leave` do not check `status === 'archived'` today (only `post` does); the membership
+design notes this intentionally. Keep that as-is; not part of #288. (Will note in PR description.)
+
+## Implementation
+
+Single edit in `src/daemon/channels/ChannelService.ts`, `join()`:
+
+```ts
+const channel = this.state.channels.find((c) => c.id === params.channelId);
+if (!channel) {
+  return { ok: false, error: { code: 'CHANNEL_NOT_FOUND', message: `No such channel: ${params.channelId}` } };
+}
+// #288: fail-closed visibility gate. You may join a channel only if you may
+// SEE it (same invariant as the read paths). Public ⇒ always; private ⇒ the
+// caller's verified workspace must already be a member. A non-member of a
+// private channel cannot self-join to unlock its history (escalation). An
+// existing member falls through to the precise DUPLICATE_MEMBER below.
+if (!this.isVisibleTo(channel, params.verifiedWorkspaceId)) {
+  return {
+    ok: false,
+    error: { code: 'NOT_AUTHORIZED', message: 'Cannot join a private channel you are not a member of' },
+  };
+}
+const members = this.state.members[channel.id] ?? [];
+// ... existing DUPLICATE_MEMBER check unchanged
+```
+
+No signature change, no new error code, no caller changes.
+
+## Test plan
+
+`src/daemon/channels/__tests__/ChannelService.test.ts` — extend the existing
+`describe('U6: visibility + membership gate')` block (where the read-gate tests live):
+
+1. **`join` on a private channel by a non-member ⇒ NOT_AUTHORIZED, no membership written, no persist side-effect.**
+   (The core #288 regression — mirrors the PoC.)
+2. **`join` on a PUBLIC channel by a non-member still succeeds** (self-join unaffected — guards against over-tightening).
+3. **`join` on a private channel by an EXISTING member ⇒ DUPLICATE_MEMBER** (gate falls through to the precise error, not NOT_AUTHORIZED).
+4. **(D1 consistency) same-workspace second agent may join a private channel where its workspace is already a member** ⇒ `{ok:true}` (read-yes/join-yes symmetry; proves we did not over-reject).
+
+Existing tests that must stay green (no behavior change for them):
+- `describe('join / leave')` — joins target public channels / channels the creator made → unaffected.
+- `describe('D5 caller-identity server-pin')` `join pin wins` — joins a channel the attacker created (so attacker ws is a member / or public) → re-verify the fixture's channel visibility; adjust the fixture to public if it was relying on the missing gate.
+- `U7: join rollback` tests — re-join by an existing member (Alice) of her own channel ⇒ visible ⇒ unaffected.
+
+## Gates
+
+- `tsc` 0 (daemon project).
+- `npm run test:parallel` (or the channels-scoped vitest) fully green, incl. the 4 new cases.
+- Re-run PoC `scripts/ch-privatejoin-repro.mjs` on a CLEAN single instance →
+  expect `HOLE_CONFIRMED: false` / "join was rejected".
+
+## Ship
+
+- main is protected → PR off main. No Claude attribution. No per-PR VERSION bump.
+- Branch: `fix/channel-join-visibility-gate`. Issue #288 closes on merge. [Unreleased].
+- PR body: state the same-user ceiling honestly; note D4 (archived) is intentionally out of scope.
+
+## Risks / non-goals
+
+- **Non-goal:** an invite/grant model (would let non-members be ADDED to private channels). Not
+  built — v1 is fail-closed: private channels are joinable only by workspaces already seeded at
+  create time. An invite model is a separate, larger authz design.
+- **Risk:** a hidden test/dogfood relying on the missing gate (private self-join). Mitigation: the
+  test-plan audit above + full suite run; the only known private-join site is the PoC (which we
+  WANT to flip).

--- a/src/daemon/channels/ChannelService.ts
+++ b/src/daemon/channels/ChannelService.ts
@@ -515,6 +515,24 @@ export class ChannelService {
       if (!channel) {
         return { ok: false, error: { code: 'CHANNEL_NOT_FOUND', message: `No such channel: ${params.channelId}` } };
       }
+      // #288 — fail-closed visibility gate. You may JOIN a channel only if you
+      // may SEE it (the same `isVisibleTo` invariant the read paths use):
+      // public ⇒ always; private ⇒ the caller's verified workspace must already
+      // be a member (seeded at create time). Without this, any same-machine
+      // pipe/MCP caller that knows a private channel's id could self-join it and
+      // unlock its full history + LIVE fan-out (the joiner lands in every future
+      // post's recipientSnapshot + receives the channel.message event) and appear
+      // in the roster — reads are membership-scoped, so join was the escalation.
+      //
+      // We return CHANNEL_NOT_FOUND with the SAME message as a missing channel
+      // (NOT a distinct NOT_AUTHORIZED) so a non-member cannot distinguish a
+      // private channel they're locked out of from a non-existent id — symmetric
+      // with get()/getMembers()/getMessages(), which hide private existence from
+      // non-members. An existing member of a private channel passes this gate
+      // (they're visible) and falls through to the precise DUPLICATE_MEMBER below.
+      if (!this.isVisibleTo(channel, params.verifiedWorkspaceId)) {
+        return { ok: false, error: { code: 'CHANNEL_NOT_FOUND', message: `No such channel: ${params.channelId}` } };
+      }
       const members = this.state.members[channel.id] ?? [];
       // Reject duplicate membership (keyed on the server-resolved workspace).
       if (members.some((m) => m.workspaceId === params.verifiedWorkspaceId && m.memberId === params.member.memberId)) {

--- a/src/daemon/channels/__tests__/ChannelService.test.ts
+++ b/src/daemon/channels/__tests__/ChannelService.test.ts
@@ -710,21 +710,22 @@ describe('ChannelService', () => {
 
     it('list lets a non-creator member of a private channel see it (but strangers still cannot)', async () => {
       const { svc } = makeService();
+      // #288: Bob (ws-2) becomes a member of the private channel the ONLY
+      // legitimate way — seeded at create time via `members` (the create path
+      // bypasses the join visibility gate by design). A post-hoc stranger
+      // self-join is now rejected (see the join-gate tests below), so this
+      // test must seed membership rather than rely on the old hole.
       const priv = await svc.create({
         name: 'secret',
         visibility: 'private',
         createdBy: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
         verifiedWorkspaceId: 'ws-1',
+        members: [{ workspaceId: 'ws-2', memberId: 'm-2', memberName: 'Bob' }],
       });
       if (!priv.ok) throw new Error('expected create ok');
-      await svc.join({
-        channelId: priv.channel.id,
-        member: { workspaceId: 'ws-2', memberId: 'm-2', memberName: 'Bob' },
-        verifiedWorkspaceId: 'ws-2',
-      });
-      // Bob — joined, so a member of the private channel — must see it.
+      // Bob — a seeded member of the private channel — must see it.
       expect(svc.list('ws-2').map((c) => c.name)).toEqual(['secret']);
-      // Eve — never joined — must NOT see it.
+      // Eve — never a member — must NOT see it.
       expect(svc.list('ws-9').map((c) => c.name)).toEqual([]);
     });
 
@@ -779,17 +780,27 @@ describe('ChannelService', () => {
       expect(svc.getMessages(priv.channel.id, undefined, 'ws-1')).toHaveLength(1);
     });
 
-    it('getMessages on a private channel respects the viewer historyFromSeq floor (no past messages)', async () => {
-      // A member who joined late (includeHistory: false) must not be
-      // able to see messages posted before they joined, even via the
-      // public RPC. The seq-floor mirrors the renderer-side
-      // isMessageVisibleToViewer rule.
+    it('getMessages on a private channel returns full history to a create-seeded member', async () => {
+      // #288: after the join visibility gate, a workspace becomes a member of a
+      // PRIVATE channel only at create time (`members[]`), and create-seeded
+      // members always get historyFromSeq:0 — so they see the FULL history.
+      //
+      // The "late joiner sees no history" (historyFromSeq>0) scenario is no
+      // longer reachable for a private channel via the public API: a stranger
+      // can't self-join (gate), and the only includeHistory:false join that
+      // passes the gate is a 2nd agent of an ALREADY-member ws — whose floor is
+      // masked because getMessages finds the viewer by workspaceId (first match
+      // = the ws's create-seeded floor-0 member, ChannelService.ts:322). The
+      // getMessages floor-apply branch stays as defensive code for a future
+      // invite model; the historyFromSeq SET path is covered by the public
+      // includeHistory:false test in `describe('join / leave')`.
       const { svc } = makeService();
       const priv = await svc.create({
         name: 'team',
         visibility: 'private',
         createdBy: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
         verifiedWorkspaceId: 'ws-1',
+        members: [{ workspaceId: 'ws-2', memberId: 'm-2', memberName: 'Bob' }],
       });
       if (!priv.ok) throw new Error('expected create ok');
       // Post a few messages as Alice.
@@ -797,31 +808,15 @@ describe('ChannelService', () => {
         await svc.post({
           channelId: priv.channel.id,
           sender: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
-          text: `pre-join-${i}`,
+          text: `msg-${i}`,
           verifiedWorkspaceId: 'ws-1',
         });
       }
-      // Bob joins without history.
-      const joinRes = await svc.join({
-        channelId: priv.channel.id,
-        member: { workspaceId: 'ws-2', memberId: 'm-2', memberName: 'Bob' },
-        includeHistory: false,
-        verifiedWorkspaceId: 'ws-2',
-      });
-      expect(joinRes.ok).toBe(true);
-      // Post a message after Bob's join.
-      await svc.post({
-        channelId: priv.channel.id,
-        sender: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
-        text: 'post-join',
-        verifiedWorkspaceId: 'ws-1',
-      });
-      // Alice (full history) sees all 4.
-      expect(svc.getMessages(priv.channel.id, undefined, 'ws-1')).toHaveLength(4);
-      // Bob (no history) sees only the post-join message.
-      const bobView = svc.getMessages(priv.channel.id, undefined, 'ws-2');
-      expect(bobView).toHaveLength(1);
-      expect(bobView[0].text).toBe('post-join');
+      // Alice (creator, floor 0) and Bob (seeded member, floor 0) both see all 3.
+      expect(svc.getMessages(priv.channel.id, undefined, 'ws-1')).toHaveLength(3);
+      expect(svc.getMessages(priv.channel.id, undefined, 'ws-2')).toHaveLength(3);
+      // A stranger still sees nothing (visibility gate on the read path).
+      expect(svc.getMessages(priv.channel.id, undefined, 'ws-9')).toEqual([]);
     });
 
     it('getMessages on a public channel has no per-member seq floor (any caller sees full history)', async () => {
@@ -841,6 +836,135 @@ describe('ChannelService', () => {
       });
       // Stranger — sees the message because the channel is public.
       expect(svc.getMessages(pub.channel.id, undefined, 'ws-9')).toHaveLength(1);
+    });
+  });
+
+  describe('#288: join visibility gate (fail-closed private join)', () => {
+    it('rejects a non-member self-join of a private channel with CHANNEL_NOT_FOUND (no membership, no persist)', async () => {
+      const { svc, writer } = makeService();
+      const priv = await svc.create({
+        name: 'secret',
+        visibility: 'private',
+        createdBy: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+        verifiedWorkspaceId: 'ws-1',
+      });
+      if (!priv.ok) throw new Error('expected create ok');
+      const callsBefore = writer.saveImmediate.mock.calls.length;
+      // ws-2 is NOT a member and was never invited — the escalation #288 closes.
+      const r = await svc.join({
+        channelId: priv.channel.id,
+        member: { workspaceId: 'ws-2', memberId: 'm-2', memberName: 'Bob' },
+        verifiedWorkspaceId: 'ws-2',
+      });
+      expect(r.ok).toBe(false);
+      if (r.ok) throw new Error('expected !ok');
+      // CHANNEL_NOT_FOUND (NOT NOT_AUTHORIZED) so a non-member cannot distinguish
+      // a private channel they're locked out of from a non-existent id —
+      // symmetric with get()/getMembers()/getMessages().
+      expect(r.error.code).toBe('CHANNEL_NOT_FOUND');
+      // No membership was written (verified from the creator's POV).
+      expect(svc.getMembers(priv.channel.id, 'ws-1').map((m) => m.workspaceId)).toEqual(['ws-1']);
+      // The gate returned before any mutation → no extra persist call.
+      expect(writer.saveImmediate.mock.calls.length).toBe(callsBefore);
+    });
+
+    it('still allows a non-member self-join of a PUBLIC channel (gate does not over-tighten)', async () => {
+      const { svc } = makeService();
+      const pub = await svc.create({
+        name: 'lobby',
+        visibility: 'public',
+        createdBy: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+        verifiedWorkspaceId: 'ws-1',
+      });
+      if (!pub.ok) throw new Error('expected create ok');
+      const r = await svc.join({
+        channelId: pub.channel.id,
+        member: { workspaceId: 'ws-2', memberId: 'm-2', memberName: 'Bob' },
+        verifiedWorkspaceId: 'ws-2',
+      });
+      expect(r.ok).toBe(true);
+      expect(svc.getMembers(pub.channel.id, 'ws-2').map((m) => m.workspaceId).sort()).toEqual(['ws-1', 'ws-2']);
+    });
+
+    it('an existing member re-joining a private channel gets DUPLICATE_MEMBER (not CHANNEL_NOT_FOUND)', async () => {
+      const { svc } = makeService();
+      const priv = await svc.create({
+        name: 'team',
+        visibility: 'private',
+        createdBy: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+        verifiedWorkspaceId: 'ws-1',
+      });
+      if (!priv.ok) throw new Error('expected create ok');
+      // ws-1 is already a member (creator) → passes the visibility gate, then
+      // hits the precise DUPLICATE_MEMBER — proving the gate doesn't mask it.
+      const r = await svc.join({
+        channelId: priv.channel.id,
+        member: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+        verifiedWorkspaceId: 'ws-1',
+      });
+      expect(r.ok).toBe(false);
+      if (r.ok) throw new Error('expected !ok');
+      expect(r.error.code).toBe('DUPLICATE_MEMBER');
+    });
+
+    it('allows a 2nd agent of an already-member workspace to join a private channel (read/join symmetry)', async () => {
+      // D1: the gate keys on workspaceId (isVisibleTo). If ws-2 already has an
+      // agent member, ws-2 can already READ the private channel, so a 2nd ws-2
+      // agent joining is consistent — not a new hole. Proves no over-rejection.
+      const { svc } = makeService();
+      const priv = await svc.create({
+        name: 'squad',
+        visibility: 'private',
+        createdBy: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+        verifiedWorkspaceId: 'ws-1',
+        members: [{ workspaceId: 'ws-2', memberId: 'lead', memberName: 'Lead' }],
+      });
+      if (!priv.ok) throw new Error('expected create ok');
+      // A different agent (memberId 'backend') of the SAME ws-2 joins.
+      const r = await svc.join({
+        channelId: priv.channel.id,
+        member: { workspaceId: 'ws-2', memberId: 'backend', memberName: 'Backend' },
+        verifiedWorkspaceId: 'ws-2',
+      });
+      expect(r.ok).toBe(true);
+      const ws2Members = svc
+        .getMembers(priv.channel.id, 'ws-2')
+        .filter((m) => m.workspaceId === 'ws-2')
+        .map((m) => m.memberId)
+        .sort();
+      expect(ws2Members).toEqual(['backend', 'lead']);
+    });
+
+    it('a rejected private join performs no mutation (empty private channel keeps emptySince)', async () => {
+      const { svc, writer } = makeService();
+      const priv = await svc.create({
+        name: 'ghost',
+        visibility: 'private',
+        createdBy: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+        verifiedWorkspaceId: 'ws-1',
+      });
+      if (!priv.ok) throw new Error('expected create ok');
+      // Creator leaves → channel is empty, emptySince stamped (reaper-eligible).
+      const left = await svc.leave({
+        channelId: priv.channel.id,
+        workspaceId: 'ws-1',
+        memberId: 'm-1',
+        verifiedWorkspaceId: 'ws-1',
+      });
+      expect(left.ok).toBe(true);
+      const callsBefore = writer.saveImmediate.mock.calls.length;
+      // A stranger tries to join the now-empty private channel. The gate must
+      // reject BEFORE the emptySince-clear so the channel stays reapable.
+      const r = await svc.join({
+        channelId: priv.channel.id,
+        member: { workspaceId: 'ws-9', memberId: 'm-9', memberName: 'Eve' },
+        verifiedWorkspaceId: 'ws-9',
+      });
+      expect(r.ok).toBe(false);
+      if (r.ok) throw new Error('expected !ok');
+      expect(r.error.code).toBe('CHANNEL_NOT_FOUND');
+      // No mutation happened → no extra persist (emptySince is untouched).
+      expect(writer.saveImmediate.mock.calls.length).toBe(callsBefore);
     });
   });
 


### PR DESCRIPTION
Closes #288.

## Problem
`ChannelService.join()` checked only `CHANNEL_NOT_FOUND` and `DUPLICATE_MEMBER` — never channel visibility. Every read path (`list`/`get`/`getMembers`/`getMessages`) is membership-scoped via `isVisibleTo`, so **join was the escalation**: any same-machine pipe/MCP caller that knew a private channel's id could self-join it and unlock its full history **+ live fan-out** (the joiner lands in every future post's `recipientSnapshot` and receives the `channel.message` event) and appear in the roster — even if never invited.

PoC (`scripts/ch-privatejoin-repro.mjs`) confirmed a non-member self-joining a private channel returned `{ok:true}`.

## Fix
Reuse the existing `isVisibleTo` invariant in `join()` — *you may join a channel only if you may see it*:
- public ⇒ always (normal self-join, unchanged)
- private ⇒ the caller's verified workspace must already be a member (seeded at create time)
- an existing member of a private channel passes the gate and falls through to the precise `DUPLICATE_MEMBER`

Rejections return **`CHANNEL_NOT_FOUND` with the same message as a missing channel** (not a distinct `NOT_AUTHORIZED`) so a non-member cannot distinguish a private channel they are locked out of from a non-existent id — symmetric with `get()`/`getMembers()`/`getMessages()`, which already hide private existence. This also closes the `get`-null vs `join`-forbidden existence oracle.

Single choke point: MCP/pipe, the renderer `channels:mutate-local` path, and the daemon handler all funnel into `ChannelService.join()`.

## Scope / non-goals
- **No UI changes.** The membership-v1 "+ member" picker already offers public channels only (`ChannelMembers.tsx:199-200`).
- **`create()` unaffected.** Creator + `members[]` seeding happens inside `create()`, bypassing `join` — the legitimate create-time path for private membership.
- **Out of scope:** archived-channel join semantics (only `post` checks archived today); an invite/grant model to *add* non-members to private channels (a separate, larger authz design). Until then private membership is create-time-only — fail-closed.

## Ceiling (no overclaim)
Bounded by the same-user OS ceiling (trust-root epic F1: a same-user process can already read workspace tokens). **Not** a remote RCE and **not** LanLink-reachable (the wire layer exposes message fields, not channel RPCs) — a same-machine privacy hardening.

## Review & verification
- Independent eng review (security / architecture / regression-trace) converged: design sound (single choke point, `isVisibleTo` reuse, placement after NOT_FOUND / before DUPLICATE, no TOCTOU — the gate runs inside the per-channel lock before any mutation); recommended `CHANNEL_NOT_FOUND` over `NOT_AUTHORIZED` (oracle); caught two existing tests that *encoded* the hole.
- **Tests:** 5 new cases (non-member private join → `CHANNEL_NOT_FOUND` + no mutation/no persist; public self-join still allowed; existing-member re-join → `DUPLICATE_MEMBER`; 2nd agent of an already-member ws may join — read/join symmetry; rejected join keeps `emptySince`). Two existing `U6` tests that set up a "member" via a stranger self-join are reseeded via `create({members})`.
- daemon tsc 0 · root tsc 0 · eslint 0 · **vitest 4148 passed** (channels 295).
- **Live CDP dogfood:** `ch-privatejoin-repro.mjs` flips `HOLE_CONFIRMED` true→false (non-member private join rejected with `CHANNEL_NOT_FOUND`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Privacy**
  * Private channels now enforce membership validation to prevent non-members from joining and accessing channel history and live feeds.
  * Unauthorized join attempts return consistent error messaging without revealing channel existence.

* **Bug Fixes**
  * Fixed vulnerability allowing unauthorized access to private channel data through self-joining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->