### PR TITLE
test,ci: make the git context watcher tests deterministic and retry apt

### DIFF
--- a/.github/workflows/ci-cross-platform-baseline.yml
+++ b/.github/workflows/ci-cross-platform-baseline.yml
@@ -84,8 +84,10 @@ jobs:
               if sudo apt-get -o Acquire::Retries=3 "$@"; then
                 return 0
               fi
-              echo "apt-get $* failed (attempt ${attempt}/3); retrying after $((attempt * 15))s"
-              sleep $((attempt * 15))
+              if [ "$attempt" -lt 3 ]; then
+                echo "apt-get $* failed (attempt ${attempt}/3); retrying after $((attempt * 15))s"
+                sleep $((attempt * 15))
+              fi
             done
             echo "apt-get $* failed after 3 attempts" >&2
             return 1

--- a/.github/workflows/ci-cross-platform-baseline.yml
+++ b/.github/workflows/ci-cross-platform-baseline.yml
@@ -69,9 +69,30 @@ jobs:
           # azure-cli.list, …), so a filename glob misses some. Matching the
           # host also survives a runner bump to deb822 (24.04 keeps the Ubuntu
           # archives in sources.list.d/ubuntu.sources, which must NOT be dropped).
+          #
+          # Dropping the third-party sources removes the deterministic 403, but
+          # the Ubuntu/Azure mirrors themselves still fail transiently (Hash Sum
+          # mismatch, connection reset, 5xx from a single mirror behind the load
+          # balancer). Acquire::Retries only retries the individual fetch inside
+          # one apt run; a mirror serving a stale index fails the whole run. Wrap
+          # both apt operations in a bounded retry with backoff so a slow/soggy
+          # mirror costs seconds instead of a red X on an unrelated PR.
+          set -euo pipefail
+          apt_retry() {
+            local attempt
+            for attempt in 1 2 3; do
+              if sudo apt-get -o Acquire::Retries=3 "$@"; then
+                return 0
+              fi
+              echo "apt-get $* failed (attempt ${attempt}/3); retrying after $((attempt * 15))s"
+              sleep $((attempt * 15))
+            done
+            echo "apt-get $* failed after 3 attempts" >&2
+            return 1
+          }
           sudo bash -c 'grep -rlE "packages\.microsoft\.com|dl\.google\.com" /etc/apt/sources.list.d/ 2>/dev/null | xargs -r rm -f'
-          sudo apt-get -o Acquire::Retries=3 update
-          sudo apt-get install -y build-essential libxss1
+          apt_retry update
+          apt_retry install -y build-essential libxss1
 
       # macos-14 (Apple Silicon) ships with Xcode Command Line Tools preinstalled.
       # We only verify presence — do NOT attempt to install, that would burn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,9 +423,26 @@ jobs:
       # matching the host keeps a future deb822 runner's ubuntu.sources intact).
       - name: Install Linux build dependencies
         run: |
+          # A transient mirror error (Hash Sum mismatch, connection reset, a
+          # single 5xx mirror) is not a reason to ship a release without its
+          # .deb/.rpm/.AppImage. Acquire::Retries only retries a fetch inside one
+          # apt run, so wrap both operations in a bounded retry with backoff.
+          set -euo pipefail
+          apt_retry() {
+            local attempt
+            for attempt in 1 2 3; do
+              if sudo apt-get -o Acquire::Retries=3 "$@"; then
+                return 0
+              fi
+              echo "apt-get $* failed (attempt ${attempt}/3); retrying after $((attempt * 15))s"
+              sleep $((attempt * 15))
+            done
+            echo "apt-get $* failed after 3 attempts" >&2
+            return 1
+          }
           sudo bash -c 'grep -rlE "packages\.microsoft\.com|dl\.google\.com" /etc/apt/sources.list.d/ 2>/dev/null | xargs -r rm -f'
-          sudo apt-get -o Acquire::Retries=3 update
-          sudo apt-get install -y build-essential libxss1 rpm fakeroot
+          apt_retry update
+          apt_retry install -y build-essential libxss1 rpm fakeroot
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -434,8 +434,10 @@ jobs:
               if sudo apt-get -o Acquire::Retries=3 "$@"; then
                 return 0
               fi
