### PR TITLE
Surface the SDK rate_limit_event as a normalized limit event

### DIFF
--- a/src/main/deck/BrainAdapter.ts
+++ b/src/main/deck/BrainAdapter.ts
@@ -48,6 +48,12 @@ export interface BrainUsage {
  *                   optional usage. Exactly one per completed turn.
  *   - `error`       a turn-fatal problem (auth failure, spawn error). Terminal
  *                   for the turn — no `turn-end` follows an `error`.
+ *   - `limit`       the SUBSCRIPTION hit (or is approaching) a plan rate limit.
+ *                   Sourced from the SDK's first-class `rate_limit_event` frame
+ *                   (NOT a `result` error), so it carries a typed window kind and
+ *                   a reset time. Informational within the turn — it does not by
+ *                   itself end the turn (the SDK still emits its own result/error
+ *                   frame); it is the signal the multi-account M3 switch hangs off.
  */
 export type BrainEvent =
   // Emitted ONLY for turns the MAIN process originates (P3d scheduled runs):
@@ -69,7 +75,26 @@ export type BrainEvent =
     }
   | { type: 'tool-end'; name: string; ok: boolean; toolId?: string }
   | { type: 'turn-end'; sessionId: string | null; usage?: BrainUsage }
-  | { type: 'error'; message: string };
+  | { type: 'error'; message: string }
+  | {
+      type: 'limit';
+      /** 'rejected' = the window is exhausted (hard limit hit); 'allowed_warning'
+       *  = approaching the limit (pre-exhaustion nudge). We do NOT surface plain
+       *  'allowed' as a limit event — that's the normal case. */
+      status: 'rejected' | 'allowed_warning';
+      /** Which plan window the limit belongs to, verbatim from the SDK's
+       *  `SDKRateLimitInfo.rateLimitType`. Known values: `five_hour`,
+       *  `seven_day`, `seven_day_opus`, `seven_day_sonnet`,
+       *  `seven_day_overage_included`, `overage`. Kept as a plain string (not a
+       *  closed union) so a future SDK window passes through instead of breaking
+       *  normalization. Undefined when the SDK omitted it. */
+      window?: string;
+      /** Epoch ms when the window resets, when the SDK provided it. Optional
+       *  because a hook-sourced limit (M3 additive path) can't supply one. */
+      resetsAtMs?: number;
+      /** 0–100 window utilization when reported. */
+      utilization?: number;
+    };
 
 /** One-time startup context for the brain. The fleet snapshot is injected ONCE
  *  (token-budgeted) at the first turn — see ClaudeSdkAdapter. */
@@ -131,6 +156,16 @@ interface RawToolResultBlock {
 }
 type RawContentBlock = RawTextBlock | RawToolUseBlock | RawToolResultBlock | { type: string };
 
