### PR TITLE
docs(changelog): 3.38.3에 빠진 #743을 넣는다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [3.38.3] — 2026-08-02
 
+### Added
+
+- Phones can reshape a pane they are the only client of. `POST /api/sessions/<id>/resize` reflows the PTY to the phone's viewport, so a 151-column desk pane stops arriving letterboxed or shrunk past reading — the wrapping happens in the PTY, before any client sees a byte, so nothing on the phone could fix it. A desk client that has the pane attached keeps ownership: the route answers `409 desk-owns-size` with the current geometry rather than starting a resize fight the desk's next layout pass would win anyway. Available without `--allow-input`, like the diff route — it delivers a SIGWINCH, not a keystroke. (#743)
+
 ### Fixed
 
 - The Schedules panel's "Add schedule" button no longer gets clipped off the right edge of a narrow deck — the create row wraps and its time/repeat controls shrink.
@@ -20,6 +24,9 @@
   silently refusing for the rest of the session. Updates that were interrupted
   no longer leave their downloaded copy behind either, where they had been
   piling up at around 120 MB each. (#742)
+
+- The lock-screen Approve button never appeared on any notification. The iOS extension has nothing but the sealed payload, so it reads an absent `risk` as "unknown" and withholds the affirmative — but the daemon only ever set `risk` on the critical branch, which is right for `/api/approvals` and wrong here. Push payloads now always state `critical` or `normal`. (#743)
+- Two builds of the phone app on one tailnet took turns breaking each other's push. An APNs token does not say which stage minted it and Apple's two hosts reject each other's, so the relay's single `APNS_ENV` was one answer for every device — the symptom was a `BadDeviceToken` that traced back to nothing. The daemon now stores the stage the app reported per device and the relay routes on it, falling back to `APNS_ENV` when a device named none. (#743)
 
 ## [3.38.2] — 2026-08-01
 

--- a/changelog.d/743.md
+++ b/changelog.d/743.md
@@ -1,8 +1,0 @@
-### Added
-
-- Phones can reshape a pane they are the only client of. `POST /api/sessions/<id>/resize` reflows the PTY to the phone's viewport, so a 151-column desk pane stops arriving letterboxed or shrunk past reading — the wrapping happens in the PTY, before any client sees a byte, so nothing on the phone could fix it. A desk client that has the pane attached keeps ownership: the route answers `409 desk-owns-size` with the current geometry rather than starting a resize fight the desk's next layout pass would win anyway. Available without `--allow-input`, like the diff route — it delivers a SIGWINCH, not a keystroke. (#743)
-
-### Fixed
-
-- The lock-screen Approve button never appeared on any notification. The iOS extension has nothing but the sealed payload, so it reads an absent `risk` as "unknown" and withholds the affirmative — but the daemon only ever set `risk` on the critical branch, which is right for `/api/approvals` and wrong here. Push payloads now always state `critical` or `normal`. (#743)
-- Two builds of the phone app on one tailnet took turns breaking each other's push. An APNs token does not say which stage minted it and Apple's two hosts reject each other's, so the relay's single `APNS_ENV` was one answer for every device — the symptom was a `BadDeviceToken` that traced back to nothing. The daemon now stores the stage the app reported per device and the relay routes on it, falling back to `APNS_ENV` when a device named none. (#743)


### PR DESCRIPTION
릴리스 브랜치 `release/3.38.3`이 `73a904b6`(#742)에서 잘렸는데, 그 뒤에 #743이 머지됐다. squash 머지는 릴리스 브랜치의 diff만 적용하므로 `79af8a4f`의 **코드는 main에 그대로 남았지만**, CHANGELOG 조립은 #740·#741·#742 fragment만 소비한 상태였다.

결과적으로 3.38.3은 이런 버전이 된다:

- `POST /api/sessions/:id/resize`(폰이 PTY 모양을 정한다), push payload `risk` 상시 명시(잠금화면 승인 버튼), APNs 스테이지 기기별 라우팅 — **코드는 실려 나간다**
- 릴리스 노트에는 **한 줄도 없다**
- `changelog.d/743.md`가 소비되지 않고 main에 남아 있다

데몬 계약이 바뀌는 변경이라 노트에 없으면 나중에 추적이 안 된다.

**버전 번호는 건드리지 않는다.** 코드가 이미 3.38.3에 있으므로 올릴 것이 없고, 이 PR은 노트를 사실에 맞추는 것뿐이다. `changelog.d/743.md`를 3.38.3 절로 접고 fragment를 소비한다. Keep a Changelog 순서대로 `### Added`가 `### Fixed` 앞에 온다.

아직 `v3.38.3` 태그가 없어 발행 전에 고칠 수 있었다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added phone-initiated terminal pane resizing, including handling for desk ownership conflicts.
  * Phone resizing no longer requires input permission.

* **Bug Fixes**
  * Fixed iOS approval notifications by ensuring they include the appropriate risk level.
  * Improved push notification delivery by routing messages according to each device’s APNs environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->