### PR TITLE
feat: workspace mirror + resume chip edge-trigger + README install fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Install instructions now lead with the package manager.** The README's Windows install section puts `winget install openwong2kim.wmux` front and center with a clear note that it avoids the SmartScreen warning — the direct Setup.exe download is demoted to a secondary "offline install" path with an explicit note about why the warning appears (the installer isn't Authenticode-signed yet).
+
 ## [3.31.0] — 2026-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ Run **fleets of Claude Code, Codex & Gemini in parallel** — each agent in its 
 
 ## ⚡ Install in 30 seconds
 
-**Windows**
+**Windows** — use a package manager (avoids the SmartScreen warning):
 
 ```powershell
 winget install openwong2kim.wmux
 ```
 
-<sub>or `choco install wmux` &nbsp;·&nbsp; or [**download Setup.exe**](https://github.com/openwong2kim/wmux/releases/latest) &nbsp;·&nbsp; winget/choco avoid the SmartScreen prompt ([why?](#install-help))</sub>
+<sub>or `choco install wmux` &nbsp;·&nbsp; [**download Setup.exe**](https://github.com/openwong2kim/wmux/releases/latest) for offline install — a SmartScreen prompt appears because the installer isn't Authenticode-signed yet; winget/choco bypass it ([why?](#install-help))</sub>
 
 **macOS** (Apple Silicon)
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -51,6 +51,7 @@ import { registerChannelLocalHandlers } from './ipc/handlers/channelLocal.handle
 import { registerFanOutHandler } from './ipc/handlers/fanout.handler';
 import { registerWorktaskHandlers } from './ipc/handlers/worktask.handler';
 import { registerDeckHandler } from './ipc/handlers/deck.handler';
+import { registerWorkspaceMirrorHandler } from './ipc/handlers/workspaceMirror.handler';
 import { registerUiPluginRpc } from './pipe/handlers/uiPlugin.rpc';
 import { registerMcpPluginRpc } from './pipe/handlers/mcp.rpc';
 import { getPluginTrustStore } from './mcp/PluginTrustStore';
@@ -601,6 +602,11 @@ registerWorktaskHandlers(() => daemonClient);
 // Agent-SDK orchestrator session runs in MAIN and drives the fleet via the wmux
 // MCP bundle. Lazily spawned on the first deck:send; disposed on before-quit.
 const disposeDeckHandler = registerDeckHandler(() => mainWindow);
+// WorkspaceMirror — renderer push (fire-and-forget) keeps a main-process cache
+// of the workspace tree + per-pane agent status warm, so routing / hook
+// resolution is served locally instead of via the workspace.list renderer
+// round-trip (which a large-buffer flush storm starves). Snapshot-only.
+const disposeWorkspaceMirrorHandler = registerWorkspaceMirrorHandler();
 // Returns an unsubscribe for the signal-health push subscription. Called from
 // before-quit so HMR reload / shutdown does not leak the listener.
 // ─── M2 — per-account usage service (hook-gated, opt-in) ─────────────────────
@@ -1518,6 +1524,7 @@ app.on('before-quit', async (e) => {
   safeStep('cleanupHandlers', () => cleanupHandlers());
   safeStep('disposeFirstRunHandlers', () => disposeFirstRunHandlers());
   safeStep('disposeDeckHandler', () => disposeDeckHandler());
+  safeStep('disposeWorkspaceMirrorHandler', () => disposeWorkspaceMirrorHandler());
   safeStep('disposeHooksRpc', () => disposeHooksRpc());
   safeStep('disposeUsagePollerListener', () => disposeUsagePollerListener());
   safeStep('usagePoller.dispose', () => usagePoller.dispose());

--- a/src/main/ipc/handlers/__tests__/workspaceMirror.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/workspaceMirror.handler.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { parseWorkspaceMirrorPayload } from '../workspaceMirror.handler';
+
+describe('parseWorkspaceMirrorPayload — defensive renderer-trust validation', () => {
+  it('accepts a well-formed payload and normalizes metadata nulls', () => {
+    const parsed = parseWorkspaceMirrorPayload({
+      ts: 42,
+      entries: [
+        {
+          id: 'ws-1',
+          name: 'alpha',
+          metadata: { cwd: 'C:/repo/a', gitBranch: 'main' },
+          activePtyId: 'pty-1',
+          ptyIds: ['pty-1', 'pty-2'],
+        },
+      ],
+      fleets: [
+        {
+          workspaceId: 'ws-1',
+          ts: 42,
+          panes: [{ ptyId: 'pty-1', agentName: 'Claude', agentStatus: 'running', isActivePane: true }],
+        },
+      ],
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed?.entries[0].metadata).toMatchObject({
+      cwd: 'C:/repo/a',
+      gitBranch: 'main',
+      agentName: null, // absent → normalized to null
+      progress: null,
+    });
+    expect(parsed?.entries[0].ptyIds).toEqual(['pty-1', 'pty-2']);
+    expect(parsed?.fleets[0].panes[0].agentStatus).toBe('running');
+  });
+
+  it('drops a non-object / missing-arrays payload entirely (keep last-good)', () => {
+    expect(parseWorkspaceMirrorPayload(null)).toBeNull();
+    expect(parseWorkspaceMirrorPayload('nope')).toBeNull();
+    expect(parseWorkspaceMirrorPayload({ ts: 1 })).toBeNull(); // no entries/fleets arrays
+    expect(parseWorkspaceMirrorPayload({ entries: [], fleets: {} })).toBeNull();
+  });
+
+  it('filters malformed entries but keeps the good ones', () => {
+    const parsed = parseWorkspaceMirrorPayload({
+      ts: 1,
+      entries: [
+        { id: 'ws-good', name: 'ok' },
+        { id: 'bad id with spaces', name: 'x' }, // id fails WORKSPACE_ID_RE
+        { name: 'no-id' },
+        { id: 'ws-2', name: 42 }, // non-string name
+      ],
+      fleets: [],
+    });
+    expect(parsed?.entries.map((e) => e.id)).toEqual(['ws-good']);
+  });
+
+  it('rejects an unknown agentStatus and non-string ptyIds inside a fleet', () => {
+    const parsed = parseWorkspaceMirrorPayload({
+      ts: 1,
+      entries: [{ id: 'ws-1', name: 'a' }],
+      fleets: [
+        {
+          workspaceId: 'ws-1',
+          ts: 1,
+          panes: [
+            { ptyId: 'pty-1', agentName: null, agentStatus: 'bogus', isActivePane: true }, // bad status
+            { ptyId: 'pty-2', agentName: null, agentStatus: 'idle', isActivePane: false }, // ok
+            { ptyId: '', agentName: null, agentStatus: 'complete', isActivePane: false }, // empty ptyId allowed
+          ],
+        },
+      ],
+    });
+    const panes = parsed?.fleets[0].panes ?? [];
+    expect(panes.map((p) => p.ptyId)).toEqual(['pty-2', '']);
+  });
+
+  it('coerces isActivePane to a strict boolean and defaults absent cwd', () => {
+    const parsed = parseWorkspaceMirrorPayload({
+      ts: 1,
+      entries: [{ id: 'ws-1', name: 'a' }],
+      fleets: [
+        {
+          workspaceId: 'ws-1',
+          ts: 1,
+          panes: [{ ptyId: 'pty-1', agentName: 'A', agentStatus: 'waiting', isActivePane: 'yes' }],
+        },
+      ],
+    });
+    const pane = parsed?.fleets[0].panes[0];
+    expect(pane?.isActivePane).toBe(false); // only strict true counts
+    expect(pane?.cwd).toBeUndefined();
+  });
+});

--- a/src/main/ipc/handlers/workspaceMirror.handler.ts
+++ b/src/main/ipc/handlers/workspaceMirror.handler.ts
@@ -1,0 +1,154 @@
+// WORKSPACE_MIRROR_PUSH handler — the renderer fire-and-forget push that keeps
+// the main-process WorkspaceMirror warm (see WorkspaceMirror.ts). Registered
+// with `ipcMain.on` (not `handle`) because it is one-way: the renderer never
+// awaits a reply, it just streams the latest full snapshot on structural / status
+// change.
+//
+// Trust basis: the renderer is a first-party surface (same process boundary as
+// deck/fanout handlers), so the payload is renderer-trusted. We still
+// format-check it defensively — a stale preload, a partial test mock, or a
+// renderer mid-teardown could send something malformed, and a bad snapshot must
+// be DROPPED (leaving the last-good one in place), never stored or thrown.
+
+import { ipcMain } from 'electron';
+import { IPC } from '../../../shared/constants';
+import { getWorkspaceMirror } from '../../workspace/WorkspaceMirror';
+import type {
+  WorkspaceListEntry,
+  FleetSnapshot,
+  FleetSnapshotPane,
+  WorkspaceMirrorPushPayload,
+} from '../../../shared/workspaceMirror';
+import type { AgentStatus } from '../../../shared/types';
+
+// Ids key maps / route hooks — reject anything that isn't a plausible id token
+// (mirrors deck.handler.ts WORKSPACE_ID_RE). Applied to workspace ids and, more
+// loosely, to pty ids below.
+const WORKSPACE_ID_RE = /^[A-Za-z0-9._-]{1,80}$/;
+// PTY ids are daemon session ids — a superset alphabet, but still bounded and
+// character-restricted so a malformed id can never become a routing key.
+const PTY_ID_RE = /^[A-Za-z0-9._:@/-]{1,120}$/;
+
+// The renderer fleet selector's status union — accept only these so a bad status
+// string can't leak into a routing consumer. Kept in sync with AgentStatus.
+const VALID_AGENT_STATUS: ReadonlySet<string> = new Set<AgentStatus>([
+  'running',
+  'complete',
+  'error',
+  'idle',
+  'waiting',
+  'awaiting_input',
+]);
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** Validate + normalize one workspace entry. Returns null to drop a bad entry. */
+function parseEntry(raw: unknown): WorkspaceListEntry | null {
+  if (!isRecord(raw)) return null;
+  const id = raw.id;
+  const name = raw.name;
+  if (typeof id !== 'string' || !WORKSPACE_ID_RE.test(id)) return null;
+  if (typeof name !== 'string') return null;
+
+  const entry: WorkspaceListEntry = { id, name };
+
+  if (isRecord(raw.metadata)) {
+    const m = raw.metadata;
+    entry.metadata = {
+      cwd: typeof m.cwd === 'string' ? m.cwd : null,
+      gitBranch: typeof m.gitBranch === 'string' ? m.gitBranch : null,
+      agentName: typeof m.agentName === 'string' ? m.agentName : null,
+      agentStatus: typeof m.agentStatus === 'string' ? m.agentStatus : null,
+      status: typeof m.status === 'string' ? m.status : null,
+      progress: typeof m.progress === 'number' ? m.progress : null,
+    };
+  }
+
+  if (typeof raw.activePtyId === 'string' && PTY_ID_RE.test(raw.activePtyId)) {
+    entry.activePtyId = raw.activePtyId;
+  } else {
+    entry.activePtyId = null;
+  }
+
+  if (Array.isArray(raw.ptyIds)) {
+    entry.ptyIds = raw.ptyIds.filter(
+      (p): p is string => typeof p === 'string' && PTY_ID_RE.test(p),
+    );
+  }
+
+  return entry;
+}
+
+/** Validate + normalize one fleet-snapshot pane. Returns null to drop it. */
+function parsePane(raw: unknown): FleetSnapshotPane | null {
+  if (!isRecord(raw)) return null;
+  // An unspawned surface reports ptyId '' — allowed (empty string is a valid,
+  // if unroutable, pane), so only reject a non-string.
+  const ptyId = raw.ptyId;
+  if (typeof ptyId !== 'string') return null;
+  if (ptyId !== '' && !PTY_ID_RE.test(ptyId)) return null;
+  const agentStatus = raw.agentStatus;
+  if (typeof agentStatus !== 'string' || !VALID_AGENT_STATUS.has(agentStatus)) return null;
+
+  const pane: FleetSnapshotPane = {
+    ptyId,
+    agentName: typeof raw.agentName === 'string' ? raw.agentName : null,
+    agentStatus: agentStatus as AgentStatus,
+    isActivePane: raw.isActivePane === true,
+  };
+  if (typeof raw.cwd === 'string') pane.cwd = raw.cwd;
+  return pane;
+}
+
+/** Validate one per-workspace fleet snapshot. Returns null to drop it. */
+function parseFleet(raw: unknown): FleetSnapshot | null {
+  if (!isRecord(raw)) return null;
+  const workspaceId = raw.workspaceId;
+  if (typeof workspaceId !== 'string' || !WORKSPACE_ID_RE.test(workspaceId)) return null;
+  const ts = typeof raw.ts === 'number' ? raw.ts : 0;
+  const panesRaw = Array.isArray(raw.panes) ? raw.panes : [];
+  const panes = panesRaw
+    .map(parsePane)
+    .filter((p): p is FleetSnapshotPane => p !== null);
+  return { workspaceId, ts, panes };
+}
+
+/**
+ * Parse the full push payload. Returns null when it is unusable (not an object /
+ * missing entries array) so the caller drops it and keeps the last-good
+ * snapshot. Individual malformed entries/panes are filtered, not fatal.
+ */
+export function parseWorkspaceMirrorPayload(raw: unknown): WorkspaceMirrorPushPayload | null {
+  if (!isRecord(raw)) return null;
+  if (!Array.isArray(raw.entries) || !Array.isArray(raw.fleets)) return null;
+  const entries = raw.entries
+    .map(parseEntry)
+    .filter((e): e is WorkspaceListEntry => e !== null);
+  const fleets = raw.fleets
+    .map(parseFleet)
+    .filter((f): f is FleetSnapshot => f !== null);
+  const ts = typeof raw.ts === 'number' ? raw.ts : 0;
+  return { ts, entries, fleets };
+}
+
+/**
+ * Register the fire-and-forget WORKSPACE_MIRROR_PUSH listener. Idempotent
+ * (removeAllListeners first) so an HMR reload / re-registration never
+ * double-stores. Returns a disposer for symmetric teardown.
+ */
+export function registerWorkspaceMirrorHandler(): () => void {
+  const onPush = (_event: Electron.IpcMainEvent, raw: unknown): void => {
+    const payload = parseWorkspaceMirrorPayload(raw);
+    // Drop a structurally-unusable push — never overwrite last-good with junk.
+    if (!payload) return;
+    getWorkspaceMirror().setSnapshot(payload);
+  };
+  ipcMain.removeAllListeners(IPC.WORKSPACE_MIRROR_PUSH);
+  ipcMain.on(IPC.WORKSPACE_MIRROR_PUSH, onPush);
+
+  return () => {
+    ipcMain.removeAllListeners(IPC.WORKSPACE_MIRROR_PUSH);
+  };
+}

--- a/src/main/notification/DaemonNotificationRouter.ts
+++ b/src/main/notification/DaemonNotificationRouter.ts
@@ -7,7 +7,8 @@ import { dispatchNotification } from './dispatchNotification';
 import { recentlySuppressed, clearPty as clearSuppression } from './idleSuppression';
 import { broadcastMetadataUpdate } from '../ipc/handlers/metadata.handler';
 import { eventBus } from '../events/EventBus';
-import { findWorkspaceIdForPty } from '../pipe/handlers/hooks.rpc';
+import { findWorkspaceIdForPty, STALE_TRUST_MS } from '../pipe/handlers/hooks.rpc';
+import { getWorkspaceMirror, type WorkspaceMirror } from '../workspace/WorkspaceMirror';
 import { sendToRenderer } from '../pipe/handlers/_bridge';
 import { agentDisplayToSlug } from '../pty/AgentDetector';
 import type { ChannelMessage } from '../../shared/channels';
@@ -99,6 +100,10 @@ export class DaemonNotificationRouter {
     // Optional clock override. Used by tests so cache-TTL behavior can be
     // exercised deterministically without faking globals.
     private now: () => number = Date.now,
+    // Main-side WorkspaceMirror (renderer-pushed workspace tree). Consulted
+    // before the cached round-trip so a resolvable ptyId never touches the
+    // renderer. Injected (default the singleton) for testability.
+    private getMirror: () => Pick<WorkspaceMirror, 'peek'> = getWorkspaceMirror,
   ) {}
 
   /**
@@ -116,6 +121,18 @@ export class DaemonNotificationRouter {
    * mutations don't have to wait out the full TTL.
    */
   private async resolveWorkspaceIdForPty(ptyId: string): Promise<string | null> {
+    // Mirror first: the renderer pushes its full workspace tree to main on every
+    // structural/status change, so a ptyId that still belongs to an open pane
+    // resolves here with no renderer round-trip. A ptyId→workspace mapping is
+    // topology-stable (independent of which surface is focused), so a mirror
+    // that is merely fresh (< STALE_TRUST_MS) is authoritative for it. A miss
+    // (empty/stale mirror, or a ptyId absent from the snapshot — e.g. a pane
+    // that just closed) falls through to the cached round-trip below.
+    const mirrored = this.getMirror().peek();
+    if (mirrored && mirrored.ageMs < STALE_TRUST_MS) {
+      const workspaceId = findWorkspaceIdForPty(ptyId, mirrored.entries);
+      if (workspaceId) return workspaceId;
+    }
     const cached = this.workspaceCache;
     if (cached && this.now() - cached.ts < WORKSPACE_LIST_CACHE_TTL_MS) {
       return findWorkspaceIdForPty(ptyId, cached.value);

--- a/src/main/notification/__tests__/DaemonNotificationRouter.mirror.test.ts
+++ b/src/main/notification/__tests__/DaemonNotificationRouter.mirror.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { DaemonClient } from '../../DaemonClient';
+import { eventBus } from '../../events/EventBus';
+
+// WP2: resolveWorkspaceIdForPty consults the main-side WorkspaceMirror before
+// its cached `workspace.list` round-trip. A ptyId that still belongs to an open
+// pane resolves off the mirror with no renderer IPC; a mirror miss (empty/stale,
+// or a ptyId absent from the snapshot) falls back to the cached round-trip.
+vi.mock('../../pipe/handlers/_bridge', () => ({ sendToRenderer: vi.fn() }));
+
+import { sendToRenderer } from '../../pipe/handlers/_bridge';
+import { DaemonNotificationRouter } from '../DaemonNotificationRouter';
+import { WorkspaceMirror } from '../../workspace/WorkspaceMirror';
+import { STALE_TRUST_MS } from '../../pipe/handlers/hooks.rpc';
+import type { WorkspaceMirrorPushPayload } from '../../../shared/workspaceMirror';
+
+const sendToRendererMock = vi.mocked(sendToRenderer);
+
+const FIXTURE_WORKSPACE_LIST = [
+  { id: 'ws-1', name: 'Workspace 1', activePtyId: 'pty-a', ptyIds: ['pty-a', 'pty-b'] },
+  { id: 'ws-2', name: 'Workspace 2', activePtyId: 'pty-c', ptyIds: ['pty-c'] },
+];
+
+function pushPayload(): WorkspaceMirrorPushPayload {
+  return {
+    ts: 0,
+    entries: [
+      { id: 'ws-1', name: 'Workspace 1', metadata: { cwd: '/a' }, activePtyId: 'pty-a', ptyIds: ['pty-a', 'pty-b'] },
+      { id: 'ws-2', name: 'Workspace 2', metadata: { cwd: '/b' }, activePtyId: 'pty-c', ptyIds: ['pty-c'] },
+    ],
+    fleets: [],
+  };
+}
+
+function makeRouter(now: () => number, mirror: WorkspaceMirror) {
+  const fakeDaemon = { on: vi.fn(), off: vi.fn() } as unknown as DaemonClient;
+  const router = new DaemonNotificationRouter(fakeDaemon, () => null, undefined, now, () => mirror);
+  return { router };
+}
+
+function resolve(router: DaemonNotificationRouter, ptyId: string): Promise<string | null> {
+  return (router as unknown as {
+    resolveWorkspaceIdForPty(ptyId: string): Promise<string | null>;
+  }).resolveWorkspaceIdForPty(ptyId);
+}
+
+describe('DaemonNotificationRouter — WorkspaceMirror fast path', () => {
+  beforeEach(() => {
+    sendToRendererMock.mockReset();
+    sendToRendererMock.mockResolvedValue(FIXTURE_WORKSPACE_LIST);
+    eventBus.reset();
+  });
+
+  afterEach(() => {
+    eventBus.reset();
+  });
+
+  it('mirror hit resolves the ptyId with NO renderer round-trip', async () => {
+    let t = 1_000_000;
+    const mirror = new WorkspaceMirror(() => t);
+    mirror.setSnapshot(pushPayload()); // fresh
+    const { router } = makeRouter(() => t, mirror);
+
+    expect(await resolve(router, 'pty-a')).toBe('ws-1');
+    expect(await resolve(router, 'pty-c')).toBe('ws-2');
+    expect(sendToRendererMock).not.toHaveBeenCalled(); // served off the mirror
+  });
+
+  it('mirror miss (ptyId absent from snapshot) falls back to the cached round-trip', async () => {
+    let t = 1_000_000;
+    const mirror = new WorkspaceMirror(() => t);
+    mirror.setSnapshot(pushPayload());
+    const { router } = makeRouter(() => t, mirror);
+
+    // 'pty-a' is in the mirror; 'pty-z' is not — only the miss hits the renderer.
+    expect(await resolve(router, 'pty-a')).toBe('ws-1');
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+
+    expect(await resolve(router, 'pty-z')).toBeNull(); // not in FIXTURE either
+    expect(sendToRendererMock).toHaveBeenCalledTimes(1); // fell through to pull
+  });
+
+  it('empty mirror (never populated) uses the cached round-trip', async () => {
+    let t = 1_000_000;
+    const mirror = new WorkspaceMirror(() => t); // never setSnapshot
+    const { router } = makeRouter(() => t, mirror);
+
+    expect(await resolve(router, 'pty-a')).toBe('ws-1');
+    expect(sendToRendererMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('stale mirror (older than STALE_TRUST_MS) falls back to the cached round-trip', async () => {
+    let t = 1_000_000;
+    const mirror = new WorkspaceMirror(() => t);
+    mirror.setSnapshot(pushPayload()); // stamped at t
+    t += STALE_TRUST_MS + 1; // now stale
+    const { router } = makeRouter(() => t, mirror);
+
+    expect(await resolve(router, 'pty-a')).toBe('ws-1');
+    expect(sendToRendererMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('mirror hit does not populate/consume the pull cache — invalidate stays a pull-path concern', async () => {
+    let t = 1_000_000;
+    const mirror = new WorkspaceMirror(() => t);
+    mirror.setSnapshot(pushPayload());
+    const { router } = makeRouter(() => t, mirror);
+
+    await resolve(router, 'pty-a'); // mirror hit, no fetch
+    router.invalidateWorkspaceCache(); // no-op for the pull cache (still empty)
+    await resolve(router, 'pty-c'); // mirror hit again
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/pipe/handlers/__tests__/hooks.rpc.mirror.test.ts
+++ b/src/main/pipe/handlers/__tests__/hooks.rpc.mirror.test.ts
@@ -1,0 +1,220 @@
+// WorkspaceMirror fast path for hooks.signal (WP2). The renderer pushes its
+// full workspace tree to main on every structural/status change; the hook
+// resolver consults that mirror FIRST, so a resolvable signal never touches the
+// renderer `workspace.list` round-trip that a large-buffer flush storm starves.
+//
+// Two layers of coverage:
+//   1. resolveWorkspacesForSignal (pure) — fresh mirror hits, stale/empty
+//      fall-through to the pull cache.
+//   2. registerHooksRpc (integration) — a fresh mirror routes a workspaceId-only
+//      signal AND a cold-pull-cache signal with ZERO sendToRenderer calls.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserWindow } from 'electron';
+import type { AgentSignal } from '../../../../../integrations/shared/signal-types';
+import type { WorkspaceListEntry } from '../../../../shared/workspaceMirror';
+
+const { sendToRendererMock, sendNotificationMock, broadcastMetadataUpdateMock } = vi.hoisted(() => ({
+  sendToRendererMock: vi.fn(),
+  sendNotificationMock: vi.fn(),
+  broadcastMetadataUpdateMock: vi.fn(),
+}));
+
+vi.mock('../_bridge', () => ({ sendToRenderer: sendToRendererMock }));
+vi.mock('../../../notification/sendNotification', () => ({ sendNotification: sendNotificationMock }));
+vi.mock('../../../ipc/handlers/metadata.handler', () => ({ broadcastMetadataUpdate: broadcastMetadataUpdateMock }));
+vi.mock('../../../notification/rendererNotificationReadiness', () => ({
+  isRendererNotificationListenerReady: () => true,
+}));
+
+import { RpcRouter } from '../../RpcRouter';
+import { eventBus } from '../../../events/EventBus';
+import type { HookSignalRouter } from '../../../hooks/HookSignalRouter';
+import {
+  registerHooksRpc,
+  resolveWorkspacesForSignal,
+  STALE_TRUST_MS,
+} from '../hooks.rpc';
+
+function signal(overrides: Partial<AgentSignal>): AgentSignal {
+  return {
+    kind: 'agent.stop',
+    agent: 'claude',
+    cwd: '/repo',
+    payload: {},
+    ts: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+const mirrorEntries = (): WorkspaceListEntry[] => [
+  { id: 'ws-1', name: 'one', metadata: { cwd: '/repo' }, activePtyId: 'pty-1', ptyIds: ['pty-1'] },
+];
+
+// A mirror double: peek() returns a fixed snapshot (or null). Spy so we can
+// assert the resolver read it.
+function fakeMirror(peek: { entries: WorkspaceListEntry[]; ageMs: number } | null) {
+  return { peek: vi.fn(() => peek) };
+}
+
+// A pull-cache double. get() is the round-trip; peek()/prime() are the env
+// fast path. Spies reveal which tier the resolver used.
+function fakeCache(opts: { peek?: { list: WorkspaceListEntry[]; ageMs: number } | null; get?: WorkspaceListEntry[] | null }) {
+  return {
+    get: vi.fn(async () => opts.get ?? null),
+    peek: vi.fn(() => opts.peek ?? null),
+    prime: vi.fn(() => { /* spy only */ }),
+  };
+}
+
+describe('resolveWorkspacesForSignal — mirror fast path (WP2)', () => {
+  it('fresh mirror resolves a workspaceId-only signal → mirror hit, NO pull', async () => {
+    const mirror = fakeMirror({ entries: mirrorEntries(), ageMs: 500 });
+    const cache = fakeCache({ get: mirrorEntries() });
+    const { workspaces, fetchMs, fastPathed } = await resolveWorkspacesForSignal(
+      signal({ workspaceId: 'ws-1', cwd: '/nomatch' }),
+      cache,
+      mirror,
+    );
+    expect(workspaces?.[0]?.id).toBe('ws-1'); // served off the mirror
+    expect(fetchMs).toBe(0);
+    expect(fastPathed).toBe(true); // counted as absorbed, not degraded
+    expect(cache.get).not.toHaveBeenCalled();
+    expect(cache.peek).not.toHaveBeenCalled(); // never fell through to the pull tier
+  });
+
+  it('fresh mirror resolves an exact-ptyId signal against a COLD pull cache → NO pull', async () => {
+    const mirror = fakeMirror({ entries: mirrorEntries(), ageMs: 100 });
+    const cache = fakeCache({ peek: null, get: null }); // pull cache never fetched
+    const { workspaces, fetchMs, fastPathed } = await resolveWorkspacesForSignal(
+      signal({ ptyId: 'pty-1', workspaceId: 'ws-1', cwd: '/repo' }),
+      cache,
+      mirror,
+    );
+    expect(workspaces?.[0]?.id).toBe('ws-1');
+    expect(fetchMs).toBe(0);
+    expect(fastPathed).toBe(true);
+    expect(cache.get).not.toHaveBeenCalled();
+  });
+
+  it('stale mirror (ageMs > STALE_TRUST_MS) falls through to the pull cache', async () => {
+    const mirror = fakeMirror({ entries: mirrorEntries(), ageMs: STALE_TRUST_MS + 1 });
+    const cache = fakeCache({ peek: null, get: mirrorEntries() });
+    const { fetchMs, fastPathed } = await resolveWorkspacesForSignal(
+      signal({ workspaceId: 'ws-1', cwd: '/repo' }),
+      cache,
+      mirror,
+    );
+    expect(cache.get).toHaveBeenCalledTimes(1); // authoritative fetch
+    expect(fastPathed).toBe(false);
+    expect(fetchMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('empty mirror (peek null) falls through to the pull cache', async () => {
+    const mirror = fakeMirror(null);
+    const cache = fakeCache({ peek: null, get: mirrorEntries() });
+    const { fastPathed } = await resolveWorkspacesForSignal(
+      signal({ workspaceId: 'ws-1', cwd: '/repo' }),
+      cache,
+      mirror,
+    );
+    expect(mirror.peek).toHaveBeenCalledTimes(1);
+    expect(cache.get).toHaveBeenCalledTimes(1);
+    expect(fastPathed).toBe(false);
+  });
+
+  it('mirror that cannot place the signal falls through (ptyId absent, cwd no match)', async () => {
+    const mirror = fakeMirror({ entries: mirrorEntries(), ageMs: 100 });
+    const cache = fakeCache({ peek: null, get: mirrorEntries() });
+    const { fastPathed } = await resolveWorkspacesForSignal(
+      signal({ ptyId: 'pty-unknown', cwd: '/nomatch' }),
+      cache,
+      mirror,
+    );
+    expect(cache.get).toHaveBeenCalledTimes(1);
+    expect(fastPathed).toBe(false);
+  });
+
+  it('with NO mirror injected, behaves exactly as the pre-WP2 pull path', async () => {
+    const cache = fakeCache({ peek: null, get: mirrorEntries() });
+    const { workspaces } = await resolveWorkspacesForSignal(
+      signal({ workspaceId: 'ws-1', cwd: '/repo' }),
+      cache,
+    );
+    expect(cache.get).toHaveBeenCalledTimes(1);
+    expect(workspaces?.[0]?.id).toBe('ws-1');
+  });
+});
+
+// ─── Integration: registerHooksRpc honours the injected mirror ───────────────
+
+function fakeWindow(): BrowserWindow {
+  return {
+    isDestroyed: () => false,
+    webContents: { send: vi.fn() },
+  } as unknown as BrowserWindow;
+}
+
+function stubHookRouter(): HookSignalRouter {
+  return {
+    recordHook: () => 'emit',
+    recordDetector: vi.fn(),
+    touchAuthority: vi.fn(),
+    isGovernedFor: vi.fn().mockReturnValue(false),
+    getLatencyMeter: () => ({
+      recordSignal: vi.fn(),
+      recordWorkspaceMatch: vi.fn(),
+      onStatsChange: () => vi.fn(),
+      getStats: () => ({}),
+    }),
+  } as unknown as HookSignalRouter;
+}
+
+describe('registerHooksRpc — mirror short-circuits the renderer round-trip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    eventBus.reset();
+    // If anything DID fall through to the pull path, this resolves it — so the
+    // ZERO-call assertion below can only pass because the mirror served first.
+    sendToRendererMock.mockResolvedValue(mirrorEntries());
+  });
+
+  afterEach(() => {
+    eventBus.reset();
+  });
+
+  async function dispatch(s: AgentSignal, getMirror: () => { peek: () => { entries: WorkspaceListEntry[]; ageMs: number } | null }) {
+    const router = new RpcRouter();
+    registerHooksRpc(router, () => fakeWindow(), stubHookRouter(), undefined, undefined, getMirror);
+    return router.dispatch({
+      id: '1',
+      method: 'hooks.signal',
+      params: s as unknown as Record<string, unknown>,
+    });
+  }
+
+  it('(a) workspaceId-only signal resolves off a fresh mirror with ZERO sendToRenderer calls', async () => {
+    const mirror = fakeMirror({ entries: mirrorEntries(), ageMs: 100 });
+    const res = await dispatch(signal({ workspaceId: 'ws-1', cwd: '/nomatch' }), () => mirror);
+    expect(res.ok).toBe(true);
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+    // The lifecycle tee still fired for the resolved pane.
+    const { events } = eventBus.poll(0, { types: ['agent.lifecycle'] });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ ptyId: 'pty-1', workspaceId: 'ws-1' });
+  });
+
+  it('(b) cold-pull-cache signal resolves off the mirror with ZERO sendToRenderer calls', async () => {
+    const mirror = fakeMirror({ entries: mirrorEntries(), ageMs: 100 });
+    // pty-1 is present in the mirror; the pull cache has never been primed.
+    const res = await dispatch(signal({ ptyId: 'pty-1', workspaceId: 'ws-1', cwd: '/repo' }), () => mirror);
+    expect(res.ok).toBe(true);
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+  });
+
+  it('stale mirror forces the renderer round-trip (falls back to workspace.list)', async () => {
+    const mirror = fakeMirror({ entries: mirrorEntries(), ageMs: STALE_TRUST_MS + 1 });
+    const res = await dispatch(signal({ workspaceId: 'ws-1', cwd: '/repo' }), () => mirror);
+    expect(res.ok).toBe(true);
+    expect(sendToRendererMock).toHaveBeenCalled();
+  });
+});

--- a/src/main/pipe/handlers/hooks.rpc.ts
+++ b/src/main/pipe/handlers/hooks.rpc.ts
@@ -51,6 +51,7 @@ import { summarizeActivity } from '../../../shared/activitySummary';
 import type { DaemonClient } from '../../DaemonClient';
 import type { ResumeBinding, PermissionMode } from '../../../shared/agentResume';
 import { readLastAssistantMessage } from '../../claude/lastAssistantMessage';
+import { getWorkspaceMirror, type WorkspaceMirror } from '../../workspace/WorkspaceMirror';
 import type { AgentLastMessage } from '../../../shared/events';
 import type { NotificationCategory } from '../../../shared/types';
 import os from 'node:os';
@@ -213,11 +214,20 @@ export function registerHooksRpc(
   // owns the pane. main resolves it to the bound account and hook-gates a usage
   // probe. Kept as a decoupled callback so this handler stays account-agnostic.
   onClaudeTurnEnd?: (workspaceId: string) => void,
+  // Main-side WorkspaceMirror (renderer-pushed snapshot of the workspace tree).
+  // Consulted FIRST in resolveWorkspacesForSignal so a hook can resolve without
+  // any renderer round-trip. Injected (default the singleton) for testability.
+  getMirror: () => Pick<WorkspaceMirror, 'peek'> = getWorkspaceMirror,
 ): () => void {
   const meter = hookRouter.getLatencyMeter();
   // Short-TTL, coalescing cache so a burst of hooks in one turn collapses to
   // a single workspace.list round-trip (see WORKSPACE_LIST_CACHE_TTL_MS note).
   const workspaceCache = createWorkspaceListCache(() => safeListWorkspaces(getWindow));
+
+  // Main-side workspace snapshot the renderer pushes on structural/status
+  // change. Resolved once here (the getter returns a stable singleton) so the
+  // hot path reads it directly — no renderer round-trip when it can serve.
+  const mirror = getMirror();
 
   // Fleet activity leading-edge throttle: ptyId → lastSentMs. Scoped to this
   // registration (like workspaceCache/floodMeter) so it lives for the handler's
@@ -264,7 +274,7 @@ export function registerHooksRpc(
     // list without a renderer round-trip (that round-trip is exactly what a
     // large-buffer flush storm starves, timing out the bridge's 2s cap). See
     // that function for the topology-stability + bounded-staleness rules.
-    const { workspaces, fetchMs, fastPathed } = await resolveWorkspacesForSignal(signal, workspaceCache);
+    const { workspaces, fetchMs, fastPathed } = await resolveWorkspacesForSignal(signal, workspaceCache, mirror);
     floodMeter.record({ degraded: fetchMs > HOOK_DEGRADED_FETCH_MS || !workspaces, fetchMs, fastPathed });
     if (!workspaces) {
       // Record as a miss because we couldn't determine match either
@@ -714,16 +724,29 @@ export function createWorkspaceListCache(
 }
 
 /**
- * Env-routed fast path (Fix B). Decide whether this signal can be routed from
- * the cache's last-known workspace list WITHOUT a renderer round-trip.
+ * Decide how this signal resolves its workspace list, cheapest source first.
+ * Three tiers, each removing more of the renderer dependency than the last:
+ *
+ *   (1) MIRROR — the main-side WorkspaceMirror, a full workspace tree the
+ *       renderer PUSHES to main on every structural/status change. When it is
+ *       populated, fresh (younger than STALE_TRUST_MS), AND the pure resolver
+ *       actually resolves a pane against its entries, we route off it with ZERO
+ *       renderer involvement — the strongest cure for the hook jank, because it
+ *       serves BOTH ptyId- and workspaceId-only signals (the renderer already
+ *       pushed the current active-surface mapping, so activePtyId is as fresh as
+ *       a push allows). An empty/never-populated mirror, a stale one, or a signal
+ *       the resolver can't place falls through to (2)/(3).
+ *   (2) ENV FAST PATH (Fix B) — peek the pull-cache's last-known list without a
+ *       fetch, under the strict same-ptyId guard below.
+ *   (3) BLOCKING PULL — the authoritative `workspace.list` round-trip.
  *
  * The round-trip (`workspace.list` → renderer) is what a large-buffer flush
  * storm starves: while the renderer is pegged parsing a multi-MB terminal
  * flush, it can't answer, the fetch times out, and the bridge's 2s hard cap
- * trips (~24% of hooks in the v3.24.0 dogfood). We remove that dependency for
- * the common case.
+ * trips (~24% of hooks in the v3.24.0 dogfood). Tiers (1) and (2) remove that
+ * dependency for the common case.
  *
- * Fast path is taken ONLY when ALL hold:
+ * The env fast path (2) is taken ONLY when ALL hold:
  *   - the signal carries WMUX_PTY_ID. A pane's daemon session id is
  *     topology-STABLE: it does not change when the active surface switches, so
  *     resolving it against a slightly stale list is safe. A `workspaceId`-only
@@ -745,16 +768,35 @@ export function createWorkspaceListCache(
  *     branch fires (id present in the list + workspace cross-check), which is
  *     the topology-stable case; any fallback returns a different id.
  *
- * On the fast path we `prime()` the cache (fire-and-forget) so it stays warm
- * for the next hook without blocking this one. `fetchMs` is 0 (no round-trip)
- * and `fastPathed` is true so the flood meter can report how many hooks the
- * cache absorbed — a green "0 degraded" during a real flush storm would
- * otherwise hide the saturation (GLM P2).
+ * On the env fast path (2) we `prime()` the cache (fire-and-forget) so it stays
+ * warm for the next hook without blocking this one. A mirror hit (1) needs no
+ * prime — the renderer refreshes the mirror on its own push cadence. In both
+ * cases `fetchMs` is 0 (no round-trip) and `fastPathed` is true so the flood
+ * meter can report how many hooks were absorbed without a fetch — a green
+ * "0 degraded" during a real flush storm would otherwise hide the saturation
+ * (GLM P2). A mirror hit counts as fastPathed, never degraded.
  */
 export async function resolveWorkspacesForSignal(
   signal: AgentSignal,
   cache: Pick<WorkspaceListCache, 'get' | 'peek' | 'prime'>,
+  mirror?: Pick<WorkspaceMirror, 'peek'>,
 ): Promise<{ workspaces: WorkspaceListEntry[] | null; fetchMs: number; fastPathed: boolean }> {
+  // (1) Mirror first. Populated + fresh + the pure resolver places a pane → no
+  // renderer round-trip at all. Unlike the env fast path below, this needs no
+  // WMUX_PTY_ID and no exact-id guard: the mirror is the renderer's own pushed
+  // tree, so a newly-created pane is already present (a create is a structural
+  // change that triggers a push), and a workspaceId-only signal resolves against
+  // an up-to-date active-surface mapping rather than a stale pull-cache one.
+  const mirrored = mirror?.peek();
+  if (
+    mirrored &&
+    mirrored.ageMs < STALE_TRUST_MS &&
+    resolvePtyIdForSignal(signal, mirrored.entries) !== null
+  ) {
+    return { workspaces: mirrored.entries, fetchMs: 0, fastPathed: true };
+  }
+
+  // (2) Env-routed fast path (Fix B): peek the pull-cache under the strict guard.
   const peeked = signal.ptyId ? cache.peek() : null;
   if (
     peeked &&

--- a/src/main/workspace/WorkspaceMirror.ts
+++ b/src/main/workspace/WorkspaceMirror.ts
@@ -1,0 +1,102 @@
+// WorkspaceMirror — a main-process cache of the renderer's workspace tree +
+// per-pane agent status, populated by renderer push (IPC.WORKSPACE_MIRROR_PUSH).
+//
+// WHY: today `workspace.list` is a main→renderer round-trip (workspace.rpc.ts →
+// useRpcBridge.ts). Hook signals fire far more often than the workspace tree
+// changes, and a large-buffer flush storm can starve that round-trip until the
+// bridge's 2s cap trips (see hooks.rpc.ts WORKSPACE_LIST_CACHE_TTL_MS). The
+// mirror lets main serve the last renderer-pushed snapshot locally instead —
+// no renderer dependency on the hot path.
+//
+// CONTRACT: routing/snapshot-only. The mirror is NEVER read by the renderer/UI
+// and is never authoritative for focus. Full-snapshot replacement (last write
+// wins) — the renderer always pushes the complete tree, so there is nothing to
+// reconcile. `now` is injectable so the staleness math is unit-testable.
+
+import type {
+  WorkspaceListEntry,
+  FleetSnapshot,
+  WorkspaceMirrorPushPayload,
+} from '../../shared/workspaceMirror';
+
+// Re-export the shared shapes so downstream main consumers (hook resolvers,
+// routing) can import them straight from the mirror.
+export type {
+  WorkspaceListEntry,
+  FleetSnapshot,
+  FleetSnapshotPane,
+  WorkspaceMirrorPushPayload,
+} from '../../shared/workspaceMirror';
+
+export class WorkspaceMirror {
+  private entries: WorkspaceListEntry[] | null = null;
+  private fleets = new Map<string, FleetSnapshot>();
+  private setAt = 0;
+  private populated = false;
+  private readonly now: () => number;
+
+  constructor(now: () => number = Date.now) {
+    this.now = now;
+  }
+
+  /**
+   * Replace the entire mirrored snapshot. Last write wins — a later push with an
+   * empty tree legitimately clears the mirror (every workspace was closed).
+   */
+  setSnapshot(payload: WorkspaceMirrorPushPayload): void {
+    this.entries = payload.entries;
+    this.fleets = new Map(payload.fleets.map((f) => [f.workspaceId, f]));
+    // Stamp with our own clock, not the renderer's `payload.ts`: `peek().ageMs`
+    // must be measured against the same clock the caller reads `now()` on, so a
+    // clock skew between renderer and main can never make a snapshot look
+    // negatively aged or arbitrarily stale.
+    this.setAt = this.now();
+    this.populated = true;
+  }
+
+  /** The mirrored workspace entries, or null if nothing has ever been pushed. */
+  getEntries(): WorkspaceListEntry[] | null {
+    return this.entries;
+  }
+
+  /**
+   * The entries plus their age in ms (measured against the injected clock),
+   * WITHOUT mutating anything. null until the first push — mirrors the hook
+   * cache's `peek()` so a routing caller can apply its own staleness bound.
+   */
+  peek(): { entries: WorkspaceListEntry[]; ageMs: number } | null {
+    if (this.entries === null) return null;
+    return { entries: this.entries, ageMs: this.now() - this.setAt };
+  }
+
+  /** The per-workspace agent-status snapshot, or null when unknown. */
+  getFleetSnapshot(workspaceId: string): FleetSnapshot | null {
+    return this.fleets.get(workspaceId) ?? null;
+  }
+
+  /**
+   * Whether the mirror has received at least one push. Distinct from
+   * `getEntries() !== null` in intent (a caller asking "is the renderer wired up
+   * yet?") — though today they coincide, a future clear-to-null would keep this
+   * true so callers can tell "never populated" (cold boot) from "populated then
+   * emptied" (all workspaces closed).
+   */
+  hasEverBeenPopulated(): boolean {
+    return this.populated;
+  }
+}
+
+// Module-level singleton. Main has exactly one renderer/workspace tree, so a
+// single shared mirror is the right scope — same pattern as the other
+// main-process singletons (EventBus, etc.).
+let singleton: WorkspaceMirror | null = null;
+
+export function getWorkspaceMirror(): WorkspaceMirror {
+  if (!singleton) singleton = new WorkspaceMirror();
+  return singleton;
+}
+
+/** Test-only: drop the singleton so a fresh mirror is built on next access. */
+export function __resetWorkspaceMirrorForTest(): void {
+  singleton = null;
+}

--- a/src/main/workspace/__tests__/WorkspaceMirror.test.ts
+++ b/src/main/workspace/__tests__/WorkspaceMirror.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import {
+  WorkspaceMirror,
+  getWorkspaceMirror,
+  __resetWorkspaceMirrorForTest,
+} from '../WorkspaceMirror';
+import type { WorkspaceMirrorPushPayload } from '../../../shared/workspaceMirror';
+
+function payload(overrides: Partial<WorkspaceMirrorPushPayload> = {}): WorkspaceMirrorPushPayload {
+  return {
+    ts: 1000,
+    entries: [
+      { id: 'ws-1', name: 'alpha', metadata: { cwd: 'C:/repo/a' }, activePtyId: 'pty-1', ptyIds: ['pty-1'] },
+    ],
+    fleets: [
+      {
+        workspaceId: 'ws-1',
+        ts: 1000,
+        panes: [{ ptyId: 'pty-1', agentName: 'Claude Code', agentStatus: 'running', isActivePane: true }],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('WorkspaceMirror', () => {
+  it('starts empty — null entries/peek, no fleet, never populated', () => {
+    const m = new WorkspaceMirror();
+    expect(m.getEntries()).toBeNull();
+    expect(m.peek()).toBeNull();
+    expect(m.getFleetSnapshot('ws-1')).toBeNull();
+    expect(m.hasEverBeenPopulated()).toBe(false);
+  });
+
+  it('setSnapshot stores entries + per-workspace fleet and flips populated', () => {
+    const m = new WorkspaceMirror();
+    m.setSnapshot(payload());
+    expect(m.getEntries()).toHaveLength(1);
+    expect(m.getEntries()?.[0].id).toBe('ws-1');
+    expect(m.getFleetSnapshot('ws-1')?.panes[0].agentStatus).toBe('running');
+    expect(m.getFleetSnapshot('ws-2')).toBeNull();
+    expect(m.hasEverBeenPopulated()).toBe(true);
+  });
+
+  it('peek reports age against the injected clock, not the renderer ts', () => {
+    let clock = 5000;
+    const m = new WorkspaceMirror(() => clock);
+    // Renderer clock (payload.ts) is deliberately far from `clock` — age must be
+    // measured on our own clock so cross-process skew can't distort it.
+    m.setSnapshot(payload({ ts: 999_999 }));
+    clock = 5300;
+    const peeked = m.peek();
+    expect(peeked).not.toBeNull();
+    expect(peeked?.ageMs).toBe(300);
+    expect(peeked?.entries[0].id).toBe('ws-1');
+  });
+
+  it('is full-replacement — last write wins, including clearing to empty', () => {
+    const m = new WorkspaceMirror();
+    m.setSnapshot(payload());
+    m.setSnapshot(
+      payload({
+        entries: [{ id: 'ws-9', name: 'zeta', activePtyId: null }],
+        fleets: [{ workspaceId: 'ws-9', ts: 2000, panes: [] }],
+      }),
+    );
+    expect(m.getEntries()?.map((e) => e.id)).toEqual(['ws-9']);
+    // The prior workspace's fleet must be gone (replacement, not merge).
+    expect(m.getFleetSnapshot('ws-1')).toBeNull();
+    expect(m.getFleetSnapshot('ws-9')?.panes).toEqual([]);
+  });
+
+  it('an empty push clears entries but keeps hasEverBeenPopulated true', () => {
+    const m = new WorkspaceMirror();
+    m.setSnapshot(payload());
+    m.setSnapshot({ ts: 3000, entries: [], fleets: [] });
+    expect(m.getEntries()).toEqual([]);
+    expect(m.peek()?.entries).toEqual([]);
+    expect(m.hasEverBeenPopulated()).toBe(true);
+  });
+
+  it('getWorkspaceMirror returns a stable singleton; reset yields a fresh one', () => {
+    __resetWorkspaceMirrorForTest();
+    const a = getWorkspaceMirror();
+    const b = getWorkspaceMirror();
+    expect(a).toBe(b);
+    a.setSnapshot(payload());
+    expect(getWorkspaceMirror().hasEverBeenPopulated()).toBe(true);
+    __resetWorkspaceMirrorForTest();
+    expect(getWorkspaceMirror().hasEverBeenPopulated()).toBe(false);
+  });
+});

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -536,6 +536,14 @@ const electronAPI = {
       return () => { ipcRenderer.removeListener(IPC.DECK_STREAM, listener); };
     },
   },
+  // WorkspaceMirror push — fire-and-forget full snapshot of the workspace tree +
+  // per-pane agent status. Keeps the main-process mirror warm so routing / hook
+  // resolution is served locally instead of via a `workspace.list` round-trip
+  // (see main/workspace/WorkspaceMirror.ts). Snapshot-only; never read by the UI.
+  workspaceMirror: {
+    push: (payload: import('../shared/workspaceMirror').WorkspaceMirrorPushPayload) =>
+      ipcRenderer.send(IPC.WORKSPACE_MIRROR_PUSH, payload),
+  },
   browser: {
     registerWebview: (surfaceId: string, webContentsId: number) =>
       ipcRenderer.invoke('browser:register-webview', surfaceId, webContentsId),

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -37,6 +37,7 @@ import { useAgentActivityClock } from '../../hooks/useAgentActivityClock';
 import { useTerminalCopyShortcut } from '../../hooks/useTerminalCopyShortcut';
 import { useNotificationListener } from '../../hooks/useNotificationListener';
 import { useRpcBridge } from '../../hooks/useRpcBridge';
+import { useWorkspaceMirrorPush } from '../../hooks/useWorkspaceMirrorPush';
 import { useResizeGuard } from '../../hooks/useResizeGuard';
 import { useApprovalInboxBridge } from '../../hooks/useApprovalInboxBridge';
 import { useRemoteInboxBridge } from '../../hooks/useRemoteInboxBridge';
@@ -338,6 +339,10 @@ export default function AppLayout() {
   useTerminalCopyShortcut();
   useNotificationListener();
   useRpcBridge();
+  // Keep the main-process WorkspaceMirror warm: push the workspace tree +
+  // per-pane agent status whenever it changes, so main resolves hooks/routing
+  // locally instead of round-tripping workspace.list back to the renderer.
+  useWorkspaceMirrorPush();
   // S-C2 Approval Inbox bridge: the SINGLE owner of permissionPrompt.onOpen /
   // onClosed (guard #2). Always-on (not gated on fleetViewVisible) so MCP
   // prompts accumulate in the store before the cockpit's Approvals tab opens.

--- a/src/renderer/hooks/__tests__/useWorkspaceMirrorPush.test.ts
+++ b/src/renderer/hooks/__tests__/useWorkspaceMirrorPush.test.ts
@@ -1,0 +1,42 @@
+// Source-structural guard for the WorkspaceMirror push policy. The hook pulls in
+// the store/window (can't be imported under vitest), so — like
+// useRpcBridge.eventsPoll.test.ts — we lock the load-bearing wiring against the
+// source. The pure payload construction is covered directly in
+// workspaceMirrorSnapshot.test.ts.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+describe('useWorkspaceMirrorPush — push policy wiring', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'useWorkspaceMirrorPush.ts'), 'utf-8');
+
+  it('gates every push on paneGate === ready (mid-reconcile safety)', () => {
+    expect(src).toMatch(/paneGate\s*!==\s*'ready'/);
+  });
+
+  it('sends through the optional-chained electronAPI workspaceMirror.push surface', () => {
+    // Optional chaining is mandatory in the renderer (a stale preload / partial
+    // test mock may not expose it — jsdom crashes on a bare access).
+    expect(src).toMatch(/window\.electronAPI\?\.workspaceMirror\?\.push\?\.\(/);
+  });
+
+  it('pushes leading-edge on a structural change (workspaces identity / active ws)', () => {
+    expect(src).toMatch(/s\.workspaces\s*!==\s*prev\.workspaces/);
+    expect(src).toMatch(/s\.activeWorkspaceId\s*!==\s*prev\.activeWorkspaceId/);
+    expect(src).toMatch(/flushLeading\(\)/);
+  });
+
+  it('debounces status-only churn with a 300ms trailing timer', () => {
+    expect(src).toMatch(/STATUS_DEBOUNCE_MS\s*=\s*300/);
+    expect(src).toMatch(/scheduleTrailing/);
+    // The debounced inputs are the fleet selector's per-pane status sources.
+    expect(src).toMatch(/surfaceAgentStatus\s*!==\s*prev\.surfaceAgentStatus/);
+    expect(src).toMatch(/agentClockMs\s*!==\s*prev\.agentClockMs/);
+  });
+
+  it('subscribes to the store and cleans up the subscription + timer on unmount', () => {
+    expect(src).toMatch(/useStore\.subscribe\(/);
+    expect(src).toMatch(/return\s*\(\)\s*=>\s*\{[\s\S]*clearTimeout\(trailingTimer\)[\s\S]*unsub\(\)/);
+  });
+});

--- a/src/renderer/hooks/__tests__/workspaceMirrorSnapshot.test.ts
+++ b/src/renderer/hooks/__tests__/workspaceMirrorSnapshot.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findActivePtyId,
+  collectAllPtyIds,
+  buildWorkspaceListEntries,
+  buildFleetSnapshots,
+  buildWorkspaceMirrorPayload,
+} from '../workspaceMirrorSnapshot';
+import type { Workspace, Pane, Surface, AgentStatus } from '../../../shared/types';
+import type { FleetSelectorState } from '../../stores/selectors/fleet';
+
+// ─── Fixtures (mirror fleet.test.ts) ─────────────────────────────────────────
+
+function surface(id: string, ptyId: string, extra: Partial<Surface> = {}): Surface {
+  return { id, ptyId, title: id, shell: 'pwsh', cwd: `C:\\repo\\${id}`, surfaceType: 'terminal', ...extra };
+}
+function leaf(id: string, surfaces: Surface[], activeSurfaceId?: string): Pane {
+  return { id, type: 'leaf', surfaces, activeSurfaceId: activeSurfaceId ?? surfaces[0]?.id ?? '' };
+}
+function branch(id: string, children: Pane[]): Pane {
+  return { id, type: 'branch', direction: 'horizontal', children };
+}
+function workspace(
+  id: string,
+  name: string,
+  rootPane: Pane,
+  activePaneId: string,
+  metadata?: Workspace['metadata'],
+): Workspace {
+  return { id, name, rootPane, activePaneId, metadata };
+}
+
+const w1 = workspace(
+  'ws-1', 'alpha',
+  leaf('p1', [surface('s1', 'pty-1')]),
+  'p1',
+  { cwd: 'C:/repo/alpha', gitBranch: 'main', agentName: 'Claude Code', agentStatus: 'running' },
+);
+// ws-2: branch, active leaf p2a has two surfaces (must pick activeSurfaceId).
+const w2 = workspace(
+  'ws-2', 'beta',
+  branch('b', [
+    leaf('p2a', [surface('s2a-first', 'pty-2a-first'), surface('s2a', 'pty-2a')], 's2a'),
+    leaf('p2b', [surface('s2b', 'pty-2b', { surfaceType: 'browser' })]),
+  ]),
+  'p2a',
+  { agentName: 'Codex', agentStatus: 'running' },
+);
+
+const surfaceAgentStatus: Record<string, AgentStatus> = {
+  'pty-1': 'awaiting_input',
+  'pty-2b': 'complete',
+};
+
+function state(): FleetSelectorState {
+  return {
+    workspaces: [w1, w2],
+    surfaceAgentStatus,
+    surfaceActivity: {},
+  };
+}
+
+describe('findActivePtyId / collectAllPtyIds', () => {
+  it('resolves the active pane + active surface pty', () => {
+    expect(findActivePtyId(w1.rootPane, w1.activePaneId)).toBe('pty-1');
+    // p2a active surface is s2a → pty-2a (NOT surfaces[0]).
+    expect(findActivePtyId(w2.rootPane, w2.activePaneId)).toBe('pty-2a');
+  });
+  it('collects every surface pty across the whole tree', () => {
+    expect(collectAllPtyIds(w2.rootPane)).toEqual(['pty-2a-first', 'pty-2a', 'pty-2b']);
+  });
+});
+
+describe('buildWorkspaceListEntries', () => {
+  it('produces the workspace.list-shaped entries with metadata nulls filled', () => {
+    const entries = buildWorkspaceListEntries([w1, w2]);
+    expect(entries[0]).toEqual({
+      id: 'ws-1',
+      name: 'alpha',
+      metadata: {
+        cwd: 'C:/repo/alpha',
+        gitBranch: 'main',
+        agentName: 'Claude Code',
+        agentStatus: 'running',
+        status: null,
+        progress: null,
+      },
+      activePtyId: 'pty-1',
+      ptyIds: ['pty-1'],
+    });
+    expect(entries[1].activePtyId).toBe('pty-2a');
+    expect(entries[1].ptyIds).toEqual(['pty-2a-first', 'pty-2a', 'pty-2b']);
+  });
+});
+
+describe('buildFleetSnapshots', () => {
+  it('rolls selectFleetPanes into one snapshot per workspace with ts stamped', () => {
+    const fleets = buildFleetSnapshots(state(), 7777);
+    const byId = Object.fromEntries(fleets.map((f) => [f.workspaceId, f]));
+    expect(Object.keys(byId).sort()).toEqual(['ws-1', 'ws-2']);
+    expect(byId['ws-1'].ts).toBe(7777);
+    // ws-1 single active pane: attention status awaiting_input wins over ws meta.
+    expect(byId['ws-1'].panes[0]).toMatchObject({
+      ptyId: 'pty-1',
+      agentName: 'Claude Code', // active pane → agentName exposed
+      agentStatus: 'awaiting_input',
+      isActivePane: true,
+    });
+    // ws-2 background browser pane keeps its per-pty complete status; agentName
+    // must NOT be borrowed from the workspace for a background pane → null.
+    const bg = byId['ws-2'].panes.find((p) => p.ptyId === 'pty-2b');
+    expect(bg).toMatchObject({ agentStatus: 'complete', agentName: null, isActivePane: false });
+  });
+});
+
+describe('buildWorkspaceMirrorPayload', () => {
+  it('stamps entries + fleets with one injected clock value', () => {
+    const payload = buildWorkspaceMirrorPayload(state(), () => 5555);
+    expect(payload.ts).toBe(5555);
+    expect(payload.entries).toHaveLength(2);
+    expect(payload.fleets.every((f) => f.ts === 5555)).toBe(true);
+  });
+});

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -20,55 +20,16 @@ import { submitBracketedPasteToPty } from '../utils/ptyMessageDelivery';
 import { publishA2aTask } from '../events/publisher';
 import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, isTerminalPtyInLeaves, resolveSelfPaneIdentity, resolveSenderPaneAddress, resolvePaneRole, findLeafPanes, type PaneAddress } from './a2aAddressing';
 import { resolveWorkspaceTarget } from './workspaceTargeting';
+import { findActivePtyId, collectAllPtyIds, buildWorkspaceListEntries } from './workspaceMirrorSnapshot';
 
 // ---------------------------------------------------------------------------
 // Pane tree utilities
 // ---------------------------------------------------------------------------
 
-/**
- * Resolve the ptyId of a workspace's active pane + active surface.
- *
- * Duplicated from StatusBar.tsx's local helper — kept inline here rather
- * than lifting to a shared module because both call sites read the active
- * pane through the renderer store and lifting would force a circular
- * dependency between renderer/utils and the store. Two tiny copies are
- * cheaper than the shared-module gymnastics.
- *
- * Used by the workspace.list RPC response so hook bridge scripts
- * (integrations/<agent>/bin/wmux-bridge.mjs) can resolve their hook
- * payload's cwd → workspace → activePtyId in a single round-trip.
- */
-function findActivePtyId(rootPane: Pane | undefined, activePaneId: string): string | null {
-  if (!rootPane) return null;
-  const findLeaf = (pane: Pane): PaneLeaf | null => {
-    if (pane.type === 'leaf') return pane.id === activePaneId ? pane : null;
-    for (const child of pane.children) {
-      const found = findLeaf(child);
-      if (found) return found;
-    }
-    return null;
-  };
-  const leaf = findLeaf(rootPane);
-  if (!leaf) return null;
-  const surface = leaf.surfaces.find((s) => s.id === leaf.activeSurfaceId);
-  return surface?.ptyId ?? null;
-}
-
-/** All ptyIds in a workspace (every leaf, every surface). */
-function collectAllPtyIds(root: Pane): string[] {
-  const ids: string[] = [];
-  const walk = (pane: Pane): void => {
-    if (pane.type === 'leaf') {
-      for (const s of pane.surfaces) {
-        if (s.ptyId) ids.push(s.ptyId);
-      }
-      return;
-    }
-    for (const child of pane.children) walk(child);
-  };
-  walk(root);
-  return ids;
-}
+// `findActivePtyId` / `collectAllPtyIds` were lifted to
+// ./workspaceMirrorSnapshot so the WorkspaceMirror push payload (which mirrors
+// the `workspace.list` reply) shares one source of truth for them. Imported
+// above; the workspace.list handler and line-492 pty sweep use them unchanged.
 
 function findPaneById(root: Pane, id: string): Pane | null {
   if (root.id === id) return root;
@@ -434,26 +395,11 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
   // -------------------------------------------------------------------------
 
   if (method === 'workspace.list') {
-    return store.workspaces.map((w) => ({
-      id: w.id,
-      name: w.name,
-      metadata: {
-        cwd: w.metadata?.cwd ?? null,
-        gitBranch: w.metadata?.gitBranch ?? null,
-        agentName: w.metadata?.agentName ?? null,
-        agentStatus: w.metadata?.agentStatus ?? null,
-        status: w.metadata?.status ?? null,
-        progress: w.metadata?.progress ?? null,
-      },
-      // Phase 1 hook plugin support — bridge scripts resolve hook payload's
-      // cwd → workspace → activePtyId. activePtyId is the active pane's
-      // active surface; ptyIds is the union over the whole workspace
-      // (used when bridge needs to disambiguate via env if cwd alone is
-      // ambiguous). Both fields are optional from the wire-format POV —
-      // existing consumers that destructure metadata only are unaffected.
-      activePtyId: findActivePtyId(w.rootPane, w.activePaneId),
-      ptyIds: collectAllPtyIds(w.rootPane),
-    }));
+    // Phase 1 hook plugin support — bridge scripts resolve hook payload's
+    // cwd → workspace → activePtyId. Shared with the WorkspaceMirror push so
+    // the mirror snapshot can never diverge from this reply (see
+    // buildWorkspaceListEntries).
+    return buildWorkspaceListEntries(store.workspaces);
   }
 
   if (method === 'workspace.new') {

--- a/src/renderer/hooks/useWorkspaceMirrorPush.ts
+++ b/src/renderer/hooks/useWorkspaceMirrorPush.ts
@@ -1,0 +1,100 @@
+// useWorkspaceMirrorPush — pushes the full workspace tree + per-pane agent
+// status snapshot to the main-process WorkspaceMirror (IPC.WORKSPACE_MIRROR_PUSH)
+// whenever it changes. This is what lets main resolve hooks / routing locally
+// instead of round-tripping `workspace.list` back to the renderer (which a
+// large-buffer flush storm starves — see hooks.rpc.ts / WorkspaceMirror.ts).
+//
+// Push policy (matches the mirror's snapshot-only contract):
+//   - LEADING-EDGE immediate push on a STRUCTURAL change — the workspaces array
+//     identity changing (tree mutation, incl. per-workspace activePaneId) or the
+//     active workspace switching. Routing correctness depends on these landing
+//     promptly, so they are never debounced.
+//   - TRAILING 300ms debounce for STATUS-ONLY churn (agent status / activity /
+//     clock tick / label / supervision). These are high-frequency and
+//     non-structural, so one coalesced push per quiet-down is enough.
+//
+// Gated on the SAME pane-readiness gate as useRpcBridge (`paneGate === 'ready'`):
+// during startup reconcile the tree's ptyIds are stale / mid-clear, so a snapshot
+// pushed then would seed the mirror with ids that are about to change.
+
+import { useEffect } from 'react';
+import { useStore } from '../stores';
+import { buildWorkspaceMirrorPayload } from './workspaceMirrorSnapshot';
+
+/** Trailing-debounce window for status-only churn (ms). */
+const STATUS_DEBOUNCE_MS = 300;
+
+export function useWorkspaceMirrorPush(): void {
+  useEffect(() => {
+    let trailingTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const push = (): void => {
+      const s = useStore.getState();
+      // Gate: never seed the mirror from a mid-reconcile tree.
+      if (s.paneGate !== 'ready') return;
+      const payload = buildWorkspaceMirrorPayload(s);
+      // Optional-chained: a stale preload (packaged update under a running
+      // renderer) or a partial test mock may not expose the send surface.
+      window.electronAPI?.workspaceMirror?.push?.(payload);
+    };
+
+    const flushLeading = (): void => {
+      // A structural push supersedes any pending trailing one.
+      if (trailingTimer) {
+        clearTimeout(trailingTimer);
+        trailingTimer = null;
+      }
+      push();
+    };
+
+    const scheduleTrailing = (): void => {
+      if (trailingTimer) return; // already coalescing this window
+      trailingTimer = setTimeout(() => {
+        trailingTimer = null;
+        push();
+      }, STATUS_DEBOUNCE_MS);
+    };
+
+    const listener = (
+      s: ReturnType<typeof useStore.getState>,
+      prev: ReturnType<typeof useStore.getState>,
+    ): void => {
+      // The gate flipping pending→ready is itself the moment the first real
+      // snapshot becomes valid — push it immediately (leading).
+      if (s.paneGate === 'ready' && prev.paneGate !== 'ready') {
+        flushLeading();
+        return;
+      }
+      if (s.paneGate !== 'ready') return;
+
+      // Structural: workspaces array identity (tree / activePaneId mutations all
+      // produce a fresh immutable array) or the active workspace switching.
+      const structural =
+        s.workspaces !== prev.workspaces || s.activeWorkspaceId !== prev.activeWorkspaceId;
+      if (structural) {
+        flushLeading();
+        return;
+      }
+
+      // Status-only churn: the fleet selector's per-pane status inputs. Debounce.
+      const statusChurn =
+        s.surfaceAgentStatus !== prev.surfaceAgentStatus ||
+        s.surfaceActivity !== prev.surfaceActivity ||
+        s.surfaceActivityAt !== prev.surfaceActivityAt ||
+        s.agentClockMs !== prev.agentClockMs ||
+        s.paneLabel !== prev.paneLabel ||
+        s.supervisionByPtyId !== prev.supervisionByPtyId;
+      if (statusChurn) scheduleTrailing();
+    };
+
+    const unsub = useStore.subscribe(listener);
+    // Seed the mirror on mount when the gate is already open (the pending→ready
+    // transition above covers the cold-start case).
+    if (useStore.getState().paneGate === 'ready') flushLeading();
+
+    return () => {
+      if (trailingTimer) clearTimeout(trailingTimer);
+      unsub();
+    };
+  }, []);
+}

--- a/src/renderer/hooks/workspaceMirrorSnapshot.ts
+++ b/src/renderer/hooks/workspaceMirrorSnapshot.ts
@@ -1,0 +1,122 @@
+// Pure builders for the WorkspaceMirror push payload (see
+// ../../shared/workspaceMirror.ts and ../../main/workspace/WorkspaceMirror.ts).
+//
+// Extracted here — with no store/window imports — so the payload construction is
+// unit-testable directly (the useWorkspaceMirrorPush hook itself pulls in the
+// store/window and can't be imported under vitest). `findActivePtyId` /
+// `collectAllPtyIds` were lifted out of useRpcBridge.ts so the mirror's `entries`
+// payload is byte-identical to the `workspace.list` reply, with a single source
+// of truth for the two helpers.
+
+import type { Pane, PaneLeaf, Workspace } from '../../shared/types';
+import type {
+  WorkspaceListEntry,
+  FleetSnapshot,
+  FleetSnapshotPane,
+  WorkspaceMirrorPushPayload,
+} from '../../shared/workspaceMirror';
+import { selectFleetPanes, type FleetSelectorState } from '../stores/selectors/fleet';
+
+/**
+ * Resolve the ptyId of a workspace's active pane + active surface.
+ *
+ * Used by the workspace.list RPC response so hook bridge scripts
+ * (integrations/<agent>/bin/wmux-bridge.mjs) can resolve their hook
+ * payload's cwd → workspace → activePtyId in a single round-trip.
+ */
+export function findActivePtyId(rootPane: Pane | undefined, activePaneId: string): string | null {
+  if (!rootPane) return null;
+  const findLeaf = (pane: Pane): PaneLeaf | null => {
+    if (pane.type === 'leaf') return pane.id === activePaneId ? pane : null;
+    for (const child of pane.children) {
+      const found = findLeaf(child);
+      if (found) return found;
+    }
+    return null;
+  };
+  const leaf = findLeaf(rootPane);
+  if (!leaf) return null;
+  const surface = leaf.surfaces.find((s) => s.id === leaf.activeSurfaceId);
+  return surface?.ptyId ?? null;
+}
+
+/** All ptyIds in a workspace (every leaf, every surface). */
+export function collectAllPtyIds(root: Pane): string[] {
+  const ids: string[] = [];
+  const walk = (pane: Pane): void => {
+    if (pane.type === 'leaf') {
+      for (const s of pane.surfaces) {
+        if (s.ptyId) ids.push(s.ptyId);
+      }
+      return;
+    }
+    for (const child of pane.children) walk(child);
+  };
+  walk(root);
+  return ids;
+}
+
+/**
+ * Build the `workspace.list`-shaped entries. MUST stay identical to the
+ * renderer's `workspace.list` reply (useRpcBridge.ts) — both call this so the
+ * mirror and the round-trip can never diverge.
+ */
+export function buildWorkspaceListEntries(workspaces: Workspace[]): WorkspaceListEntry[] {
+  return workspaces.map((w) => ({
+    id: w.id,
+    name: w.name,
+    metadata: {
+      cwd: w.metadata?.cwd ?? null,
+      gitBranch: w.metadata?.gitBranch ?? null,
+      agentName: w.metadata?.agentName ?? null,
+      agentStatus: w.metadata?.agentStatus ?? null,
+      status: w.metadata?.status ?? null,
+      progress: w.metadata?.progress ?? null,
+    },
+    // Phase 1 hook plugin support — bridge scripts resolve hook payload's
+    // cwd → workspace → activePtyId. activePtyId is the active pane's active
+    // surface; ptyIds is the union over the whole workspace.
+    activePtyId: findActivePtyId(w.rootPane, w.activePaneId),
+    ptyIds: collectAllPtyIds(w.rootPane),
+  }));
+}
+
+/**
+ * Roll `selectFleetPanes` up into one FleetSnapshot per workspace. Reuses the
+ * canonical fleet selector (its 3-tier status gate + active-pane fidelity for
+ * agentName) so the mirror's per-pane status agrees exactly with the cockpit.
+ */
+export function buildFleetSnapshots(state: FleetSelectorState, ts: number): FleetSnapshot[] {
+  const byWs = new Map<string, FleetSnapshot>();
+  for (const pane of selectFleetPanes(state)) {
+    let snap = byWs.get(pane.workspaceId);
+    if (!snap) {
+      snap = { workspaceId: pane.workspaceId, ts, panes: [] };
+      byWs.set(pane.workspaceId, snap);
+    }
+    const out: FleetSnapshotPane = {
+      ptyId: pane.ptyId,
+      // Selector exposes agentName only for the active pane (background-pane
+      // fidelity rule); null everywhere else.
+      agentName: pane.agentName ?? null,
+      agentStatus: pane.agentStatus,
+      isActivePane: pane.isActivePane,
+    };
+    if (pane.cwd !== undefined) out.cwd = pane.cwd;
+    snap.panes.push(out);
+  }
+  return [...byWs.values()];
+}
+
+/** Assemble the full push payload from the live store state at `now()`. */
+export function buildWorkspaceMirrorPayload(
+  state: FleetSelectorState,
+  now: () => number = Date.now,
+): WorkspaceMirrorPushPayload {
+  const ts = now();
+  return {
+    ts,
+    entries: buildWorkspaceListEntries(state.workspaces),
+    fleets: buildFleetSnapshots(state, ts),
+  };
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -206,6 +206,13 @@ export const IPC = {
   //   loop and resumes the brain. Same renderer-only trust boundary as DECK_SEND.
   DECK_DECISION_GET: 'deck:decision:get',
   DECK_DECISION_RESOLVE: 'deck:decision:resolve',
+  //   WORKSPACE_MIRROR_PUSH (send) renderer → main: a fire-and-forget full
+  //   snapshot of the workspace tree + per-pane agent status. Feeds the
+  //   main-process WorkspaceMirror so routing / hook resolution can be served
+  //   locally instead of via the `workspace.list` renderer round-trip (which a
+  //   large-buffer flush storm starves). Snapshot-only — never read by the UI,
+  //   never authoritative for focus. Full replacement (last write wins).
+  WORKSPACE_MIRROR_PUSH: 'workspace:mirror:push',
   //   ACCOUNT_* (invoke) renderer → main: multi-account registry CRUD +
   //   per-workspace bindings. Renderer-only trust boundary (main owns
   //   accounts.json; the renderer never resolves spawn env). Onboarding

--- a/src/shared/workspaceMirror.ts
+++ b/src/shared/workspaceMirror.ts
@@ -1,0 +1,67 @@
+// Shared wire + storage shapes for the WorkspaceMirror (a main-process cache of
+// the renderer's workspace tree + per-pane agent status, populated by renderer
+// push). Kept in `shared/` so the renderer (which builds the push payload) and
+// main (which stores it) agree on ONE type — the mirror re-exports these so
+// downstream main consumers can import from either.
+//
+// The mirror is routing/snapshot-only: it is NEVER read by the renderer/UI and
+// is never authoritative for focus. It exists to kill the hook-jank
+// `workspace.list` renderer round-trip — a main→renderer IPC that a
+// large-buffer flush storm starves (see hooks.rpc.ts WORKSPACE_LIST_CACHE_TTL_MS
+// note). With the mirror, main serves the last renderer-pushed snapshot locally.
+
+import type { AgentStatus } from './types';
+
+/**
+ * The exact per-workspace shape the hook resolvers consume (the same fields the
+ * renderer's `workspace.list` reply carries — see useRpcBridge.ts). `metadata`
+ * is a superset of the resolver's `{ cwd }` requirement so a richer snapshot
+ * still drops into any consumer that only reads `metadata.cwd`.
+ */
+export interface WorkspaceListEntry {
+  id: string;
+  name: string;
+  metadata?: {
+    cwd?: string | null;
+    gitBranch?: string | null;
+    agentName?: string | null;
+    agentStatus?: string | null;
+    status?: string | null;
+    progress?: number | null;
+  };
+  /** The active pane's active surface PTY id. Null when none has spawned. */
+  activePtyId?: string | null;
+  /** Union of every surface's PTY id across the whole workspace. */
+  ptyIds?: string[];
+}
+
+/** One pane's agent status, distilled from the renderer fleet selector
+ *  (selectFleetPanes). `agentStatus` reuses the selector's status union rather
+ *  than inventing a new one; `agentName` follows the selector's active-pane
+ *  fidelity rule (null for background panes). */
+export interface FleetSnapshotPane {
+  ptyId: string;
+  agentName: string | null;
+  agentStatus: AgentStatus;
+  cwd?: string;
+  isActivePane: boolean;
+}
+
+/** Per-workspace agent-status snapshot. `ts` is the renderer push timestamp. */
+export interface FleetSnapshot {
+  workspaceId: string;
+  ts: number;
+  panes: FleetSnapshotPane[];
+}
+
+/**
+ * The full snapshot the renderer pushes over IPC.WORKSPACE_MIRROR_PUSH. Full
+ * replacement semantics (last write wins) — a partial/delta push is never sent,
+ * so main never has to reconcile.
+ */
+export interface WorkspaceMirrorPushPayload {
+  /** Renderer clock at build time (ms). */
+  ts: number;
+  entries: WorkspaceListEntry[];
+  fleets: FleetSnapshot[];
+}


### PR DESCRIPTION
## What

This branch ships three things:

1. **Workspace mirror** — a main-process snapshot cache that the daemon and hooks consult before making a renderer round-trip, cutting latency on structural/status queries.
2. **Resume chip edge-trigger on agent exit** (#549) — the chip now stays hidden while the agent process is alive (process-truth, not activity heuristic) and surfaces exactly on exit.
3. **README install section** — leads with `winget install openwong2kim.wmux` as the hero CTA. Setup.exe is demoted to secondary "offline install" with an explicit note about why the SmartScreen warning appears (SignPath Foundation rejected the production certificate due to insufficient external reputation; winget/choco bypass it entirely).

## Why

- **Workspace mirror:** the daemon and hooks needed workspace state (surface list, agent status) but had no local cache — every query crossed IPC to the renderer. The mirror is a read-only snapshot pushed from the renderer on structural/status changes.
- **Resume chip:** on panes without OSC 133, the chip popped up mid-session when the activity heuristic decayed. Edge-triggering on process truth fixes this definitively.
- **README:** SmartScreen on direct Setup.exe download kills first impressions. SignPath Foundation's rejection means the warning will persist until reputation builds. winget/choco bypass SmartScreen entirely — making it the primary CTA is the zero-cost, zero-wait fix.

## Test plan

- [ ] Workspace mirror: open/close panes, switch workspaces — verify daemon hooks resolve without renderer round-trip
- [ ] Resume chip: launch a Claude agent, verify chip stays hidden during session, appears on exit
- [ ] Resume chip: verify `--dangerously-skip-permissions` toggle works on both chip and recovery pill
- [ ] README: verify the install section renders correctly on GitHub


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace snapshot syncing to improve workspace and hook resolution.
  * Workspace and PTY lookups can now use fresh local data for faster responses, with automatic fallback when unavailable or outdated.
  * Workspace and agent status updates are synchronized efficiently in the background.

* **Documentation**
  * Updated Windows installation guidance to recommend winget first.
  * Clarified SmartScreen warnings for unsigned offline installers and provided alternative installation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->