### PR TITLE
chore(release): 3.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.36.0] — 2026-07-26
 
 ### Added
 

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.35.1 sources.** This file is produced by
+> **Generated from wmux v3.36.0 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.35.1",
+  "version": "3.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.35.1",
+      "version": "3.36.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.35.1",
+  "version": "3.36.0",
   "description": "Workspace multiplexer for AI coding agents — run fleets of Claude Code, Codex & Gemini in parallel on Windows & macOS, with MCP browser automation built in",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Cuts 3.36.0 from the five entries that accumulated under Unreleased. Minor rather than patch: three of them add wire surface.

- Pane diff over the web API (#630)
- Pane create and close from a phone (#630)
- A server-authoritative `tier` on attention events, and a `risk` hint on approvals (#631)
- A perf gate that confirms a red with a re-run before failing the build (#632)

Version bumped in `package.json` and the lockfile, the Unreleased heading renamed, and `docs/api/reference.md` regenerated so the drift guard stays quiet. No other changes.