### PR TITLE
fix(web): warn that --expose serves the token and scrollback in cleartext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`wmux web --expose` now says out loud that the connection is unencrypted (#607, partial).** The old warning told you the access token was "the only thing gating it" and to treat the URL as a secret — true, but it skipped the sharper point: over plain HTTP on all interfaces, anyone who can sniff the network (open Wi‑Fi, ARP spoofing, a compromised switch) can read the token *and* the full scrollback off the wire, no URL required. The exposed-bind report now states exactly that and points at `tailscale serve` for an HTTPS front. Wording only — native TLS stays tracked in #607.
+
 ## [3.34.0] — 2026-07-25
 
 ### Added

--- a/docs/web-security-review-2026-07-24.md
+++ b/docs/web-security-review-2026-07-24.md
@@ -68,10 +68,10 @@ Boundary strengths already in place (no action needed):
 
 | ID | Severity | Finding | Location | Status |
 |---|---|---|---|---|
-| W1 | **Medium** | `--expose` sends the token + full scrollback in cleartext over HTTP; warning understates sniffing risk | `WebTerminalServer.ts:131` (no TLS), `web.ts:96-109` (warning) | ⏳ Open (Tier A wording shipped; TLS is follow-up) |
+| W1 | **Medium** | `--expose` sends the token + full scrollback in cleartext over HTTP; warning understates sniffing risk | `WebTerminalServer.ts:131` (no TLS), `web.ts:96-109` (warning) | ⏳ Open — [#607](https://github.com/openwong2kim/wmux/issues/607) (Tier A wording NOT yet shipped — doc overstated; TLS is follow-up) |
 | W2 | **Medium** | No frame protection → authenticated localhost page is clickjackable (worse with `--allow-input`) | `WebTerminalServer.ts:517` (`serveStatic`) | ✅ Resolved — `securityHeaders()` on every response |
 | W3 | **Low-Med** | No `Host` header validation → DNS rebinding can reach unauthenticated `/api/pair` and burn it (pairing DoS) | `WebTerminalServer.ts:238` | ✅ Resolved — Host allowlist checked before routing |
-| W4 | **Low** | No `Content-Security-Policy`; an XSS (future regression) would exfiltrate the token freely | `index.html` / `serveStatic` | ⏳ Open (`frame-ancestors 'none'` only; full policy is follow-up) |
+| W4 | **Low** | No `Content-Security-Policy`; an XSS (future regression) would exfiltrate the token freely | `index.html` / `serveStatic` | ⏳ Open — [#608](https://github.com/openwong2kim/wmux/issues/608) (`frame-ancestors 'none'` only; full policy is follow-up) |
 | W5 | **Low** | Pairing code is generated once per start; after burn/expiry it is gone until restart → permanent pairing DoS | `WebTerminalServer.ts:123,449` | ✅ Resolved — cooldown-limited regeneration |
 | W6 | **Info** | `timingSafeEqual` short-circuits on length; `nosniff` absent; SSE token in URL (unavoidable, contained) | `WebTerminalServer.ts:512-514`, `:528` | ✅ No action needed (nosniff shipped with W2) |
 
@@ -287,7 +287,7 @@ regen-on-demand option) rather than none; or, after N wrong attempts from one fa
 
 | Phase | Items | Effort | Risk reduced | Status |
 |---|---|---|---|---|
-| **P1 — ship now** | W2 (frame + nosniff + referrer) + W1 Tier A (wording) | ~1 h | Clickjacking; operator misuse of `--expose` | ✅ Shipped in this PR |
+| **P1 — ship now** | W2 (frame + nosniff + referrer) + W1 Tier A (wording) | ~1 h | Clickjacking; operator misuse of `--expose` | ◐ W2 shipped only; W1 Tier A tracked in [#607](https://github.com/openwong2kim/wmux/issues/607) |
 | **P2 — next PR** | W3 (Host allowlist) + W5 (pairing regen/rate-limit) | ~3 h | DNS-rebinding DoS; pairing DoS | ✅ Shipped in this PR |
 | **P3 — hardening** | W4 (full hashed CSP via build script) | ~0.5 day | Containment under future XSS | ⏳ Follow-up |
 | **P4 — optional** | W1 Tier C (native TLS or `tailscale serve` wrapper) | larger | Removes cleartext risk instead of warning | ⏳ Follow-up |

--- a/src/cli/commands/__tests__/web.exposeWarning.test.ts
+++ b/src/cli/commands/__tests__/web.exposeWarning.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+// W1 Tier A (docs/web-security-review-2026-07-24.md, issue #607): the --expose
+// report must state that the token and scrollback travel in cleartext, and give
+// a concrete HTTPS fronting instruction. Source-level invariant, same pattern
+// as the other CLI-output assertions in this repo.
+const src = readFileSync(path.join(__dirname, '..', 'web.ts'), 'utf8');
+
+describe('wmux web --expose cleartext warning (W1 Tier A)', () => {
+  it('the exposed branch prints an UNENCRYPTED warning with an HTTPS instruction', () => {
+    const start = src.indexOf('} else if (exposed) {');
+    expect(start).toBeGreaterThan(-1);
+    const body = src.slice(start, src.indexOf('}', start + '} else if (exposed) {'.length));
+    expect(body).toContain('UNENCRYPTED');
+    expect(body).toMatch(/sniff/);
+    expect(body).toMatch(/tailscale serve/);
+  });
+});

--- a/src/cli/commands/web.ts
+++ b/src/cli/commands/web.ts
@@ -127,8 +127,9 @@ function report(response: RpcResponse, jsonMode: boolean, mode: 'start' | 'statu
     console.log('      restart with `wmux web --allow-host <your-magicdns-name>` so the');
     console.log('      proxied Host header is accepted.');
   } else if (exposed) {
-    console.log('  ⚠ Reachable on ALL network interfaces (0.0.0.0). The access token is');
-    console.log('    the only thing gating it — treat the URL below as a secret.');
+    console.log('  ⚠ UNENCRYPTED. Anyone on this network who can sniff traffic (open Wi-Fi,');
+    console.log('    ARP spoofing, compromised switch) can read the access token and the');
+    console.log('    full scrollback. Use `tailscale serve` (HTTPS) or wait for native TLS.');
   }
   if (urls.length) {
     console.log('');


### PR DESCRIPTION
## What

`wmux web --expose`'s report warned that the access token was "the only thing gating it" and to treat the URL as a secret. True, but it missed the sharper point: the server speaks plain HTTP on all interfaces, so anyone who can sniff the network (open Wi-Fi, ARP spoofing, a compromised switch) captures the token **and the full scrollback** straight off the wire — they never need the URL. This is finding W1 (Tier A) from `docs/web-security-review-2026-07-24.md`.

The exposed-bind branch now prints:

```
⚠ UNENCRYPTED. Anyone on this network who can sniff traffic (open Wi-Fi,
  ARP spoofing, compromised switch) can read the access token and the
  full scrollback. Use `tailscale serve` (HTTPS) or wait for native TLS.
```

## Also in this PR

- A source-invariant test asserting the exposed branch contains the UNENCRYPTED wording, the sniffing statement, and the `tailscale serve` instruction (the acceptance criteria from the review doc).
- The review doc itself overstated this wording as already shipped; corrected the W1/W4 status rows and linked them to #607 / #608.
- CHANGELOG entry under Unreleased.

## Not in this PR

Native TLS (`--tls-cert`/`--tls-key` or a `tailscale serve` wrapper) stays tracked in #607 — wording only mitigates awareness; TLS is the real fix. Full hashed CSP is #608.

Part of #607.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clearer warning when exposing the web interface over unencrypted HTTP.
  * Warns that network observers could capture the access token and terminal scrollback.
  * Recommends using `tailscale serve` to provide an HTTPS front.

* **Documentation**
  * Corrected security review statuses to accurately reflect the current warning and TLS implementation progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->