### PR TITLE
feat(web): phone-API protocol version handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to wmux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **A phone that is too old to talk to your daemon can now say so.** The phone API had no version on it, so once a mobile build ships it is pinned to whatever HTTP surface the daemon happens to serve — and a mismatch would have surfaced as routes failing one by one with no explanation. `GET /api/config`, the call a client already makes at connect, now reports the protocol the daemon speaks, the oldest one it still accepts, and the release it was spawned from. A client below the floor can show "update the app" instead of a broken screen. Nothing that already works changes: a daemon predating this simply has no version fields, which reads as the pre-handshake protocol, and a phone that ignores them behaves exactly as it does today.
+
 ## [3.37.1] — 2026-07-27
 
 ### Fixed

--- a/docs/phone-client-contract.md
+++ b/docs/phone-client-contract.md
@@ -35,6 +35,39 @@ refused before routing — a DNS-rebinding guard. Send the host you dialed.
 This is **not** treated as evidence of a secure transport anywhere. It used to
 be, for minting; that was removed, because the caller writes the header.
 
+### Protocol version
+
+`GET /api/config` is the first authenticated call a client makes, and it carries
+the handshake:
+
+| Field | Meaning |
+| --- | --- |
+| `protocolVersion` | the phone contract this daemon speaks |
+| `minProtocolVersion` | the oldest client contract it still accepts |
+| `serverVersion` | the release the daemon was spawned from — display and bug reports only, never compared |
+
+Read it once at connect, before anything else on the screen depends on a route
+answering.
+
+- **A missing `protocolVersion` is not an error.** A daemon predating the
+  handshake answers the same body with all three keys absent; read that as
+  protocol `0` and carry on exactly as before. Nothing that shipped before this
+  section changed shape.
+- **If your own protocol is below `minProtocolVersion`, stop and say so.** Show
+  an explicit "update required" state naming the app, not the daemon — the
+  operator's phone is the thing that has to move. Do not retry, do not fall
+  back: the server has deleted the shape you speak, so every later call is a
+  failure with a worse explanation attached.
+- **If `protocolVersion` is above yours, keep going.** The number moves only on
+  breaking changes, and the floor is what decides whether you are still served.
+  A newer daemon that still accepts you is the normal case, not a warning.
+- `serverVersion` is a string and may be the literal `unknown`. It is never a
+  compatibility input — the two numbers above are the whole gate.
+
+The version is deliberately not on a route of its own. A separate `/api/version`
+would be a second round trip that only pre-handshake daemons could fail, which
+is precisely the daemon the handshake exists to recognise.
+
 ---
 
 ## 2. Pairing
@@ -205,7 +238,7 @@ GET /api/events?since=<cursor>     (Bearer)
 ## 5. Panes
 
 ```
-GET /api/config    → {allowInput, allowUpload}
+GET /api/config    → {allowInput, allowUpload, protocolVersion, minProtocolVersion, serverVersion}
 GET /api/sessions  → {sessions: [{id, cwd, cols, rows, state, agent, lastActivity, workspace?, shell?}]}
 POST /api/input?session=<id>   body: raw bytes
 ```

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -18,6 +18,11 @@ import {
   type GitRunner,
   type SessionDiffResult,
 } from './sessionDiff';
+import {
+  daemonServerVersion,
+  MIN_PHONE_PROTOCOL_VERSION,
+  PHONE_PROTOCOL_VERSION,
+} from './protocolVersion';
 import { startSseHeartbeat } from './sseHeartbeat';
 import { buildWebCsp } from './webCsp';
 
@@ -64,7 +69,8 @@ import { buildWebCsp } from './webCsp';
  *   GET  /api/pair?code=       the ONLY unauthenticated API route; mints this
  *                              device's own credential (refused over plaintext
  *                              off-machine transports — see mintRefusal)
- *   GET  /api/config           allowInput + allowUpload flags
+ *   GET  /api/config           allowInput + allowUpload flags, plus the phone
+ *                              protocol handshake (see protocolVersion.ts)
  *   GET  /api/sessions         pane list
  *   POST /api/sessions         spawn a pane — 403 unless `--allow-input`
  *   DELETE /api/sessions/:id   close a pane — 403 unless `--allow-input`
