### PR TITLE
fix(channels): dock polish — single header + responsive width

### DIFF
--- a/src/renderer/components/Channels/ChannelDock.tsx
+++ b/src/renderer/components/Channels/ChannelDock.tsx
@@ -7,7 +7,16 @@
 // in AppLayout's root row, so it reflows the panes instead of floating over
 // them. Mounted only when `channelDockVisible` (uiSlice); auto-opens when a
 // channel is selected (channelsSlice.setActiveChannel), collapses via the
-// header button, and reopens from the StatusBar channel toggle.
+// list header's collapse button, and reopens from the StatusBar channel toggle.
+//
+// Header: the dock has NO header of its own. The collapse affordance lives in
+// ChannelsPanel's section header (it owns the single "Channels" title + unread
+// total + new-channel + collapse), so the title shows ONCE instead of being
+// duplicated by a separate dock header.
+//
+// Width: clamped (not a hard 320px) so a narrow window doesn't crush the
+// terminals down to per-character wrapping. The dock gives back space when the
+// viewport is small and grows to 320 when there's room.
 //
 // Edge mirroring: the workspace Sidebar sits on `sidebarPosition`; the dock
 // sits opposite. AppLayout's root uses `flex-row-reverse` when the sidebar is
@@ -15,61 +24,30 @@
 // correct (opposite) edge automatically — we only flip the inner border side.
 
 import { useStore } from '../../stores';
-import { useT } from '../../hooks/useT';
 import { tokenAttrs } from '../../themes';
