### PR TITLE
fix(lanlink): avoid responder-only pairing commits

### DIFF
--- a/src/daemon/lanlink/client.ts
+++ b/src/daemon/lanlink/client.ts
@@ -116,9 +116,11 @@ export async function pairWithPeer(opts: PairJoinOptions): Promise<PairResult> {
     try {
       firstAead = await stream.next(AEAD_RECORD);
     } catch (err) {
-      if (err instanceof Error && err.message === 'connection closed') {
+      const confirmationMissing =
+        err instanceof Error && (err.message === 'connection closed' || err.message === 'LanLink client: frame timeout');
+      if (confirmationMissing) {
         throw new Error(
-          'LanLink pairing: the peer hung up after accepting the PIN but before confirmation arrived — ' +
+          'LanLink pairing: confirmation did not arrive after the peer accepted the PIN — ' +
             'check the peer daemon log. The peer may have failed to save the pairing, ' +
             'or it may already have committed it; inspect both peer lists before retrying.',
         );

--- a/src/daemon/lanlink/client.ts
+++ b/src/daemon/lanlink/client.ts
@@ -108,21 +108,19 @@ export async function pairWithPeer(opts: PairJoinOptions): Promise<PairResult> {
     const { confirm, pending } = await ini.onPake2(pake2);
     socket.write(encodeFrame(CONFIRM, confirm));
     // A close HERE — after the peer accepted our CONFIRM but before it confirmed
-    // back — is the one that cost two teams hours in #658. The bare 'connection
-    // closed' reads like a transport fault, so they went looking below lanlink;
-    // the actual cause was the peer failing to save the pairing. Name the two
-    // possibilities rather than the symptom. (Not a wire-level error frame: the
-    // responder has no authenticated channel to send one on yet, and a cleartext
-    // one would be both a PIN oracle and injectable.)
+    // back — is ambiguous: the responder may have failed locally before committing,
+    // or it may have committed and then lost the confirmation on the transport.
+    // Keep this as a local diagnostic rather than an unauthenticated wire error,
+    // which would be injectable and could become a PIN oracle.
     let firstAead: Buffer;
     try {
       firstAead = await stream.next(AEAD_RECORD);
     } catch (err) {
       if (err instanceof Error && err.message === 'connection closed') {
         throw new Error(
-          'LanLink pairing: the peer hung up after accepting the PIN but before confirming — ' +
-            'it most likely failed to save the pairing (check the peer daemon log), ' +
-            'or the connection dropped. Neither side is paired.',
+          'LanLink pairing: the peer hung up after accepting the PIN but before confirmation arrived — ' +
+            'check the peer daemon log. The peer may have failed to save the pairing, ' +
+            'or it may already have committed it; inspect both peer lists before retrying.',
         );
       }
       throw err;

--- a/src/daemon/lanlink/peers.ts
+++ b/src/daemon/lanlink/peers.ts
@@ -165,18 +165,8 @@ export class PeerStore {
       recvHighWater: 0,
       sendSeq: 0,
     };
-    // Mutate and persist as ONE unit (#658). persist() can throw several ways on
-    // win32 — the C12 fail-closed unlink when the owner-DACL cannot be applied,
-    // and a failed atomic rename, which leaves no primary file at all because the
-    // previous one was already moved aside. Whichever fires, the map used to keep
-    // the record: listPeers() reads memory, not disk, so the responder reported a
-    // healthy pairing over a file that was gone, while the same throw unwound into
-    // pump() and closed the socket before the joiner was ever confirmed. A
-    // permanent half-pair that looked like success on exactly one side.
-    //
     // The snapshot is DEEP because the other mutators edit records in place.
-    const snapshot = new Map<string, PeerRecord>();
-    for (const [uuid, existing] of this.map) snapshot.set(uuid, { ...existing });
+    const snapshot = this.snapshot();
     try {
       // Enforce the cap BEFORE committing a NEW peer (fail-closed): if the store is
       // full and there is no evictable slot, REJECT the pairing rather than overflow.
@@ -196,13 +186,40 @@ export class PeerStore {
     return rec;
   }
 
-  // NOTE: only upsertPaired rolls back. The other mutators must NOT — rolling a
-  // revoke(), a burn (noteSteadyStateAuthFail) or a receive high-water back would
-  // be fail-OPEN: it would restore access the caller asked to remove, let a host
-  // that cannot persist never reach PEER_BURN_THRESHOLD, and reopen the C8 replay
-  // gate for an authenticated-but-hostile peer. Those keep their in-memory effect
-  // and let the persist failure surface instead. Granting access is the only
-  // direction where memory running ahead of disk is the dangerous one.
+  /**
+   * Persist a pairing and retain an exact snapshot for a rollback attempt during
+   * the narrow window before the responder hands its confirmation frame to the
+   * socket. Calling the established upsert API preserves its failure semantics
+   * and test seam while the snapshot also captures an evicted or replaced peer.
+   */
+  commitPaired(r: PairResult): { record: PeerRecord; rollback: () => void } {
+    const snapshot = this.snapshot();
+    const record = this.upsertPaired(r);
+    let rolledBack = false;
+    return {
+      record,
+      rollback: () => {
+        if (rolledBack) return;
+        // Keep the restored in-memory state even if persistence fails: retaining a
+        // newly granted pairing in memory would fail open. The caller logs a
+        // persistence failure because disk recovery can then require intervention.
+        this.map = snapshot;
+        this.persist();
+        rolledBack = true;
+      },
+    };
+  }
+
+  private snapshot(): Map<string, PeerRecord> {
+    const snapshot = new Map<string, PeerRecord>();
+    for (const [uuid, existing] of this.map) snapshot.set(uuid, { ...existing });
+    return snapshot;
+  }
+
+  // NOTE: pairing commits roll back because granting access is the one direction
+  // where memory running ahead of disk is dangerous. The other mutators must NOT
+  // roll back: restoring revoke/burn/high-water state could reopen access or replay
+  // gates after a persistence failure.
 
   /**
    * Reserve the next monotonic send sequence for a peer (sender side of C8 dedup).

--- a/src/daemon/lanlink/server.ts
+++ b/src/daemon/lanlink/server.ts
@@ -516,33 +516,62 @@ export class LanLinkServer {
       this.destroy(conn);
       return;
     }
-    // Success: persist the peer, establish AEAD, send respMac as the first record.
-    // (The PAKE slot was already released when onHello's scrypt settled.)
-    //
-    // The commit can throw — a win32 owner-DACL failure makes the store refuse to
-    // hold secrets (C12 fail-closed), a failed atomic rename does the same, and a
-    // full store rejects the pairing outright. It is atomic since #658, so a throw
-    // leaves NO in-memory record and both sides stay unpaired. Catch it here so
-    // the failure is logged as a pairing outcome rather than unwinding into
-    // pump()'s broad wall, where it was indistinguishable from a wire error.
+
+    // Complete every deterministic, locally fallible response step BEFORE the
+    // durable peer commit. In particular, packaged runtimes can throw while
+    // constructing ChaCha20-Poly1305 or sealing/encoding the first AEAD record.
+    // Persisting first made those failures a permanent responder-only half-pair.
+    let opener: AeadOpener;
+    let sealer: AeadSealer;
+    let responseFrame: Buffer;
     try {
-      this.deps.peers.upsertPaired(r.result);
+      opener = new AeadOpener(r.sessionKeys.c2sKey, 1);
+      sealer = new AeadSealer(r.sessionKeys.s2cKey, 2);
+      responseFrame = encodeFrame(AEAD_RECORD, sealer.seal(r.respMac));
+    } catch (err) {
+      console.error('[LanLinkServer] pairing response preparation failed, not pairing:', err instanceof Error ? err.message : err);
+      this.destroy(conn);
+      return;
+    }
+
+    // Keep a rollback for the remaining synchronous activation/write window. The
+    // rollback restores the exact previous store (including a re-pair or an LRU
+    // eviction), unlike revoke(peerUuid), which could destroy valid prior state.
+    let commit: ReturnType<PeerStore['commitPaired']>;
+    try {
+      commit = this.deps.peers.commitPaired(r.result);
     } catch (err) {
       console.error('[LanLinkServer] pairing commit failed, not pairing:', err instanceof Error ? err.message : err);
       this.destroy(conn);
       return;
     }
-    this.establishAead(conn, r.result.peerUuid, r.sessionKeys);
-    // seal() inside the try: it is evaluated as an ARGUMENT to send(), so a throw
-    // here would escape send()'s own catch and unwind into the frame dispatcher.
-    let record: Buffer;
+
+    let stage = 'AEAD activation';
     try {
-      record = conn.sealer!.seal(r.respMac);
-    } catch {
+      this.activateAead(conn, r.result.peerUuid, opener, sealer);
+      stage = 'confirmation write';
+      if (conn.state === 'dead' || conn.socket.destroyed) throw new Error('connection closed before confirmation write');
+      // Use the sealer that prepared responseFrame: its counter is already 1.
+      // Constructing a fresh sealer here would reuse nonce/counter 1.
+      conn.socket.write(responseFrame);
+    } catch (err) {
+      let rollbackError: unknown = null;
+      try {
+        commit.rollback();
+      } catch (rollbackErr) {
+        rollbackError = rollbackErr;
+      }
+      if (rollbackError === null) {
+        console.error(`[LanLinkServer] pairing ${stage} failed; durable pairing rolled back:`, err instanceof Error ? err.message : err);
+      } else {
+        console.error(`[LanLinkServer] pairing ${stage} failed and rollback was not durable:`, err instanceof Error ? err.message : err);
+        console.error(
+          '[LanLinkServer] pairing rollback persistence failed; in-memory state was restored, but the tentative disk generation may survive recovery and reload after restart:',
+          rollbackError instanceof Error ? rollbackError.message : rollbackError,
+        );
+      }
       this.destroy(conn);
-      return;
     }
-    this.send(conn, AEAD_RECORD, record);
   }
 
   private onReconnectHello(conn: Conn, body: Buffer): void {
@@ -571,8 +600,12 @@ export class LanLinkServer {
     // Responder: opens c2s (joiner->host), seals s2c (host->joiner).
     const c2s: Direction = 1;
     const s2c: Direction = 2;
-    conn.opener = new AeadOpener(keys.c2sKey, c2s);
-    conn.sealer = new AeadSealer(keys.s2cKey, s2c);
+    this.activateAead(conn, peerUuid, new AeadOpener(keys.c2sKey, c2s), new AeadSealer(keys.s2cKey, s2c));
+  }
+
+  private activateAead(conn: Conn, peerUuid: string, opener: AeadOpener, sealer: AeadSealer): void {
+    conn.opener = opener;
+    conn.sealer = sealer;
     conn.peerUuid = peerUuid;
     conn.state = 'aead';
     if (conn.deadline) {


### PR DESCRIPTION
## Summary
- Prepare the first AEAD confirmation frame before durably committing the responder peer.
- Restore the exact previous peer-store snapshot if synchronous AEAD activation or socket handoff fails.
- Add stage-specific responder diagnostics and make the client message truthful when post-CONFIRM state is uncertain.

## Validation
- `npx vitest run src/daemon/lanlink/__tests__/pairing.test.ts src/daemon/lanlink/__tests__/aead.test.ts src/daemon/lanlink/__tests__/peers.test.ts src/daemon/lanlink/__tests__/server.test.ts` (38 passed)
- `npx tsc -p tsconfig.daemon.json --noEmit`
- `npx eslint src/daemon/lanlink/server.ts src/daemon/lanlink/client.ts src/daemon/lanlink/peers.ts` (0 errors; 3 existing non-null assertion warnings)
- `npm run build:daemon` passed in the primary checkout. The clean worktree reached `build-daemon-web` but lacked its local `node_modules/@xterm` asset path.

## Scope
`socket.write()` acceptance is not distributed confirmation. A transport loss after handoff remains an uncertain state; the client now reports that uncertainty instead of claiming neither side is paired.

Addresses #658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LAN pairing reliability when confirmations are interrupted by socket closure or frame timeouts.
  * Pairing persistence now supports rollback during the confirmation window, preventing inconsistent peer state after activation or confirmation delivery failures.
  * Enhanced secure session activation with clearer timeout handling and stage-aware error guidance for safe retry behavior.

* **Refactor**
  * Streamlined peer pairing commit/rollback flow and centralized state snapshotting to make confirmation handling more deterministic and failure-safe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->