### PR TITLE
fix(terminal): retry deferred fits after selection clears

### DIFF
--- a/changelog.d/750.md
+++ b/changelog.d/750.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Terminal dimensions recover after protected selections.** Resizing a pane
+  while text remained selected could leave xterm and the PTY at stale
+  dimensions until another resize; clearing the selection now runs the
+  deferred fit. (#750)

--- a/src/renderer/hooks/__tests__/useTerminal.deferredFit.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.deferredFit.test.ts
@@ -1,0 +1,27 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = fs.readFileSync(
+  path.resolve(process.cwd(), 'src/renderer/hooks/useTerminal.ts'),
+  'utf8',
+);
+
+describe('useTerminal deferred resize fit wiring', () => {
+  it('routes ResizeObserver work through the deferred fit scheduler', () => {
+    expect(source).toMatch(
+      /const resizeObserver = new ResizeObserver\(\(\) => \{\s*resizeFit\.requestFit\(\);\s*\}\);/,
+    );
+  });
+
+  it('retries pending resize work from the selection-change callback', () => {
+    expect(source).toMatch(
+      /terminal\.onSelectionChange\(\(\) => \{[\s\S]*?resizeFit\.onSelectionChange\(\);\s*\}\);/,
+    );
+  });
+
+  it('records every non-observer fit skipped for an active selection', () => {
+    const deferredCalls = source.match(/deferUntilSelectionClears\(\)/g) ?? [];
+    expect(deferredCalls).toHaveLength(3);
+  });
+});

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -15,6 +15,11 @@ import { openTerminalUrl } from '../utils/browserPaneActions';
 import { runCopyWithFeedback } from '../utils/copyWithFeedback';
 import { shouldFitWhilePreservingSelection } from '../utils/fitGuard';
 import { createAutoSelectionCopy } from '../utils/autoSelectionCopy';
+import {
+  createDeferredTerminalFit,
+  type DeferredTerminalFitHandle,
+  type DeferredTerminalFitOutcome,
+} from '../utils/deferredTerminalFit';
 import { decodeOsc52Write } from '../utils/osc52Clipboard';
 import { terminalFontFamilyCss } from '../utils/terminalFont';
 import { createPathLinkProvider } from '../terminal/pathLinkProvider';
@@ -565,6 +570,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
   if (!webglTokenRef.current) webglTokenRef.current = `wgl-${++webglTokenSeq}`;
   // Pending deferred-WebGL-release timer (see WEBGL_HIDDEN_DISPOSE_DELAY_MS).
   const webglDisposeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resizeFitRef = useRef<DeferredTerminalFitHandle | null>(null);
   // Glyph-corruption repair scheduler (issue #166) — created by the main
   // effect, also poked by the visibility effect on regain.
   const glyphRepaintRef = useRef<GlyphRepaintScheduler | null>(null);
@@ -1159,6 +1165,59 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       fitAddon.fit();
     }
 
