### PR TITLE
feat(design): deck typography pass — prose in sans, mono for logs only

### DIFF
--- a/src/renderer/components/Deck/CommanderView.tsx
+++ b/src/renderer/components/Deck/CommanderView.tsx
@@ -142,7 +142,7 @@ export function CommanderViewContent({
         {isEmpty && (
           <div
             data-commander-empty
-            className="text-caption font-mono text-[var(--text-muted)] text-center py-8 leading-relaxed"
+            className="text-[12.5px] text-[var(--text-muted)] text-center py-8 leading-relaxed"
             {...tokenAttrs('textMuted', 'text')}
           >
             {t('deck.commanderEmpty') ||
@@ -156,12 +156,11 @@ export function CommanderViewContent({
         {recoveryPanes.length > 0 && (
           <div
             data-commander-recovery
-            className="rounded-md border px-3 py-2.5 space-y-2 bg-[rgba(var(--bg-surface-rgb),0.5)]"
-            style={{ borderColor: 'var(--border-soft)' }}
+            className="rounded-lg px-4 py-3 space-y-2 bg-[rgba(var(--bg-surface-rgb),0.55)]"
             {...tokenAttrs('bgSurface', 'bg')}
           >
             <div
-              className="text-[11px] font-mono text-[var(--text-main)] leading-relaxed"
+              className="text-[12.5px] font-semibold text-[var(--text-main)] leading-relaxed"
               {...tokenAttrs('textMain', 'text')}
             >
               {(t('deck.recoveryTitle') ||
@@ -169,7 +168,7 @@ export function CommanderViewContent({
               ).replace('{count}', String(recoveryPanes.length))}
             </div>
             <div
-              className="text-[10px] font-mono text-[var(--text-sub)] leading-relaxed"
+              className="text-[11px] font-mono text-[var(--text-sub)] leading-relaxed"
               {...tokenAttrs('textSub', 'text')}
             >
               {recoveryPanes.map((p) => p.label).join(' · ')}
@@ -180,7 +179,7 @@ export function CommanderViewContent({
                 data-recovery-run
                 disabled={brainBusy}
                 onClick={onRecoverFleet}
-                className={`px-2.5 py-1 rounded text-[11px] font-mono text-[var(--accent-blue)] bg-[rgba(var(--bg-surface-rgb),0.8)] hover:opacity-80 transition-opacity disabled:opacity-40 ${FOCUS_RING}`}
+                className={`px-2.5 py-1 rounded-md text-[12px] font-semibold text-[var(--accent-blue)] bg-[rgba(var(--bg-surface-rgb),0.8)] hover:opacity-80 transition-opacity disabled:opacity-40 ${FOCUS_RING}`}
               >
                 {t('deck.recoveryRun') || 'Recover agents'}
               </button>
@@ -188,7 +187,7 @@ export function CommanderViewContent({
                 type="button"
                 data-recovery-dismiss
                 onClick={onDismissRecovery}
-                className={`px-2 py-1 rounded text-[10px] font-mono text-[var(--text-muted)] hover:opacity-80 transition-opacity ${FOCUS_RING}`}
+                className={`px-2 py-1 rounded-md text-[12px] text-[var(--text-muted)] hover:opacity-80 transition-opacity ${FOCUS_RING}`}
                 {...tokenAttrs('textMuted', 'text')}
               >
                 {t('deck.recoveryDismiss') || 'Dismiss'}
@@ -228,7 +227,7 @@ export function CommanderViewContent({
             className="inline-block w-3 h-3 rounded-full border-2 border-[var(--accent-blue)] border-t-transparent animate-spin"
           />
           <span
-            className="text-[10px] font-mono text-[var(--text-sub)] flex-1"
+            className="text-[12px] text-[var(--text-sub)] flex-1"
             {...tokenAttrs('textSub', 'text')}
           >
             {t('deck.commanderThinking') || 'Orchestrator is working…'}
@@ -237,7 +236,7 @@ export function CommanderViewContent({
             type="button"
             data-commander-interrupt
             onClick={onInterrupt}
-            className={`px-2 py-0.5 rounded text-[10px] font-mono text-[var(--accent-red)] bg-[rgba(var(--bg-surface-rgb),0.6)] hover:opacity-80 transition-opacity ${FOCUS_RING}`}
+            className={`px-2 py-0.5 rounded-md text-[12px] text-[var(--accent-red)] bg-[rgba(var(--bg-surface-rgb),0.6)] hover:opacity-80 transition-opacity ${FOCUS_RING}`}
             {...tokenAttrs('danger', 'text')}
           >
             {t('deck.commanderStop') || 'Stop'}
@@ -263,7 +262,7 @@ export function CommanderViewContent({
               data-action-id={action.id}
               disabled={brainBusy}
               onClick={() => onQuickAction?.(action)}
-              className={`px-2 py-0.5 rounded text-[10px] font-mono text-[var(--text-sub)] bg-[rgba(var(--bg-surface-rgb),0.6)] hover:opacity-80 transition-opacity disabled:opacity-40 ${FOCUS_RING}`}
+              className={`px-2.5 py-1 rounded-md text-[12px] text-[var(--text-sub)] bg-[rgba(var(--bg-surface-rgb),0.6)] hover:opacity-80 transition-opacity disabled:opacity-40 ${FOCUS_RING}`}
               {...tokenAttrs('textSub', 'text')}
             >
               {action.label}
@@ -289,7 +288,7 @@ export function CommanderViewContent({
           onSubmit={onSubmit}
           mentionCandidates={mentionCandidates}
           disabled={brainBusy}
-          placeholder={t('deck.commanderPlaceholder') || 'Tell the orchestrator — @mention panes…'}
+          placeholder={t('deck.commanderPlaceholder') || 'Tell the orchestrator, or @mention panes…'}
           t={t}
         />
       </div>
@@ -318,23 +317,24 @@ function CommanderBrainItem({
       className="flex flex-col gap-1"
     >
       <span
-        className={`text-caption font-mono font-bold ${isUser ? 'text-[var(--text-main)]' : 'text-[var(--accent-blue)]'}`}
+        className={`text-[12px] font-bold ${isUser ? 'text-[var(--text-main)]' : 'text-[var(--accent-blue)]'}`}
         {...(isUser ? tokenAttrs('textMain', 'text') : tokenAttrs('accent', 'text'))}
       >
         {isUser ? t('channels.me') || 'Me' : t('deck.commander') || 'Orchestrator'}
       </span>
       {message.text && (
         <div
-          className="text-[12px] font-mono text-[var(--text-main)] whitespace-pre-wrap break-words"
+          className="text-[13px] leading-relaxed text-[var(--text-main)] whitespace-pre-wrap break-words"
           data-commander-brain-text
           {...tokenAttrs('textMain', 'text')}
         >
           {message.text}
         </div>
       )}
-      {/* Tool chips — one per fleet action, in call order. */}
+      {/* Tool calls — flat monospace LOG LINES in call order (design decision
+          3: hierarchy from typography, not chip boxes). */}
       {message.tools && message.tools.length > 0 && (
-        <div className="flex flex-wrap gap-1 pt-0.5" data-commander-brain-tools>
+        <div className="flex flex-col gap-0.5 pt-1" data-commander-brain-tools>
           {message.tools.map((chip, i) => (
             <CommanderToolChip key={chip.toolId ?? `${chip.name}-${i}`} chip={chip} onJumpToPane={onJumpToPane} t={t} />
           ))}
@@ -344,7 +344,7 @@ function CommanderBrainItem({
         <div
           role="alert"
           data-commander-brain-error
-          className="text-[10px] font-mono text-[var(--accent-red)]"
+          className="text-[11px] text-[var(--accent-red)]"
           {...tokenAttrs('danger', 'text')}
         >
           {message.errorText}
@@ -354,9 +354,10 @@ function CommanderBrainItem({
   );
 }
 
-/** A single tool-call chip. Shows the tool name + a compact input summary and a
- *  status dot (running / ok / failed); when the tool targeted a pane, the whole
- *  chip is a jump button. */
+/** A single tool call rendered as a flat MONOSPACE LOG LINE (the mock's
+ *  `.call` row): a ✓/✕ result glyph (● while running), the tool name, a
+ *  truncated input summary, and, when the tool targeted a pane, a right-
+ *  aligned jump link. No box, no decorative dot — the glyph IS the status. */
 function CommanderToolChip({
   chip,
   onJumpToPane,
@@ -366,52 +367,41 @@ function CommanderToolChip({
   onJumpToPane: (workspaceId: string, paneId: string) => void;
   t: (key: string) => string;
 }): React.ReactElement {
-  const dot =
+  const glyph = chip.ok === undefined ? '●' : chip.ok ? '✓' : '✕';
+  const glyphColor =
     chip.ok === undefined
       ? 'var(--text-muted)'
       : chip.ok
         ? 'var(--accent-green)'
         : 'var(--accent-red)';
   const canJump = !!chip.paneId && !!chip.workspaceId;
-  const label = (
-    <>
-      <span
-        aria-hidden="true"
-        className="inline-block w-1.5 h-1.5 rounded-full shrink-0"
-        style={{ backgroundColor: dot }}
-      />
-      <span className="font-bold">{chip.name}</span>
-      {chip.inputSummary && <span className="opacity-70 truncate max-w-[160px]">{chip.inputSummary}</span>}
-    </>
-  );
-  const base =
-    'inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-mono bg-[rgba(var(--bg-surface-rgb),0.6)]';
-  if (canJump) {
-    return (
-      <button
-        type="button"
-        data-commander-tool-chip
-        data-tool-name={chip.name}
-        data-pane-id={chip.paneId}
-        data-workspace-id={chip.workspaceId}
-        onClick={() => onJumpToPane(chip.workspaceId!, chip.paneId!)}
-        title={t('deck.jumpToPane') || 'Jump to this pane'}
-        className={`${base} text-[var(--accent-blue)] hover:opacity-80 transition-opacity ${FOCUS_RING}`}
-        {...tokenAttrs('accent', 'text')}
-      >
-        {label}
-      </button>
-    );
-  }
   return (
-    <span
+    <div
       data-commander-tool-chip
       data-tool-name={chip.name}
-      className={`${base} text-[var(--text-sub)]`}
-      {...tokenAttrs('textSub', 'text')}
+      {...(canJump ? { 'data-pane-id': chip.paneId, 'data-workspace-id': chip.workspaceId } : {})}
+      className="flex items-baseline gap-2 text-[11px] font-mono text-[var(--text-muted)] min-w-0"
+      {...tokenAttrs('textMuted', 'text')}
     >
-      {label}
-    </span>
+      <span aria-hidden="true" className="shrink-0" style={{ color: glyphColor }}>
+        {glyph}
+      </span>
+      <span className="text-[var(--text-sub)] shrink-0" {...tokenAttrs('textSub', 'text')}>
+        {chip.name}
+      </span>
+      {chip.inputSummary && <span className="truncate">{chip.inputSummary}</span>}
+      {canJump && (
+        <button
+          type="button"
+          data-commander-tool-jump
+          onClick={() => onJumpToPane(chip.workspaceId!, chip.paneId!)}
+          className={`ml-auto shrink-0 font-sans text-[11px] text-[var(--text-muted)] underline underline-offset-2 hover:text-[var(--text-sub)] ${FOCUS_RING}`}
+          {...tokenAttrs('textMuted', 'text')}
+        >
+          {t('deck.jumpToPane') || 'Jump to this pane'}
+        </button>
+      )}
+    </div>
   );
 }
 
@@ -438,7 +428,7 @@ function CommanderThreadItem({
         <div data-commander-dispatch className="flex flex-col gap-0.5">
           <div className="flex items-baseline gap-2">
             <span
-              className="text-caption font-mono font-bold text-[var(--text-main)]"
+              className="text-[12px] font-bold text-[var(--text-main)]"
               {...tokenAttrs('textMain', 'text')}
             >
               {t('channels.me') || 'Me'}
@@ -451,7 +441,7 @@ function CommanderThreadItem({
             </span>
           </div>
           <div
-            className="text-[12px] font-mono text-[var(--text-main)] whitespace-pre-wrap break-words"
+            className="text-[13px] leading-relaxed text-[var(--text-main)] whitespace-pre-wrap break-words"
             data-commander-dispatch-text
             {...tokenAttrs('textMain', 'text')}
           >
@@ -470,7 +460,7 @@ function CommanderThreadItem({
                   disabled={!m.paneId}
                   onClick={() => m.paneId && onJumpToPane(m.workspaceId, m.paneId)}
                   title={t('deck.jumpToPane') || 'Jump to this pane'}
-                  className={`px-1.5 py-0.5 rounded text-[10px] font-mono text-[var(--accent-blue)] bg-[rgba(var(--bg-surface-rgb),0.6)] hover:opacity-80 transition-opacity disabled:opacity-50 disabled:cursor-default ${FOCUS_RING}`}
+                  className={`px-2 py-0.5 rounded-md text-[11.5px] text-[var(--accent-blue)] bg-[rgba(var(--bg-surface-rgb),0.6)] hover:opacity-80 transition-opacity disabled:opacity-50 disabled:cursor-default ${FOCUS_RING}`}
                   {...tokenAttrs('accent', 'text')}
                 >
                   @{m.name}
@@ -504,14 +494,14 @@ function CommanderThreadItem({
                       data-commander-reply-author
                       onClick={() => onJumpToPane(pane.workspaceId, pane.paneId)}
                       title={t('deck.jumpToPane') || 'Jump to this pane'}
-                      className={`text-caption font-mono font-bold text-[var(--accent-blue)] hover:underline ${FOCUS_RING}`}
+                      className={`text-[12px] font-bold text-[var(--accent-blue)] hover:underline ${FOCUS_RING}`}
                       {...tokenAttrs('accent', 'text')}
                     >
                       {author.primary}
                     </button>
                   ) : (
                     <span
-                      className="text-caption font-mono font-bold text-[var(--text-main)]"
+                      className="text-[12px] font-bold text-[var(--text-main)]"
                       data-commander-reply-author
                       {...tokenAttrs('textMain', 'text')}
                     >
@@ -519,7 +509,7 @@ function CommanderThreadItem({
                     </span>
                   )}
                   {author.chip && (
-                    <span className="text-[10px] font-mono text-[var(--text-sub)]" {...tokenAttrs('textSub', 'text')}>
+                    <span className="text-[11px] text-[var(--text-sub)]" {...tokenAttrs('textSub', 'text')}>
                       {author.chip}
                     </span>
                   )}
@@ -531,7 +521,7 @@ function CommanderThreadItem({
                   </span>
                 </div>
                 <div
-                  className="text-[12px] font-mono text-[var(--text-main)] whitespace-pre-wrap break-words"
+                  className="text-[13px] leading-relaxed text-[var(--text-main)] whitespace-pre-wrap break-words"
                   data-commander-reply-text
                   {...tokenAttrs('textMain', 'text')}
                 >

--- a/src/renderer/components/Deck/DeckSchedulesPanel.tsx
+++ b/src/renderer/components/Deck/DeckSchedulesPanel.tsx
@@ -116,7 +116,7 @@ export function DeckSchedulesPanel({
         data-deck-schedules-toggle
         aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
-        className={`px-2 py-0.5 rounded text-[10px] font-mono transition-opacity hover:opacity-80 ${
+        className={`px-2.5 py-1 rounded-md text-[12px] transition-opacity hover:opacity-80 ${
           open ? 'text-[var(--accent-blue)]' : 'text-[var(--text-sub)]'
         } bg-[rgba(var(--bg-surface-rgb),0.6)] ${FOCUS_RING}`}
         {...(open ? tokenAttrs('accent', 'text') : tokenAttrs('textSub', 'text'))}
@@ -128,17 +128,16 @@ export function DeckSchedulesPanel({
       {open && (
         <div
           data-deck-schedules-panel
-          className="w-full mt-1.5 rounded-md border px-3 py-2.5 space-y-2 bg-[rgba(var(--bg-surface-rgb),0.4)]"
-          style={{ borderColor: 'var(--border-soft)' }}
+          className="w-full mt-1.5 rounded-lg px-4 py-3 space-y-2 bg-[rgba(var(--bg-surface-rgb),0.55)]"
         >
           {/* Existing schedules */}
           {schedules.length === 0 ? (
             <div
-              className="text-[10px] font-mono text-[var(--text-muted)]"
+              className="text-[12px] text-[var(--text-muted)] leading-relaxed"
               data-deck-schedules-empty
               {...tokenAttrs('textMuted', 'text')}
             >
-              {t('deck.schedulesEmpty') || 'No schedules yet — the orchestrator runs them even after a reboot.'}
+              {t('deck.schedulesEmpty') || 'No schedules yet. Schedules survive reboots.'}
             </div>
           ) : (
             <div className="space-y-1.5">
@@ -147,7 +146,7 @@ export function DeckSchedulesPanel({
                   key={s.id}
                   data-deck-schedule-row
                   data-schedule-id={s.id}
-                  className="flex items-center gap-2 text-[11px] font-mono"
+                  className="flex items-center gap-2 text-[12.5px]"
                 >
                   <span
                     aria-hidden="true"
@@ -160,7 +159,7 @@ export function DeckSchedulesPanel({
                   >
                     {s.prompt}
                   </span>
-                  <span className="text-[10px] text-[var(--text-sub)] shrink-0" {...tokenAttrs('textSub', 'text')}>
+                  <span className="text-[11px] font-mono text-[var(--text-sub)] shrink-0" {...tokenAttrs('textSub', 'text')}>
                     {formatNextRun(s.nextRunAt)}
                     {s.intervalMinutes ? ` · ${
                       REPEAT_OPTIONS.find((o) => o.minutes === s.intervalMinutes)
@@ -175,7 +174,7 @@ export function DeckSchedulesPanel({
                     onClick={() => {
                       void resolvedApi.update({ id: s.id, enabled: !s.enabled }).then(() => refresh());
                     }}
-                    className={`px-1.5 py-0.5 rounded text-[10px] text-[var(--text-sub)] hover:opacity-80 ${FOCUS_RING}`}
+                    className={`px-1.5 py-0.5 rounded-md text-[11.5px] text-[var(--text-sub)] hover:opacity-80 ${FOCUS_RING}`}
                     {...tokenAttrs('textSub', 'text')}
                   >
                     {s.enabled ? t('deck.schedulePause') || 'Pause' : t('deck.scheduleResume') || 'Resume'}
@@ -186,7 +185,7 @@ export function DeckSchedulesPanel({
                     onClick={() => {
                       void resolvedApi.remove(s.id).then(() => refresh());
                     }}
-                    className={`px-1.5 py-0.5 rounded text-[10px] text-[var(--accent-red)] hover:opacity-80 ${FOCUS_RING}`}
+                    className={`px-1.5 py-0.5 rounded-md text-[11.5px] text-[var(--accent-red)] hover:opacity-80 ${FOCUS_RING}`}
                     {...tokenAttrs('danger', 'text')}
                   >
                     {t('deck.scheduleDelete') || 'Delete'}
@@ -197,14 +196,14 @@ export function DeckSchedulesPanel({
           )}
 
           {/* Create */}
-          <div className="flex flex-col gap-1.5 pt-1 border-t" style={{ borderColor: 'var(--border-soft)' }}>
+          <div className="flex flex-col gap-1.5 pt-2 border-t" style={{ borderColor: 'var(--border-soft)' }}>
             <input
               type="text"
               data-deck-schedule-prompt
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
               placeholder={t('deck.schedulePromptPlaceholder') || 'What should the orchestrator do?'}
-              className="w-full text-[11px] font-mono rounded px-2 py-1 bg-[var(--bg-base)] text-[var(--text-main)] border focus:outline-none"
+              className="w-full text-[12.5px] rounded-md px-2.5 py-1.5 bg-[var(--bg-base)] text-[var(--text-main)] border focus:outline-none"
               style={{ borderColor: 'var(--border-soft)' }}
             />
             <div className="flex items-center gap-1.5">
@@ -213,14 +212,14 @@ export function DeckSchedulesPanel({
                 data-deck-schedule-when
                 value={when}
                 onChange={(e) => setWhen(e.target.value)}
-                className="text-[10px] font-mono rounded px-1.5 py-1 bg-[var(--bg-base)] text-[var(--text-main)] border focus:outline-none"
+                className="text-[11px] font-mono rounded-md px-1.5 py-1 bg-[var(--bg-base)] text-[var(--text-main)] border focus:outline-none"
                 style={{ borderColor: 'var(--border-soft)' }}
               />
               <select
                 data-deck-schedule-repeat
                 value={repeat}
                 onChange={(e) => setRepeat(Number(e.target.value))}
-                className="text-[10px] font-mono rounded px-1.5 py-1 bg-[var(--bg-base)] text-[var(--text-main)] border focus:outline-none"
+                className="text-[11px] font-mono rounded-md px-1.5 py-1 bg-[var(--bg-base)] text-[var(--text-main)] border focus:outline-none"
                 style={{ borderColor: 'var(--border-soft)' }}
                 aria-label={t('deck.scheduleRepeat') || 'Repeat'}
               >
@@ -235,14 +234,14 @@ export function DeckSchedulesPanel({
                 type="button"
                 data-deck-schedule-create
                 onClick={() => void handleCreate()}
-                className={`shrink-0 whitespace-nowrap px-2.5 py-1 rounded text-[11px] font-mono text-[var(--accent-blue)] bg-[rgba(var(--bg-surface-rgb),0.8)] hover:opacity-80 ${FOCUS_RING}`}
+                className={`shrink-0 whitespace-nowrap px-2.5 py-1 rounded-md text-[12px] font-semibold text-[var(--accent-blue)] bg-[rgba(var(--bg-surface-rgb),0.8)] hover:opacity-80 ${FOCUS_RING}`}
                 {...tokenAttrs('accent', 'text')}
               >
                 {t('deck.scheduleAdd') || 'Add schedule'}
               </button>
             </div>
             {error && (
-              <div role="alert" data-deck-schedule-error className="text-[10px] font-mono text-[var(--accent-red)]" {...tokenAttrs('danger', 'text')}>
+              <div role="alert" data-deck-schedule-error className="text-[11.5px] text-[var(--accent-red)]" {...tokenAttrs('danger', 'text')}>
                 {error}
               </div>
             )}

--- a/src/renderer/components/Deck/DeckTabs.tsx
+++ b/src/renderer/components/Deck/DeckTabs.tsx
@@ -51,7 +51,7 @@ export function DeckTabs({
             data-deck-tab={tab.id}
             data-active={isActive ? 'true' : undefined}
             onClick={() => onSelect(tab.id)}
-            className={`relative flex-1 flex items-center justify-center gap-1 px-3 py-1.5 text-[11px] font-mono uppercase tracking-widest transition-colors duration-150 ${FOCUS_RING} ${
+            className={`relative flex-1 flex items-center justify-center gap-1 px-3 py-2 text-[12.5px] font-semibold transition-colors duration-150 ${FOCUS_RING} ${
               isActive
                 ? 'text-[var(--text-main)] bg-[rgba(var(--bg-surface-rgb),0.5)]'
                 : 'text-[var(--text-muted)] hover:text-[var(--text-sub)]'

--- a/src/renderer/components/Deck/__tests__/CommanderView.brain.dynamic.test.tsx
+++ b/src/renderer/components/Deck/__tests__/CommanderView.brain.dynamic.test.tsx
@@ -74,19 +74,19 @@ describe('CommanderViewContent — brain surface', () => {
     expect(container.querySelector('[data-commander-empty]')).toBeNull();
   });
 
-  it('makes a pane-targeting chip a clickable jump', () => {
+  it('makes a pane-targeting tool line a clickable jump', () => {
     const onJumpToPane = vi.fn();
     mount({ brainMessages: brainTurn(), onJumpToPane });
-    const jumpChip = container.querySelector(
-      'button[data-commander-tool-chip][data-pane-id="pane-9"]',
-    ) as HTMLButtonElement;
-    expect(jumpChip).not.toBeNull();
-    act(() => jumpChip.click());
+    const row = container.querySelector('[data-commander-tool-chip][data-pane-id="pane-9"]');
+    expect(row).not.toBeNull();
+    const jump = row!.querySelector('[data-commander-tool-jump]') as HTMLButtonElement;
+    expect(jump).not.toBeNull();
+    act(() => jump.click());
     expect(onJumpToPane).toHaveBeenCalledWith('ws-1', 'pane-9');
 
-    // The non-pane chip is a plain span, not a button.
+    // The non-pane tool line has no jump link.
     const plain = container.querySelector('[data-commander-tool-chip][data-tool-name="terminal_send"]');
-    expect(plain?.tagName).toBe('SPAN');
+    expect(plain?.querySelector('[data-commander-tool-jump]')).toBeNull();
   });
 
   it('shows the busy bar and Stop interrupts', () => {

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -733,7 +733,7 @@ export const en = {
   'deck.tabsAriaLabel': 'Command deck tabs',
   'deck.tabCommander': 'Orchestrator',
   'deck.tabChannels': 'Channels',
-  'deck.commanderPlaceholder': 'Tell the orchestrator — @mention panes…',
+  'deck.commanderPlaceholder': 'Tell the orchestrator, or @mention panes…',
   'deck.commanderEmpty':
     'Ask the orchestrator to run your agents, or @mention agent panes to command them directly.',
   'deck.jumpToPane': 'Jump to this pane',
@@ -753,7 +753,7 @@ export const en = {
   'deck.qaPrStatus': 'PR status',
   // Command Deck P3d — orchestrator schedules (reboot-surviving).
   'deck.schedules': 'Schedules',
-  'deck.schedulesEmpty': 'No schedules yet — schedules survive reboots, and the orchestrator runs them when the time comes.',
+  'deck.schedulesEmpty': 'No schedules yet. Schedules survive reboots, and the orchestrator runs them when the time comes.',
   'deck.schedulePromptPlaceholder': 'What should the orchestrator do?',
   'deck.scheduleRepeat': 'Repeat',
   'deck.scheduleRepeatNone': 'Once',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -656,7 +656,7 @@ export const ko = {
   'deck.tabsAriaLabel': '커맨드 데크 탭',
   'deck.tabCommander': '오케스트레이터',
   'deck.tabChannels': '채널',
-  'deck.commanderPlaceholder': '오케스트레이터에 지시 — @로 pane 멘션…',
+  'deck.commanderPlaceholder': '오케스트레이터에 지시하거나 @로 pane을 멘션…',
   'deck.commanderEmpty':
     '오케스트레이터에게 에이전트 운영을 맡기거나, @로 에이전트 pane을 멘션해 직접 지시하세요.',
   'deck.jumpToPane': '이 pane으로 이동',
@@ -676,7 +676,7 @@ export const ko = {
   'deck.qaPrStatus': 'PR 상태',
   // 커맨드 데크 P3d — 오케스트레이터 예약(재부팅 생존).
   'deck.schedules': '예약',
-  'deck.schedulesEmpty': '예약이 없습니다 — 예약은 재부팅 후에도 유지되고, 시간이 되면 오케스트레이터가 실행합니다.',
+  'deck.schedulesEmpty': '예약이 없습니다. 예약은 재부팅 후에도 유지되고, 시간이 되면 오케스트레이터가 실행합니다.',
   'deck.schedulePromptPlaceholder': '오케스트레이터가 무엇을 하면 될까요?',
   'deck.scheduleRepeat': '반복',
   'deck.scheduleRepeatNone': '한 번',


### PR DESCRIPTION
## What

A taste audit of the deck against the amber design system found the real gap behind "still looks off": **every string in the dock rendered in 10-12px `font-mono`**, while the mock reserves mono for terminal output, identifiers, and tool-call log lines, and lets 13px **sans** prose carry the hierarchy (design decision 3: typography makes hierarchy).

- All dock prose (messages, empty state, card titles, buttons, chips, tabs) moves to sans at mock sizes (13px body / 12.5px labels). Mono stays ONLY on pane ids, timestamps, datetime fields, and tool-call lines.
- **Tool calls: boxed chips with decorative status dots become flat monospace log lines** (✓/✕/● glyph + tool name + input summary + right-aligned jump link) — the mock's `.call` row.
- **Faces, not borders**: the recovery card and schedules panel drop their 1px borders for quiet raised faces (`bg-surface` alpha) — the mock's `.rec` treatment.
- Shape lock: dock radii standardize (faces `rounded-lg`, controls `rounded-md`); tabs drop the uppercase+tracking styling for plain sans semibold.
- Visible em-dashes ('—' in the composer placeholder and schedules empty state, ko+en) rewritten out.

## Testing

- Deck suites 55/55 green (tool-line test updated from the chip-button assertion); typecheck clean.
- Live visual check on an isolated dev instance: sans hierarchy, log-line tool calls, borderless faces.