-              echo "apt-get $* failed (attempt ${attempt}/3); retrying after $((attempt * 15))s"
-              sleep $((attempt * 15))
+              if [ "$attempt" -lt 3 ]; then
+                echo "apt-get $* failed (attempt ${attempt}/3); retrying after $((attempt * 15))s"
+                sleep $((attempt * 15))
+              fi
             done
             echo "apt-get $* failed after 3 attempts" >&2
             return 1

--- a/src/daemon/__tests__/DaemonPipeServer.test.ts
+++ b/src/daemon/__tests__/DaemonPipeServer.test.ts
@@ -381,33 +381,31 @@ describe('DaemonPipeServer', () => {
     const sockets: net.Socket[] = [];
     const closeCounts = { closed: 0, total: 40 };
 
-    await new Promise<void>((resolve) => {
-      let pending = closeCounts.total;
-      for (let i = 0; i < closeCounts.total; i++) {
-        const s = net.createConnection(pipeName);
-        sockets.push(s);
-        const markDone = () => {
-          pending--;
-          if (pending === 0) resolve();
-        };
-        s.on('close', () => {
-          closeCounts.closed++;
-          markDone();
-        });
-        s.on('error', () => {
-          markDone();
-        });
-      }
-      // Safety — resolve after 2s even if sockets linger
-      setTimeout(resolve, 2000);
-    });
+    let settled = 0;
+    for (let i = 0; i < closeCounts.total; i++) {
+      const s = net.createConnection(pipeName);
+      sockets.push(s);
+      s.on('close', () => { closeCounts.closed++; settled++; });
+      s.on('error', () => { settled++; });
+    }
+
+    // Wait for the outcome, not for a fixed span. The previous 2s safety timer
+    // was the assertion's real deadline: on a loaded runner fewer than half the
+    // excess sockets had been refused yet, and the test failed on runner speed
+    // rather than on the cap being broken.
+    const enoughRefused = () => closeCounts.closed >= closeCounts.total / 2;
+    await waitFor(
+      () => settled === closeCounts.total || enoughRefused(),
+      10_000,
+      'the per-second cap to refuse the excess connections',
+    );
 
     for (const s of sockets) s.destroy();
 
     // At least a handful of the excess connections must have been refused.
     // (We don't assert the exact number because accept() timing varies.)
     expect(closeCounts.closed).toBeGreaterThanOrEqual(closeCounts.total / 2);
-  });
+  }, 15_000);
 });
 
 // ============================================================

