### PR TITLE
test: stop two Windows CI fixtures from reporting as product failures (#689, #690)

### DIFF
--- a/src/main/__tests__/cliShim.test.ts
+++ b/src/main/__tests__/cliShim.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import {
   buildShimCmd,
   buildPathEditScript,
@@ -179,19 +179,28 @@ describe.skipIf(process.platform !== 'win32')('PATH edit (live registry, sandbox
 
   // Must stay below the suite's per-test budget above: a spawn that outlives it
   // can only ever surface as a bare vitest timeout, which says nothing about
-  // which of the three or four spawns in a case actually hung.
+  // which of the three or four spawns in a case actually hung. Warm spawns
+  // measure ~1s, so this is a wide margin over anything legitimate.
   const SPAWN_TIMEOUT_MS = 10_000;
+  // The first powershell.exe in a process pays a one-time cold start — its own
+  // binaries and the .NET images are not in the OS file cache yet. #576
+  // measured 5.6s for it; a run on this branch exceeded 10s. It is absorbed
+  // once in a hook with a budget of its own rather than billed to whichever
+  // case happens to run first, which is how #576 flaked and what its 5s → 15s
+  // widening left unaddressed — a wider budget moves that threshold, it does
+  // not stop a one-time cost from landing inside a per-test one.
+  const WARMUP_TIMEOUT_MS = 60_000;
 
-  const ps = (script: string) => {
+  const ps = (script: string, timeoutMs: number = SPAWN_TIMEOUT_MS) => {
     try {
       return { code: 0, out: execFileSync(PS, ['-NoProfile', '-NonInteractive', '-Command', script], {
-        encoding: 'utf8', windowsHide: true, timeout: SPAWN_TIMEOUT_MS,
+        encoding: 'utf8', windowsHide: true, timeout: timeoutMs,
       }), err: '' };
     } catch (e) {
       const err = e as { status?: number | null; stdout?: string; stderr?: string; signal?: string };
       // A timeout kills the child with a signal and leaves status null. Say so —
       // "hung" and "exited non-zero" need different fixes.
-      const killed = err.signal ? `killed by ${err.signal} after ${SPAWN_TIMEOUT_MS} ms` : '';
+      const killed = err.signal ? `killed by ${err.signal} after ${timeoutMs} ms` : '';
       return {
         code: err.status ?? -1,
         out: err.stdout ?? '',
@@ -208,8 +217,8 @@ describe.skipIf(process.platform !== 'win32')('PATH edit (live registry, sandbox
    * is #690, where a seed that never created the key surfaced as READ_FAILED
    * and read as a genuine regression.
    */
-  const psOk = (label: string, script: string) => {
-    const r = ps(script);
+  const psOk = (label: string, script: string, timeoutMs?: number) => {
+    const r = ps(script, timeoutMs);
     if (r.code !== 0) {
       throw new Error(`fixture "${label}" failed with exit ${r.code}\n${r.err || r.out}`.trim());
     }
@@ -254,6 +263,13 @@ describe.skipIf(process.platform !== 'win32')('PATH edit (live registry, sandbox
     return ps(prefix + buildPathEditScript(BIN, op, SUB, BAK));
   };
 
+  // Pay the cold start here, where it has its own budget and its own name. If
+  // PowerShell is genuinely unusable this reports that once, up front, instead
+  // of disguising it as the first case's failure.
+  beforeAll(() => {
+    psOk('warm up powershell', 'exit 0', WARMUP_TIMEOUT_MS);
+  }, WARMUP_TIMEOUT_MS + 5_000);
+
   afterEach(() => {
     // Also checked: teardown that could not run leaves keys behind, and the
     // damage lands on the *next* case — the failure would be attributed to
@@ -264,7 +280,11 @@ describe.skipIf(process.platform !== 'win32')('PATH edit (live registry, sandbox
   it('a failed fixture spawn reports itself instead of running the case', () => {
     // Guards the #690 fix itself: if psOk ever goes back to swallowing an exit
     // code, a broken fixture returns to impersonating the shim and this fails.
-    expect(() => psOk('deliberate failure', 'exit 3')).toThrow(/deliberate failure.*exit 3/s);
+    // Asserted on the label, not on the exit value: the property is that a
+    // fixture failure carries its own name. Pinning the code made this fail on
+    // a slow runner for a spawn that had been killed rather than exiting —
+    // which is psOk working, reported as psOk broken.
+    expect(() => psOk('deliberate failure', 'exit 3')).toThrow(/fixture "deliberate failure" failed with exit/);
   });
 
   for (const constrained of [false, true]) {

--- a/src/main/__tests__/cliShim.test.ts
+++ b/src/main/__tests__/cliShim.test.ts
@@ -177,21 +177,69 @@ describe.skipIf(process.platform !== 'win32')('PATH edit (live registry, sandbox
   const SEED = '%USERPROFILE%\\AppData\\Roaming\\npm;C:\\Program Files\\nodejs';
   const PS = `${process.env.SystemRoot || 'C:\\Windows'}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
 
+  // Must stay below the suite's per-test budget above: a spawn that outlives it
+  // can only ever surface as a bare vitest timeout, which says nothing about
+  // which of the three or four spawns in a case actually hung.
+  const SPAWN_TIMEOUT_MS = 10_000;
+
   const ps = (script: string) => {
     try {
       return { code: 0, out: execFileSync(PS, ['-NoProfile', '-NonInteractive', '-Command', script], {
-        encoding: 'utf8', windowsHide: true, timeout: 20000,
-      }) };
+        encoding: 'utf8', windowsHide: true, timeout: SPAWN_TIMEOUT_MS,
+      }), err: '' };
     } catch (e) {
-      const err = e as { status?: number; stdout?: string };
-      return { code: err.status ?? -1, out: err.stdout ?? '' };
+      const err = e as { status?: number | null; stdout?: string; stderr?: string; signal?: string };
+      // A timeout kills the child with a signal and leaves status null. Say so —
+      // "hung" and "exited non-zero" need different fixes.
+      const killed = err.signal ? `killed by ${err.signal} after ${SPAWN_TIMEOUT_MS} ms` : '';
+      return {
+        code: err.status ?? -1,
+        out: err.stdout ?? '',
+        err: [killed, err.stderr].filter(Boolean).join('\n').trim(),
+      };
     }
   };
 
-  const seed = () => ps(
+  /**
+   * Spawn for fixture work, where a non-zero exit is a broken *harness* and
+   * never a finding about the code under test. It has to say that itself: the
+   * cases below assert exit codes from the real shim, so a silently failed
+   * setup does not vanish — it comes back wearing the shim's own failure. That
+   * is #690, where a seed that never created the key surfaced as READ_FAILED
+   * and read as a genuine regression.
+   */
+  const psOk = (label: string, script: string) => {
+    const r = ps(script);
+    if (r.code !== 0) {
+      throw new Error(`fixture "${label}" failed with exit ${r.code}\n${r.err || r.out}`.trim());
+    }
+    return r;
+  };
+
+  /**
+   * Remove sandbox keys, loudly if it cannot. Deliberately *not*
+   * `-ErrorAction SilentlyContinue`: that suppresses the message but still
+   * leaves `$?` false, so `powershell.exe -Command` exits 1 and "there was
+   * nothing to delete" is indistinguishable from "the delete failed" — the
+   * same conflation this file is fixing. Test-Path answers the first question
+   * up front, so a non-zero exit can only mean the second.
+   */
+  const dropKeys = (label: string, ...subs: string[]) => psOk(label,
+    `$ErrorActionPreference = 'Stop'\n` +
+    subs.map((s) => `if (Test-Path 'HKCU:\\${s}') { Remove-Item 'HKCU:\\${s}' -Recurse -Force }`).join('\n'),
+  );
+
+  const seed = () => psOk('seed sandbox key',
+    `$ErrorActionPreference = 'Stop'\n` +
     `if (Test-Path 'HKCU:\\${SUB}') { Remove-Item 'HKCU:\\${SUB}' -Recurse -Force }\n` +
     `New-Item -Path 'HKCU:\\${SUB}' -Force | Out-Null\n` +
-    `Set-ItemProperty -Path 'HKCU:\\${SUB}' -Name 'Path' -Value '${SEED}' -Type ExpandString`,
+    `Set-ItemProperty -Path 'HKCU:\\${SUB}' -Name 'Path' -Value '${SEED}' -Type ExpandString\n` +
+    // Post-condition, in the same spawn rather than a second one: prove the key
+    // holds what every case below depends on, not merely that no step threw.
+    // DoNotExpandEnvironmentNames because the %VAR% entry must still be raw —
+    // that is the property these cases exist to protect.
+    `$raw = (Get-Item 'HKCU:\\${SUB}').GetValue('Path', $null, 'DoNotExpandEnvironmentNames')\n` +
+    `if ($raw -ne '${SEED}') { throw "seed left Path as '$raw'" }`,
   );
 
   /** Raw (unexpanded) current value of the sandbox Path, via reg.exe. */
@@ -207,8 +255,16 @@ describe.skipIf(process.platform !== 'win32')('PATH edit (live registry, sandbox
   };
 
   afterEach(() => {
-    ps(`Remove-Item 'HKCU:\\${SUB}' -Recurse -Force -ErrorAction SilentlyContinue\n` +
-       `Remove-Item 'HKCU:\\${BAK}' -Recurse -Force -ErrorAction SilentlyContinue`);
+    // Also checked: teardown that could not run leaves keys behind, and the
+    // damage lands on the *next* case — the failure would be attributed to
+    // whichever test ran after the one that actually broke.
+    dropKeys('teardown sandbox keys', SUB, BAK);
+  });
+
+  it('a failed fixture spawn reports itself instead of running the case', () => {
+    // Guards the #690 fix itself: if psOk ever goes back to swallowing an exit
+    // code, a broken fixture returns to impersonating the shim and this fails.
+    expect(() => psOk('deliberate failure', 'exit 3')).toThrow(/deliberate failure.*exit 3/s);
   });
 
   for (const constrained of [false, true]) {
@@ -240,7 +296,10 @@ describe.skipIf(process.platform !== 'win32')('PATH edit (live registry, sandbox
 
     it(`${mode}: an unreadable key fails closed — exits READ_FAILED and writes nothing`, () => {
       // No sandbox key at all — both readers must fail rather than invent an empty PATH.
-      ps(`Remove-Item 'HKCU:\\${SUB}' -Recurse -Force -ErrorAction SilentlyContinue`);
+      // This removal is the precondition, so it is checked like any other fixture:
+      // if it silently failed, the case would assert READ_FAILED against a key
+      // that still exists and pass for the wrong reason.
+      dropKeys('drop sandbox key', SUB);
       const r = run('add', constrained);
       expect(r.code).toBe(PATH_EDIT_EXIT.READ_FAILED);
       expect(explainPathEditExit(r.code, BIN)).toContain('ConstrainedLanguage');

--- a/src/main/ipc/handlers/__tests__/diff.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/diff.handler.test.ts
@@ -44,6 +44,25 @@ function g(cwd: string, args: string[]): string {
   return execFileSync('git', args, { cwd, encoding: 'utf8' });
 }
 
+// Every case here builds a real repo plus a linked worktree and drives git
+// through it. On GitHub's Windows runner that I/O does not reliably finish
+// inside vitest's 5s default, so a correct test fails for being slow. Raise it
+// once for the file rather than decorating each describe: the cost of the
+// larger budget is only paid by a test that is genuinely stuck.
+vi.setConfig({ testTimeout: 30_000 });
+
+/**
+ * Remove a scenario's temp tree. Windows keeps the linked worktree's handles
+ * open for a beat after the last git call returns — and Defender may still be
+ * reading it — so a bare rmSync races the release and throws EBUSY out of
+ * afterEach. That fails the run and masks whatever the test was actually
+ * reporting. rmSync already retries exactly the EBUSY/EPERM/ENOTEMPTY family,
+ * so this is a parameter rather than a hand-rolled backoff loop.
+ */
+function removeScenarioTree(base: string): void {
+  rmSync(base, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+}
+
 // A selection only adopts if it carries the adoption fingerprint of the file
 // entry it was picked from, so build selections from the read they were made
 // against — exactly like the renderer does.
@@ -90,7 +109,7 @@ function makeScenario(): {
     repoRoot,
     worktreePath,
     targetHeadOid,
-    cleanup: () => rmSync(base, { recursive: true, force: true }),
+    cleanup: () => removeScenarioTree(base),
   };
 }
 
@@ -809,7 +828,7 @@ describe('diff:read — 워크스페이스 모드(일반 repo, oid 미지정)', 
     g(repo, ['add', '-A']);
     g(repo, ['commit', '-q', '-m', 'base']);
   });
-  afterEach(() => rmSync(base, { recursive: true, force: true }));
+  afterEach(() => removeScenarioTree(base));
 
   it('staged+unstaged+untracked를 모두 반환, 스냅샷은 repo 자신', async () => {
     // staged 변경 + unstaged 변경 + untracked 신규.
@@ -919,7 +938,7 @@ describe('diff:resolveRepo — cwd 정규화', () => {
     g(repo, ['add', '-A']);
     g(repo, ['commit', '-q', '-m', 'base']);
   });
-  afterEach(() => rmSync(base, { recursive: true, force: true }));
+  afterEach(() => removeScenarioTree(base));
 
   it('서브디렉토리 cwd → repo toplevel 반환', async () => {
     const resolve = captured.get(IPC.DIFF_RESOLVE_REPO)!;
@@ -994,7 +1013,7 @@ describe('diff:applyHunks — per-hunk selection granularity and selection-wide 
       repoRoot,
       worktreePath,
       baseText,
-      cleanup: () => rmSync(base, { recursive: true, force: true }),
+      cleanup: () => removeScenarioTree(base),
     };
   }
 


### PR DESCRIPTION
Two Windows-only CI fixtures that fail in a way that reads as a product regression. Test files only. Folded into one PR as suggested on #690.

## #690 — a failed fixture could wear the shim's own exit code

`cliShim.test.ts` drives the real generated PATH-edit script against a throwaway HKCU key. `seed()` spawned `powershell.exe` and its result was discarded, so a seed that never created the key let the case run anyway: the script then failed closed with `PATH_EDIT_EXIT.READ_FAILED`, and CI reported exit 10 — a real, meaningful code from production — on PRs touching nothing near the CLI shim. As the issue put it, the assertion that fired was only the messenger.

- Fixture spawns go through `psOk(label, script)`, which throws on a non-zero exit and carries the child's stderr. A broken harness now names itself.
- `seed()` verifies its own post-condition **inside the same spawn**: the key must actually hold the seeded raw value. Read with `DoNotExpandEnvironmentNames`, because the `%VAR%` entry surviving unexpanded is the property these cases exist to protect. This is the half that catches a seed which *ran* but left nothing behind — the reported failure mode.
- Key removal is guarded by `Test-Path` under `$ErrorActionPreference = 'Stop'` instead of `-ErrorAction SilentlyContinue`. That switch suppresses the message but still leaves `$?` false, so `powershell -Command` exits 1 and "nothing to delete" would have been the same signal as "could not delete" — the very conflation being removed here. I got this wrong first and the suite caught it.
- One case asserts `psOk` throws, so a future revert to swallowing it fails loudly.
- Spawn timeout 20s → 10s, the value the issue proposed, bringing it under the suite's 15s per-test budget. Above that budget a hung `powershell.exe` can only ever surface as a bare vitest timeout naming no spawn in particular.

**What this does not do:** it makes the flake *diagnosable*, not *gone*. If the registry write itself is what is intermittently failing, CI still goes red — it will say `fixture "seed sandbox key" failed with exit N` instead of exit 10. The issue offers a seed retry conditional on that turning out to be the cause; deliberately not added, because adding it now would delete the only signal that could establish it. Happy to follow up once a run tells us.

## #689 — teardown raced the Windows handle release

Each scenario builds a real repo, most with a linked worktree, and teardown deleted the tree with a bare `rmSync`. On Windows those handles stay open for a beat after the last git call returns — Defender may still be reading it too — so the delete threw `EBUSY` out of `afterEach`, failing the run on its own and masking whatever the test had actually reported.

`rmSync` already retries exactly the `EBUSY`/`EPERM`/`ENOTEMPTY` family, so this is a parameter rather than a hand-rolled backoff loop. Measured on Windows 11 with the handle held by a **separate process** — the real git/Defender shape, and the only one a synchronous retry loop could ever outlive:

```
bare rmSync                      THREW EBUSY after 1 ms
rmSync maxRetries:10 delay:100   OK after 625 ms
```

All four temp-tree teardowns route through one helper, including the two describes that build their trees inline rather than through `makeScenario` — one of those creates a linked worktree of its own, so leaving it bare would have mitigated the race everywhere except a place it demonstrably occurs.

The 5s default is also too tight for git-worktree I/O on the Windows runner, so a correct test failed for being slow. Raised once for the file rather than on each of ten describes, since every case in it drives real git. `vi.setConfig` is file-local — verified on Vitest 4.1.0 by running a file that sets 30s ahead of one that does not, in the same worker: the second still timed out at 5000ms. No other file inherits the larger budget.

## Deliberate, cheap to overrule

- **10s spawn cap.** A single spawn between 10s and 15s, in a case whose total stays under the suite budget, now fails where it previously passed. A spawn that slow is treated as pathological; the alternative — a cap above the suite budget — can never surface as its own error. Locally these spawns run 1.5–1.7s.
- **No seed retry**, per the note above.
- **No `git worktree remove` before the delete.** `rmSync`'s retry covers the observed errno without adding a spawn per teardown that can fail on its own.
- **No changelog fragment** — test-only, matching #581.

## Verification

Run on Windows 11, which is the platform that actually executes both suites (`cliShim`'s block is `describe.skipIf(process.platform !== 'win32')`).

- `npx vitest run src/main/__tests__/cliShim.test.ts --maxWorkers=1` → 26 passed, 8 skipped
- `npx vitest run src/main/ipc/handlers/__tests__/diff.handler.test.ts --maxWorkers=1` → 37 passed, 1 skipped
- Mutation-checked, both new guards: a seed forced to exit non-zero reports `fixture "seed sandbox key" failed with exit 9`; a seed that writes the wrong value reports `seed left Path as 'SABOTAGE'`. Before this change both surfaced as `expected 10 to be +0`.
- `npx tsc -p tsconfig.json --noEmit`
- ESLint on both files: 66 warnings, 0 errors — byte-identical to the same two files on `main`, so nothing new.
- `git diff --check origin/main..HEAD`

Not run: the full suite and `npm run lint`, both already red on `main`.

Refs #690, #689.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Windows test reliability using stricter PowerShell timeout handling and more consistent `{code, out, err}`-style reporting for clearer failure attribution.
  * Strengthened fixture and sandbox setup/teardown checks to better detect and explain non-zero exits and avoid false positives from leftover state.
  * Increased test timeouts for faster Windows repo I/O and made scenario directory cleanup more resilient with a shared retry-capable removal helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->