### PR TITLE
Show unread count on the dock and tray

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -183,14 +183,11 @@
      list; `useNotificationPolicy` skips toast/sound/ring/flashFrame for muted
      workspaces while still recording the entry in the panel (policy A4). -->
 
-## (E5) Tray icon unread badge (cross-platform)
-- **What:** `src/main/tray.ts`에 unread count를 표시. macOS: `app.dock.setBadge(N)`, Windows: tray tooltip prefix `[N] wmux`, Linux: best-effort (NotificationServer 표준은 제한적).
-- **Why:** wmux 창이 minimize/hide 상태에서는 OS 토스트 한 번 외에는 알림 신호 부재. tray가 영구 신호 채널.
-- **Pros:** 창 안 열어도 unread 인지. macOS 사용자에게 자연스러운 UX.
-- **Cons:** Cross-platform 차이 큼 — 3 OS에서 각각 QA 세션 필요. Linux fallback 정책 결정 필요.
-- **Context:** memory `project_cross_platform_branch_policy` 정책에 따라 **feature branch + PR**로 진행. `src/main/notification/ToastManager.ts`와 같은 자리에 `TrayBadgeManager` 추가 고려. Renderer store unread count 변경 → main으로 push → tray 갱신. CC 추정 30-45분 + 3 OS QA.
-- **Depends on:** 알림 파이프라인 복구 ship + 사용자가 minimize 사용 빈도 확인
-- **Priority:** P2
+## ✅ (E5) Tray icon unread badge — DONE (2026-07-30)
+- macOS: `app.dock?.setBadge(N)` (999+ cap, 0이면 빈 문자열로 클리어). Windows/Linux: tray tooltip `[N] wmux`.
+- Renderer StatusBar에서 `computeUnreadCount` 변경 시 `useEffect`로 `IPC.NOTIFICATION_BADGE_COUNT` 전송.
+- main `registerHandlers.ts`가 렌더러 값을 음이 아닌 정수로 정규화한 뒤 `tray.ts:updateUnreadBadge()` 호출.
+- 3 OS QA는 별도. 단위 테스트로 두 플랫폼 분기·클리어·캡·정규화를 고정.
 
 ## Fix B — Scrollback restore cap-aware suspended-session promote
 - **What:** `daemon.listSessions`에 `{includeSuspended}` 파라미터 추가 + `daemon.promoteSession(id)` 신규 RPC. `AppLayout.reconcilePtys` fallback 직전에 promote 시도. cap=40 초과로 자동 복구되지 못한 suspended session도 reconnect 가능하게.

