### PR TITLE
chore(release): 3.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.37.0] — 2026-07-27
 
 ### Added
 

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.36.0 sources.** This file is produced by
+> **Generated from wmux v3.37.0 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.36.0",
+  "version": "3.37.0",
   "description": "Workspace multiplexer for AI coding agents — run fleets of Claude Code, Codex & Gemini in parallel on Windows & macOS, with MCP browser automation built in",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Release 3.37.0 — the claude-pty terminal orchestrator brain (PR #639) plus its review-hardening. package.json bump, CHANGELOG cut, regenerated API reference (drift guard).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the API reference to reflect version 3.37.0.

* **Chores**
  * Released version 3.37.0.
  * Updated the changelog to mark the 3.37.0 release date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->