### PR TITLE
docs: position wmux for AI agents, not AI coding agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **wmux describes itself as the workspace multiplexer for AI agents, not AI coding agents.** The panes, channels, worktrees, and browser wmux multiplexes were never specific to agents that write code, and the narrower line kept implying they were. README, the package description, and the Chocolatey summary now say "AI agents"; nothing about what wmux detects or how it behaves changes.
+
 ### Added
 
 - **A phone that is too old to talk to your daemon can now say so.** The phone API had no version on it, so once a mobile build ships it is pinned to whatever HTTP surface the daemon happens to serve — and a mismatch would have surfaced as routes failing one by one with no explanation. `GET /api/config`, the call a client already makes at connect, now reports the protocol the daemon speaks, the oldest one it still accepts, and the release it was spawned from. A client below the floor can show "update the app" instead of a broken screen. Nothing that already works changes: a daemon predating this simply has no version fields, which reads as the pre-handshake protocol, and a phone that ignores them behaves exactly as it does today.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # wmux
 
-### The workspace multiplexer for AI coding agents.
+### The workspace multiplexer for AI agents.
 
 Run **fleets of Claude Code, Codex & Gemini in parallel** — each agent in its own pane, or fan one prompt out into **N isolated git worktrees** you review **hunk by hunk**. Native on **Windows & macOS**, with approval gates, agent-to-agent channels, and a **real browser your agents drive**. Walk away — after a crash or **full OS reboot**, they come back mid-conversation.
 
-<img width="924" alt="wmux — the workspace multiplexer for AI coding agents, on Windows and macOS" src="docs/banner.png" />
+<img width="924" alt="wmux — the workspace multiplexer for AI agents, on Windows and macOS" src="docs/banner.png" />
 
 [![Website](https://img.shields.io/badge/wmux.app-E8A33D?label=&labelColor=151517)](https://www.wmux.app)
 [![Windows 10/11](https://img.shields.io/badge/Windows-10%2F11-0078D6?logo=windows&logoColor=white)](https://github.com/openwong2kim/wmux/releases/latest)

--- a/chocolatey/wmux.nuspec
+++ b/chocolatey/wmux.nuspec
@@ -14,7 +14,7 @@
     <projectSourceUrl>https://github.com/openwong2kim/wmux</projectSourceUrl>
     <bugTrackerUrl>https://github.com/openwong2kim/wmux/issues</bugTrackerUrl>
     <tags>terminal multiplexer ai-agent mcp windows electron developer-tools cli</tags>
-    <summary>Windows terminal multiplexer built for AI coding agents</summary>
+    <summary>Windows terminal multiplexer built for AI agents</summary>
     <description><![CDATA[
 ## wmux — Windows Terminal Multiplexer for AI Agents
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wmux",
   "productName": "wmux",
   "version": "3.37.1",
-  "description": "Workspace multiplexer for AI coding agents — run fleets of Claude Code, Codex & Gemini in parallel on Windows & macOS, with MCP browser automation built in",
+  "description": "Workspace multiplexer for AI agents — run fleets of Claude Code, Codex & Gemini in parallel on Windows & macOS, with MCP browser automation built in",
   "private": true,
   "main": ".vite/build/index.js",
   "bin": {


### PR DESCRIPTION
## Why

The tagline claimed a narrower product than wmux is. Panes, channels, git worktrees, and the browser wmux drives were never specific to agents that write code, and "for AI coding agents" kept implying they were.

## What changed

- `README.md` — headline and banner alt text
- `package.json` — package description
- `chocolatey/wmux.nuspec` — package summary (the nuspec body already said "for AI Agents")
- `CHANGELOG.md` — entry under Unreleased

Left alone on purpose, because they are statements of fact about coding agents rather than product positioning: the agent-detection note in the README, the AI provider ToS disclaimer, and the SEO keyword list.

No code paths touched.