### PR TITLE
Self-heal panes when the shared glyph atlas merges pages

### DIFF
--- a/changelog.d/741.md
+++ b/changelog.d/741.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Scattered wrong glyphs across several panes at once during CJK-heavy sessions. The shared WebGL glyph atlas's page-merge path corrupts sibling panes' cached glyph references when its page pool fills (16 pages on Apple Silicon; Hangul's 11,172 distinct syllables fill it fast); a new guard now rebuilds the atlas coherently for every sharing pane just before that path would run, and repairs within seconds if it ever does. (#741)

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -24,6 +24,7 @@ import { attachImeStormGuard } from '../terminal/imeStormGuard';
 import { webglContextPool } from '../terminal/webglContextPool';
 import { teardownWebglAddon } from '../terminal/webglTeardown';
 import { createGlyphRepaintScheduler, type GlyphRepaintScheduler } from '../terminal/glyphRepaint';
+import { atlasGuard } from '../terminal/atlasGuard';
 import { createDeadInputWatchdog } from '../terminal/deadInputWatchdog';
 import { awaitParseBarrier } from '../terminal/parseBarrier';
 import { STALE_REPLAY_INPUT_MODE_RESETS, STALE_REPLAY_DISPLAY_RESETS } from '../terminal/staleReplayModeReset';
@@ -1133,6 +1134,23 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // terminal.textarea exists once open() has run (above).
     terminal.textarea?.addEventListener('focus', onTextareaFocus);
 
+    // Shared-atlas page-merge guard (2026-08-01 report) — see atlasGuard.ts
+    // for the root cause. glyphRepaint's refresh() above never touches the
+    // shared texture atlas (by design, #191); the guard watches the atlas's
+    // page pool across ALL panes and performs a coherent clear+refresh-all
+    // before (or, worst case, right after) the addon's page-merge path runs —
+    // the merge is what corrupts glyph references pane-wide.
+    const unregisterAtlasGuard = atlasGuard.register({
+      getAddon: () => (terminalRef.current === terminal ? webglAddonRef.current : null),
+      refresh: () => {
+        try {
+          terminal.refresh(0, terminal.rows - 1);
+        } catch {
+          // terminal may already be disposed
+        }
+      },
+    });
+
     // Only fit immediately if the container is actually visible (non-zero size).
     // If the workspace starts hidden (display:none), skip the initial fit so we
     // don't corrupt the terminal with 0 cols/rows. The visibility-watcher effect
@@ -2028,6 +2046,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       terminal.textarea?.removeEventListener('keydown', onWatchdogKeyDown);
       glyphRepaint.dispose();
       glyphRepaintRef.current = null;
+      unregisterAtlasGuard();
       imeResidueGuard?.dispose();
       imeStormGuard.dispose();
       deadInputWatchdog.dispose();

--- a/src/renderer/terminal/__tests__/atlasGuard.test.ts
+++ b/src/renderer/terminal/__tests__/atlasGuard.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createAtlasGuard,
+  extractAtlas,
+  GUARD_POLL_MS,
+  GUARD_MARGIN_PAGES,
+  FALLBACK_MAX_PAGES,
+} from '../atlasGuard';
+
+// Minimal stand-ins for the addon-webgl internals the guard walks:
+// addon._renderer._charAtlas.{pages, clearTexture, constructor.maxAtlasPages}.
+
+class FakeAtlas {
+  static maxAtlasPages = 16;
+  pages: Array<{ currentRow: { x: number; y: number } }> = [];
+  clearCalls = 0;
+  constructor(pageCount: number, lastPageInUse = true) {
+    this.setPages(pageCount, lastPageInUse);
+  }
+  setPages(pageCount: number, lastPageInUse: boolean): void {
+    this.pages = Array.from({ length: pageCount }, () => ({ currentRow: { x: 0, y: 1 } }));
+    if (this.pages.length > 0 && !lastPageInUse) {
+      this.pages[this.pages.length - 1].currentRow = { x: 0, y: 0 };
+    }
+  }
+  clearTexture(): void {
+    this.clearCalls++;
+    // Mirrors the real clearTexture: pages are emptied IN PLACE, count unchanged.
+    for (const p of this.pages) p.currentRow = { x: 0, y: 0 };
+  }
+}
+
+function addonFor(atlas: FakeAtlas | null): unknown {
+  return { _renderer: { _charAtlas: atlas } };
+}
+
+function makePane(atlas: FakeAtlas | null): { entry: { getAddon(): unknown; refresh(): void }; refreshes: () => number } {
+  let count = 0;
+  return {
+    entry: { getAddon: () => addonFor(atlas), refresh: () => { count++; } },
+    refreshes: () => count,
+  };
+}
+
+describe('atlasGuard', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  // 16-page cap → merge trigger 16 → PREVENT at 16 - GUARD_MARGIN_PAGES = 12.
+  const PREVENT_AT = 16 - GUARD_MARGIN_PAGES;
+
+  it('extractAtlas degrades to null on missing internals', () => {
+    expect(extractAtlas(null)).toBeNull();
+    expect(extractAtlas({})).toBeNull();
+    expect(extractAtlas({ _renderer: {} })).toBeNull();
+    const atlas = new FakeAtlas(1);
+    expect(extractAtlas(addonFor(atlas))).toBe(atlas);
+  });
+
+  it('PREVENT: clears + refreshes every sharing pane when the pool nears the merge trigger', () => {
+    const atlas = new FakeAtlas(PREVENT_AT, true);
+    const guard = createAtlasGuard();
+    const a = makePane(atlas);
+    const b = makePane(atlas);
+    guard.register(a.entry);
+    guard.register(b.entry);
+    vi.advanceTimersByTime(GUARD_POLL_MS);
+    expect(atlas.clearCalls).toBe(1); // shared atlas — cleared once
+    expect(a.refreshes()).toBe(1);
+    expect(b.refreshes()).toBe(1); // BOTH owners repainted in the same tick
+  });
+
+  it('does not fire below the prevention threshold', () => {
+    const atlas = new FakeAtlas(PREVENT_AT - 1, true);
+    const guard = createAtlasGuard();
+    const pane = makePane(atlas);
+    guard.register(pane.entry);
+    vi.advanceTimersByTime(GUARD_POLL_MS * 3);
+    expect(atlas.clearCalls).toBe(0);
+    expect(pane.refreshes()).toBe(0);
+  });
+
+  it('does not fire when the last page is empty (pool long but not refilled)', () => {
+    const atlas = new FakeAtlas(PREVENT_AT + 2, /* lastPageInUse */ false);
+    const guard = createAtlasGuard();
+    const pane = makePane(atlas);
+    guard.register(pane.entry);
+    vi.advanceTimersByTime(GUARD_POLL_MS * 3);
+    expect(atlas.clearCalls).toBe(0);
+  });
+
+  it('anti-thrash: after a PREVENT clear, does not refire until the pool refills end-to-end', () => {
+    const atlas = new FakeAtlas(PREVENT_AT, true);
+    const guard = createAtlasGuard();
+    const pane = makePane(atlas);
+    guard.register(pane.entry);
+    vi.advanceTimersByTime(GUARD_POLL_MS);
+    expect(atlas.clearCalls).toBe(1);
+    // clearTexture emptied the pages in place; count is unchanged but the last
+    // page is idle — further ticks must be no-ops.
+    vi.advanceTimersByTime(GUARD_POLL_MS * 5);
+    expect(atlas.clearCalls).toBe(1);
+    // Pressure genuinely rebuilds (last page in use again) → fires again.
+    atlas.setPages(PREVENT_AT, true);
+    vi.advanceTimersByTime(GUARD_POLL_MS);
+    expect(atlas.clearCalls).toBe(2);
+  });
+
+  it('CURE: a page-count drop between polls (merge ran) triggers clear + refresh-all', () => {
+    const atlas = new FakeAtlas(6, /* lastPageInUse */ false); // well under threshold
+    const guard = createAtlasGuard();
+    const pane = makePane(atlas);
+    guard.register(pane.entry);
+    vi.advanceTimersByTime(GUARD_POLL_MS); // baseline poll: 6 pages, no action
+    expect(atlas.clearCalls).toBe(0);
+    atlas.setPages(3, false); // merge deleted pages — count dropped 6 → 3
+    vi.advanceTimersByTime(GUARD_POLL_MS);
+    expect(atlas.clearCalls).toBe(1);
+    expect(pane.refreshes()).toBe(1);
+  });
+
+  it('groups panes by atlas identity — an unrelated atlas is untouched', () => {
+    const hot = new FakeAtlas(PREVENT_AT, true);
+    const cold = new FakeAtlas(2, true);
+    const guard = createAtlasGuard();
+    const hotPane = makePane(hot);
+    const coldPane = makePane(cold);
+    guard.register(hotPane.entry);
+    guard.register(coldPane.entry);
+    vi.advanceTimersByTime(GUARD_POLL_MS);
+    expect(hot.clearCalls).toBe(1);
+    expect(hotPane.refreshes()).toBe(1);
+    expect(cold.clearCalls).toBe(0);
+    expect(coldPane.refreshes()).toBe(0);
+  });
+
+  it('skips panes on the DOM renderer (no addon) without firing', () => {
+    const guard = createAtlasGuard();
+    const pane = makePane(null);
+    guard.register(pane.entry);
+    vi.advanceTimersByTime(GUARD_POLL_MS * 3);
+    expect(pane.refreshes()).toBe(0);
+  });
+
+  it('falls back to FALLBACK_MAX_PAGES when maxAtlasPages is unreadable', () => {
+    const atlas = new FakeAtlas(FALLBACK_MAX_PAGES - GUARD_MARGIN_PAGES, true);
+    // Sever the static: simulate an upstream reshape of the class shape.
+    Object.defineProperty(atlas, 'constructor', { value: {} });
+    const guard = createAtlasGuard();
+    const pane = makePane(atlas);
+    guard.register(pane.entry);
+    vi.advanceTimersByTime(GUARD_POLL_MS);
+    expect(atlas.clearCalls).toBe(1);
+  });
+
+  it('stops polling when the last pane unregisters, resumes on re-register', () => {
+    let setCalls = 0;
+    let clearCalls = 0;
+    const setSpy: typeof setInterval = ((...args: Parameters<typeof setInterval>) => {
+      setCalls++;
+      return setInterval(...args);
+    }) as typeof setInterval;
+    const clearSpy: typeof clearInterval = ((id?: Parameters<typeof clearInterval>[0]) => {
+      clearCalls++;
+      clearInterval(id);
+    }) as typeof clearInterval;
+    const guard = createAtlasGuard({ setIntervalFn: setSpy, clearIntervalFn: clearSpy });
+    const atlas = new FakeAtlas(PREVENT_AT, true);
+    const pane = makePane(atlas);
+    const unregister = guard.register(pane.entry);
+    expect(setCalls).toBe(1);
+    unregister();
+    expect(clearCalls).toBe(1);
+    vi.advanceTimersByTime(GUARD_POLL_MS * 3);
+    expect(atlas.clearCalls).toBe(0); // timer really stopped
+    guard.register(pane.entry);
+    expect(setCalls).toBe(2);
+  });
+
+  it('a refresh() that throws does not break the other panes in the group', () => {
+    const atlas = new FakeAtlas(PREVENT_AT, true);
+    const guard = createAtlasGuard();
+    const broken = { getAddon: () => addonFor(atlas), refresh: () => { throw new Error('disposed'); } };
+    const healthy = makePane(atlas);
+    guard.register(broken);
+    guard.register(healthy.entry);
+    vi.advanceTimersByTime(GUARD_POLL_MS);
+    expect(healthy.refreshes()).toBe(1);
+  });
+});

