### PR TITLE
6g2: operator-join — human self-join into agent-made private channels

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -26,7 +26,7 @@ returns `EPERM`. Wire framing: newline-delimited JSON, one object per line.
 
 ## RPC methods
 
-Total: **133** methods (`ALL_RPC_METHODS` in
+Total: **135** methods (`ALL_RPC_METHODS` in
 `src/shared/rpc.ts`). Capability and risk class are read from
 `src/main/mcp/methodCapabilityMap.ts`:
 
@@ -172,6 +172,8 @@ Total: **133** methods (`ALL_RPC_METHODS` in
 | `a2a.channel.nudgeRecorded` | `a2a.channel.send` | `a2a` |
 | `a2a.channel.unread` | `a2a.channel.read` | `a2a` |
 | `a2a.channel.purgeMembership` | `a2a.channel.send` | `a2a` |
+| `a2a.channel.operatorJoin` | `a2a.channel.send` | `a2a` |
+| `a2a.channel.operatorList` | `a2a.channel.send` | `a2a` |
 | `a2a.principal.upsert` | `wmux.internal` |  |
 | `a2a.principal.remove` | `wmux.internal` |  |
 | `a2a.principal.markStaleWorkspace` | `wmux.internal` |  |

--- a/src/daemon/channels/ChannelService.ts
+++ b/src/daemon/channels/ChannelService.ts
@@ -1244,8 +1244,10 @@ export class ChannelService {
         principalId: HUMAN_SELF_PRINCIPAL_ID,
       };
       // 서버-발행 시스템 메시지(§2.1.1). systemKind로 판별하고 text는 폴백이다.
-      // deliveryStatus='delivered' + recipientSnapshot 부재 = 배달/nudge 대상이
-      // 아닌 감사 마커(wake worker가 이 행으로 재-nudge를 걸지 않는다).
+      // nudge 억제의 실제 장치는 unreadFor()의 systemKind 면제다 — 감사 마커는
+      // 누구의 unread도 만들지 않으므로 wake worker가 이 행으로 nudge를 걸지
+      // 않는다. deliveryStatus='delivered'는 "배달이 아니다"의 표기일 뿐 unread/
+      // wake 판정에는 관여하지 않는다.
       const systemMessage: ChannelMessage = {
         channelId: channel.id,
         seq,
@@ -1290,7 +1292,8 @@ export class ChannelService {
       }
       // 멤버십 변경 팬아웃 — post-join 멤버 집합(사람 포함)에 roster/sidebar 재동기
       // (join()과 동일 신호). 최선노력·비내구라 §2.1.1 시스템 메시지가 내구 흔적을
-      // 별도로 남긴다.
+      // 별도로 남긴다(단 채널 히스토리는 CHANNEL_MESSAGES_MAX에서 tail-evict되므로
+      // 이 흔적의 보존도 그 한계 내다 — 무한 감사 로그가 아니다).
       this.emitCatalog(
         channel.id,
         HUMAN_WORKSPACE_ID,
@@ -2576,6 +2579,12 @@ export class ChannelService {
           // the full row identity (workspaceId AND memberId) so a same-ws
           // SIBLING agent still owes it (same-ws A2A stays a conversation).
           if (m.workspaceId === row.workspaceId && m.memberId === row.memberId) continue;
+          // System rows (systemKind) are audit markers, not deliverable work:
+          // this exemption is what actually keeps the wake worker away from
+          // them — without it every agent member owes one plain unread for an
+          // "Operator joined" marker and gets a PTY nudge (three-model review
+          // consensus). deliveryStatus/recipientSnapshot play no role here.
+          if (m.systemKind) continue;
           unread += 1;
           const mentioned = (m.mentions ?? []).some(
             (men) =>

--- a/src/daemon/channels/ChannelService.ts
+++ b/src/daemon/channels/ChannelService.ts
@@ -41,6 +41,8 @@ import {
   type ChannelVisibility,
   HUMAN_WORKSPACE_ID,
   HUMAN_MEMBER_ID,
+  OPERATOR_JOIN_SYSTEM_TEXT,
+  type OperatorChannelSummary,
 } from '../../shared/channels';
 import { HUMAN_SELF_PRINCIPAL_ID } from '../../shared/principals';
 import { CHANNELS_EPOCH, EMPTY_CHANNEL_STATE } from '../../shared/channels';
@@ -265,6 +267,29 @@ export interface JoinChannelParams {
    * only — never an authz input (#113).
    */
   senderPtyId?: string;
+}
+
+/**
+ * operator-join (설계 §2.1) — 오퍼레이터(사람)가 에이전트들이 만든 비공개 채널에
+ * 스스로 들어가는 파라미터. **정확히 두 필드뿐**이다(타입 수준 강제, Codex #2):
+ * 좌석 행은 본문이 상수로만 구성하며, caller가 실어 보낸 member/includeHistory 등은
+ * 절대 읽지 않는다 — P5류 주입(create의 members[] 우회)의 재발 방지 핵심이다. 원시
+ * params 객체에 여분 필드가 실려 와도 이 타입엔 존재하지 않으므로 본문이 접근할
+ * 수 없다(join()과 별도 본문인 이유 — 공용 헬퍼로 caller 필드를 소비하는 형태 금지).
+ */
+export interface OperatorJoinParams {
+  channelId: string;
+  /** 서버-검증 workspaceId. 좌석이 하드코딩이라 authz 입력이 아니다 — "no anonymous
+   *  mutation" 자세 확인용 존재 검증만(kick 관례). 직결 잔여 함의는 설계 §2.1.2. */
+  verifiedWorkspaceId: string;
+}
+
+/**
+ * operator-list (설계 §2.2) — 비공개 채널 발견 어포던스. 파라미터는
+ * verifiedWorkspaceId 하나(존재 검증 전용). 전 채널의 메타데이터만 반환한다.
+ */
+export interface OperatorListParams {
+  verifiedWorkspaceId: string;
 }
 
 export interface LeaveChannelParams {
@@ -563,6 +588,36 @@ export class ChannelService {
     if (!channel) return null;
     if (!this.isVisibleTo(channel, verifiedWorkspaceId)) return null;
     return channel;
+  }
+
+  /**
+   * operator-list (설계 §2.2) — 발견 어포던스. private 채널은 list()에서 비멤버에게
+   * 숨겨지므로, GUI가 "들어갈 수 있는 방"을 보여줄 방법이 필요하다. 전 채널
+   * (공개+비공개, active+archived)의 **메타데이터만** 반환한다 — 메시지 미리보기·
+   * 멤버 상세 없음(내용을 읽으려면 operatorJoin해야 하고, 그건 시스템 메시지를
+   * 남긴다 §2.1.1). verifiedWorkspaceId는 필터가 아니라 존재 검증 전용이다: 전
+   * 채널을 반환하되(name 포함 유지 — 이름 없는 목록은 맹목 join 유발로 오히려
+   * 해롭다 §2.2), 부재 시엔 빈 목록(no anonymous). 우발 노출은 GUI 의도 게이트로
+   * 해소한다(접힘 기본 오퍼레이터 섹션 §3). 직결 잔여에서 이 메서드가 "전 private
+   * 채널 name·memberCount 열거 오라클"이 됨은 §2.2에서 디스크 등가로 명시 수용.
+   *
+   * 정렬 결정성: createdAt 오름차순, 동률은 id 사전순 tiebreak(안정 결정성).
+   */
+  operatorList(params: OperatorListParams): OperatorChannelSummary[] {
+    // 존재 검증(no anonymous). 부재는 handler가 이미 거르지만, 심층 방어로 여기서도
+    // 빈 목록을 반환한다 — 직결 잔여 호출자에게도 정체성 스탬프 없이는 열거를 주지
+    // 않는다(디스크 등가라 방어 경계는 아니나, API가 디스크보다 강하지 않게 유지).
+    if (!params.verifiedWorkspaceId) return [];
+    return this.state.channels
+      .map((c) => ({
+        id: c.id,
+        name: c.name,
+        visibility: c.visibility,
+        status: c.status,
+        memberCount: (this.state.members[c.id] ?? []).length,
+        createdAt: c.createdAt,
+      }))
+      .sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id));
   }
 
   /**
@@ -1121,6 +1176,148 @@ export class ChannelService {
         'membership',
       );
       return { ok: true, memberId: joinMemberId };
+    });
+  }
+
+  /**
+   * operator-join (설계 §2.1) — 오퍼레이터(사람)가 에이전트들이 만든 비공개 채널에
+   * **스스로** 들어가는 신뢰 경로. #288 가시성 게이트를 의식적으로 우회하지만(존재
+   * → archived → duplicate 게이트는 join()과 동일), **좌석 행은 caller 파라미터를
+   * 일절 읽지 않고 상수로만 구성**한다 — join()과 별도 본문인 이유(공용 헬퍼로
+   * caller 필드를 소비하는 형태 금지, P5류 주입 재발 방지, Codex #2).
+   *
+   * 에러 코드(§2.1): 없는 id → CHANNEL_NOT_FOUND(주인 상대 존재 은폐 불필요 —
+   * join()의 private 마스킹과 달리 여기선 실제 부재만 이 코드), archived →
+   * CHANNEL_ARCHIVED, 이미 멤버 → DUPLICATE_MEMBER(GUI가 no-op으로 처리;
+   * silent-success 아님 — join()과 의미론 일치).
+   *
+   * 성공 시 서버-발행 시스템 메시지 1건을 채널 히스토리에 **영속 append**한다
+   * (§2.1.1 필수): 좌석 push와 메시지 append를 하나의 커밋(operator-join envelope)
+   * 으로 묶어 원자성을 보장한다 — persist 실패 시 둘 다 미적용(로그 모드) 또는 둘 다
+   * 롤백(레거시 모드). 이 흔적은 (a) leave 후에도 남는 내구 감사이고 (b) #113 잔여로
+   * 위조된 입장(§2.1.2)을 사람이 GUI에서 발견하는 유일한 장치다.
+   *
+   * authz: verifiedWorkspaceId는 좌석이 하드코딩이라 authz 입력이 아니다 — 존재
+   * 검증만(kick 관례). humans-only는 트랜스포트가 강제한다(파이프 미등록 §2.3).
+   * 재진입: leave 후 재-operatorJoin은 일반 join과 같은 "새 좌석"(unread 리셋) —
+   * 상태 이월 없음(§2.1, GLM ①).
+   */
+  async operatorJoin(params: OperatorJoinParams): Promise<Result<{ memberId: string }>> {
+    // "no anonymous mutation" — verifiedWorkspaceId 부재 거부(handler와 대칭 심층
+    // 방어). 좌석은 하드코딩이라 authz 입력은 아니지만, 스탬프 없는 호출은 받지
+    // 않는다(kick/archive 관례). handler도 동일 거부(daemon/index.ts).
+    if (!params.verifiedWorkspaceId) {
+      return { ok: false, error: { code: 'NOT_AUTHORIZED', message: 'verifiedWorkspaceId is required' } };
+    }
+    return this.withChannelLock(params.channelId, async () => {
+      const channel = this.state.channels.find((c) => c.id === params.channelId);
+      if (!channel) {
+        return { ok: false, error: { code: 'CHANNEL_NOT_FOUND', message: `No such channel: ${params.channelId}` } };
+      }
+      // archived 게이트 — join()/invite()/kick()과 동일. archived 채널엔 좌석을
+      // 심지 않는다(§2.1: join은 CHANNEL_ARCHIVED로 거부).
+      if (channel.status === 'archived') {
+        return { ok: false, error: { code: 'CHANNEL_ARCHIVED', message: 'Cannot join an archived channel' } };
+      }
+      const members = this.state.members[channel.id] ?? [];
+      // duplicate 게이트 — 사람 좌석은 (HUMAN_WORKSPACE_ID, HUMAN_MEMBER_ID) 상수라
+      // caller 입력과 무관하게 이 한 행의 존재로 판정한다.
+      if (members.some((m) => m.workspaceId === HUMAN_WORKSPACE_ID && m.memberId === HUMAN_MEMBER_ID)) {
+        return { ok: false, error: { code: 'DUPLICATE_MEMBER', message: 'Already a member' } };
+      }
+      const now = this.now();
+      // 시스템 메시지가 소비할 seq — 좌석 lastReadSeq 계산에 쓸 nextSeq를 append
+      // 전에 캡처(§2.1: lastReadSeq = nextSeq-1). 메시지는 이 seq를 소비하고
+      // 오퍼레이터 본인이 작성자이므로 unread 계산이 자기-작성 메시지를 면제 →
+      // 오퍼레이터 unread = 0(§2.1 "unread = 0").
+      const seq = channel.nextSeq;
+      // 좌석 행 — **상수로만** 구성(설계 §2.1). caller params를 읽지 않는다. shape는
+      // P5 병합 human 행과 동일(memberName 없음 — 렌더러가 localized "Me"로 대체):
+      // workspaceId / memberId / joinedAt / historyFromSeq(전체 히스토리=0) /
+      // lastReadSeq(nextSeq-1) / principalId.
+      const seatRow: ChannelMember = {
+        workspaceId: HUMAN_WORKSPACE_ID,
+        memberId: HUMAN_MEMBER_ID,
+        joinedAt: now,
+        historyFromSeq: 0,
+        lastReadSeq: channel.nextSeq - 1,
+        principalId: HUMAN_SELF_PRINCIPAL_ID,
+      };
+      // 서버-발행 시스템 메시지(§2.1.1). systemKind로 판별하고 text는 폴백이다.
+      // deliveryStatus='delivered' + recipientSnapshot 부재 = 배달/nudge 대상이
+      // 아닌 감사 마커(wake worker가 이 행으로 재-nudge를 걸지 않는다).
+      const systemMessage: ChannelMessage = {
+        channelId: channel.id,
+        seq,
+        workspaceId: HUMAN_WORKSPACE_ID,
+        memberId: HUMAN_MEMBER_ID,
+        memberName: this.deriveMemberName(HUMAN_MEMBER_ID, HUMAN_SELF_PRINCIPAL_ID),
+        text: OPERATOR_JOIN_SYSTEM_TEXT,
+        postedAt: now,
+        deliveryStatus: 'delivered',
+        systemKind: 'operator-join',
+      };
+      if (this.eventLog) {
+        // 로그 모드: 좌석+메시지를 하나의 operator-join envelope로 원자 커밋. fsync
+        // 배리어 성공 후에만 둘 다 적용된다 — 실패 = 무적용(부분 상태 구조적 불가,
+        // 롤백 블록 불요). 이것이 "persist 실패 시 원자 롤백"의 로그-모드 형태다.
+        if (
+          !(await this.commitAndApply(
+            { kind: 'operator-join', channelId: channel.id, member: seatRow, message: systemMessage },
+            { verifiedWorkspaceId: params.verifiedWorkspaceId, principalId: HUMAN_SELF_PRINCIPAL_ID },
+          ))
+        ) {
+          return { ok: false, error: { code: 'PERSIST_FAILED', message: 'Failed to persist operator join' } };
+        }
+      } else {
+        // 레거시 모드: 좌석 push + seq 소비 + 메시지 append를 적용한 뒤 동기 저장.
+        // 실패 시 셋 다 원자 롤백(§2.1.1): pop 메시지 → un-bump nextSeq → pop 좌석 →
+        // emptySince 복원. join()/post()의 레거시 롤백 패턴과 동형.
+        const previousEmptySince = channel.emptySince;
+        if (channel.emptySince !== undefined) delete channel.emptySince;
+        members.push(seatRow);
+        this.state.members[channel.id] = members;
+        channel.nextSeq++;
+        (this.state.messages[channel.id] ??= []).push(systemMessage);
+        if (!this.saveOrFail()) {
+          const msgs = this.state.messages[channel.id];
+          if (msgs) msgs.pop();
+          channel.nextSeq--;
+          members.pop();
+          channel.emptySince = previousEmptySince;
+          return { ok: false, error: { code: 'PERSIST_FAILED', message: 'Failed to persist operator join' } };
+        }
+      }
+      // 멤버십 변경 팬아웃 — post-join 멤버 집합(사람 포함)에 roster/sidebar 재동기
+      // (join()과 동일 신호). 최선노력·비내구라 §2.1.1 시스템 메시지가 내구 흔적을
+      // 별도로 남긴다.
+      this.emitCatalog(
+        channel.id,
+        HUMAN_WORKSPACE_ID,
+        (this.state.members[channel.id] ?? []).map((m) => m.workspaceId),
+        'membership',
+      );
+      // 시스템 메시지 라이브 팬아웃(best-effort) — 열린 ChannelView에 즉시 표시.
+      // 실패는 post()와 동일하게 무시(내구성은 위 영속 append가 이미 보장). 시스템
+      // 마커라 recipients는 빈 목록.
+      try {
+        this.emit({
+          type: 'channel.message',
+          channelId: channel.id,
+          seq,
+          sender: {
+            workspaceId: HUMAN_WORKSPACE_ID,
+            memberId: HUMAN_MEMBER_ID,
+            memberName: systemMessage.memberName,
+          },
+          recipients: [],
+          message: systemMessage,
+          workspaceId: HUMAN_WORKSPACE_ID,
+        });
+      } catch (err) {
+        console.error('[ChannelService] operatorJoin system-message emit failed:', err);
+      }
+      return { ok: true, memberId: HUMAN_MEMBER_ID };
     });
   }
 

--- a/src/daemon/channels/__tests__/ChannelService.eventlog.test.ts
+++ b/src/daemon/channels/__tests__/ChannelService.eventlog.test.ts
@@ -194,6 +194,35 @@ describe('ChannelService × 이벤트로그 (§5 커밋경로 반전)', () => {
     h2.log.close();
   });
 
+  it('operator-join: 좌석+시스템 메시지가 1 envelope로 커밋되고 재부트 replay가 수렴', async () => {
+    const h = makeHarness();
+    // 에이전트가 만든 비공개 채널.
+    const created = await h.svc.create({
+      name: 'secret',
+      visibility: 'private',
+      createdBy: { workspaceId: 'ws-agent', memberId: 'agent-1' },
+      verifiedWorkspaceId: 'ws-agent',
+    });
+    if (!created.ok) throw new Error('create failed');
+    const before = h.log.readAllRecords().length;
+    const res = await h.svc.operatorJoin({
+      channelId: created.channel.id,
+      verifiedWorkspaceId: 'ws-human',
+    });
+    expect(res.ok).toBe(true);
+    // 좌석 push + 시스템 메시지 append가 단 하나의 operator-join envelope다(1 커밋 = 1 envelope).
+    const recs = h.log.readAllRecords();
+    expect(recs.length).toBe(before + 1);
+    expect((recs.at(-1)?.payload as { kind: string }).kind).toBe('operator-join');
+    const live = stateOf(h.svc);
+    h.log.close();
+
+    // 재부트: genesis + 전체 replay가 라이브 projection과 정확히 수렴(원자 재적용).
+    const h2 = makeHarness();
+    expect(stateOf(h2.svc)).toEqual(live);
+    h2.log.close();
+  });
+
   it('재부트(스냅샷 가속): flush된 스냅샷 + tail replay가 수렴', async () => {
     const h = makeHarness();
     const chId = await runBattery(h.svc);

--- a/src/daemon/channels/__tests__/ChannelService.operatorJoin.test.ts
+++ b/src/daemon/channels/__tests__/ChannelService.operatorJoin.test.ts
@@ -1,0 +1,396 @@
+// ─── operator-join tests (설계 §2.1/§2.2) ─────────────────────────────────────
+// 오퍼레이터(사람)가 에이전트들이 만든 비공개 채널에 스스로 들어가는 신뢰 경로와
+// 그 발견 목록에 대한 단위 테스트. 보안 스펙의 핵심(파라미터 주입 무시 / 서버-발행
+// 시스템 메시지 원자 append / 좌석 shape 정합)을 고정한다.
+
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { ChannelService } from '../ChannelService';
+import type { ChannelServiceEmit } from '../ChannelService';
+import { applyChannelEvent } from '../channelEvents';
+import type { ChannelEventPayload } from '../channelEvents';
+import {
+  HUMAN_WORKSPACE_ID,
+  HUMAN_MEMBER_ID,
+  type ChannelMessage,
+  type ChannelState,
+} from '../../../shared/channels';
+import { HUMAN_SELF_PRINCIPAL_ID } from '../../../shared/principals';
+
+// 인메모리 fake writer(ChannelService.test.ts와 동일 계약) — legacy 모드 구동.
+function makeFakeWriter(opts: { failNext?: boolean } = {}) {
+  let failNext = opts.failNext ?? false;
+  let lastSaved: ChannelState | null = null;
+  const freshState = (): ChannelState => ({
+    version: 1,
+    channels: [],
+    members: {},
+    messages: {},
+    idempotency: {},
+  });
+  const clone = (state: ChannelState): ChannelState => ({
+    version: state.version,
+    channels: state.channels.map((c) => ({ ...c })),
+    members: Object.fromEntries(
+      Object.entries(state.members).map(([k, v]) => [k, v.map((m) => ({ ...m }))]),
+    ),
+    messages: Object.fromEntries(
+      Object.entries(state.messages).map(([k, v]) => [k, v.map((m) => ({ ...m }))]),
+    ),
+    idempotency: Object.fromEntries(
+      Object.entries(state.idempotency).map(([k, v]) => [k, { ...v }]),
+    ),
+  });
+  return {
+    saveImmediate: vi.fn((state: ChannelState): boolean => {
+      if (failNext) {
+        failNext = false;
+        return false;
+      }
+      lastSaved = state;
+      return true;
+    }),
+    load: vi.fn((): ChannelState => (lastSaved ? clone(lastSaved) : freshState())),
+    setFailNext() {
+      failNext = true;
+    },
+  };
+}
+
+function makeService() {
+  const writer = makeFakeWriter();
+  const emit = vi.fn<ChannelServiceEmit>();
+  const svc = new ChannelService({
+    writer: writer as unknown as ConstructorParameters<typeof ChannelService>[0]['writer'],
+    companyId: 'co-test',
+    emit,
+    now: () => 1_700_000_000_000,
+  });
+  return { svc, writer, emit };
+}
+
+/** 에이전트가 만든 비공개 채널(사람은 비멤버) — operatorJoin의 표준 대상. */
+async function makePrivateAgentChannel(svc: ChannelService): Promise<string> {
+  const created = await svc.create({
+    name: 'secret-room',
+    visibility: 'private',
+    createdBy: { workspaceId: 'ws-agent', memberId: 'agent-1', memberName: 'Agent' },
+    verifiedWorkspaceId: 'ws-agent',
+  });
+  if (!created.ok) throw new Error(`create failed: ${created.error.code}`);
+  return created.channel.id;
+}
+
+describe('ChannelService.operatorJoin', () => {
+  it('joins a PRIVATE channel that is invisible to the human (bypasses #288 gate)', async () => {
+    const { svc } = makeService();
+    const channelId = await makePrivateAgentChannel(svc);
+    // 사전조건: 사람은 이 비공개 채널을 볼 수 없다(list/get 비가시).
+    expect(svc.get(channelId, HUMAN_WORKSPACE_ID)).toBeNull();
+
+    const res = await svc.operatorJoin({ channelId, verifiedWorkspaceId: HUMAN_WORKSPACE_ID });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error.code);
+    expect(res.memberId).toBe(HUMAN_MEMBER_ID);
+    // 사후조건: 이제 사람에게 보인다.
+    expect(svc.get(channelId, HUMAN_WORKSPACE_ID)).not.toBeNull();
+  });
+
+  it('rejects an archived channel with CHANNEL_ARCHIVED', async () => {
+    const { svc } = makeService();
+    const channelId = await makePrivateAgentChannel(svc);
+    await svc.archive({ channelId, archivedBy: 'ws-agent', verifiedWorkspaceId: 'ws-agent' });
+    const res = await svc.operatorJoin({ channelId, verifiedWorkspaceId: HUMAN_WORKSPACE_ID });
+    expect(res).toMatchObject({ ok: false, error: { code: 'CHANNEL_ARCHIVED' } });
+  });
+
+  it('rejects a second operatorJoin with DUPLICATE_MEMBER (no silent success)', async () => {
+    const { svc } = makeService();
+    const channelId = await makePrivateAgentChannel(svc);
+    await svc.operatorJoin({ channelId, verifiedWorkspaceId: HUMAN_WORKSPACE_ID });
+    const res = await svc.operatorJoin({ channelId, verifiedWorkspaceId: HUMAN_WORKSPACE_ID });
+    expect(res).toMatchObject({ ok: false, error: { code: 'DUPLICATE_MEMBER' } });
+  });
+
+  it('rejects an unknown channel with CHANNEL_NOT_FOUND', async () => {
+    const { svc } = makeService();
+    const res = await svc.operatorJoin({ channelId: 'ch-missing', verifiedWorkspaceId: HUMAN_WORKSPACE_ID });
+    expect(res).toMatchObject({ ok: false, error: { code: 'CHANNEL_NOT_FOUND' } });
+  });
+
+  it('rejects a missing verifiedWorkspaceId with NOT_AUTHORIZED (no anonymous mutation)', async () => {
+    const { svc } = makeService();
+    const channelId = await makePrivateAgentChannel(svc);
+    const res = await svc.operatorJoin({ channelId, verifiedWorkspaceId: '' });
+    expect(res).toMatchObject({ ok: false, error: { code: 'NOT_AUTHORIZED' } });
+  });
+
+  it('seat row shape matches the P5-merged human row EXACTLY (no memberName, hardcoded principal)', async () => {
+    const { svc } = makeService();
+    const channelId = await makePrivateAgentChannel(svc);
+    await svc.operatorJoin({ channelId, verifiedWorkspaceId: HUMAN_WORKSPACE_ID });
+    const rows = svc.getMembers(channelId, HUMAN_WORKSPACE_ID);
+    const human = rows.find((m) => m.memberId === HUMAN_MEMBER_ID);
+    // 정확 키 집합 — memberName 없음(렌더러가 localized "Me"로 대체), principal 하드코딩.
+    expect(human).toEqual({
+      workspaceId: HUMAN_WORKSPACE_ID,
+      memberId: HUMAN_MEMBER_ID,
+      joinedAt: 1_700_000_000_000,
+      historyFromSeq: 0,
+      lastReadSeq: 0, // create 직후 nextSeq=1 → nextSeq-1
+      principalId: HUMAN_SELF_PRINCIPAL_ID,
+    });
+    expect(human).not.toHaveProperty('memberName');
+  });
+
+  it('IGNORES injected garbage params (member / includeHistory / workspaceId) — constant seat only', async () => {
+    const { svc } = makeService();
+    const channelId = await makePrivateAgentChannel(svc);
+    // 원시 params에 P5류 주입을 시도한다(타입 표면엔 없으므로 any 캐스트로 강제 주입).
+    await svc.operatorJoin({
+      channelId,
+      verifiedWorkspaceId: HUMAN_WORKSPACE_ID,
+      member: { workspaceId: 'ws-evil', memberId: 'evil-seat', principalId: 'evil-principal' },
+      includeHistory: false,
+      workspaceId: 'ws-evil',
+      historyFromSeq: 999,
+      lastReadSeq: 999,
+    } as unknown as Parameters<ChannelService['operatorJoin']>[0]);
+    const rows = svc.getMembers(channelId, HUMAN_WORKSPACE_ID);
+    // 주입된 ws-evil/evil-seat 좌석은 존재하지 않는다.
+    expect(rows.some((m) => m.workspaceId === 'ws-evil' || m.memberId === 'evil-seat')).toBe(false);
+    const human = rows.find((m) => m.memberId === HUMAN_MEMBER_ID);
+    // 좌석은 상수: principal은 HUMAN_SELF, historyFromSeq는 0(주입된 999 아님).
+    expect(human?.principalId).toBe(HUMAN_SELF_PRINCIPAL_ID);
+    expect(human?.historyFromSeq).toBe(0);
+  });
+
+  it('appends a server-published system message that consumes a seq (durable audit)', async () => {
+    const { svc } = makeService();
+    const channelId = await makePrivateAgentChannel(svc);
+    const before = svc.get(channelId, 'ws-agent');
+    expect(before?.nextSeq).toBe(1);
+
+    await svc.operatorJoin({ channelId, verifiedWorkspaceId: HUMAN_WORKSPACE_ID });
+
+    // seq 소비: nextSeq가 1 전진.
+    const after = svc.get(channelId, 'ws-agent');
+    expect(after?.nextSeq).toBe(2);
+    // 히스토리에 systemKind 마커 1건.
+    const msgs = svc.getMessages(channelId, undefined, HUMAN_WORKSPACE_ID);
+    const sys = msgs.filter((m) => m.systemKind === 'operator-join');
+    expect(sys).toHaveLength(1);
+    expect(sys[0].seq).toBe(1);
+    expect(sys[0].workspaceId).toBe(HUMAN_WORKSPACE_ID);
+    expect(sys[0].memberId).toBe(HUMAN_MEMBER_ID);
+  });
+
+  it('atomically ROLLS BACK seat AND system message when persist fails', async () => {
+    const { svc, writer } = makeService();
+    const channelId = await makePrivateAgentChannel(svc);
+    writer.setFailNext(); // 다음 saveImmediate(=operatorJoin의 저장)가 실패한다.
+
+    const res = await svc.operatorJoin({ channelId, verifiedWorkspaceId: HUMAN_WORKSPACE_ID });
+    expect(res).toMatchObject({ ok: false, error: { code: 'PERSIST_FAILED' } });
+
+    // 좌석 미추가.
+    const rows = svc.getMembers(channelId, 'ws-agent');
+    expect(rows.some((m) => m.memberId === HUMAN_MEMBER_ID)).toBe(false);
+    // 메시지 미append.
+    expect(svc.getMessages(channelId, undefined, 'ws-agent')).toHaveLength(0);
+    // nextSeq 원복(1).
+    expect(svc.get(channelId, 'ws-agent')?.nextSeq).toBe(1);
+  });
+
+  it('emits a membership catalog fan-out INCLUDING the agent members + the human', async () => {
+    const { svc, emit } = makeService();
+    const channelId = await makePrivateAgentChannel(svc);
+    emit.mockClear();
+    await svc.operatorJoin({ channelId, verifiedWorkspaceId: HUMAN_WORKSPACE_ID });
+
+    const catalog = emit.mock.calls
+      .map((c) => c[0])
+      .find((e) => e.type === 'channel.catalog');
+    expect(catalog?.type).toBe('channel.catalog');
+    if (catalog?.type === 'channel.catalog') {
+      expect(catalog.reason).toBe('membership');
+      expect(catalog.recipientWorkspaceIds).toContain(HUMAN_WORKSPACE_ID);
+      expect(catalog.recipientWorkspaceIds).toContain('ws-agent');
+    }
+    // 시스템 메시지 라이브 팬아웃도 발생(systemKind 포함).
+    const message = emit.mock.calls
+      .map((c) => c[0])
+      .find((e) => e.type === 'channel.message');
+    expect(message?.type).toBe('channel.message');
+    if (message?.type === 'channel.message') {
+      expect(message.message.systemKind).toBe('operator-join');
+    }
+  });
+
+  it('re-operatorJoin after leave gets a FRESH seat (unread reset, no state carry)', async () => {
+    const { svc } = makeService();
+    const channelId = await makePrivateAgentChannel(svc);
+    await svc.operatorJoin({ channelId, verifiedWorkspaceId: HUMAN_WORKSPACE_ID });
+    // 사람이 leave.
+    await svc.leave({
+      channelId,
+      workspaceId: HUMAN_WORKSPACE_ID,
+      memberId: HUMAN_MEMBER_ID,
+      verifiedWorkspaceId: HUMAN_WORKSPACE_ID,
+    });
+    expect(svc.getMembers(channelId, 'ws-agent').some((m) => m.memberId === HUMAN_MEMBER_ID)).toBe(false);
+    // 재진입 — 새 좌석 lastReadSeq = 재진입 시점 nextSeq-1(상태 이월 없음).
+    const before = svc.get(channelId, 'ws-agent')?.nextSeq ?? 0;
+    const res = await svc.operatorJoin({ channelId, verifiedWorkspaceId: HUMAN_WORKSPACE_ID });
+    expect(res.ok).toBe(true);
+    const human = svc.getMembers(channelId, HUMAN_WORKSPACE_ID).find((m) => m.memberId === HUMAN_MEMBER_ID);
+    expect(human?.lastReadSeq).toBe(before - 1);
+    expect(human?.historyFromSeq).toBe(0);
+  });
+});
+
+describe('ChannelService.operatorList', () => {
+  it('returns metadata-only projection (no messages, no member detail)', async () => {
+    const { svc } = makeService();
+    await makePrivateAgentChannel(svc);
+    const list = svc.operatorList({ verifiedWorkspaceId: HUMAN_WORKSPACE_ID });
+    expect(list).toHaveLength(1);
+    // 정확 키 집합 — 프로젝션 필드만.
+    expect(Object.keys(list[0]).sort()).toEqual(
+      ['createdAt', 'id', 'memberCount', 'name', 'status', 'visibility'].sort(),
+    );
+    expect(list[0]).not.toHaveProperty('messages');
+    expect(list[0]).not.toHaveProperty('members');
+  });
+
+  it('includes private channels the caller is NOT a member of', async () => {
+    const { svc } = makeService();
+    const channelId = await makePrivateAgentChannel(svc);
+    // 사람은 비멤버지만 operatorList엔 보인다(발견 어포던스).
+    const list = svc.operatorList({ verifiedWorkspaceId: HUMAN_WORKSPACE_ID });
+    expect(list.map((c) => c.id)).toContain(channelId);
+    expect(list[0].visibility).toBe('private');
+    expect(list[0].memberCount).toBe(1); // agent creator only
+  });
+
+  it('includes ARCHIVED channels (audit visibility)', async () => {
+    const { svc } = makeService();
+    const channelId = await makePrivateAgentChannel(svc);
+    await svc.archive({ channelId, archivedBy: 'ws-agent', verifiedWorkspaceId: 'ws-agent' });
+    const list = svc.operatorList({ verifiedWorkspaceId: HUMAN_WORKSPACE_ID });
+    expect(list.find((c) => c.id === channelId)?.status).toBe('archived');
+  });
+
+  it('is deterministically ordered (createdAt asc, id tiebreak)', async () => {
+    const writer = makeFakeWriter();
+    const emit = vi.fn<ChannelServiceEmit>();
+    // 같은 now()로 두 채널을 만들어 createdAt 동률을 강제 → id tiebreak 검증.
+    const svc = new ChannelService({
+      writer: writer as unknown as ConstructorParameters<typeof ChannelService>[0]['writer'],
+      companyId: 'co-test',
+      emit,
+      now: () => 1_700_000_000_000,
+    });
+    const a = await svc.create({
+      name: 'aaa',
+      visibility: 'public',
+      createdBy: { workspaceId: 'ws-1', memberId: 'm', memberName: 'M' },
+      verifiedWorkspaceId: 'ws-1',
+    });
+    const b = await svc.create({
+      name: 'bbb',
+      visibility: 'public',
+      createdBy: { workspaceId: 'ws-1', memberId: 'm', memberName: 'M' },
+      verifiedWorkspaceId: 'ws-1',
+    });
+    if (!a.ok || !b.ok) throw new Error('create failed');
+    const list = svc.operatorList({ verifiedWorkspaceId: HUMAN_WORKSPACE_ID });
+    const ids = list.map((c) => c.id);
+    // createdAt 동률이므로 id 사전순으로 결정론적.
+    const expected = [a.channel.id, b.channel.id].sort((x, y) => x.localeCompare(y));
+    expect(ids).toEqual(expected);
+  });
+
+  it('rejects (empty list) a missing verifiedWorkspaceId', async () => {
+    const { svc } = makeService();
+    await makePrivateAgentChannel(svc);
+    expect(svc.operatorList({ verifiedWorkspaceId: '' })).toEqual([]);
+  });
+});
+
+// ─── replay 적용기: operator-join 이벤트의 원자성 + 멱등성 ─────────────────────
+describe('applyChannelEvent — operator-join (compound event replay)', () => {
+  function seedState(): ChannelState {
+    return {
+      version: 1,
+      channels: [
+        {
+          id: 'ch-1',
+          companyId: 'co',
+          name: 'secret',
+          visibility: 'private',
+          status: 'active',
+          createdAt: 1,
+          createdBy: 'ws-agent',
+          nextSeq: 1,
+        },
+      ],
+      members: { 'ch-1': [{ workspaceId: 'ws-agent', memberId: 'agent-1', joinedAt: 1, historyFromSeq: 0, lastReadSeq: 0 }] },
+      messages: { 'ch-1': [] },
+      idempotency: {},
+    };
+  }
+  const sysMsg: ChannelMessage = {
+    channelId: 'ch-1',
+    seq: 1,
+    workspaceId: HUMAN_WORKSPACE_ID,
+    memberId: HUMAN_MEMBER_ID,
+    memberName: HUMAN_MEMBER_ID,
+    text: 'Operator joined the channel.',
+    postedAt: 2,
+    deliveryStatus: 'delivered',
+    systemKind: 'operator-join',
+  };
+  const event: ChannelEventPayload = {
+    kind: 'operator-join',
+    channelId: 'ch-1',
+    member: {
+      workspaceId: HUMAN_WORKSPACE_ID,
+      memberId: HUMAN_MEMBER_ID,
+      joinedAt: 2,
+      historyFromSeq: 0,
+      lastReadSeq: 0,
+      principalId: HUMAN_SELF_PRINCIPAL_ID,
+    },
+    message: sysMsg,
+  };
+
+  it('applies BOTH effects (seat push + message append + nextSeq advance)', () => {
+    const state = seedState();
+    applyChannelEvent(state, event);
+    expect(state.members['ch-1'].some((m) => m.memberId === HUMAN_MEMBER_ID)).toBe(true);
+    expect(state.messages['ch-1']).toHaveLength(1);
+    expect(state.messages['ch-1'][0].systemKind).toBe('operator-join');
+    expect(state.channels[0].nextSeq).toBe(2);
+  });
+
+  it('is idempotent — re-applying the same event is a no-op (no dup seat, no dup message)', () => {
+    const state = seedState();
+    applyChannelEvent(state, event);
+    applyChannelEvent(state, event);
+    expect(state.members['ch-1'].filter((m) => m.memberId === HUMAN_MEMBER_ID)).toHaveLength(1);
+    expect(state.messages['ch-1']).toHaveLength(1);
+    expect(state.channels[0].nextSeq).toBe(2);
+  });
+});
+
+// ─── 경계 고정: MCP 도구 표면에 operator 메서드 부재 ──────────────────────────
+describe('operator methods are absent from the bundled MCP tool surface', () => {
+  it('src/mcp/channels.ts never references operatorJoin / operatorList', () => {
+    // vitest는 리포 루트(worktree)에서 실행된다 — cwd 기준 상대 경로로 소스를 읽는다.
+    const channelsTool = readFileSync(resolve(process.cwd(), 'src/mcp/channels.ts'), 'utf8');
+    expect(channelsTool).not.toContain('operatorJoin');
+    expect(channelsTool).not.toContain('operatorList');
+  });
+});

--- a/src/daemon/channels/__tests__/ChannelService.operatorJoin.test.ts
+++ b/src/daemon/channels/__tests__/ChannelService.operatorJoin.test.ts
@@ -186,6 +186,23 @@ describe('ChannelService.operatorJoin', () => {
     expect(sys[0].memberId).toBe(HUMAN_MEMBER_ID);
   });
 
+  it('system message owes NO unread to agent members (audit marker, not deliverable work)', async () => {
+    const { svc } = makeService();
+    const channelId = await makePrivateAgentChannel(svc);
+
+    await svc.operatorJoin({ channelId, verifiedWorkspaceId: HUMAN_WORKSPACE_ID });
+
+    // 채널 생성자(에이전트)의 unread — unreadFor()의 systemKind 면제가 wake
+    // worker의 plain-unread nudge를 막는 실제 장치다(3모델 리뷰 합의). 마커가
+    // seq는 소비하되(headSeq 전진) 누구의 unread도 만들지 않아야 한다.
+    const rows = svc.unreadFor('ws-agent', 'agent-1');
+    const row = rows.find((r) => r.channelId === channelId);
+    expect(row).toBeDefined();
+    expect(row?.headSeq).toBe(1);
+    expect(row?.unread).toBe(0);
+    expect(row?.mentionUnread).toBe(0);
+  });
+
   it('atomically ROLLS BACK seat AND system message when persist fails', async () => {
     const { svc, writer } = makeService();
     const channelId = await makePrivateAgentChannel(svc);

--- a/src/daemon/channels/channelEvents.ts
+++ b/src/daemon/channels/channelEvents.ts
@@ -95,6 +95,21 @@ export type ChannelEventPayload =
       ackedAt: number;
     }
   | {
+      /**
+       * operator-join (설계 §2.1.1) — 오퍼레이터(사람) 좌석 push + 서버-발행 시스템
+       * 메시지 append를 **하나의 envelope**로 묶는다. 두 효과를 한 커밋에 실어
+       * 원자성을 보장한다: append-only 로그에서는 좌석만 커밋되고 메시지가 실패하는
+       * 부분 상태가 구조적으로 불가능해야 하므로("persist 실패 시 좌석·메시지 원자
+       * 롤백"), join+post 두 envelope로 쪼갤 수 없다. 1 커밋 = 1 envelope 불변식
+       * 유지(D16). 적용기는 멱등: 좌석은 (workspaceId, memberId) 존재 가드, 메시지는
+       * seq 존재/trim된 과거 seq 가드(post 적용기와 동형).
+       */
+      kind: 'operator-join';
+      channelId: string;
+      member: ChannelMember;
+      message: ChannelMessage;
+    }
+  | {
       /** §6.4c reseed 마커(migrateToEventLog가 append). 상태는 스냅샷이 운반 — replay 무동작. */
       kind: 'legacy-reseed';
       reseedNumber: number;
@@ -265,6 +280,36 @@ export function applyChannelEvent(state: ChannelState, payload: unknown): void {
           if (row.workspaceId !== p.workspaceId || row.memberId !== p.memberId) continue;
           const current = typeof row.lastReadSeq === 'number' ? row.lastReadSeq : -1;
           if (cursorTarget > current) row.lastReadSeq = cursorTarget;
+        }
+      }
+      return;
+    }
+    case 'operator-join': {
+      const ch = state.channels.find((c) => c.id === p.channelId);
+      if (!ch) return;
+      // 두 효과를 독립 멱등 가드로 적용(라이브는 항상 둘 다 실행하지만, 재적용
+      // 시 부분 반영 스냅샷도 안전하게 흡수한다).
+      // 1) 사람 좌석 push — (workspaceId, memberId) 존재 시 no-op(join 적용기와 동형).
+      const members = state.members[p.channelId] ?? [];
+      if (
+        !members.some(
+          (m) => m.workspaceId === p.member.workspaceId && m.memberId === p.member.memberId,
+        )
+      ) {
+        members.push({ ...p.member });
+        state.members[p.channelId] = members;
+        // operatorJoin은 leave 후 재진입도 "새 좌석" → join과 동일하게 emptySince 해제.
+        delete ch.emptySince;
+      }
+      // 2) 시스템 메시지 append — seq 존재/trim된 과거 seq 가드(post 적용기와 동형).
+      //    clientMsgId·cursorRide·nameRefresh 없음(시스템 마커).
+      const msgs = (state.messages[p.channelId] ??= []);
+      const seq = p.message.seq;
+      if (!msgs.some((m) => m.seq === seq) && seq >= ch.nextSeq) {
+        msgs.push({ ...p.message });
+        if (ch.nextSeq <= seq) ch.nextSeq = seq + 1;
+        if (msgs.length > CHANNEL_MESSAGES_MAX) {
+          state.messages[p.channelId] = msgs.slice(msgs.length - CHANNEL_MESSAGES_MAX);
         }
       }
       return;

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1959,6 +1959,54 @@ function registerRpcHandlers(
     });
   });
 
+  // a2a.channel.operatorJoin — 오퍼레이터(사람)가 에이전트들이 만든 비공개 채널에
+  // 스스로 들어가는 신뢰 경로(operator-join 설계 §2.1). kick/purgeMembership과 동일한
+  // HUMANS-ONLY 관례: 파이프 라우터(a2a.channel.rpc.ts)에 등록되지 않고 렌더러 전용
+  // channels:mutate-local IPC로만 도달한다. stampCaller를 돌리지 않는다(archive/kick과
+  // 동일 근거): 스탬프하면 senderPtyId만 가진 파이프 에이전트에게 humans-only 목적지로
+  // 향하는 정직한 데몬-파이프 경로를 열어주게 된다. 렌더러가 미리 채운
+  // verifiedWorkspaceId만 수용한다.
+  //
+  // §2.1.2 직결 잔여(명시 수용, kick 선례와 동일 클래스): 데몬 소켓 직결 호출자(같은
+  // OS 유저)는 이 메서드를 임의 verifiedWorkspaceId로 호출해 사람 좌석을 임의 채널에
+  // 심을 수 있다. 그러나 이 호출자는 이미 channels.json을 디스크에서 메시지 전문 포함
+  // 읽을 수 있으므로(L3 천장, #113) operatorJoin이 새로 주는 읽기 능력은 없다. 새로
+  // 생기는 "위조된 사람 입장 신호"는 ChannelService가 남기는 서버-발행 시스템 메시지
+  // (§2.1.1)가 사람에게 가시화한다 — 유일하게 가능한 방어 형태다.
+  pipeServer.onRpc('a2a.channel.operatorJoin', async (params) => {
+    // Deliberately NOT stamped (humans-only, kick/purgeMembership과 동일 근거).
+    const channelId = typeof params['channelId'] === 'string' ? params['channelId'] : '';
+    const verifiedWorkspaceId =
+      typeof params['verifiedWorkspaceId'] === 'string' ? params['verifiedWorkspaceId'] : '';
+    if (!channelId || !verifiedWorkspaceId) {
+      return {
+        ok: false,
+        error: {
+          code: 'NOT_AUTHORIZED',
+          message: 'channelId and a server-resolved verifiedWorkspaceId are required',
+        },
+      };
+    }
+    // 좌석 행은 ChannelService.operatorJoin이 상수로만 구성한다 — 여기서 params의
+    // 여분 필드(member/includeHistory 등)를 전달하지 않는다(§2.1 파라미터 표면 제거).
+    return channelService.operatorJoin({ channelId, verifiedWorkspaceId });
+  });
+
+  // a2a.channel.operatorList — 비공개 채널 발견 어포던스(설계 §2.2, 읽기 전용).
+  // operatorJoin과 동일한 humans-only 트랜스포트: private 채널은 list()에서 비멤버에게
+  // 숨겨지므로 GUI가 "들어갈 수 있는 방"을 보여주려면 이 메서드가 필요하다. 읽기지만
+  // 파이프에 노출하면 에이전트가 전 private 채널 이름을 열거할 수 있으므로 파이프
+  // 미등록 + 렌더러 전용 경로만. §2.2 직결 잔여: 같은 호출자는 이미 디스크에서 동일
+  // 정보+메시지 전문을 읽는다 — API가 디스크보다 강하지 않다(명시 수용).
+  pipeServer.onRpc('a2a.channel.operatorList', async (params) => {
+    const verifiedWorkspaceId =
+      typeof params['verifiedWorkspaceId'] === 'string' ? params['verifiedWorkspaceId'] : '';
+    if (!verifiedWorkspaceId) {
+      return { ok: false, error: { code: 'NOT_AUTHORIZED', message: 'verifiedWorkspaceId is required' } };
+    }
+    return { ok: true, channels: channelService.operatorList({ verifiedWorkspaceId }) };
+  });
+
   // ── A2A task registry (envelope PR4 §5 D11) ─────────────────────────
   // 데몬 정본 A2A 태스크 서비스. main의 a2a.rpc.ts가 렌더러 delivery와 병행해 이
   // 핸들러로 정본 상태(생성·전이·취소)를 커밋한다(dual-write 브리지 — D1). 정본은

--- a/src/main/ipc/handlers/__tests__/channelLocal.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/channelLocal.handler.test.ts
@@ -99,6 +99,11 @@ describe('channelLocal.handler — CHANNEL_MUTATE_LOCAL', () => {
       // shared nudge ledger (2a-2): renderer-only for the same reason as kick —
       // a forgeable pipe caller could suppress another member's re-nudges.
       'a2a.channel.nudgeRecorded',
+      // operator-join (§2.1/§2.2): operatorJoin (self-join a private room) +
+      // operatorList (discovery) ride THIS renderer-only allow-list and are
+      // deliberately absent from the pipe router — same humans-only stance as kick.
+      'a2a.channel.operatorJoin',
+      'a2a.channel.operatorList',
     ]) {
       rpc.mockClear();
       const r = await handler(fakeEvent, method, { verifiedWorkspaceId: 'ws-ceo' });

--- a/src/main/ipc/handlers/channelLocal.handler.ts
+++ b/src/main/ipc/handlers/channelLocal.handler.ts
@@ -78,6 +78,14 @@ const CHANNEL_MUTATING_METHODS: ReadonlySet<string> = new Set<string>([
   // allow-list is exactly the boundary that keeps a forgeable agent identity
   // (#113) from registering/deleting arbitrary principals.
   'a2a.channel.purgeMembership',
+  // operator-join (설계 §2.1/§2.2) — 오퍼레이터(사람)가 에이전트들이 만든 비공개
+  // 채널에 스스로 들어가는 신뢰 경로(operatorJoin) + 그 발견 목록(operatorList).
+  // kick/purge와 동일 humans-only 관례: 파이프 라우터(a2a.channel.rpc.ts)에 등록되지
+  // 않고 이 렌더러 전용 경로로만 도달한다. operatorList는 읽기지만 파이프에 노출하면
+  // 에이전트가 전 private 채널 이름을 열거할 수 있어 humans-only 트랜스포트가 필요
+  // 하므로 같은 allowlist에 둔다.
+  'a2a.channel.operatorJoin',
+  'a2a.channel.operatorList',
   'a2a.principal.upsert',
   'a2a.principal.remove',
   'a2a.principal.markStaleWorkspace',

--- a/src/main/mcp/__tests__/firstParty.test.ts
+++ b/src/main/mcp/__tests__/firstParty.test.ts
@@ -88,6 +88,11 @@ describe('FIRST_PARTY_METHODS source invariant', () => {
       'workspace.close',
       'company.create',
       'company.destroy',
+      // operator-join (§2.3 / Codex #7): registered in RpcMethod + METHOD_CAPABILITY
+      // for completeness, but MUST NOT be first-party-granted — that would leak an
+      // agent-reachable path to the humans-only operator surface.
+      'a2a.channel.operatorJoin',
+      'a2a.channel.operatorList',
     ] as const) {
       expect(FIRST_PARTY_METHODS.has(m)).toBe(false);
     }

--- a/src/main/mcp/firstParty.ts
+++ b/src/main/mcp/firstParty.ts
@@ -136,9 +136,15 @@ export const FIRST_PARTY_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
   'a2a.channel.getMessages',
   'a2a.channel.getMembers',
   'a2a.channel.create',
-  // NOTE: a2a.channel.archive is NOT here (nor is kick). Both are humans-only —
-  // routed via the renderer-only channels:mutate-local IPC, never the MCP/pipe
-  // surface — so a first-party agent is not granted them.
+  // NOTE: a2a.channel.archive is NOT here (nor is kick, nor operatorJoin /
+  // operatorList). All are humans-only — routed via the renderer-only
+  // channels:mutate-local IPC, never the MCP/pipe surface — so a first-party
+  // agent is not granted them. operatorJoin/operatorList are deliberately
+  // excluded here (operator-join design §2.3 / Codex #7): registering them in
+  // RpcMethod + METHOD_CAPABILITY for completeness must NOT leak an agent-
+  // reachable operator path. firstParty.test.ts (which parses src/mcp/ for the
+  // methods the bundled server actually calls) never requires them, since the
+  // bundled MCP server does not call operatorJoin/operatorList.
   'a2a.channel.join',
   'a2a.channel.leave',
   'a2a.channel.post',

--- a/src/main/mcp/methodCapabilityMap.ts
+++ b/src/main/mcp/methodCapabilityMap.ts
@@ -364,6 +364,13 @@ export const METHOD_CAPABILITY: Record<RpcMethod, RequiredCapability> = {
   // mutateLocal path, not registered on the pipe router). Entries here for
   // RpcMethod completeness, same as archive/kick.
   'a2a.channel.purgeMembership':      { capability: 'a2a.channel.send', riskClass: 'a2a' },
+  // operator-join (설계 §2.1/§2.2) — operatorJoin(mutation) / operatorList(read)도
+  // humans-only다: 파이프 라우터에 등록되지 않고 렌더러 전용 mutateLocal로만 도달.
+  // 여기 등재는 RpcMethod 완전성(이 Record<RpcMethod, …>) 목적이며 first-party
+  // 그랜트에서는 제외된다(설계 §2.3). operatorList도 읽기지만 humans-only 트랜스포트가
+  // 필요하므로 send 등급으로 둔다(도달 시점엔 이미 mutateLocal 경계를 통과했다는 의미).
+  'a2a.channel.operatorJoin':         { capability: 'a2a.channel.send', riskClass: 'a2a' },
+  'a2a.channel.operatorList':         { capability: 'a2a.channel.send', riskClass: 'a2a' },
   'a2a.principal.upsert':             { capability: 'wmux.internal' },
   'a2a.principal.remove':             { capability: 'wmux.internal' },
   'a2a.principal.markStaleWorkspace': { capability: 'wmux.internal' },

--- a/src/main/pipe/handlers/__tests__/a2a.channel.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/a2a.channel.rpc.test.ts
@@ -291,10 +291,11 @@ describe('a2a.channel.rpc — mutating routing (capability a2a.channel.send)', (
 });
 
 // =========================================================================
-// 2a. archive + kick are HUMANS-ONLY — deliberately NOT routed on the pipe
+// 2a. archive + kick + operatorJoin/operatorList are HUMANS-ONLY — deliberately
+//     NOT routed on the pipe
 // =========================================================================
 
-describe('a2a.channel.rpc — archive + kick are unregistered (agents cannot reach them)', () => {
+describe('a2a.channel.rpc — archive + kick + operator methods are unregistered (agents cannot reach them)', () => {
   it.each([
     [
       'a2a.channel.archive',
@@ -303,6 +304,18 @@ describe('a2a.channel.rpc — archive + kick are unregistered (agents cannot rea
     [
       'a2a.channel.kick',
       { channelId: CHANNEL_ID, targetWorkspaceId: 'ws-victim', targetMemberId: 'm-victim', senderPtyId: 'pty-attacker' },
+    ],
+    // operator-join (§2.3 / Codex #7): operatorJoin plants the human seat and
+    // operatorList enumerates every private channel name — both humans-only,
+    // reachable ONLY via the renderer channels:mutate-local IPC. An agent that
+    // forges a fully-resolvable senderPtyId must still hit "Unknown method" here.
+    [
+      'a2a.channel.operatorJoin',
+      { channelId: CHANNEL_ID, verifiedWorkspaceId: 'ws-human', senderPtyId: 'pty-attacker' },
+    ],
+    [
+      'a2a.channel.operatorList',
+      { verifiedWorkspaceId: 'ws-human', senderPtyId: 'pty-attacker' },
     ],
   ] as const)('rejects %s with Unknown method and never reaches the daemon', async (method, params) => {
     const daemon = makeFakeDaemon(() => ({ ok: true, value: null }));

--- a/src/renderer/components/Channels/ChannelView.tsx
+++ b/src/renderer/components/Channels/ChannelView.tsx
@@ -519,7 +519,8 @@ export function ChannelViewContent({
             {rendered.map((m) => {
             // operator-join (§2.1.1/§3): a server-published system marker renders as
             // a centered muted line, not an attributed chat message. The durable
-            // append is the audit trail; here it just reads as "you joined".
+            // append is the audit trail; the copy is viewpoint-neutral because
+            // every member's view renders this same marker.
             if (m.systemKind === 'operator-join') {
               return (
                 <div
@@ -530,7 +531,7 @@ export function ChannelViewContent({
                   className="flex items-center justify-center py-0.5 text-[10px] font-mono italic text-[var(--text-muted)]"
                   {...tokenAttrs('textMuted', 'text')}
                 >
-                  {t('channels.systemOperatorJoin') || 'You joined this channel'}
+                  {t('channels.systemOperatorJoin') || 'Operator joined this channel'}
                 </div>
               );
             }

--- a/src/renderer/components/Channels/ChannelView.tsx
+++ b/src/renderer/components/Channels/ChannelView.tsx
@@ -517,6 +517,23 @@ export function ChannelViewContent({
               </button>
             )}
             {rendered.map((m) => {
+            // operator-join (§2.1.1/§3): a server-published system marker renders as
+            // a centered muted line, not an attributed chat message. The durable
+            // append is the audit trail; here it just reads as "you joined".
+            if (m.systemKind === 'operator-join') {
+              return (
+                <div
+                  key={`${channel.id}:${m.seq}`}
+                  data-channel-message
+                  data-channel-system-message="operator-join"
+                  data-seq={m.seq}
+                  className="flex items-center justify-center py-0.5 text-[10px] font-mono italic text-[var(--text-muted)]"
+                  {...tokenAttrs('textMuted', 'text')}
+                >
+                  {t('channels.systemOperatorJoin') || 'You joined this channel'}
+                </div>
+              );
+            }
             const myStatus = viewerDeliveryStatus(m, viewer?.memberId ?? null);
             const mentionsMe =
               !!viewer && !!m.mentions?.some((mn) => mn.workspaceId === viewer.workspaceId);

--- a/src/renderer/components/Channels/ChannelsPanel.tsx
+++ b/src/renderer/components/Channels/ChannelsPanel.tsx
@@ -49,7 +49,7 @@
 // R23 (creation modal), R29 (channel scope to company).
 
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
-import type { Channel, ChannelVisibility } from '../../../shared/channels';
+import type { Channel, ChannelVisibility, OperatorChannelSummary } from '../../../shared/channels';
 import { HUMAN_WORKSPACE_ID, HUMAN_MEMBER_ID } from '../../../shared/channels';
 import {
   canonicalizeChannelName,
@@ -60,7 +60,7 @@ import {
 import type { Company } from '../../../company/types';
 import { useStore } from '../../stores';
 import ChannelItem from './ChannelItem';
-import { IconPlus, IconChevron, IconChevronDir, IconRefresh } from '../icons';
+import { IconPlus, IconChevron, IconChevronDir, IconRefresh, IconLock, IconArchive } from '../icons';
 import { hydrateChannelsCatalog } from '../../hooks/useChannelsHydration';
 import { FOCUS_RING } from '../focusRing';
 import { tokenAttrs } from '../../themes';
@@ -409,6 +409,19 @@ export interface ChannelsPanelViewProps {
    *  renderer requires (it survived the app upgrade). Renders a "restart wmux"
    *  banner; posting/joining may fail with NOT_A_MEMBER until the restart. */
   daemonStale?: boolean;
+  /** operator-join (design §2.2/§3) — the discovery list backing the collapsed
+   *  "All channels" section (private non-members + archived). undefined until the
+   *  container lazy-loads it on first expand. When undefined AND the operator
+   *  handlers are wired, the section still renders its (collapsed) header so the
+   *  operator can trigger the load. */
+  operatorChannels?: OperatorChannelSummary[];
+  /** Toggle callback for the operator section. The container lazy-loads the list
+   *  on the first expand (nextExpanded === true). Wiring this prop is what turns
+   *  the section on — omit it to hide the whole affordance (tests/legacy). */
+  onOperatorToggle?: (nextExpanded: boolean) => void;
+  /** Join a private/discoverable channel as the operator. The View shows the
+   *  confirm dialog and calls this only after the operator confirms. */
+  onOperatorJoin?: (channelId: string) => void;
 }
 
 export function ChannelsPanelView(props: ChannelsPanelViewProps): React.ReactElement {
@@ -426,6 +439,9 @@ export function ChannelsPanelView(props: ChannelsPanelViewProps): React.ReactEle
     collapseDir = 'right',
     onRefresh,
     daemonStale = false,
+    operatorChannels,
+    onOperatorToggle,
+    onOperatorJoin,
   } = props;
   const t = props.t ?? ((k: string) => k);
 
@@ -433,6 +449,30 @@ export function ChannelsPanelView(props: ChannelsPanelViewProps): React.ReactEle
   const newBtnRef = useRef<HTMLButtonElement | null>(null);
   const [archivedExpanded, setArchivedExpanded] = useState(false);
   const [discoverExpanded, setDiscoverExpanded] = useState(false);
+  // operator-join (§3): the section is COLLAPSED by default — this collapse is the
+  // intent gate (private channel names do not exist on screen until expanded).
+  const [operatorExpanded, setOperatorExpanded] = useState(false);
+  // The channel awaiting the operator's join confirmation (null = dialog closed).
+  const [pendingOperatorJoin, setPendingOperatorJoin] = useState<OperatorChannelSummary | null>(null);
+  const handleOperatorToggle = useCallback(() => {
+    setOperatorExpanded((v) => {
+      const next = !v;
+      onOperatorToggle?.(next);
+      return next;
+    });
+  }, [onOperatorToggle]);
+  // Discovery items: channels the operator is NOT a member of that are either a
+  // private (joinable) room or archived (shown with a badge, not joinable). Public
+  // active non-members already appear in the Discover group above, so exclude them
+  // here. Order follows the daemon's deterministic createdAt sort.
+  const operatorItems = useMemo<OperatorChannelSummary[]>(() => {
+    if (!operatorChannels) return [];
+    return operatorChannels.filter((c) => {
+      if (memberChannelIds?.has(c.id)) return false;
+      if (c.status === 'archived') return true;
+      return c.visibility === 'private';
+    });
+  }, [operatorChannels, memberChannelIds]);
 
   const channelList = useMemo(() => Object.values(channels), [channels]);
   const isMember = useMemo(
@@ -679,6 +719,162 @@ export function ChannelsPanelView(props: ChannelsPanelViewProps): React.ReactEle
           )}
         </>
       )}
+
+      {/* Operator section (operator-join §3) — COLLAPSED by default. The collapse
+            is the intent gate: private channel names are not on screen until the
+            operator expands it. Lives OUTSIDE the channelList ternary because the
+            joinable private channels are, by definition, not in the local mirror
+            yet (list() hides them from non-members). Lazy-loads via onOperatorToggle. */}
+      {onOperatorToggle && (
+        <div className="mt-1" data-channels-operator-group>
+          <button
+            type="button"
+            className={`w-full flex items-center gap-1 px-4 py-1 text-[9px] font-mono uppercase tracking-widest text-[var(--text-muted)] hover:text-[var(--text-subtle)] transition-colors ${FOCUS_RING}`}
+            onClick={handleOperatorToggle}
+            aria-expanded={operatorExpanded}
+            data-channels-operator-toggle
+            {...tokenAttrs('textMuted', 'text')}
+          >
+            <span
+              className={`transition-transform ${operatorExpanded ? 'rotate-90' : ''}`}
+              aria-hidden="true"
+            >
+              <IconChevron size={9} />
+            </span>
+            <span>{t('channels.operatorSection') || 'All channels'}</span>
+          </button>
+          {operatorExpanded && (
+            <div className="space-y-0.5" data-channels-operator-list>
+              {operatorItems.length === 0 ? (
+                <div
+                  className="px-4 py-1 text-[10px] font-mono text-[var(--text-muted)]"
+                  data-channels-operator-empty
+                  {...tokenAttrs('textMuted', 'text')}
+                >
+                  {t('channels.empty') || 'No channels yet.'}
+                </div>
+              ) : (
+                operatorItems.map((c) => {
+                  const isArchived = c.status === 'archived';
+                  return (
+                    <div
+                      key={c.id}
+                      className={`flex items-center gap-1 px-4 py-0.5 ${isArchived ? 'opacity-60' : ''}`}
+                      data-channels-operator-item
+                      data-channel-id={c.id}
+                      data-channel-archived={isArchived ? 'true' : 'false'}
+                    >
+                      <span
+                        className="shrink-0 text-[var(--text-muted)]"
+                        aria-hidden="true"
+                        title={
+                          isArchived
+                            ? t('channels.operatorArchivedCannotJoin') || "Archived — can't be joined"
+                            : t('channels.operatorLocked') || 'Private channel — join to read'
+                        }
+                      >
+                        {isArchived ? <IconArchive size={11} /> : <IconLock size={11} />}
+                      </span>
+                      <span
+                        className="flex-1 min-w-0 truncate text-caption font-mono text-[var(--text-subtle)]"
+                        title={`#${c.name}`}
+                      >
+                        #{c.name}
+                      </span>
+                      {isArchived ? (
+                        <span
+                          className="shrink-0 px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-wide text-[var(--text-muted)]"
+                          data-channels-operator-archived-badge
+                          title={t('channels.operatorArchivedCannotJoin') || "Archived — can't be joined"}
+                          {...tokenAttrs('textMuted', 'text')}
+                        >
+                          {t('channels.archived') || 'archived'}
+                        </span>
+                      ) : (
+                        onOperatorJoin && (
+                          <button
+                            type="button"
+                            className={`shrink-0 px-1.5 py-0.5 text-[10px] rounded text-[var(--accent-green)] hover:bg-[rgba(var(--bg-surface-rgb),0.6)] transition-colors ${FOCUS_RING}`}
+                            onClick={() => setPendingOperatorJoin(c)}
+                            data-channels-operator-join
+                            aria-label={`${t('channels.operatorJoinConfirmCta') || 'Join'} #${c.name}`}
+                            {...tokenAttrs('success', 'accent')}
+                          >
+                            {t('channels.operatorJoinConfirmCta') || 'Join'}
+                          </button>
+                        )
+                      )}
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* operator-join confirm dialog (§3). The SECOND sentence of the body states
+            the §2.1.1 contract (a durable record is appended and shown to every
+            member) — it must not be removed. This dialog is an L1 device: it does
+            not stop a direct-socket forge (the system message does), it makes the
+            operator's own join a deliberate act. */}
+      {pendingOperatorJoin && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={t('channels.operatorJoinConfirmTitle') || 'Join this channel?'}
+          data-channels-operator-confirm
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+          onClick={() => setPendingOperatorJoin(null)}
+        >
+          <div
+            className="w-72 max-w-[90vw] rounded-md p-3 bg-[var(--bg-elevated)] border shadow-lg"
+            style={{ borderColor: 'var(--border-soft)' }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div
+              className="text-caption font-mono font-semibold text-[var(--text-main)] mb-1"
+              {...tokenAttrs('textMain', 'text')}
+            >
+              {t('channels.operatorJoinConfirmTitle') || 'Join this channel?'}
+            </div>
+            <div className="text-[11px] font-mono leading-snug text-[var(--text-sub)] mb-1">
+              #{pendingOperatorJoin.name}
+            </div>
+            <div
+              className="text-[11px] font-mono leading-snug text-[var(--text-sub)] mb-3"
+              data-channels-operator-confirm-body
+              {...tokenAttrs('textSub', 'text')}
+            >
+              {t('channels.operatorJoinConfirmBody') ||
+                'This is a private channel created by agents. If you join, a record is kept in the channel and shown to all members.'}
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                className={`px-2 py-1 text-[11px] rounded text-[var(--text-sub)] hover:bg-[rgba(var(--bg-surface-rgb),0.6)] ${FOCUS_RING}`}
+                onClick={() => setPendingOperatorJoin(null)}
+                data-channels-operator-confirm-cancel
+              >
+                {t('channels.operatorJoinCancel') || 'Cancel'}
+              </button>
+              <button
+                type="button"
+                className={`px-2 py-1 text-[11px] rounded text-[var(--accent-green)] hover:bg-[rgba(var(--bg-surface-rgb),0.6)] ${FOCUS_RING}`}
+                onClick={() => {
+                  const id = pendingOperatorJoin.id;
+                  setPendingOperatorJoin(null);
+                  onOperatorJoin?.(id);
+                }}
+                data-channels-operator-confirm-join
+                {...tokenAttrs('success', 'accent')}
+              >
+                {t('channels.operatorJoinConfirmCta') || 'Join'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -700,6 +896,8 @@ export function ChannelsPanel(): React.ReactElement {
   const setActiveChannel = useStore((s) => s.setActiveChannel);
   const createChannelDaemon = useStore((s) => s.createChannelDaemon);
   const joinChannelDaemon = useStore((s) => s.joinChannelDaemon);
+  const operatorListDaemon = useStore((s) => s.operatorListDaemon);
+  const operatorJoinDaemon = useStore((s) => s.operatorJoinDaemon);
   const pushToast = useStore((s) => s.pushToast);
   // Dock host wiring: the panel's collapse affordance folds the whole dock
   // away (the panel is the dock's only host — the old separate dock header
@@ -762,6 +960,56 @@ export function ChannelsPanel(): React.ReactElement {
       });
     },
     [selfWorkspaceId, channels, joinChannelDaemon, pushToast, t],
+  );
+
+  // operator-join (§2.2/§3): the discovery list, lazy-loaded on first expand of
+  // the collapsed section. Kept as component state (not the global mirror) — it is
+  // a superset that includes private rooms the operator is NOT in, so it must not
+  // pollute the authoritative channel catalog.
+  const [operatorChannels, setOperatorChannels] = useState<OperatorChannelSummary[] | undefined>(
+    undefined,
+  );
+  const reloadOperatorList = useCallback(() => {
+    void operatorListDaemon(HUMAN_WORKSPACE_ID).then(setOperatorChannels);
+  }, [operatorListDaemon]);
+  const handleOperatorToggle = useCallback(
+    (nextExpanded: boolean) => {
+      // Load on expand (and refresh on every expand so a room created since the
+      // last look shows up). Collapse leaves the last list in place — harmless,
+      // it is re-fetched on the next expand.
+      if (nextExpanded) reloadOperatorList();
+    },
+    [reloadOperatorList],
+  );
+  const handleOperatorJoin = useCallback(
+    (channelId: string) => {
+      const channelName = operatorChannels?.find((c) => c.id === channelId)?.name ?? channelId;
+      void operatorJoinDaemon(channelId).then((result) => {
+        if (result.ok) {
+          // The channel was private+hidden until now; re-pull the catalog so the
+          // freshly-visible row + members land in the mirror, then select it.
+          const bridge = useStore.getState().channelsRpc();
+          if (bridge) {
+            void hydrateChannelsCatalog({
+              rpc: bridge.rpc,
+              workspaceId: HUMAN_WORKSPACE_ID,
+              setChannels: useStore.getState().setChannels,
+            }).then(() => {
+              setActiveChannel(channelId);
+            });
+          }
+          pushToast({ level: 'info', message: t('channels.operatorJoinedToast', { channel: channelName }) });
+          reloadOperatorList();
+        } else if (result.error.message.includes('DUPLICATE')) {
+          // Already a member (e.g. joined in another window since the list loaded).
+          pushToast({ level: 'info', message: t('channels.operatorJoinedToast', { channel: channelName }) });
+          reloadOperatorList();
+        } else {
+          pushToast({ level: 'error', message: t('channels.operatorJoinFailedToast', { channel: channelName }) });
+        }
+      });
+    },
+    [operatorChannels, operatorJoinDaemon, pushToast, t, setActiveChannel, reloadOperatorList],
   );
 
   const handleCreate = useCallback(
@@ -844,6 +1092,9 @@ export function ChannelsPanel(): React.ReactElement {
       collapseDir={sidebarPosition !== 'right' ? 'right' : 'left'}
       onRefresh={handleRefresh}
       daemonStale={channelsDaemonStale}
+      operatorChannels={operatorChannels}
+      onOperatorToggle={handleOperatorToggle}
+      onOperatorJoin={handleOperatorJoin}
       t={t}
     />
   );

--- a/src/renderer/components/Channels/ChannelsPanel.tsx
+++ b/src/renderer/components/Channels/ChannelsPanel.tsx
@@ -946,7 +946,7 @@ export function ChannelsPanel(): React.ReactElement {
             level: 'info',
             message: t('channels.joinedToast', { workspace: label, channel: channelName }),
           });
-        } else if (result.error.message.includes('DUPLICATE')) {
+        } else if (result.error.code === 'DUPLICATE_MEMBER') {
           pushToast({
             level: 'info',
             message: t('channels.alreadyMemberToast', { workspace: label, channel: channelName }),
@@ -994,13 +994,20 @@ export function ChannelsPanel(): React.ReactElement {
               rpc: bridge.rpc,
               workspaceId: HUMAN_WORKSPACE_ID,
               setChannels: useStore.getState().setChannels,
-            }).then(() => {
-              setActiveChannel(channelId);
-            });
+            })
+              .then(() => {
+                setActiveChannel(channelId);
+              })
+              .catch(() => {
+                // Mirror refresh failed — the join itself is already persisted
+                // daemon-side, so the toast stays truthful; the next catalog
+                // emit converges the mirror. Swallow to avoid an unhandled
+                // rejection; channel selection is skipped until then.
+              });
           }
           pushToast({ level: 'info', message: t('channels.operatorJoinedToast', { channel: channelName }) });
           reloadOperatorList();
-        } else if (result.error.message.includes('DUPLICATE')) {
+        } else if (result.error.code === 'DUPLICATE_MEMBER') {
           // Already a member (e.g. joined in another window since the list loaded).
           pushToast({ level: 'info', message: t('channels.operatorJoinedToast', { channel: channelName }) });
           reloadOperatorList();

--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -73,6 +73,17 @@ export function IconExternalLink({ size = 14 }: { size?: number }) {
   );
 }
 
+/** Padlock — a private channel the operator is not (yet) a member of
+ *  (operator-join §3 discovery section). */
+export function IconLock({ size = 14 }: { size?: number }) {
+  return (
+    <Icon size={size}>
+      <rect x="3" y="6.2" width="8" height="5.3" rx="1" />
+      <path d="M4.6 6.2 V4.6 a2.4 2.4 0 0 1 4.8 0 V6.2" />
+    </Icon>
+  );
+}
+
 /** Plus — new workspace / new item. */
 export function IconPlus({ size = 14 }: { size?: number }) {
   return <Icon size={size}><line x1="7" y1="2.5" x2="7" y2="11.5" /><line x1="2.5" y1="7" x2="11.5" y2="7" /></Icon>;

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -221,7 +221,11 @@ export function useRpcBridge(): void {
             | 'a2a.channel.post'
             | 'a2a.channel.join'
             | 'a2a.channel.leave'
-            | 'a2a.channel.archive',
+            | 'a2a.channel.archive'
+            // operator-join (설계 §2.1/§2.2) — humans-only, 렌더러 전용 mutateLocal
+            // 경로로만 도달(파이프 미등록). operatorList는 읽기지만 같은 트랜스포트.
+            | 'a2a.channel.operatorJoin'
+            | 'a2a.channel.operatorList',
           params: Record<string, unknown>,
         ) => Promise<RpcResult>;
       };

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -699,6 +699,23 @@ export const en = {
   'channels.mentionDropped': 'These @mentions did not land (not a channel member): {names}',
   'channels.mentionUnmatched': 'These @mentions matched no one — not delivered: {names}',
   'channels.mentionNoMatch': 'No agents to mention',
+  // operator-join (design §3) — collapsed-by-default discovery section + the
+  // join-confirm dialog. The collapse IS the intent gate: private channel names
+  // do not exist on screen until the section is expanded.
+  'channels.operatorSection': 'All channels',
+  'channels.operatorLocked': 'Private channel — join to read',
+  'channels.operatorArchivedCannotJoin': "Archived — can't be joined",
+  'channels.operatorJoinConfirmTitle': 'Join this channel?',
+  // Two sentences. The SECOND states the §2.1.1 contract verbatim (a durable
+  // record is appended and shown to every member) — do NOT delete it.
+  'channels.operatorJoinConfirmBody':
+    'This is a private channel created by agents. If you join, a record is kept in the channel and shown to all members.',
+  'channels.operatorJoinConfirmCta': 'Join',
+  'channels.operatorJoinCancel': 'Cancel',
+  'channels.operatorJoinedToast': 'Joined #{channel}',
+  'channels.operatorJoinFailedToast': "Couldn't join #{channel}",
+  // Display string for the server-published operator-join system message.
+  'channels.systemOperatorJoin': 'You joined this channel',
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -715,7 +715,9 @@ export const en = {
   'channels.operatorJoinedToast': 'Joined #{channel}',
   'channels.operatorJoinFailedToast': "Couldn't join #{channel}",
   // Display string for the server-published operator-join system message.
-  'channels.systemOperatorJoin': 'You joined this channel',
+  // Viewpoint-neutral on purpose: the marker fans out to every member's view,
+  // so a second-person "You joined" would be wrong for non-operator viewers.
+  'channels.systemOperatorJoin': 'Operator joined this channel',
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -623,4 +623,20 @@ export const ko = {
   'channels.mentionDropped': '이 @멘션은 전달되지 않았습니다(채널 멤버 아님): {names}',
   'channels.mentionUnmatched': '이 @멘션은 일치하는 대상이 없어 전달되지 않았습니다: {names}',
   'channels.mentionNoMatch': '멘션할 에이전트가 없습니다',
+  // operator-join (설계 §3) — 접힘 기본 발견 섹션 + join 확인 다이얼로그. 이 접힘이
+  // 의도 게이트다: 펼치기 전에는 비공개 채널명이 화면에 존재하지 않는다.
+  'channels.operatorSection': '모든 채널',
+  'channels.operatorLocked': '비공개 채널 — 참여하면 읽을 수 있습니다',
+  'channels.operatorArchivedCannotJoin': '보관됨 — 참여할 수 없습니다',
+  'channels.operatorJoinConfirmTitle': '이 채널에 참여할까요?',
+  // 두 문장. 두 번째 문장은 §2.1.1 계약을 그대로 진술한다(내구 기록 append + 멤버
+  // 전원에게 표시) — 삭제 금지.
+  'channels.operatorJoinConfirmBody':
+    '이 채널은 에이전트들이 만든 비공개 채널입니다. 참여하면 채널에 기록이 남고 멤버 전원에게 표시됩니다.',
+  'channels.operatorJoinConfirmCta': '참여',
+  'channels.operatorJoinCancel': '취소',
+  'channels.operatorJoinedToast': '#{channel}에 참여했습니다',
+  'channels.operatorJoinFailedToast': '#{channel}에 참여하지 못했습니다',
+  // 서버-발행 operator-join 시스템 메시지의 표시 문자열.
+  'channels.systemOperatorJoin': '이 채널에 참여했습니다',
 } as const;

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -637,6 +637,7 @@ export const ko = {
   'channels.operatorJoinCancel': '취소',
   'channels.operatorJoinedToast': '#{channel}에 참여했습니다',
   'channels.operatorJoinFailedToast': '#{channel}에 참여하지 못했습니다',
-  // 서버-발행 operator-join 시스템 메시지의 표시 문자열.
-  'channels.systemOperatorJoin': '이 채널에 참여했습니다',
+  // 서버-발행 operator-join 시스템 메시지의 표시 문자열. 모든 멤버 뷰에
+  // 동일하게 렌더되므로 2인칭이 아닌 시점 중립 문구를 쓴다.
+  'channels.systemOperatorJoin': '오퍼레이터가 이 채널에 참여했습니다',
 } as const;

--- a/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
@@ -845,7 +845,13 @@ describe('channelsSlice — joinChannelDaemon (membership)', () => {
       const store = createTestStore();
       const res = await store.getState().joinChannelDaemon('ch-1', member, 'ws-join');
       expect(res.ok).toBe(false);
-      if (!res.ok) expect(res.error.message).toContain('DUPLICATE_MEMBER');
+      // 6g2: DUPLICATE_MEMBER is a modeled code now (join/operatorJoin branch
+      // on `.code` for the benign "already a member" toast) — the message
+      // passes through verbatim instead of the UNKNOWN-bucket mangling.
+      if (!res.ok) {
+        expect(res.error.code).toBe('DUPLICATE_MEMBER');
+        expect(res.error.message).toBe('Already a member');
+      }
       expect(store.getState().channelMembers['ch-1']).toBeUndefined();
     } finally {
       clearChannelsRpc();

--- a/src/renderer/stores/slices/channelsSlice.ts
+++ b/src/renderer/stores/slices/channelsSlice.ts
@@ -62,6 +62,7 @@ import type {
   ChannelMention,
   ChannelMessage,
   ChannelVisibility,
+  OperatorChannelSummary,
 } from '../../../shared/channels';
 import { HUMAN_WORKSPACE_ID } from '../../../shared/channels';
 import { panePrincipalId } from '../../../shared/principals';
@@ -282,6 +283,20 @@ export interface ChannelsSlice {
     channelId: string,
     workspaceId: string,
   ) => Promise<ChannelActionResult<Channel>>;
+
+  // ── operator-join (설계 §2.1/§2.2) — humans-only 발견 + 자가 입장 ────────────
+  /** 발견 어포던스: 전 채널(공개+비공개, active+archived)의 메타데이터만 가져온다.
+   *  private 채널은 list()에서 비멤버에게 숨겨지므로 오퍼레이터 섹션이 "들어갈 수
+   *  있는 방"을 보여주려면 이 목록이 필요하다. 읽기지만 humans-only 트랜스포트
+   *  (mutateLocal)로만 도달한다(§2.2). 실패 시 빈 배열 + 콘솔 경고(비파괴적 조회). */
+  operatorListDaemon: (workspaceId: string) => Promise<OperatorChannelSummary[]>;
+  /** 오퍼레이터(사람)가 비공개 채널에 스스로 들어간다(§2.1). 성공 시 데몬이 사람
+   *  좌석을 심고 서버-발행 시스템 메시지를 남긴다(§2.1.1). 채널 행은 지금까지
+   *  private+비멤버라 미러에 없었을 수 있으므로, 성공만 신호하고 새로 보이게 된
+   *  채널 행 재동기는 호출자의 카탈로그 재-hydrate(+ membership 이벤트)에 맡긴다. */
+  operatorJoinDaemon: (
+    channelId: string,
+  ) => Promise<ChannelActionResult<Record<string, never>>>;
 
   // ── R2: Principal registry / system cleanup (renderer-only, fire-and-forget) ──
   // All take the same humans-only mutateLocal path as kick. Failures are left as
@@ -1068,5 +1083,63 @@ export const createChannelsSlice: StateCreator<
       archivedAt: Date.now(),
       archivedBy: workspaceId,
     });
+  },
+
+  operatorListDaemon: async (workspaceId) => {
+    const bridge = get().channelsRpc();
+    if (!bridge) {
+      console.warn('[channelsSlice] operatorListDaemon invoked before bridge mounted — call ignored');
+      return [];
+    }
+    let raw: unknown;
+    try {
+      // 발견 어포던스(§2.2). 읽기지만 humans-only 트랜스포트라 mutateLocal로 탄다.
+      // 데몬은 { ok: true, channels: OperatorChannelSummary[] }를 반환한다.
+      raw = await bridge.mutateLocal('a2a.channel.operatorList', {
+        verifiedWorkspaceId: workspaceId,
+      });
+    } catch (err) {
+      console.warn('[channelsSlice] operatorListDaemon failed:', err);
+      return [];
+    }
+    if (
+      raw !== null &&
+      typeof raw === 'object' &&
+      'ok' in raw &&
+      (raw as { ok: unknown }).ok === true &&
+      'channels' in raw &&
+      Array.isArray((raw as { channels: unknown }).channels)
+    ) {
+      return (raw as { channels: OperatorChannelSummary[] }).channels;
+    }
+    console.warn('[channelsSlice] operatorListDaemon: unexpected reply shape', raw);
+    return [];
+  },
+
+  operatorJoinDaemon: async (channelId) => {
+    const bridge = get().channelsRpc();
+    if (!bridge) {
+      console.warn('[channelsSlice] operatorJoinDaemon invoked before bridge mounted — call ignored');
+      return { ok: false, error: { code: 'UNKNOWN', message: 'channels bridge not mounted' } };
+    }
+    let raw: unknown;
+    try {
+      // 좌석은 데몬이 상수로 심는다(§2.1) — verifiedWorkspaceId=ws-human만 보낸다.
+      // 여분 필드(member/includeHistory 등)는 데몬이 읽지 않으므로 전달하지 않는다.
+      raw = await bridge.mutateLocal('a2a.channel.operatorJoin', {
+        channelId,
+        verifiedWorkspaceId: HUMAN_WORKSPACE_ID,
+      });
+    } catch (err) {
+      return { ok: false, error: { code: 'UNKNOWN', message: err instanceof Error ? err.message : String(err) } };
+    }
+    if (raw === null || typeof raw !== 'object' || !('ok' in raw) || (raw as { ok: unknown }).ok !== true) {
+      return { ok: false, error: get().mapRpcError(raw, 'a2a.channel.operatorJoin failed') };
+    }
+    // 낙관적 미러 갱신: 채널 행은 지금까지 private+비멤버라 미러에 없었을 수 있으므로
+    // 좌석만 optimistic-add하지 않고, 호출자(ChannelsPanel)가 카탈로그를 재-hydrate해
+    // 새로 보이게 된 채널 행 + 멤버를 끌어온다. 데몬의 membership 카탈로그 이벤트도
+    // 동일 재동기를 유발한다(이중 안전). 여기선 성공만 신호한다.
+    return { ok: true, value: {} };
   },
 });

--- a/src/renderer/stores/slices/channelsSlice.ts
+++ b/src/renderer/stores/slices/channelsSlice.ts
@@ -141,6 +141,7 @@ export interface ChannelError {
     | 'CHANNEL_NOT_FOUND'
     | 'CHANNEL_ARCHIVED'
     | 'NOT_A_MEMBER'
+    | 'DUPLICATE_MEMBER'
     | 'PERSIST_FAILED'
     | 'ALREADY_EXISTS'
     | 'NOT_AUTHORIZED'
@@ -827,6 +828,11 @@ export const createChannelsSlice: StateCreator<
           // non-creator archive). Model it so the toast shows the real reason
           // instead of bucketing to UNKNOWN with the code mangled into the text.
           'NOT_AUTHORIZED',
+          // 6g2: join + operatorJoin branch on "already a member" for a benign
+          // info toast. Modeled so callers can test `.code` — the previous
+          // behavior (UNKNOWN bucket with the code prepended to the message)
+          // made that branch depend on a message-substring accident.
+          'DUPLICATE_MEMBER',
           'UNKNOWN',
         ]);
         if (KNOWN_CODES.has(code as ChannelError['code'])) {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -186,6 +186,44 @@ export interface ChannelMessage {
    * and for legacy pre-R1 messages — both degrade safely to "no self-pane known".
    */
   senderPtyId?: string;
+  /**
+   * 서버-발행 시스템 메시지 판별자 (operator-join 설계 §2.1.1). 존재하면 이 행은
+   * 사용자가 작성한 일반 메시지가 아니라 데몬이 발행한 감사 흔적이다 — 렌더러는
+   * `text`(영어 폴백) 대신 이 종류로 문구를 localize한다. 일반 메시지에는 부재
+   * (additive 선택 필드, `ChannelState.version` 불변 — senderPtyId 관례와 동일).
+   */
+  systemKind?: ChannelSystemMessageKind;
+}
+
+/**
+ * 서버-발행 시스템 메시지 종류 (operator-join 설계 §2.1.1). 채널 히스토리에 일반
+ * 메시지와 동일한 영속 경로로 append되는 감사 메시지의 판별자다. additive-only:
+ * 종류 추가만 허용(디스크 계약). 현재는 오퍼레이터(사람)가 비공개 채널에
+ * operatorJoin했음을 알리는 한 종류뿐이며, 이 흔적은 내구 감사(leave 후에도 남음)
+ * 이자 #113 잔여로 위조된 입장을 사람이 GUI에서 발견하게 하는 유일한 장치다.
+ */
+export type ChannelSystemMessageKind = 'operator-join';
+
+/**
+ * operator-join 시스템 메시지의 영어 폴백 본문. 렌더러는 `systemKind`로 판별해
+ * i18n 문자열로 대체하므로, 이 텍스트는 비-GUI 소비자(CLI/로그/구 렌더러)용
+ * 폴백일 뿐이다. `ChannelMessage.text`는 필수 필드라 값이 반드시 있어야 한다.
+ */
+export const OPERATOR_JOIN_SYSTEM_TEXT = 'Operator joined the channel.';
+
+/**
+ * operator-list 프로젝션 행 (operator-join 설계 §2.2) — 발견 어포던스가 반환하는
+ * 채널 메타데이터만. 메시지 미리보기·멤버 상세 없음(내용을 읽으려면 operatorJoin
+ * 해야 하고, 그건 서버-발행 시스템 메시지를 남긴다 §2.1.1). 데몬이 반환하고 렌더러
+ * 오퍼레이터 섹션이 소비하므로 shared에 둔다.
+ */
+export interface OperatorChannelSummary {
+  id: string;
+  name: string;
+  visibility: ChannelVisibility;
+  status: ChannelStatus;
+  memberCount: number;
+  createdAt: number;
 }
 
 /**

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -224,6 +224,14 @@ export type RpcMethod =
   | 'a2a.channel.nudgeRecorded'
   | 'a2a.channel.unread'
   | 'a2a.channel.purgeMembership'
+  // operator-join (설계 §2.1/§2.2) — 사람이 에이전트가 만든 비공개 채널에 스스로
+  // 들어가는 신뢰 경로 + 그 발견 목록. archive/kick/purge와 동일한 humans-only
+  // 등급: 파이프 라우터(a2a.channel.rpc.ts)에 등록되지 않고 렌더러 전용
+  // channels:mutate-local IPC로만 도달한다. 이 union 등재는 RpcMethod 완전성
+  // (METHOD_CAPABILITY 매핑) 목적이며, first-party 그랜트(FIRST_PARTY_METHODS)에는
+  // 의도적으로 제외된다(설계 §2.3 / Codex #7).
+  | 'a2a.channel.operatorJoin'
+  | 'a2a.channel.operatorList'
   | 'a2a.principal.upsert'
   | 'a2a.principal.remove'
   | 'a2a.principal.markStaleWorkspace'
@@ -366,6 +374,9 @@ export const ALL_RPC_METHODS = [
   'a2a.channel.nudgeRecorded',
   'a2a.channel.unread',
   'a2a.channel.purgeMembership',
+  // operator-join (설계 §2.1/§2.2) — humans-only, 파이프 미등록. RpcMethod 완전성.
+  'a2a.channel.operatorJoin',
+  'a2a.channel.operatorList',
   'a2a.principal.upsert',
   'a2a.principal.remove',
   'a2a.principal.markStaleWorkspace',


### PR DESCRIPTION
**DRAFT — trust-boundary change, needs a 3-model code review before merge.**

## Summary
Implements the operator-join trust path (design: `operator-join-design-2026-07-05.md` v1.1, already 3-model plan-reviewed): the human owner of the machine can pull themselves into a private channel that agents created, since agent-side invite of the human seat is (correctly) forbidden.

- `operatorJoin` / `operatorList` daemon methods on `ChannelService`, humans-only transport (renderer-local mutate IPC allowlist), **never** reachable from the pipe router / MCP / first-party grants — absence is pinned by boundary tests.
- `OperatorJoinParams` is exactly `{channelId, verifiedWorkspaceId}`; the human seat row is built from constants only (no caller-supplied field is ever consumed — P5 injection guard).
- On success the daemon appends **one server-issued system message** so the join is durably auditable (survives leave, visible to fan-out-missed members, and surfaces forged direct-socket joins to the human).

## Key implementation decision (worker report)
Append-only atomicity: a 2-envelope "seat then message" split can't be atomic (no compensating append if the message fails after the seat commits). So a new additive `operator-join` event **kind** carries both the seat row and the system message in **one envelope** — `1 commit = 1 envelope` invariant preserved, both effects under one fsync barrier. Legacy mode does explicit 3-part rollback (message → nextSeq → seat) mirroring `join()`/`post()`.

## Boundary tests (the security-critical ones)
- pipe-router non-registration (a forged senderPtyId still gets `Unknown method`, daemon rpc never called)
- `FIRST_PARTY_METHODS` exclusion, MCP tool-list absence (source-scanned)
- channelLocal allowlist pass + verifiedWorkspaceId stamp

## Verification (worker, then confirm in CI)
- `tsc --noEmit` clean; 376 targeted vitest passed (operator 19 + boundary/capability/events 97 + eventlog 17 + slices 243); eslint 0 new
- **Not run locally**: full `test:parallel` — the worktree had no `node_modules` (npx cache degraded mid-session). CI re-runs it.

## Review focus for the panel
1. The new `operator-join` envelope kind — additive-only compliance + replay idempotence
2. Atomic rollback (log mode single-envelope vs legacy 3-part)
3. Boundary tests actually pin agent-unreachability
4. System-message shape (`deliveryStatus: 'delivered'`, no `recipientSnapshot`) doesn't trip the wake-worker re-nudge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an operator-only view for discovering channels and joining private ones.
  * Private channels now show a clear lock state and join confirmation flow.
  * Joined-by-operator activity is now shown as a distinct system message in channel history.

* **Bug Fixes**
  * Unread counts no longer increase for system-generated operator join messages.
  * Duplicate join attempts now return a clearer “already a member” response.

* **Documentation**
  * Updated API references to include the new operator channel actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->