### PR TITLE
chore(approvals): update stale per-option comment and drop unused export

### DIFF
--- a/src/daemon/approvals/approvalKeystrokes.ts
+++ b/src/daemon/approvals/approvalKeystrokes.ts
@@ -44,13 +44,20 @@
 //                 itself advertises, and it is the only mapping here that is
 //                 unambiguous for ANY question shape.
 //
-// KNOWN LIMITATION, deliberately shipped: for a yes/no question '1' is the
+// DEFAULT MAPPING + per-option override. For a yes/no question '1' is the
 // affirmative answer, but AskUserQuestion options are agent-authored, so on a
 // question whose first option is not the affirmative one, "approve" means
 // "pick the first option" rather than "say yes". Nothing on the wire tells us
-// which is which. The honest surface for a phone is therefore Deny (exact) +
-// Approve (first option); a richer per-option press belongs with the option
-// list in the phone UI, which is M5/M6 scope, not here.
+// which is which at the default-mapping layer.
+//
+// Per-option press is now supported: the registry extracts structured
+// `choices` (key = the original 1-based digit, label) from the hook payload,
+// and a resolver may send `choiceKey` to select a SPECIFIC option rather than
+// the default first. The registry validates the key belongs to the request,
+// re-verifies the option row is visible, then sends exactly that digit — no CR.
+// Omitting `choiceKey` preserves the default mapping byte-for-byte, so old
+// clients keep working. See ApprovalRegistry.resolve and the phone-client
+// contract (`docs/phone-client-contract.md`, "choices" / "choiceKey").
 
 /** The two byte sequences for one agent. Single presses — never a CR chaser. */
 export interface ApprovalKeystrokes {

--- a/src/daemon/approvals/askUserQuestion.ts
+++ b/src/daemon/approvals/askUserQuestion.ts
@@ -68,8 +68,8 @@ export interface ExtractedQuestion {
  * ONLY THE FIRST QUESTION is extracted. AskUserQuestion may carry several, but
  * the keystroke map presses one option on whatever the TUI is showing, which is
  * the first question — surfacing options from a later one would describe a
- * choice the press cannot make. (Multi-question prompts are a real gap here and
- * belong with the per-option press in M5/M6.)
+ * choice the press cannot make. Multi-question prompts remain a real gap: the
+ * daemon has no way to advance to a later question and answer it separately.
  *
  * `choices` preserves the ORIGINAL 1-based index of each option in the payload
  * array as the `key`. When a label is blank/unusable the entry is dropped from
@@ -107,9 +107,10 @@ export function extractAskUserQuestion(payload: unknown): ExtractedQuestion {
  * Option labels, from either `[{label}]` or `['label']`. Entries that yield no
  * usable label are DROPPED rather than kept as empty strings — a blank row on a
  * phone is worse than a shorter list — which is why the index of an option here
- * is not promised to match the digit that selects it. Nothing presses by index
- * from this list today (approve is hard-coded to the first option); when M5/M6
- * adds per-option press it must carry the real index, not this array's.
+ * is not promised to match the digit that selects it. Per-option press (via
+ * `choiceKey`) does NOT index into this array: it uses the authoritative key on
+ * the parallel `choices` array (see readOptionLabelsWithChoices below). The
+ * legacy `options` array is display-only.
  *
  * `choices` preserves the original 1-based index: each entry is `{key, label}`
  * where `key` is the TUI digit (e.g. '1', '2', '3'). Dropped entries still

--- a/src/daemon/approvals/askUserQuestion.ts
+++ b/src/daemon/approvals/askUserQuestion.ts
@@ -205,9 +205,6 @@ export function sanitizeOptions(value: unknown): string[] | undefined {
   return labels.length > 0 ? labels : undefined;
 }
 
-/** Cap for a choice key — a 1-based digit, never more than 2 characters. */
-export const MAX_CHOICE_KEY_CHARS = 2;
-
 /**
  * Re-apply caps to `choices` read back from disk. Each entry must have a
  * valid `key` (1-2 digit string) and a non-empty `label`. Entries that fail


### PR DESCRIPTION
## Summary

Follow-up cleanup from the #712 review. Two non-behavioural fixes:

- **`approvalKeystrokes.ts` header comment was stale.** It still deferred the per-option press to "M5/M6 scope, not here", but #712 implements exactly that via `choiceKey`. Rewrote the block to describe the default-mapping fallback and the `choiceKey` override, and pointed at `ApprovalRegistry.resolve` + the phone-client contract (`docs/phone-client-contract.md`).
- **`MAX_CHOICE_KEY_CHARS` was exported but never referenced.** All key validation uses the inline `/^\d{1,2}$/` regex. Removed the dead export.

## Safety and compatibility

- Comment-only change + one removed export. No behaviour change, no wire change.
- `MAX_CHOICE_KEY_CHARS` had zero references across the tree (confirmed via `rg`).

## Validation

- `vitest run src/daemon/approvals` — **127/127 passed**
- `vitest run src/daemon/web/__tests__/WebTerminalServer.test.ts` — **136/136 passed**
- `tsc -p tsconfig.daemon.json --noEmit` — clean for the changed files

Rebased onto main after #712 merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified how approval prompts handle multiple options and structured choices.
  - Documented selecting a specific visible option by its digit after confirmation.
  - Clarified that unspecified selections preserve the default first-option behavior.
  - Explained that legacy option labels are display-only, while validated choices determine selection.

- **Maintenance**
  - Removed an unused public constant without changing choice validation or end-user behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->