### PR TITLE
Add tests for lifecycle routing and installer

### DIFF
--- a/integrations/opencode/__tests__/wmuxRouting.test.ts
+++ b/integrations/opencode/__tests__/wmuxRouting.test.ts
@@ -1,0 +1,213 @@
+// Suffix isolation + daemon-first routing for the OpenCode lifecycle plugin.
+//
+// Two invariants this locks:
+//
+//  1. INSTANCE ISOLATION. WMUX_DATA_SUFFIX is an instance boundary. Every
+//     endpoint, credential and local-state path the plugin touches must stay
+//     inside the selected namespace, and a suffixed instance must never fall
+//     back to the production (unsuffixed) daemon token or hint. With no suffix
+//     every path stays byte-identical to the pre-isolation paths.
+//
+//  2. AT-MOST-ONCE DELIVERY. The plugin walks daemon → main. It may only
+//     advance when no server answered AND the request provably was not written;
+//     any id-matched reply (including a rejection) owns the signal, and a
+//     post-write disconnect is ambiguous, so both stop the walk.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { homedir, userInfo } from 'node:os';
+import { join } from 'node:path';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import {
+  dataSuffix,
+  getWmuxHomeDir,
+  getAuthTokenPath,
+  getPipeName,
+  getDaemonAuthTokenPath,
+  getDaemonPipeName,
+  resolveTargets,
+  shouldTryNextTarget,
+} from '../plugins/wmux.js';
+
+const SAVED = { ...process.env };
+
+// Every case runs against a throwaway home. These helpers read real files
+// (auth tokens, the daemon-pipe hint), so a test that used the developer's home
+// would both leak machine state into assertions and read whatever a live daemon
+// happens to have written.
+let home: string;
+
+beforeEach(() => {
+  for (const k of ['WMUX_DATA_SUFFIX', 'WMUX_PIPE_NAME', 'WMUX_HOOKS_TO_MAIN']) {
+    delete process.env[k];
+  }
+  home = mkdtempSync(join(tmpdir(), 'wmux-oc-'));
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+});
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  process.env = { ...SAVED };
+});
+
+describe('instance suffix', () => {
+  it('is empty by default — production paths are unchanged', () => {
+    expect(dataSuffix()).toBe('');
+    expect(getWmuxHomeDir()).toBe(join(home, '.wmux'));
+    expect(getAuthTokenPath()).toBe(join(home, '.wmux-auth-token'));
+    expect(getDaemonAuthTokenPath()).toBe(join(home, '.wmux', 'daemon-auth-token'));
+  });
+
+  it('scopes EVERY path when a suffix is selected', () => {
+    process.env.WMUX_DATA_SUFFIX = '-dev';
+    expect(getWmuxHomeDir()).toBe(join(home, '.wmux-dev'));
+    expect(getAuthTokenPath()).toBe(join(home, '.wmux-dev-auth-token'));
+    expect(getDaemonAuthTokenPath()).toBe(join(home, '.wmux-dev', 'daemon-auth-token'));
+    expect(getDaemonPipeName()).toBe(join(home, '.wmux-dev', 'daemon.sock'));
+  });
+
+  it('never reaches into the production namespace from a suffixed instance', () => {
+    process.env.WMUX_DATA_SUFFIX = '-dev';
+    for (const p of [getAuthTokenPath(), getDaemonAuthTokenPath(), getDaemonPipeName(), getPipeName()]) {
+      expect(p).toContain('-dev');
+    }
+  });
+});
+
+describe('main socket resolution matches the canonical formula', () => {
+  it('uses os.homedir(), NOT a USERPROFILE-first lookup', () => {
+    // src/shared/constants.ts getPipeName() resolves the home with os.homedir().
+    // A POSIX environment that happens to carry USERPROFILE must not send the
+    // bridge looking for the socket in a directory main never bound.
+    process.env.USERPROFILE = '/somewhere/else';
+    // os.homedir() reads HOME on POSIX, which the harness points at the temp dir.
+    expect(getPipeName()).toBe(join(homedir(), '.wmux.sock'));
+    expect(getPipeName()).not.toContain('/somewhere/else');
+  });
+
+  it('applies the suffix to the socket name', () => {
+    process.env.WMUX_DATA_SUFFIX = '-dev';
+    expect(getPipeName()).toBe(join(homedir(), '.wmux-dev.sock'));
+  });
+
+  it('token and state paths still honour USERPROFILE (isolated-dogfood contract)', () => {
+    // Deliberately different from the socket: the dogfood harness isolates an
+    // instance by pointing USERPROFILE at a scratch home.
+    process.env.USERPROFILE = '/scratch/home';
+    expect(getAuthTokenPath()).toBe(join('/scratch/home', '.wmux-auth-token'));
+    expect(getWmuxHomeDir()).toBe(join('/scratch/home', '.wmux'));
+  });
+
+  it('honours an explicit WMUX_PIPE_NAME override', () => {
+    process.env.WMUX_PIPE_NAME = '/tmp/probe.sock';
+    expect(getPipeName()).toBe('/tmp/probe.sock');
+  });
+});
+
+describe('resolveTargets — daemon first, main as fallback', () => {
+  const writeMainToken = () => writeFileSync(join(home, '.wmux-auth-token'), 'main-tok', 'utf8');
+  const writeDaemonToken = () => {
+    mkdirSync(join(home, '.wmux'), { recursive: true });
+    writeFileSync(join(home, '.wmux', 'daemon-auth-token'), 'daemon-tok', 'utf8');
+  };
+
+  it('puts the daemon FIRST — it is the always-on process (works with the GUI closed)', () => {
+    writeMainToken();
+    writeDaemonToken();
+    const targets = resolveTargets();
+    expect(targets.map((t) => t.name)).toEqual(['daemon', 'main']);
+    expect(targets[0].method).toBe('daemon.hooks.signal');
+    expect(targets[1].method).toBe('hooks.signal');
+    expect(targets[0].token).toBe('daemon-tok');
+    expect(targets[1].token).toBe('main-tok');
+  });
+
+  it('skips an endpoint whose token file is absent', () => {
+    writeDaemonToken();
+    expect(resolveTargets().map((t) => t.name)).toEqual(['daemon']);
+  });
+
+  it('returns nothing when neither token exists (nothing to talk to)', () => {
+    expect(resolveTargets()).toEqual([]);
+  });
+
+  it('WMUX_HOOKS_TO_MAIN=1 is a main-only kill switch', () => {
+    writeMainToken();
+    writeDaemonToken();
+    process.env.WMUX_HOOKS_TO_MAIN = '1';
+    expect(resolveTargets().map((t) => t.name)).toEqual(['main']);
+  });
+
+  it('WMUX_PIPE_NAME collapses the walk to ONE main-addressed target', () => {
+    writeMainToken();
+    writeDaemonToken();
+    process.env.WMUX_PIPE_NAME = '/tmp/probe.sock';
+    const targets = resolveTargets();
+    expect(targets).toHaveLength(1);
+    expect(targets[0]).toMatchObject({ name: 'main', pipe: '/tmp/probe.sock', method: 'hooks.signal' });
+  });
+
+  it('an override with no main token yields no target rather than a daemon fallback', () => {
+    writeDaemonToken();
+    process.env.WMUX_PIPE_NAME = '/tmp/probe.sock';
+    expect(resolveTargets()).toEqual([]);
+  });
+
+  it('prefers the daemon-pipe HINT over the derived socket name', () => {
+    // The hint records the socket the daemon actually bound, which differs after
+    // a zombie-socket fallback rename.
+    writeDaemonToken();
+    writeFileSync(join(home, '.wmux', 'daemon-pipe'), '/tmp/renamed-daemon.sock\n', 'utf8');
+    expect(getDaemonPipeName()).toBe('/tmp/renamed-daemon.sock');
+  });
+
+  it('reads the hint only from its OWN suffix namespace', () => {
+    mkdirSync(join(home, '.wmux'), { recursive: true });
+    writeFileSync(join(home, '.wmux', 'daemon-pipe'), '/tmp/prod.sock', 'utf8');
+    process.env.WMUX_DATA_SUFFIX = '-dev';
+    // No -dev hint exists → derive inside -dev, never adopt the production one.
+    expect(getDaemonPipeName()).toBe(join(home, '.wmux-dev', 'daemon.sock'));
+  });
+});
+
+describe('shouldTryNextTarget — at-most-once delivery', () => {
+  it('advances when nothing was reached and the write never happened', () => {
+    expect(shouldTryNextTarget({ ok: false, error: 'timeout', retryable: true })).toBe(true);
+    expect(shouldTryNextTarget({ ok: false, error: 'no-target', retryable: true })).toBe(true);
+  });
+
+  it('STOPS on an outer-ok reply — that server owns the signal', () => {
+    // Including an inner logical rejection: the lifecycle handler DID run, so
+    // re-sending to main would double-deliver the same event.
+    expect(shouldTryNextTarget({ id: 'req-1', ok: true, result: { ok: true } })).toBe(false);
+    expect(shouldTryNextTarget({ id: 'req-1', ok: true, result: { ok: false, reason: 'no-workspace-match' } }))
+      .toBe(false);
+  });
+
+  it('ADVANCES on a transport/auth refusal — an older daemon never ran the handler', () => {
+    // A daemon that predates daemon.hooks.signal answers with outer ok=false and
+    // no retryable=false marker. Falling back to main is the only way that
+    // install keeps working, and it cannot double-deliver.
+    expect(shouldTryNextTarget({ id: 'req-1', ok: false, error: 'unknown-method' })).toBe(true);
+    expect(shouldTryNextTarget({ id: 'req-1', ok: false, error: 'unauthorized' })).toBe(true);
+  });
+
+  it('STOPS after an ambiguous post-write disconnect (may have been delivered)', () => {
+    expect(shouldTryNextTarget({ ok: false, error: 'closed-without-response', retryable: false })).toBe(false);
+    expect(shouldTryNextTarget({ ok: false, error: 'timeout', retryable: false })).toBe(false);
+  });
+});
+
+describe('win32 naming', () => {
+  it('uses the suffixed named-pipe convention for both endpoints', () => {
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    try {
+      process.env.WMUX_DATA_SUFFIX = '-dev';
+      const user = userInfo().username || 'default';
+      expect(getPipeName()).toBe(`\\\\.\\pipe\\wmux-dev-${user}`);
+      expect(getDaemonPipeName()).toBe(`\\\\.\\pipe\\wmux-daemon-dev-${user}`);
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original, configurable: true });
+    }
+  });
+});

