### PR TITLE
perf(render): fix multi-workspace lag — memoize panes + isolate AppLayout chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Big responsiveness fix with several workspaces open: switching and typing are smooth again.** With more than one workspace open, any small status update on one terminal (its title, working directory, or "running" indicator changing) re-rendered *every* open workspace's terminal view, not just the one that changed. Since those updates fire constantly while a terminal is active, the cost piled up in direct proportion to how many workspaces you had open, so five workspaces felt roughly five times heavier than one, and even switching between them dragged. Now an update only re-renders the workspace it actually affects. Measured on a live app: a single title change went from re-rendering all workspaces' panes to re-rendering just one.
+
 ### Changed
 
 - **Agents no longer run a helper process on every single tool call.** The Claude integration used to fire a small background process after each tool use, only to keep the "running" dot lit in the fleet view — on a tool-heavy turn that added up to seconds of overhead per turn and a lot of process churn. The running dots now come from the daemon watching each pane's output directly (which it already did), so background agents still show as working with zero per-tool overhead. One tradeoff: the fleet card's one-line "what tool just ran" label goes away for Claude (the daemon can't see the tool name), falling back to the terminal's last line instead. Existing installs pick this up when the plugin/hooks are next updated.

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback } from 'react';
+import { useEffect, useState, useRef, useCallback, memo } from 'react';
 import type { AgentSlug } from '../../../shared/events';
 import type { ResumeBinding } from '../../../shared/agentResume';
 import { useStore } from '../../stores';
@@ -252,6 +252,42 @@ function buildSessionData(dumped: Map<string, boolean>): SessionData {
     agentToolbarNewCommand: state.newConversationCommand,
   };
 }
+
+// One mounted workspace's pane subtree (all workspaces stay mounted; inactive
+// ones are display:none so their terminals keep their scrollback/PTY state).
+//
+// PERF (2026-07-13, measured): AppLayout subscribes to the whole `workspaces`
+// array, so ANY pane's metadata update (title / cwd / agentStatus / byte
+// 'running' — frequent during terminal activity) produces a new `workspaces`
+// array and re-renders AppLayout. Without this memo boundary the .map re-ran
+// every workspace's PaneContainer subtree on every such update — a single
+// title change re-rendered ~104 fibers PER workspace, so cost scaled linearly
+// with workspace count (5 workspaces = 5× the churn, felt as lag + slow
+// switching). immer keeps an UNCHANGED workspace referentially stable, so
+// React.memo here lets the N-1 untouched workspaces bail: a metadata update
+// to workspace X now re-renders only X's slot, not all of them. `isActive`
+// (a bool) flips for exactly two slots on a switch, so switching re-renders
+// just the outgoing + incoming workspace.
+export const WorkspaceSlot = memo(function WorkspaceSlot({
+  workspace,
+  isActive,
+}: {
+  workspace: Workspace;
+  isActive: boolean;
+}) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        display: isActive ? 'flex' : 'none',
+        flexDirection: 'column',
+      }}
+    >
+      <PaneContainer pane={workspace.rootPane} workspace={workspace} isWorkspaceVisible={isActive} />
+    </div>
+  );
+});
 
 export default function AppLayout() {
   // Global guard: blocks webview pointer capture during panel separator drag
@@ -1335,17 +1371,7 @@ export default function AppLayout() {
         ) : (
           <div className="flex-1 min-h-0 relative">
             {workspaces.map((ws) => (
-              <div
-                key={ws.id}
-                style={{
-                  position: 'absolute',
-                  inset: 0,
-                  display: ws.id === activeWorkspaceId ? 'flex' : 'none',
-                  flexDirection: 'column',
-                }}
-              >
-                <PaneContainer pane={ws.rootPane} workspace={ws} isWorkspaceVisible={ws.id === activeWorkspaceId} />
-              </div>
+              <WorkspaceSlot key={ws.id} workspace={ws} isActive={ws.id === activeWorkspaceId} />
             ))}
           </div>
         )}

