### PR TITLE
feat(fleet): surface completion evidence on fleet cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.19.0] — 2026-07-10
+### Added
+
+- **Fleet cards surface an agent's completion evidence.** A fleet card now shows a small `✓ evidence n/m` badge when the pane's most recently completed A2A task carries structured completion evidence — `n` is how many of the `m` evidence items are actually verified (a passed command, or a verified inspection/artifact). It's the "trust it ran unattended" proof made legible on the card: the check reads green once at least one item is verified and stays muted when nothing is (verified is a grade, not a claim), and the task title plus the evidence summary live in the badge's tooltip so the on-card text stays a single compact token. The badge reads existing task state only (no new store or round-trip), is addressed per-pane (a pane-pinned task shows on exactly that pane; a workspace-level task shows on the workspace's active pane), and simply isn't drawn when there's no such task.
 
 ### Added
 

--- a/src/renderer/components/FleetView/FleetCard.tsx
+++ b/src/renderer/components/FleetView/FleetCard.tsx
@@ -1,6 +1,9 @@
 import { memo } from 'react';
 import type { FleetPane } from '../../stores/selectors/fleet';
+import { selectLatestCompletionEvidenceTask } from '../../stores/selectors/fleet';
 import type { WorkTask } from '../../../shared/workTask';
+import type { Task } from '../../../shared/types';
+import { isVerifiedItem } from '../../../shared/completionEvidence';
 import { AGENT_STATUS_ICON } from '../Sidebar/agentStatusIcon';
 import { useT } from '../../hooks/useT';
 import { useStore } from '../../stores';
@@ -51,6 +54,46 @@ export function FleetCardMissionLine({ mission }: { mission: WorkTask | undefine
 }
 
 /**
+ * NB3 trust surface — completion-evidence badge (pure, prop-driven, testable).
+ * Given the most recent COMPLETED A2A task addressed to this pane (resolved by
+ * selectLatestCompletionEvidenceTask), it shows `✓ evidence n/m` where n is the
+ * verified-item count (verifiedItemCount) and m the total evidence items — the
+ * durable proof the agent left when it finished, made legible on the card. The
+ * tooltip carries the detail (task title + evidence summary) so the on-card text
+ * stays a single compact token. Renders null when the pane has no such task or
+ * the task carries no evidence items (additive — never a new empty row).
+ */
+export function FleetCardEvidenceBadge({ task }: { task: Task | undefined }): React.ReactElement | null {
+  if (!task) return null;
+  const evidence = task.status.evidence;
+  if (!evidence || evidence.items.length === 0) return null;
+  const total = evidence.items.length;
+  const verified = evidence.items.filter(isVerifiedItem).length;
+  return (
+    <div
+      className="flex items-center gap-1 min-w-0 text-caption font-mono"
+      data-fleet-evidence
+      data-evidence-verified={verified}
+      data-evidence-total={total}
+      title={`Completion evidence — ${task.metadata.title}: ${evidence.summary} (${verified}/${total} verified)`}
+    >
+      {/* The check is green only when at least one item is actually verified —
+          verified is a GRADE, not a gate (completionEvidence E9), so an all-
+          unverified proof reads muted, not falsely reassuring. */}
+      <span
+        className="flex-shrink-0"
+        style={{ color: verified > 0 ? 'var(--accent-green)' : 'var(--text-muted)' }}
+      >
+        ✓
+      </span>
+      <span className="truncate text-[var(--text-muted)]">
+        evidence {verified}/{total}
+      </span>
+    </div>
+  );
+}
+
+/**
  * One agent in the Fleet View grid. Status badge reuses AGENT_STATUS_ICON so the
  * cockpit stays in lockstep with the sidebar dots. awaiting_input — the
  * unattended-loop money state — gets a yellow border + "needs your input"
@@ -64,6 +107,13 @@ function FleetCard({ card, focused, onJump, tail }: FleetCardProps) {
   // paneGroupId 항목만)라 다른 미션 변경엔 리렌더되지 않고, 매칭이 없으면
   // undefined(신규 UI 표면 없음 — 기존 카드 확장).
   const mission = useStore((s) => s.missionByPaneGroup[card.workspaceId]);
+  // NB3 trust surface — the most recent completed A2A task with evidence
+  // addressed to this pane (narrow, reference-stable read: the selector returns
+  // the store's own Task object, so an unchanged winner is Object.is-equal and
+  // never re-renders this memoized card). Undefined ⇒ no badge.
+  const evidenceTask = useStore((s) =>
+    selectLatestCompletionEvidenceTask(s.a2aTasks, card.workspaceId, card.paneId, card.isActivePane),
+  );
   const isAwaitingInput = card.agentStatus === 'awaiting_input';
   const isIdle = card.agentStatus === 'idle';
   // P2: a user rename wins so the cockpit reflects the same name as the composer
@@ -152,6 +202,11 @@ function FleetCard({ card, focused, onJump, tail }: FleetCardProps) {
       {/* 사이클 C — 미션 라인(순수 prop-구동 서브컴포넌트). 이 카드가 fan-out
           태스크의 워크스페이스면 title + status를 부가 표시(매칭 없으면 null). */}
       <FleetCardMissionLine mission={mission} />
+
+      {/* NB3 trust surface — completion-evidence badge for the pane's most
+          recent completed A2A task (null when none). Sits under the mission line
+          because both describe delegated work; subordinate to the header. */}
+      <FleetCardEvidenceBadge task={evidenceTask} />
 
       {/* Affordance row — only when there is something worth a third line. */}
       {isAwaitingInput ? (

--- a/src/renderer/components/FleetView/__tests__/FleetCard.test.tsx
+++ b/src/renderer/components/FleetView/__tests__/FleetCard.test.tsx
@@ -14,9 +14,10 @@
 import { describe, expect, it } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { createElement } from 'react';
-import FleetCard, { FleetCardMissionLine } from '../FleetCard';
+import FleetCard, { FleetCardMissionLine, FleetCardEvidenceBadge } from '../FleetCard';
 import type { FleetPane } from '../../../stores/selectors/fleet';
 import type { WorkTask } from '../../../../shared/workTask';
+import type { EvidenceItem, Task } from '../../../../shared/types';
 
 const noop = () => undefined;
 
@@ -148,5 +149,81 @@ describe('FleetCard — 사이클 C mission line', () => {
     const html = renderLine(mission({ id: 'w2', title: 'Add tests', status: 'closed' }));
     expect(html).toContain('data-mission-status="closed"');
     expect(html).toContain('line-through');
+  });
+});
+
+describe('FleetCard — NB3 completion-evidence badge', () => {
+  // Pure sub-component (like FleetCardMissionLine): takes the already-resolved
+  // Task and renders the badge or null. Addressing / "which task" is the
+  // selector's job (see selectLatestCompletionEvidenceTask in fleet.test.ts) —
+  // a store-seeded full-card render can't exercise it here because
+  // renderToStaticMarkup reads zustand's INITIAL snapshot, not live state.
+  function taskWithEvidence(
+    items: EvidenceItem[],
+    over: { title?: string; summary?: string } = {},
+  ): Task {
+    return {
+      kind: 'task',
+      id: 't-evidence',
+      status: {
+        state: 'completed',
+        timestamp: '2026-07-10T00:00:00.000Z',
+        evidence: { summary: over.summary ?? 'shipped the fix', items },
+      },
+      history: [],
+      artifacts: [],
+      metadata: {
+        title: over.title ?? 'Refactor auth',
+        from: { workspaceId: 'ws-2', name: 'sender' },
+        to: { workspaceId: 'ws-1', name: 'receiver' },
+        createdAt: '2026-07-10T00:00:00.000Z',
+        updatedAt: '2026-07-10T00:00:00.000Z',
+      },
+    };
+  }
+  const passed: EvidenceItem = { kind: 'command', status: 'passed', summary: 'tsc', command: 'tsc --noEmit' };
+  const failed: EvidenceItem = { kind: 'command', status: 'failed', summary: 'lint', command: 'eslint .' };
+  const verified: EvidenceItem = { kind: 'inspection', status: 'verified', summary: 'read the diff' };
+  const unverified: EvidenceItem = { kind: 'artifact', status: 'unverified', summary: 'built a page' };
+
+  const renderBadge = (task: Task | undefined): string =>
+    renderToStaticMarkup(createElement(FleetCardEvidenceBadge, { task }));
+
+  it('renders nothing when there is no evidence task', () => {
+    expect(renderBadge(undefined)).toBe('');
+  });
+
+  it('renders nothing when the completed task carries no evidence items', () => {
+    // A well-formed completed task always has ≥1 item, but the badge must be
+    // defensive: an empty items array is not a badge.
+    expect(renderBadge(taskWithEvidence([]))).toBe('');
+  });
+
+  it('shows ✓ evidence verified/total from the evidence items', () => {
+    const html = renderBadge(taskWithEvidence([passed, failed, verified]));
+    expect(html).toContain('data-fleet-evidence');
+    expect(html).toContain('data-evidence-verified="2"');
+    expect(html).toContain('data-evidence-total="3"');
+    expect(html).toContain('evidence 2/3');
+    // Detail (title + summary) lives in the tooltip, not on-card micro-text.
+    expect(html).toContain('Refactor auth');
+    expect(html).toContain('shipped the fix');
+  });
+
+  it('paints the check green when at least one item is verified', () => {
+    const html = renderBadge(taskWithEvidence([passed, unverified]));
+    expect(html).toContain('var(--accent-green)');
+  });
+
+  it('mutes the check (no green) when nothing is verified — verified is a grade, not a claim', () => {
+    const html = renderBadge(taskWithEvidence([failed, unverified]));
+    expect(html).toContain('data-evidence-verified="0"');
+    expect(html).not.toContain('var(--accent-green)');
+  });
+
+  it('the full card has no evidence badge when the store holds no matching task', () => {
+    // The default (initial) store has empty a2aTasks — the card's own store read
+    // resolves to undefined, so no badge row is added.
+    expect(render({ card: card() })).not.toContain('data-fleet-evidence');
   });
 });

--- a/src/renderer/stores/selectors/__tests__/fleet.test.ts
+++ b/src/renderer/stores/selectors/__tests__/fleet.test.ts
@@ -3,9 +3,10 @@ import {
   selectFleetPanes,
   sortFleetPanes,
   countNeedsAttention,
+  selectLatestCompletionEvidenceTask,
   type FleetPane,
 } from '../fleet';
-import type { Workspace, Pane, Surface, AgentStatus } from '../../../../shared/types';
+import type { Workspace, Pane, Surface, AgentStatus, Task, TaskState, EvidenceItem } from '../../../../shared/types';
 
 // ─── Fixtures ──────────────────────────────────────────────────────────────
 
@@ -301,5 +302,89 @@ describe('selectFleetPanes — X8 supervision mirror', () => {
       supervisionByPtyId: { '': { status: 'armed', restartCount: 1 } },
     });
     expect(pane.supervision).toBeUndefined();
+  });
+});
+
+// ─── selectLatestCompletionEvidenceTask (NB3 trust surface) ──────────────────
+
+describe('selectLatestCompletionEvidenceTask', () => {
+  const item = (over: Partial<EvidenceItem> = {}): EvidenceItem =>
+    ({ kind: 'command', status: 'passed', summary: 'tsc', command: 'tsc', ...over } as EvidenceItem);
+
+  function task(
+    id: string,
+    over: {
+      state?: TaskState;
+      to?: { workspaceId: string; name: string; paneId?: string };
+      items?: EvidenceItem[] | undefined;
+      timestamp?: string;
+      noEvidence?: boolean;
+    } = {},
+  ): Task {
+    return {
+      kind: 'task',
+      id,
+      status: {
+        state: over.state ?? 'completed',
+        timestamp: over.timestamp ?? '2026-07-10T00:00:00.000Z',
+        ...(over.noEvidence ? {} : { evidence: { summary: 's', items: over.items ?? [item()] } }),
+      },
+      history: [],
+      artifacts: [],
+      metadata: {
+        title: `title-${id}`,
+        from: { workspaceId: 'ws-sender', name: 'from' },
+        to: over.to ?? { workspaceId: 'ws-1', name: 'to' },
+        createdAt: '2026-07-10T00:00:00.000Z',
+        updatedAt: '2026-07-10T00:00:00.000Z',
+      },
+    };
+  }
+  const store = (...tasks: Task[]): Record<string, Task> =>
+    Object.fromEntries(tasks.map((t) => [t.id, t]));
+
+  it('returns undefined when no task is addressed to the workspace', () => {
+    const s = store(task('t1', { to: { workspaceId: 'ws-OTHER', name: 'x' } }));
+    expect(selectLatestCompletionEvidenceTask(s, 'ws-1', 'p1', true)).toBeUndefined();
+  });
+
+  it('matches a ws-only (unpinned) task on the ACTIVE pane only', () => {
+    const s = store(task('t1')); // to = ws-1, no paneId
+    expect(selectLatestCompletionEvidenceTask(s, 'ws-1', 'p1', true)?.id).toBe('t1');
+    // background sibling pane of the same ws must NOT inherit a ws-level completion
+    expect(selectLatestCompletionEvidenceTask(s, 'ws-1', 'p2', false)).toBeUndefined();
+  });
+
+  it('matches a pane-pinned task on exactly that pane (active flag irrelevant)', () => {
+    const s = store(task('t1', { to: { workspaceId: 'ws-1', name: 'to', paneId: 'p2' } }));
+    expect(selectLatestCompletionEvidenceTask(s, 'ws-1', 'p2', false)?.id).toBe('t1');
+    expect(selectLatestCompletionEvidenceTask(s, 'ws-1', 'p1', true)).toBeUndefined();
+  });
+
+  it('ignores non-completed tasks even when they carry evidence', () => {
+    const s = store(task('t1', { state: 'working' }), task('t2', { state: 'failed' }));
+    expect(selectLatestCompletionEvidenceTask(s, 'ws-1', 'p1', true)).toBeUndefined();
+  });
+
+  it('ignores a completed task with no evidence or empty items', () => {
+    const none = store(task('t1', { noEvidence: true }));
+    expect(selectLatestCompletionEvidenceTask(none, 'ws-1', 'p1', true)).toBeUndefined();
+    const empty = store(task('t2', { items: [] }));
+    expect(selectLatestCompletionEvidenceTask(empty, 'ws-1', 'p1', true)).toBeUndefined();
+  });
+
+  it('picks the most recently completed task by status timestamp', () => {
+    const s = store(
+      task('old', { timestamp: '2026-07-10T00:00:00.000Z' }),
+      task('new', { timestamp: '2026-07-10T09:00:00.000Z' }),
+      task('mid', { timestamp: '2026-07-10T03:00:00.000Z' }),
+    );
+    expect(selectLatestCompletionEvidenceTask(s, 'ws-1', 'p1', true)?.id).toBe('new');
+  });
+
+  it('returns the store Task reference (not a copy) so a card read stays stable', () => {
+    const t = task('t1');
+    const s = store(t);
+    expect(selectLatestCompletionEvidenceTask(s, 'ws-1', 'p1', true)).toBe(t);
   });
 });

