### PR TITLE
chore(release): v3.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.20.0] — 2026-07-10
+
 ### Added
 
 - **Experimental: hidden panes can skip output parsing (Settings → "Skip hidden pane rendering").** Even with the shared output scheduler, hidden agents' output was still *parsed* eventually — and measurement showed that parsing total is what drags the visible pane once several background agents stream at once (4 hidden flooders pulled the visible pane down to ~10–20fps). With this toggle on (daemon sessions only, default off), hidden panes' output is queued but never parsed: the renderer does no parsing work for panes you aren't looking at. A pane whose backlog outgrows its cap is marked stale and transparently re-synchronized from the daemon's session buffer when revealed — the daemon replays the authoritative bytes onto a reset terminal, so what you see on reveal is the pane's true current state, never a duplicate or a half-parsed frame. Agent-facing buffer reads (`wmux_search_panes`, `terminal_read`) hydrate a stale pane before reading so orchestrating agents never see old output. If a re-sync can't complete (dead session, legacy daemon), the pane degrades to its last-known screen instead of sticking or losing its identity.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.19.0 sources.** This file is produced by
+> **Generated from wmux v3.20.0 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Release **v3.20.0**.

Bumps `package.json` to 3.20.0, promotes the CHANGELOG `[Unreleased]` section to `[3.20.0] — 2026-07-10`, and regenerates `docs/api/reference.md` so its baked version header matches (CI drift guard).

### Highlights since v3.19.0

**Added**
- Experimental hidden-pane retention (Settings → "Skip hidden pane rendering", default off, daemon sessions only): hidden panes' output is queued but never parsed, and a stale pane is transparently re-synchronized from the daemon on reveal (#390).
- Diff comments now wake the task agent — commenting on a hunk @-mentions the task's agents on the mission channel (J4).
- Fleet cards surface an agent's completion evidence (`✓ evidence n/m`).

**Fixed**
- Multiple workspaces full of busy agents no longer stutter the visible terminal — terminal output now flows through a single shared, budgeted scheduler (#388).
- Diff-panel comments now actually post to the mission channel (missing `sender` identity).

**Security**
- `events.poll` no longer lets an agent eavesdrop on another workspace's channels — confidentiality-sensitive events are scoped to a server-resolved identity (audit B3, #387).

### After merge
Tag `v3.20.0` at the merged commit and push it — `release.yml` builds and publishes the cross-platform installers (plus Chocolatey / winget) off the tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the API reference to reflect version 3.20.0.
  * Added the 3.20.0 release entry to the changelog.

* **Release**
  * Bumped the package version to 3.20.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->