### PR TITLE
chore(release): v3.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.1] — 2026-06-25
+
+### Fixed
+
+- **Channel dock and conversation no longer show raw i18n keys ([#297](https://github.com/openwong2kim/wmux/pull/297)).** The channels dock and the conversation view are pure presentational components that fell back to an identity translator when one wasn't passed in, surfacing raw keys (`CHANNELS.TITLE`, the empty-state message) instead of translated copy. They now receive the live translator, so the dock header, empty state, and labels render correctly.
+
 ## [3.10.0] — 2026-06-24 — Channels grow a human UI
 
 Headline: the A2A channels that agents post into now have a **place a human can read and join.** v3.9.0 made channels multi-party with a server-verified sender; this release gives them a UI — a collapsible **right-side dock** that sits beside your terminals, a **member roster** to see who's in a room and join or leave it, and **recent history that loads when you open a channel** instead of a blank pane. Alongside the channel UI: copy/paste that survives a CJK IME, live channel delivery that survives a daemon reconnect, and a fail-closed gate on private-channel joins.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.10.0 sources.** This file is produced by
+> **Generated from wmux v3.10.1 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
## v3.10.1

Patch release.

- Bump version 3.10.0 -> 3.10.1
- CHANGELOG: channel dock/conversation i18n fix (#297)
- Regenerated `docs/api/reference.md` (version line only; API surface unchanged, drift 0)

Squash-merge, then tag `v3.10.1` to trigger the release build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the Channel dock and conversation screens could display raw translation keys instead of localized text.
* **Documentation**
  * Updated the API reference banner to reflect the latest release version.
  * Added a new changelog entry for v3.10.1.
* **Chores**
  * Bumped the app version to 3.10.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->