### PR TITLE
Clean up transient PTY state on close

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -339,10 +339,9 @@
 - **Depends on:** fleet-activity-line ship 후.
 - **Priority:** P2
 
-## (bug) transient per-ptyId 맵이 surface close 시 leak (P3, found in fleet-activity adversarial review)
-- **What:** `surfacePorts`(및 `surfaceAgentStatus`)가 `closePane`/`closeSurface`에서 정리 안 됨 → 죽은 ptyId 엔트리 잔존. fleet-activity PR이 `surfaceActivity`는 양 사이트에서 정리하지만 기존 두 맵은 미수정.
-- **Why:** 적대 리뷰가 "surfacePorts를 cleanup 선례로 쓰지 말라(그 자체로 leak)"며 발견. 장기 세션서 죽은 ptyId 누적.
-- **Pros:** store 위생, 미세 메모리.
+## ✅ (bug) transient per-ptyId 맵 leak — FIXED (2026-07-30)
+- `surfacePorts`와 `surfaceAgentStatus`를 `closePane`(paneSlice.ts)과 `closeSurface`(surfaceSlice.ts) 양쪽에서 정리하도록 추가.
+- 기존 `surfaceAgent`/`surfaceActivity`/`surfacePendingQuestion` 정리 패턴과 동일.
 - **Cons:** 영향 미미(엔트리 작음).
 - **Context:** `closePane`(paneSlice.ts:322) + `closeSurface`(surfaceSlice.ts:132)에 delete 추가. fleet-activity가 정리 패턴을 이미 깔아둠.
 - **Depends on:** 없음.

--- a/src/renderer/stores/slices/__tests__/paneSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneSlice.test.ts
@@ -673,6 +673,42 @@ describe('PaneSlice', () => {
     });
   });
 
+  // The two transient maps that were still leaking at this teardown site: a
+  // closed subtree left dead surfacePorts / surfaceAgentStatus entries behind,
+  // so a REUSED ptyId inherited the previous pane's status.
+  describe('surfacePorts / surfaceAgentStatus teardown', () => {
+    it('closePane clears BOTH maps for every surface under the closed subtree', () => {
+      const ws = getActiveWorkspace(store);
+      const rootLeafId = getLeafPanes(ws.rootPane)[0].id;
+      store.getState().splitPane(rootLeafId, 'horizontal');
+      const closing = getLeafPanes(getActiveWorkspace(store).rootPane)[1];
+      store.setState((s) => {
+        const leaf = getLeafPanes(s.workspaces[0].rootPane).find((l) => l.id === closing.id);
+        if (leaf) {
+          leaf.surfaces.push({ id: 'surf-p1', ptyId: 'pty-leak-1', title: 'x', shell: '', cwd: '', surfaceType: 'terminal' } as Surface);
+          leaf.surfaces.push({ id: 'surf-p2', ptyId: 'pty-leak-2', title: 'y', shell: '', cwd: '', surfaceType: 'terminal' } as Surface);
+        }
+        s.surfacePorts['pty-leak-1'] = [5173];
+        s.surfacePorts['pty-leak-2'] = [8080];
+        s.surfaceAgentStatus['pty-leak-1'] = 'awaiting_input';
+        s.surfaceAgentStatus['pty-leak-2'] = 'running';
+        // A surface OUTSIDE the closed subtree must survive.
+        s.surfacePorts['pty-keep'] = [4000];
+        s.surfaceAgentStatus['pty-keep'] = 'complete';
+      });
+
+      store.getState().closePane(closing.id);
+
+      const state = store.getState();
+      expect(state.surfacePorts['pty-leak-1']).toBeUndefined();
+      expect(state.surfacePorts['pty-leak-2']).toBeUndefined();
+      expect(state.surfaceAgentStatus['pty-leak-1']).toBeUndefined();
+      expect(state.surfaceAgentStatus['pty-leak-2']).toBeUndefined();
+      expect(state.surfacePorts['pty-keep']).toEqual([4000]);
+      expect(state.surfaceAgentStatus['pty-keep']).toBe('complete');
+    });
+  });
+
   // [REGRESSION] surfaceActivity must NEVER be persisted. buildSessionData
   // (AppLayout.tsx) is an allowlist-by-construction whose return type is
   // SessionData; a field absent from SessionData therefore cannot be written to

