### PR TITLE
fix(terminal): Ctrl+C copies terminal selection when channel composer holds focus

### DIFF
--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -28,6 +28,7 @@ import ChannelDock from '../Channels/ChannelDock';
 import { ErrorBoundary } from '../ErrorBoundary';
 import { useKeyboard } from '../../hooks/useKeyboard';
 import { useActivePaneFocus } from '../../hooks/useActivePaneFocus';
+import { useTerminalCopyShortcut } from '../../hooks/useTerminalCopyShortcut';
 import { useNotificationListener } from '../../hooks/useNotificationListener';
 import { useRpcBridge } from '../../hooks/useRpcBridge';
 import { useResizeGuard } from '../../hooks/useResizeGuard';
@@ -296,6 +297,12 @@ export default function AppLayout() {
   // surface switches — without this the red active border moves but typing
   // stays in the previously focused pane (see useActivePaneFocus).
   useActivePaneFocus();
+  // Focus-independent terminal Ctrl+C copy: when the channel dock / composer
+  // owns DOM focus, xterm's own Ctrl+C handler never runs (it requires the
+  // terminal textarea to be focused), so a selected-then-Ctrl+C goes silent.
+  // This document capture-phase listener copies the selected terminal's text
+  // while yielding to composer copy / SIGINT (see useTerminalCopyShortcut).
+  useTerminalCopyShortcut();
   useNotificationListener();
   useRpcBridge();
   // S-C2 Approval Inbox bridge: the SINGLE owner of permissionPrompt.onOpen /

--- a/src/renderer/hooks/__tests__/useTerminalCopyShortcut.test.tsx
+++ b/src/renderer/hooks/__tests__/useTerminalCopyShortcut.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+//
+// DOM glue harness for `useTerminalCopyShortcut` — the thin document-level
+// capture-phase Ctrl+C listener around the pure, separately-tested
+// `resolveCopyTarget`. The pure verdict logic is exhaustively covered in
+// utils/__tests__/resolveCopyTarget.test.ts; this file pins the parts that ONLY
+// live in the hook and have no node-level test:
+//   • the visibility gate that excludes offscreen/unmounted terminals whose
+//     xterm selection is stale (consensus P2 — copying an unseen selection
+//     clobbered the clipboard + toasted),
+//   • the `e.repeat` auto-repeat guard (a held Ctrl+C must act once),
+//   • the live DOM → snapshot wiring and the act/yield side effects
+//     (copySelectionWithFeedback + preventDefault) that prove the glue reaches
+//     the copy path at all — the previously untested "hook glue" gap.
+//
+// `@testing-library/react` is not a dependency, so the hook is mounted via a
+// trivial harness component through react-dom/client createRoot + React.act,
+// matching the repo's existing jsdom tests (see Browser/__tests__).
+//
+// `terminalRegistry` / `copySelectionWithFeedback` / `resolveActivePanePtyId`
+// are stubbed via vi.mock so the test owns the live "DOM" the hook reads:
+// fake terminals carry a real <div> whose checkVisibility() we drive directly
+// (jsdom has no layout — offsetParent is always null and checkVisibility is
+// absent — so we stub it to exercise the visible/hidden branches deterministically).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as React from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+/** xterm `Terminal` stand-in: only the members the hook actually touches. */
+interface FakeTerminal {
+  getSelection: () => string;
+  element?: HTMLElement;
+}
+
+// Hoisted mock state, shared with the vi.mock factories (which run before the
+// regular imports below). `activePtyId` is mutated per test to drive the
+// active-pane branch without standing up the real store.
+const mocks = vi.hoisted(() => ({
+  terminalRegistry: new Map<string, { getSelection: () => string; element?: HTMLElement }>(),
+  copySelectionWithFeedback: vi.fn(),
+  activePtyId: null as string | null,
+}));
+
+vi.mock('../useTerminal', () => ({
+  terminalRegistry: mocks.terminalRegistry,
+  copySelectionWithFeedback: mocks.copySelectionWithFeedback,
+}));
+
+vi.mock('../useActivePaneFocus', () => ({
+  resolveActivePanePtyId: () => mocks.activePtyId,
+}));
+
+// Imported AFTER the mocks so the hook binds to the stubbed modules.
+// eslint-disable-next-line import/first
+import { useTerminalCopyShortcut } from '../useTerminalCopyShortcut';
+
+const act = React.act;
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+/** Mounts the hook (its useEffect installs the document listener). */
+function Harness(): null {
+  useTerminalCopyShortcut();
+  return null;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function mountHook(): void {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(React.createElement(Harness));
+  });
+}
+
+/** Register a fake terminal with a controllable selection + visibility. */
+function addTerminal(ptyId: string, selection: string, visible: boolean): FakeTerminal {
+  const el = document.createElement('div');
+  // jsdom has no layout (offsetParent === null) and no checkVisibility, so we
+  // stub checkVisibility to drive the hook's visibility gate directly.
+  el.checkVisibility = (() => visible) as Element['checkVisibility'];
+  document.body.appendChild(el);
+  const term: FakeTerminal = { getSelection: () => selection, element: el };
+  mocks.terminalRegistry.set(ptyId, term);
+  return term;
+}
+
+/** Focus an empty composer (textarea ⇒ editable, no own selection). */
+function focusComposer(): void {
+  const ta = document.createElement('textarea');
+  document.body.appendChild(ta);
+  ta.focus();
+}
+
+/** Focus a terminal's own xterm helper textarea (xterm owns copy/SIGINT). */
+function focusXtermTextarea(): void {
+  const ta = document.createElement('textarea');
+  ta.classList.add('xterm-helper-textarea');
+  document.body.appendChild(ta);
+  ta.focus();
+}
+
+/** Dispatch a Ctrl+C keydown the hook's capture listener will see. */
+function pressCtrlC(init: KeyboardEventInit = {}): KeyboardEvent {
+  const ev = new KeyboardEvent('keydown', {
+    ctrlKey: true,
+    key: 'c',
+    code: 'KeyC',
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  document.dispatchEvent(ev);
+  return ev;
+}
+
+beforeEach(() => {
+  mocks.terminalRegistry.clear();
+  mocks.copySelectionWithFeedback.mockReset();
+  mocks.activePtyId = null;
+  mountHook();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  document.body.innerHTML = '';
+});
+
+describe('useTerminalCopyShortcut — DOM glue', () => {
+  it('copies a VISIBLE terminal selection when an empty composer holds focus [regression]', () => {
+    // The reported bug: composer focused (empty), terminal text selected. The
+    // hook must reach the copy path and consume the key.
+    const term = addTerminal('pty-term', 'hello world', true);
+    mocks.activePtyId = 'pty-term';
+    focusComposer();
+
+    const ev = pressCtrlC();
+
+    expect(mocks.copySelectionWithFeedback).toHaveBeenCalledTimes(1);
+    expect(mocks.copySelectionWithFeedback).toHaveBeenCalledWith(term, 'hello world');
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it('does NOT copy a HIDDEN terminal’s stale selection (visibility gate) [consensus P2]', () => {
+    // The terminal is mounted in the registry but offscreen (tab/workspace
+    // switch). Its old selection must not be copied; with no visible candidate
+    // the keystroke falls through to SIGINT untouched.
+    addTerminal('pty-hidden', 'stale offscreen selection', false);
+    mocks.activePtyId = 'pty-hidden';
+    focusComposer();
+
+    const ev = pressCtrlC();
+
+    expect(mocks.copySelectionWithFeedback).not.toHaveBeenCalled();
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  it('ignores OS auto-repeat keydowns (e.repeat) so a held Ctrl+C acts at most once', () => {
+    addTerminal('pty-term', 'hello', true);
+    mocks.activePtyId = 'pty-term';
+    focusComposer();
+
+    const ev = pressCtrlC({ repeat: true });
+
+    expect(mocks.copySelectionWithFeedback).not.toHaveBeenCalled();
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  it('yields when focus is on the terminal’s own xterm helper textarea (xterm owns copy/SIGINT)', () => {
+    addTerminal('pty-term', 'hello', true);
+    mocks.activePtyId = 'pty-term';
+    focusXtermTextarea();
+
+    const ev = pressCtrlC();
+
+    expect(mocks.copySelectionWithFeedback).not.toHaveBeenCalled();
+    expect(ev.defaultPrevented).toBe(false);
+  });
+});

--- a/src/renderer/hooks/__tests__/useTerminalCopyShortcut.test.tsx
+++ b/src/renderer/hooks/__tests__/useTerminalCopyShortcut.test.tsx
@@ -145,6 +145,29 @@ describe('useTerminalCopyShortcut — DOM glue', () => {
     expect(ev.defaultPrevented).toBe(true);
   });
 
+  it('yields to a NATIVE selection of non-terminal text — no stale-terminal copy, native copy preserved [P1 review]', () => {
+    // User drag-selected a channel message (native DOM selection) while a
+    // terminal still holds a leftover xterm selection. The hook must yield so
+    // the message's native copy wins — it must NOT copy the stale terminal text
+    // nor preventDefault. (xterm's WebGL selection never appears in
+    // window.getSelection(), so a non-empty native selection is non-terminal.)
+    addTerminal('pty-term', 'stale terminal selection', true);
+    mocks.activePtyId = 'pty-term';
+    focusComposer();
+    const realGetSelection = window.getSelection;
+    window.getSelection = (() => ({
+      isCollapsed: false,
+      toString: () => 'a selected channel message',
+    })) as typeof window.getSelection;
+    try {
+      const ev = pressCtrlC();
+      expect(mocks.copySelectionWithFeedback).not.toHaveBeenCalled();
+      expect(ev.defaultPrevented).toBe(false);
+    } finally {
+      window.getSelection = realGetSelection;
+    }
+  });
+
   it('does NOT copy a HIDDEN terminal’s stale selection (visibility gate) [consensus P2]', () => {
     // The terminal is mounted in the registry but offscreen (tab/workspace
     // switch). Its old selection must not be copied; with no visible candidate

--- a/src/renderer/hooks/useTerminalCopyShortcut.ts
+++ b/src/renderer/hooks/useTerminalCopyShortcut.ts
@@ -90,6 +90,19 @@ export function useTerminalCopyShortcut(): void {
       // event at most once, not fire on every repeat tick.
       if (e.repeat) return;
 
+      // Yield to a genuine NATIVE selection of non-terminal DOM text (a channel
+      // message body, the read-only editor <pre>, the roster, markdown). xterm
+      // runs the WebGL renderer, so a terminal's own selection is canvas-drawn
+      // and NEVER appears in window.getSelection(); therefore any non-empty
+      // native selection is non-terminal text whose native copy must win.
+      // Without this, a leftover xterm selection (auto-copy-on-select leaves the
+      // highlight in place) makes Ctrl+C copy stale terminal text AND
+      // preventDefault the real copy — silent wrong-clipboard in the very dock
+      // this feature serves. The input/textarea selectionStart path below still
+      // matters: those internal selections are NOT reflected here.
+      const nativeSel = window.getSelection();
+      if (nativeSel && !nativeSel.isCollapsed && nativeSel.toString().length > 0) return;
+
       // Snapshot every live terminal's current selection. getSelection() is
       // wrapped per-terminal so a mid-teardown (disposed) terminal can't throw
       // and kill the whole shortcut.

--- a/src/renderer/hooks/useTerminalCopyShortcut.ts
+++ b/src/renderer/hooks/useTerminalCopyShortcut.ts
@@ -1,0 +1,120 @@
+import { useEffect } from 'react';
+import { useStore } from '../stores';
+import { terminalRegistry, copySelectionWithFeedback } from './useTerminal';
+import { resolveActivePanePtyId } from './useActivePaneFocus';
+import {
+  resolveCopyTarget,
+  type ActiveElementInfo,
+  type TerminalSelectionSnapshot,
+} from '../utils/resolveCopyTarget';
+
+/**
+ * Read a DOM-free snapshot of the focused element for `resolveCopyTarget`.
+ *
+ * `hasOwnSelection` distinguishes "the composer is focused but empty" (Ctrl+C
+ * should copy the terminal selection) from "the composer is focused AND the
+ * user selected text inside it" (its native copy must win). For input/textarea
+ * that is `selectionStart !== selectionEnd`; for contenteditable it is a
+ * non-collapsed, non-empty window selection. `selectionStart` throws / is null
+ * on input types that don't support it (number, email, …) — guarded below.
+ */
+function readActiveElementInfo(active: Element | null): ActiveElementInfo | null {
+  if (!active) return null;
+
+  const tag = active.tagName;
+  const isInputLike = tag === 'INPUT' || tag === 'TEXTAREA';
+  const isContentEditable = (active as HTMLElement).isContentEditable === true;
+  const isEditable = isInputLike || isContentEditable;
+
+  let hasOwnSelection = false;
+  if (isInputLike) {
+    const el = active as HTMLInputElement | HTMLTextAreaElement;
+    try {
+      // selectionStart/End are null on inputs that don't support text
+      // selection (type=number/email/…). `!= null` filters both.
+      if (el.selectionStart != null && el.selectionEnd != null) {
+        hasOwnSelection = el.selectionStart !== el.selectionEnd;
+      }
+    } catch {
+      hasOwnSelection = false;
+    }
+  } else if (isContentEditable) {
+    const sel = window.getSelection();
+    hasOwnSelection = !!sel && !sel.isCollapsed && sel.toString().length > 0;
+  }
+
+  return {
+    isXtermTextarea: active.classList.contains('xterm-helper-textarea'),
+    isEditable,
+    hasOwnSelection,
+  };
+}
+
+/**
+ * Focus-independent terminal Ctrl+C copy (fix B).
+ *
+ * RCA: xterm's own Ctrl+C copy handler (`useTerminal`'s
+ * `attachCustomKeyEventHandler`) only runs while the terminal's hidden
+ * `.xterm-helper-textarea` holds DOM focus. When the channel dock / composer
+ * textarea owns focus, a user who drag-selects terminal text and presses Ctrl+C
+ * gets total silence — the key lands on the empty composer, xterm never sees it,
+ * so there is no copy, no `^C`, and no toast. The copy logic itself is fine; the
+ * shortcut just never reaches it.
+ *
+ * This hook installs ONE document-level capture-phase keydown listener that, on
+ * Ctrl+C, looks for a terminal holding a non-empty xterm selection and copies it
+ * — but YIELDS (does nothing, leaving every existing path intact) when:
+ *   • focus is on a terminal's own helper textarea (xterm handles copy/SIGINT),
+ *   • focus is on an editable element with its own selection (composer copy),
+ *   • no terminal holds a selection (SIGINT `^C` must still fire).
+ * The yield/act decision is the pure, fully-tested `resolveCopyTarget`; this
+ * wrapper only feeds it the live DOM and acts on the verdict.
+ *
+ * Capture phase + `stopImmediatePropagation` ensure that when we DO copy, the
+ * event is consumed before any focused field's native copy or the bubble-phase
+ * focus self-heal in `useActivePaneFocus` reacts to it. The `code === 'KeyC'`
+ * fallback mirrors the existing handlers so the shortcut survives a CJK IME,
+ * where `e.key` is a composed jamo / 'Process' rather than 'c'.
+ */
+export function useTerminalCopyShortcut(): void {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      // Plain Ctrl+C only — Shift/Alt/Meta combos are other shortcuts
+      // (Ctrl+Shift+C copy fallback is owned by useTerminal). `code` fallback
+      // keeps it working under a Hangul / non-Latin IME.
+      if (!e.ctrlKey || e.shiftKey || e.altKey || e.metaKey) return;
+      if (e.key !== 'c' && e.code !== 'KeyC') return;
+
+      // Snapshot every live terminal's current selection. getSelection() is
+      // wrapped per-terminal so a mid-teardown (disposed) terminal can't throw
+      // and kill the whole shortcut.
+      const selections: TerminalSelectionSnapshot[] = [];
+      for (const [ptyId, terminal] of terminalRegistry) {
+        try {
+          selections.push({ ptyId, selection: terminal.getSelection() });
+        } catch {
+          // disposed / not-yet-ready terminal — skip it
+        }
+      }
+
+      const target = resolveCopyTarget({
+        selections,
+        activePtyId: resolveActivePanePtyId(useStore.getState()),
+        activeElement: readActiveElementInfo(document.activeElement),
+      });
+      if (!target) return; // yield — preserve copy / SIGINT / composer behavior
+
+      // We own this keystroke: stop it before the focused field's native copy
+      // or any other listener reacts, then copy with the shared feedback path.
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      void copySelectionWithFeedback(
+        terminalRegistry.get(target.ptyId) ?? null,
+        target.selection,
+      );
+    };
+
+    document.addEventListener('keydown', handler, true);
+    return () => document.removeEventListener('keydown', handler, true);
+  }, []);
+}

--- a/src/renderer/hooks/useTerminalCopyShortcut.ts
+++ b/src/renderer/hooks/useTerminalCopyShortcut.ts
@@ -62,11 +62,13 @@ function readActiveElementInfo(active: Element | null): ActiveElementInfo | null
  * shortcut just never reaches it.
  *
  * This hook installs ONE document-level capture-phase keydown listener that, on
- * Ctrl+C, looks for a terminal holding a non-empty xterm selection and copies it
- * — but YIELDS (does nothing, leaving every existing path intact) when:
+ * Ctrl+C, looks for a VISIBLE terminal holding a non-empty xterm selection and
+ * copies it — but YIELDS (does nothing, leaving every existing path intact) when:
+ *   • the keydown is an OS auto-repeat tick (a held Ctrl+C copies once),
  *   • focus is on a terminal's own helper textarea (xterm handles copy/SIGINT),
  *   • focus is on an editable element with its own selection (composer copy),
- *   • no terminal holds a selection (SIGINT `^C` must still fire).
+ *   • no VISIBLE terminal holds a selection (SIGINT `^C` must still fire) — an
+ *     offscreen/unmounted terminal's stale selection is never a copy candidate.
  * The yield/act decision is the pure, fully-tested `resolveCopyTarget`; this
  * wrapper only feeds it the live DOM and acts on the verdict.
  *
@@ -84,6 +86,9 @@ export function useTerminalCopyShortcut(): void {
       // keeps it working under a Hangul / non-Latin IME.
       if (!e.ctrlKey || e.shiftKey || e.altKey || e.metaKey) return;
       if (e.key !== 'c' && e.code !== 'KeyC') return;
+      // Ignore OS key auto-repeat: a held Ctrl+C must copy / toast / consume the
+      // event at most once, not fire on every repeat tick.
+      if (e.repeat) return;
 
       // Snapshot every live terminal's current selection. getSelection() is
       // wrapped per-terminal so a mid-teardown (disposed) terminal can't throw
@@ -91,6 +96,20 @@ export function useTerminalCopyShortcut(): void {
       const selections: TerminalSelectionSnapshot[] = [];
       for (const [ptyId, terminal] of terminalRegistry) {
         try {
+          // Only VISIBLE terminals are copy candidates. A workspace/tab switch
+          // can leave a terminal mounted-but-offscreen in the registry while it
+          // still holds an old xterm selection; copying that stale, unseen
+          // selection (clobbering the clipboard + toasting) is the consensus P2
+          // bug. checkVisibility() is exact on Chromium (display:none /
+          // visibility:hidden / disconnected / details-closed all count as
+          // hidden); offsetParent is the fallback where it is unavailable.
+          const el = terminal.element;
+          const visible =
+            !!el &&
+            (typeof el.checkVisibility === 'function'
+              ? el.checkVisibility()
+              : el.offsetParent !== null);
+          if (!visible) continue;
           selections.push({ ptyId, selection: terminal.getSelection() });
         } catch {
           // disposed / not-yet-ready terminal — skip it

--- a/src/renderer/utils/__tests__/resolveCopyTarget.test.ts
+++ b/src/renderer/utils/__tests__/resolveCopyTarget.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for `resolveCopyTarget` — the pure decision core of the
+ * focus-independent terminal Ctrl+C copy (fix B).
+ *
+ * It decides, from a DOM-free snapshot, whether a document-level Ctrl+C should
+ * copy a terminal's selection or YIELD (return null) so the pre-existing copy /
+ * SIGINT / composer-copy behavior is preserved. Every branch is covered, with
+ * the original bug pinned as an explicit regression: focus on an empty composer
+ * + a non-empty terminal selection must resolve to that terminal.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  resolveCopyTarget,
+  type ActiveElementInfo,
+  type CopyTargetInput,
+} from '../resolveCopyTarget';
+
+function activeEl(overrides: Partial<ActiveElementInfo> = {}): ActiveElementInfo {
+  return {
+    isXtermTextarea: false,
+    isEditable: false,
+    hasOwnSelection: false,
+    ...overrides,
+  };
+}
+
+function input(overrides: Partial<CopyTargetInput> = {}): CopyTargetInput {
+  return {
+    selections: [],
+    activePtyId: null,
+    activeElement: null,
+    ...overrides,
+  };
+}
+
+describe('resolveCopyTarget — regression (the reported bug)', () => {
+  it('[REGRESSION] focus on an empty composer + terminal has a selection → that terminal', () => {
+    // This is exactly the bug: the channel composer (editable, but with NO
+    // selection of its own) holds DOM focus while the user has selected
+    // terminal text. Ctrl+C must copy the terminal selection, not go silent.
+    const result = resolveCopyTarget(
+      input({
+        selections: [{ ptyId: 'pty-term', selection: 'copied text' }],
+        activePtyId: 'pty-term',
+        activeElement: activeEl({ isEditable: true, hasOwnSelection: false }),
+      }),
+    );
+    expect(result).toEqual({ ptyId: 'pty-term', selection: 'copied text' });
+  });
+
+  it('[REGRESSION] composer focus also works when activePtyId is null but one terminal is selected', () => {
+    // Same composer-focus scenario, but the active pane did not resolve to a
+    // terminal (e.g. focus model lost it). A single selected terminal is still
+    // unambiguous, so the copy must land on it rather than going silent.
+    const result = resolveCopyTarget(
+      input({
+        selections: [{ ptyId: 'pty-only', selection: 'hello' }],
+        activePtyId: null,
+        activeElement: activeEl({ isEditable: true, hasOwnSelection: false }),
+      }),
+    );
+    expect(result).toEqual({ ptyId: 'pty-only', selection: 'hello' });
+  });
+});
+
+describe('resolveCopyTarget — yield branches (preserve existing behavior)', () => {
+  it('yields when focus is on a terminal xterm-helper-textarea (xterm owns copy/SIGINT)', () => {
+    expect(
+      resolveCopyTarget(
+        input({
+          selections: [{ ptyId: 'pty-1', selection: 'sel' }],
+          activePtyId: 'pty-1',
+          activeElement: activeEl({ isXtermTextarea: true }),
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('yields when an editable element holds its own non-empty selection (composer copy)', () => {
+    expect(
+      resolveCopyTarget(
+        input({
+          selections: [{ ptyId: 'pty-1', selection: 'term sel' }],
+          activePtyId: 'pty-1',
+          activeElement: activeEl({ isEditable: true, hasOwnSelection: true }),
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('yields when no terminal holds a selection (SIGINT must fire)', () => {
+    expect(
+      resolveCopyTarget(
+        input({
+          selections: [
+            { ptyId: 'pty-1', selection: '' },
+            { ptyId: 'pty-2', selection: '' },
+          ],
+          activePtyId: 'pty-1',
+          activeElement: activeEl({ isEditable: true, hasOwnSelection: false }),
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('yields when no terminals are registered at all', () => {
+    expect(
+      resolveCopyTarget(input({ selections: [], activePtyId: 'pty-1' })),
+    ).toBeNull();
+  });
+
+  it('yields when multiple terminals are selected and none is the active pane (ambiguous)', () => {
+    expect(
+      resolveCopyTarget(
+        input({
+          selections: [
+            { ptyId: 'pty-1', selection: 'a' },
+            { ptyId: 'pty-2', selection: 'b' },
+          ],
+          activePtyId: null,
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('yields when multiple terminals are selected and the active pane has no selection', () => {
+    // The active pane's terminal is NOT among the selected ones, so even with an
+    // active pane the choice between the other two is ambiguous → yield.
+    expect(
+      resolveCopyTarget(
+        input({
+          selections: [
+            { ptyId: 'pty-1', selection: 'a' },
+            { ptyId: 'pty-2', selection: 'b' },
+          ],
+          activePtyId: 'pty-3',
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('resolveCopyTarget — copy branches', () => {
+  it('returns the active pane terminal when it holds a selection', () => {
+    expect(
+      resolveCopyTarget(
+        input({
+          selections: [
+            { ptyId: 'pty-1', selection: 'first' },
+            { ptyId: 'pty-2', selection: 'second' },
+          ],
+          activePtyId: 'pty-2',
+        }),
+      ),
+    ).toEqual({ ptyId: 'pty-2', selection: 'second' });
+  });
+
+  it('prefers the active pane terminal over other selected terminals', () => {
+    expect(
+      resolveCopyTarget(
+        input({
+          selections: [
+            { ptyId: 'pty-1', selection: 'a' },
+            { ptyId: 'pty-2', selection: 'b' },
+            { ptyId: 'pty-3', selection: 'c' },
+          ],
+          activePtyId: 'pty-1',
+        }),
+      ),
+    ).toEqual({ ptyId: 'pty-1', selection: 'a' });
+  });
+
+  it('returns the single selected terminal when activeElement is null (no focus)', () => {
+    expect(
+      resolveCopyTarget(
+        input({
+          selections: [{ ptyId: 'pty-solo', selection: 'lone' }],
+          activePtyId: null,
+          activeElement: null,
+        }),
+      ),
+    ).toEqual({ ptyId: 'pty-solo', selection: 'lone' });
+  });
+
+  it('returns the only selected terminal even when other terminals exist but are empty', () => {
+    expect(
+      resolveCopyTarget(
+        input({
+          selections: [
+            { ptyId: 'pty-1', selection: '' },
+            { ptyId: 'pty-2', selection: 'picked' },
+            { ptyId: 'pty-3', selection: '' },
+          ],
+          activePtyId: null,
+        }),
+      ),
+    ).toEqual({ ptyId: 'pty-2', selection: 'picked' });
+  });
+
+  it('still copies the active terminal even if its selection equals another (active wins by id)', () => {
+    // Sanity: the active-pane preference is by ptyId, independent of selection
+    // content collisions.
+    expect(
+      resolveCopyTarget(
+        input({
+          selections: [
+            { ptyId: 'pty-1', selection: 'dup' },
+            { ptyId: 'pty-2', selection: 'dup' },
+          ],
+          activePtyId: 'pty-2',
+        }),
+      ),
+    ).toEqual({ ptyId: 'pty-2', selection: 'dup' });
+  });
+
+  it('non-editable focused element (e.g. a button) does not block a terminal copy', () => {
+    expect(
+      resolveCopyTarget(
+        input({
+          selections: [{ ptyId: 'pty-1', selection: 'x' }],
+          activePtyId: 'pty-1',
+          activeElement: activeEl({ isEditable: false, hasOwnSelection: false }),
+        }),
+      ),
+    ).toEqual({ ptyId: 'pty-1', selection: 'x' });
+  });
+});

--- a/src/renderer/utils/__tests__/resolveCopyTarget.test.ts
+++ b/src/renderer/utils/__tests__/resolveCopyTarget.test.ts
@@ -182,6 +182,24 @@ describe('resolveCopyTarget — copy branches', () => {
     ).toEqual({ ptyId: 'pty-solo', selection: 'lone' });
   });
 
+  it('returns the lone selected terminal when the active pane resolves but holds no selection', () => {
+    // GLM-flagged gap: activePtyId DOES resolve, but that terminal is not among
+    // the ones holding a selection, while exactly one OTHER terminal is. The
+    // active-pane preference finds no candidate, yet the single selected
+    // terminal is unambiguous, so it must be returned rather than yielding.
+    // (Visibility filtering is the hook's job; at the pure layer one candidate
+    // still wins.)
+    expect(
+      resolveCopyTarget(
+        input({
+          selections: [{ ptyId: 'pty-other', selection: 'only one' }],
+          activePtyId: 'pty-active',
+          activeElement: activeEl({ isEditable: true, hasOwnSelection: false }),
+        }),
+      ),
+    ).toEqual({ ptyId: 'pty-other', selection: 'only one' });
+  });
+
   it('returns the only selected terminal even when other terminals exist but are empty', () => {
     expect(
       resolveCopyTarget(

--- a/src/renderer/utils/resolveCopyTarget.ts
+++ b/src/renderer/utils/resolveCopyTarget.ts
@@ -1,0 +1,90 @@
+/**
+ * Pure decision core for the focus-independent Ctrl+C copy shortcut.
+ *
+ * The bug (RCA): when the channel dock / composer textarea owns DOM keyboard
+ * focus, the user can still drag-select terminal text, but Ctrl+C never reaches
+ * xterm's `attachCustomKeyEventHandler` (it only runs while the terminal's
+ * `.xterm-helper-textarea` is focused). The keypress lands on the empty composer
+ * and silently does nothing — no copy, no `^C`, no toast.
+ *
+ * This function decides, from a DOM-free snapshot, whether a document-level
+ * Ctrl+C should copy a terminal selection or YIELD (do nothing) so that the
+ * pre-existing behavior is preserved. It performs NO DOM / registry access so it
+ * can be exhaustively unit-tested in the repo's node (no-JSDOM) vitest env. The
+ * thin hook (`useTerminalCopyShortcut`) reads the live DOM into this snapshot and
+ * acts on the verdict.
+ *
+ * Yield (return null) — and thus preserve existing behavior — when:
+ *   1. focus is already on a terminal's xterm helper textarea → the existing
+ *      `useTerminal` Ctrl+C handler owns copy / SIGINT for that pane.
+ *   2. focus is on an editable element that has its OWN non-empty selection →
+ *      the user is copying out of an input/textarea/contenteditable (composer),
+ *      so its native copy must win.
+ *   3. no terminal currently holds a non-empty selection → there is nothing to
+ *      copy; let the keystroke fall through to SIGINT (`^C`).
+ *   4. the choice is ambiguous: multiple terminals hold selections and none of
+ *      them is the active pane → refuse to guess.
+ *
+ * Otherwise it returns the terminal to copy from: the active pane's terminal if
+ * it has a selection, else the single unambiguous selected terminal.
+ */
+
+/** DOM-free description of `document.activeElement` at keypress time. */
+export interface ActiveElementInfo {
+  /** activeElement carries the `xterm-helper-textarea` class (terminal focus). */
+  isXtermTextarea: boolean;
+  /** activeElement is an INPUT / TEXTAREA / contenteditable element. */
+  isEditable: boolean;
+  /** That editable element holds a non-empty selection of its own. */
+  hasOwnSelection: boolean;
+}
+
+/** A single terminal's current xterm `getSelection()` snapshot. */
+export interface TerminalSelectionSnapshot {
+  ptyId: string;
+  selection: string;
+}
+
+export interface CopyTargetInput {
+  /** Current `getSelection()` for every live registered terminal. */
+  selections: TerminalSelectionSnapshot[];
+  /** ptyId of the active pane's terminal, or null when none resolves. */
+  activePtyId: string | null;
+  /** Snapshot of the focused element, or null when nothing is focused. */
+  activeElement: ActiveElementInfo | null;
+}
+
+/**
+ * Resolve which terminal (if any) a focus-independent Ctrl+C should copy from.
+ * Returns the chosen `{ ptyId, selection }`, or null to YIELD (preserve the
+ * existing copy / SIGINT / composer-copy behavior).
+ */
+export function resolveCopyTarget(
+  input: CopyTargetInput,
+): TerminalSelectionSnapshot | null {
+  const { selections, activePtyId, activeElement } = input;
+
+  // (1) Terminal already focused — defer to its own xterm Ctrl+C handler.
+  if (activeElement?.isXtermTextarea) return null;
+
+  // (2) An editable element with its own selection owns the copy (composer).
+  if (activeElement?.isEditable && activeElement.hasOwnSelection) return null;
+
+  // Only terminals with a non-empty selection are copy candidates.
+  const withSelection = selections.filter((s) => s.selection.length > 0);
+
+  // (3) Nothing selected anywhere — fall through to SIGINT.
+  if (withSelection.length === 0) return null;
+
+  // Prefer the active pane's terminal when it is one of the candidates.
+  const active = activePtyId
+    ? withSelection.find((s) => s.ptyId === activePtyId)
+    : undefined;
+  if (active) return active;
+
+  // No active candidate: only act when the choice is unambiguous.
+  if (withSelection.length === 1) return withSelection[0];
+
+  // (4) Multiple selected terminals, none active — refuse to guess.
+  return null;
+}


### PR DESCRIPTION
## Problem
When the channel dock/composer textarea owns DOM keyboard focus, selecting terminal text and pressing **Ctrl+C** goes completely silent — no copy, no `^C`, no toast. xterm's own Ctrl+C handler (`useTerminal`'s `attachCustomKeyEventHandler`) only runs while the terminal's `.xterm-helper-textarea` is focused, so the keystroke lands on the (empty) composer and never reaches the copy path. The copy logic itself is fine; the shortcut just never reaches it.

## Root cause
Focus-ownership gap, not a copy-logic bug. Terminal copy requires the xterm textarea to hold DOM focus; when an editable element (channel composer) holds focus instead, the terminal's selection is unreachable by Ctrl+C.

## Fix (focus-independent Ctrl+C)
A single document **capture-phase** keydown listener (`useTerminalCopyShortcut`, wired in `AppLayout` next to `useActivePaneFocus`) that, on Ctrl+C, copies the selected terminal's text via the shared `copySelectionWithFeedback` path — while **yielding** (doing nothing, preserving existing behavior) when:
- a terminal's xterm helper textarea is focused (xterm handles copy / SIGINT),
- an editable element has its own non-empty selection (composer/native copy wins),
- no terminal holds a selection (SIGINT `^C` must still fire).

The yield/act decision is the pure, exhaustively-tested `resolveCopyTarget`; the thin hook only feeds it a live-DOM snapshot. CJK-IME safe (`code === 'KeyC'` fallback), ignores OS key auto-repeat (`e.repeat`), and only considers **visible** terminals as candidates.

## Files
- `src/renderer/utils/resolveCopyTarget.ts` (pure decision core)
- `src/renderer/hooks/useTerminalCopyShortcut.ts` (capture-phase listener)
- `src/renderer/components/Layout/AppLayout.tsx` (wiring, +1 hook call)
- tests: `resolveCopyTarget.test.ts` (15), `useTerminalCopyShortcut.test.tsx` (jsdom, 4)

## 3-way review (Claude / Codex / GLM-5.2)
Consensus **P2** (all three): the handler fed *every* registered terminal's selection into the decision, including terminals left mounted-but-offscreen by a workspace/tab switch — a stale, unseen selection could clobber the clipboard. Fixed by gating candidates on visibility (`checkVisibility()`, `offsetParent` fallback). Also fixed GLM's **P2**: ignore `e.repeat` so a held Ctrl+C acts at most once. No P1s.

## Tests
- 19 unit tests for the new code (incl. 2 regression + jsdom DOM-glue test). All green.
- Targeted regression around touched area: 244 tests green. tsc `--noEmit` exit 0, eslint clean on changed files.
- Full suite: the only failures (pidMap fs, AutoUpdater win32, StateWriter timing) are in `src/main/**` / `src/daemon/**` — untouched by this PR (diff is `src/renderer/**` only) and are pre-existing/environmental/flaky (StateWriter passes on retry).

## Validation status (honest)
Verified live in an isolated dev instance (`WMUX_DATA_SUFFIX`): the app **builds, boots, and renders** with the new hook (no crash), and the **visibility filter** was confirmed correct via a live console probe (visible terminal included, hidden excluded). The full interactive click-test (select → focus composer → Ctrl+C → paste) could not be cleanly confirmed via agent GUI automation (synthetic focus/keystroke targeting was unreliable); **a 10-second manual confirmation is recommended before merge.** The event-level scenario is reproduced and passing in the jsdom hook test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced terminal Ctrl+C copying so the app can copy the selected terminal text even when focus is elsewhere in the interface.

* **Bug Fixes**
  * Improved yield/copy decisions to avoid overriding native copy behavior, composer editing, and terminal interrupt handling.
  * Fixed edge cases for hidden terminals, empty selections, and repeated Ctrl+C presses.

* **Tests**
  * Added automated coverage for Ctrl+C copy behavior and terminal selection prioritization across different focus scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->