### PR TITLE
fix(terminal): repaint mid-stream so long Claude output stops garbling (#318)

### DIFF
--- a/src/renderer/terminal/__tests__/glyphRepaint.test.ts
+++ b/src/renderer/terminal/__tests__/glyphRepaint.test.ts
@@ -4,6 +4,7 @@ import {
   BURST_BYTES_DEFAULT,
   BURST_QUIET_MS_DEFAULT,
   FOCUS_THROTTLE_MS_DEFAULT,
+  BURST_STREAM_FLUSH_MS_DEFAULT,
   type RepaintReason,
 } from '../glyphRepaint';
 
@@ -47,8 +48,10 @@ describe('glyphRepaint scheduler', () => {
       expect(repaints).toEqual(['burst']);
     });
 
-    it('keeps deferring while writes keep arriving, fires once at the end', () => {
-      const s = createGlyphRepaintScheduler({ repaint, burstBytes: 10, burstQuietMs: 50 });
+    it('keeps deferring the trailing repaint while writes keep arriving, fires once at the end', () => {
+      // burstStreamFlushMs: Infinity isolates the trailing-settle path (mid-stream
+      // flush disabled) so this asserts only the quiet-gap behavior.
+      const s = createGlyphRepaintScheduler({ repaint, burstBytes: 10, burstQuietMs: 50, burstStreamFlushMs: Infinity });
       for (let i = 0; i < 20; i++) {
         s.onData(1000);
         vi.advanceTimersByTime(49); // never quiet long enough
@@ -83,6 +86,86 @@ describe('glyphRepaint scheduler', () => {
       s.onData(-5);
       vi.advanceTimersByTime(100);
       expect(repaints).toEqual([]);
+    });
+  });
+
+  // Issue #318 — a full-screen TUI (Claude Code) repaints continuously during a
+  // long answer, so the quiet gap that ends a burst never arrives. Without the
+  // mid-stream flush the trailing repaint never fires and stale glyphs sit on
+  // screen for the whole stream. These tests advance the injected clock AND the
+  // fake quiet timer together (writes spaced under burstQuietMs) so the burst
+  // stays open the way it does in production — not as an artifact of a frozen
+  // quiet timer.
+  describe('mid-stream flush (issue #318)', () => {
+    it('flushes about every burstStreamFlushMs during a genuinely continuous stream', () => {
+      let t = 0;
+      const s = createGlyphRepaintScheduler({
+        repaint, burstBytes: 10, burstQuietMs: 50, burstStreamFlushMs: 100, now: () => t,
+      });
+      const tick = (ms: number) => { t += ms; vi.advanceTimersByTime(ms); };
+      s.onData(1000);                                          // t=0 burst start — no flush on the first write
+      for (let i = 0; i < 9; i++) { tick(40); s.onData(1000); } // 40ms apart (< 50 quiet) keeps the burst open through ~360ms
+      // cadence 100ms from burst start → flushes near t=120, 240, 360.
+      expect(repaints.length).toBeGreaterThanOrEqual(2);
+      expect(repaints.every((r) => r === 'burst')).toBe(true);
+    });
+
+    it('still fires the trailing settle repaint after a mid-stream flush (burstAccum not reset)', () => {
+      // Load-bearing invariant: the mid-stream flush must NOT reset burstAccum,
+      // or a stream ending with a sub-burstBytes tail after the last flush would
+      // never get its final repaint — the #318 corruption, regressed silently.
+      let t = 0;
+      const s = createGlyphRepaintScheduler({
+        repaint, burstBytes: 10, burstQuietMs: 50, burstStreamFlushMs: 100, now: () => t,
+      });
+      const tick = (ms: number) => { t += ms; vi.advanceTimersByTime(ms); };
+      s.onData(1000);
+      for (let i = 0; i < 4; i++) { tick(40); s.onData(1000); } // a mid-stream flush fires near t=120
+      const mid = repaints.length;
+      expect(mid).toBeGreaterThanOrEqual(1);                    // at least one mid-stream flush
+      tick(50);                                                  // quiet gap → trailing settle
+      expect(repaints.length).toBe(mid + 1);                    // trailing repaint fired too
+    });
+
+    it('does not mid-stream flush while the open burst is below burstBytes', () => {
+      let t = 0;
+      const s = createGlyphRepaintScheduler({
+        repaint, burstBytes: 1000, burstQuietMs: 50, burstStreamFlushMs: 100, now: () => t,
+      });
+      const tick = (ms: number) => { t += ms; vi.advanceTimersByTime(ms); };
+      s.onData(300);                 // t=0 accum=300
+      tick(40); s.onData(300);       // accum=600, burst open, past cadence but <1000 → no flush
+      tick(40); s.onData(300);       // accum=900 <1000 → no flush
+      expect(repaints).toEqual([]);
+      tick(40); s.onData(300);       // accum=1200 >=1000 and past cadence → flush
+      expect(repaints).toEqual(['burst']);
+    });
+
+    it('does not mid-stream flush a short burst that settles before the cadence', () => {
+      let t = 0;
+      const s = createGlyphRepaintScheduler({
+        repaint, burstBytes: 10, burstQuietMs: 50, burstStreamFlushMs: 500, now: () => t,
+      });
+      s.onData(1000);             // single chunk at t=0
+      t = 50; vi.advanceTimersByTime(50); // settle before the 500ms cadence → trailing only
+      expect(repaints).toEqual(['burst']);
+    });
+
+    it('clamps a non-positive burstStreamFlushMs to a 1ms floor (no every-write churn)', () => {
+      let t = 0;
+      const s = createGlyphRepaintScheduler({
+        repaint, burstBytes: 10, burstQuietMs: 50, burstStreamFlushMs: 0, now: () => t,
+      });
+      const tick = (ms: number) => { t += ms; vi.advanceTimersByTime(ms); };
+      s.onData(1000);                 // t=0 — floor still means t-lastFlush(0) >= 1 is false → no flush
+      expect(repaints).toEqual([]);
+      tick(1); s.onData(1000);        // 1ms later → floor satisfied → flush
+      expect(repaints).toEqual(['burst']);
+    });
+
+    it('uses a sane default cadence', () => {
+      expect(BURST_STREAM_FLUSH_MS_DEFAULT).toBeGreaterThan(0);
+      expect(BURST_STREAM_FLUSH_MS_DEFAULT).toBeLessThanOrEqual(1000);
     });
   });
 

--- a/src/renderer/terminal/glyphRepaint.ts
+++ b/src/renderer/terminal/glyphRepaint.ts
@@ -26,6 +26,15 @@
 //                 (quiet for burstQuietMs). This is the "watching agent output
 //                 garble live" case where neither focus nor visibility changes.
 //
+// Mid-stream flush (issue #318): the trailing burst repaint only fires once the
+// stream goes quiet for burstQuietMs. A full-screen TUI (Claude Code, vim)
+// repaints frames continuously during a long answer, so that quiet gap never
+// arrives and the burst repaint never fires until output finally stops — the
+// dirty-region staleness then sits on screen for the entire stream (the user's
+// "old output overlays new during long conversations" report). So once a burst
+// has qualified, we ALSO repaint every burstStreamFlushMs of continuous output,
+// not just at the trailing settle.
+//
 // All three reasons run the same full-range refresh; the caller does not vary
 // repaint cost per reason. The refresh never mutates the shared glyph atlas
 // (#191), so it cannot corrupt sibling panes — the burst-visibility gate aside,
@@ -59,6 +68,10 @@ export interface GlyphRepaintOptions {
   /** Minimum interval between focus-triggered repaints. Focus fires on every
    *  click into the pane; the atlas clear behind it should not. */
   focusThrottleMs?: number;
+  /** During a sustained burst that never goes quiet (continuous TUI repaint),
+   *  repaint at most this often. Bounds the mid-stream flush cadence so a busy
+   *  stream stays fresh without churning a full refresh on every write. */
+  burstStreamFlushMs?: number;
   /** Injectable clock for tests. */
   now?: () => number;
 }
@@ -66,6 +79,10 @@ export interface GlyphRepaintOptions {
 export const BURST_BYTES_DEFAULT = 32 * 1024;
 export const BURST_QUIET_MS_DEFAULT = 300;
 export const FOCUS_THROTTLE_MS_DEFAULT = 1000;
+// Mid-stream flush cadence (issue #318). ~2 repaints/sec during heavy streaming
+// — frequent enough that corruption never lingers visibly, infrequent enough
+// that the extra full-range refreshes are not measurable GPU churn.
+export const BURST_STREAM_FLUSH_MS_DEFAULT = 500;
 
 export function createGlyphRepaintScheduler(
   options: GlyphRepaintOptions,
@@ -75,18 +92,43 @@ export function createGlyphRepaintScheduler(
     burstBytes = BURST_BYTES_DEFAULT,
     burstQuietMs = BURST_QUIET_MS_DEFAULT,
     focusThrottleMs = FOCUS_THROTTLE_MS_DEFAULT,
+    burstStreamFlushMs: burstStreamFlushMsRaw = BURST_STREAM_FLUSH_MS_DEFAULT,
     now = Date.now,
   } = options;
+  // Floor the mid-stream cadence at 1ms so a 0/negative value can't turn the
+  // flush into a full-range refresh on every single write (the GPU churn the
+  // cadence exists to avoid). Infinity is preserved (Math.max(1, Infinity) =
+  // Infinity), so passing Infinity still disables the mid-stream flush entirely.
+  const burstStreamFlushMs = Math.max(1, burstStreamFlushMsRaw);
 
   let disposed = false;
   let burstAccum = 0;
   let quietTimer: ReturnType<typeof setTimeout> | null = null;
   let lastFocusRepaintAt = -Infinity;
+  // Burst-start / last mid-stream-flush timestamp, used by the #318 mid-stream
+  // flush so it measures from the start of the current continuous burst.
+  let lastStreamFlushAt = -Infinity;
 
   return {
     onData(byteLength: number): void {
       if (disposed || byteLength <= 0) return;
+      const t = now();
+      // A new burst begins whenever no quiet timer is pending (the previous
+      // burst already settled, or this is the first write ever). Stamp the
+      // burst start so the mid-stream flush measures from here — a short burst
+      // that settles before burstStreamFlushMs never mid-flushes, only the
+      // trailing repaint runs (unchanged behavior for interactive output).
+      if (quietTimer === null) lastStreamFlushAt = t;
       burstAccum += byteLength;
+      // Mid-stream flush (issue #318): once the burst has qualified, repaint
+      // every burstStreamFlushMs of CONTINUOUS output so a non-stop stream
+      // self-repairs instead of waiting for a quiet gap that never comes.
+      // burstAccum is deliberately NOT reset here — the burst is still open, so
+      // it keeps qualifying and the trailing repaint still runs at settle.
+      if (burstAccum >= burstBytes && t - lastStreamFlushAt >= burstStreamFlushMs) {
+        lastStreamFlushAt = t;
+        repaint('burst');
+      }
       if (quietTimer) clearTimeout(quietTimer);
       quietTimer = setTimeout(() => {
         quietTimer = null;


### PR DESCRIPTION
## What

Long Claude Code answers (and other full-screen TUIs) could leave old terminal output overlapping new output mid-stream, clearing only when you manually resized the pane. Same signature as the closed #166.

## Why

The glyph-repaint scheduler's burst trigger only fires after output goes quiet for 300ms. A TUI that repaints continuously during a long answer never produces that quiet gap, so the defensive repaint never ran for the duration of the stream. The dirty-region staleness just sat there until a resize forced a full repaint.

## Fix

Add a mid-stream flush to `glyphRepaint`: once a burst has qualified (>= 32KB), repaint every 500ms of continuous output instead of only at the quiet settle. Short interactive bursts are unchanged (they settle before the cadence fires). The cadence is floored at 1ms so a bad override can't turn it into a per-write refresh; Infinity still disables it.

No renderer/atlas changes: the #191 shared-atlas regression lock stays in place (clearTextureAtlas is not re-enabled). This targets the dirty-region class of #318. If corruption persists with GPU on after this, that points at the texture-atlas class, which needs the upstream xterm fix (TextureAtlas.clearTexture not setting _requestClearModel) rather than a wmux-side repaint.

## Testing

- New glyphRepaint unit tests: mid-stream cadence, the burstBytes gate, the 1ms clamp, and a regression test pinning the invariant that the mid-stream flush does not reset the byte accumulator (so the trailing settle repaint still fires).
- Full suite green (4428 passed).
- Independent 3-way review (codex + GLM-5.2): no correctness findings; the test hardening they flagged is included.
- Live-dogfooded on a real GPU: heavy continuous streaming renders clean.

Refs #318. The corruption is intermittent / GPU-timing dependent, so a reporter confirmation on a real long Claude Code session is welcome before closing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added periodic “mid-stream” repaint handling so the terminal can stay responsive during long continuous bursts of output.
  * Introduced a new tuning option for burst flush cadence, with a safe default and protection against overly aggressive refresh loops.

* **Bug Fixes**
  * Improved repaint timing so bursty terminal content still settles correctly after extended activity.
  * Ensured short bursts continue to use the normal trailing repaint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->