### PR TITLE
feat(design): responsive agent toolbar — icon-only below 620px container width

### DIFF
--- a/src/renderer/components/AgentToolbar/AgentToolbar.tsx
+++ b/src/renderer/components/AgentToolbar/AgentToolbar.tsx
@@ -9,7 +9,7 @@ import RichInput from './RichInput';
 import SnippetsMenu from './SnippetsMenu';
 import FileExplorerPopover from './FileExplorerPopover';
 import FanOutDialog from './FanOutDialog';
-import { IconPaperclip, IconFolder, IconStar, IconKeyboard, IconSparkles } from '../icons';
+import { IconPaperclip, IconFolder, IconStar, IconKeyboard, IconSparkles, IconUsers } from '../icons';
 
 export default function AgentToolbar() {
   const t = useT();
@@ -111,21 +111,24 @@ export default function AgentToolbar() {
   return (
     <div
       ref={containerRef}
-      className="relative flex items-center gap-2 px-2.5 py-1.5 shrink-0 border-t border-[var(--bg-surface)] bg-[var(--bg-mantle)]"
+      // wmux-toolbar is a CSS size container: below the width threshold the
+      // label spans hide and the bar collapses to icon-only (titles keep the
+      // affordances discoverable). See globals.css.
+      className="wmux-toolbar relative flex items-center gap-2 px-2.5 py-1.5 shrink-0 border-t border-[var(--bg-surface)] bg-[var(--bg-mantle)]"
       data-testid="agent-toolbar"
     >
       <button className={`${btn} ${idle}`} disabled={disabled} onClick={handleAttach} title={t('toolbar.attach')}>
-        <IconPaperclip size={13} /> {t('toolbar.attach')}
+        <IconPaperclip size={13} /> <span className="wmux-toolbar-label">{t('toolbar.attach')}</span>
       </button>
-      <button className={`${btn} ${popover === 'explorer' ? active : idle}`} onClick={() => togglePopover('explorer')}>
-        <IconFolder size={13} /> {t('toolbar.fileExplorer')}
+      <button className={`${btn} ${popover === 'explorer' ? active : idle}`} onClick={() => togglePopover('explorer')} title={t('toolbar.fileExplorer')}>
+        <IconFolder size={13} /> <span className="wmux-toolbar-label">{t('toolbar.fileExplorer')}</span>
       </button>
-      <button className={`${btn} ${popover === 'snippets' ? active : idle}`} disabled={disabled} onClick={() => togglePopover('snippets')}>
-        <IconStar size={13} /> {t('toolbar.snippets')}
+      <button className={`${btn} ${popover === 'snippets' ? active : idle}`} disabled={disabled} onClick={() => togglePopover('snippets')} title={t('toolbar.snippets')}>
+        <IconStar size={13} /> <span className="wmux-toolbar-label">{t('toolbar.snippets')}</span>
       </button>
-      <button className={`${btn} ${popover === 'rich' ? active : idle}`} disabled={disabled} onClick={() => togglePopover('rich')}>
-        <IconKeyboard size={13} /> {t('toolbar.richInput')}
-        <kbd className="ml-1 px-1 rounded border border-[var(--bg-overlay)] text-[9px] leading-tight opacity-60 font-sans">{window.electronAPI?.platform === 'darwin' ? '⌘G' : 'Ctrl G'}</kbd>
+      <button className={`${btn} ${popover === 'rich' ? active : idle}`} disabled={disabled} onClick={() => togglePopover('rich')} title={t('toolbar.richInput')}>
+        <IconKeyboard size={13} /> <span className="wmux-toolbar-label">{t('toolbar.richInput')}</span>
+        <kbd className="wmux-toolbar-label ml-1 px-1 rounded border border-[var(--bg-overlay)] text-[9px] leading-tight opacity-60 font-sans">{window.electronAPI?.platform === 'darwin' ? '⌘G' : 'Ctrl G'}</kbd>
       </button>
       <button
         className={`${btn} ${showFanOut ? active : idle}`}
@@ -133,7 +136,7 @@ export default function AgentToolbar() {
         title="Fan-out — 프롬프트 1개 → N 격리 태스크"
         data-testid="fanout-button"
       >
-        <IconSparkles size={13} /> Fan-out
+        <IconSparkles size={13} /> <span className="wmux-toolbar-label">Fan-out</span>
       </button>
       <button
         className={`${btn} ${idle}`}
@@ -141,12 +144,12 @@ export default function AgentToolbar() {
         title="Broadcast — 현재 워크스페이스의 모든 터미널 페인에 같은 텍스트(격리 없음)"
         data-testid="broadcast-button"
       >
-        Broadcast
+        <IconUsers size={13} /> <span className="wmux-toolbar-label">Broadcast</span>
       </button>
       <div className="flex-1" />
       {disabled && <span className="text-[10px] text-[var(--text-muted)]">{t('toolbar.noTerminal')}</span>}
       <button className={`${btn} ${idle}`} disabled={disabled} onClick={handleNew} title={t('toolbar.new')}>
-        <IconSparkles size={13} /> {t('toolbar.new')}
+        <IconSparkles size={13} /> <span className="wmux-toolbar-label">{t('toolbar.new')}</span>
       </button>
 
       {popover === 'explorer' && <FileExplorerPopover />}

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -604,6 +604,20 @@ button {
   --border-soft: color-mix(in srgb, var(--bg-surface) 60%, transparent);
 }
 
+/* Agent toolbar is a size container: when the terminal-grid column gets
+ * narrow (small window, dock open, sidebar open), the button labels hide and
+ * the bar collapses to icon-only. The buttons keep their title tooltips, so
+ * nothing becomes undiscoverable — it just stops clipping. */
+.wmux-toolbar {
+  container-type: inline-size;
+  container-name: wmux-toolbar;
+}
+@container wmux-toolbar (max-width: 620px) {
+  .wmux-toolbar-label {
+    display: none;
+  }
+}
+
 .sidebar-row {
   transition: background-color 150ms ease, color 150ms ease;
 }


### PR DESCRIPTION
## What

Owner asked whether the bottom toolbar buttons hide or respond to width. They did neither: a fixed flex row that clipped labels mid-word ('Snippe...', 'Bro...') whenever the dock/sidebar squeezed the terminal column.

- The toolbar is now a **CSS size container** (`container-type: inline-size`); below **620px** container width the label spans hide and the bar collapses to **icon-only**.
- Every button keeps (or gained) a `title` tooltip, so nothing becomes undiscoverable — explorer/snippets/rich-input gained theirs, and **Broadcast gained an icon** (it was text-only and would have vanished).
- Container query, not media query: it reacts to the actual column width (dock open, sidebar open, small window), not the window size.

## Testing

- Typecheck clean.
- Live check on an isolated dev instance: at 223px container width `.wmux-toolbar-label` computes `display: none` and the row renders as a clean icon strip (screenshot in session).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive agent toolbar behavior that hides text labels at narrower widths while preserving icons and tooltips.
  * Standardized toolbar controls with consistent icons and labels, including the Broadcast action.
* **Style**
  * Improved toolbar presentation and sizing behavior for compact layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->