### PR TITLE
Add a New session control to the orchestrator bar

### DIFF
--- a/changelog.d/711.md
+++ b/changelog.d/711.md
@@ -1,0 +1,14 @@
+### Added
+
+- **You can hand a workspace a fresh orchestrator without losing anything
+  else.** A **New session** control now sits with the other orchestrator
+  controls at the top of the deck. It retires the current orchestrator and
+  starts a new one that reads your project files again and takes a fresh look
+  at your panes, which is what you want once a long conversation has drifted or
+  a turn has wedged. There was no way to do this before: restarting wmux
+  deliberately resumes the same conversation, quitting the orchestrator's own
+  terminal just reopens it on that conversation, and deleting the workspace
+  takes every pane with it. Your panes, worktrees and conversation history all
+  stay, and loops and schedules keep running. It asks for a second click before
+  it commits, and stays available even mid-turn — a stuck turn is usually
+  exactly when you need it. (#711)

--- a/src/renderer/components/Deck/CommanderView.tsx
+++ b/src/renderer/components/Deck/CommanderView.tsx
@@ -66,6 +66,7 @@ import {
 import { buildQuickActions, type DeckQuickAction } from './deckQuickActions';
 import { renderBrainMarkdown } from './BrainMarkdown';
 import { DeckSchedulesPanel } from './DeckSchedulesPanel';
+import { NewSessionChipContainer } from './NewSessionChip';
 import { DeckLoopPanel } from './DeckLoopPanel';
 import { DeckDecisionCard } from './DeckDecisionCard';
 import BrainTerminalEmbed from './BrainTerminalEmbed';
@@ -224,6 +225,13 @@ export function CommanderViewContent({
         {/* Schedules chip + inline panel — new schedules bind to THIS
             workspace's orchestrator (M1.5). */}
         <DeckSchedulesPanel t={t} workspaceId={activeWorkspaceId} workspaceName={workspaceName} />
+        {/* Brain lifecycle — the last ALWAYS-ON control, so in the pty layout
+            it lands next to Wake and the two "what is the brain doing" buttons
+            sit together. Deliberately not disabled while a turn streams: a
+            stuck turn is the main reason to want a fresh orchestrator. */}
+        {activeWorkspaceId && (
+          <NewSessionChipContainer t={t} workspaceId={activeWorkspaceId} busy={brainBusy} />
+        )}
         {extra}
 
         {/* Reboot-recovery re-entry (post-reboot only) — the canned one-click

--- a/src/renderer/components/Deck/NewSessionChip.tsx
+++ b/src/renderer/components/Deck/NewSessionChip.tsx
@@ -1,0 +1,192 @@
+// ─── Command Deck — "New session" chip ──────────────────────────────────────
+//
+// Replaces this workspace's orchestrator with a fresh one: the live brain is
+// disposed (interrupting an in-flight turn) and its persisted session id is
+// dropped, so the next turn starts a brand-new conversation instead of
+// resuming. The whole main-process path already existed
+// (DECK_CONVERSATION_CLEAR); this is the affordance that reaches it.
+//
+// Why the deck needs it at all: the commander session id is persisted
+// precisely so a relaunch RESUMES the same conversation, so restarting wmux
+// does NOT hand you a fresh orchestrator. Short of deleting the workspace —
+// which takes its whole pane tree with it — there was no way to get one.
+// Quitting the terminal brain's TUI does not do it either: the next turn
+// respawns with `--resume`, giving a new process on the SAME conversation,
+// which is easy to mistake for a reset.
+//
+// Named for what it produces, not for what it destroys. "Reset" has no object
+// (the deck has a loop, schedules, a mode, a transcript, panes — all resettable
+// in principle) and "restart" already means a PANE restart in wmux's vocabulary
+// (pane.restarted / supervision armed|stopped), so either would invite "did it
+// restart my panes?". Nothing outside the conversation is touched: panes,
+// worktrees, the #commander transcript, durable memory, policy, mode, loops and
+// schedules all survive.
+//
+// Self-contained like AgentModeChip / DeckLoopPanel: all IPC goes through the
+// injected `api`, defaulting to window.electronAPI.deck in the container, and
+// it renders nothing when the preload is absent so pure jsdom tests of the
+// parent view are unaffected.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { tokenAttrs } from '../../themes';
+import { FOCUS_RING } from '../focusRing';
+
+export interface NewSessionApi {
+  /** Dispose the live brain and drop its persisted session id. */
+  clear: (workspaceId: string) => Promise<{ ok: boolean; code?: string }>;
+  /**
+   * Take one turn now. Fired right after a successful clear so the operator
+   * gets a fresh orchestrator that has ALREADY looked around (it re-reads
+   * pane_list with no stale assumptions) instead of an empty dock.
+   *
+   * Load-bearing since the terminal brain became the default: clearing kills
+   * its embedded pty, which retracts the terminal and drops the deck out of the
+   * pty layout — where the composer does not exist. Without this the operator
+   * is left staring at a dock with no brain and no obvious way to start one.
+   */
+  wake: (workspaceId: string) => Promise<{ ok: boolean; code?: string }>;
+}
+
+export interface NewSessionChipProps {
+  workspaceId: string;
+  api: NewSessionApi;
+  /**
+   * Whether a turn is streaming. Deliberately NOT used to disable the chip:
+   * "the brain is stuck in a bad turn" is the single most common reason to want
+   * a fresh one, and disabling it exactly then would be backwards. It only
+   * changes the wording, so the operator knows the click interrupts.
+   */
+  busy?: boolean;
+  t?: (key: string) => string;
+}
+
+/** How long the armed state waits for the second click before disarming. */
+const ARM_TIMEOUT_MS = 4000;
+
+export function NewSessionChip({
+  workspaceId,
+  api,
+  busy = false,
+  t,
+}: NewSessionChipProps): React.ReactElement | null {
+  const [armed, setArmed] = useState(false);
+  const [running, setRunning] = useState(false);
+  const disarmTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const label = t?.('deck.newSession') || 'New session';
+  const confirmLabel = busy
+    ? t?.('deck.newSessionConfirmBusy') || 'Interrupt & start new session?'
+    : t?.('deck.newSessionConfirm') || 'Start a new session?';
+
+  const clearDisarm = useCallback(() => {
+    if (disarmTimer.current) {
+      clearTimeout(disarmTimer.current);
+      disarmTimer.current = null;
+    }
+  }, []);
+
+  // An armed control that stays armed forever is a trap for the next click that
+  // lands anywhere near it. Time it out, and never leave a timer behind.
+  useEffect(() => clearDisarm, [clearDisarm]);
+  // Switching workspaces must not carry an arming intent to a DIFFERENT
+  // orchestrator — that is precisely the misclick the two-step exists to stop.
+  useEffect(() => {
+    setArmed(false);
+    clearDisarm();
+  }, [workspaceId, clearDisarm]);
+
+  const disarm = useCallback(() => {
+    setArmed(false);
+    clearDisarm();
+  }, [clearDisarm]);
+
+  const onClick = useCallback(() => {
+    if (running) return;
+    if (!armed) {
+      setArmed(true);
+      clearDisarm();
+      disarmTimer.current = setTimeout(() => setArmed(false), ARM_TIMEOUT_MS);
+      return;
+    }
+    disarm();
+    setRunning(true);
+    void (async () => {
+      try {
+        const res = await api.clear(workspaceId);
+        // Only wake a clear that actually happened. Waking a failed clear would
+        // spin the OLD conversation back up and read as "the button did
+        // nothing, twice".
+        if (res?.ok) {
+          await api.wake(workspaceId).catch(() => {
+            /* best-effort: a busy/rejected wake still leaves a fresh brain
+               ready for the operator's next message */
+          });
+        }
+      } catch {
+        /* the deck surfaces brain errors on its own stream; a failed clear
+           leaves the existing conversation untouched, which is the safe end */
+      } finally {
+        setRunning(false);
+      }
+    })();
+  }, [armed, running, api, workspaceId, disarm, clearDisarm]);
+
+  if (!workspaceId) return null;
+
+  return (
+    <button
+      type="button"
+      data-deck-new-session
+      data-armed={armed ? 'true' : 'false'}
+      disabled={running}
+      onClick={onClick}
+      onBlur={disarm}
+      onMouseLeave={disarm}
+      aria-label={armed ? confirmLabel : label}
+      title={
+        armed
+          ? confirmLabel
+          : t?.('deck.newSessionTooltip') ||
+            'Replace this workspace’s orchestrator with a fresh session. Panes, worktrees and the conversation history stay; loops and schedules keep running.'
+      }
+      // Neutral at rest like the other AI-directed controls on this bar
+      // (DESIGN.md: AI-directed actions stay neutral at rest) — nothing is
+      // destroyed by arming. Red only once ARMED, which is the one click that
+      // commits: DESIGN.md reserves solid red for the final confirm.
+      className={
+        armed
+          ? `px-2.5 py-1 rounded-md text-[12px] font-semibold text-[var(--accent-red)] bg-[rgba(var(--bg-surface-rgb),0.6)] transition-colors disabled:opacity-40 ${FOCUS_RING}`
+          : `px-2.5 py-1 rounded-md text-[12px] font-semibold text-[var(--text-sub)] bg-[rgba(var(--bg-surface-rgb),0.6)] hover:text-[var(--accent-amber)] transition-colors disabled:opacity-40 ${FOCUS_RING}`
+      }
+      {...(armed ? tokenAttrs('danger', 'text') : tokenAttrs('textSub', 'text'))}
+    >
+      {armed ? confirmLabel : label}
+    </button>
+  );
+}
+
+/** Wires the real preload. Renders nothing without it (jsdom parent tests). */
+export function NewSessionChipContainer({
+  workspaceId,
+  busy,
+  t,
+}: {
+  workspaceId: string;
+  busy?: boolean;
+  t?: (key: string) => string;
+}): React.ReactElement | null {
+  const deck = window.electronAPI?.deck;
+  const clear = deck?.conversation?.clear;
+  const wake = deck?.wake;
+  if (!clear || !wake) return null;
+  return (
+    <NewSessionChip
+      workspaceId={workspaceId}
+      busy={busy}
+      t={t}
+      api={{
+        clear: (id) => clear(id),
+        wake: (id) => wake(id),
+      }}
+    />
+  );
+}

--- a/src/renderer/components/Deck/__tests__/NewSessionChip.dynamic.test.tsx
+++ b/src/renderer/components/Deck/__tests__/NewSessionChip.dynamic.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+//
+// NewSessionChip: the two-step armed confirm, and the clear→wake pairing that
+// keeps the operator from being left with a dead dock. Injected fake api so no
+// preload/IPC is needed.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { NewSessionChip, type NewSessionApi } from '../NewSessionChip';
+
+// Silences React's "not configured to support act(...)" warning — the same
+// opt-in the other dynamic component tests in this repo use.
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const t = (k: string) => k; // identity — assert on keys
+
+function render(ui: React.ReactElement): { container: HTMLElement; cleanup: () => void } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(ui));
+  return {
+    container,
+    cleanup: () => { act(() => root.unmount()); container.remove(); },
+  };
+}
+
+const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve(); }); };
+
+const cleanups: Array<() => void> = [];
+afterEach(() => { while (cleanups.length) cleanups.pop()!(); });
+
+function mount(api: NewSessionApi, props: { busy?: boolean; workspaceId?: string } = {}) {
+  const r = render(
+    <NewSessionChip
+      workspaceId={props.workspaceId ?? 'ws-1'}
+      api={api}
+      busy={props.busy}
+      t={t}
+    />,
+  );
+  cleanups.push(r.cleanup);
+  const btn = () => r.container.querySelector('[data-deck-new-session]') as HTMLButtonElement;
+  return { ...r, btn };
+}
+
+function fakeApi(overrides: Partial<NewSessionApi> = {}) {
+  const calls: string[] = [];
+  const api: NewSessionApi = {
+    clear: vi.fn(async (id: string) => { calls.push(`clear:${id}`); return { ok: true }; }),
+    wake: vi.fn(async (id: string) => { calls.push(`wake:${id}`); return { ok: true }; }),
+    ...overrides,
+  };
+  return { api, calls };
+}
+
+describe('NewSessionChip — two-step armed confirm', () => {
+  it('does NOT fire on the first click; it arms', async () => {
+    const { api } = fakeApi();
+    const { btn } = mount(api);
+    await act(async () => { btn().click(); });
+    expect(btn().dataset.armed).toBe('true');
+    expect(api.clear).not.toHaveBeenCalled();
+  });
+
+  it('fires on the second click', async () => {
+    const { api, calls } = fakeApi();
+    const { btn } = mount(api);
+    await act(async () => { btn().click(); });
+    await act(async () => { btn().click(); });
+    await flush();
+    expect(calls).toEqual(['clear:ws-1', 'wake:ws-1']);
+  });
+
+  it('disarms on mouse-leave, so a stray second click cannot commit', async () => {
+    const { api } = fakeApi();
+    const { btn } = mount(api);
+    await act(async () => { btn().click(); });
+    await act(async () => { btn().dispatchEvent(new MouseEvent('mouseout', { bubbles: true })); });
+    expect(btn().dataset.armed).toBe('false');
+    await act(async () => { btn().click(); });
+    expect(api.clear).not.toHaveBeenCalled();
+  });
+
+  it('disarms when the workspace changes — arming intent must not follow the operator', async () => {
+    const { api } = fakeApi();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const ui = (wsId: string) => (
+      <NewSessionChip workspaceId={wsId} api={api} t={t} />
+    );
+    act(() => root.render(ui('ws-1')));
+    cleanups.push(() => { act(() => root.unmount()); container.remove(); });
+    const btn = () => container.querySelector('[data-deck-new-session]') as HTMLButtonElement;
+    await act(async () => { btn().click(); });
+    expect(btn().dataset.armed).toBe('true');
+    act(() => root.render(ui('ws-2')));
+    expect(btn().dataset.armed).toBe('false');
+    // A click now only re-arms — it must not clear the workspace the operator
+    // just switched to.
+    await act(async () => { btn().click(); });
+    expect(api.clear).not.toHaveBeenCalled();
+  });
+});
+
+describe('NewSessionChip — clear and wake are a pair', () => {
+  it('wakes after a successful clear, so the fresh brain is already looking around', async () => {
+    const { api, calls } = fakeApi();
+    const { btn } = mount(api);
+    await act(async () => { btn().click(); });
+    await act(async () => { btn().click(); });
+    await flush();
+    expect(calls).toEqual(['clear:ws-1', 'wake:ws-1']);
+  });
+
+  it('does NOT wake a clear that failed — that would revive the old conversation', async () => {
+    const { api, calls } = fakeApi({
+      clear: vi.fn(async () => ({ ok: false, code: 'invalid_workspace' })),
+    });
+    const { btn } = mount(api);
+    await act(async () => { btn().click(); });
+    await act(async () => { btn().click(); });
+    await flush();
+    expect(calls).toEqual([]);
+    expect(api.wake).not.toHaveBeenCalled();
+  });
+
+  it('survives a rejected wake — the clear still counts', async () => {
+    const { api } = fakeApi({ wake: vi.fn(async () => { throw new Error('busy'); }) });
+    const { btn } = mount(api);
+    await act(async () => { btn().click(); });
+    await act(async () => { btn().click(); });
+    await flush();
+    expect(api.clear).toHaveBeenCalledTimes(1);
+    expect(btn().disabled).toBe(false);
+  });
+});
+
+describe('NewSessionChip — busy', () => {
+  it('stays ENABLED while a turn streams (a stuck turn is the reason to use it)', async () => {
+    const { api } = fakeApi();
+    const { btn } = mount(api, { busy: true });
+    expect(btn().disabled).toBe(false);
+    await act(async () => { btn().click(); });
+    await act(async () => { btn().click(); });
+    await flush();
+    expect(api.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('says the click will interrupt when busy', async () => {
+    const { api } = fakeApi();
+    const { btn } = mount(api, { busy: true });
+    await act(async () => { btn().click(); });
+    expect(btn().textContent).toContain('deck.newSessionConfirmBusy');
+  });
+
+  it('uses the plain confirm wording when idle', async () => {
+    const { api } = fakeApi();
+    const { btn } = mount(api);
+    await act(async () => { btn().click(); });
+    expect(btn().textContent).toContain('deck.newSessionConfirm');
+  });
+});

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -412,6 +412,11 @@ export const en = {
   'deck.brainTerminal': 'Brain terminal',
   // The dock's report rail (the terminal-orchestrator layout's footer).
   'deck.wakeNow': 'Wake',
+  'deck.newSession': 'New session',
+  'deck.newSessionConfirm': 'Start a new session?',
+  'deck.newSessionConfirmBusy': 'Interrupt & start new session?',
+  'deck.newSessionTooltip':
+    'Replace this workspace’s orchestrator with a fresh session, so it starts from your project files with no stale assumptions. Panes, worktrees and the conversation history stay; loops and schedules keep running.',
   'deck.reportRail': 'Reports {count}',
   'deck.reportRailDecision': '1 decision',
   'deck.limit.resetsSoon': 'resets soon',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -287,6 +287,11 @@ export const ko = {
   'deck.limit.window': '사용량',
   'deck.brainTerminal': '브레인 터미널',
   'deck.wakeNow': '깨우기',
+  'deck.newSession': '새 세션',
+  'deck.newSessionConfirm': '새 세션을 시작할까요?',
+  'deck.newSessionConfirmBusy': '중단하고 새 세션을 시작할까요?',
+  'deck.newSessionTooltip':
+    '이 워크스페이스의 agent를 새 세션으로 교체합니다. 낡은 가정 없이 프로젝트 파일부터 다시 읽습니다. pane·워크트리·대화 기록은 그대로 남고, 루프와 예약은 계속 동작합니다.',
   'deck.reportRail': '보고 {count}',
   'deck.reportRailDecision': '결정 1건',
   'deck.limit.resetsSoon': '곧 초기화됨',


### PR DESCRIPTION
Replacing a workspace's orchestrator with a fresh one had no affordance — only
a complete main-process path that nothing called. `DECK_CONVERSATION_CLEAR`,
its preload binding and its store tests all shipped some time ago; a grep for
callers in `src/renderer` returned nothing. This is the button.

## Why it earns its place

None of the obvious substitutes actually work:

- **Restarting wmux doesn't.** The commander session id is persisted precisely
  so the next launch resumes the same conversation.
- **Deleting the workspace does** — and takes its entire pane tree, its
  identity across channels and A2A with it. That is a terrible exchange rate
  for replacing one brain.
- **Quitting the terminal brain's TUI doesn't either.** The next turn respawns
  with `--resume`, so you get a new *process* on the *same* conversation. It
  looks exactly like a reset and isn't, which is the specific confusion this
  control removes.

## Naming

"Reset" has no object here — the deck also has a loop, schedules, a mode, a
transcript and panes, all resettable in principle — and `restart` already means
a **pane** restart in wmux's vocabulary (`pane.restarted`, supervision
`armed`/`stopped`). Either name invites "did it restart my panes?". "New
session" says what it produces, matches what the code does (a fresh adapter
with no `resume`), and is the word Claude Code users already have.

## What survives

Everything except the conversation: panes, surfaces, worktrees, the
`#commander` transcript and report rail, durable memory, `deck-policy.md`, the
autonomy mode, loops, schedules and any pending decision. The tooltip says so —
"New session" is otherwise easy to read as "history gone".

## Clear is paired with a wake

Not left to the operator. The terminal brain is the default now, and clearing
kills its embedded pty, which retracts the terminal and drops the deck out of
the pty layout — where no composer exists. Waking immediately means the promise
the button makes is what actually appears: a fresh orchestrator that has
already re-read `pane_list`, rather than an empty dock. A *failed* clear is
deliberately not woken, since that would revive the conversation the operator
just asked to leave.

## Confirmation and placement

The repo's two-step armed chip, not a modal. The action destroys no artifact,
but it is one-way and can interrupt a live turn — exactly the weight that
pattern carries (`ChannelItem` documents it as the house style for one-way
actions; `window.confirm` is reserved for filesystem destruction like worktree
removal). Red only once armed, per DESIGN.md reserving solid red for the final
confirm; neutral at rest like the other AI-directed controls on the bar.

It sits last among the always-on controls in `renderControlBar`, after
Schedules and before the ephemeral recovery chip — so in the pty layout it
lands beside Wake and the two brain-lifecycle buttons sit together.

It stays **enabled while a turn streams**. A brain stuck in a bad turn is the
most common reason to want a fresh one, so disabling it exactly then would be
backwards; the wording changes to say the click interrupts.

## Testing

10 cases: first click arms and does not fire, second commits, mouse-leave
disarms, a workspace switch disarms (arming intent must not follow the operator
to a different orchestrator), clear→wake ordering, no wake after a failed
clear, a rejected wake still leaves the chip usable, and the busy behaviour
(enabled, wording swaps).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **New Session** control to the workspace command deck.
  * Uses an “arm then confirm” flow to replace the current orchestrator with a fresh session.
  * Provides busy-state wording and keeps the control available during turns.
  * Starts the new session while preserving panes/worktrees and continuing loops/schedules.
  * Added English and Korean translations for the new control and tooltip.
* **Tests**
  * Added dynamic UI tests covering the two-step confirmation and clear-then-wake behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->