### PR TITLE
폰 계약: PTY resize 라우트, push risk 상시 명시, APNs 스테이지 기기별 라우팅

### DIFF
--- a/changelog.d/743.md
+++ b/changelog.d/743.md
@@ -1,0 +1,8 @@
+### Added
+
+- Phones can reshape a pane they are the only client of. `POST /api/sessions/<id>/resize` reflows the PTY to the phone's viewport, so a 151-column desk pane stops arriving letterboxed or shrunk past reading — the wrapping happens in the PTY, before any client sees a byte, so nothing on the phone could fix it. A desk client that has the pane attached keeps ownership: the route answers `409 desk-owns-size` with the current geometry rather than starting a resize fight the desk's next layout pass would win anyway. Available without `--allow-input`, like the diff route — it delivers a SIGWINCH, not a keystroke. (#743)
+
+### Fixed
+
+- The lock-screen Approve button never appeared on any notification. The iOS extension has nothing but the sealed payload, so it reads an absent `risk` as "unknown" and withholds the affirmative — but the daemon only ever set `risk` on the critical branch, which is right for `/api/approvals` and wrong here. Push payloads now always state `critical` or `normal`. (#743)
+- Two builds of the phone app on one tailnet took turns breaking each other's push. An APNs token does not say which stage minted it and Apple's two hosts reject each other's, so the relay's single `APNS_ENV` was one answer for every device — the symptom was a `BadDeviceToken` that traced back to nothing. The daemon now stores the stage the app reported per device and the relay routes on it, falling back to `APNS_ENV` when a device named none. (#743)

--- a/docs/phone-client-contract.md
+++ b/docs/phone-client-contract.md
@@ -269,10 +269,11 @@ buffer is locally scrollable.
 ```
 POST /api/sessions/<id>/resize   body: {cols, rows}
   → 200 {cols, rows, owner: 'caller'}
-  → 400 {error: 'bad-geometry'}                          not an integer in 1..1000
+  → 400 {error: 'bad-geometry'}          cols 40..1000, rows 8..1000, integers
   → 404 {error: 'session not found'}
   → 409 {error: 'desk-owns-size', cols, rows, owner: 'desk'}
-  → 409 {error: 'resize-failed', detail}                 pane is dead or suspended
+  → 409 {error: 'resize-failed', detail} dead, suspended, or still recovering
+  → 429 {error: 'resize-too-often', cols, rows, retryAfterMs}
 ```
 
 A desk pane is commonly 151×47, and no readable phone font fits 151 columns. The
@@ -290,7 +291,19 @@ Do not treat the 409 as an error to retry. It is the answer: render at the size
 it names, and try again after the pane's `state` goes `detached`.
 
 **Render at the geometry in the 200, not at the one you asked for.** The daemon
-floors cols at 10 and rows at 2 (a zsh SIGBUS guard), so those can differ.
+answers with what it stored, which is not promised to equal the request.
+
+**Debounce, and bound the geometry.** One session accepts a resize at most every
+250 ms; anything sooner is `429` carrying `retryAfterMs` and the pane's current
+size. This is not only about load — every accepted resize arms the daemon's
+redraw guard, and a client resizing in a tight loop can stop new approvals from
+being detected at all. Drive this from settled layout, never from an animation
+frame.
+
+The floor is `cols >= 40`, `rows >= 8` — well above the 10/2 the daemon itself
+tolerates. That lower pair only promises the shell will not crash; a pane driven
+to 10 columns hard-wraps everything it prints, and scrollback does not re-flow,
+so those bytes stay ruined after the desk takes its size back.
 
 The route is additive, so it does **not** move `protocolVersion` (§1). A daemon
 that predates it has no such route and answers 404 for a pane you just listed —

--- a/docs/phone-client-contract.md
+++ b/docs/phone-client-contract.md
@@ -578,9 +578,9 @@ If the extension does not run, the lock screen shows a fixed placeholder
 
 ```
 POST /api/push-registration      (device credential, never the operator token)
-  body: {apnsToken, publicKey}
+  body: {apnsToken, publicKey, apnsEnvironment?: 'development' | 'production'}
   → 200 {ok: true}
-  → 400 {error: 'bad-token' | 'bad-key'}
+  → 400 {error: 'bad-token' | 'bad-key' | 'bad-apns-environment'}
   → 403 {error: 'push-is-for-devices'}
   → 409 {error: 'revoked' | 'not-found' | 'persist-failed'}
   → 503 {error: 'push-unavailable'}
@@ -591,6 +591,23 @@ X25519 public key. Register on every launch — APNs rotates tokens, and a
 registration replaces the previous one wholesale rather than merging, so a
 regenerated key pair never leaves the daemon sealing to a key you no longer
 hold.
+
+`apnsEnvironment` is which APNs stage minted your token — read it from
+`aps-environment` in your own embedded provisioning profile, never inferred from
+a build configuration.
+
+**Omit it, never guess it.** An APNs token does not say which stage it came
+from and Apple's two hosts reject each other's, so the daemon stores this per
+device and routes on it. Absent means "use whatever the relay was configured
+with", which is what happened for every device before this field existed and is
+the right answer for a build that cannot name its own stage (the simulator has
+no profile). A stage sent on a hunch earns a `BadDeviceToken` that traces back to
+nothing. A value that is neither word is a `400`, not a silent drop.
+
+A registration replaces the previous one wholesale, this field included: leaving
+it out on a later call **clears** a stage the daemon knew, rather than inheriting
+it. That is deliberate — the token now on file belongs to the build that just
+called, not to the one before it.
 
 A `410` from Apple makes the daemon forget your registration, so a reinstalled
 app must register again before it hears anything.

--- a/docs/phone-client-contract.md
+++ b/docs/phone-client-contract.md
@@ -264,6 +264,43 @@ app-owned conversation history. Without `--allow-input`, send neither; never
 forward generic taps or drags, guess a mouse protocol, or pretend the alternate
 buffer is locally scrollable.
 
+### Resizing a pane — the desk owns the size whenever it is attached
+
+```
+POST /api/sessions/<id>/resize   body: {cols, rows}
+  → 200 {cols, rows, owner: 'caller'}
+  → 400 {error: 'bad-geometry'}                          not an integer in 1..1000
+  → 404 {error: 'session not found'}
+  → 409 {error: 'desk-owns-size', cols, rows, owner: 'desk'}
+  → 409 {error: 'resize-failed', detail}                 pane is dead or suspended
+```
+
+A desk pane is commonly 151×47, and no readable phone font fits 151 columns. The
+wrapping happens in the PTY, before any client sees a byte, so the daemon is the
+only thing that can fix it.
+
+**Ownership.** There is one PTY behind both views and it can have one geometry.
+While a desk renderer has the pane wired (`state: 'attached'` in
+`/api/sessions`), that geometry is the desk's: the 409 carries the current
+`cols`/`rows` so you can render to them without a second request. A `detached`
+pane takes your numbers. You do not have to hand ownership back — a desk client
+re-derives its geometry from its own bounds and resizes on attach.
+
+Do not treat the 409 as an error to retry. It is the answer: render at the size
+it names, and try again after the pane's `state` goes `detached`.
+
+**Render at the geometry in the 200, not at the one you asked for.** The daemon
+floors cols at 10 and rows at 2 (a zsh SIGBUS guard), so those can differ.
+
+The route is additive, so it does **not** move `protocolVersion` (§1). A daemon
+that predates it has no such route and answers 404 for a pane you just listed —
+which is the probe: treat a 404 for a live id exactly like the 409, render at the
+pane's own `cols`/`rows`, and do not ask again this connection.
+
+Available **without `--allow-input`**, unlike the keyboard and the two lifecycle
+routes below: this delivers a SIGWINCH and changes two numbers. No byte reaches
+the child's stdin and nothing is executed. The Bearer gate still applies.
+
 ### Creating and closing panes
 
 ```

--- a/docs/phone-client-contract.md
+++ b/docs/phone-client-contract.md
@@ -514,10 +514,21 @@ float**; standard base64 **with** padding (not base64url); a 12-byte nonce; and 
 byte-for-byte, case-sensitive `deviceId`.
 
 The decrypted plaintext is additive JSON: `title`, `body`, optional
-`approvalId`, optional `sessionId`, and optional `requiresInAppChoice`. When
-`requiresInAppChoice` is true, the Notification Service Extension must use an
-affirmative-free category: the person has to open the app and pick a structured
-choice. Older payloads omit the field and older extensions ignore it.
+`approvalId`, optional `sessionId`, optional `requiresInAppChoice`, and `risk`.
+When `requiresInAppChoice` is true, the Notification Service Extension must use
+an affirmative-free category: the person has to open the app and pick a
+structured choice. Older payloads omit the field and older extensions ignore it.
+
+`risk` is the **one field whose sealed meaning differs from its REST meaning**.
+On `/api/approvals` it is omitted when no pattern matched (§6, "a hint, not a
+gate"). Here it is always present on an approval — `'critical'` or `'normal'` —
+because the extension has no store to consult and cannot tell a daemon that
+predates the field from one that judged the approval ordinary. It therefore
+withholds the lock-screen Approve button unless a value positively says
+`'normal'`: a missing field costs somebody a trip into the app, a wrong guess
+costs a destructive command approved from a locked pocket. Adding a third level
+is a two-sided change — the extension grants the affirmative to everything that
+is not `'critical'`, so a new level shipped daemon-side alone reads as ordinary.
 
 Reject an envelope older than `PUSH_MAX_AGE_MS` (300 000 ms).
 

--- a/relay/__tests__/index.test.ts
+++ b/relay/__tests__/index.test.ts
@@ -199,6 +199,51 @@ describe('forwarding to APNs', () => {
     expect(calls[0].url).toBe(`https://api.sandbox.push.apple.com/3/device/${TOKEN}`);
   });
 
+  it('★ lets the request pick the host, so two builds on one relay stop colliding', async () => {
+    // The relay-wide APNS_ENV says production; this device registered from a
+    // development build. Without the per-request override its token goes to the
+    // wrong Apple host and comes back BadDeviceToken with nothing to trace.
+    const calls = stubApns([{ status: 200 }, { status: 200 }]);
+    await push(validBody({ apnsEnvironment: 'development' }));
+    expect(calls[0].url).toBe(`https://api.sandbox.push.apple.com/3/device/${TOKEN}`);
+
+    // And the other way: a production token through a sandbox-configured relay.
+    await worker.fetch(
+      new Request('https://relay.example/push', {
+        method: 'POST',
+        body: JSON.stringify(validBody({ apnsEnvironment: 'production' })),
+        headers: { authorization: `Bearer ${SHARED_SECRET}` },
+      }),
+      { ...env, APNS_ENV: 'sandbox' },
+    );
+    expect(calls[1].url).toBe(`https://api.push.apple.com/3/device/${TOKEN}`);
+  });
+
+  it('falls back to APNS_ENV when the request names no stage', async () => {
+    // What every daemon that predates the field sends, and what a build with no
+    // provisioning profile (the simulator) sends. Guessing here would route a
+    // token to the wrong host.
+    const calls = stubApns([{ status: 200 }]);
+    await worker.fetch(
+      new Request('https://relay.example/push', {
+        method: 'POST',
+        body: JSON.stringify(validBody()),
+        headers: { authorization: `Bearer ${SHARED_SECRET}` },
+      }),
+      { ...env, APNS_ENV: 'sandbox' },
+    );
+    expect(calls[0].url).toBe(`https://api.sandbox.push.apple.com/3/device/${TOKEN}`);
+  });
+
+  it('refuses a stage that is not one of Apple two words', async () => {
+    const calls = stubApns([{ status: 200 }]);
+    const res = await push(validBody({ apnsEnvironment: 'https://evil.example' }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).reason).toBe('bad-apns-environment');
+    // Refused before a JWT is signed or Apple is called at all.
+    expect(calls).toHaveLength(0);
+  });
+
   it('passes priority and collapseId through as headers', async () => {
     const calls = stubApns([{ status: 200 }]);
     await push(validBody({ priority: 5, collapseId: 'ap_42' }));

--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -61,6 +61,19 @@ export interface RelayEnv {
 const APNS_HOST_PRODUCTION = 'https://api.push.apple.com';
 const APNS_HOST_SANDBOX = 'https://api.sandbox.push.apple.com';
 
+/**
+ * Which Apple host to send to. Two compiled-in constants and nothing else — the
+ * request selects between them, it never supplies one.
+ *
+ * `development` is Apple's word in `aps-environment`, `sandbox` is Apple's word
+ * for the host, and they name the same stage. Both are accepted so neither the
+ * app's vocabulary nor the deployment's has to be translated at the call site.
+ */
+export function apnsHost(perRequest: string | undefined, configured: string | undefined): string {
+  const stage = perRequest ?? configured;
+  return stage === 'development' || stage === 'sandbox' ? APNS_HOST_SANDBOX : APNS_HOST_PRODUCTION;
+}
+
 /** Give up on Apple rather than hold a daemon's socket open indefinitely. */
 const APNS_TIMEOUT_MS = 10_000;
 
@@ -218,10 +231,29 @@ function extractApnsReason(bodyText: string): string | undefined {
 async function forwardToApns(
   env: RelayEnv,
   token: string,
-  request: { apnsDeviceToken: string; ciphertext: string; priority: number; collapseId?: string },
+  request: {
+    apnsDeviceToken: string;
+    ciphertext: string;
+    priority: number;
+    collapseId?: string;
+    apnsEnvironment?: 'development' | 'production';
+  },
   nowMs: number,
 ): Promise<{ status: number; reason?: string; apnsId?: string }> {
-  const host = env.APNS_ENV === 'sandbox' ? APNS_HOST_SANDBOX : APNS_HOST_PRODUCTION;
+  // PER REQUEST FIRST, `APNS_ENV` as the fallback.
+  //
+  // An APNs token does not say which stage minted it, and the two hosts reject
+  // each other's. `APNS_ENV` is one answer for the whole deployment, so a
+  // TestFlight build and a cable-installed build pushing through the same relay
+  // took turns silently breaking each other — the symptom is a `BadDeviceToken`
+  // that traces back to nothing. The daemon knows which stage each device
+  // registered from (the app reads `aps-environment` out of its own
+  // provisioning profile), so it says, per device.
+  //
+  // Absent still means "whatever this relay was configured with": a daemon that
+  // predates the field, or a build that cannot name its own stage (the
+  // simulator has no profile), must not have a stage guessed for it.
+  const host = apnsHost(request.apnsEnvironment, env.APNS_ENV);
   const headers: Record<string, string> = {
     authorization: `bearer ${token}`,
     'apns-topic': env.APNS_TOPIC,

--- a/relay/src/validate.ts
+++ b/relay/src/validate.ts
@@ -31,12 +31,28 @@ const COLLAPSE_ID_PATTERN = /^[A-Za-z0-9_.:-]{1,64}$/;
 export const ALLOWED_PRIORITIES = [5, 10] as const;
 export type PushPriority = (typeof ALLOWED_PRIORITIES)[number];
 
+/**
+ * The two APNs stages. A token minted by one is rejected by the other, and the
+ * token itself does not say which — so the daemon has to, per device.
+ */
+export const ALLOWED_APNS_ENVIRONMENTS = ['development', 'production'] as const;
+export type ApnsEnvironment = (typeof ALLOWED_APNS_ENVIRONMENTS)[number];
+
 export interface PushRequest {
   apnsDeviceToken: string;
   /** Opaque. Never decoded by the relay. */
   ciphertext: string;
   priority: PushPriority;
   collapseId?: string;
+  /**
+   * Which Apple host this token belongs to. Absent means "use whatever this
+   * relay was configured with" (`APNS_ENV`), which is what every daemon that
+   * predates the field says and what the deployment did for all of them.
+   *
+   * An ALLOWLIST OF TWO LITERALS, never a host or a URL. The value picks
+   * between two compiled-in constants; nothing a caller sends reaches `fetch`.
+   */
+  apnsEnvironment?: ApnsEnvironment;
 }
 
 export type ValidationFailure = {
@@ -103,7 +119,18 @@ export function validatePushRequest(body: unknown): ValidationResult {
     collapseId = raw.collapseId;
   }
 
-  return { ok: true, value: { apnsDeviceToken: token, ciphertext, priority, collapseId } };
+  let apnsEnvironment: ApnsEnvironment | undefined;
+  if (raw.apnsEnvironment !== undefined) {
+    if (!ALLOWED_APNS_ENVIRONMENTS.includes(raw.apnsEnvironment as ApnsEnvironment)) {
+      return fail(400, 'bad-apns-environment');
+    }
+    apnsEnvironment = raw.apnsEnvironment as ApnsEnvironment;
+  }
+
+  return {
+    ok: true,
+    value: { apnsDeviceToken: token, ciphertext, priority, collapseId, apnsEnvironment },
+  };
 }
 
 /**

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -65,6 +65,7 @@ import type { ResumeBinding } from '../shared/agentResume';
 import { agentDisplayToSlug } from '../main/pty/AgentDetector';
 import { HookIngest, type HookArbitration } from './hooks/HookIngest';
 import { PushSender } from './push/PushSender';
+import { approvalPushCollapseId, buildApprovalPushPayload } from './push/approvalPushPayload';
 import { ApprovalRegistry } from './approvals/ApprovalRegistry';
 import { DeviceStore } from './web/DeviceStore';
 import { revokeDeviceAndDisconnect } from './web/deviceRevoke';
@@ -4453,18 +4454,7 @@ async function main(): Promise<void> {
     // the thing the notification was asking for, already handled.
     if (event.type !== 'create') return;
     const r = event.request;
-    pushSender.notify(
-      {
-        title: 'Approval needed',
-        body: r.question ?? 'A pane is waiting on an answer.',
-        approvalId: r.id,
-        sessionId: r.sessionId,
-        ...(r.choices?.length ? { requiresInAppChoice: true } : {}),
-      },
-      // One pending request per pane, so a re-prompt should replace the old
-      // banner rather than stack under it.
-      { collapseId: `ap-${r.sessionId}`.slice(0, 64) },
-    );
+    pushSender.notify(buildApprovalPushPayload(r), { collapseId: approvalPushCollapseId(r) });
   });
   const pipeServer = new DaemonPipeServer(config.daemon.pipeName);
   // Channels (a2a-channels U3). Channels live in their own file

--- a/src/daemon/push/PushSender.ts
+++ b/src/daemon/push/PushSender.ts
@@ -23,7 +23,16 @@ import {
 export interface PushTarget {
   deviceId: string;
   name: string;
-  push: { apnsToken: string; publicKey: string };
+  push: {
+    apnsToken: string;
+    publicKey: string;
+    /**
+     * Which Apple host this token belongs to, as the device reported at
+     * registration. Forwarded verbatim; absent stays absent, and the relay then
+     * uses whatever it was configured with. See `DevicePushRegistration`.
+     */
+    apnsEnvironment?: 'development' | 'production';
+  };
 }
 
 export interface PushSenderDeps {
@@ -201,6 +210,13 @@ export class PushSender {
         ciphertext: blob,
         priority: PRIORITY_IMMEDIATE,
         ...(item.collapseId ? { collapseId: item.collapseId } : {}),
+        // Per device, so two builds of this app on one tailnet stop routing
+        // each other's tokens to the wrong Apple host. Omitted when the device
+        // could not name its own stage — the relay must not have one guessed
+        // for it here either.
+        ...(target.push.apnsEnvironment
+          ? { apnsEnvironment: target.push.apnsEnvironment }
+          : {}),
       });
 
       if (status === 200) {

--- a/src/daemon/push/__tests__/PushSender.test.ts
+++ b/src/daemon/push/__tests__/PushSender.test.ts
@@ -104,6 +104,25 @@ describe('PushSender — enablement', () => {
 });
 
 describe('PushSender — sealing', () => {
+  it('★ forwards the device APNs stage, and omits it when the device named none', async () => {
+    // The relay picks the Apple host from this. Two builds of the app on one
+    // tailnet used to take turns breaking each other's push because the relay
+    // had one answer for the whole deployment.
+    const d = device('d1');
+    const staged = {
+      ...d.target,
+      push: { ...d.target.push, apnsEnvironment: 'development' as const },
+    };
+    const h = makeSender([200, 200], [staged, device('d2').target]);
+    h.sender.notify({ title: 't', body: 'b' });
+    await h.sender.flush();
+
+    const bodies = h.calls.map((c) => JSON.parse(String(c.init.body)) as Record<string, unknown>);
+    expect(bodies[0].apnsEnvironment).toBe('development');
+    // Absent stays absent — the relay must not have a stage guessed for it here.
+    expect(bodies[1]).not.toHaveProperty('apnsEnvironment');
+  });
+
   it('★ what leaves is opaque: the relay sees no title or body', async () => {
     const d = device('d1');
     const h = makeSender([200], [d.target]);

--- a/src/daemon/push/__tests__/approvalPushPayload.test.ts
+++ b/src/daemon/push/__tests__/approvalPushPayload.test.ts
@@ -31,6 +31,39 @@ describe('buildApprovalPushPayload', () => {
     expect(buildApprovalPushPayload(request({ risk: 'critical' })).risk).toBe('critical');
   });
 
+  it('★ the softer tier is critical HERE, even though the record says nothing', () => {
+    // `ApprovalRequest.risk` is only ever set by `hasCriticalRisk`, which
+    // ignores the `review` tier — so the record for a `DELETE FROM` carries no
+    // risk at all. Copying that through would stamp `normal`, and `normal` is
+    // not a description: the extension reads it as "one tap on a locked screen
+    // is enough". A second look is exactly what a lock screen cannot give.
+    for (const question of ['DELETE FROM users WHERE 1=1?', 'run kubectl delete pod api-7?']) {
+      const payload = buildApprovalPushPayload(request({ question }));
+      expect(payload.risk, question).toBe('critical');
+    }
+  });
+
+  it('★ scans option and choice labels, not only the question', () => {
+    // The question can be blandly worded while the thing being agreed to sits
+    // in a label.
+    expect(
+      buildApprovalPushPayload(request({ question: 'Proceed?', options: ['rm -rf ./build'] })).risk,
+    ).toBe('critical');
+    expect(
+      buildApprovalPushPayload(
+        request({ question: 'Proceed?', choices: [{ key: '1', label: 'terraform destroy' }] }),
+      ).risk,
+    ).toBe('critical');
+  });
+
+  it('an ordinary question is still ordinary — the gate must not swallow everything', () => {
+    // A rule that answered `critical` to everything would be the same bug in
+    // the other direction: the button would never appear and the whole change
+    // would be pointless.
+    expect(buildApprovalPushPayload(request({ question: 'Write the file to src/a.ts?' })).risk)
+      .toBe(PUSH_RISK_NORMAL);
+  });
+
   it('quotes the question, and falls back when there is none', () => {
     expect(buildApprovalPushPayload(request({ question: 'Deploy to prod?' })).body).toBe(
       'Deploy to prod?',

--- a/src/daemon/push/__tests__/approvalPushPayload.test.ts
+++ b/src/daemon/push/__tests__/approvalPushPayload.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  APPROVAL_PUSH_FALLBACK_BODY,
+  approvalPushCollapseId,
+  buildApprovalPushPayload,
+} from '../approvalPushPayload';
+import { PUSH_RISK_NORMAL } from '../../../shared/push/pushEnvelope';
+import type { ApprovalRequest } from '../../approvals/types';
+
+function request(overrides: Partial<ApprovalRequest> = {}): ApprovalRequest {
+  return {
+    id: 'ap-1',
+    sessionId: 'sess-1',
+    agent: 'claude',
+    kind: 'awaiting_input',
+    createdAt: 1753420800000,
+    state: 'pending',
+    ...overrides,
+  };
+}
+
+describe('buildApprovalPushPayload', () => {
+  it('states risk even when nothing matched', () => {
+    // The whole point: the extension withholds the lock-screen affirmative on
+    // an absent risk, so an ordinary approval has to SAY it is ordinary.
+    expect(buildApprovalPushPayload(request()).risk).toBe(PUSH_RISK_NORMAL);
+  });
+
+  it('carries a critical risk verbatim', () => {
+    expect(buildApprovalPushPayload(request({ risk: 'critical' })).risk).toBe('critical');
+  });
+
+  it('quotes the question, and falls back when there is none', () => {
+    expect(buildApprovalPushPayload(request({ question: 'Deploy to prod?' })).body).toBe(
+      'Deploy to prod?',
+    );
+    expect(buildApprovalPushPayload(request()).body).toBe(APPROVAL_PUSH_FALLBACK_BODY);
+  });
+
+  it('flags structured choices, and omits the flag otherwise', () => {
+    const withChoices = buildApprovalPushPayload(
+      request({ choices: [{ key: '1', label: 'Yes' }] }),
+    );
+    expect(withChoices.requiresInAppChoice).toBe(true);
+    expect(buildApprovalPushPayload(request()).requiresInAppChoice).toBeUndefined();
+  });
+
+  it('carries the ids the deep link is built from', () => {
+    const payload = buildApprovalPushPayload(request());
+    expect(payload.approvalId).toBe('ap-1');
+    expect(payload.sessionId).toBe('sess-1');
+    expect(payload.title).toBe('Approval needed');
+  });
+});
+
+describe('approvalPushCollapseId', () => {
+  it('collapses per pane', () => {
+    expect(approvalPushCollapseId(request())).toBe('ap-sess-1');
+    expect(approvalPushCollapseId(request({ id: 'ap-2' }))).toBe('ap-sess-1');
+  });
+
+  it('stays inside the APNs collapse-id limit', () => {
+    const id = approvalPushCollapseId(request({ sessionId: 's'.repeat(200) }));
+    expect(id.length).toBe(64);
+  });
+});

--- a/src/daemon/push/approvalPushPayload.ts
+++ b/src/daemon/push/approvalPushPayload.ts
@@ -10,7 +10,8 @@
  * version of it shipped a `risk` that was only ever set on the critical branch
  * — which switched the button off for every approval on earth.
  */
-import { PUSH_RISK_NORMAL, type PushPayload } from '../../shared/push/pushEnvelope';
+import { hasElevatedRisk } from '../../shared/criticalPatterns';
+import { PUSH_RISK_CRITICAL, PUSH_RISK_NORMAL, type PushPayload } from '../../shared/push/pushEnvelope';
 import type { ApprovalRequest } from '../approvals/types';
 
 /** Shown when the agent gave us no question text to quote. */
@@ -29,8 +30,35 @@ export function buildApprovalPushPayload(request: ApprovalRequest): PushPayload 
     // ALWAYS stated, unlike the REST field. See `PushPayload.risk`: the
     // extension has nothing but this payload, so silence there means unknown
     // and costs the button.
-    risk: request.risk ?? PUSH_RISK_NORMAL,
+    //
+    // RE-DERIVED, NOT COPIED FROM `request.risk`. The record's field answers
+    // "is this the dangerous class?" and only `critical` patterns set it, so
+    // copying it here would stamp `normal` on a `DELETE FROM users` — and
+    // `normal` is not a description, it is a grant: the extension reads
+    // anything that is not `critical` as "one tap on the lock screen is
+    // enough". Before this payload carried a risk at all the field was absent
+    // and the button was withheld, so a careless copy would turn a
+    // fail-CLOSED into a fail-OPEN for the softer tier. `hasElevatedRisk`
+    // counts both tiers for exactly this decision.
+    risk: elevatedRisk(request) ? PUSH_RISK_CRITICAL : PUSH_RISK_NORMAL,
   };
+}
+
+/**
+ * Does anything the agent wrote name a destructive action, at either tier?
+ *
+ * `choices` labels are scanned too. Today a request that has them also sets
+ * `requiresInAppChoice`, which withholds the affirmative on its own — but that
+ * is two independent reasons agreeing, not one covering the other, and the day
+ * the choice rule changes this must not quietly become the gap.
+ */
+function elevatedRisk(request: ApprovalRequest): boolean {
+  if (request.risk === 'critical') return true;
+  return hasElevatedRisk(
+    request.question,
+    ...(request.options ?? []),
+    ...(request.choices ?? []).map((c) => c.label),
+  );
 }
 
 /** One pending request per pane, so a re-prompt replaces its own banner. */

--- a/src/daemon/push/approvalPushPayload.ts
+++ b/src/daemon/push/approvalPushPayload.ts
@@ -1,0 +1,39 @@
+/**
+ * The one place an approval turns into the plaintext the phone's Notification
+ * Service Extension reads.
+ *
+ * It lives here rather than inline at the `onEvent` subscription in
+ * `daemon/index.ts` because the rules it encodes are not obvious from either
+ * end: the extension decides whether a lock-screen Approve button exists from
+ * these fields alone, and it reads an ABSENT field as "I cannot tell", not as
+ * "ordinary". Inline in a boot function that mapping had no test, and the first
+ * version of it shipped a `risk` that was only ever set on the critical branch
+ * — which switched the button off for every approval on earth.
+ */
+import { PUSH_RISK_NORMAL, type PushPayload } from '../../shared/push/pushEnvelope';
+import type { ApprovalRequest } from '../approvals/types';
+
+/** Shown when the agent gave us no question text to quote. */
+export const APPROVAL_PUSH_FALLBACK_BODY = 'A pane is waiting on an answer.';
+
+export function buildApprovalPushPayload(request: ApprovalRequest): PushPayload {
+  return {
+    title: 'Approval needed',
+    body: request.question ?? APPROVAL_PUSH_FALLBACK_BODY,
+    approvalId: request.id,
+    sessionId: request.sessionId,
+    // A structured-choice question cannot be answered by a single affirmative,
+    // so the extension must drop to a category that only deep-links into the
+    // app.
+    ...(request.choices?.length ? { requiresInAppChoice: true } : {}),
+    // ALWAYS stated, unlike the REST field. See `PushPayload.risk`: the
+    // extension has nothing but this payload, so silence there means unknown
+    // and costs the button.
+    risk: request.risk ?? PUSH_RISK_NORMAL,
+  };
+}
+
+/** One pending request per pane, so a re-prompt replaces its own banner. */
+export function approvalPushCollapseId(request: ApprovalRequest): string {
+  return `ap-${request.sessionId}`.slice(0, 64);
+}

--- a/src/daemon/web/DeviceStore.ts
+++ b/src/daemon/web/DeviceStore.ts
@@ -490,7 +490,7 @@ export class DeviceStore {
    */
   registerPush(
     deviceId: string,
-    input: { apnsToken: string; publicKey: string; apnsEnvironment?: string },
+    input: { apnsToken: string; publicKey: string; apnsEnvironment?: unknown },
   ): {
     ok: boolean;
     reason?: 'not-found' | 'revoked' | 'bad-token' | 'bad-key' | 'bad-apns-environment' | 'persist-failed';
@@ -948,7 +948,20 @@ function coercePush(raw: unknown): DevicePushRegistration | null {
     typeof o['registeredAt'] === 'number' && Number.isFinite(o['registeredAt'])
       ? o['registeredAt']
       : 0;
-  return { apnsToken, publicKey, registeredAt };
+  // Restored, not re-derived. `persist` writes this field, so a loader that
+  // dropped it would lose every device's stage on the first daemon restart and
+  // silently put the whole roster back on the relay's single `APNS_ENV` — the
+  // exact BadDeviceToken this field exists to prevent, reappearing at a moment
+  // nobody connects to a registration.
+  //
+  // Anything that is not one of Apple's two words is IGNORED rather than
+  // rejected: a hand-edited or half-written record must degrade to "stage
+  // unknown" (which the relay already handles) instead of taking the whole
+  // registration down with it, and `registerPush` is where a live client is
+  // told its value was wrong.
+  const rawEnv = o['apnsEnvironment'];
+  const apnsEnvironment = rawEnv === 'development' || rawEnv === 'production' ? rawEnv : undefined;
+  return { apnsToken, publicKey, registeredAt, ...(apnsEnvironment ? { apnsEnvironment } : {}) };
 }
 
 function coerceKdf(raw: unknown): DeviceKdfParams | null {

--- a/src/daemon/web/DeviceStore.ts
+++ b/src/daemon/web/DeviceStore.ts
@@ -204,6 +204,24 @@ export interface DevicePushRegistration {
   publicKey: string;
   /** When the device last told us these. */
   registeredAt: number;
+  /**
+   * Which APNs stage minted `apnsToken`, as the app read it out of its own
+   * embedded provisioning profile's `aps-environment`.
+   *
+   * PER DEVICE, because the alternative does not work. A token does not say
+   * which stage it came from and the two Apple hosts reject each other's, so a
+   * relay configured with one answer for the whole deployment means a
+   * TestFlight build and a cable-installed build on the same tailnet take turns
+   * silently breaking each other's push — the symptom is a `BadDeviceToken`
+   * that traces back to nothing.
+   *
+   * ABSENT IS NOT A DEFAULT TO FILL IN. It means the build could not name its
+   * own stage (the simulator has no profile) or predates the field, and a stage
+   * sent on a hunch routes the token to the wrong host. Absent is carried
+   * through as absent, and the relay then uses whatever it was configured with,
+   * which is exactly what happened before this field existed.
+   */
+  apnsEnvironment?: 'development' | 'production';
 }
 
 interface DeviceRecord {
@@ -472,8 +490,11 @@ export class DeviceStore {
    */
   registerPush(
     deviceId: string,
-    input: { apnsToken: string; publicKey: string },
-  ): { ok: boolean; reason?: 'not-found' | 'revoked' | 'bad-token' | 'bad-key' | 'persist-failed' } {
+    input: { apnsToken: string; publicKey: string; apnsEnvironment?: string },
+  ): {
+    ok: boolean;
+    reason?: 'not-found' | 'revoked' | 'bad-token' | 'bad-key' | 'bad-apns-environment' | 'persist-failed';
+  } {
     const record = this.devices.get(deviceId);
     if (!record) return { ok: false, reason: 'not-found' };
     if (record.revokedAt !== undefined) return { ok: false, reason: 'revoked' };
@@ -484,8 +505,26 @@ export class DeviceStore {
     const publicKey = typeof input?.publicKey === 'string' ? input.publicKey.trim() : '';
     if (!isBase64Bytes(publicKey, PUSH_PUBLIC_KEY_BYTES)) return { ok: false, reason: 'bad-key' };
 
+    // Rejected rather than dropped when it is neither of Apple's two words: a
+    // silently ignored stage is a token routed to the wrong host, and the app
+    // omits the field entirely when it cannot name its own stage — so anything
+    // present and unrecognised is a client bug worth saying out loud.
+    const rawEnv = input?.apnsEnvironment;
+    if (rawEnv !== undefined && rawEnv !== 'development' && rawEnv !== 'production') {
+      return { ok: false, reason: 'bad-apns-environment' };
+    }
+
     const previous = record.push;
-    record.push = { apnsToken, publicKey, registeredAt: this.now() };
+    record.push = {
+      apnsToken,
+      publicKey,
+      registeredAt: this.now(),
+      // A re-registration replaces the record wholesale, so an omitted stage
+      // clears a previously known one rather than inheriting it. That is the
+      // honest reading: the build now talking to us is the one whose token this
+      // is, and it did not name a stage.
+      ...(rawEnv ? { apnsEnvironment: rawEnv } : {}),
+    };
     if (!this.persist()) {
       // Roll back rather than push to a token that a restart forgets: the app
       // would believe it is registered and silently receive nothing.

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -227,7 +227,7 @@ export interface WebDeviceResolver {
    */
   registerPush?(
     deviceId: string,
-    input: { apnsToken: string; publicKey: string; apnsEnvironment?: string },
+    input: { apnsToken: string; publicKey: string; apnsEnvironment?: unknown },
   ): { ok: boolean; reason?: string };
 }
 
@@ -493,12 +493,39 @@ const inFlightDiffs = new Map<string, Promise<SessionDiffResult>>();
  */
 const MAX_REQUESTED_GEOMETRY = 1000;
 
-/** One side of a requested PTY geometry: an integer in `1..MAX_REQUESTED_GEOMETRY`. */
-function isGeometryValue(value: unknown): value is number {
+/**
+ * Narrowest geometry this ROUTE will forward — deliberately far above the
+ * session manager's own floor (10 cols, 2 rows).
+ *
+ * That floor is a crash guard: below ~7 columns an interactive zsh dies inside
+ * `zle.so`. It is not a claim that 10 columns is a usable terminal. A pane
+ * driven to 10 columns hard-wraps everything it prints, and those bytes are in
+ * the ring buffer for good — scrollback does not re-flow, so "the next desk
+ * attach fixes it" is true of future output and false of the transcript.
+ *
+ * A phone in the narrowest orientation still asks for far more than this, so
+ * the bound costs no real client anything.
+ */
+const MIN_REQUESTED_COLS = 40;
+const MIN_REQUESTED_ROWS = 8;
+
+/**
+ * Least time between two accepted resizes of ONE session.
+ *
+ * Sized to be invisible to a real client — the phone debounces its own layout
+ * passes at 250 ms — and to put a ceiling on what a hostile one can do.
+ */
+const MIN_RESIZE_INTERVAL_MS = 250;
+
+/** Sessions tracked for rate limiting before the map is swept against the roster. */
+const RESIZE_TRACKING_CAP = 256;
+
+/** One side of a requested PTY geometry. */
+function isGeometryValue(value: unknown, min: number): value is number {
   return (
     typeof value === 'number' &&
     Number.isInteger(value) &&
-    value >= 1 &&
+    value >= min &&
     value <= MAX_REQUESTED_GEOMETRY
   );
 }
@@ -698,6 +725,16 @@ export class WebTerminalServer {
 
   /** Lazily-built git runner for `/api/sessions/:id/diff` (see that handler). */
   private git: GitRunner | null = null;
+
+  /**
+   * When each session was last resized through `/api/sessions/:id/resize`.
+   *
+   * Per server rather than module-level, unlike the diff concurrency counter:
+   * that one bounds `git` (a machine-wide resource), this one bounds SIGWINCH
+   * to sessions this server can see, and a test that starts two servers must
+   * not have one inherit the other's history.
+   */
+  private lastResizeAt = new Map<string, number>();
 
   /**
    * Upload bodies currently buffering in memory. Bounded by
@@ -1527,10 +1564,15 @@ export class WebTerminalServer {
 
     this.readJsonBody(req, res, (body) => {
       const b = (body ?? {}) as { cols?: unknown; rows?: unknown };
-      if (!isGeometryValue(b.cols) || !isGeometryValue(b.rows)) {
+      if (
+        !isGeometryValue(b.cols, MIN_REQUESTED_COLS) ||
+        !isGeometryValue(b.rows, MIN_REQUESTED_ROWS)
+      ) {
         return this.json(res, 400, {
           error: 'bad-geometry',
-          detail: `cols and rows must be integers in 1..${MAX_REQUESTED_GEOMETRY}`,
+          detail:
+            `cols must be an integer in ${MIN_REQUESTED_COLS}..${MAX_REQUESTED_GEOMETRY}, ` +
+            `rows in ${MIN_REQUESTED_ROWS}..${MAX_REQUESTED_GEOMETRY}`,
         });
       }
 
@@ -1547,24 +1589,77 @@ export class WebTerminalServer {
           owner: 'desk',
         });
       }
+      // A session recovered from a reboot and not yet resized is MUTED, and
+      // `resizeSession` treats its first resize as the signal to unmute and
+      // start capturing. That is the desk's handshake, not ours: capture
+      // started here would begin at the phone's geometry, and the pre-resize
+      // output the mute exists to hold back would land in the ring buffer
+      // interleaved with output painted for a different width — permanently,
+      // because scrollback is not re-flowable. The route's claim that it only
+      // changes two numbers is only true once that handshake has happened.
+      if (current.deferred) {
+        return this.json(res, 409, {
+          error: 'resize-failed',
+          detail: 'the pane is still recovering and has not been attached yet',
+        });
+      }
+
+      // Frequency bound, per session. Without it a paired device can alternate
+      // two geometries as fast as it can post: every accepted resize delivers a
+      // SIGWINCH, makes a full-screen TUI reallocate and repaint, AND stamps
+      // `bridge.noteResize()`. That last one is the one that bites — the
+      // redraw guard it arms suppresses AgentDetector's emission dedup reset,
+      // so a device that keeps the guard permanently armed can stop new
+      // `awaiting_input` prompts from ever being detected. A rate limit here is
+      // not only about CPU; it is what keeps approvals from going silent.
+      const now = this.now();
+      const last = this.lastResizeAt.get(id);
+      if (last !== undefined && now - last < MIN_RESIZE_INTERVAL_MS) {
+        return this.json(res, 429, {
+          error: 'resize-too-often',
+          cols: current.meta.cols,
+          rows: current.meta.rows,
+          retryAfterMs: MIN_RESIZE_INTERVAL_MS - (now - last),
+        });
+      }
+      this.lastResizeAt.set(id, now);
+      // The map is keyed by a session id that outlives nothing else here, so it
+      // is swept against the live roster rather than left to grow with every
+      // pane the daemon has ever had.
+      if (this.lastResizeAt.size > RESIZE_TRACKING_CAP) this.sweepResizeTracking();
 
       try {
         this.deps.sessionManager.resizeSession(id, b.cols, b.rows);
       } catch (err) {
         // `dead` and `suspended` both throw here. Neither is a bug on the
-        // caller's side — the pane list it decided from is a poll old.
+        // caller's side — the pane list it decided from is a poll old. The
+        // daemon's own wording goes to the LOG, never onto the wire: it names
+        // session ids and can carry an errno or a path, and the caller's only
+        // useful action ("not this pane, not now") does not depend on which.
         this.deps.log('warn', `[web] resize failed for ${id}: ${errMsg(err)}`);
-        return this.json(res, 409, { error: 'resize-failed', detail: errMsg(err) });
+        return this.json(res, 409, {
+          error: 'resize-failed',
+          detail: 'the pane is not in a state that can be resized',
+        });
       }
 
       // The APPLIED geometry, read back from the daemon's own record: the
-      // manager floors cols at MIN_SAFE_COLS (a zsh SIGBUS guard), so what was
-      // asked for and what the PTY now is are not always the same number, and
-      // a client that rendered to its request would wrap at the wrong width.
+      // manager floors cols and rows, so what was asked for and what the PTY
+      // now is are not always the same number, and a client that rendered to
+      // its request would wrap at the wrong width.
       const after = this.deps.sessionManager.getSession(id);
+      if (!after) {
+        // The pane died between the resize and this read. Answering 200 with
+        // the REQUESTED geometry would be the one thing the paragraph above
+        // forbids — reporting a width no PTY ever had.
+        return this.json(res, 409, {
+          error: 'resize-failed',
+          detail: 'the pane is not in a state that can be resized',
+        });
+      }
       return this.json(res, 200, {
-        cols: after?.meta.cols ?? b.cols,
-        rows: after?.meta.rows ?? b.rows,
+        cols: after.meta.cols,
+        rows: after.meta.rows,
         owner: 'caller',
       });
     });
@@ -1992,17 +2087,25 @@ export class WebTerminalServer {
       };
       const apnsToken = typeof b.apnsToken === 'string' ? b.apnsToken : '';
       const publicKey = typeof b.publicKey === 'string' ? b.publicKey : '';
-      // Passed through unvalidated on purpose — the store owns the allowlist,
-      // so there is one place that decides what a stage may be. Absent stays
-      // absent: a build that cannot name its own stage must not have one
-      // guessed for it here.
-      const apnsEnvironment = typeof b.apnsEnvironment === 'string' ? b.apnsEnvironment : undefined;
+      // PRESENCE, not type. The store owns the allowlist so there is one place
+      // that decides what a stage may be — but only a field that is genuinely
+      // ABSENT may reach it as absent. Coercing a present-but-wrong value
+      // (`null`, a number, an object) to `undefined` here would answer 200 and,
+      // because a registration replaces the record wholesale, delete a stage
+      // the daemon already knew — routing that device's push to the host that
+      // rejects it, in response to a request the contract promises to refuse.
+      // Handed over RAW, never coerced. `String(['production'])` is
+      // `'production'` — a one-element array would sail through a stringifying
+      // guard and be stored as a stage the client never sent. The store
+      // strict-compares against the two literals, so anything else (an array, a
+      // number, `null`, an object) fails there and comes back 400.
+      const hasStage = 'apnsEnvironment' in b;
       let result: { ok: boolean; reason?: string };
       try {
         result = devices.registerPush!(principal.deviceId, {
           apnsToken,
           publicKey,
-          ...(apnsEnvironment !== undefined ? { apnsEnvironment } : {}),
+          ...(hasStage ? { apnsEnvironment: b.apnsEnvironment } : {}),
         });
       } catch (err) {
         this.deps.log('warn', `[web] push registration threw: ${errMsg(err)}`);
@@ -2350,6 +2453,21 @@ export class WebTerminalServer {
 
   private now(): number {
     return this.deps.now ? this.deps.now() : Date.now();
+  }
+
+  /**
+   * Drop rate-limit entries for sessions that no longer exist.
+   *
+   * Called only when the map outgrows its cap, so the common case costs
+   * nothing. Forgetting a live session's entry would be harmless anyway — it
+   * grants one extra resize — which is why this can be lazy rather than wired
+   * into session teardown.
+   */
+  private sweepResizeTracking(): void {
+    const live = new Set(this.deps.sessionManager.listLiveSessions().map((s) => s.id));
+    for (const id of this.lastResizeAt.keys()) {
+      if (!live.has(id)) this.lastResizeAt.delete(id);
+    }
   }
 
   /** The exact JSON one attention event carries on the wire, live or replayed. */

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -227,7 +227,7 @@ export interface WebDeviceResolver {
    */
   registerPush?(
     deviceId: string,
-    input: { apnsToken: string; publicKey: string },
+    input: { apnsToken: string; publicKey: string; apnsEnvironment?: string },
   ): { ok: boolean; reason?: string };
 }
 
@@ -1985,12 +1985,25 @@ export class WebTerminalServer {
       return this.json(res, 503, { error: 'push-unavailable' });
     }
     this.readJsonBody(req, res, (body) => {
-      const b = (body ?? {}) as { apnsToken?: unknown; publicKey?: unknown };
+      const b = (body ?? {}) as {
+        apnsToken?: unknown;
+        publicKey?: unknown;
+        apnsEnvironment?: unknown;
+      };
       const apnsToken = typeof b.apnsToken === 'string' ? b.apnsToken : '';
       const publicKey = typeof b.publicKey === 'string' ? b.publicKey : '';
+      // Passed through unvalidated on purpose — the store owns the allowlist,
+      // so there is one place that decides what a stage may be. Absent stays
+      // absent: a build that cannot name its own stage must not have one
+      // guessed for it here.
+      const apnsEnvironment = typeof b.apnsEnvironment === 'string' ? b.apnsEnvironment : undefined;
       let result: { ok: boolean; reason?: string };
       try {
-        result = devices.registerPush!(principal.deviceId, { apnsToken, publicKey });
+        result = devices.registerPush!(principal.deviceId, {
+          apnsToken,
+          publicKey,
+          ...(apnsEnvironment !== undefined ? { apnsEnvironment } : {}),
+        });
       } catch (err) {
         this.deps.log('warn', `[web] push registration threw: ${errMsg(err)}`);
         return this.json(res, 500, { error: 'push-registration-failed' });
@@ -1999,7 +2012,12 @@ export class WebTerminalServer {
       // `bad-token` / `bad-key` are the caller's fault; the rest are ours or the
       // operator's, and a device that was revoked mid-flight should hear that
       // rather than a generic 400.
-      const status = result.reason === 'bad-token' || result.reason === 'bad-key' ? 400 : 409;
+      const status =
+        result.reason === 'bad-token' ||
+        result.reason === 'bad-key' ||
+        result.reason === 'bad-apns-environment'
+          ? 400
+          : 409;
       return this.json(res, status, { error: result.reason ?? 'push-registration-failed' });
     });
   }

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -520,6 +520,26 @@ const MIN_RESIZE_INTERVAL_MS = 250;
 /** Sessions tracked for rate limiting before the map is swept against the roster. */
 const RESIZE_TRACKING_CAP = 256;
 
+/**
+ * Did the caller mention this field at all — as opposed to sending a value the
+ * route will go on to reject?
+ *
+ * The presence question needs its own helper because `in` is the only way to
+ * ask it and `in` THROWS on a primitive. `readJsonBody` hands through whatever
+ * `JSON.parse` returned, and `123` is valid JSON: a body of exactly `123`
+ * reaches a handler as a number, `(body ?? {})` leaves it a number because it
+ * is neither null nor undefined, and `'x' in 123` is a `TypeError` raised
+ * inside the `req.on('end')` callback — where nothing catches it. That is a
+ * one-line request from any paired device that takes the daemon down, so the
+ * guard belongs here rather than at each call site that might forget it.
+ *
+ * Arrays are excluded too: `'0' in ['production']` is true, and an array is
+ * never the object shape any of these routes documents.
+ */
+function statesField(body: unknown, field: string): boolean {
+  return typeof body === 'object' && body !== null && !Array.isArray(body) && field in body;
+}
+
 /** One side of a requested PTY geometry. */
 function isGeometryValue(value: unknown, min: number): value is number {
   return (
@@ -2099,7 +2119,7 @@ export class WebTerminalServer {
       // guard and be stored as a stage the client never sent. The store
       // strict-compares against the two literals, so anything else (an array, a
       // number, `null`, an object) fails there and comes back 400.
-      const hasStage = 'apnsEnvironment' in b;
+      const hasStage = statesField(body, 'apnsEnvironment');
       let result: { ok: boolean; reason?: string };
       try {
         result = devices.registerPush!(principal.deviceId, {

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -481,6 +481,28 @@ let activeDiffs = 0;
  */
 const inFlightDiffs = new Map<string, Promise<SessionDiffResult>>();
 
+/**
+ * Widest geometry `POST /api/sessions/:id/resize` will forward to a PTY.
+ *
+ * The session manager floors cols and rows (a zsh SIGBUS guard) but caps
+ * neither — it never needed to, because its only caller was a renderer
+ * measuring its own pane. A number off the network is different: a PTY is
+ * asked to allocate for the geometry it is given, so an unbounded `rows` is a
+ * memory-allocation request written as two integers. 1000 is far above any real
+ * display and far below anything that costs the daemon.
+ */
+const MAX_REQUESTED_GEOMETRY = 1000;
+
+/** One side of a requested PTY geometry: an integer in `1..MAX_REQUESTED_GEOMETRY`. */
+function isGeometryValue(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= 1 &&
+    value <= MAX_REQUESTED_GEOMETRY
+  );
+}
+
 interface SseClient {
   res: http.ServerResponse;
   sessionId: string;
@@ -1277,6 +1299,9 @@ export class WebTerminalServer {
       if (req.method === 'GET' && rest.endsWith('/diff')) {
         return this.handleSessionDiff(res, rest.slice(0, -'/diff'.length));
       }
+      if (req.method === 'POST' && rest.endsWith('/resize')) {
+        return this.handleSessionResize(req, res, rest.slice(0, -'/resize'.length));
+      }
       if (req.method === 'DELETE') {
         return this.handleSessionDelete(res, rest);
       }
@@ -1451,6 +1476,98 @@ export class WebTerminalServer {
     // patch under today's prompt is the exact failure this route exists to
     // prevent.
     return this.json(res, 200, result.diff, { 'Cache-Control': 'no-store' });
+  }
+
+  // --- pane geometry -------------------------------------------------------
+
+  /**
+   * `POST /api/sessions/:id/resize` — body `{cols, rows}`, answer
+   * `{cols, rows, owner}`.
+   *
+   * WHY THE ROUTE EXISTS. A desk pane is commonly 151×47. A phone rendering
+   * that faithfully has two choices, and both are bad: shrink the font until 151
+   * columns fit (unreadable) or letterbox (a third of the screen wasted, and the
+   * agent's output still wrapped for a screen nobody is looking at). The daemon
+   * is the only thing that can fix it, because the wrapping happens in the PTY,
+   * before any client sees a byte.
+   *
+   * WHO OWNS THE SIZE, when a desk and a phone watch the same PTY. The desk
+   * does, whenever it is attached. There is exactly one PTY behind both views
+   * and one geometry it can have, so this is a choice between breaking the
+   * phone's layout and breaking the layout of a window somebody is looking at
+   * on a 27" display — and the desk client re-derives its geometry from its own
+   * pane bounds on every layout pass, so "let the last writer win" is not a
+   * policy but a fight: the phone resizes, the desk's next frame resizes back,
+   * and the PTY thrashes between two geometries while both views redraw.
+   *
+   * So: `attached` (a desk renderer has this pane wired) → `409 desk-owns-size`,
+   * carrying the current geometry so the caller can render to it without a
+   * second request. `detached` → the phone's numbers are applied. A pane that
+   * the desk later attaches resizes itself on mount, so ownership returns
+   * without anything here having to take it back.
+   *
+   * NOT GATED ON `--allow-input`, on the same reasoning as
+   * `GET /api/sessions/:id/diff` and `POST /api/approvals/:id`: this delivers a
+   * SIGWINCH and changes two numbers on a struct. No byte reaches the child's
+   * stdin, nothing is executed, and a caller who could resize but not type has
+   * gained nothing it could not already do by reading the pane. The Bearer gate
+   * still applies, so this is not a new reader either. The worst a hostile
+   * paired device achieves is an awkward geometry on a pane nobody is attached
+   * to, which the next desk attach corrects.
+   */
+  private handleSessionResize(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    rawId: string,
+  ): void {
+    const id = decodePathSegment(rawId);
+    if (id === null) return this.json(res, 404, { error: 'session not found' });
+    const managed = this.deps.sessionManager.getSession(id);
+    if (!managed) return this.json(res, 404, { error: 'session not found' });
+
+    this.readJsonBody(req, res, (body) => {
+      const b = (body ?? {}) as { cols?: unknown; rows?: unknown };
+      if (!isGeometryValue(b.cols) || !isGeometryValue(b.rows)) {
+        return this.json(res, 400, {
+          error: 'bad-geometry',
+          detail: `cols and rows must be integers in 1..${MAX_REQUESTED_GEOMETRY}`,
+        });
+      }
+
+      // Re-read rather than trusting the lookup above: the body arrives over
+      // however many TCP segments it takes, and a pane can die or be attached
+      // by the desk in between.
+      const current = this.deps.sessionManager.getSession(id);
+      if (!current) return this.json(res, 404, { error: 'session not found' });
+      if (current.meta.state === 'attached') {
+        return this.json(res, 409, {
+          error: 'desk-owns-size',
+          cols: current.meta.cols,
+          rows: current.meta.rows,
+          owner: 'desk',
+        });
+      }
+
+      try {
+        this.deps.sessionManager.resizeSession(id, b.cols, b.rows);
+      } catch (err) {
+        // `dead` and `suspended` both throw here. Neither is a bug on the
+        // caller's side — the pane list it decided from is a poll old.
+        this.deps.log('warn', `[web] resize failed for ${id}: ${errMsg(err)}`);
+        return this.json(res, 409, { error: 'resize-failed', detail: errMsg(err) });
+      }
+
+      // The APPLIED geometry, read back from the daemon's own record: the
+      // manager floors cols at MIN_SAFE_COLS (a zsh SIGBUS guard), so what was
+      // asked for and what the PTY now is are not always the same number, and
+      // a client that rendered to its request would wrap at the wrong width.
+      const after = this.deps.sessionManager.getSession(id);
+      return this.json(res, 200, {
+        cols: after?.meta.cols ?? b.cols,
+        rows: after?.meta.rows ?? b.rows,
+        owner: 'caller',
+      });
+    });
   }
 
   // --- pane lifecycle (opt-in) ---------------------------------------------

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -1976,6 +1976,39 @@ describe('WebTerminalServer', () => {
     }
   });
 
+  it('★ survives a JSON body that is a scalar, on every route that reads one', async () => {
+    // `123` is valid JSON. It reaches a handler as a NUMBER, `(body ?? {})`
+    // leaves it one, and `'field' in 123` is a TypeError thrown inside
+    // `req.on('end')` — where nothing catches it. That is one line of request
+    // body from any paired device taking the daemon down with it.
+    const info = await startRW();
+    const { token } = await pairDevice('Phone');
+    const scalars = ['123', '"production"', 'true', 'null', '[]'];
+    const routes: Array<[string, string]> = [
+      ['POST', '/api/push-registration'],
+      ['POST', '/api/sessions/s1/resize'],
+      ['POST', '/api/sessions'],
+      ['POST', `/api/approvals/${'ap-scalar'}`],
+    ];
+    approvalRecords.push(mkApproval({ id: 'ap-scalar' }));
+
+    for (const [method, path] of routes) {
+      for (const body of scalars) {
+        const res = await fetch(`${base()}${path}`, {
+          method,
+          headers: { ...bearer(token), 'Content-Type': 'application/json' },
+          body,
+        });
+        // Any answer is fine — 400, 404, 409. What must NOT happen is the
+        // socket dying because the handler threw.
+        expect(res.status, `${method} ${path} ← ${body}`).toBeLessThan(500);
+      }
+    }
+    // Still serving after all of that.
+    expect((await fetch(`${base()}/api/config`, { headers: bearer(token) })).status).toBe(200);
+    expect(info.running).toBe(true);
+  });
+
   it('rejects a malformed token or key with 400', async () => {
     await startRO();
     const { token } = await pairDevice('Phone');

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -70,6 +70,10 @@ function makeDeps() {
       cmd: '/usr/bin/bash -l',
     },
   ];
+  // Every geometry the resize route forwarded, and the escape hatch for a
+  // manager that refuses (a pane that died between the lookup and the body).
+  const resizeCalls: Array<{ id: string; cols: number; rows: number }> = [];
+  const resizeBox = { throws: '' };
   // The real DaemonSessionManager is an EventEmitter; the server tees its
   // session:critical / session:notification events, so the fake must emit too.
   const sessionManager = Object.assign(new EventEmitter(), {
@@ -79,10 +83,35 @@ function makeDeps() {
       if (id === 's1') return managed;
       const row = live.find((l) => l.id === id);
       return row
-        ? { ...managed, meta: { ...managed.meta, id, cwd: '/tmp/osc7-said-so', spawnCwd: row.cwd } }
+        ? {
+            ...managed,
+            // `state` is carried through because the resize route reads it —
+            // s2 is the attached pane the desk owns.
+            meta: {
+              ...managed.meta,
+              id,
+              state: row.state,
+              cols: row.cols,
+              rows: row.rows,
+              cwd: '/tmp/osc7-said-so',
+              spawnCwd: row.cwd,
+            },
+          }
         : undefined;
     },
     listLiveSessions: () => live,
+    resizeSession: (id: string, cols: number, rows: number) => {
+      resizeCalls.push({ id, cols, rows });
+      if (resizeBox.throws) throw new Error(resizeBox.throws);
+      // Mirrors the real manager's floor (MIN_SAFE_COLS / MIN_SAFE_ROWS) so a
+      // route that echoed the REQUEST rather than the applied geometry fails
+      // here rather than in the field.
+      const target = id === 's1' ? managed.meta : live.find((l) => l.id === id);
+      if (target) {
+        target.cols = Math.max(10, cols);
+        target.rows = Math.max(2, rows);
+      }
+    },
   }) as unknown as DaemonSessionManager;
   // Lifecycle stand-in for the daemon's own daemon.createSession /
   // daemon.destroySession handlers (src/daemon/index.ts). The real ones spawn a
@@ -144,6 +173,7 @@ function makeDeps() {
 
   return {
     sessionManager, bridge, write, live, managed,
+    resizeCalls, resizeBox,
     lifecycle, lifecycleCalls, lifecycleBox,
     git, gitCalls, gitScript, gitGate, uploadsDir,
     ...makeApprovals(), ...makeDevices(),
@@ -284,6 +314,8 @@ describe('WebTerminalServer', () => {
   let pushRegistrations: Array<{ deviceId: string; apnsToken: string; publicKey: string }>;
   let deviceTouchCalls: string[];
   let deviceBox: { mintThrows: boolean };
+  let resizeCalls: Array<{ id: string; cols: number; rows: number }>;
+  let resizeBox: { throws: string };
   let lifecycleCalls: Array<{ op: 'create' | 'destroy'; arg: unknown }>;
   let lifecycleBox: { createThrows: string; destroyThrows: string; createGoesMissing: boolean };
   let gitCalls: Array<{ args: readonly string[]; cwd: string }>;
@@ -308,6 +340,8 @@ describe('WebTerminalServer', () => {
     pushRegistrations = deps.pushRegistrations;
     deviceTouchCalls = deps.deviceTouchCalls;
     deviceBox = deps.deviceBox;
+    resizeCalls = deps.resizeCalls;
+    resizeBox = deps.resizeBox;
     lifecycleCalls = deps.lifecycleCalls;
     lifecycleBox = deps.lifecycleBox;
     gitCalls = deps.gitCalls;
@@ -2454,6 +2488,90 @@ describe('WebTerminalServer', () => {
     expect(server.disconnectDevice(device.deviceId)).toBe(0);
     pane.ac.abort();
   });
+  // ── pane geometry ─────────────────────────────────────────────────────────
+
+  const postResize = (id: string, cred: string, body: unknown) =>
+    fetch(`${base()}/api/sessions/${encodeURIComponent(id)}/resize`, {
+      method: 'POST',
+      headers: { ...bearer(cred), 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+  it('★ resizes a detached pane, and answers with the geometry that was APPLIED', async () => {
+    const token = (await startRO()).token as string;
+
+    const res = await postResize('s1', token, { cols: 60, rows: 30 });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ cols: 60, rows: 30, owner: 'caller' });
+    expect(resizeCalls).toEqual([{ id: 's1', cols: 60, rows: 30 }]);
+    // Note the server: startRO. A SIGWINCH is not a keystroke, and gating this
+    // on --allow-input would leave the phone letterboxed on every daemon that
+    // has not opted into arbitrary execution.
+  });
+
+  it('★ refuses while the desk is attached, and says what to render at instead', async () => {
+    const token = (await startRO()).token as string;
+    // s2 is the attached pane. One PTY cannot be two geometries, and the desk
+    // re-derives its own on every layout pass — applying the phone's numbers
+    // here starts a fight, not a resize.
+    const res = await postResize('s2', token, { cols: 60, rows: 30 });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: 'desk-owns-size',
+      cols: 80,
+      rows: 24,
+      owner: 'desk',
+    });
+    expect(resizeCalls).toEqual([]);
+  });
+
+  it('reports the floor the manager applied, not the numbers that were asked for', async () => {
+    const token = (await startRO()).token as string;
+    // MIN_SAFE_COLS is a zsh SIGBUS guard, so a narrow request is silently
+    // widened. A client that rendered to its own request would wrap wrong.
+    const res = await postResize('s1', token, { cols: 4, rows: 1 });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ cols: 10, rows: 2, owner: 'caller' });
+  });
+
+  it('rejects a geometry that is not an integer in range', async () => {
+    const token = (await startRO()).token as string;
+    for (const body of [
+      { cols: 0, rows: 30 },
+      { cols: 60, rows: 0 },
+      { cols: 60.5, rows: 30 },
+      { cols: 1001, rows: 30 },
+      { cols: 60, rows: 1001 },
+      { cols: '60', rows: 30 },
+      { rows: 30 },
+      {},
+    ]) {
+      const res = await postResize('s1', token, body);
+      expect(res.status, JSON.stringify(body)).toBe(400);
+      expect((await res.json()).error).toBe('bad-geometry');
+    }
+    // An unbounded `rows` is a memory-allocation request written as an integer,
+    // so nothing out of range may reach the PTY.
+    expect(resizeCalls).toEqual([]);
+  });
+
+  it('404s an unknown pane and 409s one the manager refuses', async () => {
+    const token = (await startRO()).token as string;
+    expect((await postResize('nope', token, { cols: 60, rows: 30 })).status).toBe(404);
+
+    resizeBox.throws = "Session 's1' is dead";
+    const res = await postResize('s1', token, { cols: 60, rows: 30 });
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toBe('resize-failed');
+  });
+
+  it('gates the resize route on the Bearer token, and a paired phone may call it', async () => {
+    await startRO();
+    expect((await postResize('s1', 'nonsense', { cols: 60, rows: 30 })).status).toBe(401);
+    const { token } = await pairDevice('Phone');
+    expect((await postResize('s1', token, { cols: 60, rows: 30 })).status).toBe(200);
+  });
+
   // ── pane diff (read-only git) ──────────────────────────────────────────────
 
   const getDiff = (id: string, cred: string) =>

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -228,6 +228,15 @@ function makeDevices() {
       if (rec.revoked) return { ok: false, reason: 'revoked' };
       if (!/^[0-9a-f]{64,200}$/.test(input.apnsToken)) return { ok: false, reason: 'bad-token' };
       if (Buffer.from(input.publicKey, 'base64').length !== 32) return { ok: false, reason: 'bad-key' };
+      // The real store owns this allowlist; the fake mirrors it so the route's
+      // 400 mapping is exercised rather than assumed.
+      if (
+        input.apnsEnvironment !== undefined &&
+        input.apnsEnvironment !== 'development' &&
+        input.apnsEnvironment !== 'production'
+      ) {
+        return { ok: false, reason: 'bad-apns-environment' };
+      }
       return { ok: true };
     },
   };
@@ -1919,6 +1928,35 @@ describe('WebTerminalServer', () => {
     const asOperator = await post(info.token as string, { apnsToken, publicKey });
     expect(asOperator.status).toBe(403);
     expect((await asOperator.json()).error).toBe('push-is-for-devices');
+  });
+
+  it('★ carries the APNs stage the build named, and omits it when it named none', async () => {
+    await startRO();
+    const { token } = await pairDevice('Phone');
+    const apnsToken = 'a'.repeat(64);
+    const publicKey = Buffer.alloc(32, 3).toString('base64');
+    const post = (body: unknown) =>
+      fetch(`${base()}/api/push-registration`, {
+        method: 'POST',
+        headers: { ...bearer(token), 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+    expect((await post({ apnsToken, publicKey, apnsEnvironment: 'development' })).status).toBe(200);
+    expect(pushRegistrations.at(-1)).toEqual({
+      deviceId: 'dev-1', apnsToken, publicKey, apnsEnvironment: 'development',
+    });
+
+    // ABSENT STAYS ABSENT. The simulator has no provisioning profile to read a
+    // stage out of, and a stage guessed here routes the token to the host that
+    // rejects it — a BadDeviceToken that traces back to nothing.
+    expect((await post({ apnsToken, publicKey })).status).toBe(200);
+    expect(pushRegistrations.at(-1)).toEqual({ deviceId: 'dev-1', apnsToken, publicKey });
+
+    // Present but not one of Apple's two words is a client bug, said out loud.
+    const bad = await post({ apnsToken, publicKey, apnsEnvironment: 'staging' });
+    expect(bad.status).toBe(400);
+    expect((await bad.json()).error).toBe('bad-apns-environment');
   });
 
   it('rejects a malformed token or key with 400', async () => {

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -32,6 +32,9 @@ function makeDeps() {
     // where the daemon actually spawned it. Every diff assertion below expects
     // '/x', which is the whole point.
     meta: { id: 's1', cols: 80, rows: 24, state: 'detached', cwd: '/tmp/osc7-said-so', spawnCwd: '/x' },
+    // A session recovered from a reboot that has not had its first resize yet.
+    // The resize route refuses it — that first resize is the desk's unmute.
+    deferred: false,
     ringBuffer: { readAll: () => Buffer.from('screen-bytes') },
     bridge,
     ptyProcess: { write },
@@ -73,13 +76,20 @@ function makeDeps() {
   // Every geometry the resize route forwarded, and the escape hatch for a
   // manager that refuses (a pane that died between the lookup and the body).
   const resizeCalls: Array<{ id: string; cols: number; rows: number }> = [];
-  const resizeBox = { throws: '' };
+  const resizeBox: {
+    throws: string;
+    /** Store something other than the request, to prove the route reads back. */
+    applyAs: { cols: number; rows: number } | null;
+    /** The pane dies between the resize and the read-back. */
+    vanishAfter: boolean;
+  } = { throws: '', applyAs: null, vanishAfter: false };
   // The real DaemonSessionManager is an EventEmitter; the server tees its
   // session:critical / session:notification events, so the fake must emit too.
   const sessionManager = Object.assign(new EventEmitter(), {
     // Every live pane is gettable, each with its own spawn cwd, so the
     // concurrency bound can be exercised across more than one session.
     getSession: (id: string) => {
+      if (resizeBox.vanishAfter && resizeCalls.length > 0) return undefined;
       if (id === 's1') return managed;
       const row = live.find((l) => l.id === id);
       return row
@@ -103,13 +113,14 @@ function makeDeps() {
     resizeSession: (id: string, cols: number, rows: number) => {
       resizeCalls.push({ id, cols, rows });
       if (resizeBox.throws) throw new Error(resizeBox.throws);
-      // Mirrors the real manager's floor (MIN_SAFE_COLS / MIN_SAFE_ROWS) so a
-      // route that echoed the REQUEST rather than the applied geometry fails
-      // here rather than in the field.
+      // The manager may store something other than what was asked for (it
+      // floors both axes), so a route that echoed the REQUEST rather than the
+      // applied geometry has to fail here rather than in the field.
+      const applied = resizeBox.applyAs ?? { cols: Math.max(10, cols), rows: Math.max(2, rows) };
       const target = id === 's1' ? managed.meta : live.find((l) => l.id === id);
       if (target) {
-        target.cols = Math.max(10, cols);
-        target.rows = Math.max(2, rows);
+        target.cols = applied.cols;
+        target.rows = applied.rows;
       }
     },
   }) as unknown as DaemonSessionManager;
@@ -324,13 +335,13 @@ describe('WebTerminalServer', () => {
   let deviceTouchCalls: string[];
   let deviceBox: { mintThrows: boolean };
   let resizeCalls: Array<{ id: string; cols: number; rows: number }>;
-  let resizeBox: { throws: string };
+  let resizeBox: ReturnType<typeof makeDeps>['resizeBox'];
   let lifecycleCalls: Array<{ op: 'create' | 'destroy'; arg: unknown }>;
   let lifecycleBox: { createThrows: string; destroyThrows: string; createGoesMissing: boolean };
   let gitCalls: Array<{ args: readonly string[]; cwd: string }>;
   let gitScript: Record<string, { ok: boolean; stdout: string; stderr: string; ran?: boolean }>;
   let gitGate: { hold: Promise<void> | null };
-  let managed: { meta: Record<string, unknown> };
+  let managed: { meta: Record<string, unknown>; deferred: boolean };
   let live: ReturnType<typeof makeDeps>['live'];
   let uploadsDir: string;
 
@@ -1954,9 +1965,15 @@ describe('WebTerminalServer', () => {
     expect(pushRegistrations.at(-1)).toEqual({ deviceId: 'dev-1', apnsToken, publicKey });
 
     // Present but not one of Apple's two words is a client bug, said out loud.
-    const bad = await post({ apnsToken, publicKey, apnsEnvironment: 'staging' });
-    expect(bad.status).toBe(400);
-    expect((await bad.json()).error).toBe('bad-apns-environment');
+    for (const apnsEnvironment of ['staging', null, 42, { env: 'production' }, ['production']]) {
+      const bad = await post({ apnsToken, publicKey, apnsEnvironment });
+      // ★ A non-STRING must not be coerced to absent. Silently doing that
+      // answers 200 while the wholesale replace deletes a stage the daemon
+      // already knew — routing that device to the host that rejects it, in
+      // answer to a request the contract promises to refuse.
+      expect(bad.status, JSON.stringify(apnsEnvironment)).toBe(400);
+      expect((await bad.json()).error).toBe('bad-apns-environment');
+    }
   });
 
   it('rejects a malformed token or key with 400', async () => {
@@ -2563,20 +2580,35 @@ describe('WebTerminalServer', () => {
     expect(resizeCalls).toEqual([]);
   });
 
-  it('reports the floor the manager applied, not the numbers that were asked for', async () => {
+  it('★ reports the record, never the request', async () => {
     const token = (await startRO()).token as string;
-    // MIN_SAFE_COLS is a zsh SIGBUS guard, so a narrow request is silently
-    // widened. A client that rendered to its own request would wrap wrong.
-    const res = await postResize('s1', token, { cols: 4, rows: 1 });
+    // The manager is free to store something other than what was asked for.
+    // A route that echoed the request would report a width no PTY ever had.
+    resizeBox.applyAs = { cols: 72, rows: 28 };
+    const res = await postResize('s1', token, { cols: 65, rows: 50 });
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ cols: 10, rows: 2, owner: 'caller' });
+    expect(await res.json()).toEqual({ cols: 72, rows: 28, owner: 'caller' });
   });
 
-  it('rejects a geometry that is not an integer in range', async () => {
+  it('★ a pane that vanishes mid-resize is a 409, not a 200 with the request echoed', async () => {
+    const token = (await startRO()).token as string;
+    resizeBox.vanishAfter = true;
+    const res = await postResize('s1', token, { cols: 65, rows: 50 });
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toBe('resize-failed');
+  });
+
+  it('★ refuses a geometry no human would use, well above the crash floor', async () => {
     const token = (await startRO()).token as string;
     for (const body of [
+      // 10 cols does not crash zsh — that is all the manager's floor promises.
+      // It DOES hard-wrap everything the pane prints, and scrollback does not
+      // re-flow, so those bytes are ruined for good. The route's own floor is
+      // about what a terminal is for, not about what survives.
+      { cols: 10, rows: 30 },
+      { cols: 39, rows: 30 },
+      { cols: 60, rows: 7 },
       { cols: 0, rows: 30 },
-      { cols: 60, rows: 0 },
       { cols: 60.5, rows: 30 },
       { cols: 1001, rows: 30 },
       { cols: 60, rows: 1001 },
@@ -2588,19 +2620,70 @@ describe('WebTerminalServer', () => {
       expect(res.status, JSON.stringify(body)).toBe(400);
       expect((await res.json()).error).toBe('bad-geometry');
     }
-    // An unbounded `rows` is a memory-allocation request written as an integer,
-    // so nothing out of range may reach the PTY.
     expect(resizeCalls).toEqual([]);
   });
 
-  it('404s an unknown pane and 409s one the manager refuses', async () => {
+  it('★ bounds how often ONE session can be resized', async () => {
+    // Not only about CPU. Every accepted resize stamps the bridge's redraw
+    // guard, and a device that keeps that guard permanently armed stops
+    // AgentDetector from ever emitting a new prompt — approvals go silent.
+    let clock = 1_000_000;
+    const limited = new WebTerminalServer({
+      sessionManager, log: () => { /* silent */ }, assetsDir: os.tmpdir(), now: () => clock,
+    });
+    const info = await limited.start({ port: 0, host: '127.0.0.1', allowInput: false, allowUpload: false });
+    const at = `http://127.0.0.1:${info.port}/api/sessions/s1/resize`;
+    const send = (cols: number) =>
+      fetch(at, {
+        method: 'POST',
+        headers: { ...bearer(info.token as string), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cols, rows: 30 }),
+      });
+    try {
+      expect((await send(60)).status).toBe(200);
+
+      const tooSoon = await send(61);
+      expect(tooSoon.status).toBe(429);
+      const body = await tooSoon.json();
+      expect(body.error).toBe('resize-too-often');
+      // Carries somewhere to render meanwhile, and when to try again.
+      expect(body.retryAfterMs).toBeGreaterThan(0);
+      expect(body.cols).toBeGreaterThan(0);
+      expect(resizeCalls).toHaveLength(1);
+
+      clock += 250;
+      expect((await send(62)).status).toBe(200);
+      expect(resizeCalls).toHaveLength(2);
+    } finally {
+      await limited.stop();
+    }
+  });
+
+  it('★ refuses a pane that is still recovering', async () => {
+    // The first resize of a deferred session is the desk's unmute handshake.
+    // Taking it here starts capture at the phone's geometry and interleaves
+    // pre-resize output into scrollback, which cannot be re-flowed later.
+    const token = (await startRO()).token as string;
+    managed.deferred = true;
+    const res = await postResize('s1', token, { cols: 65, rows: 50 });
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toBe('resize-failed');
+    expect(resizeCalls).toEqual([]);
+  });
+
+  it('404s an unknown pane and 409s one the manager refuses, without echoing its wording', async () => {
     const token = (await startRO()).token as string;
     expect((await postResize('nope', token, { cols: 60, rows: 30 })).status).toBe(404);
 
-    resizeBox.throws = "Session 's1' is dead";
+    resizeBox.throws = "Session 's1' is dead: /Users/someone/secret/path";
     const res = await postResize('s1', token, { cols: 60, rows: 30 });
     expect(res.status).toBe(409);
-    expect((await res.json()).error).toBe('resize-failed');
+    const body = await res.json();
+    expect(body.error).toBe('resize-failed');
+    // The daemon's own message names session ids and paths. It belongs in the
+    // log, not on a wire a paired device reads.
+    expect(JSON.stringify(body)).not.toContain('secret');
+    expect(JSON.stringify(body)).not.toContain('s1');
   });
 
   it('gates the resize route on the Bearer token, and a paired phone may call it', async () => {

--- a/src/daemon/web/__tests__/deviceStore.runtime.test.ts
+++ b/src/daemon/web/__tests__/deviceStore.runtime.test.ts
@@ -695,3 +695,46 @@ describe('DeviceStore — push registration', () => {
     expect(s.pushTargets()).toEqual([]);
   });
 });
+
+describe('DeviceStore — APNs stage, per device', () => {
+  const APNS_TOKEN = 'a'.repeat(64);
+  const PUBLIC_KEY = Buffer.alloc(32, 7).toString('base64');
+
+  it('★ stores the stage and hands it to the sender', async () => {
+    const s = store();
+    const minted = await s.mint({ name: 'TestFlight phone' });
+    expect(
+      s.registerPush(minted.deviceId, {
+        apnsToken: APNS_TOKEN,
+        publicKey: PUBLIC_KEY,
+        apnsEnvironment: 'production',
+      }),
+    ).toEqual({ ok: true });
+    expect(s.pushTargets()[0]?.push.apnsEnvironment).toBe('production');
+  });
+
+  it('★ a re-registration that names no stage clears the old one', async () => {
+    // A registration replaces the record wholesale. Inheriting the previous
+    // stage would keep routing a NEW token — minted by whichever build is
+    // talking to us now — to the host the OLD build belonged to.
+    const s = store();
+    const minted = await s.mint({ name: 'Phone' });
+    s.registerPush(minted.deviceId, {
+      apnsToken: APNS_TOKEN, publicKey: PUBLIC_KEY, apnsEnvironment: 'development',
+    });
+    s.registerPush(minted.deviceId, { apnsToken: APNS_TOKEN, publicKey: PUBLIC_KEY });
+    expect(s.pushTargets()[0]?.push.apnsEnvironment).toBeUndefined();
+  });
+
+  it('refuses a stage that is neither of Apple two words', async () => {
+    const s = store();
+    const minted = await s.mint({ name: 'Phone' });
+    expect(
+      s.registerPush(minted.deviceId, {
+        apnsToken: APNS_TOKEN, publicKey: PUBLIC_KEY, apnsEnvironment: 'sandbox',
+      }),
+    ).toEqual({ ok: false, reason: 'bad-apns-environment' });
+    // Nothing was written: a rejected registration must not half-land.
+    expect(s.pushTargets()).toEqual([]);
+  });
+});

--- a/src/daemon/web/__tests__/deviceStore.runtime.test.ts
+++ b/src/daemon/web/__tests__/deviceStore.runtime.test.ts
@@ -726,6 +726,39 @@ describe('DeviceStore — APNs stage, per device', () => {
     expect(s.pushTargets()[0]?.push.apnsEnvironment).toBeUndefined();
   });
 
+  it('★ survives a daemon restart', async () => {
+    // The bug this exists for: `persist` wrote the stage and the LOADER threw
+    // it away, so one restart put the whole roster back on the relay's single
+    // APNS_ENV — reintroducing the BadDeviceToken silently, at a moment nobody
+    // connects to a registration.
+    const first = store();
+    const minted = await first.mint({ name: 'Phone' });
+    first.registerPush(minted.deviceId, {
+      apnsToken: APNS_TOKEN, publicKey: PUBLIC_KEY, apnsEnvironment: 'development',
+    });
+
+    const reloaded = store();
+    expect(reloaded.pushTargets()[0]?.push.apnsEnvironment).toBe('development');
+  });
+
+  it('a junk stage on disk degrades to unknown rather than dropping the registration', async () => {
+    const s = store();
+    const minted = await s.mint({ name: 'Phone' });
+    s.registerPush(minted.deviceId, { apnsToken: APNS_TOKEN, publicKey: PUBLIC_KEY });
+    // Hand-edit the roster the way a bad merge or a half-written file would.
+    const statePath = getDeviceStatePath(dir);
+    const raw = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    raw.devices[0].push.apnsEnvironment = 'staging';
+    fs.writeFileSync(statePath, JSON.stringify(raw));
+
+    const reloaded = store();
+    const target = reloaded.pushTargets()[0];
+    // The device is still pushable — losing the whole registration over one
+    // bad field would be a worse failure than falling back to the relay's env.
+    expect(target?.push.apnsToken).toBe(APNS_TOKEN);
+    expect(target?.push.apnsEnvironment).toBeUndefined();
+  });
+
   it('refuses a stage that is neither of Apple two words', async () => {
     const s = store();
     const minted = await s.mint({ name: 'Phone' });

--- a/src/shared/__tests__/criticalPatterns.test.ts
+++ b/src/shared/__tests__/criticalPatterns.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { CRITICAL_PATTERNS, hasCriticalRisk } from '../criticalPatterns';
+import { CRITICAL_PATTERNS, hasCriticalRisk, hasElevatedRisk } from '../criticalPatterns';
 
 describe('hasCriticalRisk', () => {
   it('matches the destructive actions the PTY scanner already knows', () => {
@@ -28,5 +28,28 @@ describe('hasCriticalRisk', () => {
     expect(CRITICAL_PATTERNS.every((p) => !p.regex.global)).toBe(true);
     expect(hasCriticalRisk('npm publish')).toBe(true);
     expect(hasCriticalRisk('npm publish')).toBe(true);
+  });
+});
+
+describe('hasElevatedRisk — the lock-screen question', () => {
+  it('counts the review tier, which hasCriticalRisk deliberately does not', () => {
+    for (const text of ['DELETE FROM users', 'kubectl delete pod api-7']) {
+      expect(hasCriticalRisk(text)).toBe(false);
+      expect(hasElevatedRisk(text)).toBe(true);
+    }
+  });
+
+  it('still counts the critical tier', () => {
+    expect(hasElevatedRisk('rm -rf ./build')).toBe(true);
+    expect(hasElevatedRisk('terraform destroy')).toBe(true);
+  });
+
+  it('says no to ordinary text, and to nothing at all', () => {
+    expect(hasElevatedRisk('write src/a.ts')).toBe(false);
+    expect(hasElevatedRisk(undefined, null, '')).toBe(false);
+  });
+
+  it('scans every argument, not only the first', () => {
+    expect(hasElevatedRisk('Proceed?', 'yes', 'DROP TABLE users')).toBe(true);
   });
 });

--- a/src/shared/criticalPatterns.ts
+++ b/src/shared/criticalPatterns.ts
@@ -53,3 +53,31 @@ export function hasCriticalRisk(...texts: (string | undefined | null)[]): boolea
   }
   return false;
 }
+
+/**
+ * Whether any piece of the supplied text names an action at EITHER tier.
+ *
+ * The counterpart to `hasCriticalRisk`, for the one caller whose question is
+ * not "is this the dangerous class?" but "may this be approved with one tap on
+ * a locked screen?".
+ *
+ * Those are different questions and the softer tier answers them differently.
+ * `DELETE FROM` and `kubectl delete` are `review` precisely because they are
+ * destructive-but-recoverable — worth a second look, not worth a red banner. A
+ * second look is exactly what a locked phone cannot give: there is no screen to
+ * read, no Face ID, and no undo behind the button. So for that decision the
+ * softer tier belongs on the same side as the harder one.
+ *
+ * See `buildApprovalPushPayload`, the only caller. Do not reach for this to set
+ * `ApprovalRequest.risk` — that field means `critical` and nothing else, and
+ * widening it would relabel every `DELETE FROM` in the UI.
+ */
+export function hasElevatedRisk(...texts: (string | undefined | null)[]): boolean {
+  for (const text of texts) {
+    if (typeof text !== 'string' || !text) continue;
+    for (const p of CRITICAL_PATTERNS) {
+      if (p.regex.test(text)) return true;
+    }
+  }
+  return false;
+}

--- a/src/shared/push/pushEnvelope.ts
+++ b/src/shared/push/pushEnvelope.ts
@@ -120,6 +120,9 @@ export const PUSH_ENVELOPE_VERSION = 1 as const;
 /** HKDF info prefix. The ephemeral and static public keys follow it. */
 export const PUSH_HKDF_INFO = 'wmux:push:v1';
 
+/** `PushPayload.risk` when no destructive-action pattern matched. */
+export const PUSH_RISK_NORMAL = 'normal';
+
 export const PUSH_AAD_PREFIX = 'wmux:push:v1';
 export const PUSH_AAD_SEPARATOR = '|';
 
@@ -178,6 +181,26 @@ export interface PushPayload {
   sessionId?: string;
   /** True when a lock-screen affirmative cannot express the required choice. */
   requiresInAppChoice?: boolean;
+  /**
+   * The approval's risk, ALWAYS stated on an approval payload — `'critical'`
+   * when a destructive-action pattern matched, `PUSH_RISK_NORMAL` when none
+   * did.
+   *
+   * This is the one place the REST shape is deliberately not copied. On
+   * `/api/approvals` the field is omitted when nothing matched, and absence
+   * reads as "no pattern matched"; here absence has to read as *unknown*. The
+   * extension has no store to consult — the sealed payload is everything it
+   * knows — so it cannot tell a sender that predates this field from a sender
+   * that decided the approval was ordinary. It therefore withholds the
+   * lock-screen affirmative unless a value positively says the approval is
+   * ordinary, and an omitted field costs somebody a trip into the app while a
+   * wrong guess costs a destructive command approved from a pocket.
+   *
+   * Adding a new elevated level is therefore a two-sided change: the extension
+   * grants the affirmative to every value that is not `'critical'`, so a level
+   * introduced here alone would be silently treated as ordinary.
+   */
+  risk?: string;
   [key: string]: unknown;
 }
 

--- a/src/shared/push/pushEnvelope.ts
+++ b/src/shared/push/pushEnvelope.ts
@@ -123,6 +123,13 @@ export const PUSH_HKDF_INFO = 'wmux:push:v1';
 /** `PushPayload.risk` when no destructive-action pattern matched. */
 export const PUSH_RISK_NORMAL = 'normal';
 
+/**
+ * `PushPayload.risk` when one did — at EITHER tier, which is wider than the
+ * REST field's `critical`. See `buildApprovalPushPayload` for why the lock
+ * screen draws the line in a different place than the UI does.
+ */
+export const PUSH_RISK_CRITICAL = 'critical';
+
 export const PUSH_AAD_PREFIX = 'wmux:push:v1';
 export const PUSH_AAD_SEPARATOR = '|';
 


### PR DESCRIPTION
iOS 앱이 이미 보내거나 읽고 있는데 서버 절반이 없던 세 가지를 닫는다. 셋 다 폰 계약이고, 앱이 쓰려면 한 릴리스에 같이 있어야 해서 PR 하나로 묶었다.

## 1. `POST /api/sessions/:id/resize` — 폰이 PTY 모양을 정한다

책상 pane은 흔히 151×47이고, 151컬럼이 들어가는 읽을 만한 폰트는 폰에 없다. 줄바꿈은 PTY에서, 어느 클라이언트가 바이트를 보기도 전에 일어나므로 이걸 고칠 수 있는 건 데몬뿐이다. 지금까지 폰은 레터박스로 눌리거나 폰트를 못 읽을 만큼 줄이는 선택지밖에 없었다.

**소유권 — 책상이 attach 중이면 책상 것이다.** PTY는 하나고 가질 수 있는 크기도 하나다. "마지막 요청이 이긴다"는 정책이 아니라 싸움이다: 폰이 줄이면 책상 렌더러가 다음 레이아웃 패스에서 자기 bounds로 되돌리고, PTY는 두 크기 사이를 오가며 양쪽 화면이 다시 그려진다. 그래서 `attached`면 409 `desk-owns-size`로 거절하되 현재 cols/rows를 실어 보내 클라이언트가 두 번 묻지 않게 한다. `detached`면 폰 값을 적용한다. 소유권을 돌려주는 코드는 없다 — 책상은 attach할 때 자기 크기로 스스로 resize한다.

**`--allow-input` 게이트 없음.** diff·approvals와 같은 근거다. SIGWINCH 하나와 숫자 두 개를 바꿀 뿐, 자식 stdin에 바이트가 닿지 않고 실행되는 것도 없다. Bearer 게이트는 그대로다. 붙어 있는 사람이 없는 pane의 모양이 어색해지는 게 최악이고, 다음 책상 attach가 그것도 고친다.

응답은 요청이 아니라 **적용된** 기하다. 매니저가 cols를 10, rows를 2로 바닥 처리하므로(zsh SIGBUS 가드) 두 값이 다를 수 있고, 자기 요청 기준으로 그리면 폭이 틀린다. 반대편으로는 라우트에서 1..1000 상한을 새로 건다 — 매니저에는 상한이 없었고 그건 유일한 호출자가 자기 pane을 재던 렌더러였기 때문이다. 네트워크에서 온 `rows`는 정수로 적힌 메모리 할당 요청이다.

additive라 `PHONE_PROTOCOL_VERSION`은 안 올린다. 구버전 데몬은 404를 주고, 방금 나열한 id에 대한 404가 곧 그 탐지다.

## 2. push payload에 `risk` 상시 명시

폰의 Notification Service Extension은 sealed payload 말고는 볼 것이 없다. 그래서 `risk`가 없으면 "패턴 안 걸림"이 아니라 **"모름"**으로 읽고 잠금화면 Approve 버튼을 내린다 — 이 필드를 모르던 데몬과 평범하다고 판단한 데몬을 구별할 방법이 없기 때문이다. 판단을 틀리는 비용이 양쪽으로 다르다: 없어서 앱을 열게 하면 불편으로 끝나지만, 넘겨짚으면 주머니 속 잠금화면에서 파괴적 명령이 승인된다.

데몬은 `risk?: 'critical'`을 critical에서만 세팅하고 평상시엔 생략해 왔다. REST `/api/approvals`에서는 그게 맞는 의미지만, push에 그대로 복사한 결과 **모든 승인에서 버튼이 꺼져 있었다.** push payload에서만 `'critical' | 'normal'`로 항상 명시한다. 계약 §push에 REST와 의미가 다른 유일한 필드로 적어 뒀다.

매핑 자체를 `buildApprovalPushPayload`로 꺼냈다. 4000줄짜리 부팅 함수 안 인라인이라 테스트가 하나도 없었고, 그래서 이 버그가 실기 전까지 안 보였다.

## 3. APNs 스테이지를 기기별로 저장하고 라우팅

APNs 토큰은 자기가 어느 스테이지에서 나왔는지 말하지 않고, Apple의 두 호스트는 서로의 토큰을 거절한다. 릴레이는 배포 전체에 대해 `APNS_ENV` 하나로 답해 왔으므로, 같은 tailnet의 TestFlight 빌드와 케이블 설치 빌드가 서로의 푸시를 조용히 깨뜨렸다 — 증상은 아무 데도 이어지지 않는 `BadDeviceToken`이다.

앱은 자기 프로비저닝 프로파일의 `aps-environment`를 읽어 **이미 스테이지를 보내고 있었고**, 그 절반이 서버에 없었다. 이제 세 층이 이어진다: 등록에서 받아 `DeviceStore`에 기기별로 저장 → `PushTarget`으로 실려 → 릴레이 요청 본문에 실린다. 릴레이는 요청 값을 먼저 보고 없으면 `APNS_ENV`로 떨어진다.

**없는 것은 채울 기본값이 아니다.** 시뮬레이터에는 프로파일이 없고 이 필드를 모르는 데몬도 있다. 넘겨짚으면 토큰이 거절하는 호스트로 간다. 없으면 없는 채로 전달되고, 릴레이는 예전과 똑같이 설정값을 쓴다. 반대로 값이 있는데 Apple의 두 단어가 아니면 조용히 버리지 않고 400이다 — 무시된 스테이지는 곧 잘못된 호스트다. 등록은 레코드를 통째로 교체하므로 스테이지도 상속되지 않는다.

릴레이에서 호스트는 컴파일된 상수 두 개 중 하나로만 고른다. 요청은 둘 중 무엇인지를 고를 뿐 호스트를 제공하지 않으며, 검증은 JWT 서명 전에 끝난다.

## 검증

- `daemon web + push + shared/push + relay` 455 tests / 19 files
- `deviceStore.runtime` 51 tests
- `tsc --noEmit`, `eslint` 신규 에러 0
- 신규 테스트 20건 (resize 6, approvalPushPayload 7, APNs 스테이지 relay 3 · store 3 · route 1)

실기 확인은 이 PR과 릴레이가 배포된 뒤에 한다. 클라이언트 절반은 wmux-ios에 이미 들어가 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Resize phone-only terminal panes with validation, ownership checks, throttling, and clear status responses.
  - Approval notifications now identify normal or critical risk and use improved session grouping.
  - Push registration supports separate development and production notification environments.

- **Bug Fixes**
  - Restored missing approval actions on notifications.
  - Fixed notification routing conflicts between app stages.
  - Improved handling of unavailable or delayed terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->