### PR TITLE
Settings: full-bleed panel + tab reorganization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Settings categories reorganized so General isn't a catch-all.** The old General tab mixed language, terminal behavior, A2A, agent toolbar, MCP, updates, tutorial, and reset all in one place. Now: **General** keeps just language/updates/tutorial/reset; a new **Terminal** tab holds shell, startup directory, split cwd, IME guard, hidden-pane retention, and scrollback; a new **Agents** tab groups the orchestrator model/auto-wake, A2A execution, the agent toolbar, and MCP together (the orchestrator settings moved out of Claude integration, which now focuses on the plugin, usage meter, and accounts). First-run setup folded into About.
 - **Settings opens full-bleed instead of a small floating dialog.** The Settings panel now fills the whole area under the titlebar — no dim scrim, no rounded floating card — so it reads as an app screen rather than a modal stacked on top of your terminals. Content stays centered at a readable width so full-width doesn't stretch every toggle description across the screen.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Settings opens full-bleed instead of a small floating dialog.** The Settings panel now fills the whole area under the titlebar — no dim scrim, no rounded floating card — so it reads as an app screen rather than a modal stacked on top of your terminals. Content stays centered at a readable width so full-width doesn't stretch every toggle description across the screen.
+
 ### Added
 
 - **Manage multiple AI subscription accounts as first-class, and bind one per workspace.** If you keep more than one Claude (or Codex) subscription — a work seat and a personal Max, say — you no longer hand-edit `CLAUDE_CONFIG_DIR` into a profile. Settings → Claude Integration → Accounts lets you add named accounts through a guided flow: it provisions an isolated config directory (your MCP servers, skills, and plugins are shared from your default account so you don't reinstall anything; only the login stays separate), hands you a one-line command to log in there, and registers the account automatically once login lands — wmux never sees or stores your token. Then right-click any workspace → *Claude account* / *Codex account* to bind an account to it: new terminals in that workspace launch on that account (a manually set `CLAUDE_CONFIG_DIR` in the workspace profile still wins). Binding applies to newly opened terminals; already-running ones keep the account they started with. Windows and Linux (macOS reads its credential from the keychain, which can't be partitioned per account).

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -34,7 +34,7 @@ import { FOCUS_RING } from '../focusRing';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-type TabId = 'general' | 'appearance' | 'notifications' | 'shortcuts' | 'claude-integration' | 'lanlink' | 'first-run-setup' | 'about';
+type TabId = 'general' | 'terminal' | 'appearance' | 'notifications' | 'shortcuts' | 'claude-integration' | 'agents' | 'lanlink' | 'about';
 type ShellInfo = { name: string; path: string; args?: string[] };
 
 // ─── Card primitive ────────────────────────────────────────────────────────────
@@ -231,11 +231,24 @@ function IconClaude() {
   );
 }
 
