### PR TITLE
feat: gate company-mode UI behind a build flag (+ channels i18n fix)

### DIFF
--- a/src/renderer/components/Channels/ChannelView.tsx
+++ b/src/renderer/components/Channels/ChannelView.tsx
@@ -338,6 +338,7 @@ export function ChannelView(): React.ReactElement | null {
         messages={messages}
         viewer={viewer}
         onClose={handleClose}
+        t={t}
         membersSlot={<ChannelMembersControl channel={channel} />}
         composerSlot={
           channel.status === 'archived' ? (

--- a/src/renderer/components/Channels/ChannelsPanel.tsx
+++ b/src/renderer/components/Channels/ChannelsPanel.tsx
@@ -62,6 +62,7 @@ import ChannelItem from './ChannelItem';
 import { IconPlus, IconChevron, IconChevronDir } from '../icons';
 import { FOCUS_RING } from '../focusRing';
 import { tokenAttrs } from '../../themes';
+import { useT } from '../../hooks/useT';
 
 // ─── Grouping / aggregation helpers (pure, exported for unit tests) ──────────
 
@@ -478,6 +479,7 @@ export function ChannelsPanel(): React.ReactElement {
   // edge so it points toward the screen edge it tucks into.
   const sidebarPosition = useStore((s) => s.sidebarPosition);
   const setChannelDockVisible = useStore((s) => s.setChannelDockVisible);
+  const t = useT();
 
   const handleCreate = useCallback(
     async (params: { name: string; visibility: ChannelVisibility }) => {
@@ -539,6 +541,7 @@ export function ChannelsPanel(): React.ReactElement {
       onCreate={handleCreate}
       onCollapse={() => setChannelDockVisible(false)}
       collapseDir={sidebarPosition !== 'right' ? 'right' : 'left'}
+      t={t}
     />
   );
 }

--- a/src/renderer/components/Palette/CommandPalette.tsx
+++ b/src/renderer/components/Palette/CommandPalette.tsx
@@ -11,6 +11,7 @@ import { usePlugins } from '../../plugins/usePlugins';
 import { postPluginCommand } from '../../plugins/pluginFrameRegistry';
 import { runProjectCommand } from '../../utils/projectCommands';
 import { applyProjectLayoutFresh } from '../../utils/projectConfigProbe';
+import { COMPANY_MODE_ENABLED } from '../../../shared/featureFlags';
 
 // ---------------------------------------------------------------------------
 // SVG Icons (inline, no external dependency)
@@ -273,7 +274,7 @@ export default function CommandPalette() {
     const state = useStore.getState();
     const hasCompany = !!state.company;
 
-    if (!hasCompany) {
+    if (COMPANY_MODE_ENABLED && !hasCompany) {
       const templates = [
         { name: 'Full-Stack Team', label: 'Company: Create Full-Stack Team' },
         { name: 'Startup MVP', label: 'Company: Create Startup MVP' },
@@ -339,7 +340,7 @@ export default function CommandPalette() {
           setVisible(false);
         },
       });
-    } else {
+    } else if (COMPANY_MODE_ENABLED) {
       items.push({
         id: 'company-provision-all',
         label: 'Company: Provision All Members',

--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -11,6 +11,7 @@ import { IconPlus, IconChevronDir } from '../icons';
 import { FOCUS_RING } from '../focusRing';
 import PluginPanels from '../../plugins/PluginPanels';
 import CompanyPanel from './CompanyPanel';
+import { COMPANY_MODE_ENABLED } from '../../../shared/featureFlags';
 
 // Pane 트리에서 모든 leaf의 PTY를 dispose
 function disposeAllPtys(pane: Pane) {
@@ -91,6 +92,7 @@ export default function Sidebar() {
           {/* Workspaces ⇄ Company toggle. Entry/exit for company mode — the
               palette commands set sidebarMode but there was no UI affordance
               to flip it back (or discover it). */}
+          {COMPANY_MODE_ENABLED && (
           <button
             className={`flex items-center justify-center w-6 h-6 rounded-md transition-colors duration-150 hover:bg-[rgba(var(--bg-surface-rgb),0.6)] ${FOCUS_RING} ${
               sidebarMode === 'company'
@@ -118,6 +120,7 @@ export default function Sidebar() {
               <path d="M10 13c0-1.7.8-2.7 2-2.7s2 1 2 2.3" />
             </svg>
           </button>
+          )}
           {/* File tree button hidden - feature unstable
           <button
             className={`text-sm leading-none transition-colors ${fileTreeVisible ? 'text-[var(--accent-blue)]' : 'text-[var(--text-subtle)] hover:text-[var(--accent-green)]'}`}
@@ -147,7 +150,7 @@ export default function Sidebar() {
           workspace list. This is the consumer of `sidebarMode` that was
           missing — CompanyPanel was orphaned (never rendered) so the
           palette's company commands had no visible surface. */}
-      {sidebarMode === 'company' ? (
+      {COMPANY_MODE_ENABLED && sidebarMode === 'company' ? (
         <CompanyPanel />
       ) : (
       /* The list container absorbs dragover for sidebar-internal reorder

--- a/src/renderer/components/StatusBar/StatusBar.tsx
+++ b/src/renderer/components/StatusBar/StatusBar.tsx
@@ -6,6 +6,7 @@ import { UsageWidgetView } from './UsageWidget';
 import { tokenAttrs } from '../../themes';
 import PluginStatusBarWidgets from '../../plugins/PluginStatusBarWidgets';
 import { sumUnread } from '../Channels/ChannelsPanel';
+import { COMPANY_MODE_ENABLED } from '../../../shared/featureFlags';
 
 /**
  * Compute the unread notification count, excluding notifications whose
@@ -148,7 +149,11 @@ export default function StatusBar() {
 
   const timeStr = time.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
   const branch = activeWs?.metadata?.gitBranch;
-  const isCompanyMode = sidebarMode === 'company';
+  // Company-mode UI is gated behind COMPANY_MODE_ENABLED (paid "wmux max").
+  // Even with a leftover persisted `sidebarMode === 'company'` (from a build
+  // where company mode was reachable), the status-bar badge + cost must stay
+  // hidden so the deactivated build shows zero company traces.
+  const isCompanyMode = COMPANY_MODE_ENABLED && sidebarMode === 'company';
 
   // Anthropic 5h/7d usage state. Hidden entirely when status === 'idle'
   // (Settings toggle off). `nowMs` is the existing per-second clock used

--- a/src/shared/featureFlags.ts
+++ b/src/shared/featureFlags.ts
@@ -1,0 +1,13 @@
+/**
+ * Build-time feature flags.
+ *
+ * COMPANY_MODE_ENABLED — the in-app "company / AI team / departments" mode
+ * (src/company) is a separate paid product idea ("wmux max"). Its source and
+ * logic stay in the tree, but the UI entry points are gated off by this flag:
+ *   - the Sidebar workspaces⇄company toggle button
+ *   - the Sidebar CompanyPanel render
+ *   - the command-palette "Company: …" commands
+ * Flip to `true` in a paid build to re-enable the whole company UI. Channels
+ * are decoupled from company mode and are unaffected either way.
+ */
+export const COMPANY_MODE_ENABLED = false;


### PR DESCRIPTION
## Summary
Company mode (the in-app "company / AI team / departments" feature under `src/company`) is gated off behind a new build-time `COMPANY_MODE_ENABLED` flag (default `false`), so the shipped app shows zero company traces. The source stays in the tree; flip the flag to `true` in a build to restore the whole company UI.

Also fixes an unrelated channels i18n bug surfaced while verifying.

## Changes
**Gate company-mode UI** (`src/shared/featureFlags.ts`, default `false`)
- Sidebar: hide the workspaces<->company toggle button + the CompanyPanel render
- Command palette: hide all "Company: ..." commands
- StatusBar: hide the company badge + cost readout (stays hidden even with a leftover persisted `sidebarMode === 'company'` from an older build)

**Channels i18n fix** (independent)
- Inject the live `t` from `useT` into the pure `ChannelsPanel` / `ChannelView` child views, which defaulted `t` to an identity function and surfaced raw keys (`CHANNELS.TITLE`, the empty-state message).

## Verification
- `tsc --noEmit` clean; targeted tests green (Sidebar company-mode + StatusBar + ChannelsPanel = 74 passed); lint 0 errors on changed files.
- Live dogfood (isolated dev instance, real OS clicks): no company badge, no sidebar toggle, palette search "company" -> "No results"; created a channel with no company active (DEFAULT_COMPANY_ID fallback); channel UI renders translated copy (no raw keys).

No VERSION bump here (per release-PR convention).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new app-wide mode flag that controls availability of company-related screens and commands.
  * Improved localization coverage for channel and panel text, including tooltips and empty-state messages.

* **Bug Fixes**
  * Company-related UI elements are now hidden when the mode is disabled.
  * Closing a workspace now more reliably cleans up open terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->