### PR TITLE
chore(release): v3.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.17.0] — 2026-07-06
+
 ### Added
 
 - **wmux now updates its own background daemon — no manual restart.** When an upgraded app reconnects to a daemon left running by an older version, it replaces it automatically: the old daemon suspends every session durably (scrollback, running commands, agent conversations), a current-version daemon starts, and your panes restore themselves — scrollback replayed, supervised commands relaunched, agents resumed. Same session preservation as a full quit-and-restart, without the quit. A brief "Updating the background daemon" toast explains the pause. The 3.16.0 stale-daemon banner remains as the fallback for the cases the replacement deliberately refuses (a NEWER daemon is never downgraded; a daemon that won't shut down cleanly is left running rather than force-killed pre-save).

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.16.0 sources.** This file is produced by
+> **Generated from wmux v3.17.0 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.16.0",
+  "version": "3.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.16.0",
+      "version": "3.17.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.16.0",
+  "version": "3.17.0",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Release v3.17.0 — bundles the two channel PRs merged today plus the already-landed B′ daemon auto-replace work.

## Included since v3.16.0
- **Daemon auto-replace (B′)** — wmux replaces an older background daemon on reconnect, durably suspending and restoring sessions (landed via #342).
- **Server-owned roster identity (#343)** — daemon-derived channel names, boot-time invite/@-mention candidates, single-seat convergence, unique `$WMUX_MEMBER_ID` per pane.
- **Wake-worker shell guard (#344)** — mention nudges never get typed into an agent-less shell.

## Release mechanics
- `package.json` / `package-lock.json` bumped 3.16.0 → 3.17.0.
- CHANGELOG `[Unreleased]` promoted to `[3.17.0] — 2026-07-06`.
- `docs/api/reference.md` regenerated (version header baked; satisfies the CI drift guard).

Tag `v3.17.0` will be pushed after this merges to trigger the installer/release automation.