### PR TITLE
fix: hook storm from orchestrator turns, auto-wake kill switch, picker anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Auto-wake is now a switch you own.** The orchestrator's event-push wakes (the automatic "here's what your agents just did" summaries) each spend a real model turn — and until now there was no way to turn them off. Settings grows an "Auto-wake on pane events" toggle: switch it off and unrequested summary turns stop entirely, saving the tokens. Loops are unaffected — a running loop keeps waking through its own iteration budget, because you explicitly started it. The switch lives next to the orchestrator's other settings and applies immediately, no restart needed.
+
+### Fixed
+
+- **The new-workspace layout menu opens under the + button again — not across the window.** Since the + button moved into the titlebar, its layout dropdown (Empty / Horizontal Split / …) kept its old sidebar anchoring and opened at the far right edge of the window, floating over the orchestrator dock. It now anchors directly beneath the + button, clamped to stay inside the window.
+
+- **The orchestrator no longer re-fires your own hooks on every tool call — a major source of background CPU churn.** The orchestrator's turns silently loaded your user-level Claude settings, including the wmux plugin's own hooks — so each tool call inside an orchestrator turn spawned an extra bridge process (~110ms of CPU each), and the orchestrator's turn-end looked like a phantom agent event. With auto-wake summaries running, this compounded into a steady process storm that could make the whole app stutter. Orchestrator turns now load no filesystem settings at all; their behavior was always defined explicitly in code, so nothing else changes.
+
+### Changed
+
+- **Korean UI: "오케스트레이터" is now just "agent".** The transliterated word overflowed tabs and labels; the Korean locale now uses the untranslated term "agent" everywhere the orchestrator is named (pane agents remain "에이전트").
+
 ## [3.21.0] — 2026-07-13
 
 ### Added

--- a/src/main/deck/ClaudeSdkAdapter.ts
+++ b/src/main/deck/ClaudeSdkAdapter.ts
@@ -485,6 +485,18 @@ export class ClaudeSdkAdapter implements BrainAdapter {
       },
       // Only the wmux MCP server; no ambient project/user MCP config is loaded.
       strictMcpConfig: true,
+      // Load NO filesystem settings. The SDK default is
+      // ['user','project','local'] (verified in sdk.mjs), which made every
+      // brain turn inherit the USER'S hooks — including the wmux Claude
+      // plugin's own PostToolUse/Stop bridge. Net effect: each orchestrator
+      // tool call spawned a ~110ms node bridge process (hook storm, CPU
+      // stutter under event-push wakes), the brain's Stop re-entered
+      // hooks.signal as a phantom agent event (self-wake feedback risk when
+      // main inherits WMUX_* env in dev), and the owner's personal hooks ran
+      // inside brain turns. The brain's contract is fully explicit already:
+      // systemPrompt is injected manually, tools via allowedTools/
+      // disallowedTools/canUseTool, MCP via strictMcpConfig.
+      settingSources: [],
       // P3a: claude keys its session transcripts by cwd, and a packaged
       // Electron app's process.cwd() is the per-version install folder
       // (Squirrel app-x.y.z) — resume would silently break on every update.

--- a/src/main/deck/CommanderEventCoalescer.ts
+++ b/src/main/deck/CommanderEventCoalescer.ts
@@ -108,6 +108,11 @@ export interface CoalescerDeps {
    *  loop needs dozens of iterations, not the small ambient default. Read
    *  fresh at every flush so start/stop applies immediately. */
   getLoop?: (workspaceId: string) => CoalescerLoopHint | null;
+  /** Global auto-wake switch (deck-autowake.json). When it reads false, an
+   *  AMBIENT flush is suppressed and its events consumed — but a RUNNING loop
+   *  still wakes (explicit opt-in, bounded by its own iteration budget).
+   *  Absent/throwing resolves to enabled (the shipped behavior). */
+  isAutoWakeEnabled?: () => boolean;
   now?: () => number;
   setTimeoutFn?: typeof setTimeout;
   clearTimeoutFn?: typeof clearTimeout;
@@ -299,6 +304,15 @@ export class CommanderEventCoalescer {
     }
   }
 
