### PR TITLE
fix(terminal): stop xterm's native paste from racing wmux's Cmd+V on macOS

### DIFF
--- a/src/renderer/hooks/__tests__/useTerminal.nativePasteBlock.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.nativePasteBlock.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * 소스 레벨 회귀 잠금 + DOM 메커니즘 검증.
+ *
+ * wmux는 Menu.setApplicationMenu()를 호출하지 않아 Electron 기본 메뉴가 깔리고,
+ * macOS에서는 Cmd+V가 NSMenu key equivalent로 처리되어 keydown의 preventDefault()로
+ * 막을 수 없다. xterm.js는 terminal.element/textarea에 자기만의 네이티브 'paste'
+ * 리스너를 직접 붙여두므로, 이 네이티브 paste가 wmux의 커스텀 비동기 IPC paste
+ * 경로(pastePtyChunked)와 동시에 pty에 써서 붙여넣기 앞부분이 유실되는 레이스가
+ * 생긴다(Windows는 단축키가 DOM keydown 흐름에 통합돼 있어 재현되지 않는다).
+ *
+ * 첫 버전은 native paste를 무조건 차단했는데, 팀 리뷰(Claude 패스)가 진짜 회귀를
+ * 잡았다: 메뉴바 Edit>Paste를 마우스로 클릭하거나 VoiceOver/UI 자동화가 keydown 없이
+ * 합성 paste 이벤트만 보내는 경로는 wmux의 keydown 핸들러가 전혀 안 돌기 때문에 xterm
+ * 자체 파이프라인이 유일한 처리 경로인데, 무조건 차단하면 그 경로가 에러도 토스트도
+ * 없이 조용히 무동작해진다. 그래서 Cmd+V/Ctrl+V/Ctrl+Shift+V 핸들러가 lastPasteKeydownAt
+ * 타임스탬프를 찍고, blockNativePaste는 그 직후(NATIVE_PASTE_RACE_WINDOW_MS 이내)에만
+ * "레이스 중"으로 보고 차단한다 — 그 밖의 native paste는 그대로 흘려보내 xterm 자체
+ * 처리에 맡긴다.
+ *
+ * 실제 xterm Terminal + Electron 네이티브 메뉴 액셀러레이터는 jsdom으로 재현할 수
+ * 없으므로, (1) 소스 레벨로 타임스탬프 찍기/윈도우 체크가 제자리에 있는지, (2) 그
+ * 윈도우 판정 로직 자체(최근 keydown → 차단, 오래됨/없음 → 통과)는 순수 jsdom 이벤트로
+ * 검증한다.
+ */
+
+const SRC = readFileSync(
+  path.resolve(process.cwd(), 'src/renderer/hooks/useTerminal.ts'),
+  'utf8',
+);
+
+describe('useTerminal blocks xterm native paste only when it races a keydown paste (source-level lock)', () => {
+  const openIdx = SRC.indexOf('terminal.open(container)');
+  const blockerIdx = SRC.indexOf('blockNativePaste');
+  const cleanupIdx = SRC.lastIndexOf('blockNativePaste');
+  const stampIndices = [...SRC.matchAll(/lastPasteKeydownAt = Date\.now\(\)/g)].map((m) => m.index ?? -1);
+
+  it('locates terminal.open(container) and the blocker', () => {
+    expect(openIdx).toBeGreaterThan(-1);
+    expect(blockerIdx).toBeGreaterThan(-1);
+  });
+
+  it('registers the blocker on container AFTER terminal.open, in the capture phase', () => {
+    expect(blockerIdx).toBeGreaterThan(openIdx);
+    expect(SRC).toMatch(/container\.addEventListener\('paste', blockNativePaste, true\)/);
+  });
+
+  it('only blocks within the race window — does not unconditionally swallow every native paste', () => {
+    expect(SRC).toMatch(
+      /if\s*\(\s*Date\.now\(\)\s*-\s*lastPasteKeydownAt\s*>\s*NATIVE_PASTE_RACE_WINDOW_MS\s*\)\s*return;/,
+    );
+  });
+
+  it('stamps lastPasteKeydownAt in all three keydown paste handlers (Cmd+V, Ctrl+V, Ctrl+Shift+V)', () => {
+    // 3곳: isMac Cmd+V, Ctrl+V, Ctrl+Shift+V. 하나라도 빠지면 그 경로는 native paste와
+    // 여전히 레이스한다.
+    expect(stampIndices.length).toBe(3);
+    stampIndices.forEach((idx) => expect(idx).toBeGreaterThan(blockerIdx));
+  });
+
+  it('disposes the blocker on unmount with the same capture flag', () => {
+    expect(cleanupIdx).toBeGreaterThan(blockerIdx);
+    expect(SRC).toMatch(/container\.removeEventListener\('paste', blockNativePaste, true\)/);
+  });
+});
+
+describe('windowed capture-phase blocker (DOM mechanism, mirrors the deployed logic)', () => {
+  const NATIVE_PASTE_RACE_WINDOW_MS = 300;
+
+  function setUp() {
+    const container = document.createElement('div');
+    const child = document.createElement('textarea'); // xterm의 hidden textarea 역할
+    container.appendChild(child);
+    document.body.appendChild(container);
+
+    const childListener = vi.fn(); // xterm 자체 paste 핸들러 역할
+    child.addEventListener('paste', childListener);
+
+    let lastPasteKeydownAt = 0;
+    const blockNativePaste = (e: Event): void => {
+      if (Date.now() - lastPasteKeydownAt > NATIVE_PASTE_RACE_WINDOW_MS) return;
+      e.preventDefault();
+      e.stopPropagation();
+    };
+    container.addEventListener('paste', blockNativePaste, true);
+
+    return {
+      container,
+      childListener,
+      markKeydown: () => { lastPasteKeydownAt = Date.now(); },
+      dispatchPaste: () => child.dispatchEvent(new Event('paste', { bubbles: true, cancelable: true })),
+      cleanup: () => document.body.removeChild(container),
+    };
+  }
+
+  it('blocks a native paste that follows a keydown-triggered paste within the race window', () => {
+    const { markKeydown, dispatchPaste, childListener, cleanup } = setUp();
+
+    markKeydown(); // Cmd+V keydown handler가 방금 실행됨을 시뮬레이션
+    dispatchPaste(); // NSMenu key equivalent가 거의 동시에 쏘는 native paste
+
+    expect(childListener).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it('lets a standalone native paste through when no keydown just fired (menu click / VoiceOver / automation)', () => {
+    const { dispatchPaste, childListener, cleanup } = setUp();
+
+    // markKeydown()을 아예 안 부름 — 메뉴바 마우스 클릭이나 UI 자동화처럼 keydown이
+    // 없는 경로. 팀 리뷰가 잡은 회귀: 예전 무조건-차단 버전은 이 케이스도 죽였다.
+    dispatchPaste();
+
+    expect(childListener).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+
+  it('lets a native paste through once the race window has elapsed since the last keydown', () => {
+    const { markKeydown, dispatchPaste, childListener, cleanup } = setUp();
+
+    markKeydown();
+    vi.useFakeTimers();
+    try {
+      // advanceTimersByTime 이후에도 fake clock 상태에서 dispatch해야 한다 —
+      // useRealTimers()를 먼저 부르면 진짜 시계로 되돌아가 경과 시간이 사라진다.
+      vi.advanceTimersByTime(NATIVE_PASTE_RACE_WINDOW_MS + 1);
+      dispatchPaste();
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(childListener).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+});

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -383,6 +383,30 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     terminal.unicode.activeVersion = '11';
     terminal.open(container);
 
+    // xterm 자체 네이티브 'paste' 리스너(terminal.element/textarea에 직접 붙어있음)가
+    // 아래 Cmd+V/Ctrl+V/Ctrl+Shift+V 핸들러와 겹칠 때만 캡처 단계에서 차단한다. wmux는
+    // Menu.setApplicationMenu()를 호출하지 않아 Electron 기본 메뉴가 깔리는데, macOS는
+    // Cmd+V가 NSMenu key equivalent로 처리되어 keydown의 preventDefault()로도 못 막는다
+    // — 그 결과 xterm 자체 paste 경로와 아래 커스텀 비동기 IPC 경로가 같은 pty에 동시에
+    // 써서 붙여넣기 앞부분이 유실/손상되는 레이스가 생긴다(createWindow.ts가 frame/
+    // autoHideMenuBar를 설정하지 않아 메뉴바는 Windows/Linux에서도 노출되므로 이론상
+    // 플랫폼 무관하게 방어한다). 단, 무조건 차단하면 안 된다 — 메뉴바 Edit>Paste를
+    // 마우스로 클릭하거나 VoiceOver/UI 자동화가 keydown 없이 합성 paste 이벤트만 보내는
+    // 경로는 아래 keydown 핸들러가 전혀 안 돌기 때문에 xterm 자체 파이프라인이 유일한
+    // 처리 경로다(팀 리뷰 발견: 무조건 차단하면 그 경로가 조용히 무동작해진다).
+    // 그래서 keydown 핸들러가 막 시작한 직후(NATIVE_PASTE_RACE_WINDOW_MS 이내)에만
+    // "레이스 중"으로 보고 차단하고, 그 밖의 native paste는 그대로 흘려보내 xterm 자체
+    // 처리에 맡긴다. 윈도우 크기는 이 파일의 기존 RIGHT_CLICK_PASTE_SUPPRESS_MS와 동일한
+    // 관례(최근 이벤트 판별용 300ms)를 따른다.
+    let lastPasteKeydownAt = 0;
+    const NATIVE_PASTE_RACE_WINDOW_MS = 300;
+    const blockNativePaste = (e: Event): void => {
+      if (Date.now() - lastPasteKeydownAt > NATIVE_PASTE_RACE_WINDOW_MS) return;
+      e.preventDefault();
+      e.stopPropagation();
+    };
+    container.addEventListener('paste', blockNativePaste, true);
+
     // Issue #167: keep the hidden IME textarea empty while idle. xterm only
     // clears it on blur, so IME-committed text accumulates there after it was
     // already sent to the PTY, and external field-replacing injectors (voice
@@ -707,6 +731,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       }
       if (isMac && e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey && (e.key === 'v' || e.code === 'KeyV')) {
         e.preventDefault();
+        lastPasteKeydownAt = Date.now(); // blockNativePaste 위: 곧 같이 뜰 native paste를 레이스로 잡는다
         void (async () => {
           const text = await window.clipboardAPI.readText();
           if (text) {
@@ -747,6 +772,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // so xterm doesn't also paste via browser's native paste event)
       if (e.ctrlKey && !e.shiftKey && (e.key === 'v' || e.code === 'KeyV')) {
         e.preventDefault();
+        lastPasteKeydownAt = Date.now(); // blockNativePaste 위 참고
         void (async () => {
           // Try text first
           const text = await window.clipboardAPI.readText();
@@ -788,6 +814,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // Ctrl+Shift+V: paste fallback
       if (e.ctrlKey && e.shiftKey && (e.key === 'V' || e.code === 'KeyV')) {
         e.preventDefault();
+        lastPasteKeydownAt = Date.now(); // blockNativePaste 위 참고
         void (async () => {
           const text = await window.clipboardAPI.readText();
           if (text) {
@@ -1276,6 +1303,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
 
     return () => {
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
+      container.removeEventListener('paste', blockNativePaste, true);
       terminal.textarea?.removeEventListener('focus', onTextareaFocus);
       terminal.textarea?.removeEventListener('keydown', onWatchdogKeyDown);
       glyphRepaint.dispose();


### PR DESCRIPTION
## Summary
- wmux는 `Menu.setApplicationMenu()`를 호출하지 않아 Electron 기본 메뉴가 깔리고, macOS에서 Cmd+V는 NSMenu key equivalent로 처리되어 DOM `keydown`의 `preventDefault()`로 막을 수 없음 — xterm.js 자체 네이티브 `'paste'` 리스너와 wmux의 커스텀 비동기 IPC paste 경로가 동시에 pty에 써서 긴 경로 붙여넣기 시 앞부분이 유실/손상되는 레이스가 있었음
- 터미널 컨테이너에 capture-phase `'paste'` 차단기를 추가하되, Cmd+V/Ctrl+V/Ctrl+Shift+V keydown 직후 300ms(레이스 윈도우) 이내에만 차단 — 무조건 차단하면 메뉴바 Edit>Paste 마우스 클릭이나 VoiceOver/UI 자동화처럼 keydown 없는 붙여넣기 경로가 조용히 무동작해지는 회귀가 생기기 때문 (팀 리뷰 Claude 패스에서 발견, `createWindow.ts`에 `frame`/`autoHideMenuBar` 미설정으로 메뉴바가 전 플랫폼에 노출됨도 함께 확인)
- 회귀 테스트 8개 추가 (소스 레벨 lock + jsdom capture-phase 이벤트 메커니즘)

## Test plan
- [x] `tsc --noEmit` 통과
- [x] `eslint` 신규 이슈 없음
- [x] 전체 vitest 스위트 통과 (신규 8개 포함)
- [ ] 실기기 macOS에서 wmux 재시작 후 (1) Cmd+V 긴 경로 붙여넣기, (2) 메뉴바 Edit > Paste 마우스 클릭 두 시나리오 수동 확인 — 코드 리뷰 근거는 확정적이나 Electron 네이티브 메뉴 액셀러레이터는 jsdom으로 재현 불가

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWKm5QJewgZR4zMcBDNgdY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paste reliability in the terminal by preventing a race that could drop the start of pasted content.
  * Native paste is now blocked only briefly after using the app’s paste shortcuts, while normal paste behavior continues to work otherwise.
  * Added coverage for both the shortcut-driven behavior and the browser-level paste flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->