### PR TITLE
fix(browser): scope browser.cdp.info target list to the caller's workspace (#580 disclosure leg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`browser_close` can no longer close another workspace's browser by surface id.** Closing by an explicit `surfaceId` searched every workspace, so a caller in workspace A could tear down workspace B's browser if it learned B's id (composing with the cross-workspace target ids `browser.cdp.info` still exposes — [#580](https://github.com/openwong2kim/wmux/issues/580)). An explicit `surfaceId` is now scoped to the caller's own workspace and fails closed when caller identity is absent, rather than falling back to whichever workspace is on screen — matching the boundary `browser_tabs` already enforces. The surface-id-less "close the browser pane" convenience is unchanged. This closes the destructive half of #580; scoping the `browser.cdp.info` disclosure itself is tracked separately. (#580)
 
+- **`browser.cdp.info` no longer volunteers other workspaces' live browser targets.** The internal RPC that the browser automation engine uses to locate a guest returned every registered CDP target — with its surface id and owning workspace — to any `browser.read` caller, which is how a foreign surface id could be discovered in the first place. It now filters that list to the caller's own workspace server-side (the port and app-shell URL, which are workspace-agnostic, are unchanged). This is defense-in-depth within the same single-OS-user trust boundary, not a hard seal: anything holding the shared CDP port can still enumerate targets directly, so sealing that off is left as a larger change. Closes the disclosure half of #580. (#580)
+
 ## [3.32.0] — 2026-07-24
 
 ### Added

--- a/docs/internal/browser-tabs-workspace-contract.md
+++ b/docs/internal/browser-tabs-workspace-contract.md
@@ -317,7 +317,7 @@ Security rules:
 - an older main without workspace ownership support MUST NOT trigger legacy global enumeration; and
 - no action may acquire `withAutomationLease(undefined)`.
 
-These rules bound what **this tool** discloses. They are not a system-wide guarantee that workspace ownership is unobservable: §8.2 records a sibling RPC that still exposes live-target metadata across workspaces.
+These rules bound what **this tool** discloses. They are not a system-wide guarantee that workspace ownership is unobservable: §8.2 records a sibling RPC (`browser.cdp.info`) whose cross-workspace metadata is now scoped as defense-in-depth, but which — like any holder of the shared CDP port — cannot hard-seal enumeration within the same-OS-user trust ceiling.
 
 If a later implementation needs CDP for a specific action, it acquires a lease for the positively owned `surfaceId` only.
 
@@ -403,19 +403,21 @@ That path is not fixed merely by making `browser_tabs select` workspace-scoped. 
 
 This should be confirmed with a focused two-workspace test and, if reproduced, tracked separately rather than silently expanding the #565 implementation.
 
-### 8.2 `browser.cdp.info` still exposes live-target metadata across workspaces
+### 8.2 `browser.cdp.info` cross-workspace target metadata (now scoped, defense-in-depth)
 
-Independent review of the implementation surfaced a pre-existing side channel that §5 does not close, and that a reader could otherwise assume it did.
+Independent review of the implementation surfaced a pre-existing side channel that §5 does not close, and that a reader could otherwise assume it did. Both legs below are now addressed; this section is kept as the record of what the boundary does and does not guarantee.
 
-`browser.cdp.info` (`src/main/pipe/handlers/browser.rpc.ts`) returns every **registered** CDP target with its `surfaceId`, `targetId`, and owning `workspaceId`, unfiltered by caller. Its capability is `browser.read` — an ordinary declarable capability, not `wmux.internal` — so a plugin the user approved for browser reads can enumerate which workspaces currently hold live browser guests, and learn their surface IDs.
+`browser.cdp.info` (`src/main/pipe/handlers/browser.rpc.ts`) used to return every **registered** CDP target with its `surfaceId`, `targetId`, and owning `workspaceId`, unfiltered by caller. Its capability is `browser.read` — an ordinary declarable capability, not `wmux.internal` — so a plugin the user approved for browser reads could enumerate which workspaces held live browser guests, and learn their surface IDs.
 
 It originally composed with a sibling in `browser.close`, which resolved an explicit `surfaceId` across **every** workspace: a caller holding `browser.read` plus `browser.navigate` could read a foreign `surfaceId` out of `browser.cdp.info` and hand it to `browser.close` to destroy another workspace's browser.
 
 **The destructive half is now closed (#580).** `browser.close` scopes an explicit `surfaceId` to the caller's own workspace — through `decideBrowserClose` + the same `closeBrowserTabInWorkspace` helper `browser_tabs` uses — and fails closed when caller identity is absent rather than falling back to the UI-active workspace (§5). This does not reintroduce the old "surface.close lesson" (an explicit ID scoped to the *active* workspace manufacturing false not-founds), because it scopes to the *caller's* workspace, which MCP always supplies and the CLI never reaches with a `surfaceId`. The surface-id-less "close the browser pane" convenience is unchanged.
 
-**The disclosure half remains.** `browser.cdp.info` still returns cross-workspace target metadata, so the read-only enumeration described above is still possible; only the close-based destruction is fixed. Both legs predated #565 and neither was introduced by it. `browser_tabs` never consults `browser.cdp.info` and never leaves the caller's workspace, so its own contract was always unaffected. The exposure is bounded: no URL, title, or page content, and a discarded surface is absent because it holds no registered target. It sits inside the repository's same-OS-user trust ceiling.
+**The disclosure half is now scoped (#580, Option 1).** `browser.cdp.info` accepts the caller's resolved `workspaceId` and filters `targets` to it server-side, marking the response `targetsScoped: true`; `PlaywrightEngine` passes its resolved workspace on every target-reading call, so the RPC no longer volunteers other workspaces' live targets to a caller that identifies itself. `cdpPort` and `shellUrl` stay unscoped because they are workspace-agnostic and load-bearing for shell recognition. A param-less call keeps the legacy unscoped shape, so an older engine still works; the engine uses the `targetsScoped` flag to tell an empty scoped list ("I own no target") from a legacy main that cannot scope.
 
-Closing the disclosure half is a separate change. `browser.cdp.info` is load-bearing for `PlaywrightEngine`'s attach path, which legitimately needs global target data to recognize the app shell, so scoping it needs its own design and its own regression tests. It is tracked in #580.
+This is **defense-in-depth within the same-OS-user trust ceiling, not a hard seal.** As long as `browser.cdp.info` returns `cdpPort`, a holder of it can still enumerate every target by querying the CDP `/json` endpoint directly (the engine itself does exactly that during discovery). Sealing that would mean brokering CDP attach instead of sharing the port — a larger change, out of scope here. What Option 1 removes is the casual/accidental cross-workspace read through the well-behaved RPC path.
+
+Both legs predated #565 and neither was introduced by it. `browser_tabs` never consulted `browser.cdp.info` and never left the caller's workspace, so its own contract was always unaffected. The exposure was already bounded: no URL, title, or page content, and a discarded surface is absent because it holds no registered target.
 
 ### 8.3 Other non-goals
 

--- a/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
@@ -172,6 +172,91 @@ describe('registerBrowserRpc', () => {
     }
   });
 
+  // #580 Option 1: browser.cdp.info filters its target list to the caller's
+  // workspace server-side when a workspaceId is supplied, so the RPC never
+  // volunteers another workspace's live targets to a caller that identifies
+  // itself. cdpPort/shellUrl stay unscoped (workspace-agnostic).
+  describe('browser.cdp.info workspace scoping (#580)', () => {
+    // A three-target catalog spanning two workspaces plus one untagged target.
+    function registerMultiWs(): RpcRouter {
+      const router = new RpcRouter();
+      const webviewCdpManager = {
+        getTarget: vi.fn(),
+        listTargets: vi.fn(() => [
+          { surfaceId: 'surface-a', targetId: 'target-a', workspaceId: 'ws-a' },
+          { surfaceId: 'surface-b', targetId: 'target-b', workspaceId: 'ws-b' },
+          { surfaceId: 'surface-untagged', targetId: 'target-u' },
+        ]),
+        getCdpPort: vi.fn(() => 18800),
+        waitForTarget: vi.fn(),
+        ensureAwake: vi.fn(async () => null),
+        setCaptureCleanup: vi.fn(),
+        withAutomationLease: vi.fn(async (_s: string, fn: () => Promise<unknown>) => fn()),
+        acquireRpcLease: vi.fn(() => 'lease-1'),
+        renewRpcLease: vi.fn(() => true),
+        releaseRpcLease: vi.fn(() => true),
+      };
+      registerBrowserRpc(router, () => null, webviewCdpManager as never);
+      return router;
+    }
+
+    it('filters targets to the caller workspace and marks the response scoped', async () => {
+      const router = registerMultiWs();
+
+      const response = await router.dispatch({
+        id: 'ws1',
+        method: 'browser.cdp.info',
+        params: { workspaceId: 'ws-a' },
+      });
+
+      expect(response.ok).toBe(true);
+      if (response.ok) {
+        expect(response.result).toEqual({
+          cdpPort: 18800,
+          targetsScoped: true,
+          targets: [{ surfaceId: 'surface-a', targetId: 'target-a', workspaceId: 'ws-a' }],
+        });
+        // Neither the foreign nor the untagged target may leak.
+        expect(JSON.stringify(response.result)).not.toContain('surface-b');
+        expect(JSON.stringify(response.result)).not.toContain('surface-untagged');
+      }
+    });
+
+    it('returns an empty scoped list when the caller owns no live target', async () => {
+      const router = registerMultiWs();
+
+      const response = await router.dispatch({
+        id: 'ws2',
+        method: 'browser.cdp.info',
+        params: { workspaceId: 'ws-none' },
+      });
+
+      expect(response.ok).toBe(true);
+      if (response.ok) {
+        // Empty + targetsScoped is the signal the engine reads as "own none",
+        // distinct from a legacy main that cannot scope at all.
+        expect(response.result).toEqual({ cdpPort: 18800, targetsScoped: true, targets: [] });
+      }
+    });
+
+    it('returns every target and no scoped flag when no workspaceId is supplied (legacy)', async () => {
+      const router = registerMultiWs();
+
+      const response = await router.dispatch({
+        id: 'ws3',
+        method: 'browser.cdp.info',
+        params: {},
+      });
+
+      expect(response.ok).toBe(true);
+      if (response.ok) {
+        const result = response.result as { targetsScoped?: boolean; targets: unknown[] };
+        expect(result.targetsScoped).toBeUndefined();
+        expect(result.targets).toHaveLength(3);
+      }
+    });
+  });
+
   it('browser.navigate rejects URLs whose resolved targets are blocked', async () => {
     validateResolvedNavigationUrlMock.mockResolvedValue({
       valid: false,

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -415,9 +415,24 @@ export function registerBrowserRpc(router: RpcRouter, getWindow: GetWindow, webv
   /**
    * browser.cdp.info
    * Returns the CDP port and minimal target metadata required for Playwright attachment.
-   * params: none
+   * params: { workspaceId?: string }
+   *
+   * When a caller passes its resolved `workspaceId`, `targets` is filtered to
+   * that workspace server-side and `targetsScoped: true` is set (#580, Option
+   * 1). This stops the RPC from volunteering other workspaces' live targets to
+   * a caller that identifies itself — defense-in-depth within the same-OS-user
+   * trust ceiling, NOT a hard seal: `cdpPort` is still returned, so a holder of
+   * it can enumerate every target via the CDP `/json` endpoint directly.
+   * `cdpPort` and `shellUrl` are workspace-agnostic and always returned in full.
+   * A param-less call keeps the legacy unscoped shape (no flag) for callers that
+   * only need the port/shell URL.
    */
-  router.register('browser.cdp.info', async () => {
+  router.register('browser.cdp.info', async (params) => {
+    const callerWorkspaceId =
+      typeof params['workspaceId'] === 'string' && params['workspaceId'].length > 0
+        ? params['workspaceId']
+        : undefined;
+
     let targets = webviewCdpManager.listTargets();
 
     // If no targets yet, wait briefly for in-flight registrations to complete.
@@ -426,6 +441,13 @@ export function registerBrowserRpc(router: RpcRouter, getWindow: GetWindow, webv
       await new Promise((r) => setTimeout(r, 1500));
       targets = webviewCdpManager.listTargets();
     }
+
+    // Server-side workspace scoping. An untagged target (older registration
+    // path) is dropped from a scoped response rather than leaked, since it
+    // cannot be proven to belong to the caller.
+    const scopedTargets = callerWorkspaceId
+      ? targets.filter((t) => t.workspaceId === callerWorkspaceId)
+      : targets;
 
     const cdpPort: number = webviewCdpManager.getCdpPort();
 
@@ -444,7 +466,11 @@ export function registerBrowserRpc(router: RpcRouter, getWindow: GetWindow, webv
     return {
       cdpPort,
       ...(shellUrl && { shellUrl }),
-      targets: targets.map((t) => ({
+      // Lets a scoped caller tell "I own no live targets" (empty + scoped) from
+      // "legacy main that can't scope" (empty + unscoped). The engine gates its
+      // leniency fallback on this.
+      ...(callerWorkspaceId && { targetsScoped: true }),
+      targets: scopedTargets.map((t) => ({
         surfaceId: t.surfaceId,
         targetId: t.targetId,
         // Owning workspace (#554) — lets the read path scope page selection to

--- a/src/mcp/playwright/PlaywrightEngine.ts
+++ b/src/mcp/playwright/PlaywrightEngine.ts
@@ -27,6 +27,13 @@ interface CdpInfoResponse {
    * isElectronShellUrl() heuristic. See browser.cdp.info handler.
    */
   shellUrl?: string;
+  /**
+   * True when the main process filtered `targets` to the caller's workspace
+   * (#580, Option 1). Distinguishes an empty scoped list ("caller owns no live
+   * targets") from an older main that cannot scope at all — the leniency
+   * fallback in resolveCallerSurface is gated on its ABSENCE.
+   */
+  targetsScoped?: boolean;
   targets: CdpTargetInfo[];
 }
 
@@ -407,14 +414,27 @@ export class PlaywrightEngine {
 
     let info: CdpInfoResponse;
     try {
-      info = (await sendRpc('browser.cdp.info')) as CdpInfoResponse;
+      // Pass our resolved workspace so main filters `targets` server-side
+      // (#580, Option 1). The response then carries only our own targets.
+      info = (await sendRpc('browser.cdp.info', { workspaceId })) as CdpInfoResponse;
     } catch {
       return { kind: 'unscoped' };
     }
     this.cacheShellUrl(info);
 
-    // Older mains don't tag targets with a workspaceId. If NONE carry one we
-    // cannot scope, so stay lenient rather than fail-closing a working setup.
+    // A main that honored the scope request marks the response `targetsScoped`.
+    // Then an empty list unambiguously means "we own no live target" (kind:
+    // 'none'), and a present one is already ours — no client-side filter needed.
+    if (info.targetsScoped) {
+      const own = info.targets[0];
+      return own
+        ? { kind: 'surface', surfaceId: own.surfaceId, workspaceId }
+        : { kind: 'none', workspaceId };
+    }
+
+    // Legacy path: an older main ignored the param and returned every target.
+    // If NONE carry a workspaceId we cannot scope at all, so stay lenient rather
+    // than fail-closing a working single-workspace setup; otherwise filter here.
     const anyTagged = info.targets.some(
       (t) => typeof t.workspaceId === 'string' && t.workspaceId.length > 0,
     );
@@ -436,22 +456,22 @@ export class PlaywrightEngine {
    */
   private async resolveSelectionContext(
     explicitSurfaceId?: string,
-  ): Promise<{ key: string; surfaceId?: string; callerHasNoSurface: boolean }> {
+  ): Promise<{ key: string; surfaceId?: string; callerHasNoSurface: boolean; workspaceId?: string }> {
     if (explicitSurfaceId) {
       return { key: `surf:${explicitSurfaceId}`, surfaceId: explicitSurfaceId, callerHasNoSurface: false };
     }
     const owned = await this.resolveCallerSurface();
     if (owned.kind === 'surface') {
-      return { key: `ws:${owned.workspaceId}`, surfaceId: owned.surfaceId, callerHasNoSurface: false };
+      return { key: `ws:${owned.workspaceId}`, surfaceId: owned.surfaceId, callerHasNoSurface: false, workspaceId: owned.workspaceId };
     }
     if (owned.kind === 'none') {
-      return { key: `ws:${owned.workspaceId}`, surfaceId: undefined, callerHasNoSurface: true };
+      return { key: `ws:${owned.workspaceId}`, surfaceId: undefined, callerHasNoSurface: true, workspaceId: owned.workspaceId };
     }
     return { key: 'unscoped', surfaceId: undefined, callerHasNoSurface: false };
   }
 
   private async _getPageImpl(
-    ctx: { key: string; surfaceId?: string; callerHasNoSurface: boolean },
+    ctx: { key: string; surfaceId?: string; callerHasNoSurface: boolean; workspaceId?: string },
   ): Promise<Page | null> {
 
     await this.ensureConnected();
@@ -475,7 +495,7 @@ export class PlaywrightEngine {
         // negative "any non-shell page" heuristic, to avoid ever returning the
         // shell when the shell happens to slip past URL classification.
         if (this.browser) {
-          const page = await this.findViaTargetDomain(surfaceId);
+          const page = await this.findViaTargetDomain(surfaceId, ctx.workspaceId);
           if (page) return page;
         }
 
@@ -501,7 +521,7 @@ export class PlaywrightEngine {
 
         // Strategy 3: Use /json endpoint + match registered targets
         if (this.cdpPort) {
-          const page = await this.findViaJsonEndpoint(surfaceId);
+          const page = await this.findViaJsonEndpoint(surfaceId, ctx.workspaceId);
           if (page) return page;
         }
         } // end !callerHasNoSurface
@@ -604,7 +624,7 @@ export class PlaywrightEngine {
   /**
    * Use CDP Target domain to discover webview targets and create a page for them.
    */
-  private async findViaTargetDomain(surfaceId?: string): Promise<Page | null> {
+  private async findViaTargetDomain(surfaceId?: string, workspaceId?: string): Promise<Page | null> {
     if (!this.browser) return null;
 
     try {
@@ -638,8 +658,13 @@ export class PlaywrightEngine {
 
         console.error(`[PlaywrightEngine] CDP targets: ${targetInfos.map(t => `${t.type}:${t.url.substring(0, 40)}`).join(', ')}`);
 
-        // Get registered wmux targets for matching
-        const info = (await sendRpc('browser.cdp.info')) as CdpInfoResponse;
+        // Get registered wmux targets for matching, scoped to the caller's
+        // workspace when known so the no-surfaceId fallback (info.targets[0])
+        // can never resolve to another workspace's guest (#580, Option 1).
+        const info = (await sendRpc(
+          'browser.cdp.info',
+          workspaceId ? { workspaceId } : {},
+        )) as CdpInfoResponse;
         this.cacheShellUrl(info);
         const wmuxTarget = surfaceId
           ? info.targets.find((t) => t.surfaceId === surfaceId)
@@ -710,7 +735,7 @@ export class PlaywrightEngine {
   /**
    * Use the /json HTTP endpoint to find webview targets and attach via CDP.
    */
-  private async findViaJsonEndpoint(surfaceId?: string): Promise<Page | null> {
+  private async findViaJsonEndpoint(surfaceId?: string, workspaceId?: string): Promise<Page | null> {
     if (!this.cdpPort || !this.browser) return null;
 
     try {
@@ -725,8 +750,12 @@ export class PlaywrightEngine {
 
       console.error(`[PlaywrightEngine] /json targets: ${targets.map(t => `${t.type}:${t.url.substring(0, 40)}`).join(', ')}`);
 
-      // Get registered wmux targets
-      const info = (await sendRpc('browser.cdp.info')) as CdpInfoResponse;
+      // Get registered wmux targets, scoped to the caller's workspace when
+      // known so the no-surfaceId fallback can't cross workspaces (#580).
+      const info = (await sendRpc(
+        'browser.cdp.info',
+        workspaceId ? { workspaceId } : {},
+      )) as CdpInfoResponse;
       this.cacheShellUrl(info);
       const wmuxTarget = surfaceId
         ? info.targets.find((t) => t.surfaceId === surfaceId)

--- a/src/mcp/playwright/__tests__/PlaywrightEngine.test.ts
+++ b/src/mcp/playwright/__tests__/PlaywrightEngine.test.ts
@@ -672,3 +672,119 @@ describe('PlaywrightEngine read-path workspace scoping (#554)', () => {
     expect(ctxC.key).not.toBe(ctxD.key); // each surfaceless workspace auto-opens independently
   });
 });
+
+/**
+ * #580 Option 1: the engine now asks main to scope browser.cdp.info to its own
+ * workspace, and reads the `targetsScoped` flag so an empty list means "I own
+ * none" rather than "legacy main." The #554 block above still covers the
+ * legacy/unscoped-response path (a main that ignores the param), which must
+ * keep working; these cover the scoped-response path a current main returns.
+ */
+describe('PlaywrightEngine read-path workspace scoping — scoped cdp.info (#580)', () => {
+  beforeEach(() => {
+    (PlaywrightEngine as unknown as { instance: PlaywrightEngine | null }).instance = null;
+    mockSendRpc.mockReset();
+    mockConnectOverCDP.mockReset();
+  });
+
+  // A main honoring the param returns ONLY the caller's targets + the flag.
+  const scopedCdpInfo = (callerWs: string) => ({
+    cdpPort: 9222,
+    targetsScoped: true,
+    targets:
+      callerWs === 'ws-A'
+        ? [{ surfaceId: 'surf-A', targetId: 'wc-1', workspaceId: 'ws-A' }]
+        : [],
+  });
+
+  it('passes the resolved workspaceId to browser.cdp.info', async () => {
+    mockSendRpc.mockImplementation((method: string, params?: unknown) =>
+      method === 'browser.cdp.info'
+        ? Promise.resolve(scopedCdpInfo((params as { workspaceId: string }).workspaceId))
+        : Promise.resolve({}),
+    );
+    const engine = PlaywrightEngine.getInstance();
+    scope(engine).setWorkspaceIdResolver(async () => 'ws-A');
+
+    await scope(engine).resolveCallerSurface();
+    expect(mockSendRpc).toHaveBeenCalledWith('browser.cdp.info', { workspaceId: 'ws-A' });
+  });
+
+  it('reports its own surface from a scoped response', async () => {
+    mockSendRpc.mockImplementation((method: string, params?: unknown) =>
+      method === 'browser.cdp.info'
+        ? Promise.resolve(scopedCdpInfo((params as { workspaceId: string }).workspaceId))
+        : Promise.resolve({}),
+    );
+    const engine = PlaywrightEngine.getInstance();
+    scope(engine).setWorkspaceIdResolver(async () => 'ws-A');
+
+    await expect(scope(engine).resolveCallerSurface()).resolves.toEqual({
+      kind: 'surface',
+      surfaceId: 'surf-A',
+      workspaceId: 'ws-A',
+    });
+  });
+
+  it("reads an EMPTY scoped response as 'none', not 'unscoped' (the targetsScoped disambiguation)", async () => {
+    mockSendRpc.mockImplementation((method: string, params?: unknown) =>
+      method === 'browser.cdp.info'
+        ? Promise.resolve(scopedCdpInfo((params as { workspaceId: string }).workspaceId))
+        : Promise.resolve({}),
+    );
+    const engine = PlaywrightEngine.getInstance();
+    // ws-B owns nothing; a scoped empty list must fail closed to 'none' so the
+    // caller never falls through to another workspace's page — the whole point
+    // of the flag, since without it an empty list is ambiguous with legacy.
+    scope(engine).setWorkspaceIdResolver(async () => 'ws-B');
+
+    await expect(scope(engine).resolveCallerSurface()).resolves.toEqual({
+      kind: 'none',
+      workspaceId: 'ws-B',
+    });
+  });
+
+  it('an empty scoped response routes getPage to auto-open the CALLER\'s own browser, scoping its queries', async () => {
+    // Under scoping, a caller that owns no live target must NOT fall through to
+    // another workspace's guest — it auto-opens its own. This asserts the two
+    // isolation-critical calls getPage makes on that path: it queries
+    // cdp.info scoped to itself, and opens in its OWN workspace. (The auto-open
+    // -> returned-page mechanics are covered independently by the #554 auto-open
+    // test; here the empty scoped response keeps the caller on the self-open
+    // branch rather than a foreign page.)
+    const shellUrl = 'file:///app/.vite/renderer/main_window/index.html';
+    let opened = false;
+
+    const browser = {
+      isConnected: vi.fn().mockReturnValue(true),
+      newBrowserCDPSession: vi.fn().mockImplementation(async () => makeFakeSession()),
+      contexts: vi.fn().mockReturnValue([]),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    mockConnectOverCDP.mockResolvedValue(browser);
+    mockSendRpc.mockImplementation((method: string, params?: unknown) => {
+      if (method === 'browser.cdp.info') {
+        const ws = (params as { workspaceId?: string } | undefined)?.workspaceId;
+        // Honor the scope request: caller owns nothing → empty + flag, both
+        // before and after the open (so it never resolves a foreign page).
+        return Promise.resolve({ cdpPort: 9222, shellUrl, ...(ws && { targetsScoped: true }), targets: [] });
+      }
+      if (method === 'browser.open') {
+        opened = true;
+        return Promise.resolve({ ok: true });
+      }
+      return Promise.resolve({});
+    });
+
+    const engine = PlaywrightEngine.getInstance();
+    autoOpen(engine).setWorkspaceIdResolver(async () => 'ws-B');
+
+    await engine.getPage();
+
+    // Opened in the caller's OWN workspace — the isolation guarantee.
+    expect(mockSendRpc).toHaveBeenCalledWith('browser.open', { workspaceId: 'ws-B' });
+    // And it asked main to scope the target list to the caller.
+    expect(mockSendRpc).toHaveBeenCalledWith('browser.cdp.info', { workspaceId: 'ws-B' });
+    expect(opened).toBe(true);
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary

Closes the **disclosure leg** of #580 — Option 1, implemented to your spec on the issue. `browser.cdp.info` no longer volunteers other workspaces' live browser targets to a caller that identifies itself.

Together with #586 (the destructive leg), this addresses both halves of #580.

## What changed

- **`browser.cdp.info` filters `targets` to the caller's workspace server-side.** It accepts an optional `workspaceId`; when present it returns only that workspace's targets and sets `targetsScoped: true`. `cdpPort` and `shellUrl` stay unscoped — they're workspace-agnostic and load-bearing for shell recognition. A param-less call keeps the legacy unscoped shape, so an older engine still works.
- **`PlaywrightEngine` passes its resolved workspace on every target-reading call** — `resolveCallerSurface`, `findViaTargetDomain`, `findViaJsonEndpoint` — threaded through `resolveSelectionContext` → `_getPageImpl`. `ensureConnected` only needs `cdpPort`/`shellUrl`, so it's left unscoped.
- **The `targetsScoped` flag disambiguates an empty list**, exactly as you flagged: with it, an empty response means "caller owns no live target" (`kind: 'none'`); without it (legacy main) the engine keeps its `anyTagged` leniency. This also means the no-`surfaceId` `targets[0]` fallback in the page finders can no longer resolve to another workspace's guest.

## Defense-in-depth, not a hard seal (as you noted)

Since `cdpPort` is still returned, anything holding it can enumerate targets by hitting the CDP `/json` endpoint directly — the engine itself does that during discovery. Sealing that would mean brokering CDP attach instead of sharing the port, which is a larger change and out of scope. This PR removes the casual/accidental cross-workspace read through the well-behaved RPC path, within the same-OS-user trust ceiling. The contract doc §8.2 and the CHANGELOG both say this plainly.

## Backward compatibility

The `workspaceId` param is additive and optional. A caller that doesn't pass it (or an older main that ignores it) gets identical behavior to before. The pre-existing #554 engine tests, which simulate an old main returning the full unfiltered list, still pass unchanged — they exercise the legacy path, and the new tests exercise the scoped path.

## Test plan

**Handler** (`browser.rpc.test.ts`):
- A `workspaceId` filters `targets` to that workspace and sets `targetsScoped: true`; neither the foreign nor an untagged target leaks.
- An owner-of-nothing gets `{ targetsScoped: true, targets: [] }` — the signal the engine reads as "own none".
- A param-less call returns all targets and no flag (legacy).

**Engine** (`PlaywrightEngine.test.ts`, new `#580` block):
- `resolveCallerSurface` passes the resolved `workspaceId` to `browser.cdp.info`.
- It reports its own surface from a scoped response.
- It reads an **empty scoped** response as `'none'`, not `'unscoped'` — the `targetsScoped` disambiguation, so the caller never falls through to another workspace's page.
- **The attach path under scoping:** on an empty scoped response, `getPage` auto-opens the caller's **own** browser — `browser.open` and `browser.cdp.info` are both called scoped to the caller (`ws-B`), never a foreign page. (The auto-open→returned-page mechanics are covered independently by the existing #554 auto-open test; this asserts the isolation-critical calls on the scoped path.)

**Checks:** `tsc --noEmit` clean; `git diff --check` clean; eslint on touched files adds **no** new findings (the 3 pre-existing errors — `new Promise(() => {})` in #529 tests, an empty constructor, an unused import — are on the base too, verified by stashing); full `npm test` green apart from two unrelated parallelism flakes (`diff.handler`, `McpRegistrar`) that both pass in isolation and touch nothing here.

## Stability tier impact

- [x] Change to an `internal` surface (no public contract impact) — `browser.cdp.info` is an internal RPC. Additive optional param; response gains an optional `targetsScoped` field.

## Substrate contract impact

`docs/internal/browser-tabs-workspace-contract.md` §8.2 updated: the disclosure leg is marked scoped-as-defense-in-depth, with the `/json`-via-port caveat spelled out; §5's cross-reference updated to match.

## Related

Closes the disclosure leg of #580 (Option 1). Sibling of #586 (destructive leg, merged) and #575 / #554. Not attempted here: brokering CDP attach to seal the port-based `/json` path — a separate, larger design.

## Reviewer checklist

- [x] CHANGELOG entry filled in (`### Fixed`, next to the #586 sibling).
- [x] Stability tier impact classified.
- [x] Substrate contract doc updated (§8.2, §5 cross-ref).
- [x] Tests cover the new behavior (scoped path) and the compatibility case (legacy unscoped path still covered by existing #554 tests).
- [x] No secrets or unrelated changes — 6 files, all intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Browser target discovery is now restricted to the caller’s workspace, preventing foreign workspace surfaces from being revealed through browser operations.
  * Browser page resolution and automatic opening remain within the caller’s workspace.

* **Documentation**
  * Clarified workspace disclosure boundaries and the limitations of CDP target protection.

* **Tests**
  * Added coverage for workspace-scoped target discovery, empty results, legacy behavior, and workspace-safe page opening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->