+  /** The global switch, never-throw. Missing dep or a throwing read = enabled. */
+  private safeAutoWakeEnabled(): boolean {
+    try {
+      return this.deps.isAutoWakeEnabled?.() ?? true;
+    } catch {
+      return true;
+    }
+  }
+
   private safeAutonomy(workspaceId: string): WorkspaceAutonomy {
     try {
       return this.deps.getAutonomy(workspaceId);
@@ -312,6 +326,19 @@ export class CommanderEventCoalescer {
     this.clearDebounce(st);
     const events = this.collectBuffer(st);
     if (events.length === 0) {
+      st.phase = 'idle';
+      return;
+    }
+    // Global auto-wake switch: OFF suppresses AMBIENT wakes. The buffered
+    // events are CONSUMED (watermark advanced) rather than held, so turning
+    // the switch back on later never replays a stale backlog. A RUNNING loop
+    // overrides the switch — the loop is an explicit opt-in that depends on
+    // these wakes and is already bounded by its own iteration budget.
+    const loopHint = this.safeGetLoop(workspaceId);
+    if (!this.safeAutoWakeEnabled() && loopHint?.running !== true) {
+      const maxSeq = events[events.length - 1].seq;
+      if (maxSeq > st.watermark) st.watermark = maxSeq;
+      this.pruneBuffer(st, maxSeq);
       st.phase = 'idle';
       return;
     }
@@ -332,12 +359,11 @@ export class CommanderEventCoalescer {
     // until the send is ACCEPTED — a busy reject must not lose events.
     const snapshotMaxSeq = events[events.length - 1].seq;
     const autonomy = this.safeAutonomy(workspaceId);
-    const loop = this.safeGetLoop(workspaceId);
     const prompt = buildEventPrompt(
       events,
       autonomy,
       { remaining: budget - st.autoWakesUsed, total: budget },
-      { loopRunning: loop?.running === true },
+      { loopRunning: loopHint?.running === true },
     );
     st.phase = 'send-pending';
 

--- a/src/main/deck/__tests__/ClaudeSdkAdapter.test.ts
+++ b/src/main/deck/__tests__/ClaudeSdkAdapter.test.ts
@@ -158,6 +158,28 @@ describe('ClaudeSdkAdapter', () => {
     }
   });
 
+  it('loads NO filesystem settings (settingSources: []) — brain turns must not inherit user hooks', async () => {
+    // RCA 2026-07-13 (stutter report): the SDK default is
+    // ['user','project','local'], so every brain turn loaded the user's
+    // ~/.claude settings INCLUDING the wmux plugin's PostToolUse/Stop hooks —
+    // each brain tool call spawned a ~110ms node bridge process and the
+    // brain's own Stop re-entered hooks.signal as a phantom agent event.
+    // The brain's contract is fully explicit (systemPrompt / allowedTools /
+    // canUseTool / strictMcpConfig); it must load nothing from disk.
+    const calls: Array<{ options: Record<string, unknown> }> = [];
+    const adapter = new ClaudeSdkAdapter({
+      queryFn: (p) => {
+        calls.push(p as { options: Record<string, unknown> });
+        return fakeHandle([{ type: 'result', subtype: 'success', session_id: 's' }]);
+      },
+      mcpBundlePath: '/fake/mcp.js',
+      loadMemory: () => '',
+    });
+    adapter.start({ systemPrompt: 'SYS' });
+    await collect(adapter.send('go'));
+    expect(calls[0].options.settingSources).toEqual([]);
+  });
+
   it('installs a canUseTool sandbox that allows own-memory Write and denies the rest', async () => {
     const calls: Array<{ options: Record<string, unknown> }> = [];
     // Inject a hermetic memory root so the sandbox never touches ~/.wmux.

--- a/src/main/deck/__tests__/CommanderEventCoalescer.test.ts
+++ b/src/main/deck/__tests__/CommanderEventCoalescer.test.ts
@@ -34,6 +34,8 @@ function mk(opts: {
   debounceMs?: number;
   autonomy?: WorkspaceAutonomy;
   loop?: { running: boolean; iterations: number } | null;
+  /** Global auto-wake switch dep — omitted = enabled (shipped behavior). */
+  isAutoWakeEnabled?: () => boolean;
 }): Harness {
   let busy = false;
   let runResult: { ok: boolean; code?: string } = { ok: true };
@@ -47,6 +49,7 @@ function mk(opts: {
     isBusy: () => busy,
     getAutonomy: () => opts.autonomy ?? { ...DEFAULT_AUTONOMY },
     getLoop: () => loop,
+    ...(opts.isAutoWakeEnabled ? { isAutoWakeEnabled: opts.isAutoWakeEnabled } : {}),
     debounceMs: opts.debounceMs ?? 1_000,
     wakeBudget: opts.wakeBudget ?? 5,
   });
@@ -377,5 +380,74 @@ describe('buildEventPrompt — untrusted structured block + fail-closed approval
       budget,
     );
     expect(on).toContain('follow-up instruction');
+  });
+});
+
+describe('CommanderEventCoalescer — global auto-wake switch', () => {
+  it('switch OFF (no loop) → no wake; events are CONSUMED (watermark advanced)', async () => {
+    const h = makeHarness({ isAutoWakeEnabled: () => false });
+    h.c.push(stop(7, 'ptyA'));
+    await vi.advanceTimersByTimeAsync(5_000);
+    await settle();
+    expect(h.prompts).toHaveLength(0);
+    expect(h.c.getPhase('ws-1')).toBe('idle');
+    // Consumed, not held: re-enabling must not replay a stale backlog.
+    expect(h.c.getWatermark('ws-1')).toBe(7);
+  });
+
+  it('switch OFF but a loop is RUNNING → the wake still fires (explicit opt-in)', async () => {
+    const h = makeHarness({
+      isAutoWakeEnabled: () => false,
+      loop: { running: true, iterations: 10 },
+    });
+    h.c.push(stop(1));
+    await vi.advanceTimersByTimeAsync(5_000);
+    await settle();
+    expect(h.prompts).toHaveLength(1);
+    expect(h.prompts[0].prompt).toContain('loop-mode: ACTIVE');
+  });
+
+  it('switch OFF with a PAUSED loop → suppressed like ambient', async () => {
+    const h = makeHarness({
+      isAutoWakeEnabled: () => false,
+      loop: { running: false, iterations: 10 },
+    });
+    h.c.push(stop(1));
+    await vi.advanceTimersByTimeAsync(5_000);
+    await settle();
+    expect(h.prompts).toHaveLength(0);
+  });
+
+  it('a THROWING switch read resolves to enabled (shipped behavior)', async () => {
+    const h = makeHarness({
+      isAutoWakeEnabled: () => {
+        throw new Error('torn read');
+      },
+    });
+    h.c.push(stop(1));
+    await vi.advanceTimersByTimeAsync(5_000);
+    await settle();
+    expect(h.prompts).toHaveLength(1);
+  });
+
+  it('turning the switch back ON wakes only for NEW events', async () => {
+    let enabled = false;
+    const h = makeHarness({ isAutoWakeEnabled: () => enabled });
+    h.c.push(stop(3));
+    await vi.advanceTimersByTimeAsync(5_000);
+    await settle();
+    expect(h.prompts).toHaveLength(0);
+
+    enabled = true;
+    h.c.push(stop(3)); // same seq — at/below watermark, dropped
+    await vi.advanceTimersByTimeAsync(5_000);
+    await settle();
+    expect(h.prompts).toHaveLength(0);
+
+    h.c.push(stop(4));
+    await vi.advanceTimersByTimeAsync(5_000);
+    await settle();
+    expect(h.prompts).toHaveLength(1);
+    expect(h.prompts[0].prompt).toContain('seq=4');
   });
 });

--- a/src/main/deck/__tests__/deckAutoWakeStore.test.ts
+++ b/src/main/deck/__tests__/deckAutoWakeStore.test.ts
@@ -1,0 +1,51 @@
+// Unit tests for the global auto-wake switch store: default-ON resolution
+// (missing/corrupt/wrong-shape file), round-trip persistence, and non-boolean
+// coercion on write.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  DEFAULT_AUTO_WAKE_ENABLED,
+  loadAutoWakeEnabled,
+  setAutoWakeEnabled,
+  getDeckAutoWakePath,
+} from '../deckAutoWakeStore';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-deck-autowake-'));
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('deckAutoWakeStore', () => {
+  it('missing file resolves to the default (enabled — the shipped behavior)', () => {
+    expect(DEFAULT_AUTO_WAKE_ENABLED).toBe(true);
+    expect(loadAutoWakeEnabled(dir)).toBe(true);
+  });
+
+  it('round-trips OFF and back ON through the file', async () => {
+    expect(await setAutoWakeEnabled(false, dir)).toBe(false);
+    expect(loadAutoWakeEnabled(dir)).toBe(false);
+    expect(await setAutoWakeEnabled(true, dir)).toBe(true);
+    expect(loadAutoWakeEnabled(dir)).toBe(true);
+  });
+
+  it('corrupt / wrong-shape file resolves to enabled (never throws)', () => {
+    fs.writeFileSync(getDeckAutoWakePath(dir), 'CORRUPT{', 'utf8');
+    expect(loadAutoWakeEnabled(dir)).toBe(true);
+    fs.writeFileSync(getDeckAutoWakePath(dir), JSON.stringify([false]), 'utf8');
+    expect(loadAutoWakeEnabled(dir)).toBe(true);
+    fs.writeFileSync(getDeckAutoWakePath(dir), JSON.stringify({ enabled: 'no' }), 'utf8');
+    expect(loadAutoWakeEnabled(dir)).toBe(true);
+  });
+
+  it('coerces a non-boolean write to false (only EXACTLY true enables)', async () => {
+    expect(await setAutoWakeEnabled('yes' as unknown as boolean, dir)).toBe(false);
+    expect(loadAutoWakeEnabled(dir)).toBe(false);
+  });
+});

--- a/src/main/deck/deckAutoWakeStore.ts
+++ b/src/main/deck/deckAutoWakeStore.ts
@@ -1,0 +1,49 @@
+// ─── Command Deck — global auto-wake switch (event-push kill switch) ─────────
+//
+// The event-push coalescer wakes a workspace's brain on pane lifecycle events
+// (agent.stop / agent.awaiting_input) — each wake is a real SDK turn that
+// costs tokens. This store is the ONE global off switch for those ambient
+// wakes (owner request 2026-07-13: unrequested summary turns burn tokens).
+//
+// Scope contract (enforced in CommanderEventCoalescer.attemptFlush):
+//   - OFF suppresses AMBIENT wakes only. A RUNNING loop still wakes — a loop
+//     is an explicit user opt-in whose iteration budget already bounds it,
+//     and silently starving it would break the loop feature.
+//   - Schedules are untouched (explicit user requests, different plumbing).
+//
+// Default is ON (missing/corrupt file → enabled): this preserves the shipped
+// behavior; the toggle exists to opt OUT. Same storage shape as
+// deck-autonomy.json (atomic JSON in the wmux data dir, WMUX_DATA_SUFFIX
+// isolated), and the same never-throw posture.
+
+import path from 'node:path';
+import { getWmuxDir } from '../../daemon/config';
+import { atomicReadJSONSync, atomicWriteJSON } from '../../daemon/util/atomicWrite';
+
+export const DEFAULT_AUTO_WAKE_ENABLED = true;
+
+export function getDeckAutoWakePath(dir: string = getWmuxDir()): string {
+  return path.join(dir, 'deck-autowake.json');
+}
+
+/** Read the global switch. Anything uncertain (missing file, torn JSON, wrong
+ *  shape) resolves to the default (enabled). Never throws. */
+export function loadAutoWakeEnabled(dir?: string): boolean {
+  try {
+    const raw = atomicReadJSONSync<unknown>(getDeckAutoWakePath(dir));
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      return DEFAULT_AUTO_WAKE_ENABLED;
+    }
+    const enabled = (raw as Record<string, unknown>).enabled;
+    return typeof enabled === 'boolean' ? enabled : DEFAULT_AUTO_WAKE_ENABLED;
+  } catch {
+    return DEFAULT_AUTO_WAKE_ENABLED;
+  }
+}
+
+/** Persist the global switch. Returns the value now in force. */
+export async function setAutoWakeEnabled(enabled: boolean, dir?: string): Promise<boolean> {
+  const next = enabled === true;
+  await atomicWriteJSON(getDeckAutoWakePath(dir), { enabled: next });
+  return next;
+}