--- a/src/renderer/stores/selectors/fleet.ts
+++ b/src/renderer/stores/selectors/fleet.ts
@@ -1,4 +1,4 @@
-import type { AgentStatus } from '../../../shared/types';
+import type { AgentStatus, Task } from '../../../shared/types';
 import { getLeafPanes } from '../../../shared/paneUtils';
 import type { StoreState } from '../index';
 
@@ -164,6 +164,50 @@ export function sortFleetPanes(
       return a.index - b.index;
     })
     .map((entry) => entry.pane);
+}
+
+// ─── NB3 trust surface — completion-evidence badge source ────────────────────
+//
+// The Fleet cockpit's promise is "trust an agent to run unattended". Completion
+// evidence (§6.M) is the durable proof an agent left when it finished a
+// delegated A2A task; surfacing it on the card is what makes that trust
+// legible. This selector answers, per card, "what is the most recent COMPLETED
+// A2A task addressed to this pane that carries evidence?" — read straight off
+// the existing a2aTasks store (no new store/RPC).
+//
+// It returns the STORE's own Task reference (never a fresh object) so a
+// card-local `useStore` subscription stays reference-stable across unrelated
+// store writes: Object.is holds when the winning task is unchanged, so the
+// memoized FleetCard does not re-render on every a2a mutation — only when THIS
+// pane's latest evidence task actually changes. The card derives the display
+// counts from the returned task (see FleetCardEvidenceBadge).
+//
+// Addressing mirrors the selector's active-pane fidelity rule for `agentName`:
+// a pane-pinned task (to.paneId) matches only that exact pane; a workspace-only
+// task matches the workspace's ACTIVE pane, so a ws-level completion is not
+// duplicated across background sibling panes.
+export function selectLatestCompletionEvidenceTask(
+  a2aTasks: Record<string, Task>,
+  workspaceId: string,
+  paneId: string,
+  isActivePane: boolean,
+): Task | undefined {
+  let best: Task | undefined;
+  for (const task of Object.values(a2aTasks)) {
+    if (task.status.state !== 'completed') continue;
+    const evidence = task.status.evidence;
+    if (!evidence || evidence.items.length === 0) continue;
+    const to = task.metadata.to;
+    if (to.workspaceId !== workspaceId) continue;
+    // Pane precision: a pinned receiver pane must BE this card; an unpinned
+    // (ws-only) task lands on the active pane only.
+    if (to.paneId ? to.paneId !== paneId : !isActivePane) continue;
+    // "Most recent" = latest completion timestamp (status.timestamp is stamped
+    // at the completed transition). Lexicographic compare is chronological for
+    // canonical ISO-8601 UTC strings (both produced by isoNow()).
+    if (!best || task.status.timestamp > best.status.timestamp) best = task;
+  }
+  return best;
 }
 
 // Statuses that count toward the "N need you" header chip: awaiting_input is the


