### PR TITLE
Promote cap-skipped suspended sessions on demand

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -192,14 +192,11 @@
 - **Depends on:** 알림 파이프라인 복구 ship + 사용자가 minimize 사용 빈도 확인
 - **Priority:** P2
 
-## Fix B — Scrollback restore cap-aware suspended-session promote
-- **What:** `daemon.listSessions`에 `{includeSuspended}` 파라미터 추가 + `daemon.promoteSession(id)` 신규 RPC. `AppLayout.reconcilePtys` fallback 직전에 promote 시도. cap=40 초과로 자동 복구되지 못한 suspended session도 reconnect 가능하게.
-- **Why:** Fix 0 (mount gate + saved ptyId 보존)는 cap *안*의 graceful Quit session만 복원. cap *초과* session (50+ panes 사용자, 또는 force-kill 후 daemon snapshot은 살아있지만 cap에 밀린 case)은 여전히 fresh terminal. design doc §5 + Update에 spec.
-- **Pros:** scrollback restore feature 100% 완성 (cap 안 + 초과 모두). power user 사용성 결정적.
-- **Cons:** RPC 2개 추가 + dynamic test R2-R5 (cap-skipped promote 4 scenario). Effort ~3-4시간.
-- **Context:** `docs/internal/scrollback-restore-design.md` §5 (Fix B) — full implementation sketch + failure modes + test matrix 이미 작성됨. 구현 시 그대로 따라가면 됨.
-- **Depends on:** Fix 0 (plan `wiggly-booping-cascade.md`) ship + 최소 1주 dogfood. dogfood에서 stale-state / RPC guard / generation race 회귀 없는 것을 확인한 *후*에야 Fix B 진행 (한 번에 두 가지 architecture change 검증 어려움).
-- **Priority:** P1 (Fix 0 dogfood 통과 후)
+## ✅ Fix B — cap-aware suspended-session promote (2026-07-30)
+- `daemon.listSessions({includeSuspended})` + 신규 `daemon.promoteSession(id)`. `pty:promote` IPC를 통해 `AppLayout.reconcilePtys`가 파괴적 clear **직전에** promote 시도. cap 초과로 자동 복구되지 못한 session도 ptyId를 유지한 채 reconnect.
+- promote 실패(cap hit / spawn 실패)는 기존 clear 경로로 그대로 흘러간다. `pty.promote`가 없는 구버전 main·local mode는 Fix B 이전 동작 유지.
+- 이미 active면 멱등 성공, suspended가 아니면 NOT_FOUND, transient ConPTY error 87만 제한 재시도.
+- **남은 검증:** 실제 PTY spawn·scrollback dump 재생·cap RESOURCE_EXHAUSTED 경로는 라이브 데몬 dogfood 필요. 구조 불변식은 `pty.handler.promote.test.ts` + `appLayout.sessionSaveInvariants.test.ts`가 고정.
 
 ## (Phase 2 / Eureka) Agent stop-hook OSC 9 signal — promoted to design doc
 - **Status:** Draft plan exists at `plans/agent-hook-integration.md` (209 lines).

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -2031,13 +2031,15 @@ function registerRpcHandlers(
   });
 
   // daemon.listSessions