--- a/src/main/__tests__/trayUnreadBadge.test.ts
+++ b/src/main/__tests__/trayUnreadBadge.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// E5 — the platform unread badge. macOS gets a real dock badge; Windows/Linux
+// have no dock, so the count is prefixed onto the tray tooltip instead. These
+// lock the two platform branches, the clear-at-zero contract, and the 999+ cap.
+
+const setBadgeMock = vi.fn();
+const setToolTipMock = vi.fn();
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    setAboutPanelOptions: vi.fn(),
+    dock: { setBadge: setBadgeMock },
+  },
+  Tray: class {
+    setToolTip = setToolTipMock;
+    setContextMenu = vi.fn();
+    on = vi.fn();
+  },
+  Menu: { buildFromTemplate: vi.fn(() => ({})) },
+  nativeImage: {
+    createFromPath: vi.fn(() => ({ setTemplateImage: vi.fn(), resize: vi.fn() })),
+  },
+  BrowserWindow: vi.fn(),
+  shell: { openPath: vi.fn(), showItemInFolder: vi.fn() },
+  dialog: {},
+}));
+
+/** Load tray.ts under a given platform, optionally creating the Tray first. */
+async function loadTray(
+  platform: string,
+  opts: { withTray?: boolean } = {},
+): Promise<typeof import('../tray')> {
+  vi.stubGlobal('process', { ...process, platform });
+  const mod = await import('../tray');
+  if (opts.withTray) {
+    const fakeWindow = { show: vi.fn(), focus: vi.fn() } as unknown as import('electron').BrowserWindow;
+    mod.createTray(fakeWindow, { onQuit: vi.fn(), onShutdownAll: vi.fn() });
+    setToolTipMock.mockClear();
+  }
+  return mod;
+}
+
+describe('updateUnreadBadge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  describe('macOS (dock badge)', () => {
+    it('writes the count as a string', async () => {
+      const { updateUnreadBadge } = await loadTray('darwin');
+      updateUnreadBadge(3);
+      expect(setBadgeMock).toHaveBeenCalledWith('3');
+    });
+
+    it('clears the badge with an empty string at zero', async () => {
+      const { updateUnreadBadge } = await loadTray('darwin');
+      updateUnreadBadge(0);
+      expect(setBadgeMock).toHaveBeenCalledWith('');
+    });
+
+    it('caps a runaway count at 999+ so the badge stays readable', async () => {
+      const { updateUnreadBadge } = await loadTray('darwin');
+      updateUnreadBadge(1000);
+      expect(setBadgeMock).toHaveBeenCalledWith('999+');
+    });
+
+    it('does not cap at exactly 999', async () => {
+      const { updateUnreadBadge } = await loadTray('darwin');
+      updateUnreadBadge(999);
+      expect(setBadgeMock).toHaveBeenCalledWith('999');
+    });
+
+    it('never touches the tray tooltip on mac (the dock owns the count)', async () => {
+      const { updateUnreadBadge } = await loadTray('darwin', { withTray: true });
+      updateUnreadBadge(5);
+      expect(setToolTipMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Windows / Linux (tray tooltip)', () => {
+    it('prefixes the tooltip with the count', async () => {
+      const { updateUnreadBadge } = await loadTray('win32', { withTray: true });
+      updateUnreadBadge(7);
+      expect(setToolTipMock).toHaveBeenCalledWith('[7] wmux');
+    });
+
+    it('restores the plain tooltip at zero', async () => {
+      const { updateUnreadBadge } = await loadTray('win32', { withTray: true });
+      updateUnreadBadge(4);
+      updateUnreadBadge(0);
+      expect(setToolTipMock).toHaveBeenLastCalledWith('wmux');
+    });
+
+    it('never touches the dock badge off mac', async () => {
+      const { updateUnreadBadge } = await loadTray('linux', { withTray: true });
+      updateUnreadBadge(2);
+      expect(setBadgeMock).not.toHaveBeenCalled();
+    });
+
+    it('is a silent no-op before the tray exists (boot ordering)', async () => {
+      const { updateUnreadBadge } = await loadTray('win32');
+      expect(() => updateUnreadBadge(2)).not.toThrow();
+      expect(setToolTipMock).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// The IPC listener is the trust boundary for this value: it comes from the
+// renderer, so main normalizes it before any platform call. registerHandlers.ts
+// pulls in the whole main-process handler graph (PTYManager, DaemonClient, MCP),
+// so the listener is not importable in a unit test — these pin the normalization
+// and the static (non-`require`) wiring at the source level, the same pattern
+// used elsewhere for main/renderer wiring that cannot be imported under vitest.
+describe('NOTIFICATION_BADGE_COUNT listener wiring', () => {
+  const src = new URL('../ipc/registerHandlers.ts', import.meta.url).pathname;
+  let text = '';
+
+  beforeEach(async () => {
+    const fs = await import('node:fs');
+    text = fs.readFileSync(src, 'utf-8');
+  });
+
+  it('imports the tray helper statically rather than with an inline require', () => {
+    expect(text).toMatch(/import \{ updateUnreadBadge \} from '\.\.\/tray';/);
+    expect(text).not.toMatch(/require\('\.\.\/tray'\)/);
+  });
+
+  it('normalizes the renderer count to a non-negative integer before applying it', () => {
+    const block = text.slice(text.indexOf('IPC.NOTIFICATION_BADGE_COUNT'));
+    expect(block).toMatch(/Number\.isFinite\(count\)/);
+    expect(block).toMatch(/Math\.floor\(count\)/);
+    expect(block).toMatch(/:\s*0;/);
+  });
+
+  it('removes the listener on cleanup so a handler swap cannot double-register', () => {
+    const removals = text.match(/removeAllListeners\(IPC\.NOTIFICATION_BADGE_COUNT\)/g) ?? [];
+    // Once defensively before registering, once in the cleanup function.
+    expect(removals.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/main/ipc/registerHandlers.ts
+++ b/src/main/ipc/registerHandlers.ts
@@ -35,6 +35,7 @@ import { IPC } from '../../shared/constants';
 import { toastManager } from '../pipe/handlers/notify.rpc';
 import { markRendererNotificationListenerReady } from '../notification/rendererNotificationReadiness';
 import { setMutedNotificationCategories } from '../notification/mutedCategories';
+import { updateUnreadBadge } from '../tray';
 import { eventBus } from '../events/EventBus';
 import { WMUX_EVENT_TYPES, type WmuxEventType } from '../../shared/events';
 import { VALID_TRANSITIONS, type TaskState } from '../../shared/types';
@@ -269,6 +270,18 @@ export function registerAllHandlers(
   ipcMain.removeAllListeners(IPC.NOTIFICATION_OS_TOAST);
   ipcMain.on(IPC.NOTIFICATION_OS_TOAST, onOsToast);
 
+  // E5 — Dock/tray unread badge. Renderer sends a count whenever the total
+  // unread changes; main applies it to the platform badge surface. A hostile or
+  // buggy renderer value is normalized to a non-negative integer here so the
+  // platform call can never receive NaN / a fraction / a negative.
+  ipcMain.removeAllListeners(IPC.NOTIFICATION_BADGE_COUNT);
+  ipcMain.on(IPC.NOTIFICATION_BADGE_COUNT, (_event: Electron.IpcMainEvent, count: number) => {
+    const safe = typeof count === 'number' && Number.isFinite(count) && count > 0
+      ? Math.floor(count)
+      : 0;
+    updateUnreadBadge(safe);
+  });
+
   // Renderer confirms useNotificationListener's effect has subscribed —
   // dispatchNotification consults this before trusting webContents.send to
   // actually reach a listener. See rendererNotificationReadiness.ts.
@@ -416,6 +429,7 @@ export function registerAllHandlers(
     ipcMain.removeAllListeners(IPC.WINDOW_HIDE);
     ipcMain.removeAllListeners(IPC.WINDOW_FLASH_FRAME);
     ipcMain.removeAllListeners(IPC.NOTIFICATION_OS_TOAST);
+    ipcMain.removeAllListeners(IPC.NOTIFICATION_BADGE_COUNT);
     ipcMain.removeAllListeners(IPC.NOTIFICATION_LISTENER_READY);
   };
 }

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -179,3 +179,19 @@ export function destroyTray(): void {
   trayWindow = null;
   trayCallbacks = null;
 }
+
+/**
+ * E5 — Set the platform unread badge. macOS: dock badge (number or empty).
+ * Windows: tray tooltip prefix. Called from main whenever the renderer sends
+ * a NOTIFICATION_BADGE_COUNT update.
+ */
+export function updateUnreadBadge(count: number): void {
+  if (process.platform === 'darwin') {
+    // app.dock.setBadge expects a string; empty string clears the badge.
+    app.dock?.setBadge(count > 0 ? String(count > 999 ? '999+' : count) : '');
+  } else if (tray) {
+    // Windows/Linux: prefix the tooltip with the count when non-zero.
+    const base = 'wmux';
+    tray.setToolTip(count > 0 ? `[${count}] ${base}` : base);
+  }
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -230,6 +230,8 @@ const electronAPI = {
     // suppression. ptyId/workspaceId become the toast's click-jump context.
     showOsToast: (payload: { title: string; body: string; ptyId?: string | null; workspaceId?: string | null; windowsFlashEnabled?: boolean; dockBounceEnabled?: boolean }) =>
       ipcRenderer.send(IPC.NOTIFICATION_OS_TOAST, payload),
+    // E5 — push unread count to main for the dock/tray badge.
+    setBadgeCount: (count: number) => ipcRenderer.send(IPC.NOTIFICATION_BADGE_COUNT, count),
     // Fired once when useNotificationListener's effect mounts and subscribes
     // — confirms to main that IPC.NOTIFICATION sends will actually reach a
     // live listener, not just a live (but reloading/unmounted) window.

--- a/src/renderer/components/StatusBar/StatusBar.tsx
+++ b/src/renderer/components/StatusBar/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties } from 'react';
+import { type CSSProperties, useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useStore } from '../../stores';
 import { useT } from '../../hooks/useT';
@@ -93,6 +93,11 @@ export default function StatusBar() {
   //    number 반환이라 zustand 기본 Object.is 비교로 값이 바뀔 때만 리렌더된다.
   const activeWs = useStore(useShallow(selectActiveWorkspaceSummary));
   const unreadCount = useStore((s) => computeUnreadCount(s.notifications, s.workspaces));
+
+  // E5 — push unread count to main for the dock/tray badge whenever it changes.
+  useEffect(() => {
+    window.electronAPI?.notification?.setBadgeCount?.(unreadCount);
+  }, [unreadCount]);
   // Bridge P2 rev2 — fleet vitals as APPEARING chips (owner call: the always-on
   // bottom instrument strip read as dead chrome at "0 running", so it's gone;
   // the signal moved here and renders ONLY when nonzero). Derived-number

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -57,6 +57,10 @@ export const IPC = {
   SESSION_SAVE_ASYNC: 'session:saveAsync',
   SESSION_LOAD: 'session:load',
   NOTIFICATION: 'notification:new',
+  // E5 — dock/tray badge unread count. Renderer sends a count update whenever
+  // the total unread changes; main applies it to the platform badge surface
+  // (macOS dock, Windows tray tooltip).
+  NOTIFICATION_BADGE_COUNT: 'notification:badge-count',
   // X2 — OS toast click → jump to the originating pane. Main sends the
   // toast's {ptyId, workspaceId} context; renderer resolves and activates
   // the workspace/pane/surface (see useNotificationListener).


### PR DESCRIPTION
With the wmux window minimized or hidden, a single OS toast was the only unread
signal — nothing persistent.

## What changed
- macOS: `app.dock.setBadge(N)`, capped at `999+`, cleared with an empty string
  at zero.
- Windows/Linux: the tray tooltip becomes `[N] wmux` (no dock exists).
- `StatusBar` pushes the existing `computeUnreadCount` result to main whenever it
  changes; main normalizes it to a non-negative integer before any platform call.

Two hygiene fixes while wiring it: the tray helper is imported statically like
every other import in `registerHandlers.ts` (it was an inline `require`), and the
renderer-supplied count is floored and finite-checked so a hostile or buggy value
cannot reach `setBadge`.

## Tests
12 cases: both platform branches, clear-at-zero, the 999+ cap and its exact
boundary, no cross-talk between dock and tray, a no-op before the tray exists,
plus wiring guards for the static import, the normalization, and listener
teardown.

`npx vitest run src/main/__tests__/ src/renderer/components/StatusBar/__tests__/` → 91 passed

## Notes
Cross-platform QA on all three OSes is still outstanding; the unit tests pin the
per-platform logic, not the OS rendering.
