### PR TITLE
fix: resolve the agent's real repo when the shell sits elsewhere (Git tab, cwd guards, resume chip)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Git tab (worktrees + review roster) now finds the repo an agent is working in, even when the shell it runs in sits elsewhere.** Repo context used to come only from the pane's shell working directory — but for an agent pane (Claude / Codex TUI) that is typically the directory the shell was *started* in (often the home dir), while the agent works in a repo somewhere else. Result: the sidebar showed the branch just fine, yet the Git tab said "not a git repository". Repo resolution now falls back to the hook-reported agent directory (the same value the sidebar branch badge already trusts) when the shell's own directory doesn't resolve to a repo.
+- **Resume no longer silently downgrades to `--continue` when the pane's tracked directory is stale.** The resume chip/pill only offers the exact `--resume <uuid>` form (with the recorded permission flag) when the conversation's origin directory matches the pane's live directory — but it compared against the shell's tracked cwd, which goes stale across `cd X; claude` one-liners (no prompt render in between, so the shell never reports the new directory). A legitimate exact resume was then downgraded to `--continue`, dropping the permission flag and possibly resuming a different conversation. The match now also accepts the hook-reported agent directory (the same value the sidebar branch badge trusts). Nothing auto-runs either way — the command is only typed, and you press Enter.
+- **A pane's tracked working directory can no longer be corrupted by terminal output that looks like a shell prompt.** Two guards, observed live (a pane's directory stored as the literal token `path`, which then broke Git-tab repo resolution): once a shell has proven it runs the wmux integration hook (it emitted an OSC 7), prompt-scrape directory detection is permanently disabled for that session — the hook is authoritative, so scraping could only ever add false positives; and scraped values must now be absolute (or `~`-anchored) paths on every platform — a bare relative token is never a real working directory.
 ## [3.28.0] — 2026-07-20
 
 ### Added

