### PR TITLE
fix(main): before-quit teardown이 예외로 hang되지 않게 try/catch로 감싸기

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Quitting no longer permanently freezes wmux (macOS).** If any step in the quit teardown (daemon disconnect, tray/pipe cleanup, etc.) threw, the app got stuck with zero windows and stopped responding to the Dock icon, relaunching, or `⌘⇥`-style activation — the only fix was `kill -9`. The teardown is now wrapped so a failure in one step can't block the rest of quitting.
 - **The hairline across the top of the window now lines up.** The pane tab strip's bottom border used a slightly different (more opaque) tone than the deck tabs beside it, and sat 1px lower — so the thin line under the tabs looked like it changed color and broke where the terminal meets the orchestrator panel. Both now share the same soft hairline at the same height (and a redundant double-line under each pane's top edge is gone); the focused pane still gets its amber underline on top.
 
 ### Changed

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1322,104 +1322,124 @@ app.on('before-quit', async (e) => {
     }
   }
 
-  cleanupHandlers();
-  disposeFirstRunHandlers();
-  disposeDeckHandler();
-  disposeHooksRpc();
-  disposeUsagePollerListener();
-  usagePoller.dispose();
-  // Tear down the respawn controller BEFORE the daemon-shutdown race so
-  // a daemon close during the race window can't trigger a respawn attempt
-  // while the rest of the app is exiting. `dispose()` only stops timers
-  // and detaches listeners — it does NOT call `onUninstall()`, so the
-  // shutdown-race path below remains the single authority for taking the
-  // client offline cleanly.
-  daemonRespawnController?.dispose();
-  daemonRespawnController = null;
+  // The entire teardown sequence below (through destroyTray()) is wrapped in
+  // try/catch as a single unit. Without it, an exception thrown by ANY of
+  // these dispose/stop calls would leave this async handler's promise
+  // rejected mid-sequence — meaning `app.quit()` below and the 1.5s
+  // force-exit fallback timer are never reached. Because `isQuitting` was
+  // already flipped to `true` above, the app would then be stuck forever:
+  // the 'second-instance' and 'activate' handlers both gate their
+  // window-recreate/focus logic on `if (isQuitting) return`, so a Dock
+  // click, a relaunch, or a taskbar click would silently no-op against a
+  // process that is alive but has zero windows and no way back — the only
+  // recovery is `kill -9`. Observed 2026-07-12 (macOS): the process sat
+  // wedged with 0 windows, unresponsive to `app.on('activate')`.
+  try {
+    cleanupHandlers();
+    disposeFirstRunHandlers();
+    disposeDeckHandler();
+    disposeHooksRpc();
+    disposeUsagePollerListener();
+    usagePoller.dispose();
+    // Tear down the respawn controller BEFORE the daemon-shutdown race so
+    // a daemon close during the race window can't trigger a respawn attempt
+    // while the rest of the app is exiting. `dispose()` only stops timers
+    // and detaches listeners — it does NOT call `onUninstall()`, so the
+    // shutdown-race path below remains the single authority for taking the
+    // client offline cleanly.
+    daemonRespawnController?.dispose();
+    daemonRespawnController = null;
 
-  // tmux-style persistence (the entire reason the daemon exists): a normal
-  // Quit must NOT kill the daemon. We DETACH — close our control socket and
-  // leave every live PTY session running inside the daemon. Watchdog keeps the
-  // daemon alive while sessions>0 (idle-shutdown only fires once the last pane
-  // is closed AND no client is attached — Watchdog.ts:159), and the next
-  // launch reconnects via ensureDaemon (ping → spawned:false) and
-  // AppLayout.reconcilePtys() reattaches each pane to its still-live session,
-  // running processes and all.
-  //
-  // Only an explicit "Shut down wmux (close all sessions)" from the tray flips
-  // fullShutdownRequested → the teardown branch: ask the daemon to shut down
-  // gracefully (it dumps RingBuffers + saves state), and if that RPC doesn't
-  // land in time, pid-kill it so a wedged daemon can't survive a teardown the
-  // user explicitly asked for.
-  //
-  // `clientAtQuit` captures the reference BEFORE any await: the daemon may
-  // close its socket mid-teardown, firing the module-level 'disconnected'
-  // handler that nulls `daemonClient`. Without a local capture the later
-  // `disconnect()` would deref null and the unhandled rejection could stall
-  // app.quit().
-  const clientAtQuit = daemonClient;
-  if (clientAtQuit?.isConnected) {
-    if (fullShutdownRequested) {
-      // Daemon-side hard timeout guard is 10 s; 8 s keeps us safely under it
-      // while giving large-session daemons room to flush RingBuffers.
-      const FULL_SHUTDOWN_TIMEOUT_MS = 8_000;
-      console.log(
-        `[Main] Full shutdown — racing daemon.shutdown (${FULL_SHUTDOWN_TIMEOUT_MS}ms budget)`,
-      );
-      logLine('info', 'main', 'full-shutdown: racing daemon.shutdown');
-      const shutdownStart = Date.now();
-      const race = await raceDaemonShutdown(clientAtQuit, FULL_SHUTDOWN_TIMEOUT_MS);
-      const elapsed = Date.now() - shutdownStart;
-      if (race.ok) {
-        console.log(`[Main] daemon.shutdown ack received (elapsed=${elapsed}ms)`);
-      } else {
-        console.warn(
-          `[Main] daemon.shutdown did not complete (elapsed=${elapsed}ms): ${race.error} — pid-kill backstop`,
+    // tmux-style persistence (the entire reason the daemon exists): a normal
+    // Quit must NOT kill the daemon. We DETACH — close our control socket and
+    // leave every live PTY session running inside the daemon. Watchdog keeps the
+    // daemon alive while sessions>0 (idle-shutdown only fires once the last pane
+    // is closed AND no client is attached — Watchdog.ts:159), and the next
+    // launch reconnects via ensureDaemon (ping → spawned:false) and
+    // AppLayout.reconcilePtys() reattaches each pane to its still-live session,
+    // running processes and all.
+    //
+    // Only an explicit "Shut down wmux (close all sessions)" from the tray flips
+    // fullShutdownRequested → the teardown branch: ask the daemon to shut down
+    // gracefully (it dumps RingBuffers + saves state), and if that RPC doesn't
+    // land in time, pid-kill it so a wedged daemon can't survive a teardown the
+    // user explicitly asked for.
+    //
+    // `clientAtQuit` captures the reference BEFORE any await: the daemon may
+    // close its socket mid-teardown, firing the module-level 'disconnected'
+    // handler that nulls `daemonClient`. Without a local capture the later
+    // `disconnect()` would deref null and the unhandled rejection could stall
+    // app.quit().
+    const clientAtQuit = daemonClient;
+    if (clientAtQuit?.isConnected) {
+      if (fullShutdownRequested) {
+        // Daemon-side hard timeout guard is 10 s; 8 s keeps us safely under it
+        // while giving large-session daemons room to flush RingBuffers.
+        const FULL_SHUTDOWN_TIMEOUT_MS = 8_000;
+        console.log(
+          `[Main] Full shutdown — racing daemon.shutdown (${FULL_SHUTDOWN_TIMEOUT_MS}ms budget)`,
         );
-        logLine('warn', 'main', `full-shutdown: daemon.shutdown timed out (${race.error}); invoking pid-kill backstop`);
-        const killed = killDaemonByPidFile();
-        logLine('warn', 'main', `full-shutdown: pid-kill backstop ${killed ? 'killed the daemon' : 'found no verified daemon to kill'}`);
+        logLine('info', 'main', 'full-shutdown: racing daemon.shutdown');
+        const shutdownStart = Date.now();
+        const race = await raceDaemonShutdown(clientAtQuit, FULL_SHUTDOWN_TIMEOUT_MS);
+        const elapsed = Date.now() - shutdownStart;
+        if (race.ok) {
+          console.log(`[Main] daemon.shutdown ack received (elapsed=${elapsed}ms)`);
+        } else {
+          console.warn(
+            `[Main] daemon.shutdown did not complete (elapsed=${elapsed}ms): ${race.error} — pid-kill backstop`,
+          );
+          logLine('warn', 'main', `full-shutdown: daemon.shutdown timed out (${race.error}); invoking pid-kill backstop`);
+          const killed = killDaemonByPidFile();
+          logLine('warn', 'main', `full-shutdown: pid-kill backstop ${killed ? 'killed the daemon' : 'found no verified daemon to kill'}`);
+        }
+      } else {
+        console.log('[Main] Quit — detaching from daemon; live sessions stay alive (tmux-style persistence)');
+        logLine('info', 'main', 'quit: detaching from daemon, sessions remain live (persistence)');
       }
+      // Detach our half of the control pipe in BOTH branches. In full-shutdown
+      // the daemon is already gone (RPC ack) or killed (backstop), so this just
+      // cleans up our socket; in the detach branch it is the whole operation.
+      // Best-effort — if the 'disconnected' handler already tore the socket
+      // down, disconnect() may throw; swallow it so the quit sequence proceeds.
+      try {
+        await clientAtQuit.disconnect();
+      } catch (err) {
+        console.warn('[Main] daemon disconnect threw (likely already torn down):', err);
+      }
+      daemonClient = null;
     } else {
-      console.log('[Main] Quit — detaching from daemon; live sessions stay alive (tmux-style persistence)');
-      logLine('info', 'main', 'quit: detaching from daemon, sessions remain live (persistence)');
+      // Local mode (daemon never connected): PTYs are children of main and die
+      // with us regardless — dispose explicitly for a clean exit. There is no
+      // persistence in local mode; that is the cost of running without a daemon.
+      ptyManager.disposeAll();
+      // Codex P2: an explicit "Shut down wmux (close all sessions)" must still
+      // tear down a daemon that is alive on disk even when main has NO live
+      // client to it — the daemon dropped/respawn-exhausted into local mode while
+      // daemon.pid still points at a live daemon. Without this the user's
+      // close-all request silently leaves that daemon and its PTYs running. The
+      // pid-kill is verify-before-kill (image + cmdline), so a recycled PID is
+      // never signalled. A normal Quit (fullShutdownRequested=false) still leaves
+      // any such daemon alone — that is the persistence promise.
+      if (fullShutdownRequested) {
+        const killed = killDaemonByPidFile();
+        logLine('warn', 'main', `full-shutdown (no live client): pid-kill backstop ${killed ? 'killed the daemon' : 'found no verified daemon to kill'}`);
+      }
     }
-    // Detach our half of the control pipe in BOTH branches. In full-shutdown
-    // the daemon is already gone (RPC ack) or killed (backstop), so this just
-    // cleans up our socket; in the detach branch it is the whole operation.
-    // Best-effort — if the 'disconnected' handler already tore the socket
-    // down, disconnect() may throw; swallow it so the quit sequence proceeds.
-    try {
-      await clientAtQuit.disconnect();
-    } catch (err) {
-      console.warn('[Main] daemon disconnect threw (likely already torn down):', err);
-    }
-    daemonClient = null;
-  } else {
-    // Local mode (daemon never connected): PTYs are children of main and die
-    // with us regardless — dispose explicitly for a clean exit. There is no
-    // persistence in local mode; that is the cost of running without a daemon.
-    ptyManager.disposeAll();
-    // Codex P2: an explicit "Shut down wmux (close all sessions)" must still
-    // tear down a daemon that is alive on disk even when main has NO live
-    // client to it — the daemon dropped/respawn-exhausted into local mode while
-    // daemon.pid still points at a live daemon. Without this the user's
-    // close-all request silently leaves that daemon and its PTYs running. The
-    // pid-kill is verify-before-kill (image + cmdline), so a recycled PID is
-    // never signalled. A normal Quit (fullShutdownRequested=false) still leaves
-    // any such daemon alone — that is the persistence promise.
-    if (fullShutdownRequested) {
-      const killed = killDaemonByPidFile();
-      logLine('warn', 'main', `full-shutdown (no live client): pid-kill backstop ${killed ? 'killed the daemon' : 'found no verified daemon to kill'}`);
-    }
-  }
 
-  claudeWorker.stop();
-  webviewCdpManager.disposeAll();
-  pipeServer.stop();
-  mcpRegistrar.unregister();
-  autoUpdater.stop();
-  destroyTray();
+    claudeWorker.stop();
+    webviewCdpManager.disposeAll();
+    pipeServer.stop();
+    mcpRegistrar.unregister();
+    autoUpdater.stop();
+    destroyTray();
+  } catch (err) {
+    // Whatever failed above, we still must reach app.quit() below — see the
+    // comment at the top of this try block for why a stuck teardown is
+    // unrecoverable without it.
+    console.error('[Main] before-quit teardown threw — continuing to quit anyway:', err);
+    logLine('error', 'main', `before-quit teardown threw: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+  }
 
   app.quit(); // re-trigger quit — isQuitting flag skips preventDefault
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1322,55 +1322,73 @@ app.on('before-quit', async (e) => {
     }
   }
 
-  // The entire teardown sequence below (through destroyTray()) is wrapped in
-  // try/catch as a single unit. Without it, an exception thrown by ANY of
-  // these dispose/stop calls would leave this async handler's promise
-  // rejected mid-sequence — meaning `app.quit()` below and the 1.5s
-  // force-exit fallback timer are never reached. Because `isQuitting` was
-  // already flipped to `true` above, the app would then be stuck forever:
-  // the 'second-instance' and 'activate' handlers both gate their
-  // window-recreate/focus logic on `if (isQuitting) return`, so a Dock
-  // click, a relaunch, or a taskbar click would silently no-op against a
-  // process that is alive but has zero windows and no way back — the only
-  // recovery is `kill -9`. Observed 2026-07-12 (macOS): the process sat
-  // wedged with 0 windows, unresponsive to `app.on('activate')`.
-  try {
-    cleanupHandlers();
-    disposeFirstRunHandlers();
-    disposeDeckHandler();
-    disposeHooksRpc();
-    disposeUsagePollerListener();
-    usagePoller.dispose();
-    // Tear down the respawn controller BEFORE the daemon-shutdown race so
-    // a daemon close during the race window can't trigger a respawn attempt
-    // while the rest of the app is exiting. `dispose()` only stops timers
-    // and detaches listeners — it does NOT call `onUninstall()`, so the
-    // shutdown-race path below remains the single authority for taking the
-    // client offline cleanly.
+  // Every teardown step below is ISOLATED in its own try/catch. Two guarantees
+  // ride on this:
+  //
+  //  1. app.quit() below and the 1.5s force-exit fallback timer must ALWAYS be
+  //     reached. If this async handler's promise rejected mid-sequence while
+  //     `isQuitting` is already `true`, the app wedges forever: the
+  //     'second-instance' and 'activate' handlers both early-return on
+  //     `if (isQuitting) return`, so a Dock click, relaunch, or taskbar click
+  //     silently no-ops against a process that is alive but has zero windows
+  //     and no way back — only `kill -9` recovers. Observed 2026-07-12 (macOS):
+  //     0 windows, unresponsive to `app.on('activate')`.
+  //
+  //  2. A single earlier disposer failure must NOT skip the daemon-shutdown /
+  //     pid-kill branch (Codex P1). An earlier version wrapped the whole
+  //     sequence in ONE try, so a throw from e.g. cleanupHandlers() jumped
+  //     straight to the catch and skipped daemon shutdown — an explicit
+  //     "Shut down wmux (close all sessions)" would then let the app exit with
+  //     the daemon + PTYs still running. Per-step isolation keeps the daemon
+  //     branch reachable no matter what the best-effort disposers do.
+  const safeStep = (label: string, fn: () => void): void => {
+    try {
+      fn();
+    } catch (err) {
+      console.error(`[Main] before-quit step "${label}" threw — continuing:`, err);
+      logLine('error', 'main', `before-quit step ${label} threw: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+    }
+  };
+
+  safeStep('cleanupHandlers', () => cleanupHandlers());
+  safeStep('disposeFirstRunHandlers', () => disposeFirstRunHandlers());
+  safeStep('disposeDeckHandler', () => disposeDeckHandler());
+  safeStep('disposeHooksRpc', () => disposeHooksRpc());
+  safeStep('disposeUsagePollerListener', () => disposeUsagePollerListener());
+  safeStep('usagePoller.dispose', () => usagePoller.dispose());
+  // Tear down the respawn controller BEFORE the daemon-shutdown race so
+  // a daemon close during the race window can't trigger a respawn attempt
+  // while the rest of the app is exiting. `dispose()` only stops timers
+  // and detaches listeners — it does NOT call `onUninstall()`, so the
+  // shutdown-race path below remains the single authority for taking the
+  // client offline cleanly.
+  safeStep('daemonRespawnController.dispose', () => {
     daemonRespawnController?.dispose();
     daemonRespawnController = null;
+  });
 
-    // tmux-style persistence (the entire reason the daemon exists): a normal
-    // Quit must NOT kill the daemon. We DETACH — close our control socket and
-    // leave every live PTY session running inside the daemon. Watchdog keeps the
-    // daemon alive while sessions>0 (idle-shutdown only fires once the last pane
-    // is closed AND no client is attached — Watchdog.ts:159), and the next
-    // launch reconnects via ensureDaemon (ping → spawned:false) and
-    // AppLayout.reconcilePtys() reattaches each pane to its still-live session,
-    // running processes and all.
-    //
-    // Only an explicit "Shut down wmux (close all sessions)" from the tray flips
-    // fullShutdownRequested → the teardown branch: ask the daemon to shut down
-    // gracefully (it dumps RingBuffers + saves state), and if that RPC doesn't
-    // land in time, pid-kill it so a wedged daemon can't survive a teardown the
-    // user explicitly asked for.
-    //
-    // `clientAtQuit` captures the reference BEFORE any await: the daemon may
-    // close its socket mid-teardown, firing the module-level 'disconnected'
-    // handler that nulls `daemonClient`. Without a local capture the later
-    // `disconnect()` would deref null and the unhandled rejection could stall
-    // app.quit().
-    const clientAtQuit = daemonClient;
+  // tmux-style persistence (the entire reason the daemon exists): a normal
+  // Quit must NOT kill the daemon. We DETACH — close our control socket and
+  // leave every live PTY session running inside the daemon. Watchdog keeps the
+  // daemon alive while sessions>0 (idle-shutdown only fires once the last pane
+  // is closed AND no client is attached — Watchdog.ts:159), and the next
+  // launch reconnects via ensureDaemon (ping → spawned:false) and
+  // AppLayout.reconcilePtys() reattaches each pane to its still-live session,
+  // running processes and all.
+  //
+  // Only an explicit "Shut down wmux (close all sessions)" from the tray flips
+  // fullShutdownRequested → the teardown branch: ask the daemon to shut down
+  // gracefully (it dumps RingBuffers + saves state), and if that RPC doesn't
+  // land in time, pid-kill it so a wedged daemon can't survive a teardown the
+  // user explicitly asked for.
+  //
+  // `clientAtQuit` captures the reference BEFORE any await: the daemon may
+  // close its socket mid-teardown, firing the module-level 'disconnected'
+  // handler that nulls `daemonClient`. Without a local capture the later
+  // `disconnect()` would deref null and the unhandled rejection could stall
+  // app.quit().
+  const clientAtQuit = daemonClient;
+  try {
     if (clientAtQuit?.isConnected) {
       if (fullShutdownRequested) {
         // Daemon-side hard timeout guard is 10 s; 8 s keeps us safely under it
@@ -1426,20 +1444,27 @@ app.on('before-quit', async (e) => {
         logLine('warn', 'main', `full-shutdown (no live client): pid-kill backstop ${killed ? 'killed the daemon' : 'found no verified daemon to kill'}`);
       }
     }
-
-    claudeWorker.stop();
-    webviewCdpManager.disposeAll();
-    pipeServer.stop();
-    mcpRegistrar.unregister();
-    autoUpdater.stop();
-    destroyTray();
   } catch (err) {
-    // Whatever failed above, we still must reach app.quit() below — see the
-    // comment at the top of this try block for why a stuck teardown is
-    // unrecoverable without it.
-    console.error('[Main] before-quit teardown threw — continuing to quit anyway:', err);
-    logLine('error', 'main', `before-quit teardown threw: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+    console.error('[Main] before-quit daemon teardown threw — continuing to quit:', err);
+    logLine('error', 'main', `before-quit daemon teardown threw: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+    // Close-all must still complete even if the graceful path above threw: a
+    // verified pid-kill is the last-resort backstop so an explicit shutdown
+    // can't leave the daemon + PTYs running. verify-before-kill (image +
+    // cmdline), and a normal Quit skips this entirely.
+    if (fullShutdownRequested) {
+      safeStep('full-shutdown pid-kill (post-throw backstop)', () => {
+        const killed = killDaemonByPidFile();
+        logLine('warn', 'main', `full-shutdown: post-throw pid-kill backstop ${killed ? 'killed the daemon' : 'found no verified daemon to kill'}`);
+      });
+    }
   }
+
+  safeStep('claudeWorker.stop', () => claudeWorker.stop());
+  safeStep('webviewCdpManager.disposeAll', () => webviewCdpManager.disposeAll());
+  safeStep('pipeServer.stop', () => pipeServer.stop());
+  safeStep('mcpRegistrar.unregister', () => mcpRegistrar.unregister());
+  safeStep('autoUpdater.stop', () => autoUpdater.stop());
+  safeStep('destroyTray', () => destroyTray());
 
   app.quit(); // re-trigger quit — isQuitting flag skips preventDefault
 


### PR DESCRIPTION
## Summary

- `Closes #419` — macOS에서 Dock 클릭/재실행/activate가 전부 씹히고 `kill -9`만 먹히던 hang의 근본원인 수정
- `app.on('before-quit', ...)`에서 `isQuitting = true` 설정 후 실행되는 teardown 시퀀스(`cleanupHandlers()` ~ `destroyTray()`, 10개 넘는 dispose/stop 호출)가 try/catch 없이 순차 실행되고 있었음
- 이 중 하나라도 예외를 던지면 async 핸들러가 그 지점에서 멈추고, 뒤따르는 `app.quit()` 재호출과 1.5초 force-exit fallback 둘 다 영원히 도달 못 함
- `second-instance`(272줄)와 `activate`(1500줄) 핸들러 둘 다 `if (isQuitting) return;` 가드가 있어서, 이 상태에 빠지면 Dock 클릭·재실행·activate 전부 무반응 — 실사용 중 macOS에서 재현(0 windows, tray 응답 없음, 크래시 로그 없음, `kill -9`로만 복구)
- 수정: teardown 전체를 try/catch로 감싸서, 어떤 dispose가 실패하든 반드시 `app.quit()` + force-exit fallback까지는 도달하도록 함. 실패는 `console.error` + `logLine('error', ...)`로 로깅

## Scope

- 파일 1개(`src/main/index.ts`) — 로직 재배치(들여쓰기 변경 포함) + try/catch 추가, 기존 동작·주석·순서는 그대로 보존
- `CHANGELOG.md`에 `[Unreleased]/### Fixed` 항목 추가 (저장소 정책상 `package.json` 버전은 건드리지 않음)

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] `npx eslint src/main/index.ts` — 기존 14개(10 errors, 4 warnings)와 동일, 신규 이슈 0개
- [x] `npx vitest run src/main/__tests__/beforeQuitDisconnectRace.test.ts src/main/__tests__/sessionEnd.daemonShutdown.test.ts src/main/__tests__/daemonShutdownRace.test.ts` — 18/18 통과
- [x] `npx vitest run src/main/` — 144 files / 1730 tests 전부 통과
- [ ] 실제 renderer 크래시를 강제로 재현해 teardown 예외 상황에서도 quit이 끝까지 도달하는지 수동 검증 (권장, 미실시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS shutdown reliability to prevent the app from becoming permanently frozen with no visible windows.
  * Ensured cleanup continues even when an individual shutdown step fails.
  * Added a fallback to terminate the daemon when graceful shutdown does not complete within the expected time.
  * Prevented shutdown failures from requiring forceful process termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->