### PR TITLE
refactor(terminal): bind the renderer and daemon to one width model

### DIFF
--- a/src/daemon/HeadlessSnapshot.ts
+++ b/src/daemon/HeadlessSnapshot.ts
@@ -29,7 +29,7 @@
 
 import { Terminal } from '@xterm/headless';
 import { SerializeAddon } from '@xterm/addon-serialize';
-import { Unicode11Addon } from '@xterm/addon-unicode11';
+import { applyUnicodeWidthModel } from '../shared/terminalUnicode';
 import {
   PartialSequenceTracker,
   MarginTracker,
@@ -188,8 +188,7 @@ async function generateTextInner(req: SnapshotRequest): Promise<TextSnapshotOutc
     logLevel: 'off',
   });
   try {
-    terminal.loadAddon(new Unicode11Addon());
-    terminal.unicode.activeVersion = '11';
+    applyUnicodeWidthModel(terminal);
 
     let utf8Carry: Buffer = Buffer.alloc(0);
     let bytesIn = 0;
@@ -287,11 +286,12 @@ async function generateInner(req: SnapshotRequest): Promise<SnapshotOutcome> {
   const serializer = new SerializeAddon();
   try {
     terminal.loadAddon(serializer);
-    // Width parity with the renderer (useTerminal sets the same): without
-    // Unicode 11 tables, CJK/emoji rows advance the cursor differently here
-    // than on screen and the snapshot paints cell-shifted tears.
-    terminal.loadAddon(new Unicode11Addon());
-    terminal.unicode.activeVersion = '11';
+    // Width parity with the renderer (useTerminal calls the same helper):
+    // without the Unicode 11 tables, CJK/emoji rows advance the cursor
+    // differently here than on screen and the snapshot paints cell-shifted
+    // tears. Going through the shared helper is what keeps the two sides from
+    // drifting — do not inline the addon here.
+    applyUnicodeWidthModel(terminal);
 
     const partialTail = new PartialSequenceTracker();
     const margins = new MarginTracker();

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -3,7 +3,7 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebglAddon } from '@xterm/addon-webgl';
 import { SearchAddon } from '@xterm/addon-search';
-import { Unicode11Addon } from '@xterm/addon-unicode11';
+import { applyUnicodeWidthModel } from '../../shared/terminalUnicode';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { useStore } from '../stores';
 import { t } from '../i18n';
@@ -863,7 +863,6 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
 
     const fitAddon = new FitAddon();
     const searchAddon = new SearchAddon();
-    const unicode11Addon = new Unicode11Addon();
     // Smart link routing (X3): localhost URLs open in the embedded browser
     // pane, external ones in the system browser; Ctrl/Cmd+click inverts. The
     // ptyId identifies the owning workspace (multiview-safe reverse lookup).
@@ -875,7 +874,6 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     });
     terminal.loadAddon(fitAddon);
     terminal.loadAddon(searchAddon);
-    terminal.loadAddon(unicode11Addon);
     terminal.loadAddon(webLinksAddon);
     // Path link provider — Ctrl+click an absolute filesystem path to open
     // it in Explorer / Finder. Coexists with WebLinksAddon (URLs); the two
@@ -932,7 +930,10 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // Activate Unicode 11 width tables — required for correct CJK / emoji
     // width. Without this, xterm defaults to v6 and TUI apps that use cursor
     // positioning (Claude Code, vim, etc.) collide frames over Korean text.
-    terminal.unicode.activeVersion = '11';
+    // Shared with the daemon's snapshot terminals through this helper; if the
+    // two sides ever measure differently, a restored snapshot paints
+    // cell-shifted against the live screen.
+    applyUnicodeWidthModel(terminal);
     terminal.open(container);
 
     // xterm 자체 네이티브 'paste' 리스너(terminal.element/textarea에 직접 붙어있음)가