--- a/src/daemon/__tests__/DaemonPipeServer.test.ts
+++ b/src/daemon/__tests__/DaemonPipeServer.test.ts
@@ -381,12 +381,21 @@ describe('DaemonPipeServer', () => {
     const sockets: net.Socket[] = [];
     const closeCounts = { closed: 0, total: 40 };
 
+    // A refused socket emits `error` AND then `close`, so counting both events
+    // would settle one socket twice and let the wait below finish while half
+    // the sockets are still in flight. Terminal state is tracked per socket.
+    const terminal = new Set<net.Socket>();
     let settled = 0;
     for (let i = 0; i < closeCounts.total; i++) {
       const s = net.createConnection(pipeName);
       sockets.push(s);
-      s.on('close', () => { closeCounts.closed++; settled++; });
-      s.on('error', () => { settled++; });
+      const markSettled = () => {
+        if (terminal.has(s)) return;
+        terminal.add(s);
+        settled++;
+      };
+      s.on('close', () => { closeCounts.closed++; markSettled(); });
+      s.on('error', markSettled);
     }
 
     // Wait for the outcome, not for a fixed span. The previous 2s safety timer

--- a/src/main/ipc/handlers/__tests__/deck.handler.loop.test.ts
+++ b/src/main/ipc/handlers/__tests__/deck.handler.loop.test.ts
@@ -918,8 +918,10 @@ describe('global concurrent-turn gate — the fleet-wide cap on autonomous turns
       type: 'agent.lifecycle', workspaceId: 'ws-3', ptyId: 'p2',
       kind: 'agent.awaiting_input', source: 'hook', agent: 'claude', decision: 'emit',
     });
-    await new Promise((r) => setTimeout(r, 1700));
-    expect(started('ws-3')).toBe(1);
+    // Poll rather than sleep a fixed 1700ms: the coalescer's 1500ms debounce is
+    // only a lower bound, and the turn's dispatch after it is not instantaneous
+    // on a loaded runner.
+    await vi.waitFor(() => expect(started('ws-3')).toBe(1), { timeout: 5_000, interval: 25 });
 
     releasers.forEach((r) => r());
     await new Promise((r) => setTimeout(r, 15));

--- a/src/main/pty/__tests__/gitContextWatch.runtime.test.ts
+++ b/src/main/pty/__tests__/gitContextWatch.runtime.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { GitContextWatcher } from '../gitContextWatch';
+
+/**
+ * Real-filesystem end-to-end proof that the production default actually wires
+ * `fs.watch` and re-emits on a real HEAD rewrite. The deterministic logic
+ * (filename filtering, debounce coalescing, re-resolve, teardown) is covered by
+ * the fake-watcher unit tests in gitContextWatch.test.ts; this one exists only
+ * so a regression in the default wiring cannot hide behind the test seam.
+ *
+ * Lives under vitest.runtime.config.ts (serial, no file parallelism) because it
+ * waits on real FSEvents/inotify delivery, whose latency is load-dependent —
+ * hence the generous per-test timeout.
+ */
+
+const tmpDirs: string[] = [];
+const watchers: GitContextWatcher[] = [];
+
+afterEach(() => {
+  for (const w of watchers.splice(0)) w.dispose();
+  for (const dir of tmpDirs.splice(0)) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* win32 lock */ }
+  }
+});
+
+function tmp(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-gitwatch-rt-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+describe('GitContextWatcher (real fs.watch)', () => {
+  it('re-emits on a real HEAD rewrite with the default fs.watch wiring', async () => {
+    const root = tmp();
+    fs.mkdirSync(path.join(root, '.git'), { recursive: true });
+    fs.writeFileSync(path.join(root, '.git', 'HEAD'), 'ref: refs/heads/main\n');
+
+    const watcher = new GitContextWatcher();
+    watchers.push(watcher);
+
+    type GitEvent = { sessionId: string; branch: string | null; isWorktree: boolean };
+    const events: GitEvent[] = [];
+    const secondEvent = new Promise<void>((resolve) => {
+      watcher.on('git', (e: GitEvent) => {
+        events.push(e);
+        if (events.length === 2) resolve();
+      });
+    });
+
+    watcher.update('s1', root);
+    expect(events).toEqual([{ sessionId: 's1', branch: 'main', isWorktree: false }]);
+
+    fs.writeFileSync(path.join(root, '.git', 'HEAD'), 'ref: refs/heads/feature-y\n');
+    await secondEvent;
+    expect(events[1].branch).toBe('feature-y');
+  }, 15_000);
+});

--- a/src/main/pty/__tests__/gitContextWatch.test.ts
+++ b/src/main/pty/__tests__/gitContextWatch.test.ts
@@ -1,8 +1,15 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { GitContextWatcher, parseHead, resolveRepo, readGitContext } from '../gitContextWatch';
+import {
+  GitContextWatcher,
+  parseHead,
+  resolveRepo,
+  readGitContext,
+  type GitWatchFactory,
+  type GitWatchListener,
+} from '../gitContextWatch';
 
 function mkTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-gitwatch-'));
@@ -22,12 +29,6 @@ function tmp(): string {
   return dir;
 }
 
-function makeWatcher(): GitContextWatcher {
-  const w = new GitContextWatcher();
-  watchers.push(w);
-  return w;
-}
-
 afterEach(() => {
   for (const w of watchers.splice(0)) w.dispose();
   for (const dir of tmpDirs.splice(0)) {
@@ -35,14 +36,29 @@ afterEach(() => {
   }
 });
 
-function waitForEvent<T>(watcher: GitContextWatcher, event: string, timeoutMs = 2000): Promise<T> {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`timeout waiting for ${event}`)), timeoutMs);
-    watcher.once(event, (payload: T) => {
-      clearTimeout(timer);
-      resolve(payload);
-    });
-  });
+/** One armed watch recorded by the fake factory. */
+interface ArmedWatch {
+  target: string;
+  listener: GitWatchListener;
+  closed: boolean;
+}
+
+/**
+ * Fake `fs.watch` so the watcher's own logic (filename filter, debounce,
+ * re-resolve, teardown) is asserted without waiting on real FSEvents/inotify
+ * delivery — which is what made these tests flaky on loaded CI runners.
+ */
+function fakeWatchFactory(): { arms: ArmedWatch[]; factory: GitWatchFactory; last(): ArmedWatch } {
+  const arms: ArmedWatch[] = [];
+  const factory: GitWatchFactory = (target, listener) => {
+    const rec: ArmedWatch = { target, listener, closed: false };
+    arms.push(rec);
+    return {
+      close() { rec.closed = true; },
+      on() { return this; },
+    };
+  };
+  return { arms, factory, last: () => arms[arms.length - 1] };
 }
 
 describe('parseHead', () => {
@@ -117,78 +133,189 @@ describe('resolveRepo', () => {
 });
 
 describe('GitContextWatcher', () => {
-  it('emits the initial branch on update()', async () => {
-    const root = tmp();
-    initFakeRepo(root, 'main');
-    const watcher = makeWatcher();
-    const eventP = waitForEvent<{ sessionId: string; branch: string | null; isWorktree: boolean }>(watcher, 'git');
-    watcher.update('s1', root);
-    const ev = await eventP;
-    expect(ev).toEqual({ sessionId: 's1', branch: 'main', isWorktree: false });
+  /** The watcher's internal REREAD_DEBOUNCE_MS. */
+  const DEBOUNCE_MS = 50;
+
+  let fake: ReturnType<typeof fakeWatchFactory>;
+  let events: Array<{ sessionId: string; branch: string | null; isWorktree: boolean }>;
+
+  /** Build a watcher wired to the fake factory, with events collected. */
+  function makeWatcher(): GitContextWatcher {
+    const w = new GitContextWatcher(fake.factory);
+    watchers.push(w);
+    w.on('git', (e) => events.push(e));
+    return w;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fake = fakeWatchFactory();
+    events = [];
   });
 
-  it('emits again when HEAD changes (branch switch)', async () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('emits the initial branch on update()', () => {
     const root = tmp();
     initFakeRepo(root, 'main');
     const watcher = makeWatcher();
-    const firstP = waitForEvent(watcher, 'git');
     watcher.update('s1', root);
-    await firstP;
+    expect(events).toEqual([{ sessionId: 's1', branch: 'main', isWorktree: false }]);
+  });
 
-    const secondP = waitForEvent<{ branch: string | null }>(watcher, 'git');
+  it('arms the watch on the git dir before the first read', () => {
+    const root = tmp();
+    initFakeRepo(root, 'main');
+    makeWatcher().update('s1', root);
+    expect(fake.arms).toHaveLength(1);
+    expect(fake.last().target).toBe(path.join(root, '.git'));
+  });
+
+  it('emits again when HEAD changes (branch switch)', () => {
+    const root = tmp();
+    initFakeRepo(root, 'main');
+    const watcher = makeWatcher();
+    watcher.update('s1', root);
+    expect(events).toHaveLength(1);
+
     fs.writeFileSync(path.join(root, '.git', 'HEAD'), 'ref: refs/heads/feature-y\n');
-    const ev = await secondP;
-    expect(ev.branch).toBe('feature-y');
+    fake.last().listener('change', 'HEAD');
+    // Nothing before the debounce elapses…
+    vi.advanceTimersByTime(DEBOUNCE_MS - 1);
+    expect(events).toHaveLength(1);
+    // …and exactly one re-emit after it.
+    vi.advanceTimersByTime(1);
+    expect(events).toHaveLength(2);
+    expect(events[1].branch).toBe('feature-y');
   });
 
-  it('does not re-emit an unchanged value on a repeated update()', async () => {
+  it('coalesces a burst of HEAD events into a single re-emit', () => {
     const root = tmp();
     initFakeRepo(root, 'main');
     const watcher = makeWatcher();
-    const events: unknown[] = [];
-    watcher.on('git', (e) => events.push(e));
     watcher.update('s1', root);
+
+    fs.writeFileSync(path.join(root, '.git', 'HEAD'), 'ref: refs/heads/feature-y\n');
+    for (let i = 0; i < 5; i++) {
+      fake.last().listener('change', 'HEAD');
+      vi.advanceTimersByTime(10); // each event restarts the debounce
+    }
+    expect(events).toHaveLength(1);
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+    expect(events).toHaveLength(2);
+    expect(events[1].branch).toBe('feature-y');
+  });
+
+  it('reacts to HEAD.lock (the rename git uses) and ignores unrelated files', () => {
+    const root = tmp();
+    initFakeRepo(root, 'main');
+    const watcher = makeWatcher();
     watcher.update('s1', root);
-    watcher.update('s1', path.join(root)); // identical cwd
-    await new Promise((r) => setTimeout(r, 150));
+
+    fs.writeFileSync(path.join(root, '.git', 'HEAD'), 'ref: refs/heads/locked\n');
+    for (const name of ['config', 'index', 'refs', 'ORIG_HEAD', 'HEADER']) {
+      fake.last().listener('change', name);
+    }
+    vi.advanceTimersByTime(DEBOUNCE_MS * 2);
+    expect(events).toHaveLength(1); // filtered out — no re-read scheduled
+
+    fake.last().listener('rename', 'HEAD.lock');
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+    expect(events).toHaveLength(2);
+    expect(events[1].branch).toBe('locked');
+  });
+
+  it('does not re-emit an unchanged value when HEAD is rewritten identically', () => {
+    const root = tmp();
+    initFakeRepo(root, 'main');
+    const watcher = makeWatcher();
+    watcher.update('s1', root);
+
+    fs.writeFileSync(path.join(root, '.git', 'HEAD'), 'ref: refs/heads/main\n');
+    fake.last().listener('change', 'HEAD');
+    vi.advanceTimersByTime(DEBOUNCE_MS * 2);
     expect(events).toHaveLength(1);
   });
 
-  it('emits branch null when leaving a repo for a non-repo cwd', async () => {
+  it('does not re-emit an unchanged value on a repeated update()', () => {
+    const root = tmp();
+    initFakeRepo(root, 'main');
+    const watcher = makeWatcher();
+    watcher.update('s1', root);
+    watcher.update('s1', root);
+    watcher.update('s1', path.join(root)); // identical cwd
+    vi.advanceTimersByTime(DEBOUNCE_MS * 4);
+    expect(events).toHaveLength(1);
+  });
+
+  it('emits branch null when leaving a repo for a non-repo cwd', () => {
     const root = tmp();
     initFakeRepo(root, 'main');
     const plain = tmp();
     const watcher = makeWatcher();
-    const firstP = waitForEvent(watcher, 'git');
     watcher.update('s1', root);
-    await firstP;
-
-    const secondP = waitForEvent<{ branch: string | null; isWorktree: boolean }>(watcher, 'git');
     watcher.update('s1', plain);
-    const ev = await secondP;
-    expect(ev.branch).toBeNull();
-    expect(ev.isWorktree).toBe(false);
+    expect(events).toHaveLength(2);
+    expect(events[1].branch).toBeNull();
+    expect(events[1].isWorktree).toBe(false);
   });
 
-  it('picks up a git init in a previously non-repo cwd without polling', async () => {
+  it('picks up a git init in a previously non-repo cwd without polling', () => {
     const root = tmp();
     const watcher = makeWatcher();
     watcher.update('s1', root);
-    await new Promise((r) => setTimeout(r, 100));
+    // Outside a repo the watch arms on the cwd itself.
+    expect(fake.last().target).toBe(root);
+    const nonRepoWatch = fake.last();
 
-    const eventP = waitForEvent<{ branch: string | null }>(watcher, 'git');
+    // Unrelated files in the cwd must not trigger a re-resolve.
+    nonRepoWatch.listener('rename', 'scratch.txt');
+    vi.advanceTimersByTime(DEBOUNCE_MS * 2);
+    expect(fake.arms).toHaveLength(1);
+
     initFakeRepo(root, 'fresh');
-    const ev = await eventP;
-    expect(ev.branch).toBe('fresh');
+    nonRepoWatch.listener('rename', '.git');
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+    expect(events.at(-1)?.branch).toBe('fresh');
+    // Re-armed on the freshly resolved git dir; the old watch was closed.
+    expect(nonRepoWatch.closed).toBe(true);
+    expect(fake.last().target).toBe(path.join(root, '.git'));
   });
 
-  it('remove() drops the session watcher', () => {
+  it('remove() closes the watch and clears a pending debounce', () => {
     const root = tmp();
-    initFakeRepo(root);
+    initFakeRepo(root, 'main');
     const watcher = makeWatcher();
     watcher.update('s1', root);
     expect(watcher.size).toBe(1);
+
+    fs.writeFileSync(path.join(root, '.git', 'HEAD'), 'ref: refs/heads/never-seen\n');
+    fake.last().listener('change', 'HEAD');
     watcher.remove('s1');
+
+    vi.advanceTimersByTime(DEBOUNCE_MS * 4);
     expect(watcher.size).toBe(0);
+    expect(fake.last().closed).toBe(true);
+    expect(events).toHaveLength(1); // the pending re-read never fired
+  });
+
+  it('dispose() closes every session watch and clears pending debounces', () => {
+    const a = tmp();
+    const b = tmp();
+    initFakeRepo(a, 'main');
+    initFakeRepo(b, 'dev');
+    const watcher = makeWatcher();
+    watcher.update('s1', a);
+    watcher.update('s2', b);
+    expect(events).toHaveLength(2);
+
+    for (const arm of fake.arms) arm.listener('change', 'HEAD');
+    watcher.dispose();
+    vi.advanceTimersByTime(DEBOUNCE_MS * 4);
+    expect(watcher.size).toBe(0);
+    expect(fake.arms.every((a2) => a2.closed)).toBe(true);
+    expect(events).toHaveLength(2);
   });
 });

--- a/src/main/pty/gitContextWatch.ts
+++ b/src/main/pty/gitContextWatch.ts
@@ -95,10 +95,28 @@ export function readGitContext(repo: ResolvedRepo): GitContext {
   }
 }
 
+/** Listener shape `fs.watch` invokes: `(eventType, filename)`. */
+export type GitWatchListener = (eventType: string, filename: string | Buffer | null) => void;
+
+/** The subset of `fs.FSWatcher` this module uses. `fs.FSWatcher` satisfies it. */
+export interface GitWatchHandle {
+  close(): void;
+  on(event: 'error', listener: () => void): unknown;
+}
+
+/**
+ * Factory that arms a watch on `target`. Defaults to `fs.watch`; tests inject a
+ * fake so watcher logic (filename filtering, debounce, re-resolve) is asserted
+ * without depending on platform FSEvents/inotify delivery latency.
+ */
+export type GitWatchFactory = (target: string, listener: GitWatchListener) => GitWatchHandle;
+
+const defaultWatchFactory: GitWatchFactory = (target, listener) => fs.watch(target, listener);
+
 interface SessionWatch {
   cwd: string;
   repo: ResolvedRepo | null;
-  watcher: fs.FSWatcher | null;
+  watcher: GitWatchHandle | null;
   debounce: NodeJS.Timeout | null;
   /** Last emitted value, JSON-encoded, to suppress no-op re-emits. */
   lastEmitted: string | null;
@@ -117,6 +135,16 @@ interface SessionWatch {
  */
 export class GitContextWatcher extends EventEmitter {
   private sessions = new Map<string, SessionWatch>();
+  private readonly watchFactory: GitWatchFactory;
+
+  /**
+   * @param watchFactory Test seam only. Omitted in production, where the
+   *   watcher arms `fs.watch` exactly as before.
+   */
+  constructor(watchFactory: GitWatchFactory = defaultWatchFactory) {
+    super();
+    this.watchFactory = watchFactory;
+  }
 
   update(sessionId: string, cwd: string): void {
     const existing = this.sessions.get(sessionId);
@@ -173,7 +201,7 @@ export class GitContextWatcher extends EventEmitter {
   private arm(sessionId: string, watch: SessionWatch): void {
     const target = watch.repo ? watch.repo.gitDir : watch.cwd;
     try {
-      watch.watcher = fs.watch(target, (_event, filename) => {
+      watch.watcher = this.watchFactory(target, (_event, filename) => {
         if (watch.repo) {
           // Only HEAD transitions matter (HEAD.lock → HEAD rename included).
           if (filename && !/^HEAD(\.lock)?$/i.test(String(filename))) return;


### PR DESCRIPTION
## Why

macOS Baseline has been failing intermittently on `gitContextWatch > emits again when HEAD changes (branch switch)` and passing on rerun. The watcher itself is correct — `arm()` runs before `readAndEmit`, so there is no arming race. The failure is inherent macOS FSEvents delivery latency plus the 50 ms re-read debounce racing a fixed 2 s timeout in the test helper. On a contended shared runner the event simply arrives late.

Reruns are not a fix: they hide the signal and cost a full cross-platform matrix every time.

## What changed

**Deterministic watcher tests.** `GitContextWatcher` takes an optional watch factory (defaulting to `fs.watch`), so the tests can drive the watch callback directly and use fake timers for the debounce. Production behavior is unchanged — one call site now goes through the injected factory.

Coverage went up rather than down. The suite now asserts the debounce boundary on both sides, burst coalescing, `HEAD.lock` acceptance with `config`/`index`/`refs`/`ORIG_HEAD` filtered out, identical-rewrite dedup, repo→non-repo transitions, `.git` appearance re-resolve including the old watch being closed and the new target re-armed, and debounce cleanup on `remove()`/`dispose()`. The two wall-clock sleeps that stood in for "nothing else was emitted" are gone.

One real-filesystem end-to-end test remains, proving the default `fs.watch` wiring re-emits on a real HEAD rewrite. It lives under `vitest.runtime.config.ts`, where the other real-I/O serial tests already are, with a generous timeout.

**apt retry on Linux runners.** Both apt call sites are wrapped in a bounded retry with backoff. `Acquire::Retries` only retries a fetch inside a single apt run, so it cannot survive a mirror returning a hash-sum mismatch or resetting the connection. Existing hardening (pinned actions, permissions, third-party source removal) is untouched.

**Two census fixes.** A 2 s "safety" timer in `DaemonPipeServer.test.ts` was actually the assertion's deadline, and a 1700 ms sleep in `deck.handler.loop.test.ts` gated a positive assertion behind a 1500 ms debounce. Both now wait on the condition.

## Not changed, deliberately

The Windows `saveDebounced` flakes in `StateWriter`/`ChannelStateWriter` were already fixed on 2026-07-18 by the `waitForCondition` helper — last occurrence 2026-07-14, no recurrence since. `SessionPipe.attachSnapshot` was likewise fixed on 2026-07-23. Re-touching those files would be churn.

## Test plan

- `tsc --noEmit`, `vitest run src/main src/shared` (3561 passed), targeted runs per commit, YAML parse plus `bash -n` on the changed workflow blocks.
- Determinism: the hardened files run **20/20** consecutive green on both the parallel and runtime configs.

## Follow-ups

A ranked census of the remaining load-sensitive sleeps is in the branch discussion — the largest clusters are `DaemonClient` pipe-settle sleeps, `DeckBriefingCard` real sleeps inside `act()`, and an 18-sleep cluster in `deck.handler.loop`. Converting those is a per-file pass, intentionally out of scope here.

Separately, two genuine cross-platform bugs surfaced while sampling failure logs (Windows 8.3 path handling in `diff.handler`/`worktree.handler`, and `execEnv`). They are unrelated to flakiness and are not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Improved Linux build and release reliability by retrying package installation steps with backoff when network/package sources are temporarily unavailable.
  * Improved Git context monitoring so branch/`HEAD` changes are detected more consistently, including updates to `HEAD` content.

* **Tests**
  * Reduced timing-related flakiness by switching from fixed delays to condition-based waiting for connection caps and concurrent turn dispatch.
  * Expanded Git context watcher coverage with both deterministic unit tests (controlled watch behavior) and a runtime end-to-end filesystem test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->