### PR TITLE
test: harden TTL and Windows symlink cases

### DIFF
--- a/src/daemon/__tests__/legacyCompat.test.ts
+++ b/src/daemon/__tests__/legacyCompat.test.ts
@@ -94,6 +94,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
@@ -165,6 +166,11 @@ describe('T14 — legacy data compatibility', () => {
       'utf-8',
     );
 
+    // Keep the detached backup within its 8 h TTL so this case exercises
+    // legacy `.bak` recovery rather than time-based session pruning.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-23T11:00:00.000Z'));
+
     const writer = new StateWriter(tmpDir);
     try {
       const loaded = writer.load();
@@ -174,6 +180,7 @@ describe('T14 — legacy data compatibility', () => {
       expect(loaded.version).toBe(1);
     } finally {
       writer.dispose();
+      vi.useRealTimers();
     }
   });
 

--- a/src/main/ipc/handlers/__tests__/diff.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/diff.handler.test.ts
@@ -364,10 +364,22 @@ describe('diff:read — F3 symlink untracked는 unsupported(repo 밖 노출 차�
   });
   afterEach(() => scn.cleanup());
 
-  it('symlink는 합성하지 않고 unsupported 라벨로 반환', async () => {
+  it('symlink는 합성하지 않고 unsupported 라벨로 반환', async ({ skip }) => {
     // worktree 밖 파일을 가리키는 symlink를 untracked로 생성.
     const outside = join(scn.repoRoot, 'a.txt'); // repo 밖(본 repo)의 실경로.
-    symlinkSync(outside, join(scn.worktreePath, 'link.txt'));
+    try {
+      symlinkSync(outside, join(scn.worktreePath, 'link.txt'));
+    } catch (error) {
+      if (
+        process.platform === 'win32' &&
+        (error as NodeJS.ErrnoException).code === 'EPERM'
+      ) {
+        skip(
+          'Windows symlink creation requires Developer Mode or administrator privileges',
+        );
+      }
+      throw error;
+    }
     const read = captured.get(IPC.DIFF_READ)!;
     const res = (await read({}, scn.worktreePath, scn.targetHeadOid)) as {
       ok: boolean;

--- a/src/main/ipc/handlers/__tests__/diff.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/diff.handler.test.ts
@@ -364,9 +364,9 @@ describe('diff:read — F3 symlink untracked는 unsupported(repo 밖 노출 차�
   });
   afterEach(() => scn.cleanup());
 
-  it('symlink는 합성하지 않고 unsupported 라벨로 반환', async ({ skip }) => {
-    // worktree 밖 파일을 가리키는 symlink를 untracked로 생성.
-    const outside = join(scn.repoRoot, 'a.txt'); // repo 밖(본 repo)의 실경로.
+  it('returns the unsupported label instead of synthesizing a symlink', async ({ skip }) => {
+    // Create an untracked symlink pointing outside the worktree.
+    const outside = join(scn.repoRoot, 'a.txt'); // Path outside the worktree.
     try {
       symlinkSync(outside, join(scn.worktreePath, 'link.txt'));
     } catch (error) {


### PR DESCRIPTION
## Summary

Harden two date- and platform-sensitive integration tests so they remain meaningful across wall-clock time and Windows privilege configurations.

## Changes

- Freeze the legacy single-`.bak` recovery case within the detached session fixture's 8-hour TTL, with defensive timer restoration at both test and suite teardown.
- Dynamically skip the untracked-symlink case only when Windows reports the expected `EPERM` privilege error; all other filesystem errors still fail the test.

## CHANGELOG entry

no CHANGELOG — tests only

## Stability tier impact

- [x] No external surface touched (internal refactor / docs / tests / CI).
- [ ] Additive change to a `stable` surface (new optional param, new field, new event type).
- [ ] Breaking change to a `stable` surface (requires major bump — block until release planning is in scope).
- [ ] Change to an `experimental` surface (note in release notes).
- [ ] Change to an `internal` surface (no contract impact).

## Substrate contract impact (Substrate 3.0)

n/a

## Test plan

- `vitest run src/daemon/__tests__/legacyCompat.test.ts src/main/ipc/handlers/__tests__/diff.handler.test.ts --reporter=verbose` — 32 passed, 1 skipped on Windows without symlink privileges.
- `vitest run --exclude "**/*.runtime.test.ts" --exclude "**/*.runtime.test.tsx" --exclude "**/*.runtime.test.mjs" --maxWorkers 4` — 7,206 passed, 19 skipped.
- `npm run test:runtime` — 22 passed, 3 skipped.
- `tsc --noEmit` — passed.
- `eslint src/daemon/__tests__/legacyCompat.test.ts src/main/ipc/handlers/__tests__/diff.handler.test.ts` — 0 errors; 42 pre-existing non-null-assertion warnings outside the changed lines.
- At the default local worker count, `npm test` reached 7,202–7,204 passing tests before unrelated Git-heavy cases exceeded the fixed 5-second timeout and hit Windows temp-directory `EBUSY`; every reported case passed in isolation, and the complete non-runtime suite passed with four workers as noted above.

## Related issues / PRs

Follow-up test hardening for #560, which fixed #557.

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed.
- [x] Tests cover the new behavior and the regression case (if a bug fix).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by making time-dependent compatibility checks deterministic.
  - Added cleanup to prevent timer state from affecting subsequent tests.
  - Improved Windows compatibility by gracefully skipping symlink checks when required permissions are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->