### PR TITLE
fix(terminal): honor OSC 52 so TUI-app copy reaches the clipboard

### DIFF
--- a/src/renderer/hooks/__tests__/useTerminal.osc52.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.osc52.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Source-level regression lock: the terminal must register an OSC 52 handler
+ * that routes the decoded payload through the clipboard IPC, and dispose it on
+ * teardown.
+ *
+ * Why source-level: the OSC 52 path only fires when xterm's parser consumes a
+ * real escape sequence from live PTY data, which needs a real Terminal wired to
+ * a renderer — jsdom can't faithfully drive it (the same constraint the
+ * imeCopyPaste / rightClickPasteMouseMode locks in this dir document). The
+ * decode + security policy is exhaustively unit-tested in
+ * utils/__tests__/osc52Clipboard.test.ts; this lock pins the WIRING so a future
+ * refactor can't silently drop it and regress TUI-app copy (Claude Code, vim,
+ * tmux, neovim) back to the silent failure the handler fixed: the app shows
+ * "copied" while the system clipboard never changes.
+ */
+
+const SRC = readFileSync(
+  path.resolve(process.cwd(), 'src/renderer/hooks/useTerminal.ts'),
+  'utf8',
+);
+
+describe('useTerminal OSC 52 clipboard-write wiring (source-level lock)', () => {
+  it('registers an OSC 52 parser handler', () => {
+    expect(SRC).toMatch(/registerOscHandler\(\s*52\s*,/);
+  });
+
+  it('routes the OSC 52 payload through the write-only decode policy', () => {
+    expect(SRC).toMatch(/decodeOsc52Write\(payload\)/);
+  });
+
+  it('forwards only a non-null decode (refused reads/clears are dropped)', () => {
+    // decodeOsc52Write returns null to REFUSE (read '?', clear, oversize,
+    // malformed); the wiring must guard on that so a refused request never
+    // reaches the clipboard.
+    expect(SRC).toMatch(/if \(text !== null\)/);
+  });
+
+  it('writes the decoded text through the clipboard IPC (1 MB cap + lock handling)', () => {
+    // Must reach window.clipboardAPI.writeText — the IPC that validates size and
+    // surfaces lock failures — not a raw clipboard call that bypasses the cap.
+    expect(SRC).toMatch(/clipboardAPI\.writeText\(text\)/);
+  });
+
+  it('disposes the OSC 52 handler on teardown (no leak across remounts)', () => {
+    expect(SRC).toMatch(/osc52Disposable\.dispose\(\)/);
+  });
+});

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -15,6 +15,7 @@ import { openTerminalUrl } from '../utils/browserPaneActions';
 import { runCopyWithFeedback } from '../utils/copyWithFeedback';
 import { shouldFitWhilePreservingSelection } from '../utils/fitGuard';
 import { createAutoSelectionCopy } from '../utils/autoSelectionCopy';
+import { decodeOsc52Write } from '../utils/osc52Clipboard';
 import { terminalFontFamilyCss } from '../utils/terminalFont';
 import { createPathLinkProvider } from '../terminal/pathLinkProvider';
 import { resolveNewlineKeyByte } from '../terminal/newlineKeys';
@@ -351,6 +352,29 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         });
       }, window.electronAPI.platform),
     );
+
+    // OSC 52 clipboard-write bridge. Full-screen TUI apps (Claude Code, vim,
+    // tmux, neovim) grab the mouse, so a drag no longer leaves an xterm-native
+    // selection; when the user copies, the app emits OSC 52 asking the terminal
+    // to set the clipboard. xterm disables OSC 52 by default (its read half
+    // leaks clipboard contents), so without this the request is silently dropped
+    // — the app says "copied" but the system clipboard never changes. We open
+    // the WRITE half only (decodeOsc52Write refuses reads/clears/oversize) and
+    // route through the existing clipboard IPC (1 MB cap + lock handling).
+    const osc52Disposable = terminal.parser.registerOscHandler(52, (payload) => {
+      const text = decodeOsc52Write(payload);
+      // Consume the sequence either way (return true): a refused read/clear must
+      // not fall through to another handler. Only a decoded write is forwarded.
+      if (text !== null) {
+        void window.clipboardAPI.writeText(text).catch(() => {
+          // OSC 52 is fire-and-forget from the app's view (it already drew its
+          // own "copied" UI); a size-cap/lock rejection has no app-visible
+          // channel, so swallow it rather than surfacing a wmux toast the user
+          // didn't trigger.
+        });
+      }
+      return true;
+    });
     // Activate Unicode 11 width tables — required for correct CJK / emoji
     // width. Without this, xterm defaults to v6 and TUI apps that use cursor
     // positioning (Claude Code, vim, etc.) collide frames over Korean text.
@@ -1193,6 +1217,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       autoCopy.dispose();
       selectionDisposable.dispose();
       pathLinkDisposable.dispose();
