### PR TITLE
feat(channels): @-mentions — composer autocomplete, highlight + dock badge, a2a inbox routing

### DIFF
--- a/src/daemon/channels/ChannelService.ts
+++ b/src/daemon/channels/ChannelService.ts
@@ -30,6 +30,7 @@ import {
   isValidChannelName,
   type Channel,
   type ChannelMember,
+  type ChannelMention,
   type ChannelMessage,
   type ChannelRecipientStatus,
   type ChannelState,
@@ -183,6 +184,12 @@ export interface PostMessageParams {
   clientMsgId?: string;
   /** Optional structured data (R10). */
   data?: unknown;
+  /** @-mentions from the composer/agent. Validated server-side: each entry is
+   *  kept only if its `workspaceId` is a CURRENT channel member (the same
+   *  membership set that gates posting), then deduped by workspace. Non-member
+   *  mentions are dropped — you cannot ping a workspace that isn't in the room.
+   *  This validated set is what Phase 2 inbox routing trusts. */
+  mentions?: ChannelMention[];
 }
 
 /** Discriminated success/failure envelope returned by every public method.
@@ -738,6 +745,25 @@ export class ChannelService {
         workspaceId: m.workspaceId,
         status: 'pending' as const,
       }));
+      // Validate @mentions against the FROZEN member set (the same snapshot the
+      // recipients use): keep only mentions of CURRENT members, deduped by
+      // workspace. A mention of a non-member is dropped — you cannot ping a
+      // workspace that isn't in the room. This bounded, member-verified set is
+      // exactly what Phase 2's inbox routing will ping; validating here (not in
+      // the renderer/MCP) keeps the trust on the server.
+      const mentionedWs = new Set<string>();
+      const mentions: ChannelMention[] = [];
+      for (const mn of params.mentions ?? []) {
+        if (!mn || typeof mn.workspaceId !== 'string') continue;
+        if (!members.some((m) => m.workspaceId === mn.workspaceId)) continue;
+        if (mentionedWs.has(mn.workspaceId)) continue;
+        mentionedWs.add(mn.workspaceId);
+        mentions.push({
+          workspaceId: mn.workspaceId,
+          name: typeof mn.name === 'string' && mn.name.length > 0 ? mn.name.slice(0, 80) : mn.workspaceId,
+          ...(typeof mn.memberId === 'string' ? { memberId: mn.memberId } : {}),
+        });
+      }
       const seq = channel.nextSeq++;
       const now = this.now();
       const message: ChannelMessage = {
@@ -752,6 +778,7 @@ export class ChannelService {
         recipientSnapshot: snapshot,
         ...(params.clientMsgId !== undefined ? { clientMsgId: params.clientMsgId } : {}),
         ...(params.data !== undefined ? { data: params.data } : {}),
+        ...(mentions.length > 0 ? { mentions } : {}),
       };
       (this.state.messages[channel.id] ??= []).push(message);
       // Update idempotency cache.

--- a/src/daemon/channels/__tests__/ChannelService.test.ts
+++ b/src/daemon/channels/__tests__/ChannelService.test.ts
@@ -495,6 +495,67 @@ describe('ChannelService', () => {
     });
   });
 
+  describe('post mentions (member-validated, deduped)', () => {
+    it('keeps member mentions, drops non-members, dedupes by workspace — on the message AND the event', async () => {
+      const { svc, emit } = makeService();
+      const created = await svc.create({
+        name: 'general',
+        visibility: 'public',
+        createdBy: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+        verifiedWorkspaceId: 'ws-1',
+      });
+      if (!created.ok) throw new Error(`create failed: ${created.error.code}`);
+      const chId = created.channel.id;
+      // ws-2 joins so it is a valid mention target; ws-ghost never joins.
+      const joined = await svc.join({
+        channelId: chId,
+        member: { workspaceId: 'ws-2', memberId: 'm-2', memberName: 'Bob' },
+        verifiedWorkspaceId: 'ws-2',
+      });
+      if (!joined.ok) throw new Error(`join failed: ${joined.error.code}`);
+
+      const post = await svc.post({
+        channelId: chId,
+        sender: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+        text: 'hey @Bob — see @Ghost',
+        verifiedWorkspaceId: 'ws-1',
+        mentions: [
+          { workspaceId: 'ws-2', name: 'Bob' }, // member → kept
+          { workspaceId: 'ws-2', name: 'Bob (dup)' }, // duplicate workspace → dropped
+          { workspaceId: 'ws-ghost', name: 'Ghost' }, // non-member → dropped
+        ],
+      });
+
+      expect(post.ok).toBe(true);
+      if (!post.ok) throw new Error(`post failed: ${post.error.code}`);
+      expect(post.message.mentions).toEqual([{ workspaceId: 'ws-2', name: 'Bob' }]);
+      // The emitted channel.message event carries the same validated set.
+      const evt = emit.mock.calls.at(-1)?.[0];
+      expect(evt?.message.mentions).toEqual([{ workspaceId: 'ws-2', name: 'Bob' }]);
+    });
+
+    it('omits the mentions field entirely when none are valid (no empty array)', async () => {
+      const { svc } = makeService();
+      const created = await svc.create({
+        name: 'general',
+        visibility: 'public',
+        createdBy: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+        verifiedWorkspaceId: 'ws-1',
+      });
+      if (!created.ok) throw new Error('create failed');
+      const post = await svc.post({
+        channelId: created.channel.id,
+        sender: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+        text: 'no valid mentions',
+        verifiedWorkspaceId: 'ws-1',
+        mentions: [{ workspaceId: 'ws-ghost', name: 'Ghost' }], // non-member only
+      });
+      expect(post.ok).toBe(true);
+      if (!post.ok) throw new Error('post failed');
+      expect(post.message.mentions).toBeUndefined();
+    });
+  });
+
   describe('concurrency', () => {
     it('two posts on the same channel observe linear seq order', async () => {
       const { svc } = makeService();

--- a/src/mcp/channels.ts
+++ b/src/mcp/channels.ts
@@ -172,8 +172,18 @@ export function registerChannelTools(server: McpServer, deps: ChannelToolDeps): 
         .string()
         .optional()
         .describe('Optional idempotency key. Two posts with the same key on the same channel return the original seq instead of appending a duplicate.'),
+      mentions: z
+        .array(
+          z.object({
+            workspace_id: z.string().describe('Mentioned member workspace id. Dropped server-side unless it is a CURRENT channel member.'),
+            name: z.string().optional().describe('Display name for the @mention (defaults to the workspace id).'),
+            member_id: z.string().optional().describe('Narrow the mention to a specific member; omit for a workspace-level mention.'),
+          }),
+        )
+        .optional()
+        .describe('@-mentions to ping specific members. Each must be a current channel member (non-members dropped). Mentioned workspaces are notified via their a2a inbox.'),
     },
-    async ({ channel_id, text, member_id, member_name, client_msg_id }) => {
+    async ({ channel_id, text, member_id, member_name, client_msg_id, mentions }) => {
       const workspaceId = await deps.resolveWorkspaceId();
       const params: Record<string, unknown> = {
         workspaceId,
@@ -187,6 +197,13 @@ export function registerChannelTools(server: McpServer, deps: ChannelToolDeps): 
         text,
       };
       if (client_msg_id !== undefined) params['clientMsgId'] = client_msg_id;
+      if (mentions !== undefined) {
+        params['mentions'] = mentions.map((m) => ({
+          workspaceId: m.workspace_id,
+          name: m.name ?? m.workspace_id,
+          ...(m.member_id !== undefined ? { memberId: m.member_id } : {}),
+        }));
+      }
       return callChannelRpc('a2a.channel.post' as RpcMethod, params);
     },
   );

--- a/src/renderer/components/Channels/ChannelItem.tsx
+++ b/src/renderer/components/Channels/ChannelItem.tsx
@@ -20,6 +20,9 @@ export interface ChannelItemViewProps {
   channel: Channel;
   isActive: boolean;
   unreadCount: number;
+  /** True when at least one unseen message @-mentions this workspace. Promotes
+   *  the unread badge to a stronger red `@` badge. */
+  mentioned?: boolean;
   onSelect: (channelId: string) => void;
 }
 
