### PR TITLE
chore(approvals): update stale per-option comment and drop unused export

### DIFF
--- a/src/daemon/approvals/approvalKeystrokes.ts
+++ b/src/daemon/approvals/approvalKeystrokes.ts
@@ -44,13 +44,20 @@
 //                 itself advertises, and it is the only mapping here that is
 //                 unambiguous for ANY question shape.
 //
-// KNOWN LIMITATION, deliberately shipped: for a yes/no question '1' is the
+// DEFAULT MAPPING + per-option override. For a yes/no question '1' is the
 // affirmative answer, but AskUserQuestion options are agent-authored, so on a
 // question whose first option is not the affirmative one, "approve" means
 // "pick the first option" rather than "say yes". Nothing on the wire tells us
-// which is which. The honest surface for a phone is therefore Deny (exact) +
-// Approve (first option); a richer per-option press belongs with the option
-// list in the phone UI, which is M5/M6 scope, not here.
+// which is which at the default-mapping layer.
+//
+// Per-option press is now supported: the registry extracts structured
+// `choices` (key = the original 1-based digit, label) from the hook payload,
+// and a resolver may send `choiceKey` to select a SPECIFIC option rather than
+// the default first. The registry validates the key belongs to the request,
+// re-verifies the option row is visible, then sends exactly that digit — no CR.
+// Omitting `choiceKey` preserves the default mapping byte-for-byte, so old
+// clients keep working. See ApprovalRegistry.resolve and the phone-client
+// contract (`docs/phone-client-contract.md`, "choices" / "choiceKey").
 
 /** The two byte sequences for one agent. Single presses — never a CR chaser. */
 export interface ApprovalKeystrokes {

--- a/src/daemon/approvals/askUserQuestion.ts
+++ b/src/daemon/approvals/askUserQuestion.ts
@@ -205,9 +205,6 @@ export function sanitizeOptions(value: unknown): string[] | undefined {
   return labels.length > 0 ? labels : undefined;
 }
 
-/** Cap for a choice key — a 1-based digit, never more than 2 characters. */
-export const MAX_CHOICE_KEY_CHARS = 2;
-
 /**
  * Re-apply caps to `choices` read back from disk. Each entry must have a
  * valid `key` (1-2 digit string) and a non-empty `label`. Entries that fail


### PR DESCRIPTION
## Summary

Follow-up cleanup from the #712 review. Two non-behavioural fixes:

- **`approvalKeystrokes.ts` header comment was stale.** It still deferred the per-option press to "M5/M6 scope, not here", but #712 implements exactly that via `choiceKey`. Rewrote the block to describe the default-mapping fallback and the `choiceKey` override, and pointed at `ApprovalRegistry.resolve` + the phone-client contract (`docs/phone-client-contract.md`).
- **`MAX_CHOICE_KEY_CHARS` was exported but never referenced.** All key validation uses the inline `/^\d{1,2}$/` regex. Removed the dead export.

## Safety and compatibility

- Comment-only change + one removed export. No behaviour change, no wire change.
- `MAX_CHOICE_KEY_CHARS` had zero references across the tree (confirmed via `rg`).

## Validation

- `vitest run src/daemon/approvals` — **127/127 passed**
- `vitest run src/daemon/web/__tests__/WebTerminalServer.test.ts` — **136/136 passed**
- `tsc -p tsconfig.daemon.json --noEmit` — clean for the changed files (only pre-existing unrelated `@anthropic-ai/claude-agent-sdk` module-miss in `src/main/deck/ClaudeSdkAdapter.ts`)

Stacked on #712 — merge after it.