### PR TITLE
chore(release): 3.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.24.0] — 2026-07-16
+
 ### Added
 
 - **You can turn off "start wmux when Windows starts."** wmux registers itself to launch at login on install, but that was never optional — if you didn't want it running every boot, there was no switch. Settings → General now has a **Startup** toggle that flips it on or off live (it reads and writes the actual Windows startup entry, so it always reflects the real state). Turning it off sticks across app updates — an update no longer silently re-enables autostart behind your back. Windows only; the toggle is hidden on other platforms. (#460)

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.23.0 sources.** This file is produced by
+> **Generated from wmux v3.24.0 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.20.0",
+  "version": "3.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.20.0",
+      "version": "3.24.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.23.0",
+  "version": "3.24.0",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Cuts the **3.24.0** release.

- Promote the accumulated `[Unreleased]` entries under a dated `## [3.24.0] — 2026-07-16` heading, leaving a fresh empty `[Unreleased]` on top.
- Bump `package.json` / `package-lock.json` to 3.24.0.
- Regenerate `docs/api/reference.md` so its baked version header reads 3.24.0 (the CI drift guard enforces this).

After merge, the `v3.24.0` tag push kicks off the installer / Chocolatey / winget build.