### PR TITLE
fix(browser): scope CDP target selection to the caller's workspace (#695 main-side leg)

### DIFF
--- a/src/main/browser-session/WebviewCdpManager.ts
+++ b/src/main/browser-session/WebviewCdpManager.ts
@@ -55,6 +55,20 @@ const DISCARD_AFTER_MS =
 // page has to fully reload before dom-ready re-registers it.
 const WAKE_TIMEOUT_MS = 15_000;
 
+/**
+ * Workspace ownership test for a target or guest (#695).
+ *
+ * A caller that named no workspace is unscoped and matches everything — that
+ * is the pre-#695 contract the pipe still depends on. A caller that named one
+ * matches only what it can be *proven* to own: an untagged target is refused
+ * rather than assumed, the same rule browser.cdp.info applies to the target
+ * list (#591). Ownership is never inferred from being the only candidate.
+ */
+function ownedBy(ownerWorkspaceId: string | undefined, callerWorkspaceId: string | undefined): boolean {
+  if (!callerWorkspaceId) return true;
+  return ownerWorkspaceId === callerWorkspaceId;
+}
+
 interface GuestState {
   /** Effective visibility reported by the renderer (workspace ∧ window ∧ ¬zoom ∧ selected). */
   visible: boolean;
@@ -75,6 +89,11 @@ interface GuestState {
   discarded: boolean;
   /** Dwell timer armed while the guest is throttle-eligible; fires a discard. */
   discardTimer: NodeJS.Timeout | null;
+  /** Owning workspace, mirrored from the last register() that reported one
+   *  (#695). It lives here rather than only on the session because a discarded
+   *  guest has no session, and ensureAwake() must still be able to tell whether
+   *  the surface it is about to wake belongs to the caller. */
+  workspaceId?: string;
 }
 
 export class WebviewCdpManager {
@@ -225,6 +244,12 @@ export class WebviewCdpManager {
     // re-register fires on every navigation, and re-arming grace there would
     // let a hidden page that reloads periodically stay unthrottled forever.
     const gs = this.ensureGuestState(surfaceId);
+    // Remember the owner so a later wake can be scoped (#695). Only ever
+    // recorded, never cleared: a legacy re-registration that reports no
+    // workspace must not silently downgrade a surface we already know the
+    // owner of. A surface belongs to one workspace for its whole life, so
+    // there is no case where this goes stale.
+    if (workspaceId) gs.workspaceId = workspaceId;
     // A registration IS the wake: the renderer remounted the webview (wake
     // signal, user click, or surface became visible again).
     gs.discarded = false;
@@ -369,21 +394,26 @@ export class WebviewCdpManager {
    * nothing to wake, or when the wake reload times out. Concurrent calls for
    * the same surface share one in-flight wake.
    */
-  async ensureAwake(surfaceId?: string): Promise<CdpTargetInfo | null> {
+  async ensureAwake(surfaceId?: string, workspaceId?: string): Promise<CdpTargetInfo | null> {
     let resolved = surfaceId;
     if (!resolved) {
-      const first = this.sessions.values().next();
-      if (!first.done) return first.value;
-      // No live session — wake the first discarded surface, if any.
+      const live = this.getTarget(undefined, workspaceId);
+      if (live) return live;
+      // No live session — wake the first discarded surface the caller owns.
+      // Unscoped this would remount somebody else's guest and hand it back:
+      // not merely a disclosure, an action taken in another workspace.
       for (const [sid, gs] of this.guestState) {
-        if (gs.discarded) { resolved = sid; break; }
+        if (gs.discarded && ownedBy(gs.workspaceId, workspaceId)) { resolved = sid; break; }
       }
       if (!resolved) return null;
     }
     const existing = this.sessions.get(resolved);
-    if (existing) return existing;
+    if (existing) return ownedBy(existing.workspaceId, workspaceId) ? existing : null;
     const gs = this.guestState.get(resolved);
     if (!gs?.discarded) return null;
+    // Explicit surfaceId reaches here too, so the wake is scoped on that path
+    // as well — a named foreign surface must not be woken either.
+    if (!ownedBy(gs.workspaceId, workspaceId)) return null;
     const inFlight = this.waking.get(resolved);
     if (inFlight) return inFlight;
     const sid = resolved;
@@ -631,12 +661,27 @@ export class WebviewCdpManager {
     }
   }
 
-  getTarget(surfaceId?: string): CdpTargetInfo | null {
+  /**
+   * Resolve a live CDP target.
+   *
+   * `workspaceId` is the caller's own workspace, when it can prove one (#695).
+   * Naming it restricts every branch below to targets that provably belong to
+   * it — including the explicit-surfaceId branch, since a surface id from
+   * another workspace is exactly the thing a scoped caller must not reach.
+   * Omitting it keeps the historical unscoped behavior, which is what the
+   * first-party pipe and single-workspace setups rely on.
+   */
+  getTarget(surfaceId?: string, workspaceId?: string): CdpTargetInfo | null {
     if (surfaceId) {
-      return this.sessions.get(surfaceId) ?? null;
+      const session = this.sessions.get(surfaceId) ?? null;
+      return session && ownedBy(session.workspaceId, workspaceId) ? session : null;
     }
-    const first = this.sessions.values().next();
-    return first.done ? null : first.value;
+    // Not "the first session" any more when a scope is named: the first
+    // session in the process routinely belongs to somebody else.
+    for (const session of this.sessions.values()) {
+      if (ownedBy(session.workspaceId, workspaceId)) return session;
+    }
+    return null;
   }
 
   waitForTarget(surfaceId: string, timeoutMs = 5000): Promise<CdpTargetInfo> {

--- a/src/main/browser-session/WebviewCdpManager.ts
+++ b/src/main/browser-session/WebviewCdpManager.ts
@@ -269,8 +269,11 @@ export class WebviewCdpManager {
 
     const pending = this.waiters.get(surfaceId);
     if (pending) {
-      for (const resolve of pending) resolve(info);
-      this.waiters.delete(surfaceId);
+      // Iterate a copy, and let each waiter remove itself once it settles. A
+      // scoped waiter that does not own this registration stays parked instead
+      // of being dropped, so it can still be satisfied by a later one it does
+      // own — or time out exactly like a surface that never existed (#695).
+      for (const resolve of [...pending]) resolve(info);
     }
 
     console.log(`[WebviewCdpManager] Registered surface=${surfaceId} target=${targetId}`);
@@ -415,7 +418,10 @@ export class WebviewCdpManager {
     // as well — a named foreign surface must not be woken either.
     if (!ownedBy(gs.workspaceId, workspaceId)) return null;
     const inFlight = this.waking.get(resolved);
-    if (inFlight) return inFlight;
+    // Joining a wake somebody else started does not inherit their scope: the
+    // shared promise resolves to whatever registered, so this caller applies
+    // its own check to the result.
+    if (inFlight) return inFlight.then((t) => (t && ownedBy(t.workspaceId, workspaceId) ? t : null));
     const sid = resolved;
     const wake = (async (): Promise<CdpTargetInfo | null> => {
       console.log(`[WebviewCdpManager] waking discarded surface=${sid}`);
@@ -434,7 +440,15 @@ export class WebviewCdpManager {
     })();
     this.waking.set(sid, wake);
     try {
-      return await wake;
+      const woken = await wake;
+      // Re-check after the wake, not only before it. Ownership was read off
+      // the pre-wake guest state, and the surface re-registers in between —
+      // commonly by a legacy path that reports no workspace at all, which
+      // would otherwise hand a scoped caller an untagged target that every
+      // later getTarget() refuses. The in-flight wake is also shared, so this
+      // promise may have been started by an unscoped caller; the scope has to
+      // be applied by whoever is receiving, not by whoever started it.
+      return woken && ownedBy(woken.workspaceId, workspaceId) ? woken : null;
     } finally {
       this.waking.delete(sid);
     }
@@ -684,9 +698,20 @@ export class WebviewCdpManager {
     return null;
   }
 
-  waitForTarget(surfaceId: string, timeoutMs = 5000): Promise<CdpTargetInfo> {
+  /**
+   * Wait for a surface's CDP target.
+   *
+   * `workspaceId` makes the wait itself scoped (#695): the promise settles only
+   * on a target the caller owns. That matters more than post-checking the
+   * result. A caller that waits unscoped and refuses afterwards still leaks the
+   * distinction — a live foreign surface answers instantly while a
+   * non-existent one costs the full timeout, so the latency alone says "that
+   * surface exists, just not for you". Waiting for *your* target makes the two
+   * cases identical in message and in timing.
+   */
+  waitForTarget(surfaceId: string, timeoutMs = 5000, workspaceId?: string): Promise<CdpTargetInfo> {
     const existing = this.sessions.get(surfaceId);
-    if (existing) return Promise.resolve(existing);
+    if (existing && ownedBy(existing.workspaceId, workspaceId)) return Promise.resolve(existing);
 
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
@@ -700,7 +725,19 @@ export class WebviewCdpManager {
       }, timeoutMs);
 
       const wrappedResolve = (target: CdpTargetInfo) => {
+        // A registration this caller does not own is not the one it is waiting
+        // for. Stay parked rather than resolving: the surface can still
+        // re-register as ours before the timeout, and settling here would hand
+        // back a foreign target — or, if we merely rejected, restore the
+        // timing tell this scope exists to remove.
+        if (!ownedBy(target.workspaceId, workspaceId)) return;
         clearTimeout(timer);
+        const pending = this.waiters.get(surfaceId);
+        if (pending) {
+          const idx = pending.indexOf(wrappedResolve);
+          if (idx >= 0) pending.splice(idx, 1);
+          if (pending.length === 0) this.waiters.delete(surfaceId);
+        }
         resolve(target);
       };
 

--- a/src/main/browser-session/__tests__/WebviewCdpManager.test.ts
+++ b/src/main/browser-session/__tests__/WebviewCdpManager.test.ts
@@ -585,6 +585,33 @@ describe('WebviewCdpManager discard mode (#517 slice C)', () => {
     expect(onWake).toHaveBeenCalledWith('b-surface');
   });
 
+  it('a scoped caller joining an in-flight wake applies its own check to the result (#695)', async () => {
+    // Concurrent wakes share one promise. Ownership was proven against the
+    // pre-wake guest state, but what actually re-registers can be something
+    // else — here the legacy path that reports no workspace at all. The check
+    // therefore belongs to whoever receives the result, not to whoever started
+    // the wake, and nothing else in the suite covers that branch.
+    const onDiscard = vi.fn((sid: string) => manager.unregister(sid));
+    const onWake = vi.fn((sid: string) => { void manager.register(sid, 43); });
+    manager.setDiscardHooks({ onDiscard, onWake });
+    await manager.register('a-surface', 42, 'ws-A');
+    manager.setLightweightMode(true);
+    manager.setDiscardMode(true);
+    manager.setVisibility('a-surface', false);
+    vi.advanceTimersByTime(DWELL);
+    expect(manager.isDiscarded('a-surface')).toBe(true);
+
+    // An unscoped caller starts the wake; the owner joins that same one.
+    const starter = manager.ensureAwake('a-surface');
+    const joiner = manager.ensureAwake('a-surface', 'ws-A');
+    await vi.advanceTimersByTimeAsync(100);
+
+    // One wake, two receivers, two different answers.
+    expect(onWake).toHaveBeenCalledTimes(1);
+    expect(await starter).not.toBeNull();
+    expect(await joiner).toBeNull();
+  });
+
   it('ensureAwake returns null for a surface that is neither registered nor discarded', async () => {
     const onWake = vi.fn();
     manager.setDiscardHooks({ onWake });

--- a/src/main/browser-session/__tests__/WebviewCdpManager.test.ts
+++ b/src/main/browser-session/__tests__/WebviewCdpManager.test.ts
@@ -145,6 +145,23 @@ describe('WebviewCdpManager workspace scoping (#695)', () => {
     expect(manager.getTarget(undefined, 'ws-A')).toBeNull();
   });
 
+  it('a scoped wait is not settled by a foreign registration, and is by an owned one', async () => {
+    // Post-checking an unscoped wait would leak by latency: a live foreign
+    // surface answers instantly while a missing one costs the whole timeout.
+    // The scoped waiter stays parked instead, so both look identical — and a
+    // parked waiter must survive to be satisfied by a registration it owns.
+    const scoped = manager.waitForTarget('shared-id', 2000, 'ws-A');
+    await manager.register('shared-id', 41, 'ws-B');
+
+    let settled = false;
+    void scoped.then(() => { settled = true; }, () => { settled = true; });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    await manager.register('shared-id', 42, 'ws-A');
+    await expect(scoped).resolves.toMatchObject({ surfaceId: 'shared-id', workspaceId: 'ws-A' });
+  });
+
   it('refuses an untagged target to a scoped caller but still serves an unscoped one', async () => {
     // Ownership is never inferred from being the only candidate — same rule
     // browser.cdp.info applies to the target list (#591).
@@ -542,6 +559,29 @@ describe('WebviewCdpManager discard mode (#517 slice C)', () => {
     const awake = manager.ensureAwake('b-surface', 'ws-B');
     await vi.advanceTimersByTimeAsync(100);
     expect(await awake).not.toBeNull();
+    expect(onWake).toHaveBeenCalledWith('b-surface');
+  });
+
+  it('ensureAwake re-checks ownership after the wake, not only before it (#695)', async () => {
+    // Ownership is read off the pre-wake guest state, but the surface
+    // re-registers in between — here by a legacy path reporting no workspace
+    // at all. Returning that would hand a scoped caller an untagged target
+    // every later getTarget() refuses: authorized once, unusable after.
+    const onDiscard = vi.fn((sid: string) => manager.unregister(sid));
+    const onWake = vi.fn((sid: string) => { void manager.register(sid, 43); });
+    manager.setDiscardHooks({ onDiscard, onWake });
+    await manager.register('b-surface', 42, 'ws-B');
+    manager.setLightweightMode(true);
+    manager.setDiscardMode(true);
+    manager.setVisibility('b-surface', false);
+    vi.advanceTimersByTime(DWELL);
+    expect(manager.isDiscarded('b-surface')).toBe(true);
+
+    const awake = manager.ensureAwake('b-surface', 'ws-B');
+    await vi.advanceTimersByTimeAsync(100);
+    expect(await awake).toBeNull();
+    // The wake itself still happened — this is a refusal to hand back an
+    // unproven target, not a refusal to remount.
     expect(onWake).toHaveBeenCalledWith('b-surface');
   });
 

--- a/src/main/browser-session/__tests__/WebviewCdpManager.test.ts
+++ b/src/main/browser-session/__tests__/WebviewCdpManager.test.ts
@@ -110,6 +110,52 @@ describe('WebviewCdpManager', () => {
   });
 });
 
+// ── #695 workspace-scoped target selection ───────────────────────────────────
+// The default lookup used to answer "the first session in the process", which
+// is whichever workspace happened to open a browser first. A caller that can
+// prove its own workspace now gets only what it can be shown to own.
+describe('WebviewCdpManager workspace scoping (#695)', () => {
+  let manager: WebviewCdpManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new WebviewCdpManager(18800);
+  });
+
+  it('the default lookup stops depending on who registered first', async () => {
+    await manager.register('b-surface', 41, 'ws-B');
+    await manager.register('a-surface', 42, 'ws-A');
+
+    // Unscoped: unchanged, still the first session in the process.
+    expect(manager.getTarget()?.surfaceId).toBe('b-surface');
+    // Scoped: registration order no longer decides whose page you get.
+    expect(manager.getTarget(undefined, 'ws-A')?.surfaceId).toBe('a-surface');
+    expect(manager.getTarget(undefined, 'ws-B')?.surfaceId).toBe('b-surface');
+  });
+
+  it('refuses a named surface belonging to another workspace', async () => {
+    await manager.register('b-surface', 41, 'ws-B');
+    // Naming it exactly is not authority to reach it.
+    expect(manager.getTarget('b-surface')?.surfaceId).toBe('b-surface');
+    expect(manager.getTarget('b-surface', 'ws-A')).toBeNull();
+  });
+
+  it('gives a scoped caller that owns nothing null, never a stranger"s target', async () => {
+    await manager.register('b-surface', 41, 'ws-B');
+    expect(manager.getTarget(undefined, 'ws-A')).toBeNull();
+  });
+
+  it('refuses an untagged target to a scoped caller but still serves an unscoped one', async () => {
+    // Ownership is never inferred from being the only candidate — same rule
+    // browser.cdp.info applies to the target list (#591).
+    await manager.register('legacy', 42);
+    expect(manager.getTarget('legacy')).not.toBeNull();
+    expect(manager.getTarget(undefined)).not.toBeNull();
+    expect(manager.getTarget('legacy', 'ws-A')).toBeNull();
+    expect(manager.getTarget(undefined, 'ws-A')).toBeNull();
+  });
+});
+
 // ── #517 lightweight mode ────────────────────────────────────────────────────
 
 describe('WebviewCdpManager lightweight mode (#517)', () => {
@@ -469,6 +515,34 @@ describe('WebviewCdpManager discard mode (#517 slice C)', () => {
     expect(onWake).toHaveBeenCalledWith('s1');
     expect(target).not.toBeNull();
     expect(manager.isDiscarded('s1')).toBe(false);
+  });
+
+  it('ensureAwake will not wake another workspace"s discarded surface (#695)', async () => {
+    // Waking is not a read. It remounts somebody else's guest and reloads
+    // their page, so an unscoped wake is an action taken inside a workspace
+    // the caller does not own — worth more than the disclosure beside it.
+    const onDiscard = vi.fn((sid: string) => manager.unregister(sid));
+    const onWake = vi.fn((sid: string) => { void manager.register(sid, 43, 'ws-B'); });
+    manager.setDiscardHooks({ onDiscard, onWake });
+    await manager.register('b-surface', 42, 'ws-B');
+    manager.setLightweightMode(true);
+    manager.setDiscardMode(true);
+    manager.setVisibility('b-surface', false);
+    vi.advanceTimersByTime(DWELL);
+    expect(manager.isDiscarded('b-surface')).toBe(true);
+
+    // The default scan finds nothing to wake for ws-A...
+    expect(await manager.ensureAwake(undefined, 'ws-A')).toBeNull();
+    // ...and naming the surface outright does not get past it either.
+    expect(await manager.ensureAwake('b-surface', 'ws-A')).toBeNull();
+    expect(onWake).not.toHaveBeenCalled();
+    expect(manager.isDiscarded('b-surface')).toBe(true);
+
+    // Its own workspace still wakes it — the scope refuses strangers, not owners.
+    const awake = manager.ensureAwake('b-surface', 'ws-B');
+    await vi.advanceTimersByTimeAsync(100);
+    expect(await awake).not.toBeNull();
+    expect(onWake).toHaveBeenCalledWith('b-surface');
   });
 
   it('ensureAwake returns null for a surface that is neither registered nor discarded', async () => {

--- a/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
@@ -761,3 +761,106 @@ describe('browser.screenshot capture fallback (#529)', () => {
     expect(response.ok).toBe(true);
   });
 });
+
+// ── #695 the caller's workspace must reach the target lookup ─────────────────
+// WebviewCdpManager can refuse a foreign target, but only if it is told whose
+// call this is. These cases pin the wiring: without them the scope exists and
+// is never engaged, which is exactly the state #695 describes.
+describe('registerBrowserRpc — workspace scope reaches target selection (#695)', () => {
+  const TARGET = {
+    surfaceId: 'surface-1',
+    webContentsId: 42,
+    targetId: 'target-1',
+    wsUrl: 'ws://127.0.0.1/devtools/page/target-1',
+    workspaceId: 'ws-a',
+  };
+
+  function registerScoped(getTarget = vi.fn(() => TARGET as typeof TARGET | null)) {
+    const router = new RpcRouter();
+    const ensureAwake = vi.fn(async () => null);
+    const cdp = {
+      getTarget,
+      ensureAwake,
+      listTargets: vi.fn(() => [TARGET]),
+      getCdpPort: vi.fn(() => 18800),
+      waitForTarget: vi.fn(async () => TARGET),
+      setCaptureCleanup: vi.fn(),
+      withAutomationLease: vi.fn(async (_s: string, fn: () => Promise<unknown>) => fn()),
+      acquireRpcLease: vi.fn(() => 'lease-1'),
+      renewRpcLease: vi.fn(() => true),
+      releaseRpcLease: vi.fn(() => true),
+    };
+    registerBrowserRpc(router, () => null as unknown as BrowserWindow, cdp as never);
+    return { router, cdp, getTarget, ensureAwake };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWebContents.isDestroyed.mockReturnValue(false);
+    sendToRendererMock.mockResolvedValue({ ok: true });
+  });
+
+  it('passes the caller workspace down on an automation op', async () => {
+    const { router, getTarget } = registerScoped();
+
+    await router.dispatch({
+      id: 'e1',
+      method: 'browser.evaluate',
+      params: { expression: '1+1', surfaceId: 'surface-1', workspaceId: 'ws-a' },
+    });
+
+    expect(getTarget).toHaveBeenCalledWith('surface-1', 'ws-a');
+  });
+
+  it('leaves a caller that names no workspace unscoped, exactly as before', async () => {
+    const { router, getTarget } = registerScoped();
+
+    await router.dispatch({
+      id: 'e2',
+      method: 'browser.evaluate',
+      params: { expression: '1+1' },
+    });
+
+    // undefined scope — the pipe stays same-trust for first-party callers.
+    expect(getTarget).toHaveBeenCalledWith(undefined, undefined);
+  });
+
+  it('scopes the lease path, which resolves a surface before any op runs', async () => {
+    const { router, getTarget, ensureAwake } = registerScoped(vi.fn(() => null));
+
+    await router.dispatch({
+      id: 'l1',
+      method: 'browser.lease.acquire',
+      params: { workspaceId: 'ws-a' },
+    });
+
+    expect(getTarget).toHaveBeenCalledWith(undefined, 'ws-a');
+    expect(ensureAwake).toHaveBeenCalledWith(undefined, 'ws-a');
+  });
+
+  it('browser.cdp.target refuses a foreign surface in the same words as a missing one', async () => {
+    // waitForTarget is exact-match and unscoped, so the refusal has to come
+    // from the re-resolve after it. The message must not distinguish "not
+    // yours" from "not there", or the error becomes the disclosure.
+    const { router } = registerScoped(vi.fn(() => null));
+
+    const foreign = await router.dispatch({
+      id: 'c1',
+      method: 'browser.cdp.target',
+      params: { surfaceId: 'surface-1', workspaceId: 'ws-other' },
+    });
+    const missing = await router.dispatch({
+      id: 'c2',
+      method: 'browser.cdp.target',
+      params: { workspaceId: 'ws-other' },
+    });
+
+    expect(foreign.ok).toBe(true);
+    expect(missing.ok).toBe(true);
+    if (foreign.ok && missing.ok) {
+      expect(foreign.result).toEqual({ error: 'no active browser webview' });
+      expect(foreign.result).toEqual(missing.result);
+      expect(JSON.stringify(foreign.result)).not.toContain('target-1');
+    }
+  });
+});

--- a/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
@@ -814,6 +814,12 @@ describe('registerBrowserRpc — scoped callers stay inside their workspace (#69
     vi.clearAllMocks();
     mockWebContents.isDestroyed.mockReturnValue(false);
     sendToRendererMock.mockResolvedValue({ ok: true });
+    // Primed here, not inherited: without it validateUrl throws a TypeError
+    // and every navigate case below fails before reaching what it tests —
+    // which makes the ok:false assertions pass for the wrong reason and only
+    // shows up when this block is run on its own.
+    validateResolvedNavigationUrlMock.mockResolvedValue({ valid: true });
+    mockWebContents.loadURL.mockResolvedValue(undefined);
   });
 
   it('does not evaluate in a surface owned by another workspace', async () => {
@@ -910,5 +916,124 @@ describe('registerBrowserRpc — scoped callers stay inside their workspace (#69
     expect(response.ok).toBe(true);
     if (response.ok) expect(response.result).toEqual({ token: null });
     expect(cdp.acquireRpcLease).not.toHaveBeenCalled();
+  });
+});
+
+// ── #695 round two: the navigate fallback, in every combination ──────────────
+// The first attempt guarded on `scope && surfaceId`, which left the case the
+// issue is actually about — a scoped caller with no surface id, whose default
+// selection is the workspace-blind one — still falling through. It also refused
+// a caller whose ownership had already been proven and whose CDP call merely
+// failed. Both directions are pinned here.
+describe('registerBrowserRpc — navigate fallback under a scope (#695)', () => {
+  const OWN = {
+    surfaceId: 'own-surface', webContentsId: 42,
+    targetId: 'target-own', wsUrl: 'ws://127.0.0.1/devtools/page/own', workspaceId: 'ws-a',
+  };
+  const FOREIGN = {
+    surfaceId: 'foreign-surface', webContentsId: 43,
+    targetId: 'target-foreign', wsUrl: 'ws://127.0.0.1/devtools/page/foreign', workspaceId: 'ws-b',
+  };
+
+  function registerWith(sessions: Map<string, typeof OWN>) {
+    const owns = (t: typeof OWN, ws?: string) => !ws || t.workspaceId === ws;
+    const cdp = {
+      getTarget: vi.fn((surfaceId?: string, ws?: string) => {
+        if (surfaceId) {
+          const t = sessions.get(surfaceId);
+          return t && owns(t, ws) ? t : null;
+        }
+        for (const t of sessions.values()) if (owns(t, ws)) return t;
+        return null;
+      }),
+      waitForTarget: vi.fn(),
+      ensureAwake: vi.fn(async () => null),
+      listTargets: vi.fn(() => [...sessions.values()]),
+      getCdpPort: vi.fn(() => 18800),
+      setCaptureCleanup: vi.fn(),
+      withAutomationLease: vi.fn(async (_s: string, fn: () => Promise<unknown>) => fn()),
+      acquireRpcLease: vi.fn(() => 'lease-1'),
+      renewRpcLease: vi.fn(() => true),
+      releaseRpcLease: vi.fn(() => true),
+    };
+    const router = new RpcRouter();
+    registerBrowserRpc(router, () => null as unknown as BrowserWindow, cdp as never);
+    return { router, cdp };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWebContents.isDestroyed.mockReturnValue(false);
+    sendToRendererMock.mockResolvedValue({ ok: true });
+    // Primed here, not inherited: without it validateUrl throws a TypeError
+    // and every navigate case below fails before reaching what it tests —
+    // which makes the ok:false assertions pass for the wrong reason and only
+    // shows up when this block is run on its own.
+    validateResolvedNavigationUrlMock.mockResolvedValue({ valid: true });
+    mockWebContents.loadURL.mockResolvedValue(undefined);
+  });
+
+  it('refuses a scoped caller that owns nothing, with no surface id to hide behind', async () => {
+    // The bridge would have picked its own default here — someone else's pane.
+    const { router } = registerWith(new Map([[FOREIGN.surfaceId, FOREIGN]]));
+
+    const response = await router.dispatch({
+      id: 'nv1', method: 'browser.navigate',
+      params: { url: 'https://example.com', workspaceId: 'ws-a' },
+    });
+
+    expect(response.ok).toBe(false);
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+  });
+
+  it('still lets a proven owner use the bridge when CDP itself fails', async () => {
+    // Ownership was established before the CDP attempt, so a loadURL failure
+    // is a transport problem, not an authorization one.
+    mockWebContents.loadURL.mockRejectedValueOnce(new Error('CDP navigation failed'));
+    const { router } = registerWith(new Map([[OWN.surfaceId, OWN]]));
+
+    const response = await router.dispatch({
+      id: 'nv2', method: 'browser.navigate',
+      params: { url: 'https://example.com', surfaceId: OWN.surfaceId, workspaceId: 'ws-a' },
+    });
+
+    expect(response.ok).toBe(true);
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.anything(), 'browser.navigate',
+      expect.objectContaining({ surfaceId: OWN.surfaceId }),
+    );
+  });
+
+  it('pins the bridge to the resolved surface when a scoped caller named none', async () => {
+    // Without this the bridge falls back to its own default pick, which is the
+    // workspace-blind selection the scope just avoided.
+    mockWebContents.loadURL.mockRejectedValueOnce(new Error('CDP navigation failed'));
+    const { router } = registerWith(new Map([[FOREIGN.surfaceId, FOREIGN], [OWN.surfaceId, OWN]]));
+
+    const response = await router.dispatch({
+      id: 'nv3', method: 'browser.navigate',
+      params: { url: 'https://example.com', workspaceId: 'ws-a' },
+    });
+
+    expect(response.ok).toBe(true);
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.anything(), 'browser.navigate',
+      expect.objectContaining({ surfaceId: OWN.surfaceId }),
+    );
+  });
+
+  it('leaves the unscoped fallback exactly as it was', async () => {
+    const { router } = registerWith(new Map());
+
+    const response = await router.dispatch({
+      id: 'nv4', method: 'browser.navigate',
+      params: { url: 'https://example.com' },
+    });
+
+    expect(response.ok).toBe(true);
+    // No surfaceId sent, no workspace pinned — the historical shape.
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.anything(), 'browser.navigate', { url: 'https://example.com' },
+    );
   });
 });

--- a/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
@@ -762,36 +762,52 @@ describe('browser.screenshot capture fallback (#529)', () => {
   });
 });
 
-// ── #695 the caller's workspace must reach the target lookup ─────────────────
-// WebviewCdpManager can refuse a foreign target, but only if it is told whose
-// call this is. These cases pin the wiring: without them the scope exists and
-// is never engaged, which is exactly the state #695 describes.
-describe('registerBrowserRpc — workspace scope reaches target selection (#695)', () => {
-  const TARGET = {
-    surfaceId: 'surface-1',
-    webContentsId: 42,
-    targetId: 'target-1',
-    wsUrl: 'ws://127.0.0.1/devtools/page/target-1',
-    workspaceId: 'ws-a',
+// ── #695 a scoped caller cannot reach another workspace ──────────────────────
+// These drive the handlers against an ownership-enforcing stand-in rather than
+// a permissive spy. Asserting that getTarget was *called* with a workspace
+// would pass just as well if the manager ignored it — the property is that a
+// foreign surface cannot be read, driven, navigated or leased.
+describe('registerBrowserRpc — scoped callers stay inside their workspace (#695)', () => {
+  const OWN = {
+    surfaceId: 'own-surface', webContentsId: 42,
+    targetId: 'target-own', wsUrl: 'ws://127.0.0.1/devtools/page/own', workspaceId: 'ws-a',
+  };
+  const FOREIGN = {
+    surfaceId: 'foreign-surface', webContentsId: 43,
+    targetId: 'target-foreign', wsUrl: 'ws://127.0.0.1/devtools/page/foreign', workspaceId: 'ws-b',
   };
 
-  function registerScoped(getTarget = vi.fn(() => TARGET as typeof TARGET | null)) {
-    const router = new RpcRouter();
-    const ensureAwake = vi.fn(async () => null);
+  function registerScoped() {
+    const sessions = new Map([[OWN.surfaceId, OWN], [FOREIGN.surfaceId, FOREIGN]]);
+    const owns = (t: typeof OWN, ws?: string) => !ws || t.workspaceId === ws;
     const cdp = {
-      getTarget,
-      ensureAwake,
-      listTargets: vi.fn(() => [TARGET]),
+      getTarget: vi.fn((surfaceId?: string, ws?: string) => {
+        if (surfaceId) {
+          const t = sessions.get(surfaceId);
+          return t && owns(t, ws) ? t : null;
+        }
+        for (const t of sessions.values()) if (owns(t, ws)) return t;
+        return null;
+      }),
+      // Scoped wait: a surface the caller does not own is indistinguishable
+      // from one that is not there — both time out.
+      waitForTarget: vi.fn(async (surfaceId: string, _timeout?: number, ws?: string) => {
+        const t = sessions.get(surfaceId);
+        if (t && owns(t, ws)) return t;
+        throw new Error(`timeout waiting for CDP target: ${surfaceId}`);
+      }),
+      ensureAwake: vi.fn(async () => null),
+      listTargets: vi.fn(() => [...sessions.values()]),
       getCdpPort: vi.fn(() => 18800),
-      waitForTarget: vi.fn(async () => TARGET),
       setCaptureCleanup: vi.fn(),
       withAutomationLease: vi.fn(async (_s: string, fn: () => Promise<unknown>) => fn()),
-      acquireRpcLease: vi.fn(() => 'lease-1'),
+      acquireRpcLease: vi.fn((sid: string) => `lease-for-${sid}`),
       renewRpcLease: vi.fn(() => true),
       releaseRpcLease: vi.fn(() => true),
     };
+    const router = new RpcRouter();
     registerBrowserRpc(router, () => null as unknown as BrowserWindow, cdp as never);
-    return { router, cdp, getTarget, ensureAwake };
+    return { router, cdp };
   }
 
   beforeEach(() => {
@@ -800,67 +816,99 @@ describe('registerBrowserRpc — workspace scope reaches target selection (#695)
     sendToRendererMock.mockResolvedValue({ ok: true });
   });
 
-  it('passes the caller workspace down on an automation op', async () => {
-    const { router, getTarget } = registerScoped();
+  it('does not evaluate in a surface owned by another workspace', async () => {
+    const { router } = registerScoped();
 
-    await router.dispatch({
-      id: 'e1',
+    const response = await router.dispatch({
+      id: 'x1',
       method: 'browser.evaluate',
-      params: { expression: '1+1', surfaceId: 'surface-1', workspaceId: 'ws-a' },
+      params: { expression: 'document.cookie', surfaceId: FOREIGN.surfaceId, workspaceId: 'ws-a' },
     });
 
-    expect(getTarget).toHaveBeenCalledWith('surface-1', 'ws-a');
+    expect(response.ok).toBe(false);
+    // The guest was never driven — not merely a refused response after the fact.
+    expect(mockWebContents.debugger.sendCommand).not.toHaveBeenCalled();
   });
 
-  it('leaves a caller that names no workspace unscoped, exactly as before', async () => {
-    const { router, getTarget } = registerScoped();
+  it('still evaluates in a surface the caller does own', async () => {
+    const { router } = registerScoped();
 
-    await router.dispatch({
-      id: 'e2',
+    const response = await router.dispatch({
+      id: 'x2',
       method: 'browser.evaluate',
-      params: { expression: '1+1' },
+      params: { expression: '1+1', surfaceId: OWN.surfaceId, workspaceId: 'ws-a' },
     });
 
-    // undefined scope — the pipe stays same-trust for first-party callers.
-    expect(getTarget).toHaveBeenCalledWith(undefined, undefined);
+    expect(response.ok).toBe(true);
+    expect(mockWebContents.debugger.sendCommand).toHaveBeenCalled();
   });
 
-  it('scopes the lease path, which resolves a surface before any op runs', async () => {
-    const { router, getTarget, ensureAwake } = registerScoped(vi.fn(() => null));
+  it('refuses to navigate a foreign surface instead of handing it to the renderer', async () => {
+    // The renderer bridge resolves a surface id with no workspace check, so
+    // falling through to it would undo the refusal one layer down.
+    const { router } = registerScoped();
 
-    await router.dispatch({
-      id: 'l1',
-      method: 'browser.lease.acquire',
-      params: { workspaceId: 'ws-a' },
+    const response = await router.dispatch({
+      id: 'n1',
+      method: 'browser.navigate',
+      params: { url: 'https://example.com', surfaceId: FOREIGN.surfaceId, workspaceId: 'ws-a' },
     });
 
-    expect(getTarget).toHaveBeenCalledWith(undefined, 'ws-a');
-    expect(ensureAwake).toHaveBeenCalledWith(undefined, 'ws-a');
+    expect(response.ok).toBe(false);
+    expect(sendToRendererMock).not.toHaveBeenCalled();
   });
 
-  it('browser.cdp.target refuses a foreign surface in the same words as a missing one', async () => {
-    // waitForTarget is exact-match and unscoped, so the refusal has to come
-    // from the re-resolve after it. The message must not distinguish "not
-    // yours" from "not there", or the error becomes the disclosure.
-    const { router } = registerScoped(vi.fn(() => null));
+  it('keeps the renderer navigate fallback for an unscoped caller', async () => {
+    // Packaged builds route the whole tool set through this path; only a
+    // caller that named a workspace loses it.
+    const { router } = registerScoped();
+
+    const response = await router.dispatch({
+      id: 'n2',
+      method: 'browser.navigate',
+      params: { url: 'https://example.com', surfaceId: 'ghost-surface' },
+    });
+
+    expect(response.ok).toBe(true);
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.anything(), 'browser.navigate',
+      expect.objectContaining({ surfaceId: 'ghost-surface' }),
+    );
+  });
+
+  it('browser.cdp.target answers a foreign surface exactly as it answers a missing one', async () => {
+    // Not compared against the no-surfaceId case — that one legitimately
+    // differs. The pair that must be indistinguishable is "exists, not yours"
+    // versus "does not exist", in message and in the path taken to get there.
+    const { router } = registerScoped();
 
     const foreign = await router.dispatch({
-      id: 'c1',
-      method: 'browser.cdp.target',
-      params: { surfaceId: 'surface-1', workspaceId: 'ws-other' },
+      id: 'c1', method: 'browser.cdp.target',
+      params: { surfaceId: FOREIGN.surfaceId, workspaceId: 'ws-a' },
     });
     const missing = await router.dispatch({
-      id: 'c2',
-      method: 'browser.cdp.target',
-      params: { workspaceId: 'ws-other' },
+      id: 'c2', method: 'browser.cdp.target',
+      params: { surfaceId: 'no-such-surface', workspaceId: 'ws-a' },
     });
 
     expect(foreign.ok).toBe(true);
     expect(missing.ok).toBe(true);
     if (foreign.ok && missing.ok) {
-      expect(foreign.result).toEqual({ error: 'no active browser webview' });
       expect(foreign.result).toEqual(missing.result);
-      expect(JSON.stringify(foreign.result)).not.toContain('target-1');
+      expect(JSON.stringify(foreign.result)).not.toContain('target-foreign');
     }
+  });
+
+  it('never leases a foreign surface for a scoped caller', async () => {
+    const { router, cdp } = registerScoped();
+
+    const response = await router.dispatch({
+      id: 'l1', method: 'browser.lease.acquire',
+      params: { surfaceId: FOREIGN.surfaceId, workspaceId: 'ws-a' },
+    });
+
+    expect(response.ok).toBe(true);
+    if (response.ok) expect(response.result).toEqual({ token: null });
+    expect(cdp.acquireRpcLease).not.toHaveBeenCalled();
   });
 });

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -399,14 +399,23 @@ export function registerBrowserRpc(
       }
     }
 
-    // Fallback to renderer bridge. The renderer resolves a surface id without
-    // any workspace check, so a scoped caller that just failed the lookup
-    // above must not be handed this path: forwarding the same foreign
-    // surfaceId one layer down would drive the pane the scope just refused,
-    // and the refusal would have bought nothing (#695). Unscoped callers keep
-    // the fallback — it is the packaged-build route for the whole tool set.
-    if (scopeOf(params) && surfaceId) {
-      throw new Error('browser.navigate: no webview target registered');
+    // Fallback to the renderer bridge, which resolves a surface with no
+    // workspace check of its own — it picks the caller-supplied id, or its own
+    // default when there is none. Neither choice is safe to hand a scoped
+    // caller unless this side has already proven ownership (#695).
+    if (scopeOf(params)) {
+      // No target means the scoped lookup refused one, or there is none to
+      // own. Routing that to the bridge would reinstate exactly the
+      // workspace-blind selection this change removes, so refuse instead.
+      if (!target) throw new Error('browser.navigate: no webview target registered');
+      // A target did resolve and CDP merely failed on it. Ownership is already
+      // established, so the bridge is fine — but pin it to that exact surface.
+      // Leaving the id absent would let the bridge choose its own default,
+      // which is the workspace-blind pick all over again.
+      return sendToRenderer(getWindow, 'browser.navigate', {
+        url: params['url'],
+        surfaceId: target.surfaceId,
+      });
     }
     return sendToRenderer(getWindow, 'browser.navigate', {
       url: params['url'],

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -399,7 +399,15 @@ export function registerBrowserRpc(
       }
     }
 
-    // Fallback to renderer bridge
+    // Fallback to renderer bridge. The renderer resolves a surface id without
+    // any workspace check, so a scoped caller that just failed the lookup
+    // above must not be handed this path: forwarding the same foreign
+    // surfaceId one layer down would drive the pane the scope just refused,
+    // and the refusal would have bought nothing (#695). Unscoped callers keep
+    // the fallback — it is the packaged-build route for the whole tool set.
+    if (scopeOf(params) && surfaceId) {
+      throw new Error('browser.navigate: no webview target registered');
+    }
     return sendToRenderer(getWindow, 'browser.navigate', {
       url: params['url'],
       ...(surfaceId && { surfaceId }),
@@ -926,15 +934,12 @@ export function registerBrowserRpc(
 
     if (surfaceId) {
       try {
-        const target = await webviewCdpManager.waitForTarget(surfaceId, 5000);
-        // waitForTarget is exact-match on surfaceId and applies no scope, so
-        // re-resolve through the scoped lookup before handing an id back. The
-        // refusal reuses the no-target message on purpose: "that surface is
-        // not yours" and "there is no such surface" must read the same, or the
-        // error itself becomes the disclosure this handler is closing.
-        if (!webviewCdpManager.getTarget(surfaceId, scopeOf(params))) {
-          return { error: 'no active browser webview' };
-        }
+        // The wait itself carries the scope, so a live-but-foreign surface is
+        // indistinguishable from one that never existed — same message, same
+        // latency. Post-checking an unscoped wait would not achieve that: the
+        // foreign case answers instantly and the missing case costs the full
+        // timeout, and that difference is itself the disclosure.
+        const target = await webviewCdpManager.waitForTarget(surfaceId, 5000, scopeOf(params));
         return {
           targetId: target.targetId,
           surfaceId: target.surfaceId,

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -93,14 +93,32 @@ export function registerBrowserRpc(
   // a call without a surfaceId would then automate a pane its caller does not
   // own instead of delegating/failing closed (codex P1). With an explicit
   // surfaceId both lookups are exact-match, so mixed mode still works.
-  const resolveTargetSurface = async (surfaceId: string | undefined): Promise<string | undefined> => {
+  const resolveTargetSurface = async (
+    surfaceId: string | undefined,
+    workspaceId: string | undefined,
+  ): Promise<string | undefined> => {
     if (backend() === 'external' && !surfaceId) return undefined;
-    let resolved = webviewCdpManager.getTarget(surfaceId)?.surfaceId;
+    let resolved = webviewCdpManager.getTarget(surfaceId, workspaceId)?.surfaceId;
     if (!resolved) {
-      resolved = (await webviewCdpManager.ensureAwake(surfaceId))?.surfaceId;
+      resolved = (await webviewCdpManager.ensureAwake(surfaceId, workspaceId))?.surfaceId;
     }
     return resolved;
   };
+
+  /**
+   * The caller's own workspace, when it sent one (#695).
+   *
+   * Passing it to getTarget/ensureAwake is what stops a target lookup from
+   * landing on another workspace's guest. A caller that sends nothing is
+   * unscoped exactly as before — the pipe is same-trust for first-party CLI
+   * callers, and single-workspace setups would otherwise break for no gain.
+   * Every scoped lookup below reads it from params here rather than through a
+   * wrapper, so the scope is visible at each site it is meant to protect.
+   */
+  const scopeOf = (params: Record<string, unknown>): string | undefined =>
+    typeof params['workspaceId'] === 'string' && params['workspaceId'].length > 0
+      ? params['workspaceId']
+      : undefined;
 
   // Resolve the guest webview's WebContents for a CDP-backed handler, throwing a
   // method-tagged error if no target is registered or the WebContents is gone.
@@ -109,12 +127,16 @@ export function registerBrowserRpc(
   // Single choke point for the external-backend contract error: a miss while the
   // backend is 'external' means the caller is asking for deep automation that
   // external mode cannot provide — say so explicitly instead of "no target".
-  const resolveWc = (surfaceId: string | undefined, method: string): Electron.WebContents => {
+  const resolveWc = (
+    surfaceId: string | undefined,
+    method: string,
+    workspaceId?: string,
+  ): Electron.WebContents => {
     // Same default-target rule as resolveTargetSurface: external + no
     // surfaceId must not grab another workspace's pane via the default lookup.
     const target = backend() === 'external' && !surfaceId
       ? null
-      : webviewCdpManager.getTarget(surfaceId);
+      : webviewCdpManager.getTarget(surfaceId, workspaceId);
     if (!target) {
       if (backend() === 'external') throw new Error(EXTERNAL_BACKEND_UNSUPPORTED_MESSAGE);
       throw new Error(`${method}: no webview target registered`);
@@ -152,7 +174,7 @@ export function registerBrowserRpc(
       // (codex P1 — otherwise the default MCP path fails once the only pane is
       // discarded). In EXTERNAL mode the default lookup is blocked entirely —
       // see resolveTargetSurface.
-      const resolved = await resolveTargetSurface(surfaceId);
+      const resolved = await resolveTargetSurface(surfaceId, scopeOf(params));
       if (!resolved) {
         if (backend() === 'external') {
           if (externalFallback) return externalFallback(params);
@@ -175,7 +197,7 @@ export function registerBrowserRpc(
     // live target under its lease (#517 slice C). Without surfaceId this
     // defaults to any discarded surface in builtin mode; external mode blocks
     // the default lookup (see resolveTargetSurface).
-    const resolved = await resolveTargetSurface(surfaceId);
+    const resolved = await resolveTargetSurface(surfaceId, scopeOf(params));
     if (!resolved) return { token: null };
     return { token: webviewCdpManager.acquireRpcLease(resolved) };
   });
@@ -364,7 +386,7 @@ export function registerBrowserRpc(
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
 
     // Try CDP direct navigation first
-    const target = webviewCdpManager.getTarget(surfaceId);
+    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
     if (target) {
       try {
         const wc = webContents.fromId(target.webContentsId);
@@ -396,7 +418,7 @@ export function registerBrowserRpc(
   registerLeased('browser.goBack', async (params) => {
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
 
-    const target = webviewCdpManager.getTarget(surfaceId);
+    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
     if (!target) throw new Error('browser.goBack: no webview target registered');
 
     const wc = webContents.fromId(target.webContentsId);
@@ -626,7 +648,7 @@ export function registerBrowserRpc(
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
     const fullPage = params['fullPage'] === true;
 
-    const target = webviewCdpManager.getTarget(surfaceId);
+    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
     if (!target) throw new Error('browser.screenshot: no webview target registered');
 
     const wc = webContents.fromId(target.webContentsId);
@@ -694,7 +716,7 @@ export function registerBrowserRpc(
     if (!expression) throw new Error('browser.evaluate: missing "expression"');
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
 
-    const target = webviewCdpManager.getTarget(surfaceId);
+    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
     if (!target) throw new Error('browser.evaluate: no webview target registered');
 
     const wc = webContents.fromId(target.webContentsId);
@@ -738,7 +760,7 @@ export function registerBrowserRpc(
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
     const clear = params['clear'] === true;
 
-    const target = webviewCdpManager.getTarget(surfaceId);
+    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
     if (!target) throw new Error('browser.console.get: no webview target registered');
 
     const state = await captureManager.ensure(target.webContentsId);
@@ -759,7 +781,7 @@ export function registerBrowserRpc(
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
     const clear = params['clear'] === true;
 
-    const target = webviewCdpManager.getTarget(surfaceId);
+    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
     if (!target) throw new Error('browser.network.get: no webview target registered');
 
     const state = await captureManager.ensure(target.webContentsId);
@@ -780,7 +802,7 @@ export function registerBrowserRpc(
     const urlPattern = typeof params['urlPattern'] === 'string' ? params['urlPattern'] : '';
     if (!urlPattern) throw new Error('browser.responseBody.get: missing "urlPattern"');
 
-    const target = webviewCdpManager.getTarget(surfaceId);
+    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
     if (!target) throw new Error('browser.responseBody.get: no webview target registered');
 
     const state = await captureManager.ensure(target.webContentsId);
@@ -801,7 +823,7 @@ export function registerBrowserRpc(
     if (!text) throw new Error('browser.type.cdp: missing "text"');
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
 
-    const target = webviewCdpManager.getTarget(surfaceId);
+    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
     if (!target) throw new Error('browser.type.cdp: no webview target registered');
 
     const wc = webContents.fromId(target.webContentsId);
@@ -821,7 +843,7 @@ export function registerBrowserRpc(
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
     const selector = typeof params['selector'] === 'string' ? params['selector'] : undefined;
 
-    const target = webviewCdpManager.getTarget(surfaceId);
+    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
     if (!target) throw new Error('browser.click.cdp: no webview target registered');
 
     const wc = webContents.fromId(target.webContentsId);
@@ -877,7 +899,7 @@ export function registerBrowserRpc(
     if (!key) throw new Error('browser.press.cdp: missing "key"');
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
 
-    const target = webviewCdpManager.getTarget(surfaceId);
+    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
     if (!target) throw new Error('browser.press.cdp: no webview target registered');
 
     const wc = webContents.fromId(target.webContentsId);
@@ -905,6 +927,14 @@ export function registerBrowserRpc(
     if (surfaceId) {
       try {
         const target = await webviewCdpManager.waitForTarget(surfaceId, 5000);
+        // waitForTarget is exact-match on surfaceId and applies no scope, so
+        // re-resolve through the scoped lookup before handing an id back. The
+        // refusal reuses the no-target message on purpose: "that surface is
+        // not yours" and "there is no such surface" must read the same, or the
+        // error itself becomes the disclosure this handler is closing.
+        if (!webviewCdpManager.getTarget(surfaceId, scopeOf(params))) {
+          return { error: 'no active browser webview' };
+        }
         return {
           targetId: target.targetId,
           surfaceId: target.surfaceId,
@@ -914,7 +944,7 @@ export function registerBrowserRpc(
       }
     }
 
-    const target = webviewCdpManager.getTarget();
+    const target = webviewCdpManager.getTarget(undefined, scopeOf(params));
     if (!target) return { error: 'no active browser webview' };
 
     return {
@@ -942,7 +972,7 @@ export function registerBrowserRpc(
   registerLeased('browser.cookies', async (params) => {
     const action = params['action'];
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
-    const wc = resolveWc(surfaceId, 'browser.cookies');
+    const wc = resolveWc(surfaceId, 'browser.cookies', scopeOf(params));
 
     if (action === 'get') {
       const urls = Array.isArray(params['urls'])
@@ -999,7 +1029,7 @@ export function registerBrowserRpc(
       throw new Error('browser.resize: width and height must be numbers');
     }
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
-    const wc = resolveWc(surfaceId, 'browser.resize');
+    const wc = resolveWc(surfaceId, 'browser.resize', scopeOf(params));
     await wc.debugger.sendCommand('Emulation.setDeviceMetricsOverride', {
       width, height, deviceScaleFactor: 0, mobile: false,
     });
@@ -1021,7 +1051,7 @@ export function registerBrowserRpc(
    */
   registerLeased('browser.emulate', async (params) => {
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
-    const wc = resolveWc(surfaceId, 'browser.emulate');
+    const wc = resolveWc(surfaceId, 'browser.emulate', scopeOf(params));
     const send = (method: string, p?: Record<string, unknown>): Promise<unknown> =>
       wc.debugger.sendCommand(method, p);
     const applied: string[] = [];


### PR DESCRIPTION
First of the two halves you sketched on #695: the main-side authority. The MCP client half is deliberately separate — see *Scope*, which also carries one correction to the sketch.

## The lookup

One `WebviewCdpManager` serves every workspace in the process. `getTarget(surfaceId?)` answered `this.sessions.values().next()` when given no surface — the first live session, which is whichever workspace opened a browser first — and returned any named surface outright when given one. `ensureAwake()` matched it and went further: with nothing live it remounts and reloads a discarded guest. That is not a read. It is an action taken inside a workspace the caller does not own.

`getTarget`, `ensureAwake` and `waitForTarget` now take the caller's workspace.

- Naming one restricts **every** branch to targets that provably belong to it, the explicit-`surfaceId` branch included — a surface id from another workspace is precisely what a scoped caller must not reach.
- Ownership is never inferred from being the only candidate: an untagged target is refused rather than assumed, the rule `browser.cdp.info` already applies to the target list (#591).
- Naming none is unscoped exactly as before. The pipe is same-trust for first-party CLI callers and single-workspace setups would break for no gain — the compatibility note in your sketch.

The wake path needs the owner to outlive the session, because a discarded guest has none, so `GuestState` mirrors the workspace reported at register time — recorded when known, never cleared, so a legacy re-registration that omits the id cannot downgrade a surface whose owner is already established. Ownership is re-checked *after* the wake as well as before it: the surface re-registers in between, commonly by a path that reports no workspace at all. The wake promise is shared between concurrent callers, so that check belongs to whoever receives the result rather than whoever started it.

## Two places the scope had to reach further than the lookup

**`browser.cdp.target` was an existence oracle.** Post-checking an unscoped wait cannot hide anything: a live foreign surface answers instantly, a surface that never existed costs the full timeout, and the latency alone says which is which. `waitForTarget` now carries the scope and stays parked on a registration the caller does not own, so the two cases are identical in message and in timing. `register()` no longer drops parked waiters, so one still owed its own registration can receive it.

**`browser.navigate` falls back to the renderer bridge**, and that bridge resolves a surface with no workspace check — it takes the caller's id, or picks its own default when there is none. Neither is safe to hand a scoped caller unless this side has already proven ownership. A scoped caller that resolves no target is now refused; one that resolved a target keeps the bridge, pinned to that exact surface, because leaving the id absent hands the choice back to the default pick this change exists to remove. Unscoped callers are untouched. This is the only renderer fallback that dropped the workspace — `browser.tabs` and `browser.close` already forward it (#575, #586).

## Scope

**Nothing changes behavior today.** No caller sends a `workspaceId` to any of these RPCs yet — `browser.cdp.info` and `browser.open` are the only two that carry one, and neither resolves a target through these lookups. This PR adds the authority; the follow-up makes the MCP tools exercise it.

That split is also where the sketch needs a correction: it says the MCP tools *"hold `requireWorkspaceId` already"*. They do not. `src/mcp/index.ts:836` injects the resolver into `registerNavigationTools` only — `registerInspectionTools`, `registerInteractionTools`, `registerStateTools` and `registerExtractionTools` take `(server)` and nothing else. So the client half is not a field added to a few `sendRpc` calls; it needs the resolver threaded into four more modules, or routed through the `PlaywrightEngine` singleton that already holds one. Worth deciding before that PR is written.

Deliberately left, each cheap to overrule:

- **Lease acquisition is not atomic with the ownership check.** `resolveTargetSurface` returns a surface id and the lease is taken after an await. For that id to become foreign the renderer would have to register the same surface id under a different workspace; and because each handler re-resolves under its own scope, the bounded worst case is briefly unthrottling a foreign guest, not driving it.
- **`register()`'s `workspaceId ?? prev?.workspaceId` inheritance** is pre-existing #554 lifecycle behavior. Rebinding ownership semantics is a separate change.
- **Renderer-side navigate scoping.** A `decideBrowserNavigate` mirroring #586's `decideBrowserClose` would let a scoped caller be *routed* instead of refused. That is renderer work, not main-side authority.
- **No changelog fragment**, since nothing user-visible changes until the client half lands. Happy to add one there, or here if you would rather it be recorded now.

## Verification

- `npx vitest run src/main/browser-session/__tests__ src/main/pipe/handlers/__tests__ --maxWorkers=1` → 640 passed
- Wider sweep including `src/mcp/playwright/__tests__` → one failure, `lazyPlaywright.test.ts > loads playwright-core on first call` at 11.4s against the 5s default. It passes alone on this branch **and** on unmodified `origin/main`, reddening only under batch load — the same one-time-cost-inside-a-per-test-budget shape as #689/#690, here from loading `playwright-core`. Not caused by this change.
- Mutation-checked against unmodified `origin/main`: thirteen of the added cases fail there. The four that pass are the compatibility assertions — they pin *historical* unscoped behavior, so passing on `main` is what they are for.
- Each security check was verified to have something holding it. Deleting the in-flight wake join check left all 639 tests green; that branch now has a case that fails without it.
- `npx tsc -p tsconfig.json --noEmit`
- ESLint on the four changed files: 9 problems, 3 errors — byte-identical to the same files on `main`. (Pre-existing `no-empty-function` on `new Promise(() => {})`.)
- `git diff --check origin/main..HEAD`

The four commits are the review trail: the first is the change, the next two respond to findings from independent review rounds, the fourth closes a coverage gap. Squash as you see fit.

Refs #695.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Access Control**
  * Workspace-scoped browser operations now restrict target selection, navigation, automation, screenshots, input, and state access to owned surfaces.
  * Unauthorized or untagged targets are rejected for scoped requests, preventing cross-workspace access and existence leaks.
  * Wake-up and remount flows re-check ownership before returning a target.

* **Compatibility**
  * Unscoped browser requests retain their existing behavior.
  * Renderer-based navigation continues to work for verified owned surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->