### PR TITLE
fix(web): serve the terminal page with a full Content-Security-Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **The `wmux web` page now ships a full Content-Security-Policy (#608).** The page previously carried only frame protection. It now declares a strict policy — every inline script is allowed by its exact hash (no `'unsafe-inline'`), and `connect-src 'self'` means that even if a rendering bug ever reintroduced an XSS, the injected script could execute but could not send the access token anywhere. The hashes are computed by the daemon from the exact page bytes it serves, so the policy can never drift out of sync with a build. Purely defense-in-depth: there is no known XSS today, and nothing changes for a working session.
+
 ### Fixed
 
 - **`wmux web --expose` now says out loud that the connection is unencrypted (#607, partial).** The old warning told you the access token was "the only thing gating it" and to treat the URL as a secret — true, but it skipped the sharper point: over plain HTTP on all interfaces, anyone who can sniff the network (open Wi‑Fi, ARP spoofing, a compromised switch) can read the token *and* the full scrollback off the wire, no URL required. The exposed-bind report now states exactly that and points at `tailscale serve` for an HTTPS front. Wording only — native TLS stays tracked in #607.

--- a/docs/web-security-review-2026-07-24.md
+++ b/docs/web-security-review-2026-07-24.md
@@ -71,7 +71,7 @@ Boundary strengths already in place (no action needed):
 | W1 | **Medium** | `--expose` sends the token + full scrollback in cleartext over HTTP; warning understates sniffing risk | `WebTerminalServer.ts:131` (no TLS), `web.ts:96-109` (warning) | ⏳ Open — [#607](https://github.com/openwong2kim/wmux/issues/607) (Tier A wording NOT yet shipped — doc overstated; TLS is follow-up) |
 | W2 | **Medium** | No frame protection → authenticated localhost page is clickjackable (worse with `--allow-input`) | `WebTerminalServer.ts:517` (`serveStatic`) | ✅ Resolved — `securityHeaders()` on every response |
 | W3 | **Low-Med** | No `Host` header validation → DNS rebinding can reach unauthenticated `/api/pair` and burn it (pairing DoS) | `WebTerminalServer.ts:238` | ✅ Resolved — Host allowlist checked before routing |
-| W4 | **Low** | No `Content-Security-Policy`; an XSS (future regression) would exfiltrate the token freely | `index.html` / `serveStatic` | ⏳ Open — [#608](https://github.com/openwong2kim/wmux/issues/608) (`frame-ancestors 'none'` only; full policy is follow-up) |
+| W4 | **Low** | No `Content-Security-Policy`; an XSS (future regression) would exfiltrate the token freely | `index.html` / `serveStatic` | ✅ Resolved — [#608](https://github.com/openwong2kim/wmux/issues/608): full policy on `GET /` with per-build inline-script hashes, `connect-src 'self'` |
 | W5 | **Low** | Pairing code is generated once per start; after burn/expiry it is gone until restart → permanent pairing DoS | `WebTerminalServer.ts:123,449` | ✅ Resolved — cooldown-limited regeneration |
 | W6 | **Info** | `timingSafeEqual` short-circuits on length; `nosniff` absent; SSE token in URL (unavoidable, contained) | `WebTerminalServer.ts:512-514`, `:528` | ✅ No action needed (nosniff shipped with W2) |
 
@@ -289,7 +289,7 @@ regen-on-demand option) rather than none; or, after N wrong attempts from one fa
 |---|---|---|---|---|
 | **P1 — ship now** | W2 (frame + nosniff + referrer) + W1 Tier A (wording) | ~1 h | Clickjacking; operator misuse of `--expose` | ◐ W2 shipped only; W1 Tier A tracked in [#607](https://github.com/openwong2kim/wmux/issues/607) |
 | **P2 — next PR** | W3 (Host allowlist) + W5 (pairing regen/rate-limit) | ~3 h | DNS-rebinding DoS; pairing DoS | ✅ Shipped in this PR |
-| **P3 — hardening** | W4 (full hashed CSP via build script) | ~0.5 day | Containment under future XSS | ⏳ Follow-up |
+| **P3 — hardening** | W4 (full hashed CSP; hashes computed server-side from the served bytes, not in the build script) | ~0.5 day | Containment under future XSS | ✅ Shipped ([#608](https://github.com/openwong2kim/wmux/issues/608)) |
 | **P4 — optional** | W1 Tier C (native TLS or `tailscale serve` wrapper) | larger | Removes cleartext risk instead of warning | ⏳ Follow-up |
 
 P1 + P2 (both shipped) bring the web surface up to the same localhost-service baseline

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -187,6 +187,8 @@ export class WebTerminalServer {
 
   // Static assets, loaded once on start and cached in memory (all small).
   private terminalHtml: Buffer | null = null;
+  /** Full CSP for the HTML page, with per-build inline-script hashes. */
+  private htmlCsp = '';
   private manifest: Buffer | null = null;
   private serviceWorker: Buffer | null = null;
   private icon: Buffer | null = null;
@@ -417,7 +419,12 @@ export class WebTerminalServer {
     // Static, unauthenticated app shell (no secrets live in these). `/pair`
     // is the same SPA shell — the frontend renders the pairing screen for it.
     if (req.method === 'GET' && (p === '/' || p === '/index.html' || p === '/pair')) {
-      return this.serveStatic(res, this.terminalHtml, 'text/html; charset=utf-8');
+      return this.serveStatic(
+        res,
+        this.terminalHtml,
+        'text/html; charset=utf-8',
+        this.htmlCsp ? { 'Content-Security-Policy': this.htmlCsp } : {},
+      );
     }
     if (req.method === 'GET' && p === '/manifest.webmanifest') {
       return this.serveStatic(res, this.manifest, 'application/manifest+json; charset=utf-8');
@@ -962,6 +969,7 @@ export class WebTerminalServer {
     this.manifest = readIfExists(path.join(dir, 'manifest.webmanifest'));
     this.serviceWorker = readIfExists(path.join(dir, 'sw.js'));
     this.icon = readIfExists(path.join(dir, 'icon-512.png'));
+    this.htmlCsp = this.terminalHtml ? buildHtmlCsp(this.terminalHtml.toString('utf8')) : '';
     if (!this.terminalHtml) {
       this.deps.log('warn', `[web] terminal.html missing under ${dir} — run \`npm run build:daemon-web\``);
     }
@@ -969,6 +977,41 @@ export class WebTerminalServer {
 }
 
 // === module helpers =========================================================
+
+/**
+ * The full Content-Security-Policy for the terminal page (#608).
+ *
+ * The build inlines every script into terminal.html, so the policy carries a
+ * `sha256-` hash per inline `<script>` block instead of `'unsafe-inline'`.
+ * Hashes are computed here, from the exact bytes being served, rather than in
+ * `build-daemon-web.mjs` — the two can then never drift apart. The directive
+ * that matters most is `connect-src 'self'`: even if a future regression
+ * reintroduced an XSS, the injected script could not send the token anywhere.
+ *
+ * `style-src` keeps `'unsafe-inline'`: xterm.js manages styles dynamically and
+ * a style injection cannot exfiltrate the token. `worker-src 'self'` admits the
+ * service worker, which `default-src 'none'` would otherwise block.
+ */
+export function buildHtmlCsp(html: string): string {
+  const hashes: string[] = [];
+  const re = /<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi;
+  for (let m = re.exec(html); m; m = re.exec(html)) {
+    if (!m[1]) continue; // e.g. <script src=...></script> — covered by 'self'
+    hashes.push(`'sha256-${crypto.createHash('sha256').update(m[1], 'utf8').digest('base64')}'`);
+  }
+  return [
+    "default-src 'none'",
+    `script-src 'self'${hashes.length ? ` ${hashes.join(' ')}` : ''}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "connect-src 'self'",
+    "manifest-src 'self'",
+    "worker-src 'self'",
+    "frame-ancestors 'none'",
+    "base-uri 'none'",
+    "form-action 'self'",
+  ].join('; ');
+}
 
 /**
  * One SSE frame. `id` is optional and emitted only on the attention stream —

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
 import { EventEmitter } from 'node:events';
 import { request as httpReq } from 'node:http';
 import { WebTerminalServer } from '../WebTerminalServer';
@@ -352,6 +354,43 @@ describe('WebTerminalServer', () => {
     expect(res.headers.get('x-content-type-options')).toBe('nosniff');
     expect(res.headers.get('referrer-policy')).toBe('no-referrer');
     expect(res.headers.get('content-security-policy')).toContain("frame-ancestors 'none'");
+  });
+
+  // W4 (#608): the HTML page carries the FULL policy — per-build inline-script
+  // hashes instead of 'unsafe-inline', and connect-src 'self' so a future XSS
+  // regression could execute but never exfiltrate the token.
+  it('serves GET / with a full CSP: script hashes + connect-src self', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-web-csp-'));
+    fs.writeFileSync(
+      path.join(dir, 'terminal.html'),
+      '<html><head><script>var a=1;</script></head><body><script>var b=2;</script></body></html>',
+    );
+    const deps = makeDeps();
+    const csps = new WebTerminalServer({
+      sessionManager: deps.sessionManager,
+      log: () => { /* silent */ },
+      assetsDir: dir,
+    });
+    try {
+      const info = await csps.start({ port: 0, host: '127.0.0.1', allowInput: false });
+      const res = await fetch(`http://127.0.0.1:${info.port}/`);
+      expect(res.status).toBe(200);
+      const csp = res.headers.get('content-security-policy') ?? '';
+      expect(csp).toContain("default-src 'none'");
+      expect(csp).toContain("connect-src 'self'");
+      expect(csp).toContain("frame-ancestors 'none'");
+      // One hash per inline <script> block, no 'unsafe-inline' for scripts.
+      expect(csp.match(/'sha256-[A-Za-z0-9+/=]+'/g)).toHaveLength(2);
+      expect(csp).not.toMatch(/script-src[^;]*'unsafe-inline'/);
+      // JSON/API responses keep the minimal baseline policy (no hashes needed).
+      const api = await fetch(`http://127.0.0.1:${info.port}/api/config`, {
+        headers: { Authorization: `Bearer ${info.token}` },
+      });
+      expect(api.headers.get('content-security-policy')).toBe("frame-ancestors 'none'");
+    } finally {
+      if (csps.isRunning) await csps.stop();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   /** Raw request so we can set Host (undici forbids overriding it on fetch()). */


### PR DESCRIPTION
## What

Finding W4 from `docs/web-security-review-2026-07-24.md`. The web terminal page previously shipped `Content-Security-Policy: frame-ancestors 'none'` only. `GET /` now carries the full strict policy:

```
default-src 'none'; script-src 'self' 'sha256-…' 'sha256-…' 'sha256-…';
style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self';
manifest-src 'self'; worker-src 'self'; frame-ancestors 'none';
base-uri 'none'; form-action 'self'
```

There is no XSS today (xterm renders raw bytes, metadata goes through `textContent`) — this is containment: with `connect-src 'self'`, even a future regression that executes injected script cannot send the token anywhere off-origin.

## Design choice

The review doc suggested computing the hashes in `build-daemon-web.mjs`. I put them in the daemon instead: `loadAssets()` hashes each inline `<script>` block of the exact `terminal.html` bytes it is about to serve. The build script and the policy can then never drift apart — a rebuilt page automatically gets matching hashes, and there is no manifest file to forget.

Notes:
- `style-src` keeps `'unsafe-inline'`: xterm manages styles dynamically, and a style injection cannot reach the token.
- `worker-src 'self'` admits the `/sw.js` service worker that `default-src 'none'` would otherwise block.
- API/JSON responses keep the minimal `frame-ancestors 'none'` baseline — hashes are meaningless there.

## Verification

- New test: `GET /` (synthetic two-script page) returns the full policy with exactly one hash per inline block and no `'unsafe-inline'` in `script-src`; API responses keep the baseline. All 38 web server tests pass, `tsc --noEmit` clean.
- Audited the real built page (577 KB): 3 inline script blocks, zero external requests (the only `http://` strings are license comments and SVG namespaces), no inline event handlers, no `style=` attributes, no `eval`/`new Function`.

Closes #608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added a strict Content Security Policy to the `wmux web` terminal page.
  * Inline scripts are protected with exact, hash-based allowlists, without relying on unsafe inline execution.
  * Restricted connections to the application itself to help prevent access-token exfiltration.
  * Permitted service-worker functionality while maintaining other security protections.

* **Documentation**
  * Updated security review and changelog documentation to reflect the CSP hardening as shipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->