--- a/src/renderer/terminal/atlasGuard.ts
+++ b/src/renderer/terminal/atlasGuard.ts
@@ -1,0 +1,179 @@
+// Shared-atlas page-merge guard for the "scattered wrong glyph" corruption
+// class (reported 2026-08-01; see TODOS.md).
+//
+// Root cause (verified against @xterm/addon-webgl 0.19 internals): the WebGL
+// glyph texture atlas is SHARED across every same-config terminal
+// (acquireTextureAtlas keeps a module-level cache with an ownedBy list). The
+// atlas caps its page pool at `TextureAtlas.maxAtlasPages =
+// min(32, MAX_TEXTURE_IMAGE_UNITS)` — 16 on Apple Silicon. When the pool is
+// full, `_createNewPage()` MERGES four pages into one and DELETES the
+// originals, rewriting every affected glyph's texturePage index and shifting
+// the indices of the pages behind them. Renderers of OTHER panes sharing the
+// atlas keep cached vertex data pointing at the old indices and sample the
+// wrong page: scattered wrong glyphs, across several panes at once, that
+// plain refresh()/resize cannot repair (the stale cache entries survive a
+// re-raster). Opening a new pane fixed it only because its mount recreates a
+// WebGL addon and rebuilds the shared atlas from scratch.
+//
+// CJK is the trigger workload: Hangul alone has 11,172 distinct syllables, so
+// Korean-heavy sessions mint new glyphs continuously and are the realistic
+// way to exhaust 16 pages.
+//
+// Strategy — keep the buggy merge path from ever executing, and repair
+// coherently if it does:
+//
+//   PREVENT  When a shared atlas's page count approaches the merge trigger
+//            (trigger − GUARD_MARGIN_PAGES) AND the last page is actually in
+//            use (pool genuinely refilled, not just long), clear the atlas
+//            (clearTexture empties every page in place and clears both cache
+//            maps) and refresh every pane sharing it in the same tick. That is
+//            the coherent all-owners rebuild upstream itself performs on font
+//            changes — the #191 hazard was clearing from ONE pane while its
+//            siblings kept stale references, which this never does.
+//
+//   CURE     If a merge slips through anyway (page count DROPPED between two
+//            polls — merges delete 4 pages and add 1, growth only ever adds
+//            1), do the same clear+refresh-all. Corruption is visible for at
+//            most one poll interval instead of indefinitely.
+//
+// The "last page in use" condition doubles as the anti-thrash gate: right
+// after a clear every page is empty, so PREVENT cannot refire until the pool
+// genuinely fills end-to-end again.
+//
+// Internal-field dependency: reaching the atlas needs `addon._renderer
+// ._charAtlas` (same accepted trade-off as webglTeardown.ts's `_renderer._gl`)
+// — every access is optional-chained, so if upstream reshapes its internals
+// the guard degrades to a silent no-op, never a crash.
+
+/** Pages of headroom left when PREVENT fires. The pool grows one page at a
+ *  time, so this is also the number of allocations the guard can miss (poll
+ *  gap) before the merge actually triggers. */
+export const GUARD_MARGIN_PAGES = 4;
+/** Poll cadence. Each tick reads two ints per pane — effectively free — and a
+ *  2s gap is far shorter than the several-page refill the margin absorbs. */
+export const GUARD_POLL_MS = 2_000;
+/** Fallback merge trigger when maxAtlasPages is unreadable: matches the
+ *  smallest real-world cap (min(32, 16 texture units) on Apple Silicon). */
+export const FALLBACK_MAX_PAGES = 16;
+
+/** One registered pane: how to reach its WebGL addon and repaint it. */
+export interface AtlasGuardEntry {
+  /** The live WebglAddon instance, or null when on the DOM renderer. */
+  getAddon(): unknown;
+  /** Full-range terminal.refresh for this pane. */
+  refresh(): void;
+}
+
+export interface AtlasGuardOptions {
+  pollMs?: number;
+  marginPages?: number;
+  setIntervalFn?: typeof setInterval;
+  clearIntervalFn?: typeof clearInterval;
+}
+
+interface AtlasLike {
+  pages?: ArrayLike<{ currentRow?: { x?: number; y?: number } }>;
+  clearTexture?: () => void;
+  constructor?: { maxAtlasPages?: number };
+}
+
+/** Duck-typed walk to the shared TextureAtlas behind a WebglAddon. Returns
+ *  null whenever any internal is missing (DOM renderer, upstream reshape). */
+export function extractAtlas(addon: unknown): AtlasLike | null {
+  const atlas = (addon as { _renderer?: { _charAtlas?: unknown } } | null | undefined)
+    ?._renderer?._charAtlas;
+  return atlas ? (atlas as AtlasLike) : null;
+}
+
+export interface AtlasGuard {
+  /** Register a pane; returns its unregister function. The poll timer runs
+   *  only while at least one pane is registered. */
+  register(entry: AtlasGuardEntry): () => void;
+}
+
+export function createAtlasGuard(options: AtlasGuardOptions = {}): AtlasGuard {
+  const {
+    pollMs = GUARD_POLL_MS,
+    marginPages = GUARD_MARGIN_PAGES,
+    setIntervalFn = setInterval,
+    clearIntervalFn = clearInterval,
+  } = options;
+
+  const entries = new Set<AtlasGuardEntry>();
+  // Page count per atlas at the previous poll — a drop between polls means a
+  // merge ran (growth is strictly one page at a time). WeakMap so a released
+  // atlas (all owner panes disposed) never leaks an entry.
+  const prevPageCount = new WeakMap<object, number>();
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  function tick(): void {
+    // Group live panes by shared atlas identity so clear+refresh covers every
+    // owner in the same tick (the whole point — no pane may keep sampling a
+    // rebuilt atlas with stale references).
+    const groups = new Map<AtlasLike, AtlasGuardEntry[]>();
+    for (const entry of entries) {
+      const atlas = extractAtlas(entry.getAddon());
+      if (!atlas) continue;
+      const group = groups.get(atlas);
+      if (group) group.push(entry);
+      else groups.set(atlas, [entry]);
+    }
+
+    for (const [atlas, group] of groups) {
+      const pages = atlas.pages;
+      if (!pages || typeof pages.length !== 'number') continue;
+      const len = pages.length;
+      const prev = prevPageCount.get(atlas as object);
+      prevPageCount.set(atlas as object, len);
+
+      const maxPages =
+        typeof atlas.constructor?.maxAtlasPages === 'number'
+          ? atlas.constructor.maxAtlasPages
+          : FALLBACK_MAX_PAGES;
+      // Mirror of the addon's own merge trigger: pages.length >= max(4, maxAtlasPages).
+      const mergeTrigger = Math.max(4, maxPages);
+      const preventAt = Math.max(2, mergeTrigger - marginPages);
+
+      const lastPage = len > 0 ? pages[len - 1] : undefined;
+      const lastPageInUse =
+        (lastPage?.currentRow?.x ?? 0) > 0 || (lastPage?.currentRow?.y ?? 0) > 0;
+
+      const merged = prev !== undefined && len < prev;
+      const nearTrigger = len >= preventAt && lastPageInUse;
+      if (!merged && !nearTrigger) continue;
+
+      console.warn(
+        `[wmux:atlas-guard] ${merged ? 'cure (merge detected)' : 'prevent'} — pages=${len}/${mergeTrigger}, panes=${group.length}`,
+      );
+      try {
+        atlas.clearTexture?.(); // shared — one call empties it for every owner
+      } catch {
+        // atlas mid-teardown; refresh below is still harmless
+      }
+      for (const entry of group) {
+        try {
+          entry.refresh();
+        } catch {
+          // pane may be disposing — the next tick simply won't see it
+        }
+      }
+    }
+  }
+
+  return {
+    register(entry: AtlasGuardEntry): () => void {
+      entries.add(entry);
+      if (timer === null) timer = setIntervalFn(tick, pollMs);
+      return () => {
+        entries.delete(entry);
+        if (entries.size === 0 && timer !== null) {
+          clearIntervalFn(timer);
+          timer = null;
+        }
+      };
+    },
+  };
+}
+
+/** App-wide singleton — panes register in useTerminal's main effect. */
+export const atlasGuard = createAtlasGuard();


