### PR TITLE
fix(daemon): make the daemon auth-token path suffix-aware (3-way lockstep)

### DIFF
--- a/scripts/daemon-token-path-probe.mjs
+++ b/scripts/daemon-token-path-probe.mjs
@@ -18,10 +18,16 @@
  * PASS criteria:
  *   P1  suffixed daemon WRITES its token to `<home>/.wmux${SUFFIX}/daemon-auth-token`
  *   P2  ...and does NOT pollute the shared, unsuffixed `<home>/.wmux/daemon-auth-token`
- *   P3  a client reading the suffix-aware token authenticates (daemon.ping ok)
- *       — proves writer <-> reader resolve the SAME path (lockstep)
- *   P4  a WRONG token is rejected (unauthorized) — sanity
- *   P5  BACKWARD COMPAT: with NO suffix, a pre-existing `~/.wmux/daemon-auth-token`
+ *   P3  a reader resolving the token path from the daemon's OWN env (the suffix-aware
+ *       ladder — `.wmux${SUFFIX}` then legacy `.wmux`) lands on EXACTLY the path the
+ *       daemon wrote: the writer<->reader path agreement ("mismatch = brick").
+ *       NOTE: this drives the path FORMULA end-to-end against the real daemon; the
+ *       reader FUNCTIONS' own logic (readDaemonAuthToken / resolveDaemonAuthToken,
+ *       suffix-first-then-legacy) is asserted with exact paths in the vitest units
+ *       (client.daemonPipe.test.ts, DaemonPipeServer.test.ts).
+ *   P4  ...and that reader-resolved token authenticates against the live daemon
+ *   P5  a WRONG token is rejected (unauthorized) — sanity
+ *   P6  BACKWARD COMPAT: with NO suffix, a pre-existing `~/.wmux/daemon-auth-token`
  *       (as older versions wrote) is adopted and still authenticates — no stranding
  *
  * Run: npm run build:daemon && node scripts/daemon-token-path-probe.mjs
@@ -134,6 +140,28 @@ function rpc(socket, method, params, authToken, timeoutMs = 15_000) {
   });
 }
 
