### PR TITLE
feat(mcp): resolve agent identity via server-side process-tree walk

### DIFF
--- a/plans/mcp-identity-shell-pid-anchor.md
+++ b/plans/mcp-identity-shell-pid-anchor.md
@@ -1,0 +1,83 @@
+# MCP 신원 REAL fix — pid-map 앵커를 셸 자기보고 PID로 교정
+
+> **레인:** L2 Core / Platform · **대체:** `proper-mcp-identity-server-side.md`(서버측-walk 설계는 라이브 데이터로 폐기 §10)
+> **선행:** WI-002(PR #299, Claude env+진단) · [[reference_mcp_env_propagation_split]]
+> **프로세스:** PLAN → ENGREVIEW(codex) → 구현 → REVIEW → DOGFOOD(라이브 Codex+Claude)
+> **준수:** [[no_claude_attribution]] · [[git_identity_openwong2kim]] · codex 게이트
+
+## 1. 근본 원인 (라이브 프로덕션 프로세스트리 직접 측정으로 확정)
+
+MCP 서버는 자기 pane을 **프로세스 트리 walk**(조상 중 pid-map 엔트리 찾기)로 해석. Codex는 env 스트립([[reference_mcp_env_propagation_split]])이라 walk가 유일 경로. **그런데 walk가 미스한다 — 진짜 이유:**
+
+**pid-map 앵커 PID가 에이전트의 셸 조상이 아니다.** 실측(사용자 라이브 dev wmux):
+- conhost 앵커(24412, 13308, pid-map에 있음) 부모 = electron(wmux). 실제 Codex 셸(49076, 29244 = `powershell.exe`, **pid-map 부재**) 부모도 electron. → **conhost와 셸이 형제(sibling).**
+- 즉 node-pty `ptyProcess.pid`가 **conhost.exe**를 가리키고, `PTYManager.writePidMap`/`pty.handler.writePidMap`이 그 conhost PID를 기록(`PTYManager.ts:200`·`pty.handler.ts:407,750`이 "셸 PID"로 가정·미검증). 에이전트(codex)는 **셸(powershell)에서 descend** → walk-up이 셸→electron으로 가며 **conhost(형제, 조상 아님)를 영원히 못 만남** → MISS → "identity unknown".
+- 부수: pid-map 87엔트리 중 4생존(prune 실패=stale 누적) + OS PID 재사용 = 유령 앵커.
+
+**핵심: walk의 위치(클라/서버)가 아니라 앵커가 틀렸다.** (그래서 peer-PID[네이티브애드온]도 서버측-walk도 무의미.)
+
+## 2. 설계 — 셸이 자기 `$PID`를 pid-map에 직접 앵커
+
+**핵심:** wmux가 이미 주입하는 셸 훅(`src/main/pty/shell-hooks/pwsh.ps1`·`bash.sh`)이 **셸 시작 시 셸 자신의 실제 PID를 pid-map에 기록.** 셸은 (a) 자기 `$PID`(=에이전트의 실제 조상) (b) `$WMUX_PTY_ID`(env, 셸은 가짐) (c) fs 접근(비샌드박스) 모두 보유 → conhost 모호성·node-pty quirk·에이전트 env-strip/샌드박스 전부 우회.
+
+```
+현행: wmux가 node-pty.pid(=conhost) 기록 → 에이전트 walk가 conhost(형제) 못 찾음 = MISS
+신규: 셸 훅이 $PID(=진짜 셸, 에이전트의 조상) 기록 → 에이전트 walk가 셸 hit
+```
+
+### 2.1 셸 측 (`pwsh.ps1`·`bash.sh`)
+- 시작 시(OSC133 init 옆): `WMUX_PTY_ID` 있으면 `{wmuxHome}/pid-map/{$PID}` = `$WMUX_PTY_ID` 기록. wmuxHome = `$USERPROFILE\.wmux{$WMUX_DATA_SUFFIX}` (셸이 USERPROFILE+SUFFIX 보유). best-effort(실패 무시), 1회.
+- cmd.exe는 훅 제약 → node-pty.pid 폴백 유지(cmd서 에이전트 희소).
+- **ENGREVIEW Q:** 셸이 직접 fs write vs OSC 이스케이프로 보고→wmux가 write(단일 writer). 권장=직접 write(단순), 단 경로/권한 검증.
+
+### 2.2 메인 측
+- node-pty.pid write **유지(폴백)** — daemon 모드선 셸 PID 맞을 수 있음(WI-002 dogfood서 walk hit). 셸 자기보고가 **추가** 앵커(둘 다 있으면 walk가 셸 hit). **ENGREVIEW Q:** node-pty.pid가 항상 conhost면 그 write는 유령 생성 → 제거? dev 클린 재현으로 confirm.
+- **stale-prune 수정(별개·동반):** removePidMapByPtyId 신뢰성 + read-path에서 죽은 PID 엔트리 정리(현 87엔트리 누적). a2a.rpc 읽기 시 live PID 아닌 엔트리 스킵(현행 일부) + 주기적 정리.
+
+### 2.3 검증 단계 (구현 1단계 = 데이터)
+- **dev 클린 재현:** 격리 dev(local+daemon 모드 각각) 신규 pane → pid-map 엔트리 PID가 conhost인가 셸(pwsh)인가 + 그 pane서 `codex`/자식 spawn → walk hit 확인. node-pty.pid 정체 확정 → §2.2 결정.
+
+## 3. 보안
+- 셸 자기보고 PID는 셸(비샌드박스, env 보유)이 자기 $PID 기록 = **위조 불가**(셸은 자기 PID만 앎). 외부 same-user가 임의 pid-map 엔트리 위조? 이미 same-user 천장(#113, pid-map dir owner-writable). 신규 약화 0. 채널 verified-senderPtyId는 이제 **올바른 셸 앵커로 walk hit** → Codex 채널 mutation 작동(현재 fail-closed→해결), 신뢰성 개선.
+- #163 터미널: 앵커 교정은 walk가 **올바른** workspace 해석 → assertWorkspaceOwnsPty 정상. 약화 없음.
+
+## 4. 엣지/회귀
+- daemon 모드(node-pty.pid=셸일 수 있음): 자기보고 추가는 무해(같은 ptyId, 같은/다른 PID 둘 다 hit). 회귀 0.
+- 셸 재시작/respawn: 훅 재실행→재기록(새 $PID). cleanup은 ptyId 매칭(content)이라 PID 무관 제거.
+- WMUX_PTY_ID 부재(CLI/비-wmux 셸): 훅 no-op(기록 안 함). 안전.
+- WI-002 env폴백/진단: 상호보완 유지(Claude 경로·진단 로깅).
+
+## 5. 테스트
+- 셸 훅 단위(pwsh.ps1·bash.sh): WMUX_PTY_ID 있을 때 pid-map write, 없을 때 no-op, 경로 조립. (`pwshHook.test.ts` 패턴.)
+- pidMap/a2a.resolve.identity: 셸-앵커 엔트리 해석 + stale 정리 회귀.
+- 회귀: 기존 walk/env/채널 provenance/#163/WI-002.
+
+## 6. DOGFOOD (라이브 — 진짜 게이트)
+`scripts/mcp-identity-anchor-dogfood.mjs`:
+1. 격리 dev wmux pane. 셸 훅이 $PID 기록 확인(pid-map 엔트리=셸 PID, conhost 아님).
+2. **그 pane서 실제 Codex 실행** → MCP가 walk로 셸 앵커 hit → 신원 해석 성공 → **채널 mutation 성공**(현재 실패→해결) 진단로그로 실증. (Codex MCP는 default pipe 연결=단일 dev 인스턴스면 OK.)
+3. Claude 동일 pane 회귀.
+4. before/after: 셸-자기보고 off(현행, Codex 미스) vs on(hit).
+5. **사용자 GUI 라이브**(Codex×2 채널) = ship 게이트([[no_ship_without_user_verification]]).
+
+## 7. 파일 영향 (예상)
+- `src/main/pty/shell-hooks/pwsh.ps1`·`bash.sh`(자기보고 1블록).
+- `src/main/pty/PTYManager.ts`·`ipc/handlers/pty.handler.ts`(node-pty.pid write 처분 — §2.2 confirm 후).
+- `src/main/pty/pidMap.ts`·`pipe/handlers/a2a.rpc.ts`(stale 정리 강화).
+- 신규 dogfood + 단위 테스트.
+- 무변경: terminalRouting(#163), channels provenance, company.*, WI-002 env폴백.
+
+## 8. NOT in scope
+서버측-walk/peer-PID/mcp.handshake(폐기). trust-root P1/P2. WI-002 제거.
+
+## ✅ 9b. ENGREVIEW (codex, 2026-06-27) — "Proceed, but revise" · 수정 LOCKED
+코어 셸-자기보고 설계 **승인**("right direction for interactive shell panes"). 구현 전 필수 수정:
+1. **★daemon 훅 추가:** 로컬 pane=`shell-hooks/pwsh.ps1·bash.sh`, **daemon pane=`src/daemon/shell-integration.ts`가 생성**(:29,117,328,346). **양쪽 다 self-report 추가**(안 그러면 daemon dogfood가 fix 미검증=프로덕션 미커버).
+2. **node-pty.pid 주장 완화:** codex가 node-pty 1.1.0 소스 확인—`WindowsTerminal._pid=_agent.innerPid`, ConPTY innerPid=native `connect().pid`=`CreateProcessW piClient.dwProcessId`=**셸이어야 정상**. → 프로덕션 conhost 앵커는 **재활용 PID(stale)**일 가능성(node-pty.pid=conhost 단정 아님). **confirm-first 게이트 필수.** node-pty.pid write는 **확인 전까지 유지**(cmd/unknown/exec의 유일 앵커).
+3. **★exec-pane 갭:** daemon exec(X8 `exec:codex`/supervised, DaemonSessionManager:274)는 OSC133 훅 스킵→self-report 없음. WMUX_PTY_ID는 받지만 Codex가 스트립→여전히 node-pty.pid 의존. **dogfood에 supervised codex 케이스 추가**, 미스 시 exec용 verified 앵커 유지 또는 self-report 셸 래핑(supervision 의미 변경 주의).
+4. **★stale-prune 동반(필수):** liveness만으론 재활용-live-PID 오라우팅 못 막음. **`writePidMap`이 먼저 `removePidMapByPtyId(ptyId)`**(같은 ptyId 옛 엔트리 삭제) + local `dispose`도 ptyId 제거 + resolver가 no-owner(렌더러 가용 시) 엔트리 삭제. read-path liveness는 additive.
+5. **보안 문구 정정:** "셸은 자기 PID만 기록"=거짓. same-user 셸코드는 임의 pid-map 파일명 기록 가능(신규 break 아님—`~/.wmux*/pid-map` 이미 same-user writable). plan은 "same-user 스푸핑 잔존" 명시. read서 ptyId 소유 검증+stale 정리로 우발 오라우팅 축소.
+
+**구현 디테일(codex):** write=hook load 시 1회, try/catch(`2>/dev/null||true`), **prompt 안에서 절대 실행 금지**(latency). PowerShell=Join-Path/따옴표(공백 경로 OK). Bash=Windows/Git Bash는 `$USERPROFILE`(있으면 `cygpath -u`), 없으면 `$HOME`; WSL≠Windows USERPROFILE 주의. OSC-보고 대안은 더 깨끗(셸측 path/suffix 로직 제거+단일 writer)하나 exec 갭은 동일—직접 write도 양쪽 훅+best-effort면 OK.
+
+**구현 1단계=confirm-first:** dev 클린 재현(local+daemon)으로 node-pty.pid 정체(conhost vs 셸) + 왜 셸 엔트리 부재(prune? recycle?) 확정 → §2.2/exec 결정.

--- a/plans/proper-mcp-identity-server-side.md
+++ b/plans/proper-mcp-identity-server-side.md
@@ -1,0 +1,118 @@
+# PROPER MCP 신원 fix — 서버측 프로세스-트리 상관 (handshake-PID)
+
+> **레인:** L2 Core / Platform · **로드맵:** W3 "MCP 신원 PROPER fix(mcp.handshake)" 당겨옴
+> **선행:** WI-002([[project_wi002_mcp_identity_quickfix]], PR #299) = Claude env 폴백+진단. 본 작업이 **진짜 멀티에이전트(Codex 포함) 해결책.**
+> **프로세스:** PLAN → ENGREVIEW(plan-eng-review + codex) → 구현 → REVIEW → DOGFOOD(라이브, Codex+Claude)
+> **준수:** [[no_claude_attribution]] · [[git_identity_openwong2kim]] · codex 게이트 · company.* 무변경
+
+---
+
+## 1. 문제 (라이브 규명 확정 — [[reference_mcp_env_propagation_split]])
+
+MCP 서버는 자기 pane/workspace를 (a)검증 PID-walk(`a2a.resolve.identity`→pid-map→**클라이언트측** getParentPid PowerShell 프로세스트리 walk) (b)`WMUX_WORKSPACE_ID` env힌트 로 해석. 라이브 실측:
+- **Claude = env FULL 전파** → (b)로 해석 가능(env 폴백=WI-002가 ptyId까지 커버).
+- **Codex = env 완전 스트립** → (b) 0. **walk(a) 전용.** + Codex가 MCP 서버를 **샌드박스**하면 클라이언트측 getParentPid의 PowerShell spawn 차단 → walk도 실패 → "Workspace identity unknown"(화면 라이브).
+
+**근본:** 신원 해석이 **클라이언트(MCP 자식) 측**에서 일어나 env(Codex 스트립)·자식 프로세스 권한(Codex 샌드박스)에 종속. **env·walk 양쪽 독립인 서버측 해석이 필요.**
+
+## 2. 설계 — handshake가 caller PID, main이 서버측 walk
+
+**핵심:** MCP 서버가 자기 `process.pid`를 RPC로 보내고, **main이 프로세스 트리를 서버측에서 walk**해 owning pane을 해석. env 불필요(PID=RPC), 샌드박스 무관(walk=main, 비샌드박스).
+
+```
+[현행 — 클라이언트측, Codex서 깨짐]
+  MCP child: getParentPid(PowerShell)×N hops  ←샌드박스 차단/env 스트립
+       └ a2a.resolve.identity → 전체 pid-map 반환 → 클라가 자기 트리 매칭
+
+[PROPER — 서버측]
+  MCP child: sendRpc('a2a.resolve.identity', { callerPid: process.pid })
+       main: Win32_Process 스냅샷 1회 → callerPid부터 위로 in-memory walk
+             → pid-map(PID→ptyId) 조상 매칭 → ptyId→live workspace(렌더러)
+             → 반환 { resolved: { workspaceId, ptyId } }
+  MCP: resolved 캐시(MY_WORKSPACE_ID/MY_PTY_ID), 이후 현행대로 사용
+```
+
+### 2.1 왜 peer-PID(GetNamedPipeClientProcessId) 아닌가 (issue-113 §3 근거)
+- Node에 peer-cred API 없음 → **네이티브 애드온**(N-API, platform×arch×abi prebuilt) 필요. 프로젝트 네이티브 애드온 0개 = 빌드/릴리스 카테고리 변경 = 고비용. **issue-113이 이미 defer.**
+- Windows TCP 폴백(항상 가동)은 peer-id 아예 없음 → 구조적 미커버.
+- → **handshake-PID(MCP가 자기 pid를 RPC로 전송)는 네이티브 애드온 회피** — pid가 기존 RPC 채널로 옴. main의 walk는 PowerShell(main은 비샌드박스, 가능).
+
+### 2.2 RPC: `a2a.resolve.identity` 확장 (신규 메서드 대신 — DRY)
+- optional `{ callerPid: number }`. 있으면 main이 서버측 walk 수행 → `resolved: {workspaceId, ptyId} | null` 추가 반환. 기존 `mappings`/`entries`는 verbatim(하위호환). **메서드명 불변 → firstParty 허용목록/methodCapabilityMap 무변경.**
+- 서버측 walk: `Win32_Process` 스냅샷 1회(전 프로세스 ParentProcessId) → callerPid부터 in-memory 상향 walk(depth cap) → pid-map 조상 매칭. (현행 클라 per-hop spawn보다 빠름.) 비동기(main UI 블록 금지).
+- 매칭 ptyId → 현행 `input.findOwnerWorkspace`(렌더러)로 live workspace 해석(재사용).
+
+### 2.3 MCP 소비 (`src/mcp/index.ts`)
+- `lookupPidMapWorkspace`/`resolveWorkspaceId`에서 **handshake(callerPid) 우선**: `resolved` 있으면 MY_WORKSPACE_ID/MY_PTY_ID 채우고 hit. 없으면(구 main) 현행 클라측 walk + env 폴백(WI-002)으로 graceful fallback. 1회 캐시.
+- 채널: MY_PTY_ID가 handshake로 채워지면 `getSenderPtyId`(verified-only)가 **walk-miss 시에도 유효** → 채널 mutation이 Codex서 작동(현재 fail-closed → 해결).
+
+## 3. 보안 (issue-113 trust 모델 정합)
+- **위조 callerPid:** 악성 same-user 클라가 victim의 pid 전송 → main이 victim workspace 해석 가능. 단 **same-user 천장(#113)**: 토큰 보유 same-user는 이미 legacy grandfather로 allow-all → 위조 pid는 **신규 경계 약화 0**(issue-113 §6 결론과 동일). 채널 verified-senderPtyId는 same-user 보안경계가 아니라 **신뢰성**(정당 caller가 신원 확보) 메커니즘.
+- **#163 터미널 라우팅:** 서버측 resolved ptyId도 `assertWorkspaceOwnsPty` 통과(현행 검증 유지). 약화 없음.
+- **connection-binding(소켓당 신원 고정) 보류:** issue-113이 same-user 신원검증=near-moot로 판정 → 추가 보안가치 marginal. 본 작업은 **신뢰성(reliability)** 해결만, 보안경계 불변. (P1 legacy 닫힘 + P2 per-identity 토큰 후에 재고.)
+
+## 4. ★OPEN 데이터 게이트 (DOGFOOD가 검증)
+**가정: Codex의 MCP 서버가 pane shell의 프로세스 조상인가?** Codex가 pane에서 `codex` 실행→MCP를 자식 spawn이면 `MCP→codex→pane shell` = 서버측 walk가 도달(✓). 단 Codex가 **백그라운드 데몬/detached로 MCP spawn**하면 조상 아님→서버측 walk도 미스(✗, 더 깊은 문제). **DOGFOOD에서 Codex를 dev pane에 띄워 서버측 walk 해석 확인이 1차 게이트.** (WI-002 진단로깅이 walk hit/miss/depth 노출.)
+- 보조 가정: 클라측 walk 실패 원인=Codex 샌드박스(H1). 서버측 walk가 우회. dogfood 확인.
+
+## 5. 엣지 케이스
+- **PID 재사용:** handshake는 startup 1회+캐시. walk 시점 스냅샷 일관. 재발급 workspace는 현행 `isLiveWorkspace`/invalidate로 self-heal(불변).
+- **구 main(resolved 미지원):** MCP가 `resolved` 부재→현행 walk+env 폴백. 하위호환.
+- **main getParentPid 비용:** Win32_Process 스냅샷 1회/handshake(캐시). async. POSIX는 `ps -eo pid,ppid` 1회.
+- **callerPid 부재/비정상:** main이 무시하고 기존 map 반환(현행 동작).
+- **렌더러 down(rpc-down):** handshake도 input.findOwnerWorkspace 필요 → 현행 grace/transient 처리 재사용.
+
+## 6. 테스트
+- 서버측 walk 순수 유닛: pid 트리 fixture + pid-map → resolved 매칭(hit/miss/depth-cap/순환방지). (electron-free 모듈로 추출.)
+- `a2a.resolve.identity.resolveIdentity.test.ts` 확장: callerPid 경로 회귀+신규.
+- mcp/index resolver: handshake 우선 + 폴백 순서 source-invariant(WI-002 패턴).
+- 회귀 0: 기존 클라측 walk/env/채널 provenance/#163.
+
+## 7. DOGFOOD (라이브)
+`scripts/proper-mcp-identity-dogfood.mjs`(신규):
+1. 격리 dev wmux(out/, 본 fix+WI-002 진단). pane 생성.
+2. **★Codex를 dev pane에 실행**(codex config `[mcp_servers.wmux] env={WMUX_SOCKET_PATH=dev,...}`로 dev 연결 — env 스트립 우회) → 서버측 handshake가 신원 해석함을 진단로그로 확인(클라 walk 미스여도 resolved hit). **채널 mutation 성공**(현재 fail-closed→해결) 실증.
+3. Claude도 동일 pane 테스트(회귀: 여전히 작동).
+4. before/after: handshake 비활성(현행 walk만, Codex 미스) vs 활성(resolved hit).
+5. 사용자 GUI 라이브 dogfood = ship 게이트([[no_ship_without_user_verification]]).
+
+## 8. NOT in scope
+- peer-PID/네이티브 애드온(issue-113 defer). connection-binding(보안 near-moot). company.*. WI-002 env폴백 제거(상호보완 유지). trust-root P1/P2(별개 에픽).
+
+## ✅ 11. CORRECTION (2026-06-27) — §10 진단이 틀린 pid-map을 읽음 → §2 서버측-walk RE-VALIDATED
+
+**§10은 결함 데이터다.** `.wmux/pid-map`(무접미사=패키지앱 app-3.3.0 stale, 87엔트리)을 읽었으나 라이브 Codex는 **`.wmux-dev` 인스턴스**(npm-start, electron `daemon-bundle`, 287엔트리). 올바른 `.wmux-dev/pid-map` 재측정:
+- **node-pty `ptyProcess.pid` = 셸(powershell.exe)** (격리 dev 클린 확인: 앵커 PID=powershell, conhost 아님). 앵커 메커니즘 **정상**.
+- **라이브 Codex 셸이 `.wmux-dev`에 정확히 앵커:** 49076→daemon-57454146, 29244→daemon-8904015f.
+- **재-walk: Codex MCP(39876)→codex(25020)→node(40452)→powershell(49076)=ANCHOR at depth 3.** 앵커가 조상체인에 있고 reachable. MCP는 자식 0(샌드박스 일치).
+
+**→ §10 "앵커 틀림" 결론 철회. 진짜 원인 = 앵커는 정확·reachable, 클라 walk가 depth-3까지 traverse 못함(Codex 샌드박스가 getParentPid PowerShell child spawn 차단; process.ppid는 depth1=codex만 무료, depth2/3는 PowerShell 필요).** `mcp-identity-shell-pid-anchor.md`(셸-자기보고)는 **무의미(앵커 이미 정확)→폐기.**
+
+**→ §2 서버측-walk가 정답으로 RE-VALIDATED:** main이 MCP pid부터 walk(비샌드박스, Win32_Process 스냅샷=`portWatch.ts:58` 재사용)→depth3 셸 앵커 hit→해석. codex 1차리뷰 게이트("MCP→codex→매핑 셸 PID 보이면 서버측 walk 타당") **충족.** codex 1차리뷰 반영: portWatch 스냅샷 재사용, handshake coalesce, callerPid=self-asserted-server-correlated 라벨, stale-prune 동반(287엔트리 누적→재활용 오라우팅). **다음=§2 구현(서버측 walk).**
+
+## ⛔ 10. (철회됨 — §11 참조) DATA INVALIDATES §2 DESIGN (2026-06-27, 틀린 pid-map `.wmux` 기준 — 무효)
+
+codex 플랜리뷰가 코어 가정(MCP가 pane shell의 자손이고 pid-map 앵커가 그 조상)을 미증명으로 **빌드 차단** 권고 → **사용자 프로덕션 실제 Codex 에이전트의 프로세스 트리를 서버측 직접 walk**(아무것도 안 띄움). 결과:
+
+- **실제 Codex×2(PID 25020, 8968): MCP 서버=`node dist/mcp/mcp/index.js`(codex 직계자식) 존재. 그러나 전체 조상체인(codex→node→powershell→electron→…→GONE)에 pid-map 앵커 0 = depth -1 MISS.** 서버측 walk도 동일하게 미스.
+- **pid-map=87엔트리 중 4 생존, 생존앵커=conhost.exe×2 / wmux.exe / TabTip.exe** = 앵커가 셸 PID 아님(conhost거나 재활용 PID). **stale 누적(prune 실패) + OS PID 재사용 = 유령**.
+- 생존 Codex 셸 PID(49076, 29244)는 pid-map 부재.
+
+**결론: walk(클라/서버 무관)가 미스하는 진짜 원인 = pid-map 앵커가 에이전트의 셸 조상이 아님**(node-pty `ptyProcess.pid`가 ConPTY서 conhost일 가능성 + stale/recycled). **§2 서버측-walk 설계는 틀린 문제를 품 — 폐기.**
+
+### ✅ REAL FIX 방향 (데이터 기반)
+**pid-map 앵커를 에이전트가 실제로 descend하는 셸 PID로** 교정:
+- **(권장) 셸 자기보고 앵커:** wmux가 이미 주입하는 셸 훅(OSC133 `pwsh.ps1`/`bash.sh`)이 셸 자신의 `$PID`+WMUX_PTY_ID를 wmux에 보고 → pid-map에 **진짜 셸 PID** 기록 → 에이전트(셸 자식)가 walk-up 시 확실히 hit. node-pty/conhost 모호성 우회.
+- **+ stale-accretion 수정:** prune 신뢰성(87엔트리 누적은 별개 버그).
+- (조사 필요) node-pty `ptyProcess.pid`가 ConPTY서 conhost인지 dev서 클린 확인.
+- 서버측 walk는 보조(여전히 클라 샌드박스 우회엔 유용하나, 앵커가 맞아야 의미).
+
+**상태: §2 폐기, REAL FIX는 별도 재-PLAN 필요(앵커 교정). 다음=dev서 node-pty pid 정체 확인 → 셸 자기보고 앵커 설계.**
+
+## 9. 파일 영향 (예상 — §2 기준, SUPERSEDED by §10)
+- `src/shared/rpc.ts`(a2a.resolve.identity 반환에 `resolved?` + callerPid 파라미터 doc).
+- `src/main/pipe/handlers/a2a.rpc.ts`(callerPid 시 서버측 walk).
+- 신규 `src/main/identity/serverSidePidWalk.ts`(+test, 순수 walk 로직).
+- `src/mcp/index.ts`(handshake 우선 + 폴백).
+- 신규 `scripts/proper-mcp-identity-dogfood.mjs`.
+- 무변경: firstParty/methodCapabilityMap(메서드명 불변), terminalRouting(#163), channels.ts/a2a.channel.rpc.ts(provenance), company.*.

--- a/scripts/proper-mcp-identity-dogfood.mjs
+++ b/scripts/proper-mcp-identity-dogfood.mjs
@@ -1,0 +1,228 @@
+/*
+ * Live dogfood — PROPER MCP identity fix (server-side process-tree walk).
+ *
+ * Proves the REAL packaged MCP server resolves its workspace identity from
+ * main's SERVER-SIDE walk even when BOTH client-side resolution paths are gone:
+ * the env hints are stripped (Codex behaviour) and — conceptually — the
+ * client-side per-hop walk is unavailable. main correlates the MCP's own pid
+ * (sent as `callerPid`) up the live process tree to the owning shell's pid-map
+ * anchor, on its UNSANDBOXED side, and hands identity straight back.
+ *
+ * Topology trick: we spawn the real mcp-bundle as a CHILD of this script, then
+ * anchor THIS SCRIPT's pid (the MCP's parent) in the isolated pid-map to the
+ * live pane's ptyId. That mirrors the production shape "MCP is a descendant of
+ * the pane's anchored shell" — server-walk: mcp.pid → script.pid(anchor) → pane.
+ * The MCP is launched with the env hints SCRUBBED, so a resolved identity can
+ * only have come from the server walk, confirmed by the `server-walk HIT` line
+ * in the MCP's stderr (the client walk logs a different `walk HIT`).
+ *
+ *   A. WITH anchor   → a2a_whoami resolves ws + pane ptyId; stderr: server-walk HIT.
+ *   B. WITHOUT anchor→ identity unknown (server miss + env stripped) — before/after.
+ *   C. CHANNEL       → with anchor, a channel mutation passes the verified-sender
+ *                      gate (fails only as CHANNEL_NOT_FOUND, never authz) — the
+ *                      Codex channels-work win (inverse of wi-002's weak-env case).
+ *
+ * NOTE: proves the CODE PATH on the real bundle + a REAL Win32_Process snapshot.
+ * Whether a live Codex's MCP is truly a descendant of the pane shell (§4 gate) is
+ * confirmed by the user GUI dogfood; the diagnostic logs expose hit/miss/depth.
+ *
+ * Run (PowerShell): npm run package; node scripts/proper-mcp-identity-dogfood.mjs
+ */
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '..');
+const APP_EXE = path.join(REPO_ROOT, 'out', 'wmux-win32-x64', 'wmux.exe');
+const MCP_BUNDLE = path.join(REPO_ROOT, 'out', 'wmux-win32-x64', 'resources', 'mcp-bundle', 'index.js');
+const USERNAME = os.userInfo().username || 'default';
+
+const results = [];
+let app = null;
+function check(name, ok, detail = '') {
+  results.push({ name, ok: !!ok });
+  console.log(`  [${ok ? 'PASS' : 'FAIL'}] ${name}${detail ? ` — ${detail}` : ''}`);
+  return ok;
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+if (process.platform !== 'win32') { console.log('proper-mcp-identity-dogfood: SKIP (win32-only)'); process.exit(0); }
+if (!fs.existsSync(APP_EXE)) { console.error(`packaged exe not found: ${APP_EXE} — run \`npm run package\` first`); process.exit(2); }
+if (!fs.existsSync(MCP_BUNDLE)) { console.error(`mcp bundle not found: ${MCP_BUNDLE} — run \`npm run package\` first`); process.exit(2); }
+
+const suffix = `-propdog${process.pid}`;
+const home = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-propdog-'));
+const isoEnv = {
+  ...process.env,
+  USERPROFILE: home, HOME: home,
+  APPDATA: path.join(home, 'AppData', 'Roaming'),
+  LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
+  WMUX_DATA_SUFFIX: suffix, WMUX_NO_DIALOG: '1',
+};
+delete isoEnv.HOMEDRIVE; delete isoEnv.HOMEPATH;
+for (const k of Object.keys(isoEnv)) { if (/^WMUX_(WORKSPACE_ID|PTY_ID|SURFACE_ID|SOCKET_PATH)$/i.test(k)) delete isoEnv[k]; }
+fs.mkdirSync(isoEnv.APPDATA, { recursive: true });
+fs.mkdirSync(isoEnv.LOCALAPPDATA, { recursive: true });
+const userDataDir = path.join(isoEnv.APPDATA, `wmux${suffix}`);
+fs.mkdirSync(userDataDir, { recursive: true });
+fs.writeFileSync(path.join(userDataDir, '.first-run'), new Date().toISOString(), 'utf8');
+
+// getPidMapDir() == `${USERPROFILE}/.wmux${SUFFIX}/pid-map` (shared/constants.ts).
+const pidMapDir = path.join(home, `.wmux${suffix}`, 'pid-map');
+const anchorFile = path.join(pidMapDir, String(process.pid)); // script pid = MCP's parent
+function writeAnchor(ptyId) { fs.mkdirSync(pidMapDir, { recursive: true }); fs.writeFileSync(anchorFile, ptyId, 'utf8'); }
+function removeAnchor() { try { fs.unlinkSync(anchorFile); } catch { /* */ } }
+
+const mainPipe = `\\\\.\\pipe\\wmux${suffix}-${USERNAME}`;
+const authTokenPath = path.join(home, `.wmux${suffix}-auth-token`);
+function readMainToken() { try { return fs.readFileSync(authTokenPath, 'utf8').trim() || null; } catch { return null; } }
+let TOKEN = null;
+
+function rpcCall(method, params = {}, { timeoutMs = 8000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const sock = net.createConnection(mainPipe);
+    let buf = ''; let settled = false; const id = randomUUID();
+    const finish = (fn) => { if (settled) return; settled = true; clearTimeout(timer); try { sock.destroy(); } catch { /* */ } fn(); };
+    const timer = setTimeout(() => finish(() => reject(new Error(`rpc timeout: ${method}`))), timeoutMs);
+    sock.setEncoding('utf8');
+    sock.once('connect', () => sock.write(JSON.stringify({ id, method, params, token: TOKEN }) + '\n'));
+    sock.once('error', (e) => finish(() => reject(e)));
+    sock.on('data', (chunk) => {
+      buf += chunk; let nl;
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl).trim(); buf = buf.slice(nl + 1);
+        if (!line) continue;
+        let msg; try { msg = JSON.parse(line); } catch { continue; }
+        if (msg.id !== id) continue;
+        finish(() => resolve(msg));
+        return;
+      }
+    });
+  });
+}
+const rpcResult = async (m, p, o) => { const r = await rpcCall(m, p, o); if (r && r.ok === false) throw new Error(typeof r.error === 'string' ? r.error : JSON.stringify(r.error)); return r?.result ?? r; };
+
+function spawnApp() {
+  const proc = spawn(APP_EXE, [], { cwd: REPO_ROOT, env: isoEnv, stdio: ['ignore', 'pipe', 'pipe'], detached: false });
+  proc.stdout.on('data', () => {}); proc.stderr.on('data', () => {});
+  return proc;
+}
+async function waitMainToken(timeoutMs) {
+  const dl = Date.now() + timeoutMs;
+  while (Date.now() < dl) { const t = readMainToken(); if (t) return t; await sleep(120); }
+  return null;
+}
+async function waitRendererReady(timeoutMs) {
+  const dl = Date.now() + timeoutMs; let last = '';
+  while (Date.now() < dl) {
+    try { const r = await rpcCall('workspace.list', {}, { timeoutMs: 4000 }); if (r && Array.isArray(r.result)) return r.result; }
+    catch (e) { last = e.message; }
+    await sleep(250);
+  }
+  throw new Error(`renderer not ready (${last})`);
+}
+
+/**
+ * Spawn the REAL packaged MCP server as a CHILD of this script (so its parent is
+ * process.pid — the pid we anchor), do the MCP stdio handshake, call one tool,
+ * and return { result, stderr }. `identityEnv` is intentionally minimal — the
+ * env hints stay scrubbed so only the server-side walk can resolve identity.
+ */
+function mcpToolCall(toolName, args, identityEnv = {}, { timeoutMs = 45000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const env = { ...isoEnv, WMUX_SOCKET_PATH: mainPipe, ...identityEnv };
+    const child = spawn(process.execPath, [MCP_BUNDLE], { cwd: REPO_ROOT, env, stdio: ['pipe', 'pipe', 'pipe'] });
+    let outBuf = ''; let errBuf = ''; let settled = false;
+    const finish = (fn) => { if (settled) return; settled = true; clearTimeout(timer); try { child.kill(); } catch { /* */ } fn(); };
+    const timer = setTimeout(() => finish(() => reject(new Error(`mcp timeout: ${toolName}\nstderr:\n${errBuf}`))), timeoutMs);
+    child.stderr.on('data', (d) => { errBuf += d.toString(); });
+    child.on('error', (e) => finish(() => reject(e)));
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      outBuf += chunk; let nl;
+      while ((nl = outBuf.indexOf('\n')) !== -1) {
+        const line = outBuf.slice(0, nl).trim(); outBuf = outBuf.slice(nl + 1);
+        if (!line) continue;
+        let msg; try { msg = JSON.parse(line); } catch { continue; }
+        if (msg.id === 2) { finish(() => resolve({ result: msg.result, error: msg.error, stderr: errBuf })); return; }
+      }
+    });
+    const send = (o) => child.stdin.write(JSON.stringify(o) + '\n');
+    send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'propdog', version: '1.0.0' } } });
+    send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+    send({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: toolName, arguments: args } });
+  });
+}
+const toolText = (res) => (typeof res?.result?.content?.[0]?.text === 'string' ? res.result.content[0].text : '');
+
+async function main() {
+  console.log(`proper-mcp-identity-dogfood — exe=${APP_EXE}\n  pidMapDir=${pidMapDir}\n  anchor(script.pid)=${process.pid}`);
+  app = spawnApp();
+  TOKEN = await waitMainToken(20000);
+  if (!TOKEN) throw new Error('main token never appeared');
+  const wss = await waitRendererReady(30000);
+  check('renderer ready + default workspace exists', wss.length >= 1, `workspaces=${wss.length}`);
+  const ws1 = wss[0].id;
+
+  await sleep(1200);
+  const surfaces = (await rpcResult('surface.list', { workspaceId: ws1 })).filter((s) => s.surfaceType !== 'browser' && s.ptyId);
+  check('default workspace has a terminal pane', surfaces.length >= 1, `surfaces=${surfaces.length}`);
+  if (surfaces.length < 1) throw new Error('need a pane to anchor identity against');
+  const panePtyId = surfaces[0].ptyId;
+  console.log(`  pane ptyId = ${panePtyId}, ws = ${ws1}`);
+
+  // ── A. WITH anchor — the server-side walk resolves identity (env scrubbed) ──
+  writeAnchor(panePtyId);
+  const withA = await mcpToolCall('a2a_whoami', {});
+  const withText = toolText(withA);
+  console.log(`  [A] whoami(text)=${withText.slice(0, 240)}`);
+  check('★ A: a2a_whoami resolves the pane ptyId via the SERVER-SIDE walk (no env)',
+    withText.includes(panePtyId), `expected ptyId ${panePtyId} in whoami`);
+  check('A: whoami resolves the workspace too', withText.includes(ws1), `expected ws ${ws1}`);
+  check('A: stderr proves the SERVER path fired (server-walk HIT, not client walk/env)',
+    /server-walk HIT/.test(withA.stderr), withA.stderr.split('\n').filter((l) => /identity:/.test(l)).join(' | ').slice(0, 240));
+
+  // ── B. WITHOUT anchor — server miss + env stripped → identity unknown ──
+  removeAnchor();
+  const noA = await mcpToolCall('a2a_whoami', {});
+  const noText = toolText(noA);
+  console.log(`  [B] whoami(text)=${noText.slice(0, 240)}`);
+  check('★ B: without the anchor the pane ptyId is NOT recovered (before/after delta)',
+    !noText.includes(panePtyId), 'ptyId must be absent when no ancestor is anchored and env is stripped');
+  check('B: stderr shows env stripped (WMUX_PTY_ID=absent)', /WMUX_PTY_ID=absent/.test(noA.stderr), '');
+
+  // ── C. CHANNEL — verified server-walk identity unlocks the channel gate ──
+  // channel_post fails closed without a VERIFIED senderPtyId. With the anchor,
+  // server-walk supplies one (MY_PTY_ID), so the gate PASSES and the only
+  // remaining failure is the missing channel — never an authz/sender rejection.
+  writeAnchor(panePtyId);
+  const chan = await mcpToolCall('channel_post', { channel_id: 'nonexistent', text: 'hi', member_id: 'm1', member_name: 'M1' });
+  const chanText = toolText(chan);
+  console.log(`  [C] channel_post(text)=${chanText.slice(0, 200)} isError=${chan.result?.isError}`);
+  const authzRejected = /NOT_AUTHORIZED|verifiable caller|no resolvable senderPtyId|identity unknown|cannot determine/i.test(chanText);
+  const gatePassed = !authzRejected; // not-found / other is fine — the sender gate let us through
+  check('★ C: verified server-walk identity passes the channel sender gate (Codex channels work)',
+    gatePassed, `must NOT be an authz/sender rejection; got: ${chanText.slice(0, 160)}`);
+  check('C: stderr proves identity came from the server walk', /server-walk HIT/.test(chan.stderr), '');
+}
+
+main()
+  .catch((e) => { console.error('FATAL', e); check('harness completed without fatal error', false, e.message); })
+  .finally(async () => {
+    try { await rpcResult('daemon.shutdown', {}).catch(() => {}); } catch { /* */ }
+    // Windows: app.kill() terminates only the main process — the Electron helper
+    // tree + bundled daemon survive and lock the temp home. Tree-kill so repeated
+    // dogfood runs don't accumulate zombies (daemon.shutdown above handles the
+    // detached daemon; this sweeps main + helpers).
+    try { if (app?.pid) spawnSync('taskkill', ['/PID', String(app.pid), '/T', '/F'], { stdio: 'ignore' }); } catch { /* */ }
+    await sleep(800);
+    try { fs.rmSync(home, { recursive: true, force: true }); } catch { /* */ }
+    const passed = results.filter((r) => r.ok).length;
+    console.log(`\nproper-mcp-identity-dogfood: ${passed}/${results.length} passed`);
+    process.exit(passed === results.length && results.length > 0 ? 0 : 1);
+  });

