### PR TITLE
fix(macos): spawn shell with UTF-8 locale fallback so CJK input isn't garbled (#321)

### DIFF
--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -10,6 +10,7 @@ import { IPC, ENV_KEYS } from '../../../shared/constants';
 import { writePidMap, removePidMapByPtyId } from '../../pty/pidMap';
 import { sanitizePtyText } from '../../../shared/types';
 import { resolveSpawnEnv } from '../../pty/resolveSpawnEnv';
+import { getShellUtf8Locale } from '../../pty/shellLocale';
 import { scheduleInitialCommand } from './scheduleInitialCommand';
 import { updateCwd } from './metadata.handler';
 import { markResize, markUserWrite } from '../../notification/idleSuppression';
@@ -343,7 +344,7 @@ export function registerPTYHandlers(
       const identity: Record<string, string> = {};
       if (options?.workspaceId) identity[ENV_KEYS.WORKSPACE_ID] = options.workspaceId;
       if (options?.surfaceId) identity[ENV_KEYS.SURFACE_ID] = options.surfaceId;
-      const resolvedEnv = resolveSpawnEnv(globalThis.process.env, options?.env, identity);
+      const resolvedEnv = resolveSpawnEnv(globalThis.process.env, options?.env, identity, getShellUtf8Locale());
 
       // Create session via daemon RPC. `env` is the FULLY-RESOLVED child env;
       // the daemon replays it verbatim (see DaemonCreateSessionParams.env).

--- a/src/main/pty/PTYManager.ts
+++ b/src/main/pty/PTYManager.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { getPipeName, ENV_KEYS, getPidMapDir } from '../../shared/constants';
 import { resolveSpawnEnv } from './resolveSpawnEnv';
+import { getShellUtf8Locale } from './shellLocale';
 import { isWindows } from '../../shared/platform';
 import { ShellDetector } from '../../shared/ShellDetector';
 
@@ -159,7 +160,7 @@ export class PTYManager {
     // pane-level A2A fail-closed. The ptyId equals the pid-map content here, so
     // the env hint and a verified walk resolve to the same logical pane (WI-002).
     identity[ENV_KEYS.PTY_ID] = id;
-    const env = resolveSpawnEnv(globalThis.process.env, options?.env, identity);
+    const env = resolveSpawnEnv(globalThis.process.env, options?.env, identity, getShellUtf8Locale());
 
     // Detect shell type and inject hook
     const shellType = this.detectShellType(shell);

--- a/src/main/pty/__tests__/resolveSpawnEnv.test.ts
+++ b/src/main/pty/__tests__/resolveSpawnEnv.test.ts
@@ -107,4 +107,28 @@ describe('resolveSpawnEnv', () => {
     const env = resolveSpawnEnv({ PATH: '/usr/bin' }, undefined, {});
     expect(env.WMUX_DATA_SUFFIX).toBeUndefined();
   });
+
+  // issue #321 — Dock-launched macOS 앱은 LANG을 상속하지 않아 셸이 C 로케일로
+  // 떨어지고 한글 입력이 <0085> 식으로 깨진다. 폴백 주입을 검증한다.
+  it('injects the fallback locale as LANG when no locale var is set', () => {
+    const env = resolveSpawnEnv({ PATH: '/usr/bin' }, undefined, {}, 'ko_KR.UTF-8');
+    expect(env.LANG).toBe('ko_KR.UTF-8');
+  });
+
+  it('never overrides a LANG/LC_ALL/LC_CTYPE the user already set', () => {
+    const withLang = resolveSpawnEnv({ LANG: 'ja_JP.UTF-8' }, undefined, {}, 'ko_KR.UTF-8');
+    expect(withLang.LANG).toBe('ja_JP.UTF-8');
+
+    const withLcAll = resolveSpawnEnv({ LC_ALL: 'en_GB.UTF-8' }, undefined, {}, 'ko_KR.UTF-8');
+    expect(withLcAll.LANG).toBeUndefined();
+    expect(withLcAll.LC_ALL).toBe('en_GB.UTF-8');
+
+    const withCtype = resolveSpawnEnv({ LC_CTYPE: 'en_US.UTF-8' }, undefined, {}, 'ko_KR.UTF-8');
+    expect(withCtype.LANG).toBeUndefined();
+  });
+
+  it('does not touch locale when no fallback is provided (Windows / opt-out)', () => {
+    const env = resolveSpawnEnv({ PATH: '/usr/bin' }, undefined, {});
+    expect(env.LANG).toBeUndefined();
+  });
 });