+// Reader-side path resolution, replicated from the shared helpers so the probe
+// EXERCISES the writer<->reader path agreement instead of hardcoding the write
+// path. Mirrors getDaemonAuthTokenPath (`${USERPROFILE||HOME}/.wmux${suffix}/
+// daemon-auth-token`) then getLegacyDaemonAuthTokenPath (`…/.wmux/…`). The daemon
+// was spawned with USERPROFILE/HOME = testHome, so a reader running in that env
+// computes exactly these candidates — driving the token READ through this ladder
+// is what proves env→path→token agreement E2E ("mismatch = brick"). Keep this in
+// lockstep with src/shared/constants.ts if the path formula changes.
+function readerResolveToken(testHome, suffix) {
+  const candidates = [
+    path.join(testHome, `.wmux${suffix ?? ''}`, 'daemon-auth-token'),
+    path.join(testHome, '.wmux', 'daemon-auth-token'), // legacy unsuffixed fallback
+  ];
+  for (const p of candidates) {
+    try {
+      const t = fs.readFileSync(p, 'utf-8').trim();
+      if (t) return { token: t, path: p };
+    } catch { /* candidate absent — try the next */ }
+  }
+  return { token: '', path: null };
+}
+
 const results = [];
 const check = (name, ok, detail) => {
   results.push({ name, ok });
@@ -168,13 +196,19 @@ async function scenarioSuffixIsolation() {
     check('P1 suffixed daemon WRITES token to the suffix-aware dir', wroteSuffixed, suffixedToken);
     check('P2 suffixed daemon does NOT pollute the shared ~/.wmux token', !fs.existsSync(legacyToken), legacyToken);
 
-    const token = fs.readFileSync(suffixedToken, 'utf-8').trim();
+    // Resolve the token the way a READER does (independent path computation from
+    // the daemon's env), NOT by hardcoding the write path — this is what actually
+    // exercises the writer<->reader agreement (GLM review).
+    const reader = readerResolveToken(testHome, suffix);
+    check('P3 a reader resolving from the daemon env lands on the daemon-written path (writer<->reader agreement)',
+      reader.path === suffixedToken, `reader-resolved=${reader.path}  daemon-wrote=${suffixedToken}`);
+
     sock = await connectSocket(resolved);
-    const good = await rpc(sock, 'daemon.ping', {}, token);
-    check('P3 client reading the suffix-aware token authenticates (lockstep)', good.ok === true, good.ok ? 'pong' : `error=${JSON.stringify(good.error)}`);
+    const good = await rpc(sock, 'daemon.ping', {}, reader.token);
+    check('P4 the reader-resolved token authenticates against the live daemon', good.ok === true, good.ok ? 'pong' : `error=${JSON.stringify(good.error)}`);
 
     const bad = await rpc(sock, 'daemon.ping', {}, 'not-the-real-token');
-    check('P4 a WRONG token is rejected (unauthorized)', bad.ok === false && String(bad.error).includes('unauthorized'), JSON.stringify(bad.error));
+    check('P5 a WRONG token is rejected (unauthorized)', bad.ok === false && String(bad.error).includes('unauthorized'), JSON.stringify(bad.error));
   } finally {
     try { sock?.destroy(); } catch { /* ignore */ }
     try { daemon.kill('SIGKILL'); } catch { /* ignore */ }
@@ -203,7 +237,7 @@ async function scenarioBackwardCompat() {
     const resolved = await waitForPipeFile(wmuxDir);
     sock = await connectSocket(resolved);
     const good = await rpc(sock, 'daemon.ping', {}, legacyToken);
-    check('P5 backward-compat: pre-existing ~/.wmux token is adopted & authenticates', good.ok === true, good.ok ? 'pong' : `error=${JSON.stringify(good.error)}`);
+    check('P6 backward-compat: pre-existing ~/.wmux token is adopted & authenticates', good.ok === true, good.ok ? 'pong' : `error=${JSON.stringify(good.error)}`);
   } finally {
     try { sock?.destroy(); } catch { /* ignore */ }
     try { daemon.kill('SIGKILL'); } catch { /* ignore */ }

--- a/scripts/daemon-token-path-probe.mjs
+++ b/scripts/daemon-token-path-probe.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+/**
+ * Daemon auth-token PATH probe — end-to-end through the REAL bundled daemon
+ * (isolated home + pipe; the developer's production wmux is untouched).
+ *
+ * Guards the fix for the suffix-unaware daemon token path: the daemon control
+ * pipe is suffix-aware (`wmux-daemon${suffix}-user`) so a dev/dogfood instance
+ * and a packaged instance run concurrently on DIFFERENT pipes — but all three
+ * token sites used to hardcode the SHARED `~/.wmux/daemon-auth-token`, so the
+ * two daemons collided on one credential file (a cold-start race or rotateToken
+ * could then brick one instance's auth). The fix routes the writer
+ * (DaemonPipeServer.getTokenPath), the launcher reader
+ * (DaemonClient.readDaemonAuthToken) and the CLI reader
+ * (cli/client.resolveDaemonAuthToken) through one suffix-aware helper
+ * (getDaemonAuthTokenPath = `${getWmuxHomeDir()}/daemon-auth-token`), with a
+ * read-only fallback to the legacy unsuffixed path.
+ *
+ * PASS criteria:
+ *   P1  suffixed daemon WRITES its token to `<home>/.wmux${SUFFIX}/daemon-auth-token`
+ *   P2  ...and does NOT pollute the shared, unsuffixed `<home>/.wmux/daemon-auth-token`
+ *   P3  a client reading the suffix-aware token authenticates (daemon.ping ok)
+ *       — proves writer <-> reader resolve the SAME path (lockstep)
+ *   P4  a WRONG token is rejected (unauthorized) — sanity
+ *   P5  BACKWARD COMPAT: with NO suffix, a pre-existing `~/.wmux/daemon-auth-token`
+ *       (as older versions wrote) is adopted and still authenticates — no stranding
+ *
+ * Run: npm run build:daemon && node scripts/daemon-token-path-probe.mjs
+ */
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DAEMON_BUNDLE = path.join(REPO_ROOT, 'dist', 'daemon-bundle', 'index.js');
+
+function writeConfig(wmuxDir, pipeName) {
+  fs.writeFileSync(
+    path.join(wmuxDir, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      daemon: { pipeName, logLevel: 'info', autoStart: true },
+      session: {
+        defaultShell: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
+        defaultCols: 80, defaultRows: 24, bufferSizeMb: 8, bufferMaxMb: 64,
+        deadSessionTtlHours: 24, deadSessionDumpBuffer: true,
+      },
+    }, null, 2),
+  );
+}
+
+function makePipeName(tag) {
+  return process.platform === 'win32'
+    ? `\\\\.\\pipe\\wmux-test-${tag}`
+    : path.join(os.tmpdir(), `wmux-test-${tag}.sock`);
+}
+
+// Spawn the real daemon with an isolated HOME and (optionally) a data suffix,
+// exactly as the main process would inherit it to the detached daemon.
+function spawnDaemon(testHome, suffix, logChunks) {
+  const d = spawn(process.execPath, [DAEMON_BUNDLE], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      USERPROFILE: testHome,
+      HOME: testHome,
+      HOMEDRIVE: undefined,
+      HOMEPATH: undefined,
+      ...(suffix ? { WMUX_DATA_SUFFIX: suffix } : { WMUX_DATA_SUFFIX: undefined }),
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  d.stdout.on('data', (c) => logChunks && logChunks.push(c.toString()));
+  d.stderr.on('data', (c) => logChunks && logChunks.push(c.toString()));
+  return d;
+}
+
+async function waitForPipeFile(wmuxDir, timeoutMs = 15_000) {
+  const pipeFile = path.join(wmuxDir, 'daemon-pipe');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(pipeFile)) {
+      const v = fs.readFileSync(pipeFile, 'utf-8').trim();
+      if (v) return v;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error('daemon-pipe did not appear within timeout');
+}
+
+async function waitForFile(p, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(p)) return true;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return false;
+}
+
+function connectSocket(pipeName) {
+  return new Promise((resolve, reject) => {
+    const s = net.createConnection(pipeName, () => resolve(s));
+    s.on('error', reject);
+  });
+}
+
+function rpc(socket, method, params, authToken, timeoutMs = 15_000) {
+  return new Promise((resolve, reject) => {
+    const id = `req-${Math.random().toString(36).slice(2, 10)}`;
+    let buffer = '';
+    const handler = (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id === id) {
+            socket.removeListener('data', handler);
+            if (msg.ok) resolve({ ok: true, result: msg.result });
+            else resolve({ ok: false, error: msg.error });
+            return;
+          }
+        } catch { /* ignore */ }
+      }
+    };
+    socket.on('data', handler);
+    socket.write(JSON.stringify({ id, method, params, token: authToken }) + '\n');
+    setTimeout(() => { socket.removeListener('data', handler); reject(new Error(`rpc timeout: ${method}`)); }, timeoutMs);
+  });
+}
+
+const results = [];
+const check = (name, ok, detail) => {
+  results.push({ name, ok });
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+};
+
+const live = [];
+function killAll() {
+  for (const d of live) { try { d.kill('SIGKILL'); } catch { /* ignore */ } }
+}
+
+async function scenarioSuffixIsolation() {
+  const tag = `tokp-${randomUUID().slice(0, 8)}`;
+  const suffix = `-probe${randomUUID().slice(0, 4)}`;
+  const testHome = path.join(os.tmpdir(), `wmux-${tag}`);
+  const suffixedDir = path.join(testHome, `.wmux${suffix}`);
+  const legacyDir = path.join(testHome, '.wmux');
+  fs.mkdirSync(suffixedDir, { recursive: true });
+
+  const pipeName = makePipeName(tag);
+  writeConfig(suffixedDir, pipeName); // NO pre-seeded token — daemon must create it
+  const log = [];
+  const daemon = spawnDaemon(testHome, suffix, log);
+  live.push(daemon);
+  let sock;
+  try {
+    const resolved = await waitForPipeFile(suffixedDir);
+
+    const suffixedToken = path.join(suffixedDir, 'daemon-auth-token');
+    const legacyToken = path.join(legacyDir, 'daemon-auth-token');
+    const wroteSuffixed = await waitForFile(suffixedToken);
+    check('P1 suffixed daemon WRITES token to the suffix-aware dir', wroteSuffixed, suffixedToken);
+    check('P2 suffixed daemon does NOT pollute the shared ~/.wmux token', !fs.existsSync(legacyToken), legacyToken);
+
+    const token = fs.readFileSync(suffixedToken, 'utf-8').trim();
+    sock = await connectSocket(resolved);
+    const good = await rpc(sock, 'daemon.ping', {}, token);
+    check('P3 client reading the suffix-aware token authenticates (lockstep)', good.ok === true, good.ok ? 'pong' : `error=${JSON.stringify(good.error)}`);
+
+    const bad = await rpc(sock, 'daemon.ping', {}, 'not-the-real-token');
+    check('P4 a WRONG token is rejected (unauthorized)', bad.ok === false && String(bad.error).includes('unauthorized'), JSON.stringify(bad.error));
+  } finally {
+    try { sock?.destroy(); } catch { /* ignore */ }
+    try { daemon.kill('SIGKILL'); } catch { /* ignore */ }
+    if (results.some((r) => !r.ok)) console.log('--- daemon log (suffix scenario) ---\n' + log.join(''));
+    try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+}
+
+async function scenarioBackwardCompat() {
+  const tag = `tokp-bc-${randomUUID().slice(0, 8)}`;
+  const testHome = path.join(os.tmpdir(), `wmux-${tag}`);
+  const wmuxDir = path.join(testHome, '.wmux'); // NO suffix — production layout
+  fs.mkdirSync(wmuxDir, { recursive: true });
+
+  const pipeName = makePipeName(tag);
+  writeConfig(wmuxDir, pipeName);
+  // Pre-seed a legacy token EXACTLY where older wmux versions wrote it.
+  const legacyToken = `legacy-${randomUUID()}`;
+  fs.writeFileSync(path.join(wmuxDir, 'daemon-auth-token'), legacyToken, 'utf-8');
+
+  const log = [];
+  const daemon = spawnDaemon(testHome, undefined, log);
+  live.push(daemon);
+  let sock;
+  try {
+    const resolved = await waitForPipeFile(wmuxDir);
+    sock = await connectSocket(resolved);
+    const good = await rpc(sock, 'daemon.ping', {}, legacyToken);
+    check('P5 backward-compat: pre-existing ~/.wmux token is adopted & authenticates', good.ok === true, good.ok ? 'pong' : `error=${JSON.stringify(good.error)}`);
+  } finally {
+    try { sock?.destroy(); } catch { /* ignore */ }
+    try { daemon.kill('SIGKILL'); } catch { /* ignore */ }
+    if (!results[results.length - 1]?.ok) console.log('--- daemon log (backward-compat scenario) ---\n' + log.join(''));
+    try { fs.rmSync(testHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+}
+
+async function main() {
+  if (!fs.existsSync(DAEMON_BUNDLE)) {
+    console.error(`Daemon bundle missing: ${DAEMON_BUNDLE}\nRun: npm run build:daemon`);
+    process.exit(2);
+  }
+  console.log('daemon-token-path-probe — real bundled daemon, isolated homes\n');
+  await scenarioSuffixIsolation();
+  await scenarioBackwardCompat();
+
+  const passed = results.filter((r) => r.ok).length;
+  const total = results.length;
+  console.log(`\n${passed}/${total} checks passed`);
+  process.exit(passed === total ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('probe crashed:', err);
+  killAll();
+  process.exit(3);
+});

--- a/src/cli/__tests__/client.daemonPipe.test.ts
+++ b/src/cli/__tests__/client.daemonPipe.test.ts
@@ -106,13 +106,53 @@ describe('resolveDaemonPipeName', () => {
 });
 
 describe('resolveDaemonAuthToken', () => {
-  it('returns the trimmed token from ~/.wmux/daemon-auth-token', () => {
+  // getDaemonAuthTokenPath / getLegacyDaemonAuthTokenPath resolve home from
+  // USERPROFILE||HOME (not os.homedir), so pin them for a deterministic path.
+  const ORIGINAL_USERPROFILE = process.env.USERPROFILE;
+  const ORIGINAL_HOME = process.env.HOME;
+
+  beforeEach(() => {
+    process.env.USERPROFILE = '/home/u';
+    process.env.HOME = '/home/u';
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_USERPROFILE === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = ORIGINAL_USERPROFILE;
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+    else process.env.HOME = ORIGINAL_HOME;
+  });
+
+  it('returns the trimmed token; default (no suffix) reads ~/.wmux/daemon-auth-token', () => {
     readFileSyncMock.mockReturnValue('  SECRET123\n');
     expect(resolveDaemonAuthToken()).toBe('SECRET123');
-    // NOTE: the daemon token path is NOT suffix-aware (hardcoded ~/.wmux).
-    const readPath = String(readFileSyncMock.mock.calls[0][0]);
-    expect(readPath).toContain('.wmux');
-    expect(readPath).toContain('daemon-auth-token');
+    const readPath = String(readFileSyncMock.mock.calls[0][0]).replace(/\\/g, '/');
+    expect(readPath).toBe('/home/u/.wmux/daemon-auth-token');
+  });
+
+  it('reads the SUFFIXED path first when WMUX_DATA_SUFFIX is set (isolation)', () => {
+    process.env.WMUX_DATA_SUFFIX = '-dev';
+    readFileSyncMock.mockReturnValue('DEVTOKEN\n');
+    expect(resolveDaemonAuthToken()).toBe('DEVTOKEN');
+    const readPath = String(readFileSyncMock.mock.calls[0][0]).replace(/\\/g, '/');
+    expect(readPath).toBe('/home/u/.wmux-dev/daemon-auth-token');
+  });
+
+  it('falls back to the legacy unsuffixed path when the suffixed path is absent', () => {
+    process.env.WMUX_DATA_SUFFIX = '-dev';
+    // First candidate (suffixed) missing, second candidate (legacy) present —
+    // a suffixed instance upgrading over a still-running older daemon.
+    readFileSyncMock
+      .mockImplementationOnce(() => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      })
+      .mockReturnValueOnce('LEGACYTOKEN\n');
+    expect(resolveDaemonAuthToken()).toBe('LEGACYTOKEN');
+    expect(readFileSyncMock).toHaveBeenCalledTimes(2);
+    const first = String(readFileSyncMock.mock.calls[0][0]).replace(/\\/g, '/');
+    const second = String(readFileSyncMock.mock.calls[1][0]).replace(/\\/g, '/');
+    expect(first).toBe('/home/u/.wmux-dev/daemon-auth-token');
+    expect(second).toBe('/home/u/.wmux/daemon-auth-token');
   });
 
   it('returns undefined when the token file is absent', () => {

--- a/src/cli/client.ts
+++ b/src/cli/client.ts
@@ -10,6 +10,8 @@ import {
   getAuthTokenPath,
   getTcpPortPath,
   getWmuxHomeDir,
+  getDaemonAuthTokenPath,
+  getLegacyDaemonAuthTokenPath,
   dataSuffix,
 } from '../shared/constants';
 
@@ -189,8 +191,10 @@ export async function sendRequest(
 //   - daemon pipe file  → src/main/daemon/launcher.ts readPipeNameFromFile
 //                          (reads `${getWmuxDir()}/daemon-pipe`)
 //   - daemon pipe name  → src/main/DaemonClient.ts getDaemonPipeName
-//   - daemon auth token → src/main/DaemonClient.ts readDaemonAuthToken
-//                          (and src/daemon/DaemonPipeServer.ts getTokenPath)
+//   - daemon auth token → src/shared/constants.ts getDaemonAuthTokenPath
+//                          (suffix-aware; written by DaemonPipeServer.getTokenPath,
+//                          read here + by DaemonClient.readDaemonAuthToken, with a
+//                          getLegacyDaemonAuthTokenPath fallback on both readers)
 // Keep these in lockstep with those modules if the daemon transport changes.
 // ---------------------------------------------------------------------------
 
@@ -229,20 +233,22 @@ export function resolveDaemonPipeName(): string {
 }
 
 /**
- * Read the daemon auth token. NOTE: unlike the main-pipe token
- * (getAuthTokenPath, suffix-aware), the daemon token path is NOT suffix-aware
- * — both the daemon (src/daemon/DaemonPipeServer.ts getTokenPath) and the
- * launcher (src/main/DaemonClient.ts readDaemonAuthToken) hardcode
- * `~/.wmux/daemon-auth-token`. Returns undefined if absent.
+ * Read the daemon auth token. Suffix-aware via getDaemonAuthTokenPath, mirroring
+ * the daemon writer (src/daemon/DaemonPipeServer.ts getTokenPath) and the
+ * launcher reader (src/main/DaemonClient.ts readDaemonAuthToken) — all three
+ * MUST resolve the same path or nothing authenticates. Falls back to the legacy
+ * unsuffixed `~/.wmux/daemon-auth-token` when the suffix-aware path is absent,
+ * so a suffixed ('-dev'/dogfood) instance upgrading over a still-running older
+ * daemon still authenticates. Returns undefined if absent.
  */
 export function resolveDaemonAuthToken(): string | undefined {
-  try {
-    const fromFile = fs
-      .readFileSync(path.join(os.homedir(), '.wmux', 'daemon-auth-token'), 'utf8')
-      .trim();
-    if (fromFile) return fromFile;
-  } catch {
-    // file absent/unreadable
+  for (const tokenPath of [getDaemonAuthTokenPath(), getLegacyDaemonAuthTokenPath()]) {
+    try {
+      const fromFile = fs.readFileSync(tokenPath, 'utf8').trim();
+      if (fromFile) return fromFile;
+    } catch {
+      // candidate absent/unreadable — try the next one
+    }
   }
   return undefined;
 }

--- a/src/daemon/DaemonPipeServer.ts
+++ b/src/daemon/DaemonPipeServer.ts
@@ -1,10 +1,9 @@
 import net from 'node:net';
 import fs from 'node:fs';
 import crypto from 'node:crypto';
-import os from 'node:os';
-import path from 'node:path';
 import type { RpcRequest, RpcResponse } from '../shared/rpc';
 import { secureWriteTokenFile, scheduleTokenFileReHarden } from '../shared/security';
+import { getDaemonAuthTokenPath } from '../shared/constants';
 
 const MAX_LINE_BUFFER = 1024 * 1024; // 1 MB — prevent OOM from malicious clients
 
@@ -374,10 +373,13 @@ export class DaemonPipeServer {
     });
   }
 
+  // Suffix-aware daemon token path (single source of truth in shared/constants).
+  // The daemon WRITER deliberately never falls back to the legacy unsuffixed
+  // path — a suffixed ('-dev'/dogfood) instance must mint its OWN token instead
+  // of adopting production's, which is the whole point of the isolation.
   private getTokenPath(): string {
     if (this.tokenPathOverride) return this.tokenPathOverride;
-    const home = os.homedir();
-    return path.join(home, '.wmux', 'daemon-auth-token');
+    return getDaemonAuthTokenPath();
   }
 
   private handleConnection(socket: net.Socket): void {

--- a/src/daemon/__tests__/DaemonPipeServer.test.ts
+++ b/src/daemon/__tests__/DaemonPipeServer.test.ts
@@ -7,6 +7,10 @@ import fs from 'node:fs';
 import { DaemonPipeServer } from '../DaemonPipeServer';
 import { SessionPipe, FLUSH_DONE_MARKER } from '../SessionPipe';
 import { RingBuffer } from '../RingBuffer';
+import {
+  getDaemonAuthTokenPath,
+  getLegacyDaemonAuthTokenPath,
+} from '../../shared/constants';
 
 // Helper: generate unique pipe name for each test to avoid conflicts
 function testPipeName(suffix: string): string {
@@ -325,6 +329,50 @@ describe('DaemonPipeServer', () => {
 
     // Cleanup tmp token file.
     try { fs.unlinkSync(tmpTokenPath); } catch { /* ignore */ }
+  });
+
+  it('loadOrCreateToken writes to the suffix-aware shared path (getDaemonAuthTokenPath), isolated from prod', async () => {
+    // Point HOME at a fresh temp dir and set a UNIQUE data suffix so the writer
+    // lands in an ISOLATED dir, never the developer's real ~/.wmux. Crucially,
+    // NO setTokenPathForTest override here — this exercises the REAL
+    // getTokenPath → getDaemonAuthTokenPath resolution that the launcher
+    // (DaemonClient.readDaemonAuthToken) and CLI (client.resolveDaemonAuthToken)
+    // readers must compute identically. Same-path lockstep is the critical
+    // invariant: if writer and readers diverge, nothing authenticates.
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-tokhome-'));
+    const suffix = `-tok${crypto.randomUUID().slice(0, 6)}`;
+    const saved = {
+      up: process.env.USERPROFILE,
+      home: process.env.HOME,
+      suf: process.env.WMUX_DATA_SUFFIX,
+    };
+    process.env.USERPROFILE = tmpHome;
+    process.env.HOME = tmpHome;
+    process.env.WMUX_DATA_SUFFIX = suffix;
+    try {
+      const writer = new DaemonPipeServer(testPipeName('tokwrite'));
+      const token = await writer.loadOrCreateToken();
+      expect(token.length).toBeGreaterThan(0);
+
+      // The daemon wrote exactly where the shared helper resolves — and the
+      // readers resolve via the SAME helper, so read ↔ write agree by
+      // construction. Assert the on-disk file at that path carries the token.
+      const writtenPath = getDaemonAuthTokenPath();
+      expect(writtenPath.replace(/\\/g, '/')).toContain(`.wmux${suffix}/daemon-auth-token`);
+      expect(fs.readFileSync(writtenPath, 'utf8').trim()).toBe(token);
+
+      // Isolation: the suffixed instance did NOT pollute the shared, unsuffixed
+      // production location (the old collision site).
+      expect(fs.existsSync(getLegacyDaemonAuthTokenPath())).toBe(false);
+    } finally {
+      if (saved.up === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = saved.up;
+      if (saved.home === undefined) delete process.env.HOME;
+      else process.env.HOME = saved.home;
+      if (saved.suf === undefined) delete process.env.WMUX_DATA_SUFFIX;
+      else process.env.WMUX_DATA_SUFFIX = saved.suf;
+      try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
   });
 
   it('should reject new connections past the per-second cap', async () => {

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -15,7 +15,11 @@ import type {
 } from '../shared/lanlink';
 import { FLUSH_DONE_MARKER } from '../daemon/SessionPipe';
 import { DAEMON_RPC_TIMEOUT_MS } from '../shared/timeouts';
-import { dataSuffix } from '../shared/constants';
+import {
+  dataSuffix,
+  getDaemonAuthTokenPath,
+  getLegacyDaemonAuthTokenPath,
+} from '../shared/constants';
 import { connectWithRetry, type ConnectAttemptResult } from './daemonConnectRetry';
 
 // RCA A2 — single source of truth in shared/timeouts.ts so the renderer's
@@ -742,15 +746,27 @@ export function getDaemonPipeName(): string {
   return path.join(os.homedir(), `.wmux-daemon${dataSuffix()}.sock`);
 }
 
-/** Read the daemon auth token from disk. Returns empty string if not found. */
+/**
+ * Read the daemon auth token from disk. Returns empty string if not found.
+ *
+ * Reads the suffix-aware path (getDaemonAuthTokenPath) first, then the legacy
+ * unsuffixed path as a migration fallback so a suffixed ('-dev'/dogfood)
+ * instance upgrading over a still-running older daemon can still authenticate
+ * — see getDaemonAuthTokenPath / getLegacyDaemonAuthTokenPath in
+ * shared/constants. MUST stay in lockstep with the daemon writer
+ * (DaemonPipeServer.getTokenPath) and the CLI reader
+ * (cli/client.resolveDaemonAuthToken): if they compute different paths, nothing
+ * authenticates.
+ */
 export function readDaemonAuthToken(): string {
-  const os = require('os');
-  const path = require('path');
   const fs = require('fs');
-  const tokenPath = path.join(os.homedir(), '.wmux', 'daemon-auth-token');
-  try {
-    return fs.readFileSync(tokenPath, 'utf8').trim();
-  } catch {
-    return '';
+  for (const tokenPath of [getDaemonAuthTokenPath(), getLegacyDaemonAuthTokenPath()]) {
+    try {
+      const token = fs.readFileSync(tokenPath, 'utf8').trim();
+      if (token) return token;
+    } catch {
+      // candidate absent/unreadable — try the next one
+    }
   }
+  return '';
 }

--- a/src/shared/__tests__/constants.test.ts
+++ b/src/shared/__tests__/constants.test.ts
@@ -6,6 +6,8 @@ import {
   getWmuxHomeDir,
   getPidMapDir,
   getTcpPortPath,
+  getDaemonAuthTokenPath,
+  getLegacyDaemonAuthTokenPath,
 } from '../constants';
 
 // WMUX_DATA_SUFFIX 기반 인스턴스 격리. dev 빌드와 packaged 빌드(또는 다른
@@ -52,5 +54,37 @@ describe('dataSuffix 인스턴스 격리', () => {
     expect(getPipeName()).not.toBe(packagedPipe);
     expect(getWmuxHomeDir()).not.toBe(packagedHome);
     expect(getAuthTokenPath()).not.toBe(packagedToken);
+  });
+});
+
+// The daemon control-pipe auth token. Unlike the main token (a
+// ~/.wmux${suffix}-auth-token FILE) this lives INSIDE the ~/.wmux dir, so the
+// suffix rides on the DIRECTORY. The daemon WRITES it, the launcher + CLI READ
+// it — all three route through getDaemonAuthTokenPath so they cannot drift.
+describe('daemon auth token path (suffix-aware, 3-way lockstep)', () => {
+  const orig = process.env.WMUX_DATA_SUFFIX;
+  afterEach(() => {
+    if (orig === undefined) delete process.env.WMUX_DATA_SUFFIX;
+    else process.env.WMUX_DATA_SUFFIX = orig;
+  });
+
+  it('default (no suffix) is byte-identical to the legacy path — no stranding on upgrade', () => {
+    delete process.env.WMUX_DATA_SUFFIX;
+    expect(getDaemonAuthTokenPath()).toBe(getLegacyDaemonAuthTokenPath());
+    expect(getDaemonAuthTokenPath()).toMatch(/\.wmux[\\/]daemon-auth-token$/);
+  });
+
+  it('lives inside the suffix-aware home dir (co-located with config.json / daemon pipe)', () => {
+    delete process.env.WMUX_DATA_SUFFIX;
+    expect(getDaemonAuthTokenPath()).toBe(`${getWmuxHomeDir()}/daemon-auth-token`);
+  });
+
+  it('a suffix isolates the token from production; the legacy fallback stays unsuffixed', () => {
+    process.env.WMUX_DATA_SUFFIX = '-dev';
+    expect(getDaemonAuthTokenPath()).toMatch(/\.wmux-dev[\\/]daemon-auth-token$/);
+    // Isolation: a suffixed instance must NOT resolve to the shared prod file.
+    expect(getDaemonAuthTokenPath()).not.toBe(getLegacyDaemonAuthTokenPath());
+    expect(getLegacyDaemonAuthTokenPath()).toMatch(/\.wmux[\\/]daemon-auth-token$/);
+    expect(getLegacyDaemonAuthTokenPath()).not.toContain('.wmux-dev');
   });
 });

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -294,6 +294,43 @@ export function getWmuxHomeDir(): string {
   return `${home}/.wmux${dataSuffix()}`;
 }
 
+// Daemon control-pipe auth token. Unlike the main-pipe token (getAuthTokenPath,
+// a `~/.wmux${suffix}-auth-token` FILE), the daemon token has ALWAYS lived
+// INSIDE the ~/.wmux directory next to config.json — so we make the *directory*
+// suffix-aware (getWmuxHomeDir) rather than the filename. This mirrors the
+// already-suffix-aware daemon control pipe (`wmux-daemon${suffix}-user`): a dev
+// / dogfood instance ('-dev') gets its own `~/.wmux-dev/daemon-auth-token`
+// instead of colliding with production's token on the shared `~/.wmux/` file
+// (concurrent dev+packaged daemons run on different pipes but historically wrote
+// the SAME token file — a cold-start race or rotateToken could then brick one
+// instance's auth). Crucially, with the default empty suffix the path resolves
+// to exactly `~/.wmux/daemon-auth-token` — byte-identical to older versions, so
+// existing installs are never stranded.
+//
+// THREE-SIDED LOCKSTEP — this is the single source of truth. The daemon WRITES
+// here (DaemonPipeServer.getTokenPath → loadOrCreateToken/rotateToken); the
+// launcher (main/DaemonClient.readDaemonAuthToken) and the CLI
+// (cli/client.resolveDaemonAuthToken) READ it. All three MUST call this helper
+// — if they compute different paths, nothing authenticates and wmux is bricked.
+export function getDaemonAuthTokenPath(): string {
+  return `${getWmuxHomeDir()}/daemon-auth-token`;
+}
+
+// Legacy (pre-suffix) daemon token location: the ALWAYS-unsuffixed
+// `~/.wmux/daemon-auth-token`, exactly as older wmux versions wrote it. READERS
+// (launcher, CLI) fall back to this when the suffix-aware path is absent, so a
+// suffixed instance upgrading OVER a still-running older daemon (which wrote
+// here) can still authenticate during the transition. It is a read-only
+// migration shim: the daemon WRITER never consults it (that would re-establish
+// the cross-instance collision for the suffixed case). With the default empty
+// suffix getDaemonAuthTokenPath() resolves to this exact string, so the fallback
+// is a no-op for production. (Same USERPROFILE/HOME base as getWmuxHomeDir,
+// which equals os.homedir() — where older versions wrote — on Windows.)
+export function getLegacyDaemonAuthTokenPath(): string {
+  const home = process.env.USERPROFILE || process.env.HOME || '';
+  return `${home}/.wmux/daemon-auth-token`;
+}
+
 // Plugin trust database — see `docs/api/mcp-plugin-spec.md`. Written by main
 // process via `PluginTrustStore` (atomicWriteJSON). NOT a secret — it stores
 // declared identities and user-issued trust grants, not credentials.

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -312,6 +312,17 @@ export function getWmuxHomeDir(): string {
 // launcher (main/DaemonClient.readDaemonAuthToken) and the CLI
 // (cli/client.resolveDaemonAuthToken) READ it. All three MUST call this helper
 // — if they compute different paths, nothing authenticates and wmux is bricked.
+//
+// Home source (GLM review): getWmuxHomeDir() uses USERPROFILE||HOME, like every
+// other wmux path helper (getAuthTokenPath / getTcpPortPath). Before this change
+// the daemon token used os.homedir() — the ONE outlier. Aligning it with
+// USERPROFILE||HOME is precisely what keeps the WRITER in lockstep with the
+// launcher+CLI READERS (which resolve through this helper). The daemon's OTHER
+// ~/.wmux files (config.json, daemon-pipe) still resolve via src/daemon/config.ts
+// getWmuxDir → os.homedir(); on every real platform os.homedir() === USERPROFILE
+// (Windows) / HOME (*nix) so token and config co-locate, but unifying getWmuxDir
+// onto getWmuxHomeDir so the whole daemon shares ONE home source is a separate
+// follow-up (it also touches config/pipe paths, out of scope for the auth fix).
 export function getDaemonAuthTokenPath(): string {
   return `${getWmuxHomeDir()}/daemon-auth-token`;
 }


### PR DESCRIPTION
## Why

The daemon control pipe is already suffix-aware (`wmux-daemon${suffix}-user`), so a dev/dogfood build (`WMUX_DATA_SUFFIX=-dev`, `~/.wmux-dev/`) and a packaged build run **concurrently on different pipes** — that isolation is by design. But the daemon **auth token** path was the one outlier: three sites hardcoded the shared `~/.wmux/daemon-auth-token`:

- writer — `DaemonPipeServer.getTokenPath` (`loadOrCreateToken`/`rotateToken`)
- reader — `main/DaemonClient.readDaemonAuthToken` (launcher)
- reader — `cli/client.resolveDaemonAuthToken` (CLI)

So two daemons collided on one credential file: a cold-start race or a `rotateToken()` could desync one instance's in-memory token from the file → its launcher/CLI read the wrong token → `unauthorized` → bricked; and a `-dev` daemon wrote its token into production `~/.wmux/` instead of `~/.wmux-dev/`, violating the isolation. This matches a dogfood flag noted alongside the Channels v2 work.

## What changed (one shared helper, 3-way lockstep)

- **`src/shared/constants.ts`** — new `getDaemonAuthTokenPath()` = `${getWmuxHomeDir()}/daemon-auth-token` (the suffix rides on the **directory**, mirroring the pipe). With the default empty suffix it resolves to exactly `~/.wmux/daemon-auth-token` — **byte-identical to older versions, so no existing install is stranded**. Plus a read-only `getLegacyDaemonAuthTokenPath()` (always-unsuffixed) migration shim.
- **`DaemonPipeServer.getTokenPath`** (writer) delegates to the helper; never uses the legacy fallback (a suffixed instance must mint its OWN token, not adopt production's).
- **`DaemonClient.readDaemonAuthToken`** + **`cli/client.resolveDaemonAuthToken`** (readers) read the suffix-aware path first, then the legacy path — so a suffixed instance upgrading over a still-running older daemon still authenticates during the transition. Lockstep doc-comments updated.

Design choice: made the **directory** suffix-aware (via `getWmuxHomeDir`) rather than mirroring the main-token's home-level filename, so the production path is unchanged and no migration is needed. `getWmuxHomeDir()` uses `USERPROFILE||HOME` like every other wmux path helper, which is what keeps the writer in lockstep with the readers.

## Verification

- `tsc` clean (root / daemon / cli); new unit tests in `constants.test.ts`, `DaemonPipeServer.test.ts`, `client.daemonPipe.test.ts` (default===legacy backward-compat, suffix isolates, reader suffix-first-then-fallback, writer writes the suffixed path without touching prod).
- New E2E probe `scripts/daemon-token-path-probe.mjs` against the **real bundled daemon** in isolated homes (production `~/.wmux` untouched), **6/6**: suffixed daemon writes to and does not pollute; a reader resolving the path from the daemon's own env lands on exactly the written path (writer↔reader agreement) and authenticates; wrong token rejected; and a pre-existing unsuffixed token is still adopted (no stranding).

## Notes

Follow-up: unify `src/daemon/config.ts` `getWmuxDir` (still `os.homedir()`) onto `getWmuxHomeDir` so the whole daemon shares one home source (config.json / daemon-pipe / token). Equal on every real platform today; only an abnormal home (USERPROFILE unset on Windows / HOME unset on *nix) would diverge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daemon authentication now supports suffix-aware token locations, helping isolated environments avoid token collisions.
  * Older token locations remain supported as a fallback for compatibility.

* **Bug Fixes**
  * Improved token lookup so the app can read the correct daemon auth token in both suffix and non-suffix setups.
  * Windows pipe handling now better distinguishes live daemons from recoverable stale ones, reducing incorrect fallback behavior.

* **Tests**
  * Expanded coverage for token-path resolution and daemon auth behavior across suffix-aware and legacy scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->