### PR TITLE
perf(hooks): drop PostToolUse — drive the running dot from daemon bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Agents no longer run a helper process on every single tool call.** The Claude integration used to fire a small background process after each tool use, only to keep the "running" dot lit in the fleet view — on a tool-heavy turn that added up to seconds of overhead per turn and a lot of process churn. The running dots now come from the daemon watching each pane's output directly (which it already did), so background agents still show as working with zero per-tool overhead. One tradeoff: the fleet card's one-line "what tool just ran" label goes away for Claude (the daemon can't see the tool name), falling back to the terminal's last line instead. Existing installs pick this up when the plugin/hooks are next updated.
+
 ## [3.21.2] — 2026-07-13
 
 ### Added

--- a/integrations/claude/.claude-plugin/plugin.json
+++ b/integrations/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux-claude-integration",
   "version": "0.1.0",
-  "description": "Deterministic Claude Code → wmux notifications via PostToolUse / Stop / SubagentStop / SessionStart hooks. Replaces wmux's regex-based agent detector with 100%-accurate hook signals when this plugin is installed.",
+  "description": "Deterministic Claude Code → wmux notifications via Stop / SubagentStop / SessionStart / PreToolUse hooks. Replaces wmux's regex-based agent detector with 100%-accurate hook signals when this plugin is installed.",
   "author": {
     "name": "wmux",
     "url": "https://github.com/openwong2kim/wmux"

--- a/integrations/claude/hooks/hooks.json
+++ b/integrations/claude/hooks/hooks.json
@@ -11,17 +11,6 @@
         ]
       }
     ],