### PR DESCRIPTION
## Problem

Since 3.38.2, Korean-heavy sessions started showing scattered wrong glyphs across several panes at once. A pane-border resize (full `refresh()`) did not repair it; opening a new split pane repaired every pane at once.

## Root cause (verified against @xterm/addon-webgl 0.19 internals)

The WebGL glyph texture atlas is shared across every same-config terminal (`acquireTextureAtlas` module cache). Its page pool caps at `min(32, MAX_TEXTURE_IMAGE_UNITS)` — 16 on Apple Silicon. When the pool is full, `_createNewPage()` merges four pages into one and deletes the originals, rewriting glyph `texturePage` indices and shifting the pages behind them. Sibling panes' renderers keep **diff-skipped vertex data** pointing at the old indices and sample the wrong page — which explains every observed symptom: multi-pane, refresh-immune (`_updateModel` diff-skips unchanged cells, so stale vertex entries survive a re-raster), and fixed only by a new pane's addon recreate.

CJK is the realistic trigger workload: Hangul alone has 11,172 distinct syllables, so Korean streams mint new glyphs continuously and exhaust 16 pages. The timing correlation with 3.38.2 is the DECRQM fix (#708) un-wedging TUI panes so more panes stream more content — the merge bug itself is pre-existing upstream.

## Fix — event-driven self-heal, public API only

The atlas forwards its page-removal event (fired **only** on a merge) through each owner's renderer to each owner's addon, so every sharing pane hears the merge on its own `WebglAddon.onRemoveTextureAtlasCanvas`. Each pane defers one macrotask (the event fires inside the atlas's own mutation mid-render; a merge emits one removal per deleted page, so the deferral also coalesces the burst) and calls its own `clearTextureAtlas()` — which clears the shared texture once (the atlas-level clear no-ops after the first pane), clears **that pane's glyph model**, and requests a redraw. That is the coherent all-owners rebuild upstream itself performs on font changes, so the #191 one-pane-clears hazard cannot occur.

No polling, no timers while idle, no internal-field reads. If upstream drops the event or the method, the heal degrades to a silent no-op.

## Review-driven redesign

The first iteration was a 2s poll over addon internals with a prevent/cure page-pressure gate. A three-model review panel (Claude, Codex, GLM) independently converged on the same faults: `clearTexture()+refresh()` never rebuilds the diff-skipped vertex model (the guard itself would corrupt panes — 2-model consensus, conf 10), the last-page-in-use anti-thrash gate mismatched the allocator's refill order (3-model consensus), and poll-window detection could be masked by regrowth (2-model). This event-driven design eliminates all three by construction.

## Tests

8 unit tests on the heal (deferral, burst coalescing, re-heal, dispose/cancel, degradation, throw-safety, injected scheduler); terminal + hooks suites 720 green; tsc + eslint clean. Heal disposal is wired into all four addon-teardown paths (pool evict, context loss, fonts.ready recreate, unmount).