### PR TITLE
Detect Kiro CLI sessions

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -340,7 +340,7 @@ const recoveredResumeBindings = new Map<string, ResumeBinding>();
 // in sync with AgentSlug in src/shared/events.ts and ALLOWED_AGENT_SLUGS in
 // integrations/shared/signal-types.ts.
 const KNOWN_AGENT_SLUGS: ReadonlySet<string> = new Set([
-  'claude', 'codex', 'gemini', 'aider', 'opencode', 'copilot', 'openclaude',
+  'claude', 'codex', 'gemini', 'aider', 'opencode', 'copilot', 'openclaude', 'kiro',
 ]);
 
 // === Constants ===

--- a/src/main/pipe/handlers/hooks.rpc.ts
+++ b/src/main/pipe/handlers/hooks.rpc.ts
@@ -1274,5 +1274,6 @@ function agentDisplayName(slug: AgentSignal['agent']): string {
     case 'opencode': return 'OpenCode';
     case 'copilot': return 'GitHub Copilot CLI';
     case 'openclaude': return 'OpenClaude';
+    case 'kiro': return 'Kiro CLI';
   }
 }

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -35,7 +35,7 @@ type CriticalEventCallback = (event: CriticalEvent) => void;
 // signals on this slug, so the two MUST stay in lock-step. New agents
 // added here must also be added to integrations/shared/signal-types.ts
 // (AgentSlug union) and to any HookSignalRouter dedup table.
-export type AgentSlug = 'claude' | 'codex' | 'gemini' | 'aider' | 'opencode' | 'copilot' | 'openclaude';
+export type AgentSlug = 'claude' | 'codex' | 'gemini' | 'aider' | 'opencode' | 'copilot' | 'openclaude' | 'kiro';
 
 interface AgentPattern {
   /** Display name. Surfaced in UI ("Claude Code", "Codex CLI"). */
@@ -62,6 +62,7 @@ export function agentDisplayToSlug(display: string): AgentSlug | undefined {
     case 'OpenCode': return 'opencode';
     case 'GitHub Copilot CLI': return 'copilot';
     case 'OpenClaude': return 'openclaude';
+    case 'Kiro CLI': return 'kiro';
     default: return undefined;
   }
 }
