### PR TITLE
fix(web): durably revoke state on stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **A successful `wmux web --stop` now means the listener is off now and stays off after a daemon restart.** If Windows refuses to delete `web-state.json`, wmux securely replaces it with a disabled record that contains no bearer token; if neither operation succeeds, it still stops the live server but reports that persisted state could not be revoked instead of acknowledging a durable stop. The popover shows that real error instead of claiming the daemon is offline, and a Tailscale front is still removed once a fresh status check confirms the listener did stop. A reusable web token is now written only after its inode has been synchronously hardened, POSIX overwrites repair mode `0600`, and boot restore no longer rewrites an identical record merely to re-harden it — existing permissions are repaired asynchronously without freezing the daemon event loop. (#620)
+
 ## [3.36.0] — 2026-07-26
 
 ### Added

--- a/src/cli/__tests__/tailscale.test.ts
+++ b/src/cli/__tests__/tailscale.test.ts
@@ -698,6 +698,32 @@ describe('startWebTransport / stopWebTransport ordering', () => {
     expect(out.reason).toBe('skipped');
   });
 
+  it('removes the front when a failed reply still confirms the listener stopped', async () => {
+    const events: string[] = [];
+    const exec: TailscaleExec = async (_cmd, args) => {
+      if (args[0] === 'serve' && args[1] === 'status') {
+        events.push('tailscale:serve-status');
+        return { stdout: serveOurs(), stderr: '' };
+      }
+      events.push('tailscale:serve-off');
+      return { stdout: '', stderr: '' };
+    };
+    const out = await stopWebTransport({
+      exec,
+      readPort: async () => WEB_PORT,
+      stopServer: async () => ({
+        failed: true,
+        liveStopped: true,
+        value: 'durable revoke failed',
+      }),
+    });
+
+    expect(events).toEqual(['tailscale:serve-status', 'tailscale:serve-off']);
+    expect(out.value).toBe('durable revoke failed');
+    expect(out.serveRemoved).toBe(true);
+    expect(out.reason).toBe('removed');
+  });
+
   it('leaves a foreign serve config alone on stop', async () => {
     const foreign = JSON.stringify({
       TCP: { '443': { HTTPS: true } },

--- a/src/cli/__tests__/web.test.ts
+++ b/src/cli/__tests__/web.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { deviceCredentialWarning } from '../commands/web';
+import {
+  annotateWebStopJsonResponse,
+  deviceCredentialWarning,
+} from '../commands/web';
 
 /**
  * `wmux web --status` and the per-device credential posture (M3).
@@ -34,5 +37,39 @@ describe('deviceCredentialWarning', () => {
     // real one, and it would fire on every `--status` against a 3.34.0 daemon.
     expect(deviceCredentialWarning({})).toBeNull();
     expect(deviceCredentialWarning({ deviceCredentials: undefined })).toBeNull();
+  });
+});
+
+describe('annotateWebStopJsonResponse', () => {
+  it('keeps a failed stop failed while reporting that its front was removed', () => {
+    expect(
+      annotateWebStopJsonResponse(
+        { id: 'stop-1', ok: false, error: 'persisted state could not be revoked' },
+        true,
+      ),
+    ).toEqual({
+      id: 'stop-1',
+      ok: false,
+      error: 'persisted state could not be revoked',
+      tailscaleServeRemoved: true,
+    });
+  });
+
+  it('annotates a successful result without changing its envelope', () => {
+    expect(
+      annotateWebStopJsonResponse(
+        { id: 'stop-2', ok: true, result: { running: false } },
+        true,
+      ),
+    ).toEqual({
+      id: 'stop-2',
+      ok: true,
+      result: { running: false, tailscaleServeRemoved: true },
+    });
+  });
+
+  it('leaves the response untouched when no front was removed', () => {
+    const response = { id: 'stop-3', ok: false as const, error: 'still running' };
+    expect(annotateWebStopJsonResponse(response, false)).toBe(response);
   });
 });

--- a/src/cli/commands/web.ts
+++ b/src/cli/commands/web.ts
@@ -51,15 +51,40 @@ export async function handleWeb(args: string[], jsonMode: boolean): Promise<void
       readPort: async () => webPortOf(await sendDaemonStringRequest('daemon.web.status', {})),
       stopServer: async () => {
         const res = await sendDaemonStringRequest('daemon.web.stop', {});
-        return { failed: getResultError(res) !== undefined, value: res };
+        const failed = getResultError(res) !== undefined;
+        // #620: the daemon stops the live listener before reporting a durable
+        // revocation failure. Confirm that state before deciding whether the
+        // tailnet front is still needed; preserve the original response so the
+        // CLI still prints the revocation error and exits 1.
+        let liveStopped = false;
+        if (failed) {
+          try {
+            liveStopped = webIsStopped(
+              await sendDaemonStringRequest('daemon.web.status', {}),
+            );
+          } catch {
+            // Verification is advisory. If the daemon disappeared before it
+            // could answer, preserve the original stop error and leave the
+            // front alone rather than guessing that no listener remains.
+          }
+        }
+        return { failed, liveStopped, value: res };
       },
     });
     const response = stop.value;
     if (jsonMode) {
-      if (stop.serveRemoved && response.ok && isRecord(response.result)) {
-        return printResult({ ...response, result: { ...response.result, tailscaleServeRemoved: true } });
+      const output = annotateWebStopJsonResponse(response, stop.serveRemoved);
+      if (stop.serveRemoved && !response.ok) {
+        // printResult intentionally renders RPC-envelope errors for humans.
+        // This command has an additional machine-relevant fact to preserve, so
+        // emit the original error envelope plus that fact and keep exit 1.
+        console.log(JSON.stringify(output, null, 2));
+        process.exit(1);
       }
-      return printResult(response);
+      return printResult(output);
+    }
+    if (stop.serveRemoved && getResultError(response) !== undefined) {
+      console.log('`tailscale serve` configuration removed.');
     }
     ensureOk(response);
     console.log('wmux web stopped.');
@@ -135,6 +160,35 @@ function webPortOf(response: RpcResponse): number | undefined {
   if (!response.ok || !isRecord(response.result)) return undefined;
   const port = response.result['port'];
   return typeof port === 'number' && Number.isInteger(port) ? port : undefined;
+}
+
+function webIsStopped(response: RpcResponse): boolean {
+  return (
+    response.ok &&
+    isRecord(response.result) &&
+    response.result['running'] === false &&
+    getResultError(response) === undefined
+  );
+}
+
+/**
+ * Preserve front-removal state in JSON even when the stop RPC itself failed.
+ *
+ * A success already has a result object to annotate. An error envelope has no
+ * result by contract, so the additive flag lives at its top level while `ok`
+ * and `error` remain untouched for existing consumers.
+ */
+export function annotateWebStopJsonResponse(
+  response: RpcResponse,
+  serveRemoved: boolean,
+): RpcResponse | (Extract<RpcResponse, { ok: false }> & { tailscaleServeRemoved: true }) {
+  if (!serveRemoved) return response;
+  if (!response.ok) return { ...response, tailscaleServeRemoved: true };
+  if (!isRecord(response.result)) return response;
+  return {
+    ...response,
+    result: { ...response.result, tailscaleServeRemoved: true },
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/cli/tailscale.ts
+++ b/src/cli/tailscale.ts
@@ -678,13 +678,24 @@ export async function stopWebTransport<T>(opts: {
   exec?: TailscaleExec;
   /** Read the running server's port. Called BEFORE the stop, deliberately. */
   readPort: () => Promise<number | undefined>;
-  stopServer: () => Promise<{ failed: boolean; value: T }>;
+  stopServer: () => Promise<{
+    failed: boolean;
+    /**
+     * A failed control reply can still follow a completed live stop (for
+     * example, durable-state revocation failed afterward). Set only after a
+     * fresh status check confirms the listener is down.
+     */
+    liveStopped?: boolean;
+    value: T;
+  }>;
 }): Promise<{ value: T; serveRemoved: boolean; reason: ServeRemoval | 'skipped' }> {
   const priorPort = await opts.readPort();
   const stopped = await opts.stopServer();
 
-  // A failed stop leaves a server running that still needs its front door.
-  if (stopped.failed || priorPort === undefined) {
+  // Most failed stops leave a server running that still needs its front door.
+  // Durable-state revocation is the exception: the listener is intentionally
+  // stopped before that error is returned, and leaving its front creates a 502.
+  if ((stopped.failed && !stopped.liveStopped) || priorPort === undefined) {
     return { value: stopped.value, serveRemoved: false, reason: 'skipped' };
   }
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -8,7 +8,14 @@ import { DaemonPipeServer } from './DaemonPipeServer';
 import { SessionPipe } from './SessionPipe';
 import { WebTerminalServer } from './web/WebTerminalServer';
 import type { WebTerminalInfo, WebSessionLifecycle } from './web/WebTerminalServer';
-import { loadWebState, saveWebState, clearWebState } from './web/webStateStore';
+import {
+  loadWebState,
+  saveWebState,
+  clearWebState,
+  getWebStatePath,
+} from './web/webStateStore';
+import { stopWebServerDurably } from './web/webStop';
+import { scheduleTokenFileReHarden } from '../shared/security';
 import { generateSnapshot, generateSnapshotUnqueued, enqueueSnapshotJob, generateTextSnapshot, capTextRowsToFrameBudget, MAX_SCROLLBACK } from './HeadlessSnapshot';
 import { StateWriter, scrubPersistedCredentials } from './StateWriter';
 import { stripCredentialValues } from '../shared/envFilter';
@@ -159,24 +166,31 @@ let webRestore: Promise<void> | null = null;
 /**
  * Record the running server's exact shape so the next daemon can reproduce it
  * (#596). Best-effort by design: the operator's start already succeeded, so a
- * write failure degrades to "will not come back on its own" and is logged —
- * never surfaced as a failed start.
+ * write failure is logged rather than surfaced as a failed start. The store
+ * neutralises best-effort, but an older locked record can remain when the
+ * filesystem refuses every write and delete.
  */
 function persistWebState(info: WebTerminalInfo, allowedHosts: string[], tailscale: boolean): void {
   if (!info.running || !info.token) return;
-  const ok = saveWebState(wmuxDir, {
-    version: 1,
-    enabled: true,
-    port: info.port ?? 7681,
-    host: info.host ?? '127.0.0.1',
-    allowInput: info.allowInput === true,
-    allowedHosts,
-    tailscale,
-    token: info.token,
-  });
-  if (!ok) {
-    log('warn', '[web] could not persist web state — the server will NOT restart with the daemon');
-  }
+  saveWebState(
+    wmuxDir,
+    {
+      version: 1,
+      enabled: true,
+      port: info.port ?? 7681,
+      host: info.host ?? '127.0.0.1',
+      allowInput: info.allowInput === true,
+      allowedHosts,
+      tailscale,
+      token: info.token,
+    },
+    (error) =>
+      log(
+        'warn',
+        '[web] could not safely persist the requested web state — this exact server may not restore, and an older locked record may remain',
+        error,
+      ),
+  );
 }
 
 /**
@@ -193,6 +207,12 @@ function persistWebState(info: WebTerminalInfo, allowedHosts: string[], tailscal
 async function restoreWebServer(sessionManager: DaemonSessionManager): Promise<void> {
   const state = loadWebState(wmuxDir);
   if (!state.enabled) return;
+
+  // This is an existing credential whose prior exposure window was already
+  // unbounded. Re-harden it asynchronously: the synchronous Windows primitive
+  // shells out for seconds and would freeze the just-opened control pipe.
+  // Every NEW token-bearing write remains synchronously harden-before-populate.
+  scheduleTokenFileReHarden(getWebStatePath(wmuxDir));
 
   try {
     if (!webTerminalServer) {
@@ -229,10 +249,17 @@ async function restoreWebServer(sessionManager: DaemonSessionManager): Promise<v
       // left open reconnects on its own (EventSource retries) with no human.
       token: state.token,
     });
-    // The bind may have landed on a different port than requested only when
-    // asked for 0, which never happens here — but re-persist anyway so the
-    // record always mirrors reality.
-    persistWebState(info, state.allowedHosts, state.tailscale);
+    // A normal restore reproduces these values exactly. Rewriting that no-op
+    // state now costs a synchronous Windows ACL shell-out, so only pay it if a
+    // future start implementation genuinely lets the bind diverge.
+    if (
+      info.port !== state.port ||
+      info.host !== state.host ||
+      info.allowInput !== state.allowInput ||
+      info.token !== state.token
+    ) {
+      persistWebState(info, state.allowedHosts, state.tailscale);
+    }
     // A restore that puts a WRITABLE terminal back on every network interface
     // happens with nobody at the desktop, so it is logged at warn: the operator
     // asked for exactly this, but "it came back on its own" should be findable
@@ -2042,8 +2069,10 @@ function registerRpcHandlers(
     // teardown of a server the operator still wants and therefore leaves the
     // persisted state alone.
     await afterRestore();
-    clearWebState(wmuxDir);
-    return webServer.stop();
+    return stopWebServerDurably(
+      () => clearWebState(wmuxDir),
+      () => webServer.stop(),
+    );
   });
   pipeServer.onRpc('daemon.web.status', async () => {
     // Without this a status() called during boot would report `running:false`

--- a/src/daemon/web/__tests__/webRestart.runtime.test.ts
+++ b/src/daemon/web/__tests__/webRestart.runtime.test.ts
@@ -80,8 +80,21 @@ function rpc(method: string, params: Record<string, unknown> = {}): Promise<RpcR
       for (const line of lines) {
         if (!line.trim()) continue;
         try {
-          const res = JSON.parse(line) as { id: string; result?: RpcResult };
-          if (res.id === id) finish(() => resolve(res.result ?? {}));
+          const res = JSON.parse(line) as {
+            id: string;
+            ok?: boolean;
+            result?: RpcResult;
+            error?: string;
+          };
+          if (res.id === id) {
+            finish(() => {
+              if (res.ok === false) {
+                reject(new Error(res.error ?? `${method}: daemon rejected the request`));
+              } else {
+                resolve(res.result ?? {});
+              }
+            });
+          }
         } catch {
           /* ignore malformed lines */
         }
@@ -209,6 +222,8 @@ describe.skipIf(!CAN_RUN)('#596 — wmux web survives a daemon restart', () => {
       const token = started.token as string;
       expect(token).toBeTruthy();
       expect(await probe(port, '/api/config', token)).toEqual({ status: 200 });
+      const statePath = path.join(WMUX_DIR, 'web-state.json');
+      const persistedMtime = fs.statSync(statePath).mtimeMs;
 
       // ── crash / reboot / one-click update restart ──
       await killDaemon(d1);
@@ -228,6 +243,10 @@ describe.skipIf(!CAN_RUN)('#596 — wmux web survives a daemon restart', () => {
       // open reconnects on its own with nobody at the desktop.
       expect(after.token).toBe(token);
       expect(await probe(port, '/api/config', token)).toEqual({ status: 200 });
+      // Restore must not rewrite an identical state record: on Windows that
+      // no-op would synchronously shell out for ACL hardening and freeze the
+      // daemon event loop for seconds. Async ACL re-hardening leaves mtime put.
+      expect(fs.statSync(statePath).mtimeMs).toBe(persistedMtime);
     },
     120_000,
   );
@@ -252,6 +271,38 @@ describe.skipIf(!CAN_RUN)('#596 — wmux web survives a daemon restart', () => {
       const restarted = await rpc('daemon.web.start', { port, host: '127.0.0.1', allowInput: false });
       expect(restarted.token).not.toBe(token);
       expect((await probe(port, '/api/config', token)).status).toBe(401);
+    },
+    120_000,
+  );
+
+  it(
+    'a durable-stop write failure rejects the RPC after the live listener is down',
+    async () => {
+      const port = await freePort();
+
+      await startDaemon();
+      const started = await rpc('daemon.web.start', {
+        port,
+        host: '127.0.0.1',
+        allowInput: false,
+      });
+      const token = started.token as string;
+      const statePath = path.join(WMUX_DIR, 'web-state.json');
+
+      // A same-name directory makes both unlink and overwrite fail while
+      // remaining portable and recoverable inside this disposable fixture.
+      fs.rmSync(statePath, { force: true });
+      fs.mkdirSync(statePath);
+
+      try {
+        await expect(rpc('daemon.web.stop')).rejects.toThrow(
+          'persisted state could not be revoked',
+        );
+        expect((await rpc('daemon.web.status')).running).toBe(false);
+        expect((await probe(port, '/api/config', token)).error).toBeTruthy();
+      } finally {
+        fs.rmSync(statePath, { recursive: true, force: true });
+      }
     },
     120_000,
   );

--- a/src/daemon/web/__tests__/webStateStore.runtime.test.ts
+++ b/src/daemon/web/__tests__/webStateStore.runtime.test.ts
@@ -1,7 +1,16 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+
+const { secureWriteTokenFileMock } = vi.hoisted(() => ({
+  secureWriteTokenFileMock: vi.fn(),
+}));
+
+vi.mock('../../../shared/security', () => ({
+  secureWriteTokenFile: secureWriteTokenFileMock,
+}));
+
 import {
   loadWebState,
   saveWebState,
@@ -13,14 +22,21 @@ import {
 } from '../webStateStore';
 
 // Disk-IO → `.runtime.test.ts` so it runs serially (vitest.runtime.config sets
-// fileParallelism:false) and the tmp+rename dance never races another file.
+// fileParallelism:false). The expensive OS ACL primitive is mocked here; the
+// shared security tests cover its native behavior.
 
 let dir: string;
 
 beforeEach(() => {
   dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-webstate-'));
+  secureWriteTokenFileMock.mockReset();
+  secureWriteTokenFileMock.mockImplementation((filePath: string, contents: string) => {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, contents, { encoding: 'utf8', mode: 0o600 });
+  });
 });
 afterEach(() => {
+  vi.restoreAllMocks();
   try {
     fs.rmSync(dir, { recursive: true, force: true });
   } catch {
@@ -46,18 +62,147 @@ describe('webStateStore (#596 — wmux web survives a daemon restart)', () => {
     expect(loadWebState(dir)).toEqual(enabled());
   });
 
+  it('hardens a disabled inode before either create or overwrite receives the token', () => {
+    const first = enabled();
+    const second = enabled({ token: 'tok-reconfigured', port: 8765 });
+    const target = getWebStatePath(dir);
+
+    expect(saveWebState(dir, first)).toBe(true);
+    expect(saveWebState(dir, second)).toBe(true);
+
+    expect(secureWriteTokenFileMock).toHaveBeenNthCalledWith(
+      1,
+      target,
+      JSON.stringify(WEB_STATE_DISABLED, null, 2),
+    );
+    expect(secureWriteTokenFileMock).toHaveBeenNthCalledWith(
+      2,
+      target,
+      JSON.stringify(WEB_STATE_DISABLED, null, 2),
+    );
+    expect(loadWebState(dir)).toEqual(second);
+  });
+
+  it('never leaves the active token when placeholder hardening and cleanup both fail', () => {
+    const target = getWebStatePath(dir);
+    const persistenceError = new Error('ACL hardening denied; cleanup was busy');
+    const onError = vi.fn();
+    secureWriteTokenFileMock.mockImplementationOnce((filePath: string, contents: string) => {
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, contents, { encoding: 'utf8', mode: 0o600 });
+      // The real helper throws after ACL failure. Omitting its own deletion
+      // models the review case where AV holds the file during cleanup too.
+      throw persistenceError;
+    });
+    vi.spyOn(fs, 'unlinkSync').mockImplementationOnce(() => {
+      throw Object.assign(new Error('EBUSY: retry was busy too'), { code: 'EBUSY' });
+    });
+
+    expect(saveWebState(dir, enabled(), onError)).toBe(false);
+    expect(onError).toHaveBeenCalledWith(persistenceError);
+    expect(fs.readFileSync(target, 'utf8')).toBe(JSON.stringify(WEB_STATE_DISABLED, null, 2));
+    expect(fs.readFileSync(target, 'utf8')).not.toContain('tok-abc');
+    expect(loadWebState(dir)).toEqual({ ...WEB_STATE_DISABLED });
+  });
+
+  it('does not let a diagnostic callback failure turn best-effort save into a throw', () => {
+    secureWriteTokenFileMock.mockImplementationOnce(() => {
+      throw new Error('disk denied persistence');
+    });
+
+    expect(
+      saveWebState(dir, enabled(), () => {
+        throw new Error('logger failed too');
+      }),
+    ).toBe(false);
+  });
+
+  it('does not recreate an unhardened inode when the placeholder disappears before populate', () => {
+    const target = getWebStatePath(dir);
+    secureWriteTokenFileMock.mockImplementationOnce((filePath: string, contents: string) => {
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, contents, { encoding: 'utf8', mode: 0o600 });
+      // External deletion in the harden → populate window. The populate step
+      // must open existing-only; path-based writeFileSync would recreate it.
+      fs.unlinkSync(filePath);
+    });
+
+    expect(saveWebState(dir, enabled())).toBe(false);
+    expect(fs.existsSync(target)).toBe(false);
+    expect(secureWriteTokenFileMock).toHaveBeenCalledWith(
+      target,
+      JSON.stringify(WEB_STATE_DISABLED, null, 2),
+    );
+  });
+
   it('no file → disabled, so a fresh install still has nothing listening', () => {
     expect(loadWebState(dir)).toEqual({ ...WEB_STATE_DISABLED });
     expect(fs.existsSync(getWebStatePath(dir))).toBe(false);
   });
 
-  it('clearWebState revokes the token — the file is gone, not just flagged off', () => {
+  it('normal deletion revokes the token and removes the file', () => {
     saveWebState(dir, enabled());
     clearWebState(dir);
     expect(fs.existsSync(getWebStatePath(dir))).toBe(false);
     expect(loadWebState(dir).token).toBe('');
-    // Clearing an already-absent file is the desired end state either way.
+  });
+
+  it('clearing an absent file succeeds only through ENOENT', () => {
+    secureWriteTokenFileMock.mockClear();
     expect(() => clearWebState(dir)).not.toThrow();
+    expect(secureWriteTokenFileMock).not.toHaveBeenCalled();
+  });
+
+  it.each(['EPERM', 'EBUSY'])(
+    'falls back to a securely written disabled record when unlink fails with %s',
+    (code) => {
+      saveWebState(dir, enabled());
+      secureWriteTokenFileMock.mockClear();
+      vi.spyOn(fs, 'unlinkSync').mockImplementationOnce(() => {
+        throw Object.assign(new Error(`${code}: file is busy`), { code });
+      });
+
+      expect(() => clearWebState(dir)).not.toThrow();
+
+      expect(secureWriteTokenFileMock).toHaveBeenCalledWith(
+        getWebStatePath(dir),
+        JSON.stringify(WEB_STATE_DISABLED, null, 2),
+      );
+      expect(loadWebState(dir)).toEqual({ ...WEB_STATE_DISABLED });
+      expect(loadWebState(dir).token).toBe('');
+    },
+  );
+
+  it('cannot report success when deletion and secure disablement both fail', () => {
+    saveWebState(dir, enabled());
+    secureWriteTokenFileMock.mockImplementationOnce(() => {
+      throw new Error('ACL hardening denied');
+    });
+    vi.spyOn(fs, 'unlinkSync').mockImplementationOnce(() => {
+      throw Object.assign(new Error('EACCES: deletion denied'), { code: 'EACCES' });
+    });
+
+    expect(() => clearWebState(dir)).toThrow(
+      'Could not revoke persisted web state: deletion failed (EACCES: deletion denied) ' +
+        'and secure disablement failed (ACL hardening denied)',
+    );
+    expect(loadWebState(dir)).toEqual(enabled());
+  });
+
+  it('accepts helper failure when its fail-closed cleanup already deleted the file', () => {
+    saveWebState(dir, enabled());
+    const target = getWebStatePath(dir);
+    secureWriteTokenFileMock.mockImplementationOnce((filePath: string) => {
+      fs.unlinkSync(filePath);
+      throw new Error('ACL hardening denied after cleanup');
+    });
+    vi.spyOn(fs, 'unlinkSync').mockImplementationOnce(() => {
+      throw Object.assign(new Error('EBUSY: first deletion denied'), { code: 'EBUSY' });
+    });
+
+    expect(() => clearWebState(dir)).not.toThrow();
+    expect(fs.existsSync(target)).toBe(false);
+    expect(loadWebState(dir)).toEqual({ ...WEB_STATE_DISABLED });
   });
 
   it('a corrupt state file degrades to disabled instead of blocking daemon boot', () => {
@@ -105,7 +250,7 @@ describe('webStateStore (#596 — wmux web survives a daemon restart)', () => {
     expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
   });
 
-  it('leaves no .tmp behind after a successful write', () => {
+  it('never creates a secret-bearing .tmp file', () => {
     saveWebState(dir, enabled());
     expect(fs.existsSync(`${getWebStatePath(dir)}.tmp`)).toBe(false);
   });

--- a/src/daemon/web/__tests__/webStop.test.ts
+++ b/src/daemon/web/__tests__/webStop.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { stopWebServerDurably } from '../webStop';
+
+describe('stopWebServerDurably (#620)', () => {
+  it('persists the disabled intent before stopping the live server', async () => {
+    const order: string[] = [];
+    const revoke = vi.fn(() => order.push('revoke'));
+    const stop = vi.fn(async () => {
+      order.push('stop');
+      return { stopped: true };
+    });
+
+    await expect(stopWebServerDurably(revoke, stop)).resolves.toEqual({ stopped: true });
+    expect(order).toEqual(['revoke', 'stop']);
+  });
+
+  it('still stops live after persistence fails, then rejects the false acknowledgement', async () => {
+    const persistenceError = new Error('disk denied the disabled record');
+    const revoke = vi.fn(() => {
+      throw persistenceError;
+    });
+    const stop = vi.fn(async () => ({ stopped: true }));
+
+    await expect(stopWebServerDurably(revoke, stop)).rejects.toThrow(
+      'The web server is stopped now, but persisted state could not be revoked; ' +
+        'it may return after a daemon restart: disk denied the disabled record',
+    );
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it('propagates the original live-stop error when persistence succeeded', async () => {
+    const liveError = new Error('listener close failed');
+    const revoke = vi.fn();
+    const stop = vi.fn(async () => {
+      throw liveError;
+    });
+
+    await expect(stopWebServerDurably(revoke, stop)).rejects.toBe(liveError);
+    expect(revoke).toHaveBeenCalledOnce();
+  });
+
+  it('reports both failures when persistence and the live stop fail together', async () => {
+    const revoke = vi.fn(() => {
+      throw new Error('disk remained enabled');
+    });
+    const stop = vi.fn(async () => {
+      throw new Error('listener close failed');
+    });
+
+    await expect(stopWebServerDurably(revoke, stop)).rejects.toThrow(
+      'The web server could not be stopped now (listener close failed), and persisted state ' +
+        'could not be revoked (disk remained enabled); the listener may still be running ' +
+        'and may return after a daemon restart.',
+    );
+    expect(stop).toHaveBeenCalledOnce();
+  });
+});

--- a/src/daemon/web/webStateStore.ts
+++ b/src/daemon/web/webStateStore.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { secureWriteTokenFile } from '../../shared/security';
 
 /**
  * Durable record of the operator's "yes, serve this" for `wmux web` (#596).
@@ -19,9 +20,9 @@ import path from 'node:path';
  * The record carries the web bearer token, and config.json is hand-edited and
  * routinely pasted into bug reports. This file is 0600 and holds nothing an
  * operator would want to edit by hand — the same posture as the sibling
- * `daemon-auth-token`, which already persists a long-lived bearer token in
- * this directory. Keeping it separate also means a malformed web state can
- * never take config.json's core structure down with it.
+ * `daemon-auth-token`, including synchronous filesystem hardening for every
+ * secret-bearing write. Keeping it separate also means a malformed web state
+ * can never take config.json's core structure down with it.
  */
 export interface WebPersistedState {
   version: 1;
@@ -71,6 +72,8 @@ export const WEB_STATE_DISABLED: Readonly<WebPersistedState> = Object.freeze({
   tailscale: false,
   token: '',
 });
+
+const WEB_STATE_DISABLED_JSON = JSON.stringify(WEB_STATE_DISABLED, null, 2);
 
 export function getWebStatePath(wmuxDir: string): string {
   return path.join(wmuxDir, STATE_FILE);
@@ -139,28 +142,140 @@ export function coerceWebState(parsed: unknown): WebPersistedState {
 }
 
 /**
- * Atomic write (tmp + rename, mirroring saveConfig). Best-effort: a failure to
- * persist must never fail the start RPC the operator just made — the server IS
- * running, it simply will not come back on its own. Returns false so the caller
- * can log the degraded outcome.
+ * Secure direct write. This deliberately gives up tmp+rename atomicity so the
+ * SAME inode can be hardened before it receives the reusable bearer token:
+ *
+ *   1. write a disabled placeholder containing no credential;
+ *   2. synchronously harden that inode;
+ *   3. overwrite the already-hardened inode with the enabled record.
+ *
+ * Writing the token before ACL hardening left an unsafe failure window when
+ * both hardening and its best-effort cleanup failed. The placeholder closes
+ * that window without reintroducing a secret-bearing temporary inode.
+ * Populate opens with `r+` and verifies the path still names that open inode,
+ * so an external deletion can fail the save but can never make this step
+ * create a new, unhardened token file.
+ *
+ * Best-effort for start: a failure to persist must never fail the RPC the
+ * operator just made. A failed reconfiguration may deliberately destroy the
+ * previous valid record — including a crash while Windows is hardening the
+ * disabled placeholder. That availability window is the fail-closed trade-off
+ * for never retaining a credential on an inode we could not harden. Returns
+ * false so the caller can log that the requested durable state was not
+ * installed; onError receives the original persistence exception after
+ * neutralisation. Diagnostic callback failures are ignored so logging cannot
+ * turn this best-effort start path into an RPC failure.
  */
-export function saveWebState(wmuxDir: string, state: WebPersistedState): boolean {
+export function saveWebState(
+  wmuxDir: string,
+  state: WebPersistedState,
+  onError?: (error: unknown) => void,
+): boolean {
   const target = getWebStatePath(wmuxDir);
-  const tmp = `${target}.tmp`;
   try {
-    fs.mkdirSync(wmuxDir, { recursive: true });
-    // mode is a no-op on Windows (NTFS ACLs govern); it still matters on
-    // POSIX, where this file is as sensitive as daemon-auth-token.
-    fs.writeFileSync(tmp, JSON.stringify(state, null, 2), { encoding: 'utf-8', mode: 0o600 });
-    fs.renameSync(tmp, target);
+    secureWriteTokenFile(target, WEB_STATE_DISABLED_JSON);
+    populateExistingWebState(target, JSON.stringify(state, null, 2));
     return true;
-  } catch {
+  } catch (error) {
+    // The placeholder normally means there is already no credential to clean
+    // up. Still neutralise best-effort in case the final overwrite wrote data
+    // before reporting an I/O failure, or the placeholder write never began
+    // and an older enabled record remains.
     try {
-      if (fs.existsSync(tmp)) fs.unlinkSync(tmp);
+      fs.unlinkSync(target);
+    } catch (unlinkError) {
+      if (!isNotFoundError(unlinkError)) {
+        try {
+          // No hardening is required for this emergency overwrite: it contains
+          // no secret and the only promise here is that the next boot sees off.
+          fs.writeFileSync(target, WEB_STATE_DISABLED_JSON, {
+            encoding: 'utf8',
+            mode: 0o600,
+          });
+        } catch {
+          // The caller receives false. At this point the filesystem rejected
+          // every available neutralisation, so an older record may remain.
+        }
+      }
+    }
+    try {
+      onError?.(error);
     } catch {
-      /* ignore cleanup errors */
+      // Diagnostics must not make an already best-effort start fail its RPC.
     }
     return false;
+  }
+}
+
+/**
+ * Populate only the inode the secure placeholder left behind.
+ *
+ * `writeFileSync(path)` implicitly carries O_CREAT: if AV or an operator
+ * deletes the placeholder between hardening and population, it would silently
+ * create a fresh inherited-DACL/umask inode and put the token there. `r+`
+ * makes absence an error, while the fd keeps a deletion after open from
+ * redirecting the write to a replacement path.
+ */
+function populateExistingWebState(target: string, contents: string): void {
+  const fd = fs.openSync(target, 'r+');
+  try {
+    const opened = fs.fstatSync(fd, { bigint: true });
+    const current = fs.statSync(target, { bigint: true });
+    if (!sameFileIdentity(opened, current)) {
+      throw new Error('web state inode changed before population');
+    }
+    // Refuse an unrelated replacement that landed before open. The only inode
+    // this step is allowed to populate is the disabled placeholder we wrote.
+    if (fs.readFileSync(fd, 'utf8') !== WEB_STATE_DISABLED_JSON) {
+      throw new Error('web state placeholder changed before population');
+    }
+
+    fs.ftruncateSync(fd, 0);
+    const data = Buffer.from(contents, 'utf8');
+    let offset = 0;
+    // readFileSync(fd) leaves the descriptor at EOF and ftruncateSync does not
+    // rewind it. Keep every write positional: offset is both buffer and file
+    // position, so short writes resume at the exact byte that remains.
+    while (offset < data.length) {
+      const written = fs.writeSync(fd, data, offset, data.length - offset, offset);
+      if (written === 0) throw new Error('web state population made no progress');
+      offset += written;
+    }
+
+    const after = fs.statSync(target, { bigint: true });
+    if (!sameFileIdentity(opened, after)) {
+      throw new Error('web state inode changed during population');
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function sameFileIdentity(opened: fs.BigIntStats, current: fs.BigIntStats): boolean {
+  // Node reports st_dev as the Windows volume serial for fstat but zero for
+  // stat(path); st_ino is the stable file ID in both forms. POSIX needs both
+  // device and inode because inode numbers are only unique within a device.
+  return (
+    opened.ino === current.ino &&
+    (process.platform === 'win32' || opened.dev === current.dev)
+  );
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 'ENOENT'
+  );
+}
+
+function persistedWebStateIsAbsent(target: string): boolean {
+  try {
+    fs.lstatSync(target);
+    return false;
+  } catch (error) {
+    return isNotFoundError(error);
   }
 }
 
@@ -170,9 +285,34 @@ export function saveWebState(wmuxDir: string, state: WebPersistedState): boolean
  * again, and the next start mints a fresh one.
  */
 export function clearWebState(wmuxDir: string): void {
+  const target = getWebStatePath(wmuxDir);
+  let deletionError: unknown;
   try {
-    fs.unlinkSync(getWebStatePath(wmuxDir));
-  } catch {
-    /* already gone — the desired end state either way */
+    fs.unlinkSync(target);
+    return;
+  } catch (error) {
+    if (isNotFoundError(error)) return;
+    deletionError = error;
+  }
+
+  // Windows can refuse deletion while an AV scanner or another process holds
+  // the file. Overwriting the intent and token is an equally durable revoke,
+  // provided the replacement is hardened before we acknowledge success.
+  try {
+    secureWriteTokenFile(target, WEB_STATE_DISABLED_JSON);
+  } catch (disableError) {
+    // secureWriteTokenFile removes a file it could not harden. Absence is the
+    // exact revocation outcome we wanted, even though the helper had to throw
+    // while getting there.
+    if (persistedWebStateIsAbsent(target)) return;
+
+    const deletionReason =
+      deletionError instanceof Error ? deletionError.message : String(deletionError);
+    const disableReason =
+      disableError instanceof Error ? disableError.message : String(disableError);
+    throw new Error(
+      `Could not revoke persisted web state: deletion failed (${deletionReason}) ` +
+        `and secure disablement failed (${disableReason})`,
+    );
   }
 }

--- a/src/daemon/web/webStop.ts
+++ b/src/daemon/web/webStop.ts
@@ -1,0 +1,47 @@
+/**
+ * Stop both forms of the web server without ever acknowledging a half-stop.
+ *
+ * Persist first: if the process dies afterward, process death stops the live
+ * listener and the next daemon sees disabled state. A persistence failure is
+ * captured rather than thrown immediately so the live listener is still
+ * stopped; only then is the durable failure surfaced to the operator.
+ */
+export async function stopWebServerDurably<T>(
+  revokePersistedState: () => void,
+  stopLiveServer: () => Promise<T>,
+): Promise<T> {
+  let persistenceFailed = false;
+  let persistenceError: unknown;
+  try {
+    revokePersistedState();
+  } catch (error) {
+    persistenceFailed = true;
+    persistenceError = error;
+  }
+
+  let result: T;
+  try {
+    result = await stopLiveServer();
+  } catch (liveError) {
+    if (!persistenceFailed) throw liveError;
+
+    const persistenceReason =
+      persistenceError instanceof Error ? persistenceError.message : String(persistenceError);
+    const liveReason = liveError instanceof Error ? liveError.message : String(liveError);
+    throw new Error(
+      `The web server could not be stopped now (${liveReason}), and persisted state ` +
+        `could not be revoked (${persistenceReason}); the listener may still be running ` +
+        'and may return after a daemon restart.',
+    );
+  }
+
+  if (persistenceFailed) {
+    const reason =
+      persistenceError instanceof Error ? persistenceError.message : String(persistenceError);
+    throw new Error(
+      'The web server is stopped now, but persisted state could not be revoked; ' +
+        `it may return after a daemon restart: ${reason}`,
+    );
+  }
+  return result;
+}

--- a/src/main/ipc/handlers/__tests__/web.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/web.handler.test.ts
@@ -289,7 +289,7 @@ describe('web.handler — forwarding', () => {
     // failure on this surface.
     expect(res.running).toBe(false);
     expect(res.transportError?.reason).toBe('not-installed');
-    expect(res.transportError!.lines.length).toBeGreaterThan(0);
+    expect(res.transportError?.lines.length).toBeGreaterThan(0);
     // And nothing was started: a server without its front is reachable only on
     // loopback, which is not what the operator asked for.
     expect(rpc).not.toHaveBeenCalledWith('daemon.web.start', expect.anything());
@@ -335,6 +335,75 @@ describe('web.handler — forwarding', () => {
     const res = (await getHandler(IPC.WEB_STOP)(fakeEvent)) as { running: boolean };
     expect(rpc).toHaveBeenCalledWith('daemon.web.stop', {});
     expect(res.running).toBe(false);
+  });
+
+  it('keeps the durable-stop error visible but removes a front once status confirms live is off', async () => {
+    const tailscaleCalls: string[] = [];
+    const exec: TailscaleExec = async (_cmd, args) => {
+      tailscaleCalls.push(args.join(' '));
+      if (args[0] === 'serve' && args[1] === 'status') {
+        return {
+          stdout: JSON.stringify({
+            TCP: { '443': { HTTPS: true } },
+            Web: {
+              'box.tail1234.ts.net:443': {
+                Handlers: { '/': { Proxy: 'http://127.0.0.1:7681' } },
+              },
+            },
+          }),
+          stderr: '',
+        };
+      }
+      return { stdout: '', stderr: '' };
+    };
+    let statusReads = 0;
+    rpc = vi.fn(async (method: string) => {
+      if (method === 'daemon.web.status') {
+        statusReads += 1;
+        return statusReads === 1
+          ? { running: true, port: 7681 }
+          : { running: false };
+      }
+      if (method === 'daemon.web.stop') {
+        throw new Error(
+          'The web server is stopped now, but persisted state could not be revoked',
+        );
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const dc = { rpc, isConnected: true } as unknown as DaemonClient;
+    registerWebHandlers(() => dc, exec);
+
+    const res = (await getHandler(IPC.WEB_STOP)(fakeEvent)) as WebTerminalInfo;
+
+    expect(res.running).toBe(false);
+    expect(res.error).toContain('persisted state could not be revoked');
+    expect(statusReads).toBe(2);
+    expect(tailscaleCalls).toContain('serve --https=443 off');
+  });
+
+  it('keeps the toggle and front on when fresh status says the live stop failed', async () => {
+    const tailscaleCalls: string[] = [];
+    const exec: TailscaleExec = async (_cmd, args) => {
+      tailscaleCalls.push(args.join(' '));
+      return { stdout: '', stderr: '' };
+    };
+    rpc = vi.fn(async (method: string) => {
+      if (method === 'daemon.web.status') return { running: true, port: 7681 };
+      if (method === 'daemon.web.stop') {
+        throw new Error('The web server could not be stopped now');
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const dc = { rpc, isConnected: true } as unknown as DaemonClient;
+    registerWebHandlers(() => dc, exec);
+
+    const res = (await getHandler(IPC.WEB_STOP)(fakeEvent)) as WebTerminalInfo;
+
+    expect(res.running).toBe(true);
+    expect(res.port).toBe(7681);
+    expect(res.error).toContain('could not be stopped now');
+    expect(tailscaleCalls).toEqual([]);
   });
 });
 

--- a/src/main/ipc/handlers/web.handler.ts
+++ b/src/main/ipc/handlers/web.handler.ts
@@ -28,9 +28,9 @@ import {
  *  1. It takes a live `getDaemonClient` getter and registers UNCONDITIONALLY
  *     (not gated on a DaemonClient snapshot). The web toggle is always present
  *     in the titlebar, so a click must ALWAYS resolve — never throw "No handler
- *     registered". When there is no daemon (local mode, or the pipe is down) the
- *     handler resolves `{ running: false, error }` so the popover can render a
- *     quiet "daemon not running" state instead of surfacing an exception toast.
+ *     registered". When the control operation cannot complete, the handler
+ *     resolves `{ running: false, error }` so the popover can render the actual
+ *     failure instead of surfacing an exception toast.
  *
  *  2. Every method resolves a WebTerminalInfo (never rejects) for the same
  *     reason — a browser-terminal toggle is a low-stakes convenience surface,
@@ -256,8 +256,9 @@ export function registerWebHandlers(
         failure = (err as Error)?.message ?? String(err);
       }
       const info = await call('daemon.web.status', {});
-      // NOT `error`: that field means "the daemon is unreachable", and this
-      // reply carries a running server.
+      // NOT `error`: that field means the control operation as a whole failed
+      // and carries no trustworthy running status. This reply has a healthy
+      // server; only the pairing-code operation failed.
       if (failure) return { ...withFront(info), pairStartError: failure };
       // A fresh code is the last moment before a camera is pointed at it.
       if (info.running && advertisesFront(info)) {
@@ -283,7 +284,22 @@ export function registerWebHandlers(
         readPort: async () => (await call('daemon.web.status', {})).port,
         stopServer: async () => {
           const info = await call('daemon.web.stop', {});
-          return { failed: info.error !== undefined, value: info };
+          const failed = info.error !== undefined;
+          // A durable-revocation error is returned AFTER the daemon has stopped
+          // the live listener. Confirm that fact rather than treating every
+          // failed reply as "still running" and leaving a dead Tailscale front.
+          const status = failed ? await call('daemon.web.status', {}) : undefined;
+          const liveStopped =
+            status !== undefined && status.error === undefined && status.running === false;
+          // `call` has to use running:false for a rejected RPC because that
+          // envelope carries no status. Once the fresh status succeeds, keep
+          // its actual running state and attach the original stop error. This
+          // leaves the toggle on when the listener itself failed to stop.
+          const value =
+            failed && status !== undefined && status.error === undefined
+              ? { ...status, error: info.error }
+              : info;
+          return { failed, liveStopped, value };
         },
       });
       return stop.value;

--- a/src/renderer/components/StatusBar/WebToggle.tsx
+++ b/src/renderer/components/StatusBar/WebToggle.tsx
@@ -203,7 +203,7 @@ export function WebPopoverBody({
         </div>
         {info.error ? (
           <div className="text-[11px] text-[var(--text-sub)] leading-snug">
-            {t('web.daemonOffline')}
+            {info.error}
           </div>
         ) : null}
         <label className="flex items-center gap-2 text-[11px] text-[var(--text-main)] cursor-pointer">
@@ -491,6 +491,12 @@ export function WebPopoverBody({
 
       {exposed ? (
         <p className="text-[10px] leading-snug text-[var(--text-sub)]">{t('web.exposeWarning')}</p>
+      ) : null}
+
+      {info.error ? (
+        <span className="text-[10px] leading-snug text-[var(--accent-red)]">
+          {info.error}
+        </span>
       ) : null}
 
       <button

--- a/src/renderer/components/StatusBar/__tests__/WebToggle.test.tsx
+++ b/src/renderer/components/StatusBar/__tests__/WebToggle.test.tsx
@@ -138,9 +138,10 @@ describe('WebPopoverBody — off state', () => {
     expect(html).toContain('bg-[var(--accent)]');
   });
 
-  it('shows the daemon-offline note when info carries an error', () => {
+  it('shows the actual control error instead of misreporting every failure as offline', () => {
     const offline = renderBody({ info: { running: false, error: 'boom' } });
-    expect(offline).toContain('web.daemonOffline');
+    expect(offline).toContain('boom');
+    expect(offline).not.toContain('web.daemonOffline');
   });
 
   it('reflects a busy Start as "starting"', () => {
@@ -199,6 +200,15 @@ describe('WebPopoverBody — on state', () => {
     expect(html).toContain('web.stop');
     expect(html).toContain('bg-[var(--bg-surface)]');
     expect(html).not.toContain('accent-red');
+  });
+
+  it('shows the exact stop error when the listener is still running', () => {
+    const html = renderBody({
+      info: { ...runningInfo, error: 'listener close failed' },
+    });
+    expect(html).toContain('listener close failed');
+    expect(html).toContain('text-[var(--accent-red)]');
+    expect(html).toContain('web.stop');
   });
 
   it('only the copied field swaps its label', () => {

--- a/src/shared/__tests__/security.test.ts
+++ b/src/shared/__tests__/security.test.ts
@@ -120,6 +120,39 @@ describe('secureWriteTokenFile', () => {
     });
   });
 
+  it('re-applies mode 0600 when overwriting an existing POSIX token file', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    try {
+      const { secureWriteTokenFile } = await import('../security');
+      const tokenPath = '/home/tester/.wmux-auth-token';
+      fsMock.existsSync.mockReturnValue(true);
+
+      secureWriteTokenFile(tokenPath, 'secret-token');
+
+      expect(fsMock.chmodSync).toHaveBeenCalledWith(tokenPath, 0o600);
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it('fails closed when a POSIX mode repair fails', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    fsMock.chmodSync.mockImplementationOnce(() => {
+      throw new Error('chmod denied');
+    });
+    try {
+      const { secureWriteTokenFile } = await import('../security');
+      const tokenPath = '/home/tester/.wmux-auth-token';
+
+      expect(() => secureWriteTokenFile(tokenPath, 'secret-token')).toThrow(
+        `Failed to set secure mode on ${tokenPath}: chmod denied`,
+      );
+      expect(fsMock.unlinkSync).toHaveBeenCalledWith(tokenPath);
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
   it('rebuilds the DACL via a DACL-only PowerShell primitive (SID payload over stdin, never Set-Acl) on Windows', async () => {
     vi.stubEnv('USERNAME', 'tester');
     vi.stubEnv('SystemRoot', 'C:\\Windows');

--- a/src/shared/security.ts
+++ b/src/shared/security.ts
@@ -467,6 +467,21 @@ export function secureWriteTokenFile(filePath: string, token: string): void {
       const message = aclErr instanceof Error ? aclErr.message : String(aclErr);
       throw new Error(`Failed to set secure ACL on ${filePath}: ${message}`);
     }
+  } else {
+    // `mode` only affects a newly-created inode. An overwrite of a file that
+    // was restored or externally loosened to 0644 must repair it too.
+    try {
+      fs.chmodSync(filePath, 0o600);
+    } catch (modeErr) {
+      console.warn('[secureWriteTokenFile] Could not set file mode:', modeErr);
+      try {
+        fs.unlinkSync(filePath);
+      } catch {
+        // Best effort cleanup of an insecure token file.
+      }
+      const message = modeErr instanceof Error ? modeErr.message : String(modeErr);
+      throw new Error(`Failed to set secure mode on ${filePath}: ${message}`);
+    }
   }
 }
 

--- a/src/shared/web.ts
+++ b/src/shared/web.ts
@@ -106,8 +106,9 @@ export interface WebTerminalInfo {
    */
   pairStartError?: string;
   /**
-   * Set ONLY by the main-process handler when it could not reach the daemon
-   * (no control pipe, or the RPC threw/timed out). Absent on a normal reply.
+   * Set by the main-process handler when the control operation failed: no
+   * daemon, a timeout, or an application-level RPC error such as a durable stop
+   * whose on-disk state could not be revoked. Absent on a normal reply.
    */
   error?: string;
 }


### PR DESCRIPTION
## Summary

Fix the two fail-open paths in #620: a durable web stop no longer acknowledges success unless persisted state is revoked, and reusable web tokens are written only to a hardened inode.

## Changes

- Persist disabled web state before stopping the live listener, report durable revocation failures precisely, and reconcile the actual listener state across the CLI, GUI, and Tailscale front.
- Harden a credential-free placeholder before populating its token through an existing-only file descriptor, repair POSIX mode `0600`, and fail closed if the hardened inode changes or disappears.
- Avoid rewriting identical state during daemon restore; repair existing permissions asynchronously so cold start does not block the daemon event loop.
- Add regression coverage for filesystem failure sequences, the daemon RPC seam, live-stop failures, GUI error rendering, CLI output, and Tailscale cleanup.

## CHANGELOG entry

### Fixed

- **A successful `wmux web --stop` now means the listener is off now and stays off after a daemon restart.** If Windows refuses to delete `web-state.json`, wmux securely replaces it with a disabled record that contains no bearer token; if neither operation succeeds, it still stops the live server but reports that persisted state could not be revoked instead of acknowledging a durable stop. The popover shows that real error instead of claiming the daemon is offline, and a Tailscale front is still removed once a fresh status check confirms the listener did stop. A reusable web token is now written only after its inode has been synchronously hardened, POSIX overwrites repair mode `0600`, and boot restore no longer rewrites an identical record merely to re-harden it — existing permissions are repaired asynchronously without freezing the daemon event loop. (#620)

## Stability tier impact

- [ ] No external surface touched (internal refactor / docs / tests / CI).
- [ ] Additive change to a `stable` surface (new optional param, new field, new event type).
- [ ] Breaking change to a `stable` surface (requires major bump — block until release planning is in scope).
- [ ] Change to an `experimental` surface (note in release notes).
- [x] Change to an `internal` surface (no contract impact).

## Substrate contract impact (Substrate 3.0)

n/a — no stable RPC method, event envelope, permission contract, or Named Pipe contract changed.

## Test plan

- Affected unit and component tests: 6 files, 163 tests passed.
- `webStateStore.runtime.test.ts`: 19 tests passed.
- Bundled Windows daemon restart/stop coverage: 4 tests passed with no skips, including durable-stop write failure after the live listener is down.
- `npm run build:daemon`
- `npm run build:cli`
- `npx tsc -p tsconfig.json --noEmit`
- ESLint on every changed TypeScript file; existing `src/daemon/index.ts` baseline remains 21 problems, with zero findings in the changed regions.
- `git diff --check origin/main..HEAD`
- `npm run test:parallel`: 605/609 files passed. Three unrelated Git/worktree test files hit the existing Windows 5-second timeout followed by EBUSY cleanup failures; rerunning those files with one worker passed 53 tests with 1 skipped.

## Related issues / PRs

Fixes #620

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed.
- [x] Tests cover the new behavior and the regression case (if a bug fix).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `wmux web --stop` durability and correctness across daemon restarts by verifying shutdown via a fresh status check.
  * Prevented web access from reappearing after stop failures and ensured persisted web state is revoked/neutralized when possible.
  * Updated JSON/exit behavior to reflect “listener removed” accurately, and fixed front-removal only after confirmed shutdown.
  * Strengthened token-file permission hardening (including POSIX `0600`) and improved related error reporting in the UI popover.

* **Tests**
  * Expanded runtime and CLI coverage for durable stop, restart persistence, and hardened revoke semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->