### PR TITLE
v3.14.0 feat: cross-workspace mention delivery + terminal/zsh fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.0] — 2026-07-05
+
+### Added
+
+- **Channel mentions now reach agents in any workspace, not just the one you're looking at.** A mention addressed to a pane in a background workspace used to sit undelivered until you switched to that workspace. The renderer now polls the event stream across all local workspaces in a single request (union scope), so a cross-workspace mention lands on its target pane immediately and the agent answers without you having to switch.
+
+### Fixed
+
+- **Reattaching no longer floods a reused shell with cursor-position replies (CPR feedback storm).** On reattach the daemon replayed persisted scrollback verbatim and xterm re-executed the one-shot terminal queries (DSR/CPR, DA, DECRQM, OSC color, DCS) a prior TUI had emitted, each firing a live auto-reply into the fresh shell. A pane left running while detached could accumulate thousands; reattach answered them all at once, pinning zsh and the daemon near 100% CPU. Query sequences are now stripped from the replay before xterm sees them; live output is untouched.
+- **A mention to an idle background agent now delivers instead of hanging until an unrelated repaint.** An agent idle since its pane attached never re-emits a status pattern, so its status stayed unknown and the paste gate held it busy forever. Unknown status is now held only for a short grace window, then delivered, guarded so a genuinely running-but-quiet agent is never pasted mid-turn (an output-quiet check plus a hard hold ceiling).
+- **Splitting a pane no longer crashes zsh on macOS.** The zsh shell-integration prompt marker (OSC 133;B) was appended without a `%{...%}` zero-width guard, so zsh's line editor miscounted the prompt width and could crash (SIGBUS in zle) during the resize sweep a split triggers. The marker is now width-guarded, matching the bash and PowerShell integrations.
+
 ## [3.13.0] — 2026-07-04
 
 ### Added

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,12 +1,21 @@
 # TODOS
 
-## 채널 멘션: 크로스-워크스페이스 전달 (오프스크린 워크스페이스 판)
+## ✅ 채널 멘션: 크로스-워크스페이스 전달 — DONE v3.14.0 (2026-07-05)
+- 데몬 `events.poll` union scope(`workspaceIds` 집합 필터, ea36425) + 렌더러 단일 폴 fan-out(`planChannelMessageDelivery` 순수함수 유닛테스트, 7a108ea)으로 구현. 1차 N-루프 시도의 same-ws 회귀는 이 재설계(TODO의 "더 나은 방향")로 회피. idle-since-attach 전달 차단은 grace+output-quiet paste 게이트로 해결(c8b3bf9, 941a639). 3모델 리뷰(Claude·Codex·GLM) 통과. 아래는 이력 보존:
+
+### (이력) 원래 TODO 본문
 - **What:** 채널은 워크스페이스 독립이어야 하는데, `useChannelsEventSubscription.ts:148`이 **활성 워크스페이스 하나만** `events.poll` 폴링. 데몬이 이벤트를 caller 워크스페이스(`recipientWorkspaceIds`)로 필터링하므로, WS1을 연 상태에서 WS2 판을 멘션하면 WS2 이벤트가 필터에서 빠져 전달 안 됨 (원문 주석에도 "for v1 we poll one / FIX-MULTI-WS follow-up"으로 명시된 알려진 v1 단축).
 - **1차 시도 → 회귀로 revert:** 폴 루프를 `startLoop(workspaceId, isFull)`로 추출해 모든 로컬 워크스페이스 폴링(활성=full, 나머지=delivery전용). 그러나 도그푸딩에서 **same-ws 활성 멘션 전달 회귀** 발생(w18 무응답). diff상 full 경로는 기존과 100% 동일한데 실패 — 원격에서 렌더러 상태 검증 불가로 원인 미확정(가설: 8+ 동시 폴 루프 스케일의 타이밍 vs fail-closed busy 선재동작). **패치 보존: `~/.wmux-multiws-delivery.patch`** — 재개 시 여기서 시작.
 - **재개 전 확정 필요:** (1) w18 회귀가 멀티-ws 때문인지 vs fail-closed busy(`channelMentionFlush` isBusy: status null/running=busy) 선재동작인지 — 로컬 dev 빌드에서 렌더러 로그로 flush 스킵 여부 관찰. (2) `setChannels` 전체 대체 클로버링 회피(delivery 모드가 표시 상태 미변경)는 맞았으나, N개 동시 폴의 비용/타이밍 재검토.
 - **더 나은 방향(재설계):** 워크스페이스별 N폴 대신 "사람=모든 로컬 수신" 단일 스코프를 데몬 `events.poll`에 추가 — 렌더러가 로컬 워크스페이스 집합을 한 번에 넘기고 데몬이 union 필터. 폴 1개로 유지되고 스케일 문제 없음. 단 데몬 events.rpc 스코프 semantics 변경 필요.
 - **시작점:** `src/renderer/hooks/useChannelsEventSubscription.ts:148`(폴 스코프), `src/main/pipe/handlers/events.rpc.ts:108-135`(caller 필터), `src/renderer/hooks/channelMentionFlush.ts`(isBusy fail-closed).
 - **Priority:** P1 (사용자가 명시적으로 요구한 기능 — "워크스페이스 제약이 있으면 안 됨").
+
+## 멘션 paste 게이트 OUTPUT_QUIET_MS 도그푸드 튜닝 (follow-up, P2)
+- **What:** `channelMentionPasteGate.ts`의 `OUTPUT_QUIET_MS=2000` / `MAX_UNKNOWN_HOLD_MS=45000`은 실측 없이 잡은 보수값. 실제 idle vs thinking 에이전트의 pty 출력 주기를 도그푸드로 관측해 튜닝. perpetual-unknown이 하드-실링으로 배달되는 경로에 debug 로그 1줄 추가 검토(사일런트 지연 가시화).
+- **Why:** 3모델 리뷰(Codex CRITICAL + Claude fallback) — QUIET 임계가 idle 커서-쿼리 주기보다 짧으면 배달 지연 가능. 현재는 실링으로 fail-safe(무배달 아닌 지연)이나 최적값은 관측 필요. Claude가 지적한 `useChannelsEventSubscription`의 stale `requireIdle` 주석(FlushOpts에 필드 없음) 정정도 이때 함께.
+- **Context:** `src/renderer/hooks/channelMentionPasteGate.ts`, `useChannelsEventSubscription.ts`. 착수점 = 실 에이전트 pty 출력 스트림 관측.
+- **Priority:** P2
 
 ## 터미널: 멘션 전달 직후 DSR-CPR(`ESC[<row>;<col>R`) 응답이 화면으로 새어 `;3R40` 폭주
 - **What:** 채널 멘션이 판에 붙여넣어진 직후, 커서 위치 응답(`ESC[40;3R`)이 Claude TUI에 소비되지 않고 터미널 스크롤백에 리터럴 텍스트로 대량 출력됨. CPU 0% = 일회성 버스트(핫루프 아님), 데이터·채널 정상, 순수 표시 깨짐.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.13.0 sources.** This file is produced by
+> **Generated from wmux v3.14.0 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",

