### PR TITLE
docs(readme): lead with winget, explain SmartScreen for direct download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Install instructions now lead with the package manager.** The README's Windows install section puts `winget install openwong2kim.wmux` front and center with a clear note that it avoids the SmartScreen warning — the direct Setup.exe download is demoted to a secondary "offline install" path with an explicit note about why the warning appears (the installer isn't Authenticode-signed yet).
+
 ## [3.31.0] — 2026-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ Run **fleets of Claude Code, Codex & Gemini in parallel** — each agent in its 
 
 ## ⚡ Install in 30 seconds
 
-**Windows**
+**Windows** — use a package manager (avoids the SmartScreen warning):
 
 ```powershell
 winget install openwong2kim.wmux
 ```
 
-<sub>or `choco install wmux` &nbsp;·&nbsp; or [**download Setup.exe**](https://github.com/openwong2kim/wmux/releases/latest) &nbsp;·&nbsp; winget/choco avoid the SmartScreen prompt ([why?](#install-help))</sub>
+<sub>or `choco install wmux` &nbsp;·&nbsp; [**download Setup.exe**](https://github.com/openwong2kim/wmux/releases/latest) for offline install — a SmartScreen prompt appears because the installer isn't Authenticode-signed yet; winget/choco bypass it ([why?](#install-help))</sub>
 
 **macOS** (Apple Silicon)
 


### PR DESCRIPTION
The Windows install section now puts `winget install openwong2kim.wmux` as the hero CTA with a clear reason (avoids SmartScreen). The direct Setup.exe download is demoted to a secondary "offline install" path with an explicit note about why the warning appears (the installer isn't Authenticode-signed yet).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Windows installation guidance to recommend package managers first.
  - Clarified that direct `Setup.exe` downloads are intended for offline installation and may trigger a SmartScreen warning.
  - Added a changelog entry documenting the updated installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->