### PR TITLE
fix(lanlink): coalesce lastSeenAt writes off the receive path

### DIFF
--- a/changelog.d/755.md
+++ b/changelog.d/755.md
@@ -1,9 +1,10 @@
 ### Fixed
 
-- **LanLink no longer rewrites its whole peer file for every message received.** Each
-  inbound record used to force two full peer-store saves, and on Windows every save
-  shelled out to `whoami.exe` and `powershell.exe` to re-apply the owner-only file
-  permissions — a step measured at seconds per call on machines running antivirus, and
-  one that blocked the whole daemon while it ran. A peer sending a burst of messages
-  could stall wmux. The "last seen" timestamp is now kept in memory and written on a
-  timer, when the connection ends, and on shutdown. (#755)
+- **LanLink halved the disk writes a received message costs.** Each inbound record used
+  to force two full rewrites of the peer file, and on Windows every rewrite shelled out
+  to `whoami.exe` and `powershell.exe` to re-apply the owner-only file permissions — a
+  step measured at seconds per call on machines running antivirus, and one that blocked
+  the whole daemon while it ran, so a peer sending a burst of messages could stall wmux.
+  The "last seen" timestamp now rides along with the write the record already needed,
+  instead of forcing one of its own. The remaining write is the replay guard, which has
+  to be durable; making that one cheap on Windows is still open. (#755)

--- a/changelog.d/755.md
+++ b/changelog.d/755.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **LanLink no longer rewrites its whole peer file for every message received.** Each
+  inbound record used to force two full peer-store saves, and on Windows every save
+  shelled out to `whoami.exe` and `powershell.exe` to re-apply the owner-only file
+  permissions — a step measured at seconds per call on machines running antivirus, and
+  one that blocked the whole daemon while it ran. A peer sending a burst of messages
+  could stall wmux. The "last seen" timestamp is now kept in memory and written on a
+  timer, when the connection ends, and on shutdown. (#755)

--- a/src/daemon/lanlink/__tests__/peers.test.ts
+++ b/src/daemon/lanlink/__tests__/peers.test.ts
@@ -284,9 +284,10 @@ describe('peers — per-peer store', () => {
 
     // A throw here would reach the server's pump() catch and kill the connection
     // over a lastSeenAt write — the #658 interaction called out in #665.
-    it('never throws when the write fails, and retries the refresh later', () => {
+    it('never throws when the write fails, and the recovered write carries the refresh', () => {
       const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      vi.useFakeTimers();
       try {
         let hardenOk = true;
         const s = new PeerStore(dir, {
@@ -294,16 +295,62 @@ describe('peers — per-peer store', () => {
           secureWrite: (p, d) => fs.writeFileSync(p, d),
         });
         s.upsertPaired(mkResult('u1'));
-        hardenOk = false; // persist() now unlinks + throws (C12)
+        const paired = s.get('u1')!.lastSeenAt;
+        vi.advanceTimersByTime(60_000);
+        hardenOk = false; // persist() now unlinks the file + throws (C12)
         s.noteSeen('u1');
         expect(() => s.flushSeen()).not.toThrow();
-        // Still pending: the next flush attempt retries it once persistence recovers.
+        // Still pending — and the recovered write must carry the actual value, not
+        // just leave a peer file that happens to exist.
         hardenOk = true;
         s.flushSeen();
-        expect(new PeerStore(dir, seam).get('u1')?.peerUuid).toBe('u1');
+        expect(new PeerStore(dir, seam).get('u1')!.lastSeenAt).toBe(paired + 60_000);
+        s.dispose();
+      } finally {
+        vi.useRealTimers();
+        if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
+      }
+    });
+
+    it('retries a failed flush on a backoff instead of waiting for the next record', async () => {
+      const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      try {
+        let hardenOk = true;
+        let writes = 0;
+        const s = new PeerStore(dir, {
+          reHarden: () => {
+            writes += 1;
+            return hardenOk;
+          },
+          secureWrite: (p, d) => fs.writeFileSync(p, d),
+          seenFlushMs: 5,
+        });
+        s.upsertPaired(mkResult('u1'));
+        hardenOk = false;
+        s.noteSeen('u1');
+        s.flushSeen(); // fails, arms a backoff retry
+        const afterFail = writes;
+        hardenOk = true;
+        // No further noteSeen and no dispose: the retry timer alone has to settle it.
+        await new Promise((r) => setTimeout(r, 80));
+        expect(writes).toBeGreaterThan(afterFail);
+        expect(new PeerStore(dir, seam).get('u1')!.lastSeenAt).toBe(s.get('u1')!.lastSeenAt);
+        s.dispose();
       } finally {
         if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
       }
+    });
+
+    it('a late noteSeen after dispose cannot arm a timer nobody flushes', () => {
+      const { s, writes } = countingStore({ seenFlushMs: 5 });
+      s.upsertPaired(mkResult('u1'));
+      s.dispose();
+      const afterDispose = writes();
+      s.noteSeen('u1');
+      expect(writes()).toBe(afterDispose);
+      s.dispose(); // idempotent
+      expect(writes()).toBe(afterDispose);
     });
 
     it('dispose flushes a pending refresh', () => {

--- a/src/daemon/lanlink/__tests__/peers.test.ts
+++ b/src/daemon/lanlink/__tests__/peers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -215,5 +215,115 @@ describe('peers — per-peer store', () => {
     s.upsertPaired(mkResult('u1'));
     // atomicWrite renames a fresh tmp inode over the path, never writes through the link.
     expect(fs.readFileSync(target, 'utf8')).toBe('IMPORTANT');
+  });
+
+  // ── #665: lastSeenAt must not persist per received record ──────────────────
+  describe('noteSeen coalesces its writes', () => {
+    /** reHarden runs exactly once per persist, so it doubles as a write counter. */
+    function countingStore(over: PeerStoreOptions = {}): { s: PeerStore; writes: () => number } {
+      let writes = 0;
+      const s = new PeerStore(dir, {
+        ...seam,
+        reHarden: () => {
+          writes += 1;
+          return true;
+        },
+        ...over,
+      });
+      const base = writes; // discount the machine-key harden done in the constructor
+      return { s, writes: () => writes - base };
+    }
+
+    it('does not write to disk per call, but updates memory', () => {
+      const { s, writes } = countingStore();
+      s.upsertPaired(mkResult('u1'));
+      const afterPair = writes();
+      const before = s.get('u1')!.lastSeenAt;
+      for (let i = 0; i < 50; i++) s.noteSeen('u1');
+      expect(writes()).toBe(afterPair); // 50 records, zero extra persists
+      expect(s.get('u1')!.lastSeenAt).toBeGreaterThanOrEqual(before);
+    });
+
+    it('flushSeen writes the pending refresh exactly once', () => {
+      const { s, writes } = countingStore();
+      s.upsertPaired(mkResult('u1'));
+      const afterPair = writes();
+      s.noteSeen('u1');
+      s.flushSeen();
+      expect(writes()).toBe(afterPair + 1);
+      s.flushSeen(); // nothing pending — no second write
+      expect(writes()).toBe(afterPair + 1);
+    });
+
+    it('reaches disk only once flushed', () => {
+      vi.useFakeTimers();
+      try {
+        const s = store();
+        s.upsertPaired(mkResult('u1'));
+        const paired = store().get('u1')!.lastSeenAt;
+        vi.advanceTimersByTime(60_000);
+        s.noteSeen('u1');
+        expect(store().get('u1')!.lastSeenAt).toBe(paired); // still only in memory
+        s.flushSeen();
+        expect(store().get('u1')!.lastSeenAt).toBe(paired + 60_000);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('a durable persist settles the pending refresh', () => {
+      const { s, writes } = countingStore();
+      s.upsertPaired(mkResult('u1'));
+      s.noteSeen('u1');
+      const afterPair = writes();
+      s.bumpHighWater('u1', 1); // writes the whole store, lastSeenAt included
+      expect(writes()).toBe(afterPair + 1);
+      s.flushSeen(); // already on disk — must not write again
+      expect(writes()).toBe(afterPair + 1);
+    });
+
+    // A throw here would reach the server's pump() catch and kill the connection
+    // over a lastSeenAt write — the #658 interaction called out in #665.
+    it('never throws when the write fails, and retries the refresh later', () => {
+      const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      try {
+        let hardenOk = true;
+        const s = new PeerStore(dir, {
+          reHarden: () => hardenOk,
+          secureWrite: (p, d) => fs.writeFileSync(p, d),
+        });
+        s.upsertPaired(mkResult('u1'));
+        hardenOk = false; // persist() now unlinks + throws (C12)
+        s.noteSeen('u1');
+        expect(() => s.flushSeen()).not.toThrow();
+        // Still pending: the next flush attempt retries it once persistence recovers.
+        hardenOk = true;
+        s.flushSeen();
+        expect(new PeerStore(dir, seam).get('u1')?.peerUuid).toBe('u1');
+      } finally {
+        if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
+      }
+    });
+
+    it('dispose flushes a pending refresh', () => {
+      const { s, writes } = countingStore();
+      s.upsertPaired(mkResult('u1'));
+      const afterPair = writes();
+      s.noteSeen('u1');
+      s.dispose();
+      expect(writes()).toBe(afterPair + 1);
+    });
+
+    it('the flush timer settles a refresh with no further traffic', async () => {
+      const { s, writes } = countingStore({ seenFlushMs: 5 });
+      s.upsertPaired(mkResult('u1'));
+      const afterPair = writes();
+      s.noteSeen('u1');
+      s.noteSeen('u1'); // a second refresh must not arm a second timer
+      await new Promise((r) => setTimeout(r, 30));
+      expect(writes()).toBe(afterPair + 1);
+      s.dispose();
+    });
   });
 });

--- a/src/daemon/lanlink/__tests__/server.test.ts
+++ b/src/daemon/lanlink/__tests__/server.test.ts
@@ -77,11 +77,18 @@ function mockController(enabled: boolean) {
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 let tmpRoot: string;
-function mkPeers(): PeerStore {
+function mkPeers(onPersist?: () => void): PeerStore {
   const dir = fs.mkdtempSync(path.join(tmpRoot, 'peers-'));
   // Skip the slow win32 PowerShell owner-DACL shell-out so the handshake tests
   // stay well under the default test timeout even under full-suite parallelism.
-  return new PeerStore(dir, { reHarden: () => true, secureWrite: (p, d) => fs.writeFileSync(p, d) });
+  // The re-harden runs exactly once per persist, so it also counts store writes.
+  return new PeerStore(dir, {
+    reHarden: () => {
+      onPersist?.();
+      return true;
+    },
+    secureWrite: (p, d) => fs.writeFileSync(p, d),
+  });
 }
 
 interface Harness {
@@ -92,8 +99,8 @@ interface Harness {
   nudges: number[];
 }
 
-async function makeServer(): Promise<Harness> {
-  const serverPeers = mkPeers();
+async function makeServer(onPeerPersist?: () => void): Promise<Harness> {
+  const serverPeers = mkPeers(onPeerPersist);
   const appended: Omit<InboxRecord, 'seq'>[] = [];
   const nudges: number[] = [];
   let seq = 0;
@@ -219,6 +226,33 @@ describe('LanLinkServer — inbound responder state machine', () => {
     expect(rec.text).toBe('hi[31m there'); // ESC stripped, CSI body remains as text
     expect(rec.id).toMatch(/^[0-9a-f-]{36}$/);
     expect(h.nudges.length).toBe(1);
+    h.server.dispose();
+  });
+
+  // #665: noteSeen used to persist the whole peer store per delivered record, so a
+  // peer streaming at the rate cap drove that many owner-DACL shell-outs a second
+  // through execFileSync — blocking the daemon event loop, not just lanlink.
+  it('costs at most one peer-store write per delivered record', async () => {
+    let writes = 0;
+    const h = await makeServer(() => {
+      writes += 1;
+    });
+    h.server.enterPairingMode('123456');
+    const clientPeers = mkPeers();
+    const result = await doPair(h, clientPeers, '123456');
+    const ch = await openAeadChannel(h, result.peerUuid, clientPeers.secretOf(result.peerUuid)!);
+    const before = writes;
+    const N = 5;
+    for (let i = 1; i <= N; i++) {
+      // ch.sealer keeps the intra-connection counter, so several records ride one channel.
+      ch.clientSock.write(
+        encodeFrame(0x10, ch.sealer.seal(Buffer.from(JSON.stringify({ kind: 'msg.text', peerName: 'B', text: 'm' + i, senderSeq: i })))),
+      );
+      await delay(10);
+    }
+    expect(h.appended.length).toBe(N);
+    // Exactly the durable high-water bump per record; lastSeenAt no longer doubles it.
+    expect(writes - before).toBe(N);
     h.server.dispose();
   });
 

--- a/src/daemon/lanlink/__tests__/server.test.ts
+++ b/src/daemon/lanlink/__tests__/server.test.ts
@@ -253,7 +253,15 @@ describe('LanLinkServer — inbound responder state machine', () => {
     expect(h.appended.length).toBe(N);
     // Exactly the durable high-water bump per record; lastSeenAt no longer doubles it.
     expect(writes - before).toBe(N);
+    // And nothing is left pending for teardown to write: noteSeen runs BEFORE
+    // bumpHighWater, so that persist already carried the timestamp out. The other
+    // order cost an extra whole-store write on every connection close — which is
+    // every single message on the sendToPeer path.
+    ch.clientSock.destroy();
+    await delay(20);
+    expect(writes - before).toBe(N);
     h.server.dispose();
+    expect(writes - before).toBe(N);
   });
 
   it('REJECTS an execute-kind app message — never appended, peer burn-bounded (C1/router)', async () => {

--- a/src/daemon/lanlink/peers.ts
+++ b/src/daemon/lanlink/peers.ts
@@ -118,7 +118,12 @@ export interface PeerStoreOptions {
   reHarden?: (filePath: string) => boolean;
   /** Test seam: override the secure (owner-DACL) machine-key write. */
   secureWrite?: (filePath: string, data: string) => void;
+  /** How long a `lastSeenAt` refresh may sit in memory before it is written (#665). */
+  seenFlushMs?: number;
 }
+
+/** Coalescing window for `lastSeenAt` writes — see PeerStore.noteSeen (#665). */
+export const SEEN_FLUSH_MS = 30_000;
 
 export class PeerStore {
   private readonly dir: string;
@@ -128,8 +133,12 @@ export class PeerStore {
   private readonly isLive: (peerUuid: string) => boolean;
   private readonly reHarden: (filePath: string) => boolean;
   private readonly secureWrite: (filePath: string, data: string) => void;
+  private readonly seenFlushMs: number;
   /** Map-backed (C20): lookups can never traverse the prototype chain. */
   private map = new Map<string, PeerRecord>();
+  /** A `lastSeenAt` refresh is live in memory but not yet on disk (#665). */
+  private seenDirty = false;
+  private seenFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(baseDir: string, opts: PeerStoreOptions = {}) {
     this.dir = path.join(baseDir, 'lanlink');
@@ -138,6 +147,7 @@ export class PeerStore {
     this.isLive = opts.isLive ?? (() => false);
     this.reHarden = opts.reHarden ?? reHardenTokenFileAcl;
     this.secureWrite = opts.secureWrite ?? secureWriteTokenFile;
+    this.seenFlushMs = opts.seenFlushMs ?? SEEN_FLUSH_MS;
     fs.mkdirSync(this.dir, { recursive: true });
     this.machineKey = this.loadOrCreateMachineKey();
     this.load();
@@ -247,11 +257,72 @@ export class PeerStore {
     this.persist();
   }
 
+  /**
+   * Refresh `lastSeenAt` IN MEMORY and arm a coalescing flush (#665).
+   *
+   * This is on the per-record receive path, so it must not persist per call: a
+   * persist is a whole-store atomicWrite + a synchronous owner-DACL re-harden
+   * (on win32 a whoami.exe + powershell.exe shell-out, measured at 1.8-3.8s per
+   * process under AV — and execFileSync blocks the daemon event loop, not just
+   * lanlink). At MAX_RECORDS_PER_SEC a single peer could drive 50 of those a
+   * second and stall the control pipe.
+   *
+   * `lastSeenAt` does not need per-message durability: it only feeds LRU
+   * eviction (pickEvictable) and lanlink.peers.list, both of which read the
+   * in-memory map. The worst a crash before the flush costs is a stale eviction
+   * hint, bounded by the flush delay.
+   */
   noteSeen(peerUuid: string): void {
     const r = this.map.get(peerUuid);
     if (!r) return;
     r.lastSeenAt = nowMs();
-    this.persist();
+    this.seenDirty = true;
+    this.armSeenFlush();
+  }
+
+  /**
+   * Write out a pending `lastSeenAt` refresh, if any. Called on the flush timer,
+   * on connection teardown, and on dispose.
+   *
+   * NEVER throws: unlike the security-critical mutators, a failed lastSeenAt
+   * write must not propagate. On the receive path a throw here would take down
+   * the connection through the server's pump() catch (#658), which is a far
+   * worse outcome than an out-of-date eviction hint.
+   */
+  flushSeen(): void {
+    this.clearSeenFlush();
+    if (!this.seenDirty) return;
+    try {
+      this.persist();
+    } catch (err) {
+      // seenDirty stays set (persist() clears it only on success), so the next
+      // noteSeen re-arms the timer and dispose() gets a final attempt. Deliberately
+      // NOT re-armed here: a persistently failing win32 ACL would otherwise log on
+      // a 30s loop forever with no traffic to justify it.
+      console.error('[LanLinkPeerStore] failed to flush lastSeenAt:', err);
+    }
+  }
+
+  private armSeenFlush(): void {
+    if (this.seenFlushTimer) return;
+    this.seenFlushTimer = setTimeout(() => {
+      this.seenFlushTimer = null;
+      this.flushSeen();
+    }, this.seenFlushMs);
+    // Never hold the daemon open for a lastSeenAt write.
+    this.seenFlushTimer.unref?.();
+  }
+
+  private clearSeenFlush(): void {
+    if (!this.seenFlushTimer) return;
+    clearTimeout(this.seenFlushTimer);
+    this.seenFlushTimer = null;
+  }
+
+  /** Flush a pending lastSeenAt and stop the timer. */
+  dispose(): void {
+    this.flushSeen();
+    this.clearSeenFlush();
   }
 
   bumpHighWater(peerUuid: string, senderSeq: number): void {
@@ -333,6 +404,11 @@ export class PeerStore {
       throw new Error('LanLink peer store: could not apply owner-only ACL — refusing to persist secrets');
     }
     this.fsyncBestEffort();
+    // A persist writes the WHOLE store, so it also settles any pending lastSeenAt
+    // refresh — but only once the write actually succeeded, so a failed persist
+    // still leaves the flush timer to retry (#665).
+    this.seenDirty = false;
+    this.clearSeenFlush();
   }
 
   private load(): void {

--- a/src/daemon/lanlink/peers.ts
+++ b/src/daemon/lanlink/peers.ts
@@ -124,6 +124,8 @@ export interface PeerStoreOptions {
 
 /** Coalescing window for `lastSeenAt` writes — see PeerStore.noteSeen (#665). */
 export const SEEN_FLUSH_MS = 30_000;
+/** Backoff attempts after a failed flush, before it waits for the next record. */
+export const SEEN_FLUSH_MAX_RETRIES = 3;
 
 export class PeerStore {
   private readonly dir: string;
@@ -139,6 +141,8 @@ export class PeerStore {
   /** A `lastSeenAt` refresh is live in memory but not yet on disk (#665). */
   private seenDirty = false;
   private seenFlushTimer: ReturnType<typeof setTimeout> | null = null;
+  private seenRetries = 0;
+  private disposed = false;
 
   constructor(baseDir: string, opts: PeerStoreOptions = {}) {
     this.dir = path.join(baseDir, 'lanlink');
@@ -271,8 +275,14 @@ export class PeerStore {
    * eviction (pickEvictable) and lanlink.peers.list, both of which read the
    * in-memory map. The worst a crash before the flush costs is a stale eviction
    * hint, bounded by the flush delay.
+   *
+   * Call this BEFORE any durable mutator that runs on the same record (the
+   * receive path's bumpHighWater): that persist then carries the fresh timestamp
+   * out with it, so the record costs one write instead of two and leaves nothing
+   * pending for connection teardown to flush.
    */
   noteSeen(peerUuid: string): void {
+    if (this.disposed) return;
     const r = this.map.get(peerUuid);
     if (!r) return;
     r.lastSeenAt = nowMs();
@@ -286,29 +296,41 @@ export class PeerStore {
    *
    * NEVER throws: unlike the security-critical mutators, a failed lastSeenAt
    * write must not propagate. On the receive path a throw here would take down
-   * the connection through the server's pump() catch (#658), which is a far
-   * worse outcome than an out-of-date eviction hint.
+   * the connection through the server's pump() catch (#658).
+   *
+   * Swallowing is NOT harmless, though, and the log says so: on win32 a persist
+   * that cannot re-apply the owner-only DACL unlinks the peer file before it
+   * throws (C12), so the failure this catches can be "the pairings, burns and
+   * high-water marks are no longer on disk", not merely "the timestamp is
+   * stale". Hence the bounded retry below rather than a silent give-up.
    */
   flushSeen(): void {
     this.clearSeenFlush();
     if (!this.seenDirty) return;
     try {
-      this.persist();
+      this.persist(); // clears seenDirty + seenRetries on success
     } catch (err) {
-      // seenDirty stays set (persist() clears it only on success), so the next
-      // noteSeen re-arms the timer and dispose() gets a final attempt. Deliberately
-      // NOT re-armed here: a persistently failing win32 ACL would otherwise log on
-      // a 30s loop forever with no traffic to justify it.
-      console.error('[LanLinkPeerStore] failed to flush lastSeenAt:', err);
+      console.error(
+        '[LanLinkPeerStore] failed to flush lastSeenAt — on win32 the peer file may have been removed by the fail-closed ACL branch:',
+        err,
+      );
+      // seenDirty is still set (persist clears it only on success). Retry on a
+      // backoff so a quiet peer's refresh — and a store file that C12 deleted —
+      // is not left waiting for the next inbound record. Bounded: a permanently
+      // broken ACL must not log on a timer forever.
+      if (this.seenRetries < SEEN_FLUSH_MAX_RETRIES) {
+        this.seenRetries += 1;
+        this.armSeenFlush(this.seenFlushMs * 2 ** this.seenRetries);
+      }
     }
   }
 
-  private armSeenFlush(): void {
-    if (this.seenFlushTimer) return;
+  private armSeenFlush(delayMs = this.seenFlushMs): void {
+    if (this.seenFlushTimer || this.disposed) return;
     this.seenFlushTimer = setTimeout(() => {
       this.seenFlushTimer = null;
       this.flushSeen();
-    }, this.seenFlushMs);
+    }, delayMs);
     // Never hold the daemon open for a lastSeenAt write.
     this.seenFlushTimer.unref?.();
   }
@@ -319,9 +341,14 @@ export class PeerStore {
     this.seenFlushTimer = null;
   }
 
-  /** Flush a pending lastSeenAt and stop the timer. */
+  /**
+   * Flush a pending lastSeenAt and stop the timer. Idempotent, and final: a late
+   * noteSeen from a socket still draining must not arm a timer nobody will flush.
+   */
   dispose(): void {
+    if (this.disposed) return;
     this.flushSeen();
+    this.disposed = true;
     this.clearSeenFlush();
   }
 
@@ -408,6 +435,7 @@ export class PeerStore {
     // refresh — but only once the write actually succeeded, so a failed persist
     // still leaves the flush timer to retry (#665).
     this.seenDirty = false;
+    this.seenRetries = 0;
     this.clearSeenFlush();
   }
 

--- a/src/daemon/lanlink/server.ts
+++ b/src/daemon/lanlink/server.ts
@@ -279,9 +279,12 @@ export class LanLinkServer {
 
   dispose(): void {
     this.disposed = true;
-    this.deps.peers.dispose();
     this.cancelPairing();
     void this.closeServer();
+    // AFTER the listener teardown: closing connections runs destroy(), whose own
+    // flushSeen would otherwise re-dirty the store behind a dispose that already
+    // flushed — once per connection, each a synchronous win32 ACL shell-out.
+    this.deps.peers.dispose();
     this.queueFirewall(() => this.fw.remove());
   }
 
@@ -682,8 +685,13 @@ export class LanLinkServer {
     // Ack ordering (non-negotiable): durable append+fsync BEFORE high-water bump,
     // app-ACK, and nudge.
     const { seq } = this.deps.inbox.append(rec);
-    this.deps.peers.bumpHighWater(peerUuid, msg.senderSeq);
+    // noteSeen FIRST (#665): it only stages lastSeenAt in memory, so the durable
+    // bumpHighWater right after carries it out in the same whole-store write. The
+    // other order left a refresh pending after every record — one extra write per
+    // connection teardown, which for the message-per-connection send path meant
+    // the record still cost two.
     this.deps.peers.noteSeen(peerUuid);
+    this.deps.peers.bumpHighWater(peerUuid, msg.senderSeq);
     // App-level AEAD-sealed ACK (after the durable write).
     this.send(conn, AEAD_RECORD, conn.sealer!.seal(Buffer.from(JSON.stringify({ ack: id }), 'utf8')));
     this.deps.nudge(seq);

--- a/src/daemon/lanlink/server.ts
+++ b/src/daemon/lanlink/server.ts
@@ -279,6 +279,7 @@ export class LanLinkServer {
 
   dispose(): void {
     this.disposed = true;
+    this.deps.peers.dispose();
     this.cancelPairing();
     void this.closeServer();
     this.queueFirewall(() => this.fw.remove());
@@ -717,6 +718,9 @@ export class LanLinkServer {
       if (n <= 0) this.connsByIp.delete(conn.ip);
       else this.connsByIp.set(conn.ip, n);
     }
+    // Settle the peer's coalesced lastSeenAt now that its stream is over (#665).
+    // No-op unless a refresh is actually pending, and flushSeen never throws.
+    if (conn.peerUuid) this.deps.peers.flushSeen();
   }
 
   /** True if a paired peer has a live AEAD connection (PeerStore eviction guard). */


### PR DESCRIPTION
## Summary

`onAeadRecord` called `peers.noteSeen()` for every delivered record, purely to refresh a `lastSeenAt` timestamp. Each call persisted the **entire** peer store: a whole-store `atomicWriteJSONSync` plus a synchronous owner-DACL re-harden — on win32 a `whoami.exe` + `powershell.exe` `execFileSync`, measured in this repo at 1.8–3.8s per process under AV. Because it is `execFileSync` it blocks the daemon event loop, not just the lanlink path. Paired with `bumpHighWater`'s own persist, one peer streaming at `MAX_RECORDS_PER_SEC` (50) could drive 100 of those a second and stall the control pipe.

`lastSeenAt` does not need per-message durability — it only feeds LRU eviction (`pickEvictable`) and `lanlink.peers.list`, both of which read the in-memory map.

## Changes

- `noteSeen` refreshes `lastSeenAt` in memory and arms a coalescing flush (30s timer, unref'd). The flush also runs on connection teardown and on `dispose()`, which the daemon shutdown path already calls.
- Any security-critical persist (pairing, revoke, burn, high-water) settles the pending refresh on its way past — and clears the dirty flag only once the write actually succeeded, so a failed persist still retries.
- `flushSeen()` never throws. On the receive path a throw would reach the server's `pump()` catch and take down the connection over a timestamp write — the #658 interaction called out in the issue.
- Regression tests at both levels: the store no longer writes per `noteSeen`, flushes exactly once, survives a failing write, and settles on the timer; the server costs **one** store write per delivered record (was two — verified by reverting the fix, which turns the assertion into 10 vs 5).

## Deliberately unchanged

`recvHighWater` keeps its durable per-record persist. It is the only cross-connection replay gate (`server.ts` re-ACKs and drops anything at or below it), so deferring it would widen the replay window after a crash. The receive path therefore drops from two store writes per record to one, not to zero. Making the persist primitive itself cheap on win32 — the issue's third suggestion, which would also remove a candidate cause of #658 — is left to a follow-up, since it changes the fail-closed C12 semantics in `shared/security` and `atomicWrite`.

Closes #665

## Stability tier impact

- [x] No external surface touched (internal refactor / docs / tests / CI).
- [ ] Additive change to a stable surface.
- [ ] Breaking change to a stable surface.
- [ ] Change to an experimental surface.
- [ ] Change to an internal surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced repeated peer-store writes by batching “last seen” updates and saving them on a timer or when connections close.
  * Ensured pending updates are persisted during shutdown.

* **Reliability**
  * Added retry handling when saving updates fails, without interrupting normal operation.

* **Tests**
  * Added coverage for batched persistence, timer-based saves, connection cleanup, shutdown behavior, and write failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->