### PR TITLE
Stop a finished pane from reporting `running` forever, and from being killed to clear it

### DIFF
--- a/changelog.d/734.md
+++ b/changelog.d/734.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- **A pane that finished its command no longer reports `running` forever.**
+  Clearing a pane back to `idle` sat behind a 30-second window built to suppress
+  a "Task may have finished" notification that had since been removed. A
+  workspace switch (any `pty:resize`) inside that window made the clear vanish,
+  and nothing retried it — the activity monitor consumes its state transition
+  before invoking callbacks, and a quiet pane never produces another burst. For
+  a plain shell, where no agent is detected, that clear is the only path there
+  is, so the pane sat at an idle prompt reporting `running` until it was closed.
+  The window also blocked the correction for the false `running` a resize
+  redraw raises in the first place. Agent panes are unaffected: their precise
+  hook and detector statuses still outrank byte silence. (#733)
+
+- **The orchestrator can no longer close a pane to clear its status.** When a
+  wedged pane held the Stop gate open, the terminal brain read "resolve these
+  panes" as "end these panes" and ran `exit`, then Ctrl+D, in a live shell the
+  user owned. The refusal text now names the prohibition, and session-terminating
+  input is refused outright when it targets a pane the caller's own turn is
+  currently blocked on. The scope is exactly that intersection — an orchestrator
+  that is not gate-held closes shells as before, and even a gate-held one may
+  close panes it is not blocked on. (#733)

--- a/plans/pane-status-stuck-running-2026-08-01.md
+++ b/plans/pane-status-stuck-running-2026-08-01.md
@@ -1,0 +1,243 @@
+# Pane status stuck at `running`, and the destructive escape from it (2026-08-01)
+
+- Status: **design, pre-review**. Tracking issue: #733.
+- Scope: `src/main/notification/idleSuppression.ts`, `DaemonNotificationRouter.onIdle`,
+  `PTYBridge.onActiveToIdle`, `src/main/deck/deckWorkStore.ts`, `stopGate.ts`,
+  and the turn-contract text shipped by #703.
+- Root cause confirmed empirically (instrumented dev build, daemon mode, Windows).
+  Evidence and repro are in #733; this document only decides what to change.
+
+## 0. What we are fixing
+
+Three defects that compound into one incident: a pane that finished its command
+keeps reporting `running`, the Stop gate therefore refuses to end the turn, and
+the brain escapes by killing the pane.
+
+They are separable and should be judged separately. F1 is the bug. F2 is what
+makes it recur after a restart. F3 is what turns a status bug into data loss.
+
+## 1. F1 — the status clear must not be gated by the notification suppressor
+
+### What is wrong
+
+`recentlySuppressed()` was written to suppress a **toast** ("Task may have
+finished") after a resize redraw or a burst of typing. That toast was later
+deleted; the comments in both handlers say so. The guard was never narrowed, so
+it now sits in front of the only surviving job: clearing `running` to `idle`.
+
+Two properties make a suppressed clear permanent rather than late:
+
+- `ActivityMonitor` mutates its state before invoking callbacks, so the
+  transition is consumed even when the callback is dropped. Nothing retries.
+- For a plain shell `AgentDetector` never matches, so no `session:agent` ever
+  arrives. `session:idle` is the only path that can clear the status.
+
+### The decisive argument
+
+`onActive` is **not** gated by `recentlySuppressed`, but `onIdle` is. A resize
+redraw is several KB, so it raises a false `running`, and then the guard blocks
+the clear that would have corrected it. The guard makes the exact case it was
+named for worse, not better. Either both edges are gated or neither is, and
+gating neither is the one that keeps the status honest.
+
+### Change
+
+Drop the `recentlySuppressed()` call from both status-clear paths. That leaves
+the function with no callers, and `markUserWrite` / `lastUserWriteAt` exist only
+to feed it, so all three are removed. `markResize` stays: `recentlyResized()`
+(3 s window, AgentDetector dedup reset) is a separate concern and keeps its
+caller.
+
+Agent panes do not lose protection. They are covered twice already, by
+`explicitTerminalStatus` inside `DaemonPTYBridge.onActiveToIdle` and by
+`AGENT_EVENT_SUPPRESSION_MS` in main. Neither is touched.
+
+Callers verified before writing this: `recentlySuppressed` has exactly the two
+production call sites named above, and `markUserWrite`'s two call sites in
+`pty.handler` exist only to feed it. One test blocks the removal —
+`pty.handler.oversize-segment.test.ts` asserts on the **source text** containing
+`markUserWrite(id)`, to prove the call was not hoisted out of the segmentation
+loop. That test's subject disappears with the function, so it is deleted rather
+than rewritten; the behaviour it guarded (per-write suppression bookkeeping) no
+longer exists to guard.
+
+### Deliberately not doing
+
+Making `ActivityMonitor` re-fire a dropped idle. The convergence hole is real —
+any future dropped callback wedges a pane the same way — but with the only
+dropper removed there is nothing left to converge from, and adding a retry timer
+to a hot path to defend against a caller that no longer exists is the wrong
+trade. Flagged for review as a judgement call, not silently skipped.
+
+## 2. F2 — active work must expire and must not auto-wake forever
+
+### What is wrong
+
+`deck-work.json` kept the record from a finished one-liner across an Escape
+interrupt, a force-kill and a full restart. On the next boot the orchestrator
+auto-woke on it with a fresh `wake-budget: 12/12`.
+
+`stopGate` blocks on `activeWork` alone, independent of the pane snapshot, and
+`ClaudePtyBrainAdapter` resets `consecutiveStopBlocks` to 0 on every turn that is
+allowed to end. So each wake buys three more refusals: twelve wakes is up to
+thirty-six refusals for work that finished in milliseconds.
+
+### Options for review
+
+- **(a) Wake budget keyed to the work record, not the session.** The budget stops
+  resetting across restarts, so a wedged record burns down and stops.
+  Smallest change, does not need a policy call about what "stale" means.
+- **(b) Clear active work on interrupt.** Escape / new-session / brain replacement
+  finalizes or drops the record. Matches intent: the human stopped it.
+- **(c) Staleness on load.** A record older than some threshold does not auto-wake;
+  it surfaces to the human instead. Needs a threshold nobody can justify yet, and
+  a genuinely long task would trip it.
+
+Recommendation: **(a) + (b)**. (a) bounds the damage of any wedged record whatever
+its cause; (b) fixes the specific way this one got wedged. (c) is deferred — the
+threshold is unjustifiable without data, and (a) already bounds the blast radius.
+
+## 3. F3 — a status number is not something to fix by killing the pane
+
+### What is wrong
+
+The Stop gate's refusal text says to "read its screen, answer what it is waiting
+on, or delegate the next step". Nothing rules out killing the pane. The brain
+escalated to `exit`, then Ctrl+D, on a live user shell.
+
+The gate itself worked: it failed open after three refusals as designed. The
+damage happened inside those three. This is independent of F1 and F2 — pane
+status will be wrong again some day, and the brain must not reach for `exit` when
+it is.
+
+### Change
+
+Name the prohibition where the brain actually reads it: the Stop-gate refusal
+string and the turn contract from #703. A pane's reported status is not a thing
+to resolve by ending the pane — no `exit`, no Ctrl+D, no kill to make a number
+change. When a pane cannot be resolved, hand it to a human with
+`deck_ask_decision` and leave the work active.
+
+### Also a narrow tool guard (review decision, 2026-08-01)
+
+Prose alone was judged too weak for a path that has already destroyed user data
+once. The brain is a separate `claude` process; if it ignores the sentence,
+nothing stops it. Blocking session-terminating input outright is still wrong — an
+orchestrator legitimately needs to close shells — so the guard is conditioned on
+the state this incident was actually in.
+
+Refuse session-terminating input (`exit`, Ctrl+D) when **both** hold: the caller's
+workspace is currently held by the Stop gate, and the target pane is one of the
+panes the gate named as outstanding. Return the reason rather than failing
+silently, so the brain learns why instead of retrying. Everything outside that
+intersection is unaffected: a normal `exit` from an unblocked orchestrator still
+works.
+
+`consecutiveStopBlocks` and the gate's outstanding-pane list already live in main,
+so the condition is readable at the tool boundary without new plumbing. The cost
+is carrying that state down to the input RPC, which is the reason this was
+originally deferred; the review judged the blast radius worth the wiring.
+
+## 4. Tests
+
+### The reason the suite missed this (review finding, confidence 9/10)
+
+Four test files mock the function that carries the bug:
+
+```
+src/main/notification/__tests__/DaemonNotificationRouter.lifecycle.test.ts:40
+  recentlySuppressed: vi.fn().mockReturnValue(false),
+```
+
+Same line in `DaemonNotificationRouter.nudgeExhausted.test.ts:35`,
+`DaemonNotificationRouter.supervision.test.ts:29`, and
+`a2a.channel.rpc.test.ts:64`. Suppression never happens in the test world, so the
+branch that wedges a pane was never executed by any of the 9251 unit tests. That
+is the whole answer to "how did this survive a green suite".
+
+**A regression test that mocks `recentlySuppressed` would repeat that blindness.**
+The F1 test therefore uses the real module: call `markResize(ptyId)` directly,
+then drive `session:idle`, then assert the `agentStatus: 'idle'` broadcast still
+goes out. Reset module state with `clearPty(ptyId)` in teardown, since the maps
+are module-global.
+
+The four dead mock lines are removed with the function.
+
+### Coverage
+
+```
+F1 — status clear
+  DaemonNotificationRouter.onIdle
+    ├── [NEW ★★★] real markResize inside the old window -> still clears   <- the wedge
+    ├── [NEW ★★ ] no resize, no write -> clears (unchanged behaviour)
+    ├── [KEEP ★★] recent agent event -> AGENT_EVENT_SUPPRESSION_MS still suppresses
+    └── [KEEP ★★] daemon explicitTerminalStatus -> daemon never emits idle
+  PTYBridge.onActiveToIdle
+    └── [NEW ★★ ] local-mode twin of the wedge case
+
+F3 — destructive-resolution guard
+  Stop gate refusal string
+    └── [NEW ★★ ] carries the prohibition (asserted on the string the model receives)
+  input RPC guard
+    ├── [NEW ★★★] gate-blocked + target is an outstanding pane -> refused with reason
+    ├── [NEW ★★ ] gate-blocked + target is some other pane     -> allowed
+    └── [NEW ★★ ] not gate-blocked                             -> allowed
+```
+
+## 5. Verification
+
+Unit tests are not enough on their own — this bug survived a full green suite for
+exactly the reason above. The landing gate is the live repro from #733 against a
+dev build: resize a plain shell pane, run a short command inside the window, and
+watch the status settle to `idle` by itself. Then the original orchestrator
+instruction end to end, with the turn finishing and nothing killed.
+
+## 6. NOT in scope
+
+- **F2 (active-work expiry).** Split to a follow-up PR by review decision — it
+  carries a policy question (what counts as stale) that should not hold up F1.
+  Until it lands, an old `deck-work.json` record can still drive auto-wakes.
+  Note for that PR: `autoWakesUsed` lives in `CommanderEventCoalescer` memory and
+  resets on construction, which is why a restart handed the wedged record a fresh
+  12/12 budget. Keying the budget to the record means persisting it.
+- **The false `running` a resize redraw raises.** A TUI repaint is several KB, so
+  it trips `onActive` and flashes `running` for ~5 s. Pre-existing, not introduced
+  here, and after F1 it self-heals instead of sticking. Left alone.
+- **`ActivityMonitor` retry-on-dropped-callback.** See section 1.
+- **The `saveAsync` storm** (277 writes in three minutes). It is a symptom of the
+  re-check loop, so F1 and F2 shrink it; coalescing is separate work.
+
+## 7. What already exists
+
+- `recentlyResized()` (3 s) already separates "was this burst a repaint?" from the
+  30 s notification suppressor. It keeps its caller and is untouched — the fix
+  narrows to the suppressor that lost its purpose.
+- The daemon already refuses to emit idle once a hook or detector settled the turn
+  (`explicitTerminalStatus`), and main already defers to a recent precise status
+  (`AGENT_EVENT_SUPPRESSION_MS`). Agent panes are covered without new code; F1
+  only restores the plain-shell path.
+- `consecutiveStopBlocks` and the gate's outstanding-pane list already exist in
+  main, so the F3 guard reads state rather than computing it.
+- `clearPty()` already exists for per-pane teardown and is what the new test uses
+  to isolate module-global state.
+
+## 8. Also folded in from review
+
+- Rewrite the `idleSuppression.ts` module docblock. It still describes the deleted
+  "Task may have finished" toast as the module's purpose, which is the exact
+  misdirection that let this bug live. A module whose header lies is how the next
+  reader repeats the mistake.
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | — | — |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR | 2 issues, 0 critical gaps |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+- **VERDICT:** ENG CLEARED — ready to implement F1 + F3. F2 split to a follow-up PR.
+
+NO UNRESOLVED DECISIONS

--- a/src/main/deck/__tests__/stopGate.test.ts
+++ b/src/main/deck/__tests__/stopGate.test.ts
@@ -123,3 +123,24 @@ describe('evaluateStopGate', () => {
     expect(evaluateStopGate({ snapshot: snapshot([]), consecutiveBlocks: 0 }).block).toBe(false);
   });
 });
+
+// Regression: #733 — the brain read "resolve these panes" as "end these panes"
+// and ran `exit`, then Ctrl+D, in a live user shell. This string is the only
+// thing it reads about a block, so the prohibition has to be in it. Asserted on
+// the string the model actually receives, not on a copy.
+describe('stop gate refusal names what not to do (#733)', () => {
+  it('forbids closing a pane to clear its status, and points at the way out', () => {
+    const verdict = evaluateStopGate({
+      snapshot: {
+        ts: Date.now(),
+        panes: [{ ptyId: 'pty-a', agentStatus: 'running' }],
+      } as unknown as FleetSnapshot,
+      consecutiveBlocks: 0,
+    });
+    expect(verdict.block).toBe(true);
+    const reason = verdict.block ? verdict.reason : '';
+    expect(reason).toMatch(/Do NOT close or kill a pane/);
+    expect(reason).toMatch(/no exit, no Ctrl\+D, no kill/);
+    expect(reason).toMatch(/deck_ask_decision/);
+  });
+});

--- a/src/main/deck/__tests__/stopGateState.test.ts
+++ b/src/main/deck/__tests__/stopGateState.test.ts
@@ -17,8 +17,21 @@ import {
   resetGateVerdicts,
   GATE_VERDICT_TTL_MS,
 } from '../stopGateState';
-import { outstandingPtyIds } from '../stopGate';
+import { evaluateStopGate, DEFAULT_MAX_SNAPSHOT_AGE_MS } from '../stopGate';
 import type { FleetSnapshot } from '../../../shared/workspaceMirror';
+
+const NOW = 1_700_000_000_000;
+
+function snapshotAt(ts: number): FleetSnapshot {
+  return {
+    ts,
+    panes: [
+      { ptyId: 'pty-running', agentStatus: 'running' },
+      { ptyId: 'pty-waiting', agentStatus: 'awaiting_input' },
+      { ptyId: 'pty-idle', agentStatus: 'idle' },
+    ],
+  } as unknown as FleetSnapshot;
+}
 
 const WS = 'ws-1';
 
@@ -64,20 +77,47 @@ describe('stopGateState (#733)', () => {
   });
 
   it('records exactly the panes the refusal names', () => {
-    // One definition of "outstanding", shared with the reason string, so the
-    // guard can never protect a different set than the model was told about.
-    const snapshot = {
-      ts: Date.now(),
-      panes: [
-        { ptyId: 'pty-running', agentStatus: 'running' },
-        { ptyId: 'pty-waiting', agentStatus: 'awaiting_input' },
-        { ptyId: 'pty-idle', agentStatus: 'idle' },
-      ],
-    } as unknown as FleetSnapshot;
+    // The verdict carries the set, so the guard cannot protect a different one
+    // than the model was told about.
+    const verdict = evaluateStopGate({
+      snapshot: snapshotAt(NOW),
+      consecutiveBlocks: 0,
+      now: NOW,
+    });
+    expect(verdict.block).toBe(true);
 
-    noteGateVerdict(WS, outstandingPtyIds(snapshot));
+    noteGateVerdict(WS, verdict.block ? verdict.outstandingPtyIds : null);
     expect(isGateHeldOn(WS, 'pty-running')).toBe(true);
     expect(isGateHeldOn(WS, 'pty-waiting')).toBe(true);
     expect(isGateHeldOn(WS, 'pty-idle')).toBe(false);
+  });
+
+  // Regression for the review catch on this PR: a stale snapshot blocks on the
+  // active-work reason alone and names NO pane. Deriving the protected set from
+  // the snapshot instead of the verdict protected panes the model was never
+  // told about — the exact drift the verdict field exists to prevent.
+  it('protects nothing when the block names no pane (stale snapshot + active work)', () => {
+    const verdict = evaluateStopGate({
+      snapshot: snapshotAt(NOW - DEFAULT_MAX_SNAPSHOT_AGE_MS - 1),
+      activeWork: { id: 'work-1' },
+      consecutiveBlocks: 0,
+      now: NOW,
+    });
+    expect(verdict.block).toBe(true);
+    // The refusal is about the work record, not about any pane.
+    expect(verdict.block && verdict.outstandingPtyIds).toEqual([]);
+
+    noteGateVerdict(WS, verdict.block ? verdict.outstandingPtyIds : null);
+    expect(isGateHeldOn(WS, 'pty-running')).toBe(false);
+  });
+
+  it('protects nothing when there is no snapshot at all', () => {
+    const verdict = evaluateStopGate({
+      snapshot: null,
+      activeWork: { id: 'work-1' },
+      consecutiveBlocks: 0,
+      now: NOW,
+    });
+    expect(verdict.block && verdict.outstandingPtyIds).toEqual([]);
   });
 });

