### PR TITLE
test(deck): P1 review follow-ups (CodeRabbit #396 nits)

### DIFF
--- a/src/renderer/components/Deck/__tests__/DeckTabs.dynamic.test.tsx
+++ b/src/renderer/components/Deck/__tests__/DeckTabs.dynamic.test.tsx
@@ -20,7 +20,7 @@ function mount(props: { active: DeckTab; onSelect?: (t: DeckTab) => void; channe
     root.render(
       createElement(DeckTabs, {
         active: props.active,
-        onSelect: props.onSelect ?? (() => {}),
+        onSelect: props.onSelect ?? vi.fn(),
         channelsUnread: props.channelsUnread,
         t: (k: string) => k,
       }),

--- a/src/renderer/stores/slices/__tests__/deckSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/deckSlice.test.ts
@@ -1,19 +1,30 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useStore } from '../../index';
+import { createDeckSlice } from '../deckSlice';
 
 describe('deckSlice', () => {
-  beforeEach(() => {
-    useStore.setState({ activeDeckTab: 'commander' });
-  });
-
   it('defaults to the Commander tab', () => {
-    expect(useStore.getState().activeDeckTab).toBe('commander');
+    // Observe the slice INITIALIZER, not the store singleton (CodeRabbit #396):
+    // a beforeEach reset-to-'commander' would keep this test green even if the
+    // slice's actual default changed.
+    const slice = createDeckSlice(
+      (() => undefined) as never,
+      (() => useStore.getState()) as never,
+      undefined as never,
+    );
+    expect(slice.activeDeckTab).toBe('commander');
   });
 
-  it('switches the active deck tab', () => {
-    useStore.getState().setActiveDeckTab('channels');
-    expect(useStore.getState().activeDeckTab).toBe('channels');
-    useStore.getState().setActiveDeckTab('commander');
-    expect(useStore.getState().activeDeckTab).toBe('commander');
+  describe('transitions', () => {
+    beforeEach(() => {
+      useStore.setState({ activeDeckTab: 'commander' });
+    });
+
+    it('switches the active deck tab', () => {
+      useStore.getState().setActiveDeckTab('channels');
+      expect(useStore.getState().activeDeckTab).toBe('channels');
+      useStore.getState().setActiveDeckTab('commander');
+      expect(useStore.getState().activeDeckTab).toBe('commander');
+    });
   });
 });


### PR DESCRIPTION
Two minor test-quality follow-ups CodeRabbit flagged on #396, addressed post-merge:

- **deckSlice default-tab test observed masked state**: the `beforeEach` forced `activeDeckTab: 'commander'`, so the "defaults to Commander" assertion passed regardless of the slice's actual initializer. It now asserts `createDeckSlice`'s initial value directly; the transition test keeps its reset in a nested describe.
- **DeckTabs mount fallback used an empty arrow** (`no-empty-function`): replaced with the already-imported `vi.fn()`.

Deck suites 18/18, tsc + eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for default deck tab initialization.
  * Added clearer validation of switching between Commander and Channels tabs.
  * Standardized test callback mocking for deck tab interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->