### PR TITLE
feat(channels): hydrate message history on channel open (P0)

### DIFF
--- a/src/renderer/components/Channels/ChannelView.tsx
+++ b/src/renderer/components/Channels/ChannelView.tsx
@@ -13,13 +13,14 @@
 //
 // Plan ref: U8, R21, R22.
 
-import { useMemo, useCallback } from 'react';
+import { useEffect, useMemo, useCallback } from 'react';
 import type {
   Channel,
   ChannelMessage,
   ChannelMember,
 } from '../../../shared/channels';
 import { useStore } from '../../stores';
+import { loadChannelHistory } from '../../hooks/useChannelsHydration';
 import { useT } from '../../hooks/useT';
 import { tokenAttrs } from '../../themes';
 import { FOCUS_RING } from '../focusRing';
@@ -289,6 +290,35 @@ export function ChannelView(): React.ReactElement | null {
     }
     return members[0] ?? null;
   }, [members, company?.ceoWorkspaceId, activeWorkspaceId]);
+
+  // P0: load RECENT message history into the store when a channel is opened.
+  // The view renders `store.channelMessages` only (it never calls getMessages
+  // itself), so without this an opened channel shows the empty-state even when
+  // it has history. `selfWs` MUST match the `viewer` workspace expression above
+  // so the daemon's per-member historyFromSeq floor and the view's filter agree.
+  // Hook order is stable — this runs on every render, before the early return.
+  useEffect(() => {
+    if (!activeChannelId) return;
+    const bridge = useStore.getState().channelsRpc();
+    if (!bridge) return;
+    const selfWs = company?.ceoWorkspaceId ?? activeWorkspaceId ?? '';
+    if (!selfWs) return;
+    // Read nextSeq fresh — the `channel` prop may be a render behind a
+    // just-arrived catalog refresh.
+    const nextSeq = useStore.getState().channels[activeChannelId]?.nextSeq ?? 1;
+    let disposed = false;
+    void loadChannelHistory({
+      rpc: bridge.rpc,
+      channelId: activeChannelId,
+      nextSeq,
+      workspaceId: selfWs,
+      apply: useStore.getState().hydrateChannelMessages,
+      isCurrent: () => !disposed,
+    });
+    return () => {
+      disposed = true;
+    };
+  }, [activeChannelId, company?.ceoWorkspaceId, activeWorkspaceId]);
 
   if (!activeChannelId || !channel) {
     // The activeChannelId-but-channel-undefined case can fire on a

--- a/src/renderer/hooks/__tests__/useChannelsHydration.test.ts
+++ b/src/renderer/hooks/__tests__/useChannelsHydration.test.ts
@@ -8,8 +8,8 @@
 // it with a mock `rpc` bridge and a spy `setChannels`.
 
 import { describe, it, expect, vi } from 'vitest';
-import { hydrateChannelsCatalog } from '../useChannelsHydration';
-import type { Channel, ChannelMember } from '../../../shared/channels';
+import { hydrateChannelsCatalog, loadChannelHistory } from '../useChannelsHydration';
+import type { Channel, ChannelMember, ChannelMessage } from '../../../shared/channels';
 
 function makeChannel(overrides: Partial<Channel> = {}): Channel {
   return {
@@ -29,6 +29,20 @@ function makeMember(overrides: Partial<ChannelMember> = {}): ChannelMember {
   return { workspaceId: 'ws-1', memberId: 'm-1', joinedAt: 1, historyFromSeq: 0, ...overrides };
 }
 
+function makeMsg(seq: number, overrides: Partial<ChannelMessage> = {}): ChannelMessage {
+  return {
+    channelId: 'ch-1',
+    seq,
+    workspaceId: 'ws-1',
+    memberId: 'm-1',
+    memberName: 'M',
+    text: `msg-${seq}`,
+    postedAt: seq,
+    deliveryStatus: 'delivered',
+    ...overrides,
+  };
+}
+
 /** Build a mock `rpc` that routes by method, with per-method handlers.
  *  The real renderer `rpc` bridge (electronAPI.rpc.invoke → pipe RpcRouter)
  *  wraps the daemon reply in the transport envelope `{ id, ok, result }` —
@@ -41,6 +55,7 @@ function wrap(daemonReply: unknown) {
 function makeRpc(handlers: {
   list?: (params: Record<string, unknown>) => unknown;
   getMembers?: (params: Record<string, unknown>) => unknown;
+  getMessages?: (params: Record<string, unknown>) => unknown;
 }) {
   return vi.fn(async (method: string, params: Record<string, unknown>) => {
     if (method === 'a2a.channel.list') {
@@ -48,6 +63,9 @@ function makeRpc(handlers: {
     }
     if (method === 'a2a.channel.getMembers') {
       return wrap(handlers.getMembers ? handlers.getMembers(params) : { ok: true, members: [] });
+    }
+    if (method === 'a2a.channel.getMessages') {
+      return wrap(handlers.getMessages ? handlers.getMessages(params) : { ok: true, messages: [] });
     }
     throw new Error(`unexpected method ${method}`);
   });
@@ -179,5 +197,74 @@ describe('hydrateChannelsCatalog', () => {
     });
     expect(n).toBe(0);
     expect(setChannels).not.toHaveBeenCalled();
+  });
+});
+
+describe('loadChannelHistory (P0 recent-history load)', () => {
+  it('floors sinceSeq at nextSeq - limit and applies the returned messages', async () => {
+    let captured: Record<string, unknown> | undefined;
+    const rpc = makeRpc({
+      getMessages: (p) => {
+        captured = p;
+        return { ok: true, messages: [makeMsg(298), makeMsg(299)] };
+      },
+    });
+    const apply = vi.fn();
+    const n = await loadChannelHistory({ rpc, channelId: 'ch-1', nextSeq: 300, workspaceId: 'ws-self', apply, limit: 200 });
+    expect(n).toBe(2);
+    expect(captured).toMatchObject({
+      channelId: 'ch-1',
+      sinceSeq: 100,
+      workspaceId: 'ws-self',
+      verifiedWorkspaceId: 'ws-self',
+    });
+    expect(apply).toHaveBeenCalledWith('ch-1', expect.arrayContaining([expect.objectContaining({ seq: 299 })]));
+  });
+
+  it('floors sinceSeq at 0 for a short channel (nextSeq < limit)', async () => {
+    let captured: Record<string, unknown> | undefined;
+    const rpc = makeRpc({
+      getMessages: (p) => {
+        captured = p;
+        return { ok: true, messages: [] };
+      },
+    });
+    await loadChannelHistory({ rpc, channelId: 'ch-1', nextSeq: 5, workspaceId: 'ws-self', apply: vi.fn(), limit: 200 });
+    expect(captured?.sinceSeq).toBe(0);
+  });
+
+  it('no-ops (no rpc, no apply) when workspaceId is empty', async () => {
+    const rpc = makeRpc({});
+    const apply = vi.fn();
+    const n = await loadChannelHistory({ rpc, channelId: 'ch-1', nextSeq: 10, workspaceId: '', apply });
+    expect(n).toBe(0);
+    expect(rpc).not.toHaveBeenCalled();
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it('bails (no apply) when the RPC throws', async () => {
+    const rpc = vi.fn(async () => {
+      throw new Error('pipe down');
+    });
+    const apply = vi.fn();
+    const n = await loadChannelHistory({ rpc, channelId: 'ch-1', nextSeq: 10, workspaceId: 'ws-self', apply });
+    expect(n).toBe(0);
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it('respects the disposed guard (no apply after dispose)', async () => {
+    const rpc = makeRpc({ getMessages: () => ({ ok: true, messages: [makeMsg(1)] }) });
+    const apply = vi.fn();
+    const n = await loadChannelHistory({ rpc, channelId: 'ch-1', nextSeq: 10, workspaceId: 'ws-self', apply, isCurrent: () => false });
+    expect(n).toBe(0);
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it('does not apply on an ok:false envelope', async () => {
+    const rpc = makeRpc({ getMessages: () => ({ ok: false, error: { code: 'CHANNEL_NOT_FOUND', message: 'x' } }) });
+    const apply = vi.fn();
+    const n = await loadChannelHistory({ rpc, channelId: 'ch-1', nextSeq: 10, workspaceId: 'ws-self', apply });
+    expect(n).toBe(0);
+    expect(apply).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/hooks/useChannelsEventSubscription.ts
+++ b/src/renderer/hooks/useChannelsEventSubscription.ts
@@ -46,6 +46,7 @@
 
 import { useEffect } from 'react';
 import { useStore } from '../stores';
+import { loadChannelHistory } from './useChannelsHydration';
 import type { WmuxEvent, ChannelMessageEvent } from '../../shared/events';
 
 /** Polling cadence. 1 Hz is the same as the PluginFrame forwardEvents
@@ -176,6 +177,25 @@ export function useChannelsEventSubscription(): void {
               s.channelMessages = {};
               s.channelUnread = {};
             });
+            // P0 (C1): the wipe just blanked the OPEN channel's hydrated
+            // history too, and nothing re-fetches it (history hydration
+            // triggers on activeChannelId change, not on resync). Re-load the
+            // active channel's recent history so the open view doesn't go
+            // blank mid-session. Best-effort — loadChannelHistory no-ops on any
+            // failure and a later event/open retries.
+            const st = useStore.getState();
+            const activeId = st.activeChannelId;
+            const activeCh = activeId ? st.channels[activeId] : undefined;
+            const rpcBridge = st.channelsRpc();
+            if (activeId && activeCh && rpcBridge && workspaceId) {
+              void loadChannelHistory({
+                rpc: rpcBridge.rpc,
+                channelId: activeId,
+                nextSeq: activeCh.nextSeq,
+                workspaceId,
+                apply: st.hydrateChannelMessages,
+              });
+            }
             return;
           }
           for (const event of result.events) {

--- a/src/renderer/hooks/useChannelsHydration.ts
+++ b/src/renderer/hooks/useChannelsHydration.ts
@@ -40,7 +40,7 @@
 
 import { useEffect } from 'react';
 import { useStore } from '../stores';
-import type { Channel, ChannelMember } from '../../shared/channels';
+import type { Channel, ChannelMember, ChannelMessage } from '../../shared/channels';
 
 /** Dependencies for the pure hydration routine. */
 export interface ChannelHydrationDeps {
@@ -133,6 +133,73 @@ export async function hydrateChannelsCatalog(deps: ChannelHydrationDeps): Promis
   if (!isCurrent()) return 0;
   setChannels(channels, members);
   return channels.length;
+}
+
+/** Recent-history load limit (P0). Channels have NO message cap (the daemon's
+ *  `ChannelService.post` pushes unbounded; only the idempotency map is
+ *  LRU-capped) and NO expiry (the 7-day TTL reaps only zero-member channels),
+ *  so a full `getMessages` would drag the entire unbounded history on open. We
+ *  load the most recent N by flooring `sinceSeq` at `nextSeq - N`; scroll-up
+ *  "load older" is deferred (P0.5). */
+export const CHANNEL_HISTORY_LOAD_LIMIT = 200;
+
+/** Dependencies for the pure channel-history load routine. */
+export interface ChannelHistoryDeps {
+  /** Read RPC bridge (`__wmuxChannelsRpc.rpc`). */
+  rpc: (method: string, params: Record<string, unknown>) => Promise<unknown>;
+  channelId: string;
+  /** The channel's current `nextSeq` (from the hydrated catalog). Floors
+   *  `sinceSeq` so we only fetch the most recent `limit` messages. */
+  nextSeq: number;
+  /** Renderer "self" workspace (Company CEO ws, else active ws). */
+  workspaceId: string;
+  /** Store action that merges the fetched rows (`channelsSlice.hydrateChannelMessages`). */
+  apply: (channelId: string, messages: ChannelMessage[]) => void;
+  /** Max messages to load. Defaults to `CHANNEL_HISTORY_LOAD_LIMIT`. */
+  limit?: number;
+  /** Liveness guard (the caller passes `() => !disposed`). */
+  isCurrent?: () => boolean;
+}
+
+/**
+ * Load a channel's RECENT message history into the store on channel open (P0).
+ * `a2a.channel.getMessages` with `sinceSeq = max(0, nextSeq - limit)` →
+ * `hydrateChannelMessages`. Best-effort: any RPC error / non-ok envelope /
+ * malformed shape / missing identity / disposed guard short-circuits to a
+ * no-op. Returns the number of messages applied (0 on any early bail).
+ *
+ * Identity alignment (critical): `workspaceId` is stamped as BOTH the read
+ * scope and `verifiedWorkspaceId`, and MUST be the same workspace the
+ * ChannelView uses to pick its `viewer` (`company?.ceoWorkspaceId ??
+ * activeWorkspaceId`). Otherwise the daemon's per-member `historyFromSeq`
+ * floor and the view's visibility filter disagree and silently drop rows.
+ */
+export async function loadChannelHistory(deps: ChannelHistoryDeps): Promise<number> {
+  const { rpc, channelId, nextSeq, workspaceId, apply } = deps;
+  const isCurrent = deps.isCurrent ?? (() => true);
+  const limit = deps.limit ?? CHANNEL_HISTORY_LOAD_LIMIT;
+  if (!workspaceId || !channelId) return 0;
+  const sinceSeq = Math.max(0, nextSeq - limit);
+  let res: unknown;
+  try {
+    res = await rpc('a2a.channel.getMessages', {
+      channelId,
+      sinceSeq,
+      workspaceId,
+      verifiedWorkspaceId: workspaceId,
+    });
+  } catch {
+    // Daemon not connected / transient pipe failure — a later open or resync retries.
+    return 0;
+  }
+  if (!isCurrent()) return 0;
+  const env = unwrapRpc(res);
+  if (!isOkObject(env)) return 0;
+  const raw = (env as { messages?: unknown }).messages;
+  if (!Array.isArray(raw)) return 0;
+  const messages = raw as ChannelMessage[];
+  apply(channelId, messages);
+  return messages.length;
 }
 
 /** Single-method facade over the channels bridge `useRpcBridge` installs.

--- a/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
@@ -300,6 +300,39 @@ describe('channelsSlice — appendMessageFromEvent', () => {
   });
 });
 
+describe('channelsSlice — hydrateChannelMessages (P0)', () => {
+  it('merges history into the store, sorted by seq', () => {
+    const store = createTestStore();
+    store.getState().hydrateChannelMessages('ch-1', [
+      makeMessage('ch-1', 3),
+      makeMessage('ch-1', 1),
+      makeMessage('ch-1', 2),
+    ]);
+    expect(store.getState().channelMessages['ch-1'].map((m) => m.seq)).toEqual([1, 2, 3]);
+  });
+
+  it('dedups by seq; the existing (live) row wins on collision', () => {
+    const store = createTestStore();
+    store.getState().appendMessageFromEvent(makeMessage('ch-1', 2, { text: 'live' }));
+    store.getState().hydrateChannelMessages('ch-1', [
+      makeMessage('ch-1', 1, { text: 'hist-1' }),
+      makeMessage('ch-1', 2, { text: 'hist-2' }),
+    ]);
+    const list = store.getState().channelMessages['ch-1'];
+    expect(list.map((m) => m.seq)).toEqual([1, 2]);
+    // The live row already in the store wins the seq-2 collision (it may carry
+    // a fresher delivery snapshot than the persisted history row).
+    expect(list.find((m) => m.seq === 2)?.text).toBe('live');
+  });
+
+  it('does NOT bump channelUnread (loading history is not new unread)', () => {
+    const store = createTestStore();
+    // ch-1 is not the active channel, so a live append WOULD bump unread.
+    store.getState().hydrateChannelMessages('ch-1', [makeMessage('ch-1', 1), makeMessage('ch-1', 2)]);
+    expect(store.getState().channelUnread['ch-1'] ?? 0).toBe(0);
+  });
+});
+
 describe('channelsSlice — markChannelRead', () => {
   it('clears the unread count for the channel', () => {
     const store = createTestStore();

--- a/src/renderer/stores/slices/channelsSlice.ts
+++ b/src/renderer/stores/slices/channelsSlice.ts
@@ -221,6 +221,13 @@ export interface ChannelsSlice {
   // ── Event-driven actions (dispatched from the subscription hook) ─
   markChannelRead: (channelId: string) => void;
   appendMessageFromEvent: (message: ChannelMessage) => void;
+  /** Hydrate a channel's message history (P0). Merges the daemon's
+   *  `getMessages` result with any live/optimistic rows already in the
+   *  store, deduped by `seq` (existing rows win — a live event may carry a
+   *  fresher delivery snapshot than the persisted history row). Result is
+   *  sorted by `seq`. Does NOT touch `channelUnread` — loading history is
+   *  not new unread. */
+  hydrateChannelMessages: (channelId: string, messages: ChannelMessage[]) => void;
 }
 
 export const createChannelsSlice: StateCreator<
@@ -385,6 +392,25 @@ export const createChannelsSlice: StateCreator<
         state.channelUnread[channelId] =
           (state.channelUnread[channelId] ?? 0) + 1;
       }
+    }),
+
+  hydrateChannelMessages: (channelId, messages) =>
+    set((state: StoreState) => {
+      const existing = state.channelMessages[channelId] ?? [];
+      // Merge history (from getMessages) with whatever live/optimistic rows
+      // are already in the store, deduped by seq. We seed the map with the
+      // history first, then overlay `existing` so a live event row WINS on a
+      // seq collision (it may carry a fresher delivery snapshot than the
+      // persisted history row — mirrors appendMessageFromEvent's overwrite).
+      const bySeq = new Map<number, ChannelMessage>();
+      for (const m of messages) bySeq.set(m.seq, m);
+      for (const m of existing) bySeq.set(m.seq, m);
+      state.channelMessages[channelId] = Array.from(bySeq.values()).sort(
+        (a, b) => a.seq - b.seq,
+      );
+      // channelUnread is intentionally NOT touched — loading history is not
+      // "new unread" (P0). Only live appends (appendMessageFromEvent /
+      // postMessageOptimistic) bump the badge.
     }),
 
   // ── *Daemon thunks (U4) — wire-path entry points ───────────────────


