### PR TITLE
feat: unattended supervisor + reboot-reattach RCA fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.0] — 2026-07-02 — Sessions survive a reboot
+
+Headline: panes that were mid-conversation before an OS reboot now come back exactly as they were — same session id, same scrollback, same permission mode — instead of resetting to a blank terminal. Alongside that, an opt-in unattended supervisor lets a trusted pane restart itself after a crash and, with explicit consent, resume without stalling at a permission prompt.
+
+### Added
+
+- **Unattended supervisor: opt-in crash restart + consent-gated permission restore.** A layout leaf can declare `unattended: true` in `wmux.json`, which restarts it on failure (a clean exit is treated as "task finished," not a crash to relaunch) and, only with a separate explicit consent given in the trust dialog, restores the permission mode it was running under before a restart. Fleet View surfaces each pane's supervision state — armed with a restart count, or a guard-tripped marker when the runaway guard stopped it.
+- **Daemon liveness moves to a three-state probe.** Replaces the old "probe failed → assume dead" pattern (the same anti-pattern behind earlier false-death and duplicate-daemon reports) with an explicit unknown/alive/dead classification, shared between the daemon and the launcher, so a slow OS probe can no longer make one daemon reclaim another live daemon's lock.
+
+### Fixed
+
+- **Terminal sessions survive an OS reboot instead of resetting.** Windows kills the daemon's PTY children before the daemon itself during a shutdown/reboot, and the daemon couldn't tell that apart from a user typing `exit` — it tombstoned the session as dead, and recovery skips dead sessions, purging exactly the ones that were in use. The daemon now recognizes the Windows shutdown-teardown exit code and suspends those sessions instead, so recovery replays them under the same id after reboot.
+- **session.json no longer loses the latest layout on shutdown.** The Windows session-end handler used to reload the on-disk snapshot and save it straight back, which never captured the renderer's newest layout. Session data is now persisted the instant a pane's terminal id changes (not just every 5 seconds), so a reboot can no longer land in the gap between a new pane and the next periodic save.
+- **A recovered session's scrollback replay no longer dismisses its own resume prompt.** Replaying a dead agent's buffered output could re-arm mouse tracking in the terminal, so simply moving the mouse toward the "resume" prompt looked like the user typing and silently dismissed it. Leaked input-reporting modes are now reset after a replay.
+- **Claude Code's permission mode is read reliably from long transcripts.** The extractor only recognized permission-mode stamps on user turns, which a large attachment record could push out of the read window; it now also recognizes the dedicated permission-mode record Claude Code writes near the end of every prompt.
+
 ## [3.11.1] — 2026-06-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ winget install openwong2kim.wmux
 | 🤝 **Agents coordinate, not just coexist** | Agent-to-agent messaging + task delegation. One agent hands a job to another, addressed by pane — and an **execute approval gate** stops any agent from running code in your workspace without your OK. This is the multi-agent moat. |
 | 🌐 **Agents drive a *real* browser** | Built-in Chrome over CDP. Say *"search Google for this"* and your agent actually clicks, types, and screenshots. Works with React inputs and CJK text. |
 | 🧭 **Fleet View cockpit** | `Ctrl+Shift+A` — every agent across every workspace on one screen, blocked ones floated to the top with a live activity line. Clear every stuck approval from one **inbox**; click any card to jump straight there. |
-| 🔔 **Knows when an agent finishes** | Desktop notification + taskbar flash on completion. Flags `rm -rf`, `git push --force`, `DROP TABLE` before they run. |
-| 💾 **Survives quit, crash & reboot** | A tmux-style daemon owns every PTY. Reopen and your sessions are **still running — processes and all.** A pane declared in `wmux.json` is **supervised like an init system** — auto-restarted across crashes and reboots, resuming the *exact* Claude conversation it was on. |
+| 🔔 **Knows when an agent finishes** | Desktop notification + taskbar flash on completion. Flags `rm -rf`, `git push --force`, `DROP TABLE` for your approval. |
+| 💾 **Survives quit, crash & reboot** | A tmux-style daemon owns every PTY. Reopen and your sessions are **still running — processes and all.** A pane declared in `wmux.json` is **supervised like an init system** — auto-restarted across crashes and reboots (the app relaunches at login), resuming the *exact* Claude conversation it was on. |
 | 🤖 **Zero-config MCP** | Launch wmux and Claude Code just works — browser + terminal tools register automatically. |
 
 ---
@@ -103,7 +103,7 @@ winget install openwong2kim.wmux
 
 **Plugins** — sandboxed iframe plugin host with a bridge + explicit permission model and pane decorations.
 
-**Daemon** — background session management (survives app restart), scrollback dump + auto-recovery, Windows startup registration (survives reboot), dead-session TTL reaping.
+**Daemon** — background session management (survives app restart), scrollback dump + auto-recovery, Windows startup registration (relaunches at login after reboot), dead-session TTL reaping.
 
 **MCP tools** — `browser_*` (open / navigate / screenshot / snapshot / click / fill / type / evaluate / press_key), `terminal_read` / `terminal_read_events` (OSC 133) / `terminal_send`, `workspace_list` / `surface_list` / `pane_list`, `a2a_*` agent-to-agent + task delegation, `company_a2a_*` coordination. Every browser tool takes a `surfaceId` so each session drives its own browser.
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -109,6 +109,14 @@
      vi.waitFor budget. Verified stable across 5 consecutive full-suite runs. -->
 
 ## Duplicate-daemon / split-brain on "Quit (keep sessions)" → relaunch (P1)
+> **STATUS 2026-07-01 — RESOLVED (pending live re-verify):** the launcher 3-defect chain SHIPPED in
+> v2.16.2 (PR #93: `checkProcessLiveness` 3-state, `tryEscalatedReping`, `classifyReclaimProbe` live-owner
+> fail-fast + exit 75). The residual daemon-side sibling — `src/daemon/index.ts` `isProcessRunning`
+> `catch → false` — is fixed on branch `feat/unattended-supervisor` (U-SPLIT: pure 3-state classifiers
+> extracted to `src/shared/processLiveness.ts`; a probe `unknown` no longer reclaims a live daemon's lock,
+> via `lockOwnerIsReclaimable`). Remaining: the dynamic autostart-triggered 2-instance race probe (live).
+> The stale "Defect 1 = `isProcessAlive catch→false`" detail below refers to the LAUNCHER site,
+> already superseded by v2.16.2.
 - **What:** "Quit (keep sessions running)" 후 `npm start` 재실행 시 둘째 데몬이 `wmux-daemon-rizz-1` 폴백 파이프로 기동 → 첫 데몬의 세션 파이프 EADDRINUSE → reattach 실패 → 새 세션 → 터미널 초기화. persistence가 깨짐 + 데몬 중복(RAM 낭비).
 - **Why:** (1) `ensureDaemon`이 살아있는 데몬에 재접속 안 하고 spawn. 유력 가설: 느린 OS probe(tasklist/WMI 타임아웃 머신)로 verify-ping 타임아웃→"데몬 없음" 오판 (false-death PR #87과 같은 근원 패턴). (2) `DaemonPipeServer.start()`(`src/daemon/DaemonPipeServer.ts:108-145`)의 `-N` 폴백이 *크래시 zombie*용인데 *살아있는 owner*와 구분 못 해 split-brain 허용.
 - **Pros:** 영속성(핵심 기능) 정상화 + 중복 데몬 제거.
@@ -148,6 +156,10 @@
 - **Priority:** P2 (renderer symptom resolved; transport-layer option deferred)
 
 ## Cross-platform liveness/probe 신뢰성 일반화 (P3, follow-up of PR #87)
+> **STATUS 2026-07-01:** the one confirmed BAD site (`isProcessAlive` / `isProcessRunning`
+> `catch → false`) is now closed on BOTH processes — launcher via v2.16.2 (`checkProcessLiveness`),
+> daemon via U-SPLIT (`feat/unattended-supervisor`, shared `processLiveness`). A broader sweep for any
+> other latent sites is still open.
 - **What:** Windows OS probe(tasklist/WMI)가 타임아웃하는 머신에서 "probe 실패=부재/죽음" 오해 패턴을 코드 전반에서 제거. PR #87이 ProcessMonitor kill 게이트는 고침. 같은 안티패턴이 남아있는지 audit(특히 데몬 verify, launcher PID 체크 — split-brain와 연결).
 - **Why:** 동일 근원 버그(느린 probe→오판)가 여러 곳에 잠복. 원칙: probe 실패는 "unknown"이지 "absent/dead"가 아님.
 - **Pros:** 느린/부하 머신에서 전반적 안정성.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.11.1 sources.** This file is produced by
+> **Generated from wmux v3.12.0 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/integrations/claude/__tests__/bridgePermissionMode.test.ts
+++ b/integrations/claude/__tests__/bridgePermissionMode.test.ts
@@ -1,0 +1,110 @@
+/**
+ * X6 ③ / U-PERM — permission-mode capture from the transcript tail.
+ *
+ * Incident (2026-07-02, U-PERM dogfood): a bypassPermissions session's resume
+ * binding persisted with NO permissionMode, so the resume pill could not
+ * re-offer bypass after the reboot. Two compounding causes:
+ *   1. Inline `"permissionMode"` stamps ride USER turns only, and a single
+ *      large attachment record (85KB observed) pushed the last stamped user
+ *      turn out of the extractor's bounded 64KB tail read.
+ *   2. Current Claude Code also writes a dedicated
+ *      `{"type":"permission-mode","permissionMode":"..."}` record within a few
+ *      KB of the tail on every prompt — but the extractor only recognized
+ *      `type:"user"`, so it walked right past it.
+ * The fix teaches the extractor the dedicated record. These tests run the REAL
+ * bridge function: the CLI entrypoint is stripped (main() runs at module top
+ * level and would read stdin) and the extractor re-exported from a temp copy.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const BRIDGE_PATH = path.resolve(process.cwd(), 'integrations/claude/bin/wmux-bridge.mjs');
+const ENTRYPOINT_MARKER = '// Run; never throw upward';
+
+let tmp: string;
+let extract: (transcriptPath: string) => string | null;
+
+function fixture(name: string, lines: unknown[]): string {
+  const p = path.join(tmp, name);
+  writeFileSync(p, lines.map((l) => JSON.stringify(l)).join('\n') + '\n', 'utf8');
+  return p;
+}
+
+beforeAll(async () => {
+  tmp = mkdtempSync(path.join(tmpdir(), 'wmux-bridge-pm-'));
+  const src = readFileSync(BRIDGE_PATH, 'utf8');
+  const cut = src.indexOf(ENTRYPOINT_MARKER);
+  expect(cut).toBeGreaterThan(-1);
+  // Strip the shebang — vite's transform (which intercepts even runtime
+  // dynamic imports under vitest) rejects it with a SyntaxError on Windows.
+  const testable = src.slice(0, cut).replace(/^#![^\n]*\n/, '')
+    + '\nexport { extractPermissionModeFromTranscript };\n';
+  const mod = path.join(tmp, 'bridge-under-test.mjs');
+  writeFileSync(mod, testable, 'utf8');
+  ({ extractPermissionModeFromTranscript: extract } = await import(pathToFileURL(mod).href));
+});
+
+afterAll(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('extractPermissionModeFromTranscript', () => {
+  it('reads the dedicated permission-mode record (current Claude Code format)', () => {
+    const p = fixture('dedicated.jsonl', [
+      { type: 'mode', mode: 'normal', sessionId: 's1' },
+      { type: 'permission-mode', permissionMode: 'bypassPermissions', sessionId: 's1' },
+      { type: 'assistant', message: { usage: { input_tokens: 1 } } },
+    ]);
+    expect(extract(p)).toBe('bypassPermissions');
+  });
+
+  it('still reads the inline user-turn stamp (older format, back-compat)', () => {
+    const p = fixture('inline.jsonl', [
+      { type: 'user', permissionMode: 'acceptEdits', message: {} },
+      { type: 'assistant', message: {} },
+    ]);
+    expect(extract(p)).toBe('acceptEdits');
+  });
+
+  it('most recent record wins across both shapes (mode changes mid-session)', () => {
+    const p = fixture('both.jsonl', [
+      { type: 'user', permissionMode: 'bypassPermissions', message: {} },
+      { type: 'assistant', message: {} },
+      { type: 'permission-mode', permissionMode: 'plan', sessionId: 's1' },
+    ]);
+    expect(extract(p)).toBe('plan');
+  });
+
+  it('incident shape: dedicated tail record survives a huge attachment that evicts the user stamp from the 64KB window', () => {
+    // Mirrors the real 2026-07-02 transcript: stamped user turn at the file
+    // start, an attachment record far larger than the tail window, then the
+    // per-prompt metadata block (incl. the dedicated record) at the tail.
+    const p = fixture('incident.jsonl', [
+      { type: 'user', permissionMode: 'bypassPermissions', message: {} },
+      { type: 'attachment', data: 'x'.repeat(80 * 1024) },
+      { type: 'last-prompt', lastPrompt: 'hi', sessionId: 's1' },
+      { type: 'permission-mode', permissionMode: 'bypassPermissions', sessionId: 's1' },
+      { type: 'assistant', message: {} },
+    ]);
+    expect(extract(p)).toBe('bypassPermissions');
+  });
+
+  it('ignores unknown mode values and keeps walking to an older valid record', () => {
+    const p = fixture('unknown.jsonl', [
+      { type: 'permission-mode', permissionMode: 'default', sessionId: 's1' },
+      { type: 'permission-mode', permissionMode: 'someFutureMode', sessionId: 's1' },
+    ]);
+    expect(extract(p)).toBe('default');
+  });
+
+  it('returns null when no recognizable record exists', () => {
+    const p = fixture('none.jsonl', [
+      { type: 'assistant', message: {} },
+      { type: 'system', content: 'x' },
+    ]);
+    expect(extract(p)).toBeNull();
+  });
+});

--- a/integrations/claude/bin/wmux-bridge.mjs
+++ b/integrations/claude/bin/wmux-bridge.mjs
@@ -226,11 +226,22 @@ function extractUsageFromTranscript(transcriptPath) {
 }
 
 // X6 ③: the permission mode the session is CURRENTLY in, read from the
-// transcript. Claude Code stamps `"permissionMode"` on every USER turn
-// (F5, verified live 2026-06-14). Walk lines from the END for the most
-// recent user turn — that's the live mode. Mirrors extractUsageFromTranscript's
-// parse-tolerant tail read (last 64KB). Returns one of the four known modes,
-// or null (file absent, no user turn yet, or an unrecognized value).
+// transcript. Two record shapes carry it (walk lines from the END; the most
+// recent of either wins — that's the live mode):
+//  - `{"type":"permission-mode","permissionMode":"..."}` — dedicated record,
+//    written near the transcript tail with each prompt's metadata block
+//    (observed live 2026-07-02; format the current Claude Code emits).
+//  - `{"type":"user",...,"permissionMode":"..."}` — inline stamp on user turns
+//    (F5, verified live 2026-06-14; older format, kept for back-compat).
+// Recognizing the dedicated record matters: user-turn stamps are sparse, and a
+// single large attachment/tool record can push the last stamped user turn out
+// of the 64KB tail window — the exact miss that left a bypassPermissions
+// session's binding without a mode in the 2026-07-02 incident (U-PERM dogfood:
+// resume pill could not re-offer bypass). The dedicated record sits within a
+// few KB of the tail, so it survives the bounded read.
+// Mirrors extractUsageFromTranscript's parse-tolerant tail read (last 64KB).
+// Returns one of the four known modes, or null (file absent, no record yet, or
+// an unrecognized value).
 const VALID_PERMISSION_MODES = new Set(['bypassPermissions', 'acceptEdits', 'plan', 'default']);
 function extractPermissionModeFromTranscript(transcriptPath) {
   try {
@@ -258,7 +269,8 @@ function extractPermissionModeFromTranscript(transcriptPath) {
       } catch {
         continue;
       }
-      if (entry && entry.type === 'user' && typeof entry.permissionMode === 'string'
+      if (entry && (entry.type === 'user' || entry.type === 'permission-mode')
+          && typeof entry.permissionMode === 'string'
           && VALID_PERMISSION_MODES.has(entry.permissionMode)) {
         return entry.permissionMode;
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.11.1",
+  "version": "3.12.0",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",

--- a/scripts/shutdown-kill-suspend-probe.mjs
+++ b/scripts/shutdown-kill-suspend-probe.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * Shutdown-kill suspend probe — reboot-reattach RCA fix (2026-07-02),
+ * end-to-end through the REAL bundled daemon.
+ *
+ * Incident: during an OS reboot Windows killed the daemon's PTY children
+ * (exitCode 0x40010004 = DBG_TERMINATE_PROCESS) BEFORE the daemon itself.
+ * The daemon observed each pty-exit, marked the session 'dead', persisted the
+ * tombstone — and post-reboot recovery purged exactly the sessions the user
+ * was working in, while unobserved ghosts survived. Renderer reconcile then
+ * found neither ptyId nor surfaceId → self-create → "terminal reset".
+ *
+ * The fix classifies 0x40010004 exits as involuntary → suspend (buffer dump +
+ * persisted 'suspended') → recovery replays the SAME id.
+ *
+ * PASS criteria:
+ *   P1  session exiting 0x40010004 → state 'suspended' (NOT dead), persisted
+ *   P2  control session exiting a normal code → state 'dead' (fix doesn't
+ *       over-suspend voluntary exits)
+ *   P3  daemon force-killed within the reclassify window (= OS kills daemon),
+ *       respawned daemon RECOVERS the suspended session under the SAME id
+ *   P4  the dead control session is NOT resurrected
+ *   P5  reclassification: a 0x40010004 exit with the daemon left ALIVE past
+ *       the 15s window flips to 'dead' (cancelled-shutdown false positive)
+ */
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DAEMON_BUNDLE = path.join(REPO_ROOT, 'dist', 'daemon-bundle', 'index.js');
+const SHUTDOWN_CODE = 1073807364; // 0x40010004 — must match shutdownKill.ts
+
+function makePipeName(tag) {
+  return process.platform === 'win32'
+    ? `\\\\.\\pipe\\wmux-test-${tag}`
+    : path.join(os.tmpdir(), `wmux-test-${tag}.sock`);
+}
+
+function writeConfig(wmuxDir, pipeName, authToken) {
+  fs.writeFileSync(
+    path.join(wmuxDir, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      daemon: { pipeName, logLevel: 'info', autoStart: true },
+      session: {
+        defaultShell: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
+        defaultCols: 80, defaultRows: 24, bufferSizeMb: 8, bufferMaxMb: 64,
+        deadSessionTtlHours: 24, deadSessionDumpBuffer: true,
+      },
+    }, null, 2),
+  );
+  fs.writeFileSync(path.join(wmuxDir, 'daemon-auth-token'), authToken, 'utf-8');
+}
+
+function spawnDaemon(testHome, logChunks) {
+  const d = spawn(process.execPath, [DAEMON_BUNDLE], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, USERPROFILE: testHome, HOME: testHome, HOMEDRIVE: undefined, HOMEPATH: undefined },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  d.stdout.on('data', (c) => logChunks && logChunks.push(c.toString()));
+  d.stderr.on('data', (c) => logChunks && logChunks.push(c.toString()));
+  return d;
+}
+
+async function waitForPipeFile(wmuxDir, timeoutMs = 15_000) {
+  const pipeFile = path.join(wmuxDir, 'daemon-pipe');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(pipeFile)) return fs.readFileSync(pipeFile, 'utf-8').trim();
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error('daemon-pipe did not appear within timeout');
+}
+
+function connectSocket(pipeName) {
+  return new Promise((resolve, reject) => {
+    const s = net.createConnection(pipeName, () => resolve(s));
+    s.on('error', reject);
+  });
+}
+
+function rpc(socket, method, params, authToken, timeoutMs = 30_000) {
+  return new Promise((resolve, reject) => {
+    const id = `req-${Math.random().toString(36).slice(2, 10)}`;
+    let buffer = '';
+    const handler = (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id === id) {
+            socket.removeListener('data', handler);
+            if (msg.ok) resolve(msg.result);
+            else reject(new Error(msg.error ?? 'rpc error'));
+            return;
+          }
+        } catch { /* ignore */ }
+      }
+    };
+    socket.on('data', handler);
+    socket.write(JSON.stringify({ id, method, params, token: authToken }) + '\n');
+    setTimeout(() => { socket.removeListener('data', handler); reject(new Error(`rpc timeout: ${method}`)); }, timeoutMs);
+  });
+}
+
+async function waitForState(sock, authToken, id, want, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let last = '(absent)';
+  while (Date.now() < deadline) {
+    const sessions = await rpc(sock, 'daemon.listSessions', {}, authToken);
+    const s = sessions.find((x) => x.id === id);
+    last = s ? s.state : '(absent)';
+    if (last === want) return true;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  console.error(`   waitForState(${id} → ${want}) timed out; last state = ${last}`);
+  return false;
+}
+
+async function main() {
+  if (!fs.existsSync(DAEMON_BUNDLE)) {
+    console.error(`Daemon bundle missing: ${DAEMON_BUNDLE}\nRun: npm run build:daemon`);
+    process.exit(2);
+  }
+
+  const tag = `shutkill-${randomUUID().slice(0, 8)}`;
+  const testHome = path.join(os.tmpdir(), `wmux-${tag}`);
+  const wmuxDir = path.join(testHome, '.wmux');
+  fs.mkdirSync(wmuxDir, { recursive: true });
+
+  const pipeName = makePipeName(tag);
+  const authToken = randomUUID();
+  writeConfig(wmuxDir, pipeName, authToken);
+
+  const shell = process.platform === 'win32'
+    ? path.join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'cmd.exe')
+    : '/bin/sh';
+  // exec unit = the command IS the pane process; its exit code IS the pty exit
+  // code (cmd /d /s /c propagates natively). ~4s alive, then the target exit.
+  const delayThenExit = (code) => process.platform === 'win32'
+    ? `ping -n 5 127.0.0.1 >nul & exit ${code}`
+    : `sleep 4; exit ${code}`;
+
+  const results = [];
+  const check = (name, ok, detail) => {
+    results.push({ name, ok });
+    console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+  };
+
+  // --- Daemon #1: shutdown-kill exit vs voluntary exit ---
+  console.log('phase 1: classify shutdown-kill vs voluntary exit');
+  const d1Log = [];
+  const d1 = spawnDaemon(testHome, d1Log);
+  let resolved = await waitForPipeFile(wmuxDir);
+  let sock = await connectSocket(resolved);
+
+  await rpc(sock, 'daemon.createSession', {
+    id: 'sess-shutkill', cmd: shell, cwd: testHome, cols: 80, rows: 24,
+    exec: { command: delayThenExit(SHUTDOWN_CODE) },
+  }, authToken);
+  await rpc(sock, 'daemon.createSession', {
+    id: 'sess-voluntary', cmd: shell, cwd: testHome, cols: 80, rows: 24,
+    exec: { command: delayThenExit(42) },
+  }, authToken);
+
+  const p1 = await waitForState(sock, authToken, 'sess-shutkill', 'suspended', 15_000);
+  check('P1 0x40010004 exit → suspended (not dead)', p1);
+  const p2 = await waitForState(sock, authToken, 'sess-voluntary', 'dead', 15_000);
+  check('P2 voluntary exit 42 → dead (no over-suspend)', p2);
+
+  // Give the interrupted handler's dump+saveImmediate a beat to land, then
+  // simulate the OS killing the daemon BEFORE the 15s reclassify window.
+  await new Promise((r) => setTimeout(r, 1_500));
+  sock.destroy();
+  d1.kill('SIGKILL');
+  await new Promise((r) => { d1.on('exit', r); setTimeout(r, 3_000); });
+
+  const persisted = JSON.parse(fs.readFileSync(path.join(wmuxDir, 'sessions.json'), 'utf-8'));
+  const persistedShut = persisted.sessions.find((s) => s.id === 'sess-shutkill');
+  check('P1b persisted state is suspended (recovery payload)', persistedShut?.state === 'suspended',
+    `state=${persistedShut?.state ?? '(absent)'}`);
+
+  // --- Daemon #2: "post-reboot" recovery must replay the suspended session ---
+  console.log('phase 2: respawn daemon → recovery');
+  // SIGKILL leaves a stale daemon-pipe file — remove it so waitForPipeFile
+  // resolves the NEW daemon's pipe, not the corpse's.
+  try { fs.unlinkSync(path.join(wmuxDir, 'daemon-pipe')); } catch { /* absent */ }
+  const d2Log = [];
+  const d2 = spawnDaemon(testHome, d2Log);
+  resolved = await waitForPipeFile(wmuxDir);
+  sock = await connectSocket(resolved);
+
+  // Assert quickly — the replayed exec unit re-runs its command and will exit
+  // again in ~4s; we only need to see it come back LIVE under the same id.
+  const sessions2 = await rpc(sock, 'daemon.listSessions', {}, authToken);
+  const recovered = sessions2.find((s) => s.id === 'sess-shutkill');
+  check('P3 suspended session recovered under SAME id',
+    !!recovered && (recovered.state === 'attached' || recovered.state === 'detached'),
+    `state=${recovered?.state ?? '(absent)'}`);
+  const zombie = sessions2.find((s) => s.id === 'sess-voluntary');
+  check('P4 dead control session NOT resurrected',
+    !zombie || zombie.state === 'dead',
+    `state=${zombie?.state ?? '(absent)'}`);
+
+  // --- Phase 3: reclassification when the daemon SURVIVES the window ---
+  console.log('phase 3: cancelled-shutdown false positive → reclassify to dead (waits ~20s)');
+  await rpc(sock, 'daemon.createSession', {
+    id: 'sess-reclass', cmd: shell, cwd: testHome, cols: 80, rows: 24,
+    exec: { command: delayThenExit(SHUTDOWN_CODE) },
+  }, authToken);
+  const p5a = await waitForState(sock, authToken, 'sess-reclass', 'suspended', 15_000);
+  const p5b = p5a && await waitForState(sock, authToken, 'sess-reclass', 'dead', 25_000);
+  check('P5 daemon survives window → reclassified dead', p5a && p5b);
+
+  await rpc(sock, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
+  sock.destroy();
+  await new Promise((r) => { d2.on('exit', r); setTimeout(r, 5_000); });
+
+  const daemonLogs = d1Log.join('') + d2Log.join('');
+  const interruptLogged = daemonLogs.includes('session:interrupted id=sess-shutkill');
+  check('LOG session:interrupted line present', interruptLogged);
+
+  // Cleanup
+  try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* locked logs on win */ }
+
+  const failed = results.filter((r) => !r.ok);
+  console.log(`\n${failed.length === 0 ? 'ALL PASS' : `${failed.length} FAILED`} (${results.length} checks)`);
+  if (failed.length > 0) {
+    console.log('\n--- daemon log tail ---');
+    console.log(daemonLogs.split('\n').slice(-60).join('\n'));
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('probe crashed:', err);
+  process.exit(1);
+});

