### PR TITLE
perf(main): leading-edge flush in DaemonDataBatcher — restore keystroke echo latency

### DIFF
--- a/src/main/pty/DaemonDataBatcher.ts
+++ b/src/main/pty/DaemonDataBatcher.ts
@@ -25,6 +25,7 @@ export class DaemonDataBatcher {
   private pending = new Map<string, string[]>();
   private pendingChars = new Map<string, number>();
   private timers = new Map<string, ReturnType<typeof setTimeout>>();
+  private lastSentAt = new Map<string, number>();
   private disposed = false;
 
   constructor(
@@ -46,7 +47,24 @@ export class DaemonDataBatcher {
       // review, PR #471).
       return;
     }
+    // Leading-edge flush: a chunk arriving on an idle session (nothing
+    // buffered, no timer, ≥intervalMs since the last send) goes out
+    // immediately. This keeps interactive keystroke echo at 0 ms added
+    // latency — the CI bench caught the always-trailing version adding the
+    // full 8 ms to echoMs.p95 (13.9 → 21.5 ms) — while agent torrents still
+    // coalesce: only the FIRST chunk of a burst bypasses the batch window.
+    // Ordering is safe: the bypass requires an empty buffer.
+    const now = Date.now();
     const buf = this.pending.get(sessionId);
+    if (
+      !buf &&
+      !this.timers.has(sessionId) &&
+      now - (this.lastSentAt.get(sessionId) ?? 0) >= this.intervalMs
+    ) {
+      this.lastSentAt.set(sessionId, now);
+      this.send(sessionId, text);
+      return;
+    }
     if (buf) {
       buf.push(text);
     } else {
@@ -78,6 +96,7 @@ export class DaemonDataBatcher {
     if (!buf || buf.length === 0) return;
     this.pending.delete(sessionId);
     this.pendingChars.delete(sessionId);
+    this.lastSentAt.set(sessionId, Date.now());
     this.send(sessionId, buf.join(''));
   }
 
@@ -90,6 +109,7 @@ export class DaemonDataBatcher {
     }
     this.pending.delete(sessionId);
     this.pendingChars.delete(sessionId);
+    this.lastSentAt.delete(sessionId);
   }
 
   /** Flush every session (handler swap / shutdown) and stop accepting timers. */

--- a/src/main/pty/__tests__/DaemonDataBatcher.test.ts
+++ b/src/main/pty/__tests__/DaemonDataBatcher.test.ts
@@ -19,24 +19,42 @@ describe('DaemonDataBatcher', () => {
     vi.useRealTimers();
   });
 
-  it('coalesces chunks within the window into one in-order send', () => {
+  it('leading-edge: a chunk on an idle session is delivered immediately', () => {
+    // Interactive keystroke echo must not pay the batch window — the CI
+    // bench caught the always-trailing version adding the full 8 ms to
+    // echoMs.p95 (13.9 → 21.5 ms).
     const b = new DaemonDataBatcher(send, 8);
-    b.push('s1', 'a');
+    b.push('s1', 'k');
+    expect(sent).toEqual([['s1', 'k']]);
+    // Typing cadence (> window between keys): every echo is immediate.
+    vi.advanceTimersByTime(50);
+    b.push('s1', 'e');
+    expect(sent).toEqual([['s1', 'k'], ['s1', 'e']]);
+  });
+
+  it('coalesces burst chunks after the leading edge into one in-order send', () => {
+    const b = new DaemonDataBatcher(send, 8);
+    b.push('s1', 'a'); // leading edge — immediate
     b.push('s1', 'b');
     b.push('s1', 'c');
-    expect(sent).toEqual([]); // nothing until the window closes
+    expect(sent).toEqual([['s1', 'a']]); // rest waits for the window
     vi.advanceTimersByTime(8);
-    expect(sent).toEqual([['s1', 'abc']]);
+    expect(sent).toEqual([['s1', 'a'], ['s1', 'bc']]);
   });
 
   it('keeps sessions independent (per-session buffers and timers)', () => {
     const b = new DaemonDataBatcher(send, 8);
-    b.push('s1', 'x');
+    b.push('s1', 'x'); // leading edge each — immediate, per session
     b.push('s2', 'y');
-    vi.advanceTimersByTime(8);
     expect(sent).toHaveLength(2);
     expect(new Map(sent).get('s1')).toBe('x');
     expect(new Map(sent).get('s2')).toBe('y');
+    // Follow-ups inside each window coalesce per session.
+    b.push('s1', 'x2');
+    b.push('s2', 'y2');
+    expect(sent).toHaveLength(2);
+    vi.advanceTimersByTime(8);
+    expect(sent).toHaveLength(4);
   });
 
   it('flushSession delivers synchronously — data always precedes a marker', () => {
@@ -53,18 +71,20 @@ describe('DaemonDataBatcher', () => {
 
   it('bounds per-session memory: exceeding the cap flushes immediately', () => {
     const b = new DaemonDataBatcher(send, 8, 10 /* tiny cap */);
+    b.push('s1', 'lead'); // leading edge — immediate, bypasses the buffer
     b.push('s1', '123456');
-    expect(sent).toEqual([]);
-    b.push('s1', '7890X'); // 11 chars total ≥ cap
-    expect(sent).toEqual([['s1', '1234567890X']]);
+    expect(sent).toEqual([['s1', 'lead']]);
+    b.push('s1', '7890X'); // 11 buffered chars ≥ cap
+    expect(sent).toEqual([['s1', 'lead'], ['s1', '1234567890X']]);
   });
 
-  it('drop discards without sending', () => {
+  it('drop discards buffered data without sending', () => {
     const b = new DaemonDataBatcher(send, 8);
-    b.push('s1', 'doomed');
+    b.push('s1', 'lead'); // leading edge — already delivered
+    b.push('s1', 'doomed'); // buffered
     b.drop('s1');
     vi.advanceTimersByTime(20);
-    expect(sent).toEqual([]);
+    expect(sent).toEqual([['s1', 'lead']]);
   });
 
   it('dispose flushes everything pending, and late pushes are DROPPED (old generation)', () => {


### PR DESCRIPTION
## Summary

The always-trailing 8 ms batch window introduced in #471 (app-weight P1-3) applied to interactive keystroke echo as well as agent torrents. The CI perf gate caught it on main: `inputLatency.echoMs.p95` went 13.9 → 21.5 ms across the #471 merge — the full window added to every keystroke. (It slipped through #471's own bench run only because the gate needs BOTH 1.5× and +10 ms; main sat at +8.3 ms.)

This adds a leading-edge flush: a chunk arriving on an idle session (empty buffer, no pending timer, ≥ `intervalMs` since the last send) is delivered immediately, and only the follow-up chunks of a burst wait for the window.

- Typing cadence (> 8 ms between keys): every echo is immediate — 0 ms added latency.
- Agent torrents: still coalesce into one send per window, plus a single leading send per burst, so the IPC-wakeup reduction from #471 is preserved.
- Ordering contract untouched: the bypass fires only when the buffer is empty, so batched data can never be overtaken, and the flush-before-marker rules are unaffected.

## Verification

- CI bisect of the drift: pre-P0 run 13.7 ms → #470 merge 13.9 ms → #471 merge 21.5 ms (baseline 13.2 ms), pointing at the batcher, not the retention flip.
- `DaemonDataBatcher` suite updated to the new contract + 2 new leading-edge regression tests; src/main/pty 224/224 green, tsc clean.
- Expecting this PR's bench run to restore `inputLatency.echoMs.p95` to ~14 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPCLDVLgEcsD3WoUMpJKAy