### PR TITLE
feat(onboarding): offer Claude Code statusline install in the first-run wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The first-run wizard now offers to enable the Claude Code statusline.** `wmux setup-statusline` — which shows model, context usage, and 5h/7d rate limits under Claude Code's input box — existed only as a CLI command, so app-only users never discovered it. The onboarding wizard now shows an opt-in "Enable statusline" step (macOS and Windows) when Claude Code is detected and at least one settings file can accept the install. It stays strictly opt-in: nothing installs at boot, an already-installed statusline shows nothing, and a user-authored statusline is never overwritten.
+
 - **In-app auto-update now works on macOS (Apple Silicon) (#609).** Settings → "Check for updates" did nothing on a Mac: the whole updater was gated to Windows, so the only way to move to a new version was to notice a release, download the DMG, and drag it over the old app. macOS (arm64) now follows the same flow Windows has: wmux polls for a newer release, downloads it, pins its SHA-256 against a manifest published by the release pipeline, and installs it on restart — sessions survive, because the daemon keeps running through the swap. Nothing is installed unless the download's hash matches the manifest exactly; on any mismatch or transport error the update is refused outright and the failure is shown rather than silently retried. A build that isn't code-signed (a locally-made one) can't self-update at all, and now says so with a link to the DMG instead of failing silently. Windows behavior, its release assets, and its manifest are all untouched; Linux and Intel Macs still have no in-app updater and are unaffected.
 
 ### Fixed

--- a/src/renderer/components/FirstRunWizard.tsx
+++ b/src/renderer/components/FirstRunWizard.tsx
@@ -54,6 +54,34 @@ function firstRunBridge(): FirstRunBridge {
   return api.firstRun;
 }
 
+// Statusline bridge (preload `statuslineBridge`). Optional: older preloads may
+// not expose it, so the accessor returns null instead of throwing and the
+// wizard simply hides the statusline offer.
+interface StatuslineBridge {
+  status: () => Promise<{
+    installed: boolean;
+    outcome: {
+      scriptDest: string;
+      scriptExists: boolean;
+      targets: Array<{ label: string; settingsPath: string; state: StatuslineTargetState }>;
+    };
+  }>;
+  install: () => Promise<{
+    ok: boolean;
+    error: string | null;
+    targets: Array<{ label: string; settingsPath: string; outcome: string }>;
+  }>;
+}
+
+export type StatuslineTargetState = 'none' | 'wmux' | 'foreign' | 'corrupt' | 'missing';
+
+function statuslineBridge(): StatuslineBridge | null {
+  const api = (window as unknown as {
+    electronAPI?: { statuslineBridge?: StatuslineBridge };
+  }).electronAPI;
+  return api?.statuslineBridge ?? null;
+}
+
 function shellOpenExternal(url: string): Promise<void> {
   const api = (window as unknown as {
     electronAPI?: { shell?: { openExternal: (u: string) => Promise<void> } };
@@ -120,6 +148,26 @@ export function formatCompletedAt(iso: string | undefined): string {
   return `${yyyy}-${mm}-${dd}`;
 }
 
+/**
+ * Whether the wizard should offer the statusline install.
+ *
+ * Hidden when already installed, and when no target could accept an install
+ * (every settings.json is foreign-owned or corrupt) — offering a button that
+ * can only no-op would be noise. 'none'/'missing' targets are installable
+ * (install creates missing settings files).
+ */
+export function decideStatuslineOffer(status: {
+  installed: boolean;
+  outcome: { targets: Array<{ state: StatuslineTargetState }> };
+} | null): 'offer' | 'hidden' {
+  if (!status) return 'hidden';
+  if (status.installed) return 'hidden';
+  const installable = status.outcome.targets.some(
+    (t) => t.state === 'none' || t.state === 'missing',
+  );
+  return installable ? 'offer' : 'hidden';
+}
+
 /** i18n keys for Tier 2 error display (D10). Falls back to UNKNOWN for unrecognized codes. */
 export function getRegisterErrorKeys(code: RegisterMcpErrorCode | string): {
   problem: string;
@@ -150,6 +198,13 @@ type SampleSubState =
   | 'timeout-fallback'
   | 'error';
 
+export type StatuslineSubState =
+  | 'unknown'   // status not fetched yet (or bridge unavailable) — block hidden
+  | 'offer'     // installable, waiting for the user's click
+  | 'installing'
+  | 'installed'
+  | 'error';
+
 const PTYID_WAIT_TIMEOUT_MS = 10_000;
 
 export default function FirstRunWizard({ mode, onClose }: FirstRunWizardProps) {
@@ -163,6 +218,8 @@ export default function FirstRunWizard({ mode, onClose }: FirstRunWizardProps) {
     { code: RegisterMcpErrorCode; message: string } | null
   >(null);
   const [sampleState, setSampleState] = useState<SampleSubState>('idle');
+  const [statuslineState, setStatuslineState] = useState<StatuslineSubState>('unknown');
+  const [statuslineError, setStatuslineError] = useState<string | null>(null);
 
   const dialogRef = useRef<HTMLDivElement>(null);
   const firstFocusRef = useRef<HTMLButtonElement>(null);
@@ -203,6 +260,49 @@ export default function FirstRunWizard({ mode, onClose }: FirstRunWizardProps) {
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  // ─── Statusline offer (opt-in; never auto-installs — owner decision 2026-07-17) ──
+  // Fetched once on mount; the block renders only when Claude is detected AND
+  // there is at least one installable settings target.
+  useEffect(() => {
+    const bridge = statuslineBridge();
+    if (!bridge) return;
+    bridge
+      .status()
+      .then((s) => {
+        if (!isMountedRef.current) return;
+        setStatuslineState(decideStatuslineOffer(s) === 'offer' ? 'offer' : 'unknown');
+      })
+      .catch(() => {
+        // Status probe failing is not worth surfacing — just keep the block hidden.
+      });
+  }, []);
+
+  const handleInstallStatusline = useCallback(async () => {
+    const bridge = statuslineBridge();
+    if (!bridge) return;
+    setStatuslineState('installing');
+    setStatuslineError(null);
+    try {
+      const outcome = await bridge.install();
+      if (!isMountedRef.current) return;
+      // ok:true still means "nothing broke", not "something was installed" —
+      // every target can be skipped (foreign/corrupt) if settings changed
+      // between the status probe and the click. Only report success when a
+      // target actually took the install.
+      const installedSomewhere = outcome.targets.some((t) => t.outcome === 'installed');
+      if (outcome.ok && installedSomewhere) {
+        setStatuslineState('installed');
+      } else {
+        setStatuslineError(outcome.error);
+        setStatuslineState('error');
+      }
+    } catch (err) {
+      if (!isMountedRef.current) return;
+      setStatuslineError(err instanceof Error ? err.message : null);
+      setStatuslineState('error');
+    }
+  }, []);
 
   // ─── Dismiss / Escape ──────────────────────────────────────────────────────
   const dismiss = useCallback(async () => {
@@ -394,6 +494,8 @@ export default function FirstRunWizard({ mode, onClose }: FirstRunWizardProps) {
         style={{
           width: 480,
           maxWidth: '90vw',
+          maxHeight: '90vh',
+          overflowY: 'auto',
           backgroundColor: 'var(--bg-base)',
           border: '1px solid var(--bg-surface)',
           boxShadow: 'var(--shadow-modal)',
@@ -508,6 +610,15 @@ export default function FirstRunWizard({ mode, onClose }: FirstRunWizardProps) {
                   );
                 })()}
               </div>
+            )}
+
+            {/* Statusline opt-in (only when Claude detected & installable) */}
+            {result.status.claudeFound && statuslineState !== 'unknown' && (
+              <StatuslineBlock
+                state={statuslineState}
+                errorDetail={statuslineError}
+                onInstall={() => void handleInstallStatusline()}
+              />
             )}
 
             {/* Sample task block */}
@@ -627,6 +738,80 @@ export function ClaudeStatusBlock({
           </button>
         </div>
       )}
+    </div>
+  );
+}
+
+export function StatuslineBlock({
+  state,
+  errorDetail,
+  onInstall,
+}: {
+  state: StatuslineSubState;
+  errorDetail?: string | null;
+  onInstall: () => void;
+}) {
+  const t = useT();
+
+  if (state === 'installed') {
+    return (
+      <div
+        className="flex flex-col gap-1 p-3 rounded-lg"
+        style={{
+          backgroundColor: 'var(--bg-surface)',
+          border: '1px solid var(--accent-green, #a6e3a1)',
+        }}
+        data-testid="first-run-wizard-statusline-installed"
+      >
+        <p className="text-sm font-semibold" style={{ color: 'var(--text-main)', margin: 0 }}>
+          ✓ {t('firstRunWizard.statuslineInstalled')}
+        </p>
+        <p className="text-xs" style={{ color: 'var(--text-sub)', margin: 0 }}>
+          {t('firstRunWizard.statuslineInstalledHint')}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-2 p-3 rounded-lg"
+      style={{ backgroundColor: 'var(--bg-surface)' }}
+      data-testid="first-run-wizard-statusline-offer"
+    >
+      <p className="text-sm font-semibold" style={{ color: 'var(--text-main)', margin: 0 }}>
+        {t('firstRunWizard.statuslineHeading')}
+      </p>
+      <p className="text-xs" style={{ color: 'var(--text-sub)', margin: 0 }}>
+        {t('firstRunWizard.statuslineDescription')}
+      </p>
+      {state === 'error' && (
+        <p
+          className="text-xs"
+          style={{ color: 'var(--accent-red, #f38ba8)', margin: 0 }}
+          data-testid="first-run-wizard-statusline-error"
+        >
+          {t('firstRunWizard.statuslineError')}
+          {errorDetail ? ` (${errorDetail})` : ''}
+        </p>
+      )}
+      <button
+        onClick={onInstall}
+        disabled={state === 'installing'}
+        data-testid="first-run-wizard-statusline-install"
+        className="self-start px-3 py-1 rounded text-xs font-medium"
+        style={{
+          backgroundColor: 'var(--accent)',
+          color: 'var(--bg-base)',
+          border: 'none',
+          cursor: state === 'installing' ? 'wait' : 'pointer',
+          opacity: state === 'installing' ? 0.7 : 1,
+        }}
+      >
+        {state === 'installing'
+          ? t('firstRunWizard.statuslineInstalling')
+          : t('firstRunWizard.statuslineEnableButton')}
+      </button>
     </div>
   );
 }

--- a/src/renderer/components/__tests__/FirstRunWizard.test.ts
+++ b/src/renderer/components/__tests__/FirstRunWizard.test.ts
@@ -23,6 +23,8 @@ import {
   getRegisterErrorKeys,
   ClaudeStatusBlock,
   SampleTaskBlock,
+  StatuslineBlock,
+  decideStatuslineOffer,
 } from '../FirstRunWizard';
 import type { FirstRunCheckResult } from '../../../shared/firstRun';
 import type { Pane } from '../../../shared/types';
@@ -370,5 +372,57 @@ describe('electronAPI.firstRun mock surface', () => {
     expect(typeof api.startSampleTask).toBe('function');
     expect(typeof api.onSampleTaskReady).toBe('function');
     expect(typeof api.onSampleTaskTimeout).toBe('function');
+  });
+});
+
+// ─── Statusline opt-in (onboarding install offer) ─────────────────────────────
+
+describe('decideStatuslineOffer', () => {
+  const status = (
+    installed: boolean,
+    states: Array<'none' | 'wmux' | 'foreign' | 'corrupt' | 'missing'>,
+  ) => ({
+    installed,
+    outcome: { targets: states.map((state) => ({ state })) },
+  });
+
+  it('offers when not installed and a target is installable', () => {
+    expect(decideStatuslineOffer(status(false, ['none']))).toBe('offer');
+    expect(decideStatuslineOffer(status(false, ['foreign', 'missing']))).toBe('offer');
+  });
+
+  it('hides when installed, when null, or when no target can accept', () => {
+    expect(decideStatuslineOffer(null)).toBe('hidden');
+    expect(decideStatuslineOffer(status(true, ['wmux']))).toBe('hidden');
+    expect(decideStatuslineOffer(status(false, ['foreign']))).toBe('hidden');
+    expect(decideStatuslineOffer(status(false, ['corrupt', 'foreign']))).toBe('hidden');
+  });
+});
+
+describe('StatuslineBlock', () => {
+  it('renders the enable button in offer state and disables it while installing', () => {
+    const offer = renderToStaticMarkup(
+      createElement(StatuslineBlock, { state: 'offer', onInstall: () => undefined }),
+    );
+    expect(offer).toContain('first-run-wizard-statusline-offer');
+    expect(offer).toContain('first-run-wizard-statusline-install');
+    expect(offer).not.toContain('disabled');
+
+    const installing = renderToStaticMarkup(
+      createElement(StatuslineBlock, { state: 'installing', onInstall: () => undefined }),
+    );
+    expect(installing).toContain('disabled');
+  });
+
+  it('renders success and error variants', () => {
+    const installed = renderToStaticMarkup(
+      createElement(StatuslineBlock, { state: 'installed', onInstall: () => undefined }),
+    );
+    expect(installed).toContain('first-run-wizard-statusline-installed');
+
+    const error = renderToStaticMarkup(
+      createElement(StatuslineBlock, { state: 'error', onInstall: () => undefined }),
+    );
+    expect(error).toContain('first-run-wizard-statusline-error');
   });
 });

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -720,6 +720,14 @@ export const en = {
   'firstRunWizard.alreadyCompleted': 'Already completed on {date}',
   'firstRunWizard.fallbackPressEnter': 'Press Enter to continue',
   'firstRunWizard.fallbackButton': 'Continue',
+  'firstRunWizard.statuslineHeading': 'Claude Code statusline (recommended)',
+  'firstRunWizard.statuslineDescription':
+    'Show model, context usage, and rate limits under Claude Code\'s input box. Your own statusline, if any, is never overwritten.',
+  'firstRunWizard.statuslineEnableButton': 'Enable statusline',
+  'firstRunWizard.statuslineInstalling': 'Installing…',
+  'firstRunWizard.statuslineInstalled': 'Statusline enabled',
+  'firstRunWizard.statuslineInstalledHint': 'New Claude Code sessions will show it automatically.',
+  'firstRunWizard.statuslineError': 'Install failed. You can retry, or run `wmux setup-statusline` from a terminal.',
 
   // First-run wizard — registerMcp Tier 2 errors (D10, problem / cause / fix)
   'firstRunWizard.error.PERM.problem': 'wmux could not write to ~/.claude.json.',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -559,6 +559,14 @@ export const ko = {
   'firstRunWizard.alreadyCompleted': '{date}에 완료되었습니다',
   'firstRunWizard.fallbackPressEnter': '계속하려면 Enter를 누르세요',
   'firstRunWizard.fallbackButton': '계속',
+  'firstRunWizard.statuslineHeading': 'Claude Code 상태줄 (권장)',
+  'firstRunWizard.statuslineDescription':
+    'Claude Code 입력창 아래에 모델·컨텍스트 사용량·사용 한도를 표시합니다. 직접 설정한 상태줄이 있으면 절대 덮어쓰지 않습니다.',
+  'firstRunWizard.statuslineEnableButton': '상태줄 켜기',
+  'firstRunWizard.statuslineInstalling': '설치 중…',
+  'firstRunWizard.statuslineInstalled': '상태줄 켜짐',
+  'firstRunWizard.statuslineInstalledHint': '새 Claude Code 세션부터 자동으로 표시됩니다.',
+  'firstRunWizard.statuslineError': '설치에 실패했습니다. 다시 시도하거나 터미널에서 `wmux setup-statusline`을 실행하세요.',
 
   // First-run wizard — registerMcp Tier 2 errors (D10, problem / cause / fix)
   'firstRunWizard.error.PERM.problem': '~/.claude.json에 쓸 수 없습니다.',


### PR DESCRIPTION
## What

The first-run wizard now shows an opt-in **Enable statusline** step when Claude Code is detected. One click installs the per-account usage statusline (model · account · context % · 5h/7d rate limits under Claude Code's input box) — the same thing `wmux setup-statusline` does, which until now was CLI-only and invisible to app-only users. Works on macOS and Windows; the existing installer already handles both.

## Why

The statusline backend, IPC handlers, and preload bridge all existed, but no UI ever called them — an app-only user (winget/Setup.exe) had no way to discover the feature.

## Design constraints respected

- **Strictly opt-in** (no-auto-install-at-boot decision, 2026-07-17): nothing runs without a click.
- The block is **hidden** when the statusline is already installed, or when every settings target is foreign-owned or corrupt (a button that can only no-op is noise).
- A user-authored `statusLine` is never overwritten (existing installer guarantee).
- Success is reported only when a target actually took the install — `ok:true` alone also covers the all-skipped case if settings changed between the status probe and the click.
- Install failures surface the underlying error message; the dialog gained `max-height`/`overflow-y` so the extra block can't push the footer off small screens.

## Tests

- `decideStatuslineOffer` offer/hidden matrix (installed, foreign-only, corrupt, missing/none targets)
- `StatuslineBlock` render variants (offer / installing disabled / installed / error)
- Full suite for the file: 30 passing; `tsc --noEmit` and eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional Claude Code statusline setup step to the first-run wizard.
  - Users can enable the statusline when eligible, with clear installing, success, and error states.
  - Existing statuslines are preserved, and installation can be retried from the terminal if needed.
  - Updated English and Korean translations for the new wizard experience.

- **Documentation**
  - Documented the statusline opt-in flow and installation behavior in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->