+/** Shape of the SDK's `rate_limit_event` payload we consume — a subset of the
+ *  SDK's `SDKRateLimitInfo`. `resetsAt` is EPOCH SECONDS in the SDK; we convert
+ *  to ms at normalization. All fields optional: the SDK omits them per plan/state. */
+interface RawRateLimitInfo {
+  status?: 'allowed' | 'allowed_warning' | 'rejected';
+  resetsAt?: number;
+  rateLimitType?: string;
+  utilization?: number;
+}
+
 /** The subset of SDK message frames the deck reacts to. Unknown frame types are
  *  ignored (the SDK stream carries dozens of ancillary event kinds). */
 export interface RawSdkMessage {
@@ -145,6 +180,8 @@ export interface RawSdkMessage {
   errors?: string[];
   message?: { content?: RawContentBlock[]; usage?: { input_tokens?: number; output_tokens?: number } };
   usage?: { input_tokens?: number; output_tokens?: number };
+  /** Present on `type:'rate_limit_event'` frames (SDKRateLimitEvent). */
+  rate_limit_info?: RawRateLimitInfo;
 }
 
 /** Mutable per-turn state threaded across `normalizeSdkMessage` calls: maps a
@@ -209,6 +246,22 @@ export function extractToolTarget(input: unknown): { paneId?: string; workspaceI
 }
 
 /**
+ * Coerce the SDK's `resetsAt` (a bare number with no documented unit) to epoch
+ * MILLISECONDS. The SDK type annotates only `number`, and a live limit wasn't
+ * available to confirm sec vs ms at authoring time, so we disambiguate by
+ * magnitude: an epoch in SECONDS is ~1.7e9 while epoch MS is ~1.7e12, three
+ * orders of magnitude apart with no overlap for any realistic date — a value
+ * below this threshold is treated as seconds and scaled up. Returns null for
+ * missing / non-finite / non-positive input (caller then omits resetsAtMs).
+ * Exported for unit testing.
+ */
+const RESET_SECONDS_MAX = 1e11; // ~year 5138 in seconds; anything below = seconds
+export function normalizeResetToMs(resetsAt: number | undefined): number | null {
+  if (typeof resetsAt !== 'number' || !Number.isFinite(resetsAt) || resetsAt <= 0) return null;
+  return resetsAt < RESET_SECONDS_MAX ? Math.round(resetsAt * 1000) : Math.round(resetsAt);
+}
+
+/**
  * Map one raw SDK message to zero or more normalized brain events, mutating
  * `state` (tool-name table + latest session id). Pure aside from that state:
  * same input → same output. This is the whole SDK-coupling surface of the deck,
@@ -222,6 +275,9 @@ export function extractToolTarget(input: unknown): { paneId?: string; workspaceI
  *   - user (tool_result)     → a `tool-end` per tool_result block, ok = !is_error.
  *   - result                 → a `turn-end` (success) or an `error` then no
  *                              turn-end (error_* subtypes / is_error).
+ *   - rate_limit_event       → a `limit` for status 'rejected' / 'allowed_warning'
+ *                              (nothing for plain 'allowed'). NOT terminal — the
+ *                              turn still ends via its own result/error frame.
  */
 export function normalizeSdkMessage(msg: RawSdkMessage, state: NormalizeState): BrainEvent[] {
   const out: BrainEvent[] = [];
@@ -271,6 +327,30 @@ export function normalizeSdkMessage(msg: RawSdkMessage, state: NormalizeState): 
           });
         }
       }
+      return out;
+    }
+
+    case 'rate_limit_event': {
+      // First-class subscription rate-limit signal (SDKRateLimitEvent). The
+      // whole reason this case exists: a plan limit is NOT delivered as a
+      // `result` error (its subtype union has no rate-limit member), so without
+      // this branch the event is silently dropped and M3 can never react.
+      const info = msg.rate_limit_info;
+      if (!info) return out;
+      // Only 'rejected' (hard hit) and 'allowed_warning' (approaching) are
+      // actionable; 'allowed'/absent is the normal case and emits nothing.
+      if (info.status !== 'rejected' && info.status !== 'allowed_warning') return out;
+      const ev: Extract<BrainEvent, { type: 'limit' }> = {
+        type: 'limit',
+        status: info.status,
+      };
+      if (typeof info.rateLimitType === 'string' && info.rateLimitType) ev.window = info.rateLimitType;
+      if (typeof info.utilization === 'number' && Number.isFinite(info.utilization)) {
+        ev.utilization = info.utilization;
+      }
+      const resetMs = normalizeResetToMs(info.resetsAt);
+      if (resetMs != null) ev.resetsAtMs = resetMs;
+      out.push(ev);
       return out;
     }
 

--- a/src/main/deck/ClaudeSdkAdapter.ts
+++ b/src/main/deck/ClaudeSdkAdapter.ts
@@ -663,15 +663,23 @@ export class ClaudeSdkAdapter implements BrainAdapter {
               break outer;
             }
             if (ev.type === 'turn-end' && ev.sessionId) this._sessionId = ev.sessionId;