@@ -32,9 +35,10 @@ export function ChannelItemView({
   channel,
   isActive,
   unreadCount,
+  mentioned = false,
   onSelect,
 }: ChannelItemViewProps): React.ReactElement {
-  const showBadge = unreadCount > 0;
+  const showBadge = unreadCount > 0 || mentioned;
   return (
     <div
       role="button"
@@ -62,11 +66,15 @@ export function ChannelItemView({
       <span className="text-[11px] font-mono truncate flex-1 min-w-0">{channel.name}</span>
       {showBadge && (
         <span
-          className="bg-[var(--accent-blue)] text-[var(--bg-base)] text-[9px] font-bold min-w-[16px] h-4 flex items-center justify-center rounded-full px-1 flex-shrink-0"
-          {...tokenAttrs('accent', 'accent')}
+          data-channel-mention={mentioned ? 'true' : undefined}
+          className={`text-[var(--bg-base)] text-[9px] font-bold min-w-[16px] h-4 flex items-center justify-center rounded-full px-1 flex-shrink-0 ${
+            mentioned ? 'bg-[var(--accent-red)]' : 'bg-[var(--accent-blue)]'
+          }`}
+          {...tokenAttrs(mentioned ? 'danger' : 'accent', 'accent')}
           {...tokenAttrs('bgBase', 'bg')}
         >
-          {unreadCount > 99 ? '99+' : unreadCount}
+          {mentioned && <span aria-hidden="true">@</span>}
+          {unreadCount > 0 ? (unreadCount > 99 ? '99+' : unreadCount) : ''}
         </span>
       )}
     </div>

--- a/src/renderer/components/Channels/ChannelView.tsx
+++ b/src/renderer/components/Channels/ChannelView.tsx
@@ -18,6 +18,7 @@ import type {
   Channel,
   ChannelMessage,
   ChannelMember,
+  ChannelMention,
 } from '../../../shared/channels';
 import { useStore } from '../../stores';
 import { loadChannelHistory } from '../../hooks/useChannelsHydration';
@@ -79,6 +80,49 @@ export function viewerDeliveryStatus(
   if (!snap) return message.deliveryStatus;
   const me = snap.find((s) => s.memberId === viewerMemberId);
   return me?.status;
+}
+
+/** Render message text with its @mention tokens highlighted. Splits on the
+ *  validated `mentions[].name` snapshots and wraps each `@name` occurrence in
+ *  an accent span; longest names first so "@John Doe" wins over "@John".
+ *  Returns the plain string when there are no mentions (the common case). */
+export function renderMessageText(
+  text: string,
+  mentions?: ChannelMention[],
+): React.ReactNode {
+  if (!mentions || mentions.length === 0) return text;
+  const names = Array.from(new Set(mentions.map((m) => m.name)))
+    .filter((n) => n.length > 0)
+    .sort((a, b) => b.length - a.length);
+  if (names.length === 0) return text;
+  const parts: React.ReactNode[] = [];
+  let i = 0;
+  let key = 0;
+  while (i < text.length) {
+    if (text[i] === '@') {
+      const matched = names.find((n) => text.startsWith(n, i + 1));
+      if (matched) {
+        parts.push(
+          <span
+            key={key++}
+            data-channel-mention-token
+            className="font-bold text-[var(--accent-blue)]"
+            {...tokenAttrs('accent', 'text')}
+          >
+            @{matched}
+          </span>,
+        );
+        i += 1 + matched.length;
+        continue;
+      }
+    }
+    // Accumulate plain text up to the next '@' (or end of string).
+    let j = i + 1;
+    while (j < text.length && text[j] !== '@') j++;
+    parts.push(text.slice(i, j));
+    i = j;
+  }
+  return parts;
 }
 
 // ─── Pure view ──────────────────────────────────────────────────────────
@@ -207,6 +251,8 @@ export function ChannelViewContent({
         ) : (
           visible.map((m) => {
             const myStatus = viewerDeliveryStatus(m, viewer?.memberId ?? null);
+            const mentionsMe =
+              !!viewer && !!m.mentions?.some((mn) => mn.workspaceId === viewer.workspaceId);
             return (
               <div
                 key={`${channel.id}:${m.seq}`}
@@ -214,7 +260,10 @@ export function ChannelViewContent({
                 data-seq={m.seq}
                 data-member-id={m.memberId}
                 data-delivery={myStatus ?? 'unknown'}
-                className="flex flex-col gap-0.5"
+                data-mentions-me={mentionsMe ? 'true' : undefined}
+                className={`flex flex-col gap-0.5 ${
+                  mentionsMe ? 'border-l-2 border-[var(--accent-blue)] pl-1.5' : ''
+                }`}
               >
                 <div className="flex items-baseline gap-2">
                   <span
@@ -237,7 +286,7 @@ export function ChannelViewContent({
                   data-channel-message-text
                   {...tokenAttrs('textMain', 'text')}
                 >
-                  {m.text}
+                  {renderMessageText(m.text, m.mentions)}
                 </div>
                 {myStatus && (
                   <div

--- a/src/renderer/components/Channels/ChannelsPanel.tsx
+++ b/src/renderer/components/Channels/ChannelsPanel.tsx
@@ -277,6 +277,7 @@ export function synthesizeChannel(params: {
 export interface ChannelsPanelViewProps {
   channels: Record<string, Channel>;
   channelUnread: Record<string, number>;
+  channelMentions: Record<string, number>;
   activeChannelId: string | null;
   company: Company | null;
   /** Translates `channels.*` keys; defaults to identity if omitted so
@@ -300,6 +301,7 @@ export function ChannelsPanelView(props: ChannelsPanelViewProps): React.ReactEle
   const {
     channels,
     channelUnread,
+    channelMentions,
     activeChannelId,
     company,
     onSelect,
@@ -411,6 +413,7 @@ export function ChannelsPanelView(props: ChannelsPanelViewProps): React.ReactEle
                 channel={ch}
                 isActive={activeChannelId === ch.id}
                 unreadCount={channelUnread[ch.id] ?? 0}
+                mentioned={(channelMentions[ch.id] ?? 0) > 0}
                 onSelect={onSelect}
               />
             ))}
@@ -447,6 +450,7 @@ export function ChannelsPanelView(props: ChannelsPanelViewProps): React.ReactEle
                       channel={ch}
                       isActive={activeChannelId === ch.id}
                       unreadCount={channelUnread[ch.id] ?? 0}
+                      mentioned={(channelMentions[ch.id] ?? 0) > 0}
                       onSelect={onSelect}
                     />
                   ))}
@@ -465,6 +469,7 @@ export function ChannelsPanelView(props: ChannelsPanelViewProps): React.ReactEle
 export function ChannelsPanel(): React.ReactElement {
   const channels = useStore((s) => s.channels);
   const channelUnread = useStore((s) => s.channelUnread);
+  const channelMentions = useStore((s) => s.channelMentions);
   const activeChannelId = useStore((s) => s.activeChannelId);
   const company = useStore((s) => s.company);
   // Channels are decoupled from in-app Company mode: when no company is set,
@@ -535,6 +540,7 @@ export function ChannelsPanel(): React.ReactElement {
     <ChannelsPanelView
       channels={channels}
       channelUnread={channelUnread}
+      channelMentions={channelMentions}
       activeChannelId={activeChannelId}
       company={company}
       onSelect={setActiveChannel}

--- a/src/renderer/components/Channels/Composer.tsx
+++ b/src/renderer/components/Channels/Composer.tsx
@@ -14,10 +14,17 @@
 //
 // Plan ref: U4 (wire-path entry), U8 (UI surface), R7, R22, R26.
 
-import { useState, useRef, useCallback, type FormEvent, type KeyboardEvent } from 'react';
+import {
+  useState,
+  useRef,
+  useCallback,
+  useMemo,
+  type FormEvent,
+  type KeyboardEvent,
+} from 'react';
 import { useStore } from '../../stores';
 import { generateId } from '../../../shared/types';
-import type { ChannelMessage } from '../../../shared/channels';
+import type { ChannelMember, ChannelMention, ChannelMessage } from '../../../shared/channels';
 import { useT } from '../../hooks/useT';
 import { tokenAttrs } from '../../themes';
 import { FOCUS_RING } from '../focusRing';
@@ -37,6 +44,7 @@ export function synthesizeChannelMessage(params: {
   senderMemberId: string;
   senderMemberName: string;
   clientMsgId?: string;
+  mentions?: ChannelMention[];
 }): ChannelMessage {
   return {
     channelId: params.channelId,
@@ -48,14 +56,67 @@ export function synthesizeChannelMessage(params: {
     postedAt: Date.now(),
     deliveryStatus: 'pending',
     clientMsgId: params.clientMsgId,
+    // The daemon re-validates + overwrites this; carried so the optimistic
+    // local insert renders @tokens before the authoritative row lands.
+    ...(params.mentions && params.mentions.length > 0
+      ? { mentions: params.mentions }
+      : {}),
   };
+}
+
+// ─── @-mention token detection ──────────────────────────────────────────
+
+/** A member the composer can @-mention. The human UI participates as one
+ *  member per workspace (memberId `local-ui`), so the display label is the
+ *  workspace name. */
+export interface MentionCandidate {
+  workspaceId: string;
+  memberId: string;
+  name: string;
+}
+
+/**
+ * Detect an in-progress `@` mention token immediately left of the caret.
+ * Returns the `start` index of the `@` and the `query` typed after it, or
+ * `null` when the caret is not inside a mention token.
+ *
+ * Rules: the `@` must sit at a word boundary (string start or after
+ * whitespace) so emails like `a@b` don't trigger it, and the token does not
+ * cross a newline. The query MAY contain spaces (workspace names can), so a
+ * trailing-space query that no longer matches any candidate simply collapses
+ * the dropdown via the empty filter — there's no hard space terminator.
+ */
+export function detectMentionToken(
+  value: string,
+  caret: number,
+): { start: number; query: string } | null {
+  for (let i = caret - 1; i >= 0; i--) {
+    const ch = value[i];
+    if (ch === '\n' || ch === '\r') return null;
+    if (ch === '@') {
+      const prev = i > 0 ? value[i - 1] : '';
+      if (prev === '' || /\s/.test(prev)) {
+        return { start: i, query: value.slice(i + 1, caret) };
+      }
+      return null;
+    }
+  }
+  return null;
 }
 
 // ─── Pure view (props-driven) ───────────────────────────────────────────
 
+const EMPTY_CANDIDATES: MentionCandidate[] = [];
+
 export interface ComposerContentProps {
   channelId: string;
-  onSubmit: (text: string) => Promise<{ ok: boolean; errorCode?: string; errorMessage?: string }>;
+  onSubmit: (
+    text: string,
+    mentions: ChannelMention[],
+  ) => Promise<{ ok: boolean; errorCode?: string; errorMessage?: string }>;
+  /** Members this composer can @-mention. The sender is excluded upstream
+   *  (you can't ping yourself). Defaults to none (no dropdown). */
+  mentionCandidates?: MentionCandidate[];
   /** Translator — defaults to identity. Tests pass a stub. */
   t?: (key: string) => string;
   /** Override the placeholder when running in a test. */
@@ -72,18 +133,44 @@ export interface ComposerContentProps {
 export function ComposerContent({
   channelId,
   onSubmit,
+  mentionCandidates,
   placeholder,
   disabled,
   t: tProp,
 }: ComposerContentProps): React.ReactElement {
   const t = tProp ?? ((key: string) => key);
+  const candidates = mentionCandidates ?? EMPTY_CANDIDATES;
   const [text, setText] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [inFlight, setInFlight] = useState(false);
+  // The in-progress `@` token under the caret (null = dropdown closed) and
+  // the highlighted option within it.
+  const [token, setToken] = useState<{ start: number; query: string } | null>(null);
+  const [activeIdx, setActiveIdx] = useState(0);
+  // Mentions the user picked from the dropdown, keyed by workspace. Sent on
+  // submit only if the @name token still survives in the text (so deleting
+  // the token drops the ping).
+  const [picked, setPicked] = useState<ChannelMention[]>([]);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   const trimmed = text.trim();
   const canSend = trimmed.length > 0 && !inFlight && !disabled;
+
+  // Candidates matching the active query (case-insensitive substring).
+  const matches = useMemo(() => {
+    if (!token) return EMPTY_CANDIDATES;
+    const q = token.query.toLowerCase();
+    return candidates.filter((c) => c.name.toLowerCase().includes(q));
+  }, [token, candidates]);
+
+  const dropdownOpen = token !== null && matches.length > 0 && !inFlight && !disabled;
+
+  const resetAfterSend = useCallback(() => {
+    setText('');
+    setPicked([]);
+    setToken(null);
+    setActiveIdx(0);
+  }, []);
 
   const handleSubmit = useCallback(
     async (e: FormEvent) => {
@@ -92,9 +179,12 @@ export function ComposerContent({
       setInFlight(true);
       setError(null);
       try {
-        const result = await onSubmit(trimmed);
+        // Attach only mentions whose @name token still survives in the body;
+        // the daemon re-validates against live membership.
+        const mentions = picked.filter((m) => text.includes(`@${m.name}`));
+        const result = await onSubmit(trimmed, mentions);
         if (result.ok) {
-          setText('');
+          resetAfterSend();
           inputRef.current?.focus();
         } else {
           setError(result.errorMessage ?? t('channels.postFailed') ?? 'Post failed');
@@ -105,11 +195,61 @@ export function ComposerContent({
         setInFlight(false);
       }
     },
-    [canSend, onSubmit, trimmed, t],
+    [canSend, onSubmit, trimmed, text, picked, resetAfterSend, t],
+  );
+
+  const applyMention = useCallback(
+    (c: MentionCandidate) => {
+      if (!token) return;
+      const before = text.slice(0, token.start);
+      const after = text.slice(token.start + 1 + token.query.length);
+      const insert = `@${c.name} `;
+      const caret = before.length + insert.length;
+      setText(before + insert + after);
+      setPicked((prev) =>
+        prev.some((p) => p.workspaceId === c.workspaceId)
+          ? prev
+          : [...prev, { workspaceId: c.workspaceId, memberId: c.memberId, name: c.name }],
+      );
+      setToken(null);
+      setActiveIdx(0);
+      // Restore focus + caret immediately after the inserted mention.
+      requestAnimationFrame(() => {
+        const el = inputRef.current;
+        if (el) {
+          el.focus();
+          el.setSelectionRange(caret, caret);
+        }
+      });
+    },
+    [token, text],
   );
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (dropdownOpen) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          setActiveIdx((i) => (i + 1) % matches.length);
+          return;
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          setActiveIdx((i) => (i - 1 + matches.length) % matches.length);
+          return;
+        }
+        // Enter or Tab commits the highlighted mention instead of submitting.
+        if (e.key === 'Enter' || e.key === 'Tab') {
+          e.preventDefault();
+          applyMention(matches[activeIdx] ?? matches[0]);
+          return;
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          setToken(null);
+          return;
+        }
+      }
       // Enter submits; Shift+Enter inserts a newline.
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
@@ -118,7 +258,18 @@ export function ComposerContent({
         }
       }
     },
-    [canSend, handleSubmit],
+    [dropdownOpen, matches, activeIdx, applyMention, canSend, handleSubmit],
+  );
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const value = e.target.value;
+      setText(value);
+      if (error) setError(null);
+      setToken(detectMentionToken(value, e.target.selectionStart ?? value.length));
+      setActiveIdx(0);
+    },
+    [error],
   );
 
   return (
@@ -139,7 +290,41 @@ export function ComposerContent({
           {error}
         </div>
       )}
-      <div className="flex items-end gap-2">
+      <div className="relative flex items-end gap-2">
+        {dropdownOpen && (
+          <div
+            data-channel-mention-dropdown
+            role="listbox"
+            className="absolute bottom-full left-0 mb-1 z-20 w-56 max-h-[40vh] overflow-y-auto rounded-md shadow-xl py-1 bg-[var(--bg-surface)]"
+            style={{ border: '1px solid var(--border-soft)' }}
+            {...tokenAttrs('bgSurface', 'bg')}
+          >
+            {matches.map((c, idx) => (
+              <button
+                type="button"
+                key={`${c.workspaceId}:${c.memberId}`}
+                data-channel-mention-option
+                data-workspace-id={c.workspaceId}
+                data-active={idx === activeIdx ? 'true' : undefined}
+                role="option"
+                aria-selected={idx === activeIdx}
+                // preventDefault on mousedown so the textarea doesn't blur
+                // (and tear down the dropdown) before the click lands.
+                onMouseDown={(ev) => ev.preventDefault()}
+                onClick={() => applyMention(c)}
+                className={`w-full flex items-center gap-1.5 px-3 py-1 text-left text-[11px] font-mono transition-colors ${FOCUS_RING} ${
+                  idx === activeIdx
+                    ? 'bg-[var(--bg-overlay)] text-[var(--text-main)]'
+                    : 'text-[var(--text-sub)] hover:bg-[var(--bg-overlay)]'
+                }`}
+                {...tokenAttrs('textSub', 'text')}
+              >
+                <span className="text-[var(--accent-blue)]" aria-hidden="true">@</span>
+                <span className="truncate">{c.name}</span>
+              </button>
+            ))}
+          </div>
+        )}
         <textarea
           ref={inputRef}
           rows={2}
@@ -147,10 +332,7 @@ export function ComposerContent({
           value={text}
           placeholder={placeholder ?? t('channels.composerPlaceholder') ?? 'Type a message…'}
           disabled={disabled || inFlight}
-          onChange={(e) => {
-            setText(e.target.value);
-            if (error) setError(null);
-          }}
+          onChange={handleChange}
           onKeyDown={handleKeyDown}
           className={`flex-1 min-w-0 resize-none bg-[var(--bg-base)] text-[var(--text-main)] text-[12px] font-mono px-2 py-1.5 rounded border border-[var(--bg-surface)] outline-none ${FOCUS_RING}`}
           aria-label={t('channels.composerAriaLabel') || 'Compose channel message'}
@@ -192,6 +374,8 @@ export interface ComposerProps {
   onError: (toast: { message: string; level: 'info' | 'warn' | 'error' }) => void;
 }
 
+const EMPTY_MEMBERS: ChannelMember[] = [];
+
 export function Composer({ channelId, onError }: ComposerProps): React.ReactElement {
   const t = useT();
   const company = useStore((s) => s.company);
@@ -200,18 +384,38 @@ export function Composer({ channelId, onError }: ComposerProps): React.ReactElem
   // ChannelsPanel / ChannelView / useChannelsHydration).
   const activeWorkspaceId = useStore((s) => s.activeWorkspaceId);
   const channel = useStore((s) => s.channels[channelId]);
+  const members = useStore((s) => s.channelMembers[channelId] ?? EMPTY_MEMBERS);
+  const workspaces = useStore((s) => s.workspaces);
   const postMessageDaemon = useStore((s) => s.postMessageDaemon);
 
+  // Sender identity: the CEO workspace when Company mode is active, else the
+  // active workspace. The daemon's post path requires
+  // sender.workspaceId === verifiedWorkspaceId AND membership.
+  const selfWorkspaceId = company?.ceoWorkspaceId ?? activeWorkspaceId ?? null;
+
+  // @-mention candidates: every member workspace except the sender's own (you
+  // can't ping yourself), deduped by workspace and labeled with the workspace
+  // name — members are workspace-level in the human UI (memberId `local-ui`).
+  const mentionCandidates = useMemo<MentionCandidate[]>(() => {
+    const seen = new Set<string>();
+    const out: MentionCandidate[] = [];
+    for (const m of members) {
+      if (m.workspaceId === selfWorkspaceId) continue;
+      if (seen.has(m.workspaceId)) continue;
+      seen.add(m.workspaceId);
+      out.push({
+        workspaceId: m.workspaceId,
+        memberId: m.memberId,
+        name: workspaces.find((w) => w.id === m.workspaceId)?.name ?? m.workspaceId,
+      });
+    }
+    return out;
+  }, [members, workspaces, selfWorkspaceId]);
+
   const handlePost = useCallback(
-    async (text: string) => {
-      // Sender identity: the CEO workspace when Company mode is active, else
-      // the active workspace. The daemon's post path requires
-      // sender.workspaceId === verifiedWorkspaceId AND membership; posting
-      // succeeds on channels this identity is a member of (e.g. ones it
-      // created here). A channel created by another client requires a join
-      // first — that is the daemon's membership rule (NOT_A_MEMBER), not a
-      // company gate.
-      const selfWorkspaceId = company?.ceoWorkspaceId ?? activeWorkspaceId;
+    async (text: string, mentions: ChannelMention[]) => {
+      // A channel created by another client requires a join first — that is
+      // the daemon's membership rule (NOT_A_MEMBER), not a company gate.
       if (!channel || !selfWorkspaceId) {
         return { ok: false, errorCode: 'UNKNOWN', errorMessage: 'No channel or workspace identity' };
       }
@@ -222,6 +426,10 @@ export function Composer({ channelId, onError }: ComposerProps): React.ReactElem
       // dedupes against the prior in-flight post.
       const clientMsgId = generateId('cmid');
       const nextSeq = channel.nextSeq;
+      // The daemon re-validates mentions against live membership and drops any
+      // non-member / forged entry; we send our best-effort set and carry it on
+      // the optimistic row so @tokens render immediately.
+      const mentionsArg = mentions.length > 0 ? mentions : undefined;
       const message = synthesizeChannelMessage({
         channelId,
         seq: nextSeq,
@@ -230,6 +438,7 @@ export function Composer({ channelId, onError }: ComposerProps): React.ReactElem
         senderMemberId: 'local-ui',
         senderMemberName: 'local-ui',
         clientMsgId,
+        mentions: mentionsArg,
       });
       const result = await postMessageDaemon(channelId, {
         text,
@@ -239,6 +448,7 @@ export function Composer({ channelId, onError }: ComposerProps): React.ReactElem
           memberName: 'local-ui',
         },
         clientMsgId,
+        mentions: mentionsArg,
         message,
       });
       if (!result.ok) {
@@ -256,7 +466,7 @@ export function Composer({ channelId, onError }: ComposerProps): React.ReactElem
       }
       return { ok: true };
     },
-    [channelId, channel, company, postMessageDaemon, onError, t],
+    [channelId, channel, selfWorkspaceId, postMessageDaemon, onError, t],
   );
 
   // The composer is bound to a single channel; an archived channel is
@@ -267,6 +477,7 @@ export function Composer({ channelId, onError }: ComposerProps): React.ReactElem
     <ComposerContent
       channelId={channelId}
       onSubmit={handlePost}
+      mentionCandidates={mentionCandidates}
       disabled={!channel || channel.status === 'archived'}
       t={t}
     />

--- a/src/renderer/components/Channels/__tests__/ChannelView.test.tsx
+++ b/src/renderer/components/Channels/__tests__/ChannelView.test.tsx
@@ -26,6 +26,7 @@ import {
   isMessageVisibleToViewer,
   sortMessagesBySeq,
   viewerDeliveryStatus,
+  renderMessageText,
 } from '../ChannelView';
 
 // ─── Test fixtures ──────────────────────────────────────────────────────
@@ -73,6 +74,64 @@ function makeMessage(
 }
 
 // ─── Pure helper tests ──────────────────────────────────────────────────
+
+describe('renderMessageText', () => {
+  it('returns the plain string when there are no mentions', () => {
+    expect(renderMessageText('hello world')).toBe('hello world');
+    expect(renderMessageText('hello', [])).toBe('hello');
+  });
+
+  it('wraps an @name token in a highlight span', () => {
+    const out = renderMessageText('hi @bob bye', [{ workspaceId: 'ws-2', name: 'bob' }]);
+    const html = renderToStaticMarkup(createElement('div', null, out));
+    expect(html).toContain('data-channel-mention-token');
+    expect(html).toContain('@bob');
+  });
+
+  it('prefers the longer name when two mentions share a prefix', () => {
+    const out = renderMessageText('ping @john doe!', [
+      { workspaceId: 'ws-2', name: 'john' },
+      { workspaceId: 'ws-3', name: 'john doe' },
+    ]);
+    const html = renderToStaticMarkup(createElement('div', null, out));
+    expect(html).toContain('@john doe');
+  });
+
+  it('leaves a bare @ that matches no member as plain text', () => {
+    const out = renderMessageText('email a@b.com', [{ workspaceId: 'ws-2', name: 'bob' }]);
+    const html = renderToStaticMarkup(createElement('div', null, out));
+    expect(html).not.toContain('data-channel-mention-token');
+  });
+});
+
+describe('ChannelViewContent — mention highlight', () => {
+  it('flags a message that mentions the viewer with data-mentions-me', () => {
+    const html = renderToStaticMarkup(
+      createElement(ChannelViewContent, {
+        channel: makeChannel(),
+        messages: [makeMessage('ch-1', 1, { text: 'hey @me', mentions: [{ workspaceId: 'ws-me', name: 'me' }] })],
+        viewer: makeMember({ workspaceId: 'ws-me' }),
+        onClose: () => undefined,
+        composerSlot: createElement('div'),
+      }),
+    );
+    expect(html).toContain('data-mentions-me="true"');
+    expect(html).toContain('data-channel-mention-token');
+  });
+
+  it('does not flag a message that mentions another workspace', () => {
+    const html = renderToStaticMarkup(
+      createElement(ChannelViewContent, {
+        channel: makeChannel(),
+        messages: [makeMessage('ch-1', 1, { mentions: [{ workspaceId: 'ws-other', name: 'other' }] })],
+        viewer: makeMember({ workspaceId: 'ws-me' }),
+        onClose: () => undefined,
+        composerSlot: createElement('div'),
+      }),
+    );
+    expect(html).not.toContain('data-mentions-me');
+  });
+});
 
 describe('isMessageVisibleToViewer', () => {
   it('returns false when viewer is null', () => {

--- a/src/renderer/components/Channels/__tests__/ChannelsPanel.test.tsx
+++ b/src/renderer/components/Channels/__tests__/ChannelsPanel.test.tsx
@@ -70,6 +70,7 @@ function resetStore() {
     s.channelMessages = {};
     s.activeChannelId = null;
     s.channelUnread = {};
+    s.channelMentions = {};
     s.company = null;
   });
 }
@@ -169,6 +170,7 @@ function renderItem(props: {
   name: string;
   isActive: boolean;
   unreadCount: number;
+  mentioned?: boolean;
   onSelect?: (id: string) => void;
 }): string {
   return renderToStaticMarkup(
@@ -176,6 +178,7 @@ function renderItem(props: {
       channel: makeChannel({ id: props.id, name: props.name }),
       isActive: props.isActive,
       unreadCount: props.unreadCount,
+      mentioned: props.mentioned,
       onSelect: props.onSelect ?? (() => undefined),
     }),
   );
@@ -244,6 +247,25 @@ describe('ChannelItemView', () => {
     expect(html).toContain('tabindex="0"');
     expect(html).toContain('data-channel-id="ch-7"');
   });
+
+  it('promotes the badge to a red @ mention badge when mentioned', () => {
+    const html = renderItem({ id: 'ch-1', name: 'general', isActive: false, unreadCount: 2, mentioned: true });
+    expect(html).toContain('data-channel-mention="true"');
+    expect(html).toContain('var(--accent-red)');
+    expect(html).toContain('@');
+  });
+
+  it('shows the mention badge even when unreadCount is 0', () => {
+    const html = renderItem({ id: 'ch-1', name: 'general', isActive: false, unreadCount: 0, mentioned: true });
+    expect(html).toContain('data-channel-mention="true"');
+    expect(html).toContain('@');
+  });
+
+  it('leaves a plain unread badge unmarked (blue, no @)', () => {
+    const html = renderItem({ id: 'ch-1', name: 'general', isActive: false, unreadCount: 3, mentioned: false });
+    expect(html).not.toContain('data-channel-mention');
+    expect(html).toContain('var(--accent-blue)');
+  });
 });
 
 describe('ChannelsPanel — click + create wiring', () => {
@@ -296,6 +318,7 @@ describe('ChannelsPanel — click + create wiring', () => {
 interface RenderPanelArgs {
   channels?: Record<string, Channel>;
   channelUnread?: Record<string, number>;
+  channelMentions?: Record<string, number>;
   activeChannelId?: string | null;
   company?: Company | null;
   onSelect?: (id: string) => void;
@@ -307,6 +330,7 @@ function renderPanel(args: RenderPanelArgs = {}): string {
     createElement(ChannelsPanelView, {
       channels: args.channels ?? {},
       channelUnread: args.channelUnread ?? {},
+      channelMentions: args.channelMentions ?? {},
       activeChannelId: args.activeChannelId ?? null,
       company: args.company === undefined ? makeCompany() : args.company,
       onSelect: args.onSelect ?? ((id) => recordedSelects.push(id)),
@@ -429,6 +453,24 @@ describe('ChannelsPanelView', () => {
     });
     // Plan U7 verification: no literal hex colors.
     expect(html).not.toMatch(/#[0-9a-fA-F]{3,8}(?=[^a-zA-Z0-9])/);
+  });
+
+  it('surfaces a mention badge on a row whose channelMentions count is positive', () => {
+    const html = renderPanel({
+      channels: { 'ch-1': makeChannel({ id: 'ch-1', name: 'general' }) },
+      channelUnread: { 'ch-1': 2 },
+      channelMentions: { 'ch-1': 1 },
+    });
+    expect(html).toContain('data-channel-mention="true"');
+  });
+
+  it('does not mark a row as mentioned when its channelMentions count is 0', () => {
+    const html = renderPanel({
+      channels: { 'ch-1': makeChannel({ id: 'ch-1', name: 'general' }) },
+      channelUnread: { 'ch-1': 2 },
+      channelMentions: {},
+    });
+    expect(html).not.toContain('data-channel-mention');
   });
 });
 

--- a/src/renderer/components/Channels/__tests__/Composer.mentions.dynamic.test.tsx
+++ b/src/renderer/components/Channels/__tests__/Composer.mentions.dynamic.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+//
+// Dynamic interaction test for the composer @-mention autocomplete (#5).
+// renderToStaticMarkup (Composer.test.tsx) can't fire input/keydown events, so
+// this mounts the REAL <ComposerContent/> via react-dom/client and drives the
+// actual DOM: typing '@', filtering, keyboard nav, commit, and the mentions[]
+// payload handed to onSubmit. Mirrors ChannelView.archive.dynamic.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createElement, act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { ComposerContent, type MentionCandidate } from '../Composer';
+
+const CANDIDATES: MentionCandidate[] = [
+  { workspaceId: 'ws-2', memberId: 'local-ui', name: 'alice' },
+  { workspaceId: 'ws-3', memberId: 'local-ui', name: 'bob' },
+  { workspaceId: 'ws-4', memberId: 'local-ui', name: 'alf' },
+];
+
+let container: HTMLDivElement;
+let root: Root;
+
+function mount(
+  props: {
+    onSubmit?: (
+      text: string,
+      mentions: unknown[],
+    ) => Promise<{ ok: boolean; errorMessage?: string }>;
+    candidates?: MentionCandidate[];
+  } = {},
+): void {
+  act(() => {
+    root.render(
+      createElement(ComposerContent, {
+        channelId: 'ch-1',
+        onSubmit: props.onSubmit ?? (async () => ({ ok: true })),
+        mentionCandidates: props.candidates ?? CANDIDATES,
+        t: (k: string) => k,
+      }),
+    );
+  });
+}
+
+const input = (): HTMLTextAreaElement => {
+  const el = container.querySelector(
+    '[data-channel-composer-input]',
+  ) as HTMLTextAreaElement | null;
+  if (!el) throw new Error('composer input not rendered');
+  return el;
+};
+const dropdown = (): HTMLElement | null =>
+  container.querySelector('[data-channel-mention-dropdown]');
+const options = (): HTMLElement[] =>
+  Array.from(container.querySelectorAll('[data-channel-mention-option]'));
+const sendBtn = (): HTMLElement => {
+  const el = container.querySelector(
+    '[data-channel-composer-send]',
+  ) as HTMLElement | null;
+  if (!el) throw new Error('send button not rendered');
+  return el;
+};
+
+// Set a controlled <textarea>'s value the way React's synthetic onChange
+// expects: the native value setter + a bubbling input event, with the caret
+// placed at `caret` (detectMentionToken reads selectionStart).
+function type(value: string, caret = value.length): void {
+  const el = input();
+  act(() => {
+    const setter = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(el),
+      'value',
+    )?.set;
+    setter?.call(el, value);
+    el.selectionStart = caret;
+    el.selectionEnd = caret;
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+const press = (k: string): void => {
+  act(() => {
+    input().dispatchEvent(
+      new KeyboardEvent('keydown', { key: k, bubbles: true, cancelable: true }),
+    );
+  });
+};
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe('ComposerContent — @-mention autocomplete (jsdom)', () => {
+  it('shows no dropdown until an @ token is typed', () => {
+    mount();
+    expect(dropdown()).toBeNull();
+    type('hello');
+    expect(dropdown()).toBeNull();
+  });
+
+  it('typing @ opens the dropdown with every candidate', () => {
+    mount();
+    type('@');
+    expect(dropdown()).not.toBeNull();
+    expect(options()).toHaveLength(3);
+  });
+
+  it('filters candidates by the query (case-insensitive substring)', () => {
+    mount();
+    type('@AL'); // uppercase — match is case-insensitive
+    const names = options().map((o) => o.textContent ?? '');
+    expect(options()).toHaveLength(2); // alice, alf — not bob
+    expect(names.some((n) => n.includes('alice'))).toBe(true);
+    expect(names.some((n) => n.includes('alf'))).toBe(true);
+    expect(names.some((n) => n.includes('bob'))).toBe(false);
+  });
+
+  it('collapses the dropdown when the query matches nothing', () => {
+    mount();
+    type('@zzz');
+    expect(dropdown()).toBeNull();
+  });
+
+  it('ArrowDown moves the active option (wrapping)', () => {
+    mount();
+    type('@al'); // [alice, alf]
+    expect(options()[0].getAttribute('data-active')).toBe('true');
+    press('ArrowDown');
+    expect(options()[0].getAttribute('data-active')).toBeNull();
+    expect(options()[1].getAttribute('data-active')).toBe('true');
+    press('ArrowDown'); // wraps back to first
+    expect(options()[0].getAttribute('data-active')).toBe('true');
+  });
+
+  it('Enter commits the highlighted mention and closes the dropdown', () => {
+    mount();
+    type('@al');
+    press('ArrowDown'); // highlight alf
+    press('Enter'); // commit alf
+    expect(input().value).toBe('@alf ');
+    expect(dropdown()).toBeNull();
+  });
+
+  it('clicking an option commits that mention', () => {
+    mount();
+    type('@');
+    act(() => {
+      options()[1].dispatchEvent(new MouseEvent('click', { bubbles: true })); // bob
+    });
+    expect(input().value).toBe('@bob ');
+    expect(dropdown()).toBeNull();
+  });
+
+  it('Escape closes the dropdown without committing', () => {
+    mount();
+    type('@al');
+    expect(dropdown()).not.toBeNull();
+    press('Escape');
+    expect(dropdown()).toBeNull();
+    expect(input().value).toBe('@al'); // text untouched
+  });
+
+  it('sends the picked mention in the mentions[] payload', async () => {
+    const onSubmit = vi.fn(async () => ({ ok: true }));
+    mount({ onSubmit });
+    type('@alice');
+    press('Enter'); // commit alice → '@alice '
+    await act(async () => {
+      sendBtn().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith('@alice', [
+      { workspaceId: 'ws-2', memberId: 'local-ui', name: 'alice' },
+    ]);
+  });
+
+  it('drops a picked mention whose @token was deleted before send', async () => {
+    const onSubmit = vi.fn(async () => ({ ok: true }));
+    mount({ onSubmit });
+    type('@alice');
+    press('Enter'); // '@alice '
+    type('different text'); // user wiped the mention token
+    await act(async () => {
+      sendBtn().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith('different text', []);
+  });
+});

--- a/src/renderer/components/Channels/__tests__/Composer.test.tsx
+++ b/src/renderer/components/Channels/__tests__/Composer.test.tsx
@@ -19,6 +19,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import {
   ComposerContent,
   synthesizeChannelMessage,
+  detectMentionToken,
 } from '../Composer';
 
 // ─── synthesizeChannelMessage ───────────────────────────────────────────
@@ -119,5 +120,63 @@ describe('ComposerContent', () => {
     const html = renderComposer();
     // Plan U8 verification: no literal hex colors.
     expect(html).not.toMatch(/#[0-9a-fA-F]{3,8}(?=[^a-zA-Z0-9])/);
+  });
+});
+
+// ─── detectMentionToken (pure caret scanner) ────────────────────────────
+
+describe('detectMentionToken', () => {
+  it('detects @ at the start of the string', () => {
+    expect(detectMentionToken('@a', 2)).toEqual({ start: 0, query: 'a' });
+  });
+  it('detects @ after whitespace', () => {
+    expect(detectMentionToken('hi @bo', 6)).toEqual({ start: 3, query: 'bo' });
+  });
+  it('returns the empty query right after a bare @', () => {
+    expect(detectMentionToken('@', 1)).toEqual({ start: 0, query: '' });
+  });
+  it('returns null when there is no @ before the caret', () => {
+    expect(detectMentionToken('hello', 5)).toBeNull();
+  });
+  it('ignores @ that is not at a word boundary (emails)', () => {
+    expect(detectMentionToken('a@b', 3)).toBeNull();
+  });
+  it('does not cross a newline', () => {
+    expect(detectMentionToken('@a\nfoo', 6)).toBeNull();
+  });
+  it('picks the nearest @ on the caret line', () => {
+    expect(detectMentionToken('@x\n@y', 5)).toEqual({ start: 3, query: 'y' });
+  });
+  it('allows spaces in the query (multi-word workspace names)', () => {
+    expect(detectMentionToken('@John D', 7)).toEqual({ start: 0, query: 'John D' });
+  });
+});
+
+// ─── synthesizeChannelMessage mentions ──────────────────────────────────
+
+describe('synthesizeChannelMessage mentions', () => {
+  it('carries mentions when provided', () => {
+    const m = synthesizeChannelMessage({
+      channelId: 'ch-1',
+      seq: 1,
+      text: 'hi @bob',
+      senderWorkspaceId: 'ws-1',
+      senderMemberId: 'm-1',
+      senderMemberName: 'Lead',
+      mentions: [{ workspaceId: 'ws-2', name: 'bob' }],
+    });
+    expect(m.mentions).toEqual([{ workspaceId: 'ws-2', name: 'bob' }]);
+  });
+  it('omits the mentions field when the array is empty', () => {
+    const m = synthesizeChannelMessage({
+      channelId: 'ch-1',
+      seq: 1,
+      text: 'hi',
+      senderWorkspaceId: 'ws-1',
+      senderMemberId: 'm-1',
+      senderMemberName: 'Lead',
+      mentions: [],
+    });
+    expect(m.mentions).toBeUndefined();
   });
 });

--- a/src/renderer/hooks/__tests__/channelMentionInbox.test.ts
+++ b/src/renderer/hooks/__tests__/channelMentionInbox.test.ts
@@ -1,0 +1,147 @@
+// ─── Tests for channel mention → a2a inbox routing (#7) ──────────────────
+//
+// Pure-function tests: routeChannelMentionToInbox takes injected deps, so we
+// drive it with spies and assert the task shape + pointer emit + idempotency
+// without a store or EventBus.
+
+import { describe, it, expect } from 'vitest';
+import {
+  routeChannelMentionToInbox,
+  channelMentionTaskId,
+  type MentionInboxDeps,
+} from '../channelMentionInbox';
+import type { ChannelMessage } from '../../../shared/channels';
+import type { Task } from '../../../shared/types';
+
+function makeMessage(overrides: Partial<ChannelMessage> = {}): ChannelMessage {
+  return {
+    channelId: 'ch-1',
+    seq: 5,
+    workspaceId: 'ws-sender',
+    memberId: 'm-1',
+    memberName: 'Alice',
+    text: 'hey @me check this',
+    postedAt: 1_700_000_000_000,
+    deliveryStatus: 'pending',
+    mentions: [{ workspaceId: 'ws-me', name: 'me' }],
+    ...overrides,
+  };
+}
+
+type CreatedTask = Parameters<MentionInboxDeps['createA2aTask']>[0];
+interface Published {
+  from: string;
+  to: string;
+  taskId: string;
+  state: string;
+  kind: string;
+}
+
+function makeDeps(overrides: Partial<MentionInboxDeps> = {}): {
+  deps: MentionInboxDeps;
+  created: CreatedTask[];
+  published: Published[];
+} {
+  const created: CreatedTask[] = [];
+  const published: Published[] = [];
+  const deps: MentionInboxDeps = {
+    getTask: () => undefined,
+    createA2aTask: (t) => {
+      created.push(t);
+      return t.id ?? 'task-x';
+    },
+    channelName: (id) => (id === 'ch-1' ? 'general' : id),
+    workspaceName: (id) => (id === 'ws-me' ? 'My WS' : id),
+    publish: (from, to, taskId, state, kind) => {
+      published.push({ from, to, taskId, state, kind });
+    },
+    ...overrides,
+  };
+  return { deps, created, published };
+}
+
+describe('channelMentionTaskId', () => {
+  it('is deterministic', () => {
+    expect(channelMentionTaskId('ch-9', 42)).toBe('chmention-ch-9-42');
+  });
+});
+
+describe('routeChannelMentionToInbox', () => {
+  it('creates nothing when the message does not mention self', () => {
+    const { deps, created, published } = makeDeps();
+    const out = routeChannelMentionToInbox(
+      makeMessage({ mentions: [{ workspaceId: 'ws-other', name: 'other' }] }),
+      'ws-me',
+      deps,
+    );
+    expect(out).toBeNull();
+    expect(created).toHaveLength(0);
+    expect(published).toHaveLength(0);
+  });
+
+  it('creates nothing when the message carries no mentions at all', () => {
+    const { deps, created } = makeDeps();
+    const out = routeChannelMentionToInbox(makeMessage({ mentions: undefined }), 'ws-me', deps);
+    expect(out).toBeNull();
+    expect(created).toHaveLength(0);
+  });
+
+  it('mints an a2a task + emits the pointer on a self-mention', () => {
+    const { deps, created, published } = makeDeps();
+    const out = routeChannelMentionToInbox(makeMessage(), 'ws-me', deps);
+
+    expect(out).toBe(channelMentionTaskId('ch-1', 5));
+    expect(created).toHaveLength(1);
+    const t = created[0];
+    expect(t.id).toBe('chmention-ch-1-5');
+    expect(t.from).toEqual({ workspaceId: 'ws-sender', name: 'Alice' });
+    expect(t.to).toEqual({ workspaceId: 'ws-me', name: 'My WS' });
+    expect(t.title).toContain('general');
+    expect(t.history).toHaveLength(1);
+    expect(t.history[0].role).toBe('user');
+    expect(t.history[0].parts[0]).toEqual({ kind: 'text', text: 'hey @me check this' });
+
+    expect(published).toHaveLength(1);
+    expect(published[0]).toMatchObject({
+      from: 'ws-sender',
+      to: 'ws-me',
+      taskId: 'chmention-ch-1-5',
+      state: 'submitted',
+      kind: 'created',
+    });
+  });
+
+  it('does not ping yourself when you authored the post', () => {
+    const { deps, created, published } = makeDeps();
+    const out = routeChannelMentionToInbox(
+      makeMessage({ workspaceId: 'ws-me', mentions: [{ workspaceId: 'ws-me', name: 'me' }] }),
+      'ws-me',
+      deps,
+    );
+    expect(out).toBeNull();
+    expect(created).toHaveLength(0);
+    expect(published).toHaveLength(0);
+  });
+
+  it('is idempotent — a re-delivered event does not double-create', () => {
+    const existing = { kind: 'task', id: 'chmention-ch-1-5' } as Task;
+    const { deps, created, published } = makeDeps({
+      getTask: (id) => (id === 'chmention-ch-1-5' ? existing : undefined),
+    });
+    const out = routeChannelMentionToInbox(makeMessage(), 'ws-me', deps);
+    expect(out).toBeNull();
+    expect(created).toHaveLength(0);
+    expect(published).toHaveLength(0);
+  });
+
+  it('returns null (no throw) when createA2aTask fails — never breaks dispatch', () => {
+    const { deps, published } = makeDeps({
+      createA2aTask: () => {
+        throw new Error('boom');
+      },
+    });
+    const out = routeChannelMentionToInbox(makeMessage(), 'ws-me', deps);
+    expect(out).toBeNull();
+    expect(published).toHaveLength(0);
+  });
+});

--- a/src/renderer/hooks/channelMentionInbox.ts
+++ b/src/renderer/hooks/channelMentionInbox.ts
@@ -1,0 +1,124 @@
+// ─── Channel mention → a2a inbox routing (Phase 2 #7) ────────────────────
+//
+// Channels have no agent-read path yet (channel_history is deferred), so an
+// agent never *sees* a channel post — even one that @-mentions it. This module
+// bridges that gap WITHOUT a new agent surface: when a channel.message that
+// mentions the current workspace lands in the renderer (the same event that
+// drives the dock badge in #6), we mint an a2a task addressed to this
+// workspace. The agent then receives it through its NORMAL inbox poll
+// (`a2a_task_query` / `wmux_events_poll` for `a2a.task`) and can reply with
+// `channel_post` (#8). We reuse the a2a task infrastructure rather than invent
+// a parallel channel-mention event type.
+//
+// Trust: the mention set is server-validated (ChannelService.post keeps only
+// current-member mentions, frozen at critical-section entry), so `from`
+// (= the post's sender workspace) is the daemon's authoritative sender, not a
+// renderer-forgeable value. The mentioned workspace's own renderer is the one
+// that observes the event and creates the task — `to` is always self.
+//
+// Routing granularity: WORKSPACE-LEVEL. The task carries no `to.paneId`, so any
+// agent in the mentioned workspace picks it up via `a2a_task_query(role:agent)`
+// — robust to splits (multiple panes/agents in one workspace) without guessing
+// which pane "owns" the mention.
+//
+// Idempotency: the task id is deterministic (`chmention-<channelId>-<seq>`), so
+// event re-delivery (resync replay, double poll) is a no-op — `getTask` short-
+// circuits before a duplicate task or a duplicate `a2a.task` event is emitted.
+
+import type { ChannelMessage } from '../../shared/channels';
+import type { Task, Message, Part, Artifact, TaskState } from '../../shared/types';
+
+/** Dependencies injected so the routing logic stays a pure, unit-testable
+ *  function (no store / window coupling). The hook wires these to the real
+ *  store actions + EventBus publisher. */
+export interface MentionInboxDeps {
+  /** Look up an existing task by id (idempotency guard). */
+  getTask: (taskId: string) => Task | undefined;
+  /** Create the inbox task; returns its id. Mirrors `a2aSlice.createA2aTask`. */
+  createA2aTask: (task: {
+    id?: string;
+    title: string;
+    from: { workspaceId: string; name: string; paneId?: string; surfaceId?: string };
+    to: { workspaceId: string; name: string; paneId?: string; surfaceId?: string };
+    history: Message[];
+    artifacts: Artifact[];
+  }) => string;
+  /** Resolve a channel's display name (falls back to the id). */
+  channelName: (channelId: string) => string;
+  /** Resolve a workspace's display name (falls back to the id). */
+  workspaceName: (workspaceId: string) => string;
+  /** Emit the dual-party `a2a.task` pointer (events/publisher.publishA2aTask). */
+  publish: (
+    from: string,
+    to: string,
+    taskId: string,
+    state: TaskState,
+    kind: 'created' | 'updated' | 'cancelled',
+  ) => void;
+}
+
+/** Deterministic task id for a channel mention — idempotent across event
+ *  re-delivery. Exported for the test + any future reconciliation. */
+export function channelMentionTaskId(channelId: string, seq: number): string {
+  return `chmention-${channelId}-${seq}`;
+}
+
+/**
+ * Route one channel.message into the a2a inbox iff it @-mentions `selfWorkspaceId`.
+ * Returns the created task id, or `null` when nothing was routed (not mentioned,
+ * self-posted, or already routed). Never throws — a routing failure must not
+ * break the channel message dispatch that drives the UI.
+ */
+export function routeChannelMentionToInbox(
+  message: ChannelMessage,
+  selfWorkspaceId: string,
+  deps: MentionInboxDeps,
+): string | null {
+  // Only act on a mention of THIS workspace.
+  if (!message.mentions?.some((m) => m.workspaceId === selfWorkspaceId)) return null;
+  // Never ping yourself — a post this workspace authored that happens to carry
+  // a self mention (composer excludes self, but a non-UI client could include
+  // it; the daemon validates membership, not self-exclusion).
+  if (message.workspaceId === selfWorkspaceId) return null;
+
+  const taskId = channelMentionTaskId(message.channelId, message.seq);
+  // Idempotent: a re-delivered event (resync replay / overlapping poll) must
+  // not mint a second task or re-emit the pointer.
+  if (deps.getTask(taskId)) return null;
+
+  const chName = deps.channelName(message.channelId);
+  const parts: Part[] = [{ kind: 'text', text: message.text }];
+  const history: Message[] = [
+    {
+      kind: 'message',
+      // Deterministic message id mirrors the task id's idempotency intent.
+      messageId: `chmention-msg-${message.channelId}-${message.seq}`,
+      role: 'user',
+      parts,
+      metadata: {
+        source: 'channel-mention',
+        channelId: message.channelId,
+        seq: message.seq,
+      },
+    },
+  ];
+
+  try {
+    deps.createA2aTask({
+      id: taskId,
+      title: `#${chName} — mention from ${message.memberName}`,
+      from: { workspaceId: message.workspaceId, name: message.memberName },
+      to: { workspaceId: selfWorkspaceId, name: deps.workspaceName(selfWorkspaceId) },
+      history,
+      artifacts: [],
+    });
+    // Emit AFTER the store write so a poller that follows the pointer can
+    // immediately query the task (created-before-queryable race guard — same
+    // ordering rule as the a2a.task.send path).
+    deps.publish(message.workspaceId, selfWorkspaceId, taskId, 'submitted', 'created');
+  } catch {
+    // Best-effort: never let inbox routing break channel message dispatch.
+    return null;
+  }
+  return taskId;
+}

--- a/src/renderer/hooks/useChannelsEventSubscription.ts
+++ b/src/renderer/hooks/useChannelsEventSubscription.ts
@@ -47,6 +47,8 @@
 import { useEffect } from 'react';
 import { useStore } from '../stores';
 import { loadChannelHistory } from './useChannelsHydration';
+import { routeChannelMentionToInbox } from './channelMentionInbox';
+import { publishA2aTask } from '../events/publisher';
 import type { WmuxEvent, ChannelMessageEvent } from '../../shared/events';
 
 /** Polling cadence. 1 Hz is the same as the PluginFrame forwardEvents
@@ -205,7 +207,21 @@ export function useChannelsEventSubscription(): void {
             // re-filter needed — the slice trusts the dispatch.
             if (event.type === 'channel.message') {
               const channelEvent = event as ChannelMessageEvent;
-              useStore.getState().appendMessageFromEvent(channelEvent.message);
+              const st = useStore.getState();
+              st.appendMessageFromEvent(channelEvent.message);
+              // #7 Phase 2: a post that @-mentions THIS workspace becomes an
+              // a2a inbox task so the workspace's agent receives it through its
+              // normal poll (a2a_task_query / wmux_events_poll), bridging the
+              // deferred channel-read gap. Workspace-level (no pane pin);
+              // idempotent by deterministic task id.
+              routeChannelMentionToInbox(channelEvent.message, workspaceId, {
+                getTask: st.getTask,
+                createA2aTask: st.createA2aTask,
+                channelName: (id) => useStore.getState().channels[id]?.name ?? id,
+                workspaceName: (id) =>
+                  useStore.getState().workspaces.find((w) => w.id === id)?.name ?? id,
+                publish: publishA2aTask,
+              });
             }
           }
         })

--- a/src/renderer/hooks/useChannelsEventSubscription.ts
+++ b/src/renderer/hooks/useChannelsEventSubscription.ts
@@ -116,7 +116,27 @@ function readEventsPollBridge(): EventsPollBridge | undefined {
  *     `refreshChannels` rebuilds from authoritative state.
  */
 export function useChannelsEventSubscription(): void {
+  // Per-recipient scoping (plan U3, R3): the daemon's per-workspace filter at
+  // `events.rpc.ts:115-124` requires the caller to identify its own workspace
+  // or it silently drops every event. Channels are decoupled from in-app
+  // Company mode, so the identity is the company CEO workspace when set, else
+  // the active workspace (mirrors useChannelsHydration / ChannelsPanel).
+  //
+  // SUBSCRIBE to this (not getState() inside a []-deps effect): a prior bug read
+  // it once at mount, and if this hook mounted before `activeWorkspaceId` was
+  // set (boot race), self was null, the effect early-returned, and events.poll
+  // NEVER started — so live channel messages, the unread/mention dock badges,
+  // AND the mention→a2a inbox routing all silently no-op'd. Keying the effect on
+  // `workspaceId` re-runs it the moment self lands, starting the poll then.
+  // Multi-workspace renderers (FIX-MULTI-WS follow-up) will iterate every member
+  // workspace here; for v1 we poll one.
+  const workspaceId = useStore((s) => s.company?.ceoWorkspaceId ?? s.activeWorkspaceId);
   useEffect(() => {
+    if (!workspaceId) {
+      // No resolvable self yet (pre-boot). The selector above re-runs this
+      // effect once `activeWorkspaceId` is set — a wait, not a dead end.
+      return;
+    }
     const bridge = readEventsPollBridge();
     if (!bridge) {
       // The renderer should never reach this state — `useRpcBridge`
@@ -127,26 +147,6 @@ export function useChannelsEventSubscription(): void {
       // sentinel-erroring the user-visible state.
       console.warn(
         '[useChannelsEventSubscription] events.poll bridge not mounted — channel events will not auto-update',
-      );
-      return;
-    }
-
-    // Per-recipient scoping (plan U3, R3): the daemon's per-workspace
-    // filter at `events.rpc.ts:115-124` requires the caller to identify
-    // its own workspace or it silently drops every event. Channels are
-    // decoupled from in-app Company mode, so the identity source is the
-    // company CEO workspace when Company mode is active, else the active
-    // workspace (mirrors useChannelsHydration / ChannelsPanel). Sending a
-    // literal `'unknown-workspace'` is NOT an option — the strict filter
-    // would silently drop every event and the UI would look identical to a
-    // healthy empty stream — so we skip + warn only when there is no
-    // workspace at all. Multi-workspace renderers (FIX-MULTI-WS follow-up)
-    // will iterate every member workspace here; for v1 we poll one.
-    const state = useStore.getState();
-    const workspaceId = state.company?.ceoWorkspaceId ?? state.activeWorkspaceId;
-    if (!workspaceId) {
-      console.warn(
-        '[useChannelsEventSubscription] no resolvable workspace (no company + no active workspace) — channel events will not auto-update',
       );
       return;
     }
@@ -245,5 +245,5 @@ export function useChannelsEventSubscription(): void {
       disposed = true;
       clearInterval(timer);
     };
-  }, []);
+  }, [workspaceId]);
 }

--- a/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
@@ -298,6 +298,72 @@ describe('channelsSlice — appendMessageFromEvent', () => {
     store.getState().appendMessageFromEvent(makeMessage('ch-1', 1));
     expect(store.getState().channelUnread['ch-1']).toBe(0);
   });
+
+  it('bumps channelMentions when an unseen message @-mentions self', () => {
+    const store = createTestStore();
+    // The self identity lives on sibling slices (company / activeWorkspaceId);
+    // inject it into the minimal channels-only test store.
+    store.setState((s) => {
+      (s as unknown as { activeWorkspaceId: string }).activeWorkspaceId = 'ws-me';
+    });
+    store.getState().createChannelOptimistic({
+      name: 'general',
+      visibility: 'public',
+      createdBy: sender,
+      channel: makeChannel(),
+    });
+    store.getState().appendMessageFromEvent(
+      makeMessage('ch-1', 1, { mentions: [{ workspaceId: 'ws-me', name: 'me' }] }),
+    );
+    expect(store.getState().channelMentions['ch-1']).toBe(1);
+    expect(store.getState().channelUnread['ch-1']).toBe(1);
+  });
+
+  it('does NOT bump channelMentions for a mention of another workspace', () => {
+    const store = createTestStore();
+    store.setState((s) => {
+      (s as unknown as { activeWorkspaceId: string }).activeWorkspaceId = 'ws-me';
+    });
+    store.getState().createChannelOptimistic({
+      name: 'general',
+      visibility: 'public',
+      createdBy: sender,
+      channel: makeChannel(),
+    });
+    store.getState().appendMessageFromEvent(
+      makeMessage('ch-1', 1, { mentions: [{ workspaceId: 'ws-other', name: 'other' }] }),
+    );
+    expect(store.getState().channelMentions['ch-1'] ?? 0).toBe(0);
+    expect(store.getState().channelUnread['ch-1']).toBe(1);
+  });
+
+  it('setActiveChannel and markChannelRead clear channelMentions', () => {
+    const store = createTestStore();
+    store.setState((s) => {
+      (s as unknown as { activeWorkspaceId: string }).activeWorkspaceId = 'ws-me';
+    });
+    store.getState().createChannelOptimistic({
+      name: 'general',
+      visibility: 'public',
+      createdBy: sender,
+      channel: makeChannel(),
+    });
+    const mention = { mentions: [{ workspaceId: 'ws-me', name: 'me' }] };
+    store.getState().appendMessageFromEvent(makeMessage('ch-1', 1, mention));
+    expect(store.getState().channelMentions['ch-1']).toBe(1);
+
+    store.getState().setActiveChannel('ch-1');
+    expect(store.getState().channelMentions['ch-1']).toBe(0);
+
+    // Re-bump (channel no longer active) then clear via markChannelRead.
+    store.setState((s) => {
+      (s as unknown as { activeChannelId: string | null }).activeChannelId = null;
+    });
+    store.getState().appendMessageFromEvent(makeMessage('ch-1', 2, mention));
+    expect(store.getState().channelMentions['ch-1']).toBe(1);
+    store.getState().markChannelRead('ch-1');
+    expect(store.getState().channelMentions['ch-1']).toBe(0);
+  });
 });
 
 describe('channelsSlice — hydrateChannelMessages (P0)', () => {

--- a/src/renderer/stores/slices/channelsSlice.ts
+++ b/src/renderer/stores/slices/channelsSlice.ts
@@ -139,6 +139,10 @@ export interface ChannelsSlice {
   channelMessages: Record<string, ChannelMessage[]>;
   activeChannelId: string | null;
   channelUnread: Record<string, number>;
+  /** Per-channel count of unseen messages that @-mention THIS renderer's
+   *  workspace — a strict subset of `channelUnread`, surfaced as a stronger
+   *  dock badge. Cleared with unread by `markChannelRead` / `setActiveChannel`. */
+  channelMentions: Record<string, number>;
 
   // ── User-initiated actions (optimistic local mutations) ─────────
   // Each action takes the daemon-resolved result as a parameter so the
@@ -256,6 +260,7 @@ export const createChannelsSlice: StateCreator<
   channelMessages: {},
   activeChannelId: null,
   channelUnread: {},
+  channelMentions: {},
 
   setActiveChannel: (channelId) =>
     set((state: StoreState) => {
@@ -266,6 +271,7 @@ export const createChannelsSlice: StateCreator<
       // here means a single source of truth (no double-bookkeeping).
       if (channelId !== null) {
         state.channelUnread[channelId] = 0;
+        state.channelMentions[channelId] = 0;
         // Auto-open the right channel dock so clicking a channel reveals the
         // conversation (the dock is collapsed by default — uiSlice).
         state.channelDockVisible = true;
@@ -275,6 +281,7 @@ export const createChannelsSlice: StateCreator<
   markChannelRead: (channelId) =>
     set((state: StoreState) => {
       state.channelUnread[channelId] = 0;
+      state.channelMentions[channelId] = 0;
     }),
 
   setChannels: (channels, members) =>
@@ -406,6 +413,15 @@ export const createChannelsSlice: StateCreator<
       if (isNew && state.activeChannelId !== channelId) {
         state.channelUnread[channelId] =
           (state.channelUnread[channelId] ?? 0) + 1;
+        // A message that @-mentions this renderer's own workspace bumps the
+        // mention counter too (the dock then shows a stronger red @ badge).
+        // `self` = the company CEO workspace when set, else the active
+        // workspace — mirrors ChannelView/Composer identity resolution.
+        const selfWs = state.company?.ceoWorkspaceId ?? state.activeWorkspaceId;
+        if (selfWs && message.mentions?.some((mn) => mn.workspaceId === selfWs)) {
+          state.channelMentions[channelId] =
+            (state.channelMentions[channelId] ?? 0) + 1;
+        }
       }
     }),
 

--- a/src/renderer/stores/slices/channelsSlice.ts
+++ b/src/renderer/stores/slices/channelsSlice.ts
@@ -58,6 +58,7 @@ import type { StoreState } from '../index';
 import type {
   Channel,
   ChannelMember,
+  ChannelMention,
   ChannelMessage,
   ChannelVisibility,
 } from '../../../shared/channels';
@@ -91,6 +92,11 @@ export interface ChannelPostParams {
   sender: ChannelMemberAddress;
   clientMsgId?: string;
   data?: unknown;
+  /** @-mentions selected in the composer. Forwarded to the daemon, which
+   *  re-validates them against current membership (the server is the source
+   *  of truth — a forged/stale mention is dropped there). The optimistic row
+   *  carries them only so the local insert renders the @tokens immediately. */
+  mentions?: ChannelMention[];
   /** The daemon's authoritative message after post. */
   message: ChannelMessage;
 }
@@ -560,6 +566,7 @@ export const createChannelsSlice: StateCreator<
         sender: params.sender,
         clientMsgId: params.clientMsgId,
         data: params.data,
+        mentions: params.mentions,
         verifiedWorkspaceId: params.sender.workspaceId,
       });
     } catch (err) {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -123,6 +123,28 @@ export interface ChannelMessage {
    * older persisted messages (pre-U2) won't have it.
    */
   recipientSnapshot?: ChannelRecipientStatus[];
+  /**
+   * @-mentions parsed from the composer at post time. Each entry pins the
+   * mentioned member's `workspaceId` — the key used both to highlight "you were
+   * mentioned" in the dock and (Phase 2) to route an agent ping to that
+   * workspace's a2a inbox — plus a `name` snapshot so the @token renders even
+   * after a name change or workspace removal. Optional: pre-mention messages
+   * won't have it.
+   */
+  mentions?: ChannelMention[];
+}
+
+/**
+ * A single @-mention carried on a {@link ChannelMessage}. The mentioned member
+ * is identified by `workspaceId` (the stable, forgery-resistant key the daemon
+ * already pins membership on); `memberId` narrows it to a specific member when
+ * one was targeted, else the mention is workspace-level. `name` is the display
+ * snapshot at post time.
+ */
+export interface ChannelMention {
+  workspaceId: string;
+  memberId?: string;
+  name: string;
 }
 
 /**


### PR DESCRIPTION
Channel @-mentions, end to end. You can @-mention a workspace in a channel post; the mention is highlighted in the message, raises a badge in the dock, and — the Phase 2 piece — lands in the mentioned workspace's a2a inbox so its agent actually receives it. That last hop reuses the a2a task infrastructure to work around the still-deferred channel-read gap.

**Backend (carried on the message)**
- `ChannelMessage.mentions[]` (shared): each entry pins the mentioned `workspaceId` plus a `name` snapshot.
- `ChannelService.post` validates mentions against the frozen member set (current members only, deduped by workspace) and attaches the validated set to both the stored message and the `channel.message` event. Server-side, so a renderer/MCP can't forge a ping target.
- MCP `channel_post` gains a `mentions` param.

**Phase 1 — human UI**
- Composer `@` autocomplete: type `@`, filter members by name, navigate with arrows, commit with Enter/Tab/click. Picked mentions ride along on the post; deleting the token before send drops that ping.
- Received messages highlight each `@name` token; a message that mentions you gets an accent border, and the channel's dock badge is promoted to a red `@` badge.

**Phase 2 — agent ping**
- A `channel.message` that mentions your workspace is routed to an a2a task (`from` = sender, `to` = self) in the renderer, so an idle agent picks it up through its normal `a2a_task_query` / `wmux_events_poll` and can reply with `channel_post`. Workspace-level (no pane pin — robust to splits); idempotent by a deterministic task id.

**Tests**
- ChannelService mention validation (member-kept / non-member-dropped / deduped), on the message and the event.
- Composer autocomplete: jsdom dynamic (dropdown, filter, keyboard nav, commit, payload, token-deleted drop) + `detectMentionToken` units.
- Render highlight + dock badge + `channelMentions` slice bump/clear (159 channel + slice tests).
- Mention → inbox routing: 7 units (mint, shape, self-skip, idempotency, no-throw).
- Typecheck + lint clean.

**Live dogfood — pending.** The packaged pipe probe is (correctly) blocked by the D5 channel-mutation gate (mutations need a server-resolved `senderPtyId`), and the dev CDP endpoint was unavailable this run. The end-to-end path is to be confirmed via GUI before/after merge; the code paths are covered by the unit/jsdom/integration tests above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end `@mentions` for channel messages, including composer autocomplete with keyboard/mouse selection and instant optimistic rendering.
  * Channel messages now highlight mentioned names, and channel list badges reflect mention activity (even when unread count is 0).
  * Mentioned channel events can route to an inbox flow for faster follow-up.

* **Bug Fixes**
  * Mentions are validated, deduplicated, and ignored when invalid; empty mention sets are omitted instead of saved/sent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->