### PR TITLE
chore(release): 3.37.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.37.1] — 2026-07-27
 
 ### Fixed
 

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.37.0 sources.** This file is produced by
+> **Generated from wmux v3.37.1 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.36.0",
+  "version": "3.37.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.36.0",
+      "version": "3.37.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.37.0",
+  "version": "3.37.1",
   "description": "Workspace multiplexer for AI coding agents — run fleets of Claude Code, Codex & Gemini in parallel on Windows & macOS, with MCP browser automation built in",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Release 3.37.1.

- Version bump `3.37.0` → `3.37.1` (package.json + lock via npm@10)
- CHANGELOG: `[Unreleased]` → `[3.37.1] — 2026-07-27` (one Fixed entry: manual update check works with auto-update off, #643)
- `docs/api/reference.md` regenerated (version-baked header, CI drift guard)

Tag `v3.37.1` will be pushed on the merge commit; installer builds hang off the tag.