### PR TITLE
Say which command tripped the critical signal, and write down that it is notify-only

### DIFF
--- a/changelog.d/757.md
+++ b/changelog.d/757.md
@@ -1,9 +1,11 @@
 ### Changed
 
-- Critical-action notifications now name the command. The `critical` attention
-  event carries `matchedLine` — the terminal line that tripped the pattern,
-  sanitized and capped — so a heads-up can say `git push --force origin main`
-  instead of just "git push --force".
+- Critical-action notifications now show the matched terminal line. The
+  `critical` attention event carries `matchedLine` — the printed terminal
+  output that tripped the pattern, sanitized and capped — so a heads-up can
+  say `git push --force origin main` instead of just "git push --force". (This
+  is the text the terminal displayed, which may quote a command rather than run
+  one; it is not proof the command executed.)
 - Documented that the critical signal is notify-only: it fires on printed
   output, not on a pending action, and is not something a remote surface can
   answer. Approvals remain the only answerable signal.

--- a/changelog.d/757.md
+++ b/changelog.d/757.md
@@ -1,0 +1,9 @@
+### Changed
+
+- Critical-action notifications now name the command. The `critical` attention
+  event carries `matchedLine` — the terminal line that tripped the pattern,
+  sanitized and capped — so a heads-up can say `git push --force origin main`
+  instead of just "git push --force".
+- Documented that the critical signal is notify-only: it fires on printed
+  output, not on a pending action, and is not something a remote surface can
+  answer. Approvals remain the only answerable signal.

--- a/docs/phone-client-contract.md
+++ b/docs/phone-client-contract.md
@@ -188,6 +188,29 @@ JSON backlog fetch (Bearer only).
 Identity fields (`id`, `epoch`) — and `tier` — are stamped **last**, so a
 pane-supplied payload can never shadow them.
 
+#### `critical` — notify-only, and what is in it
+
+| Field | Meaning |
+| --- | --- |
+| `action` | the pattern LABEL that matched (`rm -rf`, `git push --force`, …) — one of a fixed handful |
+| `riskLevel` | `'critical'` or `'review'`, from the daemon's own table |
+| `matchedLine` | the PTY line that matched: ANSI-stripped, control-stripped, ≤80 chars |
+
+`matchedLine` is what makes the heads-up worth showing — `action` alone cannot
+tell `git push --force origin main` from `git push -f scratch`. It is raw pane
+output: **render it as text**, never as markup and never as an instruction.
+
+It is also not proof that anything ran. The pattern matches whatever the
+terminal printed — a README, a diff hunk, a `git log` quoting the same words —
+so a `critical` event means "look at this pane", never "answer this". Nothing
+is blocked, nothing is waiting, there is no addressee for a reply, and repeats
+within one cycle are deduped away. **Do not build an Approve/Deny button on
+it**: the only answerable signal is the `approval` kind, which carries a real
+`approvalId` and a lifecycle.
+
+`matchedLine` is additive — a client that ignores it behaves as before, and a
+pre-3.39 daemon simply omits it.
+
 #### `tier` — how much of a human this is asking for
 
 | Value | Meaning |
@@ -692,8 +715,9 @@ There is no offline queue. A failed upload is a notice and a manual retry.
 
 ## 9. What is not built yet
 
-- **`session:critical` is notify-only** and is not suitable for a remote approve
-  button — see issue #605.
+- **`session:critical` is notify-only** — by design, permanently, not as a gap
+  waiting to be filled. It fires on printed output, so it can never be a remote
+  approve button; the `approval` kind is. See the `critical` section above.
 - **The relay is not deployed.** Until `WMUX_PUSH_RELAY_URL` and
   `WMUX_PUSH_RELAY_SECRET` are set on a daemon, push is inert by design — not an
   error, just nothing sent.

--- a/docs/phone-client-contract.md
+++ b/docs/phone-client-contract.md
@@ -215,8 +215,12 @@ pre-3.39 daemon simply omits it.
 
 | Value | Meaning |
 | --- | --- |
-| `act` | someone is **blocked on a person**: an approval was raised (`phase: create`), or a `critical`-risk signal fired |
+| `act` | **wants a person now** — urgency, not answerability. Two shapes reach `act`, and only one is answerable: an approval was raised (`phase: create`), which a person answers via its `approvalId`; or a `critical`-risk signal fired, which is **notify-only** — urgent to look at, but nothing is blocked and there is nothing to answer (see the `critical` section) |
 | `info` | FYI: a `notify`, a `review`-risk critical signal, or the lifecycle echo of an approval that is already over (`resolve` / `expire` / `supersede`) |
