### PR TITLE
chore(release): v3.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.21.0] — 2026-07-13
+
 ### Added
 
 - **The loop setup grew into a real editor — in a dialog that actually fits, with steps that can pick from your agent's skills.** "Start a loop" now opens a proper setup dialog instead of a cramped inline form (whose Start button could overflow right off the dock at narrow widths — that's fixed by design now). The dialog adds a third axis to a loop: alongside the objective (why) and the done-when checklist (when to stop), you can now write **steps** — the procedure the orchestrator should follow on each iteration. Type `/` in a step and it autocompletes from your project's and your user-level Claude skills and commands (`.claude/skills`, `.claude/commands`), with project entries shadowing user ones — running a skill step means the orchestrator types that command into the pane, same as you would. Steps ride into every loop turn as numbered, trusted context, and loops saved before this release keep working unchanged. The dock keeps only the compact status card once a loop runs.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.20.0 sources.** This file is produced by
+> **Generated from wmux v3.21.0 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.20.0",
+  "version": "3.21.0",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Release cut for **v3.21.0**.

- `package.json`: 3.20.0 → 3.21.0
- `CHANGELOG.md`: `[Unreleased]` → `[3.21.0] — 2026-07-13`
- `docs/api/reference.md`: regenerated (bakes v3.21.0 — CI drift guard)

Highlights since v3.20.0 (see CHANGELOG for the full list): the git/GitHub surface — workspace diff view, Git tab with worktree GUI, PR list + comments (GitHub via `gh`, GitLab via `glab` incl. self-hosted), ask-the-orchestrator-about-a-hunk — plus the loop setup modal with a skill picker, on top of the event-push wake / one-click loop and Command Deck work already accumulated.

Merge, then the `v3.21.0` tag push triggers the release build (installer + Chocolatey + winget).