--- a/src/main/pipe/handlers/__tests__/a2a.rpc.resolveIdentity.test.ts
+++ b/src/main/pipe/handlers/__tests__/a2a.rpc.resolveIdentity.test.ts
@@ -196,3 +196,156 @@ describe('a2a.resolve.identity — live ownership resolution', () => {
     expect((res as { result: { entries: unknown } }).result.entries).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// PROPER fix — server-side process-tree walk (callerPid) + snapshot-backed prune
+// ---------------------------------------------------------------------------
+
+type ResolveResult = {
+  mappings: Record<string, string>;
+  entries: Array<{ pid: string; ptyId: string; workspaceId: string }>;
+  resolved: { workspaceId: string; ptyId: string } | null;
+};
+
+// Inject a fake process snapshot so the walk + prune run without spawning the
+// real Win32_Process PowerShell. `listeners` is irrelevant to identity.
+function setupRouterWithSnapshot(ppidByPid: Map<number, number>): RpcRouter {
+  const router = new RpcRouter();
+  registerA2aRpc(router, () => fakeWindow, makeWorker(), {
+    snapshot: async () => ({ ppidByPid, listeners: [] }),
+  });
+  return router;
+}
+
+async function dispatchResolve(router: RpcRouter, params: Record<string, unknown>): Promise<ResolveResult> {
+  const res = await router.dispatch({ id: 'rp', method: 'a2a.resolve.identity', params });
+  expect(res.ok).toBe(true);
+  return (res as { result: ResolveResult }).result;
+}
+
+describe('a2a.resolve.identity — server-side walk (callerPid)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dirRef.current = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-pidmap-walk-'));
+  });
+  afterEach(() => {
+    try { fs.rmSync(dirRef.current, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  it('walks callerPid up the tree to the owning shell anchor and returns resolved', async () => {
+    // Measured live shape: Codex MCP(39876) → codex(25020) → node(40452) → shell(49076).
+    fs.writeFileSync(path.join(dirRef.current, '49076'), 'daemon-shell');
+    sendToRendererMock.mockImplementation(
+      (_w: unknown, method: string, p: { ptyId: string }) =>
+        Promise.resolve({
+          workspaceId: method === 'input.findOwnerWorkspace' && p.ptyId === 'daemon-shell' ? 'ws-live' : null,
+        }),
+    );
+    const ppidByPid = new Map<number, number>([
+      [39876, 25020], [25020, 40452], [40452, 49076], [49076, 57454],
+    ]);
+
+    const result = await dispatchResolve(setupRouterWithSnapshot(ppidByPid), { callerPid: 39876 });
+
+    expect(result.resolved).toEqual({ workspaceId: 'ws-live', ptyId: 'daemon-shell' });
+    // entries still surfaced verbatim (legacy client-walk fallback stays intact)
+    expect(result.entries).toEqual([{ pid: '49076', ptyId: 'daemon-shell', workspaceId: 'ws-live' }]);
+  });
+
+  it('returns resolved=null when the callerPid chain reaches no anchor', async () => {
+    fs.writeFileSync(path.join(dirRef.current, '49076'), 'daemon-shell');
+    sendToRendererMock.mockResolvedValue({ workspaceId: 'ws-live' });
+    // 49076 is live (in snapshot) but NOT on the caller's chain → walk misses it.
+    const ppidByPid = new Map<number, number>([[11111, 22222], [22222, 1], [49076, 57454]]);
+
+    const result = await dispatchResolve(setupRouterWithSnapshot(ppidByPid), { callerPid: 11111 });
+
+    expect(result.resolved).toBeNull();
+    expect(result.entries).toEqual([{ pid: '49076', ptyId: 'daemon-shell', workspaceId: 'ws-live' }]);
+  });
+
+  it('omits resolved (null) for a legacy call with no callerPid — and takes no snapshot', async () => {
+    fs.writeFileSync(path.join(dirRef.current, '70'), 'daemon-pane');
+    sendToRendererMock.mockResolvedValue({ workspaceId: 'ws-X' });
+
+    // setupRouter() wires the REAL defaultSnapshot; the absent callerPid must
+    // mean getProcessSnapshot is never reached (no PowerShell spawn in this test).
+    const result = await dispatchResolve(setupRouter(), {});
+
+    expect(result.resolved).toBeNull();
+    expect(result.mappings).toEqual({ '70': 'ws-X' });
+  });
+
+  it('takes a fresh snapshot when the coalesced one predates the caller (missing callerPid)', async () => {
+    // A coalesced snapshot triggered by an EARLIER burst handshake can predate
+    // this caller, so callerPid is absent from it → the walk would silently miss.
+    // The handler must then take one fresh snapshot that does contain it.
+    fs.writeFileSync(path.join(dirRef.current, '49076'), 'daemon-shell');
+    sendToRendererMock.mockResolvedValue({ workspaceId: 'ws-live' });
+    let calls = 0;
+    const stale = new Map<number, number>([[12345, 1]]); // lacks callerPid 39876
+    const fresh = new Map<number, number>([[39876, 25020], [25020, 49076], [49076, 57454]]);
+    const router = new RpcRouter();
+    registerA2aRpc(router, () => fakeWindow, makeWorker(), {
+      snapshot: async () => ({ ppidByPid: calls++ === 0 ? stale : fresh, listeners: [] }),
+    });
+
+    const result = await dispatchResolve(router, { callerPid: 39876 });
+
+    expect(calls).toBe(2); // coalesced (stale, missing callerPid) → one fresh refresh
+    expect(result.resolved).toEqual({ workspaceId: 'ws-live', ptyId: 'daemon-shell' });
+  });
+
+  it('does NOT retry a failed snapshot before fallback (graceful degradation, single attempt)', async () => {
+    // A failed snapshot must not trigger a second ~8s attempt: stacked timeouts
+    // would blow past the client RPC deadline and lose even the legacy mappings.
+    fs.writeFileSync(path.join(dirRef.current, '49076'), 'daemon-shell');
+    sendToRendererMock.mockResolvedValue({ workspaceId: 'ws-live' });
+    let calls = 0;
+    const router = new RpcRouter();
+    registerA2aRpc(router, () => fakeWindow, makeWorker(), {
+      snapshot: async () => { calls++; throw new Error('powershell unavailable'); },
+    });
+
+    const result = await dispatchResolve(router, { callerPid: 39876 });
+
+    expect(calls).toBe(1);                                   // failed snapshot → NO retry
+    expect(result.resolved).toBeNull();                      // no server walk
+    expect(result.mappings).toEqual({ '49076': 'ws-live' }); // legacy fallback preserved
+  });
+
+  it('skips the snapshot wait when there are no live anchors (empty-map → no stall)', async () => {
+    // The walk can never hit with zero entries, so the handler must NOT block on
+    // the snapshot. We feed a snapshot that never resolves: if it were awaited,
+    // dispatchResolve would hang; completing fast proves the skip.
+    fs.writeFileSync(path.join(dirRef.current, '49076'), 'daemon-shell');
+    sendToRendererMock.mockResolvedValue({ workspaceId: null }); // → no live entries
+    let releaseSnap!: () => void;
+    const hung = new Promise<{ ppidByPid: Map<number, number>; listeners: [] }>((r) => {
+      releaseSnap = () => r({ ppidByPid: new Map(), listeners: [] });
+    });
+    const router = new RpcRouter();
+    registerA2aRpc(router, () => fakeWindow, makeWorker(), { snapshot: () => hung });
+
+    const result = await dispatchResolve(router, { callerPid: 39876 });
+
+    expect(result.resolved).toBeNull();
+    expect(result.entries).toEqual([]);
+    expect(result.mappings).toEqual({});
+    releaseSnap(); // release the floated snapshot so nothing dangles
+    await hung;
+  });
+
+  it('never matches callerPid itself — a recycled-PID collision must not mis-route', async () => {
+    // The MCP's OWN pid (49076) collides with a still-live anchor (the OS recycled
+    // an old shell's number onto this MCP). Walking from the caller would wrongly
+    // resolve to that pane; starting at the parent must not.
+    fs.writeFileSync(path.join(dirRef.current, '49076'), 'daemon-shell');
+    sendToRendererMock.mockResolvedValue({ workspaceId: 'ws-live' });
+    const ppidByPid = new Map<number, number>([[49076, 50000], [50000, 1]]); // parent chain unanchored
+
+    const result = await dispatchResolve(setupRouterWithSnapshot(ppidByPid), { callerPid: 49076 });
+
+    expect(result.resolved).toBeNull(); // self-pid is never treated as our own anchor
+  });
+});

--- a/src/main/pipe/handlers/a2a.rpc.ts
+++ b/src/main/pipe/handlers/a2a.rpc.ts
@@ -4,10 +4,84 @@ import { sendToRenderer } from './_bridge';
 import type { ClaudeWorker } from '../../a2a/ClaudeWorker';
 import * as fs from 'fs';
 import { getPidMapDir } from '../../../shared/constants';
+import { defaultSnapshot } from '../../pty/portWatch';
+import type { PortSnapshot, SnapshotFn } from '../../pty/portWatch';
+import { walkToOwningAnchor } from '../../pty/serverSidePidWalk';
+import type { OwningAnchor } from '../../pty/serverSidePidWalk';
 
 type GetWindow = () => BrowserWindow | null;
 
-export function registerA2aRpc(router: RpcRouter, getWindow: GetWindow, claudeWorker: ClaudeWorker): void {
+/** Validate an RPC-supplied caller pid. Anything non-positive / non-integer is
+ *  ignored (older MCP build, or junk) → the handler keeps its legacy behavior. */
+function normalizeCallerPid(raw: unknown): number | null {
+  return typeof raw === 'number' && Number.isInteger(raw) && raw > 0 ? raw : null;
+}
+
+/** Resolve `p`, but never wait longer than `ms` — on timeout resolve `fallback`.
+ *  Keeps a slow process snapshot from blocking (past the client's RPC deadline)
+ *  the legacy identity fallback the handler still wants to return. */
+function withDeadline<T>(p: Promise<T>, ms: number, fallback: T): Promise<T> {
+  if (ms <= 0) return Promise.resolve(fallback);
+  return new Promise<T>((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => { if (!settled) { settled = true; resolve(fallback); } }, ms);
+    const finish = (v: T) => { if (!settled) { settled = true; clearTimeout(timer); resolve(v); } };
+    p.then(finish, () => finish(fallback));
+  });
+}
+
+/** Soft cap for the whole resolve.identity call, under the MCP client's ~10s RPC
+ *  timeout. The snapshot wait is bounded to whatever remains after the pid-map
+ *  scan so a hung Win32_Process query can't sink the legacy fallback response. */
+const RPC_SNAPSHOT_DEADLINE_MS = 8000;
+
+export function registerA2aRpc(
+  router: RpcRouter,
+  getWindow: GetWindow,
+  claudeWorker: ClaudeWorker,
+  opts: { snapshot?: SnapshotFn } = {},
+): void {
+  // Server-side process-tree snapshot for handshake identity resolution. Shared
+  // across CONCURRENT handshakes (in-flight coalescing) so the multi-agent launch
+  // burst triggers ONE Win32_Process spawn, not one per agent. The MCP side
+  // caches a resolved identity, so a successful handshake never re-fires; only
+  // the miss/fallback path re-snaps.
+  const snapshotFn: SnapshotFn = opts.snapshot ?? defaultSnapshot;
+  let snapInflight: Promise<PortSnapshot> | null = null;
+  async function getCoalescedSnapshot(): Promise<PortSnapshot | null> {
+    if (!snapInflight) {
+      snapInflight = snapshotFn().finally(() => { snapInflight = null; });
+    }
+    try {
+      return await snapInflight;
+    } catch {
+      return null; // PowerShell missing / denied → no server walk
+    }
+  }
+  // Return a process table guaranteed to contain `callerPid` (or null). A
+  // coalesced snapshot can PREDATE this caller — an earlier handshake in the same
+  // burst triggered it before this MCP's process existed — so our pid and our
+  // ancestry may be absent, silently missing the walk. When the shared table
+  // lacks callerPid, take ONE fresh snapshot. A single refresh is enough; a pid
+  // still absent afterwards is a genuine miss (caller detached / exited), not a
+  // staleness artifact.
+  async function snapshotForCaller(callerPid: number): Promise<PortSnapshot | null> {
+    const shared = await getCoalescedSnapshot();
+    // Snapshot FAILED (PowerShell/CIM unavailable or slow) — do NOT retry: a
+    // second attempt could stack two ~8s timeouts and blow past the client's RPC
+    // deadline, costing the caller even the legacy/client-walk/env fallback
+    // mappings. Degrade gracefully (no server walk; mappings/entries still
+    // returned). Refresh ONLY when the table succeeded but predates this caller.
+    if (!shared) return null;
+    if (shared.ppidByPid.has(callerPid)) return shared;
+    // Stale: this snapshot predates our process. Re-COALESCE rather than spawn
+    // directly — the first batch's inflight promise already cleared, so this
+    // joins/forms a SECOND shared snapshot with the burst's other late arrivers
+    // instead of one PowerShell spawn per caller. A callerPid still absent after
+    // that is a genuine miss the walk handles (parent undefined → null).
+    return getCoalescedSnapshot();
+  }
+
   // a2a.resolve.identity — handled in main process (not renderer).
   // Returns PID → CURRENT workspaceId mappings so an MCP server can resolve
   // which workspace it belongs to by walking its own process tree.
@@ -18,7 +92,33 @@ export function registerA2aRpc(router: RpcRouter, getWindow: GetWindow, claudeWo
   // restore while the shell process (and its frozen WMUX_WORKSPACE_ID env)
   // lives on. Storing the workspace id at create time and trusting it forever
   // is exactly what produced stale identities ("no workspace found for ws-…").
-  router.register('a2a.resolve.identity', async () => {
+  router.register('a2a.resolve.identity', async (params) => {
+    // PROPER multi-agent fix: a caller that can't walk its own process tree —
+    // Codex sandboxes the per-hop PowerShell spawn and strips the env hints —
+    // sends its OWN pid as `callerPid`. We then walk the tree HERE (main, where
+    // the snapshot is unsandboxed) from that pid up to the owning shell's
+    // pid-map anchor and return the resolved identity directly. Absent callerPid
+    // keeps the legacy contract verbatim (the client walks the returned map), so
+    // older MCP builds are unaffected.
+    //
+    // SECURITY: callerPid is caller-asserted (the pipe does not bind the
+    // connection to a pid), so a same-user caller could pass a foreign pid to
+    // resolve another pane's identity. That stays within the #113 same-user
+    // ceiling — a caller holding the pipe token is already grandfathered
+    // allow-all — so this is a reliability mechanism, not a new security boundary.
+    const callerPid = normalizeCallerPid((params as { callerPid?: unknown }).callerPid);
+    // Start the snapshot CONCURRENTLY and bound the wait (at the walk below) to the
+    // RPC budget: it feeds only the final walk, so it must never delay — or, past
+    // the client's ~10s RPC deadline, SINK — the legacy mappings/entries fallback
+    // this handler returns. Overlapping the pid-map scan + renderer resolves hides
+    // its latency in the common case; the deadline caps the degraded one
+    // (PowerShell/CIM hung → up to two 8s timeouts inside snapshotForCaller).
+    // Started only when a caller asked for server-side resolution (legacy calls
+    // pay nothing); resolves to a table containing callerPid, or null.
+    const startedAt = Date.now();
+    const snapshotPromise: Promise<PortSnapshot | null> =
+      callerPid != null ? snapshotForCaller(callerPid) : Promise.resolve(null);
+
     const dir = getPidMapDir();
     const mappings: Record<string, string> = {};
     // Additive (X4 CLI): per-PID detail including the immutable ptyId anchor,
@@ -27,7 +127,7 @@ export function registerA2aRpc(router: RpcRouter, getWindow: GetWindow, claudeWo
     // for existing MCP clients.
     const entries: Array<{ pid: string; ptyId: string; workspaceId: string }> = [];
     try {
-      if (!fs.existsSync(dir)) return { mappings, entries };
+      if (!fs.existsSync(dir)) return { mappings, entries, resolved: null };
 
       for (const file of fs.readdirSync(dir)) {
         let value: string;
@@ -73,8 +173,9 @@ export function registerA2aRpc(router: RpcRouter, getWindow: GetWindow, claudeWo
         // null here and is correctly excluded — so a stale current-format file
         // can never produce a ghost and is harmless if left on disk. Accretion
         // is bounded instead at the write boundary (see pty.handler.ts
-        // onDaemonSessionDied cleanup); pruning here would add a destructive
-        // tasklist probe to the hot path with no correctness benefit.
+        // onDaemonSessionDied cleanup); a read-path prune is deliberately out of
+        // scope — a snapshot-only liveness signal can be incomplete and would
+        // risk deleting a LIVE pane's anchor (3-way review consensus).
         try {
           const owner = await sendToRenderer(getWindow, 'input.findOwnerWorkspace', { ptyId: value });
           const wsId =
@@ -91,7 +192,48 @@ export function registerA2aRpc(router: RpcRouter, getWindow: GetWindow, claudeWo
         }
       }
     } catch { /* best-effort: identity resolution is non-critical */ }
-    return { mappings, entries };
+
+    // Server-side walk: from callerPid's PARENT up the live tree to the first
+    // ancestor that is a known live anchor. `entries` is already the set of LIVE
+    // PID→ptyId→workspace anchors resolved above, so the walk reuses it — no
+    // second pid-map read, and dead/recycled anchors are excluded by construction.
+    //
+    // We start at the PARENT, never callerPid itself: the MCP is never its own
+    // pane's shell, and matching its own pid could hit a recycled-PID anchor (an
+    // old shell's pid-map file whose number the OS reassigned to this MCP) and
+    // mis-route to a stranger workspace. The client-side walk avoids this the same
+    // way — it starts at process.ppid.
+    // The snapshot feeds ONLY the walk, and the walk can only hit if there is at
+    // least one live anchor. With no entries (empty dir / boot-respawn window /
+    // renderer gave no owners) skip the snapshot wait entirely — awaiting a
+    // slow/hung snapshot to walk an empty anchor set would stall the empty-map
+    // fallback for nothing (and terminal routing's empty-map grace loop would
+    // multiply it). The concurrently-started snapshot just resolves and is dropped
+    // (coalesced, so a boot burst shares one).
+    let resolved: { workspaceId: string; ptyId: string } | null = null;
+    if (callerPid != null && entries.length > 0) {
+      const snapshot = await withDeadline(
+        snapshotPromise,
+        RPC_SNAPSHOT_DEADLINE_MS - (Date.now() - startedAt),
+        null,
+      );
+      if (snapshot) {
+        const anchorByPid = new Map<number, OwningAnchor>();
+        for (const e of entries) {
+          const pid = Number(e.pid);
+          if (Number.isInteger(pid) && pid > 0) {
+            anchorByPid.set(pid, { ptyId: e.ptyId, workspaceId: e.workspaceId });
+          }
+        }
+        const parentPid = snapshot.ppidByPid.get(callerPid);
+        const hit = parentPid !== undefined
+          ? walkToOwningAnchor(parentPid, snapshot.ppidByPid, anchorByPid)
+          : null;
+        if (hit) resolved = { workspaceId: hit.anchor.workspaceId, ptyId: hit.anchor.ptyId };
+      }
+    }
+
+    return { mappings, entries, resolved };
   });
 
   // A2A protocol — passthrough to renderer

--- a/src/main/pty/__tests__/serverSidePidWalk.test.ts
+++ b/src/main/pty/__tests__/serverSidePidWalk.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { walkToOwningAnchor, type OwningAnchor } from '../serverSidePidWalk';
+
+function anchors(entries: Record<number, OwningAnchor>): Map<number, OwningAnchor> {
+  return new Map(Object.entries(entries).map(([pid, a]) => [Number(pid), a]));
+}
+function ppids(entries: Record<number, number>): Map<number, number> {
+  return new Map(Object.entries(entries).map(([pid, ppid]) => [Number(pid), ppid]));
+}
+const SHELL: OwningAnchor = { ptyId: 'daemon-shell', workspaceId: 'ws-live' };
+
+describe('walkToOwningAnchor — server-side ancestor walk', () => {
+  it('resolves a Codex chain MCP→codex→node→shell to the shell anchor (the live measured shape)', () => {
+    // Measured live (.wmux-dev): Codex MCP(39876) → codex(25020) → node(40452)
+    // → powershell shell(49076) which the pid-map anchors to a live pane.
+    const ppidByPid = ppids({ 39876: 25020, 25020: 40452, 40452: 49076, 49076: 57454 });
+    const anchorByPid = anchors({ 49076: SHELL });
+
+    const hit = walkToOwningAnchor(39876, ppidByPid, anchorByPid);
+
+    expect(hit).toEqual({ anchor: SHELL, pid: 49076, depth: 3 });
+  });
+
+  it('hits at depth 0 when startPid is itself an anchor', () => {
+    const hit = walkToOwningAnchor(49076, ppids({ 49076: 57454 }), anchors({ 49076: SHELL }));
+    expect(hit).toEqual({ anchor: SHELL, pid: 49076, depth: 0 });
+  });
+
+  it('returns null on a miss — the chain reaches a root with no anchor', () => {
+    // MCP → claude → electron(root, ppid=1). No ancestor is an anchor.
+    const ppidByPid = ppids({ 100: 200, 200: 300, 300: 1 });
+    const hit = walkToOwningAnchor(100, ppidByPid, anchors({ 999: SHELL }));
+    expect(hit).toBeNull();
+  });
+
+  it('returns the CLOSEST anchor when several ancestors are anchors', () => {
+    const ppidByPid = ppids({ 10: 20, 20: 30, 30: 40 });
+    const near: OwningAnchor = { ptyId: 'pty-near', workspaceId: 'ws-near' };
+    const far: OwningAnchor = { ptyId: 'pty-far', workspaceId: 'ws-far' };
+    const hit = walkToOwningAnchor(10, ppidByPid, anchors({ 20: near, 40: far }));
+    expect(hit).toEqual({ anchor: near, pid: 20, depth: 1 });
+  });
+
+  it('terminates (no infinite loop) on a cyclic parent table and still finds an anchor before the cycle', () => {
+    // 10 → 20 → 30 → 20 (cycle). Anchor at 30 is reached before the loop closes.
+    const ppidByPid = ppids({ 10: 20, 20: 30, 30: 20 });
+    const hit = walkToOwningAnchor(10, ppidByPid, anchors({ 30: SHELL }));
+    expect(hit).toEqual({ anchor: SHELL, pid: 30, depth: 2 });
+  });
+
+  it('returns null (does not hang) on a cycle with no anchor', () => {
+    const ppidByPid = ppids({ 10: 20, 20: 30, 30: 10 });
+    expect(walkToOwningAnchor(10, ppidByPid, anchors({}))).toBeNull();
+  });
+
+  it('respects maxDepth — an anchor beyond the cap is not reached', () => {
+    const ppidByPid = ppids({ 1: 2, 2: 3, 3: 4, 4: 5 });
+    const anchorByPid = anchors({ 5: SHELL }); // depth 4 from pid 1
+    expect(walkToOwningAnchor(1, ppidByPid, anchorByPid, { maxDepth: 2 })).toBeNull();
+    expect(walkToOwningAnchor(1, ppidByPid, anchorByPid, { maxDepth: 4 })).toEqual({
+      anchor: SHELL,
+      pid: 5,
+      depth: 4,
+    });
+  });
+
+  it('stops at a non-positive / root parent without matching anything', () => {
+    // 50 → 0 (root sentinel). 0 is never walked into.
+    expect(walkToOwningAnchor(50, ppids({ 50: 0 }), anchors({ 0: SHELL }))).toBeNull();
+  });
+
+  it('stops on a self-parent without looping', () => {
+    expect(walkToOwningAnchor(4, ppids({ 4: 4 }), anchors({}))).toBeNull();
+  });
+
+  it('returns null for an invalid startPid', () => {
+    const ppidByPid = ppids({ 10: 20 });
+    const anchorByPid = anchors({ 20: SHELL });
+    expect(walkToOwningAnchor(0, ppidByPid, anchorByPid)).toBeNull();
+    expect(walkToOwningAnchor(-5, ppidByPid, anchorByPid)).toBeNull();
+    expect(walkToOwningAnchor(NaN, ppidByPid, anchorByPid)).toBeNull();
+    expect(walkToOwningAnchor(1.5, ppidByPid, anchorByPid)).toBeNull();
+  });
+
+  it('returns null when the start pid is absent from the process table (no parent to follow)', () => {
+    // startPid not in ppidByPid and not an anchor → immediate miss.
+    expect(walkToOwningAnchor(777, ppids({ 1: 0 }), anchors({ 888: SHELL }))).toBeNull();
+  });
+});

--- a/src/main/pty/serverSidePidWalk.ts
+++ b/src/main/pty/serverSidePidWalk.ts
@@ -1,0 +1,95 @@
+/**
+ * Server-side process-tree walk for MCP workspace-identity resolution.
+ *
+ * The PROPER fix for the multi-agent identity problem (Codex especially). An
+ * MCP server resolves "which workspace am I?" by finding, among its process-tree
+ * ancestors, the shell PID that the pid-map anchors to a live pane. Historically
+ * that walk ran CLIENT-side, inside the MCP child: it spawned a PowerShell
+ * `Get-CimInstance` per hop to read each parent PID. Two things break it:
+ *   - Codex SANDBOXES the MCP child, denying the per-hop PowerShell spawn past
+ *     the first (free) `process.ppid` hop, so the walk never reaches the shell.
+ *   - Codex also STRIPS the env hints (WMUX_WORKSPACE_ID / WMUX_PTY_ID), so the
+ *     env fallback that rescues Claude is empty too — identity stays unknown.
+ *
+ * Moving the walk to the main process (where this module runs) sidesteps both:
+ * main is unsandboxed and already takes a full `Win32_Process` snapshot for the
+ * port watcher, so the whole ancestor chain is available in-memory. The MCP
+ * sends its own pid as `callerPid`; we walk UP from there to the first ancestor
+ * that is a known live anchor and hand the resolved identity straight back.
+ *
+ * This module is the PURE core of that walk — no I/O, no electron — so it can be
+ * behavior-tested directly. The caller (a2a.rpc.ts) supplies the two maps:
+ *   - `ppidByPid`   : child pid → parent pid for every live process (the port
+ *                     watcher's snapshot, reused — see portWatch.ts).
+ *   - `anchorByPid` : shell pid → its owning {ptyId, workspaceId}, built from the
+ *                     pid-map entries already live-resolved this request, so dead
+ *                     and recycled anchors are excluded by construction.
+ */
+
+export interface OwningAnchor {
+  /** Immutable per-process pane anchor (node-pty shell pid → ptyId). */
+  ptyId: string;
+  /** The workspace that owns `ptyId` RIGHT NOW (resolved live by the caller). */
+  workspaceId: string;
+}
+
+export interface PidWalkHit {
+  anchor: OwningAnchor;
+  /** The ancestor PID that matched an anchor (the owning shell). */
+  pid: number;
+  /** Hops from `startPid` to the match (0 = `startPid` itself is the anchor). */
+  depth: number;
+}
+
+/**
+ * Default hop cap. The measured real chain is shallow — a Codex MCP reaches its
+ * pane shell in 3 hops (MCP → codex → node → shell) — so this is generous
+ * headroom, not a tight bound. It is a backstop against a pathologically deep or
+ * corrupt parent chain; the visited-set below already guarantees termination, so
+ * the cap only limits how far we bother looking before giving up.
+ */
+const DEFAULT_MAX_DEPTH = 16;
+
+/**
+ * Walk the process tree upward from `startPid`, returning the FIRST (closest)
+ * ancestor that is a live anchor, or null if none is reachable within the cap.
+ *
+ * "Closest wins" is correct: the nearest shell ancestor is the pane that owns
+ * the caller. A higher shell (were there ever a nested one) is a less-specific
+ * owner, so stopping at the first hit gives the right answer.
+ *
+ * Termination is guaranteed three ways, so a malformed `ppidByPid` (a cycle, a
+ * self-parent, a PID 0/4 root) can never loop forever:
+ *   1. `visited` short-circuits any cycle.
+ *   2. A parent <= 0, equal to the child, or absent from the table ends the walk
+ *      (root reached / unknown).
+ *   3. `maxDepth` caps the hop count regardless.
+ */
+export function walkToOwningAnchor(
+  startPid: number,
+  ppidByPid: ReadonlyMap<number, number>,
+  anchorByPid: ReadonlyMap<number, OwningAnchor>,
+  opts: { maxDepth?: number } = {},
+): PidWalkHit | null {
+  const maxDepth = opts.maxDepth ?? DEFAULT_MAX_DEPTH;
+  if (!Number.isInteger(startPid) || startPid <= 0) return null;
+
+  const visited = new Set<number>();
+  let current = startPid;
+  for (let depth = 0; depth <= maxDepth; depth++) {
+    if (visited.has(current)) break; // cycle guard
+    visited.add(current);
+
+    const anchor = anchorByPid.get(current);
+    if (anchor) return { anchor, pid: current, depth };
+
+    const parent = ppidByPid.get(current);
+    // No parent entry → `current` is a root not in the table → stop.
+    if (parent === undefined) break;
+    // A non-positive, self-referential, or NaN parent is the end of a real
+    // chain (or a corrupt one) — stop rather than chase it.
+    if (!Number.isInteger(parent) || parent <= 0 || parent === current) break;
+    current = parent;
+  }
+  return null;
+}

--- a/src/mcp/__tests__/serverSideHandshake.test.ts
+++ b/src/mcp/__tests__/serverSideHandshake.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Source-level invariant lock for the PROPER server-side identity handshake.
+//
+// The MCP server hands main its own pid (`callerPid`) so main can walk the
+// process tree on its UNSANDBOXED side to the owning shell anchor. This is the
+// only path that resolves identity for Codex, which both sandboxes the
+// client-side per-hop PowerShell walk and strips the env hints. The wiring is a
+// one-line RPC param + a short-circuit, easy to drop in a refactor — and the
+// failure is silent (server walk just never fires, Codex silently falls back to
+// the blocked client walk). These regexes lock the three load-bearing lines.
+describe('MCP server-side identity handshake (source-level invariant)', () => {
+  const indexPath = path.join(__dirname, '..', 'index.ts');
+  const rawSrc = fs.readFileSync(indexPath, 'utf-8');
+  // Strip comments so prose mentioning these names (the rationale above each
+  // line) can't satisfy the assertions — only real code counts.
+  const src = rawSrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
+  it('sends callerPid:process.pid on the a2a.resolve.identity RPC', () => {
+    expect(src).toMatch(/a2a\.resolve\.identity[\s\S]{0,120}callerPid:\s*process\.pid/);
+  });
+
+  it('adopts the server-resolved ptyId as the VERIFIED own-pane anchor (channel sender gate)', () => {
+    // MY_PTY_ID feeds getSenderPtyId (verified-only); a server-walk hit must set
+    // it from main's correlation so channel mutations work when the client walk
+    // misses (the Codex case this whole change exists to fix).
+    expect(src).toMatch(/MY_PTY_ID\s*=\s*resolved\.ptyId/);
+  });
+
+  it('short-circuits a server-walk hit to a verified identity (status:hit) before the client walk', () => {
+    expect(src).toMatch(/status:\s*['"]hit['"]\s*,\s*wsId:\s*resolved\.workspaceId/);
+  });
+});

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -52,12 +52,14 @@ const ENV_WORKSPACE_HINT = process.env.WMUX_WORKSPACE_ID || '';
 // to this MCP child — the case the diagnostic logging below exists to surface.
 const ENV_PTY_HINT = process.env.WMUX_PTY_ID || '';
 let MY_WORKSPACE_ID = '';
-// Our OWN pane anchor (ptyId), captured alongside MY_WORKSPACE_ID on a verified
-// PID-map hit. VERIFIED provenance: set only on a walk hit, where our process
-// tree provably owns that live pane (unforgeable). Threaded to a2a.task.send as
-// `senderPtyId` so the renderer can reject a true self-send (addressing our own
-// pane). Empty when no verified hit — getTaskSenderPtyId then falls back to the
-// weak env hint for the A2A task tools, while a2a.channel.* stays verified-only.
+// Our OWN pane anchor (ptyId), captured alongside MY_WORKSPACE_ID on a PID-map
+// hit — set by EITHER our client-side walk (unforgeable: our own process tree
+// owns that live pane) OR main's server-side walk (main-correlated from a
+// caller-asserted pid; forgeable within the #113 same-user ceiling — see
+// a2a.rpc.ts). Threaded to a2a.task.send as `senderPtyId` so the renderer can
+// reject a true self-send. Empty when no hit — getTaskSenderPtyId then falls
+// back to the weak env hint for the A2A task tools, while a2a.channel.* stays
+// hit-only.
 let MY_PTY_ID = '';
 let workspaceResolved = false;
 
@@ -65,8 +67,10 @@ let workspaceResolved = false;
  * The MCP server's OWN pane anchor (ptyId) for the A2A task + terminal tools.
  *
  * Provenance split (WI-002):
- *   - MY_PTY_ID  — VERIFIED (PID-map walk hit). Unforgeable: our process tree
- *                  provably owns that live pane.
+ *   - MY_PTY_ID  — PID-map walk hit. Client-side walk is unforgeable (our own
+ *                  process tree owns that live pane); server-side walk is
+ *                  main-correlated from a caller-asserted pid (forgeable within
+ *                  the #113 same-user ceiling). Both name a pane main resolved.
  *   - ENV_PTY_HINT — WEAK (WMUX_PTY_ID env). The spawn stamps the immutable
  *                  ptyId on the shell env; it reaches here only if the launcher
  *                  propagated it. Same spoofable channel as WMUX_WORKSPACE_ID.
@@ -79,8 +83,10 @@ let workspaceResolved = false;
  *
  * NOT used for a2a.channel.* — those mutation calls gate authz on a resolvable
  * senderPtyId (a2a.channel.rpc.ts), and feeding a weak env value there would
- * downgrade that gate from unforgeable PID-tree proof to a spoofable env var.
- * Channels keep using MY_PTY_ID (verified-only) via getSenderPtyId below.
+ * downgrade that gate from a main-resolved PID-map hit to a spoofable env var.
+ * Channels keep using MY_PTY_ID (hit-only) via getSenderPtyId below — a
+ * reliability mechanism within the #113 same-user ceiling (server-walk is
+ * caller-asserted), not a same-user security boundary.
  */
 function getTaskSenderPtyId(): string {
   return MY_PTY_ID || ENV_PTY_HINT;
@@ -172,14 +178,47 @@ async function lookupPidMapWorkspace(): Promise<PidMapLookup> {
   logIdentityEnvOnce();
   let mappings: Record<string, string> | undefined;
   let entries: Array<{ pid: string; ptyId: string; workspaceId: string }> | undefined;
+  let resolved: { workspaceId?: unknown; ptyId?: unknown } | null | undefined;
   try {
-    const result = await sendRpc('a2a.resolve.identity' as RpcMethod, {});
+    // callerPid lets main resolve our identity SERVER-SIDE: it walks our process
+    // tree on its end (unsandboxed, reusing the port-watcher's process snapshot)
+    // up to the owning shell's pid-map anchor. This is the PROPER fix for Codex,
+    // which sandboxes our own per-hop PowerShell walk below AND strips the env
+    // hints — leaving the client-side walk as its only, blocked, path. Older
+    // main builds ignore the field and omit `resolved`, so we fall through to
+    // the client-side walk unchanged (graceful degradation).
+    const result = await sendRpc('a2a.resolve.identity' as RpcMethod, { callerPid: process.pid });
     mappings = (result as { mappings: Record<string, string> }).mappings;
     entries = (result as { entries?: Array<{ pid: string; ptyId: string; workspaceId: string }> }).entries;
+    resolved = (result as { resolved?: { workspaceId?: unknown; ptyId?: unknown } | null }).resolved;
   } catch {
     logIdentity('resolve.identity rpc-down');
     return { status: 'rpc-down' };
   }
+
+  // Server-side walk HIT (PROPER fix). main correlated our process tree to a
+  // live pane on its side — env-independent and sandbox-independent, so this is
+  // the path that lets Codex (and any agent whose client-side walk is blocked)
+  // resolve identity at all.
+  //
+  // Provenance: main correlates from the LIVE process table, but the STARTING
+  // pid is caller-asserted — we send our own process.pid and the pipe does not
+  // bind the connection to a pid. So MY_PTY_ID set here is server-correlated, NOT
+  // as strong as the client walk's own-ancestry proof: a same-user caller could
+  // assert a foreign pid to adopt that pane's ptyId. This stays within the #113
+  // same-user trust ceiling (a same-user caller already holds the pipe token and
+  // is grandfathered allow-all), so the channel sender gate treats MY_PTY_ID as a
+  // reliability mechanism, not a same-user security boundary.
+  if (
+    resolved &&
+    typeof resolved.workspaceId === 'string' && resolved.workspaceId &&
+    typeof resolved.ptyId === 'string' && resolved.ptyId
+  ) {
+    MY_PTY_ID = resolved.ptyId;
+    logIdentity(`server-walk HIT ws=${resolved.workspaceId} pty=${resolved.ptyId}`);
+    return { status: 'hit', wsId: resolved.workspaceId, ptyId: resolved.ptyId };
+  }
+
   if (!mappings || Object.keys(mappings).length === 0) {
     logIdentity('resolve.identity empty-map');
     return { status: 'empty-map' };
@@ -1000,13 +1039,16 @@ server.tool(
 // walk result) so the main-side a2a.channel handler resolves + stamps the
 // workspace identity server-side, ignoring any client-supplied value.
 //
-// WI-002 PROVENANCE: this MUST stay MY_PTY_ID (VERIFIED walk only) — do NOT
-// switch it to getTaskSenderPtyId(). a2a.channel.rpc.ts gates mutating channel
-// calls (create/post/archive/join/leave) on a RESOLVABLE senderPtyId and fails
-// closed without one. Feeding the weak WMUX_PTY_ID env hint here would downgrade
-// that mutation authz from unforgeable PID-tree proof to a spoofable env var a
-// same-user process could set. Channels stay fail-closed on a walk miss (safe);
-// the PROPER fix (mcp.handshake) restores a verified ptyId that covers them too.
+// WI-002 PROVENANCE: this MUST stay MY_PTY_ID (walk-hit only) — do NOT switch it
+// to getTaskSenderPtyId(). a2a.channel.rpc.ts gates mutating channel calls
+// (create/post/archive/join/leave) on a RESOLVABLE senderPtyId and fails closed
+// without one. Feeding the weak WMUX_PTY_ID env hint here would downgrade that
+// authz from a main-resolved PID-map hit to a spoofable env var. The server-side
+// walk (PROPER fix) restores a ptyId on a client-walk miss — but it is
+// main-correlated from a caller-asserted pid, so within the #113 same-user
+// ceiling this gate is a reliability mechanism (a same-user caller could assert
+// a foreign pid), not a same-user security boundary. Still fail-closed when no
+// hit at all.
 registerChannelTools(server, {
   resolveWorkspaceId: requireWorkspaceId,
   getSenderPtyId: () => MY_PTY_ID,


### PR DESCRIPTION
Follows #299 (WI-002, merged) — the PROPER fix it set up. (This supersedes #300, which GitHub auto-closed when the #299 branch was deleted on merge; same branch, now rebased onto main.)

## Problem

WI-002 (#299) restored identity resolution for Claude Code, but Codex agents still couldn't resolve their workspace at all — confirmed live, two independent causes:

- Codex strips the `WMUX_*` env hints entirely, so the env fallback is empty.
- Codex sandboxes the MCP child, blocking the per-hop PowerShell spawn the client-side PID walk needs past the first hop — so the walk never reaches the owning shell.

With both paths gone the server reports "Workspace identity unknown" and channel mutations fail closed.

## Fix

Move the walk to the main process, which isn't sandboxed. The MCP sends its own pid as `callerPid` on `a2a.resolve.identity`; main walks the live process tree (reusing the port-watcher's `Win32_Process` snapshot) from there up to the owning shell's pid-map anchor and returns the resolved `{ workspaceId, ptyId }`. The MCP adopts it before its (blocked) client walk, so `MY_PTY_ID` is populated and the channel sender gate works for env-stripped agents.

- **Walk starts at `callerPid`'s parent, never itself** — matching the client walk's `process.ppid` start, so a recycled-PID collision (an old shell's number reassigned to this MCP) can't mis-route to a stranger workspace.
- **The snapshot never blocks the fallback.** It runs concurrently with the pid-map scan, is bounded to the RPC budget, is skipped entirely when there are no anchors to match, and isn't retried on failure. A slow or hung `Win32_Process` query can't delay or sink the legacy `mappings`/`entries` response.
- **`callerPid` is caller-asserted** (the pipe doesn't bind the connection to a pid). Within the same-user trust ceiling (#113) the channel sender gate is therefore a reliability mechanism, not a security boundary — a same-user caller already holds the pipe token and is grandfathered. Comments say so where it matters.
- **Legacy callers (no `callerPid`) get the exact prior response**, so older MCP builds are unaffected.

## Not in scope

Pruning accreted dead pid-map entries is intentionally left out — a snapshot-only liveness signal can be incomplete and would risk deleting a live pane's anchor. The accretion is pre-existing and gets a dedicated, safer GC in a follow-up.

## Validation

- Full suite green (4190 passed); type-check and lint clean.
- New coverage: pure ancestor walk (hit/miss/depth/cycle/cap/self-pid), handler hit/miss + snapshot refresh + budget timeout + empty-map skip + failed-snapshot graceful path, source-invariant handshake contract.
- Live dogfood on the packaged build (`scripts/proper-mcp-identity-dogfood.mjs`, 9/9): with env hints fully stripped, the server walk resolves both workspace and pane ptyId; the before/after delta holds (no anchor → identity unknown); a channel mutation passes the sender gate (fails only as `CHANNEL_NOT_FOUND`, never authz).

Reviewed across 5 rounds via a 3-way pass (Claude + Codex + GLM); see the prune/walk/snapshot hardening above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved MCP identity resolution so the app can more reliably recognize the correct workspace and terminal context.
  - Added stronger verification for server-side identity handling, including live end-to-end checks.

- **Bug Fixes**
  - Reduced “identity unknown” cases by anchoring identity to the actual shell context instead of stale or incorrect process entries.
  - Improved handling of outdated identity data to avoid misrouting and ghost matches.
  - Hardened resolution logic to better handle missing, stale, or recycled process IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->