### PR TITLE
fix(terminal): restore visible scrollbar after xterm 6 upgrade

### DIFF
--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -268,6 +268,38 @@ button {
   background: transparent;
 }
 
+/* xterm 6 moved the terminal to a Monaco/VS Code scrollbar that AUTO-HIDES when
+   idle via an INLINE `visibility: hidden` on `.scrollbar` (NOT opacity — that was
+   a red herring), and xterm no longer paints the old `.xterm-viewport` native bar
+   that the `::-webkit-scrollbar` rules above target. Net effect: the terminal had
+   NO visible scrollbar while every other panel showed a persistent one (scrollback
+   itself worked fine). Force the scrollbar always-visible and paint the slider to
+   match the theme so it's consistent with the rest of the UI. */
+.xterm .xterm-scrollable-element > .scrollbar {
+  /* Monaco sets an INLINE `visibility: hidden` on the scrollbar when idle (the
+     real auto-hide mechanism — opacity alone was a red herring). Force it. */
+  visibility: visible !important;
+}
+/* Thin the Monaco bar (default 14px) down to the 6px the rest of the UI uses. */
+.xterm .xterm-scrollable-element > .scrollbar.vertical,
+.xterm .xterm-scrollable-element > .scrollbar.vertical > .slider {
+  width: 6px !important;
+}
+.xterm .xterm-scrollable-element > .scrollbar.invisible {
+  opacity: 1 !important;
+  pointer-events: auto !important;
+}
+.xterm .xterm-scrollable-element > .scrollbar > .slider {
+  /* Same colour as the rest of the UI's scrollbar (the ::-webkit-scrollbar above).
+     The real bug was the inline visibility:hidden, NOT the colour. */
+  visibility: visible !important;
+  background: var(--bg-surface) !important;
+  border-radius: 3px;
+}
+.xterm .xterm-scrollable-element > .scrollbar > .slider:hover {
+  background: var(--bg-overlay) !important;
+}
+
 /* Notification ring pulse on inactive panes with unread notifications */
 @keyframes notification-ring-pulse {
   0%, 100% { box-shadow: 0 0 0 0 rgba(var(--accent-blue-rgb), 0.4); }


### PR DESCRIPTION
## What
The terminal had no visible scrollbar after the xterm 6 upgrade — every other panel showed one.

## Root cause
xterm 6 swapped the terminal to a Monaco/VS Code scrollbar that auto-hides when idle via an **inline `visibility: hidden`** on `.scrollbar`, and stopped painting the `.xterm-viewport` native bar that our global `::-webkit-scrollbar` styles target. The slider colour was also left undefined. Scrollback and wheel-scroll worked the whole time — only the visual bar was gone. (Worth flagging: `opacity` looked like the culprit but was a red herring; the inline `visibility: hidden` is the real auto-hide mechanism.)

## Fix (globals.css, one file)
- `.scrollbar { visibility: visible !important }` — defeat the inline auto-hide (the actual fix)
- slider `background: var(--bg-surface)` — same colour as the other panels' scrollbar
- slider `width: 6px` — same width as the `::-webkit-scrollbar` panels (Monaco default was 14px)

## Verification
Verified live over CDP on a fresh build: rendered `dir C:\Windows\System32` to fill scrollback, and the slider now renders on the terminal's right edge and tracks scroll position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal scrollbars so they stay visible and usable instead of auto-hiding.
  * Adjusted scrollbar sizing and colors to better match the app’s theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->