### PR TITLE
fix(clipboard): resolve full POSIX path when pasting Finder-copied files on macOS

### DIFF
--- a/src/main/ipc/__tests__/clipboard.handler.test.ts
+++ b/src/main/ipc/__tests__/clipboard.handler.test.ts
@@ -4,6 +4,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
  * clipboard.handler — verifies that CLIPBOARD_WRITE surfaces failures
  * (invalid type, oversize, write failure) as thrown errors so the renderer
  * can react instead of silently showing "copied" toasts.
+ *
+ * CLIPBOARD_READ — macOS에서 Finder 파일 복사(text/uri-list 존재) 감지 시
+ * osascript로 절대 POSIX 경로를 해석하고, 실패하면 readText()로 폴백하며,
+ * 게이트를 통과하지 못하면(타 OS·일반 텍스트) 스폰 자체가 없음을 검증한다.
  */
 
 // ── Module mocks (hoisted; cannot reference outer test variables) ──────────
@@ -12,6 +16,7 @@ vi.mock('electron', () => {
   const handlers = new Map<string, (...args: unknown[]) => unknown>();
   const writeText = vi.fn();
   const readText = vi.fn(() => 'hello');
+  const availableFormats = vi.fn(() => [] as string[]);
   const ipcMain = {
     handle: vi.fn((channel: string, fn: (...args: unknown[]) => unknown) => {
       handlers.set(channel, fn);
@@ -26,12 +31,14 @@ vi.mock('electron', () => {
       writeText,
       readText,
       readImage: vi.fn(() => ({ isEmpty: () => true, toPNG: () => Buffer.from([]) })),
-      availableFormats: vi.fn(() => [] as string[]),
+      availableFormats,
     },
     app: { getPath: vi.fn(() => '/tmp') },
     // Expose registered handlers + clipboard.writeText for tests
     __handlers: handlers,
     __writeText: writeText,
+    __readText: readText,
+    __availableFormats: availableFormats,
   };
 });
 
@@ -40,13 +47,42 @@ vi.mock('fs', () => ({
   writeFileSync: vi.fn(),
 }));
 
+// osascript 셸아웃 경계 모킹 — 실제 프로세스를 스폰하지 않고
+// 성공/실패/빈 출력 시나리오를 시뮬레이션한다.
+vi.mock('node:child_process', () => {
+  const execFile = vi.fn();
+  return { execFile, default: { execFile } };
+});
+
 import * as electron from 'electron';
+import { execFile } from 'node:child_process';
 import { registerClipboardHandlers } from '../handlers/clipboard.handler';
 import { IPC } from '../../../shared/constants';
 
 // Pull the test fixtures back out of the mocked module
 const handlers = (electron as unknown as { __handlers: Map<string, (...a: unknown[]) => unknown> }).__handlers;
 const writeText = (electron as unknown as { __writeText: ReturnType<typeof vi.fn> }).__writeText;
+const readText = (electron as unknown as { __readText: ReturnType<typeof vi.fn> }).__readText;
+const availableFormats = (electron as unknown as { __availableFormats: ReturnType<typeof vi.fn> }).__availableFormats;
+const execFileMock = execFile as unknown as ReturnType<typeof vi.fn>;
+
+// execFile(file, args, opts, cb) 콜백 시그니처
+type ExecFileCb = (err: Error | null, stdout: string, stderr: string) => void;
+
+// osascript가 stdout으로 주어진 문자열을 내놓는 성공 케이스를 시뮬레이션
+function mockResolverStdout(stdout: string): void {
+  execFileMock.mockImplementation(
+    (_file: unknown, _args: unknown, _opts: unknown, cb: unknown) => {
+      (cb as ExecFileCb)(null, stdout, '');
+    }
+  );
+}
+
+// process.platform을 테스트별로 바꾸고 afterEach에서 원복한다
+const originalPlatform = process.platform;
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+}
 
 function getHandler(channel: string): (...args: unknown[]) => unknown {
   const fn = handlers.get(channel);
@@ -59,11 +95,17 @@ let stderrSpy: ReturnType<typeof vi.spyOn>;
 beforeEach(() => {
   handlers.clear();
   writeText.mockReset();
+  readText.mockReset();
+  readText.mockReturnValue('hello');
+  availableFormats.mockReset();
+  availableFormats.mockReturnValue([] as string[]);
+  execFileMock.mockReset();
   stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   registerClipboardHandlers();
 });
 
 afterEach(() => {
+  Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
   stderrSpy.mockRestore();
 });
 
@@ -117,5 +159,84 @@ describe('CLIPBOARD_WRITE — error surfacing', () => {
   it('CLIPBOARD_READ still works (sanity)', async () => {
     const handler = getHandler(IPC.CLIPBOARD_READ);
     await expect(handler({} as never)).resolves.toBe('hello');
+  });
+});
+
+describe('CLIPBOARD_READ — macOS Finder file-copy path resolution', () => {
+  it('darwin + text/uri-list + resolver success → returns absolute POSIX path (newline trimmed)', async () => {
+    setPlatform('darwin');
+    availableFormats.mockReturnValue(['text/plain', 'text/uri-list']);
+    mockResolverStdout('/Users/foo/project/out/wmux-darwin-arm64/\n');
+
+    const handler = getHandler(IPC.CLIPBOARD_READ);
+    // 디렉터리 trailing slash는 macOS가 준 그대로 유지된다
+    await expect(handler({} as never)).resolves.toBe('/Users/foo/project/out/wmux-darwin-arm64/');
+    // osascript는 절대경로 + 셸 인터폴레이션 없는 execFile로만 호출된다
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock.mock.calls[0][0]).toBe('/usr/bin/osascript');
+    // 경로가 해석됐으므로 이름만 주는 readText는 쓰이지 않는다
+    expect(readText).not.toHaveBeenCalled();
+  });
+
+  it('quotes the resolved path when it contains spaces (readImage convention)', async () => {
+    setPlatform('darwin');
+    availableFormats.mockReturnValue(['text/uri-list']);
+    mockResolverStdout('/Users/foo/My Folder/file.txt\n');
+
+    const handler = getHandler(IPC.CLIPBOARD_READ);
+    await expect(handler({} as never)).resolves.toBe('"/Users/foo/My Folder/file.txt"');
+  });
+
+  it('falls back to readText when the resolver fails (non-zero exit / timeout)', async () => {
+    setPlatform('darwin');
+    availableFormats.mockReturnValue(['text/uri-list']);
+    execFileMock.mockImplementation(
+      (_file: unknown, _args: unknown, _opts: unknown, cb: unknown) => {
+        (cb as ExecFileCb)(new Error('osascript timed out'), '', '');
+      }
+    );
+
+    const handler = getHandler(IPC.CLIPBOARD_READ);
+    await expect(handler({} as never)).resolves.toBe('hello');
+    expect(readText).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to readText when output is empty (browser URL exposes uri-list but no «class furl»)', async () => {
+    setPlatform('darwin');
+    availableFormats.mockReturnValue(['text/uri-list']);
+    // furl 가드 스크립트는 비파일 클립보드(브라우저 URL 복사 등)에서 빈 문자열을 낸다
+    mockResolverStdout('\n');
+
+    const handler = getHandler(IPC.CLIPBOARD_READ);
+    await expect(handler({} as never)).resolves.toBe('hello');
+    expect(readText).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to readText when output is not an absolute path', async () => {
+    setPlatform('darwin');
+    availableFormats.mockReturnValue(['text/uri-list']);
+    mockResolverStdout('garbage-not-a-path\n');
+
+    const handler = getHandler(IPC.CLIPBOARD_READ);
+    await expect(handler({} as never)).resolves.toBe('hello');
+  });
+
+  it('non-darwin → readText untouched and resolver is never spawned', async () => {
+    setPlatform('linux');
+    // uri-list가 있어도 darwin 게이트가 먼저 컷한다
+    availableFormats.mockReturnValue(['text/uri-list']);
+
+    const handler = getHandler(IPC.CLIPBOARD_READ);
+    await expect(handler({} as never)).resolves.toBe('hello');
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('darwin without text/uri-list (plain text copy) → readText, no spawn', async () => {
+    setPlatform('darwin');
+    availableFormats.mockReturnValue(['text/plain']);
+
+    const handler = getHandler(IPC.CLIPBOARD_READ);
+    await expect(handler({} as never)).resolves.toBe('hello');
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 });

--- a/src/main/ipc/__tests__/clipboard.handler.test.ts
+++ b/src/main/ipc/__tests__/clipboard.handler.test.ts
@@ -178,13 +178,34 @@ describe('CLIPBOARD_READ — macOS Finder file-copy path resolution', () => {
     expect(readText).not.toHaveBeenCalled();
   });
 
-  it('quotes the resolved path when it contains spaces (readImage convention)', async () => {
+  it('single-quotes the resolved path when it contains spaces', async () => {
     setPlatform('darwin');
     availableFormats.mockReturnValue(['text/uri-list']);
     mockResolverStdout('/Users/foo/My Folder/file.txt\n');
 
     const handler = getHandler(IPC.CLIPBOARD_READ);
-    await expect(handler({} as never)).resolves.toBe('"/Users/foo/My Folder/file.txt"');
+    await expect(handler({} as never)).resolves.toBe("'/Users/foo/My Folder/file.txt'");
+  });
+
+  it('neutralizes shell metacharacters in filenames ($, backtick, ", ;) via single-quoting', async () => {
+    // Finder 파일명은 사용자 통제 밖 입력이 셸로 들어가는 경계 — 큰따옴표는 $·백틱을
+    // 여전히 해석하므로 부족하다(CodeRabbit 지적). 단일따옴표 안은 전부 리터럴.
+    setPlatform('darwin');
+    availableFormats.mockReturnValue(['text/uri-list']);
+    mockResolverStdout('/Users/foo/we$ird `name";dir\n');
+
+    const handler = getHandler(IPC.CLIPBOARD_READ);
+    await expect(handler({} as never)).resolves.toBe(`'/Users/foo/we$ird \`name";dir'`);
+  });
+
+  it("escapes embedded single quotes with the POSIX '\\'' idiom", async () => {
+    setPlatform('darwin');
+    availableFormats.mockReturnValue(['text/uri-list']);
+    mockResolverStdout("/Users/foo/it's here\n");
+
+    const handler = getHandler(IPC.CLIPBOARD_READ);
+    // '...'가 '에서 닫히고 \' 리터럴을 잇고 다시 '로 열린다: 'it'\''s here'
+    await expect(handler({} as never)).resolves.toBe(`'/Users/foo/it'\\''s here'`);
   });
 
   it('falls back to readText when the resolver fails (non-zero exit / timeout)', async () => {

--- a/src/main/ipc/handlers/clipboard.handler.ts
+++ b/src/main/ipc/handlers/clipboard.handler.ts
@@ -1,6 +1,7 @@
 import { ipcMain, clipboard, app } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
+import { execFile } from 'node:child_process';
 import { IPC } from '../../../shared/constants';
 import { wrapHandler } from '../wrapHandler';
 
@@ -26,6 +27,58 @@ function cleanupStalePasteFiles(): void {
       if (fs.statSync(filePath).mtimeMs < cutoff) fs.unlinkSync(filePath);
     } catch { /* file vanished or locked; skip */ }
   }
+}
+
+// macOS Finder에서 파일/폴더를 Cmd+C 하면 clipboard.readText()는 "이름"만 준다.
+// 전체 절대경로는 public.file-url 슬롯의 불투명한 file:///.file/id= 참조에만
+// 들어있는데, 이 참조는 순수 JS(fs.realpathSync)나 셸 stat으로 해석되지 않는다
+// (ENOTDIR). AppleScript의 «class furl» 강제 변환만이 실제 POSIX 경로를 돌려주므로
+// osascript로 셸아웃한다. 셸 인터폴레이션이 없도록 exec가 아닌 execFile를 쓰고,
+// 명령은 사용자 입력을 받지 않는다(고정 스크립트).
+const OSASCRIPT_PATH = '/usr/bin/osascript';
+const OSASCRIPT_TIMEOUT_MS = 2000;
+
+/**
+ * 클립보드에 있는 Finder 파일/폴더의 절대 POSIX 경로를 해석한다.
+ *
+ * clipboard info에 «class furl»가 실제로 존재할 때만 경로를 반환한다. 브라우저에서
+ * URL을 복사하면 text/uri-list가 노출될 수 있는데, 그 경우 furl이 없어 빈 문자열이
+ * 나오고 → 호출부가 readText() 폴백으로 떨어진다. (이 furl 가드가 없으면 URL이
+ * "/https/::example.com:.." 같은 가비지 경로로 강제 변환되어 붙는다 — 라이브 프로브로 확인.)
+ *
+ * 한계: 여러 파일을 한꺼번에 복사하면 «class furl» 강제 변환은 "첫 번째" 항목만
+ * 돌려준다(단일 항목 지원이 요구사항, 다중 선택은 범위 밖).
+ *
+ * 실패·타임아웃·비파일·빈 출력은 전부 null로 반환해 붙여넣기를 절대 악화시키지 않는다.
+ */
+function resolveFinderFilePath(): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(
+      OSASCRIPT_PATH,
+      [
+        '-e', 'set out to ""',
+        '-e', 'repeat with t in (clipboard info)',
+        '-e', 'if (first item of t) is «class furl» then',
+        '-e', 'set out to POSIX path of (the clipboard as «class furl»)',
+        '-e', 'exit repeat',
+        '-e', 'end if',
+        '-e', 'end repeat',
+        '-e', 'return out',
+      ],
+      { timeout: OSASCRIPT_TIMEOUT_MS, encoding: 'utf8' },
+      (err, stdout) => {
+        if (err) {
+          resolve(null);
+          return;
+        }
+        // osascript는 결과 끝에 개행을 붙인다 — 그것만 제거하고 경로는 그대로 둔다
+        // (디렉터리의 뒤쪽 '/'는 macOS가 준 그대로 유지; cd에 문제없다).
+        const filePath = (typeof stdout === 'string' ? stdout : '').replace(/\r?\n+$/, '');
+        // 절대경로가 아니면(빈 값, 비파일 furl 결과 등) 신뢰하지 않고 폴백한다.
+        resolve(filePath.startsWith('/') ? filePath : null);
+      }
+    );
+  });
 }
 
 export function registerClipboardHandlers(): void {
@@ -58,7 +111,24 @@ export function registerClipboardHandlers(): void {
     }
   }));
 
-  ipcMain.handle(IPC.CLIPBOARD_READ, wrapHandler(IPC.CLIPBOARD_READ, (_event: Electron.IpcMainInvokeEvent) => {
+  ipcMain.handle(IPC.CLIPBOARD_READ, wrapHandler(IPC.CLIPBOARD_READ, async (_event: Electron.IpcMainInvokeEvent) => {
+    // 플랫폼 + 포맷 게이트: darwin이고 클립보드에 파일/폴더(text/uri-list)가 있을
+    // 때만 경로 해석을 시도한다. 그 외(일반 텍스트, 타 OS)는 기존과 완전히 동일하게
+    // readText()를 즉시 반환하므로 일반 붙여넣기의 지연·동작 변화는 0이다.
+    if (
+      process.platform === 'darwin' &&
+      clipboard.availableFormats().includes('text/uri-list')
+    ) {
+      const filePath = await resolveFinderFilePath();
+      if (filePath) {
+        // 이 값을 소비하는 렌더러 호출부는 전부 터미널 붙여넣기 사이트라 문자열을
+        // 그대로 pty에 쓴다(Terminal.tsx handlePaste, useTerminal.ts의 Cmd+V/
+        // Ctrl+V/Ctrl+Shift+V/우클릭). 기존 readImage 규약과 동일하게 공백이 있는
+        // 경로만 큰따옴표로 감싼다(cd "a b" 대응). 파일 해석 분기에서만 감싼다.
+        return filePath.includes(' ') ? `"${filePath}"` : filePath;
+      }
+      // 해석 실패(비파일 furl, 타임아웃, 빈 출력 등) → 아래 readText() 폴백.
+    }
     return clipboard.readText();
   }));
 

--- a/src/main/ipc/handlers/clipboard.handler.ts
+++ b/src/main/ipc/handlers/clipboard.handler.ts
@@ -38,6 +38,17 @@ function cleanupStalePasteFiles(): void {
 const OSASCRIPT_PATH = '/usr/bin/osascript';
 const OSASCRIPT_TIMEOUT_MS = 2000;
 
+// Finder 파일명은 사용자 통제 밖 입력이 셸(pty)로 들어가는 경계다. 공백만 큰따옴표로
+// 감싸는 방식은 부족하다 — 큰따옴표 안에서도 $·백틱은 셸이 해석하고, 이름에 " 자체가
+// 있으면 인용이 깨진다(CodeRabbit 지적). POSIX 단일따옴표는 내부의 모든 문자를
+// 리터럴로 만들므로(유일한 예외인 '는 '\''로 잇는다) 안전문자 외가 하나라도 있으면
+// 단일따옴표로 감싼다. macOS 한정 분기라 대상 셸은 POSIX 계열(zsh/bash/fish)뿐이다.
+const SAFE_PATH_RE = /^[A-Za-z0-9_\-./~+@%,:=]+$/;
+function quotePathForPty(p: string): string {
+  if (SAFE_PATH_RE.test(p)) return p;
+  return `'${p.replace(/'/g, `'\\''`)}'`;
+}
+
 /**
  * 클립보드에 있는 Finder 파일/폴더의 절대 POSIX 경로를 해석한다.
  *
@@ -123,9 +134,9 @@ export function registerClipboardHandlers(): void {
       if (filePath) {
         // 이 값을 소비하는 렌더러 호출부는 전부 터미널 붙여넣기 사이트라 문자열을
         // 그대로 pty에 쓴다(Terminal.tsx handlePaste, useTerminal.ts의 Cmd+V/
-        // Ctrl+V/Ctrl+Shift+V/우클릭). 기존 readImage 규약과 동일하게 공백이 있는
-        // 경로만 큰따옴표로 감싼다(cd "a b" 대응). 파일 해석 분기에서만 감싼다.
-        return filePath.includes(' ') ? `"${filePath}"` : filePath;
+        // Ctrl+V/Ctrl+Shift+V/우클릭). 파일 해석 분기에서만 인용하며, 방식은
+        // quotePathForPty 참고(공백뿐 아니라 $·백틱·" 등도 안전해야 한다).
+        return quotePathForPty(filePath);
       }
       // 해석 실패(비파일 furl, 타임아웃, 빈 출력 등) → 아래 readText() 폴백.
     }


### PR DESCRIPTION
## Summary
- macOS Finder에서 파일/폴더 Cmd+C → wmux 터미널 Cmd+V 시 전체 절대경로 대신 **이름만** 붙는 버그 수정 — `wmux-darwin-arm64` 같은 이름은 유효한 상대경로처럼 보여 `cd`가 조용히 오동작 (Terminal.app/iTerm2는 전체 경로를 붙임)
- 근본 원인(실측): Finder는 plain-text 슬롯에 이름만 넣고 전체 경로는 `public.file-url`의 불투명한 `file:///.file/id=` 참조에만 넣는데, Electron `clipboard.readText()`는 전자를 읽음. 이 참조는 순수 JS(`fs.realpathSync`)·셸 `stat`·Python 전부 해석 불가(ENOTDIR)이고 `clipboard.read('text/uri-list')`도 빈 문자열을 주는 dead end — AppleScript `«class furl»` 강제 변환만 실제 POSIX 경로를 돌려주므로 `/usr/bin/osascript` 셸아웃(execFile, 셸 인터폴레이션 없음, 2초 타임아웃)으로 해석
- 게이트: `darwin` + `availableFormats()`에 `text/uri-list` 존재 시에만 동작 → 일반 텍스트 붙여넣기는 전 플랫폼에서 지연·동작 변화 0. `clipboard info`에 furl이 실제 존재할 때만 경로를 채택하는 가드로 브라우저 URL 복사(uri-list는 있지만 furl 없음)가 `/https/::…` 가비지로 붙는 것 차단(라이브 프로브로 확인). 실패·타임아웃·빈 출력은 전부 기존 `readText()` 폴백
- 드래그앤드롭이 멀쩡했던 이유: 완전히 다른 API(`webUtils.getPathForFile`) 경로라 클립보드 모듈의 파일 참조 미지원과 무관
- 공백 포함 경로는 기존 readImage 규약과 동일하게 큰따옴표 처리 — `clipboardAPI.readText` 소비처 5곳 전부 터미널 pty 붙여넣기 사이트임을 확인
- 한계: 다중 파일 선택 복사는 첫 번째 항목만 해석됨(단일 항목이 요구사항, 코드 주석에 명시)
- 회귀 테스트 7개 추가 (성공+개행 트림/공백 인용/실패 폴백/빈 출력 폴백/비절대경로 폴백/타 OS 무스폰/uri-list 부재 무스폰)

## Test plan
- [x] `tsc --noEmit` 통과
- [x] `eslint` 신규 이슈 없음 (기존 `_event` 경고 3건은 베이스라인과 동일)
- [x] `vitest run src/main/ipc` 16파일 134개 전부 통과 (신규 7개 포함)
- [x] 라이브 osascript 프로브: 실제 파일/폴더/공백 포함 경로 해석 성공, 일반 텍스트·http URL은 빈 출력 → 폴백 확인 (Node execFile 경유 UTF-8 guillemet 전달도 검증)
- [x] 실기기 macOS에서 Finder에서 폴더 Cmd+C → wmux 터미널 Cmd+V → 전체 절대경로 확인 — 2026-07-03 사용자 실측 통과 (격리 테스트 인스턴스, cd로 실제 이동 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWKm5QJewgZR4zMcBDNgdY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clipboard reading now better recognizes Finder file and folder copies on macOS and can return the file path directly.
  * Paths with spaces are handled correctly.

* **Bug Fixes**
  * Improved clipboard fallbacks so normal text clipboard content still works when no file path can be resolved.
  * Added stronger handling for unsupported formats, empty results, and resolution failures to avoid incorrect clipboard output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