--- a/src/daemon/__tests__/shellIntegration.test.ts
+++ b/src/daemon/__tests__/shellIntegration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { classifyShell, buildSpawnInjection } from '../shell-integration';
+import { classifyShell, buildSpawnInjection, ZSH_RC } from '../shell-integration';
 
 // zsh 지원(macOS 기본 셸) — ZDOTDIR 가로채기 방식의 핵심 불변식 검증.
 describe('classifyShell', () => {
@@ -31,5 +31,22 @@ describe('buildSpawnInjection — zsh', () => {
   it('알 수 없는 셸은 injection이 없다(일반 spawn)', () => {
     expect(buildSpawnInjection('/usr/bin/fish')).toBeNull();
     expect(buildSpawnInjection('cmd.exe')).toBeNull();
+  });
+});
+
+// OSC 133 B 마커는 반드시 zsh의 %{...%} 제로폭 가드로 감싸야 한다.
+// 가드 없이 raw escape를 PROMPT에 붙이면 zle가 8바이트를 표시 폭으로
+// 오계산 → resize 스윕 중 zrefresh/resetvideo가 SIGBUS로 크래시한다 (RCA 2026-07-05).
+describe('ZSH_RC — PROMPT B 마커 폭 가드', () => {
+  it('133;B 마커를 %{ ... %} 안에 감싼다', () => {
+    // %{ 와 그 다음 %} 사이에 133;B 가 있어야 한다 (사이에 다른 % 프롬프트 이스케이프 없음).
+    expect(ZSH_RC).toMatch(/%\{[^%]*133;B[^%]*%\}/);
+  });
+
+  it('가드를 씌워도 마커 자체는 여전히 방출된다', () => {
+    // 회귀 방지: 폭 가드 때문에 마커가 통째로 사라지면 OSC 133 인덱싱이 깨진다.
+    expect(ZSH_RC).toContain('133;B');
+    // 가드 없는 옛 형태(PROMPT="${PROMPT}"$'...133;B)가 남아있지 않아야 한다.
+    expect(ZSH_RC).not.toMatch(/"\$\{PROMPT\}"\$'\\033\]133;B/);
   });
 });

--- a/src/daemon/shell-integration.ts
+++ b/src/daemon/shell-integration.ts
@@ -19,7 +19,7 @@ import { getWmuxDir } from './config';
  *   - fish                 (v3 roadmap)
  */
 
-const INTEGRATION_VERSION = 4;
+const INTEGRATION_VERSION = 5;
 const VERSION_FILE = '.version';
 
 // -----------------------------------------------------------------------
@@ -186,7 +186,7 @@ __wmux_uzd="\${WMUX_USER_ZDOTDIR:-$HOME}"
 [ -r "$__wmux_uzd/.zlogin" ] && source "$__wmux_uzd/.zlogin"
 `;
 
-const ZSH_RC = `# wmux shell integration — OSC 133 semantic markers (zsh, v${INTEGRATION_VERSION})
+export const ZSH_RC = `# wmux shell integration — OSC 133 semantic markers (zsh, v${INTEGRATION_VERSION})
 # Emits prompt/command boundaries so wmux's daemon can index command output.
 
 __wmux_uzd="\${WMUX_USER_ZDOTDIR:-$HOME}"
@@ -222,8 +222,11 @@ else
 fi
 
 # B (프롬프트 끝 / 사용자 입력 시작)을 PROMPT 끝에 한 번만 추가.
+# Wrap the raw OSC in zsh's %{...%} zero-width guard. Without it zle counts the
+# escape bytes as printable prompt width, and zrefresh/resetvideo overruns the
+# line buffer during resize sweeps → SIGBUS crash (RCA 2026-07-05).
 if [[ "$PROMPT" != *"133;B"* ]]; then
-  PROMPT="\${PROMPT}"$'\\033]133;B\\a'
+  PROMPT="\${PROMPT}%{"$'\\033]133;B\\a'"%}"
 fi
 `;
 

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -14,6 +14,7 @@ import type {
   LanLinkPeersListResult,
 } from '../shared/lanlink';
 import { FLUSH_DONE_MARKER } from '../daemon/SessionPipe';
+import { stripReplayQuerySequences } from '../shared/replayQuerySanitizer';
 import { DAEMON_RPC_TIMEOUT_MS } from '../shared/timeouts';
 import {
   dataSuffix,
@@ -691,14 +692,24 @@ export class DaemonClient extends EventEmitter {
           // the scrollback-restore-sync design — recovery cap dropped this
           // session, or it was created fresh by reconcile fallback). The
           // renderer uses this to decide whether to wipe its .txt cache.
+          // NOTE: pre-strip length on purpose — recoveredBytes answers "did
+          // the daemon have authoritative scrollback", which the renderer's
+          // reset-or-keep decision depends on, not the sanitized byte count.
           const recoveredBytes = markerIndex;
 
-          // Emit data before marker (ring buffer replay)
+          // Emit data before marker (ring buffer replay). Queries stored in
+          // the ring (DSR/CPR, DA, DECRQM, ...) are stripped first: xterm.js
+          // re-executes replayed bytes, so a stored query would fire a live
+          // auto-reply into the fresh shell's stdin — the CPR feedback storm
+          // of 2026-07-04 (see shared/replayQuerySanitizer.ts). Live bytes
+          // after the marker are never sanitized.
           if (markerIndex > 0) {
-            this.emit('session:data', {
-              sessionId,
-              data: combined.subarray(0, markerIndex),
-            });
+            const replay = stripReplayQuerySequences(
+              combined.subarray(0, markerIndex),
+            );
+            if (replay.length > 0) {
+              this.emit('session:data', { sessionId, data: replay });
+            }
           }
 
           // Fire flush-complete BEFORE the post-marker data so the

--- a/src/main/pipe/handlers/__tests__/events.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/events.rpc.test.ts
@@ -625,3 +625,149 @@ describe('events.rpc — notifications.read opt-in gate', () => {
     }
   });
 });
+
+// ─── FIX-MULTI-WS — `workspaceIds` union scoping ─────────────────────────────
+//
+// A multi-workspace renderer polls ONCE with every LOCAL workspace id; the
+// daemon filters by set membership. The core case this exists for: a
+// channel.message whose recipients include a BACKGROUND workspace must reach
+// the poll while the caller's base `workspaceId` is a different (active)
+// workspace — the single-id filter silently dropped those, so a mention of a
+// pane in an unfocused workspace never delivered until the user switched.
+describe('events.rpc — workspaceIds union scoping (FIX-MULTI-WS)', () => {
+  beforeEach(() => {
+    eventBus.reset();
+  });
+
+  /** Minimal channel.message emit — only the fields the poll filter reads
+   *  (type / workspaceId / recipientWorkspaceIds) matter here; the embedded
+   *  message payload is opaque to events.rpc. */
+  function emitChannelMessage(senderWs: string, recipients: string[]): void {
+    eventBus.emit({
+      type: 'channel.message',
+      workspaceId: senderWs,
+      channelId: 'ch-1',
+      seq: 1,
+      senderWorkspaceId: senderWs,
+      recipientWorkspaceIds: recipients,
+      message: {} as never,
+    } as never);
+  }
+
+  function emitChannelCatalog(actorWs: string, recipients: string[]): void {
+    eventBus.emit({
+      type: 'channel.catalog',
+      workspaceId: actorWs,
+      channelId: 'ch-1',
+      actorWorkspaceId: actorWs,
+      recipientWorkspaceIds: recipients,
+      reason: 'membership',
+    } as never);
+  }
+
+  it('delivers a channel.message addressed to a BACKGROUND workspace in the union (the P1 case)', async () => {
+    // Sender ws-C posts to a channel whose members include ws-B. The renderer
+    // is viewing ws-A but polls the union [ws-A, ws-B].
+    emitChannelMessage('ws-C', ['ws-B', 'ws-C']);
+    const router = setupRouter();
+    const events = await pollEvents(router, {
+      workspaceId: 'ws-A',
+      workspaceIds: ['ws-A', 'ws-B'],
+      types: ['channel.message'],
+    });
+    expect(events).toHaveLength(1);
+  });
+
+  it('drops a channel.message with NO overlap against the union (third-party leak guard)', async () => {
+    emitChannelMessage('ws-C', ['ws-C', 'ws-D']);
+    const router = setupRouter();
+    const events = await pollEvents(router, {
+      workspaceId: 'ws-A',
+      workspaceIds: ['ws-A', 'ws-B'],
+      types: ['channel.message'],
+    });
+    expect(events).toHaveLength(0);
+  });
+
+  it('single workspaceId behavior is unchanged (back-compat, no workspaceIds param)', async () => {
+    emitChannelMessage('ws-C', ['ws-B', 'ws-C']);
+    const router = setupRouter();
+    const asRecipient = await pollEvents(router, { workspaceId: 'ws-B', types: ['channel.message'] });
+    expect(asRecipient).toHaveLength(1);
+    const asThirdParty = await pollEvents(router, { workspaceId: 'ws-A', types: ['channel.message'] });
+    expect(asThirdParty).toHaveLength(0);
+  });
+
+  it('an unscoped poll (neither workspaceId nor workspaceIds) still receives ZERO channel events', async () => {
+    emitChannelMessage('ws-C', ['ws-B']);
+    emitChannelCatalog('ws-C', ['ws-B']);
+    const router = setupRouter();
+    const events = await pollEvents(router, { types: ['channel.message', 'channel.catalog'] });
+    expect(events).toHaveLength(0);
+  });
+
+  it('strict-scope types (agent.lifecycle et al.) match ANY workspace in the union, and only those', async () => {
+    eventBus.emit({ type: 'pane.created', workspaceId: 'ws-A', paneId: 'pA' });
+    eventBus.emit({ type: 'pane.created', workspaceId: 'ws-B', paneId: 'pB' });
+    eventBus.emit({ type: 'pane.created', workspaceId: 'ws-C', paneId: 'pC' });
+    const router = setupRouter();
+    const events = await pollEvents(router, {
+      workspaceId: 'ws-A',
+      workspaceIds: ['ws-A', 'ws-B'],
+    });
+    expect(events).toHaveLength(2);
+  });
+
+  it('a2a.task dual-party scoping matches against the union (background receiver)', async () => {
+    publishA2aTask({
+      taskId: 'task-1',
+      from: 'ws-C',
+      to: 'ws-B',
+      kind: 'created',
+      state: 'submitted',
+    });
+    const router = setupRouter();
+    const events = await pollEvents(router, {
+      workspaceId: 'ws-A',
+      workspaceIds: ['ws-A', 'ws-B'],
+      types: ['a2a.task'],
+    });
+    expect(events).toHaveLength(1);
+    const foreign = await pollEvents(router, {
+      workspaceId: 'ws-A',
+      workspaceIds: ['ws-A', 'ws-D'],
+      types: ['a2a.task'],
+    });
+    expect(foreign).toHaveLength(0);
+  });
+
+  it('channel.catalog matches the union, including the "*" public broadcast sentinel', async () => {
+    emitChannelCatalog('ws-C', ['ws-B']);
+    emitChannelCatalog('ws-C', ['*']);
+    const router = setupRouter();
+    const events = await pollEvents(router, {
+      workspaceId: 'ws-A',
+      workspaceIds: ['ws-A', 'ws-B'],
+      types: ['channel.catalog'],
+    });
+    expect(events).toHaveLength(2);
+    // Union with no catalog overlap: only the '*' broadcast remains visible.
+    const noOverlap = await pollEvents(router, {
+      workspaceId: 'ws-D',
+      types: ['channel.catalog'],
+    });
+    expect(noOverlap).toHaveLength(1);
+  });
+
+  it('ignores malformed workspaceIds entries (non-string / empty) instead of widening scope', async () => {
+    emitChannelMessage('ws-C', ['ws-B']);
+    const router = setupRouter();
+    // Malformed entries dropped → effective scope is just ws-A → no delivery.
+    const events = await pollEvents(router, {
+      workspaceId: 'ws-A',
+      workspaceIds: [42, '', null, { ws: 'ws-B' }],
+      types: ['channel.message'],
+    });
+    expect(events).toHaveLength(0);
+  });
+});

--- a/src/main/pipe/handlers/events.rpc.ts
+++ b/src/main/pipe/handlers/events.rpc.ts
@@ -47,10 +47,40 @@ function parseTypes(raw: unknown): WmuxEventType[] | undefined {
   return out.length > 0 ? out : undefined;
 }
 
+/** Upper bound on `workspaceIds` entries. A renderer polls its own local
+ *  workspaces (single digits in practice); 64 is hygiene against a
+ *  pathological caller flooding the filter set, not a functional limit. */
+const MAX_WORKSPACE_IDS = 64;
+
+/**
+ * FIX-MULTI-WS — parse the optional `workspaceIds` union-scope param.
+ * Non-string / empty entries are dropped; the list is capped. Returns
+ * undefined when the param is absent or yields nothing, so the single
+ * `workspaceId` path stays byte-for-byte the pre-existing behavior.
+ *
+ * Security note: this does NOT widen the pipe threat model — `workspaceId`
+ * was already caller-supplied on this router (a pipe client could poll any
+ * workspace one id at a time), and the MCP layer builds its params
+ * server-side with a pinned `workspaceId` only, so an MCP client can never
+ * inject `workspaceIds`.
+ */
+function parseWorkspaceIds(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: string[] = [];
+  for (const w of raw) {
+    if (typeof w === 'string' && w.length > 0) {
+      out.push(w);
+      if (out.length >= MAX_WORKSPACE_IDS) break;
+    }
+  }
+  return out.length > 0 ? out : undefined;
+}
+
 export function registerEventsRpc(router: RpcRouter, trustLookup?: TrustLookup): void {
   /**
    * events.poll — pull events newer than `cursor`.
-   * params: { cursor?: number, types?: WmuxEventType[], workspaceId?: string, max?: number }
+   * params: { cursor?: number, types?: WmuxEventType[], workspaceId?: string,
+   *           workspaceIds?: string[], max?: number }
    *
    * Default cursor is 0 (replay from oldest in the ring). External callers
    * SHOULD scope to their own `workspaceId` so they don't see other
@@ -64,6 +94,11 @@ export function registerEventsRpc(router: RpcRouter, trustLookup?: TrustLookup):
     const workspaceId = typeof params['workspaceId'] === 'string' && params['workspaceId'].length > 0
       ? params['workspaceId']
       : undefined;
+    // FIX-MULTI-WS: optional union scope. A multi-workspace renderer passes
+    // every LOCAL workspace id in ONE poll so a channel.message addressed to a
+    // background workspace still reaches it (the single-workspace filter
+    // silently dropped those — delivery only worked for the active workspace).
+    const workspaceIds = parseWorkspaceIds(params['workspaceIds']);
     const max = typeof params['max'] === 'number' && Number.isFinite(params['max'])
       ? Math.max(1, Math.floor(params['max']))
       : undefined;
@@ -104,46 +139,54 @@ export function registerEventsRpc(router: RpcRouter, trustLookup?: TrustLookup):
     //                precondition of post), so the dual-party code path
     //                would have missed the recipient-other-than-sender case.
     //   - everything else: strict `workspaceId === caller` (unchanged).
-    const caller = workspaceId;
+    // FIX-MULTI-WS: the caller scope is a SET — the single `workspaceId` plus
+    // the optional `workspaceIds` union. `scoped === false` (empty set) keeps
+    // the exact pre-existing unscoped semantics; a single-id set is
+    // behaviorally identical to the old `caller` equality checks.
+    const callerSet = new Set<string>(workspaceIds ?? []);
+    if (workspaceId) callerSet.add(workspaceId);
+    const scoped = callerSet.size > 0;
     result.events = result.events.filter((e) => {
       if (e.type === 'a2a.task') {
-        // The `!!caller &&` clause is LOAD-BEARING — an unscoped poll
-        // (no workspaceId) must receive ZERO a2a.task events, else a bare
-        // `events.subscribe` plugin reads every pair's task.
-        return !!caller &&
-          ((e as A2aTaskEvent).from === caller || (e as A2aTaskEvent).to === caller);
+        // The `scoped &&` clause is LOAD-BEARING — an unscoped poll
+        // (no workspaceId/workspaceIds) must receive ZERO a2a.task events,
+        // else a bare `events.subscribe` plugin reads every pair's task.
+        return scoped &&
+          (callerSet.has((e as A2aTaskEvent).from) || callerSet.has((e as A2aTaskEvent).to));
       }
       if (e.type === 'channel.message') {
         // Per-recipient scoping: same load-bearing unscoped-drop as a2a.task.
         // `e.workspaceId` is the sender (base scope); every member
         // workspace appears in `recipientWorkspaceIds` so a post reaches
-        // its full set without leaking to third parties.
+        // its full set without leaking to third parties. Union scope: the
+        // event is visible when ANY caller workspace is sender or recipient.
         const ce = e as ChannelMessageEvent;
-        if (!caller) return false;
-        if (ce.workspaceId === caller) return true;
-        return ce.recipientWorkspaceIds.includes(caller);
+        if (!scoped) return false;
+        if (callerSet.has(ce.workspaceId)) return true;
+        return ce.recipientWorkspaceIds.some((r) => callerSet.has(r));
       }
       if (e.type === 'channel.catalog') {
         // A1 — same per-recipient scoping as channel.message: base workspaceId
         // is the actor; recipientWorkspaceIds is the member set + any removed ws.
         const ce = e as ChannelCatalogEvent;
-        if (!caller) return false;
+        if (!scoped) return false;
         // '*' sentinel = broadcast to every workspace. A public channel's
         // creation is discoverable by all, but the member-scoped recipient list
         // wouldn't reach non-members (codex+GLM P2), so create() emits '*' for
         // public channels.
         if (ce.recipientWorkspaceIds.includes('*')) return true;
-        if (ce.workspaceId === caller) return true;
-        return ce.recipientWorkspaceIds.includes(caller);
+        if (callerSet.has(ce.workspaceId)) return true;
+        return ce.recipientWorkspaceIds.some((r) => callerSet.has(r));
       }
       if (e.type === 'channel.nudgeExhausted') {
         // Channels v2 — same unscoped-drop discipline as the other channel.*
         // events (channel existence must not leak to a bare subscribe). Base
         // workspaceId is the affected member's workspace; only it sees the event.
-        return !!caller && e.workspaceId === caller;
+        return scoped && callerSet.has(e.workspaceId);
       }
       // every other type: strict scope, UNCHANGED from the old EventBus gate
-      return caller ? e.workspaceId === caller : true;
+      // (generalized to set membership for the union case)
+      return scoped ? callerSet.has(e.workspaceId) : true;
     });
 
     // Re-impose the caller's page size AFTER scoping (see the over-fetch note

--- a/src/renderer/hooks/__tests__/channelMentionPasteGate.test.ts
+++ b/src/renderer/hooks/__tests__/channelMentionPasteGate.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isMentionPasteBusy,
+  createPasteGateState,
+  UNKNOWN_STATUS_GRACE_MS,
+} from '../channelMentionPasteGate';
+
+describe('isMentionPasteBusy', () => {
+  it('busy for running / awaiting_input (paste would corrupt the turn)', () => {
+    const s = createPasteGateState();
+    expect(isMentionPasteBusy('running', 'p', 0, s)).toBe(true);
+    expect(isMentionPasteBusy('awaiting_input', 'p', 0, s)).toBe(true);
+  });
+
+  it('not busy for waiting / complete / idle / any other known status', () => {
+    const s = createPasteGateState();
+    expect(isMentionPasteBusy('waiting', 'p', 0, s)).toBe(false);
+    expect(isMentionPasteBusy('complete', 'p', 0, s)).toBe(false);
+    expect(isMentionPasteBusy('idle', 'p', 0, s)).toBe(false);
+  });
+
+  // The 2026-07-05 bug: an idle-since-attach agent's status stays undefined, and
+  // the old gate held the mention forever. Grace-then-deliver is the fix.
+  it('holds unknown status during the grace window, then delivers', () => {
+    const s = createPasteGateState();
+    // First observation at t=0 arms the grace clock and holds.
+    expect(isMentionPasteBusy(undefined, 'p', 0, s)).toBe(true);
+    // Still within the window → still held.
+    expect(isMentionPasteBusy(undefined, 'p', UNKNOWN_STATUS_GRACE_MS - 1, s)).toBe(true);
+    // At/after the window → deliver (agent is quiet = idle).
+    expect(isMentionPasteBusy(undefined, 'p', UNKNOWN_STATUS_GRACE_MS, s)).toBe(false);
+    expect(isMentionPasteBusy(undefined, 'p', UNKNOWN_STATUS_GRACE_MS + 5000, s)).toBe(false);
+  });
+
+  it('grace clock is per-pty (one pane resolving does not release another)', () => {
+    const s = createPasteGateState();
+    isMentionPasteBusy(undefined, 'a', 0, s);
+    isMentionPasteBusy(undefined, 'b', 1000, s);
+    // 'a' passed its window; 'b' has not.
+    expect(isMentionPasteBusy(undefined, 'a', UNKNOWN_STATUS_GRACE_MS, s)).toBe(false);
+    expect(isMentionPasteBusy(undefined, 'b', UNKNOWN_STATUS_GRACE_MS, s)).toBe(true);
+  });
+
+  it('a running agent within grace stays held (transient post-attach window)', () => {
+    const s = createPasteGateState();
+    // Unknown at attach → held.
+    expect(isMentionPasteBusy(undefined, 'p', 0, s)).toBe(true);
+    // 'running' broadcast lands before the grace elapses → still busy, and the
+    // grace clock is cleared so a later flap re-arms fresh.
+    expect(isMentionPasteBusy('running', 'p', 1000, s)).toBe(true);
+    expect(s.firstUnknownAt.has('p')).toBe(false);
+  });
+
+  it('resets the grace clock when status resolves then goes unknown again', () => {
+    const s = createPasteGateState();
+    isMentionPasteBusy(undefined, 'p', 0, s); // arm at 0
+    isMentionPasteBusy('waiting', 'p', 500, s); // resolve → clears clock
+    // Unknown again at t=1000 re-arms; grace measured from 1000, not 0.
+    expect(isMentionPasteBusy(undefined, 'p', 1000, s)).toBe(true);
+    expect(isMentionPasteBusy(undefined, 'p', 1000 + UNKNOWN_STATUS_GRACE_MS - 1, s)).toBe(true);
+    expect(isMentionPasteBusy(undefined, 'p', 1000 + UNKNOWN_STATUS_GRACE_MS, s)).toBe(false);
+  });
+
+  it('honors a custom grace window', () => {
+    const s = createPasteGateState();
+    expect(isMentionPasteBusy(undefined, 'p', 0, s, 100)).toBe(true);
+    expect(isMentionPasteBusy(undefined, 'p', 100, s, 100)).toBe(false);
+  });
+});

--- a/src/renderer/hooks/__tests__/channelMentionPasteGate.test.ts
+++ b/src/renderer/hooks/__tests__/channelMentionPasteGate.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from 'vitest';
 import {
   isMentionPasteBusy,
   createPasteGateState,
+  notePtyOutput,
+  prunePasteGateState,
   UNKNOWN_STATUS_GRACE_MS,
+  OUTPUT_QUIET_MS,
+  MAX_UNKNOWN_HOLD_MS,
 } from '../channelMentionPasteGate';
 
 describe('isMentionPasteBusy', () => {
@@ -65,5 +69,102 @@ describe('isMentionPasteBusy', () => {
     const s = createPasteGateState();
     expect(isMentionPasteBusy(undefined, 'p', 0, s, 100)).toBe(true);
     expect(isMentionPasteBusy(undefined, 'p', 100, s, 100)).toBe(false);
+  });
+
+  // The 2026-07-05 mid-turn paste race (Codex+Claude CRITICAL): grace alone is
+  // leaky. A slow/thinking background agent stays at unknown status past the
+  // grace (its bursts miss ActivityMonitor's threshold) but keeps emitting; the
+  // output-quiet gate must hold it. A truly idle agent's output is stale, so it
+  // still delivers.
+  it('unknown past grace with NO output history delivers (idle case)', () => {
+    const s = createPasteGateState();
+    expect(isMentionPasteBusy(undefined, 'p', 0, s)).toBe(true); // arm grace
+    // Grace elapsed, lastOutputAt never stamped → both gates clear → deliver.
+    expect(isMentionPasteBusy(undefined, 'p', UNKNOWN_STATUS_GRACE_MS, s)).toBe(false);
+  });
+
+  it('unknown past grace but RECENTLY output stays busy (race fix)', () => {
+    const s = createPasteGateState();
+    expect(isMentionPasteBusy(undefined, 'p', 0, s)).toBe(true); // arm grace at 0
+    // Agent emits at t=grace (a slow think tick).
+    notePtyOutput(s, 'p', UNKNOWN_STATUS_GRACE_MS);
+    // Grace elapsed, but last output is only 500ms ago (< quiet) → HELD.
+    expect(
+      isMentionPasteBusy(undefined, 'p', UNKNOWN_STATUS_GRACE_MS + 500, s),
+    ).toBe(true);
+    // Boundary: exactly quietMs since last output → no longer < quiet → deliver.
+    expect(
+      isMentionPasteBusy(undefined, 'p', UNKNOWN_STATUS_GRACE_MS + OUTPUT_QUIET_MS, s),
+    ).toBe(false);
+  });
+
+  it('unknown past grace with STALE output delivers (quiet bar cleared)', () => {
+    const s = createPasteGateState();
+    expect(isMentionPasteBusy(undefined, 'p', 0, s)).toBe(true); // arm grace
+    notePtyOutput(s, 'p', 100); // a lone early cursor query
+    // Grace elapsed AND last output is far older than quietMs → deliver.
+    expect(
+      isMentionPasteBusy(undefined, 'p', UNKNOWN_STATUS_GRACE_MS + OUTPUT_QUIET_MS + 1, s),
+    ).toBe(false);
+  });
+
+  it('honors a custom quiet window', () => {
+    const s = createPasteGateState();
+    isMentionPasteBusy(undefined, 'p', 0, s, 100); // arm grace (custom 100ms)
+    notePtyOutput(s, 'p', 100);
+    // grace(100) elapsed at t=150; last output 50ms ago, quiet=80 → still held.
+    expect(isMentionPasteBusy(undefined, 'p', 150, s, 100, 80)).toBe(true);
+    // t=200: last output 100ms ago ≥ quiet(80) → deliver.
+    expect(isMentionPasteBusy(undefined, 'p', 200, s, 100, 80)).toBe(false);
+  });
+
+  it('notePtyOutput ignores an empty pty id', () => {
+    const s = createPasteGateState();
+    notePtyOutput(s, '', 100);
+    expect(s.lastOutputAt.has('')).toBe(false);
+    expect(s.lastOutputAt.size).toBe(0);
+  });
+
+  it('delivers past the hard ceiling even while output stays recent (never-deliver guard)', () => {
+    const s = createPasteGateState();
+    // Arm the grace clock at t=0.
+    isMentionPasteBusy(undefined, 'p', 0, s);
+    // A pathological pane keeps emitting sub-quiet output: stamp output near the
+    // ceiling so the quiet gate alone (recent output) would hold it busy.
+    notePtyOutput(s, 'p', MAX_UNKNOWN_HOLD_MS - 1000);
+    // Just before the ceiling, recent output still holds it busy.
+    expect(isMentionPasteBusy(undefined, 'p', MAX_UNKNOWN_HOLD_MS - 500, s)).toBe(true);
+    // At the ceiling, deliver regardless of still-recent output (fail-safe).
+    expect(isMentionPasteBusy(undefined, 'p', MAX_UNKNOWN_HOLD_MS, s)).toBe(false);
+  });
+
+  it('honors a custom max-hold ceiling', () => {
+    const s = createPasteGateState();
+    isMentionPasteBusy(undefined, 'p', 0, s);
+    notePtyOutput(s, 'p', 900);
+    // Custom ceiling 1000ms: recent output at t=900 would normally hold, but the
+    // ceiling forces delivery at t=1000 (grace 500, quiet 2000, maxHold 1000).
+    expect(isMentionPasteBusy(undefined, 'p', 999, s, 500, 2000, 1000)).toBe(true);
+    expect(isMentionPasteBusy(undefined, 'p', 1000, s, 500, 2000, 1000)).toBe(false);
+  });
+
+  it('prunePasteGateState drops dead ptys from both maps, keeps live ones', () => {
+    const s = createPasteGateState();
+    // Arm grace clocks for two ptys.
+    isMentionPasteBusy(undefined, 'live', 0, s);
+    isMentionPasteBusy(undefined, 'dead', 0, s);
+    // Stamp output for both.
+    notePtyOutput(s, 'live', 10);
+    notePtyOutput(s, 'dead', 10);
+    expect(s.firstUnknownAt.has('dead')).toBe(true);
+    expect(s.lastOutputAt.has('dead')).toBe(true);
+
+    prunePasteGateState(s, new Set(['live']));
+
+    // Dead pty gone from BOTH maps; live pty untouched.
+    expect(s.firstUnknownAt.has('dead')).toBe(false);
+    expect(s.lastOutputAt.has('dead')).toBe(false);
+    expect(s.firstUnknownAt.has('live')).toBe(true);
+    expect(s.lastOutputAt.has('live')).toBe(true);
   });
 });

--- a/src/renderer/hooks/__tests__/planChannelMessageDelivery.test.ts
+++ b/src/renderer/hooks/__tests__/planChannelMessageDelivery.test.ts
@@ -1,0 +1,81 @@
+/**
+ * FIX-MULTI-WS — planChannelMessageDelivery
+ *
+ * The renderer's per-`channel.message` fan-out decision: which display cache to
+ * touch (active workspace only) and which local workspaces to route the mention
+ * into (every mentioned local workspace, active OR background). This is the
+ * layer the FIRST multi-workspace attempt regressed — the daemon filter tests
+ * passed, but same-workspace ROUTING broke at renderer runtime and was
+ * undiagnosable remotely. These cases pin both directions:
+ *   - same-ws (active) mention STILL routes (the regression), and
+ *   - background-ws mention NOW routes (the fix),
+ * so the two never drift apart again in a unit-visible way.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { planChannelMessageDelivery } from '../useChannelsEventSubscription';
+
+const ACTIVE = 'ws-active';
+const BG = 'ws-background';
+const LOCAL = [ACTIVE, BG];
+
+describe('planChannelMessageDelivery — display append (active workspace only)', () => {
+  it('appends when the ACTIVE workspace is the sender', () => {
+    const plan = planChannelMessageDelivery(ACTIVE, [ACTIVE, BG], [], ACTIVE, LOCAL);
+    expect(plan.appendToDisplay).toBe(true);
+  });
+
+  it('appends when the ACTIVE workspace is a recipient (post from elsewhere)', () => {
+    const plan = planChannelMessageDelivery('ws-remote', [ACTIVE, BG], [], ACTIVE, LOCAL);
+    expect(plan.appendToDisplay).toBe(true);
+  });
+
+  it('does NOT append when the post only concerns a BACKGROUND workspace', () => {
+    // The active view holds no catalog for BG — appending would count unread
+    // against a channel it doesn't display. Its view rebuilds on switch.
+    const plan = planChannelMessageDelivery('ws-remote', [BG], [], ACTIVE, LOCAL);
+    expect(plan.appendToDisplay).toBe(false);
+  });
+
+  it('does NOT append a fully third-party post (neither sender nor recipient is active)', () => {
+    const plan = planChannelMessageDelivery('ws-x', ['ws-y'], [], ACTIVE, LOCAL);
+    expect(plan.appendToDisplay).toBe(false);
+  });
+});
+
+describe('planChannelMessageDelivery — mention routing (all local workspaces)', () => {
+  it('routes a SAME-WS mention of the active workspace (the regression guard)', () => {
+    const plan = planChannelMessageDelivery('ws-remote', [ACTIVE], [ACTIVE], ACTIVE, LOCAL);
+    expect(plan.routeWorkspaces).toEqual([ACTIVE]);
+  });
+
+  it('routes a CROSS-WS mention of a BACKGROUND workspace (the fix)', () => {
+    // Viewing ACTIVE, a post mentions the BACKGROUND workspace's pane. Before
+    // the fix this never reached the renderer; now it routes to BG.
+    const plan = planChannelMessageDelivery('ws-remote', [BG], [BG], ACTIVE, LOCAL);
+    expect(plan.routeWorkspaces).toEqual([BG]);
+  });
+
+  it('routes to BOTH when a single post mentions active + background', () => {
+    const plan = planChannelMessageDelivery('ws-remote', [ACTIVE, BG], [ACTIVE, BG], ACTIVE, LOCAL);
+    expect(new Set(plan.routeWorkspaces)).toEqual(new Set([ACTIVE, BG]));
+  });
+
+  it('does NOT route a mention of a NON-LOCAL workspace (its own renderer handles it)', () => {
+    const plan = planChannelMessageDelivery('ws-remote', [ACTIVE], ['ws-elsewhere'], ACTIVE, LOCAL);
+    expect(plan.routeWorkspaces).toEqual([]);
+  });
+
+  it('routes nothing for a post with no mentions (plain message)', () => {
+    const plan = planChannelMessageDelivery('ws-remote', [ACTIVE, BG], [], ACTIVE, LOCAL);
+    expect(plan.routeWorkspaces).toEqual([]);
+  });
+
+  it('background delivery is INDEPENDENT of display: routes to BG while appendToDisplay is false', () => {
+    // The crux of the fix in one assertion — a background mention delivers even
+    // though its workspace contributes nothing to the on-screen display.
+    const plan = planChannelMessageDelivery('ws-remote', [BG], [BG], ACTIVE, LOCAL);
+    expect(plan.appendToDisplay).toBe(false);
+    expect(plan.routeWorkspaces).toEqual([BG]);
+  });
+});

--- a/src/renderer/hooks/channelMentionPasteGate.ts
+++ b/src/renderer/hooks/channelMentionPasteGate.ts
@@ -24,6 +24,22 @@
 // A status that stays `undefined` past the grace means the agent produced no
 // activity = quiet/idle, which is paste-safe.
 //
+// RCA 2026-07-05 (mid-turn paste race, Codex+Claude CRITICAL): grace ALONE is a
+// leaky gate. A background agent that is genuinely thinking / emitting tokens
+// SLOWLY can sit at status `undefined` past the grace — its output bursts stay
+// under ActivityMonitor's 2000-byte/3s threshold, so no 'running' broadcast ever
+// lands — and the grace-only gate then pastes MID-TURN and corrupts the turn.
+// The naive fix ("any raw pty output = busy") reintroduces the c8b3bf9 bug: an
+// idle agent still emits sparse output (cursor-position queries), so raw-output
+// gating would hold an idle mention forever. So we require BOTH gates to clear:
+//   - GRACE (4s) since first-unknown, AND
+//   - OUTPUT-QUIET (2s) since the pty's last observed output.
+// A thinking agent repaints its status line on a ~1s timer, so it never crosses
+// the 2s quiet bar → held. A truly idle agent emits only rare queries, clears
+// the quiet bar → delivered. The last-output timestamps are fed by a global
+// pty-data listener (see useChannelsEventSubscription) and pruned per-pty via
+// prunePasteGateState so the maps can't leak dead ptys.
+//
 // Known statuses are unchanged: 'running'/'awaiting_input' busy, everything else
 // (including 'waiting'/'complete'/'idle') paste-safe immediately.
 
@@ -42,14 +58,57 @@ export const PASTE_UNSAFE_STATUSES: ReadonlySet<string> = new Set([
  *  mention delivers within a few poll ticks instead of never. */
 export const UNKNOWN_STATUS_GRACE_MS = 4000;
 
-/** Per-pty first-unknown-observation timestamps. Effect-scoped, mutated in place
- *  by `isMentionPasteBusy` so the grace clock survives across poll ticks. */
+/** Second gate for a persistently-unknown pty: how long the pty must have been
+ *  QUIET (no observed output) before an unknown-status mention delivers. A
+ *  thinking agent repaints its status line on a ~1s cadence and never crosses
+ *  this bar; a truly idle agent emits only sparse cursor queries and does.
+ *  Conservative default — dogfood-tuning target (RCA 2026-07-05, Codex+Claude
+ *  mid-turn-paste race). */
+export const OUTPUT_QUIET_MS = 2000;
+
+/** Hard ceiling on holding a persistently-unknown mention. After this long at
+ *  unknown status the mention delivers even if output is still recent — bounds
+ *  the output-quiet gate so a perpetual-unknown, never-quiet pane (an idle
+ *  prompt with a live clock/ticker, or a TUI AgentDetector can't classify)
+ *  can't pin a mention forever. Generous so a normal thinking agent (which
+ *  resolves to a known status or goes quiet first) never hits it; past it the
+ *  failure mode is "delivered late", not "silently never delivered" (RCA
+ *  2026-07-05, 2-model never-deliver consensus: Codex CRITICAL + Claude). */
+export const MAX_UNKNOWN_HOLD_MS = 45000;
+
+/** Per-pty grace/quiet trackers. Effect-scoped, mutated in place so the clocks
+ *  survive across poll ticks.
+ *   - firstUnknownAt: first-unknown-observation timestamp (grace clock),
+ *     mutated by `isMentionPasteBusy`.
+ *   - lastOutputAt: last observed pty output timestamp (quiet clock), stamped by
+ *     `notePtyOutput` from a global pty-data listener. Both are pruned by
+ *     `prunePasteGateState` so dead ptys can't leak. */
 export interface PasteGateState {
   firstUnknownAt: Map<string, number>;
+  lastOutputAt: Map<string, number>;
 }
 
 export function createPasteGateState(): PasteGateState {
-  return { firstUnknownAt: new Map() };
+  return { firstUnknownAt: new Map(), lastOutputAt: new Map() };
+}
+
+/** Record that `ptyId` just produced output at `now`. Fed by the renderer's
+ *  global pty-data listener; a no-op for an empty id (app-level frames). */
+export function notePtyOutput(state: PasteGateState, ptyId: string, now: number): void {
+  if (!ptyId) return;
+  state.lastOutputAt.set(ptyId, now);
+}
+
+/** Drop grace/quiet entries for ptys no longer in `livePtyIds` (leaf-pane
+ *  sweep). Bounds both maps to live panes — without this a churned pty's
+ *  timestamps live forever (3-model consensus map-leak fix). */
+export function prunePasteGateState(state: PasteGateState, livePtyIds: Set<string>): void {
+  for (const id of state.firstUnknownAt.keys()) {
+    if (!livePtyIds.has(id)) state.firstUnknownAt.delete(id);
+  }
+  for (const id of state.lastOutputAt.keys()) {
+    if (!livePtyIds.has(id)) state.lastOutputAt.delete(id);
+  }
 }
 
 /**
@@ -58,10 +117,13 @@ export function createPasteGateState(): PasteGateState {
  * @param status  live `surfaceAgent[ptyId]?.status` (undefined = unknown)
  * @param ptyId   target pty
  * @param now     current epoch ms (Date.now())
- * @param state   mutable grace tracker (see PasteGateState)
+ * @param state   mutable grace/quiet tracker (see PasteGateState)
  * @param graceMs grace window for unknown status
+ * @param quietMs output-quiet window an unknown pty must clear to deliver
  *
  * Side effect: records/clears the pty's first-unknown timestamp in `state`.
+ * The quiet clock (`lastOutputAt`) is READ here but owned by `notePtyOutput` /
+ * `prunePasteGateState` — this function never writes it.
  */
 export function isMentionPasteBusy(
   status: string | undefined,
@@ -69,18 +131,35 @@ export function isMentionPasteBusy(
   now: number,
   state: PasteGateState,
   graceMs: number = UNKNOWN_STATUS_GRACE_MS,
+  quietMs: number = OUTPUT_QUIET_MS,
+  maxHoldMs: number = MAX_UNKNOWN_HOLD_MS,
 ): boolean {
   if (status != null) {
     // Known status resolved — clear any grace clock so a later re-attach that
-    // goes unknown again starts a fresh window.
+    // goes unknown again starts a fresh window. lastOutputAt is left to prune.
     state.firstUnknownAt.delete(ptyId);
     return PASTE_UNSAFE_STATUSES.has(status);
   }
-  // Unknown: hold during the grace window, then deliver.
+  // Unknown: hold during the grace window.
   const first = state.firstUnknownAt.get(ptyId);
   if (first == null) {
     state.firstUnknownAt.set(ptyId, now);
     return true;
   }
-  return now - first < graceMs;
+  if (now - first < graceMs) return true;
+  // Hard ceiling: never hold an unknown-status mention forever. A pane stuck at
+  // unknown that keeps emitting sub-quiet output (idle prompt with a live
+  // clock/ticker) would otherwise pin the output-quiet gate below busy every
+  // tick — a silent never-deliver. Past the ceiling we deliver regardless; the
+  // failure mode flips from "mention lost, no signal" to "mention delivered
+  // late" (3-model review 2026-07-05: Codex CRITICAL + Claude fallback).
+  if (now - first >= maxHoldMs) return false;
+  // Grace elapsed, under the ceiling. Second gate: a slow/thinking agent whose
+  // bursts stay under ActivityMonitor's threshold sits at unknown past the grace
+  // but keeps emitting — hold it while its last output is still recent (mid-turn
+  // race). A truly idle pty's last output is old (only rare cursor queries its
+  // live CPR responder answers), so it clears the quiet bar and delivers.
+  const lastOut = state.lastOutputAt.get(ptyId);
+  if (lastOut != null && now - lastOut < quietMs) return true;
+  return false;
 }

--- a/src/renderer/hooks/channelMentionPasteGate.ts
+++ b/src/renderer/hooks/channelMentionPasteGate.ts
@@ -1,0 +1,86 @@
+// ─── Channel-mention paste gate — unknown-status grace window ────────────────
+//
+// RCA 2026-07-05 (idle-since-attach delivery block): the mention flush skips a
+// pane whose agent is BUSY. Busy is read from `surfaceAgent[ptyId].status`,
+// which AgentDetector only sets when a status PATTERN flows through the pty
+// output (e.g. Claude's "bypass permissions on" idle-prompt fragment → 'waiting').
+//
+// An agent that has been idle since its pty attached never re-emits that pattern
+// — it just sits emitting cursor-position queries — so its status stays
+// `undefined`. The old gate treated `undefined` as busy FOREVER (fail-closed),
+// relying on the agent's next Stop to flush the queued mention. But a
+// continuously-idle agent never Stops, so the mention was stuck until an
+// unrelated repaint (observed: splitting the pane) forced Claude to redraw the
+// idle prompt, which finally emitted 'waiting'. Cross-workspace mentions to a
+// background pane are exactly this case: the pane never gets focus, never
+// repaints, never delivers.
+//
+// The fail-closed WAS load-bearing for one real window: right after attach a
+// genuinely-running agent's first 'running' broadcast may not have landed yet,
+// and pasting into a running agent corrupts its turn. That window is transient
+// (a running agent produces output → ActivityMonitor 'active' → 'running' within
+// ~1 output burst). So we keep fail-closed for a short GRACE period after the
+// first unknown observation, then treat persistent-unknown as idle and deliver.
+// A status that stays `undefined` past the grace means the agent produced no
+// activity = quiet/idle, which is paste-safe.
+//
+// Known statuses are unchanged: 'running'/'awaiting_input' busy, everything else
+// (including 'waiting'/'complete'/'idle') paste-safe immediately.
+
+/** Paste is unsafe while the agent is actively producing ('running') or blocked
+ *  on a confirmation prompt ('awaiting_input') — those defer to the agent's
+ *  Stop. 'waiting' (turn ended, ready for input), 'complete', 'idle' are all
+ *  paste-safe (deliver immediately). */
+export const PASTE_UNSAFE_STATUSES: ReadonlySet<string> = new Set([
+  'running',
+  'awaiting_input',
+]);
+
+/** Default grace window before a persistently-unknown status is treated as idle.
+ *  Comfortably longer than the ~1-2s post-attach window in which a running
+ *  agent's first 'running' broadcast lands, short enough that a real idle-pane
+ *  mention delivers within a few poll ticks instead of never. */
+export const UNKNOWN_STATUS_GRACE_MS = 4000;
+
+/** Per-pty first-unknown-observation timestamps. Effect-scoped, mutated in place
+ *  by `isMentionPasteBusy` so the grace clock survives across poll ticks. */
+export interface PasteGateState {
+  firstUnknownAt: Map<string, number>;
+}
+
+export function createPasteGateState(): PasteGateState {
+  return { firstUnknownAt: new Map() };
+}
+
+/**
+ * Should a queued mention be HELD (agent busy) rather than pasted into `ptyId`?
+ *
+ * @param status  live `surfaceAgent[ptyId]?.status` (undefined = unknown)
+ * @param ptyId   target pty
+ * @param now     current epoch ms (Date.now())
+ * @param state   mutable grace tracker (see PasteGateState)
+ * @param graceMs grace window for unknown status
+ *
+ * Side effect: records/clears the pty's first-unknown timestamp in `state`.
+ */
+export function isMentionPasteBusy(
+  status: string | undefined,
+  ptyId: string,
+  now: number,
+  state: PasteGateState,
+  graceMs: number = UNKNOWN_STATUS_GRACE_MS,
+): boolean {
+  if (status != null) {
+    // Known status resolved — clear any grace clock so a later re-attach that
+    // goes unknown again starts a fresh window.
+    state.firstUnknownAt.delete(ptyId);
+    return PASTE_UNSAFE_STATUSES.has(status);
+  }
+  // Unknown: hold during the grace window, then deliver.
+  const first = state.firstUnknownAt.get(ptyId);
+  if (first == null) {
+    state.firstUnknownAt.set(ptyId, now);
+    return true;
+  }
+  return now - first < graceMs;
+}

--- a/src/renderer/hooks/useChannelsEventSubscription.ts
+++ b/src/renderer/hooks/useChannelsEventSubscription.ts
@@ -61,6 +61,10 @@ import { findLeafPanes } from './a2aAddressing';
 import { publishA2aTask } from '../events/publisher';
 import { flushMentions, type FlushOpts } from './channelMentionFlush';
 import { submitBracketedPasteToPty } from '../utils/ptyMessageDelivery';
+import {
+  createPasteGateState,
+  isMentionPasteBusy,
+} from './channelMentionPasteGate';
 import type {
   WmuxEvent,
   ChannelMessageEvent,
@@ -80,15 +84,6 @@ const EVENT_POLL_INTERVAL_MS = 1000;
  *  cycle. The daemon's POLL_DEFAULT_MAX (256) is the upper bound and
  *  is fine here too, but 64 keeps the per-poll JSON small. */
 const EVENT_POLL_MAX = 64;
-
-/** Paste is unsafe while the agent is actively producing ('running') or blocked
- *  on a confirmation prompt ('awaiting_input') — those defer to the agent's
- *  Stop. 'waiting' (turn ended, ready for input), 'complete', 'idle', and
- *  unknown are all paste-safe (deliver immediately). */
-const PASTE_UNSAFE_STATUSES: ReadonlySet<string> = new Set(['running', 'awaiting_input']);
-function isBusyStatus(status: string | undefined): boolean {
-  return status != null && PASTE_UNSAFE_STATUSES.has(status);
-}
 
 /**
  * FIX-MULTI-WS — per-`channel.message` delivery decision, extracted PURE so the
@@ -235,6 +230,10 @@ export function useChannelsEventSubscription(): void {
     // after a newer one and overwrite the sidebar/roster with stale membership.
     // Both hydrate paths bump this; only the latest run may commit (CodeRabbit).
     let catalogHydrationRun = 0;
+    // RCA 2026-07-05: grace clock for the isBusy unknown-status gate. Effect-
+    // scoped so the per-pty first-unknown timestamp survives across poll ticks
+    // (a fresh map per remount is correct — a remount re-establishes the poll).
+    const pasteGate = createPasteGateState();
 
     // Drain queued channel mentions into their target panes' PTYs. Reads live
     // store state on each call (no stale closure). Stop path pins onlyPtyId +
@@ -260,16 +259,18 @@ export function useChannelsEventSubscription(): void {
         // is attention-only and DELETES running/idle entries (paneSlice.setSurfaceAgentStatus),
         // so a running agent would read as undefined→idle and get pasted mid-turn (codex P1).
         // surfaceAgent retains the live status for the PTY's lifetime.
-        // A3: fail-CLOSED on unknown agent state. A missing surfaceAgent entry
-        // (a pty whose status broadcast hasn't landed yet, or a cleanup/reattach
-        // window) must NOT read as idle — pasting a nudge into a running agent
-        // corrupts its turn / fires an unintended submit. Treat unknown as busy
-        // and let the agent's Stop event flush the queued mention instead.
-        isBusy: (ptyId) => {
-          const status = st.surfaceAgent[ptyId]?.status;
-          if (status == null) return true;
-          return isBusyStatus(status);
-        },
+        // A3 + RCA 2026-07-05: fail-CLOSED on unknown agent state, but only for
+        // a GRACE window. A missing surfaceAgent entry (status broadcast not yet
+        // landed, or a cleanup/reattach window) must NOT immediately read as idle
+        // — pasting into a running agent corrupts its turn. BUT an agent that has
+        // been idle since its pty attached never re-emits a status pattern, so
+        // its status stays undefined forever; the old permanent fail-closed left
+        // such mentions stuck until an unrelated repaint (e.g. a pane split)
+        // finally emitted 'waiting'. A running agent broadcasts 'running' within
+        // ~1 output burst, so an unknown status that persists past the grace
+        // window is quiet/idle = paste-safe. See channelMentionPasteGate.
+        isBusy: (ptyId) =>
+          isMentionPasteBusy(st.surfaceAgent[ptyId]?.status, ptyId, Date.now(), pasteGate),
         deliverNudge: (ptyId, text) => submitBracketedPasteToPty(ptyId, text),
         markDelivered: st.markChannelMentionDelivered,
         isRateLimited: isNudgeRateLimited,

--- a/src/renderer/hooks/useChannelsEventSubscription.ts
+++ b/src/renderer/hooks/useChannelsEventSubscription.ts
@@ -90,6 +90,38 @@ function isBusyStatus(status: string | undefined): boolean {
   return status != null && PASTE_UNSAFE_STATUSES.has(status);
 }
 
+/**
+ * FIX-MULTI-WS — per-`channel.message` delivery decision, extracted PURE so the
+ * active-vs-background fan-out is unit-testable without the GUI. This is the
+ * exact layer the first multi-workspace attempt regressed: it kept same-ws
+ * delivery working in the daemon filter (whose tests passed) but broke the
+ * renderer's same-ws ROUTING at runtime. Testing the decision here would have
+ * caught that.
+ *
+ *   - `appendToDisplay`: update the message cache / unread / mention badges
+ *     ONLY when the ACTIVE workspace is the sender or a recipient. A background
+ *     workspace keeps no display cache (setChannels is a full replace — a
+ *     background append would count unread against a catalog the active view
+ *     doesn't hold); its view is rebuilt by hydration on switch.
+ *   - `routeWorkspaces`: the LOCAL workspaces this post @-mentions — each gets
+ *     an a2a inbox task (active OR background: the cross-workspace fix). A
+ *     workspace mentioned but not local is skipped (its own renderer routes it).
+ */
+export function planChannelMessageDelivery(
+  senderWorkspaceId: string,
+  recipientWorkspaceIds: readonly string[],
+  mentionWorkspaceIds: readonly string[],
+  activeWorkspaceId: string,
+  localIds: readonly string[],
+): { appendToDisplay: boolean; routeWorkspaces: string[] } {
+  const appendToDisplay =
+    senderWorkspaceId === activeWorkspaceId ||
+    recipientWorkspaceIds.includes(activeWorkspaceId);
+  const mentionWs = new Set(mentionWorkspaceIds);
+  const routeWorkspaces = localIds.filter((id) => mentionWs.has(id));
+  return { appendToDisplay, routeWorkspaces };
+}
+
 /** Bridge global installed by `useRpcBridge` that forwards the
  *  `events.poll` call into the main process. Single-method facade
  *  matching the function-shaped global the bridge installs — the
@@ -366,16 +398,19 @@ export function useChannelsEventSubscription(): void {
             if (event.type === 'channel.message') {
               const channelEvent = event as ChannelMessageEvent;
               const st = useStore.getState();
+              // FIX-MULTI-WS: the pure decision (append-to-active-display +
+              // which local workspaces to route the mention into). See
+              // planChannelMessageDelivery — active-vs-background split, the
+              // exact layer the first multi-ws attempt regressed.
+              const plan = planChannelMessageDelivery(
+                channelEvent.workspaceId,
+                channelEvent.recipientWorkspaceIds,
+                (channelEvent.message.mentions ?? []).map((m) => m.workspaceId),
+                workspaceId,
+                localIds,
+              );
               // Display cache / unread / mention badges: ACTIVE workspace only.
-              // A background workspace's view is rebuilt by catalog + history
-              // hydration when the user switches to it — appending here would
-              // count unread against a catalog the active view doesn't hold.
-              if (
-                channelEvent.workspaceId === workspaceId ||
-                channelEvent.recipientWorkspaceIds.includes(workspaceId)
-              ) {
-                st.appendMessageFromEvent(channelEvent.message);
-              }
+              if (plan.appendToDisplay) st.appendMessageFromEvent(channelEvent.message);
               // Route on REPLAYED events too (no historical drop): a mention
               // that arrived while this poll was down must still enqueue on
               // restart (codex R6). routeChannelMentionToInbox is idempotent
@@ -393,11 +428,7 @@ export function useChannelsEventSubscription(): void {
               // mentioned agent; a miss falls back to a ws-level task (any
               // live agent picks it up via role:agent query). Idempotent by
               // per-target deterministic task id.
-              const mentionWs = new Set(
-                (channelEvent.message.mentions ?? []).map((m) => m.workspaceId),
-              );
-              for (const wsId of localIds) {
-                if (!mentionWs.has(wsId)) continue;
+              for (const wsId of plan.routeWorkspaces) {
                 routeChannelMentionToInbox(channelEvent.message, wsId, leavesFor(wsId), {
                   getTask: st.getTask,
                   createA2aTask: st.createA2aTask,

--- a/src/renderer/hooks/useChannelsEventSubscription.ts
+++ b/src/renderer/hooks/useChannelsEventSubscription.ts
@@ -20,12 +20,18 @@
 //     tasks are pasted into the now-idle pane's PTY (see channelMentionFlush).
 //     The renderer still never pays for pane/process/notification events.
 //
-// Per-recipient scoping: `events.poll` already filters by caller's
-// `workspaceId` for the base event; the channel.event fan-out adds every
-// `recipientWorkspaceId` as a matchable key (see events.rpc.ts). This
-// hook does NOT need to re-filter — it only receives events that the
-// daemon intended for the current workspace. The slice's
-// `appendMessageFromEvent` therefore doesn't re-check `recipientWorkspaceIds`.
+// Per-recipient scoping (FIX-MULTI-WS): the poll is scoped to the UNION of
+// every local workspace (`workspaceIds` param — daemon filters by set
+// membership, see events.rpc.ts). Channels are workspace-independent, so a
+// mention of a pane in a BACKGROUND workspace must deliver while the user is
+// viewing another one — the v1 single-workspace poll silently dropped those.
+// One loop, one cursor: the first multi-loop attempt (one poll loop per
+// workspace) regressed same-workspace delivery and was reverted; the union
+// scope keeps the loop structurally identical to v1. Because the batch now
+// carries OTHER workspaces' events, this hook re-filters per event: display
+// state (message cache / unread / catalog hydration) only for events relevant
+// to the ACTIVE workspace, mention routing + flush for EVERY local recipient
+// workspace.
 //
 // Resync handling: `events.poll` returns `resync: true` when the caller's
 // cursor drifted past the 1024-event ring window. On resync we drop the
@@ -55,7 +61,13 @@ import { findLeafPanes } from './a2aAddressing';
 import { publishA2aTask } from '../events/publisher';
 import { flushMentions, type FlushOpts } from './channelMentionFlush';
 import { submitBracketedPasteToPty } from '../utils/ptyMessageDelivery';
-import type { WmuxEvent, ChannelMessageEvent, AgentLifecycleEvent } from '../../shared/events';
+import type {
+  WmuxEvent,
+  ChannelMessageEvent,
+  ChannelCatalogEvent,
+  AgentLifecycleEvent,
+} from '../../shared/events';
+import type { PaneLeaf } from '../../shared/types';
 
 /** Polling cadence. 1 Hz is the same as the PluginFrame forwardEvents
  *  loop — established precedent. Higher frequency buys sub-second
@@ -89,6 +101,9 @@ interface EventsPollBridge {
     types: readonly ('channel.message' | 'agent.lifecycle' | 'channel.catalog')[];
     max?: number;
     workspaceId: string;
+    /** FIX-MULTI-WS: union scope — every LOCAL workspace id, so background
+     *  workspaces' channel/lifecycle events arrive in the same single poll. */
+    workspaceIds?: readonly string[];
   }): Promise<EventsPollEnvelope | null>;
 }
 
@@ -143,9 +158,11 @@ export function useChannelsEventSubscription(): void {
   // NEVER started — so live channel messages, the unread/mention dock badges,
   // AND the mention→a2a inbox routing all silently no-op'd. Keying the effect on
   // `workspaceId` re-runs it the moment self lands, starting the poll then.
-  // Multi-workspace renderers (FIX-MULTI-WS follow-up) will iterate every member
-  // workspace here; for v1 we poll one.
   const workspaceId = useStore((s) => s.company?.ceoWorkspaceId ?? s.activeWorkspaceId);
+  // FIX-MULTI-WS: every local workspace id, joined so the selector returns a
+  // stable primitive (string) — the effect re-runs (rebuilding the poll scope)
+  // only when a workspace is added/removed, not on unrelated store writes.
+  const allWorkspaceIds = useStore((s) => s.workspaces.map((w) => w.id).join(','));
   useEffect(() => {
     if (!workspaceId) {
       // No resolvable self yet (pre-boot). The selector above re-runs this
@@ -166,6 +183,12 @@ export function useChannelsEventSubscription(): void {
       return;
     }
 
+    // FIX-MULTI-WS: the poll's union scope — every local workspace. The
+    // active/CEO id is unioned in defensively (it should already be in the
+    // list; a boot race where it isn't must not drop it from the scope).
+    const localIds = allWorkspaceIds ? allWorkspaceIds.split(',').filter(Boolean) : [];
+    if (!localIds.includes(workspaceId)) localIds.push(workspaceId);
+
     // A4: stamp the mount time so the first poll can keep events that arrived
     // AFTER mount (live) while skipping pre-mount ring history (see `tick`).
     const mountTs = Date.now();
@@ -184,18 +207,22 @@ export function useChannelsEventSubscription(): void {
     // Drain queued channel mentions into their target panes' PTYs. Reads live
     // store state on each call (no stale closure). Stop path pins onlyPtyId +
     // requireIdle:false; arrival path scans all targets + requireIdle:true.
-    const runFlush = (opts: FlushOpts) => {
+    // FIX-MULTI-WS: parameterized by workspace — the mention queue, pane tree,
+    // and delivery are all per-workspace, and a background workspace's queue
+    // must drain without that workspace being active. `pty.write` goes through
+    // the main process, so an unmounted (background) pane still receives.
+    const runFlush = (wsId: string, opts: FlushOpts) => {
       const st = useStore.getState();
       // A3 sweep: runFlush now fires EVERY poll (not only on a new message) so a
       // mention queued for a pane that read as 'unknown' (fail-closed busy) at
       // arrival is retried once that pane's status resolves to idle. Cheap
       // early-out when nothing is queued so the per-poll sweep skips the
       // findLeafPanes DFS on an empty queue.
-      if (st.getUndeliveredChannelMentionTasks(workspaceId).length === 0) return;
-      const selfWs = st.workspaces.find((w) => w.id === workspaceId);
+      if (st.getUndeliveredChannelMentionTasks(wsId).length === 0) return;
+      const selfWs = st.workspaces.find((w) => w.id === wsId);
       if (!selfWs) return;
       const selfLeaves = findLeafPanes(selfWs.rootPane);
-      flushMentions(workspaceId, selfLeaves, {
+      flushMentions(wsId, selfLeaves, {
         getUndeliveredChannelMentionTasks: st.getUndeliveredChannelMentionTasks,
         // surfaceAgent (NOT surfaceAgentStatus) is the busy source: surfaceAgentStatus
         // is attention-only and DELETES running/idle entries (paneSlice.setSurfaceAgentStatus),
@@ -218,10 +245,27 @@ export function useChannelsEventSubscription(): void {
       }, opts);
     };
 
+    // FIX-MULTI-WS: flush every local workspace's queue. Each per-workspace
+    // call early-outs on an empty queue, so the sweep stays cheap; on the
+    // Stop path only the pty's OWNER workspace resolves a target (the others
+    // no-match on `onlyPtyId`), so flushing all is correct and avoids trusting
+    // the lifecycle event's workspace stamp.
+    const runFlushAll = (opts: FlushOpts) => {
+      for (const wsId of localIds) runFlush(wsId, opts);
+    };
+
     const tick = () => {
       if (disposed || inFlight) return;
       inFlight = true;
-      bridge({ cursor, types: ['channel.message', 'agent.lifecycle', 'channel.catalog'], max: EVENT_POLL_MAX, workspaceId })
+      bridge({
+        cursor,
+        types: ['channel.message', 'agent.lifecycle', 'channel.catalog'],
+        max: EVENT_POLL_MAX,
+        workspaceId,
+        // FIX-MULTI-WS: union scope — the daemon filters by set membership,
+        // so background workspaces' events arrive in this same single poll.
+        workspaceIds: localIds,
+      })
         .then((raw) => {
           if (disposed || !raw) return;
           // Peel the RPC transport envelope { id, ok, result }. The daemon's
@@ -244,6 +288,11 @@ export function useChannelsEventSubscription(): void {
           }
           cursor = result.nextCursor;
           if (result.resync) {
+            // FIX-MULTI-WS: recovery below is ACTIVE-workspace display state
+            // only — background workspaces keep no display cache, so there is
+            // nothing to rebuild for them. A mention that fell out of the ring
+            // during the drift is a rare bounded loss (1024-event window),
+            // same trade-off as the pre-multi-ws behavior.
             // Drift past the ring window — drop the local message
             // cache so the next refresh rebuilds it from the
             // authoritative daemon state. The channel catalog
@@ -295,45 +344,71 @@ export function useChannelsEventSubscription(): void {
             return;
           }
           let sawCatalog = false;
-          // A16: compute this workspace's leaf set ONCE per poll batch — it can't
-          // change mid-batch, and findLeafPanes is a DFS that a busy poll (many
-          // channel.message events) would otherwise re-walk per message.
-          const batchSelfWs = useStore.getState().workspaces.find((w) => w.id === workspaceId);
-          const batchSelfLeaves = batchSelfWs ? findLeafPanes(batchSelfWs.rootPane) : [];
+          // A16 (generalized for FIX-MULTI-WS): compute each workspace's leaf
+          // set at most ONCE per poll batch — it can't change mid-batch, and
+          // findLeafPanes is a DFS that a busy poll (many channel.message
+          // events) would otherwise re-walk per message. Lazy per-workspace
+          // cache: only workspaces actually mentioned in this batch pay it.
+          const batchLeaves = new Map<string, PaneLeaf[]>();
+          const leavesFor = (wsId: string): PaneLeaf[] => {
+            const cached = batchLeaves.get(wsId);
+            if (cached) return cached;
+            const ws = useStore.getState().workspaces.find((w) => w.id === wsId);
+            const leaves = ws ? findLeafPanes(ws.rootPane) : [];
+            batchLeaves.set(wsId, leaves);
+            return leaves;
+          };
           for (const event of result.events) {
-            // The daemon already scoped by `events.poll`'s base
-            // workspaceId + per-recipient fan-out, so every event
-            // here is intended for the current workspace. No
-            // re-filter needed — the slice trusts the dispatch.
+            // FIX-MULTI-WS: the daemon scoped this batch to the UNION of local
+            // workspaces, so an event here may concern a BACKGROUND workspace.
+            // Display state is re-filtered to the active workspace; mention
+            // routing fans out to every local recipient workspace.
             if (event.type === 'channel.message') {
               const channelEvent = event as ChannelMessageEvent;
               const st = useStore.getState();
-              st.appendMessageFromEvent(channelEvent.message);
-              // Route on REPLAYED events too (no historical drop): with single-ws
-              // polling, a mention that arrived while this subscription was on
-              // ANOTHER workspace must still enqueue on switch-back (codex R6).
-              // routeChannelMentionToInbox is idempotent (deterministic task id +
-              // getTask short-circuit), and the flush's busy check stops a stale
-              // replay from pasting into a running agent. Duplicate re-delivery
-              // after a FULL renderer reload (transient delivered map lost) is a
-              // known trade-off — durable delivery state is a follow-up.
-              // #7 + agent-pane redesign: a post that @-mentions THIS workspace
-              // becomes an a2a inbox task. The router resolves the mention's
-              // pinned paneId against our own live leaves (fail-closed ptyId
-              // re-check) and pins to.paneId so a split workspace routes to
-              // EXACTLY the mentioned agent; a miss falls back to a ws-level task
-              // (any live agent picks it up via role:agent query). Idempotent by
+              // Display cache / unread / mention badges: ACTIVE workspace only.
+              // A background workspace's view is rebuilt by catalog + history
+              // hydration when the user switches to it — appending here would
+              // count unread against a catalog the active view doesn't hold.
+              if (
+                channelEvent.workspaceId === workspaceId ||
+                channelEvent.recipientWorkspaceIds.includes(workspaceId)
+              ) {
+                st.appendMessageFromEvent(channelEvent.message);
+              }
+              // Route on REPLAYED events too (no historical drop): a mention
+              // that arrived while this poll was down must still enqueue on
+              // restart (codex R6). routeChannelMentionToInbox is idempotent
+              // (deterministic task id + getTask short-circuit), and the
+              // flush's busy check stops a stale replay from pasting into a
+              // running agent. Duplicate re-delivery after a FULL renderer
+              // reload (transient delivered map lost) is a known trade-off —
+              // durable delivery state is a follow-up.
+              // #7 + agent-pane redesign: a post that @-mentions a LOCAL
+              // workspace becomes an a2a inbox task in THAT workspace — active
+              // or not (FIX-MULTI-WS: this is the cross-workspace delivery
+              // fix). The router resolves the mention's pinned paneId against
+              // that workspace's own live leaves (fail-closed ptyId re-check)
+              // and pins to.paneId so a split workspace routes to EXACTLY the
+              // mentioned agent; a miss falls back to a ws-level task (any
+              // live agent picks it up via role:agent query). Idempotent by
               // per-target deterministic task id.
-              routeChannelMentionToInbox(channelEvent.message, workspaceId, batchSelfLeaves, {
-                getTask: st.getTask,
-                createA2aTask: st.createA2aTask,
-                channelName: (id) => useStore.getState().channels[id]?.name ?? id,
-                workspaceName: (id) =>
-                  useStore.getState().workspaces.find((w) => w.id === id)?.name ?? id,
-                publish: publishA2aTask,
-                isHandled: isChannelMentionHandled,
-                markHandled: markChannelMentionHandled,
-              });
+              const mentionWs = new Set(
+                (channelEvent.message.mentions ?? []).map((m) => m.workspaceId),
+              );
+              for (const wsId of localIds) {
+                if (!mentionWs.has(wsId)) continue;
+                routeChannelMentionToInbox(channelEvent.message, wsId, leavesFor(wsId), {
+                  getTask: st.getTask,
+                  createA2aTask: st.createA2aTask,
+                  channelName: (id) => useStore.getState().channels[id]?.name ?? id,
+                  workspaceName: (id) =>
+                    useStore.getState().workspaces.find((w) => w.id === id)?.name ?? id,
+                  publish: publishA2aTask,
+                  isHandled: isChannelMentionHandled,
+                  markHandled: markChannelMentionHandled,
+                });
+              }
             } else if (event.type === 'agent.lifecycle') {
               // P1 autoresponse: agent.stop is the flush trigger, but only the
               // RIGHT kind+source is a paste-safe idle boundary.
@@ -360,8 +435,10 @@ export function useChannelsEventSubscription(): void {
               //     (no double paste — codex round-4/7). The pty's CURRENT status
               //     is the single source of truth.
               // subagent_stop / awaiting_input never reach here (kind check).
+              // FIX-MULTI-WS: the stop may belong to a BACKGROUND workspace's
+              // pane — flush all local queues; only the pty's owner matches.
               if (ev.kind === 'agent.stop') {
-                runFlush({ onlyPtyId: ev.ptyId });
+                runFlushAll({ onlyPtyId: ev.ptyId });
               }
             } else if (event.type === 'channel.catalog') {
               // A1: a channel's catalog/membership changed (create/archive/join/
@@ -369,16 +446,28 @@ export function useChannelsEventSubscription(): void {
               // re-hydrate after the batch so the sidebar + roster re-sync
               // instead of going silently stale (the audit's top structural gap:
               // 6 of 7 mutations used to emit nothing).
-              sawCatalog = true;
+              // FIX-MULTI-WS: hydration is membership-scoped to the ACTIVE
+              // workspace (setChannels is a full replace — hydrating for a
+              // background workspace would clobber the active view), so only
+              // an active-relevant catalog event triggers it. A background
+              // workspace's catalog is rebuilt on switch.
+              const ce = event as ChannelCatalogEvent;
+              if (
+                ce.recipientWorkspaceIds.includes('*') ||
+                ce.workspaceId === workspaceId ||
+                ce.recipientWorkspaceIds.includes(workspaceId)
+              ) {
+                sawCatalog = true;
+              }
             }
           }
           // Idle-immediate + A3 sweep: deliver any queued mention to a now-idle
           // pane. Runs EVERY poll (not only on a new message) so a mention queued
           // while its target pane read as 'unknown' (fail-closed busy) is retried
           // once that pane resolves to idle — without this, A3's fail-closed left
-          // such mentions undelivered forever (GLM P2). The early-out in runFlush
-          // keeps an empty-queue tick cheap.
-          runFlush({});
+          // such mentions undelivered forever (GLM P2). The per-workspace
+          // early-out in runFlush keeps an empty-queue tick cheap.
+          runFlushAll({});
           // A1: re-hydrate the catalog once per batch when any channel.catalog
           // event arrived. The six non-post mutations now emit this signal; the
           // receiver re-fetches list+members (daemon = source of truth), so a
@@ -418,5 +507,8 @@ export function useChannelsEventSubscription(): void {
       disposed = true;
       clearInterval(timer);
     };
-  }, [workspaceId]);
+    // FIX-MULTI-WS: allWorkspaceIds rebuilds the loop (and its union scope)
+    // when a workspace is added/removed — a NEW workspace must join the poll
+    // scope or its mentions would silently drop until the next remount.
+  }, [workspaceId, allWorkspaceIds]);
 }

--- a/src/renderer/hooks/useChannelsEventSubscription.ts
+++ b/src/renderer/hooks/useChannelsEventSubscription.ts
@@ -64,6 +64,8 @@ import { submitBracketedPasteToPty } from '../utils/ptyMessageDelivery';
 import {
   createPasteGateState,
   isMentionPasteBusy,
+  notePtyOutput,
+  prunePasteGateState,
 } from './channelMentionPasteGate';
 import type {
   WmuxEvent,
@@ -234,6 +236,15 @@ export function useChannelsEventSubscription(): void {
     // scoped so the per-pty first-unknown timestamp survives across poll ticks
     // (a fresh map per remount is correct — a remount re-establishes the poll).
     const pasteGate = createPasteGateState();
+    // RCA 2026-07-05 (mid-turn paste race): stamp each pty's last-output time so
+    // the paste gate's second (output-quiet) check can tell a slow/thinking
+    // background agent (still emitting) from a truly idle one. main forwards
+    // background pane pty output to the renderer too (pty.handler.ts, no mounted
+    // gating), so this sees every local pane. Optional-chained for the (test /
+    // pre-mount) window where electronAPI isn't installed yet.
+    const removePtyDataListener = window.electronAPI?.pty?.onData?.((id) =>
+      notePtyOutput(pasteGate, id, Date.now()),
+    );
 
     // Drain queued channel mentions into their target panes' PTYs. Reads live
     // store state on each call (no stale closure). Stop path pins onlyPtyId +
@@ -285,6 +296,24 @@ export function useChannelsEventSubscription(): void {
     // the lifecycle event's workspace stamp.
     const runFlushAll = (opts: FlushOpts) => {
       for (const wsId of localIds) runFlush(wsId, opts);
+    };
+
+    // Map-leak guard (3-model consensus): prune the paste gate's per-pty clocks
+    // down to the live leaf ptys. Runs in the tick's `.finally` — poll-outcome
+    // independent, so a stretch of failed polls can't let the global pty-data
+    // listener grow `lastOutputAt` unbounded (Codex map-leak follow-up).
+    const pruneGateToLivePanes = () => {
+      const st = useStore.getState();
+      const live = new Set<string>();
+      for (const wsId of localIds) {
+        const ws = st.workspaces.find((w) => w.id === wsId);
+        if (ws) {
+          for (const leaf of findLeafPanes(ws.rootPane)) {
+            for (const s of leaf.surfaces) if (s.ptyId) live.add(s.ptyId);
+          }
+        }
+      }
+      prunePasteGateState(pasteGate, live);
     };
 
     const tick = () => {
@@ -527,6 +556,7 @@ export function useChannelsEventSubscription(): void {
         })
         .finally(() => {
           inFlight = false;
+          pruneGateToLivePanes();
         });
     };
 
@@ -538,6 +568,7 @@ export function useChannelsEventSubscription(): void {
     return () => {
       disposed = true;
       clearInterval(timer);
+      removePtyDataListener?.();
     };
     // FIX-MULTI-WS: allWorkspaceIds rebuilds the loop (and its union scope)
     // when a workspace is added/removed — a NEW workspace must join the poll

--- a/src/shared/__tests__/replayQuerySanitizer.test.ts
+++ b/src/shared/__tests__/replayQuerySanitizer.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { stripReplayQuerySequences } from '../replayQuerySanitizer';
+
+const strip = (s: string): string =>
+  stripReplayQuerySequences(Buffer.from(s, 'latin1')).toString('latin1');
+
+describe('stripReplayQuerySequences', () => {
+  // The incident class: 3,653 stored DECXCPR queries re-fired on reattach.
+  it('strips DECXCPR runs (the 2026-07-04 CPR storm offender)', () => {
+    const run = '\x1b[?6n'.repeat(40);
+    expect(strip(`\x1b[40;3H\x1b[?25h${run}`)).toBe('\x1b[40;3H\x1b[?25h');
+  });
+
+  it('strips DSR family — plain CPR and status', () => {
+    expect(strip('a\x1b[6nb\x1b[5nc')).toBe('abc');
+  });
+
+  it('strips DA1/DA2/DA3', () => {
+    expect(strip('\x1b[c\x1b[0c\x1b[>c\x1b[>0c\x1b[=c')).toBe('');
+  });
+
+  it('strips XTVERSION but preserves DECSCUSR (cursor style)', () => {
+    expect(strip('\x1b[>0q')).toBe('');
+    expect(strip('\x1b[2 q')).toBe('\x1b[2 q');
+  });
+
+  it('strips DECRQM probes', () => {
+    expect(strip('\x1b[?2026$p\x1b[?2004$p\x1b[4$p')).toBe('');
+  });
+
+  it('strips OSC color queries, preserves color SETs and titles', () => {
+    expect(strip('\x1b]11;?\x07\x1b]10;?\x1b\\\x1b]4;5;?\x07')).toBe('');
+    expect(strip('\x1b]11;#000000\x07')).toBe('\x1b]11;#000000\x07');
+    // A window title ending in "?" is not a query.
+    expect(strip('\x1b]0;done?\x07')).toBe('\x1b]0;done?\x07');
+    // Semantic-prompt (133) and cwd (7) OSCs pass through.
+    expect(strip('\x1b]133;A\x07\x1b]7;file://host/x\x07')).toBe(
+      '\x1b]133;A\x07\x1b]7;file://host/x\x07',
+    );
+  });
+
+  it('strips DCS queries (DECRQSS, XTGETTCAP) and ENQ', () => {
+    expect(strip('\x1bP$qm\x1b\\\x1bP+q544e\x1b\\\x05')).toBe('');
+  });
+
+  it('preserves display sequences and multi-byte text byte-exactly', () => {
+    const display =
+      '\x1b[1m\x1b[38;5;196m한글 텍스트\x1b[0m\x1b[40;3H\x1b[K' +
+      '\x1b[71C\x1b[?1049h\x1b[2J\x1b[H\x1b[?25h\x1b[?1000h\x1b[?2004h';
+    const buf = Buffer.from(display, 'utf8');
+    const out = stripReplayQuerySequences(buf);
+    expect(out.equals(buf)).toBe(true);
+  });
+
+  it('returns the same buffer reference when nothing matched', () => {
+    const buf = Buffer.from('plain prompt $ ', 'utf8');
+    expect(stripReplayQuerySequences(buf)).toBe(buf);
+  });
+
+  it('cleans a realistic claude-boot replay tail without touching the repaint', () => {
+    // Condensed from the real ring buffer: boot probes (DA1, XTVERSION),
+    // alt-screen entry, final repaint, then the query flood.
+    const replay =
+      '\x1b[?2031h\x1b[>0q\x1b[c\x1b[?1049h\x1b[2J\x1b[H' +
+      '\x1b[39B\x1b[K\x1b[42;1H\x1b[40;3H\x1b[?25h' +
+      '\x1b[?6n'.repeat(370);
+    expect(strip(replay)).toBe(
+      '\x1b[?2031h\x1b[?1049h\x1b[2J\x1b[H' +
+        '\x1b[39B\x1b[K\x1b[42;1H\x1b[40;3H\x1b[?25h',
+    );
+  });
+});

--- a/src/shared/replayQuerySanitizer.ts
+++ b/src/shared/replayQuerySanitizer.ts
@@ -1,0 +1,70 @@
+/**
+ * Ring-replay query sanitizer (CPR feedback-storm RCA 2026-07-04).
+ *
+ * When the renderer reattaches, the daemon replays the persisted ring buffer
+ * verbatim and xterm.js RE-EXECUTES every sequence in it — including one-shot
+ * terminal queries the dead session's TUI once emitted. Each replayed query
+ * fires a live auto-reply through terminal.onData → pty.write into whatever
+ * process now owns the pty. After a daemon restart that process is a FRESH
+ * shell that never asked: zsh's ZLE eats the `ESC[?` prefix, beeps, and
+ * self-inserts the rest (`40;3R`...), and that junk echo is appended to the
+ * ring — so every subsequent reattach re-fires the whole batch again.
+ *
+ * Incident evidence: a claude pane left running while the renderer was
+ * detached (app restart window) had no responder, retried DECXCPR, and
+ * accumulated 3,653 raw `\x1b[?6n` in its ring. On reattach xterm answered
+ * all of them into the fresh zsh → 8,125 `40;3R^G` echoes, O(n²) ZLE line
+ * redraws, zsh 98% / daemon 100% CPU.
+ *
+ * The sibling guard STALE_REPLAY_INPUT_MODE_RESETS cannot cover this class:
+ * it un-latches MODES after the replay, but queries are one-shot — the reply
+ * has already been sent by the time any reset could run. The only correct
+ * point is to strip queries from the replay payload BEFORE xterm sees it.
+ * Replay is display-only, and queries have zero display value, so stripping
+ * is lossless for the user.
+ *
+ * Applied at DaemonClient.setupSessionPipe, the single choke point where the
+ * full replay exists as one contiguous buffer cleanly separated from live
+ * bytes by FLUSH_DONE_MARKER — no streaming/chunk-boundary state needed, and
+ * live queries from running TUIs are never touched.
+ */
+
+/**
+ * Every sequence family xterm.js answers with an auto-reply. Finals are
+ * unambiguous: CSI `n` is only DSR, CSI `c` only DA, CSI `$p` only DECRQM.
+ * XTVERSION requires the `>` prefix so DECSCUSR (`CSI Ps SP q`, cursor
+ * style — display-relevant) is never matched.
+ */
+const REPLAY_QUERY_SEQUENCES = new RegExp(
+  [
+    // DSR / DECDSR — CSI Ps n, CSI ? Ps n (incl. the CPR offender \x1b[?6n)
+    '\\x1b\\[\\??[0-9;]*n',
+    // DA1 / DA2 / DA3 — CSI c, CSI > c, CSI = c
+    '\\x1b\\[[>=]?[0-9;]*c',
+    // XTVERSION — CSI > Ps q
+    '\\x1b\\[>[0-9;]*q',
+    // DECRQM — CSI Ps $ p, CSI ? Ps $ p (claude probes ?2026 sync output)
+    '\\x1b\\[\\??[0-9;]*\\$p',
+    // OSC color queries — OSC 4/5/10..19 whose last param is "?" (BEL or ST
+    // terminated). Titles (OSC 0/2) never match, even ones ending in "?".
+    '\\x1b\\](?:4|5|1[0-9])(?:;[0-9]*)*;\\?(?:\\x07|\\x1b\\\\)',
+    // DCS queries — DECRQSS (DCS $ q .. ST) and XTGETTCAP (DCS + q .. ST)
+    '\\x1bP[$+]q[^\\x1b]*\\x1b\\\\',
+    // ENQ — answerback query
+    '\\x05',
+  ].join('|'),
+  'g',
+);
+
+/**
+ * Strip auto-reply-triggering query sequences from a ring-replay payload.
+ * Returns the input buffer unchanged (same reference) when nothing matched.
+ */
+export function stripReplayQuerySequences(replay: Buffer): Buffer {
+  // latin1 gives a 1:1 byte↔char mapping, so multi-byte UTF-8 text round-trips
+  // untouched and the regex only ever removes ASCII-range sequences.
+  const text = replay.toString('latin1');
+  const stripped = text.replace(REPLAY_QUERY_SEQUENCES, '');
+  if (stripped.length === text.length) return replay;
+  return Buffer.from(stripped, 'latin1');
+}


### PR DESCRIPTION
## Summary

Cross-workspace channel mention delivery plus three terminal/shell reliability fixes, all reviewed by a 3-model panel (Claude, Codex, GLM 5.2).

**Channels — cross-workspace delivery** (`ea36425`, `7a108ea`)
- The renderer polled only the active workspace, so a mention to a background-workspace pane never delivered until you switched to it. Now the renderer sends every local workspace id in one `events.poll` (union scope) and the daemon filters by set membership. The per-event active-vs-background fan-out decision is extracted into a pure function (`planChannelMessageDelivery`) with unit tests, guarding against the same-workspace regression a prior N-loop attempt caused.

**Channels — idle delivery + mid-turn paste guard** (`c8b3bf9`, `941a639`)
- An agent idle since attach never re-emits a status pattern, so its status stayed unknown and the paste gate held its mention forever. Unknown status is now held for a grace window then delivered — but guarded by a second output-quiet check (a running-but-quiet agent keeps emitting sub-burst output, so it stays held and isn't pasted mid-turn) and a hard hold ceiling (a perpetual-unknown pane delivers late, never never).

**Terminal — CPR replay feedback storm** (`ce8638d`)
- On reattach the daemon replayed persisted scrollback verbatim; xterm re-executed the one-shot terminal queries a prior TUI emitted, each firing a live auto-reply into the fresh shell. A detached running pane accumulated thousands, pinning zsh/daemon near 100% CPU on reattach. Query sequences are stripped from the replay payload before xterm sees them; live output is untouched.

**Shell — zsh split SIGBUS on macOS** (`a9d028b`)
- The zsh OSC 133;B prompt marker was appended without a `%{...%}` zero-width guard, so zsh's line editor miscounted prompt width and crashed (SIGBUS in `zle`) during the resize sweep a split triggers. Width-guarded now, matching the bash/PowerShell integrations. `INTEGRATION_VERSION` bumped so the daemon reinstalls the stub.

## Test Coverage

All new source paths have unit coverage:
- `events.rpc.ts` union scope: 8 new cases (empty-scope fail-closed, cap, non-string rejection).
- `planChannelMessageDelivery`: 10 fan-out decision cases.
- `channelMentionPasteGate`: 15 cases (grace, output-quiet mid-turn hold, idle delivery, hard ceiling, map prune).
- `replayQuerySanitizer`: query-strip + display-preserve + UTF-8 round-trip.
- `shellIntegration`: 133;B marker inside `%{...%}`.

Full suite: 4785 passed, 0 failed. tsc clean.

## Pre-Landing Review — 3-model panel (Claude · Codex · GLM 5.2)

Two rounds. Round 1 (branch diff): confirmed the events.rpc trust boundary is safe (MCP can't inject `workspaceIds`, empty-scope fail-closed for a2a/channel events), replay sanitizer has no ReDoS / UTF-8 corruption, zsh guard verified against real zsh. Codex + Claude flagged a **mid-turn paste race** (running-but-quiet agent) and a 3-model **map leak** — both fixed in `941a639`.

Round 2 (the fix): Codex flagged a residual **never-deliver risk** (output-quiet could hold a perpetual-unknown pane forever) and a prune-on-poll-success gap. Both addressed with a hard `MAX_UNKNOWN_HOLD_MS` ceiling and a poll-outcome-independent prune.

## Known follow-ups (tracked in TODOS.md)

- `OUTPUT_QUIET_MS` / `MAX_UNKNOWN_HOLD_MS` are conservative defaults pending dogfood tuning against real idle vs thinking output cadence (P2).
- Pre-existing: unscoped plugin `events.poll` fail-opens lifecycle events (P2, TODOS:227) — not touched or widened by this branch; the new channel/a2a events are fail-closed.

## Test plan
- [x] Full vitest suite: 4785 passed, 7 skipped, 0 failed
- [x] tsc --noEmit clean
- [x] zsh split SIGBUS reproduced (3/3 unguarded) and fixed (0/3 guarded) via node-pty harness
- [x] Deployed: v5 daemon running the guarded stub, split verified working by the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channel mentions now resolve across all matching local workspaces (union scoping), enabling cross-workspace delivery without switching views.

* **Bug Fixes**
  * Reattaching sessions no longer replays terminal query sequences that could trigger feedback loops and high CPU.
  * Mentions to idle background agents now deliver more reliably using tighter “unknown status” hold logic.
  * macOS pane splitting no longer crashes zsh by ensuring OSC 133 prompt markers are safely zero-width guarded.

* **Documentation**
  * Updated API reference header for the latest release source version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->