--- a/src/main/deck/__tests__/stopGateState.test.ts
+++ b/src/main/deck/__tests__/stopGateState.test.ts
@@ -1,0 +1,83 @@
+// Regression: #733 — the brain killed a live user shell to clear its status.
+//
+// The Stop gate told it "resolve these panes"; it read that as "end these
+// panes" and ran `exit`, then Ctrl+D. The refusal text now forbids that, but
+// the brain is a separate process and prose is not a control. This module is
+// the enforcement half: it remembers which panes are holding a workspace's
+// gate so `input.rpc` can refuse exactly that intersection.
+//
+// The scope matters as much as the block. Refusing every `exit` would make the
+// orchestrator unable to close shells at all, so these tests pin both edges:
+// the pane the gate named is protected, and nothing else is.
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  noteGateVerdict,
+  isGateHeldOn,
+  clearGateVerdict,
+  resetGateVerdicts,
+  GATE_VERDICT_TTL_MS,
+} from '../stopGateState';
+import { outstandingPtyIds } from '../stopGate';
+import type { FleetSnapshot } from '../../../shared/workspaceMirror';
+
+const WS = 'ws-1';
+
+describe('stopGateState (#733)', () => {
+  beforeEach(() => resetGateVerdicts());
+
+  it('protects a pane the gate is blocked on', () => {
+    noteGateVerdict(WS, ['pty-a']);
+    expect(isGateHeldOn(WS, 'pty-a')).toBe(true);
+  });
+
+  it('leaves other panes alone while the gate is held', () => {
+    // The orchestrator is blocked on pty-a. Closing an unrelated shell is
+    // still its business.
+    noteGateVerdict(WS, ['pty-a']);
+    expect(isGateHeldOn(WS, 'pty-b')).toBe(false);
+  });
+
+  it('releases every pane once the gate lets a turn end', () => {
+    noteGateVerdict(WS, ['pty-a']);
+    noteGateVerdict(WS, null);
+    expect(isGateHeldOn(WS, 'pty-a')).toBe(false);
+  });
+
+  it('does not touch other workspaces', () => {
+    noteGateVerdict(WS, ['pty-a']);
+    expect(isGateHeldOn('ws-2', 'pty-a')).toBe(false);
+  });
+
+  it('expires on its own so an abandoned turn cannot protect panes forever', () => {
+    // The bug being fixed here came from state that outlived its meaning.
+    // This record must not repeat that.
+    const t0 = 1_000_000;
+    noteGateVerdict(WS, ['pty-a'], t0);
+    expect(isGateHeldOn(WS, 'pty-a', t0 + GATE_VERDICT_TTL_MS - 1)).toBe(true);
+    expect(isGateHeldOn(WS, 'pty-a', t0 + GATE_VERDICT_TTL_MS + 1)).toBe(false);
+  });
+
+  it('clears on demand when a commander session is replaced', () => {
+    noteGateVerdict(WS, ['pty-a']);
+    clearGateVerdict(WS);
+    expect(isGateHeldOn(WS, 'pty-a')).toBe(false);
+  });
+
+  it('records exactly the panes the refusal names', () => {
+    // One definition of "outstanding", shared with the reason string, so the
+    // guard can never protect a different set than the model was told about.
+    const snapshot = {
+      ts: Date.now(),
+      panes: [
+        { ptyId: 'pty-running', agentStatus: 'running' },
+        { ptyId: 'pty-waiting', agentStatus: 'awaiting_input' },
+        { ptyId: 'pty-idle', agentStatus: 'idle' },
+      ],
+    } as unknown as FleetSnapshot;
+
+    noteGateVerdict(WS, outstandingPtyIds(snapshot));
+    expect(isGateHeldOn(WS, 'pty-running')).toBe(true);
+    expect(isGateHeldOn(WS, 'pty-waiting')).toBe(true);
+    expect(isGateHeldOn(WS, 'pty-idle')).toBe(false);
+  });
+});

