### PR TITLE
Enforce workspace scoping on status and events

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -46,11 +46,11 @@
 - **Context:** 스코핑 조사 판이 `gh pr diff 679`로 확인하던 중 판이 종료돼 결론을 못 봤다. 시작점: `PlaywrightEngine.ts`의 `resolveSelectionContext` / `explicitSurfaceId` 취급.
 - **Priority:** P0 — #679 머지 전에 답이 나와야 한다.
 
-## 스코핑 조사 U4·U8·U3 미검증 (P1)
-- **What:** `plans/workspace-scoping-survey.md`의 164지점 중 미검증 3건. **U8**(`meta.setStatus/setProgress`가 호출자 스코프 없이 사람이 보는 활성 워크스페이스에 씀)이 U7과 같은 계열로 보인다. U4(`principal.remove`/`markStaleWorkspace`가 스탬프 존재만 확인, 대상 비교 없음), U3(`operatorList` 주석은 "파이프 미등록"인데 `daemon/index.ts:3050`에 등록됨).
-- **Why:** U7은 REAL이라 PR #679가 됐고, U1은 검증 결과 ACCEPTED였다. 나머지도 갈라야 한다 — 관찰만 남기면 다음 사람이 어느 쪽인지 모른다.
-- **Context:** 판정 기준·1차 오판 사유가 문서에 기록돼 있다. 낮은 effort로 관찰 → 높은 effort로 검증 2단계가 U1에서 실효를 증명했다.
-- **Priority:** P1
+## ✅ 스코핑 조사 U4·U8·U3 검증 완료 (2026-07-30)
+- **U8** (`meta.setStatus/setProgress`): **REAL (P2) → FIXED** — `meta.rpc.ts`에 senderPtyId 기반 워크스페이스 해석 추가. 외부 caller는 서버가 해석한 ws만 쓰고, 해석 불가면 **거부**(fail-closed). 렌더러가 ws 없는 payload를 활성 워크스페이스에 적용하므로 `undefined` 통과는 취약점 그대로였다.
+- **U4** (`principal.remove`/`markStaleWorkspace`): **ACCEPTED** — transport-mitigated (renderer-only IPC + wmux.internal capability + same-user ceiling).
+- **U3** (`operatorList` "파이프 미등록"): **ACCEPTED** — 용어 혼란. 외부 facing RpcRouter에는 미등록, daemon 내부 파이프에만 등록. 주석 정정 완료.
+- 판정서: `plans/scoping-u4-u8-u3-verdict.md`
 
 ## A4 재정의 — 자식 워크스페이스 트리 대신 "막힘 노출" (P1)
 - **What:** 원안은 fan-out 태스크를 부모의 하위 워크스페이스로 만들어 오케스트레이터가 읽고 풀 수 있게 하는 것. **범위를 좁히자** — `agent.awaiting_input` 이벤트를 태스크 소유자에게만 보이게. 권한이 아니라 **가시성만**.
@@ -348,14 +348,10 @@
 - **Depends on:** 없음.
 - **Priority:** P3
 
