### PR TITLE
Keep authoritative agent status across redraws

### DIFF
--- a/src/daemon/DaemonPTYBridge.ts
+++ b/src/daemon/DaemonPTYBridge.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'node:events';
 import type { IPty } from 'node-pty';
 import { OscParser } from '../main/pty/OscParser';
 import { TerminalNotificationParser } from '../main/pty/oscNotification';
-import { AgentDetector } from '../main/pty/AgentDetector';
+import { AgentDetector, type AgentEventStatus } from '../main/pty/AgentDetector';
 import { ActivityMonitor } from '../main/pty/ActivityMonitor';
 import { parseOsc7Cwd, detectPromptCwd } from '../main/pty/cwdDetect';
 import { sanitizeTitle } from '../main/pty/titleDetect';
@@ -74,9 +74,94 @@ export class DaemonPTYBridge extends EventEmitter {
    */
   private oscCwdSeen = false;
 
+  /**
+   * A detector/hook terminal state (waiting, complete, awaiting input, error)
+   * outranks passive byte throughput until a real submitted-input boundary
+   * starts the next turn. This prevents a full-screen idle redraw from
+   * resurrecting stale `running` metadata.
+   */
+  private explicitTerminalStatus = false;
+  private submittedTurnPending = false;
+
+  /** Track bracketed-paste input so newlines inside a pasted draft are not
+   * mistaken for Enter. The closing marker and the later CR are separate writes
+   * in the normal renderer path; only that CR starts a turn. */
+  private inputInBracketedPaste = false;
+  private static readonly BRACKETED_PASTE_START = '\x1b[200~';
+  private static readonly BRACKETED_PASTE_END = '\x1b[201~';
+
   /** Called by DaemonSessionManager.resizeSession on every applied resize. */
   noteResize(): void {
     this.lastResizeAtMs = Date.now();
+  }
+
+  /**
+   * Observe bytes successfully written to PTY stdin. A CR/LF outside bracketed
+   * paste is a submitted turn; callers that send an immediate TUI choice
+   * (approval digit/ESC) pass `forceSubmitted=true` because those controls do
+   * not include Enter but still resume the blocked turn.
+   */
+  noteInput(data: string, forceSubmitted = false): void {
+    const hasSubmitBoundary = this.scanSubmittedInput(data);
+    if (!forceSubmitted && !hasSubmitBoundary) return;
+
+    this.explicitTerminalStatus = false;
+    this.submittedTurnPending = true;
+    if (this.resizeGuardTimer) {
+      clearTimeout(this.resizeGuardTimer);
+      this.resizeGuardTimer = null;
+    }
+    this.agentDetector?.resetEmissionState();
+    if (this.activityMonitor && this.sessionId) {
+      this.activityMonitor.beginTurn(this.sessionId);
+    }
+  }
+
+  /**
+   * Apply an authoritative detector/hook lifecycle edge inside the daemon.
+   * Terminal states settle the turn and block later byte-only redraws;
+   * explicit running activity opens the gate again for autonomous work.
+   */
+  noteAgentStatus(status: AgentEventStatus): void {
+    if (status === 'running') {
+      this.explicitTerminalStatus = false;
+      return;
+    }
+    this.explicitTerminalStatus = true;
+    this.submittedTurnPending = false;
+    if (this.resizeGuardTimer) {
+      clearTimeout(this.resizeGuardTimer);
+      this.resizeGuardTimer = null;
+    }
+  }
+
+  private scanSubmittedInput(data: string): boolean {
+    let remaining = data;
+    let submitted = false;
+
+    while (remaining.length > 0) {
+      if (this.inputInBracketedPaste) {
+        const closeAt = remaining.indexOf(DaemonPTYBridge.BRACKETED_PASTE_END);
+        if (closeAt < 0) return submitted;
+        this.inputInBracketedPaste = false;
+        remaining = remaining.slice(
+          closeAt + DaemonPTYBridge.BRACKETED_PASTE_END.length,
+        );
+        continue;
+      }
+
+      const openAt = remaining.indexOf(DaemonPTYBridge.BRACKETED_PASTE_START);
+      const outsidePaste = openAt < 0 ? remaining : remaining.slice(0, openAt);
+      if (/[\r\n]/.test(outsidePaste)) submitted = true;
+      if (openAt < 0) break;
+
+      this.inputInBracketedPaste = true;
+      remaining = remaining.slice(
+        openAt + DaemonPTYBridge.BRACKETED_PASTE_START.length,
+      );
+    }
+
+    return submitted;
   }
 
   // Prompt-based CWD detection. Parsing is shared with the local PTYBridge via
@@ -98,45 +183,47 @@ export class DaemonPTYBridge extends EventEmitter {
     this.agentDetector = agentDetector;
 
     this.sessionId = sessionId;
+    this.explicitTerminalStatus = false;
+    this.submittedTurnPending = false;
+    this.inputInBracketedPaste = false;
 
     const activityMonitor = new ActivityMonitor();
     this.activityMonitor = activityMonitor;
     activityMonitor.start(sessionId);
 
-    // Activity → idle notification
+    // Activity → idle notification. Once a detector or hook has already
+    // settled this turn, byte silence is weaker evidence and must not clear the
+    // explicit waiting/complete state five seconds later.
     this.idleUnsubscribe = activityMonitor.onActiveToIdle((ptyId) => {
+      if (this.explicitTerminalStatus) return;
       this.emit('idle', { sessionId: ptyId });
     });
-    // Activity → active notification (start of a sustained output burst).
-    // Also resets AgentDetector emission dedup inside the daemon process so
-    // turn N+1's idle prompt fires again even if its text is identical to
-    // turn N. The reset MUST happen in-process: AgentDetector instances
-    // live in the daemon, so the main-side DaemonNotificationRouter can't
-    // reach into them the way local-mode PTYBridge does (Codex P1).
+    // Activity → active notification. Passive bursts are accepted only while
+    // no explicit terminal state owns the pane. A submitted turn is re-armed by
+    // beginTurn(), so its very first output emits running even for a short reply.
     this.activeUnsubscribe = activityMonitor.onActive((ptyId) => {
-      // Resize-redraw guard (twin of PTYBridge local mode): a burst that
-      // starts right after a resize is the TUI repainting at the new
-      // geometry, not new agent activity — resetting the emission dedup
-      // there re-fires the unchanged idle footer.
-      //
-      // onActive fires EXACTLY ONCE per active-to-idle cycle, so skipping
-      // the reset outright (rather than deferring it) would permanently
-      // skip it for the rest of THIS cycle too — if a genuinely new turn's
-      // output continues into the same cycle (no 5s idle gap after the
-      // repaint), its completion would never see a fresh dedup state and
-      // would be silently deduped as a repeat (codex review catch, mirrors
-      // the local-mode PTYBridge fix). Defer the reset to fire once the
-      // guard window elapses instead of skipping it.
-      const elapsed = Date.now() - this.lastResizeAtMs;
-      if (elapsed < RESIZE_REDRAW_GUARD_MS) {
-        if (this.resizeGuardTimer) clearTimeout(this.resizeGuardTimer);
-        this.resizeGuardTimer = setTimeout(() => {
-          this.resizeGuardTimer = null;
+      if (this.explicitTerminalStatus) return;
+
+      const inputStartedTurn = this.submittedTurnPending;
+      this.submittedTurnPending = false;
+
+      // Real submitted input already reset detector dedup in noteInput(). For a
+      // passive startup/autonomous burst, retain the resize-redraw guard: a TUI
+      // repaint is not a new turn and must not make an unchanged footer emit
+      // another waiting notification.
+      if (!inputStartedTurn) {
+        const elapsed = Date.now() - this.lastResizeAtMs;
+        if (elapsed < RESIZE_REDRAW_GUARD_MS) {
+          if (this.resizeGuardTimer) clearTimeout(this.resizeGuardTimer);
+          this.resizeGuardTimer = setTimeout(() => {
+            this.resizeGuardTimer = null;
+            this.agentDetector?.resetEmissionState();
+          }, RESIZE_REDRAW_GUARD_MS - elapsed);
+        } else {
           this.agentDetector?.resetEmissionState();
-        }, RESIZE_REDRAW_GUARD_MS - elapsed);
-      } else {
-        this.agentDetector?.resetEmissionState();
+        }
       }
+
       // gate로 확정된 에이전트 이름을 active 이벤트에 함께 싣는다. main의
       // DaemonNotificationRouter는 daemon AgentDetector에 직접 닿지 못하지만,
       // 같은 daemon 프로세스인 여기서는 getLastAgent()가 닿는다. 이게 있어야
@@ -194,8 +281,10 @@ export class DaemonPTYBridge extends EventEmitter {
       }
     });
 
-    // Agent detection
+    // Agent detection. Apply status priority before forwarding the event so a
+    // same-chunk/full-screen redraw cannot race a terminal state back to running.
     this.agentUnsubscribe = agentDetector.onEvent((agentEvent) => {
+      this.noteAgentStatus(agentEvent.status);
       this.emit('agent', { sessionId, event: agentEvent });
     });
 
@@ -210,12 +299,26 @@ export class DaemonPTYBridge extends EventEmitter {
 
     // PTY data handler
     const onDataDisposable = ptyProcess.onData((data: string) => {
+      const buf = Buffer.from(data);
+
+      // Byte activity is weaker than a detector/hook terminal edge. Process it
+      // FIRST only while the pane is unsettled, so a waiting/complete pattern
+      // found in this same chunk is forwarded last and remains authoritative.
+      // While settled, ignore idle TUI repaints entirely until noteInput() sees
+      // a submitted turn (or an explicit running hook reopens the gate).
+      if (!this.muted && !this.explicitTerminalStatus) {
+        try {
+          activityMonitor.feed(sessionId, buf.length);
+        } catch {
+          // activity heuristics must never block detection or data forwarding.
+        }
+      }
+
       // AgentDetector는 순수 텍스트 분석(side effect 없음)이라 muted 구간에서도
       // 돌려야 한다. recovery 세션은 첫 resize 전까지 muted인데, 그 사이에
       // 에이전트 시작 배너("Claude Code vX" 등)가 출력되면 gate 정규식이 영구
       // 미활성화되어 이후 모든 status 감지가 죽는다(daemon mode agent detection
-      // 갭). feed만 muted 체크 앞으로 끌어올리고, ring buffer write·emit 등
-      // side effect는 여전히 muted로 차단해 geometry mismatch 오염은 막는다.
+      // 갭). activity보다 뒤에서 처리해 같은 chunk의 명시 상태가 최종 승자가 된다.
       try {
         agentDetector.feed(data);
       } catch {
@@ -227,9 +330,7 @@ export class DaemonPTYBridge extends EventEmitter {
       // window (Bug 2 in v2.8.0) doesn't pollute the ring buffer.
       if (this.muted) return;
       try {
-        const buf = Buffer.from(data);
         ringBuffer.write(buf);
-        activityMonitor.feed(sessionId, buf.length);
         oscParser.process(data);
 
         // Prompt-based CWD detection — fallback for shells WITHOUT the
@@ -254,7 +355,7 @@ export class DaemonPTYBridge extends EventEmitter {
         this.emit('data', buf);
       } catch (err) {
         // Still forward raw data even if parsing failed
-        this.emit('data', Buffer.from(data));
+        this.emit('data', buf);
       }
     });
     this.dataDisposable = () => onDataDisposable.dispose();
@@ -335,6 +436,9 @@ export class DaemonPTYBridge extends EventEmitter {
     }
 
     this.lastEmittedOscCwd = null;
+    this.explicitTerminalStatus = false;
+    this.submittedTurnPending = false;
+    this.inputInBracketedPaste = false;
     this.oscParser = null;
     this.agentDetector = null;
     this.activityMonitor = null;

--- a/src/daemon/__tests__/DaemonPTYBridge.turnPriority.test.ts
+++ b/src/daemon/__tests__/DaemonPTYBridge.turnPriority.test.ts
@@ -1,0 +1,235 @@
+// Turn-priority: which signal owns a pane's agent status.
+//
+// Two sources compete inside the daemon. Byte throughput (ActivityMonitor) is a
+// heuristic — a full-screen TUI redraw looks exactly like work. A detector or
+// hook lifecycle edge (waiting / complete / awaiting input) is authoritative.
+// Before this, an idle Claude repaint five seconds after a Stop hook resurrected
+// stale `running` metadata, so a pane that was actually blocked on a question
+// reported itself as busy.
+//
+// The rule these lock:
+//   1. An explicit terminal status SETTLES the turn. While settled, passive
+//      bytes are ignored entirely.
+//   2. Only a real submitted-input boundary (CR/LF outside bracketed paste, or
+//      an explicit forceSubmitted control) re-opens the gate.
+//   3. An explicit `running` edge also re-opens it (autonomous work).
+//   4. Within one chunk, activity is processed FIRST so a terminal pattern found
+//      in that same chunk is forwarded LAST and wins.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { IPty } from 'node-pty';
+import { DaemonPTYBridge } from '../DaemonPTYBridge';
+import { RingBuffer } from '../RingBuffer';
+
+const BIG = 'x'.repeat(3000); // > ActivityMonitor's 2 KB active threshold
+const PASTE_START = '\x1b[200~';
+const PASTE_END = '\x1b[201~';
+
+function makeFakePty(): { pty: IPty; feed: (data: string) => void } {
+  let dataHandler: ((data: string) => void) | null = null;
+  const pty = {
+    onData: (cb: (data: string) => void) => {
+      dataHandler = cb;
+      return { dispose: () => { dataHandler = null; } };
+    },
+    onExit: () => ({ dispose: () => {} }),
+  } as unknown as IPty;
+  return { pty, feed: (data: string) => dataHandler?.(data) };
+}
+
+describe('DaemonPTYBridge turn priority', () => {
+  let bridge: DaemonPTYBridge;
+  let feed: (data: string) => void;
+  let idle: string[];
+  let active: string[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    bridge = new DaemonPTYBridge();
+    const fake = makeFakePty();
+    feed = fake.feed;
+    idle = [];
+    active = [];
+    bridge.on('idle', (e: { sessionId: string }) => idle.push(e.sessionId));
+    bridge.on('active', (e: { sessionId: string }) => active.push(e.sessionId));
+    bridge.setupDataForwarding(fake.pty, new RingBuffer(65536), 'sess-1');
+  });
+
+  afterEach(() => {
+    bridge.cleanup();
+    vi.useRealTimers();
+  });
+
+  describe('baseline (unsettled pane)', () => {
+    it('reports a passive burst as active and then idle', () => {
+      feed(BIG);
+      expect(active).toEqual(['sess-1']);
+      vi.advanceTimersByTime(5000);
+      expect(idle).toEqual(['sess-1']);
+    });
+  });
+
+  describe('an explicit terminal status settles the turn', () => {
+    it('suppresses the idle notification that would clear it', () => {
+      feed(BIG);
+      bridge.noteAgentStatus('waiting');
+      vi.advanceTimersByTime(10_000);
+      // The pane IS waiting; a byte-silence idle event five seconds later is
+      // weaker evidence and must not overwrite it.
+      expect(idle).toEqual([]);
+    });
+
+    it('ignores a later full-screen repaint entirely', () => {
+      bridge.noteAgentStatus('complete');
+      active.length = 0;
+      feed(BIG);
+      feed(BIG);
+      vi.advanceTimersByTime(10_000);
+      expect(active).toEqual([]);
+      expect(idle).toEqual([]);
+    });
+
+    it.each(['waiting', 'complete', 'awaiting_input', 'error'] as const)(
+      'treats %s as terminal',
+      (status) => {
+        bridge.noteAgentStatus(status);
+        active.length = 0;
+        feed(BIG);
+        expect(active).toEqual([]);
+      },
+    );
+
+    it('an explicit running edge re-opens the gate for autonomous work', () => {
+      bridge.noteAgentStatus('complete');
+      feed(BIG);
+      expect(active).toEqual([]);
+
+      bridge.noteAgentStatus('running');
+      feed(BIG);
+      expect(active).toEqual(['sess-1']);
+    });
+  });
+
+  describe('noteInput — what counts as a submitted turn', () => {
+    it('ordinary typing does NOT re-open the gate', () => {
+      bridge.noteAgentStatus('waiting');
+      bridge.noteInput('git st');
+      feed(BIG);
+      expect(active).toEqual([]);
+    });
+
+    it('a CR re-opens it, and the very first output byte reports running', () => {
+      bridge.noteAgentStatus('waiting');
+      bridge.noteInput('git status\r');
+      feed('ok'); // 2 bytes — far below the 2 KB passive threshold
+      expect(active).toEqual(['sess-1']);
+    });
+
+    it('an LF also counts as submitted', () => {
+      bridge.noteAgentStatus('complete');
+      bridge.noteInput('run\n');
+      feed('.');
+      expect(active).toEqual(['sess-1']);
+    });
+
+    it('newlines INSIDE a bracketed paste are inert (a draft, not a submit)', () => {
+      bridge.noteAgentStatus('waiting');
+      bridge.noteInput(`${PASTE_START}line one\nline two\n${PASTE_END}`);
+      feed('.');
+      expect(active).toEqual([]);
+    });
+
+    it('the CR that follows a pasted draft IS the submit (separate writes)', () => {
+      bridge.noteAgentStatus('waiting');
+      bridge.noteInput(`${PASTE_START}draft\nbody${PASTE_END}`);
+      feed('.');
+      expect(active).toEqual([]);
+
+      bridge.noteInput('\r');
+      feed('.');
+      expect(active).toEqual(['sess-1']);
+    });
+
+    it('tracks an UNTERMINATED paste across writes and stays inert', () => {
+      bridge.noteAgentStatus('waiting');
+      bridge.noteInput(`${PASTE_START}first\n`);
+      bridge.noteInput('second\n');
+      feed('.');
+      expect(active).toEqual([]);
+    });
+
+    it('a CR before the paste opens still counts (text outside the paste)', () => {
+      bridge.noteAgentStatus('waiting');
+      bridge.noteInput(`go\r${PASTE_START}later\n`);
+      feed('.');
+      expect(active).toEqual(['sess-1']);
+    });
+
+    it('forceSubmitted arms a control that carries no Enter (approval digit)', () => {
+      // An approval answer is a bare "2" or ESC — no CR — yet it definitely
+      // resumes the blocked turn.
+      bridge.noteAgentStatus('awaiting_input');
+      bridge.noteInput('2', true);
+      feed('.');
+      expect(active).toEqual(['sess-1']);
+    });
+
+    it('without forceSubmitted the same bare digit stays inert', () => {
+      bridge.noteAgentStatus('awaiting_input');
+      bridge.noteInput('2');
+      feed('.');
+      expect(active).toEqual([]);
+    });
+  });
+
+  describe('same-chunk ordering', () => {
+    it('a terminal status found in the SAME chunk is the final word', () => {
+      const seen: string[] = [];
+      bridge.on('active', () => seen.push('active'));
+      bridge.on('agent', (e: { event: { status: string } }) => seen.push(`agent:${e.event.status}`));
+
+      // A big Claude frame that both looks like heavy work AND contains the
+      // idle-prompt footer. Activity must be emitted before the agent event so
+      // the renderer's last write is the authoritative 'waiting'.
+      feed(`Claude Code v2.1.172\n${BIG}\n  shift+tab to cycle modes\n`);
+
+      const lastAgent = seen.filter((s) => s.startsWith('agent:')).at(-1);
+      expect(lastAgent).toBe('agent:waiting');
+      expect(seen.indexOf('active')).toBeLessThan(seen.lastIndexOf(lastAgent!));
+    });
+
+    it('the settle from that chunk suppresses the following idle', () => {
+      feed(`Claude Code v2.1.172\n${BIG}\n  shift+tab to cycle modes\n`);
+      vi.advanceTimersByTime(10_000);
+      expect(idle).toEqual([]);
+    });
+  });
+
+  describe('lifecycle reset', () => {
+    it('cleanup() clears the settled state so a reused bridge starts fresh', () => {
+      bridge.noteAgentStatus('waiting');
+      bridge.cleanup();
+
+      // cleanup() also calls removeAllListeners(), so a reused bridge has to be
+      // re-subscribed — re-attach before asserting on the next session.
+      const reused: string[] = [];
+      bridge.on('active', (e: { sessionId: string }) => reused.push(e.sessionId));
+
+      const fake = makeFakePty();
+      bridge.setupDataForwarding(fake.pty, new RingBuffer(65536), 'sess-2');
+      fake.feed(BIG);
+      expect(reused).toEqual(['sess-2']);
+    });
+
+    it('a fresh setupDataForwarding on a settled bridge also clears the gate', () => {
+      // The reset is deliberately belt-and-braces: setupDataForwarding resets
+      // too, so a session swap that skipped cleanup() cannot inherit a settle.
+      bridge.noteAgentStatus('complete');
+      active.length = 0;
+
+      const fake = makeFakePty();
+      bridge.setupDataForwarding(fake.pty, new RingBuffer(65536), 'sess-3');
+      fake.feed(BIG);
+      expect(active).toEqual(['sess-3']);
+    });
+  });
+});

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -156,6 +156,9 @@ function createApprovalRegistry(sessionManager: DaemonSessionManager): ApprovalR
       const managed = sessionManager.getSession(sessionId);
       if (!managed) return false;
       managed.ptyProcess.write(data);
+      // Approval choices (digit/ESC) submit immediately without CR/LF. Mark
+      // this as a real turn edge only after the PTY accepted the write.
+      managed.bridge.noteInput(data, true);
       return true;
     },
     log: (level, message) => log(level, message),
@@ -1863,9 +1866,12 @@ function registerRpcHandlers(
       managed.bridge.on('data', onData);
       sessionDataListeners.set(p.id, { bridge: managed.bridge, listener: onData });
 
-      // Forward client input to PTY
+      // Forward client input to PTY. noteInput ignores ordinary typing and
+      // bracketed-paste newlines; only the submitted CR/LF re-arms running.
       pipe.onInput((data: Buffer) => {
-        managed.ptyProcess.write(data.toString());
+        const input = data.toString();
+        managed.ptyProcess.write(input);
+        managed.bridge.noteInput(input);
       });
 
       try {
@@ -2378,6 +2384,10 @@ function registerRpcHandlers(
     hookIngest = new HookIngest({
       listLiveSessions: () => sessionManager.listLiveSessions(),
       emitAgentEvent: (sessionId, data) => {
+        // Hook Stop/awaiting-input is authoritative inside the same daemon that
+        // owns byte activity. Settle the bridge before broadcasting so a later
+        // idle repaint cannot race the renderer back to stale running.
+        sessionManager.getSession(sessionId)?.bridge.noteAgentStatus(data.status);
         const event: DaemonEvent = { type: 'agent.event', sessionId, data };
         pipeServer.broadcast(event);
       },
@@ -4725,6 +4735,9 @@ async function main(): Promise<void> {
       const managed = sessionManager.getSession(sessionId);
       if (!managed) throw new Error(`session ${sessionId} is gone`);
       managed.ptyProcess.write(data);
+      // ChannelWakeWorker sends text and Enter separately. The text write is a
+      // draft; its later CR is the submitted turn boundary noteInput detects.
+      managed.bridge.noteInput(data);
     },
     // Envelope discipline (channelEventEnvelope.ts, plan R2 lesson): the
     // control pipe carries DaemonEvent {type, sessionId, data} — a raw

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -1708,6 +1708,9 @@ export class WebTerminalServer {
       const body = Buffer.concat(chunks).toString('utf8');
       try {
         managed.ptyProcess.write(body);
+        // A phone can paste drafts containing newlines; bridge.noteInput keeps
+        // bracketed-paste bodies inert and only re-arms on a submitted CR/LF.
+        managed.bridge.noteInput?.(body);
       } catch (err) {
         return this.json(res, 500, { error: `write failed: ${errMsg(err)}` });
       }

--- a/src/main/pty/ActivityMonitor.ts
+++ b/src/main/pty/ActivityMonitor.ts
@@ -79,6 +79,26 @@ export class ActivityMonitor {
     });
   }
 
+  /**
+   * Re-arm a cycle from an explicit submitted-input boundary. Unlike passive
+   * throughput detection, the next output byte is enough to prove this turn is
+   * running: short agent replies must not remain stuck in the previous
+   * waiting/complete state just because they never cross the 2 KB threshold.
+   * No callback fires until output actually arrives.
+   */
+  beginTurn(ptyId: string): void {
+    const s = this.states.get(ptyId);
+    if (!s) return;
+    if (s.idleTimer) clearTimeout(s.idleTimer);
+    s.bytes = 0;
+    s.windowStart = Date.now();
+    s.active = true;
+    s.notified = false;
+    s.activeFired = false;
+    s.idleTimer = null;
+    s.lastReschedule = 0;
+  }
+
   feed(ptyId: string, byteCount: number): void {
     const s = this.states.get(ptyId);
     if (!s) return;

--- a/src/main/pty/__tests__/ActivityMonitor.test.ts
+++ b/src/main/pty/__tests__/ActivityMonitor.test.ts
@@ -177,4 +177,92 @@ describe('ActivityMonitor', () => {
       expect(cb).toHaveBeenCalledTimes(1); // not 2
     });
   });
+
+  // beginTurn is the explicit-input counterpart to passive throughput
+  // detection. Byte volume is a heuristic for "the agent is working"; a
+  // submitted Enter is PROOF. A short reply ("Done.") never crosses the 2 KB
+  // threshold, so without this the pane stays stuck in the previous
+  // waiting/complete state for the whole turn.
+  describe('beginTurn (explicit submitted-input boundary)', () => {
+    let activeFired: string[];
+
+    beforeEach(() => {
+      activeFired = [];
+      monitor.onActive((id) => activeFired.push(id));
+    });
+
+    it('does not fire anything on its own — output must still arrive', () => {
+      monitor.start('p1');
+      monitor.beginTurn('p1');
+      expect(activeFired).toEqual([]);
+      expect(fired).toEqual([]);
+    });
+
+    it('makes the FIRST output byte emit active, even far below the threshold', () => {
+      monitor.start('p1');
+      monitor.beginTurn('p1');
+      monitor.feed('p1', 1); // one byte
+      expect(activeFired).toEqual(['p1']);
+    });
+
+    it('without beginTurn, a sub-threshold reply emits nothing (the bug it fixes)', () => {
+      monitor.start('p1');
+      monitor.feed('p1', 1);
+      expect(activeFired).toEqual([]);
+    });
+
+    it('re-arms a cycle that had already notified idle', () => {
+      monitor.start('p1');
+      monitor.feed('p1', 3000);
+      vi.advanceTimersByTime(5000);
+      expect(fired).toEqual(['p1']);
+      activeFired.length = 0;
+
+      // A new human turn: a tiny reply must still be reported as running, and
+      // must be able to reach idle again afterwards.
+      monitor.beginTurn('p1');
+      monitor.feed('p1', 5);
+      expect(activeFired).toEqual(['p1']);
+      vi.advanceTimersByTime(5000);
+      expect(fired).toEqual(['p1', 'p1']);
+    });
+
+    it('clears a pending idle timer so the previous cycle cannot fire late', () => {
+      monitor.start('p1');
+      monitor.feed('p1', 3000);
+      // Half-way through the old idle countdown, a new turn starts.
+      vi.advanceTimersByTime(2_500);
+      monitor.beginTurn('p1');
+      // The old timer must be gone; nothing arrives, so nothing fires.
+      vi.advanceTimersByTime(10_000);
+      expect(fired).toEqual([]);
+    });
+
+    it('is per-pty and does not arm a sibling', () => {
+      monitor.start('p1');
+      monitor.start('p2');
+      monitor.beginTurn('p1');
+      monitor.feed('p2', 1);
+      expect(activeFired).toEqual([]);
+      monitor.feed('p1', 1);
+      expect(activeFired).toEqual(['p1']);
+    });
+
+    it('is a no-op for an unknown pty', () => {
+      expect(() => monitor.beginTurn('does-not-exist')).not.toThrow();
+      vi.advanceTimersByTime(10_000);
+      expect(fired).toEqual([]);
+      expect(activeFired).toEqual([]);
+    });
+
+    it('is a no-op after stop() (no resurrection of a disposed pane)', () => {
+      monitor.start('p1');
+      monitor.stop('p1');
+      monitor.beginTurn('p1');
+      monitor.feed('p1', 5000);
+      vi.advanceTimersByTime(10_000);
+      expect(activeFired).toEqual([]);
+      expect(fired).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
A pane that was actually blocked on a question kept reporting `running`. Byte
throughput and lifecycle edges compete inside the daemon, and throughput was
winning: an idle Claude repaint five seconds after a Stop hook resurrected stale
`running` metadata.

## What changed
`DaemonPTYBridge` now gives an explicit detector/hook terminal state priority over
passive bytes:

1. A terminal status (`waiting` / `complete` / `awaiting_input` / `error`)
   **settles** the turn. While settled, idle repaints are ignored entirely.
2. Only a real submitted-input boundary re-opens the gate — a CR/LF outside
   bracketed paste, or an explicit control that carries no Enter
   (`noteInput(data, true)` for an approval digit/ESC).
3. An explicit `running` edge also re-opens it, for autonomous work.
4. Within one chunk, activity is processed **first** so a terminal pattern found in
   that same chunk is forwarded last and remains authoritative.

`noteInput` tracks bracketed paste across writes, so newlines inside a pasted
draft stay inert and only the later CR counts as a submit.

`ActivityMonitor.beginTurn()` re-arms a cycle from that submitted boundary: after
a real Enter the next output byte is enough to prove the turn is running, so a
short reply that never crosses the 2 KB threshold no longer stays stuck in the
previous state.

Call sites: the approval registry (digit/ESC, force-submitted), pipe client input,
the phone HTTP write, the ChannelWakeWorker, and hook-driven agent events (which
settle the bridge before broadcasting).

## Tests
21 new cases: baseline burst behaviour, all four terminal states, the running
re-open, typing vs CR vs LF, bracketed-paste inertness including an unterminated
paste across writes, force-submitted vs bare digit, same-chunk ordering, and both
reset paths. Plus 9 `beginTurn` cases including the sub-threshold reply that is
the actual bug.

20 of 21 fail against `origin/main`; after the change:
`npx vitest run src/daemon/__tests__/ src/main/pty/__tests__/ src/daemon/web/__tests__/` → 1109 passed
`npm run build:daemon` → clean