--- a/src/main/ipc/handlers/deck.handler.ts
+++ b/src/main/ipc/handlers/deck.handler.ts
@@ -38,6 +38,7 @@ import {
   setWorkspaceAutonomy,
   DEFAULT_AUTONOMY,
 } from '../../deck/deckAutonomyStore';
+import { loadAutoWakeEnabled, setAutoWakeEnabled } from '../../deck/deckAutoWakeStore';
 import {
   loadWorkspaceLoopState,
   renderLoopStateBlock,
@@ -303,6 +304,9 @@ export function registerDeckHandler(
       const loop = loadWorkspaceLoopState(workspaceId);
       return loop ? { running: loop.status === 'running', iterations: loop.iterations } : null;
     },
+    // Global kill switch (Settings): OFF drops ambient wakes; running loops
+    // still wake. Read fresh at every flush so the toggle applies immediately.
+    isAutoWakeEnabled: () => loadAutoWakeEnabled(),
   });
   const offBus = eventBus.subscribe((ev) => {
     if (ev.type !== 'agent.lifecycle') return;
@@ -654,6 +658,30 @@ export function registerDeckHandler(
     }),
   );
 
+  // ── Global auto-wake switch (Settings toggle) ─────────────────────────────
+  ipcMain.removeHandler(IPC.DECK_AUTOWAKE_GET);
+  ipcMain.handle(
+    IPC.DECK_AUTOWAKE_GET,
+    wrapHandler(IPC.DECK_AUTOWAKE_GET, async (): Promise<{ enabled: boolean }> => {
+      return { enabled: loadAutoWakeEnabled() };
+    }),
+  );
+
+  ipcMain.removeHandler(IPC.DECK_AUTOWAKE_SET);
+  ipcMain.handle(
+    IPC.DECK_AUTOWAKE_SET,
+    wrapHandler(IPC.DECK_AUTOWAKE_SET, async (
+      _event: Electron.IpcMainInvokeEvent,
+      raw: unknown,
+    ): Promise<{ enabled: boolean }> => {
+      const req = (raw && typeof raw === 'object' && !Array.isArray(raw))
+        ? (raw as Record<string, unknown>)
+        : {};
+      const enabled = await setAutoWakeEnabled(req.enabled === true);
+      return { enabled };
+    }),
+  );
+
   const disposeAll = (): void => {
     for (const { manager } of managers.values()) manager.dispose();
     managers.clear();
@@ -683,5 +711,7 @@ export function registerDeckHandler(
     ipcMain.removeHandler(IPC.DECK_LOOP_RESUME);
     ipcMain.removeHandler(IPC.DECK_LOOP_TASK);
     ipcMain.removeHandler(IPC.DECK_LOOP_SKILLS);
+    ipcMain.removeHandler(IPC.DECK_AUTOWAKE_GET);
+    ipcMain.removeHandler(IPC.DECK_AUTOWAKE_SET);
   };
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -372,6 +372,15 @@ const electronAPI = {
           skills: import('../main/deck/skillCatalogScan').SkillCatalogEntry[];
         }>,
     },
