### PR TITLE
ci: stop the phantom PR failures — drop duplicate runs, unpin apt from a repo we don't use

### DIFF
--- a/.github/workflows/ci-cross-platform-baseline.yml
+++ b/.github/workflows/ci-cross-platform-baseline.yml
@@ -7,16 +7,26 @@ name: CI Cross-Platform Baseline
 # the unix sides have never been executed). Failures get triaged via the
 # cross-platform fix budget, not by blocking merges.
 
+# Branch pushes are covered by the pull_request trigger. Listing 'feat/**' /
+# 'feature/**' under push as well ran this whole 3-OS matrix TWICE for every
+# push to a branch with an open PR — double the minutes and double the exposure
+# to runner flakes, with the push-event copy painting a red X on the commit even
+# when the PR's own copy was green. ci.yml already uses push-on-main + PR; this
+# now matches it.
 on:
   push:
     branches:
       - main
-      - 'feature/**'
-      - 'feat/**'
   pull_request:
     branches:
       - main
   workflow_dispatch:
+
+concurrency:
+  group: baseline-${{ github.ref }}
+  # Safe to cancel anywhere: this workflow is informational and writes nothing
+  # (unlike perf.yml, whose main runs append to the history file at the end).
+  cancel-in-progress: true
 
 jobs:
   baseline:
@@ -49,7 +59,15 @@ jobs:
       - name: Install Linux native build deps
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
+          # GitHub's Ubuntu images preconfigure packages.microsoft.com, which
+          # this job never installs from — build-essential and libxss1 come from
+          # the Ubuntu archives. But a bare `apt-get update` fails hard on ANY
+          # configured repo, so when that host broke (403 Forbidden on jammy
+          # InRelease, seen 2026-07-17) update exited 100 and killed the job over
+          # a repo we don't use. Drop it first, then retry the ones we need so a
+          # transient mirror hiccup doesn't read as a wmux failure.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/microsoft*.sources
+          sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install -y build-essential libxss1
 
       # macos-14 (Apple Silicon) ships with Xcode Command Line Tools preinstalled.

--- a/.github/workflows/ci-cross-platform-baseline.yml
+++ b/.github/workflows/ci-cross-platform-baseline.yml
@@ -59,14 +59,17 @@ jobs:
       - name: Install Linux native build deps
         if: runner.os == 'Linux'
         run: |
-          # GitHub's Ubuntu images preconfigure packages.microsoft.com, which
-          # this job never installs from — build-essential and libxss1 come from
-          # the Ubuntu archives. But a bare `apt-get update` fails hard on ANY
-          # configured repo, so when that host broke (403 Forbidden on jammy
-          # InRelease, seen 2026-07-17) update exited 100 and killed the job over
-          # a repo we don't use. Drop it first, then retry the ones we need so a
-          # transient mirror hiccup doesn't read as a wmux failure.
-          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/microsoft*.sources
+          # build-essential and libxss1 come from the Ubuntu archives, but
+          # `apt-get update` fails hard on ANY configured repo — and GitHub's
+          # images preconfigure third-party ones this job never installs from.
+          # On 2026-07-17 the Microsoft prod repo returned 403 on jammy
+          # InRelease, update exited 100, and the job died over a repo we don't
+          # use. Drop those sources by CONTENT, not filename: the same host is
+          # spread across differently-named files (microsoft-prod.list,
+          # azure-cli.list, …), so a filename glob misses some. Matching the
+          # host also survives a runner bump to deb822 (24.04 keeps the Ubuntu
+          # archives in sources.list.d/ubuntu.sources, which must NOT be dropped).
+          sudo bash -c 'grep -rlE "packages\.microsoft\.com|dl\.google\.com" /etc/apt/sources.list.d/ 2>/dev/null | xargs -r rm -f'
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install -y build-essential libxss1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,9 +346,17 @@ jobs:
 
       # build-essential + libxss1 for node-pty/Electron (matches the baseline CI);
       # rpm + fakeroot are required by @electron-forge/maker-rpm.
+      #
+      # The microsoft-prod repo is preconfigured on GitHub's Ubuntu images and
+      # nothing here installs from it, but `apt-get update` fails hard on ANY
+      # configured repo — when that host 403'd on 2026-07-17 it exited 100 and
+      # took the baseline job with it. On this path the cost is higher: the .deb,
+      # .rpm and .AppImage would silently go missing from a release over a repo
+      # we don't use. Drop it, then retry the archives we do need.
       - name: Install Linux build dependencies
         run: |
