### PR TITLE
fix(session): resolve session/metadata paths lazily so WMUX_DATA_SUFFIX isolation holds

### DIFF
--- a/src/main/session/SessionManager.ts
+++ b/src/main/session/SessionManager.ts
@@ -17,7 +17,23 @@ const DEBOUNCE_MS = 30_000;
 const QUEUE_KEY = 'session';
 
 export class SessionManager {
-  private filePath: string;
+  /**
+   * Resolved LAZILY (first use), never in the constructor. This class is
+   * instantiated as a module-level singleton (session.handler.ts) — module
+   * evaluation runs BEFORE index.ts applies WMUX_DATA_SUFFIX via
+   * app.setPath('userData', …), so a constructor-captured path pins
+   * session.json/metadata.json to the UN-suffixed userData dir. Every other
+   * suffixed surface (pipes, daemon home, logs, tokens) is isolated, so a
+   * suffixed instance (dev '-dev', bench/probe isolation, multi-instance)
+   * silently reads/writes ANOTHER instance's session state — the same
+   * hardcoded-shared-path class as the daemon auth-token bug fixed in #325.
+   * First use is always an IPC handler or save path, well after the suffix
+   * is applied, so lazy resolution is sufficient (no re-resolve needed).
+   */
+  private filePathCached: string | null = null;
+  private get filePath(): string {
+    return (this.filePathCached ??= path.join(app.getPath('userData'), 'session.json'));
+  }
   /**
    * Separate file for the MetadataStore's `PersistedShape` (M0-e).
    *
@@ -34,7 +50,11 @@ export class SessionManager {
    *   - schema_version (M0-a + M0-f) lives inside the metadata envelope,
    *     so its evolution does not pull session.json migrations along.
    */
-  private metadataFilePath: string;
+  /** Lazy for the same suffix-isolation reason as {@link filePath}. */
+  private metadataFilePathCached: string | null = null;
+  private get metadataFilePath(): string {
+    return (this.metadataFilePathCached ??= path.join(app.getPath('userData'), 'metadata.json'));
+  }
   private debounceTimer: NodeJS.Timeout | null = null;
   private pendingData: SessionData | null = null;
   private readonly queue = new AsyncQueue();
@@ -54,8 +74,7 @@ export class SessionManager {
   private lastSyncCommit: { epoch: number; data: SessionData } | null = null;
 
   constructor() {
-    this.filePath = path.join(app.getPath('userData'), 'session.json');
-    this.metadataFilePath = path.join(app.getPath('userData'), 'metadata.json');
+    // Paths deliberately NOT captured here — see the filePath getter.
 
     // Sync fallback for `flushSync()` on emergency exit paths
     // (Windows session-end, process crash handlers, etc.).


### PR DESCRIPTION
## What

`SessionManager` resolves `session.json` / `metadata.json` paths **lazily** on first use instead of capturing them in its constructor.

## Why

`SessionManager` is instantiated as a module-level singleton (`session.handler.ts`), and module evaluation runs **before** `index.ts` applies `WMUX_DATA_SUFFIX` via `app.setPath('userData', …)`. The constructor-captured paths therefore pinned `session.json` and `metadata.json` to the **un-suffixed** userData dir.

Every other surface of a suffixed instance (pipes, auth tokens, daemon home, logs) is properly isolated — but its session state silently read from and wrote to another instance's directory:

- **dev (`-dev`) and packaged production share one `session.json`** — a dev run could overwrite the user's real layout, and vice-versa.
- **Any isolated instance's seeded session was invisible.** This surfaced while validating the perf-bench session seeding: a seeded `session.json` for a `-bench…`/`-probe…` suffix was never loaded (`[SessionManager] load … (no session file)` with the seed file present on disk). Prior bench session seeding (e.g. the scrollback A/B legs) was loading from the un-suffixed path, not the seeded file.

This is the same hardcoded-shared-path class as the daemon auth-token bug fixed in #325.

## Fix

Paths are resolved lazily on first use — always an IPC handler or save path, long after the suffix is applied — and cached per instance. **Unsuffixed production resolves the identical path either way, so this is a no-op for release builds.**

## Test

`src/main/session/__tests__` (reboot persistence / async save / metadata) all green; the tests mock `app.getPath('userData')` per-test, and lazy resolution reads it at call time as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session file handling by resolving storage locations when needed.
  * Increased reliability when the application’s data directory changes during runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->