### PR TITLE
fix(tray): stop the session nudge and the unread badge erasing each other

### DIFF
--- a/changelog.d/738.md
+++ b/changelog.d/738.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **The unread count no longer vanishes the moment you minimise wmux.** On
+  Windows and Linux the tray tooltip is the only place an unread count shows
+  once the window is hidden — and hiding the window was itself what erased it,
+  because the "background sessions running" note and the unread badge each
+  overwrote the whole tooltip. They now share it, so a hidden wmux shows both.
+  A count that arrives while wmux is still starting up is no longer dropped
+  either. (#729, #738)

--- a/src/main/__tests__/trayUnreadBadge.test.ts
+++ b/src/main/__tests__/trayUnreadBadge.test.ts
@@ -19,6 +19,7 @@ vi.mock('electron', () => ({
     setToolTip = setToolTipMock;
     setContextMenu = vi.fn();
     on = vi.fn();
+    destroy = vi.fn();
   },
   Menu: { buildFromTemplate: vi.fn(() => ({})) },
   nativeImage: {
@@ -107,6 +108,82 @@ describe('updateUnreadBadge', () => {
       expect(() => updateUnreadBadge(2)).not.toThrow();
       expect(setToolTipMock).not.toHaveBeenCalled();
     });
+  });
+});
+
+// The tooltip is the ONLY unread surface off macOS, and it has a second author:
+// updateTraySessionCount, fired whenever the window hides to or returns from
+// the tray. Each used to write the whole string, so hiding to tray with unread
+// mail erased the count from the one surface still showing it — precisely the
+// blind spot the badge was added for.
+describe('tray tooltip composition (badge + session nudge)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('keeps the unread badge when the window hides to tray', async () => {
+    const { updateUnreadBadge, updateTraySessionCount } = await loadTray('win32', { withTray: true });
+    updateUnreadBadge(5);
+    updateTraySessionCount(7);
+    expect(setToolTipMock).toHaveBeenLastCalledWith('[5] wmux — 7 background sessions running');
+  });
+
+  it('keeps the session nudge when an unread arrives while hidden', async () => {
+    const { updateUnreadBadge, updateTraySessionCount } = await loadTray('win32', { withTray: true });
+    updateTraySessionCount(3);
+    updateUnreadBadge(2);
+    expect(setToolTipMock).toHaveBeenLastCalledWith('[2] wmux — 3 background sessions running');
+  });
+
+  it('keeps the badge when the window is shown again (nudge cleared to null)', async () => {
+    const { updateUnreadBadge, updateTraySessionCount } = await loadTray('win32', { withTray: true });
+    updateUnreadBadge(4);
+    updateTraySessionCount(6);
+    updateTraySessionCount(null);
+    expect(setToolTipMock).toHaveBeenLastCalledWith('[4] wmux');
+  });
+
+  it('drops to the plain tooltip once both signals are clear', async () => {
+    const { updateUnreadBadge, updateTraySessionCount } = await loadTray('win32', { withTray: true });
+    updateUnreadBadge(4);
+    updateTraySessionCount(6);
+    updateUnreadBadge(0);
+    updateTraySessionCount(null);
+    expect(setToolTipMock).toHaveBeenLastCalledWith('wmux');
+  });
+
+  it('singularizes a lone background session alongside the badge', async () => {
+    const { updateUnreadBadge, updateTraySessionCount } = await loadTray('win32', { withTray: true });
+    updateUnreadBadge(1);
+    updateTraySessionCount(1);
+    expect(setToolTipMock).toHaveBeenLastCalledWith('[1] wmux — 1 background session running');
+  });
+
+  it('caps the tooltip badge at 999+ like the dock badge', async () => {
+    const { updateUnreadBadge } = await loadTray('win32', { withTray: true });
+    updateUnreadBadge(1000);
+    expect(setToolTipMock).toHaveBeenLastCalledWith('[999+] wmux');
+  });
+
+  it('applies a badge that arrived before the tray existed', async () => {
+    const mod = await loadTray('win32');
+    mod.updateUnreadBadge(3);
+    expect(setToolTipMock).not.toHaveBeenCalled();
+    const fakeWindow = { show: vi.fn(), focus: vi.fn() } as unknown as import('electron').BrowserWindow;
+    mod.createTray(fakeWindow, { onQuit: vi.fn(), onShutdownAll: vi.fn() });
+    expect(setToolTipMock).toHaveBeenCalledWith('[3] wmux');
+  });
+
+  it('does not carry a count across a destroyed tray', async () => {
+    const mod = await loadTray('win32', { withTray: true });
+    mod.updateUnreadBadge(8);
+    mod.updateTraySessionCount(2);
+    mod.destroyTray();
+    setToolTipMock.mockClear();
+    const fakeWindow = { show: vi.fn(), focus: vi.fn() } as unknown as import('electron').BrowserWindow;
+    mod.createTray(fakeWindow, { onQuit: vi.fn(), onShutdownAll: vi.fn() });
+    expect(setToolTipMock).not.toHaveBeenCalledWith(expect.stringContaining('[8]'));
   });
 });
 

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -9,6 +9,31 @@ let tray: Tray | null = null;
 let trayWindow: BrowserWindow | null = null;
 let trayCallbacks: TrayCallbacks | null = null;
 