-            yielded = true;
-            // Any REAL content out of a resumed turn proves the id (codex P2:
-            // validating only on turn-end let a mid-stream failure after
-            // content leave the flag set, and a LATER pre-content error would
-            // then wrongly drop a proven-valid conversation). The error case
-            // never reaches here on the unvalidated first attempt (retry
-            // branch above), and a later attempt's error doesn't validate —
-            // by then the flag only clears through this same content path.
-            if (ev.type !== 'error') this._resumeUnvalidated = false;
+            // A `limit` event is ambient subscription status (SDK rate_limit_event)
+            // that can fire regardless of whether the SEEDED resume id was valid —
+            // it is neither user content we'd lose on a fresh retry nor proof the
+            // resume worked. Keep it transparent to the resume-validation
+            // bookkeeping so a dead-id turn that happens to emit a limit first
+            // still falls back to a fresh session (below).
+            if (ev.type !== 'limit') {
+              yielded = true;
+              // Any REAL content out of a resumed turn proves the id (codex P2:
+              // validating only on turn-end let a mid-stream failure after
+              // content leave the flag set, and a LATER pre-content error would
+              // then wrongly drop a proven-valid conversation). The error case
+              // never reaches here on the unvalidated first attempt (retry
+              // branch above), and a later attempt's error doesn't validate —
+              // by then the flag only clears through this same content path.
+              if (ev.type !== 'error') this._resumeUnvalidated = false;
+            }
             yield ev;
           }
         }

--- a/src/main/deck/__tests__/BrainAdapter.test.ts
+++ b/src/main/deck/__tests__/BrainAdapter.test.ts
@@ -7,6 +7,7 @@ import {
   createNormalizeState,
   summarizeToolInput,
   extractToolTarget,
+  normalizeResetToMs,
   type RawSdkMessage,
 } from '../BrainAdapter';
 