--- a/src/main/pty/__tests__/shellLocale.test.ts
+++ b/src/main/pty/__tests__/shellLocale.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { intlToPosixRegion, pickUtf8Locale } from '../shellLocale';
+
+describe('intlToPosixRegion', () => {
+  it('converts BCP-47 language-region to POSIX form', () => {
+    expect(intlToPosixRegion('ko-KR')).toBe('ko_KR');
+    expect(intlToPosixRegion('en-US')).toBe('en_US');
+  });
+
+  it('handles a script subtag between language and region', () => {
+    expect(intlToPosixRegion('ko-Kore-KR')).toBe('ko_KR');
+    expect(intlToPosixRegion('zh-Hans-CN')).toBe('zh_CN');
+  });
+
+  it('returns undefined when there is no region subtag', () => {
+    expect(intlToPosixRegion('en')).toBeUndefined();
+    expect(intlToPosixRegion('')).toBeUndefined();
+  });
+});
+
+describe('pickUtf8Locale', () => {
+  const available = [
+    'C',
+    'C.UTF-8',
+    'POSIX',
+    'en_US.UTF-8',
+    'ko_KR',
+    'ko_KR.UTF-8',
+    'ja_JP.UTF-8',
+  ];
+
+  it('prefers the system region when it is installed', () => {
+    expect(pickUtf8Locale(available, 'ko_KR')).toBe('ko_KR.UTF-8');
+  });
+
+  it('falls back to en_US.UTF-8 when the preferred region is not installed', () => {
+    expect(pickUtf8Locale(available, 'fr_FR')).toBe('en_US.UTF-8');
+  });
+
+  it('falls back to en_US.UTF-8 when no region is known', () => {
+    expect(pickUtf8Locale(available, undefined)).toBe('en_US.UTF-8');
+  });
+
+  it('falls back to C.UTF-8 when en_US.UTF-8 is absent', () => {
+    expect(pickUtf8Locale(['C.UTF-8', 'de_DE.UTF-8'], 'fr_FR')).toBe('C.UTF-8');
+  });
+
+  it('picks any UTF-8 locale when neither en_US nor C are present', () => {
+    expect(pickUtf8Locale(['de_DE.UTF-8'], undefined)).toBe('de_DE.UTF-8');
+  });
+
+  it('ignores non-UTF-8 locales entirely', () => {
+    expect(pickUtf8Locale(['C', 'POSIX', 'ko_KR', 'ko_KR.eucKR'], 'ko_KR')).toBeUndefined();
+  });
+
+  it('matches the utf8 spelling variant case-insensitively', () => {
+    expect(pickUtf8Locale(['en_US.utf8'], undefined)).toBe('en_US.utf8');
+  });
+});