-  pipeServer.onRpc('daemon.listSessions', async () => {
+  pipeServer.onRpc('daemon.listSessions', async (rawParams) => {
+    const params = (rawParams ?? {}) as Record<string, unknown>;
+    const includeSuspended = params['includeSuspended'] === true;
     // X8: join the supervisor's volatile runtime (restart counts, pending
     // backoff) onto supervised sessions — additive field consumed by
     // `wmux list --json` and the sidebar badge.
     // X6 ②: attach resumeAgent ONLY for sessions recovered-this-boot that were
     // interactive agents (recoveredAgentShellIds) — drives the resume pill.
-    return sessionManager.listSessions().map((s) => {
+    const activeSessions = sessionManager.listSessions().map((s) => {
       // The slug is held in the map (captured from the persisted session at
       // recovery) — NOT read off the live meta, which is a fresh shell here.
       const resumeAgent = recoveredAgentShellIds.get(s.id);
@@ -2111,6 +2113,117 @@ function registerRpcHandlers(
         ...(agentProcessAlive !== undefined ? { agentProcessAlive } : {}),
       };
     });
+
+    // Fix B: when includeSuspended is requested, append cap-skipped suspended
+    // sessions from the persisted state that aren't already in the active set.
+    if (includeSuspended) {
+      const activeIdSet = new Set(activeSessions.map((s: { id: string }) => s.id));
+      const persistedState = stateWriter.load();
+      const suspendedEntries = persistedState.sessions
+        .filter((s) => s.state === 'suspended' && !activeIdSet.has(s.id))
+        .map((s) => ({
+          id: s.id,
+          shell: s.cmd,
+          state: 'suspended' as const,
+          cwd: s.cwd,
+          createdAt: s.createdAt,
+          lastActivity: s.lastActivity,
+        }));
+      return [...activeSessions, ...suspendedEntries];
+    }
+    return activeSessions;
+  });
+
+  // daemon.promoteSession — on-demand recovery of a cap-skipped suspended
+  // session. Boot recovery honours a session cap, so a workspace beyond the cap
+  // came back with its ptyId absent and reconcile destructively cleared it. This
+  // lets the renderer spawn exactly the one session it still needs, keeping the
+  // ptyId stable so scrollback restores from the daemon's ring buffer.
+  pipeServer.onRpc('daemon.promoteSession', async (rawParams) => {
+    const params = (rawParams ?? {}) as Record<string, unknown>;
+    const sessionId = typeof params['id'] === 'string' ? params['id'] : '';
+    if (!sessionId) {
+      return { ok: false, error: { code: 'INVALID_PARAMS', message: 'id is required' } };
+    }
+
+    // Idempotent: if already active, succeed silently.
+    const existing = sessionManager.getSession(sessionId);
+    if (existing) {
+      return { ok: true, alreadyActive: true };
+    }
+
+    const state = stateWriter.load();
+    const session = state.sessions.find((s) => s.id === sessionId && s.state === 'suspended');
+    if (!session) {
+      return { ok: false, error: { code: 'NOT_FOUND', message: `No suspended session with id ${sessionId}` } };
+    }
+
+    // createSession enforces the same cap as boot recovery and throws
+    // RESOURCE_EXHAUSTED when it is already full.
+    try {
+      let scrollbackData: Buffer | undefined;
+      if (session.bufferDumpPath && fs.existsSync(session.bufferDumpPath)) {
+        scrollbackData = fs.readFileSync(session.bufferDumpPath);
+      }
+      const cwd = fs.existsSync(session.cwd) ? session.cwd : os.homedir();
+
+      const PROMOTE_RETRIES = 4;
+      let promoted: ReturnType<typeof sessionManager.createSession> | undefined;
+      let lastErr: unknown;
+      for (let attempt = 1; attempt <= PROMOTE_RETRIES; attempt++) {
+        try {
+          promoted = sessionManager.createSession({
+            id: session.id,
+            cmd: session.cmd,
+            cwd,
+            spawnCwd: session.spawnCwd,
+            env: session.env,
+            cols: session.cols,
+            rows: session.rows,
+            agent: session.agent,
+            createdAt: session.createdAt,
+            lastActivity: session.lastActivity,
+            deadTtlHours: session.deadTtlHours,
+            exec: session.exec,
+            supervision: session.supervision,
+            scrollbackData,
+            deferOutput: true,
+          });
+          break;
+        } catch (err) {
+          lastErr = err;
+          const msg = err instanceof Error ? err.message : String(err);
+          // ConPTY error 87 is the known transient spawn race; anything else is
+          // a real failure and must not be retried.
+          if (!msg.includes('error code: 87')) break;
+          if (attempt < PROMOTE_RETRIES) {
+            await new Promise((resolve) => setTimeout(resolve, 200 + attempt * 100));
+          }
+        }
+      }
+      if (!promoted) {
+        throw lastErr ?? new Error('PTY spawn failed during promote');
+      }
+
+      processMonitor.watch(promoted.id, promoted.pid, () => {
+        const managed = sessionManager.getSession(promoted!.id);
+        if (managed && managed.meta.state !== 'dead' && managed.meta.state !== 'suspended') {
+          managed.meta.state = 'dead';
+          sessionManager.emit('session:died', { id: promoted!.id, exitCode: null, reason: 'promote' });
+        }
+      });
+
+      if (session.bufferDumpPath) {
+        try { fs.unlinkSync(session.bufferDumpPath); } catch { /* ignore */ }
+      }
+
+      log('info', `[promote] Promoted suspended session ${sessionId} in ${cwd}`);
+      return { ok: true, alreadyActive: false };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log('error', `[promote] Failed to promote session ${sessionId}: ${msg}`);
+      return { ok: false, error: { code: 'SPAWN_FAILED', message: msg } };
+    }
   });
 
   // wmux web (read-only-by-default browser terminal). Lives in the daemon so it

--- a/src/main/ipc/__tests__/pty.handler.promote.test.ts
+++ b/src/main/ipc/__tests__/pty.handler.promote.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Fix B — cap-skipped suspended session promote.
+ *
+ * Boot recovery honours a session cap, so a workspace beyond the cap came back
+ * with its ptyId absent; reconcile then destructively cleared it and the pane
+ * lost both its identity and its scrollback. `daemon.promoteSession` spawns
+ * exactly the one session the renderer still needs, keeping the ptyId stable so
+ * the daemon's ring buffer restores.
+ *
+ * Structural test (house pattern: pty.handler.surfaceIdExposure.test.ts,
+ * appLayout.sessionSaveInvariants.test.ts). The chain crosses three untyped
+ * hops (renderer IPC → daemon RPC → node-pty spawn) and the daemon half only
+ * exists inside a running daemon process, so tsc and unit tests cannot catch a
+ * dropped guard. These scans fail if a refactor removes the idempotency check,
+ * the suspended-only lookup, the transient-spawn retry bound, or the
+ * error-shape the renderer branches on.
+ *
+ * NOT covered here (needs a live daemon): the actual PTY spawn, the scrollback
+ * dump replay, and the session-cap RESOURCE_EXHAUSTED path.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const srcRoot = path.join(__dirname, '..', '..', '..');
+
+describe('pty.handler PTY_PROMOTE — renderer→daemon hop', () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, '..', 'handlers', 'pty.handler.ts'),
+    'utf-8',
+  );
+
+  function promoteRegion(): string {
+    const start = source.indexOf('ipcMain.handle(IPC.PTY_PROMOTE');
+    expect(start, 'PTY_PROMOTE handler not found').toBeGreaterThanOrEqual(0);
+    return source.slice(start, start + 1200);
+  }
+
+  it('is registered only in daemon mode (local mode has no daemon to promote in)', () => {
+    const promoteAt = source.indexOf('ipcMain.handle(IPC.PTY_PROMOTE');
+    const guardAt = source.lastIndexOf('if (useDaemon && daemonClient)', promoteAt);
+    expect(guardAt).toBeGreaterThanOrEqual(0);
+    expect(guardAt).toBeLessThan(promoteAt);
+  });
+
+  it('rejects an empty id before touching the daemon', () => {
+    expect(promoteRegion()).toMatch(/if \(!id\) return \{ success: false/);
+  });
+
+  it('forwards to daemon.promoteSession and normalizes the reply the renderer reads', () => {
+    const region = promoteRegion();
+    expect(region).toMatch(/daemonClient\.rpc\('daemon\.promoteSession', \{ id \}\)/);
+    expect(region).toMatch(/if \(res\.ok\) return \{ success: true \}/);
+    // A failure must carry a message, or reconcile logs `undefined` and the
+    // operator cannot tell a cap hit from a spawn crash.
+    expect(region).toMatch(/success: false, error: res\.error\?\.message \?\? 'promote failed'/);
+  });
+
+  it('removes the handler on cleanup so a daemon reconnect cannot double-register', () => {
+    const removals = source.match(/removeHandler\(IPC\.PTY_PROMOTE\)/g) ?? [];
+    expect(removals.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('PTY_LIST threads includeSuspended through to the daemon', () => {
+    const start = source.indexOf('ipcMain.handle(IPC.PTY_LIST');
+    const region = source.slice(start, start + 1500);
+    expect(region).toMatch(/opts\?\.includeSuspended === true/);
+    expect(region).toMatch(/daemonClient\.rpc\('daemon\.listSessions', \{ includeSuspended \}\)/);
+  });
+});
+
+describe('daemon.promoteSession — guards', () => {
+  const source = fs.readFileSync(path.join(srcRoot, 'daemon', 'index.ts'), 'utf-8');
+
+  function promoteRegion(): string {
+    const start = source.indexOf("pipeServer.onRpc('daemon.promoteSession'");
+    expect(start, 'daemon.promoteSession not registered').toBeGreaterThanOrEqual(0);
+    const end = source.indexOf('pipeServer.onRpc(', start + 1);
+    return source.slice(start, end > 0 ? end : start + 6000);
+  }
+
+  it('is idempotent — an already-active session succeeds without respawning', () => {
+    const region = promoteRegion();
+    const existingAt = region.indexOf('sessionManager.getSession(sessionId)');
+    const createAt = region.indexOf('sessionManager.createSession');
+    expect(existingAt).toBeGreaterThanOrEqual(0);
+    expect(existingAt).toBeLessThan(createAt);
+    expect(region).toMatch(/return \{ ok: true, alreadyActive: true \}/);
+  });
+
+  it('only promotes a session the persisted state records as SUSPENDED', () => {
+    const region = promoteRegion();
+    expect(region).toMatch(/s\.id === sessionId && s\.state === 'suspended'/);
+    expect(region).toMatch(/code: 'NOT_FOUND'/);
+  });
+
+  it('validates the id parameter', () => {
+    expect(promoteRegion()).toMatch(/code: 'INVALID_PARAMS'/);
+  });
+
+  it('retries ONLY the known transient ConPTY spawn race, and with a bound', () => {
+    const region = promoteRegion();
+    expect(region).toMatch(/PROMOTE_RETRIES = \d+/);
+    // A non-transient failure must break immediately rather than burn the budget.
+    expect(region).toMatch(/if \(!msg\.includes\('error code: 87'\)\) break;/);
+  });
+
+  it('reuses the persisted geometry and identity rather than inventing new ones', () => {
+    const region = promoteRegion();
+    for (const field of ['id:', 'cmd:', 'cols:', 'rows:', 'agent:', 'createdAt:', 'supervision:']) {
+      expect(region, `createSession must pass ${field}`).toContain(field);
+    }
+    // The ptyId is the whole point: a new id would lose the pane binding.
+    expect(region).toMatch(/id: session\.id/);
+  });
+
+  it('falls back to the home directory when the recorded cwd is gone', () => {
+    expect(promoteRegion()).toMatch(/fs\.existsSync\(session\.cwd\) \? session\.cwd : os\.homedir\(\)/);
+  });
+
+  it('reports a spawn failure as a structured error instead of throwing at the pipe', () => {
+    expect(promoteRegion()).toMatch(/code: 'SPAWN_FAILED'/);
+  });
+
+  it('starts process monitoring for the promoted session', () => {
+    // Without this the promoted pane would never be marked dead when it exits.
+    expect(promoteRegion()).toMatch(/processMonitor\.watch\(/);
+  });
+
+  it('daemon.listSessions appends suspended entries ONLY when asked', () => {
+    const start = source.indexOf("pipeServer.onRpc('daemon.listSessions'");
+    const region = source.slice(start, source.indexOf("pipeServer.onRpc('daemon.promoteSession'"));
+    expect(region).toMatch(/includeSuspended = params\['includeSuspended'\] === true/);
+    expect(region).toMatch(/if \(includeSuspended\) \{/);
+    // No duplicates: an id already in the active list must not be re-added.
+    expect(region).toMatch(/!activeIdSet\.has\(s\.id\)/);
+    // And the default (unscoped) reply must stay exactly the active list.
+    expect(region).toMatch(/return activeSessions;/);
+  });
+});

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -772,8 +772,9 @@ export function registerPTYHandlers(
   // pty:list
   ipcMain.removeHandler(IPC.PTY_LIST);
   if (useDaemon && daemonClient) {
-    ipcMain.handle(IPC.PTY_LIST, wrapHandler(IPC.PTY_LIST, async () => {
-      const sessions = await daemonClient.rpc('daemon.listSessions', {}) as Array<{
+    ipcMain.handle(IPC.PTY_LIST, wrapHandler(IPC.PTY_LIST, async (_event: Electron.IpcMainInvokeEvent, opts?: { includeSuspended?: boolean }) => {
+      const includeSuspended = opts?.includeSuspended === true;
+      const sessions = await daemonClient.rpc('daemon.listSessions', { includeSuspended }) as Array<{
         id: string;
         cmd: string;
         state: string;
@@ -871,6 +872,15 @@ export function registerPTYHandlers(
   // pty:reconnect
   ipcMain.removeHandler(IPC.PTY_RECONNECT);
   if (useDaemon && daemonClient) {
+    // Fix B — pty:promote: on-demand recovery of a cap-skipped suspended session.
+    ipcMain.removeHandler(IPC.PTY_PROMOTE);
+    ipcMain.handle(IPC.PTY_PROMOTE, wrapHandler(IPC.PTY_PROMOTE, async (_event: Electron.IpcMainInvokeEvent, id: string) => {
+      if (!id) return { success: false, error: 'id is required' };
+      const res = await daemonClient.rpc('daemon.promoteSession', { id }) as { ok: boolean; error?: { message: string } };
+      if (res.ok) return { success: true };
+      return { success: false, error: res.error?.message ?? 'promote failed' };
+    }));
+
     ipcMain.handle(IPC.PTY_RECONNECT, wrapHandler(IPC.PTY_RECONNECT, async (_event: Electron.IpcMainInvokeEvent, id: string) => {
       try {
         const sessions = await daemonClient.rpc('daemon.listSessions', {}) as Array<{ id: string; cmd: string; state: string; pid?: number; cwd?: string }>;
@@ -1228,6 +1238,7 @@ export function registerPTYHandlers(
     ipcMain.removeHandler(IPC.PTY_RESIZE);
     ipcMain.removeHandler(IPC.PTY_DISPOSE);
     ipcMain.removeHandler(IPC.PTY_LIST);
+    ipcMain.removeHandler(IPC.PTY_PROMOTE);
     ipcMain.removeHandler(IPC.PTY_RECONNECT);
     ipcMain.removeHandler(IPC.PTY_RESYNC);
     ipcMain.removeHandler(IPC.SUPERVISE_REARM);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -58,11 +58,14 @@ const electronAPI = {
     // `supervision` (X8) is additive and present only on supervised daemon-mode
     // sessions — the renderer uses it to hydrate its supervision slice on boot
     // and daemon-reconnect. Absent in local mode and for unsupervised panes.
-    list: () =>
+    // `includeSuspended` (Fix B) additionally returns cap-skipped suspended
+    // sessions from the persisted state so reconcile can promote one on demand
+    // instead of destructively clearing its ptyId.
+    list: (opts?: { includeSuspended?: boolean }) =>
       // `surfaceId` (axis B, reboot-reattach): present only on sessions created
       // WITH a WMUX_SURFACE_ID (Terminal self-create path); reconcile uses it to
       // rebind a stale ptyId to the surviving session after a reboot.
-      ipcRenderer.invoke(IPC.PTY_LIST) as Promise<{ id: string; shell: string; surfaceId?: string; createdAt?: string; supervision?: { status: 'armed' | 'stopped'; restartCount: number }; resumeAgent?: string; resumeBinding?: ResumeBinding; commandRunning?: boolean; agentProcessAlive?: boolean }[]>,
+      ipcRenderer.invoke(IPC.PTY_LIST, opts) as Promise<{ id: string; shell: string; surfaceId?: string; createdAt?: string; state?: string; cwd?: string; supervision?: { status: 'armed' | 'stopped'; restartCount: number }; resumeAgent?: string; resumeBinding?: ResumeBinding; commandRunning?: boolean; agentProcessAlive?: boolean }[]>,
     // TASK-6 — per-pane agent RAM for the Fleet View cockpit. Given the ptyIds
     // currently shown as cards, returns { [ptyId]: { rss (bytes), image? } } by
     // walking each pane shell's descendant process tree from ONE CIM snapshot.
@@ -78,6 +81,9 @@ const electronAPI = {
       // one (session genuinely dead). The renderer retries transient failures
       // instead of immediately clearing the ptyId and replacing the session.
       ipcRenderer.invoke(IPC.PTY_RECONNECT, id) as Promise<{ success: boolean; id?: string; shell?: string; error?: string; code?: string; transient?: boolean }>,
+    // Fix B — on-demand promote of a cap-skipped suspended session.
+    promote: (id: string) =>
+      ipcRenderer.invoke(IPC.PTY_PROMOTE, id) as Promise<{ success: boolean; error?: string }>,
     // Phase 3 PR-B — live-pipe re-flush. Unlike `reconnect` (opens a fresh
     // socket), this re-runs the flush on the EXISTING session socket, so input
     // never pauses. Three success shapes: a live re-flush ('snapshot'|'raw'), a

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -689,7 +689,45 @@ export default function AppLayout() {
         // clear is logged at warn so it lands in the main log file and can be
         // correlated with the daemon's pty.list count.
         if (absentCandidates.length > 0 && !signal?.aborted) {
-          const firstAbsent = absentCandidates.map((c) => c.ptyId);
+          // Fix B — before destructively clearing, attempt to promote cap-skipped
+          // suspended sessions on demand. A successful promote + reconnect keeps
+          // the ptyId stable and restores scrollback from the daemon's ring buffer.
+          const stillAbsent: typeof absentCandidates = [];
+          if (window.electronAPI?.pty?.promote) {
+            // Ask the daemon for suspended sessions that match our absent ptyIds.
+            const allRes = await ipcInvoke<{ id: string; state?: string }[]>(() =>
+              window.electronAPI.pty.list({ includeSuspended: true }),
+            );
+            const suspendedIds = new Set(
+              allRes.ok
+                ? allRes.data.filter((s) => s.state === 'suspended').map((s) => s.id)
+                : [],
+            );
+            for (const candidate of absentCandidates) {
+              if (signal?.aborted) break;
+              if (!suspendedIds.has(candidate.ptyId)) {
+                stillAbsent.push(candidate);
+                continue;
+              }
+              // Try to promote this suspended session.
+              const promoteRes = await ipcInvoke<{ success: boolean; error?: string }>(() =>
+                window.electronAPI.pty.promote(candidate.ptyId),
+              );
+              if (promoteRes.ok && promoteRes.data.success) {
+                // Promoted! The ptyId is now active — useTerminal mount will reconnect.
+                console.log(`[lifecycle] reconcile PROMOTED suspended ptyId=${candidate.ptyId} → active (Fix B)`);
+              } else {
+                // Promote failed (cap hit, spawn error) — fall through to clear path.
+                console.warn(`[lifecycle] reconcile promote FAILED ptyId=${candidate.ptyId}: ${promoteRes.ok ? promoteRes.data.error : 'ipc error'}`);
+                stillAbsent.push(candidate);
+              }
+            }
+          } else {
+            stillAbsent.push(...absentCandidates);
+          }
+
+          // Continue with the 2-strike re-query for truly absent ptyIds.
+          const firstAbsent = stillAbsent.map((c) => c.ptyId);
           // v2 RCA fix (axis B-lite hardening): capture the re-query's FULL
           // payload. Rebind targets must come from the freshest snapshot — a
           // session that died between the two snapshots must not be picked
@@ -714,7 +752,7 @@ export default function AppLayout() {
           // ptyId); no match → clear→self-create (axis A's immediate save covers
           // empty-pane-origin sessions that carry no surfaceId). Rebind targets
           // come from the SECOND snapshot when the re-query succeeded.
-          const rebindActions = resolveReconcileRebind(absentCandidates, toClear, secondSnapshot ?? activePtys);
+          const rebindActions = resolveReconcileRebind(stillAbsent, toClear, secondSnapshot ?? activePtys);
           for (const a of rebindActions) {
             if (signal?.aborted) break;
             // CAS guard (adversarial review): the decision was computed from a

--- a/src/renderer/components/Layout/__tests__/appLayout.sessionSaveInvariants.test.ts
+++ b/src/renderer/components/Layout/__tests__/appLayout.sessionSaveInvariants.test.ts
@@ -49,8 +49,66 @@ describe('AppLayout — axis A session-save invariants', () => {
     expect(source).not.toMatch(/addEventListener\('beforeunload', saveSession\)/);
   });
 
+  // Fix B — cap-skipped suspended promote. Boot recovery honours a session cap,
+  // so a workspace beyond the cap came back with its ptyId absent and reconcile
+  // destructively cleared it (losing the pane's scrollback and identity). The
+  // promote attempt must therefore run BEFORE the clear path, and only ptyIds
+  // that are still absent afterwards may be cleared or rebound.
+  describe('Fix B — promote before clear', () => {
+    function reconcileRegion(): string {
+      const start = source.indexOf('if (absentCandidates.length > 0');
+      expect(start, 'absent-candidate branch not found').toBeGreaterThanOrEqual(0);
+      return source.slice(start, start + 4000);
+    }
+
+    it('attempts a promote before computing the clear set', () => {
+      const region = reconcileRegion();
+      const promoteAt = region.indexOf('pty.promote(');
+      const clearAt = region.indexOf('const firstAbsent');
+      expect(promoteAt, 'promote call not found').toBeGreaterThanOrEqual(0);
+      expect(clearAt, 'firstAbsent not found').toBeGreaterThanOrEqual(0);
+      expect(promoteAt).toBeLessThan(clearAt);
+    });
+
+    it('only asks the daemon to promote ptyIds it confirmed are SUSPENDED', () => {
+      const region = reconcileRegion();
+      // The suspended set comes from an includeSuspended listing, not from the
+      // absent set — promoting an id that is merely missing would spawn a
+      // session the daemon never had.
+      expect(region).toMatch(/pty\.list\(\{ includeSuspended: true \}\)/);
+      expect(region).toMatch(/state === 'suspended'/);
+      expect(region).toMatch(/if \(!suspendedIds\.has\(candidate\.ptyId\)\) \{[\s\S]*?stillAbsent\.push\(candidate\);/);
+    });
+
+    it('keeps a FAILED promote on the clear path (cap hit / spawn error)', () => {
+      const region = reconcileRegion();
+      // Both the ipc-level failure and a {success:false} body must fall through
+      // to stillAbsent, or a pane whose promote failed would be left bound to a
+      // ptyId that does not exist.
+      expect(region).toMatch(/if \(promoteRes\.ok && promoteRes\.data\.success\)/);
+      const elseAt = region.indexOf('} else {', region.indexOf('promoteRes.ok && promoteRes.data.success'));
+      expect(elseAt).toBeGreaterThan(0);
+      expect(region.slice(elseAt, elseAt + 400)).toContain('stillAbsent.push(candidate)');
+    });
+
+    it('falls back to the pre-Fix-B behaviour when the promote API is absent', () => {
+      // An older main process (or local mode) exposes no pty.promote; reconcile
+      // must then treat every absent candidate exactly as before.
+      const region = reconcileRegion();
+      expect(region).toMatch(/if \(window\.electronAPI\?\.pty\?\.promote\)/);
+      expect(region).toMatch(/stillAbsent\.push\(\.\.\.absentCandidates\)/);
+    });
+
+    it('respects the abort signal inside the promote loop', () => {
+      const region = reconcileRegion();
+      const loopAt = region.indexOf('for (const candidate of absentCandidates)');
+      expect(loopAt).toBeGreaterThanOrEqual(0);
+      expect(region.slice(loopAt, loopAt + 200)).toMatch(/if \(signal\?\.aborted\) break;/);
+    });
+  });
+
   it('rebind/clear actions CAS-guard on the surface’s current ptyId', () => {
-    const idx = source.indexOf('resolveReconcileRebind(absentCandidates');
+    const idx = source.indexOf('resolveReconcileRebind(stillAbsent');
     expect(idx, 'rebind decision call not found').toBeGreaterThanOrEqual(0);
     const applyRegion = source.slice(idx, idx + 3000);
     expect(applyRegion).toMatch(/currentPtyId !== a\.stalePtyId/);

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -7,6 +7,7 @@ export const IPC = {
   PTY_DATA: 'pty:data',
   PTY_EXIT: 'pty:exit',
   PTY_LIST: 'pty:list',
+  PTY_PROMOTE: 'pty:promote',
   // TASK-6 — per-pane agent resource attribution for the Fleet View cockpit.
   // Renderer → main invoke: takes a list of ptyIds, resolves each to its shell
   // PID (via daemon.listSessions), takes ONE Win32_Process CIM snapshot, walks


### PR DESCRIPTION
Boot recovery honours a session cap. A workspace beyond that cap came back with
its ptyId absent, so reconcile destructively cleared it — the pane lost both its
identity and its scrollback, even though the daemon still held a suspended session
for it.

## What changed
- `daemon.listSessions` accepts `{ includeSuspended }` and appends cap-skipped
  suspended sessions from the persisted state (no duplicates with the active set).
- New `daemon.promoteSession(id)` spawns exactly the one session the renderer
  needs, reusing the persisted geometry, env, agent and **id** so the ptyId stays
  stable and scrollback restores from the ring buffer.
- `pty:promote` IPC + `pty.promote()` preload binding.
- `AppLayout.reconcilePtys` attempts a promote **before** the clear path, and only
  for ptyIds it has confirmed are suspended.

Guards: already-active is an idempotent success; not-suspended is `NOT_FOUND`; a
missing id is `INVALID_PARAMS`; only the known transient ConPTY `error code: 87`
is retried, and with a bound. A failed promote (cap hit, spawn error) falls
through to the existing clear path, and an older main process without
`pty.promote` keeps the pre-change behaviour exactly.

## Tests
20 invariants across `pty.handler.promote.test.ts` and the extended
`appLayout.sessionSaveInvariants.test.ts` — promote-before-clear ordering,
suspended-only targeting, failure fallback, abort-signal handling, idempotency,
the retry bound, geometry/identity reuse, and the `includeSuspended` default.

All 20 fail against `origin/main`; after the change:
`npx vitest run src/main/ipc/__tests__/ src/renderer/components/Layout/__tests__/` → 113 passed
`npm run build:daemon` → clean, `npx tsc --noEmit` → 0 errors

## Not covered by tests
The actual PTY spawn, the scrollback dump replay, and the cap
`RESOURCE_EXHAUSTED` path need a live daemon. These are structural guards (the
house pattern for this file); the spawn path still wants dogfood.