--- a/src/renderer/components/Layout/__tests__/WorkspaceSlot.memo.test.tsx
+++ b/src/renderer/components/Layout/__tests__/WorkspaceSlot.memo.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+//
+// PERF REGRESSION (2026-07-13, measured root cause): AppLayout renders one
+// WorkspaceSlot per workspace and subscribes to the whole `workspaces` array,
+// so ANY pane's metadata update (title/cwd/agentStatus/byte-running) produces
+// a new workspaces array and re-renders AppLayout. WorkspaceSlot is React.memo
+// so the UNCHANGED workspaces bail — a metadata update to workspace X must
+// re-render ONLY X's slot, not all N. Live measurement before the memo: a
+// single title change re-rendered ALL workspaces' PaneContainer subtrees
+// (~104 fibers × N); after: only the changed one.
+//
+// These tests lock the two facts the memo relies on:
+//   1. WorkspaceSlot bails when its props are referentially equal (memo works).
+//   2. workspaceSlice.updateWorkspaceMetadata keeps OTHER workspaces
+//      referentially STABLE (immer structural sharing) — the property that
+//      makes the memo actually skip them. If a refactor rebuilds the array,
+//      the memo silently stops helping and the perf bug returns.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import type { Workspace } from '../../../../shared/types';
+
+// Mock the heavy PaneContainer with a render counter — we only care that the
+// slot's child re-renders (or not), not the terminal machinery.
+const paneRenders = new Map<string, number>();
+vi.mock('../../Pane/PaneContainer', () => ({
+  default: ({ workspace }: { workspace: Workspace }) => {
+    paneRenders.set(workspace.id, (paneRenders.get(workspace.id) ?? 0) + 1);
+    return null;
+  },
+}));
+
+// vi.mock is hoisted above imports, so this static import gets the mock.
+import { WorkspaceSlot } from '../AppLayout';
+
+function ws(id: string, agentName?: string): Workspace {
+  return {
+    id,
+    name: id,
+    rootPane: { type: 'leaf', id: `${id}-root`, surfaces: [], activeSurfaceId: '' } as unknown as Workspace['rootPane'],
+    activePaneId: `${id}-root`,
+    ...(agentName ? { metadata: { agentName } } : {}),
+  } as Workspace;
+}
+
+const cleanups: Array<() => void> = [];
+afterEach(() => { while (cleanups.length) cleanups.pop()!(); paneRenders.clear(); });
+
+function mount(node: React.ReactNode) {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  const root = createRoot(el);
+  act(() => root.render(node));
+  cleanups.push(() => { act(() => root.unmount()); el.remove(); });
+  return { el, rerender: (n: React.ReactNode) => act(() => root.render(n)) };
+}
+
+describe('WorkspaceSlot memo (perf regression guard)', () => {
+  it('does NOT re-render PaneContainer when props are referentially equal', () => {
+    const a = ws('a');
+    const { rerender } = mount(<WorkspaceSlot workspace={a} isActive={false} />);
+    expect(paneRenders.get('a')).toBe(1);
+    // Same workspace ref + same isActive → memo bails, no child re-render.
+    rerender(<WorkspaceSlot workspace={a} isActive={false} />);
+    expect(paneRenders.get('a')).toBe(1);
+  });
+
+  it('DOES re-render when the workspace reference changes (a real update)', () => {
+    const a1 = ws('a', 'n1');
+    const { rerender } = mount(<WorkspaceSlot workspace={a1} isActive={false} />);
+    expect(paneRenders.get('a')).toBe(1);
+    const a2 = ws('a', 'n2'); // new reference = changed workspace
+    rerender(<WorkspaceSlot workspace={a2} isActive={false} />);
+    expect(paneRenders.get('a')).toBe(2);
+  });
+
+  it('re-renders when isActive flips (workspace switch)', () => {
+    const a = ws('a');
+    const { rerender } = mount(<WorkspaceSlot workspace={a} isActive={false} />);
+    expect(paneRenders.get('a')).toBe(1);
+    rerender(<WorkspaceSlot workspace={a} isActive />);
+    expect(paneRenders.get('a')).toBe(2);
+  });
+});

--- a/src/renderer/stores/slices/__tests__/workspaceSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/workspaceSlice.test.ts
@@ -165,3 +165,43 @@ describe('removeWorkspace — A8: fail tasks delegated to a closed workspace', (
     expect(store.getState().a2aTasks[toA].status.state).toBe('submitted'); // to A, untouched
   });
 });
+
+// PERF INVARIANT (2026-07-13): the WorkspaceSlot React.memo in AppLayout only
+// skips re-rendering an unchanged workspace if updateWorkspaceMetadata keeps
+// the OTHER workspaces referentially identical (immer structural sharing). If a
+// refactor rebuilds the workspaces array or clones every entry, the memo
+// silently stops working and the "5 workspaces = laggy" bug returns. Lock it.
+describe('updateWorkspaceMetadata — referential stability (WorkspaceSlot memo dep)', () => {
+  it('replaces ONLY the changed workspace object; siblings keep their reference', () => {
+    const a = createWorkspace('A');
+    const b = createWorkspace('B');
+    const c = createWorkspace('C');
+    const store = createTestStore([a, b, c], a.id);
+
+    const before = store.getState().workspaces;
+    const [beforeA, beforeB, beforeC] = before;
+
+    store.getState().updateWorkspaceMetadata(b.id, { agentName: 'changed' });
+
+    const after = store.getState().workspaces;
+    expect(after).not.toBe(before);             // the array itself is new (triggers AppLayout)
+    expect(after[1]).not.toBe(beforeB);         // the CHANGED workspace is a new object
+    expect(after[1].metadata?.agentName).toBe('changed');
+    // The UNCHANGED siblings keep their exact reference → memo bails on them.
+    expect(after[0]).toBe(beforeA);
+    expect(after[2]).toBe(beforeC);
+    // And their pane trees are untouched references too (PaneContainer prop).
+    expect(after[0].rootPane).toBe(beforeA.rootPane);
+    expect(after[2].rootPane).toBe(beforeC.rootPane);
+  });
+
+  it('keeps the changed workspace pane tree stable when only metadata changes', () => {
+    const a = createWorkspace('A');
+    const store = createTestStore([a], a.id);
+    const beforeRoot = store.getState().workspaces[0].rootPane;
+    store.getState().updateWorkspaceMetadata(a.id, { agentName: 'x' });
+    // metadata change must NOT churn the rootPane reference (it's a separate
+    // prop; churning it would re-render the terminal subtree needlessly).
+    expect(store.getState().workspaces[0].rootPane).toBe(beforeRoot);
+  });
+});


