### PR TITLE
test(daemon): wait for the pipe server to register a socket, not for 50ms

### DIFF
--- a/src/daemon/__tests__/DaemonPipeServer.test.ts
+++ b/src/daemon/__tests__/DaemonPipeServer.test.ts
@@ -11,30 +11,8 @@ import {
   getDaemonAuthTokenPath,
   getLegacyDaemonAuthTokenPath,
 } from '../../shared/constants';
+import { waitFor } from '../../test-utils/waitFor';
 
-/**
- * Wait until `predicate` holds, polling instead of sleeping a fixed span.
- *
- * The server registers a socket inside its OWN `connection` handler, which is a
- * different event on the other side of the pipe from the client's `connect`. A
- * fixed sleep is a guess about how far apart those two land, and on a loaded
- * Windows runner the guess loses — named pipes have a longer accept path than
- * unix sockets, and the Windows leg is the slowest of the three-OS matrix. When
- * it loses, the socket is not in `connectedSockets` yet, so `rotateToken()`
- * iterates a set that does not contain it, the connection is never dropped, and
- * the test hangs until vitest kills it with a bare "timed out in 5000ms".
- *
- * Waiting for the condition itself is both sturdier and faster: no fixed cost on
- * a quick machine, and a named failure instead of an anonymous timeout on a slow
- * one.
- */
-async function waitFor(predicate: () => boolean, label: string, timeoutMs = 4000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) throw new Error(`timed out waiting for ${label}`);
-    await new Promise((r) => setTimeout(r, 5));
-  }
-}
 
 // Helper: generate unique pipe name for each test to avoid conflicts
 function testPipeName(suffix: string): string {
@@ -282,7 +260,7 @@ describe('DaemonPipeServer', () => {
       c1.on('connect', onConn);
       c2.on('connect', onConn);
     });
-    await waitFor(() => server.getConnectionCount() === 2, 'both sockets to register');
+    await waitFor(() => server.getConnectionCount() === 2);
     // While a client is still connected, the disconnect anchor must remain
     // untouched (otherwise the idle window would start during active use).
     expect(server.getLastDisconnectAt()).toBeNull();
@@ -292,13 +270,13 @@ describe('DaemonPipeServer', () => {
     const c2Closed = new Promise<void>((r) => c2.on('close', () => r()));
     c1.destroy();
     await c1Closed;
-    await waitFor(() => server.getConnectionCount() === 1, 'the first socket to deregister');
+    await waitFor(() => server.getConnectionCount() === 1);
     // One socket still alive — counter dropped to 1, anchor still null.
     expect(server.getLastDisconnectAt()).toBeNull();
 
     c2.destroy();
     await c2Closed;
-    await waitFor(() => server.getConnectionCount() === 0, 'the last socket to deregister');
+    await waitFor(() => server.getConnectionCount() === 0);
     const anchor = server.getLastDisconnectAt();
     expect(anchor).not.toBeNull();
     expect(anchor!).toBeGreaterThanOrEqual(before);
@@ -322,7 +300,7 @@ describe('DaemonPipeServer', () => {
     // rotateToken() only destroys sockets the SERVER has registered, so wait
     // for that rather than for the client's own connect event plus a guess.
     await new Promise<void>((resolve) => liveClient.on('connect', () => resolve()));
-    await waitFor(() => server.getConnectionCount() === 1, 'the live socket to register');
+    await waitFor(() => server.getConnectionCount() === 1);
 
     const oldToken = 'test-token-123';
     const newToken = server.rotateToken();
@@ -586,10 +564,7 @@ describe('SessionPipe', () => {
     expect(clientOutput.toString()).toContain('pty output');
 
     // Verify PTY received client input.
-    await waitFor(
-      () => Buffer.concat(inputReceived).toString() === 'user input',
-      'the PTY to receive the client input',
-    );
+    await waitFor(() => Buffer.concat(inputReceived).toString() === 'user input');
     expect(Buffer.concat(inputReceived).toString()).toBe('user input');
   });
 
@@ -611,13 +586,13 @@ describe('SessionPipe', () => {
     });
     // The server processes the auth line asynchronously; wait for the flag the
     // assertion reads rather than for a fixed span.
-    await waitFor(() => sessionPipe.isConnected, 'the session pipe to authenticate');
+    await waitFor(() => sessionPipe.isConnected);
 
     expect(sessionPipe.isConnected).toBe(true);
 
     // Disconnect
     client.destroy();
-    await waitFor(() => !sessionPipe.isConnected, 'the session pipe to notice the disconnect');
+    await waitFor(() => !sessionPipe.isConnected);
 
     expect(sessionPipe.isConnected).toBe(false);
   });

--- a/src/daemon/__tests__/DaemonPipeServer.test.ts
+++ b/src/daemon/__tests__/DaemonPipeServer.test.ts
@@ -12,6 +12,30 @@ import {
   getLegacyDaemonAuthTokenPath,
 } from '../../shared/constants';
 
+/**
+ * Wait until `predicate` holds, polling instead of sleeping a fixed span.
+ *
+ * The server registers a socket inside its OWN `connection` handler, which is a
+ * different event on the other side of the pipe from the client's `connect`. A
+ * fixed sleep is a guess about how far apart those two land, and on a loaded
+ * Windows runner the guess loses — named pipes have a longer accept path than
+ * unix sockets, and the Windows leg is the slowest of the three-OS matrix. When
+ * it loses, the socket is not in `connectedSockets` yet, so `rotateToken()`
+ * iterates a set that does not contain it, the connection is never dropped, and
+ * the test hangs until vitest kills it with a bare "timed out in 5000ms".
+ *
+ * Waiting for the condition itself is both sturdier and faster: no fixed cost on
+ * a quick machine, and a named failure instead of an anonymous timeout on a slow
+ * one.
+ */
+async function waitFor(predicate: () => boolean, label: string, timeoutMs = 4000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${label}`);
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
 // Helper: generate unique pipe name for each test to avoid conflicts
 function testPipeName(suffix: string): string {
   const id = crypto.randomUUID().slice(0, 8);
@@ -258,10 +282,7 @@ describe('DaemonPipeServer', () => {
       c1.on('connect', onConn);
       c2.on('connect', onConn);
     });
-    // Server-side socket registration runs inside the listener callback,
-    // give it a tick to land in connectedSockets.
-    await new Promise((r) => setTimeout(r, 50));
-    expect(server.getConnectionCount()).toBe(2);
+    await waitFor(() => server.getConnectionCount() === 2, 'both sockets to register');
     // While a client is still connected, the disconnect anchor must remain
     // untouched (otherwise the idle window would start during active use).
     expect(server.getLastDisconnectAt()).toBeNull();
@@ -271,15 +292,13 @@ describe('DaemonPipeServer', () => {
     const c2Closed = new Promise<void>((r) => c2.on('close', () => r()));
     c1.destroy();
     await c1Closed;
-    await new Promise((r) => setTimeout(r, 30));
+    await waitFor(() => server.getConnectionCount() === 1, 'the first socket to deregister');
     // One socket still alive — counter dropped to 1, anchor still null.
-    expect(server.getConnectionCount()).toBe(1);
     expect(server.getLastDisconnectAt()).toBeNull();
 
     c2.destroy();
     await c2Closed;
-    await new Promise((r) => setTimeout(r, 30));
-    expect(server.getConnectionCount()).toBe(0);
+    await waitFor(() => server.getConnectionCount() === 0, 'the last socket to deregister');
     const anchor = server.getLastDisconnectAt();
     expect(anchor).not.toBeNull();
     expect(anchor!).toBeGreaterThanOrEqual(before);
@@ -300,9 +319,10 @@ describe('DaemonPipeServer', () => {
     const liveClosed = new Promise<void>((resolve) => liveClient.on('close', () => resolve()));
 
     // Wait briefly for connection to be registered.
-    await new Promise<void>((resolve) => {
-      liveClient.on('connect', () => setTimeout(resolve, 50));
-    });
+    // rotateToken() only destroys sockets the SERVER has registered, so wait
+    // for that rather than for the client's own connect event plus a guess.
+    await new Promise<void>((resolve) => liveClient.on('connect', () => resolve()));
+    await waitFor(() => server.getConnectionCount() === 1, 'the live socket to register');
 
     const oldToken = 'test-token-123';
     const newToken = server.rotateToken();
@@ -565,10 +585,12 @@ describe('SessionPipe', () => {
     // Verify client received PTY output
     expect(clientOutput.toString()).toContain('pty output');
 
-    // Verify PTY received client input (small delay for async)
-    await new Promise((r) => setTimeout(r, 50));
-    const allInput = Buffer.concat(inputReceived).toString();
-    expect(allInput).toBe('user input');
+    // Verify PTY received client input.
+    await waitFor(
+      () => Buffer.concat(inputReceived).toString() === 'user input',
+      'the PTY to receive the client input',
+    );
+    expect(Buffer.concat(inputReceived).toString()).toBe('user input');
   });
 
   it('should report isConnected correctly', async () => {
@@ -584,16 +606,18 @@ describe('SessionPipe', () => {
     await new Promise<void>((resolve) => {
       client.on('connect', () => {
         client.write(SESSION_AUTH_TOKEN + '\n');
-        // Small delay to allow server to process auth + connection
-        setTimeout(resolve, 100);
+        resolve();
       });
     });
+    // The server processes the auth line asynchronously; wait for the flag the
+    // assertion reads rather than for a fixed span.
+    await waitFor(() => sessionPipe.isConnected, 'the session pipe to authenticate');
 
     expect(sessionPipe.isConnected).toBe(true);
 
     // Disconnect
     client.destroy();
-    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    await waitFor(() => !sessionPipe.isConnected, 'the session pipe to notice the disconnect');
 
     expect(sessionPipe.isConnected).toBe(false);
   });

--- a/src/daemon/__tests__/SessionPipe.attachSnapshot.test.ts
+++ b/src/daemon/__tests__/SessionPipe.attachSnapshot.test.ts
@@ -18,17 +18,7 @@ import { Terminal } from '@xterm/headless';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { SessionPipe, FLUSH_DONE_MARKER, ATTACH_SNAPSHOT_MIN_BYTES } from '../SessionPipe';
 import { RingBuffer } from '../RingBuffer';
-
-const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
-
-async function waitFor(pred: () => boolean, deadlineMs: number): Promise<void> {
-  const start = Date.now();
-  for (;;) {
-    if (pred()) return;
-    if (Date.now() - start > deadlineMs) throw new Error('waitFor: deadline exceeded');
-    await sleep(5);
-  }
-}
+import { waitFor } from '../../test-utils/waitFor';
 
 function uniqueSessionId(tag: string): string {
   return `attsnap-${tag}-${crypto.randomUUID().slice(0, 8)}`;

--- a/src/daemon/__tests__/SessionPipe.clientgone.test.ts
+++ b/src/daemon/__tests__/SessionPipe.clientgone.test.ts
@@ -3,19 +3,11 @@ import net from 'node:net';
 import crypto from 'node:crypto';
 import { SessionPipe } from '../SessionPipe';
 import { RingBuffer } from '../RingBuffer';
+import { waitFor } from '../../test-utils/waitFor';
 
 // ── helpers ─────────────────────────────────────────────────────────
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
-
-async function waitFor(pred: () => boolean, deadlineMs: number): Promise<void> {
-  const start = Date.now();
-  for (;;) {
-    if (pred()) return;
-    if (Date.now() - start > deadlineMs) throw new Error('waitFor: deadline exceeded');
-    await sleep(5);
-  }
-}
 
 function uniqueSessionId(tag: string): string {
   return `clientgone-${tag}-${crypto.randomUUID().slice(0, 8)}`;

--- a/src/daemon/__tests__/SessionPipe.reflush.test.ts
+++ b/src/daemon/__tests__/SessionPipe.reflush.test.ts
@@ -11,19 +11,11 @@ import {
 } from '../SessionPipe';
 import { RingBuffer } from '../RingBuffer';
 import { generateSnapshot } from '../HeadlessSnapshot';
+import { waitFor } from '../../test-utils/waitFor';
 
 // ── helpers ─────────────────────────────────────────────────────────
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
-
-async function waitFor(pred: () => boolean, deadlineMs: number): Promise<void> {
-  const start = Date.now();
-  for (;;) {
-    if (pred()) return;
-    if (Date.now() - start > deadlineMs) throw new Error('waitFor: deadline exceeded');
-    await sleep(5);
-  }
-}
 
 /** Unique per-test session id so named pipes / unix sockets never collide. */
 function uniqueSessionId(tag: string): string {

--- a/src/test-utils/__tests__/waitFor.test.ts
+++ b/src/test-utils/__tests__/waitFor.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { waitFor, DEFAULT_WAIT_TIMEOUT_MS } from '../waitFor';
+
+describe('waitFor', () => {
+  it('returns as soon as the condition holds, without waiting out the timeout', async () => {
+    let ready = false;
+    setTimeout(() => { ready = true; }, 20);
+
+    const started = Date.now();
+    await waitFor(() => ready, 2_000);
+    // The point of polling over sleeping: a fast machine pays ~nothing.
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
+  it('returns immediately when the condition already holds', async () => {
+    const started = Date.now();
+    await waitFor(() => true, 2_000);
+    expect(Date.now() - started).toBeLessThan(50);
+  });
+
+  it('★ names what it was waiting for when it times out', async () => {
+    // The whole reason this replaced `setTimeout(50)`: the failure that started
+    // this was an anonymous "timed out in 5000ms" that said nothing about the
+    // condition, so diagnosing it meant reading CI logs line by line.
+    // `let`, not `const`: a const 0 narrows to the literal type and `=== 1`
+    // becomes a compile error rather than a condition that never holds.
+    let connectionCount = 0;
+    connectionCount += 0;
+    await expect(waitFor(() => connectionCount === 1, 30)).rejects.toThrow(
+      /waitFor: \(\) => connectionCount === 1 did not hold within 30ms/,
+    );
+  });
+
+  it('prefers an explicit label when one is given', async () => {
+    await expect(waitFor(() => false, 30, 'the pane to attach')).rejects.toThrow(
+      'waitFor: the pane to attach did not hold within 30ms',
+    );
+  });
+
+  it('bounds a long predicate so the message stays readable', async () => {
+    // The literal has to be in the arrow's SOURCE, not behind a variable — a
+    // long value with a short expression produces a short label, which is
+    // correct and is what an earlier version of this test failed to check.
+    const predicate = (): boolean =>
+      'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' +
+        'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy' ===
+      'z';
+    let message = '';
+    await waitFor(predicate, 30).catch((err: Error) => { message = err.message; });
+    expect(message).toContain('…');
+    expect(message.length).toBeLessThan(200);
+  });
+
+  it('has a default timeout that fits under a 5s vitest timeout', () => {
+    expect(DEFAULT_WAIT_TIMEOUT_MS).toBeLessThan(5_000);
+  });
+});

--- a/src/test-utils/waitFor.ts
+++ b/src/test-utils/waitFor.ts
@@ -1,0 +1,60 @@
+/**
+ * Wait for a condition instead of sleeping a fixed span.
+ *
+ * TEST-ONLY. Nothing in `src/` outside a test should import this; production
+ * code that needs to wait for something should be given an event, not a poll.
+ *
+ * ── Why this exists as one shared thing ────────────────────────────────────
+ * Four test files had defined their own byte-identical copy, and a fifth had
+ * open-coded the same idea as `setTimeout(50)`. That last one is the reason
+ * this file exists: `DaemonPipeServer.test.ts` slept 50ms as a stand-in for
+ * "the server has registered this socket", and on a loaded windows-latest
+ * runner the sleep finished first. The socket was not yet in the server's set,
+ * `rotateToken()` did not drop it, and the test hung until vitest killed it at
+ * 5000ms with no indication of what it had been waiting for.
+ *
+ * A fixed sleep is a guess about how long something else will take. It is
+ * simultaneously too short (it flakes on a busy machine) and too long (every
+ * fast run pays it), and when it loses, the failure names nothing.
+ *
+ * ── The label ──────────────────────────────────────────────────────────────
+ * Defaults to the predicate's own source text, which is usually a better
+ * description than anything a caller would type, and costs the caller nothing:
+ *
+ *   waitFor(() => server.getConnectionCount() === 1)
+ *   → "waitFor: () => server.getConnectionCount() === 1 did not hold within 4000ms"
+ *
+ * The three copies this replaces all threw a bare "waitFor: deadline exceeded",
+ * which put their failures in exactly the position the flake above was in.
+ */
+
+/** Long enough for a contended CI runner, short enough to stay under a 5s test timeout. */
+export const DEFAULT_WAIT_TIMEOUT_MS = 4_000;
+
+/** How often the predicate is re-checked. Cheap; the predicates are memory reads. */
+const POLL_INTERVAL_MS = 5;
+
+/** Keep a runaway arrow function from producing an unreadable failure message. */
+const MAX_LABEL_CHARS = 120;
+
+export async function waitFor(
+  predicate: () => boolean,
+  timeoutMs: number = DEFAULT_WAIT_TIMEOUT_MS,
+  label?: string,
+): Promise<void> {
+  const start = Date.now();
+  for (;;) {
+    if (predicate()) return;
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(
+        `waitFor: ${label ?? describe(predicate)} did not hold within ${timeoutMs}ms`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+}
+
+function describe(predicate: () => boolean): string {
+  const source = String(predicate).replace(/\s+/g, ' ').trim();
+  return source.length > MAX_LABEL_CHARS ? `${source.slice(0, MAX_LABEL_CHARS)}…` : source;
+}


### PR DESCRIPTION
`rotateToken invalidates old token, issues new one, drops connected sockets` timed out on `windows-latest` during the 3.35.0 release, with 8311/8333 otherwise passing, and went green on a plain re-run. Noted as a loose end in #622.

## What was actually wrong

The test, not the server.

`rotateToken()` destroys the sockets in `connectedSockets`, and the server adds a socket to that set inside its own `connection` handler. That is a different event, on the other side of the pipe, from the client's `connect`. The test bridged the two with `setTimeout(50)` — a guess about how far apart they land.

Named pipes have a longer accept path than unix sockets and the Windows leg is the slowest of the three-OS matrix, so that is where the guess loses. When it does: rotation iterates a set that does not yet contain the socket, the connection is never dropped, `await liveClosed` never resolves, and vitest kills the test with an anonymous "timed out in 5000ms" that names nothing.

## The change

Wait for the condition instead of for a duration. The server already exposes everything needed — `getConnectionCount()`, `isConnected`, and in one case the input buffer the assertion itself reads.

Six sites in `DaemonPipeServer.test.ts` had this shape. Only one had failed so far; the rest are the same defect and would fail the same way.

Second commit consolidates: four test files had each defined a byte-identical `waitFor`, so it now lives in `src/test-utils/waitFor.ts` and the three copies are gone. The label defaults to the predicate's own source, which is why the ~21 existing call sites did not have to change — the second argument is still a timeout, and the message improves anyway:

```
waitFor: () => server.getConnectionCount() === 1 did not hold within 4000ms
```

The three copies all threw a bare `waitFor: deadline exceeded`, which put their failures in the same position as the flake that started this.

## Deliberately not done

The same fixed-sleep pattern appears ~68 times across 20 test files. Most are legitimate — waiting out a debounce window, where the time *is* what is under test. Converting them without diagnosing each one would be a speculative rewrite of tests that have never failed. This covers the files that already had the helper, plus the one that needed it.

## Verification

- The four touched suites: 43/43. `DaemonPipeServer.test.ts` run five times, stable.
- Faster, not just sturdier: test time 2.75s → 2.36s locally, matching the ~410ms of fixed sleeps removed.
- Three typecheck configs, and the helper has its own tests — including that a timeout names the condition.

One `no-empty-function` error remains in `SessionPipe.attachSnapshot.test.ts`; it is on `main` already and is left alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved asynchronous test reliability by waiting for expected conditions instead of using fixed delays.
  * Added coverage for timeout handling, custom labels, immediate resolution, and readable error messages.
* **Refactor**
  * Consolidated repeated test polling logic into a shared utility with configurable timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->