### PR TITLE
Supersede a stale objective when the human speaks, and stop dropping work silently

### DIFF
--- a/changelog.d/736.md
+++ b/changelog.d/736.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **What you ask for now is what the orchestrator works on.** If a request was
+  already on the books, anything you typed afterwards was recorded as a note
+  underneath it rather than as the thing to do — so a message sent after
+  reopening wmux could end up filed under an objective from hours earlier, with
+  the old one still leading. Now, speaking to an orchestrator whose request
+  predates this session replaces that request with yours. A request it is
+  actively working on still collects your message as a follow-up, so nothing
+  running is abandoned, and answering "resume it" on the startup prompt still
+  resumes the original untouched. (#733, #736)
+- **Dropping a request no longer abandons the agents working on it in
+  silence.** Starting a new session, or replacing a stale request, can discard
+  one that still has work delegated to other agents. Those agents kept running
+  with nobody waiting on them. wmux now tells you, and asks what to do about
+  them, whenever a discarded request still had something outstanding. (#736)

--- a/src/main/deck/__tests__/deckWorkStore.test.ts
+++ b/src/main/deck/__tests__/deckWorkStore.test.ts
@@ -5,7 +5,8 @@
 // autonomy is `off`. The record outlives a turn, a pane stop, an A2A handoff and
 // an app restart, and is closed only by an explicit deck_complete_work the
 // server has verified. These lock the store's contract: one active item per
-// workspace, follow-ups appended (never silently replacing running work),
+// workspace, follow-ups appended to a LIVE record (never silently replacing
+// running work) while a PARKED one is superseded and handed back to the caller,
 // pointer-only A2A projection, and compare-and-delete on completion.
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
@@ -20,6 +21,7 @@ import {
   loadActiveDeckWorks,
   hasPendingDeckWorkA2aTasks,
   renderActiveDeckWorkBlock,
+  renderStrandedDeckWorkBlock,
   getDeckWorkPath,
   setDeckWorkBootId,
   isDeckWorkParked,
@@ -41,7 +43,7 @@ afterEach(() => {
 
 describe('deckWorkStore — ownership lifecycle', () => {
   it('starts a request and loads it back from disk', () => {
-    const work = beginOrContinueDeckWork('ws-1', 'ship the badge PR', dir)!;
+    const work = beginOrContinueDeckWork('ws-1', 'ship the badge PR', dir)!.work;
     expect(work).toMatchObject({ workspaceId: 'ws-1', objective: 'ship the badge PR', followUps: [] });
     expect(work.id).toMatch(/^work-/);
     // Durability: a fresh read (no in-memory cache) must see it.
@@ -57,8 +59,8 @@ describe('deckWorkStore — ownership lifecycle', () => {
   });
 
   it('APPENDS a second human message instead of abandoning running work', () => {
-    const first = beginOrContinueDeckWork('ws-1', 'build it', dir)!;
-    const second = beginOrContinueDeckWork('ws-1', 'also add tests', dir)!;
+    const first = beginOrContinueDeckWork('ws-1', 'build it', dir)!.work;
+    const second = beginOrContinueDeckWork('ws-1', 'also add tests', dir)!.work;
     // Same work item — workers already running under it keep their owner.
     expect(second.id).toBe(first.id);
     expect(second.objective).toBe('build it');
@@ -67,14 +69,14 @@ describe('deckWorkStore — ownership lifecycle', () => {
 
   it('does not record a follow-up that merely repeats the objective', () => {
     beginOrContinueDeckWork('ws-1', 'build it', dir);
-    const again = beginOrContinueDeckWork('ws-1', 'build it', dir)!;
+    const again = beginOrContinueDeckWork('ws-1', 'build it', dir)!.work;
     expect(again.followUps).toEqual([]);
   });
 
   it('collapses an immediately repeated follow-up', () => {
     beginOrContinueDeckWork('ws-1', 'objective', dir);
     beginOrContinueDeckWork('ws-1', 'retry', dir);
-    const third = beginOrContinueDeckWork('ws-1', 'retry', dir)!;
+    const third = beginOrContinueDeckWork('ws-1', 'retry', dir)!.work;
     expect(third.followUps).toEqual(['retry']);
   });
 
@@ -97,8 +99,8 @@ describe('deckWorkStore — ownership lifecycle', () => {
   });
 
   it('preserves the ownership start while advancing updatedAt on a follow-up', () => {
-    const first = beginOrContinueDeckWork('ws-1', 'objective', dir, 1_000)!;
-    const second = beginOrContinueDeckWork('ws-1', 'follow', dir, 5_000)!;
+    const first = beginOrContinueDeckWork('ws-1', 'objective', dir, 1_000)!.work;
+    const second = beginOrContinueDeckWork('ws-1', 'follow', dir, 5_000)!.work;
     expect(first.startedAt).toBe(1_000);
     expect(second.startedAt).toBe(1_000);
     expect(second.updatedAt).toBe(5_000);
@@ -107,7 +109,7 @@ describe('deckWorkStore — ownership lifecycle', () => {
 
 describe('deckWorkStore — completion', () => {
   it('completes with a matching revision and removes the record', () => {
-    const work = beginOrContinueDeckWork('ws-1', 'objective', dir)!;
+    const work = beginOrContinueDeckWork('ws-1', 'objective', dir)!.work;
     expect(completeActiveDeckWork('ws-1', work, dir)).toMatchObject({ id: work.id });
     expect(loadActiveDeckWork('ws-1', dir)).toBeNull();
   });
@@ -115,9 +117,9 @@ describe('deckWorkStore — completion', () => {
   it('REFUSES to close a newer request with an older verdict (compare-and-delete)', () => {
     // The commander's completion check is async; a human prompt can land while
     // it is in flight. Closing on the stale record would silently drop the new work.
-    const first = beginOrContinueDeckWork('ws-1', 'objective', dir)!;
+    const first = beginOrContinueDeckWork('ws-1', 'objective', dir)!.work;
     completeActiveDeckWork('ws-1', first, dir);
-    const second = beginOrContinueDeckWork('ws-1', 'brand new request', dir)!;
+    const second = beginOrContinueDeckWork('ws-1', 'brand new request', dir)!.work;
     expect(second.id).not.toBe(first.id);
 
     expect(completeActiveDeckWork('ws-1', first, dir)).toBeNull();
@@ -127,7 +129,7 @@ describe('deckWorkStore — completion', () => {
   it('REFUSES when a human FOLLOW-UP landed mid-check (same id, new revision)', () => {
     // The id alone is not enough: a follow-up keeps the work id, so an id-only
     // comparison would delete ownership of instructions the brain never saw.
-    const before = beginOrContinueDeckWork('ws-1', 'objective', dir, 1_000)!;
+    const before = beginOrContinueDeckWork('ws-1', 'objective', dir, 1_000)!.work;
     beginOrContinueDeckWork('ws-1', 'also do this', dir, 2_000);
 
     expect(completeActiveDeckWork('ws-1', before, dir)).toBeNull();
@@ -137,7 +139,7 @@ describe('deckWorkStore — completion', () => {
   });
 
   it('REFUSES when an A2A transition landed mid-check (same id, new tasks)', () => {
-    const before = beginOrContinueDeckWork('ws-1', 'objective', dir, 1_000)!;
+    const before = beginOrContinueDeckWork('ws-1', 'objective', dir, 1_000)!.work;
     recordDeckWorkA2aTask(
       'ws-1',
       { taskId: 'task-late', to: 'ws-worker', state: 'working', ts: 3_000 },
@@ -148,7 +150,7 @@ describe('deckWorkStore — completion', () => {
   });
 
   it('completing an absent record is a null no-op', () => {
-    const ghost = beginOrContinueDeckWork('ws-1', 'objective', dir)!;
+    const ghost = beginOrContinueDeckWork('ws-1', 'objective', dir)!.work;
     clearActiveDeckWork('ws-1', dir);
     expect(completeActiveDeckWork('ws-1', ghost, dir)).toBeNull();
   });
@@ -158,6 +160,26 @@ describe('deckWorkStore — completion', () => {
     clearActiveDeckWork('ws-1', dir);
     expect(loadActiveDeckWork('ws-1', dir)).toBeNull();
     expect(() => clearActiveDeckWork('ws-1', dir)).not.toThrow();
+  });
+
+  it('clearActiveDeckWork RETURNS what it removed, pending A2A tasks included', () => {
+    // "New session" must never start refusing — it is the escape hatch for a
+    // wedged record. It must not be BLIND either: the caller needs to see the
+    // delegated tasks that just outlived their owner.
+    beginOrContinueDeckWork('ws-1', 'objective', dir, 1_000);
+    recordDeckWorkA2aTask(
+      'ws-1',
+      { taskId: 'task-orphan', to: 'ws-worker', state: 'working', ts: 2_000 },
+      dir,
+    );
+    const removed = clearActiveDeckWork('ws-1', dir);
+    expect(removed!.objective).toBe('objective');
+    expect(hasPendingDeckWorkA2aTasks(removed!)).toBe(true);
+    // The clear still succeeded — the record is gone whatever it was holding.
+    expect(loadActiveDeckWork('ws-1', dir)).toBeNull();
+    // Nothing to report the second time around.
+    expect(clearActiveDeckWork('ws-1', dir)).toBeNull();
+    expect(clearActiveDeckWork('../escape', dir)).toBeNull();
   });
 });
 
@@ -280,7 +302,7 @@ describe('deckWorkStore — boot-scoped permission (parked records)', () => {
   const restart = (id = 'boot-next'): void => setDeckWorkBootId(id);
 
   it('a record written this boot is LIVE', () => {
-    const work = beginOrContinueDeckWork('ws-1', 'ship it', dir)!;
+    const work = beginOrContinueDeckWork('ws-1', 'ship it', dir)!.work;
     expect(work.bootId).toBe('boot-current');
     expect(isDeckWorkParked(loadActiveDeckWork('ws-1', dir)!)).toBe(false);
   });
@@ -315,14 +337,85 @@ describe('deckWorkStore — boot-scoped permission (parked records)', () => {
     expect(isDeckWorkParked(work)).toBe(true);
   });
 
-  it('a HUMAN follow-up re-arms a parked record', () => {
-    beginOrContinueDeckWork('ws-1', 'ship it', dir, 1_000);
+  it('a HUMAN turn against a PARKED record starts a NEW record, live from this boot', () => {
+    // The demotion bug: the human's actual instruction used to be appended as a
+    // bullet under an objective from a previous app launch, and the append
+    // re-stamped that stale objective as live. Captured in the wild: "reply X,
+    // do nothing else" filed under "Recover my agents after the reboot".
+    const before = beginOrContinueDeckWork('ws-1', 'Recover my agents after the reboot', dir, 1_000)!.work;
     restart();
-    const resumed = beginOrContinueDeckWork('ws-1', 'yes, carry on', dir, 2_000)!;
-    expect(resumed.bootId).toBe('boot-next');
+    const result = beginOrContinueDeckWork('ws-1', 'reply X, do nothing else', dir, 2_000)!;
+    expect(result.work.id).not.toBe(before.id);
+    expect(result.work.objective).toBe('reply X, do nothing else');
+    expect(result.work.followUps).toEqual([]);
+    expect(result.work.startedAt).toBe(2_000);
+    expect(result.work.bootId).toBe('boot-next');
     expect(isDeckWorkParked(loadActiveDeckWork('ws-1', dir)!)).toBe(false);
-    // Re-arming keeps the same work item; workers under it keep their owner.
-    expect(resumed.followUps).toEqual(['yes, carry on']);
+    // The old objective is nowhere in the record that now owns the workspace.
+    expect(JSON.stringify(loadActiveDeckWork('ws-1', dir))).not.toContain('Recover my agents');
+  });
+
+  it('hands the SUPERSEDED record back instead of dropping it', () => {
+    // It can no longer be closed by deck_complete_work, so the caller owes the
+    // human a surface for it — starting with anything it delegated.
+    beginOrContinueDeckWork('ws-1', 'the old request', dir, 1_000);
+    recordDeckWorkA2aTask(
+      'ws-1',
+      { taskId: 'task-orphan', to: 'ws-worker', state: 'working', ts: 2_000 },
+      dir,
+    );
+    restart();
+    const result = beginOrContinueDeckWork('ws-1', 'a brand new request', dir, 3_000)!;
+    expect(result.superseded).toBeDefined();
+    expect(result.superseded!.objective).toBe('the old request');
+    expect(hasPendingDeckWorkA2aTasks(result.superseded!)).toBe(true);
+    // Pointers are NOT inherited: they were delegated for a different objective,
+    // and carrying them over would make the new request un-finalizable behind
+    // work its human never asked for.
+    expect(result.work.a2aTasks).toEqual({});
+  });
+
+  it('does NOT supersede a LIVE record — running workers keep their owner', () => {
+    const first = beginOrContinueDeckWork('ws-1', 'build it', dir, 1_000)!;
+    const second = beginOrContinueDeckWork('ws-1', 'also add tests', dir, 2_000)!;
+    expect(second.superseded).toBeUndefined();
+    expect(second.work.id).toBe(first.work.id);
+    expect(second.work.objective).toBe('build it');
+    expect(second.work.followUps).toEqual(['also add tests']);
+  });
+
+  it('a record with NO bootId (older build) is superseded, not appended to', () => {
+    // Fail-closed all the way through: an unstamped record reads as parked, so
+    // the next human turn owns the workspace outright.
+    writeFileSync(
+      getDeckWorkPath(dir),
+      JSON.stringify({
+        version: 1,
+        active: {
+          'ws-1': {
+            id: 'work-old', objective: 'from an older build', followUps: [],
+            startedAt: 1, updatedAt: 1, a2aTasks: {},
+          },
+        },
+      }),
+      'utf8',
+    );
+    const result = beginOrContinueDeckWork('ws-1', 'what I actually want', dir, 5_000)!;
+    expect(result.superseded!.id).toBe('work-old');
+    expect(result.work.objective).toBe('what I actually want');
+  });
+
+  it('unparkDeckWork is how a parked record RESUMES with its objective intact', () => {
+    // The two paths must not be confused: answering the startup decision
+    // ("Resume it") re-arms the SAME record; typing a new instruction replaces
+    // it. Nothing else may re-arm a record.
+    beginOrContinueDeckWork('ws-1', 'the original objective', dir, 1_000);
+    restart();
+    unparkDeckWork('ws-1', dir);
+    const result = beginOrContinueDeckWork('ws-1', 'and one more thing', dir, 2_000)!;
+    expect(result.superseded).toBeUndefined();
+    expect(result.work.objective).toBe('the original objective');
+    expect(result.work.followUps).toEqual(['and one more thing']);
   });
 
   it('an A2A transition does NOT re-arm a parked record', () => {
@@ -418,6 +511,36 @@ describe('renderActiveDeckWorkBlock', () => {
     expect(block).toContain('to=ws-worker');
     expect(block).toContain('verified-evidence=0');
     expect(block).toMatch(/query canonical state/i);
+  });
+
+  it('renderStrandedDeckWorkBlock states what was dropped and issues NO orders', () => {
+    // A record that has left the store cannot be handed back to the brain
+    // through the active block: its live variant ends in "You OWN this
+    // request… Continue delegating", which would re-issue a deleted request as
+    // an order the moment we quoted it to the human.
+    beginOrContinueDeckWork('ws-1', 'the dropped objective', dir, 1_000);
+    beginOrContinueDeckWork('ws-1', 'and this too', dir, 2_000);
+    recordDeckWorkA2aTask(
+      'ws-1',
+      { taskId: 'task-live', to: 'ws-worker', state: 'working', ts: 3_000 },
+      dir,
+    );
+    recordDeckWorkA2aTask(
+      'ws-1',
+      { taskId: 'task-done', to: 'ws-worker', state: 'completed', ts: 4_000 },
+      dir,
+    );
+    const block = renderStrandedDeckWorkBlock(clearActiveDeckWork('ws-1', dir)!);
+    expect(block).toContain('[dropped-work]');
+    expect(block).toContain('the dropped objective');
+    expect(block).toContain('and this too');
+    // Only the tasks that still need a human call — a finished one is not
+    // stranded work.
+    expect(block).toContain('task=task-live');
+    expect(block).not.toContain('task-done');
+    expect(block).not.toContain('You OWN');
+    expect(block).not.toContain('Continue delegating');
+    expect(block).not.toContain('deck_complete_work');
   });
 
   it('PARKED renders without the ownership imperatives, keeping id and objective', () => {

--- a/src/main/deck/deckWorkStore.ts
+++ b/src/main/deck/deckWorkStore.ts
@@ -237,23 +237,68 @@ export function loadLiveDeckWorks(dir?: string): Record<string, ActiveDeckWork> 
   return out;
 }
 
+/** What a human turn did to this workspace's ownership. */
+export interface DeckWorkTurnResult {
+  /** The record that owns the workspace now. */
+  work: ActiveDeckWork;
+  /** Set only when this turn REPLACED an existing record (a parked one — see
+   *  `beginOrContinueDeckWork`). It is already gone from the store, and nothing
+   *  will ever call `deck_complete_work` on it, so the caller owes the human a
+   *  surface for it: it may still hold delegated A2A tasks
+   *  (`hasPendingDeckWorkA2aTasks`) that nobody now owns. Never persisted. */
+  superseded?: ActiveDeckWork;
+}
+
 /** Start ownership for a human request, or append a human follow-up to the
  * currently-owned request. Synchronous by design: DECK_SEND must not yield
  * between its idle check and manager.send(), or an ambient turn can win the
- * workspace while the request record is being written. */
+ * workspace while the request record is being written.
+ *
+ * The append/supersede fork turns on parking, not on age (#733 follow-up):
+ *
+ *  - A LIVE record APPENDS. Workers spawned under it are still running and
+ *    still belong to that objective; replacing the record would abandon them.
+ *    This is the original contract and it does not change.
+ *  - A PARKED record is SUPERSEDED — new id, the human's text as the objective,
+ *    empty follow-ups. Appending to it structurally demoted the human's actual
+ *    instruction to a footnote of a request from a previous app launch: the
+ *    rendered block led with the old objective and closed with "you OWN this
+ *    request, continue delegating", so "reply X, do nothing else" arrived as a
+ *    bullet under an hours-old "recover my agents after the reboot". Worse, the
+ *    append re-stamped that stale objective as live, which is the whole thing
+ *    parking exists to prevent.
+ *
+ * Resuming a parked request deliberately is a different path: the human answers
+ * the startup decision and `unparkDeckWork` re-arms the SAME record, objective
+ * intact. Typing a new instruction is not that answer. */
 export function beginOrContinueDeckWork(
   workspaceId: string,
   text: string,
   dir?: string,
   now = Date.now(),
-): ActiveDeckWork | null {
+): DeckWorkTurnResult | null {
   if (!WORKSPACE_ID_RE.test(workspaceId)) return null;
   const cleaned = cleanText(text, MAX_OBJECTIVE_CHARS);
   if (!cleaned) return null;
   const file = loadFile(dir);
   const current = file.active[workspaceId];
+  const startFresh = (): ActiveDeckWork => ({
+    id: `work-${randomUUID()}`,
+    workspaceId,
+    objective: cleaned,
+    followUps: [],
+    startedAt: now,
+    updatedAt: now,
+    // Pointers to the superseded record's tasks are NOT inherited: they were
+    // delegated for a different objective, and carrying them over would make
+    // this request un-finalizable behind work its human never asked for. The
+    // caller surfaces them instead.
+    a2aTasks: {},
+    bootId: currentBootId,
+  });
   let next: ActiveDeckWork;
-  if (current) {
+  let superseded: ActiveDeckWork | undefined;
+  if (current && !isDeckWorkParked(current)) {
     const followUp = cleanText(cleaned, MAX_FOLLOW_UP_CHARS);
     const followUps = [...current.followUps];
     if (followUp && followUp !== current.objective && followUps.at(-1) !== followUp) {
@@ -263,26 +308,19 @@ export function beginOrContinueDeckWork(
       ...current,
       followUps: followUps.slice(-MAX_FOLLOW_UPS),
       updatedAt: now,
-      // A human spoke to this request during THIS boot, so it is live again.
-      // This is the ONLY re-arming path, and it is deliberately gated on a human
-      // turn: nothing the fleet does on its own may un-park a record.
+      // A human spoke to this request during THIS boot, so it stays live. (A
+      // record that is already live is the only one that reaches this branch,
+      // so this re-stamp is a no-op today; it is kept because the stamp means
+      // "a human turn touched this record during this boot".)
       bootId: currentBootId,
     };
   } else {
-    next = {
-      id: `work-${randomUUID()}`,
-      workspaceId,
-      objective: cleaned,
-      followUps: [],
-      startedAt: now,
-      updatedAt: now,
-      a2aTasks: {},
-      bootId: currentBootId,
-    };
+    next = startFresh();
+    if (current) superseded = current;
   }
   file.active[workspaceId] = next;
   saveFile(file, dir);
-  return next;
+  return superseded ? { work: next, superseded } : { work: next };
 }
 
 /** Project an A2A transition into the active human request. Events older than
@@ -356,18 +394,57 @@ export function completeActiveDeckWork(
   return current;
 }
 
-export function clearActiveDeckWork(workspaceId: string, dir?: string): void {
-  if (!WORKSPACE_ID_RE.test(workspaceId)) return;
+/** Drop the record unconditionally — the "New session" escape hatch.
+ *
+ * It NEVER refuses, unlike `deck_complete_work` (which rejects on
+ * `a2a_tasks_outstanding`). That asymmetry is deliberate and load-bearing: a
+ * conversation clear is the confirmed way out of a wedged record, so a clear
+ * that could fail would leave a workspace with no way back at all.
+ *
+ * What it must not stay is BLIND. Returns the record it removed (null when
+ * there was none) so the caller can see what it just dropped and surface any
+ * delegated A2A work that outlives it — the delete succeeds either way. */
+export function clearActiveDeckWork(workspaceId: string, dir?: string): ActiveDeckWork | null {
+  if (!WORKSPACE_ID_RE.test(workspaceId)) return null;
   const file = loadFile(dir);
-  if (!file.active[workspaceId]) return;
+  const removed = file.active[workspaceId];
+  if (!removed) return null;
   delete file.active[workspaceId];
   saveFile(file, dir);
+  return removed;
 }
 
 export function hasPendingDeckWorkA2aTasks(work: ActiveDeckWork): boolean {
   return Object.values(work.a2aTasks).some(
     (task) => task.state === 'submitted' || task.state === 'working' || task.state === 'input-required',
   );
+}
+
+/** Render a record that has just LEFT the store — superseded by a newer human
+ * request, or dropped by a conversation clear.
+ *
+ * Deliberately NOT `renderActiveDeckWorkBlock`: that block's live variant ends
+ * in ownership imperatives ("You OWN this request… Continue delegating"), which
+ * is precisely wrong for a record nobody owns any more — it would re-issue a
+ * deleted request as an order the moment we quoted it back to the human. This
+ * block only states what was dropped and which delegated tasks outlived it.
+ *
+ * Same trust basis as the active block: objective/follow-ups came from the
+ * human, and A2A rows are pointers with no worker-authored body text. */
+export function renderStrandedDeckWorkBlock(work: ActiveDeckWork): string {
+  const lines = [`[dropped-work] id: ${work.id}`, `objective: ${work.objective}`];
+  if (work.followUps.length > 0) {
+    lines.push('human follow-ups:');
+    for (const followUp of work.followUps) lines.push(`- ${followUp}`);
+  }
+  const pending = Object.values(work.a2aTasks)
+    .filter((task) => task.state === 'submitted' || task.state === 'working' || task.state === 'input-required')
+    .sort((a, b) => a.updatedAt - b.updatedAt);
+  if (pending.length > 0) {
+    lines.push('delegated A2A tasks that outlived this record (query canonical state before acting):');
+    for (const task of pending) lines.push(`- task=${task.taskId} to=${task.to} state=${task.state}`);
+  }
+  return lines.join('\n');
 }
 
 /** Trusted runtime context. The objective/follow-ups originated from the human;

--- a/src/main/ipc/handlers/__tests__/deck.handler.loop.test.ts
+++ b/src/main/ipc/handlers/__tests__/deck.handler.loop.test.ts
@@ -198,9 +198,10 @@ vi.mock('../../../deck/deckWorkStore', () => ({
   beginOrContinueDeckWork: vi.fn(() => null),
   recordDeckWorkA2aTask: vi.fn(() => null),
   completeActiveDeckWork: vi.fn(() => null),
-  clearActiveDeckWork: vi.fn(() => undefined),
+  clearActiveDeckWork: vi.fn(() => null),
   hasPendingDeckWorkA2aTasks: vi.fn(() => false),
   renderActiveDeckWorkBlock: vi.fn(() => ''),
+  renderStrandedDeckWorkBlock: vi.fn(() => ''),
 }));
 
 // Policy channel: controllable in-memory block; seed is a no-op so tests never

--- a/src/main/ipc/handlers/__tests__/deck.handler.strandedWork.test.ts
+++ b/src/main/ipc/handlers/__tests__/deck.handler.strandedWork.test.ts
@@ -1,0 +1,263 @@
+// What happens to a request record that LEAVES the store while the work it
+// delegated is still running (#733 follow-up).
+//
+// Two ways out: a fresh human turn supersedes a PARKED record, and "New
+// session" clears whatever is there. Neither may refuse, and neither may drop
+// pending A2A tasks quietly — nothing will ever call deck_complete_work on a
+// record that is gone, so the tasks it owned have no owner left. The handler
+// puts that in front of the human as a decision.
+//
+// The work store here is the REAL file-backed one, pointed at a temp dir: the
+// four unit tests that shipped with the original #733 bug all mocked the
+// culprit and passed straight over it.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const captured = new Map<string, (...args: unknown[]) => unknown>();
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, fn: (...args: unknown[]) => unknown) => {
+      captured.set(channel, fn);
+    }),
+    removeHandler: vi.fn((channel: string) => captured.delete(channel)),
+  },
+  app: { once: vi.fn(), removeListener: vi.fn() },
+}));
+
+vi.mock('../../../deck/commanderSessionStore', () => ({
+  loadCommanderSession: vi.fn(() => null),
+  saveCommanderSession: vi.fn(async () => undefined),
+  clearCommanderSession: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../deck/deckPolicy', () => ({
+  loadDeckPolicyBlock: vi.fn(() => null),
+  ensureDeckPolicySeed: vi.fn(() => undefined),
+  getDeckPolicyPath: vi.fn(() => '/fake/deck-policy.md'),
+}));
+
+// DECK_SEND refuses outright on an `off` workspace, which would never reach the
+// ownership record at all.
+vi.mock('../../../deck/deckAutonomyStore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../deck/deckAutonomyStore')>();
+  return {
+    ...actual,
+    loadWorkspaceAutonomy: vi.fn(() => ({ mode: 'danger', ...actual.modeToCaps('danger') })),
+    loadWorkspaceMode: vi.fn(() => 'danger'),
+  };
+});
+
+// Real store, temp dir — every call the handler makes goes through the same
+// files these tests read back.
+const { workDirRef } = vi.hoisted(() => ({ workDirRef: { current: '' } }));
+vi.mock('../../../deck/deckWorkStore', async (orig) => {
+  const actual = await orig<typeof import('../../../deck/deckWorkStore')>();
+  const dir = (): string => workDirRef.current;
+  return {
+    ...actual,
+    loadActiveDeckWork: (ws: string) => actual.loadActiveDeckWork(ws, dir()),
+    loadActiveDeckWorks: () => actual.loadActiveDeckWorks(dir()),
+    loadLiveDeckWork: (ws: string) => actual.loadLiveDeckWork(ws, dir()),
+    loadLiveDeckWorks: () => actual.loadLiveDeckWorks(dir()),
+    beginOrContinueDeckWork: (ws: string, text: string) =>
+      actual.beginOrContinueDeckWork(ws, text, dir()),
+    clearActiveDeckWork: (ws: string) => actual.clearActiveDeckWork(ws, dir()),
+    unparkDeckWork: (ws: string) => actual.unparkDeckWork(ws, dir()),
+    completeActiveDeckWork: (ws: string, expected: Parameters<typeof actual.completeActiveDeckWork>[1]) =>
+      actual.completeActiveDeckWork(ws, expected, dir()),
+    recordDeckWorkA2aTask: (ws: string, input: Parameters<typeof actual.recordDeckWorkA2aTask>[1]) =>
+      actual.recordDeckWorkA2aTask(ws, input, dir()),
+  };
+});
+
+// The surface under test. Kept in memory so no test touches the real decision
+// file, and so `hasPendingDecision` can be steered (the clobber guard).
+interface RaisedDecision {
+  workspaceId: string;
+  question: string;
+  options?: string[];
+  context?: string;
+}
+const { raised, pendingRef } = vi.hoisted(() => ({
+  raised: [] as RaisedDecision[],
+  pendingRef: { current: false },
+}));
+vi.mock('../../../deck/deckDecisionStore', async (orig) => {
+  const actual = await orig<typeof import('../../../deck/deckDecisionStore')>();
+  return {
+    ...actual,
+    loadDeckDecisions: vi.fn(() => ({})),
+    loadWorkspaceDecision: vi.fn(() => null),
+    hasPendingDecision: vi.fn(() => pendingRef.current),
+    raiseDecision: vi.fn(async (workspaceId: string, args: Omit<RaisedDecision, 'workspaceId'>) => {
+      raised.push({ workspaceId, ...args });
+      return null;
+    }),
+  };
+});
+
+import { registerDeckHandler } from '../deck.handler';
+import { IPC } from '../../../../shared/constants';
+import {
+  beginOrContinueDeckWork,
+  clearActiveDeckWork,
+  loadActiveDeckWork,
+  recordDeckWorkA2aTask,
+  setDeckWorkBootId,
+} from '../../../deck/deckWorkStore';
+import type { BrainAdapter, BrainEvent, BrainStartOptions } from '../../../deck/BrainAdapter';
+
+class FakeAdapter implements BrainAdapter {
+  sessionId: string | null = null;
+  start(_opts: BrainStartOptions): void {
+    /* nothing to start in the fake */
+  }
+  async *send(_text: string): AsyncIterable<BrainEvent> {
+    yield { type: 'turn-end', sessionId: 'sess-1' } as BrainEvent;
+  }
+  interrupt(): void {
+    /* no in-flight turn in the fake */
+  }
+  dispose(): void {
+    /* nothing to dispose */
+  }
+}
+
+const fakeWindow = {
+  isDestroyed: () => false,
+  webContents: { send: () => undefined },
+} as unknown as import('electron').BrowserWindow;
+
+const WS = 'ws-1';
+let cleanup: (() => void) | null = null;
+
+const send = (text: string) =>
+  captured.get(IPC.DECK_SEND)!({}, { workspaceId: WS, text }) as Promise<{ ok: boolean }>;
+const newSession = () =>
+  captured.get(IPC.DECK_CONVERSATION_CLEAR)!({}, { workspaceId: WS }) as Promise<{
+    ok: boolean;
+    code?: string;
+  }>;
+
+/** Delegate a task under whatever record currently owns the workspace. */
+const delegate = (taskId: string, state: 'working' | 'completed' = 'working'): void => {
+  recordDeckWorkA2aTask(WS, { taskId, to: 'ws-worker', state, ts: Date.now() + 1_000 });
+};
+
+beforeEach(() => {
+  captured.clear();
+  raised.length = 0;
+  pendingRef.current = false;
+  workDirRef.current = mkdtempSync(path.join(tmpdir(), 'wmux-stranded-'));
+  setDeckWorkBootId('boot-current');
+  cleanup?.();
+  cleanup = registerDeckHandler(() => fakeWindow, {
+    createAdapter: () => new FakeAdapter(),
+    // The startup reconcile raises decisions of its own for parked records;
+    // push it far past the end of the suite so it cannot pollute `raised`.
+    reconcileDelayMs: 600_000,
+  });
+});
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = null;
+  rmSync(workDirRef.current, { recursive: true, force: true });
+});
+
+describe('deck handler — a human turn against a PARKED record', () => {
+  it('starts a NEW record and surfaces the one it superseded', async () => {
+    beginOrContinueDeckWork(WS, 'Recover my agents after the reboot');
+    delegate('task-orphan');
+    const before = loadActiveDeckWork(WS)!;
+    setDeckWorkBootId('boot-next'); // the app restarted; the record is parked
+
+    await send('reply X, do nothing else');
+
+    const after = loadActiveDeckWork(WS)!;
+    expect(after.id).not.toBe(before.id);
+    expect(after.objective).toBe('reply X, do nothing else');
+    expect(after.followUps).toEqual([]);
+
+    // The dropped record reached the human, with the task nobody owns now.
+    expect(raised).toHaveLength(1);
+    expect(raised[0].workspaceId).toBe(WS);
+    expect(raised[0].question).toMatch(/delegated tasks running/i);
+    expect(raised[0].context).toContain('Recover my agents after the reboot');
+    expect(raised[0].context).toContain('task-orphan');
+    // The quoted record must not read as an order — it no longer exists.
+    expect(raised[0].context).not.toContain('You OWN');
+  });
+
+  it('does not raise for a superseded record with nothing outstanding', async () => {
+    // A decision blocks autonomous follow-through on the request the human JUST
+    // made, so it is charged only where delegated work would be orphaned.
+    beginOrContinueDeckWork(WS, 'yesterday, and it finished');
+    delegate('task-done', 'completed');
+    setDeckWorkBootId('boot-next');
+
+    await send('something else entirely');
+
+    expect(loadActiveDeckWork(WS)!.objective).toBe('something else entirely');
+    expect(raised).toEqual([]);
+  });
+
+  it('never clobbers a decision the human is already looking at', async () => {
+    beginOrContinueDeckWork(WS, 'the old request');
+    delegate('task-orphan');
+    setDeckWorkBootId('boot-next');
+    pendingRef.current = true;
+
+    await send('a new request');
+
+    expect(raised).toEqual([]);
+    expect(loadActiveDeckWork(WS)!.objective).toBe('a new request');
+  });
+
+  it('APPENDS to a live record and raises nothing', async () => {
+    beginOrContinueDeckWork(WS, 'build it');
+    delegate('task-running');
+    const before = loadActiveDeckWork(WS)!;
+
+    await send('also add tests');
+
+    const after = loadActiveDeckWork(WS)!;
+    expect(after.id).toBe(before.id);
+    expect(after.objective).toBe('build it');
+    expect(after.followUps).toEqual(['also add tests']);
+    // Running workers keep their owner, so nothing is stranded.
+    expect(raised).toEqual([]);
+  });
+});
+
+describe('deck handler — New session with delegated work outstanding', () => {
+  it('still clears, and surfaces the tasks the cleared record owned', async () => {
+    beginOrContinueDeckWork(WS, 'the cleared request');
+    delegate('task-orphan');
+
+    const verdict = await newSession();
+
+    // The escape hatch must never start refusing.
+    expect(verdict).toEqual({ ok: true });
+    expect(loadActiveDeckWork(WS)).toBeNull();
+    expect(raised).toHaveLength(1);
+    expect(raised[0].question).toMatch(/new session/i);
+    expect(raised[0].context).toContain('the cleared request');
+    expect(raised[0].context).toContain('task-orphan');
+  });
+
+  it('is quiet when there was nothing outstanding to strand', async () => {
+    beginOrContinueDeckWork(WS, 'nothing delegated');
+    expect(await newSession()).toEqual({ ok: true });
+    expect(raised).toEqual([]);
+
+    // …and with no record at all it is a plain no-op.
+    clearActiveDeckWork(WS);
+    expect(await newSession()).toEqual({ ok: true });
+    expect(raised).toEqual([]);
+  });
+});

--- a/src/main/ipc/handlers/deck.handler.ts
+++ b/src/main/ipc/handlers/deck.handler.ts
@@ -85,6 +85,7 @@ import {
 import {
   beginOrContinueDeckWork,
   clearActiveDeckWork,
+  hasPendingDeckWorkA2aTasks,
   isDeckWorkParked,
   loadActiveDeckWork,
   loadActiveDeckWorks,
@@ -92,8 +93,10 @@ import {
   loadLiveDeckWorks,
   recordDeckWorkA2aTask,
   renderActiveDeckWorkBlock,
+  renderStrandedDeckWorkBlock,
   setDeckWorkBootId,
   unparkDeckWork,
+  type ActiveDeckWork,
 } from '../../deck/deckWorkStore';
 import { scanSkillCatalog, type SkillCatalogEntry } from '../../deck/skillCatalogScan';
 import {
@@ -482,12 +485,100 @@ export function registerDeckHandler(
     }
   };
 
+  /**
+   * A request record has LEFT the store — superseded by a newer human request,
+   * or dropped by a conversation clear. It can no longer be closed by
+   * `deck_complete_work`, so anything it delegated is now unowned.
+   *
+   * The surface is a DECISION (deckDecisionStore), for three reasons. It is
+   * durable — a toast or a stream event is gone the moment the window is, and
+   * #733 itself was caused by a state clear that only ever ran from a toast
+   * nobody had kept. It is already the channel this exact record class uses:
+   * the startup reconcile asks "resume it, or drop it?" the same way. And a
+   * pending decision suppresses auto-wake for the workspace, which is the right
+   * posture while delegated tasks have no owner.
+   *
+   * It is raised ONLY when the dropped record still has pending A2A tasks. That
+   * is the whole reason the pending state matters — and a decision has a cost:
+   * it blocks autonomous follow-through on the request the human JUST made
+   * until they answer. Charging that for a record with nothing outstanding
+   * would tax every normal supersede for bookkeeping, and train people to click
+   * through the one that matters. With nothing outstanding, the human's own
+   * newer instruction is the surfacing; a log line covers diagnosis.
+   *
+   * Cancelling the tasks outright is not this layer's call: the A2A client
+   * lives behind the pipe router (deck.rpc), main has no handle on it, and
+   * "cancel someone else's running worker" is exactly the kind of fork the
+   * decision gate exists to put in front of a human. So we ask.
+   *
+   * Never throws and never blocks its caller — the supersede/clear already
+   * happened on disk, and neither may fail because of this bookkeeping.
+   */
+  const surfaceStrandedWork = (
+    workspaceId: string,
+    work: ActiveDeckWork,
+    reason: 'superseded' | 'cleared',
+  ): void => {
+    try {
+      if (!hasPendingDeckWorkA2aTasks(work)) {
+        // eslint-disable-next-line no-console
+        console.warn(`[deck] ${reason} work record ${work.id} (no delegated tasks outstanding)`);
+        return;
+      }
+      // The decision store is last-writer-wins, so a real question already
+      // waiting on this human must never be clobbered by our bookkeeping (same
+      // guard as the startup reconcile). The log keeps the drop diagnosable.
+      if (hasPendingDecision(workspaceId)) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[deck] ${reason} work record ${work.id} has outstanding A2A tasks; ` +
+          'a decision is already pending, not replacing it',
+        );
+        return;
+      }
+      const question = reason === 'superseded'
+        ? 'A newer request replaced an earlier one that still has delegated tasks running. ' +
+          'Cancel those tasks, or adopt them into the new request?'
+        : 'Starting a new session dropped a request that still has delegated tasks running. ' +
+          'Cancel those tasks, or leave them running?';
+      void raiseDecision(workspaceId, {
+        question,
+        options: reason === 'superseded'
+          ? ['Cancel the old tasks', 'Adopt them into the current request']
+          : ['Cancel the old tasks', 'Leave them running'],
+        context: renderStrandedDeckWorkBlock(work),
+      }).catch(() => {
+        /* best-effort — the log line above is the fallback record */
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('[deck] failed to surface stranded work:', err);
+    }
+  };
+
   /** Persist request ownership without ever breaking a human turn. The store is
    *  synchronous so the DECK_SEND idle-check → send sequence does not yield. */
   const beginTrackedWork = (workspaceId: string, text: string): void => {
-    const objective = text.trim() || 'Continue the request submitted directly in the commander terminal.';
+    const humanText = text.trim();
     try {
-      beginOrContinueDeckWork(workspaceId, objective);
+      // The placeholder stands in for a prompt main never saw — the terminal
+      // brain's UserPromptSubmit can carry an empty body. It is a fine objective
+      // for a workspace that owns nothing yet, and it is NOT allowed to be
+      // anything else: passed against an existing record it would either file
+      // itself as a meaningless follow-up or, worse, supersede a real objective
+      // with boilerplate. A blank turn therefore leaves the record exactly as it
+      // is — including parked, which is the fail-closed answer for a turn whose
+      // content we cannot read.
+      if (!humanText) {
+        if (loadActiveDeckWork(workspaceId)) return;
+        beginOrContinueDeckWork(
+          workspaceId,
+          'Continue the request submitted directly in the commander terminal.',
+        );
+        return;
+      }
+      const result = beginOrContinueDeckWork(workspaceId, humanText);
+      if (result?.superseded) surfaceStrandedWork(workspaceId, result.superseded, 'superseded');
     } catch (err) {
       // A persistence failure costs autonomous follow-through, never the human's
       // immediate turn. Keep the failure visible for diagnosis.
@@ -836,7 +927,14 @@ export function registerDeckHandler(
       const sessionKey = sessionKeyFor(workspaceId, entry?.vendor ?? resolveEffectiveVendor(brainVendor));
       await clearCommanderSession(sessionKey);
       try {
-        clearActiveDeckWork(workspaceId);
+        // Unconditional by contract — "New session" is the escape hatch for a
+        // wedged record and must never start refusing (deck_complete_work is
+        // the path that CAN refuse, on a2a_tasks_outstanding). But the clear is
+        // no longer blind: whatever it removed comes back, so delegated tasks
+        // that outlive the record are put in front of the human instead of
+        // being dropped with it.
+        const removed = clearActiveDeckWork(workspaceId);
+        if (removed) surfaceStrandedWork(workspaceId, removed, 'cleared');
       } catch {
         // Conversation clear is still successful if the auxiliary work record
         // could not be removed; the next prompt can supersede/reconcile it.


### PR DESCRIPTION
## Fixed

### A human turn was filed under a stale objective

With a record already open, `beginOrContinueDeckWork` kept the old objective and appended the human's text as a follow-up. Parking (#735) made that worse rather than better: a message against a record left over from a previous launch both filed itself under an hours-old objective **and** re-stamped that record live.

Captured on #733 — "reply X, do nothing else" became a bullet under *"Recover my agents after the reboot … run: `claude --continue`"*, and `renderActiveDeckWorkBlock` leads with the old objective and closes with "You OWN this request… Continue delegating". The human was not out-prioritised; the store subordinated them.

A **parked** record is now superseded: the human's text becomes a new request with its own id and no inherited A2A pointers — those were delegated for a different objective and would leave the new request un-finalizable. A **live** record still appends, which is the "never abandon running workers" contract and is unchanged. Deliberate re-arming keeps its own door: answering the startup decision still calls `unparkDeckWork`, which keeps the record and its objective intact.

### Dropping a record could strand delegated workers silently

`deck_complete_work` refuses on `a2a_tasks_outstanding`, but `clearActiveDeckWork` was a blind delete. It still cannot refuse — New session is the confirmed escape hatch for a wedged record and must always work — but it now returns what it removed, and both drop paths surface a record that still has pending A2A tasks.

Surfaced as a **decision**, and only when tasks are actually outstanding. A decision is durable (a toast dies with the window — and #733 was itself caused by a state-clear that only ran from a deleted toast), it is already the channel this record class uses, and a pending decision suppresses auto-wake, which is the right posture while delegated tasks have no owner. Raising it on every ordinary supersede would instead tax the request the human just made and train people to click through the one that matters.

The stranded block is deliberately not the active one: the live variant reads as an order, which is exactly wrong for a request that was just deleted.

### A blank turn could have destroyed the objective

A hole supersede opened. A blank `UserPromptSubmit` against an existing record used to file the "Continue the request submitted directly…" placeholder as a follow-up; as a *new* objective it would have replaced the real one. A blank turn against any existing record is now a no-op — fail-closed for a turn whose content we cannot read, and it cannot silently re-arm a parked record either.

## Verification

`tsc --noEmit` clean; deck/IPC/pipe suites 79 files, 1434 passed. Store tests write a real temp dir rather than mocking — #733 shipped because four suites mocked the culprit.

One existing test asserted the old behaviour (`a HUMAN follow-up re-arms a parked record`, expecting the same id and the text as a follow-up). That is precisely the defect, so it was rewritten, and there is now a test pinning supersede and `unparkDeckWork` apart.

## Still not in scope

**#728** — recovery runs `claude --continue`, which revives the agent's conversation and with it its old task. Clearing `deck-work.json` does not prevent that. Parking removed the autonomous path into it; the human-initiated one remains and belongs to that issue.

Closes #733
