### PR TITLE
chore(release): 3.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.28.0] — 2026-07-20
+
 ### Added
 
 - **Resume a pane's agent conversation right from the pane.** After an agent (Claude / Codex) exits back to a shell, the pane header shows a quiet `↩ Resume <agent>` chip whenever wmux captured that conversation's session. Clicking it reveals the conversation UUID (with a copy button) and a preview of the exact command it will type; **Resume** types `claude --dangerously-skip-permissions --resume <id>` into that pane — the recorded permission mode is restored, and the exact-session form is used only while the pane's directory still matches the origin (otherwise it falls back to `--continue`). Nothing auto-runs; you press Enter. The chip stays hidden while an agent is actually running in the pane: OSC 133 shell state is the authoritative gate (a foreground command owns the PTY), with an agent-activity heuristic as fallback when shell integration is off — so a resume command can never land in a live agent's input. Available on any agent pane anytime, not only right after a reboot.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.27.0 sources.** This file is produced by
+> **Generated from wmux v3.28.0 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.27.0",
+  "version": "3.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.27.0",
+      "version": "3.28.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.27.0",
+  "version": "3.28.0",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Release v3.28.0. Rolls up everything under `[Unreleased]` since 3.27.0 — the renderer flush-storm hook/buffer fixes (#506), the per-pane resume chip + durable daemon recovery logging (#507), the macOS menu-bar tray template icon (#508), plus the Git-tab / worktree-merge / Broadcast / macOS-CLI work.

Standard release commit (4 files): version 3.27.0 → 3.28.0, CHANGELOG `[Unreleased]` → `[3.28.0]`, regenerated `docs/api/reference.md`, package-lock. The `v3.28.0` tag is pushed after merge (installer/Chocolatey/winget builds hang off the tag).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package version to **3.28.0**.
  * Added the **3.28.0** release entry dated **July 20, 2026**.
  * Updated the API reference to reflect version **3.28.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->