### PR TITLE
fix(channels): show added members in the roster + restore archive tooltips

### DIFF
--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -642,6 +642,8 @@ export const en = {
   'channels.dockTitle': 'Channels',
   'channels.dockCollapse': 'Collapse channels',
   'channels.archived': 'archived',
+  'channels.archiveTooltip': 'Archive channel (read-only, one-way)',
+  'channels.archiveConfirm': 'Confirm archive — read-only, one-way',
   'channels.members': 'Members',
   'channels.you': 'you',
   'channels.noMembers': 'No members yet.',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -570,6 +570,8 @@ export const ko = {
   'channels.dockTitle': '채널',
   'channels.dockCollapse': '채널 접기',
   'channels.archived': '보관됨',
+  'channels.archiveTooltip': '채널 보관 (읽기 전용, 되돌릴 수 없음)',
+  'channels.archiveConfirm': '보관 확정 — 읽기 전용, 되돌릴 수 없음',
   'channels.members': '멤버',
   'channels.you': '나',
   'channels.noMembers': '아직 멤버가 없습니다.',

--- a/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
@@ -444,6 +444,38 @@ describe('channelsSlice — leaveChannelOptimistic', () => {
   });
 });
 
+describe('channelsSlice — joinChannelOptimistic (composite-key dedup, invite fix)', () => {
+  it('adds a workspace that reuses an existing memberId (the roster shares one UI memberId across workspaces)', () => {
+    const store = createTestStore();
+    store.getState().createChannelOptimistic({
+      name: 'general',
+      visibility: 'public',
+      createdBy: sender, // creator = (ws-1, m-1)
+      channel: makeChannel(),
+    });
+    expect(store.getState().channelMembers['ch-1']).toHaveLength(1);
+
+    // Add a DIFFERENT workspace that reuses the SAME memberId (m-1) — exactly
+    // what the members roster does (one constant UI_MEMBER_ID per add). Pre-fix
+    // this collapsed on memberId and the new member never appeared.
+    const res = store
+      .getState()
+      .joinChannelOptimistic('ch-1', { ...sender, workspaceId: 'ws-2' }, 'ws-2');
+
+    expect(res.ok).toBe(true);
+    const members = store.getState().channelMembers['ch-1'];
+    expect(members).toHaveLength(2); // pre-fix: 1 (wrongly deduped on memberId alone)
+    expect(members.map((m) => m.workspaceId).sort()).toEqual(['ws-1', 'ws-2']);
+  });
+
+  it('still dedups an exact (workspaceId, memberId) repeat', () => {
+    const store = createTestStore();
+    store.getState().joinChannelOptimistic('ch-1', { ...sender, workspaceId: 'ws-2' }, 'ws-2');
+    store.getState().joinChannelOptimistic('ch-1', { ...sender, workspaceId: 'ws-2' }, 'ws-2');
+    expect(store.getState().channelMembers['ch-1']).toHaveLength(1);
+  });
+});
+
 describe('channelsSlice — archiveChannelOptimistic', () => {
   it('replaces the catalog row with the archived variant', () => {
     const store = createTestStore();

--- a/src/renderer/stores/slices/channelsSlice.ts
+++ b/src/renderer/stores/slices/channelsSlice.ts
@@ -338,7 +338,15 @@ export const createChannelsSlice: StateCreator<
   joinChannelOptimistic: (channelId, member, workspaceId) => {
     set((state: StoreState) => {
       const existing = state.channelMembers[channelId] ?? [];
-      const already = existing.some((m) => m.memberId === member.memberId);
+      // Dedup on (workspaceId, memberId) — the SAME composite key the daemon
+      // uses (ChannelService.join). The in-app roster reuses a single constant
+      // memberId (UI_MEMBER_ID) for every workspace it adds, so keying on
+      // memberId alone collapses distinct workspaces: the creator already holds
+      // UI_MEMBER_ID, so the first "Add a workspace" looked like a duplicate and
+      // the new member never appeared in the roster (daemon added it; UI didn't).
+      const already = existing.some(
+        (m) => m.workspaceId === workspaceId && m.memberId === member.memberId,
+      );
       if (!already) {
         state.channelMembers[channelId] = [
           ...existing,


### PR DESCRIPTION
Two small follow-ups to the channels human UI (#302).

**Roster bug — added members don't appear**

`joinChannelOptimistic` deduped on `memberId` alone, but the in-app roster reuses a single constant `memberId` (`UI_MEMBER_ID`) for every workspace it adds. The creator already holds that id, so the first "Add a workspace" looked like a duplicate and the new member never showed up in the roster — even though the daemon had actually added it. Now dedup keys on `(workspaceId, memberId)`, the same composite key the daemon uses in `ChannelService.join`.

**Archive tooltips render raw i18n keys**

#302 referenced `channels.archiveTooltip` / `channels.archiveConfirm` but never added them to the locales. This i18n returns the key itself on a miss, so the tooltip showed the literal key string instead of text. Added both to en + ko.

Tests: channelsSlice suite (44 passing), including the composite-key dedup case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed channel member handling so the same member ID can appear correctly across different workspaces without being mistaken for a duplicate.
  * Prevented duplicate member entries when the same workspace/member join action is repeated.
  * Added clearer archive messaging in English and Korean, including a tooltip and confirmation prompt that explain archiving is read-only and irreversible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->