### PR TITLE
feat(eventlog): PR1 — 로그 프리미티브 (envelope §10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **이벤트 로그 프리미티브 (envelope PR1).** append-only 세그먼트 NDJSON 로그(`daemon/eventlog/AppendOnlyLog`)와 공통 이벤트 봉투 스키마(`shared/eventlog` — PROTOCOL, additive-only)를 도입 — 채널·A2A 정본을 크래시-안전 로그로 옮기는 §6.L 재배선의 기반. fsync 코얼레싱(그룹 커밋), 배치 단위 롤백(단일 ftruncate), 부트 전방 스캔 복구(최초 불량 절단·부분 승격 금지), lamport/seq 고수위 재개(재사용 금지·gap 허용), 절단 실패 시 fail-stop(조용한 좌표 발산으로 커밋 데이터를 잃지 않음). `machine-id` 민팅·복구와 atomicWrite `durable` 옵션(fsync 시퀀스) 포함. 아직 어떤 서비스도 배선되지 않음(재배선은 후속 PR).
+
 ## [3.17.0] — 2026-07-06
 
 ### Added

--- a/src/daemon/eventlog/AppendOnlyLog.ts
+++ b/src/daemon/eventlog/AppendOnlyLog.ts
@@ -8,7 +8,7 @@
  *     부트 재개값이 max일 때 첫 신규값이 정확히 max+1(오프바이원 없음).
  *   - fsync 코얼레싱(그룹커밋, §2.5): in-flight 배리어 동안 도착분은 다음 배리어로
  *     배치. 성공·실패의 단위가 모두 배치다.
- *   - 배치 단일 롤백(§2.4-4): write/fsync 실패 시 ftruncate(committedOffset) **1회**로
+ *   - 배치 단일 롤백(§2.4-4): write/fsync 실패 시 truncate(committedOffset) **1회**로(경로 기반)
  *     미커밋 전량 물리 제거 + 배치 Promise 전원 false. 순서의존 null 매장 불가.
  *   - 부트 전방 스캔·최초 불량 절단(§2.6): 활성 세그먼트를 앞에서부터 검증, 최초
  *     불량 줄에서 절단. 커밋 프리픽스는 완전·연속 보장. 남은 valid tail은 at-least-once로
@@ -289,7 +289,7 @@ export class AppendOnlyLog {
     }
 
     if (!ok) {
-      this.rollbackBatch(); // §2.4-4 단일 ftruncate + 전원 false
+      this.rollbackBatch(); // §2.4-4 단일 truncate + 전원 false
       this.fsyncInFlight = false;
       this.maybeStartFsync();
       return;
@@ -307,14 +307,26 @@ export class AppendOnlyLog {
   }
 
   /**
-   * §2.4-4 배치 단일 롤백. ftruncate(committedOffset) **한 번**으로 미커밋 전량
+   * §2.4-4 배치 단일 롤백. truncate(committedOffset) **한 번**으로 미커밋 전량
    * (배리어 + 그 뒤 대기분)을 물리 제거하고 전원 false. hwm은 되돌리지 않는다
    * (§3 함정: gap 허용, 재사용 금지).
+   *
+   * 절단은 **경로 기반 close→truncate→reopen**이다: Windows에서 'a'(append)
+   * 모드 fd는 ftruncate가 EPERM으로 실패한다(append-only 핸들엔 SetEndOfFile
+   * 권한이 없음 — CI windows 레인 실증). 이 시퀀스는 append 임계구역(동기)
+   * 안에서 완결되므로 원자성은 유지된다.
    */
   private rollbackBatch(): void {
     this.rollbackEpoch++;
     try {
-      fs.ftruncateSync(this.fd, this.committedOffset);
+      try {
+        fs.closeSync(this.fd);
+      } catch {
+        /* noop — 이미 닫혔어도 경로 truncate는 진행 */
+      }
+      this.fd = -1;
+      fs.truncateSync(this.activeSegPath, this.committedOffset);
+      this.fd = fs.openSync(this.activeSegPath, 'a');
       this.currentOffset = this.committedOffset;
     } catch {
       // 절단 실패를 삼키고 계속 쓰면 committedOffset과 물리 EOF가 발산해, 이후

--- a/src/daemon/eventlog/AppendOnlyLog.ts
+++ b/src/daemon/eventlog/AppendOnlyLog.ts
@@ -20,6 +20,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { randomUUID } from 'node:crypto';
 
 import type { EventEnvelope, EventEnvelopeDraft } from '../../shared/eventlog';
 
@@ -85,6 +86,11 @@ export class AppendOnlyLog {
   // 이미 false 처리된 배리어를 이중 resolve/커밋하지 않도록 가드.
   private rollbackEpoch = 0;
   private opened = false;
+  // fail-stop 마커(3모델 패널): 롤백 ftruncate 실패 = "committedOffset == 물리
+  // EOF" 좌표 불변식 붕괴. 이 상태로 계속 쓰면 이후 true 커밋이 불량 tail 뒤에
+  // 붙어 다음 복구·롤백이 커밋 레코드를 관통 절단한다(조용한 acked 데이터 손실).
+  // → 이후 append는 전부 즉시 false. 재개는 reopen(새 인스턴스 open)으로만.
+  private broken = false;
 
   constructor(options: AppendOnlyLogOptions) {
     this.dir = options.dir;
@@ -140,7 +146,10 @@ export class AppendOnlyLog {
     this.activeSegPath = this.segPath(activeNum);
 
     const scan = this.forwardScanFile(this.activeSegPath);
-    this.truncateFile(this.activeSegPath, scan.validEnd);
+    // §2.6 절단은 best-effort가 아니다(3모델 패널): 불량 tail이 남은 파일 위에
+    // 'a' 모드로 열면 이후 커밋이 tail 뒤에 붙고, 다음 부트 스캔이 tail에서
+    // 멈춰 그 커밋들을 폐기한다(acked 유실). 실패 = open 실패.
+    this.truncateFileStrict(this.activeSegPath, scan.validEnd);
 
     if (scan.records.length > 0) {
       this.hwmLamport = scan.maxLamport;
@@ -177,6 +186,11 @@ export class AppendOnlyLog {
       );
     }
     return new Promise<boolean>((resolve) => {
+      // fail-stop 상태(좌표 불변식 붕괴)에선 어떤 write도 안전하지 않다 — 즉시 false.
+      if (this.broken) {
+        resolve(false);
+        return;
+      }
       try {
         this.rollIfNeeded();
 
@@ -184,8 +198,12 @@ export class AppendOnlyLog {
         // 불필요한 gap을 피한다(재사용 금지 불변식은 어느 경로든 유지).
         const lamport = this.hwmLamport + 1;
         const seq = this.hwmSeq + 1;
+        // §1 "@ append": eventId·wallClock도 여기서 발급 — draft를 재시도로
+        // 재사용해도 커밋 레코드마다 eventId가 신규라 전역 유일성이 유지된다.
         const full: EventEnvelope = {
           ...draft,
+          eventId: randomUUID(),
+          wallClock: Date.now(),
           lamport,
           origin: { ...draft.origin, seq },
         };
@@ -217,8 +235,17 @@ export class AppendOnlyLog {
     return out;
   }
 
-  /** fd 닫기. PR1 테스트는 append를 await하므로 unsynced는 통상 비어있다. */
+  /**
+   * fd 닫기. 미확정(unsynced) append는 **전원 false로 확정**한다 — resolve(true)만이
+   * 내구 보장이라는 계약의 종료면이며, pending promise가 영구 미해결로 새지 않는다
+   * (패널 C2). 디스크에 남은 미fsync 줄은 다음 open의 valid-tail 승격(§2.6
+   * at-least-once)으로 흡수될 수 있다. flush-후-close(graceful shutdown)는 서비스
+   * 배선(PR3, §6.4b) 소관. in-flight 배리어는 epoch 가드로 무효화된다.
+   */
   close(): void {
+    this.rollbackEpoch++;
+    const pending = this.unsynced.splice(0, this.unsynced.length);
+    for (const rec of pending) rec.resolve(false);
     if (this.fd >= 0) {
       try {
         fs.closeSync(this.fd);
@@ -233,7 +260,7 @@ export class AppendOnlyLog {
   // ── 내부: fsync 코얼레싱 ────────────────────────────────────────────
 
   private maybeStartFsync(): void {
-    if (this.fsyncInFlight || this.unsynced.length === 0) return;
+    if (this.broken || this.fsyncInFlight || this.unsynced.length === 0) return;
     this.fsyncInFlight = true;
     // 마이크로태스크로 지연해 동기 버스트(같은 tick의 다수 append)를 한 배리어로
     // 코얼레싱한다(§2.5). 이후 tick 도착분은 in-flight 배리어의 다음으로 배치.
@@ -273,6 +300,9 @@ export class AppendOnlyLog {
     const done = this.unsynced.splice(0, barrierCount);
     for (const rec of done) rec.resolve(true);
     this.fsyncInFlight = false;
+    // §2.8 롤 기아 방지(패널 X3): 배리어 성공 직후도 배치 경계다 — append 시점에
+    // unsynced가 영영 안 비는 지속 부하에서도 여기서 롤이 성사된다.
+    if (this.unsynced.length === 0) this.rollIfNeeded();
     this.maybeStartFsync();
   }
 
@@ -285,10 +315,14 @@ export class AppendOnlyLog {
     this.rollbackEpoch++;
     try {
       fs.ftruncateSync(this.fd, this.committedOffset);
+      this.currentOffset = this.committedOffset;
     } catch {
-      // 절단 실패는 at-least-once로 흡수(§2.6-c) — false 계약은 유지.
+      // 절단 실패를 삼키고 계속 쓰면 committedOffset과 물리 EOF가 발산해, 이후
+      // true 커밋이 불량 tail 뒤에 붙고 다음 롤백/부트가 그 커밋을 관통 절단한다
+      // (3모델 패널 합의 — §2.6-c의 재부트 승격 계약은 이 in-process desync를
+      // 커버하지 않는다). → fail-stop. 이미 쓰인 tail은 다음 open의 스캔이 처리.
+      this.broken = true;
     }
-    this.currentOffset = this.committedOffset;
     const failed = this.unsynced.splice(0, this.unsynced.length);
     for (const rec of failed) rec.resolve(false);
   }
@@ -297,17 +331,30 @@ export class AppendOnlyLog {
 
   private rollIfNeeded(): void {
     // §2.8: 롤은 배치 경계(unsynced 비었을 때)에서만 — batchStartOffset이 항상
-    // 단일 파일 좌표이도록. 배치가 미결이면 현 세그먼트에 계속 쓰고 다음 배치에서 롤.
+    // 단일 파일 좌표이도록. 배치가 미결이면 현 세그먼트에 계속 쓰고 다음 경계에서 롤
+    // (append 시점 + 배리어 성공 직후 양쪽에서 시도 — 지속 부하 기아 방지).
+    if (this.broken) return;
     if (this.unsynced.length > 0) return;
     if (this.currentOffset <= this.maxSegmentBytes) return;
+    // open-then-swap(패널 C6): 새 세그먼트 개방이 성공한 뒤에만 상태를 전환한다.
+    // 실패하면 현 세그먼트를 그대로 계속 사용(상태 불변, 다음 경계에서 재시도) —
+    // 구 fd를 먼저 닫으면 개방 실패 시 fd 없는 반쪽 상태가 남는다.
+    const nextNum = this.activeSegNum + 1;
+    const nextPath = this.segPath(nextNum);
+    let nextFd: number;
+    try {
+      nextFd = this.createSegment(nextPath);
+    } catch {
+      return;
+    }
     try {
       fs.closeSync(this.fd);
     } catch {
       /* noop */
     }
-    this.activeSegNum += 1;
-    this.activeSegPath = this.segPath(this.activeSegNum);
-    this.fd = this.createSegment(this.activeSegPath);
+    this.fd = nextFd;
+    this.activeSegNum = nextNum;
+    this.activeSegPath = nextPath;
     this.committedOffset = 0;
     this.currentOffset = 0;
   }
@@ -402,13 +449,17 @@ export class AppendOnlyLog {
         break;
       }
       const rec = parsed as EventEnvelope;
-      if (typeof rec.lamport === 'number' && rec.lamport > maxLamport) {
-        maxLamport = rec.lamport;
+      // 최소 스키마 가드(패널 C5): 발급 필드가 없는 줄({} 등 비-envelope JSON)은
+      // 최초 불량으로 절단 — hwm·replay에 정체불명 레코드가 승격되지 않게.
+      if (
+        typeof rec.lamport !== 'number' ||
+        typeof rec.eventId !== 'string' ||
+        typeof rec.origin?.seq !== 'number'
+      ) {
+        break;
       }
-      const seq = rec.origin?.seq;
-      if (typeof seq === 'number' && seq > maxSeq) {
-        maxSeq = seq;
-      }
+      if (rec.lamport > maxLamport) maxLamport = rec.lamport;
+      if (rec.origin.seq > maxSeq) maxSeq = rec.origin.seq;
       records.push(rec);
       validEnd = nl + 1;
       offset = nl + 1;
@@ -417,13 +468,20 @@ export class AppendOnlyLog {
     return { validEnd, maxLamport, maxSeq, records };
   }
 
-  private truncateFile(filePath: string, size: number): void {
-    try {
-      if (fs.statSync(filePath).size > size) {
-        fs.truncateSync(filePath, size);
-      }
-    } catch {
-      // best-effort
+  /**
+   * §2.6 부트 복구 절단 — **검증형**(best-effort 금지, 3모델 패널). 절단이
+   * 실패하면 "커밋 프리픽스 = 파일 전체" 불변식을 수립할 수 없으므로 open을
+   * 실패시킨다(불량 tail 위에 열어 이후 커밋을 유실시키는 것보다 낫다).
+   */
+  private truncateFileStrict(filePath: string, size: number): void {
+    if (fs.statSync(filePath).size > size) {
+      fs.truncateSync(filePath, size);
+    }
+    const after = fs.statSync(filePath).size;
+    if (after !== size) {
+      throw new Error(
+        `AppendOnlyLog.open: 복구 절단 실패 — ${filePath} 크기 ${after} != validEnd ${size}`,
+      );
     }
   }
 }

--- a/src/daemon/eventlog/AppendOnlyLog.ts
+++ b/src/daemon/eventlog/AppendOnlyLog.ts
@@ -1,0 +1,429 @@
+/**
+ * AppendOnlyLog — 세그먼트드 NDJSON append-only writer (envelope-design §2·§3).
+ *
+ * 계약 요약(스펙 문면):
+ *   - append(): Promise<boolean> — resolve(true) = fsync 배리어로 내구화됨(커밋).
+ *     resolve(false) = 배치 롤백됨(미커밋). throw하지 않는다(§2.4-5 D16).
+ *   - lamport/origin.seq는 append 임계구역 안에서만 발급(pre-increment, §3).
+ *     부트 재개값이 max일 때 첫 신규값이 정확히 max+1(오프바이원 없음).
+ *   - fsync 코얼레싱(그룹커밋, §2.5): in-flight 배리어 동안 도착분은 다음 배리어로
+ *     배치. 성공·실패의 단위가 모두 배치다.
+ *   - 배치 단일 롤백(§2.4-4): write/fsync 실패 시 ftruncate(committedOffset) **1회**로
+ *     미커밋 전량 물리 제거 + 배치 Promise 전원 false. 순서의존 null 매장 불가.
+ *   - 부트 전방 스캔·최초 불량 절단(§2.6): 활성 세그먼트를 앞에서부터 검증, 최초
+ *     불량 줄에서 절단. 커밋 프리픽스는 완전·연속 보장. 남은 valid tail은 at-least-once로
+ *     승격될 수 있다(계약, 결함 아님 — §2.6 D17).
+ *
+ * PR1 범위: 순수 라이브러리. manifest·스냅샷·마이그레이션은 PR2 소관 — 미참조.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+import type { EventEnvelope, EventEnvelopeDraft } from '../../shared/eventlog';
+
+/** §2.8: 4MB 세그먼트 롤. */
+const DEFAULT_MAX_SEGMENT_BYTES = 4 * 1024 * 1024;
+const SEGMENT_RE = /^(\d{8})\.ndjson$/;
+const NEWLINE = 0x0a; // '\n'
+
+export interface AppendOnlyLogOptions {
+  /** events 디렉토리 경로. */
+  dir: string;
+  /**
+   * 배치 배리어 fsync. 기본은 비동기 fs.fsync(코얼레싱 창 확보). 테스트는
+   * throw 주입으로 §2.4-4 배치 롤백을 계약 고정한다(의존성 주입).
+   */
+  fsync?: (fd: number) => void | Promise<void>;
+  /** 롤 임계(기본 4MB). 테스트가 작은 값으로 롤을 강제. */
+  maxSegmentBytes?: number;
+}
+
+interface PendingRecord {
+  resolve: (ok: boolean) => void;
+}
+
+interface ScanResult {
+  /** 최초 불량 직전까지의 유효 바이트 길이(절단 오프셋). */
+  validEnd: number;
+  maxLamport: number;
+  maxSeq: number;
+  records: EventEnvelope[];
+}
+
+/**
+ * prototype-pollution 가드 reviver. atomicWrite core.ts:99-104의 가드를 로그 줄
+ * 파싱에 그대로 적용(§2.2). payload가 opaque이므로 신뢰 경계에서 필수.
+ */
+function stripProtoReviver(key: string, value: unknown): unknown {
+  if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+    return undefined;
+  }
+  return value;
+}
+
+export class AppendOnlyLog {
+  private readonly dir: string;
+  private readonly fsyncFd: (fd: number) => void | Promise<void>;
+  private readonly maxSegmentBytes: number;
+
+  private fd = -1;
+  private activeSegNum = 0;
+  private activeSegPath = '';
+
+  // §3: hwm = 마지막 사용값(max). 발급은 pre-increment(hwm+1), write 성공 시 확정.
+  private hwmLamport = 0;
+  private hwmSeq = 0;
+
+  // §2.4: committedOffset = 마지막 성공 fsync 배리어 오프셋(= 롤백 시 단일 ftruncate 지점).
+  private committedOffset = 0;
+  private currentOffset = 0;
+  private readonly unsynced: PendingRecord[] = [];
+  private fsyncInFlight = false;
+  // 롤백 세대 카운터: in-flight fsync 도중 롤백이 끼면 그 fsync 완료 콜백이
+  // 이미 false 처리된 배리어를 이중 resolve/커밋하지 않도록 가드.
+  private rollbackEpoch = 0;
+  private opened = false;
+
+  constructor(options: AppendOnlyLogOptions) {
+    this.dir = options.dir;
+    this.maxSegmentBytes = options.maxSegmentBytes ?? DEFAULT_MAX_SEGMENT_BYTES;
+    this.fsyncFd =
+      options.fsync ??
+      ((fd) =>
+        new Promise<void>((resolve, reject) => {
+          fs.fsync(fd, (err) => (err ? reject(err) : resolve()));
+        }));
+  }
+
+  /** §3: 재개된 lamport hwm(마지막 사용값). 첫 신규 append = 이 값 + 1. */
+  get lamportHwm(): number {
+    return this.hwmLamport;
+  }
+
+  /** §3: 재개된 origin.seq hwm(마지막 사용값). */
+  get seqHwm(): number {
+    return this.hwmSeq;
+  }
+
+  /** 현재 활성 세그먼트 경로(테스트 관측용). */
+  get activeSegment(): string {
+    return this.activeSegPath;
+  }
+
+  /**
+   * 부트 복구 (§2.6·§3·§2.8). 세그먼트 스캔 → 활성 세그먼트 전방 검증·절단 →
+   * hwm 복원. 롤 직후 크래시(빈 활성 세그먼트)는 first-boot로 오인하지 않고
+   * 직전 비어있지-않은 세그먼트에서 hwm을 복원한다.
+   */
+  open(): void {
+    if (this.opened) return;
+    fs.mkdirSync(this.dir, { recursive: true });
+
+    const segments = this.listSegments();
+
+    // §3-2: first-boot 판별 = 세그먼트 0개일 때만. 첫 세그먼트 생성, hwm=0.
+    if (segments.length === 0) {
+      this.activeSegNum = 1;
+      this.activeSegPath = this.segPath(1);
+      this.fd = this.createSegment(this.activeSegPath);
+      this.committedOffset = 0;
+      this.currentOffset = 0;
+      this.opened = true;
+      return;
+    }
+
+    // 활성 = 최고번호 세그먼트. §2.6 전방 스캔 + 최초 불량 절단.
+    const activeNum = segments[segments.length - 1];
+    this.activeSegNum = activeNum;
+    this.activeSegPath = this.segPath(activeNum);
+
+    const scan = this.forwardScanFile(this.activeSegPath);
+    this.truncateFile(this.activeSegPath, scan.validEnd);
+
+    if (scan.records.length > 0) {
+      this.hwmLamport = scan.maxLamport;
+      this.hwmSeq = scan.maxSeq;
+    } else {
+      // §3-3: 활성 세그먼트가 빔(롤 직후 크래시) → 직전 비어있지-않은 세그먼트로
+      // 내려가 hwm 복원. lamport 단조라 최신 비어있지-않은 세그먼트가 최고값.
+      for (let i = segments.length - 2; i >= 0; i--) {
+        const prev = this.forwardScanFile(this.segPath(segments[i]));
+        if (prev.records.length > 0) {
+          this.hwmLamport = prev.maxLamport;
+          this.hwmSeq = prev.maxSeq;
+          break;
+        }
+      }
+    }
+
+    // 활성 세그먼트를 append('a') 모드로 개방. 'a'는 매 write가 EOF에 쓰므로
+    // ftruncate 후에도 항상 유효 말미에 append된다(오프셋 관리 불필요).
+    this.fd = fs.openSync(this.activeSegPath, 'a');
+    this.committedOffset = scan.validEnd;
+    this.currentOffset = scan.validEnd;
+    this.opened = true;
+  }
+
+  /**
+   * 레코드 1건 append (§2.4). 동기 쓰기 임계구역(await 없음 → Node 단일스레드가
+   * 뮤텍스)에서 lamport/seq 발급 + write하고, 커버 fsync 배리어 완료 시 resolve.
+   */
+  append(draft: EventEnvelopeDraft): Promise<boolean> {
+    if (!this.opened) {
+      return Promise.reject(
+        new Error('AppendOnlyLog.append: open() must be called first'),
+      );
+    }
+    return new Promise<boolean>((resolve) => {
+      try {
+        this.rollIfNeeded();
+
+        // §3: pre-increment 발급. write 성공 후에만 hwm을 확정해 write-실패로 인한
+        // 불필요한 gap을 피한다(재사용 금지 불변식은 어느 경로든 유지).
+        const lamport = this.hwmLamport + 1;
+        const seq = this.hwmSeq + 1;
+        const full: EventEnvelope = {
+          ...draft,
+          lamport,
+          origin: { ...draft.origin, seq },
+        };
+        const buf = Buffer.from(`${JSON.stringify(full)}\n`, 'utf8');
+
+        this.writeFully(buf); // §2.4-2 short-write 루프
+
+        this.hwmLamport = lamport;
+        this.hwmSeq = seq;
+        this.currentOffset += buf.length;
+        this.unsynced.push({ resolve });
+      } catch {
+        // §2.4: write 에러(ENOSPC/EIO)도 배치 단일 롤백 경로로.
+        this.rollbackBatch();
+        resolve(false);
+        return;
+      }
+      this.maybeStartFsync();
+    });
+  }
+
+  /** 현 디스크 상태(복구 절단 반영)의 커밋 레코드를 순서대로 반환. replay/테스트용. */
+  readAllRecords(): EventEnvelope[] {
+    const out: EventEnvelope[] = [];
+    for (const n of this.listSegments()) {
+      const scan = this.forwardScanFile(this.segPath(n));
+      for (const rec of scan.records) out.push(rec);
+    }
+    return out;
+  }
+
+  /** fd 닫기. PR1 테스트는 append를 await하므로 unsynced는 통상 비어있다. */
+  close(): void {
+    if (this.fd >= 0) {
+      try {
+        fs.closeSync(this.fd);
+      } catch {
+        /* noop */
+      }
+      this.fd = -1;
+    }
+    this.opened = false;
+  }
+
+  // ── 내부: fsync 코얼레싱 ────────────────────────────────────────────
+
+  private maybeStartFsync(): void {
+    if (this.fsyncInFlight || this.unsynced.length === 0) return;
+    this.fsyncInFlight = true;
+    // 마이크로태스크로 지연해 동기 버스트(같은 tick의 다수 append)를 한 배리어로
+    // 코얼레싱한다(§2.5). 이후 tick 도착분은 in-flight 배리어의 다음으로 배치.
+    queueMicrotask(() => {
+      void this.runFsync();
+    });
+  }
+
+  private async runFsync(): Promise<void> {
+    const epoch = this.rollbackEpoch;
+    const barrierCount = this.unsynced.length; // 이 배리어가 커버할 레코드 수
+    const barrierEnd = this.currentOffset;
+
+    let ok = true;
+    try {
+      await this.fsyncFd(this.fd);
+    } catch {
+      ok = false;
+    }
+
+    if (this.rollbackEpoch !== epoch) {
+      // 도중 롤백됨 — 이 배리어 레코드는 이미 false 처리됨. 재개만.
+      this.fsyncInFlight = false;
+      this.maybeStartFsync();
+      return;
+    }
+
+    if (!ok) {
+      this.rollbackBatch(); // §2.4-4 단일 ftruncate + 전원 false
+      this.fsyncInFlight = false;
+      this.maybeStartFsync();
+      return;
+    }
+
+    // 성공: 배리어 커버분만 durable로 확정. 그 사이 도착분은 다음 배리어로.
+    this.committedOffset = barrierEnd;
+    const done = this.unsynced.splice(0, barrierCount);
+    for (const rec of done) rec.resolve(true);
+    this.fsyncInFlight = false;
+    this.maybeStartFsync();
+  }
+
+  /**
+   * §2.4-4 배치 단일 롤백. ftruncate(committedOffset) **한 번**으로 미커밋 전량
+   * (배리어 + 그 뒤 대기분)을 물리 제거하고 전원 false. hwm은 되돌리지 않는다
+   * (§3 함정: gap 허용, 재사용 금지).
+   */
+  private rollbackBatch(): void {
+    this.rollbackEpoch++;
+    try {
+      fs.ftruncateSync(this.fd, this.committedOffset);
+    } catch {
+      // 절단 실패는 at-least-once로 흡수(§2.6-c) — false 계약은 유지.
+    }
+    this.currentOffset = this.committedOffset;
+    const failed = this.unsynced.splice(0, this.unsynced.length);
+    for (const rec of failed) rec.resolve(false);
+  }
+
+  // ── 내부: 세그먼트·복구 ─────────────────────────────────────────────
+
+  private rollIfNeeded(): void {
+    // §2.8: 롤은 배치 경계(unsynced 비었을 때)에서만 — batchStartOffset이 항상
+    // 단일 파일 좌표이도록. 배치가 미결이면 현 세그먼트에 계속 쓰고 다음 배치에서 롤.
+    if (this.unsynced.length > 0) return;
+    if (this.currentOffset <= this.maxSegmentBytes) return;
+    try {
+      fs.closeSync(this.fd);
+    } catch {
+      /* noop */
+    }
+    this.activeSegNum += 1;
+    this.activeSegPath = this.segPath(this.activeSegNum);
+    this.fd = this.createSegment(this.activeSegPath);
+    this.committedOffset = 0;
+    this.currentOffset = 0;
+  }
+
+  private createSegment(segPath: string): number {
+    const fd = fs.openSync(segPath, 'a'); // 생성 + append 개방
+    this.fsyncDir(); // §2.5: 세그먼트 최초 생성 시 디렉토리 엔트리 내구화
+    return fd;
+  }
+
+  private writeFully(buf: Buffer): void {
+    // §2.4-2: fs.writeSync 단일 호출이 전량 쓰기를 보장하지 않음 → 루프.
+    let written = 0;
+    while (written < buf.length) {
+      written += fs.writeSync(this.fd, buf, written, buf.length - written);
+    }
+  }
+
+  private fsyncDir(): void {
+    if (process.platform === 'win32') return; // §2.3 win32 잔여
+    let dirFd = -1;
+    try {
+      dirFd = fs.openSync(this.dir, 'r');
+      fs.fsyncSync(dirFd);
+    } catch {
+      // best-effort — 디렉토리 fsync 미지원 파일시스템은 §2.3 수용 잔여
+    } finally {
+      if (dirFd >= 0) {
+        try {
+          fs.closeSync(dirFd);
+        } catch {
+          /* noop */
+        }
+      }
+    }
+  }
+
+  private listSegments(): number[] {
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(this.dir);
+    } catch {
+      return [];
+    }
+    const nums: number[] = [];
+    for (const name of entries) {
+      const m = SEGMENT_RE.exec(name);
+      if (m) nums.push(Number(m[1]));
+    }
+    nums.sort((a, b) => a - b);
+    return nums;
+  }
+
+  private segPath(n: number): string {
+    return path.join(this.dir, `${String(n).padStart(8, '0')}.ndjson`);
+  }
+
+  /**
+   * §2.6 전방 스캔. 앞에서부터 줄 단위로 파싱하며 검증하고, 최초 불량 줄(파싱
+   * 실패 또는 비-\n-종단 말미)에서 멈춘다. validEnd = 그 직전까지의 유효 길이.
+   * 최초 불량 이후는 유효 줄이 남아 있어도 전부 버린다(부분 승격 금지).
+   */
+  private forwardScanFile(filePath: string): ScanResult {
+    let buf: Buffer;
+    try {
+      buf = fs.readFileSync(filePath);
+    } catch {
+      return { validEnd: 0, maxLamport: 0, maxSeq: 0, records: [] };
+    }
+
+    let offset = 0;
+    let validEnd = 0;
+    let maxLamport = 0;
+    let maxSeq = 0;
+    const records: EventEnvelope[] = [];
+
+    while (offset < buf.length) {
+      const nl = buf.indexOf(NEWLINE, offset);
+      if (nl === -1) {
+        // 비-\n-종단 말미(미완결 torn) → 최초 불량, 절단.
+        break;
+      }
+      const line = buf.toString('utf8', offset, nl);
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line, stripProtoReviver);
+      } catch {
+        // 파싱 실패(torn 중간 등) → 최초 불량, 이후 전부 폐기.
+        break;
+      }
+      if (parsed === null || typeof parsed !== 'object') {
+        break;
+      }
+      const rec = parsed as EventEnvelope;
+      if (typeof rec.lamport === 'number' && rec.lamport > maxLamport) {
+        maxLamport = rec.lamport;
+      }
+      const seq = rec.origin?.seq;
+      if (typeof seq === 'number' && seq > maxSeq) {
+        maxSeq = seq;
+      }
+      records.push(rec);
+      validEnd = nl + 1;
+      offset = nl + 1;
+    }
+
+    return { validEnd, maxLamport, maxSeq, records };
+  }
+
+  private truncateFile(filePath: string, size: number): void {
+    try {
+      if (fs.statSync(filePath).size > size) {
+        fs.truncateSync(filePath, size);
+      }
+    } catch {
+      // best-effort
+    }
+  }
+}

--- a/src/daemon/eventlog/__tests__/AppendOnlyLog.test.ts
+++ b/src/daemon/eventlog/__tests__/AppendOnlyLog.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { AppendOnlyLog } from '../AppendOnlyLog';
+import { makeEnvelope } from '../../../shared/eventlog';
+import type {
+  EventEnvelope,
+  EventEnvelopeDraft,
+} from '../../../shared/eventlog';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-eventlog-'));
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// ── 헬퍼 ──────────────────────────────────────────────────────────────
+
+/** append 입력 초안(순서 필드는 append가 발급). */
+function draft(payload: unknown = {}): EventEnvelopeDraft {
+  return makeEnvelope({
+    domain: 'channel',
+    payload,
+    origin: { machineId: 'm1', daemonEpoch: 1 },
+    authContext: {
+      principalId: 'p',
+      verifiedWorkspaceId: 'ws',
+      trustTier: 'trusted',
+    },
+  });
+}
+
+/** 완결 레코드 1줄(raw 세그먼트 주입용 — 크래시 상태 구성). */
+function envLine(lamport: number, seq: number, payload: unknown = {}): string {
+  const env: EventEnvelope = {
+    eventId: `evt-${lamport}`,
+    origin: { machineId: 'm1', daemonEpoch: 1, seq },
+    lamport,
+    wallClock: 1000 + lamport,
+    authContext: {
+      principalId: 'p',
+      verifiedWorkspaceId: 'ws',
+      trustTier: 'trusted',
+    },
+    domain: 'channel',
+    payload,
+  };
+  return `${JSON.stringify(env)}\n`;
+}
+
+function seg(n: number): string {
+  return path.join(dir, `${String(n).padStart(8, '0')}.ndjson`);
+}
+
+const syncOk = (): void => {};
+
+// ── T-크래시: 전방 스캔·최초 불량 절단·at-least-once 승격 ─────────────────
+
+describe('T-크래시 복구', () => {
+  it('커밋 프리픽스 무손실 + valid unsynced tail 승격 + torn 말미 절단', async () => {
+    const log = new AppendOnlyLog({ dir, fsync: syncOk });
+    log.open();
+    await log.append(draft({ n: 1 }));
+    await log.append(draft({ n: 2 }));
+    log.close();
+
+    // 크래시 모사: 커밋 2건 뒤 (a) valid 줄 1건(승격 후보) + (b) torn 미완결 줄 주입.
+    fs.appendFileSync(seg(1), envLine(3, 3, { n: 3 }));
+    fs.appendFileSync(seg(1), '{"lamport":4,"origin":{"seq":4'); // 비-\n-종단
+
+    const log2 = new AppendOnlyLog({ dir });
+    log2.open();
+    // 1,2 커밋 + 3 승격 → 무손실. torn 4 → 폐기.
+    expect(log2.readAllRecords().map((r) => r.lamport)).toEqual([1, 2, 3]);
+    // 승격 레코드가 hwm 스캔에 반영(재사용 불가).
+    expect(log2.lamportHwm).toBe(3);
+    log2.close();
+  });
+
+  it('코얼레싱 배치 중간 torn(비순서 writeback) → 불량 이후 valid 줄도 폐기(부분 승격 금지)', () => {
+    fs.writeFileSync(
+      seg(1),
+      envLine(1, 1, { n: 1 }) + 'GARBAGE-not-json\n' + envLine(3, 3, { n: 3 }),
+    );
+    const log = new AppendOnlyLog({ dir });
+    log.open();
+    // 최초 불량(중간 garbage)에서 절단 → 그 뒤 valid(lamport 3)도 폐기.
+    expect(log.readAllRecords().map((r) => r.lamport)).toEqual([1]);
+    expect(log.lamportHwm).toBe(1);
+    // 활성 세그먼트가 물리적으로 절단(불량 이후 바이트 제거).
+    expect(fs.readFileSync(seg(1), 'utf8')).toBe(envLine(1, 1, { n: 1 }));
+    log.close();
+  });
+
+  it('fsync 직전 kill(전량 valid unsynced tail) → 전량 승격(절단 아님), 부분 승격 없음', () => {
+    fs.writeFileSync(
+      seg(1),
+      envLine(1, 1) + envLine(2, 2) + envLine(3, 3),
+    );
+    const log = new AppendOnlyLog({ dir });
+    log.open();
+    // 절단 or 승격 둘 중 하나 — 전량 valid이므로 승격.
+    expect(log.readAllRecords().map((r) => r.lamport)).toEqual([1, 2, 3]);
+    expect(log.lamportHwm).toBe(3);
+    log.close();
+  });
+});
+
+// ── T-fsync실패: 배치 단일 롤백 ─────────────────────────────────────────
+
+describe('T-fsync실패 주입', () => {
+  it('배치 전체 ftruncate(batchStartOffset) 1회 + 전원 false + replay 미출현', async () => {
+    let failSync = true;
+    const log = new AppendOnlyLog({
+      dir,
+      fsync: () => {
+        if (failSync) throw new Error('inject fsync failure');
+      },
+    });
+    log.open();
+
+    const ftruncSpy = vi.spyOn(fs, 'ftruncateSync');
+    const results = await Promise.all([
+      log.append(draft({ n: 1 })),
+      log.append(draft({ n: 2 })),
+      log.append(draft({ n: 3 })),
+    ]);
+
+    // 배치 Promise 전원 false.
+    expect(results).toEqual([false, false, false]);
+    // 단일 ftruncate로 배치 전체 물리 제거(순서의존 null 매장 없음).
+    expect(ftruncSpy).toHaveBeenCalledTimes(1);
+    expect(ftruncSpy).toHaveBeenCalledWith(expect.any(Number), 0);
+    // 디스크에 롤백 이벤트 없음.
+    expect(log.readAllRecords()).toEqual([]);
+
+    // 롤백 후 정상 append는 소비된 hwm 뒤(gap)에서 재개, 재사용 없음.
+    failSync = false;
+    const ok = await log.append(draft({ n: 4 }));
+    expect(ok).toBe(true);
+    const recs = log.readAllRecords();
+    expect(recs).toHaveLength(1);
+    expect(recs[0].lamport).toBe(4);
+    log.close();
+    ftruncSpy.mockRestore();
+
+    // 재부트 replay에 롤백 이벤트 미출현.
+    const log2 = new AppendOnlyLog({ dir });
+    log2.open();
+    expect(log2.readAllRecords().map((r) => r.lamport)).toEqual([4]);
+    log2.close();
+  });
+});
+
+// ── T-롤크래시: 빈 신규 세그먼트를 first-boot로 오인 금지 ──────────────────
+
+describe('T-롤 직후 크래시', () => {
+  it('빈 신규 세그먼트 → 직전 세그먼트에서 hwm 복원(리셋·재사용 없음)', async () => {
+    fs.writeFileSync(seg(1), envLine(1, 1) + envLine(2, 2) + envLine(3, 3));
+    fs.writeFileSync(seg(2), ''); // 롤이 만든 빈 신규 세그먼트, 쓰기 전 크래시
+
+    const log = new AppendOnlyLog({ dir });
+    log.open();
+    expect(log.lamportHwm).toBe(3); // first-boot 오인 시 0이 됐을 값
+    expect(log.seqHwm).toBe(3);
+
+    const ok = await log.append(draft({ n: 4 }));
+    expect(ok).toBe(true);
+    expect(log.readAllRecords().map((r) => r.lamport)).toEqual([1, 2, 3, 4]);
+    // 신규 레코드는 활성(최고번호=2) 세그먼트에 기록.
+    expect(fs.readFileSync(seg(2), 'utf8')).toContain('"lamport":4');
+    log.close();
+  });
+
+  it('torn 부분쓰기 신규 세그먼트 → 절단 후 빔 → 직전 세그먼트 복원', async () => {
+    fs.writeFileSync(seg(1), envLine(1, 1) + envLine(2, 2) + envLine(3, 3));
+    fs.writeFileSync(seg(2), '{"lamport":4,"orig'); // torn 부분쓰기
+
+    const log = new AppendOnlyLog({ dir });
+    log.open();
+    expect(log.lamportHwm).toBe(3);
+    expect(fs.readFileSync(seg(2), 'utf8')).toBe(''); // torn 절단됨
+
+    const ok = await log.append(draft({ n: 4 }));
+    expect(ok).toBe(true);
+    expect(log.readAllRecords().map((r) => r.lamport)).toEqual([1, 2, 3, 4]);
+    log.close();
+  });
+
+  it('세그먼트 롤: 임계 초과 시 신규 세그먼트, 경계 넘어 순서·연속 보존', async () => {
+    const log = new AppendOnlyLog({ dir, fsync: syncOk, maxSegmentBytes: 300 });
+    log.open();
+    for (let i = 0; i < 8; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await log.append(draft({ i }));
+    }
+    const segs = fs
+      .readdirSync(dir)
+      .filter((f) => /^\d{8}\.ndjson$/.test(f));
+    expect(segs.length).toBeGreaterThanOrEqual(2);
+    expect(log.readAllRecords().map((r) => r.lamport)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8,
+    ]);
+    log.close();
+  });
+});
+
+// ── T-lamport: 재개·gap·승격 반영 ──────────────────────────────────────
+
+describe('T-lamport 재개', () => {
+  it('재시작 후 첫 신규 = 직전 max+1 (오프바이원 없음)', async () => {
+    const log = new AppendOnlyLog({ dir, fsync: syncOk });
+    log.open();
+    await log.append(draft({ n: 1 }));
+    await log.append(draft({ n: 2 }));
+    await log.append(draft({ n: 3 }));
+    expect(log.lamportHwm).toBe(3);
+    expect(log.seqHwm).toBe(3);
+    log.close();
+
+    const log2 = new AppendOnlyLog({ dir, fsync: syncOk });
+    log2.open();
+    expect(log2.lamportHwm).toBe(3); // 디스크 라운드트립 복원
+    expect(log2.seqHwm).toBe(3);
+    await log2.append(draft({ n: 4 }));
+    const recs = log2.readAllRecords();
+    expect(recs.map((r) => r.lamport)).toEqual([1, 2, 3, 4]); // 첫 신규 = max+1
+    expect(recs[recs.length - 1].origin.seq).toBe(4);
+    log2.close();
+  });
+
+  it('배치 실패 후 hwm gap 허용·재사용 금지', async () => {
+    let failSync = false;
+    const log = new AppendOnlyLog({
+      dir,
+      fsync: () => {
+        if (failSync) throw new Error('inject');
+      },
+    });
+    log.open();
+    await log.append(draft({ n: 1 }));
+    await log.append(draft({ n: 2 }));
+    await log.append(draft({ n: 3 })); // 1,2,3 커밋
+
+    failSync = true;
+    const failed = await Promise.all([
+      log.append(draft({ n: 'a' })),
+      log.append(draft({ n: 'b' })),
+    ]);
+    expect(failed).toEqual([false, false]); // 4,5 소비되나 미커밋(롤백)
+
+    failSync = false;
+    await log.append(draft({ n: 6 }));
+    // gap(4,5)은 허용하되 재사용 금지 → 다음 성공값은 6.
+    expect(log.readAllRecords().map((r) => r.lamport)).toEqual([1, 2, 3, 6]);
+    expect(log.lamportHwm).toBe(6);
+    log.close();
+  });
+
+  it('승격 레코드의 lamport가 hwm 스캔에 반영', () => {
+    // 커밋 1,2 + 승격(unsynced valid) 5 → hwm 스캔은 max=5.
+    fs.writeFileSync(seg(1), envLine(1, 1) + envLine(2, 2) + envLine(5, 5));
+    const log = new AppendOnlyLog({ dir });
+    log.open();
+    expect(log.lamportHwm).toBe(5);
+    expect(log.seqHwm).toBe(5);
+    log.close();
+  });
+});

--- a/src/daemon/eventlog/__tests__/AppendOnlyLog.test.ts
+++ b/src/daemon/eventlog/__tests__/AppendOnlyLog.test.ts
@@ -273,3 +273,193 @@ describe('T-lamport 재개', () => {
     log.close();
   });
 });
+
+// ── 패널 반영: 발급 필드·fail-stop·비동기 배리어·롤·close 계약 ─────────────
+
+/** 수동 게이트 async fsync — await 창의 late-arrival 인터리빙을 결정적으로 재현. */
+function gatedFsync(): {
+  fsync: () => Promise<void>;
+  gates: Array<{ resolve: () => void; reject: (e: Error) => void }>;
+} {
+  const gates: Array<{ resolve: () => void; reject: (e: Error) => void }> = [];
+  return {
+    gates,
+    fsync: () =>
+      new Promise<void>((resolve, reject) => {
+        gates.push({ resolve, reject });
+      }),
+  };
+}
+
+/** 마이크로태스크를 펌핑해 배리어 시작(gates 채워짐)을 기다린다. */
+async function untilGates(gates: unknown[], n: number): Promise<void> {
+  for (let i = 0; i < 50 && gates.length < n; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve();
+  }
+  expect(gates.length).toBeGreaterThanOrEqual(n);
+}
+
+describe('발급 필드 @ append (eventId 유일성)', () => {
+  it('같은 draft를 재사용(재시도 모사)해도 커밋 레코드마다 eventId 신규 발급', async () => {
+    const log = new AppendOnlyLog({ dir, fsync: syncOk });
+    log.open();
+    const d = draft({ n: 1 });
+    expect('eventId' in d).toBe(false); // draft엔 발급 필드 없음
+    await log.append(d);
+    await log.append(d);
+    const recs = log.readAllRecords();
+    expect(recs).toHaveLength(2);
+    expect(typeof recs[0].eventId).toBe('string');
+    expect(typeof recs[0].wallClock).toBe('number');
+    expect(recs[0].eventId).not.toBe(recs[1].eventId); // 전역 유일성 유지
+    log.close();
+  });
+});
+
+describe('fail-stop: 롤백 ftruncate 실패 (3모델 합의)', () => {
+  it('절단 실패 → broken: 배치 false + 이후 append 즉시 false·무기록, reopen으로 재개', async () => {
+    let failSync = false;
+    const log = new AppendOnlyLog({
+      dir,
+      fsync: () => {
+        if (failSync) throw new Error('inject fsync');
+      },
+    });
+    log.open();
+    await log.append(draft({ n: 1 })); // 커밋
+
+    failSync = true;
+    const ftruncSpy = vi
+      .spyOn(fs, 'ftruncateSync')
+      .mockImplementationOnce(() => {
+        throw new Error('inject truncate failure');
+      });
+    const r2 = await log.append(draft({ n: 2 }));
+    expect(r2).toBe(false);
+
+    // broken — 좌표 불변식 붕괴 상태로는 어떤 write도 하지 않는다.
+    failSync = false;
+    const sizeBefore = fs.statSync(seg(1)).size;
+    const r3 = await log.append(draft({ n: 3 }));
+    expect(r3).toBe(false);
+    expect(fs.statSync(seg(1)).size).toBe(sizeBefore); // 추가 바이트 0
+    log.close();
+    ftruncSpy.mockRestore();
+
+    // 재개는 reopen — 절단 못 한 tail(n:2)은 valid 줄이라 at-least-once 승격(§2.6 계약).
+    const log2 = new AppendOnlyLog({ dir, fsync: syncOk });
+    log2.open();
+    expect(log2.readAllRecords().map((r) => r.lamport)).toEqual([1, 2]);
+    expect(log2.lamportHwm).toBe(2);
+    log2.close();
+  });
+});
+
+describe('fail-closed: 부트 복구 절단 실패 (3모델 합의)', () => {
+  it('절단 불가면 open()이 throw — 불량 tail 위에 열지 않는다', () => {
+    fs.writeFileSync(seg(1), envLine(1, 1) + 'GARBAGE-tail\n');
+    const truncSpy = vi.spyOn(fs, 'truncateSync').mockImplementation(() => {
+      /* 절단이 조용히 무효인 최악 케이스 모사 */
+    });
+    const log = new AppendOnlyLog({ dir });
+    expect(() => log.open()).toThrow(/복구 절단 실패/);
+    truncSpy.mockRestore();
+  });
+});
+
+describe('비동기 배리어 인터리빙 (코얼레싱 계약)', () => {
+  it('배리어 성공 경계에서 롤 — 지속 부하에서도 세그먼트가 임계에서 롤된다', async () => {
+    const { fsync, gates } = gatedFsync();
+    const log = new AppendOnlyLog({ dir, fsync, maxSegmentBytes: 1 });
+    log.open();
+
+    const p1 = log.append(draft({ n: 1 }));
+    await untilGates(gates, 1); // 배리어1 in-flight
+    const p2 = log.append(draft({ n: 2 })); // await 창 도착 → 다음 배리어로
+
+    gates[0].resolve();
+    await expect(p1).resolves.toBe(true);
+    // 배리어1 성공 시점엔 unsynced(p2) 비어있지 않아 롤 없음 → 배리어2로.
+    await untilGates(gates, 2);
+    gates[1].resolve();
+    await expect(p2).resolves.toBe(true);
+
+    // 배리어2 성공 경계(unsynced 빔)에서 롤 성사 — 기아 없음.
+    expect(log.activeSegment).toContain('00000002');
+    expect(log.readAllRecords().map((r) => r.lamport)).toEqual([1, 2]);
+    log.close();
+  });
+
+  it('배리어 실패는 await 창 도착분까지 전원 false + 단일 ftruncate, 이후 정상 재개', async () => {
+    const { fsync, gates } = gatedFsync();
+    const log = new AppendOnlyLog({ dir, fsync });
+    log.open();
+
+    const p1 = log.append(draft({ n: 1 }));
+    await untilGates(gates, 1);
+    const p2 = log.append(draft({ n: 2 })); // late-arrival — 배리어1 밖
+
+    const ftruncSpy = vi.spyOn(fs, 'ftruncateSync');
+    gates[0].reject(new Error('inject barrier failure'));
+    await expect(p1).resolves.toBe(false);
+    await expect(p2).resolves.toBe(false); // 후속 대기분 포함 전원 false(§2.4-4)
+    expect(ftruncSpy).toHaveBeenCalledTimes(1); // 단일 ftruncate
+    ftruncSpy.mockRestore();
+
+    const p3 = log.append(draft({ n: 3 }));
+    await untilGates(gates, 2);
+    gates[1].resolve();
+    await expect(p3).resolves.toBe(true);
+    expect(log.readAllRecords().map((r) => r.payload)).toEqual([{ n: 3 }]);
+    log.close();
+  });
+
+  it('close()는 미확정 append를 false로 확정한다(영구 pending 없음)', async () => {
+    const log = new AppendOnlyLog({
+      dir,
+      fsync: () => new Promise<void>(() => {}), // 영구 대기 배리어
+    });
+    log.open();
+    const p = log.append(draft({ n: 1 }));
+    await Promise.resolve(); // 배리어 시작
+    log.close();
+    await expect(p).resolves.toBe(false);
+  });
+});
+
+describe('스캔 스키마 가드', () => {
+  it('발급 필드 없는 JSON 줄({})은 최초 불량 — 이후 절단, hwm 미오염', () => {
+    fs.writeFileSync(seg(1), envLine(1, 1) + '{}\n' + envLine(3, 3));
+    const log = new AppendOnlyLog({ dir });
+    log.open();
+    expect(log.readAllRecords().map((r) => r.lamport)).toEqual([1]);
+    expect(log.lamportHwm).toBe(1);
+    log.close();
+  });
+});
+
+describe('롤 open-then-swap', () => {
+  it('신규 세그먼트 개방 실패 시 현 세그먼트 유지(append 계속 성공), 다음 경계에서 롤', async () => {
+    const log = new AppendOnlyLog({ dir, fsync: syncOk, maxSegmentBytes: 1 });
+    log.open();
+    const openSpy = vi.spyOn(fs, 'openSync');
+    openSpy.mockImplementationOnce(() => {
+      throw new Error('inject roll open failure');
+    });
+
+    const r1 = await log.append(draft({ n: 1 })); // 배리어 성공 경계의 롤 시도가 실패
+    expect(r1).toBe(true);
+    expect(log.activeSegment).toContain('00000001'); // 상태 불변 — 현 세그먼트 유지
+
+    const r2 = await log.append(draft({ n: 2 })); // 다음 경계(append 시점)에서 롤 성사
+    expect(r2).toBe(true);
+    // r1은 seg1에 남고(스왑 실패 시 상태 불변), r2는 롤 성사 후 seg2에 기록.
+    expect(fs.readFileSync(seg(1), 'utf8')).toContain('"lamport":1');
+    expect(fs.readFileSync(seg(1), 'utf8')).not.toContain('"lamport":2');
+    expect(fs.readFileSync(seg(2), 'utf8')).toContain('"lamport":2');
+    expect(log.readAllRecords().map((r) => r.lamport)).toEqual([1, 2]);
+    openSpy.mockRestore();
+    log.close();
+  });
+});

--- a/src/daemon/eventlog/__tests__/AppendOnlyLog.test.ts
+++ b/src/daemon/eventlog/__tests__/AppendOnlyLog.test.ts
@@ -125,7 +125,8 @@ describe('T-fsync실패 주입', () => {
     });
     log.open();
 
-    const ftruncSpy = vi.spyOn(fs, 'ftruncateSync');
+    // 절단은 경로 기반(close→truncate→reopen — win32 'a' fd ftruncate EPERM 회피).
+    const truncSpy = vi.spyOn(fs, 'truncateSync');
     const results = await Promise.all([
       log.append(draft({ n: 1 })),
       log.append(draft({ n: 2 })),
@@ -134,9 +135,9 @@ describe('T-fsync실패 주입', () => {
 
     // 배치 Promise 전원 false.
     expect(results).toEqual([false, false, false]);
-    // 단일 ftruncate로 배치 전체 물리 제거(순서의존 null 매장 없음).
-    expect(ftruncSpy).toHaveBeenCalledTimes(1);
-    expect(ftruncSpy).toHaveBeenCalledWith(expect.any(Number), 0);
+    // 단일 truncate로 배치 전체 물리 제거(순서의존 null 매장 없음).
+    expect(truncSpy).toHaveBeenCalledTimes(1);
+    expect(truncSpy).toHaveBeenCalledWith(expect.any(String), 0);
     // 디스크에 롤백 이벤트 없음.
     expect(log.readAllRecords()).toEqual([]);
 
@@ -148,7 +149,7 @@ describe('T-fsync실패 주입', () => {
     expect(recs).toHaveLength(1);
     expect(recs[0].lamport).toBe(4);
     log.close();
-    ftruncSpy.mockRestore();
+    truncSpy.mockRestore();
 
     // 재부트 replay에 롤백 이벤트 미출현.
     const log2 = new AppendOnlyLog({ dir });
@@ -330,8 +331,8 @@ describe('fail-stop: 롤백 ftruncate 실패 (3모델 합의)', () => {
     await log.append(draft({ n: 1 })); // 커밋
 
     failSync = true;
-    const ftruncSpy = vi
-      .spyOn(fs, 'ftruncateSync')
+    const truncSpy = vi
+      .spyOn(fs, 'truncateSync')
       .mockImplementationOnce(() => {
         throw new Error('inject truncate failure');
       });
@@ -345,7 +346,7 @@ describe('fail-stop: 롤백 ftruncate 실패 (3모델 합의)', () => {
     expect(r3).toBe(false);
     expect(fs.statSync(seg(1)).size).toBe(sizeBefore); // 추가 바이트 0
     log.close();
-    ftruncSpy.mockRestore();
+    truncSpy.mockRestore();
 
     // 재개는 reopen — 절단 못 한 tail(n:2)은 valid 줄이라 at-least-once 승격(§2.6 계약).
     const log2 = new AppendOnlyLog({ dir, fsync: syncOk });
@@ -400,12 +401,12 @@ describe('비동기 배리어 인터리빙 (코얼레싱 계약)', () => {
     await untilGates(gates, 1);
     const p2 = log.append(draft({ n: 2 })); // late-arrival — 배리어1 밖
 
-    const ftruncSpy = vi.spyOn(fs, 'ftruncateSync');
+    const truncSpy = vi.spyOn(fs, 'truncateSync');
     gates[0].reject(new Error('inject barrier failure'));
     await expect(p1).resolves.toBe(false);
     await expect(p2).resolves.toBe(false); // 후속 대기분 포함 전원 false(§2.4-4)
-    expect(ftruncSpy).toHaveBeenCalledTimes(1); // 단일 ftruncate
-    ftruncSpy.mockRestore();
+    expect(truncSpy).toHaveBeenCalledTimes(1); // 단일 truncate(경로 기반)
+    truncSpy.mockRestore();
 
     const p3 = log.append(draft({ n: 3 }));
     await untilGates(gates, 2);

--- a/src/daemon/util/atomicWrite/__tests__/durable.test.ts
+++ b/src/daemon/util/atomicWrite/__tests__/durable.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import {
+  atomicWriteJSON,
+  atomicWriteJSONSync,
+  atomicReadJSONSync,
+} from '../core';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-durable-'));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('durable atomic write (§2.3)', () => {
+  it('sync: durable 경로가 tmp fsync를 호출하고 내용이 왕복된다', () => {
+    const target = path.join(dir, 'manifest.json');
+    const fsyncSpy = vi.spyOn(fs, 'fsyncSync');
+    atomicWriteJSONSync(target, { a: 1 }, { durable: true });
+    // §2.3-2 tmp fd fsync가 최소 1회(+win32 아니면 §2.3-4 dir fsync).
+    expect(fsyncSpy).toHaveBeenCalled();
+    expect(atomicReadJSONSync<{ a: number }>(target)).toEqual({ a: 1 });
+  });
+
+  it('async: durable 경로가 내용을 정상 기록한다', async () => {
+    const target = path.join(dir, 'snap.json');
+    await atomicWriteJSON(target, { b: 2 }, { durable: true });
+    expect(atomicReadJSONSync<{ b: number }>(target)).toEqual({ b: 2 });
+  });
+
+  it('durable 미지정(기존 경로)은 fsync 없이 동작이 불변', () => {
+    const target = path.join(dir, 'plain.json');
+    const fsyncSpy = vi.spyOn(fs, 'fsyncSync');
+    atomicWriteJSONSync(target, { c: 3 });
+    // 기존 경로는 fsync를 호출하지 않는다(1비트 불변).
+    expect(fsyncSpy).not.toHaveBeenCalled();
+    expect(atomicReadJSONSync<{ c: number }>(target)).toEqual({ c: 3 });
+  });
+});

--- a/src/daemon/util/atomicWrite/core.ts
+++ b/src/daemon/util/atomicWrite/core.ts
@@ -59,6 +59,16 @@ export interface AtomicWriteOptions {
    * T6 uses this for quarantine timestamps.
    */
   clock?: () => number;
+
+  /**
+   * durable 쓰기 (envelope-design §2.3 D13). true면 crash-safe 시퀀스를 강제한다:
+   *   tmp write → tmp fd fsync → rename → 부모 디렉토리 fsync.
+   * 기본 경로(false/미지정)는 fsync 없는 write+rename로 **1비트도 불변**이다 —
+   * 스냅샷엔 충분하지만 정본(manifest 등)엔 전원손실 내구를 위해 durable이 필요하다.
+   * win32는 디렉토리 fsync 미지원이라 4단계를 스킵한다(§2.3 win32 잔여, 파일 자체
+   * FlushFileBuffers까지만 보장).
+   */
+  durable?: boolean;
 }
 
 export interface AtomicReadOptions<T> {
@@ -129,6 +139,49 @@ function ensureDirSync(filePath: string): void {
 async function ensureDir(filePath: string): Promise<void> {
   const dir = path.dirname(filePath);
   await fsp.mkdir(dir, { recursive: true });
+}
+
+/**
+ * durable 경로의 부모 디렉토리 fsync (§2.3-4). rename(디렉토리 엔트리)을 내구화한다.
+ * win32는 디렉토리 핸들 fsync를 지원하지 않으므로 스킵(§2.3 win32 잔여). 실패는
+ * best-effort로 흡수한다 — 파일 자체는 이미 tmp fsync로 내구화됐다.
+ */
+async function fsyncParentDir(dir: string): Promise<void> {
+  if (process.platform === 'win32') return;
+  let dh: fsp.FileHandle | undefined;
+  try {
+    dh = await fsp.open(dir, 'r');
+    await dh.sync();
+  } catch {
+    // best-effort
+  } finally {
+    if (dh) {
+      try {
+        await dh.close();
+      } catch {
+        /* noop */
+      }
+    }
+  }
+}
+
+function fsyncParentDirSync(dir: string): void {
+  if (process.platform === 'win32') return;
+  let dirFd = -1;
+  try {
+    dirFd = fs.openSync(dir, 'r');
+    fs.fsyncSync(dirFd);
+  } catch {
+    // best-effort
+  } finally {
+    if (dirFd >= 0) {
+      try {
+        fs.closeSync(dirFd);
+      } catch {
+        /* noop */
+      }
+    }
+  }
 }
 
 function serialise(data: unknown): string {
@@ -228,7 +281,18 @@ export async function atomicWriteJSON(
   try {
     // 1. Write to temp file. mode:0o600 is a no-op on Windows, but
     //    matches the StateWriter's POSIX intent.
-    await fsp.writeFile(tmp, json, { encoding: 'utf-8', mode: 0o600 });
+    if (opts.durable) {
+      // §2.3-1,2: rename 전에 tmp 내용을 fsync해 디스크에 내구화한다.
+      const fh = await fsp.open(tmp, 'w', 0o600);
+      try {
+        await fh.writeFile(json, { encoding: 'utf-8' });
+        await fh.sync();
+      } finally {
+        await fh.close();
+      }
+    } else {
+      await fsp.writeFile(tmp, json, { encoding: 'utf-8', mode: 0o600 });
+    }
 
     // 2. When rotation is enabled we shift the existing numbered
     //    slots BEFORE overwriting `.bak` so nothing is lost:
@@ -252,6 +316,11 @@ export async function atomicWriteJSON(
 
     // 4. Atomic rename tmp → target.
     await fsp.rename(tmp, targetPath);
+
+    // 5. §2.3-4: durable이면 부모 디렉토리 엔트리(rename)를 내구화(win32 스킵).
+    if (opts.durable) {
+      await fsyncParentDir(path.dirname(targetPath));
+    }
   } catch (err) {
     // Best-effort tmp cleanup so we don't leak partial files.
     await unlinkIfExists(tmp);
@@ -387,7 +456,18 @@ export function atomicWriteJSONSync(
   const json = serialise(data);
 
   try {
-    fs.writeFileSync(tmp, json, { encoding: 'utf-8', mode: 0o600 });
+    if (opts.durable) {
+      // §2.3-1,2: rename 전에 tmp 내용을 fsync해 디스크에 내구화한다.
+      const fd = fs.openSync(tmp, 'w', 0o600);
+      try {
+        fs.writeFileSync(fd, json, { encoding: 'utf-8' });
+        fs.fsyncSync(fd);
+      } finally {
+        fs.closeSync(fd);
+      }
+    } else {
+      fs.writeFileSync(tmp, json, { encoding: 'utf-8', mode: 0o600 });
+    }
 
     // Shift the numbered slots up when rotation is enabled so the
     // upcoming `.bak` overwrite does not drop a generation. See the
@@ -406,6 +486,11 @@ export function atomicWriteJSONSync(
     }
 
     fs.renameSync(tmp, targetPath);
+
+    // §2.3-4: durable이면 부모 디렉토리 엔트리(rename)를 내구화(win32 스킵).
+    if (opts.durable) {
+      fsyncParentDirSync(path.dirname(targetPath));
+    }
   } catch (err) {
     unlinkIfExistsSync(tmp);
     throw err;

--- a/src/shared/__tests__/eventlog.test.ts
+++ b/src/shared/__tests__/eventlog.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { makeEnvelope } from '../eventlog';
+
+describe('makeEnvelope', () => {
+  const base = {
+    domain: 'channel' as const,
+    payload: { text: 'hi' },
+    origin: { machineId: 'm1', daemonEpoch: 1 },
+    authContext: {
+      principalId: 'p',
+      verifiedWorkspaceId: 'ws',
+      trustTier: 'trusted' as const,
+    },
+  };
+
+  it('발급 필드(eventId·wallClock)를 채우고 순서 필드(lamport·seq)는 비운다', () => {
+    const d = makeEnvelope(base);
+    expect(typeof d.eventId).toBe('string');
+    expect(d.eventId.length).toBeGreaterThan(0);
+    expect(typeof d.wallClock).toBe('number');
+    expect(d.origin).toEqual({ machineId: 'm1', daemonEpoch: 1 });
+    // 순서 필드는 append 소관 — 초안에 존재하지 않는다.
+    expect('lamport' in d).toBe(false);
+    expect('seq' in d.origin).toBe(false);
+    expect(d.domain).toBe('channel');
+    expect(d.payload).toEqual({ text: 'hi' });
+  });
+
+  it('옵셔널(idempotencyKey·causalRefs)은 주어질 때만 실린다', () => {
+    const without = makeEnvelope(base);
+    expect('idempotencyKey' in without).toBe(false);
+    expect('causalRefs' in without).toBe(false);
+
+    const withOpt = makeEnvelope({
+      ...base,
+      idempotencyKey: 'k1',
+      causalRefs: ['e1', 'e2'],
+    });
+    expect(withOpt.idempotencyKey).toBe('k1');
+    expect(withOpt.causalRefs).toEqual(['e1', 'e2']);
+  });
+
+  it('eventId는 호출마다 유일', () => {
+    expect(makeEnvelope(base).eventId).not.toBe(makeEnvelope(base).eventId);
+  });
+});

--- a/src/shared/__tests__/eventlog.test.ts
+++ b/src/shared/__tests__/eventlog.test.ts
@@ -13,13 +13,13 @@ describe('makeEnvelope', () => {
     },
   };
 
-  it('발급 필드(eventId·wallClock)를 채우고 순서 필드(lamport·seq)는 비운다', () => {
+  it('업무 필드만 조립하고 발급 필드(eventId·wallClock·lamport·origin.seq)는 전부 비운다', () => {
     const d = makeEnvelope(base);
-    expect(typeof d.eventId).toBe('string');
-    expect(d.eventId.length).toBeGreaterThan(0);
-    expect(typeof d.wallClock).toBe('number');
     expect(d.origin).toEqual({ machineId: 'm1', daemonEpoch: 1 });
-    // 순서 필드는 append 소관 — 초안에 존재하지 않는다.
+    // 발급 필드 4종은 전부 append 소관 — 초안에 존재하지 않는다
+    // (draft 재사용 재시도가 동일 eventId를 두 번 커밋하지 못하게).
+    expect('eventId' in d).toBe(false);
+    expect('wallClock' in d).toBe(false);
     expect('lamport' in d).toBe(false);
     expect('seq' in d.origin).toBe(false);
     expect(d.domain).toBe('channel');
@@ -40,7 +40,10 @@ describe('makeEnvelope', () => {
     expect(withOpt.causalRefs).toEqual(['e1', 'e2']);
   });
 
-  it('eventId는 호출마다 유일', () => {
-    expect(makeEnvelope(base).eventId).not.toBe(makeEnvelope(base).eventId);
+  it('입력 origin 객체를 변형하지 않는다(방어적 복사)', () => {
+    const origin = { machineId: 'm1', daemonEpoch: 1 };
+    const d = makeEnvelope({ ...base, origin });
+    expect(d.origin).not.toBe(origin);
+    expect(origin).toEqual({ machineId: 'm1', daemonEpoch: 1 });
   });
 });

--- a/src/shared/__tests__/machineId.test.ts
+++ b/src/shared/__tests__/machineId.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import {
+  mintMachineId,
+  readMachineId,
+  writeMachineId,
+  resolveMachineId,
+  recoverMachineIdFromRecords,
+  machineIdPath,
+} from '../machineId';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-machineid-'));
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('machineId', () => {
+  it('mintMachineId는 uuid 형태를 생성', () => {
+    expect(mintMachineId()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it('readMachineId: 부재 시 null', () => {
+    expect(readMachineId(dir)).toBeNull();
+  });
+
+  it('resolveMachineId: 최초엔 민팅·durable 기록, 재호출은 동일값 로드(재민팅 없음)', () => {
+    const first = resolveMachineId(dir);
+    // 파일에 원시 문자열로 기록됐고 내용이 반환값과 일치.
+    expect(fs.readFileSync(machineIdPath(dir), 'utf-8')).toBe(first);
+    const second = resolveMachineId(dir);
+    expect(second).toBe(first); // 재민팅 금지
+  });
+
+  it('resolveMachineId: 파일 부재 + 레코드 복구 훅 → 재민팅 없이 복구값 재기록', () => {
+    const recovered = resolveMachineId(dir, {
+      recoverFromRecords: () => 'recovered-id',
+    });
+    expect(recovered).toBe('recovered-id');
+    // 세그먼트가 증거 — 복구값을 파일에 재기록.
+    expect(readMachineId(dir)).toBe('recovered-id');
+  });
+
+  it('recoverMachineIdFromRecords: 첫 유효 origin.machineId 반환', () => {
+    expect(
+      recoverMachineIdFromRecords([
+        { origin: {} },
+        { origin: { machineId: 'mA' } },
+        { origin: { machineId: 'mB' } },
+      ]),
+    ).toBe('mA');
+    expect(recoverMachineIdFromRecords([])).toBeUndefined();
+  });
+
+  it('writeMachineId → readMachineId 왕복', () => {
+    writeMachineId(dir, 'fixed-uuid');
+    expect(readMachineId(dir)).toBe('fixed-uuid');
+  });
+});

--- a/src/shared/eventlog.ts
+++ b/src/shared/eventlog.ts
@@ -15,8 +15,6 @@
  * 스키마는 PR5 소관 — 여기서 만들지 않는다.
  */
 
-import { randomUUID } from 'node:crypto';
-
 /**
  * 이벤트 도메인 (§1). 로그는 도메인 무지 — 스코프 밖 값도 미해석 통과.
  * Q1 재배선 대상은 'channel'·'a2a'뿐이고 나머지는 미래 소비자용 예약 슬롯.
@@ -68,7 +66,12 @@ export interface AuthContext {
  * 전용으로 순서에 절대 관여하지 않는다(§1 D10).
  */
 export interface EventEnvelope {
-  /** §1 D9: randomUUID() v4. 레코드 정체성(≠ idempotencyKey). */
+  /**
+   * §1 D9: randomUUID() v4. 레코드 정체성(≠ idempotencyKey). **append 임계구역에서
+   * 발급** — draft에 있으면 재시도가 같은 draft를 재사용할 때 서로 다른 두 커밋
+   * 레코드가 동일 eventId를 갖게 되어(at-least-once 승격과 조합) 전역 유일성이
+   * 깨진다(3모델 패널). 그래서 draft에는 존재하지 않는다.
+   */
   eventId: string;
   origin: EventOrigin;
   /** §1 D6: 데몬 전역 논리시계, 표시 순서의 정본. append가 발급(pre-increment). */
@@ -86,17 +89,23 @@ export interface EventEnvelope {
 }
 
 /**
- * makeEnvelope 산출물 — 순서 필드(lamport, origin.seq)는 제외된 초안.
+ * makeEnvelope 산출물 — 발급 필드(eventId·lamport·wallClock·origin.seq)가 전부
+ * 제외된 초안.
  *
- * lamport와 origin.seq는 AppendOnlyLog.append가 자신의 임계구역에서
- * hwm 기반으로 발급한다(§3). 서비스는 나머지 필드만 채워 draft를 만들고
- * append에 넘긴다 — 발급 주체가 로그 단독임을 타입으로 강제한다.
+ * 네 필드 모두 AppendOnlyLog.append가 자신의 임계구역에서 발급한다(§1 "@ append",
+ * §3). lamport/seq는 hwm 임계구역이 필요해서, eventId/wallClock은 draft 재사용
+ * 재시도가 동일 eventId를 두 번 커밋하지 못하게(레코드마다 신규 발급). 서비스는
+ * 업무 필드만 채워 draft를 만들고 append에 넘긴다 — 발급 주체가 로그 단독임을
+ * 타입으로 강제한다.
  */
-export type EventEnvelopeDraft = Omit<EventEnvelope, 'lamport' | 'origin'> & {
+export type EventEnvelopeDraft = Omit<
+  EventEnvelope,
+  'eventId' | 'lamport' | 'wallClock' | 'origin'
+> & {
   origin: Omit<EventOrigin, 'seq'>;
 };
 
-/** makeEnvelope 입력. eventId·wallClock은 팩토리가 발급한다. */
+/** makeEnvelope 입력. 발급 필드는 전부 append 소관이라 여기 없다. */
 export interface MakeEnvelopeInput {
   domain: EventDomain;
   payload: unknown;
@@ -108,17 +117,15 @@ export interface MakeEnvelopeInput {
 }
 
 /**
- * envelope 초안 팩토리 (§1, §5). eventId(randomUUID)·wallClock(Date.now)을
- * 확정하고, 순서 필드는 append가 채우도록 비운다.
+ * envelope 초안 팩토리 (§1, §5). 업무 필드를 조립하고 옵셔널을 정돈한다.
+ * 발급 필드(eventId·lamport·wallClock·origin.seq)는 전부 append가 채운다.
  */
 export function makeEnvelope(input: MakeEnvelopeInput): EventEnvelopeDraft {
   const draft: EventEnvelopeDraft = {
-    eventId: randomUUID(),
     origin: {
       machineId: input.origin.machineId,
       daemonEpoch: input.origin.daemonEpoch,
     },
-    wallClock: Date.now(),
     authContext: {
       principalId: input.authContext.principalId,
       verifiedWorkspaceId: input.authContext.verifiedWorkspaceId,

--- a/src/shared/eventlog.ts
+++ b/src/shared/eventlog.ts
@@ -1,0 +1,138 @@
+/**
+ * 공통 이벤트 Envelope — append-only 로그의 레코드 스키마 (envelope-design §1).
+ *
+ * ┌── PROTOCOL 파일: additive-only 규약 ──────────────────────────────┐
+ * │ 이 파일은 디스크에 영속되는 로그 레코드의 계약이다. 크래시 후 부트가       │
+ * │ 이 스키마로 과거 레코드를 재파싱하므로:                                  │
+ * │   - 필드를 제거·개명·의미변경하지 마라(과거 레코드 파싱 붕괴).           │
+ * │   - 새 필드는 반드시 옵셔널(`?:`)로만 추가하라(구 레코드엔 부재).        │
+ * │   - domain enum·TrustTier 값은 추가만 허용, 기존 값 재사용 금지.        │
+ * │ (§8 origin.keyId, §6.F evidence 등 미래 확장은 전부 옵셔널 additive.)  │
+ * └──────────────────────────────────────────────────────────────────┘
+ *
+ * 스코프 경계: payload는 도메인 소유의 opaque 값이다. 로그 계층은 절대
+ * 해석하지 않는다(§1 필드표). 채널/A2A 전이 payload·완료증거(evidence)
+ * 스키마는 PR5 소관 — 여기서 만들지 않는다.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+/**
+ * 이벤트 도메인 (§1). 로그는 도메인 무지 — 스코프 밖 값도 미해석 통과.
+ * Q1 재배선 대상은 'channel'·'a2a'뿐이고 나머지는 미래 소비자용 예약 슬롯.
+ * (additive-only: 값 추가만, 기존 값 재사용·제거 금지.)
+ */
+export type EventDomain =
+  | 'channel'
+  | 'a2a'
+  | 'task'
+  | 'approval'
+  | 'recording'
+  | 'asp';
+
+/**
+ * 신뢰 등급 (§7, §6.K 4등급과 1:1). principalId/trustTier는 라우팅·표시·
+ * 감사용이며 authz가 아니다 — 권한 판정 앵커는 verifiedWorkspaceId다.
+ * (additive-only.)
+ */
+export type TrustTier = 'trusted' | 'semi-trusted' | 'heuristic' | 'untrusted';
+
+/**
+ * 레코드 출처 (§1, §8). `(machineId, seq)`가 부트 경계를 넘어 전역 유일.
+ * daemonEpoch는 순서 비관여 provenance 스탬프(§8 D8).
+ */
+export interface EventOrigin {
+  /** §8: 설치 생애 영구 불변 UUID(교체 금지 — Q4에도 keyId로 분리). */
+  machineId: string;
+  /** §8 D8: = CHANNELS_EPOCH. 스키마 세대 출처표기 전용, 순서 비관여. */
+  daemonEpoch: number;
+  /** §8 D7: 이 머신 로그의 append 인덱스(영속 단조·비리셋). append가 발급. */
+  seq: number;
+  // keyId?: string  // §8: Q4 additive 예약 — 페어링 키 지문(machineId 대체 아님)
+}
+
+/** 신뢰 컨텍스트 (§7). 데몬 경계에서 스탬프. */
+export interface AuthContext {
+  /** §7: display/routing 스탬프(authz 아님). 데몬이 서버측에서 결정. */
+  principalId: string;
+  /** §7: 서버 핀(authz 앵커, 위조 불가). */
+  verifiedWorkspaceId: string;
+  /** §7, §6.K. */
+  trustTier: TrustTier;
+}
+
+/**
+ * 로그 레코드 1건 (§1). 한 줄(NDJSON) = 한 EventEnvelope.
+ *
+ * 순서 정본은 `lamport`(데몬 전역 논리시계)이고, `wallClock`은 표시/감사
+ * 전용으로 순서에 절대 관여하지 않는다(§1 D10).
+ */
+export interface EventEnvelope {
+  /** §1 D9: randomUUID() v4. 레코드 정체성(≠ idempotencyKey). */
+  eventId: string;
+  origin: EventOrigin;
+  /** §1 D6: 데몬 전역 논리시계, 표시 순서의 정본. append가 발급(pre-increment). */
+  lamport: number;
+  /** §1 D10: Date.now() @ append. 표시·감사 전용, 순서 비관여. */
+  wallClock: number;
+  /** §4: 업무 멱등키(있을 때만). at-least-once 승격의 재시도 흡수 앵커(§2.6). */
+  idempotencyKey?: string;
+  /** §1: 직접 원인 이벤트의 eventId[]. Q1 비게이팅 provenance. */
+  causalRefs?: string[];
+  authContext: AuthContext;
+  domain: EventDomain;
+  /** 도메인 소유 opaque. 로그 계층은 미해석(레이어 경계, §1 필드표). */
+  payload: unknown;
+}
+
+/**
+ * makeEnvelope 산출물 — 순서 필드(lamport, origin.seq)는 제외된 초안.
+ *
+ * lamport와 origin.seq는 AppendOnlyLog.append가 자신의 임계구역에서
+ * hwm 기반으로 발급한다(§3). 서비스는 나머지 필드만 채워 draft를 만들고
+ * append에 넘긴다 — 발급 주체가 로그 단독임을 타입으로 강제한다.
+ */
+export type EventEnvelopeDraft = Omit<EventEnvelope, 'lamport' | 'origin'> & {
+  origin: Omit<EventOrigin, 'seq'>;
+};
+
+/** makeEnvelope 입력. eventId·wallClock은 팩토리가 발급한다. */
+export interface MakeEnvelopeInput {
+  domain: EventDomain;
+  payload: unknown;
+  /** machineId·daemonEpoch. seq는 append가 발급하므로 여기 없음. */
+  origin: Omit<EventOrigin, 'seq'>;
+  authContext: AuthContext;
+  idempotencyKey?: string;
+  causalRefs?: string[];
+}
+
+/**
+ * envelope 초안 팩토리 (§1, §5). eventId(randomUUID)·wallClock(Date.now)을
+ * 확정하고, 순서 필드는 append가 채우도록 비운다.
+ */
+export function makeEnvelope(input: MakeEnvelopeInput): EventEnvelopeDraft {
+  const draft: EventEnvelopeDraft = {
+    eventId: randomUUID(),
+    origin: {
+      machineId: input.origin.machineId,
+      daemonEpoch: input.origin.daemonEpoch,
+    },
+    wallClock: Date.now(),
+    authContext: {
+      principalId: input.authContext.principalId,
+      verifiedWorkspaceId: input.authContext.verifiedWorkspaceId,
+      trustTier: input.authContext.trustTier,
+    },
+    domain: input.domain,
+    payload: input.payload,
+  };
+  // 옵셔널은 값이 있을 때만 실어 로그 줄을 깨끗하게 유지(additive 관례).
+  if (input.idempotencyKey !== undefined) {
+    draft.idempotencyKey = input.idempotencyKey;
+  }
+  if (input.causalRefs !== undefined) {
+    draft.causalRefs = input.causalRefs;
+  }
+  return draft;
+}

--- a/src/shared/machineId.ts
+++ b/src/shared/machineId.ts
@@ -1,0 +1,128 @@
+/**
+ * origin.machineId — 민팅·로드·레코드-복구 순수 로직 (envelope-design §8).
+ *
+ * 생애·소재 계약(§8, 패널 C8):
+ *   - machineId는 설치 생애 **영구 불변**. Q4에도 교체하지 않는다(계보 연속성).
+ *     페어링 신원은 별도 origin.keyId(additive)로 얹는다.
+ *   - 소재는 `events/machine-id`, **로그와 동일 fate**. 로그가 소실되면 이 파일도
+ *     함께 소실 → 재민팅 → 새 origin 계보 → `(machineId, seq)` 재사용이 구조적으로
+ *     불가능. 로그 밖(예: ~/.wmux/machine-id)에 두면 로그만 소실됐을 때 옛
+ *     machineId가 살아남아 소실된 seq들이 재사용된다(전역 유일성 붕괴).
+ *   - 부분 소실 복구: machine-id 파일만 없고 세그먼트가 살아 있으면, 아무 레코드의
+ *     origin.machineId에서 값을 복구해 재기록한다(재민팅 금지 — 세그먼트가 증거).
+ *
+ * shared 레이어 파일이라 daemon/util에 의존하지 않는다. machine-id는 JSON이 아닌
+ * 원시 UUID 문자열이므로, §2.3 durable 시퀀스(tmp write→tmp fsync→rename→dir fsync)를
+ * 자체 구현한다(atomicWrite core.ts의 JSON durable 경로와 동형 계약).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { randomUUID } from 'node:crypto';
+
+const MACHINE_ID_FILE = 'machine-id';
+
+/** §8: 설치 신원 신규 민팅. */
+export function mintMachineId(): string {
+  return randomUUID();
+}
+
+/** `events/machine-id` 경로. */
+export function machineIdPath(eventsDir: string): string {
+  return path.join(eventsDir, MACHINE_ID_FILE);
+}
+
+/** 파일에서 로드. 부재/공백이면 null. */
+export function readMachineId(eventsDir: string): string | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(machineIdPath(eventsDir), 'utf-8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return null;
+    throw err;
+  }
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * durable 기록 (§2.3): tmp write → tmp fsync → rename → 부모 dir fsync.
+ * win32는 디렉토리 fsync 미지원 — 4단계 스킵(§2.3 win32 잔여).
+ */
+export function writeMachineId(eventsDir: string, id: string): void {
+  fs.mkdirSync(eventsDir, { recursive: true });
+  const target = machineIdPath(eventsDir);
+  const tmp = `${target}.tmp.${process.pid}`;
+  const fd = fs.openSync(tmp, 'w', 0o600);
+  try {
+    fs.writeSync(fd, id);
+    fs.fsyncSync(fd); // rename 전 내용 내구화(§2.3-2)
+  } finally {
+    fs.closeSync(fd);
+  }
+  fs.renameSync(tmp, target);
+  fsyncDir(eventsDir); // rename(디렉토리 엔트리) 내구화(§2.3-4)
+}
+
+function fsyncDir(dir: string): void {
+  if (process.platform === 'win32') return; // §2.3 win32 잔여
+  let dirFd = -1;
+  try {
+    dirFd = fs.openSync(dir, 'r');
+    fs.fsyncSync(dirFd);
+  } catch {
+    // best-effort — 디렉토리 fsync 미지원 파일시스템은 §2.3 수용 잔여
+  } finally {
+    if (dirFd >= 0) {
+      try {
+        fs.closeSync(dirFd);
+      } catch {
+        /* noop */
+      }
+    }
+  }
+}
+
+/** 레코드 배열에서 machineId 복구(§8 재민팅 금지 근거). 첫 유효값 반환. */
+export function recoverMachineIdFromRecords(
+  records: ReadonlyArray<{ origin?: { machineId?: unknown } }>,
+): string | undefined {
+  for (const rec of records) {
+    const mid = rec.origin?.machineId;
+    if (typeof mid === 'string' && mid.length > 0) return mid;
+  }
+  return undefined;
+}
+
+export interface ResolveMachineIdOptions {
+  /**
+   * 파일 부재 시, 살아있는 세그먼트 레코드에서 machineId를 복구하는 훅(§8).
+   * 값을 반환하면 재민팅하지 않고 그 값을 재기록한다.
+   */
+  recoverFromRecords?: () => string | undefined;
+}
+
+/**
+ * 로드 → (부재 시) 레코드 복구 → (그래도 부재 시) 민팅 순서로 machineId 확정(§8).
+ * 어느 경로든 결과를 durable 기록해 다음 부트가 재사용하도록 한다.
+ */
+export function resolveMachineId(
+  eventsDir: string,
+  opts: ResolveMachineIdOptions = {},
+): string {
+  const existing = readMachineId(eventsDir);
+  if (existing) return existing;
+
+  const recovered = opts.recoverFromRecords?.();
+  if (recovered) {
+    // 세그먼트가 증거 — 재민팅 금지, 복구값 재기록(§8 부분 소실 복구).
+    writeMachineId(eventsDir, recovered);
+    return recovered;
+  }
+
+  const minted = mintMachineId();
+  writeMachineId(eventsDir, minted);
+  return minted;
+}


### PR DESCRIPTION
## 요약
envelope-design-2026-07-06.md §10 PR1 — 순수 라이브러리, 서비스 미배선.

- **`src/shared/eventlog.ts` (신설, PROTOCOL)**: `EventEnvelope`·`EventDomain`·`TrustTier`·`EventEnvelopeDraft` + `makeEnvelope()`. additive-only 규약. 순서 필드(lamport·origin.seq)는 Draft 타입에서 제외해 로그 단독 발급을 타입으로 강제.
- **`src/daemon/eventlog/AppendOnlyLog.ts` (신설)**: 세그먼트드 NDJSON writer. `append(): Promise<boolean>`, fsync 코얼레싱(§2.5) + 배치 단일 롤백(ftruncate 1회 + 전원 false, §2.4-4), short-write 루프, 전방 스캔·최초 불량 절단(§2.6, at-least-once 승격), 롤 직후 빈 세그먼트 first-boot 오인 방지(§2.8·§3), lamport/seq hwm pre-increment(gap 허용·재사용 금지).
- **`src/shared/machineId.ts` (신설)**: 민팅·로드·레코드-복구(§8). 영구 불변·로그 동일 fate.
- **`src/daemon/util/atomicWrite/core.ts` (수정)**: additive `durable?: boolean`(§2.3 D13 — tmp fsync→rename→dir fsync, win32 잔여 문서화). 기본 경로 1비트 불변(테스트로 고정).

## 테스트 (신규 22건)
- T-크래시 3(승격/torn중간 부분승격금지/전량승격) · T-fsync실패 1(단일 ftruncate+전원 false+replay 미출현) · T-롤크래시 3 · T-lamport 3(max+1/gap/승격 hwm 반영)
- makeEnvelope 3 · machineId 6 · durable 3

## 검증
- `npx tsc --noEmit` + `npx tsc --noEmit -p tsconfig.daemon.json` 그린
- `npm run test:parallel` 377 파일 / 4951 테스트 통과

## 스펙 대비 편차 (4건, 시멘틱 이탈 없음)
1. `makeEnvelope` 시그니처 — 위치인자 대신 옵션객체(authContext·origin은 데몬 서버측 발급이라 2인자 불가)
2. eventId·wallClock 발급을 `makeEnvelope`에서(lamport·seq만 append 임계구역), `log.append(makeEnvelope(...))`가 동일 논리연산
3. prototype-pollution reviver를 AppendOnlyLog에 인라인(core.ts 편집을 durable 옵션으로만 제한)
4. machineId durable write 자체 구현(shared→daemon 의존 회피, raw UUID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbgDknLN83nVzoC6V3qeXk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a durable event log with crash-safe append behavior, segmented storage, recovery after incomplete writes, and automatic resume from the last valid event.
  * Added a shared event envelope format for creating log-ready events without log-issued fields.
  * Added persistent machine identity support for event records, including recovery from existing event history.
  * Added durable atomic write support for safer file updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->