### PR TITLE
fix(mcp): scope browser RPC fallbacks by workspace

### DIFF
--- a/changelog.d/749.md
+++ b/changelog.d/749.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **Scoped MCP browser fallbacks to their calling workspace.** Browser tools no
+  longer let automation leases, CDP discovery, or RPC fallbacks select another
+  workspace's webview when the intended target is missing or ambiguous. (#749)

--- a/src/mcp/__tests__/workspaceRouting.test.ts
+++ b/src/mcp/__tests__/workspaceRouting.test.ts
@@ -22,8 +22,9 @@ import path from 'node:path';
 //      browser.rpc.ts; the handler ignores workspaceId). It carries NO workspace
 //      identity, matching browser_session_stop/status/list — so it can never
 //      reintroduce the active-workspace fallback bug.
-//   4. browser_tabs injects requireWorkspaceId() at its production registration
-//      site, so its isolated unit tests cannot mask accidental weak wiring.
+//   4. Every Playwright browser tool injects requireWorkspaceId() at its
+//      production registration site, so isolated unit tests cannot mask
+//      accidental weak wiring or an unscoped fallback/lease path.
 describe('MCP workspace routing (source-level invariants)', () => {
   const indexPath = path.join(__dirname, '..', 'index.ts');
   const rawSrc = fs.readFileSync(indexPath, 'utf-8');
@@ -179,15 +180,27 @@ describe('MCP workspace routing (source-level invariants)', () => {
     expect(src).toMatch(/setWorkspaceIdResolver\(\s*requireWorkspaceId\s*\)/);
   });
 
-  it('browser_tabs production wiring injects requireWorkspaceId (#565)', () => {
-    // navigation.tabs.test.ts injects a resolver so it can exercise the tool in
-    // isolation. This source lock covers the complementary production seam: a
-    // future rewire to the weak resolver must fail even if those unit tests pass.
-    const registrations = src.match(/registerNavigationTools\([\s\S]*?\);/g) ?? [];
-    expect(registrations).toHaveLength(1);
-    expect(registrations[0]).toMatch(
-      /registerNavigationTools\(\s*server\s*,\s*\{\s*resolveWorkspaceId:\s*requireWorkspaceId\s*\}\s*\)/,
+  it('every Playwright browser tool receives the same strict workspace resolver (#695)', () => {
+    // Unit tests inject a resolver in isolation. This source lock covers the
+    // complementary production seam: every browser registration must share the
+    // strict requireWorkspaceId dependency, never the weak/UI-active resolver.
+    expect(src).toMatch(
+      /const browserToolDeps\s*=\s*\{\s*resolveWorkspaceId:\s*requireWorkspaceId\s*\}/,
     );
+    for (const name of [
+      'Navigation',
+      'Interaction',
+      'Inspection',
+      'State',
+      'Wait',
+      'File',
+      'Utility',
+      'Extraction',
+    ]) {
+      expect(src, `${name} tools must receive browserToolDeps`).toMatch(
+        new RegExp(`register${name}Tools\\(\\s*server\\s*,\\s*browserToolDeps`),
+      );
+    }
   });
 
   it('browser_session_start is GLOBAL — carries no workspace identity (no resolver calls)', () => {
@@ -231,7 +244,7 @@ describe('MCP workspace routing (source-level invariants)', () => {
 
   it('browser_wait is wired through the same immutable catalog profile', () => {
     expect(src).toMatch(
-      /registerWaitTools\(\s*server\s*,\s*MCP_CATALOG_OPTIONS\s*\)/,
+      /registerWaitTools\(\s*server\s*,\s*browserToolDeps\s*,\s*MCP_CATALOG_OPTIONS\s*\)/,
     );
   });
 });

--- a/src/mcp/__tests__/workspaceRouting.test.ts
+++ b/src/mcp/__tests__/workspaceRouting.test.ts
@@ -197,9 +197,15 @@ describe('MCP workspace routing (source-level invariants)', () => {
       'Utility',
       'Extraction',
     ]) {
-      expect(src, `${name} tools must receive browserToolDeps`).toMatch(
-        new RegExp(`register${name}Tools\\(\\s*server\\s*,\\s*browserToolDeps`),
-      );
+      const allCalls = src.match(new RegExp(`register${name}Tools\\(`, 'g')) ?? [];
+      expect(allCalls, `${name} tools must be registered exactly once`).toHaveLength(1);
+      const strictCalls = src.match(
+        new RegExp(
+          `register${name}Tools\\(\\s*server\\s*,\\s*browserToolDeps\\s*(?:,|\\))`,
+          'g',
+        ),
+      ) ?? [];
+      expect(strictCalls, `${name} tools must receive exactly browserToolDeps`).toHaveLength(1);
     }
   });
 

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -844,14 +844,15 @@ server.tool(
 );
 
 // === Playwright browser tools ===
-registerNavigationTools(server, { resolveWorkspaceId: requireWorkspaceId });
-registerInteractionTools(server);
-registerInspectionTools(server);
-registerStateTools(server);
-registerWaitTools(server, MCP_CATALOG_OPTIONS);
-registerFileTools(server);
-registerUtilityTools(server);
-registerExtractionTools(server);
+const browserToolDeps = { resolveWorkspaceId: requireWorkspaceId };
+registerNavigationTools(server, browserToolDeps);
+registerInteractionTools(server, browserToolDeps);
+registerInspectionTools(server, browserToolDeps);
+registerStateTools(server, browserToolDeps);
+registerWaitTools(server, browserToolDeps, MCP_CATALOG_OPTIONS);
+registerFileTools(server, browserToolDeps);
+registerUtilityTools(server, browserToolDeps);
+registerExtractionTools(server, browserToolDeps);
 
 // The engine's auto-open (getPage Strategy 4) issues browser.open outside any
 // tool handler, so it cannot rely on the per-tool requireWorkspaceId() guard

--- a/src/mcp/playwright/PlaywrightEngine.ts
+++ b/src/mcp/playwright/PlaywrightEngine.ts
@@ -7,7 +7,9 @@ import { formatMacosError, MACOS_ERRORS } from '../../shared/errors/macos';
 import type { BrowserBackend } from '../../shared/browserBackend';
 import { EXTERNAL_BACKEND_UNSUPPORTED_MESSAGE } from '../../shared/browserBackend';
 import {
+  assertBrowserTargetScope,
   isWorkspaceScopeUnresolvedError,
+  WorkspaceScopeUnresolvedError,
   WORKSPACE_SCOPE_UNRESOLVED_CODE,
   type BrowserTargetScope,
 } from './browserScope';
@@ -79,8 +81,8 @@ function workspaceScopeUnresolved(reason: string): Error {
   // Log as well as throw so direct engine consumers retain a clear refusal
   // reason even when a tool later renders the error into MCP result content.
   console.error(`[PlaywrightEngine] Page selection refused — ${reason}`);
-  return new Error(
-    `${WORKSPACE_SCOPE_UNRESOLVED_CODE}: cannot determine which workspace this session owns (${reason}), ` +
+  return new WorkspaceScopeUnresolvedError(
+    `cannot determine which workspace this session owns (${reason}), ` +
       `so browser page selection cannot be scoped to it. Refusing rather than driving another workspace's browser. ` +
       `Make sure you are running inside a wmux terminal workspace.`,
   );
@@ -277,16 +279,15 @@ export class PlaywrightEngine {
    * new-browser URL), so URL equality alone can hand back the WRONG guest
    * while the lease is held for the requested one.
    *
-   * Client-side Page objects expose no targetId, so an unambiguous URL match
-   * resolves directly, and only ambiguous candidates pay for a real
-   * Target.getTargetInfo round-trip over a throwaway CDP session (codex round
-   * 4 — the earlier `_delegate._targetId` probe never matched). Ambiguity
-   * that cannot be resolved → null (fail rather than drive the wrong pane).
+   * Client-side Page objects expose no targetId, so every candidate pays for
+   * one Target.getTargetInfo round-trip over a throwaway CDP session. URL
+   * equality alone is insufficient even when unique: our own newly attached
+   * page may not have materialized yet while a foreign workspace already has
+   * the same URL. A target that cannot be proven → null.
    */
   private async matchPinnedPage(pages: Page[], targetId: string, url: string): Promise<Page | null> {
     const byUrl = pages.filter((p) => p.url() === url);
-    if (byUrl.length === 1) return byUrl[0];
-    const candidates = byUrl.length > 1 ? byUrl : pages;
+    const candidates = byUrl.length > 0 ? byUrl : pages;
     for (const p of candidates) {
       try {
         const session = await p.context().newCDPSession(p);
@@ -427,7 +428,7 @@ export class PlaywrightEngine {
    * reused by its lease and fallback RPCs (#695). This avoids a second identity
    * lookup and also scopes explicit-surface discovery on the main side.
    */
-  async getPage(surfaceId?: string, workspaceId?: string): Promise<Page | null> {
+  private async getPage(surfaceId?: string, workspaceId?: string): Promise<Page | null> {
     // Resolve the selection context (which workspace/surface this call targets)
     // BEFORE consulting any shared state, so the lock, fast-fail latch, and
     // auto-open latch are all scoped to THIS caller's workspace and can never
@@ -473,6 +474,7 @@ export class PlaywrightEngine {
    * dropped workspaceId a compile error at every tool call site.
    */
   async getPageForScope(scope: BrowserTargetScope): Promise<Page | null> {
+    assertBrowserTargetScope(scope);
     return this.getPage(scope.surfaceId, scope.workspaceId);
   }
 

--- a/src/mcp/playwright/PlaywrightEngine.ts
+++ b/src/mcp/playwright/PlaywrightEngine.ts
@@ -6,7 +6,11 @@ import { isMac } from '../../shared/platform';
 import { formatMacosError, MACOS_ERRORS } from '../../shared/errors/macos';
 import type { BrowserBackend } from '../../shared/browserBackend';
 import { EXTERNAL_BACKEND_UNSUPPORTED_MESSAGE } from '../../shared/browserBackend';
-import { WORKSPACE_SCOPE_UNRESOLVED_CODE } from './browserScope';
+import {
+  isWorkspaceScopeUnresolvedError,
+  WORKSPACE_SCOPE_UNRESOLVED_CODE,
+  type BrowserTargetScope,
+} from './browserScope';
 
 export { WORKSPACE_SCOPE_UNRESOLVED_CODE } from './browserScope';
 
@@ -72,8 +76,8 @@ const PAGE_FIND_DELAY_MS = 500;
  * permanent one. Mirrors EXTERNAL_BACKEND_UNSUPPORTED's `CODE: prose` shape.
  */
 function workspaceScopeUnresolved(reason: string): Error {
-  // Log as well as throw: several tools call getPage().catch(() => null) and
-  // fall back to an RPC path, which would otherwise swallow the reason whole.
+  // Log as well as throw so direct engine consumers retain a clear refusal
+  // reason even when a tool later renders the error into MCP result content.
   console.error(`[PlaywrightEngine] Page selection refused — ${reason}`);
   return new Error(
     `${WORKSPACE_SCOPE_UNRESOLVED_CODE}: cannot determine which workspace this session owns (${reason}), ` +
@@ -464,6 +468,15 @@ export class PlaywrightEngine {
   }
 
   /**
+   * Scope-required entry point for MCP browser tools (#695). Keeping the
+   * verified workspace and optional surface in one required object makes a
+   * dropped workspaceId a compile error at every tool call site.
+   */
+  async getPageForScope(scope: BrowserTargetScope): Promise<Page | null> {
+    return this.getPage(scope.surfaceId, scope.workspaceId);
+  }
+
+  /**
    * Resolve the surface owned by the CALLING session's workspace (#554).
    *
    * Read tools (browser_snapshot / browser_evaluate / browser_extract_*) take
@@ -593,6 +606,9 @@ export class PlaywrightEngine {
     // workspace-blind fallbacks must be skipped and we auto-open its own.
     let surfaceId = ctx.surfaceId;
     let callerHasNoSurface = ctx.callerHasNoSurface;
+    // A surfaceId returned by our own workspace-scoped browser.open is already
+    // proven even when a legacy main cannot tag its subsequent cdp.info entry.
+    let surfaceProvenByAutoOpen = false;
 
     for (let attempt = 1; attempt <= PAGE_FIND_RETRIES; attempt++) {
       try {
@@ -606,7 +622,11 @@ export class PlaywrightEngine {
         // negative "any non-shell page" heuristic, to avoid ever returning the
         // shell when the shell happens to slip past URL classification.
         if (this.browser) {
-          const page = await this.findViaTargetDomain(surfaceId, ctx.workspaceId);
+          const page = await this.findViaTargetDomain(
+            surfaceId,
+            ctx.workspaceId,
+            surfaceProvenByAutoOpen,
+          );
           if (page) return page;
         }
 
@@ -638,7 +658,11 @@ export class PlaywrightEngine {
 
         // Strategy 3: Use /json endpoint + match registered targets
         if (this.cdpPort) {
-          const page = await this.findViaJsonEndpoint(surfaceId, ctx.workspaceId);
+          const page = await this.findViaJsonEndpoint(
+            surfaceId,
+            ctx.workspaceId,
+            surfaceProvenByAutoOpen,
+          );
           if (page) return page;
         }
         } // end !callerHasNoSurface
@@ -677,12 +701,11 @@ export class PlaywrightEngine {
                 if (opened.surfaceId) {
                   surfaceId = opened.surfaceId;
                   callerHasNoSurface = false;
+                  surfaceProvenByAutoOpen = true;
                 } else {
                   // A main that did not name the surface. Fall back to
-                  // re-deriving. A refusal here is caught rather than thrown
-                  // on: the retry then finds nothing and getPage() returns
-                  // null, which is the same answer, but it arrives through the
-                  // normal path instead of aborting the loop mid-way.
+                  // re-deriving. Scope refusals stay terminal; ordinary
+                  // discovery failures continue through the normal retry path.
                   try {
                     const owned = await this.resolveCallerSurface(ctx.workspaceId);
                     if (owned.kind === 'surface') {
@@ -690,6 +713,7 @@ export class PlaywrightEngine {
                       callerHasNoSurface = false;
                     }
                   } catch (resolveErr) {
+                    if (isWorkspaceScopeUnresolvedError(resolveErr)) throw resolveErr;
                     console.error(
                       '[PlaywrightEngine] Could not pin the auto-opened surface:',
                       resolveErr instanceof Error ? resolveErr.message : String(resolveErr),
@@ -700,6 +724,7 @@ export class PlaywrightEngine {
               continue; // retry page discovery
             }
           } catch (openErr) {
+            if (isWorkspaceScopeUnresolvedError(openErr)) throw openErr;
             console.error('[PlaywrightEngine] Auto-open failed:', openErr instanceof Error ? openErr.message : String(openErr));
           }
         }
@@ -711,6 +736,7 @@ export class PlaywrightEngine {
           await this.ensureConnected(ctx.workspaceId);
         }
       } catch (err) {
+        if (isWorkspaceScopeUnresolvedError(err)) throw err;
         console.error(
           `[PlaywrightEngine] getPage attempt ${attempt} failed:`,
           err instanceof Error ? err.message : String(err),
@@ -777,7 +803,11 @@ export class PlaywrightEngine {
   /**
    * Use CDP Target domain to discover webview targets and create a page for them.
    */
-  private async findViaTargetDomain(surfaceId?: string, workspaceId?: string): Promise<Page | null> {
+  private async findViaTargetDomain(
+    surfaceId?: string,
+    workspaceId?: string,
+    surfaceProvenByAutoOpen = false,
+  ): Promise<Page | null> {
     if (!this.browser) return null;
 
     try {
@@ -822,9 +852,12 @@ export class PlaywrightEngine {
           workspaceId ? { workspaceId } : {},
         )) as CdpInfoResponse;
         this.cacheShellUrl(info);
-        const wmuxTarget = surfaceId
-          ? info.targets.find((t) => t.surfaceId === surfaceId)
-          : info.targets[0];
+        const wmuxTarget = this.selectRegisteredTarget(
+          info,
+          surfaceId,
+          workspaceId,
+          surfaceProvenByAutoOpen,
+        );
 
         // Find the webview target — match by targetId from WebviewCdpManager
         let webviewTarget = wmuxTarget
@@ -883,6 +916,7 @@ export class PlaywrightEngine {
         await cdpSession.detach().catch(() => { /* best-effort */ });
       }
     } catch (err) {
+      if (isWorkspaceScopeUnresolvedError(err)) throw err;
       console.error('[PlaywrightEngine] findViaTargetDomain error:', err instanceof Error ? err.message : String(err));
       return null;
     }
@@ -891,7 +925,11 @@ export class PlaywrightEngine {
   /**
    * Use the /json HTTP endpoint to find webview targets and attach via CDP.
    */
-  private async findViaJsonEndpoint(surfaceId?: string, workspaceId?: string): Promise<Page | null> {
+  private async findViaJsonEndpoint(
+    surfaceId?: string,
+    workspaceId?: string,
+    surfaceProvenByAutoOpen = false,
+  ): Promise<Page | null> {
     if (!this.cdpPort || !this.browser) return null;
 
     try {
@@ -913,9 +951,12 @@ export class PlaywrightEngine {
         workspaceId ? { workspaceId } : {},
       )) as CdpInfoResponse;
       this.cacheShellUrl(info);
-      const wmuxTarget = surfaceId
-        ? info.targets.find((t) => t.surfaceId === surfaceId)
-        : info.targets[0];
+      const wmuxTarget = this.selectRegisteredTarget(
+        info,
+        surfaceId,
+        workspaceId,
+        surfaceProvenByAutoOpen,
+      );
 
       // Find the webview in /json
       let jsonTarget = wmuxTarget
@@ -974,9 +1015,57 @@ export class PlaywrightEngine {
 
       return null;
     } catch (err) {
+      if (isWorkspaceScopeUnresolvedError(err)) throw err;
       console.error('[PlaywrightEngine] findViaJsonEndpoint error:', err instanceof Error ? err.message : String(err));
       return null;
     }
+  }
+
+  /**
+   * Select a registered target without trusting an older main to have honored
+   * the workspace filter. Current mains mark scoped responses explicitly;
+   * legacy responses must carry target ownership tags or selection is refused.
+   */
+  private selectRegisteredTarget(
+    info: CdpInfoResponse,
+    surfaceId?: string,
+    workspaceId?: string,
+    surfaceProvenByAutoOpen = false,
+  ): CdpTargetInfo | undefined {
+    if (!workspaceId || info.targetsScoped) {
+      return surfaceId
+        ? info.targets.find((target) => target.surfaceId === surfaceId)
+        : info.targets[0];
+    }
+
+    if (surfaceId) {
+      const target = info.targets.find((candidate) => candidate.surfaceId === surfaceId);
+      if (!target) return undefined;
+      if (!target.workspaceId && surfaceProvenByAutoOpen) return target;
+      if (!target.workspaceId) {
+        throw workspaceScopeUnresolved(
+          'the connected wmux main does not tag the requested browser target with a workspace',
+        );
+      }
+      if (target.workspaceId !== workspaceId) {
+        throw workspaceScopeUnresolved(
+          'the requested browser surface is not owned by the calling workspace',
+        );
+      }
+      return target;
+    }
+
+    const own = info.targets.find((target) => target.workspaceId === workspaceId);
+    if (own || info.targets.length === 0) return own;
+    const anyTagged = info.targets.some(
+      (target) => typeof target.workspaceId === 'string' && target.workspaceId.length > 0,
+    );
+    if (!anyTagged) {
+      throw workspaceScopeUnresolved(
+        'the connected wmux main does not tag browser targets with a workspace',
+      );
+    }
+    return undefined;
   }
 
   async getBrowser(): Promise<Browser | null> {

--- a/src/mcp/playwright/PlaywrightEngine.ts
+++ b/src/mcp/playwright/PlaywrightEngine.ts
@@ -6,6 +6,9 @@ import { isMac } from '../../shared/platform';
 import { formatMacosError, MACOS_ERRORS } from '../../shared/errors/macos';
 import type { BrowserBackend } from '../../shared/browserBackend';
 import { EXTERNAL_BACKEND_UNSUPPORTED_MESSAGE } from '../../shared/browserBackend';
+import { WORKSPACE_SCOPE_UNRESOLVED_CODE } from './browserScope';
+
+export { WORKSPACE_SCOPE_UNRESOLVED_CODE } from './browserScope';
 
 interface CdpTargetInfo {
   surfaceId: string;
@@ -52,9 +55,6 @@ const MAX_CONNECT_RETRIES = 3;
 const RETRY_DELAY_MS = 800;
 const PAGE_FIND_RETRIES = 3;
 const PAGE_FIND_DELAY_MS = 500;
-
-/** Stable error code — agents can match on this instead of the prose. */
-export const WORKSPACE_SCOPE_UNRESOLVED_CODE = 'WORKSPACE_SCOPE_UNRESOLVED';
 
 /**
  * The contract error for "page selection cannot be scoped to the caller".
@@ -199,12 +199,11 @@ export class PlaywrightEngine {
    */
   private workspaceBackend: BrowserBackend | undefined = undefined;
   /**
-   * Resolves the calling session's workspace id for auto-open. Wired by
-   * src/mcp/index.ts to requireWorkspaceId(). Auto-open issues browser.open
-   * outside any MCP tool handler, so it cannot use the per-tool
-   * requireWorkspaceId() guard and carries the resolved id explicitly instead.
-   * null means no resolver is wired, in which case auto-open is skipped (fail
-   * closed) rather than opening in an unspecified workspace.
+   * Resolves the calling session's workspace id when a caller has not already
+   * supplied one. Wired by src/mcp/index.ts to requireWorkspaceId(). Browser
+   * tool handlers resolve once before acquiring a lease and pass that id into
+   * getPage(); direct engine callers use this fallback. null means no resolver
+   * is wired, in which case selection/auto-open fails closed.
    */
   private workspaceIdResolver: (() => Promise<string>) | null = null;
 
@@ -353,13 +352,16 @@ export class PlaywrightEngine {
     }
   }
 
-  async ensureConnected(): Promise<void> {
+  async ensureConnected(workspaceId?: string): Promise<void> {
     if (this.browser?.isConnected()) return;
 
     let lastError: unknown = null;
     for (let attempt = 1; attempt <= MAX_CONNECT_RETRIES; attempt++) {
       try {
-        const info = (await sendRpc('browser.cdp.info')) as CdpInfoResponse;
+        const info = (await sendRpc(
+          'browser.cdp.info',
+          workspaceId ? { workspaceId } : {},
+        )) as CdpInfoResponse;
         this.cacheShellUrl(info);
         await this.connect(info.cdpPort);
         return;
@@ -416,15 +418,19 @@ export class PlaywrightEngine {
    * 3. Fetch /json endpoint for target discovery
    * 4. Auto-open a browser surface via RPC if none exists (so callers don't
    *    need to know about browser_open ordering)
+   *
+   * `workspaceId`, when supplied by the tool layer, is the already-verified id
+   * reused by its lease and fallback RPCs (#695). This avoids a second identity
+   * lookup and also scopes explicit-surface discovery on the main side.
    */
-  async getPage(surfaceId?: string): Promise<Page | null> {
+  async getPage(surfaceId?: string, workspaceId?: string): Promise<Page | null> {
     // Resolve the selection context (which workspace/surface this call targets)
     // BEFORE consulting any shared state, so the lock, fast-fail latch, and
     // auto-open latch are all scoped to THIS caller's workspace and can never
     // bleed into another's (#554). Context resolution needs only the control
     // RPC (browser.cdp.info); the CDP browser connection happens in
     // _getPageImpl as before.
-    const ctx = await this.resolveSelectionContext(surfaceId);
+    const ctx = await this.resolveSelectionContext(surfaceId, workspaceId);
 
     // External-backend contract (#517): the caller's workspace delegates opens
     // to the OS browser and owns no builtin webview target (callerHasNoSurface,
@@ -481,18 +487,20 @@ export class PlaywrightEngine {
    * cannot walk its own process tree — so this is not a spoofing question and
    * the #113 same-user ceiling does not cover it.
    */
-  private async resolveCallerSurface(): Promise<
+  private async resolveCallerSurface(resolvedWorkspaceId?: string): Promise<
     | { kind: 'surface'; surfaceId: string; workspaceId: string }
     | { kind: 'none'; workspaceId: string }
   > {
-    if (!this.workspaceIdResolver) throw workspaceScopeUnresolved('no workspace resolver wired');
-    let workspaceId: string;
-    try {
-      workspaceId = await this.workspaceIdResolver();
-    } catch (err) {
-      throw workspaceScopeUnresolved(
-        `workspace identity unresolved: ${err instanceof Error ? err.message : String(err)}`,
-      );
+    let workspaceId = resolvedWorkspaceId;
+    if (workspaceId === undefined) {
+      if (!this.workspaceIdResolver) throw workspaceScopeUnresolved('no workspace resolver wired');
+      try {
+        workspaceId = await this.workspaceIdResolver();
+      } catch (err) {
+        throw workspaceScopeUnresolved(
+          `workspace identity unresolved: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
     if (!workspaceId) throw workspaceScopeUnresolved('workspace identity resolved to an empty id');
 
@@ -556,11 +564,17 @@ export class PlaywrightEngine {
    */
   private async resolveSelectionContext(
     explicitSurfaceId?: string,
+    workspaceId?: string,
   ): Promise<{ key: string; surfaceId?: string; callerHasNoSurface: boolean; workspaceId?: string }> {
     if (explicitSurfaceId) {
-      return { key: `surf:${explicitSurfaceId}`, surfaceId: explicitSurfaceId, callerHasNoSurface: false };
+      return {
+        key: workspaceId ? `ws:${workspaceId}:surf:${explicitSurfaceId}` : `surf:${explicitSurfaceId}`,
+        surfaceId: explicitSurfaceId,
+        callerHasNoSurface: false,
+        ...(workspaceId && { workspaceId }),
+      };
     }
-    const owned = await this.resolveCallerSurface();
+    const owned = await this.resolveCallerSurface(workspaceId);
     if (owned.kind === 'surface') {
       return { key: `ws:${owned.workspaceId}`, surfaceId: owned.surfaceId, callerHasNoSurface: false, workspaceId: owned.workspaceId };
     }
@@ -571,7 +585,7 @@ export class PlaywrightEngine {
     ctx: { key: string; surfaceId?: string; callerHasNoSurface: boolean; workspaceId?: string },
   ): Promise<Page | null> {
 
-    await this.ensureConnected();
+    await this.ensureConnected(ctx.workspaceId);
 
     // Selection is scoped to the caller's workspace (#554), resolved by
     // getPage() -> resolveSelectionContext(). `surfaceId` set = pin to that
@@ -637,7 +651,7 @@ export class PlaywrightEngine {
         if (attempt === 1 && !this.autoOpenAttempted.has(ctx.key) && !surfaceId) {
           console.error('[PlaywrightEngine] No page found — auto-opening browser surface');
           try {
-            const opened = await this.attemptAutoOpen();
+            const opened = await this.attemptAutoOpen(ctx.workspaceId);
             if (opened) {
               // Latch (per context) only once the RPC actually went out, so a
               // fail-closed skip (no resolver / unresolved identity) leaves a
@@ -647,7 +661,7 @@ export class PlaywrightEngine {
               // Wait for the webview to register its CDP target
               await sleep(2000);
               await this.disconnect();
-              await this.ensureConnected();
+              await this.ensureConnected(ctx.workspaceId);
               // Pin the surface we just opened (#554) — otherwise
               // callerHasNoSurface keeps skipping Strategies 1-3 and the new
               // page is never found.
@@ -670,7 +684,7 @@ export class PlaywrightEngine {
                   // null, which is the same answer, but it arrives through the
                   // normal path instead of aborting the loop mid-way.
                   try {
-                    const owned = await this.resolveCallerSurface();
+                    const owned = await this.resolveCallerSurface(ctx.workspaceId);
                     if (owned.kind === 'surface') {
                       surfaceId = owned.surfaceId;
                       callerHasNoSurface = false;
@@ -694,7 +708,7 @@ export class PlaywrightEngine {
           console.error(`[PlaywrightEngine] No page found, reconnecting... (${attempt}/${PAGE_FIND_RETRIES})`);
           await sleep(PAGE_FIND_DELAY_MS);
           await this.disconnect();
-          await this.ensureConnected();
+          await this.ensureConnected(ctx.workspaceId);
         }
       } catch (err) {
         console.error(
@@ -704,7 +718,7 @@ export class PlaywrightEngine {
         if (attempt < PAGE_FIND_RETRIES) {
           await sleep(PAGE_FIND_DELAY_MS);
           await this.disconnect();
-          await this.ensureConnected();
+          await this.ensureConnected(ctx.workspaceId);
         }
       }
     }
@@ -734,20 +748,22 @@ export class PlaywrightEngine {
    * The surfaceId matters: it is the ONE selection this engine can make without
    * having to prove anything, because we are the ones who just asked for it.
    */
-  private async attemptAutoOpen(): Promise<{ surfaceId?: string } | null> {
-    if (!this.workspaceIdResolver) {
-      console.error('[PlaywrightEngine] Auto-open skipped: no workspace resolver wired');
-      return null;
-    }
-    let workspaceId: string;
-    try {
-      workspaceId = await this.workspaceIdResolver();
-    } catch (err) {
-      console.error(
-        '[PlaywrightEngine] Auto-open skipped: workspace identity unresolved:',
-        err instanceof Error ? err.message : String(err),
-      );
-      return null;
+  private async attemptAutoOpen(resolvedWorkspaceId?: string): Promise<{ surfaceId?: string } | null> {
+    let workspaceId = resolvedWorkspaceId;
+    if (workspaceId === undefined) {
+      if (!this.workspaceIdResolver) {
+        console.error('[PlaywrightEngine] Auto-open skipped: no workspace resolver wired');
+        return null;
+      }
+      try {
+        workspaceId = await this.workspaceIdResolver();
+      } catch (err) {
+        console.error(
+          '[PlaywrightEngine] Auto-open skipped: workspace identity unresolved:',
+          err instanceof Error ? err.message : String(err),
+        );
+        return null;
+      }
     }
     if (!workspaceId) {
       console.error('[PlaywrightEngine] Auto-open skipped: empty workspace id');

--- a/src/mcp/playwright/__tests__/PlaywrightEngine.test.ts
+++ b/src/mcp/playwright/__tests__/PlaywrightEngine.test.ts
@@ -233,6 +233,8 @@ interface ShellUrlInternals {
   shellUrl: string | null;
   cacheShellUrl(info: { cdpPort: number; shellUrl?: string; targets: unknown[] }): void;
   isShellPage(url: string): boolean;
+  matchPinnedPage(pages: FakePage[], targetId: string, url: string): Promise<FakePage | null>;
+  getPage(surfaceId?: string, workspaceId?: string): Promise<FakePage | null>;
 }
 function priv(engine: PlaywrightEngine): ShellUrlInternals {
   return engine as unknown as ShellUrlInternals;
@@ -290,6 +292,50 @@ describe('PlaywrightEngine runtime shell-URL handling (B)', () => {
     expect(priv(engine).isShellPage('https://example.com/')).toBe(false);
   });
 
+  it('requires targetId proof even when only one page has the pinned URL', async () => {
+    let reportedTargetId = 'wc-foreign';
+    const session = {
+      send: vi.fn().mockImplementation((method: string) =>
+        method === 'Target.getTargetInfo'
+          ? Promise.resolve({ targetInfo: { targetId: reportedTargetId } })
+          : Promise.resolve({}),
+      ),
+      detach: vi.fn().mockResolvedValue(undefined),
+    };
+    const context = {
+      newCDPSession: vi.fn().mockResolvedValue(session),
+    };
+    const onlySameUrlPage: FakePage = {
+      url: vi.fn().mockReturnValue('https://same.example/'),
+      context: vi.fn().mockReturnValue(context),
+    };
+    const engine = PlaywrightEngine.getInstance();
+
+    await expect(priv(engine).matchPinnedPage(
+      [onlySameUrlPage],
+      'wc-owned',
+      'https://same.example/',
+    )).resolves.toBeNull();
+
+    reportedTargetId = 'wc-owned';
+    await expect(priv(engine).matchPinnedPage(
+      [onlySameUrlPage],
+      'wc-owned',
+      'https://same.example/',
+    )).resolves.toBe(onlySameUrlPage);
+    expect(session.detach).toHaveBeenCalledTimes(2);
+  });
+
+  it('getPageForScope refuses a hand-built empty workspace before discovery', async () => {
+    const engine = PlaywrightEngine.getInstance();
+
+    await expect(engine.getPageForScope({
+      workspaceId: '',
+      surfaceId: 'surface-pinned',
+    })).rejects.toThrow(WORKSPACE_SCOPE_UNRESOLVED_CODE);
+    expect(mockSendRpc).not.toHaveBeenCalled();
+  });
+
   it('clears the cached shellUrl on disconnect', async () => {
     const sessions: FakeSession[] = [];
     mockConnectOverCDP.mockResolvedValue(makeFakeBrowser(sessions));
@@ -318,15 +364,19 @@ describe('PlaywrightEngine runtime shell-URL handling (B)', () => {
 
     // The caller's own registered guest, as Target.getTargets sees it.
     const session = {
-      send: vi.fn().mockImplementation((method: string) =>
-        method === 'Target.getTargets'
-          ? Promise.resolve({
-              targetInfos: [
-                { targetId: 'wc-1', type: 'page', title: '', url: 'https://example.com/', attached: true },
-              ],
-            })
-          : Promise.resolve({}),
-      ),
+      send: vi.fn().mockImplementation((method: string) => {
+        if (method === 'Target.getTargets') {
+          return Promise.resolve({
+            targetInfos: [
+              { targetId: 'wc-1', type: 'page', title: '', url: 'https://example.com/', attached: true },
+            ],
+          });
+        }
+        if (method === 'Target.getTargetInfo') {
+          return Promise.resolve({ targetInfo: { targetId: 'wc-1' } });
+        }
+        return Promise.resolve({});
+      }),
       detach: vi.fn().mockResolvedValue(undefined),
     };
     // A context whose pages() exposes both the shell and the webview.
@@ -366,7 +416,7 @@ describe('PlaywrightEngine runtime shell-URL handling (B)', () => {
       .setWorkspaceIdResolver(async () => 'ws-A');
     await engine.connect(9222);
 
-    const page = await engine.getPage();
+    const page = await priv(engine).getPage();
     expect(page).toBe(webviewPage);
     // The shell URL was learned from cdp.info during discovery.
     expect(priv(engine).shellUrl).toBe(shellUrl);
@@ -522,7 +572,7 @@ describe('PlaywrightEngine auto-open workspace routing (#190)', () => {
 
     const engine = PlaywrightEngine.getInstance();
 
-    await expect(engine.getPage()).rejects.toThrow(WORKSPACE_SCOPE_UNRESOLVED_CODE);
+    await expect(priv(engine).getPage()).rejects.toThrow(WORKSPACE_SCOPE_UNRESOLVED_CODE);
     const browserOpenCalls = mockSendRpc.mock.calls.filter((c) => c[0] === 'browser.open');
     expect(browserOpenCalls).toHaveLength(0);
   }, 15_000);
@@ -544,15 +594,19 @@ describe('PlaywrightEngine auto-open workspace routing (#190)', () => {
     // what lets the post-open re-resolve pin it (mirrors a real main — the
     // engine can no longer fall back to an unscoped "any page" selection).
     const openedSession = {
-      send: vi.fn().mockImplementation((method: string) =>
-        method === 'Target.getTargets'
-          ? Promise.resolve({
-              targetInfos: opened
-                ? [{ targetId: 'wc-new', type: 'page', title: '', url: 'https://example.com/', attached: true }]
-                : [],
-            })
-          : Promise.resolve({}),
-      ),
+      send: vi.fn().mockImplementation((method: string) => {
+        if (method === 'Target.getTargets') {
+          return Promise.resolve({
+            targetInfos: opened
+              ? [{ targetId: 'wc-new', type: 'page', title: '', url: 'https://example.com/', attached: true }]
+              : [],
+          });
+        }
+        if (method === 'Target.getTargetInfo') {
+          return Promise.resolve({ targetInfo: { targetId: 'wc-new' } });
+        }
+        return Promise.resolve({});
+      }),
       detach: vi.fn().mockResolvedValue(undefined),
     };
     const ctx = {
@@ -590,7 +644,7 @@ describe('PlaywrightEngine auto-open workspace routing (#190)', () => {
     const engine = PlaywrightEngine.getInstance();
     autoOpen(engine).setWorkspaceIdResolver(async () => 'ws-caller-1');
 
-    const page = await engine.getPage();
+    const page = await priv(engine).getPage();
 
     expect(page).toBe(webviewPage);
     expect(mockSendRpc).toHaveBeenCalledWith('browser.open', { workspaceId: 'ws-caller-1' });
@@ -616,15 +670,19 @@ describe('PlaywrightEngine auto-open workspace routing (#190)', () => {
       context: vi.fn(),
     };
     const openedSession = {
-      send: vi.fn().mockImplementation((method: string) =>
-        method === 'Target.getTargets'
-          ? Promise.resolve({
-              targetInfos: opened
-                ? [{ targetId: 'wc-legacy', type: 'page', title: '', url: 'https://example.com/', attached: true }]
-                : [],
-            })
-          : Promise.resolve({}),
-      ),
+      send: vi.fn().mockImplementation((method: string) => {
+        if (method === 'Target.getTargets') {
+          return Promise.resolve({
+            targetInfos: opened
+              ? [{ targetId: 'wc-legacy', type: 'page', title: '', url: 'https://example.com/', attached: true }]
+              : [],
+          });
+        }
+        if (method === 'Target.getTargetInfo') {
+          return Promise.resolve({ targetInfo: { targetId: 'wc-legacy' } });
+        }
+        return Promise.resolve({});
+      }),
       detach: vi.fn().mockResolvedValue(undefined),
     };
     const ctx = {
@@ -659,7 +717,7 @@ describe('PlaywrightEngine auto-open workspace routing (#190)', () => {
     const engine = PlaywrightEngine.getInstance();
     autoOpen(engine).setWorkspaceIdResolver(async () => 'ws-caller-1');
 
-    await expect(engine.getPage()).resolves.toBe(webviewPage);
+    await expect(priv(engine).getPage()).resolves.toBe(webviewPage);
     expect(mockSendRpc).toHaveBeenCalledWith('browser.open', { workspaceId: 'ws-caller-1' });
   }, 15_000);
 
@@ -709,7 +767,7 @@ describe('PlaywrightEngine auto-open workspace routing (#190)', () => {
     const engine = PlaywrightEngine.getInstance();
     autoOpen(engine).setWorkspaceIdResolver(async () => 'ws-caller-1');
 
-    await expect(engine.getPage()).rejects.toThrow(
+    await expect(priv(engine).getPage()).rejects.toThrow(
       /requested browser surface is not owned by the calling workspace/,
     );
   }, 15_000);
@@ -896,7 +954,7 @@ describe('PlaywrightEngine fail-closed page selection (unresolvable caller)', ()
       throw new Error('Workspace identity unknown.');
     });
 
-    await expect(engine.getPage()).rejects.toThrow(WORKSPACE_SCOPE_UNRESOLVED_CODE);
+    await expect(priv(engine).getPage()).rejects.toThrow(WORKSPACE_SCOPE_UNRESOLVED_CODE);
     // The refusal happens before any page selection: no CDP connection is made,
     // so the foreign page is never even a candidate.
     expect(mockConnectOverCDP).not.toHaveBeenCalled();
@@ -1088,7 +1146,7 @@ describe('PlaywrightEngine read-path workspace scoping — scoped cdp.info (#580
     const engine = PlaywrightEngine.getInstance();
     autoOpen(engine).setWorkspaceIdResolver(async () => 'ws-B');
 
-    await engine.getPage();
+    await priv(engine).getPage();
 
     // Opened in the caller's OWN workspace — the isolation guarantee.
     expect(mockSendRpc).toHaveBeenCalledWith('browser.open', { workspaceId: 'ws-B' });
@@ -1133,9 +1191,9 @@ describe('PlaywrightEngine external backend contract (#517)', () => {
     const engine = PlaywrightEngine.getInstance();
     scope(engine).setWorkspaceIdResolver(async () => 'ws-external');
 
-    await expect(engine.getPage()).rejects.toThrow(EXTERNAL_BACKEND_UNSUPPORTED_CODE);
+    await expect(priv(engine).getPage()).rejects.toThrow(EXTERNAL_BACKEND_UNSUPPORTED_CODE);
     // Same prose as the shared constant — no forked message.
-    await expect(engine.getPage()).rejects.toThrow(EXTERNAL_BACKEND_UNSUPPORTED_MESSAGE);
+    await expect(priv(engine).getPage()).rejects.toThrow(EXTERNAL_BACKEND_UNSUPPORTED_MESSAGE);
 
     // No retry/auto-open/connect loop was entered: the throw happens before
     // _getPageImpl, so the CDP browser is never connected and no browser.open
@@ -1177,7 +1235,7 @@ describe('PlaywrightEngine external backend contract (#517)', () => {
     scope(engine).setWorkspaceIdResolver(async () => 'ws-builtin');
 
     // Resolves to null (no page ever appears) — never throws the contract error.
-    await expect(engine.getPage()).resolves.toBeNull();
+    await expect(priv(engine).getPage()).resolves.toBeNull();
     // The builtin generic path still auto-opened in the caller's own workspace.
     expect(opened).toBe(true);
     expect(mockSendRpc).toHaveBeenCalledWith('browser.open', { workspaceId: 'ws-builtin' });
@@ -1193,15 +1251,19 @@ describe('PlaywrightEngine external backend contract (#517)', () => {
       context: vi.fn(),
     };
     const targetSession = {
-      send: vi.fn().mockImplementation((method: string) =>
-        method === 'Target.getTargets'
-          ? Promise.resolve({
-              targetInfos: [
-                { targetId: 'wc-1', type: 'page', title: '', url: 'https://example.com/', attached: true },
-              ],
-            })
-          : Promise.resolve({}),
-      ),
+      send: vi.fn().mockImplementation((method: string) => {
+        if (method === 'Target.getTargets') {
+          return Promise.resolve({
+            targetInfos: [
+              { targetId: 'wc-1', type: 'page', title: '', url: 'https://example.com/', attached: true },
+            ],
+          });
+        }
+        if (method === 'Target.getTargetInfo') {
+          return Promise.resolve({ targetInfo: { targetId: 'wc-1' } });
+        }
+        return Promise.resolve({});
+      }),
       detach: vi.fn().mockResolvedValue(undefined),
     };
     const ctx = {
@@ -1231,7 +1293,7 @@ describe('PlaywrightEngine external backend contract (#517)', () => {
     const engine = PlaywrightEngine.getInstance();
     scope(engine).setWorkspaceIdResolver(async () => 'ws-A');
 
-    const page = await engine.getPage();
+    const page = await priv(engine).getPage();
     expect(page).toBe(webviewPage);
     // No auto-open — the live builtin target was used.
     expect(mockSendRpc.mock.calls.filter((c) => c[0] === 'browser.open')).toHaveLength(0);

--- a/src/mcp/playwright/__tests__/PlaywrightEngine.test.ts
+++ b/src/mcp/playwright/__tests__/PlaywrightEngine.test.ts
@@ -372,7 +372,7 @@ describe('PlaywrightEngine runtime shell-URL handling (B)', () => {
     expect(priv(engine).shellUrl).toBe(shellUrl);
   });
 
-  it('strict surface targeting (#517): explicit surfaceId never falls back to another guest', async () => {
+  it('strict surface targeting rejects a legacy main that returns a foreign or untagged explicit target', async () => {
     const shellUrl = 'file:///app/.vite/renderer/main_window/index.html';
     const otherGuest: FakePage = {
       url: vi.fn().mockReturnValue('https://other-guest.example/'),
@@ -390,13 +390,21 @@ describe('PlaywrightEngine runtime shell-URL handling (B)', () => {
       close: vi.fn().mockResolvedValue(undefined),
     };
     mockConnectOverCDP.mockResolvedValue(browser);
-    // cdp.info knows about NO target for the requested surface — the pinned
-    // lookup fails, and the "first non-shell page" fallback must NOT hand
-    // back the other guest (that would drive surface B while the caller — and
-    // the automation lease — point at surface A).
+    // Simulate a legacy main that ignores the workspaceId filter and returns
+    // the explicitly requested target from another workspace. The engine must
+    // verify the ownership tag itself rather than trust the requested id.
+    let targetWorkspaceId: string | undefined = 'ws-other';
     mockSendRpc.mockImplementation((method: string) => {
       if (method === 'browser.cdp.info') {
-        return Promise.resolve({ cdpPort: 9222, shellUrl, targets: [] });
+        return Promise.resolve({
+          cdpPort: 9222,
+          shellUrl,
+          targets: [{
+            surfaceId: 'surface-pinned',
+            targetId: 'wc-foreign',
+            ...(targetWorkspaceId && { workspaceId: targetWorkspaceId }),
+          }],
+        });
       }
       return Promise.resolve({});
     });
@@ -408,8 +416,17 @@ describe('PlaywrightEngine runtime shell-URL handling (B)', () => {
     // the exact same id to getPage (#695). No engine resolver is wired here:
     // this proves the pre-resolved identity is sufficient and is forwarded to
     // every discovery request for the explicit surface.
-    const page = await engine.getPage('surface-pinned', 'ws-caller');
-    expect(page).toBeNull();
+    const scope = { workspaceId: 'ws-caller', surfaceId: 'surface-pinned' };
+    await expect(engine.getPageForScope(scope)).rejects.toThrow(
+      /requested browser surface is not owned by the calling workspace/,
+    );
+
+    // An untagged legacy response is equally unprovable and must also refuse.
+    targetWorkspaceId = undefined;
+    await expect(engine.getPageForScope(scope)).rejects.toThrow(
+      /does not tag the requested browser target with a workspace/,
+    );
+
     const infoCalls = mockSendRpc.mock.calls.filter(([method]) => method === 'browser.cdp.info');
     expect(infoCalls.length).toBeGreaterThan(0);
     expect(infoCalls.every(([, params]) =>
@@ -644,6 +661,57 @@ describe('PlaywrightEngine auto-open workspace routing (#190)', () => {
 
     await expect(engine.getPage()).resolves.toBe(webviewPage);
     expect(mockSendRpc).toHaveBeenCalledWith('browser.open', { workspaceId: 'ws-caller-1' });
+  }, 15_000);
+
+  it('auto-open refuses a target that is explicitly tagged to another workspace', async () => {
+    const shellUrl = 'file:///app/.vite/renderer/main_window/index.html';
+    let opened = false;
+
+    const session = {
+      send: vi.fn().mockImplementation((method: string) =>
+        method === 'Target.getTargets'
+          ? Promise.resolve({
+              targetInfos: opened
+                ? [{ targetId: 'wc-foreign', type: 'page', title: '', url: 'https://example.com/', attached: true }]
+                : [],
+            })
+          : Promise.resolve({}),
+      ),
+      detach: vi.fn().mockResolvedValue(undefined),
+    };
+    const context = {
+      pages: vi.fn().mockReturnValue([]),
+      newCDPSession: vi.fn().mockResolvedValue(session),
+    };
+    mockConnectOverCDP.mockResolvedValue({
+      isConnected: vi.fn().mockReturnValue(true),
+      newBrowserCDPSession: vi.fn().mockResolvedValue(session),
+      contexts: vi.fn().mockReturnValue([context]),
+      close: vi.fn().mockResolvedValue(undefined),
+    });
+    mockSendRpc.mockImplementation((method: string) => {
+      if (method === 'browser.cdp.info') {
+        return Promise.resolve({
+          cdpPort: 9222,
+          shellUrl,
+          targets: opened
+            ? [{ surfaceId: 'surf-new', targetId: 'wc-foreign', workspaceId: 'ws-other' }]
+            : [],
+        });
+      }
+      if (method === 'browser.open') {
+        opened = true;
+        return Promise.resolve({ ok: true, surfaceId: 'surf-new' });
+      }
+      return Promise.resolve({});
+    });
+
+    const engine = PlaywrightEngine.getInstance();
+    autoOpen(engine).setWorkspaceIdResolver(async () => 'ws-caller-1');
+
+    await expect(engine.getPage()).rejects.toThrow(
+      /requested browser surface is not owned by the calling workspace/,
+    );
   }, 15_000);
 });
 

--- a/src/mcp/playwright/__tests__/PlaywrightEngine.test.ts
+++ b/src/mcp/playwright/__tests__/PlaywrightEngine.test.ts
@@ -404,8 +404,17 @@ describe('PlaywrightEngine runtime shell-URL handling (B)', () => {
     const engine = PlaywrightEngine.getInstance();
     await engine.connect(9222);
 
-    const page = await engine.getPage('surface-pinned');
+    // The tool layer resolves identity before acquiring its lease and supplies
+    // the exact same id to getPage (#695). No engine resolver is wired here:
+    // this proves the pre-resolved identity is sufficient and is forwarded to
+    // every discovery request for the explicit surface.
+    const page = await engine.getPage('surface-pinned', 'ws-caller');
     expect(page).toBeNull();
+    const infoCalls = mockSendRpc.mock.calls.filter(([method]) => method === 'browser.cdp.info');
+    expect(infoCalls.length).toBeGreaterThan(0);
+    expect(infoCalls.every(([, params]) =>
+      (params as { workspaceId?: string } | undefined)?.workspaceId === 'ws-caller'
+    )).toBe(true);
   }, 20_000);
 });
 

--- a/src/mcp/playwright/__tests__/automationLease.test.ts
+++ b/src/mcp/playwright/__tests__/automationLease.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSendRpc } = vi.hoisted(() => ({ mockSendRpc: vi.fn() }));
+vi.mock('../../wmux-client', () => ({
+  sendRpc: (...args: unknown[]) => mockSendRpc(...args),
+}));
+
+import { withAutomationLease } from '../automationLease';
+
+const deps = { resolveWorkspaceId: vi.fn(async () => 'ws-test') };
+
+beforeEach(() => {
+  mockSendRpc.mockReset();
+  deps.resolveWorkspaceId.mockReset();
+  deps.resolveWorkspaceId.mockResolvedValue('ws-test');
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('automation lease workspace scope', () => {
+  it('resolves identity once and reuses it for acquire and the tool body', async () => {
+    mockSendRpc.mockImplementation((method: string) =>
+      Promise.resolve(method === 'browser.lease.acquire' ? { token: 'lease-1' } : {}),
+    );
+    const body = vi.fn(async () => 'done');
+
+    await expect(withAutomationLease(deps, 'surface-1', body)).resolves.toBe('done');
+
+    expect(deps.resolveWorkspaceId).toHaveBeenCalledTimes(1);
+    expect(body).toHaveBeenCalledWith({ workspaceId: 'ws-test', surfaceId: 'surface-1' });
+    expect(mockSendRpc.mock.calls).toEqual([
+      ['browser.lease.acquire', { workspaceId: 'ws-test', surfaceId: 'surface-1' }],
+      ['browser.lease.release', { token: 'lease-1' }],
+    ]);
+  });
+
+  it('fails closed before lease or body execution when identity is unavailable', async () => {
+    deps.resolveWorkspaceId.mockRejectedValue(new Error('Workspace identity unknown.'));
+    const body = vi.fn(async () => 'must not run');
+
+    await expect(withAutomationLease(deps, undefined, body)).rejects.toThrow(
+      'Workspace identity unknown.',
+    );
+
+    expect(mockSendRpc).not.toHaveBeenCalled();
+    expect(body).not.toHaveBeenCalled();
+  });
+
+  it('includes the same workspaceId in every late-acquire retry', async () => {
+    vi.useFakeTimers();
+    let acquireCount = 0;
+    mockSendRpc.mockImplementation((method: string) => {
+      if (method === 'browser.lease.acquire') {
+        acquireCount++;
+        return Promise.resolve({ token: acquireCount === 1 ? null : 'lease-late' });
+      }
+      return Promise.resolve({});
+    });
+
+    let finishBody!: () => void;
+    const bodyDone = new Promise<void>((resolve) => { finishBody = resolve; });
+    const operation = withAutomationLease(deps, undefined, async () => {
+      await bodyDone;
+      return 'done';
+    });
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(mockSendRpc.mock.calls.filter(([method]) => method === 'browser.lease.acquire')).toEqual([
+      ['browser.lease.acquire', { workspaceId: 'ws-test' }],
+      ['browser.lease.acquire', { workspaceId: 'ws-test' }],
+    ]);
+
+    finishBody();
+    await expect(operation).resolves.toBe('done');
+    expect(mockSendRpc).toHaveBeenCalledWith('browser.lease.release', { token: 'lease-late' });
+  });
+});

--- a/src/mcp/playwright/__tests__/interaction.fallback.test.ts
+++ b/src/mcp/playwright/__tests__/interaction.fallback.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSendRpc, getPage } = vi.hoisted(() => ({
+  mockSendRpc: vi.fn(),
+  getPage: vi.fn(),
+}));
+
+vi.mock('../../wmux-client', () => ({
+  sendRpc: (method: string, ...args: unknown[]) =>
+    method.startsWith('browser.lease.')
+      ? Promise.resolve({ token: null })
+      : mockSendRpc(method, ...args),
+}));
+
+vi.mock('../PlaywrightEngine', () => ({
+  PlaywrightEngine: { getInstance: () => ({ getPageForScope: getPage }) },
+}));
+
+import { registerInteractionTools } from '../tools/interaction';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: { type: 'text'; text: string }[];
+  isError?: boolean;
+}>;
+
+const browserToolDeps = { resolveWorkspaceId: vi.fn(async () => 'ws-test') };
+
+function collectTools(): Map<string, ToolHandler> {
+  const tools = new Map<string, ToolHandler>();
+  const server = {
+    tool: (name: string, _desc: string, _schema: unknown, handler: ToolHandler) => {
+      tools.set(name, handler);
+    },
+  };
+  registerInteractionTools(server as never, browserToolDeps);
+  return tools;
+}
+
+const fill = collectTools().get('browser_fill');
+if (!fill) throw new Error('browser_fill failed to register');
+
+beforeEach(() => {
+  browserToolDeps.resolveWorkspaceId.mockClear();
+  mockSendRpc.mockReset();
+  mockSendRpc.mockResolvedValue({});
+  getPage.mockReset();
+  getPage.mockResolvedValue(null);
+});
+
+describe('browser_fill RPC fallback workspace scope', () => {
+  it('scopes click, select-all evaluation, and typing to the same target', async () => {
+    const result = await fill({
+      fields: [{ ref: 'field-1', value: 'new value' }],
+      surfaceId: 'surface-1',
+    });
+
+    expect(getPage).toHaveBeenCalledWith({
+      workspaceId: 'ws-test',
+      surfaceId: 'surface-1',
+    });
+    expect(browserToolDeps.resolveWorkspaceId).toHaveBeenCalledTimes(1);
+    expect(mockSendRpc.mock.calls).toEqual([
+      ['browser.click.cdp', {
+        selector: '[data-wmux-ref="field-1"]',
+        workspaceId: 'ws-test',
+        surfaceId: 'surface-1',
+      }],
+      ['browser.evaluate', {
+        expression: "document.execCommand('selectAll')",
+        workspaceId: 'ws-test',
+        surfaceId: 'surface-1',
+      }],
+      ['browser.type.cdp', {
+        text: 'new value',
+        workspaceId: 'ws-test',
+        surfaceId: 'surface-1',
+      }],
+    ]);
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toBe('Filled 1/1 field(s).');
+  });
+});

--- a/src/mcp/playwright/__tests__/markdown-extractor.dom.test.ts
+++ b/src/mcp/playwright/__tests__/markdown-extractor.dom.test.ts
@@ -54,7 +54,7 @@ describe('extractStructuredData — DOM field mapping (#110)', () => {
   it('HN-style layout table maps title->link text and url->href (not duplicated subtext)', async () => {
     document.body.innerHTML = hnLikeHtml();
 
-    const out = (await extractStructuredData(directPage, undefined, 'front page stories', {
+    const out = (await extractStructuredData(directPage, { workspaceId: 'ws-test' }, 'front page stories', {
       title: 'string',
       url: 'string',
     })) as Array<{ title: unknown; url: unknown }>;
@@ -84,7 +84,7 @@ describe('extractStructuredData — DOM field mapping (#110)', () => {
         <tr><td>Gadget</td><td>$20</td><td><a href="https://shop.test/gadget">buy</a></td></tr>
       </table>`;
 
-    const out = (await extractStructuredData(directPage, undefined, 'products', {
+    const out = (await extractStructuredData(directPage, { workspaceId: 'ws-test' }, 'products', {
       title: 'string',
       price: 'string',
       url: 'string',
@@ -107,7 +107,7 @@ describe('extractStructuredData — DOM field mapping (#110)', () => {
         <tr><td>2</td><td>Beta</td><td><a href="https://x.test/b">b</a></td></tr>
       </table>`;
 
-    const out = (await extractStructuredData(directPage, undefined, 'rows', {
+    const out = (await extractStructuredData(directPage, { workspaceId: 'ws-test' }, 'rows', {
       name: 'string',
       link: 'string',
     })) as Array<{ name: unknown; link: unknown }>;
@@ -128,7 +128,7 @@ describe('extractStructuredData — DOM field mapping (#110)', () => {
         <div class="card"><h3>Card Three</h3><span class="price">$7</span><a href="https://p.test/3">view</a></div>
       </div>`;
 
-    const out = (await extractStructuredData(directPage, undefined, 'cards', {
+    const out = (await extractStructuredData(directPage, { workspaceId: 'ws-test' }, 'cards', {
       title: 'string',
       price: 'string',
       url: 'string',
@@ -151,7 +151,7 @@ describe('extractStructuredData — DOM field mapping (#110)', () => {
         <div class="item"><span class="name">Gadget</span><a href="https://shop.test/g">Buy</a></div>
         <div class="item"><span class="name">Gizmo</span><a href="https://shop.test/z">Buy</a></div>
       </div>`;
-    const out = (await extractStructuredData(directPage, undefined, 'items', {
+    const out = (await extractStructuredData(directPage, { workspaceId: 'ws-test' }, 'items', {
       name: 'string',
       url: 'string',
     })) as Array<{ name: unknown; url: unknown }>;

--- a/src/mcp/playwright/__tests__/markdown-extractor.test.ts
+++ b/src/mcp/playwright/__tests__/markdown-extractor.test.ts
@@ -97,7 +97,7 @@ describe('extractStructuredData', () => {
 
   it('returns [] for empty fields without touching the page', async () => {
     const page = { evaluate: vi.fn() };
-    const out = await extractStructuredData(page as never, undefined, 'goal', {});
+    const out = await extractStructuredData(page as never, { workspaceId: 'ws-test' }, 'goal', {});
     expect(out).toEqual([]);
     expect(page.evaluate).not.toHaveBeenCalled();
   });
@@ -105,7 +105,7 @@ describe('extractStructuredData', () => {
   it('returns table data (strategy 1) from the native page path', async () => {
     const rows = [{ name: 'a', price: '1' }];
     const page = { evaluate: vi.fn().mockResolvedValueOnce(rows) };
-    const out = await extractStructuredData(page as never, undefined, 'goal', {
+    const out = await extractStructuredData(page as never, { workspaceId: 'ws-test' }, 'goal', {
       name: 'string',
       price: 'number',
     });
@@ -122,17 +122,23 @@ describe('extractStructuredData', () => {
         .mockResolvedValueOnce([]) // lists
         .mockResolvedValueOnce(repeated), // repeated
     };
-    const out = await extractStructuredData(page as never, undefined, 'goal', { title: 'string' });
+    const out = await extractStructuredData(page as never, { workspaceId: 'ws-test' }, 'goal', { title: 'string' });
     expect(out).toEqual(repeated);
     expect(page.evaluate).toHaveBeenCalledTimes(3);
   });
 
   it('uses the RPC fallback when no page is available', async () => {
     mockSendRpc.mockResolvedValueOnce({ value: [{ name: 'rpc' }] });
-    const out = await extractStructuredData(null, 'surf', 'goal', { name: 'string' });
+    const out = await extractStructuredData(
+      null,
+      { workspaceId: 'ws-test', surfaceId: 'surf' },
+      'goal',
+      { name: 'string' },
+    );
     expect(out).toEqual([{ name: 'rpc' }]);
     const [method, params] = mockSendRpc.mock.calls[0];
     expect(method).toBe('browser.evaluate');
+    expect(params.workspaceId).toBe('ws-test');
     expect(params.surfaceId).toBe('surf');
     expect(params.expression).toContain('querySelectorAll'); // stringified table fn
   });

--- a/src/mcp/playwright/__tests__/navigation.tabs.test.ts
+++ b/src/mcp/playwright/__tests__/navigation.tabs.test.ts
@@ -9,8 +9,8 @@ vi.mock('../../wmux-client', () => ({
 import {
   BROWSER_TABS_SHAPE,
   registerNavigationTools,
-  type NavigationToolDeps,
 } from '../tools/navigation';
+import type { BrowserToolDeps } from '../browserScope';
 
 type ToolResult = {
   content: { type: 'text'; text: string }[];
@@ -18,7 +18,7 @@ type ToolResult = {
 };
 type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
 
-function collectTools(deps: NavigationToolDeps): Map<string, ToolHandler> {
+function collectTools(deps: BrowserToolDeps): Map<string, ToolHandler> {
   const tools = new Map<string, ToolHandler>();
   const server = {
     tool: (name: string, _description: string, _schema: unknown, handler: ToolHandler) => {
@@ -29,16 +29,74 @@ function collectTools(deps: NavigationToolDeps): Map<string, ToolHandler> {
   return tools;
 }
 
-describe('browser_tabs MCP workspace contract', () => {
+describe('browser navigation MCP workspace contract', () => {
   const resolveWorkspaceId = vi.fn(async () => 'ws-caller');
   let browserTabs: ToolHandler;
+  let browserNavigate: ToolHandler;
+  let browserNavigateBack: ToolHandler;
 
   beforeEach(() => {
     vi.clearAllMocks();
     resolveWorkspaceId.mockResolvedValue('ws-caller');
-    const handler = collectTools({ resolveWorkspaceId }).get('browser_tabs');
-    if (!handler) throw new Error('browser_tabs was not registered');
-    browserTabs = handler;
+    const tools = collectTools({ resolveWorkspaceId });
+    const tabsHandler = tools.get('browser_tabs');
+    const navigateHandler = tools.get('browser_navigate');
+    const backHandler = tools.get('browser_navigate_back');
+    if (!tabsHandler || !navigateHandler || !backHandler) {
+      throw new Error('browser navigation tools were not registered');
+    }
+    browserTabs = tabsHandler;
+    browserNavigate = navigateHandler;
+    browserNavigateBack = backHandler;
+  });
+
+  it('routes navigate through the calling workspace', async () => {
+    mockSendRpc.mockResolvedValue({ ok: true });
+
+    const result = await browserNavigate({
+      url: 'https://example.com/',
+      surfaceId: 'surface-a',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(resolveWorkspaceId).toHaveBeenCalledTimes(1);
+    expect(mockSendRpc).toHaveBeenCalledWith('browser.navigate', {
+      url: 'https://example.com/',
+      workspaceId: 'ws-caller',
+      surfaceId: 'surface-a',
+    });
+  });
+
+  it('reuses one workspace identity for goBack and its URL read', async () => {
+    mockSendRpc.mockImplementation((method: string) =>
+      Promise.resolve(method === 'browser.evaluate' ? { value: 'https://example.com/previous' } : {}),
+    );
+
+    const result = await browserNavigateBack({ surfaceId: 'surface-a' });
+
+    expect(result.isError).toBeUndefined();
+    expect(resolveWorkspaceId).toHaveBeenCalledTimes(1);
+    expect(mockSendRpc.mock.calls).toEqual([
+      ['browser.goBack', { workspaceId: 'ws-caller', surfaceId: 'surface-a' }],
+      [
+        'browser.evaluate',
+        {
+          expression: 'location.href',
+          workspaceId: 'ws-caller',
+          surfaceId: 'surface-a',
+        },
+      ],
+    ]);
+  });
+
+  it('does not issue a navigation RPC when workspace identity fails', async () => {
+    resolveWorkspaceId.mockRejectedValue(new Error('Workspace identity unknown.'));
+
+    const result = await browserNavigate({ url: 'https://example.com/' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Workspace identity unknown.');
+    expect(mockSendRpc).not.toHaveBeenCalled();
   });
 
   it('lists through the workspace-exact RPC and returns JSON without the internal ok flag', async () => {

--- a/src/mcp/playwright/__tests__/page-eval.test.ts
+++ b/src/mcp/playwright/__tests__/page-eval.test.ts
@@ -61,18 +61,18 @@ describe('page-eval', () => {
   describe('resolveEvaluator', () => {
     it('returns a page-backed evaluator when getPage resolves a page', async () => {
       const page = { evaluate: vi.fn().mockResolvedValue('via-page') };
-      const engine = { getPage: vi.fn().mockResolvedValue(page) };
+      const engine = { getPageForScope: vi.fn().mockResolvedValue(page) };
       const evaluate = await resolveEvaluator(engine as never, surfaceScope);
       const out = await evaluate('x');
       expect(page.evaluate).toHaveBeenCalledWith('x');
-      expect(engine.getPage).toHaveBeenCalledWith('surface-1', 'ws-test');
+      expect(engine.getPageForScope).toHaveBeenCalledWith(surfaceScope);
       expect(out).toBe('via-page');
       expect(mockSendRpc).not.toHaveBeenCalled();
     });
 
     it('returns an RPC-backed evaluator when getPage resolves null', async () => {
       mockSendRpc.mockResolvedValue({ value: 'via-rpc' });
-      const engine = { getPage: vi.fn().mockResolvedValue(null) };
+      const engine = { getPageForScope: vi.fn().mockResolvedValue(null) };
       const evaluate = await resolveEvaluator(engine as never, surfaceScope);
       const out = await evaluate('x');
       expect(mockSendRpc).toHaveBeenCalledWith('browser.evaluate', {
@@ -80,16 +80,29 @@ describe('page-eval', () => {
         workspaceId: 'ws-test',
         surfaceId: 'surface-1',
       });
-      expect(engine.getPage).toHaveBeenCalledWith('surface-1', 'ws-test');
+      expect(engine.getPageForScope).toHaveBeenCalledWith(surfaceScope);
       expect(out).toBe('via-rpc');
     });
 
     it('falls back to RPC when getPage rejects', async () => {
       mockSendRpc.mockResolvedValue({ value: 'via-rpc' });
-      const engine = { getPage: vi.fn().mockRejectedValue(new Error('boom')) };
+      const engine = { getPageForScope: vi.fn().mockRejectedValue(new Error('boom')) };
       const evaluate = await resolveEvaluator(engine as never, workspaceScope);
       const out = await evaluate('x');
       expect(out).toBe('via-rpc');
+    });
+
+    it('does not fall back when page selection itself cannot be workspace-scoped', async () => {
+      const engine = {
+        getPageForScope: vi.fn().mockRejectedValue(
+          new Error('WORKSPACE_SCOPE_UNRESOLVED: legacy main cannot prove ownership'),
+        ),
+      };
+
+      await expect(resolveEvaluator(engine as never, workspaceScope)).rejects.toThrow(
+        'WORKSPACE_SCOPE_UNRESOLVED',
+      );
+      expect(mockSendRpc).not.toHaveBeenCalled();
     });
   });
 

--- a/src/mcp/playwright/__tests__/page-eval.test.ts
+++ b/src/mcp/playwright/__tests__/page-eval.test.ts
@@ -5,6 +5,7 @@ import {
   resolveEvaluator,
   evalFunctionOrRpc,
 } from '../page-eval';
+import { WorkspaceScopeUnresolvedError } from '../browserScope';
 
 // Mock the RPC transport. Path is relative to THIS test file:
 // __tests__/ -> playwright/ -> mcp/, so ../../wmux-client === src/mcp/wmux-client.
@@ -95,7 +96,7 @@ describe('page-eval', () => {
     it('does not fall back when page selection itself cannot be workspace-scoped', async () => {
       const engine = {
         getPageForScope: vi.fn().mockRejectedValue(
-          new Error('WORKSPACE_SCOPE_UNRESOLVED: legacy main cannot prove ownership'),
+          new WorkspaceScopeUnresolvedError('legacy main cannot prove ownership'),
         ),
       };
 

--- a/src/mcp/playwright/__tests__/page-eval.test.ts
+++ b/src/mcp/playwright/__tests__/page-eval.test.ts
@@ -17,6 +17,9 @@ import { sendRpc } from '../../wmux-client';
 const mockSendRpc = sendRpc as unknown as ReturnType<typeof vi.fn>;
 
 describe('page-eval', () => {
+  const workspaceScope = { workspaceId: 'ws-test' };
+  const surfaceScope = { workspaceId: 'ws-test', surfaceId: 'surface-1' };
+
   beforeEach(() => {
     mockSendRpc.mockReset();
   });
@@ -34,21 +37,23 @@ describe('page-eval', () => {
   describe('rpcEvaluator', () => {
     it('calls browser.evaluate and unwraps .value', async () => {
       mockSendRpc.mockResolvedValue({ value: 42 });
-      const evaluate = rpcEvaluator('surface-1');
+      const evaluate = rpcEvaluator(surfaceScope);
       const out = await evaluate('expr');
       expect(mockSendRpc).toHaveBeenCalledWith('browser.evaluate', {
         expression: 'expr',
+        workspaceId: 'ws-test',
         surfaceId: 'surface-1',
       });
       expect(out).toBe(42);
     });
 
-    it('omits surfaceId when not provided', async () => {
+    it('always includes workspaceId and omits surfaceId when not provided', async () => {
       mockSendRpc.mockResolvedValue({ value: null });
-      const evaluate = rpcEvaluator();
+      const evaluate = rpcEvaluator(workspaceScope);
       await evaluate('expr');
       expect(mockSendRpc).toHaveBeenCalledWith('browser.evaluate', {
         expression: 'expr',
+        workspaceId: 'ws-test',
       });
     });
   });
@@ -57,9 +62,10 @@ describe('page-eval', () => {
     it('returns a page-backed evaluator when getPage resolves a page', async () => {
       const page = { evaluate: vi.fn().mockResolvedValue('via-page') };
       const engine = { getPage: vi.fn().mockResolvedValue(page) };
-      const evaluate = await resolveEvaluator(engine as never, 's');
+      const evaluate = await resolveEvaluator(engine as never, surfaceScope);
       const out = await evaluate('x');
       expect(page.evaluate).toHaveBeenCalledWith('x');
+      expect(engine.getPage).toHaveBeenCalledWith('surface-1', 'ws-test');
       expect(out).toBe('via-page');
       expect(mockSendRpc).not.toHaveBeenCalled();
     });
@@ -67,19 +73,21 @@ describe('page-eval', () => {
     it('returns an RPC-backed evaluator when getPage resolves null', async () => {
       mockSendRpc.mockResolvedValue({ value: 'via-rpc' });
       const engine = { getPage: vi.fn().mockResolvedValue(null) };
-      const evaluate = await resolveEvaluator(engine as never, 's');
+      const evaluate = await resolveEvaluator(engine as never, surfaceScope);
       const out = await evaluate('x');
       expect(mockSendRpc).toHaveBeenCalledWith('browser.evaluate', {
         expression: 'x',
-        surfaceId: 's',
+        workspaceId: 'ws-test',
+        surfaceId: 'surface-1',
       });
+      expect(engine.getPage).toHaveBeenCalledWith('surface-1', 'ws-test');
       expect(out).toBe('via-rpc');
     });
 
     it('falls back to RPC when getPage rejects', async () => {
       mockSendRpc.mockResolvedValue({ value: 'via-rpc' });
       const engine = { getPage: vi.fn().mockRejectedValue(new Error('boom')) };
-      const evaluate = await resolveEvaluator(engine as never);
+      const evaluate = await resolveEvaluator(engine as never, workspaceScope);
       const out = await evaluate('x');
       expect(out).toBe('via-rpc');
     });
@@ -90,7 +98,7 @@ describe('page-eval', () => {
 
     it('runs the function natively on the page when one exists', async () => {
       const page = { evaluate: vi.fn().mockResolvedValue(20) };
-      const out = await evalFunctionOrRpc(page as never, fn, { n: 10 }, 's');
+      const out = await evalFunctionOrRpc(page as never, fn, { n: 10 }, surfaceScope);
       // native page.evaluate(fn, arg) — dev path unchanged
       expect(page.evaluate).toHaveBeenCalledTimes(1);
       expect(page.evaluate.mock.calls[0][1]).toEqual({ n: 10 });
@@ -100,14 +108,15 @@ describe('page-eval', () => {
 
     it('stringifies the function for RPC when no page exists', async () => {
       mockSendRpc.mockResolvedValue({ value: 20 });
-      const out = await evalFunctionOrRpc(null, fn, { n: 10 }, 's');
+      const out = await evalFunctionOrRpc(null, fn, { n: 10 }, surfaceScope);
       expect(mockSendRpc).toHaveBeenCalledTimes(1);
       const [method, params] = mockSendRpc.mock.calls[0];
       expect(method).toBe('browser.evaluate');
       // expression = (fn.toString())(JSON.stringify(arg))
       expect(params.expression).toContain('n * 2');
       expect(params.expression).toContain('{"n":10}');
-      expect(params.surfaceId).toBe('s');
+      expect(params.workspaceId).toBe('ws-test');
+      expect(params.surfaceId).toBe('surface-1');
       expect(out).toBe(20);
     });
 
@@ -118,7 +127,7 @@ describe('page-eval', () => {
         null,
         evilFn,
         { fieldNames: ['"); globalThis.hacked = 1; ("'] },
-        undefined,
+        workspaceScope,
       );
       const expr = mockSendRpc.mock.calls[0][1].expression as string;
       // The dangerous payload is a JSON string literal, never bare code.

--- a/src/mcp/playwright/__tests__/state.fallback.test.ts
+++ b/src/mcp/playwright/__tests__/state.fallback.test.ts
@@ -28,6 +28,8 @@ vi.mock('../PlaywrightEngine', () => ({
 
 import { registerStateTools } from '../tools/state';
 
+const browserToolDeps = { resolveWorkspaceId: vi.fn(async () => 'ws-test') };
+
 type ToolHandler = (args: Record<string, unknown>) => Promise<{
   content: { type: 'text'; text: string }[];
   isError?: boolean;
@@ -41,7 +43,7 @@ function collectTools(): Map<string, ToolHandler> {
       tools.set(name, handler);
     },
   };
-  registerStateTools(server as never);
+  registerStateTools(server as never, browserToolDeps);
   return tools;
 }
 
@@ -52,6 +54,8 @@ const emulate = tools.get('browser_emulate')!;
 const resize = tools.get('browser_resize')!;
 
 beforeEach(() => {
+  browserToolDeps.resolveWorkspaceId.mockClear();
+  browserToolDeps.resolveWorkspaceId.mockResolvedValue('ws-test');
   mockSendRpc.mockReset();
   getPage.mockReset();
   getPage.mockResolvedValue(null); // default: packaged (no Playwright Page)
@@ -66,8 +70,11 @@ describe('browser_cookies RPC fallback', () => {
     expect(mockSendRpc).toHaveBeenCalledWith('browser.cookies', {
       action: 'get',
       urls: [],
+      workspaceId: 'ws-test',
       surfaceId: 's1',
     });
+    expect(getPage).toHaveBeenCalledWith('s1', 'ws-test');
+    expect(browserToolDeps.resolveWorkspaceId).toHaveBeenCalledTimes(1);
     expect(res.isError).toBeUndefined();
     expect(res.content[0].text).toContain('"value": "abc"');
   });
@@ -78,6 +85,7 @@ describe('browser_cookies RPC fallback', () => {
     expect(mockSendRpc).toHaveBeenCalledWith('browser.cookies', {
       action: 'get',
       urls: ['https://example.com'],
+      workspaceId: 'ws-test',
     });
   });
 
@@ -107,7 +115,10 @@ describe('browser_cookies RPC fallback', () => {
   it('clear routes to browser.cookies', async () => {
     mockSendRpc.mockResolvedValue({ ok: true });
     const res = await cookies({ action: 'clear' });
-    expect(mockSendRpc).toHaveBeenCalledWith('browser.cookies', { action: 'clear' });
+    expect(mockSendRpc).toHaveBeenCalledWith('browser.cookies', {
+      action: 'clear',
+      workspaceId: 'ws-test',
+    });
     expect(res.content[0].text).toContain('Cookies cleared.');
   });
 
@@ -130,6 +141,7 @@ describe('browser_storage RPC fallback', () => {
     // First call resolves the URL, second runs the stringified reader.
     expect(mockSendRpc).toHaveBeenCalledWith('browser.evaluate', {
       expression: 'location.href',
+      workspaceId: 'ws-test',
       surfaceId: 's1',
     });
     expect(res.content[0].text).toContain('"token": "xyz"');
@@ -159,6 +171,7 @@ describe('browser_resize RPC fallback', () => {
     expect(mockSendRpc).toHaveBeenCalledWith('browser.resize', {
       width: 800,
       height: 600,
+      workspaceId: 'ws-test',
       surfaceId: 's1',
     });
     expect(res.content[0].text).toContain('800x600');
@@ -179,6 +192,7 @@ describe('browser_emulate RPC fallback', () => {
     expect(params.offline).toBe(true);
     expect(params.geo).toEqual({ latitude: 1, longitude: 2 });
     expect(params.credentialsRequested).toBe(true);
+    expect(params.workspaceId).toBe('ws-test');
     expect(params.surfaceId).toBe('s1');
     expect(res.content[0].text).toContain('offline=true');
   });

--- a/src/mcp/playwright/__tests__/state.fallback.test.ts
+++ b/src/mcp/playwright/__tests__/state.fallback.test.ts
@@ -23,7 +23,7 @@ vi.mock('../../wmux-client', () => ({
 // Mock PlaywrightEngine so getPage() is controllable per test.
 const getPage = vi.fn();
 vi.mock('../PlaywrightEngine', () => ({
-  PlaywrightEngine: { getInstance: () => ({ getPage }) },
+  PlaywrightEngine: { getInstance: () => ({ getPageForScope: getPage }) },
 }));
 
 import { registerStateTools } from '../tools/state';
@@ -73,7 +73,7 @@ describe('browser_cookies RPC fallback', () => {
       workspaceId: 'ws-test',
       surfaceId: 's1',
     });
-    expect(getPage).toHaveBeenCalledWith('s1', 'ws-test');
+    expect(getPage).toHaveBeenCalledWith({ workspaceId: 'ws-test', surfaceId: 's1' });
     expect(browserToolDeps.resolveWorkspaceId).toHaveBeenCalledTimes(1);
     expect(res.isError).toBeUndefined();
     expect(res.content[0].text).toContain('"value": "abc"');

--- a/src/mcp/playwright/__tests__/wait.fallback.test.ts
+++ b/src/mcp/playwright/__tests__/wait.fallback.test.ts
@@ -13,7 +13,7 @@ const { mockSendRpc, mockLeaseRpc, getPage, getInstance } = vi.hoisted(() => {
     mockSendRpc: vi.fn(),
     mockLeaseRpc: vi.fn(),
     getPage,
-    getInstance: vi.fn(() => ({ getPage })),
+    getInstance: vi.fn(() => ({ getPageForScope: getPage })),
   };
 });
 vi.mock('../../wmux-client', () => ({
@@ -260,7 +260,7 @@ describe('browser_wait RPC fallback', () => {
     getPage.mockResolvedValue({ waitForSelector });
     const res = await wait({ selector: '#app' });
     expect(waitForSelector).toHaveBeenCalledWith('#app', { timeout: 30000 });
-    expect(getPage).toHaveBeenCalledWith(undefined, 'ws-test');
+    expect(getPage).toHaveBeenCalledWith({ workspaceId: 'ws-test' });
     expect(mockSendRpc).not.toHaveBeenCalled();
     expect(res.content[0].text).toContain('selector "#app" found');
   });

--- a/src/mcp/playwright/__tests__/wait.fallback.test.ts
+++ b/src/mcp/playwright/__tests__/wait.fallback.test.ts
@@ -42,6 +42,8 @@ type ToolHandler = (args: Record<string, unknown>) => Promise<{
   isError?: boolean;
 }>;
 
+const browserToolDeps = { resolveWorkspaceId: vi.fn(async () => 'ws-test') };
+
 function collectTools(profile: WmuxToolProfile = 'full'): Map<string, ToolHandler> {
   const tools = new Map<string, ToolHandler>();
   const server = {
@@ -49,7 +51,7 @@ function collectTools(profile: WmuxToolProfile = 'full'): Map<string, ToolHandle
       tools.set(name, handler);
     },
   };
-  registerWaitTools(server as never, {
+  registerWaitTools(server as never, browserToolDeps, {
     profile,
     context: { principal: { kind: 'unattributed' } },
   });
@@ -71,6 +73,7 @@ function evalRouter(map: Record<string, unknown>, fallback: unknown = false) {
 }
 
 beforeEach(() => {
+  browserToolDeps.resolveWorkspaceId.mockClear();
   mockSendRpc.mockReset();
   mockLeaseRpc.mockReset();
   mockLeaseRpc.mockResolvedValue({ token: null });
@@ -86,7 +89,7 @@ describe('browser_wait catalog registration', () => {
   });
 
   it('keeps the legacy schema order, profile membership, and frozen descriptors', () => {
-    const specs = createWaitToolCatalog();
+    const specs = createWaitToolCatalog(browserToolDeps);
     expect(specs.map((spec) => spec.name)).toEqual(['browser_wait']);
     expect(specs[0]?.profiles).toEqual(['full']);
     expect(Object.keys(specs[0]?.inputSchema ?? {})).toEqual([
@@ -107,8 +110,8 @@ describe('browser_wait catalog registration', () => {
   });
 
   it('reuses the exact module-scope raw shape across catalogs and SDK registration', () => {
-    const firstCatalog = createWaitToolCatalog();
-    const secondCatalog = createWaitToolCatalog();
+    const firstCatalog = createWaitToolCatalog(browserToolDeps);
+    const secondCatalog = createWaitToolCatalog(browserToolDeps);
     let registeredInputSchema: unknown;
     const server = {
       registerTool: (
@@ -119,7 +122,7 @@ describe('browser_wait catalog registration', () => {
       },
     };
 
-    registerWaitTools(server as never, {
+    registerWaitTools(server as never, browserToolDeps, {
       profile: 'full',
       context: { principal: { kind: 'unattributed' } },
     });
@@ -135,12 +138,13 @@ describe('browser_wait RPC fallback', () => {
     const res = await wait({ selector: '#app', surfaceId: 's1' });
     expect(res.isError).toBeUndefined();
     expect(res.content[0].text).toContain('selector "#app" found');
-    const [method, params] = mockSendRpc.mock.calls[0] as [string, { expression: string; surfaceId?: string }];
+    const [method, params] = mockSendRpc.mock.calls[0] as [string, { expression: string; workspaceId: string; surfaceId?: string }];
     expect(method).toBe('browser.evaluate');
     // Mirrors Playwright's default state:'visible' — attachment + visible box.
     expect(params.expression).toContain('querySelector("#app")');
     expect(params.expression).toContain('getBoundingClientRect');
     expect(params.expression).toContain('visibility');
+    expect(params.workspaceId).toBe('ws-test');
     expect(params.surfaceId).toBe('s1');
   });
 
@@ -256,6 +260,7 @@ describe('browser_wait RPC fallback', () => {
     getPage.mockResolvedValue({ waitForSelector });
     const res = await wait({ selector: '#app' });
     expect(waitForSelector).toHaveBeenCalledWith('#app', { timeout: 30000 });
+    expect(getPage).toHaveBeenCalledWith(undefined, 'ws-test');
     expect(mockSendRpc).not.toHaveBeenCalled();
     expect(res.content[0].text).toContain('selector "#app" found');
   });
@@ -273,7 +278,7 @@ describe('browser_wait RPC fallback', () => {
     await wait({ selector: '#app', surfaceId: 'surface-1' });
 
     expect(mockLeaseRpc.mock.calls).toEqual([
-      ['browser.lease.acquire', { surfaceId: 'surface-1' }],
+      ['browser.lease.acquire', { workspaceId: 'ws-test', surfaceId: 'surface-1' }],
       ['browser.lease.release', { token: 'lease-1' }],
     ]);
   });

--- a/src/mcp/playwright/__tests__/workspaceScope.test.ts
+++ b/src/mcp/playwright/__tests__/workspaceScope.test.ts
@@ -2,7 +2,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-import { requireBrowserTargetScope } from '../browserScope';
+import {
+  allowScopedRpcFallback,
+  requireBrowserTargetScope,
+} from '../browserScope';
 
 describe('browser tool workspace scope', () => {
   it('refuses an empty strict-resolver result', async () => {
@@ -11,29 +14,37 @@ describe('browser tool workspace scope', () => {
     ).rejects.toThrow('WORKSPACE_SCOPE_UNRESOLVED');
   });
 
+  it('never converts a workspace-scope refusal into an RPC fallback', () => {
+    expect(() => allowScopedRpcFallback(
+      new Error('WORKSPACE_SCOPE_UNRESOLVED: legacy main cannot prove ownership'),
+    )).toThrow('WORKSPACE_SCOPE_UNRESOLVED');
+    expect(allowScopedRpcFallback(new Error('Playwright page unavailable'))).toBeNull();
+  });
+
   it('keeps direct browser fallback RPCs behind the scope-required helper', () => {
     const root = path.join(__dirname, '..');
     const files = [
       'page-eval.ts',
-      'tools/interaction.ts',
-      'tools/inspection.ts',
-      'tools/state.ts',
+      'markdown-extractor.ts',
+      ...fs.readdirSync(path.join(root, 'tools'))
+        .filter((name) => name.endsWith('.ts'))
+        .map((name) => `tools/${name}`),
     ];
     for (const relative of files) {
       const source = fs.readFileSync(path.join(root, relative), 'utf8');
-      expect(source, `${relative} must not bypass sendScopedBrowserRpc`).not.toMatch(
-        /sendRpc\(\s*['"]browser\./,
-      );
-      expect(source, `${relative} must use the scope-required helper`).toContain(
-        'sendScopedBrowserRpc',
+      const directBrowserCalls = source.match(/sendRpc\(\s*['"]browser\.[^'"]+/g) ?? [];
+      if (relative === 'tools/navigation.ts') {
+        // browser.tabs has its own typed workspace contract; every other
+        // navigation RPC goes through sendScopedBrowserRpc.
+        expect(directBrowserCalls).toEqual(["sendRpc('browser.tabs"]);
+      } else {
+        expect(directBrowserCalls, `${relative} must not bypass sendScopedBrowserRpc`).toEqual([]);
+      }
+
+      // Tool code may only use the required scope-taking engine entry point.
+      expect(source, `${relative} must not call optional-scope getPage`).not.toMatch(
+        /await\s+engine\.getPage\(/,
       );
     }
-
-    // Navigation has one intentionally separate browser.tabs call with an
-    // explicit workspaceId contract; navigate/back/evaluate use the helper.
-    const navigation = fs.readFileSync(path.join(root, 'tools/navigation.ts'), 'utf8');
-    const directBrowserCalls = navigation.match(/sendRpc\(\s*['"]browser\.[^'"]+/g) ?? [];
-    expect(directBrowserCalls).toEqual(["sendRpc('browser.tabs"]);
-    expect(navigation).toContain('sendScopedBrowserRpc');
   });
 });

--- a/src/mcp/playwright/__tests__/workspaceScope.test.ts
+++ b/src/mcp/playwright/__tests__/workspaceScope.test.ts
@@ -1,10 +1,18 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+const { mockSendRpc } = vi.hoisted(() => ({ mockSendRpc: vi.fn() }));
+vi.mock('../../wmux-client', () => ({
+  sendRpc: (...args: unknown[]) => mockSendRpc(...args),
+}));
 
 import {
   allowScopedRpcFallback,
+  isWorkspaceScopeUnresolvedError,
   requireBrowserTargetScope,
+  sendScopedBrowserRpc,
+  WorkspaceScopeUnresolvedError,
 } from '../browserScope';
 
 describe('browser tool workspace scope', () => {
@@ -15,17 +23,57 @@ describe('browser tool workspace scope', () => {
   });
 
   it('never converts a workspace-scope refusal into an RPC fallback', () => {
+    const refusal = new WorkspaceScopeUnresolvedError(
+      'legacy main cannot prove ownership',
+    );
+    expect(isWorkspaceScopeUnresolvedError(refusal)).toBe(true);
+    expect(isWorkspaceScopeUnresolvedError(
+      new Error('WORKSPACE_SCOPE_UNRESOLVED: message text is not the type contract'),
+    )).toBe(false);
     expect(() => allowScopedRpcFallback(
-      new Error('WORKSPACE_SCOPE_UNRESOLVED: legacy main cannot prove ownership'),
+      refusal,
     )).toThrow('WORKSPACE_SCOPE_UNRESOLVED');
     expect(allowScopedRpcFallback(new Error('Playwright page unavailable'))).toBeNull();
+  });
+
+  it('makes the verified scope authoritative over caller-supplied RPC params', async () => {
+    mockSendRpc.mockResolvedValueOnce({ ok: true });
+
+    await sendScopedBrowserRpc(
+      'browser.evaluate',
+      { workspaceId: 'ws-caller' },
+      {
+        expression: 'document.title',
+        workspaceId: 'ws-foreign',
+        surfaceId: 'surface-not-leased',
+      },
+    );
+
+    expect(mockSendRpc).toHaveBeenCalledWith('browser.evaluate', {
+      expression: 'document.title',
+      workspaceId: 'ws-caller',
+    });
+  });
+
+  it('refuses a hand-built empty scope before issuing an RPC', async () => {
+    mockSendRpc.mockClear();
+
+    await expect(sendScopedBrowserRpc(
+      'browser.evaluate',
+      { workspaceId: '' },
+      { expression: 'document.title' },
+    )).rejects.toThrow('WORKSPACE_SCOPE_UNRESOLVED');
+    expect(mockSendRpc).not.toHaveBeenCalled();
   });
 
   it('keeps direct browser fallback RPCs behind the scope-required helper', () => {
     const root = path.join(__dirname, '..');
     const files = [
+      'automationLease.ts',
+      'dom-intelligence.ts',
       'page-eval.ts',
       'markdown-extractor.ts',
+      'snapshot.ts',
       ...fs.readdirSync(path.join(root, 'tools'))
         .filter((name) => name.endsWith('.ts'))
         .map((name) => `tools/${name}`),
@@ -37,6 +85,16 @@ describe('browser tool workspace scope', () => {
         // browser.tabs has its own typed workspace contract; every other
         // navigation RPC goes through sendScopedBrowserRpc.
         expect(directBrowserCalls).toEqual(["sendRpc('browser.tabs"]);
+      } else if (relative === 'automationLease.ts') {
+        // Once acquired with a workspace scope, the opaque token is the
+        // capability used by renew/release. Keep this allowlist exact.
+        expect(directBrowserCalls).toEqual([
+          "sendRpc('browser.lease.release",
+          "sendRpc('browser.lease.renew",
+          "sendRpc('browser.lease.release",
+          "sendRpc('browser.lease.renew",
+          "sendRpc('browser.lease.release",
+        ]);
       } else {
         expect(directBrowserCalls, `${relative} must not bypass sendScopedBrowserRpc`).toEqual([]);
       }

--- a/src/mcp/playwright/__tests__/workspaceScope.test.ts
+++ b/src/mcp/playwright/__tests__/workspaceScope.test.ts
@@ -1,0 +1,39 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { requireBrowserTargetScope } from '../browserScope';
+
+describe('browser tool workspace scope', () => {
+  it('refuses an empty strict-resolver result', async () => {
+    await expect(
+      requireBrowserTargetScope({ resolveWorkspaceId: async () => '' }, 'surface-1'),
+    ).rejects.toThrow('WORKSPACE_SCOPE_UNRESOLVED');
+  });
+
+  it('keeps direct browser fallback RPCs behind the scope-required helper', () => {
+    const root = path.join(__dirname, '..');
+    const files = [
+      'page-eval.ts',
+      'tools/interaction.ts',
+      'tools/inspection.ts',
+      'tools/state.ts',
+    ];
+    for (const relative of files) {
+      const source = fs.readFileSync(path.join(root, relative), 'utf8');
+      expect(source, `${relative} must not bypass sendScopedBrowserRpc`).not.toMatch(
+        /sendRpc\(\s*['"]browser\./,
+      );
+      expect(source, `${relative} must use the scope-required helper`).toContain(
+        'sendScopedBrowserRpc',
+      );
+    }
+
+    // Navigation has one intentionally separate browser.tabs call with an
+    // explicit workspaceId contract; navigate/back/evaluate use the helper.
+    const navigation = fs.readFileSync(path.join(root, 'tools/navigation.ts'), 'utf8');
+    const directBrowserCalls = navigation.match(/sendRpc\(\s*['"]browser\.[^'"]+/g) ?? [];
+    expect(directBrowserCalls).toEqual(["sendRpc('browser.tabs"]);
+    expect(navigation).toContain('sendScopedBrowserRpc');
+  });
+});

--- a/src/mcp/playwright/automationLease.ts
+++ b/src/mcp/playwright/automationLease.ts
@@ -1,4 +1,10 @@
 import { sendRpc } from '../wmux-client';
+import {
+  requireBrowserTargetScope,
+  sendScopedBrowserRpc,
+  type BrowserTargetScope,
+  type BrowserToolDeps,
+} from './browserScope';
 
 // Renew well inside main's 30s RPC-lease TTL so a long-running tool op
 // (browser_wait_for, slow page interactions) never lapses mid-flight.
@@ -13,19 +19,23 @@ const RENEW_INTERVAL_MS = 10_000;
  * automated — the #353 silent-blank-screenshot failure. Every Playwright MCP
  * tool invocation wraps its body in withAutomationLease().
  *
- * Fail-open by design: if lease RPCs fail (older main without the handlers,
- * pipe hiccup), the operation proceeds unleased — behavior is then identical
- * to pre-#517 builds with lightweight mode unavailable.
+ * Workspace identity is resolved before the first lease RPC and reused for
+ * the operation's page selection and fallback RPCs (#695). Identity failure
+ * is fail-closed; lease transport failure remains fail-open for compatibility
+ * with older mains that do not implement leases.
  */
 export async function withAutomationLease<T>(
+  deps: BrowserToolDeps,
   surfaceId: string | undefined,
-  fn: () => Promise<T>,
+  fn: (scope: BrowserTargetScope) => Promise<T>,
 ): Promise<T> {
+  const scope = await requireBrowserTargetScope(deps, surfaceId);
   let token: string | null = null;
   try {
-    const res = (await sendRpc('browser.lease.acquire', {
-      ...(surfaceId && { surfaceId }),
-    })) as { token: string | null };
+    const res = await sendScopedBrowserRpc<{ token: string | null }>(
+      'browser.lease.acquire',
+      scope,
+    );
     token = res?.token ?? null;
   } catch {
     /* lease unavailable — proceed unleased */
@@ -41,9 +51,9 @@ export async function withAutomationLease<T>(
     let done = false;
     const lateTimer = setInterval(() => {
       if (done || lateToken) return;
-      sendRpc('browser.lease.acquire', { ...(surfaceId && { surfaceId }) })
+      sendScopedBrowserRpc<{ token: string | null }>('browser.lease.acquire', scope)
         .then((r) => {
-          const tok = (r as { token: string | null })?.token ?? null;
+          const tok = r?.token ?? null;
           if (!tok) return;
           if (done || lateToken) {
             // Op already ended, or a slower earlier acquire raced us and a
@@ -62,7 +72,7 @@ export async function withAutomationLease<T>(
     }, RENEW_INTERVAL_MS);
     (lateRenew as { unref?: () => void }).unref?.();
     try {
-      return await fn();
+      return await fn(scope);
     } finally {
       done = true;
       clearInterval(lateTimer);
@@ -83,7 +93,7 @@ export async function withAutomationLease<T>(
   (renewTimer as { unref?: () => void }).unref?.();
 
   try {
-    return await fn();
+    return await fn(scope);
   } finally {
     clearInterval(renewTimer);
     sendRpc('browser.lease.release', { token: heldToken }).catch(() => {

--- a/src/mcp/playwright/browserScope.ts
+++ b/src/mcp/playwright/browserScope.ts
@@ -1,0 +1,48 @@
+import type { RpcMethod } from '../../shared/rpc';
+import { sendRpc } from '../wmux-client';
+
+/** Stable error code for browser operations whose caller cannot be scoped. */
+export const WORKSPACE_SCOPE_UNRESOLVED_CODE = 'WORKSPACE_SCOPE_UNRESOLVED';
+
+/** Dependencies shared by every workspace-routed browser tool. */
+export interface BrowserToolDeps {
+  /** Strict per-connection resolver; it must never fall back to the UI-active workspace. */
+  resolveWorkspaceId: () => Promise<string>;
+}
+
+/** The immutable routing scope reused by one browser tool invocation. */
+export interface BrowserTargetScope {
+  readonly workspaceId: string;
+  readonly surfaceId?: string;
+}
+
+/**
+ * Resolve browser routing once, before any lease or browser RPC is issued.
+ * An empty identity is a refusal: omitting it would restore main's legacy
+ * first-live-target behavior and could cross workspace boundaries (#695).
+ */
+export async function requireBrowserTargetScope(
+  deps: BrowserToolDeps,
+  surfaceId?: string,
+): Promise<BrowserTargetScope> {
+  const workspaceId = await deps.resolveWorkspaceId();
+  if (!workspaceId) {
+    throw new Error(
+      `${WORKSPACE_SCOPE_UNRESOLVED_CODE}: browser tool workspace identity resolved to an empty id.`,
+    );
+  }
+  return Object.freeze({ workspaceId, ...(surfaceId && { surfaceId }) });
+}
+
+/**
+ * Send a browser RPC whose target must be constrained to one workspace.
+ * Scope is a required argument and wins over caller-supplied params, making it
+ * impossible for a fallback helper to silently omit or override workspaceId.
+ */
+export function sendScopedBrowserRpc<T = unknown>(
+  method: RpcMethod,
+  scope: BrowserTargetScope,
+  params: Record<string, unknown> = {},
+): Promise<T> {
+  return sendRpc(method, { ...params, ...scope }) as Promise<T>;
+}

--- a/src/mcp/playwright/browserScope.ts
+++ b/src/mcp/playwright/browserScope.ts
@@ -4,6 +4,20 @@ import { sendRpc } from '../wmux-client';
 /** Stable error code for browser operations whose caller cannot be scoped. */
 export const WORKSPACE_SCOPE_UNRESOLVED_CODE = 'WORKSPACE_SCOPE_UNRESOLVED';
 
+export function isWorkspaceScopeUnresolvedError(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith(`${WORKSPACE_SCOPE_UNRESOLVED_CODE}:`);
+}
+
+/**
+ * Page discovery failures may fall back to a scoped main-process RPC. A scope
+ * refusal may not: on an older main that ignores workspaceId, doing so would
+ * recreate the cross-workspace path the refusal was meant to close.
+ */
+export function allowScopedRpcFallback(error: unknown): null {
+  if (isWorkspaceScopeUnresolvedError(error)) throw error;
+  return null;
+}
+
 /** Dependencies shared by every workspace-routed browser tool. */
 export interface BrowserToolDeps {
   /** Strict per-connection resolver; it must never fall back to the UI-active workspace. */

--- a/src/mcp/playwright/browserScope.ts
+++ b/src/mcp/playwright/browserScope.ts
@@ -4,8 +4,22 @@ import { sendRpc } from '../wmux-client';
 /** Stable error code for browser operations whose caller cannot be scoped. */
 export const WORKSPACE_SCOPE_UNRESOLVED_CODE = 'WORKSPACE_SCOPE_UNRESOLVED';
 
+/** Typed refusal used wherever continuing could select another workspace. */
+export class WorkspaceScopeUnresolvedError extends Error {
+  readonly code = WORKSPACE_SCOPE_UNRESOLVED_CODE;
+
+  constructor(reason: string) {
+    super(`${WORKSPACE_SCOPE_UNRESOLVED_CODE}: ${reason}`);
+    this.name = 'WorkspaceScopeUnresolvedError';
+  }
+}
+
 export function isWorkspaceScopeUnresolvedError(error: unknown): boolean {
-  return error instanceof Error && error.message.startsWith(`${WORKSPACE_SCOPE_UNRESOLVED_CODE}:`);
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    error.code === WORKSPACE_SCOPE_UNRESOLVED_CODE
+  );
 }
 
 /**
@@ -30,6 +44,17 @@ export interface BrowserTargetScope {
   readonly surfaceId?: string;
 }
 
+/** Runtime guard for scopes created outside requireBrowserTargetScope(). */
+export function assertBrowserTargetScope(
+  scope: BrowserTargetScope,
+): asserts scope is BrowserTargetScope {
+  if (!scope.workspaceId) {
+    throw new WorkspaceScopeUnresolvedError(
+      'browser tool workspace identity resolved to an empty id.',
+    );
+  }
+}
+
 /**
  * Resolve browser routing once, before any lease or browser RPC is issued.
  * An empty identity is a refusal: omitting it would restore main's legacy
@@ -41,8 +66,8 @@ export async function requireBrowserTargetScope(
 ): Promise<BrowserTargetScope> {
   const workspaceId = await deps.resolveWorkspaceId();
   if (!workspaceId) {
-    throw new Error(
-      `${WORKSPACE_SCOPE_UNRESOLVED_CODE}: browser tool workspace identity resolved to an empty id.`,
+    throw new WorkspaceScopeUnresolvedError(
+      'browser tool workspace identity resolved to an empty id.',
     );
   }
   return Object.freeze({ workspaceId, ...(surfaceId && { surfaceId }) });
@@ -53,10 +78,20 @@ export async function requireBrowserTargetScope(
  * Scope is a required argument and wins over caller-supplied params, making it
  * impossible for a fallback helper to silently omit or override workspaceId.
  */
-export function sendScopedBrowserRpc<T = unknown>(
+export async function sendScopedBrowserRpc<T = unknown>(
   method: RpcMethod,
   scope: BrowserTargetScope,
   params: Record<string, unknown> = {},
 ): Promise<T> {
-  return sendRpc(method, { ...params, ...scope }) as Promise<T>;
+  assertBrowserTargetScope(scope);
+  const scopedParams: Record<string, unknown> = {
+    ...params,
+    workspaceId: scope.workspaceId,
+  };
+  // The operation scope is authoritative for both routing dimensions. When
+  // no surface is pinned, a caller cannot smuggle one through params that the
+  // automation lease did not cover.
+  if (scope.surfaceId) scopedParams.surfaceId = scope.surfaceId;
+  else delete scopedParams.surfaceId;
+  return sendRpc(method, scopedParams) as Promise<T>;
 }

--- a/src/mcp/playwright/markdown-extractor.ts
+++ b/src/mcp/playwright/markdown-extractor.ts
@@ -1,6 +1,7 @@
 import type { Page } from 'playwright-core';
 import type { JsonEvaluator } from './page-eval';
 import { evalFunctionOrRpc } from './page-eval';
+import type { BrowserTargetScope } from './browserScope';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -393,7 +394,7 @@ export function treeToMarkdown(
  * requested fields.
  *
  * @param page      Playwright Page, or null to use the RPC fallback (issue #105)
- * @param surfaceId Optional surface to target on the RPC path
+ * @param scope     Required workspace and optional surface for the RPC path
  * @param goal      Human-readable description of what to extract (reserved;
  *                  not yet used to narrow scope)
  * @param fields    Mapping of field names to human descriptions, e.g.
@@ -402,7 +403,7 @@ export function treeToMarkdown(
  */
 export async function extractStructuredData(
   page: Page | null,
-  surfaceId: string | undefined,
+  scope: BrowserTargetScope,
   goal: string,
   fields: Record<string, string>,
 ): Promise<Record<string, unknown>[]> {
@@ -411,15 +412,15 @@ export async function extractStructuredData(
   if (fieldNames.length === 0) return [];
 
   // Strategy 1: Try to extract from <table> elements
-  const tableData = await extractFromTables(page, surfaceId, fieldNames);
+  const tableData = await extractFromTables(page, scope, fieldNames);
   if (tableData.length > 0) return tableData;
 
   // Strategy 2: Try to extract from repeated list items
-  const listData = await extractFromLists(page, surfaceId, fieldNames);
+  const listData = await extractFromLists(page, scope, fieldNames);
   if (listData.length > 0) return listData;
 
   // Strategy 3: Try to find repeated element patterns (grids, cards, etc.)
-  const repeatedData = await extractFromRepeatedElements(page, surfaceId, fieldNames);
+  const repeatedData = await extractFromRepeatedElements(page, scope, fieldNames);
   if (repeatedData.length > 0) return repeatedData;
 
   return [];
@@ -431,7 +432,7 @@ export async function extractStructuredData(
 
 async function extractFromTables(
   page: Page | null,
-  surfaceId: string | undefined,
+  scope: BrowserTargetScope,
   fieldNames: string[],
 ): Promise<Record<string, unknown>[]> {
   return await evalFunctionOrRpc(
@@ -515,7 +516,7 @@ async function extractFromTables(
       return [];
     },
     { fieldNames },
-    surfaceId,
+    scope,
   );
 }
 
@@ -525,7 +526,7 @@ async function extractFromTables(
 
 async function extractFromLists(
   page: Page | null,
-  surfaceId: string | undefined,
+  scope: BrowserTargetScope,
   fieldNames: string[],
 ): Promise<Record<string, unknown>[]> {
   return await evalFunctionOrRpc(
@@ -589,7 +590,7 @@ async function extractFromLists(
       return results;
     },
     { fieldNames },
-    surfaceId,
+    scope,
   );
 }
 
@@ -599,7 +600,7 @@ async function extractFromLists(
 
 async function extractFromRepeatedElements(
   page: Page | null,
-  surfaceId: string | undefined,
+  scope: BrowserTargetScope,
   fieldNames: string[],
 ): Promise<Record<string, unknown>[]> {
   return await evalFunctionOrRpc(
@@ -757,6 +758,6 @@ async function extractFromRepeatedElements(
       return [];
     },
     { fieldNames },
-    surfaceId,
+    scope,
   );
 }

--- a/src/mcp/playwright/page-eval.ts
+++ b/src/mcp/playwright/page-eval.ts
@@ -1,6 +1,6 @@
 import type { Page } from 'playwright-core';
 import type { PlaywrightEngine } from './PlaywrightEngine';
-import { sendRpc } from '../wmux-client';
+import { sendScopedBrowserRpc, type BrowserTargetScope } from './browserScope';
 
 // ---------------------------------------------------------------------------
 // Transport abstraction for DOM-extraction tools (issue #105)
@@ -29,12 +29,11 @@ export function pageEvaluator(page: Page): JsonEvaluator {
  * webContents via browser.evaluate (CDP Runtime.evaluate, returnByValue), so it
  * works in packaged builds where the Playwright Page route does not.
  */
-export function rpcEvaluator(surfaceId?: string): JsonEvaluator {
+export function rpcEvaluator(scope: BrowserTargetScope): JsonEvaluator {
   return async (expression) => {
-    const result = (await sendRpc('browser.evaluate', {
+    const result = await sendScopedBrowserRpc<{ value: unknown }>('browser.evaluate', scope, {
       expression,
-      ...(surfaceId && { surfaceId }),
-    })) as { value: unknown };
+    });
     return result.value;
   };
 }
@@ -50,10 +49,10 @@ export function rpcEvaluator(surfaceId?: string): JsonEvaluator {
  */
 export async function resolveEvaluator(
   engine: PlaywrightEngine,
-  surfaceId?: string,
+  scope: BrowserTargetScope,
 ): Promise<JsonEvaluator> {
-  const page = await engine.getPage(surfaceId).catch(() => null);
-  return page ? pageEvaluator(page) : rpcEvaluator(surfaceId);
+  const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+  return page ? pageEvaluator(page) : rpcEvaluator(scope);
 }
 
 /**
@@ -77,7 +76,7 @@ export async function evalFunctionOrRpc<A, R>(
   page: Page | null,
   fn: (arg: A) => R,
   arg: A,
-  surfaceId?: string,
+  scope: BrowserTargetScope,
 ): Promise<R> {
   if (page) {
     // Playwright types page.evaluate's function param as PageFunction<Unboxed<A>, R>,
@@ -86,9 +85,8 @@ export async function evalFunctionOrRpc<A, R>(
     return (await page.evaluate(fn as (a: unknown) => R, arg)) as R;
   }
   const expression = `(${fn.toString()})(${JSON.stringify(arg)})`;
-  const result = (await sendRpc('browser.evaluate', {
+  const result = await sendScopedBrowserRpc<{ value: R }>('browser.evaluate', scope, {
     expression,
-    ...(surfaceId && { surfaceId }),
-  })) as { value: R };
+  });
   return result.value;
 }

--- a/src/mcp/playwright/page-eval.ts
+++ b/src/mcp/playwright/page-eval.ts
@@ -1,6 +1,10 @@
 import type { Page } from 'playwright-core';
 import type { PlaywrightEngine } from './PlaywrightEngine';
-import { sendScopedBrowserRpc, type BrowserTargetScope } from './browserScope';
+import {
+  allowScopedRpcFallback,
+  sendScopedBrowserRpc,
+  type BrowserTargetScope,
+} from './browserScope';
 
 // ---------------------------------------------------------------------------
 // Transport abstraction for DOM-extraction tools (issue #105)
@@ -51,7 +55,7 @@ export async function resolveEvaluator(
   engine: PlaywrightEngine,
   scope: BrowserTargetScope,
 ): Promise<JsonEvaluator> {
-  const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+  const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
   return page ? pageEvaluator(page) : rpcEvaluator(scope);
 }
 

--- a/src/mcp/playwright/tools/extraction.ts
+++ b/src/mcp/playwright/tools/extraction.ts
@@ -5,7 +5,7 @@ import { withAutomationLease } from '../automationLease';
 import { getSmartSnapshot, getSmartSnapshotViaEval } from '../dom-intelligence';
 import { extractMarkdown, extractStructuredData } from '../markdown-extractor';
 import { resolveEvaluator, rpcEvaluator } from '../page-eval';
-import type { BrowserToolDeps } from '../browserScope';
+import { allowScopedRpcFallback, type BrowserToolDeps } from '../browserScope';
 
 // Optional surfaceId schema reused across tools
 const optionalSurfaceId = z
@@ -72,7 +72,7 @@ export function registerExtractionTools(server: McpServer, deps: BrowserToolDeps
         // Playwright path uses the CDP accessibility tree; when no Page is
         // available (packaged builds, issue #105) fall back to a DOM-based
         // snapshot over the RPC channel.
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
         const snapshot = page
           ? await getSmartSnapshot(page, { maxContentLength: maxContentLength ?? 3000 })
           : await getSmartSnapshotViaEval(rpcEvaluator(scope), { maxContentLength: maxContentLength ?? 3000 });
@@ -153,7 +153,7 @@ export function registerExtractionTools(server: McpServer, deps: BrowserToolDeps
       try {
         // Native page.evaluate(fn, arg) when a Page exists (unchanged dev path);
         // RPC fallback when not (packaged builds, issue #105).
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         const records = await extractStructuredData(page, scope, goal, fields);
 

--- a/src/mcp/playwright/tools/extraction.ts
+++ b/src/mcp/playwright/tools/extraction.ts
@@ -5,6 +5,7 @@ import { withAutomationLease } from '../automationLease';
 import { getSmartSnapshot, getSmartSnapshotViaEval } from '../dom-intelligence';
 import { extractMarkdown, extractStructuredData } from '../markdown-extractor';
 import { resolveEvaluator, rpcEvaluator } from '../page-eval';
+import type { BrowserToolDeps } from '../browserScope';
 
 // Optional surfaceId schema reused across tools
 const optionalSurfaceId = z
@@ -56,7 +57,7 @@ const BROWSER_EXTRACT_DATA_SHAPE = {
  *  - browser_extract_text     -- extract page content as clean markdown
  *  - browser_extract_data     -- extract structured data as JSON
  */
-export function registerExtractionTools(server: McpServer): void {
+export function registerExtractionTools(server: McpServer, deps: BrowserToolDeps): void {
   const engine = PlaywrightEngine.getInstance();
 
   // -----------------------------------------------------------------------
@@ -66,15 +67,15 @@ export function registerExtractionTools(server: McpServer): void {
     'browser_smart_snapshot',
     'Get a smart snapshot of the page with indexed interactive elements and clean text content. Use element ref numbers with browser_click to interact.',
     BROWSER_SMART_SNAPSHOT_SHAPE,
-    async ({ maxContentLength, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ maxContentLength, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         // Playwright path uses the CDP accessibility tree; when no Page is
         // available (packaged builds, issue #105) fall back to a DOM-based
         // snapshot over the RPC channel.
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
         const snapshot = page
           ? await getSmartSnapshot(page, { maxContentLength: maxContentLength ?? 3000 })
-          : await getSmartSnapshotViaEval(rpcEvaluator(surfaceId), { maxContentLength: maxContentLength ?? 3000 });
+          : await getSmartSnapshotViaEval(rpcEvaluator(scope), { maxContentLength: maxContentLength ?? 3000 });
 
         // Format the snapshot output: indexed elements + content summary
         const lines: string[] = [];
@@ -115,12 +116,12 @@ export function registerExtractionTools(server: McpServer): void {
     'browser_extract_text',
     'Extract page content as clean markdown text, stripping navigation and noise.',
     BROWSER_EXTRACT_TEXT_SHAPE,
-    async ({ selector, maxLength, includeLinks, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ selector, maxLength, includeLinks, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         // resolveEvaluator picks the Playwright page when available, else the
         // RPC channel (packaged builds, issue #105). extract_text's in-page work
         // is a string script, so both transports produce identical output.
-        const evaluate = await resolveEvaluator(engine, surfaceId);
+        const evaluate = await resolveEvaluator(engine, scope);
 
         const markdown = await extractMarkdown(evaluate, {
           selector,
@@ -148,13 +149,13 @@ export function registerExtractionTools(server: McpServer): void {
     'browser_extract_data',
     'Extract structured data from the page (tables, lists, repeated items) as JSON.',
     BROWSER_EXTRACT_DATA_SHAPE,
-    async ({ goal, fields, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ goal, fields, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         // Native page.evaluate(fn, arg) when a Page exists (unchanged dev path);
         // RPC fallback when not (packaged builds, issue #105).
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
-        const records = await extractStructuredData(page, surfaceId, goal, fields);
+        const records = await extractStructuredData(page, scope, goal, fields);
 
         return {
           content: [

--- a/src/mcp/playwright/tools/file.ts
+++ b/src/mcp/playwright/tools/file.ts
@@ -120,7 +120,7 @@ export function registerFileTools(server: McpServer, deps: BrowserToolDeps): voi
     BROWSER_FILE_UPLOAD_SHAPE,
     async ({ paths, ref, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId);
+        const page = await engine.getPageForScope(scope);
         if (!page) {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }
@@ -169,7 +169,7 @@ export function registerFileTools(server: McpServer, deps: BrowserToolDeps): voi
     BROWSER_DOWNLOAD_SHAPE,
     async ({ ref, filename, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId);
+        const page = await engine.getPageForScope(scope);
         if (!page) {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }
@@ -233,7 +233,7 @@ export function registerFileTools(server: McpServer, deps: BrowserToolDeps): voi
       const resolvedTimeout = timeout ?? 30000;
 
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId);
+        const page = await engine.getPageForScope(scope);
         if (!page) {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }
@@ -304,7 +304,7 @@ export function registerFileTools(server: McpServer, deps: BrowserToolDeps): voi
     BROWSER_DIALOG_SHAPE,
     async ({ accept, text, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId);
+        const page = await engine.getPageForScope(scope);
         if (!page) {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }

--- a/src/mcp/playwright/tools/file.ts
+++ b/src/mcp/playwright/tools/file.ts
@@ -4,6 +4,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { PlaywrightEngine } from '../PlaywrightEngine';
 import { withAutomationLease } from '../automationLease';
+import type { BrowserToolDeps } from '../browserScope';
 import { resolveRef } from '../snapshot';
 import { getWmuxDir } from '../../../daemon/config';
 
@@ -107,7 +108,7 @@ function validateUploadPath(input: string): string {
  *  - browser_wait_for_download  — wait for a download event
  *  - browser_dialog             — pre-register a dialog accept/dismiss handler
  */
-export function registerFileTools(server: McpServer): void {
+export function registerFileTools(server: McpServer, deps: BrowserToolDeps): void {
   const engine = PlaywrightEngine.getInstance();
 
   // -----------------------------------------------------------------------
@@ -117,9 +118,9 @@ export function registerFileTools(server: McpServer): void {
     'browser_file_upload',
     'Upload files to a file input element. Paths MUST live under ~/.wmux/uploads/ — arbitrary filesystem paths are rejected to prevent exfiltration of credentials or SSH keys via malicious pages.',
     BROWSER_FILE_UPLOAD_SHAPE,
-    async ({ paths, ref, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ paths, ref, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(surfaceId);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId);
         if (!page) {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }
@@ -166,9 +167,9 @@ export function registerFileTools(server: McpServer): void {
     'browser_download',
     'Click an element (identified by ref) and capture the resulting download. Returns the downloaded file path.',
     BROWSER_DOWNLOAD_SHAPE,
-    async ({ ref, filename, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ ref, filename, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(surfaceId);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId);
         if (!page) {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }
@@ -228,11 +229,11 @@ export function registerFileTools(server: McpServer): void {
     'browser_wait_for_download',
     'Wait for a download event on the page. Optionally filter by filename.',
     BROWSER_WAIT_FOR_DOWNLOAD_SHAPE,
-    async ({ filename, timeout, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ filename, timeout, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       const resolvedTimeout = timeout ?? 30000;
 
       try {
-        const page = await engine.getPage(surfaceId);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId);
         if (!page) {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }
@@ -301,9 +302,9 @@ export function registerFileTools(server: McpServer): void {
     'browser_dialog',
     'Pre-register a handler for the next browser dialog (alert, confirm, prompt, beforeunload). The handler will automatically accept or dismiss the dialog when it appears.',
     BROWSER_DIALOG_SHAPE,
-    async ({ accept, text, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ accept, text, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(surfaceId);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId);
         if (!page) {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }

--- a/src/mcp/playwright/tools/inspection.ts
+++ b/src/mcp/playwright/tools/inspection.ts
@@ -8,7 +8,11 @@ import { buildDomSnapshotExpression } from '../dom-intelligence';
 import { evaluateWithGesture } from '../anti-detection';
 import { detectDangerousPatterns } from '../security';
 import { sanitizeRef } from './interaction';
-import { sendScopedBrowserRpc, type BrowserToolDeps } from '../browserScope';
+import {
+  allowScopedRpcFallback,
+  sendScopedBrowserRpc,
+  type BrowserToolDeps,
+} from '../browserScope';
 
 // Optional surfaceId schema reused across tools
 const optionalSurfaceId = z
@@ -306,7 +310,7 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
     async ({ format, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         // Try Playwright for full snapshot
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
         if (page) {
           const snapshot = await generateSnapshot(page, { format: format ?? 'ai' });
           return {
@@ -346,7 +350,7 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
       try {
         // Try Playwright for element-level screenshots (ref)
         if (ref) {
-          const page = await engine.getPage(scope.surfaceId, scope.workspaceId);
+          const page = await engine.getPageForScope(scope);
           if (page) {
             const el = await resolveRef(page, ref);
             if (!el) {
@@ -409,7 +413,7 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
         let result: unknown;
 
         // Try Playwright first for gesture-aware evaluation
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
         if (page) {
           result = await evaluateWithGesture(page, expression);
         } else {
@@ -445,7 +449,7 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
     BROWSER_CONSOLE_SHAPE,
     async ({ level, clear, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         let entries: ConsoleEntry[];
         if (page) {
@@ -484,7 +488,7 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
     BROWSER_NETWORK_SHAPE,
     async ({ filter, clear, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         let entries: Array<{ url: string; method: string; status?: number }>;
         if (page) {
@@ -525,7 +529,7 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
     BROWSER_RESPONSE_BODY_SHAPE,
     async ({ urlPattern, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         let body: string | null = null;
         if (page) {
@@ -586,7 +590,7 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
     BROWSER_HIGHLIGHT_SHAPE,
     async ({ ref, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         if (page) {
           const el = await resolveRef(page, ref);

--- a/src/mcp/playwright/tools/inspection.ts
+++ b/src/mcp/playwright/tools/inspection.ts
@@ -8,7 +8,7 @@ import { buildDomSnapshotExpression } from '../dom-intelligence';
 import { evaluateWithGesture } from '../anti-detection';
 import { detectDangerousPatterns } from '../security';
 import { sanitizeRef } from './interaction';
-import { sendRpc } from '../../wmux-client';
+import { sendScopedBrowserRpc, type BrowserToolDeps } from '../browserScope';
 
 // Optional surfaceId schema reused across tools
 const optionalSurfaceId = z
@@ -293,7 +293,7 @@ function formatNetwork(
  *  - browser_response_body  -- retrieve response body by URL pattern
  *  - browser_highlight      -- visually highlight an element
  */
-export function registerInspectionTools(server: McpServer): void {
+export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps): void {
   const engine = PlaywrightEngine.getInstance();
 
   // -----------------------------------------------------------------------
@@ -303,10 +303,10 @@ export function registerInspectionTools(server: McpServer): void {
     'browser_snapshot',
     'Take an accessibility tree snapshot of the current page. Returns a text representation of the page structure with interactive elements annotated with ref numbers.',
     BROWSER_SNAPSHOT_SHAPE,
-    async ({ format, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ format, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         // Try Playwright for full snapshot
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
         if (page) {
           const snapshot = await generateSnapshot(page, { format: format ?? 'ai' });
           return {
@@ -318,10 +318,9 @@ export function registerInspectionTools(server: McpServer): void {
         // elements with data-wmux-ref so interaction tools can resolve them.
         // Same expression the page-mode root-only fallthrough runs (snapshot.ts),
         // via the shared buildDomSnapshotExpression() helper.
-        const result = await sendRpc('browser.evaluate', {
+        const result = await sendScopedBrowserRpc<{ value: string }>('browser.evaluate', scope, {
           expression: buildDomSnapshotExpression(),
-          ...(surfaceId && { surfaceId }),
-        }) as { value: string };
+        });
 
         return {
           content: [{ type: 'text' as const, text: result.value }],
@@ -343,11 +342,11 @@ export function registerInspectionTools(server: McpServer): void {
     'browser_screenshot',
     'Take a screenshot of the current page or a specific element. Returns the image as base64-encoded PNG. Requires browser_open to be called first to establish a connection, even if a browser panel is already visible.',
     BROWSER_SCREENSHOT_SHAPE,
-    async ({ fullPage, ref, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ fullPage, ref, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         // Try Playwright for element-level screenshots (ref)
         if (ref) {
-          const page = await engine.getPage(surfaceId);
+          const page = await engine.getPage(scope.surfaceId, scope.workspaceId);
           if (page) {
             const el = await resolveRef(page, ref);
             if (!el) {
@@ -361,10 +360,9 @@ export function registerInspectionTools(server: McpServer): void {
         }
 
         // Use RPC for fast, reliable screenshots (bypasses Playwright CDP discovery)
-        const result = await sendRpc('browser.screenshot', {
-          ...(surfaceId && { surfaceId }),
+        const result = await sendScopedBrowserRpc<{ data: string }>('browser.screenshot', scope, {
           ...(fullPage && { fullPage }),
-        }) as { data: string };
+        });
 
         return {
           content: [
@@ -392,7 +390,7 @@ export function registerInspectionTools(server: McpServer): void {
     'browser_evaluate',
     'Evaluate a JavaScript expression in the browser page context. Dangerous patterns (fetch, XHR, cookies, storage, eval, Function) are BLOCKED by default to mitigate prompt injection; pass allowDangerous:true to override when the caller has verified the expression is trusted.',
     BROWSER_EVALUATE_SHAPE,
-    async ({ expression, allowDangerous, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ expression, allowDangerous, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         const warnings = detectDangerousPatterns(expression);
         if (warnings.length > 0 && !allowDangerous) {
@@ -411,15 +409,14 @@ export function registerInspectionTools(server: McpServer): void {
         let result: unknown;
 
         // Try Playwright first for gesture-aware evaluation
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
         if (page) {
           result = await evaluateWithGesture(page, expression);
         } else {
           // Fallback: RPC evaluation via main process webContents
-          const rpcResult = await sendRpc('browser.evaluate', {
+          const rpcResult = await sendScopedBrowserRpc<{ value: unknown }>('browser.evaluate', scope, {
             expression,
-            ...(surfaceId && { surfaceId }),
-          }) as { value: unknown };
+          });
           result = rpcResult.value;
         }
 
@@ -446,9 +443,9 @@ export function registerInspectionTools(server: McpServer): void {
     'browser_console',
     'Retrieve console messages collected from the browser page. Messages are accumulated over time; use clear=true to reset.',
     BROWSER_CONSOLE_SHAPE,
-    async ({ level, clear, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ level, clear, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
         let entries: ConsoleEntry[];
         if (page) {
@@ -457,10 +454,9 @@ export function registerInspectionTools(server: McpServer): void {
           if (clear) consoleMessages.set(page, []);
         } else {
           // RPC fallback (packaged builds): drain the main-process CDP capture.
-          const result = await sendRpc('browser.console.get', {
-            ...(surfaceId && { surfaceId }),
+          const result = await sendScopedBrowserRpc<{ entries: ConsoleEntry[] }>('browser.console.get', scope, {
             ...(clear && { clear: true }),
-          }) as { entries: ConsoleEntry[] };
+          });
           entries = result.entries ?? [];
         }
 
@@ -486,9 +482,9 @@ export function registerInspectionTools(server: McpServer): void {
     'browser_network',
     'Retrieve network requests collected from the browser page. Requests are accumulated over time; use clear=true to reset. Use a URL glob pattern to filter.',
     BROWSER_NETWORK_SHAPE,
-    async ({ filter, clear, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ filter, clear, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
         let entries: Array<{ url: string; method: string; status?: number }>;
         if (page) {
@@ -497,10 +493,11 @@ export function registerInspectionTools(server: McpServer): void {
           if (clear) networkRequests.set(page, []);
         } else {
           // RPC fallback (packaged builds): drain the main-process CDP capture.
-          const result = await sendRpc('browser.network.get', {
-            ...(surfaceId && { surfaceId }),
+          const result = await sendScopedBrowserRpc<{
+            entries: Array<{ url: string; method: string; status?: number }>;
+          }>('browser.network.get', scope, {
             ...(clear && { clear: true }),
-          }) as { entries: Array<{ url: string; method: string; status?: number }> };
+          });
           entries = result.entries ?? [];
         }
 
@@ -526,9 +523,9 @@ export function registerInspectionTools(server: McpServer): void {
     'browser_response_body',
     'Retrieve the response body for a previously captured network request matching a URL pattern.',
     BROWSER_RESPONSE_BODY_SHAPE,
-    async ({ urlPattern, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ urlPattern, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
         let body: string | null = null;
         if (page) {
@@ -545,10 +542,9 @@ export function registerInspectionTools(server: McpServer): void {
         } else {
           // RPC fallback (packaged builds): the main process matches and returns
           // the body from its CDP capture buffer.
-          const result = await sendRpc('browser.responseBody.get', {
+          const result = await sendScopedBrowserRpc<{ body: string | null }>('browser.responseBody.get', scope, {
             urlPattern,
-            ...(surfaceId && { surfaceId }),
-          }) as { body: string | null };
+          });
           body = result.body ?? null;
         }
 
@@ -588,9 +584,9 @@ export function registerInspectionTools(server: McpServer): void {
     'browser_highlight',
     'Visually highlight an element on the page by its ref number. Adds a red outline around the element.',
     BROWSER_HIGHLIGHT_SHAPE,
-    async ({ ref, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ ref, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
         if (page) {
           const el = await resolveRef(page, ref);
@@ -608,7 +604,7 @@ export function registerInspectionTools(server: McpServer): void {
           // RPC fallback (packaged builds): resolve via the data-wmux-ref tag set
           // by browser_snapshot / browser_smart_snapshot and set the outline inline.
           const safeRef = sanitizeRef(ref);
-          const result = await sendRpc('browser.evaluate', {
+          const result = await sendScopedBrowserRpc<{ value: string }>('browser.evaluate', scope, {
             expression: `(() => {
               const el = document.querySelector('[data-wmux-ref="${safeRef}"]');
               if (!el) return 'not_found';
@@ -616,8 +612,7 @@ export function registerInspectionTools(server: McpServer): void {
               el.style.outlineOffset = '2px';
               return 'ok';
             })()`,
-            ...(surfaceId && { surfaceId }),
-          }) as { value: string };
+          });
           if (result.value === 'not_found') {
             throw new Error(`Could not resolve ref="${ref}" to an element.`);
           }

--- a/src/mcp/playwright/tools/interaction.ts
+++ b/src/mcp/playwright/tools/interaction.ts
@@ -5,7 +5,11 @@ import { withAutomationLease } from '../automationLease';
 import { resolveRef } from '../snapshot';
 import { getLocatorByRef } from '../dom-intelligence';
 import { typeHumanlike } from '../human-typing';
-import { sendRpc } from '../../wmux-client';
+import {
+  sendScopedBrowserRpc,
+  type BrowserTargetScope,
+  type BrowserToolDeps,
+} from '../browserScope';
 
 // Optional surfaceId schema reused across tools
 const optionalSurfaceId = z
@@ -116,11 +120,10 @@ function refNotFound(ref: string): string {
 // These resolve elements via data-wmux-ref attributes set by browser_snapshot.
 // ---------------------------------------------------------------------------
 
-async function rpcEval(expression: string, surfaceId?: string): Promise<string> {
-  const result = await sendRpc('browser.evaluate', {
+async function rpcEval(expression: string, scope: BrowserTargetScope): Promise<string> {
+  const result = await sendScopedBrowserRpc<{ value: string }>('browser.evaluate', scope, {
     expression,
-    ...(surfaceId && { surfaceId }),
-  }) as { value: string };
+  });
   return result.value;
 }
 
@@ -134,36 +137,32 @@ export function sanitizeRef(ref: string): string {
   return ref;
 }
 
-async function rpcClick(ref: string, surfaceId?: string, _double?: boolean): Promise<void> {
+async function rpcClick(ref: string, scope: BrowserTargetScope, _double?: boolean): Promise<void> {
   // Use CDP click: first get element coordinates via JS, then dispatch mouse events
   const safeRef = sanitizeRef(ref);
-  await sendRpc('browser.click.cdp', {
+  await sendScopedBrowserRpc('browser.click.cdp', scope, {
     selector: `[data-wmux-ref="${safeRef}"]`,
-    ...(surfaceId && { surfaceId }),
   });
 }
 
-async function rpcFill(ref: string, value: string, surfaceId?: string): Promise<void> {
+async function rpcFill(ref: string, value: string, scope: BrowserTargetScope): Promise<void> {
   // Click on the element first to focus it
-  await rpcClick(ref, surfaceId);
+  await rpcClick(ref, scope);
   // Small delay for focus
   await new Promise(r => setTimeout(r, 100));
   // Select all existing text
-  await sendRpc('browser.evaluate', {
+  await sendScopedBrowserRpc('browser.evaluate', scope, {
     expression: `document.execCommand('selectAll')`,
-    ...(surfaceId && { surfaceId }),
   });
   // Type the new value via CDP Input.insertText (handles CJK, React controlled inputs)
-  await sendRpc('browser.type.cdp', {
+  await sendScopedBrowserRpc('browser.type.cdp', scope, {
     text: value,
-    ...(surfaceId && { surfaceId }),
   });
 }
 
-async function rpcPressKey(key: string, surfaceId?: string): Promise<void> {
-  await sendRpc('browser.press.cdp', {
+async function rpcPressKey(key: string, scope: BrowserTargetScope): Promise<void> {
+  await sendScopedBrowserRpc('browser.press.cdp', scope, {
     key,
-    ...(surfaceId && { surfaceId }),
   });
 }
 
@@ -180,7 +179,7 @@ async function rpcPressKey(key: string, surfaceId?: string): Promise<void> {
  *  - browser_select           — select option(s) in a <select>
  *  - browser_scroll_into_view — scroll element into viewport
  */
-export function registerInteractionTools(server: McpServer): void {
+export function registerInteractionTools(server: McpServer, deps: BrowserToolDeps): void {
   const engine = PlaywrightEngine.getInstance();
 
   // -----------------------------------------------------------------------
@@ -190,10 +189,10 @@ export function registerInteractionTools(server: McpServer): void {
     'browser_click',
     'Click an element identified by its ref number from the accessibility snapshot, or by a smartRef from browser_smart_snapshot.',
     BROWSER_CLICK_SHAPE,
-    async ({ ref, smartRef, double, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ ref, smartRef, double, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         // Try Playwright first
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
         if (page) {
           if (smartRef !== undefined) {
@@ -225,7 +224,7 @@ export function registerInteractionTools(server: McpServer): void {
         // RPC fallback
         if (!ref && smartRef === undefined) throw new Error('Either ref or smartRef must be provided.');
         const resolvedRef = ref ?? String(smartRef);
-        await rpcClick(resolvedRef, surfaceId, double);
+        await rpcClick(resolvedRef, scope, double);
         return {
           content: [{ type: 'text' as const, text: `Clicked${double ? ' (double)' : ''} element ref=${resolvedRef}` }],
         };
@@ -246,9 +245,9 @@ export function registerInteractionTools(server: McpServer): void {
     'browser_type',
     'Type text into an element identified by its ref number.',
     BROWSER_TYPE_SHAPE,
-    async ({ ref, text, submit, humanlike, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ ref, text, submit, humanlike, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
         if (page) {
           const el = await resolveRef(page, ref);
@@ -262,8 +261,8 @@ export function registerInteractionTools(server: McpServer): void {
           if (submit) await page.keyboard.press('Enter');
         } else {
           // RPC fallback
-          await rpcFill(ref, text, surfaceId);
-          if (submit) await rpcPressKey('Enter', surfaceId);
+          await rpcFill(ref, text, scope);
+          if (submit) await rpcPressKey('Enter', scope);
         }
 
         return {
@@ -291,9 +290,9 @@ export function registerInteractionTools(server: McpServer): void {
     'browser_fill',
     'Fill multiple form fields at once. Each field is identified by a ref number.',
     BROWSER_FILL_SHAPE,
-    async ({ fields, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ fields, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
         let filled = 0;
         const errors: string[] = [];
@@ -305,7 +304,7 @@ export function registerInteractionTools(server: McpServer): void {
               if (!el) { errors.push(refNotFound(field.ref)); continue; }
               await el.fill(field.value);
             } else {
-              await rpcFill(field.ref, field.value, surfaceId);
+              await rpcFill(field.ref, field.value, scope);
             }
             filled++;
           } catch (err) {
@@ -339,14 +338,14 @@ export function registerInteractionTools(server: McpServer): void {
     'browser_press_key',
     'Press a keyboard key (e.g. Enter, Tab, Escape, ArrowDown, Control+a).',
     BROWSER_PRESS_KEY_SHAPE,
-    async ({ key, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ key, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
         if (page) {
           await page.keyboard.press(key);
         } else {
-          await rpcPressKey(key, surfaceId);
+          await rpcPressKey(key, scope);
         }
 
         return {
@@ -369,9 +368,9 @@ export function registerInteractionTools(server: McpServer): void {
     'browser_hover',
     'Hover over an element identified by its ref number.',
     BROWSER_HOVER_SHAPE,
-    async ({ ref, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ ref, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
         if (page) {
           const el = await resolveRef(page, ref);
@@ -387,7 +386,7 @@ export function registerInteractionTools(server: McpServer): void {
             el.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
             el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
             return 'ok';
-          })()`, surfaceId);
+          })()`, scope);
           if (val === 'not_found') throw new Error(refNotFound(ref));
         }
 
@@ -411,9 +410,9 @@ export function registerInteractionTools(server: McpServer): void {
     'browser_drag',
     'Drag an element from sourceRef to targetRef.',
     BROWSER_DRAG_SHAPE,
-    async ({ sourceRef, targetRef, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ sourceRef, targetRef, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
         if (page) {
           const sourceEl = await resolveRef(page, sourceRef);
@@ -451,7 +450,7 @@ export function registerInteractionTools(server: McpServer): void {
             tgt.dispatchEvent(new DragEvent('drop', { bubbles: true, dataTransfer: dt }));
             src.dispatchEvent(new DragEvent('dragend', { bubbles: true, dataTransfer: dt }));
             return 'ok';
-          })()`, surfaceId);
+          })()`, scope);
           if (val === 'source_not_found') throw new Error(refNotFound(sourceRef));
           if (val === 'target_not_found') throw new Error(refNotFound(targetRef));
         }
@@ -476,9 +475,9 @@ export function registerInteractionTools(server: McpServer): void {
     'browser_select',
     'Select option(s) in a <select> element by value.',
     BROWSER_SELECT_SHAPE,
-    async ({ ref, values, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ ref, values, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
         if (page) {
           const el = await resolveRef(page, ref);
@@ -494,7 +493,7 @@ export function registerInteractionTools(server: McpServer): void {
             [...el.options].forEach(o => { o.selected = vals.includes(o.value); });
             el.dispatchEvent(new Event('change', { bubbles: true }));
             return 'ok';
-          })()`, surfaceId);
+          })()`, scope);
           if (val === 'not_found') throw new Error(refNotFound(ref));
         }
 
@@ -518,9 +517,9 @@ export function registerInteractionTools(server: McpServer): void {
     'browser_scroll_into_view',
     'Scroll an element into the visible viewport.',
     BROWSER_SCROLL_INTO_VIEW_SHAPE,
-    async ({ ref, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ ref, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
         if (page) {
           const el = await resolveRef(page, ref);
@@ -533,7 +532,7 @@ export function registerInteractionTools(server: McpServer): void {
             if (!el) return 'not_found';
             el.scrollIntoView({ block: 'center', behavior: 'smooth' });
             return 'ok';
-          })()`, surfaceId);
+          })()`, scope);
           if (val === 'not_found') throw new Error(refNotFound(ref));
         }
 
@@ -557,12 +556,12 @@ export function registerInteractionTools(server: McpServer): void {
     'browser_scroll',
     'Scroll the page or a scrollable element. Use direction and amount to control scrolling.',
     BROWSER_SCROLL_SHAPE,
-    async ({ direction, amount, ref, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ direction, amount, ref, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       const px = amount ?? 500;
       const deltaX = direction === 'right' ? px : direction === 'left' ? -px : 0;
       const deltaY = direction === 'down' ? px : direction === 'up' ? -px : 0;
       try {
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
         if (page) {
           if (ref) {
@@ -587,12 +586,12 @@ export function registerInteractionTools(server: McpServer): void {
               if (!el) return 'not_found';
               el.scrollBy(${deltaX}, ${deltaY});
               return 'ok';
-            })()`, surfaceId);
+            })()`, scope);
           } else {
             await rpcEval(`(() => {
               window.scrollBy(${deltaX}, ${deltaY});
               return 'ok';
-            })()`, surfaceId);
+            })()`, scope);
           }
         }
 

--- a/src/mcp/playwright/tools/interaction.ts
+++ b/src/mcp/playwright/tools/interaction.ts
@@ -6,6 +6,7 @@ import { resolveRef } from '../snapshot';
 import { getLocatorByRef } from '../dom-intelligence';
 import { typeHumanlike } from '../human-typing';
 import {
+  allowScopedRpcFallback,
   sendScopedBrowserRpc,
   type BrowserTargetScope,
   type BrowserToolDeps,
@@ -192,7 +193,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
     async ({ ref, smartRef, double, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         // Try Playwright first
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         if (page) {
           if (smartRef !== undefined) {
@@ -247,7 +248,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
     BROWSER_TYPE_SHAPE,
     async ({ ref, text, submit, humanlike, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         if (page) {
           const el = await resolveRef(page, ref);
@@ -292,7 +293,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
     BROWSER_FILL_SHAPE,
     async ({ fields, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         let filled = 0;
         const errors: string[] = [];
@@ -340,7 +341,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
     BROWSER_PRESS_KEY_SHAPE,
     async ({ key, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         if (page) {
           await page.keyboard.press(key);
@@ -370,7 +371,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
     BROWSER_HOVER_SHAPE,
     async ({ ref, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         if (page) {
           const el = await resolveRef(page, ref);
@@ -412,7 +413,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
     BROWSER_DRAG_SHAPE,
     async ({ sourceRef, targetRef, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         if (page) {
           const sourceEl = await resolveRef(page, sourceRef);
@@ -477,7 +478,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
     BROWSER_SELECT_SHAPE,
     async ({ ref, values, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         if (page) {
           const el = await resolveRef(page, ref);
@@ -519,7 +520,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
     BROWSER_SCROLL_INTO_VIEW_SHAPE,
     async ({ ref, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         if (page) {
           const el = await resolveRef(page, ref);
@@ -561,7 +562,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
       const deltaX = direction === 'right' ? px : direction === 'left' ? -px : 0;
       const deltaY = direction === 'down' ? px : direction === 'up' ? -px : 0;
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         if (page) {
           if (ref) {

--- a/src/mcp/playwright/tools/navigation.ts
+++ b/src/mcp/playwright/tools/navigation.ts
@@ -3,6 +3,11 @@ import { z } from 'zod';
 import { validateNavigationUrl } from '../../../shared/types';
 import { sendRpc } from '../../wmux-client';
 import {
+  requireBrowserTargetScope,
+  sendScopedBrowserRpc,
+  type BrowserToolDeps,
+} from '../browserScope';
+import {
   browserTabsError,
   isBrowserTabsResult,
   type BrowserTabDescriptor,
@@ -49,11 +54,6 @@ export const BROWSER_TABS_SHAPE = {
     .optional()
     .describe('Removed unsafe numeric index. Use surfaceId returned by "list" or "new".'),
 };
-
-export interface NavigationToolDeps {
-  /** Strict per-connection resolver. It throws rather than falling back to the UI-active workspace. */
-  resolveWorkspaceId: () => Promise<string>;
-}
 
 function tabsToolError(result: BrowserTabsErrorResult) {
   return {
@@ -111,7 +111,7 @@ function tabsToolSuccess(result: BrowserTabsSuccessResult) {
  *  - browser_navigate_back — go back in history
  *  - browser_tabs          — list / new / select / close tabs
  */
-export function registerNavigationTools(server: McpServer, deps: NavigationToolDeps): void {
+export function registerNavigationTools(server: McpServer, deps: BrowserToolDeps): void {
   // -----------------------------------------------------------------------
   // browser_navigate
   // -----------------------------------------------------------------------
@@ -129,8 +129,9 @@ export function registerNavigationTools(server: McpServer, deps: NavigationToolD
           };
         }
 
+        const scope = await requireBrowserTargetScope(deps, surfaceId);
         // Use RPC for fast, reliable navigation (bypasses Playwright CDP discovery)
-        await sendRpc('browser.navigate', { url, ...(surfaceId && { surfaceId }) });
+        await sendScopedBrowserRpc('browser.navigate', scope, { url });
         return {
           content: [{ type: 'text' as const, text: `Navigated to ${url}` }],
         };
@@ -153,17 +154,15 @@ export function registerNavigationTools(server: McpServer, deps: NavigationToolD
     BROWSER_NAVIGATE_BACK_SHAPE,
     async ({ surfaceId }) => {
       try {
-        await sendRpc('browser.goBack', {
-          ...(surfaceId && { surfaceId }),
-        });
+        const scope = await requireBrowserTargetScope(deps, surfaceId);
+        await sendScopedBrowserRpc('browser.goBack', scope);
 
         await new Promise((resolve) => setTimeout(resolve, 300));
 
         // Get current URL
-        const urlResult = await sendRpc('browser.evaluate', {
+        const urlResult = await sendScopedBrowserRpc<{ value: string }>('browser.evaluate', scope, {
           expression: 'location.href',
-          ...(surfaceId && { surfaceId }),
-        }) as { value: string };
+        });
 
         return {
           content: [{ type: 'text' as const, text: `Navigated back to ${urlResult.value}` }],

--- a/src/mcp/playwright/tools/state.ts
+++ b/src/mcp/playwright/tools/state.ts
@@ -7,6 +7,7 @@ import { withAutomationLease } from '../automationLease';
 import { matchSensitiveDomain } from '../security';
 import { evalFunctionOrRpc } from '../page-eval';
 import {
+  allowScopedRpcFallback,
   sendScopedBrowserRpc,
   type BrowserTargetScope,
   type BrowserToolDeps,
@@ -172,7 +173,7 @@ export function registerStateTools(server: McpServer, deps: BrowserToolDeps): vo
     async ({ action, url, cookies, allowSensitiveDomains, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         // Playwright Page when available (dev), else CDP over RPC (packaged, #111).
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         switch (action) {
           case 'get': {
@@ -283,7 +284,7 @@ export function registerStateTools(server: McpServer, deps: BrowserToolDeps): vo
         // browser_storage is pure page.evaluate, so it unifies over the same
         // evaluate transport the extraction tools use: a Playwright Page when
         // available, else browser.evaluate over RPC (packaged builds, #111).
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         const storageName = type === 'local' ? 'localStorage' : 'sessionStorage';
 
@@ -392,7 +393,7 @@ export function registerStateTools(server: McpServer, deps: BrowserToolDeps): vo
     BROWSER_EMULATE_SHAPE,
     async ({ offline, headers, credentials, geo, media, timezone, locale, device, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
         const applied: string[] = [];
 
         // Resolve a device preset (if any) up front: both transports need its
@@ -564,7 +565,7 @@ export function registerStateTools(server: McpServer, deps: BrowserToolDeps): vo
     BROWSER_RESIZE_SHAPE,
     async ({ width, height, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         if (page) {
           await page.setViewportSize({ width, height });

--- a/src/mcp/playwright/tools/state.ts
+++ b/src/mcp/playwright/tools/state.ts
@@ -6,7 +6,11 @@ import { PlaywrightEngine } from '../PlaywrightEngine';
 import { withAutomationLease } from '../automationLease';
 import { matchSensitiveDomain } from '../security';
 import { evalFunctionOrRpc } from '../page-eval';
-import { sendRpc } from '../../wmux-client';
+import {
+  sendScopedBrowserRpc,
+  type BrowserTargetScope,
+  type BrowserToolDeps,
+} from '../browserScope';
 
 // Optional surfaceId schema reused across tools
 const optionalSurfaceId = z
@@ -130,13 +134,12 @@ const BROWSER_RESIZE_SHAPE = {
 // the Playwright Page first and falls back to RPC only when no Page is available.
 
 /** Current page URL, transport-agnostic. Used for sensitive-domain checks. */
-async function currentUrl(page: Page | null, surfaceId?: string): Promise<string> {
+async function currentUrl(page: Page | null, scope: BrowserTargetScope): Promise<string> {
   if (page) return page.url();
   try {
-    const r = (await sendRpc('browser.evaluate', {
+    const r = await sendScopedBrowserRpc<{ value: unknown }>('browser.evaluate', scope, {
       expression: 'location.href',
-      ...(surfaceId && { surfaceId }),
-    })) as { value: unknown };
+    });
     return typeof r.value === 'string' ? r.value : '';
   } catch {
     return '';
@@ -156,7 +159,7 @@ async function currentUrl(page: Page | null, surfaceId?: string): Promise<string
  *  - browser_emulate  -- apply various emulation settings
  *  - browser_resize   -- change the viewport size
  */
-export function registerStateTools(server: McpServer): void {
+export function registerStateTools(server: McpServer, deps: BrowserToolDeps): void {
   const engine = PlaywrightEngine.getInstance();
 
   // -----------------------------------------------------------------------
@@ -166,10 +169,10 @@ export function registerStateTools(server: McpServer): void {
     'browser_cookies',
     'Manage browser cookies: get, set, or clear. Reads from sensitive domains (email, banking, auth) are blocked and values from such domains are redacted unless allowSensitiveDomains:true is set.',
     BROWSER_COOKIES_SHAPE,
-    async ({ action, url, cookies, allowSensitiveDomains, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ action, url, cookies, allowSensitiveDomains, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         // Playwright Page when available (dev), else CDP over RPC (packaged, #111).
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
         switch (action) {
           case 'get': {
@@ -184,11 +187,12 @@ export function registerStateTools(server: McpServer): void {
             }
             const allCookies: Array<{ domain?: string; value: string; [k: string]: unknown }> = page
               ? await page.context().cookies(url ? [url] : [])
-              : ((await sendRpc('browser.cookies', {
+              : (await sendScopedBrowserRpc<{
+                  cookies: Array<{ domain?: string; value: string }>;
+                }>('browser.cookies', scope, {
                   action: 'get',
                   urls: url ? [url] : [],
-                  ...(surfaceId && { surfaceId }),
-                })) as { cookies: Array<{ domain?: string; value: string }> }).cookies;
+                })).cookies;
             const safe = allCookies.map((c) => {
               const hit = matchSensitiveDomain(c.domain ?? '');
               if (hit && !allowSensitiveDomains) {
@@ -225,10 +229,9 @@ export function registerStateTools(server: McpServer): void {
             if (page) {
               await page.context().addCookies(cookiesToAdd);
             } else {
-              await sendRpc('browser.cookies', {
+              await sendScopedBrowserRpc('browser.cookies', scope, {
                 action: 'set',
                 cookies: cookiesToAdd,
-                ...(surfaceId && { surfaceId }),
               });
             }
 
@@ -246,9 +249,8 @@ export function registerStateTools(server: McpServer): void {
             if (page) {
               await page.context().clearCookies();
             } else {
-              await sendRpc('browser.cookies', {
+              await sendScopedBrowserRpc('browser.cookies', scope, {
                 action: 'clear',
-                ...(surfaceId && { surfaceId }),
               });
             }
             return {
@@ -276,19 +278,19 @@ export function registerStateTools(server: McpServer): void {
     'browser_storage',
     'Manage localStorage or sessionStorage: get, set, or clear. Reads on sensitive pages (email, banking, auth) are blocked unless allowSensitiveDomains:true is set.',
     BROWSER_STORAGE_SHAPE,
-    async ({ type, action, key, value, allowSensitiveDomains, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ type, action, key, value, allowSensitiveDomains, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         // browser_storage is pure page.evaluate, so it unifies over the same
         // evaluate transport the extraction tools use: a Playwright Page when
         // available, else browser.evaluate over RPC (packaged builds, #111).
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
         const storageName = type === 'local' ? 'localStorage' : 'sessionStorage';
 
         switch (action) {
           case 'get': {
             if (!allowSensitiveDomains) {
-              const sensitive = matchSensitiveDomain(await currentUrl(page, surfaceId));
+              const sensitive = matchSensitiveDomain(await currentUrl(page, scope));
               if (sensitive) {
                 throw new Error(
                   `browser_storage get blocked: current page "${sensitive}" is on the sensitive-domain blocklist (email / banking / auth). ` +
@@ -314,7 +316,7 @@ export function registerStateTools(server: McpServer): void {
                 return entries;
               },
               [storageName, key] as [string, string | undefined],
-              surfaceId,
+              scope,
             );
 
             const text =
@@ -337,7 +339,7 @@ export function registerStateTools(server: McpServer): void {
                 storage.setItem(sKey, sValue);
               },
               [storageName, key, value ?? ''] as [string, string, string],
-              surfaceId,
+              scope,
             );
 
             return {
@@ -358,7 +360,7 @@ export function registerStateTools(server: McpServer): void {
                 storage.clear();
               },
               storageName,
-              surfaceId,
+              scope,
             );
 
             return {
@@ -388,9 +390,9 @@ export function registerStateTools(server: McpServer): void {
     'browser_emulate',
     'Apply emulation settings to the browser page: offline mode, custom headers, HTTP credentials, geolocation, color scheme, timezone, locale, or device preset.',
     BROWSER_EMULATE_SHAPE,
-    async ({ offline, headers, credentials, geo, media, timezone, locale, device, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ offline, headers, credentials, geo, media, timezone, locale, device, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
         const applied: string[] = [];
 
         // Resolve a device preset (if any) up front: both transports need its
@@ -516,9 +518,11 @@ export function registerStateTools(server: McpServer): void {
               emulateParams.deviceReset = true;
             }
           }
-          if (surfaceId) emulateParams.surfaceId = surfaceId;
-
-          const res = (await sendRpc('browser.emulate', emulateParams)) as { applied: string[] };
+          const res = await sendScopedBrowserRpc<{ applied: string[] }>(
+            'browser.emulate',
+            scope,
+            emulateParams,
+          );
           applied.push(...res.applied);
         }
 
@@ -558,18 +562,17 @@ export function registerStateTools(server: McpServer): void {
     'browser_resize',
     'Resize the browser viewport to the specified dimensions.',
     BROWSER_RESIZE_SHAPE,
-    async ({ width, height, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ width, height, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
         if (page) {
           await page.setViewportSize({ width, height });
         } else {
           // Packaged RPC fallback (#111): CDP Emulation.setDeviceMetricsOverride.
-          await sendRpc('browser.resize', {
+          await sendScopedBrowserRpc('browser.resize', scope, {
             width,
             height,
-            ...(surfaceId && { surfaceId }),
           });
         }
 

--- a/src/mcp/playwright/tools/utility.ts
+++ b/src/mcp/playwright/tools/utility.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { PlaywrightEngine } from '../PlaywrightEngine';
 import { withAutomationLease } from '../automationLease';
+import type { BrowserToolDeps } from '../browserScope';
 
 // Optional surfaceId schema reused across tools
 const optionalSurfaceId = z
@@ -101,7 +102,7 @@ async function ensureExportDir(filePath: string): Promise<void> {
  *  - browser_pdf   — export the current page as a PDF
  *  - browser_trace — start or stop Playwright tracing
  */
-export function registerUtilityTools(server: McpServer): void {
+export function registerUtilityTools(server: McpServer, deps: BrowserToolDeps): void {
   const engine = PlaywrightEngine.getInstance();
 
   // -----------------------------------------------------------------------
@@ -111,11 +112,11 @@ export function registerUtilityTools(server: McpServer): void {
     'browser_pdf',
     'Export the current page as a PDF file. Falls back to CDP Page.printToPDF when Playwright pdf() is unavailable (e.g. CDP-connected browsers).',
     BROWSER_PDF_SHAPE,
-    async ({ path: outputPath, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ path: outputPath, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         const resolvedPath = resolveBrowserExportPath(outputPath, 'output.pdf');
         await ensureExportDir(resolvedPath);
-        const page = await engine.getPage(surfaceId);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId);
         if (!page) {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }
@@ -176,9 +177,9 @@ export function registerUtilityTools(server: McpServer): void {
     'browser_trace',
     'Start or stop Playwright tracing. Use "start" to begin recording and "stop" to save the trace file.',
     BROWSER_TRACE_SHAPE,
-    async ({ action, path: outputPath, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    async ({ action, path: outputPath, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(surfaceId);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId);
         if (!page) {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }

--- a/src/mcp/playwright/tools/utility.ts
+++ b/src/mcp/playwright/tools/utility.ts
@@ -116,7 +116,7 @@ export function registerUtilityTools(server: McpServer, deps: BrowserToolDeps): 
       try {
         const resolvedPath = resolveBrowserExportPath(outputPath, 'output.pdf');
         await ensureExportDir(resolvedPath);
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId);
+        const page = await engine.getPageForScope(scope);
         if (!page) {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }
@@ -179,7 +179,7 @@ export function registerUtilityTools(server: McpServer, deps: BrowserToolDeps): 
     BROWSER_TRACE_SHAPE,
     async ({ action, path: outputPath, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId);
+        const page = await engine.getPageForScope(scope);
         if (!page) {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }

--- a/src/mcp/playwright/tools/wait.ts
+++ b/src/mcp/playwright/tools/wait.ts
@@ -4,6 +4,7 @@ import { PlaywrightEngine } from '../PlaywrightEngine';
 import { withAutomationLease } from '../automationLease';
 import { detectDangerousPatterns } from '../security';
 import { rpcEvaluator } from '../page-eval';
+import type { BrowserToolDeps } from '../browserScope';
 import {
   defineWmuxTool,
   registerWmuxTools,
@@ -127,7 +128,7 @@ function sleep(ms: number): Promise<void> {
  * Tools:
  *  - browser_wait — wait for a URL, selector, text, JS predicate, or network idle
  */
-export function createWaitToolCatalog() {
+export function createWaitToolCatalog(deps: BrowserToolDeps) {
   const engine = PlaywrightEngine.getInstance();
 
   // -----------------------------------------------------------------------
@@ -139,16 +140,16 @@ export function createWaitToolCatalog() {
       'Wait for a condition: URL pattern, CSS selector, text content, custom JS predicate, or network idle. Priority: url > selector > text > fn > networkidle.',
     inputSchema: BROWSER_WAIT_SHAPE,
     profiles: ['full'],
-    invoke: async ({ url, selector, text, fn, timeout, surfaceId }) => withAutomationLease(surfaceId, async () => {
+    invoke: async ({ url, selector, text, fn, timeout, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       const resolvedTimeout = timeout ?? 30000;
 
       try {
-        const page = await engine.getPage(surfaceId).catch(() => null);
+        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
 
         // Packaged RPC fallback (#114): no Playwright Page, so poll the condition
         // over the CDP channel until it holds or the timeout elapses.
         if (!page) {
-          const evaluate = rpcEvaluator(surfaceId);
+          const evaluate = rpcEvaluator(scope);
           let predicate: () => Promise<boolean>;
           let label: string;
           let warningPrefix = '';
@@ -316,7 +317,8 @@ export function createWaitToolCatalog() {
 /** Register the wait catalog through the wire-neutral current-SDK adapter. */
 export function registerWaitTools(
   server: McpServer,
+  deps: BrowserToolDeps,
   options: RegisterWmuxToolsOptions,
 ): void {
-  registerWmuxTools(server, createWaitToolCatalog(), options);
+  registerWmuxTools(server, createWaitToolCatalog(deps), options);
 }

--- a/src/mcp/playwright/tools/wait.ts
+++ b/src/mcp/playwright/tools/wait.ts
@@ -4,7 +4,7 @@ import { PlaywrightEngine } from '../PlaywrightEngine';
 import { withAutomationLease } from '../automationLease';
 import { detectDangerousPatterns } from '../security';
 import { rpcEvaluator } from '../page-eval';
-import type { BrowserToolDeps } from '../browserScope';
+import { allowScopedRpcFallback, type BrowserToolDeps } from '../browserScope';
 import {
   defineWmuxTool,
   registerWmuxTools,
@@ -144,7 +144,7 @@ export function createWaitToolCatalog(deps: BrowserToolDeps) {
       const resolvedTimeout = timeout ?? 30000;
 
       try {
-        const page = await engine.getPage(scope.surfaceId, scope.workspaceId).catch(() => null);
+        const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         // Packaged RPC fallback (#114): no Playwright Page, so poll the condition
         // over the CDP channel until it holds or the timeout elapses.


### PR DESCRIPTION
## Summary

Scope MCP browser-tool RPC fallbacks and automation leases to the calling session's resolved workspace, closing the cross-workspace target-selection gap left after #679. Browser operations now fail closed when ownership cannot be proven while retaining compatibility with current and supported legacy main processes.

## Changes

- Resolve one immutable browser target scope per tool invocation and reuse it for initial/late automation lease acquisition, page discovery, navigation, auto-open, and every fallback RPC.
- Require scoped Playwright page lookup, validate legacy target ownership and CDP target IDs, and preserve only the narrowly-proven legacy auto-open path.
- Add typed workspace-scope refusals plus source-level and behavioral regression tests across all browser tool groups, including browser_fill's click/evaluate/type fallback sequence.

## CHANGELOG entry

### Fixed

- **Scoped MCP browser fallbacks to their calling workspace.** Browser tools no longer let lease acquisition, CDP discovery, or RPC fallback select a webview from whichever workspace happens to be active when the caller's target is missing or ambiguous. (#749)

## Stability tier impact

- [ ] No external surface touched (internal refactor / docs / tests / CI).
- [ ] Additive change to a stable surface (new optional param, new field, new event type).
- [ ] Breaking change to a stable surface (requires major bump — block until release planning is in scope).
- [x] Change to an experimental surface (note in release notes).
- [ ] Change to an internal surface (no contract impact).

The browser/CDP RPC and MCP tool family is experimental per docs/api/inventory.md.

## Substrate contract impact (Substrate 3.0)

n/a — no RPC method, event type, capability, or public wire shape is added. Existing experimental browser RPCs now consistently receive the already-supported workspaceId.

## Test plan

- npx tsc --noEmit — passed.
- npm run build:mcp — passed.
- MCP workspace/browser regression suite — 14 files, 157 tests passed.
- Main-side browser ownership suite — 2 files, 94 tests passed.
- npm run test:parallel — 655 files / 9,627 tests passed; 2 files / 27 tests skipped.
- npm run test:runtime — 96 passed, 6 skipped, 2 unrelated PowerShell OSC 133 tests failed because local node-pty could not AttachConsole. Re-running that file reproduced the environment failure; this PR does not touch daemon or shell-integration code.
- Exact-digest independent review — Claude Opus, Grok 4.5, and Gemini 3.1 Pro High all approved.

## Related issues / PRs

Closes #695.

Main-side ownership enforcement is already present from #701.

## Reviewer checklist

- [ ] CHANGELOG entry above is filled in or explicitly marked n/a.
- [ ] Stability tier impact is correctly classified.
- [ ] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed.
- [ ] Tests cover the new behavior and the regression case (if a bug fix).
- [ ] No accidental commit of secrets, tokens, .env, or unrelated large binaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Browser automation now remains scoped to the calling workspace across navigation, interaction, inspection, extraction, file, state, utility, and wait operations.
  * Prevented fallback discovery and RPC requests from selecting another workspace’s browser surface.
  * Ambiguous, missing, unverified, or unresolved browser targets now fail safely instead of being used.
* **Tests**
  * Expanded coverage for workspace routing, target ownership, automation leases, fallback behavior, and browser tool registration.
* **Documentation**
  * Added a changelog entry describing workspace-scoped browser fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->