### PR TITLE
fix(ui): strip native button appearance on macOS

### DIFF
--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -241,6 +241,14 @@ html, body, #root {
   font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
 }
 
+/* 네이티브 버튼 외형 제거: macOS에서 <button>이 Aqua 그라데이션·베벨·그림자를
+   직접 그려 평평한 커스텀 테마 위로 새어나오는 문제를 막는다. checkbox/radio/
+   select는 네이티브 외형(체크표시·드롭다운 화살표)이 필요하므로 건드리지 않는다. */
+button {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
 /* Custom scrollbar */
 ::-webkit-scrollbar {
   width: 6px;


### PR DESCRIPTION
## Problem
On macOS, `<button>` defaults to `appearance: button`, so the OS paints its native Aqua bevel/gradient/shadow on top of the app's flat, CSS-variable-themed buttons (e.g. the agent toolbar). Computed style shows the CSS is flat (`background-image: none; box-shadow: none`) but the control still renders the native chrome — confirmed via CDP `getComputedStyle(...).appearance === "button"`.

## Fix
Reset `appearance: none` on `button` globally. All buttons are fully custom-styled via CSS variables, so the native look is never wanted. `checkbox`/`radio`/`select` are intentionally excluded so they keep native check marks and dropdown arrows.

## Cross-platform
No regression on Windows/Linux: their buttons already render flat because each sets an explicit background/border; `appearance: none` only removes any residual native chrome.

## Test
macOS arm64 (dev build): agent-toolbar buttons go from glossy native pills to flat themed buttons. Verified via CDP that `appearance` is now `none` and `select` controls are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated button styling so native browser appearance is removed, ensuring a more consistent look across platforms.
  * Prevented macOS-specific default button visuals, such as gradient, bevel, and shadow effects, from appearing.
  * Left other form controls unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->