### PR TITLE
fix(cli-shim): fail closed on an untrusted PATH read instead of wiping the user PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Installing wmux can no longer wipe your entire user PATH.** On a machine where PowerShell runs in ConstrainedLanguage — how AppLocker/WDAC lock down enterprise Windows — the CLI shim's PATH edit could replace all of `HKCU\Environment\Path` with a single entry, the wmux `bin` directory. Every other entry was destroyed and unrecoverable: npm-global CLIs (`%APPDATA%\npm`), toolchains, everything user-scoped. The cause was an asymmetry rather than an overwrite: the script *read* the registry with a .NET method call (blocked in ConstrainedLanguage) but *wrote* it back with a cmdlet (not blocked), and with no `$ErrorActionPreference = 'Stop'` it sailed past both read errors, resolved the current PATH to empty, and persisted the bin directory as the whole thing. The edit is now fail-closed and, more importantly, actually works under ConstrainedLanguage: the raw value is read via `reg.exe`, which is immune to language mode and — unlike `Get-ItemProperty` — does not expand `%VAR%` entries and bake them in. If every read strategy fails the registry is left untouched, a structural invariant aborts any edit that would drop an entry other than the bin directory, the pre-edit value is backed up to `HKCU:\Software\wmux\UserPathBackup`, and the cosmetic `WM_SETTINGCHANGE` broadcast can no longer report a successful write as a failure. The source-build `install.ps1` path was verified unaffected. (#573)
+
 ## [3.32.0] — 2026-07-24
 
 ### Added

