### PR TITLE
Route a background-workspace browser.open into the freshly split pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A browser opened by an agent in a background workspace no longer clones its terminal and strands a stray empty pane.** When an agent working in a workspace you weren't looking at opened a browser (the create path — that workspace had no browser pane yet), the browser was attached to the agent's own terminal pane instead of the freshly split one, and the empty split pane was left behind to sprout a stray terminal the moment you focused that workspace. The cause: a background split intentionally leaves the workspace's active-pane selection untouched (so it can't hijack the pane you're focused on), but the browser-open code read that unchanged selection as if it were the new pane. It now uses the exact pane the split created, so the browser lands where it should and no empty pane is orphaned. (#531)
+
 ## [3.30.0] — 2026-07-22
 
 ### Added

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -917,25 +917,15 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     const direction =
       params.direction === 'vertical' ? 'vertical' : 'horizontal';
 
-    // Snapshot this workspace's empty leaves BEFORE the split so the freshly
-    // created (always-empty) leaf can be identified afterwards — without
-    // widening splitPane's boolean return, which would ripple to ~30 keybind /
-    // palette / test callsites.
-    const emptyBefore = new Set(
-      findLeafPanes(ws.rootPane).filter((l) => l.surfaces.length === 0).map((l) => l.id),
-    );
+    // splitPane returns the exact new leaf id, so there is no need to diff the
+    // empty-leaf set before/after (that heuristic could pick the wrong leaf if a
+    // reentrant subscriber emptied another pane during the split's set()).
+    const newPaneId = store.splitPane(ws.activePaneId, direction, ws.id);
+    if (!newPaneId) return { error: 'pane.split: pane cap reached (max 20 per workspace)' };
 
-    const ok = store.splitPane(ws.activePaneId, direction, ws.id);
-    if (!ok) return { error: 'pane.split: pane cap reached (max 20 per workspace)' };
-
-    // Locate the new leaf: the one empty leaf that was not empty-listed before.
     const afterSplit = useStore.getState();
     const splitWs = afterSplit.workspaces.find((w) => w.id === ws.id);
     if (!splitWs) return { ok: true }; // ws vanished in the async gap; split still happened
-    const newLeaf = findLeafPanes(splitWs.rootPane).find(
-      (l) => l.surfaces.length === 0 && !emptyBefore.has(l.id),
-    );
-    const newPaneId = newLeaf?.id;
 
     // Active-ws split: the AppLayout empty-leaf funnel owns PTY creation (it
     // carries the full startup-cwd / project-seed / X8-supervision chain), so
@@ -951,7 +941,6 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // surface-less — no terminal — until the user activates that workspace. An
     // external agent that splits-then-sends needs a live PTY immediately, so
     // spawn it here, mirroring surface.new's create + orphan-guard + adopt.
-    if (!newPaneId) return { ok: true }; // couldn't locate the new leaf; tree split still ok
 
     // Same cwd precedence the funnel applies (split-inherited > profile
     // startupCwd > global startupDirectory > main-side homedir). Consume the

