### PR TITLE
chore(release): 3.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.26.0] — 2026-07-17
+
+### Added
+
+- **Type `/clear` to the orchestrator to reset its context.** The brain's conversation memory (and its persisted resume session) is dropped, so the next turn starts completely fresh — useful when it has accumulated stale instructions or gone down a wrong path. The visible transcript stays as your audit trail; `/reset` works as an alias. An in-flight turn is interrupted first.
+
+- **wmux now offers to install its Claude Code hooks — and tells you when you're missing them.** Agent completion and approval detection is hook-primary, but the hook bridge previously required knowing the `wmux setup-hooks` CLI existed; without it, every signal silently degraded to screen-reading. A prompt now appears at launch when hooks are missing, and again when you raise a workspace's agent mode — with an Install button that does the same idempotent install as the CLI. wmux still never edits your Claude settings without that explicit click.
+
 ### Changed
 
 - **The agent mode knob is now three honest positions — Off, Assist, Auto (danger) — and the default is Off.** The previous four modes (off/manual/assist/orchestrate) collapsed into three that mean what they say: **Off** (the new default) gives the orchestrator no autonomy at all until you opt in; **Assist** wakes it only when a pane is blocked on input, to notify you — it never approves anything; **Auto (danger)** wakes it on every agent event and lets it drive work to completion on its own judgment, including pressing approval prompts. Existing workspaces keep working: a stored `manual` mode reads as Off, `orchestrate` as Auto.
 
 - **Auto mode actually presses approvals now.** The orchestrator was told "regex-detected prompts are notify-only, never approve" while the only source of approval events *was* the regex detector — so even the most permissive mode never pressed anything, silently. In Auto mode the brain is now instructed to verify first (read the pane and confirm a real approval prompt is on screen) and then press it, so a stray "y/N" in ordinary output still can't trigger a blind keystroke. Assist mode remains notify-only.
 
-- **Type `/clear` to the orchestrator to reset its context.** The brain's conversation memory (and its persisted resume session) is dropped, so the next turn starts completely fresh — useful when it has accumulated stale instructions or gone down a wrong path. The visible transcript stays as your audit trail; `/reset` works as an alias. An in-flight turn is interrupted first.
-
-- **wmux now offers to install its Claude Code hooks — and tells you when you're missing them.** Agent completion and approval detection is hook-primary, but the hook bridge previously required knowing the `wmux setup-hooks` CLI existed; without it, every signal silently degraded to screen-reading. A prompt now appears at launch when hooks are missing, and again when you raise a workspace's agent mode — with an Install button that does the same idempotent install as the CLI. wmux still never edits your Claude settings without that explicit click.
-
 - **The orchestrator treats your pane roles as a workflow, not just labels.** With Planner / Builder / Reviewer panes set up, non-trivial work now flows through them unprompted — plan first when the task is ambiguous, and review before reporting "done" — instead of one pane doing everything while the team you assembled sits idle.
 
 - **The orchestrator now reuses your existing panes before spawning new ones.** Its standing instructions gained a reuse-before-spawn rule: check the pane list for an idle shell or a finished agent and send work there, spawning a fresh pane only when nothing is free or the work genuinely needs to run in parallel. Previously it happily split a new pane while a suitable one sat idle next to it.
+
+### Fixed
+
+- **Dropdown menus were white-on-white in dark themes.** Native `<select>` popups (like the Fleet role dropdown) rendered their option list on the OS default white background while the text inherited the theme's light color. The popup now follows your theme in both directions.
 
 ## [3.25.0] — 2026-07-17
 

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.25.0 sources.** This file is produced by
+> **Generated from wmux v3.26.0 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.25.0",
+  "version": "3.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.25.0",
+      "version": "3.26.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.25.0",
+  "version": "3.26.0",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Release 3.26.0 — rolls up the Unreleased section.

MINOR: agent autonomy modes reshaped to off/assist/auto (default off), Auto mode now actually presses approvals (verify-then-press), `/clear` resets the orchestrator context, and the in-app hooks install prompt replaces CLI-only setup.

Release checklist (mirrors the 3.25.0 release diff):
- [x] `package.json` 3.25.0 → 3.26.0
- [x] `package-lock.json` bumped in both spots
- [x] CHANGELOG: `[Unreleased]` stub kept, section reclassification (Added/Changed/Fixed)
- [x] `node scripts/gen-api-reference.mjs` (drift guard)

Tag `v3.26.0` will be pushed after merge to kick the installer build.