### PR TITLE
feat(dev): set Dock icon in dev on macOS

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -685,6 +685,18 @@ app.on('ready', async () => {
   logLine('info', 'main', 'app.on(ready) fired');
   console.log('[Main] App ready, creating window...');
 
+  // Dev Dock 아이콘: dev에선 패키징 안 된 제네릭 Electron 바이너리로 실행돼
+  // macOS Dock에 기본 원자 아이콘이 뜬다. 패키지 빌드는 packagerConfig.icon으로
+  // 실제 아이콘이 박히지만 dev는 그게 없으므로, 개발 편의상 실제 아이콘으로 교체.
+  // packaged 빌드는 이미 올바른 아이콘이라 건드리지 않는다(!app.isPackaged 가드).
+  if (!app.isPackaged && process.platform === 'darwin') {
+    try {
+      app.dock?.setIcon(path.join(app.getAppPath(), 'assets', 'icon.png'));
+    } catch (err) {
+      console.warn('[Main] dev Dock 아이콘 설정 실패(무시):', err);
+    }
+  }
+
   // Populate the native About panel (macOS shows this automatically in
   // the app menu; Windows/Linux render it when `app.showAboutPanel()`
   // is called from the tray). Including copyright + website here is


### PR DESCRIPTION
## Problem
Running `npm start` in dev launches the unpackaged Electron binary, so macOS shows the generic Electron (atom) icon in the Dock instead of the wmux icon. Packaged builds are fine (`packagerConfig.icon` embeds `assets/icon`).

## Fix
In the `app.on("ready")` handler, call `app.dock.setIcon(assets/icon.png)` guarded by `!app.isPackaged && process.platform === "darwin"`. Dev-only, best-effort (failures logged and ignored). Packaged builds are untouched.

## Test
macOS arm64: after restarting the dev app, the Dock shows the wmux icon instead of the Electron atom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS startup behavior in development by setting a custom app icon when available.
  * If the icon can’t be applied, the app now continues launching normally instead of stopping on the error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->