### PR TITLE
fix(terminal): copy/paste survive CJK IME (match physical KeyC/KeyV)

### DIFF
--- a/src/renderer/hooks/__tests__/useTerminal.imeCopyPaste.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.imeCopyPaste.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Source-level regression lock: terminal copy/paste keybindings must match the
+ * physical `code` (KeyC / KeyV), not just `e.key`.
+ *
+ * Under a CJK IME (Hangul, etc.) xterm derives Ctrl+<letter> from the deprecated
+ * `keyCode`, which becomes 229 ("Process"). The DOM `keydown` then carries
+ * `e.key` as the composed jamo ('ㅊ' / 'ㅍ') or 'Process' — never 'c' / 'v'.
+ * A handler that only checks `e.key === 'c'` silently misses, so Ctrl+C falls
+ * through to xterm and becomes SIGINT instead of copying — the reported
+ * "Ctrl+C copy broken in Hangul input mode" bug. Same class as the Ctrl+J
+ * newline (#258) and IME Escape (#189) fixes, which already match by code.
+ *
+ * The custom key handler runs against a real xterm Terminal plus DOM keydown
+ * events that jsdom can't faithfully drive (and can't synthesize an active IME
+ * at all), so the invariant is pinned at the source level — matching the
+ * rightClickPasteMouseMode / atlasClear / webglTeardown locks in this dir.
+ */
+
+const SRC = readFileSync(
+  path.resolve(process.cwd(), 'src/renderer/hooks/useTerminal.ts'),
+  'utf8',
+);
+
+const handlerStart = SRC.indexOf('attachCustomKeyEventHandler');
+const HANDLER = SRC.slice(handlerStart);
+
+describe('useTerminal copy/paste survives a CJK IME (source-level lock)', () => {
+  it('locates the custom key event handler', () => {
+    expect(handlerStart).toBeGreaterThan(-1);
+  });
+
+  it('Ctrl+C copy matches physical KeyC, not only e.key', () => {
+    expect(HANDLER).toMatch(/e\.key === 'c' \|\| e\.code === 'KeyC'/);
+  });
+
+  it('Ctrl+V paste matches physical KeyV, not only e.key', () => {
+    expect(HANDLER).toMatch(/e\.key === 'v' \|\| e\.code === 'KeyV'/);
+  });
+
+  it('Ctrl+Shift+C copy matches physical KeyC', () => {
+    expect(HANDLER).toMatch(/e\.key === 'C' \|\| e\.code === 'KeyC'/);
+  });
+
+  it('Ctrl+Shift+V paste matches physical KeyV', () => {
+    expect(HANDLER).toMatch(/e\.key === 'V' \|\| e\.code === 'KeyV'/);
+  });
+
+  it('the Ctrl+Shift catch-all exempts KeyC/KeyV so the copy/paste handlers below stay reachable', () => {
+    // Without this exemption the Ctrl+Shift+C / Ctrl+Shift+V handlers are dead
+    // (the catch-all returns false first).
+    expect(HANDLER).toMatch(
+      /e\.ctrlKey && e\.shiftKey && e\.code !== 'KeyC' && e\.code !== 'KeyV'/,
+    );
+  });
+});

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -610,8 +610,13 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       )) {
         return false; // let DOM bubble to useKeyboard's zoom handlers
       }
-      if (e.ctrlKey && e.shiftKey) {
-        return false; // all Ctrl+Shift combos → app shortcuts
+      // Ctrl+Shift+C / Ctrl+Shift+V are explicit copy/paste, handled below.
+      // Let them fall through; bubble every OTHER Ctrl+Shift combo to app
+      // shortcuts. Exception matched by physical `code` so it survives a CJK IME
+      // (e.key would be a composed jamo / 'Process', not 'C'/'V') — without this
+      // the copy/paste handlers below were dead under any IME and even plain.
+      if (e.ctrlKey && e.shiftKey && e.code !== 'KeyC' && e.code !== 'KeyV') {
+        return false; // all other Ctrl+Shift combos → app shortcuts
       }
 
       // Custom keybindings: let function keys and matched combos pass through to useKeyboard
@@ -630,8 +635,14 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         }
       }
 
