### PR TITLE
fix(terminal): defer dispose during mouse drag to stop remount TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dragging your mouse across a terminal during a workspace switch no longer throws a recurring uncaught error.** Selecting text in a terminal registers document-level mouse listeners (so a drag that leaves the terminal can still be released), and on a remount — a workspace switch, a reconnect — `Terminal.dispose()` nullified xterm's internal render service before those listeners came down. A `mouseup` landing in that gap read `dimensions` off a half-torn-down instance and threw `TypeError: Cannot read properties of undefined (reading 'dimensions')`, dozens of times per session. wmux now tracks whether a drag is active on any terminal and defers only the internal `dispose()` until the mouse is released (with a 2-second backstop for a drag abandoned outside the window), closing the race without patching xterm internals; all PTY listeners are already torn down at that point, so no new data arrives while disposal waits. The redundant back-to-back reconciliation runs visible on load are now numbered in the console — so "one cycle walking four workspaces" is distinguishable from "four cycles" — and the dev-only Electron "Insecure Content-Security-Policy" warning is suppressed in development (Vite's HMR requires `unsafe-eval`; the production CSP remains strict with no `unsafe-eval`).
+
 ## [3.33.0] — 2026-07-24
 
 ### Added

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,3 +1,16 @@
+// #582: Suppress Electron's dev-only "Insecure Content-Security-Policy"
+// warning at the earliest possible point — before `app` ready and before any
+// BrowserWindow is created. Vite's HMR requires `unsafe-eval`, so the warning
+// is unavoidable in dev; the production CSP (enforced in createWindow) is
+// strict with no `unsafe-eval`, so this is dev-only noise reduction, not a
+// security trade-off. This MUST run before createWindow()/loadMainRenderer()
+// so the override is active before the first renderer navigates — setting it
+// inside createWindow (after loadMainRenderer) leaves a window where Electron
+// reads the flag before the override lands.
+if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
+  process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = 'true';
+}
+
 process.on('unhandledRejection', (reason) => {
   console.error('[Main] Unhandled rejection:', reason);
 });

--- a/src/main/window/createWindow.ts
+++ b/src/main/window/createWindow.ts
@@ -141,11 +141,20 @@ export function createWindow(opts: { deferLoad?: boolean } = {}): BrowserWindow 
   }
 
   // CSP header — production only.
-  // In development, Vite serves scripts from localhost with inline module loaders,
-  // which are incompatible with strict CSP. We only enforce CSP in production builds.
+  // In development, Vite serves scripts from localhost with inline module
+  // loaders and eval-based HMR, which are incompatible with strict CSP.
+  // We only enforce CSP in production builds.
   // 'unsafe-inline' in style-src is required because Tailwind CSS and xterm.js
   // inject inline styles at runtime; removing it breaks UI rendering.
