### PR TITLE
feat(channels): add an archive button to the channel header

### DIFF
--- a/src/renderer/components/Channels/ChannelView.tsx
+++ b/src/renderer/components/Channels/ChannelView.tsx
@@ -13,7 +13,7 @@
 //
 // Plan ref: U8, R21, R22.
 
-import { useEffect, useMemo, useCallback } from 'react';
+import { useEffect, useMemo, useCallback, useState } from 'react';
 import type {
   Channel,
   ChannelMessage,
@@ -24,7 +24,7 @@ import { loadChannelHistory } from '../../hooks/useChannelsHydration';
 import { useT } from '../../hooks/useT';
 import { tokenAttrs } from '../../themes';
 import { FOCUS_RING } from '../focusRing';
-import { IconX } from '../icons';
+import { IconX, IconArchive, IconCheck } from '../icons';
 import { Composer } from './Composer';
 import { ChannelMembersControl } from './ChannelMembers';
 
@@ -88,6 +88,9 @@ export interface ChannelViewContentProps {
   messages: ChannelMessage[];
   viewer: ChannelMember | null;
   onClose: () => void;
+  /** Archive the channel (one-way). Provided only when the viewer may archive
+   *  it (the creator). Absent → no archive affordance is rendered. */
+  onArchive?: () => void;
   /** Translator — defaults to identity. Tests pass a stub. */
   t?: (key: string) => string;
   /** Wrapper rendered after the message list; the composer lives here. */
@@ -103,11 +106,15 @@ export function ChannelViewContent({
   messages,
   viewer,
   onClose,
+  onArchive,
   composerSlot,
   membersSlot,
   t: tProp,
 }: ChannelViewContentProps): React.ReactElement {
   const t = tProp ?? ((key: string) => key);
+  // Two-click confirm for the one-way archive: first click arms (button turns
+  // red + shows a check), second commits; blur cancels.
+  const [archiveArmed, setArchiveArmed] = useState(false);
   const visible = useMemo(
     () => sortMessagesBySeq(messages).filter((m) => isMessageVisibleToViewer(m, viewer)),
     [messages, viewer],
@@ -147,6 +154,28 @@ export function ChannelViewContent({
         </div>
         <div className="flex items-center gap-1 flex-shrink-0">
           {membersSlot}
+          {onArchive && channel.status !== 'archived' && (
+            <button
+              type="button"
+              aria-label={archiveArmed ? (t('channels.archiveConfirm') || 'Confirm archive (read-only, one-way)') : (t('channels.archiveTooltip') || 'Archive channel')}
+              title={archiveArmed ? (t('channels.archiveConfirm') || 'Confirm archive — read-only, one-way') : (t('channels.archiveTooltip') || 'Archive channel (read-only, one-way)')}
+              onClick={() => {
+                if (archiveArmed) { setArchiveArmed(false); onArchive(); }
+                else { setArchiveArmed(true); }
+              }}
+              onBlur={() => setArchiveArmed(false)}
+              className={`flex items-center justify-center w-5 h-5 rounded transition-colors duration-150 ${FOCUS_RING} ${
+                archiveArmed
+                  ? 'text-[var(--accent-red)] bg-[rgba(var(--bg-surface-rgb),0.6)]'
+                  : 'text-[var(--text-subtle)] hover:text-[var(--text-sub)] hover:bg-[rgba(var(--bg-surface-rgb),0.6)]'
+              }`}
+              data-channel-view-archive
+              data-armed={archiveArmed ? 'true' : 'false'}
+              {...tokenAttrs('textSub', 'text')}
+            >
+              {archiveArmed ? <IconCheck size={11} /> : <IconArchive size={11} />}
+            </button>
+          )}
           <button
             type="button"
             aria-label={t('channels.closeTooltip') || 'Close channel'}
@@ -262,8 +291,23 @@ export function ChannelView(): React.ReactElement | null {
   const activeWorkspaceId = useStore((s) => s.activeWorkspaceId);
   const setActiveChannel = useStore((s) => s.setActiveChannel);
   const pushToast = useStore((s) => s.pushToast);
+  const archiveChannelDaemon = useStore((s) => s.archiveChannelDaemon);
 
   const handleClose = useCallback(() => setActiveChannel(null), [setActiveChannel]);
+
+  // The renderer's "self" workspace — same expression as `viewer` below (the
+  // company CEO when set, else the active workspace).
+  const selfWs = company?.ceoWorkspaceId ?? activeWorkspaceId ?? '';
+  // Archive is creator-only (the daemon also enforces this). Offer the affordance
+  // only when this workspace created the channel, so a non-creator never sees a
+  // button that would just toast NOT_AUTHORIZED.
+  const canArchive = !!selfWs && !!channel && channel.createdBy === selfWs;
+  const handleArchive = useCallback(() => {
+    if (!activeChannelId || !selfWs) return;
+    void archiveChannelDaemon(activeChannelId, selfWs).then((res) => {
+      if (!res.ok) pushToast({ message: res.error.message, level: 'error' });
+    });
+  }, [activeChannelId, selfWs, archiveChannelDaemon, pushToast]);
 
   // Pick a stable viewer — first member whose workspaceId matches the
   // current renderer's workspace (the company's `ceoWorkspaceId` is the
@@ -338,6 +382,7 @@ export function ChannelView(): React.ReactElement | null {
         messages={messages}
         viewer={viewer}
         onClose={handleClose}
+        onArchive={canArchive ? handleArchive : undefined}
         t={t}
         membersSlot={<ChannelMembersControl channel={channel} />}
         composerSlot={

--- a/src/renderer/components/Channels/__tests__/ChannelView.archive.dynamic.test.tsx
+++ b/src/renderer/components/Channels/__tests__/ChannelView.archive.dynamic.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+//
+// Dynamic interaction test for the channel-archive affordance. The header
+// archive button is a TWO-CLICK confirm (first click ARMS, second COMMITS;
+// blur cancels), so an accidental single click can't trigger the one-way
+// archive. renderToStaticMarkup (ChannelView.test.tsx) cannot fire clicks,
+// so this mounts the REAL <ChannelViewContent/> via react-dom/client and
+// drives the actual DOM events — the click flow the user dogfoods.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createElement, act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Channel, ChannelMember, ChannelMessage } from '../../../../shared/channels';
+import { ChannelViewContent } from '../ChannelView';
+
+function makeChannel(overrides: Partial<Channel> = {}): Channel {
+  return {
+    id: 'ch-1',
+    companyId: 'co-1',
+    name: 'general',
+    visibility: 'public',
+    status: 'active',
+    createdAt: 1_700_000_000_000,
+    createdBy: 'ws-1',
+    nextSeq: 1,
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function mount(props: { channel?: Channel; onArchive?: () => void }): void {
+  act(() => {
+    root.render(
+      createElement(ChannelViewContent, {
+        channel: props.channel ?? makeChannel(),
+        messages: [] as ChannelMessage[],
+        viewer: null as ChannelMember | null,
+        onClose: () => undefined,
+        onArchive: props.onArchive,
+        composerSlot: createElement('div', { 'data-fake-composer': true }),
+      }),
+    );
+  });
+}
+
+function archiveBtn(): HTMLElement {
+  const el = container.querySelector('[data-channel-view-archive]') as HTMLElement | null;
+  if (!el) throw new Error('archive button not rendered');
+  return el;
+}
+const click = (el: HTMLElement) =>
+  act(() => { el.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe('ChannelViewContent — archive two-click confirm (jsdom)', () => {
+  it('first click ARMS (does not archive); second click COMMITS once', () => {
+    const onArchive = vi.fn();
+    mount({ onArchive });
+
+    expect(archiveBtn().getAttribute('data-armed')).toBe('false');
+    expect(onArchive).not.toHaveBeenCalled();
+
+    click(archiveBtn()); // arm
+    expect(archiveBtn().getAttribute('data-armed')).toBe('true');
+    expect(onArchive).not.toHaveBeenCalled();
+
+    click(archiveBtn()); // commit
+    expect(onArchive).toHaveBeenCalledTimes(1);
+    expect(archiveBtn().getAttribute('data-armed')).toBe('false'); // disarms after commit
+  });
+
+  it('blur cancels the armed state without archiving', () => {
+    const onArchive = vi.fn();
+    mount({ onArchive });
+
+    click(archiveBtn());
+    expect(archiveBtn().getAttribute('data-armed')).toBe('true');
+
+    // React wires onBlur via focusout delegation at the root.
+    act(() => { archiveBtn().dispatchEvent(new FocusEvent('focusout', { bubbles: true })); });
+    expect(archiveBtn().getAttribute('data-armed')).toBe('false');
+    expect(onArchive).not.toHaveBeenCalled();
+  });
+
+  it('renders no archive affordance for an already-archived channel', () => {
+    mount({ channel: makeChannel({ status: 'archived' }), onArchive: () => undefined });
+    expect(container.querySelector('[data-channel-view-archive]')).toBeNull();
+  });
+});

--- a/src/renderer/components/Channels/__tests__/ChannelView.test.tsx
+++ b/src/renderer/components/Channels/__tests__/ChannelView.test.tsx
@@ -157,6 +157,7 @@ function renderView(args: {
   messages?: ChannelMessage[];
   viewer?: ChannelMember | null;
   onClose?: () => void;
+  onArchive?: () => void;
   composerSlot?: React.ReactNode;
 } = {}): string {
   return renderToStaticMarkup(
@@ -165,6 +166,7 @@ function renderView(args: {
       messages: args.messages ?? [],
       viewer: args.viewer === undefined ? null : args.viewer,
       onClose: args.onClose ?? (() => undefined),
+      onArchive: args.onArchive,
       composerSlot: args.composerSlot ?? <div data-fake-composer />,
     }),
   );
@@ -274,6 +276,25 @@ describe('ChannelViewContent', () => {
       channel: makeChannel({ status: 'active' }),
     });
     expect(html).not.toContain('data-channel-archived-badge');
+  });
+
+  it('renders the archive affordance when onArchive is provided and the channel is active', () => {
+    const html = renderView({ onArchive: () => undefined });
+    expect(html).toContain('data-channel-view-archive');
+    expect(html).toContain('data-armed="false"'); // unarmed until first click
+  });
+
+  it('does NOT render the archive affordance when onArchive is absent (non-creator)', () => {
+    const html = renderView(); // no onArchive
+    expect(html).not.toContain('data-channel-view-archive');
+  });
+
+  it('does NOT render the archive affordance for an already-archived channel', () => {
+    const html = renderView({
+      channel: makeChannel({ status: 'archived' }),
+      onArchive: () => undefined,
+    });
+    expect(html).not.toContain('data-channel-view-archive');
   });
 
   it('mounts the composer slot at the bottom of the view', () => {

--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -34,6 +34,17 @@ export function IconCheck({ size = 14 }: { size?: number }) {
   return <Icon size={size}><polyline points="2.5,7.4 5.8,10.5 11.5,3.5" /></Icon>;
 }
 
+/** Archive — a lidded box with a handle. Channel archive (read-only, one-way). */
+export function IconArchive({ size = 14 }: { size?: number }) {
+  return (
+    <Icon size={size}>
+      <rect x="2" y="2.4" width="10" height="2.6" rx="0.6" />
+      <path d="M3 5 V11 a0.6 0.6 0 0 0 0.6 0.6 H10.4 a0.6 0.6 0 0 0 0.6 -0.6 V5" />
+      <line x1="5.6" y1="7.6" x2="8.4" y2="7.6" />
+    </Icon>
+  );
+}
+
 export function IconChevron({ size = 14 }: { size?: number }) {
   // Points right; rotate 90° via transform for an expanded/down state.
   return <Icon size={size}><polyline points="5.5,3 9.5,7 5.5,11" /></Icon>;

--- a/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
@@ -750,6 +750,94 @@ describe('channelsSlice — leaveChannelDaemon (membership, self-only)', () => {
   });
 });
 
+describe('channelsSlice — archiveChannelDaemon (lifecycle, creator-only)', () => {
+  it('on RPC success: calls a2a.channel.archive and marks the channel archived', async () => {
+    const { calls } = withChannelsRpc(async () => ({ ok: true })); // daemon returns EmptyResult
+    try {
+      const store = createTestStore();
+      store.getState().createChannelOptimistic({
+        name: 'general',
+        visibility: 'public',
+        createdBy: sender,
+        channel: makeChannel({ id: 'ch-1', status: 'active' }),
+      });
+
+      const res = await store.getState().archiveChannelDaemon('ch-1', 'ws-1');
+      expect(res.ok).toBe(true);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].method).toBe('a2a.channel.archive');
+      expect(calls[0].params).toMatchObject({
+        channelId: 'ch-1',
+        verifiedWorkspaceId: 'ws-1',
+        archivedBy: 'ws-1',
+      });
+      // Daemon returns no row → the thunk synthesizes the archived variant.
+      const ch = store.getState().channels['ch-1'];
+      expect(ch.status).toBe('archived');
+      expect(typeof ch.archivedAt).toBe('number');
+      expect(ch.archivedBy).toBe('ws-1');
+    } finally {
+      clearChannelsRpc();
+    }
+  });
+
+  it('on NOT_AUTHORIZED: returns the error and leaves the channel active', async () => {
+    withChannelsRpc(async () => ({
+      ok: false,
+      error: { code: 'NOT_AUTHORIZED', message: 'Only the channel creator or the company CEO may archive this channel' },
+    }));
+    try {
+      const store = createTestStore();
+      store.getState().createChannelOptimistic({
+        name: 'general',
+        visibility: 'public',
+        createdBy: sender,
+        channel: makeChannel({ id: 'ch-1', status: 'active' }),
+      });
+      const res = await store.getState().archiveChannelDaemon('ch-1', 'ws-other');
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        // NOT_AUTHORIZED isn't in the renderer's known-code union → bucketed to
+        // UNKNOWN, with the daemon code preserved in the message.
+        expect(res.error.code).toBe('UNKNOWN');
+        expect(res.error.message).toContain('NOT_AUTHORIZED');
+      }
+      // No optimistic flip on failure.
+      expect(store.getState().channels['ch-1'].status).toBe('active');
+    } finally {
+      clearChannelsRpc();
+    }
+  });
+
+  it('channel not in the local mirror: returns CHANNEL_NOT_FOUND without calling the bridge', async () => {
+    const { calls } = withChannelsRpc(async () => ({ ok: true }));
+    try {
+      const store = createTestStore();
+      const res = await store.getState().archiveChannelDaemon('ch-missing', 'ws-1');
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error.code).toBe('CHANNEL_NOT_FOUND');
+      expect(calls).toHaveLength(0); // short-circuits before the RPC
+    } finally {
+      clearChannelsRpc();
+    }
+  });
+
+  it('bridge missing: returns UNKNOWN without mutating state', async () => {
+    clearChannelsRpc();
+    const store = createTestStore();
+    store.getState().createChannelOptimistic({
+      name: 'general',
+      visibility: 'public',
+      createdBy: sender,
+      channel: makeChannel({ id: 'ch-1', status: 'active' }),
+    });
+    const res = await store.getState().archiveChannelDaemon('ch-1', 'ws-1');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe('UNKNOWN');
+    expect(store.getState().channels['ch-1'].status).toBe('active');
+  });
+});
+
 describe('channelsSlice — postMessageDaemon (U4, R4 + R11)', () => {
   it('on RPC success: applies the daemon row, returns ok, propagates clientMsgId', async () => {
     const { calls } = withChannelsRpc(async (_method, params) => ({

--- a/src/renderer/stores/slices/channelsSlice.ts
+++ b/src/renderer/stores/slices/channelsSlice.ts
@@ -193,6 +193,15 @@ export interface ChannelsSlice {
     memberId: string,
     workspaceId: string,
   ) => Promise<ChannelActionResult<Record<string, never>>>;
+  // Archive a channel (one-way; read-only thereafter). Creator-only by the
+  // daemon's authz gate; `workspaceId` is the verified caller (the renderer's
+  // self). The daemon returns an empty result, so the thunk synthesizes the
+  // archived row for `archiveChannelOptimistic` — best-effort until the next
+  // catalog refresh corrects `archivedAt`.
+  archiveChannelDaemon: (
+    channelId: string,
+    workspaceId: string,
+  ) => Promise<ChannelActionResult<Channel>>;
 
   // Internal helpers — exposed on the slice so the `*Daemon` thunks
   // can call them via `get()`, and so tests can drive the bridge-
@@ -627,5 +636,41 @@ export const createChannelsSlice: StateCreator<
       return { ok: false, error: get().mapRpcError(raw, 'a2a.channel.leave failed') };
     }
     return get().leaveChannelOptimistic(channelId, memberId);
+  },
+
+  archiveChannelDaemon: async (channelId, workspaceId) => {
+    const bridge = get().channelsRpc();
+    if (!bridge) {
+      console.warn('[channelsSlice] archiveChannelDaemon invoked before bridge mounted — call ignored');
+      return { ok: false, error: { code: 'UNKNOWN', message: 'channels bridge not mounted' } };
+    }
+    const existing = get().channels[channelId];
+    if (!existing) {
+      return { ok: false, error: { code: 'CHANNEL_NOT_FOUND', message: `No such channel: ${channelId}` } };
+    }
+    let raw: unknown;
+    try {
+      // Archive authz is creator-or-CEO, gated daemon-side on verifiedWorkspaceId
+      // (the renderer's own/CEO workspace). `archivedBy` is metadata only.
+      raw = await bridge.mutateLocal('a2a.channel.archive', {
+        channelId,
+        verifiedWorkspaceId: workspaceId,
+        archivedBy: workspaceId,
+      });
+    } catch (err) {
+      return { ok: false, error: { code: 'UNKNOWN', message: err instanceof Error ? err.message : String(err) } };
+    }
+    if (raw === null || typeof raw !== 'object' || !('ok' in raw) || (raw as { ok: unknown }).ok !== true) {
+      return { ok: false, error: get().mapRpcError(raw, 'a2a.channel.archive failed') };
+    }
+    // The daemon returns an empty result, not the row — synthesize the archived
+    // channel optimistically. The daemon is authoritative; the next catalog
+    // refresh overwrites `archivedAt` with the persisted value.
+    return get().archiveChannelOptimistic(channelId, {
+      ...existing,
+      status: 'archived',
+      archivedAt: Date.now(),
+      archivedBy: workspaceId,
+    });
   },
 });


### PR DESCRIPTION
Closes the "you can't close a channel from the UI" gap. The daemon's `channel_archive` (one-way, read-only) and the renderer-only mutate IPC already supported archive; only the affordance was missing (deferred in the v3.10.0 "human UI" pass — `ChannelItem.tsx` even noted "archive / rename are deferred").

## What

A creator-only **Archive** button in the channel header (between the members roster and the close X):

- Shows only when the current workspace **created** the channel — matching the daemon's creator-or-CEO authz gate — and only while the channel is still active. A non-creator never sees a button that would just return `NOT_AUTHORIZED`.
- **Two-click confirm**: the first click arms (the button turns red and shows a check), the second commits; blur cancels. The one-way archive can't fire on a stray click.
- On success the channel flips to archived (the existing badge + read-only composer) via the optimistic path; failures surface a toast.

## Wiring

- `archiveChannelDaemon` routes `a2a.channel.archive` over the renderer-only mutate IPC (already allow-listed in `channelLocal.handler`), **synthesizes** the archived row (the daemon returns an empty result, not the channel) for the existing `archiveChannelOptimistic`, and maps daemon errors to the `ChannelError` envelope.
- New `IconArchive` matches the existing 14×14 stroke icon set.

## Verification

- **Slice thunk tests**: success → `a2a.channel.archive` called + archived row applied; `NOT_AUTHORIZED` → error, channel stays active; channel-not-found → short-circuits before the RPC; bridge-missing.
- **Pure render tests**: creator gating (button shown/hidden), archived channel hides the button.
- **jsdom interaction test** mounts the real `ChannelViewContent` and fires real DOM clicks to lock the two-click arm→commit, blur-cancel, and archived-hidden behavior (renderToStaticMarkup can't click).
- Type-check + lint clean; full channel suite green (125); the packaged build boots clean with the change.

Note: the packaged build disables remote debugging (CDP), so the literal in-app click could not be pixel-automated; the jsdom test exercises the same component, DOM events, and React handlers, so it's functionally equivalent to clicking in the app.

## Not in scope

Archive from the channel-list row, channel rename, and a `channel_history` read RPC remain deferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a creator-only archive action in channel views with a two-step confirmation to prevent accidental archiving.
  * Archived channels now update immediately in the interface after a successful action.
  * Added a new archive icon for the channel controls.

* **Bug Fixes**
  * Improved archive behavior when the channel is already archived or when archive access is unavailable.
  * Added clearer error handling if archiving cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->