### PR TITLE
fix(terminal): stop the focus self-heal from thrashing input dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Typing no longer intermittently goes dead in a pane until you open a new one.** On some machines, keystrokes would sporadically stop reaching the terminal — you'd type and nothing happened, and the only way back was to split off a fresh pane. The cause was a focus tug-of-war: when the pane that should hold keyboard focus was momentarily off-screen (mid workspace-switch or a re-mounting terminal), the focus self-heal kept shoving focus at it, focus bounced straight back to nothing, and the loop spun — dropping the keystrokes caught in between. The self-heal now refuses to hand focus to a terminal that isn't actually visible and confirms focus truly landed before counting it as recovered, which breaks the loop. It also now records which element dropped focus, so any remaining cases name their own cause in the logs. (This is a distinct bug from the earlier IME "claim-storm" — the field logs ruled that out.)
+
 ## [3.24.0] — 2026-07-16
 
 ### Added

--- a/src/renderer/hooks/__tests__/useActivePaneFocus.test.ts
+++ b/src/renderer/hooks/__tests__/useActivePaneFocus.test.ts
@@ -271,7 +271,11 @@ describe('isFocusOrphaned', () => {
 // be re-focused — but only when focus is genuinely orphaned.
 
 /** Drives the heal with a controllable activeElement sequence + manual defer. */
-function makeReassertHarness(seq: Array<'body' | 'real' | 'null'>, target: string | null) {
+function makeReassertHarness(
+  seq: Array<'body' | 'real' | 'null'>,
+  target: string | null,
+  focusSucceeds = true,
+) {
   const body = {} as Element;
   const real = {} as Element;
   const resolve = { body, real, null: null } as const;
@@ -279,6 +283,7 @@ function makeReassertHarness(seq: Array<'body' | 'real' | 'null'>, target: strin
   let i = 0;
   const focused: string[] = [];
   const healed: string[] = [];
+  const culprits: Array<string | null> = [];
   const deferQueue: Array<() => void> = [];
 
   const deps: FocusReassertDeps = {
@@ -287,15 +292,19 @@ function makeReassertHarness(seq: Array<'body' | 'real' | 'null'>, target: strin
     // heal that reads activeElement twice (sync + deferred) sees both stages.
     getActiveElement: () => active[Math.min(i++, active.length - 1)],
     getBody: () => body,
-    focusTerminal: (id) => focused.push(id),
+    // Returns whether focus actually landed. focusSucceeds=false models an
+    // invisible / mid-remount terminal whose focus() is a silent no-op.
+    focusTerminal: (id) => { focused.push(id); return focusSucceeds; },
     defer: (cb) => deferQueue.push(cb),
-    onHeal: (id) => healed.push(id),
+    describeCulprit: () => 'textarea.xterm-helper-textarea',
+    onHeal: (id, culprit) => { healed.push(id); culprits.push(culprit); },
   };
 
   return {
     deps,
     focused,
     healed,
+    culprits,
     deferredCount: () => deferQueue.length,
     drain: () => { while (deferQueue.length) { const cb = deferQueue.shift(); if (cb) cb(); } },
   };
@@ -326,6 +335,26 @@ describe('reassertFocusIfOrphaned', () => {
     h.drain();
     expect(h.focused).toEqual([]);
     expect(h.healed).toEqual([]);
+  });
+
+  it('records the orphaning culprit on a real heal', () => {
+    const h = makeReassertHarness(['body', 'body'], 'pty-1');
+    reassertFocusIfOrphaned(h.deps);
+    h.drain();
+    expect(h.healed).toEqual(['pty-1']);
+    expect(h.culprits).toEqual(['textarea.xterm-helper-textarea']);
+  });
+
+  it('does NOT count a heal when focus() fails to land (invisible / mid-remount terminal)', () => {
+    // The reclaim↔orphan thrash: focus target resolves and we attempt it, but
+    // the terminal is invisible so focus() is a no-op and DOM focus stays on
+    // <body>. focusTerminal returns false → no heal fires, so the loop can't
+    // spin and the log isn't spammed.
+    const h = makeReassertHarness(['body', 'body'], 'pty-1', false);
+    reassertFocusIfOrphaned(h.deps);
+    h.drain();
+    expect(h.focused).toEqual(['pty-1']); // we DID attempt it
+    expect(h.healed).toEqual([]);         // but it was not a heal
   });
 
   it('does NOT yank focus when a real element claims it before the deferred frame', () => {

--- a/src/renderer/hooks/useActivePaneFocus.ts
+++ b/src/renderer/hooks/useActivePaneFocus.ts
@@ -162,12 +162,25 @@ export interface FocusReassertDeps {
   resolveTarget: () => string | null;
   getActiveElement: () => Element | null;
   getBody: () => Element | null;
-  /** Pull DOM focus onto a terminal's xterm by ptyId. No-op if unregistered. */
-  focusTerminal: (ptyId: string) => void;
+  /** Pull DOM focus onto a terminal's xterm by ptyId. Returns true ONLY when
+   *  the terminal exists, is actually focusable (visible in layout), AND focus
+   *  landed on a real element. Returns false for a missing / invisible / still-
+   *  mounting terminal — focusing such a terminal is a silent no-op that leaves
+   *  DOM focus on <body>, and treating that as a heal is exactly what let the
+   *  reclaim↔orphan thrash spin (focusout → reclaim → focus() bounces back to
+   *  body → focusout → ...), the intermittent "typing dead until I make a new
+   *  pane" bug. */
+  focusTerminal: (ptyId: string) => boolean;
   /** Defer one frame so we read activeElement AFTER the focus change settles. */
   defer: (cb: () => void) => void;
-  /** Instrumentation: called with the ptyId whenever a heal actually fires. */
-  onHeal?: (ptyId: string) => void;
+  /** Instrumentation: the element that just lost focus (focusout target), or
+   *  null when the signal was not a focusout (keydown / window-focus). Logged
+   *  on a real heal so the NEXT dead-input episode NAMES what dropped focus to
+   *  <body> instead of leaving the orphaning source a guess. */
+  describeCulprit?: () => string | null;
+  /** Instrumentation: called with the ptyId (and culprit, if known) whenever a
+   *  heal actually fires. */
+  onHeal?: (ptyId: string, culprit: string | null) => void;
 }
 
 /**
@@ -193,8 +206,12 @@ export function reassertFocusIfOrphaned(deps: FocusReassertDeps): void {
     if (!isFocusOrphaned(deps.getActiveElement(), deps.getBody())) return;
     const ptyId = deps.resolveTarget();
     if (!ptyId) return;
-    deps.focusTerminal(ptyId);
-    deps.onHeal?.(ptyId);
+    // Only count it as a heal if focus actually LANDED. A no-op focus() on an
+    // invisible / mid-remount terminal leaves DOM focus on <body>; healing
+    // "successfully" onto it would re-fire on the next focusout and thrash.
+    const healed = deps.focusTerminal(ptyId);
+    if (!healed) return;
+    deps.onHeal?.(ptyId, deps.describeCulprit?.() ?? null);
   });
 }
 
@@ -244,16 +261,45 @@ export function useActivePaneFocus(): void {
     // keydown landing right before unmount could otherwise leave a queued rAF
     // that refocuses a terminal from a torn-down effect instance.
     const pending = new Set<number>();
-    const onSignal = (): void => reassertFocusIfOrphaned({
+    const onSignal = (ev?: Event): void => reassertFocusIfOrphaned({
       resolveTarget: () => resolveActivePanePtyId(useStore.getState()),
       getActiveElement: () => document.activeElement,
       getBody: () => document.body,
-      focusTerminal: (id) => terminalRegistry.get(id)?.focus(),
+      focusTerminal: (id) => {
+        const term = terminalRegistry.get(id);
+        if (!term) return false;
+        // An invisible / mid-remount terminal (display:none ancestor during a
+        // workspace-switch or hidden-pane window) can't hold focus. offsetParent
+        // is null iff the element or an ancestor is display:none — exactly that
+        // case. Skip it so we don't focus() into the void and spin the
+        // reclaim↔orphan thrash loop (see focusTerminal doc on FocusReassertDeps).
+        const el = (term as unknown as { element?: HTMLElement }).element;
+        if (el && el.offsetParent === null) return false;
+        term.focus();
+        // Confirm focus actually landed on a real element. If the terminal was
+        // not focusable after all, activeElement is still <body> and this is not
+        // a real heal — report failure so the caller neither loops nor logs it.
+        return !isFocusOrphaned(document.activeElement, document.body);
+      },
       defer: (cb) => {
         const handle = requestAnimationFrame(() => { pending.delete(handle); cb(); });
         pending.add(handle);
       },
-      onHeal: (id) => console.debug(`[useActivePaneFocus] reclaimed orphaned focus → pty=${id}`),
+      // For a focusout, the event target is the element that just RELINQUISHED
+      // focus to <body> — i.e. the orphaning culprit. Snapshot it here (the
+      // event is stale by the deferred frame). keydown / window-focus carry no
+      // meaningful culprit.
+      describeCulprit: () => {
+        const t = ev && ev.type === 'focusout' ? (ev.target as Element | null) : null;
+        if (!t || !(t instanceof Element)) return null;
+        const cls = typeof t.className === 'string' && t.className ? `.${t.className.trim().split(/\s+/).join('.')}` : '';
+        const id = t.id ? `#${t.id}` : '';
+        return `${t.tagName.toLowerCase()}${id}${cls}`;
+      },
+      onHeal: (id, culprit) => console.debug(
+        `[useActivePaneFocus] reclaimed orphaned focus → pty=${id}` +
+        (culprit ? ` (lost-from=${culprit})` : ''),
+      ),
     });
     // window 'focus': OS focus returns (alt-tab back) onto <body>.
     // 'focusout': an element (overlay input) just relinquished / was unmounted;


### PR DESCRIPTION
## What

Intermittent bug: typing sporadically stops reaching a terminal pane, and the only recovery is opening a new pane. Reported on another machine running packaged 3.24.0.

## Root cause (confirmed from field logs)

The install's `main-2026-07-16.log` shows **zero `[wmux:dead-input]` watchdog hits** but a **flood of `reclaimed orphaned focus`** bursts (many per second, all on agent PTYs). That rules out the long-suspected IME keyCode-229 claim-storm and pins it on **orphaned focus**.

When the pane that should hold keyboard focus is momentarily unfocusable — off-screen during a workspace switch, or a re-mounting terminal — the focus self-heal (`reassertFocusIfOrphaned`) focused it anyway. `focus()` on an invisible xterm textarea is a silent no-op that leaves DOM focus on `<body>`, so the next `focusout` re-fired the heal and the reclaim↔orphan loop spun, dropping the keystrokes caught in each gap. Splitting a new pane "fixed" it only by moving the active pane onto a fresh, visible terminal that broke the loop.

## Fix

- `focusTerminal` now returns a boolean. It skips a terminal whose element is not in layout (`offsetParent === null`) and confirms focus actually left `<body>` before reporting success. `reassertFocusIfOrphaned` counts a heal only when focus truly landed, so a no-op `focus()` can no longer sustain the loop or spam the log.
- On a real heal, snapshot the `focusout` target (the element that dropped focus) and log it as `lost-from=<tag#id.class>`, so any residual orphaning names its own source next time.

## Tests

`useActivePaneFocus.test.ts` gains coverage for the false-return (invisible / mid-remount) and culprit paths. 30/30 in that file, full suite green except a pre-existing Windows `symlinkSync` EPERM diff test (unrelated subsystem).

## Note

This is diagnosed but not yet dogfooded on the affected machine (the bug does not reproduce locally). The visibility guard should eliminate the thrash; the `lost-from=` log will name the original orphaning source if any case remains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where keyboard input could intermittently stop reaching a terminal pane.
  * Improved focus recovery to avoid targeting hidden or unavailable terminals.
  * Focus is now considered recovered only when it successfully lands, reducing incorrect recovery behavior.
  * Added diagnostic details to help identify which element caused focus to be lost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->