--- a/src/shared/__tests__/terminalUnicode.test.ts
+++ b/src/shared/__tests__/terminalUnicode.test.ts
@@ -1,0 +1,124 @@
+/**
+ * The shared terminal width model.
+ *
+ * `applyUnicodeWidthModel` is the only place the renderer (useTerminal.ts) and
+ * the daemon's snapshot terminals (HeadlessSnapshot.ts x2) get their width
+ * tables from, so testing the helper covers all three grids. It is also
+ * deliberately the ONLY coverage the ANSI snapshot path can have: the serialize
+ * addon re-emits characters, so its payload is byte-identical under Unicode 6
+ * and Unicode 11 and no black-box test can observe that path's width model.
+ * Making divergence structurally impossible is the substitute for testing it.
+ *
+ * Two guards live here, and they fail for different reasons on purpose.
+ */
+import { describe, it, expect } from 'vitest';
+import { Terminal } from '@xterm/headless';
+import { applyUnicodeWidthModel, TERMINAL_UNICODE_VERSION } from '../terminalUnicode';
+
+/** Cursor column after writing `text` at home — i.e. the measured width. */
+async function measureWidth(text: string): Promise<number> {
+  // cols=200 so nothing here can wrap and confuse the reading.
+  const term = new Terminal({ cols: 200, rows: 4, allowProposedApi: true, logLevel: 'off' });
+  try {
+    applyUnicodeWidthModel(term);
+    await new Promise<void>((resolve) => term.write(`\x1b[H${text}`, resolve));
+    return term.buffer.active.cursorX;
+  } finally {
+    term.dispose();
+  }
+}
+
+describe('applyUnicodeWidthModel — the version it claims is the version that registers', () => {
+  it('registers and activates TERMINAL_UNICODE_VERSION', () => {
+    const term = new Terminal({ cols: 20, rows: 4, allowProposedApi: true, logLevel: 'off' });
+    try {
+      applyUnicodeWidthModel(term);
+      // `activeVersion` accepts only a registered id. If a future addon bump
+      // renames or drops this one, the assignment does not throw — the terminal
+      // quietly stays on xterm's Unicode 6 default and every width below
+      // changes. Asserting the id is REGISTERED, not just assigned, is what
+      // catches that: without the first expectation a renamed version would
+      // still read back as '11' from a terminal measuring at v6.
+      expect(term.unicode.versions).toContain(TERMINAL_UNICODE_VERSION);
+      expect(term.unicode.activeVersion).toBe(TERMINAL_UNICODE_VERSION);
+    } finally {
+      term.dispose();
+    }
+  });
+});
+
+describe('applyUnicodeWidthModel — the widths TUI frames are built on', () => {
+  // Widths are pinned as absolute numbers rather than compared against another
+  // addon. The differential form this replaces (Unicode 11 vs the width model
+  // of the day) only means something while two width models are in the tree;
+  // absolute numbers keep meaning when there is one, and they are what a future
+  // addon swap has to reproduce case by case.
+  //
+  // Read the table in two halves, because the halves guard different things:
+  //
+  //   • CJK and the box/block/braille/powerline ranges measure IDENTICALLY
+  //     under xterm's Unicode 6 default, so these rows do NOT fail if the width
+  //     model goes missing — that is the version guard's job above. They are
+  //     here to fail on a future width-model CHANGE, which is the risk that
+  //     costs users: a shifted Hangul or box-drawing width tears every Claude
+  //     Code / vim frame drawn over Korean text, which is the exact bug the
+  //     Unicode 11 tables were added to fix.
+  //   • the emoji rows are what Unicode 11 buys over the v6 default (v6 says 1)
+  //     and therefore DO fail if the model is dropped or mis-registered.
+  const WIDTHS: ReadonlyArray<readonly [string, string, number]> = [
+    ['Hangul syllables', '한글', 4],
+    ['Hangul composed vs decomposed', '각각', 4],
+    ['Hangul jamo block', 'ㄱㄴㄷ', 6],
+    ['kanji', '日本語', 6],
+    ['hiragana + katakana', 'ひらがなカタカナ', 16],
+    ['fullwidth forms', 'ＡＢＣ１２３', 12],
+    ['halfwidth katakana', 'ｱｲｳ', 3],
+    ['CJK punctuation', '。、「」', 8],
+    ['CJK ext-B (supplementary plane)', '\u{20000}\u{2A6DF}', 4],
+    ['ambiguous-width symbols stay narrow', '±§¶', 3],
+    ['box drawing', '─│┌┐└┘├┤┬┴┼', 11],
+    ['block elements', '█▉▊▋▌▍▎▏', 8],
+    ['braille', '⣿⠿⡇', 3],
+    ['powerline glyphs', '', 2],
+    ['ASCII', 'hello world', 11],
+    ['mixed CJK + ASCII', 'wmux 터미널 v3', 14],
+    ['combining marks add no width', 'é', 1],
+    // Unicode 6 measures each of these as 1.
+    ['emoji U+1F600', '\u{1F600}', 2],
+    ['emoji U+1F926', '\u{1F926}', 2],
+    ['emoji U+1F9D1', '\u{1F9D1}', 2],
+  ];
+
+  it.each(WIDTHS)('%s measures %s as %d cells', async (_name, text, expected) => {
+    expect(await measureWidth(text)).toBe(expected);
+  });
+
+  it('measures emoji wider than xterm would without the width model', async () => {
+    // Pins the premise of the emoji rows above: they are a real difference from
+    // the default, not numbers that would pass with no addon loaded at all. If
+    // this ever stops holding, the emoji rows have stopped guarding anything
+    // and the table needs a new mutation-sensitive case.
+    const bare = new Terminal({ cols: 200, rows: 4, allowProposedApi: true, logLevel: 'off' });
+    try {
+      await new Promise<void>((resolve) => bare.write('\x1b[H\u{1F600}', resolve));
+      expect(bare.buffer.active.cursorX).toBe(1);
+    } finally {
+      bare.dispose();
+    }
+    expect(await measureWidth('\u{1F600}')).toBe(2);
+  });
+});
+
+describe('applyUnicodeWidthModel — the known cost of measuring per codepoint', () => {
+  it('over-measures multi-codepoint emoji, which is accepted (see terminalUnicode.ts)', async () => {
+    // NOT a wish list. These numbers are the deliberate trade recorded in the
+    // "Why Unicode 11 and not grapheme clustering" note: each of these is ONE
+    // user-perceived character that Unicode 11 widths per codepoint and sums.
+    // Pinned so the cost stays visible and so a width-model change that fixes
+    // them shows up as a decision rather than as a surprise.
+    expect(await measureWidth('\u{1F468}‍\u{1F469}‍\u{1F467}')).toBe(6);
+    expect(await measureWidth('\u{1F44D}\u{1F3FD}')).toBe(4);
+    // A regional-indicator flag already measures correctly.
+    expect(await measureWidth('\u{1F1F0}\u{1F1F7}')).toBe(2);
+  });
+});

