### PR TITLE
fix(push): 잠금화면 승인 버튼이 실제로 뜨게 한다

### DIFF
--- a/src/daemon/push/__tests__/approvalPushPayload.test.ts
+++ b/src/daemon/push/__tests__/approvalPushPayload.test.ts
@@ -71,12 +71,98 @@ describe('buildApprovalPushPayload', () => {
     expect(buildApprovalPushPayload(request()).body).toBe(APPROVAL_PUSH_FALLBACK_BODY);
   });
 
-  it('flags structured choices, and omits the flag otherwise', () => {
-    const withChoices = buildApprovalPushPayload(
-      request({ choices: [{ key: '1', label: 'Yes' }] }),
+  it('prints the options when a button will act on one — the button says only "first option"', () => {
+    const payload = buildApprovalPushPayload(
+      request({
+        question: 'Deploy to prod?',
+        choices: [
+          { key: '1', label: 'Yes, deploy' },
+          { key: '2', label: 'No' },
+        ],
+      }),
     );
-    expect(withChoices.requiresInAppChoice).toBe(true);
-    expect(buildApprovalPushPayload(request()).requiresInAppChoice).toBeUndefined();
+    expect(payload.body).toBe('Deploy to prod?\nYes, deploy · No');
+  });
+
+  it('keeps the body bare when no affirmative is offered', () => {
+    // Three options means the person opens the app and reads the card there;
+    // pasting them onto a lock screen would be noise, not consent.
+    const payload = buildApprovalPushPayload(
+      request({
+        question: 'Which one?',
+        choices: [
+          { key: '1', label: 'A' },
+          { key: '2', label: 'B' },
+          { key: '3', label: 'C' },
+        ],
+      }),
+    );
+    expect(payload.body).toBe('Which one?');
+  });
+
+  it('★ a two-option question earns the affirmative, titled with the agent’s own label', () => {
+    // The regression this exists to prevent: the rule used to be "has choices
+    // at all", and since the only source of approvals is the AskUserQuestion
+    // hook — which always carries choices — the lock-screen button was dark
+    // for every approval that has ever existed.
+    const payload = buildApprovalPushPayload(
+      request({
+        choices: [
+          { key: '1', label: '승인' },
+          { key: '2', label: '거부' },
+        ],
+      }),
+    );
+    expect(payload.requiresInAppChoice).toBeUndefined();
+    expect(payload.firstOption).toBe('승인');
+  });
+
+  it('three or more options is a picker, and no single button can stand for it', () => {
+    const payload = buildApprovalPushPayload(
+      request({
+        choices: [
+          { key: '1', label: 'Yes' },
+          { key: '2', label: 'Yes, and don’t ask again' },
+          { key: '3', label: 'No' },
+        ],
+      }),
+    );
+    expect(payload.requiresInAppChoice).toBe(true);
+    expect(payload.firstOption).toBeUndefined();
+  });
+
+  it('an unlabelled option cannot title a button, so it falls back rather than borrowing a word', () => {
+    const payload = buildApprovalPushPayload(
+      request({
+        choices: [
+          { key: '1', label: '   ' },
+          { key: '2', label: 'No' },
+        ],
+      }),
+    );
+    expect(payload.requiresInAppChoice).toBe(true);
+    expect(payload.firstOption).toBeUndefined();
+  });
+
+  it('no structured choices at all keeps the pre-existing shape', () => {
+    const payload = buildApprovalPushPayload(request());
+    expect(payload.requiresInAppChoice).toBeUndefined();
+    expect(payload.firstOption).toBeUndefined();
+  });
+
+  it('a destructive label still loses the button, relaxed choice rule or not', () => {
+    // Two labels, both readable — the choice rule alone would hand out the
+    // affirmative. `risk` is the independent gate that must still refuse.
+    const payload = buildApprovalPushPayload(
+      request({
+        question: 'Run this?',
+        choices: [
+          { key: '1', label: 'Yes, run rm -rf /' },
+          { key: '2', label: 'No' },
+        ],
+      }),
+    );
+    expect(payload.risk).toBe('critical');
   });
 
   it('carries the ids the deep link is built from', () => {

--- a/src/daemon/push/approvalPushPayload.ts
+++ b/src/daemon/push/approvalPushPayload.ts
@@ -12,21 +12,30 @@
  */
 import { hasElevatedRisk } from '../../shared/criticalPatterns';
 import { PUSH_RISK_CRITICAL, PUSH_RISK_NORMAL, type PushPayload } from '../../shared/push/pushEnvelope';
-import type { ApprovalRequest } from '../approvals/types';
+import type { ApprovalChoice, ApprovalRequest } from '../approvals/types';
 
 /** Shown when the agent gave us no question text to quote. */
 export const APPROVAL_PUSH_FALLBACK_BODY = 'A pane is waiting on an answer.';
 
 export function buildApprovalPushPayload(request: ApprovalRequest): PushPayload {
+  const choiceFields = lockScreenChoiceFields(request.choices);
   return {
     title: 'Approval needed',
-    body: request.question ?? APPROVAL_PUSH_FALLBACK_BODY,
+    // The options ride in the body whenever an affirmative is on offer.
+    //
+    // The extension titles that button from a STATIC category — it cannot name
+    // a dynamic one, because a category the notification daemon has not
+    // ingested yet renders with no buttons at all, which is worse than a
+    // generic word. So the button reads "Approve — first option", and this is
+    // what makes that phrase unambiguous: the first option is printed right
+    // above it. Without this line somebody would be tapping a pronoun.
+    //
+    // Same shape the in-app local notifier already uses (` · ` separated), so
+    // the two paths read alike.
+    body: bodyFor(request, choiceFields.firstOption !== undefined),
     approvalId: request.id,
     sessionId: request.sessionId,
-    // A structured-choice question cannot be answered by a single affirmative,
-    // so the extension must drop to a category that only deep-links into the
-    // app.
-    ...(request.choices?.length ? { requiresInAppChoice: true } : {}),
+    ...choiceFields,
     // ALWAYS stated, unlike the REST field. See `PushPayload.risk`: the
     // extension has nothing but this payload, so silence there means unknown
     // and costs the button.
@@ -42,6 +51,64 @@ export function buildApprovalPushPayload(request: ApprovalRequest): PushPayload 
     // counts both tiers for exactly this decision.
     risk: elevatedRisk(request) ? PUSH_RISK_CRITICAL : PUSH_RISK_NORMAL,
   };
+}
+
+/**
+ * The question, plus the options when a button will act on one of them.
+ *
+ * Only when the affirmative is offered: everywhere else the person opens the
+ * app to answer and reads the options on the card, and pasting them onto a
+ * lock screen there would be noise rather than consent.
+ */
+function bodyFor(request: ApprovalRequest, offersAffirmative: boolean): string {
+  const question = request.question ?? APPROVAL_PUSH_FALLBACK_BODY;
+  if (!offersAffirmative) return question;
+  const labels = (request.choices ?? []).map((c) => c.label.trim()).filter((l) => l.length > 0);
+  return labels.length > 0 ? `${question}\n${labels.join(' · ')}` : question;
+}
+
+/**
+ * The largest choice set one affirmative button can stand for.
+ *
+ * Two is the consent shape: a tap means "the first one", and the other side is
+ * Deny, which every category already offers. Three is a picker — no single
+ * button can represent it without hiding an option — and that keeps the
+ * in-app-only category.
+ */
+const AFFIRMATIVE_MAX_CHOICES = 2;
+
+/**
+ * Can a lock-screen affirmative express this question, and what should it say?
+ *
+ * **Why this is not simply "has choices".** It used to be, and the cost was
+ * that the button never appeared at all: the only source of approvals is the
+ * `AskUserQuestion` hook, and those always carry structured choices, so every
+ * approval on earth took the in-app-only branch. The feature was dark.
+ *
+ * **Why relaxing it is still safe.** The rule this runs on is that *the
+ * button's title is the choice*: a button reading "Approve" asks somebody to
+ * commit to text they have not read, and a button reading the option's own
+ * label does not. So the affirmative is offered only when there is a label to
+ * title it with, and that label travels as `firstOption` for the extension to
+ * use. An empty or missing label cannot title a button, so it falls back
+ * rather than borrowing a generic word.
+ *
+ * `risk` is unaffected and still decides this independently — `elevatedRisk`
+ * already scans choice labels precisely so that this relaxation could not turn
+ * into a gap.
+ */
+function lockScreenChoiceFields(
+  choices?: ApprovalChoice[],
+): { requiresInAppChoice?: true; firstOption?: string } {
+  // No structured choices at all is the pre-existing shape: the extension's
+  // static category already handles it and nothing here should change.
+  if (!choices?.length) return {};
+
+  const labels = choices.map((c) => c.label?.trim() ?? '');
+  if (choices.length > AFFIRMATIVE_MAX_CHOICES || labels.some((l) => l.length === 0)) {
+    return { requiresInAppChoice: true };
+  }
+  return { firstOption: labels[0] };
 }
 
 /**

--- a/src/shared/push/pushEnvelope.ts
+++ b/src/shared/push/pushEnvelope.ts
@@ -189,6 +189,23 @@ export interface PushPayload {
   /** True when a lock-screen affirmative cannot express the required choice. */
   requiresInAppChoice?: boolean;
   /**
+   * The label of the option an affirmative tap would select — the agent's own
+   * words, not ours.
+   *
+   * Present only when the affirmative is offered at all, which is the point:
+   * the safety rule this feature runs on is that *the button's title is the
+   * choice*. A button reading "Approve" asks somebody to commit to text they
+   * have not read; a button reading the option's own label does not. So the
+   * label travels with the payload and the extension titles the action from
+   * it, rather than the extension inventing a generic word.
+   *
+   * Absent when there is nothing safe to title it with, and the extension then
+   * falls back to its static category. Never a substitute for
+   * `requiresInAppChoice` or `risk` — those still decide *whether* the button
+   * appears; this only decides what it says.
+   */
+  firstOption?: string;
+  /**
    * The approval's risk, ALWAYS stated on an approval payload — `'critical'`
    * when a destructive-action pattern matched, `PUSH_RISK_NORMAL` when none
    * did.


### PR DESCRIPTION
## 무엇이 문제였나

`buildApprovalPushPayload`가 **구조화된 선택지가 하나라도 있으면** `requiresInAppChoice: true`를 실었다.

```ts
...(request.choices?.length ? { requiresInAppChoice: true } : {}),
```

그런데 승인을 만드는 경로는 `noteHookAwaitingInput` 하나뿐이고, 그 입력은 `AskUserQuestion` 훅이며, 그 승인은 **항상** choices를 갖는다. 결과적으로 잠금화면 affirmative 버튼은 **지금까지 존재한 모든 승인에서 한 번도 뜨지 않았다.**

실기(iPhone 16 Pro, 데몬 3.38.3)에서 알림을 길게 눌러 확인한 결과 버튼이 `Answer… / Deny / Reply…` 셋뿐이었다. 폰에서 한 번 탭으로 답한다는 기능이 통째로 꺼져 있었다.

## 무엇을 바꿨나

조건을 "선택지가 있다" → **"선택지가 한 버튼으로 대표될 수 없다"**로 바꿨다.

| 선택지 | 결과 |
|---|---|
| 없음 | 기존 그대로 (정적 카테고리) |
| **2개, 라벨 있음** | **affirmative 제공** + `firstOption`에 첫 라벨 |
| 3개 이상 | `requiresInAppChoice: true` — 어떤 단일 버튼도 대표 못 함 |
| 라벨이 빈 것 포함 | `requiresInAppChoice: true` — 버튼 제목을 지을 수 없음 |

2개는 동의 형태다. 한 번 누르면 첫 번째이고, 반대쪽은 어차피 모든 카테고리가 제공하는 Deny다.

## 왜 안전한가

이 기능이 딛고 선 규칙은 **"버튼의 제목이 곧 선택"**이다. "Approve"라고만 적힌 버튼은 읽지 않은 문장에 커밋하라는 요구지만, 선택지 자신의 문구가 적힌 버튼은 그렇지 않다.

그래서 첫 선택지 라벨을 `firstOption`으로 함께 싣는다. **다만 확장은 정적 카테고리만 지목할 수 있다** — 알림 데몬이 아직 삼키지 않은 동적 카테고리를 지목하면 버튼이 아예 사라져 지금보다 나빠진다(iOS 앱 `ApprovalNotificationCategories.ensure` 주석에 기록된 제약). 그래서 버튼 문구는 `Approve — first option`으로 남기고, **본문에 선택지를 함께 찍어** 그 말이 무엇을 가리키는지 읽고 누르게 했다.

```
Approval needed
Deploy to prod?
Yes, deploy · No
```

구분자 ` · `는 앱의 로컬 알림 경로(`ApprovalNotificationDraft.body`)와 같은 모양이라, 두 경로가 같게 읽힌다.

**`risk`는 손대지 않았다.** `elevatedRisk`가 이미 choices 라벨까지 독립적으로 훑는다 — 이 파일 주석이 *"the day the choice rule changes this must not quietly become the gap"* 이라고 미리 적어둔 그대로다. 파괴적 라벨을 가진 2선택지 승인은 이 완화와 무관하게 버튼을 잃으며, 테스트로 고정했다.

## 테스트

`src/daemon/push/__tests__/approvalPushPayload.test.ts`에 6개 추가/갱신:

- ★ 2선택지가 affirmative를 얻고 `firstOption`에 라벨이 실린다 (회귀 원본)
- 3개 이상은 picker라 단일 버튼이 대표 못 한다
- 라벨이 빈 선택지는 일반 단어를 빌리지 않고 물러선다
- 선택지 없음은 기존 형태 유지
- 파괴적 라벨은 완화와 무관하게 `risk: critical`
- 본문에 선택지가 찍히는 조건 (affirmative일 때만)

**게이트**: `npx tsc --noEmit` 통과, `vitest run src/daemon/push src/shared/push` **73 passed**.

## 배포 순서

앱이 `firstOption`을 읽기 전이라도 안전하다 — 추가 필드이고, 버튼 제목은 정적 카테고리에서 오며, 본문 변경은 데몬 단독으로 효과가 난다. 즉 이 PR 단독으로 잠금화면 버튼이 살아난다.

## 후속 (이 PR 아님)

버튼 제목에 선택지 자신의 문구를 박으려면 확장이 동적 카테고리를 안전하게 등록할 수 있어야 한다. 등록 순서(`setNotificationCategories` → `notificationCategories()` 왕복) 문제라 실기 실험이 필요하고, 별건으로 다룬다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)