-    "PostToolUse": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/bin/wmux-bridge.mjs\" PostToolUse"
-          }
-        ]
-      }
-    ],
     "Stop": [
       {
         "matcher": "",

--- a/src/cli/commands/__tests__/setupHooks.test.ts
+++ b/src/cli/commands/__tests__/setupHooks.test.ts
@@ -47,7 +47,7 @@ describe('installHooks', () => {
     expect(outcome.ok).toBe(true);
     expect(outcome.error).toBeNull();
     expect(outcome.events.sort()).toEqual(
-      ['PostToolUse', 'SessionStart', 'Stop', 'SubagentStop'],
+      ['SessionStart', 'Stop', 'SubagentStop'],
     );
     expect(fs.existsSync(bridgeDest)).toBe(true);
     expect(fs.readFileSync(bridgeDest, 'utf8')).toBe('BRIDGE_CONTENT_V1\n');
@@ -55,7 +55,7 @@ describe('installHooks', () => {
     const s = readSettings();
     const hooks = s.hooks as Record<string, unknown[]>;
     expect(Object.keys(hooks).sort()).toEqual(
-      ['PostToolUse', 'SessionStart', 'Stop', 'SubagentStop'],
+      ['SessionStart', 'Stop', 'SubagentStop'],
     );
     // Each entry references the stable dest path, NOT the source/install dir.
     const stop = hooks.Stop[0] as { hooks: { command: string }[] };
@@ -116,7 +116,7 @@ describe('installHooks', () => {
     installHooks(paths());
 
     const hooks = readSettings().hooks as Record<string, unknown[]>;
-    for (const event of ['Stop', 'SubagentStop', 'SessionStart', 'PostToolUse']) {
+    for (const event of ['Stop', 'SubagentStop', 'SessionStart']) {
       const wmuxGroups = (hooks[event] as { hooks: { command: string }[] }[]).filter((g) =>
         g.hooks.some((h) => h.command.includes('wmux-bridge.mjs')),
       );
@@ -172,7 +172,7 @@ describe('removeHooks', () => {
 
     const outcome = removeHooks(paths());
     expect(outcome.ok).toBe(true);
-    expect(outcome.removed).toBe(4);
+    expect(outcome.removed).toBe(3);
 
     const s = readSettings();
     expect(s.model).toBe('opus');
@@ -234,7 +234,7 @@ describe('statusHooks', () => {
     const s = statusHooks(paths());
     expect(s.settingsExists).toBe(true);
     expect(s.installedEvents.sort()).toEqual(
-      ['PostToolUse', 'SessionStart', 'Stop', 'SubagentStop'],
+      ['SessionStart', 'Stop', 'SubagentStop'],
     );
     expect(s.bridgeExists).toBe(true);
     expect(s.bridgeStale).toBe(false);

--- a/src/cli/commands/setupHooks.ts
+++ b/src/cli/commands/setupHooks.ts
@@ -41,8 +41,11 @@ GLOBAL FLAGS
   --json       Output raw JSON (useful for scripting).
 `.trimStart();
 
-/** The 4 Claude Code hook events wmux subscribes to (mirrors hooks.json). */
-const HOOK_EVENTS = ['Stop', 'SubagentStop', 'SessionStart', 'PostToolUse'] as const;
+/** The Claude Code hook events wmux subscribes to (mirrors hooks.json).
+ *  PostToolUse was removed 2026-07-13: it fired a ~110ms node bridge on EVERY
+ *  tool call only to feed the fleet "running" dot, which the daemon's
+ *  byte-based ActivityMonitor now drives for free (see markSurfaceRunning). */
+const HOOK_EVENTS = ['Stop', 'SubagentStop', 'SessionStart'] as const;
 type HookEvent = (typeof HOOK_EVENTS)[number];
 
 /** Substring that identifies a wmux-owned hook command in settings.json. */

--- a/src/renderer/hooks/__tests__/useNotificationListener.activity.dynamic.test.tsx
+++ b/src/renderer/hooks/__tests__/useNotificationListener.activity.dynamic.test.tsx
@@ -154,6 +154,27 @@ describe('useNotificationListener — Fleet activity line (METADATA_UPDATE.activ
     expect(useStore.getState().surfaceActivity['pty-1']).toBe('✎ leak.ts');
   });
 
+  // Byte-based per-PTY 'running' (daemon ActivityMonitor) has no activity
+  // string; it must stamp the running freshness clock (surfaceActivityAt) so a
+  // background dot lights — this replaced the per-tool PostToolUse hook. The
+  // attention-only surfaceAgentStatus map still drops 'running'.
+  it('stamps surfaceActivityAt from a byte-based agentStatus=running (no string)', () => {
+    seedActivePaneSurface('pty-1');
+    act(() => { metaCb!({ ptyId: 'pty-1', agentStatus: 'running' }); });
+    expect(useStore.getState().surfaceActivityAt['pty-1']).toBeGreaterThan(0);
+    // running is not an attention status → not retained in the status map.
+    expect(useStore.getState().surfaceAgentStatus['pty-1']).toBeUndefined();
+    // and no phantom activity string was written.
+    expect(useStore.getState().surfaceActivity['pty-1']).toBeUndefined();
+  });
+
+  it('does NOT stamp surfaceActivityAt for a non-running agentStatus', () => {
+    // Fresh ptyId — surfaceActivityAt is not reset between tests in this suite.
+    seedActivePaneSurface('pty-nr');
+    act(() => { metaCb!({ ptyId: 'pty-nr', agentStatus: 'awaiting_input' }); });
+    expect(useStore.getState().surfaceActivityAt['pty-nr']).toBeUndefined();
+  });
+
   // A metadata payload that also carries a real workspace field (e.g. cwd) must
   // still apply that field; only `activity` is diverted. This proves the
   // destructure removed activity WITHOUT eating the rest of the payload.

--- a/src/renderer/hooks/useNotificationListener.ts
+++ b/src/renderer/hooks/useNotificationListener.ts
@@ -543,6 +543,13 @@ export function useNotificationListener() {
         // metadata update (no agentStatus) is a no-op here.
         if (typeof rest.agentStatus === 'string') {
           state.setSurfaceAgentStatus(ptyId, rest.agentStatus as AgentStatus);
+          // Byte-based per-PTY 'running' (daemon ActivityMonitor) is otherwise
+          // DROPPED by setSurfaceAgentStatus (attention-only). Stamp the running
+          // freshness clock so a BACKGROUND pane's dot lights from bytes — this
+          // replaced the per-tool-call PostToolUse hook as the running source.
+          if (rest.agentStatus === 'running') {
+            state.markSurfaceRunning(ptyId);
+          }
         }
         // Part A: stamp per-surface agent IDENTITY (name + status) keyed by
         // ptyId so a2a_discover / surface_list / pane_list can label each pane

--- a/src/renderer/stores/selectors/__tests__/fleet.test.ts
+++ b/src/renderer/stores/selectors/__tests__/fleet.test.ts
@@ -458,8 +458,10 @@ describe('selectAllWorkspaceAgentStatus', () => {
 describe('selectFleetPanes hook-driven running', () => {
   const NOW = 1_000_000_000_000;
   // One quiet background pane (no attention, no active-metadata running) whose
-  // only signal is a PostToolUse stamp — the "thinking mid-turn / background
-  // running" case the byte-silence path misread as idle.
+  // only signal is a `surfaceActivityAt` stamp — the "thinking mid-turn /
+  // background running" case. The stamp is source-agnostic: since 2026-07-13
+  // it comes from the daemon's byte-based 'running' broadcast (markSurfaceRunning)
+  // rather than the per-tool-call PostToolUse hook; the selector is unchanged.
   const wq = workspace('ws-q', 'quiet', leaf('pq', [surface('sq', 'pty-q')]), 'other-pane');
   const base = { workspaces: [wq], surfaceAgentStatus: {}, surfaceActivity: {} };
 

--- a/src/renderer/stores/slices/__tests__/paneSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneSlice.test.ts
@@ -505,6 +505,19 @@ describe('PaneSlice', () => {
       expect(store.getState().surfaceAgentStatus['']).toBeUndefined();
     });
 
+    it('markSurfaceRunning stamps the freshness clock WITHOUT an activity string', () => {
+      // Byte-based 'running' has no tool name — it must light the dot (via
+      // surfaceActivityAt) but leave surfaceActivity empty (raw-tail fallback).
+      store.getState().markSurfaceRunning('pty-b');
+      expect(store.getState().surfaceActivityAt['pty-b']).toBeGreaterThan(0);
+      expect(store.getState().surfaceActivity['pty-b']).toBeUndefined();
+    });
+
+    it('markSurfaceRunning ignores an empty ptyId', () => {
+      store.getState().markSurfaceRunning('');
+      expect(store.getState().surfaceActivityAt['']).toBeUndefined();
+    });
+
     it('overwrites an existing attention status with a newer attention status', () => {
       store.getState().setSurfaceAgentStatus('pty-1', 'waiting');
       store.getState().setSurfaceAgentStatus('pty-1', 'complete');

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -118,12 +118,24 @@ export interface PaneSlice {
   // (buildSessionData is an allowlist and deliberately omits it).
   surfaceActivity: Record<string, string>;
   setSurfaceActivity: (ptyId: string, activity: string | null) => void;
-  // Hook-driven "running" (orca-style): epoch-ms of each pane's last PostToolUse
-  // activity, stamped alongside surfaceActivity. The fleet selector treats a
-  // fresh stamp (within HOOK_RUNNING_TTL_MS) as 'running' even when the terminal
-  // has gone quiet — so a Claude agent thinking mid-turn (no output, no new
-  // tool) is not misread as idle by the 5s byte-silence path. Cleared with the
-  // activity string (new-idle broadcast / pane disposal).
+  // Stamp the "running" freshness clock for a pane WITHOUT an activity string —
+  // the byte-based per-PTY 'running' broadcast has no tool name. Same 120s-TTL
+  // decay as setSurfaceActivity's stamp; lights background dots from bytes.
+  markSurfaceRunning: (ptyId: string) => void;
+  // "running" freshness (orca-style): epoch-ms of each pane's last activity
+  // signal. The fleet selector treats a fresh stamp (within HOOK_RUNNING_TTL_MS)
+  // as 'running' even when the terminal has gone quiet — so an agent thinking
+  // mid-turn (no output) is not misread as idle by the 5s byte-silence path,
+  // AND a BACKGROUND pane (no ws-metadata status) lights its dot.
+  //
+  // Sources (2026-07-13): the DAEMON's byte-based per-PTY 'running' broadcast
+  // (ActivityMonitor onActive → DaemonNotificationRouter → METADATA_UPDATE.
+  // agentStatus='running' → markSurfaceRunning) is the primary source; this
+  // replaced the per-tool-call PostToolUse hook (which spawned a ~110ms node
+  // bridge on EVERY tool call). An agent that still emits PostToolUse also
+  // stamps this via setSurfaceActivity (which carries the activity string too).
+  // Cleared with the activity string (pane disposal); byte-'running' has no
+  // string, so it stamps the timestamp only (markSurfaceRunning).
   surfaceActivityAt: Record<string, number>;
   // A coarse clock the status derivation re-reads so a fresh stamp DECAYS to
   // idle on its own with no new store event. Bumped ~every 2s by
@@ -278,6 +290,13 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
       delete state.surfaceActivity[ptyId];
       delete state.surfaceActivityAt[ptyId];
     }
+  }),
+
+  markSurfaceRunning: (ptyId) => set((state: StoreState) => {
+    if (!ptyId) return;
+    // Byte-based 'running' with no tool name: stamp only the freshness clock,
+    // NOT the activity string (leave the card's raw-tail fallback in place).
+    state.surfaceActivityAt[ptyId] = Date.now();
   }),
 
   splitCwdSeed: {},


### PR DESCRIPTION
## Summary

Outcome of a "should the PostToolUse hook exist?" review. **Verdict: it can't just be removed, but it can be replaced.**

The Claude plugin's `PostToolUse` hook fires a fresh ~110ms node bridge process on **every tool call** (89% of all hook traffic in bridge.log, dominated by Claude Code). It does **not** stutter wmux — that was the orchestrator-loads-its-own-hooks storm fixed in 3.21.1. The remaining cost is on the **pane agent's tool loop** (~5s of added latency over a 50-tool turn) plus overall machine CPU.

### Why it can't just be removed

`agent.activity` (PostToolUse) feeds `surfaceActivityAt`, which the fleet selector uses (120s TTL) to light the **running dot for background / multi-pane agents** and smooth "thinking mid-turn". That rolls up into the sidebar workspace dots. Remove it blindly and working background agents show idle — a core cockpit regression.

### The replacement (a signal we already had and were discarding)

The daemon's `ActivityMonitor` **already** detects per-PTY 'running' from output **bytes**, and `DaemonNotificationRouter.onActive` **already** broadcasts `METADATA_UPDATE.agentStatus='running'` per-PTY. But the renderer's `setSurfaceAgentStatus` is attention-only and **dropped** 'running' — so background dots had no source but PostToolUse.

Now a byte-`running` update stamps `surfaceActivityAt` via a new `markSurfaceRunning` action (timestamp only, no tool string). The fleet selector is unchanged (source-agnostic); background dots light from bytes with the same 120s TTL. Then PostToolUse comes out of `hooks.json` + the CLI installer, so the per-tool spawn stops.

```
BEFORE:  every tool call → node bridge (~110ms) → agent.activity → surfaceActivityAt → dot
AFTER:   output bytes → daemon ActivityMonitor → METADATA_UPDATE running
                      → markSurfaceRunning → surfaceActivityAt → dot   (0 spawn)
```

## Fidelity (parity, minus the tool-name string)

- **Continuous >120s single op**: both old and new rely on the 120s TTL (a long single `Bash` only fires PostToolUse at completion; bytes fire once per burst). **Parity — no regression.**
- **Low-output tools** (<2000 bytes / 3s, never crossing the byte threshold): bytes may not fire → dot stays idle where PostToolUse lit it. Accepted (a truly low-output agent is barely "visibly running"; the active pane still lights via ws-metadata).
- **Activity STRING** (the "✎ fleet.ts" tool label on the fleet card): lost — bytes carry no tool name. FleetCard already falls back to the raw scrollback tail.

## Scope (surgical)

Codex uses notify (no `hooks.json`), so **Claude was the only PostToolUse source**. Changed: Claude `hooks.json` + `plugin.json` description, the CLI `setupHooks.ts` installer (mirrors hooks.json), `paneSlice.markSurfaceRunning`, the `useNotificationListener` wiring. The dead `agent.activity` path in `hooks.rpc` is left as-is (harmless, and a future agent could register PostToolUse).

## Test Coverage

- `paneSlice`: markSurfaceRunning stamps `surfaceActivityAt` only (no string); empty-ptyId no-op.
- `useNotificationListener` (dynamic): `agentStatus='running'` stamps `surfaceActivityAt` (not the attention map, no phantom string); a non-running status does not stamp.
- `fleet` selector: existing `surfaceActivityAt`→running tests already prove the dot (source-agnostic).
- `setupHooks`: install/remove/status no longer include PostToolUse.
- Broad sweep: renderer hooks/stores + CLI + hooks.rpc — **1081 tests green**; tsc + eslint clean.

## Notes

- No version bump (PRs never bump — release is an explicit owner action).
- Existing installs pick this up when the plugin/hooks are next updated (`wmux setup-hooks` re-run or plugin update); until then they keep firing PostToolUse harmlessly.
- Follow-up if dogfood needs it: an ActivityMonitor "still-active heartbeat" so background dots don't drop during >120s continuous bursts (parity today means it's not required).