### PR TITLE
fix(deck): stop the New session tooltip claiming the conversation survives

### DIFF
--- a/changelog.d/737.md
+++ b/changelog.d/737.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **The New session button no longer promises to keep the conversation it
+  discards.** Its tooltip listed the conversation history among the things that
+  stay, when starting a fresh session is precisely what clears it — the reverse
+  of what happens, on the one control you reach for when the orchestrator is
+  stuck on stale context. It now says the orchestrator forgets the conversation
+  and the #commander transcript remains as the record. (#737)

--- a/src/renderer/components/Deck/NewSessionChip.tsx
+++ b/src/renderer/components/Deck/NewSessionChip.tsx
@@ -146,7 +146,7 @@ export function NewSessionChip({
         armed
           ? confirmLabel
           : t?.('deck.newSessionTooltip') ||
-            'Replace this workspace’s orchestrator with a fresh session. Panes, worktrees and the conversation history stay; loops and schedules keep running.'
+            'Replace this workspace’s orchestrator with a fresh session. The brain forgets the conversation so far — the #commander transcript stays as the record. Panes, worktrees, loops and schedules are untouched.'
       }
       // Neutral at rest like the other AI-directed controls on this bar
       // (DESIGN.md: AI-directed actions stay neutral at rest) — nothing is

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -424,7 +424,7 @@ export const en = {
   'deck.newSessionConfirm': 'Start a new session?',
   'deck.newSessionConfirmBusy': 'Interrupt & start new session?',
   'deck.newSessionTooltip':
-    'Replace this workspace’s orchestrator with a fresh session, so it starts from your project files with no stale assumptions. Panes, worktrees and the conversation history stay; loops and schedules keep running.',
+    'Replace this workspace’s orchestrator with a fresh session, so it starts from your project files with no stale assumptions. The brain forgets the conversation so far — the #commander transcript stays as the record. Panes, worktrees, loops and schedules are untouched.',
   'deck.reportRail': 'Reports {count}',
   'deck.reportRailDecision': '1 decision',
   'deck.limit.resetsSoon': 'resets soon',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -295,7 +295,7 @@ export const ko = {
   'deck.newSessionConfirm': '새 세션을 시작할까요?',
   'deck.newSessionConfirmBusy': '중단하고 새 세션을 시작할까요?',
   'deck.newSessionTooltip':
-    '이 워크스페이스의 agent를 새 세션으로 교체합니다. 낡은 가정 없이 프로젝트 파일부터 다시 읽습니다. pane·워크트리·대화 기록은 그대로 남고, 루프와 예약은 계속 동작합니다.',
+    '이 워크스페이스의 agent를 새 세션으로 교체합니다. 낡은 가정 없이 프로젝트 파일부터 다시 읽습니다. 브레인은 지금까지의 대화를 잊습니다 — #commander 기록은 그대로 남습니다. pane·워크트리·루프·예약은 건드리지 않습니다.',
   'deck.reportRail': '보고 {count}',
   'deck.reportRailDecision': '결정 1건',
   'deck.limit.resetsSoon': '곧 초기화됨',


### PR DESCRIPTION
The `New session` chip's tooltip said:

> Panes, worktrees and **the conversation history stay**; loops and schedules keep running.

Discarding that conversation is the entire reason the chip exists.
`DECK_CONVERSATION_CLEAR` disposes the live brain and drops the persisted
session id so the next turn starts a fresh conversation instead of resuming.
So the tooltip reads as a promise that the brain still remembers — exactly
backwards for the one control an operator reaches for when the brain is stuck
on stale context.

What actually survives is the **#commander transcript** — the audit trail, as
the handler itself says ("The channel transcript stays — history is the audit
trail; only the brain's context resets"). The old line put panes, worktrees and
"conversation history" in one list, which made those two very different things
read as one claim.

Now: what the brain forgets and what stays as the record are one sentence, and
the untouched list (panes, worktrees, loops, schedules) is its own.

Strings only — `en.ts`, `ko.ts`, and the component's inline fallback. No logic
change.

## Tests

`npx tsc --noEmit` clean; `NewSessionChip` suite (4 tests) green. Found while
dogfooding #711 on a live build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the New Session button tooltip to clarify that the orchestrator conversation is forgotten while the `#commander` transcript remains.
  - Clarified that panes, worktrees, loops, and schedules are unaffected when starting a new session.
  - Updated the Korean translation to reflect the same behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->