--- a/integrations/opencode/plugins/wmux.js
+++ b/integrations/opencode/plugins/wmux.js
@@ -66,23 +66,23 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 // Keep these formulas in lockstep with src/shared/constants.ts. A non-empty
 // suffix is an instance boundary: this plugin never probes production paths as
 // an implicit fallback when its selected namespace is suffixed.
-function dataSuffix() {
+export function dataSuffix() {
   return process.env.WMUX_DATA_SUFFIX || '';
 }
 
-function getHomeDir() {
+export function getHomeDir() {
   return process.env.USERPROFILE || process.env.HOME || homedir();
 }
 
-function getWmuxHomeDir() {
+export function getWmuxHomeDir() {
   return join(getHomeDir(), `.wmux${dataSuffix()}`);
 }
 
-function getAuthTokenPath() {
+export function getAuthTokenPath() {
   return join(getHomeDir(), `.wmux${dataSuffix()}-auth-token`);
 }
 
-function getPipeName() {
+export function getPipeName() {
   // WMUX_PIPE_NAME is an explicit single-endpoint override for isolated probes
   // and advanced multi-instance setups. It must not fall through to a real
   // daemon when the selected override is unavailable.
@@ -97,14 +97,14 @@ function getPipeName() {
 
 // ----- Daemon endpoint (hook ingest lives in the daemon) ------------------
 
-function getDaemonAuthTokenPath() {
+export function getDaemonAuthTokenPath() {
   return join(getWmuxHomeDir(), 'daemon-auth-token');
 }
 
 // The hint records the socket the daemon actually bound, including a zombie-
 // socket fallback rename. It is read only from the selected suffix namespace;
 // the derived fallback is in that same namespace as well.
-function getDaemonPipeName() {
+export function getDaemonPipeName() {
   try {
     const fromFile = readFileSync(join(getWmuxHomeDir(), 'daemon-pipe'), 'utf8').trim();
     if (fromFile) return fromFile;
@@ -130,7 +130,7 @@ function readTokenFile(tokenPath) {
 // Ordered endpoints. Missing token files skip their endpoint. The existing
 // WMUX_PIPE_NAME override remains a MAIN-addressed, one-target escape hatch;
 // WMUX_HOOKS_TO_MAIN=1 is the main-only kill switch.
-function resolveTargets() {
+export function resolveTargets() {
   const mainToken = readTokenFile(getAuthTokenPath());
   const pipeOverride = process.env.WMUX_PIPE_NAME;
   if (typeof pipeOverride === 'string' && pipeOverride.length > 0) {
@@ -362,7 +362,7 @@ async function sendRpcWithRetry(pipePath, request, deadline = Date.now() + HOOK_
 // A dispatch/auth refusal from an old daemon has outer ok=false and no
 // retryable=false marker; falling back to main is safe because the lifecycle
 // handler did not run.
-function shouldTryNextTarget(result) {
+export function shouldTryNextTarget(result) {
   if (result && result.ok === true) return false;
   if (result && result.retryable === false) return false;
   return true;

--- a/src/shared/__tests__/lifecycleIntegrations.test.ts
+++ b/src/shared/__tests__/lifecycleIntegrations.test.ts
@@ -1,0 +1,238 @@
+// Lifecycle asset install/refresh.
+//
+// wmux ships hook bridges into directories other tools own (~/.wmux/hooks,
+// ~/.config/opencode/plugins). The installer therefore has one hard rule: it
+// only ever replaces a destination it can PROVE is wmux-owned, identified by a
+// marker in the file itself. Anything else is reported as foreign and left
+// exactly as the user wrote it. Writes are atomic (temp + rename) so a crash
+// mid-install cannot leave a truncated bridge that a hook would then execute.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, readdirSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  inspectLifecycleAsset,
+  installLifecycleAsset,
+  findLifecycleAssetSourceFrom,
+  resolveLifecycleIntegrationPaths,
+  statusLifecycleIntegrations,
+  OPENCODE_PLUGIN_BUNDLE_BASENAME,
+  OPENCODE_PLUGIN_INSTALL_BASENAME,
+  OPENCODE_PLUGIN_MANAGED_MARKER,
+  CODEX_NOTIFY_MANAGED_MARKER,
+} from '../lifecycleIntegrations';
+
+const MARKER = OPENCODE_PLUGIN_MANAGED_MARKER;
+
+let dir: string;
+let src: string;
+let dest: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), 'wmux-lifecycle-'));
+  src = path.join(dir, 'source.js');
+  dest = path.join(dir, 'installed', 'wmux.js');
+  writeFileSync(src, `// ${MARKER}\nexport const v = 2;\n`, 'utf8');
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const spec = (over: Partial<Parameters<typeof inspectLifecycleAsset>[0]> = {}) => ({
+  sourcePath: src,
+  destinationPath: dest,
+  ownershipMarkers: [MARKER],
+  ...over,
+});
+
+describe('inspectLifecycleAsset', () => {
+  it('reports missing when nothing is installed yet', () => {
+    expect(inspectLifecycleAsset(spec()).state).toBe('missing');
+  });
+
+  it('reports current when the bytes already match', () => {
+    mkdirSync(path.dirname(dest), { recursive: true });
+    writeFileSync(dest, readFileSync(src));
+    expect(inspectLifecycleAsset(spec()).state).toBe('current');
+  });
+
+  it('reports stale for an OLDER wmux-owned copy', () => {
+    mkdirSync(path.dirname(dest), { recursive: true });
+    writeFileSync(dest, `// ${MARKER}\nexport const v = 1;\n`, 'utf8');
+    expect(inspectLifecycleAsset(spec()).state).toBe('stale');
+  });
+
+  it('reports FOREIGN for a same-name file without a wmux marker', () => {
+    mkdirSync(path.dirname(dest), { recursive: true });
+    writeFileSync(dest, 'export const mine = true;\n', 'utf8');
+    expect(inspectLifecycleAsset(spec()).state).toBe('foreign');
+  });
+
+  it('accepts any of several markers so an older naming still reads as ours', () => {
+    mkdirSync(path.dirname(dest), { recursive: true });
+    writeFileSync(dest, '// wmux ↔ OpenCode plugin bridge (old header)\n', 'utf8');
+    expect(
+      inspectLifecycleAsset(spec({ ownershipMarkers: [MARKER, 'wmux ↔ OpenCode plugin bridge'] })).state,
+    ).toBe('stale');
+  });
+
+  it('reports source-missing rather than throwing when the bundle is absent', () => {
+    expect(inspectLifecycleAsset(spec({ sourcePath: null })).state).toBe('source-missing');
+    expect(inspectLifecycleAsset(spec({ sourcePath: path.join(dir, 'nope.js') })).state)
+      .toBe('source-missing');
+  });
+
+  it('never creates the destination directory (read-only probe)', () => {
+    inspectLifecycleAsset(spec());
+    expect(() => statSync(path.dirname(dest))).toThrow();
+  });
+});
+
+describe('installLifecycleAsset', () => {
+  it('installs when absent', () => {
+    const out = installLifecycleAsset(spec());
+    expect(out).toMatchObject({ action: 'installed', state: 'current' });
+    expect(readFileSync(dest, 'utf8')).toBe(readFileSync(src, 'utf8'));
+  });
+
+  it('refreshes a stale wmux-owned copy', () => {
+    mkdirSync(path.dirname(dest), { recursive: true });
+    writeFileSync(dest, `// ${MARKER}\nexport const v = 1;\n`, 'utf8');
+    const out = installLifecycleAsset(spec());
+    expect(out).toMatchObject({ action: 'refreshed', state: 'current' });
+    expect(readFileSync(dest, 'utf8')).toContain('v = 2');
+  });
+
+  it('is idempotent when already current (no rewrite)', () => {
+    installLifecycleAsset(spec());
+    const before = statSync(dest).mtimeMs;
+    const out = installLifecycleAsset(spec());
+    expect(out.action).toBe('none');
+    expect(statSync(dest).mtimeMs).toBe(before);
+  });
+
+  it('REFUSES to overwrite a foreign file and leaves it byte-identical', () => {
+    mkdirSync(path.dirname(dest), { recursive: true });
+    const mine = 'export const mine = true;\n';
+    writeFileSync(dest, mine, 'utf8');
+
+    const out = installLifecycleAsset(spec());
+    expect(out).toMatchObject({ action: 'none', state: 'foreign' });
+    expect(readFileSync(dest, 'utf8')).toBe(mine);
+  });
+
+  it('does nothing when the bundled source is unavailable', () => {
+    const out = installLifecycleAsset(spec({ sourcePath: null }));
+    expect(out).toMatchObject({ action: 'none', state: 'source-missing' });
+    expect(() => statSync(dest)).toThrow();
+  });
+
+  it('leaves no temp file behind after a successful install', () => {
+    installLifecycleAsset(spec());
+    const leftovers = readdirSync(path.dirname(dest)).filter((f) => f.endsWith('.tmp'));
+    expect(leftovers).toEqual([]);
+  });
+
+  it('creates the destination directory when it does not exist', () => {
+    expect(installLifecycleAsset(spec()).state).toBe('current');
+    expect(statSync(path.dirname(dest)).isDirectory()).toBe(true);
+  });
+});
+
+describe('findLifecycleAssetSourceFrom', () => {
+  it('finds a bundled asset by walking up from the start directory', () => {
+    const deep = path.join(dir, 'a', 'b', 'c');
+    mkdirSync(deep, { recursive: true });
+    const bundled = path.join(dir, 'a', OPENCODE_PLUGIN_BUNDLE_BASENAME);
+    writeFileSync(bundled, 'x', 'utf8');
+    expect(findLifecycleAssetSourceFrom(deep, OPENCODE_PLUGIN_BUNDLE_BASENAME, ['nope'])).toBe(bundled);
+  });
+
+  it('finds a repo-layout asset through the dev-relative path', () => {
+    const start = path.join(dir, 'dist', 'main');
+    mkdirSync(start, { recursive: true });
+    const repoCopy = path.join(dir, 'integrations', 'opencode', 'plugins', OPENCODE_PLUGIN_INSTALL_BASENAME);
+    mkdirSync(path.dirname(repoCopy), { recursive: true });
+    writeFileSync(repoCopy, 'x', 'utf8');
+    expect(
+      findLifecycleAssetSourceFrom(start, OPENCODE_PLUGIN_BUNDLE_BASENAME, [
+        'integrations', 'opencode', 'plugins', OPENCODE_PLUGIN_INSTALL_BASENAME,
+      ]),
+    ).toBe(repoCopy);
+  });
+
+  it('returns null instead of throwing when nothing is found', () => {
+    expect(findLifecycleAssetSourceFrom(dir, 'absent-bundle.js', ['also', 'absent'])).toBeNull();
+  });
+});
+
+describe('resolveLifecycleIntegrationPaths', () => {
+  it('targets the conventional install locations and carries ownership markers', () => {
+    const paths = resolveLifecycleIntegrationPaths('/home/u', dir);
+    expect(paths.codex.destinationPath).toBe(path.join('/home/u', '.wmux', 'hooks', 'wmux-codex-notify.mjs'));
+    expect(paths.codex.ownershipMarkers).toContain(CODEX_NOTIFY_MANAGED_MARKER);
+    expect(paths.opencode.destinationPath).toBe(
+      path.join('/home/u', '.config', 'opencode', 'plugins', OPENCODE_PLUGIN_INSTALL_BASENAME),
+    );
+    expect(paths.opencode.ownershipMarkers).toContain(OPENCODE_PLUGIN_MANAGED_MARKER);
+  });
+
+  it('honours an ABSOLUTE XDG_CONFIG_HOME for the OpenCode plugin', () => {
+    // OpenCode reads its config from XDG_CONFIG_HOME; installing into ~/.config
+    // regardless would put the plugin somewhere OpenCode never loads.
+    process.env.XDG_CONFIG_HOME = '/xdg/cfg';
+    try {
+      const paths = resolveLifecycleIntegrationPaths('/home/u', dir);
+      expect(paths.opencode.destinationPath).toBe(
+        path.join('/xdg/cfg', 'opencode', 'plugins', OPENCODE_PLUGIN_INSTALL_BASENAME),
+      );
+      // The wmux-owned hook dir is NOT an XDG location and must not move.
+      expect(paths.codex.destinationPath).toContain(path.join('/home/u', '.wmux'));
+    } finally {
+      delete process.env.XDG_CONFIG_HOME;
+    }
+  });
+
+  it('IGNORES a relative XDG_CONFIG_HOME (spec says it must be absolute)', () => {
+    process.env.XDG_CONFIG_HOME = 'relative/cfg';
+    try {
+      expect(resolveLifecycleIntegrationPaths('/home/u', dir).opencode.destinationPath).toBe(
+        path.join('/home/u', '.config', 'opencode', 'plugins', OPENCODE_PLUGIN_INSTALL_BASENAME),
+      );
+    } finally {
+      delete process.env.XDG_CONFIG_HOME;
+    }
+  });
+
+  it('statusLifecycleIntegrations reports without writing anything', () => {
+    const home = path.join(dir, 'home');
+    mkdirSync(home, { recursive: true });
+    const status = statusLifecycleIntegrations(resolveLifecycleIntegrationPaths(home, dir));
+    expect(status.codexBridge.state).toBeDefined();
+    expect(status.opencodePlugin.state).toBeDefined();
+    // No install happened as a side effect of asking.
+    expect(() => statSync(path.join(home, '.wmux', 'hooks'))).toThrow();
+    expect(() => statSync(path.join(home, '.config', 'opencode', 'plugins'))).toThrow();
+  });
+});
+
+describe('source preference', () => {
+  it('prefers a live repo checkout over a possibly stale dist build', () => {
+    // A developer running from source after an old `build:cli` must not have the
+    // installed integration downgraded to the stale bundle.
+    const start = path.join(dir, 'app');
+    mkdirSync(start, { recursive: true });
+    const distCopy = path.join(dir, 'dist', 'cli-bundle', OPENCODE_PLUGIN_BUNDLE_BASENAME);
+    mkdirSync(path.dirname(distCopy), { recursive: true });
+    writeFileSync(distCopy, 'stale', 'utf8');
+    const repoCopy = path.join(dir, 'integrations', 'opencode', 'plugins', OPENCODE_PLUGIN_INSTALL_BASENAME);
+    mkdirSync(path.dirname(repoCopy), { recursive: true });
+    writeFileSync(repoCopy, 'fresh', 'utf8');
+
+    const found = findLifecycleAssetSourceFrom(start, OPENCODE_PLUGIN_BUNDLE_BASENAME, [
+      'integrations', 'opencode', 'plugins', OPENCODE_PLUGIN_INSTALL_BASENAME,
+    ]);
+    expect(found).toBe(repoCopy);
+    expect(readFileSync(found!, 'utf8')).toBe('fresh');
+  });
+});

--- a/src/shared/__tests__/mcpRegistration.test.ts
+++ b/src/shared/__tests__/mcpRegistration.test.ts
@@ -185,6 +185,50 @@ describe('registerCodexNotify — resume-capture notify (skip-if-foreign)', () =
     writeCodex('model = "x"\n');
     expect(readCodexNotifyStatus(home).state).toBe('none');
   });
+
+  // A `notify` slot that is present but not a string array is user-owned or
+  // unknown either way. It used to fall through the array-shaped read as
+  // "absent" and get overwritten; anything wmux cannot PROVE it owns is now a
+  // conflict and is left exactly as written.
+  describe('a notify slot wmux cannot prove it owns', () => {
+    it('treats a plain-string notify as foreign', () => {
+      const p = writeCodex('notify = "my-script.sh"\n');
+      const r = registerCodexNotify(home, NOTIFY);
+      expect(r.skipped).toBe('foreign');
+      expect(r.wrote).toBe(false);
+      expect(fs.readFileSync(p, 'utf8')).toContain('my-script.sh');
+      expect(readCodexNotifyStatus(home).state).toBe('foreign');
+    });
+
+    it('treats an array with non-string entries as foreign', () => {
+      const p = writeCodex('notify = ["node", 42]\n');
+      const r = registerCodexNotify(home, NOTIFY);
+      expect(r.skipped).toBe('foreign');
+      expect(fs.readFileSync(p, 'utf8')).toContain('42');
+      expect(readCodexNotifyStatus(home).state).toBe('foreign');
+    });
+
+    it('CLAIMS an empty array — it names no program, so nothing is clobbered', () => {
+      writeCodex('notify = []\n');
+      const r = registerCodexNotify(home, NOTIFY);
+      expect(r.skipped).toBeNull();
+      expect(r.wrote).toBe(true);
+      expect(readCodexNotifyStatus(home)).toMatchObject({ state: 'wmux', path: NOTIFY });
+    });
+
+    it('reports a malformed config distinctly from "no notify"', () => {
+      writeCodex('this = = broken [[');
+      expect(readCodexNotifyStatus(home).state).toBe('malformed');
+    });
+
+    it('still adopts a wmux-shaped notify that merely points at an old path', () => {
+      writeCodex(`notify = ["node", "C:\\\\old\\\\wmux-codex-notify.mjs"]\n`);
+      const r = registerCodexNotify(home, NOTIFY);
+      expect(r.skipped).toBeNull();
+      expect(r.wrote).toBe(true);
+      expect(readCodexNotifyStatus(home)).toMatchObject({ state: 'wmux', path: NOTIFY });
+    });
+  });
 });
 
 describe('registerTarget — Gemini (unverified, never created)', () => {


### PR DESCRIPTION
Stacked on #714 — **base is `fix/cli-lifecycle-routing`, not `main`.** Merge #714
first; this then shows as a small test-only diff.

I built the same lifecycle change independently before noticing #714 already
covered it. Rather than ship a duplicate, this reduces to just the coverage that
was missing, against #714's source.

## What this adds
**50 test cases**, no behavioural change. The only source edit is `export` on nine
existing helpers in the OpenCode plugin so the path and target-walk logic can be
called from a test; the plugin runtime still loads only the default export.

### `integrations/opencode/__tests__/wmuxRouting.test.ts` (31)
- **Instance isolation** — every path (wmux home, main token, daemon token, daemon
  socket) scoped by `WMUX_DATA_SUFFIX`; a suffixed instance never reaches the
  production namespace; with no suffix the paths stay byte-identical to before.
- **Canonical socket** — the main socket resolves through `os.homedir()`, matching
  `src/shared/constants.ts getPipeName()`. Pinned specifically because a
  `USERPROFILE`-first lookup would send the bridge to a directory main never
  bound, while token/state paths deliberately keep honouring `USERPROFILE` for
  isolated dogfood.
- **Daemon-first walk** — ordering, per-endpoint skip on a missing token, the
  `WMUX_HOOKS_TO_MAIN` kill switch, the `WMUX_PIPE_NAME` single-target escape
  hatch (and that it does not fall back to the daemon), hint-over-derived
  preference, and per-namespace hint reads.
- **At-most-once delivery** — advances only when the request provably never
  reached a server; an outer-ok reply owns the signal; a post-write disconnect is
  ambiguous and stops the walk; a legacy-daemon transport refusal correctly falls
  through to main.
- win32 named-pipe naming for both endpoints.

### `src/shared/__tests__/lifecycleIntegrations.test.ts` (19)
missing / current / stale / foreign / source-missing classification, multi-marker
ownership, atomic install and refresh, **foreign files left byte-identical**, no
temp leftovers, source lookup through bundle and repo layouts, absolute
`XDG_CONFIG_HOME` honoured and a relative one ignored, live-checkout preferred
over a stale `dist`, and that `status` never writes.

### `src/shared/__tests__/mcpRegistration.test.ts` (+4)
A `notify` slot that is a plain string or contains non-string entries is a
conflict; an empty array names no program so wmux may claim it; a malformed config
reports distinctly from "no notify".

## Verification
`npx vitest run integrations/ src/cli/ src/shared/__tests__/lifecycleIntegrations.test.ts src/shared/__tests__/mcpRegistration.test.ts src/main/mcp/__tests__/` → **622 passed, 3 skipped**
`npx tsc --noEmit` → 0 errors

The routing suite runs against a throwaway `HOME`. These helpers read real token
and hint files, so a suite using the developer's home would read whatever a live
daemon happened to have written — that mistake produced two false failures while
writing this.
