### PR TITLE
feat(deck): per-workspace agent modes with a wake value filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Per-workspace agent modes — one knob for how autonomous the agent is.** Each workspace gets a mode chip (next to the loop and schedule chips) with four levels. **Off**: no autonomy at all, and it stops any running loop and schedule for that workspace (you can still type to it). **Manual**: replies only when you type, never wakes itself on agent events. **Assist** (the default): wakes only when a pane is actually blocked waiting for input, or to drive a loop you started — a plain "a turn finished" no longer triggers a summary, which is the token-burning spam this removes. **Orchestrate**: wakes on every agent event and may drive panes and press approvals. The current mode is always visible, so "why is it quiet?" and "why is it talking?" are both answered on screen. The global auto-wake switch from 3.21.1 stays as a master override on top of the per-workspace modes.
+
+### Changed
+
+- **The default agent posture is now "assist with a value filter" instead of "summarize every turn".** Existing workspaces that had the old report-on-every-event default move to assist, so the summary spam stops for them too without losing useful wakes (you still get pinged when a pane needs input). Stopping or pausing a loop now returns the agent to its workspace mode's baseline rather than a fixed floor.
+
 ## [3.21.1] — 2026-07-13
 
 ### Added

--- a/src/main/deck/CommanderEventCoalescer.ts
+++ b/src/main/deck/CommanderEventCoalescer.ts
@@ -33,8 +33,8 @@
 // persistence across reload, and the per-turn action fan-out cap (bounds
 // actions WITHIN a wake; the budget bounds wake FREQUENCY).
 
-import type { WorkspaceAutonomy } from './deckAutonomyStore';
-import { DEFAULT_AUTONOMY } from './deckAutonomyStore';
+import type { WorkspaceAutonomy, WakePolicy } from './deckAutonomyStore';
+import { DEFAULT_AUTONOMY, modeToWakePolicy } from './deckAutonomyStore';
 
 /** The two lifecycle kinds we wake on (decision 7 — subagent_stop /
  *  notification excluded). */
@@ -321,6 +321,20 @@ export class CommanderEventCoalescer {
     }
   }
 