--- a/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
@@ -7,6 +7,8 @@ type TestState = {
   activeWorkspaceId: string;
   surfaceAgent: Record<string, { name: string; status: string }>;
   surfaceActivity: Record<string, string>;
+  surfacePorts: Record<string, number[]>;
+  surfaceAgentStatus: Record<string, string>;
 };
 
 function createHarness() {
@@ -16,6 +18,8 @@ function createHarness() {
     activeWorkspaceId: workspace.id,
     surfaceAgent: {},
     surfaceActivity: {},
+    surfacePorts: {},
+    surfaceAgentStatus: {},
   };
 
   const set = (updater: (state: TestState) => void) => {
@@ -438,5 +442,63 @@ describe('surfaceSlice.closeSurface — surfaceActivity cleanup (Fleet activity 
 
     expect(state.surfaceActivity['pty-1']).toBeUndefined();
     expect(state.surfaceActivity['pty-2']).toBe('✎ keep.ts');
+  });
+});
+
+// surfacePorts and surfaceAgentStatus were the two transient per-ptyId maps
+// still leaking here: every closed surface left a dead entry behind, and a
+// REUSED ptyId inherited the previous surface's status (reading as blocked or
+// running from birth). Found in the fleet-activity adversarial review.
+describe('surfaceSlice.closeSurface — surfacePorts / surfaceAgentStatus cleanup', () => {
+  it('clears BOTH transient maps for the closed surface ptyId', () => {
+    const { state, slice } = createHarness();
+    const paneId = state.workspaces[0].rootPane.id;
+    slice.addSurface(paneId, 'pty-1', 'pwsh', 'C:\\a');
+    const pane = state.workspaces[0].rootPane;
+    if (pane.type !== 'leaf') throw new Error('expected leaf pane');
+    const surfaceId = pane.surfaces.find((s) => s.ptyId === 'pty-1')!.id;
+    state.surfacePorts['pty-1'] = [5173];
+    state.surfaceAgentStatus['pty-1'] = 'awaiting_input';
+
+    slice.closeSurface(paneId, surfaceId);
+
+    expect(state.surfacePorts['pty-1']).toBeUndefined();
+    expect(state.surfaceAgentStatus['pty-1']).toBeUndefined();
+  });
+
+  it('leaves other surfaces’ ports and status untouched', () => {
+    const { state, slice } = createHarness();
+    const paneId = state.workspaces[0].rootPane.id;
+    slice.addSurface(paneId, 'pty-1', 'pwsh', 'C:\\a');
+    slice.addSurface(paneId, 'pty-2', 'pwsh', 'C:\\b');
+    const pane = state.workspaces[0].rootPane;
+    if (pane.type !== 'leaf') throw new Error('expected leaf pane');
+    const surfaceId1 = pane.surfaces.find((s) => s.ptyId === 'pty-1')!.id;
+    state.surfacePorts['pty-1'] = [3000];
+    state.surfacePorts['pty-2'] = [4000];
+    state.surfaceAgentStatus['pty-1'] = 'running';
+    state.surfaceAgentStatus['pty-2'] = 'complete';
+
+    slice.closeSurface(paneId, surfaceId1);
+
+    expect(state.surfacePorts['pty-1']).toBeUndefined();
+    expect(state.surfacePorts['pty-2']).toEqual([4000]);
+    expect(state.surfaceAgentStatus['pty-1']).toBeUndefined();
+    expect(state.surfaceAgentStatus['pty-2']).toBe('complete');
+  });
+
+  it('a ptyId reused by a later surface starts with NO inherited status', () => {
+    const { state, slice } = createHarness();
+    const paneId = state.workspaces[0].rootPane.id;
+    slice.addSurface(paneId, 'pty-reused', 'pwsh', 'C:\\a');
+    const pane = state.workspaces[0].rootPane;
+    if (pane.type !== 'leaf') throw new Error('expected leaf pane');
+    const firstId = pane.surfaces.find((s) => s.ptyId === 'pty-reused')!.id;
+    state.surfaceAgentStatus['pty-reused'] = 'awaiting_input';
+
+    slice.closeSurface(paneId, firstId);
+    slice.addSurface(paneId, 'pty-reused', 'pwsh', 'C:\\a');
+
+    expect(state.surfaceAgentStatus['pty-reused']).toBeUndefined();
   });
 });

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -559,6 +559,8 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
             delete state.surfacePendingQuestion[s.ptyId];
             delete state.surfaceActivityAt[s.ptyId];
             delete state.surfaceOutputAt[s.ptyId];