--- a/src/renderer/stores/slices/__tests__/paneSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneSlice.test.ts
@@ -200,11 +200,16 @@ describe('PaneSlice', () => {
 
     it('splits the explicit background workspace while another ws stays active', () => {
       const { ws1, ws2 } = twoWorkspaces();
-      const ok = store.getState().splitPane(ws2.rootPane.id, 'horizontal', ws2.id);
-      expect(ok).toBe(true);
+      const newPaneId = store.getState().splitPane(ws2.rootPane.id, 'horizontal', ws2.id);
 
       const ws2After = store.getState().workspaces.find((w) => w.id === ws2.id)!;
       expect(ws2After.rootPane.type).toBe('branch'); // ws2 got the split
+      // The returned id is the exact new leaf — for a background split it is NOT
+      // the (unmoved) activePaneId, so the caller must use the return value.
+      const leaves = getLeafPanes(ws2After.rootPane);
+      expect(leaves).toHaveLength(2);
+      const newLeaf = leaves.find((l) => l.id !== ws2.rootPane.id)!;
+      expect(newPaneId).toBe(newLeaf.id);
       const ws1After = store.getState().workspaces.find((w) => w.id === ws1.id)!;
       expect(ws1After.rootPane.type).toBe('leaf');    // ws1 untouched
       expect(store.getState().activeWorkspaceId).toBe(ws1.id); // global focus didn't move
@@ -441,7 +446,9 @@ describe('PaneSlice', () => {
       for (let i = 0; i < MAX_PANES_PER_WORKSPACE - 1; i++) {
         const ws = getActiveWorkspace(store);
         const ok = store.getState().splitPane(ws.activePaneId, 'horizontal');
-        expect(ok).toBe(true);
+        // Active-ws split: the new leaf becomes the active pane, so the returned
+        // id equals the post-split activePaneId.
+        expect(ok).toBe(getActiveWorkspace(store).activePaneId);
       }
       const wsAfter = getActiveWorkspace(store);
       expect(getLeafPanes(wsAfter.rootPane)).toHaveLength(MAX_PANES_PER_WORKSPACE);

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -32,12 +32,14 @@ export const MAX_PANES_PER_WORKSPACE = 20;
 export interface PaneSlice {
   /**
    * Split a leaf pane into a new horizontal/vertical branch.
-   * Returns `true` on success, `false` if the workspace is at
-   * MAX_PANES_PER_WORKSPACE (callers chaining `addBrowserSurface`,
-   * RPC handlers, etc. must abort on `false` so they don't mutate
-   * the still-active original pane).
+   * Returns the new pane's id on success, or `false` if the workspace is
+   * at MAX_PANES_PER_WORKSPACE. Callers chaining `addBrowserSurface`, RPC
+   * handlers, etc. must abort on `false` so they don't mutate the
+   * still-active original pane; the returned id is the exact new leaf,
+   * which for a BACKGROUND-workspace split is NOT `activePaneId` (focus
+   * scoping #236 leaves the active selection untouched).
    */
-  splitPane: (paneId: string, direction: 'horizontal' | 'vertical', workspaceId?: string, position?: 'before' | 'after') => boolean;
+  splitPane: (paneId: string, direction: 'horizontal' | 'vertical', workspaceId?: string, position?: 'before' | 'after') => string | false;
   /** Close a leaf pane. `workspaceId` lets RPC/CLI callers target a
    * non-active workspace (defaults to the active one — existing callers are
    * unchanged). */
@@ -373,7 +375,7 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
   splitPane: (paneId, direction, workspaceId, position = 'after') => {
     let event: { wsId: string; newPaneId: string; branchId: string; previousActiveId: string; focusMoved: boolean } | null = null;
     let blockedAtCap = false;
-    let created = false;
+    let createdPaneId: string | false = false;
     set((state: StoreState) => {
       const targetWsId = workspaceId || state.activeWorkspaceId;
       const ws = state.workspaces.find((w: Workspace) => w.id === targetWsId);
@@ -389,7 +391,6 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
         blockedAtCap = true;
         return;
       }
-      created = true;
 
       // Issue #173: capture the splitting pane's live cwd (OSC 7-tracked on
       // its active surface) so the new pane's PTY can start there. Browser /
@@ -411,6 +412,7 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
         ws.nextPaneOrdinal ??
         (getLeafPanes(ws.rootPane).reduce((m, l) => Math.max(m, l.ordinal ?? 0), 0) + 1);
       const newPane = createLeafPane(undefined, paneOrdinal);
+      createdPaneId = newPane.id;
       ws.nextPaneOrdinal = paneOrdinal + 1;
       // `position` drives 4-way directional split from Ctrl+Shift+Arrow:
       // 'before' puts the new pane left/up of the target, 'after' (default)
@@ -487,7 +489,7 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
         level: 'warn',
       });
     }
-    return created;
+    return createdPaneId;
   },
 
   closePane: (paneId, workspaceId) => {

--- a/src/renderer/utils/__tests__/browserPane.test.ts
+++ b/src/renderer/utils/__tests__/browserPane.test.ts
@@ -4,7 +4,7 @@ import { immer } from 'zustand/middleware/immer';
 import { createPaneSlice, type PaneSlice, MAX_PANES_PER_WORKSPACE } from '../../stores/slices/paneSlice';
 import { createSurfaceSlice, type SurfaceSlice } from '../../stores/slices/surfaceSlice';
 import { createWorkspace, createLeafPane, type Workspace } from '../../../shared/types';
-import { getLeafPanes } from '../../../shared/paneUtils';
+import { getLeafPanes, findLeaf } from '../../../shared/paneUtils';
 import {
   isSafeBrowserUrl,
   isLocalhostUrl,
@@ -251,6 +251,93 @@ describe('openUrlInBrowserPaneImpl', () => {
 
       expect(result.ok).toBe(true);
       expect(firstBrowser(activeWs(store)).surface.browserUrl).toBe('http://127.0.0.1:5173/');
+    });
+  });
+
+  describe('background create path (#531)', () => {
+    // Build a second workspace B that holds a single terminal pane, leave the
+    // original workspace A active, and return the ids the assertions need.
+    function backgroundWsWithTerminal(cwd = 'D:\\proj') {
+      const other = createWorkspace('Background');
+      store.setState((state) => {
+        state.workspaces.push(other);
+      });
+      const terminalPaneId = other.rootPane.id;
+      store.getState().addSurface(terminalPaneId, 'pty-b', 'pwsh', cwd, other.id);
+      return { wsId: other.id, terminalPaneId };
+    }
+
+    it('routes the browser into the freshly split pane, not the agent terminal', () => {
+      const { deps } = makeDeps(store);
+      const activeBefore = store.getState().activeWorkspaceId;
+      const { wsId, terminalPaneId } = backgroundWsWithTerminal();
+
+      const result = openUrlInBrowserPaneImpl(
+        'http://localhost:5173',
+        { workspaceId: wsId, focusPane: false },
+        deps,
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.reused).toBe(false);
+
+      const state = store.getState();
+      const wsB = state.workspaces.find((w) => w.id === wsId)!;
+
+      // 1. No focus hijack — the user's active workspace is untouched.
+      expect(state.activeWorkspaceId).toBe(activeBefore);
+      // 2. B's own selection stays on the original terminal pane (focus scoping).
+      expect(wsB.activePaneId).toBe(terminalPaneId);
+      // 3. The browser landed on the returned NEW pane; the terminal pane keeps
+      //    exactly its one terminal surface (no 1:1 clone merge).
+      const newLeaf = findLeaf(wsB.rootPane, result.paneId)!;
+      expect(newLeaf.id).not.toBe(terminalPaneId);
+      expect(newLeaf.surfaces.map((s) => s.surfaceType)).toEqual(['browser']);
+      const terminalLeaf = findLeaf(wsB.rootPane, terminalPaneId)!;
+      expect(terminalLeaf.surfaces).toHaveLength(1);
+      expect(terminalLeaf.surfaces[0].surfaceType ?? 'terminal').toBe('terminal');
+      // 4. No stray empty leaf left for EmptyLeafFunnel to fill with a PTY.
+      const emptyLeaves = getLeafPanes(wsB.rootPane).filter((l) => l.surfaces.length === 0);
+      expect(emptyLeaves).toHaveLength(0);
+      // 5. The inherited-cwd seed for the browser pane is cleared (it never
+      //    reaches the terminal funnel, so it would otherwise leak).
+      expect(state.splitCwdSeed[result.paneId]).toBeUndefined();
+    });
+
+    it('clears the inherited-cwd seed even when the source terminal has a cwd', () => {
+      const { deps } = makeDeps(store);
+      const { wsId } = backgroundWsWithTerminal('D:\\src\\app');
+
+      const result = openUrlInBrowserPaneImpl(
+        'http://localhost:5173',
+        { workspaceId: wsId, focusPane: false },
+        deps,
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(store.getState().splitCwdSeed[result.paneId]).toBeUndefined();
+    });
+
+    it('active create still routes the browser into the new pane (no regression)', () => {
+      const { deps } = makeDeps(store);
+      // A single-workspace store: the active workspace holds one terminal pane.
+      const activeWsId = store.getState().activeWorkspaceId;
+      const terminalPaneId = activeWs(store).rootPane.id;
+      store.getState().addSurface(terminalPaneId, 'pty-a', 'pwsh', 'D:\\proj', activeWsId);
+
+      const result = openUrlInBrowserPaneImpl('http://localhost:5173', {}, deps);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const ws = activeWs(store);
+      const newLeaf = findLeaf(ws.rootPane, result.paneId)!;
+      expect(newLeaf.id).not.toBe(terminalPaneId);
+      expect(newLeaf.surfaces.map((s) => s.surfaceType)).toEqual(['browser']);
+      // Active split: the browser pane becomes the active selection.
+      expect(ws.activePaneId).toBe(result.paneId);
+      expect(store.getState().splitCwdSeed[result.paneId]).toBeUndefined();
     });
   });
 

--- a/src/renderer/utils/browserPane.ts
+++ b/src/renderer/utils/browserPane.ts
@@ -95,8 +95,9 @@ export interface BrowserPaneStoreApi {
   workspaces: BrowserPaneWorkspaceLike[];
   activeWorkspaceId: string;
   zoomedPaneId: string | null;
-  splitPane: (paneId: string, direction: 'horizontal' | 'vertical', workspaceId?: string) => boolean;
+  splitPane: (paneId: string, direction: 'horizontal' | 'vertical', workspaceId?: string) => string | false;
   addBrowserSurface: (paneId: string, url?: string, partition?: string, workspaceId?: string) => void;
+  clearSplitCwdSeed: (paneId: string) => void;
   updateBrowserUrl: (surfaceId: string, url: string) => void;
   updateBrowserPartition: (partition: string, surfaceId?: string) => void;
   setActiveSurface: (paneId: string, surfaceId: string, workspaceId?: string) => void;
@@ -224,15 +225,21 @@ export function openUrlInBrowserPaneImpl(
   // per-workspace leaf cap (and pushes its own toast) — bail so the browser
   // surface is not dropped onto the still-active original pane.
   const prevActivePaneId = ws.activePaneId;
-  if (!state.splitPane(prevActivePaneId, 'horizontal', targetWsId)) {
+  const newPaneId = state.splitPane(prevActivePaneId, 'horizontal', targetWsId);
+  // splitPane returns the exact new leaf id. Deriving it from the post-split
+  // `activePaneId` is wrong for a BACKGROUND workspace, where focus scoping
+  // (#236) leaves activePaneId on the original terminal pane — the browser
+  // would then merge into that terminal and strand the split leaf empty.
+  if (!newPaneId) {
     return { ok: false, error: 'pane-cap' };
   }
 
   const after = deps.getState();
-  const afterWs = after.workspaces.find((w) => w.id === targetWsId);
-  if (!afterWs) return { ok: false, error: 'workspace-not-found' };
-  const newPaneId = afterWs.activePaneId;
   after.addBrowserSurface(newPaneId, targetUrl, opts.partition, targetWsId);
+  // splitPane seeds an inherited cwd for the new pane (paneSlice #173) so a
+  // terminal funnel can start the shell there. A browser leaf never goes
+  // through that funnel, so the seed would leak — clear it.
+  after.clearSplitCwdSeed(newPaneId);
 
   if (!focusPane) {
     // Restore focus to the original pane (no-op when the target workspace is
@@ -242,10 +249,14 @@ export function openUrlInBrowserPaneImpl(
 
   const finalWs = deps.getState().workspaces.find((w) => w.id === targetWsId);
   const newLeaf = finalWs ? findLeafById(finalWs.rootPane, newPaneId) : null;
-  const surface = newLeaf?.surfaces[newLeaf.surfaces.length - 1];
+  // Invariant: the browser surface must have landed on the new leaf.
+  // addBrowserSurface silently no-ops on an unknown pane id, which would
+  // otherwise leak a bogus `{ ok: true, surfaceId: '' }`.
+  const surface = newLeaf?.surfaces.find((s) => s.surfaceType === 'browser');
+  if (!surface) return { ok: false, error: 'workspace-not-found' };
   return {
     ok: true,
-    surfaceId: surface?.id ?? '',
+    surfaceId: surface.id,
     paneId: newPaneId,
     url: targetUrl || DEFAULT_BROWSER_URL,
     reused: false,


### PR DESCRIPTION
When an agent in a background workspace opened a URL in the built-in browser, the workspace came out mangled: the browser surface merged into the agent's own terminal pane (rendering side by side with it, which reads as a "1:1 clone" of the terminal), and an extra empty terminal appeared next to it. Reproduced live exactly as reported.

## Root cause

The create path in `openUrlInBrowserPaneImpl` split the target workspace's active pane and then assumed `activePaneId` now pointed at the freshly created pane. That assumption only holds for the active workspace: `splitPane`'s focus scoping (#236) deliberately does not move `activePaneId` for a background workspace, so there the id still pointed at the original terminal pane. The browser surface landed on that terminal pane, and the actually-new pane was left empty — until the user focused the workspace and `EmptyLeafFunnel` did its job on the empty leaf, auto-creating the stray terminal.

Both reported symptoms come from that one mis-identification, which is why the bug needs a background workspace *and* the create path (no browser surface yet) to show — the reuse path was always fine.

## Fix

`splitPane` already knows the new pane's id, so it now returns it (`string | false` instead of `boolean`; `false` still means the pane cap blocked the split, so `if (!ok)` callers are unaffected). Both consumers use the returned id directly:

- the browser create path attaches the browser surface to exactly that pane — no fallback to `activePaneId`, and an invariant check verifies the surface actually landed (`addBrowserSurface` silently no-ops on an unknown pane id, which would otherwise leak `{ok: true, surfaceId: ''}`);
- the `pane.split` RPC handler drops its before/after empty-leaf-diff workaround, which existed only because the return value used to be a bare boolean.

One subtlety the fix itself introduced: `splitPane` seeds an inherited cwd for the new pane so a terminal funnel can start the shell there. A browser leaf never goes through that funnel, so the seed would leak — it is now cleared after the browser surface is attached.

## Testing

- New `browserPane` cases for the background create path, asserting the full contract: the global active workspace is untouched, the background workspace's active pane stays on its original terminal, the browser lands on the returned new pane, no empty leaves remain, and no stale cwd seed remains. Plus an active-workspace regression case and an inherited-cwd seed case.
- `paneSlice` split tests updated for the new return value (pane-cap still returns `false`).
- 512 tests green across the touched suites, `tsc --noEmit` clean.
- Live verification on an isolated instance, driving the exact reported sequence (agent-style `browser.open` at a background workspace, then switching to it): before the fix the workspace ends up as `[terminal + browser] [stray terminal]`; after, it is `[terminal] [browser]` with zero empty leaves.

Addresses the pane-routing bug reported in #531. Leaving that issue open — the reporter will confirm on a released build and close it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed browser panes opening in background workspaces and leaving behind empty or cloned terminal panes.
  * Browser panes now open in the newly created split pane without changing the active workspace or pane.
  * Improved handling when workspace pane limits prevent creating a new pane.
  * Ensured browser panes are attached correctly and inherited working-directory state is cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
