### PR TITLE
fix: wake worker never nudges agent-less shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Channel mention nudges are no longer typed into a plain shell terminal. When a member's agent pane was busy (its real Claude pane owned by the on-screen window), the wake worker could auto-submit its `wmux channel read …` hint into an agent-less shell, where it ran as a stray command; it now stays silent there and leaves delivery to polling.
+
 ## [3.16.0] — 2026-07-05
 
 ### Added

--- a/src/daemon/channels/__tests__/channelWakeWorker.test.ts
+++ b/src/daemon/channels/__tests__/channelWakeWorker.test.ts
@@ -464,6 +464,41 @@ describe('pickTargetWithPrincipal — R2 registry direct targeting', () => {
     expect(pickTargetWithPrincipal(sessions, 'ws-b', 'codex', undefined, undefined)?.id).toBe('b');
   });
 
+  it('a principal DIRECT HIT on an agent-less session falls through to the heuristic (no shell nudge)', () => {
+    // Codex micro-pass on the shell-nudge fix: a registry row's ptyId can
+    // outlive the agent (agent exits, pane keeps its shell, row stays live
+    // until the next upsert/purge). The direct-hit branch must carry the
+    // same agent-required discipline as the fallback.
+    const PID3 = 'pane:ws-b/pY';
+    // Direct hit points at a session with NO detected agent; the only other
+    // pane is also agent-less → null overall.
+    expect(
+      pickTargetWithPrincipal(
+        [session({ id: 'was-agent-now-shell', lastDetectedAgent: undefined })],
+        'ws-b',
+        'w2-1(codex)',
+        PID3,
+        () => 'was-agent-now-shell',
+      ),
+    ).toBeNull();
+    // Direct hit agent-less, but the heuristic SLUG-MATCHES a real agent
+    // pane → the fall-through still delivers. (With an auto-name memberId
+    // the two-pane case stays null — the heuristic never guesses between a
+    // shell and an unmatched agent pane; that ambiguity rule is unchanged.)
+    expect(
+      pickTargetWithPrincipal(
+        [
+          session({ id: 'was-agent-now-shell', lastDetectedAgent: undefined }),
+          session({ id: 'real-agent', lastDetectedAgent: 'codex' }),
+        ],
+        'ws-b',
+        'codex',
+        PID3,
+        () => 'was-agent-now-shell',
+      )?.id,
+    ).toBe('real-agent');
+  });
+
   it('the heuristic fallback carries the same agent-required discipline (no shell nudge)', () => {
     const PID2 = 'pane:ws-b/pX';
     // Stale principal → heuristic fallback; the only pane is an agent-less

--- a/src/daemon/channels/__tests__/channelWakeWorker.test.ts
+++ b/src/daemon/channels/__tests__/channelWakeWorker.test.ts
@@ -285,10 +285,13 @@ describe('pickTarget — never guess', () => {
   });
 
   it('falls back to the ONLY eligible session when no slug matches', () => {
+    // The attached claude is deferred to the renderer, leaving a single
+    // eligible pane 'b'. The fallback target must host an agent to receive
+    // the nudge (a bare shell is excluded — see the agent-less shell test).
     const target = pickTarget(
       [
         session({ id: 'a', lastDetectedAgent: 'claude', attached: true }),
-        session({ id: 'b', lastDetectedAgent: undefined }),
+        session({ id: 'b', lastDetectedAgent: 'codex' }),
       ],
       'ws-b',
       'reviewer',
@@ -333,9 +336,11 @@ describe('pickTarget — never guess', () => {
     const attachedClaude = session({ id: 'a', lastDetectedAgent: 'claude', attached: true });
     const shell = session({ id: 'b', lastDetectedAgent: undefined });
     expect(pickTarget([attachedClaude, shell], 'ws-b', 'claude')).toBeNull();
-    // …while a DIFFERENT member still falls back to that only eligible pane
-    // (it may well be where that agent actually runs, sans detection).
-    expect(pickTarget([attachedClaude, shell], 'ws-b', 'codex')?.id).toBe('b');
+    // …and a DIFFERENT member does NOT fall back to that agent-less shell
+    // either: the single-pane fallback now requires a detected agent, so a
+    // bare shell hands off to polling (null) rather than eating a mis-typed
+    // nudge (2026-07-05 dogfood regression guard).
+    expect(pickTarget([attachedClaude, shell], 'ws-b', 'codex')).toBeNull();
   });
 
   it('never targets a session from another workspace', () => {
@@ -347,13 +352,46 @@ describe('pickTarget — never guess', () => {
     // but renders nothing and the pre-crash agent process is gone. Live
     // dogfood showed the worker burning mention nudges into that void.
     expect(pickTarget([session({ id: 'a', deferred: true })], 'ws-b', 'codex')).toBeNull();
-    // …and a deferred slug-match must not shadow a live fallback either.
+    // …and a deferred slug-match must not shadow a live fallback either. The
+    // live pane 'b' hosts an agent (a bare shell would not be nudged).
     const target = pickTarget(
-      [session({ id: 'a', deferred: true, lastDetectedAgent: 'codex' }), session({ id: 'b', lastDetectedAgent: undefined })],
+      [session({ id: 'a', deferred: true, lastDetectedAgent: 'codex' }), session({ id: 'b', lastDetectedAgent: 'opencode' })],
       'ws-b',
       'codex',
     );
     expect(target?.id).toBe('b');
+  });
+
+  it('never nudges an agent-less shell — the single-pane fallback requires a detected agent (dogfood 2026-07-05)', () => {
+    // Live -dev proof: the member's real claude pane was ATTACHED (deferred to
+    // the renderer Stop-hook path), leaving a bare zsh (lastDetectedAgent none)
+    // as the lone "eligible" pane. The old fallback auto-submitted
+    // `wmux channel read ch-… --since N` into that shell, which ran the pasted
+    // hint as a command. A shell with no agent is never a wake target.
+    expect(
+      pickTarget(
+        [
+          session({ id: 'shell', lastDetectedAgent: undefined }),
+          session({ id: 'claude', lastDetectedAgent: 'claude', attached: true }),
+        ],
+        'ws-b',
+        'reviewer',
+      ),
+    ).toBeNull();
+  });
+
+  it('an agent-less shell as the ONLY live pane hands off to polling (null), never a shell nudge', () => {
+    expect(pickTarget([session({ id: 'shell', lastDetectedAgent: undefined })], 'ws-b', 'codex')).toBeNull();
+    // An empty-string agent counts as no agent too (truthy guard).
+    expect(pickTarget([session({ id: 'shell', lastDetectedAgent: '' })], 'ws-b', 'codex')).toBeNull();
+  });
+
+  it('the single-pane fallback still fires when that pane hosts an agent (detached claude or a non-matching slug)', () => {
+    // Detached claude — headless, the worker is the only delivery path.
+    expect(pickTarget([session({ id: 'a', lastDetectedAgent: 'claude' })], 'ws-b', 'reviewer')?.id).toBe('a');
+    // A different agent slug than the member id still gets the fallback: it is
+    // a real agent pane, just not slug-matched.
+    expect(pickTarget([session({ id: 'a', lastDetectedAgent: 'opencode' })], 'ws-b', 'reviewer')?.id).toBe('a');
   });
 });
 
@@ -376,13 +414,14 @@ describe('pickTargetWithPrincipal — R2 registry direct targeting', () => {
 
   it('a stale principal (undefined ptyId) falls back to the existing heuristic', () => {
     const target = pickTargetWithPrincipal(
-      [session({ id: 'only', lastDetectedAgent: undefined })],
+      [session({ id: 'only', lastDetectedAgent: 'codex' })],
       'ws-b',
       'w2-1(codex)',
       PID,
       () => undefined,
     );
-    // Fallback rule 3: the only eligible session.
+    // Fallback rule 3: the only eligible agent session (a bare shell would
+    // hand off to polling — see the agent-required fallback test).
     expect(target?.id).toBe('only');
   });
 
@@ -423,6 +462,31 @@ describe('pickTargetWithPrincipal — R2 registry direct targeting', () => {
   it('behaves identically to the existing pickTarget when principalId/lookup fn are absent', () => {
     const sessions = [session({ id: 'b', lastDetectedAgent: 'codex' })];
     expect(pickTargetWithPrincipal(sessions, 'ws-b', 'codex', undefined, undefined)?.id).toBe('b');
+  });
+
+  it('the heuristic fallback carries the same agent-required discipline (no shell nudge)', () => {
+    const PID2 = 'pane:ws-b/pX';
+    // Stale principal → heuristic fallback; the only pane is an agent-less
+    // shell → null (never auto-submit into a bare shell).
+    expect(
+      pickTargetWithPrincipal(
+        [session({ id: 'shell', lastDetectedAgent: undefined })],
+        'ws-b',
+        'w2-1(codex)',
+        PID2,
+        () => undefined,
+      ),
+    ).toBeNull();
+    // …but a lone AGENT pane still gets the fallback nudge.
+    expect(
+      pickTargetWithPrincipal(
+        [session({ id: 'agent', lastDetectedAgent: 'codex' })],
+        'ws-b',
+        'w2-1(codex)',
+        PID2,
+        () => undefined,
+      )?.id,
+    ).toBe('agent');
   });
 });
 

--- a/src/daemon/channels/channelWakeWorker.ts
+++ b/src/daemon/channels/channelWakeWorker.ts
@@ -347,8 +347,10 @@ export class ChannelWakeWorker {
  *     eligible like any agent (headless has no other delivery path —
  *     Codex round-3);
  *  2. eligible session whose detected agent slug === memberId;
- *  3. else the ONLY eligible session in the workspace;
- *  4. else null (multi-pane ambiguity falls back to polling).
+ *  3. else the ONLY eligible session in the workspace — but ONLY when it
+ *     actually hosts a detected agent; a bare shell is never nudged
+ *     (2026-07-05 dogfood, see the guard below);
+ *  4. else null (multi-pane ambiguity / agent-less shell falls back to polling).
  */
 /**
  * R2 — direct principal targeting. When the member row has a principalId and
@@ -405,6 +407,15 @@ export function pickTarget(
     (s) => s.lastDetectedAgent === memberId && s.lastDetectedAgent === 'claude' && s.attached === true,
   );
   if (ownedByRenderer) return null;
-  if (eligible.length === 1) return eligible[0];
+  // Single-pane fallback — but ONLY if that pane actually hosts an agent to
+  // receive the nudge. A bare shell with no detected agent (lastDetectedAgent
+  // undefined/empty) is NOT a wake target: live -dev dogfood 2026-07-05 caught
+  // the worker auto-submitting `wmux channel read ch-… --since N` into an
+  // agent-less zsh — the member's real Claude pane was ATTACHED, so it deferred
+  // to the renderer Stop-hook path and left the shell as the lone "eligible"
+  // pane; the pasted hint (text + Enter) then ran as a shell command. If the
+  // only eligible pane is such a shell, hand off to polling (null) — the same
+  // philosophy as the budget-exhausted human handoff, never a guess.
+  if (eligible.length === 1 && Boolean(eligible[0].lastDetectedAgent)) return eligible[0];
   return null;
 }

--- a/src/daemon/channels/channelWakeWorker.ts
+++ b/src/daemon/channels/channelWakeWorker.ts
@@ -129,6 +129,11 @@ interface NudgeTrackerEntry {
   plainNudgedAtSeq: number;
   /** Epoch ms of the last exhaustion announcement (0 = never). */
   lastExhaustedAnnounceAt: number;
+  /** Last time we LOGGED that no eligible agent pane exists for this key —
+   *  the null-target hold would otherwise be fully silent (no nudge, no
+   *  budget spend, no exhaustion handoff), which is exactly the invisible
+   *  infinite-hold class the delivery audit flagged. Log-only, slow cadence. */
+  lastNoTargetAnnounceAt: number;
 }
 
 const keyOf = (ws: string, e: { channelId: string; memberId: string }): string =>
@@ -141,6 +146,7 @@ const freshTrackerState = (): NudgeTrackerEntry => ({
   lastMentionNudgeAt: 0,
   plainNudgedAtSeq: -1,
   lastExhaustedAnnounceAt: 0,
+  lastNoTargetAnnounceAt: 0,
 });
 
 const sanitizeLine = (s: string): string =>
@@ -287,7 +293,23 @@ export class ChannelWakeWorker {
           entry.principalId,
           this.deps.livePtyIdOf?.bind(this.deps),
         );
-        if (!target) continue; // ambiguity / no live pane / claude-only → polling fallback
+        if (!target) {
+          // Ambiguity / no live pane / claude-only / agent-less shells →
+          // polling fallback. Surface the silent hold on a slow cadence so a
+          // member that can never be targeted (e.g. its agent exited and only
+          // bare shells remain) is visible in the log instead of stalling
+          // invisibly with zero budget spend (Codex micro-pass, 2026-07-05).
+          const never = state.lastNoTargetAnnounceAt === 0;
+          if (never || this.deps.now() - state.lastNoTargetAnnounceAt >= EXHAUSTED_REANNOUNCE_MS) {
+            state.lastNoTargetAnnounceAt = this.deps.now();
+            this.tracker.set(key, state);
+            this.deps.log(
+              'info',
+              `[wake] no eligible agent pane for ${key} (${entry.unread} unread) — holding for detection/poll`,
+            );
+          }
+          continue;
+        }
         if (this.deps.now() - target.lastActivityMs < WAKE_QUIET_MS) continue; // busy — retry next tick
 
         // A failed write must not burn the nudge budget (G5 spirit: never
@@ -379,9 +401,17 @@ export function pickTargetWithPrincipal(
       const s = sessions.find((x) => x.id === ptyId && x.deferred !== true);
       if (s && s.workspaceId === workspaceId) {
         if (s.lastDetectedAgent === 'claude' && s.attached === true) return null;
-        return s;
+        // Same agent-required discipline as the heuristic fallback (Codex
+        // micro-pass on the 2026-07-05 shell-nudge fix): a registry row's
+        // ptyId can outlive the agent — the agent exits, the pane keeps its
+        // shell, the row stays live until the next upsert/purge. A direct
+        // hit on a session with NO detected agent must not auto-submit into
+        // that bare shell; fall through to the heuristic (which now refuses
+        // agent-less panes too).
+        if (s.lastDetectedAgent) return s;
       }
-      // Session gone / workspace mismatch → heuristic fallback (never guess).
+      // Session gone / workspace mismatch / agent-less pane → heuristic
+      // fallback (never guess).
     }
   }
   return pickTarget(sessions, workspaceId, memberId);


### PR DESCRIPTION
## Summary

Live dogfood (2026-07-05 evening, -dev instance) caught the channel wake worker auto-submitting mention nudges into a **bare zsh shell**: the tagged member's real Claude pane was ATTACHED, so `pickTarget` deferred it to the renderer Stop-hook path — and the single-pane fallback (`eligible.length === 1`) then grabbed the only remaining pane in the workspace, an agent-less shell, and typed `wmux channel read ch-… --since N` + Enter into it (8 nudges logged to `daemon-bfed8e17`, nudge text present in that pane's buffer; the real agent pane got zero).

**Fix (two commits):**
1. `pickTarget`'s single-pane fallback requires a detected agent; an agent-less shell hands off to polling (null) — same philosophy as the budget-exhausted human handoff, never a guess. Scoped to the fallback line so the multi-pane never-guess ambiguity rule is unchanged.
2. Micro-pass hardening: the principal DIRECT-HIT branch carried the same bypass (a registry row's ptyId can outlive its agent — agent exits, pane keeps the shell, row stays live until the next upsert/purge); it now requires a detected agent and falls through to the heuristic. And a null target — which spends no budget and never reaches the exhaustion handoff — is now logged once per (channel, member) on the slow re-announce cadence, so silent infinite holds are visible.

**Why the user saw "message not delivered":** four overlapping causes were identified in the live investigation; this PR fixes the one real daemon bug. The rest, for the record: renderer delivery has a designed unknown-status grace (≤45s) after restart; agents deliberately do NOT reply to greeting-only mentions (the P2 anti-loop reply gate — test with a question/task, not "hi"); and `deliveryStatus`/`recipientSnapshot` are not updated by the renderer paste path (known P3 receipts debt), so the data reads "pending" even after delivery.

Corrected 4 legacy tests that had pinned the shell-nudge defect as green (verified each old assertion was the defect, not intended behavior — e.g. the exact `[attached claude, shell] → shell` case reproduced live today).

## Review
Root cause verified live by Fable (daemon logs + pane buffer forensics + code trace), fix implemented by Opus per ledger spec, then Codex micro-pass (caught the direct-hit bypass, fixed in commit 2) — findings log in `.workflow/LEDGER.md` 5차.

## Test plan
- [x] channelWakeWorker suite: 31 passed (26 existing-corrected + 5 new: shell+attached-claude → null, shell-only → null incl. empty-string agent, single agent pane still nudged, principal-heuristic discipline, direct-hit fall-through)
- [x] Full suite 4862 pass, tsc daemon+main clean, no version bump (release-tag convention)
- [ ] Dogfood: restart the -dev app, tag the attached-claude member with a QUESTION — the plain shell must receive nothing; the log should show either a renderer delivery or `[wake] no eligible agent pane` instead of shell nudges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CULj3yLZSLcXcHGRPwMqNa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented channel mention nudges from being delivered as stray shell commands when the referenced member’s agent pane is busy.
  * Tightened wake-target selection so agent-less panes are never selected; eligible delivery now waits for suitable detectable agent panes.
  * When unread activity exists but no eligible agent pane is available, the worker now tracks and periodically logs these occurrences rather than stalling silently.

* **Tests**
  * Expanded regression coverage for wake-target selection, including deferred/detached session edge cases and principal-based fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->