+    // Track last sent dimensions to avoid redundant resizes. The resize fit
+    // scheduler also remembers a fit blocked by an active selection; releasing
+    // a selection does not produce another ResizeObserver event by itself.
+    let lastSentCols = 0;
+    let lastSentRows = 0;
+    const resizeFit = createDeferredTerminalFit({
+      hasSelection: () => terminal.hasSelection(),
+      attemptFit: (): DeferredTerminalFitOutcome => {
+        try {
+          const term = terminalRef.current;
+          if (!term) return 'skipped';
+
+          if (container.offsetWidth === 0 || container.offsetHeight === 0) {
+            return 'skipped';
+          }
+
+          // xterm's SelectionService clears the active selection on any
+          // rowsChanged event from fit(). Retry from onSelectionChange instead.
+          if (!shouldFitWhilePreservingSelection(term)) {
+            console.debug('[Terminal] resize fit skipped — active selection');
+            return 'deferred';
+          }
+
+          const prevYBase = term.buffer.active.baseY;
+          const prevYDisp = term.buffer.active.viewportY;
+          const wasScrolledUp = prevYDisp < prevYBase;
+          const distFromBottom = prevYBase - prevYDisp;
+
+          fitAddon.fit();
+
+          if (wasScrolledUp) {
+            const newYBase = term.buffer.active.baseY;
+            const targetYDisp = Math.max(0, newYBase - distFromBottom);
+            term.scrollToLine(targetYDisp);
+          }
+
+          const { cols, rows } = term;
+          const currentPtyId = ptyIdRef.current;
+          if (currentPtyId && cols > 0 && rows > 0
+            && (cols !== lastSentCols || rows !== lastSentRows)) {
+            lastSentCols = cols;
+            lastSentRows = rows;
+            sendResize(currentPtyId, cols, rows);
+          }
+          return 'fitted';
+        } catch {
+          // Ignore fit errors during unmount.
+          return 'skipped';
+        }
+      },
+    });
+    resizeFitRef.current = resizeFit;
+
     // Wait for fonts to fully load, then rebuild the WebGL glyph atlas.
     // font-display:swap causes the browser to render with a fallback font first,
     // so the WebGL atlas may contain glyphs measured with wrong metrics.
@@ -1181,17 +1240,16 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // the contract here prevents future regressions if anything triggers
       // a font load mid-session.
       if (!shouldFitWhilePreservingSelection(terminalRef.current)) {
+        resizeFit.deferUntilSelectionClears();
+        // Repainting the rebuilt atlas does not disturb selection. The
+        // deferred fit will repaint again if it changes terminal dimensions.
+        terminal.refresh(0, terminal.rows - 1);
         console.debug('[Terminal] fonts.ready fit skipped — active selection');
         return;
       }
       fitAddon.fit();
       terminal.refresh(0, terminal.rows - 1);
     });
-
-    // Track last sent dimensions to avoid redundant resizes
-    let lastSentCols = 0;
-    let lastSentRows = 0;
-    let resizeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
     // Auto-copy on selection (debounced) — selection survives just long enough
     // for the user to release the mouse, then we push it to the clipboard.
@@ -1208,6 +1266,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     });
     const selectionDisposable = terminal.onSelectionChange(() => {
       autoCopy.onSelection(terminal.getSelection());
+      resizeFit.onSelectionChange();
     });
 
     // Clipboard + shortcut handling
@@ -1990,57 +2049,13 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // Fitting a hidden terminal produces 0 cols/rows, which corrupts the PTY buffer
     // and manifests as "infinite content duplication" when switching back to it.
     const resizeObserver = new ResizeObserver(() => {
-      if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
-      resizeDebounceTimer = setTimeout(() => {
-        resizeDebounceTimer = null;
-        requestAnimationFrame(() => {
-          try {
-            const term = terminalRef.current;
-            if (!term) return;
-
-            if (container.offsetWidth === 0 || container.offsetHeight === 0) return;
-
-            // Selection-preservation guard: xterm's SelectionService clears
-            // the active selection on any rowsChanged event from fit().
-            // While the user is dragging out a selection (or while a
-            // selection is live waiting to be copied) skip this fit and let
-            // the next ResizeObserver tick handle the resize once the
-            // selection is released.
-            if (!shouldFitWhilePreservingSelection(term)) {
-              console.debug('[Terminal] resize fit skipped — active selection');
-              return;
-            }
-
-            const prevYBase = term.buffer.active.baseY;
-            const prevYDisp = term.buffer.active.viewportY;
-            const wasScrolledUp = prevYDisp < prevYBase;
-            const distFromBottom = prevYBase - prevYDisp;
-
-            fitAddon.fit();
-
-            if (wasScrolledUp) {
-              const newYBase = term.buffer.active.baseY;
-              const targetYDisp = Math.max(0, newYBase - distFromBottom);
-              term.scrollToLine(targetYDisp);
-            }
-
-            const { cols, rows } = term;
-            const currentPtyId = ptyIdRef.current;
-            if (currentPtyId && cols > 0 && rows > 0 && (cols !== lastSentCols || rows !== lastSentRows)) {
-              lastSentCols = cols;
-              lastSentRows = rows;
-              sendResize(currentPtyId, cols, rows);
-            }
-          } catch {
-            // ignore fit errors during unmount
-          }
-        });
-      }, 100);
+      resizeFit.requestFit();
     });
     resizeObserver.observe(container);
 
     return () => {
-      if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
+      resizeFit.dispose();
+      if (resizeFitRef.current === resizeFit) resizeFitRef.current = null;
       if (isMac) { container.removeEventListener('paste', blockNativePaste, true); }
       terminal.textarea?.removeEventListener('focus', onTextareaFocus);
       terminal.textarea?.removeEventListener('keydown', onWatchdogKeyDown);
@@ -2194,6 +2209,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     }
     // Selection-preservation guard — see ResizeObserver above.
     if (!shouldFitWhilePreservingSelection(terminalRef.current)) {
+      resizeFitRef.current?.deferUntilSelectionClears();
       console.debug('[Terminal] font/theme fit skipped — active selection');
       return;
     }