--- a/src/daemon/DaemonPTYBridge.ts
+++ b/src/daemon/DaemonPTYBridge.ts
@@ -66,6 +66,14 @@ export class DaemonPTYBridge extends EventEmitter {
    */
   private lastEmittedOscCwd: string | null = null;
 
+  /**
+   * OSC 7-sticky: set on the first OSC 7 from this session's shell and never
+   * cleared. While true, prompt-scrape cwd detection is skipped entirely — the
+   * hook is the authoritative source, and the scraper's only remaining effect
+   * would be false positives from screen text shaped like a prompt.
+   */
+  private oscCwdSeen = false;
+
   /** Called by DaemonSessionManager.resizeSession on every applied resize. */
   noteResize(): void {
     this.lastResizeAtMs = Date.now();
@@ -158,6 +166,12 @@ export class DaemonPTYBridge extends EventEmitter {
         // the prompt-detect guard (lastDetectedCwd) below; the first OSC 7
         // after spawn always emits because the cache starts null.
         const cwd = parseOsc7Cwd(event.data);
+        // OSC 7-sticky (2026-07-21): this shell has the integration hook — the
+        // authoritative cwd source. Disable prompt scraping for the session's
+        // lifetime so screen text that happens to match a prompt regex (agent
+        // TUI output printing "user@host:path$"-shaped strings — observed live
+        // as a pane cwd stored as the literal "path") can never override it.
+        this.oscCwdSeen = true;
         if (cwd !== this.lastEmittedOscCwd) {
           this.lastEmittedOscCwd = cwd;
           this.emit('cwd', { sessionId, cwd });
@@ -218,18 +232,23 @@ export class DaemonPTYBridge extends EventEmitter {
         activityMonitor.feed(sessionId, buf.length);
         oscParser.process(data);
 
-        // Prompt-based CWD detection
-        promptBuffer += data;
-        if (promptBuffer.length > 1024) promptBuffer = promptBuffer.slice(-512);
+        // Prompt-based CWD detection — fallback for shells WITHOUT the
+        // integration hook only. Once OSC 7 has been seen (oscCwdSeen), the
+        // scraper is permanently off for this session: the hook re-emits on
+        // every prompt, so scraping can only ever add false positives.
+        if (!this.oscCwdSeen) {
+          promptBuffer += data;
+          if (promptBuffer.length > 1024) promptBuffer = promptBuffer.slice(-512);
 
-        const clean = promptBuffer.replace(DaemonPTYBridge.ANSI_STRIP, '');
-        const detectedCwd = detectPromptCwd(clean);
-        if (detectedCwd !== null) {
-          if (detectedCwd !== lastDetectedCwd) {
-            lastDetectedCwd = detectedCwd;
-            this.emit('cwd', { sessionId, cwd: detectedCwd });
+          const clean = promptBuffer.replace(DaemonPTYBridge.ANSI_STRIP, '');
+          const detectedCwd = detectPromptCwd(clean);
+          if (detectedCwd !== null) {
+            if (detectedCwd !== lastDetectedCwd) {
+              lastDetectedCwd = detectedCwd;
+              this.emit('cwd', { sessionId, cwd: detectedCwd });
+            }
+            promptBuffer = '';
           }
-          promptBuffer = '';
         }
 
         this.emit('data', buf);

--- a/src/daemon/__tests__/DaemonPTYBridge.cwdDedup.test.ts
+++ b/src/daemon/__tests__/DaemonPTYBridge.cwdDedup.test.ts
@@ -65,3 +65,45 @@ describe('DaemonPTYBridge OSC 7 cwd dedup (app-weight P1-4)', () => {
     expect(cwdEvents.map((e) => e.cwd)).toEqual(['C:\\a', 'C:\\b', 'C:\\a']);
   });
 });
+
+// OSC 7-sticky (2026-07-21): once the shell has proven it runs the integration
+// hook, prompt scraping must be permanently off for the session — screen text
+// shaped like a prompt (agent TUI output printing "user@host:path$") was
+// observed live overriding the hook's cwd with the literal token "path".
+describe('DaemonPTYBridge OSC 7-sticky scrape disable', () => {
+  let bridge: DaemonPTYBridge;
+  let feed: (data: string) => void;
+  let cwdEvents: Array<{ sessionId: string; cwd: string }>;
+
+  beforeEach(() => {
+    bridge = new DaemonPTYBridge();
+    const fake = makeFakePty();
+    feed = fake.feed;
+    cwdEvents = [];
+    bridge.on('cwd', (e) => cwdEvents.push(e));
+    bridge.setupDataForwarding(fake.pty, new RingBuffer(4096), 'sess-1');
+  });
+
+  afterEach(() => {
+    bridge.cleanup();
+  });
+
+  it('prompt scraping works before any OSC 7 (un-hooked shell fallback)', () => {
+    feed('me@host:/home/me/work$');
+    expect(cwdEvents.map((e) => e.cwd)).toEqual(['/home/me/work']);
+  });
+
+  it('after an OSC 7, prompt-shaped screen text no longer emits a cwd', () => {
+    feed(osc7('C:/repo'));
+    // Agent TUI prints something the bash-prompt regex would match.
+    feed('me@host:/some/fake$');
+    expect(cwdEvents.map((e) => e.cwd)).toEqual(['C:\\repo']);
+  });
+
+  it('the hook keeps reporting cwd changes after scraping is disabled', () => {
+    feed(osc7('C:/repo'));
+    feed('me@host:/some/fake$');
+    feed(osc7('C:/other'));
+    expect(cwdEvents.map((e) => e.cwd)).toEqual(['C:\\repo', 'C:\\other']);
+  });
+});

--- a/src/main/pty/PTYBridge.ts
+++ b/src/main/pty/PTYBridge.ts
@@ -243,6 +243,12 @@ export class PTYBridge {
     const oscParser = new OscParser();
     this.oscParsers.set(ptyId, oscParser);
 
+    // OSC 7-sticky: flips true on the first OSC 7 from this PTY's shell and
+    // never resets — from then on the prompt-scrape fallback below is skipped
+    // (the hook re-emits on every prompt; scraping could only add false
+    // positives, e.g. agent TUI output shaped like "user@host:path$").
+    let oscCwdSeen = false;
+
     // Desktop-notification sequences (OSC 9/777/99). Stateful for OSC 99
     // chunk assembly, so it lives per-PTY alongside the OscParser. Captured
     // by the onOsc closure below; no separate cleanup needed — it dies with
@@ -267,6 +273,11 @@ export class PTYBridge {
           break;
         }
         case 7: {
+          // OSC 7-sticky (2026-07-21): the hook is the authoritative cwd
+          // source — permanently disable prompt scraping for this PTY so
+          // screen text shaped like a prompt can never override it (twin of
+          // the DaemonPTYBridge guard).
+          oscCwdSeen = true;
           const cwd = parseOsc7Cwd(event.data);
           updateCwd(ptyId, cwd);
           win.webContents.send(IPC.CWD_CHANGED, ptyId, cwd);
@@ -560,8 +571,10 @@ export class PTYBridge {
       agentDetector.feed(data);
     });
 
-    // 4. Prompt buffer + CWD detection
+    // 4. Prompt buffer + CWD detection — fallback for shells WITHOUT the
+    // integration hook only (see oscCwdSeen above).
     this.addMiddleware(ptyId, (data) => {
+      if (oscCwdSeen) return;
       const win = this.getWindow();
       if (!win || win.isDestroyed()) return;
 

--- a/src/renderer/components/Deck/GitTab.tsx
+++ b/src/renderer/components/Deck/GitTab.tsx
@@ -32,9 +32,15 @@ type MergeStart = { ok: true; status: MergeSessionStatus } | { ok: false; error:
 type MergeStatus = { ok: true; status: MergeSessionStatus | null } | { ok: false; error: string };
 type MergeAction = { ok: true } | { ok: false; error: string };
 
-// 활성 워크스페이스의 활성 pane → 활성 surface cwd (팔레트 Show Git Diff와 동일 규칙).
+// 활성 워크스페이스의 활성 pane → repo-base cwd 후보 목록(우선순위 순).
 // 셀렉터로도 재사용(store 상태에서 원시 문자열로 수렴 — 리렌더 최소화).
-function selectActivePaneCwd(state: StoreState): string {
+//
+// 왜 목록인가(2026-07-21 실측): 에이전트 TUI pane은 surface.cwd(셸의 cwd)가
+// repo 밖일 수 있다 — 셸은 홈에 앉아 있고 에이전트만 repo에서 작업하는 경우
+// (관측: surface.cwd=C:\Users\me, metadata.cwd=D:\wmux). metadata.cwd는 hook이
+// 보고한 에이전트 cwd로 사이드바 브랜치가 이미 신뢰하는 값이므로 두 번째
+// 후보로 넣는다. load()가 순서대로 resolveRepo를 시도해 첫 성공을 채택한다.
+function selectActivePaneCwdCandidates(state: StoreState): string {
   const ws = state.workspaces.find((w) => w.id === state.activeWorkspaceId);
   if (!ws) return '';
   const findLeaf = (pane: Pane): PaneLeaf | null => {
@@ -48,8 +54,17 @@ function selectActivePaneCwd(state: StoreState): string {
   const leaf = findLeaf(ws.rootPane);
   const surface = leaf?.surfaces.find((s) => s.id === leaf.activeSurfaceId);
   // 오염된 cwd(스크래핑 오탐으로 저장된 불가능한 모양)는 건너뛰고 폴백 사용.
-  const cwd = surface?.cwd && isPlausibleCwd(surface.cwd) ? surface.cwd : '';
-  return cwd || ws.profile?.startupCwd || state.startupDirectory || '';
+  // platform은 호스트 OS 기준(ReviewTab.normRepo와 동일 소스) — 렌더러의
+  // process.platform 기본값은 CI POSIX 러너에서 Windows 경로를 오거부한다.
+  const plat = (window as unknown as { electronAPI?: { platform?: string } }).electronAPI?.platform;
+  const surfaceCwd = surface?.cwd && isPlausibleCwd(surface.cwd, plat ?? undefined) ? surface.cwd : '';
+  const candidates = [
+    surfaceCwd,
+    ws.metadata?.cwd ?? '',
+    ws.profile?.startupCwd ?? '',
+    state.startupDirectory || '',
+  ].filter(Boolean);
+  return [...new Set(candidates)].join('\0');
 }
 
 function pathLeaf(p: string): string {
@@ -90,9 +105,11 @@ export function GitTab({ cwd }: { cwd?: string } = {}): React.ReactElement {
   // 포커스가 옮겨가도 재조회되도록 load의 dep으로 쓴다(Codex P2). 단 중앙 surface로
   // 렌더될 땐 prop cwd(생성 시 캡처된 surface.cwd)가 repo base로 우선한다 — 자기
   // 빈 cwd를 활성 pane에서 읽어 repo가 틀어지는 문제를 막는다. prop 미제공(덱 하위
-  // 호환) 시에만 selectActivePaneCwd 폴백.
-  const activePaneCwd = useStore(selectActivePaneCwd);
-  const activeCwd = cwd ?? activePaneCwd;
+  // 호환) 시에만 selectActivePaneCwdCandidates 폴백.
+  const activePaneCwdCandidates = useStore(selectActivePaneCwdCandidates);
+  // prop cwd(중앙 surface 생성 시 캡처)가 있으면 그것만 시도 — 활성 pane 폴백 금지
+  // (자기 빈 cwd를 활성 pane에서 읽어 repo가 틀어지는 문제, GitTab.cwdProp 테스트).
+  const activeCwdCandidates = cwd != null ? cwd : activePaneCwdCandidates;
   const pushToast = useStore((s) => s.pushToast);
   const [repoPath, setRepoPath] = useState<string | null>(null);
   // 본(main) 워크트리 경로 — "main" 배지·Remove 숨김 기준. 현재 워크트리
@@ -122,9 +139,14 @@ export function GitTab({ cwd }: { cwd?: string } = {}): React.ReactElement {
       setLoading(false);
       return;
     }
-    const cwd = activeCwd;
-    const resolved = cwd ? await resolveRepo(cwd) : ({ ok: false } as const);
-    if (seq !== loadSeq.current) return; // superseded by a newer load
+    // 후보를 순서대로 시도해 첫 git-resolve 성공을 채택한다(에이전트 pane의
+    // 셸 cwd가 repo 밖이어도 metadata.cwd 폴백이 잡는다 — 2026-07-21).
+    let resolved: { ok: true; repoPath: string } | { ok: false } = { ok: false };
+    for (const candidate of activeCwdCandidates.split('\0').filter(Boolean)) {
+      resolved = await resolveRepo(candidate);
+      if (seq !== loadSeq.current) return; // superseded by a newer load
+      if (resolved.ok) break;
+    }
     if (!resolved.ok) {
       setRepoPath(null);
       setWorktrees([]);
@@ -151,7 +173,7 @@ export function GitTab({ cwd }: { cwd?: string } = {}): React.ReactElement {
       if (seq !== loadSeq.current) return; // superseded by a newer load
       if (ms.ok) setSession(ms.status);
     }
-  }, [activeCwd]);
+  }, [activeCwdCandidates]);
 
   // 탭 마운트 시 + 활성 워크스페이스/pane cwd 변경 시 재조회(pull-only).
   // load가 activeCwd에 의존하므로 pane 포커스 전환도 여기서 재조회된다.

--- a/src/renderer/components/Deck/ReviewTab.tsx
+++ b/src/renderer/components/Deck/ReviewTab.tsx
@@ -25,6 +25,7 @@ import { useT } from '../../hooks/useT';
 import { tokenAttrs } from '../../themes';
 import { FOCUS_RING } from '../focusRing';
 import type { Pane, PaneLeaf, PrStatus } from '../../../shared/types';
+import { isPlausibleCwd } from '../../../shared/cwdShape';
 import type { DiffReadResult, DiffReadError } from '../../../shared/diffParse';
 
 // A workspace's review row — resolved repo + summed numstat, or the reason
@@ -63,6 +64,41 @@ function findFirstLeaf(root: Pane): PaneLeaf | null {
 
 function pathLeaf(p: string): string {
   return p.split(/[/\\]/).filter(Boolean).pop() || p;
+}
+
+// 워크스페이스의 repo-base cwd 후보(우선순위 순) — GitTab과 동일 규칙(2026-07-21).
+// 에이전트 TUI pane은 surface.cwd(셸 cwd)가 repo 밖일 수 있어(셸=홈, 에이전트=repo)
+// hook이 보고한 metadata.cwd를 두 번째 후보로 넣고, 호출부가 순서대로
+// resolveRepo를 시도해 첫 성공을 채택한다.
+function repoCwdCandidates(
+  ws: { rootPane: Pane; activePaneId: string; metadata?: { cwd?: string }; profile?: { startupCwd?: string } },
+  startupDirectory: string,
+): string[] {
+  const leaf = findActiveLeaf(ws.rootPane, ws.activePaneId) ?? findFirstLeaf(ws.rootPane);
+  const surface = leaf?.surfaces.find((s) => s.id === leaf.activeSurfaceId);
+  // platform은 호스트 OS 기준(normRepo와 동일 소스) — 렌더러의 process.platform
+  // 기본값은 CI POSIX 러너에서 Windows 경로를 오거부한다.
+  const plat = (window as unknown as { electronAPI?: { platform?: string } }).electronAPI?.platform;
+  const surfaceCwd = surface?.cwd && isPlausibleCwd(surface.cwd, plat ?? undefined) ? surface.cwd : '';
+  const candidates = [
+    surfaceCwd,
+    ws.metadata?.cwd ?? '',
+    ws.profile?.startupCwd ?? '',
+    startupDirectory,
+  ].filter(Boolean);
+  return [...new Set(candidates)];
+}
+
+/** 후보를 순서대로 resolveRepo에 넣어 첫 성공을 반환(없으면 null). */
+async function resolveFirstRepo(
+  bridge: DiffBridge,
+  candidates: string[],
+): Promise<string | null> {
+  for (const cwd of candidates) {
+    const r = await bridge.resolveRepo(cwd);
+    if (r.ok) return r.repoPath;
+  }
+  return null;
 }
 
 interface DiffBridge {
@@ -129,14 +165,12 @@ export function ReviewTab(): React.ReactElement {
     let scope: Set<string> | null = null;
     const active = state.workspaces.find((w) => w.id === state.activeWorkspaceId);
     if (bridge && wtList && active) {
-      const leaf = findActiveLeaf(active.rootPane, active.activePaneId) ?? findFirstLeaf(active.rootPane);
-      const surface = leaf?.surfaces.find((s) => s.id === leaf.activeSurfaceId);
-      const cwd = surface?.cwd || active.profile?.startupCwd || state.startupDirectory || '';
-      if (cwd) {
+      const candidates = repoCwdCandidates(active, state.startupDirectory || '');
+      if (candidates.length > 0) {
         try {
-          const r = await bridge.resolveRepo(cwd);
-          if (r.ok) {
-            const wl = await wtList(r.repoPath);
+          const repoPath = await resolveFirstRepo(bridge, candidates);
+          if (repoPath !== null) {
+            const wl = await wtList(repoPath);
             if (wl.ok) scope = new Set(wl.worktrees.map((w) => normRepo(w.path)));
           }
         } catch {
@@ -147,9 +181,7 @@ export function ReviewTab(): React.ReactElement {
 
     const out: ReviewRow[] = [];
     for (const ws of state.workspaces) {
-      const leaf = findActiveLeaf(ws.rootPane, ws.activePaneId) ?? findFirstLeaf(ws.rootPane);
-      const surface = leaf?.surfaces.find((s) => s.id === leaf.activeSurfaceId);
-      const cwd = surface?.cwd || ws.profile?.startupCwd || state.startupDirectory || '';
+      const candidates = repoCwdCandidates(ws, state.startupDirectory || '');
       const row: ReviewRow = {
         workspaceId: ws.id,
         name: ws.name,
@@ -161,12 +193,12 @@ export function ReviewTab(): React.ReactElement {
         deletions: 0,
         error: null,
       };
-      if (bridge && cwd) {
+      if (bridge && candidates.length > 0) {
         try {
-          const resolved = await bridge.resolveRepo(cwd);
-          if (resolved.ok) {
-            row.repoPath = resolved.repoPath;
-            const diff = await bridge.read(resolved.repoPath, '', 'workspace');
+          const repoPath = await resolveFirstRepo(bridge, candidates);
+          if (repoPath !== null) {
+            row.repoPath = repoPath;
+            const diff = await bridge.read(repoPath, '', 'workspace');
             if (diff.ok) {
               row.files = diff.numstat.length;
               for (const n of diff.numstat) {

--- a/src/renderer/components/Deck/__tests__/GitTab.metadataCwd.dynamic.test.tsx
+++ b/src/renderer/components/Deck/__tests__/GitTab.metadataCwd.dynamic.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+//
+// Regression (2026-07-21, live-observed): an agent TUI pane's surface.cwd is the
+// SHELL's directory (e.g. the home dir the shell was spawned in), while the
+// agent's real working repo is only in workspace metadata.cwd (reported by the
+// hook bridge — the same value the sidebar branch badge already trusts). The
+// Git tab used to resolve the repo from surface.cwd only and showed "not a git
+// repository" even though the sidebar showed the branch. It must fall back to
+// metadata.cwd when the surface cwd does not resolve.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createElement, act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useStore } from '../../../stores';
+import { GitTab } from '../GitTab';
+import type { SessionData, Workspace } from '../../../../shared/types';
+
+const HOME = '/home/me'; // shell's cwd — NOT a repo
+const REPO = '/home/me/proj'; // agent's cwd from metadata — the repo
+
+function makeWs(surfaceCwd: string, metadataCwd: string): Workspace {
+  return {
+    id: 'ws-1',
+    name: 'Alpha',
+    rootPane: {
+      id: 'leaf',
+      type: 'leaf',
+      activeSurfaceId: 's1',
+      surfaces: [{ id: 's1', ptyId: 'pty-1', title: 't', shell: 'bash', cwd: surfaceCwd, surfaceType: 'terminal' }],
+    },
+    activePaneId: 'leaf',
+    metadata: { cwd: metadataCwd },
+  } as unknown as Workspace;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+// Only the repo path resolves; the shell home does not.
+const resolveRepo = vi.fn((cwd: string) =>
+  Promise.resolve(cwd === REPO ? { ok: true as const, repoPath: REPO } : { ok: false as const }),
+);
+
+beforeEach(() => {
+  resolveRepo.mockClear();
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    diff: { resolveRepo },
+    worktree: {
+      list: (repoPath: string) =>
+        Promise.resolve({
+          ok: true,
+          repoPath,
+          mainPath: repoPath,
+          worktrees: [{ path: repoPath, branch: 'main', headOid: '0000000', locked: null, prunable: null }],
+        }),
+      add: vi.fn(),
+      remove: vi.fn(),
+    },
+  };
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+});
+
+const flush = async (): Promise<void> => {
+  for (let i = 0; i < 6; i++) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+};
+
+describe('GitTab — metadata.cwd fallback (agent pane whose shell sits outside the repo)', () => {
+  it('resolves the repo via metadata.cwd when the surface cwd is not a repo', async () => {
+    const data: SessionData = {
+      workspaces: [makeWs(HOME, REPO)],
+      activeWorkspaceId: 'ws-1',
+      sidebarVisible: true,
+    };
+    act(() => useStore.getState().loadSession(data));
+    act(() => root.render(createElement(GitTab)));
+    await flush();
+
+    // Tried the shell cwd first (per-pane behavior preserved), then fell back.
+    expect(resolveRepo).toHaveBeenCalledWith(HOME);
+    expect(resolveRepo).toHaveBeenCalledWith(REPO);
+    // The worktree roster rendered — no "not a git repository" placeholder.
+    expect(container.querySelector('[data-git-worktree-list]')?.textContent).toContain('main');
+  });
+
+  it('a corrupted relative surface cwd (the "path" incident) is skipped entirely', async () => {
+    const data: SessionData = {
+      workspaces: [makeWs('path', REPO)],
+      activeWorkspaceId: 'ws-1',
+      sidebarVisible: true,
+    };
+    act(() => useStore.getState().loadSession(data));
+    act(() => root.render(createElement(GitTab)));
+    await flush();
+
+    // The implausible token never reaches resolveRepo; metadata.cwd wins.
+    expect(resolveRepo).not.toHaveBeenCalledWith('path');
+    expect(resolveRepo).toHaveBeenCalledWith(REPO);
+    expect(container.querySelector('[data-git-worktree-list]')?.textContent).toContain('main');
+  });
+});

--- a/src/renderer/components/Deck/__tests__/ReviewTab.dynamic.test.tsx
+++ b/src/renderer/components/Deck/__tests__/ReviewTab.dynamic.test.tsx
@@ -201,6 +201,25 @@ describe('ReviewTab — diff-first roster', () => {
     expect(rows).toHaveLength(2); // 폴백: 둘 다 표시
   });
 
+  // Regression (2026-07-21): agent pane whose SHELL sits outside the repo —
+  // surface.cwd is the shell home, the agent's repo lives in metadata.cwd
+  // (hook-reported, already trusted by the sidebar). The row must resolve via
+  // the metadata.cwd fallback instead of degrading to "no repo".
+  it('falls back to metadata.cwd when the surface cwd is not a repo', async () => {
+    seed(
+      [workspace('ws-agent', 'agent-ws', 'C:/not-a-repo', {
+        metadata: { cwd: 'D:/repo-dirty' },
+      } as Partial<Workspace>)],
+      'ws-agent',
+    );
+    await mount();
+    const row = container.querySelector('[data-review-list] li')!;
+    expect(row.textContent).toContain('agent-ws');
+    expect(row.textContent).not.toContain('no repo');
+    // Resolved to the dirty repo → summed numstat renders.
+    expect(row.textContent).toContain('+15');
+  });
+
   it('branch from workspace metadata and PR number render in the row', async () => {
     seed(
       [workspace('ws-dirty', 'meta-ws', 'D:/repo-dirty', {

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -453,8 +453,17 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
           if (/^[A-Za-z]:\//.test(out)) out = out[0].toLowerCase() + out.slice(1);
           return out;
         };
-        const paneCwd = pane.surfaces.find((s) => s.id === pane.activeSurfaceId)?.cwd;
-        const cwdMatches = !!(resumeBinding && paneCwd && normCwd(resumeBinding.cwd) === normCwd(paneCwd));
+        // Candidates, not a single cwd (2026-07-21): surface.cwd goes stale
+        // across `cd X; claude` one-liners (no prompt render → no OSC 7), which
+        // wrongly downgraded a legitimate exact resume to `--continue`. The
+        // workspace's hook-reported agent cwd (metadata.cwd) is the second
+        // candidate — same rationale as buildPaneResumeCommand (ResumeInfoChip).
+        const paneCwdCandidates = [
+          pane.surfaces.find((s) => s.id === pane.activeSurfaceId)?.cwd,
+          workspace.metadata?.cwd,
+        ];
+        const cwdMatches = !!resumeBinding &&
+          paneCwdCandidates.some((c) => !!c && normCwd(resumeBinding.cwd) === normCwd(c));
         // The binding must be for THIS launcher's agent. The pill's slug
         // (resumeHint) and the binding are surfaced independently, and the daemon
         // only fills lastDetectedAgent when empty — so a stale hint for one agent
@@ -577,7 +586,10 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
         <ResumeInfoChip
           ptyId={activeSurfacePtyId}
           binding={resumeBinding}
-          paneCwd={pane.surfaces.find((s) => s.id === pane.activeSurfaceId)?.cwd}
+          paneCwds={[
+            pane.surfaces.find((s) => s.id === pane.activeSurfaceId)?.cwd,
+            workspace.metadata?.cwd,
+          ]}
         />
       )}
       <SurfaceTabs

--- a/src/renderer/components/Pane/ResumeInfoChip.tsx
+++ b/src/renderer/components/Pane/ResumeInfoChip.tsx
@@ -7,20 +7,32 @@ import {
 } from '../../../shared/agentResume';
 
 /**
- * Assemble the resume command for a pane from its binding + LIVE cwd. Mirrors
- * the reboot-recovery pill's gates (Pane.tsx) so the two never diverge:
+ * Assemble the resume command for a pane from its binding + LIVE cwd
+ * candidates. Mirrors the reboot-recovery pill's gates (Pane.tsx) so the two
+ * never diverge:
  *   - exact form (`--resume <id>` + the recorded permission flag) ONLY when the
- *     binding's origin cwd still matches the pane's live cwd (`--resume` is
- *     cwd-scoped); the permission flag rides the SAME line (both must land
- *     together);
+ *     binding's origin cwd still matches one of the pane's cwd candidates
+ *     (`--resume` is cwd-scoped); the permission flag rides the SAME line
+ *     (both must land together);
  *   - otherwise the cwd-relative fallback (Claude `--continue` / Codex
  *     `resume --last`), which carries no recorded mode.
+ *
+ * Why candidates, not a single cwd (2026-07-21, live-observed): surface.cwd is
+ * the SHELL's tracked cwd and goes stale across `cd X; claude` one-liners (no
+ * prompt render → no OSC 7) — the shell truly sat in the binding's cwd, yet the
+ * gate compared against the stale value and wrongly downgraded a legitimate
+ * exact resume to `--continue` (dropping the permission flag with it). The
+ * workspace's hook-reported agent cwd (metadata.cwd) is the second candidate.
+ * A false positive types a `--resume` that claude rejects visibly (nothing
+ * auto-runs — the user presses Enter); a false negative silently resumes the
+ * WRONG conversation. Loud beats silent.
+ *
  * Returns `null` for a non-resumable agent (no grammar). Pure + exported so the
  * exact-vs-fallback decision is unit-testable without rendering.
  */
 export function buildPaneResumeCommand(
   binding: ResumeBinding,
-  paneCwd: string | undefined,
+  paneCwds: ReadonlyArray<string | undefined>,
 ): { command: string; exact: boolean } | null {
   const grammar = resumeGrammarFor(binding.agent);
   if (!grammar) return null;
@@ -30,7 +42,8 @@ export function buildPaneResumeCommand(
     if (/^[A-Za-z]:\//.test(out)) out = out[0].toLowerCase() + out.slice(1);
     return out;
   };
-  const exact = !!(paneCwd && normCwd(binding.cwd) === normCwd(paneCwd));
+  const target = normCwd(binding.cwd);
+  const exact = paneCwds.some((c) => !!c && normCwd(c) === target);
   const permFlag = exact ? permissionFlagFor(binding.permissionMode) : '';
   const command = exact
     ? `${binding.agent}${permFlag ? ` ${permFlag}` : ''} ${grammar.withId(binding.sessionId)}`
@@ -53,15 +66,17 @@ export function buildPaneResumeCommand(
 export default function ResumeInfoChip(props: {
   ptyId: string;
   binding: ResumeBinding;
-  /** The pane's live surface cwd (OSC 7-updated) for the cwd-match re-guard. */
-  paneCwd: string | undefined;
+  /** Live cwd candidates for the cwd-match re-guard, in trust order:
+   *  surface.cwd (OSC 7-tracked shell cwd), then the workspace's hook-reported
+   *  agent cwd (metadata.cwd) — see buildPaneResumeCommand. */
+  paneCwds: ReadonlyArray<string | undefined>;
 }): React.ReactElement | null {
-  const { ptyId, binding, paneCwd } = props;
+  const { ptyId, binding, paneCwds } = props;
   const t = useT();
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
 
-  const built = buildPaneResumeCommand(binding, paneCwd);
+  const built = buildPaneResumeCommand(binding, paneCwds);
   if (!built) return null; // not a resumable agent — nothing to offer
   const { command } = built;
 

--- a/src/renderer/components/Pane/__tests__/ResumeInfoChip.test.ts
+++ b/src/renderer/components/Pane/__tests__/ResumeInfoChip.test.ts
@@ -19,7 +19,7 @@ describe('buildPaneResumeCommand', () => {
   it('cwd match + bypassPermissions → exact resume with the skip-permissions flag', () => {
     const out = buildPaneResumeCommand(
       claude({ permissionMode: 'bypassPermissions' }),
-      '/Users/me/proj',
+      ['/Users/me/proj'],
     );
     expect(out).toEqual({
       command: 'claude --dangerously-skip-permissions --resume a1b2c3d4-0000-0000-0000-9f8e7d6c5b4a',
@@ -28,7 +28,7 @@ describe('buildPaneResumeCommand', () => {
   });
 
   it('cwd match + default mode → exact resume, no permission flag', () => {
-    const out = buildPaneResumeCommand(claude(), '/Users/me/proj');
+    const out = buildPaneResumeCommand(claude(), ['/Users/me/proj']);
     expect(out).toEqual({
       command: 'claude --resume a1b2c3d4-0000-0000-0000-9f8e7d6c5b4a',
       exact: true,
@@ -38,34 +38,59 @@ describe('buildPaneResumeCommand', () => {
   it('cwd mismatch → cwd-relative fallback, never an exact resume against the wrong dir', () => {
     const out = buildPaneResumeCommand(
       claude({ permissionMode: 'bypassPermissions' }),
-      '/Users/me/OTHER',
+      ['/Users/me/OTHER'],
     );
     // Fallback carries NO recorded permission mode and no --resume <id>.
     expect(out).toEqual({ command: 'claude --continue', exact: false });
   });
 
   it('missing live cwd → fallback (cannot confirm the cwd-scoped resume)', () => {
-    const out = buildPaneResumeCommand(claude(), undefined);
+    const out = buildPaneResumeCommand(claude(), [undefined]);
     expect(out).toEqual({ command: 'claude --continue', exact: false });
   });
 
   it('codex uses the subcommand grammar', () => {
     const out = buildPaneResumeCommand(
       claude({ agent: 'codex', sessionId: 'sess-77' }),
-      '/Users/me/proj',
+      ['/Users/me/proj'],
     );
     expect(out).toEqual({ command: 'codex resume sess-77', exact: true });
   });
 
   it('trailing-slash / Windows drive-letter case differences still count as a match', () => {
-    expect(buildPaneResumeCommand(claude({ cwd: '/Users/me/proj/' }), '/Users/me/proj')?.exact).toBe(true);
+    expect(buildPaneResumeCommand(claude({ cwd: '/Users/me/proj/' }), ['/Users/me/proj'])?.exact).toBe(true);
     expect(
-      buildPaneResumeCommand(claude({ cwd: 'D:\\repo' }), 'd:/repo')?.exact,
+      buildPaneResumeCommand(claude({ cwd: 'D:\\repo' }), ['d:/repo'])?.exact,
     ).toBe(true);
   });
 
+  // Regression (2026-07-21, live-observed): surface.cwd stale at the shell's
+  // spawn dir (`cd X; claude` one-liner → no prompt render → no OSC 7) while
+  // the hook-reported workspace cwd (metadata.cwd) matched the binding — the
+  // gate wrongly downgraded to `--continue`, dropping the permission flag.
+  it('stale first candidate + matching second candidate (metadata.cwd) → exact resume', () => {
+    const out = buildPaneResumeCommand(
+      claude({ cwd: 'D:\\wmux', permissionMode: 'bypassPermissions' }),
+      ['C:\\Users\\me', 'D:\\wmux'],
+    );
+    expect(out).toEqual({
+      command: 'claude --dangerously-skip-permissions --resume a1b2c3d4-0000-0000-0000-9f8e7d6c5b4a',
+      exact: true,
+    });
+  });
+
+  it('no candidate matches → fallback', () => {
+    const out = buildPaneResumeCommand(claude(), ['C:\\Users\\me', 'D:\\other']);
+    expect(out).toEqual({ command: 'claude --continue', exact: false });
+  });
+
+  it('empty candidate list → fallback', () => {
+    const out = buildPaneResumeCommand(claude(), []);
+    expect(out).toEqual({ command: 'claude --continue', exact: false });
+  });
+
   it('non-resumable agent → null (no affordance)', () => {
-    expect(buildPaneResumeCommand(claude({ agent: 'gemini' }), '/Users/me/proj')).toBeNull();
+    expect(buildPaneResumeCommand(claude({ agent: 'gemini' }), ['/Users/me/proj'])).toBeNull();
   });
 });
 
@@ -85,7 +110,7 @@ describe('ResumeInfoChip render smoke', () => {
 
   it('mounts and renders the collapsed resume trigger without throwing', () => {
     const html = renderToStaticMarkup(
-      createElement(ResumeInfoChip, { ptyId: 'pty-1', binding, paneCwd: '/Users/me/proj' }),
+      createElement(ResumeInfoChip, { ptyId: 'pty-1', binding, paneCwds: ['/Users/me/proj'] }),
     );
     expect(html).toContain('Resume'); // trigger label (t('resume.label'))
     // Collapsed by default → the UUID is NOT in the initial markup.
@@ -95,7 +120,7 @@ describe('ResumeInfoChip render smoke', () => {
   it('renders nothing for a non-resumable agent', () => {
     const html = renderToStaticMarkup(
       createElement(ResumeInfoChip, {
-        ptyId: 'pty-1', binding: { ...binding, agent: 'gemini' }, paneCwd: '/Users/me/proj',
+        ptyId: 'pty-1', binding: { ...binding, agent: 'gemini' }, paneCwds: ['/Users/me/proj'],
       }),
     );
     expect(html).toBe('');

--- a/src/shared/__tests__/cwdShape.test.ts
+++ b/src/shared/__tests__/cwdShape.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { isPlausibleCwd } from '../cwdShape';
+
+// Regression (2026-07-21): a pane's cwd was stored as the literal string "path"
+// — a prompt-scrape false positive that the old win32 rule ("any non-empty
+// string passes") let through, breaking the Git tab's repo resolution. A real
+// cwd is always absolute (or ~-anchored); relative tokens are rejected on every
+// platform.
+describe('isPlausibleCwd — absolute-shape guard', () => {
+  it('rejects a bare relative token on every platform (the "path" incident)', () => {
+    for (const plat of ['win32', 'darwin', 'linux']) {
+      expect(isPlausibleCwd('path', plat)).toBe(false);
+      expect(isPlausibleCwd('some words', plat)).toBe(false);
+      expect(isPlausibleCwd('rel/child', plat)).toBe(false);
+    }
+  });
+
+  it('rejects the empty string', () => {
+    expect(isPlausibleCwd('', 'win32')).toBe(false);
+  });
+
+  it('accepts Windows drive and UNC shapes on win32', () => {
+    expect(isPlausibleCwd('C:\\Users\\me', 'win32')).toBe(true);
+    expect(isPlausibleCwd('D:/wmux', 'win32')).toBe(true);
+    expect(isPlausibleCwd('\\\\server\\share', 'win32')).toBe(true);
+  });
+
+  it('accepts POSIX-absolute paths on win32 (WSL panes)', () => {
+    expect(isPlausibleCwd('/home/me/project', 'win32')).toBe(true);
+  });
+
+  it('accepts ~-anchored paths (bash \\w renders $HOME as ~)', () => {
+    expect(isPlausibleCwd('~', 'linux')).toBe(true);
+    expect(isPlausibleCwd('~/work', 'darwin')).toBe(true);
+    expect(isPlausibleCwd('~/work', 'win32')).toBe(true);
+  });
+
+  it('still rejects Windows shapes on POSIX platforms (2026-07-20 incident)', () => {
+    expect(isPlausibleCwd('C:\\Users\\me', 'darwin')).toBe(false);
+    expect(isPlausibleCwd('\\\\server\\share', 'linux')).toBe(false);
+  });
+
+  it('accepts POSIX-absolute paths on POSIX platforms', () => {
+    expect(isPlausibleCwd('/home/me', 'linux')).toBe(true);
+    expect(isPlausibleCwd('/Users/me', 'darwin')).toBe(true);
+  });
+
+  it('rejects a ~-prefixed non-anchor token (e.g. "~foo" is a username ref, not a cwd we track)', () => {
+    expect(isPlausibleCwd('~foo/bar', 'linux')).toBe(false);
+  });
+});

--- a/src/shared/cwdShape.ts
+++ b/src/shared/cwdShape.ts
@@ -4,6 +4,13 @@
 // shown in terminal text for a real prompt and overwrote a macOS pane's cwd with
 // a Windows path. This filters out paths whose shape can't exist on the platform.
 // It does not check existence (fs) — this module is used in the renderer too.
+//
+// Tightened (2026-07-21): a real cwd is always absolute (or ~-anchored, the way
+// bash's \w renders $HOME). A bare relative token like "path" can only come from
+// scraping screen text that happened to match a prompt regex (observed live: a
+// pane's cwd stored as the literal string "path", which then broke the Git tab's
+// repo resolution). Reject anything that is not drive-absolute, UNC, POSIX-
+// absolute, or ~-anchored — on every platform.
 
 /** Whether the cwd shape can exist on the current platform. platform defaults to the runtime environment. */
 export function isPlausibleCwd(
@@ -12,6 +19,10 @@ export function isPlausibleCwd(
 ): boolean {
   if (!cwd) return false;
   const isWinShape = /^[A-Za-z]:[\\/]/.test(cwd) || cwd.startsWith('\\\\');
-  if (platform === 'win32') return true; // win32 also allows WSL POSIX paths — pass
+  // Absolute (or ~-anchored) shapes only — a relative token is never a real cwd.
+  const isPosixShape = cwd.startsWith('/') || cwd === '~' || cwd.startsWith('~/');
+  if (!isWinShape && !isPosixShape) return false;
+  // win32 also allows WSL POSIX paths — both shapes pass.
+  if (platform === 'win32') return true;
   return !isWinShape;
 }


### PR DESCRIPTION
## Summary

Three fixes around one root problem, all observed live while dogfooding 3.28.0: for an agent pane (Claude / Codex TUI), the shell's tracked working directory is not where the agent actually works.

**Git tab / Review roster** — repo resolution used only the pane's shell cwd, so an agent pane whose shell sat in the home dir showed "not a git repository" while the sidebar happily showed the branch. Both surfaces now try an ordered candidate list (plausible surface cwd → hook-reported workspace `metadata.cwd` → profile startupCwd → app startup dir) and adopt the first candidate that git-resolves. `metadata.cwd` is the same value the sidebar branch badge already trusts.

**cwd corruption guards** — a pane's cwd was seen stored as the literal token `path`: agent TUI output shaped like a shell prompt fooled the prompt-scrape detector. Two guards: once a session's shell emits OSC 7 (proving the integration hook runs), prompt scraping is permanently disabled for that session in both the daemon and local PTY bridges; and scraped values must be absolute (or `~`-anchored) on every platform — a bare relative token is never a real cwd.

**Resume chip exact-match gate** — `cd X; claude` one-liners render no prompt in between, so the surface cwd stays stale at the shell's spawn dir and the chip wrongly downgraded a legitimate exact resume (`--resume <id>` + recorded permission flag) to `--continue`. The gate now also accepts the hook-reported agent cwd. A false positive types a `--resume` that claude rejects visibly (nothing auto-runs); a false negative silently resumes the wrong conversation — loud beats silent.

Also restores the `## [3.28.0]` CHANGELOG header that an earlier edit accidentally deleted (its released entries had slid under `[Unreleased]`).

## Test plan

- [x] `tsc --noEmit` clean
- [x] All touched suites pass (36 tests across 5 files): `cwdShape.test.ts`, `DaemonPTYBridge.cwdDedup.test.ts`, `ReviewTab.dynamic.test.tsx`, `GitTab.metadataCwd.dynamic.test.tsx` (new jsdom regression: shell cwd outside the repo, metadata.cwd resolves), `ResumeInfoChip.test.ts` (new regression: stale first candidate + matching metadata.cwd → exact resume)
- [x] Full local suite: 6776 pass / 27 fail — every failure is in `src/main/` git-fixture/updater/pidMap suites untouched by this diff, and the same failures reproduce on a clean `main` checkout on this machine (live wmux daemon locks temp files — known local-only pattern). CI on a fresh runner is the arbiter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Git and Review tabs now find repositories using additional workspace directory information when the shell directory is stale or outside a repository.
  - Resume actions retain exact-session behavior and permission settings despite outdated shell paths.
  - Terminal directory tracking now prioritizes reliable shell-reported updates and ignores misleading prompt text.
  - Invalid relative directory values are rejected to prevent incorrect repository detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->