-## (security) Unscoped plugin events.poll leaks cross-workspace lifecycle events (P2)
-- **What:** `PluginFrame.tsx:89`가 `events.poll`을 `{}`(workspaceId 없음)로 호출 → `events.rpc.ts:97` `caller ? e.workspaceId===caller : true`가 unscoped 호출에 **전 워크스페이스**의 `pane.created/closed/focused/process.*`를 통과시킴. `events.subscribe` capability를 declare한 플러그인이 다른 ws의 lifecycle을 관측 가능. `a2a.task`만 unscoped서 fail-closed.
-- **Why:** substrate 격리 원칙 위반. `a2a.task`의 `!!caller &&` fail-closed 절이 lifecycle 타입엔 없음. focus-rpc 리뷰(plan-eng-review, security 전문가)서 발견 — 선재 버그이며 focus 픽스가 만든 게 아니지만 EMIT이 약간 넓힘.
-- **Pros:** 플러그인 샌드박스의 cross-ws 관측 차단.
-- **Cons:** 둘 중 택1 — (a) `PluginFrame`이 호스트 프레임의 workspaceId를 poll에 실어보냄, 또는 (b) unscoped poll에서 lifecycle 타입도 fail-closed(`a2a.task`처럼). (a)가 깔끔하나 플러그인이 여러 ws를 의도적으로 보는 합법 케이스가 있는지 확인 필요.
-- **Context:** `src/main/pipe/handlers/events.rpc.ts:93-104`(post-filter), `src/renderer/plugins/PluginFrame.tsx:88-89`(unscoped poll). 시작점=poll params에 workspaceId 주입 vs 필터 fail-closed 결정.
-- **Depends on:** 없음 (focus 픽스와 독립).
-- **Priority:** P2 (보안 격리)
+## ✅ (security) Unscoped plugin events.poll — FIXED (2026-07-30)
+- 방안 (a) 채택: `PluginFrame.tsx`의 `events.poll` 호출에 `activeWorkspaceId`를 실어보냄(첫 poll·후속 poll 양쪽). 활성 워크스페이스가 바뀌면 effect가 재구독.
+- 플러그인은 이제 active workspace의 lifecycle 이벤트만 수신. 다른 ws의 `pane.created/closed/focused/process.*` 누출 차단.
+- PRIVATE 타입(a2a.task, channel.*)은 이미 unscoped poll에서 fail-closed였음 — 변경 없음.
 
 ## surface.focus capability를 pane.read로 통일 (P3)
 - **What:** `methodCapabilityMap.ts:181` `surface.focus` = `wmux.internal` → `pane.read`로(sibling `pane.focus:186`과 일치). first-party MCP에 surface.focus 도구 노출 + 서드파티 declarable.

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -3090,8 +3090,10 @@ function registerRpcHandlers(
   // a2a.channel.operatorList — 비공개 채널 발견 어포던스(설계 §2.2, 읽기 전용).
   // operatorJoin과 동일한 humans-only 트랜스포트: private 채널은 list()에서 비멤버에게
   // 숨겨지므로 GUI가 "들어갈 수 있는 방"을 보여주려면 이 메서드가 필요하다. 읽기지만
-  // 파이프에 노출하면 에이전트가 전 private 채널 이름을 열거할 수 있으므로 파이프
-  // 미등록 + 렌더러 전용 경로만. §2.2 직결 잔여: 같은 호출자는 이미 디스크에서 동일
+  // 파이프에 노출하면 에이전트가 전 private 채널 이름을 열거할 수 있으므로 외부 파이프
+  // (main RpcRouter) 미등록 + 렌더러 전용 경로만. 이 daemon 내부 파이프(DaemonPipeServer)
+  // 에는 등록돼 있으나 main process만 접근 가능.
+  // §2.2 직결 잔여: 같은 호출자는 이미 디스크에서 동일
   // 정보+메시지 전문을 읽는다 — API가 디스크보다 강하지 않다(명시 수용).
   pipeServer.onRpc('a2a.channel.operatorList', async (params) => {
     const verifiedWorkspaceId =

--- a/src/main/pipe/handlers/__tests__/meta.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/meta.rpc.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RpcRouter } from '../../RpcRouter';
+
+// The handler reaches the renderer twice: once to resolve the caller's pane
+// (input.findOwnerWorkspace via _bridge) and once to broadcast the metadata
+// payload (metadata.handler → window.webContents.send). Mock both seams so the
+// scoping decision is observable without Electron.
+vi.mock('../_bridge', () => ({ sendToRenderer: vi.fn() }));
+vi.mock('../../../ipc/handlers/metadata.handler', () => ({
+  broadcastMetadataUpdate: vi.fn(),
+}));
+
+import { registerMetaRpc } from '../meta.rpc';
+import { sendToRenderer } from '../_bridge';
+import { broadcastMetadataUpdate } from '../../../ipc/handlers/metadata.handler';
+
+const win = { isDestroyed: () => false } as never;
+const getWindow = () => win;
+
+function setup(): RpcRouter {
+  const router = new RpcRouter();
+  registerMetaRpc(router, getWindow);
+  return router;
+}
+
+/** The payload the renderer would receive, or null when nothing was sent. */
+function sentPayload(): Record<string, unknown> | null {
+  const mock = vi.mocked(broadcastMetadataUpdate);
+  if (mock.mock.calls.length === 0) return null;
+  return mock.mock.calls.at(-1)![1] as unknown as Record<string, unknown>;
+}
+
+/** Resolve senderPtyId 'pty-<x>' → workspace 'ws-<x>'; anything else is unknown. */
+function ownerResolver(known: Record<string, string>): void {
+  vi.mocked(sendToRenderer).mockImplementation(
+    async (_win: unknown, method: string, params?: unknown) => {
+      if (method !== 'input.findOwnerWorkspace') return null;
+      const ptyId = (params as { ptyId?: string } | undefined)?.ptyId ?? '';
+      const workspaceId = known[ptyId];
+      return workspaceId ? { workspaceId } : null;
+    },
+  );
+}
+
+describe('meta.rpc — U8 workspace scoping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ownerResolver({ 'pty-a': 'ws-a', 'pty-b': 'ws-b' });
+  });
+
+  describe('external callers (agents / MCP)', () => {
+    it('scopes meta.setStatus to the senderPtyId-resolved workspace', async () => {
+      const router = setup();
+      const res = await router.dispatch({
+        id: '1',
+        method: 'meta.setStatus',
+        params: { text: 'building', senderPtyId: 'pty-b' },
+      });
+      expect(res.ok).toBe(true);
+      expect(sentPayload()).toMatchObject({ status: 'building', workspaceId: 'ws-b' });
+    });
+
+    it('IGNORES a forged workspaceId and uses the resolved one (the U8 core)', async () => {
+      const router = setup();
+      await router.dispatch({
+        id: '2',
+        method: 'meta.setStatus',
+        params: { text: 'owned', senderPtyId: 'pty-a', workspaceId: 'ws-victim' },
+      });
+      expect(sentPayload()).toMatchObject({ workspaceId: 'ws-a' });
+      expect(sentPayload()!['workspaceId']).not.toBe('ws-victim');
+    });
+
+    it('scopes meta.setProgress the same way and clamps the value', async () => {
+      const router = setup();
+      await router.dispatch({
+        id: '3',
+        method: 'meta.setProgress',
+        params: { value: 250, senderPtyId: 'pty-b', workspaceId: 'ws-victim' },
+      });
+      expect(sentPayload()).toMatchObject({ progress: 100, workspaceId: 'ws-b' });
+    });
+
+    it('clamps a negative progress to 0', async () => {
+      const router = setup();
+      await router.dispatch({
+        id: '4',
+        method: 'meta.setProgress',
+        params: { value: -5, senderPtyId: 'pty-a' },
+      });
+      expect(sentPayload()).toMatchObject({ progress: 0, workspaceId: 'ws-a' });
+    });
+
+    // FAIL-CLOSED. The renderer applies a workspace-less payload to
+    // `activeWorkspaceId` (useNotificationListener: payloadWsId ??
+    // state.activeWorkspaceId), so returning `undefined` here would write into
+    // whichever workspace the human is looking at. These four cases must
+    // therefore be refused, and nothing may reach the renderer.
+    it('REFUSES an external caller that sends no senderPtyId', async () => {
+      const router = setup();
+      const res = await router.dispatch({
+        id: '5',
+        method: 'meta.setStatus',
+        params: { text: 'unscoped' },
+      });
+      expect(res.ok).toBe(false);
+      expect(broadcastMetadataUpdate).not.toHaveBeenCalled();
+    });
+
+    it('REFUSES an external caller whose senderPtyId does not resolve', async () => {
+      const router = setup();
+      const res = await router.dispatch({
+        id: '6',
+        method: 'meta.setStatus',
+        params: { text: 'ghost', senderPtyId: 'pty-nowhere' },
+      });
+      expect(res.ok).toBe(false);
+      expect(broadcastMetadataUpdate).not.toHaveBeenCalled();
+    });
+
+    it('REFUSES an unscoped caller even when it supplies a workspaceId', async () => {
+      const router = setup();
+      const res = await router.dispatch({
+        id: '7',
+        method: 'meta.setProgress',
+        params: { value: 50, workspaceId: 'ws-victim' },
+      });
+      expect(res.ok).toBe(false);
+      expect(broadcastMetadataUpdate).not.toHaveBeenCalled();
+    });
+
+    it('REFUSES when the renderer resolution throws', async () => {
+      vi.mocked(sendToRenderer).mockRejectedValue(new Error('renderer gone'));
+      const router = setup();
+      const res = await router.dispatch({
+        id: '8',
+        method: 'meta.setStatus',
+        params: { text: 'x', senderPtyId: 'pty-a' },
+      });
+      expect(res.ok).toBe(false);
+      expect(broadcastMetadataUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('first-party caller (renderer bridge)', () => {
+    it('honours the caller-supplied workspaceId without any pane resolution', async () => {
+      const router = setup();
+      const res = await router.dispatch(
+        { id: '9', method: 'meta.setStatus', params: { text: 'ok', workspaceId: 'ws-chosen' } },
+        { firstParty: true },
+      );
+      expect(res.ok).toBe(true);
+      expect(sentPayload()).toMatchObject({ status: 'ok', workspaceId: 'ws-chosen' });
+      // The trusted operator surface must not pay for a renderer round-trip.
+      expect(sendToRenderer).not.toHaveBeenCalled();
+    });
+
+    it('keeps the active-workspace default for a first-party call with no workspaceId', async () => {
+      const router = setup();
+      const res = await router.dispatch(
+        { id: '10', method: 'meta.setProgress', params: { value: 42 } },
+        { firstParty: true },
+      );
+      expect(res.ok).toBe(true);
+      expect(sentPayload()).toMatchObject({ progress: 42 });
+      expect(sentPayload()!['workspaceId']).toBeUndefined();
+    });
+  });
+
+  describe('param validation (unchanged)', () => {
+    it('rejects a non-string text', async () => {
+      const router = setup();
+      const res = await router.dispatch(
+        { id: '11', method: 'meta.setStatus', params: { text: 5 } },
+        { firstParty: true },
+      );
+      expect(res.ok).toBe(false);
+    });
+
+    it('rejects a non-number value', async () => {
+      const router = setup();
+      const res = await router.dispatch(
+        { id: '12', method: 'meta.setProgress', params: { value: 'high' } },
+        { firstParty: true },
+      );
+      expect(res.ok).toBe(false);
+    });
+  });
+});

--- a/src/main/pipe/handlers/meta.rpc.ts
+++ b/src/main/pipe/handlers/meta.rpc.ts
@@ -1,19 +1,68 @@
 import type { BrowserWindow } from 'electron';
 import type { RpcRouter } from '../RpcRouter';
+import type { RpcContext } from '../../../shared/rpc';
 import type { MetadataUpdatePayload } from '../../../shared/types';
 import { broadcastMetadataUpdate } from '../../ipc/handlers/metadata.handler';
+import { sendToRenderer } from './_bridge';
 
 type GetWindow = () => BrowserWindow | null;
 
 /**
- * meta.setStatus / meta.setProgress write through the unified
- * MetadataUpdatePayload shape on IPC.METADATA_UPDATE. The previous
- * discriminated `{kind, ...}` payload conflicted with the (ptyId, data)
- * shape sent by metadata.handler.ts, which broke preload's listener for one
- * of the two paths. Both paths now agree on a single shape.
+ * Resolve the caller's workspace from senderPtyId (server-derived, not
+ * caller-supplied). Returns '' when unresolvable.
  *
- * Without ptyId/workspaceId, the renderer applies the update to the active
- * workspace (status/progress are workspace-level fields).
+ * Mirrors the pattern in fanout.rpc.ts / events.rpc.ts.
+ */
+async function resolveCallerWorkspace(getWindow: GetWindow, params: Record<string, unknown>): Promise<string> {
+  const senderPtyId =
+    typeof params['senderPtyId'] === 'string' ? params['senderPtyId'] : '';
+  if (!senderPtyId) return '';
+  try {
+    const owner = await sendToRenderer(getWindow, 'input.findOwnerWorkspace', { ptyId: senderPtyId });
+    const wsId =
+      owner && typeof owner === 'object' && 'workspaceId' in owner
+        ? (owner as Record<string, unknown>)['workspaceId']
+        : null;
+    return typeof wsId === 'string' && wsId ? wsId : '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * The workspace an external caller is allowed to write, or a throw.
+ *
+ * This MUST fail closed rather than return undefined: the renderer applies a
+ * workspace-less MetadataUpdatePayload to `activeWorkspaceId`
+ * (useNotificationListener: `payloadWsId ?? state.activeWorkspaceId`). Passing
+ * undefined through would therefore write into whichever workspace the human
+ * happens to be looking at — the exact unscoped write U8 reported. An agent
+ * that cannot prove which pane it is calling from gets an error instead.
+ */
+async function requireCallerWorkspace(
+  method: string,
+  getWindow: GetWindow,
+  params: Record<string, unknown>,
+): Promise<string> {
+  const resolved = await resolveCallerWorkspace(getWindow, params);
+  if (!resolved) {
+    throw new Error(
+      `${method}: cannot resolve the calling pane's workspace — send a verified senderPtyId`,
+    );
+  }
+  return resolved;
+}
+
+/**
+ * meta.setStatus / meta.setProgress write through the unified
+ * MetadataUpdatePayload shape on IPC.METADATA_UPDATE.
+ *
+ * U8 fix (2026-07-30): workspace scoping is now SERVER-RESOLVED from
+ * senderPtyId (same pattern as fanout.rpc / events.rpc). The caller-supplied
+ * workspaceId is ignored for external callers, and an external caller whose
+ * workspace cannot be resolved is refused. First-party callers (the renderer
+ * bridge) keep using the caller-supplied workspaceId since they are trusted and
+ * the renderer itself controls which workspace to target.
  */
 function sendMeta(getWindow: GetWindow, payload: MetadataUpdatePayload): Promise<{ ok: boolean }> {
   const win = getWindow();
@@ -26,29 +75,45 @@ function sendMeta(getWindow: GetWindow, payload: MetadataUpdatePayload): Promise
 
 export function registerMetaRpc(router: RpcRouter, getWindow: GetWindow): void {
   /**
-   * meta.setStatus — sets an arbitrary status text string on the active
-   * workspace.
-   * params: { text: string, workspaceId?: string }
+   * meta.setStatus — sets an arbitrary status text string on a workspace.
+   * params: { text: string, workspaceId?: string, senderPtyId?: string }
+   *
+   * U8: external callers (agents/MCP) have their workspace resolved from
+   * senderPtyId. The caller-supplied workspaceId is only trusted for
+   * first-party callers (renderer bridge).
    */
-  router.register('meta.setStatus', (params) => {
+  router.register('meta.setStatus', async (params, ctx) => {
     if (typeof params['text'] !== 'string') {
       throw new Error('meta.setStatus: missing required param "text"');
     }
-    const workspaceId = typeof params['workspaceId'] === 'string' ? params['workspaceId'] : undefined;
-    return sendMeta(getWindow, { status: params['text'], workspaceId });
+    let workspaceId: string | undefined;
+    if (ctx?.firstParty) {
+      // Trusted in-process caller (renderer) — honour their supplied workspaceId.
+      workspaceId = typeof params['workspaceId'] === 'string' ? params['workspaceId'] : undefined;
+    } else {
+      // External caller — resolve from senderPtyId, ignore caller-supplied ws.
+      workspaceId = await requireCallerWorkspace('meta.setStatus', getWindow, params);
+    }
+    return sendMeta(getWindow, { status: params['text'] as string, workspaceId });
   });
 
   /**
-   * meta.setProgress — sets a progress value (0–100) on the active workspace.
-   * params: { value: number, workspaceId?: string }
-   * Values outside 0–100 are clamped.
+   * meta.setProgress — sets a progress value (0–100) on a workspace.
+   * params: { value: number, workspaceId?: string, senderPtyId?: string }
+   *
+   * U8: same workspace-scoping as meta.setStatus.
    */
-  router.register('meta.setProgress', (params) => {
+  router.register('meta.setProgress', async (params, ctx) => {
     if (typeof params['value'] !== 'number') {
       throw new Error('meta.setProgress: missing required param "value" (number)');
     }
     const value = Math.min(100, Math.max(0, params['value']));
-    const workspaceId = typeof params['workspaceId'] === 'string' ? params['workspaceId'] : undefined;
+    let workspaceId: string | undefined;
+    if (ctx?.firstParty) {
+      workspaceId = typeof params['workspaceId'] === 'string' ? params['workspaceId'] : undefined;
+    } else {
+      workspaceId = await requireCallerWorkspace('meta.setProgress', getWindow, params);
+    }
     return sendMeta(getWindow, { progress: value, workspaceId });
   });
 }

--- a/src/renderer/plugins/PluginFrame.tsx
+++ b/src/renderer/plugins/PluginFrame.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { useStore } from '../stores';
 import {
   PLUGIN_BRIDGE_VERSION,
   PLUGIN_PROTOCOL_SCHEME,
@@ -53,6 +54,9 @@ export default function PluginFrame({
   className?: string;
 }) {
   const frameRef = useRef<HTMLIFrameElement>(null);
+  // Fix: scope events.poll to the active workspace so plugins cannot observe
+  // other workspaces' lifecycle events (TODOS: "Unscoped plugin events.poll").
+  const activeWorkspaceId = useStore((s) => s.activeWorkspaceId);
 
   useEffect(() => {
     const iframe = frameRef.current;
@@ -86,7 +90,9 @@ export default function PluginFrame({
         if (disposed || inFlight) return;
         inFlight = true;
         window.electronAPI.plugins
-          .rpc(pluginName, 'events.poll', cursor === null ? {} : { cursor })
+          .rpc(pluginName, 'events.poll', cursor === null
+            ? { workspaceId: activeWorkspaceId }
+            : { cursor, workspaceId: activeWorkspaceId })
           .then((raw) => {
             const resp = raw as { ok?: boolean; result?: { events?: unknown[]; nextCursor?: number } } | null;
             if (!resp || resp.ok !== true || !resp.result) {
@@ -163,7 +169,7 @@ export default function PluginFrame({
       port?.close();
       port = null;
     };
-  }, [pluginName, entry, forwardEvents]);
+  }, [pluginName, entry, forwardEvents, activeWorkspaceId]);
 
   return (
     <iframe

--- a/src/renderer/plugins/__tests__/pluginFrameEventScope.test.ts
+++ b/src/renderer/plugins/__tests__/pluginFrameEventScope.test.ts
@@ -28,7 +28,7 @@ describe('PluginFrame — events.poll workspace scoping', () => {
   });
 
   it('sends workspaceId on the events.poll call, on BOTH the first and subsequent polls', () => {
-    const call = src.match(/rpc\(\s*pluginName,\s*'events\.poll'[\s\S]*?\)\n/);
+    const call = src.match(/rpc\(\s*pluginName,\s*'events\.poll'[\s\S]*?\)\r?\n/);
     expect(call, 'events.poll call site not found').not.toBeNull();
     const text = call![0];
     // The cursor===null (first poll) and cursor branches are separate object

--- a/src/renderer/plugins/__tests__/pluginFrameEventScope.test.ts
+++ b/src/renderer/plugins/__tests__/pluginFrameEventScope.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Workspace scoping for the plugin `events.poll` loop.
+ *
+ * PluginFrame used to poll with `{}` / `{ cursor }` — no workspaceId. On the
+ * server, `events.rpc.ts` drops only the PRIVATE types (a2a.task, channel.*)
+ * for an unscoped poll; every LIFECYCLE type (pane.created / closed / focused,
+ * process.*) falls through to an all-workspace firehose. So a plugin that
+ * declared `events.subscribe` observed lifecycle events from workspaces the
+ * user never granted it. The fix sends the active workspaceId on every poll and
+ * re-subscribes when the active workspace changes.
+ *
+ * PluginFrame renders an iframe and opens a MessagePort, and the default vitest
+ * environment here is `node`, so the component cannot be mounted in this suite.
+ * These are source-structural guards — the same pattern used by
+ * useRpcBridge.focus.test.ts / useRpcBridge.browserClose.test.ts for renderer
+ * wiring that can't be imported under vitest. The server-side filter behaviour
+ * itself is covered by events.rpc.test.ts.
+ */
+describe('PluginFrame — events.poll workspace scoping', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'PluginFrame.tsx'), 'utf-8');
+
+  it('reads the active workspace from the store', () => {
+    expect(src).toMatch(/const\s+activeWorkspaceId\s*=\s*useStore\(\s*\(s\)\s*=>\s*s\.activeWorkspaceId\s*\)/);
+  });
+
+  it('sends workspaceId on the events.poll call, on BOTH the first and subsequent polls', () => {
+    const call = src.match(/rpc\(\s*pluginName,\s*'events\.poll'[\s\S]*?\)\n/);
+    expect(call, 'events.poll call site not found').not.toBeNull();
+    const text = call![0];
+    // The cursor===null (first poll) and cursor branches are separate object
+    // literals; a fix applied to only one of them still leaks on the other.
+    const scoped = text.match(/workspaceId:\s*activeWorkspaceId/g) ?? [];
+    expect(scoped.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('never polls with a bare {} or cursor-only param object', () => {
+    expect(src).not.toMatch(/'events\.poll',\s*cursor === null \? \{\} :/);
+    expect(src).not.toMatch(/'events\.poll',\s*\{\s*\}\s*\)/);
+    expect(src).not.toMatch(/'events\.poll',\s*\{\s*cursor\s*\}\s*\)/);
+  });
+
+  it('re-runs the subscribe effect when the active workspace changes', () => {
+    // Without activeWorkspaceId in the deps the loop would keep polling the
+    // workspace that was active at mount after the user switched away.
+    expect(src).toMatch(/\}, \[pluginName, entry, forwardEvents, activeWorkspaceId\]\);/);
+  });
+});


### PR DESCRIPTION
Two workspace-isolation holes from the scoping survey, plus the verdict on the
three items it left unverified.

## U8 — `meta.setStatus` / `meta.setProgress` (REAL)
Both RPCs trusted a caller-supplied `workspaceId`, so any agent or MCP client
could write status/progress into a workspace it has no relationship with.

Now the workspace is **server-resolved** from `senderPtyId` (the same pattern as
`fanout.rpc` / `events.rpc`) and the caller-supplied value is ignored for
external callers. First-party callers (the renderer bridge) keep supplying it —
the renderer legitimately chooses which workspace to target.

Fail-closed matters here: the renderer applies a workspace-less payload to
`activeWorkspaceId` (`payloadWsId ?? state.activeWorkspaceId`), so returning
`undefined` would still write into whatever workspace the human is looking at —
the original vulnerability. An external caller that cannot prove which pane it is
calling from is now **refused**.

## Unscoped plugin `events.poll` (REAL)
`PluginFrame` polled with no `workspaceId`. Server-side only the PRIVATE types
(`a2a.task`, `channel.*`) are dropped for an unscoped poll; every lifecycle type
fell through to an all-workspace firehose, so a plugin holding
`events.subscribe` observed other workspaces' `pane.*` / `process.*` events.

The poll now carries `activeWorkspaceId` on both the first and subsequent polls,
and re-subscribes when the active workspace changes.

## U4 / U3 — accepted, not bugs
- **U4** (`principal.remove` / `markStaleWorkspace`): transport-mitigated —
  renderer-only IPC + `wmux.internal` capability + same-user ceiling.
- **U3** (`operatorList` "not pipe-registered"): terminology confusion. It is
  absent from the external-facing `RpcRouter` and registered only on the daemon's
  internal pipe, which only the main process can reach. Comment corrected.

## Tests
12 cases in `meta.rpc.test.ts` (resolution, forged-workspaceId rejection,
clamping, all four fail-closed paths, first-party passthrough) and 4 wiring
guards in `pluginFrameEventScope.test.ts`.

Both fail against `origin/main` (8 and 4 failures) and pass after:
`npx vitest run src/main/pipe/handlers/__tests__/meta.rpc.test.ts src/main/pipe/handlers/__tests__/events.rpc.test.ts src/renderer/plugins/__tests__/` → 64 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved workspace isolation for metadata operations and plugin event polling.
  * Requests without a resolvable workspace are now rejected.

* **Bug Fixes**
  * Plugin event polling now follows the active workspace and refreshes when it changes.
  * Metadata status and progress updates use the correct workspace scope.

* **Tests**
  * Added coverage for workspace validation, caller behavior, progress handling, and workspace changes.

* **Documentation**
  * Clarified security boundaries for operator-list communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->