### PR TITLE
ci: publish artifacts even when a maker fails; raise the peer cap-loop timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,8 +310,20 @@ jobs:
         timeout-minutes: 60
 
       # Append the .zip/.dmg to the release the `build` job already created.
-      # continue-on-error: a macOS upload hiccup must not fail the whole release.
+      #
+      # `if: always()` is load-bearing, not defensive dressing. Forge builds the
+      # makers in order and `make` exits non-zero on the FIRST one that fails —
+      # so a flaky DMG step (v3.28.1 hit `hdiutil detach: No such file or
+      # directory`) skips this step entirely and the runner is discarded with a
+      # perfectly good .zip still on it. That zip backs the
+      # update.electronjs.org feed, so one maker hiccup silently took out both
+      # the download AND auto-update for macOS. The find below already handles
+      # "nothing was built", so running unconditionally costs nothing and
+      # salvages whatever did get made.
+      #
+      # continue-on-error: an upload hiccup must not fail the whole release.
       - name: Upload macOS artifacts to the release
+        if: always()
         continue-on-error: true
         shell: bash
         env:
@@ -373,7 +385,10 @@ jobs:
         run: npm run make
         timeout-minutes: 30
 
+      # Same reasoning as the macOS upload: deb/rpm/AppImage are made in
+      # sequence, so one failing maker must not discard the ones that succeeded.
       - name: Upload Linux artifacts to the release
+        if: always()
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A single failing installer step no longer discards the platform's whole release.** Forge builds makers in sequence and stops at the first failure, so when the macOS DMG step hit a transient `hdiutil detach` error during v3.28.1, the upload step never ran — and the runner was thrown away with a perfectly good `.zip` still on it. That zip is what backs the auto-update feed, so one flaky maker silently took out both the download **and** auto-update for macOS until the job was re-run. Both the macOS and Linux upload steps now run regardless of whether the build step failed, publishing whatever artifacts did get made.
+
 ## [3.28.1] — 2026-07-21
 
 ### Fixed

--- a/src/daemon/lanlink/__tests__/peers.test.ts
+++ b/src/daemon/lanlink/__tests__/peers.test.ts
@@ -99,6 +99,16 @@ describe('peers — per-peer store', () => {
     expect(store().get('u1')).toBeNull(); // HMAC failed -> fresh empty store
   });
 
+  // Both cap-loop tests below drive PEER_CAP (64) real pairings, and every
+  // upsertPaired persists the whole store: an atomic temp-write + rename with
+  // rotation, followed by an fsync. That is ~64 forced disk flushes per test —
+  // legitimately slow I/O, not a hang. They run in ~0.3-0.4s on a warm dev box
+  // but have timed out at vitest's 5s default on loaded CI runners (three times
+  // in one day, on Windows where AV scanning taxes every write). Raised here,
+  // per-test, rather than globally: the other nine tests in this file finish in
+  // under 30ms and should keep the strict default.
+  const CAP_LOOP_TIMEOUT_MS = 30_000;
+
   it('rejects a new pairing when the store is full and nothing is evictable (fail-closed)', () => {
     const live = new Set<string>();
     const s = new PeerStore(dir, { ...seam, isLive: (u) => live.has(u) });
@@ -107,7 +117,7 @@ describe('peers — per-peer store', () => {
       live.add('u' + i); // every paired peer holds a live connection
     }
     expect(() => s.upsertPaired(mkResult('uNEW'))).toThrow(/full/i);
-  });
+  }, CAP_LOOP_TIMEOUT_MS);
 
   it('LRU eviction at cap never drops a burned peer', () => {
     const s = store();
@@ -115,7 +125,7 @@ describe('peers — per-peer store', () => {
     for (let i = 0; i < PEER_BURN_THRESHOLD; i++) s.noteSteadyStateAuthFail('u0');
     for (let i = 1; i <= PEER_CAP + 5; i++) s.upsertPaired(mkResult('u' + i, (i % 250) + 1));
     expect(store().list().some((p) => p.peerUuid === 'u0')).toBe(true);
-  });
+  }, CAP_LOOP_TIMEOUT_MS);
 
   it('list() never leaks the long-term secret', () => {
     const s = store();


### PR DESCRIPTION
Two follow-ups from the v3.28.1 release, both of which cost real time today.

## 1. A failing maker discarded the platform's whole release

Forge builds makers in sequence and `make` exits non-zero at the **first** failure. During v3.28.1 the macOS DMG step hit a transient `hdiutil detach: No such file or directory`, so:

- `Build & Make` exited 1
- the **upload step never ran** — `continue-on-error: true` only applies to a step that actually runs
- the ephemeral runner was discarded with a `.zip` that had already been built **successfully** still on it

That zip backs the update.electronjs.org feed, so one flaky maker silently took out the macOS download *and* auto-update until the job was re-run by hand. The release sat with Windows and Linux assets only.

`if: always()` on both the macOS and Linux upload steps publishes whatever did get made. The existing `find` already no-ops when nothing was built, so running unconditionally costs nothing.

This exact hazard was raised in review of the DMG-signing PR (#513) and deferred as out of scope. It stopped being hypothetical a few hours later.

## 2. `peers.test.ts` cap-loop tests timed out three times in one day

Not flaky logic — legitimately slow I/O. Measured locally:

```
9 of 11 tests                        0-30ms
rejects a new pairing when full…    328ms
LRU eviction at cap…                421ms
                                   ──────
vitest default timeout              5000ms
```

The two slow ones are exactly the two that failed in CI. Each drives `PEER_CAP` (64) real pairings, and every `upsertPaired` persists the whole store: atomic temp-write + rename with rotation, then an fsync. That's ~64 forced disk flushes per test — fine on a warm dev box, not on a loaded runner where AV scanning taxes every write.

Raised to 30s **per-test**, not globally: the other nine finish under 30ms and should keep the strict default.

## Test plan

- [x] Full suite: 6816 passed, 8 skipped (519 files) + runtime suite 20 passed
- [x] `peers.test.ts` passes; no new eslint findings (the one warning at :42 is pre-existing)
- [x] `release.yml` parses as valid YAML; both upload steps confirmed to carry `if: always()` and keep `continue-on-error: true`
- [x] No version bump (repo policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release reliability on macOS and Linux. If one installer format fails, other successfully generated artifacts are still published.
  - Prevented valid macOS ZIP files and Linux packages from being discarded after an unrelated packaging error, helping keep auto-updates available.

- **Documentation**
  - Updated the changelog with details about the improved packaging and artifact publishing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->