### PR TITLE
perf(terminal): daemon headless snapshot + seamless live-pipe reflush (phase 3 PR-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Revealing a stale hidden pane now repaints from a compact daemon-side snapshot instead of replaying the raw session history.** With "Skip hidden pane rendering" on, revealing a pane whose backlog overflowed used to tear down its data socket and replay up to 8 MB of raw bytes for the renderer to re-parse — a visible multi-second repaint (and a brief input dead-zone) at the exact moment you switch to the pane. The daemon now parses the session history itself in a headless terminal and re-flushes a serialized screen — typically dozens of times smaller — **over the live socket**, so input keeps flowing throughout and the pane paints its true current state (scrollback, colors, cursor, and input modes like bracketed paste included) near-instantly. Anything a snapshot cannot reproduce faithfully — full-screen TUIs on the alternate screen, active scroll margins, a pathologically slow parse — automatically falls back to the old raw replay, and legacy daemons fall back to the old reconnect: worst case is the previous behavior, never a wrong screen. Revealing a *dead* session's stale pane now also paints its final screen (read-only snapshot) instead of leaving whatever was last drawn.
+
 ## [3.20.0] — 2026-07-10
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.18.0",
+  "version": "3.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.18.0",
+      "version": "3.20.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -51,6 +51,7 @@
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "@vitejs/plugin-react": "^4.7.0",
+        "@xterm/addon-serialize": "^0.14.0",
         "@xterm/headless": "^6.0.0",
         "autoprefixer": "^10.4.27",
         "electron": "41.0.3",
@@ -5797,6 +5798,13 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.16.0.tgz",
       "integrity": "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-serialize": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-serialize/-/addon-serialize-0.14.0.tgz",
+      "integrity": "sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@xterm/addon-unicode11": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "@vitejs/plugin-react": "^4.7.0",
+    "@xterm/addon-serialize": "^0.14.0",
     "@xterm/headless": "^6.0.0",
     "autoprefixer": "^10.4.27",
     "electron": "41.0.3",

--- a/scripts/perf-bench.mjs
+++ b/scripts/perf-bench.mjs
@@ -1391,9 +1391,22 @@ async function measureHiddenFlood(inst, agentCounts) {
     const sorted = [...agentCounts].sort((a, b) => a - b);
     for (const n of sorted) {
       while (hidden.length < n) {
-        const res = await client.call('mcp.claimWorkspace', { name: `hf-flood-${hidden.length + 1}` });
-        if (!res || typeof res.ptyId !== 'string' || res.error) {
-          throw new Error(`hiddenFlood: mcp.claimWorkspace failed — ${res?.error ?? JSON.stringify(res)}`);
+        // Retry rate-limited claims: pty:create shares the daemon's per-socket
+        // RPC budget with everything else on the pipe, and on a fast runner
+        // the N8 top-up can land inside a still-hot window (observed on CI:
+        // "[RESOURCE_EXHAUSTED] rate limited" killed the whole scenario, which
+        // the perf gate then flags as scenario-missing). The window resets
+        // every 1s, so a short backoff always clears it.
+        let res = null;
+        for (let attempt = 1; attempt <= 5; attempt++) {
+          res = await client.call('mcp.claimWorkspace', { name: `hf-flood-${hidden.length + 1}` });
+          const msg = res?.error ?? '';
+          if (res && typeof res.ptyId === 'string' && !res.error) break;
+          if (!/rate limited|RESOURCE_EXHAUSTED/i.test(String(msg)) || attempt === 5) {
+            throw new Error(`hiddenFlood: mcp.claimWorkspace failed — ${msg || JSON.stringify(res)}`);
+          }
+          console.log(`[hiddenFlood] claimWorkspace rate-limited — retry ${attempt}/5 in 1.2s`);
+          await sleep(1200);
         }
         hidden.push(res.ptyId);
         await sleep(200);

--- a/scripts/phase3-resync-probe.mjs
+++ b/scripts/phase3-resync-probe.mjs
@@ -1,0 +1,306 @@
+// Phase 3 PR-B — isolated daemon resync probe (갭-프리 실증).
+//
+// Boots the BUNDLED daemon (dist/daemon-bundle/index.js) in a throwaway HOME
+// with WMUX_DATA_SUFFIX isolation, creates a real PTY session, attaches a
+// fake-renderer session-pipe client, then repeatedly triggers
+// `daemon.resyncSession` WHILE the PTY is flooding output.
+//
+// What it proves end-to-end (on top of the socket-level unit test):
+//  - the client-reconstructed screen (initial flush → live → RESYNC_BEGIN →
+//    snapshot replay → live ...) has CONTIGUOUS numbered flood lines after
+//    each burst quiesces — a byte lost at any resync seam (T1: snapshot /
+//    partial-tail / post-marker tail / live) tears or drops a line;
+//  - input written mid-resync still reaches the PTY (무단절);
+//  - every reflush took the snapshot path (mode=snapshot in daemon log) —
+//    an unexpected raw fallback fails the probe.
+//
+// Run: node scripts/phase3-resync-probe.mjs   (needs `npm run build:daemon` first)
+
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import headless from '@xterm/headless';
+import unicode11 from '@xterm/addon-unicode11';
+
+const { Terminal } = headless;
+const { Unicode11Addon } = unicode11;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+const SUFFIX = '-resyncprobe';
+const USERNAME = os.userInfo().username;
+const COLS = 200;
+const ROWS = 30;
+const BURSTS = 3;
+const LINES_PER_BURST = 4000;
+
+const FLUSH_DONE = Buffer.from('\x00WMUX_FLUSH_DONE\x00');
+const RESYNC_BEGIN = Buffer.from('\x00WMUX_RESYNC_BEGIN\x00');
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function waitFor(label, fn, timeoutMs = 15000, intervalMs = 100) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() > deadline) throw new Error(`timeout waiting for ${label}`);
+    await sleep(intervalMs);
+  }
+}
+
+// --- control-pipe RPC client -------------------------------------------------
+class ControlClient {
+  constructor(pipeName, token) {
+    this.pipeName = pipeName;
+    this.token = token;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.buf = '';
+  }
+  connect() {
+    return new Promise((resolve, reject) => {
+      const sock = net.createConnection(this.pipeName);
+      sock.setEncoding('utf8');
+      sock.once('connect', () => { this.sock = sock; resolve(); });
+      sock.once('error', reject);
+      sock.on('data', (chunk) => {
+        this.buf += chunk;
+        const lines = this.buf.split('\n');
+        this.buf = lines.pop() ?? '';
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          let msg;
+          try { msg = JSON.parse(line); } catch { continue; }
+          const p = this.pending.get(msg.id);
+          if (p) {
+            this.pending.delete(msg.id);
+            msg.ok ? p.resolve(msg.result) : p.reject(new Error(msg.error));
+          }
+        }
+      });
+    });
+  }
+  rpc(method, params = {}) {
+    return new Promise((resolve, reject) => {
+      const id = String(this.nextId++);
+      this.pending.set(id, { resolve, reject });
+      this.sock.write(JSON.stringify({ id, method, params, token: this.token }) + '\n');
+      setTimeout(() => {
+        if (this.pending.delete(id)) reject(new Error(`rpc timeout: ${method}`));
+      }, 10000).unref?.();
+    });
+  }
+  close() { this.sock?.destroy(); }
+}
+
+// --- fake renderer: session pipe client + marker-aware reconstruction --------
+class RendererSim {
+  constructor() {
+    this.terminal = new Terminal({ cols: COLS, rows: ROWS, scrollback: 5000, allowProposedApi: true, logLevel: 'off' });
+    this.terminal.loadAddon(new Unicode11Addon());
+    this.terminal.unicode.activeVersion = '11';
+    this.mode = 'accumulating'; // initial flush
+    this.pendingChunks = [];
+    this.lastByteAt = Date.now();
+    this.flushCount = 0;
+  }
+  async write(data) {
+    await new Promise((r) => this.terminal.write(data, r));
+  }
+  /** Feed raw socket bytes; applies the DaemonClient/useTerminal contract:
+   *  accumulate → FLUSH_DONE → reset + write(replay) → live; live+BEGIN →
+   *  back to accumulate. */
+  async feed(chunk) {
+    this.lastByteAt = Date.now();
+    let rest = chunk;
+    for (;;) {
+      if (this.mode === 'accumulating') {
+        this.pendingChunks.push(rest);
+        const combined = Buffer.concat(this.pendingChunks);
+        const idx = combined.indexOf(FLUSH_DONE);
+        if (idx === -1) return;
+        const replay = combined.subarray(0, idx);
+        this.terminal.reset();
+        await this.write(replay);
+        this.flushCount++;
+        this.pendingChunks = [];
+        this.mode = 'live';
+        rest = Buffer.from(combined.subarray(idx + FLUSH_DONE.length));
+        if (rest.length === 0) return;
+        continue;
+      }
+      // live: watch for RESYNC_BEGIN (probe always "armed" — simpler than main,
+      // and marker bytes never legitimately appear in PTY output)
+      const bIdx = rest.indexOf(RESYNC_BEGIN);
+      if (bIdx === -1) {
+        await this.write(rest);
+        return;
+      }
+      await this.write(rest.subarray(0, bIdx));
+      this.mode = 'accumulating';
+      rest = Buffer.from(rest.subarray(bIdx + RESYNC_BEGIN.length));
+      if (rest.length === 0) return;
+    }
+  }
+  bufferLines() {
+    const buf = this.terminal.buffer.active;
+    const lines = [];
+    for (let y = 0; y < buf.length; y++) {
+      lines.push(buf.getLine(y)?.translateToString(true) ?? '');
+    }
+    return lines;
+  }
+}
+
+async function main() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-resyncprobe-'));
+  const env = {
+    ...process.env,
+    USERPROFILE: home,
+    HOME: home,
+    WMUX_DATA_SUFFIX: SUFFIX,
+  };
+  console.log(`[probe] home=${home}`);
+  const daemonLog = [];
+  const daemon = spawn(process.execPath, [path.join(REPO_ROOT, 'dist', 'daemon-bundle', 'index.js')], {
+    cwd: REPO_ROOT, env, stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  daemon.stdout.on('data', (d) => daemonLog.push(d.toString()));
+  daemon.stderr.on('data', (d) => daemonLog.push(d.toString()));
+  const failures = [];
+  try {
+    const token = await waitFor('auth token', () => {
+      try { return fs.readFileSync(path.join(home, `.wmux${SUFFIX}`, 'daemon-auth-token'), 'utf8').trim() || null; } catch { return null; }
+    });
+    const control = new ControlClient(`\\\\.\\pipe\\wmux-daemon${SUFFIX}-${USERNAME}`, token);
+    await waitFor('control pipe', async () => {
+      try { await control.connect(); return true; } catch { return null; }
+    });
+    console.log('[probe] control pipe connected');
+
+    const sessionId = `resyncprobe-${Date.now().toString(36)}`;
+    const sessionEnv = {
+      PATH: process.env.PATH ?? '',
+      SYSTEMROOT: process.env.SYSTEMROOT ?? 'C:\\Windows',
+      SYSTEMDRIVE: process.env.SYSTEMDRIVE ?? 'C:',
+      COMSPEC: process.env.COMSPEC ?? 'C:\\Windows\\System32\\cmd.exe',
+      USERPROFILE: home,
+      TEMP: process.env.TEMP ?? home,
+      TMP: process.env.TMP ?? home,
+      PSModulePath: process.env.PSModulePath ?? '',
+    };
+    // Pre-write the flood scripts: no inline shell quoting (powershell 5.1
+    // mangles the nested-quote one-liner), and cmd.exe keeps the prompt ASCII.
+    for (let burst = 0; burst < BURSTS; burst++) {
+      const start = burst * LINES_PER_BURST;
+      fs.writeFileSync(
+        path.join(home, `flood-${burst}.js`),
+        `for(let i=${start};i<${start + LINES_PER_BURST};i++)console.log('line-'+String(i).padStart(6,'0')+' probe '.repeat(8))`,
+      );
+    }
+    await control.rpc('daemon.createSession', {
+      id: sessionId, cmd: 'cmd.exe', cwd: home, env: sessionEnv, cols: COLS, rows: ROWS,
+    });
+    await control.rpc('daemon.attachSession', { id: sessionId });
+
+    // Session pipe attach (fake renderer).
+    const sim = new RendererSim();
+    const sessSock = await new Promise((resolve, reject) => {
+      const s = net.createConnection(`\\\\.\\pipe\\wmux-session-${sessionId}`);
+      s.once('connect', () => resolve(s));
+      s.once('error', reject);
+    });
+    const feedQueue = [];
+    let feeding = false;
+    sessSock.on('data', (chunk) => {
+      feedQueue.push(chunk);
+      if (feeding) return;
+      feeding = true;
+      (async () => {
+        while (feedQueue.length) await sim.feed(feedQueue.shift());
+        feeding = false;
+      })().catch((e) => failures.push(`sim feed error: ${e.message}`));
+    });
+    sessSock.write(token + '\n');
+    await waitFor('initial flush', () => sim.mode === 'live', 10000);
+    console.log('[probe] session attached, initial flush complete');
+
+    const quiesce = async () => {
+      await waitFor('stream quiesce', () => Date.now() - sim.lastByteAt > 1500 && !feeding, 60000, 200);
+    };
+    await quiesce(); // let the prompt settle
+
+    for (let burst = 0; burst < BURSTS; burst++) {
+      const start = burst * LINES_PER_BURST;
+      const cmd = `"${process.execPath}" flood-${burst}.js\r`;
+      sessSock.write(cmd);
+      // Fire resyncs while the flood is running.
+      await sleep(400);
+      for (let k = 0; k < 2; k++) {
+        const res = await control.rpc('daemon.resyncSession', { id: sessionId, scrollback: 5000 });
+        console.log(`[probe] burst=${burst} resync#${k} mode=${res.mode}${res.fallbackReason ? ` fallback=${res.fallbackReason}` : ''}`);
+        if (res.mode !== 'snapshot') failures.push(`burst ${burst} resync ${k}: expected snapshot, got ${res.mode} (${res.fallbackReason})`);
+        await sleep(350);
+      }
+      await quiesce();
+      // Continuity assertion: every line-N visible in the buffer must be
+      // contiguous ascending and end at the burst's last line.
+      const nums = [];
+      for (const line of sim.bufferLines()) {
+        const m = /^line-(\d{6}) probe/.exec(line);
+        if (m) nums.push(parseInt(m[1], 10));
+      }
+      const last = nums[nums.length - 1];
+      let contiguous = nums.length > 10;
+      for (let i = 1; i < nums.length; i++) {
+        if (nums[i] !== nums[i - 1] + 1) { contiguous = false; failures.push(`burst ${burst}: gap ${nums[i - 1]} -> ${nums[i]}`); break; }
+      }
+      if (last !== start + LINES_PER_BURST - 1) {
+        failures.push(`burst ${burst}: last visible line ${last}, expected ${start + LINES_PER_BURST - 1}`);
+      }
+      console.log(`[probe] burst=${burst} lines-in-buffer=${nums.length} last=${last} contiguous=${contiguous} ${contiguous && last === start + LINES_PER_BURST - 1 ? 'PASS' : 'FAIL'}`);
+      if (nums.length === 0) {
+        const tail = sim.bufferLines().filter((l) => l.trim()).slice(-12);
+        console.log('[probe] screen tail:\n' + tail.map((l) => '    |' + l).join('\n'));
+      }
+    }
+
+    // 무단절 input check: type an echo during one more resync.
+    sessSock.write('echo probe-input-alive\r');
+    await control.rpc('daemon.resyncSession', { id: sessionId, scrollback: 5000 }).catch((e) => failures.push(`final resync failed: ${e.message}`));
+    await quiesce();
+    const flat = sim.bufferLines().join('\n');
+    if (!flat.includes('probe-input-alive')) failures.push('input written around resync never echoed (input dead-zone?)');
+    else console.log('[probe] input-alive PASS');
+
+    const reflushLogs = daemonLog.join('').split('\n').filter((l) => l.includes('[SessionPipe.reflush]'));
+    console.log(`[probe] daemon reflush log lines: ${reflushLogs.length}`);
+    for (const l of reflushLogs) console.log('  ' + l.trim());
+
+    await control.rpc('daemon.destroySession', { id: sessionId }).catch(() => {});
+    await control.rpc('daemon.shutdown', {}).catch(() => {});
+    control.close();
+    sessSock.destroy();
+  } finally {
+    await sleep(500);
+    try { daemon.kill('SIGKILL'); } catch { /* already gone */ }
+    // Best-effort temp cleanup — locked files are fine to leave in %TEMP%.
+    try { fs.rmSync(home, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+
+  if (failures.length) {
+    console.error(`\n[probe] FAIL (${failures.length}):`);
+    for (const f of failures) console.error('  - ' + f);
+    process.exit(1);
+  }
+  console.log('\n[probe] ALL PASS');
+}
+
+main().catch((err) => {
+  console.error('[probe] fatal:', err);
+  process.exit(1);
+});

--- a/scripts/phase3-resync-probe.mjs
+++ b/scripts/phase3-resync-probe.mjs
@@ -105,6 +105,7 @@ class RendererSim {
     this.terminal.unicode.activeVersion = '11';
     this.mode = 'accumulating'; // initial flush
     this.pendingChunks = [];
+    this.liveCarry = Buffer.alloc(0);
     this.lastByteAt = Date.now();
     this.flushCount = 0;
   }
@@ -134,15 +135,25 @@ class RendererSim {
         continue;
       }
       // live: watch for RESYNC_BEGIN (probe always "armed" — simpler than main,
-      // and marker bytes never legitimately appear in PTY output)
-      const bIdx = rest.indexOf(RESYNC_BEGIN);
+      // and marker bytes never legitimately appear in PTY output). Carry a
+      // possible marker-prefix tail across chunk boundaries so a BEGIN split
+      // over two socket reads is still detected (mirrors the main scanner).
+      const scan = this.liveCarry.length > 0 ? Buffer.concat([this.liveCarry, rest]) : rest;
+      this.liveCarry = Buffer.alloc(0);
+      const bIdx = scan.indexOf(RESYNC_BEGIN);
       if (bIdx === -1) {
-        await this.write(rest);
+        let hold = 0;
+        const maxK = Math.min(RESYNC_BEGIN.length - 1, scan.length);
+        for (let k = maxK; k >= 1; k--) {
+          if (scan.subarray(scan.length - k).equals(RESYNC_BEGIN.subarray(0, k))) { hold = k; break; }
+        }
+        this.liveCarry = Buffer.from(scan.subarray(scan.length - hold));
+        await this.write(scan.subarray(0, scan.length - hold));
         return;
       }
-      await this.write(rest.subarray(0, bIdx));
+      await this.write(scan.subarray(0, bIdx));
       this.mode = 'accumulating';
-      rest = Buffer.from(rest.subarray(bIdx + RESYNC_BEGIN.length));
+      rest = Buffer.from(scan.subarray(bIdx + RESYNC_BEGIN.length));
       if (rest.length === 0) return;
     }
   }
@@ -281,8 +292,8 @@ async function main() {
     console.log(`[probe] daemon reflush log lines: ${reflushLogs.length}`);
     for (const l of reflushLogs) console.log('  ' + l.trim());
 
-    await control.rpc('daemon.destroySession', { id: sessionId }).catch(() => {});
-    await control.rpc('daemon.shutdown', {}).catch(() => {});
+    await control.rpc('daemon.destroySession', { id: sessionId }).catch(() => { /* teardown is best-effort */ });
+    await control.rpc('daemon.shutdown', {}).catch(() => { /* daemon may already be exiting */ });
     control.close();
     sessSock.destroy();
   } finally {

--- a/src/daemon/HeadlessSnapshot.ts
+++ b/src/daemon/HeadlessSnapshot.ts
@@ -1,0 +1,251 @@
+/**
+ * On-demand headless terminal snapshot (phase 3 PR-B).
+ *
+ * Parses a session's raw ANSI history (ring buffer + live tee) through
+ * `@xterm/headless` and serializes the resulting screen + scrollback into a
+ * compact re-executable ANSI payload. The renderer paints this instead of
+ * re-parsing the full 8 MB raw replay on reveal.
+ *
+ * There is deliberately NO persistent mirror: reveals are human-frequency, so
+ * a terminal is constructed per request and disposed after (daemon
+ * steady-state cost stays zero, resize needs no tracking — dims come from
+ * `meta.cols/rows` at request time).
+ *
+ * System invariant ("slower, never wrong"): every condition the snapshot
+ * cannot reproduce faithfully returns `{ ok: false }` so the caller degrades
+ * to the raw-replay ladder:
+ *  - alternate screen buffer active (vim & friends — DECSC, saved titles and
+ *    other unserialized state make fidelity unprovable),
+ *  - DECSTBM scroll margins in effect (not serialized by the addon),
+ *  - the stream ends inside an escape sequence too large to re-ship,
+ *  - the parse exceeded its time budget,
+ *  - anything thrown by xterm itself.
+ *
+ * IMPORTANT (query safety): no `onData` handler is ever wired on the headless
+ * terminal. It must never answer DA1/DSR/OSC color queries — the renderer's
+ * xterm is the authoritative responder; a daemon-side reply would race ahead
+ * of it and feed the shell wrong values.
+ */
+
+import { Terminal } from '@xterm/headless';
+import { SerializeAddon } from '@xterm/addon-serialize';
+import { Unicode11Addon } from '@xterm/addon-unicode11';
+import {
+  PartialSequenceTracker,
+  MarginTracker,
+  SgrMouseEncodingTracker,
+  incompleteUtf8SuffixLength,
+} from './util/ansiStreamScan';
+
+export interface SnapshotRequest {
+  cols: number;
+  rows: number;
+  /** Scrollback lines for the headless buffer (defaults to 5000, clamped). */
+  scrollback?: number;
+  /** Raw history captured at T0 (ring buffer readAll). */
+  initial: Buffer;
+  /**
+   * Live-tee drain: returns (and removes) chunks that arrived since the last
+   * call. Called repeatedly until it comes back empty. Omit for read-only
+   * snapshots of quiescent sessions (dead-session serialize).
+   */
+  drainQueue?: () => Buffer[];
+  /** Wall-clock budget for the whole parse+serialize (default 2000 ms). */
+  budgetMs?: number;
+}
+
+export type SnapshotFallbackReason =
+  | 'alt-screen'
+  | 'margins'
+  | 'partial-tail-overflow'
+  | 'budget'
+  | 'error';
+
+export type SnapshotOutcome =
+  | { ok: true; payload: Buffer; bytesIn: number; durationMs: number }
+  | { ok: false; reason: SnapshotFallbackReason; detail?: string };
+
+// Measured (resync probe, 2026-07-10): chunked parse runs ~4 MB/s, so a FULL
+// 8 MB ring — the flagship flooded-pane case — needs ~2 s. A 2 s budget would
+// degrade exactly that case to the 8 MB raw replay this module exists to
+// avoid; 4 s keeps headroom while still bounding a pathological stream.
+const DEFAULT_BUDGET_MS = 4000;
+const DEFAULT_SCROLLBACK = 5000;
+const MAX_SCROLLBACK = 50_000;
+/** Feed slice size — keeps each synchronous parse burst bounded so the daemon
+ * event loop (input forwarding!) never stalls behind an 8 MB write. */
+const FEED_SLICE_BYTES = 256 * 1024;
+
+/**
+ * Global serialization queue (concurrency 1). Simultaneous reveals across
+ * panes would otherwise multiply peak memory (one headless terminal each) and
+ * fight for the event loop.
+ */
+let queueTail: Promise<unknown> = Promise.resolve();
+
+export function generateSnapshot(req: SnapshotRequest): Promise<SnapshotOutcome> {
+  const run = queueTail.then(() => generateInner(req));
+  // The queue must survive a rejected run (generateInner never rejects by
+  // design, but a defensive catch keeps one bug from wedging all snapshots).
+  queueTail = run.catch(() => undefined);
+  return run;
+}
+
+async function generateInner(req: SnapshotRequest): Promise<SnapshotOutcome> {
+  const started = Date.now();
+  const budgetMs = req.budgetMs ?? DEFAULT_BUDGET_MS;
+  const scrollback = clamp(req.scrollback ?? DEFAULT_SCROLLBACK, 0, MAX_SCROLLBACK);
+
+  const terminal = new Terminal({
+    cols: req.cols,
+    rows: req.rows,
+    scrollback,
+    allowProposedApi: true,
+    logLevel: 'off',
+  });
+  const serializer = new SerializeAddon();
+  try {
+    terminal.loadAddon(serializer);
+    // Width parity with the renderer (useTerminal sets the same): without
+    // Unicode 11 tables, CJK/emoji rows advance the cursor differently here
+    // than on screen and the snapshot paints cell-shifted tears.
+    terminal.loadAddon(new Unicode11Addon());
+    terminal.unicode.activeVersion = '11';
+
+    const partialTail = new PartialSequenceTracker();
+    const margins = new MarginTracker();
+    const sgrMouse = new SgrMouseEncodingTracker();
+    // Bytes at a chunk tail that form an incomplete UTF-8 char — carried into
+    // the next chunk; whatever remains at finalize is appended raw after the
+    // snapshot so the renderer's byte stream stays contiguous.
+    let utf8Carry: Buffer = Buffer.alloc(0);
+    let bytesIn = 0;
+
+    const feed = async (raw: Buffer): Promise<boolean> => {
+      bytesIn += raw.length;
+      const buf = utf8Carry.length > 0 ? Buffer.concat([utf8Carry, raw]) : raw;
+      utf8Carry = Buffer.alloc(0);
+      for (let off = 0; off < buf.length; off += FEED_SLICE_BYTES) {
+        const end = Math.min(off + FEED_SLICE_BYTES, buf.length);
+        let slice = buf.subarray(off, end);
+        if (end === buf.length) {
+          const pending = incompleteUtf8SuffixLength(slice);
+          if (pending > 0) {
+            utf8Carry = Buffer.from(slice.subarray(slice.length - pending));
+            slice = slice.subarray(0, slice.length - pending);
+          }
+        }
+        if (slice.length === 0) continue;
+        const text = slice.toString('utf8');
+        partialTail.feed(text);
+        margins.feed(text);
+        sgrMouse.feed(text);
+        // Await the parse callback: backpressure AND an event-loop yield per
+        // slice (xterm completes writes asynchronously).
+        await new Promise<void>((resolve) => terminal.write(text, resolve));
+        if (Date.now() - started > budgetMs) return false;
+      }
+      return true;
+    };
+
+    if (!(await feed(req.initial))) {
+      return { ok: false, reason: 'budget' };
+    }
+    if (req.drainQueue) {
+      // Drain the live tee until we observe it empty. The check and the
+      // caller's finalize both run synchronously relative to socket events,
+      // so chunks that arrive after our last observation become the caller's
+      // post-marker tail — never lost, never double-fed.
+      for (;;) {
+        const chunks = req.drainQueue();
+        if (chunks.length === 0) break;
+        for (const chunk of chunks) {
+          if (!(await feed(chunk))) {
+            return { ok: false, reason: 'budget' };
+          }
+        }
+      }
+    }
+
+    if (terminal.buffer.active.type === 'alternate') {
+      return { ok: false, reason: 'alt-screen' };
+    }
+    if (margins.active) {
+      return { ok: false, reason: 'margins' };
+    }
+    const tail = partialTail.isPending ? partialTail.pendingTail : '';
+    if (tail === null) {
+      return { ok: false, reason: 'partial-tail-overflow' };
+    }
+
+    const core = serializer.serialize();
+    const modesTail = buildModesTail(terminal, sgrMouse);
+    const payload = Buffer.concat([
+      Buffer.from(core + modesTail + tail, 'utf8'),
+      utf8Carry,
+    ]);
+    return { ok: true, payload, bytesIn, durationMs: Date.now() - started };
+  } catch (err) {
+    return { ok: false, reason: 'error', detail: err instanceof Error ? err.message : String(err) };
+  } finally {
+    try {
+      terminal.dispose();
+    } catch {
+      /* already disposed on some error paths */
+    }
+  }
+}
+
+/**
+ * SerializeAddon restores content but not DECSET/mode state (F5): a lost
+ * bracketed-paste mode turns a multi-line paste into line-by-line execution;
+ * lost application-cursor mode breaks arrow keys. Rebuild the tail from the
+ * headless terminal's public modes, plus the SGR mouse-encoding pair the
+ * public API does not expose (tracked from the raw stream).
+ *
+ * Not covered (accepted): DECSC saved cursor, cursor visibility (DECTCEM) —
+ * apps that use them are overwhelmingly alt-screen TUIs, which already fell
+ * back to raw replay above.
+ */
+function buildModesTail(terminal: Terminal, sgrMouse: SgrMouseEncodingTracker): string {
+  const modes = terminal.modes;
+  let tail = '';
+  if (modes.insertMode) tail += '\x1b[4h';
+  if (!modes.wraparoundMode) tail += '\x1b[?7l';
+  if (modes.originMode) tail += '\x1b[?6h';
+  if (modes.reverseWraparoundMode) tail += '\x1b[?45h';
+  if (modes.applicationCursorKeysMode) tail += '\x1b[?1h';
+  if (modes.applicationKeypadMode) tail += '\x1b=';
+  if (modes.sendFocusMode) tail += '\x1b[?1004h';
+  if (modes.bracketedPasteMode) tail += '\x1b[?2004h';
+  switch (modes.mouseTrackingMode) {
+    case 'x10':
+      tail += '\x1b[?9h';
+      break;
+    case 'vt200':
+      tail += '\x1b[?1000h';
+      break;
+    case 'drag':
+      tail += '\x1b[?1002h';
+      break;
+    case 'any':
+      tail += '\x1b[?1003h';
+      break;
+    case 'none':
+      break;
+  }
+  if (modes.mouseTrackingMode !== 'none') {
+    if (sgrMouse.sgrPixels) tail += '\x1b[?1016h';
+    else if (sgrMouse.sgr) tail += '\x1b[?1006h';
+  }
+  // Synchronized output: if the app was cut mid-batch, re-arming ?2026
+  // matches the parser state; the closing 2026l arrives with the live bytes
+  // (xterm has an internal timeout, so a crashed app cannot wedge painting).
+  if (modes.synchronizedOutputMode) tail += '\x1b[?2026h';
+  return tail;
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  if (!Number.isFinite(v)) return lo;
+  return Math.max(lo, Math.min(hi, Math.floor(v)));
+}

--- a/src/daemon/HeadlessSnapshot.ts
+++ b/src/daemon/HeadlessSnapshot.ts
@@ -73,8 +73,9 @@ const DEFAULT_BUDGET_MS = 4000;
 const DEFAULT_SCROLLBACK = 5000;
 const MAX_SCROLLBACK = 50_000;
 /** Feed slice size — keeps each synchronous parse burst bounded so the daemon
- * event loop (input forwarding!) never stalls behind an 8 MB write. */
-const FEED_SLICE_BYTES = 256 * 1024;
+ * event loop (input forwarding!) never stalls behind an 8 MB write.
+ * Exported for the slice-boundary regression test. */
+export const FEED_SLICE_BYTES = 256 * 1024;
 
 /**
  * Global serialization queue (concurrency 1). Simultaneous reveals across
@@ -83,12 +84,33 @@ const FEED_SLICE_BYTES = 256 * 1024;
  */
 let queueTail: Promise<unknown> = Promise.resolve();
 
-export function generateSnapshot(req: SnapshotRequest): Promise<SnapshotOutcome> {
-  const run = queueTail.then(() => generateInner(req));
-  // The queue must survive a rejected run (generateInner never rejects by
-  // design, but a defensive catch keeps one bug from wedging all snapshots).
+/**
+ * Acquire the global snapshot slot and run `job` while holding it. Exposed so
+ * SessionPipe.reflush can put its ENTIRE suppress→snapshot→finalize window
+ * inside the slot: a reflush that queued AFTER announcing RESYNC_BEGIN would
+ * suppress its pane's live output for the whole queue wait (N×budget under
+ * concurrent reveals) and blow past the renderer's resync timeout — the
+ * suppression window must equal the work window, not the wait window.
+ */
+export function enqueueSnapshotJob<T>(job: () => Promise<T>): Promise<T> {
+  const run = queueTail.then(job);
+  // The queue must survive a rejected job (a defensive catch keeps one bug
+  // from wedging all snapshots).
   queueTail = run.catch(() => undefined);
   return run;
+}
+
+export function generateSnapshot(req: SnapshotRequest): Promise<SnapshotOutcome> {
+  return enqueueSnapshotJob(() => generateInner(req));
+}
+
+/**
+ * Non-queued variant for callers that already hold the slot via
+ * enqueueSnapshotJob (SessionPipe.reflush). Calling this without the slot
+ * forfeits the memory/event-loop serialization the queue exists for.
+ */
+export function generateSnapshotUnqueued(req: SnapshotRequest): Promise<SnapshotOutcome> {
+  return generateInner(req);
 }
 
 async function generateInner(req: SnapshotRequest): Promise<SnapshotOutcome> {
@@ -125,15 +147,26 @@ async function generateInner(req: SnapshotRequest): Promise<SnapshotOutcome> {
       bytesIn += raw.length;
       const buf = utf8Carry.length > 0 ? Buffer.concat([utf8Carry, raw]) : raw;
       utf8Carry = Buffer.alloc(0);
-      for (let off = 0; off < buf.length; off += FEED_SLICE_BYTES) {
+      for (let off = 0; off < buf.length; ) {
         const end = Math.min(off + FEED_SLICE_BYTES, buf.length);
+        const isFinal = end === buf.length;
         let slice = buf.subarray(off, end);
-        if (end === buf.length) {
-          const pending = incompleteUtf8SuffixLength(slice);
-          if (pending > 0) {
-            utf8Carry = Buffer.from(slice.subarray(slice.length - pending));
-            slice = slice.subarray(0, slice.length - pending);
+        // EVERY slice end can split a multibyte char, not just the buffer end:
+        // an interior 256 KB boundary through a CJK/emoji char would decode
+        // both halves as U+FFFD. Interior boundaries simply retreat past the
+        // incomplete lead so the next slice re-reads it whole; only bytes
+        // pending at the END of the buffer leave via the cross-feed carry.
+        const pending = incompleteUtf8SuffixLength(slice);
+        if (pending > 0) {
+          slice = slice.subarray(0, slice.length - pending);
+          if (isFinal) {
+            utf8Carry = Buffer.from(buf.subarray(end - pending, end));
+            off = end;
+          } else {
+            off = end - pending; // interior retreat: strictly > previous off (slice ≫ 3 bytes)
           }
+        } else {
+          off = end;
         }
         if (slice.length === 0) continue;
         const text = slice.toString('utf8');

--- a/src/daemon/SessionPipe.ts
+++ b/src/daemon/SessionPipe.ts
@@ -239,12 +239,15 @@ export class SessionPipe {
       | { ok: false; reason: string; detail?: string }
     >;
   }): Promise<{ mode: 'snapshot' | 'raw'; fallbackReason?: string }> {
+    // Order matters: an in-flight reflush holds `flushed=false` from its T0
+    // block, so the busy check must run BEFORE the flushed check or a
+    // concurrent call would always misreport as UNAVAILABLE.
+    if (this.reflushInFlight) {
+      throw new Error('RESYNC_BUSY: a re-flush is already in progress');
+    }
     const socket = this.client;
     if (!socket || socket.destroyed || !this.flushed) {
       throw new Error('RESYNC_UNAVAILABLE: no flushed client on session pipe');
-    }
-    if (this.reflushInFlight) {
-      throw new Error('RESYNC_BUSY: a re-flush is already in progress');
     }
     this.reflushInFlight = true;
     const teeQueue: Buffer[] = [];

--- a/src/daemon/SessionPipe.ts
+++ b/src/daemon/SessionPipe.ts
@@ -238,18 +238,61 @@ export class SessionPipe {
       | { ok: true; payload: Buffer; bytesIn: number; durationMs: number }
       | { ok: false; reason: string; detail?: string }
     >;
+    /**
+     * Global snapshot-slot acquisition (HeadlessSnapshot.enqueueSnapshotJob).
+     * The ENTIRE suppress→snapshot→finalize window runs inside the slot so
+     * that under concurrent reveals a queued pane keeps streaming live until
+     * its work can actually start — announcing RESYNC_BEGIN before holding
+     * the slot would suppress it for N×budget and outlive the renderer's
+     * resync timeout (Codex P2). Omitted (tests) → run immediately.
+     */
+    enqueue?: <T>(job: () => Promise<T>) => Promise<T>;
   }): Promise<{ mode: 'snapshot' | 'raw'; fallbackReason?: string }> {
     // Order matters: an in-flight reflush holds `flushed=false` from its T0
     // block, so the busy check must run BEFORE the flushed check or a
-    // concurrent call would always misreport as UNAVAILABLE.
+    // concurrent call would always misreport as UNAVAILABLE. The busy window
+    // covers the queue wait too (reflushInFlight is set before enqueue).
     if (this.reflushInFlight) {
       throw new Error('RESYNC_BUSY: a re-flush is already in progress');
     }
+    if (!this.isFlushed) {
+      throw new Error('RESYNC_UNAVAILABLE: no flushed client on session pipe');
+    }
+    this.reflushInFlight = true;
+    try {
+      const enqueue = opts.enqueue ?? (<T>(job: () => Promise<T>) => job());
+      return await enqueue(() => this.reflushInSlot(opts));
+    } finally {
+      this.reflushInFlight = false;
+    }
+  }
+
+  /** The slot-holding body of {@link reflush} — see the protocol notes there. */
+  private async reflushInSlot(opts: {
+    bridge: {
+      on(event: 'data', listener: (data: Buffer) => void): unknown;
+      removeListener(event: 'data', listener: (data: Buffer) => void): unknown;
+    };
+    cols: number;
+    rows: number;
+    scrollback?: number;
+    generate: (req: {
+      cols: number;
+      rows: number;
+      scrollback?: number;
+      initial: Buffer;
+      drainQueue: () => Buffer[];
+    }) => Promise<
+      | { ok: true; payload: Buffer; bytesIn: number; durationMs: number }
+      | { ok: false; reason: string; detail?: string }
+    >;
+  }): Promise<{ mode: 'snapshot' | 'raw'; fallbackReason?: string }> {
+    // Re-validate under the slot: the client can disconnect (or be replaced
+    // by a fresh connection mid-initial-flush) during the queue wait.
     const socket = this.client;
     if (!socket || socket.destroyed || !this.flushed) {
       throw new Error('RESYNC_UNAVAILABLE: no flushed client on session pipe');
     }
-    this.reflushInFlight = true;
     const teeQueue: Buffer[] = [];
     const tee = (data: Buffer) => {
       teeQueue.push(Buffer.isBuffer(data) ? data : Buffer.from(data));
@@ -326,7 +369,6 @@ export class SessionPipe {
       return { mode: 'raw', fallbackReason: outcome.reason };
     } finally {
       opts.bridge.removeListener('data', tee);
-      this.reflushInFlight = false;
     }
   }
 

--- a/src/daemon/SessionPipe.ts
+++ b/src/daemon/SessionPipe.ts
@@ -8,6 +8,16 @@ import type { RingBuffer } from './RingBuffer';
 export const FLUSH_DONE_MARKER = Buffer.from('\x00WMUX_FLUSH_DONE\x00');
 
 /**
+ * In-band announcement that a live-pipe re-flush is starting (phase 3 PR-B).
+ * Written on the ALREADY-FLUSHED stream right before live output is
+ * suppressed; everything after it up to the next FLUSH_DONE_MARKER is replay
+ * (snapshot or raw) that the client must accumulate exactly like the initial
+ * flush. Carrying the state transition in the stream itself is what makes the
+ * protocol race-free: no RPC-vs-stream ordering can misclassify bytes.
+ */
+export const RESYNC_BEGIN_MARKER = Buffer.from('\x00WMUX_RESYNC_BEGIN\x00');
+
+/**
  * Per-session data pipe for raw byte streaming.
  * Created on attach, destroyed on detach.
  *
@@ -23,6 +33,7 @@ export class SessionPipe {
   private client: net.Socket | null = null;
   private inputCallback: ((data: Buffer) => void) | null = null;
   private flushed = false;
+  private reflushInFlight = false;
   private connectionRate = { count: 0, resetAt: 0 };
 
   // A single session pipe is legitimately consumed by at most one renderer at a time.
@@ -181,6 +192,139 @@ export class SessionPipe {
   /** Whether a client is currently connected. */
   get isConnected(): boolean {
     return this.client !== null && !this.client.destroyed;
+  }
+
+  /** Whether the connected client has completed its initial flush (live mode). */
+  get isFlushed(): boolean {
+    return this.isConnected && this.flushed;
+  }
+
+  /**
+   * Live-pipe re-flush (phase 3 PR-B): re-run the flush sequence on the
+   * EXISTING connected socket — no teardown, no re-auth, so the input path
+   * (which never checks `flushed`, see handleClient step 3) keeps flowing and
+   * there is no input dead-zone and no dead-pane replacement.
+   *
+   * Gap-free byte accounting: every PTY byte lands in exactly one of
+   *   - pre-T0  — ring buffer readAll, parsed into the snapshot,
+   *   - T0..T1  — tee'd from the bridge while the snapshot is generated;
+   *               drained into the snapshot, with any post-last-drain
+   *               leftovers written verbatim AFTER the marker (they are live
+   *               bytes the headless parser never saw),
+   *   - post-T1 — normal live writes (flushed=true again).
+   * T0 and T1 are single synchronous blocks, so no 'data' event can interleave
+   * with the capture or the finalize.
+   *
+   * Degrade ladder ("slower, never wrong"): when the generator declines
+   * (alt-screen, margins, budget, error), fall back to a classic raw
+   * ring-buffer replay — the exact bytes the initial flush would send.
+   */
+  async reflush(opts: {
+    /** The session's PTY bridge — tee source for bytes arriving mid-generation. */
+    bridge: {
+      on(event: 'data', listener: (data: Buffer) => void): unknown;
+      removeListener(event: 'data', listener: (data: Buffer) => void): unknown;
+    };
+    cols: number;
+    rows: number;
+    scrollback?: number;
+    generate: (req: {
+      cols: number;
+      rows: number;
+      scrollback?: number;
+      initial: Buffer;
+      drainQueue: () => Buffer[];
+    }) => Promise<
+      | { ok: true; payload: Buffer; bytesIn: number; durationMs: number }
+      | { ok: false; reason: string; detail?: string }
+    >;
+  }): Promise<{ mode: 'snapshot' | 'raw'; fallbackReason?: string }> {
+    const socket = this.client;
+    if (!socket || socket.destroyed || !this.flushed) {
+      throw new Error('RESYNC_UNAVAILABLE: no flushed client on session pipe');
+    }
+    if (this.reflushInFlight) {
+      throw new Error('RESYNC_BUSY: a re-flush is already in progress');
+    }
+    this.reflushInFlight = true;
+    const teeQueue: Buffer[] = [];
+    const tee = (data: Buffer) => {
+      teeQueue.push(Buffer.isBuffer(data) ? data : Buffer.from(data));
+    };
+    try {
+      // T0 — one synchronous block: announce, suppress live writes, capture
+      // the ring, arm the tee. Nothing can arrive between these statements.
+      socket.write(RESYNC_BEGIN_MARKER);
+      this.flushed = false;
+      const initial = this.ringBuffer.readAll();
+      opts.bridge.on('data', tee);
+
+      let outcome: Awaited<ReturnType<typeof opts.generate>>;
+      try {
+        outcome = await opts.generate({
+          cols: opts.cols,
+          rows: opts.rows,
+          scrollback: opts.scrollback,
+          initial,
+          drainQueue: () => teeQueue.splice(0),
+        });
+      } catch (err) {
+        outcome = {
+          ok: false,
+          reason: 'error',
+          detail: err instanceof Error ? err.message : String(err),
+        };
+      }
+
+      // T1 — finalize. MUST stay synchronous through `flushed = true`: a
+      // 'data' event firing between tee removal and re-enable would be lost.
+      opts.bridge.removeListener('data', tee);
+      if (this.client !== socket || socket.destroyed) {
+        // Client vanished (or reconnected fresh) mid-generation — the new
+        // connection runs its own initial flush; abort without touching it.
+        throw new Error('RESYNC_DISCONNECTED: client changed during re-flush');
+      }
+      // RIS prefix: live bytes that raced ahead of RESYNC_BEGIN were buffered
+      // by the renderer's pending-resync state and get written BEFORE this
+      // replay — but they are pre-T0 bytes the snapshot (or raw readAll)
+      // already contains. A full reset first makes the replay idempotent
+      // against that duplicated prefix instead of appending misaligned.
+      const RIS = Buffer.from('\x1bc');
+      if (outcome.ok) {
+        const tailRaw = teeQueue.length > 0 ? Buffer.concat(teeQueue.splice(0)) : null;
+        socket.write(RIS);
+        socket.write(outcome.payload);
+        socket.write(FLUSH_DONE_MARKER);
+        this.flushed = true;
+        if (tailRaw && tailRaw.length > 0) {
+          socket.write(tailRaw);
+        }
+        // eslint-disable-next-line no-console
+        console.log(
+          `[SessionPipe.reflush] sessionId=${this.sessionId} mode=snapshot payload=${outcome.payload.length} parsed=${outcome.bytesIn} durationMs=${outcome.durationMs}`,
+        );
+        return { mode: 'snapshot' };
+      }
+      // Raw degrade: the ring keeps being written by the session manager
+      // independent of this pipe, so a fresh readAll here already contains
+      // every tee'd byte — the classic replay, gap-free because this block
+      // is synchronous.
+      teeQueue.length = 0;
+      const raw = this.ringBuffer.readAll();
+      socket.write(RIS);
+      socket.write(raw);
+      socket.write(FLUSH_DONE_MARKER);
+      this.flushed = true;
+      // A3 rollout metric: fallback-rate by reason.
+      // eslint-disable-next-line no-console
+      console.log(
+        `[SessionPipe.reflush] sessionId=${this.sessionId} mode=raw fallbackReason=${outcome.reason}${outcome.detail ? ` detail=${outcome.detail}` : ''} bytes=${raw.length}`,
+      );
+      return { mode: 'raw', fallbackReason: outcome.reason };
+    } finally {
+      opts.bridge.removeListener('data', tee);
+      this.reflushInFlight = false;
+    }
   }
 
   private handleClient(socket: net.Socket): void {

--- a/src/daemon/__tests__/HeadlessSnapshot.test.ts
+++ b/src/daemon/__tests__/HeadlessSnapshot.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+import { Terminal } from '@xterm/headless';
+import { Unicode11Addon } from '@xterm/addon-unicode11';
+import { generateSnapshot } from '../HeadlessSnapshot';
+
+// ── Round-trip harness ──────────────────────────────────────────────
+//
+// Fidelity is proven by CELL COMPARISON: parse the raw bytes continuously
+// into a "reference" terminal, restore the snapshot payload into another
+// terminal, and assert the two buffers (text + cursor + relevant modes)
+// agree. Both terminals use the exact config the generator uses
+// (@xterm/headless, Unicode 11 tables, allowProposedApi) so widths line up.
+
+function makeTerminal(cols: number, rows: number): Terminal {
+  const t = new Terminal({ cols, rows, scrollback: 5000, allowProposedApi: true });
+  t.loadAddon(new Unicode11Addon());
+  t.unicode.activeVersion = '11';
+  return t;
+}
+
+function writeAsync(t: Terminal, data: string | Uint8Array): Promise<void> {
+  return new Promise<void>((resolve) => t.write(data as string | Uint8Array, resolve));
+}
+
+async function referenceTerminal(bytes: Buffer, cols: number, rows: number): Promise<Terminal> {
+  const t = makeTerminal(cols, rows);
+  await writeAsync(t, bytes);
+  return t;
+}
+
+async function restoredTerminal(payload: Buffer, cols: number, rows: number): Promise<Terminal> {
+  const t = makeTerminal(cols, rows);
+  await writeAsync(t, payload);
+  return t;
+}
+
+/** Every row of the normal buffer (scrollback + viewport), whitespace-trimmed. */
+function bufferText(t: Terminal): string[] {
+  const buf = t.buffer.normal;
+  const lines: string[] = [];
+  for (let i = 0; i < buf.length; i++) {
+    const line = buf.getLine(i);
+    lines.push(line ? line.translateToString(true) : '');
+  }
+  return lines;
+}
+
+/** Trailing blank rows are not fidelity-relevant (the cursor encodes them). */
+function trimTrailingBlank(lines: string[]): string[] {
+  let end = lines.length;
+  while (end > 0 && lines[end - 1] === '') end--;
+  return lines.slice(0, end);
+}
+
+function cursor(t: Terminal): { x: number; y: number } {
+  return { x: t.buffer.active.cursorX, y: t.buffer.active.cursorY };
+}
+
+async function expectRoundTrip(bytes: Buffer, cols: number, rows: number): Promise<Buffer> {
+  const res = await generateSnapshot({ cols, rows, initial: bytes });
+  expect(res.ok).toBe(true);
+  if (!res.ok) throw new Error(`unexpected fallback: ${res.reason}`);
+  const ref = await referenceTerminal(bytes, cols, rows);
+  const restored = await restoredTerminal(res.payload, cols, rows);
+  expect(trimTrailingBlank(bufferText(restored))).toEqual(trimTrailingBlank(bufferText(ref)));
+  expect(cursor(restored)).toEqual(cursor(ref));
+  return res.payload;
+}
+
+describe('HeadlessSnapshot — fidelity round-trips', () => {
+  it('reproduces plain text with SGR colors across scrollback', async () => {
+    const rows = 10;
+    let s = '';
+    for (let i = 0; i < 50; i++) {
+      s += `\x1b[3${i % 8}mline number ${i} with some content\x1b[0m\r\n`;
+    }
+    await expectRoundTrip(Buffer.from(s), 80, rows);
+  });
+
+  it('reproduces a CJK + emoji row at the correct widths', async () => {
+    const bytes = Buffer.from('한글 테스트 🚀 中文 done\r\nsecond line ascii\r\n');
+    await expectRoundTrip(bytes, 40, 10);
+  });
+
+  it('restores bracketed-paste mode', async () => {
+    const res = await generateSnapshot({
+      cols: 80,
+      rows: 24,
+      initial: Buffer.from('\x1b[?2004hprompt$ \r\n'),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const restored = await restoredTerminal(res.payload, 80, 24);
+    expect(restored.modes.bracketedPasteMode).toBe(true);
+  });
+
+  it('restores application-cursor-keys mode', async () => {
+    const res = await generateSnapshot({
+      cols: 80,
+      rows: 24,
+      initial: Buffer.from('\x1b[?1hcontent\r\n'),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const restored = await restoredTerminal(res.payload, 80, 24);
+    expect(restored.modes.applicationCursorKeysMode).toBe(true);
+  });
+
+  it('restores mouse tracking mode and re-emits the SGR encoding', async () => {
+    const res = await generateSnapshot({
+      cols: 80,
+      rows: 24,
+      initial: Buffer.from('\x1b[?1002h\x1b[?1006happ ready\r\n'),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const restored = await restoredTerminal(res.payload, 80, 24);
+    expect(restored.modes.mouseTrackingMode).toBe('drag');
+    // The public API does not expose the ?1006 encoding; the generator must
+    // re-inject it explicitly so the app keeps receiving SGR-format reports.
+    expect(res.payload.toString('utf8')).toContain('\x1b[?1006h');
+  });
+
+  it('degrades on the alternate screen buffer', async () => {
+    const res = await generateSnapshot({
+      cols: 80,
+      rows: 24,
+      initial: Buffer.from('\x1b[?1049h\x1b[HVIM-LIKE CONTENT\r\n'),
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toBe('alt-screen');
+  });
+
+  it('degrades while DECSTBM margins are active, but not after they are cleared', async () => {
+    const active = await generateSnapshot({
+      cols: 80,
+      rows: 24,
+      initial: Buffer.from('\x1b[2;10rmargined content\r\n'),
+    });
+    expect(active.ok).toBe(false);
+    if (!active.ok) expect(active.reason).toBe('margins');
+
+    const cleared = await generateSnapshot({
+      cols: 80,
+      rows: 24,
+      initial: Buffer.from('\x1b[2;10rmargined\x1b[rback to full\r\n'),
+    });
+    expect(cleared.ok).toBe(true);
+  });
+
+  it('keeps an unfinished trailing sequence so the next live bytes complete it', async () => {
+    const bytes = Buffer.from('hello \x1b[3'); // ends mid-CSI
+    const res = await generateSnapshot({ cols: 80, rows: 24, initial: bytes });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    // The partial tail is shipped verbatim so the renderer's parser holds it.
+    expect(res.payload.toString('utf8').endsWith('\x1b[3')).toBe(true);
+
+    // Continuing with '1mRED' must land identically to a continuous parse.
+    const restored = await restoredTerminal(res.payload, 80, 24);
+    await writeAsync(restored, '1mRED');
+    const ref = await referenceTerminal(Buffer.from('hello \x1b[31mRED'), 80, 24);
+    expect(trimTrailingBlank(bufferText(restored))).toEqual(trimTrailingBlank(bufferText(ref)));
+  });
+
+  it('carries a UTF-8 char split between the initial buffer and a drain chunk', async () => {
+    const han = Buffer.from('한'); // 3 bytes
+    const initial = Buffer.concat([Buffer.from('AB'), han.subarray(0, 2)]);
+    let drained = false;
+    const res = await generateSnapshot({
+      cols: 80,
+      rows: 24,
+      initial,
+      drainQueue: () => {
+        if (drained) return [];
+        drained = true;
+        return [han.subarray(2)];
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const restored = await restoredTerminal(res.payload, 80, 24);
+    const ref = await referenceTerminal(Buffer.from('AB한'), 80, 24);
+    expect(trimTrailingBlank(bufferText(restored))).toEqual(trimTrailingBlank(bufferText(ref)));
+  });
+
+  it('drains the live tee over multiple rounds', async () => {
+    const rounds: Buffer[][] = [[Buffer.from('mid1 ')], [Buffer.from('mid2 ')]];
+    let i = 0;
+    const res = await generateSnapshot({
+      cols: 80,
+      rows: 24,
+      initial: Buffer.from('start '),
+      drainQueue: () => rounds[i++] ?? [],
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const restored = await restoredTerminal(res.payload, 80, 24);
+    const ref = await referenceTerminal(Buffer.from('start mid1 mid2 '), 80, 24);
+    expect(trimTrailingBlank(bufferText(restored))).toEqual(trimTrailingBlank(bufferText(ref)));
+  });
+
+  it('degrades to a budget fallback when the parse exceeds its time budget', async () => {
+    const big = Buffer.alloc(8 * 1024 * 1024, 0x41); // 8 MB of 'A'
+    const res = await generateSnapshot({ cols: 80, rows: 24, initial: big, budgetMs: 0 });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('budget');
+  }, 20000);
+
+  it('smoke: serializes several MB of text within a generous budget', async () => {
+    const line = 'x'.repeat(79) + '\r\n';
+    const target = 4 * 1024 * 1024;
+    let s = '';
+    while (s.length < target) s += line;
+    const res = await generateSnapshot({
+      cols: 80,
+      rows: 24,
+      initial: Buffer.from(s),
+      budgetMs: 60000,
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      // eslint-disable-next-line no-console
+      console.log(`[HeadlessSnapshot smoke] bytesIn=${res.bytesIn} durationMs=${res.durationMs}`);
+    }
+  }, 60000);
+});

--- a/src/daemon/__tests__/HeadlessSnapshot.test.ts
+++ b/src/daemon/__tests__/HeadlessSnapshot.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Terminal } from '@xterm/headless';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
-import { generateSnapshot } from '../HeadlessSnapshot';
+import { generateSnapshot, FEED_SLICE_BYTES } from '../HeadlessSnapshot';
 
 // ── Round-trip harness ──────────────────────────────────────────────
 //
@@ -225,4 +225,30 @@ describe('HeadlessSnapshot — fidelity round-trips', () => {
       console.log(`[HeadlessSnapshot smoke] bytesIn=${res.bytesIn} durationMs=${res.durationMs}`);
     }
   }, 60000);
+
+  // CodeRabbit critical regression: an INTERIOR 256 KB feed-slice boundary
+  // used to split multibyte chars (only the final slice carried its tail),
+  // decoding both halves as U+FFFD.
+  it('keeps a multibyte char intact across an interior feed-slice boundary', async () => {
+    const cols = 120;
+    const rows = 10;
+    // Pad so the 3-byte '한' straddles the FEED_SLICE_BYTES boundary
+    // (1 byte in slice 0, 2 bytes in slice 1), then end with a marker line.
+    const pad = 'x'.repeat(64) + '\r\n'; // 66 ASCII bytes
+    let s = '';
+    while (s.length + pad.length <= FEED_SLICE_BYTES - 1) s += pad;
+    s += 'x'.repeat(FEED_SLICE_BYTES - 1 - s.length); // exactly SLICE-1 bytes
+    const bytes = Buffer.concat([
+      Buffer.from(s),
+      Buffer.from('한글 boundary check\r\nend-marker$ '),
+    ]);
+    expect(bytes[FEED_SLICE_BYTES - 1]).toBe(Buffer.from('한')[0]); // straddles
+    const res = await generateSnapshot({ cols, rows, initial: bytes });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const restored = await restoredTerminal(res.payload, cols, rows);
+    const text = bufferText(restored).join('\n');
+    expect(text).toContain('한글 boundary check');
+    expect(text).not.toContain('�');
+  }, 30000);
 });

--- a/src/daemon/__tests__/SessionPipe.reflush.test.ts
+++ b/src/daemon/__tests__/SessionPipe.reflush.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import net from 'node:net';
+import crypto from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import { Terminal } from '@xterm/headless';
+import { Unicode11Addon } from '@xterm/addon-unicode11';
+import {
+  SessionPipe,
+  FLUSH_DONE_MARKER,
+  RESYNC_BEGIN_MARKER,
+} from '../SessionPipe';
+import { RingBuffer } from '../RingBuffer';
+import { generateSnapshot } from '../HeadlessSnapshot';
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+async function waitFor(pred: () => boolean, deadlineMs: number): Promise<void> {
+  const start = Date.now();
+  for (;;) {
+    if (pred()) return;
+    if (Date.now() - start > deadlineMs) throw new Error('waitFor: deadline exceeded');
+    await sleep(5);
+  }
+}
+
+/** Unique per-test session id so named pipes / unix sockets never collide. */
+function uniqueSessionId(tag: string): string {
+  return `reflush-${tag}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+interface Client {
+  socket: net.Socket;
+  chunks: Buffer[];
+  wire: () => Buffer;
+}
+
+function connectClient(pipeName: string, token: string): Promise<Client> {
+  return new Promise<Client>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    const socket = net.createConnection(pipeName, () => {
+      socket.write(token + '\n');
+      resolve({ socket, chunks, wire: () => Buffer.concat(chunks) });
+    });
+    socket.on('data', (c: Buffer) => chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c)));
+    socket.on('error', reject);
+  });
+}
+
+interface WireSegments {
+  replay1: Buffer;
+  live1: Buffer;
+  replay2: Buffer;
+  live2: Buffer;
+  resynced: boolean;
+}
+
+/**
+ * Split the client's received byte stream into its protocol segments:
+ *   [replay1][FLUSH_DONE][live1][RESYNC_BEGIN][replay2][FLUSH_DONE][live2...]
+ */
+function parseWire(buf: Buffer): WireSegments | null {
+  const f = FLUSH_DONE_MARKER.length;
+  const r = RESYNC_BEGIN_MARKER.length;
+  const f1 = buf.indexOf(FLUSH_DONE_MARKER);
+  if (f1 < 0) return null;
+  const rs = buf.indexOf(RESYNC_BEGIN_MARKER, f1 + f);
+  if (rs < 0) {
+    return { replay1: buf.subarray(0, f1), live1: Buffer.alloc(0), replay2: Buffer.alloc(0), live2: Buffer.alloc(0), resynced: false };
+  }
+  const f2 = buf.indexOf(FLUSH_DONE_MARKER, rs + r);
+  if (f2 < 0) {
+    return { replay1: buf.subarray(0, f1), live1: buf.subarray(f1 + f, rs), replay2: Buffer.alloc(0), live2: Buffer.alloc(0), resynced: false };
+  }
+  return {
+    replay1: buf.subarray(0, f1),
+    live1: buf.subarray(f1 + f, rs),
+    replay2: buf.subarray(rs + r, f2),
+    live2: buf.subarray(f2 + f),
+    resynced: true,
+  };
+}
+
+// Headless terminal harness matching generateSnapshot's config exactly.
+function makeTerminal(cols: number, rows: number): Terminal {
+  const t = new Terminal({ cols, rows, scrollback: 5000, allowProposedApi: true });
+  t.loadAddon(new Unicode11Addon());
+  t.unicode.activeVersion = '11';
+  return t;
+}
+
+function writeAsync(t: Terminal, data: Uint8Array): Promise<void> {
+  return new Promise<void>((resolve) => t.write(data, resolve));
+}
+
+function bufferText(t: Terminal): string[] {
+  const buf = t.buffer.normal;
+  const lines: string[] = [];
+  for (let i = 0; i < buf.length; i++) {
+    const line = buf.getLine(i);
+    lines.push(line ? line.translateToString(true) : '');
+  }
+  return lines;
+}
+
+function trimTrailingBlank(lines: string[]): string[] {
+  let end = lines.length;
+  while (end > 0 && lines[end - 1] === '') end--;
+  return lines.slice(0, end);
+}
+
+const TOKEN = 'reflush-session-token';
+
+// Cleanup registry — each test pushes teardown steps (LIFO).
+let cleanups: Array<() => void | Promise<void>> = [];
+afterEach(async () => {
+  for (const c of cleanups.reverse()) {
+    try {
+      await c();
+    } catch {
+      /* best-effort */
+    }
+  }
+  cleanups = [];
+});
+
+describe('SessionPipe.reflush — gap-free live re-flush', () => {
+  it('reconstructs the full stream from [snapshot replay2 + live2] with no gap', async () => {
+    const ring = new RingBuffer(1024 * 1024);
+    const bridge = new EventEmitter();
+    const pipe = new SessionPipe(uniqueSessionId('gapfree'), ring, TOKEN);
+    cleanups.push(() => pipe.stop());
+    await pipe.start();
+
+    // Seed pre-attach history, and start the chronological reference log.
+    const seed = Buffer.from('boot line 0\r\nboot line 1\r\n');
+    ring.write(seed);
+    const original: Buffer[] = [seed];
+
+    const client = await connectClient(pipe.getPipeName(), TOKEN);
+    cleanups.push(() => { client.socket.destroy(); });
+    await waitFor(() => pipe.isFlushed, 3000);
+
+    // A PTY byte is atomic across these three sinks (mirrors the daemon:
+    // SessionManager writes the ring and the client, the reflush tee reads
+    // the bridge). No await splits them, so no chunk straddles T0.
+    const floodChunk = (data: Buffer): void => {
+      original.push(data);
+      ring.write(data);
+      pipe.writeToClient(data);
+      bridge.emit('data', data);
+    };
+
+    const TOTAL = 40;
+    let n = 0;
+    const interval = setInterval(() => {
+      if (n >= TOTAL) {
+        clearInterval(interval);
+        return;
+      }
+      floodChunk(Buffer.from(`\x1b[3${n % 8}mrow ${n} payload xyz\x1b[0m\r\n`));
+      n++;
+    }, 2);
+    cleanups.push(() => clearInterval(interval));
+
+    // Fire the re-flush mid-flood; chunks keep arriving during generation.
+    await sleep(12);
+    const result = await pipe.reflush({ bridge, cols: 80, rows: 24, generate: generateSnapshot });
+    expect(result.mode).toBe('snapshot');
+
+    // Let the flood drain, then append a sentinel that can only land in live2.
+    await waitFor(() => n >= TOTAL, 3000);
+    clearInterval(interval);
+    const sentinel = Buffer.from(`SENTINEL-${crypto.randomUUID().slice(0, 8)}\r\n`);
+    floodChunk(sentinel);
+
+    await waitFor(() => {
+      const p = parseWire(client.wire());
+      return !!(p && p.resynced && p.live2.includes(sentinel));
+    }, 5000);
+
+    const parsed = parseWire(client.wire());
+    expect(parsed?.resynced).toBe(true);
+    if (!parsed || !parsed.resynced) throw new Error('resync segments not found');
+
+    // The proof: replaying [snapshot] then [live tail] equals a continuous
+    // parse of every original byte. Any lost/duplicated byte would diverge.
+    const restored = makeTerminal(80, 24);
+    await writeAsync(restored, parsed.replay2);
+    await writeAsync(restored, parsed.live2);
+
+    const reference = makeTerminal(80, 24);
+    await writeAsync(reference, Buffer.concat(original));
+
+    expect(trimTrailingBlank(bufferText(restored))).toEqual(trimTrailingBlank(bufferText(reference)));
+  }, 20000);
+
+  it('keeps forwarding client input while a re-flush is generating', async () => {
+    const ring = new RingBuffer(1024 * 1024);
+    const bridge = new EventEmitter();
+    const pipe = new SessionPipe(uniqueSessionId('input'), ring, TOKEN);
+    cleanups.push(() => pipe.stop());
+
+    const inputs: Buffer[] = [];
+    pipe.onInput((d) => inputs.push(d));
+    await pipe.start();
+
+    ring.write(Buffer.from('shell prompt$ \r\n'));
+    const client = await connectClient(pipe.getPipeName(), TOKEN);
+    cleanups.push(() => { client.socket.destroy(); });
+    await waitFor(() => pipe.isFlushed, 3000);
+
+    // Deliberately slow generator so we can type into the socket mid-flight.
+    const slowGenerate: typeof generateSnapshot = async (req) => {
+      await sleep(60);
+      return generateSnapshot(req);
+    };
+    const p = pipe.reflush({ bridge, cols: 80, rows: 24, generate: slowGenerate });
+
+    await sleep(15);
+    client.socket.write('typed-during-resync');
+
+    const result = await p;
+    expect(result.mode).toBe('snapshot');
+
+    await sleep(20);
+    expect(Buffer.concat(inputs).toString()).toContain('typed-during-resync');
+  }, 20000);
+
+  it('degrades to raw replay and ships the ring bytes verbatim on alt-screen', async () => {
+    const ring = new RingBuffer(1024 * 1024);
+    const bridge = new EventEmitter();
+    const pipe = new SessionPipe(uniqueSessionId('raw'), ring, TOKEN);
+    cleanups.push(() => pipe.stop());
+    await pipe.start();
+
+    // Alt-screen forces the snapshot generator to decline.
+    const seed = Buffer.from('\x1b[?1049h\x1b[HALT SCREEN CONTENT\r\nsecond\r\n');
+    ring.write(seed);
+
+    const client = await connectClient(pipe.getPipeName(), TOKEN);
+    cleanups.push(() => { client.socket.destroy(); });
+    await waitFor(() => pipe.isFlushed, 3000);
+
+    const result = await pipe.reflush({ bridge, cols: 80, rows: 24, generate: generateSnapshot });
+    expect(result.mode).toBe('raw');
+    expect(result.fallbackReason).toBe('alt-screen');
+
+    await waitFor(() => {
+      const p = parseWire(client.wire());
+      return !!(p && p.resynced);
+    }, 5000);
+    const parsed = parseWire(client.wire())!;
+    // Raw degrade replays a RIS reset (\x1bc) followed by the exact ring bytes.
+    const expectedReplay2 = Buffer.concat([Buffer.from('\x1bc'), seed]);
+    expect(parsed.replay2.equals(expectedReplay2)).toBe(true);
+  }, 20000);
+
+  it('rejects a concurrent re-flush with RESYNC_BUSY', async () => {
+    const ring = new RingBuffer(1024 * 1024);
+    const bridge = new EventEmitter();
+    const pipe = new SessionPipe(uniqueSessionId('busy'), ring, TOKEN);
+    cleanups.push(() => pipe.stop());
+    await pipe.start();
+
+    ring.write(Buffer.from('content\r\n'));
+    const client = await connectClient(pipe.getPipeName(), TOKEN);
+    cleanups.push(() => { client.socket.destroy(); });
+    await waitFor(() => pipe.isFlushed, 3000);
+
+    const slowGenerate: typeof generateSnapshot = async (req) => {
+      await sleep(60);
+      return generateSnapshot(req);
+    };
+    const first = pipe.reflush({ bridge, cols: 80, rows: 24, generate: slowGenerate });
+
+    // A concurrent re-flush MUST reject rather than corrupt the stream. Note:
+    // the first re-flush sets `flushed = false` synchronously at T0, so the
+    // second call trips the RESYNC_UNAVAILABLE guard (which is checked before
+    // reflushInFlight) — the RESYNC_BUSY guard is therefore never actually
+    // reachable. Either way the concurrency invariant holds: the second call
+    // is refused.
+    await expect(
+      pipe.reflush({ bridge, cols: 80, rows: 24, generate: generateSnapshot }),
+    ).rejects.toThrow(/RESYNC_(BUSY|UNAVAILABLE)/);
+
+    await expect(first).resolves.toBeDefined();
+  }, 20000);
+
+  it('rejects with RESYNC_UNAVAILABLE when no client is attached', async () => {
+    const ring = new RingBuffer(1024 * 1024);
+    const bridge = new EventEmitter();
+    const pipe = new SessionPipe(uniqueSessionId('unavail'), ring, TOKEN);
+    cleanups.push(() => pipe.stop());
+    await pipe.start();
+
+    await expect(
+      pipe.reflush({ bridge, cols: 80, rows: 24, generate: generateSnapshot }),
+    ).rejects.toThrow('RESYNC_UNAVAILABLE');
+  }, 20000);
+
+  it('rejects with RESYNC_DISCONNECTED if the client dies mid-generation, then serves a fresh client', async () => {
+    const ring = new RingBuffer(1024 * 1024);
+    const bridge = new EventEmitter();
+    const pipe = new SessionPipe(uniqueSessionId('disc'), ring, TOKEN);
+    cleanups.push(() => pipe.stop());
+    await pipe.start();
+
+    const seed = Buffer.from('durable content\r\n');
+    ring.write(seed);
+
+    const client = await connectClient(pipe.getPipeName(), TOKEN);
+    await waitFor(() => pipe.isFlushed, 3000);
+
+    const slowGenerate: typeof generateSnapshot = async (req) => {
+      await sleep(80);
+      return generateSnapshot(req);
+    };
+    const p = pipe.reflush({ bridge, cols: 80, rows: 24, generate: slowGenerate });
+
+    await sleep(15);
+    client.socket.destroy();
+
+    await expect(p).rejects.toThrow('RESYNC_DISCONNECTED');
+
+    // The pipe must recover: a brand-new client gets a normal initial flush.
+    await waitFor(() => !pipe.isConnected, 3000);
+    const client2 = await connectClient(pipe.getPipeName(), TOKEN);
+    cleanups.push(() => { client2.socket.destroy(); });
+    await waitFor(() => client2.wire().includes(FLUSH_DONE_MARKER), 3000);
+    const parsed = parseWire(client2.wire());
+    expect(parsed?.replay1.equals(seed)).toBe(true);
+  }, 20000);
+});

--- a/src/daemon/__tests__/SessionPipe.reflush.test.ts
+++ b/src/daemon/__tests__/SessionPipe.reflush.test.ts
@@ -332,4 +332,60 @@ describe('SessionPipe.reflush — gap-free live re-flush', () => {
     const parsed = parseWire(client2.wire());
     expect(parsed?.replay1.equals(seed)).toBe(true);
   }, 20000);
+
+  // Codex P2 regression: a reflush queued behind the global snapshot slot
+  // must NOT announce RESYNC_BEGIN (and suppress live output) until its work
+  // can actually start — under concurrent dirty-pane reveals the queue wait
+  // is N×budget, which would outlive the renderer's resync timeout while the
+  // pane sits suppressed.
+  it('a queued reflush keeps the pane live until its snapshot slot starts', async () => {
+    const ring = new RingBuffer(1024 * 1024);
+    const bridge = new EventEmitter();
+    const pipe = new SessionPipe(uniqueSessionId('slotwait'), ring, TOKEN);
+    cleanups.push(() => pipe.stop());
+    await pipe.start();
+
+    const seed = Buffer.from('seed$ \r\n');
+    ring.write(seed);
+    // Mirror the daemon's attachSession wiring: bridge data → client socket.
+    bridge.on('data', (d: Buffer) => pipe.writeToClient(d));
+    const client = await connectClient(pipe.getPipeName(), TOKEN);
+    cleanups.push(() => { client.socket.destroy(); });
+    await waitFor(() => pipe.isFlushed, 3000);
+
+    // A slot that does not open until we say so — simulates another pane's
+    // snapshot holding the global queue.
+    let releaseSlot!: () => void;
+    const gate = new Promise<void>((r) => { releaseSlot = r; });
+    const enqueue = async <T,>(job: () => Promise<T>): Promise<T> => {
+      await gate;
+      return job();
+    };
+
+    const reflushDone = pipe.reflush({
+      bridge: bridge as never,
+      cols: 80,
+      rows: 24,
+      generate: generateSnapshot,
+      enqueue,
+    });
+    // Belt: the busy window covers the queue wait too.
+    await expect(
+      pipe.reflush({ bridge: bridge as never, cols: 80, rows: 24, generate: generateSnapshot, enqueue }),
+    ).rejects.toThrow(/RESYNC_BUSY/);
+
+    // While queued: no BEGIN on the wire, and live bytes still flow.
+    const liveDuringWait = Buffer.from('typed-while-queued\r\n');
+    ring.write(liveDuringWait);
+    bridge.emit('data', liveDuringWait);
+    await waitFor(() => client.wire().includes(liveDuringWait), 3000);
+    expect(client.wire().indexOf(RESYNC_BEGIN_MARKER)).toBe(-1);
+
+    releaseSlot();
+    const result = await reflushDone;
+    expect(result.mode).toBe('snapshot');
+    await waitFor(() => parseWire(client.wire())?.resynced === true, 3000);
+    const parsed = parseWire(client.wire());
+    expect(parsed?.live1.includes(liveDuringWait)).toBe(true);
+  }, 20000);
 });

--- a/src/daemon/__tests__/ansiStreamScan.test.ts
+++ b/src/daemon/__tests__/ansiStreamScan.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PartialSequenceTracker,
+  MarginTracker,
+  SgrMouseEncodingTracker,
+  incompleteUtf8SuffixLength,
+  MAX_PENDING_TAIL_CHARS,
+} from '../util/ansiStreamScan';
+
+/** Feed a whole string through a fresh tracker in one shot. */
+function trackAll(s: string): PartialSequenceTracker {
+  const t = new PartialSequenceTracker();
+  t.feed(s);
+  return t;
+}
+
+describe('PartialSequenceTracker', () => {
+  it('reports no pending tail after only completed sequences', () => {
+    // CSI SGR, OSC-BEL, OSC-ST, ESC c (RIS) — all self-terminating.
+    const t = trackAll('\x1b[31mhello\x1b[0m\x1b]0;title\x07\x1bP1;2|q\x1b\\\x1bc');
+    expect(t.isPending).toBe(false);
+    expect(t.pendingTail).toBe('');
+  });
+
+  it('captures the exact tail when the stream ends mid-CSI', () => {
+    const t = trackAll('done \x1b[31');
+    expect(t.isPending).toBe(true);
+    expect(t.pendingTail).toBe('\x1b[31');
+  });
+
+  it('captures a mid-OSC tail from the sequence start (no BEL yet)', () => {
+    const t = trackAll('text\x1b]0;partial-title');
+    expect(t.isPending).toBe(true);
+    expect(t.pendingTail).toBe('\x1b]0;partial-title');
+  });
+
+  it('captures a mid-DCS tail from the sequence start (no ST yet)', () => {
+    const t = trackAll('\x1bP1;2|data-so-far');
+    expect(t.isPending).toBe(true);
+    expect(t.pendingTail).toBe('\x1bP1;2|data-so-far');
+  });
+
+  it('resolves a CSI split across three feeds', () => {
+    const t = new PartialSequenceTracker();
+    t.feed('\x1b');
+    expect(t.isPending).toBe(true);
+    t.feed('[3');
+    expect(t.isPending).toBe(true);
+    t.feed('1m');
+    expect(t.isPending).toBe(false);
+    expect(t.pendingTail).toBe('');
+  });
+
+  it('terminates an OSC when ESC is followed by backslash (ST)', () => {
+    const t = trackAll('\x1b]0;title\x1b\\');
+    expect(t.isPending).toBe(false);
+    expect(t.pendingTail).toBe('');
+  });
+
+  it('re-interprets ESC + non-backslash inside a string as a new sequence (stays pending)', () => {
+    // The OSC is aborted by ESC, and ESC [ opens a fresh (unfinished) CSI.
+    const t = trackAll('\x1b]0;abc\x1b[');
+    expect(t.isPending).toBe(true);
+  });
+
+  it('drops the tail (null) once an unterminated OSC exceeds the cap, then recovers on BEL', () => {
+    const huge = '\x1b]' + 'A'.repeat(MAX_PENDING_TAIL_CHARS + 100);
+    const t = trackAll(huge);
+    expect(t.isPending).toBe(true);
+    expect(t.pendingTail).toBeNull();
+
+    // A terminator returns the machine to ground; the tail is empty again.
+    t.feed('\x07');
+    expect(t.isPending).toBe(false);
+    expect(t.pendingTail).toBe('');
+  });
+
+  it('lets CAN abort a CSI sequence', () => {
+    const t = trackAll('\x1b[31\x18');
+    expect(t.isPending).toBe(false);
+    expect(t.pendingTail).toBe('');
+  });
+
+  it('lets SUB abort a string sequence', () => {
+    const t = trackAll('\x1b]0;partial\x1a');
+    expect(t.isPending).toBe(false);
+    expect(t.pendingTail).toBe('');
+  });
+});
+
+describe('MarginTracker', () => {
+  it('activates on DECSTBM with params and clears on a bare reset', () => {
+    const t = new MarginTracker();
+    t.feed('\x1b[5;20r');
+    expect(t.active).toBe(true);
+    t.feed('\x1b[r');
+    expect(t.active).toBe(false);
+  });
+
+  it('treats CSI ; r (no digits) as a full-screen reset', () => {
+    const t = new MarginTracker();
+    t.feed('\x1b[5;20r');
+    expect(t.active).toBe(true);
+    t.feed('\x1b[;r');
+    expect(t.active).toBe(false);
+  });
+
+  it('is reset by RIS (ESC c)', () => {
+    const t = new MarginTracker();
+    t.feed('\x1b[2;10r');
+    expect(t.active).toBe(true);
+    t.feed('\x1bc');
+    expect(t.active).toBe(false);
+  });
+
+  it('is reset by DECSTR (CSI ! p)', () => {
+    const t = new MarginTracker();
+    t.feed('\x1b[2;10r');
+    expect(t.active).toBe(true);
+    t.feed('\x1b[!p');
+    expect(t.active).toBe(false);
+  });
+
+  it('detects a DECSTBM split across a chunk boundary', () => {
+    const t = new MarginTracker();
+    t.feed('\x1b[5;2');
+    expect(t.active).toBe(false); // sequence not complete yet
+    t.feed('0r');
+    expect(t.active).toBe(true);
+  });
+});
+
+describe('SgrMouseEncodingTracker', () => {
+  it('toggles ?1006 (SGR) with h / l', () => {
+    const t = new SgrMouseEncodingTracker();
+    t.feed('\x1b[?1006h');
+    expect(t.sgr).toBe(true);
+    t.feed('\x1b[?1006l');
+    expect(t.sgr).toBe(false);
+  });
+
+  it('tracks ?1006 and ?1016 independently', () => {
+    const t = new SgrMouseEncodingTracker();
+    t.feed('\x1b[?1006h');
+    expect(t.sgr).toBe(true);
+    expect(t.sgrPixels).toBe(false);
+    t.feed('\x1b[?1016h');
+    expect(t.sgrPixels).toBe(true);
+    // Turning SGR off must not touch the pixels flag.
+    t.feed('\x1b[?1006l');
+    expect(t.sgr).toBe(false);
+    expect(t.sgrPixels).toBe(true);
+  });
+
+  it('is reset by RIS', () => {
+    const t = new SgrMouseEncodingTracker();
+    t.feed('\x1b[?1006h\x1b[?1016h');
+    expect(t.sgr).toBe(true);
+    expect(t.sgrPixels).toBe(true);
+    t.feed('\x1bc');
+    expect(t.sgr).toBe(false);
+    expect(t.sgrPixels).toBe(false);
+  });
+
+  it('detects an encoding set split across a chunk boundary', () => {
+    const t = new SgrMouseEncodingTracker();
+    t.feed('\x1b[?100');
+    expect(t.sgr).toBe(false);
+    t.feed('6h');
+    expect(t.sgr).toBe(true);
+  });
+});
+
+describe('incompleteUtf8SuffixLength', () => {
+  it('returns 0 for pure ASCII', () => {
+    expect(incompleteUtf8SuffixLength(Buffer.from('hello'))).toBe(0);
+  });
+
+  it('returns 0 for a complete 3-byte character', () => {
+    expect(incompleteUtf8SuffixLength(Buffer.from('한'))).toBe(0);
+  });
+
+  it('returns the partial length for a truncated 3-byte character', () => {
+    const han = Buffer.from('한'); // 3 bytes
+    expect(incompleteUtf8SuffixLength(han.subarray(0, 1))).toBe(1);
+    expect(incompleteUtf8SuffixLength(han.subarray(0, 2))).toBe(2);
+  });
+
+  it('returns the partial length for a truncated 4-byte emoji', () => {
+    const rocket = Buffer.from('🚀'); // 4 bytes: F0 9F 9A 80
+    expect(rocket.length).toBe(4);
+    expect(incompleteUtf8SuffixLength(rocket.subarray(0, 2))).toBe(2);
+    expect(incompleteUtf8SuffixLength(rocket.subarray(0, 3))).toBe(3);
+    expect(incompleteUtf8SuffixLength(rocket)).toBe(0); // complete
+  });
+
+  it('returns 0 for an invalid lead byte', () => {
+    expect(incompleteUtf8SuffixLength(Buffer.from([0xff]))).toBe(0);
+    // A lone continuation byte with no lead is also not a recoverable prefix.
+    expect(incompleteUtf8SuffixLength(Buffer.from([0x80]))).toBe(0);
+  });
+
+  it('ignores completed multibyte chars that precede ASCII', () => {
+    // '한' (complete) followed by 'A' — nothing at the tail is incomplete.
+    expect(incompleteUtf8SuffixLength(Buffer.from('한A'))).toBe(0);
+  });
+});

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -6,7 +6,7 @@ import { DaemonSessionManager } from './DaemonSessionManager';
 import { PaneSupervisor } from './PaneSupervisor';
 import { DaemonPipeServer } from './DaemonPipeServer';
 import { SessionPipe } from './SessionPipe';
-import { generateSnapshot } from './HeadlessSnapshot';
+import { generateSnapshot, generateSnapshotUnqueued, enqueueSnapshotJob } from './HeadlessSnapshot';
 import { StateWriter, scrubPersistedCredentials } from './StateWriter';
 import { stripCredentialValues } from '../shared/envFilter';
 import { LanLinkInbox } from './lanlink/inbox';
@@ -1294,7 +1294,12 @@ function registerRpcHandlers(
       cols: managed.meta.cols,
       rows: managed.meta.rows,
       scrollback: typeof p.scrollback === 'number' ? p.scrollback : undefined,
-      generate: generateSnapshot,
+      // The reflush owns the global snapshot slot for its whole
+      // suppress→finalize window (Codex P2: announcing RESYNC_BEGIN while
+      // queued would suppress the pane for N×budget under concurrent
+      // reveals), so it takes the slot-acquirer and the unqueued generator.
+      generate: generateSnapshotUnqueued,
+      enqueue: enqueueSnapshotJob,
     });
     log('info', `[resync] session=${p.id} mode=${result.mode}${result.fallbackReason ? ` fallback=${result.fallbackReason}` : ''}`);
     return { ok: true, mode: result.mode, fallbackReason: result.fallbackReason };

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -6,6 +6,7 @@ import { DaemonSessionManager } from './DaemonSessionManager';
 import { PaneSupervisor } from './PaneSupervisor';
 import { DaemonPipeServer } from './DaemonPipeServer';
 import { SessionPipe } from './SessionPipe';
+import { generateSnapshot } from './HeadlessSnapshot';
 import { StateWriter, scrubPersistedCredentials } from './StateWriter';
 import { stripCredentialValues } from '../shared/envFilter';
 import { LanLinkInbox } from './lanlink/inbox';
@@ -1269,6 +1270,76 @@ function registerRpcHandlers(
     const p = params as unknown as DaemonResizeParams;
     sessionManager.resizeSession(p.id, p.cols, p.rows);
     return { ok: true };
+  });
+
+  // daemon.resyncSession (phase 3 PR-B) — re-run the flush sequence on the
+  // live, already-connected session pipe: RESYNC_BEGIN marker → headless
+  // snapshot (or raw-replay degrade) → FLUSH_DONE marker. The socket is never
+  // torn down, so input keeps flowing throughout ("무단절 reflush").
+  pipeServer.onRpc('daemon.resyncSession', async (params) => {
+    const p = params as unknown as { id: string; scrollback?: number };
+    const managed = sessionManager.getSession(p.id);
+    if (!managed) {
+      throw new Error(`SESSION_NOT_FOUND: ${p.id}`);
+    }
+    if (managed.meta.state === 'dead' || managed.meta.state === 'suspended') {
+      throw new Error(`SESSION_DEAD: ${p.id} is ${managed.meta.state} — use daemon.serializeSession`);
+    }
+    const pipe = sessionPipes.get(p.id);
+    if (!pipe || !pipe.isFlushed) {
+      throw new Error(`NO_PIPE: session ${p.id} has no flushed client pipe`);
+    }
+    const result = await pipe.reflush({
+      bridge: managed.bridge,
+      cols: managed.meta.cols,
+      rows: managed.meta.rows,
+      scrollback: typeof p.scrollback === 'number' ? p.scrollback : undefined,
+      generate: generateSnapshot,
+    });
+    log('info', `[resync] session=${p.id} mode=${result.mode}${result.fallbackReason ? ` fallback=${result.fallbackReason}` : ''}`);
+    return { ok: true, mode: result.mode, fallbackReason: result.fallbackReason };
+  });
+
+  // daemon.serializeSession (phase 3 PR-B) — read-only snapshot of a session
+  // that has NO live pipe (dead/suspended), returned over the control RPC so
+  // a dirty reveal can paint the final screen. NEVER clears or replaces the
+  // session (F2: a dead pane's last screen must survive reveal). Payload is
+  // size-capped for the 1 MB control-pipe line limit: an oversized snapshot
+  // retries viewport-only, then reports 'unavailable' (renderer keeps its
+  // current stale screen — status quo, never wrong).
+  pipeServer.onRpc('daemon.serializeSession', async (params) => {
+    const p = params as unknown as { id: string; scrollback?: number };
+    const managed = sessionManager.getSession(p.id);
+    if (!managed) {
+      throw new Error(`SESSION_NOT_FOUND: ${p.id}`);
+    }
+    const MAX_RPC_PAYLOAD_BYTES = 512 * 1024; // base64 ×1.37 + JSON stays < 1 MB
+    const scrollback = Math.min(typeof p.scrollback === 'number' ? p.scrollback : 2000, 10_000);
+    const base = {
+      cols: managed.meta.cols,
+      rows: managed.meta.rows,
+      initial: managed.ringBuffer.readAll(),
+    };
+    let outcome = await generateSnapshot({ ...base, scrollback });
+    if (outcome.ok && outcome.payload.length > MAX_RPC_PAYLOAD_BYTES) {
+      outcome = await generateSnapshot({ ...base, scrollback: 0 });
+    }
+    if (!outcome.ok) {
+      log('info', `[serialize] session=${p.id} unavailable reason=${outcome.reason}`);
+      return { ok: true, mode: 'unavailable', reason: outcome.reason };
+    }
+    if (outcome.payload.length > MAX_RPC_PAYLOAD_BYTES) {
+      log('info', `[serialize] session=${p.id} unavailable reason=too-large bytes=${outcome.payload.length}`);
+      return { ok: true, mode: 'unavailable', reason: 'too-large' };
+    }
+    log('info', `[serialize] session=${p.id} mode=snapshot payload=${outcome.payload.length}`);
+    return {
+      ok: true,
+      mode: 'snapshot',
+      payloadBase64: outcome.payload.toString('base64'),
+      cols: managed.meta.cols,
+      rows: managed.meta.rows,
+    };
   });
 
   // daemon.listSessions

--- a/src/daemon/util/ansiStreamScan.ts
+++ b/src/daemon/util/ansiStreamScan.ts
@@ -1,0 +1,229 @@
+/**
+ * Streaming ANSI scanners for the headless-snapshot path (phase 3 PR-B).
+ *
+ * All three trackers are fed the SAME decoded text chunks that are written to
+ * the headless terminal, in order, and answer questions the public xterm API
+ * cannot at snapshot time:
+ *
+ *  - PartialSequenceTracker — the trailing bytes of the stream that form an
+ *    UNFINISHED escape sequence. xterm's parser holds them internally and
+ *    SerializeAddon drops them, so a resync cut mid-sequence would make the
+ *    next live chunk render the sequence's continuation literally. The tail
+ *    is appended verbatim after the serialized snapshot so the renderer's
+ *    parser ends up holding the same pending state.
+ *
+ *  - MarginTracker — DECSTBM scroll margins are not exposed by the public
+ *    buffer API and are not serialized. Any set-margin still in effect means
+ *    the snapshot would silently lose scroll-region behavior, so the caller
+ *    degrades to raw replay ("slower, never wrong").
+ *
+ *  - SgrMouseEncodingTracker — `terminal.modes.mouseTrackingMode` exposes the
+ *    tracking PROTOCOL but not the report ENCODING (?1006 SGR / ?1016 SGR
+ *    pixels). Restoring the protocol without the encoding would feed the app
+ *    reports in a format it never negotiated.
+ */
+
+const ESCAPE = 0x1b;
+
+const enum ScanState {
+  Ground,
+  Esc,
+  EscIntermediate,
+  Csi,
+  // OSC / DCS / SOS / PM / APC — consumed until BEL or ST (ESC \).
+  String,
+  StringEsc,
+}
+
+/** Longest pending tail we are willing to ship (a giant unterminated OSC is
+ * not worth buffering — the caller falls back to raw replay instead). */
+export const MAX_PENDING_TAIL_CHARS = 4096;
+
+export class PartialSequenceTracker {
+  private state = ScanState.Ground;
+  private tail = '';
+  private overflowed = false;
+
+  feed(chunk: string): void {
+    for (let i = 0; i < chunk.length; i++) {
+      const c = chunk.charCodeAt(i);
+      const next = this.advance(c);
+      if (next === ScanState.Ground) {
+        this.state = ScanState.Ground;
+        this.tail = '';
+        this.overflowed = false;
+        continue;
+      }
+      if (this.state === ScanState.Ground) {
+        // Entering a sequence (next is non-Ground here) — start capturing.
+        this.tail = '';
+        this.overflowed = false;
+      }
+      this.state = next;
+      if (!this.overflowed) {
+        if (this.tail.length >= MAX_PENDING_TAIL_CHARS) {
+          this.overflowed = true;
+          this.tail = '';
+        } else {
+          this.tail += chunk[i];
+        }
+      }
+    }
+  }
+
+  /** True when the stream currently ends inside an escape sequence. */
+  get isPending(): boolean {
+    return this.state !== ScanState.Ground;
+  }
+
+  /**
+   * The unfinished sequence's chars, or null when it exceeded the cap and can
+   * no longer be reproduced (callers must degrade to raw replay in that case).
+   */
+  get pendingTail(): string | null {
+    if (this.state === ScanState.Ground) return '';
+    return this.overflowed ? null : this.tail;
+  }
+
+  /** One state-machine step. Returns the state AFTER consuming `c`. */
+  private advance(c: number): ScanState {
+    switch (this.state) {
+      case ScanState.Ground:
+        return c === ESCAPE ? ScanState.Esc : ScanState.Ground;
+      case ScanState.Esc:
+        if (c === 0x5b /* [ */) return ScanState.Csi;
+        if (
+          c === 0x5d /* ] OSC */ ||
+          c === 0x50 /* P DCS */ ||
+          c === 0x58 /* X SOS */ ||
+          c === 0x5e /* ^ PM */ ||
+          c === 0x5f /* _ APC */
+        ) {
+          return ScanState.String;
+        }
+        if (c >= 0x20 && c <= 0x2f) return ScanState.EscIntermediate;
+        // Final byte (ESC c, ESC =, ...) or a control char aborting the
+        // sequence — either way the parser is back at ground.
+        return ScanState.Ground;
+      case ScanState.EscIntermediate:
+        if (c >= 0x20 && c <= 0x2f) return ScanState.EscIntermediate;
+        if (c === ESCAPE) return ScanState.Esc;
+        return ScanState.Ground; // final byte dispatches (or aborts)
+      case ScanState.Csi:
+        // Params 0x30-0x3f and intermediates 0x20-0x2f continue the sequence.
+        if ((c >= 0x30 && c <= 0x3f) || (c >= 0x20 && c <= 0x2f)) {
+          return ScanState.Csi;
+        }
+        if (c >= 0x40 && c <= 0x7e) return ScanState.Ground; // final byte
+        if (c === ESCAPE) return ScanState.Esc;
+        if (c === 0x18 /* CAN */ || c === 0x1a /* SUB */) return ScanState.Ground;
+        // Embedded C0 controls execute without ending the sequence.
+        return ScanState.Csi;
+      case ScanState.String:
+        if (c === 0x07 /* BEL */) return ScanState.Ground;
+        if (c === ESCAPE) return ScanState.StringEsc;
+        if (c === 0x18 || c === 0x1a) return ScanState.Ground;
+        return ScanState.String;
+      case ScanState.StringEsc:
+        if (c === 0x5c /* \ — ST */) return ScanState.Ground;
+        // xterm aborts the string and dispatches the ESC with this char.
+        this.state = ScanState.Esc;
+        return this.advance(c);
+    }
+  }
+}
+
+/** Chars kept across feeds so a sequence split at a chunk boundary still
+ * matches (longest pattern of interest is ~12 chars). */
+const REGEX_CARRY_CHARS = 16;
+
+// eslint-disable-next-line no-control-regex
+const MARGIN_RE = /\x1b(?:\[([0-9;]*)r|\[!p|c)/g;
+
+export class MarginTracker {
+  private carry = '';
+  private _active = false;
+
+  feed(chunk: string): void {
+    const text = this.carry + chunk;
+    MARGIN_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = MARGIN_RE.exec(text)) !== null) {
+      if (m[1] === undefined) {
+        // RIS (ESC c) or DECSTR (CSI ! p) reset margins to full screen.
+        this._active = false;
+      } else {
+        // DECSTBM: params containing a digit narrow the region; a bare
+        // `CSI r` (or `CSI ; r`) resets to full screen. We cannot compare
+        // against the actual row count here, so any explicit params count
+        // as active — conservative (worst case: raw-replay fallback).
+        this._active = /\d/.test(m[1]);
+      }
+    }
+    this.carry = text.slice(-REGEX_CARRY_CHARS);
+  }
+
+  get active(): boolean {
+    return this._active;
+  }
+}
+
+// eslint-disable-next-line no-control-regex
+const SGR_MOUSE_RE = /\x1b(?:\[\?(1006|1016)([hl])|c)/g;
+
+export class SgrMouseEncodingTracker {
+  private carry = '';
+  private _sgr = false;
+  private _sgrPixels = false;
+
+  feed(chunk: string): void {
+    const text = this.carry + chunk;
+    SGR_MOUSE_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = SGR_MOUSE_RE.exec(text)) !== null) {
+      if (m[1] === undefined) {
+        // RIS resets both encodings.
+        this._sgr = false;
+        this._sgrPixels = false;
+      } else if (m[1] === '1006') {
+        this._sgr = m[2] === 'h';
+      } else {
+        this._sgrPixels = m[2] === 'h';
+      }
+    }
+    this.carry = text.slice(-REGEX_CARRY_CHARS);
+  }
+
+  get sgr(): boolean {
+    return this._sgr;
+  }
+
+  get sgrPixels(): boolean {
+    return this._sgrPixels;
+  }
+}
+
+/**
+ * Number of bytes at the END of `buf` that form an incomplete UTF-8 sequence.
+ * The headless feed decodes per-chunk; a multi-byte char split across chunks
+ * must be carried to the next chunk (or, at finalize, appended raw after the
+ * snapshot so the byte stream stays contiguous for the renderer).
+ */
+export function incompleteUtf8SuffixLength(buf: Buffer): number {
+  const len = buf.length;
+  // A UTF-8 sequence is at most 4 bytes; scan back at most 3 (a lead byte 4
+  // bytes back would have all its continuations already).
+  for (let back = 1; back <= 3 && back <= len; back++) {
+    const b = buf[len - back];
+    if ((b & 0b1100_0000) === 0b1000_0000) continue; // continuation — keep looking
+    // Found a lead byte `back` bytes from the end.
+    let expected = 0;
+    if ((b & 0b1000_0000) === 0) expected = 1;
+    else if ((b & 0b1110_0000) === 0b1100_0000) expected = 2;
+    else if ((b & 0b1111_0000) === 0b1110_0000) expected = 3;
+    else if ((b & 0b1111_1000) === 0b1111_0000) expected = 4;
+    else return 0; // invalid lead — let the decoder produce U+FFFD as usual
+    return expected > back ? back : 0;
+  }
+  return 0;
+}

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -13,8 +13,8 @@ import type {
   LanLinkSendArgs,
   LanLinkPeersListResult,
 } from '../shared/lanlink';
-import { FLUSH_DONE_MARKER } from '../daemon/SessionPipe';
 import { stripReplayQuerySequences } from '../shared/replayQuerySanitizer';
+import { SessionPipeStreamScanner } from './daemon/sessionPipeStreamScanner';
 import { DAEMON_RPC_TIMEOUT_MS } from '../shared/timeouts';
 import {
   dataSuffix,
@@ -47,6 +47,10 @@ interface PendingRequest {
 export class DaemonClient extends EventEmitter {
   private controlPipe: net.Socket | null = null;
   private sessionPipes: Map<string, net.Socket> = new Map();
+  // Per-session stream state machine (marker scanning + flush accounting).
+  // Keyed by sessionId, lifecycle-bound to the socket in sessionPipes: created
+  // in setupSessionPipe, dropped on socket close/error/disconnect.
+  private sessionScanners: Map<string, SessionPipeStreamScanner> = new Map();
   private connected: boolean = false;
   private requestId: number = 0;
   private pendingRequests: Map<string, PendingRequest> = new Map();
@@ -151,6 +155,7 @@ export class DaemonClient extends EventEmitter {
       try { socket.destroy(); } catch { /* ignore */ }
     }
     this.sessionPipes.clear();
+    this.sessionScanners.clear();
 
     // Reject pending requests so in-flight RPC promises settle instead
     // of dangling. The async `disconnect()` already does this; the sync
@@ -265,6 +270,7 @@ export class DaemonClient extends EventEmitter {
       socket.destroy();
       this.sessionPipes.delete(sessionId);
     }
+    this.sessionScanners.delete(sessionId);
   }
 
   /**
@@ -661,88 +667,70 @@ export class DaemonClient extends EventEmitter {
   }
 
   private setupSessionPipe(sessionId: string, socket: net.Socket): void {
-    let flushed = false;
-    let pendingChunks: Buffer[] = [];
-    let pendingBytes = 0;
-    const MAX_PENDING_BYTES = 10 * 1024 * 1024; // 10 MB safety cap
+    // The marker scanning / flush accounting lives in a pure state machine so
+    // it can be unit-tested in isolation (see sessionPipeStreamScanner.ts). The
+    // scanner returns ordered events; this closure only fans them out onto the
+    // EventBus, preserving the original emit signatures and ordering.
+    const scanner = new SessionPipeStreamScanner({
+      stripReplay: stripReplayQuerySequences,
+    });
+    this.sessionScanners.set(sessionId, scanner);
+
+    const drain = (events: ReturnType<SessionPipeStreamScanner['feed']>) => {
+      for (const ev of events) {
+        if (ev.type === 'data') {
+          this.emit('session:data', { sessionId, data: ev.data });
+        } else {
+          this.emit('session:flushComplete', { sessionId, recoveredBytes: ev.recoveredBytes });
+        }
+      }
+    };
 
     socket.on('data', (chunk: Buffer) => {
-      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-
-      if (!flushed) {
-        pendingChunks.push(buf);
-        pendingBytes += buf.length;
-
-        // Prevent unbounded accumulation if flush marker never arrives
-        if (pendingBytes > MAX_PENDING_BYTES) {
-          flushed = true;
-          pendingChunks = [];
-          pendingBytes = 0;
-          return;
-        }
-
-        // Accumulate until we see the FLUSH_DONE_MARKER
-        const combined = Buffer.concat(pendingChunks);
-        const markerIndex = combined.indexOf(FLUSH_DONE_MARKER);
-
-        if (markerIndex !== -1) {
-          flushed = true;
-          // markerIndex is exactly the count of replayed scrollback bytes:
-          // 0 when the daemon's ringBuffer was empty (mismatch case from
-          // the scrollback-restore-sync design — recovery cap dropped this
-          // session, or it was created fresh by reconcile fallback). The
-          // renderer uses this to decide whether to wipe its .txt cache.
-          // NOTE: pre-strip length on purpose — recoveredBytes answers "did
-          // the daemon have authoritative scrollback", which the renderer's
-          // reset-or-keep decision depends on, not the sanitized byte count.
-          const recoveredBytes = markerIndex;
-
-          // Emit data before marker (ring buffer replay). Queries stored in
-          // the ring (DSR/CPR, DA, DECRQM, ...) are stripped first: xterm.js
-          // re-executes replayed bytes, so a stored query would fire a live
-          // auto-reply into the fresh shell's stdin — the CPR feedback storm
-          // of 2026-07-04 (see shared/replayQuerySanitizer.ts). Live bytes
-          // after the marker are never sanitized.
-          if (markerIndex > 0) {
-            const replay = stripReplayQuerySequences(
-              combined.subarray(0, markerIndex),
-            );
-            if (replay.length > 0) {
-              this.emit('session:data', { sessionId, data: replay });
-            }
-          }
-
-          // Fire flush-complete BEFORE the post-marker data so the
-          // renderer's reset-or-keep decision lands before any live PTY
-          // bytes start composing on the buffer.
-          this.emit('session:flushComplete', { sessionId, recoveredBytes });
-
-          // Emit data after marker (if any real-time data arrived in same chunk)
-          const afterMarker = combined.subarray(markerIndex + FLUSH_DONE_MARKER.length);
-          if (afterMarker.length > 0) {
-            this.emit('session:data', { sessionId, data: afterMarker });
-          }
-
-          pendingChunks = [];
-          pendingBytes = 0;
-        }
-      } else {
-        // Real-time mode — emit directly
-        this.emit('session:data', { sessionId, data: buf });
-      }
+      drain(scanner.feed(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
     });
 
     socket.on('close', () => {
-      pendingChunks = [];
-      pendingBytes = 0;
+      this.sessionScanners.delete(sessionId);
       this.sessionPipes.delete(sessionId);
     });
 
     socket.on('error', () => {
-      pendingChunks = [];
-      pendingBytes = 0;
+      this.sessionScanners.delete(sessionId);
       this.sessionPipes.delete(sessionId);
     });
+  }
+
+  /**
+   * Arm the session's live stream scanner to watch for the in-band
+   * RESYNC_BEGIN_MARKER (phase 3 PR-B). Returns true only when a live scanner
+   * exists for the session; a missing or still-accumulating scanner returns
+   * false so the caller can degrade (the session pipe is not ready for a live
+   * re-flush). MUST be paired with a matching disarm on the failure path so a
+   * scanner left armed does not sit watching a normal live stream for a marker
+   * that will never come.
+   */
+  armSessionResync(sessionId: string): boolean {
+    const scanner = this.sessionScanners.get(sessionId);
+    if (!scanner || scanner.mode !== 'live') return false;
+    scanner.armResync();
+    return true;
+  }
+
+  /**
+   * Disarm the session's resync scanner and flush any bytes it was holding back
+   * as a possible marker prefix (those are real live output). Safe to call when
+   * no scanner exists or it was never armed.
+   */
+  disarmSessionResync(sessionId: string): void {
+    const scanner = this.sessionScanners.get(sessionId);
+    if (!scanner) return;
+    const events = scanner.disarmResync();
+    for (const ev of events) {
+      if (ev.type === 'data') {
+        this.emit('session:data', { sessionId, data: ev.data });
+      }
+    }
   }
 }
 

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -690,15 +690,18 @@ export class DaemonClient extends EventEmitter {
       drain(scanner.feed(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
     });
 
-    socket.on('close', () => {
-      this.sessionScanners.delete(sessionId);
-      this.sessionPipes.delete(sessionId);
-    });
-
-    socket.on('error', () => {
-      this.sessionScanners.delete(sessionId);
-      this.sessionPipes.delete(sessionId);
-    });
+    // Identity-guarded teardown (CodeRabbit): a forceFresh reconnect installs
+    // a replacement socket+scanner under the same sessionId BEFORE the old
+    // socket's async close/error callbacks run — an unconditional delete here
+    // would evict the LIVE replacement and leave the session's stream dead.
+    const teardownIfCurrent = () => {
+      if (this.sessionPipes.get(sessionId) === socket) {
+        this.sessionScanners.delete(sessionId);
+        this.sessionPipes.delete(sessionId);
+      }
+    };
+    socket.on('close', teardownIfCurrent);
+    socket.on('error', teardownIfCurrent);
   }
 
   /**

--- a/src/main/daemon/__tests__/sessionPipeStreamScanner.test.ts
+++ b/src/main/daemon/__tests__/sessionPipeStreamScanner.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SessionPipeStreamScanner,
+  type ScanEvent,
+} from '../sessionPipeStreamScanner';
+import { FLUSH_DONE_MARKER, RESYNC_BEGIN_MARKER } from '../../../daemon/SessionPipe';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const b = (s: string): Buffer => Buffer.from(s, 'binary');
+const identityStrip = (buf: Buffer): Buffer => buf;
+
+interface Collected {
+  /** All 'data' event payloads concatenated, in order. */
+  data: Buffer;
+  /** recoveredBytes of each flushComplete, in order. */
+  flushes: number[];
+  /** Event type sequence, e.g. ['data', 'flushComplete', 'data']. */
+  order: Array<ScanEvent['type']>;
+}
+
+function collect(events: ScanEvent[]): Collected {
+  const parts: Buffer[] = [];
+  const flushes: number[] = [];
+  const order: Array<ScanEvent['type']> = [];
+  for (const ev of events) {
+    order.push(ev.type);
+    if (ev.type === 'data') parts.push(ev.data);
+    else flushes.push(ev.recoveredBytes);
+  }
+  return { data: Buffer.concat(parts), flushes, order };
+}
+
+function newScanner(opts?: { maxPendingBytes?: number; stripReplay?: (b: Buffer) => Buffer }) {
+  return new SessionPipeStreamScanner({
+    stripReplay: opts?.stripReplay ?? identityStrip,
+    maxPendingBytes: opts?.maxPendingBytes,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Initial flush — accumulate until FLUSH_DONE_MARKER
+// ---------------------------------------------------------------------------
+
+describe('initial flush', () => {
+  it('single chunk [replay][DONE][live] — emit order and recoveredBytes', () => {
+    const s = newScanner();
+    const replay = b('scrollback-bytes');
+    const live = b('live-tail');
+    const events = s.feed(Buffer.concat([replay, FLUSH_DONE_MARKER, live]));
+    const c = collect(events);
+
+    expect(c.order).toEqual(['data', 'flushComplete', 'data']);
+    expect(c.flushes).toEqual([replay.length]);
+    expect(collect([events[0]]).data.equals(replay)).toBe(true);
+    expect(collect([events[2]]).data.equals(live)).toBe(true);
+    expect(s.mode).toBe('live');
+  });
+
+  it('no live tail in the flush chunk — only replay + flushComplete', () => {
+    const s = newScanner();
+    const replay = b('abc');
+    const c = collect(s.feed(Buffer.concat([replay, FLUSH_DONE_MARKER])));
+    expect(c.order).toEqual(['data', 'flushComplete']);
+    expect(c.flushes).toEqual([3]);
+    expect(c.data.equals(replay)).toBe(true);
+  });
+
+  it('empty ring (recoveredBytes=0) — flushComplete first, no pre-marker data', () => {
+    const s = newScanner();
+    const live = b('hello');
+    const events = s.feed(Buffer.concat([FLUSH_DONE_MARKER, live]));
+    const c = collect(events);
+    expect(c.order).toEqual(['flushComplete', 'data']);
+    expect(c.flushes).toEqual([0]);
+    expect(c.data.equals(live)).toBe(true);
+  });
+
+  it('replay across several chunks then DONE — accumulates, preserves total bytes', () => {
+    const s = newScanner();
+    expect(s.feed(b('part1-'))).toEqual([]);
+    expect(s.feed(b('part2-'))).toEqual([]);
+    const c = collect(s.feed(Buffer.concat([b('part3'), FLUSH_DONE_MARKER])));
+    expect(c.order).toEqual(['data', 'flushComplete']);
+    expect(c.data.equals(b('part1-part2-part3'))).toBe(true);
+    expect(c.flushes).toEqual([b('part1-part2-part3').length]);
+  });
+
+  it('DONE marker split across a chunk boundary — found once the buffer joins', () => {
+    const s = newScanner();
+    const replay = b('xy');
+    const half = Math.floor(FLUSH_DONE_MARKER.length / 2);
+    // chunk 1: replay + first half of the marker — no marker yet
+    expect(s.feed(Buffer.concat([replay, FLUSH_DONE_MARKER.subarray(0, half)]))).toEqual([]);
+    // chunk 2: rest of the marker + a live byte
+    const c = collect(s.feed(Buffer.concat([FLUSH_DONE_MARKER.subarray(half), b('L')])));
+    expect(c.order).toEqual(['data', 'flushComplete', 'data']);
+    expect(c.flushes).toEqual([replay.length]); // pre-strip length across the boundary
+    expect(c.data.equals(b('xyL'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripReplay is applied to the pre-marker replay only
+// ---------------------------------------------------------------------------
+
+describe('stripReplay', () => {
+  it('sanitizes the replay while recoveredBytes stays the PRE-strip length', () => {
+    // strip removes the literal token "<Q>" (stand-in for a stored CPR query)
+    const strip = (buf: Buffer): Buffer => b(buf.toString('binary').split('<Q>').join(''));
+    const s = newScanner({ stripReplay: strip });
+    const replay = b('aa<Q>bb');
+    const live = b('LIVE');
+    const events = s.feed(Buffer.concat([replay, FLUSH_DONE_MARKER, live]));
+    const c = collect(events);
+
+    // data before marker is the STRIPPED replay
+    expect(collect([events[0]]).data.equals(b('aabb'))).toBe(true);
+    // recoveredBytes is the ORIGINAL (pre-strip) replay length
+    expect(c.flushes).toEqual([replay.length]);
+    // live tail is never sanitized
+    expect(collect([events[2]]).data.equals(live)).toBe(true);
+  });
+
+  it('replay that strips to empty emits no data event, still flushComplete', () => {
+    const strip = (): Buffer => Buffer.alloc(0);
+    const s = newScanner({ stripReplay: strip });
+    const replay = b('\x1b[6n'); // pure query, sanitized away
+    const c = collect(s.feed(Buffer.concat([replay, FLUSH_DONE_MARKER])));
+    expect(c.order).toEqual(['flushComplete']);
+    expect(c.flushes).toEqual([replay.length]); // still reports authoritative scrollback
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Live, unarmed — zero-scan passthrough
+// ---------------------------------------------------------------------------
+
+describe('live unarmed passthrough', () => {
+  function toLive(s: SessionPipeStreamScanner) {
+    s.feed(FLUSH_DONE_MARKER); // fast-forward to live mode
+  }
+
+  it('passes chunks through verbatim', () => {
+    const s = newScanner();
+    toLive(s);
+    const c = collect(s.feed(b('echo output')));
+    expect(c.order).toEqual(['data']);
+    expect(c.data.equals(b('echo output'))).toBe(true);
+  });
+
+  it('marker-lookalike bytes are NOT intercepted when unarmed', () => {
+    const s = newScanner();
+    toLive(s);
+    // A byte run that looks like the RESYNC marker but arrives while disarmed.
+    const c = collect(s.feed(RESYNC_BEGIN_MARKER));
+    expect(c.order).toEqual(['data']);
+    expect(c.data.equals(RESYNC_BEGIN_MARKER)).toBe(true);
+    expect(s.mode).toBe('live');
+  });
+
+  it('empty chunk yields no events', () => {
+    const s = newScanner();
+    toLive(s);
+    expect(s.feed(Buffer.alloc(0))).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Armed — cross-chunk RESYNC_BEGIN detection + re-flush cycle
+// ---------------------------------------------------------------------------
+
+describe('armed resync scan', () => {
+  function armedLive(opts?: Parameters<typeof newScanner>[0]) {
+    const s = newScanner(opts);
+    s.feed(FLUSH_DONE_MARKER); // → live
+    s.armResync();
+    return s;
+  }
+
+  it('BEGIN in a single chunk — pre-marker data emitted, then accumulates residual', () => {
+    const s = armedLive();
+    const pre = b('tail-of-live');
+    // residual after BEGIN is the start of the re-flush replay (no DONE yet)
+    const events = s.feed(Buffer.concat([pre, RESYNC_BEGIN_MARKER, b('snap-start')]));
+    const c = collect(events);
+    expect(c.order).toEqual(['data']); // only the pre-marker live bytes
+    expect(c.data.equals(pre)).toBe(true);
+    expect(s.mode).toBe('accumulating');
+  });
+
+  it('BEGIN split across two chunks (tail is a strict prefix)', () => {
+    const s = armedLive();
+    const cut = 8;
+    // chunk 1: live bytes + first part of BEGIN → live bytes emitted, prefix held
+    const c1 = collect(s.feed(Buffer.concat([b('LIVE'), RESYNC_BEGIN_MARKER.subarray(0, cut)])));
+    expect(c1.data.equals(b('LIVE'))).toBe(true);
+    expect(s.mode).toBe('live'); // not yet switched — marker incomplete
+    // chunk 2: rest of BEGIN + residual → switch to accumulating, no data
+    const c2 = collect(s.feed(Buffer.concat([RESYNC_BEGIN_MARKER.subarray(cut), b('resid')])));
+    expect(c2.order).toEqual([]);
+    expect(s.mode).toBe('accumulating');
+  });
+
+  it('BEGIN split across three chunks', () => {
+    const s = armedLive();
+    const a = 5, bcut = 13;
+    collect(s.feed(RESYNC_BEGIN_MARKER.subarray(0, a)));
+    collect(s.feed(RESYNC_BEGIN_MARKER.subarray(a, bcut)));
+    expect(s.mode).toBe('live');
+    const c = collect(s.feed(RESYNC_BEGIN_MARKER.subarray(bcut)));
+    expect(c.order).toEqual([]);
+    expect(s.mode).toBe('accumulating');
+  });
+
+  it('tail looked like a marker prefix but was not — held bytes released, total preserved', () => {
+    const s = armedLive();
+    // chunk 1 ends with a genuine BEGIN prefix
+    const prefix = RESYNC_BEGIN_MARKER.subarray(0, 9);
+    const c1 = collect(s.feed(Buffer.concat([b('AAA'), prefix])));
+    expect(c1.data.equals(b('AAA'))).toBe(true); // prefix held back
+    // chunk 2 breaks the marker (does not continue it)
+    const c2 = collect(s.feed(b('X-more')));
+    // the held prefix + the new bytes are all released as live data
+    const total = Buffer.concat([c1.data, c2.data]);
+    expect(total.equals(Buffer.concat([b('AAA'), prefix, b('X-more')]))).toBe(true);
+    expect(s.mode).toBe('live');
+  });
+
+  it('full re-flush round trip: BEGIN → snapshot → DONE → live tail', () => {
+    const s = armedLive();
+    const preLive = b('before-resync');
+    const snapshot = b('rendered-snapshot-payload');
+    const postLive = b('after-reflush');
+
+    // Everything in one stream write (the daemon writes these back-to-back).
+    const events = s.feed(
+      Buffer.concat([preLive, RESYNC_BEGIN_MARKER, snapshot, FLUSH_DONE_MARKER, postLive]),
+    );
+    const c = collect(events);
+
+    expect(c.order).toEqual(['data', 'data', 'flushComplete', 'data']);
+    // pre-marker live, then the snapshot replay, then the live tail
+    expect(collect([events[0]]).data.equals(preLive)).toBe(true);
+    expect(collect([events[1]]).data.equals(snapshot)).toBe(true);
+    expect(c.flushes).toEqual([snapshot.length]); // recoveredBytes = snapshot length
+    expect(collect([events[3]]).data.equals(postLive)).toBe(true);
+    expect(s.mode).toBe('live');
+
+    // Back to steady state — a subsequent chunk is a plain passthrough.
+    const after = collect(s.feed(b('normal')));
+    expect(after.order).toEqual(['data']);
+    expect(after.data.equals(b('normal'))).toBe(true);
+  });
+
+  it('re-flush spread across multiple chunks', () => {
+    const s = armedLive();
+    // BEGIN alone
+    expect(collect(s.feed(RESYNC_BEGIN_MARKER)).order).toEqual([]);
+    expect(s.mode).toBe('accumulating');
+    // snapshot in pieces
+    expect(s.feed(b('snap-'))).toEqual([]);
+    expect(s.feed(b('more'))).toEqual([]);
+    // DONE + tail
+    const c = collect(s.feed(Buffer.concat([FLUSH_DONE_MARKER, b('T')])));
+    expect(c.order).toEqual(['data', 'flushComplete', 'data']);
+    expect(c.flushes).toEqual([b('snap-more').length]);
+    expect(c.data.equals(b('snap-moreT'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// disarm
+// ---------------------------------------------------------------------------
+
+describe('disarmResync', () => {
+  it('releases a held carry as a data event', () => {
+    const s = newScanner();
+    s.feed(FLUSH_DONE_MARKER);
+    s.armResync();
+    const prefix = RESYNC_BEGIN_MARKER.subarray(0, 7);
+    const c1 = collect(s.feed(Buffer.concat([b('D'), prefix])));
+    expect(c1.data.equals(b('D'))).toBe(true); // prefix withheld
+
+    const released = collect(s.disarmResync());
+    expect(released.order).toEqual(['data']);
+    expect(released.data.equals(prefix)).toBe(true);
+  });
+
+  it('no carry → no events', () => {
+    const s = newScanner();
+    s.feed(FLUSH_DONE_MARKER);
+    s.armResync();
+    expect(s.disarmResync()).toEqual([]);
+  });
+
+  it('after disarm, marker-lookalikes pass straight through again', () => {
+    const s = newScanner();
+    s.feed(FLUSH_DONE_MARKER);
+    s.armResync();
+    s.disarmResync();
+    const c = collect(s.feed(RESYNC_BEGIN_MARKER));
+    expect(c.order).toEqual(['data']);
+    expect(c.data.equals(RESYNC_BEGIN_MARKER)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MAX_PENDING overflow — must mirror the original DaemonClient closure exactly
+// ---------------------------------------------------------------------------
+
+describe('max pending overflow', () => {
+  it('drops the buffer and flips to live, emitting nothing (initial flush)', () => {
+    const s = newScanner({ maxPendingBytes: 10 });
+    // 6 bytes, no marker — still accumulating, no events
+    expect(s.feed(b('123456'))).toEqual([]);
+    expect(s.mode).toBe('accumulating');
+    // +6 bytes → 12 > 10 cap → overflow: drop everything, go live, no events
+    expect(s.feed(b('789012'))).toEqual([]);
+    expect(s.mode).toBe('live');
+    // subsequent bytes now pass straight through (buffered bytes were dropped)
+    const c = collect(s.feed(b('after')));
+    expect(c.order).toEqual(['data']);
+    expect(c.data.equals(b('after'))).toBe(true);
+  });
+
+  it('a marker arriving in the SAME overflowing chunk is still dropped (cap wins)', () => {
+    const s = newScanner({ maxPendingBytes: 5 });
+    // one chunk that exceeds the cap AND contains the marker — original behavior
+    // is overflow-wins: nothing emitted, straight to live.
+    const c = collect(s.feed(Buffer.concat([b('bigreplay'), FLUSH_DONE_MARKER])));
+    expect(c.order).toEqual([]);
+    expect(s.mode).toBe('live');
+  });
+});

--- a/src/main/daemon/sessionPipeStreamScanner.ts
+++ b/src/main/daemon/sessionPipeStreamScanner.ts
@@ -1,0 +1,217 @@
+import { FLUSH_DONE_MARKER, RESYNC_BEGIN_MARKER } from '../../daemon/SessionPipe';
+
+/**
+ * Stream events produced while scanning a session pipe's byte stream.
+ *
+ * `data`          — raw PTY bytes to forward to the renderer, in order.
+ * `flushComplete` — the ring-buffer flush (or a live re-flush) finished;
+ *                   `recoveredBytes` is the PRE-STRIP length of the replayed
+ *                   scrollback that preceded the FLUSH_DONE_MARKER (0 means the
+ *                   daemon had no authoritative scrollback — see the note in
+ *                   the flush-detection block below).
+ */
+export type ScanEvent =
+  | { type: 'data'; data: Buffer }
+  | { type: 'flushComplete'; recoveredBytes: number };
+
+const DEFAULT_MAX_PENDING_BYTES = 10 * 1024 * 1024; // 10 MB safety cap
+const EMPTY = Buffer.alloc(0);
+
+/**
+ * Pure state machine for a single session pipe's inbound byte stream (phase 3
+ * PR-B). Extracted verbatim from DaemonClient.setupSessionPipe so the exact
+ * byte accounting is testable in isolation, then extended with the live
+ * re-flush protocol.
+ *
+ * Two modes:
+ *   - accumulating — buffer bytes until FLUSH_DONE_MARKER, then emit the
+ *     pre-marker replay (query-sanitized), a flushComplete, and any post-marker
+ *     live tail. This is the initial ring-buffer flush, and — after a
+ *     RESYNC_BEGIN — the re-flush.
+ *   - live — steady state. When NOT armed, chunks pass straight through with
+ *     zero scanning or copying (the common case; overhead must stay at 0). When
+ *     armed for a resync, the stream is scanned for RESYNC_BEGIN_MARKER, which
+ *     the daemon writes in-band right before it re-runs the flush sequence on
+ *     the same socket. Carrying the transition in the stream is what makes the
+ *     protocol race-free (no RPC-vs-stream ordering can misclassify bytes).
+ */
+export class SessionPipeStreamScanner {
+  private _mode: 'accumulating' | 'live' = 'accumulating';
+  private armed = false;
+  private pendingChunks: Buffer[] = [];
+  private pendingBytes = 0;
+  // live + armed only: the longest stream tail that is a strict prefix of
+  // RESYNC_BEGIN_MARKER, held back until the next chunk can confirm or deny it.
+  private carry: Buffer = EMPTY;
+  private readonly maxPendingBytes: number;
+  private readonly stripReplay: (b: Buffer) => Buffer;
+
+  constructor(opts: { maxPendingBytes?: number; stripReplay: (b: Buffer) => Buffer }) {
+    this.maxPendingBytes = opts.maxPendingBytes ?? DEFAULT_MAX_PENDING_BYTES;
+    this.stripReplay = opts.stripReplay;
+  }
+
+  get mode(): 'accumulating' | 'live' {
+    return this._mode;
+  }
+
+  /** Start watching a live stream for the in-band RESYNC_BEGIN_MARKER. */
+  armResync(): void {
+    this.armed = true;
+  }
+
+  /**
+   * Stop watching for RESYNC_BEGIN. Any bytes held back as a possible marker
+   * prefix are real live output the daemon never followed with a marker, so
+   * they are released as a final `data` event. Returns events (not void) so the
+   * carry release is routed through the same ordered emit path as feed().
+   */
+  disarmResync(): ScanEvent[] {
+    this.armed = false;
+    if (this.carry.length > 0) {
+      const held = this.carry;
+      this.carry = EMPTY;
+      return [{ type: 'data', data: held }];
+    }
+    return [];
+  }
+
+  /** Feed one inbound chunk; returns the resulting events in stream order. */
+  feed(chunk: Buffer): ScanEvent[] {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+
+    if (this._mode === 'accumulating') {
+      return this.accumulate(buf);
+    }
+
+    if (!this.armed) {
+      // Steady state — no scan, no copy. Identical to the original live path.
+      return buf.length > 0 ? [{ type: 'data', data: buf }] : [];
+    }
+
+    return this.scanArmed(buf);
+  }
+
+  /**
+   * Buffer until FLUSH_DONE_MARKER, then emit replay → flushComplete → live
+   * tail. Byte-for-byte identical to the original setupSessionPipe closure;
+   * also reused for the post-RESYNC re-flush.
+   */
+  private accumulate(buf: Buffer): ScanEvent[] {
+    this.pendingChunks.push(buf);
+    this.pendingBytes += buf.length;
+
+    // Prevent unbounded accumulation if the flush marker never arrives. Matches
+    // the original: drop everything buffered, flip to live, emit nothing.
+    if (this.pendingBytes > this.maxPendingBytes) {
+      this._mode = 'live';
+      this.armed = false;
+      this.pendingChunks = [];
+      this.pendingBytes = 0;
+      return [];
+    }
+
+    const combined = Buffer.concat(this.pendingChunks);
+    const markerIndex = combined.indexOf(FLUSH_DONE_MARKER);
+    if (markerIndex === -1) return [];
+
+    this._mode = 'live';
+    this.pendingChunks = [];
+    this.pendingBytes = 0;
+
+    const events: ScanEvent[] = [];
+
+    // markerIndex is exactly the count of replayed scrollback bytes: 0 when the
+    // daemon's ringBuffer was empty (mismatch case — recovery cap dropped this
+    // session, or it was created fresh by reconcile fallback). The renderer
+    // uses this to decide whether to wipe its .txt cache.
+    // NOTE: pre-strip length on purpose — recoveredBytes answers "did the daemon
+    // have authoritative scrollback", which the renderer's reset-or-keep
+    // decision depends on, not the sanitized byte count.
+    const recoveredBytes = markerIndex;
+
+    // Emit data before marker (ring buffer replay). Queries stored in the ring
+    // (DSR/CPR, DA, DECRQM, ...) are stripped first: xterm.js re-executes
+    // replayed bytes, so a stored query would fire a live auto-reply into the
+    // fresh shell's stdin — the CPR feedback storm of 2026-07-04 (see
+    // shared/replayQuerySanitizer.ts). Live bytes after the marker are never
+    // sanitized.
+    if (markerIndex > 0) {
+      const replay = this.stripReplay(combined.subarray(0, markerIndex));
+      if (replay.length > 0) {
+        events.push({ type: 'data', data: replay });
+      }
+    }
+
+    // Fire flush-complete BEFORE the post-marker data so the renderer's
+    // reset-or-keep decision lands before any live PTY bytes start composing on
+    // the buffer.
+    events.push({ type: 'flushComplete', recoveredBytes });
+
+    // Emit data after marker (if any real-time data arrived in the same chunk).
+    // After both the initial flush and a re-flush the scanner is disarmed, so
+    // this tail is plain live output — passed straight through like the original.
+    const afterMarker = combined.subarray(markerIndex + FLUSH_DONE_MARKER.length);
+    if (afterMarker.length > 0) {
+      events.push({ type: 'data', data: afterMarker });
+    }
+
+    return events;
+  }
+
+  /**
+   * live + armed: scan for RESYNC_BEGIN_MARKER across chunk boundaries. On a
+   * hit, flush the pre-marker bytes, drop the marker, disarm, and hand the
+   * post-marker residual to the accumulator (the re-flush replay). On a miss,
+   * hold back only the tail that could still complete into the marker and emit
+   * the rest immediately (echo latency must not regress).
+   */
+  private scanArmed(buf: Buffer): ScanEvent[] {
+    const combined = this.carry.length > 0 ? Buffer.concat([this.carry, buf]) : buf;
+    this.carry = EMPTY;
+
+    const markerIndex = combined.indexOf(RESYNC_BEGIN_MARKER);
+    if (markerIndex !== -1) {
+      const events: ScanEvent[] = [];
+      if (markerIndex > 0) {
+        events.push({ type: 'data', data: combined.subarray(0, markerIndex) });
+      }
+      // Consume the marker and re-enter accumulation for the re-flush. Auto
+      // disarm: the resync episode is now owned by the FLUSH_DONE cycle.
+      this.armed = false;
+      this._mode = 'accumulating';
+      const residual = combined.subarray(markerIndex + RESYNC_BEGIN_MARKER.length);
+      if (residual.length > 0) {
+        events.push(...this.accumulate(residual));
+      }
+      return events;
+    }
+
+    // No full marker in this buffer. Only a tail that is a strict prefix of the
+    // marker can still complete on the next chunk; everything before it is
+    // definitely live data.
+    const hold = this.matchingPrefixLen(combined);
+    if (hold === 0) {
+      return combined.length > 0 ? [{ type: 'data', data: combined }] : [];
+    }
+    const emittable = combined.subarray(0, combined.length - hold);
+    this.carry = combined.subarray(combined.length - hold);
+    return emittable.length > 0 ? [{ type: 'data', data: emittable }] : [];
+  }
+
+  /**
+   * Length of the longest suffix of `buf` that equals a prefix of
+   * RESYNC_BEGIN_MARKER (in [0, marker.length - 1]). Called only when the full
+   * marker is absent, so a match can exist only at the tail.
+   */
+  private matchingPrefixLen(buf: Buffer): number {
+    const marker = RESYNC_BEGIN_MARKER;
+    const maxK = Math.min(marker.length - 1, buf.length);
+    for (let k = maxK; k >= 1; k--) {
+      if (buf.subarray(buf.length - k).equals(marker.subarray(0, k))) {
+        return k;
+      }
+    }
+    return 0;
+  }
+}

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -854,6 +854,92 @@ export function registerPTYHandlers(
     }));
   }
 
+  // pty:resync (phase 3 PR-B) — live-pipe re-flush. Rehydrates a pane WITHOUT
+  // tearing down its session socket (no input dead-zone, no dead-pane swap):
+  //   - live session  → arm the stream scanner for the in-band RESYNC_BEGIN,
+  //     then daemon.resyncSession re-runs the flush (snapshot, or raw degrade).
+  //   - dead/suspended → daemon.serializeSession returns a read-only snapshot
+  //     over the control RPC ('dead-snapshot') that paints the final screen
+  //     without resurrecting the session.
+  // Legacy daemons (pre-PR-B) lack these RPCs; the 'legacy-daemon' code tells
+  // the renderer to fall back to the classic pty:reconnect. Renderer keys off
+  // `transient` to decide retry-vs-give-up exactly as pty:reconnect does.
+  ipcMain.removeHandler(IPC.PTY_RESYNC);
+  ipcMain.handle(IPC.PTY_RESYNC, wrapHandler(IPC.PTY_RESYNC, async (_event: Electron.IpcMainInvokeEvent, id: string, opts?: { scrollback?: number }) => {
+    if (!useDaemon || !daemonClient) {
+      // Local mode has no daemon SessionPipe to re-flush — the renderer keeps
+      // its live buffer as-is (never wrong). Permanent, do not retry.
+      return { success: false, code: 'local-mode', transient: false };
+    }
+    const scrollback = opts?.scrollback;
+    try {
+      const sessions = await daemonClient.rpc('daemon.listSessions', {}) as Array<{ id: string; state: string }>;
+      const session = sessions.find(s => s.id === id);
+      if (!session) {
+        return { success: false, code: 'session-gone', transient: false };
+      }
+
+      if (session.state === 'dead' || session.state === 'suspended') {
+        // No live pipe to re-flush — pull a read-only snapshot instead. This
+        // never resurrects or replaces the session (daemon-side F2 guarantee).
+        const snap = await daemonClient.rpc('daemon.serializeSession', { id, scrollback }) as {
+          mode: 'snapshot' | 'unavailable';
+          payloadBase64?: string;
+          cols?: number;
+          rows?: number;
+          reason?: string;
+        };
+        if (snap.mode === 'snapshot') {
+          return {
+            success: true,
+            mode: 'dead-snapshot',
+            payloadBase64: snap.payloadBase64,
+            cols: snap.cols,
+            rows: snap.rows,
+          };
+        }
+        // Snapshot generator declined (alt-screen, too-large, ...). The renderer
+        // keeps its current stale screen — status quo, never wrong.
+        return { success: false, code: 'serialize-unavailable', reason: snap.reason, transient: false };
+      }
+
+      // Live session — the re-flush rides the existing connected socket.
+      if (!daemonClient.isSessionPipeWritable(id)) {
+        // Pipe not (yet) writable — the socket may be mid-replacement. Retry.
+        return { success: false, code: 'pipe-not-writable', transient: true };
+      }
+      if (!daemonClient.armSessionResync(id)) {
+        // No live scanner (pipe absent or still doing its initial flush). Retry.
+        return { success: false, code: 'pipe-not-writable', transient: true };
+      }
+      try {
+        const res = await daemonClient.rpc('daemon.resyncSession', { id, scrollback }) as {
+          mode: 'snapshot' | 'raw';
+        };
+        // The scanner disarms itself when it consumes the in-band RESYNC_BEGIN
+        // the daemon just wrote, so no disarm is needed on the success path.
+        return { success: true, mode: res.mode };
+      } catch (err) {
+        // RPC failed AFTER arming — the scanner is still watching for a BEGIN
+        // marker that will now never come. Disarm so it doesn't misclassify a
+        // future coincidental byte run (harmless but must not linger).
+        daemonClient.disarmSessionResync(id);
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('Unknown method')) {
+          // Pre-PR-B daemon: no daemon.resyncSession. Renderer degrades to the
+          // classic pty:reconnect. Permanent for THIS daemon build.
+          return { success: false, code: 'legacy-daemon', transient: false };
+        }
+        return { success: false, code: 'rpc-error', reason: msg, transient: true };
+      }
+    } catch (err) {
+      // listSessions / serializeSession threw (timeout, ECONNRESET, or a legacy
+      // daemon missing serializeSession). No scanner was armed on this path.
+      const msg = err instanceof Error ? err.message : String(err);
+      return { success: false, code: 'rpc-error', reason: msg, transient: true };
+    }
+  }));
+
   // X8 supervision control — rearm a tripped runaway guard / stop supervision.
   // Renderer-only by design (decision ⑥): only the user re-arms a guard, never
   // an external MCP/CLI client (the daemon RPCs are 'wmux.internal'-gated). Both
@@ -967,6 +1053,7 @@ export function registerPTYHandlers(
     ipcMain.removeHandler(IPC.PTY_DISPOSE);
     ipcMain.removeHandler(IPC.PTY_LIST);
     ipcMain.removeHandler(IPC.PTY_RECONNECT);
+    ipcMain.removeHandler(IPC.PTY_RESYNC);
     ipcMain.removeHandler(IPC.SUPERVISE_REARM);
     ipcMain.removeHandler(IPC.SUPERVISE_STOP);
 

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -7,6 +7,7 @@ import { PTYBridge } from '../../pty/PTYBridge';
 import { ShellDetector } from '../../../shared/ShellDetector';
 import { DaemonClient } from '../../DaemonClient';
 import { IPC, ENV_KEYS } from '../../../shared/constants';
+import { DAEMON_RESYNC_RPC_TIMEOUT_MS } from '../../../shared/timeouts';
 import { writePidMap, removePidMapByPtyId } from '../../pty/pidMap';
 import { sanitizePtyText } from '../../../shared/types';
 import { resolveSpawnEnv } from '../../pty/resolveSpawnEnv';
@@ -882,7 +883,9 @@ export function registerPTYHandlers(
       if (session.state === 'dead' || session.state === 'suspended') {
         // No live pipe to re-flush — pull a read-only snapshot instead. This
         // never resurrects or replaces the session (daemon-side F2 guarantee).
-        const snap = await daemonClient.rpc('daemon.serializeSession', { id, scrollback }) as {
+        // Extended timeout: serialization queues behind the same global
+        // daemon-side snapshot slot as live reflushes (shared/timeouts.ts).
+        const snap = await daemonClient.rpc('daemon.serializeSession', { id, scrollback }, { timeoutMs: DAEMON_RESYNC_RPC_TIMEOUT_MS }) as {
           mode: 'snapshot' | 'unavailable';
           payloadBase64?: string;
           cols?: number;
@@ -913,7 +916,12 @@ export function registerPTYHandlers(
         return { success: false, code: 'pipe-not-writable', transient: true };
       }
       try {
-        const res = await daemonClient.rpc('daemon.resyncSession', { id, scrollback }) as {
+        // Extended timeout (Codex round-2 P2): the reflush legitimately waits
+        // behind the global snapshot slot under concurrent reveals — the
+        // default 10s RPC ceiling would disarm the scanner and tear the
+        // socket via reconnect while the daemon still writes the in-band
+        // replay. Must stay below the renderer's 32s resync-abort ceiling.
+        const res = await daemonClient.rpc('daemon.resyncSession', { id, scrollback }, { timeoutMs: DAEMON_RESYNC_RPC_TIMEOUT_MS }) as {
           mode: 'snapshot' | 'raw';
         };
         // The scanner disarms itself when it consumes the in-band RESYNC_BEGIN

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -67,6 +67,18 @@ const electronAPI = {
       // one (session genuinely dead). The renderer retries transient failures
       // instead of immediately clearing the ptyId and replacing the session.
       ipcRenderer.invoke(IPC.PTY_RECONNECT, id) as Promise<{ success: boolean; id?: string; shell?: string; error?: string; code?: string; transient?: boolean }>,
+    // Phase 3 PR-B — live-pipe re-flush. Unlike `reconnect` (opens a fresh
+    // socket), this re-runs the flush on the EXISTING session socket, so input
+    // never pauses. Three success shapes: a live re-flush ('snapshot'|'raw'), a
+    // read-only snapshot of a dead/suspended session ('dead-snapshot', carries
+    // the payload to paint), or a coded failure. `code:'legacy-daemon'` means
+    // the daemon predates PR-B — the caller should fall back to `reconnect`.
+    resync: (id: string, opts?: { scrollback?: number }) =>
+      ipcRenderer.invoke(IPC.PTY_RESYNC, id, opts) as Promise<
+        | { success: true; mode: 'snapshot' | 'raw' }
+        | { success: true; mode: 'dead-snapshot'; payloadBase64: string; cols: number; rows: number }
+        | { success: false; code: string; reason?: string; transient?: boolean }
+      >,
     onData: (callback: (id: string, data: string) => void) => {
       const listener = (_event: Electron.IpcRendererEvent, id: string, data: string) => callback(id, data);
       ipcRenderer.on(IPC.PTY_DATA, listener);

--- a/src/renderer/hooks/__tests__/useTerminal.hiddenRetention.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.hiddenRetention.test.ts
@@ -73,7 +73,7 @@ describe('Phase 3 PR-A — useTerminal hidden-pane retention wiring (source-leve
     // must not: it calls pty.reconnect directly and aborts into markClean.
     const idx = src.indexOf('const startResync');
     expect(idx).toBeGreaterThan(0);
-    const body = src.slice(idx, idx + 1600);
+    const body = src.slice(idx, idx + 3000);
     expect(body).toMatch(/window\.electronAPI\.pty\.reconnect\(id\)/);
     expect(body).not.toMatch(/clearSurfacePtyIdByPty|reconnectPtyWithRetry/);
     const abortIdx = src.indexOf('const abortResync');
@@ -107,7 +107,7 @@ describe('Phase 3 PR-B — useTerminal snapshot-resync ladder (source-level)', (
   const hookPath = path.join(__dirname, '..', 'useTerminal.ts');
   const src = fs.readFileSync(hookPath, 'utf-8');
   const startIdx = src.indexOf('const startResync');
-  const body = src.slice(startIdx, startIdx + 3200);
+  const body = src.slice(startIdx, startIdx + 4600);
 
   it('prefers the non-disruptive pty.resync, guarded against stale preloads', () => {
     // A packaged app updated under a running renderer may lack pty.resync —
@@ -126,7 +126,7 @@ describe('Phase 3 PR-B — useTerminal snapshot-resync ladder (source-level)', (
     expect(body).toMatch(/'local-mode'/);
     expect(body).toMatch(/abortResync\(`resync-failed:\$\{code\}`\)/);
     // The RPC rejecting entirely (IPC failure) also lands on reconnect.
-    expect(body).toMatch(/\.catch\(\(\)\s*=>\s*\{\s*fallbackReconnect\(\);\s*\}\)/);
+    expect(body).toMatch(/\.catch\(\(\)\s*=>\s*\{\s*rpcSettled = true;\s*fallbackReconnect\(\);\s*\}\)/);
   });
 
   it('a live resync leaves settlement to the flush-complete handler (timer stays armed)', () => {

--- a/src/renderer/hooks/__tests__/useTerminal.hiddenRetention.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.hiddenRetention.test.ts
@@ -98,3 +98,61 @@ describe('Phase 3 PR-A — useTerminal hidden-pane retention wiring (source-leve
     expect(exitWrites.length).toBe(2);
   });
 });
+
+// Phase 3 PR-B — snapshot resync ladder wiring. The behavioral halves live in
+// the daemon suites (HeadlessSnapshot / SessionPipe.reflush) and the main
+// scanner suite; this pins the renderer's ladder ordering the same way the
+// PR-A block above pins retention wiring.
+describe('Phase 3 PR-B — useTerminal snapshot-resync ladder (source-level)', () => {
+  const hookPath = path.join(__dirname, '..', 'useTerminal.ts');
+  const src = fs.readFileSync(hookPath, 'utf-8');
+  const startIdx = src.indexOf('const startResync');
+  const body = src.slice(startIdx, startIdx + 3200);
+
+  it('prefers the non-disruptive pty.resync, guarded against stale preloads', () => {
+    // A packaged app updated under a running renderer may lack pty.resync —
+    // the typeof guard degrades straight to the PR-A reconnect path.
+    expect(body).toMatch(/typeof window\.electronAPI\.pty\.resync !== 'function'/);
+    expect(body).toMatch(/window\.electronAPI\.pty\.resync\(id,\s*\{\s*scrollback:\s*scrollbackLines\s*\}\)/);
+  });
+
+  it('falls back to reconnect ONLY for transport-shaped failures', () => {
+    // legacy-daemon / pipe-not-writable / rpc-error / local-mode → the raw
+    // reconnect ladder; session-gone & serialize-unavailable mean no better
+    // screen exists, so they degrade in place instead of tearing the socket.
+    expect(body).toMatch(/'legacy-daemon'/);
+    expect(body).toMatch(/'pipe-not-writable'/);
+    expect(body).toMatch(/'rpc-error'/);
+    expect(body).toMatch(/'local-mode'/);
+    expect(body).toMatch(/abortResync\(`resync-failed:\$\{code\}`\)/);
+    // The RPC rejecting entirely (IPC failure) also lands on reconnect.
+    expect(body).toMatch(/\.catch\(\(\)\s*=>\s*\{\s*fallbackReconnect\(\);\s*\}\)/);
+  });
+
+  it('a live resync leaves settlement to the flush-complete handler (timer stays armed)', () => {
+    // No paint and no settle on {success, mode: snapshot|raw} — the replay is
+    // in flight on the session pipe; RESYNC_TIMEOUT still guards a wedge.
+    const successBranch = body.slice(body.indexOf("res.mode === 'dead-snapshot'"));
+    expect(successBranch).toMatch(/if \(res\?\.success\) \{[\s\S]{0,400}?return;/);
+  });
+
+  it('dead-snapshot paint mirrors the flush-complete contract', () => {
+    const idx = src.indexOf('const paintDeadSnapshot');
+    expect(idx).toBeGreaterThan(0);
+    const paint = src.slice(idx, idx + 1600);
+    // discard stale backlog → reset → write payload → write held bytes → clean.
+    const discard = paint.indexOf('discardTerminalOutput(term)');
+    const reset = paint.indexOf('term.reset()');
+    const write = paint.indexOf('term.write(bytes)');
+    const clean = paint.indexOf('markTerminalClean(term)');
+    expect(discard).toBeGreaterThan(0);
+    expect(reset).toBeGreaterThan(discard);
+    expect(write).toBeGreaterThan(reset);
+    expect(clean).toBeGreaterThan(write);
+    // A dead process cannot own input-reporting modes — always neutralize
+    // (same rationale as staleReplayModeReset, without the resumeAgent gate).
+    expect(paint).toMatch(/STALE_REPLAY_INPUT_MODE_RESETS/);
+    // No flush marker is coming: it settles the resync state itself.
+    expect(paint).toMatch(/st\.resolvers\.splice\(0\)\.forEach/);
+  });
+});

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -360,12 +360,47 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     st.resolvers.splice(0).forEach((r) => r());
   }, []);
 
-  /** Re-synchronize a dirty pane's full screen state from the daemon: trigger
-   *  a reconnect (SessionPipe replay of the RingBuffer) while holding incoming
-   *  bytes out of xterm; the flush-complete handler then resets the stale
-   *  buffer and writes the replay onto the clean one. Resolves when the resync
-   *  settles (replayed OR degraded). Never clears the ptyId — a dead session's
-   *  last screen must survive reveal (unlike reconnectPtyWithRetry). */
+  /** PR-B: paint a dead session's serialized last screen. There is no flush
+   *  marker coming (the payload rode the control RPC, not the session pipe),
+   *  so this settles the resync state itself, mirroring the flush-complete
+   *  contract: discard stale backlog → reset → write → clean. The dead
+   *  process cannot own input-reporting modes, so the stale-replay resets are
+   *  always appended (same rationale as staleReplayModeReset.ts, without the
+   *  resumeAgent round-trip — dead is dead). */
+  const paintDeadSnapshot = useCallback((payloadBase64: string) => {
+    const st = resyncRef.current;
+    if (!st.pending) return; // timed out or cancelled while the RPC ran
+    st.pending = false;
+    if (st.timer) { clearTimeout(st.timer); st.timer = null; }
+    const term = terminalRef.current;
+    if (term) {
+      try {
+        const bytes = Uint8Array.from(atob(payloadBase64), (c) => c.charCodeAt(0));
+        console.log(`[wmux:hidden-retention] dead-snapshot paint ptyId=${ptyIdRef.current} payload=${bytes.length}`);
+        discardTerminalOutput(term);
+        term.reset();
+        term.write(bytes);
+        term.write(STALE_REPLAY_INPUT_MODE_RESETS);
+        for (const chunk of st.buffer) term.write(chunk);
+        markTerminalClean(term);
+      } catch { /* disposed mid-paint — teardown owns cleanup */ }
+    }
+    st.buffer.length = 0;
+    st.bufferedChars = 0;
+    st.resolvers.splice(0).forEach((r) => r());
+  }, []);
+
+  /** Re-synchronize a dirty pane's full screen state from the daemon while
+   *  holding incoming bytes out of xterm; the flush-complete handler then
+   *  resets the stale buffer and writes the replay onto the clean one.
+   *  Resolves when the resync settles (replayed OR degraded). Never clears
+   *  the ptyId — a dead session's last screen must survive reveal (unlike
+   *  reconnectPtyWithRetry).
+   *
+   *  PR-B ladder: live-pipe snapshot reflush (pty.resync — no socket
+   *  teardown, no input dead-zone) → legacy reconnect (raw replay over a
+   *  fresh socket, PR-A behavior) → degrade to the stale-but-unstuck screen.
+   *  Dead sessions short-circuit to a read-only serialized snapshot. */
   const startResync = useCallback((reason: string): Promise<void> => {
     const term = terminalRef.current;
     const id = ptyIdRef.current;
@@ -378,13 +413,43 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     st.bufferedChars = 0;
     console.log(`[useTerminal] hidden-pane resync ptyId=${id} (${reason})`);
     st.timer = setTimeout(() => abortResync('timeout'), RESYNC_TIMEOUT_MS);
-    window.electronAPI.pty.reconnect(id).then((res) => {
-      if (!res?.success) abortResync(`reconnect-failed${res?.code ? `:${res.code}` : ''}`);
-    }).catch((err: unknown) => {
-      abortResync(`reconnect-error:${err instanceof Error ? err.message : String(err)}`);
+    const fallbackReconnect = () => {
+      window.electronAPI.pty.reconnect(id).then((res) => {
+        if (!res?.success) abortResync(`reconnect-failed${res?.code ? `:${res.code}` : ''}`);
+      }).catch((err: unknown) => {
+        abortResync(`reconnect-error:${err instanceof Error ? err.message : String(err)}`);
+      });
+    };
+    // Optional-chain style guard: a stale preload (packaged app updated under
+    // a running renderer) may not expose resync yet.
+    if (typeof window.electronAPI.pty.resync !== 'function') {
+      fallbackReconnect();
+      return done;
+    }
+    window.electronAPI.pty.resync(id, { scrollback: scrollbackLines }).then((res) => {
+      if (res?.success && res.mode === 'dead-snapshot') {
+        paintDeadSnapshot(res.payloadBase64);
+        return;
+      }
+      if (res?.success) {
+        // snapshot | raw — the replay is in flight on the live pipe; the
+        // flush-complete handler settles the resync (timeout still armed).
+        return;
+      }
+      const code = res && !res.success ? res.code : 'no-response';
+      if (code === 'legacy-daemon' || code === 'pipe-not-writable' || code === 'rpc-error' || code === 'local-mode') {
+        console.log(`[wmux:hidden-retention] resync fallback to reconnect ptyId=${id} code=${code}`);
+        fallbackReconnect();
+        return;
+      }
+      // session-gone / serialize-unavailable: nothing better than the current
+      // screen exists — degrade in place (status quo, never stuck).
+      abortResync(`resync-failed:${code}`);
+    }).catch(() => {
+      fallbackReconnect();
     });
     return done;
-  }, [abortResync]);
+  }, [abortResync, paintDeadSnapshot, scrollbackLines]);
 
   const fit = useCallback(() => {
     const container = containerRef.current;

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -412,8 +412,31 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     st.buffer.length = 0;
     st.bufferedChars = 0;
     console.log(`[useTerminal] hidden-pane resync ptyId=${id} (${reason})`);
-    st.timer = setTimeout(() => abortResync('timeout'), RESYNC_TIMEOUT_MS);
+    // Timeout with bounded re-arm: the daemon serializes snapshot work behind
+    // a global slot, so under concurrent dirty-pane reveals this pane's RPC
+    // can legitimately wait several budgets before its replay even starts. A
+    // fixed timer would abort mid-queue and the late replay would then arrive
+    // on a settled pane (Codex P2). While the RPC is still in flight the
+    // daemon is alive and working — re-arm instead of aborting, up to a hard
+    // cap; a truly wedged daemon is caught by the RPC's own timeout, which
+    // settles the promise and stops the re-arms.
+    let rpcSettled = false;
+    let timerRearms = 0;
+    const armResyncTimer = () => {
+      st.timer = setTimeout(() => {
+        if (!rpcSettled && timerRearms < 3) {
+          timerRearms++;
+          armResyncTimer();
+          return;
+        }
+        abortResync('timeout');
+      }, RESYNC_TIMEOUT_MS);
+    };
+    armResyncTimer();
     const fallbackReconnect = () => {
+      // The reconnect path never waits on the daemon's snapshot slot — stop
+      // the timer re-arms so a hung reconnect aborts on the normal window.
+      rpcSettled = true;
       window.electronAPI.pty.reconnect(id).then((res) => {
         if (!res?.success) abortResync(`reconnect-failed${res?.code ? `:${res.code}` : ''}`);
       }).catch((err: unknown) => {
@@ -427,6 +450,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       return done;
     }
     window.electronAPI.pty.resync(id, { scrollback: scrollbackLines }).then((res) => {
+      rpcSettled = true;
       if (res?.success && res.mode === 'dead-snapshot') {
         paintDeadSnapshot(res.payloadBase64);
         return;
@@ -446,6 +470,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // screen exists — degrade in place (status quo, never stuck).
       abortResync(`resync-failed:${code}`);
     }).catch(() => {
+      rpcSettled = true;
       fallbackReconnect();
     });
     return done;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -8,6 +8,12 @@ export const IPC = {
   PTY_EXIT: 'pty:exit',
   PTY_LIST: 'pty:list',
   PTY_RECONNECT: 'pty:reconnect',
+  // Phase 3 PR-B — live-pipe re-flush. Re-runs the daemon SessionPipe flush on
+  // the EXISTING connected socket (no teardown / re-auth), so a hidden pane can
+  // be rehydrated from a headless snapshot without an input dead-zone. Distinct
+  // from PTY_RECONNECT, which opens a fresh socket. Renderer degrades to
+  // reconnect against legacy daemons (code:'legacy-daemon').
+  PTY_RESYNC: 'pty:resync',
   // X8 pane supervision. PTY_RESTARTED fires when the daemon's PaneSupervisor
   // re-created a session under the SAME id with a fresh PTY (a supervised
   // restart). Distinct from PTY_EXIT — the renderer must re-attach the

--- a/src/shared/timeouts.ts
+++ b/src/shared/timeouts.ts
@@ -26,3 +26,20 @@ export const DAEMON_RPC_TIMEOUT_MS = 10_000;
  * never trips the destructive startup fallback.
  */
 export const RECONCILE_TIMEOUT_MS = DAEMON_RPC_TIMEOUT_MS + 5_000;
+
+/**
+ * Phase 3 PR-B: per-request timeout for `daemon.resyncSession` /
+ * `daemon.serializeSession`. These legitimately outlive the default RPC
+ * ceiling — snapshot work is serialized behind a global daemon-side slot
+ * (concurrency 1, up to ~4 s parse budget per pane), so under concurrent
+ * dirty-pane reveals the Nth pane waits (N-1)×budget before its own work even
+ * starts. Timing out early would disarm the stream scanner and fall back to a
+ * socket-tearing reconnect while the daemon may still write the in-band
+ * replay (Codex round-2 P2).
+ *
+ * Invariant: this must stay BELOW the renderer's total resync-abort ceiling
+ * (RESYNC_TIMEOUT_MS × (1 + max re-arms) in useTerminal, currently 32 s) so
+ * the RPC always settles — success or timeout — before the renderer stops
+ * extending its timer and aborts.
+ */
+export const DAEMON_RESYNC_RPC_TIMEOUT_MS = 30_000;


### PR DESCRIPTION
## Summary

Phase 3 PR-B (follows #390 PR-A). Revealing a dirty hidden pane currently tears down its session socket and replays up to **8 MB of raw ring-buffer bytes** for the renderer to re-parse (`recoveredBytes=8388608`) — a visible multi-second repaint plus an input dead-zone at the exact moment the user switches workspaces. This PR makes the daemon parse the session history itself (`@xterm/headless` + `@xterm/addon-serialize`) and re-flush a compact serialized screen **over the live socket**: input never pauses, and the reveal paints its true state (scrollback, colors, cursor, bracketed-paste/app-cursor/mouse modes) near-instantly.

System invariant preserved everywhere: **slower, never wrong** — every condition a snapshot cannot reproduce faithfully degrades down a ladder that ends at today's behavior.

## Protocol (race-free by construction)

The daemon announces a re-flush **in-band** with a new `RESYNC_BEGIN_MARKER` on the already-flushed stream, then re-runs the classic flush sequence (`payload` + `FLUSH_DONE_MARKER`) on the same socket. Because the mode transition rides the stream itself, no RPC-vs-stream ordering can misclassify bytes. Main's marker scanning — extracted verbatim from `DaemonClient.setupSessionPipe` into a pure, unit-tested state machine — only scans in live mode while explicitly armed by the `pty:resync` handler, so steady-state throughput is untouched and held-back bytes are limited to a strict marker prefix (echo latency cannot regress).

Gap-free byte accounting in `SessionPipe.reflush()`: T0 (announce, suppress live, capture ring, arm bridge tee) and T1 (stop tee, write payload + marker + post-drain tail, re-enable) are single synchronous blocks — every PTY byte lands in exactly one stream segment. A leading RIS makes the replay idempotent against live bytes that raced ahead of the marker.

## Fidelity hazards found & handled

- **Partial escape tail** (not in the original design): a resync cut mid-escape-sequence leaves bytes in the headless parser that `serialize()` drops, so the live continuation would render literally. A streaming tracker ships the unfinished sequence after the snapshot; an oversized pending tail (>4 KB) degrades to raw.
- **DECSET modes** (design F5): rebuilt from `terminal.modes` + a raw-stream tracker for the SGR mouse encodings (`?1006/?1016`) the public API doesn't expose.
- **Alt-screen / DECSTBM margins**: not serializable — degrade to raw replay (vim & friends).
- **Split UTF-8 at chunk boundaries**: carried across feed slices; finalize appends leftover bytes raw so the renderer's byte stream stays contiguous.
- **Query safety**: the headless terminal has no `onData` wiring — it can never double-answer DA/DSR/OSC queries (the renderer stays the authoritative responder).

## Dead sessions (F2)

`daemon.serializeSession` returns a read-only snapshot over the control RPC (512 KB cap, viewport-only retry under the 1 MB control-pipe line limit) so a dead pane's reveal paints its final screen — never resurrecting or replacing the session, never clearing the ptyId. The renderer always appends the stale-replay input-mode resets there (a dead process cannot own mouse/paste reporting).

## Renderer ladder

`startResync`: `pty.resync` (non-disruptive) → `pty.reconnect` (PR-A raw replay; also the legacy-daemon and stale-preload path) → degrade in place. All PR-B code sits behind the existing PR-A dirty-reveal machinery, which is behind the default-OFF retention toggle.

## Verification

- **Isolated E2E probe** `scripts/phase3-resync-probe.mjs` (bundled daemon + real PTY): 7 resyncs mid-flood, all snapshot-mode, numbered flood lines contiguous through every seam, 5000-line scrollback preserved, input typed during reflush echoes. 817 KB history parsed in ~200 ms; **342 KB payload vs the 8 MB raw replay**.
- **New unit suites (77 tests)**: `ansiStreamScan` (25), `HeadlessSnapshot` fidelity round-trips incl. CJK/emoji width parity and partial-tail continuation (12), `SessionPipe.reflush` socket-level gap-free proof (6), `sessionPipeStreamScanner` incl. split-marker and disarm-release cases (21), `useTerminal` ladder wiring (13).
- Full `tsc` + daemon `tsc` green; full suite green except two pre-existing flaky files that fail identically on clean HEAD and pass in isolation.
- Budget calibrated from measurement: parse runs ~4 MB/s, so the generation budget is 4 s (2 s would degrade the full-8 MB flagship case this PR exists for).

Part of the phase 3 render-perf epic (#388, #390). PR-C (default-ON flip + bench gate) follows after dogfood.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hidden panes now reveal using compact snapshot-based rehydration to reduce repaint delays and avoid input dead zones.
  * Dead or suspended sessions can restore the last visible screen without opening a fresh connection.
  * Added phase-3 resync support for live panes, with fallbacks for unsupported states, unavailable snapshots, legacy behavior, and transient failures.
* **Bug Fixes**
  * Improved gap-free restoration of terminal output during resync under heavy activity.
  * More reliable handling of split control sequences and multibyte UTF-8 content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->