### PR TITLE
fix(renderer): stop es2020 lowering from wedging panes that probe DECRQM

### DIFF
--- a/changelog.d/708.md
+++ b/changelog.d/708.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **A pane running a TUI that asks the terminal about its own modes no longer
+  freezes.** `opencode` probes six terminal modes the moment it starts, and each
+  probe hit a miscompiled xterm handler that threw. The throw killed that pane's
+  parser for good: the process kept running and its title kept updating, but the
+  screen never painted again and every agent read of it came back
+  `RPC timeout: input.readScreen (5000ms)` — with nothing to explain why. The
+  renderer bundle is now built at a target that stops mangling the handler.
+  (#708)
+- **Reading a pane can no longer hang.** The read path waited on the pane's
+  parser without a deadline, so a stalled pane took the whole read down with it
+  and the caller got nothing. Reads now wait a bounded moment and return what
+  the pane has, which is worth far more than a timeout. (#708)

--- a/scripts/__tests__/rendererBuildTarget.test.mjs
+++ b/scripts/__tests__/rendererBuildTarget.test.mjs
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { transformSync } from 'esbuild';
+
+/**
+ * Regression guard for the renderer's esbuild target.
+ *
+ * Below es2021 esbuild lowers logical assignment (`a ||= b`) to `a || (a = b)`,
+ * and when it has proved the binding dead it drops the `let a;` declaration
+ * while KEEPING the write — producing `void 0 || (x = {})` against an
+ * undeclared name, which throws under ESM strict mode.
+ *
+ * That miscompiled @xterm/xterm 6's DECRQM handler (`InputHandler.requestMode`,
+ * `CSI ? Ps $ p`). The throw escaped xterm's WriteBuffer drain loop, so the
+ * first TUI to probe terminal modes (opencode does, on startup) permanently
+ * wedged that pane's write buffer: the pane froze and every MCP read of it
+ * (input.readScreen / pane.search) timed out.
+ *
+ * The shape below is xterm's source verbatim in structure — a `let` with no
+ * initializer, fed to a TS-enum IIFE via `||=`, then never read again.
+ */
+const XTERM_REQUEST_MODE_SHAPE = `
+export function requestMode(params, ansi) {
+  let DecRqmTypes;
+  ((v) => (v[v.NOT_RECOGNIZED = 0] = 'NOT_RECOGNIZED', v[v.SET = 1] = 'SET'))(DecRqmTypes ||= {});
+  const modes = { origin: true };
+  const reply = (m, s) => String(m) + ';' + String(s);
+  return ansi ? reply(params, 0) : reply(params, modes.origin ? 1 : 2);
+}
+`;
+
+function rendererTarget() {
+  const src = readFileSync(new URL('../../vite.renderer.config.ts', import.meta.url), 'utf8');
+  const match = /^\s*target:\s*'([^']+)'/m.exec(src);
+  return match?.[1];
+}
+
+describe('renderer build target', () => {
+  it('is pinned in vite.renderer.config.ts', () => {
+    expect(rendererTarget()).toBeTruthy();
+  });
+
+  it('does not lower logical assignment (the es2020 miscompile)', () => {
+    const { code } = transformSync(XTERM_REQUEST_MODE_SHAPE, {
+      loader: 'js',
+      format: 'esm',
+      minify: true,
+      target: rendererTarget(),
+    });
+    // The lowered form is what strands an undeclared binding.
+    expect(code).not.toMatch(/void 0\s*\|\|\s*\(/);
+    expect(code).toMatch(/\|\|=/);
+  });
+
+  it('produces a requestMode that actually runs instead of throwing ReferenceError', async () => {
+    const { code } = transformSync(XTERM_REQUEST_MODE_SHAPE, {
+      loader: 'js',
+      format: 'esm',
+      minify: true,
+      target: rendererTarget(),
+    });
+    // Strict mode (module scope) is what turns the stray write into a throw,
+    // so evaluate the same way the renderer does.
+    const mod = await import(
+      `data:text/javascript,${encodeURIComponent(code)}`
+    );
+    expect(() => mod.requestMode(6, false)).not.toThrow();
+  });
+
+  it('the es2020 default this guards against really does miscompile', () => {
+    const { code } = transformSync(XTERM_REQUEST_MODE_SHAPE, {
+      loader: 'js',
+      format: 'esm',
+      minify: true,
+      target: 'es2020',
+    });
+    expect(code).toMatch(/void 0\s*\|\|\s*\(/);
+  });
+});

--- a/src/renderer/hooks/__tests__/useTerminal.hiddenRetention.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.hiddenRetention.test.ts
@@ -103,10 +103,13 @@ describe('Phase 3 PR-A — useTerminal hidden-pane retention wiring (source-leve
     expect(src).toMatch(/export\s+async\s+function\s+hydrateTerminalForRead/);
     expect(src).toMatch(/hydrateRegistry\.set\(ptyId,\s*hydrateForRead\)/);
     expect(src).toMatch(/hydrateRegistry\.get\(ptyId\)\s*===\s*hydrateForRead[\s\S]{0,120}hydrateRegistry\.delete\(ptyId\)/);
-    // Hydration ends with a parse barrier so callers read a settled buffer.
+    // Hydration ends with a parse barrier so callers read a settled buffer —
+    // a BOUNDED one, so a wedged xterm write buffer (a handler that threw
+    // mid-drain strands every queued callback) cannot hang the read instead.
     const idx = src.indexOf('const hydrateForRead');
     const body = src.slice(idx, idx + 900);
-    expect(body).toMatch(/terminal\.write\(''\s*,\s*resolve\)/);
+    expect(body).toMatch(/await\s+awaitParseBarrier\(terminal\)/);
+    expect(src).toMatch(/import\s+\{\s*awaitParseBarrier\s*\}\s+from\s+'\.\.\/terminal\/parseBarrier'/);
     // Teardown silences any in-flight resync.
     // Cleanup cancels with the effect's CAPTURED ptyId (not the mutable ref —
     // a PTY swap could clear the wrong pane's badge; CodeRabbit PR #470).

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -25,6 +25,7 @@ import { webglContextPool } from '../terminal/webglContextPool';
 import { teardownWebglAddon } from '../terminal/webglTeardown';
 import { createGlyphRepaintScheduler, type GlyphRepaintScheduler } from '../terminal/glyphRepaint';
 import { createDeadInputWatchdog } from '../terminal/deadInputWatchdog';
+import { awaitParseBarrier } from '../terminal/parseBarrier';
 import { STALE_REPLAY_INPUT_MODE_RESETS, STALE_REPLAY_DISPLAY_RESETS } from '../terminal/staleReplayModeReset';
 import {
   writeTerminalOutput,
@@ -1946,7 +1947,10 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // daemon resync; otherwise hand over any retained backlog. The trailing
     // empty write is a parse barrier — its callback runs only after xterm
     // has parsed everything handed above, so the caller reads a settled
-    // buffer.
+    // buffer. The barrier is BOUNDED: a pane whose xterm write buffer has
+    // wedged (a handler that threw mid-drain strands every queued callback)
+    // would otherwise never call back, and the read would burn its whole RPC
+    // deadline and return nothing. See parseBarrier.ts.
     const hydrateForRead = async (): Promise<void> => {
       if (terminalRef.current !== terminal) return;
       if (isTerminalDirty(terminal)) {
@@ -1954,9 +1958,12 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       } else {
         flushTerminalOutput(terminal);
       }
-      await new Promise<void>((resolve) => {
-        try { terminal.write('', resolve); } catch { resolve(); }
-      });
+      const parsed = await awaitParseBarrier(terminal);
+      if (!parsed) {
+        console.warn(
+          `[useTerminal] parse barrier timed out ptyId=${ptyIdRef.current} — reading a possibly unsettled buffer (xterm write buffer may be wedged)`,
+        );
+      }
     };
     if (ptyId) hydrateRegistry.set(ptyId, hydrateForRead);
 

--- a/src/renderer/terminal/__tests__/parseBarrier.test.ts
+++ b/src/renderer/terminal/__tests__/parseBarrier.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { awaitParseBarrier, PARSE_BARRIER_TIMEOUT_MS, type BarrierWritable } from '../parseBarrier';
+
+/** A terminal whose write buffer drains normally — the callback fires. */
+const healthy = (): BarrierWritable => ({
+  write: (_data, cb) => { cb?.(); },
+});
+
+/** A terminal whose write buffer is WEDGED: xterm accepted the write and
+ *  queued the callback, but the drain loop died earlier and never advances,
+ *  so the callback is stranded forever. This is the real failure mode — a
+ *  handler that threw inside WriteBuffer._innerWrite. */
+const wedged = (): BarrierWritable => ({
+  write: () => { /* callback intentionally never invoked */ },
+});
+
+describe('awaitParseBarrier', () => {
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('resolves true as soon as xterm reports the pane parsed', async () => {
+    await expect(awaitParseBarrier(healthy())).resolves.toBe(true);
+  });
+
+  it('resolves false instead of hanging when the write buffer is wedged', async () => {
+    vi.useFakeTimers();
+    const settled = awaitParseBarrier(wedged(), 1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(settled).resolves.toBe(false);
+  });
+
+  it('bounds the wait well inside the 5s RPC deadline that reads run under', () => {
+    expect(PARSE_BARRIER_TIMEOUT_MS).toBeLessThan(5_000);
+  });
+
+  it('treats a synchronous write throw (disposed terminal) as settled, not a hang', async () => {
+    const disposed: BarrierWritable = {
+      write: () => { throw new Error('Terminal disposed'); },
+    };
+    await expect(awaitParseBarrier(disposed)).resolves.toBe(false);
+  });
+
+  it('ignores a late callback that arrives after the timeout already fired', async () => {
+    vi.useFakeTimers();
+    let late: (() => void) | undefined;
+    const slow: BarrierWritable = { write: (_d, cb) => { late = cb; } };
+    const settled = awaitParseBarrier(slow, 500);
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(settled).resolves.toBe(false);
+    // The stranded callback eventually running must not throw or re-resolve.
+    expect(() => late?.()).not.toThrow();
+  });
+});

--- a/src/renderer/terminal/__tests__/parseBarrier.test.ts
+++ b/src/renderer/terminal/__tests__/parseBarrier.test.ts
@@ -28,8 +28,28 @@ describe('awaitParseBarrier', () => {
     await expect(settled).resolves.toBe(false);
   });
 
-  it('bounds the wait well inside the 5s RPC deadline that reads run under', () => {
+  it('bounds the wait inside the 5s RPC deadline that reads run under', () => {
     expect(PARSE_BARRIER_TIMEOUT_MS).toBeLessThan(5_000);
+  });
+
+  // The budget is squeezed from both sides, and the lower bound is the one that
+  // is easy to lose: a dirty pane replaying the whole daemon ring (≤8MB, parsed
+  // at ~5–35MB/s) needs ~2s, and a barrier that expires first hands the reader a
+  // half-applied replay while reporting success. Reads that quietly go stale are
+  // harder to notice than reads that fail, so pin the floor.
+  it('leaves room for a healthy full-ring replay to finish parsing (~2s)', () => {
+    expect(PARSE_BARRIER_TIMEOUT_MS).toBeGreaterThanOrEqual(2_000);
+  });
+
+  it('lets a slow-but-healthy parse settle instead of timing it out', async () => {
+    vi.useFakeTimers();
+    // Parses for 2s — the full-ring worst case — then calls back.
+    const slowButHealthy: BarrierWritable = {
+      write: (_d, cb) => { setTimeout(() => cb?.(), 2_000); },
+    };
+    const settled = awaitParseBarrier(slowButHealthy);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(settled).resolves.toBe(true);
   });
 
   it('treats a synchronous write throw (disposed terminal) as settled, not a hang', async () => {

--- a/src/renderer/terminal/parseBarrier.ts
+++ b/src/renderer/terminal/parseBarrier.ts
@@ -20,13 +20,24 @@
  *   caller's RPC deadline is 5s and a timeout returns nothing at all, whereas a
  *   bounded wait still returns the pane's real (if fractionally older) content.
  *   So the barrier gives xterm a budget and then reads regardless.
+ *
+ *   The budget has to clear the slowest HEALTHY parse, not just be small. Too
+ *   tight and a pane replaying a full daemon ring is treated as wedged, and the
+ *   read scans a partially applied replay and reports it as complete — worse
+ *   than the timeout it replaced, because nothing says the answer is short.
+ *   See PARSE_BARRIER_TIMEOUT_MS.
  */
 
-/** Budget for the barrier. Generous next to an ordinary parse (xterm drains in
- *  12ms slices and a settled pane calls back on the next tick) and comfortably
- *  inside the 5s RPC deadline, so a busy-but-healthy pane still settles fully
- *  while a wedged one costs the reader a fraction of its budget. */
-export const PARSE_BARRIER_TIMEOUT_MS = 1_000;
+/** Budget for the barrier. Sized by the largest LEGITIMATE parse, not by a
+ *  round number: a dirty pane that falls back to a raw replay hands the whole
+ *  daemon ring (≤8MB — see RESYNC_BUFFER_MAX_CHARS in useTerminal.ts) to xterm
+ *  and settles BEFORE that backlog is parsed, and xterm parses ~5–35MB/s
+ *  (xterm.js flow-control docs), so a healthy full-ring replay can need ~2s.
+ *  A tighter budget would expire on such a pane and the reader would silently
+ *  scan a half-applied replay — the failure this barrier exists to prevent,
+ *  reintroduced in a quieter form. 3s clears that worst case and still leaves
+ *  2s of headroom under the caller's 5s RPC deadline. */
+export const PARSE_BARRIER_TIMEOUT_MS = 3_000;
 
 /** The subset of xterm's Terminal this barrier needs. */
 export interface BarrierWritable {

--- a/src/renderer/terminal/parseBarrier.ts
+++ b/src/renderer/terminal/parseBarrier.ts
@@ -1,0 +1,64 @@
+/**
+ * Bounded parse barrier for the MCP read path (pane.search / input.readScreen).
+ *
+ * Why this exists:
+ *   Before reading a pane's xterm buffer we hand it an empty write and wait for
+ *   the callback — xterm invokes it only after everything queued ahead of it has
+ *   been parsed, so the reader sees a settled buffer instead of a half-applied
+ *   frame.
+ *
+ *   That callback is not guaranteed to fire. xterm's WriteBuffer drains inside
+ *   `_innerWrite`, and a handler that THROWS mid-dispatch takes the whole drain
+ *   loop with it: `_bufferOffset` never advances, nothing reschedules, and every
+ *   callback behind it — including the barrier's — is stranded for the lifetime
+ *   of that Terminal. One real instance was the es2020-lowering miscompile of
+ *   `@xterm/xterm`'s DECRQM handler (see the target note in
+ *   vite.renderer.config.ts); a wedged pane made every terminal_read against it
+ *   fail with `RPC timeout: input.readScreen (5000ms)` and no other signal.
+ *
+ *   A read is allowed to be slightly stale. It is NOT allowed to hang: the
+ *   caller's RPC deadline is 5s and a timeout returns nothing at all, whereas a
+ *   bounded wait still returns the pane's real (if fractionally older) content.
+ *   So the barrier gives xterm a budget and then reads regardless.
+ */
+
+/** Budget for the barrier. Generous next to an ordinary parse (xterm drains in
+ *  12ms slices and a settled pane calls back on the next tick) and comfortably
+ *  inside the 5s RPC deadline, so a busy-but-healthy pane still settles fully
+ *  while a wedged one costs the reader a fraction of its budget. */
+export const PARSE_BARRIER_TIMEOUT_MS = 1_000;
+
+/** The subset of xterm's Terminal this barrier needs. */
+export interface BarrierWritable {
+  write(data: string, callback?: () => void): void;
+}
+
+/**
+ * Resolve once xterm reports the pane parsed, or once the budget expires —
+ * whichever lands first. Resolves `true` when the barrier settled properly and
+ * `false` when it timed out (the caller reads either way; the flag exists so a
+ * wedged pane is observable rather than silently slow).
+ *
+ * A synchronous throw from `write` (disposed terminal, xterm's pending-data
+ * watermark) settles as a timeout too — there is nothing left to wait for.
+ */
+export function awaitParseBarrier(
+  terminal: BarrierWritable,
+  timeoutMs: number = PARSE_BARRIER_TIMEOUT_MS,
+): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (parsed: boolean): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(parsed);
+    };
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    try {
+      terminal.write('', () => finish(true));
+    } catch {
+      finish(false);
+    }
+  });
+}

--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -8,6 +8,19 @@ export default defineConfig({
     __APP_VERSION__: JSON.stringify(pkg.version),
   },
   build: {
+    // The renderer only ever runs inside this app's own Chromium (Electron 41 →
+    // Chrome 146), so Vite's default `modules` target (es2020) buys nothing and
+    // actively MISCOMPILES a dependency: below es2021 esbuild lowers logical
+    // assignment (`a ||= b`) to `a || (a = b)`, and for a binding it has proved
+    // dead it then drops the `let a;` declaration while KEEPING the write. In
+    // @xterm/xterm 6's `InputHandler.requestMode` (the DECRQM `CSI ? Ps $ p`
+    // handler) that produced `void 0 || (i = {})` with no declaration for `i`,
+    // which throws `ReferenceError: i is not defined` under ESM strict mode the
+    // first time any TUI probes terminal modes. The throw escapes xterm's
+    // WriteBuffer._innerWrite, so that pane's write buffer never advances again:
+    // the pane freezes and every reader of it (input.readScreen / pane.search)
+    // hangs on the parse barrier. Targeting es2022 keeps `||=` intact.
+    target: 'es2022',
     rollupOptions: {
       output: {
         // TASK-2: split heavy, stable vendor bundles out of the main chunk so


### PR DESCRIPTION
## The bug

A pane running `opencode` froze on startup — the process stayed alive and kept
updating its title, but the pane never painted again and every MCP read of it
failed with `RPC timeout: input.readScreen (5000ms)`. Panes running Claude Code,
Codex CLI and Kiro CLI in the same workspace were fine. Shrinking `tail_lines`
from 300 to 20 changed nothing, so this was never about read cost.

## Root cause

Two defects, layered.

### 1. The renderer build miscompiled xterm

`vite.renderer.config.ts` set no `build.target`, so Vite's default `modules`
(es2020) applied. Below es2021 esbuild lowers logical assignment (`a ||= b`) to
`a || (a = b)`, and for a binding it has proved dead it then drops the `let a;`
declaration while keeping the write.

`@xterm/xterm` 6's `InputHandler.requestMode` — the DECRQM (`CSI ? Ps $ p`)
handler — is exactly that shape. Upstream `lib/xterm.mjs` is correct:

```js
requestMode(e, i) { let r; (P => (...))(r ||= {}); ... }
```

The shipped bundle was not:

```js
requestMode(t, e) { (y => (...))(void 0 || (i = {})); ... }
//                                        ^ no declaration for `i`
```

Under ESM strict mode that write throws. Captured live from the running
renderer over CDP:

```
ReferenceError: i is not defined
  at kd.requestMode (vendor-xterm-Brb_LsZ_.js:24:103533)
  at wd.parse       (vendor-xterm-Brb_LsZ_.js:24:67927)
stateAtThrow: 5   // ParserState.CSI_INTERMEDIATE — the '$' of `$p`
```

Only opencode tripped it because only opencode probes terminal modes: its
startup capability burst carries six DECRQM requests
(`\e[?1016$p \e[?2027$p \e[?2031$p \e[?1004$p \e[?2004$p \e[?2026$p`).

The throw escapes xterm's `WriteBuffer._innerWrite`, which is what makes it
permanent: `_bufferOffset` never advances and nothing reschedules, so the
Terminal stops parsing for the rest of its life. Measured on the wedged pane:

| | healthy pane | wedged pane |
|---|---|---|
| `_writeBuffer.length` | 0 | 105 |
| `_bufferOffset` | 0 | 0 (nothing consumed) |
| `_pendingData` | 0 | 37912 |
| `parser.currentState` | 0 GROUND | 5 CSI_INTERMEDIATE |

39989 bytes had reached the session; 37912 were still unparsed.

### 2. The read path waited on that buffer forever

`useTerminal.ts` ended hydration with an unbounded parse barrier
(`terminal.write('', resolve)`). On a wedged buffer the callback never comes,
the renderer never replies, and main's 5s IPC deadline
(`_bridge.ts` `DEFAULT_TIMEOUT_MS`) fires. That is the timeout users saw, and
it is why `tail_lines` made no difference — the hang is upstream of the read.
`pane.search` goes through the same barrier and timed out identically.

Renderer-only: the daemon bundles `@xterm/headless` with `esbuild --bundle` and
no minify, so `terminal_read_events` kept working throughout — which is what
made it clear the session itself was healthy.

## Changes

- **`vite.renderer.config.ts`** — pin `target: 'es2022'`. The renderer only ever
  runs in this app's own Chromium (Electron 41 / Chrome 146), so the
  conservative default bought nothing and cost correctness.
- **`src/renderer/terminal/parseBarrier.ts`** (new) — `awaitParseBarrier()`,
  bounded at 1s. Resolves `true` when xterm reports the pane parsed, `false` on
  timeout; a synchronous `write` throw settles as a timeout too.
- **`src/renderer/hooks/useTerminal.ts`** — hydration uses the bounded barrier
  and warns when it expires. A read now returns a slightly stale buffer instead
  of nothing at all, whatever state xterm is in.

Bundle diff, before → after:

```
before: requestMode(t,e){ (y=>(...))(void 0||(i={})); ...
after:  requestMode(t,e){ let i;(b=>(...))(i||={}); ...
```

## Tests

- `src/renderer/terminal/__tests__/parseBarrier.test.ts` — 5 cases, including a
  wedged terminal resolving `false` rather than hanging, and a late callback
  arriving after the timeout.
- `scripts/__tests__/rendererBuildTarget.test.mjs` — 4 cases. Minifies xterm's
  `requestMode` shape at the configured target, imports the result as strict
  ESM and calls it, and asserts es2020 really does produce the broken form so
  the guard cannot quietly stop guarding.
- `useTerminal.hiddenRetention.test.ts` — existing source-level assertion
  updated for the new barrier.

## Verification

| | |
|---|---|
| `tsc --noEmit` | pass |
| `eslint` (changed files) | 0 new errors (3 pre-existing in `useTerminal.ts`, unchanged on this branch) |
| `npm run test:parallel` | 9202 passed, 636 files |
| `npm run test:runtime` | 90 passed |
| `npm run package` | pass; app ships the corrected chunk |

**End-to-end is not automated here.** A harness that boots an isolated instance
(temp HOME + `WMUX_DATA_SUFFIX`), runs `opencode` in the default pane and calls
`input.readScreen` failed three times before reaching the call: the pane's
surface never received a `ptyId` (`SessionManager saveAsync: 0 pty []`). That is
a harness/environment problem, not a signal about this change — nothing was
measured. Debugging it was dropped deliberately. Real-world confirmation will
come from dogfooding a fresh build: launch `opencode` in a pane and check that
`terminal_read` returns content instead of timing out.

## Review note

An automated review of this branch reported `parseBarrier.ts` as missing. It was
untracked at bundle time, so the reviewer saw the import but not the module. It
is included in this commit; `tsc` and the packaged build both resolve it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal screen-read reliability by adding a bounded parse completion wait during input hydration.
  * Prevented pane freezes by stabilizing terminal mode probing with the renderer build target.
  * Avoided indefinite reads by returning safely when parse completion is delayed or a terminal write callback never arrives.
* **New Features**
  * Introduced a parse barrier utility with a short timeout to improve MCP readScreen behavior.
* **Tests**
  * Added regression coverage for parse barrier timeouts and renderer esbuild target behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->