### PR TITLE
feat(worktask): detach a dependent child task from its parent

### DIFF
--- a/changelog.d/715.md
+++ b/changelog.d/715.md
@@ -1,0 +1,13 @@
+### Added
+
+- **You can set a dependent child task loose without stopping it.** A **Detach
+  from parent** action now sits in the context menu of a child workspace that a
+  fan-out spun up. Detaching releases that task from its parent — the parent
+  stops tracking it and its mission channel folds away into Archived — while the
+  workspace itself, its worktree, branch, terminals and running agent all keep
+  going, now on their own. Before this, a child task was tied to its parent for
+  its whole life: the only way to end the relationship was to close it, which
+  tears down the worktree and the work along with it. Detach keeps everything
+  and simply cuts the leash. The cleanup scanner knows a detached worktree is
+  still live, so it is never offered up for deletion, and detaching something
+  twice is harmless. (#715)

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -3250,6 +3250,10 @@ function registerRpcHandlers(
       taskId,
       verifiedWorkspaceId,
       ...(typeof p['idempotencyKey'] === 'string' ? { idempotencyKey: p['idempotencyKey'] } : {}),
+      // Non-destructive detach close (frees the child from its parent). This RPC
+      // path never touches worktree/branch/PTY in the first place, so detach only
+      // adds evidence to the close record.
+      ...(p['detach'] === true ? { detach: true } : {}),
     });
   });
 

--- a/src/daemon/worktask/WorkTaskService.ts
+++ b/src/daemon/worktask/WorkTaskService.ts
@@ -127,6 +127,14 @@ export interface CloseMissionInput {
   /** 서버핀 authz 앵커(§3). */
   verifiedWorkspaceId: string;
   idempotencyKey?: string;
+  /**
+   * Non-destructive detach close. When true, performs the same log close + channel
+   * archive as an ordinary close, but stamps the close record with workspace-detached
+   * evidence to carve in `detachedAt`. worktree/branch/PTY/workspace are concerns
+   * outside this layer, so the daemon never touches them anyway (the caller bypasses
+   * the remove path). Result carries `detached: true`.
+   */
+  detach?: boolean;
 }
 
 /**
@@ -152,6 +160,8 @@ export type CloseMissionOk = {
   taskId: string;
   /** J3 §1(CX2): 채널 archive 미확정 — 부트 reconcile이 재시도 수렴. */
   archivePending?: boolean;
+  /** Was a detach close (for the caller's UI to check). Absent on an ordinary close. */
+  detached?: boolean;
 };
 export type UpdateMissionOk = { ok: true; taskId: string };
 
@@ -230,9 +240,18 @@ export class WorkTaskService {
       return;
     }
     if (p.kind === 'task.close') {
-      const taskId = (p as WorkTaskClosePayload).taskId;
+      const c = p as WorkTaskClosePayload;
+      const taskId = c.taskId;
       if (typeof taskId === 'string') {
-        this.idempotencyRecord('close', ws, rec.idempotencyKey, { ok: true, taskId });
+        // Restore the idempotency receipt for a detach close with detached:true too
+        // (hardened after review), so a retry after restart returns the same response
+        // as the original success.
+        const detached = c.evidence?.kind === 'workspace-detached';
+        this.idempotencyRecord('close', ws, rec.idempotencyKey, {
+          ok: true,
+          taskId,
+          ...(detached ? { detached: true } : {}),
+        });
       }
     }
   }
