### PR TITLE
fix(macos): use Cmd for clipboard, multiview, and shortcuts

### DIFF
--- a/src/renderer/components/AgentToolbar/AgentToolbar.tsx
+++ b/src/renderer/components/AgentToolbar/AgentToolbar.tsx
@@ -98,7 +98,7 @@ export default function AgentToolbar() {
         ★ {t('toolbar.snippets')}
       </button>
       <button className={`${btn} ${popover === 'rich' ? active : idle}`} disabled={disabled} onClick={() => togglePopover('rich')}>
-        ⌨ {t('toolbar.richInput')} <span className="opacity-50">Ctrl G</span>
+        ⌨ {t('toolbar.richInput')} <span className="opacity-50">{window.electronAPI.platform === 'darwin' ? '⌘G' : 'Ctrl G'}</span>
       </button>
       <div className="flex-1" />
       {disabled && <span className="text-[10px] text-[var(--text-muted)] font-mono">{t('toolbar.noTerminal')}</span>}

--- a/src/renderer/components/AgentToolbar/AgentToolbar.tsx
+++ b/src/renderer/components/AgentToolbar/AgentToolbar.tsx
@@ -98,7 +98,7 @@ export default function AgentToolbar() {
         ★ {t('toolbar.snippets')}
       </button>
       <button className={`${btn} ${popover === 'rich' ? active : idle}`} disabled={disabled} onClick={() => togglePopover('rich')}>
-        ⌨ {t('toolbar.richInput')} <span className="opacity-50">{window.electronAPI.platform === 'darwin' ? '⌘G' : 'Ctrl G'}</span>
+        ⌨ {t('toolbar.richInput')} <span className="opacity-50">{window.electronAPI?.platform === 'darwin' ? '⌘G' : 'Ctrl G'}</span>
       </button>
       <div className="flex-1" />
       {disabled && <span className="text-[10px] text-[var(--text-muted)] font-mono">{t('toolbar.noTerminal')}</span>}

--- a/src/renderer/components/Browser/BrowserToolbar.tsx
+++ b/src/renderer/components/Browser/BrowserToolbar.tsx
@@ -124,7 +124,7 @@ export default function BrowserToolbar({
   // panel is active.
   useEffect(() => {
     if (!isActive) return;
-    const isMac = window.electronAPI.platform === 'darwin';
+    const isMac = window.electronAPI?.platform === 'darwin';
     const handler = (e: KeyboardEvent) => {
       const cmdOrCtrl = isMac ? e.metaKey : e.ctrlKey;
       if (cmdOrCtrl && !e.shiftKey && !e.altKey && e.key === 'l') {

--- a/src/renderer/components/Browser/BrowserToolbar.tsx
+++ b/src/renderer/components/Browser/BrowserToolbar.tsx
@@ -120,11 +120,14 @@ export default function BrowserToolbar({
     }
   }, [currentUrl, isFocused]);
 
-  // Ctrl+L focuses the URL bar — only register when this browser panel is active
+  // Ctrl+L (⌘L on macOS) focuses the URL bar — only register when this browser
+  // panel is active.
   useEffect(() => {
     if (!isActive) return;
+    const isMac = window.electronAPI.platform === 'darwin';
     const handler = (e: KeyboardEvent) => {
-      if (e.ctrlKey && !e.shiftKey && !e.altKey && e.key === 'l') {
+      const cmdOrCtrl = isMac ? e.metaKey : e.ctrlKey;
+      if (cmdOrCtrl && !e.shiftKey && !e.altKey && e.key === 'l') {
         e.preventDefault();
         inputRef.current?.focus();
         inputRef.current?.select();

--- a/src/renderer/components/Sidebar/MiniSidebar.tsx
+++ b/src/renderer/components/Sidebar/MiniSidebar.tsx
@@ -72,7 +72,10 @@ export default function MiniSidebar() {
           const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
             // Suppress click that fires immediately after a drag.
             if (Date.now() - dragStartTimeRef.current < 200) return;
-            if (e.ctrlKey) {
+            // 멀티뷰 토글: 플랫폼 주 보조키 + 클릭 (cmdOrCtrl 패턴, WorkspaceItem과 동일).
+            // macOS=⌘, Win/Linux=Ctrl.
+            const cmdOrCtrl = window.electronAPI.platform === 'darwin' ? e.metaKey : e.ctrlKey;
+            if (cmdOrCtrl) {
               e.preventDefault();
               toggleMultiviewWorkspace(ws.id);
             } else {

--- a/src/renderer/components/Sidebar/MiniSidebar.tsx
+++ b/src/renderer/components/Sidebar/MiniSidebar.tsx
@@ -74,7 +74,7 @@ export default function MiniSidebar() {
             if (Date.now() - dragStartTimeRef.current < 200) return;
             // 멀티뷰 토글: 플랫폼 주 보조키 + 클릭 (cmdOrCtrl 패턴, WorkspaceItem과 동일).
             // macOS=⌘, Win/Linux=Ctrl.
-            const cmdOrCtrl = window.electronAPI.platform === 'darwin' ? e.metaKey : e.ctrlKey;
+            const cmdOrCtrl = window.electronAPI?.platform === 'darwin' ? e.metaKey : e.ctrlKey;
             if (cmdOrCtrl) {
               e.preventDefault();
               toggleMultiviewWorkspace(ws.id);

--- a/src/renderer/components/Sidebar/WorkspaceItem.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceItem.tsx
@@ -291,7 +291,7 @@ export default function WorkspaceItem({ workspace, isActive, isMultiview, index,
     // 멀티뷰 토글: 플랫폼 주 보조키 + 클릭 (useKeyboard의 cmdOrCtrl 패턴과 동일).
     // macOS=⌘, Win/Linux=Ctrl. macOS에서 Ctrl+클릭은 OS 우클릭(컨텍스트 메뉴)으로
     // 깔끔히 분리되고, Win/Linux에선 Super+클릭이 오작동하지 않는다.
-    const cmdOrCtrl = window.electronAPI.platform === 'darwin' ? e.metaKey : e.ctrlKey;
+    const cmdOrCtrl = window.electronAPI?.platform === 'darwin' ? e.metaKey : e.ctrlKey;
     if (cmdOrCtrl) {
       e.preventDefault();
       onCtrlSelect();

--- a/src/renderer/components/Sidebar/WorkspaceItem.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceItem.tsx
@@ -288,7 +288,11 @@ export default function WorkspaceItem({ workspace, isActive, isMultiview, index,
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     // 드래그 직후 클릭 이벤트 무시 (200ms 이내)
     if (Date.now() - dragStartTimeRef.current < 200) return;
-    if (e.ctrlKey) {
+    // 멀티뷰 토글: 플랫폼 주 보조키 + 클릭 (useKeyboard의 cmdOrCtrl 패턴과 동일).
+    // macOS=⌘, Win/Linux=Ctrl. macOS에서 Ctrl+클릭은 OS 우클릭(컨텍스트 메뉴)으로
+    // 깔끔히 분리되고, Win/Linux에선 Super+클릭이 오작동하지 않는다.
+    const cmdOrCtrl = window.electronAPI.platform === 'darwin' ? e.metaKey : e.ctrlKey;
+    if (cmdOrCtrl) {
       e.preventDefault();
       onCtrlSelect();
     } else {

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -639,7 +639,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // handlers below stay intact, so Ctrl+C still sends SIGINT and the
       // Windows/Linux flow is unchanged. Match physical `code` so it survives a
       // CJK IME (e.key would be a composed jamo / 'Process', not 'c'/'v').
-      const isMac = window.electronAPI.platform === 'darwin';
+      const isMac = window.electronAPI?.platform === 'darwin';
       if (isMac && e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey && (e.key === 'c' || e.code === 'KeyC')) {
         const sel = terminal.getSelection();
         if (sel) {

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -635,6 +635,39 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         }
       }
 
+      // macOS-native clipboard: ⌘C copies the selection, ⌘V pastes. The Ctrl
+      // handlers below stay intact, so Ctrl+C still sends SIGINT and the
+      // Windows/Linux flow is unchanged. Match physical `code` so it survives a
+      // CJK IME (e.key would be a composed jamo / 'Process', not 'c'/'v').
+      const isMac = window.electronAPI.platform === 'darwin';
+      if (isMac && e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey && (e.key === 'c' || e.code === 'KeyC')) {
+        const sel = terminal.getSelection();
+        if (sel) {
+          void copySelectionWithFeedback(terminal, sel);
+          return false;
+        }
+        return true; // no selection → let the OS handle ⌘C
+      }
+      if (isMac && e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey && (e.key === 'v' || e.code === 'KeyV')) {
+        e.preventDefault();
+        void (async () => {
+          const text = await window.clipboardAPI.readText();
+          if (text) {
+            const modes = (terminal as unknown as { modes?: { bracketedPasteMode?: boolean } }).modes;
+            await pastePtyChunked((d) => window.electronAPI.pty.write(ptyId, d), text, modes);
+            return;
+          }
+          if (window.clipboardAPI.readImage) {
+            const imagePath = await window.clipboardAPI.readImage();
+            if (imagePath) {
+              const quoted = imagePath.includes(' ') ? `"${imagePath}"` : imagePath;
+              window.electronAPI.pty.write(ptyId, quoted);
+            }
+          }
+        })().catch(() => {});
+        return false;
+      }
+
       // Ctrl+C: copy if selection exists, otherwise send SIGINT. Match physical
       // `code` (KeyC) too — under a CJK IME xterm derives Ctrl+<letter> from the
       // deprecated keyCode, which becomes 229 ("Process"), so `e.key` is the


### PR DESCRIPTION
## Problem
Several renderer gestures only checked `e.ctrlKey`, so on macOS the native `Cmd` key did nothing. On macOS `Ctrl+click` is also the OS secondary-click, so the workspace multiview gesture opened a context menu instead of toggling.

## Fix
Apply the codebase's existing `cmdOrCtrl` pattern (`isMac ? e.metaKey : e.ctrlKey`, as in `useKeyboard.ts`) so each platform uses its primary modifier:
- **Terminal copy/paste** (`useTerminal.ts`): add `Cmd+C` / `Cmd+V`. `Ctrl+C` still sends SIGINT; Windows/Linux unchanged. IME-safe via physical `code`.
- **Workspace multiview** (`WorkspaceItem.tsx`, `MiniSidebar.tsx`): `Cmd+click` on macOS, `Ctrl+click` on Windows/Linux. Avoids `Super+click` misfires off-mac and keeps `Ctrl+click` as the macOS context-menu gesture.
- **Browser URL bar** (`BrowserToolbar.tsx`): `Cmd+L` on macOS, `Ctrl+L` elsewhere.
- **Agent toolbar hint** (`AgentToolbar.tsx`): show `⌘G` on macOS, `Ctrl G` elsewhere.

## Out of scope (intentional)
Custom keybindings deliberately stay on literal `Ctrl` cross-OS (see `useKeyboard.ts`), so the settings capture/matcher are left untouched.

## Test
Manual on macOS arm64 (dev build): Cmd+C/V copy-paste in a terminal pane, Cmd+click toggles workspace multiview, Cmd+L focuses the browser URL bar, Rich Input hint shows ⌘G. Ctrl+C still interrupts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)