@@ -102,6 +103,13 @@ export function agentStatusToSignalKind(
 // ---------------------------------------------------------------------------
 // Per-agent patterns — ONLY agent-specific, no generic patterns
 // ---------------------------------------------------------------------------
+
+// Kiro's TUI is identified by a compound signature. A product-name mention by
+// itself is not enough: agents routinely print logs/docs about other agents.
+// Require an anchored Kiro chrome line (the exact banner or trust-mode footer)
+// AND the anchored composer placeholder from the same PTY session.
+const KIRO_CHROME_LINE = /^(?:Kiro\s*CLI(?:\s+v?\d[\w.-]*)?|Trust\s*All\s*Tools\s*active,\s*confirmations\s*are\s*off(?:\s*·.*)?)$/i;
+const KIRO_PROMPT_LINE = /^[▸>❯]?\s*ask\s*a\s*question\s*or\s*describe\s*a\s*task\s*↵?\s*$/i;
 
 const AGENT_PATTERNS: AgentPattern[] = [
   // ── Claude Code ────────────────────────────────────────────────────────────
@@ -268,6 +276,18 @@ const AGENT_PATTERNS: AgentPattern[] = [
     ],
   },
 
+  // ── Kiro CLI ──────────────────────────────────────────────────────────────
+  // The generic gate loop below special-cases this slug and opens it only
+  // after BOTH KIRO_CHROME_LINE and KIRO_PROMPT_LINE have been observed.
+  {
+    agent: 'Kiro CLI',
+    slug: 'kiro',
+    gate: KIRO_CHROME_LINE,
+    patterns: [
+      { regex: KIRO_PROMPT_LINE, status: 'waiting', message: 'Ready for input' },
+    ],
+  },
+
   // ── OpenCode ──────────────────────────────────────────────────────────────
   {
     agent: 'OpenCode',
@@ -319,6 +339,11 @@ export class AgentDetector {
   // ActivityMonitor 'active' transitions to label the running status with the
   // agent that owns this PTY.
   private lastAgent: string | null = null;
+  // Kiro uses a compound gate so another agent merely mentioning "Kiro CLI"
+  // cannot steal this PTY's identity. Evidence is scoped to this detector/PTy.
+  private kiroChromeSeen = false;
+  private kiroPromptSeen = false;
+  private kiroPromptEvidence: string | null = null;
 
   /**
    * Register a callback for agent status events.
@@ -396,12 +421,88 @@ export class AgentDetector {
    * 검사와 processLine 양쪽에서 사용). activeAgents 가드로 세션당 1회만 발화.
    */
   private checkGates(clean: string): void {
+    // Kiro has no hook fallback, so identify its live TUI from two independent
+    // pieces of chrome. Newer v3 builds show the docs URL instead of a "Kiro
+    // CLI" banner; their cursor-drawn composer can also collapse whitespace in
+    // the raw PTY stream. Probe only a bounded tail and only when a cheap
+    // literal hint is present. Once Kiro is active this entire path is skipped.
+    const kiroIsActive = this.activeAgents.has('Kiro CLI');
+    if (!kiroIsActive && (!this.kiroChromeSeen || !this.kiroPromptSeen)) {
+      const probe = clean.length > 4096 ? clean.slice(-4096) : clean;
+      const mayContainChrome = !this.kiroChromeSeen && (
+        probe.includes('kiro') ||
+        probe.includes('Kiro') ||
+        probe.includes('KIRO') ||
+        probe.includes('Trust All Tools')
+      );
+      const mayContainPrompt = !this.kiroPromptSeen && (
+        probe.includes('ask') || probe.includes('Ask')
+      );
+
+      if (mayContainChrome || mayContainPrompt) {
+        // feed/processLine also call this with an ANSI-stripped candidate. Avoid
+        // doing the regex replacement twice when this candidate is already clean.
+        const evidenceLine = probe.includes('\u001b')
+          ? probe.replace(ANSI_STRIP, '')
+          : probe;
+        const normalized = evidenceLine.trim();
+        const lower = normalized.toLowerCase();
+
+        if (
+          mayContainChrome &&
+          (lower.includes('kiro.dev/docs/cli/') || KIRO_CHROME_LINE.test(normalized))
+        ) {
+          this.kiroChromeSeen = true;
+        }
+
+        if (mayContainPrompt) {
+          const promptStart = lower.lastIndexOf('ask');
+          const compactPrompt = promptStart >= 0
+            ? lower.slice(promptStart, promptStart + 96).replace(/\s+/g, '')
+            : '';
+          const promptMatch = normalized.match(KIRO_PROMPT_LINE);
+          if (
+            promptMatch ||
+            compactPrompt.includes('askaquestionordescribeatask')
+          ) {
+            this.kiroPromptSeen = true;
+            // When this is a normal complete line, retain the exact value the
+            // ordinary pattern pass will see so its same-frame dedup hits. The
+            // canonical fallback is only for cursor-concatenated evidence that
+            // cannot match the line pattern later in processLine.
+            this.kiroPromptEvidence = promptMatch?.[0]
+              ?? 'ask a question or describe a task';
+          }
+        }
+      }
+    }
+
     for (const ap of AGENT_PATTERNS) {
-      if (ap.gate && !this.activeAgents.has(ap.agent) && ap.gate.test(clean)) {
-        this.activeAgents.add(ap.agent);
-        this.lastAgent = ap.agent;
-        for (const cb of this.callbacks) {
-          cb({ agent: ap.agent, status: 'running', message: 'Agent started' });
+      // Gate checks run on every PTY output chunk. Never re-run regexes for an
+      // already-active agent; this keeps full-screen repaint traffic O(inactive
+      // agents) and makes the Kiro additions cheaper than the previous loop.
+      if (!ap.gate || this.activeAgents.has(ap.agent)) continue;
+      const gateMatched = ap.slug === 'kiro'
+        ? this.kiroChromeSeen && this.kiroPromptSeen
+        : ap.gate.test(clean);
+      if (!gateMatched) continue;
+
+      this.activeAgents.add(ap.agent);
+      this.lastAgent = ap.agent;
+      for (const cb of this.callbacks) {
+        cb({ agent: ap.agent, status: 'running', message: 'Agent started' });
+      }
+      // The two Kiro evidence lines may arrive in either order. If the
+      // composer prompt arrived first, its normal pattern pass happened while
+      // the gate was still closed. Replay the saved evidence once.
+      if (ap.slug === 'kiro' && this.kiroPromptEvidence) {
+        const key = `${ap.agent}:waiting`;
+        const value = this.kiroPromptEvidence;
+        if (this.lastEmittedFor.get(key) !== value) {
+          this.lastEmittedFor.set(key, value);
+          for (const cb of this.callbacks) {
+            cb({ agent: ap.agent, status: 'waiting', message: 'Ready for input' });
+          }
         }
       }
     }

--- a/src/main/pty/__tests__/AgentDetector.test.ts
+++ b/src/main/pty/__tests__/AgentDetector.test.ts
@@ -362,4 +362,106 @@ describe('AgentDetector', () => {
       }));
     });
   });
+
+  // ── Kiro CLI ──────────────────────────────────────────────────────────────
+  // Kiro has no hook bridge, so its identity comes entirely from PTY chrome.
+  // A product-name mention is NOT enough: agents routinely print logs and docs
+  // that name other agents. The gate requires an anchored chrome line AND the
+  // anchored composer placeholder from the SAME detector (i.e. the same PTY).
+  describe('Kiro CLI compound gate', () => {
+    const KIRO_BANNER = 'Kiro CLI v0.9.3\n';
+    const KIRO_DOCS = 'https://kiro.dev/docs/cli/\n';
+    const KIRO_TRUST = 'Trust All Tools active, confirmations are off\n';
+    const KIRO_PROMPT = '▸ ask a question or describe a task ↵\n';
+
+    it('opens the gate only after BOTH chrome and prompt evidence arrive', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+
+      det.feed(KIRO_BANNER);
+      expect(cb).not.toHaveBeenCalled();
+      expect(det.getLastAgent()).toBeNull();
+
+      det.feed(KIRO_PROMPT);
+      expect(det.getLastAgent()).toBe('Kiro CLI');
+      const statuses = cb.mock.calls.map((c) => c[0].status);
+      expect(cb.mock.calls[0][0]).toMatchObject({ agent: 'Kiro CLI', status: 'running' });
+      expect(statuses).toContain('waiting');
+    });
+
+    it('accepts the two evidence lines in EITHER order (prompt first)', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+
+      // The composer placeholder can be painted before the banner scrolls in.
+      det.feed(KIRO_PROMPT);
+      expect(det.getLastAgent()).toBeNull();
+
+      det.feed(KIRO_BANNER);
+      expect(det.getLastAgent()).toBe('Kiro CLI');
+      // The saved prompt evidence is replayed exactly once so the pane is not
+      // stuck at 'running' while it is really idle and waiting for input.
+      const waiting = cb.mock.calls.filter((c) => c[0].status === 'waiting');
+      expect(waiting).toHaveLength(1);
+      expect(waiting[0][0]).toMatchObject({ agent: 'Kiro CLI', message: 'Ready for input' });
+    });
+
+    it('accepts the v3 docs-URL chrome variant as chrome evidence', () => {
+      const det = new AgentDetector();
+      det.feed(KIRO_DOCS);
+      expect(det.getLastAgent()).toBeNull();
+      det.feed(KIRO_PROMPT);
+      expect(det.getLastAgent()).toBe('Kiro CLI');
+    });
+
+    it('accepts the trust-mode footer as chrome evidence', () => {
+      const det = new AgentDetector();
+      det.feed(KIRO_TRUST);
+      det.feed(KIRO_PROMPT);
+      expect(det.getLastAgent()).toBe('Kiro CLI');
+    });
+
+    it('does NOT activate from a product mention alone (no prompt evidence)', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('Read the Kiro CLI release notes and compare with KIRO docs\n');
+      det.feed('$ grep -R "Kiro CLI" .\n');
+      expect(cb).not.toHaveBeenCalled();
+      expect(det.getLastAgent()).toBeNull();
+    });
+
+    it('does NOT steal a PTY that another agent already owns while merely mentioning Kiro', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('Claude Code v2.1.172\n');
+      expect(det.getLastAgent()).toBe('Claude Code');
+      cb.mockClear();
+
+      // Claude printing Kiro's chrome text as quoted evidence must not hand the
+      // pane's identity to Kiro — only real Kiro chrome + composer can.
+      det.feed('The other pane printed "Kiro CLI v0.9.3" in its log\n');
+      expect(cb).not.toHaveBeenCalled();
+      expect(det.getLastAgent()).toBe('Claude Code');
+    });
+
+    it('evidence is per-detector: one PTY cannot satisfy another PTY’s gate', () => {
+      const a = new AgentDetector();
+      const b = new AgentDetector();
+      a.feed(KIRO_BANNER);
+      b.feed(KIRO_PROMPT);
+      expect(a.getLastAgent()).toBeNull();
+      expect(b.getLastAgent()).toBeNull();
+    });
+
+    it('maps the display name to the kiro slug in both directions', async () => {
+      const { agentDisplayToSlug } = await import('../AgentDetector');
+      const { agentSlugToDisplay } = await import('../../../shared/hooks/signal-types');
+      expect(agentDisplayToSlug('Kiro CLI')).toBe('kiro');
+      expect(agentSlugToDisplay('kiro')).toBe('Kiro CLI');
+    });
+  });
 });