--- a/src/main/pty/resolveSpawnEnv.ts
+++ b/src/main/pty/resolveSpawnEnv.ts
@@ -29,6 +29,7 @@ export function resolveSpawnEnv(
   baseEnv: NodeJS.ProcessEnv,
   profileEnv: Record<string, string> | undefined,
   identity: Record<string, string>,
+  fallbackLocale?: string,
 ): Record<string, string> {
   const env = buildSafeChildEnv(baseEnv);
   // Capture the instance-isolation suffix from the SPAWNING process's own env
@@ -64,5 +65,12 @@ export function resolveSpawnEnv(
   // process.env (never a persisted blob), so a simple presence check is enough —
   // the daemon recovery path scrubs a stale blob suffix separately.
   if (typeof dataSuffix === 'string' && dataSuffix) env[ENV_KEYS.DATA_SUFFIX] = dataSuffix;
+  // 로케일 폴백 (issue #321): 셸이 UTF-8 로케일을 하나도 못 받으면 C/POSIX로 떨어져
+  // zsh ZLE가 한글·CJK 멀티바이트 입력을 조합하지 못하고 `<0085>` 식으로 깨진다.
+  // macOS를 Dock/Finder로 실행하면 `LANG`이 상속되지 않는 게 대표적 트리거. 사용자가
+  // 프로필/rc로 이미 로케일을 지정했으면(아래 셋 중 하나라도) 절대 덮어쓰지 않는다.
+  if (fallbackLocale && !env.LANG && !env.LC_ALL && !env.LC_CTYPE) {
+    env.LANG = fallbackLocale;
+  }
   return env;
 }

--- a/src/main/pty/shellLocale.ts
+++ b/src/main/pty/shellLocale.ts
@@ -1,0 +1,93 @@
+import { execFileSync } from 'node:child_process';
+
+/**
+ * 스폰되는 셸에 넣어줄 UTF-8 로케일을 결정한다.
+ *
+ * 왜 필요한가 (issue #321):
+ *   macOS에서 앱을 Dock/Finder로 실행하면 로그인 셸의 `LANG`이 상속되지 않는다.
+ *   그러면 자식 셸이 C/POSIX 로케일로 떨어지고, zsh ZLE(라인 에디터)가 멀티바이트
+ *   UTF-8 입력(한글·CJK)을 조합하지 못해 `<0085>` 같은 메타 표기로 깨져 보인다.
+ *   Windows 콘솔은 코드페이지/UTF-16 기반이라 `LANG` 개념이 없어 영향이 없다.
+ *
+ * 해결: 스폰 env에 `LANG`/`LC_ALL`/`LC_CTYPE`가 하나도 없을 때만, 시스템에 실제로
+ *   설치된 UTF-8 로케일을 폴백으로 주입한다. 사용자가 셸 rc나 워크스페이스 프로필로
+ *   직접 로케일을 지정한 경우는 건드리지 않는다(호출부에서 보장).
+ */
+
+/**
+ * `Intl`이 주는 BCP-47 로케일("ko-KR")을 POSIX 리전 형태("ko_KR")로 변환한다.
+ * 리전 서브태그가 없으면(예: "en") undefined를 반환해 리전 없는 추측을 피한다.
+ */
+export function intlToPosixRegion(bcp47: string): string | undefined {
+  // "ko-Kore-KR" 같은 스크립트 서브태그가 낄 수 있으니 언어와 2글자 리전만 취한다.
+  const parts = bcp47.split('-');
+  const lang = parts[0]?.toLowerCase();
+  const region = parts.find((p) => /^[A-Za-z]{2}$/.test(p) && p === p.toUpperCase());
+  if (!lang || !region) return undefined;
+  return `${lang}_${region}`;
+}
+
+/**
+ * 설치된 로케일 목록(`locale -a` 출력)에서 최선의 UTF-8 로케일을 고른다.
+ * 우선순위: 시스템 리전 → en_US.UTF-8 → C.UTF-8 → 임의의 UTF-8. 없으면 undefined.
+ *
+ * 순수 함수(입출력 없음)라 단위 테스트가 쉽다.
+ */
+export function pickUtf8Locale(available: string[], preferredRegion?: string): string | undefined {
+  // 대소문자 무시 조회용 맵(정규화 키 → 원본 문자열).
+  const utf8 = new Map<string, string>();
+  for (const raw of available) {
+    const name = raw.trim();
+    if (!name) continue;
+    const key = name.toLowerCase().replace('utf8', 'utf-8');
+    if (key.endsWith('.utf-8')) utf8.set(key, name);
+  }
+  const lookup = (candidate: string): string | undefined => {
+    const hit = utf8.get(candidate.toLowerCase().replace('utf8', 'utf-8'));
+    return hit;
+  };
+
+  if (preferredRegion) {
+    const hit = lookup(`${preferredRegion}.UTF-8`);
+    if (hit) return hit;
+  }
+  return lookup('en_US.UTF-8') ?? lookup('C.UTF-8') ?? utf8.values().next().value;
+}
+
+// 프로세스당 한 번만 계산(스폰마다 `locale -a`를 돌리지 않도록 메모이즈).
+let cached: string | undefined;
+let resolved = false;
+
+/**
+ * 이 머신에서 스폰 셸에 줄 UTF-8 로케일. Windows는 undefined(불필요).
+ * `locale` 바이너리가 없거나 실패하면 en_US.UTF-8을 최선의 기본값으로 반환한다
+ * (darwin/linux에 사실상 항상 존재).
+ */
+export function getShellUtf8Locale(): string | undefined {
+  if (resolved) return cached;
+  resolved = true;
+  if (process.platform === 'win32') {
+    cached = undefined;
+    return cached;
+  }
+  let preferredRegion: string | undefined;
+  try {
+    preferredRegion = intlToPosixRegion(Intl.DateTimeFormat().resolvedOptions().locale);
+  } catch {
+    preferredRegion = undefined;
+  }
+  try {
+    const out = execFileSync('locale', ['-a'], { encoding: 'utf8', timeout: 3000 });
+    cached = pickUtf8Locale(out.split('\n'), preferredRegion) ?? 'en_US.UTF-8';
+  } catch {
+    // `locale -a`를 못 돌리면 UTF-8 조합만 되면 되므로 보편적으로 존재하는 값으로.
+    cached = 'en_US.UTF-8';
+  }
+  return cached;
+}
+
+/** 테스트 전용: 메모이즈 캐시 초기화. */
+export function __resetShellLocaleCacheForTest(): void {
+  cached = undefined;
+  resolved = false;
+}


### PR DESCRIPTION
Fixes #321

## 증상
macOS에서 한글(멀티바이트/CJK)을 터미널에 입력하면 `<0085> <0087> <009d> …` 컨트롤 코드 박스로 깨져 보인다. Windows는 정상.

## 근본 원인 (확정)
Dock/Finder로 실행한 macOS 앱은 로그인 셸의 `LANG`을 상속하지 않아 스폰된 셸이 **C/POSIX 로케일**로 떨어진다. 그러면 zsh ZLE가 멀티바이트 UTF-8 입력을 조합하지 못하고 high byte를 `<XX>` 메타 표기로 출력한다. 깨지는 pane에서 확인:
```
$ echo "LANG=$LANG"; locale
LANG=""
LC_CTYPE="C"
```
Windows 콘솔은 코드페이지/UTF-16 기반이라 `LANG` 개념이 없어 영향이 없다 → "Windows는 되고 macOS만 깨짐"과 일치.

입력 파이프라인(`xterm.onData` → IPC → `sanitizePtyText` → `node-pty.write`)은 정상 유니코드를 보존함을 바이트 수학으로 검증했다. 결함은 로케일뿐.

## 수정
스폰 env에 `LANG`/`LC_ALL`/`LC_CTYPE`가 하나도 없을 때만 UTF-8 로케일 폴백을 주입한다.
- `src/main/pty/shellLocale.ts` (신규): 설치된 로케일(`locale -a`) 중 **시스템 리전 → en_US.UTF-8 → C.UTF-8** 순으로 선택, 프로세스당 1회 메모이즈. Windows는 undefined.
- `src/main/pty/resolveSpawnEnv.ts`: 폴백 파라미터 추가·주입 (로컬+데몬 스폰 공용 경로 한 곳).
- `PTYManager.ts`, `pty.handler.ts`: `getShellUtf8Locale()` 전달.

사용자가 셸 rc나 워크스페이스 프로필로 로케일을 지정한 경우는 **절대 덮어쓰지 않는다**.

## 테스트
- `shellLocale.test.ts` (신규): 리전 변환, 우선순위 선택, non-UTF-8 무시.
- `resolveSpawnEnv.test.ts`: 폴백 주입 / 기존 로케일 미덮어씀 / 미제공 시 무동작.
- 총 22개 통과, `tsc --noEmit` · eslint 통과.

## 검증
실제 macOS(ko_KR)에서 주입값 `LANG=ko_KR.UTF-8` 확인, 앱에서 한글 입력 정상 동작 확인 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shell sessions now prefer a UTF-8 locale when one is available, improving character handling in terminal environments.
  * Locale selection now falls back more gracefully across common UTF-8 options when a preferred locale is unavailable.
* **Bug Fixes**
  * Improved environment setup for spawned and recovered shell sessions so locale settings are applied more reliably.
  * Existing locale variables are preserved when already set, avoiding unintended overrides.
* **Tests**
  * Added coverage for locale conversion, locale selection, and environment fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->