### PR TITLE
fix(design): align the top-chrome hairline (pane strip ↔ deck)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The hairline across the top of the window now lines up.** The pane tab strip's bottom border used a slightly different (more opaque) tone than the deck tabs beside it, and sat 1px lower — so the thin line under the tabs looked like it changed color and broke where the terminal meets the orchestrator panel. Both now share the same soft hairline at the same height (and a redundant double-line under each pane's top edge is gone); the focused pane still gets its amber underline on top.
+
 ### Changed
 
 - **Color-discipline pass across the shell: one amber, and it only ever means "here."** The status lights now speak one consistent language everywhere (sidebar, pane tabs, Fleet roster): amber = running, green = done, **red = needs you** (this last one was wrongly amber before), gray = idle — and a running agent is no longer the same green as a finished one. Amber stopped leaking onto things that aren't "live or focused": notification/unread counts, the git-branch glyph, the orchestrator's name label, fan-out and reply chips, and the reboot "resume" pill are all quiet now, with the accent appearing on hover instead. A couple of stray emoji in the chrome (the 🔔 on a workspace's last-notification line, the ⚙ settings button) became crisp monochrome icons, and popover corners were tightened to match the design system. The result is calmer: on a busy multi-agent screen, the few amber marks left are the ones that actually tell you where to look.

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -273,6 +273,13 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
         // focus is signaled by the amber underline on the tab strip (mock's
         // .pane.focused .pane-head treatment), not a loud full border box.
         border: `1px solid ${isActive ? 'var(--bg-overlay)' : 'var(--border-soft)'}`,
+        // No TOP border: it sat redundantly under the 36px titlebar's own bottom
+        // hairline (a double line) AND pushed the tab strip down 1px, so the
+        // pane's bottom-hairline seam landed 1px below the deck tabs' — the
+        // "the top line doesn't connect" report. Content now starts at the
+        // column top, aligned with the deck. The attention ring keeps its other
+        // three sides (its border-color override still applies).
+        borderTopWidth: 0,
       }}
       onClick={handleClick}
       data-onboarding-target="pane-area"

--- a/src/renderer/components/Pane/SurfaceTabs.tsx
+++ b/src/renderer/components/Pane/SurfaceTabs.tsx
@@ -172,9 +172,16 @@ export default function SurfaceTabs({
       // Bridge P1.6 — h-9 (36px chrome module): matches sidebar header/footer,
       // deck tabs, and the agent toolbar so all top/bottom hairlines align.
       className="flex items-center bg-[var(--bg-mantle)] border-b border-[var(--bg-surface)] h-9 overflow-x-auto"
-      // Focused pane = amber underline under the strip (inset so it never
-      // shifts layout) — the single focus signal in the design system.
-      style={paneActive ? { boxShadow: 'inset 0 -2px 0 var(--accent-cursor)' } : undefined}
+      // borderColor → --border-soft so this strip's bottom hairline matches the
+      // deck tabs / sidebar / titlebar seams (they all override to border-soft;
+      // this one was left on the opaque --bg-surface, so the top-chrome line
+      // changed color at the pane↔deck seam). Focused pane adds the amber
+      // underline on top (inset so it never shifts layout) — the single focus
+      // signal in the design system.
+      style={{
+        borderColor: 'var(--border-soft)',
+        ...(paneActive ? { boxShadow: 'inset 0 -2px 0 var(--accent-cursor)' } : {}),
+      }}
       data-pane-tabs-active={paneActive ? 'true' : undefined}
       {...tokenAttrs('bgMantle', 'bg')}
       {...tokenAttrs('bgSurface', 'border')}


### PR DESCRIPTION
The thin line under the top tabs "changed color and didn't connect" at the seam where the terminal meets the orchestrator panel (owner report, screenshot). Two causes, both fixed:

1. **Color** — the pane tab strip's bottom border was left on the opaque `--bg-surface`, while every other chrome seam (deck tabs, sidebar, titlebar) overrides to `--border-soft`. Added the same override so the hairline is one tone across all columns.
2. **Alignment** — the pane wrapper's 1px **top** border pushed the tab strip down 1px (bottom seam at y+1 vs the deck tabs) and doubled up under the 36px titlebar's own bottom hairline. Dropped the pane top border (`borderTopWidth: 0`); the strip now starts at the column top and its bottom seam aligns. The attention ring keeps its other three sides.

Verified live over CDP: pane-strip bottom and deck-tabs bottom both at y=72 (`aligned=true`), hairline colors match (`--border-soft` on both), and the focused-pane amber underline still renders on top. Typecheck clean. No version bump; entry under `[Unreleased]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pane tab border rendering to remove a visible double-line seam.
  * Aligned the tab strip’s hairline with deck tabs for consistent color and positioning.
  * Preserved the focused-pane indicator while improving border consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->