-import { FOCUS_RING } from '../focusRing';
-import { IconChevronDir } from '../icons';
 import { ChannelsPanel } from './ChannelsPanel';
 import { ChannelView } from './ChannelView';
 
 export default function ChannelDock(): React.ReactElement {
-  const t = useT();
   const sidebarPosition = useStore((s) => s.sidebarPosition);
-  const setChannelDockVisible = useStore((s) => s.setChannelDockVisible);
 
   // Workspace sidebar is on `sidebarPosition`; the dock is on the opposite
   // edge. When the sidebar is on the LEFT (default), the dock is on the RIGHT,
-  // so its content border faces left (border-l) and the collapse chevron
-  // points right (toward the screen edge it tucks into).
+  // so its content border faces left (border-l).
   const dockOnRight = sidebarPosition !== 'right';
 
   return (
     <div
       className={`flex flex-col h-full bg-[var(--bg-mantle)] ${dockOnRight ? 'border-l' : 'border-r'} border-[var(--bg-surface)]`}
-      style={{ width: 320, borderColor: 'var(--border-soft)' }}
+      style={{ width: 'clamp(248px, 26vw, 320px)', borderColor: 'var(--border-soft)' }}
       data-channel-dock
       {...tokenAttrs('bgMantle', 'bg')}
       {...tokenAttrs('bgSurface', 'border')}
     >
-      {/* Slim header — collapse affordance on the inner edge (mirrors the
-          Sidebar footer collapse). The "Channels" section title + unread total
-          live in ChannelsPanel's own header just below. */}
-      <div
-        className={`flex items-center justify-between px-3 py-1.5 border-b border-[var(--bg-surface)] shrink-0 ${dockOnRight ? '' : 'flex-row-reverse'}`}
-        style={{ borderColor: 'var(--border-soft)' }}
-        {...tokenAttrs('bgSurface', 'border')}
-      >
-        <span
-          className="text-[10px] font-mono tracking-widest uppercase text-[var(--text-muted)]"
-          {...tokenAttrs('textMuted', 'text')}
-        >
-          {t('channels.dockTitle') || 'Channels'}
-        </span>
-        <button
-          type="button"
-          className={`flex items-center justify-center w-5 h-5 rounded text-[var(--text-muted)] hover:text-[var(--text-main)] hover:bg-[rgba(var(--bg-surface-rgb),0.6)] transition-colors duration-150 ${FOCUS_RING}`}
-          onClick={() => setChannelDockVisible(false)}
-          title={t('channels.dockCollapse') || 'Collapse channels'}
-          aria-label={t('channels.dockCollapse') || 'Collapse channels'}
-          data-channel-dock-collapse
-        >
-          {/* Chevron points toward the edge the dock tucks into. */}
-          <IconChevronDir dir={dockOnRight ? 'right' : 'left'} />
-        </button>
-      </div>
-
-      {/* Channel list — capped so a long catalog can't crowd out the
-          conversation; scrolls within its share. */}
+      {/* Channel list — its own header now carries the collapse affordance
+          (merged from the old dock header to kill the duplicate "Channels"
+          title). Capped so a long catalog can't crowd out the conversation;
+          scrolls within its share. */}
       <div className="shrink-0 max-h-[45%] overflow-y-auto">
         <ChannelsPanel />
       </div>

--- a/src/renderer/components/Channels/ChannelsPanel.tsx
+++ b/src/renderer/components/Channels/ChannelsPanel.tsx
@@ -59,7 +59,7 @@ import {
 import type { Company } from '../../../company/types';
 import { useStore } from '../../stores';
 import ChannelItem from './ChannelItem';
-import { IconPlus, IconChevron } from '../icons';
+import { IconPlus, IconChevron, IconChevronDir } from '../icons';
 import { FOCUS_RING } from '../focusRing';
 import { tokenAttrs } from '../../themes';
 
@@ -286,6 +286,13 @@ export interface ChannelsPanelViewProps {
     name: string;
     visibility: ChannelVisibility;
   }) => boolean | Promise<boolean>;
+  /** When provided, render a collapse affordance in the header. The dock host
+   *  passes this to fold the whole dock away — it lives here (not in a separate
+   *  dock header) so the "Channels" title shows ONCE, not twice. */
+  onCollapse?: () => void;
+  /** Direction the collapse chevron points — toward the screen edge the dock
+   *  tucks into. Defaults to 'right' (sidebar-left / dock-right layout). */
+  collapseDir?: 'left' | 'right';
 }
 
 export function ChannelsPanelView(props: ChannelsPanelViewProps): React.ReactElement {
@@ -296,6 +303,8 @@ export function ChannelsPanelView(props: ChannelsPanelViewProps): React.ReactEle
     company,
     onSelect,
     onCreate,
+    onCollapse,
+    collapseDir = 'right',
   } = props;
   const t = props.t ?? ((k: string) => k);
 
@@ -327,7 +336,9 @@ export function ChannelsPanelView(props: ChannelsPanelViewProps): React.ReactEle
       className="border-t border-[var(--bg-surface)] py-2"
       style={{ borderColor: 'var(--border-soft)' }}
     >
-      {/* Header row — section title + new-channel affordance */}
+      {/* Header row — section title + actions (new-channel + collapse).
+            The collapse button is merged here from the old ChannelDock header
+            so the "Channels" title renders once, not twice. */}
       <div className="relative flex items-center justify-between px-4 pb-1">
         <span
           className="text-[10px] font-mono tracking-widest uppercase text-[var(--text-muted)]"
@@ -344,19 +355,33 @@ export function ChannelsPanelView(props: ChannelsPanelViewProps): React.ReactEle
             </span>
           )}
         </span>
