### PR TITLE
fix(daemon): reap phantom PTY exits instead of tombstoning live shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **A phone that is too old to talk to your daemon can now say so.** The phone API had no version on it, so once a mobile build ships it is pinned to whatever HTTP surface the daemon happens to serve — and a mismatch would have surfaced as routes failing one by one with no explanation. `GET /api/config`, the call a client already makes at connect, now reports the protocol the daemon speaks, the oldest one it still accepts, and the release it was spawned from. A client below the floor can show "update the app" instead of a broken screen. Nothing that already works changes: a daemon predating this simply has no version fields, which reads as the pre-handshake protocol, and a phone that ignores them behaves exactly as it does today.
 
+### Fixed
+
+- **A pane no longer goes dead while the shell inside it keeps running.** On Windows, node-pty sometimes reports that a terminal exited when in fact only its output socket closed — the code it hands back is empty, and `powershell.exe` and whatever agent it was hosting are still very much alive. wmux believed the report, marked the pane dead, and walked away, which meant an agent kept burning memory and API quota with nothing left to reach it or shut it down, and the pane came back in your home directory instead of your project. wmux now asks the operating system whether the process is actually gone before believing any exit that arrives without a code. If it is still there, wmux shuts the whole tree down itself — the shell and everything it started — and closes the pane properly, saying so in the log. The exact report from the terminal layer is logged verbatim, which is what the underlying investigation needs. Real exits are untouched: an exit that carries a code, or a signal, still behaves exactly as before. (#646)
+
+- **Shells orphaned by that bug are now cleaned up at startup.** Because the pane had already been written off, nothing ever reaped those processes — one report found shells still running eleven and twelve days after the daemon that spawned them had gone. On startup wmux now checks its own records of closed panes: if one still points at a running process, and the machine has not rebooted since (so the process id can't belong to something else), and it really is the shell wmux started, it is shut down and noted in the log. Anything uncertain is left alone.
+
 ## [3.37.1] — 2026-07-27
 
 ### Fixed

--- a/src/daemon/DaemonPTYBridge.ts
+++ b/src/daemon/DaemonPTYBridge.ts
@@ -260,10 +260,20 @@ export class DaemonPTYBridge extends EventEmitter {
     this.dataDisposable = () => onDataDisposable.dispose();
 
     // PTY exit handler. Capture `signal` alongside exitCode: a clean shell
-    // exit carries a numeric exitCode and no signal, whereas a terminated
-    // process (ConPTY torn down, killed) shows up as a signal or a null
-    // exitCode. That distinction is what the silent-death investigation needs
-    // to tell "the shell exited on its own" from "something killed it".
+    // exit carries a numeric exitCode and no signal, whereas a killed process
+    // reports the signal that killed it. That distinction is what the
+    // silent-death investigation needs to tell "the shell exited on its own"
+    // from "something killed it".
+    //
+    // A NULL exitCode with no signal is neither (#646). It is node-pty's
+    // conout-socket-close path: the Windows agent's exit handler runs with
+    // `_agent.exitCode === undefined` when the socket drops, and the shell may
+    // well still be running. This comment used to call that shape the
+    // involuntary-teardown signature, which contradicted the classifier in
+    // shutdownKill.ts (only 0x40010004 / our own shutdown flag qualify) — and
+    // the classifier is what runs, so null was treated as a voluntary exit and
+    // buried a live shell. Consumers must not infer a death from a null code
+    // alone; see phantomExit.ts for the liveness check that settles it.
     const onExitDisposable = ptyProcess.onExit(({ exitCode, signal }) => {
       this.emit('exit', { sessionId, exitCode, signal });
     });

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -16,7 +16,7 @@ import { isMac } from '../shared/platform';
 import { getWindowsDefaultShell, resolveBareShellName, resolveLaunchableWindowsExe } from '../shared/shellResolution';
 import { ENV_KEYS } from '../shared/constants';
 import { createDefaultConfig } from './config';
-import { isPhantomExit, isPidAlive } from './phantomExit';
+import { getProcessStartTime, isPhantomExit, isPidAlive } from './phantomExit';
 
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
@@ -119,7 +119,8 @@ const clampRows = (rows: number): number => Math.max(MIN_SAFE_ROWS, rows);
  *      A PTY exit classified as involuntary (OS shutdown killing children —
  *      see shutdownKill.ts). The session is SUSPENDED, not dead: daemon/index
  *      dumps the buffer + persists so post-reboot recovery replays the same id.
- *  - 'session:phantomExit'  → { id, pid, exitCode, signal, cmd, lastActivityMsAgo, raw }
+ *  - 'session:phantomExit'  → { id, pid, pidStartTime, exitCode, signal, cmd,
+ *                               lastActivityMsAgo, raw }
  *      A PTY exit that reported no exit code and no signal while the shell pid
  *      is STILL ALIVE (node-pty's ConPTY socket-close path — see
  *      phantomExit.ts / issue #646). Mechanism only: no state is set and no
@@ -592,6 +593,8 @@ export class DaemonSessionManager extends EventEmitter {
           signal: payload.signal,
           cmd: meta.cmd,
           lastActivityMsAgo,
+          // Identity of the pid we are about to ask the policy layer to kill.
+          pidStartTime: meta.pidStartTime,
           // Carried, not logged here: this class has no access to the daemon's
           // file logger, and a console.log would never reach the daemon log
           // the native-layer investigation actually reads. index.ts prints it
@@ -633,6 +636,17 @@ export class DaemonSessionManager extends EventEmitter {
       bridge.setMuted(true);
     }
     bridge.setupDataForwarding(ptyProcess, ringBuffer, params.id, promptLog);
+
+    // #646: stamp the pid's OS creation time so later reaping paths can tell
+    // OUR shell from whatever process inherits the pid after recycling.
+    // Deliberately not awaited — createSession is synchronous and the probe
+    // shells out. The value lands on the live meta well before any tombstone
+    // could be written, and every sessions.json write reads meta at write
+    // time, so persistence picks it up. If the probe fails the field stays
+    // absent and the reaping paths fall back to their weaker check.
+    void getProcessStartTime(meta.pid).then((startTime) => {
+      if (startTime) meta.pidStartTime = startTime;
+    });
 
     this.emit('session:created', { session: { ...meta } });
     return { ...meta };

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -119,13 +119,15 @@ const clampRows = (rows: number): number => Math.max(MIN_SAFE_ROWS, rows);
  *      A PTY exit classified as involuntary (OS shutdown killing children —
  *      see shutdownKill.ts). The session is SUSPENDED, not dead: daemon/index
  *      dumps the buffer + persists so post-reboot recovery replays the same id.
- *  - 'session:phantomExit'  → { id, pid, exitCode, signal, cmd, lastActivityMsAgo }
+ *  - 'session:phantomExit'  → { id, pid, exitCode, signal, cmd, lastActivityMsAgo, raw }
  *      A PTY exit that reported no exit code and no signal while the shell pid
  *      is STILL ALIVE (node-pty's ConPTY socket-close path — see
  *      phantomExit.ts / issue #646). Mechanism only: no state is set and no
  *      death is announced here. daemon/index.ts owns the policy — it reaps the
  *      orphaned process tree and then runs the normal death flow, matching how
- *      the session:interrupted policy lives there too.
+ *      the session:interrupted policy lives there too. `raw` is the verbatim
+ *      node-pty payload, forwarded so the daemon log records the exact shape
+ *      the native layer produced (this class cannot reach that logger).
  *  - 'session:stateChanged' → { id: string, state: DaemonSessionState }
  */
 export class DaemonSessionManager extends EventEmitter {
@@ -579,11 +581,6 @@ export class DaemonSessionManager extends EventEmitter {
         !involuntary && isPhantomExit(payload.exitCode, payload.signal, meta.pid, isPidAlive);
       const lastActivityMsAgo = Date.now() - new Date(meta.lastActivity).getTime();
       if (phantom) {
-        // Log the payload verbatim: the native-layer investigation needs the
-        // exact shape node-pty handed us, not our interpretation of it.
-        console.log(
-          `[DaemonSessionManager] phantom PTY exit for ${params.id} (pid ${meta.pid} still alive) — raw node-pty payload: ${JSON.stringify(payload)}`,
-        );
         // The bridge's PTY object is unusable either way (its outSocket is
         // already destroyed), so release its timers/listeners here. State and
         // the death announcement are the policy layer's call.
@@ -595,6 +592,11 @@ export class DaemonSessionManager extends EventEmitter {
           signal: payload.signal,
           cmd: meta.cmd,
           lastActivityMsAgo,
+          // Carried, not logged here: this class has no access to the daemon's
+          // file logger, and a console.log would never reach the daemon log
+          // the native-layer investigation actually reads. index.ts prints it
+          // on the [lifecycle] line.
+          raw: JSON.stringify(payload),
         });
         return;
       }

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -16,6 +16,7 @@ import { isMac } from '../shared/platform';
 import { getWindowsDefaultShell, resolveBareShellName, resolveLaunchableWindowsExe } from '../shared/shellResolution';
 import { ENV_KEYS } from '../shared/constants';
 import { createDefaultConfig } from './config';
+import { isPhantomExit, isPidAlive } from './phantomExit';
 
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
@@ -118,6 +119,13 @@ const clampRows = (rows: number): number => Math.max(MIN_SAFE_ROWS, rows);
  *      A PTY exit classified as involuntary (OS shutdown killing children —
  *      see shutdownKill.ts). The session is SUSPENDED, not dead: daemon/index
  *      dumps the buffer + persists so post-reboot recovery replays the same id.
+ *  - 'session:phantomExit'  → { id, pid, exitCode, signal, cmd, lastActivityMsAgo }
+ *      A PTY exit that reported no exit code and no signal while the shell pid
+ *      is STILL ALIVE (node-pty's ConPTY socket-close path — see
+ *      phantomExit.ts / issue #646). Mechanism only: no state is set and no
+ *      death is announced here. daemon/index.ts owns the policy — it reaps the
+ *      orphaned process tree and then runs the normal death flow, matching how
+ *      the session:interrupted policy lives there too.
  *  - 'session:stateChanged' → { id: string, state: DaemonSessionState }
  */
 export class DaemonSessionManager extends EventEmitter {
@@ -562,6 +570,34 @@ export class DaemonSessionManager extends EventEmitter {
       // as 'dead' purged exactly the in-use sessions from recovery. Classified
       // exits suspend instead — recovery replays them under the same id.
       const involuntary = this.involuntaryExitClassifier(payload.exitCode, payload.signal);
+      // #646: a code-less, signal-less exit whose pid is still alive is not a
+      // death at all — it is node-pty's conout-socket-close path firing while
+      // powershell.exe keeps running. Believing it tombstoned the session and
+      // orphaned the live shell + agent. Checked BEFORE the dead/suspended
+      // classification because both of those record an exit that didn't happen.
+      const phantom =
+        !involuntary && isPhantomExit(payload.exitCode, payload.signal, meta.pid, isPidAlive);
+      const lastActivityMsAgo = Date.now() - new Date(meta.lastActivity).getTime();
+      if (phantom) {
+        // Log the payload verbatim: the native-layer investigation needs the
+        // exact shape node-pty handed us, not our interpretation of it.
+        console.log(
+          `[DaemonSessionManager] phantom PTY exit for ${params.id} (pid ${meta.pid} still alive) — raw node-pty payload: ${JSON.stringify(payload)}`,
+        );
+        // The bridge's PTY object is unusable either way (its outSocket is
+        // already destroyed), so release its timers/listeners here. State and
+        // the death announcement are the policy layer's call.
+        managed.bridge.cleanup();
+        this.emit('session:phantomExit', {
+          id: params.id,
+          pid: meta.pid,
+          exitCode: payload.exitCode,
+          signal: payload.signal,
+          cmd: meta.cmd,
+          lastActivityMsAgo,
+        });
+        return;
+      }
       meta.state = involuntary ? 'suspended' : 'dead';
       meta.exitCode = payload.exitCode;
       // Clean up bridge timers/listeners to prevent leaks when sessions die naturally
@@ -570,7 +606,6 @@ export class DaemonSessionManager extends EventEmitter {
       // exited: code/signal, the shell, and how long it had been idle before
       // dying. Silent PTY deaths (no log, no recorded exitCode) made the
       // "powershell exits -1 under claude" report undiagnosable.
-      const lastActivityMsAgo = Date.now() - new Date(meta.lastActivity).getTime();
       const forensics = {
         id: params.id,
         exitCode: payload.exitCode,

--- a/src/daemon/StateWriter.ts
+++ b/src/daemon/StateWriter.ts
@@ -11,6 +11,7 @@ import {
 } from './util/atomicWrite';
 import { AsyncQueue } from './util/AsyncQueue';
 import { stripCredentialValues } from '../shared/envFilter';
+import { isPidAlive } from './phantomExit';
 
 /**
  * 영속 직전 자격증명 *값*을 제거한 DaemonState fresh 사본. 모든 sessions.json write
@@ -113,6 +114,13 @@ const SUSPENDED_TTL_HOURS_DEFAULT = 7 * 24;
 // workday gap and kills overnight orphans; the per-instance config
 // (config.session.detachedTtlHours) overrides this at the daemon.
 const DETACHED_TTL_HOURS_DEFAULT = 8;
+
+// #646: how far past its own deadTtlHours a tombstone may be kept alive while
+// its pid still answers, so recovery's reconciliation pass can still find and
+// reap the orphaned shell. 7x turns the default 24 h tombstone into a week,
+// which covers the reported 11-12-day orphans' daemon-restart cadence without
+// letting a record live forever on the strength of a recycled pid.
+const DEAD_TOMBSTONE_LIVE_PID_TTL_MULTIPLIER = 7;
 
 /**
  * Persists DaemonState (sessions.json) to disk using the shared
@@ -343,7 +351,8 @@ export class StateWriter {
     }
 
     // Prune expired sessions. Three paths:
-    //   - dead: per-session TTL (s.deadTtlHours)
+    //   - dead: per-session TTL (s.deadTtlHours), extended while the recorded
+    //     pid is still alive so #646's reconciliation pass can still reap it.
     //   - suspended: this.suspendedTtlHours (configurable, default 7d —
     //     v2.8.1 hotfix; see top of this file for the accumulation incident
     //     this prevents).
@@ -381,7 +390,23 @@ export class StateWriter {
       }
       const sinceMs = now - new Date(s.lastActivity).getTime();
       if (s.state === 'dead') {
-        return sinceMs < s.deadTtlHours * 60 * 60 * 1000;
+        const ttlMs = s.deadTtlHours * 60 * 60 * 1000;
+        if (sinceMs < ttlMs) return true;
+        // #646: a tombstone is supposed to mean the process is gone, but a
+        // phantom PTY exit could write one over a still-running shell. Pruning
+        // it here would drop the only record of that pid before recovery's
+        // reconciliation pass ever sees it, and nothing would ever reap the
+        // process — which is precisely how the reported orphans survived 11-12
+        // days. So keep an expired tombstone alive as long as its pid is.
+        //
+        // Bounded, because pid liveness stops meaning anything after a reboot
+        // or a pid recycle: past the hard cap the record is dropped regardless.
+        // Recovery only acts on it within the same proven boot anyway, so the
+        // cap costs nothing real and stops a recycled pid from immortalising a
+        // record.
+        const hardCapMs = ttlMs * DEAD_TOMBSTONE_LIVE_PID_TTL_MULTIPLIER;
+        if (sinceMs >= hardCapMs) return false;
+        return typeof s.pid === 'number' && isPidAlive(s.pid);
       }
       if (s.state === 'suspended') {
         return sinceMs < this.suspendedTtlHours * 60 * 60 * 1000;

--- a/src/daemon/__tests__/StateWriter.test.ts
+++ b/src/daemon/__tests__/StateWriter.test.ts
@@ -175,6 +175,11 @@ describe('StateWriter', () => {
       state: 'dead',
       lastActivity: new Date(now - 25 * 60 * 60 * 1000).toISOString(),
       deadTtlHours: 24,
+      // #646: an expired tombstone is now kept while its pid still answers, so
+      // this fixture needs a pid that can never be alive — otherwise the
+      // default 12345 could be a real process on the test machine and this
+      // assertion would pass or fail depending on who is running it.
+      pid: 0,
     });
     // Dead session from 1 hour ago with 24h TTL — should survive
     const recent = makeSession({
@@ -194,6 +199,56 @@ describe('StateWriter', () => {
     expect(ids).not.toContain('expired');
     expect(ids).toContain('recent-dead');
     expect(ids).toContain('alive');
+  });
+
+  // #646: pruning ran BEFORE recovery's reconciliation pass, so a tombstone
+  // written over a still-running shell — the exact 11-12-day orphans in the
+  // report — was dropped before anything could reap its process.
+  it('load KEEPS an expired DEAD session whose pid is still alive (#646)', () => {
+    const now = Date.now();
+    const orphan = makeSession({
+      id: 'orphan-tombstone',
+      state: 'dead',
+      lastActivity: new Date(now - 25 * 60 * 60 * 1000).toISOString(),
+      deadTtlHours: 24,
+      pid: process.pid, // guaranteed alive
+    });
+
+    writer.saveImmediate(makeState([orphan]));
+
+    expect(writer.load().sessions.map((s) => s.id)).toContain('orphan-tombstone');
+  });
+
+  it('load drops a live-pid DEAD session once past the hard cap (#646)', () => {
+    const now = Date.now();
+    // 7x the record's own 24h TTL is the cap; 8 days is past it. Without the
+    // cap a recycled pid could keep a tombstone on disk indefinitely.
+    const ancient = makeSession({
+      id: 'ancient-tombstone',
+      state: 'dead',
+      lastActivity: new Date(now - 8 * 24 * 60 * 60 * 1000).toISOString(),
+      deadTtlHours: 24,
+      pid: process.pid,
+    });
+
+    writer.saveImmediate(makeState([ancient]));
+
+    expect(writer.load().sessions.map((s) => s.id)).not.toContain('ancient-tombstone');
+  });
+
+  it('load still prunes an expired DEAD session with no usable pid (#646)', () => {
+    const now = Date.now();
+    const noPid = makeSession({
+      id: 'no-pid-tombstone',
+      state: 'dead',
+      lastActivity: new Date(now - 25 * 60 * 60 * 1000).toISOString(),
+      deadTtlHours: 24,
+      pid: undefined as unknown as number, // legacy record
+    });
+
+    writer.saveImmediate(makeState([noPid]));
+
+    expect(writer.load().sessions.map((s) => s.id)).not.toContain('no-pid-tombstone');
   });
 
   it('load prunes SUSPENDED sessions past 7-day TTL (v2.8.1 hotfix)', () => {

--- a/src/daemon/__tests__/phantomExit.test.ts
+++ b/src/daemon/__tests__/phantomExit.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { isPhantomExit, isPidAlive, shouldReconcileTombstone } from '../phantomExit';
+import {
+  isPhantomExit,
+  isPidAlive,
+  isSameBootProven,
+  shouldReconcileTombstone,
+} from '../phantomExit';
 
 // Issue #646: node-pty's ConPTY conout-socket-close path emits `exit` with
 // `_agent.exitCode === undefined` (null on our side) while powershell.exe is
@@ -66,11 +71,34 @@ describe('isPidAlive', () => {
   });
 });
 
+describe('isSameBootProven', () => {
+  it('proves the same boot only when the stored id exists and matches', () => {
+    expect(isSameBootProven('boot-a', 'boot-a')).toBe(true);
+  });
+
+  it('a different boot id is a reboot', () => {
+    expect(isSameBootProven('boot-a', 'boot-b')).toBe(false);
+  });
+
+  it('a state file with no boot id proves nothing — never reconcile', () => {
+    // The original `rebooted` flag read this case as "no reboot happened",
+    // which would authorize killing a recycled pid across a real reboot.
+    expect(isSameBootProven(undefined, 'boot-a')).toBe(false);
+    expect(isSameBootProven(null, 'boot-a')).toBe(false);
+    expect(isSameBootProven('', 'boot-a')).toBe(false);
+  });
+
+  it('an unknown current boot id proves nothing either', () => {
+    expect(isSameBootProven('boot-a', null)).toBe(false);
+    expect(isSameBootProven(null, null)).toBe(false);
+  });
+});
+
 // Boot-time reconciliation: a `dead` record holding a live pid is the
 // persisted residue of the same bug, and it hid orphans from every census.
 describe('shouldReconcileTombstone', () => {
-  const alive = { rebooted: false, alive: () => true };
-  const dead = { rebooted: false, alive: () => false };
+  const alive = { sameBootProven: true, alive: () => true };
+  const dead = { sameBootProven: true, alive: () => false };
 
   it('reconciles a dead record whose pid is still alive within the same boot', () => {
     expect(shouldReconcileTombstone({ state: 'dead', pid: 20516 }, alive)).toBe(true);
@@ -80,9 +108,11 @@ describe('shouldReconcileTombstone', () => {
     expect(shouldReconcileTombstone({ state: 'dead', pid: 20516 }, dead)).toBe(false);
   });
 
-  it('never reconciles after a reboot — the pid may have been recycled', () => {
+  it('never reconciles without proof of the same boot — the pid may have been recycled', () => {
+    // Covers both a detected reboot AND a state file carrying no bootId at
+    // all: absence of evidence must not read as evidence of no reboot.
     expect(
-      shouldReconcileTombstone({ state: 'dead', pid: 20516 }, { rebooted: true, alive: () => true }),
+      shouldReconcileTombstone({ state: 'dead', pid: 20516 }, { sameBootProven: false, alive: () => true }),
     ).toBe(false);
   });
 

--- a/src/daemon/__tests__/phantomExit.test.ts
+++ b/src/daemon/__tests__/phantomExit.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import {
+  classifyReapIdentity,
   isPhantomExit,
   isPidAlive,
   isSameBootProven,
+  mayReap,
   shouldReconcileTombstone,
 } from '../phantomExit';
 
@@ -68,6 +70,57 @@ describe('isPidAlive', () => {
     expect(isPidAlive(0)).toBe(false);
     expect(isPidAlive(-1)).toBe(false);
     expect(isPidAlive(Number.NaN)).toBe(false);
+  });
+});
+
+// Both reaping paths kill a whole process TREE, and Windows recycles pids
+// aggressively while a tombstone can outlive its shell by deadTtlHours. The
+// creation time is what separates "our orphan" from "a stranger's shell".
+describe('classifyReapIdentity', () => {
+  const T1 = '20260727142800.123456+540';
+  const T2 = '20260727150000.000000+540';
+
+  it('a matching recorded creation time is proof', () => {
+    expect(
+      classifyReapIdentity({ storedStartTime: T1, currentStartTime: T1, looksLikeOurShell: true }),
+    ).toBe('start-time');
+  });
+
+  it('a recorded time overrides the executable-name match when it disagrees', () => {
+    // The recycled-pid case: a brand new powershell.exe wearing our old pid
+    // passes the name check, so the name check must not get a vote here.
+    expect(
+      classifyReapIdentity({ storedStartTime: T1, currentStartTime: T2, looksLikeOurShell: true }),
+    ).toBe('unconfirmed');
+  });
+
+  it('an unreadable current creation time never counts as a match', () => {
+    expect(
+      classifyReapIdentity({ storedStartTime: T1, currentStartTime: null, looksLikeOurShell: true }),
+    ).toBe('unconfirmed');
+  });
+
+  it('falls back to the executable-name heuristic only when nothing was recorded', () => {
+    // Pre-fix tombstones have no creation time; accepting the weaker evidence
+    // is what lets existing orphans be cleaned up at all.
+    expect(
+      classifyReapIdentity({ storedStartTime: undefined, currentStartTime: T1, looksLikeOurShell: true }),
+    ).toBe('heuristic');
+    expect(
+      classifyReapIdentity({ storedStartTime: null, currentStartTime: null, looksLikeOurShell: true }),
+    ).toBe('heuristic');
+  });
+
+  it('no recorded time and not our shell means no evidence at all', () => {
+    expect(
+      classifyReapIdentity({ storedStartTime: undefined, currentStartTime: T1, looksLikeOurShell: false }),
+    ).toBe('unconfirmed');
+  });
+
+  it('only an unconfirmed identity blocks the kill', () => {
+    expect(mayReap('start-time')).toBe(true);
+    expect(mayReap('heuristic')).toBe(true);
+    expect(mayReap('unconfirmed')).toBe(false);
   });
 });
 

--- a/src/daemon/__tests__/phantomExit.test.ts
+++ b/src/daemon/__tests__/phantomExit.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { isPhantomExit, isPidAlive, shouldReconcileTombstone } from '../phantomExit';
+
+// Issue #646: node-pty's ConPTY conout-socket-close path emits `exit` with
+// `_agent.exitCode === undefined` (null on our side) while powershell.exe is
+// still running. Tombstoning that exit orphaned the live shell + agent. The
+// guard must fire ONLY on the code-less, signal-less, still-alive shape —
+// everything else is a real death and keeps the normal flow.
+describe('isPhantomExit', () => {
+  const alwaysAlive = () => true;
+  const alwaysDead = () => false;
+
+  it('matches the observed incident signature: null exitCode, no signal, pid alive', () => {
+    expect(isPhantomExit(null, undefined, 20516, alwaysAlive)).toBe(true);
+  });
+
+  it('treats an undefined exitCode the same as null (node-pty passes through undefined)', () => {
+    expect(isPhantomExit(undefined, undefined, 20516, alwaysAlive)).toBe(true);
+  });
+
+  it('a null exitCode whose pid is GONE is a real death, not a phantom', () => {
+    expect(isPhantomExit(null, undefined, 20516, alwaysDead)).toBe(false);
+  });
+
+  it('any recorded exit code is a real death even if the pid still answers', () => {
+    expect(isPhantomExit(0, undefined, 20516, alwaysAlive)).toBe(false); // `exit`
+    expect(isPhantomExit(1, undefined, 20516, alwaysAlive)).toBe(false); // error exit
+    expect(isPhantomExit(1073807364, undefined, 20516, alwaysAlive)).toBe(false); // shutdown kill
+  });
+
+  it('a signal is a death report — the process was killed, not disconnected', () => {
+    expect(isPhantomExit(null, 9, 20516, alwaysAlive)).toBe(false);
+    expect(isPhantomExit(null, 15, 20516, alwaysAlive)).toBe(false);
+  });
+
+  it('an unknown or nonsensical pid can never be proven alive', () => {
+    expect(isPhantomExit(null, undefined, undefined, alwaysAlive)).toBe(false);
+    expect(isPhantomExit(null, undefined, 0, alwaysAlive)).toBe(false);
+    expect(isPhantomExit(null, undefined, -1, alwaysAlive)).toBe(false); // would be a process GROUP on posix
+    expect(isPhantomExit(null, undefined, 1.5, alwaysAlive)).toBe(false);
+  });
+
+  it('consults liveness only for the code-less shape (no needless syscalls)', () => {
+    const seen: number[] = [];
+    const spy = (pid: number) => {
+      seen.push(pid);
+      return true;
+    };
+    isPhantomExit(0, undefined, 20516, spy);
+    isPhantomExit(null, 9, 20516, spy);
+    expect(seen).toEqual([]);
+    isPhantomExit(null, undefined, 20516, spy);
+    expect(seen).toEqual([20516]);
+  });
+});
+
+describe('isPidAlive', () => {
+  it('reports our own process as alive', () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+  });
+
+  it('rejects pids that cannot exist rather than throwing', () => {
+    expect(isPidAlive(0)).toBe(false);
+    expect(isPidAlive(-1)).toBe(false);
+    expect(isPidAlive(Number.NaN)).toBe(false);
+  });
+});
+
+// Boot-time reconciliation: a `dead` record holding a live pid is the
+// persisted residue of the same bug, and it hid orphans from every census.
+describe('shouldReconcileTombstone', () => {
+  const alive = { rebooted: false, alive: () => true };
+  const dead = { rebooted: false, alive: () => false };
+
+  it('reconciles a dead record whose pid is still alive within the same boot', () => {
+    expect(shouldReconcileTombstone({ state: 'dead', pid: 20516 }, alive)).toBe(true);
+  });
+
+  it('leaves a dead record alone once its pid is really gone', () => {
+    expect(shouldReconcileTombstone({ state: 'dead', pid: 20516 }, dead)).toBe(false);
+  });
+
+  it('never reconciles after a reboot — the pid may have been recycled', () => {
+    expect(
+      shouldReconcileTombstone({ state: 'dead', pid: 20516 }, { rebooted: true, alive: () => true }),
+    ).toBe(false);
+  });
+
+  it('only tombstones qualify — live and suspended sessions are not orphans', () => {
+    expect(shouldReconcileTombstone({ state: 'attached', pid: 20516 }, alive)).toBe(false);
+    expect(shouldReconcileTombstone({ state: 'detached', pid: 20516 }, alive)).toBe(false);
+    expect(shouldReconcileTombstone({ state: 'suspended', pid: 20516 }, alive)).toBe(false);
+  });
+
+  it('old state files without a pid are skipped, not guessed at', () => {
+    expect(shouldReconcileTombstone({ state: 'dead' }, alive)).toBe(false);
+    expect(shouldReconcileTombstone({ state: 'dead', pid: 0 }, alive)).toBe(false);
+  });
+});

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -42,7 +42,14 @@ import { AgentProcessTracker } from './AgentProcessTracker';
 import { Watchdog } from './Watchdog';
 import { selectRecoverableSessions } from './recoverySelector';
 import { isShutdownKillExit, SHUTDOWN_KILL_RECLASSIFY_MS } from './shutdownKill';
-import { isPidAlive, isSameBootProven, shouldReconcileTombstone } from './phantomExit';
+import {
+  classifyReapIdentity,
+  getProcessStartTime,
+  isPidAlive,
+  isSameBootProven,
+  mayReap,
+  shouldReconcileTombstone,
+} from './phantomExit';
 import { createSnapshotRunner } from './snapshotRunner';
 import { RingBuffer } from './RingBuffer';
 import { GitContextWatcher } from '../main/pty/gitContextWatch';
@@ -843,6 +850,56 @@ async function reapProcessTree(pid: number, reason: string): Promise<void> {
   }
 }
 
+/**
+ * Confirm the pid really is the shell we spawned, then reap it (#646).
+ *
+ * Every reaping path goes through here, because a pid is not an identity: an
+ * exited shell's pid can be handed to an unrelated process, and both reaping
+ * paths kill an entire process TREE. Killing the wrong one takes out a user's
+ * own shell and everything running in it.
+ *
+ * Strongest available evidence wins, and a recorded creation time is
+ * authoritative when present — the executable-name check must never override
+ * a mismatch, since a recycled pid running `powershell.exe` would sail through
+ * it. When nothing confirms the pid, the kill is SKIPPED and logged; the
+ * caller still completes whatever bookkeeping it was doing.
+ *
+ * Returns whether the reap was authorized.
+ */
+async function reapIfIdentityConfirmed(opts: {
+  pid: number;
+  cmd: string;
+  storedStartTime?: string;
+  reason: string;
+}): Promise<boolean> {
+  const [currentStartTime, looksLikeOurShell] = await Promise.all([
+    getProcessStartTime(opts.pid),
+    // Only consulted when no creation time was recorded, but probing both in
+    // parallel keeps the slow path off the critical path of the common case.
+    isOurShellProcess(opts.pid, opts.cmd),
+  ]);
+  const identity = classifyReapIdentity({
+    storedStartTime: opts.storedStartTime,
+    currentStartTime,
+    looksLikeOurShell,
+  });
+  if (!mayReap(identity)) {
+    log(
+      'warn',
+      `[reap] refusing to kill pid ${opts.pid} (${opts.reason}): identity unconfirmed ` +
+        `(storedStartTime=${opts.storedStartTime ?? 'none'} currentStartTime=${currentStartTime ?? 'unknown'} ` +
+        `looksLikeOurShell=${looksLikeOurShell} cmd=${opts.cmd}) — the pid may belong to another process now`,
+    );
+    return false;
+  }
+  // Say which evidence authorized the kill: 'start-time' is proof,
+  // 'heuristic' is the weaker executable-name match we accept only for
+  // records written before creation times were recorded.
+  log('info', `[reap] identity=${identity} authorized killing pid ${opts.pid} (${opts.reason})`);
+  await reapProcessTree(opts.pid, opts.reason);
+  return true;
+}
+
 /** Check if a PID belongs to the shell process we originally spawned.
  *  Prevents killing unrelated processes after PID recycling (e.g. reboot). */
 async function isOurShellProcess(pid: number, expectedCmd: string): Promise<boolean> {
@@ -1085,11 +1142,14 @@ async function recoverSessions(
       // shell → it is an orphan of that bug, so reap it.
       if (shouldReconcileTombstone(session, { sameBootProven, alive: isPidAlive })) {
         const pid = session.pid;
-        if (await isOurShellProcess(pid, session.cmd)) {
+        const reaped = await reapIfIdentityConfirmed({
+          pid,
+          cmd: session.cmd,
+          storedStartTime: session.pidStartTime,
+          reason: `tombstone reconciliation of session ${session.id}`,
+        });
+        if (reaped) {
           log('info', `[recovery] reconciled tombstone ${session.id}: pid ${pid} was still alive`);
-          await reapProcessTree(pid, `tombstone reconciliation of session ${session.id}`);
-        } else {
-          log('warn', `[recovery] tombstone ${session.id} holds live pid ${pid}, but it is not our shell (${session.cmd}) — skipping kill`);
         }
       }
       continue;
@@ -3549,7 +3609,7 @@ function wireEvents(
   // and would leave the still-live shell behind — exactly the orphan this fix
   // exists to prevent. Reattaching to the live ConPTY instead of killing it is
   // a separate piece of work (likely an upstream node-pty fix).
-  sessionManager.on('session:phantomExit', (payload: { id: string; pid?: number; exitCode: number | null; signal?: number; cmd?: string; lastActivityMsAgo?: number; raw?: string }) => {
+  sessionManager.on('session:phantomExit', (payload: { id: string; pid?: number; pidStartTime?: string; exitCode: number | null; signal?: number; cmd?: string; lastActivityMsAgo?: number; raw?: string }) => {
     // `raw` is the verbatim node-pty payload — printed as-is because the
     // native-layer investigation needs the exact shape node-pty produced, not
     // our reading of it.
@@ -3571,7 +3631,17 @@ function wireEvents(
       finish();
       return;
     }
-    void reapProcessTree(payload.pid, `phantom exit of session ${payload.id}`).finally(finish);
+    // Identity-check even here, where the exit event just named this pid: the
+    // shell could have exited for real between the event and this probe, and
+    // the pid could already belong to something else. If it cannot be
+    // confirmed the kill is skipped — but the session still dies, because a
+    // pane whose transport is gone is over either way.
+    void reapIfIdentityConfirmed({
+      pid: payload.pid,
+      cmd: payload.cmd ?? '',
+      storedStartTime: payload.pidStartTime,
+      reason: `phantom exit of session ${payload.id}`,
+    }).finally(finish);
   });
 
   // A pane the user closes while a reclassification is pending must not get a

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -3542,10 +3542,13 @@ function wireEvents(
   // and would leave the still-live shell behind — exactly the orphan this fix
   // exists to prevent. Reattaching to the live ConPTY instead of killing it is
   // a separate piece of work (likely an upstream node-pty fix).
-  sessionManager.on('session:phantomExit', (payload: { id: string; pid?: number; exitCode: number | null; signal?: number; cmd?: string; lastActivityMsAgo?: number }) => {
+  sessionManager.on('session:phantomExit', (payload: { id: string; pid?: number; exitCode: number | null; signal?: number; cmd?: string; lastActivityMsAgo?: number; raw?: string }) => {
+    // `raw` is the verbatim node-pty payload — printed as-is because the
+    // native-layer investigation needs the exact shape node-pty produced, not
+    // our reading of it.
     log(
       'info',
-      `[lifecycle] session:phantomExit id=${payload.id} pid=${payload.pid ?? '?'} exitCode=${payload.exitCode ?? 'null'} signal=${payload.signal ?? 'none'} cmd=${payload.cmd ?? '?'} idleMsBeforeExit=${payload.lastActivityMsAgo ?? '?'} — PTY reported an exit with no code and no signal, but the pid is STILL ALIVE (node-pty conout-socket-close, see #646). Reaping the orphaned process tree, then marking dead.`,
+      `[lifecycle] session:phantomExit id=${payload.id} pid=${payload.pid ?? '?'} exitCode=${payload.exitCode ?? 'null'} signal=${payload.signal ?? 'none'} cmd=${payload.cmd ?? '?'} idleMsBeforeExit=${payload.lastActivityMsAgo ?? '?'} rawPtyPayload=${payload.raw ?? '?'} — PTY reported an exit with no code and no signal, but the pid is STILL ALIVE (node-pty conout-socket-close, see #646). Reaping the orphaned process tree, then marking dead.`,
     );
     const finish = () => {
       const managed = sessionManager.getSession(payload.id);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -3603,8 +3603,8 @@ function wireEvents(
   // unreachable — but it and its agent child keep running, which is how users
   // ended up with powershell.exe processes outliving their daemon by days.
   //
-  // Policy: kill the tree ourselves, then run the ordinary death flow with a
-  // `phantom-exit` reason so the log says what happened. Deliberately NOT the
+  // Policy: run the ordinary death flow with a `phantom-exit` reason so the
+  // log says what happened, then kill the tree. Deliberately NOT the
   // session:interrupted (suspend) path: that respawns the session on recovery
   // and would leave the still-live shell behind — exactly the orphan this fix
   // exists to prevent. Reattaching to the live ConPTY instead of killing it is
@@ -3617,31 +3617,34 @@ function wireEvents(
       'info',
       `[lifecycle] session:phantomExit id=${payload.id} pid=${payload.pid ?? '?'} exitCode=${payload.exitCode ?? 'null'} signal=${payload.signal ?? 'none'} cmd=${payload.cmd ?? '?'} idleMsBeforeExit=${payload.lastActivityMsAgo ?? '?'} rawPtyPayload=${payload.raw ?? '?'} — PTY reported an exit with no code and no signal, but the pid is STILL ALIVE (node-pty conout-socket-close, see #646). Reaping the orphaned process tree, then marking dead.`,
     );
-    const finish = () => {
-      const managed = sessionManager.getSession(payload.id);
-      // Destroyed meanwhile (user closed the pane) → the destroy path already
-      // did the teardown; announcing a death now would be a ghost event.
-      if (!managed) return;
+    // Mark dead SYNCHRONOUSLY, before the reap. The reap shells out to
+    // taskkill and can take seconds; leaving the session 'attached' for that
+    // window meant a graceful shutdown landing in it would persist the session
+    // as 'suspended', and the next boot would faithfully respawn a pane over a
+    // shell we had just reaped. Nothing about the death depends on the kill
+    // succeeding — the transport is gone either way — so the kill runs in the
+    // background afterwards.
+    const managed = sessionManager.getSession(payload.id);
+    // Destroyed meanwhile (user closed the pane) → the destroy path already
+    // did the teardown, so announcing a death now would be a ghost event. The
+    // process still has to go, so this only skips the bookkeeping.
+    if (managed) {
       managed.meta.state = 'dead';
       managed.meta.exitCode = payload.exitCode;
       sessionManager.emit('session:died', { ...payload, reason: 'phantom-exit' });
       sessionManager.emit('session:stateChanged', { id: payload.id, state: 'dead' });
-    };
-    if (payload.pid === undefined) {
-      finish();
-      return;
     }
+    if (payload.pid === undefined) return;
     // Identity-check even here, where the exit event just named this pid: the
     // shell could have exited for real between the event and this probe, and
     // the pid could already belong to something else. If it cannot be
-    // confirmed the kill is skipped — but the session still dies, because a
-    // pane whose transport is gone is over either way.
+    // confirmed the kill is skipped — the session is already dead regardless.
     void reapIfIdentityConfirmed({
       pid: payload.pid,
       cmd: payload.cmd ?? '',
       storedStartTime: payload.pidStartTime,
       reason: `phantom exit of session ${payload.id}`,
-    }).finally(finish);
+    });
   });
 
   // A pane the user closes while a reclassification is pending must not get a

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -42,7 +42,7 @@ import { AgentProcessTracker } from './AgentProcessTracker';
 import { Watchdog } from './Watchdog';
 import { selectRecoverableSessions } from './recoverySelector';
 import { isShutdownKillExit, SHUTDOWN_KILL_RECLASSIFY_MS } from './shutdownKill';
-import { isPidAlive, shouldReconcileTombstone } from './phantomExit';
+import { isPidAlive, isSameBootProven, shouldReconcileTombstone } from './phantomExit';
 import { createSnapshotRunner } from './snapshotRunner';
 import { RingBuffer } from './RingBuffer';
 import { GitContextWatcher } from '../main/pty/gitContextWatch';
@@ -1032,6 +1032,13 @@ async function recoverSessions(
   // Detect reboot: if bootId changed, all old PIDs are stale — skip kill attempts
   const currentBootId = await getBootId();
   const rebooted = state.bootId != null && state.bootId !== currentBootId;
+  // #646: `rebooted` is "we can prove a reboot happened", so a state file with
+  // no bootId at all (written by a pre-bootId build, or lost) reads as false —
+  // fine for the kill-stale-pid paths it was written for, fatal for tombstone
+  // reconciliation, which would then taskkill a recycled pid after a real
+  // reboot. Reconciliation needs the opposite claim: proof that we are on the
+  // SAME boot, which requires the bootId to exist AND match.
+  const sameBootProven = isSameBootProven(state.bootId, currentBootId);
   if (rebooted) {
     log('info', `Boot ID changed (${state.bootId} → ${currentBootId}) — reboot detected, skipping PID kills`);
   }
@@ -1073,10 +1080,10 @@ async function recoverSessions(
       // this fix a phantom PTY exit could write one while the shell kept
       // running, and because recovery skips dead records the orphan was
       // invisible to every census — reporters found shells outliving their
-      // daemon by 11–12 days. Reconcile here: same boot (so the pid cannot
-      // have been recycled), pid still alive, and it really is our shell →
-      // it is an orphan of that bug, so reap it.
-      if (shouldReconcileTombstone(session, { rebooted, alive: isPidAlive })) {
+      // daemon by 11–12 days. Reconcile here: PROVEN same boot (so the pid
+      // cannot have been recycled), pid still alive, and it really is our
+      // shell → it is an orphan of that bug, so reap it.
+      if (shouldReconcileTombstone(session, { sameBootProven, alive: isPidAlive })) {
         const pid = session.pid;
         if (await isOurShellProcess(pid, session.cmd)) {
           log('info', `[recovery] reconciled tombstone ${session.id}: pid ${pid} was still alive`);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -799,6 +799,49 @@ async function processLiveness(pid: number): Promise<ProcessLiveness> {
   }
 }
 
+/**
+ * Kill a shell process and everything under it (#646).
+ *
+ * Used whenever we discover a shell that wmux has already stopped accounting
+ * for — a phantom PTY exit, or a persisted tombstone whose pid still answers.
+ * The whole TREE has to go, not just the shell: the thing actually burning RAM
+ * and API quota is the agent running inside it, and killing the shell alone
+ * would reparent that child and leave the orphan behind.
+ *
+ * Best-effort by construction. Failure is logged and swallowed: the caller is
+ * on its way to marking the session dead either way, and throwing here would
+ * cost the other sessions (the daemon's uncaughtException handler treats three
+ * repeats as fatal).
+ */
+async function reapProcessTree(pid: number, reason: string): Promise<void> {
+  try {
+    if (process.platform === 'win32') {
+      const { execFile } = require('child_process');
+      const { promisify } = require('util');
+      const execFileAsync = promisify(execFile);
+      const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+      const taskkill = path.join(systemRoot, 'System32', 'taskkill.exe');
+      await execFileAsync(taskkill, ['/pid', String(pid), '/T', '/F'], {
+        encoding: 'utf-8',
+        timeout: 5000,
+        windowsHide: true,
+      });
+    } else {
+      // The PTY child leads its own process group, so the negative pid takes
+      // its descendants with it. If it somehow isn't a group leader (ESRCH /
+      // EPERM), fall back to the process alone rather than giving up.
+      try {
+        process.kill(-pid, 'SIGKILL');
+      } catch {
+        process.kill(pid, 'SIGKILL');
+      }
+    }
+    log('info', `[reap] killed process tree for pid ${pid} (${reason})`);
+  } catch (err) {
+    log('warn', `[reap] failed to kill process tree for pid ${pid} (${reason}):`, err);
+  }
+}
+
 /** Check if a PID belongs to the shell process we originally spawned.
  *  Prevents killing unrelated processes after PID recycling (e.g. reboot). */
 async function isOurShellProcess(pid: number, expectedCmd: string): Promise<boolean> {
@@ -3464,6 +3507,42 @@ function wireEvents(
       sessionManager.emit('session:stateChanged', { id: payload.id, state: 'dead' });
     }, SHUTDOWN_KILL_RECLASSIFY_MS);
     interruptedTimers.set(payload.id, timer);
+  });
+
+  // session:phantomExit → reap-and-die (#646).
+  //
+  // node-pty told us the PTY exited, but the shell pid is still alive: this is
+  // the ConPTY conout-socket-close path, not a death. The transport is gone for
+  // good (node-pty already destroyed its outSocket), so the shell is
+  // unreachable — but it and its agent child keep running, which is how users
+  // ended up with powershell.exe processes outliving their daemon by days.
+  //
+  // Policy: kill the tree ourselves, then run the ordinary death flow with a
+  // `phantom-exit` reason so the log says what happened. Deliberately NOT the
+  // session:interrupted (suspend) path: that respawns the session on recovery
+  // and would leave the still-live shell behind — exactly the orphan this fix
+  // exists to prevent. Reattaching to the live ConPTY instead of killing it is
+  // a separate piece of work (likely an upstream node-pty fix).
+  sessionManager.on('session:phantomExit', (payload: { id: string; pid?: number; exitCode: number | null; signal?: number; cmd?: string; lastActivityMsAgo?: number }) => {
+    log(
+      'info',
+      `[lifecycle] session:phantomExit id=${payload.id} pid=${payload.pid ?? '?'} exitCode=${payload.exitCode ?? 'null'} signal=${payload.signal ?? 'none'} cmd=${payload.cmd ?? '?'} idleMsBeforeExit=${payload.lastActivityMsAgo ?? '?'} — PTY reported an exit with no code and no signal, but the pid is STILL ALIVE (node-pty conout-socket-close, see #646). Reaping the orphaned process tree, then marking dead.`,
+    );
+    const finish = () => {
+      const managed = sessionManager.getSession(payload.id);
+      // Destroyed meanwhile (user closed the pane) → the destroy path already
+      // did the teardown; announcing a death now would be a ghost event.
+      if (!managed) return;
+      managed.meta.state = 'dead';
+      managed.meta.exitCode = payload.exitCode;
+      sessionManager.emit('session:died', { ...payload, reason: 'phantom-exit' });
+      sessionManager.emit('session:stateChanged', { id: payload.id, state: 'dead' });
+    };
+    if (payload.pid === undefined) {
+      finish();
+      return;
+    }
+    void reapProcessTree(payload.pid, `phantom exit of session ${payload.id}`).finally(finish);
   });
 
   // A pane the user closes while a reclassification is pending must not get a

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -42,6 +42,7 @@ import { AgentProcessTracker } from './AgentProcessTracker';
 import { Watchdog } from './Watchdog';
 import { selectRecoverableSessions } from './recoverySelector';
 import { isShutdownKillExit, SHUTDOWN_KILL_RECLASSIFY_MS } from './shutdownKill';
+import { isPidAlive, shouldReconcileTombstone } from './phantomExit';
 import { createSnapshotRunner } from './snapshotRunner';
 import { RingBuffer } from './RingBuffer';
 import { GitContextWatcher } from '../main/pty/gitContextWatch';
@@ -1067,7 +1068,25 @@ async function recoverSessions(
   }
 
   for (const session of state.sessions) {
-    if (session.state === 'dead') continue;
+    if (session.state === 'dead') {
+      // #646: a tombstone is supposed to mean "the process is gone". Before
+      // this fix a phantom PTY exit could write one while the shell kept
+      // running, and because recovery skips dead records the orphan was
+      // invisible to every census — reporters found shells outliving their
+      // daemon by 11–12 days. Reconcile here: same boot (so the pid cannot
+      // have been recycled), pid still alive, and it really is our shell →
+      // it is an orphan of that bug, so reap it.
+      if (shouldReconcileTombstone(session, { rebooted, alive: isPidAlive })) {
+        const pid = session.pid;
+        if (await isOurShellProcess(pid, session.cmd)) {
+          log('info', `[recovery] reconciled tombstone ${session.id}: pid ${pid} was still alive`);
+          await reapProcessTree(pid, `tombstone reconciliation of session ${session.id}`);
+        } else {
+          log('warn', `[recovery] tombstone ${session.id} holds live pid ${pid}, but it is not our shell (${session.cmd}) — skipping kill`);
+        }
+      }
+      continue;
+    }
     // Cap-skipped: leave session untouched in state.sessions. It will be
     // re-evaluated on the next launch.
     if (!recoverableIds.has(session.id)) continue;

--- a/src/daemon/phantomExit.ts
+++ b/src/daemon/phantomExit.ts
@@ -91,6 +91,88 @@ export function isPhantomExit(
 }
 
 /**
+ * The OS-reported creation time of a pid, or null if it cannot be read.
+ *
+ * A pid on its own is not an identity — Windows recycles pids aggressively and
+ * a tombstone can outlive its shell by `deadTtlHours`, so "pid 20516 is alive"
+ * says nothing about WHICH process is alive. (pid, startTime) is effectively
+ * unique: the OS cannot hand the same pid to a second process at the same
+ * instant. Recording it at spawn and comparing it before a kill is what stops
+ * reconciliation from taskkill-ing an innocent shell that inherited the pid.
+ *
+ * Null on ANY failure — probe error, timeout, unparseable output, process
+ * already gone. Callers must treat null as "identity unknown", never as a
+ * match, since the whole point is to withhold the kill when unsure.
+ */
+export async function getProcessStartTime(pid: number): Promise<string | null> {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  try {
+    const { execFile } = await import('node:child_process');
+    const { promisify } = await import('node:util');
+    const path = await import('node:path');
+    const execFileAsync = promisify(execFile);
+    if (process.platform === 'win32') {
+      const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+      const wmic = path.join(systemRoot, 'System32', 'wbem', 'wmic.exe');
+      const { stdout } = await execFileAsync(
+        wmic,
+        ['process', 'where', `ProcessId=${pid}`, 'get', 'CreationDate', '/value'],
+        { encoding: 'utf-8', timeout: 3000, windowsHide: true },
+      );
+      // "CreationDate=20260727142800.123456+540"
+      const match = String(stdout).match(/CreationDate=(\S+)/i);
+      const value = match?.[1]?.trim();
+      return value ? value : null;
+    }
+    const { stdout } = await execFileAsync('ps', ['-o', 'lstart=', '-p', String(pid)], {
+      encoding: 'utf-8',
+      timeout: 3000,
+    });
+    const value = String(stdout).trim();
+    return value ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * How confidently can we say the process behind `pid` is the one we spawned?
+ *
+ *  - `start-time`   — the recorded creation time matches what the OS reports
+ *                     now. (pid, startTime) is unique, so this is proof.
+ *  - `heuristic`    — no creation time was recorded (a tombstone written by a
+ *                     build predating it), but the executable still looks like
+ *                     our shell. Weaker: any `powershell.exe` passes. Accepted
+ *                     only so pre-existing orphans can still be cleaned up.
+ *  - `unconfirmed`  — a creation time was recorded and does NOT match (the pid
+ *                     belongs to something else now), or nothing corroborates
+ *                     the pid at all. Never kill on this.
+ *
+ * A recorded start time is authoritative when present: if it disagrees, the
+ * executable-name heuristic must not be allowed to override it — that is
+ * exactly the recycled-pid case (`powershell.exe` reborn under the same pid).
+ */
+export type ReapIdentity = 'start-time' | 'heuristic' | 'unconfirmed';
+
+export function classifyReapIdentity(opts: {
+  storedStartTime?: string | null;
+  currentStartTime: string | null;
+  looksLikeOurShell: boolean;
+}): ReapIdentity {
+  if (opts.storedStartTime) {
+    return opts.currentStartTime !== null && opts.currentStartTime === opts.storedStartTime
+      ? 'start-time'
+      : 'unconfirmed';
+  }
+  return opts.looksLikeOurShell ? 'heuristic' : 'unconfirmed';
+}
+
+/** Is this identity level strong enough to authorize killing the tree? */
+export function mayReap(identity: ReapIdentity): boolean {
+  return identity !== 'unconfirmed';
+}
+
+/**
  * Can we PROVE the state file was written during the boot we are running in?
  *
  * Only a stored bootId that exists and matches counts. A missing stored bootId

--- a/src/daemon/phantomExit.ts
+++ b/src/daemon/phantomExit.ts
@@ -91,6 +91,22 @@ export function isPhantomExit(
 }
 
 /**
+ * Can we PROVE the state file was written during the boot we are running in?
+ *
+ * Only a stored bootId that exists and matches counts. A missing stored bootId
+ * (pre-bootId build, or a lost/rewritten state file) proves nothing and must
+ * never be read as "no reboot happened" — that inversion is what would let
+ * tombstone reconciliation kill a recycled pid across a real reboot.
+ */
+export function isSameBootProven(
+  storedBootId: string | null | undefined,
+  currentBootId: string | null | undefined,
+): boolean {
+  if (storedBootId == null || currentBootId == null) return false;
+  return storedBootId === currentBootId;
+}
+
+/**
  * Boot-time counterpart of the guard: should this persisted tombstone be
  * reconciled — i.e. does a `dead` record still have a live process behind it?
  *
@@ -98,21 +114,24 @@ export function isPhantomExit(
  * `selectRecoverableSessions`: the eligibility policy is the part worth
  * unit-testing, and it must not require a daemon boot to exercise.
  *
- * The `rebooted` gate is the load-bearing safety check. After a reboot the
- * OS recycles pids freely, so a persisted pid that answers `kill(pid, 0)`
- * says nothing about OUR shell — it is probably some unrelated process, and
- * killing its tree would be catastrophic. Only when the bootId is unchanged
- * (same boot, no pid reuse possible for a pid we recorded this boot) is a
- * live pid behind a `dead` record provably our own orphan.
+ * `sameBootProven` is the load-bearing safety check, and it is deliberately
+ * phrased as POSITIVE proof rather than "not rebooted". After a reboot the OS
+ * recycles pids freely, so a persisted pid that answers `kill(pid, 0)` says
+ * nothing about OUR shell — it is probably some unrelated process, and killing
+ * its tree would be catastrophic. Absence of evidence is not proof: a state
+ * file written before bootIds were recorded has no bootId at all, which the
+ * old "rebooted" phrasing read as "no reboot happened" and would have
+ * authorized a kill across an actual reboot. The caller must pass true only
+ * when a stored bootId EXISTS and equals the current one.
  *
  * Old state files predating pid persistence, or records written before the
  * pid was known, simply have no pid — those are skipped, not guessed at.
  */
 export function shouldReconcileTombstone(
   session: { state: string; pid?: number },
-  opts: { rebooted: boolean; alive: (pid: number) => boolean },
+  opts: { sameBootProven: boolean; alive: (pid: number) => boolean },
 ): boolean {
-  if (opts.rebooted) return false;
+  if (!opts.sameBootProven) return false;
   if (session.state !== 'dead') return false;
   const pid = session.pid;
   if (pid === undefined || pid === null) return false;

--- a/src/daemon/phantomExit.ts
+++ b/src/daemon/phantomExit.ts
@@ -1,0 +1,114 @@
+/**
+ * Phantom-exit detection for PTY exits (issue #646).
+ *
+ * RCA 2026-07-27 (Windows, ConPTY): node-pty's Windows backend emits `exit`
+ * from TWO distinct paths. One is the real process exit (the shell's own
+ * code). The other fires when the conout socket closes — the agent's
+ * `_$onProcessExit` runs with `_agent.exitCode === undefined`, which reaches
+ * us as an exitCode of `null` with no signal, while `powershell.exe` (and
+ * whatever agent it is hosting) is STILL RUNNING.
+ *
+ * The classifier in shutdownKill.ts only treats 0x40010004 / our own
+ * `shuttingDown` flag as involuntary, so a null exitCode fell through to the
+ * VOLUNTARY path and the session was tombstoned `dead`. Three damages
+ * followed, all from the same false tombstone:
+ *  1. the live shell + agent were orphaned — RAM and API quota kept burning,
+ *     and nothing ever reaped them (a reporter found shells outliving their
+ *     daemon by 11–12 days);
+ *  2. sessions.json persisted a `dead` record holding a LIVE pid, which
+ *     survived daemon restarts and hid the orphan from every census;
+ *  3. the renderer, seeing its binding die, self-created a replacement pane
+ *     in the wrong cwd.
+ *
+ * The guard is cheap and one-sided: before believing a null exitCode, ask the
+ * OS whether the pid is still there. If it is, this was not a death — it was
+ * the socket closing. The daemon then REAPS the orphaned tree itself and runs
+ * the normal death flow with a `phantom-exit` reason, so the session ends up
+ * `dead` with no live process behind it. Deliberately NOT reclassified as
+ * `suspended`: that path respawns the session and would abandon the very
+ * shell we are trying not to orphan.
+ *
+ * Stream reattachment to the still-live ConPTY is out of scope — node-pty's
+ * Node-side `_outSocket` is already destroyed by the time we see the exit, so
+ * the realistic win here is prevention plus reaping, not resurrection.
+ */
+
+/**
+ * Is this pid still present? `signal 0` performs the permission/existence
+ * check without delivering anything.
+ *
+ * EPERM means the process EXISTS but belongs to another user — alive for our
+ * purposes (the point is "is this pid still occupied", and treating EPERM as
+ * dead would let a genuine orphan through). ESRCH is the only real "gone".
+ */
+export function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    return code === 'EPERM';
+  }
+}
+
+/**
+ * Pure decision: is this PTY `exit` a phantom — i.e. the transport died but
+ * the process did not?
+ *
+ * True only when ALL of:
+ *  - no exit code (null/undefined). A real exit always records one.
+ *  - no signal. A killed process reports the signal that killed it, and that
+ *    IS a death; only the code-less AND signal-less shape is anomalous.
+ *  - a known pid, still alive per `alive`.
+ *
+ * Platform-agnostic on purpose. The observed incidents are all Windows
+ * ConPTY, but on posix a genuine exit likewise always carries either a code
+ * or a signal, so code-less + signal-less + still-running is just as much a
+ * lie there — and gating on win32 would only hide the same bug elsewhere.
+ *
+ * `alive` is injected so the decision is testable without real processes;
+ * production passes `isPidAlive`.
+ */
+export function isPhantomExit(
+  exitCode: number | null | undefined,
+  signal: number | undefined,
+  pid: number | undefined,
+  alive: (pid: number) => boolean,
+): boolean {
+  if (exitCode !== null && exitCode !== undefined) return false;
+  if (signal !== undefined && signal !== null) return false;
+  if (pid === undefined || pid === null) return false;
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  return alive(pid);
+}
+
+/**
+ * Boot-time counterpart of the guard: should this persisted tombstone be
+ * reconciled — i.e. does a `dead` record still have a live process behind it?
+ *
+ * Pulled out of `recoverSessions` for the same reason as
+ * `selectRecoverableSessions`: the eligibility policy is the part worth
+ * unit-testing, and it must not require a daemon boot to exercise.
+ *
+ * The `rebooted` gate is the load-bearing safety check. After a reboot the
+ * OS recycles pids freely, so a persisted pid that answers `kill(pid, 0)`
+ * says nothing about OUR shell — it is probably some unrelated process, and
+ * killing its tree would be catastrophic. Only when the bootId is unchanged
+ * (same boot, no pid reuse possible for a pid we recorded this boot) is a
+ * live pid behind a `dead` record provably our own orphan.
+ *
+ * Old state files predating pid persistence, or records written before the
+ * pid was known, simply have no pid — those are skipped, not guessed at.
+ */
+export function shouldReconcileTombstone(
+  session: { state: string; pid?: number },
+  opts: { rebooted: boolean; alive: (pid: number) => boolean },
+): boolean {
+  if (opts.rebooted) return false;
+  if (session.state !== 'dead') return false;
+  const pid = session.pid;
+  if (pid === undefined || pid === null) return false;
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  return opts.alive(pid);
+}

--- a/src/daemon/phantomExit.ts
+++ b/src/daemon/phantomExit.ts
@@ -40,6 +40,13 @@
  * EPERM means the process EXISTS but belongs to another user — alive for our
  * purposes (the point is "is this pid still occupied", and treating EPERM as
  * dead would let a genuine orphan through). ESRCH is the only real "gone".
+ *
+ * Known Windows caveat: `kill(pid, 0)` can succeed for a pid whose process has
+ * already exited, so this probe leans towards "alive". Both callers are built
+ * for that. At exit time a false positive costs nothing — the session still
+ * ends up dead, just via the reap path, and the reap of an absent pid is a
+ * no-op. At boot the reconciliation pass additionally confirms the pid really
+ * is our shell before killing anything.
  */
 export function isPidAlive(pid: number): boolean {
   if (!Number.isInteger(pid) || pid <= 0) return false;

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -26,6 +26,22 @@ export interface DaemonSession {
   createdAt: string;        // ISO 8601
   lastActivity: string;     // ISO 8601
   pid: number;              // child process PID
+  /**
+   * OS-reported creation time of `pid`, as the platform prints it (Windows
+   * WMIC `CreationDate`, posix `ps -o lstart=`). Opaque — only ever compared
+   * for equality against a fresh reading of the same pid.
+   *
+   * A pid alone is not an identity: Windows recycles pids aggressively and a
+   * tombstone can outlive its shell by `deadTtlHours`, so a later "pid is
+   * alive" check can be answering about a completely different process.
+   * (pid, pidStartTime) is unique, and #646's reaping paths kill a process
+   * tree — they must not fire on a recycled pid.
+   *
+   * Optional: filled in asynchronously just after spawn (so it is absent for
+   * the first moments of a session's life), and absent entirely from records
+   * written before this field existed. Consumers must degrade, not guess.
+   */
+  pidStartTime?: string;
   cmd: string;              // executed command
   /**
    * LIVE working directory. Updated at runtime from the OSC 7 sequences the


### PR DESCRIPTION
## The bug

On Windows, node-pty emits `exit` from two different places. One is the real process exit. The other fires when the ConPTY conout socket closes: the agent's exit handler runs with `_agent.exitCode === undefined`, which reaches us as a `null` exit code with no signal — while `powershell.exe` and whatever agent it is hosting are still running.

`isShutdownKillExit` only treats `0x40010004` (or our own `shuttingDown` flag) as involuntary, so `null` fell through to the **voluntary** path and the session was tombstoned `dead`. Three damages followed from that single false tombstone:

1. the live shell + agent were orphaned — RAM and API quota kept burning, and because recovery skips `dead` records nothing ever reaped them (the reporter found shells outliving their daemon by 11–12 days);
2. `sessions.json` persisted a `dead` record holding a **live** pid, which survived daemon restarts and hid the orphan from every census;
3. the renderer, seeing its binding die, self-created a replacement pane in the wrong cwd.

`DaemonPTYBridge.ts` documented a null exit code as the involuntary-teardown signature, directly contradicting the classifier — and the classifier is what runs.

## The guard

New `src/daemon/phantomExit.ts` holds the pure predicates, in the style of `shutdownKill.ts`:

- `isPidAlive(pid)` — `process.kill(pid, 0)`, with `EPERM` counting as alive.
- `isPhantomExit(exitCode, signal, pid, alive)` — true only for the code-less, signal-less, known-pid, still-alive shape. Platform-agnostic on purpose: on posix a genuine exit likewise always carries a code or a signal, so that shape is anomalous there too, and gating on win32 would only hide the same bug elsewhere.
- `shouldReconcileTombstone(session, { rebooted, alive })` — the boot-time eligibility policy (below).

`DaemonSessionManager`'s exit handler consults the guard *before* the dead/suspended classification. On a phantom it logs the raw node-pty payload verbatim (the native-layer investigation asked for this), cleans up the bridge, and emits a new `session:phantomExit` event carrying `{ id, pid, exitCode, signal, cmd, lastActivityMsAgo }`. It sets no state and announces no death — the manager stays mechanism-only, matching how the `session:interrupted` policy lives in `index.ts`.

## Reap and die

`index.ts` subscribes to `session:phantomExit` next to `session:interrupted`, logs a `[lifecycle]` line explaining that the pid is alive after a code-less exit, kills the process **tree** (`taskkill /pid <pid> /T /F` on Windows, `SIGKILL` to the process group with a single-process fallback elsewhere), and then runs the ordinary death path with `reason: 'phantom-exit'` so the log distinguishes it from a real exit. Observable outcome: session `dead`, pid actually gone, log says phantom.

Two roads not taken:

- **Not `suspended`.** That path respawns the session on recovery, which would abandon the very shell we are trying not to orphan.
- **Not a new session state.** A pane whose transport is gone but whose process lives is not a state users can act on — node-pty has already destroyed its `_outSocket`, so nothing can reattach. Parking the session there would keep a recorded orphan instead of an unrecorded one.

## Reconciliation

`recoverSessions` now inspects `dead` records instead of skipping them outright. When the boot id is unchanged (so the recorded pid cannot have been recycled), the pid is still alive, and `isOurShellProcess` confirms it really is the shell we spawned, the tree is reaped and logged as `[recovery] reconciled tombstone <id>: pid <pid> was still alive`. Anything uncertain — rebooted, no pid recorded, or a pid that is not our shell — is left alone. Persisted sessions already carried `pid` (`DaemonSession.pid` is required and `buildState` persists the meta verbatim), so no state-shape change was needed; the predicate treats a missing pid as ineligible for old files anyway.

## Out of scope (follow-ups)

- **Stream reattachment** to the still-live ConPTY. Realistically an upstream node-pty fix.
- **The renderer's wrong-cwd self-create.** The guard removes the trigger for it in this path, but the self-create behaviour itself is untouched.

## Tests

`src/daemon/__tests__/phantomExit.test.ts`, 14 cases across `isPhantomExit`, `isPidAlive`, and `shouldReconcileTombstone` — liveness is injected, so no real processes are involved. Full suite: 8693 passed, `tsc --noEmit` clean.

Fixes #646


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal sessions being incorrectly marked as exited when the underlying output stream closes without an exit code or signal.
  * Improved session recovery by cleaning up orphaned terminals using safer, start-time–verified process-tree shutdown and enhanced tombstone reconciliation.
  * Adjusted dead-session retention so expired dead records are reconsidered if their process is still alive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->