+    // Global auto-wake switch — the event-push kill switch (Settings toggle).
+    // OFF suppresses the ambient wake-turns (unrequested event summaries);
+    // a running loop still wakes.
+    autoWake: {
+      get: () =>
+        ipcRenderer.invoke(IPC.DECK_AUTOWAKE_GET) as Promise<{ enabled: boolean }>,
+      set: (enabled: boolean) =>
+        ipcRenderer.invoke(IPC.DECK_AUTOWAKE_SET, { enabled }) as Promise<{ enabled: boolean }>,
+    },
     // Normalized BrainEvent push, enveloped with the workspace whose
     // orchestrator produced it (see BrainAdapter.BrainEvent).
     onStream: (

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -596,6 +596,25 @@ function OrchestratorSection() {
   const setChannelsTabVisible = useStore((s) => s.setChannelsTabVisible);
   const gitTabVisible = useStore((s) => s.gitTabVisible);
   const setGitTabVisible = useStore((s) => s.setGitTabVisible);
+  // Global auto-wake switch — persisted in MAIN (deck-autowake.json) because
+  // the event-push coalescer that spends the tokens lives there. Read on
+  // mount; optimistic toggle with echo reconciliation.
+  const [autoWake, setAutoWake] = useState(true);
+  useEffect(() => {
+    let cancelled = false;
+    window.electronAPI.deck?.autoWake
+      ?.get()
+      .then((r) => { if (!cancelled) setAutoWake(r.enabled); })
+      .catch(() => undefined); // keep the default-on rendering
+    return () => { cancelled = true; };
+  }, []);
+  const onAutoWakeChange = (enabled: boolean) => {
+    setAutoWake(enabled);
+    window.electronAPI.deck?.autoWake
+      ?.set(enabled)
+      .then((r) => setAutoWake(r.enabled))
+      .catch(() => setAutoWake(!enabled));
+  };
   const options = ORCHESTRATOR_MODEL_OPTIONS.map((o) => ({
     value: o.value,
     label: o.labelKey
@@ -614,6 +633,16 @@ function OrchestratorSection() {
           onChange={setDeckBrainModel}
           options={options}
           label={t('settings.orchestratorModel')}
+        />
+      </SettingRow>
+      <SettingRow
+        label={t('settings.autoWake')}
+        description={t('settings.autoWakeDesc')}
+      >
+        <Toggle
+          checked={autoWake}
+          onChange={onAutoWakeChange}
+          label={t('settings.autoWake')}
         />
       </SettingRow>
       <SettingRow

--- a/src/renderer/components/Sidebar/PresetPicker.tsx
+++ b/src/renderer/components/Sidebar/PresetPicker.tsx
@@ -1,12 +1,19 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback, type CSSProperties } from 'react';
 import { LAYOUT_PRESETS } from '../../../shared/layoutPresets';
 import { useStore } from '../../stores';
 
 interface PresetPickerProps {
   onClose: () => void;
+  /** Viewport-fixed anchor (left/top px). The default `absolute right-2
+   *  top-10` placement predates the Bridge titlebar (#409) and only works
+   *  inside the sidebar's positioning context — rendered from the titlebar
+   *  it resolved against the full-width header and the menu opened at the
+   *  far RIGHT edge of the window (owner-reported). The titlebar measures
+   *  its + button and passes the anchor instead. */
+  anchorStyle?: CSSProperties;
 }
 
-export default function PresetPicker({ onClose }: PresetPickerProps) {
+export default function PresetPicker({ onClose, anchorStyle }: PresetPickerProps) {
   const addWorkspace = useStore((s) => s.addWorkspace);
   const addWorkspaceWithPreset = useStore((s) => s.addWorkspaceWithPreset);
   const ref = useRef<HTMLDivElement>(null);
@@ -50,7 +57,8 @@ export default function PresetPicker({ onClose }: PresetPickerProps) {
   return (
     <div
       ref={ref}
-      className="absolute right-2 top-10 z-50 w-52 bg-[var(--bg-overlay)] border border-[var(--bg-surface)] rounded-md shadow-lg py-1 text-xs font-mono"
+      style={anchorStyle}
+      className={`${anchorStyle ? 'fixed' : 'absolute right-2 top-10'} z-50 w-52 bg-[var(--bg-overlay)] border border-[var(--bg-surface)] rounded-md shadow-lg py-1 text-xs font-mono`}
     >
       {/* Empty workspace option */}
       <button

--- a/src/renderer/components/Sidebar/__tests__/PresetPicker.anchor.test.tsx
+++ b/src/renderer/components/Sidebar/__tests__/PresetPicker.anchor.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+//
+// PresetPicker anchoring contract (owner-reported 2026-07-13): rendered from
+// the TITLEBAR + button the picker must use the passed viewport-fixed anchor —
+// the legacy `absolute right-2 top-10` classes resolved against the full-width
+// header and the menu opened at the far RIGHT edge of the window. The sidebar
+// call site passes no anchor and keeps the legacy placement.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import PresetPicker from '../PresetPicker';
+
+function render(ui: React.ReactElement): { container: HTMLDivElement; cleanup: () => void } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(ui));
+  return {
+    container,
+    cleanup: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()!();
+});
+
+describe('PresetPicker anchoring', () => {
+  it('uses the viewport-fixed anchor when one is passed (titlebar call site)', () => {
+    const { container, cleanup } = render(
+      <PresetPicker onClose={() => {}} anchorStyle={{ left: 204, top: 40 }} />,
+    );
+    cleanups.push(cleanup);
+    const menu = container.firstElementChild as HTMLElement;
+    expect(menu.className).toContain('fixed');
+    expect(menu.className).not.toContain('right-2');
+    expect(menu.style.left).toBe('204px');
+    expect(menu.style.top).toBe('40px');
+  });
+
+  it('keeps the legacy sidebar placement when no anchor is passed', () => {
+    const { container, cleanup } = render(<PresetPicker onClose={() => {}} />);
+    cleanups.push(cleanup);
+    const menu = container.firstElementChild as HTMLElement;
+    expect(menu.className).toContain('absolute');
+    expect(menu.className).toContain('right-2');
+  });
+});

--- a/src/renderer/components/Titlebar/Titlebar.tsx
+++ b/src/renderer/components/Titlebar/Titlebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, type CSSProperties } from 'react';
+import { useEffect, useState, useCallback, useRef, type CSSProperties } from 'react';
 import { useStore } from '../../stores';
 import { tokenAttrs } from '../../themes';
 import StatusBar from '../StatusBar/StatusBar';
@@ -75,7 +75,22 @@ export default function Titlebar() {
   const isMac = platform === 'darwin';
   const isWin = platform === 'win32';
   const [pickerOpen, setPickerOpen] = useState(false);
-  const togglePicker = useCallback(() => setPickerOpen((v) => !v), []);
+  // Anchor the preset dropdown UNDER the + button. Measured at open time
+  // (the button's viewport rect), clamped so the 208px menu never overflows
+  // the window — without this the picker's legacy sidebar anchor (`right-2`)
+  // resolved against the full-width header and opened at the far right edge.
+  const plusBtnRef = useRef<HTMLButtonElement | null>(null);
+  const [pickerLeft, setPickerLeft] = useState(8);
+  const togglePicker = useCallback(() => {
+    setPickerOpen((v) => {
+      if (!v) {
+        const r = plusBtnRef.current?.getBoundingClientRect();
+        const menuWidth = 208; // w-52
+        if (r) setPickerLeft(Math.max(8, Math.min(r.left, window.innerWidth - menuWidth - 8)));
+      }
+      return !v;
+    });
+  }, []);
   const closePicker = useCallback(() => setPickerOpen(false), []);
 
   useTitleBarOverlaySync();
@@ -119,6 +134,7 @@ export default function Titlebar() {
           WMUX
         </span>
         <button
+          ref={plusBtnRef}
           type="button"
           onClick={togglePicker}
           className={`flex items-center justify-center w-6 h-6 rounded-md text-[var(--text-muted)] hover:text-[var(--accent-green)] hover:bg-[rgba(var(--bg-surface-rgb),0.6)] transition-colors duration-150 ml-auto ${FOCUS_RING}`}
@@ -129,7 +145,12 @@ export default function Titlebar() {
         >
           <IconPlus size={14} />
         </button>
-        {pickerOpen && <PresetPicker onClose={closePicker} />}
+        {pickerOpen && (
+          <PresetPicker
+            onClose={closePicker}
+            anchorStyle={{ left: pickerLeft, top: TITLEBAR_HEIGHT + 4 }}
+          />
+        )}
       </div>
       {/* The status strip (P1.5) fills the rest of the bar: transient
           indicators on the left, the status/clock/settings cluster pinned

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -293,6 +293,11 @@ export const en = {
   'settings.orchestratorModelDesc':
     'The Claude model the Command Deck orchestrator runs on. Changes apply from your next command; the conversation carries over.',
   'settings.orchestratorModelDefault': 'Default (subscription model)',
+  // Global event-push kill switch: OFF stops the unrequested wake-turns
+  // (each one is a real token-spending SDK turn); a running loop still wakes.
+  'settings.autoWake': 'Auto-wake on pane events',
+  'settings.autoWakeDesc':
+    'Wake the orchestrator to summarize when a pane stops or awaits input. Each wake is a real turn that spends tokens — turn this off to stop the unrequested summaries. A running loop keeps waking either way.',
   'settings.channelsTabVisible': 'Show Channels tab',
   'settings.channelsTabVisibleDesc':
     'Show the Channels tab (the human channel UI) in the dock. Agent and orchestrator channel traffic keeps working either way — turn this on only when you want to inspect the raw messages.',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -230,15 +230,21 @@ export const ko = {
   'settings.tabNotifications': '알림',
   'settings.tabShortcuts': '단축키',
   'settings.tabAbout': '정보',
-  // 오케스트레이터 (커맨드 데크 브레인) 설정
-  'settings.orchestrator': '오케스트레이터',
-  'settings.orchestratorModel': '오케스트레이터 모델',
+  // agent (커맨드 데크 브레인) 설정 — 명칭은 영문 "agent" 고정(번역·한글화
+  // 금지, 오너 결정 2026-07-13: "오케스트레이터"는 한글 UI에서 넘침).
+  'settings.orchestrator': 'agent',
+  'settings.orchestratorModel': 'agent 모델',
   'settings.orchestratorModelDesc':
-    '커맨드 데크 오케스트레이터가 사용할 Claude 모델. 변경은 다음 지시부터 적용되고 대화는 이어집니다.',
+    '커맨드 데크 agent가 사용할 Claude 모델. 변경은 다음 지시부터 적용되고 대화는 이어집니다.',
   'settings.orchestratorModelDefault': '기본 (구독 기본 모델)',
+  // 이벤트 자동 깨우기 킬스위치: 끄면 요청하지 않은 자동 요약 턴(토큰 소비)이
+  // 멈춘다. 실행 중인 루프는 계속 깨운다.
+  'settings.autoWake': 'pane 이벤트 자동 깨우기',
+  'settings.autoWakeDesc':
+    'pane이 멈추거나 입력을 기다릴 때 agent를 깨워 요약합니다. 깨울 때마다 토큰을 쓰는 실제 턴이 돌아갑니다 — 요청하지 않은 요약이 싫으면 끄세요. 실행 중인 루프는 꺼도 계속 동작합니다.',
   'settings.channelsTabVisible': '채널 탭 표시',
   'settings.channelsTabVisibleDesc':
-    '도크에 채널 탭(사람용 채널 UI)을 표시합니다. 꺼도 에이전트·오케스트레이터의 채널 통신은 그대로 동작합니다 — 원문을 직접 확인하고 싶을 때만 켜세요.',
+    '도크에 채널 탭(사람용 채널 UI)을 표시합니다. 꺼도 에이전트·agent의 채널 통신은 그대로 동작합니다 — 원문을 직접 확인하고 싶을 때만 켜세요.',
   // LanLink 제어 평면 (PR-3)
   'settings.lanlinkTab': 'LanLink',
   'settings.lanlink': 'LanLink (LAN 에이전트 메시징)',
@@ -655,10 +661,11 @@ export const ko = {
   'channels.mentionUnmatched': '이 @멘션은 일치하는 대상이 없어 전달되지 않았습니다: {names}',
   'channels.mentionNoMatch': '멘션할 에이전트가 없습니다',
   // Command Deck (Phase 1) — 탭형 도크 + LLM 없는 지휘 composer.
-  // 명명 규칙(오너 결정 2026-07-11): 두뇌/기능 = "오케스트레이터", pane 집합 = "에이전트".
+  // 명명 규칙(오너 결정 2026-07-13 개정): 두뇌/기능 = "agent"(영문 고정, 번역
+  // 안 함 — "오케스트레이터"는 한글 UI에서 넘침), pane 집합 = "에이전트".
   // "함대(fleet)" 어휘는 사용자 표면에서 쓰지 않는다.
   'deck.tabsAriaLabel': '커맨드 데크 탭',
-  'deck.tabCommander': '오케스트레이터',
+  'deck.tabCommander': 'agent',
   'deck.tabChannels': '채널',
   'deck.tabGit': 'Git',
   // Deck Git 탭 — 워크트리 표면(v1).
@@ -697,11 +704,11 @@ export const ko = {
   'settings.gitTabVisibleDesc':
     '우측 도크에 Git 탭(워크트리)을 표시합니다. 정보성 표면 — 최소 크롬을 원하면 숨기세요.',
   'deck.collapseDock': '도크 접기',
-  'deck.commanderPlaceholder': '오케스트레이터에 지시하거나 @로 pane을 멘션…',
+  'deck.commanderPlaceholder': 'agent에 지시하거나 @로 pane을 멘션…',
   'deck.commanderEmpty':
-    '오케스트레이터에게 에이전트 운영을 맡기거나, @로 에이전트 pane을 멘션해 직접 지시하세요.',
+    'agent에게 에이전트 운영을 맡기거나, @로 에이전트 pane을 멘션해 직접 지시하세요.',
   'deck.jumpToPane': '이 pane으로 이동',
-  // Bridge P2① — 오케스트레이터 스레드 위에 고정되는 에이전트 명단.
+  // Bridge P2① — agent 스레드 위에 고정되는 에이전트 명단.
   'deck.fleetLabel': '에이전트',
   'deck.fleetNeedsYou': '{count}개 응답 필요',
   'deck.fleetNeedsInput': '입력 필요',
@@ -709,11 +716,11 @@ export const ko = {
   'strip.running': '{count}개 실행 중',
   'strip.needsYou': '{count}개 응답 필요',
   'strip.needsYouTooltip': '응답이 필요한 pane으로 이동',
-  // 커맨드 데크 Phase 2 — 오케스트레이터 두뇌(Agent SDK).
-  'deck.commander': '오케스트레이터',
-  'deck.commanderThinking': '오케스트레이터가 작업 중…',
+  // 커맨드 데크 Phase 2 — agent 두뇌(Agent SDK).
+  'deck.commander': 'agent',
+  'deck.commanderThinking': 'agent가 작업 중…',
   'deck.commanderStop': '중지',
-  'deck.commanderUnavailable': '오케스트레이터를 사용할 수 없습니다',
+  'deck.commanderUnavailable': 'agent를 사용할 수 없습니다',
   'deck.commanderBusy': '이미 실행 중인 명령이 있습니다.',
   'deck.commanderFailed': '명령을 실행하지 못했습니다.',
   // 커맨드 데크 P3b — 재부팅 복구 인사 카드.
@@ -723,10 +730,10 @@ export const ko = {
   // 커맨드 데크 P3c — composer 위 퀵액션 칩.
   'deck.qaFleetStatus': '에이전트 상태',
   'deck.qaPrStatus': 'PR 상태',
-  // 커맨드 데크 P3d — 오케스트레이터 예약(재부팅 생존).
+  // 커맨드 데크 P3d — agent 예약(재부팅 생존).
   'deck.schedules': '예약',
-  'deck.schedulesEmpty': '예약이 없습니다. 예약은 재부팅 후에도 유지되고, 시간이 되면 오케스트레이터가 실행합니다.',
-  'deck.schedulePromptPlaceholder': '오케스트레이터가 무엇을 하면 될까요?',
+  'deck.schedulesEmpty': '예약이 없습니다. 예약은 재부팅 후에도 유지되고, 시간이 되면 agent가 실행합니다.',
+  'deck.schedulePromptPlaceholder': 'agent가 무엇을 하면 될까요?',
   'deck.scheduleRepeat': '반복',
   'deck.scheduleRepeatNone': '한 번',
   'deck.scheduleRepeat30m': '30분마다',
@@ -739,7 +746,7 @@ export const ko = {
   'deck.scheduleDelete': '삭제',
   'deck.scheduleInvalid': '지시 내용과 유효한 시간을 입력하세요.',
   'deck.scheduleLimit': '예약 개수 한도에 도달했습니다.',
-  // M1.5 — 워크스페이스별 오케스트레이터: 예약은 워크스페이스에 귀속된다.
+  // M1.5 — 워크스페이스별 agent: 예약은 워크스페이스에 귀속된다.
   'deck.scheduleNoWorkspace': '먼저 워크스페이스를 여세요 — 예약은 워크스페이스에 속합니다.',
   'deck.scheduleNeedsWorkspace': '워크스페이스 지정 필요',
   'deck.scheduleAdoptHere': '이 워크스페이스로',
@@ -775,7 +782,7 @@ export const ko = {
   'deck.loopStepAdd': '단계 추가',
   'deck.loopStepRemove': '단계 제거',
   'deck.loopStepsHint':
-    '"/"로 시작하는 단계는 pane 에이전트의 스킬에서 고릅니다 — 실행은 오케스트레이터가 그 커맨드를 pane에 타이핑하는 것입니다.',
+    '"/"로 시작하는 단계는 pane 에이전트의 스킬에서 고릅니다 — 실행은 agent가 그 커맨드를 pane에 타이핑하는 것입니다.',
   'deck.loopDoneWhen': '완료 조건 (선택)',
   'deck.loopIterationsLabel': '반복',
   'deck.loopSkillProject': '프로젝트',
@@ -805,8 +812,8 @@ export const ko = {
   'diff.commentFired': '코멘트를 미션 채널에 발사했습니다 — {count}개 에이전트 호출',
   // 워크스페이스 git diff — 팔레트 진입 거부: 활성 pane cwd가 git repo가 아님.
   'diff.noRepo': 'git 저장소가 아닙니다 — repo 안의 pane에서 실행하세요',
-  // diff → 오케스트레이터 질문 (컨텍스트 블록 + 질문 단일 메시지).
+  // diff → agent 질문 (컨텍스트 블록 + 질문 단일 메시지).
   'diff.ask': '질문',
-  'diff.askOrchestrator': '이 hunk에 대해 오케스트레이터에게 질문',
-  'diff.askPrompt': '오케스트레이터에게 질문 (hunk 컨텍스트는 자동 첨부됩니다):',
+  'diff.askOrchestrator': '이 hunk에 대해 agent에게 질문',
+  'diff.askPrompt': 'agent에게 질문 (hunk 컨텍스트는 자동 첨부됩니다):',
 } as const;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -142,6 +142,11 @@ export const IPC = {
   //   수 있는 스킬/커맨드 카탈로그를 디스크(.claude/skills|commands)에서 스캔.
   //   읽기 전용, 렌더러 전용.
   DECK_LOOP_SKILLS: 'deck:loop:skills',
+  //   DECK_AUTOWAKE_* — the global event-push kill switch (Settings toggle).
+  //   OFF suppresses ambient wake-turns (the unrequested summaries); a
+  //   running loop still wakes. Same renderer-only trust boundary.
+  DECK_AUTOWAKE_GET: 'deck:autowake:get',
+  DECK_AUTOWAKE_SET: 'deck:autowake:set',
   // Clipboard (main process bridge)
   CLIPBOARD_WRITE: 'clipboard:write',
   CLIPBOARD_READ: 'clipboard:read',


### PR DESCRIPTION
## Summary

Users reported heavy stutter ("hooks firing too much") right after v3.21.0. Root cause investigation traced it to a compounding process storm, fixed here along with two UX complaints.

**Hook storm (root cause)** — The Agent SDK defaults `settingSources` to `['user','project','local']`, so every orchestrator turn loaded the user's `~/.claude` settings including the wmux plugin's own PostToolUse/Stop hooks. Each brain tool call spawned a ~110ms node bridge process (measured on the reporting machine), and the brain's own Stop re-entered `hooks.signal` as a phantom agent event. With v3.21.0 event-push auto-wakes on by default, this multiplied: agent stop → wake turn (full CLI spawn) → its tool calls re-fire hooks → more spawns. Evidence: bridge.log with 72,250 spawns, 89% PostToolUse, 21,517 (30%) `no-workspace-match`, peak 99 spawns/min. Orchestrator turns now load **no filesystem settings** — their contract was always explicit in code (manual systemPrompt, allowedTools/disallowedTools/canUseTool, strictMcpConfig), so nothing else changes.

**Auto-wake kill switch** — The unrequested "here's what your agents did" summaries had no off switch, and each one is a real token-spending SDK turn. Settings (orchestrator section) grows an "Auto-wake on pane events" toggle, persisted main-side in `deck-autowake.json` (default ON, fail-open to shipped behavior, never-throw). OFF suppresses ambient wakes and consumes buffered events (watermark advanced — re-enabling never replays a stale backlog). A **running loop still wakes**: it's an explicit opt-in bounded by its own iteration budget. Read fresh at every flush, so the toggle applies immediately.

**Layout picker opened across the window** — The titlebar + button's preset menu (Empty / Horizontal Split / …) kept its pre-Bridge sidebar anchoring (`absolute right-2 top-10`), which resolved against the full-width header and opened at the far right edge over the orchestrator dock. Reproduced via CDP on the live dev app. The titlebar now measures the + button at open time and passes a viewport-fixed, clamped anchor; the sidebar call site keeps its legacy placement.

**Korean UI rename** — "오케스트레이터" overflows tabs/labels; every user-facing Korean string now uses the untranslated term "agent" (pane agents remain "에이전트"). Other locales unchanged.

## Test Coverage

- `settingSources: []` regression test (fails without the fix) — ClaudeSdkAdapter.test.ts, 21/21
- Auto-wake switch: 5 coalescer gate tests (off suppresses + consumes, running loop overrides, paused loop suppressed, throwing read fails open, re-enable only wakes for new events) + 4 store tests (default-on, round-trip, corrupt file, non-boolean coercion)
- Picker anchor: 2 tests (fixed anchor when passed, legacy placement without)
- Full affected sweep: 63 files / **810 tests green**; tsc + eslint clean

## Pre-Landing Review

Self-reviewed the full diff (290 insertions). No SQL/trust-boundary surface; the new IPC pair is renderer-only (same process-boundary trust basis as the other DECK_* handlers), input coerced with `=== true`, store writes atomic. One deliberate posture: the auto-wake flag fails OPEN (default enabled) because it preserves shipped behavior — the dangerous-capability stores (autonomy caps) remain fail-closed and untouched.

## Notes

- No version bump (PRs never bump — release is an explicit owner action).
- Known local-only test failure (`diff.handler` symlink EPERM) is pre-existing Windows-privilege flake, untouched area.
- Follow-ups worth considering (not in this PR): `React.memo` on the deck's message bubbles + thread cap (progressive re-render cost during streaming), and whether the PostToolUse hook is worth its per-tool-call spawn at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Settings toggle to disable automatic summary wake-ups from pane events.
  * Running loops continue operating normally when automatic wake-ups are disabled.
* **Bug Fixes**
  * Workspace layout menus now open beneath the “+” button and remain within the window.
  * Prevented repeated loading of local settings and hooks during tool calls, reducing duplicate actions and background resource use.
* **Localization**
  * Updated Korean interface terminology to use “agent” consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->