### PR TITLE
Let the macOS in-app update actually install

### DIFF
--- a/changelog.d/742.md
+++ b/changelog.d/742.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **Check for updates now installs the update on macOS.** Pressing it downloaded
+  and verified the new version and then did nothing at all: no restart, no
+  error, and nothing on any press after that. Installing asks macOS to close
+  every window first and only goes ahead once they are all gone, but wmux keeps
+  its window alive so it can sit in the tray, so the close was cancelled and the
+  installer waited forever on a wmux that was never going to quit. The signal
+  that was meant to let those windows go was listening for something that is
+  never sent to it, so it never arrived. wmux now says so directly and there is
+  no message left to miss. If installing still fails to restart the app, wmux
+  stops waiting, brings the window back and tells you what happened instead of
+  going quiet, and the button works again on the next press rather than
+  silently refusing for the rest of the session. Updates that were interrupted
+  no longer leave their downloaded copy behind either, where they had been
+  piling up at around 120 MB each. (#742)

--- a/changelog.d/742.md
+++ b/changelog.d/742.md
@@ -1,6 +1,6 @@
 ### Fixed
 
-- **Check for updates now installs the update on macOS.** Pressing it downloaded
+- **Check for updates now installs the update on Apple Silicon Macs.** Pressing it downloaded
   and verified the new version and then did nothing at all: no restart, no
   error, and nothing on any press after that. Installing asks macOS to close
   every window first and only goes ahead once they are all gone, but wmux keeps

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -359,7 +359,13 @@ let mainWindow: BrowserWindow | null = null;
 // reordering hook/router boot earlier than the PTY layer.
 let hookSignalRouter: HookSignalRouter | null = null;
 const ptyBridge = new PTYBridge(ptyManager, () => mainWindow, () => hookSignalRouter);
-const autoUpdater = new AutoUpdater(() => mainWindow);
+// The hooks carry the two things the updater cannot reach: the quit flag that
+// lets windows actually close (without it quitAndInstall never installs — see
+// prepareInstallQuit) and the way back if that handoff stalls.
+const autoUpdater = new AutoUpdater(() => mainWindow, {
+  onBeforeInstallQuit: () => prepareInstallQuit(),
+  onInstallQuitAborted: () => abortInstallQuit(),
+});
 
 const rpcRouter = new RpcRouter();
 markBoot('pre-pipe-server-ctor');
@@ -1073,15 +1079,7 @@ app.on('ready', async () => {
     logLine(lvl, 'renderer', `${where} — ${message}`);
   });
 
-  attachWindowRecovery(mainWindow);
-
-  // Intercept window close — hide to tray instead of destroying
-  mainWindow.on('close', (e) => {
-    if (!isQuitting) {
-      e.preventDefault();
-      mainWindow!.hide();
-    }
-  });
+  adoptMainWindow(mainWindow);
 
   // Phase 2 — UsagePoller hidden-window cost control. We treat tray-hide
   // as "user not looking" so the poller's 30-min skip threshold kicks in
@@ -1634,20 +1632,79 @@ app.on('window-all-closed', () => {
   // Actual quit is triggered from the tray "Quit" menu item.
 });
 
-// Squirrel.Mac's quitAndInstall() emits 'before-quit-for-update' and then
-// closes every window BEFORE any 'before-quit' fires — with isQuitting still
-// false, the hide-to-tray close intercept above would cancel that close and
-// stall the update restart forever. Flip the flag here so windows close
-// through. The renderer session save already ran in AutoUpdater.performInstall,
-// and the detached daemon keeps every session alive across the relaunch; the
-// broker is stopped explicitly since the full before-quit teardown is skipped
-// on this path.
-// (EventEmitter cast: the event is real but missing from this Electron
-// version's typed app-event union.)
-(app as unknown as NodeJS.EventEmitter).on('before-quit-for-update', () => {
+// quitAndInstall() closes every window and only installs once the window list
+// empties. With isQuitting still false the hide-to-tray close intercept above
+// cancels that close, so the window list never empties, the install never runs,
+// and ShipIt waits forever on a process that will not exit. Flipping the flag
+// here is what lets the windows close through.
+//
+// This used to hang off `app.on('before-quit-for-update')`. That listener never
+// fired: the event belongs to Electron's `autoUpdater`, not to `app`, and the
+// `as unknown as NodeJS.EventEmitter` cast that was added to "work around the
+// missing type" silenced the very error that said so. The updater now calls
+// this directly, so there is no event name left to get wrong.
+//
+// The full before-quit teardown is skipped on this path, so anything it
+// guarantees has to be done here: the broker is stopped explicitly, and the
+// session state is flushed the same way the darwin before-quit pass flushes it
+// (the renderer-side save already ran in AutoUpdater.performInstall, but that
+// does not cover the main process's pending debounced write).
+// Wiring every main window needs, wherever it was created. Boot, the Dock
+// 'activate' path and the aborted-install recovery all built windows their own
+// way, and only boot attached the hide-to-tray close intercept — a window from
+// either of the other two destroyed itself on close instead of hiding.
+function adoptMainWindow(win: BrowserWindow): void {
+  attachWindowRecovery(win);
+  // Intercept window close — hide to tray instead of destroying
+  win.on('close', (e) => {
+    if (!isQuitting) {
+      e.preventDefault();
+      win.hide();
+    }
+  });
+}
+
+function prepareInstallQuit(): void {
   isQuitting = true;
   mcpBrokerSupervisor.stop();
-});
+  try {
+    sessionManager.flushSync();
+  } catch (err) {
+    console.error('[Main] install-quit flushSync failed:', err);
+  }
+}
+
+// The handoff above is one-way unless it can be undone. If Squirrel never
+// terminates us, the windows are already gone and `isQuitting` makes
+// 'second-instance' and 'activate' early-return — a live process with no window
+// and no way back, recoverable only with kill -9 (observed 2026-07-12). The
+// updater's watchdog calls this to put the app back within reach before it
+// reports the failure.
+async function abortInstallQuit(): Promise<void> {
+  isQuitting = false;
+  // stop() latches, so start() alone would be a no-op — without resume() one
+  // aborted install leaves MCP down for the rest of the session, silently.
+  mcpBrokerSupervisor.resume();
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.show();
+    return;
+  }
+  // quitAndInstall already destroyed the window (isQuitting was true, so the
+  // hide-to-tray intercept let the close through). Build a new one and wait for
+  // its renderer, or the caller's error IPC lands before any listener exists.
+  const win = createWindow();
+  mainWindow = win;
+  adoptMainWindow(win);
+  await new Promise<void>((resolve) => {
+    if (win.isDestroyed()) { resolve(); return; }
+    if (!win.webContents.isLoading()) { resolve(); return; }
+    const done = () => { clearTimeout(cap); resolve(); };
+    // Never block the failure report on a renderer that will not finish.
+    const cap = setTimeout(done, 10_000);
+    win.webContents.once('did-finish-load', done);
+    win.once('closed', done);
+  });
+}
 
 app.on('before-quit', async (e) => {
   if (isQuitting) return; // second pass — let quit proceed
@@ -1919,7 +1976,7 @@ app.on('activate', () => {
   const windows = BrowserWindow.getAllWindows();
   if (windows.length === 0) {
     mainWindow = createWindow();
-    attachWindowRecovery(mainWindow);
+    adoptMainWindow(mainWindow);
     return;
   }
   // macOS: 창을 닫아도 hide()만 하고 파괴하지 않으므로(위 close 인터셉트)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1085,27 +1085,6 @@ app.on('ready', async () => {
   // as "user not looking" so the poller's 30-min skip threshold kicks in
   // and we don't burn Anthropic quota for a UI nobody sees. Show always
   // unpauses immediately and forces a catch-up fetch.
-  mainWindow.on('hide', () => {
-    usagePoller.setWindowVisible(false);
-    accountUsageService.setWindowVisible(false);
-    // Quit-to-tray is the accumulation blind spot: the daemon keeps every
-    // live session (and any agent inside it) running with no visible UI.
-    // Refresh the tray's session-count nudge so the user can see how much is
-    // still alive in the background. Best-effort — a tray hint must never
-    // block window hide, and listSessions may reject mid daemon-respawn.
-    void refreshTraySessionCount();
-  });
-  mainWindow.on('show', () => {
-    usagePoller.setWindowVisible(true);
-    accountUsageService.setWindowVisible(true);
-    // Window is visible again — the panes speak for themselves, so clear the
-    // background-session nudge back to the plain "wmux" tooltip/menu. Bump the
-    // refresh token first so a slow in-flight hide refresh can't overwrite this
-    // clear with a stale count after it resolves. (codex review P3)
-    trayRefreshToken++;
-    updateTraySessionCount(null);
-  });
-
   // System tray — lets the app stay alive when window is closed.
   // Phase A — A3/A5 fix (codex review P1, session 019e2af8): the callback
   // used to set isQuitting=true before tray.ts then called app.quit(). The
@@ -1345,30 +1324,6 @@ app.on('ready', async () => {
   // cause, so this correctly re-arms for the full reload→remount window;
   // the renderer flips it back via IPC.NOTIFICATION_LISTENER_READY once
   // useNotificationListener's effect actually resubscribes.
-  mainWindow.webContents.on('did-start-loading', () => {
-    markRendererNotificationListenerNotReady();
-  });
-
-  let didFailLoadCount = 0;
-  mainWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription) => {
-    // ERR_ABORTED(-3): 새 내비게이션이 이전 로드를 정상 취소한 경우 — 재시도 불필요.
-    if (errorCode === -3) return;
-    console.error('[Main] Page failed to load:', errorCode, errorDescription);
-    didFailLoadCount += 1;
-    if (didFailLoadCount > 10) {
-      console.error('[Main] did-fail-load 10회 초과 — 자동 reload 중단. dev server(npm start)나 빌드 자산을 확인하세요.');
-      return;
-    }
-    const delay = Math.min(500 * 2 ** (didFailLoadCount - 1), 30_000);
-    setTimeout(() => {
-      if (mainWindow && !mainWindow.isDestroyed()) mainWindow.reload();
-    }, delay);
-  });
-  mainWindow.webContents.on('did-finish-load', () => {
-    didFailLoadCount = 0; // 로드 성공 — 백오프 카운터 리셋
-    console.log('[Main] Page loaded successfully');
-  });
-
   if (mainWindow && !mainWindow.isDestroyed()) {
     loadMainRenderer(mainWindow);
     markBoot('renderer-load-triggered');
@@ -1461,9 +1416,6 @@ app.on('ready', async () => {
     }
   });
 
-  mainWindow.on('closed', () => {
-    mainWindow = null;
-  });
   // M0-e — hydrate MetadataStore from disk, then wire the persist callback
   // so subsequent `metadataStore.set/clear/onPaneDeleted` flush to disk
   // BEFORE the `pane.metadata.changed` event publishes (race spec #1).
@@ -1655,12 +1607,75 @@ app.on('window-all-closed', () => {
 // either of the other two destroyed itself on close instead of hiding.
 function adoptMainWindow(win: BrowserWindow): void {
   attachWindowRecovery(win);
+
+  win.on('closed', () => {
+    // Guarded: a recovery window may be adopted while the old reference is
+    // still being torn down, and only the current one may clear the binding.
+    if (mainWindow === win) mainWindow = null;
+  });
+
   // Intercept window close — hide to tray instead of destroying
   win.on('close', (e) => {
     if (!isQuitting) {
       e.preventDefault();
       win.hide();
     }
+  });
+
+  // Phase 2 — UsagePoller hidden-window cost control. We treat tray-hide
+  // as "user not looking" so the poller's 30-min skip threshold kicks in
+  // and we don't burn Anthropic quota for a UI nobody sees. Show always
+  // unpauses immediately and forces a catch-up fetch.
+  win.on('hide', () => {
+    usagePoller.setWindowVisible(false);
+    accountUsageService.setWindowVisible(false);
+    // Quit-to-tray is the accumulation blind spot: the daemon keeps every
+    // live session (and any agent inside it) running with no visible UI.
+    // Refresh the tray's session-count nudge so the user can see how much is
+    // still alive in the background. Best-effort — a tray hint must never
+    // block window hide, and listSessions may reject mid daemon-respawn.
+    void refreshTraySessionCount();
+  });
+  win.on('show', () => {
+    usagePoller.setWindowVisible(true);
+    accountUsageService.setWindowVisible(true);
+    // Window is visible again — the panes speak for themselves, so clear the
+    // background-session nudge back to the plain "wmux" tooltip/menu. Bump the
+    // refresh token first so a slow in-flight hide refresh can't overwrite this
+    // clear with a stale count after it resolves. (codex review P3)
+    trayRefreshToken++;
+    updateTraySessionCount(null);
+  });
+
+  // A reload/remount means the renderer's notification listener is gone until
+  // it resubscribes; re-arm so a stale "ready" cannot outlive the old renderer.
+  // The renderer flips it back via IPC.NOTIFICATION_LISTENER_READY.
+  win.webContents.on('did-start-loading', () => {
+    markRendererNotificationListenerNotReady();
+  });
+
+  // Reload backoff. Attached here rather than at the boot site so every window
+  // gets it — the update-recovery window in particular exists only to render a
+  // failure message, and a blank window that never retries would reproduce the
+  // silence it was created to break.
+  let didFailLoadCount = 0;
+  win.webContents.on('did-fail-load', (_event, errorCode, errorDescription) => {
+    // ERR_ABORTED(-3): 새 내비게이션이 이전 로드를 정상 취소한 경우 — 재시도 불필요.
+    if (errorCode === -3) return;
+    console.error('[Main] Page failed to load:', errorCode, errorDescription);
+    didFailLoadCount += 1;
+    if (didFailLoadCount > 10) {
+      console.error('[Main] did-fail-load 10회 초과 — 자동 reload 중단. dev server(npm start)나 빌드 자산을 확인하세요.');
+      return;
+    }
+    const delay = Math.min(500 * 2 ** (didFailLoadCount - 1), 30_000);
+    setTimeout(() => {
+      if (!win.isDestroyed()) win.reload();
+    }, delay);
+  });
+  win.webContents.on('did-finish-load', () => {
+    didFailLoadCount = 0; // 로드 성공 — 백오프 카운터 리셋
+    console.log('[Main] Page loaded successfully');
   });
 }
 
@@ -1692,9 +1707,12 @@ async function abortInstallQuit(): Promise<void> {
   // quitAndInstall already destroyed the window (isQuitting was true, so the
   // hide-to-tray intercept let the close through). Build a new one and wait for
   // its renderer, or the caller's error IPC lands before any listener exists.
-  const win = createWindow();
+  // deferLoad so the reload backoff and console wiring are attached before the
+  // navigation starts — this window's whole job is to render the failure.
+  const win = createWindow({ deferLoad: true });
   mainWindow = win;
   adoptMainWindow(win);
+  loadMainRenderer(win);
   await new Promise<void>((resolve) => {
     if (win.isDestroyed()) { resolve(); return; }
     if (!win.webContents.isLoading()) { resolve(); return; }

--- a/src/main/mcp/BrokerSupervisor.ts
+++ b/src/main/mcp/BrokerSupervisor.ts
@@ -190,4 +190,17 @@ export class BrokerSupervisor {
       this.child = null;
     }
   }
+
+  /**
+   * Undo `stop()` for a teardown that turned out not to happen — an install-quit
+   * that was prepared and then aborted (see AutoUpdaterHooks). `stop()` latches
+   * `stopped` so a dying app cannot respawn the broker, and `start()` refuses to
+   * run while that latch is set; an aborted teardown has to clear it or MCP
+   * stays down for the rest of the session with nothing saying so.
+   */
+  resume(): void {
+    if (!this.stopped) return;
+    this.stopped = false;
+    this.start();
+  }
 }

--- a/src/main/updater/AutoUpdater.ts
+++ b/src/main/updater/AutoUpdater.ts
@@ -13,7 +13,7 @@
 
 import { autoUpdater, app, type BrowserWindow, ipcMain, net, shell } from 'electron';
 import { createWriteStream } from 'node:fs';
-import { unlink } from 'node:fs/promises';
+import { readdir, stat, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import { IPC } from '../../shared/constants';
@@ -35,6 +35,23 @@ const MANIFEST_URL = `https://github.com/${REPO}/releases/latest/download/${MANI
 // 업데이트 자동 확인 간격 (30분)
 const CHECK_INTERVAL_MS = 30 * 60 * 1000;
 
+// Once quitAndInstall() is called, terminating this process is Squirrel's job
+// and takes about a second. If we are still running after this, ShipIt is
+// waiting on a process that will never die — unwind instead of leaving the UI
+// silent forever (#update-hang).
+const INSTALL_HANDOFF_TIMEOUT_MS = 30_000;
+// Squirrel downloading and unpacking a ~120 MB bundle before it reports
+// 'update-downloaded'. Generous on purpose: a slow disk or an antivirus scan
+// makes this minutes, and aborting a healthy update is worse than waiting.
+const INSTALL_STAGING_TIMEOUT_MS = 10 * 60 * 1000;
+
+// Verified installers are named `wmux-update-<version>-<pid>-<artifact>`. A
+// stage-then-stall leaves one behind (only the supersede and error paths
+// unlink), so they accumulate at ~120 MB each. Swept at startup; the age floor
+// keeps a concurrent instance's in-flight download safe.
+const TEMP_ARTIFACT_PREFIX = 'wmux-update-';
+const TEMP_ARTIFACT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
 // In-app auto-update runs on Windows (Squirrel.Windows `.Setup.exe`) and on
 // Apple Silicon macOS (Squirrel.Mac, signed+notarized ZIP). Everything else —
 // Intel macOS (no build is produced) and Linux (users update via their package
@@ -51,9 +68,42 @@ interface UpdateInfo {
   url: string;
 }
 
+/**
+ * Main-process state the updater cannot reach on its own, but which decides
+ * whether an install can actually happen.
+ *
+ * `quitAndInstall()` asks Electron to close every window and only installs once
+ * the window list empties. A hide-to-tray `close` intercept cancels that close,
+ * so the install never runs and ShipIt waits on us forever. The main process
+ * therefore has to be told an install-quit is starting BEFORE we hand off — and
+ * told to undo it if the handoff stalls, or it is left with no window and a
+ * quit flag that makes it ignore Dock clicks and relaunch.
+ *
+ * Both hooks are required, not optional: the bug this interface exists to
+ * prevent was a quit signal that silently never arrived.
+ */
+export interface AutoUpdaterHooks {
+  /**
+   * Invoked synchronously immediately before Squirrel is told to install. Must
+   * let windows actually close, and must flush any state the normal quit path
+   * would have flushed — that path is skipped entirely on this route.
+   */
+  onBeforeInstallQuit: () => void;
+  /**
+   * Undo `onBeforeInstallQuit` after a handoff that never terminated us: clear
+   * the quit flag, restore anything the prepare tore down, and bring a window
+   * back. Without this the recovery path is worse than the failure it recovers
+   * from. Resolve only once the restored window can receive IPC — the updater
+   * waits on this before reporting, so the error is not sent into a renderer
+   * that has not attached its listeners yet.
+   */
+  onInstallQuitAborted: () => void | Promise<void>;
+}
+
 export class AutoUpdater {
   private checkTimer: ReturnType<typeof setInterval> | null = null;
   private getWindow: () => BrowserWindow | null;
+  private hooks: AutoUpdaterHooks;
   private isChecking = false;
   private enabled = true;
   private pendingUpdate: UpdateInfo | null = null;
@@ -70,8 +120,9 @@ export class AutoUpdater {
   // launch the installer twice.
   private isInstalling = false;
 
-  constructor(getWindow: () => BrowserWindow | null) {
+  constructor(getWindow: () => BrowserWindow | null, hooks: AutoUpdaterHooks) {
     this.getWindow = getWindow;
+    this.hooks = hooks;
   }
 
   start(): void {
@@ -89,11 +140,42 @@ export class AutoUpdater {
       return;
     }
 
+    void this.sweepStaleArtifacts();
+
     // 앱 시작 후 15초 뒤 첫 번째 확인 (시작 부하 방지)
     setTimeout(() => this.check(), 15_000);
 
     // 이후 주기적 확인
     this.checkTimer = setInterval(() => this.check(), CHECK_INTERVAL_MS);
+  }
+
+  /**
+   * Drop verified installers left in temp by an install that staged but never
+   * completed. Best-effort and never blocks startup: a failure here costs disk,
+   * not correctness. Only files older than TEMP_ARTIFACT_MAX_AGE_MS are removed
+   * so a second instance downloading right now keeps its artifact.
+   */
+  private async sweepStaleArtifacts(): Promise<void> {
+    const tempDir = app.getPath('temp');
+    let names: string[];
+    try {
+      names = await readdir(tempDir);
+    } catch {
+      return;
+    }
+    const cutoff = Date.now() - TEMP_ARTIFACT_MAX_AGE_MS;
+    for (const name of names) {
+      if (!name.startsWith(TEMP_ARTIFACT_PREFIX)) continue;
+      const full = join(tempDir, name);
+      try {
+        const info = await stat(full);
+        if (info.mtimeMs >= cutoff) continue;
+        await unlink(full);
+        console.log(`[AutoUpdater] swept stale update artifact ${name}`);
+      } catch {
+        /* best-effort — another instance may own it, or it vanished mid-sweep */
+      }
+    }
   }
 
   setEnabled(enabled: boolean): void {
@@ -418,15 +500,26 @@ export class AutoUpdater {
       console.log(`[AutoUpdater] install ignored on ${process.platform} — no in-app installer for this platform.`);
       return;
     }
+    // Both guards below used to return with only a console.log. Nothing reached
+    // the renderer, so a press that hit one of them looked identical to a press
+    // that did nothing at all — which is exactly how a stalled install
+    // presented: silent, and silent again on every retry. Every refusal now
+    // says so on UPDATE_ERROR, the one channel the UI already renders.
     const tempPath = this.downloadedPath;
     if (!tempPath) {
-      // The UI only surfaces the install button after 'downloaded' fired, so
-      // this is a defensive no-op (e.g. a prior download failed).
       console.log('[AutoUpdater] install ignored — no verified installer downloaded yet.');
+      this.sendToRenderer(IPC.UPDATE_ERROR, {
+        status: 'error',
+        message: 'No verified installer is ready yet. Check for updates again to download one.',
+      });
       return;
     }
     if (this.isInstalling) {
       console.log('[AutoUpdater] install already in progress — ignoring re-entrant call.');
+      this.sendToRenderer(IPC.UPDATE_ERROR, {
+        status: 'error',
+        message: 'An update install is already in progress. If nothing happens, restart wmux and try again.',
+      });
       return;
     }
     this.isInstalling = true;
@@ -480,15 +573,79 @@ export class AutoUpdater {
    * Fail-closed: any Squirrel error (most commonly "code signature" on a local
    * unsigned build) tears the feed down, clears the install guard, and surfaces
    * UPDATE_ERROR instead of leaving the UI stuck mid-install.
+   *
+   * Two phases, each with its own deadline, because they fail differently:
+   *
+   *   setFeedURL ─> checkForUpdates ─── staging (Squirrel downloads + unpacks
+   *        │                            120 MB over loopback) ──> update-downloaded
+   *        └── arm STAGING deadline ────────────────────────────────┐
+   *                                                                 │ (cleared)
+   *                        onBeforeInstallQuit ─> quitAndInstall ────┤
+   *                             └── arm HANDOFF deadline ───┐        │
+   *                                                         ▼        ▼
+   *                                      still alive? ─> unwind   process exits
+   *                                      (abort quit, restore window, report)
+   *
+   * The quit is prepared as late as possible — immediately before
+   * quitAndInstall, not before staging. Staging can legitimately take minutes on
+   * a slow disk or behind antivirus, and a tight deadline covering it would abort
+   * healthy updates; it also keeps the app in the dangerous "quitting" state
+   * (windows closable, broker stopped) for the shortest possible window.
+   *
+   * Every exit from an attempt runs through settleAttempt(), which detaches the
+   * Squirrel listeners. Without that, a late event from a torn-down attempt can
+   * re-enter — a stray 'error' double-reports, and a stray 'update-downloaded'
+   * calls quitAndInstall AFTER the abort restored the quit flag, re-creating the
+   * exact hang this fix exists to remove.
    */
   private async installDarwin(zipPath: string): Promise<void> {
     const feed = new LocalUpdateFeed();
-    const cleanup = () => { void feed.stop(); };
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let quitPrepared = false;
+    let settled = false;
+
+    const armDeadline = (ms: number, onExpiry: () => void) => {
+      if (timer !== null) clearTimeout(timer);
+      timer = setTimeout(() => { timer = null; onExpiry(); }, ms);
+    };
+
+    /** Terminal for this attempt: no Squirrel callback may act after this. */
+    const settleAttempt = () => {
+      settled = true;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      autoUpdater.removeAllListeners('update-downloaded');
+      autoUpdater.removeAllListeners('error');
+      void feed.stop();
+    };
+
     const failInstall = (message: string) => {
-      cleanup();
+      if (settled) return; // already reported — a late Squirrel event, ignore it
+      settleAttempt();
+      // Order matters: put the app back within reach BEFORE reporting, or the
+      // error lands on a process the user cannot bring to the front. The hook
+      // resolves once its window can actually receive IPC — a freshly created
+      // window has no listeners attached until its renderer has loaded, and
+      // sending into it early would drop the error and keep the UI silent.
+      const reachable = quitPrepared
+        ? (() => {
+          quitPrepared = false;
+          try {
+            return Promise.resolve(this.hooks.onInstallQuitAborted());
+          } catch (err) {
+            console.error('[AutoUpdater] onInstallQuitAborted threw — app may need a manual restart:', err);
+            return Promise.resolve();
+          }
+        })()
+        : Promise.resolve();
+
       this.isInstalling = false; // let the user retry
       console.error('[AutoUpdater] macOS install failed (fail-closed):', message);
-      this.sendToRenderer(IPC.UPDATE_ERROR, { status: 'error', message });
+      void reachable
+        .catch((err) => { console.error('[AutoUpdater] install-quit abort failed:', err); })
+        .then(() => { this.sendToRenderer(IPC.UPDATE_ERROR, { status: 'error', message }); });
     };
 
     try {
@@ -496,16 +653,36 @@ export class AutoUpdater {
       autoUpdater.removeAllListeners('update-downloaded');
       autoUpdater.removeAllListeners('error');
       autoUpdater.on('update-downloaded', () => {
+        if (settled) return; // late event from an attempt that already failed
         console.log('[AutoUpdater] Squirrel.Mac staged the verified update — restarting to install (sessions persist in the daemon)');
-        cleanup();
         // Squirrel has its own staged copy now — drop our temp ZIP so it does
         // not survive the relaunch and pile up release after release.
         void unlink(zipPath).catch(() => { /* best-effort cleanup */ });
         this.downloadedPath = null;
+
+        // Let the windows close (the hide-to-tray intercept would otherwise
+        // cancel the close quitAndInstall waits on), then deadline the handoff:
+        // from here Squirrel owns terminating us, and if it does not, ShipIt
+        // waits forever on a process that will never exit.
+        quitPrepared = true;
+        this.hooks.onBeforeInstallQuit();
+        armDeadline(INSTALL_HANDOFF_TIMEOUT_MS, () => {
+          failInstall(
+            `The update was downloaded and verified, but installing it did not restart wmux within ${Math.round(INSTALL_HANDOFF_TIMEOUT_MS / 1000)}s. ` +
+            `Quit wmux completely and try again, or install the latest release manually from https://github.com/${REPO}/releases`,
+          );
+        });
         autoUpdater.quitAndInstall();
       });
       autoUpdater.on('error', (err: Error) => {
         failInstall(this.describeDarwinInstallError(err));
+      });
+
+      armDeadline(INSTALL_STAGING_TIMEOUT_MS, () => {
+        failInstall(
+          `The update was downloaded and verified, but macOS did not finish preparing it within ${Math.round(INSTALL_STAGING_TIMEOUT_MS / 60_000)} minutes. ` +
+          `Try again, or install the latest release manually from https://github.com/${REPO}/releases`,
+        );
       });
       autoUpdater.setFeedURL({ url: feedUrl, serverType: 'json' });
       autoUpdater.checkForUpdates();

--- a/src/main/updater/__tests__/AutoUpdater.download.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.download.test.ts
@@ -13,6 +13,11 @@ const DL_URL = `https://github.com/openwong2kim/wmux/releases/download/v${NEW_VE
 const INSTALLER_BODY = Buffer.from('FAKE-INSTALLER-BYTES');
 const GOOD_SHA = createHash('sha256').update(INSTALLER_BODY).digest('hex');
 
+/** Quit hooks every AutoUpdater requires (see AutoUpdaterHooks). */
+function quitHooks() {
+  return { onBeforeInstallQuit: vi.fn(), onInstallQuitAborted: vi.fn() };
+}
+
 const realPlatform = process.platform;
 afterEach(() => {
   Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true });
@@ -137,7 +142,7 @@ describe('AutoUpdater two-step flow (win32)', () => {
 
   it('a background check auto-downloads, streams progress, and emits downloaded (no auto-install)', async () => {
     const { AutoUpdater, sent, openPath, quit, win } = await loadWin32();
-    const updater = new AutoUpdater(() => win as never);
+    const updater = new AutoUpdater(() => win as never, quitHooks());
     updater.start();
 
     // Background poll (not user-triggered): downloads + verifies, then STOPS.
@@ -160,7 +165,7 @@ describe('AutoUpdater two-step flow (win32)', () => {
 
   it('a user-triggered check (UPDATE_CHECK) is one-shot: auto-installs once verified', async () => {
     const { AutoUpdater, ipcHandlers, openPath, quit, win } = await loadWin32();
-    const updater = new AutoUpdater(() => win as never);
+    const updater = new AutoUpdater(() => win as never, quitHooks());
     updater.start();
 
     // The manual "check for updates" button routes through UPDATE_CHECK — a
@@ -176,7 +181,7 @@ describe('AutoUpdater two-step flow (win32)', () => {
 
   it('UPDATE_INSTALL launches the downloaded file without re-fetching the manifest, then quits', async () => {
     const { AutoUpdater, ipcHandlers, requestUrls, openPath, quit, win } = await loadWin32();
-    const updater = new AutoUpdater(() => win as never);
+    const updater = new AutoUpdater(() => win as never, quitHooks());
     updater.start();
 
     await backgroundCheck(updater);
@@ -197,7 +202,7 @@ describe('AutoUpdater two-step flow (win32)', () => {
   it('rejects on sha256 mismatch: emits error, no downloaded path, install is a no-op', async () => {
     const BAD_SHA = 'a'.repeat(64);
     const { AutoUpdater, ipcHandlers, sent, openPath, quit, win } = await loadWin32({ sha: BAD_SHA });
-    const updater = new AutoUpdater(() => win as never);
+    const updater = new AutoUpdater(() => win as never, quitHooks());
     updater.start();
 
     await backgroundCheck(updater);
@@ -217,7 +222,7 @@ describe('AutoUpdater two-step flow (win32)', () => {
 
   it('a manual press mid-poll preserves the one-shot intent so the in-flight download installs', async () => {
     const { AutoUpdater, openPath, quit, win } = await loadWin32();
-    const updater = new AutoUpdater(() => win as never);
+    const updater = new AutoUpdater(() => win as never, quitHooks());
     updater.start();
 
     const internals = updater as unknown as {
@@ -247,7 +252,7 @@ describe('AutoUpdater two-step flow (win32)', () => {
   it('a failed one-shot fast-path install clears the intent (no unattended restart later)', async () => {
     const { AutoUpdater, openPath, quit, win } = await loadWin32();
     openPath.mockResolvedValueOnce('launch failed'); // shell.openPath resolves with an error string, never throws
-    const updater = new AutoUpdater(() => win as never);
+    const updater = new AutoUpdater(() => win as never, quitHooks());
     updater.start();
 
     const internals = updater as unknown as {
@@ -274,7 +279,7 @@ describe('AutoUpdater two-step flow (win32)', () => {
   it('a failed one-shot download does not restart the app (install intent cleared)', async () => {
     const BAD_SHA = 'a'.repeat(64);
     const { AutoUpdater, ipcHandlers, openPath, quit, win } = await loadWin32({ sha: BAD_SHA });
-    const updater = new AutoUpdater(() => win as never);
+    const updater = new AutoUpdater(() => win as never, quitHooks());
     updater.start();
 
     // User pressed the button, but the download fails verification: the app
@@ -289,7 +294,7 @@ describe('AutoUpdater two-step flow (win32)', () => {
   it('removes the partial temp file when verification fails (no tampered artifact left in temp)', async () => {
     const BAD_SHA = 'a'.repeat(64);
     const { AutoUpdater, unlinkMock, win } = await loadWin32({ sha: BAD_SHA });
-    const updater = new AutoUpdater(() => win as never);
+    const updater = new AutoUpdater(() => win as never, quitHooks());
     updater.start();
 
     await backgroundCheck(updater);
@@ -303,7 +308,7 @@ describe('AutoUpdater two-step flow (win32)', () => {
 
   it('a newer release supersedes a downloaded one: old artifact unlinked, new one downloaded', async () => {
     const { AutoUpdater, feed, sent, unlinkMock, win } = await loadWin32();
-    const updater = new AutoUpdater(() => win as never);
+    const updater = new AutoUpdater(() => win as never, quitHooks());
     updater.start();
 
     // First poll downloads + verifies 9.9.10.

--- a/src/main/updater/__tests__/AutoUpdater.platform.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.platform.test.ts
@@ -27,6 +27,15 @@ const FAKE_VERSION = '9.9.9';
 const EXPECTED_WIN32_FEED = `https://update.electronjs.org/openwong2kim/wmux/win32/${FAKE_VERSION}`;
 const EXPECTED_DARWIN_FEED = `https://update.electronjs.org/openwong2kim/wmux/darwin-arm64/${FAKE_VERSION}`;
 
+/**
+ * Quit hooks every AutoUpdater needs. Required, not optional: the macOS install
+ * hang existed because the main process's quit signal silently never arrived,
+ * so a construction that forgets to wire it must not compile.
+ */
+function quitHooks() {
+  return { onBeforeInstallQuit: vi.fn(), onInstallQuitAborted: vi.fn() };
+}
+
 /** Platforms with no in-app updater: [platform, arch]. */
 const UNSUPPORTED: ReadonlyArray<readonly [NodeJS.Platform, string]> = [
   ['linux', 'x64'],
@@ -151,7 +160,7 @@ describe('AutoUpdater platform gating', () => {
     vi.useFakeTimers();
     const { AutoUpdater, requestUrls } = await loadForPlatform('win32');
 
-    const updater = new AutoUpdater(() => null);
+    const updater = new AutoUpdater(() => null, quitHooks());
     updater.start();
 
     // First check fires 15s after start.
@@ -165,7 +174,7 @@ describe('AutoUpdater platform gating', () => {
     vi.useFakeTimers();
     const { AutoUpdater, requestUrls } = await loadForPlatform('win32');
 
-    const updater = new AutoUpdater(() => null);
+    const updater = new AutoUpdater(() => null, quitHooks());
     updater.start();
     await vi.advanceTimersByTimeAsync(15_000); // first check
     const afterFirst = requestUrls.length;
@@ -179,7 +188,7 @@ describe('AutoUpdater platform gating', () => {
     vi.useFakeTimers();
     const { AutoUpdater, requestUrls } = await loadForPlatform('darwin');
 
-    const updater = new AutoUpdater(() => null);
+    const updater = new AutoUpdater(() => null, quitHooks());
     updater.start();
     await vi.advanceTimersByTimeAsync(15_000);
 
@@ -193,7 +202,7 @@ describe('AutoUpdater platform gating', () => {
     vi.useFakeTimers();
     const { AutoUpdater, ipcHandlers } = await loadForPlatform('darwin');
 
-    const updater = new AutoUpdater(() => null);
+    const updater = new AutoUpdater(() => null, quitHooks());
     updater.start();
 
     const checkHandler = ipcHandlers.get(IPC.UPDATE_CHECK);
@@ -209,7 +218,7 @@ describe('AutoUpdater platform gating', () => {
       vi.useFakeTimers();
       const { AutoUpdater, requestUrls } = await loadForPlatform(platform, undefined, arch);
 
-      const updater = new AutoUpdater(() => null);
+      const updater = new AutoUpdater(() => null, quitHooks());
       updater.start();
 
       // Advance well past the first-check delay AND a full interval.
@@ -225,7 +234,7 @@ describe('AutoUpdater platform gating', () => {
     async (platform, arch) => {
       const { AutoUpdater, ipcHandlers, requestUrls } = await loadForPlatform(platform, undefined, arch);
 
-      const updater = new AutoUpdater(() => null);
+      const updater = new AutoUpdater(() => null, quitHooks());
       updater.start();
 
       const checkHandler = ipcHandlers.get(IPC.UPDATE_CHECK);
@@ -248,7 +257,7 @@ describe('AutoUpdater platform gating', () => {
     vi.useFakeTimers();
     const { AutoUpdater, ipcHandlers } = await loadForPlatform('win32');
 
-    const updater = new AutoUpdater(() => null);
+    const updater = new AutoUpdater(() => null, quitHooks());
     updater.start();
 
     const checkHandler = ipcHandlers.get(IPC.UPDATE_CHECK);
@@ -324,7 +333,7 @@ describe('AutoUpdater #502 — quit after launching the installer', () => {
   async function downloadUpdateFor(loaded: Awaited<ReturnType<typeof loadForPlatform>>) {
     const { AutoUpdater, ipcHandlers } = loaded;
     const { win, sent } = makeWin();
-    const updater = new AutoUpdater(() => win as never);
+    const updater = new AutoUpdater(() => win as never, quitHooks());
     (updater as unknown as { registerIpcHandlers: () => void }).registerIpcHandlers();
 
     const installHandler = ipcHandlers.get(IPC.UPDATE_INSTALL);
@@ -366,7 +375,7 @@ describe('AutoUpdater #502 — quit after launching the installer', () => {
   it('win32: UPDATE_INSTALL with no downloaded installer neither launches nor quits', async () => {
     const loaded = await loadForPlatform('win32'); // 204 feed — nothing downloads
     const { AutoUpdater, ipcHandlers } = loaded;
-    const updater = new AutoUpdater(() => null);
+    const updater = new AutoUpdater(() => null, quitHooks());
     (updater as unknown as { registerIpcHandlers: () => void }).registerIpcHandlers();
 
     const installHandler = ipcHandlers.get(IPC.UPDATE_INSTALL);
@@ -430,13 +439,14 @@ describe('AutoUpdater darwin-arm64 install (Squirrel.Mac loopback feed)', () => 
         executeJavaScript: async () => undefined,
       },
     };
-    const updater = new loaded.AutoUpdater(() => win as never);
+    const hooks = quitHooks();
+    const updater = new loaded.AutoUpdater(() => win as never, hooks);
     (updater as unknown as { registerIpcHandlers: () => void }).registerIpcHandlers();
     await (updater as unknown as { check: (oneShot?: boolean) => Promise<void> }).check();
     await until(() => sent.some((m) => m.channel === IPC.UPDATE_AVAILABLE && m.data.status === 'downloaded'));
     const installHandler = loaded.ipcHandlers.get(IPC.UPDATE_INSTALL);
     if (typeof installHandler !== 'function') throw new Error('UPDATE_INSTALL handler was not registered');
-    return { loaded, installHandler, sent };
+    return { loaded, installHandler, sent, hooks, updater };
   }
 
   it('downloads the manifest-named .zip (not a Windows .Setup.exe)', async () => {
@@ -470,12 +480,134 @@ describe('AutoUpdater darwin-arm64 install (Squirrel.Mac loopback feed)', () => 
     await installHandler();
     await until(() => loaded.nativeUpdater.setFeedURL.mock.calls.length > 0);
     loaded.nativeUpdater.emit('error', new Error('Could not get code signature for running application'));
+    // The report waits on the abort hook (which may have to rebuild a window),
+    // so it lands a microtask later.
+    await until(() => sent.some((m) => m.channel === IPC.UPDATE_ERROR));
 
     const err = sent.find((m) => m.channel === IPC.UPDATE_ERROR);
-    expect(err).toBeDefined();
     expect(String(err!.data.message)).toContain('not code-signed');
     expect(String(err!.data.message)).toContain('releases');
     expect(loaded.nativeUpdater.quitAndInstall).not.toHaveBeenCalled();
+  });
+
+  // Regression, macOS install hang: quitAndInstall() closes every window and
+  // only installs once the window list empties, so the main process has to be
+  // told to stop intercepting closes FIRST. Asserting quitAndInstall was called
+  // is not enough — that assertion passed for the entire life of the bug. The
+  // ordering is the contract.
+  it('prepares the install-quit at the handoff — after staging, before quitAndInstall', async () => {
+    const { loaded, installHandler, hooks } = await downloadOnDarwin();
+
+    await installHandler();
+    await until(() => loaded.nativeUpdater.setFeedURL.mock.calls.length > 0);
+
+    // Staging is Squirrel downloading and unpacking ~120 MB. Preparing the quit
+    // here would leave the app closable and the broker stopped for all of it.
+    expect(hooks.onBeforeInstallQuit).not.toHaveBeenCalled();
+
+    loaded.nativeUpdater.emit('update-downloaded');
+
+    expect(hooks.onBeforeInstallQuit).toHaveBeenCalledTimes(1);
+    expect(hooks.onInstallQuitAborted).not.toHaveBeenCalled();
+    const preparedAt = hooks.onBeforeInstallQuit.mock.invocationCallOrder[0]!;
+    const quitAt = loaded.nativeUpdater.quitAndInstall.mock.invocationCallOrder[0]!;
+    expect(preparedAt).toBeLessThan(quitAt);
+  });
+
+  it('a late Squirrel event after a failed attempt cannot re-trigger the install', async () => {
+    const { loaded, installHandler, sent, hooks } = await downloadOnDarwin();
+
+    await installHandler();
+    await until(() => loaded.nativeUpdater.setFeedURL.mock.calls.length > 0);
+    loaded.nativeUpdater.emit('error', new Error('boom'));
+    await until(() => sent.some((m) => m.channel === IPC.UPDATE_ERROR));
+
+    // Squirrel finishing late must not call quitAndInstall now: the abort has
+    // already restored the quit flag, so the close intercept is live again and
+    // the install would wedge exactly as it did before this fix.
+    loaded.nativeUpdater.emit('update-downloaded');
+    loaded.nativeUpdater.emit('error', new Error('late second error'));
+
+    expect(loaded.nativeUpdater.quitAndInstall).not.toHaveBeenCalled();
+    expect(hooks.onBeforeInstallQuit).not.toHaveBeenCalled();
+    expect(sent.filter((m) => m.channel === IPC.UPDATE_ERROR)).toHaveLength(1);
+  });
+
+  it('a handoff that never restarts the app unwinds: abort, retryable, reported', async () => {
+    // The download runs on real timers (the poll helper needs them); only the
+    // install handoff is put on fake ones so the 30s deadline is reachable.
+    const { loaded, installHandler, sent, hooks, updater } = await downloadOnDarwin();
+    vi.useFakeTimers();
+    try {
+      const install = installHandler();
+      await vi.advanceTimersByTimeAsync(1_000); // performInstall's session-save wait
+      await install;
+      expect(loaded.nativeUpdater.setFeedURL).toHaveBeenCalled();
+
+      // Squirrel staged and called quitAndInstall, but the process is still
+      // alive — exactly the wedge that left ShipIt waiting forever.
+      loaded.nativeUpdater.emit('update-downloaded');
+      expect(hooks.onInstallQuitAborted).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      // The quit flag is undone, so the app is reachable again...
+      expect(hooks.onInstallQuitAborted).toHaveBeenCalledTimes(1);
+      // ...before the failure is reported, or the error lands on a process the
+      // user cannot bring to the front.
+      const abortedAt = hooks.onInstallQuitAborted.mock.invocationCallOrder[0]!;
+      expect(abortedAt).toBeGreaterThan(hooks.onBeforeInstallQuit.mock.invocationCallOrder[0]!);
+
+      const err = sent.find((m) => m.channel === IPC.UPDATE_ERROR);
+      expect(err).toBeDefined();
+      expect(String(err!.data.message)).toContain('did not restart wmux');
+      expect(String(err!.data.message)).toContain('releases');
+
+      // And the install guard is clear, so pressing the button again works.
+      expect((updater as unknown as { isInstalling: boolean }).isInstalling).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('staging is given minutes, not the handoff deadline', async () => {
+    const { loaded, installHandler, sent, hooks } = await downloadOnDarwin();
+    vi.useFakeTimers();
+    try {
+      const install = installHandler();
+      await vi.advanceTimersByTimeAsync(1_000);
+      await install;
+
+      // A slow disk or an antivirus scan can make Squirrel take this long to
+      // unpack ~120 MB. Aborting here would break healthy updates.
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(sent.filter((m) => m.channel === IPC.UPDATE_ERROR)).toHaveLength(0);
+      expect(hooks.onInstallQuitAborted).not.toHaveBeenCalled();
+
+      // ...but a stage that never finishes is still reported rather than silent.
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+      const err = sent.find((m) => m.channel === IPC.UPDATE_ERROR);
+      expect(String(err?.data.message)).toContain('did not finish preparing');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('the deadline stops once the install fails, so it cannot fire twice', async () => {
+    const { loaded, installHandler, sent } = await downloadOnDarwin();
+    vi.useFakeTimers();
+    try {
+      const install = installHandler();
+      await vi.advanceTimersByTimeAsync(1_000);
+      await install;
+      loaded.nativeUpdater.emit('error', new Error('boom'));
+
+      await vi.advanceTimersByTimeAsync(20 * 60 * 1000);
+
+      expect(sent.filter((m) => m.channel === IPC.UPDATE_ERROR)).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -493,7 +625,7 @@ describe('AutoUpdater — the auto-update toggle gates background polls only', (
         send: (channel: string, data: Record<string, unknown>) => { sent.push({ channel, data }); },
       },
     };
-    const updater = new AutoUpdater(() => win as never);
+    const updater = new AutoUpdater(() => win as never, quitHooks());
     updater.start();
 
     // User turns auto-update OFF before the first scheduled check fires.
@@ -523,7 +655,7 @@ describe('AutoUpdater — the auto-update toggle gates background polls only', (
     vi.useFakeTimers();
     const { AutoUpdater, requestUrls, ipcListeners } = await loadForPlatform('win32');
 
-    const updater = new AutoUpdater(() => null);
+    const updater = new AutoUpdater(() => null, quitHooks());
     updater.start();
     ipcListeners.get(IPC.AUTO_UPDATE_ENABLED)!(null, false);
     await vi.advanceTimersByTimeAsync(15_000);


### PR DESCRIPTION
## The bug

Pressing **Check for updates** on macOS downloaded and SHA-256-verified the new version, then did nothing. No restart, no error, and nothing on any press after that.

`before-quit-for-update` belongs to Electron's `autoUpdater`, not to `app`, but the listener was registered on `app`. The `as unknown as NodeJS.EventEmitter` cast added to "work around the missing type" silenced the compiler error that would have said so, so `isQuitting` was never set.

`quitAndInstall()` closes every window and installs only once the window list empties. The hide-to-tray `close` intercept cancels that close while `isQuitting` is false. So the window list never emptied, the install never ran, and Squirrel's ShipIt helper waited on a process that was never going to exit. `isInstalling` then latched true for the process lifetime, so every later press hit a guard that returned without emitting anything — hence the silence on retry.

Verified on a live 3.38.1 install: ShipIt sat at `Detected this as an install request` for 45+ minutes with the staged 3.38.2 bundle fully unpacked and correctly signed, while the app kept running with its window open.

## The fix

Replace the dead event with two required constructor hooks the updater calls directly, so there is no event name left to get wrong. The prepare hook sets the quit flag, stops the broker, and flushes session state (the normal before-quit teardown is skipped entirely on this path). The abort hook reverses all of it.

The handoff is deadlined in two phases, because they fail differently:

```
setFeedURL -> checkForUpdates --- staging (Squirrel unpacks ~120 MB) --> update-downloaded
     |                                                                          |
     +-- staging deadline (10 min) ------------------------------ (cleared) ----+
                                    onBeforeInstallQuit -> quitAndInstall
                                         +-- handoff deadline (30 s) --> unwind or exit
```

Preparing the quit at the handoff rather than before staging keeps the app out of the closable, broker-stopped state for the whole download, and stops a tight deadline from aborting a healthy but slow update.

Every exit from an attempt detaches the Squirrel listeners. Without that a late `update-downloaded` could call `quitAndInstall()` after the abort had already restored the quit flag, re-creating the same hang.

Also in this change:

- **Restore the broker on abort.** `stop()` latches `stopped` and `start()` refuses to run while it is set, so one aborted install left MCP down for the rest of the session with nothing saying so. Adds `BrokerSupervisor.resume()`.
- **Wire recovery-created windows like the boot window.** Only boot attached the hide-to-tray `close` intercept, so a window from the `activate` or recovery path destroyed itself on close instead of hiding. Extracted to `adoptMainWindow`.
- **Report after the window is back.** The failure is reported once the restored window can receive IPC, not before it has listeners.
- **No more silent refusals.** Both early returns in `performInstall` now emit `UPDATE_ERROR`.
- **Sweep leaked installers.** An interrupted install left a verified ~120 MB artifact in temp; four had accumulated on the machine this was found on.

## Tests

The regression test asserts the prepare hook fires **before** `quitAndInstall`. Asserting that `quitAndInstall` was called is not enough — that assertion passed for the entire life of the bug. Verified by re-introducing the fault: the ordering tests fail, and pass again once restored.

New coverage: handoff stall unwinds and stays retryable; staging is given minutes but a stage that never finishes is still reported; a late Squirrel event after a failed attempt cannot re-trigger the install or double-report.

Full suite: 9585 passed, 0 failed.

## Scope

macOS Apple Silicon only. Windows reaches `app.quit()` and runs the normal `before-quit` pass, so it is unaffected and unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update installation reliability, including recovery when installation is interrupted or fails.
  * Added clearer error feedback when an update restart does not complete.
  * Prevented stale update events from triggering unintended reinstalls.
  * Cleaned up temporary files from interrupted updates.
  * Improved window recovery and hide-to-tray behavior during startup, activation, and updates.
  * Safely paused and restored background services and application sessions during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->