### PR TITLE
chore(release): 3.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.29.0] — 2026-07-21
+
 ### Fixed
 
 - **Typing stays responsive — and Hangul/CJK composition no longer truncates — while an agent floods a visible pane.** A TUI redraw is a burst of tiny cursor-move writes, and handing each one to the terminal separately made the GPU re-rasterize the whole grid dozens of times a second; while a frame was held for paint, keystrokes and IME composition events queued behind it, so fast typing dropped characters and "했습니다" could land as "했". wmux now honors the terminal's own frame markers (DEC mode 2026 synchronized output, which Claude Code and Codex emit): it holds a frame's intermediate writes out of the renderer and releases them in one shot when the frame closes, so the GPU paints once per redraw instead of once per fragment. A frame that opened right after a keystroke is treated as latency-sensitive and released within a frame or two, so your own echo always paints ahead of an agent's autonomous output. Windows ConPTY only for now.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.28.1 sources.** This file is produced by
+> **Generated from wmux v3.29.0 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.28.1",
+  "version": "3.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.28.1",
+      "version": "3.29.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.28.1",
+  "version": "3.29.0",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Release v3.29.0.

Promotes the `[Unreleased]` GPU repaint-burst fixes (#525) to `[3.29.0]`, bumps `package.json` / `package-lock.json`, and regenerates `docs/api/reference.md` (the version header the CI drift guard checks).

Headline: DEC 2026 synchronized-output coalescing kills the Windows typing/IME/paste lag under agent output floods, and a bounded reveal catch-up removes the workspace-switch raster burst.

Tag `v3.29.0` is pushed after this merges — installer builds hang off the tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version 3.29.0 dated July 21, 2026.
  * Updated API reference metadata to reflect version 3.29.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->