### PR TITLE
feat(channels): durable inbox v2 with per-member cursors, agent ack, a wmux channel CLI, and a wake worker

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -255,7 +255,7 @@ Total: **124** methods (`ALL_RPC_METHODS` in
 
 ## Event types
 
-The EventBus exposes **14** event types
+The EventBus exposes **15** event types
 (`WMUX_EVENT_TYPES` in `src/shared/events.ts`), polled via `events.poll`.
 Wire shapes (the fields beyond the common `seq` / `ts` / `workspaceId` /
 `type`) are documented in [`inventory.md`](./inventory.md#event-types) and
@@ -277,6 +277,7 @@ typed in `src/shared/events.ts`.
 | `a2a.task` |
 | `channel.message` |
 | `channel.catalog` |
+| `channel.nudgeExhausted` |
 
 ---
 

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -26,7 +26,7 @@ returns `EPERM`. Wire framing: newline-delimited JSON, one object per line.
 
 ## RPC methods
 
-Total: **123** methods (`ALL_RPC_METHODS` in
+Total: **124** methods (`ALL_RPC_METHODS` in
 `src/shared/rpc.ts`). Capability and risk class are read from
 `src/main/mcp/methodCapabilityMap.ts`:
 
@@ -169,6 +169,7 @@ Total: **123** methods (`ALL_RPC_METHODS` in
 | `a2a.channel.invite` | `a2a.channel.send` | `a2a` |
 | `a2a.channel.kick` | `a2a.channel.send` | `a2a` *(renderer-only; not routed on the main pipe/MCP path)* |
 | `a2a.channel.ack` | `a2a.channel.read` | `a2a` |
+| `a2a.channel.unread` | `a2a.channel.read` | `a2a` |
 
 ### `company.a2a`
 

--- a/scripts/channels-v2-inbox-probe.mjs
+++ b/scripts/channels-v2-inbox-probe.mjs
@@ -118,11 +118,17 @@ function rpc(socket, method, params, authToken, timeoutMs = 30_000) {
   });
 }
 
-/** Attach to a session's dedicated pipe and stream its PTY output. */
-function tapSessionStream(sessionId, authToken) {
+/**
+ * Attach to a session's dedicated pipe and stream its PTY output.
+ * On POSIX the daemon derives the socket path from ITS home — which the
+ * probe overrides to the isolated testHome — so the tap must resolve
+ * against testHome too, not the probe's own os.homedir() (CodeRabbit
+ * review; Windows named pipes live in a global namespace and don't care).
+ */
+function tapSessionStream(sessionId, authToken, homeDir) {
   const pipeName = process.platform === 'win32'
     ? `\\\\.\\pipe\\wmux-session-${sessionId}`
-    : path.join(os.homedir(), `.wmux-session-${sessionId}.sock`);
+    : path.join(homeDir, `.wmux-session-${sessionId}.sock`);
   const chunks = [];
   return new Promise((resolve, reject) => {
     const s = net.createConnection(pipeName, () => {
@@ -139,6 +145,19 @@ function tapSessionStream(sessionId, authToken) {
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// Live handles for crash-path cleanup: a thrown RPC timeout or respawn
+// failure must not leak a RUNNING daemon or open pipes (CodeRabbit review).
+// The happy path tears these down in-line; the main().catch handler sweeps
+// whatever is still live. The temp home is deliberately KEPT on crash —
+// it holds the daemon's channels.json/sessions state, i.e. the postmortem.
+const live = { daemon: null, sock: null, tapB: null, home: null };
+function cleanupLive() {
+  try { live.tapB?.close(); } catch { /* ignore */ }
+  try { live.sock?.destroy(); } catch { /* ignore */ }
+  try { live.daemon?.kill('SIGKILL'); } catch { /* ignore */ }
+  live.tapB = live.sock = live.daemon = null;
+}
+
 async function main() {
   if (!fs.existsSync(DAEMON_BUNDLE)) {
     console.error(`Daemon bundle missing: ${DAEMON_BUNDLE}\nRun: npm run build:daemon`);
@@ -149,6 +168,7 @@ async function main() {
   const testHome = path.join(os.tmpdir(), `wmux-${tag}`);
   const wmuxDir = path.join(testHome, '.wmux');
   fs.mkdirSync(wmuxDir, { recursive: true });
+  live.home = testHome;
   const pipeName = makePipeName(tag);
   const authToken = randomUUID();
   writeConfig(wmuxDir, pipeName, authToken);
@@ -171,9 +191,9 @@ async function main() {
 
   console.log(`channels-v2-inbox-probe — home=${testHome}`);
   const d1Log = [];
-  let daemon = spawnDaemon(testHome, d1Log);
+  let daemon = (live.daemon = spawnDaemon(testHome, d1Log));
   let resolved = await waitForPipeFile(wmuxDir);
-  let sock = await connectSocket(resolved);
+  let sock = (live.sock = await connectSocket(resolved));
 
   // Two live "agent panes": A (sender) and B (the nudge target). Interactive
   // shells — they idle at a prompt, which is exactly the wake worker's
@@ -187,7 +207,7 @@ async function main() {
 
   // P5 needs the session pipe live — attach B and tap its stream.
   await rpc(sock, 'daemon.attachSession', { id: SESS_B }, authToken);
-  const tapB = await tapSessionStream(SESS_B, authToken);
+  const tapB = (live.tapB = await tapSessionStream(SESS_B, authToken, testHome));
 
   // --- P1: stamped create (senderPtyId only) ---
   const created = await rpc(sock, 'a2a.channel.create', {
@@ -235,6 +255,14 @@ async function main() {
     posted?.ok === true && entryB?.unread === 1 && entryB?.mentionUnread === 1,
     `entry=${JSON.stringify(entryB ?? null)}`);
 
+  // --- P4b: the POSTER owes nothing about its own message (self-exemption +
+  // caught-up cursor ride — Codex review) ---
+  const unreadA = await rpc(sock, 'a2a.channel.unread', { senderPtyId: SESS_A }, authToken);
+  const entryA = (unreadA?.entries ?? []).find((e) => e.channelId === channelId);
+  check('P4b poster owes nothing about its own post (cursor rode over it)',
+    entryA != null && entryA.unread === 0 && entryA.lastReadSeq === 1,
+    `entry=${JSON.stringify(entryA ?? null)}`);
+
   // --- P5: wake worker injects the nudge into B's PTY ---
   // Quiet gate = 10s of output silence; tick = 15s (post fast-path kicks a
   // sweep 1s after the post but the fresh prompt keeps the pane "active"
@@ -280,15 +308,15 @@ async function main() {
   // connect while the new listener comes up.
   try { fs.unlinkSync(path.join(wmuxDir, 'daemon-pipe')); } catch { /* ignore */ }
   const d2Log = [];
-  daemon = spawnDaemon(testHome, d2Log);
+  daemon = live.daemon = spawnDaemon(testHome, d2Log);
   resolved = await waitForPipeFile(wmuxDir);
-  sock = null;
+  sock = live.sock = null;
   {
     const deadline = Date.now() + 10_000;
     let lastErr = null;
     while (Date.now() < deadline && !sock) {
       try {
-        sock = await connectSocket(resolved);
+        sock = live.sock = await connectSocket(resolved);
       } catch (err) {
         lastErr = err;
         await sleep(300);
@@ -310,9 +338,8 @@ async function main() {
     persistedCursor === (entryB?.headSeq ?? 1) && entryB3?.unread === 0,
     `disk=${persistedCursor} respawned=${JSON.stringify(entryB3 ?? unread3)}`);
 
-  // Teardown.
-  try { sock.destroy(); } catch { /* ignore */ }
-  try { daemon.kill('SIGKILL'); } catch { /* ignore */ }
+  // Teardown (happy path also removes the temp home).
+  cleanupLive();
   await sleep(300);
   try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* ignore */ }
 
@@ -323,5 +350,7 @@ async function main() {
 
 main().catch((err) => {
   console.error('probe crashed:', err);
+  cleanupLive();
+  if (live.home) console.error(`temp home kept for postmortem: ${live.home}`);
   process.exit(1);
 });

--- a/scripts/channels-v2-inbox-probe.mjs
+++ b/scripts/channels-v2-inbox-probe.mjs
@@ -279,6 +279,19 @@ async function main() {
   check('P5 wake worker injected the nudge line into the idle member pane', nudged,
     nudged ? undefined : `streamTail=${JSON.stringify(tapB.text().slice(-200))}`);
 
+  // --- P6a: a HUMAN-style ack (no memberId — the renderer's open-channel
+  // read receipt) must NOT consume the agent's cursor (Codex re-review P1:
+  // a human glancing at a channel used to clear agent unread and silence
+  // the wake worker on unprocessed work) ---
+  const receiptAck = await rpc(sock, 'a2a.channel.ack', {
+    channelId, uptoSeq: entryB?.headSeq ?? 1, senderPtyId: SESS_B,
+  }, authToken);
+  const unreadAfterReceipt = await rpc(sock, 'a2a.channel.unread', { senderPtyId: SESS_B }, authToken);
+  const entryBr = (unreadAfterReceipt?.entries ?? []).find((e) => e.channelId === channelId && e.memberId === 'codex');
+  check('P6a receipt-only ack (no memberId) leaves the agent cursor untouched',
+    receiptAck?.ok === true && entryBr?.unread === 1 && entryBr?.lastReadSeq === 0,
+    `after=${JSON.stringify(entryBr ?? null)}`);
+
   // --- P6: agent ack clears unread ---
   const acked = await rpc(sock, 'a2a.channel.ack', {
     channelId, uptoSeq: entryB?.headSeq ?? 1, memberId: 'codex', senderPtyId: SESS_B,

--- a/scripts/channels-v2-inbox-probe.mjs
+++ b/scripts/channels-v2-inbox-probe.mjs
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+/**
+ * Channels v2 durable-inbox probe — end-to-end through the REAL bundled
+ * daemon (isolated home + pipe; production wmux untouched).
+ *
+ * Chain under test (steps 0–3a of the redesign):
+ *   daemon-side caller stamping (senderPtyId → env-record workspace) →
+ *   member cursor (lastReadSeq) → unread/mention read model → agent ack →
+ *   wake-worker PTY nudge injection → cursor survival across daemon death.
+ *
+ * PASS criteria:
+ *   P1  create with senderPtyId ONLY (no verifiedWorkspaceId) → stamped:
+ *       channel.createdBy === ws-A
+ *   P2  mutation with an unresolvable senderPtyId → NOT_AUTHORIZED (fail-closed)
+ *   P3  join with senderPtyId B + member{memberId} (no workspace claim) →
+ *       roster row pinned to ws-B
+ *   P4  post from A @mentioning ws-B → B's a2a.channel.unread reports
+ *       unread=1, mentionUnread=1
+ *   P5  the wake worker injects the nudge line into B's PTY (observed via
+ *       the session pipe stream: '[wmux] #<channel>' + the read command)
+ *   P6  agent ack (memberId-narrowed, uptoSeq=head) → unread=0
+ *   P7  daemon SIGKILL + respawn → the cursor SURVIVED daemon death:
+ *       channels.json carries lastReadSeq AND a fresh unread query over the
+ *       respawned daemon still reports 0 for B
+ *
+ * Run: npm run build:daemon && node scripts/channels-v2-inbox-probe.mjs
+ */
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DAEMON_BUNDLE = path.join(REPO_ROOT, 'dist', 'daemon-bundle', 'index.js');
+
+const WS_A = 'ws-probe-a';
+const WS_B = 'ws-probe-b';
+const SESS_A = 'sess-agent-a';
+const SESS_B = 'sess-agent-b';
+
+function makePipeName(tag) {
+  return process.platform === 'win32'
+    ? `\\\\.\\pipe\\wmux-test-${tag}`
+    : path.join(os.tmpdir(), `wmux-test-${tag}.sock`);
+}
+
+function writeConfig(wmuxDir, pipeName, authToken) {
+  fs.writeFileSync(
+    path.join(wmuxDir, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      daemon: { pipeName, logLevel: 'info', autoStart: true },
+      session: {
+        defaultShell: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
+        defaultCols: 80, defaultRows: 24, bufferSizeMb: 8, bufferMaxMb: 64,
+        deadSessionTtlHours: 24, deadSessionDumpBuffer: true,
+      },
+    }, null, 2),
+  );
+  fs.writeFileSync(path.join(wmuxDir, 'daemon-auth-token'), authToken, 'utf-8');
+}
+
+function spawnDaemon(testHome, logChunks) {
+  const d = spawn(process.execPath, [DAEMON_BUNDLE], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, USERPROFILE: testHome, HOME: testHome, HOMEDRIVE: undefined, HOMEPATH: undefined },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  d.stdout.on('data', (c) => logChunks && logChunks.push(c.toString()));
+  d.stderr.on('data', (c) => logChunks && logChunks.push(c.toString()));
+  return d;
+}
+
+async function waitForPipeFile(wmuxDir, timeoutMs = 15_000) {
+  const pipeFile = path.join(wmuxDir, 'daemon-pipe');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(pipeFile)) return fs.readFileSync(pipeFile, 'utf-8').trim();
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error('daemon-pipe did not appear within timeout');
+}
+
+function connectSocket(pipeName) {
+  return new Promise((resolve, reject) => {
+    const s = net.createConnection(pipeName, () => resolve(s));
+    s.on('error', reject);
+  });
+}
+
+function rpc(socket, method, params, authToken, timeoutMs = 30_000) {
+  return new Promise((resolve, reject) => {
+    const id = `req-${Math.random().toString(36).slice(2, 10)}`;
+    let buffer = '';
+    const handler = (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id === id) {
+            socket.removeListener('data', handler);
+            if (msg.ok) resolve(msg.result);
+            else reject(new Error(typeof msg.error === 'string' ? msg.error : JSON.stringify(msg.error)));
+            return;
+          }
+        } catch { /* ignore */ }
+      }
+    };
+    socket.on('data', handler);
+    socket.write(JSON.stringify({ id, method, params, token: authToken }) + '\n');
+    setTimeout(() => { socket.removeListener('data', handler); reject(new Error(`rpc timeout: ${method}`)); }, timeoutMs);
+  });
+}
+
+/** Attach to a session's dedicated pipe and stream its PTY output. */
+function tapSessionStream(sessionId, authToken) {
+  const pipeName = process.platform === 'win32'
+    ? `\\\\.\\pipe\\wmux-session-${sessionId}`
+    : path.join(os.homedir(), `.wmux-session-${sessionId}.sock`);
+  const chunks = [];
+  return new Promise((resolve, reject) => {
+    const s = net.createConnection(pipeName, () => {
+      s.write(authToken + '\n');
+      resolve({
+        text: () => chunks.join(''),
+        close: () => { try { s.destroy(); } catch { /* ignore */ } },
+      });
+    });
+    s.on('data', (c) => chunks.push(c.toString()));
+    s.on('error', reject);
+  });
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function main() {
+  if (!fs.existsSync(DAEMON_BUNDLE)) {
+    console.error(`Daemon bundle missing: ${DAEMON_BUNDLE}\nRun: npm run build:daemon`);
+    process.exit(2);
+  }
+
+  const tag = `chv2-${randomUUID().slice(0, 8)}`;
+  const testHome = path.join(os.tmpdir(), `wmux-${tag}`);
+  const wmuxDir = path.join(testHome, '.wmux');
+  fs.mkdirSync(wmuxDir, { recursive: true });
+  const pipeName = makePipeName(tag);
+  const authToken = randomUUID();
+  writeConfig(wmuxDir, pipeName, authToken);
+
+  const results = [];
+  const check = (name, ok, detail) => {
+    results.push({ name, ok });
+    console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+  };
+
+  const shell = process.platform === 'win32'
+    ? path.join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'cmd.exe')
+    : '/bin/sh';
+  const sessEnv = (ws) => ({
+    ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+    ...(process.env.ComSpec ? { ComSpec: process.env.ComSpec } : {}),
+    ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+    WMUX_WORKSPACE_ID: ws,
+  });
+
+  console.log(`channels-v2-inbox-probe — home=${testHome}`);
+  const d1Log = [];
+  let daemon = spawnDaemon(testHome, d1Log);
+  let resolved = await waitForPipeFile(wmuxDir);
+  let sock = await connectSocket(resolved);
+
+  // Two live "agent panes": A (sender) and B (the nudge target). Interactive
+  // shells — they idle at a prompt, which is exactly the wake worker's
+  // quiet-gate precondition.
+  await rpc(sock, 'daemon.createSession', {
+    id: SESS_A, cmd: shell, cwd: testHome, cols: 80, rows: 24, env: sessEnv(WS_A),
+  }, authToken);
+  await rpc(sock, 'daemon.createSession', {
+    id: SESS_B, cmd: shell, cwd: testHome, cols: 80, rows: 24, env: sessEnv(WS_B),
+  }, authToken);
+
+  // P5 needs the session pipe live — attach B and tap its stream.
+  await rpc(sock, 'daemon.attachSession', { id: SESS_B }, authToken);
+  const tapB = await tapSessionStream(SESS_B, authToken);
+
+  // --- P1: stamped create (senderPtyId only) ---
+  const created = await rpc(sock, 'a2a.channel.create', {
+    name: 'probe-inbox',
+    visibility: 'public',
+    createdBy: { memberId: 'pm', memberName: 'pm' },
+    senderPtyId: SESS_A,
+  }, authToken);
+  const channelId = created?.channel?.id ?? '';
+  check('P1 create stamped from session env (createdBy === ws-A)',
+    created?.ok === true && created?.channel?.createdBy === WS_A,
+    `createdBy=${created?.channel?.createdBy ?? '(none)'}`);
+
+  // --- P2: fail-closed on unresolvable senderPtyId ---
+  const ghost = await rpc(sock, 'a2a.channel.post', {
+    channelId, text: 'forged', sender: { memberId: 'x', memberName: 'x' }, senderPtyId: 'pty-ghost',
+  }, authToken);
+  check('P2 unresolvable senderPtyId mutation → NOT_AUTHORIZED',
+    ghost?.ok === false && ghost?.error?.code === 'NOT_AUTHORIZED',
+    ghost?.error?.message?.slice(0, 60));
+
+  // --- P3: join B with member backfill ---
+  const joined = await rpc(sock, 'a2a.channel.join', {
+    channelId, member: { memberId: 'codex', memberName: 'codex' }, senderPtyId: SESS_B,
+  }, authToken);
+  const members = await rpc(sock, 'a2a.channel.getMembers', {
+    channelId, senderPtyId: SESS_B,
+  }, authToken);
+  const rowB = (members?.members ?? []).find((m) => m.memberId === 'codex');
+  check('P3 join backfills the member workspace from the daemon stamp',
+    joined?.ok === true && rowB?.workspaceId === WS_B,
+    `row=${JSON.stringify(rowB ?? null)}`);
+
+  // --- P4: post with mention → unread + mentionUnread for B ---
+  const posted = await rpc(sock, 'a2a.channel.post', {
+    channelId,
+    text: 'codex: please handle this',
+    sender: { memberId: 'pm', memberName: 'pm' },
+    mentions: [{ workspaceId: WS_B, memberId: 'codex', name: 'codex' }],
+    senderPtyId: SESS_A,
+  }, authToken);
+  const unread1 = await rpc(sock, 'a2a.channel.unread', { senderPtyId: SESS_B }, authToken);
+  const entryB = (unread1?.entries ?? []).find((e) => e.channelId === channelId && e.memberId === 'codex');
+  check('P4 unread read-model: B owes 1 unread, 1 mention',
+    posted?.ok === true && entryB?.unread === 1 && entryB?.mentionUnread === 1,
+    `entry=${JSON.stringify(entryB ?? null)}`);
+
+  // --- P5: wake worker injects the nudge into B's PTY ---
+  // Quiet gate = 10s of output silence; tick = 15s (post fast-path kicks a
+  // sweep 1s after the post but the fresh prompt keeps the pane "active"
+  // for a bit). Poll the tapped stream up to 45s.
+  let nudged = false;
+  {
+    const deadline = Date.now() + 45_000;
+    while (Date.now() < deadline) {
+      const text = tapB.text();
+      if (text.includes('[wmux] #probe-inbox') && text.includes('wmux channel read')) { nudged = true; break; }
+      await sleep(1_000);
+    }
+  }
+  check('P5 wake worker injected the nudge line into the idle member pane', nudged,
+    nudged ? undefined : `streamTail=${JSON.stringify(tapB.text().slice(-200))}`);
+
+  // --- P6: agent ack clears unread ---
+  const acked = await rpc(sock, 'a2a.channel.ack', {
+    channelId, uptoSeq: entryB?.headSeq ?? 1, memberId: 'codex', senderPtyId: SESS_B,
+  }, authToken);
+  const unread2 = await rpc(sock, 'a2a.channel.unread', { senderPtyId: SESS_B }, authToken);
+  const entryB2 = (unread2?.entries ?? []).find((e) => e.channelId === channelId && e.memberId === 'codex');
+  check('P6 memberId-narrowed ack → unread 0 (cursor advanced)',
+    acked?.ok === true && entryB2?.unread === 0 && entryB2?.lastReadSeq === (entryB?.headSeq ?? 1),
+    `after=${JSON.stringify(entryB2 ?? null)}`);
+
+  // --- P7: cursor survives daemon DEATH (SIGKILL, no graceful flush) ---
+  tapB.close();
+  try { sock.destroy(); } catch { /* ignore */ }
+  daemon.kill('SIGKILL');
+  await sleep(1_500);
+
+  // channels.json on disk carries the cursor (saveImmediate on ack).
+  let persistedCursor = null;
+  try {
+    const state = JSON.parse(fs.readFileSync(path.join(wmuxDir, 'channels.json'), 'utf8'));
+    const row = (state.members?.[channelId] ?? []).find((m) => m.memberId === 'codex');
+    persistedCursor = row?.lastReadSeq ?? null;
+  } catch { /* file unreadable */ }
+
+  // The SIGKILLed daemon left a stale daemon-pipe hint file — remove it so
+  // waitForPipeFile observes the RESPAWNED daemon's write, and retry the
+  // connect while the new listener comes up.
+  try { fs.unlinkSync(path.join(wmuxDir, 'daemon-pipe')); } catch { /* ignore */ }
+  const d2Log = [];
+  daemon = spawnDaemon(testHome, d2Log);
+  resolved = await waitForPipeFile(wmuxDir);
+  sock = null;
+  {
+    const deadline = Date.now() + 10_000;
+    let lastErr = null;
+    while (Date.now() < deadline && !sock) {
+      try {
+        sock = await connectSocket(resolved);
+      } catch (err) {
+        lastErr = err;
+        await sleep(300);
+      }
+    }
+    if (!sock) throw lastErr ?? new Error('respawned daemon pipe never accepted');
+  }
+  // Recovery replays the session records (same ids, env preserved) — give it
+  // a moment, then query unread over the RESPAWNED daemon with B's identity.
+  await sleep(2_000);
+  let unread3 = null;
+  try {
+    unread3 = await rpc(sock, 'a2a.channel.unread', { senderPtyId: SESS_B }, authToken);
+  } catch (err) {
+    unread3 = { err: String(err) };
+  }
+  const entryB3 = (unread3?.entries ?? []).find?.((e) => e.channelId === channelId && e.memberId === 'codex');
+  check('P7 cursor survives daemon SIGKILL (persisted + respawned daemon agrees)',
+    persistedCursor === (entryB?.headSeq ?? 1) && entryB3?.unread === 0,
+    `disk=${persistedCursor} respawned=${JSON.stringify(entryB3 ?? unread3)}`);
+
+  // Teardown.
+  try { sock.destroy(); } catch { /* ignore */ }
+  try { daemon.kill('SIGKILL'); } catch { /* ignore */ }
+  await sleep(300);
+  try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* ignore */ }
+
+  const failed = results.filter((r) => !r.ok);
+  console.log(`\n${failed.length === 0 ? 'ALL PASS' : `${failed.length} FAILED`} (${results.length} checks)`);
+  process.exit(failed.length === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('probe crashed:', err);
+  process.exit(1);
+});

--- a/src/cli/commands/__tests__/channel.test.ts
+++ b/src/cli/commands/__tests__/channel.test.ts
@@ -1,0 +1,194 @@
+/**
+ * `wmux channel` — the universal agent surface for Channels v2.
+ *
+ * What these tests pin:
+ *  1. Transport: every subcommand rides the DAEMON pipe (sendDaemonRequest),
+ *     never the main pipe — that is what keeps the CLI working headless.
+ *  2. Identity: senderPtyId rides along (walk hit here via the mocked
+ *     resolveSelfContext; env-fallback is covered separately) and the CLI
+ *     NEVER claims a workspace (no verifiedWorkspaceId, no sender.workspaceId
+ *     — the daemon stamps/backfills those server-side).
+ *  3. Envelope unwrap: a daemon-level `{ok:false, error:{code,message}}`
+ *     RESULT (inside an ok pipe envelope) exits 1 with the code visible.
+ *  4. Fail-closed UX: a mutation with no resolvable pane identity exits 1
+ *     BEFORE any RPC is issued, with an actionable message.
+ *  5. Name → id resolution: `read general` resolves via a2a.channel.list.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../client', () => ({
+  sendRequest: vi.fn(),
+  sendDaemonRequest: vi.fn(),
+}));
+vi.mock('../../identity', () => ({
+  resolveSelfContext: vi.fn(),
+  getParentPidDefault: vi.fn(),
+}));
+
+import { sendDaemonRequest } from '../../client';
+import { resolveSelfContext } from '../../identity';
+import { handleChannel } from '../channel';
+
+const daemonRpc = sendDaemonRequest as unknown as ReturnType<typeof vi.fn>;
+const selfContext = resolveSelfContext as unknown as ReturnType<typeof vi.fn>;
+
+const ORIGINAL_ENV_PTY = process.env.WMUX_PTY_ID;
+const ORIGINAL_ENV_MEMBER = process.env.WMUX_MEMBER_ID;
+
+let exitSpy: ReturnType<typeof vi.spyOn>;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+class ExitCalled extends Error {
+  constructor(public readonly code: number | undefined) {
+    super(`exit(${code})`);
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.WMUX_PTY_ID;
+  delete process.env.WMUX_MEMBER_ID;
+  if (ORIGINAL_ENV_PTY !== undefined) process.env.WMUX_PTY_ID = undefined as unknown as string;
+  if (ORIGINAL_ENV_MEMBER !== undefined) process.env.WMUX_MEMBER_ID = undefined as unknown as string;
+  delete process.env.WMUX_PTY_ID;
+  delete process.env.WMUX_MEMBER_ID;
+  selfContext.mockResolvedValue({ ptyId: 'pty-self', workspaceId: 'ws-self' });
+  exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    throw new ExitCalled(code);
+  }) as never);
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+const okEnvelope = (result: unknown) => ({ id: 'x', ok: true as const, result });
+
+describe('wmux channel — transport + identity', () => {
+  it('unread rides the daemon pipe with senderPtyId and NO workspace claim', async () => {
+    daemonRpc.mockResolvedValue(okEnvelope({ ok: true, entries: [] }));
+    await handleChannel('unread', [], false);
+    expect(daemonRpc).toHaveBeenCalledWith('a2a.channel.unread', {
+      senderPtyId: 'pty-self',
+    });
+    const params = daemonRpc.mock.calls[0][1] as Record<string, unknown>;
+    expect(params).not.toHaveProperty('verifiedWorkspaceId');
+  });
+
+  it('falls back to env WMUX_PTY_ID when the verified walk misses (headless)', async () => {
+    selfContext.mockResolvedValue({});
+    process.env.WMUX_PTY_ID = 'pty-env';
+    daemonRpc.mockResolvedValue(okEnvelope({ ok: true, entries: [] }));
+    await handleChannel('unread', [], false);
+    expect(daemonRpc).toHaveBeenCalledWith('a2a.channel.unread', {
+      senderPtyId: 'pty-env',
+    });
+  });
+
+  it('post sends sender WITHOUT workspaceId (daemon backfills from its own stamp)', async () => {
+    daemonRpc.mockResolvedValue(okEnvelope({ ok: true, message: { seq: 3 } }));
+    await handleChannel('post', ['ch-1', 'hello', 'world', '--member', 'codex'], false);
+    expect(daemonRpc).toHaveBeenCalledWith('a2a.channel.post', {
+      channelId: 'ch-1',
+      text: 'hello world',
+      sender: { memberId: 'codex', memberName: 'codex' },
+      senderPtyId: 'pty-self',
+    });
+  });
+
+  it('post keeps body tokens that start with a dash (flag stripper is pair-aware)', async () => {
+    daemonRpc.mockResolvedValue(okEnvelope({ ok: true, message: { seq: 4 } }));
+    await handleChannel('post', ['ch-1', 'step', '-1', 'failed', '--member', 'codex'], false);
+    const params = daemonRpc.mock.calls[0][1] as { text: string };
+    expect(params.text).toBe('step -1 failed');
+  });
+
+  it('ack forwards uptoSeq + memberId; "all" maps to MAX_SAFE_INTEGER (daemon clamps to head)', async () => {
+    daemonRpc.mockResolvedValue(okEnvelope({ ok: true, acked: 0, lastReadSeq: 9 }));
+    await handleChannel('ack', ['ch-1', 'all', '--member', 'codex'], false);
+    expect(daemonRpc).toHaveBeenCalledWith('a2a.channel.ack', {
+      channelId: 'ch-1',
+      uptoSeq: Number.MAX_SAFE_INTEGER,
+      memberId: 'codex',
+      senderPtyId: 'pty-self',
+    });
+  });
+
+  it('read resolves a channel NAME to its id via a2a.channel.list', async () => {
+    daemonRpc
+      .mockResolvedValueOnce(okEnvelope({ ok: true, channels: [{ id: 'ch-9', name: 'general', visibility: 'public' }] }))
+      .mockResolvedValueOnce(okEnvelope({ ok: true, messages: [{ seq: 1, memberName: 'pm', text: 'hi' }] }));
+    await handleChannel('read', ['general'], false);
+    expect(daemonRpc).toHaveBeenNthCalledWith(1, 'a2a.channel.list', { senderPtyId: 'pty-self' });
+    expect(daemonRpc).toHaveBeenNthCalledWith(2, 'a2a.channel.getMessages', {
+      channelId: 'ch-9',
+      limit: 50,
+      senderPtyId: 'pty-self',
+    });
+    expect(logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n')).toContain('[seq 1] pm: hi');
+  });
+
+  it('--since / --limit flag values are never mistaken for positionals', async () => {
+    daemonRpc.mockResolvedValue(okEnvelope({ ok: true, messages: [] }));
+    await handleChannel('read', ['--since', '3', 'ch-1', '--limit', '5'], false);
+    expect(daemonRpc).toHaveBeenCalledWith('a2a.channel.getMessages', {
+      channelId: 'ch-1',
+      sinceSeq: 3,
+      limit: 5,
+      senderPtyId: 'pty-self',
+    });
+  });
+});
+
+describe('wmux channel — failure surfaces', () => {
+  it('a mutation with no resolvable pane identity fails closed BEFORE any RPC', async () => {
+    selfContext.mockResolvedValue({});
+    await expect(handleChannel('post', ['ch-1', 'hi'], false)).rejects.toThrow(ExitCalled);
+    expect(daemonRpc).not.toHaveBeenCalled();
+    expect(errSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n')).toContain('not inside a wmux pane');
+  });
+
+  it('a daemon-level channel error (result.ok=false) exits 1 with the error code visible', async () => {
+    daemonRpc.mockResolvedValue(
+      okEnvelope({ ok: false, error: { code: 'NOT_A_MEMBER', message: 'Not a channel member' } }),
+    );
+    await expect(handleChannel('post', ['ch-1', 'hi'], false)).rejects.toThrow(ExitCalled);
+    expect(errSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n')).toContain('NOT_A_MEMBER');
+  });
+
+  it('a reads-path call still works with NO pane identity (visibility falls to the daemon gate)', async () => {
+    selfContext.mockResolvedValue({});
+    daemonRpc.mockResolvedValue(
+      okEnvelope({ ok: false, error: { code: 'NOT_AUTHORIZED', message: 'verifiedWorkspaceId is required' } }),
+    );
+    // No senderPtyId at all → the daemon's own guard produces the rejection;
+    // the CLI must surface it, not crash.
+    await expect(handleChannel('list', [], false)).rejects.toThrow(ExitCalled);
+    expect(daemonRpc).toHaveBeenCalledWith('a2a.channel.list', {});
+    expect(errSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n')).toContain('NOT_AUTHORIZED');
+  });
+
+  it('unread surfaces trimmedBeforeCursor as a WARNING (silent loss is forbidden)', async () => {
+    daemonRpc.mockResolvedValue(
+      okEnvelope({
+        ok: true,
+        entries: [
+          {
+            channelId: 'ch-1',
+            name: 'general',
+            memberId: 'codex',
+            lastReadSeq: 2,
+            headSeq: 9,
+            unread: 3,
+            mentionUnread: 1,
+            trimmedBeforeCursor: 4,
+          },
+        ],
+      }),
+    );
+    await handleChannel('unread', [], false);
+    const out = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    expect(out).toContain('3 unread');
+    expect(out).toContain('1 mention you');
+    expect(out).toContain('WARNING: 4 message(s) trimmed');
+  });
+});

--- a/src/cli/commands/__tests__/channel.test.ts
+++ b/src/cli/commands/__tests__/channel.test.ts
@@ -153,10 +153,12 @@ describe('wmux channel — transport + identity', () => {
   it('read resolves a channel NAME to its id via a2a.channel.list', async () => {
     daemonRpc
       .mockResolvedValueOnce(okEnvelope({ ok: true, channels: [{ id: 'ch-9', name: 'general', visibility: 'public' }] }))
+      // Quiet own-row lookup (read's cursor default + ack hint).
+      .mockResolvedValueOnce(okEnvelope({ ok: true, entries: [] }))
       .mockResolvedValueOnce(okEnvelope({ ok: true, messages: [{ seq: 1, memberName: 'pm', text: 'hi' }] }));
     await handleChannel('read', ['general'], false);
     expect(daemonRpc).toHaveBeenNthCalledWith(1, 'a2a.channel.list', { senderPtyId: 'pty-self' });
-    expect(daemonRpc).toHaveBeenNthCalledWith(2, 'a2a.channel.getMessages', {
+    expect(daemonRpc).toHaveBeenNthCalledWith(3, 'a2a.channel.getMessages', {
       channelId: 'ch-9',
       limit: 50,
       senderPtyId: 'pty-self',
@@ -171,6 +173,37 @@ describe('wmux channel — transport + identity', () => {
       channelId: 'ch-1',
       sinceSeq: 3,
       limit: 5,
+      senderPtyId: 'pty-self',
+    });
+  });
+
+  it('read without --since starts from the caller\'s OWN cursor (single row) and pages oldest-first', async () => {
+    const row = { channelId: 'ch-1', name: 'g', memberId: 'codex', lastReadSeq: 4, headSeq: 9, unread: 5, mentionUnread: 0, trimmedBeforeCursor: 0 };
+    daemonRpc
+      .mockResolvedValueOnce(okEnvelope({ ok: true, entries: [row] }))
+      .mockResolvedValueOnce(okEnvelope({ ok: true, messages: [{ seq: 5, memberName: 'pm', text: 'a' }, { seq: 6, memberName: 'pm', text: 'b' }] }));
+    await handleChannel('read', ['ch-1', '--limit', '2'], false);
+    // sinceSeq = lastReadSeq + 1: the printed ack hint can never jump the
+    // cursor over unseen messages (pages are contiguous from the cursor).
+    expect(daemonRpc).toHaveBeenNthCalledWith(2, 'a2a.channel.getMessages', {
+      channelId: 'ch-1',
+      sinceSeq: 5,
+      limit: 2,
+      senderPtyId: 'pty-self',
+    });
+    const out = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    // Full page → the continue hint points at the NEXT page.
+    expect(out).toContain('--since 7');
+    expect(out).toContain('wmux channel ack ch-1 6');
+  });
+
+  it('a bare -- ends option parsing: post bodies keep flag-like tokens (--limit 5)', async () => {
+    daemonRpc.mockResolvedValue(okEnvelope({ ok: true, message: { seq: 8 } }));
+    await handleChannel('post', ['ch-1', '--member', 'codex', '--', 'try', 'again', 'with', '--limit', '5'], false);
+    expect(daemonRpc).toHaveBeenCalledWith('a2a.channel.post', {
+      channelId: 'ch-1',
+      text: 'try again with --limit 5',
+      sender: { memberId: 'codex', memberName: 'codex' },
       senderPtyId: 'pty-self',
     });
   });

--- a/src/cli/commands/__tests__/channel.test.ts
+++ b/src/cli/commands/__tests__/channel.test.ts
@@ -35,7 +35,6 @@ const selfContext = resolveSelfContext as unknown as ReturnType<typeof vi.fn>;
 const ORIGINAL_ENV_PTY = process.env.WMUX_PTY_ID;
 const ORIGINAL_ENV_MEMBER = process.env.WMUX_MEMBER_ID;
 
-let exitSpy: ReturnType<typeof vi.spyOn>;
 let logSpy: ReturnType<typeof vi.spyOn>;
 let errSpy: ReturnType<typeof vi.spyOn>;
 
@@ -54,11 +53,11 @@ beforeEach(() => {
   delete process.env.WMUX_PTY_ID;
   delete process.env.WMUX_MEMBER_ID;
   selfContext.mockResolvedValue({ ptyId: 'pty-self', workspaceId: 'ws-self' });
-  exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+  vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
     throw new ExitCalled(code);
   }) as never);
-  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-  errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 });
 
 const okEnvelope = (result: unknown) => ({ id: 'x', ok: true as const, result });
@@ -113,6 +112,44 @@ describe('wmux channel — transport + identity', () => {
     });
   });
 
+  it('ack without --member resolves the caller\'s SINGLE row from unread (no "agent" guess)', async () => {
+    const row = { channelId: 'ch-1', name: 'g', memberId: 'codex', lastReadSeq: 2, headSeq: 9, unread: 7, mentionUnread: 0, trimmedBeforeCursor: 0 };
+    daemonRpc
+      .mockResolvedValueOnce(okEnvelope({ ok: true, entries: [row] }))
+      .mockResolvedValueOnce(okEnvelope({ ok: true, acked: 1, lastReadSeq: 9 }));
+    await handleChannel('ack', ['ch-1', 'all'], false);
+    expect(daemonRpc).toHaveBeenNthCalledWith(1, 'a2a.channel.unread', { senderPtyId: 'pty-self' });
+    expect(daemonRpc).toHaveBeenNthCalledWith(2, 'a2a.channel.ack', {
+      channelId: 'ch-1',
+      uptoSeq: Number.MAX_SAFE_INTEGER,
+      memberId: 'codex',
+      senderPtyId: 'pty-self',
+    });
+  });
+
+  it('ack without --member on a MULTI-row workspace fails loudly (never guesses a cursor)', async () => {
+    const mk = (memberId: string) => ({ channelId: 'ch-1', name: 'g', memberId, lastReadSeq: 0, headSeq: 3, unread: 3, mentionUnread: 0, trimmedBeforeCursor: 0 });
+    daemonRpc.mockResolvedValueOnce(okEnvelope({ ok: true, entries: [mk('codex'), mk('opencode')] }));
+    await expect(handleChannel('ack', ['ch-1', 'all'], false)).rejects.toThrow(ExitCalled);
+    // Only the unread lookup ran — the ack RPC never fired.
+    expect(daemonRpc).toHaveBeenCalledTimes(1);
+    expect(errSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n')).toContain('--member');
+  });
+
+  it('post without --member posts AS the resolved row (self-unread exemption depends on it)', async () => {
+    const row = { channelId: 'ch-1', name: 'g', memberId: 'codex', lastReadSeq: 2, headSeq: 2, unread: 0, mentionUnread: 0, trimmedBeforeCursor: 0 };
+    daemonRpc
+      .mockResolvedValueOnce(okEnvelope({ ok: true, entries: [row] }))
+      .mockResolvedValueOnce(okEnvelope({ ok: true, message: { seq: 3 } }));
+    await handleChannel('post', ['ch-1', 'hi'], false);
+    expect(daemonRpc).toHaveBeenNthCalledWith(2, 'a2a.channel.post', {
+      channelId: 'ch-1',
+      text: 'hi',
+      sender: { memberId: 'codex', memberName: 'codex' },
+      senderPtyId: 'pty-self',
+    });
+  });
+
   it('read resolves a channel NAME to its id via a2a.channel.list', async () => {
     daemonRpc
       .mockResolvedValueOnce(okEnvelope({ ok: true, channels: [{ id: 'ch-9', name: 'general', visibility: 'public' }] }))
@@ -151,7 +188,8 @@ describe('wmux channel — failure surfaces', () => {
     daemonRpc.mockResolvedValue(
       okEnvelope({ ok: false, error: { code: 'NOT_A_MEMBER', message: 'Not a channel member' } }),
     );
-    await expect(handleChannel('post', ['ch-1', 'hi'], false)).rejects.toThrow(ExitCalled);
+    // Explicit --member skips row resolution, so the post RPC itself errors.
+    await expect(handleChannel('post', ['ch-1', 'hi', '--member', 'codex'], false)).rejects.toThrow(ExitCalled);
     expect(errSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n')).toContain('NOT_A_MEMBER');
   });
 

--- a/src/cli/commands/__tests__/channel.test.ts
+++ b/src/cli/commands/__tests__/channel.test.ts
@@ -97,8 +97,8 @@ describe('wmux channel — transport + identity', () => {
   it('post keeps body tokens that start with a dash (flag stripper is pair-aware)', async () => {
     daemonRpc.mockResolvedValue(okEnvelope({ ok: true, message: { seq: 4 } }));
     await handleChannel('post', ['ch-1', 'step', '-1', 'failed', '--member', 'codex'], false);
-    const params = daemonRpc.mock.calls[0][1] as { text: string };
-    expect(params.text).toBe('step -1 failed');
+    const postCall = daemonRpc.mock.calls.find((c: unknown[]) => c[0] === 'a2a.channel.post');
+    expect((postCall?.[1] as { text: string }).text).toBe('step -1 failed');
   });
 
   it('ack forwards uptoSeq + memberId; "all" maps to MAX_SAFE_INTEGER (daemon clamps to head)', async () => {
@@ -115,11 +115,12 @@ describe('wmux channel — transport + identity', () => {
   it('ack without --member resolves the caller\'s SINGLE row from unread (no "agent" guess)', async () => {
     const row = { channelId: 'ch-1', name: 'g', memberId: 'codex', lastReadSeq: 2, headSeq: 9, unread: 7, mentionUnread: 0, trimmedBeforeCursor: 0 };
     daemonRpc
+      .mockResolvedValueOnce(okEnvelope({ ok: true, channels: [] })) // ref resolution (id passthrough)
       .mockResolvedValueOnce(okEnvelope({ ok: true, entries: [row] }))
       .mockResolvedValueOnce(okEnvelope({ ok: true, acked: 1, lastReadSeq: 9 }));
     await handleChannel('ack', ['ch-1', 'all'], false);
-    expect(daemonRpc).toHaveBeenNthCalledWith(1, 'a2a.channel.unread', { senderPtyId: 'pty-self' });
-    expect(daemonRpc).toHaveBeenNthCalledWith(2, 'a2a.channel.ack', {
+    expect(daemonRpc).toHaveBeenNthCalledWith(2, 'a2a.channel.unread', { senderPtyId: 'pty-self' });
+    expect(daemonRpc).toHaveBeenNthCalledWith(3, 'a2a.channel.ack', {
       channelId: 'ch-1',
       uptoSeq: Number.MAX_SAFE_INTEGER,
       memberId: 'codex',
@@ -129,23 +130,39 @@ describe('wmux channel — transport + identity', () => {
 
   it('ack without --member on a MULTI-row workspace fails loudly (never guesses a cursor)', async () => {
     const mk = (memberId: string) => ({ channelId: 'ch-1', name: 'g', memberId, lastReadSeq: 0, headSeq: 3, unread: 3, mentionUnread: 0, trimmedBeforeCursor: 0 });
-    daemonRpc.mockResolvedValueOnce(okEnvelope({ ok: true, entries: [mk('codex'), mk('opencode')] }));
+    daemonRpc
+      .mockResolvedValueOnce(okEnvelope({ ok: true, channels: [] }))
+      .mockResolvedValueOnce(okEnvelope({ ok: true, entries: [mk('codex'), mk('opencode')] }));
     await expect(handleChannel('ack', ['ch-1', 'all'], false)).rejects.toThrow(ExitCalled);
-    // Only the unread lookup ran — the ack RPC never fired.
-    expect(daemonRpc).toHaveBeenCalledTimes(1);
+    // Ref resolution + the unread lookup ran — the ack RPC never fired.
+    expect(daemonRpc).toHaveBeenCalledTimes(2);
     expect(errSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n')).toContain('--member');
   });
 
   it('post without --member posts AS the resolved row (self-unread exemption depends on it)', async () => {
     const row = { channelId: 'ch-1', name: 'g', memberId: 'codex', lastReadSeq: 2, headSeq: 2, unread: 0, mentionUnread: 0, trimmedBeforeCursor: 0 };
     daemonRpc
+      .mockResolvedValueOnce(okEnvelope({ ok: true, channels: [] }))
       .mockResolvedValueOnce(okEnvelope({ ok: true, entries: [row] }))
       .mockResolvedValueOnce(okEnvelope({ ok: true, message: { seq: 3 } }));
     await handleChannel('post', ['ch-1', 'hi'], false);
-    expect(daemonRpc).toHaveBeenNthCalledWith(2, 'a2a.channel.post', {
+    expect(daemonRpc).toHaveBeenNthCalledWith(3, 'a2a.channel.post', {
       channelId: 'ch-1',
       text: 'hi',
       sender: { memberId: 'codex', memberName: 'codex' },
+      senderPtyId: 'pty-self',
+    });
+  });
+
+  it('a channel NAME starting with "ch-" still resolves via the listing (exact ids win)', async () => {
+    daemonRpc
+      .mockResolvedValueOnce(okEnvelope({ ok: true, channels: [{ id: 'ch-abc123', name: 'ch-release', visibility: 'public' }] }))
+      .mockResolvedValueOnce(okEnvelope({ ok: true, entries: [] }))
+      .mockResolvedValueOnce(okEnvelope({ ok: true, messages: [] }));
+    await handleChannel('read', ['ch-release'], false);
+    expect(daemonRpc).toHaveBeenNthCalledWith(3, 'a2a.channel.getMessages', {
+      channelId: 'ch-abc123',
+      limit: 50,
       senderPtyId: 'pty-self',
     });
   });
@@ -180,12 +197,13 @@ describe('wmux channel — transport + identity', () => {
   it('read without --since starts from the caller\'s OWN cursor (single row) and pages oldest-first', async () => {
     const row = { channelId: 'ch-1', name: 'g', memberId: 'codex', lastReadSeq: 4, headSeq: 9, unread: 5, mentionUnread: 0, trimmedBeforeCursor: 0 };
     daemonRpc
+      .mockResolvedValueOnce(okEnvelope({ ok: true, channels: [] }))
       .mockResolvedValueOnce(okEnvelope({ ok: true, entries: [row] }))
       .mockResolvedValueOnce(okEnvelope({ ok: true, messages: [{ seq: 5, memberName: 'pm', text: 'a' }, { seq: 6, memberName: 'pm', text: 'b' }] }));
     await handleChannel('read', ['ch-1', '--limit', '2'], false);
     // sinceSeq = lastReadSeq + 1: the printed ack hint can never jump the
     // cursor over unseen messages (pages are contiguous from the cursor).
-    expect(daemonRpc).toHaveBeenNthCalledWith(2, 'a2a.channel.getMessages', {
+    expect(daemonRpc).toHaveBeenNthCalledWith(3, 'a2a.channel.getMessages', {
       channelId: 'ch-1',
       sinceSeq: 5,
       limit: 2,
@@ -195,6 +213,20 @@ describe('wmux channel — transport + identity', () => {
     // Full page → the continue hint points at the NEXT page.
     expect(out).toContain('--since 7');
     expect(out).toContain('wmux channel ack ch-1 6');
+  });
+
+  it('multi-row + --since maps the ack hint back to the ONE matching row (--member included)', async () => {
+    const mk = (memberId: string, lastReadSeq: number) => ({ channelId: 'ch-1', name: 'g', memberId, lastReadSeq, headSeq: 9, unread: 9 - lastReadSeq, mentionUnread: 0, trimmedBeforeCursor: 0 });
+    daemonRpc
+      .mockResolvedValueOnce(okEnvelope({ ok: true, channels: [] }))
+      .mockResolvedValueOnce(okEnvelope({ ok: true, entries: [mk('codex', 4), mk('opencode', 7)] }))
+      .mockResolvedValueOnce(okEnvelope({ ok: true, messages: [{ seq: 5, memberName: 'pm', text: 'a' }] }));
+    // --since 5 came from codex's unread hint (cursor 4 + 1) — the ack hint
+    // must carry --member codex, or following it hits the never-guess error
+    // and the wake worker re-nudges forever (Codex round-3).
+    await handleChannel('read', ['ch-1', '--since', '5'], false);
+    const out = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    expect(out).toContain('wmux channel ack ch-1 5 --member codex');
   });
 
   it('a bare -- ends option parsing: post bodies keep flag-like tokens (--limit 5)', async () => {
@@ -218,9 +250,9 @@ describe('wmux channel — failure surfaces', () => {
   });
 
   it('a daemon-level channel error (result.ok=false) exits 1 with the error code visible', async () => {
-    daemonRpc.mockResolvedValue(
-      okEnvelope({ ok: false, error: { code: 'NOT_A_MEMBER', message: 'Not a channel member' } }),
-    );
+    daemonRpc
+      .mockResolvedValueOnce(okEnvelope({ ok: true, channels: [] })) // ref resolution succeeds
+      .mockResolvedValue(okEnvelope({ ok: false, error: { code: 'NOT_A_MEMBER', message: 'Not a channel member' } }));
     // Explicit --member skips row resolution, so the post RPC itself errors.
     await expect(handleChannel('post', ['ch-1', 'hi', '--member', 'codex'], false)).rejects.toThrow(ExitCalled);
     expect(errSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n')).toContain('NOT_A_MEMBER');

--- a/src/cli/commands/__tests__/channel.test.ts
+++ b/src/cli/commands/__tests__/channel.test.ts
@@ -83,6 +83,16 @@ describe('wmux channel — transport + identity', () => {
     });
   });
 
+  it('unread honors $WMUX_MEMBER_ID like post/ack (GLM review — consistent member filtering)', async () => {
+    process.env.WMUX_MEMBER_ID = 'codex';
+    daemonRpc.mockResolvedValue(okEnvelope({ ok: true, entries: [] }));
+    await handleChannel('unread', [], false);
+    expect(daemonRpc).toHaveBeenCalledWith('a2a.channel.unread', {
+      memberId: 'codex',
+      senderPtyId: 'pty-self',
+    });
+  });
+
   it('post sends sender WITHOUT workspaceId (daemon backfills from its own stamp)', async () => {
     daemonRpc.mockResolvedValue(okEnvelope({ ok: true, message: { seq: 3 } }));
     await handleChannel('post', ['ch-1', 'hello', 'world', '--member', 'codex'], false);
@@ -128,6 +138,15 @@ describe('wmux channel — transport + identity', () => {
     });
   });
 
+  it('ack rejects a fractional/oversized uptoSeq before any RPC (GLM review — no silent no-op)', async () => {
+    // 1.5 would pass the daemon's isSafeInteger guard as a clamp-to-0 no-op,
+    // then echo the row's real cursor and print a false success. Reject in CLI.
+    await expect(handleChannel('ack', ['ch-1', '1.5'], false)).rejects.toThrow(ExitCalled);
+    await expect(handleChannel('ack', ['ch-1', '99999999999999999'], false)).rejects.toThrow(ExitCalled);
+    expect(daemonRpc).not.toHaveBeenCalled();
+    expect(errSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n')).toContain('whole number');
+  });
+
   it('ack without --member on a MULTI-row workspace fails loudly (never guesses a cursor)', async () => {
     const mk = (memberId: string) => ({ channelId: 'ch-1', name: 'g', memberId, lastReadSeq: 0, headSeq: 3, unread: 3, mentionUnread: 0, trimmedBeforeCursor: 0 });
     daemonRpc
@@ -152,6 +171,17 @@ describe('wmux channel — transport + identity', () => {
       sender: { memberId: 'codex', memberName: 'codex' },
       senderPtyId: 'pty-self',
     });
+  });
+
+  it('read prints NO ack hint for a non-member (rows=0) — an ack there is a no-op (GLM review)', async () => {
+    daemonRpc
+      .mockResolvedValueOnce(okEnvelope({ ok: true, channels: [] })) // ref resolution
+      .mockResolvedValueOnce(okEnvelope({ ok: true, entries: [] }))   // quietOwnMemberRows → no rows
+      .mockResolvedValueOnce(okEnvelope({ ok: true, messages: [{ seq: 5, memberName: 'pm', text: 'hi' }] }));
+    await handleChannel('read', ['ch-1'], false);
+    const out = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    expect(out).toContain('[seq 5] pm: hi');
+    expect(out).not.toContain('wmux channel ack'); // no misleading hint for a non-member
   });
 
   it('a channel NAME starting with "ch-" still resolves via the listing (exact ids win)', async () => {

--- a/src/cli/commands/channel.ts
+++ b/src/cli/commands/channel.ts
@@ -1,0 +1,346 @@
+// ─── `wmux channel` — the universal agent surface for Channels v2 ─────────
+//
+// Any shell-capable agent running inside a wmux pane (Codex, OpenCode,
+// Hermes, a bash loop…) participates in channels through these subcommands —
+// no MCP client required. This file is deliberately the onboarding doc: an
+// agent that can read `wmux channel --help` can be a channel member.
+//
+// Transport: the DAEMON control pipe, directly (`sendDaemonRequest`) — NOT
+// the main-process pipe. Rationale (design doc "두 RPC 표면과 신뢰 모델"):
+// the daemon owns channel state and survives the GUI, so `wmux channel`
+// keeps working headless (GUI closed, reboot-recovery window) — which is the
+// money-demo path. Identity: we attach `senderPtyId` and the daemon stamps
+// `verifiedWorkspaceId` server-side from its OWN session record
+// (channelCallerIdentity.ts) — the CLI never claims a workspace.
+//
+// senderPtyId resolution ladder:
+//   1. verified PID-map walk via the MAIN pipe (resolveSelfContext, X4) —
+//      strongest, but needs the GUI alive;
+//   2. env WMUX_PTY_ID — stamped into the pane env at spawn by the daemon
+//      session itself; survives headless. Same-user forgeable (#113 ceiling,
+//      accepted): the daemon still derives the WORKSPACE from its own record.
+// Outside a wmux pane both fail → mutations fail closed (NOT_AUTHORIZED).
+
+import { sendRequest, sendDaemonRequest } from '../client';
+import { parseFlag, hasFlag } from '../utils';
+import { resolveSelfContext, getParentPidDefault } from '../identity';
+import type { RpcMethod, RpcResponse } from '../../shared/rpc';
+import { ENV_KEYS } from '../../shared/constants';
+
+export const CHANNEL_HELP = `
+wmux channel — durable agent messaging (Channels v2)
+
+  You are (probably) an agent in a wmux pane. Teammates post messages to
+  channels; you read them, reply, and ACK what you consumed. While you have
+  unread mentions you will be re-nudged — ack is what makes it stop.
+
+  wmux channel unread [--member <id>]
+      Your per-channel unread + mention counts. Cheap; call when nudged.
+  wmux channel read <channel> [--since <seq>] [--limit <n>]
+      Print messages (oldest first). <channel> is an id (ch-…) or a name.
+  wmux channel post <channel> <text…> [--member <id>] [--name <display>]
+      Post a message. Your workspace identity is stamped server-side.
+  wmux channel ack <channel> <uptoSeq|all> [--member <id>]
+      Mark messages ≤ uptoSeq consumed ('all' = everything currently there).
+      Advance-only; clears unread; stops re-nudges.
+  wmux channel join <channel> [--member <id>] [--name <display>]
+      Join a public channel as <member>.
+  wmux channel list
+      Channels visible to your workspace.
+
+  --member defaults to $WMUX_MEMBER_ID, then "agent". Use a stable, short
+  id (e.g. "codex") so humans can tell agents apart in the roster.
+  --json on any subcommand prints the raw RPC payload.
+
+  Typical loop when nudged: unread → read → do the work → post → ack.
+`;
+
+interface ChannelCallOpts {
+  /** Require a resolvable pane identity before issuing the call. */
+  mutating: boolean;
+}
+
+/** senderPtyId ladder: verified walk (main pipe) → pane env → ''. */
+async function resolveSenderPtyId(): Promise<string> {
+  try {
+    const ctx = await resolveSelfContext({
+      sendRequest,
+      env: process.env,
+      ppid: process.ppid,
+      getParentPid: getParentPidDefault,
+    });
+    if (ctx.ptyId) return ctx.ptyId;
+  } catch {
+    // main pipe down (headless) — fall through to the env hint
+  }
+  const envPty = process.env[ENV_KEYS.PTY_ID];
+  return typeof envPty === 'string' && envPty.trim().length > 0 ? envPty.trim() : '';
+}
+
+/**
+ * Issue one channel RPC on the daemon pipe with senderPtyId attached, and
+ * unwrap the two-layer envelope (pipe RpcResponse → ChannelService Result).
+ * Exits the process with a readable error on either layer's failure.
+ */
+async function callChannel(
+  method: RpcMethod,
+  params: Record<string, unknown>,
+  opts: ChannelCallOpts,
+): Promise<Record<string, unknown>> {
+  const senderPtyId = await resolveSenderPtyId();
+  if (!senderPtyId && opts.mutating) {
+    console.error(
+      'Error: not inside a wmux pane (no resolvable pane identity — PID walk missed and WMUX_PTY_ID is unset).\n' +
+        'Channel mutations are fail-closed without one. Run this from a shell inside a wmux pane.',
+    );
+    process.exit(1);
+  }
+  let response: RpcResponse;
+  try {
+    response = await sendDaemonRequest(method, {
+      ...params,
+      ...(senderPtyId ? { senderPtyId } : {}),
+    });
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+  if (!response.ok) {
+    console.error(`Error: ${response.error}`);
+    process.exit(1);
+  }
+  const result = response.result as Record<string, unknown> | null;
+  if (result !== null && typeof result === 'object' && result['ok'] === false) {
+    const err = result['error'] as { code?: string; message?: string } | undefined;
+    console.error(`Error [${err?.code ?? 'UNKNOWN'}]: ${err?.message ?? 'channel call failed'}`);
+    process.exit(1);
+  }
+  return result ?? {};
+}
+
+/** `<channel>` accepts a channel id (ch-…) or a name; names resolve via list. */
+async function resolveChannelId(ref: string): Promise<string> {
+  if (ref.startsWith('ch-')) return ref;
+  const result = await callChannel('a2a.channel.list' as RpcMethod, {}, { mutating: false });
+  const channels = (result['channels'] as Array<{ id?: string; name?: string; status?: string }> | undefined) ?? [];
+  const matches = channels.filter((c) => c.name === ref);
+  if (matches.length === 1 && typeof matches[0].id === 'string') return matches[0].id;
+  if (matches.length > 1) {
+    console.error(`Error: channel name "${ref}" is ambiguous (${matches.length} matches) — use the channel id.`);
+    process.exit(1);
+  }
+  console.error(
+    `Error: no visible channel named "${ref}". Run \`wmux channel list\` to see what your workspace can reach.`,
+  );
+  process.exit(1);
+}
+
+function memberIdFrom(args: string[]): string {
+  return parseFlag(args, '--member') ?? process.env['WMUX_MEMBER_ID'] ?? 'agent';
+}
+
+/**
+ * Strip the channel option flags (and their values) so the remainder is pure
+ * positional payload — mirrors input.ts stripInputFlags. Without this a flag
+ * VALUE (`--since 3`) would be mistaken for a positional (`read 3 …`), and a
+ * post body containing a token that starts with `-` would be silently eaten.
+ */
+const VALUE_FLAGS = new Set(['--member', '--name', '--since', '--limit']);
+function positionalsOf(args: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (VALUE_FLAGS.has(a)) {
+      i++; // skip the flag's value
+      continue;
+    }
+    if (a === '--json') continue;
+    out.push(a);
+  }
+  return out;
+}
+
+const fmtMsg = (m: { seq?: number; memberName?: string; memberId?: string; text?: string }): string =>
+  `[seq ${m.seq}] ${m.memberName ?? m.memberId ?? '?'}: ${m.text ?? ''}`;
+
+export async function handleChannel(sub: string | undefined, args: string[], jsonMode: boolean): Promise<void> {
+  switch (sub) {
+    case 'unread': {
+      const memberId = parseFlag(args, '--member');
+      const result = await callChannel(
+        'a2a.channel.unread' as RpcMethod,
+        { ...(memberId !== undefined ? { memberId } : {}) },
+        { mutating: false },
+      );
+      const entries =
+        (result['entries'] as Array<{
+          channelId: string;
+          name: string;
+          memberId: string;
+          lastReadSeq: number;
+          headSeq: number;
+          unread: number;
+          mentionUnread: number;
+          trimmedBeforeCursor: number;
+        }> | undefined) ?? [];
+      if (jsonMode) {
+        console.log(JSON.stringify(entries, null, 2));
+        return;
+      }
+      const owed = entries.filter((e) => e.unread > 0 || e.trimmedBeforeCursor > 0);
+      if (owed.length === 0) {
+        console.log('No unread channel messages.');
+        return;
+      }
+      for (const e of owed) {
+        const trimmed = e.trimmedBeforeCursor > 0 ? `  [WARNING: ${e.trimmedBeforeCursor} message(s) trimmed before you read them]` : '';
+        console.log(
+          `#${e.name} (${e.channelId}) member=${e.memberId}: ${e.unread} unread` +
+            (e.mentionUnread > 0 ? ` (${e.mentionUnread} mention you)` : '') +
+            ` — read: wmux channel read ${e.channelId} --since ${e.lastReadSeq + 1}${trimmed}`,
+        );
+      }
+      return;
+    }
+
+    case 'read': {
+      const [ref] = positionalsOf(args);
+      if (!ref) {
+        console.error('Usage: wmux channel read <channel> [--since <seq>] [--limit <n>]');
+        process.exit(1);
+      }
+      const channelId = await resolveChannelId(ref);
+      const since = parseFlag(args, '--since');
+      const limit = parseFlag(args, '--limit');
+      const params: Record<string, unknown> = { channelId };
+      if (since !== undefined) params['sinceSeq'] = Number(since);
+      params['limit'] = limit !== undefined ? Number(limit) : 50;
+      const result = await callChannel('a2a.channel.getMessages' as RpcMethod, params, { mutating: false });
+      const messages = (result['messages'] as Array<{ seq: number; memberName?: string; memberId?: string; text?: string }> | undefined) ?? [];
+      if (jsonMode) {
+        console.log(JSON.stringify(messages, null, 2));
+        return;
+      }
+      if (messages.length === 0) {
+        console.log('(no messages)');
+        return;
+      }
+      for (const m of messages) console.log(fmtMsg(m));
+      const last = messages[messages.length - 1];
+      console.log(`(consumed? then: wmux channel ack ${channelId} ${last.seq})`);
+      return;
+    }
+
+    case 'post': {
+      const [ref, ...textParts] = positionalsOf(args);
+      const text = textParts.join(' ');
+      if (!ref || !text) {
+        console.error('Usage: wmux channel post <channel> <text…> [--member <id>] [--name <display>]');
+        process.exit(1);
+      }
+      const channelId = await resolveChannelId(ref);
+      const memberId = memberIdFrom(args);
+      const memberName = parseFlag(args, '--name') ?? memberId;
+      const result = await callChannel(
+        'a2a.channel.post' as RpcMethod,
+        {
+          channelId,
+          text,
+          // sender.workspaceId is deliberately ABSENT — the daemon backfills
+          // it from the server-side stamp (channelCallerIdentity.ts).
+          sender: { memberId, memberName },
+        },
+        { mutating: true },
+      );
+      if (jsonMode) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      const message = result['message'] as { seq?: number } | undefined;
+      console.log(`Posted to ${channelId} as ${memberId} (seq ${message?.seq ?? '?'}).`);
+      const dropped = result['droppedMentions'] as Array<{ workspaceId: string }> | undefined;
+      if (dropped && dropped.length > 0) {
+        console.log(`WARNING: ${dropped.length} @mention(s) did NOT land (target not a channel member): ${dropped.map((d) => d.workspaceId).join(', ')}`);
+      }
+      return;
+    }
+
+    case 'ack': {
+      const [ref, uptoRaw] = positionalsOf(args);
+      if (!ref || !uptoRaw) {
+        console.error("Usage: wmux channel ack <channel> <uptoSeq|all> [--member <id>]");
+        process.exit(1);
+      }
+      const channelId = await resolveChannelId(ref);
+      // 'all' = everything currently in the channel; the daemon clamps to head.
+      const uptoSeq = uptoRaw === 'all' ? Number.MAX_SAFE_INTEGER : Number(uptoRaw);
+      if (!Number.isFinite(uptoSeq) || uptoSeq < 0) {
+        console.error(`Error: uptoSeq must be a non-negative number or 'all' (got "${uptoRaw}").`);
+        process.exit(1);
+      }
+      const memberId = memberIdFrom(args);
+      const result = await callChannel(
+        'a2a.channel.ack' as RpcMethod,
+        { channelId, uptoSeq, memberId },
+        { mutating: true },
+      );
+      if (jsonMode) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(`Acked ${channelId} up to seq ${result['lastReadSeq'] ?? uptoSeq} as ${memberId}.`);
+      return;
+    }
+
+    case 'join': {
+      const [ref] = positionalsOf(args);
+      if (!ref) {
+        console.error('Usage: wmux channel join <channel> [--member <id>] [--name <display>]');
+        process.exit(1);
+      }
+      const channelId = await resolveChannelId(ref);
+      const memberId = memberIdFrom(args);
+      const memberName = parseFlag(args, '--name') ?? memberId;
+      const result = await callChannel(
+        'a2a.channel.join' as RpcMethod,
+        { channelId, member: { memberId, memberName } },
+        { mutating: true },
+      );
+      if (jsonMode) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(`Joined ${channelId} as ${memberId}. New messages from now count as your unread.`);
+      return;
+    }
+
+    case 'list': {
+      const result = await callChannel('a2a.channel.list' as RpcMethod, {}, { mutating: false });
+      const channels = (result['channels'] as Array<{ id?: string; name?: string; visibility?: string; status?: string }> | undefined) ?? [];
+      if (jsonMode) {
+        console.log(JSON.stringify(channels, null, 2));
+        return;
+      }
+      if (channels.length === 0) {
+        console.log('No channels visible to this workspace.');
+        return;
+      }
+      for (const c of channels) {
+        console.log(`#${c.name}  ${c.id}  (${c.visibility ?? '?'}${c.status === 'archived' ? ', archived' : ''})`);
+      }
+      return;
+    }
+
+    case 'help':
+    case undefined: {
+      console.log(CHANNEL_HELP.trim());
+      return;
+    }
+
+    default: {
+      console.error(`Unknown channel subcommand: "${sub}".`);
+      console.log(CHANNEL_HELP.trim());
+      process.exit(1);
+    }
+  }
+}

--- a/src/cli/commands/channel.ts
+++ b/src/cli/commands/channel.ts
@@ -37,12 +37,16 @@ wmux channel — durable agent messaging (Channels v2)
   wmux channel unread [--member <id>]
       Your per-channel unread + mention counts. Cheap; call when nudged.
   wmux channel read <channel> [--since <seq>] [--limit <n>]
-      Print messages (oldest first). <channel> is an id (ch-…) or a name.
+      Print messages, oldest first, paging forward. Without --since it
+      starts from YOUR unread cursor (when you have one member row here).
+      A full page prints a continue hint. <channel> is an id (ch-…) or name.
   wmux channel post <channel> <text…> [--member <id>] [--name <display>]
       Post a message. Your workspace identity is stamped server-side.
+      Body may contain flag-like tokens after a bare --:
+        wmux channel post dev -- try again with --limit 5
   wmux channel ack <channel> <uptoSeq|all> [--member <id>]
       Mark messages ≤ uptoSeq consumed ('all' = everything currently there).
-      Advance-only; clears unread; stops re-nudges.
+      Advance-only; clears unread; stops re-nudges. Ack only what you read.
   wmux channel join <channel> [--member <id>] [--name <display>]
       Join a public channel as <member>.
   wmux channel list
@@ -175,6 +179,36 @@ async function resolveOwnMemberId(channelId: string, args: string[]): Promise<st
 }
 
 /**
+ * Best-effort variant of the row lookup for READ-path hints: never exits,
+ * returns [] on any failure. Read output must not be killed by a failed
+ * auxiliary call after the messages already printed.
+ */
+async function quietOwnMemberRows(
+  channelId: string,
+): Promise<Array<{ memberId: string; lastReadSeq: number }>> {
+  try {
+    const senderPtyId = await resolveSenderPtyId();
+    const response = await sendDaemonRequest('a2a.channel.unread' as RpcMethod, {
+      ...(senderPtyId ? { senderPtyId } : {}),
+    });
+    if (!response.ok) return [];
+    const result = response.result as {
+      ok?: boolean;
+      entries?: Array<{ channelId?: string; memberId?: string; lastReadSeq?: number }>;
+    } | null;
+    if (!result || result.ok === false || !Array.isArray(result.entries)) return [];
+    return result.entries
+      .filter((e) => e.channelId === channelId && typeof e.memberId === 'string')
+      .map((e) => ({
+        memberId: e.memberId as string,
+        lastReadSeq: typeof e.lastReadSeq === 'number' ? e.lastReadSeq : 0,
+      }));
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Strip the channel option flags (and their values) so the remainder is pure
  * positional payload — mirrors input.ts stripInputFlags. Without this a flag
  * VALUE (`--since 3`) would be mistaken for a positional (`read 3 …`), and a
@@ -199,6 +233,16 @@ const fmtMsg = (m: { seq?: number; memberName?: string; memberId?: string; text?
   `[seq ${m.seq}] ${m.memberName ?? m.memberId ?? '?'}: ${m.text ?? ''}`;
 
 export async function handleChannel(sub: string | undefined, args: string[], jsonMode: boolean): Promise<void> {
+  // A bare `--` ends option parsing: everything after it is verbatim
+  // positional payload — post bodies often contain flag-like tokens
+  // (`wmux channel post dev -- try --limit 5`), and the pair-aware stripper
+  // below would otherwise eat them as channel options (Codex re-review P3).
+  // The global --json/--help flags are consumed by the CLI entry before argv
+  // reaches subcommands, so those two cannot ride a body either way.
+  const dd = args.indexOf('--');
+  const verbatim = dd === -1 ? [] : args.slice(dd + 1);
+  args = dd === -1 ? args : args.slice(0, dd);
+  const positionals = positionalsOf(args).concat(verbatim);
   switch (sub) {
     case 'unread': {
       const memberId = parseFlag(args, '--member');
@@ -239,7 +283,7 @@ export async function handleChannel(sub: string | undefined, args: string[], jso
     }
 
     case 'read': {
-      const [ref] = positionalsOf(args);
+      const [ref] = positionals;
       if (!ref) {
         console.error('Usage: wmux channel read <channel> [--since <seq>] [--limit <n>]');
         process.exit(1);
@@ -247,9 +291,19 @@ export async function handleChannel(sub: string | undefined, args: string[], jso
       const channelId = await resolveChannelId(ref);
       const since = parseFlag(args, '--since');
       const limit = parseFlag(args, '--limit');
-      const params: Record<string, unknown> = { channelId };
-      if (since !== undefined) params['sinceSeq'] = Number(since);
-      params['limit'] = limit !== undefined ? Number(limit) : 50;
+      // Consume-oriented default (Codex re-review P1): with no --since, start
+      // from YOUR cursor when this workspace has exactly one member row here.
+      // Pages are then oldest-first and contiguous, so the printed ack hint
+      // can never jump the cursor over messages you haven't seen. No single
+      // row (browsing / multi-agent workspace / not a member) → the newest-N
+      // display window, and the hints below adapt.
+      const rows = await quietOwnMemberRows(channelId);
+      let sinceUsed: number | undefined;
+      if (since !== undefined) sinceUsed = Number(since);
+      else if (rows.length === 1) sinceUsed = rows[0].lastReadSeq + 1;
+      const limitUsed = limit !== undefined ? Number(limit) : 50;
+      const params: Record<string, unknown> = { channelId, limit: limitUsed };
+      if (sinceUsed !== undefined) params['sinceSeq'] = sinceUsed;
       const result = await callChannel('a2a.channel.getMessages' as RpcMethod, params, { mutating: false });
       const messages = (result['messages'] as Array<{ seq: number; memberName?: string; memberId?: string; text?: string }> | undefined) ?? [];
       if (jsonMode) {
@@ -262,12 +316,24 @@ export async function handleChannel(sub: string | undefined, args: string[], jso
       }
       for (const m of messages) console.log(fmtMsg(m));
       const last = messages[messages.length - 1];
-      console.log(`(consumed? then: wmux channel ack ${channelId} ${last.seq})`);
+      if (sinceUsed !== undefined && messages.length === limitUsed) {
+        console.log(`(full page — more may remain: wmux channel read ${channelId} --since ${last.seq + 1})`);
+      }
+      if (rows.length > 1 && sinceUsed === undefined) {
+        // Multi-row workspace browsing the tail: acking this page's head seq
+        // could jump a cursor over unseen middle messages — route through the
+        // per-row cursors instead of printing a lossy one-liner.
+        console.log(
+          `(this workspace has ${rows.length} member rows — run: wmux channel unread, then read --since <cursor+1> and ack --member <id>)`,
+        );
+      } else {
+        console.log(`(consumed? then: wmux channel ack ${channelId} ${last.seq})`);
+      }
       return;
     }
 
     case 'post': {
-      const [ref, ...textParts] = positionalsOf(args);
+      const [ref, ...textParts] = positionals;
       const text = textParts.join(' ');
       if (!ref || !text) {
         console.error('Usage: wmux channel post <channel> <text…> [--member <id>] [--name <display>]');
@@ -306,7 +372,7 @@ export async function handleChannel(sub: string | undefined, args: string[], jso
     }
 
     case 'ack': {
-      const [ref, uptoRaw] = positionalsOf(args);
+      const [ref, uptoRaw] = positionals;
       if (!ref || !uptoRaw) {
         console.error("Usage: wmux channel ack <channel> <uptoSeq|all> [--member <id>]");
         process.exit(1);
@@ -332,12 +398,18 @@ export async function handleChannel(sub: string | undefined, args: string[], jso
         console.log(JSON.stringify(result, null, 2));
         return;
       }
-      console.log(`Acked ${channelId} up to seq ${result['lastReadSeq'] ?? uptoSeq} as ${memberId ?? 'this workspace'}.`);
+      if (memberId !== undefined) {
+        console.log(`Acked ${channelId} up to seq ${result['lastReadSeq'] ?? uptoSeq} as ${memberId}.`);
+      } else {
+        // No member row here → the daemon recorded read receipts only; there
+        // is no cursor to advance (and none was silently invented).
+        console.log(`Recorded a read receipt for ${channelId} (no member row here — no cursor advanced).`);
+      }
       return;
     }
 
     case 'join': {
-      const [ref] = positionalsOf(args);
+      const [ref] = positionals;
       if (!ref) {
         console.error('Usage: wmux channel join <channel> [--member <id>] [--name <display>]');
         process.exit(1);

--- a/src/cli/commands/channel.ts
+++ b/src/cli/commands/channel.ts
@@ -253,7 +253,11 @@ export async function handleChannel(sub: string | undefined, args: string[], jso
   const positionals = positionalsOf(args).concat(verbatim);
   switch (sub) {
     case 'unread': {
-      const memberId = parseFlag(args, '--member');
+      // Same identity ladder as post/ack (GLM review): explicit --member, then
+      // $WMUX_MEMBER_ID — so a multi-agent workspace that pins its member id in
+      // the env gets a filtered summary here too, not the whole workspace's rows.
+      // Absent both = every row (the daemon's default).
+      const memberId = parseFlag(args, '--member') ?? (process.env['WMUX_MEMBER_ID'] || undefined);
       const result = await callChannel(
         'a2a.channel.unread' as RpcMethod,
         { ...(memberId !== undefined ? { memberId } : {}) },
@@ -346,9 +350,12 @@ export async function handleChannel(sub: string | undefined, args: string[], jso
             `(this workspace has ${rows.length} member rows — run: wmux channel unread, then read --since <cursor+1> and ack --member <id>)`,
           );
         }
-      } else {
+      } else if (rows.length === 1) {
         console.log(`(consumed? then: wmux channel ack ${channelId} ${last.seq})`);
       }
+      // rows.length === 0 (not a member / browsing) prints NO ack hint (GLM
+      // review): this caller has no cursor, so an ack would be a receipt-only
+      // no-op — a hint here just invites a command that does nothing.
       return;
     }
 
@@ -397,14 +404,20 @@ export async function handleChannel(sub: string | undefined, args: string[], jso
         console.error("Usage: wmux channel ack <channel> <uptoSeq|all> [--member <id>]");
         process.exit(1);
       }
-      await requirePaneIdentityOrExit();
-      const channelId = await resolveChannelId(ref);
-      // 'all' = everything currently in the channel; the daemon clamps to head.
+      // Validate the seq BEFORE any network round-trip (fail fast on a local
+      // arg). 'all' = everything currently in the channel; the daemon clamps
+      // to head. Require a whole seq (GLM review): the daemon rejects
+      // fractional/oversized uptoSeq by clamping to 0 (a no-op), but then
+      // echoes the row's ACTUAL cursor — so `ack ch 1.5` would print
+      // "Acked … up to seq <current>" and look successful while nothing moved.
+      // MAX_SAFE_INTEGER ('all') is itself a safe integer, so the sentinel passes.
       const uptoSeq = uptoRaw === 'all' ? Number.MAX_SAFE_INTEGER : Number(uptoRaw);
-      if (!Number.isFinite(uptoSeq) || uptoSeq < 0) {
-        console.error(`Error: uptoSeq must be a non-negative number or 'all' (got "${uptoRaw}").`);
+      if (!Number.isSafeInteger(uptoSeq) || uptoSeq < 0) {
+        console.error(`Error: uptoSeq must be a non-negative whole number or 'all' (got "${uptoRaw}").`);
         process.exit(1);
       }
+      await requirePaneIdentityOrExit();
+      const channelId = await resolveChannelId(ref);
       // Which cursor moves? Resolve MY row — never a made-up default (see
       // resolveOwnMemberId). undefined (not a member) sends no memberId so
       // the daemon answers honestly instead of no-opping a phantom row.

--- a/src/cli/commands/channel.ts
+++ b/src/cli/commands/channel.ts
@@ -22,7 +22,7 @@
 // Outside a wmux pane both fail → mutations fail closed (NOT_AUTHORIZED).
 
 import { sendRequest, sendDaemonRequest } from '../client';
-import { parseFlag, hasFlag } from '../utils';
+import { parseFlag } from '../utils';
 import { resolveSelfContext, getParentPidDefault } from '../identity';
 import type { RpcMethod, RpcResponse } from '../../shared/rpc';
 import { ENV_KEYS } from '../../shared/constants';
@@ -48,8 +48,11 @@ wmux channel — durable agent messaging (Channels v2)
   wmux channel list
       Channels visible to your workspace.
 
-  --member defaults to $WMUX_MEMBER_ID, then "agent". Use a stable, short
-  id (e.g. "codex") so humans can tell agents apart in the roster.
+  --member is your member id in the channel. Defaults to $WMUX_MEMBER_ID;
+  post/ack without it resolve your workspace's SINGLE member row in that
+  channel (two+ rows → pass --member; never guessed). join defaults to
+  "agent" — pick a stable, short id (e.g. "codex") so humans can tell
+  agents apart in the roster.
   --json on any subcommand prints the raw RPC payload.
 
   Typical loop when nudged: unread → read → do the work → post → ack.
@@ -77,6 +80,19 @@ async function resolveSenderPtyId(): Promise<string> {
   return typeof envPty === 'string' && envPty.trim().length > 0 ? envPty.trim() : '';
 }
 
+function exitNoPaneIdentity(): never {
+  console.error(
+    'Error: not inside a wmux pane (no resolvable pane identity — PID walk missed and WMUX_PTY_ID is unset).\n' +
+      'Channel mutations are fail-closed without one. Run this from a shell inside a wmux pane.',
+  );
+  process.exit(1);
+}
+
+/** Mutations fail closed BEFORE any RPC (including helper lookups). */
+async function requirePaneIdentityOrExit(): Promise<void> {
+  if (!(await resolveSenderPtyId())) exitNoPaneIdentity();
+}
+
 /**
  * Issue one channel RPC on the daemon pipe with senderPtyId attached, and
  * unwrap the two-layer envelope (pipe RpcResponse → ChannelService Result).
@@ -88,13 +104,7 @@ async function callChannel(
   opts: ChannelCallOpts,
 ): Promise<Record<string, unknown>> {
   const senderPtyId = await resolveSenderPtyId();
-  if (!senderPtyId && opts.mutating) {
-    console.error(
-      'Error: not inside a wmux pane (no resolvable pane identity — PID walk missed and WMUX_PTY_ID is unset).\n' +
-        'Channel mutations are fail-closed without one. Run this from a shell inside a wmux pane.',
-    );
-    process.exit(1);
-  }
+  if (!senderPtyId && opts.mutating) exitNoPaneIdentity();
   let response: RpcResponse;
   try {
     response = await sendDaemonRequest(method, {
@@ -137,6 +147,31 @@ async function resolveChannelId(ref: string): Promise<string> {
 
 function memberIdFrom(args: string[]): string {
   return parseFlag(args, '--member') ?? process.env['WMUX_MEMBER_ID'] ?? 'agent';
+}
+
+/**
+ * Which member row is THIS caller in <channelId>? Explicit `--member` (or
+ * $WMUX_MEMBER_ID) wins; otherwise resolve from the caller's own unread
+ * entries — server-filtered to the verified workspace, so the rows ARE the
+ * identities this caller can legitimately act as. Wake-worker discipline:
+ * never guess. A made-up default ("agent") used to no-op the ack against the
+ * REAL row (codex/opencode/…) while printing success, leaving the wake
+ * worker re-nudging forever (Codex review). Two+ rows without an explicit
+ * choice is an error; zero rows returns undefined (let the daemon speak).
+ */
+async function resolveOwnMemberId(channelId: string, args: string[]): Promise<string | undefined> {
+  const explicit = parseFlag(args, '--member') ?? process.env['WMUX_MEMBER_ID'];
+  if (explicit !== undefined && explicit.length > 0) return explicit;
+  const result = await callChannel('a2a.channel.unread' as RpcMethod, {}, { mutating: false });
+  const entries = (result['entries'] as Array<{ channelId: string; memberId: string }> | undefined) ?? [];
+  const ids = Array.from(new Set(entries.filter((e) => e.channelId === channelId).map((e) => e.memberId)));
+  if (ids.length > 1) {
+    console.error(
+      `Error: your workspace has ${ids.length} member identities in this channel (${ids.join(', ')}) — pass --member <id> so the right cursor moves.`,
+    );
+    process.exit(1);
+  }
+  return ids[0];
 }
 
 /**
@@ -238,8 +273,13 @@ export async function handleChannel(sub: string | undefined, args: string[], jso
         console.error('Usage: wmux channel post <channel> <text…> [--member <id>] [--name <display>]');
         process.exit(1);
       }
+      await requirePaneIdentityOrExit();
       const channelId = await resolveChannelId(ref);
-      const memberId = memberIdFrom(args);
+      // Post AS the row you actually occupy: an invented default would
+      // misattribute the message in the roster AND defeat the self-unread
+      // exemption (your own post would nudge you). Zero rows falls back to
+      // the legacy default and lets the daemon's NOT_A_MEMBER speak.
+      const memberId = (await resolveOwnMemberId(channelId, args)) ?? memberIdFrom(args);
       const memberName = parseFlag(args, '--name') ?? memberId;
       const result = await callChannel(
         'a2a.channel.post' as RpcMethod,
@@ -271,6 +311,7 @@ export async function handleChannel(sub: string | undefined, args: string[], jso
         console.error("Usage: wmux channel ack <channel> <uptoSeq|all> [--member <id>]");
         process.exit(1);
       }
+      await requirePaneIdentityOrExit();
       const channelId = await resolveChannelId(ref);
       // 'all' = everything currently in the channel; the daemon clamps to head.
       const uptoSeq = uptoRaw === 'all' ? Number.MAX_SAFE_INTEGER : Number(uptoRaw);
@@ -278,17 +319,20 @@ export async function handleChannel(sub: string | undefined, args: string[], jso
         console.error(`Error: uptoSeq must be a non-negative number or 'all' (got "${uptoRaw}").`);
         process.exit(1);
       }
-      const memberId = memberIdFrom(args);
+      // Which cursor moves? Resolve MY row — never a made-up default (see
+      // resolveOwnMemberId). undefined (not a member) sends no memberId so
+      // the daemon answers honestly instead of no-opping a phantom row.
+      const memberId = await resolveOwnMemberId(channelId, args);
       const result = await callChannel(
         'a2a.channel.ack' as RpcMethod,
-        { channelId, uptoSeq, memberId },
+        { channelId, uptoSeq, ...(memberId !== undefined ? { memberId } : {}) },
         { mutating: true },
       );
       if (jsonMode) {
         console.log(JSON.stringify(result, null, 2));
         return;
       }
-      console.log(`Acked ${channelId} up to seq ${result['lastReadSeq'] ?? uptoSeq} as ${memberId}.`);
+      console.log(`Acked ${channelId} up to seq ${result['lastReadSeq'] ?? uptoSeq} as ${memberId ?? 'this workspace'}.`);
       return;
     }
 

--- a/src/cli/commands/channel.ts
+++ b/src/cli/commands/channel.ts
@@ -132,17 +132,25 @@ async function callChannel(
   return result ?? {};
 }
 
-/** `<channel>` accepts a channel id (ch-…) or a name; names resolve via list. */
+/**
+ * `<channel>` accepts a channel id or a name. Channel NAMES may legally
+ * start with "ch-" too (lowercase letters/digits/hyphens), so a prefix
+ * check cannot separate the two (Codex round-3: a channel named
+ * "ch-release" was unreachable by name). Resolution: exact id in the
+ * caller's visible listing wins, then exact unique name; an unmatched
+ * ch-… ref passes through so the daemon answers authoritatively.
+ */
 async function resolveChannelId(ref: string): Promise<string> {
-  if (ref.startsWith('ch-')) return ref;
   const result = await callChannel('a2a.channel.list' as RpcMethod, {}, { mutating: false });
   const channels = (result['channels'] as Array<{ id?: string; name?: string; status?: string }> | undefined) ?? [];
+  if (channels.some((c) => c.id === ref)) return ref;
   const matches = channels.filter((c) => c.name === ref);
   if (matches.length === 1 && typeof matches[0].id === 'string') return matches[0].id;
   if (matches.length > 1) {
     console.error(`Error: channel name "${ref}" is ambiguous (${matches.length} matches) — use the channel id.`);
     process.exit(1);
   }
+  if (ref.startsWith('ch-')) return ref;
   console.error(
     `Error: no visible channel named "${ref}". Run \`wmux channel list\` to see what your workspace can reach.`,
   );
@@ -319,13 +327,25 @@ export async function handleChannel(sub: string | undefined, args: string[], jso
       if (sinceUsed !== undefined && messages.length === limitUsed) {
         console.log(`(full page — more may remain: wmux channel read ${channelId} --since ${last.seq + 1})`);
       }
-      if (rows.length > 1 && sinceUsed === undefined) {
-        // Multi-row workspace browsing the tail: acking this page's head seq
-        // could jump a cursor over unseen middle messages — route through the
-        // per-row cursors instead of printing a lossy one-liner.
-        console.log(
-          `(this workspace has ${rows.length} member rows — run: wmux channel unread, then read --since <cursor+1> and ack --member <id>)`,
-        );
+      if (rows.length > 1) {
+        // Multi-row workspace: a bare ack would hit the never-guess error, so
+        // the hint must carry the member (Codex round-3) — from an explicit
+        // --member on this read, or by mapping --since back to the ONE row
+        // whose cursor it came from (the unread output prints per-row
+        // `--since cursor+1`, so the mapping is usually exact).
+        const explicit = parseFlag(args, '--member');
+        const matched = sinceUsed !== undefined ? rows.filter((r) => r.lastReadSeq + 1 === sinceUsed) : [];
+        const hintId = explicit ?? (matched.length === 1 ? matched[0].memberId : undefined);
+        if (hintId !== undefined) {
+          console.log(`(consumed? then: wmux channel ack ${channelId} ${last.seq} --member ${hintId})`);
+        } else {
+          // No safe attribution (tail browse / ambiguous cursor match) —
+          // route through the per-row cursors instead of printing a command
+          // that either errors or jumps a cursor over unseen messages.
+          console.log(
+            `(this workspace has ${rows.length} member rows — run: wmux channel unread, then read --since <cursor+1> and ack --member <id>)`,
+          );
+        }
       } else {
         console.log(`(consumed? then: wmux channel ack ${channelId} ${last.seq})`);
       }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@ import { handleBrowser, handleOpen } from './commands/browser';
 import { handleMcp } from './commands/mcp';
 import { handleSetupHooks } from './commands/setupHooks';
 import { handleDoctor } from './commands/doctor';
+import { handleChannel } from './commands/channel';
 
 const HELP_TEXT = `
 wmux CLI
@@ -61,6 +62,17 @@ SYSTEM COMMANDS
   set-progress <0-100>              Set a progress value on the active workspace
   identify                          Show wmux app info
   capabilities                      List all supported RPC methods
+
+CHANNEL COMMANDS (agent messaging — Channels v2 durable inbox)
+  channel unread                    Your per-channel unread + mention counts
+  channel read <ch> [--since <seq>] Print messages (id or name; oldest first)
+  channel post <ch> <text…>         Post a message [--member <id>]
+  channel ack <ch> <uptoSeq|all>    Mark consumed — clears unread, stops re-nudges
+  channel join <ch>                 Join a public channel [--member <id>]
+  channel list                      Channels visible to your workspace
+
+  Works headless (talks to the daemon directly). Typical nudged-agent loop:
+  unread → read → work → post → ack. Run 'wmux channel help' for details.
 
 DIAGNOSTICS
   doctor                            Run health checks (env, daemon, boot phases,
@@ -168,6 +180,8 @@ async function main(): Promise<void> {
       await handleSetupHooks(rest, jsonMode);
     } else if (cmd === 'doctor') {
       await handleDoctor(rest, jsonMode);
+    } else if (cmd === 'channel') {
+      await handleChannel(rest[0], rest.slice(1), jsonMode);
     } else {
       console.error(`Unknown command: "${cmd}". Run 'wmux --help' for usage.`);
       process.exit(1);

--- a/src/daemon/channels/ChannelService.ts
+++ b/src/daemon/channels/ChannelService.ts
@@ -1426,6 +1426,20 @@ export class ChannelService {
    * Today nothing trims the log, so it is 0; the field exists so the cap
    * work lights it up instead of adding a new wire shape.
    */
+  /**
+   * Distinct workspaces that hold ≥1 member row in any non-archived channel.
+   * The wake worker sweeps these — it must not invent recipients, only serve
+   * the membership the daemon already persists.
+   */
+  memberWorkspaces(): string[] {
+    const out = new Set<string>();
+    for (const channel of this.state.channels) {
+      if (channel.status === 'archived') continue;
+      for (const m of this.state.members[channel.id] ?? []) out.add(m.workspaceId);
+    }
+    return Array.from(out);
+  }
+
   unreadFor(
     verifiedWorkspaceId: string,
     memberId?: string,

--- a/src/daemon/channels/ChannelService.ts
+++ b/src/daemon/channels/ChannelService.ts
@@ -938,6 +938,13 @@ export class ChannelService {
         memberId: invitee.memberId,
         joinedAt: now,
         historyFromSeq,
+        // v2 cursor — seed like join() (Codex review P1): the invitee may SEE
+        // history but owes unread only from the invite onward. Without this
+        // the row had NO cursor and unreadFor's missing-cursor fallback pinned
+        // it to the LIVE head on every query — messages posted after the
+        // invite looked pre-consumed, the wake worker never fired for invited
+        // members, and the load-time backfill cemented the loss on restart.
+        lastReadSeq: channel.nextSeq - 1,
       });
       this.state.members[channel.id] = members;
       if (!this.saveOrFail()) {
@@ -1197,6 +1204,19 @@ export class ChannelService {
         ...(mentions.length > 0 ? { mentions } : {}),
       };
       (this.state.messages[channel.id] ??= []).push(message);
+      // Channels v2 (Codex review): a poster has, by definition, seen the
+      // channel up to its own message. When the sender's row was fully
+      // caught up before this post, ride the cursor over the new seq —
+      // roster badges stay honest ("behind" never counts your own reply)
+      // and `read --since` doesn't replay your own words. A sender with
+      // OLDER unread keeps its cursor: the backlog is still owed
+      // (unreadFor additionally exempts self-authored messages, so even
+      // that sender is never re-nudged about itself).
+      const senderRow = members.find(
+        (m) => m.workspaceId === params.sender.workspaceId && m.memberId === params.sender.memberId,
+      );
+      const senderRowRode = senderRow !== undefined && senderRow.lastReadSeq === seq - 1;
+      if (senderRow && senderRowRode) senderRow.lastReadSeq = seq;
       // Update idempotency cache.
       if (params.clientMsgId) {
         const channelIdMap = this.idempotency.get(channel.id) ?? new Map();
@@ -1219,10 +1239,12 @@ export class ChannelService {
         );
       }
       if (!this.saveOrFail()) {
-        // Roll back: un-bump nextSeq, pop the message, drop idempotency entry.
+        // Roll back: un-bump nextSeq, pop the message, drop idempotency entry,
+        // and un-ride the sender cursor.
         channel.nextSeq--;
         const msgs = this.state.messages[channel.id];
         if (msgs) msgs.pop();
+        if (senderRow && senderRowRode) senderRow.lastReadSeq = seq - 1;
         if (params.clientMsgId) {
           const channelIdMap = this.idempotency.get(channel.id);
           if (channelIdMap) {
@@ -1478,6 +1500,12 @@ export class ChannelService {
         let mentionUnread = 0;
         for (const m of msgs) {
           if (m.seq <= cursor || m.seq < visibleFloor) continue;
+          // Self-authored messages are never owed (Codex review): a reply
+          // must not turn into the replier's own unread — the wake worker
+          // would nudge the pane about the message it just sent. Keyed on
+          // the full row identity (workspaceId AND memberId) so a same-ws
+          // SIBLING agent still owes it (same-ws A2A stays a conversation).
+          if (m.workspaceId === row.workspaceId && m.memberId === row.memberId) continue;
           unread += 1;
           const mentioned = (m.mentions ?? []).some(
             (men) =>

--- a/src/daemon/channels/ChannelService.ts
+++ b/src/daemon/channels/ChannelService.ts
@@ -1275,6 +1275,22 @@ export class ChannelService {
         }
         return { ok: false, error: { code: 'PERSIST_FAILED', message: 'Failed to persist post' } };
       }
+      // The cursor ride above advanced a PERSISTED member cursor — badge
+      // honesty needs the same catalog signal an explicit ack emits (Codex
+      // round-4): the channel.message event raises the head in open rosters
+      // while the cached member row's lastReadSeq stays stale, so a
+      // caught-up poster would show "1 behind" its own message until an
+      // unrelated catalog event lands. Emitted BEFORE channel.message so
+      // that event stays the LAST emit of a post (consumers are order-
+      // agnostic; tests pin the message event's tail position).
+      if (senderRowRode) {
+        this.emitCatalog(
+          channel.id,
+          params.sender.workspaceId,
+          members.map((m) => m.workspaceId),
+          'cursor',
+        );
+      }
       // Emit AFTER successful persist — the post is durable on disk by the
       // time consumers see it. A failed emit does not block the post
       // (the plan's contract is: persist-first, then notify).

--- a/src/daemon/channels/ChannelService.ts
+++ b/src/daemon/channels/ChannelService.ts
@@ -1483,12 +1483,22 @@ export class ChannelService {
           'cursor',
         );
       }
-      // `lastReadSeq` echoes the advanced cursor — only meaningful for a
-      // member-scoped ack (a receipt-only ack moves no cursor).
+      // Echo the row's ACTUAL post-ack cursor, not the clamped request
+      // target: a stale/backward ack (row already past uptoSeq) performs no
+      // flip and must not report a rewind it never did — cursors are
+      // advance-only and clients trust this echo (Codex round-3). Only
+      // meaningful for a member-scoped ack (receipt-only moves no cursor).
+      let echoedCursor: number | undefined;
+      if (params.memberId !== undefined) {
+        const row = (this.state.members[params.channelId] ?? []).find(
+          (m) => m.workspaceId === params.verifiedWorkspaceId && m.memberId === params.memberId,
+        );
+        echoedCursor = row && typeof row.lastReadSeq === 'number' ? row.lastReadSeq : cursorTarget;
+      }
       return {
         ok: true,
         acked: flips.length,
-        ...(params.memberId !== undefined ? { lastReadSeq: cursorTarget } : {}),
+        ...(echoedCursor !== undefined ? { lastReadSeq: echoedCursor } : {}),
       };
     });
   }

--- a/src/daemon/channels/ChannelService.ts
+++ b/src/daemon/channels/ChannelService.ts
@@ -321,6 +321,20 @@ export class ChannelService {
     this.ceoWorkspaceId = deps.ceoWorkspaceId;
     this.emit = deps.emit;
     this.now = deps.now ?? (() => Date.now());
+    // Channels v2 cursor backfill — member rows persisted before the
+    // `lastReadSeq` field existed get the channel HEAD ("start reading from
+    // now"), NOT 0: a 0 default would flag the entire history unread on
+    // upgrade and trigger a re-nudge storm (design doc, spec-review issue 4).
+    // Deterministic on every construction, so a crash before the next persist
+    // simply re-derives the same values.
+    for (const channel of this.state.channels) {
+      const head = channel.nextSeq - 1;
+      for (const member of this.state.members[channel.id] ?? []) {
+        if (typeof member.lastReadSeq !== 'number' || !Number.isFinite(member.lastReadSeq)) {
+          member.lastReadSeq = head;
+        }
+      }
+    }
     // Hydrate the idempotency LRU from persisted state (R9). Without
     // this, a daemon restart loses every `clientMsgId → seq` mapping
     // and a retry after restart silently allocates a fresh seq — the
@@ -538,6 +552,9 @@ export class ChannelService {
           memberId: params.createdBy.memberId,
           joinedAt: now,
           historyFromSeq: 0,
+          // v2 cursor seeded at head (nextSeq-1 = 0 on a fresh channel):
+          // a brand-new channel starts with zero unread.
+          lastReadSeq: 0,
         },
       ];
       for (const member of params.members ?? []) {
@@ -553,6 +570,7 @@ export class ChannelService {
           memberId: member.memberId,
           joinedAt: now,
           historyFromSeq: 0,
+          lastReadSeq: 0,
         });
       }
       this.state.members[channel.id] = initialMembers;
@@ -706,6 +724,10 @@ export class ChannelService {
         memberId: params.member.memberId,
         joinedAt: now,
         historyFromSeq,
+        // v2 cursor: "start reading from now" — a joiner may SEE history
+        // (historyFromSeq) but does not owe an ack for the backlog; unread
+        // starts at 0 so the wake worker never nudge-storms a fresh member.
+        lastReadSeq: channel.nextSeq - 1,
       });
       this.state.members[channel.id] = members;
       if (!this.saveOrFail()) {
@@ -1299,7 +1321,14 @@ export class ChannelService {
     channelId: string;
     verifiedWorkspaceId: string;
     uptoSeq: number;
-  }): Promise<Result<{ acked: number }>> {
+    /**
+     * Channels v2: narrow the cursor advance to ONE member row (agent
+     * CLI/MCP path). Absent = advance every row of the verified workspace
+     * (renderer "human read the channel" semantics). recipientSnapshot
+     * flips stay workspace-scoped either way (legacy delivery bookkeeping).
+     */
+    memberId?: string;
+  }): Promise<Result<{ acked: number; lastReadSeq?: number }>> {
     return this.withChannelLock(params.channelId, async () => {
       const channel = this.state.channels.find((c) => c.id === params.channelId);
       // Symmetric existence-hiding with get/getMessages: a non-member of a
@@ -1341,6 +1370,22 @@ export class ChannelService {
           }
         }
       }
+      // Channels v2 — advance the durable per-member read cursor alongside the
+      // legacy recipientSnapshot flips. Advance-only, clamped to the channel
+      // head: an ack can never mark the future read nor move backwards.
+      // `memberId` narrows the ack to one member row (the agent CLI/MCP path
+      // supplies it); absent = every row of the verified workspace (the
+      // renderer's "human read the channel" semantics, unchanged).
+      const cursorTarget = Math.min(params.uptoSeq, channel.nextSeq - 1);
+      const cursorFlips: Array<{ row: ChannelMember; prev: number | undefined }> = [];
+      for (const row of this.state.members[params.channelId] ?? []) {
+        if (row.workspaceId !== params.verifiedWorkspaceId) continue;
+        if (params.memberId !== undefined && row.memberId !== params.memberId) continue;
+        const current = typeof row.lastReadSeq === 'number' ? row.lastReadSeq : -1;
+        if (cursorTarget > current) {
+          cursorFlips.push({ row, prev: row.lastReadSeq });
+        }
+      }
       const now = this.now();
       for (const f of flips) {
         f.entry.status = 'delivered';
@@ -1350,17 +1395,101 @@ export class ChannelService {
         // per-recipient detail remains in recipientSnapshot for callers who need it).
         if (f.msg.deliveryStatus !== 'delivered') f.msg.deliveryStatus = 'delivered';
       }
-      if (flips.length > 0 && !this.saveOrFail()) {
+      for (const f of cursorFlips) {
+        f.row.lastReadSeq = cursorTarget;
+      }
+      if ((flips.length > 0 || cursorFlips.length > 0) && !this.saveOrFail()) {
         // Roll back the in-memory flips so memory ↔ disk stay consistent.
         for (const f of flips) {
           f.entry.status = f.prevEntryStatus;
           f.entry.lastAttemptAt = f.prevLastAttemptAt;
           f.msg.deliveryStatus = f.prevMsgStatus;
         }
+        for (const f of cursorFlips) {
+          f.row.lastReadSeq = f.prev;
+        }
         return { ok: false, error: { code: 'PERSIST_FAILED', message: 'Failed to persist ack' } };
       }
-      return { ok: true, acked: flips.length };
+      return { ok: true, acked: flips.length, lastReadSeq: cursorTarget };
     });
+  }
+
+  /**
+   * Channels v2 — per-member unread summary for the verified caller.
+   * `unread` counts retained messages this member may see (seq ≥
+   * historyFromSeq) beyond its cursor; `mentionUnread` narrows that to
+   * messages that @-mention the caller (workspace-level mention, or a
+   * memberId-targeted mention matching this row). `trimmedBeforeCursor`
+   * reports messages that retention removed BEFORE the member consumed
+   * them — silent loss is the one thing this subsystem must never do, so
+   * the gap is surfaced, not swallowed (design doc, spec-review issue 5).
+   * Today nothing trims the log, so it is 0; the field exists so the cap
+   * work lights it up instead of adding a new wire shape.
+   */
+  unreadFor(
+    verifiedWorkspaceId: string,
+    memberId?: string,
+  ): Array<{
+    channelId: string;
+    name: string;
+    memberId: string;
+    lastReadSeq: number;
+    headSeq: number;
+    unread: number;
+    mentionUnread: number;
+    trimmedBeforeCursor: number;
+  }> {
+    const out: Array<{
+      channelId: string;
+      name: string;
+      memberId: string;
+      lastReadSeq: number;
+      headSeq: number;
+      unread: number;
+      mentionUnread: number;
+      trimmedBeforeCursor: number;
+    }> = [];
+    for (const channel of this.state.channels) {
+      if (channel.status === 'archived') continue;
+      const rows = (this.state.members[channel.id] ?? []).filter(
+        (m) => m.workspaceId === verifiedWorkspaceId && (memberId === undefined || m.memberId === memberId),
+      );
+      if (rows.length === 0) continue;
+      const msgs = this.state.messages[channel.id] ?? [];
+      const headSeq = channel.nextSeq - 1;
+      for (const row of rows) {
+        const cursor = typeof row.lastReadSeq === 'number' ? row.lastReadSeq : headSeq;
+        const visibleFloor = row.historyFromSeq;
+        let unread = 0;
+        let mentionUnread = 0;
+        for (const m of msgs) {
+          if (m.seq <= cursor || m.seq < visibleFloor) continue;
+          unread += 1;
+          const mentioned = (m.mentions ?? []).some(
+            (men) =>
+              men.workspaceId === verifiedWorkspaceId &&
+              (men.memberId === undefined || men.memberId === row.memberId),
+          );
+          if (mentioned) mentionUnread += 1;
+        }
+        // Retained-log gap: messages between the cursor and the first retained
+        // seq were trimmed before this member read them.
+        const firstRetainedSeq = msgs.length > 0 ? msgs[0].seq : headSeq + 1;
+        const firstUnconsumed = Math.max(cursor + 1, visibleFloor);
+        const trimmedBeforeCursor = Math.max(0, firstRetainedSeq - firstUnconsumed);
+        out.push({
+          channelId: channel.id,
+          name: channel.name,
+          memberId: row.memberId,
+          lastReadSeq: cursor,
+          headSeq,
+          unread,
+          mentionUnread,
+          trimmedBeforeCursor,
+        });
+      }
+    }
+    return out;
   }
 
   // ── Internals ──────────────────────────────────────────────────────

--- a/src/daemon/channels/ChannelService.ts
+++ b/src/daemon/channels/ChannelService.ts
@@ -79,8 +79,10 @@ export interface ChannelCatalogEvent {
    *  workspace removed by this change (so a kicked/left member also drops the
    *  channel from its mirror). */
   recipientWorkspaceIds: string[];
-  /** What changed — advisory only; the receiver re-hydrates regardless. */
-  reason: 'created' | 'archived' | 'membership';
+  /** What changed — advisory only; the receiver re-hydrates regardless.
+   *  'cursor' = a member's read cursor advanced (agent ack): roster "N
+   *  behind" badges hydrate from the same catalog fetch (Codex re-review). */
+  reason: 'created' | 'archived' | 'membership' | 'cursor';
 }
 
 /** Shape of the `emit` callback injected by the daemon. Carries either a posted
@@ -450,10 +452,23 @@ export class ChannelService {
       floor = Math.max(floor, viewer.historyFromSeq);
     }
     const filtered = all.filter((m) => m.seq >= floor);
-    // Tail-slice to the most recent `limit` when a cap is requested.
-    // `Math.max(0, …)` keeps limit=0 → [] and limit>length → full list
-    // correct (a bare `.slice(-0)` would return the whole array).
     if (limit !== undefined && limit >= 0) {
+      // Two paging modes (Codex re-review P1):
+      //  - sinceSeq given → the caller is CONSUMING forward from a cursor:
+      //    return the OLDEST `limit` rows at/after it. Tail-slicing here made
+      //    the unread→read→ack loop lossy past `limit` unread — the page
+      //    showed the newest rows, acking its head seq then jumped the cursor
+      //    over everything between the cursor and the page (silent loss).
+      //    Oldest-first pages are contiguous, so "ack the highest seq you
+      //    read, repeat until drained" is always safe.
+      //  - no sinceSeq → display semantics: the most recent `limit` rows.
+      // The renderer never passes `limit` (it floors sinceSeq instead —
+      // loadChannelHistory), so the split touches only the CLI/MCP consume
+      // path. `Math.max(0, …)` keeps limit=0 → [] and limit>length → full
+      // list correct (a bare `.slice(-0)` would return the whole array).
+      if (sinceSeq !== undefined) {
+        return filtered.slice(0, limit);
+      }
       return filtered.slice(Math.max(0, filtered.length - limit));
     }
     return filtered;
@@ -1345,9 +1360,10 @@ export class ChannelService {
     uptoSeq: number;
     /**
      * Channels v2: narrow the cursor advance to ONE member row (agent
-     * CLI/MCP path). Absent = advance every row of the verified workspace
-     * (renderer "human read the channel" semantics). recipientSnapshot
-     * flips stay workspace-scoped either way (legacy delivery bookkeeping).
+     * CLI/MCP path). Absent = READ RECEIPT ONLY — recipientSnapshot flips
+     * for the workspace (legacy delivery bookkeeping, the renderer's
+     * open-channel ack) but NO cursor moves: a human glancing at a channel
+     * must never mark an agent's inbox consumed (Codex re-review P1).
      */
     memberId?: string;
   }): Promise<Result<{ acked: number; lastReadSeq?: number }>> {
@@ -1395,17 +1411,38 @@ export class ChannelService {
       // Channels v2 — advance the durable per-member read cursor alongside the
       // legacy recipientSnapshot flips. Advance-only, clamped to the channel
       // head: an ack can never mark the future read nor move backwards.
-      // `memberId` narrows the ack to one member row (the agent CLI/MCP path
-      // supplies it); absent = every row of the verified workspace (the
-      // renderer's "human read the channel" semantics, unchanged).
+      //
+      // Cursor advance is MEMBER-SCOPED ONLY (Codex re-review P1): the
+      // renderer's open-channel ack carries no memberId — it is a human READ
+      // RECEIPT (deliveryStatus), never an agent's consumption claim.
+      // Advancing every workspace row on it let a human's glance clear an
+      // agent's cursor: unread hit zero, the wake worker went silent, and the
+      // agent's work was silently dropped. No memberId ⇒ receipts only.
       const cursorTarget = Math.min(params.uptoSeq, channel.nextSeq - 1);
       const cursorFlips: Array<{ row: ChannelMember; prev: number | undefined }> = [];
-      for (const row of this.state.members[params.channelId] ?? []) {
-        if (row.workspaceId !== params.verifiedWorkspaceId) continue;
-        if (params.memberId !== undefined && row.memberId !== params.memberId) continue;
-        const current = typeof row.lastReadSeq === 'number' ? row.lastReadSeq : -1;
-        if (cursorTarget > current) {
-          cursorFlips.push({ row, prev: row.lastReadSeq });
+      if (params.memberId !== undefined) {
+        const wsRows = (this.state.members[params.channelId] ?? []).filter(
+          (m) => m.workspaceId === params.verifiedWorkspaceId,
+        );
+        // A narrowed ack that matches NO row is a caller bug (stale
+        // $WMUX_MEMBER_ID, typo) — fail loudly instead of returning a
+        // success that consumed nothing while the wake worker keeps
+        // re-nudging (Codex re-review).
+        if (!wsRows.some((m) => m.memberId === params.memberId)) {
+          return {
+            ok: false,
+            error: {
+              code: 'NOT_A_MEMBER',
+              message: `No member row "${params.memberId}" for this workspace in the channel`,
+            },
+          };
+        }
+        for (const row of wsRows) {
+          if (row.memberId !== params.memberId) continue;
+          const current = typeof row.lastReadSeq === 'number' ? row.lastReadSeq : -1;
+          if (cursorTarget > current) {
+            cursorFlips.push({ row, prev: row.lastReadSeq });
+          }
         }
       }
       const now = this.now();
@@ -1432,7 +1469,27 @@ export class ChannelService {
         }
         return { ok: false, error: { code: 'PERSIST_FAILED', message: 'Failed to persist ack' } };
       }
-      return { ok: true, acked: flips.length, lastReadSeq: cursorTarget };
+      // A cursor advance changes the roster's "N behind" badges, which
+      // hydrate from the catalog — without a signal an agent's ack leaves
+      // every open roster stale until some unrelated membership event lands
+      // (Codex re-review). Reason 'cursor' is advisory; receivers re-hydrate
+      // regardless. Receipt-only acks (no cursor movement) stay silent — the
+      // renderer fires one on every channel open.
+      if (cursorFlips.length > 0) {
+        this.emitCatalog(
+          params.channelId,
+          params.verifiedWorkspaceId,
+          (this.state.members[params.channelId] ?? []).map((m) => m.workspaceId),
+          'cursor',
+        );
+      }
+      // `lastReadSeq` echoes the advanced cursor — only meaningful for a
+      // member-scoped ack (a receipt-only ack moves no cursor).
+      return {
+        ok: true,
+        acked: flips.length,
+        ...(params.memberId !== undefined ? { lastReadSeq: cursorTarget } : {}),
+      };
     });
   }
 

--- a/src/daemon/channels/__tests__/ChannelService.test.ts
+++ b/src/daemon/channels/__tests__/ChannelService.test.ts
@@ -1359,7 +1359,7 @@ describe('ChannelService', () => {
       expect(svc.getMessages(pub.channel.id, undefined, 'ws-9')).toHaveLength(1);
     });
 
-    it('getMessages tail-limits to the most recent N (and undefined limit = full history, no regression)', async () => {
+    it('getMessages pages: newest-N display without sinceSeq, oldest-N consume with it (undefined limit = full history)', async () => {
       const { svc } = makeService();
       const pub = await svc.create({
         name: 'busy',
@@ -1379,13 +1379,16 @@ describe('ChannelService', () => {
       // Regression guard: omitting limit returns the FULL history (the human
       // ChannelView relies on this — the default-50 lives in the MCP tool, not here).
       expect(svc.getMessages(pub.channel.id, undefined, 'ws-1')).toHaveLength(5);
-      // Tail-limit returns the most recent N, in seq order.
+      // No sinceSeq → display semantics: the most recent N, in seq order.
       expect(svc.getMessages(pub.channel.id, undefined, 'ws-1', 2).map((m) => m.seq)).toEqual([4, 5]);
       // limit >= length returns everything; limit 0 returns nothing.
       expect(svc.getMessages(pub.channel.id, undefined, 'ws-1', 100)).toHaveLength(5);
       expect(svc.getMessages(pub.channel.id, undefined, 'ws-1', 0)).toEqual([]);
-      // sinceSeq floor applies first, then the tail-limit on the remainder.
-      expect(svc.getMessages(pub.channel.id, 3, 'ws-1', 1).map((m) => m.seq)).toEqual([5]);
+      // sinceSeq given → CONSUME semantics: the OLDEST N from the cursor, so
+      // paging forward is contiguous and "ack the highest seq you read" can
+      // never jump over unseen messages (Codex re-review P1).
+      expect(svc.getMessages(pub.channel.id, 3, 'ws-1', 1).map((m) => m.seq)).toEqual([3]);
+      expect(svc.getMessages(pub.channel.id, 3, 'ws-1', 0)).toEqual([]);
     });
   });
 

--- a/src/daemon/channels/__tests__/channelCallerIdentity.test.ts
+++ b/src/daemon/channels/__tests__/channelCallerIdentity.test.ts
@@ -1,0 +1,99 @@
+// Channels v2 Step 0 — daemon-side caller stamping unit tests.
+// Rules under test (channelCallerIdentity.ts):
+//   1. pre-stamped verifiedWorkspaceId → trusted verbatim, params untouched
+//   2. senderPtyId resolvable → server-side stamp + caller-field backfill
+//   3a. neither present → pass through (per-handler guard rejects)
+//   3b. senderPtyId present but unresolvable → fail-closed NOT_AUTHORIZED
+import { describe, it, expect } from 'vitest';
+import { stampChannelCaller, type ResolveSessionWorkspace } from '../channelCallerIdentity';
+
+const resolver =
+  (map: Record<string, string>): ResolveSessionWorkspace =>
+  (id) =>
+    map[id] ?? '';
+
+describe('stampChannelCaller', () => {
+  it('rule 1: trusts a pre-stamped verifiedWorkspaceId verbatim and does not re-resolve', () => {
+    const r = stampChannelCaller(
+      resolver({ 'pty-1': 'ws-other' }),
+      { verifiedWorkspaceId: 'ws-main-stamped', senderPtyId: 'pty-1' },
+      { kind: 'none' },
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.params['verifiedWorkspaceId']).toBe('ws-main-stamped');
+    }
+  });
+
+  it('rule 2: stamps verifiedWorkspaceId from the daemon session binding', () => {
+    const r = stampChannelCaller(resolver({ 'pty-1': 'ws-a' }), { senderPtyId: 'pty-1' }, { kind: 'none' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.params['verifiedWorkspaceId']).toBe('ws-a');
+  });
+
+  it('rule 2: backfills an omitted ref-style caller field (post sender)', () => {
+    const r = stampChannelCaller(
+      resolver({ 'pty-1': 'ws-a' }),
+      { senderPtyId: 'pty-1', sender: { memberId: 'codex', memberName: 'codex' } },
+      { kind: 'ref', key: 'sender' },
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.params['sender']).toEqual({ memberId: 'codex', memberName: 'codex', workspaceId: 'ws-a' });
+      expect(r.params['verifiedWorkspaceId']).toBe('ws-a');
+    }
+  });
+
+  it('rule 2: leaves an EXPLICIT ref workspaceId alone (sender-pin gate still verifies it)', () => {
+    const r = stampChannelCaller(
+      resolver({ 'pty-1': 'ws-a' }),
+      { senderPtyId: 'pty-1', sender: { workspaceId: 'ws-forged', memberId: 'x' } },
+      { kind: 'ref', key: 'sender' },
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      // verified is the daemon's answer; the mismatching explicit sender is
+      // left for ChannelService's sender-pin gate to reject.
+      expect(r.params['verifiedWorkspaceId']).toBe('ws-a');
+      expect((r.params['sender'] as Record<string, unknown>)['workspaceId']).toBe('ws-forged');
+    }
+  });
+
+  it('rule 2: backfills a flat caller field (leave workspaceId)', () => {
+    const r = stampChannelCaller(
+      resolver({ 'pty-1': 'ws-a' }),
+      { senderPtyId: 'pty-1', memberId: 'codex' },
+      { kind: 'flat', key: 'workspaceId' },
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.params['workspaceId']).toBe('ws-a');
+  });
+
+  it('rule 3a: passes through when neither identity input is present', () => {
+    const r = stampChannelCaller(resolver({}), { channelId: 'ch-1' }, { kind: 'none' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.params['verifiedWorkspaceId']).toBeUndefined();
+  });
+
+  it('rule 3b: fails closed when senderPtyId cannot be resolved', () => {
+    const r = stampChannelCaller(resolver({}), { senderPtyId: 'pty-ghost' }, { kind: 'none' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.code).toBe('NOT_AUTHORIZED');
+      expect(r.error.message).toContain('pty-ghost');
+    }
+  });
+
+  it('does not mutate the input params object', () => {
+    const raw = { senderPtyId: 'pty-1', sender: { memberId: 'codex' } };
+    const snapshot = JSON.parse(JSON.stringify(raw));
+    stampChannelCaller(resolver({ 'pty-1': 'ws-a' }), raw, { kind: 'ref', key: 'sender' });
+    expect(raw).toEqual(snapshot);
+  });
+
+  it('treats a whitespace-only senderPtyId as absent (rule 3a)', () => {
+    const r = stampChannelCaller(resolver({ '  ': 'ws-weird' }), { senderPtyId: '   ' }, { kind: 'none' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.params['verifiedWorkspaceId']).toBeUndefined();
+  });
+});

--- a/src/daemon/channels/__tests__/channelCursor.test.ts
+++ b/src/daemon/channels/__tests__/channelCursor.test.ts
@@ -255,14 +255,21 @@ describe('lastReadSeq cursor', () => {
   });
 
   it('a caught-up poster rides its cursor over its own message (never "behind" its reply)', async () => {
-    const { svc } = makeService();
+    const { svc, emit } = makeService();
     const channelId = await seedChannel(svc);
+    emit.mockClear();
     const seq = await post(svc, channelId, B, 'codex', 'my reply');
     const mine = svc.unreadFor(B, 'codex')[0];
     expect(mine.lastReadSeq).toBe(seq);
     expect(mine.unread).toBe(0);
     // The OTHER side still owes it (self-exemption is row-scoped).
     expect(svc.unreadFor(A)[0].unread).toBe(1);
+    // The ride advanced a PERSISTED cursor → same catalog signal as an ack,
+    // or open rosters would show the poster "1 behind" its own message
+    // (Codex round-4).
+    const catalogs = emit.mock.calls.filter((c) => c[0]?.type === 'channel.catalog');
+    expect(catalogs).toHaveLength(1);
+    expect(catalogs[0][0]).toMatchObject({ channelId, reason: 'cursor' });
   });
 
   it('a behind poster keeps its backlog but never owes its OWN post', async () => {

--- a/src/daemon/channels/__tests__/channelCursor.test.ts
+++ b/src/daemon/channels/__tests__/channelCursor.test.ts
@@ -133,9 +133,13 @@ describe('lastReadSeq cursor', () => {
     if (r1.ok) expect(r1.lastReadSeq).toBe(2);
     expect(svc.unreadFor(B)[0].unread).toBe(0);
 
-    // Regression attempt: ack(1) after cursor=2 must not move backwards.
+    // Regression attempt: ack(1) after cursor=2 must not move backwards —
+    // and the RESPONSE must echo the row's actual cursor (2), not the stale
+    // request target (1): a client trusting the echo would otherwise believe
+    // the cursor rewound and re-read from seq 2 (Codex round-3).
     const r2 = await svc.ack({ channelId, verifiedWorkspaceId: B, uptoSeq: 1, memberId: 'codex' });
     expect(r2.ok).toBe(true);
+    if (r2.ok) expect(r2.lastReadSeq).toBe(2);
     expect(svc.unreadFor(B)[0].lastReadSeq).toBe(2);
   });
 

--- a/src/daemon/channels/__tests__/channelCursor.test.ts
+++ b/src/daemon/channels/__tests__/channelCursor.test.ts
@@ -33,12 +33,13 @@ function makeWriter(initial?: ChannelState) {
 }
 
 function makeService(writer = makeWriter()) {
+  const emit = vi.fn();
   const svc = new ChannelService({
     writer: writer as never,
     companyId: 'co-test',
-    emit: vi.fn(),
+    emit,
   });
-  return { svc, writer };
+  return { svc, writer, emit };
 }
 
 const A = 'ws-a';
@@ -138,7 +139,7 @@ describe('lastReadSeq cursor', () => {
     expect(svc.unreadFor(B)[0].lastReadSeq).toBe(2);
   });
 
-  it('memberId narrows the cursor advance; omitting it advances every row of the workspace', async () => {
+  it('memberId narrows the cursor advance; omitting it is a READ RECEIPT — no cursor moves', async () => {
     const { svc } = makeService();
     const channelId = await seedChannel(svc);
     // Second agent row for the same workspace B.
@@ -154,9 +155,50 @@ describe('lastReadSeq cursor', () => {
     expect(byMember['codex'].unread).toBe(0);
     expect(byMember['reviewer'].unread).toBe(1);
 
-    // Workspace-wide ack (renderer semantics) catches the sibling up.
+    // Workspace-wide ack = the renderer's open-channel receipt (a HUMAN
+    // glanced at the channel). It must NOT consume the sibling agent's
+    // inbox — before this rule a human read silently cleared agent cursors
+    // and the wake worker went quiet on unprocessed work (Codex re-review P1).
+    const receipt = await svc.ack({ channelId, verifiedWorkspaceId: B, uptoSeq: 1 });
+    expect(receipt.ok).toBe(true);
+    if (receipt.ok) expect(receipt.lastReadSeq).toBeUndefined();
+    expect(svc.unreadFor(B).find((e) => e.memberId === 'reviewer')?.unread).toBe(1);
+  });
+
+  it('a narrowed ack naming a nonexistent member row fails loudly (NOT_A_MEMBER)', async () => {
+    const { svc } = makeService();
+    const channelId = await seedChannel(svc);
+    await post(svc, channelId, A, 'pm', 'm1');
+    // Stale $WMUX_MEMBER_ID / typo: before the fix this returned ok with
+    // nothing consumed — the CLI printed success while the wake worker kept
+    // re-nudging the REAL row forever (Codex re-review).
+    const r = await svc.ack({ channelId, verifiedWorkspaceId: B, uptoSeq: 1, memberId: 'agent' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe('NOT_A_MEMBER');
+    expect(svc.unreadFor(B)[0].unread).toBe(1);
+  });
+
+  it('a cursor advance emits a channel.catalog(reason=cursor); a receipt-only ack stays silent', async () => {
+    const { svc, emit } = makeService();
+    const channelId = await seedChannel(svc);
+    await post(svc, channelId, A, 'pm', 'm1');
+    emit.mockClear();
+
+    // Receipt-only (renderer open) → no catalog chatter.
     await svc.ack({ channelId, verifiedWorkspaceId: B, uptoSeq: 1 });
-    expect(svc.unreadFor(B).every((e) => e.unread === 0)).toBe(true);
+    expect(emit.mock.calls.filter((c) => c[0]?.type === 'channel.catalog')).toHaveLength(0);
+
+    // Member ack → the roster's "N behind" badges hydrate from the catalog,
+    // so the advance must signal a re-sync (Codex re-review).
+    await svc.ack({ channelId, verifiedWorkspaceId: B, uptoSeq: 1, memberId: 'codex' });
+    const catalogs = emit.mock.calls.filter((c) => c[0]?.type === 'channel.catalog');
+    expect(catalogs).toHaveLength(1);
+    expect(catalogs[0][0]).toMatchObject({ channelId, reason: 'cursor' });
+
+    // Repeat ack (no movement) → silent again.
+    emit.mockClear();
+    await svc.ack({ channelId, verifiedWorkspaceId: B, uptoSeq: 1, memberId: 'codex' });
+    expect(emit.mock.calls.filter((c) => c[0]?.type === 'channel.catalog')).toHaveLength(0);
   });
 
   it('rolls the cursor back when persist fails', async () => {

--- a/src/daemon/channels/__tests__/channelCursor.test.ts
+++ b/src/daemon/channels/__tests__/channelCursor.test.ts
@@ -186,6 +186,52 @@ describe('lastReadSeq cursor', () => {
     expect(entries[0].trimmedBeforeCursor).toBe(0);
   });
 
+  it('seeds an INVITED member cursor at the invite-time head (Codex review P1)', async () => {
+    const { svc } = makeService();
+    const channelId = await seedChannel(svc);
+    await post(svc, channelId, A, 'pm', 'before-invite');
+    const invited = await svc.invite({
+      channelId,
+      invitedMember: { workspaceId: 'ws-c', memberId: 'opencode', memberName: 'opencode' },
+      verifiedWorkspaceId: A,
+    });
+    expect(invited.ok).toBe(true);
+    // Nothing owed at invite time ("start reading from now", like join)…
+    const atInvite = svc.unreadFor('ws-c')[0];
+    expect(atInvite.lastReadSeq).toBe(1);
+    expect(atInvite.unread).toBe(0);
+    // …but a message posted AFTER the invite IS owed. Before the fix the
+    // row had no cursor at all: unreadFor pinned it to the live head on
+    // every query, so invited members never accumulated unread and the
+    // wake worker never fired for them.
+    await post(svc, channelId, A, 'pm', 'after-invite');
+    expect(svc.unreadFor('ws-c')[0].unread).toBe(1);
+  });
+
+  it('a caught-up poster rides its cursor over its own message (never "behind" its reply)', async () => {
+    const { svc } = makeService();
+    const channelId = await seedChannel(svc);
+    const seq = await post(svc, channelId, B, 'codex', 'my reply');
+    const mine = svc.unreadFor(B, 'codex')[0];
+    expect(mine.lastReadSeq).toBe(seq);
+    expect(mine.unread).toBe(0);
+    // The OTHER side still owes it (self-exemption is row-scoped).
+    expect(svc.unreadFor(A)[0].unread).toBe(1);
+  });
+
+  it('a behind poster keeps its backlog but never owes its OWN post', async () => {
+    const { svc } = makeService();
+    const channelId = await seedChannel(svc);
+    await post(svc, channelId, A, 'pm', 'm1'); // codex is now 1 behind
+    await post(svc, channelId, B, 'codex', 'reply while behind');
+    const mine = svc.unreadFor(B, 'codex')[0];
+    // Cursor did NOT ride (the backlog is still owed)…
+    expect(mine.lastReadSeq).toBe(0);
+    // …and unread counts m1 only: the self-authored reply is exempt, so
+    // the wake worker cannot nudge the pane about the message it just sent.
+    expect(mine.unread).toBe(1);
+  });
+
   it('unreadFor respects the historyFromSeq visibility floor', async () => {
     const { svc } = makeService();
     const created = await svc.create({

--- a/src/daemon/channels/__tests__/channelCursor.test.ts
+++ b/src/daemon/channels/__tests__/channelCursor.test.ts
@@ -1,0 +1,215 @@
+// Channels v2 Step 1 — durable per-member read cursor (lastReadSeq) tests.
+// Covers: seeding at create/join, upgrade backfill to head (NOT 0 — the
+// re-nudge-storm guard), advance-only ack with optional member narrowing,
+// persist-failure rollback, and the unreadFor() read model.
+import { describe, it, expect, vi } from 'vitest';
+import { ChannelService } from '../ChannelService';
+import type { ChannelState } from '../../../shared/channels';
+
+function makeWriter(initial?: ChannelState) {
+  let failNext = false;
+  let last: ChannelState | null = initial ? structuredClone(initial) : null;
+  return {
+    load: (): ChannelState =>
+      last
+        ? structuredClone(last)
+        : { version: 1, channels: [], members: {}, messages: {}, idempotency: {} },
+    saveImmediate: vi.fn((state: ChannelState): boolean => {
+      if (failNext) {
+        failNext = false;
+        return false;
+      }
+      last = structuredClone(state);
+      return true;
+    }),
+    save: vi.fn(),
+    flush: vi.fn(),
+    flushSync: vi.fn(),
+    dispose: vi.fn(),
+    failNext: () => {
+      failNext = true;
+    },
+  };
+}
+
+function makeService(writer = makeWriter()) {
+  const svc = new ChannelService({
+    writer: writer as never,
+    companyId: 'co-test',
+    emit: vi.fn(),
+  });
+  return { svc, writer };
+}
+
+const A = 'ws-a';
+const B = 'ws-b';
+
+async function seedChannel(svc: ChannelService) {
+  const created = await svc.create({
+    name: 'cursor-test',
+    visibility: 'public',
+    createdBy: { workspaceId: A, memberId: 'pm', memberName: 'pm' },
+    verifiedWorkspaceId: A,
+  });
+  if (!created.ok) throw new Error('create failed');
+  const channelId = created.channel.id;
+  const joined = await svc.join({
+    channelId,
+    member: { workspaceId: B, memberId: 'codex', memberName: 'codex' },
+    verifiedWorkspaceId: B,
+  });
+  if (!joined.ok) throw new Error('join failed');
+  return channelId;
+}
+
+async function post(svc: ChannelService, channelId: string, ws: string, memberId: string, text: string, mentions?: Array<{ workspaceId: string; memberId?: string; name: string }>) {
+  const r = await svc.post({
+    channelId,
+    text,
+    sender: { workspaceId: ws, memberId, memberName: memberId },
+    verifiedWorkspaceId: ws,
+    ...(mentions ? { mentions } : {}),
+  });
+  if (!r.ok) throw new Error(`post failed: ${JSON.stringify(r.error)}`);
+  return r.message.seq;
+}
+
+describe('lastReadSeq cursor', () => {
+  it('seeds the creator cursor at 0 and a joiner cursor at the join-time head', async () => {
+    const { svc } = makeService();
+    const created = await svc.create({
+      name: 'seed',
+      visibility: 'public',
+      createdBy: { workspaceId: A, memberId: 'pm', memberName: 'pm' },
+      verifiedWorkspaceId: A,
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    const channelId = created.channel.id;
+    await post(svc, channelId, A, 'pm', 'one');
+    await post(svc, channelId, A, 'pm', 'two');
+    await svc.join({
+      channelId,
+      member: { workspaceId: B, memberId: 'codex', memberName: 'codex' },
+      verifiedWorkspaceId: B,
+    });
+    const entries = svc.unreadFor(B);
+    expect(entries).toHaveLength(1);
+    // Joined at head seq 2 → zero unread despite two prior messages.
+    expect(entries[0].lastReadSeq).toBe(2);
+    expect(entries[0].unread).toBe(0);
+  });
+
+  it('backfills a pre-v2 member row (no lastReadSeq) to the channel head on load', async () => {
+    const { svc, writer } = makeService();
+    const channelId = await seedChannel(svc);
+    await post(svc, channelId, A, 'pm', 'm1');
+    await post(svc, channelId, A, 'pm', 'm2');
+    // Simulate a pre-v2 file: strip lastReadSeq from the persisted rows.
+    const state = writer.load();
+    for (const rows of Object.values(state.members)) {
+      for (const row of rows) delete (row as unknown as Record<string, unknown>)['lastReadSeq'];
+    }
+    const writer2 = makeWriter(state);
+    const svc2 = new ChannelService({ writer: writer2 as never, companyId: 'co-test', emit: vi.fn() });
+    const entries = svc2.unreadFor(B);
+    expect(entries).toHaveLength(1);
+    // Head backfill ("start reading from now"), NOT 0 — no unread storm.
+    expect(entries[0].lastReadSeq).toBe(2);
+    expect(entries[0].unread).toBe(0);
+  });
+
+  it('ack advances the cursor, is clamped to head, and never moves backwards', async () => {
+    const { svc } = makeService();
+    const channelId = await seedChannel(svc);
+    await post(svc, channelId, A, 'pm', 'm1');
+    await post(svc, channelId, A, 'pm', 'm2');
+    expect(svc.unreadFor(B)[0].unread).toBe(2);
+
+    // Overshoot: clamped to head (2), not persisted as 99.
+    const r1 = await svc.ack({ channelId, verifiedWorkspaceId: B, uptoSeq: 99, memberId: 'codex' });
+    expect(r1.ok).toBe(true);
+    if (r1.ok) expect(r1.lastReadSeq).toBe(2);
+    expect(svc.unreadFor(B)[0].unread).toBe(0);
+
+    // Regression attempt: ack(1) after cursor=2 must not move backwards.
+    const r2 = await svc.ack({ channelId, verifiedWorkspaceId: B, uptoSeq: 1, memberId: 'codex' });
+    expect(r2.ok).toBe(true);
+    expect(svc.unreadFor(B)[0].lastReadSeq).toBe(2);
+  });
+
+  it('memberId narrows the cursor advance; omitting it advances every row of the workspace', async () => {
+    const { svc } = makeService();
+    const channelId = await seedChannel(svc);
+    // Second agent row for the same workspace B.
+    await svc.join({
+      channelId,
+      member: { workspaceId: B, memberId: 'reviewer', memberName: 'reviewer' },
+      verifiedWorkspaceId: B,
+    });
+    await post(svc, channelId, A, 'pm', 'm1');
+
+    await svc.ack({ channelId, verifiedWorkspaceId: B, uptoSeq: 1, memberId: 'codex' });
+    const byMember = Object.fromEntries(svc.unreadFor(B).map((e) => [e.memberId, e]));
+    expect(byMember['codex'].unread).toBe(0);
+    expect(byMember['reviewer'].unread).toBe(1);
+
+    // Workspace-wide ack (renderer semantics) catches the sibling up.
+    await svc.ack({ channelId, verifiedWorkspaceId: B, uptoSeq: 1 });
+    expect(svc.unreadFor(B).every((e) => e.unread === 0)).toBe(true);
+  });
+
+  it('rolls the cursor back when persist fails', async () => {
+    const { svc, writer } = makeService();
+    const channelId = await seedChannel(svc);
+    await post(svc, channelId, A, 'pm', 'm1');
+    writer.failNext();
+    const r = await svc.ack({ channelId, verifiedWorkspaceId: B, uptoSeq: 1, memberId: 'codex' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe('PERSIST_FAILED');
+    // Cursor unchanged → the unread is still owed and a retry is not a no-op.
+    expect(svc.unreadFor(B)[0].unread).toBe(1);
+  });
+
+  it('unreadFor counts mention-unread separately (workspace-level and member-targeted)', async () => {
+    const { svc } = makeService();
+    const channelId = await seedChannel(svc);
+    await post(svc, channelId, A, 'pm', 'plain message');
+    await post(svc, channelId, A, 'pm', 'hey @codex', [{ workspaceId: B, memberId: 'codex', name: 'codex' }]);
+    await post(svc, channelId, A, 'pm', 'hey @ws-b', [{ workspaceId: B, name: 'B' }]);
+
+    const entries = svc.unreadFor(B, 'codex');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].unread).toBe(3);
+    // member-targeted mention + workspace-level mention both count for codex.
+    expect(entries[0].mentionUnread).toBe(2);
+    expect(entries[0].trimmedBeforeCursor).toBe(0);
+  });
+
+  it('unreadFor respects the historyFromSeq visibility floor', async () => {
+    const { svc } = makeService();
+    const created = await svc.create({
+      name: 'floor',
+      visibility: 'public',
+      createdBy: { workspaceId: A, memberId: 'pm', memberName: 'pm' },
+      verifiedWorkspaceId: A,
+    });
+    if (!created.ok) return;
+    const channelId = created.channel.id;
+    await post(svc, channelId, A, 'pm', 'before-join');
+    await svc.join({
+      channelId,
+      member: { workspaceId: B, memberId: 'codex', memberName: 'codex' },
+      verifiedWorkspaceId: B,
+      includeHistory: false,
+    });
+    // Force the cursor BELOW the visibility floor to prove the floor wins.
+    // (Not reachable through the public API — simulates a hand-edited file.)
+    const rows = (svc as unknown as { state: ChannelState }).state.members[channelId];
+    const codexRow = rows.find((m) => m.memberId === 'codex');
+    if (codexRow) codexRow.lastReadSeq = 0;
+    const entries = svc.unreadFor(B);
+    // seq 1 is below historyFromSeq (2) → not owed, not counted.
+    expect(entries[0].unread).toBe(0);
+  });
+});

--- a/src/daemon/channels/__tests__/channelWakeWorker.test.ts
+++ b/src/daemon/channels/__tests__/channelWakeWorker.test.ts
@@ -1,0 +1,222 @@
+// Channels v2 Step 3a — wake worker tests.
+// Pins the safety rules that came out of the live P3' pre-verification:
+//   F2 split-write (text, THEN Enter as a separate write),
+//   quiet gate, target discipline (never guess), mention backoff + cap +
+//   exhaustion broadcast, plain-unread once-per-head-advance, ack reset.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  ChannelWakeWorker,
+  pickTarget,
+  MENTION_NUDGE_CAP,
+  MENTION_NUDGE_BACKOFF_MS,
+  WAKE_QUIET_MS,
+  type WakeUnreadEntry,
+  type WakeSessionView,
+} from '../channelWakeWorker';
+
+function entry(partial: Partial<WakeUnreadEntry>): WakeUnreadEntry {
+  return {
+    channelId: 'ch-1',
+    name: 'general',
+    memberId: 'codex',
+    lastReadSeq: 2,
+    headSeq: 4,
+    unread: 2,
+    mentionUnread: 0,
+    trimmedBeforeCursor: 0,
+    ...partial,
+  };
+}
+
+function session(partial: Partial<WakeSessionView>): WakeSessionView {
+  return {
+    id: 'pty-1',
+    lastDetectedAgent: 'codex',
+    lastActivityMs: 0, // long quiet by default
+    workspaceId: 'ws-b',
+    ...partial,
+  };
+}
+
+interface Harness {
+  worker: ChannelWakeWorker;
+  writes: Array<{ sessionId: string; data: string }>;
+  broadcasts: Array<Record<string, unknown>>;
+  setEntries(e: WakeUnreadEntry[]): void;
+  setSessions(s: WakeSessionView[]): void;
+  setNow(ms: number): void;
+}
+
+function makeHarness(): Harness {
+  let entries: WakeUnreadEntry[] = [];
+  let sessions: WakeSessionView[] = [];
+  let nowMs = 1_000_000;
+  const writes: Array<{ sessionId: string; data: string }> = [];
+  const broadcasts: Array<Record<string, unknown>> = [];
+  const worker = new ChannelWakeWorker({
+    memberWorkspaces: () => ['ws-b'],
+    unreadFor: () => entries,
+    listLiveSessions: () => sessions,
+    write: (sessionId, data) => writes.push({ sessionId, data }),
+    broadcast: (event) => broadcasts.push(event),
+    log: () => {},
+    now: () => nowMs,
+    enterDelayMs: 1,
+  });
+  return {
+    worker,
+    writes,
+    broadcasts,
+    setEntries: (e) => (entries = e),
+    setSessions: (s) => (sessions = s),
+    setNow: (ms) => (nowMs = ms),
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const flushEnter = () => vi.advanceTimersByTime(5);
+
+describe('ChannelWakeWorker — injection mechanics', () => {
+  it('injects the nudge line and the Enter as TWO separate writes (F2)', () => {
+    const h = makeHarness();
+    h.setEntries([entry({ unread: 2, mentionUnread: 1 })]);
+    h.setSessions([session({})]);
+    h.worker.tickOnce();
+    expect(h.writes).toHaveLength(1);
+    expect(h.writes[0].sessionId).toBe('pty-1');
+    expect(h.writes[0].data).toContain('#general: 2 unread (1 mention you)');
+    expect(h.writes[0].data).toContain('wmux channel read ch-1 --since 3');
+    expect(h.writes[0].data).not.toContain('\r');
+    flushEnter();
+    expect(h.writes).toHaveLength(2);
+    expect(h.writes[1].data).toBe('\r');
+  });
+
+  it('respects the quiet gate: a recently-active pane is skipped, then nudged once quiet', () => {
+    const h = makeHarness();
+    h.setNow(1_000_000);
+    h.setEntries([entry({ mentionUnread: 1 })]);
+    h.setSessions([session({ lastActivityMs: 1_000_000 - (WAKE_QUIET_MS - 1) })]);
+    h.worker.tickOnce();
+    expect(h.writes).toHaveLength(0);
+    // Quiet long enough now.
+    h.setNow(1_000_000 + WAKE_QUIET_MS);
+    h.worker.tickOnce();
+    expect(h.writes).toHaveLength(1);
+  });
+
+  it('strips control characters from the injected line', () => {
+    const h = makeHarness();
+    h.setEntries([entry({ name: 'gen\x1b[31meral', mentionUnread: 1 })]);
+    h.setSessions([session({})]);
+    h.worker.tickOnce();
+    // eslint-disable-next-line no-control-regex
+    expect(h.writes[0].data).not.toMatch(/[\x00-\x1f\x7f]/);
+  });
+});
+
+describe('ChannelWakeWorker — re-nudge policy', () => {
+  it('mention unread: re-nudges with backoff up to the cap, then broadcasts exhaustion ONCE', () => {
+    const h = makeHarness();
+    h.setEntries([entry({ mentionUnread: 1 })]);
+    h.setSessions([session({})]);
+    let t = 1_000_000;
+    for (let i = 0; i < MENTION_NUDGE_CAP; i++) {
+      h.setNow(t);
+      h.worker.tickOnce();
+      flushEnter();
+      // Immediately re-ticking within the backoff window must NOT re-nudge.
+      h.worker.tickOnce();
+      expect(h.writes.filter((w) => w.data !== '\r')).toHaveLength(i + 1);
+      t += (MENTION_NUDGE_BACKOFF_MS[i + 1] ?? 0) + 1;
+    }
+    // Budget exhausted → no more writes, one exhaustion broadcast.
+    h.setNow(t + 10_000_000);
+    h.worker.tickOnce();
+    h.worker.tickOnce();
+    expect(h.writes.filter((w) => w.data !== '\r')).toHaveLength(MENTION_NUDGE_CAP);
+    const exhausted = h.broadcasts.filter((b) => b['type'] === 'channel.nudgeExhausted');
+    expect(exhausted).toHaveLength(1);
+    expect(exhausted[0]).toMatchObject({ channelId: 'ch-1', workspaceId: 'ws-b', memberId: 'codex' });
+  });
+
+  it('ack (unread=0) resets the episode: a fresh unread gets a fresh nudge budget', () => {
+    const h = makeHarness();
+    h.setSessions([session({})]);
+    h.setEntries([entry({ mentionUnread: 1 })]);
+    h.worker.tickOnce();
+    expect(h.writes.filter((w) => w.data !== '\r')).toHaveLength(1);
+    // Ack lands → unread 0 → tracker cleared.
+    h.setEntries([entry({ unread: 0, mentionUnread: 0 })]);
+    h.worker.tickOnce();
+    // New mention episode nudges immediately again (budget reset).
+    h.setEntries([entry({ mentionUnread: 1, headSeq: 9, lastReadSeq: 8, unread: 1 })]);
+    h.worker.tickOnce();
+    expect(h.writes.filter((w) => w.data !== '\r')).toHaveLength(2);
+  });
+
+  it('plain unread: nudges ONCE, and again only after the head advances', () => {
+    const h = makeHarness();
+    h.setSessions([session({})]);
+    h.setEntries([entry({ unread: 2, mentionUnread: 0, headSeq: 4 })]);
+    h.worker.tickOnce();
+    h.worker.tickOnce();
+    expect(h.writes.filter((w) => w.data !== '\r')).toHaveLength(1);
+    // New message arrives (head advances) → one more nudge allowed.
+    h.setEntries([entry({ unread: 3, mentionUnread: 0, headSeq: 5 })]);
+    h.worker.tickOnce();
+    h.worker.tickOnce();
+    expect(h.writes.filter((w) => w.data !== '\r')).toHaveLength(2);
+  });
+});
+
+describe('pickTarget — never guess', () => {
+  it('prefers the slug-matching non-claude session', () => {
+    const target = pickTarget(
+      [
+        session({ id: 'a', lastDetectedAgent: 'claude' }),
+        session({ id: 'b', lastDetectedAgent: 'codex' }),
+        session({ id: 'c', lastDetectedAgent: undefined }),
+      ],
+      'ws-b',
+      'codex',
+    );
+    expect(target?.id).toBe('b');
+  });
+
+  it('falls back to the ONLY non-claude session when no slug matches', () => {
+    const target = pickTarget(
+      [session({ id: 'a', lastDetectedAgent: 'claude' }), session({ id: 'b', lastDetectedAgent: undefined })],
+      'ws-b',
+      'reviewer',
+    );
+    expect(target?.id).toBe('b');
+  });
+
+  it('returns null on ambiguity (two non-claude sessions, no slug match)', () => {
+    expect(
+      pickTarget(
+        [session({ id: 'a', lastDetectedAgent: undefined }), session({ id: 'b', lastDetectedAgent: 'codex' })],
+        'ws-b',
+        'reviewer',
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null when the only live session is a claude pane (Stop-hook owns it)', () => {
+    expect(pickTarget([session({ id: 'a', lastDetectedAgent: 'claude' })], 'ws-b', 'codex')).toBeNull();
+    // …and a claude pane is never picked even when the memberId literally
+    // says "claude" — the generic injector must not double-nudge that path.
+    expect(pickTarget([session({ id: 'a', lastDetectedAgent: 'claude' })], 'ws-b', 'claude')).toBeNull();
+  });
+
+  it('never targets a session from another workspace', () => {
+    expect(pickTarget([session({ id: 'a', workspaceId: 'ws-other' })], 'ws-b', 'codex')).toBeNull();
+  });
+});

--- a/src/daemon/channels/__tests__/channelWakeWorker.test.ts
+++ b/src/daemon/channels/__tests__/channelWakeWorker.test.ts
@@ -219,4 +219,18 @@ describe('pickTarget — never guess', () => {
   it('never targets a session from another workspace', () => {
     expect(pickTarget([session({ id: 'a', workspaceId: 'ws-other' })], 'ws-b', 'codex')).toBeNull();
   });
+
+  it('never targets a deferred (recovered-not-yet-activated) session — dogfood G5', () => {
+    // After a daemon crash+respawn the recovered pane is bookkept 'attached'
+    // but renders nothing and the pre-crash agent process is gone. Live
+    // dogfood showed the worker burning mention nudges into that void.
+    expect(pickTarget([session({ id: 'a', deferred: true })], 'ws-b', 'codex')).toBeNull();
+    // …and a deferred slug-match must not shadow a live fallback either.
+    const target = pickTarget(
+      [session({ id: 'a', deferred: true, lastDetectedAgent: 'codex' }), session({ id: 'b', lastDetectedAgent: undefined })],
+      'ws-b',
+      'codex',
+    );
+    expect(target?.id).toBe('b');
+  });
 });

--- a/src/daemon/channels/__tests__/channelWakeWorker.test.ts
+++ b/src/daemon/channels/__tests__/channelWakeWorker.test.ts
@@ -260,9 +260,12 @@ describe('pickTarget — never guess', () => {
     expect(target?.id).toBe('b');
   });
 
-  it('falls back to the ONLY non-claude session when no slug matches', () => {
+  it('falls back to the ONLY eligible session when no slug matches', () => {
     const target = pickTarget(
-      [session({ id: 'a', lastDetectedAgent: 'claude' }), session({ id: 'b', lastDetectedAgent: undefined })],
+      [
+        session({ id: 'a', lastDetectedAgent: 'claude', attached: true }),
+        session({ id: 'b', lastDetectedAgent: undefined }),
+      ],
       'ws-b',
       'reviewer',
     );
@@ -279,11 +282,23 @@ describe('pickTarget — never guess', () => {
     ).toBeNull();
   });
 
-  it('returns null when the only live session is a claude pane (Stop-hook owns it)', () => {
-    expect(pickTarget([session({ id: 'a', lastDetectedAgent: 'claude' })], 'ws-b', 'codex')).toBeNull();
-    // …and a claude pane is never picked even when the memberId literally
-    // says "claude" — the generic injector must not double-nudge that path.
-    expect(pickTarget([session({ id: 'a', lastDetectedAgent: 'claude' })], 'ws-b', 'claude')).toBeNull();
+  it('an ATTACHED claude pane is never picked (the renderer Stop-hook path owns it)', () => {
+    const attachedClaude = session({ id: 'a', lastDetectedAgent: 'claude', attached: true });
+    expect(pickTarget([attachedClaude], 'ws-b', 'codex')).toBeNull();
+    // …even when the memberId literally says "claude" — the generic injector
+    // must not double-nudge a pane the renderer path already delivers to.
+    expect(pickTarget([attachedClaude], 'ws-b', 'claude')).toBeNull();
+  });
+
+  it('a DETACHED claude pane IS a target — headless has no Stop-hook path (Codex round-3)', () => {
+    // No renderer attached (the reboot-recovery / GUI-closed window): the
+    // worker is the ONLY delivery path, so a Claude-only workspace must not
+    // stay silent forever (it never even reached the exhaustion handoff —
+    // no nudge was ever spent).
+    const headless = session({ id: 'a', lastDetectedAgent: 'claude' });
+    expect(pickTarget([headless], 'ws-b', 'claude')?.id).toBe('a');
+    // Fallback rule too: the only eligible pane in the workspace.
+    expect(pickTarget([headless], 'ws-b', 'codex')?.id).toBe('a');
   });
 
   it('never targets a session from another workspace', () => {

--- a/src/daemon/channels/__tests__/channelWakeWorker.test.ts
+++ b/src/daemon/channels/__tests__/channelWakeWorker.test.ts
@@ -123,6 +123,18 @@ describe('ChannelWakeWorker — injection mechanics', () => {
     expect(h.writes).toHaveLength(1);
   });
 
+  it('a JUST-active pane (lastActivityMs≈now) is held off by the quiet gate — GLM fail-safe', () => {
+    // The daemon adapter seeds a broken/missing lastActivity to Date.now()
+    // rather than 0 (which would read as "quiet since the epoch" and always
+    // pass the gate). Model that here: lastActivityMs === now ⇒ gate holds.
+    const h = makeHarness();
+    h.setNow(1_000_000);
+    h.setEntries([entry({ mentionUnread: 1 })]);
+    h.setSessions([session({ lastActivityMs: 1_000_000 })]);
+    h.worker.tickOnce();
+    expect(h.writes).toHaveLength(0);
+  });
+
   it('strips control characters from the injected line', () => {
     const h = makeHarness();
     h.setEntries([entry({ name: 'gen\x1b[31meral', mentionUnread: 1 })]);

--- a/src/daemon/channels/__tests__/channelWakeWorker.test.ts
+++ b/src/daemon/channels/__tests__/channelWakeWorker.test.ts
@@ -11,6 +11,7 @@ import {
   MENTION_NUDGE_BACKOFF_MS,
   WAKE_QUIET_MS,
   WAKE_TICK_MS,
+  EXHAUSTED_REANNOUNCE_MS,
   type WakeUnreadEntry,
   type WakeSessionView,
 } from '../channelWakeWorker';
@@ -133,7 +134,7 @@ describe('ChannelWakeWorker — injection mechanics', () => {
 });
 
 describe('ChannelWakeWorker — re-nudge policy', () => {
-  it('mention unread: re-nudges with backoff up to the cap, then broadcasts exhaustion ONCE', () => {
+  it('mention unread: re-nudges with backoff up to the cap, then hands off (once per re-announce window)', () => {
     const h = makeHarness();
     h.setEntries([entry({ mentionUnread: 1 })]);
     h.setSessions([session({})]);
@@ -147,14 +148,24 @@ describe('ChannelWakeWorker — re-nudge policy', () => {
       expect(h.writes.filter((w) => w.data !== '\r')).toHaveLength(i + 1);
       t += (MENTION_NUDGE_BACKOFF_MS[i + 1] ?? 0) + 1;
     }
-    // Budget exhausted → no more writes, one exhaustion broadcast.
-    h.setNow(t + 10_000_000);
+    // Budget exhausted → no more writes; the handoff announced ONCE (the
+    // immediate in-window re-tick inside the loop above fired it).
+    const announced = () => h.broadcasts.filter((b) => b['type'] === 'channel.nudgeExhausted');
+    expect(announced()).toHaveLength(1);
+    expect(announced()[0]).toMatchObject({ channelId: 'ch-1', workspaceId: 'ws-b', memberId: 'codex' });
+    // Ticks INSIDE the re-announce window stay silent…
+    h.setNow(t + 1_000);
     h.worker.tickOnce();
-    h.worker.tickOnce();
+    expect(announced()).toHaveLength(1);
     expect(h.writes.filter((w) => w.data !== '\r')).toHaveLength(MENTION_NUDGE_CAP);
-    const exhausted = h.broadcasts.filter((b) => b['type'] === 'channel.nudgeExhausted');
-    expect(exhausted).toHaveLength(1);
-    expect(exhausted[0]).toMatchObject({ channelId: 'ch-1', workspaceId: 'ws-b', memberId: 'codex' });
+    // …and the handoff re-announces once the window elapses: the broadcast
+    // reaches only CURRENTLY connected clients — headless it lands on
+    // nobody, so eventual delivery needs the slow cadence (Codex round-4).
+    // Ack (unread=0) still ends the episode entirely (test below).
+    h.setNow(t + 1_000 + EXHAUSTED_REANNOUNCE_MS + 1);
+    h.worker.tickOnce();
+    expect(announced()).toHaveLength(2);
+    expect(h.writes.filter((w) => w.data !== '\r')).toHaveLength(MENTION_NUDGE_CAP); // still no new nudges
   });
 
   it('ack (unread=0) resets the episode: a fresh unread gets a fresh nudge budget', () => {
@@ -299,6 +310,19 @@ describe('pickTarget — never guess', () => {
     expect(pickTarget([headless], 'ws-b', 'claude')?.id).toBe('a');
     // Fallback rule too: the only eligible pane in the workspace.
     expect(pickTarget([headless], 'ws-b', 'codex')?.id).toBe('a');
+  });
+
+  it('an attached claude MEMBER never reroutes to an unrelated pane (Codex round-4)', () => {
+    // GUI alive: claude's delivery is owned by the renderer path. With one
+    // other eligible pane around, the single-pane fallback must NOT fire
+    // for memberId "claude" — that would double-deliver into the wrong
+    // pane and burn claude's budget there.
+    const attachedClaude = session({ id: 'a', lastDetectedAgent: 'claude', attached: true });
+    const shell = session({ id: 'b', lastDetectedAgent: undefined });
+    expect(pickTarget([attachedClaude, shell], 'ws-b', 'claude')).toBeNull();
+    // …while a DIFFERENT member still falls back to that only eligible pane
+    // (it may well be where that agent actually runs, sans detection).
+    expect(pickTarget([attachedClaude, shell], 'ws-b', 'codex')?.id).toBe('b');
   });
 
   it('never targets a session from another workspace', () => {

--- a/src/daemon/channels/__tests__/channelWakeWorker.test.ts
+++ b/src/daemon/channels/__tests__/channelWakeWorker.test.ts
@@ -10,6 +10,7 @@ import {
   MENTION_NUDGE_CAP,
   MENTION_NUDGE_BACKOFF_MS,
   WAKE_QUIET_MS,
+  WAKE_TICK_MS,
   type WakeUnreadEntry,
   type WakeSessionView,
 } from '../channelWakeWorker';
@@ -42,24 +43,32 @@ interface Harness {
   worker: ChannelWakeWorker;
   writes: Array<{ sessionId: string; data: string }>;
   broadcasts: Array<Record<string, unknown>>;
+  logs: string[];
   setEntries(e: WakeUnreadEntry[]): void;
   setSessions(s: WakeSessionView[]): void;
   setNow(ms: number): void;
+  /** Non-null ⇒ the next write() calls throw it (dead-PTY simulation). */
+  setWriteError(err: Error | null): void;
 }
 
 function makeHarness(): Harness {
   let entries: WakeUnreadEntry[] = [];
   let sessions: WakeSessionView[] = [];
   let nowMs = 1_000_000;
+  let writeError: Error | null = null;
   const writes: Array<{ sessionId: string; data: string }> = [];
   const broadcasts: Array<Record<string, unknown>> = [];
+  const logs: string[] = [];
   const worker = new ChannelWakeWorker({
     memberWorkspaces: () => ['ws-b'],
     unreadFor: () => entries,
     listLiveSessions: () => sessions,
-    write: (sessionId, data) => writes.push({ sessionId, data }),
+    write: (sessionId, data) => {
+      if (writeError) throw writeError;
+      writes.push({ sessionId, data });
+    },
     broadcast: (event) => broadcasts.push(event),
-    log: () => {},
+    log: (_level, message) => logs.push(message),
     now: () => nowMs,
     enterDelayMs: 1,
   });
@@ -67,9 +76,11 @@ function makeHarness(): Harness {
     worker,
     writes,
     broadcasts,
+    logs,
     setEntries: (e) => (entries = e),
     setSessions: (s) => (sessions = s),
     setNow: (ms) => (nowMs = ms),
+    setWriteError: (err) => (writeError = err),
   };
 }
 
@@ -173,6 +184,65 @@ describe('ChannelWakeWorker — re-nudge policy', () => {
     h.worker.tickOnce();
     h.worker.tickOnce();
     expect(h.writes.filter((w) => w.data !== '\r')).toHaveLength(2);
+  });
+});
+
+describe('ChannelWakeWorker — crash safety (an accelerator must never kill the daemon)', () => {
+  it('a PTY write that throws is contained and does NOT burn the nudge budget', () => {
+    const h = makeHarness();
+    h.setEntries([entry({ mentionUnread: 1 })]);
+    h.setSessions([session({})]);
+    // The pane dies between target selection and the write: node-pty throws
+    // synchronously on a destroyed stream.
+    h.setWriteError(new Error('write EPIPE'));
+    expect(() => h.worker.tickOnce()).not.toThrow();
+    expect(h.writes).toHaveLength(0);
+    expect(h.logs.some((l) => l.includes('nudge write') && l.includes('failed'))).toBe(true);
+    // Budget preserved (G5: never spend nudges into a void) — the very next
+    // tick retries and the nudge lands.
+    h.setWriteError(null);
+    h.worker.tickOnce();
+    expect(h.writes.filter((w) => w.data !== '\r')).toHaveLength(1);
+  });
+
+  it('a throwing dep inside a scheduled sweep never escapes the timer', () => {
+    const logs: string[] = [];
+    const worker = new ChannelWakeWorker({
+      memberWorkspaces: () => {
+        throw new Error('state corrupted');
+      },
+      unreadFor: () => [],
+      listLiveSessions: () => [],
+      write: () => undefined,
+      broadcast: () => undefined,
+      log: (_level, message) => logs.push(message),
+      now: () => 0,
+    });
+    worker.start();
+    // A bare setInterval callback that throws = uncaught exception = daemon
+    // down. safeTick must swallow + log instead.
+    expect(() => vi.advanceTimersByTime(WAKE_TICK_MS + 1)).not.toThrow();
+    expect(logs.some((l) => l.includes('sweep failed'))).toBe(true);
+    worker.stop();
+  });
+
+  it('the post fast-path kick is guarded the same way', () => {
+    const logs: string[] = [];
+    const worker = new ChannelWakeWorker({
+      memberWorkspaces: () => {
+        throw new Error('state corrupted');
+      },
+      unreadFor: () => [],
+      listLiveSessions: () => [],
+      write: () => undefined,
+      broadcast: () => undefined,
+      log: (_level, message) => logs.push(message),
+      now: () => 0,
+    });
+    worker.notifyChannelActivity();
+    expect(() => vi.advanceTimersByTime(1_500)).not.toThrow();
+    expect(logs.some((l) => l.includes('sweep failed'))).toBe(true);
+    worker.stop();
   });
 });
 

--- a/src/daemon/channels/channelCallerIdentity.ts
+++ b/src/daemon/channels/channelCallerIdentity.ts
@@ -1,0 +1,128 @@
+// ─── Channels v2 (durable inbox) Step 0: daemon-side caller stamping ───────
+//
+// Lets a HEADLESS pipe client (the `wmux channel` CLI, or any agent-side
+// tool running inside a pane's process tree) mutate/read channels without
+// the GUI being alive. Before this module, `verifiedWorkspaceId` had exactly
+// one honest producer — the MAIN process (a2a.channel.rpc.ts D5 stamp, which
+// needs a live renderer to resolve pty → workspace) — so a daemon-pipe
+// caller with no GUI was locked out of every channel op (fail-closed).
+//
+// The daemon, however, already holds a server-side pty → workspace binding:
+// `daemon.createSession` persists the FULLY-RESOLVED child env, and main
+// force-stamps `WMUX_WORKSPACE_ID` into that env at spawn time (see
+// pty.handler.ts "Env resolution happens HERE in main"). Reading it back
+// from the daemon's OWN session record is server-side provenance — NOT the
+// caller's env claim (the spoofable hint the WI-002 audit retired).
+//
+// Acceptance rule (design doc "두 RPC 표면과 신뢰 모델", fail-closed):
+//   1. Request already carries `verifiedWorkspaceId`  → trust it verbatim.
+//      That value has exactly two honest producers today — main's D5 stamp
+//      and the renderer-local mutate path — and this preserves their
+//      behavior byte-for-byte. (A same-user pipe client can forge it; that
+//      is the documented #113 same-user ceiling / audit-B1 residual, NOT a
+//      boundary this module claims to close. True peer identification =
+//      GetNamedPipeClientProcessId, strategy track.)
+//   2. No `verifiedWorkspaceId` but a `senderPtyId` the daemon can resolve
+//      from its session store → stamp `verifiedWorkspaceId` server-side
+//      (NEW headless path), and backfill the caller-identity field of the
+//      payload (sender/createdBy/member/workspaceId) when the caller left
+//      it empty — a pipe client cannot be expected to know its workspace.
+//   3. Neither resolvable → { ok:false, NOT_AUTHORIZED } (fail-closed),
+//      matching the per-handler guards that already reject bare requests.
+//
+// Staleness note: the binding is stamped at spawn time. A workspace id that
+// is re-minted while the session lives would leave a stale binding; under
+// the #113 ceiling this is ADVISORY attribution either way, and the GUI
+// paths (rule 1) keep using the renderer's live answer.
+
+/** Resolve a live session's owning workspace, '' when unknown. */
+export type ResolveSessionWorkspace = (sessionId: string) => string;
+
+/**
+ * Which payload field carries the CALLER's own identity for this method —
+ * backfilled from the stamped workspace when the caller omitted it. Target
+ * identities (e.g. invite's `invitedMember`) are deliberately NOT listed.
+ */
+export type CallerFieldSpec =
+  | { kind: 'none' }
+  | { kind: 'ref'; key: 'sender' | 'createdBy' | 'member' }
+  | { kind: 'flat'; key: 'workspaceId' };
+
+export interface StampOk {
+  ok: true;
+  params: Record<string, unknown>;
+}
+
+export interface StampErr {
+  ok: false;
+  error: { code: 'NOT_AUTHORIZED'; message: string };
+}
+
+const asRecord = (v: unknown): Record<string, unknown> | null =>
+  v !== null && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
+
+const nonEmptyString = (v: unknown): string =>
+  typeof v === 'string' && v.trim().length > 0 ? v.trim() : '';
+
+/**
+ * Stamp the caller identity for one `a2a.channel.*` daemon RPC request.
+ * Returns a SHALLOW-cloned params object (never mutates the input); nested
+ * caller-ref objects are cloned before backfill.
+ */
+export function stampChannelCaller(
+  resolveSessionWorkspace: ResolveSessionWorkspace,
+  rawParams: Record<string, unknown>,
+  callerField: CallerFieldSpec,
+): StampOk | StampErr {
+  const params: Record<string, unknown> = { ...rawParams };
+
+  // Rule 1 — pre-stamped request (main D5 / renderer-local): trust verbatim.
+  if (nonEmptyString(params['verifiedWorkspaceId'])) {
+    return { ok: true, params };
+  }
+
+  const senderPtyId = nonEmptyString(params['senderPtyId']);
+  if (!senderPtyId) {
+    // Rule 3a — nothing to resolve. Let the per-handler guard produce its
+    // canonical "verifiedWorkspaceId is required" rejection (byte-identical
+    // behavior for today's callers).
+    return { ok: true, params };
+  }
+
+  // Rule 2 — headless caller: resolve pty → workspace from the daemon's own
+  // session record (server-side provenance).
+  const ws = resolveSessionWorkspace(senderPtyId);
+  if (!ws) {
+    // Rule 3b — a caller ASKED for pty-based identity and the daemon cannot
+    // vouch for that pty: fail closed with a precise reason instead of the
+    // generic missing-verifiedWorkspaceId error.
+    return {
+      ok: false,
+      error: {
+        code: 'NOT_AUTHORIZED',
+        message:
+          `channel caller identity: senderPtyId "${senderPtyId}" is not a live daemon session ` +
+          'with a workspace binding (WMUX_WORKSPACE_ID) — cannot stamp verifiedWorkspaceId',
+      },
+    };
+  }
+
+  params['verifiedWorkspaceId'] = ws;
+
+  // Backfill the caller's own identity field when omitted, so a pipe client
+  // does not need to know (or guess) its workspace id. An EXPLICIT value is
+  // left alone — the downstream sender-pin gates (e.g. post's
+  // sender.workspaceId === verifiedWorkspaceId) still verify it.
+  if (callerField.kind === 'ref') {
+    const ref = asRecord(params[callerField.key]);
+    if (ref && !nonEmptyString(ref['workspaceId'])) {
+      params[callerField.key] = { ...ref, workspaceId: ws };
+    }
+  } else if (callerField.kind === 'flat') {
+    if (!nonEmptyString(params[callerField.key])) {
+      params[callerField.key] = ws;
+    }
+  }
+
+  return { ok: true, params };
+}

--- a/src/daemon/channels/channelWakeWorker.ts
+++ b/src/daemon/channels/channelWakeWorker.ts
@@ -120,7 +120,7 @@ export class ChannelWakeWorker {
 
   start(): void {
     if (this.interval) return;
-    this.interval = setInterval(() => this.tickOnce(), WAKE_TICK_MS);
+    this.interval = setInterval(() => this.safeTick(), WAKE_TICK_MS);
     this.interval.unref?.();
   }
 
@@ -147,9 +147,24 @@ export class ChannelWakeWorker {
     if (this.kickTimer) return;
     this.kickTimer = setTimeout(() => {
       this.kickTimer = null;
-      this.tickOnce();
+      this.safeTick();
     }, 1_000);
     this.kickTimer.unref?.();
+  }
+
+  /**
+   * Every scheduled entry point goes through here: a sweep runs on a bare
+   * timer, so ANY dep throw (a PTY write racing session death, corrupted
+   * channel state) would otherwise become an uncaught exception and take
+   * the whole daemon down. The worker is an accelerator — it is never
+   * allowed to be the thing that kills the process (CodeRabbit review).
+   */
+  private safeTick(): void {
+    try {
+      this.tickOnce();
+    } catch (err) {
+      this.deps.log('warn', `[wake] sweep failed (skipping this tick): ${String(err)}`);
+    }
   }
 
   /** One sweep over every member workspace. Public for tests + the kick path. */
@@ -205,7 +220,9 @@ export class ChannelWakeWorker {
         if (!target) continue; // ambiguity / no live pane / claude-only → polling fallback
         if (this.deps.now() - target.lastActivityMs < WAKE_QUIET_MS) continue; // busy — retry next tick
 
-        this.inject(target.id, entry);
+        // A failed write must not burn the nudge budget (G5 spirit: never
+        // spend nudges into a void) — retry on a later tick instead.
+        if (!this.inject(target.id, entry)) continue;
 
         if (wantMention) {
           state.mentionNudges += 1;
@@ -218,14 +235,24 @@ export class ChannelWakeWorker {
     }
   }
 
-  /** F2: text first, Enter as a SEPARATE write after a short delay. */
-  private inject(sessionId: string, entry: WakeUnreadEntry): void {
+  /**
+   * F2: text first, Enter as a SEPARATE write after a short delay.
+   * Returns false when the text write throws (the session died between
+   * target selection and the write — a PTY write to a destroyed stream
+   * throws synchronously); the caller then keeps the nudge budget intact.
+   */
+  private inject(sessionId: string, entry: WakeUnreadEntry): boolean {
     const mention = entry.mentionUnread > 0 ? ` (${entry.mentionUnread} mention you)` : '';
     const line = sanitizeLine(
       `[wmux] #${entry.name}: ${entry.unread} unread${mention} — run: wmux channel read ${entry.channelId} --since ${entry.lastReadSeq + 1}`,
     );
     this.deps.log('info', `[wake] nudging ${sessionId} for ${entry.channelId}#${entry.memberId} (${entry.unread} unread)`);
-    this.deps.write(sessionId, line);
+    try {
+      this.deps.write(sessionId, line);
+    } catch (err) {
+      this.deps.log('warn', `[wake] nudge write to ${sessionId} failed (session died mid-race?): ${String(err)}`);
+      return false;
+    }
     const t = setTimeout(() => {
       this.pendingEnter.delete(t);
       try {
@@ -237,6 +264,7 @@ export class ChannelWakeWorker {
     }, this.deps.enterDelayMs ?? ENTER_DELAY_MS);
     t.unref?.();
     this.pendingEnter.add(t);
+    return true;
   }
 }
 

--- a/src/daemon/channels/channelWakeWorker.ts
+++ b/src/daemon/channels/channelWakeWorker.ts
@@ -1,0 +1,253 @@
+// ─── Channels v2 Step 3a: the wake worker ──────────────────────────────────
+//
+// The push half of the durable inbox. Delivery correctness lives in the
+// PULL path (cursor + unread — a message is never lost by a missed nudge);
+// this worker only shortens the time until an agent LOOKS. It injects a
+// one-line hint into an idle member pane's PTY:
+//
+//   [wmux] #general: 2 unread (1 mention you) — run: wmux channel read ch-… --since 5
+//
+// Wake strategy stack (design doc):
+//   - Claude panes are SKIPPED here — the existing Stop-hook mention path
+//     owns them (surfaceAgent busy check, proven in production).
+//   - Generic panes (Codex/OpenCode/…) get the PTY injection below.
+//   - Agents that poll (`wmux channel unread` in AGENTS.md) need no nudge
+//     at all — the worker is an accelerator, never a dependency.
+//
+// Safety rules (all live-dogfood findings, 2026-07-02):
+//   F2  — text and Enter are written SEPARATELY (a single "text\r" write
+//         trips TUI bracketed-paste heuristics and strands the nudge in the
+//         composer, uncommitted).
+//   Quiet gate — inject only after QUIET_MS of output silence (a busy agent
+//         mid-stream must never get bytes spliced into its input; input
+//         activity echoes as output for both shells and TUIs, so output
+//         quiet is the conservative proxy for both).
+//   Target discipline — inject only when the pane is unambiguous: a live
+//         non-claude session whose detected agent slug equals the member id,
+//         else the ONLY live non-claude session in the workspace. Ambiguity
+//         = no injection (polling fallback), never a guess.
+//   Re-nudge policy — mention-unread re-nudges with backoff up to a hard
+//         cap, then STOPS and emits `channel.nudgeExhausted` (loop-storm
+//         guard: two agents must not ping-pong each other's token budgets
+//         forever). Plain unread nudges ONCE per head advance. Ack resets
+//         everything (cursor catches up → unread 0 → tracker cleared).
+//
+// State is deliberately IN-MEMORY (nudge attempts are retry bookkeeping,
+// not truth — the deliveryStatus dead-code audit finding is not coming
+// back as a schema field).
+
+export interface WakeUnreadEntry {
+  channelId: string;
+  name: string;
+  memberId: string;
+  lastReadSeq: number;
+  headSeq: number;
+  unread: number;
+  mentionUnread: number;
+  trimmedBeforeCursor: number;
+}
+
+export interface WakeSessionView {
+  id: string;
+  /** Canonical agent slug last detected in this pane ('claude', 'codex', …). */
+  lastDetectedAgent?: string;
+  /** Epoch ms of the last PTY output activity. */
+  lastActivityMs: number;
+  /** Owning workspace ('' when the session has no binding). */
+  workspaceId: string;
+}
+
+export interface ChannelWakeWorkerDeps {
+  memberWorkspaces(): string[];
+  unreadFor(workspaceId: string): WakeUnreadEntry[];
+  /** Live sessions only (attached/detached — a usable PTY child exists). */
+  listLiveSessions(): WakeSessionView[];
+  /** Write raw bytes into a session's PTY stdin. */
+  write(sessionId: string, data: string): void;
+  /** Broadcast a daemon event (nudge exhaustion → human attention). */
+  broadcast(event: Record<string, unknown>): void;
+  log(level: 'debug' | 'info' | 'warn', message: string): void;
+  now(): number;
+  /** Test seam: ms between the text write and the Enter write. */
+  enterDelayMs?: number;
+}
+
+// Conservative defaults (Step 3b tunes with field data).
+export const WAKE_TICK_MS = 15_000;
+export const WAKE_QUIET_MS = 10_000;
+/** Backoff BETWEEN mention re-nudges: immediate, then 1m, then 5m. */
+export const MENTION_NUDGE_BACKOFF_MS = [0, 60_000, 300_000] as const;
+/** Hard cap of mention nudges per (channel, member) episode. */
+export const MENTION_NUDGE_CAP = MENTION_NUDGE_BACKOFF_MS.length;
+const ENTER_DELAY_MS = 150;
+const NUDGE_MAX_LEN = 220;
+
+interface NudgeTrackerEntry {
+  /** Mention nudges sent in the current unread episode. */
+  mentionNudges: number;
+  lastMentionNudgeAt: number;
+  /** Head seq at the time of the last PLAIN nudge (one per head advance). */
+  plainNudgedAtSeq: number;
+  exhaustedAnnounced: boolean;
+}
+
+const keyOf = (ws: string, e: { channelId: string; memberId: string }): string =>
+  `${e.channelId}|${ws}|${e.memberId}`;
+
+const sanitizeLine = (s: string): string =>
+  // eslint-disable-next-line no-control-regex
+  s.replace(/[\x00-\x1f\x7f]/g, ' ').slice(0, NUDGE_MAX_LEN);
+
+export class ChannelWakeWorker {
+  private readonly deps: ChannelWakeWorkerDeps;
+  private readonly tracker = new Map<string, NudgeTrackerEntry>();
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private kickTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly pendingEnter = new Set<ReturnType<typeof setTimeout>>();
+
+  constructor(deps: ChannelWakeWorkerDeps) {
+    this.deps = deps;
+  }
+
+  start(): void {
+    if (this.interval) return;
+    this.interval = setInterval(() => this.tickOnce(), WAKE_TICK_MS);
+    this.interval.unref?.();
+  }
+
+  stop(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    if (this.kickTimer) {
+      clearTimeout(this.kickTimer);
+      this.kickTimer = null;
+    }
+    for (const t of this.pendingEnter) clearTimeout(t);
+    this.pendingEnter.clear();
+  }
+
+  /**
+   * Fast path: a channel event just fired (post) — check soon instead of
+   * waiting for the next 15 s tick. Debounced so a burst of posts costs one
+   * sweep. The 1 s delay also lets the post's own output echo settle before
+   * the quiet gate looks at the pane.
+   */
+  notifyChannelActivity(): void {
+    if (this.kickTimer) return;
+    this.kickTimer = setTimeout(() => {
+      this.kickTimer = null;
+      this.tickOnce();
+    }, 1_000);
+    this.kickTimer.unref?.();
+  }
+
+  /** One sweep over every member workspace. Public for tests + the kick path. */
+  tickOnce(): void {
+    let sessions: WakeSessionView[] | null = null; // lazy — most ticks have zero unread
+    for (const ws of this.deps.memberWorkspaces()) {
+      for (const entry of this.deps.unreadFor(ws)) {
+        const key = keyOf(ws, entry);
+        if (entry.unread === 0) {
+          // Ack caught the cursor up — the episode is over; a future unread
+          // starts a fresh nudge budget.
+          this.tracker.delete(key);
+          continue;
+        }
+        const state = this.tracker.get(key) ?? {
+          mentionNudges: 0,
+          lastMentionNudgeAt: 0,
+          plainNudgedAtSeq: -1,
+          exhaustedAnnounced: false,
+        };
+
+        const wantMention = entry.mentionUnread > 0;
+        if (wantMention) {
+          if (state.mentionNudges >= MENTION_NUDGE_CAP) {
+            if (!state.exhaustedAnnounced) {
+              state.exhaustedAnnounced = true;
+              this.tracker.set(key, state);
+              this.deps.log(
+                'warn',
+                `[wake] nudge budget exhausted for ${key} (${MENTION_NUDGE_CAP} mention nudges, still ${entry.unread} unread) — handing off to humans`,
+              );
+              this.deps.broadcast({
+                type: 'channel.nudgeExhausted',
+                channelId: entry.channelId,
+                channelName: entry.name,
+                workspaceId: ws,
+                memberId: entry.memberId,
+                unread: entry.unread,
+                mentionUnread: entry.mentionUnread,
+              });
+            }
+            continue;
+          }
+          const backoff = MENTION_NUDGE_BACKOFF_MS[state.mentionNudges] ?? 0;
+          if (this.deps.now() - state.lastMentionNudgeAt < backoff) continue;
+        } else {
+          // Plain unread: one nudge per head advance.
+          if (state.plainNudgedAtSeq >= entry.headSeq) continue;
+        }
+
+        sessions ??= this.deps.listLiveSessions();
+        const target = pickTarget(sessions, ws, entry.memberId);
+        if (!target) continue; // ambiguity / no live pane / claude-only → polling fallback
+        if (this.deps.now() - target.lastActivityMs < WAKE_QUIET_MS) continue; // busy — retry next tick
+
+        this.inject(target.id, entry);
+
+        if (wantMention) {
+          state.mentionNudges += 1;
+          state.lastMentionNudgeAt = this.deps.now();
+        } else {
+          state.plainNudgedAtSeq = entry.headSeq;
+        }
+        this.tracker.set(key, state);
+      }
+    }
+  }
+
+  /** F2: text first, Enter as a SEPARATE write after a short delay. */
+  private inject(sessionId: string, entry: WakeUnreadEntry): void {
+    const mention = entry.mentionUnread > 0 ? ` (${entry.mentionUnread} mention you)` : '';
+    const line = sanitizeLine(
+      `[wmux] #${entry.name}: ${entry.unread} unread${mention} — run: wmux channel read ${entry.channelId} --since ${entry.lastReadSeq + 1}`,
+    );
+    this.deps.log('info', `[wake] nudging ${sessionId} for ${entry.channelId}#${entry.memberId} (${entry.unread} unread)`);
+    this.deps.write(sessionId, line);
+    const t = setTimeout(() => {
+      this.pendingEnter.delete(t);
+      try {
+        this.deps.write(sessionId, '\r');
+      } catch {
+        // session died between the two writes — the pull path still owns
+        // correctness; drop silently.
+      }
+    }, this.deps.enterDelayMs ?? ENTER_DELAY_MS);
+    t.unref?.();
+    this.pendingEnter.add(t);
+  }
+}
+
+/**
+ * Injection target discipline: never guess.
+ *  1. live non-claude session whose detected agent slug === memberId;
+ *  2. else the ONLY live non-claude session in the workspace;
+ *  3. else null (Claude panes ride the Stop-hook path; multi-pane ambiguity
+ *     falls back to polling).
+ */
+export function pickTarget(
+  sessions: WakeSessionView[],
+  workspaceId: string,
+  memberId: string,
+): WakeSessionView | null {
+  const inWs = sessions.filter((s) => s.workspaceId === workspaceId);
+  const nonClaude = inWs.filter((s) => s.lastDetectedAgent !== 'claude');
+  const slugMatch = nonClaude.filter((s) => s.lastDetectedAgent === memberId);
+  if (slugMatch.length === 1) return slugMatch[0];
+  if (slugMatch.length > 1) return null;
+  if (nonClaude.length === 1) return nonClaude[0];
+  return null;
+}

--- a/src/daemon/channels/channelWakeWorker.ts
+++ b/src/daemon/channels/channelWakeWorker.ts
@@ -100,6 +100,16 @@ export const WAKE_QUIET_MS = 10_000;
 export const MENTION_NUDGE_BACKOFF_MS = [0, 60_000, 300_000] as const;
 /** Hard cap of mention nudges per (channel, member) episode. */
 export const MENTION_NUDGE_CAP = MENTION_NUDGE_BACKOFF_MS.length;
+/**
+ * Re-announce interval for an exhausted episode. The broadcast reaches only
+ * CURRENTLY connected clients — in the headless window there is nobody, and
+ * a once-ever announcement would be lost forever while the worker has
+ * already stopped nudging (Codex round-4). Re-announcing on a slow cadence
+ * makes the human handoff eventually-delivered (a GUI that reconnects gets
+ * it within one interval) and doubles as bounded escalation while a mention
+ * rots unanswered. Ack resets the episode and stops it.
+ */
+export const EXHAUSTED_REANNOUNCE_MS = 30 * 60_000;
 const ENTER_DELAY_MS = 150;
 const NUDGE_MAX_LEN = 220;
 
@@ -109,7 +119,8 @@ interface NudgeTrackerEntry {
   lastMentionNudgeAt: number;
   /** Head seq at the time of the last PLAIN nudge (one per head advance). */
   plainNudgedAtSeq: number;
-  exhaustedAnnounced: boolean;
+  /** Epoch ms of the last exhaustion announcement (0 = never). */
+  lastExhaustedAnnounceAt: number;
 }
 
 const keyOf = (ws: string, e: { channelId: string; memberId: string }): string =>
@@ -195,14 +206,15 @@ export class ChannelWakeWorker {
           mentionNudges: 0,
           lastMentionNudgeAt: 0,
           plainNudgedAtSeq: -1,
-          exhaustedAnnounced: false,
+          lastExhaustedAnnounceAt: 0,
         };
 
         const wantMention = entry.mentionUnread > 0;
         if (wantMention) {
           if (state.mentionNudges >= MENTION_NUDGE_CAP) {
-            if (!state.exhaustedAnnounced) {
-              state.exhaustedAnnounced = true;
+            const never = state.lastExhaustedAnnounceAt === 0;
+            if (never || this.deps.now() - state.lastExhaustedAnnounceAt >= EXHAUSTED_REANNOUNCE_MS) {
+              state.lastExhaustedAnnounceAt = this.deps.now();
               this.tracker.set(key, state);
               this.deps.log(
                 'warn',
@@ -302,6 +314,16 @@ export function pickTarget(
   const slugMatch = eligible.filter((s) => s.lastDetectedAgent === memberId);
   if (slugMatch.length === 1) return slugMatch[0];
   if (slugMatch.length > 1) return null;
+  // The member's OWN pane exists but is an ATTACHED claude pane: the
+  // renderer Stop-hook path owns that delivery — do NOT reroute the nudge
+  // to an unrelated single pane, which would double-deliver AND burn the
+  // budget in the wrong place (Codex round-4). A DEFERRED slug-match, by
+  // contrast, still falls through: nobody lives there and the one live
+  // pane may be the member's actual home (dogfood G5).
+  const ownedByRenderer = inWs.some(
+    (s) => s.lastDetectedAgent === memberId && s.lastDetectedAgent === 'claude' && s.attached === true,
+  );
+  if (ownedByRenderer) return null;
   if (eligible.length === 1) return eligible[0];
   return null;
 }

--- a/src/daemon/channels/channelWakeWorker.ts
+++ b/src/daemon/channels/channelWakeWorker.ts
@@ -55,6 +55,15 @@ export interface WakeSessionView {
   lastActivityMs: number;
   /** Owning workspace ('' when the session has no binding). */
   workspaceId: string;
+  /**
+   * True for a RECOVERED session still in deferred-output mode (waiting for
+   * its first renderer resize to activate). Live dogfood 2026-07-02: after a
+   * daemon SIGKILL+respawn, such a pane is bookkept 'attached' but nothing
+   * renders and the pre-crash agent process is gone — the worker burned 2 of
+   * its 3 mention nudges into that void. A deferred pane has no agent to
+   * wake, so it is never an injection target.
+   */
+  deferred?: boolean;
 }
 
 export interface ChannelWakeWorkerDeps {
@@ -233,6 +242,8 @@ export class ChannelWakeWorker {
 
 /**
  * Injection target discipline: never guess.
+ *  0. deferred (recovered-not-yet-activated) sessions are excluded outright —
+ *     no agent lives there and nothing renders (dogfood G5 finding);
  *  1. live non-claude session whose detected agent slug === memberId;
  *  2. else the ONLY live non-claude session in the workspace;
  *  3. else null (Claude panes ride the Stop-hook path; multi-pane ambiguity
@@ -243,7 +254,7 @@ export function pickTarget(
   workspaceId: string,
   memberId: string,
 ): WakeSessionView | null {
-  const inWs = sessions.filter((s) => s.workspaceId === workspaceId);
+  const inWs = sessions.filter((s) => s.workspaceId === workspaceId && s.deferred !== true);
   const nonClaude = inWs.filter((s) => s.lastDetectedAgent !== 'claude');
   const slugMatch = nonClaude.filter((s) => s.lastDetectedAgent === memberId);
   if (slugMatch.length === 1) return slugMatch[0];

--- a/src/daemon/channels/channelWakeWorker.ts
+++ b/src/daemon/channels/channelWakeWorker.ts
@@ -8,8 +8,13 @@
 //   [wmux] #general: 2 unread (1 mention you) — run: wmux channel read ch-… --since 5
 //
 // Wake strategy stack (design doc):
-//   - Claude panes are SKIPPED here — the existing Stop-hook mention path
-//     owns them (surfaceAgent busy check, proven in production).
+//   - ATTACHED Claude panes are SKIPPED here — the renderer's Stop-hook
+//     mention path owns them (surfaceAgent busy check, proven in
+//     production). A DETACHED Claude pane has no renderer and therefore no
+//     Stop-hook path — headless (the reboot-recovery window) it is a valid
+//     injection target like any other agent (Codex round-3: a Claude-only
+//     workspace used to stay silent forever in headless, never even
+//     reaching the exhaustion handoff because no nudge was ever spent).
 //   - Generic panes (Codex/OpenCode/…) get the PTY injection below.
 //   - Agents that poll (`wmux channel unread` in AGENTS.md) need no nudge
 //     at all — the worker is an accelerator, never a dependency.
@@ -64,6 +69,13 @@ export interface WakeSessionView {
    * wake, so it is never an injection target.
    */
   deferred?: boolean;
+  /**
+   * True when a renderer is attached to this session (GUI alive). Claude
+   * panes are excluded ONLY while attached — the renderer's Stop-hook
+   * mention path owns them there. Detached = headless: no renderer path
+   * exists, so the worker must nudge Claude panes itself (Codex round-3).
+   */
+  attached?: boolean;
 }
 
 export interface ChannelWakeWorkerDeps {
@@ -272,10 +284,13 @@ export class ChannelWakeWorker {
  * Injection target discipline: never guess.
  *  0. deferred (recovered-not-yet-activated) sessions are excluded outright —
  *     no agent lives there and nothing renders (dogfood G5 finding);
- *  1. live non-claude session whose detected agent slug === memberId;
- *  2. else the ONLY live non-claude session in the workspace;
- *  3. else null (Claude panes ride the Stop-hook path; multi-pane ambiguity
- *     falls back to polling).
+ *  1. ATTACHED claude panes are excluded — the renderer's Stop-hook mention
+ *     path owns them while a GUI is alive; a DETACHED claude pane is
+ *     eligible like any agent (headless has no other delivery path —
+ *     Codex round-3);
+ *  2. eligible session whose detected agent slug === memberId;
+ *  3. else the ONLY eligible session in the workspace;
+ *  4. else null (multi-pane ambiguity falls back to polling).
  */
 export function pickTarget(
   sessions: WakeSessionView[],
@@ -283,10 +298,10 @@ export function pickTarget(
   memberId: string,
 ): WakeSessionView | null {
   const inWs = sessions.filter((s) => s.workspaceId === workspaceId && s.deferred !== true);
-  const nonClaude = inWs.filter((s) => s.lastDetectedAgent !== 'claude');
-  const slugMatch = nonClaude.filter((s) => s.lastDetectedAgent === memberId);
+  const eligible = inWs.filter((s) => s.lastDetectedAgent !== 'claude' || s.attached !== true);
+  const slugMatch = eligible.filter((s) => s.lastDetectedAgent === memberId);
   if (slugMatch.length === 1) return slugMatch[0];
   if (slugMatch.length > 1) return null;
-  if (nonClaude.length === 1) return nonClaude[0];
+  if (eligible.length === 1) return eligible[0];
   return null;
 }

--- a/src/daemon/channels/index.ts
+++ b/src/daemon/channels/index.ts
@@ -29,6 +29,17 @@ export {
   type ResolveSessionWorkspace,
 } from './channelCallerIdentity';
 export {
+  ChannelWakeWorker,
+  pickTarget,
+  WAKE_TICK_MS,
+  WAKE_QUIET_MS,
+  MENTION_NUDGE_BACKOFF_MS,
+  MENTION_NUDGE_CAP,
+  type ChannelWakeWorkerDeps,
+  type WakeSessionView,
+  type WakeUnreadEntry,
+} from './channelWakeWorker';
+export {
   wrapChannelMessageEnvelope,
   wrapChannelCatalogEnvelope,
   type ChannelMessageDaemonEvent,

--- a/src/daemon/channels/index.ts
+++ b/src/daemon/channels/index.ts
@@ -24,6 +24,11 @@ export {
 
 export { ChannelStateWriter } from './ChannelStateWriter';
 export {
+  stampChannelCaller,
+  type CallerFieldSpec,
+  type ResolveSessionWorkspace,
+} from './channelCallerIdentity';
+export {
   wrapChannelMessageEnvelope,
   wrapChannelCatalogEnvelope,
   type ChannelMessageDaemonEvent,

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1657,13 +1657,31 @@ function registerRpcHandlers(
     const rawUpto = params['uptoSeq'];
     // Guard NaN/Infinity/negative (review A1 P3) — uptoSeq is a monotonic seq floor.
     const uptoSeq = typeof rawUpto === 'number' && Number.isFinite(rawUpto) && rawUpto >= 0 ? rawUpto : 0;
+    // Channels v2: optional member narrowing (agent path). Absent = whole-ws ack.
+    const memberId = typeof params['memberId'] === 'string' && params['memberId'].length > 0 ? params['memberId'] : undefined;
     if (!channelId) {
       return { ok: false, error: { code: 'CHANNEL_NOT_FOUND', message: 'channelId is required' } };
     }
     if (!verifiedWorkspaceId) {
       return { ok: false, error: { code: 'NOT_AUTHORIZED', message: 'verifiedWorkspaceId is required' } };
     }
-    return channelService.ack({ channelId, verifiedWorkspaceId, uptoSeq });
+    return channelService.ack({ channelId, verifiedWorkspaceId, uptoSeq, ...(memberId !== undefined ? { memberId } : {}) });
+  });
+
+  // Channels v2 — per-member unread summary (durable-inbox read model).
+  // Read-only; the wake worker computes the same numbers in-process, this
+  // RPC is the CLI/agent surface.
+  pipeServer.onRpc('a2a.channel.unread', async (rawParams) => {
+    const stamped = stampCaller(rawParams, { kind: 'none' });
+    if (!stamped.ok) return stamped;
+    const params = stamped.params;
+    const verifiedWorkspaceId =
+      typeof params['verifiedWorkspaceId'] === 'string' ? params['verifiedWorkspaceId'] : '';
+    if (!verifiedWorkspaceId) {
+      return { ok: false, error: { code: 'NOT_AUTHORIZED', message: 'verifiedWorkspaceId is required' } };
+    }
+    const memberId = typeof params['memberId'] === 'string' && params['memberId'].length > 0 ? params['memberId'] : undefined;
+    return { ok: true, entries: channelService.unreadFor(verifiedWorkspaceId, memberId) };
   });
 
   pipeServer.onRpc('a2a.channel.create', async (rawParams) => {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -2639,6 +2639,10 @@ async function main(): Promise<void> {
         // bookkept live but renders nothing and holds no agent — the worker
         // must never spend nudges on it.
         deferred: sessionManager.getSession(meta.id)?.deferred === true,
+        // Attached ⇔ a renderer holds this session ⇔ the Stop-hook mention
+        // path can deliver to Claude panes. Detached (headless) Claude panes
+        // are the worker's job (Codex round-3).
+        attached: meta.state === 'attached',
       })),
     // Contract: this MAY throw (a pane can die between target selection and
     // the write; writing a destroyed PTY stream throws synchronously — and a

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -2626,6 +2626,10 @@ async function main(): Promise<void> {
         // WMUX_WORKSPACE_ID into the session env at spawn; the daemon
         // persists it) — meta already carries env, no getSession round-trip.
         workspaceId: (meta.env?.[ENV_KEYS.WORKSPACE_ID] ?? '').trim(),
+        // Dogfood G5: a recovered session still in deferred-output mode is
+        // bookkept live but renders nothing and holds no agent — the worker
+        // must never spend nudges on it.
+        deferred: sessionManager.getSession(meta.id)?.deferred === true,
       })),
     write: (sessionId, data) => {
       sessionManager.getSession(sessionId)?.ptyProcess.write(data);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -2641,15 +2641,29 @@ async function main(): Promise<void> {
         deferred: sessionManager.getSession(meta.id)?.deferred === true,
       })),
     // Contract: this MAY throw (a pane can die between target selection and
-    // the write; writing a destroyed PTY stream throws synchronously). Do
-    // NOT swallow here — the worker catches the throw itself, treats it as
-    // failed delivery, and PRESERVES the nudge budget for a retry (G5:
-    // never spend nudges into a void). Its timer entry points are also
-    // guarded, so a throw can never escape into the event loop.
+    // the write; writing a destroyed PTY stream throws synchronously — and a
+    // session GONE from the manager throws here explicitly, because a silent
+    // no-op would let inject() report success and burn the nudge budget with
+    // zero bytes delivered, Codex re-review). Do NOT swallow either case —
+    // the worker catches the throw itself, treats it as failed delivery, and
+    // PRESERVES the budget for a retry (G5: never spend nudges into a void).
+    // Its timer entry points are also guarded, so a throw can never escape
+    // into the event loop.
     write: (sessionId, data) => {
-      sessionManager.getSession(sessionId)?.ptyProcess.write(data);
+      const managed = sessionManager.getSession(sessionId);
+      if (!managed) throw new Error(`session ${sessionId} is gone`);
+      managed.ptyProcess.write(data);
     },
-    broadcast: (event) => pipeServer.broadcast(event as never),
+    // Envelope discipline (channelEventEnvelope.ts, plan R2 lesson): the
+    // control pipe carries DaemonEvent {type, sessionId, data} — a raw
+    // payload broadcast would be silently unmatched by DaemonClient's
+    // switch, which is exactly how channel.message was once lost. The
+    // worker's one broadcast today is nudge exhaustion (human handoff).
+    broadcast: (event) => {
+      if (event['type'] === 'channel.nudgeExhausted') {
+        pipeServer.broadcast({ type: 'channel.nudgeExhausted', sessionId: '', data: event });
+      }
+    },
     log: (level, message) => log(level, message),
     now: () => Date.now(),
   });

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -12,7 +12,7 @@ import { LanLinkController } from './lanlink/controller';
 import { LanLinkServer } from './lanlink/server';
 import { PeerStore } from './lanlink/peers';
 import { coerceLanLinkPatch } from '../shared/lanlink';
-import { ChannelService, ChannelStateWriter, wrapChannelMessageEnvelope, wrapChannelCatalogEnvelope, stampChannelCaller, type CallerFieldSpec } from './channels';
+import { ChannelService, ChannelStateWriter, ChannelWakeWorker, wrapChannelMessageEnvelope, wrapChannelCatalogEnvelope, stampChannelCaller, type CallerFieldSpec } from './channels';
 import { DEFAULT_COMPANY_ID } from '../shared/channels';
 import { ProcessMonitor } from './ProcessMonitor';
 import { Watchdog } from './Watchdog';
@@ -2314,6 +2314,9 @@ let paneSupervisorRef: PaneSupervisor | null = null;
 // (close the net.Server, drop live connections, remove the firewall rules).
 let lanLinkServerRef: LanLinkServer | null = null;
 
+// Channels v2 — wake worker handle for shutdown + the emit fast path.
+let channelWakeWorkerRef: ChannelWakeWorker | null = null;
+
 // === State builder ===
 
 /** Cached boot ID — populated at startup via initBootId() */
@@ -2401,6 +2404,11 @@ async function shutdown(
 
   // Stop watchdog
   watchdog.stop();
+
+  // Channels v2 — stop the wake worker BEFORE sessions are torn down so a
+  // pending Enter timer can never write into a disposed PTY.
+  try { channelWakeWorkerRef?.stop(); } catch { /* best effort */ }
+  channelWakeWorkerRef = null;
 
   // X8: cancel pending supervised restarts FIRST — a backoff timer firing
   // mid-shutdown would spawn a fresh PTY between the buffer dump and
@@ -2589,12 +2597,42 @@ async function main(): Promise<void> {
           pipeServer.broadcast(wrapChannelCatalogEnvelope(event));
         } else {
           pipeServer.broadcast(wrapChannelMessageEnvelope(event));
+          // Channels v2 wake fast-path: a fresh post means someone may owe a
+          // read — sweep soon instead of waiting for the next 15 s tick.
+          // Correctness never depends on this (pull path owns it).
+          channelWakeWorkerRef?.notifyChannelActivity();
         }
       } catch (err) {
         const ref = event.type === 'channel.catalog' ? event.channelId : `${event.channelId}#${event.seq}`;
         log('warn', `channel emit failed for ${ref}:`, err);
       }
     },
+  });
+
+  // Channels v2 Step 3a — the wake worker (see channelWakeWorker.ts for the
+  // full strategy stack + safety rules). Adapters keep it decoupled: session
+  // views come from the manager's live list, the workspace binding is the
+  // SAME env-record read the Step 0 stamping uses, and writes go through the
+  // session's PTY exactly like client keystrokes.
+  channelWakeWorkerRef = new ChannelWakeWorker({
+    memberWorkspaces: () => channelService.memberWorkspaces(),
+    unreadFor: (ws) => channelService.unreadFor(ws),
+    listLiveSessions: () =>
+      sessionManager.listLiveSessions().map((meta) => ({
+        id: meta.id,
+        ...(meta.lastDetectedAgent !== undefined ? { lastDetectedAgent: meta.lastDetectedAgent as string } : {}),
+        lastActivityMs: new Date(meta.lastActivity).getTime() || 0,
+        // Same env-record binding the Step 0 stamping reads (main stamps
+        // WMUX_WORKSPACE_ID into the session env at spawn; the daemon
+        // persists it) — meta already carries env, no getSession round-trip.
+        workspaceId: (meta.env?.[ENV_KEYS.WORKSPACE_ID] ?? '').trim(),
+      })),
+    write: (sessionId, data) => {
+      sessionManager.getSession(sessionId)?.ptyProcess.write(data);
+    },
+    broadcast: (event) => pipeServer.broadcast(event as never),
+    log: (level, message) => log(level, message),
+    now: () => Date.now(),
   });
   const processMonitor = new ProcessMonitor();
 
@@ -2855,6 +2893,9 @@ async function main(): Promise<void> {
     memory: process.memoryUsage().rss,
     uptime: Math.floor((Date.now() - startTime) / 1000),
   }));
+
+  // Channels v2 — start the wake worker sweep (15 s tick + post fast-path).
+  channelWakeWorkerRef?.start();
 
   // 8b. Reap dead sessions that exceeded their TTL (hourly)
   const reapInterval = setInterval(() => {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -12,7 +12,7 @@ import { LanLinkController } from './lanlink/controller';
 import { LanLinkServer } from './lanlink/server';
 import { PeerStore } from './lanlink/peers';
 import { coerceLanLinkPatch } from '../shared/lanlink';
-import { ChannelService, ChannelStateWriter, wrapChannelMessageEnvelope, wrapChannelCatalogEnvelope } from './channels';
+import { ChannelService, ChannelStateWriter, wrapChannelMessageEnvelope, wrapChannelCatalogEnvelope, stampChannelCaller, type CallerFieldSpec } from './channels';
 import { DEFAULT_COMPANY_ID } from '../shared/channels';
 import { ProcessMonitor } from './ProcessMonitor';
 import { Watchdog } from './Watchdog';
@@ -26,7 +26,7 @@ import { initDaemonLogSink } from './util/logSink';
 import type { DaemonState } from './types';
 import type { DaemonEvent, DaemonCreateSessionParams, DaemonSessionIdParams, DaemonResizeParams, DaemonSetResumeBindingParams } from '../shared/rpc';
 import { monitorEventLoopDelay, performance as nodePerformance } from 'node:perf_hooks';
-import { DAEMON_EXIT_ALREADY_RUNNING } from '../shared/constants';
+import { DAEMON_EXIT_ALREADY_RUNNING, ENV_KEYS } from '../shared/constants';
 import { toResumeCommand, resumeOfferForRecovered, mergeResumeBinding, normalizeResumeCwd } from '../shared/agentResume';
 import type { ResumeBinding } from '../shared/agentResume';
 import { agentDisplayToSlug } from '../main/pty/AgentDetector';
@@ -1530,7 +1530,29 @@ function registerRpcHandlers(
   // covers the daemon transport, and finer-grained plugin permission will
   // land in the follow-up PR that introduces the permission enforcer for
   // method dispatch (mcp-plugin-spec).
-  pipeServer.onRpc('a2a.channel.list', async (params) => {
+  //
+  // Channels v2 Step 0 — daemon-side caller stamping. Every handler below
+  // (EXCEPT archive/kick, which stay humans-only: their honest reachable
+  // surface remains the renderer-local mutate path) first runs
+  // `stampChannelCaller`: a pre-stamped `verifiedWorkspaceId` is trusted
+  // verbatim (main D5 / renderer paths, unchanged), and a headless caller
+  // that supplies only `senderPtyId` gets a SERVER-side stamp resolved from
+  // the daemon's own session record (env WMUX_WORKSPACE_ID, persisted at
+  // spawn by main). See channelCallerIdentity.ts for the acceptance rules.
+  const resolveSessionWorkspace = (sessionId: string): string => {
+    const env = sessionManager.getSession(sessionId)?.meta.env;
+    const ws = env?.[ENV_KEYS.WORKSPACE_ID];
+    return typeof ws === 'string' && ws.trim().length > 0 ? ws.trim() : '';
+  };
+  const stampCaller = (
+    rawParams: Record<string, unknown>,
+    callerField: CallerFieldSpec,
+  ): ReturnType<typeof stampChannelCaller> => stampChannelCaller(resolveSessionWorkspace, rawParams, callerField);
+
+  pipeServer.onRpc('a2a.channel.list', async (rawParams) => {
+    const stamped = stampCaller(rawParams, { kind: 'none' });
+    if (!stamped.ok) return stamped;
+    const params = stamped.params;
     const verifiedWorkspaceId =
       typeof params['verifiedWorkspaceId'] === 'string' ? params['verifiedWorkspaceId'] : '';
     if (!verifiedWorkspaceId) {
@@ -1545,7 +1567,10 @@ function registerRpcHandlers(
     return { ok: true, channels: channelService.list(verifiedWorkspaceId) };
   });
 
-  pipeServer.onRpc('a2a.channel.get', async (params) => {
+  pipeServer.onRpc('a2a.channel.get', async (rawParams) => {
+    const stamped = stampCaller(rawParams, { kind: 'none' });
+    if (!stamped.ok) return stamped;
+    const params = stamped.params;
     const channelId = typeof params['channelId'] === 'string' ? params['channelId'] : '';
     const verifiedWorkspaceId =
       typeof params['verifiedWorkspaceId'] === 'string' ? params['verifiedWorkspaceId'] : '';
@@ -1568,7 +1593,10 @@ function registerRpcHandlers(
     return { ok: true, channel };
   });
 
-  pipeServer.onRpc('a2a.channel.getMessages', async (params) => {
+  pipeServer.onRpc('a2a.channel.getMessages', async (rawParams) => {
+    const stamped = stampCaller(rawParams, { kind: 'none' });
+    if (!stamped.ok) return stamped;
+    const params = stamped.params;
     const channelId = typeof params['channelId'] === 'string' ? params['channelId'] : '';
     const verifiedWorkspaceId =
       typeof params['verifiedWorkspaceId'] === 'string' ? params['verifiedWorkspaceId'] : '';
@@ -1597,7 +1625,10 @@ function registerRpcHandlers(
     return { ok: true, messages: channelService.getMessages(channelId, sinceSeq, verifiedWorkspaceId, limit) };
   });
 
-  pipeServer.onRpc('a2a.channel.getMembers', async (params) => {
+  pipeServer.onRpc('a2a.channel.getMembers', async (rawParams) => {
+    const stamped = stampCaller(rawParams, { kind: 'none' });
+    if (!stamped.ok) return stamped;
+    const params = stamped.params;
     const channelId = typeof params['channelId'] === 'string' ? params['channelId'] : '';
     const verifiedWorkspaceId =
       typeof params['verifiedWorkspaceId'] === 'string' ? params['verifiedWorkspaceId'] : '';
@@ -1616,7 +1647,10 @@ function registerRpcHandlers(
     return { ok: true, members: channelService.getMembers(channelId, verifiedWorkspaceId) };
   });
 
-  pipeServer.onRpc('a2a.channel.ack', async (params) => {
+  pipeServer.onRpc('a2a.channel.ack', async (rawParams) => {
+    const stamped = stampCaller(rawParams, { kind: 'none' });
+    if (!stamped.ok) return stamped;
+    const params = stamped.params;
     const channelId = typeof params['channelId'] === 'string' ? params['channelId'] : '';
     const verifiedWorkspaceId =
       typeof params['verifiedWorkspaceId'] === 'string' ? params['verifiedWorkspaceId'] : '';
@@ -1632,8 +1666,10 @@ function registerRpcHandlers(
     return channelService.ack({ channelId, verifiedWorkspaceId, uptoSeq });
   });
 
-  pipeServer.onRpc('a2a.channel.create', async (params) => {
-    const p = params as unknown as import('./channels/ChannelService').CreateChannelParams;
+  pipeServer.onRpc('a2a.channel.create', async (rawParams) => {
+    const stamped = stampCaller(rawParams, { kind: 'ref', key: 'createdBy' });
+    if (!stamped.ok) return stamped;
+    const p = stamped.params as unknown as import('./channels/ChannelService').CreateChannelParams;
     if (!p.name || !p.visibility || !p.createdBy) {
       return { ok: false, error: { code: 'INVALID_NAME', message: 'name, visibility, and createdBy are required' } };
     }
@@ -1652,6 +1688,10 @@ function registerRpcHandlers(
     return channelService.create(p);
   });
 
+  // NOTE (Channels v2 Step 0): archive is deliberately NOT run through
+  // `stampCaller` — archive/kick are HUMANS-ONLY (renderer-local mutate path,
+  // which pre-stamps verifiedWorkspaceId). Stamping here would hand every
+  // pane agent an honest daemon-pipe route to a destructive humans-only op.
   pipeServer.onRpc('a2a.channel.archive', async (params) => {
     const channelId = typeof params['channelId'] === 'string' ? params['channelId'] : '';
     const archivedBy = typeof params['archivedBy'] === 'string' ? params['archivedBy'] : '';
@@ -1669,8 +1709,10 @@ function registerRpcHandlers(
     return channelService.archive({ channelId, archivedBy, verifiedWorkspaceId });
   });
 
-  pipeServer.onRpc('a2a.channel.join', async (params) => {
-    const p = params as unknown as import('./channels/ChannelService').JoinChannelParams;
+  pipeServer.onRpc('a2a.channel.join', async (rawParams) => {
+    const stamped = stampCaller(rawParams, { kind: 'ref', key: 'member' });
+    if (!stamped.ok) return stamped;
+    const p = stamped.params as unknown as import('./channels/ChannelService').JoinChannelParams;
     if (!p.channelId || !p.member || !p.verifiedWorkspaceId) {
       return {
         ok: false,
@@ -1680,8 +1722,10 @@ function registerRpcHandlers(
     return channelService.join(p);
   });
 
-  pipeServer.onRpc('a2a.channel.leave', async (params) => {
-    const p = params as unknown as import('./channels/ChannelService').LeaveChannelParams;
+  pipeServer.onRpc('a2a.channel.leave', async (rawParams) => {
+    const stamped = stampCaller(rawParams, { kind: 'flat', key: 'workspaceId' });
+    if (!stamped.ok) return stamped;
+    const p = stamped.params as unknown as import('./channels/ChannelService').LeaveChannelParams;
     if (!p.channelId || !p.workspaceId || !p.memberId || !p.verifiedWorkspaceId) {
       return {
         ok: false,
@@ -1691,8 +1735,10 @@ function registerRpcHandlers(
     return channelService.leave(p);
   });
 
-  pipeServer.onRpc('a2a.channel.post', async (params) => {
-    const p = params as unknown as import('./channels/ChannelService').PostMessageParams;
+  pipeServer.onRpc('a2a.channel.post', async (rawParams) => {
+    const stamped = stampCaller(rawParams, { kind: 'ref', key: 'sender' });
+    if (!stamped.ok) return stamped;
+    const p = stamped.params as unknown as import('./channels/ChannelService').PostMessageParams;
     if (!p.channelId || !p.sender || typeof p.text !== 'string' || !p.verifiedWorkspaceId) {
       return {
         ok: false,
@@ -1705,8 +1751,12 @@ function registerRpcHandlers(
     return channelService.post(p);
   });
 
-  pipeServer.onRpc('a2a.channel.invite', async (params) => {
-    const p = params as unknown as import('./channels/ChannelService').InviteChannelParams;
+  pipeServer.onRpc('a2a.channel.invite', async (rawParams) => {
+    // NOTE: `invitedMember` is a TARGET identity, never backfilled — only the
+    // INVITER's verifiedWorkspaceId is stamped here.
+    const stamped = stampCaller(rawParams, { kind: 'none' });
+    if (!stamped.ok) return stamped;
+    const p = stamped.params as unknown as import('./channels/ChannelService').InviteChannelParams;
     if (
       !p.channelId ||
       !p.invitedMember ||
@@ -1731,6 +1781,7 @@ function registerRpcHandlers(
   // 'a2a.channel.kick', so no MCP/agent client can reach it — only the renderer-only
   // channels:mutate-local IPC forwards it. See KickChannelParams for the rationale.
   pipeServer.onRpc('a2a.channel.kick', async (params) => {
+    // Deliberately NOT stamped (humans-only, same rationale as archive above).
     const p = params as unknown as import('./channels/ChannelService').KickChannelParams;
     if (!p.channelId || !p.targetWorkspaceId || !p.targetMemberId || !p.verifiedWorkspaceId) {
       return {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -2630,7 +2630,15 @@ async function main(): Promise<void> {
       sessionManager.listLiveSessions().map((meta) => ({
         id: meta.id,
         ...(meta.lastDetectedAgent !== undefined ? { lastDetectedAgent: meta.lastDetectedAgent as string } : {}),
-        lastActivityMs: new Date(meta.lastActivity).getTime() || 0,
+        // Fail SAFE on a broken/missing timestamp (GLM review): a NaN getTime()
+        // must not become 0, which reads as "quiet since the epoch" and makes
+        // the pane permanently pass the quiet gate (perpetual nudge candidate).
+        // Unknown last-activity ⇒ treat as JUST active ⇒ the quiet gate holds
+        // off — the accelerator stays silent, the pull path still owns delivery.
+        lastActivityMs: (() => {
+          const t = new Date(meta.lastActivity).getTime();
+          return Number.isFinite(t) ? t : Date.now();
+        })(),
         // Same env-record binding the Step 0 stamping reads (main stamps
         // WMUX_WORKSPACE_ID into the session env at spawn; the daemon
         // persists it) — meta already carries env, no getSession round-trip.

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1539,9 +1539,15 @@ function registerRpcHandlers(
   // that supplies only `senderPtyId` gets a SERVER-side stamp resolved from
   // the daemon's own session record (env WMUX_WORKSPACE_ID, persisted at
   // spawn by main). See channelCallerIdentity.ts for the acceptance rules.
+  // LIVE sessions only (attached/detached): the manager retains dead
+  // tombstones for hours (dead-TTL) and suspended records across restarts,
+  // and a pane that no longer has a usable PTY child cannot legitimately be
+  // the caller — a stale senderPtyId must fail closed exactly like an
+  // unknown one (CodeRabbit review). Uses the manager's canonical live
+  // filter rather than re-implementing state checks here.
   const resolveSessionWorkspace = (sessionId: string): string => {
-    const env = sessionManager.getSession(sessionId)?.meta.env;
-    const ws = env?.[ENV_KEYS.WORKSPACE_ID];
+    const meta = sessionManager.listLiveSessions().find((m) => m.id === sessionId);
+    const ws = meta?.env?.[ENV_KEYS.WORKSPACE_ID];
     return typeof ws === 'string' && ws.trim().length > 0 ? ws.trim() : '';
   };
   const stampCaller = (
@@ -1655,8 +1661,11 @@ function registerRpcHandlers(
     const verifiedWorkspaceId =
       typeof params['verifiedWorkspaceId'] === 'string' ? params['verifiedWorkspaceId'] : '';
     const rawUpto = params['uptoSeq'];
-    // Guard NaN/Infinity/negative (review A1 P3) — uptoSeq is a monotonic seq floor.
-    const uptoSeq = typeof rawUpto === 'number' && Number.isFinite(rawUpto) && rawUpto >= 0 ? rawUpto : 0;
+    // Guard NaN/Infinity/negative/fractional (review A1 P3 + CodeRabbit) —
+    // uptoSeq is a monotonic seq floor and the cursor it advances persists,
+    // so only whole seq values may reach ChannelService.ack. Invalid ⇒ 0
+    // (a no-op ack: the cursor never moves backwards).
+    const uptoSeq = typeof rawUpto === 'number' && Number.isSafeInteger(rawUpto) && rawUpto >= 0 ? rawUpto : 0;
     // Channels v2: optional member narrowing (agent path). Absent = whole-ws ack.
     const memberId = typeof params['memberId'] === 'string' && params['memberId'].length > 0 ? params['memberId'] : undefined;
     if (!channelId) {
@@ -2631,6 +2640,12 @@ async function main(): Promise<void> {
         // must never spend nudges on it.
         deferred: sessionManager.getSession(meta.id)?.deferred === true,
       })),
+    // Contract: this MAY throw (a pane can die between target selection and
+    // the write; writing a destroyed PTY stream throws synchronously). Do
+    // NOT swallow here — the worker catches the throw itself, treats it as
+    // failed delivery, and PRESERVES the nudge budget for a retry (G5:
+    // never spend nudges into a void). Its timer entry points are also
+    // guarded, so a throw can never escape into the event loop.
     write: (sessionId, data) => {
       sessionManager.getSession(sessionId)?.ptyProcess.write(data);
     },

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -643,6 +643,12 @@ export class DaemonClient extends EventEmitter {
           // tees it onto the main EventBus as a WmuxEvent `channel.catalog`.
           this.emit('channel:catalog', { data: event.data });
           break;
+        case 'channel.nudgeExhausted':
+          // Channels v2 wake worker — a mention episode ran out of nudge
+          // budget; humans must look. DaemonNotificationRouter surfaces it
+          // (toast + OS notification) and tees it onto the EventBus.
+          this.emit('channel:nudgeExhausted', { data: event.data });
+          break;
         default:
           break;
       }

--- a/src/main/mcp/firstParty.ts
+++ b/src/main/mcp/firstParty.ts
@@ -143,6 +143,11 @@ export const FIRST_PARTY_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
   'a2a.channel.leave',
   'a2a.channel.post',
   'a2a.channel.invite',
+  // Channels v2 durable inbox — the consume signal (ack) + the cheap unread
+  // poll. Both agent-reachable by design: ack is what stops the wake worker's
+  // re-nudges, so denying it to agents would re-ping them forever.
+  'a2a.channel.ack',
+  'a2a.channel.unread',
   // company mode (all wmux.internal — undeclarable, hence the need for this list)
   'company.a2a.whoami',
   'company.a2a.send',

--- a/src/main/mcp/methodCapabilityMap.ts
+++ b/src/main/mcp/methodCapabilityMap.ts
@@ -355,6 +355,7 @@ export const METHOD_CAPABILITY: Record<RpcMethod, RequiredCapability> = {
   'a2a.channel.archive':     { capability: 'a2a.channel.send', riskClass: 'a2a' },
   'a2a.channel.kick':        { capability: 'a2a.channel.send', riskClass: 'a2a' },
   'a2a.channel.ack':         { capability: 'a2a.channel.read', riskClass: 'a2a' },
+  'a2a.channel.unread':      { capability: 'a2a.channel.read', riskClass: 'a2a' },
 
   // --- Company subsystem (substrate-internal team/orchestration). All
   //     internal for v3.0; can be re-classified once spec covers a2a teams.

--- a/src/main/notification/DaemonNotificationRouter.ts
+++ b/src/main/notification/DaemonNotificationRouter.ts
@@ -430,7 +430,8 @@ export class DaemonNotificationRouter {
         recipientWorkspaceIds.push(event.actorWorkspaceId);
       }
       const reason =
-        event.reason === 'created' || event.reason === 'archived' || event.reason === 'membership'
+        event.reason === 'created' || event.reason === 'archived' || event.reason === 'membership' ||
+        event.reason === 'cursor'
           ? event.reason
           : 'membership';
       eventBus.emit({
@@ -443,6 +444,65 @@ export class DaemonNotificationRouter {
       });
     } catch (err) {
       console.warn('[DaemonNotificationRouter] emitChannelCatalog error:', err);
+    }
+  }
+
+  /**
+   * Channels v2 wake worker — the mention-nudge budget for one (channel,
+   * member) episode is exhausted; the worker stopped re-nudging and the
+   * episode is HANDED TO HUMANS. This is the promise the wake worker's
+   * `channel.nudgeExhausted` broadcast makes, and this handler is where it
+   * is kept: an in-app toast + OS notification for the operator, plus an
+   * EventBus tee so orchestrator clients (`wmux_events_poll`) can observe
+   * stranded mentions. A malformed payload is dropped, not thrown.
+   */
+  private emitChannelNudgeExhausted(event: {
+    channelId?: string;
+    channelName?: unknown;
+    workspaceId?: unknown;
+    memberId?: unknown;
+    unread?: unknown;
+    mentionUnread?: unknown;
+  }): void {
+    try {
+      if (
+        typeof event.channelId !== 'string' ||
+        event.channelId.length === 0 ||
+        typeof event.workspaceId !== 'string' ||
+        event.workspaceId.length === 0 ||
+        typeof event.memberId !== 'string' ||
+        event.memberId.length === 0
+      ) {
+        console.warn(
+          '[DaemonNotificationRouter] channel.nudgeExhausted payload missing required fields; dropping',
+          event,
+        );
+        return;
+      }
+      const channelName =
+        typeof event.channelName === 'string' && event.channelName.length > 0
+          ? event.channelName
+          : event.channelId;
+      const unread = typeof event.unread === 'number' ? event.unread : 0;
+      const mentionUnread = typeof event.mentionUnread === 'number' ? event.mentionUnread : 0;
+      const title = `#${channelName}: ${event.memberId} is not responding`;
+      const body = `${mentionUnread} mention${mentionUnread === 1 ? '' : 's'} unanswered after repeated nudges — needs a human`;
+      const win = this.getWindow();
+      sendNotification(win, null, { type: 'agent', title, body });
+      // workspaceId makes the OS toast clickable — click jumps to the
+      // affected member's workspace (same contract as notify.rpc).
+      toastManager.show(title, body, { workspaceId: event.workspaceId });
+      eventBus.emit({
+        type: 'channel.nudgeExhausted',
+        channelId: event.channelId,
+        channelName,
+        memberId: event.memberId,
+        unread,
+        mentionUnread,
+        workspaceId: event.workspaceId,
+      });
+    } catch (err) {
+      console.warn('[DaemonNotificationRouter] emitChannelNudgeExhausted error:', err);
     }
   }
 
@@ -688,6 +748,19 @@ export class DaemonNotificationRouter {
       }
     };
 
+    // Channels v2 — wake-worker nudge exhaustion: the human handoff. See
+    // emitChannelNudgeExhausted for the surfaces (toast + OS notification +
+    // EventBus tee).
+    const onChannelNudgeExhausted = (payload: { data: unknown }) => {
+      try {
+        const ev = payload.data as Parameters<typeof this.emitChannelNudgeExhausted>[0] | null;
+        if (!ev || typeof ev !== 'object') return;
+        this.emitChannelNudgeExhausted(ev);
+      } catch (err) {
+        console.warn('[DaemonNotificationRouter] channel:nudgeExhausted error:', err);
+      }
+    };
+
     this.daemonClient.on('session:agent', onAgent);
     this.daemonClient.on('session:active', onActive);
     this.daemonClient.on('session:idle', onIdle);
@@ -708,6 +781,7 @@ export class DaemonNotificationRouter {
     // (events.rpc.ts), NOT this tee's.
     this.daemonClient.on('channel:message', onChannelMessage);
     this.daemonClient.on('channel:catalog', onChannelCatalog);
+    this.daemonClient.on('channel:nudgeExhausted', onChannelNudgeExhausted);
 
     // Invalidate the workspace.list cache whenever a workspace's metadata
     // mutates. Workspace creation/deletion does not currently publish to
@@ -732,6 +806,7 @@ export class DaemonNotificationRouter {
       () => this.daemonClient.off('supervision:changed', onSupervisionChanged),
       () => this.daemonClient.off('channel:message', onChannelMessage),
       () => this.daemonClient.off('channel:catalog', onChannelCatalog),
+      () => this.daemonClient.off('channel:nudgeExhausted', onChannelNudgeExhausted),
       unsubscribeMeta,
     );
   }

--- a/src/main/notification/__tests__/DaemonNotificationRouter.nudgeExhausted.test.ts
+++ b/src/main/notification/__tests__/DaemonNotificationRouter.nudgeExhausted.test.ts
@@ -1,0 +1,134 @@
+// Channels v2 — tests for the wake worker's HUMAN HANDOFF surface:
+//   channel:nudgeExhausted → in-app/OS notification + EventBus tee
+//   `channel.nudgeExhausted` (scoped to the affected member's workspace).
+//
+// The wake worker promises "budget exhausted → hand to humans"; this file
+// pins the main-side half of that promise (the daemon-side broadcast is
+// covered by channelWakeWorker.test.ts). Mirrors the mocking approach of
+// DaemonNotificationRouter.supervision.test.ts.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { DaemonClient } from '../../DaemonClient';
+import { eventBus } from '../../events/EventBus';
+
+vi.mock('electron', () => ({ BrowserWindow: class {} }));
+
+vi.mock('../../pipe/handlers/notify.rpc', () => ({
+  toastManager: { show: vi.fn() },
+}));
+
+vi.mock('../../ipc/handlers/metadata.handler', () => ({
+  broadcastMetadataUpdate: vi.fn(),
+}));
+
+vi.mock('../sendNotification', () => ({
+  sendNotification: vi.fn(),
+}));
+
+vi.mock('../idleSuppression', () => ({
+  recentlySuppressed: vi.fn().mockReturnValue(false),
+  clearPty: vi.fn(),
+}));
+
+vi.mock('../../pipe/handlers/_bridge', () => ({
+  sendToRenderer: vi.fn().mockResolvedValue([]),
+}));
+
+import { toastManager } from '../../pipe/handlers/notify.rpc';
+import { sendNotification } from '../sendNotification';
+import { DaemonNotificationRouter } from '../DaemonNotificationRouter';
+
+const toastShowMock = vi.mocked(toastManager.show);
+const sendNotificationMock = vi.mocked(sendNotification);
+
+type NudgeListener = (payload: { data: unknown }) => void;
+
+function makeRouter() {
+  let captured: NudgeListener | undefined;
+  const fakeDaemon = {
+    on: vi.fn((event: string, cb: (payload: never) => void) => {
+      if (event === 'channel:nudgeExhausted') captured = cb as NudgeListener;
+    }),
+    off: vi.fn(),
+  } as unknown as DaemonClient;
+  const router = new DaemonNotificationRouter(fakeDaemon, () => null);
+  router.start();
+  return { router, fire: (data: unknown) => captured?.({ data }) };
+}
+
+const pollExhausted = () => eventBus.poll(0, { types: ['channel.nudgeExhausted'] }).events;
+
+beforeEach(() => {
+  toastShowMock.mockReset();
+  sendNotificationMock.mockReset();
+  eventBus.reset();
+});
+
+afterEach(() => {
+  eventBus.reset();
+});
+
+describe('DaemonNotificationRouter — channel.nudgeExhausted (human handoff)', () => {
+  it('surfaces the exhaustion to humans (toast + notification) AND tees it onto the EventBus', () => {
+    const { router, fire } = makeRouter();
+    try {
+      fire({
+        type: 'channel.nudgeExhausted',
+        channelId: 'ch-1',
+        channelName: 'general',
+        workspaceId: 'ws-b',
+        memberId: 'codex',
+        unread: 3,
+        mentionUnread: 2,
+      });
+
+      // Human surfaces: an in-app/OS toast pointing at the affected workspace.
+      expect(toastShowMock).toHaveBeenCalledTimes(1);
+      const [title, body, opts] = toastShowMock.mock.calls[0];
+      expect(String(title)).toContain('#general');
+      expect(String(title)).toContain('codex');
+      expect(String(body)).toContain('2 mentions');
+      expect(opts).toMatchObject({ workspaceId: 'ws-b' });
+      expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+
+      // Orchestrator surface: the EventBus tee, scoped to the member's ws.
+      const events = pollExhausted();
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        type: 'channel.nudgeExhausted',
+        channelId: 'ch-1',
+        channelName: 'general',
+        memberId: 'codex',
+        unread: 3,
+        mentionUnread: 2,
+        workspaceId: 'ws-b',
+      });
+    } finally {
+      router.stop();
+    }
+  });
+
+  it('drops a malformed payload (no throw, no toast, no bus entry)', () => {
+    const { router, fire } = makeRouter();
+    try {
+      expect(() => fire({ channelId: '', workspaceId: 'ws-b' })).not.toThrow();
+      expect(() => fire(null)).not.toThrow();
+      expect(() => fire({ channelId: 'ch-1', workspaceId: 'ws-b' })).not.toThrow(); // no memberId
+      expect(toastShowMock).not.toHaveBeenCalled();
+      expect(pollExhausted()).toHaveLength(0);
+    } finally {
+      router.stop();
+    }
+  });
+
+  it('falls back to the channelId when the name is missing', () => {
+    const { router, fire } = makeRouter();
+    try {
+      fire({ channelId: 'ch-9', workspaceId: 'ws-b', memberId: 'codex' });
+      const [title] = toastShowMock.mock.calls[0];
+      expect(String(title)).toContain('ch-9');
+      expect(pollExhausted()[0]).toMatchObject({ channelName: 'ch-9', unread: 0, mentionUnread: 0 });
+    } finally {
+      router.stop();
+    }
+  });
+});

--- a/src/main/pipe/handlers/a2a.channel.rpc.ts
+++ b/src/main/pipe/handlers/a2a.channel.rpc.ts
@@ -78,10 +78,10 @@ async function resolveCallerWorkspace(getWindow: GetWindow, params: unknown): Pr
 }
 
 /**
- * Register the nine `a2a.channel.*` pipe-RPC methods. Each forwards to the
- * daemon's ChannelService via `DaemonClient`, but FIRST stamps a
- * server-resolved `verifiedWorkspaceId` (D5) so the daemon's authz gates run
- * against an identity the caller cannot forge.
+ * Register the eleven `a2a.channel.*` pipe-RPC methods (v2 added ack +
+ * unread). Each forwards to the daemon's ChannelService via `DaemonClient`,
+ * but FIRST stamps a server-resolved `verifiedWorkspaceId` (D5) so the
+ * daemon's authz gates run against an identity the caller cannot forge.
  */
 export function registerA2aChannelRpc(
   router: RpcRouter,
@@ -126,11 +126,17 @@ export function registerA2aChannelRpc(
   router.register('a2a.channel.get', (p) => forward('a2a.channel.get', p, false));
   router.register('a2a.channel.getMessages', (p) => forward('a2a.channel.getMessages', p, false));
   router.register('a2a.channel.getMembers', (p) => forward('a2a.channel.getMembers', p, false));
-  // NOTE: a2a.channel.ack is intentionally NOT registered here. It mutates
-  // (recipientSnapshot/deliveryStatus) but has no senderPtyId (renderer-driven on
-  // read), so the pipe path would leave its verifiedWorkspaceId unpinned →
-  // forgeable receipts. It rides the renderer-only channels:mutate-local path
-  // (channelLocal.handler) instead, pinned + pipe-unreachable.
+  router.register('a2a.channel.unread', (p) => forward('a2a.channel.unread', p, false));
+  // Channels v2: a2a.channel.ack IS now agent-reachable — registered as
+  // MUTATING, so it requires a resolvable senderPtyId and gets a server-pinned
+  // verifiedWorkspaceId (D5), unlike the historical renderer-driven ack that
+  // had no senderPtyId and would have left receipts forgeable (the reason it
+  // was previously kept off this router). The renderer keeps its own
+  // channels:mutate-local path (channelLocal.handler) — both routes land on
+  // the same daemon handler, which additionally stamps headless callers
+  // (channelCallerIdentity.ts). The cursor this advances (lastReadSeq) is the
+  // durable-inbox consume signal: the wake worker stops re-nudging on ack.
+  router.register('a2a.channel.ack', (p) => forward('a2a.channel.ack', p, true));
 
   // Mutating — capability 'a2a.channel.send' (verifiable caller required)
   router.register('a2a.channel.create', (p) => forward('a2a.channel.create', p, true));

--- a/src/main/pipe/handlers/events.rpc.ts
+++ b/src/main/pipe/handlers/events.rpc.ts
@@ -136,6 +136,12 @@ export function registerEventsRpc(router: RpcRouter, trustLookup?: TrustLookup):
         if (ce.workspaceId === caller) return true;
         return ce.recipientWorkspaceIds.includes(caller);
       }
+      if (e.type === 'channel.nudgeExhausted') {
+        // Channels v2 — same unscoped-drop discipline as the other channel.*
+        // events (channel existence must not leak to a bare subscribe). Base
+        // workspaceId is the affected member's workspace; only it sees the event.
+        return !!caller && e.workspaceId === caller;
+      }
       // every other type: strict scope, UNCHANGED from the old EventBus gate
       return caller ? e.workspaceId === caller : true;
     });

--- a/src/mcp/__tests__/index.channel.test.ts
+++ b/src/mcp/__tests__/index.channel.test.ts
@@ -81,6 +81,8 @@ const channelList = tools.get('channel_list');
 const channelRead = tools.get('channel_read');
 const channelInvite = tools.get('channel_invite');
 const channelGetMembers = tools.get('channel_get_members');
+const channelAck = tools.get('channel_ack');
+const channelUnread = tools.get('channel_unread');
 
 if (
   !channelCreate ||
@@ -90,7 +92,9 @@ if (
   !channelList ||
   !channelRead ||
   !channelInvite ||
-  !channelGetMembers
+  !channelGetMembers ||
+  !channelAck ||
+  !channelUnread
 ) {
   throw new Error('channel tools failed to register');
 }
@@ -100,10 +104,11 @@ beforeEach(() => {
 });
 
 describe('channel_* tools: registration', () => {
-  it('registers all eight standard tools', () => {
+  it('registers all ten standard tools', () => {
     // channel_read exposes message history; channel_invite adds another
     // workspace (the only path into a private channel); channel_get_members
-    // exposes the roster (who is in the channel).
+    // exposes the roster (who is in the channel). Channels v2 adds
+    // channel_ack (durable-inbox consume signal) + channel_unread (cheap poll).
     expect(channelCreate).toBeDefined();
     expect(channelPost).toBeDefined();
     expect(channelJoin).toBeDefined();
@@ -112,6 +117,8 @@ describe('channel_* tools: registration', () => {
     expect(channelRead).toBeDefined();
     expect(channelInvite).toBeDefined();
     expect(channelGetMembers).toBeDefined();
+    expect(channelAck).toBeDefined();
+    expect(channelUnread).toBeDefined();
   });
 
   it('does not register a channel_history tool (history is exposed via channel_read)', () => {
@@ -478,11 +485,13 @@ describe('channel_get_members', () => {
 });
 
 describe('FIRST_PARTY_METHODS allowlist (channel coverage)', () => {
-  it('grants the bundled first-party MCP server access to all nine agent-reachable a2a.channel.* methods', () => {
+  it('grants the bundled first-party MCP server access to all eleven agent-reachable a2a.channel.* methods', () => {
     // Without these, the bundled Claude/Codex MCP server is deadlocked in
     // enforce mode (plans/first-party-mcp-trust.md §2). archive + kick are
     // humans-only (renderer-IPC, never the pipe/MCP) so they are deliberately
-    // absent — see the negative assertion below.
+    // absent — see the negative assertion below. v2 adds ack + unread: ack is
+    // the durable-inbox consume signal, so denying it to agents would leave
+    // the wake worker re-pinging them forever.
     for (const m of [
       'a2a.channel.list',
       'a2a.channel.get',
@@ -493,6 +502,8 @@ describe('FIRST_PARTY_METHODS allowlist (channel coverage)', () => {
       'a2a.channel.leave',
       'a2a.channel.post',
       'a2a.channel.invite',
+      'a2a.channel.ack',
+      'a2a.channel.unread',
     ] as const) {
       expect(
         FIRST_PARTY_METHODS.has(m),
@@ -504,5 +515,80 @@ describe('FIRST_PARTY_METHODS allowlist (channel coverage)', () => {
   it('does NOT grant archive or kick (humans-only — must never be agent-reachable)', () => {
     expect(FIRST_PARTY_METHODS.has('a2a.channel.archive')).toBe(false);
     expect(FIRST_PARTY_METHODS.has('a2a.channel.kick')).toBe(false);
+  });
+});
+
+describe('channel_ack (Channels v2)', () => {
+  it('forwards channelId/uptoSeq/memberId + verifiedWorkspaceId to a2a.channel.ack', async () => {
+    mockSendRpc.mockResolvedValue({ ok: true, acked: 0, lastReadSeq: 7 });
+    const res = await channelAck({ channel_id: 'ch-1', upto_seq: 7, member_id: 'codex' });
+    expect(mockSendRpc).toHaveBeenCalledWith('a2a.channel.ack', {
+      workspaceId: 'ws-test',
+      verifiedWorkspaceId: 'ws-test',
+      channelId: 'ch-1',
+      uptoSeq: 7,
+      memberId: 'codex',
+    });
+    expect(res.isError).toBeUndefined();
+  });
+
+  it('omits memberId when not provided (workspace-wide ack)', async () => {
+    mockSendRpc.mockResolvedValue({ ok: true, acked: 2, lastReadSeq: 3 });
+    await channelAck({ channel_id: 'ch-1', upto_seq: 3 });
+    expect(mockSendRpc).toHaveBeenCalledWith('a2a.channel.ack', {
+      workspaceId: 'ws-test',
+      verifiedWorkspaceId: 'ws-test',
+      channelId: 'ch-1',
+      uptoSeq: 3,
+    });
+  });
+
+  it('surfaces CHANNEL_NOT_FOUND as isError', async () => {
+    mockSendRpc.mockResolvedValue({
+      ok: false,
+      error: { code: 'CHANNEL_NOT_FOUND', message: 'No such channel' },
+    });
+    const res = await channelAck({ channel_id: 'ch-ghost', upto_seq: 1 });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('CHANNEL_NOT_FOUND');
+  });
+});
+
+describe('channel_unread (Channels v2)', () => {
+  it('forwards verifiedWorkspaceId (+ optional memberId) to a2a.channel.unread', async () => {
+    mockSendRpc.mockResolvedValue({ ok: true, entries: [] });
+    await channelUnread({ member_id: 'codex' });
+    expect(mockSendRpc).toHaveBeenCalledWith('a2a.channel.unread', {
+      workspaceId: 'ws-test',
+      verifiedWorkspaceId: 'ws-test',
+      memberId: 'codex',
+    });
+    await channelUnread({});
+    expect(mockSendRpc).toHaveBeenLastCalledWith('a2a.channel.unread', {
+      workspaceId: 'ws-test',
+      verifiedWorkspaceId: 'ws-test',
+    });
+  });
+
+  it('passes through the entries envelope', async () => {
+    mockSendRpc.mockResolvedValue({
+      ok: true,
+      entries: [
+        {
+          channelId: 'ch-1',
+          name: 'general',
+          memberId: 'codex',
+          lastReadSeq: 3,
+          headSeq: 5,
+          unread: 2,
+          mentionUnread: 1,
+          trimmedBeforeCursor: 0,
+        },
+      ],
+    });
+    const res = await channelUnread({});
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0].text).toContain('"unread": 2');
+    expect(res.content[0].text).toContain('"trimmedBeforeCursor": 0');
   });
 });

--- a/src/mcp/channels.ts
+++ b/src/mcp/channels.ts
@@ -274,11 +274,13 @@ export function registerChannelTools(server: McpServer, deps: ChannelToolDeps): 
   // the agent's context window — reading a busy channel is a token cost.
   server.tool(
     'channel_read',
-    'Read recent messages from a channel you can see (public, or private if you are a member). ' +
-      'Returns the most recent `limit` messages (default 50, newest last); use `since_seq` to page ' +
-      'forward from a known seq. Reading consumes your context window, so prefer a small `limit` and ' +
-      'read deliberately. A private channel you are not a member of returns an empty list; a missing ' +
-      'channel returns an error.',
+    'Read messages from a channel you can see (public, or private if you are a member). ' +
+      'With `since_seq` (pass your cursor + 1 from channel_unread) it returns the OLDEST `limit` ' +
+      'messages from that point — contiguous pages, so ack the highest seq you read and repeat ' +
+      'until fewer than `limit` return to drain safely. Without `since_seq` it returns the most ' +
+      'recent `limit` messages (display). Reading consumes your context window, so prefer a small ' +
+      '`limit`. A private channel you are not a member of returns an empty list; a missing channel ' +
+      'returns an error.',
     {
       channel_id: z.string().describe('Target channel id.'),
       since_seq: z
@@ -376,18 +378,18 @@ export function registerChannelTools(server: McpServer, deps: ChannelToolDeps): 
   // will be re-pinged about the same messages.
   server.tool(
     'channel_ack',
-    'Acknowledge channel messages up to a seq (inclusive) as consumed. Call this after channel_read with the highest seq you processed — it advances your durable read cursor, clears your unread count, and stops re-nudges for those messages. Advance-only (acking an older seq never rewinds) and clamped to the channel head.',
+    'Acknowledge channel messages up to a seq (inclusive) as consumed. Call this after channel_read with the highest seq you actually processed (read oldest-first via since_seq and repeat until drained — do not ack past messages you have not seen). Advances your durable read cursor, clears your unread count, and stops re-nudges. Advance-only (acking an older seq never rewinds) and clamped to the channel head. Requires member_id to move a cursor; an unknown member_id is an error, and omitting it records read receipts only.',
     {
       channel_id: z.string().describe('Target channel id.'),
       upto_seq: z
         .number()
         .int()
         .min(0)
-        .describe('Highest message seq you have consumed (inclusive) — typically the last seq returned by channel_read.'),
+        .describe('Highest message seq you have consumed (inclusive) — the last seq returned by the channel_read page you just processed.'),
       member_id: z
         .string()
         .optional()
-        .describe('Narrow the ack to one of your member rows (e.g. "backend"). Omit to ack every row your workspace holds in this channel.'),
+        .describe('YOUR member row in this channel (e.g. "codex") — required to advance your cursor; an id with no row errors instead of silently no-opping. Omit = read receipts only, no cursor moves (a human-glance semantic, not consumption).'),
     },
     async ({ channel_id, upto_seq, member_id }) => {
       const workspaceId = await deps.resolveWorkspaceId();

--- a/src/mcp/channels.ts
+++ b/src/mcp/channels.ts
@@ -1,6 +1,7 @@
 // ─── Channel tools for the bundled MCP server ───────────────────────────
 //
-// Nine standard MCP tools that expose the `a2a.channel.*` pipe RPC surface to
+// Standard MCP tools (eleven — Channels v2 added channel_ack/channel_unread)
+// that expose the `a2a.channel.*` pipe RPC surface to
 // first-party MCP clients (Claude Code, Codex CLI). Each tool is a thin
 // pass-through over `sendRpc` plus a per-call workspaceId resolved by the
 // caller (index.ts injects `resolveWorkspaceId` so tests can stub it
@@ -107,7 +108,7 @@ async function callChannelRpc(
   }
 }
 
-/** Register the nine standard channel tools on the given MCP server. The
+/** Register the standard channel tools on the given MCP server. The
  *  parent module injects `resolveWorkspaceId` so workspace identity follows
  *  the same verification rules as the rest of the bundled server (verified
  *  PID-map hit first, env-hint fallback on miss). */
@@ -363,6 +364,64 @@ export function registerChannelTools(server: McpServer, deps: ChannelToolDeps): 
         workspaceId,
         verifiedWorkspaceId: workspaceId,
         channelId: channel_id,
+      });
+    },
+  );
+
+  // ── channel_ack (Channels v2) ─────────────────────────────────────
+  // The consume signal of the durable inbox: advances the caller's
+  // per-member read cursor (lastReadSeq). The wake worker re-nudges a
+  // member while it has unread mentions and STOPS on ack — so an agent
+  // that reads a channel should ack the highest seq it processed, or it
+  // will be re-pinged about the same messages.
+  server.tool(
+    'channel_ack',
+    'Acknowledge channel messages up to a seq (inclusive) as consumed. Call this after channel_read with the highest seq you processed — it advances your durable read cursor, clears your unread count, and stops re-nudges for those messages. Advance-only (acking an older seq never rewinds) and clamped to the channel head.',
+    {
+      channel_id: z.string().describe('Target channel id.'),
+      upto_seq: z
+        .number()
+        .int()
+        .min(0)
+        .describe('Highest message seq you have consumed (inclusive) — typically the last seq returned by channel_read.'),
+      member_id: z
+        .string()
+        .optional()
+        .describe('Narrow the ack to one of your member rows (e.g. "backend"). Omit to ack every row your workspace holds in this channel.'),
+    },
+    async ({ channel_id, upto_seq, member_id }) => {
+      const workspaceId = await deps.resolveWorkspaceId();
+      return callChannelRpc('a2a.channel.ack' as RpcMethod, {
+        workspaceId,
+        verifiedWorkspaceId: workspaceId,
+        channelId: channel_id,
+        uptoSeq: upto_seq,
+        ...(member_id !== undefined ? { memberId: member_id } : {}),
+      });
+    },
+  );
+
+  // ── channel_unread (Channels v2) ──────────────────────────────────
+  // The cheap "do I owe anything?" poll: per-channel unread + mention-unread
+  // counts derived from the durable cursor. Reading this does NOT consume
+  // messages (only channel_ack advances the cursor). `trimmedBeforeCursor`
+  // > 0 means retention removed messages before you read them — the gap is
+  // reported, never silently swallowed.
+  server.tool(
+    'channel_unread',
+    'Summarize your unread channel messages: per-channel unread count, mention-unread count (messages that @-mention you), your cursor (lastReadSeq), the channel head seq, and trimmedBeforeCursor (messages lost to retention before you read them — never silently dropped). Cheap to call; does not consume messages. Follow up with channel_read + channel_ack.',
+    {
+      member_id: z
+        .string()
+        .optional()
+        .describe('Narrow the summary to one of your member rows. Omit for every row your workspace holds.'),
+    },
+    async ({ member_id }) => {
+      const workspaceId = await deps.resolveWorkspaceId();
+      return callChannelRpc('a2a.channel.unread' as RpcMethod, {
+        workspaceId,
+        verifiedWorkspaceId: workspaceId,
+        ...(member_id !== undefined ? { memberId: member_id } : {}),
       });
     },
   );

--- a/src/renderer/components/Channels/ChannelMembers.tsx
+++ b/src/renderer/components/Channels/ChannelMembers.tsx
@@ -45,6 +45,14 @@ export interface JoinableWorkspace {
 
 export interface ChannelMembersViewProps {
   members: ChannelMember[];
+  /**
+   * Channels v2 — highest message seq the renderer has loaded for this
+   * channel. Drives the per-member "N behind" badge derived from the durable
+   * read cursor (`member.lastReadSeq`): the roster shows how far each AGENT
+   * member's consumption lags, from persisted fact rather than guesswork.
+   * Omit (or 0) → no badges (e.g. roster opened before messages hydrate).
+   */
+  headSeq?: number;
   /** workspaceId → human-readable label (workspace name, falls back to id). */
   workspaceLabel: (workspaceId: string) => string;
   /** The human's own workspace (null when none resolvable). */
@@ -68,6 +76,7 @@ export interface ChannelMembersViewProps {
  *  per-row self-leave, humans-only kick of other members, and a "+ member" picker. */
 export function ChannelMembersView({
   members,
+  headSeq,
   workspaceLabel,
   selfWorkspaceId,
   selfMemberId,
@@ -130,6 +139,15 @@ export function ChannelMembersView({
           ) : (
             members.map((m) => {
               const self = isSelf(m);
+              // Channels v2 — consumption lag from the durable cursor. Only
+              // meaningful for agent rows (humans advance the ws-wide cursor
+              // just by reading the dock) and only when the head is known.
+              // A pre-v2 row without lastReadSeq shows no badge (never a
+              // fabricated number).
+              const behind =
+                !self && m.memberId !== selfMemberId && typeof headSeq === 'number' && headSeq > 0 && typeof m.lastReadSeq === 'number'
+                  ? Math.max(0, headSeq - m.lastReadSeq)
+                  : 0;
               return (
                 <div
                   key={`${m.workspaceId}:${m.memberId}`}
@@ -147,6 +165,16 @@ export function ChannelMembersView({
                       <span className="text-[var(--text-muted)]"> · {m.memberId}</span>
                     )}
                   </span>
+                  {behind > 0 && (
+                    <span
+                      data-channel-member-behind
+                      className="flex-shrink-0 text-[9px] text-[var(--text-muted)]"
+                      title={t('channels.memberBehindTitle') || 'Unread messages this member has not consumed (durable cursor)'}
+                      {...tokenAttrs('textMuted', 'text')}
+                    >
+                      {behind} {t('channels.memberBehind') || 'behind'}
+                    </span>
+                  )}
                   {self ? (
                     <button
                       type="button"
@@ -218,6 +246,13 @@ export function ChannelMembersView({
 export function ChannelMembersControl({ channel }: { channel: Channel }): React.ReactElement {
   const t = useT();
   const members = useStore((s) => s.channelMembers[channel.id] ?? EMPTY_MEMBERS);
+  // Channels v2 — head seq for the "N behind" cursor badges, derived from the
+  // loaded message tail (the render cap keeps the array bounded; the LAST
+  // element carries the highest seq the renderer knows).
+  const headSeq = useStore((s) => {
+    const msgs = s.channelMessages[channel.id];
+    return msgs && msgs.length > 0 ? msgs[msgs.length - 1].seq : 0;
+  });
   const workspaces = useStore((s) => s.workspaces);
   const company = useStore((s) => s.company);
   const activeWorkspaceId = useStore((s) => s.activeWorkspaceId);
@@ -340,6 +375,7 @@ export function ChannelMembersControl({ channel }: { channel: Channel }): React.
   return (
     <ChannelMembersView
       members={rosterMembers}
+      headSeq={headSeq}
       workspaceLabel={workspaceLabel}
       selfWorkspaceId={selfWorkspaceId}
       selfMemberId={UI_MEMBER_ID}

--- a/src/renderer/components/Channels/__tests__/ChannelMembers.test.tsx
+++ b/src/renderer/components/Channels/__tests__/ChannelMembers.test.tsx
@@ -138,4 +138,18 @@ describe('ChannelMembers — wiring regression guard', () => {
     expect(view).toContain('membersSlot');
     expect(view).toMatch(/<ChannelMembersControl\s+channel=\{channel\}\s*\/>/);
   });
+
+  it('Channels v2: agent rows show a cursor-derived "behind" badge, never a fabricated one', () => {
+    // The badge exists and is derived from the durable cursor vs the head…
+    expect(members).toContain('data-channel-member-behind');
+    expect(members).toMatch(/headSeq - m\.lastReadSeq/);
+    // …only for agent rows (humans advance the ws cursor by reading the dock)…
+    expect(members).toMatch(/!self && m\.memberId !== selfMemberId/);
+    // …and NEVER invented: a pre-v2 row without lastReadSeq shows no badge.
+    expect(members).toMatch(/typeof m\.lastReadSeq === 'number'/);
+    // Container derives the head from the loaded message tail (render-capped
+    // array, last element = highest seq the renderer knows).
+    expect(members).toMatch(/channelMessages\[channel\.id\]/);
+    expect(members).toMatch(/msgs\[msgs\.length - 1\]\.seq/);
+  });
 });

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -653,6 +653,8 @@ export const en = {
   'channels.archiveConfirm': 'Confirm archive — read-only, one-way',
   'channels.members': 'Members',
   'channels.membershipNote': 'Anyone in a member workspace can read and post.',
+  'channels.memberBehind': 'behind',
+  'channels.memberBehindTitle': 'Unread messages this member has not consumed (durable cursor)',
   'channels.you': 'you',
   'channels.noMembers': 'No members yet.',
   'channels.leaveChannel': 'Leave channel',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -578,6 +578,8 @@ export const ko = {
   'channels.archiveConfirm': '보관 확정 — 읽기 전용, 되돌릴 수 없음',
   'channels.members': '멤버',
   'channels.membershipNote': '멤버 워크스페이스에 속한 에이전트는 모두 읽고 쓸 수 있습니다.',
+  'channels.memberBehind': '밀림',
+  'channels.memberBehindTitle': '이 멤버가 아직 소비하지 않은 메시지 수 (영속 커서 기준)',
   'channels.you': '나',
   'channels.noMembers': '아직 멤버가 없습니다.',
   'channels.leaveChannel': '채널 나가기',

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -84,6 +84,22 @@ export interface ChannelMember {
    * here.
    */
   historyFromSeq: number;
+  /**
+   * Channels v2 (durable inbox): highest `seq` this member has CONSUMED.
+   * Advance-only (`a2a.channel.ack` clamps to the channel head and never
+   * moves backwards); `unread = messages with historyFromSeq ≤ seq >
+   * lastReadSeq`. This is the delivery substrate — the wake worker re-nudges
+   * a member while it has unread mentions, and stops on ack.
+   *
+   * OPTIONAL for backward compat (additive field, `ChannelState.version`
+   * stays 1): rows persisted before v2 lack it and are backfilled to the
+   * channel HEAD at ChannelService construction ("start reading from now"),
+   * NOT to 0 — a 0 default would mark the entire history unread on upgrade
+   * and set off a re-nudge storm. Same rule at join/create seeding time.
+   * Multiple panes acking the same (workspaceId, memberId) row = last-ack-wins
+   * (documented v1 simplification).
+   */
+  lastReadSeq?: number;
 }
 
 /**

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -76,7 +76,14 @@ export type WmuxEventType =
   // any ws this change removed (so a kicked/left member also drops its mirror).
   // Public-channel creation may instead use the `'*'` sentinel in
   // `recipientWorkspaceIds` to broadcast discoverability to EVERY workspace.
-  | 'channel.catalog';
+  | 'channel.catalog'
+  // Channels v2 wake worker: the mention-nudge budget for one (channel,
+  // member) episode is exhausted — the worker stops re-nudging and hands the
+  // episode to HUMANS. Tee'd from the daemon broadcast so orchestrator
+  // clients can observe stranded mentions; the primary human surface is the
+  // in-app toast + OS notification (DaemonNotificationRouter). Scoped to the
+  // affected member's workspace (base workspaceId).
+  | 'channel.nudgeExhausted';
 
 export const WMUX_EVENT_TYPES: readonly WmuxEventType[] = [
   'pane.created',
@@ -93,6 +100,7 @@ export const WMUX_EVENT_TYPES: readonly WmuxEventType[] = [
   'a2a.task',
   'channel.message',
   'channel.catalog',
+  'channel.nudgeExhausted',
 ] as const;
 
 export interface WmuxEventBase {
@@ -382,8 +390,27 @@ export interface ChannelCatalogEvent extends WmuxEventBase {
    *  instead carry the single `'*'` sentinel = "broadcast to every workspace"
    *  (discoverability). `events.poll` fans out accordingly. */
   recipientWorkspaceIds: string[];
-  /** What changed — advisory; the receiver re-hydrates regardless. */
-  reason: 'created' | 'archived' | 'membership';
+  /** What changed — advisory; the receiver re-hydrates regardless. 'cursor' =
+   *  a member's read cursor advanced (agent ack): the roster's "N behind"
+   *  badges hydrate from the same catalog fetch, so a cursor move must
+   *  re-sync it too (Codex re-review). */
+  reason: 'created' | 'archived' | 'membership' | 'cursor';
+}
+
+/**
+ * Channels v2 wake worker — the mention-nudge budget for one (channel,
+ * member) episode ran out (backoff ladder exhausted, mentions still
+ * unread). The worker will NOT re-nudge again until an ack resets the
+ * episode; a human must look. Base `workspaceId` = the affected member's
+ * workspace.
+ */
+export interface ChannelNudgeExhaustedEvent extends WmuxEventBase {
+  type: 'channel.nudgeExhausted';
+  channelId: string;
+  channelName: string;
+  memberId: string;
+  unread: number;
+  mentionUnread: number;
 }
 
 export type WmuxEvent =
@@ -400,7 +427,8 @@ export type WmuxEvent =
   | PaneSupervisionEvent
   | A2aTaskEvent
   | ChannelMessageEvent
-  | ChannelCatalogEvent;
+  | ChannelCatalogEvent
+  | ChannelNudgeExhaustedEvent;
 
 export const RING_CAPACITY = 1024;
 export const POLL_DEFAULT_MAX = 256;

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -220,7 +220,8 @@ export type RpcMethod =
   | 'a2a.channel.post'
   | 'a2a.channel.invite'
   | 'a2a.channel.kick'
-  | 'a2a.channel.ack';
+  | 'a2a.channel.ack'
+  | 'a2a.channel.unread';
 
 // All available methods as array (for system.capabilities)
 export const ALL_RPC_METHODS = [
@@ -347,6 +348,7 @@ export const ALL_RPC_METHODS = [
   'a2a.channel.invite',
   'a2a.channel.kick',
   'a2a.channel.ack',
+  'a2a.channel.unread',
 ] as const satisfies readonly RpcMethod[];
 
 // === RPC Parameter Types ===

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -421,7 +421,14 @@ export interface DaemonEvent {
     // `data` carries the ChannelCatalogEvent; main tees it onto the in-process
     // EventBus as a WmuxEvent `channel.catalog`, scoped per-recipient by
     // `events.poll` exactly like channel.message.
-    | 'channel.catalog';
+    | 'channel.catalog'
+    // Channels v2 wake worker — a (channel, member) mention episode ran out
+    // of nudge budget; the worker stops and HUMANS must look. `sessionId` is
+    // '' and `data` carries the flat payload (channelId, channelName,
+    // workspaceId = affected member ws, memberId, unread, mentionUnread).
+    // Main surfaces it directly (toast + OS notification) AND tees it onto
+    // the EventBus as WmuxEvent `channel.nudgeExhausted` for orchestrators.
+    | 'channel.nudgeExhausted';
   sessionId: string;
   data: unknown;
 }


### PR DESCRIPTION
## Why

Channel delivery was fire-and-forget push chat, and four symptoms kept showing up in dogfooding: non-Claude agents could not really participate (the only integrated path was MCP plus Claude's Stop hook), conversations died after a single mention ping, senders had no way to tell whether anything was consumed, and the human UI sat on top of all that guesswork.

This PR swaps the delivery substrate. Consumption becomes a durable per-member fact (a read cursor on the member row), agents pull and ack, and the daemon wakes idle member panes. The chat room UI stays what it always was: a view over the log.

## What's in

- **Daemon-side caller stamping** (`channelCallerIdentity.ts`): a headless pipe client can authenticate a channel op with just `senderPtyId`; the daemon resolves the workspace from its own session record (the env binding main stamps at spawn). Pre-stamped requests (the GUI paths) are byte-for-byte untouched. Unresolvable identity fails closed. archive/kick stay humans-only and are deliberately not stamped.
- **`ChannelMember.lastReadSeq`**: advance-only cursor, clamped to the channel head. Existing rows are backfilled to head ("start reading from now"), so upgrading cannot mark whole histories unread and trigger a nudge storm. `ack` takes an optional `memberId` for the agent path; renderer semantics are unchanged.
- **`a2a.channel.unread`** plus MCP tools `channel_ack` / `channel_unread`: per-member unread and mention counts, and `trimmedBeforeCursor` so retention can never silently swallow unconsumed messages.
- **`wmux channel` CLI** (unread / read / post / ack / join / list): talks to the daemon pipe directly, so it keeps working with the GUI closed. `--help` doubles as the onboarding doc for any shell-capable agent (Codex, OpenCode, a bash loop). Identity ladder: verified PID-map walk when the GUI is up, `WMUX_PTY_ID` env fallback when headless.
- **Wake worker** (`channelWakeWorker.ts`): injects a one-line hint into an idle member pane. The text and the Enter are written separately (a single `text\r` chunk trips TUI paste heuristics and strands the nudge uncommitted). 10s quiet gate. It never guesses targets: agent-slug match, else the only non-Claude live pane in the workspace, else nothing; deferred (recovered) sessions are excluded. Mention re-nudges back off (0/1m/5m) and hard-stop at 3 with a `channel.nudgeExhausted` broadcast so two agents can never ping-pong each other's budgets forever. Claude panes keep the existing Stop-hook path.
- **Roster badges**: agent rows show "N behind" derived from the cursor. Never fabricated (rows without a cursor show nothing); human rows are exempt.

## Verification

- 38 new unit tests across stamping, cursor semantics, wake policy, CLI, and MCP tools. tsc clean on all four configs. Full vitest: 4611 passing. One pre-existing debounce timing test flakes under full-suite load only (alternates between StateWriter and ChannelStateWriter, passes in isolation, untouched by this diff).
- New E2E probe `scripts/channels-v2-inbox-probe.mjs` against the real bundled daemon, 7/7: stamping, fail-closed ghost identity, join backfill, unread/mention counts, the wake worker actually injecting into an idle pane (observed through the session pipe), ack, and cursor survival across a daemon SIGKILL plus respawn.
- Live dogfood in an isolated packaged instance with a real Codex CLI agent: five CLI-only turns, wake latency right at 2.0s on every turn, all posts attributed to the correct workspace, ack cleared unread each time. Killing the daemon mid-conversation preserved the transcript and cursors exactly. That run also surfaced the deferred-session gap fixed in the last commit.

## Notes

- No new security claims. Same-user identity remains the documented #113 ceiling; the daemon stamp is server-side provenance for attribution, not a boundary.
- `deliveryStatus` stays as-is: it carries the receipt semantics it gained in the A2A fix sprint.
- Follow-ups tracked outside this PR: the daemon token path is not suffix-aware (an intentional pair with the CLI today, needs a two-sided change), wake-detection tuning once there is field data, and the reboot demo, which pairs this with agent resume.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `wmux channel` CLI command with Channels v2 subcommands (unread, read, post, ack, join, list) and matching MCP tools (`channel_unread`, `channel_ack`).
  * Extended first-party RPC support with `a2a.channel.unread` and `a2a.channel.ack`.
  * Introduced per-member durable cursors, “member behind” badges, and wake-worker mention/unread nudging with `channel.nudgeExhausted` notifications/events.
* **Bug Fixes**
  * Improved durable cursor seeding/backfill, fail-closed auth behavior, and consistent ack/read consumption across sessions and daemon restarts.
* **Tests / Documentation**
  * Expanded CLI/daemon/worker/MCP test coverage and updated API reference method/event listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->