--- a/src/shared/terminalUnicode.ts
+++ b/src/shared/terminalUnicode.ts
@@ -1,0 +1,98 @@
+/**
+ * Single source of truth for the terminal width model.
+ *
+ * Two places own a terminal grid that must agree — the renderer's xterm
+ * (useTerminal.ts) and the daemon's headless snapshot terminals
+ * (HeadlessSnapshot.ts) — because a snapshot is restored onto the renderer's
+ * grid. If they drift, a restored snapshot paints cell-shifted against the
+ * live screen: the daemon wraps a row at a different column than the screen
+ * does, and everything after it sits one or more cells off.
+ *
+ * Nothing in the type system enforced that before: each site named the addon
+ * and the version string itself, so a future addon bump that updated one site
+ * and missed another would diverge silently and still pass CI — every test
+ * would go green with the two grids measuring differently. Both sites now go
+ * through `applyUnicodeWidthModel`, which makes the divergence unspeakable:
+ * there is one addon choice and one version string, in one place.
+ *
+ * There is a THIRD grid that does NOT use this helper: the `wmux web` browser
+ * terminal (`src/daemon/web/frontend/app.js`) loads no Unicode addon at all and
+ * so renders at xterm's Unicode 6 default. That divergence predates this
+ * module — closing it means inlining the addon into the hand-built web bundle
+ * and regenerating the CSP script hashes (`webCsp.ts`), which is its own piece
+ * of work. Do not read this file as evidence that every wmux terminal agrees.
+ *
+ * The E0 conformance harness (`core/harness/`) also does NOT use this helper;
+ * it is pinned to Unicode 11 independently as the differential baseline. See
+ * the note at the top of `core/harness/differ.ts`.
+ *
+ * ── Why Unicode 11 and not grapheme clustering ──────────────────────────────
+ *
+ * `@xterm/addon-unicode-graphemes` measures by grapheme cluster (UAX #29), so a
+ * ZWJ sequence, a skin-tone modifier, a keycap and a VS16 emoji-presentation
+ * selector each measure as ONE 2-cell cluster instead of the sum of their
+ * codepoints. That is more correct per spec. It was evaluated in full and
+ * DECLINED (owner decision, 2026-07-28). Do not re-propose it without new
+ * information; the reasons were:
+ *
+ *   1. VS16 is the only class it actually changes for our content, and it is
+ *      the contested one. Programs on the other side of the PTY — ncurses, Go
+ *      `runewidth` in its default mode, older Python `wcwidth` — still measure
+ *      ⚠️ ❤️ ✔️ as ONE column using the classic wcwidth tables. Those programs
+ *      are exactly what runs in our panes, so widening VS16 buys spec accuracy
+ *      at the cost of agreeing with the apps we host.
+ *   2. Upstream decodes its compressed Unicode trie with
+ *      `new DataView(data.buffer)`, dropping `byteOffset`. Node returns a small
+ *      `Buffer.from(str, 'base64')` as a view into its shared pool, so in any
+ *      Node process that already allocated a small Buffer the addon reads its
+ *      trie header out of unrelated bytes — throwing `Data error`, hanging on a
+ *      multi-gigabyte allocation, or (worst) loading quietly and answering with
+ *      wrong widths. Reported upstream:
+ *      https://github.com/xtermjs/xterm.js/issues/6079. Working around it in
+ *      the embedder is possible but leaves module import ORDER load-bearing.
+ *   3. A grapheme cluster is held in a single cell and UAX #29 puts no bound on
+ *      its length, so one cell can hold an entire ZWJ run (measured: 1,499,999
+ *      characters). A scrollback limit counted in ROWS then stops bounding the
+ *      buffer's memory.
+ *   4. CJK throughput measured ~37% lower.
+ *
+ * The trade is: multi-codepoint emoji (👨‍👩‍👧, 👍🏽, 1️⃣) measure as the sum of
+ * their codepoints and therefore over-measure. That is a real, known defect —
+ * it just costs less than the four above.
+ */
+
+import { Unicode11Addon } from '@xterm/addon-unicode11';
+
+/**
+ * Unicode version registered by `Unicode11Addon`. Every site that measures
+ * character width must activate exactly this string; a mismatch silently drops
+ * the terminal back to xterm's Unicode 6 default.
+ */
+export const TERMINAL_UNICODE_VERSION = '11';
+
+/**
+ * The subset of a terminal this helper touches. Declared structurally so the
+ * same function serves the renderer's `@xterm/xterm` Terminal and the daemon's
+ * `@xterm/headless` Terminal, whose `ITerminalAddon` types come from different
+ * packages and are otherwise not interchangeable.
+ */
+export interface UnicodeWidthTarget {
+  loadAddon(addon: never): void;
+  unicode: { activeVersion: string };
+}
+
+/**
+ * Load the Unicode 11 width tables and activate them.
+ *
+ * Requires the terminal to have been constructed with `allowProposedApi: true`
+ * — registering a Unicode version provider is a proposed API, and xterm throws
+ * without it.
+ *
+ * The addon instance is deliberately not returned: no caller needs it, and
+ * handing one out is how a second site ends up managing the width model
+ * separately from this one.
+ */
+export function applyUnicodeWidthModel(terminal: UnicodeWidthTarget): void {
+  terminal.loadAddon(new Unicode11Addon() as never);
+  terminal.unicode.activeVersion = TERMINAL_UNICODE_VERSION;
+}


