### PR TITLE
fix(worktask): J3 후속 — refire 경로 트래버설 차단·분할 오버레이 owner 스코프·서피스 재사용 backfill

### DIFF
--- a/src/main/ipc/handlers/__tests__/worktask.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/worktask.handler.test.ts
@@ -142,6 +142,22 @@ describe('worktask:refire (§3·F2 — 원래 initialCommand 재전송)', () => 
     const res = (await call(IPC.WORKTASK_REFIRE, { ptyId: 'p' })) as { ok: boolean };
     expect(res.ok).toBe(false);
   });
+
+  it('F7 — `..` 트래버설로 루트를 탈출하는 worktreePath는 거부(prefix 검사 우회 차단)', async () => {
+    daemon = makeDaemon([]);
+    dispose = registerWorktaskHandlers(() => daemon.client);
+    // 문자열 prefix로는 루트 하위처럼 보이지만 resolve하면 밖으로 나가는 경로.
+    // join()은 `..`를 미리 접으므로 원시 문자열로 구성해야 우회가 재현된다.
+    const traversal = `${join(base, 'worktrees')}/../../escaped`;
+    mkdirSync(join(base, '..', 'escaped'), { recursive: true });
+    const res = (await call(IPC.WORKTASK_REFIRE, { ptyId: 'p', worktreePath: traversal, initialCommand: 'claude x' })) as {
+      ok: boolean;
+      error?: string;
+    };
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('전용 루트');
+    expect(daemon.writes).toHaveLength(0);
+  });
 });
 
 describe('task:close owner 스코프(F1 E2E — 자식 실패·owner 성공)', () => {

--- a/src/main/ipc/handlers/worktask.handler.ts
+++ b/src/main/ipc/handlers/worktask.handler.ts
@@ -214,10 +214,12 @@ export function registerWorktaskHandlers(getDaemonClient: () => DaemonClient | n
   };
 }
 
-/** F7 — worktreePath 정규화 후 전용 루트({wmux home}/worktrees) 하위 여부. */
+/** F7 — worktreePath 정규화 후 전용 루트({wmux home}/worktrees) 하위 여부.
+ *  path.resolve로 `..`를 먼저 붕괴시킨다 — normalizeWorktreePath는 구분자/대소문자만
+ *  다루므로 그것만으로는 `{root}/worktrees/../../etc`가 prefix 검사를 통과한다. */
 function isUnderWorktreeRoot(worktreePath: string): boolean {
-  const root = normalizeWorktreePath(path.join(getWmuxHomeDir(), 'worktrees'));
-  const p = normalizeWorktreePath(worktreePath);
+  const root = normalizeWorktreePath(path.resolve(getWmuxHomeDir(), 'worktrees'));
+  const p = normalizeWorktreePath(path.resolve(worktreePath));
   return p === root || p.startsWith(root + '/');
 }
 

--- a/src/main/worktask/FanOutService.ts
+++ b/src/main/worktask/FanOutService.ts
@@ -189,9 +189,9 @@ export class FanOutService {
     // 전체를 선검증한다 — 부적격이 하나라도 있으면 mission.start 전에 N개 전부 거부해
     // "부적격이면 태스크 생성 0" 계약을 이행한다. 실 taskId는 아직 없으므로 인덱스별
     // 자리표시자로 slug/경로/branch를 파생·검증한다.
-    for (let k = 0; k < n; k++) {
+    for (const [k, preflightTitle] of titles.entries()) {
       const placeholder = `wtask-preflight-${String(k).padStart(8, '0')}`;
-      const pf = await this.worktrees.preflight(req.repoPath, titles[k]!, placeholder, {
+      const pf = await this.worktrees.preflight(req.repoPath, preflightTitle, placeholder, {
         checkBranchConflict: true,
       });
       if (!pf.ok) {
@@ -201,8 +201,7 @@ export class FanOutService {
 
     // ── 태스크 순차 처리(직렬 큐가 이미 강제하지만, 스폰 부하도 직렬로) ──
     const tasks: FanOutTaskResult[] = [];
-    for (let k = 0; k < n; k++) {
-      const title = titles[k]!;
+    for (const [k, title] of titles.entries()) {
       const missionIdemKey = `${req.idempotencyKey}-${k}`;
       const r = await this.spawnOne({
         index: k,
@@ -257,13 +256,12 @@ export class FanOutService {
 
     // ② worktree 생성(전용 루트·직렬 큐). 프리플라이트를 태스크별 taskId로 재실행해
     //    실 slug·경로를 확정한다(bare/submodule/LFS는 이미 ⓪에서 걸렸으니 재확인은 저렴).
-    let plan: TaskWorktreePlan;
     const pf = await this.worktrees.preflight(ctx.repoPath, ctx.title, taskId);
     if (!pf.ok) {
       await this.compensate(taskId, ctx.verifiedWorkspaceId);
       return { ...base, error: `worktree preflight failed: ${pf.error}` };
     }
-    plan = pf.plan;
+    const plan: TaskWorktreePlan = pf.plan;
     const created = await this.worktrees.createWorktree(plan);
     if (!created.ok) {
       await this.compensate(taskId, ctx.verifiedWorkspaceId);

--- a/src/renderer/components/Diff/DiffPanel.tsx
+++ b/src/renderer/components/Diff/DiffPanel.tsx
@@ -341,6 +341,9 @@ export default function DiffPanel({ taskId, isActive, surfaceId, verifiedWorkspa
     try {
       const res = await api.workTask.close(taskId, verifiedWorkspaceId);
       if (res.ok) {
+        // F11과 정합: close가 커밋됐으니 로컬 meta도 closed로 — PR/닫기 버튼이
+        // 제거된 worktree를 상대로 다시 눌리지 않게 즉시 숨긴다.
+        setMeta((m) => (m ? { ...m, status: 'closed' } : m));
         pushToast({
           level: res.archivePending ? 'warn' : 'info',
           message: res.unmaterialized

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -686,7 +686,7 @@ function SplitSurfaceView({
             taskId={surface.diffTaskId || ''}
             isActive={surface.id === activeSurfaceId}
             surfaceId={surface.id}
-            verifiedWorkspaceId={workspaceId}
+            verifiedWorkspaceId={surface.diffOwnerWorkspaceId || workspaceId}
           />
         ) : (
           <EditorPanel

--- a/src/renderer/hooks/useNotificationListener.ts
+++ b/src/renderer/hooks/useNotificationListener.ts
@@ -704,11 +704,15 @@ export function useNotificationListener() {
                   void (async () => {
                     const api = window.electronAPI.workTask;
                     if (!api) return;
-                    const res = await api.refire({ ptyId, worktreePath: worktreePath as string, initialCommand: initialCommand as string });
-                    if (res.ok) {
-                      useStore.getState().pushToast({ level: 'info', message: `태스크 "${entry.title}": 프롬프트를 재발사했습니다.` });
-                    } else {
-                      useStore.getState().pushToast({ level: 'error', message: `재발사 불가: ${res.error}` });
+                    try {
+                      const res = await api.refire({ ptyId, worktreePath: worktreePath as string, initialCommand: initialCommand as string });
+                      if (res.ok) {
+                        useStore.getState().pushToast({ level: 'info', message: `태스크 "${entry.title}": 프롬프트를 재발사했습니다.` });
+                      } else {
+                        useStore.getState().pushToast({ level: 'error', message: `재발사 불가: ${res.error}` });
+                      }
+                    } catch (e) {
+                      useStore.getState().pushToast({ level: 'error', message: `재발사 불가: ${e instanceof Error ? e.message : String(e)}` });
                     }
                   })();
                 },

--- a/src/renderer/stores/slices/surfaceSlice.ts
+++ b/src/renderer/stores/slices/surfaceSlice.ts
@@ -149,9 +149,14 @@ export const createSurfaceSlice: StateCreator<StoreState, [['zustand/immer', nev
     if (!ws) return;
     const pane = findLeafPane(ws.rootPane, paneId);
     if (!pane) return;
-    // 같은 태스크 diff가 이미 열려 있으면 그 탭으로 전환.
+    // 같은 태스크 diff가 이미 열려 있으면 그 탭으로 전환. F1 backfill: J3 이전에
+    // 만들어진 서피스는 diffOwnerWorkspaceId가 없다 — 재사용 시 이번에 전달된
+    // owner를 채워 owner 스코프 RPC(close/PR/meta)가 자식 ws로 폴백하지 않게 한다.
     const existing = pane.surfaces.find((s) => s.surfaceType === 'diff' && s.diffTaskId === taskId);
     if (existing) {
+      if (ownerWorkspaceId && !existing.diffOwnerWorkspaceId) {
+        existing.diffOwnerWorkspaceId = ownerWorkspaceId;
+      }
       pane.activeSurfaceId = existing.id;
       return;
     }


### PR DESCRIPTION
머지 후 도착한 #380 리뷰 코멘트 5건의 후속 반영(전건 실코드 확인).

- **refire 경로 검증 우회 차단**: `isUnderWorktreeRoot`가 `..` 붕괴 없이 prefix만 검사해 `{root}/worktrees/../../…`가 통과 → `path.resolve` 선행으로 차단. 우회를 재현하는 회귀 테스트 추가(원시 문자열 구성 — `join()`은 `..`를 미리 접어 재현 불가).
- **분할 오버레이 F1 누락**: hasBoth(터미널+브라우저 스플릿) 오버레이 경로의 DiffPanel만 `diffOwnerWorkspaceId` 폴백 없이 담는 ws id를 넘겨 그 뷰에서 close/PR/meta가 owner 스코프 조회에 실패하던 것 수정.
- **서피스 재사용 backfill**: J3 이전에 만들어진 diff 서피스를 재사용할 때 이번에 전달된 owner ws id를 채움.
- close 성공 시 로컬 meta를 closed로 갱신해 PR/닫기 버튼 즉시 숨김(F11 정합).
- refire IPC 거부 catch(unhandled rejection 제거).
- FanOutService lint 잔재 정리(non-null 단언 2·prefer-const — 변경 파일 eslint 0 에러).

게이트: tsc 클린, 관련 테스트 469 그린.