### PR TITLE
fix: green up main after #562 — main-bundle @xterm/headless resolve + flaky delta test

### DIFF
--- a/src/daemon/SessionPipe.ts
+++ b/src/daemon/SessionPipe.ts
@@ -5,6 +5,12 @@ import crypto from 'node:crypto';
 import { getSessionSocketPath } from '../shared/constants';
 import type { RingBuffer } from './RingBuffer';
 import { generateSnapshot, MAX_SCROLLBACK } from './HeadlessSnapshot';
+import { FLUSH_DONE_MARKER, RESYNC_BEGIN_MARKER } from './sessionPipeMarkers';
+
+// Re-exported for existing importers; the definitions live in the dependency-free
+// sessionPipeMarkers module so the Electron main bundle can import the markers
+// without dragging SessionPipe's @xterm/headless dependency into its Vite graph.
+export { FLUSH_DONE_MARKER, RESYNC_BEGIN_MARKER };
 
 /**
  * TASK-10: initial-attach flushes at or above this size go through the
@@ -13,19 +19,6 @@ import { generateSnapshot, MAX_SCROLLBACK } from './HeadlessSnapshot';
  * (The resync/reflush path has its own caller-side policy — see reflush.)
  */
 export const ATTACH_SNAPSHOT_MIN_BYTES = 256 * 1024;
-
-/** Marker sent after Ring Buffer flush to signal transition to real-time mode. */
-export const FLUSH_DONE_MARKER = Buffer.from('\x00WMUX_FLUSH_DONE\x00');
-
-/**
- * In-band announcement that a live-pipe re-flush is starting (phase 3 PR-B).
- * Written on the ALREADY-FLUSHED stream right before live output is
- * suppressed; everything after it up to the next FLUSH_DONE_MARKER is replay
- * (snapshot or raw) that the client must accumulate exactly like the initial
- * flush. Carrying the state transition in the stream itself is what makes the
- * protocol race-free: no RPC-vs-stream ordering can misclassify bytes.
- */
-export const RESYNC_BEGIN_MARKER = Buffer.from('\x00WMUX_RESYNC_BEGIN\x00');
 
 /**
  * Per-session data pipe for raw byte streaming.

--- a/src/daemon/__tests__/SessionPipe.attachSnapshot.test.ts
+++ b/src/daemon/__tests__/SessionPipe.attachSnapshot.test.ts
@@ -245,16 +245,17 @@ describe('SessionPipe initial-attach snapshot (TASK-10)', () => {
     const raw = bigHistory(ATTACH_SNAPSHOT_MIN_BYTES * 2); // longer parse window
     const ring = new RingBuffer(8 * 1024 * 1024);
     ring.write(raw);
+    // While the snapshot builds (flushed=false), live PTY output goes to the
+    // ring only — exactly what the daemon's data path does. Inject the marker
+    // right after the flush's first (pre-parse) readAll so it is deterministically
+    // in the ring during the parse; a wall-clock sleep raced the shared
+    // concurrency-1 snapshot queue and flaked on slower CI runners (macos-14).
+    const liveMarker = Buffer.from('\r\nLIVE-DELTA-MARKER-9f2\r\n', 'utf8');
+    injectAfterFirstReadAll(ring, liveMarker);
     const pipe = await startPipe(uniqueSessionId('delta'), ring, () => ({ cols: COLS, rows: ROWS }));
 
     const client = await connectClient(pipe.getPipeName(), TOKEN);
     clients.push(client);
-
-    // While the snapshot builds (flushed=false), live PTY output goes to the
-    // ring only — exactly what the daemon's data path does.
-    const liveMarker = Buffer.from('\r\nLIVE-DELTA-MARKER-9f2\r\n', 'utf8');
-    await sleep(30); // let auth complete and the parse start
-    ring.write(liveMarker);
 
     await waitFor(() => client.wire().includes(FLUSH_DONE_MARKER), 20_000);
     const replay = replaySegment(client.wire())!;

--- a/src/daemon/sessionPipeMarkers.ts
+++ b/src/daemon/sessionPipeMarkers.ts
@@ -1,0 +1,22 @@
+/**
+ * In-band stream markers for the per-session data pipe protocol.
+ *
+ * These live in their own dependency-free module so the Electron main bundle
+ * can import them (via sessionPipeStreamScanner) WITHOUT pulling in SessionPipe
+ * and its transitive `@xterm/headless` dependency — the Vite main build cannot
+ * resolve that package's exports, which broke `Package app` when TASK-10 added
+ * the HeadlessSnapshot import to SessionPipe. Keep this file import-free.
+ */
+
+/** Marker sent after Ring Buffer flush to signal transition to real-time mode. */
+export const FLUSH_DONE_MARKER = Buffer.from('\x00WMUX_FLUSH_DONE\x00');
+
+/**
+ * In-band announcement that a live-pipe re-flush is starting (phase 3 PR-B).
+ * Written on the ALREADY-FLUSHED stream right before live output is
+ * suppressed; everything after it up to the next FLUSH_DONE_MARKER is replay
+ * (snapshot or raw) that the client must accumulate exactly like the initial
+ * flush. Carrying the state transition in the stream itself is what makes the
+ * protocol race-free: no RPC-vs-stream ordering can misclassify bytes.
+ */
+export const RESYNC_BEGIN_MARKER = Buffer.from('\x00WMUX_RESYNC_BEGIN\x00');

