### PR TITLE
chore(changelog): assemble release notes from one file per PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,14 @@ In QA/design-review mode, flag any code that doesn't match DESIGN.md.
 - **PRs never bump the version.** `package.json` stays at the last released
   version on every feature branch. Do NOT let /ship (or any workflow) bump
   MAJOR/MINOR/PATCH, claim version slots, or prefix PR titles with `vX.Y.Z`.
-- CHANGELOG: each PR adds its user-facing entries under `## [Unreleased]`
-  at the top (Keep a Changelog). Merge conflicts there are append-merges.
-- **Release = explicit user action**: bump `package.json` version, rename
+- CHANGELOG: a PR does **not** edit `CHANGELOG.md`. It adds one fragment,
+  `changelog.d/<pr-number>.md`, holding its user-facing entries under plain
+  Keep a Changelog headings. Separate files cannot conflict — editing the one
+  shared insertion point meant every merge left every other open PR dirty.
+  See `changelog.d/README.md`.
+- **Release = explicit user action**: run
+  `node scripts/collect-changelog.mjs` to fold the fragments into
+  `CHANGELOG.md`, bump `package.json` version, rename
   `[Unreleased]` → `[X.Y.Z] — YYYY-MM-DD`, run
   `node scripts/gen-api-reference.mjs` (the generated header bakes the
   version — the CI drift guard enforces this), commit `chore(release)`,

--- a/changelog.d/687.md
+++ b/changelog.d/687.md
@@ -1,0 +1,3 @@
+### Changed
+
+- **Release notes are now assembled from one file per pull request.** Every PR used to add its entry at the same line of `CHANGELOG.md` — the one directly under `### Added` — and git cannot order two insertions at the same position, so it reported a conflict. With eleven branches open, merging one of them left five others conflicted, and a conflicted PR quietly stops running CI, so the state of the queue became unreadable within a day. A PR now adds `changelog.d/<pr-number>.md` instead, and separate files cannot collide; `node scripts/collect-changelog.mjs` folds them into `CHANGELOG.md` at release time, in PR-number order. Nothing changes for readers — the published changelog keeps the same shape and the same Keep a Changelog sections.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,44 @@
+# changelog.d — one file per pull request
+
+A PR does **not** edit `CHANGELOG.md`. It adds one file here, named after its
+PR number:
+
+```
+changelog.d/684.md
+```
+
+## Why
+
+Every PR used to insert its entry at the same place — the line right after
+`### Added` inside `## [Unreleased]`. Git sees two different insertions at one
+position and cannot order them, so it reports a conflict. That is not a
+mistake anyone made; it is what a shared insertion point means. The cost grew
+with the number of open PRs: merging one PR left every other open PR
+conflicted, and merging a second re-conflicted the ones just fixed.
+
+Separate files cannot collide. The conflict is designed out rather than
+resolved over and over.
+
+## Format
+
+Plain Keep a Changelog sections. Use only the headings you need, in any order:
+
+```markdown
+### Added
+
+- **Short bold claim.** Then the paragraph, written for a person reading the
+  release notes — what changed, and what it was like before.
+
+### Fixed
+
+- **Another one.** …
+```
+
+Cite your PR number at the end of an entry the same way as before — `(#684)`.
+
+## Release
+
+`node scripts/collect-changelog.mjs` folds every fragment into
+`CHANGELOG.md` under `## [Unreleased]`, in PR-number order, and deletes the
+fragments. That runs as part of cutting a release, before the version bump.
+`--check` reports what would be folded without writing anything.

--- a/scripts/__tests__/collectChangelog.test.mjs
+++ b/scripts/__tests__/collectChangelog.test.mjs
@@ -1,4 +1,4 @@
-// Fragment folding (scripts/collect-changelog.mjs).
+// Fragment folding (scripts/lib/changelog-fragments.mjs).
 //
 // The point of fragments is that a release loses nothing: whatever a PR wrote
 // in changelog.d/ has to come out the other side of the fold, in a stable
@@ -6,7 +6,7 @@
 // a fold that silently drops a section would be discovered at release time,
 // with the fragments already deleted.
 import { describe, expect, it } from 'vitest';
