### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci-cross-platform-baseline.yml
+++ b/.github/workflows/ci-cross-platform-baseline.yml
@@ -45,10 +45,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
   validate:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -35,11 +35,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: perf-${{ github.run_id }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
           SETUP_SHA256: ${{ steps.checksum.outputs.sha256 }}
         run: |
           $version  = $env:PKG_VERSION
-          $sha256   = ($env:SETUP_SHA256).ToLower()
+          $sha256   = "$env:SETUP_SHA256".ToLower()
           $setupExe = "wmux-$version.Setup.exe"
           $url      = "https://github.com/openwong2kim/wmux/releases/download/v$version/$setupExe"
           $manifest = [ordered]@{

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,8 @@ jobs:
       - name: Replace unsigned Setup.exe with the signed one
         if: env.SIGNPATH_ENABLED == 'true'
         shell: pwsh
+        env:
+          SIGNING_POLICY_SLUG: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
         run: |
           $signed = Get-ChildItem "out/signed" -Recurse -Filter "*.Setup.exe" | Select-Object -First 1
           if (-not $signed) { Write-Error "SignPath returned no signed Setup.exe"; exit 1 }
@@ -78,7 +80,7 @@ jobs:
           # (release-signing), so a test-signed release still publishes.
           $sig = Get-AuthenticodeSignature $dest.FullName
           if (-not $sig.SignerCertificate) { Write-Error "Signed exe carries no signature: $($sig.Status)"; exit 1 }
-          if ('${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}' -eq 'release-signing' -and $sig.Status -ne 'Valid') {
+          if ($env:SIGNING_POLICY_SLUG -eq 'release-signing' -and $sig.Status -ne 'Valid') {
             Write-Error "Production signature is not Valid: $($sig.Status)"; exit 1
           }
           Write-Host "Signed Setup.exe in place (status=$($sig.Status), publisher: $($sig.SignerCertificate.Subject))"
@@ -106,9 +108,12 @@ jobs:
       # update.electronjs.org's JSON cannot carry a custom hash field, so this
       # side-car is fetched from the releases/latest/download/ alias.
       - name: Write update manifest
+        env:
+          PKG_VERSION: ${{ steps.pkg.outputs.version }}
+          SETUP_SHA256: ${{ steps.checksum.outputs.sha256 }}
         run: |
-          $version  = "${{ steps.pkg.outputs.version }}"
-          $sha256   = "${{ steps.checksum.outputs.sha256 }}".ToLower()
+          $version  = $env:PKG_VERSION
+          $sha256   = ($env:SETUP_SHA256).ToLower()
           $setupExe = "wmux-$version.Setup.exe"
           $url      = "https://github.com/openwong2kim/wmux/releases/download/v$version/$setupExe"
           $manifest = [ordered]@{
@@ -125,8 +130,10 @@ jobs:
       # release notes are the real changelog (not just the auto PR-title line).
       # generate_release_notes still appends "What's Changed" + the compare link.
       - name: Extract release notes from CHANGELOG
+        env:
+          PKG_VERSION: ${{ steps.pkg.outputs.version }}
         run: |
-          $version = "${{ steps.pkg.outputs.version }}"
+          $version = $env:PKG_VERSION
           $lines = Get-Content CHANGELOG.md
           $start = -1; $end = $lines.Count
           for ($i = 0; $i -lt $lines.Count; $i++) {
@@ -153,8 +160,7 @@ jobs:
         continue-on-error: true
         # The version reaches the script through env rather than direct `${{ }}`
         # interpolation, so a crafted package.json version string is data to
-        # PowerShell instead of script text. (The surrounding steps still
-        # interpolate directly — pre-existing, out of scope for a release PR.)
+        # PowerShell instead of script text.
         env:
           PKG_VERSION: ${{ steps.pkg.outputs.version }}
         run: |
@@ -200,9 +206,12 @@ jobs:
           draft: false
 
       - name: Build Chocolatey package
+        env:
+          PKG_VERSION: ${{ steps.pkg.outputs.version }}
+          SETUP_SHA256: ${{ steps.checksum.outputs.sha256 }}
         run: |
-          $version = "${{ steps.pkg.outputs.version }}"
-          $sha256  = "${{ steps.checksum.outputs.sha256 }}"
+          $version = $env:PKG_VERSION
+          $sha256  = $env:SETUP_SHA256
           # Inject version into nuspec
           (Get-Content chocolatey/wmux.nuspec) -replace '\$version\$', $version | Set-Content chocolatey/wmux.nuspec
           # Inject checksum into install script
@@ -215,10 +224,11 @@ jobs:
       - name: Push to Chocolatey
         if: env.CHOCO_API_KEY != ''
         continue-on-error: true
-        run: choco push out/choco/wmux.${{ steps.pkg.outputs.version }}.nupkg --source https://push.chocolatey.org --api-key ${{ secrets.CHOCO_API_KEY }}
+        run: choco push "out/choco/wmux.$env:PKG_VERSION.nupkg" --source https://push.chocolatey.org --api-key $env:CHOCO_API_KEY
         shell: pwsh
         env:
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+          PKG_VERSION: ${{ steps.pkg.outputs.version }}
 
   winget:
     name: Publish to WinGet

--- a/scripts/__tests__/workflowSecurity.test.mjs
+++ b/scripts/__tests__/workflowSecurity.test.mjs
@@ -32,7 +32,7 @@ function externalActionUses(text) {
   const uses = [];
   for (const [index, line] of text.split('\n').entries()) {
     const match =
-      /^\s*(?:-\s*)?(?:uses|"uses"|'uses'):\s*([^\s#]+)(?:\s+#\s*(.*))?$/.exec(
+      /^\s*(?:-\s*)?(?:uses|"uses"|'uses'):\s*([^\s#]+)(?:\s+#\s*(.*))?\s*$/.exec(
         line,
       );
     if (!match) continue;
@@ -114,12 +114,12 @@ describe('GitHub Actions workflow security contracts', () => {
     expect(runExpressionViolations(release.name, release.text)).toEqual([]);
   });
 
-  it('detects a mutable action tag', () => {
+  it('detects a mutable action tag even with trailing whitespace', () => {
     const ci = WORKFLOWS.find(({ name }) => name === 'ci.yml');
     expect(ci).toBeDefined();
     const mutated = ci.text.replace(
       /actions\/checkout@[0-9a-f]{40} # v4/,
-      'actions/checkout@v4',
+      'actions/checkout@v4 ',
     );
     expect(mutated).not.toBe(ci.text);
     expect(actionPinViolations(ci.name, mutated).join(' | ')).toContain(

--- a/scripts/__tests__/workflowSecurity.test.mjs
+++ b/scripts/__tests__/workflowSecurity.test.mjs
@@ -1,0 +1,157 @@
+// Security contracts for GitHub Actions workflows (#615 F4/F5).
+//
+// A mutable action tag can be retargeted after review, and a GitHub expression
+// interpolated into a `run:` script becomes executable source rather than data.
+// Keep both properties mechanically enforced instead of relying on reviewers
+// to spot a single unsafe line across several workflow files.
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const WORKFLOW_DIR = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '.github',
+  'workflows',
+);
+
+const WORKFLOWS = fs
+  .readdirSync(WORKFLOW_DIR)
+  .filter((name) => /\.ya?ml$/i.test(name))
+  .sort()
+  .map((name) => ({
+    name,
+    text: fs
+      .readFileSync(path.join(WORKFLOW_DIR, name), 'utf8')
+      .replace(/\r\n/g, '\n'),
+  }));
+
+function externalActionUses(text) {
+  const uses = [];
+  for (const [index, line] of text.split('\n').entries()) {
+    const match =
+      /^\s*(?:-\s*)?(?:uses|"uses"|'uses'):\s*([^\s#]+)(?:\s+#\s*(.*))?$/.exec(
+        line,
+      );
+    if (!match) continue;
+    const spec = match[1].replace(/^(['"])(.*)\1$/, '$2');
+    if (spec.startsWith('./') || spec.startsWith('docker://')) continue;
+    uses.push({ line: index + 1, spec, comment: match[2] ?? '' });
+  }
+  return uses;
+}
+
+export function actionPinViolations(fileName, text) {
+  const violations = [];
+  for (const use of externalActionUses(text)) {
+    const at = use.spec.lastIndexOf('@');
+    const ref = at === -1 ? '' : use.spec.slice(at + 1);
+    if (!/^[0-9a-f]{40}$/.test(ref)) {
+      violations.push(
+        `${fileName}:${use.line} external action is not pinned to a full commit SHA: ${use.spec}`,
+      );
+    }
+    if (!/^v\d+(?:\.\d+)*\b/.test(use.comment)) {
+      violations.push(
+        `${fileName}:${use.line} pinned action has no readable version comment`,
+      );
+    }
+  }
+  return violations;
+}
+
+function runScripts(text) {
+  const lines = text.split('\n');
+  const scripts = [];
+  for (let index = 0; index < lines.length; index++) {
+    const match =
+      /^(\s*)(-\s+)?(?:run|"run"|'run'):\s*(.*)$/.exec(lines[index]);
+    if (!match) continue;
+    const indent = match[1].length + (match[2]?.length ?? 0);
+    const header = match[3].trim();
+    const continuation = [];
+    for (let bodyIndex = index + 1; bodyIndex < lines.length; bodyIndex++) {
+      const line = lines[bodyIndex];
+      if (line.trim() !== '' && line.length - line.trimStart().length <= indent) {
+        break;
+      }
+      continuation.push(line);
+    }
+    const blockHeader =
+      /^[|>](?:(?:[-+][1-9]?)|(?:[1-9][-+]?))?$/.test(header);
+    scripts.push({
+      line: index + 1,
+      text: blockHeader
+        ? continuation.join('\n')
+        : [header, ...continuation].join('\n'),
+    });
+  }
+  return scripts;
+}
+
+export function runExpressionViolations(fileName, text) {
+  return runScripts(text)
+    .filter((script) => /\$\{\{[\s\S]*?\}\}/.test(script.text))
+    .map(
+      (script) =>
+        `${fileName}:${script.line} run script interpolates a GitHub expression; pass it through env instead`,
+    );
+}
+
+describe('GitHub Actions workflow security contracts', () => {
+  it('pins every external action to an immutable commit with a version comment', () => {
+    const violations = WORKFLOWS.flatMap(({ name, text }) =>
+      actionPinViolations(name, text),
+    );
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps GitHub expressions out of release run scripts', () => {
+    const release = WORKFLOWS.find(({ name }) => name === 'release.yml');
+    expect(release).toBeDefined();
+    expect(runExpressionViolations(release.name, release.text)).toEqual([]);
+  });
+
+  it('detects a mutable action tag', () => {
+    const ci = WORKFLOWS.find(({ name }) => name === 'ci.yml');
+    expect(ci).toBeDefined();
+    const mutated = ci.text.replace(
+      /actions\/checkout@[0-9a-f]{40} # v4/,
+      'actions/checkout@v4',
+    );
+    expect(mutated).not.toBe(ci.text);
+    expect(actionPinViolations(ci.name, mutated).join(' | ')).toContain(
+      'not pinned to a full commit SHA',
+    );
+  });
+
+  it('detects direct expression interpolation in a release script', () => {
+    const release = WORKFLOWS.find(({ name }) => name === 'release.yml');
+    expect(release).toBeDefined();
+    const mutated = release.text.replace(
+      '$version  = $env:PKG_VERSION',
+      '$version  = "${{ steps.pkg.outputs.version }}"',
+    );
+    expect(mutated).not.toBe(release.text);
+    expect(
+      runExpressionViolations(release.name, mutated).join(' | '),
+    ).toContain('pass it through env instead');
+  });
+
+  it('detects expression interpolation in a folded run continuation', () => {
+    const release = WORKFLOWS.find(({ name }) => name === 'release.yml');
+    expect(release).toBeDefined();
+    const runLine =
+      '        run: choco push "out/choco/wmux.$env:PKG_VERSION.nupkg" --source https://push.chocolatey.org --api-key $env:CHOCO_API_KEY';
+    const mutated = release.text.replace(
+      runLine,
+      `${runLine}\n          ; Write-Host "\${{ steps.pkg.outputs.version }}"`,
+    );
+    expect(mutated).not.toBe(release.text);
+    expect(
+      runExpressionViolations(release.name, mutated).join(' | '),
+    ).toContain('pass it through env instead');
+  });
+});


### PR DESCRIPTION
Refs #615 (F4, F5). This intentionally does not close the issue; F3 and F6 remain.

## Summary

- pin every previously mutable `actions/*@v4` reference in the CI, cross-platform baseline, and perf workflows to the immutable commit currently behind that major tag
- pass release outputs, the SignPath policy variable, and the Chocolatey credential through step `env:` before PowerShell parses the script
- add workflow security contract tests that reject mutable external action refs and GitHub expressions inside release `run:` scripts, including trailing-whitespace and folded-continuation mutations

## Security rationale

A mutable action tag can be retargeted after review. These pins preserve the implementations the workflows resolve to today:

- `actions/checkout` v4 → `11d5960a326750d5838078e36cf38b85af677262`
- `actions/setup-node` v4 → `49933ea5288caeca8642d1e84afbd3f7d6820020`
- `actions/upload-artifact` v4 → `ea165f8d65b6e75b540449e92b4886f43607fa02`

GitHub expressions inside `run:` are substituted before PowerShell parses the script, so their values become script source. Passing the same values through environment variables keeps them data instead. The SignPath policy comparison was the material case: a repository variable containing a quote could previously break out of the PowerShell string.

The already immutable, older checkout pin in `release.yml` is deliberately unchanged. F4 is about immutability, not forcing every workflow onto the same action release.

## Scope boundaries

`perf.yml` retains its existing `${{ steps.histflag.outputs.value }}` splice. That output is produced inside the workflow and is constrained to exactly two reviewed literals by `perfWorkflow.test.mjs`. Treating the two-argument value as one environment string would change PowerShell argv behavior, so it is not part of F5's release-workflow remediation.

There is no package, runtime, protocol, or user-facing behavior change, so this PR does not add a CHANGELOG entry. F3 and F6 remain for separate follow-up.

## Review follow-up

An independent read-only review found no blockers (`READY WITH NON-BLOCKING NOTES`). Its two concrete pre-PR suggestions are included in the second commit:

- action-pin detection remains active when a `uses:` line has trailing whitespace
- an absent checksum retains the previous empty-string behavior after the move to `env:`

## Verification

- `actionlint 1.7.12` — passed with no diagnostics
- `npx vitest run scripts/__tests__/workflowSecurity.test.mjs scripts/__tests__/perfWorkflow.test.mjs` — 25 passed
- `npx tsc -p tsconfig.json --noEmit` — passed
- `node --check scripts/__tests__/workflowSecurity.test.mjs` — passed
- `git diff --check origin/main..HEAD` — passed
- branch diff secret-pattern scan — no matches

### Local baseline notes

- two exact `npm run test:parallel` attempts were red under full Windows parallel load with changing timeout/`EBUSY` failure sets (12 failures, then 11); every affected file passed without raising its timeout when isolated with `--maxWorkers=1`
- `npm run lint` reports the repository's existing baseline of 1173 problems; this PR changes no `.ts` or `.tsx` files

The PR workflows are the authoritative hosted-runner check. The tag-only release job cannot be exercised by a PR, so its remaining verification is syntax/contract coverage here and the next real release run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Improved CI and release workflow security by pinning automation actions to fixed versions.
  * Reduced risks from direct expression interpolation in release scripts.
  * Strengthened production Windows signing validation.

* **Tests**
  * Added automated checks to verify workflow action pinning and safe script variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->