+  /** Swallow a set of buffered events without a turn: advance the watermark
+   *  past them and prune, so re-enabling wakes never replays a stale backlog.
+   *  Used by every suppression path (global switch off, mode wake policy). */
+  private consume(st: WsState, events: readonly BufferedEvent[]): void {
+    if (events.length === 0) {
+      st.phase = 'idle';
+      return;
+    }
+    const maxSeq = events[events.length - 1].seq;
+    if (maxSeq > st.watermark) st.watermark = maxSeq;
+    this.pruneBuffer(st, maxSeq);
+    st.phase = 'idle';
+  }
+
   private attemptFlush(workspaceId: string, st: WsState): void {
     if (this.disposed) return;
     this.clearDebounce(st);
@@ -335,12 +349,32 @@ export class CommanderEventCoalescer {
     // overrides the switch — the loop is an explicit opt-in that depends on
     // these wakes and is already bounded by its own iteration budget.
     const loopHint = this.safeGetLoop(workspaceId);
-    if (!this.safeAutoWakeEnabled() && loopHint?.running !== true) {
-      const maxSeq = events[events.length - 1].seq;
-      if (maxSeq > st.watermark) st.watermark = maxSeq;
-      this.pruneBuffer(st, maxSeq);
-      st.phase = 'idle';
+    const loopRunning = loopHint?.running === true;
+    if (!this.safeAutoWakeEnabled() && !loopRunning) {
+      this.consume(st, events);
       return;
+    }
+    // Per-workspace mode wake policy. A RUNNING loop overrides to 'all' (the
+    // same carve-out as the global switch: an explicit opt-in must keep
+    // iterating). 'none' (manual/off) consumes everything silently; for
+    // 'value-filtered' (assist) we drop plain agent.stop — the summary-spam —
+    // and only proceed if a pane is actually blocked on input.
+    const autonomy = this.safeAutonomy(workspaceId);
+    const policy: WakePolicy = loopRunning ? 'all' : modeToWakePolicy(autonomy.mode);
+    if (policy === 'none') {
+      this.consume(st, events);
+      return;
+    }
+    let flushEvents = events;
+    if (policy === 'value-filtered') {
+      const worthy = events.filter((e) => e.kind === 'agent.awaiting_input');
+      if (worthy.length === 0) {
+        // Only plain stops buffered — consume them, no turn. THIS is the fix
+        // for "the agent summarizes every unit of work".
+        this.consume(st, events);
+        return;
+      }
+      flushEvents = worthy;
     }
     if (this.deps.isBusy(workspaceId)) {
       // A racer (scheduler / human) grabbed the turn — hold; its onIdle retries.
@@ -356,14 +390,16 @@ export class CommanderEventCoalescer {
     }
 
     // Snapshot the flush set. Do NOT advance the watermark or clear the buffer
-    // until the send is ACCEPTED — a busy reject must not lose events.
+    // until the send is ACCEPTED — a busy reject must not lose events. The
+    // watermark advances past ALL buffered events (including value-filtered-out
+    // stops), so a dropped stop is consumed, not re-surfaced; only the worthy
+    // events go into the prompt.
     const snapshotMaxSeq = events[events.length - 1].seq;
-    const autonomy = this.safeAutonomy(workspaceId);
     const prompt = buildEventPrompt(
-      events,
+      flushEvents,
       autonomy,
       { remaining: budget - st.autoWakesUsed, total: budget },
-      { loopRunning: loopHint?.running === true },
+      { loopRunning: loopRunning },
     );
     st.phase = 'send-pending';
 

--- a/src/main/deck/__tests__/CommanderEventCoalescer.test.ts
+++ b/src/main/deck/__tests__/CommanderEventCoalescer.test.ts
@@ -11,6 +11,15 @@ import {
 } from '../CommanderEventCoalescer';
 import { DEFAULT_AUTONOMY, type WorkspaceAutonomy } from '../deckAutonomyStore';
 
+/** Wake-on-everything autonomy (mode=orchestrate) — the harness default so the
+ *  plumbing tests aren't affected by the assist value filter. */
+const ORCHESTRATE_AUTONOMY: WorkspaceAutonomy = {
+  mode: 'orchestrate',
+  summarize: true,
+  continueInstruction: true,
+  approvalPress: true,
+};
+
 // Two microtask flushes: enough to settle a runTurn().then() chain.
 const settle = async () => {
   await Promise.resolve();
@@ -47,7 +56,10 @@ function mk(opts: {
       return runResult;
     },
     isBusy: () => busy,
-    getAutonomy: () => opts.autonomy ?? { ...DEFAULT_AUTONOMY },
+    // Default to ORCHESTRATE (wake on every event) so the plumbing tests below
+    // — coalescing, budget, watermark — exercise the wake path regardless of
+    // the new mode value filter. The value-filter behavior gets its own block.
+    getAutonomy: () => opts.autonomy ?? { ...ORCHESTRATE_AUTONOMY },
     getLoop: () => loop,
     ...(opts.isAutoWakeEnabled ? { isAutoWakeEnabled: opts.isAutoWakeEnabled } : {}),
     debounceMs: opts.debounceMs ?? 1_000,
@@ -270,7 +282,7 @@ describe('CommanderEventCoalescer — loop iteration budget (Ralph max-iteration
     // continue tier
     const drive = makeHarness({
       loop: { running: true, iterations: 10 },
-      autonomy: { summarize: true, continueInstruction: true, approvalPress: false },
+      autonomy: { mode: 'orchestrate', summarize: true, continueInstruction: true, approvalPress: false },
     });
     drive.c.push(stop(1, 'ptyA'));
     drive.c.notifyIdle('ws-1');
@@ -278,8 +290,11 @@ describe('CommanderEventCoalescer — loop iteration budget (Ralph max-iteration
     expect(drive.prompts[0].prompt).toContain('loop-mode: ACTIVE —');
     expect(drive.prompts[0].prompt).toContain('NEXT CONCRETE STEP');
 
-    // report tier
-    const report = makeHarness({ loop: { running: true, iterations: 10 } });
+    // report tier — a running loop with continueInstruction OFF (report-only).
+    const report = makeHarness({
+      loop: { running: true, iterations: 10 },
+      autonomy: { mode: 'manual', summarize: false, continueInstruction: false, approvalPress: false },
+    });
     report.c.push(stop(1, 'ptyA'));
     report.c.notifyIdle('ws-1');
     await settle();
@@ -340,7 +355,7 @@ describe('buildEventPrompt — untrusted structured block + fail-closed approval
   it('CRITICAL: a detector-source awaiting_input is NEVER approvable, even with approvalPress on', () => {
     const p = buildEventPrompt(
       [buf({ source: 'detector', kind: 'agent.awaiting_input' })],
-      { summarize: true, continueInstruction: true, approvalPress: true },
+      { mode: 'orchestrate', summarize: true, continueInstruction: true, approvalPress: true },
       budget,
     );
     expect(p).toContain('NOTIFY ONLY');
@@ -350,7 +365,7 @@ describe('buildEventPrompt — untrusted structured block + fail-closed approval
   it('approvalPress off → a hook awaiting_input is NOTIFY ONLY', () => {
     const off = buildEventPrompt(
       [buf({ source: 'hook', kind: 'agent.awaiting_input' })],
-      { summarize: true, continueInstruction: false, approvalPress: false },
+      { mode: 'orchestrate', summarize: true, continueInstruction: false, approvalPress: false },
       budget,
     );
     expect(off).toContain('NOTIFY ONLY');
@@ -360,7 +375,7 @@ describe('buildEventPrompt — untrusted structured block + fail-closed approval
   it('approvalPress on + hook source → the press is authorized', () => {
     const on = buildEventPrompt(
       [buf({ source: 'hook', kind: 'agent.awaiting_input' })],
-      { summarize: true, continueInstruction: false, approvalPress: true },
+      { mode: 'orchestrate', summarize: true, continueInstruction: false, approvalPress: true },
       budget,
     );
     expect(on).toContain('MAY press the approval');
@@ -369,14 +384,14 @@ describe('buildEventPrompt — untrusted structured block + fail-closed approval
   it('a stop is summarize-only unless continueInstruction is on', () => {
     const off = buildEventPrompt(
       [buf({ source: 'hook', kind: 'agent.stop' })],
-      { summarize: true, continueInstruction: false, approvalPress: false },
+      { mode: 'orchestrate', summarize: true, continueInstruction: false, approvalPress: false },
       budget,
     );
     expect(off).toContain('summarize only');
 
     const on = buildEventPrompt(
       [buf({ source: 'hook', kind: 'agent.stop' })],
-      { summarize: true, continueInstruction: true, approvalPress: false },
+      { mode: 'orchestrate', summarize: true, continueInstruction: true, approvalPress: false },
       budget,
     );
     expect(on).toContain('follow-up instruction');
@@ -449,5 +464,84 @@ describe('CommanderEventCoalescer — global auto-wake switch', () => {
     await settle();
     expect(h.prompts).toHaveLength(1);
     expect(h.prompts[0].prompt).toContain('seq=4');
+  });
+});
+
+describe('CommanderEventCoalescer — mode wake policy (value filter)', () => {
+  const assist: WorkspaceAutonomy = {
+    mode: 'assist', summarize: true, continueInstruction: true, approvalPress: false,
+  };
+  const manual: WorkspaceAutonomy = {
+    mode: 'manual', summarize: false, continueInstruction: false, approvalPress: false,
+  };
+
+  it('assist DROPS a plain stop (consumed, no turn) — the summary-spam fix', async () => {
+    const h = makeHarness({ autonomy: assist });
+    h.c.push(stop(3));
+    await vi.advanceTimersByTimeAsync(5_000);
+    await settle();
+    expect(h.prompts).toHaveLength(0);
+    expect(h.c.getPhase('ws-1')).toBe('idle');
+    // consumed, not held — re-enabling must not replay it.
+    expect(h.c.getWatermark('ws-1')).toBe(3);
+  });
+
+  it('assist WAKES on awaiting_input (a pane blocked on input)', async () => {
+    const h = makeHarness({ autonomy: assist });
+    h.c.push(awaiting(4));
+    await vi.advanceTimersByTimeAsync(5_000);
+    await settle();
+    expect(h.prompts).toHaveLength(1);
+    expect(h.prompts[0].prompt).toContain('kind=awaiting');
+  });
+
+  it('assist flushes awaiting_input but consumes a co-buffered stop', async () => {
+    const h = makeHarness({ autonomy: assist, debounceMs: 1_000 });
+    h.c.push(stop(5, 'ptyA'));
+    await vi.advanceTimersByTimeAsync(400);
+    h.c.push(awaiting(6, { ptyId: 'ptyB' }));
+    await vi.advanceTimersByTimeAsync(1_000);
+    await settle();
+    expect(h.prompts).toHaveLength(1);
+    // Only the worthy awaiting event is surfaced; the stop is not.
+    expect(h.prompts[0].prompt).toContain('seq=6');
+    expect(h.prompts[0].prompt).not.toContain('seq=5');
+    // But the stop was consumed (watermark past it), not left to re-fire.
+    expect(h.c.getWatermark('ws-1')).toBe(6);
+  });
+
+  it('assist + a RUNNING loop wakes on a plain stop (override to all)', async () => {
+    const h = makeHarness({ autonomy: assist, loop: { running: true, iterations: 10 } });
+    h.c.push(stop(1));
+    await vi.advanceTimersByTimeAsync(5_000);
+    await settle();
+    expect(h.prompts).toHaveLength(1);
+    expect(h.prompts[0].prompt).toContain('loop-mode: ACTIVE');
+  });
+
+  it('manual consumes EVERYTHING (stop AND awaiting), no turn', async () => {
+    const h = makeHarness({ autonomy: manual });
+    h.c.push(stop(1));
+    h.c.push(awaiting(2, { ptyId: 'ptyB' }));
+    await vi.advanceTimersByTimeAsync(5_000);
+    await settle();
+    expect(h.prompts).toHaveLength(0);
+    expect(h.c.getWatermark('ws-1')).toBe(2);
+  });
+
+  it('manual + a RUNNING loop still wakes (explicit opt-in override)', async () => {
+    const h = makeHarness({ autonomy: manual, loop: { running: true, iterations: 5 } });
+    h.c.push(stop(1));
+    await vi.advanceTimersByTimeAsync(5_000);
+    await settle();
+    expect(h.prompts).toHaveLength(1);
+  });
+
+  it('global auto-wake OFF overrides even mode=orchestrate', async () => {
+    const h = makeHarness({ autonomy: ORCHESTRATE_AUTONOMY, isAutoWakeEnabled: () => false });
+    h.c.push(awaiting(1));
+    await vi.advanceTimersByTimeAsync(5_000);
+    await settle();
+    expect(h.prompts).toHaveLength(0);
   });
 });

--- a/src/main/deck/__tests__/deckAutonomyStore.test.ts
+++ b/src/main/deck/__tests__/deckAutonomyStore.test.ts
@@ -1,7 +1,8 @@
 // Unit tests for the per-workspace autonomy store: fail-closed resolution,
-// round-trip persistence, sanitize-on-load (the file is hand-editable), and the
-// merge-write path. The security-load-bearing property: ANY doubt resolves to
-// DEFAULT (summarize on, the two dangerous caps off).
+// round-trip persistence, sanitize-on-load (the file is hand-editable), the
+// merge-write path, AND the agent-mode layer (mode ⇄ caps, legacy derivation).
+// Security-load-bearing property: the DANGEROUS cap (approvalPress) is never
+// on unless a workspace is explicitly `orchestrate`.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
@@ -9,10 +10,17 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   DEFAULT_AUTONOMY,
+  DEFAULT_MODE,
+  modeToCaps,
+  modeToWakePolicy,
+  deriveMode,
   loadWorkspaceAutonomy,
+  loadWorkspaceMode,
   loadDeckAutonomy,
   setWorkspaceAutonomy,
+  setWorkspaceMode,
   getDeckAutonomyPath,
+  type AgentMode,
 } from '../deckAutonomyStore';
 
 let dir: string;
@@ -24,28 +32,69 @@ afterEach(() => {
   fs.rmSync(dir, { recursive: true, force: true });
 });
 
-describe('deckAutonomyStore', () => {
-  it('unknown workspace resolves to DEFAULT (summarize on, dangerous off)', () => {
-    expect(loadWorkspaceAutonomy('ws-1', dir)).toEqual({ ...DEFAULT_AUTONOMY });
+describe('deckAutonomyStore — mode ⇄ caps', () => {
+  it('modeToCaps: only orchestrate turns on the dangerous approvalPress cap', () => {
+    expect(modeToCaps('off')).toEqual({ summarize: false, continueInstruction: false, approvalPress: false });
+    expect(modeToCaps('manual')).toEqual({ summarize: false, continueInstruction: false, approvalPress: false });
+    expect(modeToCaps('assist')).toEqual({ summarize: true, continueInstruction: true, approvalPress: false });
+    expect(modeToCaps('orchestrate')).toEqual({ summarize: true, continueInstruction: true, approvalPress: true });
+  });
+
+  it('modeToWakePolicy maps each mode', () => {
+    expect(modeToWakePolicy('off')).toBe('none');
+    expect(modeToWakePolicy('manual')).toBe('none');
+    expect(modeToWakePolicy('assist')).toBe('value-filtered');
+    expect(modeToWakePolicy('orchestrate')).toBe('all');
+  });
+
+  it('deriveMode back-maps legacy caps by the dangerous caps', () => {
+    expect(deriveMode({ summarize: true, continueInstruction: false, approvalPress: true })).toBe('orchestrate');
+    expect(deriveMode({ summarize: true, continueInstruction: true, approvalPress: false })).toBe('assist');
+    // all-off legacy (the pre-mode "report only" default) → the product default.
+    expect(deriveMode({ summarize: true, continueInstruction: false, approvalPress: false })).toBe(DEFAULT_MODE);
+  });
+
+  it('DEFAULT is the product default mode (assist), dangerous cap off', () => {
+    expect(DEFAULT_MODE).toBe('assist');
     expect(DEFAULT_AUTONOMY).toEqual({
+      mode: 'assist',
       summarize: true,
-      continueInstruction: false,
+      continueInstruction: true,
       approvalPress: false,
     });
   });
+});
 
-  it('round-trips a merged update through the file', async () => {
-    const next = await setWorkspaceAutonomy('ws-1', { continueInstruction: true }, dir);
-    expect(next).toEqual({ summarize: true, continueInstruction: true, approvalPress: false });
-    expect(loadWorkspaceAutonomy('ws-1', dir)).toEqual(next);
-    // A second workspace is untouched (per-ws map).
-    expect(loadWorkspaceAutonomy('ws-2', dir)).toEqual({ ...DEFAULT_AUTONOMY });
+describe('deckAutonomyStore', () => {
+  it('unknown workspace resolves to DEFAULT', () => {
+    expect(loadWorkspaceAutonomy('ws-1', dir)).toEqual({ ...DEFAULT_AUTONOMY });
+    expect(loadWorkspaceMode('ws-1', dir)).toBe('assist');
   });
 
-  it('merge preserves prior caps and only overwrites the patched field', async () => {
-    await setWorkspaceAutonomy('ws-1', { approvalPress: true, continueInstruction: true }, dir);
-    const next = await setWorkspaceAutonomy('ws-1', { approvalPress: false }, dir);
-    expect(next).toEqual({ summarize: true, continueInstruction: true, approvalPress: false });
+  it('setWorkspaceMode round-trips mode + derived caps', async () => {
+    const next = await setWorkspaceMode('ws-1', 'orchestrate', dir);
+    expect(next).toEqual({ mode: 'orchestrate', summarize: true, continueInstruction: true, approvalPress: true });
+    expect(loadWorkspaceAutonomy('ws-1', dir)).toEqual(next);
+    expect(loadWorkspaceMode('ws-1', dir)).toBe('orchestrate');
+  });
+
+  it('setWorkspaceMode off writes the all-off caps', async () => {
+    const next = await setWorkspaceMode('ws-1', 'off', dir);
+    expect(next).toEqual({ mode: 'off', summarize: false, continueInstruction: false, approvalPress: false });
+  });
+
+  it('an unknown mode string is a no-op returning DEFAULT (never writes)', async () => {
+    const r = await setWorkspaceMode('ws-1', 'bogus' as AgentMode, dir);
+    expect(r).toEqual({ ...DEFAULT_AUTONOMY });
+    expect(loadDeckAutonomy(dir)).toEqual({});
+  });
+
+  it('setWorkspaceAutonomy (cap-only patch) PRESERVES the stored mode', async () => {
+    await setWorkspaceMode('ws-1', 'orchestrate', dir);
+    // The loop cap-override path patches ONLY caps — the mode must survive.
+    const next = await setWorkspaceAutonomy('ws-1', { continueInstruction: false }, dir);
+    expect(next.mode).toBe('orchestrate');
+    expect(next.continueInstruction).toBe(false);
   });
 
   it('missing / corrupt file fails closed to DEFAULT (never throws)', () => {
@@ -55,35 +104,43 @@ describe('deckAutonomyStore', () => {
     expect(loadDeckAutonomy(dir)).toEqual({});
   });
 
-  it('sanitizes hand-edited entries: dangerous caps only true when EXACTLY true', () => {
+  it('legacy entries with NO mode field back-derive one from caps', () => {
     fs.writeFileSync(
       getDeckAutonomyPath(dir),
       JSON.stringify({
-        'ws-1': { summarize: false, continueInstruction: 'yes', approvalPress: 1 },
-        'ws-2': { approvalPress: true },
-        'bad key!': { approvalPress: true },
+        'ws-legacy-orch': { summarize: true, continueInstruction: true, approvalPress: true },
+        'ws-legacy-assist': { summarize: true, continueInstruction: true, approvalPress: false },
+        'ws-legacy-default': { summarize: true, continueInstruction: false, approvalPress: false },
       }),
       'utf8',
     );
-    // ws-1: summarize explicitly false; the two dangerous caps were non-boolean
-    // truthy → coerced OFF (fail-closed).
-    expect(loadWorkspaceAutonomy('ws-1', dir)).toEqual({
-      summarize: false,
-      continueInstruction: false,
-      approvalPress: false,
-    });
-    // ws-2: an explicit true is honored.
-    expect(loadWorkspaceAutonomy('ws-2', dir)).toEqual({
-      summarize: true,
-      continueInstruction: false,
-      approvalPress: true,
-    });
-    // Bad workspace key dropped entirely → DEFAULT.
-    expect(loadWorkspaceAutonomy('bad key!', dir)).toEqual({ ...DEFAULT_AUTONOMY });
+    expect(loadWorkspaceMode('ws-legacy-orch', dir)).toBe('orchestrate');
+    expect(loadWorkspaceMode('ws-legacy-assist', dir)).toBe('assist');
+    // pre-mode "report only" default → the new product default (spam fix applied).
+    expect(loadWorkspaceMode('ws-legacy-default', dir)).toBe('assist');
+  });
+
+  it('a stored valid mode field is used as-is', () => {
+    fs.writeFileSync(
+      getDeckAutonomyPath(dir),
+      JSON.stringify({ 'ws-1': { mode: 'manual', summarize: false, continueInstruction: false, approvalPress: false } }),
+      'utf8',
+    );
+    expect(loadWorkspaceMode('ws-1', dir)).toBe('manual');
+  });
+
+  it('an invalid stored mode string falls back to deriveMode(caps)', () => {
+    fs.writeFileSync(
+      getDeckAutonomyPath(dir),
+      JSON.stringify({ 'ws-1': { mode: 'bogus', summarize: true, continueInstruction: false, approvalPress: true } }),
+      'utf8',
+    );
+    // caps have approval on → derives orchestrate.
+    expect(loadWorkspaceMode('ws-1', dir)).toBe('orchestrate');
   });
 
   it('a bad workspaceId never writes a key and returns DEFAULT', async () => {
-    const r = await setWorkspaceAutonomy('bad key!', { approvalPress: true }, dir);
+    const r = await setWorkspaceMode('bad key!', 'orchestrate', dir);
     expect(r).toEqual({ ...DEFAULT_AUTONOMY });
     expect(loadDeckAutonomy(dir)).toEqual({});
   });

--- a/src/main/deck/deckAutonomyStore.ts
+++ b/src/main/deck/deckAutonomyStore.ts
@@ -32,7 +32,47 @@ import path from 'node:path';
 import { getWmuxDir } from '../../daemon/config';
 import { atomicReadJSONSync, atomicWriteJSON } from '../../daemon/util/atomicWrite';
 
+// ─── Agent mode (per-workspace, owner design 2026-07-13) ─────────────────────
+//
+// The user-facing control. One of four levels; the three raw caps below are
+// DERIVED from it (modeToCaps) and the coalescer reads `mode` for its wake
+// policy. This is the single knob; caps are the mechanism.
+//
+//   off          no wake; the handler ALSO tears down running loops + disables
+//                cadence schedules (kill switch). Human can still type.
+//   manual       no ambient wake (stop/awaiting events consumed silently). A
+//                loop the user explicitly started still wakes (override).
+//   assist       value-filtered wake: ambient wakes ONLY on awaiting_input
+//                (a pane blocked on input) — plain agent.stop is dropped, which
+//                is the summary-spam we are killing. A running loop wakes on
+//                everything (override) and its turns may drive panes.
+//   orchestrate  wake on every lifecycle event; may drive + press approvals.
+//
+//   wake policy:  off/manual → 'none'   assist → 'value-filtered'   orch → 'all'
+//   (a RUNNING loop overrides to 'all' in every mode except off, mirroring the
+//    global auto-wake switch's loop carve-out.)
+export type AgentMode = 'off' | 'manual' | 'assist' | 'orchestrate';
+
+export type WakePolicy = 'none' | 'value-filtered' | 'all';
+
+/** The wake policy a mode implies (before the running-loop override). */
+export function modeToWakePolicy(mode: AgentMode): WakePolicy {
+  switch (mode) {
+    case 'orchestrate':
+      return 'all';
+    case 'assist':
+      return 'value-filtered';
+    case 'manual':
+    case 'off':
+      return 'none';
+  }
+}
+
 export interface WorkspaceAutonomy {
+  /** The user-facing mode this workspace is in. Source of truth; the three
+   *  caps below are derived from it on write (a loop may transiently override
+   *  the caps, never the mode). */
+  mode: AgentMode;
   /** Open a turn that reports fleet state and stops. Default on. */
   summarize: boolean;
   /** Brain may send a follow-up instruction into a pane. Default off. */
@@ -41,11 +81,45 @@ export interface WorkspaceAutonomy {
   approvalPress: boolean;
 }
 
-/** Fail-closed default: report state, touch nothing. */
+const ALL_MODES: readonly AgentMode[] = ['off', 'manual', 'assist', 'orchestrate'];
+
+/** Derive the three raw caps from a mode. The dangerous caps (approvalPress)
+ *  stay OFF except in `orchestrate`, so a fresh/corrupt workspace never gains
+ *  auto-approval. `continueInstruction` is on for assist/orchestrate but only
+ *  bites under a running loop (ambient assist drops plain stops via the value
+ *  filter), so an ambient assist workspace is a notifier, not a driver. */
+export function modeToCaps(mode: AgentMode): Omit<WorkspaceAutonomy, 'mode'> {
+  switch (mode) {
+    case 'orchestrate':
+      return { summarize: true, continueInstruction: true, approvalPress: true };
+    case 'assist':
+      return { summarize: true, continueInstruction: true, approvalPress: false };
+    case 'manual':
+    case 'off':
+      return { summarize: false, continueInstruction: false, approvalPress: false };
+  }
+}
+
+/** Back-derive a mode from raw caps — used ONLY for legacy files written before
+ *  the `mode` field existed (after that the mode is always stored). Maps by the
+ *  dangerous caps: approval → orchestrate; continue → assist; else → the product
+ *  default (the pre-mode "report only" default becomes assist + value filter,
+ *  which is exactly the summary-spam fix applied to existing users). */
+export function deriveMode(caps: Omit<WorkspaceAutonomy, 'mode'>): AgentMode {
+  if (caps.approvalPress) return 'orchestrate';
+  if (caps.continueInstruction) return 'assist';
+  return DEFAULT_MODE;
+}
+
+/** Product default for a workspace with no entry (owner decision 2026-07-13). */
+export const DEFAULT_MODE: AgentMode = 'assist';
+
+/** Product default entry. NOTE: the only truly dangerous cap (approvalPress)
+ *  stays false here, so this doubles as the fail-closed fallback on a torn
+ *  file — a fresh/corrupt workspace can notify but never auto-approve. */
 export const DEFAULT_AUTONOMY: Readonly<WorkspaceAutonomy> = {
-  summarize: true,
-  continueInstruction: false,
-  approvalPress: false,
+  mode: DEFAULT_MODE,
+  ...modeToCaps(DEFAULT_MODE),
 };
 
 /** Same workspace-id shape the deck handler validates before keying maps. */
@@ -55,17 +129,24 @@ export function getDeckAutonomyPath(dir: string = getWmuxDir()): string {
   return path.join(dir, 'deck-autonomy.json');
 }
 
-/** Coerce one raw entry to a WorkspaceAutonomy, defaulting every field
- *  fail-closed. A non-boolean `summarize` still defaults ON (harmless); the two
- *  dangerous caps default OFF unless the stored value is EXACTLY `true`. */
+/** Coerce one raw entry to a WorkspaceAutonomy. The caps are read as stored (a
+ *  loop may have transiently overridden them). The mode is used as stored when
+ *  it is a known value; a legacy entry with no `mode` field back-derives one
+ *  from its caps (deriveMode) so old files keep working. */
 function sanitizeEntry(raw: unknown): WorkspaceAutonomy {
   if (!raw || typeof raw !== 'object') return { ...DEFAULT_AUTONOMY };
   const o = raw as Record<string, unknown>;
-  return {
+  const caps = {
+    // summarize's legacy default was ON; keep that unless EXACTLY false.
     summarize: o.summarize === false ? false : true,
     continueInstruction: o.continueInstruction === true,
     approvalPress: o.approvalPress === true,
   };
+  const mode: AgentMode =
+    typeof o.mode === 'string' && (ALL_MODES as readonly string[]).includes(o.mode)
+      ? (o.mode as AgentMode)
+      : deriveMode(caps);
+  return { mode, ...caps };
 }
 
 type AutonomyFile = Record<string, WorkspaceAutonomy>;
@@ -118,6 +199,9 @@ export async function setWorkspaceAutonomy(
   const all = loadAll(dir);
   const current = all[workspaceId] ?? { ...DEFAULT_AUTONOMY };
   const next: WorkspaceAutonomy = {
+    // The mode is preserved unless explicitly patched — the loop cap-override
+    // path patches ONLY caps and must never silently change the stored mode.
+    mode: patch.mode ?? current.mode,
     summarize: typeof patch.summarize === 'boolean' ? patch.summarize : current.summarize,
     continueInstruction:
       typeof patch.continueInstruction === 'boolean'
@@ -129,4 +213,28 @@ export async function setWorkspaceAutonomy(
   all[workspaceId] = next;
   await atomicWriteJSON(getDeckAutonomyPath(dir), all);
   return next;
+}
+
+/** Set a workspace's MODE and write the mode-derived caps together (the atomic
+ *  "one knob" operation). Returns the resolved entry. A bad workspaceId or an
+ *  unknown mode is a no-op returning DEFAULT (never writes a bad key/mode).
+ *  The `off` teardown (stop loops / disable schedules) lives in the handler —
+ *  this store only owns the mode+caps write. */
+export async function setWorkspaceMode(
+  workspaceId: string,
+  mode: AgentMode,
+  dir?: string,
+): Promise<WorkspaceAutonomy> {
+  if (!WORKSPACE_ID_RE.test(workspaceId)) return { ...DEFAULT_AUTONOMY };
+  if (!(ALL_MODES as readonly string[]).includes(mode)) return { ...DEFAULT_AUTONOMY };
+  const all = loadAll(dir);
+  const next: WorkspaceAutonomy = { mode, ...modeToCaps(mode) };
+  all[workspaceId] = next;
+  await atomicWriteJSON(getDeckAutonomyPath(dir), all);
+  return next;
+}
+
+/** Resolve just the mode (fail-closed to the product default). */
+export function loadWorkspaceMode(workspaceId: string, dir?: string): AgentMode {
+  return loadWorkspaceAutonomy(workspaceId, dir).mode;
 }

--- a/src/main/ipc/handlers/__tests__/deck.handler.loop.test.ts
+++ b/src/main/ipc/handlers/__tests__/deck.handler.loop.test.ts
@@ -80,20 +80,32 @@ vi.mock('../../../deck/deckLoopStateStore', () => ({
   }),
 }));
 
-// Autonomy store: record every cap write.
+// Autonomy store: record every cap write. Pure functions (modeToCaps /
+// modeToWakePolicy / deriveMode) use the REAL implementation via importOriginal
+// — only the IO reads/writes are stubbed. The workspace's resting mode is
+// 'assist' (the product default), so loop-stop restores to assist caps.
 const capWrites: { ws: string; patch: Record<string, unknown> }[] = [];
-vi.mock('../../../deck/deckAutonomyStore', () => ({
-  DEFAULT_AUTONOMY: { summarize: true, continueInstruction: false, approvalPress: false },
-  loadWorkspaceAutonomy: vi.fn(() => ({
-    summarize: true,
-    continueInstruction: false,
-    approvalPress: false,
-  })),
-  setWorkspaceAutonomy: vi.fn(async (ws: string, patch: Record<string, unknown>) => {
-    capWrites.push({ ws, patch });
-    return patch;
-  }),
-}));
+vi.mock('../../../deck/deckAutonomyStore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../deck/deckAutonomyStore')>();
+  return {
+    ...actual,
+    loadWorkspaceAutonomy: vi.fn(() => ({
+      mode: 'assist' as const,
+      summarize: true,
+      continueInstruction: true,
+      approvalPress: false,
+    })),
+    loadWorkspaceMode: vi.fn(() => 'assist' as const),
+    setWorkspaceAutonomy: vi.fn(async (ws: string, patch: Record<string, unknown>) => {
+      capWrites.push({ ws, patch });
+      return patch;
+    }),
+    setWorkspaceMode: vi.fn(async (ws: string, mode: string) => {
+      capWrites.push({ ws, patch: { mode } });
+      return { mode, ...actual.modeToCaps(mode as import('../../../deck/deckAutonomyStore').AgentMode) };
+    }),
+  };
+});
 
 // Schedule store: in-memory array; scheduler stays inert (nothing due).
 interface FakeSchedule {
@@ -257,8 +269,10 @@ describe('deck:loop:stop / pause / resume — the OFF contract', () => {
     expect(res.ok).toBe(true);
     expect(loops.has('ws-1')).toBe(false);
     expect(schedules).toHaveLength(0); // pending cadence never fires post-stop
+    // Loop-stop restores caps to the workspace's MODE (assist), not a hardcoded
+    // fail-closed floor — the mode is the resting autonomy the user chose.
     expect(capWrites).toEqual([
-      { ws: 'ws-1', patch: { summarize: true, continueInstruction: false, approvalPress: false } },
+      { ws: 'ws-1', patch: { summarize: true, continueInstruction: true, approvalPress: false } },
     ]);
   });
 
@@ -274,9 +288,11 @@ describe('deck:loop:stop / pause / resume — the OFF contract', () => {
     await invoke(IPC.DECK_LOOP_PAUSE, { workspaceId: 'ws-1' });
     expect(loops.get('ws-1')!.status).toBe('paused');
     expect(schedules[0].enabled).toBe(false);
+    // pause restores to mode (assist) caps — the loop-state 'paused' + removed
+    // override is what stops the driving, not a cap floor.
     expect(capWrites.pop()).toEqual({
       ws: 'ws-1',
-      patch: { summarize: true, continueInstruction: false, approvalPress: false },
+      patch: { summarize: true, continueInstruction: true, approvalPress: false },
     });
 
     await invoke(IPC.DECK_LOOP_RESUME, { workspaceId: 'ws-1' });
@@ -345,11 +361,14 @@ describe('deck:send × auto-wake race — the loop-stall guard (dogfood finding 
     await Promise.resolve(); // let it enter busy
 
     // A worker pane stops while the brain is busy — the coalescer buffers it.
+    // awaiting_input (not a plain stop) so the default assist mode's value
+    // filter wakes on it — this test exercises the busy-reject plumbing, not
+    // the wake filter.
     eventBus.emit({
       type: 'agent.lifecycle',
       workspaceId: 'ws-1',
       ptyId: 'p1',
-      kind: 'agent.stop',
+      kind: 'agent.awaiting_input',
       source: 'hook',
       agent: 'claude',
       decision: 'emit',

--- a/src/main/ipc/handlers/deck.handler.ts
+++ b/src/main/ipc/handlers/deck.handler.ts
@@ -36,7 +36,10 @@ import { CommanderEventCoalescer } from '../../deck/CommanderEventCoalescer';
 import {
   loadWorkspaceAutonomy,
   setWorkspaceAutonomy,
-  DEFAULT_AUTONOMY,
+  setWorkspaceMode,
+  loadWorkspaceMode,
+  modeToCaps,
+  type AgentMode,
 } from '../../deck/deckAutonomyStore';
 import { loadAutoWakeEnabled, setAutoWakeEnabled } from '../../deck/deckAutoWakeStore';
 import {
@@ -431,8 +434,23 @@ export function registerDeckHandler(
       approvalPress: false,
     });
   };
+  // Loop-stop restores caps to the workspace's CURRENT MODE, not the global
+  // DEFAULT — otherwise stopping a loop in an `orchestrate` workspace would
+  // silently downgrade it to the default mode's caps. The mode is the source
+  // of truth; the loop only ever transiently overrode the caps.
   const dropCaps = async (workspaceId: string): Promise<void> => {
-    await setWorkspaceAutonomy(workspaceId, { ...DEFAULT_AUTONOMY });
+    const mode = loadWorkspaceMode(workspaceId);
+    await setWorkspaceAutonomy(workspaceId, modeToCaps(mode));
+  };
+  // The `off` mode kill-switch teardown: stop any running loop and delete its
+  // cadence schedule so nothing autonomous survives. Same posture as loop-stop
+  // (which also drops caps — here the mode write owns the caps). Idempotent.
+  const tearDownAutomation = async (workspaceId: string): Promise<void> => {
+    const loop = loadWorkspaceLoopState(workspaceId);
+    if (loop?.scheduleId) {
+      await saveDeckSchedules(loadDeckSchedules().filter((s) => s.id !== loop.scheduleId));
+    }
+    if (loop) await clearLoop(workspaceId);
   };
   const setLoopScheduleEnabled = async (
     scheduleId: string | undefined,
@@ -682,6 +700,49 @@ export function registerDeckHandler(
     }),
   );
 
+  // ── Per-workspace agent mode (off/manual/assist/orchestrate) ──────────────
+  const VALID_MODES: ReadonlySet<string> = new Set(['off', 'manual', 'assist', 'orchestrate']);
+
+  ipcMain.removeHandler(IPC.DECK_MODE_GET);
+  ipcMain.handle(
+    IPC.DECK_MODE_GET,
+    wrapHandler(IPC.DECK_MODE_GET, async (
+      _event: Electron.IpcMainInvokeEvent,
+      raw: unknown,
+    ): Promise<{ mode: AgentMode | null }> => {
+      const req = (raw && typeof raw === 'object' && !Array.isArray(raw))
+        ? (raw as Record<string, unknown>)
+        : {};
+      const workspaceId = readWorkspaceId(req);
+      if (!workspaceId) return { mode: null };
+      return { mode: loadWorkspaceMode(workspaceId) };
+    }),
+  );
+
+  ipcMain.removeHandler(IPC.DECK_MODE_SET);
+  ipcMain.handle(
+    IPC.DECK_MODE_SET,
+    wrapHandler(IPC.DECK_MODE_SET, async (
+      _event: Electron.IpcMainInvokeEvent,
+      raw: unknown,
+    ): Promise<{ ok: boolean; mode?: AgentMode; code?: string }> => {
+      const req = (raw && typeof raw === 'object' && !Array.isArray(raw))
+        ? (raw as Record<string, unknown>)
+        : {};
+      const workspaceId = readWorkspaceId(req);
+      if (!workspaceId) return { ok: false, code: 'invalid_workspace' };
+      const mode = req.mode;
+      if (typeof mode !== 'string' || !VALID_MODES.has(mode)) {
+        return { ok: false, code: 'invalid_mode' };
+      }
+      // `off` is the kill switch: tear down running automation BEFORE writing
+      // the mode+caps, so a stopped loop can't race a final wake in between.
+      if (mode === 'off') await tearDownAutomation(workspaceId);
+      const next = await setWorkspaceMode(workspaceId, mode as AgentMode);
+      return { ok: true, mode: next.mode };
+    }),
+  );
+
   const disposeAll = (): void => {
     for (const { manager } of managers.values()) manager.dispose();
     managers.clear();
@@ -713,5 +774,7 @@ export function registerDeckHandler(
     ipcMain.removeHandler(IPC.DECK_LOOP_SKILLS);
     ipcMain.removeHandler(IPC.DECK_AUTOWAKE_GET);
     ipcMain.removeHandler(IPC.DECK_AUTOWAKE_SET);
+    ipcMain.removeHandler(IPC.DECK_MODE_GET);
+    ipcMain.removeHandler(IPC.DECK_MODE_SET);
   };
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -381,6 +381,20 @@ const electronAPI = {
       set: (enabled: boolean) =>
         ipcRenderer.invoke(IPC.DECK_AUTOWAKE_SET, { enabled }) as Promise<{ enabled: boolean }>,
     },
+    // Per-workspace agent mode — off/manual/assist/orchestrate. The single
+    // autonomy knob; 'off' also tears down running loops + schedules.
+    mode: {
+      get: (workspaceId: string) =>
+        ipcRenderer.invoke(IPC.DECK_MODE_GET, { workspaceId }) as Promise<{
+          mode: import('../main/deck/deckAutonomyStore').AgentMode | null;
+        }>,
+      set: (workspaceId: string, mode: import('../main/deck/deckAutonomyStore').AgentMode) =>
+        ipcRenderer.invoke(IPC.DECK_MODE_SET, { workspaceId, mode }) as Promise<{
+          ok: boolean;
+          mode?: import('../main/deck/deckAutonomyStore').AgentMode;
+          code?: string;
+        }>,
+    },
     // Normalized BrainEvent push, enveloped with the workspace whose
     // orchestrator produced it (see BrainAdapter.BrainEvent).
     onStream: (

--- a/src/renderer/components/Deck/AgentModeChip.tsx
+++ b/src/renderer/components/Deck/AgentModeChip.tsx
@@ -1,0 +1,148 @@
+// ─── Command Deck — per-workspace agent mode chip ───────────────────────────
+//
+// The single user-facing autonomy control (owner design 2026-07-13). Lives with
+// the quick-action chips so the CURRENT mode is always visible — the answer to
+// both "why is it quiet?" and "why is it talking?" is on screen. Click → a
+// dropdown of the four modes.
+//
+//   off          no autonomy; also stops running loops + schedules (kill switch)
+//   manual       replies only when you type (ambient events consumed silently)
+//   assist       wakes only when a pane needs input, or to drive a running loop
+//   orchestrate  wakes on every agent event; may drive + press approvals
+//
+// Self-contained (the DeckLoopPanel / DeckSchedulesPanel pattern): all IPC goes
+// through the injected `api` prop, defaulting to window.electronAPI.deck.mode in
+// the container. Renders nothing when the preload is absent, so pure jsdom tests
+// of the parent view are unaffected.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { tokenAttrs } from '../../themes';
+import { FOCUS_RING } from '../focusRing';
+import type { AgentMode } from '../../../main/deck/deckAutonomyStore';
+
+export interface AgentModeApi {
+  get: (workspaceId: string) => Promise<{ mode: AgentMode | null }>;
+  set: (
+    workspaceId: string,
+    mode: AgentMode,
+  ) => Promise<{ ok: boolean; mode?: AgentMode; code?: string }>;
+}
+
+/** Order shown in the dropdown, least → most autonomous. */
+const MODE_ORDER: readonly AgentMode[] = ['off', 'manual', 'assist', 'orchestrate'];
+
+function modeLabel(t: (k: string) => string, mode: AgentMode): string {
+  return t(`deck.mode.${mode}`) || mode;
+}
+function modeDesc(t: (k: string) => string, mode: AgentMode): string {
+  return t(`deck.mode.${mode}Desc`) || '';
+}
+
+export function AgentModeChip({
+  api,
+  workspaceId,
+  t,
+}: {
+  /** Injected in tests; defaults to the preload bridge in the container. */
+  api: AgentModeApi;
+  workspaceId: string;
+  t: (key: string) => string;
+}): React.ReactElement | null {
+  const [mode, setMode] = useState<AgentMode | null>(null);
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .get(workspaceId)
+      .then((r) => { if (!cancelled) setMode(r.mode ?? 'assist'); })
+      .catch(() => { if (!cancelled) setMode('assist'); });
+    return () => { cancelled = true; };
+  }, [api, workspaceId]);
+
+  // Close the dropdown on outside click / Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const pick = useCallback(
+    (next: AgentMode) => {
+      setOpen(false);
+      const prev = mode;
+      setMode(next); // optimistic
+      api
+        .set(workspaceId, next)
+        .then((r) => { if (r.ok && r.mode) setMode(r.mode); else setMode(prev); })
+        .catch(() => setMode(prev));
+    },
+    [api, workspaceId, mode],
+  );
+
+  if (mode === null) return null; // pre-first-read; avoids a label flash
+
+  return (
+    <div ref={rootRef} className="relative" data-agent-mode-chip>
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className={`px-2.5 py-1 rounded-md text-[12px] text-[var(--text-sub)] bg-[rgba(var(--bg-surface-rgb),0.6)] hover:opacity-80 transition-opacity ${FOCUS_RING}`}
+        title={modeDesc(t, mode)}
+        {...tokenAttrs('textSub', 'text')}
+      >
+        {t('deck.mode.label') || 'Mode'}: {modeLabel(t, mode)}
+      </button>
+      {open && (
+        <div
+          role="listbox"
+          className="absolute bottom-full left-0 mb-1 z-50 w-64 bg-[var(--bg-overlay)] border border-[var(--bg-surface)] rounded-md shadow-lg py-1 text-xs"
+        >
+          {MODE_ORDER.map((m) => (
+            <button
+              key={m}
+              type="button"
+              role="option"
+              aria-selected={m === mode}
+              data-mode-option={m}
+              onClick={() => pick(m)}
+              className={`w-full text-left px-3 py-1.5 hover:bg-[var(--bg-surface)] transition-colors ${
+                m === mode ? 'text-[var(--accent)]' : 'text-[var(--text-main)]'
+              }`}
+            >
+              <div className="font-semibold">{modeLabel(t, m)}</div>
+              <div className="text-[var(--text-muted)] text-[10px]">{modeDesc(t, m)}</div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Container: binds the preload bridge. Renders nothing if the API is absent
+ *  (older preload / pure jsdom parent tests). */
+export function AgentModeChipContainer({
+  workspaceId,
+  t,
+}: {
+  workspaceId?: string;
+  t: (key: string) => string;
+}): React.ReactElement | null {
+  const api = (window as unknown as {
+    electronAPI?: { deck?: { mode?: AgentModeApi } };
+  }).electronAPI?.deck?.mode;
+  if (!api || !workspaceId) return null;
+  return <AgentModeChip api={api} workspaceId={workspaceId} t={t} />;
+}

--- a/src/renderer/components/Deck/CommanderView.tsx
+++ b/src/renderer/components/Deck/CommanderView.tsx
@@ -66,6 +66,7 @@ import { buildQuickActions, type DeckQuickAction } from './deckQuickActions';
 import { renderBrainMarkdown } from './BrainMarkdown';
 import { DeckSchedulesPanel } from './DeckSchedulesPanel';
 import { DeckLoopPanel } from './DeckLoopPanel';
+import { AgentModeChipContainer } from './AgentModeChip';
 
 const EMPTY_MESSAGES: ChannelMessage[] = [];
 
@@ -326,6 +327,9 @@ export function CommanderViewContent({
           {/* The one-click loop chip + panel (loop engineering v1) — same
               self-contained pattern; the loop binds to THIS workspace. */}
           <DeckLoopPanel t={t} workspaceId={activeWorkspaceId} cwd={activePaneCwd} />
+          {/* Per-workspace agent mode (off/manual/assist/orchestrate) — the
+              single autonomy knob, always-visible current mode. */}
+          <AgentModeChipContainer t={t} workspaceId={activeWorkspaceId} />
         </div>
       )}
 

--- a/src/renderer/components/Deck/__tests__/AgentModeChip.test.tsx
+++ b/src/renderer/components/Deck/__tests__/AgentModeChip.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+//
+// AgentModeChip: reads the current mode on mount, renders it as a chip, and
+// sets a new mode from the dropdown (optimistic + echo). Injected fake api so
+// no preload/IPC is needed.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { AgentModeChip, type AgentModeApi } from '../AgentModeChip';
+import type { AgentMode } from '../../../../main/deck/deckAutonomyStore';
+
+const t = (k: string) => k; // identity — assert on keys
+
+function render(ui: React.ReactElement): { container: HTMLElement; cleanup: () => void } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(ui));
+  return {
+    container,
+    cleanup: () => { act(() => root.unmount()); container.remove(); },
+  };
+}
+
+const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve(); }); };
+
+const cleanups: Array<() => void> = [];
+afterEach(() => { while (cleanups.length) cleanups.pop()!(); });
+
+function fakeApi(initial: AgentMode): { api: AgentModeApi; sets: AgentMode[] } {
+  const sets: AgentMode[] = [];
+  return {
+    sets,
+    api: {
+      get: async () => ({ mode: initial }),
+      set: async (_ws, mode) => { sets.push(mode); return { ok: true, mode }; },
+    },
+  };
+}
+
+describe('AgentModeChip', () => {
+  it('renders the current mode label after the initial read', async () => {
+    const { api } = fakeApi('manual');
+    const { container, cleanup } = render(<AgentModeChip api={api} workspaceId="ws-1" t={t} />);
+    cleanups.push(cleanup);
+    await flush();
+    const chip = container.querySelector('[data-agent-mode-chip] button')!;
+    expect(chip.textContent).toContain('deck.mode.manual');
+  });
+
+  it('opens the dropdown and sets a new mode (optimistic + persisted)', async () => {
+    const { api, sets } = fakeApi('assist');
+    const { container, cleanup } = render(<AgentModeChip api={api} workspaceId="ws-1" t={t} />);
+    cleanups.push(cleanup);
+    await flush();
+
+    // open
+    const chip = container.querySelector('[data-agent-mode-chip] > button') as HTMLButtonElement;
+    act(() => chip.click());
+    // pick 'off'
+    const off = container.querySelector('[data-mode-option="off"]') as HTMLButtonElement;
+    expect(off).toBeTruthy();
+    await act(async () => { off.click(); await Promise.resolve(); });
+
+    expect(sets).toEqual(['off']);
+    // chip reflects the new mode; dropdown closed
+    expect((container.querySelector('[data-agent-mode-chip] > button')!).textContent).toContain('deck.mode.off');
+    expect(container.querySelector('[data-mode-option="off"]')).toBeNull();
+  });
+
+  it('renders nothing until the first read resolves (no label flash)', () => {
+    const api: AgentModeApi = { get: () => new Promise(() => {}), set: async () => ({ ok: true }) };
+    const { container, cleanup } = render(<AgentModeChip api={api} workspaceId="ws-1" t={t} />);
+    cleanups.push(cleanup);
+    expect(container.querySelector('[data-agent-mode-chip]')).toBeNull();
+  });
+});

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -293,6 +293,17 @@ export const en = {
   'settings.orchestratorModelDesc':
     'The Claude model the Command Deck orchestrator runs on. Changes apply from your next command; the conversation carries over.',
   'settings.orchestratorModelDefault': 'Default (subscription model)',
+  // Per-workspace agent mode — the single autonomy knob (off/manual/assist/
+  // orchestrate). Shown as a chip in the agent panel.
+  'deck.mode.label': 'Mode',
+  'deck.mode.off': 'Off',
+  'deck.mode.offDesc': 'No autonomy. Stops any running loop and schedule. You can still type.',
+  'deck.mode.manual': 'Manual',
+  'deck.mode.manualDesc': 'Replies only when you type. Never wakes itself on agent events.',
+  'deck.mode.assist': 'Assist',
+  'deck.mode.assistDesc': 'Wakes only when a pane needs input, or to drive a running loop. No summary spam.',
+  'deck.mode.orchestrate': 'Orchestrate',
+  'deck.mode.orchestrateDesc': 'Wakes on every agent event; may drive panes and press approvals.',
   // Global event-push kill switch: OFF stops the unrequested wake-turns
   // (each one is a real token-spending SDK turn); a running loop still wakes.
   'settings.autoWake': 'Auto-wake on pane events',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -237,6 +237,17 @@ export const ko = {
   'settings.orchestratorModelDesc':
     '커맨드 데크 agent가 사용할 Claude 모델. 변경은 다음 지시부터 적용되고 대화는 이어집니다.',
   'settings.orchestratorModelDefault': '기본 (구독 기본 모델)',
+  // 워크스페이스별 agent 모드 — 단일 자율성 노브(off/manual/assist/orchestrate).
+  // agent 패널에 칩으로 표시.
+  'deck.mode.label': '모드',
+  'deck.mode.off': 'Off',
+  'deck.mode.offDesc': '자율 동작 없음. 실행 중인 루프·예약도 정지. 직접 타이핑은 여전히 가능.',
+  'deck.mode.manual': 'Manual',
+  'deck.mode.manualDesc': '직접 물을 때만 대답. agent 이벤트로 스스로 깨어나지 않음.',
+  'deck.mode.assist': 'Assist',
+  'deck.mode.assistDesc': 'pane이 입력을 기다릴 때, 또는 실행 중인 루프를 진행할 때만 깨어남. 요약 스팸 없음.',
+  'deck.mode.orchestrate': 'Orchestrate',
+  'deck.mode.orchestrateDesc': '모든 agent 이벤트에 깨어남. pane 조작·승인 押下까지 가능.',
   // 이벤트 자동 깨우기 킬스위치: 끄면 요청하지 않은 자동 요약 턴(토큰 소비)이
   // 멈춘다. 실행 중인 루프는 계속 깨운다.
   'settings.autoWake': 'pane 이벤트 자동 깨우기',

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -147,6 +147,12 @@ export const IPC = {
   //   running loop still wakes. Same renderer-only trust boundary.
   DECK_AUTOWAKE_GET: 'deck:autowake:get',
   DECK_AUTOWAKE_SET: 'deck:autowake:set',
+  //   DECK_MODE_* — the per-workspace agent mode (off/manual/assist/
+  //   orchestrate). Mode is the single user-facing autonomy knob; the raw caps
+  //   are derived from it. `set` with mode='off' also tears down running loops
+  //   + schedules. Same renderer-only trust boundary.
+  DECK_MODE_GET: 'deck:mode:get',
+  DECK_MODE_SET: 'deck:mode:set',
   // Clipboard (main process bridge)
   CLIPBOARD_WRITE: 'clipboard:write',
   CLIPBOARD_READ: 'clipboard:read',


### PR DESCRIPTION
## Summary

Fixes the owner-reported "the agent summarizes every unit of work → token burn." The coarse on/off from 3.21.1 wasn't the answer; the real fix is a **per-workspace mode with a wake value filter**.

Each workspace gets a mode chip (next to the loop/schedule chips) with four levels — the single autonomy knob; the raw caps are derived from it:

| Mode | Behavior |
|------|----------|
| **off** | No autonomy. Stops any running loop + disables its schedule (kill switch). You can still type. |
| **manual** | Replies only when you type. Never wakes on agent events. |
| **assist** (default) | Wakes ONLY on `awaiting_input` (a pane blocked on input), or to drive a running loop. A plain `agent.stop` is dropped — this is the summary spam we remove. |
| **orchestrate** | Wakes on every event; may drive panes and press approvals. |

The current mode is always on screen, so "why is it quiet?" and "why is it talking?" are both answered without digging.

## The token fix (the load-bearing change)

`CommanderEventCoalescer.attemptFlush` gained a wake-policy branch. In `assist` (the default), it drops plain `agent.stop` events (consumes them, advances the watermark so re-enabling never replays a backlog) and only proceeds when an `awaiting_input` remains. A **running loop overrides to wake-on-all** in every mode but `off`, mirroring the global auto-wake switch's loop carve-out. `manual`/`off` consume everything; `orchestrate` is today's wake-on-all.

## Eng-reviewed — issues caught before implementation

1. **Mode ↔ loop-cap desync**: a loop started in `manual` wouldn't wake (mode wake policy = none). Fixed by the running-loop override (a loop always wakes unless `off`).
2. **The plan's "error" wake trigger doesn't exist**: `CoalescedKind` is only `stop | awaiting_input` (`push()` drops the rest), so value-filtered = "drop stop, keep awaiting_input". Simpler and correct.
3. **loop-stop/pause restored to a hardcoded DEFAULT**: now restores to the workspace's mode caps (the mode is the resting autonomy; the loop only transiently overrode).

Owner decisions locked: default = `assist` + filter (legacy all-off entries derive to assist, so the spam fix reaches existing users too); `off` stops automation but still accepts typed turns; the global auto-wake toggle stays as a master override above modes; `approvalPress` stays off except in `orchestrate` (fail-closed preserved).

## Test Coverage

- `deckAutonomyStore`: mode↔caps mapping, wake-policy mapping, legacy `deriveMode`, mode round-trip, cap-patch preserves mode, corrupt-file fail-closed, invalid-mode no-op — 15 tests.
- `CommanderEventCoalescer`: assist drops plain stop (consumed), wakes on awaiting_input, flushes awaiting while consuming a co-buffered stop, loop override, manual consumes all, manual+loop wakes, global-off overrides orchestrate — 8 new tests (43 total green).
- `deck.handler.loop`: off-teardown + loop-stop/pause restore-to-mode via the updated mock — green.
- `AgentModeChip`: jsdom render/select/no-flash — 3 tests.
- tsc + eslint clean (the 2 `constants.ts` `require` warnings are pre-existing in `getPipeName`).

## Notes

- No version bump (PRs never bump — release is an explicit owner action).
- Backend + renderer both change, so this needs a dev restart to dogfood live (HMR covers renderer only). Verified at the unit level; owner dogfood after merge.
- Known local-only failure `diff.handler` symlink EPERM is a pre-existing Windows-privilege flake in an untouched area.
- Follow-up worth considering: the loop `report`/`continue` tier is now largely redundant with the mode — could fold it in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-workspace agent modes: Off, Manual, Assist, and Orchestrate.
  * Added a workspace control for viewing and changing the active agent mode.
  * Agent wake behavior now adjusts based on the selected mode.
  * Switching a workspace to Off stops active loops and removes scheduled activity.
  * Assist is now the default mode, with updated loop stop and pause behavior.
  * Added English and Korean translations for the new mode controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->