### PR TITLE
Settle a fit deferred by the selection guard

### DIFF
--- a/changelog.d/754.md
+++ b/changelog.d/754.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Resizing while text is selected no longer leaves the terminal at the wrong
+  size.** If you selected some output and then resized — dragging a split
+  separator, toggling the sidebar, resizing the window — the terminal and the
+  shell behind it stayed at the old dimensions even after you cleared the
+  selection. Output wrapped at the wrong column and full-screen programs drew
+  against stale dimensions until something else happened to resize the pane. The
+  deferred resize now runs as soon as the selection goes away. (#754)

--- a/src/renderer/hooks/__tests__/useTerminal.deferredFit.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.deferredFit.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 
+// Source locks must not depend on line endings: `validate` runs on
+// windows-latest, where the checkout is CRLF, so any assertion carrying a
+// literal \n passes on macOS/Linux and fails only in CI. Normalise once here and
+// keep every pattern below whitespace-tolerant.
+const readSource = (p: string) => fs.readFileSync(p, 'utf-8').replace(/\r\n/g, '\n');
+
 // #747 regression lock (source-level).
 //
 // The selection guard skips fit() so a reflow can't wipe what the user is
@@ -17,7 +23,7 @@ import path from 'node:path';
 // #191 atlas lock and the Fix D / A6 invariants alongside it.
 describe('#747 — a deferred fit must be recorded and settled', () => {
   const hookPath = path.join(__dirname, '..', 'useTerminal.ts');
-  const src = fs.readFileSync(hookPath, 'utf-8');
+  const src = readSource(hookPath);
 
   it('no site calls the raw guard — every one goes through claimFit', () => {
     // This is the load-bearing assertion. Calling shouldFitWhilePreservingSelection
@@ -47,7 +53,11 @@ describe('#747 — a deferred fit must be recorded and settled', () => {
     // desync this fixes.
     const start = src.indexOf('const runFit = () => {');
     expect(start).toBeGreaterThan(-1);
-    const block = src.slice(start, src.indexOf('\n    };', start));
+    // Bound the block by the next declaration rather than an indentation
+    // pattern — a formatter change must not silently shrink or widen the slice.
+    const end = src.indexOf('const autoCopy = createAutoSelectionCopy', start);
+    expect(end, 'runFit is no longer followed by autoCopy — re-anchor this slice').toBeGreaterThan(start);
+    const block = src.slice(start, end);
     expect(block).toMatch(/fitAddon\.fit\(\)/);
     expect(block).toMatch(/sendResize\(/);
     expect(block).toMatch(/scrollToLine\(/);
@@ -64,11 +74,12 @@ describe('#747 — a deferred fit must be recorded and settled', () => {
     // Without a handle, several selection changes in one debt window each queue
     // their own fit, and a frame can still land after the terminal is disposed.
     expect(src).toMatch(/pendingFitRaf/);
-    const cleanupStart = src.indexOf('if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);\n      if (pendingFitRaf');
     expect(
-      cleanupStart,
+      src,
       'the queued fit frame is not cancelled next to the debounce timer in cleanup',
-    ).toBeGreaterThan(-1);
+    ).toMatch(
+      /clearTimeout\(resizeDebounceTimer\);\s*if \(pendingFitRaf !== null\) cancelAnimationFrame\(pendingFitRaf\);/,
+    );
   });
 
   it('the ResizeObserver delegates to runFit instead of duplicating it', () => {

--- a/src/renderer/hooks/__tests__/useTerminal.deferredFit.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.deferredFit.test.ts
@@ -4,40 +4,31 @@ import path from 'node:path';
 
 // #747 regression lock (source-level).
 //
-// The selection guard skips fit() so a mid-drag reflow can't wipe the user's
-// selection. Every skip site used to just `return`, on the shared assumption
+// The selection guard skips fit() so a reflow can't wipe what the user is
+// selecting. Every skip site used to just `return`, on the shared assumption
 // that "the next ResizeObserver tick (after the user releases)" would run the
 // deferred fit. Releasing a selection is not a size change and fires no tick,
 // so a resize that landed while a selection was live was lost outright: xterm
 // and — through sendResize — the daemon PTY stayed pinned to the old cols/rows.
-// Output wrapped at the wrong column and full-screen TUIs drew against stale
-// dimensions until something unrelated happened to resize the container.
 //
-// A skipped fit is now a recorded debt (pendingFitRef) settled by the
-// onSelectionChange handler. The dangerous edit is a future contributor adding
-// a fifth guarded site that bails without recording the debt — silently
-// reintroducing the bug for that path only. Like the #191 atlas lock and the
-// Fix D / A6 invariants next to it, this is xterm-bound behaviour that can't be
-// asserted without a real terminal, so it is pinned at the source level.
+// The guard+debt decision now lives in claimFit(), which is unit-tested for real
+// in utils/__tests__/fitGuard.test.ts. What CANNOT be asserted without a live
+// xterm is the wiring in this hook, so that part is pinned here, matching the
+// #191 atlas lock and the Fix D / A6 invariants alongside it.
 describe('#747 — a deferred fit must be recorded and settled', () => {
   const hookPath = path.join(__dirname, '..', 'useTerminal.ts');
   const src = fs.readFileSync(hookPath, 'utf-8');
 
-  it('every selection-guard bail records the debt', () => {
-    // Each guard reads `if (!shouldFitWhilePreservingSelection(...)) { ... }`.
-    // Slice each block and require pendingFitRef to be set inside it.
-    const sites = [...src.matchAll(/if \(!shouldFitWhilePreservingSelection\([^)]*\)\) \{/g)];
-    expect(sites.length).toBeGreaterThan(0);
-
-    for (const site of sites) {
-      const start = site.index as number;
-      const block = src.slice(start, src.indexOf('}', src.indexOf('return;', start)));
-      expect(
-        block,
-        `a selection-guard bail at index ${start} returns without recording pendingFitRef — ` +
-          'the deferred fit would be lost (#747)',
-      ).toMatch(/pendingFitRef\.current = true/);
-    }
+  it('no site calls the raw guard — every one goes through claimFit', () => {
+    // This is the load-bearing assertion. Calling shouldFitWhilePreservingSelection
+    // directly lets a site bail without recording the debt, which is the bug.
+    // claimFit cannot be used that way: refusing and remembering are one call.
+    expect(
+      src,
+      'a site calls shouldFitWhilePreservingSelection directly — use claimFit(term, pendingFitRef) ' +
+        'so the deferred fit cannot be dropped (#747)',
+    ).not.toMatch(/shouldFitWhilePreservingSelection/);
+    expect(src).toMatch(/claimFit\(/);
   });
 
   it('the selection-release handler settles the debt', () => {
@@ -51,7 +42,7 @@ describe('#747 — a deferred fit must be recorded and settled', () => {
 
   it('the settled fit runs the real fit path, not a thinner copy', () => {
     // The retry must go through runFit so it keeps scroll preservation and the
-    // sendResize dedupe. A hand-rolled `fitAddon.fit()` in the handler would
+    // sendResize dedupe. A hand-rolled fitAddon.fit() in the handler would
     // resize xterm while leaving the PTY on the old size — the same class of
     // desync this fixes.
     const start = src.indexOf('const runFit = () => {');
@@ -61,8 +52,23 @@ describe('#747 — a deferred fit must be recorded and settled', () => {
     expect(block).toMatch(/sendResize\(/);
     expect(block).toMatch(/scrollToLine\(/);
     // Clearing the debt on the path that actually fits is what stops the retry
-    // from firing forever on every subsequent selection change.
+    // from re-firing on every later selection change.
     expect(block).toMatch(/pendingFitRef\.current = false/);
+    // Identity guard: a ptyId change re-runs the create effect, and a frame
+    // queued by the previous one must not fit the old container and then send
+    // those dimensions to ptyIdRef.current, which now points at the new pty.
+    expect(block).toMatch(/term !== terminal/);
+  });
+
+  it('the queued retry is cancellable and cancelled at teardown', () => {
+    // Without a handle, several selection changes in one debt window each queue
+    // their own fit, and a frame can still land after the terminal is disposed.
+    expect(src).toMatch(/pendingFitRaf/);
+    const cleanupStart = src.indexOf('if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);\n      if (pendingFitRaf');
+    expect(
+      cleanupStart,
+      'the queued fit frame is not cancelled next to the debounce timer in cleanup',
+    ).toBeGreaterThan(-1);
   });
 
   it('the ResizeObserver delegates to runFit instead of duplicating it', () => {

--- a/src/renderer/hooks/__tests__/useTerminal.deferredFit.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.deferredFit.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// #747 regression lock (source-level).
+//
+// The selection guard skips fit() so a mid-drag reflow can't wipe the user's
+// selection. Every skip site used to just `return`, on the shared assumption
+// that "the next ResizeObserver tick (after the user releases)" would run the
+// deferred fit. Releasing a selection is not a size change and fires no tick,
+// so a resize that landed while a selection was live was lost outright: xterm
+// and — through sendResize — the daemon PTY stayed pinned to the old cols/rows.
+// Output wrapped at the wrong column and full-screen TUIs drew against stale
+// dimensions until something unrelated happened to resize the container.
+//
+// A skipped fit is now a recorded debt (pendingFitRef) settled by the
+// onSelectionChange handler. The dangerous edit is a future contributor adding
+// a fifth guarded site that bails without recording the debt — silently
+// reintroducing the bug for that path only. Like the #191 atlas lock and the
+// Fix D / A6 invariants next to it, this is xterm-bound behaviour that can't be
+// asserted without a real terminal, so it is pinned at the source level.
+describe('#747 — a deferred fit must be recorded and settled', () => {
+  const hookPath = path.join(__dirname, '..', 'useTerminal.ts');
+  const src = fs.readFileSync(hookPath, 'utf-8');
+
+  it('every selection-guard bail records the debt', () => {
+    // Each guard reads `if (!shouldFitWhilePreservingSelection(...)) { ... }`.
+    // Slice each block and require pendingFitRef to be set inside it.
+    const sites = [...src.matchAll(/if \(!shouldFitWhilePreservingSelection\([^)]*\)\) \{/g)];
+    expect(sites.length).toBeGreaterThan(0);
+
+    for (const site of sites) {
+      const start = site.index as number;
+      const block = src.slice(start, src.indexOf('}', src.indexOf('return;', start)));
+      expect(
+        block,
+        `a selection-guard bail at index ${start} returns without recording pendingFitRef — ` +
+          'the deferred fit would be lost (#747)',
+      ).toMatch(/pendingFitRef\.current = true/);
+    }
+  });
+
+  it('the selection-release handler settles the debt', () => {
+    const start = src.indexOf('terminal.onSelectionChange(');
+    expect(start).toBeGreaterThan(-1);
+    const block = src.slice(start, src.indexOf('});', start));
+    expect(block).toMatch(/pendingFitRef\.current/);
+    expect(block).toMatch(/hasSelection\(\)/);
+    expect(block).toMatch(/runFit/);
+  });
+
+  it('the settled fit runs the real fit path, not a thinner copy', () => {
+    // The retry must go through runFit so it keeps scroll preservation and the
+    // sendResize dedupe. A hand-rolled `fitAddon.fit()` in the handler would
+    // resize xterm while leaving the PTY on the old size — the same class of
+    // desync this fixes.
+    const start = src.indexOf('const runFit = () => {');
+    expect(start).toBeGreaterThan(-1);
+    const block = src.slice(start, src.indexOf('\n    };', start));
+    expect(block).toMatch(/fitAddon\.fit\(\)/);
+    expect(block).toMatch(/sendResize\(/);
+    expect(block).toMatch(/scrollToLine\(/);
+    // Clearing the debt on the path that actually fits is what stops the retry
+    // from firing forever on every subsequent selection change.
+    expect(block).toMatch(/pendingFitRef\.current = false/);
+  });
+
+  it('the ResizeObserver delegates to runFit instead of duplicating it', () => {
+    const start = src.indexOf('new ResizeObserver(');
+    expect(start).toBeGreaterThan(-1);
+    const block = src.slice(start, src.indexOf('resizeObserver.observe(', start));
+    expect(block).toMatch(/runFit/);
+    // A second copy of the fit body here would drift out of sync with the retry.
+    expect(block).not.toMatch(/fitAddon\.fit\(\)/);
+  });
+});

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -13,7 +13,7 @@ import { isDaemonModeActive } from '../daemon/daemonMode';
 import { pastePtyChunked, chunkOnDataIfNeeded } from '../utils/clipboardChunk';
 import { openTerminalUrl } from '../utils/browserPaneActions';
 import { runCopyWithFeedback } from '../utils/copyWithFeedback';
-import { shouldFitWhilePreservingSelection } from '../utils/fitGuard';
+import { claimFit } from '../utils/fitGuard';
 import { createAutoSelectionCopy } from '../utils/autoSelectionCopy';
 import { decodeOsc52Write } from '../utils/osc52Clipboard';
 import { terminalFontFamilyCss } from '../utils/terminalFont';
@@ -833,6 +833,10 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     if (container.offsetWidth === 0 || container.offsetHeight === 0) return;
     try {
       fitAddonRef.current.fit();
+      // This path fits and resizes too, so it settles any deferred debt (#747) —
+      // otherwise the flag sticks and every later selection change re-runs a fit
+      // that is already done.
+      pendingFitRef.current = false;
       const currentPtyId = ptyIdRef.current;
       if (currentPtyId) {
         const { cols, rows } = terminalRef.current;
@@ -1196,14 +1200,18 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // resolves on mount before the user can select anything), but pinning
       // the contract here prevents future regressions if anything triggers
       // a font load mid-session.
-      if (!shouldFitWhilePreservingSelection(terminalRef.current)) {
-        pendingFitRef.current = true;
+      if (!claimFit(terminalRef.current, pendingFitRef)) {
         console.debug('[Terminal] fonts.ready fit deferred — active selection');
         return;
       }
       fitAddon.fit();
       terminal.refresh(0, terminal.rows - 1);
     });
+
+    // pendingFitRef lives at hook scope so every guarded site can reach it, so a
+    // debt left by the PREVIOUS terminal (ptyId change re-runs this effect) would
+    // otherwise make the new one fit on its first selection change.
+    pendingFitRef.current = false;
 
     // Track last sent dimensions to avoid redundant resizes
     let lastSentCols = 0;
@@ -1218,10 +1226,20 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // workspace). Fitting a hidden terminal produces 0 cols/rows, which
     // corrupts the PTY buffer and manifests as "infinite content duplication"
     // when switching back to it.
+    // One outstanding retry at a time. Without a handle we could neither cancel
+    // a queued fit at teardown nor stop several selection events in the same
+    // debt window from each scheduling their own.
+    let pendingFitRaf: number | null = null;
     const runFit = () => {
       try {
         const term = terminalRef.current;
         if (!term) return;
+        // Identity guard, as at every other async site in this hook (fonts.ready,
+        // hydrateForRead, …). A ptyId change re-runs this effect; a frame queued
+        // by the previous one would otherwise fit against the OLD container and
+        // fitAddon and then send those dimensions to ptyIdRef.current — which by
+        // then points at the NEW pty.
+        if (term !== terminal) return;
 
         if (container.offsetWidth === 0 || container.offsetHeight === 0) return;
 
@@ -1230,8 +1248,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         // is dragging out a selection (or while one is live waiting to be
         // copied) skip this fit and record the debt — releasing the selection
         // fires no ResizeObserver tick, so without this the fit is simply lost.
-        if (!shouldFitWhilePreservingSelection(term)) {
-          pendingFitRef.current = true;
+        if (!claimFit(term, pendingFitRef)) {
           console.debug('[Terminal] resize fit deferred — active selection');
           return;
         }
@@ -1282,7 +1299,11 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // a size change. rAF so xterm has finished updating its selection state
       // before fit() reflows the buffer, matching the observer's own timing.
       if (pendingFitRef.current && !terminal.hasSelection()) {
-        requestAnimationFrame(runFit);
+        if (pendingFitRaf !== null) cancelAnimationFrame(pendingFitRaf);
+        pendingFitRaf = requestAnimationFrame(() => {
+          pendingFitRaf = null;
+          runFit();
+        });
       }
     });
 
@@ -2069,13 +2090,18 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
       resizeDebounceTimer = setTimeout(() => {
         resizeDebounceTimer = null;
-        requestAnimationFrame(runFit);
+        if (pendingFitRaf !== null) cancelAnimationFrame(pendingFitRaf);
+        pendingFitRaf = requestAnimationFrame(() => {
+          pendingFitRaf = null;
+          runFit();
+        });
       }, 100);
     });
     resizeObserver.observe(container);
 
     return () => {
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
+      if (pendingFitRaf !== null) cancelAnimationFrame(pendingFitRaf);
       if (isMac) { container.removeEventListener('paste', blockNativePaste, true); }
       terminal.textarea?.removeEventListener('focus', onTextareaFocus);
       terminal.textarea?.removeEventListener('keydown', onWatchdogKeyDown);
@@ -2228,8 +2254,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       containerRef.current.style.backgroundColor = xtermTheme.background ?? '';
     }
     // Selection-preservation guard — see ResizeObserver above.
-    if (!shouldFitWhilePreservingSelection(terminalRef.current)) {
-      pendingFitRef.current = true;
+    if (!claimFit(terminalRef.current, pendingFitRef)) {
       console.debug('[Terminal] font/theme fit deferred — active selection');
       return;
     }
@@ -2348,8 +2373,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         // where the pool kept the old (possibly stale) context alive instead of
         // rebuilding it.
         glyphRepaintRef.current?.onVisible();
-        if (!shouldFitWhilePreservingSelection(terminalRef.current)) {
-          pendingFitRef.current = true;
+        if (!claimFit(terminalRef.current, pendingFitRef)) {
           console.debug('[Terminal] visibility fit deferred — active selection');
           return;
         }

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -552,6 +552,22 @@ interface UseTerminalOptions {
 export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>, options: UseTerminalOptions) {
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
+  /**
+   * A fit() that the selection guard skipped, and nobody re-ran (#747).
+   *
+   * Every guarded site defers on the same reasoning: xterm clears the active
+   * selection on any rowsChanged, so skip now and let "the next ResizeObserver
+   * tick" handle it once the user releases. But releasing a selection is not a
+   * size change and fires no tick. If nothing else resized the container
+   * afterwards, xterm — and, through sendResize, the daemon PTY — stayed pinned
+   * to the pre-resize cols/rows: output wrapped at the wrong column and
+   * full-screen TUIs drew against stale dimensions until something unrelated
+   * happened to resize.
+   *
+   * Set by any site that skips; settled by the onSelectionChange handler in the
+   * create effect, which re-runs the real fit once the selection is gone.
+   */
+  const pendingFitRef = useRef(false);
   const searchAddonRef = useRef<SearchAddon | null>(null);
   // WebGL addon ref — shared across effects so visibility toggling can
   // dispose/recreate the addon without exceeding the GPU context limit.
@@ -1181,7 +1197,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // the contract here prevents future regressions if anything triggers
       // a font load mid-session.
       if (!shouldFitWhilePreservingSelection(terminalRef.current)) {
-        console.debug('[Terminal] fonts.ready fit skipped — active selection');
+        pendingFitRef.current = true;
+        console.debug('[Terminal] fonts.ready fit deferred — active selection');
         return;
       }
       fitAddon.fit();
@@ -1192,6 +1209,58 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     let lastSentCols = 0;
     let lastSentRows = 0;
     let resizeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    // The container-resize fit, extracted so the selection-release retry below
+    // runs the SAME path — including scroll preservation and sendResize —
+    // rather than a thinner copy that drifts (#747).
+    //
+    // IMPORTANT: skip when the container has zero dimensions (display:none
+    // workspace). Fitting a hidden terminal produces 0 cols/rows, which
+    // corrupts the PTY buffer and manifests as "infinite content duplication"
+    // when switching back to it.
+    const runFit = () => {
+      try {
+        const term = terminalRef.current;
+        if (!term) return;
+
+        if (container.offsetWidth === 0 || container.offsetHeight === 0) return;
+
+        // Selection-preservation guard: xterm's SelectionService clears the
+        // active selection on any rowsChanged event from fit(). While the user
+        // is dragging out a selection (or while one is live waiting to be
+        // copied) skip this fit and record the debt — releasing the selection
+        // fires no ResizeObserver tick, so without this the fit is simply lost.
+        if (!shouldFitWhilePreservingSelection(term)) {
+          pendingFitRef.current = true;
+          console.debug('[Terminal] resize fit deferred — active selection');
+          return;
+        }
+        pendingFitRef.current = false;
+
+        const prevYBase = term.buffer.active.baseY;
+        const prevYDisp = term.buffer.active.viewportY;
+        const wasScrolledUp = prevYDisp < prevYBase;
+        const distFromBottom = prevYBase - prevYDisp;
+
+        fitAddon.fit();
+
+        if (wasScrolledUp) {
+          const newYBase = term.buffer.active.baseY;
+          const targetYDisp = Math.max(0, newYBase - distFromBottom);
+          term.scrollToLine(targetYDisp);
+        }
+
+        const { cols, rows } = term;
+        const currentPtyId = ptyIdRef.current;
+        if (currentPtyId && cols > 0 && rows > 0 && (cols !== lastSentCols || rows !== lastSentRows)) {
+          lastSentCols = cols;
+          lastSentRows = rows;
+          sendResize(currentPtyId, cols, rows);
+        }
+      } catch {
+        // ignore fit errors during unmount
+      }
+    };
 
     // Auto-copy on selection (debounced) — selection survives just long enough
     // for the user to release the mouse, then we push it to the clipboard.
@@ -1208,6 +1277,13 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     });
     const selectionDisposable = terminal.onSelectionChange(() => {
       autoCopy.onSelection(terminal.getSelection());
+      // Settle a deferred fit (#747). This is the event the guards' "next
+      // ResizeObserver tick" assumed but never got: a selection release is not
+      // a size change. rAF so xterm has finished updating its selection state
+      // before fit() reflows the buffer, matching the observer's own timing.
+      if (pendingFitRef.current && !terminal.hasSelection()) {
+        requestAnimationFrame(runFit);
+      }
     });
 
     // Clipboard + shortcut handling
@@ -1993,48 +2069,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
       resizeDebounceTimer = setTimeout(() => {
         resizeDebounceTimer = null;
-        requestAnimationFrame(() => {
-          try {
-            const term = terminalRef.current;
-            if (!term) return;
-
-            if (container.offsetWidth === 0 || container.offsetHeight === 0) return;
-
-            // Selection-preservation guard: xterm's SelectionService clears
-            // the active selection on any rowsChanged event from fit().
-            // While the user is dragging out a selection (or while a
-            // selection is live waiting to be copied) skip this fit and let
-            // the next ResizeObserver tick handle the resize once the
-            // selection is released.
-            if (!shouldFitWhilePreservingSelection(term)) {
-              console.debug('[Terminal] resize fit skipped — active selection');
-              return;
-            }
-
-            const prevYBase = term.buffer.active.baseY;
-            const prevYDisp = term.buffer.active.viewportY;
-            const wasScrolledUp = prevYDisp < prevYBase;
-            const distFromBottom = prevYBase - prevYDisp;
-
-            fitAddon.fit();
-
-            if (wasScrolledUp) {
-              const newYBase = term.buffer.active.baseY;
-              const targetYDisp = Math.max(0, newYBase - distFromBottom);
-              term.scrollToLine(targetYDisp);
-            }
-
-            const { cols, rows } = term;
-            const currentPtyId = ptyIdRef.current;
-            if (currentPtyId && cols > 0 && rows > 0 && (cols !== lastSentCols || rows !== lastSentRows)) {
-              lastSentCols = cols;
-              lastSentRows = rows;
-              sendResize(currentPtyId, cols, rows);
-            }
-          } catch {
-            // ignore fit errors during unmount
-          }
-        });
+        requestAnimationFrame(runFit);
       }, 100);
     });
     resizeObserver.observe(container);
@@ -2194,7 +2229,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     }
     // Selection-preservation guard — see ResizeObserver above.
     if (!shouldFitWhilePreservingSelection(terminalRef.current)) {
-      console.debug('[Terminal] font/theme fit skipped — active selection');
+      pendingFitRef.current = true;
+      console.debug('[Terminal] font/theme fit deferred — active selection');
       return;
     }
     // Visibility guard — when the workspace tab containing this terminal is
@@ -2313,7 +2349,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         // rebuilding it.
         glyphRepaintRef.current?.onVisible();
         if (!shouldFitWhilePreservingSelection(terminalRef.current)) {
-          console.debug('[Terminal] visibility fit skipped — active selection');
+          pendingFitRef.current = true;
+          console.debug('[Terminal] visibility fit deferred — active selection');
           return;
         }
         fit();

--- a/src/renderer/utils/__tests__/fitGuard.test.ts
+++ b/src/renderer/utils/__tests__/fitGuard.test.ts
@@ -6,7 +6,7 @@
  * SelectionService responds to `rowsChanged` by unconditionally clearing).
  */
 import { describe, it, expect } from 'vitest';
-import { shouldFitWhilePreservingSelection } from '../fitGuard';
+import { claimFit, shouldFitWhilePreservingSelection } from '../fitGuard';
 
 describe('shouldFitWhilePreservingSelection', () => {
   it('returns true when the terminal has no active selection', () => {
@@ -34,5 +34,39 @@ describe('shouldFitWhilePreservingSelection', () => {
     };
     shouldFitWhilePreservingSelection(term);
     expect(calls).toBe(1);
+  });
+});
+
+// #747 — deferring and remembering are one decision. A site that checked the
+// guard but forgot to record the debt silently dropped the resize: xterm and the
+// daemon PTY stayed pinned to the old cols/rows because nothing re-ran the fit
+// (a selection release is not a size change, so no ResizeObserver tick fires).
+// claimFit exists so a call site cannot get that half-right.
+describe('claimFit', () => {
+  it('allows the fit and leaves the debt alone when there is no selection', () => {
+    const pending = { current: false };
+    expect(claimFit({ hasSelection: () => false }, pending)).toBe(true);
+    expect(pending.current).toBe(false);
+  });
+
+  it('refuses the fit AND records the debt when a selection is live', () => {
+    const pending = { current: false };
+    expect(claimFit({ hasSelection: () => true }, pending)).toBe(false);
+    expect(pending.current).toBe(true);
+  });
+
+  it('does not clear an existing debt when it allows a fit', () => {
+    // Settling is the retry path's job — it clears the flag only after the fit
+    // actually runs. Clearing here would drop a debt owed by another site.
+    const pending = { current: true };
+    expect(claimFit({ hasSelection: () => false }, pending)).toBe(true);
+    expect(pending.current).toBe(true);
+  });
+
+  it('allows the fit for a null term without recording a debt', () => {
+    const pending = { current: false };
+    expect(claimFit(null, pending)).toBe(true);
+    expect(claimFit(undefined, pending)).toBe(true);
+    expect(pending.current).toBe(false);
   });
 });

--- a/src/renderer/utils/fitGuard.ts
+++ b/src/renderer/utils/fitGuard.ts
@@ -30,3 +30,23 @@ export function shouldFitWhilePreservingSelection(
   if (!term) return true; // nothing to preserve, defer to caller's other guards
   return !term.hasSelection();
 }
+
+/**
+ * Ask for permission to fit, recording the debt if the answer is no.
+ *
+ * Prefer this over calling the guard directly. Deferring and remembering are one
+ * decision — a site that checks the guard but forgets to set the flag silently
+ * drops the resize, which is exactly the shape of #747. Bundling them means a
+ * new call site cannot get it half-right.
+ *
+ * @returns true when the caller should fit now; false when it must skip, in
+ * which case `pending.current` is set and the retry path owns settling it.
+ */
+export function claimFit(
+  term: { hasSelection(): boolean } | null | undefined,
+  pending: { current: boolean },
+): boolean {
+  if (shouldFitWhilePreservingSelection(term)) return true;
+  pending.current = true;
+  return false;
+}

--- a/src/renderer/utils/fitGuard.ts
+++ b/src/renderer/utils/fitGuard.ts
@@ -9,9 +9,15 @@
  * is copied" because mousemove restarts the selection from the cursor's
  * current position.
  *
- * Skipping `fit()` while the user has an active selection prevents the
- * clear; the next ResizeObserver tick (after the user releases) handles the
- * deferred resize.
+ * Skipping `fit()` while the user has an active selection prevents the clear.
+ *
+ * A skipped fit is a DEFERRED fit, and the caller owns settling it. This
+ * docstring used to promise that "the next ResizeObserver tick (after the user
+ * releases)" would, but releasing a selection is not a size change and fires no
+ * tick — so a resize that landed mid-selection was simply lost, leaving xterm
+ * and the daemon PTY pinned to the old cols/rows (#747). useTerminal records the
+ * debt in `pendingFitRef` and re-runs the fit from its onSelectionChange
+ * handler; any new caller of this guard must do the same.
  */
 
 /**


### PR DESCRIPTION
Closes #747.

## The bug

`shouldFitWhilePreservingSelection` skips `fit()` while a selection is live, so a
reflow can't wipe what the user is dragging out. Every skip site relied on the
same promise, written into fitGuard's own docstring:

> the next ResizeObserver tick (after the user releases) handles the deferred
> resize.

There is no such tick. `ResizeObserver` fires on *size change*, and releasing a
selection is not one. A resize that landed while a selection was live was dropped
outright: xterm kept the old `cols`/`rows`, and since `sendResize` is downstream
of `fit()`, so did the daemon PTY. Output wrapped at the wrong column and
full-screen TUIs drew against stale dimensions until something unrelated happened
to resize the container.

Reproduce: select some output in a pane and leave the selection up, drag the split
separator or toggle the sidebar, then click to clear the selection. `stty size`
inside that pane still reports the pre-resize dimensions.

## The fix

A skipped fit is a recorded debt, settled by the event the docstring assumed —
`onSelectionChange`, once the selection is actually gone. The retry runs the same
`runFit` the ResizeObserver uses, so it keeps scroll preservation and the
`sendResize` dedupe instead of drifting as a thinner copy.

`claimFit(term, pendingFitRef)` replaces direct guard calls. Checking the guard
and recording the debt were two steps a call site could get half-right, and
getting them half-right *is* the bug — so they are one call now. All four guarded
sites (fonts.ready, ResizeObserver, font/theme, visibility) go through it.

## Review notes

Panel review caught three things worth calling out, all fixed here:

- **The retry frame was neither tracked nor cancelled**, and `runFit` skipped the
  `terminalRef.current !== terminal` identity check that every other async site in
  this hook performs. A `ptyId` change re-runs the create effect, so a queued
  frame could fit the previous container and then send those dimensions to
  `ptyIdRef.current` — pointing at the new pty by then. One cancellable handle is
  now shared by both schedulers and cancelled beside the debounce timer in
  cleanup.
- **Debt lifecycle.** It is reset when a new terminal takes over the hook, and the
  shared `fit` callback settles it too — that path fits and resizes, so leaving
  the flag set made every later selection change re-run a fit already done.
- **The first version of the source lock was weak.** It matched a single-line
  guard shape, so a new site written across multiple lines, or via a helper call,
  would skip the debt and the test would still pass — a false negative in exactly
  the regression it existed to catch. `claimFit` makes the invariant structural:
  the lock is now "nothing calls the raw guard", and the decision itself is unit
  tested.

## Known limitation (deliberate)

While a selection is *held*, the fit stays deferred — that is the guard's whole
purpose, not an oversight. A user who selects text, resizes, and leaves the
selection up keeps the old dimensions until they clear it. Fitting sooner would
destroy the selection, which is the behaviour the guard was added to prevent.

One behaviour drift is accepted: the fonts.ready site used to run
`terminal.refresh(0, rows - 1)` after its fit, and the settle path does not.
That site's own comment calls itself "mostly defensive" (fonts resolve on mount,
before a selection can exist), and the glyph repaint scheduler covers staleness
on reveal.

## Testing

- `fitGuard.test.ts` — `claimFit` allows and records correctly, does not clear a
  debt owed by another site, and handles a null term. Real unit tests, not source
  matching.
- `useTerminal.deferredFit.test.ts` — source-level lock for the wiring that needs
  a live xterm to exercise: nothing calls the raw guard, the selection handler
  settles through `runFit`, `runFit` keeps scroll preservation + `sendResize` +
  the identity guard, the frame is cancellable and cancelled at teardown, and the
  observer delegates instead of duplicating the fit body. Same pattern as the
  `#191` atlas lock beside it.
- Both locks were mutation-tested: removing the debt record, and rewriting a site
  to call the raw guard across multiple lines, each fail with a message naming the
  fix.
- Full renderer suite: 2777 passing across 219 files. `tsc --noEmit` clean.
  `eslint` reports 3 pre-existing `no-empty-function` errors in `useTerminal.ts`
  that are present on `main` at the same call sites (line numbers shifted); no new
  ones.
