### PR TITLE
feat(channels): P5 통합 휴먼 정체성 — 워크스페이스 독립 채널 뷰 (v3.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.0] — 2026-07-05
+
+### Added
+
+- **You are ONE person in channels now — everywhere.** Your channel identity is a single app-wide seat instead of one seat per workspace: the roster shows just "Me" (no more "Me · Workspace 2"), your channel list / memberships / unread badges are identical no matter which workspace is open, and joining or creating a channel no longer stamps whichever workspace happened to be active. The daemon merges your previously scattered per-workspace rows into the one seat at boot (deterministic, crash-safe, keeps your earliest join date and furthest read position).
+- **Upgrades can't silently wipe your channels anymore.** wmux keeps the background daemon alive across app restarts by design, so an upgraded app could attach to an old daemon and channels would look missing (posts failed with no explanation). The channels panel now detects the stale daemon and shows a "quit wmux fully and start it again" banner; it clears itself after the restart.
+
+### Changed
+
+- **The unread badge is honest now.** Agent posts from the workspace you're looking at used to be silently muted (workspace-level self-mute); with the unified seat, only YOUR OWN posts stay quiet — an agent posting from any workspace counts as unread, because it's news to you.
+- Adding a whole workspace as a channel member is retired — you are already in your channels as one seat, and agents join as individual panes.
+
+### Fixed
+
+- **Private agent-only channels no longer leak into your dock.** A private channel between agents whose workspace happened to be active could bump your unread badge for a channel you can't even open (phantom badge). Display is now scoped to channels you are actually in.
+- The channel wake worker no longer sweeps the virtual human seat every tick (it owns no terminal, so the sweep was pure CPU drift that grew with history).
+
+### Security
+
+- The reserved human seat cannot be invited, claimed, or targeted from the agent pipe — an agent could previously seed a phantom "human" member row that force-injected its channel into your always-on view. Rejected at both the pipe router and the daemon, so a direct-socket caller cannot bypass it either.
+
 ## [3.15.0] — 2026-07-05
 
 ### Added

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.15.0 sources.** This file is produced by
+> **Generated from wmux v3.16.0 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.11.1",
+  "version": "3.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.11.1",
+      "version": "3.16.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",

--- a/plans/channels-remediation-plan-2026-07-05.md
+++ b/plans/channels-remediation-plan-2026-07-05.md
@@ -164,6 +164,18 @@
 
 **목표:** 어느 워크스페이스를 봐도 채널 unread/멤버십/뷰가 동일. 배달은 이미 ws-독립인데(FIX-MULTI-WS) 휴먼 뷰만 활성-종속인 비대칭 해소. **결정 필요 §D3.**
 
+> **우선순위 승격 (2026-07-05):** 사용자가 두 차례 직접 부딪힘("활성 ws 따라 동작이 달라짐", 로스터 "나 · Workspace 2" 스크린샷). P3/P4보다 앞으로 — **P2 착지 직후 착수.**
+>
+> **확정 설계 (v1.2, Fable): 가상 휴먼 워크스페이스** — R4가 예정한 "external principal = 가상 ws additive" 메커니즘을 휴먼에 선차용.
+> - `HUMAN_WORKSPACE_ID = 'ws-human'` 예약 상수(shared/channels.ts). 휴먼 멤버 행 = `(ws-human, 'local-ui', principalId:'human:me')` — memberId는 기존 예약 id 유지(파이프 스푸핑 거부 배선 재사용), 표시 로직("나") 무변경.
+> - **daemon load-time 병합 마이그레이션(additive, 1회)**: 채널별 모든 `(anyWs, local-ui)` 행 → `(ws-human, local-ui)` 단일 행. lastReadSeq=max, historyFromSeq=min, 기존 행 제거. 스키마 필드 무변경(version 1 유지).
+> - **authz**: 휴먼 뮤테이션은 renderer-local 경로가 `verifiedWorkspaceId='ws-human'` 스탬프(프로세스 경계 신뢰, 기존 모델 그대로). 파이프에서 'ws-human' 주장 → **거부**(local-ui 스푸핑 가드와 동일 계열, a2a.channel.rpc.ts + channelCallerIdentity).
+> - **표시/이벤트**: 렌더러 poll `workspaceIds`에 'ws-human' 상수 union → ws-human이 수신자인 채널은 **활성 워크스페이스 무관하게 항상 표시**(appendToDisplay 규칙 확장). myChannelIds/viewer/ack/leave의 self 판정 전부 ws-human 기준으로 교체.
+> - **안전 불변식 유지**: ws-human엔 pane이 없고 inbox의 human 필터가 존재 → 휴먼 멘션은 구조적으로 PTY 불가침 그대로. wake worker memberWorkspaces에서 ws-human 제외(휴먼은 GUI 배지).
+> - **UI**: 로스터 "나" 단독(꼬리표 소멸 — 행이 하나라 모호성 없음). "워크스페이스 추가" 섹션은 "에이전트 판 추가" 중심으로 재편(에이전트 pane 행이 이미 ws 멤버십을 제공하므로 ws-단위 추가는 불필요 — 제거 또는 보조로 강등, +4d 시드와 함께).
+> - **기각 대안**: 렌더러-only 병합(디스크 진실이 흩어진 채 남는 반쪽 수정), 회사모드 승격(무거운 우회).
+> - **리스크**: 데몬 마이그레이션 = 최고위험 영역 → test-first + 3모델 리뷰 + 도그푸드 게이트. 렌더러 self-판정 치환은 범위 넓지만 기계적.
+
 - **문제:** 표시가 `activeWorkspaceId` 정체성에 묶임 — `planChannelMessageDelivery` appendToDisplay=활성만(`useChannelsEventSubscription.ts:114-116`), `selfWorkspaceId`=활성(`ChannelsPanel.tsx:691`), list/hydration이 활성 ws 질의. 휴먼이 워크스페이스별 `local-ui`로 흩어진 결과. [감사 §5, planChannelMessageDelivery]
 - **변경:**
   - 5a. `appendToDisplay`를 "활성만" → **어느 로컬 ws든 멤버인 채널이면 표시**(union).

--- a/src/daemon/channels/ChannelService.ts
+++ b/src/daemon/channels/ChannelService.ts
@@ -38,7 +38,10 @@ import {
   type ChannelRecipientStatus,
   type ChannelState,
   type ChannelVisibility,
+  HUMAN_WORKSPACE_ID,
+  HUMAN_MEMBER_ID,
 } from '../../shared/channels';
+import { HUMAN_SELF_PRINCIPAL_ID } from '../../shared/principals';
 import type { ChannelStateWriter } from './ChannelStateWriter';
 
 /**
@@ -362,6 +365,34 @@ export class ChannelService {
           member.lastReadSeq = head;
         }
       }
+    }
+    // P5 (unified human identity) — merge every per-workspace human row into
+    // THE single virtual-workspace row. Pre-P5, joining/creating stamped the
+    // then-active workspace, scattering the one human across `(ws-X,
+    // 'local-ui')` rows and binding the channel view to the active workspace.
+    // Deterministic on every construction (same crash-safety contract as the
+    // lastReadSeq backfill above — and it runs AFTER it, so every cursor is a
+    // number): a pre-P5 state re-merges identically, a post-P5 state is a
+    // no-op, and the merged shape persists on the next regular save.
+    for (const channel of this.state.channels) {
+      const rows = this.state.members[channel.id] ?? [];
+      const humanRows = rows.filter((m) => m.memberId === HUMAN_MEMBER_ID);
+      if (humanRows.length === 0) continue;
+      if (humanRows.length === 1 && humanRows[0].workspaceId === HUMAN_WORKSPACE_ID) continue;
+      this.state.members[channel.id] = [
+        {
+          workspaceId: HUMAN_WORKSPACE_ID,
+          memberId: HUMAN_MEMBER_ID,
+          // Earliest seat wins: the human has been "in" since their first join.
+          joinedAt: Math.min(...humanRows.map((m) => m.joinedAt)),
+          // Widest visibility + furthest cursor: the human could already see
+          // everything any seat saw, and consumed up to the furthest ack.
+          historyFromSeq: Math.min(...humanRows.map((m) => m.historyFromSeq)),
+          lastReadSeq: Math.max(...humanRows.map((m) => m.lastReadSeq ?? 0)),
+          principalId: HUMAN_SELF_PRINCIPAL_ID,
+        },
+        ...rows.filter((m) => m.memberId !== HUMAN_MEMBER_ID),
+      ];
     }
     // Hydrate the idempotency LRU from persisted state (R9). Without
     // this, a daemon restart loses every `clientMsgId → seq` mapping

--- a/src/daemon/channels/ChannelService.ts
+++ b/src/daemon/channels/ChannelService.ts
@@ -385,8 +385,15 @@ export class ChannelService {
           memberId: HUMAN_MEMBER_ID,
           // Earliest seat wins: the human has been "in" since their first join.
           joinedAt: Math.min(...humanRows.map((m) => m.joinedAt)),
-          // Widest visibility + furthest cursor: the human could already see
-          // everything any seat saw, and consumed up to the furthest ack.
+          // Widest visibility + furthest cursor: the human is ONE principal, so
+          // if any seat read up to seq N the human has seen the content up to N
+          // (ship review: Claude adversarial confirmed this semantic). Codex
+          // flagged a narrow edge — a seat with a narrow history floor but a
+          // high (e.g. backfilled-to-head) cursor could mark a low seq read that
+          // only a WIDER-history seat could see but didn't. It is benign here:
+          // the ws-human cursor feeds only the now-excluded wake sweep (never a
+          // renderer badge — the renderer computes unread from live events), and
+          // opening the channel re-acks to head regardless.
           historyFromSeq: Math.min(...humanRows.map((m) => m.historyFromSeq)),
           lastReadSeq: Math.max(...humanRows.map((m) => m.lastReadSeq ?? 0)),
           principalId: HUMAN_SELF_PRINCIPAL_ID,
@@ -627,6 +634,12 @@ export class ChannelService {
           // v2 cursor seeded at head (nextSeq-1 = 0 on a fresh channel):
           // a brand-new channel starts with zero unread.
           lastReadSeq: 0,
+          // P5: stamp the human principal when the creator is the human seat, so
+          // a GUI-created channel's human row matches the migrated shape.
+          ...(params.verifiedWorkspaceId === HUMAN_WORKSPACE_ID &&
+          params.createdBy.memberId === HUMAN_MEMBER_ID
+            ? { principalId: HUMAN_SELF_PRINCIPAL_ID }
+            : {}),
         },
       ];
       for (const member of params.members ?? []) {
@@ -802,8 +815,18 @@ export class ChannelService {
         // (historyFromSeq) but does not owe an ack for the backlog; unread
         // starts at 0 so the wake worker never nudge-storms a fresh member.
         lastReadSeq: channel.nextSeq - 1,
-        // R2: principal stable coordinate (additive, for display/routing).
-        ...(params.member.principalId ? { principalId: params.member.principalId } : {}),
+        // R2: principal stable coordinate (additive, for display/routing). P5:
+        // a fresh human seat (ws-human, local-ui) is stamped with the human
+        // principal daemon-side so it matches the migrated row's shape — the
+        // renderer join/create paths send no principalId (ship review:
+        // data-migration shape drift), so normalize here where every transport
+        // converges.
+        ...(params.verifiedWorkspaceId === HUMAN_WORKSPACE_ID &&
+        params.member.memberId === HUMAN_MEMBER_ID
+          ? { principalId: HUMAN_SELF_PRINCIPAL_ID }
+          : params.member.principalId
+            ? { principalId: params.member.principalId }
+            : {}),
       });
       this.state.members[channel.id] = members;
       if (!this.saveOrFail()) {
@@ -1061,6 +1084,23 @@ export class ChannelService {
         return { ok: false, error: { code: 'CHANNEL_ARCHIVED', message: 'Cannot invite to an archived channel' } };
       }
       const invitee = params.invitedMember;
+      // P5: the reserved human workspace is never an invite TARGET. The human
+      // joins channels themselves via the GUI (self-join as ws-human); an invite
+      // into ws-human could only seed a phantom (ws-human, <non-local-ui>) row —
+      // the load-time merge folds only memberId 'local-ui', and every renderer
+      // membership check is workspaceId-keyed, so such a row force-injects a
+      // channel into the human's always-on view (ship review: 5-model consensus).
+      // Enforced HERE (not just the main-pipe router) so a direct daemon-pipe
+      // caller under the #113 same-user ceiling cannot bypass it either.
+      if (invitee.workspaceId === HUMAN_WORKSPACE_ID) {
+        return {
+          ok: false,
+          error: {
+            code: 'NOT_AUTHORIZED',
+            message: 'The reserved human workspace cannot be invited; the human joins via the GUI',
+          },
+        };
+      }
       if (members.some((m) => m.workspaceId === invitee.workspaceId && m.memberId === invitee.memberId)) {
         return { ok: false, error: { code: 'DUPLICATE_MEMBER', message: 'Already a member' } };
       }
@@ -1669,7 +1709,15 @@ export class ChannelService {
     const out = new Set<string>();
     for (const channel of this.state.channels) {
       if (channel.status === 'archived') continue;
-      for (const m of this.state.members[channel.id] ?? []) out.add(m.workspaceId);
+      for (const m of this.state.members[channel.id] ?? []) {
+        // P5: never sweep the virtual human workspace. It owns no PTY session,
+        // so pickTarget always misses — but including it made the wake worker
+        // walk every channel's every message each 15s tick for an unread cursor
+        // that can never be nudged or exhausted (ship review: Claude adversarial
+        // F5 CPU drift + data-migration). The human is reached by the GUI badge.
+        if (m.workspaceId === HUMAN_WORKSPACE_ID) continue;
+        out.add(m.workspaceId);
+      }
     }
     return Array.from(out);
   }

--- a/src/daemon/channels/ChannelService.ts
+++ b/src/daemon/channels/ChannelService.ts
@@ -602,6 +602,22 @@ export class ChannelService {
       if (this.state.channels.some((c) => c.companyId === this.companyId && c.name === name)) {
         return { ok: false, error: { code: 'INVALID_NAME', message: `Channel name already exists: ${name}` } };
       }
+      // P5: the reserved human workspace is never seeded as an initial member
+      // from create(). Symmetric with invite()'s guard — enforced daemon-side so
+      // a direct-socket caller (under the #113 ceiling) cannot bypass the
+      // main-router members[] guard and plant a phantom human row (ship review).
+      // Validated BEFORE the channel is pushed into state so a rejection leaves
+      // NO orphaned in-memory channel (adversarial review: the in-loop guard
+      // early-returned after the push, leaking a phantom row until restart).
+      if ((params.members ?? []).some((m) => m.workspaceId === HUMAN_WORKSPACE_ID)) {
+        return {
+          ok: false,
+          error: {
+            code: 'NOT_AUTHORIZED',
+            message: 'The reserved human workspace cannot be seeded as a channel member',
+          },
+        };
+      }
       const now = this.now();
       const channel: Channel = {
         id: `ch-${randomUUID()}`,
@@ -643,19 +659,6 @@ export class ChannelService {
         },
       ];
       for (const member of params.members ?? []) {
-        // P5: the reserved human workspace is never seeded as an initial member
-        // from create(). Symmetric with invite()'s guard — enforced daemon-side
-        // so a direct-socket caller (under the #113 ceiling) cannot bypass the
-        // main-router members[] guard and plant a phantom human row (ship review).
-        if (member.workspaceId === HUMAN_WORKSPACE_ID) {
-          return {
-            ok: false,
-            error: {
-              code: 'NOT_AUTHORIZED',
-              message: 'The reserved human workspace cannot be seeded as a channel member',
-            },
-          };
-        }
         if (
           initialMembers.some(
             (m) => m.workspaceId === member.workspaceId && m.memberId === member.memberId,

--- a/src/daemon/channels/ChannelService.ts
+++ b/src/daemon/channels/ChannelService.ts
@@ -643,6 +643,19 @@ export class ChannelService {
         },
       ];
       for (const member of params.members ?? []) {
+        // P5: the reserved human workspace is never seeded as an initial member
+        // from create(). Symmetric with invite()'s guard — enforced daemon-side
+        // so a direct-socket caller (under the #113 ceiling) cannot bypass the
+        // main-router members[] guard and plant a phantom human row (ship review).
+        if (member.workspaceId === HUMAN_WORKSPACE_ID) {
+          return {
+            ok: false,
+            error: {
+              code: 'NOT_AUTHORIZED',
+              message: 'The reserved human workspace cannot be seeded as a channel member',
+            },
+          };
+        }
         if (
           initialMembers.some(
             (m) => m.workspaceId === member.workspaceId && m.memberId === member.memberId,

--- a/src/daemon/channels/__tests__/ChannelService.test.ts
+++ b/src/daemon/channels/__tests__/ChannelService.test.ts
@@ -2503,3 +2503,18 @@ describe('P5 migration — ship-review hardening', () => {
     expect(svc.memberWorkspaces()).not.toContain(HUMAN_WS);
   });
 });
+
+describe('ChannelService.create — P5 reserved human workspace guard (ship review, Codex delta)', () => {
+  it('rejects a create whose initial members[] seeds the reserved human workspace', async () => {
+    const { svc } = makeService();
+    const res = await svc.create({
+      name: 'sneaky',
+      visibility: 'private',
+      createdBy: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+      verifiedWorkspaceId: 'ws-1',
+      members: [{ workspaceId: 'ws-human', memberId: 'agentX', memberName: 'X' }],
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe('NOT_AUTHORIZED');
+  });
+});

--- a/src/daemon/channels/__tests__/ChannelService.test.ts
+++ b/src/daemon/channels/__tests__/ChannelService.test.ts
@@ -2516,5 +2516,17 @@ describe('ChannelService.create — P5 reserved human workspace guard (ship revi
     });
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error.code).toBe('NOT_AUTHORIZED');
+    // Adversarial review: the rejection must leave NO orphaned in-memory channel.
+    // The phantom would be private + memberless (invisible to list), so the
+    // OBSERVABLE consequence is the duplicate-name check: a subsequent VALID
+    // create of the same name must SUCCEED (a leaked orphan would falsely
+    // collide). The guard now validates BEFORE the channel is pushed into state.
+    const retry = await svc.create({
+      name: 'sneaky',
+      visibility: 'private',
+      createdBy: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+      verifiedWorkspaceId: 'ws-1',
+    });
+    expect(retry.ok).toBe(true);
   });
 });

--- a/src/daemon/channels/__tests__/ChannelService.test.ts
+++ b/src/daemon/channels/__tests__/ChannelService.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { ChannelService } from '../ChannelService';
 import type { ChannelServiceEmit } from '../ChannelService';
 import type {
+  ChannelMember,
   ChannelMessage,
   ChannelState,
 } from '../../../shared/channels';
@@ -2424,5 +2425,81 @@ describe('P5 — unified human identity migration (load-time merge)', () => {
     const rows = svc.getMembers('ch-1', 'ws-a');
     expect(rows).toHaveLength(1);
     expect(rows[0].memberId).toBe('w1-1(claude)');
+  });
+});
+
+describe('P5 migration — ship-review hardening', () => {
+  const HUMAN_WS = 'ws-human';
+  const UI = 'local-ui';
+
+  function seeded(state: ChannelState) {
+    const writer = makeFakeWriter();
+    writer.saveImmediate(state);
+    const emit = vi.fn<ChannelServiceEmit>();
+    const svc = new ChannelService({
+      writer: writer as unknown as ConstructorParameters<typeof ChannelService>[0]['writer'],
+      companyId: COMPANY,
+      emit,
+      now: () => 1_700_000_000_000,
+    });
+    return { svc, writer };
+  }
+  function baseChannel(nextSeq: number) {
+    return {
+      id: 'ch-1', companyId: COMPANY, name: 'general', visibility: 'public' as const,
+      status: 'active' as const, createdAt: 1, createdBy: 'ws-a', nextSeq,
+    };
+  }
+
+  it('merges pre-v2 human rows (no lastReadSeq): cursor = channel head, not the ?? 0 fallback (backfill-before-merge order)', () => {
+    const st: ChannelState = {
+      version: 1,
+      channels: [baseChannel(11)], // head = 10
+      members: {
+        'ch-1': [
+          { workspaceId: 'ws-a', memberId: UI, joinedAt: 100, historyFromSeq: 0 } as ChannelMember,
+          { workspaceId: 'ws-b', memberId: UI, joinedAt: 50, historyFromSeq: 3 } as ChannelMember,
+        ],
+      },
+      messages: { 'ch-1': [] },
+      idempotency: {},
+    };
+    const { svc } = seeded(st);
+    const human = svc.getMembers('ch-1', HUMAN_WS).find((m) => m.memberId === UI);
+    // backfill sets both missing cursors to head (10) BEFORE the merge, so max = 10.
+    // A future reorder of the two constructor blocks would collapse this to 0.
+    expect(human?.lastReadSeq).toBe(10);
+    expect(human?.historyFromSeq).toBe(0);
+  });
+
+  it('re-merges a ws-human row mixed with stale scattered rows (old-daemon join after upgrade)', () => {
+    const st: ChannelState = {
+      version: 1,
+      channels: [baseChannel(11)],
+      members: {
+        'ch-1': [
+          { workspaceId: HUMAN_WS, memberId: UI, joinedAt: 80, historyFromSeq: 2, lastReadSeq: 6, principalId: 'human:me' },
+          { workspaceId: 'ws-a', memberId: UI, joinedAt: 40, historyFromSeq: 0, lastReadSeq: 9 },
+        ],
+      },
+      messages: { 'ch-1': [] },
+      idempotency: {},
+    };
+    const { svc } = seeded(st);
+    const rows = svc.getMembers('ch-1', HUMAN_WS).filter((m) => m.memberId === UI);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ workspaceId: HUMAN_WS, joinedAt: 40, historyFromSeq: 0, lastReadSeq: 9 });
+  });
+
+  it('the wake worker never sweeps the reserved human workspace', () => {
+    const st: ChannelState = {
+      version: 1,
+      channels: [baseChannel(3)],
+      members: { 'ch-1': [{ workspaceId: HUMAN_WS, memberId: UI, joinedAt: 1, historyFromSeq: 0, lastReadSeq: 0 }] },
+      messages: { 'ch-1': [] },
+      idempotency: {},
+    };
+    const { svc } = seeded(st);
+    expect(svc.memberWorkspaces()).not.toContain(HUMAN_WS);
   });
 });

--- a/src/daemon/channels/__tests__/ChannelService.test.ts
+++ b/src/daemon/channels/__tests__/ChannelService.test.ts
@@ -2305,3 +2305,124 @@ describe('ack (A1: delivery receipt makes deliveryStatus real)', () => {
 
 // Keep the imports referenced for type-checking the test file in isolation.
 void ({} as ChannelMessage);
+
+describe('P5 — unified human identity migration (load-time merge)', () => {
+  const HUMAN_WS = 'ws-human';
+  const UI = 'local-ui';
+
+  /** Seed a pre-P5 persisted state through the fake writer, then construct a
+   *  service against it — mirroring a daemon restart over old data. */
+  function seededService(state: ChannelState) {
+    const writer = makeFakeWriter();
+    writer.saveImmediate(state);
+    const emit = vi.fn<ChannelServiceEmit>();
+    const svc = new ChannelService({
+      writer: writer as unknown as ConstructorParameters<typeof ChannelService>[0]['writer'],
+      companyId: COMPANY,
+      emit,
+      now: () => 1_700_000_000_000,
+    });
+    return { svc, writer };
+  }
+
+  function preP5State(): ChannelState {
+    return {
+      version: 1,
+      channels: [
+        {
+          id: 'ch-1',
+          companyId: COMPANY,
+          name: 'general',
+          visibility: 'public',
+          status: 'active',
+          createdAt: 1,
+          createdBy: 'ws-a',
+          nextSeq: 11,
+        },
+      ],
+      members: {
+        'ch-1': [
+          { workspaceId: 'ws-a', memberId: UI, joinedAt: 100, historyFromSeq: 0, lastReadSeq: 4 },
+          { workspaceId: 'ws-b', memberId: UI, joinedAt: 50, historyFromSeq: 3, lastReadSeq: 9 },
+          {
+            workspaceId: 'ws-a',
+            memberId: 'w1-1(claude)',
+            joinedAt: 60,
+            historyFromSeq: 0,
+            lastReadSeq: 2,
+            principalId: 'pane:ws-a/pane-1',
+          },
+        ],
+      },
+      messages: { 'ch-1': [] },
+      idempotency: {},
+    };
+  }
+
+  it('merges scattered (ws, local-ui) rows into ONE (ws-human) row — earliest join, widest history, furthest cursor', () => {
+    const { svc } = seededService(preP5State());
+    const rows = svc.getMembers('ch-1', 'ws-a');
+    const humanRows = rows.filter((m) => m.memberId === UI);
+    expect(humanRows).toHaveLength(1);
+    expect(humanRows[0]).toMatchObject({
+      workspaceId: HUMAN_WS,
+      memberId: UI,
+      joinedAt: 50, // earliest seat
+      historyFromSeq: 0, // widest visibility
+      lastReadSeq: 9, // furthest ack
+      principalId: 'human:me',
+    });
+  });
+
+  it('leaves agent-pane member rows untouched', () => {
+    const { svc } = seededService(preP5State());
+    const agent = svc.getMembers('ch-1', 'ws-a').find((m) => m.memberId === 'w1-1(claude)');
+    expect(agent).toMatchObject({
+      workspaceId: 'ws-a',
+      joinedAt: 60,
+      historyFromSeq: 0,
+      lastReadSeq: 2,
+      principalId: 'pane:ws-a/pane-1',
+    });
+  });
+
+  it('is idempotent — a post-P5 state re-loads without change (restart no-op)', () => {
+    const first = seededService(preP5State());
+    // Force a persist so the writer holds the POST-migration shape, then
+    // construct again over it (second restart).
+    const persisted = await_persist(first);
+    const second = seededService(persisted);
+    const rows = second.svc.getMembers('ch-1', HUMAN_WS);
+    expect(rows.filter((m) => m.memberId === UI)).toHaveLength(1);
+    expect(rows).toHaveLength(2);
+
+    function await_persist(s: { svc: ChannelService; writer: ReturnType<typeof makeFakeWriter> }): ChannelState {
+      // getMembers is read-only; grab the live state via a join that no-ops…
+      // simpler: reach through the writer — the constructor does NOT persist,
+      // so rebuild the post-migration shape from the service's own reads.
+      const members = s.svc.getMembers('ch-1', HUMAN_WS).map((m) => ({ ...m }));
+      const st = preP5State();
+      st.members['ch-1'] = members;
+      return st;
+    }
+  });
+
+  it('a channel with a single pre-P5 human row still moves it to ws-human', () => {
+    const st = preP5State();
+    st.members['ch-1'] = [st.members['ch-1'][0]];
+    const { svc } = seededService(st);
+    const rows = svc.getMembers('ch-1', HUMAN_WS);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].workspaceId).toBe(HUMAN_WS);
+    expect(rows[0].lastReadSeq).toBe(4);
+  });
+
+  it('a channel with no human rows is untouched', () => {
+    const st = preP5State();
+    st.members['ch-1'] = [st.members['ch-1'][2]];
+    const { svc } = seededService(st);
+    const rows = svc.getMembers('ch-1', 'ws-a');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].memberId).toBe('w1-1(claude)');
+  });
+});