+            delete state.surfacePorts[s.ptyId];
+            delete state.surfaceAgentStatus[s.ptyId];
             clearNudgesFor(s.ptyId); // A5: don't let a reused ptyId inherit this pane's nudge cap
             // J3 F4: onExhausted 매핑도 이 ptyId 소멸과 함께 evict.
             if (state.taskPtyRegistry) delete state.taskPtyRegistry[s.ptyId];

--- a/src/renderer/stores/slices/surfaceSlice.ts
+++ b/src/renderer/stores/slices/surfaceSlice.ts
@@ -228,6 +228,11 @@ export const createSurfaceSlice: StateCreator<StoreState, [['zustand/immer', nev
     // Drop the pending question too: a leaked entry would let a REUSED ptyId
     // inherit a dead pane's question and read as blocked from birth.
     if (closedPtyId && state.surfacePendingQuestion) delete state.surfacePendingQuestion[closedPtyId];
+    // Drop per-surface ports and agent status too (fleet-activity adversarial
+    // review): without this, every closed surface leaves a dead ptyId entry
+    // behind, and a REUSED ptyId inherits the previous surface's status.
+    if (closedPtyId && state.surfacePorts) delete state.surfacePorts[closedPtyId];
+    if (closedPtyId && state.surfaceAgentStatus) delete state.surfaceAgentStatus[closedPtyId];
     if (closedPtyId) clearNudgesFor(closedPtyId); // A5: free the rate-cap entry for a reusable ptyId
     // J3 F4: onExhausted 매핑도 이 ptyId 소멸과 함께 evict(무한 성장·재사용 ptyId 오염 방지).
     if (closedPtyId && state.taskPtyRegistry) delete state.taskPtyRegistry[closedPtyId];


### PR DESCRIPTION
`surfacePorts` and `surfaceAgentStatus` were the last two transient per-ptyId maps
not cleaned up when a pane or surface closed. Every close left a dead entry
behind, and because ptyIds are reusable a new surface could inherit the previous
one's status — reading as blocked or running from birth.

Found in the fleet-activity adversarial review, which flagged `surfacePorts` as
unsafe to copy as a cleanup precedent because it leaked itself.

## What changed
Both maps are now evicted at the two real teardown sites, matching the existing
`surfaceAgent` / `surfaceActivity` / `surfacePendingQuestion` pattern:

- `paneSlice.closePane` — for every surface under the closed subtree
- `surfaceSlice.closeSurface` — for the closed surface

## Tests
`paneSlice.test.ts`: subtree teardown clears both maps and leaves surfaces outside
the subtree untouched.
`surfaceSlice.test.ts`: both maps cleared, siblings preserved, and a reused ptyId
starts with no inherited status.

Verified the tests fail against the unfixed slices (4 failures) and pass after:
`npx vitest run src/renderer/stores/slices/__tests__/` → 118 passed
