### PR TITLE
fix(channels): wake idle agents after daemon restart

### DIFF
--- a/changelog.d/705.md
+++ b/changelog.d/705.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Channel delivery wakes idle agents again after a daemon restart.** Restart
+  recovery marks every pane principal stale, and an agent that has finished and
+  is waiting produces no output to refresh that flag, so the wake worker could
+  leave it unwakeable indefinitely. The registry now supplies only the pane's
+  PTY coordinate; the daemon's rebuilt attached/detached session table decides
+  whether that target is live. Exact principal targets that cannot be verified
+  are skipped rather than redirected to a sibling agent. (#705)

--- a/src/daemon/channels/__tests__/channelWakeWorker.test.ts
+++ b/src/daemon/channels/__tests__/channelWakeWorker.test.ts
@@ -398,7 +398,7 @@ describe('pickTarget — never guess', () => {
 describe('pickTargetWithPrincipal — R2 registry direct targeting', () => {
   const PID = 'pane:ws-b/p1';
 
-  it('directly selects the LIVE principal\'s ptyId session without the heuristic (auto-name memberId)', () => {
+  it('directly selects the principal ptyId present in the live snapshot without the heuristic (auto-name memberId)', () => {
     // memberId "w2-1(codex)" never matches the slug heuristic — without the
     // principal path this member would never get nudged. With two same-slug
     // panes the heuristic would have returned null on ambiguity.
@@ -412,7 +412,7 @@ describe('pickTargetWithPrincipal — R2 registry direct targeting', () => {
     expect(target?.id).toBe('pty-y');
   });
 
-  it('a stale principal (undefined ptyId) falls back to the existing heuristic', () => {
+  it('a missing principal coordinate falls back to the existing heuristic', () => {
     const target = pickTargetWithPrincipal(
       [session({ id: 'only', lastDetectedAgent: 'codex' })],
       'ws-b',
@@ -501,7 +501,7 @@ describe('pickTargetWithPrincipal — R2 registry direct targeting', () => {
 
   it('the heuristic fallback carries the same agent-required discipline (no shell nudge)', () => {
     const PID2 = 'pane:ws-b/pX';
-    // Stale principal → heuristic fallback; the only pane is an agent-less
+    // Missing principal coordinate → heuristic fallback; the only pane is an agent-less
     // shell → null (never auto-submit into a bare shell).
     expect(
       pickTargetWithPrincipal(

--- a/src/daemon/channels/__tests__/channelWakeWorker.test.ts
+++ b/src/daemon/channels/__tests__/channelWakeWorker.test.ts
@@ -16,6 +16,14 @@ import {
   type WakeUnreadEntry,
   type WakeSessionView,
 } from '../channelWakeWorker';
+import {
+  PrincipalService,
+  type PrincipalWriterLike,
+} from '../../principals/PrincipalService';
+import {
+  panePrincipalId,
+  type PrincipalState,
+} from '../../../shared/principals';
 
 function entry(partial: Partial<WakeUnreadEntry>): WakeUnreadEntry {
   return {
@@ -53,7 +61,9 @@ interface Harness {
   setWriteError(err: Error | null): void;
 }
 
-function makeHarness(): Harness {
+function makeHarness(
+  principalPtyIdOf?: (principalId: string) => string | undefined,
+): Harness {
   let entries: WakeUnreadEntry[] = [];
   let sessions: WakeSessionView[] = [];
   let nowMs = 1_000_000;
@@ -65,6 +75,7 @@ function makeHarness(): Harness {
     memberWorkspaces: () => ['ws-b'],
     unreadFor: () => entries,
     listLiveSessions: () => sessions,
+    principalPtyIdOf,
     write: (sessionId, data) => {
       if (writeError) throw writeError;
       writes.push({ sessionId, data });
@@ -94,6 +105,41 @@ afterEach(() => {
 });
 
 const flushEnter = () => vi.advanceTimersByTime(5);
+
+function restartedPrincipalService(
+  principalId: string,
+  workspaceId: string,
+  paneId: string,
+  ptyId: string,
+): PrincipalService {
+  const persisted: PrincipalState = {
+    version: 1,
+    principals: [{
+      id: principalId,
+      kind: 'pane-agent',
+      display: 'w2-1(codex)',
+      reachability: 'pty-nudge',
+      liveness: 'live',
+      workspaceId,
+      paneId,
+      ptyId,
+      memberId: 'w2-1(codex)',
+      agentSlug: 'codex',
+      createdAt: 1,
+      lastSeenAt: 1,
+    }],
+  };
+  const clone = (): PrincipalState => ({
+    version: persisted.version,
+    principals: persisted.principals.map((principal) => ({ ...principal })),
+  });
+  const writer: PrincipalWriterLike = {
+    load: clone,
+    saveImmediate: () => true,
+    saveDebounced: () => undefined,
+  };
+  return new PrincipalService({ writer, now: () => 2 });
+}
 
 describe('ChannelWakeWorker — injection mechanics', () => {
   it('injects the nudge line and the Enter as TWO separate writes (F2)', () => {
@@ -143,6 +189,47 @@ describe('ChannelWakeWorker — injection mechanics', () => {
     h.worker.tickOnce();
     // eslint-disable-next-line no-control-regex
     expect(h.writes[0].data).not.toMatch(/[\x00-\x1f\x7f]/);
+  });
+});
+
+describe('ChannelWakeWorker — principal routing after daemon restart', () => {
+  it('wakes the exact rebuilt live session even though its registry row was backfilled stale', () => {
+    const principalId = panePrincipalId('ws-b', 'pane-1');
+    const principalService = restartedPrincipalService(
+      principalId,
+      'ws-b',
+      'pane-1',
+      'pty-exact',
+    );
+    expect(principalService.find(principalId)?.liveness).toBe('stale');
+
+    const h = makeHarness((id) => principalService.ptyIdOf(id));
+    h.setEntries([entry({ memberId: 'w2-1(codex)', principalId, mentionUnread: 1 })]);
+    h.setSessions([
+      session({ id: 'pty-sibling', lastDetectedAgent: 'codex' }),
+      session({ id: 'pty-exact', lastDetectedAgent: 'codex' }),
+    ]);
+
+    h.worker.tickOnce();
+    expect(h.writes).toEqual([
+      expect.objectContaining({ sessionId: 'pty-exact' }),
+    ]);
+    flushEnter();
+    expect(h.writes.map((write) => write.sessionId)).toEqual([
+      'pty-exact',
+      'pty-exact',
+    ]);
+  });
+
+  it('does not wake a sibling when the stable principal target is no longer live', () => {
+    const principalId = panePrincipalId('ws-b', 'pane-gone');
+    const h = makeHarness((id) => (id === principalId ? 'pty-gone' : undefined));
+    h.setEntries([entry({ memberId: 'codex', principalId, mentionUnread: 1 })]);
+    h.setSessions([session({ id: 'pty-sibling', lastDetectedAgent: 'codex' })]);
+
+    h.worker.tickOnce();
+    flushEnter();
+    expect(h.writes).toEqual([]);
   });
 });
 
@@ -412,7 +499,7 @@ describe('pickTargetWithPrincipal — R2 registry direct targeting', () => {
     expect(target?.id).toBe('pty-y');
   });
 
-  it('a missing principal coordinate falls back to the existing heuristic', () => {
+  it('a missing exact principal coordinate fails closed instead of waking a sibling', () => {
     const target = pickTargetWithPrincipal(
       [session({ id: 'only', lastDetectedAgent: 'codex' })],
       'ws-b',
@@ -420,12 +507,10 @@ describe('pickTargetWithPrincipal — R2 registry direct targeting', () => {
       PID,
       () => undefined,
     );
-    // Fallback rule 3: the only eligible agent session (a bare shell would
-    // hand off to polling — see the agent-required fallback test).
-    expect(target?.id).toBe('only');
+    expect(target).toBeNull();
   });
 
-  it('falls back if the session the registry points to is dead (race), and does not assert on workspace mismatch', () => {
+  it('refuses a dead exact principal target or workspace mismatch rather than waking a sibling', () => {
     const dead = pickTargetWithPrincipal(
       [session({ id: 'other', lastDetectedAgent: 'codex' })],
       'ws-b',
@@ -433,7 +518,7 @@ describe('pickTargetWithPrincipal — R2 registry direct targeting', () => {
       PID,
       () => 'pty-gone',
     );
-    expect(dead?.id).toBe('other'); // heuristic rule 2 (slug match)
+    expect(dead).toBeNull();
 
     const wsMismatch = pickTargetWithPrincipal(
       [session({ id: 'pty-z', workspaceId: 'ws-OTHER', lastDetectedAgent: 'codex' })],
@@ -464,7 +549,7 @@ describe('pickTargetWithPrincipal — R2 registry direct targeting', () => {
     expect(pickTargetWithPrincipal(sessions, 'ws-b', 'codex', undefined, undefined)?.id).toBe('b');
   });
 
-  it('a principal DIRECT HIT on an agent-less session falls through to the heuristic (no shell nudge)', () => {
+  it('an agent-less exact principal target fails closed instead of waking a sibling', () => {
     // Codex micro-pass on the shell-nudge fix: a registry row's ptyId can
     // outlive the agent (agent exits, pane keeps its shell, row stays live
     // until the next upsert/purge). The direct-hit branch must carry the
@@ -481,10 +566,8 @@ describe('pickTargetWithPrincipal — R2 registry direct targeting', () => {
         () => 'was-agent-now-shell',
       ),
     ).toBeNull();
-    // Direct hit agent-less, but the heuristic SLUG-MATCHES a real agent
-    // pane → the fall-through still delivers. (With an auto-name memberId
-    // the two-pane case stays null — the heuristic never guesses between a
-    // shell and an unmatched agent pane; that ambiguity rule is unchanged.)
+    // Even a slug-matching sibling must not receive a nudge addressed to the
+    // principal whose exact pane has fallen back to a shell.
     expect(
       pickTargetWithPrincipal(
         [
@@ -495,13 +578,13 @@ describe('pickTargetWithPrincipal — R2 registry direct targeting', () => {
         'codex',
         PID3,
         () => 'was-agent-now-shell',
-      )?.id,
-    ).toBe('real-agent');
+      ),
+    ).toBeNull();
   });
 
-  it('the heuristic fallback carries the same agent-required discipline (no shell nudge)', () => {
+  it('the legacy heuristic fallback carries the same agent-required discipline (no shell nudge)', () => {
     const PID2 = 'pane:ws-b/pX';
-    // Missing principal coordinate → heuristic fallback; the only pane is an agent-less
+    // No principal resolver (legacy wiring); the only pane is an agent-less
     // shell → null (never auto-submit into a bare shell).
     expect(
       pickTargetWithPrincipal(
@@ -509,7 +592,7 @@ describe('pickTargetWithPrincipal — R2 registry direct targeting', () => {
         'ws-b',
         'w2-1(codex)',
         PID2,
-        () => undefined,
+        undefined,
       ),
     ).toBeNull();
     // …but a lone AGENT pane still gets the fallback nudge.
@@ -519,7 +602,7 @@ describe('pickTargetWithPrincipal — R2 registry direct targeting', () => {
         'ws-b',
         'w2-1(codex)',
         PID2,
-        () => undefined,
+        undefined,
       )?.id,
     ).toBe('agent');
   });

--- a/src/daemon/channels/channelWakeWorker.ts
+++ b/src/daemon/channels/channelWakeWorker.ts
@@ -87,10 +87,11 @@ export interface ChannelWakeWorkerDeps {
   unreadFor(workspaceId: string): WakeUnreadEntry[];
   /** Live sessions only (attached/detached — a usable PTY child exists). */
   listLiveSessions(): WakeSessionView[];
-  /** R2 — principal registry lookup: returns the ptyId (session id) of a LIVE
-   *  principal only. Stale → undefined → falls back to the existing heuristic.
-   *  Optional (test / legacy-wiring compatible). */
-  livePtyIdOf?(principalId: string): string | undefined;
+  /** R2 — principal registry lookup: returns the last registered ptyId
+   *  coordinate without interpreting registry liveness. This worker proves
+   *  liveness against listLiveSessions(), whose attached/detached snapshot is
+   *  daemon-owned and survives a restart. Optional (test / legacy compatible). */
+  principalPtyIdOf?(principalId: string): string | undefined;
   /** Write raw bytes into a session's PTY stdin. */
   write(sessionId: string, data: string): void;
   /** Broadcast a daemon event (nudge exhaustion → human attention). */
@@ -291,7 +292,7 @@ export class ChannelWakeWorker {
           ws,
           entry.memberId,
           entry.principalId,
-          this.deps.livePtyIdOf?.bind(this.deps),
+          this.deps.principalPtyIdOf?.bind(this.deps),
         );
         if (!target) {
           // Ambiguity / no live pane / claude-only / agent-less shells →
@@ -376,7 +377,8 @@ export class ChannelWakeWorker {
  */
 /**
  * R2 — direct principal targeting. When the member row has a principalId and
- * the registry knows a LIVE ptyId, aim straight at that session (an auto-name
+ * the registry knows a ptyId that is present in the daemon's LIVE session
+ * snapshot, aim straight at that session (an auto-name
  * memberId never matches the slug heuristic, so without the principal path an
  * R2 pane member would never get nudged). Keeps the same discipline as the
  * existing pickTarget:
@@ -393,10 +395,10 @@ export function pickTargetWithPrincipal(
   workspaceId: string,
   memberId: string,
   principalId: string | undefined,
-  livePtyIdOf: ((principalId: string) => string | undefined) | undefined,
+  principalPtyIdOf: ((principalId: string) => string | undefined) | undefined,
 ): WakeSessionView | null {
-  if (principalId && livePtyIdOf) {
-    const ptyId = livePtyIdOf(principalId);
+  if (principalId && principalPtyIdOf) {
+    const ptyId = principalPtyIdOf(principalId);
     if (ptyId) {
       const s = sessions.find((x) => x.id === ptyId && x.deferred !== true);
       if (s && s.workspaceId === workspaceId) {

--- a/src/daemon/channels/channelWakeWorker.ts
+++ b/src/daemon/channels/channelWakeWorker.ts
@@ -27,10 +27,11 @@
 //         mid-stream must never get bytes spliced into its input; input
 //         activity echoes as output for both shells and TUIs, so output
 //         quiet is the conservative proxy for both).
-//   Target discipline — inject only when the pane is unambiguous: a live
-//         non-claude session whose detected agent slug equals the member id,
-//         else the ONLY live non-claude session in the workspace. Ambiguity
-//         = no injection (polling fallback), never a guess.
+//   Target discipline — a stable principal coordinate must resolve to that
+//         exact live agent pane or no injection occurs. Legacy rows without a
+//         usable principal lookup use the slug/only-live-agent heuristic.
+//         Ambiguity or an invalid exact target = polling fallback, never a
+//         guess.
 //   Re-nudge policy — mention-unread re-nudges with backoff up to a hard
 //         cap, then STOPS and emits `channel.nudgeExhausted` (loop-storm
 //         guard: two agents must not ping-pong each other's token budgets
@@ -386,9 +387,10 @@ export class ChannelWakeWorker {
  *   - an ATTACHED claude pane → null — the renderer Stop-hook owns it. Do not
  *     fall back to the heuristic (re-routing to the wrong single pane = double
  *     delivery + wasted budget);
- *   - if the session the registry points to is dead (race) or the workspace
- *     mismatches (stale registry), do not assert — fall back to the existing
- *     heuristic.
+ *   - if the exact coordinate is missing, dead, in another workspace, or no
+ *     longer hosts an agent, fail closed. A stable principal must never be
+ *     re-routed to a sibling by the heuristic;
+ *   - use the heuristic only for legacy rows without a principal id or lookup.
  */
 export function pickTargetWithPrincipal(
   sessions: WakeSessionView[],
@@ -397,26 +399,19 @@ export function pickTargetWithPrincipal(
   principalId: string | undefined,
   principalPtyIdOf: ((principalId: string) => string | undefined) | undefined,
 ): WakeSessionView | null {
-  if (principalId && principalPtyIdOf) {
-    const ptyId = principalPtyIdOf(principalId);
-    if (ptyId) {
-      const s = sessions.find((x) => x.id === ptyId && x.deferred !== true);
-      if (s && s.workspaceId === workspaceId) {
-        if (s.lastDetectedAgent === 'claude' && s.attached === true) return null;
-        // Same agent-required discipline as the heuristic fallback (Codex
-        // micro-pass on the 2026-07-05 shell-nudge fix): a registry row's
-        // ptyId can outlive the agent — the agent exits, the pane keeps its
-        // shell, the row stays live until the next upsert/purge. A direct
-        // hit on a session with NO detected agent must not auto-submit into
-        // that bare shell; fall through to the heuristic (which now refuses
-        // agent-less panes too).
-        if (s.lastDetectedAgent) return s;
-      }
-      // Session gone / workspace mismatch / agent-less pane → heuristic
-      // fallback (never guess).
-    }
-  }
-  return pickTarget(sessions, workspaceId, memberId);
+  if (!principalId || !principalPtyIdOf) return pickTarget(sessions, workspaceId, memberId);
+
+  const ptyId = principalPtyIdOf(principalId);
+  if (!ptyId) return null;
+
+  const session = sessions.find((candidate) => candidate.id === ptyId && candidate.deferred !== true);
+  if (!session || session.workspaceId !== workspaceId) return null;
+  if (session.lastDetectedAgent === 'claude' && session.attached === true) return null;
+
+  // A registry coordinate can outlive the agent: the agent exits while the
+  // pane keeps its shell. Never auto-submit there, and never redirect a nudge
+  // addressed to this stable principal into a sibling pane.
+  return session.lastDetectedAgent ? session : null;
 }
 
 export function pickTarget(

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -4681,9 +4681,11 @@ async function main(): Promise<void> {
   channelWakeWorkerRef = new ChannelWakeWorker({
     memberWorkspaces: () => channelService.memberWorkspaces(),
     unreadFor: (ws) => channelService.unreadFor(ws),
-    // R2: member row principalId → direct LIVE ptyId lookup. A stale principal
-    // returns undefined and falls back to the existing slug heuristic.
-    livePtyIdOf: (principalId) => principalService.livePtyIdOf(principalId),
+    // R2: the registry supplies the member's last PTY coordinate even after
+    // restart backfill marks it stale. listLiveSessions below is the daemon-
+    // owned liveness authority: only attached/detached sessions enter the
+    // target snapshot, so a genuinely dead coordinate still falls back.
+    principalPtyIdOf: (principalId) => principalService.ptyIdOf(principalId),
     listLiveSessions: () =>
       sessionManager.listLiveSessions().map((meta) => ({
         id: meta.id,

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -4926,9 +4926,9 @@ async function main(): Promise<void> {
     } catch (err) {
       log('error', `supervisor onSessionDied failed for ${payload.id}:`, err);
     }
-    // R2: a dead session's pane-agent principal goes stale immediately — the
-    // safety premise that keeps the wake worker from targeting a stale
-    // principal's ptyId.
+    // R2: reflect the dead session immediately in registry/UI liveness. Wake
+    // targeting separately validates the stored coordinate against
+    // listLiveSessions(), whose attached/detached filter is the safety gate.
     try {
       principalService.markStaleByPtyId(payload.id);
     } catch (err) {

--- a/src/daemon/principals/PrincipalService.ts
+++ b/src/daemon/principals/PrincipalService.ts
@@ -97,13 +97,17 @@ export class PrincipalService {
   }
 
   /**
-   * For the wake worker: returns ptyId only when the principal is live. A
-   * stale record's ptyId may be a dead (or reused) session id, so it is never
-   * returned.
+   * Return a pane principal's last registered PTY coordinate.
+   *
+   * This deliberately does NOT interpret registry `liveness`: the daemon
+   * backfills every pane-agent to stale on restart, including idle panes whose
+   * persisted sessions were successfully rebuilt as detached. Callers must
+   * prove that the returned id is present in the daemon's live-session table
+   * before acting on it.
    */
-  livePtyIdOf(id: string): string | undefined {
+  ptyIdOf(id: string): string | undefined {
     const p = this.state.principals.find((r) => r.id === id);
-    if (!p || p.liveness !== 'live') return undefined;
+    if (!p || p.kind !== 'pane-agent') return undefined;
     return p.ptyId;
   }
 

--- a/src/daemon/principals/__tests__/PrincipalService.test.ts
+++ b/src/daemon/principals/__tests__/PrincipalService.test.ts
@@ -3,7 +3,7 @@
 //   1. upsert → list round trip + liveness live
 //   2. On restart (reconstruction) every pane-agent is backfilled stale + human:me seed
 //   3. markStaleByPtyId / markStaleByWorkspace / remove
-//   4. livePtyIdOf returns ptyId only when live (no stale ptyId leakage)
+//   4. ptyIdOf preserves the routing coordinate independently of liveness
 // The writer is injected as an in-memory fake, per the ChannelService.test convention.
 
 import { describe, it, expect, vi } from 'vitest';
@@ -117,13 +117,21 @@ describe('PrincipalService', () => {
     expect(svc.find(HUMAN_SELF_PRINCIPAL_ID)).toBeDefined();
   });
 
-  it('livePtyIdOf: returns ptyId only when live — a stale ptyId must not leak into wake targeting', () => {
-    const svc = new PrincipalService({ writer: makeFakeWriter() });
-    svc.upsert(paneInput(1));
+  it('ptyIdOf: preserves the routing coordinate across restart backfill', () => {
+    const writer = makeFakeWriter();
+    const svc1 = new PrincipalService({ writer });
+    svc1.upsert(paneInput(1));
     const id = panePrincipalId('ws-1', 'pane-1');
 
-    expect(svc.livePtyIdOf(id)).toBe('pty-1');
-    svc.markStaleByPtyId('pty-1');
-    expect(svc.livePtyIdOf(id)).toBeUndefined();
+    // Restart backfill makes the registry row stale even though the daemon
+    // rebuilds the persisted session as detached. Callers that already hold a
+    // live-session snapshot still need the coordinate so that snapshot — not
+    // renderer-owned registry liveness — can decide whether the PTY exists.
+    const svc2 = new PrincipalService({ writer });
+    expect(svc2.find(id)?.liveness).toBe('stale');
+    expect(svc2.ptyIdOf(id)).toBe('pty-1');
+
+    svc2.remove(id);
+    expect(svc2.ptyIdOf(id)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Restore channel wake targeting for idle agents after a daemon restart. The
principal registry supplies the PTY coordinate while the daemon-owned live
session snapshot remains the liveness authority; a stable principal that no
longer resolves now fails closed instead of waking a sibling agent.

## Changes

- Return a pane principal's last registered PTY coordinate without interpreting
  renderer-owned registry liveness.
- Accept that coordinate only when it appears in the daemon's attached/detached
  session snapshot; existing workspace, deferred-session, agent, and attached-
  Claude checks stay intact.
- Refuse missing, dead, mismatched, or agent-less exact principal targets rather
  than falling back to a heuristic that could inject into a sibling pane.
- Cover restart backfill through the real principal service and wake-worker
  production seam, plus fail-closed sibling routing.

## CHANGELOG entry

### Fixed

- **Channel delivery wakes idle agents again after a daemon restart.** Restart
  recovery marks every pane principal stale, and an agent that has finished and
  is waiting produces no output to refresh that flag, so the wake worker could
  leave it unwakeable indefinitely. The registry now supplies only the pane's
  PTY coordinate; the daemon's rebuilt attached/detached session table decides
  whether that target is live. Exact principal targets that cannot be verified
  are skipped rather than redirected to a sibling agent. (#705)

## Stability tier impact

- [ ] No external surface touched (internal refactor / docs / tests / CI).
- [ ] Additive change to a `stable` surface (new optional param, new field, new event type).
- [ ] Breaking change to a `stable` surface (requires major bump — block until release planning is in scope).
- [ ] Change to an `experimental` surface (note in release notes).
- [x] Change to an `internal` surface (no contract impact).

## Substrate contract impact (Substrate 3.0)

n/a — no RPC shape, event type, permission enforcement point, or Named Pipe
contract changed.

## Test plan

- Principal routing regression suites: 51 passed.
- Daemon channel and principal suites: 459 passed.
- `npx tsc -p tsconfig.daemon.json --noEmit`
- `npx tsc --noEmit`
- `npm run build:mcp && npm run probe:mcp`
- `npx tsc --noEmit -p relay/tsconfig.json`
- ESLint passed on all touched non-entrypoint files; `src/daemon/index.ts`
  retains only its pre-existing baseline findings outside this diff.
- `npm run test:runtime`: 90 passed, 9 skipped in the clean run. A later
  concurrent stress rerun hit unrelated five-second timeouts in the untouched
  device-store runtime file; 47/48 passed when that file was rerun alone.
- Full `npm test` reached 9,105 passed before unrelated Windows timeout/`EBUSY`
  failures under parallel load. Every failed file passed when rerun in
  isolation (105 passed, 8 skipped).

## Related issues / PRs

Closes #693.
Follow-up to #692.

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed.
- [x] Tests cover the new behavior and the regression case.
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed channel delivery after daemon restarts so previously idle agents can be woken again.
  - Ensured messages route only to the exact verified agent session.
  - Prevented stale or unavailable targets from incorrectly waking sibling agents or bare shell panes.
- **Tests**
  - Added coverage for restart recovery, stale routing data, unavailable targets, and agent-only wake behavior.
- **Documentation**
  - Added a changelog entry describing the restart and routing fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->