### PR TITLE
fix(updater): let a manual check run with auto-update switched off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **"Check for updates" now works with auto-update switched off.** The toggle was wired through the one gate every check passes, so turning background polling off also turned the manual button into a no-op that reported "checking" and went silent — leaving reinstalling as the only way to update. The toggle now silences background polls only; pressing the button is an explicit request and always checks.
+
 ## [3.37.0] — 2026-07-27
 
 ### Added

--- a/src/main/updater/AutoUpdater.ts
+++ b/src/main/updater/AutoUpdater.ts
@@ -121,7 +121,11 @@ export class AutoUpdater {
     // Defense in depth: never poll the update feed on an unsupported platform,
     // even if a caller invokes check() directly.
     if (!isUpdaterSupported) return;
-    if (!this.enabled) return;
+    // The auto-update toggle silences BACKGROUND polls only. A manual
+    // "check for updates" press (oneShot) is an explicit user request and
+    // must work with the toggle off — otherwise the toggle bricks the only
+    // update path short of reinstalling.
+    if (!this.enabled && !oneShot) return;
     // Record the one-shot intent BEFORE the isChecking guard: if a background
     // poll is already downloading, its downloadUpdate completion will honor the
     // intent and install, so a manual press mid-poll still updates in one click.

--- a/src/main/updater/__tests__/AutoUpdater.platform.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.platform.test.ts
@@ -478,3 +478,46 @@ describe('AutoUpdater darwin-arm64 install (Squirrel.Mac loopback feed)', () => 
     expect(loaded.nativeUpdater.quitAndInstall).not.toHaveBeenCalled();
   });
 });
+
+describe('AutoUpdater — the auto-update toggle gates background polls only', () => {
+  it('toggle off: background polls stop, but a manual UPDATE_CHECK still hits the feed', async () => {
+    vi.useFakeTimers();
+    const { AutoUpdater, requestUrls, ipcHandlers, ipcListeners } = await loadForPlatform('win32');
+
+    const updater = new AutoUpdater(() => null);
+    updater.start();
+
+    // User turns auto-update OFF before the first scheduled check fires.
+    ipcListeners.get(IPC.AUTO_UPDATE_ENABLED)!(null, false);
+
+    // Neither the 15s first check nor a full 30-min interval may touch the network.
+    await vi.advanceTimersByTimeAsync(15_000 + 30 * 60 * 1000);
+    expect(requestUrls).toHaveLength(0);
+
+    // A manual "check for updates" press is an explicit request: it must work
+    // with the toggle off — otherwise the toggle bricks the only update path.
+    const reply = await ipcHandlers.get(IPC.UPDATE_CHECK)!();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(reply).toEqual({ status: 'checking' });
+    expect(requestUrls).toContain(EXPECTED_WIN32_FEED);
+
+    updater.stop();
+  });
+
+  it('toggle back on: background polling resumes at the next interval', async () => {
+    vi.useFakeTimers();
+    const { AutoUpdater, requestUrls, ipcListeners } = await loadForPlatform('win32');
+
+    const updater = new AutoUpdater(() => null);
+    updater.start();
+    ipcListeners.get(IPC.AUTO_UPDATE_ENABLED)!(null, false);
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(requestUrls).toHaveLength(0);
+
+    ipcListeners.get(IPC.AUTO_UPDATE_ENABLED)!(null, true);
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+    expect(requestUrls).toContain(EXPECTED_WIN32_FEED);
+
+    updater.stop();
+  });
+});

--- a/src/main/updater/__tests__/AutoUpdater.platform.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.platform.test.ts
@@ -484,7 +484,16 @@ describe('AutoUpdater — the auto-update toggle gates background polls only', (
     vi.useFakeTimers();
     const { AutoUpdater, requestUrls, ipcHandlers, ipcListeners } = await loadForPlatform('win32');
 
-    const updater = new AutoUpdater(() => null);
+    // Capture renderer events so the test can assert the check RAN TO
+    // COMPLETION, not merely that a request left the building.
+    const sent: Array<{ channel: string; data: Record<string, unknown> }> = [];
+    const win = {
+      isDestroyed: () => false,
+      webContents: {
+        send: (channel: string, data: Record<string, unknown>) => { sent.push({ channel, data }); },
+      },
+    };
+    const updater = new AutoUpdater(() => win as never);
     updater.start();
 
     // User turns auto-update OFF before the first scheduled check fires.
@@ -497,9 +506,15 @@ describe('AutoUpdater — the auto-update toggle gates background polls only', (
     // A manual "check for updates" press is an explicit request: it must work
     // with the toggle off — otherwise the toggle bricks the only update path.
     const reply = await ipcHandlers.get(IPC.UPDATE_CHECK)!();
-    await vi.advanceTimersByTimeAsync(0);
     expect(reply).toEqual({ status: 'checking' });
+    // The unrouted feed URL answers 204 (up to date): the check must complete
+    // and report not-available — a check that fired and then died would leave
+    // no terminal event and fail here.
+    await vi.waitFor(() => {
+      expect(sent.some((m) => m.channel === IPC.UPDATE_NOT_AVAILABLE)).toBe(true);
+    });
     expect(requestUrls).toContain(EXPECTED_WIN32_FEED);
+    expect(sent.some((m) => m.channel === IPC.UPDATE_ERROR)).toBe(false);
 
     updater.stop();
   });


### PR DESCRIPTION
## What

The auto-update toggle fed the single early-return that every update check passes through, so turning background polling off also turned the manual "check for updates" button into a no-op: the IPC handler had already replied `checking`, then `check()` bailed silently. With the toggle off, the only way to update was reinstalling.

## Fix

`check()` now bails on `!enabled` only for background polls. A manual press (`oneShot`) is an explicit user request and always checks — one line in `AutoUpdater.ts`.

## Tests

Two regression tests in `AutoUpdater.platform.test.ts`:
- toggle off → neither the 15s first check nor a 30-min interval touches the network, but a manual `UPDATE_CHECK` still hits the feed (fails without the fix)
- toggle back on → background polling resumes at the next interval

`tsc --noEmit` clean; updater suite 46/46.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the **Check for updates** button so it still performs an explicit update check when automatic updates are disabled (instead of acting like a no-op).
  * Disabling automatic updates now silences only scheduled background polling, not user-initiated checks.
  * Re-enabling automatic updates correctly resumes the next scheduled update checks.
* **Tests**
  * Added coverage to verify manual checks work while auto-update polling is gated and that polling resumes after re-enabling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->