### PR DESCRIPTION
## Symptom (owner-reported)

Five workspaces, one terminal each, and the whole app stutters — even switching between workspaces drags. Persisted after the hook fixes (those were the agent tool loop, not wmux's renderer).

## Root cause (measured, two layers)

At 5 workspaces during metadata churn (title/cwd/agentStatus/running — frequent while any terminal is active): **CPU 53% busy, half of it React**, `jsxDEV` alone = 36% of busy. Measured live via the React DevTools commit hook + CPU profiler.

1. **Per-workspace pane fan-out.** `AppLayout` rendered one `PaneContainer` per workspace with no memo boundary, so any metadata update re-rendered all N. (commit 1)
2. **Dominant: AppLayout re-rendering its own chrome.** `AppLayout` subscribed to the whole `s.workspaces` array, so any pane's metadata/surface update re-created its entire ~1300-line chrome JSX (titlebar, sidebar, dock, toolbar, dialogs). **After memoizing the panes, CPU stayed 52%** — proof the panes weren't the cost; AppLayout itself was. (commit 2)

## Fix (two commits)

**1. `React.memo(WorkspaceSlot)`** — immer keeps an unchanged workspace referentially stable, so a metadata update to workspace X re-renders only X's slot. Measured: pane re-renders per commit 5→2.

**2. AppLayout render isolation** — extract `<WorkspaceViewport>` that owns the single `useStore(s => s.workspaces)` subscription (+ a memoized `MultiviewWorkspaceSlot` so multiview also isolates). AppLayout now subscribes only to **derived-stable selectors** (`selectActiveEmptyLeafIdsKey`, `selectProjectCwdSignature`, `hasActiveWorkspace`, `workspaces.length`) that don't change on metadata/surface churn — so its chrome stops re-rendering. The empty-leaf PTY funnel + wmux.json discovery effects read the full workspace via `getState()` with a version-skew guard.

```
pane metadata/surface update → new workspaces array
   → WorkspaceViewport re-renders (cheap: map + memoized slots, unchanged bail)
   → AppLayout does NOT re-render → chrome JSX not re-created  (36% jsxDEV gone)
```

## Reviewed (autoplan: Codex + independent Claude eng subagent)

Both caught two real bugs in the original plan **before implementation**:
- The plan's "read `workspaces` via getState inside the discovery effect" would **silently break wmux.json auto-discovery** (a getState read never schedules the effect). → kept `projectCwdSignature` a subscribed selector.
- Subscribing AppLayout to `rootPane` is **NOT churn-stable**: `updateSurfaceCwd`/`updateSurfaceTitleByPty` (surfaceSlice.ts:300/318) mutate surfaces inside rootPane, so immer replaces it on every terminal OSC update. → subscribe to the empty-leaf-signature selector instead (verified in code; the two models disagreed and I resolved it by reading surfaceSlice).
- Multiview grid rendered `PaneContainer` directly (not memoized) → added `MultiviewWorkspaceSlot`.

## Tests

- Selector purity (the load-bearing guards): `selectActiveEmptyLeafIdsKey` stays byte-identical across surface title/cwd churn (same empty-leaf set) and changes on split/close; `selectProjectCwdSignature` stable on non-cwd metadata churn, changes when a cwd first appears.
- `WorkspaceSlot` memo: bails on referentially-equal props, re-renders on a changed workspace ref or `isActive` flip.
- `updateWorkspaceMetadata` referential-stability invariant (siblings + rootPane stable).
- tsc + Layout/selector/workspaceSlice suites green.

## Notes

- No version bump (release is an explicit owner action).
- Pure renderer change; a dev restart is the clean way to dogfood the 5-workspace feel (HMR covers renderer). Correctness is unit-tested + dual-eng-reviewed; the live 5-workspace CPU drop is mechanism-certain (AppLayout no longer in the metadata-churn re-render path) and is the owner's dogfood confirmation.
- Follow-up (separate): the deck message-bubble markdown re-parse per delta (only during orchestrator streaming).