### PR TITLE
chore(release): 3.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.30.0] — 2026-07-22
+
 ### Added
 
 - **A browser pane's CDP target is registered as soon as the guest attaches**, instead of only after the page finishes loading, so automation can reach a pane whose page is slow or unreachable. Two related fixes: an already-attached debugger no longer aborts registration outright (the guard never matched Electron's actual error text), which previously left a reloaded guest permanently unregistered. (#517)

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.29.0 sources.** This file is produced by
+> **Generated from wmux v3.30.0 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.29.0",
+  "version": "3.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.29.0",
+      "version": "3.30.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.29.0",
+  "version": "3.30.0",
   "description": "cmux for Windows — run multiple AI CLI agents (Claude Code, Codex, Gemini) side-by-side with an MCP bridge and browser automation",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Release 3.30.0.

Version bump, CHANGELOG promotion (Unreleased → 3.30.0), regenerated API reference.

Ships the built-in browser lightweight-mode work from #517: CPU throttling of invisible browser guests (#528) and opt-in memory relief that discards long-hidden panes (#530), plus the CDP-registration fixes found during dogfood.

Tag `v3.30.0` will be pushed after merge to trigger the installer builds.