### PR DESCRIPTION
NB3 trust surfacing: fleet cards now show a small `✓ evidence n/m` badge for the most recent completed A2A task addressed to that pane — n is the verified item count, m the total evidence items. The check is green only when at least one item is verified (evidence is a grade, not a gate — matching the completion-evidence design), muted otherwise; task title + summary ride in the tooltip so the card keeps a single caption token. Rendered only when evidence exists.

Data comes straight from the existing a2aSlice task store via a reference-stable selector (unchanged winner → same reference → no memo-card re-render), following the active-pane fidelity rules the fleet selectors already use. No new stores or RPCs.

A delivery-status dot was deliberately **not** added: the renderer's channel-message mirror is scoped to human-membership channels and its deliveryStatus goes stale (ack emits no event), so a dot would show false 'pending' on delivered messages — the delivery signal belongs to wake-nudge records in a later pass.

Gates: tsc 0 · eslint 0 (changed files) · FleetView+selector suites 73/73 · additive only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Fleet cards now display a compact completion-evidence badge for the latest completed task with structured evidence.
  - The badge shows verified and total evidence counts, with task details and evidence summaries available in its tooltip.
  - Evidence is matched to the appropriate workspace and pane, and omitted when no qualifying evidence exists.
  - Verified evidence is highlighted visually when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->