--- a/src/main/deck/stopGate.ts
+++ b/src/main/deck/stopGate.ts
@@ -39,22 +39,22 @@ export const DEFAULT_MAX_CONSECUTIVE_BLOCKS = 3;
  *  "running" means "was running when the renderer last got a frame". */
 export const DEFAULT_MAX_SNAPSHOT_AGE_MS = 30_000;
 
-export type StopGateVerdict = { block: false } | { block: true; reason: string };
+export type StopGateVerdict =
+  | { block: false }
+  /**
+   * `outstandingPtyIds` is the set of panes this refusal is actually about, and
+   * it is EMPTY for a block that names none — an active-work hold with a
+   * missing or stale snapshot. `input.rpc` protects exactly this set (#733), so
+   * it has to travel with the verdict rather than be re-derived by the caller:
+   * a caller re-reading a stale snapshot would protect panes the model was
+   * never told about, which is the drift this field exists to make impossible.
+   */
+  | { block: true; reason: string; outstandingPtyIds: string[] };
 
 /** Pane statuses that mean "this pane still needs the orchestrator". The same
  *  attention set CommanderEventCoalescer treats as non-quiescent. */
 function isOutstanding(status: FleetSnapshotPane['agentStatus']): boolean {
   return status === 'running' || status === 'awaiting_input';
-}
-
-/**
- * The panes a gate refusal is blocking on. Same predicate the refusal string
- * uses, exported so `input.rpc` can protect exactly the panes the model was
- * just told to resolve — no second definition of "outstanding" to drift (#733).
- */
-export function outstandingPtyIds(snapshot: FleetSnapshot | null): string[] {
-  if (!snapshot) return [];
-  return snapshot.panes.filter((p) => isOutstanding(p.agentStatus)).map((p) => p.ptyId);
 }
 
 /** Short human label for one blocking pane, used in the reason string. */