--- a/src/daemon/channels/channelCallerIdentity.ts
+++ b/src/daemon/channels/channelCallerIdentity.ts
@@ -34,6 +34,19 @@
 // is re-minted while the session lives would leave a stale binding; under
 // the #113 ceiling this is ADVISORY attribution either way, and the GUI
 // paths (rule 1) keep using the renderer's live answer.
+//
+// P5 ws-human residual (ship review, Codex + Claude adversarial F7): rule 1
+// trusts a pre-stamped `verifiedWorkspaceId` verbatim, so a DIRECT daemon-pipe
+// caller (bypassing the main router's ws-human guard) can pre-stamp
+// `verifiedWorkspaceId: 'ws-human'` and act as the unified human seat (post as
+// "Me", advance the human cursor). This is the SAME #113 same-user ceiling as
+// forging any other workspace id — a same-user process that reaches the daemon
+// socket already has full same-user authority; P5 only makes the human's id a
+// well-known constant instead of a discoverable uuid. The main-pipe router
+// (a2a.channel.rpc.ts) rejects ws-human for capability-gated MCP/plugin
+// callers, and invite-into-ws-human is rejected daemon-side (invite()); the
+// remaining direct-socket vector is the accepted ceiling, not a new boundary
+// this module can close (that needs GetNamedPipeClientProcessId, strategy track).
 
 /** Resolve a live session's owning workspace, '' when unknown. */
 export type ResolveSessionWorkspace = (sessionId: string) => string;

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -15,7 +15,7 @@ import { coerceLanLinkPatch } from '../shared/lanlink';
 import { ChannelService, ChannelStateWriter, ChannelWakeWorker, wrapChannelMessageEnvelope, wrapChannelCatalogEnvelope, stampChannelCaller, type CallerFieldSpec } from './channels';
 import { PrincipalService, PrincipalStateWriter } from './principals';
 import { isPrincipalUpsertInput } from '../shared/principals';
-import { DEFAULT_COMPANY_ID } from '../shared/channels';
+import { DEFAULT_COMPANY_ID, CHANNELS_EPOCH } from '../shared/channels';
 import { ProcessMonitor } from './ProcessMonitor';
 import { Watchdog } from './Watchdog';
 import { selectRecoverableSessions } from './recoverySelector';
@@ -1574,7 +1574,10 @@ function registerRpcHandlers(
         },
       };
     }
-    return { ok: true, channels: channelService.list(verifiedWorkspaceId) };
+    // `channelsEpoch` is additive (ship review C1): the renderer compares it
+    // against its own CHANNELS_EPOCH on hydration to detect a stale daemon
+    // (pre-P5 daemons simply omit the field).
+    return { ok: true, channelsEpoch: CHANNELS_EPOCH, channels: channelService.list(verifiedWorkspaceId) };
   });
 
   pipeServer.onRpc('a2a.channel.get', async (rawParams) => {

--- a/src/main/pipe/handlers/__tests__/a2a.channel.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/a2a.channel.rpc.test.ts
@@ -800,3 +800,49 @@ describe('a2a.channel.rpc — P5 invite ws-human is REJECTED (5-model consensus)
     expect(daemon.rpc).not.toHaveBeenCalled();
   });
 });
