### PR TITLE
chore(release): v3.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.21.1] — 2026-07-13
+
 ### Added
 
 - **Auto-wake is now a switch you own.** The orchestrator's event-push wakes (the automatic "here's what your agents just did" summaries) each spend a real model turn — and until now there was no way to turn them off. Settings grows an "Auto-wake on pane events" toggle: switch it off and unrequested summary turns stop entirely, saving the tokens. Loops are unaffected — a running loop keeps waking through its own iteration budget, because you explicitly started it. The switch lives next to the orchestrator's other settings and applies immediately, no restart needed.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.21.0 sources.** This file is produced by
+> **Generated from wmux v3.21.1 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Patch release for the post-v3.21.0 stutter reports.

- `package.json` 3.21.0 → 3.21.1
- CHANGELOG: `[Unreleased]` → `[3.21.1] — 2026-07-13` (hook-storm fix, auto-wake switch, picker anchor, Korean "agent" rename)
- `docs/api/reference.md` regenerated (CI drift guard)

Tag `v3.21.1` will be pushed after this merges (installer + Chocolatey/winget hang off the tag).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version 3.21.1.
  * Updated the API reference to reflect the 3.21.1 release.
  * Added the 3.21.1 entry to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->