### PR TITLE
feat(terminal): dead-input diagnostics + re-focus on multiview toggle

### DIFF
--- a/src/renderer/hooks/__tests__/useActivePaneFocus.test.ts
+++ b/src/renderer/hooks/__tests__/useActivePaneFocus.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   resolveActivePanePtyId,
+  computeFocusKey,
   driveFocusToTerminal,
   isFocusOrphaned,
   reassertFocusIfOrphaned,
@@ -67,6 +68,46 @@ describe('resolveActivePanePtyId', () => {
   it('returns null for a browser surface (no xterm to focus)', () => {
     const root = leaf('p1', [surface('s1', 'pty-1', 'browser')], 's1');
     expect(resolveActivePanePtyId({ workspaces: [ws('w1', root, 'p1')], activeWorkspaceId: 'w1' })).toBeNull();
+  });
+
+  // ─── computeFocusKey — input-dead (multiview remount) regression ────────────
+  describe('computeFocusKey', () => {
+    const root = leaf('p1', [surface('s1', 'pty-1')], 's1');
+    const base = { workspaces: [ws('w1', root, 'p1')], activeWorkspaceId: 'w1', multiviewIds: [] as string[] };
+
+    it('encodes ws + pane + surface + pty', () => {
+      const key = computeFocusKey(base);
+      expect(key).toContain('w1');
+      expect(key).toContain('p1');
+      expect(key).toContain('s1');
+      expect(key).toContain('pty-1');
+    });
+
+    it('CHANGES when the active workspace enters/leaves the multiview grid', () => {
+      // Single view vs grid remounts the active terminal, but leaves the focus
+      // target (ws/pane/surface/pty) unchanged. The key MUST differ so the focus
+      // effect re-runs and re-focuses the freshly remounted xterm — otherwise
+      // typing is dead until a click.
+      const single = computeFocusKey({ ...base, multiviewIds: [] });
+      const grid = computeFocusKey({ ...base, multiviewIds: ['w1', 'w2'] }); // active w1 ∈ grid
+      expect(single).not.toBe(grid);
+    });
+
+    it('does NOT change for edits to OTHER workspaces while the active one stays gridded', () => {
+      // Adding/removing an unrelated workspace does not remount the active
+      // terminal, so it must not re-run the focus effect (no needless focus steal).
+      const two = computeFocusKey({ ...base, multiviewIds: ['w1', 'w2'] });
+      const three = computeFocusKey({ ...base, multiviewIds: ['w1', 'w2', 'w3'] });
+      expect(two).toBe(three);
+    });
+
+    it('is stable when nothing changes', () => {
+      expect(computeFocusKey(base)).toBe(computeFocusKey({ ...base, workspaces: [ws('w1', root, 'p1')] }));
+    });
+
+    it('returns empty string when no active workspace resolves', () => {
+      expect(computeFocusKey({ workspaces: [], activeWorkspaceId: 'nope', multiviewIds: [] })).toBe('');
+    });
   });
 
   it('returns null for an editor surface', () => {

--- a/src/renderer/hooks/useActivePaneFocus.ts
+++ b/src/renderer/hooks/useActivePaneFocus.ts
@@ -35,6 +35,42 @@ export function resolveActivePanePtyId(
   return surface.ptyId;
 }
 
+/**
+ * Compact signature of the current focus target: active workspace + pane +
+ * surface + its pty, PLUS the multiview set. The focus effect keys on this so it
+ * re-runs whenever any of them changes. Pure (no DOM) for unit testing.
+ *
+ * ptyId matters for boot reconcile: a restored surface's stale ptyId is cleared
+ * then re-created (same ws/pane/surface, new pty), and focus must follow it.
+ *
+ * The active-workspace-in-grid flag matters because toggling multiview swaps
+ * AppLayout's render branch (single view vs grid), which REMOUNTS the pane
+ * subtree and its terminals with the SAME ws/pane/surface/pty. Without a term
+ * that captures that flip the effect would not re-run, driveFocusToTerminal's
+ * one-shot subscription would stay disarmed, and the freshly remounted xterm
+ * would never get DOM focus (typing goes nowhere until a click). We key on the
+ * boolean, not the raw multiviewIds set, so edits to OTHER workspaces do not
+ * needlessly re-run the effect (input-dead investigation, sibling to #318).
+ *
+ * The space separator can't appear in an id, so distinct targets never collide.
+ */
+export function computeFocusKey(
+  state: { workspaces: Workspace[]; activeWorkspaceId: string; multiviewIds: string[] },
+): string {
+  const ws = state.workspaces.find((w) => w.id === state.activeWorkspaceId);
+  if (!ws) return '';
+  const leaf = findLeaf(ws.rootPane, ws.activePaneId);
+  const surface = leaf?.surfaces.find((x) => x.id === leaf.activeSurfaceId);
+  // Only whether the ACTIVE workspace renders in the multiview grid (vs single
+  // view) — that boolean is what flips its render branch and remounts its
+  // terminal (AppLayout gate: multiviewIds.length >= 2 && includes(active)).
+  // Keying on the full multiviewIds set would also re-run the effect for
+  // unrelated edits (adding/removing OTHER workspaces) and needlessly re-steal
+  // focus to the terminal.
+  const activeInGrid = state.multiviewIds.length >= 2 && state.multiviewIds.includes(state.activeWorkspaceId);
+  return `${state.activeWorkspaceId} ${ws.activePaneId} ${leaf?.activeSurfaceId ?? ''} ${surface?.ptyId ?? ''} ${activeInGrid ? 'grid' : 'single'}`;
+}
+
 export interface FocusDriverDeps {
   getTerminal: (ptyId: string) => { focus(): void } | undefined;
   /** Subscribe to terminal registrations; returns an unsubscribe fn. */
@@ -179,20 +215,10 @@ export function reassertFocusIfOrphaned(deps: FocusReassertDeps): void {
  * bridge, and the boot-time session restore (late xterm registration).
  */
 export function useActivePaneFocus(): void {
-  // Subscribe to a compact signature of the focus target so the effect only
-  // re-runs when the active workspace, pane, surface OR its bound pty
-  // actually changes. The ptyId term matters for boot reconcile: a restored
-  // surface whose stale ptyId is cleared and then re-created by Terminal's
-  // self-create path keeps the same ws/pane/surface ids — only the ptyId
-  // changes, and the focus must follow it. The space separator can't appear
-  // in an id, so distinct targets never collide into the same key.
-  const focusKey = useStore((s) => {
-    const ws = s.workspaces.find((w) => w.id === s.activeWorkspaceId);
-    if (!ws) return '';
-    const leaf = findLeaf(ws.rootPane, ws.activePaneId);
-    const surface = leaf?.surfaces.find((x) => x.id === leaf.activeSurfaceId);
-    return `${s.activeWorkspaceId} ${ws.activePaneId} ${leaf?.activeSurfaceId ?? ''} ${surface?.ptyId ?? ''}`;
-  });
+  // Re-run the focus effect whenever the focus target OR the multiview set
+  // changes. Logic + rationale (why multiviewIds is in the key) live in
+  // computeFocusKey.
+  const focusKey = useStore(computeFocusKey);
 
   useEffect(() => {
     const ptyId = resolveActivePanePtyId(useStore.getState());

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -24,6 +24,7 @@ import { attachImeStormGuard } from '../terminal/imeStormGuard';
 import { webglContextPool } from '../terminal/webglContextPool';
 import { teardownWebglAddon } from '../terminal/webglTeardown';
 import { createGlyphRepaintScheduler, type GlyphRepaintScheduler } from '../terminal/glyphRepaint';
+import { createDeadInputWatchdog } from '../terminal/deadInputWatchdog';
 import { reconnectPtyWithRetry as reconnectPtyWithRetryImpl } from './reconnectPtyWithRetry';
 
 // Module-level terminal registry for scrollback persistence
@@ -413,6 +414,35 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       },
     });
 
+    // Diagnostic-only dead-input watchdog for the intermittent "typing dead
+    // until remount (multiview toggle)" field bug. It attempts NO recovery — it
+    // logs the discriminating evidence the next time input dies in the wild so
+    // the machine/IME-dependent cause can be confirmed from a user log instead
+    // of a local repro that has never triggered. keyCodes all 229 => IME claim
+    // storm; activeElement tells orphaned-focus (body/other) apart from an
+    // IME-layer death (focus still on the xterm textarea). console.warn is
+    // mirrored into the main-side log by src/main/index.ts's console-message
+    // listener, so it lands in the file the user can share.
+    const deadInputWatchdog = createDeadInputWatchdog({
+      report: ({ keydownCount, keyCodes, codes, spanMs }) => {
+        const active = document.activeElement;
+        const activeDesc = active
+          ? `${active.tagName.toLowerCase()}.${(active.className || '').toString().slice(0, 40)}`
+          : 'null';
+        // ptyIdRef.current, not the captured ptyId, so a reconnect that swaps
+        // the pty still attributes the log to the live session.
+        console.warn(
+          `[wmux:dead-input] pty=${ptyIdRef.current} ${keydownCount} keys in ${spanMs}ms reached no onData ` +
+          `keyCodes=[${keyCodes.join(',')}] codes=[${codes.join(',')}] activeElement=${activeDesc}`,
+        );
+      },
+    });
+    const onWatchdogKeyDown = (e: Event): void => {
+      const ke = e as KeyboardEvent;
+      deadInputWatchdog.onKeyDown({ keyCode: ke.keyCode, isComposing: ke.isComposing, code: ke.code });
+    };
+    terminal.textarea?.addEventListener('keydown', onWatchdogKeyDown);
+
     // Paint the container backdrop with the xterm theme background so the 4px
     // padding (and the sub-cell rounding gap xterm leaves around its grid) fades
     // into the terminal content instead of exposing the app's --bg-base behind
@@ -584,6 +614,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       if (newlineByte !== null) {
         e.preventDefault();
         window.electronAPI.pty.write(ptyId, newlineByte);
+        deadInputWatchdog.onData(); // direct write bypasses terminal.onData
         return false;
       }
 
@@ -602,6 +633,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       if (e.code === 'Escape' && !e.isComposing && e.keyCode === 229) {
         e.preventDefault();
         window.electronAPI.pty.write(ptyId, '\x1b');
+        deadInputWatchdog.onData(); // direct write bypasses terminal.onData
         return false;
       }
 
@@ -910,6 +942,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // pastes, and IME commits all still clear as intended.
       if (data !== '\x1b[I' && data !== '\x1b[O') {
         useStore.getState().clearResumeHint(ptyId);
+        // Real user input reached the app — clear the dead-input watchdog.
+        deadInputWatchdog.onData();
       }
       void chunkOnDataIfNeeded(
         (d) => window.electronAPI.pty.write(ptyId, d),
@@ -1210,10 +1244,12 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     return () => {
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
       terminal.textarea?.removeEventListener('focus', onTextareaFocus);
+      terminal.textarea?.removeEventListener('keydown', onWatchdogKeyDown);
       glyphRepaint.dispose();
       glyphRepaintRef.current = null;
       imeResidueGuard?.dispose();
       imeStormGuard.dispose();
+      deadInputWatchdog.dispose();
       autoCopy.dispose();
       selectionDisposable.dispose();
       pathLinkDisposable.dispose();

--- a/src/renderer/terminal/__tests__/deadInputWatchdog.test.ts
+++ b/src/renderer/terminal/__tests__/deadInputWatchdog.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createDeadInputWatchdog,
+  isNonInputKey,
+  DEAD_INPUT_THRESHOLD_DEFAULT,
+  DEAD_INPUT_WINDOW_MS_DEFAULT,
+  DEAD_INPUT_COOLDOWN_MS_DEFAULT,
+  type DeadInputReport,
+} from '../deadInputWatchdog';
+
+describe('deadInputWatchdog', () => {
+  const setup = (opts?: Partial<Parameters<typeof createDeadInputWatchdog>[0]>) => {
+    let t = 0;
+    const reports: DeadInputReport[] = [];
+    const w = createDeadInputWatchdog({
+      report: (r) => reports.push(r),
+      threshold: 4,
+      windowMs: 400,
+      cooldownMs: 10_000,
+      now: () => t,
+      ...opts,
+    });
+    const key = (keyCode: number, isComposing = false, code = 'KeyA') => w.onKeyDown({ keyCode, isComposing, code });
+    const at = (ms: number) => { t = ms; };
+    return { w, reports, key, at };
+  };
+
+  it('reports when enough input keydowns go unanswered across the window', () => {
+    const { reports, key, at } = setup();
+    at(0); key(229);
+    at(150); key(229);
+    at(300); key(229);
+    expect(reports).toEqual([]);        // only 3 so far
+    at(450); key(229);                  // 4th, span 450 >= 400 → report
+    expect(reports).toHaveLength(1);
+    expect(reports[0].keydownCount).toBe(4);
+    expect(reports[0].keyCodes).toEqual([229]);  // all IME-claimed
+    expect(reports[0].codes).toEqual(['KeyA']);
+  });
+
+  it('does not report below the threshold', () => {
+    const { reports, key, at } = setup();
+    at(0); key(229); at(500); key(229); at(1000); key(229); // 3, well past window
+    expect(reports).toEqual([]);
+  });
+
+  it('does not report a fast burst that does not span the window', () => {
+    const { reports, key, at } = setup();
+    at(0); key(65); at(50); key(66); at(100); key(67); at(150); key(68); // 4 keys, span 150 < 400
+    expect(reports).toEqual([]);
+  });
+
+  it('resets when input actually reaches the app (onData)', () => {
+    const { w, reports, key, at } = setup();
+    at(0); key(229); at(150); key(229); at(300); key(229);
+    w.onData();                         // input got through → reset
+    at(450); key(229); at(600); key(229); at(750); key(229);
+    expect(reports).toEqual([]);        // only 3 since the reset
+  });
+
+  it('does NOT report healthy IME composition (isComposing resets the accumulator)', () => {
+    // Normal slow CJK typing: 229 keydowns with isComposing=true, no onData until
+    // commit. This has the same shape as the storm we hunt EXCEPT isComposing —
+    // it must never self-report, or the diagnostic is worthless for Korean users.
+    const { reports, key, at } = setup();
+    for (let i = 0; i < 8; i++) { at(i * 200); key(229, true, 'KeyR'); } // spans 1.4s, composing
+    expect(reports).toEqual([]);
+  });
+
+  it('ignores modifier / lock / function keys (they produce no shell input)', () => {
+    const { reports, key, at } = setup();
+    at(0); key(16, false, 'ShiftLeft');
+    at(150); key(17, false, 'ControlLeft');
+    at(300); key(18, false, 'AltLeft');
+    at(450); key(112, false, 'F1');
+    at(600); key(20, false, 'CapsLock');
+    expect(reports).toEqual([]);        // none of these count
+  });
+
+  it('still catches a storm interleaved with modifier keys', () => {
+    const { reports, key, at } = setup();
+    at(0); key(229, false, 'KeyH');
+    at(150); key(16, false, 'ShiftLeft'); // ignored, does not reset
+    at(300); key(229, false, 'KeyA');
+    at(450); key(229, false, 'KeyN');
+    at(600); key(229, false, 'KeyG');     // 4 real input keys, span 600 → report
+    expect(reports).toHaveLength(1);
+    expect(reports[0].keydownCount).toBe(4);
+    expect(reports[0].codes).toEqual(['KeyH', 'KeyA', 'KeyN', 'KeyG']);
+  });
+
+  it('rate-limits to one report per episode (cooldown)', () => {
+    const { reports, key, at } = setup();
+    at(0); key(229); at(150); key(229); at(300); key(229); at(450); key(229); // report #1
+    expect(reports).toHaveLength(1);
+    at(600); key(229); at(900); key(229); at(1200); key(229); at(1500); key(229); // within cooldown
+    expect(reports).toHaveLength(1);
+    at(11_000); key(229); at(11_500); key(229); at(12_000); key(229); at(12_500); key(229); // past cooldown
+    expect(reports).toHaveLength(2);
+  });
+
+  it('is a no-op after dispose', () => {
+    const { w, reports, key, at } = setup();
+    w.dispose();
+    at(0); key(229); at(150); key(229); at(300); key(229); at(450); key(229);
+    expect(reports).toEqual([]);
+  });
+
+  it('isNonInputKey classifies keys correctly', () => {
+    for (const c of ['ShiftLeft', 'ControlRight', 'AltLeft', 'MetaRight', 'CapsLock', 'NumLock', 'F1', 'F12']) {
+      expect(isNonInputKey(c)).toBe(true);
+    }
+    for (const c of ['KeyA', 'Enter', 'Tab', 'ArrowUp', 'Space', 'Digit1']) {
+      expect(isNonInputKey(c)).toBe(false);
+    }
+  });
+
+  it('exports sane defaults', () => {
+    expect(DEAD_INPUT_THRESHOLD_DEFAULT).toBeGreaterThanOrEqual(2);
+    expect(DEAD_INPUT_WINDOW_MS_DEFAULT).toBeGreaterThan(0);
+    expect(DEAD_INPUT_COOLDOWN_MS_DEFAULT).toBeGreaterThanOrEqual(1000);
+  });
+});

--- a/src/renderer/terminal/deadInputWatchdog.ts
+++ b/src/renderer/terminal/deadInputWatchdog.ts
@@ -1,0 +1,150 @@
+// Diagnostic-only watchdog for the intermittent "input dead until remount" bug
+// (field report: typing stops reaching the PTY; only a terminal remount, e.g.
+// toggling multiview, recovers it). The bug is machine/IME-dependent and has not
+// reproduced locally, so instead of a blind fix this instrument captures the
+// discriminating evidence the NEXT time it happens in the wild.
+//
+// Signal: the user pressed several *input* keys into the focused xterm textarea,
+// but ZERO of them produced `terminal.onData` (xterm's "send this to the shell"
+// event) within a time window. That is "keys pressed, nothing reached the app" —
+// dead input. The caller logs the report with `document.activeElement` so we
+// also learn WHERE focus sat (the xterm textarea vs. something else), which
+// tells orphaned-focus apart from an IME-layer death.
+//
+// What is deliberately NOT counted, so healthy input never self-reports:
+//   - Keydowns during an IME composition (`isComposing === true`). A live
+//     composition means input IS being processed; healthy CJK typing otherwise
+//     looks identical to the storm (229 keydowns, no onData until the candidate
+//     commits). The storm we hunt keeps isComposing=false the whole time (it
+//     never opens a composition), so it still accumulates. Composing keydowns
+//     reset the accumulator (they are activity).
+//   - Modifier / lock / function keys (Shift/Ctrl/Alt/Meta/CapsLock/F-keys),
+//     which never produce shell input and so are not evidence of dead input.
+//
+// This module NEVER mutates terminal state or attempts recovery. It only
+// reports. Pure logic (timers via injected clock) so it is unit-testable
+// without a DOM. Rate-limited so one dead-input episode logs once, not per key.
+
+/** Keys that never produce shell input, so their keydowns are not dead-input
+ *  evidence: the modifier/lock keys and the function row. Arrow/Tab/Enter DO
+ *  produce data in a terminal and are intentionally NOT excluded. */
+const NON_INPUT_KEY = /^(?:Shift|Control|Alt|Meta)(?:Left|Right)$|^(?:CapsLock|NumLock|ScrollLock)$|^F\d+$/;
+
+export function isNonInputKey(code: string): boolean {
+  return NON_INPUT_KEY.test(code);
+}
+
+export interface DeadInputWatchdogKey {
+  /** Legacy keyCode. 229 ("Process") means the IME claimed the key. */
+  keyCode: number;
+  /** Whether an IME composition was active for this keydown. */
+  isComposing: boolean;
+  /** Physical key code (diagnostic + non-input-key filter). */
+  code: string;
+}
+
+export interface DeadInputReport {
+  /** Input keydowns observed since the last input actually reached the app. */
+  keydownCount: number;
+  /** Distinct legacy keyCodes seen (all 229 = IME claim storm). */
+  keyCodes: number[];
+  /** Distinct physical codes seen (diagnostic). */
+  codes: string[];
+  /** Span from the first unanswered keydown to the report, in ms. */
+  spanMs: number;
+}
+
+export interface DeadInputWatchdogOptions {
+  /** Called once per episode when dead input is detected. */
+  report: (info: DeadInputReport) => void;
+  /** Unanswered input keydowns required before a report fires. Default 4. */
+  threshold?: number;
+  /** The unanswered keydowns must span at least this long. Guards against a
+   *  fast burst that legitimately produces one onData for many keys. Default 400ms. */
+  windowMs?: number;
+  /** Minimum gap between reports so one stuck episode logs once. Default 10s. */
+  cooldownMs?: number;
+  /** Injectable clock for tests. */
+  now?: () => number;
+}
+
+export const DEAD_INPUT_THRESHOLD_DEFAULT = 4;
+export const DEAD_INPUT_WINDOW_MS_DEFAULT = 400;
+export const DEAD_INPUT_COOLDOWN_MS_DEFAULT = 10_000;
+
+export interface DeadInputWatchdog {
+  /** A keydown reached the focused terminal textarea. */
+  onKeyDown(key: DeadInputWatchdogKey): void;
+  /** xterm emitted data to the shell — input is flowing, so reset. */
+  onData(): void;
+  /** Drop all state (no-op after). */
+  dispose(): void;
+}
+
+export function createDeadInputWatchdog(options: DeadInputWatchdogOptions): DeadInputWatchdog {
+  const {
+    report,
+    threshold = DEAD_INPUT_THRESHOLD_DEFAULT,
+    windowMs = DEAD_INPUT_WINDOW_MS_DEFAULT,
+    cooldownMs = DEAD_INPUT_COOLDOWN_MS_DEFAULT,
+    now = Date.now,
+  } = options;
+
+  let disposed = false;
+  let count = 0;
+  let firstAt = 0;
+  const keyCodes = new Set<number>();
+  const codes = new Set<string>();
+  let lastReportAt = -Infinity;
+
+  const reset = (): void => {
+    count = 0;
+    firstAt = 0;
+    keyCodes.clear();
+    codes.clear();
+  };
+
+  return {
+    onKeyDown(key: DeadInputWatchdogKey): void {
+      if (disposed) return;
+      // A live composition = the IME is processing input. Treat as activity and
+      // reset so healthy CJK typing never self-reports (the storm stays
+      // isComposing=false and still accumulates).
+      if (key.isComposing) { reset(); return; }
+      // Modifier/lock/function keys produce no shell input — not dead-input
+      // evidence, so ignore without counting or resetting.
+      if (isNonInputKey(key.code)) return;
+      const t = now();
+      if (count === 0) firstAt = t;
+      count += 1;
+      keyCodes.add(key.keyCode);
+      codes.add(key.code);
+      const spanMs = t - firstAt;
+      if (count >= threshold && spanMs >= windowMs && t - lastReportAt >= cooldownMs) {
+        lastReportAt = t;
+        const info: DeadInputReport = {
+          keydownCount: count,
+          keyCodes: [...keyCodes],
+          codes: [...codes],
+          spanMs,
+        };
+        // Keep lastReportAt (do not clear it in reset) so a still-stuck episode
+        // does not re-log every key — only after the cooldown.
+        reset();
+        report(info);
+      }
+    },
+
+    onData(): void {
+      if (disposed) return;
+      // Input reached the app — whatever the user pressed got through, so this
+      // is not a dead-input episode. Clear the accumulator.
+      reset();
+    },
+
+    dispose(): void {
+      disposed = true;
+      reset();
+    },
+  };
+}


### PR DESCRIPTION
## What

Two changes for the intermittent "typing dead until I toggle multiview" bug (sibling to #318). The root cause is machine/IME-dependent and has not reproduced locally, so this ships an instrument to confirm it in the wild plus one clean latent-gap fix — not a blind fix.

## Diagnostics — deadInputWatchdog

When several *input* keydowns reach the focused xterm textarea but none produce `terminal.onData` (nor a direct PTY write), log the evidence: keyCodes (all 229 = IME claim storm), physical codes, and `document.activeElement` (tells orphaned-focus apart from an IME-layer death where focus is still on the textarea). `console.warn` is mirrored to the main log by the existing webContents `console-message` handler, so a user can share it. Report only — no recovery attempted.

To avoid false evidence it excludes healthy IME composition (`isComposing`) and modifier/lock/function keys, and resets on the direct-write key paths (newline/escape). Normal CJK typing never self-reports.

## Fix — computeFocusKey re-focuses on multiview toggle

Toggling multiview swaps AppLayout's render branch (single view vs grid), remounting the pane subtree and its terminals with the same ws/pane/surface/pty. The focus effect's key did not capture that, so it never re-ran: `driveFocusToTerminal`'s one-shot subscription stayed disarmed and the remounted xterm never got DOM focus. The key now includes whether the active workspace is in the grid (a boolean, so unrelated-workspace edits do not needlessly re-steal focus). Key extracted to a pure, tested function.

## Review + testing

- Independent 3-way review (Claude + Codex + GLM-5.2): the healthy-IME false-positive, modifier-key noise, and focus-steal precision they flagged are all folded in.
- New unit tests: deadInputWatchdog (composition/modifier exclusion, threshold/window/cooldown/reset/dispose), computeFocusKey (grid flip vs unrelated edits). Full suite green (4438).

Refs #318. This is diagnostics + a latent focus fix; the underlying IME-storm fix will follow once a reproduction log (`[wmux:dead-input] ... keyCodes=[...]`) confirms the variant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal focus behavior so it refreshes more reliably when switching between grid and non-grid views.
  * Added diagnostics for intermittent “typing dead” cases to help detect when terminal input stops responding.
  * Better handling of IME input and non-character keys to reduce false alerts.

* **Tests**
  * Added coverage for focus key changes and dead-input detection behavior across edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->