### PR TITLE
chore(release): v3.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.21.3] — 2026-07-13
+
 ### Fixed
 
 - **Big responsiveness fix with several workspaces open: switching and typing are smooth again.** With more than one workspace open, any small status update on one terminal (its title, working directory, or "running" indicator changing) re-rendered the *entire* app, plus every open workspace's terminal view, not just the one that changed. Since those updates fire constantly while a terminal is active, the cost piled up in direct proportion to how many workspaces you had open, so five workspaces felt roughly five times heavier than one, and even switching between them dragged. On a live 5-workspace app a single title change was pushing CPU past 50%, half of it React re-rendering the whole window chrome. This is fixed on two levels: each workspace's panes only re-render when that workspace actually changes, and the main window chrome (titlebar, sidebar, dock, toolbar) no longer re-renders on terminal churn at all. Now an update only touches the workspace it affects.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.21.2 sources.** This file is produced by
+> **Generated from wmux v3.21.3 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.21.2",
+  "version": "3.21.3",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Performance release.

- **Multi-workspace lag fix (two layers):** `React.memo` per-workspace pane subtree (#436) + AppLayout chrome render isolation (#437 — the dominant fix). Measured on a live 5-workspace app under title churn: **53% → 29% CPU**, with the window chrome no longer re-rendering on terminal activity.
- **PostToolUse → byte-detector** for the fleet running dot (#435): no more ~110ms helper process per tool call.

- `package.json` 3.21.2 → 3.21.3
- CHANGELOG: `[Unreleased]` → `[3.21.3] — 2026-07-13`
- `docs/api/reference.md` regenerated (CI drift guard)

Tag `v3.21.3` pushed after merge (installer + Chocolatey/winget hang off the tag).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version 3.21.3 dated July 13, 2026.
* **Documentation**
  * Updated the API reference to reflect generation from version 3.21.3 sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->