-          sudo apt-get update
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/microsoft*.sources
+          sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install -y build-essential libxss1 rpm fakeroot
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,15 +347,17 @@ jobs:
       # build-essential + libxss1 for node-pty/Electron (matches the baseline CI);
       # rpm + fakeroot are required by @electron-forge/maker-rpm.
       #
-      # The microsoft-prod repo is preconfigured on GitHub's Ubuntu images and
-      # nothing here installs from it, but `apt-get update` fails hard on ANY
-      # configured repo — when that host 403'd on 2026-07-17 it exited 100 and
-      # took the baseline job with it. On this path the cost is higher: the .deb,
-      # .rpm and .AppImage would silently go missing from a release over a repo
-      # we don't use. Drop it, then retry the archives we do need.
+      # Everything above comes from the Ubuntu archives, but `apt-get update`
+      # fails hard on ANY configured repo, and GitHub's images preconfigure
+      # third-party ones nothing here installs from. When the Microsoft prod repo
+      # 403'd on 2026-07-17 update exited 100 and killed the baseline job; on THIS
+      # path the cost is higher — the .deb, .rpm and .AppImage would go missing
+      # from a release over a repo we don't use. Dropped by content rather than
+      # filename (the same host spans microsoft-prod.list, azure-cli.list, …, and
+      # matching the host keeps a future deb822 runner's ubuntu.sources intact).
       - name: Install Linux build dependencies
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/microsoft*.sources
+          sudo bash -c 'grep -rlE "packages\.microsoft\.com|dl\.google\.com" /etc/apt/sources.list.d/ 2>/dev/null | xargs -r rm -f'
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install -y build-essential libxss1 rpm fakeroot
 


### PR DESCRIPTION
> "PR 올릴 때마다 매번 실패한다" — found it. Two separate defects stacked, and neither was wmux code.

## 1. Every `feat/*` PR ran the baseline matrix twice

`ci-cross-platform-baseline.yml` triggered on **both**:

```yaml
push:         [main, 'feature/**', 'feat/**']
pull_request: [main]
```

So a push to a `feat/*` branch **with an open PR** fired two identical 3-OS runs of the same commit. Evidence from this week:

- **#480** (`feat/notification-overhaul`) — two Baseline sets, `runs/29558060897` and `runs/29558062562`
- **#482** (`chore/release-3.25.0`) — one set, because the branch name didn't match the push filter

That doubles the minutes, doubles the exposure to runner flakes, and — the actual annoyance — the **push-event copy paints a red X on the commit even when the PR's own copy is green**. On `feat/acp-brain-adapter` at 02:27 the two copies of the *same commit* disagreed: the `pull_request` run passed, the `push` run failed.

Branch pushes are already covered by `pull_request`, and `ci.yml` has always used push-on-main + PR. Baseline now matches it.

Also added a `concurrency` group: superseded runs kept burning minutes. `perf.yml` has had one; this didn't. Safe to `cancel-in-progress` anywhere here since the workflow writes nothing (unlike perf's history append).

## 2. The failure underneath: an apt repo we never use

```
E: Failed to fetch https://packages.microsoft.com/ubuntu/22.04/prod/dists/jammy/InRelease  403  Forbidden
E: The repository '...jammy InRelease' is no longer signed.
##[error]Process completed with exit code 100
```

GitHub's Ubuntu images preconfigure `packages.microsoft.com`. Nothing here installs from it — `build-essential`, `libxss1`, `rpm` and `fakeroot` all come from the Ubuntu archives — but `apt-get update` fails hard on **any** configured repo, so a Microsoft-side outage took the job down.

Both apt call sites now drop that repo before updating, and retry the archives they actually need.

**`release.yml` carried the same landmine** on the Linux build job, where the cost is higher than a red X: the `.deb`, `.rpm` and `.AppImage` would have gone missing from a release over a repo we don't use. Fixed there too.

## Blast radius

`main` has **no required status checks**, and this workflow's own header says it is informational and not a release gate. So this changes no merge gate — it stops a non-gate workflow from reporting failures it never had.

## Verification

- Both workflows parse; triggers now `push: [main]` + `pull_request: [main]`; apt steps still install the same package sets; the new node-pty PDB step is untouched.
- **This PR is its own test**: it targets `main`, so the ubuntu-22.04 baseline leg runs here on the patched apt step. It should also produce exactly **one** Baseline set, not two.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI and Release Improvements**
  - Improved Linux build and release reliability by avoiding failures from preconfigured third-party APT repositories and retrying package index updates.
  - Reduced redundant CI activity by canceling in-progress runs for the same branch/ref when newer runs start.
  - Limited baseline CI to runs on pushes and pull requests targeting the main branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->