+      osc52Disposable.dispose();
       resizeObserver.disconnect();
       removeDataListener?.();
       removeExitListener?.();

--- a/src/renderer/utils/__tests__/osc52Clipboard.test.ts
+++ b/src/renderer/utils/__tests__/osc52Clipboard.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { decodeOsc52Write } from '../osc52Clipboard';
+
+/** Encode `s` as the base64 an app would put in an OSC 52 Pd field. */
+const b64 = (s: string): string => Buffer.from(s, 'utf-8').toString('base64');
+
+describe('decodeOsc52Write', () => {
+  it('decodes a clipboard write with Pc=c', () => {
+    expect(decodeOsc52Write(`c;${b64('Hello')}`)).toBe('Hello');
+  });
+
+  it('decodes with an empty Pc (default selection)', () => {
+    expect(decodeOsc52Write(`;${b64('hi')}`)).toBe('hi');
+  });
+
+  it('round-trips UTF-8 (Korean + emoji)', () => {
+    const text = '복사됨 😀 가나다';
+    expect(decodeOsc52Write(`c;${b64(text)}`)).toBe(text);
+  });
+
+  it('always targets the system clipboard regardless of Pc selection chars', () => {
+    expect(decodeOsc52Write(`p;${b64('primary')}`)).toBe('primary');
+    expect(decodeOsc52Write(`s0;${b64('select0')}`)).toBe('select0');
+    expect(decodeOsc52Write(`cp;${b64('both')}`)).toBe('both');
+  });
+
+  it('preserves text containing base64-significant chars (+, /, =)', () => {
+    const text = 'a+b/c=d and a ; semicolon';
+    expect(decodeOsc52Write(`c;${b64(text)}`)).toBe(text);
+  });
+
+  it('REFUSES a read request (Pd = "?") — no clipboard exfiltration', () => {
+    expect(decodeOsc52Write('c;?')).toBeNull();
+    expect(decodeOsc52Write(';?')).toBeNull();
+  });
+
+  it('REFUSES a clear request (empty Pd) — no silent wipe', () => {
+    expect(decodeOsc52Write('c;')).toBeNull();
+    expect(decodeOsc52Write(';')).toBeNull();
+  });
+
+  it('REFUSES a malformed payload with no ";"', () => {
+    expect(decodeOsc52Write('cYWJj')).toBeNull();
+    expect(decodeOsc52Write('')).toBeNull();
+  });
+
+  it('REFUSES invalid base64', () => {
+    expect(decodeOsc52Write('c;@@@not-base64@@@')).toBeNull();
+  });
+
+  it('REFUSES an oversized payload before decoding', () => {
+    const huge = 'c;' + 'A'.repeat(2_000_001);
+    expect(decodeOsc52Write(huge)).toBeNull();
+  });
+
+  it('accepts a payload right at the size limit', () => {
+    // 'A'.repeat(LEN) is valid base64; decode succeeds and returns a (large)
+    // string rather than refusing. The clipboard IPC's 1 MB cap is the next gate.
+    const atLimit = 'c;' + 'A'.repeat(2_000_000);
+    expect(decodeOsc52Write(atLimit)).not.toBeNull();
+  });
+});