@@ -257,6 +276,12 @@ export class WorkTaskService {
       if (!task || task.status === 'closed') return;
       task.status = 'closed';
       task.closedAt = c.closedAt;
+      // If detach evidence is present, restore detachedAt (shared replay/runtime
+      // path). Old records lack evidence, so detachedAt stays unset — interpreted
+      // as an ordinary close (safe fallback).
+      if (c.evidence && c.evidence.kind === 'workspace-detached') {
+        task.detachedAt = c.evidence.detachedAt;
+      }
       return;
     }
     if (p.kind === 'task.update') {
@@ -330,6 +355,12 @@ export class WorkTaskService {
     const now = this.now();
     for (const [id, task] of this.tasks) {
       if (task.status !== 'closed' || task.closedAt === undefined) continue;
+      // Detached tasks are exempt from GC (hardened after review). Detach
+      // closes while leaving the child worktree alive, so evicting it from the
+      // projection would let the cleanup scanner misclassify that live worktree as
+      // an orphan-dir (deletion candidate). As long as detachedAt is set, keep it in
+      // the projection so the scanner/UI keep protecting it as a "live worktree".
+      if (task.detachedAt !== undefined) continue;
       if (now - task.closedAt <= WORKTASK_CLOSED_GC_MS) continue;
       this.tasks.delete(id);
     }
@@ -458,15 +489,31 @@ export class WorkTaskService {
       }
       // 재close: 이미 closed면 멱등 no-op ack. archive 재시도는 하지 않는다
       // (부트 reconcile 태스크 방향이 담당) — 성립한 close에 대해 caller는 성공을 받는다.
+      // A retry on a task already closed via detach reflects detached:true as-is
+      // (hardened after review), so the UI doesn't misread it as "detach
+      // failed". Conversely, requesting detach late on a task already closed via an
+      // ordinary close does not stamp detachedAt — an ordinary close may have
+      // already removed the worktree, so detach no longer means anything there.
       if (task.status === 'closed') {
-        const result: CloseMissionOk = { ok: true, taskId: task.id };
+        const result: CloseMissionOk = {
+          ok: true,
+          taskId: task.id,
+          ...(task.detachedAt !== undefined ? { detached: true } : {}),
+        };
         this.idempotencyRecord('close', input.verifiedWorkspaceId, input.idempotencyKey, result);
         return result;
       }
 
-      // 1. task.close envelope append → projection 적용.
+      // 1. task.close envelope append → apply to projection. For detach, attach
+      //    workspace-detached evidence so a newer daemon can distinguish it from an
+      //    ordinary close via detachedAt.
       const closedAt = this.now();
-      const payload: WorkTaskClosePayload = { kind: 'task.close', taskId: task.id, closedAt };
+      const payload: WorkTaskClosePayload = {
+        kind: 'task.close',
+        taskId: task.id,
+        closedAt,
+        ...(input.detach ? { evidence: { kind: 'workspace-detached', detachedAt: closedAt } } : {}),
+      };
       const committed = await this.log.append(
         this.envelope(payload, input.verifiedWorkspaceId, input.idempotencyKey),
       );
@@ -484,6 +531,7 @@ export class WorkTaskService {
         ok: true,
         taskId: task.id,
         ...(archived ? {} : { archivePending: true }),
+        ...(input.detach ? { detached: true } : {}),
       };
       this.idempotencyRecord('close', input.verifiedWorkspaceId, input.idempotencyKey, result);
       return result;

--- a/src/daemon/worktask/__tests__/WorkTaskService.test.ts
+++ b/src/daemon/worktask/__tests__/WorkTaskService.test.ts
@@ -19,7 +19,7 @@ import type { ChannelServiceDeps } from '../../channels/ChannelService';
 import type { ChannelState } from '../../../shared/channels';
 import { WorkTaskService } from '../WorkTaskService';
 import type { WorkTaskChannelPort } from '../WorkTaskService';
-import { missionTopicFor, taskIdFromMissionTopic, normalizeWorktreePath } from '../../../shared/workTask';
+import { missionTopicFor, taskIdFromMissionTopic, normalizeWorktreePath, WORKTASK_CLOSED_GC_MS } from '../../../shared/workTask';
 
 let dir: string;
 const syncOk = (): void => {
@@ -276,6 +276,126 @@ describe('mission.close archives the channel, it never destroys it', () => {
       'what the agent did',
     ]);
     expect(channelSvc.getMembers(channelId, 'ws-owner').length).toBeGreaterThan(0);
+  });
+});
+
+// ═══ Detach — non-destructive close carrying a workspace-detached marker ════
+//
+// Detach releases a dependent child task from its parent WITHOUT touching the
+// child's workspace/worktree/branch/PTY. It rides the same close RPC as an
+// ordinary close, so an old daemon still reads it as closed (no dependency
+// resurrection); a new daemon distinguishes it by the `detachedAt` timestamp
+// restored from the close record's workspace-detached evidence.
+
+describe('mission.close with detach — non-destructive close carries a detachedAt marker', () => {
+  it('stamps detachedAt on the projection, returns detached:true, and archives the channel', async () => {
+    const { port, channels } = makeFakeChannelPort();
+    const log = newLog();
+    const svc = newWorkTaskService(log, port, { now: () => 5000 });
+    await svc.boot();
+
+    const started = await svc.startMission({ title: 'Child task', verifiedWorkspaceId: 'ws-owner', memberId: 'lead' });
+    expect(started.ok).toBe(true);
+    if (!started.ok) return;
+    const { taskId, channelId } = started;
+
+    const detached = await svc.closeMission({ taskId, verifiedWorkspaceId: 'ws-owner', detach: true });
+    expect(detached.ok).toBe(true);
+    if (!detached.ok) return;
+    expect(detached.detached).toBe(true);
+
+    // status is still `closed` (so an old daemon never re-attaches), but detachedAt
+    // distinguishes it from a plain harvest close.
+    const task = svc.getTask(taskId);
+    expect(task?.status).toBe('closed');
+    expect(task?.detachedAt).toBe(5000);
+
+    // The channel is archived (records preserved), same as an ordinary close.
+    expect(channels.get(channelId)?.status).toBe('archived');
+  });
+
+  it('restores detachedAt from the close-record evidence on replay (survives restart)', async () => {
+    const { port } = makeFakeChannelPort();
+    const log = newLog();
+    const svc = newWorkTaskService(log, port, { now: () => 8000 });
+    await svc.boot();
+
+    const started = await svc.startMission({ title: 'Detach me', verifiedWorkspaceId: 'ws-owner', memberId: 'lead' });
+    if (!started.ok) return;
+    await svc.closeMission({ taskId: started.taskId, verifiedWorkspaceId: 'ws-owner', detach: true });
+
+    // Restart: a fresh service replays the same log. detachedAt must come back
+    // from the persisted workspace-detached evidence, not from in-memory state.
+    // svc2 shares the fixed clock so the just-closed task stays inside the
+    // closed-projection GC window (a real Date.now() would evict closedAt=8000).
+    const { port: port2 } = makeFakeChannelPort();
+    const svc2 = newWorkTaskService(log, port2, { now: () => 8000 });
+    await svc2.boot();
+    expect(svc2.getTask(started.taskId)?.detachedAt).toBe(8000);
+  });
+
+  it('a plain close leaves detachedAt unset (evidence absent = ordinary close)', async () => {
+    const { port } = makeFakeChannelPort();
+    const log = newLog();
+    const svc = newWorkTaskService(log, port);
+    await svc.boot();
+
+    const started = await svc.startMission({ title: 'Harvest me', verifiedWorkspaceId: 'ws-owner', memberId: 'lead' });
+    if (!started.ok) return;
+    const closed = await svc.closeMission({ taskId: started.taskId, verifiedWorkspaceId: 'ws-owner' });
+    expect(closed.ok).toBe(true);
+    if (!closed.ok) return;
+    expect(closed.detached).toBeUndefined();
+    expect(svc.getTask(started.taskId)?.detachedAt).toBeUndefined();
+  });
+
+  it('re-detach of an already-detached task returns detached:true (no false-failure)', async () => {
+    const { port } = makeFakeChannelPort();
+    const log = newLog();
+    const svc = newWorkTaskService(log, port, { now: () => 3000 });
+    await svc.boot();
+
+    const started = await svc.startMission({ title: 'Twice', verifiedWorkspaceId: 'ws-owner', memberId: 'lead' });
+    if (!started.ok) return;
+    await svc.closeMission({ taskId: started.taskId, verifiedWorkspaceId: 'ws-owner', detach: true });
+
+    // Second detach (double-click / retry) must still report detached:true.
+    const again = await svc.closeMission({ taskId: started.taskId, verifiedWorkspaceId: 'ws-owner', detach: true });
+    expect(again.ok).toBe(true);
+    if (!again.ok) return;
+    expect(again.detached).toBe(true);
+  });
+
+  it('gcClosedTasks exempts detached tasks so the live worktree stays protected', async () => {
+    const { port } = makeFakeChannelPort();
+    const log = newLog();
+    // Fixed clock far past the GC window relative to closedAt=1000.
+    const svc = newWorkTaskService(log, port, { now: () => 1000 });
+    await svc.boot();
+    const started = await svc.startMission({ title: 'Detached survivor', verifiedWorkspaceId: 'ws-owner', memberId: 'lead' });
+    if (!started.ok) return;
+    await svc.closeMission({ taskId: started.taskId, verifiedWorkspaceId: 'ws-owner', detach: true });
+
+    // Advance the clock well beyond WORKTASK_CLOSED_GC_MS and run GC.
+    const svcAny = svc as unknown as { now: () => number };
+    svcAny.now = () => 1000 + WORKTASK_CLOSED_GC_MS + 1;
+    svc.gcClosedTasks();
+    // The detached task must survive GC (a plain-closed one would be evicted).
+    expect(svc.getTask(started.taskId)?.detachedAt).toBe(1000);
+  });
+
+  it('gcClosedTasks still evicts a plain-closed task past the window', async () => {
+    const { port } = makeFakeChannelPort();
+    const log = newLog();
+    const svc = newWorkTaskService(log, port, { now: () => 1000 });
+    await svc.boot();
+    const started = await svc.startMission({ title: 'Harvested', verifiedWorkspaceId: 'ws-owner', memberId: 'lead' });
+    if (!started.ok) return;
+    await svc.closeMission({ taskId: started.taskId, verifiedWorkspaceId: 'ws-owner' });
+    const svcAny = svc as unknown as { now: () => number };
+    svcAny.now = () => 1000 + WORKTASK_CLOSED_GC_MS + 1;
+    svc.gcClosedTasks();
+    expect(svc.getTask(started.taskId)).toBeUndefined();
   });
 });
 

