### PR TITLE
fix(deck): make scheduled orchestrator turns visible in the deck thread

### DIFF
--- a/src/main/deck/BrainAdapter.ts
+++ b/src/main/deck/BrainAdapter.ts
@@ -50,6 +50,12 @@ export interface BrainUsage {
  *                   for the turn — no `turn-end` follows an `error`.
  */
 export type BrainEvent =
+  // Emitted ONLY for turns the MAIN process originates (P3d scheduled runs):
+  // the renderer opens a turn (user bubble + streaming assistant) exactly as
+  // its own composer send would, so a scheduled run is as visible as a typed
+  // one. Adapters never emit this — deck.handler's scheduler does, right
+  // before manager.send.
+  | { type: 'turn-start'; prompt: string }
   | { type: 'text-delta'; text: string }
   | {
       type: 'tool-start';

--- a/src/main/ipc/handlers/deck.handler.ts
+++ b/src/main/ipc/handlers/deck.handler.ts
@@ -149,7 +149,20 @@ export function registerDeckHandler(
   // DECK_STREAM like any typed command). A scheduled turn reuses the live
   // manager — and its model — or lazily creates one exactly like deck:send.
   const scheduler = new DeckScheduler({
-    runTurn: (prompt) => ensureManager(undefined, managerModel).send(prompt),
+    runTurn: (prompt) => {
+      const mgr = ensureManager(undefined, managerModel);
+      // A main-originated turn has no renderer-side optimistic message, so the
+      // stream would hit a thread with no open turn and be dropped. Announce
+      // the turn first — but only when the manager will actually accept it
+      // (a busy reject must not open a phantom stuck-streaming bubble). The
+      // status check and send are one synchronous sequence, so nothing can
+      // interleave between them.
+      if (mgr.getStatus().status !== 'idle') {
+        return Promise.resolve({ ok: false, code: 'busy' as const });
+      }
+      emit({ type: 'turn-start', prompt });
+      return mgr.send(prompt);
+    },
   });
   scheduler.start();
 

--- a/src/renderer/components/Deck/DeckSchedulesPanel.tsx
+++ b/src/renderer/components/Deck/DeckSchedulesPanel.tsx
@@ -235,7 +235,7 @@ export function DeckSchedulesPanel({
                 type="button"
                 data-deck-schedule-create
                 onClick={() => void handleCreate()}
-                className={`px-2.5 py-1 rounded text-[11px] font-mono text-[var(--accent-blue)] bg-[rgba(var(--bg-surface-rgb),0.8)] hover:opacity-80 ${FOCUS_RING}`}
+                className={`shrink-0 whitespace-nowrap px-2.5 py-1 rounded text-[11px] font-mono text-[var(--accent-blue)] bg-[rgba(var(--bg-surface-rgb),0.8)] hover:opacity-80 ${FOCUS_RING}`}
                 {...tokenAttrs('accent', 'text')}
               >
                 {t('deck.scheduleAdd') || 'Add schedule'}

--- a/src/renderer/stores/slices/__tests__/deckSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/deckSlice.test.ts
@@ -42,6 +42,21 @@ describe('deckSlice', () => {
       expect(s.brainMessages[1]).toMatchObject({ role: 'assistant', status: 'streaming' });
     });
 
+    it('turn-start (P3d scheduled run) opens a turn exactly like a typed send', () => {
+      const st = useStore.getState();
+      st.applyDeckBrainEvent({ type: 'turn-start', prompt: '[Scheduled task] check PRs' });
+      let s = useStore.getState();
+      expect(s.brainStatus).toBe('busy');
+      expect(s.brainMessages[0]).toMatchObject({ role: 'user', text: '[Scheduled task] check PRs' });
+      expect(s.brainMessages[1]).toMatchObject({ role: 'assistant', status: 'streaming' });
+      // The scheduled turn's stream lands in that open turn.
+      st.applyDeckBrainEvent({ type: 'text-delta', text: 'on it' });
+      st.applyDeckBrainEvent({ type: 'turn-end', sessionId: 'sess-s' });
+      s = useStore.getState();
+      expect(s.brainStatus).toBe('idle');
+      expect(s.brainMessages[1]).toMatchObject({ text: 'on it', status: 'done' });
+    });
+
     it('streams events into the open turn and returns to idle on turn-end', () => {
       const st = useStore.getState();
       st.startDeckBrainTurn('go');

--- a/src/renderer/stores/slices/deckSlice.ts
+++ b/src/renderer/stores/slices/deckSlice.ts
@@ -95,6 +95,21 @@ export const createDeckSlice: StateCreator<
 
   applyDeckBrainEvent: (event) =>
     set((state: StoreState) => {
+      // A main-originated turn (P3d scheduled run) announces itself with
+      // `turn-start` — open the turn exactly like startDeckBrainTurn so the
+      // scheduled run renders as visibly as a typed one.
+      if (event.type === 'turn-start') {
+        state.brainMessages.push({ id: generateId('dbu'), role: 'user', text: event.prompt });
+        state.brainMessages.push({
+          id: generateId('dba'),
+          role: 'assistant',
+          text: '',
+          tools: [],
+          status: 'streaming',
+        });
+        state.brainStatus = 'busy';
+        return;
+      }
       state.brainMessages = applyBrainEvent(state.brainMessages, event);
       if (event.type === 'turn-end' || event.type === 'error') {
         state.brainStatus = 'idle';


### PR DESCRIPTION
## What

The P3d packaged probe caught a real bug in #403: a scheduled run fired correctly (store advanced, `lastResult=ok`) but **nothing appeared in the deck thread**. A main-originated turn has no renderer-side optimistic message, so the entire event stream hit a thread with no open turn and was dropped by `applyBrainEvent`'s defensive no-op.

## Fix

- New `BrainEvent` variant `turn-start` — emitted ONLY by the scheduler in `deck.handler` (never by adapters) over `DECK_STREAM`, right before `manager.send`.
- `deckSlice.applyDeckBrainEvent` opens the turn on `turn-start` exactly like `startDeckBrainTurn` (user bubble + streaming assistant + busy), so a scheduled run renders as visibly as a typed one and the composer disables for its duration (one-turn contract).
- Emitted only when the manager is idle: a busy reject must not open a phantom stuck-streaming bubble. The idle check and send are one synchronous sequence — nothing can interleave.

## Testing

- `scripts/deck-p3d-probe.mjs` on the packaged build: **4/4 PASS** (was 3/4 — S3 "due schedule fires as an orchestrator turn" failed before the fix).
- New deckSlice unit test: `turn-start` opens a turn and the scheduled stream lands in it.
- Typecheck clean; deck suites 121/121.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Scheduled brain turns now create a full conversation entry using the scheduled prompt, with a live streaming assistant response.
  - Scheduled turns now use the same “turn start” flow to mirror typed sends.

- **Bug Fixes**
  - Prevented scheduled turns from starting while another brain turn is active.
  - Busy scheduled runs now exit safely without creating duplicate turns or messages.

- **UI**
  - Improved layout for the “Add schedule” button to keep its label on one line.

- **Tests**
  - Added coverage to verify scheduled turn start, streaming updates, and turn completion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->