### PR TITLE
fix(renderer): restore the DOM renderer when WebGL teardown skips xterm's own restore

### DIFF
--- a/changelog.d/759.md
+++ b/changelog.d/759.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Panes no longer flicker and settle black after a WebGL teardown.** When
+  xterm's WebGL addon was disposed (pane hidden, tab switch, font reload) and
+  an internal step threw mid-dispose, the addon's own "hand back to the DOM
+  renderer" step was silently skipped — leaving the pane with no renderer at
+  all. Every render tick after that (cursor blink, scroll, resize) threw, so
+  the pane flickered and then stayed black until relaunch. Teardown now
+  verifies a renderer survived and restores the DOM renderer itself when it
+  did not. (#759)

--- a/src/renderer/hooks/__tests__/useTerminal.webglTeardown.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.webglTeardown.test.ts
@@ -28,8 +28,8 @@ describe('useTerminal WebGL teardown (source-level lock)', () => {
     );
   });
 
-  it('routes the pool-evict, fonts.ready and unmount paths through teardownWebglAddon', () => {
+  it('routes the pool-evict, fonts.ready, unmount and context-loss paths through teardownWebglAddon', () => {
     const calls = SRC.match(/teardownWebglAddon\(/g) ?? [];
-    expect(calls.length).toBeGreaterThanOrEqual(3);
+    expect(calls.length).toBeGreaterThanOrEqual(4);
   });
 });

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1103,7 +1103,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // just loses GPU acceleration until it is granted a context again.
     function disposeWebgl() {
       if (!webglAddonRef.current) return;
-      teardownWebglAddon(webglAddonRef.current);
+      teardownWebglAddon(webglAddonRef.current, terminal);
       webglAddonRef.current = null;
       try {
         terminal.refresh(0, terminal.rows - 1);
@@ -1192,7 +1192,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         // recreating — this runs once per terminal on mount, so on a multi-pane
         // restore it is a burst of dispose+create pairs; leaking the old
         // contexts here is a prime zombie-context source.
-        teardownWebglAddon(webglAddonRef.current);
+        teardownWebglAddon(webglAddonRef.current, terminal);
         webglAddonRef.current = null;
         loadWebgl();
       }
@@ -2140,7 +2140,11 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // too, not just dispose, or unmount churn leaks zombie contexts (#191 / #197).
       webglContextPool.release(webglTokenRef.current);
       if (webglAddonRef.current) {
-        teardownWebglAddon(webglAddonRef.current);
+        // Pass the terminal so a skipped renderer-restore is repaired even
+        // here: terminal.dispose() below can be DEFERRED by an active drag
+        // (#582), and a rendererless terminal living through that window
+        // throws on every render tick.
+        teardownWebglAddon(webglAddonRef.current, terminal);
         webglAddonRef.current = null;
       }
       loadWebglRef.current = null;

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1079,8 +1079,13 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           // A real GPU driver reset (not our pool eviction): the context is
           // gone. Dispose, drop to xterm's DOM renderer, and free our pool slot
           // so the pool stops counting us and can re-grant on the next toggle.
+          // Route through teardownWebglAddon (not a bare addon.dispose()): a
+          // dispose against a genuinely lost context is the most likely one to
+          // throw mid-store and skip xterm's own DOM-renderer restore, which
+          // is exactly the rendererless flicker-then-black state
+          // ensureRendererRestored repairs.
           console.warn('[Terminal] WebGL context lost — falling back to DOM renderer');
-          addon.dispose();
+          teardownWebglAddon(addon, terminal);
           webglAddonRef.current = null;
           webglContextPool.notifyDisposed(webglTokenRef.current);
           try {

--- a/src/renderer/terminal/__tests__/webglTeardown.test.ts
+++ b/src/renderer/terminal/__tests__/webglTeardown.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
+import type { Terminal } from '@xterm/xterm';
 import type { WebglAddon } from '@xterm/addon-webgl';
-import { teardownWebglAddon } from '../webglTeardown';
+import { teardownWebglAddon, isRendererMissing } from '../webglTeardown';
 
 /**
  * teardownWebglAddon does what xterm's WebglAddon.dispose() alone does not:
@@ -58,6 +59,82 @@ describe('teardownWebglAddon', () => {
 });
 
 /**
+ * Renderer-restore guarantee (flicker-then-black RCA, 2026-08-02).
+ *
+ * WebglAddon.dispose() restores the DOM renderer via a disposable in its own
+ * DisposableStore; a throw from an EARLIER disposable aborts that loop, so the
+ * restore never runs and the pane is left with `_renderer.value === undefined`.
+ * xterm's RenderService.dimensions getter then throws on every render tick
+ * (`Cannot read properties of undefined (reading 'dimensions')`) — the pane
+ * flickers and settles black. teardownWebglAddon must detect that state and
+ * restore the DOM renderer itself.
+ */
+function makeTerminal(opts: {
+  rendererValue?: unknown;
+  disposed?: boolean;
+} = {}) {
+  const { rendererValue, disposed = false } = opts;
+  const domRenderer = { kind: 'dom' };
+  const setRenderer = vi.fn();
+  const handleResize = vi.fn();
+  const createRenderer = vi.fn(() => domRenderer);
+  const terminal = {
+    cols: 80,
+    rows: 24,
+    _core: {
+      _store: { _isDisposed: disposed },
+      _renderService: {
+        _renderer: { value: rendererValue },
+        setRenderer,
+        handleResize,
+      },
+      _createRenderer: createRenderer,
+    },
+  } as unknown as Terminal;
+  return { terminal, domRenderer, setRenderer, handleResize, createRenderer };
+}
+
+describe('teardownWebglAddon renderer-restore guarantee', () => {
+  it('restores the DOM renderer when dispose left the render service empty', () => {
+    const f = makeAddon({ disposeThrows: true });
+    const t = makeTerminal({ rendererValue: undefined });
+    teardownWebglAddon(f.addon, t.terminal);
+    expect(t.createRenderer).toHaveBeenCalledOnce();
+    expect(t.setRenderer).toHaveBeenCalledWith(t.domRenderer);
+    // Mirrors the addon's skipped restore step: re-derive dimensions so the
+    // next render tick paints instead of throwing.
+    expect(t.handleResize).toHaveBeenCalledWith(80, 24);
+  });
+
+  it('leaves a live renderer alone (the normal dispose path)', () => {
+    const f = makeAddon();
+    const t = makeTerminal({ rendererValue: { kind: 'dom' } });
+    teardownWebglAddon(f.addon, t.terminal);
+    expect(t.setRenderer).not.toHaveBeenCalled();
+    expect(t.createRenderer).not.toHaveBeenCalled();
+  });
+
+  it('does not restore into a disposed terminal', () => {
+    const f = makeAddon();
+    const t = makeTerminal({ rendererValue: undefined, disposed: true });
+    teardownWebglAddon(f.addon, t.terminal);
+    expect(t.setRenderer).not.toHaveBeenCalled();
+  });
+
+  it('degrades to a no-op when the private internals changed shape', () => {
+    const f = makeAddon();
+    const terminal = { cols: 80, rows: 24, _core: {} } as unknown as Terminal;
+    expect(() => teardownWebglAddon(f.addon, terminal)).not.toThrow();
+  });
+
+  it('isRendererMissing reports the rendererless-but-live state only', () => {
+    expect(isRendererMissing(makeTerminal({ rendererValue: undefined }).terminal)).toBe(true);
+    expect(isRendererMissing(makeTerminal({ rendererValue: { kind: 'dom' } }).terminal)).toBe(false);
+    expect(isRendererMissing(makeTerminal({ rendererValue: undefined, disposed: true }).terminal)).toBe(false);
+  });
+});
+
+/**
  * Dependency-shape lock. teardownWebglAddon force-releases the context by
  * walking the private path addon._renderer._gl (WebglAddon._renderer →
  * WebglRenderer._gl). The behavioural tests above all mock that shape, so an
@@ -81,5 +158,37 @@ describe('@xterm/addon-webgl private-path shape lock', () => {
 
   it('WebglRenderer still exposes the _gl field teardown reads', () => {
     expect(addonSrc).toMatch(/this\._gl\b/);
+  });
+});
+
+/**
+ * Shape lock for the renderer-restore path. ensureRendererRestored replays the
+ * exact sequence WebglAddon's own (skippable) restore disposable runs:
+ * `_core._renderService.setRenderer(_core._createRenderer())` + `handleResize`.
+ * And isRendererMissing keys off RenderService reading `_renderer.value` —
+ * the unguarded getter whose throw IS the flicker-then-black symptom. If an
+ * @xterm bump renames any of these, the restore silently degrades to a no-op
+ * (the black-pane bug returns) while the mock tests stay green — so pin the
+ * paths against the installed package sources here.
+ */
+describe('renderer-restore private-path shape lock', () => {
+  const addonSrc = readFileSync(require.resolve('@xterm/addon-webgl'), 'utf8');
+  const xtermSrc = readFileSync(require.resolve('@xterm/xterm'), 'utf8');
+
+  it('WebglAddon still restores via _core._renderService.setRenderer(_core._createRenderer())', () => {
+    expect(addonSrc).toMatch(/_core\._renderService/);
+    expect(addonSrc).toMatch(/setRenderer\([^)]*_createRenderer\(\)/);
+  });
+
+  it('the restore step still re-derives dimensions via handleResize', () => {
+    expect(addonSrc).toMatch(/\.handleResize\(/);
+  });
+
+  it('RenderService still reads the unguarded _renderer.value the restore repairs', () => {
+    expect(xtermSrc).toMatch(/this\._renderer\.value\.dimensions/);
+  });
+
+  it('Terminal core still tracks disposal via _store._isDisposed', () => {
+    expect(addonSrc).toMatch(/_core\._store\._isDisposed/);
   });
 });

--- a/src/renderer/terminal/webglTeardown.ts
+++ b/src/renderer/terminal/webglTeardown.ts
@@ -1,3 +1,4 @@
+import type { Terminal } from '@xterm/xterm';
 import type { WebglAddon } from '@xterm/addon-webgl';
 
 /**
@@ -14,8 +15,80 @@ import type { WebglAddon } from '@xterm/addon-webgl';
  * The context is captured BEFORE dispose (dispose may detach the renderer) and
  * field access is guarded: if the addon internals ever change shape, `gl` is
  * undefined and we degrade to a plain dispose (zombie returns, but no crash).
+ *
+ * --- Renderer-restore guarantee (flicker-then-black RCA, 2026-08-02) ---
+ *
+ * WebglAddon registers its "hand the terminal back to the DOM renderer" step
+ * as a disposable inside its own DisposableStore. If ANY earlier disposable in
+ * that store throws mid-dispose (GL work against a dying context can), the
+ * store's loop aborts and the restore step never runs. Our catch below
+ * swallows that throw — correct for teardown robustness, but it used to leave
+ * the pane with NO renderer at all: xterm's `RenderService.dimensions` getter
+ * reads `_renderer.value.dimensions` unguarded, so every subsequent render
+ * tick (cursor blink, scroll, fit) threw
+ * `Uncaught TypeError: Cannot read properties of undefined (reading 'dimensions')`
+ * — observed 2,990× across one 85-minute production storm — and the pane
+ * flickered, then stayed black until relaunch. The refresh()-based repaint
+ * band-aids (#166/#191/#318) never touched this layer: they repaint THROUGH
+ * the render service, which is exactly the thing that is broken here.
+ *
+ * So after dispose we VERIFY the render service still holds a renderer and,
+ * if it does not, restore the DOM renderer ourselves — the same
+ * `setRenderer(_createRenderer())` + `handleResize` sequence the addon's own
+ * skipped disposable would have run. Every private-path access is optional-
+ * chained: on an internals change we degrade to the old behaviour (no restore,
+ * no crash) and the shape-lock test fails loudly instead.
  */
-export function teardownWebglAddon(addon: WebglAddon): void {
+
+/** Private xterm internals walked by the renderer-restore step. Kept in one
+ *  named shape so webglTeardown.test.ts can lock the exact paths against
+ *  @xterm package bumps. */
+interface XtermCoreInternals {
+  _core?: {
+    _store?: { _isDisposed?: boolean };
+    _renderService?: {
+      _renderer?: { value?: unknown };
+      setRenderer?: (renderer: unknown) => void;
+      handleResize?: (cols: number, rows: number) => void;
+    };
+    _createRenderer?: () => unknown;
+  };
+}
+
+/**
+ * True when the terminal is live but its RenderService has no renderer — the
+ * "every render tick throws" state this module exists to prevent. Exported so
+ * tests can assert the invariant directly.
+ */
+export function isRendererMissing(terminal: Terminal): boolean {
+  const core = (terminal as unknown as XtermCoreInternals)._core;
+  if (!core || core._store?._isDisposed) return false;
+  const renderer = core._renderService?._renderer;
+  if (!renderer) return false;
+  return renderer.value === undefined || renderer.value === null;
+}
+
+/** Restore xterm's DOM renderer when the WebGL addon's own restore step was
+ *  skipped by a throw mid-dispose. No-op when a renderer is present, the
+ *  terminal is disposed, or the private internals changed shape. */
+function ensureRendererRestored(terminal: Terminal): void {
+  try {
+    if (!isRendererMissing(terminal)) return;
+    const core = (terminal as unknown as XtermCoreInternals)._core;
+    const renderService = core?._renderService;
+    const createRenderer = core?._createRenderer;
+    if (!renderService?.setRenderer || typeof createRenderer !== 'function') return;
+    renderService.setRenderer(createRenderer.call(core));
+    // Mirror the addon's skipped restore step: a resize re-derives the DOM
+    // renderer's dimensions so the very next render tick paints correctly.
+    renderService.handleResize?.(terminal.cols, terminal.rows);
+    console.warn('[Terminal] WebGL dispose left no renderer — restored the DOM renderer');
+  } catch {
+    /* restore is best-effort; never let it break teardown */
+  }
+}
+
+export function teardownWebglAddon(addon: WebglAddon, terminal?: Terminal): void {
   const gl = (addon as unknown as { _renderer?: { _gl?: WebGL2RenderingContext } })._renderer?._gl;
   try {
     addon.dispose();
@@ -27,4 +100,5 @@ export function teardownWebglAddon(addon: WebglAddon): void {
   } catch {
     /* best effort — context may already be lost */
   }
+  if (terminal) ensureRendererRestored(terminal);
 }


### PR DESCRIPTION
## Problem

Panes flicker and then settle **black** until relaunch. Production logs show the mechanism: `Uncaught TypeError: Cannot read properties of undefined (reading 'dimensions')` thrown from the xterm vendor bundle **2,990 times across one 85-minute storm**, coinciding with surface register/unregister churn. Meanwhile `Too many active WebGL` / `context lost` warnings: zero — this is not context-cap eviction.

## Root cause

`WebglAddon.dispose()` restores the DOM renderer via a disposable registered in its **own DisposableStore**. If any earlier disposable in that store throws mid-dispose (GL work against a dying context can), the store's loop aborts and the restore step never runs. `teardownWebglAddon` swallows that throw — correct for teardown robustness — but the pane was left with **no renderer at all**: xterm's `RenderService.dimensions` getter reads `this._renderer.value.dimensions` unguarded, so every subsequent render tick (cursor blink, scroll, fit) threw. The pane flickers as frames fail, then stays black.

The refresh()-based repaint band-aids (#166/#191/#318) never touched this layer — they repaint *through* the render service, which is exactly the thing that is broken here.

## Fix

After dispose, **verify** the render service still holds a renderer; if not, restore the DOM renderer ourselves — the same `setRenderer(_createRenderer())` + `handleResize` sequence the addon's skipped disposable would have run. All three teardown sites (pool evict, fonts.ready atlas rebuild, unmount — where `terminal.dispose()` can be deferred by an active drag, #582) pass the terminal so the invariant holds everywhere.

Every private-path access is optional-chained (internals change ⇒ degrade to old behaviour, no crash), and the exact paths are shape-locked by tests against the installed @xterm sources so a package bump fails loudly instead of silently reviving the black-pane bug.

## Tests

- `webglTeardown.test.ts`: +5 behavioural cases (restore fires when renderer missing; no-op on live renderer / disposed terminal / changed internals; `isRendererMissing` truth table) and +4 shape locks (`_core._renderService.setRenderer(_core._createRenderer())`, `handleResize`, `RenderService`'s unguarded `_renderer.value.dimensions` read, `_core._store._isDisposed`).
- Full renderer hook/terminal suites: 737 tests, 57 files — green. `tsc --noEmit` clean; lint errors in `useTerminal.ts` are preexisting on main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where terminal panes could turn black after WebGL renderer teardown errors.
  * Terminals now automatically restore the standard renderer when needed, including during deferred cleanup.
  * Improved recovery handling while preserving active renderers and disposed terminals correctly.
* **Tests**
  * Added coverage for renderer recovery and teardown edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->