### PR TITLE
chore(release): 3.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.31.0] — 2026-07-22
+
 ### Added
 
 - **Per-account Claude usage in Claude Code's statusline (`wmux setup-statusline`).** The global StatusBar widget shows one account's 5h/7d usage, but panes in a single workspace can run different Claude accounts — each pane needs its *own* number. A new `wmux setup-statusline` command sets Claude Code's `statusLine` to a wmux script that renders `model · account · 5h N% · 7d N%` on the line under the input box; because the statusline process inherits `CLAUDE_CONFIG_DIR` from its own claude process, every pane shows the usage of the account it actually runs on — including accounts selected by hand with `$env:CLAUDE_CONFIG_DIR`. The numbers are zero-cost: Claude Code ≥2.1 pipes the session's live `rate_limits` (5h/7d used percentage) to the statusline on stdin, so there is no extra API traffic and no token spend — the script reads stdin plus wmux's `accounts.json` (for the account name) and nothing else. Installs into the default `~/.claude` profile and every registered claude account; a user's own custom statusLine is never overwritten. `--remove` / `--status` supported.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.30.0 sources.** This file is produced by
+> **Generated from wmux v3.31.0 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.30.0",
+  "version": "3.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.30.0",
+      "version": "3.31.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.30.0",
+  "version": "3.31.0",
   "description": "Workspace multiplexer for AI coding agents — run fleets of Claude Code, Codex & Gemini in parallel on Windows & macOS, with MCP browser automation built in",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Release 3.31.0 (minor — new features land this cycle).

Mechanical release commit only: version bump, CHANGELOG `[Unreleased]` → `[3.31.0]` promotion, regenerated `docs/api/reference.md`. No behavioral code changes.

### Highlights
- **Added** — per-account Claude usage in the statusline (`wmux setup-statusline`); both resume affordances gained a default-on `--dangerously-skip-permissions` toggle; OpenCode recognized as a first-party MCP host under enforce mode (#536); 30+ concurrent-session scale fixes; upgrade session-restore no longer strands blank/duplicate panes (#537); bounded browser screenshots on hidden panes (#529); Windows split-pane cwd tracking via OSC 7 (#540); background-workspace browser-open no longer strands empty panes (#531).
- **Changed** — statusline reset indicators readability + 7d remaining time.
- **Fixed** — Resume chip no longer appears mid-session; zsh OSC 7 percent-encoding parity (#541 follow-up).

See CHANGELOG for the full entries.

After merge: push the `v3.31.0` tag on main to trigger installer/Choco/winget builds.