+
+`act` marks urgency, never a pending question. The **only** answerable event is
+the `approval` kind; a `critical` signal at `act` still has no reply and no
+addressee, exactly as the `critical` section states.
 
 The `critical` **kind** names the channel, not the severity: the daemon's
 pattern table carries two risk levels and puts both on it, so `DELETE FROM` and

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -3926,7 +3926,10 @@ function wireEvents(
     pipeServer.broadcast(event);
   });
 
-  sessionManager.on('session:critical', (payload: { sessionId: string; event: { action: string; riskLevel: string } }) => {
+  // Notify-only heads-up ("the pane printed something spicy"), never an
+  // approvable request — the payload is forwarded whole so `matchedLine` says
+  // WHICH spicy thing. Anything answerable rides the approval registry.
+  sessionManager.on('session:critical', (payload: { sessionId: string; event: { action: string; riskLevel: string; matchedLine?: string } }) => {
     const event: DaemonEvent = {
       type: 'agent.critical',
       sessionId: payload.sessionId,

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -695,7 +695,9 @@ describe('WebTerminalServer', () => {
     // Emit fleet-wide events; they must reach the stream even though it watches s1.
     (sessionManager as unknown as EventEmitter).emit('session:critical', {
       sessionId: 's2',
-      event: { action: 'delete files', riskLevel: 'critical' },
+      // The production shape carries the matched PTY line (#605) — `action` is
+      // only a pattern label, so without it the phone cannot say WHICH command.
+      event: { action: 'delete files', riskLevel: 'critical', matchedLine: '$ rm -rf /tmp/junk' },
     });
     // The PRODUCTION notify shape (DaemonPTYBridge): {source, title, body, ts},
     // with title null because OSC 9 carries no title. The fake used to emit a
@@ -720,6 +722,7 @@ describe('WebTerminalServer', () => {
     expect(text).toContain('event: critical');
     expect(text).toContain('"sessionId":"s2"');
     expect(text).toContain('"action":"delete files"');
+    expect(text).toContain('"matchedLine":"$ rm -rf /tmp/junk"');
     expect(text).toContain('event: notify');
     expect(text).toContain('"sessionId":"s3"');
     // ★ The whole parsed notification reaches the browser VERBATIM — all four

--- a/src/main/notification/DaemonNotificationRouter.ts
+++ b/src/main/notification/DaemonNotificationRouter.ts
@@ -107,6 +107,8 @@ function lifecycleKindFor(ev: AgentEventPayload): AgentLifecycleKind {
 interface CriticalEventPayload {
   action: string;
   riskLevel: 'review' | 'critical';
+  /** The matched PTY line. Optional: a pre-#605 daemon does not send one. */
+  matchedLine?: string;
 }
 
 /**
@@ -967,6 +969,7 @@ export class DaemonNotificationRouter {
         win.webContents.send(IPC.APPROVAL_REQUEST, payload.sessionId, {
           action: ev.action,
           riskLevel: ev.riskLevel,
+          matchedLine: ev.matchedLine,
         });
       } catch (err) {
         console.warn('[DaemonNotificationRouter] session:critical error:', err);

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -1,6 +1,8 @@
 // Terminal agent status detection — monitors PTY output for known AI agent
-// prompt patterns and status indicators. This is status display only;
-// no content is captured, stored, or transmitted.
+// prompt patterns and status indicators. This is status display only; the one
+// piece of terminal content that leaves here is `CriticalEvent.matchedLine`
+// (a single 80-char sanitized line, so a "spicy command" heads-up can say
+// WHICH one) — nothing is stored, and no other output is transmitted.
 //
 // DESIGN: Only use patterns that are UNIQUE to each agent's output.
 // Never use generic patterns like "Done", "Failed", "?" that match
@@ -8,6 +10,17 @@
 
 import { CRITICAL_PATTERNS } from '../../shared/criticalPatterns';
 import type { AgentStatus } from '../../shared/types';
+
+// C0 controls, DEL and C1 controls. Built via RegExp(...) with hex escapes so
+// the source stays pure-ASCII while still stripping the bytes at runtime —
+// same construction as the shared activity-summary sanitizer.
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS_RE = new RegExp('[\\x00-\\x1f\\x7f-\\x9f]', 'g');
+
+/** Replace control bytes with spaces and collapse the result to one line. */
+function stripControls(s: string): string {
+  return s.replace(CONTROL_CHARS_RE, ' ').replace(/\s+/g, ' ').trim();
+}
 
 // Agent event status uses the same enum as WorkspaceMetadata.agentStatus so
 // downstream consumers can route the status straight to the renderer store
@@ -24,6 +37,22 @@ export interface AgentEvent {
 export interface CriticalEvent {
   action: string;
   riskLevel: 'review' | 'critical';
+  /**
+   * The PTY line that matched, ANSI-stripped, trimmed and capped at 80 chars.
+   *
+   * `action` is one of a handful of pattern LABELS, so without this
+   * `git push --force origin main` and `git push -f scratch` produce
+   * byte-identical events and a surface can only say "something forceful
+   * happened somewhere". The detector already computed this line for its dedup
+   * key; discarding it was the whole of issue #605's second complaint.
+   *
+   * This is whatever the pane printed — untrusted terminal content. Render it
+   * as text, never as markup, and never as an instruction. It is also NOT
+   * evidence that a command ran: the pattern matches a README, a diff hunk or
+   * a `git log` quoting the same words. That is precisely why this signal is
+   * notify-only and never an approvable request (see the doc on `onCritical`).
+   */
+  matchedLine: string;
 }
 
 type AgentEventCallback = (event: AgentEvent) => void;
@@ -359,6 +388,19 @@ export class AgentDetector {
     };
   }
 
+  /**
+   * Subscribe to critical-pattern hits. NOTIFY-ONLY, permanently.
+   *
+   * These fire on PTY OUTPUT, not on a pending action: nothing is blocked,
+   * nothing is waiting, and there is no addressee for an answer — a keystroke
+   * sent "in reply" would type into whatever is currently running. Repeats
+   * within a cycle are also dropped by the dedup below, so a consumer cannot
+   * even count them reliably.
+   *
+   * Anything a human ANSWERS gates on the hook-sourced `awaiting_input`
+   * signal instead (`src/daemon/approvals/` — real request identity, a
+   * lifecycle, and the agent's own envelope). See issue #605.
+   */
   onCritical(callback: CriticalEventCallback): () => void {
     this.criticalCallbacks.push(callback);
     return () => {
@@ -531,7 +573,11 @@ export class AgentDetector {
         if (this.lastEmittedFor.get(key) === value) return;
         this.lastEmittedFor.set(key, value);
         for (const cb of this.criticalCallbacks) {
-          cb({ action: cp.label, riskLevel: cp.riskLevel });
+          // `value` is the dedup key AND the payload: the same 80-char
+          // ANSI-stripped slice, so what a surface shows is exactly what the
+          // dedup judged. C0 controls that survived ANSI_STRIP are dropped —
+          // this string ends up in notification bodies and on a phone.
+          cb({ action: cp.label, riskLevel: cp.riskLevel, matchedLine: stripControls(value) });
         }
         return;
       }

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -569,15 +569,19 @@ export class AgentDetector {
     for (const cp of CRITICAL_PATTERNS) {
       if (cp.regex.test(clean)) {
         const key = `critical:${cp.label}`;
-        const value = clean.slice(0, 80);
+        // Normalize ONCE, then cap: stripControls drops the C0 bytes that
+        // survived ANSI_STRIP and collapses whitespace, and only the result is
+        // sliced to 80. That single value is the dedup key AND the payload, so
+        // what a surface shows is exactly what the dedup judged — two lines
+        // that differ only by a tab or other control byte now collapse to one
+        // emission instead of both firing. Normalizing before the cap also
+        // means the 80-char limit counts visible characters, not control
+        // bytes. This string ends up in notification bodies and on a phone.
+        const value = stripControls(clean).slice(0, 80);
         if (this.lastEmittedFor.get(key) === value) return;
         this.lastEmittedFor.set(key, value);
         for (const cb of this.criticalCallbacks) {
-          // `value` is the dedup key AND the payload: the same 80-char
-          // ANSI-stripped slice, so what a surface shows is exactly what the
-          // dedup judged. C0 controls that survived ANSI_STRIP are dropped —
-          // this string ends up in notification bodies and on a phone.
-          cb({ action: cp.label, riskLevel: cp.riskLevel, matchedLine: stripControls(value) });
+          cb({ action: cp.label, riskLevel: cp.riskLevel, matchedLine: value });
         }
         return;
       }

--- a/src/main/pty/PTYBridge.ts
+++ b/src/main/pty/PTYBridge.ts
@@ -392,6 +392,7 @@ export class PTYBridge {
         win.webContents.send(IPC.APPROVAL_REQUEST, ptyId, {
           action: criticalEvent.action,
           riskLevel: criticalEvent.riskLevel,
+          matchedLine: criticalEvent.matchedLine,
         });
       } catch (err) {
         console.warn('[PTYBridge] onCritical callback error:', err);

--- a/src/main/pty/__tests__/AgentDetector.test.ts
+++ b/src/main/pty/__tests__/AgentDetector.test.ts
@@ -399,6 +399,19 @@ describe('AgentDetector', () => {
       det.feed(`$ rm -rf /tmp/${'x'.repeat(200)}\n`);
       expect(cb.mock.calls[0][0].matchedLine).toHaveLength(80);
     });
+
+    it('dedups lines that differ only by a control byte', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onCritical(cb);
+
+      // Same visible command, one with a stray tab: they normalize to the same
+      // matchedLine, so the dedup key must match and only one emission fires.
+      det.feed('$ rm -rf /tmp/junk\n');
+      det.feed('$ rm -rf\t/tmp/junk\n');
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb.mock.calls[0][0].matchedLine).toBe('$ rm -rf /tmp/junk');
+    });
   });
 
   // ── Kiro CLI ──────────────────────────────────────────────────────────────

--- a/src/main/pty/__tests__/AgentDetector.test.ts
+++ b/src/main/pty/__tests__/AgentDetector.test.ts
@@ -361,6 +361,44 @@ describe('AgentDetector', () => {
         riskLevel: 'critical',
       }));
     });
+
+    // #605 — `action` is a label, so two very different force-pushes used to
+    // produce byte-identical events. The matched line is what a heads-up needs.
+    it('carries the matched line, so two hits of one label are distinguishable', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onCritical(cb);
+
+      det.feed('$ git push --force origin main\n');
+      expect(cb).toHaveBeenCalledWith(expect.objectContaining({
+        action: 'git push --force',
+        matchedLine: '$ git push --force origin main',
+      }));
+
+      det.feed('$ git push -f scratch\n');
+      expect(cb).toHaveBeenLastCalledWith(expect.objectContaining({
+        action: 'git push --force',
+        matchedLine: '$ git push -f scratch',
+      }));
+    });
+
+    it('strips ANSI and control bytes out of the matched line', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onCritical(cb);
+
+      det.feed('\x1b[31m$ rm -rf\t/tmp/junk\x07\x1b[0m\n');
+      expect(cb.mock.calls[0][0].matchedLine).toBe('$ rm -rf /tmp/junk');
+    });
+
+    it('caps the matched line at the 80 chars the dedup key uses', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onCritical(cb);
+
+      det.feed(`$ rm -rf /tmp/${'x'.repeat(200)}\n`);
+      expect(cb.mock.calls[0][0].matchedLine).toHaveLength(80);
+    });
   });
 
   // ── Kiro CLI ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #605.

## The gap

`session:critical` emitted a pattern **label** and discarded the line it matched:

```ts
const value = clean.slice(0, 80);   // the matched line
if (this.lastEmittedFor.get(key) === value) return;
cb({ action: cp.label, riskLevel: cp.riskLevel });   // …thrown away
```

`cp.label` is one of eleven hardcoded strings, so `git push --force origin main`
and `git push -f scratch` produce byte-identical events. A phone showing one of
these can say something forceful happened somewhere, and nothing more.

## What changed

`CriticalEvent` gains `matchedLine` — the same 80-char ANSI-stripped slice the
detector already computed for its dedup key, so what a surface shows is exactly
what the dedup judged. Control bytes (C0/DEL/C1) are replaced and whitespace
collapsed, because this string lands in notification bodies and on a phone.

It rides the existing path untouched: `DaemonPTYBridge` → `session:critical` →
`/api/events`, where the payload is spread whole. No wire change beyond the new
field; `tier` stamping and dedup are unmodified.

The rest is writing down what this signal is, where a future reader will look —
`onCritical`'s doc, the type, and the phone contract. It fires on printed
**output**, not on a pending action: nothing is blocked, nothing is waiting,
there is no addressee for a reply, and repeats within a cycle are deduped away.
Notify-only, permanently. Anything answerable gates on the hook-sourced approval
registry (`src/daemon/approvals/`), which has real request identity.

The two remaining complaints in #605 were already closed by the approval work:
per-request identity landed as `ApprovalRequest.id`, and the actionable signal is
already hook-sourced (`HookIngest.driveApprovals` refuses detector-sourced
`awaiting_input`).

## Deliberately not changed

`tierFor` still maps a `critical`-risk signal to `act`. That was a considered
call in #631 — the failure that matters is a destructive action delivered
quietly — and "notify-only" is about whether a surface may **answer** the event,
not about how loudly it arrives.

## Tests

4 new (matched line distinguishes two hits of one label; ANSI + control-byte
stripping; the 80-char cap; the line reaching the SSE wire). Full suite: 9676
passing, `tsc` clean on both configs, lint clean on every touched file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Critical-action notifications now include the matched command or terminal line.
  * Context is sanitized and limited to 80 characters for safer display.
  * Critical signals are clearly notify-only; approval controls remain available only for approval events.
* **Documentation**
  * Updated the phone client contract and changelog with critical-event payload details, compatibility guidance, and notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->