--- a/src/main/ipc/handlers/worktask.handler.ts
+++ b/src/main/ipc/handlers/worktask.handler.ts
@@ -41,6 +41,8 @@ interface ProjectionTask {
   worktreePath?: string;
   paneGroupId?: string;
   prUrl?: string;
+  /** Detach-close marker — when present, the task is closed but its worktree/branch/PTY are still alive as an independent task. */
+  detachedAt?: number;
 }
 
 export function registerWorktaskHandlers(getDaemonClient: () => DaemonClient | null): () => void {
@@ -140,7 +142,12 @@ export function registerWorktaskHandlers(getDaemonClient: () => DaemonClient | n
       // 활성 worktree가 orphan으로 오분류되는 것을 방지). taskId로 dedup.
       const byId = new Map<string, ScanOpenTask>();
       for (const t of tasks) {
-        if (t.status !== 'open') continue;
+        // Add both open tasks and detached tasks (closed but the worktree is still
+        // alive) to the protected set. This lets the scanner stop a detached task's
+        // live worktree from being misclassified as an orphan-dir (deletion
+        // candidate) (hardened after review).
+        const detached = t.detachedAt !== undefined;
+        if (t.status !== 'open' && !detached) continue;
         // 데몬 목록은 요청 owner 스코프라 owner = verifiedWorkspaceId(F1: close가
         // owner 스코프 authz라 엔트리에 owner를 실어 정합화 버튼이 올바른 신원을 쓰게).
         byId.set(t.id, {
@@ -148,6 +155,7 @@ export function registerWorktaskHandlers(getDaemonClient: () => DaemonClient | n
           title: t.title,
           ownerWorkspaceId: verifiedWorkspaceId,
           ...(t.worktreePath ? { worktreePath: t.worktreePath } : {}),
+          ...(detached ? { detached: true } : {}),
         });
       }
       const known = Array.isArray((raw as Record<string, unknown>).knownOpen)

--- a/src/main/worktask/WorktaskScanService.ts
+++ b/src/main/worktask/WorktaskScanService.ts
@@ -61,13 +61,22 @@ export interface WorktaskScanResult {
   entries: WorktaskScanEntry[];
 }
 
-/** projection 대조 입력(open 태스크만 — 호출측이 status로 필터). */
+/** Projection comparison input (open tasks + detached tasks — the caller filters by status). */
 export interface ScanOpenTask {
   taskId: string;
   title: string;
   /** F1 — owner(부모) ws id. 이상 엔트리 close를 owner 스코프로 부르는 재료. */
   ownerWorkspaceId?: string;
   worktreePath?: string;
+  /**
+   * A detached task (closed but its worktree/branch/PTY are still alive). When true,
+   * that worktree is a "normally working, independent workspace" and is excluded
+   * entirely from the cleanup list — classified neither as orphan-dir (deletion
+   * candidate) nor as preserved (needs harvesting). This is the protection line that
+   * upholds detach's "hands off the worktree" contract at the scanner layer
+   * (hardened after review).
+   */
+  detached?: boolean;
 }
 
 export interface WorktaskScanServiceOptions {
@@ -113,6 +122,11 @@ export class WorktaskScanService {
     const openByNormPath = new Map<string, ScanOpenTask>();
     for (const t of openTasks) {
       if (!t.worktreePath) {
+        // Detached tasks only ever arrive already materialized, so they have a
+        // worktreePath. Defensively, a detached task with no worktree has nothing
+        // to protect and nothing to reconcile (the independent workspace was
+        // already deleted) — skip it silently.
+        if (t.detached) continue;
         entries.push({
           category: 'unmaterialized-open',
           taskId: t.taskId,
@@ -133,6 +147,10 @@ export class WorktaskScanService {
       seen.add(norm);
       const matched = openByNormPath.get(norm);
       if (matched) {
+        // Detached — a live, independent workspace. Whether clean or dirty, it is
+        // never a cleanup candidate, so exclude it entirely from the list (this
+        // blocks orphan-dir/deletion misclassification — the core protection line).
+        if (matched.detached) continue;
         // linked — dirty만 '보존 잔존'으로. clean은 정상 작업이라 제외.
         let dirty = false;
         try {
@@ -170,6 +188,10 @@ export class WorktaskScanService {
     // ── disk-missing: worktreePath를 주장하나 디스크에 없는 open 태스크 ──
     for (const [norm, t] of openByNormPath) {
       if (seen.has(norm)) continue;
+      // A detached task is already closed — if its worktree is gone, the user
+      // deleted the independent workspace themselves, so it's not a "reconcile via
+      // close" candidate (it's already closed). Skip it silently.
+      if (t.detached) continue;
       entries.push({
         category: 'disk-missing',
         taskId: t.taskId,

--- a/src/main/worktask/__tests__/WorktaskScanService.test.ts
+++ b/src/main/worktask/__tests__/WorktaskScanService.test.ts
@@ -101,6 +101,31 @@ describe('J3 §1 정리 스캔 4종 판정', () => {
   });
 });
 
+describe('detach 보호 — 살아있는 detached worktree는 정리 목록에서 완전히 제외', () => {
+  it('detached=true 매칭 worktree는 clean이든 dirty든 orphan-dir/preserved로 등재되지 않는다', async () => {
+    const wt = seedWorktree('detached-slug');
+    // Even when dirty (active independent work) it must not be listed — the orphan-dir misclassification is the core defect.
+    const svc = makeSvc(new Set([wt]));
+    const res = await svc.scan([{ taskId: 'wtask-d', title: 'Independent', worktreePath: wt, detached: true }]);
+    expect(res.entries.find((x) => x.worktreePath === wt)).toBeUndefined();
+    expect(res.entries).toHaveLength(0);
+  });
+
+  it('detached인데 worktree가 이미 없으면 disk-missing으로 잘못 등재하지 않는다(이미 closed)', async () => {
+    const svc = makeSvc();
+    const ghost = path.join(root, REPO_HASH, 'gone-detached');
+    const res = await svc.scan([{ taskId: 'wtask-dm', title: 'Gone', worktreePath: ghost, detached: true }]);
+    expect(res.entries).toHaveLength(0);
+  });
+
+  it('보호 대조: detached 플래그가 없으면 같은 dirty worktree는 preserved로 등재된다', async () => {
+    const wt = seedWorktree('not-detached-slug');
+    const svc = makeSvc(new Set([wt]));
+    const res = await svc.scan([{ taskId: 'wtask-nd', title: 'Harvest', worktreePath: wt }]);
+    expect(res.entries.find((x) => x.category === 'preserved' && x.worktreePath === wt)).toBeTruthy();
+  });
+});
+
 describe('J3 §1 GC 이후 역추적(closed 태스크 소멸 후 task.json)', () => {
   it('projection에서 GC된 closed 태스크의 worktree를 taskId·closedAt로 역추적', async () => {
     // closed 태스크가 7일 GC로 projection에서 사라진 상태 = openTasks에 부재.

--- a/src/renderer/components/Sidebar/WorkspaceItem.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceItem.tsx
@@ -283,6 +283,13 @@ function WorkspaceItem({ workspaceId, isActive, isMultiview, index, onSelect, on
   const projectState = useStore((s) => s.projectConfigs[workspaceId]);
   // J3 §4 — 태스크 워크스페이스의 페인 cwd가 worktree 경계 밖으로 이탈했는지(경고만).
   const departedCwd = useStore((s) => s.departedPaneGroups[workspaceId]);
+  // Detach: this workspace is a dependent child task iff its id is an open
+  // WorkTask's paneGroupId. When so, surface a "detach from parent" action that
+  // releases the mission (non-destructive close) while leaving this workspace,
+  // its worktree/branch/PTY and running agent completely untouched.
+  const childMission = useStore((s) => s.missionByPaneGroup[workspaceId]);
+  const detachMissionForPaneGroup = useStore((s) => s.detachMissionForPaneGroup);
+  const isDependentChild = childMission?.status === 'open';
 
   // Idle badge — how long since ANY of this workspace's surfaces last showed
   // life: agent activity (surfaceActivityAt, same stamps the fleet 'running'
@@ -334,6 +341,27 @@ function WorkspaceItem({ workspaceId, isActive, isMultiview, index, onSelect, on
   const reportOpen = (p: Promise<{ ok: boolean; error?: string }>) => {
     p.then((res) => { if (!res?.ok) notifyOpenFailed(t, res?.error); })
       .catch((err) => notifyOpenFailed(t, String(err?.message ?? err)));
+  };
+
+  /**
+   * Detach this dependent child task from its parent. Non-destructive: the
+   * mission is closed with a workspace-detached marker and its channel archived,
+   * but this workspace, its worktree/branch/PTY and running agent stay exactly as
+   * they are — it simply stops being tracked as a child of the parent.
+   */
+  const handleDetach = () => {
+    setMenuPos(null);
+    detachMissionForPaneGroup(workspaceId)
+      .then((ok) => {
+        useStore.getState().pushToast(
+          ok
+            ? { level: 'info', message: t('workspace.detachDone') }
+            : { level: 'warn', message: t('workspace.detachFailed') },
+        );
+      })
+      .catch(() => {
+        useStore.getState().pushToast({ level: 'warn', message: t('workspace.detachFailed') });
+      });
   };
 
   /** Open the workspace's current working directory in the OS file explorer. */
@@ -843,6 +871,20 @@ function WorkspaceItem({ workspaceId, isActive, isMultiview, index, onSelect, on
               </div>
             )}
           </div>
+
+          {/* Detach from parent — only for a dependent child task workspace.
+              Releases the mission (non-destructive) without touching this
+              workspace, its worktree/branch/PTY, or the running agent. */}
+          {isDependentChild && (
+            <button
+              className="w-full text-left px-3 py-1.5 text-xs transition-colors hover:bg-[var(--bg-overlay)] border-t border-[color-mix(in_srgb,var(--bg-overlay)_60%,transparent)] mt-1 pt-2"
+              style={{ color: 'var(--text-main)' }}
+              onClick={handleDetach}
+              title={t('workspace.detachHint')}
+            >
+              {t('workspace.detach')}
+            </button>
+          )}
         </div>
       )}
 

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -258,7 +258,12 @@ export function useRpcBridge(): void {
     (window as unknown as {
       __wmuxMissionRpc: {
         list: (params: { verifiedWorkspaceId: string }) => Promise<RpcResult>;
-        close: (params: { taskId: string; verifiedWorkspaceId: string }) => Promise<RpcResult>;
+        close: (params: {
+          taskId: string;
+          verifiedWorkspaceId: string;
+          /** Non-destructive detach close (worktree/branch/PTY untouched, only evidence added to the close record). */
+          detach?: boolean;
+        }) => Promise<RpcResult>;
       };
     }).__wmuxMissionRpc = {
       list: (params) =>

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -43,6 +43,10 @@ export const en = {
   'workspace.closeConfirmDetail': '{count} terminal(s) will be closed',
   'workspace.closeCancel': 'Cancel',
   'workspace.closeConfirmYes': 'Close',
+  'workspace.detach': 'Detach from parent',
+  'workspace.detachHint': 'Release this task from its parent — keeps the workspace, worktree, branch and agent running',
+  'workspace.detachDone': 'Detached — now running independently',
+  'workspace.detachFailed': 'Could not detach this task',
 
   // X1 workspace-context sidebar (git branch / PR / ports / notification)
   'workspace.gitBranch': 'Git branch',

--- a/src/renderer/stores/slices/workTaskSlice.ts
+++ b/src/renderer/stores/slices/workTaskSlice.ts
@@ -112,6 +112,16 @@ export interface WorkTaskSlice {
    * existence, and the next boot reconcile converges.
    */
   closeMissionForRemovedWorkspace: (paneGroupId: string) => Promise<void>;
+  /**
+   * Detaches a dependent child task from its parent (non-destructive close):
+   * the mission is closed with a `workspace-detached` marker so the parent stops
+   * tracking it, while the child's **workspace, worktree, branch, PTY and running
+   * agent are left completely untouched** — it keeps running, just independently.
+   * The daemon archives the mission channel (records preserved, not destroyed),
+   * the same as an ordinary close. Returns true on success. Best-effort refresh
+   * of the local cache follows. Only open, still-materialized child tasks qualify.
+   */
+  detachMissionForPaneGroup: (paneGroupId: string) => Promise<boolean>;
 }
 
 export const createWorkTaskSlice: StateCreator<
@@ -215,5 +225,44 @@ export const createWorkTaskSlice: StateCreator<
     }
     // Reflect it in the local cache right away, so we do not wait for the next poll.
     await get().refreshMissions(task.owner.verifiedWorkspaceId);
+  },
+
+  detachMissionForPaneGroup: async (paneGroupId) => {
+    if (!paneGroupId) return false;
+    const task = get().missionByPaneGroup[paneGroupId];
+    if (!task) return false;
+    // Already detached (closed with a detachedAt marker) = idempotent success, not
+    // a failure — a double-click or a race against the cache refresh must NOT raise
+    // a "could not detach" toast for a task that is already independent.
+    if (task.status === 'closed') return task.detachedAt !== undefined;
+    // Only an open, still-dependent child can be detached.
+    if (task.status !== 'open') return false;
+    const bridge = readMissionRpc();
+    if (!bridge?.close) return false;
+    let res: unknown;
+    try {
+      // Same authz anchor as a lifetime close: the daemon gate is owner-OR-CEO and
+      // the owner is the PARENT, so pass the task owner (not the child) as the
+      // verified workspace. `detach: true` rides the same close RPC — the daemon
+      // stamps a workspace-detached marker and archives the channel, and the
+      // renderer/main path deliberately touches nothing else (worktree/branch/PTY).
+      res = await bridge.close({
+        taskId: task.id,
+        verifiedWorkspaceId: task.owner.verifiedWorkspaceId,
+        detach: true,
+      });
+    } catch {
+      // Daemon not connected / transient failure — the child keeps running; the
+      // user can retry. Boot reconcile does NOT auto-detach (detach is an explicit
+      // user action), so a failure simply leaves the dependency in place.
+      return false;
+    }
+    if (!isOkObject(unwrapRpc(res))) {
+      console.warn('[workTaskSlice] mission detach rejected for task', task.id, res);
+      return false;
+    }
+    // Refresh the parent's mission cache so the row reflects detached immediately.
+    await get().refreshMissions(task.owner.verifiedWorkspaceId);
+    return true;
   },
 });

--- a/src/shared/workTask.ts
+++ b/src/shared/workTask.ts
@@ -63,6 +63,16 @@ export interface WorkTask {
   paneGroupId?: string;
   // ── J2 ──
   prUrl?: string;
+  /**
+   * Detach timestamp (non-destructive close marker). When set, this task was not a
+   * "harvest close" but **detached from its parent** — status is still `closed`, but
+   * its worktree/branch/PTY/dedicated workspace are untouched and still alive. This
+   * is the only signal distinguishing it from an ordinary close. Restored on replay
+   * from the close record's `evidence.detachedAt` (workspace-detached). An older
+   * daemon doesn't know this field but still recognizes status=closed, so it won't
+   * re-attach the child (prevents state resurrection).
+   */
+  detachedAt?: number;
   // ── §6.M 예약 (P2에서 활성화, J0 미구현 — §5 계약 참조) ──
   /** lease는 데몬 단독 소유(§5.3) — 어떤 caller도 wire로 쓰지 못한다. */
   lease?: { expiresAt: number; claimantRef: string };
@@ -83,13 +93,31 @@ export interface WorkTaskCreatePayload {
   task: WorkTask;
 }
 
-/** 태스크 종료 — id·closedAt. `evidence?`는 §6.M P2 예약 슬롯(J0 미해석). */
+/**
+ * Evidence for a non-destructive detach close (the first concrete consumer of the
+ * §6.M P2 evidence slot). When a close record carries this evidence, a newer daemon
+ * interprets it as detach (independence from the parent) and restores
+ * `WorkTask.detachedAt`. An older daemon ignores the evidence but still applies the
+ * close itself, so it only recognizes status=closed (the parent-child dependency is
+ * not resurrected).
+ */
+export interface WorkTaskDetachEvidence {
+  kind: 'workspace-detached';
+  /** Detach time (= the close's closedAt). The timestamp that distinguishes it from an ordinary close. */
+  detachedAt: number;
+}
+
+/**
+ * Task close — id, closedAt. `evidence?` used to be the §6.M P2 reserved slot;
+ * detach is its first consumer (WorkTaskDetachEvidence). Future evidence kinds
+ * widen this union.
+ */
 export interface WorkTaskClosePayload {
   kind: 'task.close';
   taskId: string;
   closedAt: number;
-  /** §6.M P2 완료증거 예약 슬롯 — J0 close는 사람 액션이라 게이트 없음(§5.5). */
-  evidence?: unknown;
+  /** §6.M P2 completion-evidence slot — detach's non-destructive close is the first concrete consumer (§5.5). */
+  evidence?: WorkTaskDetachEvidence;
 }
 
 /**


### PR DESCRIPTION
## What

Adds **detach**: releasing a dependent child WorkTask (a sub-workspace) from its parent **without touching the child's workspace, worktree, branch, PTY, or running agent**. The child keeps running — just independently.

A **"Detach from parent"** action appears in the sidebar context menu of a dependent child workspace.

## How

Rather than a new event that an old daemon could silently ignore (which would risk resurrecting the parent–child dependency), detach rides the existing `task.close`:

- The close record gains **`workspace-detached` evidence** carrying a `detachedAt` timestamp.
- An **old daemon** still reads the task as `closed`, so it never re-attaches the child.
- A **new daemon** distinguishes detach from a plain harvest close via `detachedAt`.
- The mission channel is **archived** (records preserved), the same as an ordinary close.

Detach uses the mission RPC path (`task.mission.close` with `detach: true`), which by design never removes the worktree — so the "hands off the worktree/branch/PTY" contract holds structurally.

## Closed-state consumers made `detachedAt`-aware

Because detach injects a *live-but-closed* state, every consumer that keys on open/closed is updated so a live detached worktree is never misread:

- **Cleanup scanner** excludes a live detached worktree — never offered as an `orphan-dir` (deletion candidate).
- **Closed-projection GC** exempts detached tasks, so the signal stays durable and the scanner keeps protecting the worktree.
- **Re-detach / already-detached** is an idempotent success instead of a false failure (no misleading toast; replay receipts carry `detached`).

## Tests

Adds regression coverage for: detach stamps `detachedAt` + returns `detached:true`, replay restores it across restart, GC exempts detached (but still evicts a plain-closed task), re-detach idempotency, and the scanner protection (live detached worktree excluded; the non-detached counterpart still surfaces as `preserved`). Full affected suite green; `tsc` (base + daemon) clean.

## Notes

- Per repo policy: no version bump, no `CHANGELOG.md` edit (a `changelog.d/` fragment will be added once this PR has a number).
- Accepted trade-off: the mission channel is archived on detach (design decision), so a still-live child writing to that channel will fail — surfaced during review, kept intentionally.