@@ -1246,9 +1252,19 @@ export class WebTerminalServer {
     }
     const principal = auth.principal;
     if (req.method === 'GET' && p === '/api/config') {
+      // The handshake rides HERE rather than on a route of its own: this is
+      // already the first call a client makes after pairing, so a dedicated
+      // /api/version would be a second round trip that only pre-handshake
+      // daemons could fail — exactly the daemons it exists to detect. A client
+      // talking to one of those gets a body with no version keys at all, which
+      // reads as "protocol 0", the same way a missing `allowUpload` reads as
+      // false.
       return this.json(res, 200, {
         allowInput: this.opts?.allowInput === true,
         allowUpload: this.opts?.allowUpload === true,
+        protocolVersion: PHONE_PROTOCOL_VERSION,
+        minProtocolVersion: MIN_PHONE_PROTOCOL_VERSION,
+        serverVersion: daemonServerVersion(),
       });
     }
     if (req.method === 'GET' && p === '/api/sessions') {

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from 'node:events';
 import { request as httpReq } from 'node:http';
 import { WebTerminalServer, type WebDeviceResolver } from '../WebTerminalServer';
 import { GIT_HARDENING_CONFIG, type GitRunner } from '../sessionDiff';
+import { MIN_PHONE_PROTOCOL_VERSION, PHONE_PROTOCOL_VERSION } from '../protocolVersion';
 
 /** Drop the fixed `-c key=value` hardening prefix, leaving the command itself. */
 const gitBody = (args: readonly string[]): string[] => args.slice(GIT_HARDENING_CONFIG.length);
@@ -356,7 +357,49 @@ describe('WebTerminalServer', () => {
     // Bearer header → 200
     const ok = await fetch(`${base()}/api/config`, { headers: bearer(token) });
     expect(ok.status).toBe(200);
-    expect(await ok.json()).toEqual({ allowInput: false, allowUpload: false });
+    expect(await ok.json()).toMatchObject({ allowInput: false, allowUpload: false });
+  });
+
+  it('★ /api/config carries the phone protocol handshake', async () => {
+    // A shipped native client cannot be updated by the daemon, so the daemon
+    // has to say which contract it is speaking. This is the route the client
+    // already calls at connect time, and a daemon predating the handshake
+    // answers the same body with these three keys absent — which is how a
+    // client reads "protocol 0".
+    const info = await startRO();
+    const res = await fetch(`${base()}/api/config`, { headers: bearer(info.token as string) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.protocolVersion).toBe(PHONE_PROTOCOL_VERSION);
+    expect(body.minProtocolVersion).toBe(MIN_PHONE_PROTOCOL_VERSION);
+    // The floor can never exceed what the server itself speaks — that would
+    // lock out every client including a freshly built one.
+    expect(body.minProtocolVersion).toBeLessThanOrEqual(body.protocolVersion);
+    // Present and non-empty. The value is the launcher-injected release or the
+    // 'unknown' sentinel; tests run without the launcher, so both are valid and
+    // only the field's existence is contractual.
+    expect(typeof body.serverVersion).toBe('string');
+    expect(body.serverVersion.length).toBeGreaterThan(0);
+  });
+
+  it('★ the handshake survives a bind that refuses to pair', async () => {
+    // A plaintext non-loopback bind refuses to mint credentials, which is the
+    // one state where the server answers operator surfaces differently. An
+    // already-paired phone still reaches /api/config there, so the version
+    // fields must not be a property of the happy path only — a client that
+    // could not read them would report "update required" for a transport
+    // problem.
+    const info = await server.start({ port: 0, host: '0.0.0.0', allowInput: false, allowUpload: false });
+    expect(server.status().pairRefusal?.reason).toBe('insecure-transport');
+
+    const res = await fetch(`http://127.0.0.1:${info.port}/api/config`, {
+      headers: bearer(info.token as string),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      protocolVersion: PHONE_PROTOCOL_VERSION,
+      minProtocolVersion: MIN_PHONE_PROTOCOL_VERSION,
+    });
   });
 
   it('never lists the orchestrator brain as a pane', async () => {
@@ -2910,7 +2953,7 @@ describe('WebTerminalServer', () => {
   it('reports allowUpload on /api/config so the phone can hide the button', async () => {
     const info = await startUpload();
     const res = await fetch(`${base()}/api/config`, { headers: bearer(info.token as string) });
-    expect(await res.json()).toEqual({ allowInput: false, allowUpload: true });
+    expect(await res.json()).toMatchObject({ allowInput: false, allowUpload: true });
     // status() carries it too — that is what `wmux web --status` prints.
     expect(server.status().allowUpload).toBe(true);
   });

--- a/src/daemon/web/protocolVersion.ts
+++ b/src/daemon/web/protocolVersion.ts
@@ -1,0 +1,47 @@
+import { ENV_KEYS } from '../../shared/constants';
+
+/**
+ * The phone API's own version, independent of the daemon's release version.
+ *
+ * Why a second number at all: once a native client ships, the HTTP surface is
+ * pinned to binaries the daemon cannot update. The release version moves for
+ * reasons a phone does not care about (a renderer fix, a CLI flag), so keying
+ * client compatibility on it would strand phones on every unrelated release.
+ * This number moves only when the wire contract does.
+ *
+ * BUMP `PHONE_PROTOCOL_VERSION` when the phone-facing HTTP surface changes in a
+ * way a client can observe: a route removed or renamed, a field removed or
+ * given a new meaning, a status code repurposed. Do NOT bump it for additive
+ * changes — a new optional field or a new route is invisible to a client that
+ * does not read it, and every additive change so far has been shipped that way
+ * on purpose (see `tier`, `allowUpload`).
+ *
+ * BUMP `MIN_PHONE_PROTOCOL_VERSION` only when the server genuinely can no
+ * longer serve an older client — that is, when support for the old shape is
+ * actually deleted, not merely deprecated. It is a hard cutoff: every client
+ * below it is told to update and can do nothing else, so raising it strands
+ * whoever has not opened the App Store. Keep it lagging as far behind
+ * `PHONE_PROTOCOL_VERSION` as the code allows.
+ */
+export const PHONE_PROTOCOL_VERSION = 1;
+
+/** Oldest client protocol this server still accepts. See the note above. */
+export const MIN_PHONE_PROTOCOL_VERSION = 1;
+
+/**
+ * The release the daemon was spawned from, for display and bug reports only.
+ *
+ * Deliberately the SAME source the B′ stale-daemon auto-replacement reads
+ * (`daemon.ping.spawnedByVersion`): the launcher injects it unconditionally, so
+ * two accessors reading two sources would eventually disagree about which
+ * daemon is running — and the copy that drifts would be the one an operator is
+ * shown in a bug report. Reading `package.json` here would also be wrong from a
+ * bundled daemon, which has no package.json beside it.
+ *
+ * The 'unknown' sentinel carries the same meaning it does there: B′-or-later
+ * code whose spawn path is unclear. Never compare it as a version — clients gate
+ * on the protocol numbers above, never on this string.
+ */
+export function daemonServerVersion(): string {
+  return process.env[ENV_KEYS.SPAWNED_BY_VERSION] || 'unknown';
+}


### PR DESCRIPTION
## Problem

The phone API is unversioned. Once a TestFlight iOS build ships, the HTTP surface
is hard-coupled to binaries the daemon cannot update — and a mismatch would have
surfaced as routes failing one at a time, with no way for the app to say "you are
too old" rather than "something went wrong".

## What this adds

`src/daemon/web/protocolVersion.ts`:

- `PHONE_PROTOCOL_VERSION = 1` — bumped only when the phone-facing wire changes
  incompatibly (route removed/renamed, field removed or re-meaninged). Additive
  changes never bump it.
- `MIN_PHONE_PROTOCOL_VERSION = 1` — the hard cutoff; bumped only when support
  for an older shape is actually deleted, since every client below it is stranded.
- `daemonServerVersion()` — reads the same `WMUX_SPAWNED_BY_VERSION` the B′
  stale-daemon auto-replacement reads, rather than a second source that would
  eventually disagree with it (and rather than a `package.json` a bundled daemon
  does not have beside it).

`GET /api/config` now carries `protocolVersion`, `minProtocolVersion` and
`serverVersion` alongside the existing flags. No new route: `/api/config` is
already the first authenticated call a client makes, so a dedicated
`/api/version` would be a second round trip that only pre-handshake daemons
could fail — precisely the daemon the handshake exists to recognise.

## Compatibility

- **Old daemon, new client**: the three keys are simply absent. The client reads
  that as protocol 0 and behaves exactly as it does today — the same way a
  missing `allowUpload` reads as `false`.
- **Old client, new daemon**: the fields are ignored; nothing that shipped
  changes shape. `MIN_PHONE_PROTOCOL_VERSION` stays at 1, so nobody is cut off.
- **Client below the floor** (future): show an explicit "update required" state
  and stop, rather than retrying into worse errors.
- A newer `protocolVersion` than the client's is not a warning — the floor is
  what decides whether a client is still served.

`serverVersion` is display/bug-report only and may be the literal `unknown`;
clients gate on the two numbers, never on that string.

## Tests

Two new cases in `src/daemon/web/__tests__/WebTerminalServer.test.ts`:

- `/api/config` carries all three fields with the exported values, and
  `minProtocolVersion <= protocolVersion` (a floor above what the server speaks
  would lock out even a freshly built client).
- The handshake survives a bind that refuses to pair (`0.0.0.0` plaintext,
  `pairRefusal: insecure-transport`) — an already-paired phone still reaches
  `/api/config` there, and a client that could not read the version fields would
  report "update required" for what is actually a transport problem.

Two existing exact-match assertions on the `/api/config` body were relaxed to
`toMatchObject`, since the body is now additive.

## Docs

`docs/phone-client-contract.md` gains a "Protocol version" subsection under §1
documenting the three fields, the missing-key case, and the required client
behaviour on each comparison outcome. `CHANGELOG.md` gets an `[Unreleased]`
entry. No version bump.

## Gates

`npx tsc -p tsconfig.daemon.json --noEmit` clean; `npx vitest run src/daemon/web`
301 passed / 4 skipped; eslint on the touched files reports pre-existing warnings
only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added phone protocol version details to the `/api/config` response.
  * Older phone clients can now detect incompatible daemon versions and display an update-required message instead of failing silently.
  * Protocol information remains available even when secure pairing is refused.

* **Documentation**
  * Documented the phone protocol handshake, supported version fields, and client behavior for incompatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->