### PR TITLE
security: confine renderer repo paths before git/gh runs in them (F2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **A successful `wmux web --stop` now means the listener is off now and stays off after a daemon restart.** If Windows refuses to delete `web-state.json`, wmux securely replaces it with a disabled record that contains no bearer token; if neither operation succeeds, it still stops the live server but reports that persisted state could not be revoked instead of acknowledging a durable stop. The popover shows that real error instead of claiming the daemon is offline, and a Tailscale front is still removed once a fresh status check confirms the listener did stop. A reusable web token is now written only after its inode has been synchronously hardened, POSIX overwrites repair mode `0600`, and boot restore no longer rewrites an identical record merely to re-harden it — existing permissions are repaired asynchronously without freezing the daemon event loop. (#620)
 
+### Security
+
+- **A repository path from the Git tab is confined before any `git`/`gh` command runs in it.** The worktree, diff, and GitHub-PR IPC handlers used to validate a renderer-supplied `repoPath`/`worktreePath`/`cwd` as a non-empty string and then hand it straight to `git -C <path>` (or `gh` in that directory). The path now passes through the same sensitive-path guard that `fs:readFile`/`fs:writeFile` and `git:status` already use — it is canonicalized with `realpath` and rejected if it resolves into a blocked location (`~/.ssh`, `~/.aws`, `~/.gnupg`, credential stores, the auth-token files, …), so a request cannot make a git command operate inside a secret directory. This sits inside the same-user ceiling `docs/SECURITY.md §3` already accepts — it is a consistency fix that brings these handlers up to the confinement the filesystem handlers had, not a new boundary. (F2, #615)
+
 ## [3.36.0] — 2026-07-26
 
 ### Added

--- a/src/main/ipc/handlers/__tests__/worktree.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/worktree.handler.test.ts
@@ -180,11 +180,11 @@ describe('worktree.handler — list/add/remove 왕복', () => {
     expect(r.worktrees!.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('F2 (#615) — 홈 .ssh 하위의 유효한 repo도 confine 거부', async () => {
-    // resolveToplevel이 fs.handler의 sensitive-path blocklist를 실제로 거치는지
-    // 검증한다. 홈을 test base로 옮겨 <home>/.ssh/repo를 진짜 git repo로 만든 뒤,
-    // 유효한 repo임에도 handler가 fail-soft로 거부해야 한다(미확인 repoPath가
-    // `git -C <path>`로 직행하던 갭을 닫았다는 회귀 방어선).
+  it('F2 (#615) — a valid repo under home .ssh is still confine-rejected', async () => {
+    // Verifies resolveToplevel actually routes through fs.handler's sensitive-path
+    // blocklist. Relocate home to the test base, make <home>/.ssh/repo a real git
+    // repo, and assert the handler fail-softs despite it being a valid repo — the
+    // regression guard for the gap where an unconfined repoPath ran `git -C <path>`.
     const homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(scn.base);
     try {
       const sshRepo = join(scn.base, '.ssh', 'repo');

--- a/src/main/ipc/handlers/__tests__/worktree.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/worktree.handler.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync, realpathSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import os from 'node:os';
 import { join, basename, dirname } from 'node:path';
 
 const captured = new Map<string, (...args: unknown[]) => unknown>();
@@ -26,7 +26,7 @@ function g(cwd: string, args: string[]): string {
 function makeRepo(): { base: string; repo: string; cleanup: () => void } {
   // realpathSync.native로 8.3 단축폼(CI Windows RUNNER~1)을 롱폼으로 정규화 —
   // 핸들러가 git canonical 경로 기준으로 파생·비교하므로 fixture도 맞춰야 한다.
-  const base = realpathSync.native(mkdtempSync(join(tmpdir(), 'wmux-wth-')));
+  const base = realpathSync.native(mkdtempSync(join(os.tmpdir(), 'wmux-wth-')));
   const repo = join(base, 'repo');
   mkdirSync(repo);
   g(repo, ['init', '-q', '-b', 'main']);
@@ -178,5 +178,24 @@ describe('worktree.handler — list/add/remove 왕복', () => {
     const r = (await list({}, join(scn.repo, 'sub'))) as ListRes;
     expect(r.ok).toBe(true);
     expect(r.worktrees!.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('F2 (#615) — 홈 .ssh 하위의 유효한 repo도 confine 거부', async () => {
+    // resolveToplevel이 fs.handler의 sensitive-path blocklist를 실제로 거치는지
+    // 검증한다. 홈을 test base로 옮겨 <home>/.ssh/repo를 진짜 git repo로 만든 뒤,
+    // 유효한 repo임에도 handler가 fail-soft로 거부해야 한다(미확인 repoPath가
+    // `git -C <path>`로 직행하던 갭을 닫았다는 회귀 방어선).
+    const homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(scn.base);
+    try {
+      const sshRepo = join(scn.base, '.ssh', 'repo');
+      mkdirSync(dirname(sshRepo), { recursive: true });
+      mkdirSync(sshRepo);
+      g(sshRepo, ['init', '-q', '-b', 'main']);
+      const list = captured.get(IPC.WORKTREE_LIST)!;
+      const r = (await list({}, sshRepo)) as ListRes;
+      expect(r.ok).toBe(false);
+    } finally {
+      homeSpy.mockRestore();
+    }
   });
 });

--- a/src/main/ipc/handlers/diff.handler.ts
+++ b/src/main/ipc/handlers/diff.handler.ts
@@ -12,6 +12,7 @@ import { join, isAbsolute, normalize, dirname } from 'node:path';
 import { IPC } from '../../../shared/constants';
 import { wrapHandler } from '../wrapHandler';
 import { git } from '../../git/git';
+import { resolveAccessiblePath } from './fs.handler';
 import {
   parseUnifiedDiff,
   reassemblePatch,
@@ -456,10 +457,13 @@ export function registerDiffHandlers(): () => void {
         if (typeof worktreePath !== 'string' || !worktreePath) {
           return { ok: false, error: 'worktreePath 필요', code: 'bad-args' };
         }
+        // F2 (#615): confine the renderer path before it reaches `git -C`.
+        const safeWt = await resolveAccessiblePath(worktreePath);
+        if (!safeWt) return { ok: false, error: 'worktreePath 필요', code: 'bad-args' };
         // targetHeadOid는 선택 — 미지정 시 타겟 repo HEAD로 도출.
         const head = typeof targetHeadOid === 'string' ? targetHeadOid : '';
         // mode 미지정/오값은 'task'(기존 계약). 'workspace'만 명시 분기.
-        return readDiff(worktreePath, head, mode === 'workspace' ? 'workspace' : 'task');
+        return readDiff(safeWt, head, mode === 'workspace' ? 'workspace' : 'task');
       },
     ),
   );
@@ -479,7 +483,10 @@ export function registerDiffHandlers(): () => void {
         cwd: unknown,
       ): Promise<{ ok: true; repoPath: string } | { ok: false }> => {
         if (typeof cwd !== 'string' || !cwd) return { ok: false };
-        const r = await git(['rev-parse', '--show-toplevel'], cwd);
+        // F2 (#615): confine the renderer path before it reaches `git -C`.
+        const safeCwd = await resolveAccessiblePath(cwd);
+        if (!safeCwd) return { ok: false };
+        const r = await git(['rev-parse', '--show-toplevel'], safeCwd);
         const top = r.code === 0 ? r.stdout.trim() : '';
         return top ? { ok: true, repoPath: top } : { ok: false };
       },
@@ -499,11 +506,14 @@ export function registerDiffHandlers(): () => void {
         if (typeof worktreePath !== 'string' || !worktreePath) {
           return { ok: false, error: 'worktreePath 필요', code: 'apply' };
         }
+        // F2 (#615): confine the renderer path before git/file writes touch it.
+        const safeWt = await resolveAccessiblePath(worktreePath);
+        if (!safeWt) return { ok: false, error: 'worktreePath 필요', code: 'apply' };
         const r = req as DiffApplyRequest;
         if (!r || !r.snapshot || !Array.isArray(r.selections)) {
           return { ok: false, error: 'applyHunks 요청 형식 오류', code: 'apply' };
         }
-        return applyHunks(r, worktreePath);
+        return applyHunks(r, safeWt);
       },
     ),
   );

--- a/src/main/ipc/handlers/github.handler.ts
+++ b/src/main/ipc/handlers/github.handler.ts
@@ -7,6 +7,7 @@
 import { ipcMain } from 'electron';
 import { IPC } from '../../../shared/constants';
 import { wrapHandler } from '../wrapHandler';
+import { resolveAccessiblePath } from './fs.handler';
 import { detectRemoteHost, isGithubHost } from '../../github/PrProvider';
 import type { PrSummary, PrDetail, PrProvider } from '../../github/PrProvider';
 import { ghPrService } from '../../github/GhPrService';
@@ -54,7 +55,12 @@ export function registerGithubHandlers(): () => void {
       if (typeof repoPath !== 'string' || !repoPath) {
         return { ok: false, code: 'error', message: 'repoPath required' } satisfies GithubPrListResult;
       }
-      return prList(repoPath, force === true);
+      // F2 (#615): confine the renderer path before it reaches `gh -C` / cwd.
+      const safeRepo = await resolveAccessiblePath(repoPath);
+      if (!safeRepo) {
+        return { ok: false, code: 'error', message: 'repoPath required' } satisfies GithubPrListResult;
+      }
+      return prList(safeRepo, force === true);
     }),
   );
 
@@ -75,11 +81,14 @@ export function registerGithubHandlers(): () => void {
         if (typeof number !== 'number' || !Number.isInteger(number) || number <= 0) {
           return { ok: false, code: 'error', message: 'valid PR number required' };
         }
+        // F2 (#615): confine the renderer path before it reaches `gh -C` / cwd.
+        const safeRepo = await resolveAccessiblePath(repoPath);
+        if (!safeRepo) return { ok: false, code: 'error', message: 'repoPath required' };
         // 목록과 동일한 provider로 라우팅(호스트 재감지 — 상세는 저빈도라 무해).
-        const host = await detectRemoteHost(repoPath);
+        const host = await detectRemoteHost(safeRepo);
         if (!host) return { ok: false, code: 'error', message: 'no origin remote' };
         const res = await providerFor(host).prDetail(
-          repoPath,
+          safeRepo,
           number,
           typeof updatedAt === 'string' ? updatedAt : '',
         );

--- a/src/main/ipc/handlers/worktree.handler.ts
+++ b/src/main/ipc/handlers/worktree.handler.ts
@@ -18,6 +18,7 @@ import { randomUUID } from 'node:crypto';
 import { IPC } from '../../../shared/constants';
 import { wrapHandler } from '../wrapHandler';
 import { git } from '../../git/git';
+import { resolveAccessiblePath } from './fs.handler';
 import {
   parseWorktreePorcelain,
   validateGitRef,
@@ -89,8 +90,14 @@ function withRepoLock<T>(repoKey: string, fn: () => Promise<T>): Promise<T> {
 }
 
 // cwd(서브디렉토리 가능) → 자기 worktree toplevel. 비-git이면 null.
+// F2 (#615): every worktree entry point funnels through here, so confine the
+// renderer-supplied path against the shared sensitive-path blocklist before it
+// reaches `git -C <path>`. Closes the gap where an unconfined repoPath ran git
+// inside e.g. ~/.ssh. resolveAccessiblePath also canonicalizes via realpath.
 async function resolveToplevel(cwd: string): Promise<string | null> {
-  const r = await git(['rev-parse', '--show-toplevel'], cwd);
+  const safe = await resolveAccessiblePath(cwd);
+  if (!safe) return null;
+  const r = await git(['rev-parse', '--show-toplevel'], safe);
   const top = r.code === 0 ? r.stdout.trim() : '';
   return top || null;
 }


### PR DESCRIPTION
Closes F2 of #615.

## Problem

The worktree, diff, and GitHub-PR IPC handlers validated a renderer-supplied `repoPath` / `worktreePath` / `cwd` as a non-empty string and then handed it straight to `git -C <path>` (or `gh` in that directory). No confinement, no sensitive-path blocklist. A request could make a git command operate inside a secret directory (e.g. `~/.ssh`).

This sits inside the same-user ceiling `docs/SECURITY.md §3` already accepts. It is a consistency fix: `fs:readFile` / `fs:writeFile` (`fs.handler.ts`) and `git:status` (`toolbar.handler.ts`) already route through the `resolveAccessiblePath` guard — these three handlers did not.

## Fix

Route the path through the same `resolveAccessiblePath` guard the filesystem handlers use: canonicalize with `realpath`, reject anything that resolves into a blocked location (`~/.ssh`, `~/.aws`, `~/.gnupg`, credential stores, the auth-token files).

- **`worktree.handler.ts`** — all seven entry points (list/add/remove/merge-start/status/land/discard) funnel through `resolveToplevel(cwd)`, so one guard there covers them all.
- **`diff.handler.ts`** — confine at `DIFF_READ`, `DIFF_RESOLVE_REPO`, `DIFF_APPLY_HUNKS` (the last also writes files).
- **`github.handler.ts`** — confine at `GITHUB_PR_LIST`, `GITHUB_PR_DETAIL`.
- **`toolbar.handler.ts`** — already guarded, unchanged.

Scoped to the `-C` working directory only. `git worktree add <new-path>` passes a not-yet-existing path as a subcommand argument (`realpath` would fail on it), so it is deliberately left unconfined — that is the precise vector F2 describes.

## Tests

- New regression test in `worktree.handler.test.ts`: a valid git repo created under `<home>/.ssh` is still rejected (uses `vi.spyOn(os, 'homedir')` to relocate home deterministically, cross-platform).
- `npm run test:parallel`: 8579 passed, 0 failed.
- `tsc --noEmit`: clean. `eslint`: 0 errors.

## Scope

Additive input validation on the IPC boundary. No behavior change for legitimate repo paths (subdirectory resolution and canonicalization preserved). No dependency, schema, or config changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added stronger confinement for repository paths used by Git, GitHub, diff, and worktree actions, including canonicalization and blocking access to sensitive credential/secret directories.
  * Unsafe or inaccessible paths now fail safely instead of proceeding with Git-related operations.
* **Tests**
  * Added an end-to-end test to verify worktree handling rejects repos located under a mocked sensitive home directory subtree (for example, under `~/.ssh`).
* **Documentation**
  * Updated the Unreleased changelog with the new security behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->