+// The tooltip has two independent authors — the background-session nudge
+// (updateTraySessionCount, fired on hide/show) and the unread badge
+// (updateUnreadBadge, fired by the renderer). Each used to write the whole
+// string, so whichever spoke last erased the other: hiding to tray with unread
+// mail wiped the count off the only surface that was still showing it, which is
+// exactly the blind spot the badge exists to cover. Both now write to state and
+// the tooltip is composed in one place from both.
+let traySessionCount: number | null = null;
+let trayUnreadCount = 0;
+
+/**
+ * Compose and apply the tooltip from every signal that has one. Safe before the
+ * tray exists — the state is still recorded, and createTray applies it, so a
+ * badge that arrives during boot is not lost.
+ */
+function applyTrayTooltip(): void {
+  if (!tray) return;
+  const sessions =
+    typeof traySessionCount === 'number' && traySessionCount > 0
+      ? ` — ${traySessionCount} background session${traySessionCount === 1 ? '' : 's'} running`
+      : '';
+  const unread = trayUnreadCount > 0 ? `[${trayUnreadCount > 999 ? '999+' : trayUnreadCount}] ` : '';
+  tray.setToolTip(`${unread}wmux${sessions}`);
+}
+
 /**
  * Resolve a license-style file that ships in <exe>/resources/ when packaged
  * and lives at the repo root in dev. Returns null if the file is missing
@@ -116,12 +141,11 @@ function buildContextMenu(
  * no-op before the tray exists. Best-effort cosmetic surface — never throws.
  */
 export function updateTraySessionCount(sessionCount: number | null): void {
+  // Recorded before the guard: a count that arrives while the tray is being
+  // built must not be dropped, and it is half of the composed tooltip.
+  traySessionCount = sessionCount;
   if (!tray || !trayWindow || !trayCallbacks) return;
-  tray.setToolTip(
-    typeof sessionCount === 'number' && sessionCount > 0
-      ? `wmux — ${sessionCount} background session${sessionCount === 1 ? '' : 's'} running`
-      : 'wmux',
-  );
+  applyTrayTooltip();
   tray.setContextMenu(buildContextMenu(trayWindow, trayCallbacks, sessionCount));
 }
 
@@ -152,7 +176,11 @@ export function createTray(mainWindow: BrowserWindow, callbacks: TrayCallbacks):
   tray = new Tray(trayImage);
   trayWindow = mainWindow;
   trayCallbacks = callbacks;
