### PR TITLE
chore(release): v3.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.21.2] — 2026-07-13
+
 ### Added
 
 - **Per-workspace agent modes — one knob for how autonomous the agent is.** Each workspace gets a mode chip (next to the loop and schedule chips) with four levels. **Off**: no autonomy at all, and it stops any running loop and schedule for that workspace (you can still type to it). **Manual**: replies only when you type, never wakes itself on agent events. **Assist** (the default): wakes only when a pane is actually blocked waiting for input, or to drive a loop you started — a plain "a turn finished" no longer triggers a summary, which is the token-burning spam this removes. **Orchestrate**: wakes on every agent event and may drive panes and press approvals. The current mode is always visible, so "why is it quiet?" and "why is it talking?" are both answered on screen. The global auto-wake switch from 3.21.1 stays as a master override on top of the per-workspace modes.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.21.1 sources.** This file is produced by
+> **Generated from wmux v3.21.2 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Patch release: per-workspace agent modes with a wake value filter (#433) — the structural fix for the "agent summarizes every turn" token burn.

- `package.json` 3.21.1 → 3.21.2
- CHANGELOG: `[Unreleased]` → `[3.21.2] — 2026-07-13`
- `docs/api/reference.md` regenerated (CI drift guard)

Tag `v3.21.2` will be pushed after this merges (installer + Chocolatey/winget hang off the tag).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version 3.21.2 dated July 13, 2026.
  * Updated the API reference documentation to reflect version 3.21.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->