### PR TITLE
test: deflake brick-recovery TTL prune (fixture pid could be alive on CI)

### DIFF
--- a/src/daemon/__tests__/v281BrickRecovery.integration.test.ts
+++ b/src/daemon/__tests__/v281BrickRecovery.integration.test.ts
@@ -174,7 +174,11 @@ describe('v2.8.1 brick recovery — full Bug 1 flow', () => {
     writer.saveImmediate({
       version: 1,
       sessions: [
-        session('dead-tight', 'dead', new Date(now - 25 * HOUR).toISOString()),
+        // pid -1 can never be alive. The fixture's default pid (4242) is a
+        // real pid on some CI runners, and #646's keep-expired-tombstones-
+        // while-the-pid-lives rule then retains this session and flakes the
+        // assertion below.
+        { ...session('dead-tight', 'dead', new Date(now - 25 * HOUR).toISOString()), pid: -1 },
         {
           ...session(
             'suspended-tight',
@@ -190,5 +194,25 @@ describe('v2.8.1 brick recovery — full Bug 1 flow', () => {
     const ids = loaded.sessions.map((s) => s.id);
     expect(ids).not.toContain('dead-tight');
     expect(ids).toContain('suspended-tight');
+  });
+
+  it('TTL prune keeps an expired dead tombstone while its pid is still alive (#646)', () => {
+    // The counterpart of the test above, and the reason its fixture pins
+    // pid -1: an expired tombstone whose recorded pid still runs must
+    // survive the prune so recovery's reconciliation pass can reap the
+    // process. process.pid is this test runner — alive by definition.
+    const now = Date.now();
+    writer.saveImmediate({
+      version: 1,
+      sessions: [
+        {
+          ...session('dead-live-pid', 'dead', new Date(now - 25 * HOUR).toISOString()),
+          pid: process.pid,
+        },
+      ],
+    });
+
+    const ids = writer.load().sessions.map((s) => s.id);
+    expect(ids).toContain('dead-live-pid');
   });
 });


### PR DESCRIPTION
## Summary

`v281BrickRecovery.integration.test.ts` broke two consecutive main pushes today (validate on the #653 merge, Windows Baseline on #656) with the same assertion: an expired dead session that should have been pruned was still there.

Root cause: the fixture pins `pid: 4242`. Since #646, `StateWriter.load()` keeps an expired dead tombstone alive as long as its recorded pid still runs, so the test's outcome depended on whether the CI runner happened to have a live pid 4242 — a coin flip that came up tails twice in a row today and will keep recurring.

- The pruned fixture now uses `pid: -1`, which `isPidAlive` rejects unconditionally, making the prune deterministic.
- Added the counterpart test locking #646's intended behaviour: an expired tombstone with a live pid (`process.pid`) survives the prune.

No production code changes.

## Test plan

- [x] `vitest run v281BrickRecovery.integration.test.ts` — 4 passed (was 3)
- [x] `tsc --noEmit` clean, touched file lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved regression coverage for cleanup of expired dead sessions.
  * Added validation that expired records are retained while their associated process is still running.
  * Reduced test flakiness by explicitly setting process identifiers in test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->