### PR TITLE
Fix lifecycle routing for Claude, Codex, and OpenCode

### DIFF
--- a/integrations/claude/bin/wmux-bridge.mjs
+++ b/integrations/claude/bin/wmux-bridge.mjs
@@ -8,12 +8,13 @@
 //   3. Builds the canonical AgentSignal envelope.
 //   4. Sends the envelope to the first wmux endpoint that answers:
 //        a. the DAEMON control pipe — `daemon.hooks.signal`, token from
-//           ~/.wmux/daemon-auth-token. The daemon is the always-on process,
-//           so this is the one that still works with the GUI closed.
-//        b. the MAIN pipe — `hooks.signal`, token from ~/.wmux-auth-token.
-//           The pre-M1 path; kept for an older wmux, and forced by
-//           WMUX_HOOKS_TO_MAIN=1 (kill switch).
-//   5. Logs the outcome (and which endpoint served it) to ~/.wmux/bridge.log.
+//           ~/.wmux${suffix}/daemon-auth-token. The daemon is the always-on
+//           process, so this is the one that still works with the GUI closed.
+//        b. the MAIN pipe — `hooks.signal`, token from
+//           ~/.wmux${suffix}-auth-token. The pre-M1 path; kept for an older
+//           wmux, and forced by WMUX_HOOKS_TO_MAIN=1 (kill switch).
+//   5. Logs the outcome (and which endpoint served it) to
+//      ~/.wmux${suffix}/bridge.log.
 //   6. Exits 0 (so a wmux problem never breaks Claude Code) — UNLESS invoked
 //      with `--gate` and the endpoint answers with a `block`, in which case the
 //      reason goes to stderr and the exit code is 2 (Claude Code's "do not let
@@ -39,7 +40,8 @@ const HOOK_TIMEOUT_MS = 2000; // hard cap so we never slow Claude
 // which bridge produced it — the installed copy is refreshed by byte-comparison
 // (setupHooks.refreshHookBridge, run at boot), never by this number.
 //   0.2.0 — daemon-first targeting (daemon.hooks.signal → hooks.signal).
-const BRIDGE_VERSION = '0.2.0';
+//   0.3.0 — suffix-isolated lifecycle routing and bridge state.
+const BRIDGE_VERSION = '0.3.0';
 
 // A2 (2026-05-29 user dogfood: 8 connect-errors during a brief main-process
 // restart / handler-swap window): retry a TRANSIENT connect failure a few
