### PR TITLE
NB2 wave2: fan-out missions in sidebar + fleet panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Fan-out missions are now visible in the sidebar and fleet panel.** Workspaces created by a J1 fan-out now show up under a "Missions" group at the top of the sidebar (title, open/closed status, and a link into the mission's channel) — the group only appears when a workspace has fanned out, so ordinary workspaces are unaffected. The fleet panel's cards also grow a mission line when they belong to a fan-out task. The existing worktree badge (⊕) is untouched — it marks the low-level "this is a git worktree" fact, while the new Missions section marks the higher-level "this is a fan-out task" fact, and a workspace can carry both. Mission data is read-only and pulled (mount + workspace-set changes + a 15s background poll for status drift + an immediate refetch right after a fan-out completes), since the daemon doesn't push mission updates.
+
 ### Changed
 
 - **Fleet view is now always-on chrome instead of a full-screen modal.** `Ctrl+Shift+A` still toggles it, but it now mounts as a fixed-width panel alongside the workspace sidebar and channel dock (mirroring the channel dock's existing flex-sibling layout) rather than a `fixed` overlay with a backdrop — other panes stay visible and interactive while it's open, and closing it no longer drops keyboard focus into `<body>`: the element that had focus when it opened is restored. The fleet/approvals/remote tabs, keyboard row-navigation, and approve/deny shortcuts are unchanged; the card grid narrows to fit the panel's width instead of a full-screen layout. Two focus bugs found in review were fixed before this landed: opening the panel now lands real DOM focus on the active card/row (not just the panel container, which used to leave keyboard users unable to reach any card when only one was present), and row shortcuts (Enter=approve, Backspace/Delete=deny) now only fire when the option row itself is focused — previously an auto-approve checkbox could steal focus and cause those keys to mis-fire as an approval/denial.

--- a/src/renderer/components/AgentToolbar/FanOutDialog.tsx
+++ b/src/renderer/components/AgentToolbar/FanOutDialog.tsx
@@ -113,6 +113,10 @@ export default function FanOutDialog({ onClose }: FanOutDialogProps) {
         verifiedWorkspaceId: activeWorkspace?.id ?? '',
       });
       reportResult(res, pushToast);
+      // fan-out 완료 직후 미션 캐시 즉시 refetch(순수 pull이라 push가 없다 —
+      // 배경 폴링을 기다리지 않고 사이드바 "Missions" 섹션을 바로 채운다).
+      const parentId = activeWorkspace?.id;
+      if (parentId) void useStore.getState().refreshMissions(parentId);
       onClose();
     } catch (err) {
       pushToast({ level: 'error', message: `fan-out 실패: ${err instanceof Error ? err.message : String(err)}` });

--- a/src/renderer/components/FleetView/FleetCard.tsx
+++ b/src/renderer/components/FleetView/FleetCard.tsx
@@ -1,7 +1,9 @@
 import { memo } from 'react';
 import type { FleetPane } from '../../stores/selectors/fleet';
+import type { WorkTask } from '../../../shared/workTask';
 import { AGENT_STATUS_ICON } from '../Sidebar/agentStatusIcon';
 import { useT } from '../../hooks/useT';
+import { useStore } from '../../stores';
 
 // Compact, scan-friendly cwd: keep the last two path segments. Mirrors the
 // sidebar's shortenPath so the cockpit reads the same as the workspace rows.
@@ -24,6 +26,31 @@ interface FleetCardProps {
 }
 
 /**
+ * 사이클 C — fan-out 미션 라인(순수 prop-구동, 테스트 가능). 매칭 미션이 없으면
+ * null(기존 카드 확장 — 신규 UI 표면 아님). status로 색·취소선을 인코딩한다.
+ */
+export function FleetCardMissionLine({ mission }: { mission: WorkTask | undefined }): React.ReactElement | null {
+  if (!mission) return null;
+  const isOpen = mission.status === 'open';
+  return (
+    <div
+      className="flex items-center gap-1.5 min-w-0 text-caption font-mono"
+      data-fleet-mission
+      data-mission-status={mission.status}
+      title={`Mission: ${mission.title} (${mission.status})`}
+    >
+      <span
+        className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+        style={{ backgroundColor: isOpen ? 'var(--accent-green)' : 'var(--text-muted)' }}
+      />
+      <span className={`truncate ${isOpen ? 'text-[var(--text-sub)]' : 'text-[var(--text-muted)] line-through'}`}>
+        {mission.title}
+      </span>
+    </div>
+  );
+}
+
+/**
  * One agent in the Fleet View grid. Status badge reuses AGENT_STATUS_ICON so the
  * cockpit stays in lockstep with the sidebar dots. awaiting_input — the
  * unattended-loop money state — gets a yellow border + "needs your input"
@@ -32,6 +59,11 @@ interface FleetCardProps {
 function FleetCard({ card, focused, onJump, tail }: FleetCardProps) {
   const t = useT();
   const icon = AGENT_STATUS_ICON[card.agentStatus];
+  // 사이클 C — 이 카드의 워크스페이스가 fan-out 태스크의 전용 워크스페이스
+  // (paneGroupId)면 미션 title·status를 부가 표시한다. 좁은 셀렉터(자기
+  // paneGroupId 항목만)라 다른 미션 변경엔 리렌더되지 않고, 매칭이 없으면
+  // undefined(신규 UI 표면 없음 — 기존 카드 확장).
+  const mission = useStore((s) => s.missionByPaneGroup[card.workspaceId]);
   const isAwaitingInput = card.agentStatus === 'awaiting_input';
   const isIdle = card.agentStatus === 'idle';
   // P2: a user rename wins so the cockpit reflects the same name as the composer
@@ -116,6 +148,10 @@ function FleetCard({ card, focused, onJump, tail }: FleetCardProps) {
           </>
         )}
       </div>
+
+      {/* 사이클 C — 미션 라인(순수 prop-구동 서브컴포넌트). 이 카드가 fan-out
+          태스크의 워크스페이스면 title + status를 부가 표시(매칭 없으면 null). */}
+      <FleetCardMissionLine mission={mission} />
 
       {/* Affordance row — only when there is something worth a third line. */}
       {isAwaitingInput ? (

--- a/src/renderer/components/FleetView/__tests__/FleetCard.test.tsx
+++ b/src/renderer/components/FleetView/__tests__/FleetCard.test.tsx
@@ -14,8 +14,9 @@
 import { describe, expect, it } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { createElement } from 'react';
-import FleetCard from '../FleetCard';
+import FleetCard, { FleetCardMissionLine } from '../FleetCard';
 import type { FleetPane } from '../../../stores/selectors/fleet';
+import type { WorkTask } from '../../../../shared/workTask';
 
 const noop = () => undefined;
 
@@ -112,5 +113,40 @@ describe('FleetCard — X8 supervision chip', () => {
 
   it('renders no supervision chip when the pane is unsupervised', () => {
     expect(render({ card: card() })).not.toContain('data-fleet-supervision');
+  });
+});
+
+describe('FleetCard — 사이클 C mission line', () => {
+  function mission(over: Partial<WorkTask> & Pick<WorkTask, 'id' | 'title' | 'status'>): WorkTask {
+    const ref = { principalId: 'p', verifiedWorkspaceId: 'parent-a' };
+    return {
+      missionChannelId: `chan-${over.id}`,
+      createdAt: 0,
+      createdBy: ref,
+      owner: ref,
+      ...over,
+    } as WorkTask;
+  }
+  const renderLine = (m: WorkTask | undefined): string =>
+    renderToStaticMarkup(createElement(FleetCardMissionLine, { mission: m }));
+
+  it('renders nothing when the card has no matching mission', () => {
+    expect(renderLine(undefined)).toBe('');
+    // 미션 캐시가 비어 있으면(생성 시점) 카드 본체에도 미션 라인이 없다.
+    expect(render({ card: card() })).not.toContain('data-fleet-mission');
+  });
+
+  it('shows an open mission title + status', () => {
+    const html = renderLine(mission({ id: 'w1', title: 'Refactor auth', status: 'open' }));
+    expect(html).toContain('data-fleet-mission');
+    expect(html).toContain('data-mission-status="open"');
+    expect(html).toContain('Refactor auth');
+    expect(html).not.toContain('line-through');
+  });
+
+  it('strikes through a closed mission', () => {
+    const html = renderLine(mission({ id: 'w2', title: 'Add tests', status: 'closed' }));
+    expect(html).toContain('data-mission-status="closed"');
+    expect(html).toContain('line-through');
   });
 });

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -38,6 +38,7 @@ import { useApprovalInboxBridge } from '../../hooks/useApprovalInboxBridge';
 import { useRemoteInboxBridge } from '../../hooks/useRemoteInboxBridge';
 import { useChannelsEventSubscription } from '../../hooks/useChannelsEventSubscription';
 import { useChannelsHydration } from '../../hooks/useChannelsHydration';
+import { useMissionsPolling } from '../../hooks/useMissionsPolling';
 import { usePaneDecorationChannel } from '../../plugins/usePaneDecorationChannel';
 import { useIpc } from '../../hooks/useIpc';
 import type { SessionData, PaneLeaf, Pane, Surface, Workspace } from '../../../shared/types';
@@ -337,6 +338,10 @@ export default function AppLayout() {
   // agents or persisted across restart were invisible. Decoupled from in-app
   // Company mode (falls back to the active workspace for identity).
   useChannelsHydration();
+  // 사이클 C — 미션(WorkTask) 캐시. task.mission.list를 owner-scoped로 폴링해
+  // 사이드바 "Missions" 섹션 + FleetCard 미션 라인을 채운다(순수 pull, 성긴 폴링 —
+  // useMissionsPolling 헤더 참조).
+  useMissionsPolling();
   // Plugin host (B-1): ui.decoratePane push → uiSlice pane decorations.
   usePaneDecorationChannel();
   const { invoke: ipcInvoke } = useIpc();

--- a/src/renderer/components/Sidebar/MissionsSection.tsx
+++ b/src/renderer/components/Sidebar/MissionsSection.tsx
@@ -1,0 +1,123 @@
+// ─── 사이드바 "Missions" 섹션 (NB2 파동2 사이클 C) ───────────────────────────
+//
+// fan-out(J1)이 만든 미션(WorkTask)을 워크스페이스 리스트 상단의 별도 그룹으로
+// 승격한다. 각 미션 = 프롬프트 1개가 펼쳐진 격리 태스크이고, `paneGroupId`가 곧
+// 그 태스크 전용 자식 워크스페이스 id다. 행은 title·status(open/closed)와 미션
+// 채널로 이어지는 링크를 보여준다.
+//
+// worktree 배지(⊕, WorkspaceItem)와의 공존: 배지는 "이 워크스페이스가 git worktree"
+// 라는 저수준 사실을, 이 섹션은 "이 워크스페이스가 fan-out 태스크"라는 상위 개념을
+// 얹는다(worktree ⊂ task는 아님 — broadcast 모드는 격리 없음). 둘은 서로 다른 축이라
+// 같은 자식 워크스페이스가 사이드바 리스트(배지 있음)와 이 섹션(미션 행)에 모두 나올
+// 수 있고, 이는 의도된 이중 표현이다.
+//
+// 빈 상태: 미션이 하나도 없으면(대부분의 일반 워크스페이스) 이 컴포넌트는 null을
+// 반환해 **공간을 전혀 차지하지 않는다**(헤더조차 렌더하지 않음).
+
+import { memo, useMemo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useStore } from '../../stores';
+import type { WorkTask } from '../../../shared/workTask';
+
+/**
+ * 모든 부모 캐시를 평탄화·정렬한 미션 목록(순수 함수 — 테스트 가능). open을 먼저,
+ * 그 안에서 최신(createdAt desc) 순으로 정렬한다. 태스크는 부모 하나에만 속하므로
+ * 중복은 없다.
+ */
+export function flattenMissions(byWorkspace: Record<string, WorkTask[]>): WorkTask[] {
+  const all: WorkTask[] = [];
+  for (const tasks of Object.values(byWorkspace)) all.push(...tasks);
+  return all.sort((a, b) => {
+    if (a.status !== b.status) return a.status === 'open' ? -1 : 1;
+    return b.createdAt - a.createdAt;
+  });
+}
+
+function useFlatMissions(): WorkTask[] {
+  const byWorkspace = useStore(useShallow((s) => s.missionsByWorkspace));
+  return useMemo(() => flattenMissions(byWorkspace), [byWorkspace]);
+}
+
+function MissionRow({ task }: { task: WorkTask }): React.ReactElement {
+  // 자식 워크스페이스 존재 여부(존재할 때만 행 클릭으로 점프 가능).
+  const childExists = useStore((s) =>
+    task.paneGroupId ? s.workspaces.some((w) => w.id === task.paneGroupId) : false,
+  );
+  const isOpen = task.status === 'open';
+  const statusColor = isOpen ? 'var(--accent-green)' : 'var(--text-muted)';
+
+  const jumpToChild = (): void => {
+    if (task.paneGroupId && childExists) {
+      useStore.getState().setActiveWorkspace(task.paneGroupId);
+    }
+  };
+  const openMissionChannel = (): void => {
+    // 기존 채널 열기 경로 재사용(setActiveChannel이 dock을 열고 채널을 선택) —
+    // 새 라우팅을 만들지 않는다.
+    useStore.getState().setActiveChannel(task.missionChannelId);
+  };
+
+  return (
+    <div
+      className={`group flex items-center gap-2 mx-2 px-3 py-1 rounded-md select-none ${
+        task.paneGroupId && childExists
+          ? 'cursor-pointer hover:bg-[rgba(var(--bg-surface-rgb),0.5)]'
+          : ''
+      }`}
+      onClick={jumpToChild}
+      data-mission-row
+      data-task-id={task.id}
+      data-task-status={task.status}
+    >
+      {/* status dot: open=green, closed=muted */}
+      <span
+        className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+        style={{ backgroundColor: statusColor }}
+        title={isOpen ? 'open' : 'closed'}
+      />
+      <span
+        className={`flex-1 min-w-0 truncate text-caption font-mono ${
+          isOpen ? 'text-[var(--text-sub)]' : 'text-[var(--text-muted)] line-through'
+        }`}
+        title={task.title}
+      >
+        {task.title}
+      </span>
+      {/* 미션 채널 링크 — 기존 ChannelDock으로 해당 채널을 연다. */}
+      <button
+        type="button"
+        className="flex-shrink-0 text-[10px] font-mono text-[var(--text-subtle)] hover:text-[var(--accent-blue)] transition-colors"
+        onClick={(e) => {
+          e.stopPropagation();
+          openMissionChannel();
+        }}
+        title={`Open mission channel`}
+        aria-label={`Open mission channel for ${task.title}`}
+        data-mission-channel-link
+      >
+        #
+      </button>
+    </div>
+  );
+}
+
+function MissionsSection(): React.ReactElement | null {
+  const missions = useFlatMissions();
+  // 빈 상태: 미션이 없으면 아무 것도 렌더하지 않는다(공간 0).
+  if (missions.length === 0) return null;
+
+  return (
+    <div className="mb-1" data-missions-section>
+      <div className="px-4 pt-1 pb-1 text-[9px] font-mono font-semibold tracking-widest text-[var(--text-muted)] uppercase">
+        Missions
+      </div>
+      <div className="space-y-0.5">
+        {missions.map((task) => (
+          <MissionRow key={task.id} task={task} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default memo(MissionsSection);

--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -3,6 +3,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useStore } from '../../stores';
 import { selectWorkspaceIdName } from '../../stores/selectors/workspaceProjections';
 import WorkspaceItem from './WorkspaceItem';
+import MissionsSection from './MissionsSection';
 import PresetPicker from './PresetPicker';
 import type { Pane } from '../../../shared/types';
 import { useT } from '../../hooks/useT';
@@ -168,6 +169,10 @@ export default function Sidebar() {
           }
         }}
       >
+        {/* 사이클 C — fan-out 미션 섹션. 미션이 없으면(일반 워크스페이스) 아무
+            것도 렌더하지 않아 공간을 차지하지 않는다(MissionsSection이 null 반환).
+            worktree 배지(⊕)와 공존 — 배지는 저수준 사실, 이 섹션은 상위 개념. */}
+        <MissionsSection />
         {/* A1/A2: 각 항목에 id + 안정 콜백만 내린다. 콜백은 모두 id 인자를 받는
             스토어 액션/useCallback 핸들러라 렌더마다 새로 만들어지지 않아
             memo(WorkspaceItem)가 실효한다. 항목 내용은 WorkspaceItem이 자기

--- a/src/renderer/components/Sidebar/__tests__/MissionsSection.test.tsx
+++ b/src/renderer/components/Sidebar/__tests__/MissionsSection.test.tsx
@@ -1,0 +1,66 @@
+// MissionsSection tests (NB2 파동2 사이클 C).
+//
+// Vitest는 jsdom 없이 node env로 돈다 — renderToStaticMarkup은 zustand의 SSR
+// 스냅샷(스토어 생성 시점 상태)만 읽어 setState 이후 값은 반영하지 못한다. 따라서
+// 표시 로직의 핵심(평탄화·정렬)은 순수 함수 flattenMissions로 분리해 직접 검증하고,
+// 빈 상태(null 반환 → 공간 0)만 SSR로 고정한다(생성 시점 미션 캐시는 비어 있음).
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { createElement } from 'react';
+import MissionsSection, { flattenMissions } from '../MissionsSection';
+import type { WorkTask } from '../../../../shared/workTask';
+
+function mission(over: Partial<WorkTask> & Pick<WorkTask, 'id' | 'title'>): WorkTask {
+  const ref = { principalId: 'p', verifiedWorkspaceId: 'parent-a' };
+  return {
+    status: 'open',
+    missionChannelId: `chan-${over.id}`,
+    createdAt: 0,
+    createdBy: ref,
+    owner: ref,
+    ...over,
+  } as WorkTask;
+}
+
+describe('MissionsSection', () => {
+  it('빈 캐시에서는 아무 것도 렌더하지 않는다(공간 0)', () => {
+    // 스토어 생성 시점 missionsByWorkspace는 비어 있으므로 SSR은 빈 상태를 본다.
+    const html = renderToStaticMarkup(createElement(MissionsSection));
+    expect(html).toBe('');
+  });
+
+  describe('flattenMissions (순수)', () => {
+    it('빈 맵은 빈 배열', () => {
+      expect(flattenMissions({})).toEqual([]);
+    });
+
+    it('여러 부모의 미션을 하나로 합친다', () => {
+      const out = flattenMissions({
+        'parent-a': [mission({ id: 'a1', title: 'A' })],
+        'parent-b': [mission({ id: 'b1', title: 'B' }), mission({ id: 'b2', title: 'C' })],
+      });
+      expect(out.map((t) => t.id).sort()).toEqual(['a1', 'b1', 'b2']);
+    });
+
+    it('open을 closed보다 먼저 정렬한다', () => {
+      const out = flattenMissions({
+        p: [
+          mission({ id: 'closed', title: 'Z', status: 'closed', createdAt: 100 }),
+          mission({ id: 'open', title: 'A', status: 'open', createdAt: 1 }),
+        ],
+      });
+      expect(out[0].id).toBe('open');
+      expect(out[1].id).toBe('closed');
+    });
+
+    it('같은 상태 안에서는 최신(createdAt desc) 순', () => {
+      const out = flattenMissions({
+        p: [
+          mission({ id: 'older', title: 'O', createdAt: 1 }),
+          mission({ id: 'newer', title: 'N', createdAt: 5 }),
+        ],
+      });
+      expect(out.map((t) => t.id)).toEqual(['newer', 'older']);
+    });
+  });
+});

--- a/src/renderer/hooks/useMissionsPolling.ts
+++ b/src/renderer/hooks/useMissionsPolling.ts
@@ -1,0 +1,67 @@
+// ─── 미션(WorkTask) 폴링 훅 (NB2 파동2 사이클 C) ─────────────────────────────
+//
+// AppLayout에 1회 마운트(useChannelsHydration과 평행). workTaskSlice로 미션 캐시를
+// 채운다. 왜 이렇게(순수 pull + 성긴 폴링)인가는 workTaskSlice 헤더 참조:
+//   - daemon WorkTaskService는 EventBus에 아무 것도 emit하지 않음 → push 없음.
+//   - fan-out 물질화(paneGroupId 등)는 FanOutService.start() 반환 전 동기 커밋 →
+//     완료 시점 토폴로지 완결. 남는 드리프트는 상태(open→closed)뿐(저빈도).
+// 그래서 트리거는:
+//   1. 마운트 + 워크스페이스 목록(id 집합) 변화 → 즉시 refetch(모든 부모 후보).
+//   2. 성긴 배경 폴링(MISSION_POLL_INTERVAL_MS) → 상태 드리프트 반영.
+//   3. daemon (re)connect → 콜드부트/리스폰 후 재수화.
+// fan-out 완료 직후 refetch는 FanOutDialog가 refreshMissions를 직접 호출한다(즉시성).
+//
+// listMissions는 owner-scoped라, "어떤 워크스페이스가 부모인지"를 미리 알 필요 없이
+// 현재 존재하는 모든 워크스페이스 id를 각각 조회하면 된다(fan-out 안 한 워크스페이스는
+// 빈 배열을 돌려주므로 무해 — 사이드바 섹션은 빈 캐시에서 아무것도 렌더하지 않는다).
+
+import { useEffect } from 'react';
+import { useStore } from '../stores';
+
+/**
+ * 미션 상태 드리프트(open→closed)를 잡기 위한 성긴 배경 폴링 주기. 채널 unread의
+ * 1Hz events.poll(라이브 메시지 배달용)과 **의도적으로 다르다** — 미션은 사람/에이전트가
+ * 이따금 닫는 저빈도 상태라 15초면 충분하고, owner-scoped 맵 조회라 데몬 부하도 미미하다.
+ */
+export const MISSION_POLL_INTERVAL_MS = 15_000;
+
+/** 현재 워크스페이스 id 전부에 대해 미션을 refetch(각 owner-scoped 조회). */
+function refreshAllParents(): void {
+  const state = useStore.getState();
+  const ids = state.workspaces.map((w) => w.id);
+  for (const id of ids) {
+    void state.refreshMissions(id);
+  }
+}
+
+/**
+ * AppLayout에 1회 마운트. React state는 소유하지 않고 스토어로 디스패치만 한다.
+ * 워크스페이스 id 집합이 바뀔 때마다 재수화하고, 성긴 배경 폴링으로 상태를 갱신한다.
+ */
+export function useMissionsPolling(): void {
+  // id 집합 문자열: 워크스페이스 추가/삭제 시에만 effect를 재실행(이름/메타 변경엔 무반응).
+  const workspaceIdsKey = useStore((s) => s.workspaces.map((w) => w.id).join(','));
+
+  useEffect(() => {
+    // 마운트 + id 집합 변화 시 즉시 refetch.
+    refreshAllParents();
+
+    // 성긴 배경 폴링(상태 드리프트용).
+    const timer = setInterval(refreshAllParents, MISSION_POLL_INTERVAL_MS);
+
+    // daemon (re)connect 시 콜드부트/리스폰 후 재수화.
+    let disposed = false;
+    void window.electronAPI.daemon.whenReady().then(() => {
+      if (!disposed) refreshAllParents();
+    });
+    const offConnected = window.electronAPI.daemon.onConnected(() => {
+      if (!disposed) refreshAllParents();
+    });
+
+    return () => {
+      disposed = true;
+      clearInterval(timer);
+      offConnected();
+    };
+  }, [workspaceIdsKey]);
+}

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -232,6 +232,24 @@ export function useRpcBridge(): void {
         window.electronAPI.rpc.mutateChannelLocal(method, params) as Promise<RpcResult>,
     };
 
+    // ── In-renderer entry point for workTaskSlice / useMissionsPolling ────
+    // Mission (WorkTask) reads for the sidebar "Missions" section + FleetCard
+    // mission line. `task.mission.list` is owner-scoped (the daemon returns
+    // only tasks whose owner == the passed workspace), so the parent workspace
+    // that fanned out queries its own children. Read-only, same `rpc.invoke`
+    // plumbing as `__wmuxEventsPoll` — a no-senderPtyId renderer read keeps its
+    // caller-supplied verifiedWorkspaceId (process-boundary trust; see the
+    // header of src/main/pipe/handlers/a2a.channel.rpc.ts). No mission mutation
+    // ever rides this bridge (materialization is FanOutService's internal path).
+    (window as unknown as {
+      __wmuxMissionRpc: {
+        list: (params: { verifiedWorkspaceId: string }) => Promise<RpcResult>;
+      };
+    }).__wmuxMissionRpc = {
+      list: (params) =>
+        window.electronAPI.rpc.invoke('task.mission.list', params) as Promise<RpcResult>,
+    };
+
     // A2A task garbage collection timer — prune terminal-state tasks every 5 min
     const gcTimer = setInterval(() => {
       useStore.getState().gcTerminalTasks();
@@ -243,6 +261,7 @@ export function useRpcBridge(): void {
       delete (window as unknown as { __wmuxRunPaneSearch?: unknown }).__wmuxRunPaneSearch;
       delete (window as unknown as { __wmuxEventsPoll?: unknown }).__wmuxEventsPoll;
       delete (window as unknown as { __wmuxChannelsRpc?: unknown }).__wmuxChannelsRpc;
+      delete (window as unknown as { __wmuxMissionRpc?: unknown }).__wmuxMissionRpc;
     };
   }, []);
 }

--- a/src/renderer/stores/index.ts
+++ b/src/renderer/stores/index.ts
@@ -16,8 +16,9 @@ import { createResumeSlice, type ResumeSlice } from './slices/resumeSlice';
 import { createAgentToolbarSlice, type AgentToolbarSlice } from './slices/agentToolbarSlice';
 import { createRemoteInboxSlice, type RemoteInboxSlice } from './slices/remoteInboxSlice';
 import { createChannelsSlice, type ChannelsSlice } from './slices/channelsSlice';
+import { createWorkTaskSlice, type WorkTaskSlice } from './slices/workTaskSlice';
 
-export type StoreState = WorkspaceSlice & PaneSlice & SurfaceSlice & UISlice & NotificationSlice & A2aSlice & ApprovalInboxSlice & CompanySlice & ToastSlice & SearchSlice & ProjectConfigSlice & SupervisionSlice & ResumeSlice & AgentToolbarSlice & RemoteInboxSlice & ChannelsSlice;
+export type StoreState = WorkspaceSlice & PaneSlice & SurfaceSlice & UISlice & NotificationSlice & A2aSlice & ApprovalInboxSlice & CompanySlice & ToastSlice & SearchSlice & ProjectConfigSlice & SupervisionSlice & ResumeSlice & AgentToolbarSlice & RemoteInboxSlice & ChannelsSlice & WorkTaskSlice;
 
 export const useStore = create<StoreState>()(
   immer((...args) => ({
@@ -37,5 +38,6 @@ export const useStore = create<StoreState>()(
     ...createAgentToolbarSlice(...args),
     ...createRemoteInboxSlice(...args),
     ...createChannelsSlice(...args),
+    ...createWorkTaskSlice(...args),
   }))
 );

--- a/src/renderer/stores/slices/__tests__/workTaskSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/workTaskSlice.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { createWorkTaskSlice, type WorkTaskSlice } from '../workTaskSlice';
+import type { WorkTask } from '../../../../shared/workTask';
+
+// WorkTaskSlice는 StoreState 전체가 아니라 자기 상태만 건드리므로 최소 목 스토어로
+// 검증한다(companySlice.test.ts 관례 동형).
+function createTestStore() {
+  return create<WorkTaskSlice>()(
+    immer((...args) => ({
+      // @ts-expect-error — 최소 목 스토어는 전체 StoreState와 일치하지 않는다.
+      ...createWorkTaskSlice(...args),
+    })),
+  );
+}
+
+/** 미션 픽스처 헬퍼(필수 필드만 채운다 — 렌더러는 read-only 소비자). */
+function mission(over: Partial<WorkTask> & Pick<WorkTask, 'id' | 'title'>): WorkTask {
+  const ref = { principalId: 'p', verifiedWorkspaceId: over.owner?.verifiedWorkspaceId ?? 'parent-a' };
+  return {
+    status: 'open',
+    missionChannelId: `chan-${over.id}`,
+    createdAt: 0,
+    createdBy: ref,
+    owner: ref,
+    ...over,
+  } as WorkTask;
+}
+
+describe('workTaskSlice', () => {
+  let store: ReturnType<typeof createTestStore>;
+
+  beforeEach(() => {
+    store = createTestStore();
+  });
+
+  it('setMissions가 부모별로 캐싱하고 paneGroupId 역인덱스를 만든다', () => {
+    store.getState().setMissions('parent-a', [
+      mission({ id: 'wtask-1', title: 'A', paneGroupId: 'child-1' }),
+      mission({ id: 'wtask-2', title: 'B', paneGroupId: 'child-2' }),
+    ]);
+    expect(store.getState().missionsByWorkspace['parent-a']).toHaveLength(2);
+    expect(store.getState().getMissionForPaneGroup('child-1')?.id).toBe('wtask-1');
+    expect(store.getState().getMissionForPaneGroup('child-2')?.title).toBe('B');
+  });
+
+  it('paneGroupId 미물질화(fan-out 진행 중) 태스크는 역인덱스에서 빠진다', () => {
+    store.getState().setMissions('parent-a', [
+      mission({ id: 'wtask-1', title: 'A' }), // paneGroupId 없음
+    ]);
+    expect(store.getState().missionsByWorkspace['parent-a']).toHaveLength(1);
+    expect(store.getState().getMissionForPaneGroup('child-1')).toBeUndefined();
+  });
+
+  it('여러 부모의 미션을 하나의 paneGroupId 인덱스로 합친다', () => {
+    store.getState().setMissions('parent-a', [mission({ id: 'wtask-1', title: 'A', paneGroupId: 'child-1' })]);
+    store.getState().setMissions('parent-b', [mission({ id: 'wtask-9', title: 'Z', paneGroupId: 'child-9', owner: { principalId: 'p', verifiedWorkspaceId: 'parent-b' } })]);
+    expect(store.getState().getMissionForPaneGroup('child-1')?.id).toBe('wtask-1');
+    expect(store.getState().getMissionForPaneGroup('child-9')?.id).toBe('wtask-9');
+  });
+
+  it('setMissions 재호출은 그 부모의 목록만 통째로 교체한다(다른 부모 보존)', () => {
+    store.getState().setMissions('parent-a', [mission({ id: 'wtask-1', title: 'A', paneGroupId: 'child-1' })]);
+    store.getState().setMissions('parent-b', [mission({ id: 'wtask-2', title: 'B', paneGroupId: 'child-2' })]);
+    // parent-a를 빈 목록으로 교체 → child-1 인덱스 사라지고 parent-b는 유지.
+    store.getState().setMissions('parent-a', []);
+    expect(store.getState().getMissionForPaneGroup('child-1')).toBeUndefined();
+    expect(store.getState().getMissionForPaneGroup('child-2')?.id).toBe('wtask-2');
+  });
+
+  it('clearMissionsFor는 부모 캐시와 그 역인덱스를 제거한다', () => {
+    store.getState().setMissions('parent-a', [mission({ id: 'wtask-1', title: 'A', paneGroupId: 'child-1' })]);
+    store.getState().clearMissionsFor('parent-a');
+    expect(store.getState().missionsByWorkspace['parent-a']).toBeUndefined();
+    expect(store.getState().getMissionForPaneGroup('child-1')).toBeUndefined();
+  });
+
+  describe('refreshMissions (브리지 경유)', () => {
+    afterEach(() => {
+      delete (globalThis as { window?: unknown }).window;
+    });
+
+    it('rpc.invoke 봉투({result:{ok,tasks}})를 벗겨 setMissions에 투영한다', async () => {
+      const listFn = vi.fn().mockResolvedValue({
+        ok: true,
+        result: { ok: true, tasks: [mission({ id: 'wtask-1', title: 'A', paneGroupId: 'child-1' })] },
+      });
+      (globalThis as { window?: unknown }).window = { __wmuxMissionRpc: { list: listFn } };
+
+      await store.getState().refreshMissions('parent-a');
+
+      expect(listFn).toHaveBeenCalledWith({ verifiedWorkspaceId: 'parent-a' });
+      expect(store.getState().getMissionForPaneGroup('child-1')?.id).toBe('wtask-1');
+    });
+
+    it('브리지 미설치/거부/비배열 응답은 조용한 no-op(캐시 불변)', async () => {
+      // 브리지 없음.
+      (globalThis as { window?: unknown }).window = {};
+      await store.getState().refreshMissions('parent-a');
+      expect(store.getState().missionsByWorkspace['parent-a']).toBeUndefined();
+
+      // ok=false 봉투.
+      (globalThis as { window?: unknown }).window = {
+        __wmuxMissionRpc: { list: vi.fn().mockResolvedValue({ ok: false }) },
+      };
+      await store.getState().refreshMissions('parent-a');
+      expect(store.getState().missionsByWorkspace['parent-a']).toBeUndefined();
+    });
+
+    it('빈 verifiedWorkspaceId는 브리지를 부르지 않는다', async () => {
+      const listFn = vi.fn();
+      (globalThis as { window?: unknown }).window = { __wmuxMissionRpc: { list: listFn } };
+      await store.getState().refreshMissions('');
+      expect(listFn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/renderer/stores/slices/workTaskSlice.ts
+++ b/src/renderer/stores/slices/workTaskSlice.ts
@@ -1,0 +1,134 @@
+// ─── 미션(WorkTask) 렌더러 캐시 슬라이스 (NB2 파동2 사이클 C) ────────────────
+//
+// J1 fan-out은 프롬프트 1개를 N개의 격리 태스크(WorkTask)로 펼치고, 각 태스크에
+// 전용 워크스페이스를 만든다(`WorkTask.paneGroupId` = 그 자식 워크스페이스 id).
+// 이 슬라이스는 `task.mission.list` RPC 결과를 **부모 워크스페이스별로** 캐싱해,
+// 사이드바 "Missions" 섹션과 FleetCard가 "이 워크스페이스가 fan-out한 미션"을
+// 그릴 수 있게 한다.
+//
+// ── 폴링 방식 판단(실코드 확인) ─────────────────────────────────────────────
+// daemon WorkTaskService는 EventBus에 **아무 이벤트도 emit하지 않는다**(grep 확인).
+// 즉 미션 목록/상태 변화는 렌더러로 push되지 않는 **순수 pull**이다. 반면 fan-out
+// 물질화(branch/worktreePath/paneGroupId)는 FanOutService.start()가 반환하기 전에
+// task.mission.update로 **동기 커밋**되므로, fan-out 완료 시점엔 토폴로지가 이미
+// 완결돼 있다. 따라서:
+//   - 채널 unread(events.poll 1Hz)처럼 잦은 폴링은 불필요·과함 — 그 주기는 라이브
+//     메시지 배달용이고, 미션은 저빈도 상태(open→closed) 변화뿐이다.
+//   - 대신 (a) 마운트/워크스페이스 목록 변화 시 refetch, (b) fan-out 완료 직후
+//     refetch, (c) 상태 드리프트(open→closed)를 위한 성긴 배경 폴링으로 충분하다.
+// 이 판단은 useMissionsPolling 훅에 구현한다(이 슬라이스는 캐시·역인덱스만 소유).
+
+import type { StateCreator } from 'zustand';
+import type { StoreState } from '../index';
+import type { WorkTask } from '../../../shared/workTask';
+
+/** useRpcBridge가 설치하는 미션 읽기 브리지(단일 메서드 파사드). */
+interface MissionRpcBridge {
+  list: (params: Record<string, unknown>) => Promise<unknown>;
+}
+
+function readMissionRpc(): MissionRpcBridge | undefined {
+  return (window as unknown as { __wmuxMissionRpc?: MissionRpcBridge }).__wmuxMissionRpc;
+}
+
+/**
+ * `rpc.invoke`는 데몬 응답을 프로토콜 봉투 `{ id, ok, result }`로 감싼다(result가
+ * 데몬 자신의 `{ ok, tasks }`). useChannelsHydration의 unwrapRpc와 동형 — 전송
+ * 봉투를 벗겨 데몬 응답을 노출한다.
+ */
+function unwrapRpc(res: unknown): unknown {
+  if (
+    res !== null &&
+    typeof res === 'object' &&
+    'result' in res &&
+    (res as { result?: unknown }).result !== null &&
+    typeof (res as { result?: unknown }).result === 'object'
+  ) {
+    return (res as { result: unknown }).result;
+  }
+  return res;
+}
+
+function isOkObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && (v as { ok?: unknown }).ok === true;
+}
+
+/**
+ * 모든 부모별 캐시를 훑어 `paneGroupId → WorkTask` 역인덱스를 재구성한다. 태스크
+ * 총량은 워크스페이스당 open 캡(256)·fan-out 캡(8)으로 바운드되므로 전량 재구성이
+ * 저렴하다(부분 갱신보다 정확하고 단순 — 부모 삭제/재fan-out 시 유령 항목 없음).
+ * paneGroupId 미물질화(fan-out 진행 중) 태스크는 인덱스에서 빠진다(옵셔널 필드).
+ */
+function rebuildPaneGroupIndex(byWorkspace: Record<string, WorkTask[]>): Record<string, WorkTask> {
+  const index: Record<string, WorkTask> = {};
+  for (const tasks of Object.values(byWorkspace)) {
+    for (const task of tasks) {
+      if (task.paneGroupId) index[task.paneGroupId] = task;
+    }
+  }
+  return index;
+}
+
+export interface WorkTaskSlice {
+  /** 부모 워크스페이스 id → 그 워크스페이스가 owner인 미션(WorkTask) 목록 캐시. */
+  missionsByWorkspace: Record<string, WorkTask[]>;
+  /** paneGroupId(=자식 워크스페이스 id) → WorkTask 역인덱스(O(1) 조회). */
+  missionByPaneGroup: Record<string, WorkTask>;
+
+  /** 한 부모의 미션 목록을 통째로 교체하고 역인덱스를 재구성한다(정본=데몬). */
+  setMissions: (parentWorkspaceId: string, tasks: WorkTask[]) => void;
+  /** 브리지 경유로 `task.mission.list`를 당겨 setMissions에 투영(best-effort). */
+  refreshMissions: (parentWorkspaceId: string) => Promise<void>;
+  /** 한 부모의 캐시를 제거(워크스페이스 닫힘 등) 후 역인덱스 재구성. */
+  clearMissionsFor: (parentWorkspaceId: string) => void;
+  /** paneGroupId로 미션 조회(사이드바/FleetCard 매칭). */
+  getMissionForPaneGroup: (paneGroupId: string) => WorkTask | undefined;
+}
+
+export const createWorkTaskSlice: StateCreator<
+  StoreState,
+  [['zustand/immer', never]],
+  [],
+  WorkTaskSlice
+> = (set, get) => ({
+  missionsByWorkspace: {},
+  missionByPaneGroup: {},
+
+  setMissions: (parentWorkspaceId, tasks) =>
+    set((state: StoreState) => {
+      state.missionsByWorkspace[parentWorkspaceId] = tasks;
+      state.missionByPaneGroup = rebuildPaneGroupIndex(state.missionsByWorkspace);
+    }),
+
+  clearMissionsFor: (parentWorkspaceId) =>
+    set((state: StoreState) => {
+      if (state.missionsByWorkspace[parentWorkspaceId] === undefined) return;
+      delete state.missionsByWorkspace[parentWorkspaceId];
+      state.missionByPaneGroup = rebuildPaneGroupIndex(state.missionsByWorkspace);
+    }),
+
+  refreshMissions: async (parentWorkspaceId) => {
+    if (!parentWorkspaceId) return;
+    const bridge = readMissionRpc();
+    if (!bridge) return; // useRpcBridge가 먼저 설치한다(훅 순서); 미스는 다음 트리거에 자가치유.
+    let res: unknown;
+    try {
+      // 읽기 경로: senderPtyId 없는 렌더러 호출은 caller-supplied verifiedWorkspaceId를
+      // 그대로 쓴다(프로세스 경계 신뢰 — a2a.channel.rpc.ts 헤더의 문서화된 잔여).
+      res = await bridge.list({ verifiedWorkspaceId: parentWorkspaceId });
+    } catch {
+      // 데몬 미연결/일시 파이프 실패 — 다음 트리거가 재시도.
+      return;
+    }
+    const env = unwrapRpc(res);
+    if (!isOkObject(env)) return;
+    const rawTasks = (env as { tasks?: unknown }).tasks;
+    if (!Array.isArray(rawTasks)) return;
+    get().setMissions(parentWorkspaceId, rawTasks as WorkTask[]);
+  },
+
+  getMissionForPaneGroup: (paneGroupId) => {
+    if (!paneGroupId) return undefined;
+    return get().missionByPaneGroup[paneGroupId];
+  },
+});


### PR DESCRIPTION
## Summary
- Adds a "Missions" sidebar section (title, open/closed status, mission-channel link) for workspaces created by a J1 fan-out, plus a matching mission line on fleet-panel cards. Ordinary workspaces are unaffected (section renders nothing when there are no missions).
- New `workTaskSlice` caches `task.mission.list` results per parent workspace and maintains a `paneGroupId → WorkTask` reverse index for O(1) card/row lookups.
- Data flow is pull-only by design: the daemon's WorkTaskService emits no events, so refetch triggers are mount, workspace-set changes, daemon reconnect, an immediate refetch right after a fan-out completes, and a 15s background poll for open→closed drift.
- The existing worktree badge (⊕) is untouched — it's a different, orthogonal fact (git worktree vs. fan-out task) and both can be true for the same workspace.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:parallel` — 5474 passed, 0 regressions; new tests for `workTaskSlice`, `MissionsSection`, and `FleetCard`'s mission line
- [x] Verified the Missions section renders nothing (no header, no space) when a workspace has zero missions