### PR TITLE
fix(dev): pin Vite dev server to IPv4 loopback

### DIFF
--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -7,4 +7,12 @@ export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
   },
+  server: {
+    // Pin the dev server to IPv4 loopback. When Vite binds localhost to IPv6
+    // ([::1]) only, Electron's loadURL('http://localhost:5173') can resolve to
+    // IPv4 (127.0.0.1) first and hit ERR_CONNECTION_REFUSED — a blank window in
+    // dev. Forcing 127.0.0.1 keeps the served URL and the loaded URL on the same
+    // stack.
+    host: '127.0.0.1',
+  },
 });


### PR DESCRIPTION
## Problem
On hosts where `localhost` resolves IPv6-first, Vite binds the dev server to `[::1]` only. Electron's `loadURL("http://localhost:5173")` can resolve to IPv4 `127.0.0.1` first and fail with `ERR_CONNECTION_REFUSED`, leaving a blank flickering window in `npm start` dev mode. Packaged builds are unaffected (they load via `file://`).

## Fix
Set `server.host: "127.0.0.1"` in `vite.renderer.config.ts` so the served URL and the loaded URL stay on the same stack. Dev-only; no effect on packaged output.

## Test
- Before: `lsof -iTCP:5173` shows `[::1]:5173 (LISTEN)`, `curl 127.0.0.1:5173` -> refused, renderer blank.
- After: `127.0.0.1:5173 (LISTEN)`, both `127.0.0.1` and `localhost` -> 200, renderer loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the development server to bind to `127.0.0.1`, making local access more consistent across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->