### PR TITLE
fix: open the Claude detection gate from the OSC window-title sequence

### DIFF
--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -379,6 +379,9 @@ export class AgentDetector {
     // 뿐이라 미완성 라인에서 미리 봐도 안전하다.
     const tail = this.lineBuffer.replace(ANSI_STRIP, '').trim();
     if (tail) this.checkGates(tail);
+    // Raw-tail gate check — see processLine: current Claude Code only carries
+    // its name inside the OSC window-title escape, which the strip removes.
+    if (this.lineBuffer) this.checkGates(this.lineBuffer);
   }
 
   /**
@@ -399,6 +402,17 @@ export class AgentDetector {
   }
 
   private processLine(line: string): void {
+    // RAW-line gate check BEFORE the empty-clean bail. Live incident
+    // 2026-07-17 (Fable-era Claude Code): the TUI renders no visible
+    // "Claude Code" text — the name only appears in the OSC 0 window-title
+    // sequence (`ESC ]0;✳ Claude Code BEL`), which ANSI_STRIP removes
+    // wholesale; a title-only line then strips to empty and used to return
+    // before any gate check, leaving the gate permanently closed and every
+    // Claude pattern (including approval awaiting_input) dead. Gates are
+    // activation-only signals, so matching inside escape payloads is safe;
+    // status patterns still run on cleaned lines only.
+    this.checkGates(line);
+
     const clean = line.replace(ANSI_STRIP, '').trim();
     if (!clean) return;
 

--- a/src/main/pty/__tests__/AgentDetector.test.ts
+++ b/src/main/pty/__tests__/AgentDetector.test.ts
@@ -67,6 +67,34 @@ describe('AgentDetector', () => {
     });
   });
 
+  describe('OSC-title gate (live incident 2026-07-17, Fable-era Claude Code)', () => {
+    it('opens the Claude gate from the OSC 0 window-title sequence alone', () => {
+      // The current TUI renders no visible "Claude Code" text — the name only
+      // appears in the window title escape, which ANSI_STRIP removes. The gate
+      // must therefore also be checked against the raw line.
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('\x1b]0;✳ Claude Code\x07\n');
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb.mock.calls[0][0]).toMatchObject({ agent: 'Claude Code', status: 'running' });
+      // Approval detection now works even though no visible banner ever appeared.
+      cb.mockClear();
+      det.feed('│ Do you want to overwrite calculator.html? │\n');
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb.mock.calls[0][0]).toMatchObject({ status: 'awaiting_input' });
+    });
+
+    it('opens the gate from an OSC title stuck in an incomplete line (no newline)', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('\x1b]0;⠂ Claude Code\x07'); // no newline — tail path
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb.mock.calls[0][0]).toMatchObject({ agent: 'Claude Code', status: 'running' });
+    });
+  });
+
   describe('Claude file-edit approval prompts (live incident 2026-07-17)', () => {
     const gated = () => {
       const det = new AgentDetector();


### PR DESCRIPTION
## Problem

Live verification of #487 surfaced the deeper root cause of the 100-minute approval wedge: **the Claude detection gate never opens on current (Fable-era) Claude Code.** The TUI no longer renders "Claude Code" as visible text anywhere — the name only appears in the OSC 0 window-title escape (`ESC ]0;* Claude Code BEL`). `ANSI_STRIP` removes OSC sequences wholesale before gate matching, and a title-only line strips to empty and returned before any gate check. With the gate permanently closed, every Claude pattern — including the approval `awaiting_input` patterns added in #487 — was dead code at runtime.

## Change

`processLine` now runs the gate check against the **raw** line before stripping (and `feed` checks the raw incomplete-line tail). Gates are activation-only signals, so matching inside escape payloads is safe; status patterns still run on cleaned lines only.

## Verification

- 31/31 detector tests pass, including 2 new OSC-title gate cases (completed line + no-newline tail path).
- Replayed the actual wedged pane ring buffer (105KB) through the detector in 4KB streaming chunks: `running` (gate via OSC title) → `waiting` → `awaiting_input "Edit approval requested"` — the exact chain that was silent in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved agent detection when identifying information appears only in terminal window-title escape sequences.
  - Agent activity is now recognized even without visible banner text or a trailing newline.
  - Approval prompts continue to be detected after activation.

- **Tests**
  - Added coverage for window-title detection and incomplete terminal sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->