### PR TITLE
chore(release): 3.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.35.1] — 2026-07-26
+
 ### Fixed
 
 - **The app's `web` popover can now actually connect a phone.** It offered two options and neither worked: the default served only to this machine, so the address it showed was meaningless on a phone, and "Expose to network" reached the phone but then refused to pair, because a device credential never expires and is not handed out over plain HTTP. Worse, the popover advertised a fresh pairing code every ten seconds in exactly that state — you read six characters onto a phone and only the redemption told you it was never going to work. There is now a "Serve over HTTPS (needs Tailscale)" option that sets up the same one-command Tailscale front `wmux web --tailscale` uses, and when pairing cannot succeed the popover says why and what to do instead of showing a code. If Tailscale is missing or logged out, the popover says which of those it is and links straight to the install page rather than leaving you a URL to retype. Ticking it unticks "Expose to network" and the reverse: `tailscale serve` proxies to this machine only, so a wildcard bind alongside it is a second and weaker way in, not an addition. "Expose to network" now also says plainly that it serves panes for watching but cannot pair a phone.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.35.0 sources.** This file is produced by
+> **Generated from wmux v3.35.1 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.35.0",
+  "version": "3.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.35.0",
+      "version": "3.35.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.35.0",
+  "version": "3.35.1",
   "description": "Workspace multiplexer for AI coding agents — run fleets of Claude Code, Codex & Gemini in parallel on Windows & macOS, with MCP browser automation built in",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Cuts 3.35.1 from the three PRs merged today: the GUI phone pairing path (#627), QR scan pairing (#628), and the pipe-server test fix (#625).

The usual four files — version in `package.json` and both places in the lockfile, `[Unreleased]` promoted to `[3.35.1]`, and `docs/api/reference.md` regenerated because its header bakes the version and CI's drift guard enforces it.

Owner picked PATCH. Worth noting for the next one: the changelog carries two `### Added` entries (device naming, QR pairing) and the public `WebTerminalInfo` grew five fields, which by the SemVer line in the changelog header would read MINOR. Recorded here rather than silently, so the precedent is visible.