### PR TITLE
Keep multiviewIds consistent when members go away

### DIFF
--- a/changelog.d/753.md
+++ b/changelog.d/753.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **Closing a workspace no longer leaves multiview in a broken state.** Closing
+  members of a multiview group from the sidebar could leave the app showing a
+  single tile still wrapped in multiview chrome, with no way back except
+  `Ctrl+Shift+G`. The closed workspace is now dropped from the group, and the
+  group disbands once fewer than two members remain. (#753)
+- **Ctrl+click on the workspace you are looking at no longer closes the whole
+  grid.** Removing the active workspace from a multiview group took every other
+  tile with it. Focus now moves to a neighbouring tile first, the way the tile's
+  own ✕ button already behaved. (#753)

--- a/src/renderer/components/Layout/WorkspaceViewport.tsx
+++ b/src/renderer/components/Layout/WorkspaceViewport.tsx
@@ -68,12 +68,12 @@ const MultiviewWorkspaceSlot = memo(function MultiviewWorkspaceSlot({
 }: {
   workspace: Workspace;
   isActive: boolean;
-  /** Count of multiview members — the close handler needs it to hand off focus. */
+  /** Count of multiview members — a change here can reflow this tile out of view. */
   multiviewCount: number;
   /** Current grid arrangement — a layout change can move this tile out of view. */
   arrangement: MultiviewArrangement;
   onActivate: (id: string) => void;
-  onRemove: (id: string, isActive: boolean, multiviewCount: number) => void;
+  onRemove: (id: string) => void;
 }) {
   // An explicit arrangement lets the grid scroll (see multiviewGrid.ts), so a
   // tile reached by Ctrl+Shift+Arrow can be off-screen. `nearest` scrolls the
@@ -109,7 +109,7 @@ const MultiviewWorkspaceSlot = memo(function MultiviewWorkspaceSlot({
         <button
           onClick={(e) => {
             e.stopPropagation();
-            onRemove(workspace.id, isActive, multiviewCount);
+            onRemove(workspace.id);
           }}
           className="ml-auto opacity-60 hover:opacity-100"
           style={{
@@ -153,18 +153,11 @@ export function WorkspaceViewport() {
   const removeMultiviewWorkspace = useStore((s) => s.removeMultiviewWorkspace);
   const t = useT();
 
-  // Close a multiview tile. If closing the ACTIVE tile with others remaining,
-  // hand focus to a neighbor first — otherwise the grid gate
-  // (multiviewIds.includes(activeId)) fails the next render and the view
-  // collapses to the just-closed workspace (reads as "the window reset").
-  const handleRemoveTile = (id: string, isActive: boolean, count: number) => {
-    if (isActive && count > 2) {
-      const removedIdx = multiviewIds.indexOf(id);
-      const nextActive = multiviewIds[removedIdx + 1] ?? multiviewIds[removedIdx - 1];
-      if (nextActive) setActiveWorkspace(nextActive);
-    }
-    removeMultiviewWorkspace(id);
-  };
+  // The focus handoff that used to live here — activate a neighbour before
+  // removing the active tile, so the grid gate doesn't collapse the whole view —
+  // moved into removeMultiviewWorkspace (#752). The sidebar's Ctrl+click path
+  // had no equivalent and lost the grid; keeping one copy in the store is what
+  // stops the two from drifting apart again.
 
   // Fix 0 — while startup reconcile is in flight, show a placeholder. Chrome
   // stays mounted (it's AppLayout, not here) so the user sees wmux is alive.
@@ -204,7 +197,7 @@ export function WorkspaceViewport() {
             multiviewCount={multiviewIds.length}
             arrangement={multiviewArrangement}
             onActivate={setActiveWorkspace}
-            onRemove={handleRemoveTile}
+            onRemove={removeMultiviewWorkspace}
           />
         ))}
       </div>

--- a/src/renderer/stores/slices/__tests__/uiSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/uiSlice.test.ts
@@ -442,8 +442,15 @@ describe('UISlice — multiview', () => {
       // @ts-expect-error — cross-slice field overlaid for the test
       activeWorkspaceId: id,
     }));
-    // @ts-expect-error — cross-slice fields injected for the test
-    store.setState({ multiviewIds: ids, activeWorkspaceId: active, setActiveWorkspace });
+    store.setState({
+      multiviewIds: ids,
+      // @ts-expect-error — cross-slice fields injected for the test
+      activeWorkspaceId: active,
+      // The handoff only considers members that still exist, so the test store
+      // needs real workspaces behind the ids.
+      workspaces: ids.map((id) => ({ id })),
+      setActiveWorkspace,
+    });
     return { store, setActiveWorkspace };
   }
 
@@ -482,6 +489,33 @@ describe('UISlice — multiview', () => {
     store.getState().toggleMultiviewWorkspace('A');
     expect(setActiveWorkspace).not.toHaveBeenCalled();
     expect(store.getState().multiviewIds).toEqual([]);
+  });
+
+  it('skips a dead neighbour instead of handing focus to a workspace that is gone', () => {
+    // setActiveWorkspace ignores unknown ids, so choosing a stale member would
+    // be a silent no-op and the grid would close anyway — the exact failure the
+    // handoff exists to prevent.
+    const { store, setActiveWorkspace } = withActiveSpy(['A', 'GHOST', 'B', 'C'], 'A');
+    store.setState({
+      // @ts-expect-error — cross-slice field overlaid for the test
+      workspaces: [{ id: 'A' }, { id: 'B' }, { id: 'C' }],
+    });
+    store.getState().toggleMultiviewWorkspace('A');
+    expect(setActiveWorkspace).toHaveBeenCalledWith('B');
+    expect(setActiveWorkspace).not.toHaveBeenCalledWith('GHOST');
+  });
+
+  it('never hands focus back to the workspace being removed', () => {
+    // A duplicated id would otherwise make the neighbour of A be A itself, so
+    // the grid would close on the very next line.
+    const { store, setActiveWorkspace } = withActiveSpy(['A', 'A', 'B', 'C'], 'A');
+    store.setState({
+      // @ts-expect-error — cross-slice field overlaid for the test
+      workspaces: [{ id: 'A' }, { id: 'B' }, { id: 'C' }],
+    });
+    store.getState().toggleMultiviewWorkspace('A');
+    expect(setActiveWorkspace).not.toHaveBeenCalledWith('A');
+    expect(setActiveWorkspace).toHaveBeenCalledWith('B');
   });
 
   it('removeMultiviewWorkspace removes only the targeted workspace from a 3+ group', () => {

--- a/src/renderer/stores/slices/__tests__/uiSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/uiSlice.test.ts
@@ -431,6 +431,59 @@ describe('UISlice — multiview', () => {
   // The fix introduces a dedicated remove primitive so close intent cannot
   // accidentally re-add the workspace through toggle semantics.
 
+  // #752 — dropping the ACTIVE workspace used to take the whole grid with it,
+  // because the render gate needs the active workspace to be a member. The tile
+  // ✕ compensated in the view; the sidebar's Ctrl+click had no equivalent and
+  // silently closed the grid. The handoff now lives in the store, so both
+  // entry points get it and cannot drift apart again.
+  function withActiveSpy(ids: string[], active: string) {
+    const store = createTestStore();
+    const setActiveWorkspace = vi.fn((id: string) => store.setState({
+      // @ts-expect-error — cross-slice field overlaid for the test
+      activeWorkspaceId: id,
+    }));
+    // @ts-expect-error — cross-slice fields injected for the test
+    store.setState({ multiviewIds: ids, activeWorkspaceId: active, setActiveWorkspace });
+    return { store, setActiveWorkspace };
+  }
+
+  it('toggling off the active member hands focus to a neighbour instead of closing the grid', () => {
+    const { store, setActiveWorkspace } = withActiveSpy(['A', 'B', 'C'], 'A');
+    store.getState().toggleMultiviewWorkspace('A');
+    expect(setActiveWorkspace).toHaveBeenCalledWith('B');
+    expect(store.getState().multiviewIds).toEqual(['B', 'C']);
+    // The gate is `active ∈ multiviewIds`; without the handoff this is false
+    // and every remaining tile disappears at once.
+    // @ts-expect-error — cross-slice field overlaid for the test
+    expect(store.getState().multiviewIds).toContain(store.getState().activeWorkspaceId as string);
+  });
+
+  it('removing the active tile hands focus to a neighbour too (same rule, other entry point)', () => {
+    const { store, setActiveWorkspace } = withActiveSpy(['A', 'B', 'C'], 'B');
+    store.getState().removeMultiviewWorkspace('B');
+    expect(setActiveWorkspace).toHaveBeenCalledWith('C');
+    expect(store.getState().multiviewIds).toEqual(['A', 'C']);
+    // @ts-expect-error — cross-slice field overlaid for the test
+    expect(store.getState().multiviewIds).toContain(store.getState().activeWorkspaceId as string);
+  });
+
+  it('falls back to the previous member when the active tile is last', () => {
+    const { store, setActiveWorkspace } = withActiveSpy(['A', 'B', 'C'], 'C');
+    store.getState().toggleMultiviewWorkspace('C');
+    expect(setActiveWorkspace).toHaveBeenCalledWith('B');
+    expect(store.getState().multiviewIds).toEqual(['A', 'B']);
+  });
+
+  it('does not hand off when the group collapses anyway', () => {
+    // Two members: removing one leaves a single member, which auto-clears to
+    // single view. Reassigning focus there would yank the user to a workspace
+    // they did not ask for.
+    const { store, setActiveWorkspace } = withActiveSpy(['A', 'B'], 'A');
+    store.getState().toggleMultiviewWorkspace('A');
+    expect(setActiveWorkspace).not.toHaveBeenCalled();
+    expect(store.getState().multiviewIds).toEqual([]);
+  });
+
   it('removeMultiviewWorkspace removes only the targeted workspace from a 3+ group', () => {
     // [A, B, C] active A. Click X on inactive B → grid stays as [A, C].
     // Pre-fix this collapsed to []; the active-tile case still collapses

--- a/src/renderer/stores/slices/__tests__/workspaceSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/workspaceSlice.test.ts
@@ -239,6 +239,31 @@ describe('removeWorkspace — multiview membership is pruned', () => {
     expect(store.getState().multiviewIds).toEqual([]);
   });
 
+  it('promotes a surviving GRID MEMBER when the active member is closed', () => {
+    // The third entry point into #752: promoting by array position can land on
+    // a workspace outside the group, and the gate needs the active workspace to
+    // be a member — so closing the active tile from the sidebar would take every
+    // remaining tile with it.
+    // workspaces [A,B,C,D], group [A,B,D], active B. Positional promotion would
+    // pick C, which is not a member.
+    const [a, b, c, d] = [createWorkspace('A'), createWorkspace('B'), createWorkspace('C'), createWorkspace('D')];
+    const store = createMvStore([a, b, c, d], b.id, [a.id, b.id, d.id]);
+    store.getState().removeWorkspace(b.id);
+    expect(store.getState().multiviewIds).toEqual([a.id, d.id]);
+    expect(store.getState().multiviewIds).toContain(store.getState().activeWorkspaceId);
+    expect(store.getState().activeWorkspaceId).toBe(d.id); // the grid neighbour
+  });
+
+  it('falls back to positional promotion when the group does not survive', () => {
+    // Group of two: removing one disbands it, so there is no member to promote
+    // and the ordinary neighbour-by-position rule applies.
+    const [a, b, c] = [createWorkspace('A'), createWorkspace('B'), createWorkspace('C')];
+    const store = createMvStore([a, b, c], a.id, [a.id, b.id]);
+    store.getState().removeWorkspace(a.id);
+    expect(store.getState().multiviewIds).toEqual([]);
+    expect(store.getState().activeWorkspaceId).toBe(b.id);
+  });
+
   it('leaves the group alone when a non-member is closed', () => {
     const [a, b, c] = [createWorkspace('A'), createWorkspace('B'), createWorkspace('C')];
     const store = createMvStore([a, b, c], a.id, [a.id, b.id]);

--- a/src/renderer/stores/slices/__tests__/workspaceSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/workspaceSlice.test.ts
@@ -205,3 +205,44 @@ describe('updateWorkspaceMetadata — referential stability (WorkspaceSlot memo 
     expect(store.getState().workspaces[0].rootPane).toBe(beforeRoot);
   });
 });
+
+// #751 — removeWorkspace spliced the workspace but left its id in multiviewIds.
+// The grid gate counts multiviewIds while the tiles are filtered against live
+// workspaces, so one live member plus one stale id rendered a one-tile "grid"
+// with multiview chrome, escapable only via Ctrl+Shift+G.
+describe('removeWorkspace — multiview membership is pruned', () => {
+  function createMvStore(workspaces: Workspace[], activeId: string, multiviewIds: string[]) {
+    return create<WorkspaceSlice & { multiviewIds: string[] }>()(
+      immer((...args) => ({
+        // @ts-expect-error — minimal test store doesn't match full StoreState
+        ...createWorkspaceSlice(...args),
+        workspaces,
+        activeWorkspaceId: activeId,
+        multiviewIds,
+      })),
+    );
+  }
+
+  it('drops the closed workspace from the group', () => {
+    const [a, b, c] = [createWorkspace('A'), createWorkspace('B'), createWorkspace('C')];
+    const store = createMvStore([a, b, c], a.id, [a.id, b.id, c.id]);
+    store.getState().removeWorkspace(b.id);
+    expect(store.getState().multiviewIds).toEqual([a.id, c.id]);
+  });
+
+  it('clears the group when closing would leave a single member', () => {
+    // Otherwise the gate (multiviewIds.length >= 2) still passes while only one
+    // tile can be rendered — the one-tile grid from #751.
+    const [a, b, c] = [createWorkspace('A'), createWorkspace('B'), createWorkspace('C')];
+    const store = createMvStore([a, b, c], a.id, [a.id, b.id]);
+    store.getState().removeWorkspace(b.id);
+    expect(store.getState().multiviewIds).toEqual([]);
+  });
+
+  it('leaves the group alone when a non-member is closed', () => {
+    const [a, b, c] = [createWorkspace('A'), createWorkspace('B'), createWorkspace('C')];
+    const store = createMvStore([a, b, c], a.id, [a.id, b.id]);
+    store.getState().removeWorkspace(c.id);
+    expect(store.getState().multiviewIds).toEqual([a.id, b.id]);
+  });
+});

--- a/src/renderer/stores/slices/companySlice.ts
+++ b/src/renderer/stores/slices/companySlice.ts
@@ -12,7 +12,7 @@ import {
   MAX_INBOX_SIZE,
 } from '../../../shared/types';
 import type { QueuedMessage } from '../../company/MessageQueue';
-import { clearColdParkEntry } from './workspaceSlice';
+import { clearColdParkEntry, pruneMultiviewMembership } from './workspaceSlice';
 
 /** Maximum number of pending messages in the queue to prevent memory exhaustion. */
 const MAX_MESSAGE_QUEUE_SIZE = 500;
@@ -122,6 +122,7 @@ export const createCompanySlice: StateCreator<StoreState, [['zustand/immer', nev
   destroyCompany: () => set((state) => {
     // Remove all company-linked workspaces
     state.workspaces = state.workspaces.filter((ws) => !ws.companyRole);
+    pruneMultiviewMembership(state);
     // If active workspace was a company one, switch to first remaining
     if (!state.workspaces.some((ws) => ws.id === state.activeWorkspaceId)) {
       state.activeWorkspaceId = state.workspaces[0]?.id || '';
@@ -166,6 +167,7 @@ export const createCompanySlice: StateCreator<StoreState, [['zustand/immer', nev
     // Remove workspaces linked to this department's members
     const memberWsIds = new Set(dept.members.map((m) => m.workspaceId).filter(Boolean));
     state.workspaces = state.workspaces.filter((ws) => !memberWsIds.has(ws.id));
+    pruneMultiviewMembership(state);
     if (!state.workspaces.some((ws) => ws.id === state.activeWorkspaceId)) {
       state.activeWorkspaceId = state.workspaces[0]?.id || '';
       clearColdParkEntry(state, state.activeWorkspaceId); // keep promoted ws visible

--- a/src/renderer/stores/slices/uiSlice.ts
+++ b/src/renderer/stores/slices/uiSlice.ts
@@ -1204,7 +1204,25 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
     state.multiviewArrangement = arrangement;
   }),
 
-  toggleMultiviewWorkspace: (wsId) => set((state) => {
+  toggleMultiviewWorkspace: (wsId) => {
+    // Removing the ACTIVE workspace from the group closes the whole grid: the
+    // render gate gives up unless the active workspace is a member, so every
+    // other tile vanishes at once and it reads as "the window reset" (#752).
+    // Hand focus to a neighbour first when the group survives the removal —
+    // this is the rule the tile ✕ button already followed on its own, now in
+    // the store so both entry points get it.
+    const pre = get();
+    if (
+      pre.multiviewIds.includes(wsId) &&
+      wsId === pre.activeWorkspaceId &&
+      pre.multiviewIds.length > 2
+    ) {
+      const i = pre.multiviewIds.indexOf(wsId);
+      const next = pre.multiviewIds[i + 1] ?? pre.multiviewIds[i - 1];
+      // Route through setActiveWorkspace so activation side-effects fire.
+      if (next) pre.setActiveWorkspace(next);
+    }
+    set((state) => {
     const idx = state.multiviewIds.indexOf(wsId);
     if (idx >= 0) {
       state.multiviewIds.splice(idx, 1);
@@ -1234,9 +1252,24 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
     if (state.multiviewIds.length <= 1) {
       state.multiviewIds = [];
     }
-  }),
+    });
+  },
 
-  removeMultiviewWorkspace: (wsId) => set((state) => {
+  removeMultiviewWorkspace: (wsId) => {
+    // Same focus handoff as the toggle — see toggleMultiviewWorkspace (#752).
+    // Living here rather than in the view means the sidebar and the tile ✕
+    // cannot drift apart again.
+    const pre = get();
+    if (
+      pre.multiviewIds.includes(wsId) &&
+      wsId === pre.activeWorkspaceId &&
+      pre.multiviewIds.length > 2
+    ) {
+      const i = pre.multiviewIds.indexOf(wsId);
+      const next = pre.multiviewIds[i + 1] ?? pre.multiviewIds[i - 1];
+      if (next) pre.setActiveWorkspace(next);
+    }
+    set((state) => {
     const idx = state.multiviewIds.indexOf(wsId);
     if (idx < 0) return; // no-op on non-members
     state.multiviewIds.splice(idx, 1);
@@ -1244,7 +1277,8 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
     if (state.multiviewIds.length <= 1) {
       state.multiviewIds = [];
     }
-  }),
+    });
+  },
 
   clearMultiview: () => set((state) => {
     state.multiviewIds = [];

--- a/src/renderer/stores/slices/uiSlice.ts
+++ b/src/renderer/stores/slices/uiSlice.ts
@@ -662,6 +662,38 @@ export function resetInspectState(state: InspectStateFields): void {
   state.inspectXtermTarget = null;
 }
 
+/**
+ * Move focus off `wsId` before it leaves the multiview grid (#752).
+ *
+ * The render gate gives up unless the active workspace is a member, so dropping
+ * the active one used to take every other tile with it — it read as "the window
+ * reset". The tile ✕ button compensated in the view; the sidebar's Ctrl+click
+ * called the toggle raw and did not. Both go through here now, so they cannot
+ * drift apart again.
+ *
+ * Candidates are filtered to members that still EXIST and are DISTINCT from the
+ * one leaving. `setActiveWorkspace` silently ignores an unknown id, so picking a
+ * stale one would be a no-op and the grid would close anyway; picking a
+ * duplicate of `wsId` would re-activate the very workspace being removed.
+ *
+ * No handoff when fewer than two members would remain — the group disbands on
+ * its own then, and yanking focus would land the user somewhere they never asked
+ * for.
+ */
+function handOffBeforeLeavingGrid(state: StoreState, wsId: string): void {
+  if (wsId !== state.activeWorkspaceId) return;
+  const workspaces = state.workspaces ?? [];
+  const live = state.multiviewIds.filter(
+    (id, i, arr) => arr.indexOf(id) === i && workspaces.some((w) => w.id === id),
+  );
+  if (live.length <= 2) return;
+  const i = live.indexOf(wsId);
+  if (i < 0) return;
+  const next = live[i + 1] ?? live[i - 1];
+  // Route through setActiveWorkspace so activation side-effects fire.
+  if (next && next !== wsId) state.setActiveWorkspace?.(next);
+}
+
 export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]], [], UISlice> = (set, get) => ({
   // ─── Startup gate (Fix 0) ─────────────────────────────────────────────
   paneGate: 'pending',
@@ -1205,23 +1237,7 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
   }),
 
   toggleMultiviewWorkspace: (wsId) => {
-    // Removing the ACTIVE workspace from the group closes the whole grid: the
-    // render gate gives up unless the active workspace is a member, so every
-    // other tile vanishes at once and it reads as "the window reset" (#752).
-    // Hand focus to a neighbour first when the group survives the removal —
-    // this is the rule the tile ✕ button already followed on its own, now in
-    // the store so both entry points get it.
-    const pre = get();
-    if (
-      pre.multiviewIds.includes(wsId) &&
-      wsId === pre.activeWorkspaceId &&
-      pre.multiviewIds.length > 2
-    ) {
-      const i = pre.multiviewIds.indexOf(wsId);
-      const next = pre.multiviewIds[i + 1] ?? pre.multiviewIds[i - 1];
-      // Route through setActiveWorkspace so activation side-effects fire.
-      if (next) pre.setActiveWorkspace(next);
-    }
+    handOffBeforeLeavingGrid(get(), wsId);
     set((state) => {
     const idx = state.multiviewIds.indexOf(wsId);
     if (idx >= 0) {
@@ -1256,19 +1272,7 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
   },
 
   removeMultiviewWorkspace: (wsId) => {
-    // Same focus handoff as the toggle — see toggleMultiviewWorkspace (#752).
-    // Living here rather than in the view means the sidebar and the tile ✕
-    // cannot drift apart again.
-    const pre = get();
-    if (
-      pre.multiviewIds.includes(wsId) &&
-      wsId === pre.activeWorkspaceId &&
-      pre.multiviewIds.length > 2
-    ) {
-      const i = pre.multiviewIds.indexOf(wsId);
-      const next = pre.multiviewIds[i + 1] ?? pre.multiviewIds[i - 1];
-      if (next) pre.setActiveWorkspace(next);
-    }
+    handOffBeforeLeavingGrid(get(), wsId);
     set((state) => {
     const idx = state.multiviewIds.indexOf(wsId);
     if (idx < 0) return; // no-op on non-members

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -42,6 +42,25 @@ export function clearColdParkEntry(
   if (state.lastVisibleAt && state.lastVisibleAt[id] !== undefined) delete state.lastVisibleAt[id];
 }
 
+/**
+ * Drop multiview members whose workspace is gone, and disband a group left with
+ * fewer than two. Call from every path where workspaces disappear — the same set
+ * clearColdParkEntry covers (removeWorkspace, company destroy/removeDept,
+ * loadSession) — because they fail the same way: the grid gate counts
+ * `multiviewIds` while the tiles are filtered against live workspaces, so one
+ * live member plus one stale id renders a one-tile "grid" with full multiview
+ * chrome that nothing but Ctrl+Shift+G dismisses (#751).
+ * Guarded for stores/tests mounted without uiSlice.
+ */
+export function pruneMultiviewMembership(state: {
+  workspaces: Workspace[];
+  multiviewIds?: string[];
+}): void {
+  if (!state.multiviewIds || state.multiviewIds.length === 0) return;
+  const live = state.multiviewIds.filter((id) => state.workspaces.some((w) => w.id === id));
+  state.multiviewIds = live.length <= 1 ? [] : live;
+}
+
 function isTerminalOnlyWorkspace(ws: Workspace): boolean {
   for (const leaf of collectLeafPanes(ws.rootPane)) {
     for (const s of leaf.surfaces) {
@@ -367,25 +386,31 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
           p.type === 'leaf' ? p.surfaces.map((s) => s.ptyId).filter(Boolean) : p.children.flatMap(collectPtyIds);
         for (const pid of collectPtyIds(removedWs.rootPane)) delete state.taskPtyRegistry[pid];
       }
+      // Order matters: capture the group BEFORE pruning so the promotion below
+      // can still tell who this workspace's neighbours in the grid were.
+      const mvBefore = state.multiviewIds ? [...state.multiviewIds] : [];
       state.workspaces.splice(idx, 1);
       // Drop it from the multiview group too (#751). This does NOT contradict
       // the "multiviewIds is intentionally preserved" note in setActiveWorkspace
       // — that is about switching AWAY from a group, which the user can undo by
-      // clicking a member. A removed workspace can never come back, so its id is
-      // pure garbage: the grid gate counts multiviewIds while the tiles are
-      // filtered against live workspaces, so one live member plus one stale id
-      // rendered a one-tile "grid" with multiview chrome and no way out except
-      // Ctrl+Shift+G.
-      // Guarded for tests that mount workspaceSlice without uiSlice, matching
-      // the cold-park guard in toggleMultiviewWorkspace.
-      const mvIdx = state.multiviewIds?.indexOf(id) ?? -1;
-      if (mvIdx >= 0) {
-        state.multiviewIds.splice(mvIdx, 1);
-        // Same rule the toggle uses: a group of one is not a group.
-        if (state.multiviewIds.length <= 1) state.multiviewIds = [];
-      }
+      // clicking a member. A removed workspace can never come back.
+      pruneMultiviewMembership(state);
       if (state.activeWorkspaceId === id) {
-        state.activeWorkspaceId = state.workspaces[Math.min(idx, state.workspaces.length - 1)].id;
+        // Promote a surviving GRID MEMBER when one exists. Promoting by array
+        // position alone can land on a workspace outside the group, and the
+        // render gate needs the active workspace to be a member — so closing
+        // the active tile from the sidebar would take every remaining tile with
+        // it. That is the same collapse #752 fixed for the toggle paths; this is
+        // the third entry point into it.
+        const mvNow = state.multiviewIds ?? [];
+        let next: string | undefined;
+        if (mvNow.length >= 2) {
+          const i = mvBefore.indexOf(id);
+          const neighbor = i >= 0 ? (mvBefore[i + 1] ?? mvBefore[i - 1]) : undefined;
+          next = neighbor && mvNow.includes(neighbor) ? neighbor : mvNow[0];
+        }
+        state.activeWorkspaceId =
+          next ?? state.workspaces[Math.min(idx, state.workspaces.length - 1)].id;
         // Cold-park: the newly-promoted workspace must not stay parked.
         clearColdParkEntry(state, state.activeWorkspaceId);
       }
@@ -646,6 +671,8 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
       }
 
       state.workspaces = data.workspaces;
+      // The previous session's group cannot describe this one's workspaces.
+      pruneMultiviewMembership(state);
       state.activeWorkspaceId = data.activeWorkspaceId;
       state.sidebarVisible = data.sidebarVisible;
 

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -368,6 +368,22 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
         for (const pid of collectPtyIds(removedWs.rootPane)) delete state.taskPtyRegistry[pid];
       }
       state.workspaces.splice(idx, 1);
+      // Drop it from the multiview group too (#751). This does NOT contradict
+      // the "multiviewIds is intentionally preserved" note in setActiveWorkspace
+      // — that is about switching AWAY from a group, which the user can undo by
+      // clicking a member. A removed workspace can never come back, so its id is
+      // pure garbage: the grid gate counts multiviewIds while the tiles are
+      // filtered against live workspaces, so one live member plus one stale id
+      // rendered a one-tile "grid" with multiview chrome and no way out except
+      // Ctrl+Shift+G.
+      // Guarded for tests that mount workspaceSlice without uiSlice, matching
+      // the cold-park guard in toggleMultiviewWorkspace.
+      const mvIdx = state.multiviewIds?.indexOf(id) ?? -1;
+      if (mvIdx >= 0) {
+        state.multiviewIds.splice(mvIdx, 1);
+        // Same rule the toggle uses: a group of one is not a group.
+        if (state.multiviewIds.length <= 1) state.multiviewIds = [];
+      }
       if (state.activeWorkspaceId === id) {
         state.activeWorkspaceId = state.workspaces[Math.min(idx, state.workspaces.length - 1)].id;
         // Cold-park: the newly-promoted workspace must not stay parked.


### PR DESCRIPTION
Closes #751. Closes #752.

Both were found by dogfooding #748 in a packaged build, not by the test suite.
Both are pre-existing: the multiview group could describe workspaces that were
not, or could not be, on screen.

## #751 — a closed member left a stale id, so the grid could render one tile

`removeWorkspace` spliced the workspace out of `workspaces` but never touched
`multiviewIds`. The render gate counts the raw list while the tiles are filtered
against live workspaces:

```ts
if (multiviewIds.length >= 2 && multiviewIds.includes(activeWorkspaceId)) {
  const tiles = multiviewIds
    .map((id) => workspaces.find((w) => w.id === id))
    .filter((ws): ws is Workspace => ws !== undefined);
```

One live member plus one stale id passes the gate and draws a **single tile**
with full multiview chrome — header, X button — instead of falling back to the
normal single-workspace view. It stays that way until `Ctrl+Shift+G`.

Reproduce: put three workspaces in multiview, then close two of them from the
sidebar (not from the tile's X).

The id is now dropped inside the same transaction that removes the workspace,
and the group clears when fewer than two members would remain.

This does not contradict the `multiviewIds is intentionally preserved` note in
`setActiveWorkspace` — that is about navigating *away* from a group, which the
user can undo by clicking a member. A removed workspace cannot come back, so
keeping its id serves nobody.

## #752 — Ctrl+click on the active workspace closed the whole grid

The gate needs the active workspace to be a member, so toggling it off took every
other tile with it. It reads as "I clicked one workspace and multiview reset."

The tile's own X button already handled this, with a comment naming the failure:

```ts
// Close a multiview tile. If closing the ACTIVE tile with others remaining,
// hand focus to a neighbor first — otherwise the grid gate
// (multiviewIds.includes(activeId)) fails the next render and the view
// collapses to the just-closed workspace (reads as "the window reset").
```

The sidebar path called `toggleMultiviewWorkspace` raw and had no equivalent —
two entry points for one intent, one of which knew about the trap.

The handoff moves into `toggleMultiviewWorkspace` and `removeMultiviewWorkspace`.
`WorkspaceViewport` drops its copy and wires the X straight to the store action,
so the two paths cannot drift apart again. No handoff happens when the group would
collapse anyway (two members), since reassigning focus there would yank the user
to a workspace they did not ask for.

## Testing

- `uiSlice.test.ts` — toggling off the active member activates a neighbour and the
  group survives; the same for the X-button action; falls back to the previous
  member when the active tile is last; no handoff when the group collapses anyway.
- `workspaceSlice.test.ts` — closing a member prunes it; closing down to one member
  clears the group; closing a non-member leaves it alone.
- Full renderer suite: 2764 passing across 218 files. `tsc --noEmit` and `eslint`
  clean.

The pruning is written as `state.multiviewIds?.indexOf(id) ?? -1` to survive test
stores that mount `workspaceSlice` without `uiSlice`, matching the existing guard
in `toggleMultiviewWorkspace`'s cold-park block.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus handling when removing or toggling the active multiview tile.
  * Automatically moves focus to an adjacent tile, with reliable fallback behavior.
  * Preserves multiview membership for remaining tiles during removal.
  * Removes closed workspaces from multiview groups.
  * Automatically clears multiview mode when fewer than two tiles remain.
  * Prevents closing the entire grid when removing the active tile via Ctrl+click.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->