@@ -98,7 +98,7 @@ export function evaluateStopGate(input: {
       'deck_complete_work({summary, verification}). If work remains, delegate or unblock the next step.'
     : null;
   if (!snapshot) {
-    return finalizeReason ? { block: true, reason: finalizeReason } : { block: false };
+    return finalizeReason ? { block: true, reason: finalizeReason, outstandingPtyIds: [] } : { block: false };
   }
   // Staleness means pane state cannot be used to infer outstanding workers. An
   // active-work record can still hold the turn because it is durable runtime
@@ -106,12 +106,12 @@ export function evaluateStopGate(input: {
   const maxAge = input.maxSnapshotAgeMs ?? DEFAULT_MAX_SNAPSHOT_AGE_MS;
   const age = (input.now ?? Date.now()) - snapshot.ts;
   if (age > maxAge) {
-    return finalizeReason ? { block: true, reason: finalizeReason } : { block: false };
+    return finalizeReason ? { block: true, reason: finalizeReason, outstandingPtyIds: [] } : { block: false };
   }
 
   const outstanding = snapshot.panes.filter((p) => isOutstanding(p.agentStatus));
   if (outstanding.length === 0) {
-    return finalizeReason ? { block: true, reason: finalizeReason } : { block: false };
+    return finalizeReason ? { block: true, reason: finalizeReason, outstandingPtyIds: [] } : { block: false };
   }
 
   // This string is the ONLY thing the model reads about the refusal, so it
@@ -128,6 +128,7 @@ export function evaluateStopGate(input: {
   const noun = outstanding.length === 1 ? 'pane' : 'panes';
   return {
     block: true,
+    outstandingPtyIds: outstanding.map((p) => p.ptyId),
     reason:
       `Do not end this turn yet: ${outstanding.length} worker ${noun} still need you — ${list}. ` +
       'Check each one (read its screen, answer what it is waiting on, or delegate the next step). ' +

--- a/src/main/deck/stopGate.ts
+++ b/src/main/deck/stopGate.ts
@@ -47,6 +47,16 @@ function isOutstanding(status: FleetSnapshotPane['agentStatus']): boolean {
   return status === 'running' || status === 'awaiting_input';
 }
 
+/**
+ * The panes a gate refusal is blocking on. Same predicate the refusal string
+ * uses, exported so `input.rpc` can protect exactly the panes the model was
+ * just told to resolve — no second definition of "outstanding" to drift (#733).
+ */
+export function outstandingPtyIds(snapshot: FleetSnapshot | null): string[] {
+  if (!snapshot) return [];
+  return snapshot.panes.filter((p) => isOutstanding(p.agentStatus)).map((p) => p.ptyId);
+}
+
 /** Short human label for one blocking pane, used in the reason string. */
 function describePane(pane: FleetSnapshotPane): string {
   const name = pane.agentName && pane.agentName.length > 0 ? pane.agentName : pane.ptyId;
@@ -106,6 +116,14 @@ export function evaluateStopGate(input: {
 
   // This string is the ONLY thing the model reads about the refusal, so it
   // names the panes, their statuses, and the action that clears the gate.
+  //
+  // It also has to name what NOT to do. Issue #733: a pane wedged at `running`
+  // held the gate, and the brain escalated to `exit` and then Ctrl+D on a live
+  // user shell — reading "resolve the pane" as "end the pane". A reported
+  // status is not resolved by killing the thing it describes, and the pane
+  // belongs to a human who did not ask for it to close. `input.rpc` enforces
+  // this for the panes named here; the sentence exists so the model does not
+  // have to learn it by being refused.
   const list = outstanding.map(describePane).join(', ');
   const noun = outstanding.length === 1 ? 'pane' : 'panes';
   return {
@@ -113,6 +131,9 @@ export function evaluateStopGate(input: {
     reason:
       `Do not end this turn yet: ${outstanding.length} worker ${noun} still need you — ${list}. ` +
       'Check each one (read its screen, answer what it is waiting on, or delegate the next step). ' +
+      'Do NOT close or kill a pane to clear its status — no exit, no Ctrl+D, no kill. ' +
+      'Those sessions belong to the human. If a pane will not resolve, leave it running and ' +
+      'raise it with deck_ask_decision instead of ending it. ' +
       (finalizeReason ?? 'If there is genuinely nothing left for you to do, say so and stop again.'),
   };
 }

--- a/src/main/deck/stopGateState.ts
+++ b/src/main/deck/stopGateState.ts
@@ -1,0 +1,77 @@
+// ─── Which panes are currently holding a workspace's Stop gate ──────────────
+//
+// Issue #733: a pane wedged at `running` held the gate open, and the brain
+// escaped by running `exit` and then Ctrl+D in that pane — killing a live shell
+// the human owned. The refusal text now forbids that, but prose is not a
+// control: the brain is a separate `claude` process and can ignore it.
+//
+// This module is the enforcement half. `stopGate` already computes exactly the
+// set of panes it is blocking on, so recording that set costs nothing and lets
+// `input.rpc` refuse the one action that turned a status bug into data loss:
+// session-terminating input, aimed at a pane the caller is currently blocked
+// on. Everything else is untouched — an orchestrator that is not gate-held may
+// close shells freely, and even a gate-held one may close panes it is not
+// blocked on.
+//
+// The record is deliberately short-lived. A gate verdict is a statement about
+// one moment; the failure mode we just fixed came from state that outlived its
+// meaning and was never re-checked, so this one expires on its own rather than
+// waiting for something to clear it.
+
+/** How long a recorded verdict is trusted. A Stop gate decision is re-made on
+ *  every Stop, which is far more often than this — the TTL only bounds how long
+ *  a crashed or abandoned turn can keep panes protected. */
+export const GATE_VERDICT_TTL_MS = 60_000;
+
+interface GateHold {
+  ptyIds: Set<string>;
+  at: number;
+}
+
+const holds = new Map<string, GateHold>();
+
+/**
+ * Record the outcome of one Stop-gate evaluation. Pass the panes the gate named
+ * as outstanding, or an empty list / null when the turn was allowed to end.
+ */
+export function noteGateVerdict(
+  workspaceId: string,
+  outstandingPtyIds: readonly string[] | null,
+  now: number = Date.now(),
+): void {
+  if (!outstandingPtyIds || outstandingPtyIds.length === 0) {
+    holds.delete(workspaceId);
+    return;
+  }
+  holds.set(workspaceId, { ptyIds: new Set(outstandingPtyIds), at: now });
+}
+
+/**
+ * Is `ptyId` one of the panes currently holding `workspaceId`'s Stop gate?
+ * False for an unknown workspace, an expired verdict, or a pane the gate did
+ * not name — the guard fails OPEN, because wrongly refusing a legitimate write
+ * is worse than the narrow case it protects.
+ */
+export function isGateHeldOn(
+  workspaceId: string,
+  ptyId: string,
+  now: number = Date.now(),
+): boolean {
+  const hold = holds.get(workspaceId);
+  if (!hold) return false;
+  if (now - hold.at > GATE_VERDICT_TTL_MS) {
+    holds.delete(workspaceId);
+    return false;
+  }
+  return hold.ptyIds.has(ptyId);
+}
+
+/** Drop a workspace's record — called when its commander session is replaced. */
+export function clearGateVerdict(workspaceId: string): void {
+  holds.delete(workspaceId);
+}
+
+/** Test seam. */
+export function resetGateVerdicts(): void {
+  holds.clear();
+}

--- a/src/main/ipc/__tests__/pty.handler.oversize-segment.test.ts
+++ b/src/main/ipc/__tests__/pty.handler.oversize-segment.test.ts
@@ -137,14 +137,4 @@ describe('pty.handler PTY_WRITE oversize segmentation (paste-truncation fix)', (
     expect(block).toMatch(/data\.length\s*>\s*PTY_WRITE_HARD_LIMIT/);
   });
 
-  it('preserves user-write marker so idle suppression still fires', () => {
-    const block = writeBlock();
-    // markUserWrite must run for every accepted write — the idle
-    // notification suppression (see idleSuppression.ts) depends on
-    // this stamp to avoid firing "task may have finished" while the
-    // user is actively typing/pasting. If a future refactor moves
-    // markUserWrite into the segmentation loop or skips it for
-    // oversize paths, idle notifications regress.
-    expect(block).toMatch(/markUserWrite\(id\)/);
-  });
 });

--- a/src/main/ipc/handlers/deck.handler.ts
+++ b/src/main/ipc/handlers/deck.handler.ts
@@ -31,8 +31,8 @@ import {
   resolveBrainBridgePath,
   type DaemonClientLike,
 } from '../../deck/ClaudePtyBrainAdapter';
-import { evaluateStopGate, outstandingPtyIds } from '../../deck/stopGate';
-import { noteGateVerdict } from '../../deck/stopGateState';
+import { evaluateStopGate } from '../../deck/stopGate';
+import { noteGateVerdict, clearGateVerdict } from '../../deck/stopGateState';
 import type { BrainVendor } from '../../../shared/types';
 import { getMemoryRootDir } from '../../deck/commanderMemory';
 import { loadDeckPolicyBlock, ensureDeckPolicySeed } from '../../deck/deckPolicy';
@@ -277,11 +277,14 @@ export function registerDeckHandler(
                 consecutiveBlocks,
               });
               // Record which panes are holding the gate so input.rpc can refuse
-              // session-terminating input aimed at them (#733). Cleared as soon
-              // as the gate lets a turn end.
+              // session-terminating input aimed at them (#733). The list comes
+              // off the verdict, never off the snapshot: an active-work hold on
+              // a stale snapshot blocks without naming a pane, and re-reading
+              // that snapshot here would protect panes the model was never told
+              // about. Cleared as soon as the gate lets a turn end.
               noteGateVerdict(
                 workspaceId,
-                verdict.block ? outstandingPtyIds(snapshot) : null,
+                verdict.block ? verdict.outstandingPtyIds : null,
               );
               return verdict;
             },
@@ -323,6 +326,17 @@ export function registerDeckHandler(
     vendor: BrainVendor;
   }
   const managers = new Map<string, ManagedCommander>();
+
+  /**
+   * Retire a workspace's commander. Every dispose path routes through here so
+   * the Stop-gate hold dies with the commander that created it (#733) — a new
+   * commander in the same workspace must not inherit the old one's protected
+   * pane set.
+   */
+  const retireManager = (workspaceId: string): void => {
+    managers.delete(workspaceId);
+    clearGateVerdict(workspaceId);
+  };
 
   // Fleet-wide ceiling on CONCURRENT autonomous turns. Each workspace's manager
   // is already one-turn-at-a-time, but a hook storm across many workspaces could
@@ -486,7 +500,7 @@ export function registerDeckHandler(
       existing.manager.getStatus().status !== 'busy'
     ) {
       existing.manager.dispose();
-      managers.delete(workspaceId);
+      retireManager(workspaceId);
       forgetAmbient(workspaceId);
     }
     const current = managers.get(workspaceId);
@@ -734,7 +748,7 @@ export function registerDeckHandler(
       const entry = managers.get(workspaceId);
       if (entry) {
         entry.manager.dispose(); // interrupts an in-flight turn, flips to disposed
-        managers.delete(workspaceId);
+        retireManager(workspaceId);
         forgetAmbient(workspaceId);
       }
       // The vendor this workspace actually RAN as, not the one selected: a
@@ -793,7 +807,7 @@ export function registerDeckHandler(
         for (const [workspaceId, entry] of [...managers]) {
           if (entry.fullPower !== enabled && entry.manager.getStatus().status !== 'busy') {
             entry.manager.dispose();
-            managers.delete(workspaceId);
+            retireManager(workspaceId);
             forgetAmbient(workspaceId);
           }
         }
@@ -828,7 +842,7 @@ export function registerDeckHandler(
             entry.manager.getStatus().status !== 'busy'
           ) {
             entry.manager.dispose();
-            managers.delete(workspaceId);
+            retireManager(workspaceId);
             forgetAmbient(workspaceId);
             // A retired terminal brain takes its embedded pty with it.
             emitBrainPty(workspaceId, null);
@@ -866,7 +880,7 @@ export function registerDeckHandler(
         for (const [workspaceId, entry] of [...managers]) {
           if (entry.vendor !== vendor && entry.manager.getStatus().status !== 'busy') {
             entry.manager.dispose();
-            managers.delete(workspaceId);
+            retireManager(workspaceId);
             forgetAmbient(workspaceId);
             // The retired brain's embedded terminal is gone with it — retract
             // the pty id so the deck falls back to the bubble view instead of

--- a/src/main/ipc/handlers/deck.handler.ts
+++ b/src/main/ipc/handlers/deck.handler.ts
@@ -31,7 +31,8 @@ import {
   resolveBrainBridgePath,
   type DaemonClientLike,
 } from '../../deck/ClaudePtyBrainAdapter';
-import { evaluateStopGate } from '../../deck/stopGate';
+import { evaluateStopGate, outstandingPtyIds } from '../../deck/stopGate';
+import { noteGateVerdict } from '../../deck/stopGateState';
 import type { BrainVendor } from '../../../shared/types';
 import { getMemoryRootDir } from '../../deck/commanderMemory';
 import { loadDeckPolicyBlock, ensureDeckPolicySeed } from '../../deck/deckPolicy';
@@ -268,12 +269,22 @@ export function registerDeckHandler(
             // The Stop gate: the orchestrator may not end a turn while worker
             // panes are still running or waiting on it. The mirror lookup lives
             // here, not in the adapter, so the predicate stays pure.
-            evaluateStopGate: (workspaceId, consecutiveBlocks) =>
-              evaluateStopGate({
-                snapshot: getWorkspaceMirror().getFleetSnapshot(workspaceId),
+            evaluateStopGate: (workspaceId, consecutiveBlocks) => {
+              const snapshot = getWorkspaceMirror().getFleetSnapshot(workspaceId);
+              const verdict = evaluateStopGate({
+                snapshot,
                 activeWork: loadActiveDeckWork(workspaceId),
                 consecutiveBlocks,
-              }),
+              });
+              // Record which panes are holding the gate so input.rpc can refuse
+              // session-terminating input aimed at them (#733). Cleared as soon
+              // as the gate lets a turn end.
+              noteGateVerdict(
+                workspaceId,
+                verdict.block ? outstandingPtyIds(snapshot) : null,
+              );
+              return verdict;
+            },
             onForeignTurnEnd: adapterOpts.onForeignTurnEnd,
             onForeignSessionId: adapterOpts.onForeignSessionId,
             // The model picker applies to the TUI brain too (`--model`);

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -25,7 +25,7 @@ import {
   type SessionDataHandler,
 } from './sessionDataDispatcher';
 import { updateCwd } from './metadata.handler';
-import { markResize, markUserWrite } from '../../notification/idleSuppression';
+import { markResize } from '../../notification/idleSuppression';
 import { wrapHandler } from '../wrapHandler';
 import { dispatchNotification } from '../../notification/dispatchNotification';
 import {
@@ -586,10 +586,6 @@ export function registerPTYHandlers(
   }
 
   // pty:write
-  // User keystrokes echo back through the PTY (the shell/TUI writes them
-  // to the screen), so they show up to ActivityMonitor as agent output.
-  // Mark the user-write timestamp so the idle fallback suppresses itself
-  // while the user is typing (see idleSuppression.ts).
   //
   // Oversize backstop (defense-in-depth): the renderer chunks paste
   // payloads into PTY_WRITE_BACKSTOP_CHUNK_SIZE-byte segments before
@@ -636,7 +632,6 @@ export function registerPTYHandlers(
       if (data.length > PTY_WRITE_BACKSTOP) {
         console.warn(`[PTY_WRITE] oversize payload ${data.length} chars > ${PTY_WRITE_BACKSTOP}; segmenting locally. Renderer should chunk at the source.`);
       }
-      markUserWrite(id);
       const segments = segmentOversize(data);
       let allDelivered = true;
       for (const segment of segments) {
@@ -667,7 +662,6 @@ export function registerPTYHandlers(
       if (data.length > PTY_WRITE_BACKSTOP) {
         console.warn(`[PTY_WRITE] oversize payload ${data.length} chars > ${PTY_WRITE_BACKSTOP}; segmenting locally. Renderer should chunk at the source.`);
       }
-      markUserWrite(id);
       const segments = segmentOversize(data);
       for (const segment of segments) {
         ptyManager.write(id, sanitizePtyText(segment));
@@ -678,10 +672,9 @@ export function registerPTYHandlers(
 
   // pty:resize
   // TUI agents (Claude, Codex, etc.) respond to SIGWINCH with a full-screen
-  // redraw, which spikes ActivityMonitor's byte counter and triggers the
-  // "Task may have finished" fallback when the user moves on within 5s.
-  // Mark the resize timestamp so the fallback suppresses itself for the
-  // suppression window (see idleSuppression.ts).
+  // redraw. Mark the resize timestamp so the AgentDetector emission-reset
+  // guard can tell that repaint from a genuinely new turn — an unchanged idle
+  // footer must not re-fire a stale "Ready for input" (see idleSuppression.ts).
   ipcMain.removeHandler(IPC.PTY_RESIZE);
   if (useDaemon && daemonClient) {
     ipcMain.handle(IPC.PTY_RESIZE, wrapHandler(IPC.PTY_RESIZE, async (_event: Electron.IpcMainInvokeEvent, id: string, cols: number, rows: number) => {

--- a/src/main/notification/DaemonNotificationRouter.ts
+++ b/src/main/notification/DaemonNotificationRouter.ts
@@ -4,7 +4,7 @@ import type { AgentStatus } from '../../shared/types';
 import type { HookSignalRouter } from '../hooks/HookSignalRouter';
 import { IPC } from '../../shared/constants';
 import { dispatchNotification } from './dispatchNotification';
-import { recentlySuppressed, clearPty as clearSuppression } from './idleSuppression';
+import { clearPty as clearSuppression } from './idleSuppression';
 import { broadcastMetadataUpdate } from '../ipc/handlers/metadata.handler';
 import { eventBus } from '../events/EventBus';
 import {
@@ -935,8 +935,11 @@ export class DaemonNotificationRouter {
       const now = Date.now();
       const lastAgentAt = this.lastAgentEventAt.get(payload.sessionId) ?? 0;
       if (now - lastAgentAt < AGENT_EVENT_SUPPRESSION_MS) return;
-      // Same resize/typing suppression as local mode (see idleSuppression.ts).
-      if (recentlySuppressed(payload.sessionId, now)) return;
+      // No resize/typing gate here: this handler's only job is the status
+      // clear, and dropping it wedges the pane at `running` permanently
+      // (ActivityMonitor has already consumed the transition, and a quiet pane
+      // never produces another burst to re-fire it). See idleSuppression.ts
+      // and issue #733. The precise-status deference above still applies.
       try {
         const win = this.getWindow();
         // Daemon-mode twin of PTYBridge.onActiveToIdle: keep the stale-'running'

--- a/src/main/notification/__tests__/DaemonNotificationRouter.lifecycle.test.ts
+++ b/src/main/notification/__tests__/DaemonNotificationRouter.lifecycle.test.ts
@@ -37,7 +37,6 @@ vi.mock('../dispatchNotification', () => ({
 }));
 
 vi.mock('../idleSuppression', () => ({
-  recentlySuppressed: vi.fn().mockReturnValue(false),
   clearPty: vi.fn(),
 }));
 

--- a/src/main/notification/__tests__/DaemonNotificationRouter.nudgeExhausted.test.ts
+++ b/src/main/notification/__tests__/DaemonNotificationRouter.nudgeExhausted.test.ts
@@ -32,7 +32,6 @@ vi.mock('../dispatchNotification', () => ({
 }));
 
 vi.mock('../idleSuppression', () => ({
-  recentlySuppressed: vi.fn().mockReturnValue(false),
   clearPty: vi.fn(),
 }));
 

--- a/src/main/notification/__tests__/DaemonNotificationRouter.statusClear.test.ts
+++ b/src/main/notification/__tests__/DaemonNotificationRouter.statusClear.test.ts
@@ -1,0 +1,128 @@
+// Regression: #733 — a finished pane stayed `running` forever.
+//
+// `session:idle` is the ONLY path that clears a plain shell's status back to
+// `idle`: AgentDetector never matches a bare PowerShell/bash, so no
+// `session:agent` ever arrives. That clear used to sit behind
+// `recentlySuppressed()`, a 30s window built for a notification that had
+// already been deleted. A workspace switch (pty:resize) inside the window made
+// the handler drop the clear, and ActivityMonitor consumes its transition
+// BEFORE invoking callbacks, so nothing ever retried. The pane reported
+// `running` at an idle prompt until it was closed.
+//
+// ── Why this file does not mock idleSuppression ──────────────────────────────
+// Four existing suites stub it with `recentlySuppressed: () => false`, which is
+// exactly why 9251 unit tests stayed green through this bug: the branch that
+// wedges a pane was never executed. These tests drive the REAL module — they
+// call `markResize()` the way pty.handler does — so a future guard reintroduced
+// in front of the status clear fails here instead of shipping.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { DaemonClient } from '../../DaemonClient';
+
+vi.mock('electron', () => ({ BrowserWindow: class {} }));
+
+vi.mock('../../pipe/handlers/notify.rpc', () => ({
+  toastManager: { show: vi.fn() },
+}));
+
+vi.mock('../../ipc/handlers/metadata.handler', () => ({
+  broadcastMetadataUpdate: vi.fn(),
+}));
+
+vi.mock('../dispatchNotification', () => ({
+  dispatchNotification: vi.fn(),
+}));
+
+vi.mock('../../pipe/handlers/_bridge', () => ({
+  sendToRenderer: vi.fn(),
+}));
+
+import { broadcastMetadataUpdate } from '../../ipc/handlers/metadata.handler';
+import { markResize, clearPty } from '../idleSuppression';
+import { DaemonNotificationRouter } from '../DaemonNotificationRouter';
+
+const broadcastMetadataUpdateMock = vi.mocked(broadcastMetadataUpdate);
+
+const PTY = 'daemon-plain-shell';
+
+interface Captured {
+  idle?: (payload: { sessionId: string }) => void;
+  agent?: (payload: { sessionId: string; event: unknown }) => void;
+}
+
+function makeRouter() {
+  const captured: Captured = {};
+  const fakeDaemon = {
+    on: vi.fn((event: string, cb: (payload: never) => void) => {
+      if (event === 'session:idle') captured.idle = cb as Captured['idle'];
+      if (event === 'session:agent') captured.agent = cb as Captured['agent'];
+    }),
+    off: vi.fn(),
+  } as unknown as DaemonClient;
+  const router = new DaemonNotificationRouter(fakeDaemon, () => null);
+  router.start();
+  return { router, captured };
+}
+
+/** Did the handler broadcast the status clear for this pane? */
+function clearedIdle(): boolean {
+  return broadcastMetadataUpdateMock.mock.calls.some(
+    ([, patch]) =>
+      (patch as { ptyId?: string; agentStatus?: string }).ptyId === PTY &&
+      (patch as { agentStatus?: string }).agentStatus === 'idle',
+  );
+}
+
+describe('DaemonNotificationRouter status clear (#733)', () => {
+  beforeEach(() => {
+    broadcastMetadataUpdateMock.mockClear();
+    // Module-global maps — isolate every case.
+    clearPty(PTY);
+  });
+
+  afterEach(() => {
+    clearPty(PTY);
+    vi.useRealTimers();
+  });
+
+  it('clears a quiet pane to idle when nothing has happened', () => {
+    const { router, captured } = makeRouter();
+    captured.idle?.({ sessionId: PTY });
+    expect(clearedIdle()).toBe(true);
+    router.stop();
+  });
+
+  it('still clears when a resize just happened — the #733 wedge', () => {
+    const { router, captured } = makeRouter();
+    // What a workspace switch does, through the same entry point pty.handler
+    // uses. Before the fix this made the clear vanish for good.
+    markResize(PTY);
+    captured.idle?.({ sessionId: PTY });
+    expect(clearedIdle()).toBe(true);
+    router.stop();
+  });
+
+  it('still clears long after a resize, so the pane cannot wedge', () => {
+    vi.useFakeTimers();
+    const { router, captured } = makeRouter();
+    markResize(PTY);
+    // Comfortably inside the window the old guard used (30s).
+    vi.advanceTimersByTime(5_000);
+    captured.idle?.({ sessionId: PTY });
+    expect(clearedIdle()).toBe(true);
+    router.stop();
+  });
+
+  it('defers to a recent precise agent status instead of overwriting it', () => {
+    const { router, captured } = makeRouter();
+    // A real waiting/complete signal outranks byte silence — this protection
+    // is deliberately kept, so agent panes do not flip to idle mid-turn.
+    captured.agent?.({
+      sessionId: PTY,
+      event: { agent: 'Claude Code', status: 'waiting', message: 'Ready' },
+    });
+    broadcastMetadataUpdateMock.mockClear();
+    captured.idle?.({ sessionId: PTY });
+    expect(clearedIdle()).toBe(false);
+    router.stop();
+  });
+});

--- a/src/main/notification/__tests__/DaemonNotificationRouter.supervision.test.ts
+++ b/src/main/notification/__tests__/DaemonNotificationRouter.supervision.test.ts
@@ -26,7 +26,6 @@ vi.mock('../sendNotification', () => ({
 }));
 
 vi.mock('../idleSuppression', () => ({
-  recentlySuppressed: vi.fn().mockReturnValue(false),
   clearPty: vi.fn(),
 }));
 

--- a/src/main/notification/idleSuppression.ts
+++ b/src/main/notification/idleSuppression.ts
@@ -1,65 +1,41 @@
 /**
- * Per-PTY suppression for the ActivityMonitor "Task may have finished"
- * fallback notification.
+ * Per-PTY resize bookkeeping for the AgentDetector emission-reset guard.
  *
- * The fallback fires when output has been quiet for IDLE_DELAY_MS (5s) after
- * a sustained burst. That heuristic produces false positives in two
- * everyday cases:
+ * This module used to carry a second, much wider guard: a 30s window that
+ * suppressed the ActivityMonitor "Task may have finished" fallback
+ * NOTIFICATION after a resize redraw or a burst of typing. That toast was
+ * removed (see PTYBridge.onActiveToIdle / DaemonNotificationRouter.onIdle —
+ * the byte-silence heuristic cannot tell a finished turn from a mid-turn tool
+ * call, so it raised false "Task may have finished" toasts on plain shells).
  *
- *   1. PTY resize: switching to a workspace fits xterm, sends pty:resize,
- *      and TUI agents (Claude, Codex) respond with a full-screen redraw.
- *      The redraw is several KB → ActivityMonitor enters 'active'. If the
- *      user leaves the workspace within 5s, the idle timer fires later and
- *      a notification appears for a workspace the user just visited
- *      without typing anything.
+ * The window outlived the toast and kept gating the handler's only remaining
+ * job: clearing a stale `running` back to `idle`. That was strictly wrong.
+ * `onActive` was never gated, so a resize redraw — several KB of repaint —
+ * raised a false `running` and then the window blocked the very clear that
+ * would have corrected it. Worse, ActivityMonitor consumes its state
+ * transition BEFORE invoking callbacks, so a swallowed idle never retried:
+ * a quiet pane stayed `running` forever, and for a plain shell (no
+ * AgentDetector match, so no `session:agent` ever arrives) `session:idle` is
+ * the only path that can clear the status at all. See issue #733.
  *
- *   2. User typing: keystrokes echo back through the PTY (the shell or TUI
- *      writes the typed character to the screen). Long input, paste, or
- *      sustained typing crosses the active threshold; pausing to think
- *      then fires the idle notification while the user is still composing.
- *
- * Both PTYBridge (local mode) and DaemonNotificationRouter (daemon mode)
- * consult `recentlySuppressed(ptyId)` before emitting the activity
- * fallback, and skip when a recent resize / user write happened.
- *
- * AgentDetector emissions are NOT gated by this — they are precise signals
- * tied to specific prompt patterns, not throughput heuristics.
+ * What remains is the narrow, still-justified guard: a resize is followed
+ * within a couple of seconds by the TUI's full-screen redraw, and resetting
+ * AgentDetector's emission dedup on that burst would let an UNCHANGED idle
+ * footer re-match and re-fire a stale "Ready for input".
  */
 
-// Window length: bigger than ActivityMonitor's IDLE_DELAY_MS (5s) so any
-// idle timer that started during the suppression window still observes the
-// suppression when it fires. 30s gives ample headroom for slow typists
-// and large redraws without masking genuine long-running agent output.
-const SUPPRESSION_WINDOW_MS = 30_000;
-
 const lastResizeAt = new Map<string, number>();
-const lastUserWriteAt = new Map<string, number>();
 
 export function markResize(ptyId: string): void {
   lastResizeAt.set(ptyId, Date.now());
 }
 
-export function markUserWrite(ptyId: string): void {
-  lastUserWriteAt.set(ptyId, Date.now());
-}
-
-export function recentlySuppressed(ptyId: string, now: number = Date.now()): boolean {
-  const r = lastResizeAt.get(ptyId) ?? 0;
-  const w = lastUserWriteAt.get(ptyId) ?? 0;
-  return (now - r < SUPPRESSION_WINDOW_MS) || (now - w < SUPPRESSION_WINDOW_MS);
-}
-
 /**
- * Resize-only check with a caller-chosen (much shorter) window. Used by the
- * AgentDetector emission-reset guard in PTYBridge: a pty:resize is followed
- * within a couple of seconds by the TUI's full-screen redraw burst, and
- * resetting the detector's dedup on that burst lets the UNCHANGED idle
- * footer re-match and re-fire a stale "Ready for input". 3s is deliberately
- * far tighter than SUPPRESSION_WINDOW_MS: this guard delays a dedup RESET
- * (bookkeeping), not a user-visible notification — a genuinely new agent
- * turn re-arms on its next non-resize burst. The daemon process keeps its
- * own timestamp (DaemonPTYBridge.noteResize); these Maps are main-process
- * state only.
+ * Resize-recency check with a caller-chosen window. Used by the AgentDetector
+ * emission-reset guard in PTYBridge, which delays a dedup RESET (bookkeeping),
+ * never a user-visible status update — a genuinely new agent turn re-arms on
+ * its next non-resize burst. The daemon process keeps its own timestamp
+ * (DaemonPTYBridge.noteResize); this Map is main-process state only.
  */
 export const RESIZE_REDRAW_GUARD_MS = 3_000;
 
@@ -73,5 +49,4 @@ export function recentlyResized(
 
 export function clearPty(ptyId: string): void {
   lastResizeAt.delete(ptyId);
-  lastUserWriteAt.delete(ptyId);
 }

--- a/src/main/pipe/handlers/__tests__/a2a.channel.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/a2a.channel.rpc.test.ts
@@ -61,7 +61,6 @@ vi.mock('../../../notification/sendNotification', () => ({
 }));
 
 vi.mock('../../../notification/idleSuppression', () => ({
-  recentlySuppressed: vi.fn().mockReturnValue(false),
   clearPty: vi.fn(),
 }));
 

--- a/src/main/pipe/handlers/__tests__/input.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/input.rpc.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { BrowserWindow } from 'electron';
 import { RpcRouter } from '../../RpcRouter';
-import { registerInputRpc, decideTerminalOmittedTarget } from '../input.rpc';
+import { registerInputRpc, decideTerminalOmittedTarget, isSessionTerminatingInput } from '../input.rpc';
 import type { RoleBindingResolver } from '../input.rpc';
 import type { PTYManager } from '../../../pty/PTYManager';
 import type { RoleBinding } from '../../../../shared/orchestratorRole';
@@ -505,5 +505,30 @@ describe('input.send — role→model enforcement (D2)', () => {
       },
     });
     expect(writeMock.mock.calls[0]).toEqual(['pty-a', 'claude code is failing on windows']);
+  });
+});
+
+
+// Regression: #733 — the brain ran `exit`, then Ctrl+D, in a live user shell to
+// clear a pane stuck at `running`. This is the detector half of the guard that
+// now refuses that. Narrow on purpose: it backstops one escalation, it is not a
+// sandbox, so a false positive (blocking a legitimate write) costs more than a
+// miss.
+describe('isSessionTerminatingInput (#733)', () => {
+  it('matches the ways a session actually gets ended', () => {
+    expect(isSessionTerminatingInput('exit')).toBe(true);
+    expect(isSessionTerminatingInput('exit\r')).toBe(true);
+    expect(isSessionTerminatingInput('  exit  \n')).toBe(true);
+    expect(isSessionTerminatingInput('EXIT')).toBe(true);
+    expect(isSessionTerminatingInput('logout')).toBe(true);
+    expect(isSessionTerminatingInput('\x04')).toBe(true);
+  });
+
+  it('leaves ordinary writes alone', () => {
+    expect(isSessionTerminatingInput('npm test')).toBe(false);
+    expect(isSessionTerminatingInput('exit 1')).toBe(false);
+    expect(isSessionTerminatingInput('grep exit log.txt')).toBe(false);
+    expect(isSessionTerminatingInput('tell me how to exit vim')).toBe(false);
+    expect(isSessionTerminatingInput('')).toBe(false);
   });
 });

--- a/src/main/pipe/handlers/__tests__/input.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/input.rpc.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import type { BrowserWindow } from 'electron';
 import { RpcRouter } from '../../RpcRouter';
 import { registerInputRpc, decideTerminalOmittedTarget, isSessionTerminatingInput } from '../input.rpc';
+import { noteGateVerdict, resetGateVerdicts } from '../../../deck/stopGateState';
 import type { RoleBindingResolver } from '../input.rpc';
 import type { PTYManager } from '../../../pty/PTYManager';
 import type { RoleBinding } from '../../../../shared/orchestratorRole';
@@ -530,5 +531,65 @@ describe('isSessionTerminatingInput (#733)', () => {
     expect(isSessionTerminatingInput('grep exit log.txt')).toBe(false);
     expect(isSessionTerminatingInput('tell me how to exit vim')).toBe(false);
     expect(isSessionTerminatingInput('')).toBe(false);
+  });
+});
+
+// Regression: #733 — the end-to-end seam, not just its parts. The gate records
+// which panes hold it, and this handler is what actually refuses to end one.
+// Both edges are pinned: the protected pane is refused, everything else writes.
+describe('input.send refuses to end a gate-held pane (#733)', () => {
+  function setupWithWrite(): { router: RpcRouter; writeMock: ReturnType<typeof vi.fn> } {
+    const writeMock = vi.fn();
+    const pty = { get: vi.fn(() => ({ id: 'x' })), write: writeMock } as unknown as PTYManager;
+    const router = new RpcRouter();
+    registerInputRpc(router, pty, () => fakeWindow);
+    return { router, writeMock };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetGateVerdicts();
+    sendToRendererMock.mockImplementation((_w: unknown, method: string) => {
+      if (method === 'input.findOwnerWorkspace') return Promise.resolve({ workspaceId: 'ws-1' });
+      return Promise.resolve(null);
+    });
+  });
+
+  const send = (router: RpcRouter, text: string, ptyId: string) =>
+    router.dispatch({
+      id: 'g',
+      method: 'input.send',
+      params: { text, ptyId, workspaceId: 'ws-1' },
+    });
+
+  it('refuses `exit` aimed at the pane holding the caller open', async () => {
+    const { router, writeMock } = setupWithWrite();
+    noteGateVerdict('ws-1', ['pty-held']);
+    const res = await send(router, 'exit', 'pty-held');
+    expect(res.ok).toBe(false);
+    expect(writeMock).not.toHaveBeenCalled();
+  });
+
+  it('lets the same pane take ordinary work', async () => {
+    const { router, writeMock } = setupWithWrite();
+    noteGateVerdict('ws-1', ['pty-held']);
+    const res = await send(router, 'npm test', 'pty-held');
+    expect(res.ok).toBe(true);
+    expect(writeMock).toHaveBeenCalled();
+  });
+
+  it('lets the caller close a pane the gate is NOT blocked on', async () => {
+    const { router, writeMock } = setupWithWrite();
+    noteGateVerdict('ws-1', ['pty-held']);
+    const res = await send(router, 'exit', 'pty-other');
+    expect(res.ok).toBe(true);
+    expect(writeMock).toHaveBeenCalled();
+  });
+
+  it('lets an unblocked orchestrator close shells as before', async () => {
+    const { router, writeMock } = setupWithWrite();
+    const res = await send(router, 'exit', 'pty-held');
+    expect(res.ok).toBe(true);
+    expect(writeMock).toHaveBeenCalled();
   });
 });

--- a/src/main/pipe/handlers/input.rpc.ts
+++ b/src/main/pipe/handlers/input.rpc.ts
@@ -5,6 +5,7 @@ import type { DaemonClient } from '../../DaemonClient';
 import { sendToRenderer } from './_bridge';
 import { sanitizePtyText } from '../../../shared/types';
 import { applyRoleBinding, normalizeRoleBinding, type RoleBinding } from '../../../shared/orchestratorRole';
+import { isGateHeldOn } from '../../deck/stopGateState';
 
 type GetWindow = () => BrowserWindow | null;
 
@@ -145,6 +146,52 @@ export function makeRoleBindingResolver(getWindow: GetWindow): RoleBindingResolv
   };
 }
 
+/**
+ * Does this payload end the session rather than talk to it?
+ *
+ * Two shapes, both seen in #733: an `exit` command committed on its own line,
+ * and a raw EOT (Ctrl+D). Deliberately narrow — `exit 1` inside a script, or
+ * the word "exit" in a sentence, is not a match. False negatives are fine here
+ * (the guard is a backstop for one specific escalation, not a sandbox); false
+ * positives would block legitimate writes.
+ */
+export function isSessionTerminatingInput(text: string): boolean {
+  // eslint-disable-next-line no-control-regex -- EOT is the byte we are matching
+  if (/\x04/.test(text)) return true;
+  return text
+    .split(/[\r\n]/)
+    .some((line) => /^\s*(exit|logout)\s*$/i.test(line));
+}
+
+/**
+ * Refuse to end a pane the caller's Stop gate is currently blocked on (#733).
+ *
+ * The failure this exists for: a pane wedged at `running` held the gate, the
+ * brain was told "resolve these panes", and it resolved one by killing it —
+ * a live shell the human owned. The gate already names the panes it is waiting
+ * on, so the refusal is exactly that intersection and nothing wider. An
+ * orchestrator that is not gate-held, or one aiming at a pane the gate did not
+ * name, is unaffected.
+ *
+ * Throws so the caller gets the reason back and can act on it, rather than
+ * having the write silently swallowed.
+ */
+function assertNotKillingAGateHeldPane(
+  callerWs: string | undefined,
+  ptyId: string,
+  text: string,
+  op: string,
+): void {
+  if (!callerWs) return;
+  if (!isSessionTerminatingInput(text)) return;
+  if (!isGateHeldOn(callerWs, ptyId)) return;
+  throw new Error(
+    `${op}: refusing to end pane "${ptyId}" — your turn is currently held open by this pane. ` +
+      'A pane\'s status is not resolved by closing it, and this session belongs to the human. ' +
+      'Read its screen, answer what it is waiting on, or raise it with deck_ask_decision.',
+  );
+}
+
 export function registerInputRpc(
   router: RpcRouter,
   ptyManager: PTYManager,
@@ -184,6 +231,8 @@ export function registerInputRpc(
     }
 
     await assertWorkspaceOwnsPty(getWindow, ptyId, callerWs, 'input.send');
+
+    assertNotKillingAGateHeldPane(callerWs, ptyId, text, 'input.send');
 
     let safeText = params['raw'] === true ? text : sanitizePtyText(text);
 
@@ -311,6 +360,9 @@ export function registerInputRpc(
     }
 
     await assertWorkspaceOwnsPty(getWindow, ptyId, callerWs, 'input.sendKey');
+
+    // Ctrl+D arrives here as its escape sequence, so the same guard applies.
+    assertNotKillingAGateHeldPane(callerWs, ptyId, sequence, 'input.sendKey');
 
     const instance = ptyManager.get(ptyId);
     if (instance) {

--- a/src/main/pty/PTYBridge.ts
+++ b/src/main/pty/PTYBridge.ts
@@ -9,7 +9,7 @@ import { sanitizeTitle } from './titleDetect';
 import { IPC } from '../../shared/constants';
 import { updateCwd, removeCwd, updateBranch, removeBranch, broadcastMetadataUpdate } from '../ipc/handlers/metadata.handler';
 import { dispatchNotification } from '../notification/dispatchNotification';
-import { recentlySuppressed, recentlyResized, RESIZE_REDRAW_GUARD_MS, clearPty as clearSuppression } from '../notification/idleSuppression';
+import { recentlyResized, RESIZE_REDRAW_GUARD_MS, clearPty as clearSuppression } from '../notification/idleSuppression';
 import { eventBus } from '../events/EventBus';
 import type { HookSignalRouter } from '../hooks/HookSignalRouter';
 import type { AgentStatus } from '../../shared/types';
@@ -79,11 +79,11 @@ export class PTYBridge {
       const now = Date.now();
       const lastAgentAt = this.lastAgentEventAt.get(ptyId) ?? 0;
       if (now - lastAgentAt < AGENT_EVENT_SUPPRESSION_MS) return;
-      // Suppress the activity fallback when the recent burst was actually
-      // a pty:resize redraw (workspace switch) or user keystroke echo —
-      // both spike ActivityMonitor's byte counter without being a real
-      // agent task ending. See idleSuppression.ts for rationale.
-      if (recentlySuppressed(ptyId, now)) return;
+      // No resize/typing gate here: this handler's only job is the status
+      // clear, and dropping it wedges the pane at `running` permanently
+      // (ActivityMonitor has already consumed the transition, and a quiet pane
+      // never produces another burst to re-fire it). See idleSuppression.ts
+      // and issue #733. The precise-status deference above still applies.
       try {
         const win = this.getWindow();
         // Clear stale 'running' → 'idle' so the sidebar dot self-heals when a


### PR DESCRIPTION
Part of #733. F1 and F3 from that issue; F2 (active-work expiry) follows separately — see "What is left" below.

## The pane that never went idle

Ask the orchestrator to run a one-liner in a plain shell pane. The command runs, exits 0, the orchestrator reads the output back correctly — and then cannot finish, because the pane still reports `running`. It re-reads, re-sends, and escalates: it runs `exit` in the pane, then starts sending Ctrl+D. It killed a live shell that belonged to me.

Two separate defects, and the second one is the reason the first one cost data.

## F1 — a guard written for a deleted toast was swallowing the status clear

`recentlySuppressed()` existed to suppress the ActivityMonitor "Task may have finished" **notification** after a resize redraw or a burst of typing. That toast was removed later; the comments in both handlers say so plainly. The guard was never narrowed to match, so it ended up in front of the only job the handler still had: clearing `running` back to `idle`.

Two things made a suppressed clear permanent rather than merely late:

- `ActivityMonitor` mutates its state *before* invoking callbacks, so the transition is consumed even when the callback is dropped. Nothing retries it, and a quiet pane never produces another burst.
- For a plain shell `AgentDetector` never matches, so no `session:agent` ever arrives. `session:idle` is the *only* path that can clear the status at all.

The argument that settled it: `onActive` was never gated. A resize redraw is several KB, so it raises a false `running` — and then the guard blocked the very clear that would have corrected it. It made the exact case it was named for worse. Either both edges are gated or neither is, and gating neither is the one that keeps the status honest.

So the call goes, which leaves the function unreferenced; `markUserWrite`/`lastUserWriteAt` exist only to feed it, so they go too. `markResize` stays — `recentlyResized()` (3 s, AgentDetector dedup) is a different concern with its own caller. Agent panes keep both protections they already had: `explicitTerminalStatus` in the daemon and `AGENT_EVENT_SUPPRESSION_MS` here.

The trigger is ordinary, which is worth stating: a `pty:resize` fires on every workspace switch and layout change, and the window was 30 seconds.

### Why a green suite missed it

Four test files stubbed the function that carries the bug:

```
recentlySuppressed: vi.fn().mockReturnValue(false),
```

Suppression never happened in the test world, so the branch that wedges a pane was never executed by any of the 9251 tests. That is the whole answer.

A regression test that mocked it would repeat that blindness, so the new one drives the real module: it calls `markResize()` the way `pty.handler` does, then asserts the clear still goes out. I checked it is not vacuous by reintroducing a suppression-shaped guard — three of its four cases fail. The four dead mock lines are removed with the function.

## F3 — a status number is not resolved by killing the thing it describes

The gate itself behaved as designed: it failed open after three refusals. The damage happened inside those three, and it will happen again the next time pane status is wrong about something, so this is worth fixing independently of F1.

The refusal string is the only thing the model reads about a block, and it was silent on the one action that loses data. It now says so.

Prose is not a control, though — the brain is a separate `claude` process and can ignore a sentence. `stopGate` already computes the exact set of panes it is blocking on, so `stopGateState` records that set and `input.rpc` refuses session-terminating input aimed at it. The scope is that intersection and nothing wider: an orchestrator that is not gate-held may close shells freely, and even a gate-held one may close panes it is not blocked on. `outstandingPtyIds` is exported from `stopGate` rather than reimplemented, so the panes the guard protects cannot drift from the panes the model was told about.

The record expires after 60 s on its own. The bug this PR fixes came from state that outlived its meaning and was never re-checked; the new state must not repeat that.

## Verification

Unit tests alone were not the gate here — this bug survived a full green suite for the reason above. The landing check was the live repro on a dev build.

Before, on a fresh boot with a reattached pane: `PowerShell running`, top bar `1 running`, at an idle prompt, indefinitely. After, same boot and same pane: `PowerShell idle`, `The agent is idle.` Running a command takes it to `running` and it settles back to `idle` on its own.

Suite: 9607 passed. Two failures in `mergeSession.test.ts` are `EBUSY: resource busy or locked` on Windows worktree cleanup, unrelated to these files — that file passes 18/18 in isolation.

## What is left

F2 from #733 (active-work expiry) is deliberately not here — it carries a policy question about what counts as stale, and holding F1 for it did not make sense. Until it lands, an old `deck-work.json` record can still drive auto-wakes; I watched that happen during verification, so it is not theoretical. `autoWakesUsed` lives in `CommanderEventCoalescer` memory and resets on construction, which is why a restart hands a wedged record a fresh 12/12 budget — keying the budget to the record means persisting it.

#733 stays open for that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed panes that remained marked as running after commands completed, including after resizing.
  * Prevented protected panes from being closed or terminated while they block an active turn.
  * Normal pane termination remains available when protection does not apply.
* **Tests**
  * Added regression coverage for pane status clearing, protection behavior, workspace isolation, expiry, and termination commands.
* **Documentation**
  * Documented the pane-status and protected-termination fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->