### PR DESCRIPTION
The renderer (`useTerminal.ts`) and the daemon's two snapshot terminals (`HeadlessSnapshot.ts`) each named the unicode addon and the version string themselves. Nothing tied them together.

That is worse than it sounds. An addon bump that updated one site and missed another would leave the two grids measuring differently — **and every test would still pass**, because a snapshot only paints cell-shifted once it is restored onto a grid that wraps rows at a different column. The failure is invisible until a restored pane draws one column off from the live one.

All three now go through `applyUnicodeWidthModel` in `src/shared/terminalUnicode.ts`: one addon choice, one version string, in one place.

**No width changes.** The model stays Unicode 11 and every measured width is identical to before.

## Two guards, failing for different reasons

- **The version guard asserts the id is *registered*, not merely assigned.** An addon that renames or drops its version does not throw on assignment — the terminal quietly falls back to xterm's Unicode 6 default and every width changes.
- **The width table pins absolute numbers** rather than diffing against a second addon, because the differential form only means anything while two width models are in the tree. Its CJK / box-drawing / block / braille rows measure the same under Unicode 6, so they do not catch a *missing* width model — they catch a future width-model **change**, which is what tears TUI frames drawn over Korean text. Its emoji rows are what Unicode 11 buys over the default and do catch a missing one, with a premise test pinning that difference.

The known cost of per-codepoint measurement — a ZWJ family at 6 cells, a skin-tone thumbs-up at 4 — is asserted too, so the trade stays visible and a future change to it reads as a decision rather than a surprise.

## Why Unicode 11 and not grapheme clustering

The module records this, because it is the answer to the next person who proposes the swap — and it was evaluated in full before being declined (#671).

- **VS16 is the only class it changes for our content**, and the programs running inside our panes still measure it as one column. Counting this repository: VS16 in 26 files; ZWJ families in 2, both fixtures written for that change; skin tones and keycaps, zero.
- **Upstream mis-reads its own compressed trie** when Node hands it a pooled `Buffer` — https://github.com/xtermjs/xterm.js/issues/6079. Three symptoms depending on what the process allocated first, the worst being silently wrong widths with nothing thrown.
- **One grapheme cluster in one cell removes the memory bound a row-counted scrollback implies**: 13 MB of input retained 214 MB.
- **CJK throughput measured ~37% lower.**

## Verification

`tsc --noEmit` clean · `test:parallel` and `test:runtime` green · eslint on changed files clean. Both guards mutation-verified: removing the addon load, and renaming the version string, each turn their own test red.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in how terminal content measures Unicode characters, including CJK text, combining marks, box-drawing symbols, and emoji.
  * Aligned rendered terminal output and text snapshots to use the same Unicode width behavior.

* **Tests**
  * Added coverage for Unicode character widths and multi-codepoint emoji sequences to help prevent display and cursor-position regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->