@@ -87,19 +89,24 @@ const HOOK_TO_KIND = {
 
 // ----- Path helpers (Node built-ins only) ---------------------------------
 
-// Instance suffix ('' in production, '-dev' under a dev build). Ordinary panes
-// never see WMUX_DATA_SUFFIX (it is stripped from their env), so this stays ''
-// for them and nothing changes. Brain ptys DO carry it — the deck spawns them
-// with the full instance env — and without honouring it here their signals
-// would be delivered to the PRODUCTION instance's pipe while the dev deck
-// waits forever (dogfood 2026-07-26).
+// Instance suffix ('' in production, '-dev' under a dev build). PTY spawn
+// propagation preserves WMUX_DATA_SUFFIX from the owning wmux process so every
+// hook resolves back to that same instance. With no suffix, every path remains
+// byte-identical to the production paths used before instance isolation.
 function instanceSuffix() {
   return process.env.WMUX_DATA_SUFFIX || '';
 }
 
+function getHomeDir() {
+  return process.env.USERPROFILE || process.env.HOME || homedir();
+}
+
+function getWmuxHomeDir() {
+  return join(getHomeDir(), `.wmux${instanceSuffix()}`);
+}
+
 function getAuthTokenPath() {
-  const home = process.env.USERPROFILE || process.env.HOME || homedir();
-  return join(home, `.wmux${instanceSuffix()}-auth-token`);
+  return join(getHomeDir(), `.wmux${instanceSuffix()}-auth-token`);
 }
 
 function getPipeName() {
@@ -118,13 +125,11 @@ function getPipeName() {
 // at the daemon first and keep the main pipe as the fallback for an older wmux
 // (whose daemon has no `daemon.hooks.signal`) or a daemon that is down.
 //
-// Same ~/.wmux (NO data-suffix) limitation as bridge.log: the bridge cannot see
-// WMUX_DATA_SUFFIX (a reserved WMUX_* var, stripped from the pane env), so a
-// dev-suffix daemon is unreachable from here — packaged-only testing for this
-// path, unchanged from the pre-M1 bridge.
+// Daemon credentials, hints, and fallback endpoints belong to the same
+// suffix-aware wmux home as the hook. A suffixed event deliberately never
+// probes the unsuffixed production daemon token or hint as a migration fallback.
 function getDaemonAuthTokenPath() {
-  const home = process.env.USERPROFILE || process.env.HOME || homedir();
-  return join(home, '.wmux', 'daemon-auth-token');
+  return join(getWmuxHomeDir(), 'daemon-auth-token');
 }
 
 // Prefer the `daemon-pipe` hint file the daemon writes at boot — it carries the
@@ -132,18 +137,17 @@ function getDaemonAuthTokenPath() {
 // zombie pipe forced a `-N` fallback rename. Mirrors src/cli/client.ts
 // `resolveDaemonPipeName` + src/shared/constants.ts `getDaemonSocketPath`.
 function getDaemonPipeName() {
-  const home = process.env.USERPROFILE || process.env.HOME || homedir();
   try {
-    const fromFile = readFileSync(join(home, '.wmux', 'daemon-pipe'), 'utf8').trim();
+    const fromFile = readFileSync(join(getWmuxHomeDir(), 'daemon-pipe'), 'utf8').trim();
     if (fromFile) return fromFile;
   } catch {
     // Hint file absent/unreadable — fall through to the derived name.
   }
   if (process.platform === 'win32') {
     const username = userInfo().username || 'default';
-    return `\\\\.\\pipe\\wmux-daemon-${username}`;
+    return `\\\\.\\pipe\\wmux-daemon${instanceSuffix()}-${username}`;
   }
-  return join(home, '.wmux', 'daemon.sock');
+  return join(getWmuxHomeDir(), 'daemon.sock');
 }
 
 function readTokenFile(tokenPath) {
@@ -212,8 +216,7 @@ function resolveTargets(gateMode = false) {
 }
 
 function getBridgeLogPath() {
-  const home = process.env.USERPROFILE || process.env.HOME || homedir();
-  const dir = join(home, '.wmux');
+  const dir = getWmuxHomeDir();
   try {
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
   } catch {
@@ -231,14 +234,11 @@ function getBridgeLogPath() {
 // (recovery) and reconnect, attributing each record to the EXACT pane by its
 // WMUX_PTY_ID. Pipe-free local file write, so it never depends on wmux being up.
 //
-// Path matches the bridge.log convention (~/.wmux, NO data-suffix): the bridge
-// cannot see WMUX_DATA_SUFFIX (a reserved WMUX_* var, stripped from the pane
-// env), so dev/prod-concurrent isolation falls back to cwd routing — same
-// pre-existing limitation as bridge.log. In production (no suffix) and in the
-// USERPROFILE-isolated dogfood, bridge and daemon resolve the same dir.
+// The spool lives under the suffix-aware wmux home so the bridge and daemon
+// always resolve the same instance directory and concurrent instances cannot
+// consume or overwrite one another's recovery records.
 function getResumeSpoolDir() {
-  const home = process.env.USERPROFILE || process.env.HOME || homedir();
-  const dir = join(home, '.wmux', 'resume-spool');
+  const dir = join(getWmuxHomeDir(), 'resume-spool');
   try {
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
   } catch {
@@ -287,11 +287,10 @@ function spoolResumeBinding(record) {
 
 // ----- PostToolUse activity stamp (source-side throttle) ------------------
 
-// Stamp files live next to bridge.log (same no-suffix ~/.wmux limitation).
+// Stamp files live next to bridge.log in the suffix-aware wmux home.
 // One zero-byte file per throttle key; mtime is the last-send timestamp.
 function getActivityStampPath(key) {
-  const home = process.env.USERPROFILE || process.env.HOME || homedir();
-  const dir = join(home, '.wmux', 'activity-stamps');
+  const dir = join(getWmuxHomeDir(), 'activity-stamps');
   try {
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
   } catch {

--- a/integrations/codex/bin/wmux-codex-notify.mjs
+++ b/integrations/codex/bin/wmux-codex-notify.mjs
@@ -1,33 +1,39 @@
 #!/usr/bin/env node
-// wmux ↔ Codex CLI notify bridge (resume-binding capture).
+// wmux-managed: codex-lifecycle-bridge
+// wmux ↔ Codex CLI notify bridge (lifecycle + resume-binding capture).
 //
 // Registered as Codex's `notify` program in ~/.codex/config.toml:
 //   notify = ["node", "<abs path to this file>"]
-// Codex spawns it on `agent-turn-complete`, appending ONE extra argv: a JSON
-// payload `{ session_id, transcript_path, cwd, hook_event_name, model, ... }`
-// (https://developers.openai.com/codex/config-advanced). The spawned process
-// inherits the pane env, so WMUX_PTY_ID pins the capture to the exact pane.
+// Codex spawns it on lifecycle notifications, appending ONE extra argv. The
+// official `agent-turn-complete` payload uses
+// `{ type, thread-id, turn-id, cwd, input-messages, last-assistant-message }`;
+// older Codex builds may use
+// `{ session_id, transcript_path, cwd, hook_event_name, model, ... }`.
+// The spawned process inherits the pane env, so WMUX_PTY_ID pins the capture to
+// the exact pane and WMUX_DATA_SUFFIX pins every endpoint/file to that instance.
 //
 // This script:
 //   1. Parses the LAST argv as the Codex notify JSON payload.
-//   2. Builds the canonical AgentSignal envelope (agent:'codex', kind:'agent.stop').
-//   3. Sends the envelope to the first wmux endpoint that answers: the DAEMON
-//      control pipe (`daemon.hooks.signal`, token ~/.wmux/daemon-auth-token —
-//      the always-on process, so this still lands with the GUI closed), else
-//      the MAIN pipe (`hooks.signal`, token ~/.wmux-auth-token). Either side
-//      builds the resume binding from signal.agent + agentSessionId + cwd +
+//   2. Ignores unrelated official lifecycle event types.
+//   3. Builds a canonical, metadata-only AgentSignal envelope
+//      (agent:'codex', kind:'agent.stop'); prompt and assistant content is never
+//      logged or forwarded.
+//   4. Sends the envelope to the first wmux endpoint that owns the request: the
+//      DAEMON control pipe (`daemon.hooks.signal`, suffix-scoped daemon token —
+//      the always-on process, so this still lands with the GUI closed), else the
+//      MAIN pipe (`hooks.signal`, suffix-scoped main token). Either side builds
+//      the resume binding from signal.agent + agentSessionId + cwd + optional
 //      transcript_path; both paths are fully agent-agnostic.
 //      WMUX_HOOKS_TO_MAIN=1 forces main-only.
-//   5. On failure, spools a resume-binding record the daemon drains on next boot.
+//   5. On failure, spools a suffix-scoped resume-binding record for daemon boot.
 //   6. Exits 0 ALWAYS, under a hard timeout, so a wmux problem never stalls Codex.
 //
 // SELF-CONTAINED: JS-only, Node built-ins only — no imports from src/ or
 // integrations/shared/ (mirrors integrations/claude/bin/wmux-bridge.mjs; the
 // Claude bridge's plugin constraint blocks a shared import, so full DRY across
-// the two is impossible — the shared ~120 lines of infra are duplicated by
-// design, per the codex-resume-support eng review, decision 2). This bridge is
-// LEANER than the Claude one: Codex gives session_id directly (no transcript
-// basename derivation), and has no permission-mode / usage to extract.
+// the two is impossible — the shared infra is duplicated by design). This
+// bridge is leaner than the Claude one: Codex supplies an official thread id (or
+// legacy session_id) directly and has no permission-mode / usage to extract.
 
 import { readFileSync, existsSync, mkdirSync, appendFileSync, writeFileSync, renameSync, unlinkSync } from 'node:fs';
 import { homedir, userInfo } from 'node:os';
@@ -36,9 +42,11 @@ import { createConnection } from 'node:net';
 import { randomUUID } from 'node:crypto';
 
 const HOOK_TIMEOUT_MS = 2000; // hard cap so we never stall a Codex turn
+const AGENT_TURN_COMPLETE = 'agent-turn-complete';
 // Stamped on every codex-notify.log line; bump on behavior changes.
 //   0.2.0 — daemon-first targeting (daemon.hooks.signal → hooks.signal).
-const BRIDGE_VERSION = '0.2.0';
+//   0.3.0 — official payload routing + suffix-isolated endpoint/state paths.
+const BRIDGE_VERSION = '0.3.0';
 const CONNECT_RETRY_BACKOFFS_MS = [100, 250];
 const TRANSIENT_CONNECT_CODES = new Set([
   'EPERM', 'ECONNREFUSED', 'ECONNRESET', 'EPIPE', 'ETIMEDOUT', 'EBUSY', 'EAGAIN',
@@ -47,52 +55,65 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // ----- Path helpers (Node built-ins only) ---------------------------------
 
+// Keep these formulas in lockstep with src/shared/constants.ts. A non-empty
+// suffix is an instance boundary: this bridge never probes production paths as
+// a fallback when its selected namespace is suffixed.
+function dataSuffix() {
+  return process.env.WMUX_DATA_SUFFIX || '';
+}
+
+function getHomeDir() {
+  return process.env.USERPROFILE || process.env.HOME || homedir();
+}
+
+function getWmuxHomeDir() {
+  return join(getHomeDir(), `.wmux${dataSuffix()}`);
+}
+
 function getAuthTokenPath() {
-  const home = process.env.USERPROFILE || process.env.HOME || homedir();
-  return join(home, '.wmux-auth-token');
+  return join(getHomeDir(), `.wmux${dataSuffix()}-auth-token`);
 }
 
 function getPipeName() {
   // WMUX_PIPE_NAME override: for the isolated capture probe
   // (scripts/codex-resume-capture-probe.mjs) and advanced multi-instance setups.
-  // Not a security widening — a same-user process can already read the auth
-  // token from ~/.wmux-auth-token, so redirecting the pipe grants nothing new.
+  // Not a security widening — a same-user process can already read the selected
+  // namespace's auth token, so redirecting the pipe grants nothing new.
   const override = process.env.WMUX_PIPE_NAME;
   if (typeof override === 'string' && override.length > 0) return override;
   if (process.platform === 'win32') {
     const username = userInfo().username || 'default';
-    return `\\\\.\\pipe\\wmux-${username}`;
+    return `\\\\.\\pipe\\wmux${dataSuffix()}-${username}`;
   }
-  return join(homedir() || '/tmp', '.wmux.sock');
+  return join(homedir() || '/tmp', `.wmux${dataSuffix()}.sock`);
 }
 
 // ----- Daemon endpoint (M1: hook ingest lives in the daemon) ---------------
 //
 // The daemon is the always-on process and owns hook ingest, so it is tried
 // first; the main pipe stays as the fallback for an older wmux or a daemon that
-// is down. Same ~/.wmux (no data-suffix) limitation as the log path — the pane
-// env strips WMUX_DATA_SUFFIX, so a dev-suffix daemon is unreachable here.
+// is down. WMUX_DATA_SUFFIX is propagated into pane environments, so daemon and
+// main discovery stays inside the pane's selected instance namespace.
 function getDaemonAuthTokenPath() {
-  const home = process.env.USERPROFILE || process.env.HOME || homedir();
-  return join(home, '.wmux', 'daemon-auth-token');
+  return join(getWmuxHomeDir(), 'daemon-auth-token');
 }
 
-// Prefer the `daemon-pipe` hint file the daemon writes at boot (the name it
-// ACTUALLY bound, which differs from the convention after a zombie-pipe
-// fallback rename), then the derived name.
+// Prefer the suffix-scoped `daemon-pipe` hint the daemon writes at boot (the
+// name it ACTUALLY bound, which differs from the convention after a zombie-pipe
+// fallback rename), then derive a socket in that same namespace. Never consult
+// an unsuffixed hint or endpoint for a suffixed instance.
 function getDaemonPipeName() {
-  const home = process.env.USERPROFILE || process.env.HOME || homedir();
   try {
-    const fromFile = readFileSync(join(home, '.wmux', 'daemon-pipe'), 'utf8').trim();
+    const fromFile = readFileSync(join(getWmuxHomeDir(), 'daemon-pipe'), 'utf8').trim();
     if (fromFile) return fromFile;
   } catch {
-    // Hint file absent/unreadable — fall through to the derived name.
+    // Hint file absent/unreadable — derive within the selected namespace.
   }
   if (process.platform === 'win32') {
     const username = userInfo().username || 'default';
-    return `\\\\.\\pipe\\wmux-daemon-${username}`;
+    return `\\\\.\\pipe\\wmux-daemon${dataSuffix()}-${username}`;
   }
-  return join(home, '.wmux', 'daemon.sock');
+  return join(getWmuxHomeDir(), 'daemon.sock');
 }
 
 function readTokenFile(tokenPath) {
@@ -128,8 +149,7 @@ function resolveTargets() {
 }
 
 function getLogPath() {
-  const home = process.env.USERPROFILE || process.env.HOME || homedir();
-  const dir = join(home, '.wmux');
+  const dir = getWmuxHomeDir();
   try {
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
   } catch { /* appendFileSync below also fails → swallowed */ }
@@ -153,11 +173,9 @@ function logEvent(outcome, extra) {
 //
 // Same record shape + ptyId key + atomic temp→rename + don't-replace-newer rule
 // the daemon ingest expects (mirrors integrations/claude/bin/wmux-bridge.mjs).
-// Path matches the bridge convention (~/.wmux, no data-suffix — a reserved
-// WMUX_* var the pane env strips).
+// The spool lives in the same suffix-scoped data directory the daemon drains.
 function getResumeSpoolDir() {
-  const home = process.env.USERPROFILE || process.env.HOME || homedir();
-  const dir = join(home, '.wmux', 'resume-spool');
+  const dir = join(getWmuxHomeDir(), 'resume-spool');
   try {
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
   } catch { /* writeFileSync below throws + is swallowed */ }
@@ -306,22 +324,34 @@ async function main() {
   let payload;
   try {
     payload = JSON.parse(raw);
-  } catch (err) {
-    logEvent('malformed-payload', { error: String(err) });
+  } catch {
+    // JSON parse diagnostics may quote the input; never copy them to the log.
+    logEvent('malformed-payload');
     return;
   }
-  if (!payload || typeof payload !== 'object') {
-    logEvent('non-object-payload', {});
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    logEvent('non-object-payload');
     return;
   }
 
-  const sessionId = nonEmptyStr(payload.session_id);
-  if (!sessionId) {
-    // No session id → nothing resumable to capture. (Non-turn events, or a
-    // Codex version that omits it.) Drop quietly.
-    logEvent('no-session-id', { event: payload.hook_event_name });
+  // Official lifecycle payloads are explicitly typed. If `type` is present it
+  // is authoritative: a legacy-looking session_id must not turn an unrelated
+  // official event into agent.stop. With no official type, retain the legacy
+  // notify behavior (including old clients that omitted hook_event_name).
+  const hasOfficialType = Object.prototype.hasOwnProperty.call(payload, 'type');
+  if (hasOfficialType && payload.type !== AGENT_TURN_COMPLETE) {
+    logEvent('ignored-event-type', { format: 'official' });
     return;
   }
+
+  const sessionId = nonEmptyStr(payload['thread-id']) ?? nonEmptyStr(payload.session_id);
+  if (!sessionId) {
+    // No thread/session id → nothing resumable to capture. Drop quietly without
+    // logging any caller-provided payload field.
+    logEvent('no-session-id', { format: hasOfficialType ? 'official' : 'legacy' });
+    return;
+  }
+  const turnId = nonEmptyStr(payload['turn-id']);
   const cwd = nonEmptyStr(payload.cwd) ?? process.cwd();
   const transcriptPath = nonEmptyStr(payload.transcript_path);
 
@@ -340,8 +370,9 @@ async function main() {
 
   // Canonical AgentSignal envelope. kind 'agent.stop' = a turn completed (the
   // strongest "task done" signal); it triggers the agent-agnostic resume-binding
-  // capture in hooks.rpc.ts. transcript_path rides in the payload — hooks.rpc
-  // reads signal.payload.transcript_path for the binding's D5 liveness probe.
+  // capture in hooks.rpc.ts. Only non-sensitive, allowlisted metadata rides in
+  // signal.payload: official turn-id and the legacy transcript_path used by the
+  // binding's D5 liveness probe. Native input/assistant content is never copied.
   const envelope = {
     kind: 'agent.stop',
     agent: 'codex',
@@ -350,7 +381,10 @@ async function main() {
     ...(envSurfaceId ? { surfaceId: envSurfaceId } : {}),
     ...(envPtyId ? { ptyId: envPtyId } : {}),
     cwd,
-    payload: { ...(transcriptPath ? { transcript_path: transcriptPath } : {}) },
+    payload: {
+      ...(turnId ? { 'turn-id': turnId } : {}),
+      ...(transcriptPath ? { transcript_path: transcriptPath } : {}),
+    },
     ts: Date.now(),
   };
 

--- a/integrations/opencode/plugins/wmux.js
+++ b/integrations/opencode/plugins/wmux.js
@@ -1,3 +1,4 @@
+// wmux-managed: opencode-lifecycle-bridge
 // wmux ↔ OpenCode plugin bridge (turn-completion lifecycle signal).
 //
 // OpenCode plugins are IN-PROCESS modules loaded by the `opencode` CLI at
@@ -14,32 +15,45 @@
 // orchestrator that assigned work to an OpenCode pane never learned when it
 // finished. This plugin closes the gap on the DETERMINISTIC path: OpenCode's
 // `session.idle` event (a session finished its turn) → a canonical wmux
-// AgentSignal (agent:'opencode', kind:'agent.stop') sent over the same
-// `hooks.signal` pipe RPC the Codex/Claude bridges use. hooks.rpc.ts is fully
-// agent-agnostic, so no wmux-side change is needed to accept 'opencode'.
+// AgentSignal (agent:'opencode', kind:'agent.stop') sent daemon-first over
+// `daemon.hooks.signal`, with the main process's `hooks.signal` as the fallback
+// when the daemon was not reached. Both handlers are agent-agnostic.
 //
 // SELF-CONTAINED: Node built-ins only (Bun implements node:net / node:fs /
 // node:os / node:crypto), no imports from src/ or integrations/shared/ — the
-// plugin runtime cannot resolve TS or repo-relative modules. The ~120 lines of
-// pipe-RPC infra are duplicated from integrations/codex/bin/wmux-codex-notify.mjs
-// by design (same constraint the Codex/Claude bridges accept).
+// plugin runtime cannot resolve TS or repo-relative modules. The pipe-RPC infra
+// is duplicated from integrations/codex/bin/wmux-codex-notify.mjs by design
+// (same constraint the Codex/Claude bridges accept).
 //
 // Routing: the envelope carries WMUX_PTY_ID (injected by the wmux daemon into
-// the pane env at spawn) — the exact per-pane key hooks.rpc.ts prefers. Since
+// the pane env at spawn) — the exact per-pane key hook ingest prefers. Since
 // opencode runs INSIDE a wmux pane, the env propagates through and pins the
 // signal to the right pane even when a workspace has several panes.
 //
-// Best-effort + non-blocking: every failure is swallowed + logged to
-// ~/.wmux/opencode-bridge.log; a wmux problem must never stall an opencode turn.
+// Best-effort + non-blocking: every failure is swallowed + logged to the
+// selected ~/.wmux${WMUX_DATA_SUFFIX}/opencode-bridge.log namespace; a wmux
+// problem must never stall an opencode turn.
 
-import { readFileSync, existsSync, mkdirSync, appendFileSync } from 'node:fs';
+import {
+  readFileSync,
+  existsSync,
+  mkdirSync,
+  appendFileSync,
+  writeFileSync,
+  renameSync,
+  unlinkSync,
+} from 'node:fs';
 import { homedir, userInfo } from 'node:os';
 import { join } from 'node:path';
 import { createConnection } from 'node:net';
 import { randomUUID } from 'node:crypto';
 
 const HOOK_TIMEOUT_MS = 2000;
-const BRIDGE_VERSION = '0.1.0';
+// Stamped on every opencode-bridge.log line; bump on behavior changes.
+//   0.2.0 — suffix-isolated daemon-first lifecycle routing + durable stop metadata.
+//   0.2.1 — session.idle dispatch detached from the OpenCode event loop.
+//   0.2.2 — safe legacy-daemon fallback and canonical main socket discovery.
+const BRIDGE_VERSION = '0.2.2';
 const CONNECT_RETRY_BACKOFFS_MS = [100, 250];
 const TRANSIENT_CONNECT_CODES = new Set([
   'EPERM', 'ECONNREFUSED', 'ECONNRESET', 'EPIPE', 'ETIMEDOUT', 'EBUSY', 'EAGAIN',
@@ -48,27 +62,102 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // ----- Path helpers (Node built-ins only) ---------------------------------
 
+// Keep these formulas in lockstep with src/shared/constants.ts. A non-empty
+// suffix is an instance boundary: this plugin never probes production paths as
+// an implicit fallback when its selected namespace is suffixed.
+function dataSuffix() {
+  return process.env.WMUX_DATA_SUFFIX || '';
+}
+
+function getHomeDir() {
+  return process.env.USERPROFILE || process.env.HOME || homedir();
+}
+
+function getWmuxHomeDir() {
+  return join(getHomeDir(), `.wmux${dataSuffix()}`);
+}
+
 function getAuthTokenPath() {
-  const home = process.env.USERPROFILE || process.env.HOME || homedir();
-  return join(home, '.wmux-auth-token');
+  return join(getHomeDir(), `.wmux${dataSuffix()}-auth-token`);
 }
 
 function getPipeName() {
-  // WMUX_PIPE_NAME override for isolated / suffixed instances (same escape hatch
-  // as the Codex bridge). Not a security widening — a same-user process can
-  // already read the auth token, so redirecting the pipe grants nothing new.
+  // WMUX_PIPE_NAME is an explicit single-endpoint override for isolated probes
+  // and advanced multi-instance setups. It must not fall through to a real
+  // daemon when the selected override is unavailable.
   const override = process.env.WMUX_PIPE_NAME;
   if (typeof override === 'string' && override.length > 0) return override;
   if (process.platform === 'win32') {
     const username = userInfo().username || 'default';
-    return `\\\\.\\pipe\\wmux-${username}`;
+    return `\\\\.\\pipe\\wmux${dataSuffix()}-${username}`;
   }
-  return join(homedir() || '/tmp', '.wmux.sock');
+  return join(homedir() || '/tmp', `.wmux${dataSuffix()}.sock`);
+}
+
+// ----- Daemon endpoint (hook ingest lives in the daemon) ------------------
+
+function getDaemonAuthTokenPath() {
+  return join(getWmuxHomeDir(), 'daemon-auth-token');
+}
+
+// The hint records the socket the daemon actually bound, including a zombie-
+// socket fallback rename. It is read only from the selected suffix namespace;
+// the derived fallback is in that same namespace as well.
+function getDaemonPipeName() {
+  try {
+    const fromFile = readFileSync(join(getWmuxHomeDir(), 'daemon-pipe'), 'utf8').trim();
+    if (fromFile) return fromFile;
+  } catch {
+    // Hint absent/unreadable — derive inside the selected namespace.
+  }
+  if (process.platform === 'win32') {
+    const username = userInfo().username || 'default';
+    return `\\\\.\\pipe\\wmux-daemon${dataSuffix()}-${username}`;
+  }
+  return join(getWmuxHomeDir(), 'daemon.sock');
+}
+
+function readTokenFile(tokenPath) {
+  try {
+    const token = readFileSync(tokenPath, 'utf8').trim();
+    return token || null;
+  } catch {
+    return null;
+  }
+}
+
+// Ordered endpoints. Missing token files skip their endpoint. The existing
+// WMUX_PIPE_NAME override remains a MAIN-addressed, one-target escape hatch;
+// WMUX_HOOKS_TO_MAIN=1 is the main-only kill switch.
+function resolveTargets() {
+  const mainToken = readTokenFile(getAuthTokenPath());
+  const pipeOverride = process.env.WMUX_PIPE_NAME;
+  if (typeof pipeOverride === 'string' && pipeOverride.length > 0) {
+    return mainToken
+      ? [{ name: 'main', pipe: pipeOverride, token: mainToken, method: 'hooks.signal' }]
+      : [];
+  }
+
+  const targets = [];
+  if (process.env.WMUX_HOOKS_TO_MAIN !== '1') {
+    const daemonToken = readTokenFile(getDaemonAuthTokenPath());
+    if (daemonToken) {
+      targets.push({
+        name: 'daemon',
+        pipe: getDaemonPipeName(),
+        token: daemonToken,
+        method: 'daemon.hooks.signal',
+      });
+    }
+  }
+  if (mainToken) {
+    targets.push({ name: 'main', pipe: getPipeName(), token: mainToken, method: 'hooks.signal' });
+  }
+  return targets;
 }
 
 function getLogPath() {
-  const home = process.env.USERPROFILE || process.env.HOME || homedir();
-  const dir = join(home, '.wmux');
+  const dir = getWmuxHomeDir();
   try {
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
   } catch { /* appendFileSync below also fails → swallowed */ }
@@ -86,6 +175,43 @@ function logEvent(outcome, extra) {
   try {
     appendFileSync(getLogPath(), line + '\n', { encoding: 'utf8' });
   } catch { /* no writable home → swallow */ }
+}
+
+// ----- Resume-binding spool (daemon drains on next boot) -----------------
+
+function getResumeSpoolDir() {
+  const dir = join(getWmuxHomeDir(), 'resume-spool');
+  try {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+  } catch { /* writeFileSync below throws + is swallowed */ }
+  return dir;
+}
+
+// This is deliberately a resume-binding record, never a deferred signal. In
+// particular it cannot contain permission titles, prompt text, or any payload.
+function spoolResumeBinding(record) {
+  try {
+    if (!record || !record.ptyId || !record.sessionId) return;
+    const safe = String(record.ptyId).replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 80);
+    if (!safe) return;
+    const dir = getResumeSpoolDir();
+    const file = join(dir, `${safe}.json`);
+    const tmp = join(dir, `${safe}.${process.pid}.${randomUUID()}.json.tmp`);
+    writeFileSync(tmp, JSON.stringify(record), { encoding: 'utf8', mode: 0o600 });
+    try {
+      if (existsSync(file)) {
+        const existing = JSON.parse(readFileSync(file, 'utf8'));
+        if (typeof existing?.ts === 'number' && existing.ts > record.ts) {
+          try { unlinkSync(tmp); } catch { /* ignore */ }
+          return;
+        }
+      }
+    } catch { /* replace a corrupt/unreadable existing spool */ }
+    renameSync(tmp, file);
+    logEvent('resume-spooled', { ptyId: record.ptyId, sessionId: record.sessionId });
+  } catch (err) {
+    logEvent('resume-spool-error', { error: String(err) });
+  }
 }
 
 // ----- Envelope builder (pure — exported for unit testing) -----------------
@@ -166,7 +292,10 @@ function sendRpc(pipePath, request, timeoutMs = HOOK_TIMEOUT_MS) {
       resolve(result);
     };
 
-    const timer = setTimeout(() => settle({ ok: false, error: 'timeout' }), timeoutMs);
+    const timer = setTimeout(
+      () => settle({ ok: false, error: 'timeout', retryable: !wrote }),
+      timeoutMs,
+    );
 
     sock.on('connect', () => {
       sock.write(JSON.stringify(request) + '\n');
@@ -174,14 +303,24 @@ function sendRpc(pipePath, request, timeoutMs = HOOK_TIMEOUT_MS) {
     });
     sock.on('data', (chunk) => {
       buffer += chunk.toString('utf8');
-      const nl = buffer.indexOf('\n');
-      if (nl !== -1) {
-        clearTimeout(timer);
+      // The daemon broadcasts agent events on this same connection. Ignore
+      // broadcasts, malformed lines, and other callers' replies; only our id
+      // can settle this request.
+      for (;;) {
+        const nl = buffer.indexOf('\n');
+        if (nl === -1) return;
+        const line = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+        let parsed;
         try {
-          settle(JSON.parse(buffer.slice(0, nl)));
+          parsed = JSON.parse(line);
         } catch {
-          settle({ ok: false, error: 'malformed-response' });
+          continue;
         }
+        if (!parsed || parsed.id !== request.id) continue;
+        clearTimeout(timer);
+        settle(parsed);
+        return;
       }
     });
     sock.on('error', (err) => {
@@ -190,15 +329,16 @@ function sendRpc(pipePath, request, timeoutMs = HOOK_TIMEOUT_MS) {
     });
     sock.on('close', () => {
       clearTimeout(timer);
-      settle({ ok: false, error: 'closed-without-response' });
+      settle({ ok: false, error: 'closed-without-response', retryable: !wrote });
     });
   });
 }
 
-async function sendRpcWithRetry(pipePath, request) {
-  const deadline = Date.now() + HOOK_TIMEOUT_MS;
+// A multi-target walk shares one deadline so daemon-first routing never doubles
+// the plugin's pre-existing maximum wait.
+async function sendRpcWithRetry(pipePath, request, deadline = Date.now() + HOOK_TIMEOUT_MS) {
   let attempt = 0;
-  let last = { ok: false, error: 'timeout' };
+  let last = { ok: false, error: 'timeout', retryable: true };
   for (;;) {
     const remaining = deadline - Date.now();
     if (remaining <= 0) return last;
@@ -215,68 +355,97 @@ async function sendRpcWithRetry(pipePath, request) {
   }
 }
 
-// ----- Signal dispatch -----------------------------------------------------
-
-/** Read the wmux auth token, or null (logged) when unavailable. */
-function readAuthToken() {
-  const tokenPath = getAuthTokenPath();
-  if (!existsSync(tokenPath)) {
-    logEvent('no-auth-token', { path: tokenPath });
-    return null;
-  }
-  let token;
-  try {
-    token = readFileSync(tokenPath, 'utf8').trim();
-  } catch (err) {
-    logEvent('auth-token-read-error', { error: String(err) });
-    return null;
-  }
-  if (!token) {
-    logEvent('empty-auth-token', {});
-    return null;
-  }
-  return token;
+// Advance only when the request provably never reached a server. Any outer-ok
+// reply (including an inner logical rejection such as no-workspace-match) owns
+// the signal, and a post-write disconnect is ambiguous, so both stop the walk.
+// A dispatch/auth refusal from an old daemon has outer ok=false and no
+// retryable=false marker; falling back to main is safe because the lifecycle
+// handler did not run.
+function shouldTryNextTarget(result) {
+  if (result && result.ok === true) return false;
+  if (result && result.retryable === false) return false;
+  return true;
 }
 
-/** Send one already-built AgentSignal envelope over the wmux hooks.signal pipe. */
+async function sendToTargets(targets, buildRequest) {
+  const deadline = Date.now() + HOOK_TIMEOUT_MS;
+  let result = { ok: false, error: 'no-target', retryable: true };
+  let target = null;
+  for (const candidate of targets) {
+    if (Date.now() >= deadline) break;
+    target = candidate;
+    result = await sendRpcWithRetry(candidate.pipe, buildRequest(candidate), deadline);
+    if (!shouldTryNextTarget(result)) break;
+  }
+  return { result, target };
+}
+
+// ----- Signal dispatch -----------------------------------------------------
+
+function spoolStopResumeBinding(envelope) {
+  if (envelope.kind !== 'agent.stop' || !envelope.ptyId || !envelope.agentSessionId) return;
+  spoolResumeBinding({
+    ptyId: envelope.ptyId,
+    agent: 'opencode',
+    sessionId: envelope.agentSessionId,
+    cwd: envelope.cwd,
+    ts: envelope.ts,
+  });
+}
+
+/** Send one already-built AgentSignal envelope to daemon first, then main. */
 async function sendSignal(envelope, idPrefix) {
-  const token = readAuthToken();
-  if (!token) return;
-  const request = {
-    id: `${idPrefix}-${randomUUID()}`,
-    method: 'hooks.signal',
+  const targets = resolveTargets();
+  if (targets.length === 0) {
+    logEvent('no-auth-token', { paths: [getDaemonAuthTokenPath(), getAuthTokenPath()] });
+    spoolStopResumeBinding(envelope);
+    return;
+  }
+
+  // Reuse one id across the target walk so every accepted reply is correlated
+  // to this one lifecycle event.
+  const requestId = `${idPrefix}-${randomUUID()}`;
+  const { result: rpcResult, target } = await sendToTargets(targets, (candidate) => ({
+    id: requestId,
+    method: candidate.method,
     params: envelope,
-    token,
-  };
-  const rpcResult = await sendRpcWithRetry(getPipeName(), request);
+    token: candidate.token,
+  }));
   const outerOk = rpcResult && rpcResult.ok === true;
   const innerOk = outerOk && rpcResult.result && rpcResult.result.ok === true;
   if (innerOk) {
-    logEvent('ok', { kind: envelope.kind, ptyId: envelope.ptyId, sessionId: envelope.agentSessionId });
+    logEvent('ok', {
+      kind: envelope.kind,
+      target: target?.name,
+      ptyId: envelope.ptyId,
+      sessionId: envelope.agentSessionId,
+    });
   } else {
     logEvent(outerOk ? 'rpc-rejected' : 'rpc-failed', {
       kind: envelope.kind,
+      target: target?.name,
       reason: rpcResult?.result?.reason,
       error: rpcResult?.error,
       detail: rpcResult?.detail,
     });
+    spoolStopResumeBinding(envelope);
   }
 }
 
 // ----- Plugin export -------------------------------------------------------
 
-/** How long a `permission.updated` may sit unanswered before we treat it as a
- *  genuine wait. Auto-approved permissions (opencode `"permission": "allow"`)
- *  fire permission.updated then permission.replied within milliseconds; holding
- *  briefly lets us cancel those and only surface awaiting_input for permissions
- *  a human/orchestrator actually has to act on. Not latency-critical. */
+/** How long a permission request may sit unanswered before we treat it as a
+ *  genuine wait. Auto-approved permissions fire an ask/update and then a reply
+ *  within milliseconds; holding briefly lets us cancel those and only surface
+ *  awaiting_input for permissions a human/orchestrator actually has to act on.
+ *  Not latency-critical. */
 const PERMISSION_SETTLE_MS = 500;
 
 /**
  * The OpenCode plugin. Subscribes to the event stream and forwards:
- *   - session.idle          → agent.stop           (a turn finished)
- *   - permission.updated    → agent.awaiting_input  (blocked on an approval),
- *                             debounced so auto-allowed permissions don't fire.
+ *   - session.idle                         → agent.stop
+ *   - permission.asked / permission.updated → agent.awaiting_input,
+ *                                             debounced for auto-approval.
  * Child (sub-agent) sessions are suppressed so the orchestrator wakes on the
  * root session's turns, not every sub-agent turn. Every branch is guarded +
  * best-effort — an exception here must never disrupt the opencode session.
@@ -287,8 +456,8 @@ const PERMISSION_SETTLE_MS = 500;
 export const WmuxBridge = async ({ directory, client } = {}) => {
   logEvent('loaded', { directory: nonEmptyStr(directory), hasClient: !!client });
   const cwd = nonEmptyStr(directory);
-  // permissionID → settle timer. A permission.replied for the same id before the
-  // timer fires cancels the awaiting_input (the permission auto-resolved).
+  // permission request id → settle timer. A permission.replied for the same id
+  // before the timer fires cancels awaiting_input (the permission auto-resolved).
   const pendingPermissions = new Map();
 
   return {
@@ -298,20 +467,33 @@ export const WmuxBridge = async ({ directory, client } = {}) => {
 
         if (event.type === 'session.idle') {
           const sessionId = nonEmptyStr(event?.properties?.sessionID);
-          if (await isChildSession(client, sessionId)) {
-            logEvent('skip-child-idle', { sessionId });
-            return;
-          }
-          await sendSignal(buildOpencodeEnvelope('agent.stop', { cwd, sessionId }), 'opencode-idle');
+          // OpenCode awaits plugin event handlers. Detach the child lookup and
+          // pipe RPC so even a wedged endpoint cannot add the 2s transport cap
+          // to the TUI's idle transition. The OpenCode process is long-lived;
+          // sendSignal retains its own bounded deadline and error logging.
+          void (async () => {
+            try {
+              if (await isChildSession(client, sessionId)) {
+                logEvent('skip-child-idle', { sessionId });
+                return;
+              }
+              await sendSignal(buildOpencodeEnvelope('agent.stop', { cwd, sessionId }), 'opencode-idle');
+            } catch (err) {
+              logEvent('idle-signal-error', { error: String(err) });
+            }
+          })();
           return;
         }
 
-        if (event.type === 'permission.updated') {
-          // properties: Permission { id, sessionID, title, ... }
+        if (event.type === 'permission.asked' || event.type === 'permission.updated') {
+          // Current permission.asked and legacy permission.updated both carry a
+          // request-like object with id/sessionID; legacy builds may add title.
           const perm = event?.properties ?? {};
-          const permId = nonEmptyStr(perm.id);
+          const permId = nonEmptyStr(perm.id)
+            ?? nonEmptyStr(perm.requestID)
+            ?? nonEmptyStr(perm.permissionID);
           if (!permId || pendingPermissions.has(permId)) return;
-          const sessionId = nonEmptyStr(perm.sessionID);
+          const sessionId = nonEmptyStr(perm.sessionID) ?? nonEmptyStr(perm.sessionId);
           const title = nonEmptyStr(perm.title);
           const timer = setTimeout(() => {
             pendingPermissions.delete(permId);
@@ -342,8 +524,11 @@ export const WmuxBridge = async ({ directory, client } = {}) => {
         }
 
         if (event.type === 'permission.replied') {
-          // properties: { sessionID, permissionID, response }
-          const permId = nonEmptyStr(event?.properties?.permissionID);
+          // Current/legacy SDKs have used requestID, permissionID, and id.
+          const reply = event?.properties ?? {};
+          const permId = nonEmptyStr(reply.requestID)
+            ?? nonEmptyStr(reply.permissionID)
+            ?? nonEmptyStr(reply.id);
           const timer = permId ? pendingPermissions.get(permId) : undefined;
           if (timer) {
             clearTimeout(timer);

--- a/integrations/opencode/plugins/wmux.js
+++ b/integrations/opencode/plugins/wmux.js
@@ -53,7 +53,8 @@ const HOOK_TIMEOUT_MS = 2000;
 //   0.2.0 — suffix-isolated daemon-first lifecycle routing + durable stop metadata.
 //   0.2.1 — session.idle dispatch detached from the OpenCode event loop.
 //   0.2.2 — safe legacy-daemon fallback and canonical main socket discovery.
-const BRIDGE_VERSION = '0.2.2';
+//   0.2.3 — consistent permission request/reply correlation.
+const BRIDGE_VERSION = '0.2.3';
 const CONNECT_RETRY_BACKOFFS_MS = [100, 250];
 const TRANSIENT_CONNECT_CODES = new Set([
   'EPERM', 'ECONNREFUSED', 'ECONNRESET', 'EPIPE', 'ETIMEDOUT', 'EBUSY', 'EAGAIN',
@@ -459,6 +460,9 @@ export const WmuxBridge = async ({ directory, client } = {}) => {
   // permission request id → settle timer. A permission.replied for the same id
   // before the timer fires cancels awaiting_input (the permission auto-resolved).
   const pendingPermissions = new Map();
+  const permissionRequestId = (properties = {}) => nonEmptyStr(properties.id)
+    ?? nonEmptyStr(properties.requestID)
+    ?? nonEmptyStr(properties.permissionID);
 
   return {
     event: async ({ event }) => {
@@ -489,9 +493,7 @@ export const WmuxBridge = async ({ directory, client } = {}) => {
           // Current permission.asked and legacy permission.updated both carry a
           // request-like object with id/sessionID; legacy builds may add title.
           const perm = event?.properties ?? {};
-          const permId = nonEmptyStr(perm.id)
-            ?? nonEmptyStr(perm.requestID)
-            ?? nonEmptyStr(perm.permissionID);
+          const permId = permissionRequestId(perm);
           if (!permId || pendingPermissions.has(permId)) return;
           const sessionId = nonEmptyStr(perm.sessionID) ?? nonEmptyStr(perm.sessionId);
           const title = nonEmptyStr(perm.title);
@@ -526,9 +528,7 @@ export const WmuxBridge = async ({ directory, client } = {}) => {
         if (event.type === 'permission.replied') {
           // Current/legacy SDKs have used requestID, permissionID, and id.
           const reply = event?.properties ?? {};
-          const permId = nonEmptyStr(reply.requestID)
-            ?? nonEmptyStr(reply.permissionID)
-            ?? nonEmptyStr(reply.id);
+          const permId = permissionRequestId(reply);
           const timer = permId ? pendingPermissions.get(permId) : undefined;
           if (timer) {
             clearTimeout(timer);

--- a/scripts/copy-bridge.mjs
+++ b/scripts/copy-bridge.mjs
@@ -16,21 +16,35 @@ const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 const destDir = join(repoRoot, 'dist', 'cli-bundle');
 
 // Self-contained agent bridges shipped in the CLI bundle (extraResource):
-//   - Claude Code hook bridge (installed to ~/.wmux/hooks by `wmux setup-hooks`)
-//   - Codex resume-capture notify bridge (installed + registered by McpRegistrar)
+//   - Claude Code hook/statusline bridges
+//   - Codex lifecycle notify bridge
+//   - OpenCode lifecycle plugin (renamed in the bundle to avoid generic wmux.js)
 const bridges = [
-  join(repoRoot, 'integrations', 'claude', 'bin', 'wmux-bridge.mjs'),
-  join(repoRoot, 'integrations', 'claude', 'bin', 'wmux-statusline.mjs'),
-  join(repoRoot, 'integrations', 'codex', 'bin', 'wmux-codex-notify.mjs'),
+  {
+    src: join(repoRoot, 'integrations', 'claude', 'bin', 'wmux-bridge.mjs'),
+    dest: 'wmux-bridge.mjs',
+  },
+  {
+    src: join(repoRoot, 'integrations', 'claude', 'bin', 'wmux-statusline.mjs'),
+    dest: 'wmux-statusline.mjs',
+  },
+  {
+    src: join(repoRoot, 'integrations', 'codex', 'bin', 'wmux-codex-notify.mjs'),
+    dest: 'wmux-codex-notify.mjs',
+  },
+  {
+    src: join(repoRoot, 'integrations', 'opencode', 'plugins', 'wmux.js'),
+    dest: 'wmux-opencode-plugin.js',
+  },
 ];
 
 mkdirSync(destDir, { recursive: true });
-for (const src of bridges) {
+for (const { src, dest: destBasename } of bridges) {
   if (!existsSync(src)) {
     console.error(`copy-bridge: source not found: ${src}`);
     process.exit(1);
   }
-  const dest = join(destDir, src.split(/[\\/]/).pop());
+  const dest = join(destDir, destBasename);
   copyFileSync(src, dest);
   console.log(`copy-bridge: ${src} -> ${dest}`);
 }

--- a/src/cli/commands/setupHooks.ts
+++ b/src/cli/commands/setupHooks.ts
@@ -24,18 +24,18 @@ import * as path from 'path';
  */
 
 const HELP_TEXT = `
-wmux setup-hooks — install Claude Code hooks without the marketplace plugin
+wmux setup-hooks — install official CLI lifecycle integrations
 
 USAGE
   wmux setup-hooks [--remove | --status] [--json]
 
 ACTIONS (mutually exclusive; default = install)
-  (default)    Install wmux hook entries into ~/.claude/settings.json and copy
-               the bridge to ~/.wmux/hooks/wmux-bridge.mjs.
-  --remove     Remove only the wmux-owned hook entries (leaves your other hooks).
-  --status     Report whether wmux hooks are installed, whether the copied bridge
-               is up to date, and a double-signal warning if the plugin is also
-               installed.
+  (default)    Install or refresh Claude Code hooks, the Codex notify bridge,
+               and the OpenCode lifecycle plugin. Existing foreign hooks,
+               notify commands, and plugin files are never overwritten.
+  --remove     Remove only wmux-owned Claude hook entries (legacy behavior;
+               Codex/OpenCode files and foreign configuration are untouched).
+  --status     Report Claude, Codex, and OpenCode lifecycle integration status.
 
 GLOBAL FLAGS
   --json       Output raw JSON (useful for scripting).
@@ -85,8 +85,9 @@ export function defaultPaths(): SetupHooksPaths {
  *   - `cli-bundle/wmux-bridge.mjs`             (패키징 앱의 메인 프로세스 — __dirname이
  *                                               app.asar/.vite/build라 walk-up이
  *                                               Resources에 닿았을 때 cli-bundle/로 진입)
- *   - `dist/cli-bundle/wmux-bridge.mjs`        (repo dist after `build:cli`)
- *   - `integrations/claude/bin/wmux-bridge.mjs` (dev fallback — repo checkout)
+ *   - `integrations/claude/bin/wmux-bridge.mjs` (live dev checkout; preferred
+ *                                               over a potentially stale dist)
+ *   - `dist/cli-bundle/wmux-bridge.mjs`        (repo build fallback)
  * Returns null when none exist, in which case install aborts with guidance.
  * 주의: 이 함수는 CLI뿐 아니라 hooksBridge.handler(메인 프로세스, 인앱 "hook 설치"
  * 버튼)에서도 호출된다 — cli-bundle/ 후보가 없으면 인앱 설치가 항상 실패한다(#489 후속).
@@ -95,8 +96,9 @@ export function findBridgeSourceFrom(startDir: string): string | null {
   const candidates = [
     'wmux-bridge.mjs',
     path.join('cli-bundle', 'wmux-bridge.mjs'),
-    path.join('dist', 'cli-bundle', 'wmux-bridge.mjs'),
+    // Prefer live checkout source over a potentially stale dist build.
     path.join('integrations', 'claude', 'bin', 'wmux-bridge.mjs'),
+    path.join('dist', 'cli-bundle', 'wmux-bridge.mjs'),
   ];
   let dir = startDir;
   for (let i = 0; i < 6; i++) {
@@ -714,6 +716,51 @@ function printStatus(outcome: StatusOutcome, jsonMode: boolean): void {
   }
 }
 
+// ----- Aggregate lifecycle integration printing ----------------------------
+
+interface PrintableAssetStatus {
+  sourcePath: string | null;
+  destinationPath: string;
+  state: string;
+  error: string | null;
+}
+
+function printAssetStatus(label: string, asset: PrintableAssetStatus): void {
+  switch (asset.state) {
+    case 'current':
+      console.log(`${label}: ${asset.destinationPath} (up to date)`);
+      break;
+    case 'missing':
+      console.log(`${label}: NOT installed (${asset.destinationPath})`);
+      break;
+    case 'stale':
+      console.log(`${label}: ${asset.destinationPath} (STALE — re-run \`wmux setup-hooks\`)`);
+      break;
+    case 'foreign':
+      console.warn(`${label}: CONFLICT — ${asset.destinationPath} is not wmux-owned; left untouched`);
+      break;
+    case 'source-missing':
+      console.log(`${label}: bundled source unavailable; reinstall or rebuild wmux`);
+      break;
+    default:
+      console.log(`${label}: ERROR${asset.error ? ` — ${asset.error}` : ''}`);
+      break;
+  }
+}
+
+function printAssetInstall(
+  label: string,
+  asset: PrintableAssetStatus & { action: 'none' | 'installed' | 'refreshed' },
+): void {
+  if (asset.action === 'installed') {
+    console.log(`${label}: installed → ${asset.destinationPath}`);
+  } else if (asset.action === 'refreshed') {
+    console.log(`${label}: refreshed → ${asset.destinationPath}`);
+  } else {
+    printAssetStatus(label, asset);
+  }
+}
+
 // ----- Dispatch -----------------------------------------------------------
 
 export async function handleSetupHooks(args: string[], jsonMode: boolean): Promise<void> {
@@ -743,15 +790,8 @@ export async function handleSetupHooks(args: string[], jsonMode: boolean): Promi
 
   const paths = defaultPaths();
 
-  if (status) {
-    const outcome = statusHooks(paths);
-    printStatus(outcome, jsonMode);
-    // Scripted `wmux setup-hooks --status && …` must be able to gate on a
-    // corrupted settings.json.
-    if (outcome.settingsCorrupted) process.exit(1);
-    return;
-  }
-
+  // Preserve the historical --remove contract: it only edits Claude's
+  // settings.json and never deletes shared scripts or another CLI's config.
   if (remove) {
     const outcome = removeHooks(paths);
     printRemove(outcome, jsonMode);
@@ -759,7 +799,70 @@ export async function handleSetupHooks(args: string[], jsonMode: boolean): Promi
     return;
   }
 
-  const outcome = installHooks(paths);
-  printInstall(outcome, jsonMode);
+  const lifecycle = await import('../../shared/lifecycleIntegrations');
+  const lifecyclePaths = lifecycle.resolveLifecycleIntegrationPaths(os.homedir(), __dirname);
+
+  if (status) {
+    const claude = statusHooks(paths);
+    const integrations = lifecycle.statusLifecycleIntegrations(lifecyclePaths);
+    const outcome = { claude, ...integrations };
+    if (jsonMode) {
+      console.log(JSON.stringify(outcome, null, 2));
+    } else {
+      printStatus(claude, false);
+      printAssetStatus('codex bridge', integrations.codexBridge);
+      if (!integrations.codexNotify.configExists) {
+        console.log(`codex notify: Codex config not found (${integrations.codexNotify.configPath})`);
+      } else if (integrations.codexNotify.state === 'wmux') {
+        console.log(`codex notify: registered → ${integrations.codexNotify.path}`);
+      } else if (integrations.codexNotify.state === 'stale') {
+        console.warn(
+          `codex notify: STALE (${integrations.codexNotify.path ?? integrations.codexNotify.configPath}); ` +
+          're-run `wmux setup-hooks`',
+        );
+      } else if (integrations.codexNotify.state === 'foreign') {
+        console.warn(`codex notify: CONFLICT in ${integrations.codexNotify.configPath}; foreign notify left untouched`);
+      } else if (integrations.codexNotify.state === 'malformed') {
+        console.warn(`codex notify: MALFORMED config left untouched (${integrations.codexNotify.configPath})`);
+      } else {
+        console.log(`codex notify: NOT registered (${integrations.codexNotify.configPath})`);
+      }
+      printAssetStatus('opencode plugin', integrations.opencodePlugin);
+    }
+    // Keep the existing scripted contract: status is non-zero only when the
+    // Claude settings file is corrupt, not merely because an optional CLI is
+    // absent or a user-owned integration occupies its slot.
+    if (claude.settingsCorrupted) process.exit(1);
+    return;
+  }
+
+  // Run each integration independently so a corrupt Claude settings file does
+  // not prevent safe Codex/OpenCode installation (and vice versa).
+  const claude = installHooks(paths);
+  const integrations = lifecycle.installLifecycleIntegrations(lifecyclePaths);
+  const outcome = { ...integrations, ok: claude.ok && integrations.ok, claude };
+  if (jsonMode) {
+    console.log(JSON.stringify(outcome, null, 2));
+  } else {
+    printInstall(claude, false);
+    printAssetInstall('codex bridge', integrations.codexBridge);
+    if (!integrations.codexNotify) {
+      console.warn('codex notify: not registered because the bridge could not be installed safely');
+    } else if (integrations.codexNotify.skipped === 'absent') {
+      console.log(`codex notify: Codex config not found (${integrations.codexNotify.configPath})`);
+    } else if (integrations.codexNotify.skipped === 'foreign') {
+      console.warn(`codex notify: CONFLICT in ${integrations.codexNotify.configPath}; foreign notify left untouched`);
+    } else if (integrations.codexNotify.skipped === 'malformed') {
+      console.warn(`codex notify: malformed config left untouched (${integrations.codexNotify.configPath})`);
+    } else if (integrations.codexNotify.wrote) {
+      console.log(`codex notify: registered in ${integrations.codexNotify.configPath}`);
+    } else {
+      console.log(`codex notify: already registered in ${integrations.codexNotify.configPath}`);
+    }
+    printAssetInstall('opencode plugin', integrations.opencodePlugin);
+    if (integrations.opencodePlugin.action !== 'none') {
+      console.log('Restart existing OpenCode sessions so they load the wmux plugin.');
+    }
+  }
   if (!outcome.ok) process.exit(1);
 }

--- a/src/cli/commands/setupHooks.ts
+++ b/src/cli/commands/setupHooks.ts
@@ -805,7 +805,9 @@ export async function handleSetupHooks(args: string[], jsonMode: boolean): Promi
   if (status) {
     const claude = statusHooks(paths);
     const integrations = lifecycle.statusLifecycleIntegrations(lifecyclePaths);
-    const outcome = { claude, ...integrations };
+    // Preserve the legacy Claude-only root fields for scripts while exposing
+    // the richer per-integration objects alongside them.
+    const outcome = { ...claude, claude, ...integrations };
     if (jsonMode) {
       console.log(JSON.stringify(outcome, null, 2));
     } else {
@@ -840,7 +842,12 @@ export async function handleSetupHooks(args: string[], jsonMode: boolean): Promi
   // not prevent safe Codex/OpenCode installation (and vice versa).
   const claude = installHooks(paths);
   const integrations = lifecycle.installLifecycleIntegrations(lifecyclePaths);
-  const outcome = { ...integrations, ok: claude.ok && integrations.ok, claude };
+  const outcome = {
+    ...claude,
+    ...integrations,
+    ok: claude.ok && integrations.ok,
+    claude,
+  };
   if (jsonMode) {
     console.log(JSON.stringify(outcome, null, 2));
   } else {

--- a/src/main/mcp/McpRegistrar.ts
+++ b/src/main/mcp/McpRegistrar.ts
@@ -11,6 +11,14 @@ import { canConnectBrokerPipe } from './brokerProbe';
 import { stabilizeMcpBundle } from './stabilizeBundle';
 import { CODEX_NOTIFY_BASENAME } from '../../shared/configIO';
 import {
+  CODEX_NOTIFY_MANAGED_MARKER,
+  OPENCODE_PLUGIN_BUNDLE_BASENAME,
+  OPENCODE_PLUGIN_INSTALL_BASENAME,
+  OPENCODE_PLUGIN_MANAGED_MARKER,
+  findLifecycleAssetSourceFrom,
+  installLifecycleAsset,
+} from '../../shared/lifecycleIntegrations';
+import {
   readAllTargetStatuses,
   registerTarget,
   unregisterTarget,
@@ -193,13 +201,17 @@ export class McpRegistrar {
         }
       }
 
-      // X6 codex resume: register the Codex resume-capture `notify` bridge in the
-      // SAME codex config.toml. Isolated so a notify failure never aborts MCP
-      // registration (and vice-versa).
+      // Official lifecycle integrations are isolated so one agent's config or
+      // filesystem failure never aborts MCP registration or another bridge.
       try {
         this.installAndRegisterCodexNotify();
       } catch (err) {
         console.error('[McpRegistrar] Codex notify registration failed:', err);
+      }
+      try {
+        this.installOpenCodePlugin();
+      } catch (err) {
+        console.error('[McpRegistrar] OpenCode plugin installation failed:', err);
       }
 
       this.registered = true;
@@ -342,38 +354,87 @@ export class McpRegistrar {
   }
 
   /**
-   * Install the Codex notify bridge to a STABLE, version-free location
-   * (`~/.wmux/hooks/wmux-codex-notify.mjs`) and register it as Codex's `notify`
-   * program. Copying fresh on every boot keeps the installed script in lock-step
-   * with the running app version while the config path never goes stale (unlike
-   * the versioned resources path). Skip-if-foreign lives in registerCodexNotify.
+   * Install the Codex notify bridge to a stable path and register it without
+   * replacing a foreign destination or foreign root `notify` command.
    */
   private installAndRegisterCodexNotify(): void {
     const src = this.getCodexNotifySourcePath();
-    if (!src) {
-      console.warn('[McpRegistrar] Codex notify script not found — skipping notify registration.');
-      return;
-    }
     const dest = path.join(this.home, '.wmux', 'hooks', CODEX_NOTIFY_BASENAME);
-    try {
-      const destDir = path.dirname(dest);
-      if (!fs.existsSync(destDir)) fs.mkdirSync(destDir, { recursive: true });
-      fs.copyFileSync(src, dest);
-    } catch (err) {
-      console.error('[McpRegistrar] Failed to install Codex notify script:', err);
+    const installed = installLifecycleAsset({
+      sourcePath: src,
+      destinationPath: dest,
+      ownershipMarkers: [CODEX_NOTIFY_MANAGED_MARKER],
+    });
+    if (installed.state !== 'current') {
+      const detail = installed.error ? `: ${installed.error}` : '';
+      console.warn(
+        `[McpRegistrar] Codex notify bridge ${installed.state}; left ${dest} untouched${detail}`,
+      );
       return;
     }
+    if (installed.action !== 'none') {
+      console.log(`[McpRegistrar] Codex notify bridge ${installed.action} → ${dest}`);
+    }
+
     const result = registerCodexNotify(this.home, dest);
     if (result.skipped === 'foreign') {
-      // Surface the skip (GLM outside-voice: don't silently downgrade). The
-      // user's own notify is preserved; Codex resume falls back to the pill's
-      // `codex resume --last`. Also queryable via getStatus().codexNotify.
+      // The user's own notify is preserved; Codex resume falls back to the
+      // pill's `codex resume --last`. Also queryable via getStatus().
       console.warn(
         `[McpRegistrar] Codex notify: skipped — a foreign notify occupies the slot in ${result.configPath}. ` +
         'Codex resume auto-capture is OFF; the resume pill falls back to `codex resume --last`.',
       );
+    } else if (result.skipped === 'malformed') {
+      console.warn(`[McpRegistrar] Codex notify: malformed config left untouched at ${result.configPath}`);
     } else if (result.wrote) {
       console.log(`[McpRegistrar] Codex notify → ${dest}`);
+    }
+  }
+
+  /** Resolve the bundled OpenCode plugin in packaged and development layouts. */
+  private getOpenCodePluginSourcePath(): string | null {
+    if (app.isPackaged) {
+      const bundled = path.join(
+        process.resourcesPath,
+        'cli-bundle',
+        OPENCODE_PLUGIN_BUNDLE_BASENAME,
+      );
+      return fs.existsSync(bundled) ? bundled : null;
+    }
+    return findLifecycleAssetSourceFrom(
+      app.getAppPath(),
+      OPENCODE_PLUGIN_BUNDLE_BASENAME,
+      ['integrations', 'opencode', 'plugins', OPENCODE_PLUGIN_INSTALL_BASENAME],
+    );
+  }
+
+  /**
+   * Install/refresh the global OpenCode lifecycle plugin only when OpenCode's
+   * config root already exists (or wmux previously installed the destination).
+   * A same-name user plugin without the wmux marker is always preserved.
+   */
+  private installOpenCodePlugin(): void {
+    const configRoot = path.join(this.home, '.config', 'opencode');
+    const dest = path.join(configRoot, 'plugins', OPENCODE_PLUGIN_INSTALL_BASENAME);
+    if (!fs.existsSync(configRoot) && !fs.existsSync(dest)) return;
+
+    const installed = installLifecycleAsset({
+      sourcePath: this.getOpenCodePluginSourcePath(),
+      destinationPath: dest,
+      ownershipMarkers: [
+        OPENCODE_PLUGIN_MANAGED_MARKER,
+        'wmux ↔ OpenCode plugin bridge',
+      ],
+    });
+    if (installed.state !== 'current') {
+      const detail = installed.error ? `: ${installed.error}` : '';
+      console.warn(
+        `[McpRegistrar] OpenCode lifecycle plugin ${installed.state}; left ${dest} untouched${detail}`,
+      );
+      return;
+    }
+    if (installed.action !== 'none') {
+      console.log(`[McpRegistrar] OpenCode lifecycle plugin ${installed.action} → ${dest}`);
     }
   }
 }

--- a/src/main/mcp/McpRegistrar.ts
+++ b/src/main/mcp/McpRegistrar.ts
@@ -11,12 +11,9 @@ import { canConnectBrokerPipe } from './brokerProbe';
 import { stabilizeMcpBundle } from './stabilizeBundle';
 import { CODEX_NOTIFY_BASENAME } from '../../shared/configIO';
 import {
-  CODEX_NOTIFY_MANAGED_MARKER,
   OPENCODE_PLUGIN_BUNDLE_BASENAME,
-  OPENCODE_PLUGIN_INSTALL_BASENAME,
-  OPENCODE_PLUGIN_MANAGED_MARKER,
-  findLifecycleAssetSourceFrom,
   installLifecycleAsset,
+  resolveLifecycleIntegrationPaths,
 } from '../../shared/lifecycleIntegrations';
 import {
   readAllTargetStatuses,
@@ -358,12 +355,11 @@ export class McpRegistrar {
    * replacing a foreign destination or foreign root `notify` command.
    */
   private installAndRegisterCodexNotify(): void {
-    const src = this.getCodexNotifySourcePath();
-    const dest = path.join(this.home, '.wmux', 'hooks', CODEX_NOTIFY_BASENAME);
+    const spec = resolveLifecycleIntegrationPaths(this.home, app.getAppPath()).codex;
+    const dest = spec.destinationPath;
     const installed = installLifecycleAsset({
-      sourcePath: src,
-      destinationPath: dest,
-      ownershipMarkers: [CODEX_NOTIFY_MANAGED_MARKER],
+      ...spec,
+      sourcePath: this.getCodexNotifySourcePath(),
     });
     if (installed.state !== 'current') {
       const detail = installed.error ? `: ${installed.error}` : '';
@@ -392,7 +388,7 @@ export class McpRegistrar {
   }
 
   /** Resolve the bundled OpenCode plugin in packaged and development layouts. */
-  private getOpenCodePluginSourcePath(): string | null {
+  private getOpenCodePluginSourcePath(devSource: string | null): string | null {
     if (app.isPackaged) {
       const bundled = path.join(
         process.resourcesPath,
@@ -401,11 +397,7 @@ export class McpRegistrar {
       );
       return fs.existsSync(bundled) ? bundled : null;
     }
-    return findLifecycleAssetSourceFrom(
-      app.getAppPath(),
-      OPENCODE_PLUGIN_BUNDLE_BASENAME,
-      ['integrations', 'opencode', 'plugins', OPENCODE_PLUGIN_INSTALL_BASENAME],
-    );
+    return devSource;
   }
 
   /**
@@ -414,17 +406,14 @@ export class McpRegistrar {
    * A same-name user plugin without the wmux marker is always preserved.
    */
   private installOpenCodePlugin(): void {
-    const configRoot = path.join(this.home, '.config', 'opencode');
-    const dest = path.join(configRoot, 'plugins', OPENCODE_PLUGIN_INSTALL_BASENAME);
+    const spec = resolveLifecycleIntegrationPaths(this.home, app.getAppPath()).opencode;
+    const dest = spec.destinationPath;
+    const configRoot = path.dirname(path.dirname(dest));
     if (!fs.existsSync(configRoot) && !fs.existsSync(dest)) return;
 
     const installed = installLifecycleAsset({
-      sourcePath: this.getOpenCodePluginSourcePath(),
-      destinationPath: dest,
-      ownershipMarkers: [
-        OPENCODE_PLUGIN_MANAGED_MARKER,
-        'wmux ↔ OpenCode plugin bridge',
-      ],
+      ...spec,
+      sourcePath: this.getOpenCodePluginSourcePath(spec.sourcePath),
     });
     if (installed.state !== 'current') {
       const detail = installed.error ? `: ${installed.error}` : '';

--- a/src/shared/__tests__/lifecycleIntegrations.test.ts
+++ b/src/shared/__tests__/lifecycleIntegrations.test.ts
@@ -1,0 +1,302 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  CODEX_NOTIFY_MANAGED_MARKER,
+  OPENCODE_PLUGIN_MANAGED_MARKER,
+  findLifecycleAssetSourceFrom,
+  inspectLifecycleAsset,
+  installLifecycleAsset,
+  installLifecycleIntegrations,
+  resolveLifecycleIntegrationPaths,
+  statusLifecycleIntegrations,
+  type LifecycleAssetSpec,
+  type LifecycleIntegrationPaths,
+} from '../lifecycleIntegrations';
+import { CODEX_NOTIFY_BASENAME } from '../configIO';
+import { getMcpTarget } from '../mcpTargets';
+
+let home = '';
+const codexTarget = getMcpTarget('codex')!;
+
+const SOURCE_TEXT = `${CODEX_NOTIFY_MANAGED_MARKER}\n// wmux-managed lifecycle bridge body\n`;
+const FOREIGN_TEXT = '// a user-owned script; no wmux marker anywhere\n';
+const MARKERS = [CODEX_NOTIFY_MANAGED_MARKER] as const;
+
+/** Build a spec whose source is a real temp file with the given contents. */
+function specWithSource(text: string, destinationPath: string): LifecycleAssetSpec {
+  const sourcePath = path.join(home, `src-${Math.random().toString(36).slice(2)}.mjs`);
+  fs.writeFileSync(sourcePath, text, 'utf8');
+  return { sourcePath, destinationPath, ownershipMarkers: MARKERS };
+}
+
+function writeCodexConfig(text: string): string {
+  const p = codexTarget.configPath(home);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, text, 'utf8');
+  return p;
+}
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-life-'));
+  // Two tests assert the default ~/.config opencode destination. An ambient
+  // XDG_CONFIG_HOME in the runner env would silently reroute that and flake
+  // CI, so clear it; the XDG-honoring test sets its own value after this.
+  delete process.env.XDG_CONFIG_HOME;
+});
+afterEach(() => {
+  try { fs.rmSync(home, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+describe('inspectLifecycleAsset — read-only freshness/ownership', () => {
+  it('reports source-missing when no source path is supplied', () => {
+    const dest = path.join(home, 'dest.mjs');
+    const status = inspectLifecycleAsset({ sourcePath: null, destinationPath: dest, ownershipMarkers: MARKERS });
+    expect(status.state).toBe('source-missing');
+    expect(status.error).toBeNull();
+  });
+
+  it('reports source-missing when the source file does not exist', () => {
+    const dest = path.join(home, 'dest.mjs');
+    const status = inspectLifecycleAsset({ sourcePath: path.join(home, 'absent.mjs'), destinationPath: dest, ownershipMarkers: MARKERS });
+    expect(status.state).toBe('source-missing');
+  });
+
+  it('reports missing when the destination does not exist', () => {
+    const dest = path.join(home, 'dest.mjs');
+    const status = inspectLifecycleAsset(specWithSource(SOURCE_TEXT, dest));
+    expect(status.state).toBe('missing');
+  });
+
+  it('reports current when source and destination are byte-identical', () => {
+    const dest = path.join(home, 'dest.mjs');
+    const spec = specWithSource(SOURCE_TEXT, dest);
+    fs.copyFileSync(spec.sourcePath!, dest);
+    expect(inspectLifecycleAsset(spec).state).toBe('current');
+  });
+
+  it('reports stale when the destination differs but carries an ownership marker', () => {
+    const dest = path.join(home, 'dest.mjs');
+    // An OLDER wmux build: same marker, different body.
+    fs.writeFileSync(dest, `${CODEX_NOTIFY_MANAGED_MARKER}\n// older body\n`, 'utf8');
+    const status = inspectLifecycleAsset(specWithSource(SOURCE_TEXT, dest));
+    expect(status.state).toBe('stale');
+  });
+
+  it('reports foreign when the destination differs and has no ownership marker', () => {
+    const dest = path.join(home, 'dest.mjs');
+    fs.writeFileSync(dest, FOREIGN_TEXT, 'utf8');
+    const status = inspectLifecycleAsset(specWithSource(SOURCE_TEXT, dest));
+    expect(status.state).toBe('foreign');
+  });
+
+  it('reports error (not missing) when the destination exists but is unreadable as a file', () => {
+    const dest = path.join(home, 'a-directory');
+    fs.mkdirSync(dest, { recursive: true });
+    const status = inspectLifecycleAsset(specWithSource(SOURCE_TEXT, dest));
+    expect(status.state).toBe('error');
+    expect(status.error).not.toBeNull();
+  });
+
+  it('never creates a directory or throws on an unreadable source', () => {
+    const sourceAsDir = path.join(home, 'src-dir');
+    fs.mkdirSync(sourceAsDir, { recursive: true });
+    const status = inspectLifecycleAsset({ sourcePath: sourceAsDir, destinationPath: path.join(home, 'd.mjs'), ownershipMarkers: MARKERS });
+    expect(status.state).toBe('error');
+    expect(status.error).not.toBeNull();
+  });
+});
+
+describe('installLifecycleAsset — atomic install with foreign preservation', () => {
+  it('installs into a missing destination and reports action=installed', () => {
+    const dest = path.join(home, 'nested', 'dest.mjs');
+    const spec = specWithSource(SOURCE_TEXT, dest);
+    const outcome = installLifecycleAsset(spec);
+    expect(outcome.state).toBe('current');
+    expect(outcome.action).toBe('installed');
+    expect(fs.readFileSync(dest, 'utf8')).toBe(SOURCE_TEXT);
+    // No leftover temp files in the destination directory.
+    expect(fs.readdirSync(path.dirname(dest)).filter((f) => f.endsWith('.tmp'))).toEqual([]);
+  });
+
+  it('refreshes a stale wmux-owned destination and reports action=refreshed', () => {
+    const dest = path.join(home, 'dest.mjs');
+    fs.writeFileSync(dest, `${CODEX_NOTIFY_MANAGED_MARKER}\n// older body\n`, 'utf8');
+    const spec = specWithSource(SOURCE_TEXT, dest);
+    const outcome = installLifecycleAsset(spec);
+    expect(outcome.action).toBe('refreshed');
+    expect(fs.readFileSync(dest, 'utf8')).toBe(SOURCE_TEXT);
+  });
+
+  it('is a no-op (action=none) when already current', () => {
+    const dest = path.join(home, 'dest.mjs');
+    const spec = specWithSource(SOURCE_TEXT, dest);
+    fs.copyFileSync(spec.sourcePath!, dest);
+    expect(installLifecycleAsset(spec).action).toBe('none');
+  });
+
+  it('NEVER overwrites a foreign destination', () => {
+    const dest = path.join(home, 'dest.mjs');
+    fs.writeFileSync(dest, FOREIGN_TEXT, 'utf8');
+    const spec = specWithSource(SOURCE_TEXT, dest);
+    const outcome = installLifecycleAsset(spec);
+    expect(outcome.action).toBe('none');
+    expect(outcome.state).toBe('foreign');
+    expect(fs.readFileSync(dest, 'utf8')).toBe(FOREIGN_TEXT);
+  });
+
+  it('reports action=none / source-missing when the source is absent', () => {
+    const dest = path.join(home, 'dest.mjs');
+    const outcome = installLifecycleAsset({ sourcePath: path.join(home, 'nope.mjs'), destinationPath: dest, ownershipMarkers: MARKERS });
+    expect(outcome.action).toBe('none');
+    expect(outcome.state).toBe('source-missing');
+    expect(fs.existsSync(dest)).toBe(false);
+  });
+});
+
+describe('findLifecycleAssetSourceFrom — source resolution prefers live checkout over dist', () => {
+  it('prefers the integrations/ source over a stale dist build at the same level', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-find-'));
+    try {
+      const devFile = path.join(root, 'integrations', 'codex', 'bin', CODEX_NOTIFY_BASENAME);
+      const distFile = path.join(root, 'dist', 'cli-bundle', CODEX_NOTIFY_BASENAME);
+      fs.mkdirSync(path.dirname(devFile), { recursive: true });
+      fs.mkdirSync(path.dirname(distFile), { recursive: true });
+      fs.writeFileSync(devFile, 'dev', 'utf8');
+      fs.writeFileSync(distFile, 'stale-dist', 'utf8');
+      const found = findLifecycleAssetSourceFrom(root, CODEX_NOTIFY_BASENAME, ['integrations', 'codex', 'bin', CODEX_NOTIFY_BASENAME]);
+      expect(found).toBe(devFile);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('walks up parent directories until a candidate is found', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-findup-'));
+    try {
+      const deep = path.join(root, 'a', 'b', 'c');
+      fs.mkdirSync(deep, { recursive: true });
+      const candidate = path.join(root, 'integrations', 'opencode', 'plugins', 'wmux.js');
+      fs.mkdirSync(path.dirname(candidate), { recursive: true });
+      fs.writeFileSync(candidate, 'x', 'utf8');
+      // The opencode dev file has a DIFFERENT basename than its bundle name.
+      const found = findLifecycleAssetSourceFrom(deep, 'wmux-opencode-plugin.js', ['integrations', 'opencode', 'plugins', 'wmux.js']);
+      expect(found).toBe(candidate);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null when no candidate exists anywhere up the tree', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-findnull-'));
+    try {
+      expect(findLifecycleAssetSourceFrom(root, 'nope.mjs', ['x', 'y', 'nope.mjs'])).toBeNull();
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('resolveLifecycleIntegrationPaths — destination + marker wiring', () => {
+  it('resolves codex + opencode destinations and carries ownership markers', () => {
+    const paths = resolveLifecycleIntegrationPaths(home, home);
+    expect(paths.codex.destinationPath).toBe(path.join(home, '.wmux', 'hooks', CODEX_NOTIFY_BASENAME));
+    expect(paths.codex.ownershipMarkers).toContain(CODEX_NOTIFY_MANAGED_MARKER);
+    expect(paths.opencode.destinationPath).toBe(path.join(home, '.config', 'opencode', 'plugins', 'wmux.js'));
+    expect(paths.opencode.ownershipMarkers).toEqual([OPENCODE_PLUGIN_MANAGED_MARKER, 'wmux ↔ OpenCode plugin bridge']);
+  });
+
+  it('honors XDG_CONFIG_HOME for the opencode plugin destination', () => {
+    const xdg = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-xdg-'));
+    const prev = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = xdg;
+    try {
+      const paths = resolveLifecycleIntegrationPaths(home, home);
+      expect(paths.opencode.destinationPath.startsWith(xdg)).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.XDG_CONFIG_HOME; else process.env.XDG_CONFIG_HOME = prev;
+      fs.rmSync(xdg, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores a relative XDG_CONFIG_HOME (falls back to ~/.config)', () => {
+    const prev = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = 'relative/path';
+    try {
+      const paths = resolveLifecycleIntegrationPaths(home, home);
+      expect(paths.opencode.destinationPath).toBe(path.join(home, '.config', 'opencode', 'plugins', 'wmux.js'));
+    } finally {
+      if (prev === undefined) delete process.env.XDG_CONFIG_HOME; else process.env.XDG_CONFIG_HOME = prev;
+    }
+  });
+});
+
+describe('statusLifecycleIntegrations — codexNotify staleness', () => {
+  function pathsWithSource(): LifecycleIntegrationPaths {
+    const paths = resolveLifecycleIntegrationPaths(home, home);
+    // Give the codex bridge a real source so inspect does not short-circuit.
+    const src = path.join(home, 'codex-src.mjs');
+    fs.writeFileSync(src, SOURCE_TEXT, 'utf8');
+    paths.codex = { ...paths.codex, sourcePath: src };
+    return paths;
+  }
+
+  it('marks codexNotify stale when wmux notify points at a different path', () => {
+    const paths = pathsWithSource();
+    writeCodexConfig(`notify = ["node", "C:\\\\some\\\\other\\\\${CODEX_NOTIFY_BASENAME}"]\n`);
+    const status = statusLifecycleIntegrations(paths);
+    // isWmuxOwnedNotify is true (ends with the basename), but the configured
+    // path differs from the managed destination → statusLifecycleIntegrations
+    // downgrades 'wmux' to 'stale'. Deterministic, not a maybe.
+    expect(status.codexNotify.state).toBe('stale');
+  });
+
+  it('marks codexNotify stale when the configured script no longer exists', () => {
+    const paths = pathsWithSource();
+    // Point at the managed destination path, but never install the script there.
+    // JSON.stringify yields a valid TOML basic string (escapes backslashes),
+    // mirroring configIO.notifyLineText — do NOT pre-escape the path.
+    writeCodexConfig(`notify = ["node", ${JSON.stringify(paths.codex.destinationPath)}]\n`);
+    const status = statusLifecycleIntegrations(paths);
+    expect(status.codexNotify.state).toBe('stale');
+  });
+
+  it('reports codexNotify wmux when the registered script exists at the managed path', () => {
+    const paths = pathsWithSource();
+    fs.mkdirSync(path.dirname(paths.codex.destinationPath), { recursive: true });
+    fs.writeFileSync(paths.codex.destinationPath, SOURCE_TEXT, 'utf8');
+    writeCodexConfig(`notify = ["node", ${JSON.stringify(paths.codex.destinationPath)}]\n`);
+    const status = statusLifecycleIntegrations(paths);
+    expect(status.codexNotify.state).toBe('wmux');
+  });
+});
+
+describe('installLifecycleIntegrations — aggregation + codexNotify gating', () => {
+  it('returns ok=false when a source is missing (fatal), and leaves codexNotify null', () => {
+    // No source files resolvable from an empty home → both sources missing.
+    const paths = resolveLifecycleIntegrationPaths(home, home);
+    const outcome = installLifecycleIntegrations(paths);
+    expect(outcome.ok).toBe(false);
+    expect(outcome.codexNotify).toBeNull();
+  });
+
+  it('registers codex notify only when the codex bridge reached current', () => {
+    const paths = resolveLifecycleIntegrationPaths(home, home);
+    // Provide real sources for BOTH bridges so neither is source-missing (fatal).
+    const codexSrc = path.join(home, 'codex-src.mjs');
+    const opencodeSrc = path.join(home, 'opencode-src.js');
+    fs.writeFileSync(codexSrc, SOURCE_TEXT, 'utf8');
+    fs.writeFileSync(opencodeSrc, SOURCE_TEXT, 'utf8');
+    paths.codex = { ...paths.codex, sourcePath: codexSrc };
+    paths.opencode = { ...paths.opencode, sourcePath: opencodeSrc };
+    writeCodexConfig('model = "x"\n');
+
+    const outcome = installLifecycleIntegrations(paths);
+    expect(outcome.codexBridge.state).toBe('current');
+    expect(outcome.codexBridge.action).toBe('installed');
+    expect(outcome.codexNotify).not.toBeNull();
+    expect(outcome.codexNotify!.skipped).toBeNull();
+    expect(outcome.ok).toBe(true);
+  });
+});

--- a/src/shared/__tests__/mcpRegistration.test.ts
+++ b/src/shared/__tests__/mcpRegistration.test.ts
@@ -185,6 +185,41 @@ describe('registerCodexNotify — resume-capture notify (skip-if-foreign)', () =
     writeCodex('model = "x"\n');
     expect(readCodexNotifyStatus(home).state).toBe('none');
   });
+
+  // Regression: a non-array `notify` (e.g. a bare string) used to slip past the
+  // foreign guard (getNotify returned null for non-arrays) and be OVERWRITTEN.
+  // inspectNotifySlot now treats any present, non-string-array slot as a conflict.
+  it('NEVER clobbers a non-array (string) notify — reports foreign, untouched', () => {
+    const original = 'model = "x"\nnotify = "some-program"\n';
+    const p = writeCodex(original);
+    const r = registerCodexNotify(home, NOTIFY);
+    expect(r.skipped).toBe('foreign');
+    expect(r.wrote).toBe(false);
+    expect(fs.readFileSync(p, 'utf8')).toBe(original); // byte-stable
+    expect(readCodexNotifyStatus(home).state).toBe('foreign');
+  });
+
+  it('NEVER clobbers a notify array containing non-string elements', () => {
+    const original = 'model = "x"\nnotify = ["node", 123]\n';
+    const p = writeCodex(original);
+    const r = registerCodexNotify(home, NOTIFY);
+    expect(r.skipped).toBe('foreign');
+    expect(r.wrote).toBe(false);
+    expect(fs.readFileSync(p, 'utf8')).toBe(original);
+  });
+
+  it('claims an explicit empty notify array (a no-op slot)', () => {
+    writeCodex('model = "x"\nnotify = []\n');
+    const r = registerCodexNotify(home, NOTIFY);
+    expect(r.skipped).toBeNull();
+    expect(r.wrote).toBe(true);
+    expect(readCodexNotifyStatus(home).state).toBe('wmux');
+  });
+
+  it('readCodexNotifyStatus reports malformed (not none) when config exists but is unparseable', () => {
+    writeCodex('this = = broken [[');
+    expect(readCodexNotifyStatus(home).state).toBe('malformed');
+  });
 });
 
 describe('registerTarget — Gemini (unverified, never created)', () => {

--- a/src/shared/lifecycleIntegrations.ts
+++ b/src/shared/lifecycleIntegrations.ts
@@ -1,0 +1,232 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { randomBytes } from 'crypto';
+import { CODEX_NOTIFY_BASENAME } from './configIO';
+import {
+  readCodexNotifyStatus,
+  registerCodexNotify,
+  type CodexNotifyStatus,
+  type RegisterNotifyResult,
+} from './mcpRegistration';
+
+/** Stable bundle/install names for first-party lifecycle integrations. */
+export const OPENCODE_PLUGIN_BUNDLE_BASENAME = 'wmux-opencode-plugin.js';
+export const OPENCODE_PLUGIN_INSTALL_BASENAME = 'wmux.js';
+export const CODEX_NOTIFY_MANAGED_MARKER = 'wmux ↔ Codex CLI notify bridge';
+export const OPENCODE_PLUGIN_MANAGED_MARKER = 'wmux-managed: opencode-lifecycle-bridge';
+
+export type LifecycleAssetState =
+  | 'current'
+  | 'missing'
+  | 'stale'
+  | 'foreign'
+  | 'source-missing'
+  | 'error';
+
+export interface LifecycleAssetSpec {
+  sourcePath: string | null;
+  destinationPath: string;
+  /** Any one marker identifies an older or current wmux-owned destination. */
+  ownershipMarkers: readonly string[];
+}
+
+export interface LifecycleAssetStatus {
+  sourcePath: string | null;
+  destinationPath: string;
+  state: LifecycleAssetState;
+  error: string | null;
+}
+
+export interface LifecycleAssetInstallOutcome extends LifecycleAssetStatus {
+  action: 'none' | 'installed' | 'refreshed';
+}
+
+function isMissingError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT';
+}
+
+/** Read-only freshness/ownership check. Never creates a directory or throws. */
+export function inspectLifecycleAsset(spec: LifecycleAssetSpec): LifecycleAssetStatus {
+  const base = {
+    sourcePath: spec.sourcePath,
+    destinationPath: spec.destinationPath,
+    error: null,
+  };
+  if (!spec.sourcePath || !fs.existsSync(spec.sourcePath)) {
+    return { ...base, state: 'source-missing' };
+  }
+
+  let source: Buffer;
+  try {
+    source = fs.readFileSync(spec.sourcePath);
+  } catch (error) {
+    return { ...base, state: 'error', error: String(error) };
+  }
+
+  let destination: Buffer;
+  try {
+    destination = fs.readFileSync(spec.destinationPath);
+  } catch (error) {
+    if (isMissingError(error)) return { ...base, state: 'missing' };
+    return { ...base, state: 'error', error: String(error) };
+  }
+
+  if (source.equals(destination)) return { ...base, state: 'current' };
+  const destinationText = destination.toString('utf8');
+  const owned = spec.ownershipMarkers.some((marker) => destinationText.includes(marker));
+  return { ...base, state: owned ? 'stale' : 'foreign' };
+}
+
+/**
+ * Install or refresh one wmux-owned lifecycle asset atomically. A destination
+ * without a wmux marker is reported as foreign and is never overwritten.
+ */
+export function installLifecycleAsset(spec: LifecycleAssetSpec): LifecycleAssetInstallOutcome {
+  const before = inspectLifecycleAsset(spec);
+  if (before.state !== 'missing' && before.state !== 'stale') {
+    return { ...before, action: 'none' };
+  }
+
+  try {
+    const source = fs.readFileSync(spec.sourcePath as string);
+    const destinationDir = path.dirname(spec.destinationPath);
+    if (!fs.existsSync(destinationDir)) {
+      fs.mkdirSync(destinationDir, { recursive: true, mode: 0o700 });
+    }
+    const tempPath = `${spec.destinationPath}.${process.pid}-${randomBytes(6).toString('hex')}.tmp`;
+    fs.writeFileSync(tempPath, source, { mode: 0o600 });
+    try {
+      fs.renameSync(tempPath, spec.destinationPath);
+    } catch (error) {
+      try { fs.unlinkSync(tempPath); } catch { /* best-effort cleanup */ }
+      throw error;
+    }
+    return {
+      sourcePath: spec.sourcePath,
+      destinationPath: spec.destinationPath,
+      state: 'current',
+      error: null,
+      action: before.state === 'missing' ? 'installed' : 'refreshed',
+    };
+  } catch (error) {
+    return {
+      sourcePath: spec.sourcePath,
+      destinationPath: spec.destinationPath,
+      state: 'error',
+      error: String(error),
+      action: 'none',
+    };
+  }
+}
+
+/** Locate one bundled lifecycle asset from CLI, packaged, or repo layouts. */
+export function findLifecycleAssetSourceFrom(
+  startDir: string,
+  bundleBasename: string,
+  devRelativePath: readonly string[],
+): string | null {
+  const candidates = [
+    bundleBasename,
+    path.join('cli-bundle', bundleBasename),
+    // A source checkout is authoritative in development. Checking it before
+    // dist prevents an old build from downgrading an installed integration.
+    path.join(...devRelativePath),
+    path.join('dist', 'cli-bundle', bundleBasename),
+  ];
+  let current = startDir;
+  for (let i = 0; i < 6; i++) {
+    for (const relative of candidates) {
+      const candidate = path.join(current, relative);
+      if (fs.existsSync(candidate)) return candidate;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return null;
+}
+
+export interface LifecycleIntegrationPaths {
+  home: string;
+  codex: LifecycleAssetSpec;
+  opencode: LifecycleAssetSpec;
+}
+
+export function resolveLifecycleIntegrationPaths(home: string, startDir: string): LifecycleIntegrationPaths {
+  return {
+    home,
+    codex: {
+      sourcePath: findLifecycleAssetSourceFrom(
+        startDir,
+        CODEX_NOTIFY_BASENAME,
+        ['integrations', 'codex', 'bin', CODEX_NOTIFY_BASENAME],
+      ),
+      destinationPath: path.join(home, '.wmux', 'hooks', CODEX_NOTIFY_BASENAME),
+      ownershipMarkers: [CODEX_NOTIFY_MANAGED_MARKER],
+    },
+    opencode: {
+      sourcePath: findLifecycleAssetSourceFrom(
+        startDir,
+        OPENCODE_PLUGIN_BUNDLE_BASENAME,
+        ['integrations', 'opencode', 'plugins', OPENCODE_PLUGIN_INSTALL_BASENAME],
+      ),
+      destinationPath: path.join(home, '.config', 'opencode', 'plugins', OPENCODE_PLUGIN_INSTALL_BASENAME),
+      ownershipMarkers: [OPENCODE_PLUGIN_MANAGED_MARKER, 'wmux ↔ OpenCode plugin bridge'],
+    },
+  };
+}
+
+export interface LifecycleCodexNotifyStatus extends Omit<CodexNotifyStatus, 'state'> {
+  /** stale = wmux-shaped config points somewhere other than the managed current file. */
+  state: CodexNotifyStatus['state'] | 'stale';
+}
+
+export interface LifecycleIntegrationsStatus {
+  codexBridge: LifecycleAssetStatus;
+  codexNotify: LifecycleCodexNotifyStatus;
+  opencodePlugin: LifecycleAssetStatus;
+}
+
+const normalizePath = (value: string): string => value.replace(/\\/g, '/');
+
+export function statusLifecycleIntegrations(paths: LifecycleIntegrationPaths): LifecycleIntegrationsStatus {
+  const rawNotify = readCodexNotifyStatus(paths.home);
+  let codexNotify: LifecycleCodexNotifyStatus = rawNotify;
+  if (rawNotify.state === 'wmux') {
+    const configuredPath = rawNotify.path;
+    const pathMatches = !!configuredPath
+      && normalizePath(configuredPath) === normalizePath(paths.codex.destinationPath);
+    const scriptExists = !!configuredPath && fs.existsSync(configuredPath);
+    if (!pathMatches || !scriptExists) codexNotify = { ...rawNotify, state: 'stale' };
+  }
+  return {
+    codexBridge: inspectLifecycleAsset(paths.codex),
+    codexNotify,
+    opencodePlugin: inspectLifecycleAsset(paths.opencode),
+  };
+}
+
+export interface LifecycleIntegrationsInstallOutcome {
+  ok: boolean;
+  codexBridge: LifecycleAssetInstallOutcome;
+  codexNotify: RegisterNotifyResult | null;
+  opencodePlugin: LifecycleAssetInstallOutcome;
+}
+
+/** Install/refresh runtime assets and register Codex notify without clobbering conflicts. */
+export function installLifecycleIntegrations(
+  paths: LifecycleIntegrationPaths,
+): LifecycleIntegrationsInstallOutcome {
+  const codexBridge = installLifecycleAsset(paths.codex);
+  const codexNotify = codexBridge.state === 'current'
+    ? registerCodexNotify(paths.home, paths.codex.destinationPath)
+    : null;
+  const opencodePlugin = installLifecycleAsset(paths.opencode);
+  const fatalStates = new Set<LifecycleAssetState>(['source-missing', 'error']);
+  return {
+    ok: !fatalStates.has(codexBridge.state) && !fatalStates.has(opencodePlugin.state),
+    codexBridge,
+    codexNotify,
+    opencodePlugin,
+  };
+}

--- a/src/shared/lifecycleIntegrations.ts
+++ b/src/shared/lifecycleIntegrations.ts
@@ -152,6 +152,13 @@ export interface LifecycleIntegrationPaths {
   opencode: LifecycleAssetSpec;
 }
 
+function resolveOpenCodeConfigHome(home: string): string {
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME;
+  return xdgConfigHome && path.isAbsolute(xdgConfigHome)
+    ? xdgConfigHome
+    : path.join(home, '.config');
+}
+
 export function resolveLifecycleIntegrationPaths(home: string, startDir: string): LifecycleIntegrationPaths {
   return {
     home,
@@ -170,7 +177,12 @@ export function resolveLifecycleIntegrationPaths(home: string, startDir: string)
         OPENCODE_PLUGIN_BUNDLE_BASENAME,
         ['integrations', 'opencode', 'plugins', OPENCODE_PLUGIN_INSTALL_BASENAME],
       ),
-      destinationPath: path.join(home, '.config', 'opencode', 'plugins', OPENCODE_PLUGIN_INSTALL_BASENAME),
+      destinationPath: path.join(
+        resolveOpenCodeConfigHome(home),
+        'opencode',
+        'plugins',
+        OPENCODE_PLUGIN_INSTALL_BASENAME,
+      ),
       ownershipMarkers: [OPENCODE_PLUGIN_MANAGED_MARKER, 'wmux ↔ OpenCode plugin bridge'],
     },
   };

--- a/src/shared/mcpRegistration.ts
+++ b/src/shared/mcpRegistration.ts
@@ -275,6 +275,10 @@ function inspectNotifySlot(parsed: Record<string, unknown>): {
   if (!Array.isArray(raw) || !raw.every((value) => typeof value === 'string')) {
     return { present: true, validStringArray: false, notify: null };
   }
+  // An explicit empty array names no program, so it is safe for wmux to claim.
+  if (raw.length === 0) {
+    return { present: false, validStringArray: true, notify: null };
+  }
   return { present: true, validStringArray: true, notify: raw as string[] };
 }
 

--- a/src/shared/mcpRegistration.ts
+++ b/src/shared/mcpRegistration.ts
@@ -28,7 +28,6 @@ import {
   isWmuxOwnedEntry,
   upsertMcpServer,
   removeMcpServers,
-  getNotify,
   isWmuxOwnedNotify,
   upsertNotifyToml,
   removeNotifyToml,
@@ -263,6 +262,22 @@ export interface RegisterNotifyResult {
 
 const norm = (p: string): string => p.replace(/\\/g, '/');
 
+/** Preserve any present root notify value we cannot prove is wmux-owned. */
+function inspectNotifySlot(parsed: Record<string, unknown>): {
+  present: boolean;
+  validStringArray: boolean;
+  notify: string[] | null;
+} {
+  if (!Object.prototype.hasOwnProperty.call(parsed, 'notify')) {
+    return { present: false, validStringArray: true, notify: null };
+  }
+  const raw = parsed['notify'];
+  if (!Array.isArray(raw) || !raw.every((value) => typeof value === 'string')) {
+    return { present: true, validStringArray: false, notify: null };
+  }
+  return { present: true, validStringArray: true, notify: raw as string[] };
+}
+
 export function registerCodexNotify(home: string, notifyScript: string): RegisterNotifyResult {
   const target = getMcpTarget('codex');
   if (!target) return { configPath: '', skipped: 'absent', wrote: false };
@@ -282,11 +297,15 @@ export function registerCodexNotify(home: string, notifyScript: string): Registe
     return { configPath, skipped: 'malformed', wrote: false };
   }
 
-  const notify = getNotify(parsed);
-  if (notify && !isWmuxOwnedNotify(notify)) {
-    return { configPath, skipped: 'foreign', wrote: false }; // never clobber
+  const slot = inspectNotifySlot(parsed);
+  // A root notify slot that is non-array, contains non-string values, or names
+  // another program is user-owned/unknown. Treat all of those as a conflict so
+  // setup never rewrites a value it cannot prove belongs to wmux.
+  if (slot.present && (!slot.validStringArray || !isWmuxOwnedNotify(slot.notify))) {
+    return { configPath, skipped: 'foreign', wrote: false };
   }
-  if (isWmuxOwnedNotify(notify) && norm(notify![1]) === norm(notifyScript)) {
+  const notify = slot.notify;
+  if (isWmuxOwnedNotify(notify) && norm(notify?.[1] ?? '') === norm(notifyScript)) {
     return { configPath, skipped: null, wrote: false }; // already current — idempotent
   }
 
@@ -327,8 +346,9 @@ export interface CodexNotifyStatus {
   configPath: string;
   configExists: boolean;
   /** 'wmux' = our bridge is registered; 'foreign' = a user notify occupies the
-   *  slot (capture off — surfaced so the skip isn't silent); 'none' = no notify. */
-  state: 'wmux' | 'foreign' | 'none';
+   *  slot; 'malformed' = config could not be parsed and was left untouched;
+   *  'none' = no notify. */
+  state: 'wmux' | 'foreign' | 'malformed' | 'none';
   /** Our script path when state === 'wmux'. */
   path: string | null;
 }
@@ -346,11 +366,13 @@ export function readCodexNotifyStatus(home: string): CodexNotifyStatus {
   if (!configExists) return { configPath, configExists, state: 'none', path: null };
   try {
     const parsed = parseConfig(fs.readFileSync(configPath, 'utf8'), 'toml');
-    const notify = getNotify(parsed);
-    if (!notify) return { configPath, configExists, state: 'none', path: null };
-    if (isWmuxOwnedNotify(notify)) return { configPath, configExists, state: 'wmux', path: notify[1] };
-    return { configPath, configExists, state: 'foreign', path: null };
+    const slot = inspectNotifySlot(parsed);
+    if (!slot.present) return { configPath, configExists, state: 'none', path: null };
+    if (!slot.validStringArray || !isWmuxOwnedNotify(slot.notify)) {
+      return { configPath, configExists, state: 'foreign', path: null };
+    }
+    return { configPath, configExists, state: 'wmux', path: slot.notify?.[1] ?? null };
   } catch {
-    return { configPath, configExists, state: 'none', path: null };
+    return { configPath, configExists, state: 'malformed', path: null };
   }
 }


### PR DESCRIPTION
## Summary
- isolate Claude, Codex, and OpenCode lifecycle routing and bridge state with `WMUX_DATA_SUFFIX`
- parse the official Codex turn-complete payload without forwarding prompt or assistant content
- install and refresh the OpenCode plugin, keep `session.idle` non-blocking, and safely fall back from unsupported daemons
- extend `setup-hooks` install/status handling while preserving foreign notify and plugin configuration

## Validation
- `npx tsc --noEmit`
- `npx tsc --noEmit -p tsconfig.daemon.json`
- targeted ESLint: 0 errors / 0 warnings
- targeted Vitest suite: 152 tests passed
- `npm run package`
- production + suffixed daemon routing smoke
- Codex official payload privacy smoke
- OpenCode non-blocking and daemon-to-main fallback smoke
- installed integration status: all up to date

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenCode lifecycle integration alongside Claude and Codex.
  * Added isolated routing for multiple concurrent integration instances.
  * Added support for official Codex lifecycle events and thread/turn metadata.
  * Added automatic installation, status reporting, and safe refreshing of managed integration assets.
  * Added coordinated setup and removal status reporting across integrations.

* **Bug Fixes**
  * Prevented unrelated or malformed lifecycle events from being processed.
  * Preserved foreign or malformed configuration instead of overwriting it.
  * Improved fallback handling, retries, and durable delivery of lifecycle signals.
  * Reduced sensitive payload details in diagnostic logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->