### PR TITLE
chore(release): 3.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.28.1] — 2026-07-21
+
 ### Fixed
 
 - **The Git tab (worktrees + review roster) now finds the repo an agent is working in, even when the shell it runs in sits elsewhere.** Repo context used to come only from the pane's shell working directory — but for an agent pane (Claude / Codex TUI) that is typically the directory the shell was *started* in (often the home dir), while the agent works in a repo somewhere else. Result: the sidebar showed the branch just fine, yet the Git tab said "not a git repository". Repo resolution now falls back to the hook-reported agent directory (the same value the sidebar branch badge already trusts) when the shell's own directory doesn't resolve to a repo.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.28.0 sources.** This file is produced by
+> **Generated from wmux v3.28.1 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.28.0",
+  "version": "3.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.28.0",
+      "version": "3.28.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.28.0",
+  "version": "3.28.1",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Release 3.28.1. Version bump + CHANGELOG promotion + regenerated API reference (the generated header bakes the version, which the drift guard enforces).

## What ships

**Orchestration — a pane that asks you something now says so** (#513)

A pane's turn-end reached the orchestrator as a bare "pane stopped". The only way to learn *why* it stopped was to read the rendered terminal, where a question the agent **printed** is indistinguishable from text pending in its **input box** — so orchestrators reported blocked panes as "still running" and pressed Enter to submit lines that were never there. Turn-ends now carry the agent's own closing words, a question-ending stop is stamped **BLOCKED ON A QUESTION**, `pane_list` exposes `pendingQuestion`, and `terminal_send_key` stops implying that delivering Enter submitted anything.

**Repo resolution — the Git tab follows the agent, not the shell** (#511)

Worktrees, review roster, cwd guards and the resume chip now resolve the repo the agent is actually working in.

**macOS — the `.dmg` is signed and notarized too** (#510)

The `.app` inside was always signed, notarized and stapled; the container was not. Any failure downgrades to a warning and ships the image unsigned rather than failing the build and taking the `.zip` with it.

**Docs** (#512) — README covers macOS install and the Gatekeeper first-open prompt.

## Verification

- [x] Full suite: 6816 passed, 8 skipped (519 files) + runtime suite 20 passed
- [x] `tsc --noEmit` clean
- [x] `gen-api-reference.mjs --check` clean (drift guard)
- [x] Release diff is exactly the four expected files, matching the 3.28.0 release commit shape

Tag `v3.28.1` goes up after this merges — that's what builds the installers. It is also the first real exercise of the DMG signing path from #510, which cannot be tested outside CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)