-function IconFirstRun() {
+function IconTerminal() {
   return (
     <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
-      <line x1="3.5" y1="1.8" x2="3.5" y2="12.2" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-      <path d="M3.5 2.5h6.7l-1.7 2.3 1.7 2.3H3.5z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" />
+      <rect x="1.5" y="2.5" width="11" height="9" rx="1.5" stroke="currentColor" strokeWidth="1.3" />
+      <path d="M4 5.5 5.8 7 4 8.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+      <line x1="7.2" y1="8.7" x2="10" y2="8.7" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function IconAgents() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+      <line x1="7" y1="4.2" x2="4" y2="9" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      <line x1="7" y1="4.2" x2="10" y2="9" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      <circle cx="7" cy="3.2" r="1.7" stroke="currentColor" strokeWidth="1.3" />
+      <circle cx="3.5" cy="10.2" r="1.7" stroke="currentColor" strokeWidth="1.3" />
+      <circle cx="10.5" cy="10.2" r="1.7" stroke="currentColor" strokeWidth="1.3" />
     </svg>
   );
 }
@@ -1508,7 +1521,7 @@ function UpdateStatus() {
   };
 
   const handleInstall = () => {
-    window.electronAPI.updater.installUpdate().catch(() => {});
+    window.electronAPI.updater.installUpdate().catch(() => { /* best-effort — updater surfaces its own errors */ });
   };
 
   const statusText = (() => {
@@ -1590,52 +1603,12 @@ function TabGeneral() {
   const t = useT();
   const locale = useStore((s) => s.locale);
   const setLocale = useStore((s) => s.setLocale);
-
-  const defaultShell = useStore((s) => s.defaultShell);
-  const setDefaultShell = useStore((s) => s.setDefaultShell);
-  const scrollbackLines = useStore((s) => s.scrollbackLines);
-  const setScrollbackLines = useStore((s) => s.setScrollbackLines);
-  const scrollbackRestoreEnabled = useStore((s) => s.scrollbackRestoreEnabled);
-  const setScrollbackRestoreEnabled = useStore((s) => s.setScrollbackRestoreEnabled);
-  const a2aAutoApproveExecute = useStore((s) => s.a2aAutoApproveExecute);
-  const setA2aAutoApproveExecute = useStore((s) => s.setA2aAutoApproveExecute);
-  const splitInheritsCwd = useStore((s) => s.splitInheritsCwd);
-  const setSplitInheritsCwd = useStore((s) => s.setSplitInheritsCwd);
-  const imeResidueGuardEnabled = useStore((s) => s.imeResidueGuardEnabled);
-  const setImeResidueGuardEnabled = useStore((s) => s.setImeResidueGuardEnabled);
-  const hiddenPaneRetentionEnabled = useStore((s) => s.hiddenPaneRetentionEnabled);
-  const setHiddenPaneRetentionEnabled = useStore((s) => s.setHiddenPaneRetentionEnabled);
-  const startupDirectory = useStore((s) => s.startupDirectory);
-  const setStartupDirectory = useStore((s) => s.setStartupDirectory);
   const autoUpdateEnabled = useStore((s) => s.autoUpdateEnabled);
-  const agentToolbarEnabled = useStore((s) => s.agentToolbarEnabled);
-  const setAgentToolbarEnabled = useStore((s) => s.setAgentToolbarEnabled);
-  const newConversationCommand = useStore((s) => s.newConversationCommand);
-  const setNewConversationCommand = useStore((s) => s.setNewConversationCommand);
-  const [detectedShells, setDetectedShells] = useState<ShellInfo[]>([]);
   const storeSetAutoUpdate = useStore((s) => s.setAutoUpdateEnabled);
   const setAutoUpdateEnabled = (enabled: boolean) => {
     storeSetAutoUpdate(enabled);
     window.electronAPI.settings.setAutoUpdateEnabled(enabled);
   };
-  const shellOptions = detectedShells.map((shell) => ({ value: shell.path, label: shell.name }));
-
-  useEffect(() => {
-    let cancelled = false;
-    window.electronAPI.shell.list()
-      .then((shells) => {
-        if (cancelled) return;
-        setDetectedShells(shells);
-        const shellPaths = new Set(shells.map((shell) => shell.path));
-        if (shells.length > 0 && !shellPaths.has(useStore.getState().defaultShell)) {
-          setDefaultShell(resolveDefaultShellPath(useStore.getState().defaultShell, shells));
-        }
-      })
-      .catch(() => {
-        if (!cancelled) setDetectedShells([]);
-      });
-    return () => { cancelled = true; };
-  }, [setDefaultShell]);
 
   return (
     <div className="flex flex-col gap-4">
@@ -1661,7 +1634,82 @@ function TabGeneral() {
         </div>
       </div>
 
-      {/* Shell & scrollback */}
+      {/* Updates */}
+      <div className="flex flex-col gap-2">
+        <SectionLabel label={t('settings.updates')} />
+        <SettingRow label={t('settings.autoUpdate')} description={t('settings.autoUpdateDesc')}>
+          <Toggle
+            checked={autoUpdateEnabled}
+            onChange={setAutoUpdateEnabled}
+            label={t('settings.autoUpdate')}
+          />
+        </SettingRow>
+        <UpdateStatus />
+      </div>
+
+      {/* Tutorial */}
+      <div className="flex flex-col gap-2">
+        <SectionLabel label={t('settings.tutorial')} />
+        <SettingRow label={t('settings.restartTutorial')} description={t('settings.restartTutorialDesc')}>
+          <Button
+            variant="secondary"
+            className="shrink-0"
+            style={{ color: 'var(--text-subtle)' }}
+            onClick={() => {
+              useStore.getState().startOnboarding();
+              useStore.getState().setSettingsPanelVisible(false);
+            }}
+          >
+            {t('settings.restartTutorial')}
+          </Button>
+        </SettingRow>
+      </div>
+
+      {/* Reset */}
+      <ResetSection />
+    </div>
+  );
+}
+
+// ─── Terminal tab — shell, cwd, scrollback, pane behavior ────────────────────
+function TabTerminal() {
+  const t = useT();
+  const defaultShell = useStore((s) => s.defaultShell);
+  const setDefaultShell = useStore((s) => s.setDefaultShell);
+  const scrollbackLines = useStore((s) => s.scrollbackLines);
+  const setScrollbackLines = useStore((s) => s.setScrollbackLines);
+  const scrollbackRestoreEnabled = useStore((s) => s.scrollbackRestoreEnabled);
+  const setScrollbackRestoreEnabled = useStore((s) => s.setScrollbackRestoreEnabled);
+  const splitInheritsCwd = useStore((s) => s.splitInheritsCwd);
+  const setSplitInheritsCwd = useStore((s) => s.setSplitInheritsCwd);
+  const imeResidueGuardEnabled = useStore((s) => s.imeResidueGuardEnabled);
+  const setImeResidueGuardEnabled = useStore((s) => s.setImeResidueGuardEnabled);
+  const hiddenPaneRetentionEnabled = useStore((s) => s.hiddenPaneRetentionEnabled);
+  const setHiddenPaneRetentionEnabled = useStore((s) => s.setHiddenPaneRetentionEnabled);
+  const startupDirectory = useStore((s) => s.startupDirectory);
+  const setStartupDirectory = useStore((s) => s.setStartupDirectory);
+  const [detectedShells, setDetectedShells] = useState<ShellInfo[]>([]);
+  const shellOptions = detectedShells.map((shell) => ({ value: shell.path, label: shell.name }));
+
+  useEffect(() => {
+    let cancelled = false;
+    window.electronAPI.shell.list()
+      .then((shells) => {
+        if (cancelled) return;
+        setDetectedShells(shells);
+        const shellPaths = new Set(shells.map((shell) => shell.path));
+        if (shells.length > 0 && !shellPaths.has(useStore.getState().defaultShell)) {
+          setDefaultShell(resolveDefaultShellPath(useStore.getState().defaultShell, shells));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setDetectedShells([]);
+      });
+    return () => { cancelled = true; };
+  }, [setDefaultShell]);
+
+  return (
+    <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-2">
         <SectionLabel label={t('settings.terminal')} />
         <SettingRow label={t('settings.defaultShell')}>
@@ -1718,6 +1766,24 @@ function TabGeneral() {
           />
         </SettingRow>
       </div>
+    </div>
+  );
+}
+
+// ─── Agents tab — orchestrator, A2A, agent toolbar, MCP ──────────────────────
+function TabAgents() {
+  const t = useT();
+  const a2aAutoApproveExecute = useStore((s) => s.a2aAutoApproveExecute);
+  const setA2aAutoApproveExecute = useStore((s) => s.setA2aAutoApproveExecute);
+  const agentToolbarEnabled = useStore((s) => s.agentToolbarEnabled);
+  const setAgentToolbarEnabled = useStore((s) => s.setAgentToolbarEnabled);
+  const newConversationCommand = useStore((s) => s.newConversationCommand);
+  const setNewConversationCommand = useStore((s) => s.setNewConversationCommand);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Orchestrator (moved out of Claude integration) */}
+      <OrchestratorSection />
 
       {/* A2A execution */}
       <div className="flex flex-col gap-2">
@@ -1728,37 +1794,6 @@ function TabGeneral() {
             onChange={setA2aAutoApproveExecute}
             label={t('settings.a2aAutoApproveExecute')}
           />
-        </SettingRow>
-      </div>
-
-      {/* Updates */}
-      <div className="flex flex-col gap-2">
-        <SectionLabel label={t('settings.updates')} />
-        <SettingRow label={t('settings.autoUpdate')} description={t('settings.autoUpdateDesc')}>
-          <Toggle
-            checked={autoUpdateEnabled}
-            onChange={setAutoUpdateEnabled}
-            label={t('settings.autoUpdate')}
-          />
-        </SettingRow>
-        <UpdateStatus />
-      </div>
-
-      {/* Tutorial */}
-      <div className="flex flex-col gap-2">
-        <SectionLabel label={t('settings.tutorial')} />
-        <SettingRow label={t('settings.restartTutorial')} description={t('settings.restartTutorialDesc')}>
-          <Button
-            variant="secondary"
-            className="shrink-0"
-            style={{ color: 'var(--text-subtle)' }}
-            onClick={() => {
-              useStore.getState().startOnboarding();
-              useStore.getState().setSettingsPanelVisible(false);
-            }}
-          >
-            {t('settings.restartTutorial')}
-          </Button>
         </SettingRow>
       </div>
 
@@ -1790,9 +1825,6 @@ function TabGeneral() {
 
       {/* MCP integration */}
       <McpStatusSection />
-
-      {/* Reset */}
-      <ResetSection />
     </div>
   );
 }
@@ -4044,12 +4076,13 @@ export default function SettingsPanel() {
 
   const tabs: { id: TabId; label: string; icon: ReactNode }[] = [
     { id: 'general',            label: t('settings.tabGeneral'),         icon: <IconGeneral /> },
+    { id: 'terminal',           label: t('settings.tabTerminal'),        icon: <IconTerminal /> },
     { id: 'appearance',         label: t('settings.tabAppearance'),      icon: <IconAppearance /> },
     { id: 'notifications',      label: t('settings.tabNotifications'),   icon: <IconNotifications /> },
     { id: 'shortcuts',          label: t('settings.tabShortcuts'),       icon: <IconShortcuts /> },
     { id: 'claude-integration', label: t('claudeIntegration.tab'),       icon: <IconClaude /> },
+    { id: 'agents',             label: t('settings.tabAgents'),          icon: <IconAgents /> },
     { id: 'lanlink',            label: t('settings.lanlinkTab'),         icon: <IconLanLink /> },
-    { id: 'first-run-setup',    label: t('settings.firstRunSetup'),      icon: <IconFirstRun /> },
     { id: 'about',              label: t('settings.tabAbout'),           icon: <IconAbout /> },
   ];
 
@@ -4169,13 +4202,14 @@ export default function SettingsPanel() {
           <div className="flex-1 overflow-y-auto px-5 py-4">
             <div className="mx-auto w-full max-w-[820px]">
               {activeTab === 'general'            && <TabGeneral />}
+              {activeTab === 'terminal'           && <TabTerminal />}
               {activeTab === 'appearance'         && <TabAppearance />}
               {activeTab === 'notifications'      && <TabNotifications />}
               {activeTab === 'shortcuts'          && <TabShortcuts />}
-              {activeTab === 'claude-integration' && <><ClaudeIntegrationSection /><AccountsSection /><OrchestratorSection /></>}
+              {activeTab === 'claude-integration' && <><ClaudeIntegrationSection /><AccountsSection /></>}
+              {activeTab === 'agents'             && <TabAgents />}
               {activeTab === 'lanlink'            && <><LanLinkSection /><LanLinkPairingSection /></>}
-              {activeTab === 'first-run-setup'    && <TabFirstRunSetup />}
-              {activeTab === 'about'              && <TabAbout />}
+              {activeTab === 'about'              && <><TabAbout /><TabFirstRunSetup /></>}
             </div>
           </div>
         </div>

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -4099,26 +4099,20 @@ export default function SettingsPanel() {
   };
 
   return (
-    // Backdrop
+    // Full-bleed surface under the 36px custom titlebar (DESIGN.md Window
+    // Chrome). Settings fills the whole terminal area instead of floating as a
+    // small centered modal: no scrim, no rounding/shadow/border, opaque
+    // bg-base — it reads as an app screen, not a dialog stacked on top. Closed
+    // via Esc (keydown handler above) or the header X / footer Close.
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center pt-[8vh]"
-      style={{ backgroundColor: 'var(--backdrop-modal)' }}
-      onMouseDown={(e) => {
-        if (e.target === e.currentTarget) handleClose();
-      }}
+      className="fixed inset-x-0 bottom-0 z-50 flex flex-col"
+      style={{ top: 36, backgroundColor: 'var(--bg-base)' }}
     >
-      {/* Panel — 800x560 */}
+      {/* Panel — fills the full-bleed surface */}
       <div
         ref={panelRef}
-        className="flex flex-col rounded-xl overflow-hidden shadow-2xl"
-        style={{
-          width: 800,
-          height: 560,
-          backgroundColor: 'var(--bg-base)',
-          border: '1px solid var(--bg-surface)',
-          boxShadow: 'var(--shadow-modal)',
-        }}
-        onMouseDown={(e) => e.stopPropagation()}
+        className="flex flex-col flex-1 min-h-0 overflow-hidden"
+        style={{ backgroundColor: 'var(--bg-base)' }}
       >
         {/* Header */}
         <div
@@ -4169,16 +4163,20 @@ export default function SettingsPanel() {
             })}
           </nav>
 
-          {/* Right content */}
+          {/* Right content — scrolls full-width, but the content column is
+              centered at a readable max-width so full-bleed doesn't stretch
+              toggle rows across the whole screen. */}
           <div className="flex-1 overflow-y-auto px-5 py-4">
-            {activeTab === 'general'            && <TabGeneral />}
-            {activeTab === 'appearance'         && <TabAppearance />}
-            {activeTab === 'notifications'      && <TabNotifications />}
-            {activeTab === 'shortcuts'          && <TabShortcuts />}
-            {activeTab === 'claude-integration' && <><ClaudeIntegrationSection /><AccountsSection /><OrchestratorSection /></>}
-            {activeTab === 'lanlink'            && <><LanLinkSection /><LanLinkPairingSection /></>}
-            {activeTab === 'first-run-setup'    && <TabFirstRunSetup />}
-            {activeTab === 'about'              && <TabAbout />}
+            <div className="mx-auto w-full max-w-[820px]">
+              {activeTab === 'general'            && <TabGeneral />}
+              {activeTab === 'appearance'         && <TabAppearance />}
+              {activeTab === 'notifications'      && <TabNotifications />}
+              {activeTab === 'shortcuts'          && <TabShortcuts />}
+              {activeTab === 'claude-integration' && <><ClaudeIntegrationSection /><AccountsSection /><OrchestratorSection /></>}
+              {activeTab === 'lanlink'            && <><LanLinkSection /><LanLinkPairingSection /></>}
+              {activeTab === 'first-run-setup'    && <TabFirstRunSetup />}
+              {activeTab === 'about'              && <TabAbout />}
+            </div>
           </div>
         </div>
 

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -283,9 +283,11 @@ export const en = {
   'settings.close': 'Close',
   'settings.shortcuts': 'Keyboard Shortcuts',
   'settings.tabGeneral': 'General',
+  'settings.tabTerminal': 'Terminal',
   'settings.tabAppearance': 'Appearance',
   'settings.tabNotifications': 'Notifications',
   'settings.tabShortcuts': 'Shortcuts',
+  'settings.tabAgents': 'Agents',
   'settings.tabAbout': 'About',
   // Orchestrator (command deck brain) settings
   'settings.orchestrator': 'Orchestrator',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -226,9 +226,11 @@ export const ko = {
   'settings.close': '닫기',
   'settings.shortcuts': '단축키',
   'settings.tabGeneral': '일반',
+  'settings.tabTerminal': '터미널',
   'settings.tabAppearance': '외관',
   'settings.tabNotifications': '알림',
   'settings.tabShortcuts': '단축키',
+  'settings.tabAgents': '에이전트',
   'settings.tabAbout': '정보',
   // agent (커맨드 데크 브레인) 설정 — 명칭은 영문 "agent" 고정(번역·한글화
   // 금지, 오너 결정 2026-07-13: "오케스트레이터"는 한글 UI에서 넘침).


### PR DESCRIPTION
Two UX changes to the Settings surface.

## Full-bleed panel
Settings used to open as a small 800×560 floating card with a dim scrim. It now fills the whole area under the 36px titlebar with an opaque background — no scrim, no rounding/shadow/border — so it reads as an app screen rather than a dialog stacked on your terminals. Content stays centered at a readable 820px width so full-bleed doesn't stretch every toggle description across the screen. Close is unchanged (Esc / header X / footer Close).

## Tab reorganization
General had become a catch-all (language, terminal behavior, A2A, agent toolbar, MCP, updates, tutorial, reset). Regrouped into 9 focused tabs:

- **General** — language, updates, tutorial, reset
- **Terminal** (new) — shell, startup dir, split cwd, IME guard, hidden-pane retention, scrollback
- **Agents** (new) — orchestrator model/auto-wake (moved out of Claude integration), A2A execution, agent toolbar, MCP
- **Claude integration** — now just plugin status, usage meter, accounts
- First-run setup folded into About

Splits `TabGeneral` into `TabGeneral`/`TabTerminal`/`TabAgents`, adds tab icons and en/ko labels. Also fixes a pre-existing empty-catch lint error in this file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated **Terminal** and **Agents** sections in Settings.
  - Reorganized related options, including orchestrator, MCP, toolbar, and terminal settings.
  - Added Korean and English translations for the new Settings sections.

- **Improvements**
  - Redesigned Settings as a full-bleed panel with centered, readable content.
  - Refined General settings to focus on language, updates, tutorials, and reset options.
  - Improved auto-update handling and update installation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->