### PR DESCRIPTION
P0 of the channels full-chat roadmap (office-hours design doc). **Renderer-only** — the daemon's `getMessages` RPC already exists.

## Problem
`ChannelView` rendered `store.channelMessages` only and never called `getMessages` (`ChannelView.tsx:252`), so opening a channel that HAS history showed the empty-state ("No messages yet — be the first to post.") — actively wrong, worse than blank. Reload lost the conversation. And an eventBus `resync` wiped the open channel blank mid-session with no re-fetch. Messages were only ever populated by live `channel.message` events.

## Fix — 4 coupled parts
- **`channelsSlice.hydrateChannelMessages(channelId, messages[])`** — merge the daemon's `getMessages` rows with any live/optimistic rows already in the store, deduped by `seq` (existing live rows win — fresher delivery snapshot), sorted by `seq`. Does NOT touch `channelUnread` (history is not new unread).
- **`loadChannelHistory` (useChannelsHydration)** — `getMessages` with `sinceSeq = max(0, nextSeq - 200)` → `hydrateChannelMessages`. Loads RECENT N, not the whole history: channel messages have **no cap and no expiry** (the 7-day TTL reaps only zero-member channels — `ChannelStateWriter.load()` "Has members: keep always"), so a full load would drag an unbounded log on open. `nextSeq` comes from the hydrated catalog → **zero daemon change**.
- **ChannelView** — on `activeChannelId` change, trigger `loadChannelHistory` with `selfWs = company?.ceoWorkspaceId ?? activeWorkspaceId`, the SAME workspace the view's `viewer` uses, so the daemon's per-member `historyFromSeq` floor and the view filter agree (else rows are silently dropped).
- **useChannelsEventSubscription** — on `resync`, re-hydrate the active channel after the cache wipe so the open view doesn't go blank mid-session (closes the spec-review C1 coupling: the resync handler was corrupting P0's deliverable).

Scroll-up "load older" deferred (P0.5).

## Verification
- tsc 0 (renderer + root), eslint 0, **vitest 4157 passed** (9 new: 6 `loadChannelHistory` + 3 `hydrateChannelMessages`).
- **Live (office-hours Assignment, pending):** open a channel that already has messages and confirm history renders without manual injection, then have one non-maintainer react ("oh, it's a chat"). That reaction gates whether P1 (live stability) / P2 (sender identity) are worth building.

## Scope
First step of the maintainer-confirmed "full human chat" direction, keeping the agent+human-in-one-room differentiator. Builds on @AnandSundar's channel foundation (#269/#280) — this connects the durable history he built to the view that wasn't reading it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channel message history now loads when opening a channel, displaying up to 200 recent messages.
  * Channel views are preserved during cache resync events, preventing blank channel states mid-session.
  * Message history is automatically fetched and displayed with proper deduplication and sequencing.

* **Tests**
  * Added comprehensive tests for channel message history loading and store hydration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->