### PR TITLE
chore(release): 3.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.27.0] — 2026-07-18
+
 ### Added
 
 - **A merge conflict on a pane's PR now wakes the owning workspace too.** Completing the PR-feedback trio (red CI, review comments, and now conflicts): when a pane's pull request becomes conflicting against its base, the workspace's orchestrator wakes once — `auto` may send the pane one instruction to rebase/merge its base and resolve the conflict, `assist` reports, `off` stays silent. Edge-triggered per episode (fires once, re-arms when the conflict clears) and rides the same throttled `gh` read the review-comment router already makes, so it adds no extra polling. GitHub via `gh`'s `mergeable`, GitLab via `has_conflicts`.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.26.0 sources.** This file is produced by
+> **Generated from wmux v3.27.0 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.26.0",
+  "version": "3.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.26.0",
+      "version": "3.27.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.26.0",
+  "version": "3.27.0",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Cuts the **3.27.0** release from the current `main`.

Mechanical release commit only — no feature code. Bumps `package.json` + `package-lock.json`, renames CHANGELOG `[Unreleased]` → `[3.27.0] — 2026-07-18` (a fresh empty `[Unreleased]` stub stays on top), and regenerates `docs/api/reference.md` so its baked version header matches (CI drift guard).

### What ships in 3.27.0

**Added**
- PR merge-conflict / red-CI / review-comment signals now wake the owning workspace's orchestrator (auto drives the fix, assist reports, off stays silent).
- New **Review tab** in the deck — every open workspace's branch, PR badge, and uncommitted diff stat on one screen.
- Sidebar workspaces show git sync state (`↑ ↓ ●`) and idle duration next to the branch name.

**Changed**
- A driving loop proposes its own completion (confirm-completion decision) instead of idling to the budget; iteration budget relabelled "pause after N auto-wakes"; loop setup dialog spells out effective authority and defaults to Continue.
- Fan-out → **Multi Task (병렬 작업)** with per-task prompts and a Compete/Parallel toggle.
- A running loop's authority composes with the workspace mode (`min(ceiling, tier)`) instead of overriding it.
- Orchestrator agent-mode chip is colour-coded by state; macOS default launch hotkey → Ctrl+7.

**Fixed**
- Fail-closed on incomplete legacy-state migration retry (no silent channel-data loss).
- File-edit approval prompts now detected (no more panes stranded for hours); orchestrator no longer delegates routing to workers that can't route; idle CPU/GPU drain from perpetual UI animations removed; several orchestrator control-bar / macOS titlebar / install-hooks fixes.

See CHANGELOG.md for the full entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the API reference to reflect version 3.27.0 sources.
* **Chores**
  * Released version 3.27.0.
  * Added the v3.27.0 entry to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->