### PR TITLE
fix: tighten OpenClaude detection patterns to stop notification spam

### DIFF
--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -192,18 +192,23 @@ const AGENT_PATTERNS: AgentPattern[] = [
   // ── OpenClaude ───────────────────────────────────────────────────────────
   // Gate: OpenClaude startup banner — same fork-derived TUI as Claude Code
   // but prints "OpenClaude" or "Open Claude" in its banner.
+  // NOTE: OpenClaude's status bar prints "bypass permissions on" on every
+  // re-render, so we only match the literal prompt line ("> " at BOL) for
+  // the waiting state. The old /bypass permissions on/ pattern caused
+  // repeated "Ready for input" notifications.
   {
     agent: 'OpenClaude',
     slug: 'openclaude',
     gate: /Open\s*Claude|openclaude|╭.*OpenClaude/,
     patterns: [
-      { regex: /bypass permissions on/,          status: 'waiting',          message: 'Ready for input' },
-      { regex: /shift\+tab to cycle/,            status: 'waiting',          message: 'Ready for input' },
-      { regex: /^[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*Do you want to proceed\?[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/,                                                                                  status: 'awaiting_input',   message: 'Approval requested' },
+      // OpenClaude prompt indicator — the ">" prompt line at the bottom.
+      // Must match "> " at the START of a line (the actual prompt), not
+      // embedded text like ">> bypass permissions on".
+      { regex: /^>\s+$/,                                                                                    status: 'waiting',          message: 'Ready for input' },
+      { regex: /^[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*Do you want to proceed\?[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/,                                                              status: 'awaiting_input',   message: 'Approval requested' },
       { regex: /^[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*Allow tool use for (?:[A-Z][A-Za-z]+|mcp__[A-Za-z0-9-]+__[A-Za-z0-9_-]+)\??[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/, status: 'awaiting_input',   message: 'Tool approval requested' },
       { regex: /^[\s│║┃═━─╌╍┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*Do\s*you\s*want\s*to\s*(?:create|overwrite|make\s*this\s*edit\s*to)\s*\S[^?]*\?[\s│║┃═━─╌╍┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/, status: 'awaiting_input',   message: 'Edit approval requested' },
       { regex: /^[\s│║┃═━─╌╍┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*Do\s*you\s*want\s*to\s*(?:create|overwrite|make\s*this\s*edit\s*to)[\s│║┃═━─╌╍┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/,             status: 'awaiting_input',   message: 'Edit approval requested' },
-      { regex: />$/,                                                                                                                                                    status: 'waiting',          message: 'Ready for input' },
     ],
   },
 

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -192,19 +192,17 @@ const AGENT_PATTERNS: AgentPattern[] = [
   // ── OpenClaude ───────────────────────────────────────────────────────────
   // Gate: OpenClaude startup banner — same fork-derived TUI as Claude Code
   // but prints "OpenClaude" or "Open Claude" in its banner.
-  // NOTE: OpenClaude's status bar prints "bypass permissions on" on every
-  // re-render, so we only match the literal prompt line ("> " at BOL) for
-  // the waiting state. The old /bypass permissions on/ pattern caused
-  // repeated "Ready for input" notifications.
+  // NOTE: "bypass permissions on" is NOT used for waiting because OpenClaude
+  // re-renders its status bar every frame, flooding notifications. Instead
+  // "/shift\+tab to cycle/" (the keyboard hint shown only at the input
+  // prompt) is the stable idle indicator, matching the Claude Code approach.
   {
     agent: 'OpenClaude',
     slug: 'openclaude',
     gate: /Open\s*Claude|openclaude|╭.*OpenClaude/,
     patterns: [
-      // OpenClaude prompt indicator — the ">" prompt line at the bottom.
-      // Must match "> " at the START of a line (the actual prompt), not
-      // embedded text like ">> bypass permissions on".
-      { regex: /^>\s+$/,                                                                                    status: 'waiting',          message: 'Ready for input' },
+      // Waiting — OpenClaude's idle prompt indicator (keyboard hint).
+      { regex: /shift\+tab to cycle/,            status: 'waiting',          message: 'Ready for input' },
       { regex: /^[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*Do you want to proceed\?[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/,                                                              status: 'awaiting_input',   message: 'Approval requested' },
       { regex: /^[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*Allow tool use for (?:[A-Z][A-Za-z]+|mcp__[A-Za-z0-9-]+__[A-Za-z0-9_-]+)\??[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/, status: 'awaiting_input',   message: 'Tool approval requested' },
       { regex: /^[\s│║┃═━─╌╍┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*Do\s*you\s*want\s*to\s*(?:create|overwrite|make\s*this\s*edit\s*to)\s*\S[^?]*\?[\s│║┃═━─╌╍┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/, status: 'awaiting_input',   message: 'Edit approval requested' },

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -191,18 +191,22 @@ const AGENT_PATTERNS: AgentPattern[] = [
 
   // ── OpenClaude ───────────────────────────────────────────────────────────
   // Gate: OpenClaude startup banner — same fork-derived TUI as Claude Code
-  // but prints "OpenClaude" or "Open Claude" in its banner.
+  // but draws its own banner.
   // NOTE: "bypass permissions on" is NOT used for waiting because OpenClaude
-  // re-renders its status bar every frame, flooding notifications. Instead
-  // "/shift\+tab to cycle/" (the keyboard hint shown only at the input
-  // prompt) is the stable idle indicator, matching the Claude Code approach.
+  // re-renders its status bar every frame, flooding notifications (confirmed
+  // via debug capture 2026-07-22 — the line reaches the detector as a single
+  // concatenated token "…bypassPermissions modeisactive…" every ~16ms).
+  // "shift+tab to cycle" does NOT appear in OpenClaude's TUI at all (unlike
+  // Claude Code). The actual prompt after ANSI strip + trim is just ">" or
+  // "> ○" (with spinner), so we match those directly.
   {
     agent: 'OpenClaude',
     slug: 'openclaude',
     gate: /Open\s*Claude|openclaude|╭.*OpenClaude/,
     patterns: [
-      // Waiting — OpenClaude's idle prompt indicator (keyboard hint).
-      { regex: /shift\+tab to cycle/,            status: 'waiting',          message: 'Ready for input' },
+      // Waiting — the bare ">" prompt after trim, optionally followed by a
+      // spinner character (○) when the TUI is waiting for input.
+      { regex: /^>[\s○◌●]*$/,                                                                               status: 'waiting',          message: 'Ready for input' },
       { regex: /^[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*Do you want to proceed\?[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/,                                                              status: 'awaiting_input',   message: 'Approval requested' },
       { regex: /^[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*Allow tool use for (?:[A-Z][A-Za-z]+|mcp__[A-Za-z0-9-]+__[A-Za-z0-9_-]+)\??[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/, status: 'awaiting_input',   message: 'Tool approval requested' },
       { regex: /^[\s│║┃═━─╌╍┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*Do\s*you\s*want\s*to\s*(?:create|overwrite|make\s*this\s*edit\s*to)\s*\S[^?]*\?[\s│║┃═━─╌╍┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/, status: 'awaiting_input',   message: 'Edit approval requested' },


### PR DESCRIPTION
## Summary
- Remove `/bypass permissions on/` pattern that matches OpenClaude's status bar on every re-render, causing repeated "Ready for input" notifications
- Remove `/>$/` pattern that matches any line ending with `>`, replacing it with strict `/>\s+$/` that only matches the actual prompt line
- These patterns were flooding the notification center with duplicate OpenClaude notifications

## Test plan
- [x] Build succeeds
- [ ] Run OpenClaude in wmux pane — verify notifications only appear once when agent is actually waiting for input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenClaude prompt detection to prevent duplicate “Ready for input” notifications.
  * Refined OpenClaude “waiting” status recognition so idle notifications are emitted only from the intended prompt indicator.
  * Removed overly broad matching rules that could trigger incorrect idle states, while keeping the existing proceed/tool/edit approval detections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->