--- a/src/main/daemon/sessionPipeStreamScanner.ts
+++ b/src/main/daemon/sessionPipeStreamScanner.ts
@@ -1,4 +1,4 @@
-import { FLUSH_DONE_MARKER, RESYNC_BEGIN_MARKER } from '../../daemon/SessionPipe';
+import { FLUSH_DONE_MARKER, RESYNC_BEGIN_MARKER } from '../../daemon/sessionPipeMarkers';
 
 /**
  * Stream events produced while scanning a session pipe's byte stream.


### PR DESCRIPTION
Two CI failures on the #562 merge commit (`5c73433d`), fixed here. `CI` and the daemon/mcp suites were green; these two jobs were red.

## 1. Perf / bench — `Package app` build break (the real one)

`electron-forge package`'s Vite main build failed: `Failed to resolve entry for package "@xterm/headless"`.

**Cause:** TASK-10 added `import { generateSnapshot } from './HeadlessSnapshot'` to `SessionPipe`, and `HeadlessSnapshot` imports `@xterm/headless`. The Electron **main** bundle reaches `SessionPipe` through one edge — `sessionPipeStreamScanner` imports `FLUSH_DONE_MARKER` / `RESYNC_BEGIN_MARKER` from it — so Vite pulled `@xterm/headless` into the main graph and choked on its exports map. The esbuild **daemon** bundle handles the package fine, which is why `build:daemon` and every non-package job stayed green.

**Fix:** moved the two protocol markers into a dependency-free `sessionPipeMarkers` module. `SessionPipe` re-exports them; the main-side scanner imports them from there — severing `main → SessionPipe → HeadlessSnapshot → @xterm/headless`. Verified with esbuild metafiles: main-graph references to `@xterm/headless` drop from present → **0**, while `SessionPipe` (daemon bundle) still resolves it (4 refs).

## 2. Baseline (macos-14) — flaky attach-snapshot delta test

`bytes arriving DURING the parse ship as a delta before FLUSH_DONE` injected the live marker via a wall-clock `sleep(30)`, racing the shared concurrency-1 snapshot queue — the parse could finish outside the window on slower runners (green on ubuntu/windows/local, red on macos-14). Switched it to the same `injectAfterFirstReadAll` hook the failed-parse and no-gain delta tests already use, making it deterministic. Product code unchanged.

## Verify
- `tsc --noEmit` clean; daemon suite 1272 passed; delta test 3× green
- esbuild metafile trace confirms the main bundle no longer references `@xterm/headless`