+
+describe('a2a.channel.rpc — P5 create members[] cannot seed reserved identities (Codex delta)', () => {
+  it('REJECTS channel_create with a ws-human entry in initial members[]', async () => {
+    const daemon = makeFakeDaemon(() => ({ ok: true, value: null }));
+    const router = setupHandlerRouter(daemon);
+    const res = await router.dispatch({
+      id: 'p5-create-phantom-member',
+      method: 'a2a.channel.create',
+      params: {
+        name: 'sneaky',
+        visibility: 'private',
+        members: [{ workspaceId: 'ws-human', memberId: 'agentX', memberName: 'X' }],
+        senderPtyId: 'pty-attacker',
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      const r = res.result as { ok: boolean; error?: { code: string } };
+      expect(r.ok).toBe(false);
+      expect(r.error?.code).toBe('NOT_AUTHORIZED');
+    }
+    expect(daemon.rpc).not.toHaveBeenCalled();
+  });
+
+  it('REJECTS channel_create with a local-ui entry in initial members[]', async () => {
+    const daemon = makeFakeDaemon(() => ({ ok: true, value: null }));
+    const router = setupHandlerRouter(daemon);
+    const res = await router.dispatch({
+      id: 'p5-create-spoof-member',
+      method: 'a2a.channel.create',
+      params: {
+        name: 'sneaky2',
+        visibility: 'private',
+        members: [{ workspaceId: 'ws-1', memberId: 'local-ui', memberName: 'Me' }],
+        senderPtyId: 'pty-attacker',
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      const r = res.result as { ok: boolean; error?: { code: string } };
+      expect(r.ok).toBe(false);
+      expect(r.error?.code).toBe('NOT_AUTHORIZED');
+    }
+    expect(daemon.rpc).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/pipe/handlers/__tests__/a2a.channel.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/a2a.channel.rpc.test.ts
@@ -735,12 +735,12 @@ describe('a2a.channel.rpc — P5 reserved human workspace (ws-human) guard', () 
     expect(daemon.rpc).not.toHaveBeenCalled();
   });
 
-  it('ALLOWS inviting the human seat (invitedMember=ws-human is a target, not a caller)', async () => {
-    let received: Record<string, unknown> = {};
-    const daemon = makeFakeDaemon((_m, params) => {
-      received = params as Record<string, unknown>;
-      return { ok: true, value: null };
-    });
+  it('REJECTS inviting ws-human as a TARGET (5-model review: no invite-the-human post-P5)', async () => {
+    // The human joins via the GUI, never by invite. A ws-human invitedMember
+    // could only seed a phantom (ws-human, non-local-ui) row (the real seat's
+    // local-ui memberId is blocked by the C4 guard) that force-injects a channel
+    // into the human's always-on view. The router (and daemon invite()) reject it.
+    const daemon = makeFakeDaemon(() => ({ ok: true, value: null }));
     const router = setupHandlerRouter(daemon);
     const res = await router.dispatch({
       id: 'p5-invite-human',
@@ -752,8 +752,12 @@ describe('a2a.channel.rpc — P5 reserved human workspace (ws-human) guard', () 
       },
     });
     expect(res.ok).toBe(true);
-    expect(daemon.rpc).toHaveBeenCalledTimes(1);
-    expect((received.invitedMember as Record<string, unknown>).workspaceId).toBe('ws-human');
+    if (res.ok) {
+      const r = res.result as { ok: boolean; error?: { code: string } };
+      expect(r.ok).toBe(false);
+      expect(r.error?.code).toBe('NOT_AUTHORIZED');
+    }
+    expect(daemon.rpc).not.toHaveBeenCalled();
   });
 
   it('ALLOWS a no-PTY read scoped to ws-human (the renderer reads ride this router)', async () => {
@@ -770,5 +774,29 @@ describe('a2a.channel.rpc — P5 reserved human workspace (ws-human) guard', () 
     });
     expect(res.ok).toBe(true);
     expect(received.verifiedWorkspaceId).toBe('ws-human');
+  });
+});
+
+describe('a2a.channel.rpc — P5 invite ws-human is REJECTED (5-model consensus)', () => {
+  it('REJECTS inviting ws-human with a non-local-ui memberId (phantom-row injection)', async () => {
+    const daemon = makeFakeDaemon(() => ({ ok: true, value: null }));
+    const router = setupHandlerRouter(daemon);
+    const res = await router.dispatch({
+      id: 'p5-invite-phantom',
+      method: 'a2a.channel.invite',
+      params: {
+        channelId: CHANNEL_ID,
+        invitedMember: { workspaceId: 'ws-human', memberId: 'agentX', memberName: 'X' },
+        senderPtyId: 'pty-attacker',
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      const r = res.result as { ok: boolean; error?: { code: string; message: string } };
+      expect(r.ok).toBe(false);
+      expect(r.error?.code).toBe('NOT_AUTHORIZED');
+      expect(r.error?.message).toContain('ws-human');
+    }
+    expect(daemon.rpc).not.toHaveBeenCalled();
   });
 });

--- a/src/main/pipe/handlers/__tests__/a2a.channel.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/a2a.channel.rpc.test.ts
@@ -689,3 +689,86 @@ describe('a2a.channel.rpc — events.poll per-recipient scoping (PROTOCOL §2.8)
     expect(mine[0].channelId).toBe('ch-2');
   });
 });
+
+describe('a2a.channel.rpc — P5 reserved human workspace (ws-human) guard', () => {
+  it('REJECTS a pipe post claiming ws-human as the sender (human-seat impersonation)', async () => {
+    const daemon = makeFakeDaemon(() => ({ ok: true, value: null }));
+    const router = setupHandlerRouter(daemon);
+    const res = await router.dispatch({
+      id: 'p5-spoof-post',
+      method: 'a2a.channel.post',
+      params: {
+        channelId: CHANNEL_ID,
+        sender: { workspaceId: 'ws-human', memberId: 'me2', memberName: 'Me' },
+        text: 'hi from "the human"',
+        senderPtyId: 'pty-attacker',
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      const r = res.result as { ok: boolean; error?: { code: string; message: string } };
+      expect(r.ok).toBe(false);
+      expect(r.error?.code).toBe('NOT_AUTHORIZED');
+      expect(r.error?.message).toContain('ws-human');
+    }
+    expect(daemon.rpc).not.toHaveBeenCalled();
+  });
+
+  it('REJECTS a pipe join claiming ws-human as the member', async () => {
+    const daemon = makeFakeDaemon(() => ({ ok: true, value: null }));
+    const router = setupHandlerRouter(daemon);
+    const res = await router.dispatch({
+      id: 'p5-spoof-join',
+      method: 'a2a.channel.join',
+      params: {
+        channelId: CHANNEL_ID,
+        member: { workspaceId: 'ws-human', memberId: 'agent', memberName: 'A' },
+        senderPtyId: 'pty-attacker',
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      const r = res.result as { ok: boolean; error?: { code: string } };
+      expect(r.ok).toBe(false);
+      expect(r.error?.code).toBe('NOT_AUTHORIZED');
+    }
+    expect(daemon.rpc).not.toHaveBeenCalled();
+  });
+
+  it('ALLOWS inviting the human seat (invitedMember=ws-human is a target, not a caller)', async () => {
+    let received: Record<string, unknown> = {};
+    const daemon = makeFakeDaemon((_m, params) => {
+      received = params as Record<string, unknown>;
+      return { ok: true, value: null };
+    });
+    const router = setupHandlerRouter(daemon);
+    const res = await router.dispatch({
+      id: 'p5-invite-human',
+      method: 'a2a.channel.invite',
+      params: {
+        channelId: CHANNEL_ID,
+        invitedMember: { workspaceId: 'ws-human', memberId: 'local-ui2', memberName: 'Me' },
+        senderPtyId: 'pty-attacker',
+      },
+    });
+    expect(res.ok).toBe(true);
+    expect(daemon.rpc).toHaveBeenCalledTimes(1);
+    expect((received.invitedMember as Record<string, unknown>).workspaceId).toBe('ws-human');
+  });
+
+  it('ALLOWS a no-PTY read scoped to ws-human (the renderer reads ride this router)', async () => {
+    let received: Record<string, unknown> = {};
+    const daemon = makeFakeDaemon((_m, params) => {
+      received = params as Record<string, unknown>;
+      return { ok: true, value: [] };
+    });
+    const router = setupHandlerRouter(daemon);
+    const res = await router.dispatch({
+      id: 'p5-read-human',
+      method: 'a2a.channel.list',
+      params: { verifiedWorkspaceId: 'ws-human' },
+    });
+    expect(res.ok).toBe(true);
+    expect(received.verifiedWorkspaceId).toBe('ws-human');
+  });
+});

--- a/src/main/pipe/handlers/a2a.channel.rpc.ts
+++ b/src/main/pipe/handlers/a2a.channel.rpc.ts
@@ -118,18 +118,32 @@ export function registerA2aChannelRpc(
         }
       }
     }
+    // Every caller-supplied identity ref the spoof guards below must cover: the
+    // four scalar refs PLUS each entry of create's initial `members[]` array
+    // (ship review — Codex: create's members[] was the ONE identity path the
+    // per-key guards missed, so a pipe channel_create could seed a reserved-id
+    // member row and bypass both guards below).
+    const identityRefs: Array<Record<string, unknown>> = [];
+    for (const key of ['member', 'invitedMember', 'createdBy', 'sender'] as const) {
+      const ref = base[key];
+      if (ref && typeof ref === 'object' && !Array.isArray(ref)) {
+        identityRefs.push(ref as Record<string, unknown>);
+      }
+    }
+    if (Array.isArray(base.members)) {
+      for (const m of base.members) {
+        if (m && typeof m === 'object' && !Array.isArray(m)) {
+          identityRefs.push(m as Record<string, unknown>);
+        }
+      }
+    }
     // R2 review C4: 'local-ui' is the GUI human's reserved identity — if a pipe
     // path uses this label, it would be shown in the roster/transcript
     // impersonating the human ("me"). The GUI never goes through this router
     // (channels:mutate-local only), so a 'local-ui' over the pipe is always a
     // spoof — reject.
-    for (const key of ['member', 'invitedMember', 'createdBy', 'sender'] as const) {
-      const ref = base[key] as Record<string, unknown> | undefined;
-      if (
-        ref &&
-        typeof ref === 'object' &&
-        (ref.memberId === 'local-ui' || ref.memberName === 'local-ui')
-      ) {
+    for (const ref of identityRefs) {
+      if (ref.memberId === 'local-ui' || ref.memberName === 'local-ui') {
         return {
           ok: false,
           error: {
@@ -141,20 +155,18 @@ export function registerA2aChannelRpc(
     }
     // P5 — 'ws-human' is the reserved VIRTUAL workspace of the unified human
     // identity, created and managed ONLY by the renderer-local mutate path. A
-    // pipe caller must never touch it, as a CALLER (post/join/create as "Me")
-    // OR as an invite TARGET. `invitedMember` is included (5-model ship review):
-    // the human is NOT invited post-P5 (they self-join via the GUI), and the
-    // pre-existing 'local-ui' guard already blocks invitedMember.memberId ===
-    // 'local-ui', so the only thing an invitedMember=ws-human exemption could
-    // do is seed a bogus (ws-human, <non-local-ui>) row that the load-time
-    // merge (which folds only memberId === 'local-ui') can never clean and that
-    // every renderer membership check (workspaceId-keyed) treats as the human —
-    // an agent force-injecting a channel into the human's always-on view. Reject
-    // it. Reads keep the documented process-boundary residual (renderer reads
-    // ride this router scoped to ws-human).
-    for (const key of ['member', 'invitedMember', 'createdBy', 'sender'] as const) {
-      const ref = base[key] as Record<string, unknown> | undefined;
-      if (ref && typeof ref === 'object' && ref.workspaceId === HUMAN_WORKSPACE_ID) {
+    // pipe caller must never touch it, as a CALLER (post/join/create as "Me"),
+    // an invite TARGET, or a create initial-member. `invitedMember` and the
+    // create `members[]` entries are both covered (ship review): the only thing
+    // a ws-human ref from the pipe could do is seed a bogus (ws-human,
+    // <non-local-ui>) row that the load-time merge (which folds only memberId
+    // === 'local-ui') can never clean and that every renderer membership check
+    // (workspaceId-keyed) treats as the human — an agent force-injecting a
+    // channel into the human's always-on view. Reject it. Reads keep the
+    // documented process-boundary residual (renderer reads ride this router
+    // scoped to ws-human).
+    for (const ref of identityRefs) {
+      if (ref.workspaceId === HUMAN_WORKSPACE_ID) {
         return {
           ok: false,
           error: {

--- a/src/main/pipe/handlers/a2a.channel.rpc.ts
+++ b/src/main/pipe/handlers/a2a.channel.rpc.ts
@@ -140,23 +140,26 @@ export function registerA2aChannelRpc(
       }
     }
     // P5 — 'ws-human' is the reserved VIRTUAL workspace of the unified human
-    // identity. Only the renderer-local mutate path may ACT as it; a pipe
-    // caller claiming it as its own identity would impersonate the human's
-    // seat (post as "Me", join/create/ack the human's row). Reject the claim
-    // on caller-identity refs only:
-    //   - `invitedMember` is deliberately EXEMPT — inviting the human seat is
-    //     a TARGET identity (pre-P5 capability parity: any member could invite
-    //     the human's workspace).
-    //   - Reads keep the documented process-boundary residual: the renderer's
-    //     own reads ride this router scoped to ws-human.
-    for (const key of ['member', 'createdBy', 'sender'] as const) {
+    // identity, created and managed ONLY by the renderer-local mutate path. A
+    // pipe caller must never touch it, as a CALLER (post/join/create as "Me")
+    // OR as an invite TARGET. `invitedMember` is included (5-model ship review):
+    // the human is NOT invited post-P5 (they self-join via the GUI), and the
+    // pre-existing 'local-ui' guard already blocks invitedMember.memberId ===
+    // 'local-ui', so the only thing an invitedMember=ws-human exemption could
+    // do is seed a bogus (ws-human, <non-local-ui>) row that the load-time
+    // merge (which folds only memberId === 'local-ui') can never clean and that
+    // every renderer membership check (workspaceId-keyed) treats as the human —
+    // an agent force-injecting a channel into the human's always-on view. Reject
+    // it. Reads keep the documented process-boundary residual (renderer reads
+    // ride this router scoped to ws-human).
+    for (const key of ['member', 'invitedMember', 'createdBy', 'sender'] as const) {
       const ref = base[key] as Record<string, unknown> | undefined;
       if (ref && typeof ref === 'object' && ref.workspaceId === HUMAN_WORKSPACE_ID) {
         return {
           ok: false,
           error: {
             code: 'NOT_AUTHORIZED',
-            message: `'${HUMAN_WORKSPACE_ID}' is the reserved human workspace and cannot be claimed from the pipe`,
+            message: `'${HUMAN_WORKSPACE_ID}' is the reserved human workspace and cannot be claimed or targeted from the pipe`,
           },
         };
       }

--- a/src/main/pipe/handlers/a2a.channel.rpc.ts
+++ b/src/main/pipe/handlers/a2a.channel.rpc.ts
@@ -46,6 +46,7 @@
 import type { BrowserWindow } from 'electron';
 import type { RpcRouter } from '../RpcRouter';
 import type { DaemonClient } from '../../DaemonClient';
+import { HUMAN_WORKSPACE_ID } from '../../../shared/channels';
 import { sendToRenderer } from './_bridge';
 
 type GetWindow = () => BrowserWindow | null;
@@ -134,6 +135,28 @@ export function registerA2aChannelRpc(
           error: {
             code: 'NOT_AUTHORIZED',
             message: "'local-ui' is a reserved GUI identity and cannot be used from the pipe",
+          },
+        };
+      }
+    }
+    // P5 — 'ws-human' is the reserved VIRTUAL workspace of the unified human
+    // identity. Only the renderer-local mutate path may ACT as it; a pipe
+    // caller claiming it as its own identity would impersonate the human's
+    // seat (post as "Me", join/create/ack the human's row). Reject the claim
+    // on caller-identity refs only:
+    //   - `invitedMember` is deliberately EXEMPT — inviting the human seat is
+    //     a TARGET identity (pre-P5 capability parity: any member could invite
+    //     the human's workspace).
+    //   - Reads keep the documented process-boundary residual: the renderer's
+    //     own reads ride this router scoped to ws-human.
+    for (const key of ['member', 'createdBy', 'sender'] as const) {
+      const ref = base[key] as Record<string, unknown> | undefined;
+      if (ref && typeof ref === 'object' && ref.workspaceId === HUMAN_WORKSPACE_ID) {
+        return {
+          ok: false,
+          error: {
+            code: 'NOT_AUTHORIZED',
+            message: `'${HUMAN_WORKSPACE_ID}' is the reserved human workspace and cannot be claimed from the pipe`,
           },
         };
       }

--- a/src/renderer/channels/__tests__/authorDisplay.test.ts
+++ b/src/renderer/channels/__tests__/authorDisplay.test.ts
@@ -63,9 +63,9 @@ describe('rosterMemberLabel (identity audit C-A3)', () => {
   const SELF_WS = 'ws-self';
   const UI = 'local-ui';
 
-  it("labels only the viewer's own row as Me (empty primary)", () => {
+  it("labels only the viewer's own row as Me — with NO workspace suffix (P5: one human seat)", () => {
     const own = rosterMemberLabel({ workspaceId: SELF_WS, memberId: UI }, SELF_WS, UI, 'Workspace 1');
-    expect(own).toEqual({ primary: '', showWorkspaceSuffix: true });
+    expect(own).toEqual({ primary: '', showWorkspaceSuffix: false });
   });
 
   it("labels another workspace's human seat with its workspace name, no duplicate suffix", () => {
@@ -92,5 +92,23 @@ describe('formatChannelAuthor — untrusted memberName (ship review pin)', () =>
     );
     expect(a.kind).toBe('agent');
     expect(a.chip).toBe('w1-1(codex)');
+  });
+});
+
+describe('formatChannelAuthor — P5 unified human seat', () => {
+  it('a post from ws-human renders as plain "Me" with NO chip (one human, no ambiguity)', () => {
+    const a = formatChannelAuthor(
+      { workspaceId: 'ws-human', memberId: 'local-ui', memberName: 'local-ui' },
+      noWs,
+    );
+    expect(a).toMatchObject({ kind: 'human', primary: '', chip: null });
+  });
+
+  it('a PRE-P5 human post (real workspace id) keeps its workspace chip as history', () => {
+    const a = formatChannelAuthor(
+      { workspaceId: WS, memberId: 'local-ui', memberName: 'local-ui' },
+      () => 'Workspace 2',
+    );
+    expect(a.chip).toBe('Workspace 2');
   });
 });

--- a/src/renderer/channels/authorDisplay.ts
+++ b/src/renderer/channels/authorDisplay.ts
@@ -11,11 +11,14 @@
 //   agent → primary = memberName (fallback memberId), chip = memberId
 //           (skipped when the primary already carries it)
 //   human → primary = the localized "Me" (substituted by the component),
-//           chip = the workspace name (every GUI seat shares the reserved
-//           'local-ui' member id, so the workspace IS the seat's identity)
+//           chip = null for a post from the unified ws-human seat (one human,
+//           no chip needed); a pre-P5 human post keeps its workspace-name chip
+//           as historical context
 //
 // Server-owned roster names (remediation plan Phase 1b) will replace the
 // free-form primary later; this layer is schema-free and works on history.
+
+import { HUMAN_MEMBER_ID, HUMAN_WORKSPACE_ID } from '../../shared/channels';
 
 export interface ChannelAuthorDisplay {
   kind: 'human' | 'agent';
@@ -28,8 +31,6 @@ export interface ChannelAuthorDisplay {
   /** Stable per-workspace hue (0-359) for the author color badge. */
   hue: number;
 }
-
-import { HUMAN_MEMBER_ID, HUMAN_WORKSPACE_ID } from '../../shared/channels';
 
 /** Deterministic workspaceId → hue. The same workspace always renders the
  *  same badge color across sessions; distinct workspaces usually differ. */

--- a/src/renderer/channels/authorDisplay.ts
+++ b/src/renderer/channels/authorDisplay.ts
@@ -29,9 +29,7 @@ export interface ChannelAuthorDisplay {
   hue: number;
 }
 
-/** The reserved GUI member id (one human seat per workspace). Matches the
- *  daemon's reserved identity — see a2a.channel.rpc.ts (pipe spoof reject). */
-const HUMAN_MEMBER_ID = 'local-ui';
+import { HUMAN_MEMBER_ID } from '../../shared/channels';
 
 /** Deterministic workspaceId → hue. The same workspace always renders the
  *  same badge color across sessions; distinct workspaces usually differ. */

--- a/src/renderer/channels/authorDisplay.ts
+++ b/src/renderer/channels/authorDisplay.ts
@@ -29,7 +29,7 @@ export interface ChannelAuthorDisplay {
   hue: number;
 }
 
-import { HUMAN_MEMBER_ID } from '../../shared/channels';
+import { HUMAN_MEMBER_ID, HUMAN_WORKSPACE_ID } from '../../shared/channels';
 
 /** Deterministic workspaceId → hue. The same workspace always renders the
  *  same badge color across sessions; distinct workspaces usually differ. */
@@ -63,6 +63,12 @@ export function formatChannelAuthor(
   // agent naming itself "local-ui" must NOT render as the human seat (the
   // pipe rejects that name, but the display layer pins it too; ship review).
   if (memberId === HUMAN_MEMBER_ID) {
+    // P5: a post from the unified human seat needs NO chip — there is exactly
+    // one human, "나/Me" alone identifies them. Pre-P5 posts carry the real
+    // workspace they were sent from; keep that chip as historical context.
+    if (message.workspaceId === HUMAN_WORKSPACE_ID) {
+      return { kind: 'human', primary: '', chip: null, hue };
+    }
     const ws = resolveWorkspaceName(message.workspaceId)?.trim();
     return { kind: 'human', primary: '', chip: ws || shortId(message.workspaceId), hue };
   }
@@ -97,7 +103,10 @@ export function rosterMemberLabel(
   workspaceLabel: string,
 ): RosterMemberLabel {
   const isSelf = member.workspaceId === selfWorkspaceId && member.memberId === selfMemberId;
-  if (isSelf) return { primary: '', showWorkspaceSuffix: true };
+  // P5: the unified human row is the ONLY human row — "나/Me" alone is
+  // unambiguous, and its workspace is the reserved virtual one (a raw
+  // 'ws-human' suffix would just leak an internal token).
+  if (isSelf) return { primary: '', showWorkspaceSuffix: false };
   if (member.memberId === selfMemberId) {
     // Another workspace's human seat — the workspace is its identity.
     return { primary: workspaceLabel, showWorkspaceSuffix: false };

--- a/src/renderer/components/Channels/ChannelMembers.tsx
+++ b/src/renderer/components/Channels/ChannelMembers.tsx
@@ -11,24 +11,22 @@
 //   - ChannelMembersControl — store-connected; resolves identity, the joinable
 //     workspace list, and wires join/leave + the self-leave view cleanup.
 //
-// Scope (P1b — invite):
+// Scope (P5 — unified human seat):
 //   - Remove (✕) is SELF-ONLY and shows on the exact (self ws, self memberId)
 //     row — you can leave, not eject (matches daemon leave() capability).
-//   - "+ member" shows for any non-archived channel with a resolvable self ws.
-//     A MEMBER may add any non-member workspace (invite — the only path into a
-//     private channel; daemon gates on the inviter being a member). A NON-member
-//     can only self-join (public), so the picker offers just their own ws.
-//     Adding self → joinChannelDaemon (self-pin); adding another → inviteChannelDaemon.
+//   - There is ONE app-wide human seat (ws-human); agents join as panes via the
+//     "add an agent pane" picker. The old "add a workspace" picker is retired —
+//     the container passes an empty joinableWorkspaces list.
 //   - On a successful self-leave of the active channel, the container clears
 //     activeChannelId so the dock doesn't show a dead/blank pane.
 //
 // No hex literals — theme tokens only. Agents keep per-agent membership via the
-// MCP channel_post member_id; the UI identity is workspace-level (memberId
-// 'local-ui'), which is correct (one human per workspace).
+// MCP channel_post member_id; the human UI identity is the single reserved seat
+// (HUMAN_MEMBER_ID on HUMAN_WORKSPACE_ID).
 
 import { useState } from 'react';
 import type { Channel, ChannelMember } from '../../../shared/channels';
-import { HUMAN_WORKSPACE_ID } from '../../../shared/channels';
+import { HUMAN_WORKSPACE_ID, HUMAN_MEMBER_ID } from '../../../shared/channels';
 import { panePrincipalId } from '../../../shared/principals';
 import { useStore } from '../../stores';
 import { useT } from '../../hooks/useT';
@@ -38,10 +36,6 @@ import { IconX, IconUsers } from '../icons';
 import { findLeafPanes } from '../../hooks/a2aAddressing';
 import { rosterMemberLabel } from '../../channels/authorDisplay';
 import { buildMentionCandidates } from './Composer';
-
-/** Stable UI member id — the human/GUI participates as one member per
- *  workspace. Mirrors the value the composer + create path already send. */
-const UI_MEMBER_ID = 'local-ui';
 
 export interface JoinableWorkspace {
   id: string;
@@ -436,10 +430,10 @@ export function ChannelMembersControl({ channel }: { channel: Channel }): React.
       channel.visibility === 'public'
         ? useStore
             .getState()
-            .joinChannelDaemon(channel.id, { workspaceId, memberId: UI_MEMBER_ID, memberName: label }, workspaceId)
+            .joinChannelDaemon(channel.id, { workspaceId, memberId: HUMAN_MEMBER_ID, memberName: label }, workspaceId)
         : useStore
             .getState()
-            .inviteChannelDaemon(channel.id, { workspaceId, memberId: UI_MEMBER_ID, memberName: label }, selfWorkspaceId ?? workspaceId);
+            .inviteChannelDaemon(channel.id, { workspaceId, memberId: HUMAN_MEMBER_ID, memberName: label }, selfWorkspaceId ?? workspaceId);
     void action.then((result) => {
       if (result.ok) {
         pushToast({ level: 'info', message: t('channels.joinedToast', { workspace: label, channel: channel.name }) });
@@ -527,7 +521,7 @@ export function ChannelMembersControl({ channel }: { channel: Channel }): React.
       headSeq={headSeq}
       workspaceLabel={workspaceLabel}
       selfWorkspaceId={selfWorkspaceId}
-      selfMemberId={UI_MEMBER_ID}
+      selfMemberId={HUMAN_MEMBER_ID}
       joinableWorkspaces={joinableWorkspaces}
       joinablePanes={joinablePanes}
       canJoin={canJoin}

--- a/src/renderer/components/Channels/ChannelMembers.tsx
+++ b/src/renderer/components/Channels/ChannelMembers.tsx
@@ -28,6 +28,7 @@
 
 import { useState } from 'react';
 import type { Channel, ChannelMember } from '../../../shared/channels';
+import { HUMAN_WORKSPACE_ID } from '../../../shared/channels';
 import { panePrincipalId } from '../../../shared/principals';
 import { useStore } from '../../stores';
 import { useT } from '../../hooks/useT';
@@ -281,14 +282,16 @@ export function ChannelMembersView({
                 ))
               )}
 
-              <div className="px-3 py-1 text-[9px] font-mono uppercase tracking-widest text-[var(--text-muted)]" {...tokenAttrs('textMuted', 'text')}>
-                {t('channels.addMember') || 'Add a workspace'}
-              </div>
-              {joinableWorkspaces.length === 0 ? (
-                <div className="px-3 py-1.5 text-[10px] font-mono text-[var(--text-muted)]" {...tokenAttrs('textMuted', 'text')}>
-                  {t('channels.allWorkspacesMembers') || 'All workspaces are members.'}
+              {/* P5: the "add a workspace" section only renders when a caller
+                    still supplies candidates (legacy/tests) — the container now
+                    passes [] because the human is one seat and agents join as
+                    panes. Section removal proper rides the P6 roster rework. */}
+              {joinableWorkspaces.length > 0 && (
+                <div className="px-3 py-1 text-[9px] font-mono uppercase tracking-widest text-[var(--text-muted)]" {...tokenAttrs('textMuted', 'text')}>
+                  {t('channels.addMember') || 'Add a workspace'}
                 </div>
-              ) : (
+              )}
+              {joinableWorkspaces.length > 0 && (
                 joinableWorkspaces.map((w) => (
                   <button
                     key={w.id}
@@ -327,13 +330,14 @@ export function ChannelMembersControl({ channel }: { channel: Channel }): React.
   });
   const workspaces = useStore((s) => s.workspaces);
   const company = useStore((s) => s.company);
-  const activeWorkspaceId = useStore((s) => s.activeWorkspaceId);
   const pushToast = useStore((s) => s.pushToast);
   // R2: agent-detection mirror used to compute explicit-join candidates + liveness.
   const surfaceAgent = useStore((s) => s.surfaceAgent);
   const paneLabel = useStore((s) => s.paneLabel);
 
-  const selfWorkspaceId = company?.ceoWorkspaceId ?? activeWorkspaceId ?? null;
+  // P5 (unified human identity): self is the reserved human workspace —
+  // isSelf/leave/kick authz no longer depend on which workspace is active.
+  const selfWorkspaceId: string | null = HUMAN_WORKSPACE_ID;
   const workspaceLabel = (workspaceId: string): string =>
     workspaces.find((w) => w.id === workspaceId)?.name ?? workspaceId;
 
@@ -352,14 +356,11 @@ export function ChannelMembersControl({ channel }: { channel: Channel }): React.
   // now just another member row. Agents render as per-member rows for attribution.
   const rosterMembers = members;
 
-  // The human GUI operates EVERY local workspace, so the picker offers every
-  // workspace that is not already a member — not just the active one. The old
-  // "a non-member may only self-join" rule is an AGENT constraint (an agent can't
-  // act for a sibling workspace); the first-party GUI can, and the daemon trusts
-  // the renderer-supplied workspaceId across the process boundary.
-  const joinableWorkspaces: JoinableWorkspace[] = workspaces
-    .filter((w) => !members.some((m) => m.workspaceId === w.id))
-    .map((w) => ({ id: w.id, name: w.name }));
+  // P5: "add a WORKSPACE" is gone as a membership concept — the human is ONE
+  // seat (ws-human) and agents join as panes. An empty list keeps the section
+  // unrendered (the view gates on length) without churning the props contract;
+  // full prop removal rides the P6 roster rework.
+  const joinableWorkspaces: JoinableWorkspace[] = [];
 
   // R2 — explicit-join candidates: live agent panes across all workspaces that
   // are not yet members of this channel. The candidate predicate (live agent

--- a/src/renderer/components/Channels/ChannelView.tsx
+++ b/src/renderer/components/Channels/ChannelView.tsx
@@ -633,9 +633,6 @@ export function ChannelView(): React.ReactElement | null {
   const members = useStore((s) =>
     activeChannelId ? s.channelMembers[activeChannelId] ?? EMPTY_MEMBERS : EMPTY_MEMBERS,
   );
-  // Channels are decoupled from in-app Company mode: the active workspace is
-  // the renderer's "self" identity when no company is set (mirrors
-  // useChannelsHydration / ChannelsPanel).
   // Identity audit 1a: workspace display names for the sender identity chips
   // (human posts read "Me · <workspace>"). Subscribe to a STRING projection of
   // (id, name) pairs, not the workspaces array itself — the array reference
@@ -723,15 +720,9 @@ export function ChannelView(): React.ReactElement | null {
     [selfWs, activeChannelId],
   );
 
-  // Pick a stable viewer — first member whose workspaceId matches the
-  // current renderer's workspace (the company's `ceoWorkspaceId` is the
-  // closest available stand-in for the renderer's own identity, since
-  // the slice doesn't carry per-renderer identity yet), falling back
-  // to the first member of the channel. The fallback matters when the
-  // renderer's own workspace is not a member of the channel — e.g. a
-  // private channel from another workspace that the renderer is
-  // previewing. Multi-workspace subscription is a known gap (see
-  // plan Open Questions `FIX-MULTI-WS`).
+  // Pick a stable viewer — the unified human (ws-human) member row when the
+  // human is in this channel; members[0] fallback for previewing a channel the
+  // human is not in (the code keys on HUMAN_WORKSPACE_ID below).
   //
   // Rules of hooks: the `useMemo` MUST run on every render, including
   // the early-return path below. Earlier versions had the `useMemo`

--- a/src/renderer/components/Channels/ChannelView.tsx
+++ b/src/renderer/components/Channels/ChannelView.tsx
@@ -27,6 +27,7 @@ import { tokenAttrs } from '../../themes';
 import { FOCUS_RING } from '../focusRing';
 import { IconX, IconArchive, IconCheck, IconChevron } from '../icons';
 import { formatChannelAuthor } from '../../channels/authorDisplay';
+import { HUMAN_WORKSPACE_ID, HUMAN_MEMBER_ID } from '../../../shared/channels';
 import { Composer } from './Composer';
 import { ChannelMembersControl } from './ChannelMembers';
 
@@ -632,11 +633,9 @@ export function ChannelView(): React.ReactElement | null {
   const members = useStore((s) =>
     activeChannelId ? s.channelMembers[activeChannelId] ?? EMPTY_MEMBERS : EMPTY_MEMBERS,
   );
-  const company = useStore((s) => s.company);
   // Channels are decoupled from in-app Company mode: the active workspace is
   // the renderer's "self" identity when no company is set (mirrors
   // useChannelsHydration / ChannelsPanel).
-  const activeWorkspaceId = useStore((s) => s.activeWorkspaceId);
   // Identity audit 1a: workspace display names for the sender identity chips
   // (human posts read "Me · <workspace>"). Subscribe to a STRING projection of
   // (id, name) pairs, not the workspaces array itself — the array reference
@@ -664,9 +663,9 @@ export function ChannelView(): React.ReactElement | null {
   // Close the conversation view only (deselect) — the channel stays + you stay a member.
   const handleClose = useCallback(() => setActiveChannel(null), [setActiveChannel]);
 
-  // The renderer's "self" workspace — same expression as `viewer` below (the
-  // company CEO when set, else the active workspace).
-  const selfWs = company?.ceoWorkspaceId ?? activeWorkspaceId ?? '';
+  // P5 (unified human identity): the human's channel identity is the reserved
+  // virtual workspace, independent of company mode or the active workspace.
+  const selfWs = HUMAN_WORKSPACE_ID;
   // The X = LEAVE the channel (removes this workspace's UI membership), then
   // close the view. Gate on the ACTUAL (selfWs, 'local-ui') GUI member row, not
   // just any member of this workspace: handleLeave always removes memberId
@@ -675,11 +674,11 @@ export function ChannelView(): React.ReactElement | null {
   // Agent-only membership — and a public channel you're only previewing — show
   // no leave affordance.
   const selfIsMember =
-    !!selfWs && members.some((m) => m.workspaceId === selfWs && m.memberId === 'local-ui');
+    !!selfWs && members.some((m) => m.workspaceId === selfWs && m.memberId === HUMAN_MEMBER_ID);
   const handleLeave = useCallback(() => {
     if (!activeChannelId || !selfWs) return;
-    // memberId 'local-ui' is the human/GUI member id (one per workspace).
-    void leaveChannelDaemon(activeChannelId, 'local-ui', selfWs).then((res) => {
+    // The one unified human seat leaves — there is no per-workspace row anymore.
+    void leaveChannelDaemon(activeChannelId, HUMAN_MEMBER_ID, selfWs).then((res) => {
       if (res.ok) {
         setActiveChannel(null);
         pushToast({
@@ -742,13 +741,12 @@ export function ChannelView(): React.ReactElement | null {
   // return makes the hook order stable across renders.
   const viewer = useMemo<ChannelMember | null>(() => {
     if (members.length === 0) return null;
-    const ownWorkspaceId = company?.ceoWorkspaceId ?? activeWorkspaceId;
-    if (ownWorkspaceId) {
-      const own = members.find((m) => m.workspaceId === ownWorkspaceId);
-      if (own) return own;
-    }
+    // P5: the viewer is the unified human row when present; the members[0]
+    // fallback remains for previewing channels the human is not in.
+    const own = members.find((m) => m.workspaceId === HUMAN_WORKSPACE_ID);
+    if (own) return own;
     return members[0] ?? null;
-  }, [members, company?.ceoWorkspaceId, activeWorkspaceId]);
+  }, [members]);
 
   // P0: load RECENT message history into the store when a channel is opened.
   // The view renders `store.channelMessages` only (it never calls getMessages
@@ -760,8 +758,7 @@ export function ChannelView(): React.ReactElement | null {
     if (!activeChannelId) return;
     const bridge = useStore.getState().channelsRpc();
     if (!bridge) return;
-    const selfWs = company?.ceoWorkspaceId ?? activeWorkspaceId ?? '';
-    if (!selfWs) return;
+    const selfWs = HUMAN_WORKSPACE_ID;
     // Read nextSeq fresh — the `channel` prop may be a render behind a
     // just-arrived catalog refresh.
     const nextSeq = useStore.getState().channels[activeChannelId]?.nextSeq ?? 1;
@@ -805,7 +802,7 @@ export function ChannelView(): React.ReactElement | null {
     return () => {
       disposed = true;
     };
-  }, [activeChannelId, company?.ceoWorkspaceId, activeWorkspaceId]);
+  }, [activeChannelId]);
 
   if (!activeChannelId || !channel) {
     // The activeChannelId-but-channel-undefined case can fire on a

--- a/src/renderer/components/Channels/ChannelsPanel.tsx
+++ b/src/renderer/components/Channels/ChannelsPanel.tsx
@@ -50,6 +50,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import type { Channel, ChannelVisibility } from '../../../shared/channels';
+import { HUMAN_WORKSPACE_ID, HUMAN_MEMBER_ID } from '../../../shared/channels';
 import {
   canonicalizeChannelName,
   isValidChannelName,
@@ -671,7 +672,6 @@ export function ChannelsPanel(): React.ReactElement {
   // Channels are decoupled from in-app Company mode: when no company is set,
   // the active workspace stands in as the creator identity so the `+` button
   // works without one (mirrors useChannelsHydration's identity resolution).
-  const activeWorkspaceId = useStore((s) => s.activeWorkspaceId);
   const workspaces = useStore((s) => s.workspaces);
   const channelMembers = useStore((s) => s.channelMembers);
   const setActiveChannel = useStore((s) => s.setActiveChannel);
@@ -688,7 +688,10 @@ export function ChannelsPanel(): React.ReactElement {
 
   // Self workspace = CEO ws under Company mode, else the active workspace
   // (mirrors handleCreate / ChannelMembersControl identity resolution).
-  const selfWorkspaceId = company?.ceoWorkspaceId ?? activeWorkspaceId ?? null;
+  // P5 (unified human identity): the human's channel identity is the reserved
+  // virtual workspace — membership, join, post, and "my channels" no longer
+  // depend on which workspace is active.
+  const selfWorkspaceId: string | null = HUMAN_WORKSPACE_ID;
 
   // Channel ids the self workspace is a member of — drives the joined vs
   // discoverable split in the view. O(channels) but the catalog is small.
@@ -710,12 +713,13 @@ export function ChannelsPanel(): React.ReactElement {
   const handleJoinDiscoverable = useCallback(
     (channelId: string) => {
       if (!selfWorkspaceId) return;
-      const label =
-        workspaces.find((w) => w.id === selfWorkspaceId)?.name ?? selfWorkspaceId;
+      // P5: the unified human seat joins — the row is workspace-independent and
+      // renders as the localized "Me"; no workspace label is involved anymore.
+      const label = t('channels.me') || 'Me';
       const channelName = channels[channelId]?.name ?? channelId;
       void joinChannelDaemon(
         channelId,
-        { workspaceId: selfWorkspaceId, memberId: 'local-ui', memberName: label },
+        { workspaceId: selfWorkspaceId, memberId: HUMAN_MEMBER_ID, memberName: HUMAN_MEMBER_ID },
         selfWorkspaceId,
       ).then((result) => {
         if (result.ok) {
@@ -750,8 +754,7 @@ export function ChannelsPanel(): React.ReactElement {
       // the active workspace. The daemon pins `createdBy` to the verified
       // (renderer-supplied, process-boundary-trusted) workspace anyway; this
       // is the value it pins to. Bail only if there is no workspace at all.
-      const selfWorkspaceId = company?.ceoWorkspaceId ?? activeWorkspaceId;
-      if (!selfWorkspaceId) return false;
+      const selfWorkspaceId = HUMAN_WORKSPACE_ID;
       // Synthesize the row the slice would use as the optimistic
       // insert. The `*Daemon` thunk will overwrite this with the
       // daemon's authoritative row on success — the synthesized row
@@ -797,8 +800,7 @@ export function ChannelsPanel(): React.ReactElement {
     const bridge = useStore.getState().channelsRpc();
     if (!bridge) return;
     const s = useStore.getState();
-    const wsId = s.company?.ceoWorkspaceId ?? s.activeWorkspaceId ?? '';
-    if (!wsId) return;
+    const wsId = HUMAN_WORKSPACE_ID;
     void hydrateChannelsCatalog({
       rpc: bridge.rpc,
       workspaceId: wsId,

--- a/src/renderer/components/Channels/ChannelsPanel.tsx
+++ b/src/renderer/components/Channels/ChannelsPanel.tsx
@@ -366,7 +366,7 @@ export function synthesizeChannel(params: {
     visibility: params.visibility,
     status: 'active',
     createdAt: Date.now(),
-    createdBy: 'local-ui',
+    createdBy: HUMAN_MEMBER_ID,
     nextSeq: 1,
   };
 }
@@ -669,9 +669,8 @@ export function ChannelsPanel(): React.ReactElement {
   const channelMentions = useStore((s) => s.channelMentions);
   const activeChannelId = useStore((s) => s.activeChannelId);
   const company = useStore((s) => s.company);
-  // Channels are decoupled from in-app Company mode: when no company is set,
-  // the active workspace stands in as the creator identity so the `+` button
-  // works without one (mirrors useChannelsHydration's identity resolution).
+  // P5: the human's creator identity is the reserved ws-human seat (see
+  // selfWorkspaceId below), independent of which workspace is active.
   const workspaces = useStore((s) => s.workspaces);
   const channelMembers = useStore((s) => s.channelMembers);
   const setActiveChannel = useStore((s) => s.setActiveChannel);
@@ -686,8 +685,6 @@ export function ChannelsPanel(): React.ReactElement {
   const setChannelDockVisible = useStore((s) => s.setChannelDockVisible);
   const t = useT();
 
-  // Self workspace = CEO ws under Company mode, else the active workspace
-  // (mirrors handleCreate / ChannelMembersControl identity resolution).
   // P5 (unified human identity): the human's channel identity is the reserved
   // virtual workspace — membership, join, post, and "my channels" no longer
   // depend on which workspace is active.
@@ -750,10 +747,8 @@ export function ChannelsPanel(): React.ReactElement {
       // daemon's authoritative row (the daemon ignores any client companyId
       // and stamps its own — keeping them equal avoids a flicker on refresh).
       const companyId = company?.id ?? DEFAULT_COMPANY_ID;
-      // Sender identity: the CEO workspace when Company mode is active, else
-      // the active workspace. The daemon pins `createdBy` to the verified
-      // (renderer-supplied, process-boundary-trusted) workspace anyway; this
-      // is the value it pins to. Bail only if there is no workspace at all.
+      // P5: the creator identity is the reserved ws-human seat; the daemon
+      // re-pins `createdBy` to the verified workspace anyway.
       const selfWorkspaceId = HUMAN_WORKSPACE_ID;
       // Synthesize the row the slice would use as the optimistic
       // insert. The `*Daemon` thunk will overwrite this with the
@@ -770,8 +765,8 @@ export function ChannelsPanel(): React.ReactElement {
         visibility: params.visibility,
         createdBy: {
           workspaceId: selfWorkspaceId,
-          memberId: 'local-ui',
-          memberName: 'local-ui',
+          memberId: HUMAN_MEMBER_ID,
+          memberName: HUMAN_MEMBER_ID,
         },
         channel,
       });

--- a/src/renderer/components/Channels/ChannelsPanel.tsx
+++ b/src/renderer/components/Channels/ChannelsPanel.tsx
@@ -405,6 +405,10 @@ export interface ChannelsPanelViewProps {
    *  members from the daemon (manual re-sync for when a workspace/agent that
    *  came online isn't reflected yet). */
   onRefresh?: () => void;
+  /** Ship review C1 — the attached daemon predates the channels migration this
+   *  renderer requires (it survived the app upgrade). Renders a "restart wmux"
+   *  banner; posting/joining may fail with NOT_A_MEMBER until the restart. */
+  daemonStale?: boolean;
 }
 
 export function ChannelsPanelView(props: ChannelsPanelViewProps): React.ReactElement {
@@ -421,6 +425,7 @@ export function ChannelsPanelView(props: ChannelsPanelViewProps): React.ReactEle
     onCollapse,
     collapseDir = 'right',
     onRefresh,
+    daemonStale = false,
   } = props;
   const t = props.t ?? ((k: string) => k);
 
@@ -461,6 +466,23 @@ export function ChannelsPanelView(props: ChannelsPanelViewProps): React.ReactEle
       className="border-t border-[var(--bg-surface)] py-2"
       style={{ borderColor: 'var(--border-soft)' }}
     >
+      {/* Ship review C1 — stale-daemon banner. The long-lived daemon survived
+            the app upgrade without the channels migration this renderer needs;
+            channels may look missing and posts may fail until it restarts.
+            Informational only (no auto-kill: the daemon holds live sessions). */}
+      {daemonStale && (
+        <div
+          data-channels-daemon-stale
+          className="mx-3 mb-1.5 px-2.5 py-1.5 rounded text-[10px] font-mono leading-snug text-[var(--text-sub)] bg-[rgba(var(--bg-surface-rgb),0.7)]"
+          style={{ border: '1px solid var(--border-soft)' }}
+          {...tokenAttrs('textSub', 'text')}
+        >
+          <span aria-hidden="true">⚠ </span>
+          {t('channels.daemonStaleBanner') ||
+            'Channels were updated, but the background daemon is still on the old version. Quit wmux fully and start it again to finish.'}
+        </div>
+      )}
+
       {/* Header row — section title + actions (new-channel + collapse).
             The collapse button is merged here from the old ChannelDock header
             so the "Channels" title renders once, not twice. */}
@@ -668,6 +690,7 @@ export function ChannelsPanel(): React.ReactElement {
   const channelUnread = useStore((s) => s.channelUnread);
   const channelMentions = useStore((s) => s.channelMentions);
   const activeChannelId = useStore((s) => s.activeChannelId);
+  const channelsDaemonStale = useStore((s) => s.channelsDaemonStale);
   const company = useStore((s) => s.company);
   // P5: the human's creator identity is the reserved ws-human seat (see
   // selfWorkspaceId below), independent of which workspace is active.
@@ -819,6 +842,7 @@ export function ChannelsPanel(): React.ReactElement {
       onCollapse={() => setChannelDockVisible(false)}
       collapseDir={sidebarPosition !== 'right' ? 'right' : 'left'}
       onRefresh={handleRefresh}
+      daemonStale={channelsDaemonStale}
       t={t}
     />
   );

--- a/src/renderer/components/Channels/Composer.tsx
+++ b/src/renderer/components/Channels/Composer.tsx
@@ -27,7 +27,7 @@ import { findLeafPanes } from '../../hooks/a2aAddressing';
 import { generateId, type Workspace } from '../../../shared/types';
 import type { AgentSlug } from '../../../shared/events';
 import type { ChannelMember, ChannelMention, ChannelMessage } from '../../../shared/channels';
-import { HUMAN_WORKSPACE_ID } from '../../../shared/channels';
+import { HUMAN_WORKSPACE_ID, HUMAN_MEMBER_ID } from '../../../shared/channels';
 import { useT } from '../../hooks/useT';
 import { tokenAttrs } from '../../themes';
 import { FOCUS_RING } from '../focusRing';
@@ -629,7 +629,7 @@ export function ComposerContent({
 
 // ─── Container ──────────────────────────────────────────────────────────
 
-/** Resolves the active company + member identity from the store and
+/** Resolves the unified human (ws-human) identity from the store and
  *  wires the composer to `postMessageOptimistic`. The `onError` is the
  *  toast slot from the parent (`useStore((s) => s.pushToast)`). */
 export interface ComposerProps {
@@ -641,9 +641,6 @@ const EMPTY_MEMBERS: ChannelMember[] = [];
 
 export function Composer({ channelId, onError }: ComposerProps): React.ReactElement {
   const t = useT();
-  // Channels are decoupled from in-app Company mode: the active workspace
-  // stands in as the sender identity when no company is set (mirrors
-  // ChannelsPanel / ChannelView / useChannelsHydration).
   const channel = useStore((s) => s.channels[channelId]);
   const members = useStore((s) => s.channelMembers[channelId] ?? EMPTY_MEMBERS);
   const workspaces = useStore((s) => s.workspaces);
@@ -697,8 +694,8 @@ export function Composer({ channelId, onError }: ComposerProps): React.ReactElem
         seq: nextSeq,
         text,
         senderWorkspaceId: selfWorkspaceId,
-        senderMemberId: 'local-ui',
-        senderMemberName: 'local-ui',
+        senderMemberId: HUMAN_MEMBER_ID,
+        senderMemberName: HUMAN_MEMBER_ID,
         clientMsgId,
         mentions: mentionsArg,
       });
@@ -706,8 +703,8 @@ export function Composer({ channelId, onError }: ComposerProps): React.ReactElem
         text,
         sender: {
           workspaceId: selfWorkspaceId,
-          memberId: 'local-ui',
-          memberName: 'local-ui',
+          memberId: HUMAN_MEMBER_ID,
+          memberName: HUMAN_MEMBER_ID,
         },
         clientMsgId,
         mentions: mentionsArg,

--- a/src/renderer/components/Channels/Composer.tsx
+++ b/src/renderer/components/Channels/Composer.tsx
@@ -27,6 +27,7 @@ import { findLeafPanes } from '../../hooks/a2aAddressing';
 import { generateId, type Workspace } from '../../../shared/types';
 import type { AgentSlug } from '../../../shared/events';
 import type { ChannelMember, ChannelMention, ChannelMessage } from '../../../shared/channels';
+import { HUMAN_WORKSPACE_ID } from '../../../shared/channels';
 import { useT } from '../../hooks/useT';
 import { tokenAttrs } from '../../themes';
 import { FOCUS_RING } from '../focusRing';
@@ -640,11 +641,9 @@ const EMPTY_MEMBERS: ChannelMember[] = [];
 
 export function Composer({ channelId, onError }: ComposerProps): React.ReactElement {
   const t = useT();
-  const company = useStore((s) => s.company);
   // Channels are decoupled from in-app Company mode: the active workspace
   // stands in as the sender identity when no company is set (mirrors
   // ChannelsPanel / ChannelView / useChannelsHydration).
-  const activeWorkspaceId = useStore((s) => s.activeWorkspaceId);
   const channel = useStore((s) => s.channels[channelId]);
   const members = useStore((s) => s.channelMembers[channelId] ?? EMPTY_MEMBERS);
   const workspaces = useStore((s) => s.workspaces);
@@ -652,10 +651,10 @@ export function Composer({ channelId, onError }: ComposerProps): React.ReactElem
   const paneLabel = useStore((s) => s.paneLabel);
   const postMessageDaemon = useStore((s) => s.postMessageDaemon);
 
-  // Sender identity: the CEO workspace when Company mode is active, else the
-  // active workspace. The daemon's post path requires
-  // sender.workspaceId === verifiedWorkspaceId AND membership.
-  const selfWorkspaceId = company?.ceoWorkspaceId ?? activeWorkspaceId ?? null;
+  // P5 (unified human identity): the composer posts as the reserved human
+  // workspace — the daemon's post path requires sender.workspaceId ===
+  // verifiedWorkspaceId AND membership, both of which are the ws-human row now.
+  const selfWorkspaceId: string | null = HUMAN_WORKSPACE_ID;
 
   // @-mention candidates (agent-pane redesign): every LIVE AGENT pane in a member
   // workspace except our own. We walk each member workspace's live pane tree and

--- a/src/renderer/components/Channels/__tests__/ChannelMembers.test.tsx
+++ b/src/renderer/components/Channels/__tests__/ChannelMembers.test.tsx
@@ -109,12 +109,13 @@ describe('ChannelMembers — wiring regression guard', () => {
     expect(members).toMatch(/m\.workspaceId === selfWorkspaceId && m\.memberId === selfMemberId/);
   });
 
-  it('operator model: the picker offers EVERY non-member workspace (not self-only)', () => {
-    // The human GUI operates every local workspace, so the picker is no longer
-    // gated to the active workspace. The old self-only filter is gone, and the
-    // joinable list starts from the full workspace set.
+  it('P5 unified human: "add a workspace" is no longer a membership concept', () => {
+    // The human is ONE seat (ws-human) and agents join as panes — the container
+    // passes an empty joinable-workspace list, the section stays unrendered, and
+    // self identity is the reserved human workspace, not the active one.
     expect(members).not.toContain('w.id === selfWorkspaceId');
-    expect(members).toMatch(/const joinableWorkspaces: JoinableWorkspace\[\] = workspaces/);
+    expect(members).toMatch(/const joinableWorkspaces: JoinableWorkspace\[\] = \[\];/);
+    expect(members).toMatch(/selfWorkspaceId: string \| null = HUMAN_WORKSPACE_ID/);
   });
 
   it('add routes by channel visibility: public → self-join, private → invite', () => {

--- a/src/renderer/components/Channels/__tests__/ChannelsPanel.test.tsx
+++ b/src/renderer/components/Channels/__tests__/ChannelsPanel.test.tsx
@@ -349,6 +349,7 @@ interface RenderPanelArgs {
   channelMentions?: Record<string, number>;
   activeChannelId?: string | null;
   company?: Company | null;
+  daemonStale?: boolean;
   onSelect?: (id: string) => void;
   onCreate?: (params: { name: string; visibility: 'public' | 'private' }) => boolean;
 }
@@ -361,6 +362,7 @@ function renderPanel(args: RenderPanelArgs = {}): string {
       channelMentions: args.channelMentions ?? {},
       activeChannelId: args.activeChannelId ?? null,
       company: args.company === undefined ? makeCompany() : args.company,
+      daemonStale: args.daemonStale,
       onSelect: args.onSelect ?? ((id) => recordedSelects.push(id)),
       onCreate:
         args.onCreate ??
@@ -580,5 +582,17 @@ describe('ChannelsPanel — createChannelOptimistic wiring', () => {
     expect(after.channels[channel.id]).toBeDefined();
     expect(after.channels[channel.id].companyId).toBe(DEFAULT_COMPANY_ID);
     expect(after.channelMembers[channel.id]).toHaveLength(1);
+  });
+});
+
+describe('ChannelsPanelView — stale-daemon banner (ship review C1)', () => {
+  it('renders the restart banner when daemonStale is true', () => {
+    const html = renderPanel({ daemonStale: true });
+    expect(html).toContain('data-channels-daemon-stale');
+  });
+
+  it('renders NO banner by default (current daemon / flag unset)', () => {
+    expect(renderPanel()).not.toContain('data-channels-daemon-stale');
+    expect(renderPanel({ daemonStale: false })).not.toContain('data-channels-daemon-stale');
   });
 });

--- a/src/renderer/hooks/__tests__/planChannelMessageDelivery.test.ts
+++ b/src/renderer/hooks/__tests__/planChannelMessageDelivery.test.ts
@@ -1,105 +1,91 @@
 /**
- * FIX-MULTI-WS — planChannelMessageDelivery
+ * planChannelMessageDelivery — the renderer's per-`channel.message` fan-out
+ * decision: whether to append to the human's DISPLAY cache, and which local
+ * workspaces to ROUTE the mention into.
  *
- * The renderer's per-`channel.message` fan-out decision: which display cache to
- * touch (active workspace only) and which local workspaces to route the mention
- * into (every mentioned local workspace, active OR background). This is the
- * layer the FIRST multi-workspace attempt regressed — the daemon filter tests
- * passed, but same-workspace ROUTING broke at renderer runtime and was
- * undiagnosable remotely. These cases pin both directions:
- *   - same-ws (active) mention STILL routes (the regression), and
- *   - background-ws mention NOW routes (the fix),
- * so the two never drift apart again in a unit-visible way.
+ * P5 (unified human identity): display is scoped to HUMAN membership only —
+ * a channel appends to the human's dock iff the reserved ws-human seat is a
+ * recipient, independent of the active workspace (the old active-workspace
+ * display branch leaked private agent-only traffic into the human's view;
+ * ship review: Codex privacy_leak + Claude adversarial F4). Mention ROUTING is
+ * unchanged: it fans out to every mentioned LOCAL workspace (real workspaces
+ * only — ws-human owns no panes and must never be a routing target).
  */
 
 import { describe, it, expect } from 'vitest';
 import { planChannelMessageDelivery } from '../useChannelsEventSubscription';
 
+const HUMAN = 'ws-human';
 const ACTIVE = 'ws-active';
 const BG = 'ws-background';
 const LOCAL = [ACTIVE, BG];
 
-describe('planChannelMessageDelivery — display append (active workspace only)', () => {
-  it('appends when the ACTIVE workspace is the sender', () => {
-    const plan = planChannelMessageDelivery(ACTIVE, [ACTIVE, BG], [], ACTIVE, LOCAL);
+describe('planChannelMessageDelivery — display append (human membership only)', () => {
+  it('appends when the human seat is a recipient, regardless of active workspace', () => {
+    const plan = planChannelMessageDelivery('ws-agent', [HUMAN, ACTIVE], [], LOCAL);
     expect(plan.appendToDisplay).toBe(true);
   });
 
-  it('appends when the ACTIVE workspace is a recipient (post from elsewhere)', () => {
-    const plan = planChannelMessageDelivery('ws-remote', [ACTIVE, BG], [], ACTIVE, LOCAL);
+  it('appends a human-recipient channel even when NO local workspace is a recipient', () => {
+    // The whole point of P5: the human sees their channels no matter which
+    // workspace is on screen.
+    const plan = planChannelMessageDelivery('ws-agent', [HUMAN, 'ws-other'], [], LOCAL);
     expect(plan.appendToDisplay).toBe(true);
   });
 
-  it('does NOT append when the post only concerns a BACKGROUND workspace', () => {
-    // The active view holds no catalog for BG — appending would count unread
-    // against a channel it doesn't display. Its view rebuilds on switch.
-    const plan = planChannelMessageDelivery('ws-remote', [BG], [], ACTIVE, LOCAL);
+  it('does NOT append an agent-only channel the human is not in (no active-ws leak)', () => {
+    // Pre-P5 this appended because the active workspace was a recipient; that
+    // branch is gone (privacy leak / phantom unread badges).
+    const plan = planChannelMessageDelivery('ws-agent', [ACTIVE, BG], [], LOCAL);
     expect(plan.appendToDisplay).toBe(false);
   });
 
-  it('does NOT append a fully third-party post (neither sender nor recipient is active)', () => {
-    const plan = planChannelMessageDelivery('ws-x', ['ws-y'], [], ACTIVE, LOCAL);
+  it('does NOT append a fully third-party post', () => {
+    const plan = planChannelMessageDelivery('ws-x', ['ws-y'], [], LOCAL);
     expect(plan.appendToDisplay).toBe(false);
   });
 });
 
 describe('planChannelMessageDelivery — mention routing (all local workspaces)', () => {
   it('routes a SAME-WS mention of the active workspace (the regression guard)', () => {
-    const plan = planChannelMessageDelivery('ws-remote', [ACTIVE], [ACTIVE], ACTIVE, LOCAL);
+    const plan = planChannelMessageDelivery('ws-remote', [ACTIVE], [ACTIVE], LOCAL);
     expect(plan.routeWorkspaces).toEqual([ACTIVE]);
   });
 
-  it('routes a CROSS-WS mention of a BACKGROUND workspace (the fix)', () => {
-    // Viewing ACTIVE, a post mentions the BACKGROUND workspace's pane. Before
-    // the fix this never reached the renderer; now it routes to BG.
-    const plan = planChannelMessageDelivery('ws-remote', [BG], [BG], ACTIVE, LOCAL);
+  it('routes a CROSS-WS mention of a BACKGROUND workspace (the multi-ws fix)', () => {
+    const plan = planChannelMessageDelivery('ws-remote', [BG], [BG], LOCAL);
     expect(plan.routeWorkspaces).toEqual([BG]);
   });
 
   it('routes to BOTH when a single post mentions active + background', () => {
-    const plan = planChannelMessageDelivery('ws-remote', [ACTIVE, BG], [ACTIVE, BG], ACTIVE, LOCAL);
+    const plan = planChannelMessageDelivery('ws-remote', [ACTIVE, BG], [ACTIVE, BG], LOCAL);
     expect(new Set(plan.routeWorkspaces)).toEqual(new Set([ACTIVE, BG]));
   });
 
   it('does NOT route a mention of a NON-LOCAL workspace (its own renderer handles it)', () => {
-    const plan = planChannelMessageDelivery('ws-remote', [ACTIVE], ['ws-elsewhere'], ACTIVE, LOCAL);
+    const plan = planChannelMessageDelivery('ws-remote', [ACTIVE], ['ws-elsewhere'], LOCAL);
     expect(plan.routeWorkspaces).toEqual([]);
   });
 
   it('routes nothing for a post with no mentions (plain message)', () => {
-    const plan = planChannelMessageDelivery('ws-remote', [ACTIVE, BG], [], ACTIVE, LOCAL);
+    const plan = planChannelMessageDelivery('ws-remote', [ACTIVE, BG], [], LOCAL);
     expect(plan.routeWorkspaces).toEqual([]);
-  });
-
-  it('background delivery is INDEPENDENT of display: routes to BG while appendToDisplay is false', () => {
-    // The crux of the fix in one assertion — a background mention delivers even
-    // though its workspace contributes nothing to the on-screen display.
-    const plan = planChannelMessageDelivery('ws-remote', [BG], [BG], ACTIVE, LOCAL);
-    expect(plan.appendToDisplay).toBe(false);
-    expect(plan.routeWorkspaces).toEqual([BG]);
   });
 });
 
-describe('planChannelMessageDelivery — P5 unified human display', () => {
-  it('a channel the HUMAN is in displays regardless of the active workspace', () => {
-    const plan = planChannelMessageDelivery(
-      'ws-agent-sender',
-      ['ws-human', 'ws-other'],
-      [],
-      'ws-active-unrelated',
-      ['ws-active-unrelated', 'ws-other'],
-    );
+describe('planChannelMessageDelivery — P5 invariants', () => {
+  it('a mention of the virtual human seat is NEVER a routing target (ws-human owns no panes)', () => {
+    // Display appends (human is a recipient) but routing must stay empty — the
+    // caller feeds real localIds (not the poll union that includes ws-human), so
+    // even a ws-human mention resolves to zero panes.
+    const plan = planChannelMessageDelivery('ws-agent', [HUMAN], [HUMAN], LOCAL);
     expect(plan.appendToDisplay).toBe(true);
+    expect(plan.routeWorkspaces).toEqual([]);
   });
 
-  it('an agent-only channel still follows the active-workspace rule', () => {
-    const plan = planChannelMessageDelivery(
-      'ws-agent-sender',
-      ['ws-other'],
-      [],
-      'ws-active-unrelated',
-      ['ws-active-unrelated', 'ws-other'],
-    );
-    expect(plan.appendToDisplay).toBe(false);
+  it('human display is independent of routing: appends for the human, routes to a mentioned agent', () => {
+    const plan = planChannelMessageDelivery('ws-remote', [HUMAN, BG], [BG], LOCAL);
+    expect(plan.appendToDisplay).toBe(true);
+    expect(plan.routeWorkspaces).toEqual([BG]);
   });
 });

--- a/src/renderer/hooks/__tests__/planChannelMessageDelivery.test.ts
+++ b/src/renderer/hooks/__tests__/planChannelMessageDelivery.test.ts
@@ -79,3 +79,27 @@ describe('planChannelMessageDelivery — mention routing (all local workspaces)'
     expect(plan.routeWorkspaces).toEqual([BG]);
   });
 });
+
+describe('planChannelMessageDelivery — P5 unified human display', () => {
+  it('a channel the HUMAN is in displays regardless of the active workspace', () => {
+    const plan = planChannelMessageDelivery(
+      'ws-agent-sender',
+      ['ws-human', 'ws-other'],
+      [],
+      'ws-active-unrelated',
+      ['ws-active-unrelated', 'ws-other'],
+    );
+    expect(plan.appendToDisplay).toBe(true);
+  });
+
+  it('an agent-only channel still follows the active-workspace rule', () => {
+    const plan = planChannelMessageDelivery(
+      'ws-agent-sender',
+      ['ws-other'],
+      [],
+      'ws-active-unrelated',
+      ['ws-active-unrelated', 'ws-other'],
+    );
+    expect(plan.appendToDisplay).toBe(false);
+  });
+});

--- a/src/renderer/hooks/__tests__/useChannelsHydration.test.ts
+++ b/src/renderer/hooks/__tests__/useChannelsHydration.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { hydrateChannelsCatalog, loadChannelHistory } from '../useChannelsHydration';
 import type { Channel, ChannelMember, ChannelMessage } from '../../../shared/channels';
+import { CHANNELS_EPOCH } from '../../../shared/channels';
 
 function makeChannel(overrides: Partial<Channel> = {}): Channel {
   return {
@@ -266,5 +267,44 @@ describe('loadChannelHistory (P0 recent-history load)', () => {
     const n = await loadChannelHistory({ rpc, channelId: 'ch-1', nextSeq: 10, workspaceId: 'ws-self', apply });
     expect(n).toBe(0);
     expect(apply).not.toHaveBeenCalled();
+  });
+});
+
+describe('hydrateChannelsCatalog — stale-daemon epoch detection (ship review C1)', () => {
+  it('flags stale when the list reply has NO channelsEpoch (pre-P5 daemon)', async () => {
+    const setDaemonStale = vi.fn();
+    await hydrateChannelsCatalog({
+      rpc: makeRpc({ list: () => ({ ok: true, channels: [makeChannel()] }) }),
+      workspaceId: 'ws-human',
+      setChannels: vi.fn(),
+      setDaemonStale,
+    });
+    expect(setDaemonStale).toHaveBeenCalledWith(true);
+  });
+
+  it('clears stale when the daemon reports a current epoch (self-heal after restart)', async () => {
+    const setDaemonStale = vi.fn();
+    await hydrateChannelsCatalog({
+      rpc: makeRpc({
+        list: () => ({ ok: true, channelsEpoch: CHANNELS_EPOCH, channels: [makeChannel()] }),
+      }),
+      workspaceId: 'ws-human',
+      setChannels: vi.fn(),
+      setDaemonStale,
+    });
+    expect(setDaemonStale).toHaveBeenCalledWith(false);
+  });
+
+  it('does NOT signal on a failed list (no false banner while the daemon reconnects)', async () => {
+    const setDaemonStale = vi.fn();
+    await hydrateChannelsCatalog({
+      rpc: vi.fn(async () => {
+        throw new Error('pipe down');
+      }),
+      workspaceId: 'ws-human',
+      setChannels: vi.fn(),
+      setDaemonStale,
+    });
+    expect(setDaemonStale).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/hooks/channelMentionInbox.ts
+++ b/src/renderer/hooks/channelMentionInbox.ts
@@ -34,13 +34,9 @@
 // one post (one seq) get distinct task ids instead of colliding.
 
 import type { ChannelMessage } from '../../shared/channels';
+import { HUMAN_MEMBER_ID } from '../../shared/channels';
 import type { Task, Message, Part, Artifact, TaskState, PaneLeaf } from '../../shared/types';
 import { resolveSenderPaneAddress } from './a2aAddressing';
-
-/** Reserved GUI member id — the human seat (one per workspace, no PTY). Mirrors
- *  the daemon's reserved identity (a2a.channel.rpc.ts spoof reject) and the UI
- *  (ChannelMembers UI_MEMBER_ID). A mention of THIS member targets the HUMAN. */
-const HUMAN_MEMBER_ID = 'local-ui';
 
 /** Dependencies injected so the routing logic stays a pure, unit-testable
  *  function (no store / window coupling). The hook wires these to the real

--- a/src/renderer/hooks/useChannelsEventSubscription.ts
+++ b/src/renderer/hooks/useChannelsEventSubscription.ts
@@ -61,6 +61,7 @@ import {
   isChannelMentionDeliveredPersisted,
   markChannelMentionDeliveredPersisted,
 } from './channelMentionHandled';
+import { HUMAN_WORKSPACE_ID } from '../../shared/channels';
 import { isNudgeRateLimited, recordNudge, shouldWarnLoopSuspect } from './channelMentionRateLimit';
 import { findLeafPanes } from './a2aAddressing';
 import { panePrincipalId } from '../../shared/principals';
@@ -117,7 +118,12 @@ export function planChannelMessageDelivery(
   activeWorkspaceId: string,
   localIds: readonly string[],
 ): { appendToDisplay: boolean; routeWorkspaces: string[] } {
+  // P5: any channel the unified HUMAN is a member of displays regardless of
+  // which workspace is active — the whole point of the virtual human seat is
+  // that switching workspaces no longer changes what the human sees. Channels
+  // the human is NOT in (agent-only rooms) keep the active-workspace rule.
   const appendToDisplay =
+    recipientWorkspaceIds.includes(HUMAN_WORKSPACE_ID) ||
     senderWorkspaceId === activeWorkspaceId ||
     recipientWorkspaceIds.includes(activeWorkspaceId);
   const mentionWs = new Set(mentionWorkspaceIds);
@@ -181,29 +187,23 @@ function readEventsPollBridge(): EventsPollBridge | undefined {
  *     `refreshChannels` rebuilds from authoritative state.
  */
 export function useChannelsEventSubscription(): void {
-  // Per-recipient scoping (plan U3, R3): the daemon's per-workspace filter at
-  // `events.rpc.ts:115-124` requires the caller to identify its own workspace
-  // or it silently drops every event. Channels are decoupled from in-app
-  // Company mode, so the identity is the company CEO workspace when set, else
-  // the active workspace (mirrors useChannelsHydration / ChannelsPanel).
+  // P5 (unified human identity): the HUMAN's channel identity is the reserved
+  // virtual workspace — hydration/catalog reads and the human's display scope
+  // key on it, NOT on whichever workspace happens to be active. The ACTIVE
+  // workspace still matters for one thing: displaying agent-only channels the
+  // human is not a member of while one of their workspaces is (the legacy
+  // rule), so it is read separately and fed to planChannelMessageDelivery.
   //
-  // SUBSCRIBE to this (not getState() inside a []-deps effect): a prior bug read
-  // it once at mount, and if this hook mounted before `activeWorkspaceId` was
-  // set (boot race), self was null, the effect early-returned, and events.poll
-  // NEVER started — so live channel messages, the unread/mention dock badges,
-  // AND the mention→a2a inbox routing all silently no-op'd. Keying the effect on
-  // `workspaceId` re-runs it the moment self lands, starting the poll then.
-  const workspaceId = useStore((s) => s.company?.ceoWorkspaceId ?? s.activeWorkspaceId);
+  // SUBSCRIBE to activeWs (not getState() inside a []-deps effect): a prior bug
+  // read identity once at mount and never re-ran on the boot race. The human
+  // identity itself is a constant now, so the poll can start immediately.
+  const workspaceId = HUMAN_WORKSPACE_ID;
+  const activeWs = useStore((s) => s.activeWorkspaceId);
   // FIX-MULTI-WS: every local workspace id, joined so the selector returns a
   // stable primitive (string) — the effect re-runs (rebuilding the poll scope)
   // only when a workspace is added/removed, not on unrelated store writes.
   const allWorkspaceIds = useStore((s) => s.workspaces.map((w) => w.id).join(','));
   useEffect(() => {
-    if (!workspaceId) {
-      // No resolvable self yet (pre-boot). The selector above re-runs this
-      // effect once `activeWorkspaceId` is set — a wait, not a dead end.
-      return;
-    }
     const bridge = readEventsPollBridge();
     if (!bridge) {
       // The renderer should never reach this state — `useRpcBridge`
@@ -218,11 +218,13 @@ export function useChannelsEventSubscription(): void {
       return;
     }
 
-    // FIX-MULTI-WS: the poll's union scope — every local workspace. The
-    // active/CEO id is unioned in defensively (it should already be in the
-    // list; a boot race where it isn't must not drop it from the scope).
+    // FIX-MULTI-WS: the poll's union scope — every local workspace. P5 widens
+    // it with the reserved human workspace so events addressed to the unified
+    // human seat arrive too. `localIds` (REAL workspaces only) keeps feeding
+    // mention ROUTING and the flush/prune sweeps — ws-human owns no panes and
+    // must never become a routing target; `pollIds` is scope only.
     const localIds = allWorkspaceIds ? allWorkspaceIds.split(',').filter(Boolean) : [];
-    if (!localIds.includes(workspaceId)) localIds.push(workspaceId);
+    const pollIds = [...localIds, workspaceId];
 
     // A4: stamp the mount time so the first poll can keep events that arrived
     // AFTER mount (live) while skipping pre-mount ring history (see `tick`).
@@ -401,9 +403,9 @@ export function useChannelsEventSubscription(): void {
         types: ['channel.message', 'agent.lifecycle', 'channel.catalog'],
         max: EVENT_POLL_MAX,
         workspaceId,
-        // FIX-MULTI-WS: union scope — the daemon filters by set membership,
-        // so background workspaces' events arrive in this same single poll.
-        workspaceIds: localIds,
+        // FIX-MULTI-WS + P5: union scope — every local workspace PLUS the
+        // reserved human workspace; the daemon filters by set membership.
+        workspaceIds: pollIds,
       })
         .then((raw) => {
           if (disposed || !raw) return;
@@ -525,7 +527,10 @@ export function useChannelsEventSubscription(): void {
                 channelEvent.workspaceId,
                 channelEvent.recipientWorkspaceIds,
                 (channelEvent.message.mentions ?? []).map((m) => m.workspaceId),
-                workspaceId,
+                // P5: the ACTIVE workspace only drives the legacy agent-channel
+                // display rule; human-membership display is decided inside the
+                // plan via HUMAN_WORKSPACE_ID (workspace-switch independent).
+                activeWs ?? '',
                 localIds,
               );
               // Display cache / unread / mention badges: ACTIVE workspace only,
@@ -617,7 +622,11 @@ export function useChannelsEventSubscription(): void {
               if (
                 ce.recipientWorkspaceIds.includes('*') ||
                 ce.workspaceId === workspaceId ||
-                ce.recipientWorkspaceIds.includes(workspaceId)
+                ce.recipientWorkspaceIds.includes(workspaceId) ||
+                // P5: catalog changes touching the ACTIVE workspace still
+                // re-hydrate (agent membership churn in the visible view).
+                (!!activeWs &&
+                  (ce.workspaceId === activeWs || ce.recipientWorkspaceIds.includes(activeWs)))
               ) {
                 sawCatalog = true;
               }
@@ -674,5 +683,5 @@ export function useChannelsEventSubscription(): void {
     // FIX-MULTI-WS: allWorkspaceIds rebuilds the loop (and its union scope)
     // when a workspace is added/removed — a NEW workspace must join the poll
     // scope or its mentions would silently drop until the next remount.
-  }, [workspaceId, allWorkspaceIds]);
+  }, [activeWs, allWorkspaceIds]);
 }

--- a/src/renderer/hooks/useChannelsEventSubscription.ts
+++ b/src/renderer/hooks/useChannelsEventSubscription.ts
@@ -115,17 +115,18 @@ export function planChannelMessageDelivery(
   senderWorkspaceId: string,
   recipientWorkspaceIds: readonly string[],
   mentionWorkspaceIds: readonly string[],
-  activeWorkspaceId: string,
   localIds: readonly string[],
 ): { appendToDisplay: boolean; routeWorkspaces: string[] } {
-  // P5: any channel the unified HUMAN is a member of displays regardless of
-  // which workspace is active — the whole point of the virtual human seat is
-  // that switching workspaces no longer changes what the human sees. Channels
-  // the human is NOT in (agent-only rooms) keep the active-workspace rule.
-  const appendToDisplay =
-    recipientWorkspaceIds.includes(HUMAN_WORKSPACE_ID) ||
-    senderWorkspaceId === activeWorkspaceId ||
-    recipientWorkspaceIds.includes(activeWorkspaceId);
+  // P5: display exactly the channels the unified HUMAN is a member of, and
+  // ONLY those — the human's view is workspace-independent. The old
+  // active-workspace branch (ship review: Codex privacy_leak + Claude
+  // adversarial F4) leaked private agent-only channel traffic into the human's
+  // dock (the active workspace was a recipient but ws-human was not), producing
+  // phantom unread badges on channels the human can't even open. Mention
+  // ROUTING still fans out to every real local workspace (routeWorkspaces) so
+  // agents are pinged; only the human's DISPLAY is scoped to their membership.
+  void senderWorkspaceId; // retained for signature stability / future use
+  const appendToDisplay = recipientWorkspaceIds.includes(HUMAN_WORKSPACE_ID);
   const mentionWs = new Set(mentionWorkspaceIds);
   const routeWorkspaces = localIds.filter((id) => mentionWs.has(id));
   return { appendToDisplay, routeWorkspaces };
@@ -188,17 +189,11 @@ function readEventsPollBridge(): EventsPollBridge | undefined {
  */
 export function useChannelsEventSubscription(): void {
   // P5 (unified human identity): the HUMAN's channel identity is the reserved
-  // virtual workspace — hydration/catalog reads and the human's display scope
-  // key on it, NOT on whichever workspace happens to be active. The ACTIVE
-  // workspace still matters for one thing: displaying agent-only channels the
-  // human is not a member of while one of their workspaces is (the legacy
-  // rule), so it is read separately and fed to planChannelMessageDelivery.
-  //
-  // SUBSCRIBE to activeWs (not getState() inside a []-deps effect): a prior bug
-  // read identity once at mount and never re-ran on the boot race. The human
-  // identity itself is a constant now, so the poll can start immediately.
+  // virtual workspace — hydration/catalog reads, display scope, and mutations
+  // all key on it, NEVER on the active workspace, so switching workspaces no
+  // longer changes what the human sees. It is a constant, so the poll starts
+  // immediately (the old activeWorkspaceId boot race is gone).
   const workspaceId = HUMAN_WORKSPACE_ID;
-  const activeWs = useStore((s) => s.activeWorkspaceId);
   // FIX-MULTI-WS: every local workspace id, joined so the selector returns a
   // stable primitive (string) — the effect re-runs (rebuilding the poll scope)
   // only when a workspace is added/removed, not on unrelated store writes.
@@ -521,16 +516,12 @@ export function useChannelsEventSubscription(): void {
               const st = useStore.getState();
               // FIX-MULTI-WS: the pure decision (append-to-active-display +
               // which local workspaces to route the mention into). See
-              // planChannelMessageDelivery — active-vs-background split, the
-              // exact layer the first multi-ws attempt regressed.
+              // planChannelMessageDelivery — display is scoped to human
+              // membership (P5), routing fans out to real local workspaces.
               const plan = planChannelMessageDelivery(
                 channelEvent.workspaceId,
                 channelEvent.recipientWorkspaceIds,
                 (channelEvent.message.mentions ?? []).map((m) => m.workspaceId),
-                // P5: the ACTIVE workspace only drives the legacy agent-channel
-                // display rule; human-membership display is decided inside the
-                // plan via HUMAN_WORKSPACE_ID (workspace-switch independent).
-                activeWs ?? '',
                 localIds,
               );
               // Display cache / unread / mention badges: ACTIVE workspace only,
@@ -618,15 +609,14 @@ export function useChannelsEventSubscription(): void {
               // background workspace would clobber the active view), so only
               // an active-relevant catalog event triggers it. A background
               // workspace's catalog is rebuilt on switch.
+              // P5: catalog re-hydrates on any change touching the human seat
+              // or broadcast — the human's catalog is ws-human-scoped, so an
+              // active-workspace-only catalog change is not the human's view.
               const ce = event as ChannelCatalogEvent;
               if (
                 ce.recipientWorkspaceIds.includes('*') ||
                 ce.workspaceId === workspaceId ||
-                ce.recipientWorkspaceIds.includes(workspaceId) ||
-                // P5: catalog changes touching the ACTIVE workspace still
-                // re-hydrate (agent membership churn in the visible view).
-                (!!activeWs &&
-                  (ce.workspaceId === activeWs || ce.recipientWorkspaceIds.includes(activeWs)))
+                ce.recipientWorkspaceIds.includes(workspaceId)
               ) {
                 sawCatalog = true;
               }
@@ -682,6 +672,8 @@ export function useChannelsEventSubscription(): void {
     };
     // FIX-MULTI-WS: allWorkspaceIds rebuilds the loop (and its union scope)
     // when a workspace is added/removed — a NEW workspace must join the poll
-    // scope or its mentions would silently drop until the next remount.
-  }, [activeWs, allWorkspaceIds]);
+    // scope or its mentions would silently drop until the next remount. P5: the
+    // active workspace no longer affects display, so it is not a dependency (no
+    // poll restart on workspace switch).
+  }, [allWorkspaceIds]);
 }

--- a/src/renderer/hooks/useChannelsHydration.ts
+++ b/src/renderer/hooks/useChannelsHydration.ts
@@ -41,6 +41,7 @@
 import { useEffect } from 'react';
 import { useStore } from '../stores';
 import type { Channel, ChannelMember, ChannelMessage } from '../../shared/channels';
+import { HUMAN_WORKSPACE_ID } from '../../shared/channels';
 
 /** Dependencies for the pure hydration routine. */
 export interface ChannelHydrationDeps {
@@ -223,13 +224,11 @@ function readChannelsRpc(): ChannelsRpcBridge | undefined {
  * its daemon listener on unmount.
  */
 export function useChannelsHydration(): void {
-  // Subscribe to the self workspace id (NOT read once via getState). On boot the
-  // hook can mount BEFORE activeWorkspaceId is set; with empty deps it captured
-  // workspaceId='' and hydrateChannelsCatalog bailed (no channels, no members) —
-  // so @mention candidates (which come from channelMembers) were always empty.
-  // Keying the effect on workspaceId re-runs hydration the moment identity
-  // resolves. Mirrors the boot-race fix in useChannelsEventSubscription (2b40035).
-  const workspaceId = useStore((s) => s.company?.ceoWorkspaceId ?? s.activeWorkspaceId ?? '');
+  // P5 (unified human identity): the catalog hydrates as the reserved human
+  // workspace — every public channel plus every private channel the HUMAN is
+  // a member of, independent of which workspace is active. This also removes
+  // the old boot race (identity used to wait on activeWorkspaceId).
+  const workspaceId = HUMAN_WORKSPACE_ID;
   useEffect(() => {
     let disposed = false;
 

--- a/src/renderer/hooks/useChannelsHydration.ts
+++ b/src/renderer/hooks/useChannelsHydration.ts
@@ -10,9 +10,9 @@
 // and dispatches the result into `setChannels`.
 //
 // Identity: channels are decoupled from in-app Company mode. The "self"
-// workspace is the Company CEO workspace when Company mode is active, else
-// the active workspace — so channels hydrate (and stay visible) without a
-// company. Reads ride the `rpc` bridge (the pipe RpcRouter); the main-side
+// workspace is the reserved unified human seat (ws-human, P5) — so channels
+// hydrate (and stay visible) independent of which workspace is active. Reads
+// ride the `rpc` bridge (the pipe RpcRouter); the main-side
 // `a2a.channel.*` read handler accepts a caller-supplied workspace for a
 // no-senderPtyId renderer caller (process-boundary trust — see the header of
 // `src/main/pipe/handlers/a2a.channel.rpc.ts`). Only the unforgeable D5 pin
@@ -27,11 +27,11 @@
 //   3. `daemon.onConnected` — covers respawn/reconnect after the first
 //      hydration already ran.
 //
-// Scope note (FIX-MULTI-WS): the daemon's `list(verifiedWorkspaceId)` returns
-// every PUBLIC channel plus PRIVATE channels the passed workspace is a member
-// of. With a single self-workspace, private channels owned by a different
-// workspace stay hidden until the multi-workspace identity follow-up lands.
-// Public channels (the create modal's default) always hydrate.
+// Scope note: the daemon's `list(verifiedWorkspaceId)` returns every PUBLIC
+// channel plus PRIVATE channels the passed workspace is a member of. Since the
+// self-workspace is now the unified ws-human seat (P5), every private channel
+// the human joined hydrates; public channels (the create modal's default)
+// always hydrate.
 //
 // The core list→getMembers→setChannels logic is extracted into the pure
 // `hydrateChannelsCatalog` (mirroring the `createLateReconcileOnConnect` /

--- a/src/renderer/hooks/useChannelsHydration.ts
+++ b/src/renderer/hooks/useChannelsHydration.ts
@@ -120,7 +120,8 @@ export async function hydrateChannelsCatalog(deps: ChannelHydrationDeps): Promis
   // the field. Signal BOTH directions so the banner self-clears once the daemon
   // restarts (this routine re-runs on every reconnect).
   const rawEpoch = (listEnv as { channelsEpoch?: unknown }).channelsEpoch;
-  deps.setDaemonStale?.((typeof rawEpoch === 'number' ? rawEpoch : 0) < CHANNELS_EPOCH);
+  const epoch = typeof rawEpoch === 'number' && Number.isFinite(rawEpoch) ? rawEpoch : 0;
+  deps.setDaemonStale?.(epoch < CHANNELS_EPOCH);
 
   // Fetch members per channel in parallel (best-effort — a channel whose
   // getMembers fails hydrates with no member entry and is reconciled on the

--- a/src/renderer/hooks/useChannelsHydration.ts
+++ b/src/renderer/hooks/useChannelsHydration.ts
@@ -41,7 +41,7 @@
 import { useEffect } from 'react';
 import { useStore } from '../stores';
 import type { Channel, ChannelMember, ChannelMessage } from '../../shared/channels';
-import { HUMAN_WORKSPACE_ID } from '../../shared/channels';
+import { HUMAN_WORKSPACE_ID, CHANNELS_EPOCH } from '../../shared/channels';
 
 /** Dependencies for the pure hydration routine. */
 export interface ChannelHydrationDeps {
@@ -52,6 +52,12 @@ export interface ChannelHydrationDeps {
   workspaceId: string;
   /** Catalog setter (`channelsSlice.setChannels`). */
   setChannels: (channels: Channel[], members: Record<string, ChannelMember[]>) => void;
+  /** Ship review C1 — stale-daemon signal. Called with `true` when the daemon's
+   *  `a2a.channel.list` reply carries a missing/lower `channelsEpoch` (a
+   *  long-lived pre-P5 daemon survived the app upgrade: the human's channel
+   *  identity can't resolve until it restarts), `false` when the epoch is
+   *  current. Optional so tests/legacy callers are untouched. */
+  setDaemonStale?: (stale: boolean) => void;
   /** Liveness guard. When it returns false the routine bails before
    *  dispatching (the hook passes `() => !disposed`). Defaults to always-live
    *  for tests. */
@@ -108,6 +114,13 @@ export async function hydrateChannelsCatalog(deps: ChannelHydrationDeps): Promis
   const rawChannels = (listEnv as { channels?: unknown }).channels;
   if (!Array.isArray(rawChannels)) return 0;
   const channels = rawChannels as Channel[];
+
+  // Ship review C1 — stale-daemon detection. A CURRENT daemon stamps
+  // `channelsEpoch >= CHANNELS_EPOCH` on the list reply; a pre-P5 daemon omits
+  // the field. Signal BOTH directions so the banner self-clears once the daemon
+  // restarts (this routine re-runs on every reconnect).
+  const rawEpoch = (listEnv as { channelsEpoch?: unknown }).channelsEpoch;
+  deps.setDaemonStale?.((typeof rawEpoch === 'number' ? rawEpoch : 0) < CHANNELS_EPOCH);
 
   // Fetch members per channel in parallel (best-effort — a channel whose
   // getMembers fails hydrates with no member entry and is reconciled on the
@@ -240,6 +253,7 @@ export function useChannelsHydration(): void {
         rpc: bridge.rpc,
         workspaceId,
         setChannels: useStore.getState().setChannels,
+        setDaemonStale: useStore.getState().setChannelsDaemonStale,
         isCurrent: () => !disposed,
       });
     };

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -660,7 +660,6 @@ export const en = {
   'channels.noMembers': 'No members yet.',
   'channels.leaveChannel': 'Leave channel',
   'channels.addMember': 'Add a workspace',
-  'channels.allWorkspacesMembers': 'All workspaces are members.',
   'channels.me': 'Me',
   'channels.addAgentPane': 'Add an agent pane',
   'channels.noAgentPanes': 'No live agent panes to add.',

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -666,6 +666,8 @@ export const en = {
   'channels.memberLiveTitle': 'Agent pane is live',
   'channels.memberStaleTitle': 'Agent pane is gone or restarting',
   'channels.joinedToast': 'Added {workspace} to #{channel}',
+  'channels.daemonStaleBanner':
+    'Channels were updated, but the background daemon is still running the old version. Quit wmux fully and start it again to finish the update.',
   'channels.alreadyMemberToast': '{workspace} is already in #{channel}',
   'channels.joinFailedToast': "Couldn't add {workspace} to the channel",
   'channels.leftToast': 'Left #{channel}',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -591,6 +591,8 @@ export const ko = {
   'channels.memberLiveTitle': '에이전트 판이 살아 있습니다',
   'channels.memberStaleTitle': '에이전트 판이 사라졌거나 재시작 중입니다',
   'channels.joinedToast': '{workspace}을(를) #{channel}에 추가했습니다',
+  'channels.daemonStaleBanner':
+    '채널이 업데이트되었지만 백그라운드 데몬이 이전 버전으로 실행 중입니다. wmux를 완전히 종료한 뒤 다시 시작하면 적용됩니다.',
   'channels.alreadyMemberToast': '{workspace}은(는) 이미 #{channel}에 있습니다',
   'channels.joinFailedToast': '{workspace} 추가에 실패했습니다',
   'channels.leftToast': '#{channel}에서 나갔습니다',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -585,7 +585,6 @@ export const ko = {
   'channels.noMembers': '아직 멤버가 없습니다.',
   'channels.leaveChannel': '채널 나가기',
   'channels.addMember': '워크스페이스 추가',
-  'channels.allWorkspacesMembers': '모든 워크스페이스가 멤버입니다.',
   'channels.me': '나',
   'channels.addAgentPane': '에이전트 판 추가',
   'channels.noAgentPanes': '추가할 에이전트 판이 없습니다.',

--- a/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
@@ -294,10 +294,9 @@ describe('channelsSlice — appendMessageFromEvent', () => {
       createdBy: sender,
       channel: makeChannel(),
     });
-    // self = ws-1 (not viewing ch-1). An MCP/agent post from ws-1 has no
-    // optimistic row, so without the self guard it would unread-badge itself.
-    store.setState((s) => ({ ...s, activeWorkspaceId: 'ws-1' }) as TestState);
-    store.getState().appendMessageFromEvent(makeMessage('ch-1', 1, { workspaceId: 'ws-1' }));
+    // P5: self = the unified human seat (ws-human). A post from the human's
+    // own seat must not unread-badge; agent posts (any workspace) DO badge.
+    store.getState().appendMessageFromEvent(makeMessage('ch-1', 1, { workspaceId: 'ws-human' }));
     expect(store.getState().channelUnread['ch-1'] ?? 0).toBe(0);
     expect(store.getState().channelMentions['ch-1'] ?? 0).toBe(0);
     // Another workspace's post on the same (inactive) channel still bumps.
@@ -313,11 +312,10 @@ describe('channelsSlice — appendMessageFromEvent', () => {
       createdBy: sender,
       channel: makeChannel(),
     });
-    store.setState((s) => ({ ...s, activeWorkspaceId: 'ws-1' }) as TestState);
-    // Same-ws sender @mentions self-ws (pane A → sibling pane B): being mentioned
-    // is a real signal, so the @ badge bumps independently of the unread self-mute.
+    // P5: the human's own post that @mentions the human seat (edge) — the @
+    // badge bumps independently of the unread self-mute.
     store.getState().appendMessageFromEvent(
-      makeMessage('ch-1', 1, { workspaceId: 'ws-1', mentions: [{ workspaceId: 'ws-1', name: 'B' }] }),
+      makeMessage('ch-1', 1, { workspaceId: 'ws-human', mentions: [{ workspaceId: 'ws-human', name: 'me' }] }),
     );
     expect(store.getState().channelMentions['ch-1']).toBe(1);
     expect(store.getState().channelUnread['ch-1'] ?? 0).toBe(0); // unread still self-muted
@@ -338,11 +336,7 @@ describe('channelsSlice — appendMessageFromEvent', () => {
 
   it('bumps channelMentions when an unseen message @-mentions self', () => {
     const store = createTestStore();
-    // The self identity lives on sibling slices (company / activeWorkspaceId);
-    // inject it into the minimal channels-only test store.
-    store.setState((s) => {
-      (s as unknown as { activeWorkspaceId: string }).activeWorkspaceId = 'ws-me';
-    });
+    // P5: mention-of-self = a mention of the unified human seat (ws-human).
     store.getState().createChannelOptimistic({
       name: 'general',
       visibility: 'public',
@@ -350,7 +344,7 @@ describe('channelsSlice — appendMessageFromEvent', () => {
       channel: makeChannel(),
     });
     store.getState().appendMessageFromEvent(
-      makeMessage('ch-1', 1, { mentions: [{ workspaceId: 'ws-me', name: 'me' }] }),
+      makeMessage('ch-1', 1, { mentions: [{ workspaceId: 'ws-human', name: 'me' }] }),
     );
     expect(store.getState().channelMentions['ch-1']).toBe(1);
     expect(store.getState().channelUnread['ch-1']).toBe(1);
@@ -385,7 +379,7 @@ describe('channelsSlice — appendMessageFromEvent', () => {
       createdBy: sender,
       channel: makeChannel(),
     });
-    const mention = { mentions: [{ workspaceId: 'ws-me', name: 'me' }] };
+    const mention = { mentions: [{ workspaceId: 'ws-human', name: 'me' }] };
     store.getState().appendMessageFromEvent(makeMessage('ch-1', 1, mention));
     expect(store.getState().channelMentions['ch-1']).toBe(1);
 

--- a/src/renderer/stores/slices/channelsSlice.ts
+++ b/src/renderer/stores/slices/channelsSlice.ts
@@ -63,6 +63,7 @@ import type {
   ChannelMessage,
   ChannelVisibility,
 } from '../../../shared/channels';
+import { HUMAN_WORKSPACE_ID } from '../../../shared/channels';
 import { panePrincipalId } from '../../../shared/principals';
 import { computePaneAutoName } from '../../utils/paneNaming';
 import { findLeafPanes } from '../../hooks/a2aAddressing';
@@ -554,9 +555,10 @@ export const createChannelsSlice: StateCreator<
         next[idx] = message;
         state.channelMessages[channelId] = next;
       }
-      // `self` = the company CEO workspace when set, else the active workspace —
-      // mirrors ChannelView/Composer identity resolution.
-      const selfWs = state.company?.ceoWorkspaceId ?? state.activeWorkspaceId;
+      // P5: `self` = the unified human seat — the human's own posts are muted;
+      // agent posts (any workspace, incl. the active one) DO count as unread
+      // now, which is the honest badge (they are news to the human).
+      const selfWs = HUMAN_WORKSPACE_ID;
       if (isNew && state.activeChannelId !== channelId) {
         // A6 self-mute (unread): a workspace's OWN posts must not badge it as
         // unread. A composer post never bumps unread anyway (the activeChannelId

--- a/src/renderer/stores/slices/channelsSlice.ts
+++ b/src/renderer/stores/slices/channelsSlice.ts
@@ -174,6 +174,12 @@ export interface ChannelsSlice {
    *  workspace — a strict subset of `channelUnread`, surfaced as a stronger
    *  dock badge. Cleared with unread by `markChannelRead` / `setActiveChannel`. */
   channelMentions: Record<string, number>;
+  /** Ship review C1 — true when the attached daemon reported a channels epoch
+   *  older than this renderer requires (a long-lived pre-P5 daemon survived the
+   *  app upgrade). Drives the "restart wmux" banner in ChannelsPanel; set from
+   *  hydration on every (re)connect, so it self-clears after a daemon restart. */
+  channelsDaemonStale: boolean;
+  setChannelsDaemonStale: (stale: boolean) => void;
 
   // ── User-initiated actions (optimistic local mutations) ─────────
   // Each action takes the daemon-resolved result as a parameter so the
@@ -348,6 +354,12 @@ export const createChannelsSlice: StateCreator<
   activeChannelId: null,
   channelUnread: {},
   channelMentions: {},
+  channelsDaemonStale: false,
+
+  setChannelsDaemonStale: (stale) =>
+    set((state: StoreState) => {
+      state.channelsDaemonStale = stale;
+    }),
 
   setActiveChannel: (channelId) =>
     set((state: StoreState) => {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -270,6 +270,28 @@ export const EMPTY_CHANNEL_STATE: ChannelState = {
  */
 export const DEFAULT_COMPANY_ID = 'co-default';
 
+/**
+ * P5 (unified human identity) — the VIRTUAL workspace that owns every human
+ * membership row. The human is ONE principal, not one-per-workspace: joining
+ * or creating a channel used to stamp whichever workspace happened to be
+ * active (`(ws-X, 'local-ui')`), scattering "you" across rows and binding the
+ * whole channel view to the active workspace. All human rows merge into
+ * `(HUMAN_WORKSPACE_ID, HUMAN_MEMBER_ID)` at daemon load — deterministic and
+ * crash-safe, the same contract as the lastReadSeq backfill. No collision is
+ * possible: real workspace ids are `ws-<uuid>`.
+ *
+ * Trust: only the renderer-local mutate path (channels:mutate-local) may claim
+ * this workspace id; a pipe caller asserting it is rejected — same class as
+ * the 'local-ui' spoof guard (a2a.channel.rpc.ts).
+ */
+export const HUMAN_WORKSPACE_ID = 'ws-human';
+
+/** The reserved human/GUI member id (one seat, app-wide). The pipe rejects it
+ *  as a caller identity (a2a.channel.rpc.ts spoof guard); the renderer
+ *  substitutes the localized "Me" at display time. Single source of truth —
+ *  renderer modules and the daemon previously each carried their own copy. */
+export const HUMAN_MEMBER_ID = 'local-ui';
+
 /** Channel name length bounds. `CHANNEL_NAME_MIN` is the empty-length
  *  floor; the regex below requires at least 1 character. */
 export const CHANNEL_NAME_MIN = 1;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -292,6 +292,21 @@ export const HUMAN_WORKSPACE_ID = 'ws-human';
  *  renderer modules and the daemon previously each carried their own copy. */
 export const HUMAN_MEMBER_ID = 'local-ui';
 
+/**
+ * Channels schema epoch — the DAEMON-SIDE migration generation the current
+ * renderer requires. The daemon reports it additively on the
+ * `a2a.channel.list` response; the renderer compares on hydration and shows a
+ * "restart wmux" banner when the value is missing/lower (a long-lived daemon
+ * survives app upgrades by design, so a P5 renderer can find itself attached
+ * to a pre-P5 daemon whose state still holds scattered per-workspace human
+ * rows — posts would fail NOT_A_MEMBER with no explanation; ship review C1).
+ * Bump ONLY when a new daemon load-time channel migration is a prerequisite
+ * for renderer correctness.
+ *
+ * Epoch 1 = P5 unified human identity (ws-human row merge).
+ */
+export const CHANNELS_EPOCH = 1;
+
 /** Channel name length bounds. `CHANNEL_NAME_MIN` is the empty-length
  *  floor; the regex below requires at least 1 character. */
 export const CHANNEL_NAME_MIN = 1;


### PR DESCRIPTION
## 무엇

채널의 사람 정체성을 워크스페이스당 좌석에서 **앱 전역 단일 좌석(가상 워크스페이스 `ws-human`)**으로 통합. 로스터의 "나 · Workspace 2" 꼬리표 소멸, 채널 목록·멤버십·unread가 활성 워크스페이스와 무관하게 동일, join/create가 "열려있던 워크스페이스"를 박는 문제 제거.

## 어떻게

- **데몬 load-time 병합 마이그레이션**: 채널별 흩어진 `(ws-X, local-ui)` 행 → `(ws-human, local-ui, human:me)` 단일 행 (joinedAt=min, historyFromSeq=min, lastReadSeq=max; 매 부팅 결정적·멱등·crash-safe — lastReadSeq backfill과 동일 계약)
- **렌더러 전면 치환**: hydration·poll(union에 ws-human)·join·create·post·ack·leave·kick·viewer·컴포저·unread self-mute 전부 ws-human 기준; 멘션 라우팅은 실workspace 전용(ws-human은 pane이 없음 — 불변식 테스트로 고정)
- **파이프/데몬 가드**: ws-human을 호출자·초대 타겟 어느 쪽으로도 파이프에서 거부(데몬 invite()에서도 거부 — 직결 소켓 우회 차단)
- **Stale-daemon 배너(C1)**: `a2a.channel.list` 응답에 additive `CHANNELS_EPOCH` — 구 데몬에 붙으면 패널에 "완전 종료 후 재시작" 배너, 재시작 후 자가 해제. 자동 데몬 kill 없음(라이브 세션 보유·split-brain 이력 영역)

## 리뷰 — 3모델 패널 (Codex + GLM 5.2 + Claude)

Claude 전문가 4종(테스팅/보안/유지보수성/데이터마이그레이션) + Claude 적대 + **GLM 5.2**(diff 인라인) + **Codex**(exec, reasoning high). 교차 합의 처리:

| 발견 | 합의 | 처리 |
|---|---|---|
| ws-human 초대 예외 → 유령 행 주입 | **5모델** | 라우터+데몬 양쪽 거부 + 테스트 |
| 신 렌더러+구 데몬 스큐 = 채널 전멸 | 3모델 CRITICAL | C1 배너(사용자 결정: 감지+고지, 자동 재기동은 별도 PR 후보) |
| activeWs 표시 분기 = private 유출/팬텀 배지 | Codex+적대 | 분기 제거(휴먼 멤버십 단일 규칙) |
| wake worker ws-human 스윕 = CPU 드리프트 | 적대+데이터MIG | memberWorkspaces에서 제외 |
| max() 커서 병합 unread 삼킴 | Codex vs 적대 불일치 | 유지+엣지 문서화(wake 스윕 제외로 소비자 없음) |
| 직결 파이프 ws-human 사칭 | Codex vs 보안 불일치 | #113 same-user 천장으로 문서화 |
| backfill→merge 순서 미고정 등 테스트 갭 | 테스팅 | pre-v2/혼합세대/불변식 테스트 추가 |

GLM 단독 4건은 검증 결과 환각/기구현으로 기각(교차 검증의 가치).

## 검증

- 전체 스위트 **4854 + 20 + 65 그린**, tsc clean
- GUI 도그푸드: 실 channels.json 3채널 병합, 로스터 "나" 단독, 워크스페이스 전환 무관 동일 뷰, 멘션 배달 회귀 없음 (사용자 확인)
- 다운그레이드: 데이터 무손실(병합 행을 구 데몬이 일반 멤버로 취급), private 접근은 재업그레이드 시 복구 — 릴리스 노트에 명시

## 알려진 잔여(후속)

- 세션 보존 데몬 자동 교체(B′) — 별도 daemon-lifecycle PR 후보
- pre-P5 메시지의 recipientSnapshot 영수증은 과거 워크스페이스 좌표로 남음(표시상 pending 고정, 기능 무해) — P3 영수증 정비에서 처리
- private 에이전트 전용 채널의 인간 모더레이션(P5로 의도적 스코프 축소) — P6에서 재검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CULj3yLZSLcXcHGRPwMqNa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified “human seat” for channels, including load-time consolidation of prior human identities and consistent composer/member/leave/join behavior.
  * Added a “restart wmux” banner when the background service is stale, using a new channels epoch signal.
* **Bug Fixes**
  * Improved unread/mention behavior so agent posts are handled correctly for the open workspace, and private agent-only channels no longer appear in dock unread.
  * Avoided unnecessary wake sweeps by excluding the reserved human workspace.
* **Security**
  * Blocked unauthorized claims, invitations, and targeting of the reserved human seat across both the pipe and daemon layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->