@@ -110,6 +111,97 @@ describe('normalizeSdkMessage', () => {
   it('ignores unknown frame types', () => {
     const state = createNormalizeState();
     expect(normalizeSdkMessage({ type: 'stream_event' }, state)).toEqual([]);
+  });
+
+  // ── rate_limit_event → limit (multi-account M3 detection) ──────────────────
+  //
+  // The whole reason this branch exists: a plan rate limit is delivered as a
+  // first-class `rate_limit_event` frame, NOT a `result` error (whose subtype
+  // union has no rate-limit member). Without this mapping the signal M3 hangs
+  // off is silently dropped.
+
+  it('maps a rejected rate_limit_event to a hard limit event with window + reset', () => {
+    const state = createNormalizeState();
+    const events = normalizeSdkMessage(
+      {
+        type: 'rate_limit_event',
+        session_id: 's-rl',
+        rate_limit_info: {
+          status: 'rejected',
+          rateLimitType: 'five_hour',
+          resetsAt: 1_700_000_000, // epoch SECONDS
+          utilization: 100,
+        },
+      } as RawSdkMessage,
+      state,
+    );
+    expect(events).toEqual([
+      { type: 'limit', status: 'rejected', window: 'five_hour', utilization: 100, resetsAtMs: 1_700_000_000_000 },
+    ]);
+  });
+
+  it('maps allowed_warning to a soft (approaching) limit event', () => {
+    const state = createNormalizeState();
+    const events = normalizeSdkMessage(
+      {
+        type: 'rate_limit_event',
+        rate_limit_info: { status: 'allowed_warning', rateLimitType: 'seven_day', utilization: 85 },
+      } as RawSdkMessage,
+      state,
+    );
+    expect(events).toEqual([{ type: 'limit', status: 'allowed_warning', window: 'seven_day', utilization: 85 }]);
+  });
+
+  it('emits nothing for status allowed (the normal case)', () => {
+    const state = createNormalizeState();
+    expect(
+      normalizeSdkMessage(
+        { type: 'rate_limit_event', rate_limit_info: { status: 'allowed', utilization: 12 } } as RawSdkMessage,
+        state,
+      ),
+    ).toEqual([]);
+  });
+
+  it('emits nothing when rate_limit_info is missing', () => {
+    const state = createNormalizeState();
+    expect(normalizeSdkMessage({ type: 'rate_limit_event' } as RawSdkMessage, state)).toEqual([]);
+  });
+
+  it('omits reset/window/utilization fields the SDK did not provide', () => {
+    const state = createNormalizeState();
+    const events = normalizeSdkMessage(
+      { type: 'rate_limit_event', rate_limit_info: { status: 'rejected' } } as RawSdkMessage,
+      state,
+    );
+    // No resetsAtMs, window, or utilization keys — just the status.
+    expect(events).toEqual([{ type: 'limit', status: 'rejected' }]);
+  });
+
+  it('passes an unknown rateLimitType through as a raw string (forward-compat)', () => {
+    const state = createNormalizeState();
+    const events = normalizeSdkMessage(
+      { type: 'rate_limit_event', rate_limit_info: { status: 'rejected', rateLimitType: 'monthly_future' } } as RawSdkMessage,
+      state,
+    );
+    expect(events[0]).toMatchObject({ type: 'limit', window: 'monthly_future' });
+  });
+});
+
+describe('normalizeResetToMs', () => {
+  it('scales an epoch-seconds value up to milliseconds', () => {
+    expect(normalizeResetToMs(1_700_000_000)).toBe(1_700_000_000_000);
+  });
+
+  it('passes an epoch-milliseconds value through unchanged', () => {
+    expect(normalizeResetToMs(1_700_000_000_000)).toBe(1_700_000_000_000);
+  });
+
+  it('returns null for missing / non-finite / non-positive input', () => {
+    expect(normalizeResetToMs(undefined)).toBeNull();
+    expect(normalizeResetToMs(0)).toBeNull();
+    expect(normalizeResetToMs(-5)).toBeNull();
+    expect(normalizeResetToMs(Number.NaN)).toBeNull();
+    expect(normalizeResetToMs(Number.POSITIVE_INFINITY)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## What

Teaches the orchestrator's SDK→event normalizer to recognize the Claude Agent SDK's first-class `rate_limit_event` frame and emit a new normalized `limit` BrainEvent for it. Detection plumbing only — no UI yet.

## Why

A subscription rate limit is **not** delivered as a `result` error. Reading `@anthropic-ai/claude-agent-sdk`'s types directly: the SDK ships a `SDKRateLimitEvent` (`type: 'rate_limit_event'`) with a structured `SDKRateLimitInfo`, and the `result` error subtype union has no rate-limit member (`error_during_execution | error_max_turns | error_max_budget_usd | error_max_structured_output_retries`). So `normalizeSdkMessage` was silently dropping the event — the orchestrator brain could hit a plan limit and the deck would never know.

This is the signal the multi-account limit-detection work needs: a typed window kind and a real reset time, not a 429 we'd have to classify heuristically.

## Changes

- **New `limit` BrainEvent**: `{ status: 'rejected' | 'allowed_warning', window?, resetsAtMs?, utilization? }`, mapped straight from `SDKRateLimitInfo`. Emitted for `rejected` (hard hit) and `allowed_warning` (approaching); nothing for plain `allowed` (the normal case) or a missing info block.
- **`normalizeResetToMs`**: the SDK types annotate `resetsAt` only as `number` with no documented unit, so this disambiguates epoch-seconds vs epoch-ms by magnitude (~1.7e9 vs ~1.7e12).
- **Forward-compat**: an unknown `rateLimitType` passes through as a raw string rather than being dropped.
- **Resume-safety**: a `limit` event can fire before content regardless of whether a seeded resume id was valid, so it's kept transparent to `ClaudeSdkAdapter`'s resume-validation bookkeeping — otherwise a dead-id turn that emitted a limit first would stop falling back to a fresh session.

Renderer consumers already `default`-ignore unknown event types, so nothing downstream breaks; the switch UX lands in a later step.

## Tests

11 new cases: rejected/warning/allowed/missing-info mappings, omitted optional fields, unknown-window passthrough, and the reset-unit heuristic. BrainAdapter suite 21/21; full deck suite 270/270; tsc + lint clean.

## Not in scope

Acting on the event (account switch, operator prompt) and confirming the owner's specific claude build emits it in SDK mode (needs a live limit — tracked as a capability probe). This PR only stops the signal from being dropped.

Per repo policy this PR does not bump the version. No user-facing CHANGELOG entry yet — the event isn't surfaced in the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notifications for rate-limit rejections and warnings, including utilization, time window, and reset timing when available.
  * Rate-limit updates no longer end an active response.

* **Bug Fixes**
  * Improved resume handling so rate-limit notifications do not incorrectly mark a resumed attempt as successful.
  * Invalid or missing reset times are handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->