### PR TITLE
Add explicit approval choices for phone clients

### DIFF
--- a/docs/phone-client-contract.md
+++ b/docs/phone-client-contract.md
@@ -252,6 +252,18 @@ Check `/api/config` and hide the keyboard rather than letting a user type into a
 403. `fetch` resolves on 401 and 403 — a lone `.catch()` sees neither, which is a
 mistake the browser client made and shipped.
 
+Phone scrolling has two ownership modes. A terminal's normal buffer is local
+scrollback and must remain local (ordinary shells and Kiro use this path).
+Alternate-screen TUIs have no terminal scrollback. With `--allow-input`, a
+vertical phone drag may send line-granular wheel events only while the remote
+TUI has negotiated mouse reporting, and only encoded with that negotiated
+protocol. If no mouse mode is active and no wheel event was sent, the completed
+swipe may fall back to standard `PgUp`/`PgDn` terminal navigation. Claude Code's
+fullscreen renderer documents both wheel scrolling and those keys for its
+app-owned conversation history. Without `--allow-input`, send neither; never
+forward generic taps or drags, guess a mouse protocol, or pretend the alternate
+buffer is locally scrollable.
+
 ### Creating and closing panes
 
 ```
@@ -347,15 +359,69 @@ prompt, the daemon records a request any authenticated surface can answer.
 
 ```
 GET  /api/approvals          → {pending: [...], recentlyResolved: [...]}