-import { parseFragment, collect, applyToChangelog, fragmentFiles } from '../collect-changelog.mjs';
+import { parseFragment, collect, applyToChangelog, fragmentFiles } from '../lib/changelog-fragments.mjs';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';

--- a/scripts/__tests__/collectChangelog.test.mjs
+++ b/scripts/__tests__/collectChangelog.test.mjs
@@ -1,0 +1,94 @@
+// Fragment folding (scripts/collect-changelog.mjs).
+//
+// The point of fragments is that a release loses nothing: whatever a PR wrote
+// in changelog.d/ has to come out the other side of the fold, in a stable
+// order, next to entries already sitting under [Unreleased]. These pin that —
+// a fold that silently drops a section would be discovered at release time,
+// with the fragments already deleted.
+import { describe, expect, it } from 'vitest';
+import { parseFragment, collect, applyToChangelog, fragmentFiles } from '../collect-changelog.mjs';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+describe('parseFragment', () => {
+  it('keeps a multi-line entry as one entry', () => {
+    const parsed = parseFragment(`### Added
+
+- **A thing.** First line of the paragraph,
+  and its continuation, indented.
+
+- **Another.** Short.
+`);
+    expect(parsed.Added).toHaveLength(2);
+    expect(parsed.Added[0]).toContain('and its continuation');
+    expect(parsed.Added[1]).toBe('- **Another.** Short.');
+  });
+
+  it('splits by section and accepts them in any order', () => {
+    const parsed = parseFragment('### Fixed\n\n- one\n\n### Added\n\n- two\n');
+    expect(parsed).toEqual({ Fixed: ['- one'], Added: ['- two'] });
+  });
+
+  it('refuses an unknown section rather than dropping it', () => {
+    expect(() => parseFragment('### Improvements\n\n- one\n', 'f.md')).toThrow(/unknown section/);
+  });
+
+  it('refuses prose that belongs to no section', () => {
+    expect(() => parseFragment('just a note\n\n### Added\n\n- one\n', 'f.md')).toThrow(/outside any/);
+  });
+});
+
+describe('collect', () => {
+  it('orders fragments by PR number, not by string', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'frag-'));
+    fs.writeFileSync(path.join(dir, '9.md'), '### Added\n\n- nine\n');
+    fs.writeFileSync(path.join(dir, '100.md'), '### Added\n\n- hundred\n');
+    fs.writeFileSync(path.join(dir, 'README.md'), '# not an entry\n');
+    // "100" sorts before "9" as a string — the numeric sort is the point.
+    expect(collect(fragmentFiles(dir)).Added).toEqual(['- nine', '- hundred']);
+  });
+});
+
+describe('applyToChangelog', () => {
+  const base = `# Changelog
+
+## [Unreleased]
+
+### Changed
+
+- an entry written straight into the file
+
+## [3.37.2] — 2026-07-28
+
+### Fixed
+
+- something old
+`;
+
+  it('appends fragment entries after the ones already there', () => {
+    const out = applyToChangelog(base, { Changed: ['- from a fragment'] });
+    const unreleased = out.slice(out.indexOf('## [Unreleased]'), out.indexOf('## [3.37.2]'));
+    expect(unreleased).toContain('- an entry written straight into the file');
+    expect(unreleased.indexOf('straight into the file')).toBeLessThan(
+      unreleased.indexOf('from a fragment'),
+    );
+  });
+
+  it('creates a section that did not exist yet, in Keep a Changelog order', () => {
+    const out = applyToChangelog(base, { Added: ['- new'], Fixed: ['- repaired'] });
+    const unreleased = out.slice(out.indexOf('## [Unreleased]'), out.indexOf('## [3.37.2]'));
+    expect(unreleased.indexOf('### Added')).toBeLessThan(unreleased.indexOf('### Changed'));
+    expect(unreleased.indexOf('### Changed')).toBeLessThan(unreleased.indexOf('### Fixed'));
+  });
+
+  it('leaves every released section untouched', () => {
+    const out = applyToChangelog(base, { Added: ['- new'] });
+    expect(out).toContain('## [3.37.2] — 2026-07-28');
+    expect(out).toContain('- something old');
+  });
+
+  it('refuses a changelog with no [Unreleased] heading', () => {
+    expect(() => applyToChangelog('# Changelog\n\n## [1.0.0]\n', {})).toThrow(/Unreleased/);
+  });
+});