--- a/scripts/shutdown-kill-suspend-probe.mjs
+++ b/scripts/shutdown-kill-suspend-probe.mjs
@@ -22,6 +22,12 @@
  *   P4  the dead control session is NOT resurrected
  *   P5  reclassification: a 0x40010004 exit with the daemon left ALIVE past
  *       the 15s window flips to 'dead' (cancelled-shutdown false positive)
+ *   P6  adversarial-review finding: a client reconnect attempt against a
+ *       'suspended' session (renderer retry during the misclassification
+ *       window, before it knows the pty died) must reject gracefully — NOT
+ *       wire a fresh SessionPipe into the destroyed ptyProcess and crash the
+ *       daemon. Asserted by attaching, then confirming the daemon is still
+ *       alive and answering RPCs afterward.
  */
 import { spawn } from 'node:child_process';
 import net from 'node:net';
@@ -176,6 +182,24 @@ async function main() {
   check('P1 0x40010004 exit → suspended (not dead)', p1);
   const p2 = await waitForState(sock, authToken, 'sess-voluntary', 'dead', 15_000);
   check('P2 voluntary exit 42 → dead (no over-suspend)', p2);
+
+  // P6 — reconnect attempt against the suspended session must reject, not
+  // wire a pipe into the destroyed ptyProcess and crash the daemon.
+  let p6AttachRejected = false;
+  let p6AttachErr = '';
+  try {
+    await rpc(sock, 'daemon.attachSession', { id: 'sess-shutkill' }, authToken, 5_000);
+  } catch (err) {
+    p6AttachRejected = true;
+    p6AttachErr = err.message ?? String(err);
+  }
+  check('P6a attachSession on suspended session rejects', p6AttachRejected, p6AttachErr);
+  let p6DaemonAlive = false;
+  try {
+    await rpc(sock, 'daemon.listSessions', {}, authToken, 5_000);
+    p6DaemonAlive = true;
+  } catch { /* daemon crashed or hung */ }
+  check('P6b daemon still alive/responsive after rejected attach', p6DaemonAlive);
 
   // Give the interrupted handler's dump+saveImmediate a beat to land, then
   // simulate the OS killing the daemon BEFORE the 15s reclassify window.

--- a/scripts/u-perm-restore-probe.mjs
+++ b/scripts/u-perm-restore-probe.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+/**
+ * U-PERM dynamic probe — consent-gated unattended permission-mode restore on
+ * RECOVERY, end-to-end through the REAL bundled daemon.
+ *
+ * This is the check jsdom/unit tests structurally cannot do: it drives the full
+ * create-RPC -> persist(sessions.json) -> reboot(respawn) -> recoverSessions ->
+ * resumeLaunchCommand -> spawn chain, catching any runtime field-drop of
+ * `supervision.restorePermissionMode` that tsc can't see (the field is optional
+ * on every hop, so a field-by-field copy silently omits it). Three such drops
+ * existed and were fixed (pty.handler resolveSupervisionPolicy, daemon RPC
+ * createSession handler, DaemonSessionManager meta copy).
+ *
+ * Two supervised `claude` units (a recording shim, NOT the real CLI) recover:
+ *   POS: supervision.restorePermissionMode = true  + a bypassPermissions binding
+ *   NEG: supervision.restorePermissionMode = false + a bypassPermissions binding
+ *
+ * PASS criteria:
+ *   P1  POS recovery replay = `claude --resume <id> --dangerously-skip-permissions`
+ *   P2  NEG recovery replay = `claude --resume <id>` with NO bypass flag (gate off)
+ *   P3  daemon logs "permission-mode restore ON" exactly once (the POS unit)
+ */
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DAEMON_BUNDLE = path.join(REPO_ROOT, 'dist', 'daemon-bundle', 'index.js');
+
+function makePipeName(tag) {
+  return process.platform === 'win32'
+    ? `\\\\.\\pipe\\wmux-test-${tag}`
+    : path.join(os.tmpdir(), `wmux-test-${tag}.sock`);
+}
+
+function writeConfig(wmuxDir, pipeName, authToken) {
+  fs.writeFileSync(
+    path.join(wmuxDir, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      daemon: { pipeName, logLevel: 'info', autoStart: true },
+      session: {
+        defaultShell: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
+        defaultCols: 80, defaultRows: 24, bufferSizeMb: 8, bufferMaxMb: 64,
+        deadSessionTtlHours: 24, deadSessionDumpBuffer: true,
+      },
+    }, null, 2),
+  );
+  fs.writeFileSync(path.join(wmuxDir, 'daemon-auth-token'), authToken, 'utf-8');
+}
+
+function spawnDaemon(testHome, stderrChunks) {
+  const d = spawn(process.execPath, [DAEMON_BUNDLE], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, USERPROFILE: testHome, HOME: testHome, HOMEDRIVE: undefined, HOMEPATH: undefined },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  d.stdout.on('data', (c) => stderrChunks && stderrChunks.push(c.toString()));
+  d.stderr.on('data', (c) => stderrChunks && stderrChunks.push(c.toString()));
+  return d;
+}
+
+async function waitForPipeFile(wmuxDir, timeoutMs = 10_000) {
+  const pipeFile = path.join(wmuxDir, 'daemon-pipe');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(pipeFile)) return fs.readFileSync(pipeFile, 'utf-8').trim();
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error('daemon-pipe did not appear within timeout');
+}
+
+function connectSocket(pipeName) {
+  return new Promise((resolve, reject) => {
+    const s = net.createConnection(pipeName, () => resolve(s));
+    s.on('error', reject);
+  });
+}
+
+function rpc(socket, method, params, authToken, timeoutMs = 30_000) {
+  return new Promise((resolve, reject) => {
+    const id = `req-${Math.random().toString(36).slice(2, 10)}`;
+    let buffer = '';
+    const handler = (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id === id) {
+            socket.removeListener('data', handler);
+            if (msg.ok) resolve(msg.result);
+            else reject(new Error(msg.error ?? 'rpc error'));
+            return;
+          }
+        } catch { /* ignore */ }
+      }
+    };
+    socket.on('data', handler);
+    socket.write(JSON.stringify({ id, method, params, token: authToken }) + '\n');
+    setTimeout(() => { socket.removeListener('data', handler); reject(new Error(`rpc timeout: ${method}`)); }, timeoutMs);
+  });
+}
+
+function readShimLog(logPath) {
+  if (!fs.existsSync(logPath)) return [];
+  return fs.readFileSync(logPath, 'utf-8').split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+
+async function main() {
+  if (!fs.existsSync(DAEMON_BUNDLE)) {
+    console.error(`Daemon bundle missing: ${DAEMON_BUNDLE}\nRun: npm run build:daemon`);
+    process.exit(2);
+  }
+
+  const tag = `uperm-${randomUUID().slice(0, 8)}`;
+  const testHome = path.join(os.tmpdir(), `wmux-${tag}`);
+  const wmuxDir = path.join(testHome, '.wmux');
+  const shimDir = path.join(testHome, 'shim');
+  const projPos = path.join(testHome, 'proj-pos');
+  const projNeg = path.join(testHome, 'proj-neg');
+  for (const d of [wmuxDir, shimDir, projPos, projNeg]) fs.mkdirSync(d, { recursive: true });
+
+  // `claude` shim: record argv+cwd, then stay alive so the unit is LIVE at
+  // shutdown (-> suspended -> recovered).
+  const shimLog = path.join(testHome, 'shim.log');
+  fs.writeFileSync(path.join(shimDir, 'claude-shim.mjs'),
+    `import fs from 'node:fs';\n` +
+    `fs.appendFileSync(process.env.UPERM_SHIM_LOG, JSON.stringify({argv: process.argv.slice(2), cwd: process.cwd(), ts: Date.now()})+'\\n');\n` +
+    `setInterval(() => {}, 1 << 30);\n`);
+  if (process.platform === 'win32') {
+    fs.writeFileSync(path.join(shimDir, 'claude.cmd'), `@echo off\r\nnode "%~dp0claude-shim.mjs" %*\r\n`);
+  } else {
+    const sh = path.join(shimDir, 'claude');
+    fs.writeFileSync(sh, `#!/bin/sh\nnode "$(dirname "$0")/claude-shim.mjs" "$@"\n`);
+    fs.chmodSync(sh, 0o755);
+  }
+
+  // Real transcript files so bindingTranscriptLives (D5 existence probe) passes
+  // and the EXACT-session --resume path fires (that's the branch that appends
+  // the permission flag).
+  const transcriptPos = path.join(testHome, 'conv-pos.jsonl');
+  const transcriptNeg = path.join(testHome, 'conv-neg.jsonl');
+  fs.writeFileSync(transcriptPos, '{"type":"user"}\n');
+  fs.writeFileSync(transcriptNeg, '{"type":"user"}\n');
+
+  const pipeName = makePipeName(tag);
+  const authToken = randomUUID();
+  writeConfig(wmuxDir, pipeName, authToken);
+
+  const childEnv = {
+    ...process.env,
+    PATH: shimDir + path.delimiter + (process.env.PATH ?? ''),
+    Path: shimDir + path.delimiter + (process.env.Path ?? process.env.PATH ?? ''),
+    UPERM_SHIM_LOG: shimLog,
+  };
+  const shell = process.platform === 'win32' ? 'cmd.exe' : '/bin/sh';
+  const limit = { burst: 5, healthyUptimeSec: 300 };
+
+  // --- Daemon #1: create both supervised units + their resume bindings ---
+  const d1 = spawnDaemon(testHome, null);
+  let resolved = await waitForPipeFile(wmuxDir);
+  let sock = await connectSocket(resolved);
+
+  await rpc(sock, 'daemon.createSession', {
+    id: 'sess-pos', cmd: shell, cwd: projPos, env: childEnv, cols: 80, rows: 24,
+    exec: { command: 'claude' },
+    supervision: { restart: 'on-failure', limit, restorePermissionMode: true },
+  }, authToken);
+  await rpc(sock, 'daemon.setResumeBinding', {
+    id: 'sess-pos',
+    resumeBinding: { agent: 'claude', sessionId: 'conv-pos', cwd: projPos, permissionMode: 'bypassPermissions', transcriptPath: transcriptPos, ts: Date.now() },
+  }, authToken);
+
+  await rpc(sock, 'daemon.createSession', {
+    id: 'sess-neg', cmd: shell, cwd: projNeg, env: childEnv, cols: 80, rows: 24,
+    exec: { command: 'claude' },
+    supervision: { restart: 'on-failure', limit, restorePermissionMode: false },
+  }, authToken);
+  await rpc(sock, 'daemon.setResumeBinding', {
+    id: 'sess-neg',
+    resumeBinding: { agent: 'claude', sessionId: 'conv-neg', cwd: projNeg, permissionMode: 'bypassPermissions', transcriptPath: transcriptNeg, ts: Date.now() },
+  }, authToken);
+
+  await new Promise((r) => setTimeout(r, 2000)); // fresh launches record
+  await rpc(sock, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
+  sock.destroy();
+  await new Promise((r) => { d1.on('exit', r); setTimeout(r, 5000); });
+
+  const afterFresh = readShimLog(shimLog);
+
+  // --- Daemon #2: respawn -> recoverSessions replays both units ---
+  const d2Log = [];
+  const d2 = spawnDaemon(testHome, d2Log);
+  resolved = await waitForPipeFile(wmuxDir);
+  sock = await connectSocket(resolved);
+  await new Promise((r) => setTimeout(r, 3000)); // recovery replays + shims record
+  await rpc(sock, 'daemon.shutdown', {}, authToken, 10_000).catch(() => {});
+  sock.destroy();
+  await new Promise((r) => { d2.on('exit', r); setTimeout(r, 5000); });
+
+  const afterRecovery = readShimLog(shimLog);
+  const recoveryLaunches = afterRecovery.slice(afterFresh.length);
+  const daemonLog = d2Log.join('');
+
+  const posLaunch = recoveryLaunches.find((e) => e.argv.includes('conv-pos'));
+  const negLaunch = recoveryLaunches.find((e) => e.argv.includes('conv-neg'));
+
+  const results = [];
+  const P1 = !!posLaunch
+    && posLaunch.argv.includes('--resume')
+    && posLaunch.argv.includes('conv-pos')
+    && posLaunch.argv.includes('--dangerously-skip-permissions');
+  results.push(['P1 POS (consent ON) recovery = --resume <id> --dangerously-skip-permissions', P1, JSON.stringify(posLaunch?.argv ?? null)]);
+
+  const P2 = !!negLaunch
+    && negLaunch.argv.includes('--resume')
+    && negLaunch.argv.includes('conv-neg')
+    && !negLaunch.argv.includes('--dangerously-skip-permissions');
+  results.push(['P2 NEG (consent OFF) recovery = --resume <id> with NO bypass flag', P2, JSON.stringify(negLaunch?.argv ?? null)]);
+
+  const restoreOnCount = (daemonLog.match(/permission-mode restore ON/g) ?? []).length;
+  const P3 = restoreOnCount === 1;
+  results.push(['P3 daemon logged "restore ON" exactly once (POS only)', P3, `count=${restoreOnCount}`]);
+
+  try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* ignore */ }
+
+  console.log('\n=== U-PERM PERMISSION-RESTORE PROBE ===');
+  for (const [name, pass, detail] of results) {
+    console.log(`  ${pass ? 'PASS' : 'FAIL'}  ${name}\n        [${detail}]`);
+  }
+  const allPass = results.every(([, p]) => p);
+  console.log(`\n${allPass ? 'ALL PASS' : 'FAILURES PRESENT'}\n`);
+  process.exit(allPass ? 0 : 1);
+}
+
+main().catch((err) => { console.error('probe error:', err); process.exit(2); });

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -93,11 +93,28 @@ const DEFERRED_UNMUTE_DELAY_MS = 100;
  *  - 'session:created'      → { session: DaemonSession }
  *  - 'session:destroyed'    → { id: string }
  *  - 'session:died'         → { id: string, exitCode: number | null }
+ *  - 'session:interrupted'  → { id, exitCode, signal, cmd, lastActivityMsAgo }
+ *      A PTY exit classified as involuntary (OS shutdown killing children —
+ *      see shutdownKill.ts). The session is SUSPENDED, not dead: daemon/index
+ *      dumps the buffer + persists so post-reboot recovery replays the same id.
  *  - 'session:stateChanged' → { id: string, state: DaemonSessionState }
  */
 export class DaemonSessionManager extends EventEmitter {
   private sessions = new Map<string, ManagedSession>();
   private config: DaemonConfig | null = null;
+
+  /**
+   * Injected by daemon/index.ts (keeps this class free of platform/shutdown
+   * knowledge). Returns true when a PTY exit is an involuntary teardown
+   * (system shutdown) → suspend for recovery instead of marking dead.
+   * Default: never — behavior identical to pre-fix unless wired.
+   */
+  private involuntaryExitClassifier: (exitCode: number | null, signal?: number) => boolean =
+    () => false;
+
+  setInvoluntaryExitClassifier(fn: (exitCode: number | null, signal?: number) => boolean): void {
+    this.involuntaryExitClassifier = fn;
+  }
 
   /** Optionally set config so that session.bufferSizeMb is respected. */
   setConfig(config: DaemonConfig): void {
@@ -470,7 +487,12 @@ export class DaemonSessionManager extends EventEmitter {
     });
 
     bridge.on('exit', (payload: { sessionId: string; exitCode: number | null; signal?: number }) => {
-      meta.state = 'dead';
+      // Shutdown-kill classification (reboot-reattach RCA 2026-07-02): an OS
+      // shutdown kills PTY children before the daemon. Persisting those exits
+      // as 'dead' purged exactly the in-use sessions from recovery. Classified
+      // exits suspend instead — recovery replays them under the same id.
+      const involuntary = this.involuntaryExitClassifier(payload.exitCode, payload.signal);
+      meta.state = involuntary ? 'suspended' : 'dead';
       meta.exitCode = payload.exitCode;
       // Clean up bridge timers/listeners to prevent leaks when sessions die naturally
       managed.bridge.cleanup();
@@ -479,13 +501,19 @@ export class DaemonSessionManager extends EventEmitter {
       // dying. Silent PTY deaths (no log, no recorded exitCode) made the
       // "powershell exits -1 under claude" report undiagnosable.
       const lastActivityMsAgo = Date.now() - new Date(meta.lastActivity).getTime();
-      this.emit('session:died', {
+      const forensics = {
         id: params.id,
         exitCode: payload.exitCode,
         signal: payload.signal,
         cmd: meta.cmd,
         lastActivityMsAgo,
-      });
+      };
+      if (involuntary) {
+        this.emit('session:interrupted', forensics);
+        this.emit('session:stateChanged', { id: params.id, state: 'suspended' as DaemonSessionState });
+        return;
+      }
+      this.emit('session:died', forensics);
       this.emit('session:stateChanged', { id: params.id, state: 'dead' as DaemonSessionState });
     });
 

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -586,7 +586,12 @@ export class DaemonSessionManager extends EventEmitter {
   attachSession(id: string): void {
     const managed = this.sessions.get(id);
     if (!managed) throw new Error(`Session '${id}' not found`);
+    // 'suspended' holds no live ptyProcess (shutdown-kill classification —
+    // see shutdownKill.ts): the RPC handler would wire a fresh SessionPipe
+    // straight into a destroyed process. Reject like 'dead' so the caller's
+    // existing retry/backoff path handles it instead of crashing the daemon.
     if (managed.meta.state === 'dead') throw new Error(`Session '${id}' is dead`);
+    if (managed.meta.state === 'suspended') throw new Error(`Session '${id}' is suspended`);
 
     managed.meta.state = 'attached';
     this.emit('session:stateChanged', { id, state: 'attached' as DaemonSessionState });
@@ -605,6 +610,8 @@ export class DaemonSessionManager extends EventEmitter {
     const managed = this.sessions.get(id);
     if (!managed) throw new Error(`Session '${id}' not found`);
     if (managed.meta.state === 'dead') throw new Error(`Session '${id}' is dead`);
+    // Same rationale as attachSession — no live ptyProcess to resize.
+    if (managed.meta.state === 'suspended') throw new Error(`Session '${id}' is suspended`);
 
     managed.ptyProcess.resize(cols, rows);
     managed.meta.cols = cols;

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -370,6 +370,10 @@ export class DaemonSessionManager extends EventEmitter {
         restart: params.supervision.restart,
         limit: { ...params.supervision.limit },
         status: params.supervision.status,
+        // U-PERM: carry the consent-gated restore bit into the persisted meta so
+        // recovery/restart replay can honor it. Omitted from the own-copy above
+        // would silently disable the whole feature (tsc-invisible: optional field).
+        ...(params.supervision.restorePermissionMode === true ? { restorePermissionMode: true } : {}),
       };
     }
 

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -934,4 +934,74 @@ describe('DaemonSessionManager', () => {
       });
     });
   });
+
+  // Shutdown-kill classification (reboot-reattach RCA 2026-07-02): an exit the
+  // injected classifier marks involuntary must SUSPEND the session (recovery
+  // replays it under the same id) instead of marking it dead (recovery purges
+  // it — which is how every in-use session vanished across an OS reboot).
+  describe('involuntary exit classification (shutdown-kill)', () => {
+    it('default classifier: exits keep the pre-fix died flow', () => {
+      manager.createSession({ id: 'default-die', cmd: 'cmd.exe', cwd: '.' });
+      const died = vi.fn();
+      const interrupted = vi.fn();
+      manager.on('session:died', died);
+      manager.on('session:interrupted', interrupted);
+
+      lastMockPty?.simulateExit(1073807364); // even the shutdown code — unwired = unchanged
+
+      expect(died).toHaveBeenCalledTimes(1);
+      expect(interrupted).not.toHaveBeenCalled();
+      expect(manager.getSession('default-die')?.meta.state).toBe('dead');
+    });
+
+    it('classified exit → suspended + session:interrupted, NO session:died', () => {
+      manager.setInvoluntaryExitClassifier((exitCode) => exitCode === 1073807364);
+      manager.createSession({ id: 'shutdown-kill', cmd: 'cmd.exe', cwd: '.' });
+      const died = vi.fn();
+      const interrupted = vi.fn();
+      const stateChanged = vi.fn();
+      manager.on('session:died', died);
+      manager.on('session:interrupted', interrupted);
+      manager.on('session:stateChanged', stateChanged);
+
+      lastMockPty?.simulateExit(1073807364);
+
+      expect(died).not.toHaveBeenCalled();
+      // Same forensics contract as session:died — daemon logging depends on it.
+      expect(interrupted).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'shutdown-kill', exitCode: 1073807364 }),
+      );
+      expect(stateChanged).toHaveBeenCalledWith({ id: 'shutdown-kill', state: 'suspended' });
+      const managed = manager.getSession('shutdown-kill');
+      expect(managed?.meta.state).toBe('suspended');
+      // exitCode still recorded for forensics even on the suspend path.
+      expect(managed?.meta.exitCode).toBe(1073807364);
+    });
+
+    it('classifier false → normal death even when wired', () => {
+      manager.setInvoluntaryExitClassifier((exitCode) => exitCode === 1073807364);
+      manager.createSession({ id: 'user-exit', cmd: 'cmd.exe', cwd: '.' });
+      const died = vi.fn();
+      const interrupted = vi.fn();
+      manager.on('session:died', died);
+      manager.on('session:interrupted', interrupted);
+
+      lastMockPty?.simulateExit(0); // user typed `exit`
+
+      expect(died).toHaveBeenCalledWith(expect.objectContaining({ id: 'user-exit', exitCode: 0 }));
+      expect(interrupted).not.toHaveBeenCalled();
+      expect(manager.getSession('user-exit')?.meta.state).toBe('dead');
+    });
+
+    it('interrupted-suspended session survives in listSessions but is not live', () => {
+      manager.setInvoluntaryExitClassifier(() => true);
+      manager.createSession({ id: 'susp-list', cmd: 'cmd.exe', cwd: '.' });
+      lastMockPty?.simulateExit(1073807364);
+
+      // Persisted via listSessions (buildState) — this is the recovery payload.
+      expect(manager.listSessions().find((s) => s.id === 'susp-list')?.state).toBe('suspended');
+      // Not a live PTY holder — Watchdog idle-shutdown must not be held by it.
+      expect(manager.listLiveSessions().find((s) => s.id === 'susp-list')).toBeUndefined();
+    });
+  });
 });

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -1003,5 +1003,30 @@ describe('DaemonSessionManager', () => {
       // Not a live PTY holder — Watchdog idle-shutdown must not be held by it.
       expect(manager.listLiveSessions().find((s) => s.id === 'susp-list')).toBeUndefined();
     });
+
+    // Adversarial review (2026-07-02): attachSession/resizeSession only
+    // guarded 'dead', so an RPC against a 'suspended' session (renderer
+    // reconnect during the misclassification window) would flip it to
+    // 'attached' or resize a destroyed ptyProcess — a real crash risk, since
+    // the caller (daemon/index.ts) then wires a fresh SessionPipe straight
+    // into a socket that no longer has a live process behind it.
+    it('attachSession rejects a suspended session (no live ptyProcess to wire)', () => {
+      manager.setInvoluntaryExitClassifier(() => true);
+      manager.createSession({ id: 'susp-attach', cmd: 'cmd.exe', cwd: '.' });
+      lastMockPty?.simulateExit(1073807364);
+      expect(manager.getSession('susp-attach')?.meta.state).toBe('suspended');
+
+      expect(() => manager.attachSession('susp-attach')).toThrow(/suspended/i);
+      // Rejection must not have side-effected the state.
+      expect(manager.getSession('susp-attach')?.meta.state).toBe('suspended');
+    });
+
+    it('resizeSession rejects a suspended session (no live ptyProcess to resize)', () => {
+      manager.setInvoluntaryExitClassifier(() => true);
+      manager.createSession({ id: 'susp-resize', cmd: 'cmd.exe', cwd: '.' });
+      lastMockPty?.simulateExit(1073807364);
+
+      expect(() => manager.resizeSession('susp-resize', 100, 40)).toThrow(/suspended/i);
+    });
   });
 });

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -858,6 +858,33 @@ describe('DaemonSessionManager', () => {
       expect(session.supervision?.status).toBe('stopped');
     });
 