-  if (!MAIN_WINDOW_VITE_DEV_SERVER_URL) {
+  //
+  // #582: In dev, we suppress Electron's "Insecure Content-Security-Policy"
+  // warning via ELECTRON_DISABLE_SECURITY_WARNINGS. Vite's HMR requires
+  // unsafe-eval, so any dev CSP we set would still trip the warning. The
+  // production CSP below is strict (no unsafe-eval), so this suppression is
+  // dev-only noise reduction, not a security trade-off.
+  if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
+    process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = 'true';
+  } else {
     const cspPolicy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self'; frame-src 'self' https: http:";
 
     mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {

--- a/src/main/window/createWindow.ts
+++ b/src/main/window/createWindow.ts
@@ -147,14 +147,14 @@ export function createWindow(opts: { deferLoad?: boolean } = {}): BrowserWindow 
   // 'unsafe-inline' in style-src is required because Tailwind CSS and xterm.js
   // inject inline styles at runtime; removing it breaks UI rendering.
   //
-  // #582: In dev, we suppress Electron's "Insecure Content-Security-Policy"
-  // warning via ELECTRON_DISABLE_SECURITY_WARNINGS. Vite's HMR requires
-  // unsafe-eval, so any dev CSP we set would still trip the warning. The
-  // production CSP below is strict (no unsafe-eval), so this suppression is
-  // dev-only noise reduction, not a security trade-off.
-  if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
-    process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = 'true';
-  } else {
+  // #582: The dev-only "Insecure Content-Security-Policy" warning is suppressed
+  // via ELECTRON_DISABLE_SECURITY_WARNINGS — but that is now set at the very
+  // top of the main entry (src/main/index.ts), before this function runs, so
+  // the override is live before the first renderer navigates. Vite's HMR
+  // requires unsafe-eval, so any dev CSP we set would still trip the warning;
+  // the production CSP below is strict (no unsafe-eval), so this is dev-only
+  // noise reduction, not a security trade-off.
+  if (!MAIN_WINDOW_VITE_DEV_SERVER_URL) {
     const cspPolicy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self'; frame-src 'self' https: http:";
 
     mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -432,6 +432,9 @@ export default function AppLayout() {
   // the shared promise of whatever run is in flight. Late re-reconciles
   // after the first run completes still trigger a fresh pass.
   const reconcileInFlightRef = useRef<Promise<void> | null>(null);
+  // #582: monotonic reconcile cycle counter for clearer console logs —
+  // distinguishes "1 cycle walking 4 workspaces" from "4 cycles" (#582).
+  const reconcileCycleRef = useRef(0);
 
   useEffect(() => {
     // File drop via preload onFileDrop (reliable cross-platform)
@@ -538,7 +541,13 @@ export default function AppLayout() {
         if (signal?.aborted) return;
         const activePtys = listResult.data;
         const activeIds = new Set(activePtys.map((p: { id: string }) => p.id));
-        console.log('[AppLayout] Daemon active PTYs:', [...activeIds]);
+        // #582: include workspace count so "Reconciling workspace: X" logs that
+        // follow are unambiguously a single cycle walking N workspaces, not N
+        // separate cycles. The monotonic cycle number helps correlate across
+        // startup + late-reconcile runs in the console capture.
+        const wsCount = useStore.getState().workspaces.length;
+        reconcileCycleRef.current++;
+        console.log(`[AppLayout] Reconcile cycle #${reconcileCycleRef.current}: daemon has ${activeIds.size} PTYs across ${wsCount} workspace(s)`);
 
         // RCA A1 — empty-list guard (the single most important non-destructive
         // change). `pty.list` returning ZERO live sessions on a reconnect
@@ -691,7 +700,7 @@ export default function AppLayout() {
             useStore.getState().updateSurfacePtyId(a.paneId, a.surfaceId, a.newPtyId);
           }
         }
-        console.log('[AppLayout] Reconciliation complete');
+        console.log(`[AppLayout] Reconcile cycle #${reconcileCycleRef.current} complete (${absentCandidates.length} absent candidate(s))`);
       } finally {
         reconcileInFlightRef.current = null;
       }

--- a/src/renderer/hooks/__tests__/terminalDragGuard.test.ts
+++ b/src/renderer/hooks/__tests__/terminalDragGuard.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { isTerminalDragActive, __resetTerminalDragForTests } from '../useTerminal';
+
+// #582 — xterm's CoreMouseService registers document-level mouseup/mousemove
+// listeners on mousedown so a drag can be released outside the terminal
+// element. Terminal.dispose() nullifies _renderService before removing those
+// listeners; a mouseup firing in that gap throws an uncaught TypeError from
+// getMouseReportCoords. The cleanup in useTerminal defers dispose while
+// isTerminalDragActive() is true. These tests pin the drag-detection logic.
+
+describe('terminal mouse-drag guard (#582)', () => {
+  beforeEach(() => {
+    __resetTerminalDragForTests();
+  });
+
+  afterEach(() => {
+    __resetTerminalDragForTests();
+  });
+
+  it('reports no drag before any interaction', () => {
+    expect(isTerminalDragActive()).toBe(false);
+  });
+
+  it('activates on mousedown inside an .xterm element', () => {
+    const xtermEl = document.createElement('div');
+    xtermEl.className = 'xterm';
+    document.body.appendChild(xtermEl);
+
+    // isTerminalDragActive() lazily installs capture-phase listeners on first
+    // call — trigger that before dispatching the event.
+    isTerminalDragActive();
+
+    xtermEl.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(isTerminalDragActive()).toBe(true);
+
+    document.body.removeChild(xtermEl);
+  });
+
+  it('activates on mousedown on a child of .xterm (selection drag)', () => {
+    const xtermEl = document.createElement('div');
+    xtermEl.className = 'xterm';
+    const screen = document.createElement('div');
+    screen.className = 'xterm-screen';
+    xtermEl.appendChild(screen);
+    document.body.appendChild(xtermEl);
+
+    isTerminalDragActive();
+    screen.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(isTerminalDragActive()).toBe(true);
+
+    document.body.removeChild(xtermEl);
+  });
+
+  it('does NOT activate on mousedown outside .xterm', () => {
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+
+    isTerminalDragActive();
+    button.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(isTerminalDragActive()).toBe(false);
+
+    document.body.removeChild(button);
+  });
+
+  it('clears on document mouseup (drag released anywhere)', () => {
+    const xtermEl = document.createElement('div');
+    xtermEl.className = 'xterm';
+    document.body.appendChild(xtermEl);
+
+    isTerminalDragActive();
+    xtermEl.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(isTerminalDragActive()).toBe(true);
+
+    // Mouse released OUTSIDE the terminal (the whole point of xterm's
+    // document-level listeners).
+    document.dispatchEvent(new MouseEvent('mouseup'));
+    expect(isTerminalDragActive()).toBe(false);
+
+    document.body.removeChild(xtermEl);
+  });
+
+  it('clears on window blur (mouse left the window mid-drag)', () => {
+    const xtermEl = document.createElement('div');
+    xtermEl.className = 'xterm';
+    document.body.appendChild(xtermEl);
+
+    isTerminalDragActive();
+    xtermEl.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(isTerminalDragActive()).toBe(true);
+
+    window.dispatchEvent(new Event('blur'));
+    expect(isTerminalDragActive()).toBe(false);
+
+    document.body.removeChild(xtermEl);
+  });
+
+  it('installs listeners only once across multiple calls', () => {
+    // Calling isTerminalDragActive() multiple times must not re-register
+    // document listeners — each call after the first is a flag read.
+    isTerminalDragActive();
+    isTerminalDragActive();
+    isTerminalDragActive();
+
+    const xtermEl = document.createElement('div');
+    xtermEl.className = 'xterm';
+    document.body.appendChild(xtermEl);
+
+    xtermEl.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(isTerminalDragActive()).toBe(true);
+
+    document.body.removeChild(xtermEl);
+  });
+});

--- a/src/renderer/hooks/__tests__/terminalDragGuard.test.ts
+++ b/src/renderer/hooks/__tests__/terminalDragGuard.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { isTerminalDragActive, __resetTerminalDragForTests } from '../useTerminal';
 
 // #582 — xterm's CoreMouseService registers document-level mouseup/mousemove
@@ -96,17 +96,54 @@ describe('terminal mouse-drag guard (#582)', () => {
   });
 
   it('installs listeners only once across multiple calls', () => {
-    // Calling isTerminalDragActive() multiple times must not re-register
-    // document listeners — each call after the first is a flag read.
-    isTerminalDragActive();
-    isTerminalDragActive();
-    isTerminalDragActive();
+    // Spy BEFORE the first call so registration counts are observable.
+    // Repeated getter calls must not re-register document/window listeners —
+    // each call after the first is a flag read.
+    const docSpy = vi.spyOn(document, 'addEventListener');
+    const winSpy = vi.spyOn(window, 'addEventListener');
 
+    isTerminalDragActive();
+    // First call installs: capture-phase mousedown + mouseup on document,
+    // blur on window.
+    expect(docSpy).toHaveBeenCalledTimes(2);
+    expect(winSpy).toHaveBeenCalledTimes(1);
+
+    isTerminalDragActive();
+    isTerminalDragActive();
+    // Subsequent calls are pure flag reads — no re-registration.
+    expect(docSpy).toHaveBeenCalledTimes(2);
+    expect(winSpy).toHaveBeenCalledTimes(1);
+
+    // Existing drag-activation behavior still holds after repeated calls.
     const xtermEl = document.createElement('div');
     xtermEl.className = 'xterm';
     document.body.appendChild(xtermEl);
 
     xtermEl.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(isTerminalDragActive()).toBe(true);
+
+    document.body.removeChild(xtermEl);
+    docSpy.mockRestore();
+    winSpy.mockRestore();
+  });
+
+  it('detects a drag that started before any cleanup read (#582 regression)', () => {
+    // The original bug: the mousedown listener was installed lazily from the
+    // cleanup path (isTerminalDragActive), so a drag whose mousedown happened
+    // before the first read was missed and dispose fired mid-drag. Once the
+    // listener is installed (here by the first getter call, in production by
+    // the mount effect), a selection that starts before the cleanup read must
+    // still report active so dispose is deferred.
+    isTerminalDragActive(); // install listeners
+
+    const xtermEl = document.createElement('div');
+    xtermEl.className = 'xterm';
+    document.body.appendChild(xtermEl);
+
+    // Drag starts — no isTerminalDragActive() call in between.
+    xtermEl.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+    // The cleanup read happens later and must see the active drag.
     expect(isTerminalDragActive()).toBe(true);
 
     document.body.removeChild(xtermEl);

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -158,6 +158,7 @@ export function isTerminalDragActive(): boolean {
 /** Test seam: reset the drag flag between test cases. */
 export function __resetTerminalDragForTests(): void {
   _terminalDragActive = false;
+  _dragListenersInstalled = false;
 }
 
 // === P0-5: per-pane freshness state for the UI ==============================
@@ -703,6 +704,16 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
   useEffect(() => {
     const container = containerRef.current;
     if (!container || !ptyId) return;
+
+    // #582: Install the global drag listeners when a terminal mounts — BEFORE
+    // the user can start a selection/mouse-tracking drag on it. Previously the
+    // only call site was the cleanup path (isTerminalDragActive), installed
+    // lazily, which meant the FIRST drag→remount after startup ran before the
+    // mousedown listener existed: the drag was missed, the flag read false, and
+    // dispose fired immediately — the exact race this guard exists to close.
+    // Idempotent (guarded by _dragListenersInstalled), so only the first mount
+    // pays the addEventListener cost.
+    _ensureDragListeners();
 
     const terminal = new Terminal({
       cursorBlink: true,
@@ -1408,7 +1419,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // silent backstop in `pty.handler.ts`. The helper preserves xterm's
     // own bracketed-paste markers if it pre-wrapped the payload.
     let inputBuffer = '';
-    terminal.onData((data) => {
+    const onDataDisposable = terminal.onData((data) => {
       // X6 ②: the user is driving this shell themselves — retract any pending
       // resume offer so the pill can't fire into a session they've moved on in.
       //
@@ -1888,6 +1899,14 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       selectionDisposable.dispose();
       pathLinkDisposable.dispose();
       osc52Disposable.dispose();
+      // #582: dispose the xterm→PTY input listener BEFORE the deferred-
+      // dispose block below. While terminal.dispose() waits for an active
+      // drag to release, xterm's document-level mousemove/mouseup handlers
+      // (active in DECSET mouse modes, e.g. tmux/vim) can still synthesize
+      // mouse reports that flow through onData → pty.write into a PTY whose
+      // other listeners are already torn down. Dropping this disposable here
+      // stops stray input during the defer window.
+      onDataDisposable.dispose();
       resizeObserver.disconnect();
       removeDataListener?.();
       removeExitListener?.();
@@ -1926,19 +1945,48 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // terminal. xterm nullifies _renderService before removing its
       // document-level mouseup/mousemove listeners — a mouseup firing in
       // that gap throws an uncaught TypeError from getMouseReportCoords.
-      // All PTY listeners above are already torn down, so deferring only
-      // the internal dispose is safe (no new data arrives). The backstop
-      // timeout covers the edge case where the mouse leaves the window
-      // mid-drag (no mouseup fires).
+      // All PTY listeners above are already torn down (including onData, so
+      // no stray input flows during the wait), so deferring only the internal
+      // dispose is safe. The backstop covers a drag abandoned outside the
+      // window (no mouseup, no blur); it re-checks the flag so a genuinely
+      // long selection isn't cut down mid-drag — which would reopen the exact
+      // half-disposed race this guard exists to close. Both handles are
+      // released on either completion path so neither lingers.
       let _disposed = false;
+      let _deferTimer: ReturnType<typeof setTimeout> | null = null;
+      let _deferMouseUp: (() => void) | null = null;
       const safeDispose = (): void => {
         if (_disposed) return;
         _disposed = true;
+        if (_deferTimer !== null) {
+          clearTimeout(_deferTimer);
+          _deferTimer = null;
+        }
+        if (_deferMouseUp) {
+          document.removeEventListener('mouseup', _deferMouseUp);
+          _deferMouseUp = null;
+        }
         try { terminal.dispose(); } catch { /* already disposed */ }
       };
       if (isTerminalDragActive()) {
-        document.addEventListener('mouseup', safeDispose, { once: true });
-        setTimeout(safeDispose, 2000);
+        _deferMouseUp = safeDispose;
+        document.addEventListener('mouseup', _deferMouseUp);
+        // Bounded retries: if the drag is still active when each 2s interval
+        // elapses, keep waiting (a real selection can exceed 2s). After
+        // _retriesLeft hits zero the terminal is force-disposed as a leak
+        // guard for a stuck button that never emits mouseup/blur.
+        let _retriesLeft = 5;
+        const scheduleBackstop = (): void => {
+          _deferTimer = setTimeout(() => {
+            if (_disposed) return;
+            if (isTerminalDragActive() && _retriesLeft-- > 0) {
+              scheduleBackstop();
+            } else {
+              safeDispose();
+            }
+          }, 2000);
+        };
+        scheduleBackstop();
       } else {
         safeDispose();
       }

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -123,6 +123,43 @@ export function __resetPtyDispatchersForTests(): void {
   ptyFlushDispatcher.reset();
 }
 
+// === #582: terminal mouse-drag dispose guard =================================
+// xterm's CoreMouseService registers document-level `mouseup`/`mousemove`
+// listeners dynamically on mousedown (so a selection/mouse-tracking drag can
+// be released outside the terminal element). On Terminal.dispose(), xterm
+// nullifies `_renderService` before removing those document listeners. If a
+// mouseup fires in that gap — which happens during remount churn (workspace
+// switch, StrictMode double-mount) — getMouseReportCoords reads
+// `_renderService.dimensions` on a half-torn-down instance and throws an
+// uncaught TypeError. We track active drags on any `.xterm` element so the
+// cleanup path can defer `terminal.dispose()` until the drag completes,
+// closing the race window without patching xterm internals.
+let _terminalDragActive = false;
+let _dragListenersInstalled = false;
+function _ensureDragListeners(): void {
+  if (_dragListenersInstalled || typeof document === 'undefined') return;
+  _dragListenersInstalled = true;
+  // Capture-phase: fire before xterm's own listeners so the flag is accurate.
+  document.addEventListener('mousedown', (e: Event) => {
+    const target = e.target;
+    if (target instanceof Element && target.closest('.xterm')) {
+      _terminalDragActive = true;
+    }
+  }, true);
+  const clear = (): void => { _terminalDragActive = false; };
+  document.addEventListener('mouseup', clear, true);
+  window.addEventListener('blur', clear, true);
+}
+/** Returns true while a mouse button is held down over any terminal element. */
+export function isTerminalDragActive(): boolean {
+  _ensureDragListeners();
+  return _terminalDragActive;
+}
+/** Test seam: reset the drag flag between test cases. */
+export function __resetTerminalDragForTests(): void {
+  _terminalDragActive = false;
+}
+
 // === P0-5: per-pane freshness state for the UI ==============================
 // 'syncing'  — a daemon resync is in flight (reveal/read of a dirty pane).
 // 'stale'    — a resync degraded; the screen may be missing output until the
@@ -1885,7 +1922,26 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // is being disposed, parsing the backlog would be wasted work and a
       // post-dispose drain write would throw.
       discardTerminalOutput(terminal);
-      terminal.dispose();
+      // #582: defer terminal.dispose() if a mouse drag is active on any
+      // terminal. xterm nullifies _renderService before removing its
+      // document-level mouseup/mousemove listeners — a mouseup firing in
+      // that gap throws an uncaught TypeError from getMouseReportCoords.
+      // All PTY listeners above are already torn down, so deferring only
+      // the internal dispose is safe (no new data arrives). The backstop
+      // timeout covers the edge case where the mouse leaves the window
+      // mid-drag (no mouseup fires).
+      let _disposed = false;
+      const safeDispose = (): void => {
+        if (_disposed) return;
+        _disposed = true;
+        try { terminal.dispose(); } catch { /* already disposed */ }
+      };
+      if (isTerminalDragActive()) {
+        document.addEventListener('mouseup', safeDispose, { once: true });
+        setTimeout(safeDispose, 2000);
+      } else {
+        safeDispose();
+      }
       terminalRef.current = null;
       fitAddonRef.current = null;
       searchAddonRef.current = null;


### PR DESCRIPTION
## What

Fixes the recurring uncaught `TypeError: Cannot read properties of undefined (reading 'dimensions')` that fires from xterm's own mouse-tracking code during terminal remount churn (workspace switch, reconnect). Closes #582.

## Why

xterm's `CoreMouseService` registers document-level `mouseup`/`mousemove` listeners on `mousedown` so a selection drag can be released outside the terminal element. `Terminal.dispose()` nullifies `_renderService` **before** removing those listeners. A `mouseup` landing in that gap runs `getMouseReportCoords`, which reads `_renderService.dimensions` on a half-torn-down instance and throws — dozens of times per session. Not user-blocking (the terminal still works) but a real uncaught exception on ordinary text-selection drags, and the noise masks real regressions.

## Changes

- **`src/renderer/hooks/useTerminal.ts`** — Track whether a mouse drag is active on any `.xterm` element (capture-phase document listeners, installed once). In the cleanup path, if a drag is active, defer only the internal `terminal.dispose()` until `mouseup` (2-second backstop for a drag abandoned outside the window). All PTY listeners are already torn down at that point, so no new data arrives while disposal waits. No xterm internals are patched.
- **`src/renderer/components/Layout/AppLayout.tsx`** — Number the reconciliation cycles in the console so "one cycle walking N workspaces" is distinguishable from "N cycles" (the second part of #582's diagnosis).
- **`src/main/window/createWindow.ts`** — Suppress the dev-only Electron "Insecure Content-Security-Policy" warning in development. Vite's HMR requires `unsafe-eval`; the production CSP remains strict with no `unsafe-eval`, so this is dev-only noise reduction, not a security trade-off (the third part of #582).
- **`src/renderer/hooks/__tests__/terminalDragGuard.test.ts`** — New: pins the drag-detection logic (activate on `.xterm` mousedown, clear on document mouseup / window blur, single listener install).

## Verification

- `tsc --noEmit -p tsconfig.json` — clean
- `vitest run terminalDragGuard.test.ts` — 7/7 pass
- eslint on changed files — no new findings (pre-existing findings untouched)
- Live dogfood: booted the dev app (isolated `wmux-dogfood582` profile) with `ELECTRON_ENABLE_LOGGING=1`, drove the live renderer over CDP, and replayed the #582 drag→document-`mouseup` race on the real `.xterm` element — no exception thrown, zero uncaught exceptions during the session, the modified `useTerminal` module confirmed loaded, and the real daemon-reattach path (the remount churn that triggered the bug) ran error-free on boot.

## Versioning

No version bump (per repo policy). CHANGELOG entry under `[Unreleased]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a workspace-switching issue where dragging text across a terminal could trigger recurring errors.
  * Improved terminal teardown behavior during active mouse drags to avoid crashes and stray input during the transition.
* **Chores**
  * Enhanced diagnostic logging for workspace/terminal reconciliation activity.
  * Reduced an Electron security-policy warning in development (production protections remain enabled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->