### PR TITLE
feat(env): stop persisting credential values to disk and RPC (env-passthrough PR2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **환경변수 정책이 pane 종류에 따라 달라진다 — 사용자가 직접 연 셸은 이제 자격증명 변수를 그대로 물려받는다 (env-passthrough PR1).** 이전에는 `*_KEY`·`*_TOKEN`·`*_SECRET`·`*_PASSWORD`류 이름의 환경변수가 모든 pane에서 일괄 제거되어, 사용자가 wmux 셸에서 손수 실행한 Claude Code·MCP 서버가 `${KAD_GATEWAY_KEY}` 같은 변수를 빈 값으로 치환하고 "Missing environment variables"로 연결에 실패했다. 이제 정책은 변수 이름이 아니라 **스폰 출처(실행 컨텍스트)** 로 갈린다: 사용자가 UI로 직접 연 인터랙티브 셸 pane은 다른 터미널(tmux·Windows Terminal)처럼 OS 자격증명 변수를 투과받고(단 wmux/Electron 내부 auth는 계속 차단), wmux가 자율 스폰한 에이전트·감독 exec pane은 종전대로 자격증명을 차단한다. 분류는 fail-closed — 출처가 불명확한 스폰은 자격증명이 새는 방향이 아니라 차단되는 방향으로 떨어진다. 에이전트 pane에서 자격증명이 차단되면 어떤 변수가 제외됐는지 로컬 로그 한 줄로 남겨 "왜 없지?"를 즉시 답한다. (secret 값의 디스크 비영속화·명시적 grant 통로·Windows 레지스트리 신선 병합은 후속 PR2·PR3.)
 
+### Security
+
+- **세션 환경변수의 자격증명 값이 더 이상 디스크·RPC에 남지 않는다 (env-passthrough PR2).** PR1이 사용자 셸에 자격증명 변수를 투과시키면서, 그 값이 데몬 세션 메타를 통해 `~/.wmux/sessions.json`에 평문으로 저장되고 `daemon.listSessions` RPC로 노출되기 시작했다. 이제 데몬은 세션 상태를 디스크에 쓰거나 RPC로 반환하는 **모든 직렬화 경계**(정상 저장·30초 스냅샷·종료 시 suspend 저장·Windows 동기 종료 폴백·`daemon.listSessions`·`daemon.createSession` 응답)에서 자격증명 이름의 변수 **값**을 제거한다. 값은 자식 프로세스를 스폰하는 인메모리 환경에만 존재하고(스폰·감독 재시작은 영향 없음), 비자격 변수(`PATH`·로케일·wmux identity)는 그대로 보존된다. 부팅 시 기존 `sessions.json`과 모든 `.bak` 백업 슬롯을 1회 스크럽해 과거에 저장된 자격증명을 제거하며, 이 마이그레이션은 total·non-throwing이라 손상된 항목이 있어도 세션을 잃지 않는다. 한계: 데몬 재기동으로 복구된 pane은 재기동 후 자격증명을 다시 받지 못한다(새 pane을 열면 반영 — 명시적 grant 통로와 라이브 재해석은 PR3).
+
 ## [3.17.0] — 2026-07-06
 
 ### Added

--- a/plans/env-passthrough-pr2-design-2026-07-08.md
+++ b/plans/env-passthrough-pr2-design-2026-07-08.md
@@ -1,0 +1,160 @@
+# env-passthrough PR2 설계 — secret 값 비영속 (직렬화 경계 strip + 마이그레이션)
+
+작성: 2026-07-08 | 베이스: PR1(`feat/env-execution-context`) 위 스택 | 대상: E-CRIT-4/1
+
+## 1. 동기 — PR1이 노출을 넓혔다
+
+PR1 이전에는 모든 pane이 gated라 `meta.env`에 자격증명이 아예 없었다. PR1 이후
+**사용자 셸(passthrough)은 자격증명을 투과받고**, 그 resolved env가 데몬 세션 메타로
+들어간다. 그런데 그 메타는:
+
+- **디스크에 평문 영속** — `buildState`(`daemon/index.ts:2620`)가 `listSessions()`를
+  그대로 `sessions.json`에 씀.
+- **RPC로 노출** — `daemon.listSessions`(`daemon/index.ts:1276,1291`)가 `{...s}`(env
+  포함)를 반환. 데몬 토큰을 가진 **모든** same-user 프로세스(도그푸드 MCP 포함)가
+  전 세션의 env를 읽음.
+
+즉 PR1은 사용자의 `GITHUB_TOKEN`·`KAD_GATEWAY_KEY` 등을 `~/.wmux/sessions.json`
+평문 + 데몬 RPC로 흘리기 시작했다. **이건 새 기능이 아니라 PR1이 넓힌 유출 — 최우선 차단.**
+
+## 2. 근본 원인 (코드 확정)
+
+- 데몬은 `meta.env`(resolved, 자격증명 값 포함)를 **직렬화 경계에서 그대로** 내보낸다.
+  인메모리 메타와 직렬화/공개 표현이 분리돼 있지 않다.
+- 데몬 인증(`DaemonPipeServer.ts:436-447`)은 토큰 일치만 검증하고 **caller 신원을
+  구분하지 않는다**. pane도 토큰을 보유하므로, 데몬 RPC 게이트만으론 pane과 main을
+  못 가른다 → grant를 데몬이 해석하면 self-grant 벡터(E-CRIT-7).
+
+## 3. 설계 — 인메모리 full env ↔ 직렬화 stripped env 분리
+
+**원칙: 자격증명 *값*은 인메모리 spawn env에만 존재하고, 디스크·RPC로 나가는 어떤
+표현에도 담기지 않는다.**
+
+### 3.1 직렬화 경계 strip (핵심)
+- `shared/envFilter`에 `stripCredentialValues(env)` 추가 — `isCredentialEnvKey`가 참인
+  키를 제거한 fresh 사본(내부 WMUX_*/identity/PATH/LANG 등 비자격 키는 보존).
+- 적용 지점 2곳:
+  - `daemon.listSessions` 응답 — 각 세션의 `env`를 stripped로 치환 (RPC 유출 차단).
+  - `buildState` — 영속 직전 세션 `env`를 stripped로 치환 (디스크 유출 차단).
+- **인메모리 `ManagedSession.meta.env`는 full 유지** — spawn(`DaemonSessionManager`
+  createSession)과 in-daemon suspend→restore가 이걸 직접 쓰므로 무영향.
+
+### 3.2 in-daemon vs cross-restart 복구 구분
+- **in-daemon 복구**(suspend/restore, 같은 데몬 생애): 인메모리 meta.env(full) 사용 →
+  자격증명 유지 (동작 불변).
+- **cross-restart 복구**(데몬 재기동, sessions.json에서): stripped env 사용 → 자격증명
+  **부재**. 이는 수용된 저하 — PR3의 live 재해석이 이걸 닫는다. 릴리스 노트 명시.
+  (PR1 이전에도 재기동 후 gated pane은 자격증명이 없었으니, 사용자 셸에 한해 "재기동
+  후 새 pane을 열어야 자격증명 복귀"라는 기존 한계와 동일 계열.)
+
+### 3.3 마이그레이션 스크럽
+- 데몬 부팅 로드 시 기존 `sessions.json`의 각 세션 env에서 자격증명 값을 스크럽.
+- `DaemonState.version`을 1→2로 범프, 로드 시 `.bak` 백업 후 스크럽본 저장.
+- 스크럽 실패/파싱 오류는 fail-safe: 원본 보존 + 경고(세션을 잃느니 유출 위험을
+  로그로 알리고 다음 저장 때 재시도). 절대 세션 목록을 통째로 드롭하지 않는다.
+
+## 4. 왜 grant 서비스는 이 PR에서 빼는가
+
+- **결합 리스크**: 명시 grant는 "자격증명을 gated pane에 재주입"인데, 재주입한 값은
+  다시 영속되면 안 되고(이 PR의 strip과 상호작용), cross-restart 복구 시 재해석이
+  필요(E-HIGH-6/7, 부팅 순서 위험). 이는 PR3의 live 재해석과 한 몸.
+- **신뢰 경계**: grant는 **main-side 적용**이어야 안전하다(데몬은 caller 구분 불가).
+  즉 main이 env 해석 시 grant된 자격증명을 strip 이후 재주입, 데몬은 여전히 verbatim
+  재생. 이 설계는 데몬 grant 서비스가 불필요함을 의미하고, PR3(live 소스)와 함께
+  구현하는 게 자연스럽다.
+- 따라서 **PR2 = 순수 유출 차단**(능력 추가 없음). grant 능력은 PR3에 편입 권고.
+
+## 5. 변경 파일 (예상)
+- `shared/envFilter.ts` — `stripCredentialValues` 추가 (+테스트).
+- `daemon/index.ts` — `daemon.listSessions` 응답 strip, `buildState` 영속 strip.
+- `daemon/StateWriter.ts`(로드 경로) 또는 `daemon/index.ts` 부팅 — 마이그레이션 스크럽
+  + version 2 + 백업.
+- 테스트: strip 순수 함수, listSessions RPC 미유출, 영속 미유출, 마이그레이션 멱등·
+  fail-safe, in-daemon 복구 자격증명 유지.
+
+## 6. 수용 기준
+- [ ] 사용자 셸(passthrough) pane 생성 후 `sessions.json`에 자격증명 **값**이 없다
+      (이름/비자격 env는 있어도 무방).
+- [ ] `daemon.listSessions` 응답에 자격증명 값이 없다.
+- [ ] in-daemon suspend→restore 후 셸이 여전히 자격증명을 본다(동작 불변).
+- [ ] 기존 자격증명 함유 `sessions.json`이 부팅 시 스크럽되고 `.bak` 백업이 남는다.
+- [ ] 마이그레이션 파싱 실패 시 세션 목록을 잃지 않는다(fail-safe).
+- [ ] PR1 회귀 없음(정책 분기·투과·게이트 불변).
+
+## 7. Non-goals
+- 명시 grant 통로(자격증명 재주입) — PR3.
+- cross-restart 복구의 자격증명 재해석 / live 소스(EnvSource) — PR3.
+- identity 1급 필드화 — 이 PR의 strip은 WMUX_* 를 보존하므로 `pty:list`의
+  `s.env[WMUX_SURFACE_ID]` 복원이 계속 동작(불필요). 필요 시 PR3.
+- Windows 레지스트리 병합 — PR3.
+
+## 8. 리스크
+- **마이그레이션이 최대 리스크**: 스크럽이 비자격 env(PATH/LANG/identity)를 잘못
+  지우면 재기동 후 전 세션 셸이 깨진다. `stripCredentialValues`는 자격증명 키만
+  건드리고(화이트리스트 아닌 좁은 블랙리스트), 백업 + fail-safe로 방어.
+- 병렬 데몬 작업(완료증거·envelope)과 `daemon/index.ts` 충돌면 — 최소 diff·additive로.
+
+---
+
+# Eng Review 개정 (2026-07-08, Codex + Claude eng 서브에이전트 확정)
+
+§3~§5의 "buildState + listSessions strip"은 **불완전·위험**으로 판명. 아래로 대체.
+
+## R1. chokepoint = StateWriter (디스크), NOT buildState
+
+buildState+listSessions는 디스크 writer 3개를 놓친다(양 모델 확정):
+- `snapshotRunner.ts:71,85` — 자체 DaemonState를 listSessions()로 만들어 30초/생성마다 저장
+- `index.ts:2755` — shutdown suspend가 `managedSessions.map(m => ({...m.meta}))` **직접**
+  직렬화(buildState·listSessions 둘 다 우회) — **재부팅 복구의 주 영속 경로**
+- `index.ts:3490` — Windows sync-exit 폴백이 위와 동일
+
+**해결**: `StateWriter`(sessions.json의 **유일한** writer)에 private `toPersistable(state)`
+—각 `session.env`를 `stripCredentialValues`로 **교체(fresh 사본)** — 를 두고 모든 write
+경로(saveImmediate·async 큐 task·sync 폴백·flushSync)에 적용. 이러면 위 3개 + 미래
+writer까지 **구조적으로** 커버.
+
+## R2. 마이그레이션 = 버전 레지스트리 폐기, 부팅 스크럽으로
+
+버전 범프(1→2 레지스트리 스텝)는 3중 하자(양 모델 확정):
+- premigrate/`.bak`/rotation `.bak.N`이 **원본 자격증명을 영구 보존**(core.ts:490,
+  rotation.ts:48, migrate.ts:278) — 스크럽하려는 그 secret이 백업에 남음
+- 던지는 마이그레이터 = parse 실패 취급 → 백업 폴백 → 전 세션 드롭(core.ts:537)
+- 4개 writer가 `version:1` 하드코딩 → 범프해도 매 저장이 되돌려 **매 부팅 재실행**;
+  v0/no-version은 exact-step 부재로 throw→세션 상실(migrate.ts:126)
+
+**해결(레지스트리 안 씀)**: 부팅 시 load()+recovery 후,
+1. 기존 `sessions.json` **주 파일 + 모든 `.bak`/`.bak.N` 슬롯**을 1회 in-place 스크럽
+   (각각 read→`stripCredentialValues`→원자적 rewrite; 없으면 skip). total·non-throwing —
+   env가 없거나 non-object면 `{}`로 두고 세션은 **보존**(절대 throw/드롭 금지).
+2. 이후 정상 write는 R1의 StateWriter strip으로 자동 clean 유지(rename된 `.bak`도
+   이미 스크럽된 주 파일에서 오므로 clean).
+- 레거시 함유 파일은 load가 인메모리로 자격증명을 올려 **첫 recovery는 자격증명 유지**
+  (graceful), 직후 스크럽으로 at-rest 제거.
+
+## R3. RPC 노출도 닫기 (fresh 사본)
+
+- `daemon.listSessions`(index.ts:1276,1291) — 응답의 각 env를 stripped로 **교체**.
+- `daemon.createSession` 반환(index.ts:1122) — main은 `pid`만 씀(pty.handler:443) →
+  **최소 반환**(pid 등)으로 축소하거나 env strip.
+
+## R4. fresh 사본 교체, in-place mutation 금지 (핵심 버그 예방)
+
+`listSessions`는 `{...m.meta}` shallow copy라 `.env`가 **live meta.env와 동일 참조**
+(DaemonSessionManager.ts:665). `delete s.env[k]`로 in-place 수정하면 **live env 오염 →
+spawn/supervised-restart 붕괴**. 반드시 `{...s, env: stripCredentialValues(s.env)}`로
+**참조 교체**. `stripCredentialValues`는 fresh 반환(buildFilteredEnv 재사용)이지만,
+호출부가 반환값으로 **교체**해야 안전.
+
+## R5. 개정 수용 기준 (추가)
+- [ ] shutdown suspend·30초 스냅샷·Windows sync-exit 저장 후에도 sessions.json에
+      자격증명 값 없음 (StateWriter chokepoint 실증).
+- [ ] 부팅 후 주 파일 + 모든 `.bak` 슬롯에 자격증명 값 없음.
+- [ ] `daemon.createSession`/`daemon.listSessions` 응답에 자격증명 값 없음.
+- [ ] strip이 live 인메모리 meta.env를 오염시키지 않음(스폰·supervised-restart 불변).
+- [ ] env가 non-object인 세션도 마이그레이션에서 보존됨(throw 없음).
+
+## R6. 문구 정정
+"in-daemon suspend→restore"는 부정확 — suspended 세션의 in-daemon restore는 없다
+(attach/resize가 throw, DaemonSessionManager.ts:616/636). 유일한 in-daemon 재기동은
+`restartSupervisedSession`(dead 세션, index.ts:986, live meta.env 사용). §3.2 문구를
+"in-daemon supervised-restart는 live meta.env 사용"으로 정정.

--- a/src/daemon/StateWriter.ts
+++ b/src/daemon/StateWriter.ts
@@ -31,7 +31,12 @@ function toPersistable(state: DaemonState): DaemonState {
  * 값을 제거한다. PR1 이후 사용자 셸(passthrough)의 자격증명이 평문으로 남은 레거시
  * 파일을 정리 — recovery(load) 전에 호출해 이후 로드가 스크럽본을 읽게 한다.
  * total·non-throwing: 읽기/파싱 실패한 슬롯은 건너뛰고, 세션 목록은 절대 드롭하지 않는다.
- * rotation 없이 임시파일→rename으로 슬롯 자체를 제자리 스크럽(백업의 백업을 만들지 않음).
+ * rotation 없이 임시파일→fsync→rename으로 슬롯 자체를 제자리 스크럽(백업의 백업 없음).
+ *
+ * 범위: 주 파일 + rotation 백업(.bak~.bak.3)만. `*.premigrate.bak`(migrate)·`corrupted/`
+ * (quarantine) 사본은 대상 아님 — 현재 DAEMON_STATE_REGISTRY가 identity라 premigrate
+ * 스냅샷이 생성되지 않고, quarantine은 파싱 불가 파일만 격리하므로 오늘은 무해. 실제
+ * daemon-state 마이그레이션 스텝을 추가하면 그때 이 두 경로도 스크럽 대상에 포함해야 한다.
  */
 export function scrubPersistedCredentials(baseDir: string): void {
   const primary = path.join(baseDir, 'sessions.json');
@@ -45,17 +50,35 @@ export function scrubPersistedCredentials(baseDir: string): void {
       if (!parsed || !Array.isArray(parsed.sessions)) continue;
       let changed = false;
       for (const session of parsed.sessions) {
-        if (!session || typeof session.env !== 'object' || session.env === null) continue;
-        const before = Object.keys(session.env as Record<string, string>).length;
-        const stripped = stripCredentialValues(session.env as Record<string, string>);
+        if (!session || !('env' in session)) continue; // env 없는 세션은 그대로 보존
+        const env = session.env;
+        if (env === null || typeof env !== 'object') {
+          // 비객체 env(예: 손상/수기편집으로 문자열 "GITHUB_TOKEN=ghp...")는 자격증명을
+          // 숨길 수 있으므로 빈 객체로 교체 — skip하면 그 문자열이 그대로 남는다(Codex
+          // 리뷰). stripCredentialValues의 non-object→{} 계약과 일치.
+          session.env = {};
+          changed = true;
+          continue;
+        }
+        const before = Object.keys(env as Record<string, string>).length;
+        const stripped = stripCredentialValues(env as Record<string, string>);
         if (Object.keys(stripped).length !== before) {
           session.env = stripped;
           changed = true;
         }
       }
       if (!changed) continue;
+      // fsync 후 rename — 부팅 배치 스크럽이 여러 슬롯(주+.bak.N)을 연달아 다시 쓰는데,
+      // 플러시 없이 rename만 하면 전원 손실 시 모든 슬롯이 동시에 찢겨 load가 유효 슬롯을
+      // 못 찾는다(3모델 리뷰 F2). 슬롯당 1회 부팅 비용이라 fsync 오버헤드는 무시 가능.
       const tmp = `${file}.scrub.tmp`;
-      fs.writeFileSync(tmp, JSON.stringify(parsed), { encoding: 'utf-8', mode: 0o600 });
+      const fd = fs.openSync(tmp, 'w', 0o600);
+      try {
+        fs.writeSync(fd, JSON.stringify(parsed));
+        fs.fsyncSync(fd);
+      } finally {
+        fs.closeSync(fd);
+      }
       fs.renameSync(tmp, file);
     } catch (err) {
       // total·non-throwing — 한 슬롯 실패가 다른 슬롯이나 부팅을 막지 않는다.

--- a/src/daemon/StateWriter.ts
+++ b/src/daemon/StateWriter.ts
@@ -7,8 +7,62 @@ import {
   atomicWriteJSONSync,
   createMigrator,
   DAEMON_STATE_REGISTRY,
+  BACKUP_SUFFIXES,
 } from './util/atomicWrite';
 import { AsyncQueue } from './util/AsyncQueue';
+import { stripCredentialValues } from '../shared/envFilter';
+
+/**
+ * 영속 직전 자격증명 *값*을 제거한 DaemonState fresh 사본. 모든 sessions.json write
+ * 경로(saveImmediate·saveDebounced·flushSync·race-recovery)가 이걸 거치므로, 자격증명은
+ * 인메모리 meta.env에만 존재하고 디스크에는 절대 도달하지 않는다. 세션의 다른 필드와
+ * 비자격 env(PATH·identity 등)는 보존. **fresh 사본** — live 인메모리 meta를 오염시키지
+ * 않는다(스폰/supervised-restart는 인메모리 env를 그대로 씀).
+ */
+function toPersistable(state: DaemonState): DaemonState {
+  return {
+    ...state,
+    sessions: state.sessions.map((s) => ({ ...s, env: stripCredentialValues(s.env) })),
+  };
+}
+
+/**
+ * 부팅 1회 레거시 스크럽: 기존 sessions.json 주 파일 + 모든 .bak 슬롯에서 자격증명
+ * 값을 제거한다. PR1 이후 사용자 셸(passthrough)의 자격증명이 평문으로 남은 레거시
+ * 파일을 정리 — recovery(load) 전에 호출해 이후 로드가 스크럽본을 읽게 한다.
+ * total·non-throwing: 읽기/파싱 실패한 슬롯은 건너뛰고, 세션 목록은 절대 드롭하지 않는다.
+ * rotation 없이 임시파일→rename으로 슬롯 자체를 제자리 스크럽(백업의 백업을 만들지 않음).
+ */
+export function scrubPersistedCredentials(baseDir: string): void {
+  const primary = path.join(baseDir, 'sessions.json');
+  const targets = [primary, ...BACKUP_SUFFIXES.map((suffix) => `${primary}${suffix}`)];
+  for (const file of targets) {
+    try {
+      if (!fs.existsSync(file)) continue;
+      const parsed = JSON.parse(fs.readFileSync(file, 'utf-8')) as {
+        sessions?: Array<{ env?: unknown }>;
+      } | null;
+      if (!parsed || !Array.isArray(parsed.sessions)) continue;
+      let changed = false;
+      for (const session of parsed.sessions) {
+        if (!session || typeof session.env !== 'object' || session.env === null) continue;
+        const before = Object.keys(session.env as Record<string, string>).length;
+        const stripped = stripCredentialValues(session.env as Record<string, string>);
+        if (Object.keys(stripped).length !== before) {
+          session.env = stripped;
+          changed = true;
+        }
+      }
+      if (!changed) continue;
+      const tmp = `${file}.scrub.tmp`;
+      fs.writeFileSync(tmp, JSON.stringify(parsed), { encoding: 'utf-8', mode: 0o600 });
+      fs.renameSync(tmp, file);
+    } catch (err) {
+      // total·non-throwing — 한 슬롯 실패가 다른 슬롯이나 부팅을 막지 않는다.
+      console.warn(`[StateWriter] credential scrub skipped ${file}:`, (err as Error)?.message ?? err);
+    }
+  }
+}
 
 const DEBOUNCE_MS = 30_000;
 const QUEUE_KEY = 'state';
@@ -78,7 +132,7 @@ export class StateWriter {
     // synchronous atomic-write helper.
     this.queue.setSyncFallback(QUEUE_KEY, () => {
       if (this.pendingState !== null) {
-        atomicWriteJSONSync(this.filePath, this.pendingState, {
+        atomicWriteJSONSync(this.filePath, toPersistable(this.pendingState), {
           validate: StateWriter.isDaemonState,
           rotationEnabled: true,
         });
@@ -112,7 +166,7 @@ export class StateWriter {
     // handles that case.)
     this.queue.clear();
     try {
-      atomicWriteJSONSync(this.filePath, state, {
+      atomicWriteJSONSync(this.filePath, toPersistable(state), {
         validate: StateWriter.isDaemonState,
         rotationEnabled: true,
       });
@@ -152,7 +206,7 @@ export class StateWriter {
         // that fires while atomicWriteJSON is mid-flight.
         const epochAtStart = this.immediateEpoch;
         try {
-          await atomicWriteJSON(this.filePath, payload, {
+          await atomicWriteJSON(this.filePath, toPersistable(payload), {
             validate: StateWriter.isDaemonState,
             rotationEnabled: true,
           });
@@ -165,7 +219,7 @@ export class StateWriter {
             this.lastImmediateState !== null
           ) {
             try {
-              atomicWriteJSONSync(this.filePath, this.lastImmediateState, {
+              atomicWriteJSONSync(this.filePath, toPersistable(this.lastImmediateState), {
                 validate: StateWriter.isDaemonState,
                 rotationEnabled: true,
               });
@@ -291,7 +345,7 @@ export class StateWriter {
       const state = this.pendingState;
       this.pendingState = null;
       try {
-        atomicWriteJSONSync(this.filePath, state, {
+        atomicWriteJSONSync(this.filePath, toPersistable(state), {
           validate: StateWriter.isDaemonState,
           rotationEnabled: true,
         });

--- a/src/daemon/__tests__/StateWriter.scrub.test.ts
+++ b/src/daemon/__tests__/StateWriter.scrub.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { scrubPersistedCredentials } from '../StateWriter';
+
+// PR2 부팅 마이그레이션: 기존 sessions.json 주 파일 + .bak 슬롯에서 자격증명 값을
+// 스크럽하되, total·non-throwing이라 세션을 절대 잃지 않는다.
+describe('scrubPersistedCredentials', () => {
+  let dir: string;
+  const primary = (): string => path.join(dir, 'sessions.json');
+  const readSessions = (file: string): Array<{ id: string; env?: Record<string, unknown> }> =>
+    JSON.parse(fs.readFileSync(file, 'utf-8')).sessions;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-scrub-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('주 파일에서 자격증명 값을 제거하고 비자격 env·세션은 보존', () => {
+    fs.writeFileSync(primary(), JSON.stringify({
+      version: 1,
+      sessions: [
+        { id: 'a', env: { PATH: '/usr/bin', WMUX_SURFACE_ID: 's1', GITHUB_TOKEN: 'ghp', KAD_GATEWAY_KEY: 'sec' } },
+        { id: 'b', env: { PATH: '/bin' } },
+      ],
+    }));
+    scrubPersistedCredentials(dir);
+    const sessions = readSessions(primary());
+    expect(sessions).toHaveLength(2);               // 세션 보존
+    expect(sessions[0].env!.PATH).toBe('/usr/bin'); // 비자격 보존
+    expect(sessions[0].env!.WMUX_SURFACE_ID).toBe('s1');
+    expect(sessions[0].env!.GITHUB_TOKEN).toBeUndefined(); // 자격증명 제거
+    expect(sessions[0].env!.KAD_GATEWAY_KEY).toBeUndefined();
+    expect(sessions[1].env!.PATH).toBe('/bin');
+  });
+
+  it('.bak 슬롯도 스크럽', () => {
+    const bak = `${primary()}.bak`;
+    fs.writeFileSync(bak, JSON.stringify({
+      version: 1, sessions: [{ id: 'a', env: { PATH: '/p', ANTHROPIC_API_KEY: 'sk' } }],
+    }));
+    // 주 파일도 있어야 스크럽 루프가 도는 게 아니라 각 슬롯 독립 — 주 파일 없이도 .bak 처리
+    scrubPersistedCredentials(dir);
+    expect(readSessions(bak)[0].env!.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(readSessions(bak)[0].env!.PATH).toBe('/p');
+  });
+
+  it('env가 non-object인 세션도 드롭하지 않음(non-throwing)', () => {
+    fs.writeFileSync(primary(), JSON.stringify({
+      version: 1,
+      sessions: [
+        { id: 'a', env: null },
+        { id: 'b' },                    // env 없음
+        { id: 'c', env: { API_KEY: 'x', PATH: '/p' } },
+      ],
+    }));
+    expect(() => scrubPersistedCredentials(dir)).not.toThrow();
+    const sessions = readSessions(primary());
+    expect(sessions.map((s) => s.id)).toEqual(['a', 'b', 'c']); // 전부 보존
+    expect(sessions[2].env!.API_KEY).toBeUndefined();
+    expect(sessions[2].env!.PATH).toBe('/p');
+  });
+
+  it('파일 부재·손상 JSON에서 throw하지 않고 다른 슬롯은 계속 처리', () => {
+    // 주 파일은 손상, .bak은 정상 — .bak은 스크럽돼야 하고 전체는 throw 없음
+    fs.writeFileSync(primary(), '{ this is not json');
+    fs.writeFileSync(`${primary()}.bak`, JSON.stringify({
+      version: 1, sessions: [{ id: 'a', env: { GH_TOKEN: 't', HOME: '/h' } }],
+    }));
+    expect(() => scrubPersistedCredentials(dir)).not.toThrow();
+    expect(readSessions(`${primary()}.bak`)[0].env!.GH_TOKEN).toBeUndefined();
+    expect(readSessions(`${primary()}.bak`)[0].env!.HOME).toBe('/h');
+  });
+
+  it('자격증명이 없으면 파일을 건드리지 않음(불필요한 rewrite 회피)', () => {
+    fs.writeFileSync(primary(), JSON.stringify({ version: 1, sessions: [{ id: 'a', env: { PATH: '/p' } }] }));
+    const mtimeBefore = fs.statSync(primary()).mtimeMs;
+    scrubPersistedCredentials(dir);
+    // changed=false면 rewrite 안 함 — 세션은 그대로
+    expect(readSessions(primary())[0].env!.PATH).toBe('/p');
+    expect(mtimeBefore).toBeGreaterThan(0);
+  });
+});

--- a/src/daemon/__tests__/StateWriter.scrub.test.ts
+++ b/src/daemon/__tests__/StateWriter.scrub.test.ts
@@ -48,20 +48,24 @@ describe('scrubPersistedCredentials', () => {
     expect(readSessions(bak)[0].env!.PATH).toBe('/p');
   });
 
-  it('env가 non-object인 세션도 드롭하지 않음(non-throwing)', () => {
+  it('비객체 env는 {}로 교체하되 세션은 드롭하지 않음(자격증명 문자열 은닉 차단)', () => {
     fs.writeFileSync(primary(), JSON.stringify({
       version: 1,
       sessions: [
-        { id: 'a', env: null },
-        { id: 'b' },                    // env 없음
-        { id: 'c', env: { API_KEY: 'x', PATH: '/p' } },
+        { id: 'a', env: null },                       // null → {}
+        { id: 'b' },                                  // env 없음 → 그대로
+        { id: 'c', env: 'GITHUB_TOKEN=ghp_leak' },    // 문자열(자격증명 은닉) → {}
+        { id: 'd', env: { API_KEY: 'x', PATH: '/p' } },
       ],
     }));
     expect(() => scrubPersistedCredentials(dir)).not.toThrow();
     const sessions = readSessions(primary());
-    expect(sessions.map((s) => s.id)).toEqual(['a', 'b', 'c']); // 전부 보존
-    expect(sessions[2].env!.API_KEY).toBeUndefined();
-    expect(sessions[2].env!.PATH).toBe('/p');
+    expect(sessions.map((s) => s.id)).toEqual(['a', 'b', 'c', 'd']); // 전부 보존
+    expect(sessions[0].env).toEqual({});              // null → {}
+    expect('env' in sessions[1]).toBe(false);         // env 없던 세션은 그대로
+    expect(sessions[2].env).toEqual({});              // 자격증명 문자열 제거
+    expect(sessions[3].env!.API_KEY).toBeUndefined();
+    expect(sessions[3].env!.PATH).toBe('/p');
   });
 
   it('파일 부재·손상 JSON에서 throw하지 않고 다른 슬롯은 계속 처리', () => {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -6,7 +6,8 @@ import { DaemonSessionManager } from './DaemonSessionManager';
 import { PaneSupervisor } from './PaneSupervisor';
 import { DaemonPipeServer } from './DaemonPipeServer';
 import { SessionPipe } from './SessionPipe';
-import { StateWriter } from './StateWriter';
+import { StateWriter, scrubPersistedCredentials } from './StateWriter';
+import { stripCredentialValues } from '../shared/envFilter';
 import { LanLinkInbox } from './lanlink/inbox';
 import { LanLinkController } from './lanlink/controller';
 import { LanLinkServer } from './lanlink/server';
@@ -1119,7 +1120,8 @@ function registerRpcHandlers(
     // recoverable trace instead of losing the brand-new pane entirely.
     triggerSnapshot();
 
-    return session;
+    // 응답에서 자격증명 값 제거(main은 pid 등만 사용). fresh env 교체 — live meta 불변.
+    return { ...session, env: stripCredentialValues(session.env) };
   });
 
   // daemon.destroySession
@@ -1288,7 +1290,10 @@ function registerRpcHandlers(
       // cwd + existence guards). Strip the meta field, then re-attach the
       // guarded transient one. Without this strip, the carry-forward would
       // bypass the D5/F7 guards (caught by x6-resume-binding-dogfood D/E).
-      const base = { ...s };
+      // 자격증명 값을 뺀 fresh env로 교체 — 데몬 토큰 보유 클라이언트가 RPC로 세션
+      // 자격증명을 읽지 못하게. s.env는 live 인메모리 meta.env와 동일 참조라 in-place
+      // 수정 금지(스폰이 깨짐); stripCredentialValues는 fresh를 반환하므로 교체만 한다.
+      const base = { ...s, env: stripCredentialValues(s.env) };
       delete base.resumeBinding;
       const withRuntime = base.supervision
         ? { ...base, supervisionRuntime: paneSupervisor.getRuntime(s.id) }
@@ -3246,6 +3251,11 @@ async function main(): Promise<void> {
   });
   paneSupervisorRef = paneSupervisor;
 
+  // PR2 레거시 마이그레이션: recovery(load) 전에 기존 sessions.json 주 파일 + 모든
+  // .bak 슬롯에서 자격증명 값을 1회 스크럽. PR1이 사용자 셸 자격증명 투과를 열며 그
+  // 값이 평문으로 영속되기 시작했으므로, 재기동 시 at-rest 자격증명을 제거한다.
+  // (이후 정상 write는 StateWriter의 toPersistable로 자동 clean 유지.)
+  scrubPersistedCredentials(wmuxDir);
   const maxRecover = Math.min(config.session.maxSessions, MAX_RECOVER_SESSIONS);
   await recoverSessions(stateWriter, sessionManager, processMonitor, maxRecover);
   markDaemonBoot('recovery-done');

--- a/src/shared/__tests__/envFilter.test.ts
+++ b/src/shared/__tests__/envFilter.test.ts
@@ -7,6 +7,7 @@ import {
   withheldCredentialNames,
   isInternalEnvKey,
   isCredentialEnvKey,
+  stripCredentialValues,
 } from '../envFilter';
 
 describe('isSensitiveEnvKey', () => {
@@ -173,5 +174,36 @@ describe('withheldCredentialNames', () => {
 
   it('is empty when no credentials are present', () => {
     expect(withheldCredentialNames({ PATH: '/p', HOME: '/h' })).toEqual([]);
+  });
+});
+
+describe('stripCredentialValues (직렬화 경계 — 디스크/RPC)', () => {
+  it('자격증명 값만 제거하고 비자격 env(PATH·identity)는 보존', () => {
+    const stripped = stripCredentialValues({
+      PATH: '/usr/bin',
+      WMUX_SURFACE_ID: 'surf-1',      // identity — 보존 (pty:list 복원 의존)
+      KAD_GATEWAY_KEY: 'secret',       // 자격증명 — 제거
+      GITHUB_TOKEN: 'ghp',             // 자격증명 — 제거
+      SSH_AUTH_SOCK: '/s',             // safe-passthrough — 보존
+    });
+    expect(stripped.PATH).toBe('/usr/bin');
+    expect(stripped.WMUX_SURFACE_ID).toBe('surf-1');
+    expect(stripped.SSH_AUTH_SOCK).toBe('/s');
+    expect(stripped.KAD_GATEWAY_KEY).toBeUndefined();
+    expect(stripped.GITHUB_TOKEN).toBeUndefined();
+  });
+
+  it('fresh 사본을 반환 — 입력을 in-place 수정하지 않음(live meta.env 오염 방지)', () => {
+    const live = { PATH: '/p', GITHUB_TOKEN: 'ghp' };
+    const stripped = stripCredentialValues(live);
+    expect(live.GITHUB_TOKEN).toBe('ghp'); // 원본 불변
+    expect(stripped.GITHUB_TOKEN).toBeUndefined();
+    expect(stripped).not.toBe(live);
+  });
+
+  it('env가 undefined/null/비객체면 빈 객체(마이그레이션 total·non-throwing)', () => {
+    expect(stripCredentialValues(undefined)).toEqual({});
+    expect(stripCredentialValues(null)).toEqual({});
+    expect(stripCredentialValues('not-an-object' as unknown as Record<string, string>)).toEqual({});
   });
 });

--- a/src/shared/__tests__/envFilter.test.ts
+++ b/src/shared/__tests__/envFilter.test.ts
@@ -206,4 +206,27 @@ describe('stripCredentialValues (직렬화 경계 — 디스크/RPC)', () => {
     expect(stripCredentialValues(null)).toEqual({});
     expect(stripCredentialValues('not-an-object' as unknown as Record<string, string>)).toEqual({});
   });
+
+  it('선행 밑줄 없는 well-known 비밀도 제거 (3모델 리뷰 확정)', () => {
+    // `_PASSWORD$`/`_KEY$` 패턴에 안 걸리지만 자격증명인 exact 이름들.
+    for (const name of ['PGPASSWORD', 'MYSQL_PWD', 'SECRET_KEY_BASE', 'LDAPPASSWORD',
+      'AWS_ACCESS_KEY_ID', 'REDIS_URL', 'MONGO_URL', 'MONGODB_URI']) {
+      expect(isCredentialEnvKey(name)).toBe(true);
+    }
+    const stripped = stripCredentialValues({
+      PATH: '/p', PGPASSWORD: 'pg', SECRET_KEY_BASE: 'rails', REDIS_URL: 'redis://u:p@h',
+    });
+    expect(stripped.PATH).toBe('/p');
+    expect(stripped.PGPASSWORD).toBeUndefined();
+    expect(stripped.SECRET_KEY_BASE).toBeUndefined();
+    expect(stripped.REDIS_URL).toBeUndefined();
+  });
+
+  it('exact 추가는 유사 비자격 키를 오탐하지 않음', () => {
+    // exact 이름으로만 넓혔으므로(광역 패턴 아님), 비슷하지만 비밀이 아닌 키는 통과.
+    expect(isCredentialEnvKey('PGPASSFILE')).toBe(false);  // passfile 경로(값이 비밀 아님)
+    expect(isCredentialEnvKey('PGHOST')).toBe(false);
+    expect(isCredentialEnvKey('MYSQL_HOST')).toBe(false);
+    expect(isCredentialEnvKey('REDIS_HOST')).toBe(false);  // REDIS_URL이 아님
+  });
 });

--- a/src/shared/envFilter.ts
+++ b/src/shared/envFilter.ts
@@ -147,3 +147,29 @@ export function withheldCredentialNames(
   }
   return names;
 }
+
+/**
+ * 자격증명 *값*을 뺀 **fresh** env 사본 — 디스크/RPC 직렬화 경계에서 쓴다
+ * (sessions.json 영속, daemon.listSessions/createSession 응답). INTERNAL 키는
+ * 건드리지 않고(스폰에서 이미 처리) 자격증명 이름만 제거하며, 비자격 env(PATH·LANG·
+ * WMUX_* identity)는 보존한다.
+ *
+ * env가 없거나 객체가 아니면 빈 객체를 돌려준다 — 레거시/손상 sessions.json 스크럽이
+ * total·non-throwing이어야 세션을 잃지 않는다.
+ *
+ * **반드시 반환값으로 교체할 것.** 입력 객체를 in-place로 수정하지 않으므로, 호출부는
+ * `{ ...s, env: stripCredentialValues(s.env) }`처럼 참조를 교체해야 한다. listSessions가
+ * 넘기는 env는 live 인메모리 meta.env와 동일 참조라, in-place 삭제 시 스폰이 깨진다.
+ */
+export function stripCredentialValues(
+  env: Record<string, string> | undefined | null,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!env || typeof env !== 'object') return out;
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) continue;
+    if (isCredentialEnvKey(key)) continue;
+    out[key] = value as string;
+  }
+  return out;
+}

--- a/src/shared/envFilter.ts
+++ b/src/shared/envFilter.ts
@@ -45,13 +45,25 @@ const CREDENTIAL_PATTERNS: ReadonlyArray<RegExp> = [
 const CREDENTIAL_EXACT: ReadonlySet<string> = new Set([
   'AWS_SECRET_ACCESS_KEY',
   'AWS_SESSION_TOKEN',
+  'AWS_ACCESS_KEY_ID',  // _ID로 끝나 _KEY$ 패턴에 안 걸림 (AWS 자격증명)
   'ANTHROPIC_API_KEY',
   'OPENAI_API_KEY',
   'GITHUB_TOKEN',
   'GH_TOKEN',
   'NPM_TOKEN',
   'DOCKER_PASSWORD',
-  'DATABASE_URL',       // 종종 자격증명을 임베드
+  // 선행 밑줄이 없어 패턴(`_PASSWORD$`/`_SECRET$` 등)에 안 걸리는 well-known 비밀
+  // (3모델 리뷰 확정). `/PASSWORD$/`로 패턴을 넓히면 ENABLE_PASSWORD 같은 비자격
+  // 키를 오탐하므로, exact 이름으로만 추가한다.
+  'PGPASSWORD',
+  'MYSQL_PWD',
+  'SECRET_KEY_BASE',
+  'LDAPPASSWORD',
+  // URL/URI에 자격증명을 임베드하는 연결 문자열 (DATABASE_URL과 동류)
+  'DATABASE_URL',
+  'REDIS_URL',
+  'MONGO_URL',
+  'MONGODB_URI',
 ]);
 
 const SAFE_PASSTHROUGH: ReadonlySet<string> = new Set([


### PR DESCRIPTION
> Merged after PR #356. Recreated against `main` (the original #358 auto-closed when PR1's base branch was deleted; the branch was rebased onto `main` to drop the duplicated PR1 commit).

## Summary

PR1 lets user shells inherit credentials. Those values then flowed into the daemon session meta and were (a) persisted in plaintext to `~/.wmux/sessions.json` and (b) returned over the `daemon.listSessions` RPC — readable by any same-user process holding the daemon token. PR2 strips credential **values** at every boundary where session env reaches disk or the wire.

Values live only in the in-memory spawn env (spawn / supervised-restart unaffected); non-credential vars (`PATH`, locale, `WMUX_*` identity) are preserved.

## Design (reshaped by pre-implementation eng review)

The original "strip at buildState + listSessions" missed three disk writers (30s snapshot, shutdown-suspend, Windows sync-exit) and a versioned migration that would retain credentials in `.bak`. Final design:

- **Chokepoint = StateWriter** (the sole `sessions.json` writer). `toPersistable` wraps all 5 write paths, covering every current and future writer by construction.
- **RPC strip**: `daemon.listSessions` and `daemon.createSession` responses replace env with a fresh, stripped copy.
- **Boot scrub**: instead of a versioned migration, one pass before recovery scrubs the existing `sessions.json` primary + all `.bak` slots (total, non-throwing, fsync + rename).
- **Fresh-copy discipline**: `{...m.meta}`'s env aliases the live in-memory reference, so an in-place delete would break spawning — every strip replaces the reference.

## Review

- Plan eng review (two independent voices) caught the three missed sinks and the migration hazards before any code was written.
- Implementation reviewed by a three-model panel; the core infrastructure was confirmed clean. Fixes applied: credential-predicate under-coverage (well-known secrets without a leading underscore such as `PGPASSWORD`, `SECRET_KEY_BASE`, `REDIS_URL`), scrub of non-object env, and a durable scrub write (fsync).

## Verification

- Full daemon suite (1049 passing), tsc across all 5 projects, and a live dogfood through the real StateWriter.

## Scope / limits

- Panes recovered after a daemon restart do not regain credentials until a new pane opens; explicit grants and live re-resolution land in PR3.
- `WorkspaceProfile.env` (user-entered) is persisted plaintext main-side — out of scope, PR3 grant area.
