### PR TITLE
test(cli-shim): raise live-registry PATH suite timeout above PowerShell cold start

### DIFF
--- a/src/main/__tests__/cliShim.test.ts
+++ b/src/main/__tests__/cliShim.test.ts
@@ -164,7 +164,12 @@ describe('deriveShimPaths', () => {
 // including under ConstrainedLanguage, the exact mode that caused the wipe.
 import { execFileSync } from 'child_process';
 
-describe.skipIf(process.platform !== 'win32')('PATH edit (live registry, sandbox key)', () => {
+// Each case spawns real powershell.exe + reg.exe. On a busy Windows CI runner
+// the FIRST case pays the one-time PowerShell cold-start and lands just over
+// vitest's 5s default (observed 5.6s in CI while its siblings ran 1–2s), so it
+// flakes intermittently. Raise the per-test budget for the whole suite — these
+// are the slowest tests here anyway, and a genuinely hung reg.exe still fails.
+describe.skipIf(process.platform !== 'win32')('PATH edit (live registry, sandbox key)', { timeout: 15_000 }, () => {
   const SUB = 'Software\\wmux-cliShim-test';
   const BAK = 'Software\\wmux-cliShim-test-bak';
   const BIN = 'C:\\Users\\u\\AppData\\Local\\wmux\\bin';


### PR DESCRIPTION
## Summary

Fixes the intermittent `Baseline (windows-latest)` / `validate` failure tracked in #576: the `PATH edit (live registry, sandbox key)` suite in `cliShim.test.ts` flakes because its **first** case pays the one-time `powershell.exe` cold-start and lands just over vitest's 5s default. The assertion never runs — it is a harness-margin issue, not a product regression.

Closes #576.

## Change

One line, plus a comment. The suite gets a 15s per-test budget:

```ts
describe.skipIf(process.platform !== 'win32')('PATH edit (live registry, sandbox key)', { timeout: 15_000 }, () => {
```

Applied to the suite rather than the single case because more than one case in it goes slow under load — but the CI failure is always the first one, which is the only one that pays cold start.

## Why 15s

The maintainer triage on #576 suggested 10–15s; this takes the top of that range. Grounding:

- In CI the failing case measured **5.6s**; its nine siblings ran **1.1–2.3s**. 15s is ~2.7× the observed worst case.
- Under pathological local full-suite parallelism (my machine, all cores busy) I saw individual cases reach ~25s, but that contention is worse than a CI runner's and is not representative — I mention it only so the number is on the table. If you'd prefer more headroom it is a one-character change; I erred toward keeping hang-detection tight rather than padding it.
- A genuinely hung `reg.exe` still fails well inside 15s, so this does not mask a real defect.

## The one trap here

The options object must be the **second** argument: `describe(name, { timeout }, fn)`. vitest 4 **removed** the trailing-options signature — passing it after the callback is a hard `TypeError` that fails collection for the whole file, not a silently ignored option:

```
TypeError: Signature "test(name, fn, { ... })" was deprecated in Vitest 3 and
removed in Vitest 4. Please, provide options as a second argument instead.
```

I verified both the working form and the failing 3rd-arg form against this repo's vitest 4.1.0 before writing it.

## Test plan

- `npx vitest run src/main/__tests__/cliShim.test.ts` on **Windows** → **25 passed / 8 skipped** (the 8 are the Darwin-only `installCliShimDarwin` suite, correctly skipped on win32). The live-registry cases exercise a throwaway `HKCU\Software\wmux-cliShim-test` key and clean up after themselves.
- `tsc --noEmit` → clean.
- `git diff --check` → clean.

## Stability tier impact

- [x] No external surface touched (test-only).

## Substrate contract impact

n/a — test-only.

## Related issues / PRs

Closes #576. The flake was surfaced during CI on #575 (now merged).

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a. — n/a, test-only, no user-visible behavior.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs updated if the surface changed. — n/a.
- [x] Tests cover the new behavior and the regression case. — this *is* the test change; verified passing on Windows.
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout for a Windows-specific integration test to reduce intermittent failures on slower environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->