-POST /api/approvals/<id>     body: {decision: 'approve' | 'deny'}
+POST /api/approvals/<id>     body: {decision: 'approve' | 'deny', choiceKey?: string}
 ```
 
 Request fields: `id`, `sessionId`, `agent`, `kind`, `state`, `createdAt`, and
-optionally `workspaceId`, `question`, `options`, `risk`, `screenTail`,
-`decision`, `resolvedBy`, `resolvedAt`.
+optionally `workspaceId`, `question`, `options`, `choices`, `risk`, `screenTail`,
+`decision`, `resolvedBy`, `resolvedAt`, `selectedChoiceKey`.
 
 `question` and `options` are the agent's own text, sanitized and capped. Render
 them — a blind Approve button is not an informed answer.
+
+### `choices` — structured option keys for per-option resolution
+
+`choices` is an array of `{key, label}` objects, present when the daemon
+extracted usable options from the `AskUserQuestion` payload. Each `key` is the
+1-based digit ('1', '2', …) that selects that option in Claude Code's TUI,
+preserving the original index even when unlabeled entries are dropped from the
+legacy `options` array.
+
+A client that supports per-option buttons sends `choiceKey` in the resolve body
+instead of relying on the default first-option mapping. This is strictly opt-in:
+omitting `choiceKey` preserves existing behavior byte-for-byte.
+
+### `choiceKey` — selecting a specific option on resolve
+
+```json
+POST /api/approvals/<id>
+{
+  "decision": "approve",
+  "choiceKey": "2"
+}
+```
+
+When present:
+- The daemon validates `choiceKey` belongs to the stored request's `choices` set.
+- The screen re-verify confirms the corresponding option row is visible.
+- Exactly that digit is sent to the PTY — no CR, same as default approve.
+- On success, `selectedChoiceKey` is persisted on the resolved history record.
+
+When absent:
+- Existing behaviour: approve sends '1' (first option), deny sends ESC.
+- Byte-for-byte identical to clients that predate this field.
+
+Malformed keys (empty, non-string, non-digit, or attached to `deny`) return
+400 `{error: 'invalid-choice-key'}` before the registry is called. A well-formed
+but unknown or stale key returns 422 with the same error. In both cases the
+request stays pending — no default option is pressed.
+
+### Agent support — Claude native, others terminal-only
+
+Claude Code's `AskUserQuestion` prompt is natively supported: the daemon
+extracts the question, options, and structured choices from the hook payload and
+maps resolve decisions to precise TUI keystrokes.
+
+Claude Code's **permission prompts** (tool-approval gate, "Do you want to
+proceed?") have no hook — they are detector-only. Until Claude Code exposes an
+authoritative hook for permission prompts, the phone cannot answer them.
+
+**Codex CLI, Kiro CLI, and other TUI-only agents** have no hook integration and
+no authoritative keystroke mapping. They report `unsupported-agent` (501). Their
+prompts are answered with the phone pane's terminal controls when `--allow-input`
+is enabled, or at the desktop otherwise. Structured choice
+support for these agents will be added only after their respective projects
+expose authoritative approval hooks — the daemon does not guess keystrokes.
 
 ### `risk` — a hint, not a gate
 
@@ -389,8 +455,10 @@ there before writing.
 | Status | Body | Meaning |
 | --- | --- | --- |
 | 200 | `{state, durable}` | Answered. `durable: false` means the keystroke landed but the record did not survive — the answer is real, the history will not show it. Do **not** retry |
+| 400 | `{error: 'invalid-choice-key'}` | A supplied choice key is malformed or was attached to `deny`. Nothing is sent |
 | 409 | `{error: 'already-resolved', resolvedBy}` | Another surface won. `resolvedBy` names it (`operator`, or `device <name> (<id>)`) |
 | 410 | `{error: 'expired' \| 'prompt-gone', state?}` | The request outlived its usefulness, or the prompt left the screen. Stop showing it |
+| 422 | `{error: 'invalid-choice-key'}` | The `choiceKey` does not belong to this request's choices, or the option is not visible on screen. The request is still pending — retry with a valid key or omit `choiceKey` |
 | 501 | `{error: 'unsupported-agent'}` | No keystroke map for this agent. Still answerable at the desktop — do not expire it locally |
 | 404 | `{error: 'not-found'}` | No such request |
 
@@ -399,10 +467,10 @@ deny sends ESC. Neither is followed by a carriage return: on a select, the digit
 both moves and confirms, and a stray CR would press whatever the TUI renders
 next.
 
-**Known limitation, shipped deliberately:** options are agent-authored, so
-Approve means "pick the first option", not "say yes". Deny is exact. A per-option
-press needs the option list in the UI — that is app-side work, and the wire
-already carries `options`.
+**Per-option press via `choiceKey`:** when `choices` is present on the request,
+a client can send `choiceKey` to select a specific option rather than always
+picking the first. The daemon sends exactly that digit — no CR. This removes the
+"blind first option" limitation for clients that render the choice list.
 
 ### Lifecycle you must reflect
 
@@ -444,6 +512,12 @@ HKDF with a **zero-length salt** and `info = "wmux:push:v1" || epk || spk` in
 that order; the timestamp interpolated into the AAD as an **integer, not a
 float**; standard base64 **with** padding (not base64url); a 12-byte nonce; and a
 byte-for-byte, case-sensitive `deviceId`.
+
+The decrypted plaintext is additive JSON: `title`, `body`, optional
+`approvalId`, optional `sessionId`, and optional `requiresInAppChoice`. When
+`requiresInAppChoice` is true, the Notification Service Extension must use an
+affirmative-free category: the person has to open the app and pick a structured
+choice. Older payloads omit the field and older extensions ignore it.
 
 Reject an envelope older than `PUSH_MAX_AGE_MS` (300 000 ms).
 

--- a/src/daemon/approvals/ApprovalRegistry.ts
+++ b/src/daemon/approvals/ApprovalRegistry.ts
@@ -44,7 +44,7 @@
 
 import crypto from 'node:crypto';
 import { hasCriticalRisk } from '../../shared/criticalPatterns';
-import { keystrokesForAgent, looksLikeApprovalPrompt } from './approvalKeystrokes';
+import { keystrokesForAgent, looksLikeApprovalPrompt, looksLikeChoiceOnScreen } from './approvalKeystrokes';
 import {
   formatScreenTail,
   loadApprovalState,
@@ -72,7 +72,11 @@ import type {
  * would be editing registry state through the back door.
  */
 function copyRequest(r: ApprovalRequest): ApprovalRequest {
-  return { ...r, ...(r.options ? { options: [...r.options] } : {}) };
+  return {
+    ...r,
+    ...(r.options ? { options: [...r.options] } : {}),
+    ...(r.choices ? { choices: r.choices.map((c) => ({ ...c })) } : {}),
+  };
 }
 
 export interface ApprovalRegistryDeps {
@@ -202,6 +206,7 @@ export class ApprovalRegistry implements ApprovalRegistryApi, ApprovalHookSink {
     workspaceId?: string;
     question?: string;
     options?: string[];
+    choices?: Array<{ key: string; label: string }>;
   }): Promise<void> {
     // Snapshot BEFORE queuing. `mutate` runs the body after the chain drains,
     // which can be seconds later (a resolve ahead of it is holding the chain
@@ -215,6 +220,7 @@ export class ApprovalRegistry implements ApprovalRegistryApi, ApprovalHookSink {
       workspaceId: input.workspaceId,
       question: input.question,
       options: input.options ? [...input.options] : undefined,
+      choices: input.choices ? input.choices.map((c) => ({ ...c })) : undefined,
     };
     return this.mutate(() => {
       const superseded = this.requests.find(
@@ -237,6 +243,7 @@ export class ApprovalRegistry implements ApprovalRegistryApi, ApprovalHookSink {
         // request.
         ...(snapshot.question ? { question: snapshot.question } : {}),
         ...(snapshot.options && snapshot.options.length > 0 ? { options: [...snapshot.options] } : {}),
+        ...(snapshot.choices && snapshot.choices.length > 0 ? { choices: snapshot.choices.map((c) => ({ ...c })) } : {}),
         // Danger HINT for UI step-up, computed once at creation from the same
         // pattern list the PTY critical-action scanner uses. A miss or a false
         // positive changes nothing about whether this request can be answered.
@@ -304,6 +311,49 @@ export class ApprovalRegistry implements ApprovalRegistryApi, ApprovalHookSink {
         };
       }
 
+      // ── choiceKey validation ──────────────────────────────────────────────
+      // When present, the caller is selecting a specific option rather than the
+      // default first-option mapping. Validate that the key belongs to this
+      // request's stored choices — fail closed on any mismatch.
+      let choiceDigit: string | null = null;
+      let choiceLabel: string | null = null;
+      if (params.choiceKey !== undefined) {
+        // Only an affirmative can select an option. Empty is malformed rather
+        // than "absent": silently defaulting it would press option 1.
+        if (params.decision !== 'approve' || params.choiceKey === '') {
+          return {
+            result: {
+              ok: false,
+              reason: 'invalid-choice-key',
+              request: copyRequest(record),
+            } as ApprovalResolveResult,
+          };
+        }
+        if (!record.choices || record.choices.length === 0) {
+          // choiceKey sent for a request that has no choices — invalid.
+          return {
+            result: {
+              ok: false,
+              reason: 'invalid-choice-key',
+              request: copyRequest(record),
+            } as ApprovalResolveResult,
+          };
+        }
+        const match = record.choices.find((c) => c.key === params.choiceKey);
+        if (!match) {
+          // choiceKey not in the stored set — fail closed.
+          return {
+            result: {
+              ok: false,
+              reason: 'invalid-choice-key',
+              request: copyRequest(record),
+            } as ApprovalResolveResult,
+          };
+        }
+        choiceDigit = match.key;
+        choiceLabel = match.label;
+      }
+
       const rows = await this.safeReadScreen(record.sessionId);
       if (!rows || rows.length === 0 || !looksLikeApprovalPrompt(rows)) {
         // Refusal expires the request: whatever the pane is showing now, it is
@@ -322,7 +372,37 @@ export class ApprovalRegistry implements ApprovalRegistryApi, ApprovalHookSink {
         };
       }
 
-      const data = params.decision === 'approve' ? keys.approve : keys.deny;
+      // ── choiceKey screen re-verify ────────────────────────────────────────
+      // When resolving with a specific choiceKey, verify that the option row
+      // matching that key+label is visible on screen. This prevents stale
+      // choices from typing digits into a prompt that has redrawn with different
+      // options. The check looks for `<digit>. <label-substring>` or
+      // `<digit>) <label-substring>` on a row that also has the selection cursor.
+      if (choiceDigit && choiceLabel) {
+        if (!looksLikeChoiceOnScreen(rows, choiceDigit, choiceLabel)) {
+          // The option is not visible — fail closed without expiring. The prompt
+          // may still be valid for a default approve/deny, just not for this
+          // specific choice (e.g. a re-render reordered options).
+          this.deps.log?.(
+            'info',
+            `[approvals] refused choiceKey '${choiceDigit}' on ${record.id}: option not visible on screen`,
+          );
+          return {
+            result: {
+              ok: false,
+              reason: 'invalid-choice-key',
+              request: copyRequest(record),
+            } as ApprovalResolveResult,
+          };
+        }
+      }
+
+      // Determine the data to send: choiceKey overrides the default mapping.
+      // When choiceKey is set, we send exactly that digit — no CR.
+      // When absent, existing behaviour: approve → '1', deny → ESC.
+      const data = params.decision === 'deny'
+        ? keys.deny
+        : (choiceDigit ?? keys.approve);
       let delivered = false;
       try {
         delivered = this.deps.writeToSession(record.sessionId, data);
@@ -353,13 +433,15 @@ export class ApprovalRegistry implements ApprovalRegistryApi, ApprovalHookSink {
       record.resolvedBy = sanitizeResolvedBy(params.resolvedBy);
       record.resolvedAt = this.now();
       record.screenTail = formatScreenTail(rows);
+      // Persist which specific choice was selected (if any).
+      if (choiceDigit) record.selectedChoiceKey = choiceDigit;
       this.deps.log?.(
         'info',
         // The SANITIZED value, not the raw param. Sanitizing only what gets
         // stored left the log line taking a CR/LF straight from the caller,
         // which is the forged-log-line injection sanitizeResolvedBy exists to
         // prevent — the field was clean on disk and dirty in the log.
-        `[approvals] ${params.decision} ${record.id} on ${record.sessionId} by ${record.resolvedBy || 'unknown'}`,
+        `[approvals] ${params.decision} ${record.id} on ${record.sessionId} by ${record.resolvedBy || 'unknown'}${choiceDigit ? ` (choice ${choiceDigit})` : ''}`,
       );
       return {
         events: [{ type: 'resolve' as ApprovalEventType, request: copyRequest(record) }],

--- a/src/daemon/approvals/__tests__/ApprovalRegistry.test.ts
+++ b/src/daemon/approvals/__tests__/ApprovalRegistry.test.ts
@@ -14,7 +14,7 @@ import {
   SCREEN_TAIL_ROWS,
   SCREEN_TAIL_ROW_CHARS,
 } from '../approvalStore';
-import { keystrokesForAgent, looksLikeApprovalPrompt } from '../approvalKeystrokes';
+import { keystrokesForAgent, looksLikeApprovalPrompt, looksLikeChoiceOnScreen } from '../approvalKeystrokes';
 import { MAX_OPTIONS, MAX_OPTION_LABEL_CHARS, MAX_QUESTION_CHARS } from '../askUserQuestion';
 import type { ApprovalEvent } from '../types';
 
@@ -104,7 +104,7 @@ function awaitingInput(
   registry: ApprovalRegistry,
   sessionId = 'pty-a',
   agent = 'claude',
-  extras: { question?: string; options?: string[] } = {},
+  extras: { question?: string; options?: string[]; choices?: Array<{ key: string; label: string }> } = {},
 ): Promise<void> {
   return registry.noteHookAwaitingInput({ sessionId, agent, workspaceId: 'ws-1', ...extras });
 }
@@ -788,5 +788,259 @@ it('logs the SANITIZED label, not the raw parameter', async () => {
     for (const row of screenTail.split('\n')) {
       expect(row.length).toBeLessThanOrEqual(SCREEN_TAIL_ROW_CHARS);
     }
+  });
+});
+
+describe('choices and choiceKey — per-option resolve', () => {
+  const CHOICES_INPUT = {
+    question: 'Which approach?',
+    options: ['Rewrite the parser', 'Patch the existing one'],
+    choices: [
+      { key: '1', label: 'Rewrite the parser' },
+      { key: '2', label: 'Patch the existing one' },
+    ],
+  };
+
+  /** A screen that shows option 2 with a cursor on it. */
+  const SCREEN_WITH_CHOICE_2 = [
+    '╭──────────────────────────────────────────╮',
+    '│ Which approach?                           │',
+    '│                                          │',
+    '│   1. Rewrite the parser                   │',
+    '│ ❯ 2. Patch the existing one              │',
+    '╰──────────────────────────────────────────╯',
+  ];
+
+  it('carries choices onto the pending record', async () => {
+    const h = makeRegistry();
+    await awaitingInput(h.registry, 'pty-a', 'claude', CHOICES_INPUT);
+
+    const pending = h.registry.list().pending[0];
+    expect(pending.choices).toEqual(CHOICES_INPUT.choices);
+  });
+
+  it('choices are deep-copied — a consumer cannot mutate registry state', async () => {
+    const h = makeRegistry();
+    await awaitingInput(h.registry, 'pty-a', 'claude', CHOICES_INPUT);
+
+    const pending = h.registry.list().pending[0];
+    pending.choices![0].key = '99';
+    pending.choices!.push({ key: '3', label: 'injected' });
+
+    expect(h.registry.list().pending[0].choices).toEqual(CHOICES_INPUT.choices);
+  });
+
+  it('resolving with a valid choiceKey sends that digit (not the default "1")', async () => {
+    const h = makeRegistry();
+    h.setScreen(SCREEN_WITH_CHOICE_2);
+    await awaitingInput(h.registry, 'pty-a', 'claude', CHOICES_INPUT);
+    await settle();
+
+    const res = await h.registry.resolve({
+      id: 'req-1',
+      decision: 'approve',
+      resolvedBy: 'phone',
+      choiceKey: '2',
+    });
+
+    expect(res.ok).toBe(true);
+    expect(h.writes).toEqual([{ sessionId: 'pty-a', data: '2' }]);
+  });
+
+  it('persists selectedChoiceKey on the resolved record', async () => {
+    const h = makeRegistry();
+    h.setScreen(SCREEN_WITH_CHOICE_2);
+    await awaitingInput(h.registry, 'pty-a', 'claude', CHOICES_INPUT);
+    await settle();
+
+    await h.registry.resolve({
+      id: 'req-1',
+      decision: 'approve',
+      resolvedBy: 'phone',
+      choiceKey: '2',
+    });
+
+    const resolved = h.registry.list().recentlyResolved[0];
+    expect(resolved.selectedChoiceKey).toBe('2');
+  });
+
+  it('choiceKey that does not belong to the stored choices fails with invalid-choice-key', async () => {
+    const h = makeRegistry();
+    await awaitingInput(h.registry, 'pty-a', 'claude', CHOICES_INPUT);
+    await settle();
+
+    const res = await h.registry.resolve({
+      id: 'req-1',
+      decision: 'approve',
+      resolvedBy: 'phone',
+      choiceKey: '9',
+    });
+
+    expect(res).toMatchObject({ ok: false, reason: 'invalid-choice-key' });
+    expect(h.writes).toHaveLength(0);
+    // Request stays pending — a valid key can still be sent.
+    expect(h.registry.list().pending).toHaveLength(1);
+  });
+
+  it('choiceKey on a request with no choices fails with invalid-choice-key', async () => {
+    const h = makeRegistry();
+    await awaitingInput(h.registry, 'pty-a', 'claude'); // no choices
+    await settle();
+
+    const res = await h.registry.resolve({
+      id: 'req-1',
+      decision: 'approve',
+      resolvedBy: 'phone',
+      choiceKey: '1',
+    });
+
+    expect(res).toMatchObject({ ok: false, reason: 'invalid-choice-key' });
+    expect(h.writes).toHaveLength(0);
+    expect(h.registry.list().pending).toHaveLength(1);
+  });
+
+  it('choiceKey fails when the option is not visible on screen', async () => {
+    const h = makeRegistry();
+    // Screen only shows option 1, not option 2
+    h.setScreen([
+      '╭──────────────────────────────────────────╮',
+      '│ ❯ 1. Rewrite the parser                   │',
+      '╰──────────────────────────────────────────╯',
+    ]);
+    await awaitingInput(h.registry, 'pty-a', 'claude', CHOICES_INPUT);
+    await settle();
+
+    const res = await h.registry.resolve({
+      id: 'req-1',
+      decision: 'approve',
+      resolvedBy: 'phone',
+      choiceKey: '2',
+    });
+
+    expect(res).toMatchObject({ ok: false, reason: 'invalid-choice-key' });
+    expect(h.writes).toHaveLength(0);
+    // Still pending — not expired, because the prompt IS there, just not this choice.
+    expect(h.registry.list().pending).toHaveLength(1);
+  });
+
+  it('omitting choiceKey preserves default behavior: approve sends "1"', async () => {
+    const h = makeRegistry();
+    await awaitingInput(h.registry, 'pty-a', 'claude', CHOICES_INPUT);
+    await settle();
+
+    const res = await h.registry.resolve({
+      id: 'req-1',
+      decision: 'approve',
+      resolvedBy: 'phone',
+      // No choiceKey
+    });
+
+    expect(res.ok).toBe(true);
+    expect(h.writes).toEqual([{ sessionId: 'pty-a', data: '1' }]);
+  });
+
+  it('omitting choiceKey preserves default behavior: deny sends ESC', async () => {
+    const h = makeRegistry();
+    await awaitingInput(h.registry, 'pty-a', 'claude', CHOICES_INPUT);
+    await settle();
+
+    const res = await h.registry.resolve({
+      id: 'req-1',
+      decision: 'deny',
+      resolvedBy: 'phone',
+    });
+
+    expect(res.ok).toBe(true);
+    expect(h.writes).toEqual([{ sessionId: 'pty-a', data: '\x1b' }]);
+  });
+
+  it('empty string choiceKey fails closed instead of pressing the first option', async () => {
+    const h = makeRegistry();
+    await awaitingInput(h.registry, 'pty-a', 'claude', CHOICES_INPUT);
+    await settle();
+
+    const res = await h.registry.resolve({
+      id: 'req-1',
+      decision: 'approve',
+      resolvedBy: 'phone',
+      choiceKey: '',
+    });
+
+    expect(res).toMatchObject({ ok: false, reason: 'invalid-choice-key' });
+    expect(h.writes).toHaveLength(0);
+    expect(h.registry.list().pending).toHaveLength(1);
+  });
+
+  it('deny with a choiceKey fails closed instead of sending an affirmative digit', async () => {
+    const h = makeRegistry();
+    h.setScreen(SCREEN_WITH_CHOICE_2);
+    await awaitingInput(h.registry, 'pty-a', 'claude', CHOICES_INPUT);
+    await settle();
+
+    const res = await h.registry.resolve({
+      id: 'req-1',
+      decision: 'deny',
+      resolvedBy: 'phone',
+      choiceKey: '2',
+    });
+
+    expect(res).toMatchObject({ ok: false, reason: 'invalid-choice-key' });
+    expect(h.writes).toHaveLength(0);
+    expect(h.registry.list().pending).toHaveLength(1);
+  });
+
+  it('choices survive a restart on the history record', async () => {
+    const first = makeRegistry();
+    await awaitingInput(first.registry, 'pty-a', 'claude', CHOICES_INPUT);
+
+    const second = makeRegistry();
+    await settle();
+
+    expect(second.registry.list().recentlyResolved[0].choices).toEqual(CHOICES_INPUT.choices);
+  });
+
+  it('selectedChoiceKey survives a restart', async () => {
+    const first = makeRegistry();
+    first.setScreen(SCREEN_WITH_CHOICE_2);
+    await awaitingInput(first.registry, 'pty-a', 'claude', CHOICES_INPUT);
+    await settle();
+    await first.registry.resolve({ id: 'req-1', decision: 'approve', resolvedBy: 'phone', choiceKey: '2' });
+
+    const second = makeRegistry();
+    await settle();
+
+    const record = second.registry.list().recentlyResolved.find((r) => r.id === 'req-1');
+    expect(record?.selectedChoiceKey).toBe('2');
+  });
+});
+
+describe('looksLikeChoiceOnScreen', () => {
+  it('finds a visible option with the correct digit and label prefix', () => {
+    const rows = ['│ ❯ 2. Patch the existing one              │'];
+    expect(looksLikeChoiceOnScreen(rows, '2', 'Patch the existing one')).toBe(true);
+  });
+
+  it('matches partial label (20-char prefix)', () => {
+    const rows = ['  > 1. This is a very long option label that goes on and on'];
+    expect(looksLikeChoiceOnScreen(rows, '1', 'This is a very long option label that goes on')).toBe(true);
+  });
+
+  it('rejects a different digit for the same label', () => {
+    const rows = ['│ ❯ 2. Patch the existing one              │'];
+    expect(looksLikeChoiceOnScreen(rows, '1', 'Patch the existing one')).toBe(false);
+  });
+
+  it('rejects when the label is not on screen at all', () => {
+    const rows = ['│ ❯ 1. Rewrite the parser                   │'];
+    expect(looksLikeChoiceOnScreen(rows, '2', 'Patch the existing one')).toBe(false);
+  });
+
+  it('works with ) separator', () => {
+    const rows = ['  ❯ 3) Third option here'];
+    expect(looksLikeChoiceOnScreen(rows, '3', 'Third option here')).toBe(true);
+  });
+
+  it('returns false for empty rows', () => {
+    expect(looksLikeChoiceOnScreen([], '1', 'anything')).toBe(false);
   });
 });

--- a/src/daemon/approvals/__tests__/askUserQuestion.test.ts
+++ b/src/daemon/approvals/__tests__/askUserQuestion.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   extractAskUserQuestion,
+  sanitizeChoices,
   sanitizeOptions,
   sanitizeQuestion,
   MAX_OPTIONS,
@@ -42,6 +43,10 @@ describe('extractAskUserQuestion — normal extraction', () => {
     expect(extractAskUserQuestion(canonical())).toEqual({
       question: 'Which approach should I take?',
       options: ['Rewrite the parser', 'Patch the existing one'],
+      choices: [
+        { key: '1', label: 'Rewrite the parser' },
+        { key: '2', label: 'Patch the existing one' },
+      ],
     });
   });
 
@@ -54,14 +59,22 @@ describe('extractAskUserQuestion — normal extraction', () => {
     const out = extractAskUserQuestion({
       tool_input: { question: 'Proceed?', options: [{ label: 'Yes' }, { label: 'No' }] },
     });
-    expect(out).toEqual({ question: 'Proceed?', options: ['Yes', 'No'] });
+    expect(out).toEqual({
+      question: 'Proceed?',
+      options: ['Yes', 'No'],
+      choices: [{ key: '1', label: 'Yes' }, { key: '2', label: 'No' }],
+    });
   });
 
   it('tolerates bare-string options', () => {
     const out = extractAskUserQuestion({
       tool_input: { questions: [{ question: 'Proceed?', options: ['Yes', 'No'] }] },
     });
-    expect(out).toEqual({ question: 'Proceed?', options: ['Yes', 'No'] });
+    expect(out).toEqual({
+      question: 'Proceed?',
+      options: ['Yes', 'No'],
+      choices: [{ key: '1', label: 'Yes' }, { key: '2', label: 'No' }],
+    });
   });
 
   it('reads only the FIRST question — the keystroke can only answer that one', () => {
@@ -75,6 +88,7 @@ describe('extractAskUserQuestion — normal extraction', () => {
     });
     expect(out.question).toBe('First?');
     expect(out.options).toEqual(['A']);
+    expect(out.choices).toEqual([{ key: '1', label: 'A' }]);
   });
 
   it('keeps a question with no options, and options with no question', () => {
@@ -83,6 +97,7 @@ describe('extractAskUserQuestion — normal extraction', () => {
     });
     expect(extractAskUserQuestion({ tool_input: { options: ['Yes'] } })).toEqual({
       options: ['Yes'],
+      choices: [{ key: '1', label: 'Yes' }],
     });
   });
 });
@@ -208,5 +223,92 @@ describe('read-back sanitisers (a hand-edited approvals.json)', () => {
     expect(sanitizeOptions('nope')).toBeUndefined();
     expect(sanitizeOptions([])).toBeUndefined();
     expect(sanitizeOptions(['  ', null])).toBeUndefined();
+  });
+});
+
+describe('extractAskUserQuestion — choices preserve original 1-based indices', () => {
+  it('choices keys are 1-based indices matching the original array position', () => {
+    const out = extractAskUserQuestion({
+      tool_input: { options: ['Alpha', 'Beta', 'Gamma'] },
+    });
+    expect(out.choices).toEqual([
+      { key: '1', label: 'Alpha' },
+      { key: '2', label: 'Beta' },
+      { key: '3', label: 'Gamma' },
+    ]);
+  });
+
+  it('dropped entries advance the index — gaps preserve original digits', () => {
+    // Entry at index 0 is blank (dropped), entries at 1 and 2 are kept.
+    // Their keys should be '2' and '3', NOT '1' and '2'.
+    const out = extractAskUserQuestion({
+      tool_input: { options: ['', 'Beta', 'Gamma'] },
+    });
+    expect(out.options).toEqual(['Beta', 'Gamma']);
+    expect(out.choices).toEqual([
+      { key: '2', label: 'Beta' },
+      { key: '3', label: 'Gamma' },
+    ]);
+  });
+
+  it('null entries advance the index too', () => {
+    const out = extractAskUserQuestion({
+      tool_input: { options: [null, { label: '' }, { label: 'Third' }] },
+    });
+    expect(out.options).toEqual(['Third']);
+    expect(out.choices).toEqual([{ key: '3', label: 'Third' }]);
+  });
+
+  it('absent options yield no choices', () => {
+    const out = extractAskUserQuestion({ tool_input: { question: 'Hello?' } });
+    expect(out.choices).toBeUndefined();
+  });
+});
+
+describe('sanitizeChoices (read-back from disk)', () => {
+  it('accepts well-formed choices', () => {
+    expect(sanitizeChoices([
+      { key: '1', label: 'Yes' },
+      { key: '2', label: 'No' },
+    ])).toEqual([
+      { key: '1', label: 'Yes' },
+      { key: '2', label: 'No' },
+    ]);
+  });
+
+  it('drops entries with invalid keys', () => {
+    expect(sanitizeChoices([
+      { key: 'abc', label: 'Bad key' },
+      { key: '1', label: 'Good' },
+      { key: '999', label: 'Too long' },
+    ])).toEqual([{ key: '1', label: 'Good' }]);
+  });
+
+  it('drops entries with empty labels', () => {
+    expect(sanitizeChoices([
+      { key: '1', label: '   ' },
+      { key: '2', label: 'Valid' },
+    ])).toEqual([{ key: '2', label: 'Valid' }]);
+  });
+
+  it('returns undefined for non-array input', () => {
+    expect(sanitizeChoices(undefined)).toBeUndefined();
+    expect(sanitizeChoices('nope')).toBeUndefined();
+    expect(sanitizeChoices(null)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty array', () => {
+    expect(sanitizeChoices([])).toBeUndefined();
+  });
+
+  it('caps at MAX_OPTIONS', () => {
+    const big = Array.from({ length: 50 }, (_, i) => ({ key: String(i + 1), label: `opt-${i}` }));
+    const out = sanitizeChoices(big);
+    expect(out).toHaveLength(MAX_OPTIONS);
+  });
+
+  it('cleans control characters from labels', () => {
+    const out = sanitizeChoices([{ key: '1', label: 'Hello\x00World' }]);
+    expect(out?.[0].label).toBe('Hello World');
   });
 });

--- a/src/daemon/approvals/approvalKeystrokes.ts
+++ b/src/daemon/approvals/approvalKeystrokes.ts
@@ -116,3 +116,38 @@ const CURSOR_OPTION_ROW =
 export function looksLikeApprovalPrompt(rows: readonly string[]): boolean {
   return rows.some((row) => CURSOR_OPTION_ROW.test(row));
 }
+
+/**
+ * Is a SPECIFIC option (identified by its digit and label) visible on screen?
+ *
+ * Looks for any row containing `<digit>.` or `<digit>)` followed (after some
+ * whitespace) by at least the first 20 characters of the label. We require only
+ * a prefix because the TUI may truncate long labels at the terminal width.
+ *
+ * Does NOT require the selection cursor — the option may not be highlighted,
+ * but it must be rendered. The cursor check is already done by
+ * `looksLikeApprovalPrompt` (which is called before this).
+ *
+ * Biased to refuse: a false negative costs the caller a fallback to the default
+ * approve/deny, not a lost answer. A false positive would type the wrong digit.
+ */
+export function looksLikeChoiceOnScreen(
+  rows: readonly string[],
+  digit: string,
+  label: string,
+): boolean {
+  // Use enough of the label to be distinctive but not so much that a TUI
+  // line-wrap causes a miss. 20 chars is ~3 words, well above ambiguity.
+  const labelPrefix = label.slice(0, 20).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // Match: optional framing, the digit followed by . or ), whitespace, then
+  // the label prefix.
+  const pattern = new RegExp(
+    `${escapeDigit(digit)}[.)][\\s]+${labelPrefix}`,
+  );
+  return rows.some((row) => pattern.test(row));
+}
+
+function escapeDigit(d: string): string {
+  // Digits are regex-safe, but be explicit for safety.
+  return d.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/daemon/approvals/approvalStore.ts
+++ b/src/daemon/approvals/approvalStore.ts
@@ -15,7 +15,7 @@
 
 import path from 'node:path';
 import { atomicReadJSONSync, atomicWriteJSON } from '../util/atomicWrite';
-import { sanitizeOptions, sanitizeQuestion } from './askUserQuestion';
+import { sanitizeChoices, sanitizeOptions, sanitizeQuestion } from './askUserQuestion';
 import type { ApprovalDecision, ApprovalRequest, ApprovalState } from './types';
 
 const STATE_FILE = 'approvals.json';
@@ -110,6 +110,12 @@ function coerceRequest(raw: unknown): ApprovalRequest | null {
   if (question) out.question = question;
   const options = sanitizeOptions(o['options']);
   if (options) out.options = options;
+  const choices = sanitizeChoices(o['choices']);
+  if (choices) out.choices = choices;
+  // selectedChoiceKey: a 1-2 digit string, validated against the choices set.
+  if (typeof o['selectedChoiceKey'] === 'string' && /^\d{1,2}$/.test(o['selectedChoiceKey'])) {
+    out.selectedChoiceKey = o['selectedChoiceKey'];
+  }
   // Closed set of one: anything else on disk is dropped rather than passed
   // through, so a hand-edited file cannot invent a risk level a client would
   // then have to interpret.

--- a/src/daemon/approvals/askUserQuestion.ts
+++ b/src/daemon/approvals/askUserQuestion.ts
@@ -52,10 +52,12 @@ const CONTROL_CHARS_RE = /[\x00-\x1f\x7f-\x9f]/g;
 export interface ExtractedQuestion {
   question?: string;
   options?: string[];
+  /** Structured choices preserving the original 1-based index as key. */
+  choices?: Array<{ key: string; label: string }>;
 }
 
 /**
- * Extract `{question, options}` from a PreToolUse hook payload.
+ * Extract `{question, options, choices}` from a PreToolUse hook payload.
  *
  * The canonical Claude Code `AskUserQuestion` tool_input is
  * `{questions: [{question, header, multiSelect, options: [{label, description}]}]}`.
@@ -68,6 +70,13 @@ export interface ExtractedQuestion {
  * the first question — surfacing options from a later one would describe a
  * choice the press cannot make. (Multi-question prompts are a real gap here and
  * belong with the per-option press in M5/M6.)
+ *
+ * `choices` preserves the ORIGINAL 1-based index of each option in the payload
+ * array as the `key`. When a label is blank/unusable the entry is dropped from
+ * `options` (the legacy array), but the next entry's key still reflects its
+ * real position. This is critical: the digit that selects an option in the TUI
+ * is its 1-based position in the original array, not its position in the
+ * filtered list.
  *
  * Never throws. Any field it cannot make sense of is simply absent.
  */
@@ -87,8 +96,9 @@ export function extractAskUserQuestion(payload: unknown): ExtractedQuestion {
   const question = clean(readString(source, 'question'), MAX_QUESTION_CHARS);
   if (question) out.question = question;
 
-  const options = readOptionLabels(source);
+  const { options, choices } = readOptionLabelsWithChoices(source);
   if (options.length > 0) out.options = options;
+  if (choices.length > 0) out.choices = choices;
 
   return out;
 }
@@ -100,24 +110,41 @@ export function extractAskUserQuestion(payload: unknown): ExtractedQuestion {
  * is not promised to match the digit that selects it. Nothing presses by index
  * from this list today (approve is hard-coded to the first option); when M5/M6
  * adds per-option press it must carry the real index, not this array's.
+ *
+ * `choices` preserves the original 1-based index: each entry is `{key, label}`
+ * where `key` is the TUI digit (e.g. '1', '2', '3'). Dropped entries still
+ * advance the counter so subsequent keys are correct.
  */
-function readOptionLabels(source: Record<string, unknown>): string[] {
+function readOptionLabelsWithChoices(source: Record<string, unknown>): {
+  options: string[];
+  choices: Array<{ key: string; label: string }>;
+} {
   const raw = readArray(source, 'options');
-  if (!raw) return [];
-  const labels: string[] = [];
+  if (!raw) return { options: [], choices: [] };
+  const options: string[] = [];
+  const choices: Array<{ key: string; label: string }> = [];
   // Bound the entries INSPECTED, not just the labels accepted. Breaking only on
-  // `labels.length` meant an array of a million nulls yielded nothing and was
+  // `options.length` meant an array of a million nulls yielded nothing and was
   // walked in full, on the daemon's event loop, driven by a hook payload the
   // agent authors. `MAX_INSPECTED_OPTIONS` gives a malformed-but-honest payload
   // some slack while keeping the work constant.
-  for (const entry of raw.slice(0, MAX_INSPECTED_OPTIONS)) {
-    if (labels.length >= MAX_OPTIONS) break;
+  let inspected = 0;
+  for (let i = 0; i < raw.length && inspected < MAX_INSPECTED_OPTIONS; i++) {
+    inspected++;
+    if (options.length >= MAX_OPTIONS) break;
+    const entry = raw[i];
     const label = typeof entry === 'string'
       ? clean(entry, MAX_OPTION_LABEL_CHARS)
       : clean(readString(entry, 'label'), MAX_OPTION_LABEL_CHARS);
-    if (label) labels.push(label);
+    if (label) {
+      options.push(label);
+      // Key is the 1-based position in the ORIGINAL array — the digit Claude's
+      // TUI uses to select this option, regardless of how many prior entries
+      // were dropped for being unlabeled.
+      choices.push({ key: String(i + 1), label });
+    }
   }
-  return labels;
+  return { options, choices };
 }
 
 function isObject(v: unknown): v is Record<string, unknown> {
@@ -176,4 +203,33 @@ export function sanitizeOptions(value: unknown): string[] | undefined {
     if (label) labels.push(label);
   }
   return labels.length > 0 ? labels : undefined;
+}
+
+/** Cap for a choice key — a 1-based digit, never more than 2 characters. */
+export const MAX_CHOICE_KEY_CHARS = 2;
+
+/**
+ * Re-apply caps to `choices` read back from disk. Each entry must have a
+ * valid `key` (1-2 digit string) and a non-empty `label`. Entries that fail
+ * are dropped.
+ */
+export function sanitizeChoices(
+  value: unknown,
+): Array<{ key: string; label: string }> | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out: Array<{ key: string; label: string }> = [];
+  for (const entry of value.slice(0, MAX_INSPECTED_OPTIONS)) {
+    if (out.length >= MAX_OPTIONS) break;
+    if (typeof entry !== 'object' || entry === null) continue;
+    const e = entry as Record<string, unknown>;
+    const key = typeof e['key'] === 'string' ? e['key'] : '';
+    const label = clean(typeof e['label'] === 'string' ? e['label'] : '', MAX_OPTION_LABEL_CHARS);
+    // Key must be a 1-2 digit string (e.g. '1', '12') — reject the original,
+    // do not truncate. A key that does not match is a corrupt or hand-edited
+    // record and must be dropped.
+    if (/^\d{1,2}$/.test(key) && label) {
+      out.push({ key, label });
+    }
+  }
+  return out.length > 0 ? out : undefined;
 }

--- a/src/daemon/approvals/types.ts
+++ b/src/daemon/approvals/types.ts
@@ -11,6 +11,23 @@
 export type ApprovalDecision = 'approve' | 'deny';
 
 /**
+ * A structured approval choice. Each carries a `key` the resolver sends back
+ * and a human-readable `label`. The key is the 1-based index string ('1', '2',
+ * …) that identifies the original option in Claude Code's AskUserQuestion TUI —
+ * preserving the digit even when unlabeled entries are dropped from `options`.
+ *
+ * Additive alongside the legacy `options` array: old clients that only know
+ * `options` continue to render label-only rows, and new clients that understand
+ * `choices` get the key they need to resolve a specific option.
+ */
+export interface ApprovalChoice {
+  /** The keystroke digit ('1', '2', …) that selects this option in the TUI. */
+  key: string;
+  /** Sanitized display label — same content as the corresponding `options` entry. */
+  label: string;
+}
+
+/**
  * Lifecycle of one request. Only `pending` is actionable; the other three are
  * terminal.
  *   - resolved   a human answered it and the keystroke reached the PTY
@@ -60,6 +77,17 @@ export interface ApprovalRequest {
    */
   options?: string[];
   /**
+   * Structured choices with key+label, additive alongside `options`. Each
+   * `key` is the 1-based digit that selects the option in Claude Code's TUI,
+   * preserving the original index even when unlabeled entries are dropped from
+   * `options`. New clients use this to send `choiceKey` on resolve; old clients
+   * fall back to `options` for display-only rendering.
+   *
+   * Present only when the payload carried at least one usable option with a
+   * deterministic key. Absent (not empty) when no choices could be extracted.
+   */
+  choices?: ApprovalChoice[];
+  /**
    * A HINT that the question names a destructive action — set at creation when
    * `question`/`options` match the daemon's existing critical-action patterns
    * (shared/criticalPatterns.ts, the same list the PTY scanner uses).
@@ -82,6 +110,11 @@ export interface ApprovalRequest {
   resolvedBy?: string;
   resolvedAt?: number;
   decision?: ApprovalDecision;
+  /**
+   * When resolved with a specific `choiceKey`, the key that was selected. Lets
+   * the history UI show WHICH option was chosen, not just approve/deny.
+   */
+  selectedChoiceKey?: string;
   /**
    * The pane tail the registry actually looked at when it made the resolve
    * decision — the verified screen on a success, the REJECTED screen on a
@@ -107,13 +140,19 @@ export interface ApprovalRequest {
  * same answer to the caller ("this request is dead, re-read the list"), and
  * the precise state is on `request.state` for a caller that wants to say which.
  * A refused pre-write re-verify reports `prompt-gone` and expires the request.
+ *
+ * `invalid-choice-key` is returned when a `choiceKey` was provided but it does
+ * not belong to this request's `choices` set, or when the screen re-verify
+ * cannot confirm the selected option row is visible. Fails closed — never
+ * types a digit for a choice it cannot verify.
  */
 export type ApprovalResolveFailure =
   | 'not-found'
   | 'already-resolved'
   | 'expired'
   | 'unsupported-agent'
-  | 'prompt-gone';
+  | 'prompt-gone'
+  | 'invalid-choice-key';
 
 export type ApprovalResolveResult =
   | {
@@ -175,6 +214,8 @@ export interface ApprovalHookSink {
     /** A4 — already extracted and sanitized by the envelope-aware caller. */
     question?: string;
     options?: string[];
+    /** Structured choices with key+label, extracted alongside options. */
+    choices?: ApprovalChoice[];
   }): void;
   expireForSession(sessionId: string, reason: ApprovalExpiryReason): void;
 }
@@ -190,6 +231,17 @@ export interface ApprovalResolveParams {
   decision: ApprovalDecision;
   /** Free-form label for the 409 UX. Empty string is accepted, not rejected. */
   resolvedBy: string;
+  /**
+   * When present, selects a specific option by its `choices[].key` rather than
+   * using the default mapping (approve → first option, deny → ESC). The daemon
+   * validates the key belongs to the stored request, re-verifies the
+   * corresponding option row is visible on screen, and sends exactly that one
+   * digit. Invalid or absent keys fail closed.
+   *
+   * Omitting this field preserves existing behavior byte-for-byte: approve
+   * sends '1', deny sends ESC.
+   */
+  choiceKey?: string;
 }
 
 /**

--- a/src/daemon/hooks/HookIngest.ts
+++ b/src/daemon/hooks/HookIngest.ts
@@ -577,6 +577,7 @@ export class HookIngest {
       ...(workspaceId ? { workspaceId } : {}),
       ...(asked.question ? { question: asked.question } : {}),
       ...(asked.options ? { options: asked.options } : {}),
+      ...(asked.choices ? { choices: asked.choices } : {}),
     });
   }
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -2415,6 +2415,7 @@ function registerRpcHandlers(
       id?: unknown;
       decision?: unknown;
       resolvedBy?: unknown;
+      choiceKey?: unknown;
     };
     const id = typeof p.id === 'string' ? p.id : '';
     // Anything that is not exactly one of the two decisions is refused rather
@@ -2430,8 +2431,25 @@ function registerRpcHandlers(
     // pipe client must not be able to send an unbounded or control-character
     // string through it.
     const resolvedBy = typeof p.resolvedBy === 'string' ? p.resolvedBy : '';
+    // Presence-sensitive for the same reason as the HTTP route: never turn a
+    // malformed choice into a legacy first-option press, and never let a deny
+    // request smuggle an affirmative choice digit.
+    const hasChoiceKey = p.choiceKey !== undefined;
+    if (hasChoiceKey && (
+      decision !== 'approve'
+      || typeof p.choiceKey !== 'string'
+      || !/^\d{1,2}$/.test(p.choiceKey)
+    )) {
+      return { ok: false, reason: 'invalid-choice-key' };
+    }
+    const choiceKey = hasChoiceKey ? p.choiceKey as string : undefined;
     if (!approvalRegistry) return { ok: false, reason: 'not-found' };
-    return approvalRegistry.resolve({ id, decision, resolvedBy });
+    return approvalRegistry.resolve({
+      id,
+      decision,
+      resolvedBy,
+      ...(choiceKey !== undefined ? { choiceKey } : {}),
+    });
   });
 
   // daemon.getAgentName — daemon AgentDetector가 gate로 확정한 에이전트 표시명을
@@ -4312,6 +4330,7 @@ async function main(): Promise<void> {
         body: r.question ?? 'A pane is waiting on an answer.',
         approvalId: r.id,
         sessionId: r.sessionId,
+        ...(r.choices?.length ? { requiresInAppChoice: true } : {}),
       },
       // One pending request per pane, so a re-prompt should replace the old
       // banner rather than stack under it.

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -1965,8 +1965,29 @@ export class WebTerminalServer {
       if (decision !== 'approve' && decision !== 'deny') {
         return this.json(res, 400, { error: "decision must be 'approve' or 'deny'" });
       }
+      // choiceKey is presence-sensitive. A malformed, empty, or deny-side
+      // key must never be dropped into the legacy "approve first option" path.
+      const parsedBody = body as Record<string, unknown> | null;
+      const hasChoiceKey = parsedBody !== null
+        && typeof parsedBody === 'object'
+        && !Array.isArray(parsedBody)
+        && Object.prototype.hasOwnProperty.call(parsedBody, 'choiceKey');
+      const rawChoiceKey = hasChoiceKey ? parsedBody?.['choiceKey'] : undefined;
+      if (hasChoiceKey && (
+        decision !== 'approve'
+        || typeof rawChoiceKey !== 'string'
+        || !/^\d{1,2}$/.test(rawChoiceKey)
+      )) {
+        return this.json(res, 400, { error: 'invalid-choice-key' });
+      }
+      const choiceKey = hasChoiceKey ? rawChoiceKey as string : undefined;
       approvals
-        .resolve({ id, decision, resolvedBy: describePrincipal(principal) })
+        .resolve({
+          id,
+          decision,
+          resolvedBy: describePrincipal(principal),
+          ...(choiceKey !== undefined ? { choiceKey } : {}),
+        })
         .then((result) => {
           if (result.ok) {
             // 200 with `durable:false` rather than an error: the keystroke IS in
@@ -1997,6 +2018,11 @@ export class WebTerminalServer {
             // guess bytes. Not the caller's fault: 501, not 4xx.
             case 'unsupported-agent':
               return this.json(res, 501, { error: 'unsupported-agent' });
+            // The choiceKey does not belong to this request or the option is not
+            // visible on screen. The request is still pending — the caller can
+            // retry with a valid key or use the default approve/deny.
+            case 'invalid-choice-key':
+              return this.json(res, 422, { error: 'invalid-choice-key' });
             case 'not-found':
               return this.json(res, 404, { error: 'not-found' });
             default: {
@@ -2762,6 +2788,10 @@ function approvalWire(r: ApprovalRequest): Record<string, unknown> {
     // options list is a fact the registry recorded, not a missing field.
     ...(typeof r.question === 'string' ? { question: r.question } : {}),
     ...(Array.isArray(r.options) ? { options: r.options } : {}),
+    // Structured choices with key+label for per-option resolve. Additive
+    // alongside options — old clients ignore it, new clients use it for
+    // choiceKey resolution.
+    ...(Array.isArray(r.choices) && r.choices.length > 0 ? { choices: r.choices } : {}),
     // A hint for UI step-up (see ApprovalRequest.risk). Never a permission:
     // every request on this list is answerable through POST regardless.
     ...(r.risk ? { risk: r.risk } : {}),
@@ -2769,6 +2799,8 @@ function approvalWire(r: ApprovalRequest): Record<string, unknown> {
     ...(r.decision ? { decision: r.decision } : {}),
     ...(r.resolvedBy ? { resolvedBy: r.resolvedBy } : {}),
     ...(typeof r.resolvedAt === 'number' ? { resolvedAt: r.resolvedAt } : {}),
+    // Which specific choice was selected, when resolved via choiceKey.
+    ...(r.selectedChoiceKey ? { selectedChoiceKey: r.selectedChoiceKey } : {}),
   };
 }
 

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -1442,6 +1442,40 @@ describe('WebTerminalServer', () => {
     expect(resolveCalls[0].decision).toBe('deny');
   });
 
+  it('passes a valid choiceKey to the registry unchanged', async () => {
+    const info = await startRO();
+    approvalRecords.push(mkApproval({ id: 'ap-choice' }));
+    const res = await postApproval(info.token as string, 'ap-choice', {
+      decision: 'approve',
+      choiceKey: '2',
+    });
+    expect(res.status).toBe(200);
+    expect(resolveCalls).toEqual([{
+      id: 'ap-choice',
+      decision: 'approve',
+      choiceKey: '2',
+      resolvedBy: 'operator',
+    }]);
+  });
+
+  it('rejects malformed or deny-side choiceKey without reaching the registry', async () => {
+    const info = await startRO();
+    const token = info.token as string;
+    const bodies = [
+      { decision: 'approve', choiceKey: '' },
+      { decision: 'approve', choiceKey: 'abc' },
+      { decision: 'approve', choiceKey: 2 },
+      { decision: 'approve', choiceKey: null },
+      { decision: 'deny', choiceKey: '2' },
+    ];
+    for (const body of bodies) {
+      const res = await postApproval(token, 'ap-choice', body);
+      expect(res.status, JSON.stringify(body)).toBe(400);
+      expect(await res.json()).toEqual({ error: 'invalid-choice-key' });
+    }
+    expect(resolveCalls).toEqual([]);
+  });
+
   it('maps every registry refusal onto its own status code', async () => {
     const cases: Array<{ result: ApprovalResolveResult; status: number; body: Record<string, unknown> }> = [
       // Someone else answered first — and the loser is told who.
@@ -1460,6 +1494,8 @@ describe('WebTerminalServer', () => {
         status: 410,
         body: { error: 'expired', state: 'superseded' },
       },
+      // A well-formed key that is not valid for this live request stays pending.
+      { result: { ok: false, reason: 'invalid-choice-key' }, status: 422, body: { error: 'invalid-choice-key' } },
       // No keystroke map for this agent — the daemon refuses to guess bytes.
       { result: { ok: false, reason: 'unsupported-agent' }, status: 501, body: { error: 'unsupported-agent' } },
       { result: { ok: false, reason: 'not-found' }, status: 404, body: { error: 'not-found' } },

--- a/src/shared/push/pushEnvelope.ts
+++ b/src/shared/push/pushEnvelope.ts
@@ -176,6 +176,8 @@ export interface PushPayload {
   body: string;
   approvalId?: string;
   sessionId?: string;
+  /** True when a lock-screen affirmative cannot express the required choice. */
+  requiresInAppChoice?: boolean;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- extract structured Claude `AskUserQuestion` choices while preserving each option's real TUI digit
- accept `choiceKey` on phone approval resolves, validate it fail-closed, re-verify the option on screen, and persist the selected key
- suppress ambiguous lock-screen affirmative actions when an approval requires an in-app choice
- document explicit-choice resolution and negotiated alternate-screen phone scrolling

## Safety and compatibility
- malformed, empty, or deny-side `choiceKey` is rejected before the registry is called
- unknown or stale keys remain pending and send no PTY bytes
- omitting `choiceKey` preserves legacy behavior exactly: approve sends `1`, deny sends `ESC`, neither sends CR
- unsupported agents remain terminal-only; no approval keys are guessed

## Validation
- `git diff --check origin/main...HEAD`
- approval/web/push focused suite: **319/319 passed**
- `npm run build:daemon` (including daemon web CSP gate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Approval requests can now present structured, numbered choices for selection.
  - Selected choices are saved and shown in approval history.
  - Push notifications can indicate when selection must be completed in-app.
  - Phone terminal scrolling now supports local scrollback and alternate-screen paging or mouse-wheel behavior.

- **Bug Fixes**
  - Invalid, unavailable, or invisible choice selections are rejected with clear errors.
  - Approval choice data is validated and safely preserved across restarts.
  - Choice labels and keys are sanitized for reliable display and selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->