-        <button
-          type="button"
-          className={`flex items-center justify-center w-5 h-5 rounded text-[var(--text-subtle)] hover:text-[var(--accent-green)] hover:bg-[rgba(var(--bg-surface-rgb),0.6)] transition-colors duration-150 ${FOCUS_RING}`}
-          onClick={() => setCreatorOpen((v) => !v)}
-          title={t('channels.newChannelTooltip') || 'New channel'}
-          aria-label={t('channels.newChannelTooltip') || 'New channel'}
-          data-channels-new
-          {...tokenAttrs('textSub', 'text')}
-          {...tokenAttrs('success', 'accent')}
-          data-derived="textSubtle"
-        >
-          <IconPlus size={11} />
-        </button>
+        <div className="flex items-center gap-0.5">
+          <button
+            type="button"
+            className={`flex items-center justify-center w-5 h-5 rounded text-[var(--text-subtle)] hover:text-[var(--accent-green)] hover:bg-[rgba(var(--bg-surface-rgb),0.6)] transition-colors duration-150 ${FOCUS_RING}`}
+            onClick={() => setCreatorOpen((v) => !v)}
+            title={t('channels.newChannelTooltip') || 'New channel'}
+            aria-label={t('channels.newChannelTooltip') || 'New channel'}
+            data-channels-new
+            {...tokenAttrs('textSub', 'text')}
+            {...tokenAttrs('success', 'accent')}
+            data-derived="textSubtle"
+          >
+            <IconPlus size={11} />
+          </button>
+          {onCollapse && (
+            <button
+              type="button"
+              className={`flex items-center justify-center w-5 h-5 rounded text-[var(--text-muted)] hover:text-[var(--text-main)] hover:bg-[rgba(var(--bg-surface-rgb),0.6)] transition-colors duration-150 ${FOCUS_RING}`}
+              onClick={onCollapse}
+              title={t('channels.dockCollapse') || 'Collapse channels'}
+              aria-label={t('channels.dockCollapse') || 'Collapse channels'}
+              data-channel-dock-collapse
+            >
+              <IconChevronDir dir={collapseDir} />
+            </button>
+          )}
+        </div>
         {creatorOpen && (
           <CreateChannelModal
             onClose={() => setCreatorOpen(false)}
@@ -447,6 +472,12 @@ export function ChannelsPanel(): React.ReactElement {
   const activeWorkspaceId = useStore((s) => s.activeWorkspaceId);
   const setActiveChannel = useStore((s) => s.setActiveChannel);
   const createChannelDaemon = useStore((s) => s.createChannelDaemon);
+  // Dock host wiring: the panel's collapse affordance folds the whole dock
+  // away (the panel is the dock's only host — the old separate dock header
+  // was removed to drop the duplicate title). The chevron mirrors the dock's
+  // edge so it points toward the screen edge it tucks into.
+  const sidebarPosition = useStore((s) => s.sidebarPosition);
+  const setChannelDockVisible = useStore((s) => s.setChannelDockVisible);
 
   const handleCreate = useCallback(
     async (params: { name: string; visibility: ChannelVisibility }) => {
@@ -506,6 +537,8 @@ export function ChannelsPanel(): React.ReactElement {
       company={company}
       onSelect={setActiveChannel}
       onCreate={handleCreate}
+      onCollapse={() => setChannelDockVisible(false)}
+      collapseDir={sidebarPosition !== 'right' ? 'right' : 'left'}
     />
   );
 }


### PR DESCRIPTION
## What

Two polish fixes to the right-side channel dock (shipped in #287), both surfaced by the live dock dogfood.

### 1. Duplicate "Channels" header
`ChannelDock` drew its own header (title + collapse) on top of `ChannelsPanel`'s section header, so the title rendered twice. Dropped the dock's own header and merged the collapse affordance into `ChannelsPanel`'s header — it now owns the single title + unread total + new-channel + collapse, all on one row.

The container wires `onCollapse` (`setChannelDockVisible(false)`) and the chevron direction from `sidebarPosition`, so `ChannelDock` keeps its `<ChannelsPanel />` call unchanged and the wiring-guard test needs no edit.

### 2. Hard 320px width crushed terminals
On narrow windows the fixed `width: 320` squeezed the terminal area down to per-character wrapping (`PS D:\wm` / `ux>`). Clamped to `clamp(248px, 26vw, 320px)` so the dock yields space when the viewport is small and grows to 320 when there's room.

## Notes
- `data-channel-dock-collapse` selector preserved (dogfood compat)
- No VERSION bump (follows wmux release-PR convention)

## Test
- `tsc` 0 errors
- channel component tests 77/77
- zero test edits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Channels area now includes a built-in collapse control in the panel header.
  * The channels dock now uses a more responsive width that adapts to the window size.

* **UI Changes**
  * The dock layout was simplified so the channel list header and collapse action live in one place.
  * The collapse direction now adjusts based on sidebar placement for a more natural experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->