### PR TITLE
chore(release): 3.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.35.0] — 2026-07-25
+
 ### Security
 
 - **The `wmux web` page now ships a full Content-Security-Policy (#608).** The page previously carried only frame protection. It now declares a strict policy — every inline script is allowed by its exact hash (no `'unsafe-inline'`), and `connect-src 'self'` means that even if a rendering bug ever reintroduced an XSS, the injected script could execute but could not send the access token anywhere. The hashes are computed by the daemon from the exact page bytes it serves, so the policy can never drift out of sync with a build. Purely defense-in-depth: there is no known XSS today, and nothing changes for a working session.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.34.0 sources.** This file is produced by
+> **Generated from wmux v3.35.0 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.34.0",
+  "version": "3.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.34.0",
+      "version": "3.35.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.34.0",
+  "version": "3.35.0",
   "description": "Workspace multiplexer for AI coding agents — run fleets of Claude Code, Codex & Gemini in parallel on Windows & macOS, with MCP browser automation built in",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Version bump, CHANGELOG promotion, regenerated API reference. Four files, the same shape as every previous release commit.

## What ships in 3.35.0

Everything under `[Unreleased]`, which is the phone-access line from #616 plus the security work that landed alongside it:

- **Reach your agents from a phone.** Hooks arrive at the always-on daemon rather than the desktop, so an agent signal survives closing the window. An `AskUserQuestion` prompt becomes a request any paired surface can answer — allowed on a read-only server, because answering one daemon-raised request is strictly narrower than `--allow-input`.
- **Per-device credentials.** Pairing hands each phone its own revocable credential instead of the server-wide token; revoking one cuts its live streams immediately and fails closed. `wmux web --new-token` revokes every paired device, which it had stopped doing once credentials became per-device.
- **`wmux web --tailscale`** sets up tailnet HTTPS in one command, and `--status` now prints the address a phone can actually use rather than the loopback bind.
- **A full CSP** on the served page, with hashes computed from the exact bytes the daemon serves.
- **Groundwork for push:** a relay that cannot read what it forwards, and an envelope sealed to a key that never leaves the phone.

The iOS app itself is not in this release; the contract it implements is documented in `docs/phone-client-contract.md`.

## Verification

`main` is green at 84e751d5 (Baseline on all three platforms, Perf, CI). The API reference regenerates byte-identical apart from the version line the drift guard checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the API reference to reflect version 3.35.0 sources.
* **Release**
  * Published version 3.35.0.
  * Added the v3.35.0 release entry to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->