--- a/src/main/__tests__/cliShim.test.ts
+++ b/src/main/__tests__/cliShim.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildShimCmd, buildPathEditScript, deriveShimPaths } from '../cliShim';
+import { buildShimCmd, buildPathEditScript, deriveShimPaths, explainPathEditExit } from '../cliShim';
 
 describe('buildShimCmd', () => {
   it('discovers app-* dynamically, scopes ELECTRON_RUN_AS_NODE, and forwards args + exit code', () => {
@@ -40,7 +40,7 @@ describe('buildPathEditScript', () => {
     expect(script).toContain("'Environment'");
     // Idempotency: only writes when membership actually changes
     expect(script).toContain('if (-not $hit) { $parts += $bin; $changed = $true }');
-    expect(script).toContain('if ($changed) {');
+    expect(script).toContain('if (-not $changed) { exit 0 }');
   });
 
   it('remove: filters only the exact bin entry', () => {
@@ -62,6 +62,81 @@ describe('buildPathEditScript', () => {
       expect(script).not.toContain('SetEnvironmentVariable');
     }
   });
+
+  // Regression: the original script read the registry with a .NET method call
+  // and wrote it back with a cmdlet. Under ConstrainedLanguage the read throws
+  // but the write succeeds, so the user's entire PATH was replaced by binDir.
+  describe('fail-closed guarantees', () => {
+    for (const op of ['add', 'remove'] as const) {
+      it(`${op}: refuses to write on an untrusted read`, () => {
+        const script = buildPathEditScript('C:\\wmux\\bin', op);
+        // Errors must not be swallowed into a subsequent write.
+        expect(script.split('\n')[0]).toBe(`$ErrorActionPreference = 'Stop'`);
+        // The .NET read is wrapped, and a failure leaves $cur null...
+        expect(script).toContain('} catch { $cur = $null }');
+        // ...which bails out before any Set-ItemProperty.
+        expect(script).toContain('if ($null -eq $cur) { exit 10 }');
+        expect(script.indexOf('if ($null -eq $cur) { exit 10 }')).toBeLessThan(
+          script.indexOf('Set-ItemProperty'),
+        );
+      });
+
+      it(`${op}: asserts no unrelated entry is dropped before writing`, () => {
+        const script = buildPathEditScript('C:\\wmux\\bin', op);
+        expect(script).toContain('$orig = @($parts)');
+        expect(script).toContain('if ($lost.Count -gt 0) { exit 11 }');
+        expect(script.indexOf('exit 11')).toBeLessThan(script.indexOf('Set-ItemProperty'));
+      });
+    }
+
+    it('falls back to reg.exe, which survives ConstrainedLanguage and stays unexpanded', () => {
+      const script = buildPathEditScript('C:\\wmux\\bin', 'add');
+      expect(script).toContain('reg.exe');
+      // Get-ItemProperty would EXPAND %VAR% and bake it in — must not be the reader.
+      expect(script).not.toContain('Get-ItemProperty');
+      // Whole-key query, so "no Path value" is distinguishable from "unreadable".
+      expect(script).toContain(`query 'HKCU\\Environment'`);
+      expect(script).not.toContain('/v Path');
+    });
+
+    it('backs up the previous value outside HKCU:\\Environment', () => {
+      const script = buildPathEditScript('C:\\wmux\\bin', 'add');
+      expect(script).toContain(`Set-ItemProperty -Path 'HKCU:\\Software\\wmux' -Name 'UserPathBackup'`);
+      // A stray value under Environment would become a real env var.
+      expect(script).not.toContain(`-Path 'HKCU:\\Environment' -Name 'UserPathBackup'`);
+    });
+
+    it('isolates the WM_SETTINGCHANGE broadcast so it cannot mask a good write', () => {
+      const script = buildPathEditScript('C:\\wmux\\bin', 'add');
+      const write = script.indexOf(`-Name 'Path'`);
+      const broadcast = script.indexOf('Add-Type');
+      expect(write).toBeLessThan(broadcast);
+      expect(script.slice(broadcast)).toContain('} catch { }');
+      expect(script.trimEnd().endsWith('exit 0')).toBe(true);
+    });
+
+    it('subKey redirects every registry site together', () => {
+      const script = buildPathEditScript('C:\\wmux\\bin', 'add', 'Software\\wmux-test');
+      expect(script).toContain(`OpenSubKey('Software\\wmux-test'`);
+      expect(script).toContain(`query 'HKCU\\Software\\wmux-test'`);
+      expect(script).toContain(`Set-ItemProperty -Path 'HKCU:\\Software\\wmux-test' -Name 'Path'`);
+      // No registry site may still point at the real Environment key. (The bare
+      // literal 'Environment' legitimately remains as the WM_SETTINGCHANGE lParam.)
+      expect(script).not.toContain(`OpenSubKey('Environment'`);
+      expect(script).not.toContain(`query 'HKCU\\Environment'`);
+      expect(script).not.toContain(`-Path 'HKCU:\\Environment'`);
+    });
+  });
+});
+
+describe('explainPathEditExit', () => {
+  it('explains the deliberate bail-outs and nothing else', () => {
+    expect(explainPathEditExit(10, 'C:\\wmux\\bin')).toContain('ConstrainedLanguage');
+    expect(explainPathEditExit(10, 'C:\\wmux\\bin')).toContain('C:\\wmux\\bin');
+    expect(explainPathEditExit(11, 'C:\\wmux\\bin')).toContain('aborted');
+    expect(explainPathEditExit(0, 'C:\\wmux\\bin')).toBeNull();
+    expect(explainPathEditExit(1, 'C:\\wmux\\bin')).toBeNull();
+  });
 });
 
 describe('deriveShimPaths', () => {
@@ -73,6 +148,101 @@ describe('deriveShimPaths', () => {
     expect(cliJsPath).toBe(
       'C:\\Users\\u\\AppData\\Local\\wmux\\app-3.2.0\\resources\\cli-bundle\\index.js',
     );
+  });
+});
+
+// ─── live PATH edit against a throwaway registry key (Windows only) ──────────
+// The string assertions above can only prove the guards are *present*. This
+// runs the real generated script through the real spawn path and asserts the
+// property that actually matters: a pre-existing PATH is never destroyed —
+// including under ConstrainedLanguage, the exact mode that caused the wipe.
+import { execFileSync } from 'child_process';
+
+describe.skipIf(process.platform !== 'win32')('PATH edit (live registry, sandbox key)', () => {
+  const SUB = 'Software\\wmux-cliShim-test';
+  const BAK = 'Software\\wmux-cliShim-test-bak';
+  const BIN = 'C:\\Users\\u\\AppData\\Local\\wmux\\bin';
+  // A %VAR% entry is included on purpose: it must survive unexpanded.
+  const SEED = '%USERPROFILE%\\AppData\\Roaming\\npm;C:\\Program Files\\nodejs';
+  const PS = `${process.env.SystemRoot || 'C:\\Windows'}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
+
+  const ps = (script: string) => {
+    try {
+      return { code: 0, out: execFileSync(PS, ['-NoProfile', '-NonInteractive', '-Command', script], {
+        encoding: 'utf8', windowsHide: true, timeout: 20000,
+      }) };
+    } catch (e) {
+      const err = e as { status?: number; stdout?: string };
+      return { code: err.status ?? -1, out: err.stdout ?? '' };
+    }
+  };
+
+  const seed = () => ps(
+    `if (Test-Path 'HKCU:\\${SUB}') { Remove-Item 'HKCU:\\${SUB}' -Recurse -Force }\n` +
+    `New-Item -Path 'HKCU:\\${SUB}' -Force | Out-Null\n` +
+    `Set-ItemProperty -Path 'HKCU:\\${SUB}' -Name 'Path' -Value '${SEED}' -Type ExpandString`,
+  );
+
+  /** Raw (unexpanded) current value of the sandbox Path, via reg.exe. */
+  const readRaw = () => {
+    const out = ps(`& "$env:SystemRoot\\System32\\reg.exe" query 'HKCU\\${SUB}' /v Path`).out;
+    const m = out.match(/^\s+Path\s+REG_\S+\s{4}(.*)$/m);
+    return m ? m[1].trim() : null;
+  };
+
+  const run = (op: 'add' | 'remove', constrained: boolean) => {
+    const prefix = constrained ? `$ExecutionContext.SessionState.LanguageMode = 'ConstrainedLanguage'\n` : '';
+    return ps(prefix + buildPathEditScript(BIN, op, SUB, BAK));
+  };
+
+  afterEach(() => {
+    ps(`Remove-Item 'HKCU:\\${SUB}' -Recurse -Force -ErrorAction SilentlyContinue\n` +
+       `Remove-Item 'HKCU:\\${BAK}' -Recurse -Force -ErrorAction SilentlyContinue`);
+  });
+
+  for (const constrained of [false, true]) {
+    const mode = constrained ? 'ConstrainedLanguage' : 'FullLanguage';
+
+    it(`${mode}: add appends without destroying existing entries`, () => {
+      seed();
+      const r = run('add', constrained);
+      const after = readRaw();
+      expect(r.code).toBe(0);
+      // Every seeded entry survives, unexpanded, in order — and bin is appended.
+      expect(after).toBe(`${SEED};${BIN}`);
+      expect(after).toContain('%USERPROFILE%');
+    });
+
+    it(`${mode}: add is idempotent`, () => {
+      seed();
+      expect(run('add', constrained).code).toBe(0);
+      expect(run('add', constrained).code).toBe(0);
+      expect(readRaw()).toBe(`${SEED};${BIN}`);
+    });
+
+    it(`${mode}: remove strips only the bin entry`, () => {
+      seed();
+      run('add', constrained);
+      expect(run('remove', constrained).code).toBe(0);
+      expect(readRaw()).toBe(SEED);
+    });
+  }
+
+  it('an unreadable key fails closed: exits READ_FAILED and writes nothing', () => {
+    // No sandbox key at all — both readers must fail rather than invent an empty PATH.
+    ps(`Remove-Item 'HKCU:\\${SUB}' -Recurse -Force -ErrorAction SilentlyContinue`);
+    const r = ps(buildPathEditScript(BIN, 'add', SUB, BAK));
+    expect(r.code).toBe(10);
+    expect(explainPathEditExit(r.code, BIN)).toContain('ConstrainedLanguage');
+    // Crucially: the key was NOT created as a side effect of the failed edit.
+    expect(readRaw()).toBeNull();
+  });
+
+  it('backs the previous value up before writing', () => {
+    seed();
+    run('add', false);
+    const bak = ps(`(Get-ItemProperty -Path 'HKCU:\\${BAK}' -Name 'UserPathBackup').UserPathBackup`).out.trim();
+    expect(bak).toBe(SEED);
   });
 });
 

--- a/src/main/__tests__/cliShim.test.ts
+++ b/src/main/__tests__/cliShim.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { buildShimCmd, buildPathEditScript, deriveShimPaths, explainPathEditExit } from '../cliShim';
+import {
+  buildShimCmd,
+  buildPathEditScript,
+  deriveShimPaths,
+  explainPathEditExit,
+  PATH_EDIT_EXIT,
+} from '../cliShim';
 
 describe('buildShimCmd', () => {
   it('discovers app-* dynamically, scopes ELECTRON_RUN_AS_NODE, and forwards args + exit code', () => {
@@ -226,24 +232,26 @@ describe.skipIf(process.platform !== 'win32')('PATH edit (live registry, sandbox
       expect(run('remove', constrained).code).toBe(0);
       expect(readRaw()).toBe(SEED);
     });
+
+    it(`${mode}: an unreadable key fails closed — exits READ_FAILED and writes nothing`, () => {
+      // No sandbox key at all — both readers must fail rather than invent an empty PATH.
+      ps(`Remove-Item 'HKCU:\\${SUB}' -Recurse -Force -ErrorAction SilentlyContinue`);
+      const r = run('add', constrained);
+      expect(r.code).toBe(PATH_EDIT_EXIT.READ_FAILED);
+      expect(explainPathEditExit(r.code, BIN)).toContain('ConstrainedLanguage');
+      // Crucially: the key was NOT created as a side effect of the failed edit.
+      expect(readRaw()).toBeNull();
+    });
+
+    it(`${mode}: backs the previous value up before writing`, () => {
+      seed();
+      expect(run('add', constrained).code).toBe(0);
+      // Read back from the harness (always FullLanguage) — this asserts what the
+      // script wrote, not how it read.
+      const bak = ps(`(Get-ItemProperty -Path 'HKCU:\\${BAK}' -Name 'UserPathBackup').UserPathBackup`).out.trim();
+      expect(bak).toBe(SEED);
+    });
   }
-
-  it('an unreadable key fails closed: exits READ_FAILED and writes nothing', () => {
-    // No sandbox key at all — both readers must fail rather than invent an empty PATH.
-    ps(`Remove-Item 'HKCU:\\${SUB}' -Recurse -Force -ErrorAction SilentlyContinue`);
-    const r = ps(buildPathEditScript(BIN, 'add', SUB, BAK));
-    expect(r.code).toBe(10);
-    expect(explainPathEditExit(r.code, BIN)).toContain('ConstrainedLanguage');
-    // Crucially: the key was NOT created as a side effect of the failed edit.
-    expect(readRaw()).toBeNull();
-  });
-
-  it('backs the previous value up before writing', () => {
-    seed();
-    run('add', false);
-    const bak = ps(`(Get-ItemProperty -Path 'HKCU:\\${BAK}' -Name 'UserPathBackup').UserPathBackup`).out.trim();
-    expect(bak).toBe(SEED);
-  });
 });
 
 // ─── darwin CLI shim (P3) ────────────────────────────────────────────────────

--- a/src/main/cliShim.ts
+++ b/src/main/cliShim.ts
@@ -15,13 +15,37 @@
  * PATH editing runs as ONE PowerShell invocation per operation (Squirrel
  * event handlers must not stall on serial spawns) and goes through the raw
  * registry, not [Environment]::Get/SetEnvironmentVariable:
- *   - read with GetValue(..., DoNotExpandEnvironmentNames) so existing
- *     `%VAR%` entries are NOT expanded-and-baked-in on rewrite,
+ *   - read the raw value so existing `%VAR%` entries are NOT
+ *     expanded-and-baked-in on rewrite,
  *   - write with Set-ItemProperty -Type ExpandString so REG_EXPAND_SZ is
  *     preserved (SetEnvironmentVariable demotes to REG_SZ),
  *   - broadcast WM_SETTINGCHANGE so newly opened shells see the change
  *     (a bare registry write never notifies Explorer).
  * `setx` is avoided entirely — it truncates values over 1024 chars.
+ *
+ * The PATH edit is a read-modify-write against a value whose loss is
+ * unrecoverable, so it is built to FAIL CLOSED. Every rule below exists
+ * because the original version violated it and wiped user PATHs outright:
+ *
+ *   1. The write only ever runs on a *trusted* read. `[Microsoft.Win32.Registry]`
+ *      method calls throw under ConstrainedLanguage (AppLocker/WDAC lock down
+ *      enterprise machines this way), but `Set-ItemProperty` keeps working —
+ *      so a script that reads with .NET and writes with a cmdlet silently
+ *      resolves the current PATH to empty and then persists `<binDir>` as the
+ *      user's ENTIRE PATH. `reg.exe` is an external process, so it is immune
+ *      to language mode AND returns the raw (unexpanded) value, which
+ *      `Get-ItemProperty` does not. It is the fallback reader; when both
+ *      readers fail we exit without touching the registry.
+ *   2. A structural invariant is asserted between the read and the write: no
+ *      pre-existing entry other than `binDir` may disappear. Any future bug
+ *      that resolves the current PATH to the wrong thing aborts here instead
+ *      of persisting.
+ *   3. The pre-edit raw value is copied to HKCU:\Software\wmux\UserPathBackup
+ *      first (NOT into HKCU:\Environment, where a stray value would become a
+ *      bogus environment variable).
+ *   4. The WM_SETTINGCHANGE broadcast is best-effort and isolated: `Add-Type`
+ *      is blocked under ConstrainedLanguage, and a cosmetic notification
+ *      failure must not be reported as an edit failure.
  */
 
 import * as fs from 'fs';
@@ -59,6 +83,17 @@ export function buildShimCmd(): string {
 }
 
 /**
+ * Exit codes from the PATH edit script. Anything non-zero other than these is
+ * an unexpected PowerShell failure. All of them mean "registry NOT modified".
+ */
+export const PATH_EDIT_EXIT = {
+  /** Registry unreadable by both strategies — refused to write. */
+  READ_FAILED: 10,
+  /** Computed result would have dropped unrelated entries — refused to write. */
+  INVARIANT_VIOLATED: 11,
+} as const;
+
+/**
  * One-shot PowerShell script that adds/removes `binDir` on the user Path.
  *
  * The membership test is an exact, case-insensitive string match (PowerShell
@@ -66,31 +101,103 @@ export function buildShimCmd(): string {
  * the identical literal from deriveShimPaths, so no normalization beyond
  * trailing-separator trim is needed — and entries we did NOT add are passed
  * through byte-for-byte (quotes, `%VAR%` tokens and all).
+ *
+ * See the module header for why the read/write asymmetry below is load-bearing.
+ *
+ * `subKey`/`backupSubKey` exist so the regression test can execute the real
+ * script against throwaway HKCU subkeys instead of the user's actual
+ * Environment. Production callers must never pass them.
  */
-export function buildPathEditScript(binDir: string, op: 'add' | 'remove'): string {
+export function buildPathEditScript(
+  binDir: string,
+  op: 'add' | 'remove',
+  subKey = 'Environment',
+  backupSubKey = 'Software\\wmux',
+): string {
   const escaped = binDir.replace(/'/g, "''");
+  // PowerShell single-quoted literals treat `\` literally, so only `'` needs escaping.
+  const key = subKey.replace(/'/g, "''");
+  const bakKey = backupSubKey.replace(/'/g, "''");
   const mutate =
     op === 'add'
       ? `if (-not $hit) { $parts += $bin; $changed = $true }`
       : `if ($hit) { $parts = @($parts | Where-Object { $_.TrimEnd('\\','/') -ne $bin }); $changed = $true }`;
   return [
+    `$ErrorActionPreference = 'Stop'`,
     `$bin = '${escaped}'.TrimEnd('\\','/')`,
-    // Raw (unexpanded) read — keeps %VAR% entries intact across the rewrite.
-    `$key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)`,
-    `$cur = [string]$key.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)`,
+    ``,
+    // ── Read the CURRENT raw user Path ──────────────────────────────────────
+    // Strategy 1 (fast path): .NET raw read. Throws under ConstrainedLanguage.
+    `$cur = $null`,
+    `try {`,
+    `  $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('${key}', $false)`,
+    `  if ($null -ne $key) {`,
+    `    $cur = [string]$key.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)`,
+    `  }`,
+    `} catch { $cur = $null }`,
+    ``,
+    // Strategy 2: reg.exe — immune to language mode, and unlike Get-ItemProperty
+    // it returns the value UNEXPANDED, so %VAR% entries survive the rewrite.
+    // Queries the whole key (not /v Path) so "value absent" is distinguishable
+    // from "key unreadable": a fresh profile legitimately has no user Path.
+    `if ($null -eq $cur) {`,
+    `  try {`,
+    `    $prevEap = $ErrorActionPreference`,
+    `    $ErrorActionPreference = 'Continue'`,
+    `    $out = & "$env:SystemRoot\\System32\\reg.exe" query 'HKCU\\${key}' 2>$null`,
+    `    $rc = $LASTEXITCODE`,
+    `    $ErrorActionPreference = $prevEap`,
+    `    if ($rc -eq 0) {`,
+    `      $cur = ''`,
+    `      foreach ($line in $out) {`,
+    `        if ($line -match '^\\s+Path\\s+(REG_\\S+)\\s{4}(.*)$') {`,
+    // An unexpected value type means we do not understand the current state.
+    `          if ($matches[1] -ne 'REG_EXPAND_SZ' -and $matches[1] -ne 'REG_SZ') { exit ${PATH_EDIT_EXIT.READ_FAILED} }`,
+    `          $cur = $matches[2]`,
+    `          break`,
+    `        }`,
+    `      }`,
+    `    }`,
+    `  } catch { $cur = $null }`,
+    `}`,
+    // Fail closed: never derive a write from a read that did not happen.
+    `if ($null -eq $cur) { exit ${PATH_EDIT_EXIT.READ_FAILED} }`,
+    ``,
+    // ── Compute the edit ────────────────────────────────────────────────────
     `$parts = @($cur -split ';' | Where-Object { $_.Trim().Length -gt 0 })`,
+    `$orig = @($parts)`,
     `$hit = [bool]($parts | Where-Object { $_.TrimEnd('\\','/') -eq $bin })`,
     `$changed = $false`,
     mutate,
-    `if ($changed) {`,
+    `if (-not $changed) { exit 0 }`,
+    ``,
+    // ── Invariant: this edit may only ever touch $bin ────────────────────────
+    `$lost = @($orig | Where-Object { $_.TrimEnd('\\','/') -ne $bin } | Where-Object { $parts -notcontains $_ })`,
+    `if ($lost.Count -gt 0) { exit ${PATH_EDIT_EXIT.INVARIANT_VIOLATED} }`,
+    op === 'add'
+      ? `if ($parts -notcontains $bin) { exit ${PATH_EDIT_EXIT.INVARIANT_VIOLATED} }`
+      : `if ($parts | Where-Object { $_.TrimEnd('\\','/') -eq $bin }) { exit ${PATH_EDIT_EXIT.INVARIANT_VIOLATED} }`,
+    ``,
+    // ── Back up, then write ─────────────────────────────────────────────────
+    // Backup lives under Software\wmux, NOT Environment: any value written
+    // there becomes a real environment variable for the user.
+    `try {`,
+    `  if (-not (Test-Path 'HKCU:\\${bakKey}')) { New-Item -Path 'HKCU:\\${bakKey}' -Force | Out-Null }`,
+    `  Set-ItemProperty -Path 'HKCU:\\${bakKey}' -Name 'UserPathBackup' -Value $cur -Type String`,
+    `} catch { }`,
     // ExpandString == REG_EXPAND_SZ — SetEnvironmentVariable would demote to REG_SZ.
-    `  Set-ItemProperty -Path 'HKCU:\\Environment' -Name 'Path' -Value ($parts -join ';') -Type ExpandString`,
-    // WM_SETTINGCHANGE broadcast so new shells pick the change up without relogin.
+    `Set-ItemProperty -Path 'HKCU:\\${key}' -Name 'Path' -Value ($parts -join ';') -Type ExpandString`,
+    ``,
+    // WM_SETTINGCHANGE broadcast so new shells pick the change up without
+    // relogin. Cosmetic and Add-Type is blocked under ConstrainedLanguage, so
+    // its failure must never mask a successful write.
+    `try {`,
     `  $sig = '[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)] public static extern System.IntPtr SendMessageTimeout(System.IntPtr hWnd, uint Msg, System.UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out System.UIntPtr lpdwResult);'`,
     `  $w = Add-Type -MemberDefinition $sig -Name 'Win32SendMessageTimeout' -Namespace 'Wmux' -PassThru`,
     `  [System.UIntPtr]$res = [System.UIntPtr]::Zero`,
     `  $null = $w::SendMessageTimeout([System.IntPtr]0xffff, 0x1A, [System.UIntPtr]::Zero, 'Environment', 2, 5000, [ref]$res)`,
-    `}`,
+    `} catch { }`,
+    `exit 0`,
   ].join('\n');
 }
 
@@ -104,12 +211,47 @@ function powershellExe(): string {
   );
 }
 
+/**
+ * Human-readable explanation for a PATH edit that refused to run, or null when
+ * the exit code is not one of our deliberate fail-closed bail-outs.
+ */
+export function explainPathEditExit(code: number, binDir: string): string | null {
+  switch (code) {
+    case PATH_EDIT_EXIT.READ_FAILED:
+      return (
+        `could not read the current user PATH from the registry, so it was left ` +
+        `untouched. This usually means PowerShell is locked to ConstrainedLanguage ` +
+        `by AppLocker/WDAC policy. Add "${binDir}" to your PATH manually to use the ` +
+        `wmux CLI.`
+      );
+    case PATH_EDIT_EXIT.INVARIANT_VIOLATED:
+      return (
+        `the computed PATH would have dropped unrelated entries, so the edit was ` +
+        `aborted and the registry left untouched. Add "${binDir}" to your PATH manually.`
+      );
+    default:
+      return null;
+  }
+}
+
 function runPathEdit(binDir: string, op: 'add' | 'remove'): void {
-  execFileSync(
-    powershellExe(),
-    ['-NoProfile', '-NonInteractive', '-Command', buildPathEditScript(binDir, op)],
-    { encoding: 'utf8', windowsHide: true, timeout: 20000 },
-  );
+  try {
+    execFileSync(
+      powershellExe(),
+      ['-NoProfile', '-NonInteractive', '-Command', buildPathEditScript(binDir, op)],
+      { encoding: 'utf8', windowsHide: true, timeout: 20000 },
+    );
+  } catch (err) {
+    const code = (err as { status?: number }).status;
+    const explained = typeof code === 'number' ? explainPathEditExit(code, binDir) : null;
+    // A deliberate bail-out is a warning, not a failure: the registry is intact
+    // and the only cost is that the CLI is not on PATH yet.
+    if (explained) {
+      console.warn(`[cliShim] PATH ${op} skipped — ${explained}`);
+      return;
+    }
+    throw err;
+  }
 }
 
 export interface ShimPaths {


### PR DESCRIPTION
Closes #573.

Installing wmux on a machine where PowerShell runs in **ConstrainedLanguage** (AppLocker/WDAC — standard enterprise lockdown) replaced all of `HKCU\Environment\Path` with a single entry, the wmux `bin` directory. Every pre-existing user PATH entry was destroyed, unrecoverably.

## Root cause

Not an overwrite, and not `setx` — there is no `setx` in the repo. The bug is an **asymmetry between how the script reads and how it writes**:

```powershell
$key   = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)   # .NET  — blocked
$cur   = [string]$key.GetValue('Path', '', [...]::DoNotExpandEnvironmentNames)      # .NET  — blocked
$parts = @($cur -split ';' | Where-Object { $_.Trim().Length -gt 0 })               # → @()
if (-not $hit) { $parts += $bin; $changed = $true }                                 # → @($bin)
Set-ItemProperty -Path 'HKCU:\Environment' ... -Type ExpandString                   # cmdlet — NOT blocked
```

ConstrainedLanguage blocks arbitrary .NET method invocation but leaves cmdlets working. With no `$ErrorActionPreference = 'Stop'` and no `try`/`catch`, execution sails past `MethodInvocationNotSupportedInConstrainedLanguage` and the follow-on `InvokeMethodOnNull`, resolves the current PATH to an empty array, and persists `$bin` as the user's entire PATH — as `REG_EXPAND_SZ`, matching the reported registry evidence exactly.

The defect class is *a read-modify-write whose read can fail silently and whose write proceeds anyway*. ConstrainedLanguage is the field trigger; a null key or a denied ACL produces the same wipe.

## Approach

`reg.exe` is an external process, so it is immune to language mode, and unlike `Get-ItemProperty` it returns the value **raw and unexpanded**. Using it as the read fallback means the edit now *works correctly* under ConstrainedLanguage rather than merely failing safely.

Two alternatives were evaluated and rejected:

- `[Environment]::Get/SetEnvironmentVariable` — the natural-looking fix, but `SetEnvironmentVariable` demotes `REG_EXPAND_SZ` → `REG_SZ`, permanently baking in the user's `%VAR%` entries; and `System.Environment` is itself a .NET type, so both calls are blocked under ConstrainedLanguage anyway (verified). It would fail identically.
- `Get-ItemProperty` as the reader — works under ConstrainedLanguage, but **expands** `REG_EXPAND_SZ`, rewriting `%USERPROFILE%\...` as a literal path.

## Changes

`src/main/cliShim.ts` — every guard below corresponds to a rule the original violated:

1. **Fail closed.** `$ErrorActionPreference = 'Stop'`, explicit `try`/`catch` around each reader, and if *both* fail the script exits `READ_FAILED` (10) without touching the registry. The whole-key `reg query` (rather than `/v Path`) keeps "value absent on a fresh profile" distinguishable from "key unreadable".
2. **Structural invariant.** Between read and write, assert that no pre-existing entry other than `binDir` disappears; otherwise exit `INVARIANT_VIOLATED` (11). A future bug that mis-resolves the current PATH aborts here instead of persisting.
3. **Backup.** The pre-edit raw value is copied to `HKCU:\Software\wmux\UserPathBackup` first — deliberately *not* under `HKCU:\Environment`, where a stray value would become a real environment variable for the user.
4. **Isolated broadcast.** `Add-Type` is blocked under ConstrainedLanguage, and the `WM_SETTINGCHANGE` call was making the process exit non-zero even when the write had succeeded. It is now best-effort and cannot mask a good write.
5. `explainPathEditExit()` turns a deliberate bail-out into an actionable warning ("add `<binDir>` to your PATH manually") instead of an opaque `execFileSync` throw; unexpected failures still propagate.

## Testing

`buildPathEditScript` gains test-only `subKey` / `backupSubKey` seams so the regression test can run **the real generated script through the real `execFileSync` spawn path** against a throwaway HKCU key — proving the property that matters, not just that a guard string is present.

Seeded with `C:\Program Files\Git\cmd;%USERPROFILE%\AppData\Roaming\npm;C:\Program Files\nodejs;C:\Windows\System32`:

| Mode | before this PR | after |
| --- | --- | --- |
| FullLanguage | appended correctly | appended correctly |
| **ConstrainedLanguage** | **`Path` = `…\wmux\bin`, 4/4 entries destroyed** | appended correctly, `%USERPROFILE%` preserved unexpanded |

Live tests cover, under **both** language modes: add appends without loss, add is idempotent, remove strips only the bin entry — plus an unreadable key exiting `READ_FAILED` while creating nothing, and the backup being written. `describe.skipIf(process.platform !== 'win32')` keeps the macOS/Linux CI baseline green.

```
Tests  23 passed | 8 skipped (31)     # 8 skipped = existing darwin suite
tsc --noEmit: clean
eslint: 0 errors (4 pre-existing duplicate-import warnings, unchanged)
```

## Scope

`src/` contains exactly one registry write, so the blast radius is this file. `install.ps1` (source-build path) looks like the same shape but was verified **not** destructive: its `GetEnvironmentVariable` / `SetEnvironmentVariable` are both `System.Environment` statics, so under ConstrainedLanguage they block together and no write occurs.

Users already hit by this cannot be repaired by wmux — the old code kept no backup. Recovery guidance is in #573; a `wmux doctor` detector is noted there as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows installer PATH updates in PowerShell constrained environments by failing safely when PATH cannot be reliably read.
  * Prevents existing PATH entries from being overwritten or truncated; ensures only the wmux shim entry can be changed.
  * Adds a backup of the prior PATH before applying updates.
  * Corrected installer status/reporting behavior tied to the environment-change broadcast.
* **Tests**
  * Expanded unit coverage for generated PATH-edit behavior and added a Windows integration-style validation for constrained and normal modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->