-  tray.setToolTip('wmux');
+  // Not a bare 'wmux': an unread count can arrive before the tray is built
+  // (the renderer mounts its listener on its own schedule), and that badge
+  // would otherwise be dropped until the next time the count happened to
+  // change. applyTrayTooltip is a no-op when nothing has been recorded.
+  applyTrayTooltip();
 
   // License / About handlers — surface the MIT notice for wmux itself
   // and the bundled THIRD_PARTY_NOTICES so users (and downstream
@@ -178,20 +206,26 @@ export function destroyTray(): void {
   }
   trayWindow = null;
   trayCallbacks = null;
+  // Both tooltip inputs belong to the destroyed tray's lifetime. Leaving them
+  // behind would let a stale count compose itself onto the next tray.
+  traySessionCount = null;
+  trayUnreadCount = 0;
 }
 
 /**
  * E5 — Set the platform unread badge. macOS: dock badge (number or empty).
- * Windows: tray tooltip prefix. Called from main whenever the renderer sends
+ * Windows/Linux: tray tooltip prefix, composed with the background-session
+ * nudge instead of overwriting it. Called from main whenever the renderer sends
  * a NOTIFICATION_BADGE_COUNT update.
  */
 export function updateUnreadBadge(count: number): void {
   if (process.platform === 'darwin') {
     // app.dock.setBadge expects a string; empty string clears the badge.
     app.dock?.setBadge(count > 0 ? String(count > 999 ? '999+' : count) : '');
-  } else if (tray) {
-    // Windows/Linux: prefix the tooltip with the count when non-zero.
-    const base = 'wmux';
-    tray.setToolTip(count > 0 ? `[${count}] ${base}` : base);
+    return;
   }
+  // Windows/Linux: no dock, so the count rides the tray tooltip — composed
+  // with the background-session nudge rather than replacing it.
+  trayUnreadCount = count;
+  applyTrayTooltip();
 }


### PR DESCRIPTION
Found dogfooding #729 on a live build, then reproduced on a packaged one.

## The bug

Off macOS there is no dock, so the tray tooltip is the only unread surface —
and it had two independent authors, each writing the whole string:

- `updateUnreadBadge` → `[N] wmux` (base hardcoded)
- `updateTraySessionCount` → `wmux — N background sessions running`

Whichever spoke last erased the other. The losing case is exactly the one the
badge exists for: hide the window to the tray with unread mail, the hide-path
session refresh fires, and the count disappears from the only place still
showing it — while the unread count is still non-zero.

Reproduced on the packaged build by reading the real tooltip through UI
Automation:

```
after badge push : [5] wmux
after hide        : wmux — 7 background sessions running
```

Showing the window again clears the nudge to `null` and wipes the badge a
second time.

## The fix

Both signals write to module state; the tooltip is composed in one place from
both, so they coexist: `[5] wmux — 7 background sessions running`.

Two things fall out of holding the state:

- the session count is recorded **before** the `!tray` guard, and `createTray`
  applies whatever has been recorded — so a badge that arrives during boot is
  no longer dropped until the number happens to change again (the previous
  "pre-tray no-op" silently lost it);
- `destroyTray` clears both, so a stale count cannot compose itself onto the
  next tray.

The tooltip badge also picks up the `999+` cap the dock badge already had — same
count, and an unbounded one stretches the tooltip.

## Tests

The existing unit tests passed throughout: each pinned one writer in isolation
and the defect only exists where they meet. Added 8 cases — both orders, both
clears, singular/plural with a badge present, the cap, boot ordering, and the
destroy reset. **Six of the eight fail against `origin/main`** (the other two
end in the same terminal state under both versions, so they are guard rails,
not evidence).

```
npx vitest run src/main/__tests__/ src/main/ipc/__tests__/   → 258 passed, 8 skipped
npx tsc --noEmit                                             → 0 errors
```

Not covered: the OS rendering itself on macOS and Linux. The mac branch is
untouched (dock badge, early return) and the Windows path is what was verified
live.