--- a/scripts/collect-changelog.mjs
+++ b/scripts/collect-changelog.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+// Fold changelog.d/<pr>.md fragments into CHANGELOG.md under [Unreleased].
+//
+// Fragments exist so that two PRs never insert at the same line of one file —
+// see changelog.d/README.md. This script is the other half: at release time the
+// fragments are merged back into the one file readers actually read.
+//
+//   node scripts/collect-changelog.mjs           fold and delete fragments
+//   node scripts/collect-changelog.mjs --check    report only, write nothing
+//
+// Ordering is by PR number, so the result is stable no matter what order the
+// files landed in — the same inputs always produce the same CHANGELOG.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const FRAGMENT_DIR = path.join(ROOT, 'changelog.d');
+const CHANGELOG = path.join(ROOT, 'CHANGELOG.md');
+
+// Keep a Changelog's section order. A fragment may use any subset; anything
+// else is a typo we refuse rather than silently drop.
+const SECTIONS = ['Added', 'Changed', 'Deprecated', 'Removed', 'Fixed', 'Security'];
+
+/** Fragment files, oldest PR first. README.md is documentation, not an entry. */
+export function fragmentFiles(dir = FRAGMENT_DIR) {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.md') && f !== 'README.md')
+    .sort((a, b) => {
+      const na = Number.parseInt(a, 10);
+      const nb = Number.parseInt(b, 10);
+      // Non-numeric names sort last, by name — they are still valid entries.
+      if (Number.isNaN(na) && Number.isNaN(nb)) return a.localeCompare(b);
+      if (Number.isNaN(na)) return 1;
+      if (Number.isNaN(nb)) return -1;
+      return na - nb;
+    })
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Split one fragment into `{ Added: [entry, …], … }`.
+ *
+ * An entry is everything between one `- ` bullet and the next, so a multi-line
+ * paragraph survives intact. Text before any `###` heading is an error: it
+ * would otherwise vanish into no section at all.
+ */
+export function parseFragment(text, name = '<fragment>') {
+  const out = {};
+  let section = null;
+  let buffer = [];
+
+  const flush = () => {
+    if (!section || buffer.length === 0) return;
+    const entry = buffer.join('\n').replace(/\s+$/, '');
+    if (entry) (out[section] ??= []).push(entry);
+    buffer = [];
+  };
+
+  for (const line of text.split('\n')) {
+    const heading = /^###\s+(.+?)\s*$/.exec(line);
+    if (heading) {
+      flush();
+      const title = heading[1];
+      if (!SECTIONS.includes(title)) {
+        throw new Error(
+          `${name}: unknown section "${title}" — expected one of ${SECTIONS.join(', ')}`,
+        );
+      }
+      section = title;
+      continue;
+    }
+    if (/^-\s/.test(line)) {
+      flush();
+      buffer.push(line);
+      continue;
+    }
+    if (buffer.length > 0) {
+      buffer.push(line);
+      continue;
+    }
+    if (line.trim() && !section) {
+      throw new Error(`${name}: text outside any "### Section" heading: ${line.trim().slice(0, 60)}`);
+    }
+  }
+  flush();
+  return out;
+}
+
+/** Merge every fragment into one `{ section: [entry, …] }`, in file order. */
+export function collect(files) {
+  const merged = {};
+  for (const file of files) {
+    const parsed = parseFragment(fs.readFileSync(file, 'utf8'), path.basename(file));
+    for (const [section, entries] of Object.entries(parsed)) {
+      (merged[section] ??= []).push(...entries);
+    }
+  }
+  return merged;
+}
+
+/**
+ * Insert the collected entries into CHANGELOG.md under `## [Unreleased]`.
+ *
+ * Entries already written directly under `[Unreleased]` are kept and the new
+ * ones are appended after them — the fragment flow can be adopted without
+ * having to move what is already there.
+ */
+export function applyToChangelog(changelog, merged) {
+  const start = changelog.indexOf('## [Unreleased]');
+  if (start === -1) throw new Error('CHANGELOG.md has no "## [Unreleased]" heading');
+  const after = changelog.indexOf('\n## ', start + 1);
+  const end = after === -1 ? changelog.length : after + 1;
+
+  const body = changelog.slice(start, end);
+  const rest = changelog.slice(end);
+
+  // Existing entries per section inside [Unreleased], so nothing is lost.
+  const existing = {};
+  let current = null;
+  for (const line of body.split('\n')) {
+    const heading = /^###\s+(.+?)\s*$/.exec(line);
+    if (heading) {
+      current = heading[1];
+      existing[current] ??= [];
+      continue;
+    }
+    if (current) (existing[current] ??= []).push(line);
+  }
+
+  const sections = SECTIONS.filter((s) => existing[s]?.some((l) => l.trim()) || merged[s]?.length);
+  const parts = [`## [Unreleased]`, ''];
+  for (const section of sections) {
+    parts.push(`### ${section}`, '');
+    const kept = (existing[section] ?? []).join('\n').trim();
+    if (kept) parts.push(kept, '');
+    for (const entry of merged[section] ?? []) parts.push(entry, '');
+  }
+  return `${parts.join('\n').replace(/\n+$/, '')}\n\n${rest.replace(/^\n+/, '')}`;
+}
+
+function main() {
+  const check = process.argv.includes('--check');
+  const files = fragmentFiles();
+  if (files.length === 0) {
+    console.log('collect-changelog: no fragments in changelog.d/');
+    return;
+  }
+
+  const merged = collect(files);
+  const counts = Object.entries(merged)
+    .map(([s, e]) => `${s} ${e.length}`)
+    .join(', ');
+  console.log(`collect-changelog: ${files.length} fragment(s) — ${counts}`);
+  for (const f of files) console.log(`  ${path.relative(ROOT, f)}`);
+
+  if (check) {
+    console.log('collect-changelog: --check, nothing written');
+    return;
+  }
+
+  fs.writeFileSync(CHANGELOG, applyToChangelog(fs.readFileSync(CHANGELOG, 'utf8'), merged));
+  for (const f of files) fs.unlinkSync(f);
+  console.log('collect-changelog: folded into CHANGELOG.md, fragments removed');
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) main();

--- a/scripts/collect-changelog.mjs
+++ b/scripts/collect-changelog.mjs
@@ -1,146 +1,15 @@
 #!/usr/bin/env node
 // Fold changelog.d/<pr>.md fragments into CHANGELOG.md under [Unreleased].
 //
-// Fragments exist so that two PRs never insert at the same line of one file —
-// see changelog.d/README.md. This script is the other half: at release time the
-// fragments are merged back into the one file readers actually read.
-//
 //   node scripts/collect-changelog.mjs           fold and delete fragments
-//   node scripts/collect-changelog.mjs --check    report only, write nothing
+//   node scripts/collect-changelog.mjs --check   report only, write nothing
 //
-// Ordering is by PR number, so the result is stable no matter what order the
-// files landed in — the same inputs always produce the same CHANGELOG.
+// The folding itself lives in scripts/lib/changelog-fragments.mjs so it can be
+// imported by tests; this file is the command line around it.
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const FRAGMENT_DIR = path.join(ROOT, 'changelog.d');
-const CHANGELOG = path.join(ROOT, 'CHANGELOG.md');
-
-// Keep a Changelog's section order. A fragment may use any subset; anything
-// else is a typo we refuse rather than silently drop.
-const SECTIONS = ['Added', 'Changed', 'Deprecated', 'Removed', 'Fixed', 'Security'];
-
-/** Fragment files, oldest PR first. README.md is documentation, not an entry. */
-export function fragmentFiles(dir = FRAGMENT_DIR) {
-  if (!fs.existsSync(dir)) return [];
-  return fs
-    .readdirSync(dir)
-    .filter((f) => f.endsWith('.md') && f !== 'README.md')
-    .sort((a, b) => {
-      const na = Number.parseInt(a, 10);
-      const nb = Number.parseInt(b, 10);
-      // Non-numeric names sort last, by name — they are still valid entries.
-      if (Number.isNaN(na) && Number.isNaN(nb)) return a.localeCompare(b);
-      if (Number.isNaN(na)) return 1;
-      if (Number.isNaN(nb)) return -1;
-      return na - nb;
-    })
-    .map((f) => path.join(dir, f));
-}
-
-/**
- * Split one fragment into `{ Added: [entry, …], … }`.
- *
- * An entry is everything between one `- ` bullet and the next, so a multi-line
- * paragraph survives intact. Text before any `###` heading is an error: it
- * would otherwise vanish into no section at all.
- */
-export function parseFragment(text, name = '<fragment>') {
-  const out = {};
-  let section = null;
-  let buffer = [];
-
-  const flush = () => {
-    if (!section || buffer.length === 0) return;
-    const entry = buffer.join('\n').replace(/\s+$/, '');
-    if (entry) (out[section] ??= []).push(entry);
-    buffer = [];
-  };
-
-  for (const line of text.split('\n')) {
-    const heading = /^###\s+(.+?)\s*$/.exec(line);
-    if (heading) {
-      flush();
-      const title = heading[1];
-      if (!SECTIONS.includes(title)) {
-        throw new Error(
-          `${name}: unknown section "${title}" — expected one of ${SECTIONS.join(', ')}`,
-        );
-      }
-      section = title;
-      continue;
-    }
-    if (/^-\s/.test(line)) {
-      flush();
-      buffer.push(line);
-      continue;
-    }
-    if (buffer.length > 0) {
-      buffer.push(line);
-      continue;
-    }
-    if (line.trim() && !section) {
-      throw new Error(`${name}: text outside any "### Section" heading: ${line.trim().slice(0, 60)}`);
-    }
-  }
-  flush();
-  return out;
-}
-
-/** Merge every fragment into one `{ section: [entry, …] }`, in file order. */
-export function collect(files) {
-  const merged = {};
-  for (const file of files) {
-    const parsed = parseFragment(fs.readFileSync(file, 'utf8'), path.basename(file));
-    for (const [section, entries] of Object.entries(parsed)) {
-      (merged[section] ??= []).push(...entries);
-    }
-  }
-  return merged;
-}
-
-/**
- * Insert the collected entries into CHANGELOG.md under `## [Unreleased]`.
- *
- * Entries already written directly under `[Unreleased]` are kept and the new
- * ones are appended after them — the fragment flow can be adopted without
- * having to move what is already there.
- */
-export function applyToChangelog(changelog, merged) {
-  const start = changelog.indexOf('## [Unreleased]');
-  if (start === -1) throw new Error('CHANGELOG.md has no "## [Unreleased]" heading');
-  const after = changelog.indexOf('\n## ', start + 1);
-  const end = after === -1 ? changelog.length : after + 1;
-
-  const body = changelog.slice(start, end);
-  const rest = changelog.slice(end);
-
-  // Existing entries per section inside [Unreleased], so nothing is lost.
-  const existing = {};
-  let current = null;
-  for (const line of body.split('\n')) {
-    const heading = /^###\s+(.+?)\s*$/.exec(line);
-    if (heading) {
-      current = heading[1];
-      existing[current] ??= [];
-      continue;
-    }
-    if (current) (existing[current] ??= []).push(line);
-  }
-
-  const sections = SECTIONS.filter((s) => existing[s]?.some((l) => l.trim()) || merged[s]?.length);
-  const parts = [`## [Unreleased]`, ''];
-  for (const section of sections) {
-    parts.push(`### ${section}`, '');
-    const kept = (existing[section] ?? []).join('\n').trim();
-    if (kept) parts.push(kept, '');
-    for (const entry of merged[section] ?? []) parts.push(entry, '');
-  }
-  return `${parts.join('\n').replace(/\n+$/, '')}\n\n${rest.replace(/^\n+/, '')}`;
-}
+import { ROOT, CHANGELOG, fragmentFiles, collect, applyToChangelog } from './lib/changelog-fragments.mjs';
 
 function main() {
   const check = process.argv.includes('--check');
@@ -167,4 +36,4 @@ function main() {
   console.log('collect-changelog: folded into CHANGELOG.md, fragments removed');
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) main();
+main();

--- a/scripts/lib/changelog-fragments.mjs
+++ b/scripts/lib/changelog-fragments.mjs
@@ -1,0 +1,146 @@
+/**
+ * Folding changelog.d/<pr>.md fragments into CHANGELOG.md.
+ *
+ * Fragments exist so that two PRs never insert at the same line of one file —
+ * see changelog.d/README.md. These functions are the other half: at release
+ * time the fragments are merged back into the one file readers actually read.
+ *
+ * Ordering is by PR number, so the result is stable no matter what order the
+ * files landed in — the same inputs always produce the same CHANGELOG.
+ *
+ * The CLI lives in scripts/collect-changelog.mjs. It carries the shebang; this
+ * file does not, so tests can import it (the same split the license scripts
+ * use — a shebang is not valid JS to every parser that reads a module).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// `..` twice: this file sits in scripts/lib, the repo root is two levels up.
+export const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+export const FRAGMENT_DIR = path.join(ROOT, 'changelog.d');
+export const CHANGELOG = path.join(ROOT, 'CHANGELOG.md');
+
+// Keep a Changelog's section order. A fragment may use any subset; anything
+// else is a typo we refuse rather than silently drop.
+const SECTIONS = ['Added', 'Changed', 'Deprecated', 'Removed', 'Fixed', 'Security'];
+
+/** Fragment files, oldest PR first. README.md is documentation, not an entry. */
+export function fragmentFiles(dir = FRAGMENT_DIR) {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.md') && f !== 'README.md')
+    .sort((a, b) => {
+      const na = Number.parseInt(a, 10);
+      const nb = Number.parseInt(b, 10);
+      // Non-numeric names sort last, by name — they are still valid entries.
+      if (Number.isNaN(na) && Number.isNaN(nb)) return a.localeCompare(b);
+      if (Number.isNaN(na)) return 1;
+      if (Number.isNaN(nb)) return -1;
+      return na - nb;
+    })
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Split one fragment into `{ Added: [entry, …], … }`.
+ *
+ * An entry is everything between one `- ` bullet and the next, so a multi-line
+ * paragraph survives intact. Text before any `###` heading is an error: it
+ * would otherwise vanish into no section at all.
+ */
+export function parseFragment(text, name = '<fragment>') {
+  const out = {};
+  let section = null;
+  let buffer = [];
+
+  const flush = () => {
+    if (!section || buffer.length === 0) return;
+    const entry = buffer.join('\n').replace(/\s+$/, '');
+    if (entry) (out[section] ??= []).push(entry);
+    buffer = [];
+  };
+
+  for (const line of text.split('\n')) {
+    const heading = /^###\s+(.+?)\s*$/.exec(line);
+    if (heading) {
+      flush();
+      const title = heading[1];
+      if (!SECTIONS.includes(title)) {
+        throw new Error(
+          `${name}: unknown section "${title}" — expected one of ${SECTIONS.join(', ')}`,
+        );
+      }
+      section = title;
+      continue;
+    }
+    if (/^-\s/.test(line)) {
+      flush();
+      buffer.push(line);
+      continue;
+    }
+    if (buffer.length > 0) {
+      buffer.push(line);
+      continue;
+    }
+    if (line.trim() && !section) {
+      throw new Error(`${name}: text outside any "### Section" heading: ${line.trim().slice(0, 60)}`);
+    }
+  }
+  flush();
+  return out;
+}
+
+/** Merge every fragment into one `{ section: [entry, …] }`, in file order. */
+export function collect(files) {
+  const merged = {};
+  for (const file of files) {
+    const parsed = parseFragment(fs.readFileSync(file, 'utf8'), path.basename(file));
+    for (const [section, entries] of Object.entries(parsed)) {
+      (merged[section] ??= []).push(...entries);
+    }
+  }
+  return merged;
+}
+
+/**
+ * Insert the collected entries into CHANGELOG.md under `## [Unreleased]`.
+ *
+ * Entries already written directly under `[Unreleased]` are kept and the new
+ * ones are appended after them — the fragment flow can be adopted without
+ * having to move what is already there.
+ */
+export function applyToChangelog(changelog, merged) {
+  const start = changelog.indexOf('## [Unreleased]');
+  if (start === -1) throw new Error('CHANGELOG.md has no "## [Unreleased]" heading');
+  const after = changelog.indexOf('\n## ', start + 1);
+  const end = after === -1 ? changelog.length : after + 1;
+
+  const body = changelog.slice(start, end);
+  const rest = changelog.slice(end);
+
+  // Existing entries per section inside [Unreleased], so nothing is lost.
+  const existing = {};
+  let current = null;
+  for (const line of body.split('\n')) {
+    const heading = /^###\s+(.+?)\s*$/.exec(line);
+    if (heading) {
+      current = heading[1];
+      existing[current] ??= [];
+      continue;
+    }
+    if (current) (existing[current] ??= []).push(line);
+  }
+
+  const sections = SECTIONS.filter((s) => existing[s]?.some((l) => l.trim()) || merged[s]?.length);
+  const parts = [`## [Unreleased]`, ''];
+  for (const section of sections) {
+    parts.push(`### ${section}`, '');
+    const kept = (existing[section] ?? []).join('\n').trim();
+    if (kept) parts.push(kept, '');
+    for (const entry of merged[section] ?? []) parts.push(entry, '');
+  }
+  return `${parts.join('\n').replace(/\n+$/, '')}\n\n${rest.replace(/^\n+/, '')}`;
+}


### PR DESCRIPTION
## The problem, measured

Every PR adds its entry at the same line of `CHANGELOG.md` — directly under `### Added` inside `[Unreleased]`. Git sees two different insertions at one position and cannot order them, so it reports a conflict. That is not a mistake anyone is making; it is what a shared insertion point means.

Today it cost real time. Four merges left most of the open queue `DIRTY`, and merging one further docs-only PR (#669) re-dirtied five branches that had just been fixed by hand. Two of those had green check marks displayed from a base they were no longer on, because **a conflicted PR silently stops queueing CI** — so the queue looked healthier than it was.

## The change

A PR no longer edits `CHANGELOG.md`. It adds `changelog.d/<pr-number>.md` with plain Keep a Changelog headings. Separate files cannot collide, so the conflict is designed out rather than resolved over and over.

`node scripts/collect-changelog.mjs` folds the fragments into `CHANGELOG.md` at release time and deletes them. Ordering is by PR number, so the same fragments always produce the same file. Entries already written directly under `[Unreleased]` are kept and new ones appended after them — this can be adopted without moving anything that is there today (the eleven entries currently sitting in `[Unreleased]` stay put).

`--check` reports what would be folded without writing.

## Refusals

The fold deletes the fragments it consumed, so anything it skipped silently would be unrecoverable. Two inputs are therefore errors, not warnings:

- a heading that is not one of the six Keep a Changelog sections (a typo like `### Improvements`)
- prose sitting outside any heading

## Verification

- 9 unit tests covering multi-line entries, section ordering, numeric-not-lexical file ordering (`9.md` before `100.md`), preservation of released sections, and both refusals
- mutation-checked: replacing the numeric sort with a string sort turns the ordering test red
- dry-run against the real `CHANGELOG.md` with this PR's own fragment — `[Unreleased]` keeps its existing Added/Changed/Fixed sections and the fragment lands under Changed

`CLAUDE.md`'s release procedure is updated to run the fold before the version bump. No version bump here.

## Note on the other open branches

This does not retroactively fix them — the five currently `DIRTY` branches still each need their `CHANGELOG.md` conflict resolved once. It stops the next merge from creating a sixth round.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated tooling to collect release-note fragments, organize entries by pull request number, and merge them into the unreleased changelog.
  * Added a check mode to preview available release-note fragments without modifying files.

* **Documentation**
  * Clarified the release workflow and required formatting for changelog entries.
  * Documented supported changelog categories and fragment conventions.

* **Tests**
  * Added coverage for parsing, ordering, validation, merging, and release-section handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->