### PR TITLE
chore(release): 3.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.24.1] — 2026-07-16
+
 ### Fixed
 
 - **Typing no longer intermittently goes dead in a pane until you open a new one.** On some machines, keystrokes would sporadically stop reaching the terminal — you'd type and nothing happened, and the only way back was to split off a fresh pane. The cause was a focus tug-of-war: when the pane that should hold keyboard focus was momentarily off-screen (mid workspace-switch or a re-mounting terminal), the focus self-heal kept shoving focus at it, focus bounced straight back to nothing, and the loop spun — dropping the keystrokes caught in between. The self-heal now refuses to hand focus to a terminal that isn't actually visible and confirms focus truly landed before counting it as recovered, which breaks the loop. It also now records which element dropped focus, so any remaining cases name their own cause in the logs. (This is a distinct bug from the earlier IME "claim-storm" — the field logs ruled that out.)

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.24.0 sources.** This file is produced by
+> **Generated from wmux v3.24.1 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.24.0",
+  "version": "3.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.24.0",
+      "version": "3.24.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.24.0",
+  "version": "3.24.1",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Patch release. Bumps `package.json` to 3.24.1, promotes the `[Unreleased]` CHANGELOG entry to `[3.24.1]`, and regenerates `docs/api/reference.md` (version header baked to 3.24.1, enforced by the CI drift guard).

Contents: the focus self-heal fix from #468 — intermittent dead typing in a pane (recovered only by opening a new pane), root-caused to orphaned-focus thrash from field logs.

Tag `v3.24.1` will be pushed after merge to trigger the installer/Chocolatey/winget release build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the 3.24.1 release section to the changelog.
  * Updated API reference documentation to reflect version 3.24.1.

* **Chores**
  * Updated the package version to 3.24.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->