+    it('persists supervision.restorePermissionMode through the owned copy (U-PERM)', () => {
+      const session = manager.createSession({
+        id: 'sup-restore',
+        cmd: 'pwsh.exe',
+        cwd: '.',
+        exec: { command: 'claude' },
+        supervision: { restart: 'on-failure', limit: { burst: 5, healthyUptimeSec: 300 }, status: 'armed', restorePermissionMode: true },
+      });
+      // The consent-gated bit must survive the field-by-field own-copy — a plain
+      // {restart,limit,status} rebuild silently dropped it (tsc-invisible: the
+      // field is optional on the target). Covers the persist half; the create RPC
+      // handler + recovery replay halves are covered by scripts/u-perm-restore-probe.mjs.
+      expect(session.supervision?.restorePermissionMode).toBe(true);
+      expect(manager.getSession('sup-restore')?.meta.supervision?.restorePermissionMode).toBe(true);
+    });
+
+    it('omits restorePermissionMode when consent is off', () => {
+      const session = manager.createSession({
+        id: 'sup-norestore',
+        cmd: 'pwsh.exe',
+        cwd: '.',
+        exec: { command: 'claude' },
+        supervision: { restart: 'on-failure', limit: { burst: 5, healthyUptimeSec: 300 }, status: 'armed', restorePermissionMode: false },
+      });
+      expect(session.supervision?.restorePermissionMode).toBeUndefined();
+    });
+
     describe('removeTombstone', () => {
       it('removes a dead tombstone silently so the same id can be re-created', () => {
         manager.createSession({ id: 'tomb', cmd: 'pwsh.exe', cwd: '.', exec: { command: 'claude /loop' } });

--- a/src/daemon/__tests__/shutdownKill.test.ts
+++ b/src/daemon/__tests__/shutdownKill.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { isShutdownKillExit, SHUTDOWN_KILL_EXIT_CODE } from '../shutdownKill';
+
+// Reboot-reattach RCA 2026-07-02: Windows kills PTY children with
+// DBG_TERMINATE_PROCESS (0x40010004) at shutdown/logoff BEFORE the daemon
+// dies. Those exits must classify as involuntary (→ suspend for recovery),
+// while ordinary shell exits must keep the normal death flow.
+describe('isShutdownKillExit', () => {
+  const win = (exitCode: number | null, shuttingDown = false) =>
+    isShutdownKillExit(exitCode, { platform: 'win32', shuttingDown });
+
+  it('matches the observed incident signature: win32 + 0x40010004', () => {
+    expect(SHUTDOWN_KILL_EXIT_CODE).toBe(1073807364); // the exact code in the incident log
+    expect(win(1073807364)).toBe(true);
+  });
+
+  it('voluntary shell exits are NOT shutdown kills', () => {
+    expect(win(0)).toBe(false); // `exit`
+    expect(win(1)).toBe(false); // error exit / taskkill
+    expect(win(null)).toBe(false); // no code recorded
+    expect(win(-1073741502)).toBe(false); // 0xC0000142 — spawn-during-shutdown corpse, already dead-on-arrival
+  });
+
+  it('the Windows code does not classify on posix (different teardown semantics)', () => {
+    expect(isShutdownKillExit(1073807364, { platform: 'linux', shuttingDown: false })).toBe(false);
+    expect(isShutdownKillExit(1073807364, { platform: 'darwin', shuttingDown: false })).toBe(false);
+  });
+
+  it('ANY exit during our own graceful shutdown is involuntary (posix SIGTERM fan-out race)', () => {
+    expect(isShutdownKillExit(0, { platform: 'linux', shuttingDown: true })).toBe(true);
+    expect(isShutdownKillExit(143, { platform: 'darwin', shuttingDown: true })).toBe(true);
+    expect(win(0, true)).toBe(true);
+  });
+});

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -201,11 +201,16 @@ function log(level: string, msg: string, ...args: unknown[]): void {
 //
 // X6 ③: with a captured resumeBinding whose cwd still matches, the rewrite
 // targets the EXACT session (`claude --resume <id>`); otherwise it falls back to
-// `--continue` (latest-in-cwd). The permission mode is deliberately NOT restored
-// here — supervised auto-run has no human in the loop, so re-granting
-// `--dangerously-skip-permissions` silently every reboot is unsafe (D6
-// fail-safe). Permission restore happens ONLY on the pill path (explicit user
-// Enter); the trust-gated supervised auto-restore is a deferred follow-up.
+// `--continue` (latest-in-cwd). Permission-mode restore (re-applying the
+// captured `--dangerously-skip-permissions` etc.) is OPT-IN via the persisted
+// `supervision.restorePermissionMode` bit (U-PERM): main sets it at CREATION
+// only when the leaf declared `unattended` AND the user gave explicit unattended
+// consent for the project (ProjectTrustRecord.unattended). The daemon honors
+// that bit verbatim here — no trust file is read at replay (Minimal design-lock
+// 2026-07-01: trust is gated at creation, consistent with how every other
+// supervised replay is unconditional post-creation). Absent/false → D6 fail-safe
+// (plain --resume/--continue, NO bypass flag). The pill path (explicit user
+// Enter) still opts in via permissionFlagFor separately.
 // X6 ③ (D5): a binding is usable for an EXACT-session resume only when its
 // origin transcript still exists. A purged id turns `--resume` into a silent
 // "No conversation found." (F8 — exit 0, so no exit-code fallback). We probe the
@@ -219,7 +224,13 @@ function bindingTranscriptLives(binding: ResumeBinding | undefined): boolean {
 }
 
 function resumeLaunchCommand(
-  session: { id: string; exec?: { command: string }; cwd: string; resumeBinding?: ResumeBinding },
+  session: {
+    id: string;
+    exec?: { command: string };
+    cwd: string;
+    resumeBinding?: ResumeBinding;
+    supervision?: { restorePermissionMode?: boolean };
+  },
   spoolBinding?: ResumeBinding,
 ): string | undefined {
   if (!session.exec) return undefined;
@@ -237,9 +248,24 @@ function resumeLaunchCommand(
   }
   // D5: drop to `--continue` when the exact transcript is gone (pass no binding).
   const usableBinding = bindingTranscriptLives(binding) ? binding : undefined;
-  const rewritten = toResumeCommand(session.exec.command, usableBinding, session.cwd);
+  // U-PERM: honor the persisted, consent-gated restore bit (set by main at
+  // creation). When ON, toResumeCommand appends the captured permission flag
+  // (e.g. --dangerously-skip-permissions) — but ONLY inside its binding+cwd-match
+  // branch, so a purged transcript (usableBinding undefined) still yields a plain
+  // --continue with no bypass (fail-safe). No trust file is read here.
+  const restorePermissionMode = session.supervision?.restorePermissionMode === true;
+  const rewritten = toResumeCommand(
+    session.exec.command,
+    usableBinding,
+    session.cwd,
+    restorePermissionMode ? { restorePermissionMode: true } : undefined,
+  );
   if (rewritten === session.exec.command) return undefined; // not a known agent launcher / already resuming
-  log('info', `X6 resume: replaying session ${session.id} as resume form in ${session.cwd}`);
+  log(
+    'info',
+    `X6 resume: replaying session ${session.id} as resume form in ${session.cwd}` +
+      (restorePermissionMode ? ' (unattended permission-mode restore ON)' : ''),
+  );
   return rewritten;
 }
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1898,6 +1898,19 @@ function wireEvents(
   // Misclassification safety net: if the daemon is still alive after
   // SHUTDOWN_KILL_RECLASSIFY_MS (cancelled shutdown / isolated conhost kill),
   // reclassify as a genuine death and run the standard died flow.
+  //
+  // Pipe/listener cleanup IS done here (adversarial review), unlike the other
+  // died-only steps above: an isolated conhost kill (the exact case the
+  // reclassify timer exists for) leaves the daemon AND a still-connected
+  // renderer alive for up to SHUTDOWN_KILL_RECLASSIFY_MS. Without stopping the
+  // SessionPipe, its `onInput` closure keeps forwarding client keystrokes
+  // straight into the now-destroyed `ptyProcess.write()` — an unhandled
+  // socket 'error' with no listener, which the daemon's own uncaughtException
+  // handler treats as fatal after 3 repeats, killing every OTHER session as
+  // collateral. Stopping the pipe destroys the client's connection for THIS
+  // session only (the renderer's own reconnect-with-retry handles that as a
+  // transient failure) without broadcasting session.died or touching the
+  // renderer's saved binding.
   sessionManager.on('session:interrupted', (payload: { id: string; exitCode: number | null; signal?: number; cmd?: string; lastActivityMsAgo?: number }) => {
     log('info', `[lifecycle] session:interrupted id=${payload.id} exitCode=${payload.exitCode ?? 'null'} signal=${payload.signal ?? 'none'} cmd=${payload.cmd ?? '?'} — shutdown-kill classified, suspending for recovery (reclassify in ${SHUTDOWN_KILL_RECLASSIFY_MS}ms if daemon survives)`);
     // The PTY is gone — stop the liveness poll BEFORE it can observe the dead
@@ -1909,9 +1922,36 @@ function wireEvents(
       log('warn', `session:interrupted unwatch failed for ${payload.id}:`, err);
     }
     // Graceful-shutdown race (posix SIGTERM fan-out / mid-suspend deaths): the
-    // shutdown loop is already dumping every non-dead session and persisting
-    // the suspend state — doing it again here would just race the same file.
+    // shutdown loop already stops every session's pipe (see `pipeStops` above)
+    // and is dumping every non-dead session's buffer — doing either again here
+    // would just race the same pipe/file.
     if (shuttingDown) return;
+
+    // Remove the PTY→client data listener to prevent a leak (mirrors
+    // session:died) — the bridge is dead and will emit nothing more, but the
+    // map entry would otherwise dangle.
+    try {
+      const tracked = sessionDataListeners.get(payload.id);
+      if (tracked) {
+        tracked.bridge.removeListener('data', tracked.listener);
+        sessionDataListeners.delete(payload.id);
+      }
+    } catch (err) {
+      log('warn', `session:interrupted data-listener cleanup failed for ${payload.id}:`, err);
+    }
+
+    // Stop the SessionPipe so its onInput closure can never write another
+    // keystroke into the destroyed ptyProcess (see comment above the
+    // listener). This is the crash-prevention step.
+    try {
+      const pipe = sessionPipes.get(payload.id);
+      if (pipe) {
+        pipe.stop().catch(() => {});
+        sessionPipes.delete(payload.id);
+      }
+    } catch (err) {
+      log('warn', `session:interrupted pipe stop failed for ${payload.id}:`, err);
+    }
 
     const managed = sessionManager.getSession(payload.id);
     if (!managed) return;

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -31,6 +31,7 @@ import type { ResumeBinding } from '../shared/agentResume';
 import { agentDisplayToSlug } from '../main/pty/AgentDetector';
 import type { AgentSlug } from '../shared/events';
 import { LANLINK_SENTINEL_SESSION_ID } from '../shared/lanlink';
+import { classifyTasklistOutput, classifyKillOutcome, lockOwnerIsReclaimable, type ProcessLiveness } from '../shared/processLiveness';
 
 // X6 Feature ②: sessions RECOVERED this daemon boot that were running an
 // INTERACTIVE agent (non-exec, non-supervised) → ptyId → the agent slug to
@@ -398,31 +399,44 @@ function ingestResumeSpool(
 
 // === PID / Lock helpers ===
 
-async function isProcessRunning(pid: number): Promise<boolean> {
+/**
+ * Three-state liveness probe for the daemon lock (Defect-1 of the split-brain
+ * chain). A probe FAILURE — `tasklist` stalling under Defender/CPU/WMI load, or
+ * an exec error — is `unknown`, NEVER `dead`. The prior boolean form read that
+ * flaky failure as "process absent" (catch → false), letting a second daemon
+ * treat a LIVE daemon's lock as stale and stomp it (duplicate-daemon →
+ * session-pipe EADDRINUSE → terminal reset). Only positive confirmation of death
+ * authorizes reclaiming the lock (see lockOwnerIsReclaimable). Mirrors the
+ * launcher-side checkProcessLiveness so both processes share one contract
+ * (src/shared/processLiveness).
+ */
+async function processLiveness(pid: number): Promise<ProcessLiveness> {
   if (process.platform === 'win32') {
-    // process.kill(pid, 0) is unreliable on Windows — always succeeds for stale PIDs.
+    // process.kill(pid, 0) is unreliable on Windows — it succeeds for stale PIDs
+    // — so probe with tasklist. A thrown probe leaves stdout null → unknown.
+    let stdout: string | null = null;
     try {
       const { execFile } = require('child_process');
       const { promisify } = require('util');
       const execFileAsync = promisify(execFile);
-      const pathMod = require('path');
       const systemRoot = process.env.SystemRoot || 'C:\\Windows';
-      const tasklist = pathMod.join(systemRoot, 'System32', 'tasklist.exe');
-      const { stdout } = await execFileAsync(
+      const tasklist = path.join(systemRoot, 'System32', 'tasklist.exe');
+      const res = await execFileAsync(
         tasklist,
         ['/fi', `PID eq ${pid}`, '/fo', 'csv', '/nh'],
         { encoding: 'utf-8', timeout: 3000, windowsHide: true },
       );
-      return (stdout as string).includes(`"${pid}"`);
+      stdout = res.stdout as string;
     } catch {
-      return false;
+      stdout = null; // timeout / exec failure → unknown (NOT dead)
     }
+    return classifyTasklistOutput(pid, stdout);
   }
   try {
     process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
+    return classifyKillOutcome(undefined);
+  } catch (err: unknown) {
+    return classifyKillOutcome((err as NodeJS.ErrnoException | undefined)?.code);
   }
 }
 
@@ -483,9 +497,13 @@ async function acquireLock(): Promise<boolean> {
       try {
         const existingPid = parseInt(fs.readFileSync(LOCK_FILE, 'utf-8').trim(), 10);
         if (!isNaN(existingPid)) {
-          const running = await isProcessRunning(existingPid);
-          if (running) {
-            log('error', `Another daemon is already running (PID ${existingPid})`);
+          // 3-state liveness (Defect-1 fix): a probe FAILURE is `unknown`, never
+          // `dead`. The lock is reclaimable ONLY on positive confirmation of
+          // death — `alive` OR `unknown` (a flaky tasklist) means "assume a live
+          // daemon holds it, do not stomp its lock and spawn a second daemon."
+          const liveness = await processLiveness(existingPid);
+          if (!lockOwnerIsReclaimable(liveness)) {
+            log('error', `Another daemon holds the lock (PID ${existingPid}, liveness=${liveness})`);
             return false;
           }
           // tasklist says not running — but could be a tasklist failure.

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1047,7 +1047,15 @@ function registerRpcHandlers(
       // a persisted 'stopped' only ever enters through recovery replay.
       exec: p.exec,
       supervision: p.supervision
-        ? { restart: p.supervision.restart, limit: p.supervision.limit, status: 'armed' }
+        ? {
+            restart: p.supervision.restart,
+            limit: p.supervision.limit,
+            status: 'armed',
+            // U-PERM: preserve the consent-gated restore bit through the create
+            // RPC — a field-by-field copy silently dropped it (tsc-invisible:
+            // the field is optional on the target).
+            ...(p.supervision.restorePermissionMode === true ? { restorePermissionMode: true } : {}),
+          }
         : undefined,
     });
     if (session.supervision) {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -17,6 +17,7 @@ import { DEFAULT_COMPANY_ID } from '../shared/channels';
 import { ProcessMonitor } from './ProcessMonitor';
 import { Watchdog } from './Watchdog';
 import { selectRecoverableSessions } from './recoverySelector';
+import { isShutdownKillExit, SHUTDOWN_KILL_RECLASSIFY_MS } from './shutdownKill';
 import { createSnapshotRunner } from './snapshotRunner';
 import { RingBuffer } from './RingBuffer';
 import { GitContextWatcher } from '../main/pty/gitContextWatch';
@@ -734,7 +735,7 @@ async function recoverSessions(
         // Start process monitoring for the new PTY
         processMonitor.watch(recovered.id, recovered.pid, () => {
           const managed = sessionManager.getSession(recovered.id);
-          if (managed && managed.meta.state !== 'dead') {
+          if (managed && managed.meta.state !== 'dead' && managed.meta.state !== 'suspended') {
             managed.meta.state = 'dead';
             sessionManager.emit('session:died', { id: recovered.id, exitCode: null, reason: 'recovery' });
           }
@@ -793,7 +794,7 @@ async function recoverSessions(
 
           processMonitor.watch(recovered.id, recovered.pid, () => {
             const managed = sessionManager.getSession(recovered.id);
-            if (managed && managed.meta.state !== 'dead') {
+            if (managed && managed.meta.state !== 'dead' && managed.meta.state !== 'suspended') {
               managed.meta.state = 'dead';
               sessionManager.emit('session:died', { id: recovered.id, exitCode: null, reason: 'recovery' });
             }
@@ -836,7 +837,7 @@ async function recoverSessions(
 
         processMonitor.watch(recovered.id, recovered.pid, () => {
           const managed = sessionManager.getSession(recovered.id);
-          if (managed && managed.meta.state !== 'dead') {
+          if (managed && managed.meta.state !== 'dead' && managed.meta.state !== 'suspended') {
             managed.meta.state = 'dead';
             sessionManager.emit('session:died', { id: recovered.id, exitCode: null, reason: 'recovery' });
           }
@@ -997,7 +998,7 @@ function restartSupervisedSession(
   // Same external-death safety net as the create/recovery paths.
   processMonitor.watch(recovered.id, recovered.pid, () => {
     const current = sessionManager.getSession(recovered.id);
-    if (current && current.meta.state !== 'dead') {
+    if (current && current.meta.state !== 'dead' && current.meta.state !== 'suspended') {
       current.meta.state = 'dead';
       sessionManager.emit('session:died', { id: recovered.id, exitCode: null, reason: 'process-monitor' });
     }
@@ -1071,7 +1072,7 @@ function registerRpcHandlers(
       // Process died externally — session manager's bridge exit handler
       // should already handle this via PTY onExit, but this is a safety net
       const managed = sessionManager.getSession(session.id);
-      if (managed && managed.meta.state !== 'dead') {
+      if (managed && managed.meta.state !== 'dead' && managed.meta.state !== 'suspended') {
         managed.meta.state = 'dead';
         sessionManager.emit('session:died', { id: session.id, exitCode: null, reason: 'process-monitor' });
       }
@@ -1884,6 +1885,85 @@ function wireEvents(
     }
   });
 
+  // session:interrupted → shutdown-kill path (reboot-reattach RCA 2026-07-02).
+  // The PTY was torn down by the OS (system shutdown/logoff), not by the user.
+  // Suspend-in-place: dump the ring buffer, persist state 'suspended' so the
+  // post-reboot recovery replays the SAME session id and the renderer's saved
+  // ptyId binding reconnects. Deliberately NOT done here (vs session:died):
+  //  - no `session.died` broadcast — a still-alive renderer must not clear its
+  //    binding during the shutdown window;
+  //  - no buffer-dump deletion — the dump IS the recovery payload;
+  //  - no supervisor restart — spawning processes during OS shutdown just
+  //    yields 0xC0000142 corpses; recovery replays supervision after reboot.
+  // Misclassification safety net: if the daemon is still alive after
+  // SHUTDOWN_KILL_RECLASSIFY_MS (cancelled shutdown / isolated conhost kill),
+  // reclassify as a genuine death and run the standard died flow.
+  sessionManager.on('session:interrupted', (payload: { id: string; exitCode: number | null; signal?: number; cmd?: string; lastActivityMsAgo?: number }) => {
+    log('info', `[lifecycle] session:interrupted id=${payload.id} exitCode=${payload.exitCode ?? 'null'} signal=${payload.signal ?? 'none'} cmd=${payload.cmd ?? '?'} — shutdown-kill classified, suspending for recovery (reclassify in ${SHUTDOWN_KILL_RECLASSIFY_MS}ms if daemon survives)`);
+    // The PTY is gone — stop the liveness poll BEFORE it can observe the dead
+    // pid and re-emit session:died (which would resurrect the purge this fix
+    // removes). The watch closures also skip 'suspended' as defense in depth.
+    try {
+      processMonitor.unwatch(payload.id);
+    } catch (err) {
+      log('warn', `session:interrupted unwatch failed for ${payload.id}:`, err);
+    }
+    // Graceful-shutdown race (posix SIGTERM fan-out / mid-suspend deaths): the
+    // shutdown loop is already dumping every non-dead session and persisting
+    // the suspend state — doing it again here would just race the same file.
+    if (shuttingDown) return;
+
+    const managed = sessionManager.getSession(payload.id);
+    if (!managed) return;
+    try {
+      stateWriter.ensureBufferDir();
+      const dumpPath = stateWriter.getBufferDumpPath(payload.id);
+      managed.ringBuffer
+        .dumpToFile(dumpPath)
+        .then(() => {
+          managed.meta.bufferDumpPath = dumpPath;
+        })
+        .catch((err) => {
+          // Dump failed — recovery still replays via the 30s snapshot (or
+          // empty scrollback); losing scrollback beats losing the session.
+          log('warn', `session:interrupted buffer dump failed for ${payload.id}:`, err);
+        })
+        .finally(() => {
+          // Persistence anchor: the 'suspended' record MUST land before the
+          // OS kills us. saveImmediate is synchronous-atomic on the state file.
+          try {
+            stateWriter.saveImmediate(buildState(sessionManager));
+          } catch (err) {
+            log('error', `session:interrupted state save failed for ${payload.id}:`, err);
+          }
+        });
+    } catch (err) {
+      log('error', `session:interrupted suspend failed for ${payload.id}:`, err);
+    }
+
+    const timer = setTimeout(() => {
+      interruptedTimers.delete(payload.id);
+      const current = sessionManager.getSession(payload.id);
+      // Destroyed/replayed meanwhile → nothing to reclassify.
+      if (!current || current.meta.state !== 'suspended') return;
+      log('info', `[lifecycle] session:interrupted id=${payload.id} — daemon survived ${SHUTDOWN_KILL_RECLASSIFY_MS}ms, no shutdown happened → reclassifying as death`);
+      current.meta.state = 'dead';
+      sessionManager.emit('session:died', { ...payload, reason: 'interrupted-timeout' });
+      sessionManager.emit('session:stateChanged', { id: payload.id, state: 'dead' });
+    }, SHUTDOWN_KILL_RECLASSIFY_MS);
+    interruptedTimers.set(payload.id, timer);
+  });
+
+  // A pane the user closes while a reclassification is pending must not get a
+  // ghost died event 15s later.
+  sessionManager.on('session:destroyed', (payload: { id: string }) => {
+    const t = interruptedTimers.get(payload.id);
+    if (t) {
+      clearTimeout(t);
+      interruptedTimers.delete(payload.id);
+    }
+  });
+
   // session:created → save state (debounced since saveImmediate is called in RPC handler)
   sessionManager.on('session:created', () => {
     const state = buildState(sessionManager);
@@ -2161,6 +2241,12 @@ let shuttingDown = false;
 // even when the async path was interrupted mid-dump.
 let dumpsCompleted = false;
 
+// Pending shutdown-kill reclassification timers, keyed by session id (see the
+// session:interrupted listener in wireEvents). Module-level so shutdown() can
+// cancel them — a reclassify-to-dead firing mid-graceful-shutdown would race
+// the suspend loop's own state save.
+const interruptedTimers = new Map<string, NodeJS.Timeout>();
+
 async function shutdown(
   signal: string,
   sessionManager: DaemonSessionManager,
@@ -2175,6 +2261,11 @@ async function shutdown(
   if (shuttingDown) return;
   shuttingDown = true;
   log('info', `Received ${signal} — shutting down gracefully`);
+
+  // Cancel pending shutdown-kill reclassifications — the suspend loop below is
+  // now the single owner of every non-dead session's persisted state.
+  for (const t of interruptedTimers.values()) clearTimeout(t);
+  interruptedTimers.clear();
 
   // Hard timeout guard — force exit if shutdown hangs
   const shutdownTimeout = setTimeout(() => {
@@ -2346,6 +2437,13 @@ async function main(): Promise<void> {
 
   const sessionManager = new DaemonSessionManager();
   sessionManager.setConfig(config);
+  // Shutdown-kill classification (reboot-reattach RCA 2026-07-02): a PTY exit
+  // with the Windows console-teardown code, or ANY exit while our own graceful
+  // shutdown is in flight, is an involuntary kill — suspend for recovery
+  // instead of persisting a dead tombstone. See shutdownKill.ts for the RCA.
+  sessionManager.setInvoluntaryExitClassifier((exitCode) =>
+    isShutdownKillExit(exitCode, { platform: process.platform, shuttingDown }),
+  );
   const pipeServer = new DaemonPipeServer(config.daemon.pipeName);
   // Channels (a2a-channels U3). Channels live in their own file
   // (`channels.json`, see ChannelStateWriter doc) so a channel-loss event

--- a/src/daemon/shutdownKill.ts
+++ b/src/daemon/shutdownKill.ts
@@ -1,0 +1,52 @@
+/**
+ * Shutdown-kill classification for PTY exits.
+ *
+ * RCA 2026-07-02 (reboot-reattach): during an OS shutdown/reboot Windows
+ * terminates the daemon's PTY children BEFORE the daemon process itself.
+ * The daemon then observes each `pty-exit` and — unable to tell a system
+ * teardown from a user typing `exit` — marked those sessions 'dead' and
+ * persisted the tombstones. Post-reboot recovery skips 'dead', so exactly
+ * the sessions that were being USED (attached, in the renderer layout) got
+ * purged, while unobserved ghosts survived. The renderer's saved ptyIds then
+ * matched nothing → self-create → "terminal reset after reboot".
+ *
+ * Classification signals:
+ *  - exitCode 0x40010004 (DBG_TERMINATE_PROCESS): what conhost/ConPTY children
+ *    report when Windows tears the console session down at shutdown/logoff.
+ *    Observed on all 11 purged sessions in the 2026-07-02 incident log. A
+ *    voluntary shell exit reports the shell's own code (0, 1, ...), never this.
+ *  - `shuttingDown`: the daemon's own graceful-shutdown flag. Covers the posix
+ *    path (SIGTERM fans out to children concurrently with our suspend loop)
+ *    and any pty that dies while the graceful suspend is in flight.
+ *
+ * A session classified as a shutdown-kill is SUSPENDED (buffer dumped, state
+ * persisted) instead of marked dead, so recovery replays it under the SAME id
+ * and the renderer's persisted binding reconnects. Misclassification (e.g. a
+ * cancelled shutdown, or someone force-killing a lone conhost) is corrected by
+ * a reclassification timer in daemon/index.ts: if the daemon is still alive
+ * after the window, the standard death flow runs.
+ */
+
+/** DBG_TERMINATE_PROCESS — Windows console teardown at shutdown/logoff. */
+export const SHUTDOWN_KILL_EXIT_CODE = 0x40010004;
+
+/**
+ * How long the daemon must survive a shutdown-kill-classified exit before
+ * concluding the OS did NOT go down (cancelled shutdown / isolated conhost
+ * kill) and running the normal death flow. During a real shutdown the daemon
+ * is killed within seconds, so the timer never fires and the suspended state
+ * persisted at classification time is what recovery sees after reboot.
+ */
+export const SHUTDOWN_KILL_RECLASSIFY_MS = 15_000;
+
+/**
+ * Pure decision: should this PTY exit suspend the session (recovery replays
+ * it) instead of killing it (recovery purges it)?
+ */
+export function isShutdownKillExit(
+  exitCode: number | null,
+  opts: { platform: NodeJS.Platform; shuttingDown: boolean },
+): boolean {
+  if (opts.shuttingDown) return true;
+  return opts.platform === 'win32' && exitCode === SHUTDOWN_KILL_EXIT_CODE;
+}

--- a/src/main/__tests__/sessionEnd.daemonShutdown.test.ts
+++ b/src/main/__tests__/sessionEnd.daemonShutdown.test.ts
@@ -39,9 +39,16 @@ describe('A5 — session-end (WM_ENDSESSION) handler invariants', () => {
     expect(handler).toMatch(/'session-end'\s+as\s+any[\s\S]{0,40}async\s*\(\s*\)\s*=>/);
   });
 
-  it('emergency sync SessionManager.save still runs', () => {
+  it('flushes the live singleton via flushSync (no stale reload-resave)', () => {
     const handler = extractHandler();
-    expect(handler).toMatch(/sm\.save\(existing\)/);
+    // v2 RCA fix (reboot-reattach): the previous `new SessionManager().load() ->
+    // save(existing)` re-confirmed a STALE on-disk snapshot (and could resurrect a
+    // .bak fossil), overwriting the renderer's newest layout. The renderer now
+    // persists ptyId changes synchronously (event-driven session.save), so
+    // session-end only flushes the LIVE singleton's pending debounced write.
+    expect(handler).toMatch(/sessionManager\.flushSync\(\)/);
+    // Guard against the stale reload-resave pattern ever coming back.
+    expect(handler).not.toMatch(/sm\.save\(existing\)/);
   });
 
   it('races daemon.shutdown via raceDaemonShutdown before disconnectSync', () => {

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -8,6 +8,7 @@ import { getWmuxDir } from '../../daemon/config';
 import { getDaemonPipeName, readDaemonAuthToken } from '../DaemonClient';
 import { DAEMON_EXIT_ALREADY_RUNNING } from '../../shared/constants';
 import { markBoot } from '../util/bootTrace';
+import { classifyTasklistOutput, classifyKillOutcome, type ProcessLiveness } from '../../shared/processLiveness';
 
 export interface DaemonInfo {
   pid: number;
@@ -63,31 +64,12 @@ function askUserToRecoverFromStalePid(opts: {
   return choice === 0;
 }
 
-export type ProcessLiveness = 'alive' | 'dead' | 'unknown';
-
-/**
- * Classify a Windows `tasklist` probe result. `stdout === null` means the
- * probe itself failed (timeout under Defender realtime scan, CPU/WMI
- * pressure, exec error) — that is `unknown`, NOT `dead`. Only an
- * authoritative empty listing (exec succeeded, PID absent) is `dead`.
- */
-export function classifyTasklistOutput(pid: number, stdout: string | null): ProcessLiveness {
-  if (stdout === null) return 'unknown';
-  return stdout.includes(`"${pid}"`) ? 'alive' : 'dead';
-}
-
-/**
- * Classify a POSIX `process.kill(pid, 0)` outcome. No error → the signal
- * reached a live process (`alive`). `ESRCH` → authoritative "no such
- * process" (`dead`). `EPERM` → the process exists but we may not signal it
- * (`alive`). Anything else → `unknown`.
- */
-export function classifyKillOutcome(code: string | undefined): ProcessLiveness {
-  if (code === undefined) return 'alive';
-  if (code === 'ESRCH') return 'dead';
-  if (code === 'EPERM') return 'alive';
-  return 'unknown';
-}
+// `ProcessLiveness` + the pure classifiers now live in shared/processLiveness so
+// the daemon (a bare Node process that must NOT import this electron-dependent
+// module) shares the exact same contract. Re-exported here so existing importers
+// (launcher.liveness.test.ts) keep resolving them from '../launcher'.
+export { classifyTasklistOutput, classifyKillOutcome };
+export type { ProcessLiveness };
 
 /**
  * Three-state liveness probe. A probe FAILURE (timeout / exec error) is

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1401,17 +1401,24 @@ app.on('before-quit', async (e) => {
 // handler may not complete in time, so we do a synchronous emergency save here.
 if (process.platform === 'win32') {
   app.on('session-end' as any, async () => {
-    console.log('[Main] session-end received — emergency sync save + daemon race');
+    console.log('[Main] session-end received — flush pending session write + daemon race');
     try {
-      // Import SessionManager lazily to avoid circular deps
-      const { SessionManager } = require('./session/SessionManager');
-      const sm = new SessionManager();
-      const existing = sm.load();
-      if (existing) {
-        sm.save(existing); // ensure last periodic save is flushed to disk
-      }
+      // v2 RCA fix (reboot-reattach): the previous block built a FRESH
+      // `new SessionManager()`, `load()`ed the on-disk snapshot, and `save()`d
+      // it back. That did NOT capture the renderer's latest layout — it merely
+      // re-confirmed whatever stale (possibly `.bak`-fallback fossil) snapshot
+      // was already on disk, overwriting nothing useful and resurrecting fossils.
+      // The renderer now persists ptyId changes the instant they happen
+      // (event-driven session.save → synchronous main-side write), so disk
+      // already holds the latest layout here. Flush the LIVE singleton's
+      // pending debounced write as a safety net — a no-op today (saveDebounced
+      // has no production callers; SESSION_SAVE goes through sync save()), but
+      // it keeps this path correct if a debounced producer ever appears. Never
+      // reload-and-resave stale state.
+      const { sessionManager } = require('./ipc/handlers/session.handler');
+      sessionManager.flushSync();
     } catch (err) {
-      console.error('[Main] Emergency session save failed:', err);
+      console.error('[Main] session-end flushSync failed:', err);
     }
 
     if (daemonClient?.isConnected) {

--- a/src/main/ipc/__tests__/pty.handler.surfaceIdExposure.test.ts
+++ b/src/main/ipc/__tests__/pty.handler.surfaceIdExposure.test.ts
@@ -1,0 +1,45 @@
+/**
+ * v2 RCA fix (reboot-reattach, axis B-lite) — PTY_LIST surfaceId exposure.
+ *
+ * Structural test (house pattern: pty.handler.resize-retry.test.ts). The
+ * surfaceId chain (daemon env WMUX_SURFACE_ID → PTY_LIST map → renderer
+ * reconcile rebind) is wired through untyped RPC payloads and optional
+ * chaining, so tsc cannot catch a dropped hop — the exact tsc-invisible
+ * field-drop class behind the U-PERM runtime drops (testing specialist,
+ * confidence 78). This scan fails if a refactor strips the mapping, the
+ * suspended-exclusion, or the createdAt exposure.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+describe('pty.handler PTY_LIST — axis B-lite surfaceId exposure invariants', () => {
+  const handlerPath = path.join(__dirname, '..', 'handlers', 'pty.handler.ts');
+  const source = fs.readFileSync(handlerPath, 'utf-8');
+
+  /** Narrow to the daemon-mode PTY_LIST handler region. */
+  function listRegion(): string {
+    const start = source.indexOf('ipcMain.handle(IPC.PTY_LIST');
+    expect(start, 'daemon-mode PTY_LIST handler not found').toBeGreaterThanOrEqual(0);
+    const end = source.indexOf('ipcMain.handle(IPC.PTY_LIST', start + 1);
+    return source.slice(start, end > 0 ? end : start + 4000);
+  }
+
+  it('maps env.WMUX_SURFACE_ID onto the returned surfaceId field', () => {
+    const region = listRegion();
+    expect(region).toMatch(/s\.env\?\.\[ENV_KEYS\.SURFACE_ID\]/);
+    expect(region).toMatch(/surfaceId:\s*s\.env\[ENV_KEYS\.SURFACE_ID\]/);
+  });
+
+  it('excludes suspended sessions from rebind targets (no live PTY behind them)', () => {
+    const region = listRegion();
+    // The surfaceId attachment must be conditioned on NOT-suspended.
+    expect(region).toMatch(/s\.state\s*!==\s*'suspended'/);
+  });
+
+  it('keeps the dead filter AND exposes createdAt for newest-wins duplicate resolution', () => {
+    const region = listRegion();
+    expect(region).toMatch(/\.filter\(s => s\.state !== 'dead'\)/);
+    expect(region).toMatch(/createdAt:\s*s\.createdAt/);
+  });
+});

--- a/src/main/ipc/handlers/projectConfig.handler.ts
+++ b/src/main/ipc/handlers/projectConfig.handler.ts
@@ -29,6 +29,7 @@ export function registerProjectConfigHandlers(): () => void {
     root: unknown,
     decision: unknown,
     contentHash: unknown,
+    unattended: unknown,
   ): Promise<{ ok: boolean }> => {
     if (typeof root !== 'string' || root.length === 0 || root.length > MAX_PATH_LEN) {
       throw new Error('Invalid project root');
@@ -42,7 +43,9 @@ export function registerProjectConfigHandlers(): () => void {
       throw new Error('Invalid trust decision');
     }
     if (typeof contentHash !== 'string') throw new Error('Invalid content hash');
-    await store.setDecision(root, decision, contentHash);
+    // Unattended reboot-survival consent is a strict opt-in boolean; anything
+    // that isn't literally true (absent, non-boolean) is treated as no consent.
+    await store.setDecision(root, decision, contentHash, unattended === true);
     return { ok: true };
   }));
 

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -661,6 +661,13 @@ export function registerPTYHandlers(
         id: string;
         cmd: string;
         state: string;
+        // v2 RCA fix (reboot-reattach, axis B-lite): the daemon's listSessions
+        // returns the full session incl. `env`, which carries WMUX_SURFACE_ID on
+        // Terminal-self-create-originated sessions. Surface it to the renderer so
+        // reconcile can rebind-by-surfaceId before clearing a stale ptyId. Daemon
+        // stays unchanged (it already returns env verbatim).
+        env?: Record<string, string>;
+        createdAt?: string;
         // X8 — supervised sessions carry the sticky policy/status on meta and an
         // additive volatile runtime joined by the daemon's listSessions handler.
         supervision?: { restart: string; limit: unknown; status: 'armed' | 'stopped' };
@@ -681,6 +688,22 @@ export function registerPTYHandlers(
         .map(s => ({
           id: s.id,
           shell: s.cmd,
+          // v2 RCA fix (axis B-lite): expose WMUX_SURFACE_ID (env) so the
+          // renderer's reconcile can rebind a stale ptyId to the live session on
+          // the SAME surface instead of clearing → self-create. Present only on
+          // Terminal-self-create-originated sessions (empty-pane funnel mints the
+          // surface after pty.create, so those carry no surfaceId — axis A's
+          // immediate save covers that path instead). `suspended` sessions are
+          // excluded from rebind targets: they hold NO live PTY (recovery
+          // tombstones), and actively binding a surface INTO one yields a blank,
+          // inputless pane (adversarial review). They stay in the id list so the
+          // non-destructive clear guards still see them.
+          ...(s.env?.[ENV_KEYS.SURFACE_ID] && s.state !== 'suspended'
+            ? { surfaceId: s.env[ENV_KEYS.SURFACE_ID] }
+            : {}),
+          // v2 RCA fix (axis B-lite): create time for newest-wins duplicate
+          // resolution in the renderer's rebind decision.
+          ...(s.createdAt ? { createdAt: s.createdAt } : {}),
           ...(s.supervision
             ? {
                 supervision: {

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -66,6 +66,10 @@ function isAllowedShell(shell: string): boolean {
 interface PtyCreateSupervisionInput {
   restart: 'on-failure' | 'always';
   limit?: { burst?: number; healthyUptimeSec?: number };
+  /** U-PERM: the consent-gated permission-restore bit computed by the layout
+   * funnel. Forwarded to the daemon so a reboot replay can restore the pane's
+   * captured permission mode. Daemon-only (like the rest of supervision). */
+  restorePermissionMode?: boolean;
 }
 
 type PtyCreateOptions = {
@@ -108,6 +112,9 @@ function resolveSupervisionPolicy(input: PtyCreateSupervisionInput): DaemonSuper
         PROJECT_SUPERVISION_HEALTHY_UPTIME_SEC_MAX,
       ),
     },
+    // U-PERM: forward the consent-gated restore bit (strict opt-in). Dropping it
+    // here would silently disable reboot permission restore end-to-end.
+    ...(input.restorePermissionMode === true ? { restorePermissionMode: true } : {}),
   };
 }
 

--- a/src/main/project/ProjectConfigStore.ts
+++ b/src/main/project/ProjectConfigStore.ts
@@ -48,6 +48,18 @@ export interface ProjectTrustRecord {
   /** sha256 (hex) of the wmux.json bytes the user reviewed when deciding. */
   contentHash: string;
   decidedAt: number;
+  /**
+   * Unattended reboot-survival consent (Minimal design 2026-07-01). The user
+   * gave a SEPARATE, explicit approval (a distinct checkbox in the trust dialog)
+   * for this project's declared unattended panes to restore their captured
+   * permission mode on reboot — up to and including `--dangerously-skip-permissions`.
+   * Bound to THESE bytes (same record, same contentHash): a changed file goes
+   * 'stale' and this no longer applies. Only meaningful when status='trusted';
+   * a 'denied' record forces this false. Absent on old records → false.
+   */
+  unattended?: boolean;
+  /** When the unattended consent was last set (audit; ms). */
+  unattendedDecidedAt?: number;
 }
 
 export interface ProjectTrustDb {
@@ -90,7 +102,16 @@ function normalizeRecord(raw: unknown): ProjectTrustRecord | undefined {
   if (r.status !== 'trusted' && r.status !== 'denied') return undefined;
   if (typeof r.contentHash !== 'string' || !/^[0-9a-f]{64}$/.test(r.contentHash)) return undefined;
   const decidedAt = typeof r.decidedAt === 'number' && Number.isFinite(r.decidedAt) ? r.decidedAt : 0;
-  return { status: r.status, contentHash: r.contentHash, decidedAt };
+  const rec: ProjectTrustRecord = { status: r.status, contentHash: r.contentHash, decidedAt };
+  // Unattended consent only survives on a 'trusted' record and only as a strict
+  // boolean true — a denied record or a garbage value can never grant it.
+  if (r.status === 'trusted' && r.unattended === true) {
+    rec.unattended = true;
+    if (typeof r.unattendedDecidedAt === 'number' && Number.isFinite(r.unattendedDecidedAt)) {
+      rec.unattendedDecidedAt = r.unattendedDecidedAt;
+    }
+  }
+  return rec;
 }
 
 interface ConfigCacheEntry {
@@ -212,7 +233,12 @@ export class ProjectConfigStore {
     else if (record.status === 'denied') trust = 'denied';
     else trust = record.contentHash === read.contentHash ? 'trusted' : 'stale';
 
-    return { found: true, root, configPath, config: read.config, contentHash: read.contentHash, trust };
+    // Surface the unattended consent ONLY when the live bytes are currently
+    // trusted — a 'stale' record's consent was for old content, so the funnel
+    // must not restore permissions against a file the user hasn't re-reviewed.
+    const unattended = trust === 'trusted' && record?.unattended === true;
+
+    return { found: true, root, configPath, config: read.config, contentHash: read.contentHash, trust, unattended };
   }
 
   // ── Trust DB ───────────────────────────────────────────────────────────────
@@ -255,16 +281,33 @@ export class ProjectConfigStore {
    * DISPLAYED — if the file changed while the dialog was open, the grant
    * binds to the reviewed bytes and the live file evaluates as 'stale',
    * never silently approving unseen content.
+   *
+   * `unattended` is the EXPLICIT (required) unattended reboot-survival consent.
+   * It is written as part of the SAME record (full replace, never a merge) so a
+   * re-trust of new/changed bytes can never carry a prior unattended grant
+   * forward silently — the caller must pass the checkbox's current value every
+   * time. A 'denied' decision forces it false.
    */
-  async setDecision(root: string, status: 'trusted' | 'denied', contentHash: string): Promise<void> {
+  async setDecision(
+    root: string,
+    status: 'trusted' | 'denied',
+    contentHash: string,
+    unattended: boolean,
+  ): Promise<void> {
     if (!/^[0-9a-f]{64}$/.test(contentHash)) throw new Error('Invalid content hash');
     const key = normalizeProjectRoot(root);
+    const now = Date.now();
     await this.mutate((db) => {
       const exists = Object.prototype.hasOwnProperty.call(db.projects, key);
       if (!exists && Object.keys(db.projects).length >= this.entryCap) {
         throw new Error('Project trust DB is full');
       }
-      db.projects[key] = { status, contentHash, decidedAt: Date.now() };
+      const record: ProjectTrustRecord = { status, contentHash, decidedAt: now };
+      if (status === 'trusted' && unattended === true) {
+        record.unattended = true;
+        record.unattendedDecidedAt = now;
+      }
+      db.projects[key] = record;
     });
   }
 

--- a/src/main/project/__tests__/ProjectConfigStore.test.ts
+++ b/src/main/project/__tests__/ProjectConfigStore.test.ts
@@ -106,7 +106,7 @@ describe('getState — config + trust evaluation', () => {
     writeConfig(proj, VALID);
     const store = makeStore();
     const s1 = await store.getState(proj);
-    await store.setDecision(s1.root!, 'trusted', s1.contentHash!);
+    await store.setDecision(s1.root!, 'trusted', s1.contentHash!, false);
     const s2 = await store.getState(proj);
     expect(s2.trust).toBe('trusted');
   });
@@ -116,7 +116,7 @@ describe('getState — config + trust evaluation', () => {
     writeConfig(proj, VALID);
     const store = makeStore();
     const s1 = await store.getState(proj);
-    await store.setDecision(s1.root!, 'trusted', s1.contentHash!);
+    await store.setDecision(s1.root!, 'trusted', s1.contentHash!, false);
     // Edit the file — e.g. a malicious PR changed a command.
     writeConfig(proj, { ...VALID, commands: [{ id: 'dev', title: 'Dev', command: 'evil.exe' }] });
     const s2 = await store.getState(proj);
@@ -128,7 +128,7 @@ describe('getState — config + trust evaluation', () => {
     writeConfig(proj, VALID);
     const store = makeStore();
     const s1 = await store.getState(proj);
-    await store.setDecision(s1.root!, 'denied', s1.contentHash!);
+    await store.setDecision(s1.root!, 'denied', s1.contentHash!, false);
     writeConfig(proj, { ...VALID, commands: [{ id: 'x', title: 'X', command: 'other' }] });
     const s2 = await store.getState(proj);
     expect(s2.trust).toBe('denied');
@@ -139,7 +139,7 @@ describe('getState — config + trust evaluation', () => {
     writeConfig(proj, VALID);
     const store = makeStore();
     const s1 = await store.getState(proj);
-    await store.setDecision(s1.root!, 'trusted', s1.contentHash!);
+    await store.setDecision(s1.root!, 'trusted', s1.contentHash!, false);
     await store.clearDecision(s1.root!);
     const s2 = await store.getState(proj);
     expect(s2.trust).toBe('untrusted');
@@ -153,7 +153,7 @@ describe('getState — config + trust evaluation', () => {
     // File changes while the approval dialog is open…
     writeConfig(proj, { ...VALID, commands: [{ id: 'dev', title: 'Dev', command: 'evil.exe' }] });
     // …user approves what they SAW (old hash).
-    await store.setDecision(s1.root!, 'trusted', s1.contentHash!);
+    await store.setDecision(s1.root!, 'trusted', s1.contentHash!, false);
     const s2 = await store.getState(proj);
     expect(s2.trust).toBe('stale'); // live bytes ≠ reviewed bytes
   });
@@ -163,14 +163,14 @@ describe('getState — config + trust evaluation', () => {
     writeConfig(proj, VALID);
     const store = makeStore();
     const s1 = await store.getState(proj);
-    await store.setDecision(s1.root!, 'trusted', s1.contentHash!);
+    await store.setDecision(s1.root!, 'trusted', s1.contentHash!, false);
     const fresh = makeStore();
     const s2 = await fresh.getState(proj);
     expect(s2.trust).toBe('trusted');
   });
 
   it('rejects malformed content hashes', async () => {
-    await expect(makeStore().setDecision(tmpRoot, 'trusted', 'nope')).rejects.toThrow();
+    await expect(makeStore().setDecision(tmpRoot, 'trusted', 'nope', false)).rejects.toThrow();
   });
 
   it('refuses NEW roots past the entry cap but allows updates', async () => {
@@ -179,11 +179,11 @@ describe('getState — config + trust evaluation', () => {
     const store = new ProjectConfigStore(trustPath, { entryCap: 4 });
     const hash = createHash('sha256').update('x').digest('hex');
     for (let i = 0; i < 4; i++) {
-      await store.setDecision(path.join(tmpRoot, `p${i}`), 'trusted', hash);
+      await store.setDecision(path.join(tmpRoot, `p${i}`), 'trusted', hash, false);
     }
-    await expect(store.setDecision(path.join(tmpRoot, 'overflow'), 'trusted', hash)).rejects.toThrow(/full/);
+    await expect(store.setDecision(path.join(tmpRoot, 'overflow'), 'trusted', hash, false)).rejects.toThrow(/full/);
     // Existing root stays updatable.
-    await expect(store.setDecision(path.join(tmpRoot, 'p0'), 'denied', hash)).resolves.toBeUndefined();
+    await expect(store.setDecision(path.join(tmpRoot, 'p0'), 'denied', hash, false)).resolves.toBeUndefined();
   });
 
   it('survives a corrupt trust file', async () => {
@@ -215,5 +215,71 @@ describe('normalizeProjectRoot', () => {
     if (process.platform === 'win32') {
       expect(normalizeProjectRoot(tmpRoot.toUpperCase())).toBe(b);
     }
+  });
+});
+
+describe('setDecision — unattended reboot-survival consent (U-PERM)', () => {
+  it('persists and surfaces unattended consent for trusted bytes', async () => {
+    const proj = path.join(tmpRoot, 'proj');
+    writeConfig(proj, VALID);
+    const store = makeStore();
+    const s1 = await store.getState(proj);
+    await store.setDecision(s1.root!, 'trusted', s1.contentHash!, true);
+    const s2 = await store.getState(proj);
+    expect(s2.trust).toBe('trusted');
+    expect(s2.unattended).toBe(true);
+  });
+
+  it('omits unattended when the checkbox was not ticked', async () => {
+    const proj = path.join(tmpRoot, 'proj');
+    writeConfig(proj, VALID);
+    const store = makeStore();
+    const s1 = await store.getState(proj);
+    await store.setDecision(s1.root!, 'trusted', s1.contentHash!, false);
+    expect((await store.getState(proj)).unattended).toBe(false);
+  });
+
+  it('re-trust with consent OFF clears a prior grant — no silent carry-forward (codex P2)', async () => {
+    const proj = path.join(tmpRoot, 'proj');
+    writeConfig(proj, VALID);
+    const store = makeStore();
+    const s1 = await store.getState(proj);
+    await store.setDecision(s1.root!, 'trusted', s1.contentHash!, true);
+    expect((await store.getState(proj)).unattended).toBe(true);
+    // Same bytes, re-trusted WITHOUT the checkbox → full-record replace drops it.
+    await store.setDecision(s1.root!, 'trusted', s1.contentHash!, false);
+    expect((await store.getState(proj)).unattended).toBe(false);
+  });
+
+  it('does not surface unattended while the file is stale (consent bound to old bytes)', async () => {
+    const proj = path.join(tmpRoot, 'proj');
+    writeConfig(proj, VALID);
+    const store = makeStore();
+    const s1 = await store.getState(proj);
+    await store.setDecision(s1.root!, 'trusted', s1.contentHash!, true);
+    writeConfig(proj, { ...VALID, commands: [{ id: 'dev', title: 'Dev', command: 'other' }] });
+    const s2 = await store.getState(proj);
+    expect(s2.trust).toBe('stale');
+    expect(s2.unattended).toBe(false); // must not apply to un-reviewed bytes
+  });
+
+  it('a denied decision forces unattended false even when requested', async () => {
+    const proj = path.join(tmpRoot, 'proj');
+    writeConfig(proj, VALID);
+    const store = makeStore();
+    const s1 = await store.getState(proj);
+    await store.setDecision(s1.root!, 'denied', s1.contentHash!, true);
+    const s2 = await store.getState(proj);
+    expect(s2.trust).toBe('denied');
+    expect(s2.unattended ?? false).toBe(false);
+  });
+
+  it('persists unattended across store instances', async () => {
+    const proj = path.join(tmpRoot, 'proj');
+    writeConfig(proj, VALID);
+    const store = makeStore();
+    const s1 = await store.getState(proj);
+    await store.setDecision(s1.root!, 'trusted', s1.contentHash!, true);
+    expect((await makeStore().getState(proj)).unattended).toBe(true);
   });
 });

--- a/src/main/session/SessionManager.ts
+++ b/src/main/session/SessionManager.ts
@@ -1,4 +1,5 @@
 import { app } from 'electron';
+import fs from 'node:fs';
 import path from 'node:path';
 import type { SessionData } from '../../shared/types';
 import type { PersistedShape } from '../metadata/MetadataStore';
@@ -77,6 +78,9 @@ export class SessionManager {
         rotationEnabled: true,
       });
       this.pendingData = null;
+      // v2 RCA fix (axis A ③): log exactly which ptyIds this snapshot commits so
+      // a fossil-vs-fresh persistence question is answerable from the log alone.
+      console.log(`[SessionManager] save: ${SessionManager.summarizePtyIds(data)}`);
     } catch (err) {
       console.error('[SessionManager] Failed to save session:', err);
     }
@@ -156,6 +160,10 @@ export class SessionManager {
           validate: SessionManager.isSessionData,
           rotationEnabled: true,
         });
+        // v2 RCA fix (axis A ③): session-end's LAST write must be observable too
+        // — same ptyId summary as save()/load() so a reboot postmortem can see
+        // exactly what hit disk last.
+        console.log(`[SessionManager] flushSync: ${SessionManager.summarizePtyIds(data)}`);
       } catch (err) {
         console.error('[SessionManager] flushSync immediate write failed:', err);
       }
@@ -163,6 +171,16 @@ export class SessionManager {
   }
 
   load(): SessionData | null {
+    // v2 RCA fix (adversarial review): distinguish "no session file" (true
+    // first launch → null) from "file exists but unreadable" (transient AV/
+    // indexer lock at boot). The old catch collapsed both to null; the renderer
+    // treats null as FIRST LAUNCH, sets sessionLoadedRef=true, and the very
+    // next event-driven save would overwrite the user's good session.json with
+    // the default empty workspace. Rethrowing instead makes the IPC reject →
+    // the renderer's startup catch runs the clearAllPtyState fallback with
+    // sessionLoadedRef=false, which gates ALL saves — the on-disk layout
+    // survives for the next boot.
+    const hadFile = fs.existsSync(this.filePath);
     try {
       // T7: wire the lazy-migration hook. Production registry ships
       // as identity (v1, no steps) and `createMigrator` safely
@@ -174,14 +192,64 @@ export class SessionManager {
         SESSION_DATA_REGISTRY,
         this.filePath,
       );
-      return atomicReadJSONSync<SessionData>(this.filePath, {
+      const loaded = atomicReadJSONSync<SessionData>(this.filePath, {
         validate: SessionManager.isSessionData,
         migrator,
       });
+      // The atomic-read helper swallows read/validate failures internally
+      // (falls through the .bak chain, then returns null) — so a locked or
+      // fully-corrupt-with-backups file surfaces as null, indistinguishable
+      // from first launch. Promote that to an error when the file EXISTS:
+      // refusing to load is recoverable (next boot retries; the file is
+      // preserved for salvage), silently treating it as first launch is not
+      // (the next save overwrites the user's layout with the default).
+      if (loaded === null && hadFile) {
+        throw new Error('session.json exists but could not be read/validated — refusing to treat as first launch');
+      }
+      // v2 RCA fix (axis A ③): log which ptyIds we actually loaded. Correlated
+      // with the daemon's recovery log, a mismatch here is the fossil-reattach
+      // signature (session.json holds a ptyId the daemon no longer has).
+      console.log(`[SessionManager] load from ${path.basename(this.filePath)}: ${loaded ? SessionManager.summarizePtyIds(loaded) : '(no session file)'}`);
+      return loaded;
     } catch (err) {
       console.error('[SessionManager] Failed to load session:', err);
+      if (hadFile) throw err;
       return null;
     }
+  }
+
+  /** Truncation caps for the ptyId log summary — one knob, three call sites
+   *  (save/load/flushSync) so the correlated log lines can never drift. */
+  private static readonly LOG_MAX_IDS = 6;
+  private static readonly LOG_ID_PREFIX = 16;
+
+  /** One-line ptyId summary shared by save()/load()/flushSync() logging. */
+  private static summarizePtyIds(data: SessionData): string {
+    const ids = SessionManager.collectPtyIds(data);
+    const shown = ids.slice(0, SessionManager.LOG_MAX_IDS).map((i) => i.slice(0, SessionManager.LOG_ID_PREFIX)).join(', ');
+    return `${ids.length} pty [${shown}${ids.length > SessionManager.LOG_MAX_IDS ? ', …' : ''}]`;
+  }
+
+  /**
+   * v2 RCA fix (axis A ③): enumerate every persisted surface ptyId in a
+   * SessionData snapshot. Used only for save/load logging so fossil-ptyId
+   * persistence and `.bak`-fallback resurrection are observable in the log.
+   */
+  private static collectPtyIds(data: SessionData): string[] {
+    const ids: string[] = [];
+    const walk = (pane: unknown): void => {
+      if (!pane || typeof pane !== 'object') return;
+      const p = pane as { type?: string; surfaces?: Array<{ ptyId?: string }>; children?: unknown[] };
+      if (p.type === 'leaf') {
+        for (const s of p.surfaces ?? []) if (s.ptyId) ids.push(s.ptyId);
+      } else if (Array.isArray(p.children)) {
+        for (const c of p.children) walk(c);
+      }
+    };
+    for (const ws of data.workspaces ?? []) {
+      walk((ws as { rootPane?: unknown }).rootPane);
+    }
+    return ids;
   }
 
   /**

--- a/src/main/session/__tests__/SessionManager.rebootPersistence.test.ts
+++ b/src/main/session/__tests__/SessionManager.rebootPersistence.test.ts
@@ -1,0 +1,110 @@
+/**
+ * v2 RCA fix (reboot-reattach, axis A) — SessionManager persistence contract.
+ *
+ * 1. load() distinguishes "no file" (first launch → null) from "file exists
+ *    but unreadable" (transient AV/indexer lock → THROW). The old
+ *    collapse-to-null made the renderer treat a locked session.json as a first
+ *    launch and overwrite it with the default empty workspace (adversarial
+ *    review P2 — data loss).
+ * 2. save()/load() log a ptyId summary (axis A ③ observability): the
+ *    fossil-vs-fresh question after a reboot must be answerable from the log.
+ *
+ * Electron `app.getPath('userData')` is mocked to a per-test tmpdir (same
+ * pattern as SessionManager.metadata.test.ts).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const tmpRoot = path.join(os.tmpdir(), 'wmux-sessionmgr-reboot-test');
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => tmpRoot),
+  },
+}));
+
+import { SessionManager } from '../SessionManager';
+import type { SessionData } from '../../../shared/types';
+
+function freshDir(): void {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  fs.mkdirSync(tmpRoot, { recursive: true });
+}
+
+/** Nested-branch SessionData with N ptyId-bearing surfaces (+ one ptyId-less). */
+function makeSession(ptyIds: string[]): SessionData {
+  const leaves = ptyIds.map((id, i) => ({
+    id: `pane-${i}`,
+    type: 'leaf' as const,
+    surfaces: [
+      { id: `surf-${i}`, ptyId: id, title: 't', shell: 'pwsh', cwd: 'D:/x' },
+      ...(i === 0 ? [{ id: 'surf-empty', ptyId: '', title: 'e', shell: 'pwsh', cwd: 'D:/x' }] : []),
+    ],
+    activeSurfaceId: `surf-${i}`,
+  }));
+  const rootPane = leaves.length === 1
+    ? leaves[0]
+    : { id: 'branch-0', type: 'branch' as const, direction: 'horizontal' as const, children: leaves };
+  return {
+    workspaces: [{ id: 'ws-1', name: 'W1', rootPane, activePaneId: leaves[0].id } as SessionData['workspaces'][number]],
+    activeWorkspaceId: 'ws-1',
+    sidebarVisible: true,
+  };
+}
+
+describe('SessionManager — reboot persistence contract', () => {
+  beforeEach(freshDir);
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('load() returns null when session.json does not exist (true first launch)', () => {
+    const sm = new SessionManager();
+    expect(sm.load()).toBeNull();
+  });
+
+  it('load() THROWS when session.json exists but is unreadable — never silently null', () => {
+    const sm = new SessionManager();
+    sm.save(makeSession(['pty-real']));
+    // Simulate a transient read failure (AV/indexer lock at boot).
+    const readSpy = vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
+      throw Object.assign(new Error('EBUSY: resource busy or locked'), { code: 'EBUSY' });
+    });
+    try {
+      expect(() => sm.load()).toThrow();
+    } finally {
+      readSpy.mockRestore();
+    }
+    // The on-disk layout survives untouched for the next boot.
+    expect(fs.existsSync(path.join(tmpRoot, 'session.json'))).toBe(true);
+  });
+
+  it('save() → load() round-trips and logs the ptyId summary on both sides', () => {
+    const logSpy = vi.spyOn(console, 'log');
+    const sm = new SessionManager();
+    sm.save(makeSession(['pty-aaaa-1111', 'pty-bbbb-2222']));
+
+    const saveLine = logSpy.mock.calls.map((c) => String(c[0])).find((m) => m.includes('[SessionManager] save:'));
+    expect(saveLine).toContain('2 pty');
+    expect(saveLine).toContain('pty-aaaa-1111');
+    expect(saveLine).toContain('pty-bbbb-2222');
+
+    const loaded = sm.load();
+    expect(loaded).not.toBeNull();
+    const loadLine = logSpy.mock.calls.map((c) => String(c[0])).find((m) => m.includes('[SessionManager] load'));
+    expect(loadLine).toContain('2 pty');
+  });
+
+  it('ptyId summary truncates beyond 6 ids but reports the full count', () => {
+    const logSpy = vi.spyOn(console, 'log');
+    const sm = new SessionManager();
+    sm.save(makeSession(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8']));
+    const saveLine = logSpy.mock.calls.map((c) => String(c[0])).find((m) => m.includes('[SessionManager] save:'));
+    expect(saveLine).toContain('8 pty');
+    expect(saveLine).toContain('…');
+    expect(saveLine).not.toContain('p7');
+  });
+});

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -44,7 +44,7 @@ const electronAPI = {
     // wmux.json leaf — `exec` runs the command as the pane's ROOT process and
     // `supervision` arms the daemon's PaneSupervisor (daemon mode only; the
     // local branch ignores them with a one-time warning toast).
-    create: (options?: { shell?: string; cwd?: string; cols?: number; rows?: number; workspaceId?: string; surfaceId?: string; env?: Record<string, string>; initialCommand?: string; exec?: string; supervision?: { restart: 'on-failure' | 'always'; limit?: { burst?: number; healthyUptimeSec?: number } } }) =>
+    create: (options?: { shell?: string; cwd?: string; cols?: number; rows?: number; workspaceId?: string; surfaceId?: string; env?: Record<string, string>; initialCommand?: string; exec?: string; supervision?: { restart: 'on-failure' | 'always'; limit?: { burst?: number; healthyUptimeSec?: number }; restorePermissionMode?: boolean } }) =>
       ipcRenderer.invoke(IPC.PTY_CREATE, options),
     write: (id: string, data: string) => {
       ipcRenderer.send(IPC.PTY_WRITE, id, data);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -280,8 +280,8 @@ const electronAPI = {
   projectConfig: {
     get: (cwd: string) =>
       ipcRenderer.invoke(IPC.PROJECT_CONFIG_GET, cwd) as Promise<import('../shared/wmuxProjectConfig').ProjectConfigState>,
-    setTrust: (root: string, decision: 'trusted' | 'denied' | 'clear', contentHash?: string) =>
-      ipcRenderer.invoke(IPC.PROJECT_CONFIG_SET_TRUST, root, decision, contentHash) as Promise<{ ok: boolean }>,
+    setTrust: (root: string, decision: 'trusted' | 'denied' | 'clear', contentHash?: string, unattended?: boolean) =>
+      ipcRenderer.invoke(IPC.PROJECT_CONFIG_SET_TRUST, root, decision, contentHash, unattended === true) as Promise<{ ok: boolean }>,
   },
   // Plugin host (B-1). `list` returns loaded UI plugin summaries + load
   // failures; `rpc` forwards a host-validated bridge request from a plugin

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -57,7 +57,10 @@ const electronAPI = {
     // sessions — the renderer uses it to hydrate its supervision slice on boot
     // and daemon-reconnect. Absent in local mode and for unsupervised panes.
     list: () =>
-      ipcRenderer.invoke(IPC.PTY_LIST) as Promise<{ id: string; shell: string; supervision?: { status: 'armed' | 'stopped'; restartCount: number }; resumeAgent?: string; resumeBinding?: ResumeBinding }[]>,
+      // `surfaceId` (axis B, reboot-reattach): present only on sessions created
+      // WITH a WMUX_SURFACE_ID (Terminal self-create path); reconcile uses it to
+      // rebind a stale ptyId to the surviving session after a reboot.
+      ipcRenderer.invoke(IPC.PTY_LIST) as Promise<{ id: string; shell: string; surfaceId?: string; createdAt?: string; supervision?: { status: 'armed' | 'stopped'; restartCount: number }; resumeAgent?: string; resumeBinding?: ResumeBinding }[]>,
     reconnect: (id: string) =>
       // RCA A1 — `transient` distinguishes a recoverable failure (pipe not
       // writable yet, RPC threw during a handler-swap window) from a permanent

--- a/src/renderer/components/FleetView/FleetCard.tsx
+++ b/src/renderer/components/FleetView/FleetCard.tsx
@@ -42,13 +42,24 @@ export default function FleetCard({ card, focused, onJump, tail }: FleetCardProp
   const activity = card.activity?.trim() || undefined;
   const showTail =
     !activity && card.surfaceType === 'terminal' && !!tail && tail.length > 0;
+  // X8 supervision chip: a declared/unattended agent shows it's armed (⟳, plus
+  // the restart count once it has restarted) or that the runaway guard tripped
+  // (⟳! red — the supervisor gave up, a human is needed). Mirrors the pane badge
+  // so the cockpit reads the same as the pane header. Absent → no chip.
+  const supervision = card.supervision;
+  const supervisionStopped = supervision?.status === 'stopped';
+  const supervisionLabel = supervision
+    ? `${supervisionStopped ? 'supervision stopped' : 'supervised'}, ${supervision.restartCount} restart${
+        supervision.restartCount === 1 ? '' : 's'
+      }`
+    : '';
 
   return (
     <button
       type="button"
       role="option"
       aria-selected={focused}
-      aria-label={`${displayName}, ${t(icon.labelKey)}, ${card.workspaceName}`}
+      aria-label={`${displayName}, ${t(icon.labelKey)}, ${card.workspaceName}${supervision ? `, ${supervisionLabel}` : ''}`}
       tabIndex={focused ? 0 : -1}
       onClick={onJump}
       data-fleet-card
@@ -76,6 +87,17 @@ export default function FleetCard({ card, focused, onJump, tail }: FleetCardProp
         <span className="flex-1 min-w-0 truncate text-[13px] font-medium text-[var(--text-main)]">
           {displayName}
         </span>
+        {supervision && (
+          <span
+            data-fleet-supervision
+            data-supervision-status={supervision.status}
+            className="flex-shrink-0 text-[10px] font-mono"
+            style={{ color: supervisionStopped ? 'var(--accent-red)' : 'var(--text-subtle)' }}
+            title={supervisionLabel}
+          >
+            {`${supervisionStopped ? '⟳!' : '⟳'}${supervision.restartCount > 0 ? ` ${supervision.restartCount}` : ''}`}
+          </span>
+        )}
         <span className="flex-shrink-0 text-[10px] font-mono" style={{ color: icon.dotVar }}>
           {t(icon.labelKey)}
         </span>

--- a/src/renderer/components/FleetView/FleetView.tsx
+++ b/src/renderer/components/FleetView/FleetView.tsx
@@ -40,6 +40,9 @@ export default function FleetView() {
   // here so the selector re-runs when an agent's PostToolUse activity changes.
   const surfaceActivity = useStore((s) => s.surfaceActivity);
   const paneLabel = useStore((s) => s.paneLabel);
+  // X8 supervision mirror — subscribed here so the selector re-runs when a
+  // supervised pane arms/stops or its restart count changes.
+  const supervisionByPtyId = useStore((s) => s.supervisionByPtyId);
 
   // S-C2: tab lives in uiSlice (not FleetView-local) so the A2A / MCP approval
   // modals can suppress themselves while the inbox tab is open (AppLayout delta
@@ -69,8 +72,8 @@ export default function FleetView() {
   // trees or the per-pty attention map change (the two inputs the selector
   // reads), not on every unrelated store mutation.
   const panes = useMemo(
-    () => sortFleetPanes(selectFleetPanes({ workspaces, surfaceAgentStatus, surfaceActivity, paneLabel }), fleetSortMode),
-    [workspaces, surfaceAgentStatus, surfaceActivity, paneLabel, fleetSortMode],
+    () => sortFleetPanes(selectFleetPanes({ workspaces, surfaceAgentStatus, surfaceActivity, paneLabel, supervisionByPtyId }), fleetSortMode),
+    [workspaces, surfaceAgentStatus, surfaceActivity, paneLabel, supervisionByPtyId, fleetSortMode],
   );
   const needsCount = useMemo(() => countNeedsAttention(panes), [panes]);
 

--- a/src/renderer/components/FleetView/__tests__/FleetCard.test.tsx
+++ b/src/renderer/components/FleetView/__tests__/FleetCard.test.tsx
@@ -88,3 +88,29 @@ describe('FleetCard — activity line vs tail fallback', () => {
     expect(html).toContain('browser'); // capitalized via CSS, raw text is 'browser'
   });
 });
+
+describe('FleetCard — X8 supervision chip', () => {
+  it('renders an armed chip with the restart count', () => {
+    const html = render({ card: card({ supervision: { status: 'armed', restartCount: 3 } }) });
+    expect(html).toContain('data-fleet-supervision');
+    expect(html).toContain('data-supervision-status="armed"');
+    expect(html).toContain('⟳ 3');
+  });
+
+  it('omits the count on an armed pane with zero restarts', () => {
+    const html = render({ card: card({ supervision: { status: 'armed', restartCount: 0 } }) });
+    expect(html).toContain('data-fleet-supervision');
+    expect(html).not.toContain('⟳ 0');
+  });
+
+  it('renders a stopped (guard-tripped) chip in red', () => {
+    const html = render({ card: card({ supervision: { status: 'stopped', restartCount: 5 } }) });
+    expect(html).toContain('data-supervision-status="stopped"');
+    expect(html).toContain('⟳!');
+    expect(html).toContain('var(--accent-red)');
+  });
+
+  it('renders no supervision chip when the pane is unsupervised', () => {
+    expect(render({ card: card() })).not.toContain('data-fleet-supervision');
+  });
+});

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -965,6 +965,9 @@ export default function AppLayout() {
                   healthyUptimeSec:
                     projectSeed?.restartLimit?.healthyUptimeSec ?? PROJECT_SUPERVISION_DEFAULT_HEALTHY_UPTIME_SEC,
                 },
+                // U-PERM: consent-gated at layout-apply (buildTree). Included only
+                // when true so unsupervised/unconsented panes persist no bit.
+                ...(projectSeed?.restorePermissionMode === true ? { restorePermissionMode: true } : {}),
               },
             }
           : (seedCommand !== undefined ? { initialCommand: seedCommand } : {});

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -6,6 +6,8 @@ import { useT } from '../../hooks/useT';
 import Sidebar from '../Sidebar/Sidebar';
 import MiniSidebar from '../Sidebar/MiniSidebar';
 import PaneContainer from '../Pane/PaneContainer';
+import { registerSessionSaver, saveSessionNow } from '../../utils/sessionSaveBridge';
+import { resolveReconcileRebind } from '../../hooks/resolveReconcileRebind';
 import StatusBar from '../StatusBar/StatusBar';
 import NotificationPanel from '../Notification/NotificationPanel';
 import CommandPalette from '../Palette/CommandPalette';
@@ -449,7 +451,7 @@ export default function AppLayout() {
     }
     const run = (async () => {
       try {
-        const listResult = await ipcInvoke<{ id: string }[]>(() =>
+        const listResult = await ipcInvoke<{ id: string; surfaceId?: string; createdAt?: string }[]>(() =>
           window.electronAPI.pty.list()
         );
         if (!listResult.ok) {
@@ -556,9 +558,15 @@ export default function AppLayout() {
         // correlated with the daemon's pty.list count.
         if (absentCandidates.length > 0 && !signal?.aborted) {
           const firstAbsent = absentCandidates.map((c) => c.ptyId);
+          // v2 RCA fix (axis B-lite hardening): capture the re-query's FULL
+          // payload. Rebind targets must come from the freshest snapshot — a
+          // session that died between the two snapshots must not be picked
+          // (review consensus: codex P2 + testing + adversarial).
+          let secondSnapshot: { id: string; surfaceId?: string; createdAt?: string }[] | null = null;
           const toClear = await resolvePtyIdsToClear(firstAbsent, {
             reList: async () => {
-              const r = await ipcInvoke<{ id: string }[]>(() => window.electronAPI.pty.list());
+              const r = await ipcInvoke<{ id: string; surfaceId?: string; createdAt?: string }[]>(() => window.electronAPI.pty.list());
+              if (r.ok) secondSnapshot = r.data;
               return r.ok
                 ? { ok: true, ids: new Set(r.data.map((p: { id: string }) => p.id)) }
                 : { ok: false };
@@ -566,12 +574,46 @@ export default function AppLayout() {
             isCurrent: () => !signal?.aborted,
             log: (level, message) => (level === 'warn' ? console.warn(message) : console.log(message)),
           });
-          for (const c of absentCandidates) {
+          // v2 RCA fix (axis B-lite): decide clear-vs-rebind per candidate (pure,
+          // unit-tested in resolveReconcileRebind.test.ts). Acts ONLY on ptyIds
+          // already judged dead (in toClear), so it never swaps a live-attached
+          // ptyId (codex #5). A live session on the SAME surfaceId → rebind
+          // (recovers the reboot case where the session survived under a new
+          // ptyId); no match → clear→self-create (axis A's immediate save covers
+          // empty-pane-origin sessions that carry no surfaceId). Rebind targets
+          // come from the SECOND snapshot when the re-query succeeded.
+          const rebindActions = resolveReconcileRebind(absentCandidates, toClear, secondSnapshot ?? activePtys);
+          for (const a of rebindActions) {
             if (signal?.aborted) break;
-            if (toClear.has(c.ptyId)) {
-              console.warn(`[lifecycle] reconcile clearing ptyId=${c.ptyId} surface=${c.surfaceId} (absent from TWO daemon snapshots) → Terminal self-create`);
-              useStore.getState().updateSurfacePtyId(c.paneId, c.surfaceId, '');
+            // CAS guard (adversarial review): the decision was computed from a
+            // snapshot ≥600ms old. On a late reconcile, useTerminal's own
+            // reattach path may have already cleared this surface and
+            // self-created a FRESH ptyId — stomping it would orphan a live
+            // session (or wrong-bind). Apply only if the surface still holds
+            // the exact stale ptyId the decision was made against.
+            const wsNow = useStore.getState().workspaces;
+            let currentPtyId: string | undefined;
+            for (const ws of wsNow) {
+              const walk = (p: Pane): boolean => {
+                if (p.type === 'leaf') {
+                  if (p.id !== a.paneId) return false;
+                  currentPtyId = p.surfaces.find((s) => s.id === a.surfaceId)?.ptyId;
+                  return true;
+                }
+                return p.children.some(walk);
+              };
+              if (walk(ws.rootPane)) break;
             }
+            if (currentPtyId !== a.stalePtyId) {
+              console.warn(`[lifecycle] reconcile ${a.kind} SKIPPED surface=${a.surfaceId}: ptyId moved (${a.stalePtyId} → ${currentPtyId ?? 'gone'}) since snapshot`);
+              continue;
+            }
+            if (a.kind === 'rebind') {
+              console.warn(`[lifecycle] reconcile REBIND surface=${a.surfaceId} stale=${a.stalePtyId} → live=${a.newPtyId} (surfaceId match, dead ptyId recovered)`);
+            } else {
+              console.warn(`[lifecycle] reconcile clearing ptyId=${a.stalePtyId} surface=${a.surfaceId} (absent from TWO daemon snapshots, no surface match) → Terminal self-create`);
+            }
+            useStore.getState().updateSurfacePtyId(a.paneId, a.surfaceId, a.newPtyId);
           }
         }
         console.log('[AppLayout] Reconciliation complete');
@@ -674,6 +716,16 @@ export default function AppLayout() {
             }, RECONCILE_TIMEOUT_MS)
           ),
         ]);
+        // v2 RCA fix (axis A): persist the reconciled layout ON SUCCESS ONLY.
+        // Rebinds/clears from a completed reconcile must reach disk now — not
+        // wait for the 5s tick a reboot could pre-empt. Deliberately NOT in the
+        // finally: the catch path just ran clearAllPtyState() as a blank-slate
+        // fallback, and persisting THAT would wipe good ptyIds from disk. Left
+        // unsaved, the old on-disk ptyIds can still reattach next boot (daemon
+        // recovery replays the same ids) — strictly better (codex P1).
+        // Gen-guarded like clearAllPtyState: a superseded startup must not
+        // persist a snapshot the fresher run is still reconciling.
+        if (gen === startupGenRef.current) saveSessionNow();
       } catch (err) {
         // Fix 0 explicit fallback. Reconcile aborted, timed out, session.load
         // rejected, daemon.whenReady rejected, or any other startup throw.
@@ -838,7 +890,9 @@ export default function AppLayout() {
     };
   }, []);
 
-  // Save session on beforeunload (with scrollback dump — sync fire-and-forget)
+  // Session saver: registered on the sessionSaveBridge (event-driven immediate
+  // saves — the axis-A reboot fix) + bound to beforeunload (scrollback dump,
+  // sync fire-and-forget legacy exit save).
   useEffect(() => {
     const saveSession = () => {
       const dumped = dumpScrollbackBuffersSync();
@@ -846,8 +900,32 @@ export default function AppLayout() {
       window.electronAPI.session.save(data);
     };
 
-    window.addEventListener('beforeunload', saveSession);
-    return () => window.removeEventListener('beforeunload', saveSession);
+    // v2 RCA fix (axis A): register the saver for event-driven immediate
+    // persistence. beforeunload is unreliable on OS reboot (the process is
+    // force-killed before it fires), so ptyId-changing sites (self-create,
+    // addSurface, reconcile completion) call saveSessionNow() to flush right away
+    // — closing the "vulnerable 5s window" between a self-create and the next
+    // periodic tick, which is exactly where a reboot loses the new ptyId.
+    //
+    // GUARDED like the 5s periodic save: if session.load() failed at startup,
+    // the store still holds the DEFAULT empty workspace — an event-driven save
+    // (failed startup also flips paneGate and self-creates panes) would sync-
+    // overwrite the user's good session.json with that default. Same data-loss
+    // class the periodic tick's sessionLoadedRef guard exists to prevent.
+    const saveSessionGuarded = () => {
+      if (!sessionLoadedRef.current) return;
+      saveSession();
+    };
+    registerSessionSaver(saveSessionGuarded);
+    // beforeunload gets the SAME guard (adversarial review): an exit while
+    // session.load() is in flight / failed must not overwrite a good
+    // session.json with the default workspace either. First launch is safe —
+    // load()===null sets sessionLoadedRef=true before any unload can fire.
+    window.addEventListener('beforeunload', saveSessionGuarded);
+    return () => {
+      window.removeEventListener('beforeunload', saveSessionGuarded);
+      registerSessionSaver(null);
+    };
   }, []);
 
   // Periodic session save — protects against crashes.
@@ -1001,6 +1079,8 @@ export default function AppLayout() {
           return;
         }
         const shellName = created.shell ? shellDisplayName(created.shell) : 'Terminal';
+        // v2 RCA fix (axis A): the immediate persist now lives INSIDE addSurface
+        // (surfaceSlice centralization) so every binding call site gets it.
         addSurface(paneId, created.id, shellName, created.cwd || '');
         // Set initial CWD in workspace metadata from first pane
         if (created.cwd) {

--- a/src/renderer/components/Layout/__tests__/appLayout.sessionSaveInvariants.test.ts
+++ b/src/renderer/components/Layout/__tests__/appLayout.sessionSaveInvariants.test.ts
@@ -1,0 +1,60 @@
+/**
+ * v2 RCA fix (reboot-reattach, axis A) — AppLayout session-save invariants.
+ *
+ * Structural test (house pattern: sessionEnd.daemonShutdown.test.ts,
+ * pty.handler.resize-retry.test.ts): AppLayout has no jsdom fixture, and these
+ * invariants encode review-confirmed data-loss/correctness decisions that a
+ * refactor could silently undo with every unit test staying green:
+ *
+ *   1. The startup save runs on the SUCCESS path only, generation-guarded —
+ *      NOT in the finally (the catch just ran clearAllPtyState; persisting
+ *      that wipes good ptyIds from disk — codex P1).
+ *   2. The registered saver + beforeunload are BOTH gated on sessionLoadedRef
+ *      (a failed session.load must never let the default empty workspace
+ *      overwrite a good session.json — Claude adversarial P2).
+ *   3. Rebind/clear actions apply through a compare-and-swap on the surface's
+ *      CURRENT ptyId (a ≥600ms-stale snapshot must not stomp a ptyId that
+ *      useTerminal's own reattach already replaced — Claude adversarial P2).
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+describe('AppLayout — axis A session-save invariants', () => {
+  const appLayoutPath = path.join(__dirname, '..', 'AppLayout.tsx');
+  const source = fs.readFileSync(appLayoutPath, 'utf-8');
+
+  function startupRegion(): string {
+    const start = source.indexOf('// 앱 시작 시 세션 복원');
+    expect(start, 'startup restore effect not found').toBeGreaterThanOrEqual(0);
+    const end = source.indexOf('First-run wizard', start);
+    return source.slice(start, end > 0 ? end : start + 8000);
+  }
+
+  it('startup save is success-only + generation-guarded, and NOT in the finally', () => {
+    const region = startupRegion();
+    expect(region).toMatch(/if \(gen === startupGenRef\.current\) saveSessionNow\(\);/);
+    const finallyIdx = region.indexOf('} finally {');
+    expect(finallyIdx).toBeGreaterThan(0);
+    const finallyBlock = region.slice(finallyIdx, region.indexOf('})();', finallyIdx));
+    expect(finallyBlock).not.toContain('saveSessionNow');
+  });
+
+  it('registered saver and beforeunload share the sessionLoadedRef guard', () => {
+    // The guarded closure must check sessionLoadedRef before saving…
+    expect(source).toMatch(/const saveSessionGuarded = \(\) => \{\s*\n\s*if \(!sessionLoadedRef\.current\) return;/);
+    // …and be the thing registered AND bound to beforeunload (not the raw saver).
+    expect(source).toMatch(/registerSessionSaver\(saveSessionGuarded\)/);
+    expect(source).toMatch(/addEventListener\('beforeunload', saveSessionGuarded\)/);
+    expect(source).not.toMatch(/addEventListener\('beforeunload', saveSession\)/);
+  });
+
+  it('rebind/clear actions CAS-guard on the surface’s current ptyId', () => {
+    const idx = source.indexOf('resolveReconcileRebind(absentCandidates');
+    expect(idx, 'rebind decision call not found').toBeGreaterThanOrEqual(0);
+    const applyRegion = source.slice(idx, idx + 3000);
+    expect(applyRegion).toMatch(/currentPtyId !== a\.stalePtyId/);
+    // Rebind targets must come from the freshest (second) snapshot when available.
+    expect(applyRegion).toMatch(/secondSnapshot \?\? activePtys/);
+  });
+});

--- a/src/renderer/components/Project/ProjectConfigDialog.tsx
+++ b/src/renderer/components/Project/ProjectConfigDialog.tsx
@@ -10,7 +10,7 @@
 // Visual language mirrors PermissionApprovalDialog (centered modal, accent
 // border, right-rail actions).
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useStore } from '../../stores';
 import { useT } from '../../hooks/useT';
 import { countLayoutLeaves, PROJECT_SUPERVISION_DEFAULT_BURST } from '../../../shared/wmuxProjectConfig';
@@ -25,6 +25,10 @@ interface LayoutRow {
    * approval screen surfaces it so the user sees the autonomous behavior they
    * are about to trust (auto-restart). */
   supervision?: { restart: 'on-failure' | 'always'; burst: number };
+  /** U-PERM — this leaf declared `unattended` (restorePermissionMode), so it
+   * would restore its captured permission mode on reboot IF the user gives the
+   * separate unattended consent below. */
+  unattended?: boolean;
 }
 
 /** Layout startup commands with their pane position, depth-first. */
@@ -41,6 +45,7 @@ function layoutRows(node: WmuxProjectLayoutNode, acc: LayoutRow[] = []): LayoutR
           // applies the same fallback).
           row.supervision = { restart: n.restart, burst: n.restartLimit?.burst ?? PROJECT_SUPERVISION_DEFAULT_BURST };
         }
+        if (n.restorePermissionMode === true) row.unattended = true;
         acc.push(row);
       }
       return;
@@ -56,11 +61,16 @@ export default function ProjectConfigDialog() {
   const wsId = useStore((s) => s.projectDialogWsId);
   const setWsId = useStore((s) => s.setProjectDialogWsId);
   const project = useStore((s) => (wsId ? s.projectConfigs[wsId] : undefined));
+  // U-PERM: unattended reboot-survival consent — a SEPARATE opt-in from base
+  // trust. Defaults UNCHECKED on every open (incl. re-trust of new/stale bytes)
+  // so consent is re-affirmed for exactly the bytes shown, never carried forward.
+  const [unattendedConsent, setUnattendedConsent] = useState(false);
 
   // Re-probe on open so the dialog reflects the LIVE file — a wmux.json
   // edited since the last probe shows as 'stale' here, not as still-trusted.
   useEffect(() => {
     if (wsId) void probeProjectConfig(wsId);
+    setUnattendedConsent(false);
   }, [wsId]);
 
   if (!wsId || !project || !project.found) return null;
@@ -70,6 +80,10 @@ export default function ProjectConfigDialog() {
   const isTrusted = trust === 'trusted';
   const commands = project.config?.commands ?? [];
   const layout = project.config?.layout;
+  const rows = layout ? layoutRows(layout) : [];
+  // Leaves that would restore their captured permission mode on reboot — the
+  // subject of the separate unattended consent below (review mode only).
+  const unattendedRows = rows.filter((r) => r.unattended);
 
   const notice = project.invalid
     ? t('project.invalid')
@@ -170,7 +184,7 @@ export default function ProjectConfigDialog() {
               )}
             </div>
             <ul className="text-[11px] font-mono mt-1" style={{ color: 'var(--text-sub2)' }}>
-              {layoutRows(layout).map((row) => (
+              {rows.map((row) => (
                 <li key={row.index} className="break-all">
                   · {t('project.pane')} {row.index}: {row.label}
                   {row.supervision && (
@@ -182,6 +196,32 @@ export default function ProjectConfigDialog() {
               ))}
             </ul>
           </div>
+        )}
+
+        {!isTrusted && !project.invalid && unattendedRows.length > 0 && (
+          <label
+            className="flex flex-col gap-2 p-3 rounded-md cursor-pointer"
+            style={{ backgroundColor: 'var(--bg-surface)', borderLeft: '3px solid var(--accent-yellow)' }}
+          >
+            <div className="text-xs font-semibold" style={{ color: 'var(--accent-yellow)' }}>
+              {t('project.unattendedHeading')}
+            </div>
+            <ul className="text-[11px] font-mono flex flex-col gap-0.5" style={{ color: 'var(--text-sub2)' }}>
+              {unattendedRows.map((row) => (
+                <li key={row.index} className="break-all">· {t('project.pane')} {row.index}: {row.label}</li>
+              ))}
+            </ul>
+            <div className="flex items-start gap-2 text-[11px]" style={{ color: 'var(--text-sub)' }}>
+              <input
+                type="checkbox"
+                checked={unattendedConsent}
+                onChange={(e) => setUnattendedConsent(e.target.checked)}
+                className="mt-0.5 shrink-0"
+                aria-label={t('project.unattendedHeading')}
+              />
+              <span>{t('project.unattendedConsent', { count: unattendedRows.length })}</span>
+            </div>
+          </label>
         )}
 
         <div className="flex items-center justify-end gap-2">
@@ -222,7 +262,7 @@ export default function ProjectConfigDialog() {
               </button>
               {!project.invalid && (
                 <button
-                  onClick={() => { void decideProjectTrust(wsId, 'trusted'); close(); }}
+                  onClick={() => { void decideProjectTrust(wsId, 'trusted', unattendedConsent); close(); }}
                   className="px-4 py-1.5 rounded-lg text-xs font-medium"
                   style={{ backgroundColor: 'var(--accent-yellow)', color: 'var(--bg-base)' }}
                 >

--- a/src/renderer/components/Terminal/Terminal.tsx
+++ b/src/renderer/components/Terminal/Terminal.tsx
@@ -139,6 +139,14 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
     void ipcInvokeRef.current<{ id: string }>(() =>
       window.electronAPI.pty.create(withWorkspaceProfile(withDefaultShell({ shell, cwd, cols, rows, workspaceId, surfaceId }, defaultShell), profile))
     ).then((result) => {
+      // v2 RCA fix (adversarial review): release the latch once this create
+      // settles. It guards against DOUBLE-create within one attempt, but as a
+      // one-shot it permanently bricked any LATER self-create on the same
+      // mounted Terminal — a designed cycle now that reconcile rebind can land
+      // on a session that dies (rebind → reconnect fails → clear → '' → this
+      // effect must run again). Without the reset, the pane stays blank until
+      // a remount.
+      creatingRef.current = false;
       if (!result.ok) {
         // Toast surfaced by useIpc (e.g. DAEMON_DISCONNECTED). Nothing to do.
         return;

--- a/src/renderer/hooks/__tests__/resolveReconcileRebind.test.ts
+++ b/src/renderer/hooks/__tests__/resolveReconcileRebind.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { resolveReconcileRebind, buildLiveBySurface, type LiveSessionInfo } from '../resolveReconcileRebind';
+
+const cand = (paneId: string, surfaceId: string, ptyId: string) => ({ paneId, surfaceId, ptyId });
+const live = (id: string, surfaceId?: string, createdAt?: string): LiveSessionInfo => ({ id, surfaceId, createdAt });
+
+describe('resolveReconcileRebind (axis B-lite: clear-vs-rebind policy)', () => {
+  it('rebinds a dead ptyId to a live session on the SAME surfaceId', () => {
+    const actions = resolveReconcileRebind(
+      [cand('p1', 's1', 'dead-1')],
+      new Set(['dead-1']),
+      [live('live-1', 's1')],
+    );
+    expect(actions).toEqual([
+      { paneId: 'p1', surfaceId: 's1', newPtyId: 'live-1', kind: 'rebind', stalePtyId: 'dead-1' },
+    ]);
+  });
+
+  it('clears a dead ptyId when no live session shares its surfaceId', () => {
+    const actions = resolveReconcileRebind(
+      [cand('p1', 's1', 'dead-1')],
+      new Set(['dead-1']),
+      [live('live-x' /* no surfaceId: empty-pane-origin session */)],
+    );
+    expect(actions).toEqual([
+      { paneId: 'p1', surfaceId: 's1', newPtyId: '', kind: 'clear', stalePtyId: 'dead-1' },
+    ]);
+  });
+
+  // REGRESSION CRITICAL (plan §4): reconcile must NEVER swap a ptyId that is only
+  // absent from ONE snapshot (still possibly live). Only 2-strike-confirmed-dead
+  // ptyIds (in toClear) may be acted on — everything else is left in place.
+  it('never touches a ptyId absent from toClear — even with a surface match', () => {
+    const actions = resolveReconcileRebind(
+      [cand('p1', 's1', 'maybe-live')],
+      new Set<string>(), // not confirmed dead
+      [live('live-1', 's1')], // a live session shares the surface, but...
+    );
+    expect(actions).toEqual([]); // ...no action: the ptyId stays put
+  });
+
+  // Review hardening (codex + testing + adversarial): duplicate claimants on one
+  // surfaceId pick the NEWEST createdAt — the binding the user last saw — not
+  // whatever Map insertion order (oldest) happened to yield.
+  it('duplicate live surfaceId: newest createdAt wins deterministically', () => {
+    const actions = resolveReconcileRebind(
+      [cand('p1', 's1', 'dead-1')],
+      new Set(['dead-1']),
+      [
+        live('orphan-old', 's1', '2026-06-15T00:00:00.000Z'),
+        live('fresh-new', 's1', '2026-07-01T13:49:00.000Z'),
+      ],
+    );
+    expect(actions[0]).toMatchObject({ kind: 'rebind', newPtyId: 'fresh-new' });
+  });
+
+  it('duplicate with missing createdAt: a parseable date beats an unparseable one', () => {
+    const map = buildLiveBySurface([
+      live('no-date', 's1'),
+      live('dated', 's1', '2026-07-01T00:00:00.000Z'),
+    ]);
+    expect(map.get('s1')).toBe('dated');
+  });
+
+  // Review hardening (testing specialist): one live pty may satisfy at most ONE
+  // candidate — a second dead candidate on the same surfaceId must fall back to
+  // clear, never double-bind one daemon session onto two surfaces.
+  it('two dead candidates on the same surfaceId do not double-bind one live pty', () => {
+    const actions = resolveReconcileRebind(
+      [cand('p1', 's1', 'dead-1'), cand('p2', 's1', 'dead-2')],
+      new Set(['dead-1', 'dead-2']),
+      [live('live-1', 's1')],
+    );
+    expect(actions).toEqual([
+      { paneId: 'p1', surfaceId: 's1', newPtyId: 'live-1', kind: 'rebind', stalePtyId: 'dead-1' },
+      { paneId: 'p2', surfaceId: 's1', newPtyId: '', kind: 'clear', stalePtyId: 'dead-2' },
+    ]);
+  });
+
+  it('mixes rebind + clear and skips non-dead candidates in one pass', () => {
+    const actions = resolveReconcileRebind(
+      [
+        cand('p1', 's1', 'dead-1'),     // → rebind (surface match)
+        cand('p2', 's2', 'dead-2'),     // → clear (no match)
+        cand('p3', 's3', 'still-live'), // → untouched (not in toClear)
+      ],
+      new Set(['dead-1', 'dead-2']),
+      [live('live-1', 's1')],
+    );
+    expect(actions).toEqual([
+      { paneId: 'p1', surfaceId: 's1', newPtyId: 'live-1', kind: 'rebind', stalePtyId: 'dead-1' },
+      { paneId: 'p2', surfaceId: 's2', newPtyId: '', kind: 'clear', stalePtyId: 'dead-2' },
+    ]);
+  });
+
+  it('returns [] for no candidates', () => {
+    expect(resolveReconcileRebind([], new Set(), [])).toEqual([]);
+  });
+});

--- a/src/renderer/hooks/resolveReconcileRebind.ts
+++ b/src/renderer/hooks/resolveReconcileRebind.ts
@@ -1,0 +1,94 @@
+/**
+ * v2 RCA fix (reboot-reattach, axis B-lite) — pure decision for reconcile's
+ * clear-vs-rebind step. Extracted from AppLayout.reconcilePtys so the policy is
+ * unit-testable in isolation (no store / electron), mirroring reconcileWithReQuery.
+ *
+ * A `candidate` is a surface whose stored ptyId was ABSENT from the daemon's live
+ * list. `toClear` is the 2-strike-confirmed-dead subset (absent from BOTH
+ * snapshots). `liveList` is the daemon's live sessions — pass the SECOND
+ * (re-query) snapshot when available so rebind targets are as fresh as the
+ * clear decisions (review finding: a session that died between snapshots must
+ * not be picked as a rebind target).
+ *
+ * Policy (review-hardened):
+ *   - Only sessions carrying a surfaceId (WMUX_SURFACE_ID at create time —
+ *     Terminal-self-create-originated) are rebind targets.
+ *   - Duplicate claimants on one surfaceId: NEWEST createdAt wins (the binding
+ *     the user last saw). Ties/missing createdAt keep the first encountered —
+ *     deterministic either way. (oldest-wins was the naive Map behavior; three
+ *     reviewers flagged it.)
+ *   - A live pty is consumed by at most ONE candidate (no double-bind); a
+ *     second candidate on the same surfaceId falls back to clear.
+ *   - Candidates NOT in `toClear` (possibly live — absent from only one
+ *     snapshot) yield NO action. Regression-critical invariant: reconcile never
+ *     swaps a live-attached ptyId.
+ */
+
+export interface RebindCandidate {
+  paneId: string;
+  surfaceId: string;
+  ptyId: string;
+}
+
+export interface LiveSessionInfo {
+  id: string;
+  surfaceId?: string;
+  /** ISO 8601 create time — used to pick the newest duplicate claimant. */
+  createdAt?: string;
+}
+
+export interface RebindAction {
+  paneId: string;
+  surfaceId: string;
+  /** New ptyId to bind: a live session's id for 'rebind', '' for 'clear'. */
+  newPtyId: string;
+  kind: 'rebind' | 'clear';
+  /** The dead ptyId being replaced — for logging/correlation and the caller's
+   *  compare-and-swap guard (skip if the surface's ptyId moved on). */
+  stalePtyId: string;
+}
+
+/** Newest-createdAt-wins map of surfaceId → live ptyId. Exported for tests. */
+export function buildLiveBySurface(liveList: readonly LiveSessionInfo[]): Map<string, string> {
+  const best = new Map<string, LiveSessionInfo>();
+  for (const s of liveList) {
+    if (!s.surfaceId) continue;
+    const prev = best.get(s.surfaceId);
+    if (!prev) {
+      best.set(s.surfaceId, s);
+      continue;
+    }
+    const prevT = prev.createdAt ? Date.parse(prev.createdAt) : NaN;
+    const curT = s.createdAt ? Date.parse(s.createdAt) : NaN;
+    // Strictly newer wins; ties and unparseable dates keep the incumbent.
+    if (!Number.isNaN(curT) && (Number.isNaN(prevT) || curT > prevT)) {
+      best.set(s.surfaceId, s);
+    }
+  }
+  const map = new Map<string, string>();
+  for (const [surfaceId, s] of best) map.set(surfaceId, s.id);
+  return map;
+}
+
+export function resolveReconcileRebind(
+  candidates: readonly RebindCandidate[],
+  toClear: ReadonlySet<string>,
+  liveList: readonly LiveSessionInfo[],
+): RebindAction[] {
+  const liveBySurface = buildLiveBySurface(liveList);
+  const consumed = new Set<string>();
+  const actions: RebindAction[] = [];
+  for (const c of candidates) {
+    // Only act on ptyIds CONFIRMED dead (absent from both daemon snapshots).
+    // Anything else stays live and untouched — the core non-destructive invariant.
+    if (!toClear.has(c.ptyId)) continue;
+    const livePty = liveBySurface.get(c.surfaceId);
+    if (livePty && !consumed.has(livePty)) {
+      consumed.add(livePty);
+      actions.push({ paneId: c.paneId, surfaceId: c.surfaceId, newPtyId: livePty, kind: 'rebind', stalePtyId: c.ptyId });
+    } else {
+      actions.push({ paneId: c.paneId, surfaceId: c.surfaceId, newPtyId: '', kind: 'clear', stalePtyId: c.ptyId });
+    }
+  }
+  return actions;
+}

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -25,6 +25,7 @@ import { webglContextPool } from '../terminal/webglContextPool';
 import { teardownWebglAddon } from '../terminal/webglTeardown';
 import { createGlyphRepaintScheduler, type GlyphRepaintScheduler } from '../terminal/glyphRepaint';
 import { createDeadInputWatchdog } from '../terminal/deadInputWatchdog';
+import { STALE_REPLAY_INPUT_MODE_RESETS } from '../terminal/staleReplayModeReset';
 import { reconnectPtyWithRetry as reconnectPtyWithRetryImpl } from './reconnectPtyWithRetry';
 
 // Module-level terminal registry for scrollback persistence
@@ -996,6 +997,28 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     let pendingFlushReset = false;
     let lastFlushRecoveredBytes: number | null = null;
     let removeFlushListener: (() => void) | null = null;
+    // Stale-replay mode reset (see ../terminal/staleReplayModeReset.ts): a
+    // recovered session's ring replay re-executes the dead agent's DECSET
+    // arming (mouse/focus/paste reporting) into xterm, so the fresh shell's
+    // pane emits mouse reports that both dismiss the resume pill (onData
+    // "user typed" heuristic) and land in the shell as junk input. After a
+    // replaying flush, ask the daemon whether this pane is a recovered agent
+    // shell (`resumeAgent` — set ONLY for sessions recovered this boot whose
+    // agent has NOT been re-detected) and if so disable the leaked modes,
+    // terminal-side only. The pty.list round-trip doubles as ordering: by the
+    // time it resolves, the replay bytes are already queued into xterm, so
+    // the resets always land after the sequences they cancel. Gating on the
+    // daemon (not the renderer's resumeHint slice) avoids the boot race where
+    // the flush completes before AppLayout has hydrated the hint.
+    const resetStaleReplayModes = (recoveredBytes: number) => {
+      if (recoveredBytes <= 0) return;
+      void window.electronAPI.pty.list().then((sessions) => {
+        if (terminalRef.current !== terminal) return;
+        if (sessions.find((s) => s.id === ptyId)?.resumeAgent) {
+          terminal.write(STALE_REPLAY_INPUT_MODE_RESETS);
+        }
+      }).catch(() => { /* best-effort — a transient list failure just skips the reset */ });
+    };
     let firstDataFired = false;
     const fireFirstData = () => {
       if (!firstDataFired) {
@@ -1068,6 +1091,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           pendingFlushReset = false;
           if (recoveredBytes > 0) terminal.reset();
         }
+        resetStaleReplayModes(recoveredBytes);
       });
 
       // Fix 0 (round 3) — all listeners (pty.onData, pty.onFlushComplete,
@@ -1169,6 +1193,15 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // Fix D — daemon (re)attach is owned by the daemon-mode effect below
       // (fires at mount if active, or on a later daemon:connected). connectPty
       // above has already registered pty.onData/onExit, so replay lands safely.
+      // The daemon flush replays the ring buffer even when there is no .txt to
+      // restore (scrollback-restore toggle off), so the stale-mode reset must
+      // listen here too — the leaked DECSET arming rides the replay, not the
+      // .txt cache.
+      removeFlushListener = window.electronAPI.pty.onFlushComplete((id, recoveredBytes) => {
+        if (id !== ptyId) return;
+        if (terminalRef.current !== terminal) return;
+        resetStaleReplayModes(recoveredBytes);
+      });
     }
 
     // Resize PTY on initial fit — only when we actually have valid dimensions.

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -184,6 +184,11 @@ export const en = {
   // as a process that wmux auto-restarts. {restart}=on-failure|always,
   // {burst}=consecutive-failure cap before the runaway guard stops it.
   'project.supervisionBadge': '↻ auto-restarts ({restart}, up to {burst} consecutive)',
+  // Unattended reboot-survival consent — a SEPARATE opt-in from base trust. The
+  // checkbox restores each unattended pane's last-used permission mode on reboot
+  // (may include --dangerously-skip-permissions), so it is surfaced explicitly.
+  'project.unattendedHeading': 'Unattended (skip permission prompts after reboot)',
+  'project.unattendedConsent': 'Allow reboots to auto-run these {count} pane(s) without permission prompts. Each restores its last-used permission mode, which may include --dangerously-skip-permissions.',
   'palette.catWorkspace': 'Workspace',
   'palette.catSurface': 'Surface',
   'palette.catCommand': 'Command',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -135,6 +135,8 @@ export const ko = {
   'project.badgeTooltip': 'wmux.json — 프로젝트 커맨드·레이아웃',
   'project.discoveredToast': 'wmux.json 발견 — 사이드바 배지를 클릭해 프로젝트 커맨드를 검토하세요',
   'project.supervisionBadge': '↻ 자동 재시작 ({restart}, 연속 {burst}회까지)',
+  'project.unattendedHeading': '무인 실행 (재부팅 후 권한 프롬프트 스킵)',
+  'project.unattendedConsent': '재부팅 시 이 {count}개 pane을 권한 확인 없이 자동 실행하도록 허용. 각 pane은 마지막 사용 권한 모드로 복원되며, --dangerously-skip-permissions가 포함될 수 있습니다.',
   'palette.catWorkspace': '워크스페이스',
   'palette.catSurface': '서피스',
   'palette.catCommand': '커맨드',

--- a/src/renderer/stores/selectors/__tests__/fleet.test.ts
+++ b/src/renderer/stores/selectors/__tests__/fleet.test.ts
@@ -272,3 +272,34 @@ describe('countNeedsAttention', () => {
     expect(countNeedsAttention(panes)).toBe(2);
   });
 });
+
+describe('selectFleetPanes — X8 supervision mirror', () => {
+  const wsSup = workspace('ws-s', 'sup', leaf('ps', [surface('ss', 'pty-s')]), 'ps');
+  const base = { workspaces: [wsSup], surfaceAgentStatus: {}, surfaceActivity: {} };
+
+  it('surfaces supervision for a supervised pane (keyed by active-surface ptyId)', () => {
+    const [pane] = selectFleetPanes({ ...base, supervisionByPtyId: { 'pty-s': { status: 'armed', restartCount: 3 } } });
+    expect(pane.supervision).toEqual({ status: 'armed', restartCount: 3 });
+  });
+
+  it('carries a guard-tripped (stopped) verdict through', () => {
+    const [pane] = selectFleetPanes({ ...base, supervisionByPtyId: { 'pty-s': { status: 'stopped', restartCount: 5 } } });
+    expect(pane.supervision).toEqual({ status: 'stopped', restartCount: 5 });
+  });
+
+  it('leaves supervision undefined for an unsupervised pane (empty map or omitted)', () => {
+    expect(selectFleetPanes({ ...base, supervisionByPtyId: {} })[0].supervision).toBeUndefined();
+    expect(selectFleetPanes(base)[0].supervision).toBeUndefined();
+  });
+
+  it('never attaches supervision to an unspawned surface (empty ptyId)', () => {
+    const wsNoPty = workspace('ws-n', 'nopty', leaf('pn', [surface('sn', '')]), 'pn');
+    const [pane] = selectFleetPanes({
+      workspaces: [wsNoPty],
+      surfaceAgentStatus: {},
+      surfaceActivity: {},
+      supervisionByPtyId: { '': { status: 'armed', restartCount: 1 } },
+    });
+    expect(pane.supervision).toBeUndefined();
+  });
+});

--- a/src/renderer/stores/selectors/fleet.ts
+++ b/src/renderer/stores/selectors/fleet.ts
@@ -38,6 +38,15 @@ export interface FleetPane {
    * when absent. Reflects the most recent FINISHED tool, not the live one.
    */
   activity?: string;
+  /**
+   * X8 supervision mirror for this pane's active-surface PTY, from the per-ptyId
+   * `supervisionByPtyId` slice (daemon PaneSupervisor sticky status + restart
+   * count). Undefined when the pane is unsupervised. Lets the cockpit show that
+   * a declared/unattended agent is armed (and how many times it has restarted)
+   * or that its runaway guard tripped (`stopped` — the supervisor gave up and a
+   * human is needed).
+   */
+  supervision?: { status: 'armed' | 'stopped'; restartCount: number };
 }
 
 /** Minimal store surface the selector reads — keeps the fixture trivial and the
@@ -46,6 +55,9 @@ export type FleetSelectorState = Pick<StoreState, 'workspaces' | 'surfaceAgentSt
   /** P2 — pane rename mirror. Optional so existing fixtures stay terse; the
    *  live FleetView always passes the real map. */
   paneLabel?: StoreState['paneLabel'];
+  /** X8 supervision mirror (per-ptyId). Optional so existing fixtures stay
+   *  terse; the live FleetView always passes the real map. */
+  supervisionByPtyId?: StoreState['supervisionByPtyId'];
 };
 
 // Priority of each status for "which one wants the user most". Lower = more
@@ -112,6 +124,10 @@ export function selectFleetPanes(state: FleetSelectorState): FleetPane[] {
         // itself). Undefined when the agent emits no PostToolUse hook — the
         // card then shows the raw tail. Empty ptyId never has an entry.
         activity: ptyId ? state.surfaceActivity[ptyId] : undefined,
+        // X8 supervision mirror for the active surface's PTY (same key as the
+        // pane badge). Only supervised panes have an entry; unsupervised →
+        // undefined. An unspawned surface (empty ptyId) never carries one.
+        supervision: ptyId ? state.supervisionByPtyId?.[ptyId] : undefined,
       });
     }
   }

--- a/src/renderer/stores/slices/__tests__/projectConfigSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/projectConfigSlice.test.ts
@@ -235,4 +235,48 @@ describe('projectConfigSlice', () => {
       expect(store.getState().projectLayoutAutoApplied['other']).toBeUndefined();
     });
   });
+
+  describe('U-PERM — restorePermissionMode consent gating (buildTree)', () => {
+    // A trusted project whose first leaf is a declared unattended supervised
+    // agent; the sibling is a plain supervised command (no restore intent).
+    function unattendedState(unattended: boolean): ProjectConfigState {
+      return trustedState({
+        unattended,
+        config: {
+          version: 1,
+          layout: {
+            type: 'branch',
+            direction: 'horizontal',
+            children: [
+              { type: 'leaf', command: 'claude', restart: 'on-failure', restorePermissionMode: true },
+              { type: 'leaf', command: 'npm run dev' },
+            ],
+          },
+        },
+      });
+    }
+
+    it('sets the seed bit on the unattended leaf only when the user consented', () => {
+      store.getState().setProjectConfig(wsId, unattendedState(true));
+      store.getState().applyProjectLayout(wsId);
+      const leaves = collectLeaves(store.getState().workspaces[0].rootPane);
+      const seeds = store.getState().projectPaneSeed;
+      expect(seeds[leaves[0].id]).toMatchObject({
+        command: 'claude',
+        restart: 'on-failure',
+        restorePermissionMode: true,
+      });
+      // The non-unattended sibling never carries the bit.
+      expect(seeds[leaves[1].id]?.restorePermissionMode).toBeUndefined();
+    });
+
+    it('omits the bit when declared but not consented (still supervised, no bypass)', () => {
+      store.getState().setProjectConfig(wsId, unattendedState(false));
+      store.getState().applyProjectLayout(wsId);
+      const leaves = collectLeaves(store.getState().workspaces[0].rootPane);
+      const seeds = store.getState().projectPaneSeed;
+      expect(seeds[leaves[0].id]?.restart).toBe('on-failure'); // supervision stays on
+      expect(seeds[leaves[0].id]?.restorePermissionMode).toBeUndefined(); // but no permission restore
+    });
+  });
 });

--- a/src/renderer/stores/slices/__tests__/surfaceSlice.persistBinding.test.ts
+++ b/src/renderer/stores/slices/__tests__/surfaceSlice.persistBinding.test.ts
@@ -1,0 +1,90 @@
+/**
+ * v2 RCA fix (reboot-reattach, axis A) — centralized binding persistence.
+ *
+ * addSurface / updateSurfacePtyId must flush session.json via the
+ * sessionSaveBridge the moment a surface↔ptyId binding changes, but ONLY when
+ * paneGate === 'ready' (startup-reconcile mutations are persisted once by the
+ * success-path save; a mid-reconcile snapshot on disk is the half-reconciled
+ * garbage class the periodic tick's gate guards against).
+ *
+ * Functional store test (hand-rolled minimal cross-slice state, same pattern
+ * as workspaceSlice.loadSession.test.ts) so a refactor that drops the
+ * persistBindingNow call fails HERE instead of silently killing axis A — the
+ * exact tsc-invisible field-drop class from the U-PERM runtime drops.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { createSurfaceSlice, type SurfaceSlice } from '../surfaceSlice';
+import { createWorkspace, type Workspace } from '../../../../shared/types';
+import { registerSessionSaver } from '../../../utils/sessionSaveBridge';
+
+type TestState = SurfaceSlice & {
+  workspaces: Workspace[];
+  activeWorkspaceId: string;
+  paneGate: 'pending' | 'ready';
+};
+
+function createTestStore() {
+  const ws = createWorkspace('W1', 1);
+  return create<TestState>()(
+    immer((...a) => ({
+      ...(createSurfaceSlice as unknown as (...args: unknown[]) => SurfaceSlice)(...a),
+      workspaces: [ws],
+      activeWorkspaceId: ws.id,
+      paneGate: 'pending' as const,
+    })),
+  );
+}
+
+describe('surfaceSlice — centralized immediate binding persistence', () => {
+  const saver = vi.fn();
+  beforeEach(() => {
+    saver.mockClear();
+    registerSessionSaver(saver);
+  });
+  afterEach(() => registerSessionSaver(null));
+
+  it('addSurface persists immediately when paneGate is ready', () => {
+    const store = createTestStore();
+    store.setState((s) => { s.paneGate = 'ready'; });
+    const paneId = store.getState().workspaces[0].rootPane.id;
+    store.getState().addSurface(paneId, 'pty-new', 'pwsh', 'D:/x');
+    expect(saver).toHaveBeenCalledTimes(1);
+  });
+
+  it('addSurface does NOT persist while paneGate is pending (startup reconcile)', () => {
+    const store = createTestStore();
+    const paneId = store.getState().workspaces[0].rootPane.id;
+    store.getState().addSurface(paneId, 'pty-new', 'pwsh', 'D:/x');
+    expect(saver).not.toHaveBeenCalled();
+  });
+
+  it('updateSurfacePtyId persists immediately when ready (self-create + rebind path)', () => {
+    const store = createTestStore();
+    const paneId = store.getState().workspaces[0].rootPane.id;
+    store.getState().addSurface(paneId, 'pty-old', 'pwsh', 'D:/x');
+    const pane = store.getState().workspaces[0].rootPane;
+    const surfaceId = pane.type === 'leaf' ? pane.surfaces[0].id : '';
+    store.setState((s) => { s.paneGate = 'ready'; });
+    saver.mockClear();
+
+    store.getState().updateSurfacePtyId(paneId, surfaceId, 'pty-fresh');
+    expect(saver).toHaveBeenCalledTimes(1);
+    // The store mutation must land BEFORE the save fires (saver reads getState()).
+    const after = store.getState().workspaces[0].rootPane;
+    expect(after.type === 'leaf' && after.surfaces[0].ptyId).toBe('pty-fresh');
+  });
+
+  it('updateSurfacePtyId stays silent while pending', () => {
+    const store = createTestStore();
+    const paneId = store.getState().workspaces[0].rootPane.id;
+    store.getState().addSurface(paneId, 'pty-old', 'pwsh', 'D:/x');
+    const pane = store.getState().workspaces[0].rootPane;
+    const surfaceId = pane.type === 'leaf' ? pane.surfaces[0].id : '';
+    saver.mockClear();
+
+    store.getState().updateSurfacePtyId(paneId, surfaceId, '');
+    expect(saver).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/stores/slices/projectConfigSlice.ts
+++ b/src/renderer/stores/slices/projectConfigSlice.ts
@@ -28,6 +28,14 @@ export interface ProjectPaneSeed {
    * pty.create instead of an `initialCommand`. */
   restart?: 'on-failure' | 'always';
   restartLimit?: { burst?: number; healthyUptimeSec?: number };
+  /**
+   * U-PERM: the EFFECTIVE unattended permission-restore decision — the leaf's
+   * `restorePermissionMode` intent AND the project's explicit unattended consent
+   * (ProjectConfigState.unattended), computed at layout-apply time. The funnel
+   * passes this into the supervised pty.create's supervision policy; the daemon
+   * honors it verbatim at replay. Only ever set alongside `restart`.
+   */
+  restorePermissionMode?: boolean;
 }
 
 export interface ApplyProjectLayoutResult {
@@ -89,11 +97,15 @@ function joinProjectCwd(root: string, relative: string | undefined): string {
   return `${base}${sep}${cleaned.replace(/[/\\]+/g, sep)}`;
 }
 
-/** Build an empty pane tree from the layout, recording one seed per leaf. */
+/** Build an empty pane tree from the layout, recording one seed per leaf.
+ * `unattendedConsented` gates the per-leaf permission-restore bit: an unattended
+ * leaf only restores its captured permission mode on reboot when the user gave
+ * explicit unattended consent for this project (Minimal design 2026-07-01). */
 function buildTree(
   node: WmuxProjectLayoutNode,
   root: string,
   seeds: Record<string, ProjectPaneSeed>,
+  unattendedConsented: boolean,
 ): Pane {
   if (node.type === 'leaf') {
     const leaf = createLeafPane();
@@ -111,6 +123,12 @@ function buildTree(
       if (node.restart !== undefined) {
         seed.restart = node.restart;
         if (node.restartLimit !== undefined) seed.restartLimit = node.restartLimit;
+        // U-PERM: turn on captured-permission restore only when BOTH the leaf
+        // declared `unattended` (normalized to restorePermissionMode) AND the
+        // user consented. No consent → omitted → daemon D6 fail-safe on reboot.
+        if (node.restorePermissionMode === true && unattendedConsented) {
+          seed.restorePermissionMode = true;
+        }
       }
     }
     seeds[leaf.id] = seed;
@@ -120,7 +138,7 @@ function buildTree(
     id: generateId('pane'),
     type: 'branch',
     direction: node.direction,
-    children: node.children.map((child) => buildTree(child, root, seeds)),
+    children: node.children.map((child) => buildTree(child, root, seeds, unattendedConsented)),
     ...(node.sizes ? { sizes: node.sizes } : {}),
   };
   return branch;
@@ -174,7 +192,9 @@ export const createProjectConfigSlice: StateCreator<
       if (!ws) return;
       disposedPtyIds = collectPtyIds(ws.rootPane);
       const seeds: Record<string, ProjectPaneSeed> = {};
-      const newRoot = buildTree(layout, project.root as string, seeds);
+      // Consent is re-read from the (trusted) project state here, so revoking it
+      // (re-trust without the checkbox) makes the next layout-apply omit restore.
+      const newRoot = buildTree(layout, project.root as string, seeds, project.unattended === true);
       // P2: full-tree replace → number leaves fresh 1..n (parallels applyLayoutTemplate).
       ws.nextPaneOrdinal = assignPaneOrdinals(newRoot, 1);
       ws.rootPane = newRoot;

--- a/src/renderer/stores/slices/surfaceSlice.ts
+++ b/src/renderer/stores/slices/surfaceSlice.ts
@@ -4,6 +4,7 @@ import type { Pane, PaneLeaf, Surface, Workspace } from '../../../shared/types';
 import { createSurface, generateId } from '../../../shared/types';
 import { isSafeBrowserUrl } from '../../utils/browserPane';
 import { clearNudgesFor } from '../../hooks/channelMentionRateLimit';
+import { saveSessionNow } from '../../utils/sessionSaveBridge';
 
 export interface SurfaceSlice {
   /** Add a terminal surface to a pane. `workspaceId` lets RPC / eager-spawn
@@ -59,17 +60,40 @@ function findLeafPane(root: Pane, id: string): PaneLeaf | null {
   return null;
 }
 
-export const createSurfaceSlice: StateCreator<StoreState, [['zustand/immer', never]], [], SurfaceSlice> = (set) => ({
-  addSurface: (paneId, ptyId, shell, cwd, workspaceId) => set((state: StoreState) => {
-    const targetWsId = workspaceId || state.activeWorkspaceId;
-    const ws = state.workspaces.find((w: Workspace) => w.id === targetWsId);
-    if (!ws) return;
-    const pane = findLeafPane(ws.rootPane, paneId);
-    if (!pane) return;
-    const surface = createSurface(ptyId, shell, cwd);
-    pane.surfaces.push(surface);
-    pane.activeSurfaceId = surface.id;
-  }),
+/**
+ * v2 RCA fix (reboot-reattach, axis A): centralized immediate persistence for
+ * surface↔ptyId bindings. EVERY caller of addSurface / updateSurfacePtyId
+ * (Terminal self-create, '+' tab, palette, keyboard split, project commands,
+ * MCP surface_new / pane_split, reconcile rebind/clear, …) gets the flush for
+ * free — call-site-by-call-site saveSessionNow() sprinkling covered only 2 of
+ * 9 binding sites (codex P2 + maintainability review).
+ *
+ * Gated on paneGate==='ready': startup-reconcile mutations (clears/rebinds
+ * while the gate is still 'pending') are deliberately NOT persisted here — the
+ * startup path saves once on SUCCESSFUL reconcile completion, and persisting a
+ * mid-reconcile snapshot is exactly the half-reconciled-garbage class the 5s
+ * periodic tick's own gate guards against. The registered saver additionally
+ * no-ops until session.load() succeeded (sessionLoadedRef guard in AppLayout).
+ */
+function persistBindingNow(get: () => StoreState): void {
+  if (get().paneGate !== 'ready') return;
+  saveSessionNow();
+}
+
+export const createSurfaceSlice: StateCreator<StoreState, [['zustand/immer', never]], [], SurfaceSlice> = (set, get) => ({
+  addSurface: (paneId, ptyId, shell, cwd, workspaceId) => {
+    set((state: StoreState) => {
+      const targetWsId = workspaceId || state.activeWorkspaceId;
+      const ws = state.workspaces.find((w: Workspace) => w.id === targetWsId);
+      if (!ws) return;
+      const pane = findLeafPane(ws.rootPane, paneId);
+      if (!pane) return;
+      const surface = createSurface(ptyId, shell, cwd);
+      pane.surfaces.push(surface);
+      pane.activeSurfaceId = surface.id;
+    });
+    persistBindingNow(get);
+  },
 
   addBrowserSurface: (paneId, url, partition, workspaceId) => set((state: StoreState) => {
     const targetWsId = workspaceId || state.activeWorkspaceId;
@@ -171,17 +195,20 @@ export const createSurfaceSlice: StateCreator<StoreState, [['zustand/immer', nev
     pane.activeSurfaceId = pane.surfaces[(idx - 1 + pane.surfaces.length) % pane.surfaces.length].id;
   }),
 
-  updateSurfacePtyId: (paneId, surfaceId, ptyId) => set((state: StoreState) => {
-    for (const ws of state.workspaces) {
-      const pane = findLeafPane(ws.rootPane, paneId);
-      if (!pane) continue;
-      const surface = pane.surfaces.find((s) => s.id === surfaceId);
-      if (surface) {
-        surface.ptyId = ptyId;
-        return;
+  updateSurfacePtyId: (paneId, surfaceId, ptyId) => {
+    set((state: StoreState) => {
+      for (const ws of state.workspaces) {
+        const pane = findLeafPane(ws.rootPane, paneId);
+        if (!pane) continue;
+        const surface = pane.surfaces.find((s) => s.id === surfaceId);
+        if (surface) {
+          surface.ptyId = ptyId;
+          return;
+        }
       }
-    }
-  }),
+    });
+    persistBindingNow(get);
+  },
 
   updateSurfaceTitle: (surfaceId, title) => set((state: StoreState) => {
     for (const ws of state.workspaces) {

--- a/src/renderer/terminal/__tests__/staleReplayModeReset.test.ts
+++ b/src/renderer/terminal/__tests__/staleReplayModeReset.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+/**
+ * Stale-replay input-mode reset (reboot-reattach RCA 2026-07-02).
+ *
+ * A recovered session's ring replay re-executes the dead agent's DECSET
+ * arming sequences into xterm — most damagingly ?1003 (any-motion mouse
+ * tracking), which makes the pane emit SGR mouse reports through onData the
+ * moment the pointer moves toward the resume pill, dismissing it via the
+ * "user typed" heuristic before it can be clicked.
+ *
+ * The reset constant is verified BEHAVIORALLY against a real (headless)
+ * xterm Terminal: arm the exact modes observed in the incident buffers, write
+ * the reset, assert everything is disarmed and that the reset itself provokes
+ * no response bytes. The useTerminal wiring is pinned at the source level,
+ * matching the other regression locks in hooks/__tests__.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { Terminal } from '@xterm/xterm';
+import { STALE_REPLAY_INPUT_MODE_RESETS } from '../staleReplayModeReset';
+
+const write = (term: Terminal, data: string) =>
+  new Promise<void>((resolve) => term.write(data, resolve));
+
+// What the 2026-07-02 incident buffers actually ended with: both attached
+// panes' replays left these ENABLED (the agent was killed mid-run by the OS
+// shutdown, so the disable sequences never got written).
+const DEAD_AGENT_ARMING =
+  '\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1004h\x1b[?1006h\x1b[?2004h';
+
+describe('STALE_REPLAY_INPUT_MODE_RESETS — behavioral (headless xterm)', () => {
+  it('disarms mouse/focus/paste reporting armed by a replayed dead-agent buffer', async () => {
+    const term = new Terminal();
+    try {
+      await write(term, DEAD_AGENT_ARMING);
+      expect(term.modes.mouseTrackingMode).toBe('any');
+      expect(term.modes.sendFocusMode).toBe(true);
+      expect(term.modes.bracketedPasteMode).toBe(true);
+
+      await write(term, STALE_REPLAY_INPUT_MODE_RESETS);
+      expect(term.modes.mouseTrackingMode).toBe('none');
+      expect(term.modes.sendFocusMode).toBe(false);
+      expect(term.modes.bracketedPasteMode).toBe(false);
+    } finally {
+      term.dispose();
+    }
+  });
+
+  it('provokes no response bytes of its own (nothing new for onData to mistake for typing)', async () => {
+    const term = new Terminal();
+    try {
+      const emitted: string[] = [];
+      term.onData((d) => emitted.push(d));
+      await write(term, STALE_REPLAY_INPUT_MODE_RESETS);
+      expect(emitted).toEqual([]);
+    } finally {
+      term.dispose();
+    }
+  });
+
+  it('is pure DECRST and leaves display state (alt screen, cursor) alone', () => {
+    // Only `CSI ? Pd l` — the reset must never arm a mode or swap screens.
+    // eslint-disable-next-line no-control-regex
+    expect(STALE_REPLAY_INPUT_MODE_RESETS).toMatch(/^(\x1b\[\?\d+l)+$/);
+    expect(STALE_REPLAY_INPUT_MODE_RESETS).not.toContain('1049');
+    expect(STALE_REPLAY_INPUT_MODE_RESETS).not.toContain('[?25');
+  });
+});
+
+describe('useTerminal stale-replay reset wiring (source-level lock)', () => {
+  const src = readFileSync(
+    path.resolve(process.cwd(), 'src/renderer/hooks/useTerminal.ts'),
+    'utf8',
+  );
+
+  it('gates on the daemon resumeAgent field (recovered-this-boot, agent not re-detected)', () => {
+    const idx = src.indexOf('const resetStaleReplayModes');
+    expect(idx).toBeGreaterThan(-1);
+    const body = src.slice(idx, idx + 900);
+    // No replay → nothing leaked → no reset.
+    expect(body).toMatch(/recoveredBytes\s*<=\s*0\)\s*return/);
+    // The daemon is the authority — NOT the renderer's resumeHint slice, which
+    // hydrates racily against the boot flush.
+    expect(body).toMatch(/window\.electronAPI\.pty\.list\(\)/);
+    expect(body).toMatch(/resumeAgent/);
+    // Terminal-side only: the leaked modes live in xterm, the PTY never saw them.
+    expect(body).toMatch(/terminal\.write\(STALE_REPLAY_INPUT_MODE_RESETS\)/);
+    expect(body).not.toMatch(/pty\.write/);
+  });
+
+  it('runs after the flush in BOTH branches (.txt restore present and absent)', () => {
+    const calls = src.match(/resetStaleReplayModes\(recoveredBytes\)/g) ?? [];
+    expect(calls).toHaveLength(2);
+  });
+});

--- a/src/renderer/terminal/staleReplayModeReset.ts
+++ b/src/renderer/terminal/staleReplayModeReset.ts
@@ -1,0 +1,39 @@
+/**
+ * Stale-replay input-mode reset (reboot-reattach RCA 2026-07-02, resume-pill
+ * self-dismiss).
+ *
+ * When the daemon recovers a session after an OS reboot, attaching replays the
+ * persisted ring buffer verbatim. If the pane was running a TUI agent when
+ * Windows killed it (exitCode 0x40010004), the replayed bytes contain the
+ * agent's DECSET arming sequences — mouse tracking (?1000/?1002/?1003/?1006),
+ * focus reporting (?1004), bracketed paste (?2004) — with no matching disable,
+ * because the process never got to shut down. xterm re-executes them, so the
+ * FRESH shell now sitting in the pane inherits input-reporting modes it never
+ * asked for:
+ *
+ *  - ?1003 (any-motion tracking) makes xterm emit SGR mouse reports through
+ *    onData the moment the pointer crosses the pane. The onData "user typed →
+ *    retract resume offer" heuristic in useTerminal only exempts focus
+ *    reports, so moving the mouse TOWARD the resume pill is what dismissed it.
+ *  - The same report bytes are written to the shell's stdin as junk input.
+ *
+ * This string disables every input-REPORTING mode xterm.js implements, plus
+ * bracketed paste (a leaked ?2004h wraps pastes in markers the fresh shell
+ * never negotiated). Written to the TERMINAL only (terminal.write), never to
+ * the PTY. Display state (?1049 alt screen, ?25 cursor) is intentionally left
+ * alone — resetting it would visibly alter the restored scrollback.
+ *
+ * Callers must gate on the daemon's `resumeAgent` field from pty.list: it is
+ * only present for sessions recovered THIS daemon boot whose agent has not
+ * been re-detected, i.e. exactly the panes where the mode-arming process is
+ * known dead. A live reconnect (agent still running and legitimately using
+ * the mouse) never carries it, so its modes are never clobbered.
+ */
+export const STALE_REPLAY_INPUT_MODE_RESETS =
+  '\x1b[?9l' + // X10 mouse
+  '\x1b[?1000l' + // VT200 mouse (click)
+  '\x1b[?1002l' + // button-event tracking (drag)
+  '\x1b[?1003l' + // any-event tracking (motion — the pill killer)
+  '\x1b[?1006l' + // SGR extended mouse encoding
+  '\x1b[?1004l' + // focus in/out reporting
+  '\x1b[?2004l'; // bracketed paste

--- a/src/renderer/utils/__tests__/sessionSaveBridge.test.ts
+++ b/src/renderer/utils/__tests__/sessionSaveBridge.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { registerSessionSaver, saveSessionNow } from '../sessionSaveBridge';
+
+afterEach(() => registerSessionSaver(null));
+
+describe('sessionSaveBridge (axis A: event-driven immediate persistence)', () => {
+  it('saveSessionNow is a no-op before any saver is registered', () => {
+    registerSessionSaver(null);
+    expect(() => saveSessionNow()).not.toThrow();
+  });
+
+  it('calls the registered saver once per saveSessionNow', () => {
+    const saver = vi.fn();
+    registerSessionSaver(saver);
+    saveSessionNow();
+    saveSessionNow();
+    expect(saver).toHaveBeenCalledTimes(2);
+  });
+
+  it('swallows saver errors — never throws to the caller (teardown site safety)', () => {
+    registerSessionSaver(() => { throw new Error('boom'); });
+    expect(() => saveSessionNow()).not.toThrow();
+  });
+
+  it('unregister (null) restores the no-op', () => {
+    const saver = vi.fn();
+    registerSessionSaver(saver);
+    registerSessionSaver(null);
+    saveSessionNow();
+    expect(saver).not.toHaveBeenCalled();
+  });
+
+  it('a newer registration replaces the previous saver', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    registerSessionSaver(first);
+    registerSessionSaver(second);
+    saveSessionNow();
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/utils/projectConfigProbe.ts
+++ b/src/renderer/utils/projectConfigProbe.ts
@@ -97,10 +97,14 @@ export async function applyProjectLayoutFresh(workspaceId: string): Promise<bool
   return applyProjectLayoutNow(workspaceId);
 }
 
-/** Persist a trust decision, re-probe, and (on trust) try the auto-apply. */
+/** Persist a trust decision, re-probe, and (on trust) try the auto-apply.
+ * `unattended` is the explicit unattended reboot-survival consent — only
+ * meaningful for a 'trusted' decision (main forces it false otherwise). The
+ * caller passes the checkbox's current value every time (no carry-forward). */
 export async function decideProjectTrust(
   workspaceId: string,
   decision: 'trusted' | 'denied' | 'clear',
+  unattended = false,
 ): Promise<void> {
   const project = useStore.getState().projectConfigs[workspaceId];
   if (!project?.root) return;
@@ -111,6 +115,7 @@ export async function decideProjectTrust(
       // Bind the grant to the BYTES THE DIALOG SHOWED — if the file changed
       // while the dialog was open, main evaluates the live file as 'stale'.
       decision === 'clear' ? undefined : project.contentHash,
+      decision === 'trusted' && unattended,
     );
   } catch (err) {
     useStore.getState().pushToast({

--- a/src/renderer/utils/ptyCreateOptions.ts
+++ b/src/renderer/utils/ptyCreateOptions.ts
@@ -31,6 +31,9 @@ export interface PtyCreateOptions {
   supervision?: {
     restart: 'on-failure' | 'always';
     limit?: { burst?: number; healthyUptimeSec?: number };
+    /** U-PERM: consent-gated permission-restore bit (funnel-computed). Daemon
+     * mode only; forwarded through pty.create to the daemon's supervision policy. */
+    restorePermissionMode?: boolean;
   };
 }
 

--- a/src/renderer/utils/sessionSaveBridge.ts
+++ b/src/renderer/utils/sessionSaveBridge.ts
@@ -1,0 +1,41 @@
+/**
+ * v2 RCA fix (reboot-reattach, axis A): event-driven immediate session persistence.
+ *
+ * The renderer must flush session.json the INSTANT a surface's ptyId changes
+ * (Terminal self-create, empty-pane addSurface, reconcile completion) — not wait
+ * for the 5s periodic tick. An OS reboot inside that window loses the freshly
+ * created ptyId, so session.json keeps a stale/fossil ptyId and the next boot
+ * fails to reattach (clears → self-creates a new session, orphaning the live one).
+ *
+ * The actual saver (`session.save(buildSessionData(dumpScrollbackBuffersSync()))`)
+ * lives in AppLayout, whose helpers pull heavy deps (terminalRegistry, store,
+ * scrollback serialization). Exporting them would create an
+ * AppLayout → PaneContainer → Pane → AppLayout import cycle. Instead AppLayout
+ * registers its saver closure here on mount, and teardown/creation sites call
+ * `saveSessionNow()`. No import cycle: this module imports nothing.
+ *
+ * Single-window app → a single module-level slot is sufficient. `saveSessionNow`
+ * is a no-op before registration (early boot) and after teardown.
+ */
+
+let saver: (() => void) | null = null;
+
+/** AppLayout registers (mount) / clears (unmount) its synchronous saver closure. */
+export function registerSessionSaver(fn: (() => void) | null): void {
+  saver = fn;
+}
+
+/** Persist the current session.json snapshot right now. Best-effort immediate:
+ *  the saver fires an async `session.save` IPC (fire-and-forget) and MAIN writes
+ *  synchronously on receipt — so the in-flight window is milliseconds, versus
+ *  the 5 s periodic tick this exists to pre-empt. Not a durability ack. Safe
+ *  no-op if no saver is registered yet. Never throws to its caller. */
+export function saveSessionNow(): void {
+  if (!saver) return;
+  try {
+    saver();
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[saveSessionNow] immediate session save failed:', err);
+  }
+}

--- a/src/shared/__tests__/processLiveness.test.ts
+++ b/src/shared/__tests__/processLiveness.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyTasklistOutput,
+  classifyKillOutcome,
+  lockOwnerIsReclaimable,
+} from '../processLiveness';
+
+describe('processLiveness — classifiers (shared contract)', () => {
+  it('reads a FAILED tasklist probe (null) as unknown, never dead (Defect-1)', () => {
+    expect(classifyTasklistOutput(1234, null)).toBe('unknown');
+  });
+  it('reads an authoritative listing without the PID as dead', () => {
+    expect(classifyTasklistOutput(1234, '')).toBe('dead');
+    expect(classifyTasklistOutput(1234, '"other.exe","9999","Console","1","10 K"\r\n')).toBe('dead');
+  });
+  it('reads a present PID as alive', () => {
+    expect(classifyTasklistOutput(1234, '"node.exe","1234","Console","1","50,000 K"\r\n')).toBe('alive');
+  });
+  it('maps POSIX kill outcomes: none→alive, ESRCH→dead, EPERM→alive, else→unknown', () => {
+    expect(classifyKillOutcome(undefined)).toBe('alive');
+    expect(classifyKillOutcome('ESRCH')).toBe('dead');
+    expect(classifyKillOutcome('EPERM')).toBe('alive');
+    expect(classifyKillOutcome('ETIMEDOUT')).toBe('unknown');
+    expect(classifyKillOutcome('EINVAL')).toBe('unknown');
+  });
+});
+
+describe('lockOwnerIsReclaimable — Defect-1 lock-staleness decision', () => {
+  it('reclaims ONLY a confirmed-dead owner', () => {
+    expect(lockOwnerIsReclaimable('dead')).toBe(true);
+  });
+  it('never reclaims a live owner', () => {
+    expect(lockOwnerIsReclaimable('alive')).toBe(false);
+  });
+  it('never reclaims on an unknown (flaky) probe — the split-brain guard', () => {
+    // The whole point: a tasklist timeout must NOT let a second daemon remove a
+    // live daemon's lock. unknown → not reclaimable → acquireLock returns false
+    // ("assume a live daemon holds it") rather than stomping the lock.
+    expect(lockOwnerIsReclaimable('unknown')).toBe(false);
+  });
+});

--- a/src/shared/__tests__/wmuxProjectConfig.test.ts
+++ b/src/shared/__tests__/wmuxProjectConfig.test.ts
@@ -294,6 +294,107 @@ describe('normalizeWmuxProjectConfig — X8 supervision (strict, decision ⑪)',
   });
 });
 
+describe('normalizeWmuxProjectConfig — unattended sugar + restorePermissionMode (decision ⑨/⑩)', () => {
+  function layoutWith(leaf: Record<string, unknown>) {
+    return { direction: 'horizontal', panes: [{ command: 'claude', ...leaf }, { command: 'echo sibling' }] };
+  }
+  function firstLeaf(input: Record<string, unknown>) {
+    const config = normalizeWmuxProjectConfig({ layout: layoutWith(input) });
+    const layout = config?.layout;
+    if (!layout || layout.type !== 'branch') return undefined;
+    return layout.children[0];
+  }
+
+  it('expands `unattended: true` to restart:on-failure + restorePermissionMode', () => {
+    expect(firstLeaf({ unattended: true })).toEqual({
+      type: 'leaf',
+      command: 'claude',
+      restart: 'on-failure',
+      restorePermissionMode: true,
+    });
+  });
+
+  it('lets an explicit restart override the sugar default (keeps restore)', () => {
+    expect(firstLeaf({ unattended: true, restart: 'always' })).toEqual({
+      type: 'leaf',
+      command: 'claude',
+      restart: 'always',
+      restorePermissionMode: true,
+    });
+  });
+
+  it('lets explicit restorePermissionMode:false opt out of restore while staying supervised', () => {
+    const leaf = firstLeaf({ unattended: true, restorePermissionMode: false });
+    expect(leaf).toEqual({ type: 'leaf', command: 'claude', restart: 'on-failure' });
+    expect(leaf && 'restorePermissionMode' in leaf).toBe(false);
+  });
+
+  it('accepts the explicit (non-sugar) restart + restorePermissionMode form', () => {
+    expect(firstLeaf({ restart: 'always', restorePermissionMode: true })).toEqual({
+      type: 'leaf',
+      command: 'claude',
+      restart: 'always',
+      restorePermissionMode: true,
+    });
+  });
+
+  it('carries restartLimit alongside the unattended expansion', () => {
+    expect(firstLeaf({ unattended: true, restartLimit: { burst: 3 } })).toEqual({
+      type: 'leaf',
+      command: 'claude',
+      restart: 'on-failure',
+      restartLimit: { burst: 3 },
+      restorePermissionMode: true,
+    });
+  });
+
+  it('treats `unattended: false` as a no-op', () => {
+    expect(firstLeaf({ unattended: false })).toEqual({ type: 'leaf', command: 'claude' });
+  });
+
+  it('treats a bare `restorePermissionMode: false` as a no-op', () => {
+    expect(firstLeaf({ restorePermissionMode: false })).toEqual({ type: 'leaf', command: 'claude' });
+  });
+
+  it('rejects restore-without-supervision: unattended:true + restart:never (conflict guard)', () => {
+    expect(
+      normalizeWmuxProjectConfig({ layout: layoutWith({ unattended: true, restart: 'never' }) }),
+    ).toBeUndefined();
+  });
+
+  it('rejects a bare restorePermissionMode:true with no restart (conflict guard)', () => {
+    expect(normalizeWmuxProjectConfig({ layout: layoutWith({ restorePermissionMode: true }) })).toBeUndefined();
+  });
+
+  it('rejects unattended:true on a leaf with no command (restart needs a unit)', () => {
+    expect(
+      normalizeWmuxProjectConfig({ layout: { direction: 'horizontal', panes: [{ unattended: true }, { command: 'x' }] } }),
+    ).toBeUndefined();
+  });
+
+  it('rejects unattended:true alongside a url', () => {
+    expect(
+      normalizeWmuxProjectConfig({
+        layout: { direction: 'horizontal', panes: [{ url: 'http://localhost:3000', unattended: true }, { command: 'x' }] },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('drops the layout on a non-boolean unattended (no silent downgrade)', () => {
+    expect(normalizeWmuxProjectConfig({ layout: layoutWith({ unattended: 'yes' }) })).toBeUndefined();
+    expect(normalizeWmuxProjectConfig({ layout: layoutWith({ unattended: 1 }) })).toBeUndefined();
+  });
+
+  it('drops the layout on a non-boolean restorePermissionMode', () => {
+    expect(
+      normalizeWmuxProjectConfig({ layout: layoutWith({ restart: 'always', restorePermissionMode: 'true' }) }),
+    ).toBeUndefined();
+    expect(
+      normalizeWmuxProjectConfig({ layout: layoutWith({ restart: 'always', restorePermissionMode: 1 }) }),
+    ).toBeUndefined();
+  });
+});
+
 describe('isValidProjectRelativeCwd', () => {
   it('accepts plain relative segments', () => {
     expect(isValidProjectRelativeCwd('src')).toBe(true);

--- a/src/shared/processLiveness.ts
+++ b/src/shared/processLiveness.ts
@@ -1,0 +1,49 @@
+// Three-state process-liveness classification, shared by the main-side daemon
+// launcher (checkProcessLiveness) and the daemon itself (acquireLock). Kept PURE
+// (no fs / child_process / electron) so both bundles import the exact same
+// contract — the daemon runs as a bare Node process and must not pull in
+// launcher.ts (which imports electron) — and so vitest can pin it directly.
+//
+// A probe FAILURE (timeout / exec error) is `unknown`, NEVER `dead`. Reading a
+// flaky probe as "process absent" was Defect-1 of the duplicate-daemon /
+// split-brain chain: a second daemon whose `tasklist` stalled under load read a
+// LIVE daemon's lock as stale, removed it, and spawned over it → session-pipe
+// EADDRINUSE → terminal reset. Only positive confirmation of death may authorize
+// a destructive / spawn-over branch.
+
+export type ProcessLiveness = 'alive' | 'dead' | 'unknown';
+
+/**
+ * Classify a Windows `tasklist` probe result. `stdout === null` means the probe
+ * itself failed (timeout under Defender realtime scan, CPU/WMI pressure, exec
+ * error) — that is `unknown`, NOT `dead`. Only an authoritative listing (exec
+ * succeeded) with the PID absent is `dead`.
+ */
+export function classifyTasklistOutput(pid: number, stdout: string | null): ProcessLiveness {
+  if (stdout === null) return 'unknown';
+  return stdout.includes(`"${pid}"`) ? 'alive' : 'dead';
+}
+
+/**
+ * Classify a POSIX `process.kill(pid, 0)` outcome. No error → the signal reached
+ * a live process (`alive`). `ESRCH` → authoritative "no such process" (`dead`).
+ * `EPERM` → the process exists but we may not signal it (`alive`). Anything else
+ * → `unknown`.
+ */
+export function classifyKillOutcome(code: string | undefined): ProcessLiveness {
+  if (code === undefined) return 'alive';
+  if (code === 'ESRCH') return 'dead';
+  if (code === 'EPERM') return 'alive';
+  return 'unknown';
+}
+
+/**
+ * A daemon lock file is reclaimable ONLY when its owner PID is positively
+ * confirmed dead. `alive` (owner running) and `unknown` (a flaky probe) both
+ * mean "assume a live daemon holds it — do NOT remove the lock and spawn over
+ * it." This is the daemon-side counterpart of the launcher's "treat unknown as
+ * alive, do not spawn" rule (Defect-1 of the split-brain chain).
+ */
+export function lockOwnerIsReclaimable(liveness: ProcessLiveness): boolean {
+  return liveness === 'dead';
+}

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -468,6 +468,18 @@ export interface DaemonCreateSessionParams {
 export interface DaemonSupervisionPolicy {
   restart: 'on-failure' | 'always';
   limit: { burst: number; healthyUptimeSec: number };
+  /**
+   * Unattended reboot-survival: when true, a supervised replay (recovery /
+   * restart) re-applies the pane's CAPTURED permission mode (from its
+   * resumeBinding) so an unattended agent resumes without stalling at a prompt.
+   * This is the EFFECTIVE, consent-gated decision — main computes it at creation
+   * as `leaf.restorePermissionMode && the project's explicit unattended consent`
+   * (see ProjectTrustRecord.unattended) and persists it. The daemon honors this
+   * bit verbatim at replay and reads no trust file (Minimal design 2026-07-01:
+   * trust is re-checked at CREATION, consistent with X6/X8 replay). Absent/false
+   * → the D6 fail-safe (no bypass flag added). Only meaningful with `restart`.
+   */
+  restorePermissionMode?: boolean;
 }
 
 /**

--- a/src/shared/wmuxProjectConfig.ts
+++ b/src/shared/wmuxProjectConfig.ts
@@ -76,6 +76,20 @@ export interface WmuxProjectLayoutLeaf {
   /** X8 runaway-guard bounds. Partial by design: only author-written fields
    * survive normalization; omitted ones default at the funnel (SSOT consts). */
   restartLimit?: { burst?: number; healthyUptimeSec?: number };
+  /**
+   * Unattended reboot-survival opt-in (the normalized, EXPANDED flag). When
+   * true, a reboot/crash replay re-applies the agent's captured permission mode
+   * (e.g. `--dangerously-skip-permissions`) so an unattended agent resumes
+   * without stalling at a prompt. This is only an INTENT: the daemon honors it
+   * at replay ONLY against a matching, still-trusted per-session grant (live
+   * content-hash + trust-epoch re-check — see the unattended-supervisor plan).
+   * Requires an effective `restart` (a bare restore with no supervision is a
+   * contradiction and rejects the layout). Authors usually write the
+   * `unattended: true` sugar, which expands to `restart: 'on-failure'` (exit 0
+   * = task done, only crashes relaunch) + this flag; explicit `restart` /
+   * `restorePermissionMode` override the expansion.
+   */
+  restorePermissionMode?: boolean;
 }
 
 export interface WmuxProjectLayoutBranch {
@@ -221,14 +235,31 @@ function clampSupervisionBound(value: number, min: number, max: number): number 
  */
 type NormalizedSupervision =
   | 'invalid'
-  | { restart?: 'on-failure' | 'always'; restartLimit?: { burst?: number; healthyUptimeSec?: number } };
+  | {
+      restart?: 'on-failure' | 'always';
+      restartLimit?: { burst?: number; healthyUptimeSec?: number };
+      restorePermissionMode?: boolean;
+    };
 
 function normalizeSupervision(
   rawRestart: unknown,
   rawLimit: unknown,
   command: string | undefined,
   url: string | undefined,
+  rawUnattended: unknown,
+  rawRestorePermissionMode: unknown,
 ): NormalizedSupervision {
+  // `unattended: true` sugar (decision ⑨/⑩): one word to declare a
+  // reboot-surviving unattended agent. Expands to `restart: 'on-failure'`
+  // (exit 0 = task done → respected; only crashes relaunch) + permission-mode
+  // restore on reboot. Explicit `restart` / `restorePermissionMode` override the
+  // expansion. Strict: a non-boolean `unattended` is a typo, not a downgrade.
+  let sugar = false;
+  if (rawUnattended !== undefined) {
+    if (typeof rawUnattended !== 'boolean') return 'invalid';
+    sugar = rawUnattended;
+  }
+
   // restart enum. Accept exactly 'on-failure' | 'always' | 'never'; 'never'
   // normalizes to "field omitted" (documented no-op alias). Any other defined
   // value is a typo we refuse to silently downgrade → invalid.
@@ -241,6 +272,21 @@ function normalizeSupervision(
     } else {
       return 'invalid';
     }
+  } else if (sugar) {
+    // Sugar fills restart ONLY when the author didn't write one. An explicit
+    // `restart: 'never'` stays "unsupervised" and collides with the sugar's
+    // permission-restore intent below (rejected — decision ⑨ conflict guard).
+    restart = 'on-failure';
+  }
+
+  // restorePermissionMode: explicit boolean, or true via `unattended` sugar
+  // (unless the author explicitly set it false). Strict on non-boolean.
+  let restorePermissionMode: boolean | undefined;
+  if (rawRestorePermissionMode !== undefined) {
+    if (typeof rawRestorePermissionMode !== 'boolean') return 'invalid';
+    if (rawRestorePermissionMode) restorePermissionMode = true;
+  } else if (sugar) {
+    restorePermissionMode = true;
   }
 
   // An effective restart needs a command (the process IS the unit) and cannot
@@ -249,6 +295,12 @@ function normalizeSupervision(
     if (command === undefined) return 'invalid';
     if (url !== undefined) return 'invalid';
   }
+
+  // Permission-mode restore is meaningless — and contradictory — without
+  // supervision: only a replayed exec unit can have anything restored on
+  // reboot. Reject `unattended:true` + `restart:'never'`, or a bare
+  // `restorePermissionMode:true` with no restart (decision ⑨ conflict guard).
+  if (restorePermissionMode === true && restart === undefined) return 'invalid';
 
   // restartLimit: present fields must validate; missing fields stay absent and
   // are defaulted at the funnel. Accept a partial object (only one field).
@@ -277,9 +329,17 @@ function normalizeSupervision(
   }
 
   // A restartLimit with no effective restart is a cosmetic orphan — drop it
-  // silently (it changes nothing) rather than reject the layout.
+  // silently (it changes nothing) rather than reject the layout. (restorePermission
+  // is guaranteed absent here — the conflict guard above already rejected it.)
   if (restart === undefined) return {};
-  return restartLimit !== undefined ? { restart, restartLimit } : { restart };
+  const result: {
+    restart: 'on-failure' | 'always';
+    restartLimit?: { burst?: number; healthyUptimeSec?: number };
+    restorePermissionMode?: boolean;
+  } = { restart };
+  if (restartLimit !== undefined) result.restartLimit = restartLimit;
+  if (restorePermissionMode === true) result.restorePermissionMode = true;
+  return result;
 }
 
 /** Returns the normalized node, or null when ANY part is invalid — layout is
@@ -296,6 +356,8 @@ function normalizeLayoutNode(input: unknown, depth: number, budget: LayoutBudget
     url?: unknown;
     restart?: unknown;
     restartLimit?: unknown;
+    unattended?: unknown;
+    restorePermissionMode?: unknown;
   };
 
   // Branch: presence of `panes` is the discriminator.
@@ -336,7 +398,14 @@ function normalizeLayoutNode(input: unknown, depth: number, budget: LayoutBudget
 
   // X8 supervision (decision ⑪ — STRICT; a bad value drops the whole layout
   // rather than silently downgrading to unsupervised).
-  const supervision = normalizeSupervision(src.restart, src.restartLimit, command, url);
+  const supervision = normalizeSupervision(
+    src.restart,
+    src.restartLimit,
+    command,
+    url,
+    src.unattended,
+    src.restorePermissionMode,
+  );
   if (supervision === 'invalid') return null;
 
   const leaf: WmuxProjectLayoutLeaf = { type: 'leaf' };
@@ -345,6 +414,7 @@ function normalizeLayoutNode(input: unknown, depth: number, budget: LayoutBudget
   if (url !== undefined) leaf.url = url;
   if (supervision.restart !== undefined) leaf.restart = supervision.restart;
   if (supervision.restartLimit !== undefined) leaf.restartLimit = supervision.restartLimit;
+  if (supervision.restorePermissionMode === true) leaf.restorePermissionMode = true;
   return leaf;
 }
 

--- a/src/shared/wmuxProjectConfig.ts
+++ b/src/shared/wmuxProjectConfig.ts
@@ -130,6 +130,13 @@ export interface ProjectConfigState {
   invalid?: boolean;
   contentHash?: string;
   trust?: ProjectTrustState;
+  /**
+   * Unattended reboot-survival consent for THESE bytes (surfaced only when
+   * `trust === 'trusted'`). Drives the layout funnel's per-leaf
+   * `restorePermissionMode` gate: an unattended leaf restores its captured
+   * permission mode on reboot ONLY when the user gave this explicit consent.
+   */
+  unattended?: boolean;
 }
 
 // ── Field validators ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

**Unattended supervisor (headline feature)**
- `wmux.json` gains an `unattended: true` leaf option that restarts a pane on failure (clean exit ≠ crash) and, only with a separate explicit consent given in the trust dialog, restores the permission mode it was running under before a restart.
- Fleet View surfaces each pane's supervision state — armed with a restart count, or a guard-tripped marker when the runaway guard stopped it.
- Daemon liveness moves to a three-state (unknown/alive/dead) probe shared between the daemon and launcher, closing the daemon-side half of the "probe timeout → assume dead" anti-pattern behind earlier false-death and duplicate-daemon reports.
- A field-drop bug (the consent bit silently lost across three field-by-field supervision copies on the create path, invisible to tsc because the field is optional at every hop) is caught and fixed with a dedicated bundled-daemon probe.

**Reboot-reattach RCA fix**
Root cause: an OS reboot kills the daemon's PTY children before the daemon itself. Unable to tell that apart from a user exit, the daemon tombstoned every in-use session as `dead`, and recovery skips `dead` — purging exactly the sessions that were being used while unobserved ghosts survived. Renderer reconcile then found nothing to reattach to and self-created fresh terminals ("session reset after every reboot").

- **Daemon**: classify the Windows shutdown-teardown exit code (and any exit during our own graceful shutdown) as involuntary → suspend the session (buffer dumped, state persisted) instead of killing it, so recovery replays it under the same id. A 15s reclassification timer corrects a cancelled-shutdown false positive back to a normal death.
- **Main**: `session-end` no longer reloads-and-resaves a stale on-disk snapshot (which could resurrect a `.bak` fossil); session data is now persisted the instant a pane's ptyId changes instead of only every 5s, closing the reboot-timing gap. `SessionManager.load()` now distinguishes "no file" from "file exists but unreadable" so a transient lock at boot can't be mistaken for first-launch and silently overwrite a good session.
- **Renderer**: event-driven immediate persistence on every binding call site (not just 2 of 9), plus a `surfaceId`-based rebind so a stale ptyId confirmed dead across two daemon snapshots can reattach to a live session on the same surface instead of clearing.
- **Terminal**: a recovered session's scrollback replay was re-arming leaked mouse-tracking modes from the dead process, which silently dismissed the resume prompt the instant the mouse moved toward it — reset those modes after a replay.
- **Bridge**: the permission-mode extractor only recognized inline stamps on user turns, which a large attachment record could push out of the read window — it now also recognizes Claude Code's dedicated permission-mode record.

## Adversarial review finding (fixed in this PR)

An independent adversarial review subagent caught a real crash risk introduced by the shutdown-kill suspend path: `session:interrupted` deliberately skips the `session.died` broadcast (so a still-alive renderer doesn't clear its binding mid-window), but it also skipped the `SessionPipe`/data-listener cleanup that `session:died` always does. For up to 15s — the exact misclassification window the reclassify timer exists to cover — a still-connected client's keystrokes would forward straight into a destroyed `ptyProcess.write()` with no error handling, which the daemon's own uncaughtException handler treats as fatal after 3 repeats, crashing the daemon and taking every other session down as collateral. Fixed by stopping the pipe on suspend and rejecting `attachSession`/`resizeSession` against a suspended session. Verified with 2 new unit tests and a new P6 check in the dynamic probe that attaches to a suspended session through the real bundled daemon and confirms it survives.

## Test Coverage

Extensive unit test coverage across all touched modules (DaemonSessionManager, SessionManager, AppLayout, surfaceSlice, useTerminal, pty.handler, bridge extractor) plus two dynamic bundled-daemon probes (`scripts/u-perm-restore-probe.mjs`, `scripts/shutdown-kill-suspend-probe.mjs`) that exercise the real create → persist → kill → recover → respawn chain end to end — the class of wiring-drop bug unit tests with a mocked PTY bridge structurally cannot catch.

Full suite: 4555 pass, 0 fail, 7 skipped. tsc clean.

## Pre-Landing Review

Self-reviewed (SQL/data-safety N/A — no DB in this diff; race-condition, trust-boundary, and state-machine-completeness passes done manually against the diff). One adversarial-review finding (above), fixed with tests.

## Verification

- All 9 checks pass in `scripts/shutdown-kill-suspend-probe.mjs` (bundled daemon: shutdown-kill classification, persistence, cross-restart recovery under the same id, reclassification, and the new crash-prevention check).
- All checks pass in `scripts/u-perm-restore-probe.mjs` (consent-gated permission restore across the full create/persist/respawn/recover/spawn chain).
- **Live OS reboot dogfood**: confirmed working — sessions reattach under the same id after a real reboot, with attached sessions' scrollback intact.

## Test plan

- [x] Full test suite passes (4555 tests, 0 failures)
- [x] tsc clean
- [x] Dynamic bundled-daemon probes pass (16 checks total across 2 probes)
- [x] Live OS reboot dogfood confirmed by the user