### PR TITLE
Default the orchestrator to the terminal brain

### DIFF
--- a/changelog.d/710.md
+++ b/changelog.d/710.md
@@ -1,0 +1,29 @@
+### Changed
+
+- **The orchestrator now runs on the terminal brain by default.** The Command
+  Deck drives your own `claude` binary in an embedded terminal instead of the
+  Agent SDK, so it needs no API key and picks up its per-workspace `CLAUDE.md`
+  from disk every time it starts. The SDK brain has not gone anywhere: it stays
+  selectable under Settings › Orchestrator, and wmux still falls back to it
+  automatically when daemon mode is unavailable. Existing installs move over on
+  the next launch. The move is reversible and costs no history — each brain
+  keeps its own conversation, so switching back in Settings picks your SDK
+  conversation up exactly where it was. (#710)
+
+### Fixed
+
+- **The orchestrator model picker now applies to the terminal brain.** The
+  model only ever reached the orchestrator when you typed into the deck
+  composer, and the terminal brain has no composer — you type into its terminal.
+  Choosing a model therefore did nothing for it, and scheduled or event-driven
+  turns ran on whatever model your last typed message happened to leave behind.
+  The picker now applies on every path. (#710)
+- **A workspace that started without a running daemon no longer loses its
+  terminal conversation.** With no daemon the deck quietly serves the SDK brain
+  instead, but it filed that conversation under the terminal brain's name. The
+  terminal conversation could not be resumed afterwards, the substitute brain
+  was told it had no memory to write to, and the workspace stayed on the
+  substitute even after the daemon came back. (#710)
+- **Full-power mode no longer looks available when it cannot do anything.** It
+  only applies to the SDK brain, so under the terminal and Hermes brains the
+  toggle now explains that instead of silently ignoring the click. (#710)

--- a/src/main/ipc/handlers/__tests__/deck.handler.model.test.ts
+++ b/src/main/ipc/handlers/__tests__/deck.handler.model.test.ts
@@ -92,6 +92,13 @@ const send = (payload: Record<string, unknown>) =>
     code?: string;
   }>;
 
+/** Select the brain vendor. Needed by the full-power cases: full power is an
+ *  SDK-only knob, and the DEFAULT vendor is the terminal brain, which ignores
+ *  it (so it must not swap on a toggle). The model cases deliberately stay on
+ *  the default — `--model` reaches the terminal brain too. */
+const setVendor = (vendor: string) =>
+  captured.get(IPC.DECK_BRAIN_VENDOR_SET)!({}, { vendor }) as Promise<{ vendor: string }>;
+
 beforeEach(() => {
   captured.clear();
   adapters = [];
@@ -120,6 +127,26 @@ describe('deck:send — orchestrator model override', () => {
     expect(adapters).toHaveLength(2);
     expect(adapters[0].disposed).toBe(true);
     expect(adapters[1].model).toBe('sonnet');
+  });
+
+  it('swaps the TERMINAL brain too — `--model` reaches its TUI as well', async () => {
+    // Regression: the swap check used to gate on vendor==='claude', so a model
+    // change never respawned the terminal brain even though createAdapter
+    // forwards `model` to it. The picker looked live and did nothing.
+    await setVendor('claude-pty');
+    await send({ text: 'hi', model: 'opus' });
+    await send({ text: 'again', model: 'sonnet' });
+    expect(adapters).toHaveLength(2);
+    expect(adapters[0].disposed).toBe(true);
+    expect(adapters[1].model).toBe('sonnet');
+  });
+
+  it('leaves an ACP brain alone on a model change (it ignores the flag)', async () => {
+    await setVendor('hermes');
+    await send({ text: 'hi', model: 'opus' });
+    await send({ text: 'again', model: 'sonnet' });
+    expect(adapters).toHaveLength(1);
+    expect(adapters[0].disposed).toBe(false);
   });
 
   it('switching back to default is also a swap', async () => {
@@ -231,6 +258,7 @@ describe('deck full-power mode (BYOB approach A) — MAIN-side authority', () =>
       return a;
     });
 
+    await setVendor('claude'); // full power is an SDK-only knob
     const turn = send({ text: 'long turn' });
     await setFullPower(true);
     expect(adapters[0].disposed).toBe(false); // in-flight turn survives

--- a/src/main/ipc/handlers/__tests__/deck.handler.model.test.ts
+++ b/src/main/ipc/handlers/__tests__/deck.handler.model.test.ts
@@ -99,6 +99,16 @@ const send = (payload: Record<string, unknown>) =>
 const setVendor = (vendor: string) =>
   captured.get(IPC.DECK_BRAIN_VENDOR_SET)!({}, { vendor }) as Promise<{ vendor: string }>;
 
+/** Sync the orchestrator model picker (main-side authority). */
+const setModel = (model: unknown) =>
+  captured.get(IPC.DECK_MODEL_SET)!({}, { model }) as Promise<{ model: string }>;
+
+/** A turn that did NOT come from the deck composer — the Wake button, a
+ *  schedule, an event push. This is the ONLY turn shape the terminal brain has
+ *  (its layout has no composer), so it is where the model has to apply. */
+const wake = (workspaceId = 'ws-1') =>
+  captured.get(IPC.DECK_WAKE)!({}, { workspaceId }) as Promise<{ ok: boolean }>;
+
 beforeEach(() => {
   captured.clear();
   adapters = [];
@@ -127,6 +137,57 @@ describe('deck:send — orchestrator model override', () => {
     expect(adapters).toHaveLength(2);
     expect(adapters[0].disposed).toBe(true);
     expect(adapters[1].model).toBe('sonnet');
+  });
+
+  it('applies the picker to a composer-less terminal brain (main-side authority)', async () => {
+    // The regression this whole seam exists for: the terminal brain's layout
+    // has no composer, so DECK_SEND — the only way the model used to reach
+    // main — never fires for it. The picker was inert for the DEFAULT vendor.
+    await setVendor('claude-pty');
+    await setModel('opus');
+    await wake();
+    expect(adapters).toHaveLength(1);
+    expect(adapters[0].model).toBe('opus');
+  });
+
+  it('retires an idle stale-model brain on the set, so the next turn is on the new model', async () => {
+    await setVendor('claude-pty');
+    await setModel('opus');
+    await wake();
+    await setModel('sonnet');
+    expect(adapters[0].disposed).toBe(true);
+    await wake();
+    expect(adapters).toHaveLength(2);
+    expect(adapters[1].model).toBe('sonnet');
+  });
+
+  it('leaves an ACP brain alone on a model set (it ignores the flag)', async () => {
+    await setVendor('hermes');
+    await setModel('opus');
+    await wake();
+    await setModel('sonnet');
+    expect(adapters[0].disposed).toBe(false);
+    expect(adapters).toHaveLength(1);
+  });
+
+  it('sanitizes a hostile model on the authority path too (never reaches the CLI)', async () => {
+    await setModel('opus; rm -rf /');
+    expect((await setModel('opus; rm -rf /')).model).toBe('');
+    await wake();
+    expect(adapters[0].model).toBeUndefined();
+  });
+
+  it('an autonomous turn no longer pins a brain to the vendor default', async () => {
+    // Previously the autonomous path passed `managers.get(ws)?.model ?? ''`, so
+    // a schedule that woke first spawned on '' and the operator's picker only
+    // took effect once something was TYPED — which then dispose+respawned the
+    // brain (killing a live TUI) on the very next composer send.
+    await setModel('opus');
+    await wake();
+    expect(adapters[0].model).toBe('opus');
+    await send({ text: 'hi', model: 'opus' });
+    expect(adapters).toHaveLength(1);
+    expect(adapters[0].disposed).toBe(false);
   });
 
   it('swaps the TERMINAL brain too — `--model` reaches its TUI as well', async () => {

--- a/src/main/ipc/handlers/__tests__/deck.handler.vendor.test.ts
+++ b/src/main/ipc/handlers/__tests__/deck.handler.vendor.test.ts
@@ -218,8 +218,20 @@ describe('deck handler — the commander system prompt per vendor', () => {
   });
 
   it('keeps the Write/memory policy for the SDK brain', async () => {
+    // Explicit: the terminal brain is the DEFAULT vendor now, so this case has
+    // to select the SDK brain rather than lean on whatever the default is.
+    await setVendor('claude');
     await send('ws-2');
     const prompt = adapters[0].startOptions?.systemPrompt ?? '';
     expect(prompt).toContain('You have a Write tool');
+  });
+
+  it('defaults to the terminal brain before the renderer syncs a vendor', async () => {
+    // The main-side vendor is authoritative for turns that beat the renderer's
+    // first DECK_BRAIN_VENDOR_SET (a schedule or event wake at launch). It must
+    // agree with the store default, or those turns silently run the SDK brain.
+    await send('ws-1');
+    const prompt = adapters[0].startOptions?.systemPrompt ?? '';
+    expect(prompt).toContain('You have NO durable memory in this mode');
   });
 });

--- a/src/main/ipc/handlers/__tests__/deck.handler.vendor.test.ts
+++ b/src/main/ipc/handlers/__tests__/deck.handler.vendor.test.ts
@@ -138,9 +138,12 @@ describe('deck handler — brain vendor narrowing', () => {
     expect((await setVendor('claude')).vendor).toBe('claude');
   });
 
-  it('fails closed to claude for anything unknown', async () => {
+  it('fails closed to the terminal brain for anything unknown', async () => {
+    // The fail-closed target follows the DEFAULT, which moved with the store's
+    // (uiSlice / loadSession). Coercing to a different vendor than the renderer
+    // would also split the commander session key for the same bad input.
     for (const bad of ['gpt', '', null, 42, { vendor: 'claude-pty' }]) {
-      expect((await setVendor(bad)).vendor).toBe('claude');
+      expect((await setVendor(bad)).vendor).toBe('claude-pty');
     }
   });
 
@@ -224,6 +227,61 @@ describe('deck handler — the commander system prompt per vendor', () => {
     await send('ws-2');
     const prompt = adapters[0].startOptions?.systemPrompt ?? '';
     expect(prompt).toContain('You have a Write tool');
+  });
+
+  it('no daemon → the terminal brain resolves to the SDK brain, key and policy together', async () => {
+    // The terminal brain's pty IS a daemon session, so with no daemon the deck
+    // serves an SDK brain instead. Everything derived from the vendor has to
+    // follow that runtime, not the request: otherwise an SDK session id lands
+    // under the `::claude-pty` key (leaving the real terminal conversation
+    // unresumable) and an SDK brain that DOES have Write is told it has no
+    // durable memory.
+    captured.clear();
+    cleanup?.();
+    adapters = [];
+    sessionKeys.length = 0;
+    cleanup = registerDeckHandler(() => fakeWindow, {
+      getDaemonClient: () => null,
+      createAdapter: (opts) => {
+        const a = new FakeAdapter(opts.vendor, opts.workspaceId, opts.onPtySpawned, opts.model);
+        adapters.push(a);
+        return a;
+      },
+    });
+
+    await setVendor('claude-pty');
+    await send('ws-1');
+    expect(adapters[0].vendor).toBe('claude');
+    expect(sessionKeys).toContain('ws-1');
+    expect(sessionKeys).not.toContain('ws-1::claude-pty');
+    expect(adapters[0].startOptions?.systemPrompt ?? '').toContain('You have a Write tool');
+  });
+
+  it('promotes the fallback brain back to the terminal one once the daemon returns', async () => {
+    // The fallback manager must be recorded as what it IS ('claude'), or the
+    // swap check compares two REQUESTS ('claude-pty' vs 'claude-pty'), finds
+    // them equal, and strands the workspace on the SDK brain until restart.
+    captured.clear();
+    cleanup?.();
+    adapters = [];
+    let daemon: unknown = null;
+    cleanup = registerDeckHandler(() => fakeWindow, {
+      getDaemonClient: () => daemon as never,
+      createAdapter: (opts) => {
+        const a = new FakeAdapter(opts.vendor, opts.workspaceId, opts.onPtySpawned, opts.model);
+        adapters.push(a);
+        return a;
+      },
+    });
+
+    await setVendor('claude-pty');
+    await send('ws-1');
+    expect(adapters[0].vendor).toBe('claude');
+    daemon = {};
+    await send('ws-1');
+    expect(adapters).toHaveLength(2);
+    expect(adapters[0].disposed).toBe(true);
+    expect(adapters[1].vendor).toBe('claude-pty');
   });
 
   it('defaults to the terminal brain before the renderer syncs a vendor', async () => {

--- a/src/main/ipc/handlers/__tests__/deck.handler.vendor.test.ts
+++ b/src/main/ipc/handlers/__tests__/deck.handler.vendor.test.ts
@@ -17,12 +17,18 @@ vi.mock('electron', () => ({
 }));
 
 const sessionKeys: string[] = [];
+/** Keys DECK_CONVERSATION_CLEAR actually targeted. A clear that names a key
+ *  nothing ever wrote is a silent no-op, so the key itself is the assertion. */
+const clearedKeys: string[] = [];
 vi.mock('../../../deck/commanderSessionStore', () => ({
   loadCommanderSession: vi.fn((key: string) => {
     sessionKeys.push(key);
     return null;
   }),
   saveCommanderSession: vi.fn(async () => undefined),
+  clearCommanderSession: vi.fn(async (key: string) => {
+    clearedKeys.push(key);
+  }),
 }));
 
 vi.mock('../../../deck/deckPolicy', () => ({
@@ -126,6 +132,7 @@ beforeEach(() => {
   prompts = [];
   failNextTurn = false;
   sessionKeys.length = 0;
+  clearedKeys.length = 0;
   cleanup?.();
   cleanup = null;
   register();
@@ -282,6 +289,62 @@ describe('deck handler — the commander system prompt per vendor', () => {
     expect(adapters).toHaveLength(2);
     expect(adapters[0].disposed).toBe(true);
     expect(adapters[1].vendor).toBe('claude-pty');
+  });
+
+  it('clears the key the workspace actually WROTE, not the one it selected', async () => {
+    // A `/clear` on a fallen-back workspace used to target
+    // `ws-1::claude-pty` — a key nothing had written — so it no-op'd and the
+    // conversation survived its own reset with no error anywhere.
+    captured.clear();
+    cleanup?.();
+    adapters = [];
+    sessionKeys.length = 0;
+    clearedKeys.length = 0;
+    cleanup = registerDeckHandler(() => fakeWindow, {
+      getDaemonClient: () => null,
+      createAdapter: (opts) => {
+        const a = new FakeAdapter(opts.vendor, opts.workspaceId, opts.onPtySpawned, opts.model);
+        adapters.push(a);
+        return a;
+      },
+    });
+
+    await setVendor('claude-pty');
+    await send('ws-1');
+    await captured.get(IPC.DECK_CONVERSATION_CLEAR)!({}, { workspaceId: 'ws-1' });
+    expect(clearedKeys).toEqual(['ws-1']);
+  });
+
+  it('clears the composite key for a real terminal brain', async () => {
+    await setVendor('claude-pty');
+    await send('ws-1');
+    await captured.get(IPC.DECK_CONVERSATION_CLEAR)!({}, { workspaceId: 'ws-1' });
+    expect(clearedKeys).toEqual(['ws-1::claude-pty']);
+  });
+
+  it('keeps injecting ambient blocks into a fallen-back headless brain', async () => {
+    // The changed-only rule exists because a VISIBLE TUI types its whole prompt
+    // on screen. A fallback SDK brain is headless, so gating it like the TUI
+    // silently stopped autonomy/policy edits from reaching it after turn one.
+    captured.clear();
+    cleanup?.();
+    adapters = [];
+    prompts = [];
+    cleanup = registerDeckHandler(() => fakeWindow, {
+      getDaemonClient: () => null,
+      createAdapter: (opts) => {
+        const a = new FakeAdapter(opts.vendor, opts.workspaceId, opts.onPtySpawned, opts.model);
+        adapters.push(a);
+        return a;
+      },
+    });
+
+    await setVendor('claude-pty');
+    await send('ws-1');
+    await send('ws-1');
+    await send('ws-1');
+    expect(prompts).toHaveLength(3);
+    for (const p of prompts) expect(p).toContain('[autonomy]');
   });
 
   it('defaults to the terminal brain before the renderer syncs a vendor', async () => {

--- a/src/main/ipc/handlers/deck.handler.ts
+++ b/src/main/ipc/handlers/deck.handler.ts
@@ -337,6 +337,42 @@ export function registerDeckHandler(
     return /^[A-Za-z0-9._-]{1,64}$/.test(trimmed) ? trimmed : '';
   };
 
+  /**
+   * The vendor that will actually serve a spawn right now. It diverges from the
+   * SELECTED one in exactly one place: the terminal brain's pty IS a daemon
+   * session, so with no daemon createAdapter hands back an SDK brain instead.
+   *
+   * A MISSING accessor is not the same signal as one that returns null: the
+   * former means this host never wired daemon mode into the deck at all (the
+   * unit-test harness, which injects its own factory), the latter is the real
+   * "the daemon is gone" report createAdapter falls back on. Only the latter
+   * downgrades, so a test that selects the terminal brain still gets
+   * terminal-brain semantics.
+   */
+  const resolveEffectiveVendor = (requested: BrainVendor): BrainVendor => {
+    const daemonAvailable = opts.getDaemonClient ? !!opts.getDaemonClient() : true;
+    return requested === 'claude-pty' && !daemonAvailable ? 'claude' : requested;
+  };
+
+  /**
+   * What a workspace is actually RUNNING as: the live manager's recorded
+   * runtime, or — with nothing spawned — what a spawn right now would resolve
+   * to. Every decision derived from the vendor has to read this rather than the
+   * raw selection, or it describes a brain that isn't there. The two that did:
+   * `/clear` computed a session key nothing had ever written (so clearing a
+   * fallen-back workspace silently kept its conversation), and the ambient
+   * dedup treated a headless SDK brain as the visible TUI (so autonomy/policy
+   * edits stopped reaching it after the first turn).
+   */
+  const vendorForWorkspace = (workspaceId: string): BrainVendor =>
+    managers.get(workspaceId)?.vendor ?? resolveEffectiveVendor(brainVendor);
+
+  /** BYOB M0: each vendor keeps its OWN conversation thread. Bare workspaceId
+   *  for the SDK brain so sessions persisted before vendors existed keep
+   *  resuming; composite for everyone else. */
+  const sessionKeyFor = (workspaceId: string, vendor: BrainVendor): string =>
+    vendor === 'claude' ? workspaceId : `${workspaceId}::${vendor}`;
+
   // Brain vendor (BYOB M0) — same main-authority contract as full power.
   // Defaults to the terminal brain (owner decision 2026-07-30) so a turn that
   // races the renderer's first DECK_BRAIN_VENDOR_SET sync lands on the same
@@ -388,16 +424,7 @@ export function registerDeckHandler(
     // is unresumable), an SDK brain told it has no Write tool, and a fallback
     // manager tagged 'claude-pty' that the daemon coming back could never
     // dislodge — because `vendor !== existing.vendor` compared two requests.
-    const requestedVendor = brainVendor;
-    // A MISSING accessor is not the same signal as one that returns null: the
-    // former means this host never wired daemon mode into the deck at all (the
-    // unit-test harness, which injects its own factory), the latter is the real
-    // "the daemon is gone" report that createAdapter falls back on. Only the
-    // latter downgrades, so a test that selects the terminal brain still gets
-    // terminal-brain semantics.
-    const daemonAvailable = opts.getDaemonClient ? !!opts.getDaemonClient() : true;
-    const vendor: BrainVendor =
-      requestedVendor === 'claude-pty' && !daemonAvailable ? 'claude' : requestedVendor;
+    const vendor = resolveEffectiveVendor(brainVendor);
     const existing = managers.get(workspaceId);
     // Only vendor-RELEVANT settings participate in the swap check, so a change
     // never needlessly dispose+respawns a brain that ignores it (GLM review).
@@ -427,10 +454,7 @@ export function registerDeckHandler(
     if (current) return current.manager;
     // P3a: resume this workspace's persisted conversation from the previous
     // app run. A dead id is soft — the adapter falls back to a fresh session.
-    // BYOB M0: each vendor keeps its OWN conversation thread — a composite
-    // store key for non-default vendors, the bare wsId for Claude so existing
-    // persisted sessions keep resuming across this change.
-    const sessionKey = vendor === 'claude' ? workspaceId : `${workspaceId}::${vendor}`;
+    const sessionKey = sessionKeyFor(workspaceId, vendor);
     const persisted = loadCommanderSession(sessionKey);
     // The adapter's foreign-turn callback needs the manager the adapter is
     // about to be constructed INTO — late-bound through this holder, exactly
@@ -551,7 +575,13 @@ export function registerDeckHandler(
     // still applies on the very next turn; unchanged rules stop drowning the
     // terminal. Headless brains keep the unconditional every-turn injection.
     const ambientText = ambient.join('\n\n');
-    if (brainVendor === 'claude-pty') {
+    // Gate on what this workspace is RUNNING, not what was selected. A
+    // `claude-pty` request that fell back to the SDK brain is headless, and
+    // treating it as the visible TUI applies the changed-only rule to a brain
+    // nothing is drowning — so an autonomy/policy edit would stop reaching it
+    // after the first turn. Unknown workspace → the else branch, which injects
+    // unconditionally: the safe direction.
+    if (vendorForWorkspace(workspaceId) === 'claude-pty') {
       if (ambientText && shownAmbientBlocks.get(workspaceId) !== ambientText) {
         pendingAmbientBlocks.set(workspaceId, ambientText);
         blocks.push(ambientText);
@@ -659,8 +689,13 @@ export function registerDeckHandler(
         managers.delete(workspaceId);
         forgetAmbient(workspaceId);
       }
-      const vendor = brainVendor;
-      const sessionKey = vendor === 'claude' ? workspaceId : `${workspaceId}::${vendor}`;
+      // The vendor this workspace actually RAN as, not the one selected: a
+      // `claude-pty` request that fell back to the SDK brain persisted under
+      // the bare workspaceId, so keying the clear off the selection would
+      // target `${workspaceId}::claude-pty` — a key nothing ever wrote. The
+      // clear would no-op and the conversation would survive its own reset.
+      // `entry` is captured above, so this still reads the retired manager.
+      const sessionKey = sessionKeyFor(workspaceId, entry?.vendor ?? resolveEffectiveVendor(brainVendor));
       await clearCommanderSession(sessionKey);
       return { ok: true };
     }),

--- a/src/main/ipc/handlers/deck.handler.ts
+++ b/src/main/ipc/handlers/deck.handler.ts
@@ -320,6 +320,23 @@ export function registerDeckHandler(
   // Synced by DECK_FULLPOWER_SET: on change and once after session hydration.
   let fullPowerEnabled = false;
 
+  // Orchestrator model — same main-authority contract as full power and the
+  // vendor. Previously the model rode ONLY on the DECK_SEND payload, so it
+  // reached main exactly when a human typed into the deck composer. That made
+  // it invisible on two paths that matter: the terminal brain has no composer
+  // at all (its TUI is the input path), and automation-driven turns spawned
+  // brains on whatever the last typed turn happened to leave cached — or on
+  // the SDK default when nothing had been typed yet.
+  let brainModel = '';
+
+  /** Sanitize a model override to a plausible token. It ends up on the brain
+   *  subprocess command line (`--model`), so anything outside this alphabet is
+   *  dropped to '' (the vendor default) rather than forwarded. */
+  const sanitizeModel = (raw: unknown): string => {
+    const trimmed = typeof raw === 'string' ? raw.trim() : '';
+    return /^[A-Za-z0-9._-]{1,64}$/.test(trimmed) ? trimmed : '';
+  };
+
   // Brain vendor (BYOB M0) — same main-authority contract as full power.
   // Defaults to the terminal brain (owner decision 2026-07-30) so a turn that
   // races the renderer's first DECK_BRAIN_VENDOR_SET sync lands on the same
@@ -359,7 +376,28 @@ export function registerDeckHandler(
     // authority (fullPowerEnabled), never from the caller — every turn path
     // gets the same answer.
     const fullPower = fullPowerEnabled;
-    const vendor = brainVendor;
+    // The vendor the operator SELECTED vs. the runtime that will actually
+    // serve this workspace. They diverge in exactly one place: the terminal
+    // brain's pty IS a daemon session, so with no daemon createAdapter hands
+    // back an SDK brain instead. Resolving that here rather than leaving it
+    // buried in the factory is what keeps the derived state honest —
+    // sessionKey, the memory policy, the swap check and the recorded entry all
+    // key off the runtime that exists, not the one that was asked for.
+    // Consequences of getting it wrong, all previously live: an SDK session id
+    // written under the `::claude-pty` key (so the real terminal conversation
+    // is unresumable), an SDK brain told it has no Write tool, and a fallback
+    // manager tagged 'claude-pty' that the daemon coming back could never
+    // dislodge — because `vendor !== existing.vendor` compared two requests.
+    const requestedVendor = brainVendor;
+    // A MISSING accessor is not the same signal as one that returns null: the
+    // former means this host never wired daemon mode into the deck at all (the
+    // unit-test harness, which injects its own factory), the latter is the real
+    // "the daemon is gone" report that createAdapter falls back on. Only the
+    // latter downgrades, so a test that selects the terminal brain still gets
+    // terminal-brain semantics.
+    const daemonAvailable = opts.getDaemonClient ? !!opts.getDaemonClient() : true;
+    const vendor: BrainVendor =
+      requestedVendor === 'claude-pty' && !daemonAvailable ? 'claude' : requestedVendor;
     const existing = managers.get(workspaceId);
     // Only vendor-RELEVANT settings participate in the swap check, so a change
     // never needlessly dispose+respawns a brain that ignores it (GLM review).
@@ -548,10 +586,11 @@ export function registerDeckHandler(
       if (fleetContext && fleetContext.length > FLEET_CONTEXT_MAX_CHARS) {
         fleetContext = fleetContext.slice(0, FLEET_CONTEXT_MAX_CHARS) + '\n…(truncated)';
       }
-      // Model override: sanitize to a plausible model token — this ends up on
-      // the SDK subprocess command line, so reject anything but [A-Za-z0-9._-].
-      const rawModel = typeof req.model === 'string' ? req.model.trim() : '';
-      const model = /^[A-Za-z0-9._-]{1,64}$/.test(rawModel) ? rawModel : '';
+      // A send may still carry the model (the composer rides it along), but it
+      // is no longer the only way main learns it — fall back to the synced
+      // authority so a payload that omits it does not silently reset the brain
+      // to the vendor default.
+      const model = sanitizeModel(req.model) || brainModel;
       const mgr = ensureManager(workspaceId, fleetContext, model);
       // Human input resets this workspace's auto-wake budget and subsumes any
       // buffered push events (the human's own turn re-observes live state) —
@@ -674,6 +713,43 @@ export function registerDeckHandler(
     }),
   );
 
+  ipcMain.removeHandler(IPC.DECK_MODEL_SET);
+  ipcMain.handle(
+    IPC.DECK_MODEL_SET,
+    wrapHandler(IPC.DECK_MODEL_SET, async (
+      _event: Electron.IpcMainInvokeEvent,
+      raw: unknown,
+    ): Promise<{ ok: true; model: string }> => {
+      const req = (raw && typeof raw === 'object' && !Array.isArray(raw))
+        ? (raw as Record<string, unknown>)
+        : {};
+      const model = sanitizeModel(req.model);
+      if (model !== brainModel) {
+        brainModel = model;
+        // Retire IDLE managers on the stale model so the next turn on ANY path
+        // spawns on the new one. Busy managers finish their in-flight turn and
+        // ensureManager swaps them on their next (never-swap-mid-turn). Gated
+        // on the vendors the model actually reaches — an ACP brain ignores it,
+        // and respawning one would cost a conversation for nothing.
+        for (const [workspaceId, entry] of [...managers]) {
+          const modelApplies = entry.vendor === 'claude' || entry.vendor === 'claude-pty';
+          if (
+            modelApplies &&
+            entry.model !== model &&
+            entry.manager.getStatus().status !== 'busy'
+          ) {
+            entry.manager.dispose();
+            managers.delete(workspaceId);
+            forgetAmbient(workspaceId);
+            // A retired terminal brain takes its embedded pty with it.
+            emitBrainPty(workspaceId, null);
+          }
+        }
+      }
+      return { ok: true, model };
+    }),
+  );
+
   ipcMain.removeHandler(IPC.DECK_BRAIN_VENDOR_SET);
   ipcMain.handle(
     IPC.DECK_BRAIN_VENDOR_SET,
@@ -684,9 +760,15 @@ export function registerDeckHandler(
       const req = (raw && typeof raw === 'object' && !Array.isArray(raw))
         ? (raw as Record<string, unknown>)
         : {};
-      // Fail closed to the default: only known vendor ids are accepted.
+      // Fail closed to the default: only known vendor ids are accepted. The
+      // default is the terminal brain, matching every other default site
+      // (uiSlice, loadSession, brainVendor above) — coercing to 'claude' here
+      // would split main and the store onto different vendors, and with them
+      // onto different commander session keys, for the same bad input.
       const vendor: BrainVendor =
-        req.vendor === 'hermes' || req.vendor === 'claude-pty' ? req.vendor : 'claude';
+        req.vendor === 'claude' || req.vendor === 'hermes' || req.vendor === 'claude-pty'
+          ? req.vendor
+          : 'claude-pty';
       if (vendor !== brainVendor) {
         brainVendor = vendor;
         // Retire IDLE stale-vendor brains now (same contract as full power):
@@ -743,9 +825,12 @@ export function registerDeckHandler(
     // a workspace already running a turn must not momentarily consume — or, for
     // the queued path, sit and WAIT on — one of the scarce global slots. ensureManager
     // still runs first (unchanged lazy-creation semantics), we just don't hold the
-    // gate across the check. Scheduled/event-woken turns reuse the live manager's
-    // model; full power always comes from the main-side authority in ensureManager.
-    const preMgr = ensureManager(workspaceId, undefined, managers.get(workspaceId)?.model ?? '');
+    // gate across the check. Scheduled/event-woken turns take the model from the
+    // main-side authority, exactly like full power and the vendor — reusing the
+    // live manager's cached model instead meant an autonomous turn could pin a
+    // brain to '' (the vendor default) and the operator's picker never applied
+    // to a workspace nothing had been typed into.
+    const preMgr = ensureManager(workspaceId, undefined, brainModel);
     if (preMgr.getStatus().status !== 'idle') {
       return { ok: false, code: 'busy' as const };
     }
@@ -767,7 +852,7 @@ export function registerDeckHandler(
       // settings-driven manager swap) could have started/retired this workspace's
       // brain during the wait. From here the status check and send are one
       // synchronous sequence (nothing awaits between them).
-      const mgr = ensureManager(workspaceId, undefined, managers.get(workspaceId)?.model ?? '');
+      const mgr = ensureManager(workspaceId, undefined, brainModel);
       if (mgr.getStatus().status !== 'idle') {
         return { ok: false, code: 'busy' as const };
       }
@@ -1887,6 +1972,7 @@ export function registerDeckHandler(
     ipcMain.removeHandler(IPC.DECK_WAKE);
     ipcMain.removeHandler(IPC.DECK_STATUS);
     ipcMain.removeHandler(IPC.DECK_FULLPOWER_SET);
+    ipcMain.removeHandler(IPC.DECK_MODEL_SET);
     ipcMain.removeHandler(IPC.DECK_BRAIN_VENDOR_SET);
     ipcMain.removeHandler(IPC.DECK_SCHEDULES_LIST);
     ipcMain.removeHandler(IPC.DECK_SCHEDULES_CREATE);

--- a/src/main/ipc/handlers/deck.handler.ts
+++ b/src/main/ipc/handlers/deck.handler.ts
@@ -321,7 +321,11 @@ export function registerDeckHandler(
   let fullPowerEnabled = false;
 
   // Brain vendor (BYOB M0) — same main-authority contract as full power.
-  let brainVendor: BrainVendor = 'claude';
+  // Defaults to the terminal brain (owner decision 2026-07-30) so a turn that
+  // races the renderer's first DECK_BRAIN_VENDOR_SET sync lands on the same
+  // vendor the store defaults to. createAdapter still falls back to the SDK
+  // brain when daemon mode is unavailable.
+  let brainVendor: BrainVendor = 'claude-pty';
 
   // Event-push coalescer. Declared here, constructed below once
   // runTurnForWorkspace exists — the manager's onIdle closure references it
@@ -357,13 +361,21 @@ export function registerDeckHandler(
     const fullPower = fullPowerEnabled;
     const vendor = brainVendor;
     const existing = managers.get(workspaceId);
-    // model/fullPower are Claude-specific — an ACP brain ignores them, so a
-    // change must not needlessly dispose+respawn a non-Claude brain (GLM
-    // review): only vendor-relevant settings participate in the swap check.
-    const claudeSettingsChanged =
-      vendor === 'claude' && existing
-        ? model !== existing.model || fullPower !== existing.fullPower
-        : false;
+    // Only vendor-RELEVANT settings participate in the swap check, so a change
+    // never needlessly dispose+respawns a brain that ignores it (GLM review).
+    // The two knobs have different reach, and conflating them left the model
+    // picker dead on the terminal brain (harmless while it was opt-in, a
+    // default-path bug once it became the default):
+    //   model     — reaches BOTH Claude runtimes; createAdapter forwards it to
+    //               the SDK brain and to the TUI's `--model` alike.
+    //   fullPower — SDK-only: it tunes settingSources/canUseTool, which an
+    //               interactive session has no equivalent for.
+    // An ACP brain ignores both.
+    const modelApplies = vendor === 'claude' || vendor === 'claude-pty';
+    const claudeSettingsChanged = existing
+      ? (modelApplies && model !== existing.model) ||
+        (vendor === 'claude' && fullPower !== existing.fullPower)
+      : false;
     if (
       existing &&
       (vendor !== existing.vendor || claudeSettingsChanged) &&

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -510,6 +510,13 @@ const electronAPI = {
           code?: string;
         }>,
     },
+    // Orchestrator model picker → main-side authority, so scheduled and
+    // event-woken turns (and the composer-less terminal brain) all see it.
+    modelSet: (model: string) =>
+      ipcRenderer.invoke(IPC.DECK_MODEL_SET, { model }) as Promise<{
+        ok: true;
+        model: string;
+      }>,
     // The operator's `/clear` — resets one workspace orchestrator's brain
     // context (fresh SDK conversation on the next turn). Transcript stays.
     conversation: {

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -228,6 +228,9 @@ function buildSessionData(dumped: Map<string, boolean>): SessionData {
     // a user who deliberately turned it off (CodeRabbit, PR #474).
     deckBrainFullPower: state.deckBrainFullPower,
     deckBrainVendor: state.deckBrainVendor,
+    // Must persist, or the one-shot terminal-brain upgrade re-runs on every
+    // load and overrides a user who picks the SDK brain back.
+    deckBrainVendorMigrated: state.deckBrainVendorMigrated,
     channelsTabVisible: state.channelsTabVisible,
     paneActionsVisible: state.paneActionsVisible,
     splitInheritsCwd: state.splitInheritsCwd,
@@ -934,6 +937,14 @@ export default function AppLayout() {
   useEffect(() => {
     void window.electronAPI?.deck?.brainVendorSet?.(deckBrainVendorLive);
   }, [deckBrainVendorLive]);
+
+  // …and for the orchestrator model. The composer still rides it on each send,
+  // but that path does not exist for the terminal brain (no composer — the TUI
+  // is the input) and never covered scheduled / event-woken turns.
+  const deckBrainModelLive = useStore((s) => s.deckBrainModel);
+  useEffect(() => {
+    void window.electronAPI?.deck?.modelSet?.(deckBrainModelLive);
+  }, [deckBrainModelLive]);
 
   // ─── First-run onboarding (spotlight) detection ─────────────────────
   // D8: spotlight stays gated behind firstRunCompleted so the wizard always

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -283,16 +283,20 @@ interface ToggleProps {
   checked: boolean;
   onChange: (checked: boolean) => void;
   label: string;
+  /** Inert + dimmed. For a setting the CURRENT vendor/mode ignores, so the row
+   *  explains itself instead of silently doing nothing when clicked. */
+  disabled?: boolean;
 }
 
-function Toggle({ checked, onChange, label }: ToggleProps) {
+function Toggle({ checked, onChange, label, disabled }: ToggleProps) {
   return (
     <button
       role="switch"
       aria-checked={checked}
       aria-label={label}
+      disabled={disabled}
       onClick={() => onChange(!checked)}
-      className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors shrink-0 ${FOCUS_RING}`}
+      className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors shrink-0 disabled:opacity-40 disabled:cursor-not-allowed ${FOCUS_RING}`}
       style={{ backgroundColor: checked ? 'var(--accent-blue)' : 'var(--bg-overlay)' }}
     >
       <span
@@ -869,7 +873,7 @@ function OrchestratorSection() {
         <SettingSelect
           value={deckBrainVendor}
           onChange={(v) =>
-            setDeckBrainVendor(v === 'hermes' || v === 'claude-pty' ? v : 'claude')
+            setDeckBrainVendor(v === 'claude' || v === 'hermes' ? v : 'claude-pty')
           }
           options={[
             { value: 'claude', label: t('settings.orchestratorBrainClaude') },
@@ -891,14 +895,25 @@ function OrchestratorSection() {
         />
       </SettingRow>
       <RoleBindingEditor />
+      {/* Full power tunes settingSources/canUseTool — both SDK-only knobs. The
+          terminal brain (an interactive TUI) and ACP brains ignore the flag
+          entirely (see createAdapter in deck.handler), so with the terminal
+          brain now the default the row would otherwise read as a toggle that
+          does nothing when clicked. Inert + a reason instead of hidden: the
+          setting still exists, it just belongs to the other vendor. */}
       <SettingRow
         label={t('settings.orchestratorFullPower')}
-        description={t('settings.orchestratorFullPowerDesc')}
+        description={
+          deckBrainVendor === 'claude'
+            ? t('settings.orchestratorFullPowerDesc')
+            : t('settings.orchestratorFullPowerSdkOnly')
+        }
       >
         <Toggle
           checked={deckBrainFullPower}
           onChange={setDeckBrainFullPower}
           label={t('settings.orchestratorFullPower')}
+          disabled={deckBrainVendor !== 'claude'}
         />
       </SettingRow>
       <SettingRow

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -374,9 +374,9 @@ export const en = {
   'settings.orchestrator': 'Orchestrator',
   'settings.orchestratorBrain': 'Orchestrator brain',
   'settings.orchestratorBrainDesc':
-    'Which agent runtime drives the Command Deck. Claude Code is the default; Hermes (ACP) requires the Hermes Agent CLI installed and authenticated on this machine — run its own setup first. Applies from the next brain turn; each brain keeps its own conversation history.',
-  'settings.orchestratorBrainClaude': 'Claude Code (default)',
-  'settings.orchestratorBrainClaudePty': 'Claude Code (terminal) — subscription',
+    'Which agent runtime drives the Command Deck. The terminal brain is the default — it drives your own claude binary on your subscription. Hermes (ACP) requires the Hermes Agent CLI installed and authenticated on this machine — run its own setup first. Applies from the next brain turn; each brain keeps its own conversation history.',
+  'settings.orchestratorBrainClaude': 'Claude Code (SDK)',
+  'settings.orchestratorBrainClaudePty': 'Claude Code (terminal, default) — subscription',
   'settings.orchestratorBrainHermes': 'Hermes Agent (ACP) — experimental',
   'settings.orchestratorModel': 'Orchestrator model',
   'settings.orchestratorModelDesc':
@@ -385,6 +385,8 @@ export const en = {
   'settings.orchestratorFullPower': 'Full-power mode',
   'settings.orchestratorFullPowerDesc':
     'Load your Claude Code skills, CLAUDE.md and hooks into orchestrator turns. Your hooks run inside brain turns (your own code, outside any wmux sandbox), tool calls may get slower, and the brain cannot write its memory notes while this is on. Applies from the next brain turn.',
+  'settings.orchestratorFullPowerSdkOnly':
+    'Applies to the Claude Code (SDK) brain only. The terminal brain already runs your own Claude Code setup, and Hermes ignores the flag — switch the orchestrator brain above to change this.',
   // D2 — role → agent/model enforcement editor (Settings › Orchestrator).
   'settings.roleBindings': 'Role → model enforcement',
   'settings.roleBindingsDesc':

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -270,9 +270,9 @@ export const ko = {
   'settings.orchestrator': 'agent',
   'settings.orchestratorBrain': 'agent 브레인',
   'settings.orchestratorBrainDesc':
-    '커맨드 데크를 구동할 에이전트 런타임. 기본은 Claude Code, Hermes(ACP)는 이 PC에 Hermes Agent CLI 설치·인증이 필요합니다(자체 setup 먼저). 다음 agent 턴부터 적용되며 브레인별로 대화 이력이 따로 유지됩니다.',
-  'settings.orchestratorBrainClaude': 'Claude Code (기본)',
-  'settings.orchestratorBrainClaudePty': 'Claude Code (터미널) — 구독',
+    '커맨드 데크를 구동할 에이전트 런타임. 기본은 터미널 브레인으로, 본인 claude 바이너리를 구독으로 구동합니다. Hermes(ACP)는 이 PC에 Hermes Agent CLI 설치·인증이 필요합니다(자체 setup 먼저). 다음 agent 턴부터 적용되며 브레인별로 대화 이력이 따로 유지됩니다.',
+  'settings.orchestratorBrainClaude': 'Claude Code (SDK)',
+  'settings.orchestratorBrainClaudePty': 'Claude Code (터미널, 기본) — 구독',
   'settings.orchestratorBrainHermes': 'Hermes Agent (ACP) — 실험적',
   'settings.orchestratorModel': 'agent 모델',
   'settings.orchestratorModelDesc':
@@ -281,6 +281,8 @@ export const ko = {
   'settings.orchestratorFullPower': '풀파워 모드',
   'settings.orchestratorFullPowerDesc':
     'Claude Code의 스킬·CLAUDE.md·훅을 agent 턴에 로드합니다. 개인 훅이 agent 턴 안에서 실행되고(wmux 샌드박스 밖의 본인 코드), 툴 호출이 느려질 수 있으며, 켜져 있는 동안 agent는 메모리 노트를 쓸 수 없습니다. 다음 agent 턴부터 적용됩니다.',
+  'settings.orchestratorFullPowerSdkOnly':
+    'Claude Code(SDK) 브레인에만 적용됩니다. 터미널 브레인은 이미 본인 Claude Code 설정으로 돌아가고 Hermes는 이 플래그를 무시합니다 — 위에서 브레인을 바꾸면 사용할 수 있습니다.',
   // 워크스페이스별 agent 모드 — 단일 자율성 노브(off/assist/auto).
   'deck.limit.window': '사용량',
   'deck.brainTerminal': '브레인 터미널',

--- a/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
+++ b/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
@@ -734,6 +734,17 @@ describe('loadSession — orchestrator brain vendor coercion', () => {
     expect(store.getState().deckBrainVendor).toBe('claude');
   });
 
+  it('treats a non-boolean marker as unmigrated (session.json is hand-editable)', () => {
+    // `"false"` is truthy: read loosely it would pass as a migrated marker and
+    // lock a legacy 'claude' in as a deliberate choice, permanently exempting
+    // that profile from the upgrade.
+    for (const junk of ['false', 'true', 1, {}]) {
+      const store = createTestStore();
+      store.getState().loadSession(sessionWithVendor('claude', junk as never));
+      expect(store.getState().deckBrainVendor).toBe('claude-pty');
+    }
+  });
+
   it('falls back to the default for an unknown vendor id, migrated or not', () => {
     for (const migrated of [undefined, true]) {
       const store = createTestStore();

--- a/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
+++ b/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
@@ -49,6 +49,7 @@ type TestState = WorkspaceSlice & {
   browserBackend: 'builtin' | 'external';
   // Orchestrator brain vendor — loadSession re-coerces it on every load.
   deckBrainVendor: BrainVendor;
+  deckBrainVendorMigrated: boolean;
 };
 
 function createTestStore() {
@@ -94,6 +95,9 @@ function createTestStore() {
       // test can prove loadSession never writes it (it isn't a SessionData key).
       browserBackend: 'builtin',
       deckBrainVendor: 'claude-pty',
+      // Seeded false (not the uiSlice default) so the marker assertions prove
+      // loadSession sets it rather than reading back the fixture.
+      deckBrainVendorMigrated: false,
     }))
   );
 }
@@ -681,7 +685,7 @@ describe('WorkspaceSlice.loadSession — config merge (forward-compat)', () => {
 // deliberately picked the SDK brain gets silently moved onto the terminal one
 // — and onto a different session key, orphaning their live conversation.
 describe('loadSession — orchestrator brain vendor coercion', () => {
-  function sessionWithVendor(vendor: unknown): SessionData {
+  function sessionWithVendor(vendor: unknown, migrated?: boolean): SessionData {
     const ws: Workspace = {
       id: 'ws-1',
       name: 'WS',
@@ -692,30 +696,49 @@ describe('loadSession — orchestrator brain vendor coercion', () => {
       workspaces: [ws],
       activeWorkspaceId: ws.id,
       ...(vendor === undefined ? {} : { deckBrainVendor: vendor }),
+      ...(migrated === undefined ? {} : { deckBrainVendorMigrated: migrated }),
     } as unknown as SessionData;
   }
 
-  it('takes the terminal-brain default when the session never recorded a vendor', () => {
+  // ── pre-migration sessions (no marker) — every install on disk looks like this
+  it("upgrades a pre-migration 'claude' — it is the OLD DEFAULT, not a choice", () => {
+    // The load-bearing case. AppLayout always serialized the vendor, so an
+    // untouched pre-migration profile carries a literal 'claude'; reading that
+    // as a deliberate pick would strand the whole install base on the SDK brain
+    // and leave the new default reaching new profiles only.
     const store = createTestStore();
-    store.getState().loadSession(sessionWithVendor(undefined));
+    store.getState().loadSession(sessionWithVendor('claude'));
     expect(store.getState().deckBrainVendor).toBe('claude-pty');
   });
 
-  it('restores an explicit SDK choice instead of migrating it to the default', () => {
+  it('keeps a pre-migration hermes/claude-pty pick (only reachable explicitly)', () => {
+    for (const picked of ['hermes', 'claude-pty'] as const) {
+      const store = createTestStore();
+      store.getState().loadSession(sessionWithVendor(picked));
+      expect(store.getState().deckBrainVendor).toBe(picked);
+    }
+  });
+
+  it('marks any loaded session migrated so the upgrade cannot run twice', () => {
     const store = createTestStore();
     store.getState().loadSession(sessionWithVendor('claude'));
+    expect(store.getState().deckBrainVendorMigrated).toBe(true);
+  });
+
+  // ── post-migration sessions (marker present) — the vendor is authoritative
+  it('restores an SDK choice made AFTER the migration', () => {
+    // Without the marker this would be re-upgraded on every load and the user
+    // could never stay on the SDK brain.
+    const store = createTestStore();
+    store.getState().loadSession(sessionWithVendor('claude', true));
     expect(store.getState().deckBrainVendor).toBe('claude');
   });
 
-  it('restores an explicit hermes choice', () => {
-    const store = createTestStore();
-    store.getState().loadSession(sessionWithVendor('hermes'));
-    expect(store.getState().deckBrainVendor).toBe('hermes');
-  });
-
-  it('falls back to the default for an unknown vendor id (session.json is hand-editable)', () => {
-    const store = createTestStore();
-    store.getState().loadSession(sessionWithVendor('gpt-9'));
-    expect(store.getState().deckBrainVendor).toBe('claude-pty');
+  it('falls back to the default for an unknown vendor id, migrated or not', () => {
+    for (const migrated of [undefined, true]) {
+      const store = createTestStore();
+      store.getState().loadSession(sessionWithVendor('gpt-9', migrated));
+      expect(store.getState().deckBrainVendor).toBe('claude-pty');
+    }
   });
 });

--- a/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
+++ b/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { createWorkspaceSlice, type WorkspaceSlice } from '../workspaceSlice';
-import { DEFAULT_PREFIX_CONFIG, DEFAULT_CUSTOM_KEYBINDINGS, type Company, type Pane, type SessionData, type Workspace } from '../../../../shared/types';
+import { DEFAULT_PREFIX_CONFIG, DEFAULT_CUSTOM_KEYBINDINGS, type BrainVendor, type Company, type Pane, type SessionData, type Workspace } from '../../../../shared/types';
 
 // Fix 0 — minimum cross-slice state surface that workspaceSlice.loadSession
 // and clearAllPtyState mutate. We intentionally don't pull in the full
@@ -47,6 +47,8 @@ type TestState = WorkspaceSlice & {
   newConversationCommand: string;
   // #517 — main-owned browser backend mirror (NOT a SessionData key).
   browserBackend: 'builtin' | 'external';
+  // Orchestrator brain vendor — loadSession re-coerces it on every load.
+  deckBrainVendor: BrainVendor;
 };
 
 function createTestStore() {
@@ -91,6 +93,7 @@ function createTestStore() {
       // #517 — main-owned backend mirror. Seeded here so the non-persistence
       // test can prove loadSession never writes it (it isn't a SessionData key).
       browserBackend: 'builtin',
+      deckBrainVendor: 'claude-pty',
     }))
   );
 }
@@ -669,5 +672,50 @@ describe('WorkspaceSlice.loadSession — config merge (forward-compat)', () => {
     } finally {
       (globalThis.window as unknown as { electronAPI: { platform?: string } }).electronAPI.platform = prevPlatform;
     }
+  });
+});
+
+// The terminal brain became the default orchestrator (owner decision
+// 2026-07-30). The coercion below is the whole migration: 'claude' stopped
+// being the fallback, so it has to be whitelisted explicitly or a user who
+// deliberately picked the SDK brain gets silently moved onto the terminal one
+// — and onto a different session key, orphaning their live conversation.
+describe('loadSession — orchestrator brain vendor coercion', () => {
+  function sessionWithVendor(vendor: unknown): SessionData {
+    const ws: Workspace = {
+      id: 'ws-1',
+      name: 'WS',
+      rootPane: makeBrowserSurfaceTree('https://example.com'),
+      activePaneId: 'pane-root',
+    };
+    return {
+      workspaces: [ws],
+      activeWorkspaceId: ws.id,
+      ...(vendor === undefined ? {} : { deckBrainVendor: vendor }),
+    } as unknown as SessionData;
+  }
+
+  it('takes the terminal-brain default when the session never recorded a vendor', () => {
+    const store = createTestStore();
+    store.getState().loadSession(sessionWithVendor(undefined));
+    expect(store.getState().deckBrainVendor).toBe('claude-pty');
+  });
+
+  it('restores an explicit SDK choice instead of migrating it to the default', () => {
+    const store = createTestStore();
+    store.getState().loadSession(sessionWithVendor('claude'));
+    expect(store.getState().deckBrainVendor).toBe('claude');
+  });
+
+  it('restores an explicit hermes choice', () => {
+    const store = createTestStore();
+    store.getState().loadSession(sessionWithVendor('hermes'));
+    expect(store.getState().deckBrainVendor).toBe('hermes');
+  });
+
+  it('falls back to the default for an unknown vendor id (session.json is hand-editable)', () => {
+    const store = createTestStore();
+    store.getState().loadSession(sessionWithVendor('gpt-9'));
+    expect(store.getState().deckBrainVendor).toBe('claude-pty');
   });
 });

--- a/src/renderer/stores/slices/uiSlice.ts
+++ b/src/renderer/stores/slices/uiSlice.ts
@@ -183,6 +183,10 @@ export interface UISlice {
   // the deck. Main-authoritative like fullPower — AppLayout syncs it.
   deckBrainVendor: import('../../../shared/types').BrainVendor;
   setDeckBrainVendor: (vendor: import('../../../shared/types').BrainVendor) => void;
+  /** Whether this session has been through the terminal-brain default
+   *  migration. Persisted so the one-shot upgrade cannot re-run and override a
+   *  user who picks the SDK brain back AFTER it. See SessionData. */
+  deckBrainVendorMigrated: boolean;
 
   // Whether the deck shows the Channels tab (the human channel UI). Default
   // OFF: the orchestrator is the single interface and channels are its
@@ -885,8 +889,16 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
   // selectable — and is still the automatic fallback when there is no daemon.
   deckBrainVendor: 'claude-pty',
 
+  // A store with no session loaded is a FRESH profile — it starts on the new
+  // default and has nothing to migrate. loadSession flips this for a session
+  // that predates the migration.
+  deckBrainVendorMigrated: true,
+
   setDeckBrainVendor: (vendor) => set((state) => {
     state.deckBrainVendor = vendor;
+    // An explicit pick is exactly what the marker records: from here on the
+    // stored vendor is authoritative and must never be re-upgraded.
+    state.deckBrainVendorMigrated = true;
   }),
 
   channelsTabVisible: false,

--- a/src/renderer/stores/slices/uiSlice.ts
+++ b/src/renderer/stores/slices/uiSlice.ts
@@ -879,7 +879,11 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
     state.deckBrainFullPower = enabled;
   }),
 
-  deckBrainVendor: 'claude',
+  // The terminal brain is the default orchestrator (owner decision 2026-07-30):
+  // it drives the user's OWN claude binary, so it needs no API key and reads
+  // its per-workspace CLAUDE.md from disk on every spawn. The SDK brain stays
+  // selectable — and is still the automatic fallback when there is no daemon.
+  deckBrainVendor: 'claude-pty',
 
   setDeckBrainVendor: (vendor) => set((state) => {
     state.deckBrainVendor = vendor;

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -728,7 +728,11 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
       // which is what lets a user pick the SDK brain back and keep it.
       const recordedVendor = data.deckBrainVendor;
       const explicitlyPicked = recordedVendor === 'hermes' || recordedVendor === 'claude-pty';
-      state.deckBrainVendor = data.deckBrainVendorMigrated
+      // Strict boolean, like deckBrainFullPower above: session.json is
+      // hand-editable, and a truthy non-boolean (`"false"`) would otherwise
+      // pass as a migrated marker and lock a legacy 'claude' in as a choice.
+      const alreadyMigrated = data.deckBrainVendorMigrated === true;
+      state.deckBrainVendor = alreadyMigrated
         ? (recordedVendor === 'claude' || explicitlyPicked ? recordedVendor : 'claude-pty')
         : (explicitlyPicked ? recordedVendor : 'claude-pty');
       // Loading a session always leaves the profile migrated — the next save

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -711,10 +711,17 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
       // Fail closed to raw mode: only an explicit true enables full power.
       state.deckBrainFullPower = data.deckBrainFullPower === true;
       // Fail closed to the default brain: only known vendor ids are restored.
+      // 'claude' must be listed EXPLICITLY now that it is no longer the
+      // fallback — it is a deliberate SDK choice, and a session that recorded
+      // it must keep resuming its own conversation instead of being migrated
+      // onto the terminal brain (which keys its sessions separately). An
+      // ABSENT field means the user never chose, so it takes the new default.
       state.deckBrainVendor =
-        data.deckBrainVendor === 'hermes' || data.deckBrainVendor === 'claude-pty'
+        data.deckBrainVendor === 'claude' ||
+        data.deckBrainVendor === 'hermes' ||
+        data.deckBrainVendor === 'claude-pty'
           ? data.deckBrainVendor
-          : 'claude';
+          : 'claude-pty';
       // Fail closed to hidden: only an explicit boolean shows the (frozen)
       // human channel UI.
       if (typeof data.channelsTabVisible === 'boolean') {

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -710,18 +710,30 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
       state.orchestratorRoleBindings = normalizeRoleBindings(data.orchestratorRoleBindings);
       // Fail closed to raw mode: only an explicit true enables full power.
       state.deckBrainFullPower = data.deckBrainFullPower === true;
-      // Fail closed to the default brain: only known vendor ids are restored.
-      // 'claude' must be listed EXPLICITLY now that it is no longer the
-      // fallback — it is a deliberate SDK choice, and a session that recorded
-      // it must keep resuming its own conversation instead of being migrated
-      // onto the terminal brain (which keys its sessions separately). An
-      // ABSENT field means the user never chose, so it takes the new default.
-      state.deckBrainVendor =
-        data.deckBrainVendor === 'claude' ||
-        data.deckBrainVendor === 'hermes' ||
-        data.deckBrainVendor === 'claude-pty'
-          ? data.deckBrainVendor
-          : 'claude-pty';
+      // Brain vendor. Fail closed to the default: only known ids are restored.
+      //
+      // The marker — not the value — decides whether a recorded 'claude' is a
+      // CHOICE. AppLayout has always serialized deckBrainVendor unconditionally,
+      // so "absent" describes no real install: every pre-migration session on
+      // disk carries a literal 'claude' regardless of whether its user ever
+      // opened Settings. Keying off the value alone would therefore pin the
+      // entire existing install base to the SDK brain and leave the new default
+      // reaching new profiles only.
+      //
+      // Pre-migration (no marker): 'claude' is read as the OLD DEFAULT and
+      // upgraded once. 'hermes'/'claude-pty' were only ever reachable by an
+      // explicit pick, so they are kept. Non-destructive — sessions are keyed
+      // per vendor and nothing is cleared, so Settings restores the exact SDK
+      // conversation. Post-migration: every recorded vendor is authoritative,
+      // which is what lets a user pick the SDK brain back and keep it.
+      const recordedVendor = data.deckBrainVendor;
+      const explicitlyPicked = recordedVendor === 'hermes' || recordedVendor === 'claude-pty';
+      state.deckBrainVendor = data.deckBrainVendorMigrated
+        ? (recordedVendor === 'claude' || explicitlyPicked ? recordedVendor : 'claude-pty')
+        : (explicitlyPicked ? recordedVendor : 'claude-pty');
+      // Loading a session always leaves the profile migrated — the next save
+      // records it, so the one-shot upgrade cannot run twice.
+      state.deckBrainVendorMigrated = true;
       // Fail closed to hidden: only an explicit boolean shows the (frozen)
       // human channel UI.
       if (typeof data.channelsTabVisible === 'boolean') {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -165,6 +165,17 @@ export const IPC = {
   //                   turn path consults it, idle stale-vendor brains retire
   //                   on change, renderer pushes on change + after hydration.
   DECK_BRAIN_VENDOR_SET: 'deck:brainvendor:set',
+  //   DECK_MODEL_SET  (invoke) renderer → main: sync the orchestrator model
+  //                   picker. Same main-authority contract as
+  //                   DECK_FULLPOWER_SET / DECK_BRAIN_VENDOR_SET, and it
+  //                   exists for the same reason those do: the model used to
+  //                   ride ONLY on the DECK_SEND payload, so it reached main
+  //                   just when a human typed into the deck composer. The
+  //                   terminal brain has no composer (its TUI is the input
+  //                   path), which left the picker inert for that vendor, and
+  //                   automation-driven turns spawned brains on whatever model
+  //                   the last typed turn happened to leave behind.
+  DECK_MODEL_SET: 'deck:model:set',
   //   DECK_BRAIN_PTY  (send) main → renderer: the `claude-pty` brain just
   //                   spawned its interactive TUI in daemon session <ptyId>.
   //                   One-way and additive to DECK_STREAM (which carries only

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -619,13 +619,31 @@ export interface SessionData {
    *  Code ecosystem (skills/CLAUDE.md/hooks) into brain turns. Absent/false =
    *  raw mode (the safe default). */
   deckBrainFullPower?: boolean;
-  /** Orchestrator brain vendor (BYOB M0). Absent = 'claude-pty', the terminal
-   *  brain that drives the user's own claude binary (the default since
-   *  2026-07-30); 'claude' = the Claude SDK brain; 'hermes' = the generic ACP
-   *  adapter configured for Hermes Agent. A recorded 'claude' is an explicit
-   *  choice and is restored as-is — only an absent/unknown value takes the
-   *  default. */
+  /** Orchestrator brain vendor (BYOB M0). 'claude-pty' = the terminal brain
+   *  that drives the user's own claude binary (the default since 2026-07-30);
+   *  'claude' = the Claude SDK brain; 'hermes' = the generic ACP adapter
+   *  configured for Hermes Agent. Read together with deckBrainVendorMigrated —
+   *  before that marker exists a recorded 'claude' cannot be trusted as a
+   *  choice. */
   deckBrainVendor?: BrainVendor;
+  /** One-shot marker for the terminal-brain default migration (2026-07-30).
+   *
+   *  It exists because the old schema recorded no INTENT. AppLayout has always
+   *  serialized deckBrainVendor unconditionally, so every pre-migration session
+   *  carries a literal 'claude' whether the user picked the SDK brain or simply
+   *  never opened Settings — the two are indistinguishable by value, and
+   *  treating them alike either strands the whole install base on the old
+   *  default or silently overrides deliberate picks on every load.
+   *
+   *  Absent = pre-migration: 'claude' is read as the OLD DEFAULT and upgraded
+   *  once ('hermes'/'claude-pty' were only ever reachable by an explicit pick,
+   *  so they survive). Present = every recorded vendor is authoritative,
+   *  including a 'claude' the user chooses AFTER the migration.
+   *
+   *  The upgrade is non-destructive: commander sessions are keyed per vendor
+   *  and nothing is cleared, so switching back in Settings resumes the exact
+   *  SDK conversation the migration stepped away from. */
+  deckBrainVendorMigrated?: boolean;
   /** Whether the deck shows the Channels tab (human channel UI). Default
    *  false — the orchestrator is the single interface; the tab is an
    *  opt-in inspection surface (Settings). */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -619,8 +619,12 @@ export interface SessionData {
    *  Code ecosystem (skills/CLAUDE.md/hooks) into brain turns. Absent/false =
    *  raw mode (the safe default). */
   deckBrainFullPower?: boolean;
-  /** Orchestrator brain vendor (BYOB M0). Absent/'claude' = the Claude SDK
-   *  brain; 'hermes' = the generic ACP adapter configured for Hermes Agent. */
+  /** Orchestrator brain vendor (BYOB M0). Absent = 'claude-pty', the terminal
+   *  brain that drives the user's own claude binary (the default since
+   *  2026-07-30); 'claude' = the Claude SDK brain; 'hermes' = the generic ACP
+   *  adapter configured for Hermes Agent. A recorded 'claude' is an explicit
+   *  choice and is restored as-is — only an absent/unknown value takes the
+   *  default. */
   deckBrainVendor?: BrainVendor;
   /** Whether the deck shows the Channels tab (human channel UI). Default
    *  false — the orchestrator is the single interface; the tab is an


### PR DESCRIPTION
The Command Deck now starts on the terminal brain — it drives the user's own
`claude` binary, so it needs no API key and re-reads its per-workspace
`CLAUDE.md` from disk on every spawn. Nothing is removed: the SDK brain stays
selectable in Settings and remains the automatic fallback when daemon mode is
unavailable. Only the default moves.

## Making the default actually reach existing installs

The first pass looked correct and did nothing for anyone who already had wmux
installed. `AppLayout` has always serialized `deckBrainVendor` unconditionally,
so "absent" describes no session on disk — every profile predating this carries
a literal `'claude'`, whether its user deliberately picked the SDK brain or
never opened Settings. Reading that value as a choice pins the whole existing
base to the SDK brain and quietly narrows the change to new profiles.

The old schema simply never recorded intent, so a one-shot
`deckBrainVendorMigrated` marker now carries it. Before the marker, `'claude'`
is read as the old default and upgraded once (`'hermes'`/`'claude-pty'` were
only ever reachable by an explicit pick, so they survive). After it, every
recorded vendor is authoritative — which is what lets someone pick the SDK
brain back and keep it across loads.

The upgrade is non-destructive. Commander sessions are keyed per vendor and
nothing is cleared, so switching back in Settings resumes the exact SDK
conversation the migration stepped away from. The unavoidable cost: a user who
deliberately chose the SDK brain before this ships is migrated once too, because
no data distinguishes them.

## The requested vendor is not always the one that runs

The terminal brain's pty *is* a daemon session, so with no daemon
`createAdapter` hands back an SDK brain — while every derived value still said
`'claude-pty'`. That wrote SDK session ids under the `::claude-pty` key (leaving
the real terminal conversation unresumable), told a brain that has `Write` it
had no durable memory, forwarded full power to an SDK adapter the UI had just
disabled, and tagged the fallback manager `'claude-pty'` so the daemon coming
back could never dislodge it — the swap check was comparing two *requests*.
Resolving the effective vendor once, in `ensureManager`, fixes all four.

## Controls that were inert on the new default path

- **Model picker.** It rode only on the `DECK_SEND` payload, so it reached main
  exactly when a human typed into the deck composer — and the terminal brain's
  layout has no composer (its TUI is the input path). Automation-driven turns
  spawned brains on whatever the last typed turn left cached. It is now
  main-authoritative like full power and the vendor.
- **Full power.** It tunes `settingSources`/`canUseTool`, which an interactive
  session has no equivalent for, so its toggle is now inert with a reason under
  the other vendors instead of silently doing nothing when clicked.
- **Vendor coercion.** `DECK_BRAIN_VENDOR_SET` still failed closed to
  `'claude'`, splitting main and the renderer onto different vendors — and
  different session keys — for one bad input.

## Testing

19 new cases: the migration matrix (old default upgraded, explicit picks kept,
marker set and honoured, unknown ids), effective-vendor resolution (no-daemon
downgrade carries the key and memory policy with it; promotion once the daemon
returns), and the model authority (picker applies through the composer-less
wake path, stale-model retirement, ACP left alone, hostile strings sanitized).

Two existing tests were leaning on the old default implicitly and one was
locking in the old coercion; those now state their vendor explicitly.

`tsc` clean, 9251 unit + 90 runtime tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The terminal-based brain is now the default orchestrator, using the local Claude subscription (no API key required).
  * Added syncing for the orchestrator “model” setting from the UI to the orchestrator, including for scheduled/wake turns.
  * Orchestrator vendor/model selection now updates more reliably across app restarts via an automatic one-time migration (preserving history).

* **Bug Fixes**
  * Improved fallback behavior when daemon mode isn’t available, preventing terminal conversation loss for workspaces started without it.
  * Model/vendor selection and conversation clearing now target the correct persisted workspace/session.
  * Full-power mode UI now shows clearer availability and disables itself when unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->