--- a/src/renderer/channels/agentCandidateSeed.ts
+++ b/src/renderer/channels/agentCandidateSeed.ts
@@ -32,6 +32,7 @@ const AGENT_SLUGS: ReadonlySet<string> = new Set([
   'aider',
   'opencode',
   'copilot',
+  'kiro',
 ] satisfies AgentSlug[]);
 
 /** Narrow a daemon-reported agent identity to a known slug. The daemon's

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -40,7 +40,7 @@ import type { PaneMetadata, WorkspaceMetadata, TaskState } from './types';
  * (shared depends on main). New agents added to the union MUST be added
  * to all three locations.
  */
-export type AgentSlug = 'claude' | 'codex' | 'gemini' | 'aider' | 'opencode' | 'copilot' | 'openclaude';
+export type AgentSlug = 'claude' | 'codex' | 'gemini' | 'aider' | 'opencode' | 'copilot' | 'openclaude' | 'kiro';
 
 export type WmuxEventType =
   | 'pane.created'

--- a/src/shared/hooks/signal-types.ts
+++ b/src/shared/hooks/signal-types.ts
@@ -55,7 +55,7 @@ export type AgentSignalKind =
  * renderer layer, NOT carried in the envelope. This keeps envelopes
  * lowercase + whitespace-free for safe routing key construction.
  */