@@ -2302,9 +2318,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // Defer fit to allow CSS display change to take effect before measuring.
       // Selection-preservation guard — workspace/tab switch then immediate
       // selection + Ctrl+C used to wipe the selection because this fit had
-      // no guard (unlike ResizeObserver and font/theme paths). The next
-      // ResizeObserver tick (after selection is released) handles the
-      // deferred resize naturally.
+      // no guard (unlike ResizeObserver and font/theme paths). Record a
+      // deferred fit so selection release can retry it explicitly.
       const id = requestAnimationFrame(() => {
         // Issue #166 — repaint BEFORE the selection guard: refresh() does not
         // touch the selection, and a stale pane must repair on view-switch-back
@@ -2313,6 +2328,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         // rebuilding it.
         glyphRepaintRef.current?.onVisible();
         if (!shouldFitWhilePreservingSelection(terminalRef.current)) {
+          resizeFitRef.current?.deferUntilSelectionClears();
           console.debug('[Terminal] visibility fit skipped — active selection');
           return;
         }

--- a/src/renderer/utils/__tests__/deferredTerminalFit.test.ts
+++ b/src/renderer/utils/__tests__/deferredTerminalFit.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createDeferredTerminalFit,
+  type DeferredTerminalFitOutcome,
+} from '../deferredTerminalFit';
+
+function createFrameQueue() {
+  let nextId = 1;
+  const frames = new Map<number, () => void>();
+
+  return {
+    request: (fn: () => void): number => {
+      const id = nextId;
+      nextId += 1;
+      frames.set(id, fn);
+      return id;
+    },
+    cancel: (id: number): void => {
+      frames.delete(id);
+    },
+    flush: (): void => {
+      const queued = [...frames.values()];
+      frames.clear();
+      for (const frame of queued) frame();
+    },
+    size: (): number => frames.size,
+  };
+}
+
+describe('createDeferredTerminalFit', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('debounces resize requests before attempting one animation-frame fit', () => {
+    const frames = createFrameQueue();
+    const attemptFit = vi.fn<() => DeferredTerminalFitOutcome>(() => 'fitted');
+    const fit = createDeferredTerminalFit({
+      attemptFit,
+      hasSelection: () => false,
+      requestAnimationFrameFn: frames.request,
+      cancelAnimationFrameFn: frames.cancel,
+    });
+
+    fit.requestFit();
+    vi.advanceTimersByTime(40);
+    fit.requestFit();
+    vi.advanceTimersByTime(99);
+
+    expect(frames.size()).toBe(0);
+    expect(attemptFit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(frames.size()).toBe(1);
+    frames.flush();
+
+    expect(attemptFit).toHaveBeenCalledTimes(1);
+  });
+
+  it('supersedes an animation-frame fit when a newer resize arrives', () => {
+    const frames = createFrameQueue();
+    const attemptFit = vi.fn<() => DeferredTerminalFitOutcome>(() => 'fitted');
+    const fit = createDeferredTerminalFit({
+      attemptFit,
+      hasSelection: () => false,
+      requestAnimationFrameFn: frames.request,
+      cancelAnimationFrameFn: frames.cancel,
+    });
+
+    fit.requestFit();
+    vi.advanceTimersByTime(100);
+    expect(frames.size()).toBe(1);
+
+    fit.requestFit();
+    expect(frames.size()).toBe(0);
+    vi.advanceTimersByTime(100);
+    expect(frames.size()).toBe(1);
+    frames.flush();
+
+    expect(attemptFit).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a fit deferred by a live selection when the selection clears', () => {
+    const frames = createFrameQueue();
+    let selected = true;
+    const attemptFit = vi.fn<() => DeferredTerminalFitOutcome>(
+      () => (selected ? 'deferred' : 'fitted'),
+    );
+    const fit = createDeferredTerminalFit({
+      attemptFit,
+      hasSelection: () => selected,
+      requestAnimationFrameFn: frames.request,
+      cancelAnimationFrameFn: frames.cancel,
+    });
+
+    fit.requestFit();
+    vi.advanceTimersByTime(100);
+    frames.flush();
+    expect(attemptFit).toHaveBeenCalledTimes(1);
+
+    fit.onSelectionChange();
+    vi.advanceTimersByTime(100);
+    frames.flush();
+    expect(attemptFit).toHaveBeenCalledTimes(1);
+
+    selected = false;
+    fit.onSelectionChange();
+    vi.advanceTimersByTime(99);
+    expect(frames.size()).toBe(0);
+    vi.advanceTimersByTime(1);
+    frames.flush();
+
+    expect(attemptFit).toHaveBeenCalledTimes(2);
+  });
+
+  it('records fits deferred outside the ResizeObserver path', () => {
+    const frames = createFrameQueue();
+    let selected = true;
+    const attemptFit = vi.fn<() => DeferredTerminalFitOutcome>(() => 'fitted');
+    const fit = createDeferredTerminalFit({
+      attemptFit,
+      hasSelection: () => selected,
+      requestAnimationFrameFn: frames.request,
+      cancelAnimationFrameFn: frames.cancel,
+    });
+
+    fit.deferUntilSelectionClears();
+    fit.onSelectionChange();
+    vi.advanceTimersByTime(100);
+    expect(frames.size()).toBe(0);
+
+    selected = false;
+    fit.onSelectionChange();
+    vi.advanceTimersByTime(100);
+    frames.flush();
+
+    expect(attemptFit).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the fit deferred if a new selection appears before the retry runs', () => {
+    const frames = createFrameQueue();
+    let selected = true;
+    const attemptFit = vi.fn<() => DeferredTerminalFitOutcome>(
+      () => (selected ? 'deferred' : 'fitted'),
+    );
+    const fit = createDeferredTerminalFit({
+      attemptFit,
+      hasSelection: () => selected,
+      requestAnimationFrameFn: frames.request,
+      cancelAnimationFrameFn: frames.cancel,
+    });
+
+    fit.requestFit();
+    vi.advanceTimersByTime(100);
+    frames.flush();
+
+    selected = false;
+    fit.onSelectionChange();
+    vi.advanceTimersByTime(100);
+    selected = true;
+    frames.flush();
+
+    selected = false;
+    fit.onSelectionChange();
+    vi.advanceTimersByTime(100);
+    frames.flush();
+
+    expect(attemptFit).toHaveBeenCalledTimes(3);
+    expect(attemptFit.mock.results.map((result) => result.value)).toEqual([
+      'deferred',
+      'deferred',
+      'fitted',
+    ]);
+  });
+
+  it('does not retry an ordinary skipped fit on selection changes', () => {
+    const frames = createFrameQueue();
+    const attemptFit = vi.fn<() => DeferredTerminalFitOutcome>(() => 'skipped');
+    const fit = createDeferredTerminalFit({
+      attemptFit,
+      hasSelection: () => false,
+      requestAnimationFrameFn: frames.request,
+      cancelAnimationFrameFn: frames.cancel,
+    });
+
+    fit.requestFit();
+    vi.advanceTimersByTime(100);
+    frames.flush();
+    fit.onSelectionChange();
+    vi.advanceTimersByTime(100);
+    frames.flush();
+
+    expect(attemptFit).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispose cancels both debounced and animation-frame work', () => {
+    const frames = createFrameQueue();
+    const attemptFit = vi.fn<() => DeferredTerminalFitOutcome>(() => 'fitted');
+    const fit = createDeferredTerminalFit({
+      attemptFit,
+      hasSelection: () => false,
+      requestAnimationFrameFn: frames.request,
+      cancelAnimationFrameFn: frames.cancel,
+    });
+
+    fit.requestFit();
+    fit.dispose();
+    vi.advanceTimersByTime(100);
+    expect(frames.size()).toBe(0);
+
+    fit.requestFit();
+    vi.advanceTimersByTime(100);
+    expect(frames.size()).toBe(1);
+    fit.dispose();
+    frames.flush();
+
+    expect(attemptFit).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/utils/deferredTerminalFit.ts
+++ b/src/renderer/utils/deferredTerminalFit.ts
@@ -1,0 +1,97 @@
+/**
+ * Debounces terminal resize fits and retries a fit that was blocked by an
+ * active selection once that selection clears.
+ *
+ * xterm clears selections when a fit changes the row count. ResizeObserver
+ * does not fire merely because a selection was released, so the scheduler
+ * keeps an explicit deferred bit instead of waiting for another resize.
+ */
+
+export type DeferredTerminalFitOutcome = 'fitted' | 'deferred' | 'skipped';
+
+export interface DeferredTerminalFitDeps {
+  /** Attempt the fit and report whether it ran, was deferred, or was skipped. */
+  attemptFit: () => DeferredTerminalFitOutcome;
+  /** Whether the terminal currently has an active selection. */
+  hasSelection: () => boolean;
+  /** Debounce window in milliseconds. Defaults to 100. */
+  debounceMs?: number;
+  /** Test seams for the timer and animation-frame queues. */
+  setTimeoutFn?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clearTimeoutFn?: (handle: ReturnType<typeof setTimeout>) => void;
+  requestAnimationFrameFn?: (fn: () => void) => number;
+  cancelAnimationFrameFn?: (handle: number) => void;
+}
+
+export interface DeferredTerminalFitHandle {
+  /** Debounce and queue a fit attempt. */
+  requestFit: () => void;
+  /** Record a fit skipped by a caller outside the normal resize path. */
+  deferUntilSelectionClears: () => void;
+  /** Retry a deferred fit when the terminal reports that selection changed. */
+  onSelectionChange: () => void;
+  /** Cancel queued work during terminal teardown. */
+  dispose: () => void;
+}
+
+const DEFAULT_DEBOUNCE_MS = 100;
+
+export function createDeferredTerminalFit(
+  deps: DeferredTerminalFitDeps,
+): DeferredTerminalFitHandle {
+  const debounceMs = deps.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  const setT = deps.setTimeoutFn ?? ((fn, ms) => setTimeout(fn, ms));
+  const clearT = deps.clearTimeoutFn ?? ((handle) => clearTimeout(handle));
+  const requestFrame = deps.requestAnimationFrameFn
+    ?? ((fn) => requestAnimationFrame(fn));
+  const cancelFrame = deps.cancelAnimationFrameFn
+    ?? ((handle) => cancelAnimationFrame(handle));
+
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let animationFrame: number | null = null;
+  let waitingForSelectionRelease = false;
+
+  const requestFit = (): void => {
+    if (animationFrame !== null) {
+      cancelFrame(animationFrame);
+      animationFrame = null;
+    }
+    if (debounceTimer !== null) clearT(debounceTimer);
+    debounceTimer = setT(() => {
+      debounceTimer = null;
+      animationFrame = requestFrame(() => {
+        animationFrame = null;
+        waitingForSelectionRelease = deps.attemptFit() === 'deferred';
+      });
+    }, debounceMs);
+  };
+
+  const deferUntilSelectionClears = (): void => {
+    waitingForSelectionRelease = true;
+  };
+
+  const onSelectionChange = (): void => {
+    if (!waitingForSelectionRelease || deps.hasSelection()) return;
+    waitingForSelectionRelease = false;
+    requestFit();
+  };
+
+  const dispose = (): void => {
+    waitingForSelectionRelease = false;
+    if (debounceTimer !== null) {
+      clearT(debounceTimer);
+      debounceTimer = null;
+    }
+    if (animationFrame !== null) {
+      cancelFrame(animationFrame);
+      animationFrame = null;
+    }
+  };
+
+  return {
+    requestFit,
+    deferUntilSelectionClears,
+    onSelectionChange,
+    dispose,
+  };
+}

--- a/src/renderer/utils/fitGuard.ts
+++ b/src/renderer/utils/fitGuard.ts
@@ -10,8 +10,8 @@
  * current position.
  *
  * Skipping `fit()` while the user has an active selection prevents the
- * clear; the next ResizeObserver tick (after the user releases) handles the
- * deferred resize.
+ * clear. Callers must explicitly retry the fit when the selection clears;
+ * selection release by itself does not trigger ResizeObserver.
  */
 
 /**


### PR DESCRIPTION
## Summary

Retry terminal fits that were skipped to preserve an active xterm selection. This prevents xterm and the backing PTY from remaining at stale dimensions after the selection clears.

## Changes

- Route ResizeObserver fitting through a debounced scheduler that records selection-blocked attempts and retries them from `onSelectionChange`.
- Reuse the existing scroll-preserving fit and deduplicated PTY resize path for deferred work, including fits skipped by font/theme and visibility guards.
- Add focused scheduler race/teardown tests and source-level wiring guards for the xterm-bound hook.

## CHANGELOG entry

### Fixed

- **Terminal dimensions recover after protected selections.** Resizing a pane while text remained selected could leave xterm and the PTY at stale dimensions until another resize; clearing the selection now runs the deferred fit.

## Stability tier impact

- [ ] No external surface touched (internal refactor / docs / tests / CI).
- [ ] Additive change to a `stable` surface (new optional param, new field, new event type).
- [ ] Breaking change to a `stable` surface (requires major bump — block until release planning is in scope).
- [ ] Change to an `experimental` surface (note in release notes).
- [x] Change to an `internal` surface (no contract impact).

## Substrate contract impact (Substrate 3.0)

n/a

## Test plan

- `npx vitest run src/renderer/utils/__tests__/deferredTerminalFit.test.ts src/renderer/utils/__tests__/fitGuard.test.ts src/renderer/hooks/__tests__/useTerminal.deferredFit.test.ts` — 14 passed.
- `npx vitest run src/renderer` — 2,754 passed across 219 files.
- `npm run test:parallel` — 9,621 passed, 27 skipped across 656 files.
- `npx tsc --noEmit` — passed.
- Targeted ESLint for the new scheduler/tests and fit guard — passed.
- `npm run test:runtime` — 96 passed, 6 skipped, 2 unrelated `shellIntegration.runtime.test.ts` cases timed out after the Windows `node-pty` helper reported `AttachConsole failed` on local Node 24.18.0.
- `npm run lint` — not clean on current `main` baseline (218 existing errors); no errors in the targeted new helper/test files.
- Manual Electron reproduction — not run locally; CI and maintainer smoke testing remain useful for the xterm interaction.

## Related issues / PRs

Closes #747.

## Reviewer checklist

- [ ] CHANGELOG entry above is filled in or explicitly marked n/a.
- [ ] Stability tier impact is correctly classified.
- [ ] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed.
- [ ] Tests cover the new behavior and the regression case (if a bug fix).
- [ ] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.