### PR TITLE
chore(release): v3.11.1 — honor OSC 52 for TUI-app clipboard copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.1] — 2026-06-29
+
+### Fixed
+
+- **Copy from full-screen TUI apps reaches the clipboard (OSC 52) ([#314](https://github.com/openwong2kim/wmux/pull/314)).** Full-screen TUI apps (Claude Code, vim, tmux, neovim) take over the mouse, so a drag no longer lands an xterm-native selection. On copy they emit an OSC 52 escape asking the terminal to set the clipboard, but xterm disables OSC 52 by default and wmux never registered a handler. The app showed "copied" while the system clipboard never changed, which looked like a corporate clipboard lockdown. wmux now honors OSC 52 for writes (clipboard reads, clears, oversized, and malformed payloads are refused) and routes the text through the existing clipboard path.
+
 ## [3.11.0] — 2026-06-29 — Channels become a two-way agent surface
 
 Headline: v3.10.0 gave channels a place a **human** can read; v3.11.0 closes the loop on the **agent** side. An agent can now *read* a channel instead of only posting into it, *discover* and join public rooms, *invite* another workspace into a private one, and get *pulled in by an @-mention* that arrives as an inbox task and a one-line nudge in its terminal. The conversation view grows up alongside: markdown rendering, a scrollback window that pages older history in from the daemon, and in-channel search. Plus more accurate MCP agent identity and a batch of macOS keyboard and appearance fixes.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.11.0 sources.** This file is produced by
+> **Generated from wmux v3.11.1 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Patch release **v3.11.1**.

Single fix: wmux now honors OSC 52, so copying inside a full-screen TUI app (Claude Code, vim, tmux, neovim) reaches the system clipboard. Previously those apps reported "copied" while the clipboard never changed, since xterm disables OSC 52 by default and wmux had no handler. Write half only; clipboard reads, clears, oversized, and malformed payloads are refused. (#314)

Routine bump: `package.json` + lock, regenerated `docs/api/reference.md` (version string only, no API change), `CHANGELOG.md`.

Tagging `v3.11.1` after merge triggers `release.yml` (GitHub Release + Chocolatey + winget).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Copying from full-screen terminal apps now works correctly with the system clipboard.
  * Clipboard handling now ignores unsupported or invalid clipboard requests to prevent bad transfers.

* **Chores**
  * Updated the project version to 3.11.1.
  * Refreshed the generated API reference and release notes for the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->