-export type AgentSlug = 'claude' | 'codex' | 'gemini' | 'aider' | 'opencode' | 'copilot' | 'openclaude';
+export type AgentSlug = 'claude' | 'codex' | 'gemini' | 'aider' | 'opencode' | 'copilot' | 'openclaude' | 'kiro';
 
 /**
  * slug → display name. The exact inverse of `agentDisplayToSlug` in
@@ -77,6 +77,7 @@ export function agentSlugToDisplay(slug: AgentSlug): string {
     case 'opencode': return 'OpenCode';
     case 'copilot': return 'GitHub Copilot CLI';
     case 'openclaude': return 'OpenClaude';
+    case 'kiro': return 'Kiro CLI';
   }
 }
 
@@ -174,7 +175,7 @@ export interface HookSignalResponse {
  *  unknown agent values rather than accepting any string (codex round-2
  *  review P2 #9). Keep this in sync with the AgentSlug union above. */
 const ALLOWED_AGENT_SLUGS: ReadonlySet<string> = new Set([
-  'claude', 'codex', 'gemini', 'aider', 'opencode', 'copilot', 'openclaude',
+  'claude', 'codex', 'gemini', 'aider', 'opencode', 'copilot', 'openclaude', 'kiro',
 ]);
 
 export function isAgentSignal(value: unknown): value is AgentSignal {

--- a/src/shared/orchestratorRole.ts
+++ b/src/shared/orchestratorRole.ts
@@ -151,6 +151,7 @@ const KNOWN_AGENT_STEMS: ReadonlySet<string> = new Set([
   'opencode',
   'copilot',
   'openclaude',
+  'kiro-cli',
 ]);
 
 /** Max lengths for the binding fields at the normalization boundary. `args` is


### PR DESCRIPTION
Kiro CLI panes were invisible to wmux: no agent name, no status, no notifications.
Kiro ships no hook bridge, so its identity has to come from the PTY stream.

## What changed
`'kiro'` joins the `AgentSlug` union in all five authoritative places (shared
events, hook signal types, orchestrator stems, the renderer candidate seed, and
the daemon allowlist), and `AgentDetector` learns a **compound** gate.

A product-name mention is not enough — agents routinely print logs and docs that
name other agents. Activation requires BOTH from the same PTY:

- anchored chrome: the `Kiro CLI vX` banner, the trust-mode footer, or the v3
  `kiro.dev/docs/cli/` line
- the anchored composer placeholder (`ask a question or describe a task`)

Evidence may arrive in either order; when the composer lands first its `waiting`
state is replayed once so a genuinely idle pane is not stuck reporting `running`.
The gate loop now also skips regexes for already-active agents, which makes this
cheaper than the loop it replaces on full-screen repaint traffic.

## Tests
9 new cases in `AgentDetector.test.ts`: both-required, either order, docs-URL and
trust-footer variants, mention-only rejection, no-steal from an active Claude
pane, per-detector evidence isolation, and slug/display round-trip.

`npx vitest run src/main/pty/__tests__/AgentDetector.test.ts src/renderer/channels/__tests__/agentCandidateSeed.test.ts integrations/shared/__tests__/signal-types.test.ts` → 66 passed
`npm run build:daemon` → clean

## Notes
Detection only. No approval route is added for Kiro (it has no hook surface), so
Kiro panes get identity, status and notifications but not phone approvals.