-      // Ctrl+C: copy if selection exists, otherwise send SIGINT
-      if (e.ctrlKey && !e.shiftKey && e.key === 'c') {
+      // Ctrl+C: copy if selection exists, otherwise send SIGINT. Match physical
+      // `code` (KeyC) too — under a CJK IME xterm derives Ctrl+<letter> from the
+      // deprecated keyCode, which becomes 229 ("Process"), so `e.key` is the
+      // composed jamo ('ㅊ') or 'Process' rather than 'c'. Without the code
+      // fallback the copy silently falls through to SIGINT (the reported "Ctrl+C
+      // copy broken in Hangul mode" bug). Same IME class as the Ctrl+J / Escape
+      // handlers above.
+      if (e.ctrlKey && !e.shiftKey && (e.key === 'c' || e.code === 'KeyC')) {
         const sel = terminal.getSelection();
         if (sel) {
           // main now throws on clipboard failure — await + catch so the
@@ -644,7 +655,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
 
       // Ctrl+V: paste from clipboard (use our IPC clipboard, block event
       // so xterm doesn't also paste via browser's native paste event)
-      if (e.ctrlKey && !e.shiftKey && e.key === 'v') {
+      if (e.ctrlKey && !e.shiftKey && (e.key === 'v' || e.code === 'KeyV')) {
         e.preventDefault();
         void (async () => {
           // Try text first
@@ -671,7 +682,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       }
 
       // Ctrl+Shift+C: copy fallback
-      if (e.ctrlKey && e.shiftKey && e.key === 'C') {
+      if (e.ctrlKey && e.shiftKey && (e.key === 'C' || e.code === 'KeyC')) {
         const sel = terminal.getSelection();
         if (sel) {
           // Note: original handler did NOT clearSelection here. Preserve that
@@ -685,7 +696,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         return false;
       }
       // Ctrl+Shift+V: paste fallback
-      if (e.ctrlKey && e.shiftKey && e.key === 'V') {
+      if (e.ctrlKey && e.shiftKey && (e.key === 'V' || e.code === 'KeyV')) {
         e.preventDefault();
         void (async () => {
           const text = await window.clipboardAPI.readText();


### PR DESCRIPTION
## Summary
Terminal copy/paste was broken under a CJK (Hangul, etc.) input method.

`Ctrl+C`/`Ctrl+V` and `Ctrl+Shift+C`/`Ctrl+Shift+V` only matched `e.key`. Under an active CJK IME, xterm derives `Ctrl+<letter>` from the deprecated `keyCode`, which becomes 229 ("Process"), so `e.key` arrives as a composed jamo ('ㅊ'/'ㅍ') or 'Process' — never 'c'/'v'. The copy handler missed and fell through to SIGINT; paste did nothing. Same IME class already fixed for the Ctrl+J newline (#258) and Escape (#189).

Two fixes in `useTerminal.ts`:
- **Copy/paste match the physical `e.code`** (KeyC/KeyV) as a fallback, so they work regardless of IME/layout state.
- **Revive Ctrl+Shift+C/V**: the `Ctrl+Shift → bubble` catch-all ran first and made those handlers dead code. Exempt KeyC/KeyV from it.

## Test Coverage
Added `useTerminal.imeCopyPaste.test.ts` — a source-level regression lock (the custom key handler runs against a real xterm + active IME that jsdom cannot drive, matching the existing rightClickPaste / atlasClear locks). Pins the `e.code` fallback on all four handlers plus the catch-all exemption.

Regression proof: with the fix stashed, 5/6 lock assertions fail; with the fix, all 6 pass.

## Verification
- `tsc -p tsconfig.json` clean (renderer)
- full vitest: **4163 passed, 7 skipped** (regression 0, +6 new)
- pre-existing `.catch(()=>{})` lint warnings in the paste handlers are unrelated to this diff

## Test plan
- [x] renderer tsc clean
- [x] vitest 4163 passed
- [x] regression lock fails without fix, passes with fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed copy/paste keyboard shortcuts (Ctrl+C, Ctrl+V, Ctrl+Shift+C, Ctrl+Shift+V) in terminal when using CJK/IME input methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->