--- a/src/renderer/utils/osc52Clipboard.ts
+++ b/src/renderer/utils/osc52Clipboard.ts
@@ -1,0 +1,76 @@
+/**
+ * OSC 52 clipboard-write decode + security policy (pure).
+ *
+ * Background:
+ * Full-screen TUI apps (Claude Code, vim, tmux, neovim, …) take over the mouse
+ * (mouse tracking mode), so a drag no longer lands an xterm-native selection.
+ * When the user copies, those apps don't touch the OS clipboard directly — they
+ * can't, they run sandboxed inside the terminal — they emit an OSC 52 escape
+ * sequence (`ESC ] 52 ; Pc ; Pd ST`) asking the *terminal* to do it. xterm.js
+ * disables OSC 52 by default (its read half leaks clipboard contents to any
+ * program that asks), so without an explicit handler wmux silently drops the
+ * request: the app shows "copied", the system clipboard never changes.
+ *
+ * This module is the pure decode + policy core. `useTerminal` registers the
+ * thin xterm OSC-52 handler that feeds it the raw payload and writes the result
+ * through the existing clipboard IPC (which already enforces a 1 MB cap and
+ * surfaces lock failures). Kept DOM-free so it unit-tests in the node vitest env.
+ *
+ * Security policy — we open the WRITE half only:
+ *   • READ requests (`Pd === '?'`) are REFUSED — never let an app exfiltrate the
+ *     user's clipboard. This read leak is the whole reason xterm ships OSC 52 off.
+ *   • CLEAR requests (empty `Pd`) are REFUSED — an app should not be able to
+ *     silently wipe the clipboard.
+ *   • Oversized payloads are REFUSED before decode — a multi-megabyte base64
+ *     blob shouldn't be allocated/decoded on the main thread (DoS). The clipboard
+ *     IPC's 1 MB cap is the second line of defense on the decoded text.
+ *   • Malformed / non-base64 payloads are REFUSED.
+ * Writing the system clipboard is allowed: the app is something the user ran,
+ * and a clipboard write (unlike a read) leaks nothing.
+ */
+
+// OSC 52 payload is `Pc;Pd`. 1 MB of text is ~1.4 M base64 chars; allow some
+// headroom, then let the clipboard IPC's 1 MB cap reject the decoded text. Past
+// this we refuse before allocating/decoding.
+const MAX_OSC52_BASE64_LEN = 2_000_000;
+
+/**
+ * Decode an OSC 52 payload into the text to place on the clipboard, or return
+ * null to REFUSE (read request, clear request, oversized, or malformed). The
+ * caller should consume the sequence either way (return true to xterm) so a
+ * refused request doesn't fall through to any other handler.
+ *
+ * @param payload the raw OSC 52 data xterm hands the `52` handler: `Pc;Pd`
+ *   (everything between `ESC ] 52 ;` and the terminator).
+ */
+export function decodeOsc52Write(payload: string): string | null {
+  // `Pc;Pd` — split on the FIRST ';'. Pc is selection chars (c/p/q/s/0-7), Pd is
+  // base64 or '?'. Neither contains ';', so a single split is unambiguous.
+  const semi = payload.indexOf(';');
+  if (semi === -1) return null; // no `Pc;Pd` shape → malformed
+
+  const pd = payload.slice(semi + 1);
+
+  if (pd === '?') return null; // read request — refuse (no clipboard exfiltration)
+  if (pd === '') return null; // clear request — refuse (no silent wipe)
+  if (pd.length > MAX_OSC52_BASE64_LEN) return null; // oversized — refuse before decode
+
+  try {
+    return decodeBase64Utf8(pd);
+  } catch {
+    return null; // not valid base64 → refuse
+  }
+}
+
+/**
+ * Decode standard base64 into a UTF-8 string. `atob` yields one Latin-1 char
+ * per byte, so naively returning it mangles any multi-byte UTF-8 (Korean,
+ * emoji). Re-read the bytes and decode as UTF-8 so `복사`/😀 survive the round
+ * trip. Throws (caught above) on invalid base64.
+ */
+function decodeBase64Utf8(b64: string): string {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new TextDecoder('utf-8').decode(bytes);
+}


### PR DESCRIPTION
## Problem

Copying from a full-screen TUI app (Claude Code, vim, tmux, neovim) inside wmux did not reach the system clipboard. The app showed "copied" but pasting elsewhere gave stale or empty contents, and no wmux toast appeared. A plain shell copied fine, so it looked like a corporate clipboard lockdown. It was not.

These apps grab the mouse, so a drag no longer lands an xterm-native selection. On copy they emit OSC 52 asking the terminal to set the clipboard. xterm.js ships OSC 52 off by default (its read half leaks the clipboard) and wmux never added a handler, so the request was silently dropped. The empty xterm selection also explains the missing wmux toast: Ctrl+C falls through to SIGINT and auto-copy-on-select writes nothing.

## Change

- `osc52Clipboard.ts`: pure decode + security policy. Write half only. Reads (`?`), clears, oversized payloads, and malformed base64 are refused. Refusing reads is the whole reason xterm disables OSC 52, so the exfiltration hole stays closed.
- `useTerminal.ts`: register `parser.registerOscHandler(52, ...)`, decode, then write through the existing clipboard IPC (1 MB cap + lock handling already enforced there). Disposed on teardown.
- Tests: 11 unit (UTF-8 round-trip for Korean/emoji, every refusal path) + 5 source-level wiring locks. The live path needs a real PTY-fed parser jsdom cannot drive, so the wiring is pinned at the source level like the imeCopyPaste / rightClickPasteMouseMode locks.

## Verification

- tsc: clean
- vitest: 270 pass (16 new OSC 52 + 254 copy/terminal regression subset); full suite runs in CI
- Live repro (git-bash in a wmux shell):

  ```
  printf '\033]52;c;%s\007' "$(printf wmux-osc52-ok | base64)"
  ```

  Before: clipboard unchanged. After: paste yields `wmux-osc52-ok`.

Closes #313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal apps can now copy text to the system clipboard using OSC 52 write sequences.
  * Clipboard handling now better preserves Unicode text and common special characters.

* **Bug Fixes**
  * OSC 52 clipboard writes are now ignored when the request is invalid, too large, or meant to read/clear clipboard contents.
  * Terminal cleanup now removes clipboard listeners when the app closes or remounts.

* **Tests**
  * Added regression coverage to protect OSC 52 clipboard behavior going forward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->