### PR TITLE
Recover dead panes in their original working directory

### DIFF
--- a/changelog.d/762.md
+++ b/changelog.d/762.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Dead panes now reopen in their original working directory.** Renderer-
+  created replacements inherit the dead session's validated spawn directory,
+  fall back to its last live directory and then home, and retain any surviving
+  agent resume offer. (#762)

--- a/src/main/ipc/__tests__/pty.handler.surfaceIdExposure.test.ts
+++ b/src/main/ipc/__tests__/pty.handler.surfaceIdExposure.test.ts
@@ -31,10 +31,10 @@ describe('pty.handler PTY_LIST — axis B-lite surfaceId exposure invariants', (
     expect(region).toMatch(/surfaceId:\s*s\.env\[ENV_KEYS\.SURFACE_ID\]/);
   });
 
-  it('excludes suspended sessions from rebind targets (no live PTY behind them)', () => {
+  it('excludes suspended and dead sessions from rebind targets (no live PTY behind them)', () => {
     const region = listRegion();
-    // The surfaceId attachment must be conditioned on NOT-suspended.
-    expect(region).toMatch(/s\.state\s*!==\s*'suspended'/);
+    // The surfaceId attachment must be conditioned on a live session state.
+    expect(region).toMatch(/s\.state\s*!==\s*'suspended'\s*&&\s*s\.state\s*!==\s*'dead'/);
   });
 
   it('keeps dead sessions opt-in AND exposes createdAt for newest-wins duplicate resolution', () => {

--- a/src/main/ipc/__tests__/pty.handler.surfaceIdExposure.test.ts
+++ b/src/main/ipc/__tests__/pty.handler.surfaceIdExposure.test.ts
@@ -37,9 +37,17 @@ describe('pty.handler PTY_LIST — axis B-lite surfaceId exposure invariants', (
     expect(region).toMatch(/s\.state\s*!==\s*'suspended'/);
   });
 
-  it('keeps the dead filter AND exposes createdAt for newest-wins duplicate resolution', () => {
+  it('keeps dead sessions opt-in AND exposes createdAt for newest-wins duplicate resolution', () => {
     const region = listRegion();
-    expect(region).toMatch(/\.filter\(s => s\.state !== 'dead'\)/);
+    expect(region).toMatch(/\.filter\(s => includeDead \|\| s\.state !== 'dead'\)/);
     expect(region).toMatch(/createdAt:\s*s\.createdAt/);
+  });
+
+  it('surfaces only the recovery fields needed for an explicitly included dead session', () => {
+    const region = listRegion();
+    expect(region).toMatch(/state:\s*s\.state/);
+    expect(region).toMatch(/cwd:\s*s\.cwd/);
+    expect(region).toMatch(/includeDead\s*&&\s*s\.state === 'dead'\s*&&\s*s\.spawnCwd/);
+    expect(region).toMatch(/spawnCwd:\s*s\.spawnCwd/);
   });
 });

--- a/src/main/ipc/handlers/__tests__/pty.reconnectCwd.test.ts
+++ b/src/main/ipc/handlers/__tests__/pty.reconnectCwd.test.ts
@@ -34,11 +34,22 @@ describe('PTY_RECONNECT seeds cwd (source-level lock)', () => {
   });
 
   it('the listSessions response type includes cwd', () => {
-    expect(RECONNECT).toMatch(/id: string; cmd: string; state: string; pid\?: number; cwd\?: string/);
+    expect(RECONNECT).toMatch(/cwd\?: string/);
   });
 
   it('calls updateCwd with the session cwd on reconnect', () => {
     expect(RECONNECT).toMatch(/if \(session\.cwd\) updateCwd\(id, session\.cwd\)/);
+  });
+});
+
+describe('PTY_RECONNECT carries dead-session recovery metadata (#650)', () => {
+  it('reads spawnCwd and guarded resume metadata from listSessions', () => {
+    expect(RECONNECT).toMatch(/spawnCwd\?: string/);
+    expect(RECONNECT).toMatch(/resumeBinding\?: ResumeBinding/);
+  });
+
+  it('returns a recovery descriptor only when the dead record still exists', () => {
+    expect(RECONNECT).toMatch(/session \? \{ recovery: createDeadPaneRecovery\(session\) \} : \{\}/);
   });
 });
 

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -1,5 +1,4 @@
 import { ipcMain, BrowserWindow } from 'electron';
-import fs from 'node:fs';
 import path from 'node:path';
 import { StringDecoder } from 'node:string_decoder';
 import { PTYManager } from '../../pty/PTYManager';
@@ -38,6 +37,9 @@ import {
 } from '../../../shared/wmuxProjectConfig';
 import type { DaemonSupervisionPolicy } from '../../../shared/rpc';
 import type { ResumeBinding } from '../../../shared/agentResume';
+import type { AgentSlug } from '../../../shared/events';
+import { createDeadPaneRecovery, type DeadPaneRecovery } from '../../../shared/ptyRecovery';
+import { resolvePtyCreateCwd, type PtyCwdSource } from '../../pty/resolvePtyCwd';
 
 /**
  * Allowed shell basenames (compared case-insensitively).
@@ -87,6 +89,9 @@ interface PtyCreateSupervisionInput {
 type PtyCreateOptions = {
   shell?: string;
   cwd?: string;
+  /** Dead-session replacement candidates. Main validates spawnCwd, then cwd;
+   * neither value is trusted merely because it came from the renderer. */
+  recoveryCwds?: Pick<DeadPaneRecovery, 'spawnCwd' | 'cwd'>;
   cols?: number;
   rows?: number;
   workspaceId?: string;
@@ -189,31 +194,21 @@ const RESIZE_RETRY_DELAY_MS = 20;
  */
 
 /**
- * Validate and resolve cwd. Returns undefined if invalid.
- * Shared by both daemon and local modes.
- */
-function validateCwd(cwd: string | undefined): string | undefined {
-  if (!cwd) return undefined;
-  const resolved = path.resolve(cwd);
-  // Block UNC paths (e.g. \\server\share)
-  if (resolved.startsWith('\\\\')) return undefined;
-  if (!fs.existsSync(resolved)) return undefined;
-  const stat = fs.statSync(resolved);
-  if (!stat.isDirectory()) return undefined;
-  return resolved;
-}
-
-/**
  * Diagnostic one-liner for the cwd a create request resolved to (issue #515).
- * `why` is: valid (used as-is) | dropped (validateCwd rejected — missing/UNC/
+ * `why` is: valid (used as-is) | dropped (cwd validation rejected — missing/UNC/
  * not-a-dir) | absent (caller sent no cwd). When dropped/absent the spawn layer
  * falls back to homedir, which is exactly the "panes land in home" symptom, so
  * this makes future reports diagnosable straight from the log.
  */
-function logCwdResolution(sessionId: string, incoming: string | undefined, safe: string | undefined): void {
+function logCwdResolution(
+  sessionId: string,
+  incoming: string | undefined,
+  safe: string | undefined,
+  source: PtyCwdSource,
+): void {
   const why = incoming ? (safe ? 'valid' : 'dropped') : 'absent';
   const effective = safe ?? '(home-fallback)';
-  console.log(`[pty:create] ${sessionId} cwd in=${incoming ?? '-'} → ${effective} (${why})`);
+  console.log(`[pty:create] ${sessionId} cwd in=${incoming ?? '-'} → ${effective} (${why}, source=${source})`);
 }
 
 export function registerPTYHandlers(
@@ -358,7 +353,8 @@ export function registerPTYHandlers(
           ? resolveSupervisionPolicy(options.supervision)
           : undefined;
 
-      const safeCwd = validateCwd(options?.cwd);
+      const cwdResolution = resolvePtyCreateCwd(options?.cwd, options?.recoveryCwds);
+      const safeCwd = cwdResolution.safeCwd;
       const effectiveCwd = safeCwd ?? require('os').homedir();
       // Daemon-mode default shell. On Windows prefer PowerShell 7 over 5.1 via
       // ShellDetector (issue #176) — mirrors PTYManager.getDefaultShell() so
@@ -368,7 +364,7 @@ export function registerPTYHandlers(
       // Generate a unique session ID
       const crypto = require('crypto');
       const sessionId = `daemon-${crypto.randomUUID().slice(0, 8)}`;
-      logCwdResolution(sessionId, options?.cwd, safeCwd);
+      logCwdResolution(sessionId, cwdResolution.incomingCwd, safeCwd, cwdResolution.source);
 
       // Identity env vars for the spawned shell. The daemon's
       // `buildSafeChildEnv` passes WMUX_WORKSPACE_ID / WMUX_SURFACE_ID
@@ -557,7 +553,8 @@ export function registerPTYHandlers(
         }
       }
 
-      const safeCwd = validateCwd(options?.cwd);
+      const cwdResolution = resolvePtyCreateCwd(options?.cwd, options?.recoveryCwds);
+      const safeCwd = cwdResolution.safeCwd;
       const effectiveCwd = safeCwd ?? undefined;
       // Split off initialCommand — it's written into the shell post-create, not
       // a spawn option. exec/supervision are daemon-only (handled above) and
@@ -565,7 +562,7 @@ export function registerPTYHandlers(
       // from only the local-relevant fields instead of spreading the payload.
       const { initialCommand, shell, cols, rows, workspaceId, surfaceId, env, spawnKind } = options ?? {};
       const instance = ptyManager.create({ shell, cols, rows, workspaceId, surfaceId, env, cwd: effectiveCwd, spawnKind });
-      logCwdResolution(instance.id, options?.cwd, safeCwd);
+      logCwdResolution(instance.id, cwdResolution.incomingCwd, safeCwd, cwdResolution.source);
       ptyBridge.setupDataForwarding(instance.id);
       const actualCwd = effectiveCwd || require('os').homedir();
       updateCwd(instance.id, actualCwd);
@@ -765,12 +762,15 @@ export function registerPTYHandlers(
   // pty:list
   ipcMain.removeHandler(IPC.PTY_LIST);
   if (useDaemon && daemonClient) {
-    ipcMain.handle(IPC.PTY_LIST, wrapHandler(IPC.PTY_LIST, async (_event: Electron.IpcMainInvokeEvent, opts?: { includeSuspended?: boolean }) => {
+    ipcMain.handle(IPC.PTY_LIST, wrapHandler(IPC.PTY_LIST, async (_event: Electron.IpcMainInvokeEvent, opts?: { includeSuspended?: boolean; includeDead?: boolean }) => {
       const includeSuspended = opts?.includeSuspended === true;
+      const includeDead = opts?.includeDead === true;
       const sessions = await daemonClient.rpc('daemon.listSessions', { includeSuspended }) as Array<{
         id: string;
         cmd: string;
         state: string;
+        cwd?: string;
+        spawnCwd?: string;
         // v2 RCA fix (reboot-reattach, axis B-lite): the daemon's listSessions
         // returns the full session incl. `env`, which carries WMUX_SURFACE_ID on
         // Terminal-self-create-originated sessions. Surface it to the renderer so
@@ -783,7 +783,7 @@ export function registerPTYHandlers(
         supervision?: { restart: string; limit: unknown; status: 'armed' | 'stopped' };
         supervisionRuntime?: { status: 'armed' | 'stopped'; restartCount: number };
         // X6 ② — present only for an interactive agent pane recovered this boot.
-        resumeAgent?: string;
+        resumeAgent?: AgentSlug;
         // X6 ③ — the captured resume binding (origin id + cwd + permission mode),
         // surfaced alongside resumeAgent (recovery-only, cwd-matched) for the pill.
         resumeBinding?: ResumeBinding;
@@ -802,8 +802,8 @@ export function registerPTYHandlers(
       // hydration (X8). Status comes from the runtime when present (live
       // armed/stopped after a guard trip) and falls back to the persisted meta
       // status; restartCount is volatile (0 until the supervisor restarts once).
-      const live = sessions
-        .filter(s => s.state !== 'dead')
+      const listed = sessions
+        .filter(s => includeDead || s.state !== 'dead')
         // Orchestrator brain ptys (the `claude-pty` vendor) are deck-embedded,
         // not fleet panes: the renderer must never adopt one into a surface and
         // the orchestrator must never see itself in pane_list. This is the ONE
@@ -814,6 +814,9 @@ export function registerPTYHandlers(
         .map(s => ({
           id: s.id,
           shell: s.cmd,
+          state: s.state,
+          ...(s.cwd ? { cwd: s.cwd } : {}),
+          ...(includeDead && s.state === 'dead' && s.spawnCwd ? { spawnCwd: s.spawnCwd } : {}),
           // v2 RCA fix (axis B-lite): expose WMUX_SURFACE_ID (env) so the
           // renderer's reconcile can rebind a stale ptyId to the live session on
           // the SAME surface instead of clearing → self-create. Present only on
@@ -853,8 +856,8 @@ export function registerPTYHandlers(
       // or short list here, correlated with a renderer ptyId-clear, is the
       // signature of the session-replacement bug. Without this line the
       // decision was invisible in the daemon/main logs.
-      console.log(`[lifecycle] pty.list -> ${live.length} live session(s) of ${sessions.length} total`);
-      return live;
+      console.log(`[lifecycle] pty.list -> ${listed.length} session(s) of ${sessions.length} total (includeDead=${includeDead})`);
+      return listed;
     }));
   } else {
     ipcMain.handle(IPC.PTY_LIST, wrapHandler(IPC.PTY_LIST, () => {
@@ -876,14 +879,29 @@ export function registerPTYHandlers(
 
     ipcMain.handle(IPC.PTY_RECONNECT, wrapHandler(IPC.PTY_RECONNECT, async (_event: Electron.IpcMainInvokeEvent, id: string) => {
       try {
-        const sessions = await daemonClient.rpc('daemon.listSessions', {}) as Array<{ id: string; cmd: string; state: string; pid?: number; cwd?: string }>;
+        const sessions = await daemonClient.rpc('daemon.listSessions', {}) as Array<{
+          id: string;
+          cmd: string;
+          state: string;
+          pid?: number;
+          cwd?: string;
+          spawnCwd?: string;
+          resumeAgent?: AgentSlug;
+          resumeBinding?: ResumeBinding;
+        }>;
         const session = sessions.find(s => s.id === id);
         if (!session || session.state === 'dead') {
           // RCA A1 — permanent failure: the daemon authoritatively reports the
           // session as absent or dead. Safe for the renderer to clear the
           // ptyId and self-create. transient:false signals "do not retry".
           console.log(`[lifecycle] pty.reconnect id=${id} result=fail code=session-dead (transient=false)`);
-          return { success: false, error: 'Session not found or dead', code: 'session-dead', transient: false };
+          return {
+            success: false,
+            error: 'Session not found or dead',
+            code: 'session-dead',
+            transient: false,
+            ...(session ? { recovery: createDeadPaneRecovery(session) } : {}),
+          };
         }
 
         // 재접속 시 cwd를 즉시 복원한다(owner-reported: 앱 재시작 후 워크스페이스

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -37,7 +37,6 @@ import {
 } from '../../../shared/wmuxProjectConfig';
 import type { DaemonSupervisionPolicy } from '../../../shared/rpc';
 import type { ResumeBinding } from '../../../shared/agentResume';
-import type { AgentSlug } from '../../../shared/events';
 import { createDeadPaneRecovery, type DeadPaneRecovery } from '../../../shared/ptyRecovery';
 import { resolvePtyCreateCwd, type PtyCwdSource } from '../../pty/resolvePtyCwd';
 
@@ -783,7 +782,7 @@ export function registerPTYHandlers(
         supervision?: { restart: string; limit: unknown; status: 'armed' | 'stopped' };
         supervisionRuntime?: { status: 'armed' | 'stopped'; restartCount: number };
         // X6 ② — present only for an interactive agent pane recovered this boot.
-        resumeAgent?: AgentSlug;
+        resumeAgent?: string;
         // X6 ③ — the captured resume binding (origin id + cwd + permission mode),
         // surfaced alongside resumeAgent (recovery-only, cwd-matched) for the pill.
         resumeBinding?: ResumeBinding;
@@ -825,9 +824,10 @@ export function registerPTYHandlers(
           // immediate save covers that path instead). `suspended` sessions are
           // excluded from rebind targets: they hold NO live PTY (recovery
           // tombstones), and actively binding a surface INTO one yields a blank,
-          // inputless pane (adversarial review). They stay in the id list so the
-          // non-destructive clear guards still see them.
-          ...(s.env?.[ENV_KEYS.SURFACE_ID] && s.state !== 'suspended'
+          // inputless pane (adversarial review). Dead sessions are excluded for
+          // the same reason when includeDead exposes their recovery metadata.
+          // Both states stay in the id list so non-destructive guards see them.
+          ...(s.env?.[ENV_KEYS.SURFACE_ID] && s.state !== 'suspended' && s.state !== 'dead'
             ? { surfaceId: s.env[ENV_KEYS.SURFACE_ID] }
             : {}),
           // v2 RCA fix (axis B-lite): create time for newest-wins duplicate
@@ -886,7 +886,7 @@ export function registerPTYHandlers(
           pid?: number;
           cwd?: string;
           spawnCwd?: string;
-          resumeAgent?: AgentSlug;
+          resumeAgent?: string;
           resumeBinding?: ResumeBinding;
         }>;
         const session = sessions.find(s => s.id === id);

--- a/src/main/pty/__tests__/resolvePtyCwd.test.ts
+++ b/src/main/pty/__tests__/resolvePtyCwd.test.ts
@@ -1,5 +1,35 @@
-import { describe, expect, it, vi } from 'vitest';
-import { resolvePtyCreateCwd } from '../resolvePtyCwd';
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolvePtyCreateCwd, validatePtyCwd } from '../resolvePtyCwd';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('validatePtyCwd', () => {
+  it('returns a resolved path only when stat reports a directory', () => {
+    const stat = vi.spyOn(fs, 'statSync');
+    stat.mockReturnValueOnce({ isDirectory: () => true } as fs.Stats);
+    stat.mockReturnValueOnce({ isDirectory: () => false } as fs.Stats);
+
+    expect(validatePtyCwd('relative-directory')).toBe(path.resolve('relative-directory'));
+    expect(validatePtyCwd('relative-file')).toBeUndefined();
+  });
+
+  it('treats missing, inaccessible, or concurrently removed paths as invalid', () => {
+    vi.spyOn(fs, 'statSync').mockImplementation(() => {
+      throw Object.assign(new Error('gone'), { code: 'ENOENT' });
+    });
+
+    expect(validatePtyCwd('removed-directory')).toBeUndefined();
+  });
+
+  it('rejects UNC paths before touching the filesystem on Windows', () => {
+    if (process.platform !== 'win32') return;
+    const stat = vi.spyOn(fs, 'statSync');
+    expect(validatePtyCwd('\\\\server\\share')).toBeUndefined();
+    expect(stat).not.toHaveBeenCalled();
+  });
+});
 
 describe('resolvePtyCreateCwd', () => {
   it('prefers a valid persisted spawnCwd for a dead-session replacement', () => {

--- a/src/main/pty/__tests__/resolvePtyCwd.test.ts
+++ b/src/main/pty/__tests__/resolvePtyCwd.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolvePtyCreateCwd } from '../resolvePtyCwd';
+
+describe('resolvePtyCreateCwd', () => {
+  it('prefers a valid persisted spawnCwd for a dead-session replacement', () => {
+    const validate = vi.fn((cwd?: string) => cwd === 'D:\\spawn' ? 'D:\\spawn' : undefined);
+    expect(resolvePtyCreateCwd('C:\\profile', {
+      spawnCwd: 'D:\\spawn',
+      cwd: 'D:\\live',
+    }, validate)).toEqual({
+      incomingCwd: 'D:\\spawn',
+      safeCwd: 'D:\\spawn',
+      source: 'recovery-spawnCwd',
+    });
+    expect(validate).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the live cwd when spawnCwd no longer validates', () => {
+    const validate = vi.fn((cwd?: string) => cwd === 'D:\\live' ? 'D:\\live' : undefined);
+    expect(resolvePtyCreateCwd(undefined, {
+      spawnCwd: 'D:\\missing',
+      cwd: 'D:\\live',
+    }, validate)).toEqual({
+      incomingCwd: 'D:\\live',
+      safeCwd: 'D:\\live',
+      source: 'recovery-cwd',
+    });
+  });
+
+  it('selects home fallback when no dead-session cwd validates', () => {
+    expect(resolvePtyCreateCwd('C:\\profile', {
+      spawnCwd: 'D:\\missing',
+      cwd: 'E:\\missing',
+    }, () => undefined)).toEqual({
+      incomingCwd: 'D:\\missing',
+      source: 'recovery-home',
+    });
+  });
+
+  it('selects home fallback for a known recovery with no cwd metadata', () => {
+    expect(resolvePtyCreateCwd('C:\\profile', {}, () => undefined)).toEqual({
+      incomingCwd: undefined,
+      source: 'recovery-home',
+    });
+  });
+
+  it('preserves ordinary create behavior when no recovery exists', () => {
+    expect(resolvePtyCreateCwd('C:\\profile', undefined, (cwd) => cwd)).toEqual({
+      incomingCwd: 'C:\\profile',
+      safeCwd: 'C:\\profile',
+      source: 'requested',
+    });
+  });
+});

--- a/src/main/pty/resolvePtyCwd.ts
+++ b/src/main/pty/resolvePtyCwd.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { DeadPaneRecovery } from '../../shared/ptyRecovery';
+
+export type PtyCwdSource = 'requested' | 'recovery-spawnCwd' | 'recovery-cwd' | 'recovery-home';
+
+export interface ResolvedPtyCwd {
+  incomingCwd?: string;
+  safeCwd?: string;
+  source: PtyCwdSource;
+}
+
+/** Validate and resolve a renderer-provided cwd. Returns undefined if invalid. */
+export function validatePtyCwd(cwd: string | undefined): string | undefined {
+  if (!cwd) return undefined;
+  const resolved = path.resolve(cwd);
+  // Block UNC paths (e.g. \\server\share).
+  if (resolved.startsWith('\\\\')) return undefined;
+  if (!fs.existsSync(resolved)) return undefined;
+  const stat = fs.statSync(resolved);
+  if (!stat.isDirectory()) return undefined;
+  return resolved;
+}
+
+/**
+ * Resolve create-time cwd without letting renderer metadata become authority.
+ * A known dead-session replacement tries persisted spawnCwd, then its last live
+ * cwd; when neither validates, the caller deliberately falls back to home.
+ * Ordinary creates retain their existing single-cwd behavior.
+ */
+export function resolvePtyCreateCwd(
+  requestedCwd: string | undefined,
+  recovery: Pick<DeadPaneRecovery, 'spawnCwd' | 'cwd'> | undefined,
+  validate: (cwd: string | undefined) => string | undefined = validatePtyCwd,
+): ResolvedPtyCwd {
+  if (recovery !== undefined) {
+    const spawnCwd = validate(recovery.spawnCwd);
+    if (spawnCwd) {
+      return { incomingCwd: recovery.spawnCwd, safeCwd: spawnCwd, source: 'recovery-spawnCwd' };
+    }
+
+    const liveCwd = validate(recovery.cwd);
+    if (liveCwd) {
+      return { incomingCwd: recovery.cwd, safeCwd: liveCwd, source: 'recovery-cwd' };
+    }
+
+    return {
+      incomingCwd: recovery.spawnCwd ?? recovery.cwd,
+      source: 'recovery-home',
+    };
+  }
+
+  return {
+    incomingCwd: requestedCwd,
+    safeCwd: validate(requestedCwd),
+    source: 'requested',
+  };
+}

--- a/src/main/pty/resolvePtyCwd.ts
+++ b/src/main/pty/resolvePtyCwd.ts
@@ -16,9 +16,13 @@ export function validatePtyCwd(cwd: string | undefined): string | undefined {
   const resolved = path.resolve(cwd);
   // Block UNC paths (e.g. \\server\share).
   if (resolved.startsWith('\\\\')) return undefined;
-  if (!fs.existsSync(resolved)) return undefined;
-  const stat = fs.statSync(resolved);
-  if (!stat.isDirectory()) return undefined;
+  try {
+    if (!fs.statSync(resolved).isDirectory()) return undefined;
+  } catch {
+    // Missing, inaccessible, or removed between resolution and stat: let the
+    // caller continue to the next recovery candidate or home fallback.
+    return undefined;
+  }
   return resolved;
 }
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -8,6 +8,8 @@ import type {
 import { isFileDrag } from '../shared/dragDrop';
 import type { NotificationCategory } from '../shared/types';
 import type { ResumeBinding } from '../shared/agentResume';
+import type { DeadPaneRecovery } from '../shared/ptyRecovery';
+import type { AgentSlug } from '../shared/events';
 import type {
   RemoteInboxItem,
   LanLinkStatus,
@@ -46,7 +48,7 @@ const electronAPI = {
     // wmux.json leaf — `exec` runs the command as the pane's ROOT process and
     // `supervision` arms the daemon's PaneSupervisor (daemon mode only; the
     // local branch ignores them with a one-time warning toast).
-    create: (options?: { shell?: string; cwd?: string; cols?: number; rows?: number; workspaceId?: string; surfaceId?: string; env?: Record<string, string>; initialCommand?: string; exec?: string; supervision?: { restart: 'on-failure' | 'always'; limit?: { burst?: number; healthyUptimeSec?: number }; restorePermissionMode?: boolean } }) =>
+    create: (options?: { shell?: string; cwd?: string; recoveryCwds?: Pick<DeadPaneRecovery, 'spawnCwd' | 'cwd'>; cols?: number; rows?: number; workspaceId?: string; surfaceId?: string; env?: Record<string, string>; initialCommand?: string; exec?: string; supervision?: { restart: 'on-failure' | 'always'; limit?: { burst?: number; healthyUptimeSec?: number }; restorePermissionMode?: boolean } }) =>
       ipcRenderer.invoke(IPC.PTY_CREATE, options),
     write: (id: string, data: string) => {
       ipcRenderer.send(IPC.PTY_WRITE, id, data);
@@ -61,11 +63,11 @@ const electronAPI = {
     // `includeSuspended` (Fix B) additionally returns cap-skipped suspended
     // sessions from the persisted state so reconcile can promote one on demand
     // instead of destructively clearing its ptyId.
-    list: (opts?: { includeSuspended?: boolean }) =>
+    list: (opts?: { includeSuspended?: boolean; includeDead?: boolean }) =>
       // `surfaceId` (axis B, reboot-reattach): present only on sessions created
       // WITH a WMUX_SURFACE_ID (Terminal self-create path); reconcile uses it to
       // rebind a stale ptyId to the surviving session after a reboot.
-      ipcRenderer.invoke(IPC.PTY_LIST, opts) as Promise<{ id: string; shell: string; surfaceId?: string; createdAt?: string; state?: string; cwd?: string; supervision?: { status: 'armed' | 'stopped'; restartCount: number }; resumeAgent?: string; resumeBinding?: ResumeBinding; commandRunning?: boolean; agentProcessAlive?: boolean }[]>,
+      ipcRenderer.invoke(IPC.PTY_LIST, opts) as Promise<{ id: string; shell: string; surfaceId?: string; createdAt?: string; state?: string; cwd?: string; spawnCwd?: string; supervision?: { status: 'armed' | 'stopped'; restartCount: number }; resumeAgent?: AgentSlug; resumeBinding?: ResumeBinding; commandRunning?: boolean; agentProcessAlive?: boolean }[]>,
     // TASK-6 — per-pane agent RAM for the Fleet View cockpit. Given the ptyIds
     // currently shown as cards, returns { [ptyId]: { rss (bytes), image? } } by
     // walking each pane shell's descendant process tree from ONE CIM snapshot.
@@ -80,7 +82,7 @@ const electronAPI = {
       // writable yet, RPC threw during a handler-swap window) from a permanent
       // one (session genuinely dead). The renderer retries transient failures
       // instead of immediately clearing the ptyId and replacing the session.
-      ipcRenderer.invoke(IPC.PTY_RECONNECT, id) as Promise<{ success: boolean; id?: string; shell?: string; error?: string; code?: string; transient?: boolean }>,
+      ipcRenderer.invoke(IPC.PTY_RECONNECT, id) as Promise<{ success: boolean; id?: string; shell?: string; error?: string; code?: string; transient?: boolean; recovery?: DeadPaneRecovery }>,
     // Fix B — on-demand promote of a cap-skipped suspended session.
     promote: (id: string) =>
       ipcRenderer.invoke(IPC.PTY_PROMOTE, id) as Promise<{ success: boolean; error?: string }>,

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -67,6 +67,17 @@ import { planAgentCandidateSeed, asAgentSlug, markSeedAttempted } from '../../ch
 import { RECONCILE_TIMEOUT_MS } from '../../../shared/timeouts';
 import AgentToolbar from '../AgentToolbar/AgentToolbar';
 import Titlebar from '../Titlebar/Titlebar';
+import {
+  createDeadPaneRecovery,
+  type DeadPaneSessionSnapshot,
+} from '../../../shared/ptyRecovery';
+
+interface ReconcilePtySession extends DeadPaneSessionSnapshot {
+  id: string;
+  state?: string;
+  surfaceId?: string;
+  createdAt?: string;
+}
 
 /**
  * Fix 0 — startup reconcile timeout.
@@ -577,8 +588,8 @@ export default function AppLayout() {
     }
     const run = (async () => {
       try {
-        const listResult = await ipcInvoke<{ id: string; surfaceId?: string; createdAt?: string }[]>(() =>
-          window.electronAPI.pty.list()
+        const listResult = await ipcInvoke<ReconcilePtySession[]>(() =>
+          window.electronAPI.pty.list({ includeDead: true })
         );
         if (!listResult.ok) {
           // Throw — the startup catch depends on this to fire
@@ -588,7 +599,11 @@ export default function AppLayout() {
           throw new Error(`reconcilePtys aborted: ${listResult.error.code}`);
         }
         if (signal?.aborted) return;
-        const activePtys = listResult.data;
+        const listedPtys = listResult.data;
+        const activePtys = listedPtys.filter((p) => p.state !== 'dead');
+        const deadPtys = new Map(
+          listedPtys.filter((p) => p.state === 'dead').map((p) => [p.id, p]),
+        );
         const activeIds = new Set(activePtys.map((p: { id: string }) => p.id));
         // #582: include workspace count so "Reconciling workspace: X" logs that
         // follow are unambiguously a single cycle walking N workspaces, not N
@@ -602,13 +617,10 @@ export default function AppLayout() {
         // change). `pty.list` returning ZERO live sessions on a reconnect
         // almost always means the daemon/RPC isn't ready yet (main just
         // reconnected, daemon mid-rehydrate), NOT that every session died.
-        // The pre-fix code would then clear every surface's ptyId and let
-        // Terminal self-create empty sessions — exactly the reported
-        // "daemon reset, all sessions replaced" bug. Preserve everything this
-        // cycle; useTerminal mount re-validates each ptyId individually (with
-        // retry), and a subsequent reconcile / daemon:connected runs again
-        // once the list is populated. A genuine "all sessions dead" state is
-        // rare and self-heals on the next mount's reconnect.
+        // Preserve every saved id whose death is UNCONFIRMED. #650 is the
+        // deliberate exception: includeDead gives us authoritative tombstones,
+        // so a pane explicitly present in deadPtys may continue through the
+        // recovery path even when it is the only saved session.
         const hasSavedPtyIds = useStore.getState().workspaces.some(ws => {
           const walk = (p: Pane): boolean =>
             p.type === 'leaf'
@@ -616,9 +628,9 @@ export default function AppLayout() {
               : p.children.some(walk);
           return walk(ws.rootPane);
         });
-        if (activeIds.size === 0 && hasSavedPtyIds) {
-          console.warn('[lifecycle] reconcile: daemon returned 0 live sessions but saved ptyIds exist — preserving all (no destructive clear, likely daemon not ready yet)');
-          return;
+        const preserveUnconfirmedOnEmpty = activeIds.size === 0 && hasSavedPtyIds;
+        if (preserveUnconfirmedOnEmpty) {
+          console.warn(`[lifecycle] reconcile: daemon returned 0 live sessions with saved ptyIds — preserving unconfirmed ids; ${deadPtys.size} confirmed dead tombstone(s) may recover`);
         }
 
         // Fix 0 (round 3) — reconcile is now ONLY a liveness check.
@@ -659,6 +671,8 @@ export default function AppLayout() {
               if (activeIds.has(surface.ptyId)) {
                 console.log(`[AppLayout] Surface ${surface.id}: ptyId ${surface.ptyId} alive in daemon, Terminal will reconnect on mount`);
                 // Leave ptyId in place. useTerminal mount reconnects.
+              } else if (preserveUnconfirmedOnEmpty && !deadPtys.has(surface.ptyId)) {
+                console.warn(`[lifecycle] reconcile preserving unconfirmed ptyId=${surface.ptyId} surface=${surface.id} while live list is empty`);
               } else {
                 absentCandidates.push({ paneId: pane.id, surfaceId: surface.id, ptyId: surface.ptyId });
               }
@@ -782,6 +796,17 @@ export default function AppLayout() {
             if (a.kind === 'rebind') {
               console.warn(`[lifecycle] reconcile REBIND surface=${a.surfaceId} stale=${a.stalePtyId} → live=${a.newPtyId} (surfaceId match, dead ptyId recovered)`);
             } else {
+              const deadSession = deadPtys.get(a.stalePtyId);
+              if (deadSession) {
+                // #650: stage before the synchronous clear. Terminal receives
+                // both cwd candidates and main validates spawnCwd → cwd → home;
+                // any surviving binding moves to the replacement pty on create.
+                useStore.getState().stageDeadPaneRecovery(
+                  a.surfaceId,
+                  createDeadPaneRecovery(deadSession),
+                  a.stalePtyId,
+                );
+              }
               console.warn(`[lifecycle] reconcile clearing ptyId=${a.stalePtyId} surface=${a.surfaceId} (absent from TWO daemon snapshots, no surface match) → Terminal self-create`);
             }
             useStore.getState().updateSurfacePtyId(a.paneId, a.surfaceId, a.newPtyId);

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -794,6 +794,10 @@ export default function AppLayout() {
               continue;
             }
             if (a.kind === 'rebind') {
+              // This is an already-live daemon session, not the self-created
+              // replacement covered by #650. Its own live metadata remains
+              // authoritative; never attach a different dead session's cwd or
+              // resume binding merely because both claimed the same surface.
               console.warn(`[lifecycle] reconcile REBIND surface=${a.surfaceId} stale=${a.stalePtyId} → live=${a.newPtyId} (surfaceId match, dead ptyId recovered)`);
             } else {
               const deadSession = deadPtys.get(a.stalePtyId);

--- a/src/renderer/components/Layout/__tests__/appLayout.deadPaneRecovery.test.ts
+++ b/src/renderer/components/Layout/__tests__/appLayout.deadPaneRecovery.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const source = fs.readFileSync(
+  path.resolve(process.cwd(), 'src/renderer/components/Layout/AppLayout.tsx'),
+  'utf8',
+);
+
+describe('AppLayout dead-pane recovery wiring (#650)', () => {
+  const start = source.indexOf('const reconcilePtys = useCallback');
+  const end = source.indexOf('// 앱 시작 시 세션 복원', start);
+  const reconcile = source.slice(start, end);
+
+  it('requests tombstones explicitly and excludes them from the active set', () => {
+    expect(reconcile).toMatch(/pty\.list\(\{ includeDead: true \}\)/);
+    expect(reconcile).toMatch(/listedPtys\.filter\(\(p\) => p\.state !== 'dead'\)/);
+  });
+
+  it('preserves unknown ids on an empty live list but still recovers confirmed tombstones', () => {
+    expect(reconcile).toMatch(/preserveUnconfirmedOnEmpty\s*=\s*activeIds\.size === 0 && hasSavedPtyIds/);
+    expect(reconcile).toMatch(/preserveUnconfirmedOnEmpty && !deadPtys\.has\(surface\.ptyId\)/);
+  });
+
+  it('stages recovery before clearing the stale surface binding', () => {
+    const clearBranch = reconcile.indexOf("const deadSession = deadPtys.get(a.stalePtyId)");
+    const stage = reconcile.indexOf('stageDeadPaneRecovery(', clearBranch);
+    const clear = reconcile.indexOf('updateSurfacePtyId(a.paneId, a.surfaceId, a.newPtyId)', clearBranch);
+    expect(clearBranch).toBeGreaterThan(-1);
+    expect(stage).toBeGreaterThan(clearBranch);
+    expect(clear).toBeGreaterThan(stage);
+  });
+});

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -854,7 +854,12 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
         isWorkspaceVisible={isWorkspaceVisible}
         isZoomHidden={isZoomHidden}
         onCloseSurface={handleCloseSurface}
-        onPtyCreated={(surfaceId, ptyId) => updateSurfacePtyId(pane.id, surfaceId, ptyId)}
+        onPtyCreated={(surfaceId, ptyId) => {
+          // Bind first so Terminal immediately sees a non-empty externalPtyId;
+          // then move any staged dead-session resume offer onto the new id.
+          updateSurfacePtyId(pane.id, surfaceId, ptyId);
+          useStore.getState().completeDeadPaneRecovery(surfaceId, ptyId);
+        }}
         emptyMessage={t('pane.empty')}
       />
       </ErrorBoundary>

--- a/src/renderer/components/Terminal/Terminal.tsx
+++ b/src/renderer/components/Terminal/Terminal.tsx
@@ -3,7 +3,7 @@ import { useTerminal, copySelectionWithFeedback, getPaneSyncUi, subscribePaneSyn
 import { useStore } from '../../stores';
 import { t } from '../../i18n';
 import { useIpc } from '../../hooks/useIpc';
-import { resolveRespawnCwd, withDefaultShell, withWorkspaceProfile } from '../../utils/ptyCreateOptions';
+import { resolveRespawnCwd, shouldHealSurfaceCwd, withDefaultShell, withWorkspaceProfile } from '../../utils/ptyCreateOptions';
 import { pastePtyChunked } from '../../utils/clipboardChunk';
 import { openTerminalUrl } from '../../utils/browserPaneActions';
 import { terminalFontFamilyCss } from '../../utils/terminalFont';
@@ -209,13 +209,16 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
       // Skip the heal when main landed somewhere OTHER than what we requested
       // (validateCwd dropped it → homedir fallback): engraving the fallback
       // would hide a broken/missing startup dir behind a healthy-looking cwd.
-      // Compare loosely (case + trailing separators) — main path.resolve()s.
-      const normalize = (p: string) => p.replace(/[\\/]+$/, '').toLowerCase();
       const spawned = result.data.cwd;
-      if (spawned && (!respawnCwd || normalize(spawned) === normalize(respawnCwd))) {
+      const shouldHeal = shouldHealSurfaceCwd({
+        spawnedCwd: spawned,
+        requestedCwd: respawnCwd,
+        recoveryCwds: deadPaneRecovery,
+      });
+      if (spawned && shouldHeal) {
         useStore.getState().updateSurfaceCwd(result.data.id, spawned);
-      } else if (spawned && respawnCwd) {
-        console.warn(`[Terminal] requested cwd ${respawnCwd} but spawned in ${spawned} (startup dir missing/invalid?) — keeping surface cwd untouched`);
+      } else if (spawned && (respawnCwd || deadPaneRecovery)) {
+        console.warn(`[Terminal] requested cwd ${requestedCwd ?? '(recovery home fallback)'} but spawned in ${spawned} (requested dirs missing/invalid?) — keeping surface cwd untouched`);
       }
     });
 

--- a/src/renderer/components/Terminal/Terminal.tsx
+++ b/src/renderer/components/Terminal/Terminal.tsx
@@ -55,6 +55,9 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
   const setViCopyModeActive = useStore((s) => s.setViCopyModeActive);
   const searchBarVisible = useStore((s) => s.searchBarVisible);
   const setSearchBarVisible = useStore((s) => s.setSearchBarVisible);
+  const deadPaneRecovery = useStore((s) =>
+    ownerSurfaceId ? s.pendingDeadPaneRecoveryBySurfaceId[ownerSurfaceId] : undefined,
+  );
   const bookmarks = useStore((s) => (ptyId ? s.terminalBookmarks[ptyId] : undefined)) ?? EMPTY_BOOKMARKS;
   const { invoke: ipcInvoke } = useIpc();
   // Keep the invoker stable across re-renders without re-triggering the PTY
@@ -151,17 +154,34 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
     // contaminated) surface.cwd prop, so a dead-session respawn heals back to
     // profile.startupCwd instead of perpetuating home.
     const startupDirectory = useStore.getState().startupDirectory;
-    const respawnCwd = resolveRespawnCwd({ surfaceCwd: cwd, profile, startupDirectory });
+    // #650: a known-dead session carries BOTH persisted cwd candidates to
+    // main, which validates spawnCwd → live cwd → home. Ordinary blank surfaces
+    // stay on #515's profile-first resolver; recovery never changes that policy.
+    const respawnCwd = deadPaneRecovery
+      ? undefined
+      : resolveRespawnCwd({ surfaceCwd: cwd, profile, startupDirectory });
     // Derive the source tag from the RESOLVED value (not a parallel branch tree)
     // so the log can never disagree with what was actually requested.
     const cwdSource =
-      respawnCwd === undefined ? 'none'
+      deadPaneRecovery ? 'dead-session'
+      : respawnCwd === undefined ? 'none'
       : respawnCwd === profile?.startupCwd ? 'profile'
       : respawnCwd === cwd ? 'surface'
       : 'global';
-    console.log(`[Terminal] self-create PTY: shell=${shell}, cwd=${respawnCwd ?? '(home)'} source=${cwdSource} surfaceCwd=${cwd ?? '-'} cols=${cols}, rows=${rows}, ws=${workspaceId}, surface=${surfaceId ?? '-'}`);
+    const requestedCwd = deadPaneRecovery?.spawnCwd ?? deadPaneRecovery?.cwd ?? respawnCwd;
+    console.log(`[Terminal] self-create PTY: shell=${shell}, cwd=${requestedCwd ?? '(home)'} source=${cwdSource} surfaceCwd=${cwd ?? '-'} cols=${cols}, rows=${rows}, ws=${workspaceId}, surface=${surfaceId ?? '-'}`);
     void ipcInvokeRef.current<{ id: string; cwd?: string }>(() =>
-      window.electronAPI.pty.create(withWorkspaceProfile(withDefaultShell({ shell, cwd: respawnCwd, cols, rows, workspaceId, surfaceId, spawnKind: 'user-shell' }, defaultShell), profile))
+      window.electronAPI.pty.create(withWorkspaceProfile(withDefaultShell({
+        shell,
+        ...(deadPaneRecovery
+          ? { recoveryCwds: { spawnCwd: deadPaneRecovery.spawnCwd, cwd: deadPaneRecovery.cwd } }
+          : { cwd: respawnCwd }),
+        cols,
+        rows,
+        workspaceId,
+        surfaceId,
+        spawnKind: 'user-shell',
+      }, defaultShell), profile))
     ).then((result) => {
       // v2 RCA fix (adversarial review): release the latch once this create
       // settles. It guards against DOUBLE-create within one attempt, but as a
@@ -200,7 +220,7 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
     });
 
     return () => { cancelled = true; };
-  }, [externalPtyId, shell, cwd]); // onPtyCreated 제거 (stale closure 방지)
+  }, [externalPtyId, shell, cwd, deadPaneRecovery]); // onPtyCreated 제거 (stale closure 방지)
 
   // isVisible = workspace is shown AND this surface tab is the active one.
   // useTerminal uses this to skip fit() when the container is display:none.

--- a/src/renderer/hooks/__tests__/reconnectPtyWithRetry.test.ts
+++ b/src/renderer/hooks/__tests__/reconnectPtyWithRetry.test.ts
@@ -23,7 +23,22 @@ describe('reconnectPtyWithRetry (RCA A1 non-destructive contract)', () => {
     const reconnect = vi.fn(async () => ({ success: false, transient: false, error: 'Session not found or dead' }));
     await reconnectPtyWithRetry('pty-dead', alwaysCurrent, { reconnect, clearPtyId, sleep: noSleep, log: noLog });
     expect(reconnect).toHaveBeenCalledTimes(1); // no retry on permanent
-    expect(clearPtyId).toHaveBeenCalledWith('pty-dead');
+    expect(clearPtyId).toHaveBeenCalledWith('pty-dead', undefined);
+  });
+
+  it('passes dead-session recovery metadata into the clear path', async () => {
+    const clearPtyId = vi.fn();
+    const recovery = { spawnCwd: 'D:\\repo', cwd: 'D:\\live' };
+    const reconnect = vi.fn(async () => ({
+      success: false,
+      transient: false,
+      error: 'Session is dead',
+      recovery,
+    }));
+
+    await reconnectPtyWithRetry('pty-dead', alwaysCurrent, { reconnect, clearPtyId, sleep: noSleep, log: noLog });
+
+    expect(clearPtyId).toHaveBeenCalledWith('pty-dead', recovery);
   });
 
   it('transient failure then success → retries and PRESERVES the session (never clears)', async () => {

--- a/src/renderer/hooks/reconnectPtyWithRetry.ts
+++ b/src/renderer/hooks/reconnectPtyWithRetry.ts
@@ -1,3 +1,5 @@
+import type { DeadPaneRecovery } from '../../shared/ptyRecovery';
+
 /**
  * RCA A1 — reconnect a live daemon session with retry, distinguishing
  * transient from permanent failure.
@@ -25,13 +27,14 @@ export interface ReconnectResult {
   success: boolean;
   error?: string;
   transient?: boolean;
+  recovery?: DeadPaneRecovery;
 }
 
 export interface ReconnectDeps {
   /** Invoke the pty.reconnect RPC. */
   reconnect: (id: string) => Promise<ReconnectResult>;
   /** Clear the surface's ptyId so the next mount self-creates. */
-  clearPtyId: (id: string) => void;
+  clearPtyId: (id: string, recovery?: DeadPaneRecovery) => void;
   /** Sleep between retries. Injectable so tests don't wait real time. */
   sleep?: (ms: number) => Promise<void>;
   /** Optional structured logger. Defaults to console. */
@@ -68,7 +71,7 @@ export async function reconnectPtyWithRetry(
     // Permanent failure (daemon says the session is dead): clear now, no retry.
     if (result?.transient === false) {
       log('warn', `[useTerminal] pty.reconnect ${ptyId} permanent failure (${lastErr}) — clearing ptyId for self-create`);
-      if (isCurrent()) deps.clearPtyId(ptyId);
+      if (isCurrent()) deps.clearPtyId(ptyId, result.recovery);
       return;
     }
     // Transient (or unknown): back off and retry unless attempts are exhausted.

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -428,7 +428,7 @@ export const WEBGL_HIDDEN_DISPOSE_DELAY_MS = 5_000;
 function reconnectPtyWithRetry(ptyId: string, isCurrent: () => boolean): Promise<void> {
   return reconnectPtyWithRetryImpl(ptyId, isCurrent, {
     reconnect: (id) => window.electronAPI.pty.reconnect(id),
-    clearPtyId: (id) => useStore.getState().clearSurfacePtyIdByPty(id),
+    clearPtyId: (id, recovery) => useStore.getState().clearSurfacePtyIdByPty(id, recovery),
   });
 }
 

--- a/src/renderer/stores/slices/__tests__/resumeSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/resumeSlice.test.ts
@@ -4,6 +4,10 @@ import { useStore } from '../../index';
 // X6 Feature ② — resume-hint slice. Mirrors supervisionSlice.test structure.
 describe('resumeSlice', () => {
   beforeEach(() => {
+    useStore.setState((state) => {
+      state.pendingDeadPaneRecoveryBySurfaceId = {};
+      state.deadPaneRecoveryOfferByPtyId = {};
+    });
     useStore.getState().hydrateResume({});
     useStore.getState().hydrateResumeBindings({});
     // clear readiness by re-hydrating is not enough (separate map) — mark fresh
@@ -91,6 +95,70 @@ describe('resumeSlice', () => {
       useStore.getState().setResumeHint('pty-z', 'claude');
       // readiness map is independent — pty-z not marked ready
       expect(useStore.getState().ptyReadyByPtyId['pty-z']).toBeUndefined();
+    });
+  });
+
+  describe('dead-pane replacement hand-off (#650)', () => {
+    it('moves a staged binding to the replacement pty', () => {
+      const resumeBinding = binding('dead-conversation');
+      useStore.getState().stageDeadPaneRecovery('surface-a', {
+        spawnCwd: 'D:\\wmux',
+        resumeAgent: 'claude',
+        resumeBinding,
+      });
+
+      useStore.getState().completeDeadPaneRecovery('surface-a', 'pty-new');
+
+      expect(useStore.getState().pendingDeadPaneRecoveryBySurfaceId['surface-a']).toBeUndefined();
+      expect(useStore.getState().resumeHintByPtyId['pty-new']).toBe('claude');
+      expect(useStore.getState().resumeBindingByPtyId['pty-new']).toEqual(resumeBinding);
+    });
+
+    it('survives normal daemon hydration until the offer is dismissed', () => {
+      useStore.getState().stageDeadPaneRecovery('surface-a', {
+        resumeBinding: binding('dead-conversation'),
+      });
+      useStore.getState().completeDeadPaneRecovery('surface-a', 'pty-new');
+
+      useStore.getState().hydrateResume({});
+      useStore.getState().hydrateResumeBindings({});
+      expect(useStore.getState().resumeHintByPtyId['pty-new']).toBe('claude');
+      expect(useStore.getState().resumeBindingByPtyId['pty-new']?.sessionId).toBe('dead-conversation');
+
+      useStore.getState().clearResumeHint('pty-new');
+      useStore.getState().hydrateResume({});
+      useStore.getState().hydrateResumeBindings({});
+      expect(useStore.getState().resumeHintByPtyId['pty-new']).toBeUndefined();
+      expect(useStore.getState().resumeBindingByPtyId['pty-new']).toBeUndefined();
+    });
+
+    it('consumes cwd-only recovery without inventing a resume offer', () => {
+      useStore.getState().stageDeadPaneRecovery('surface-a', { spawnCwd: 'D:\\wmux' });
+      useStore.getState().completeDeadPaneRecovery('surface-a', 'pty-new');
+      expect(useStore.getState().pendingDeadPaneRecoveryBySurfaceId['surface-a']).toBeUndefined();
+      expect(useStore.getState().deadPaneRecoveryOfferByPtyId['pty-new']).toBeUndefined();
+      expect(useStore.getState().resumeHintByPtyId['pty-new']).toBeUndefined();
+    });
+
+    it('carries an unconsumed offer across a second replacement', () => {
+      useStore.getState().stageDeadPaneRecovery('surface-a', {
+        spawnCwd: 'D:\\first',
+        resumeBinding: binding('dead-conversation'),
+      });
+      useStore.getState().completeDeadPaneRecovery('surface-a', 'pty-first');
+
+      useStore.getState().stageDeadPaneRecovery(
+        'surface-a',
+        { spawnCwd: 'D:\\second' },
+        'pty-first',
+      );
+      useStore.getState().completeDeadPaneRecovery('surface-a', 'pty-second');
+
+      expect(useStore.getState().deadPaneRecoveryOfferByPtyId['pty-first']).toBeUndefined();
+      expect(useStore.getState().resumeHintByPtyId['pty-first']).toBeUndefined();
+      expect(useStore.getState().resumeHintByPtyId['pty-second']).toBe('claude');
+      expect(useStore.getState().resumeBindingByPtyId['pty-second']?.sessionId).toBe('dead-conversation');
+      expect(useStore.getState().deadPaneRecoveryOfferByPtyId['pty-second']?.spawnCwd).toBe('D:\\second');
     });
   });
 });

--- a/src/renderer/stores/slices/__tests__/workspaceSlice.deadPaneRecovery.test.ts
+++ b/src/renderer/stores/slices/__tests__/workspaceSlice.deadPaneRecovery.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { createWorkspaceSlice, type WorkspaceSlice } from '../workspaceSlice';
+import { createSurface, type Workspace } from '../../../../shared/types';
+import type { DeadPaneRecovery } from '../../../../shared/ptyRecovery';
+
+type TestState = WorkspaceSlice & {
+  pendingDeadPaneRecoveryBySurfaceId: Record<string, DeadPaneRecovery>;
+};
+
+function createTestStore() {
+  return create<TestState>()(
+    immer((...args) => ({
+      // @ts-expect-error — intentionally minimal cross-slice test store.
+      ...createWorkspaceSlice(...args),
+      pendingDeadPaneRecoveryBySurfaceId: {},
+    })),
+  );
+}
+
+describe('WorkspaceSlice.clearSurfacePtyIdByPty (#650)', () => {
+  it('stages recovery metadata on the matched surface before clearing its ptyId', () => {
+    const store = createTestStore();
+    const surface = createSurface('pty-dead', 'pwsh', 'C:\\old');
+    store.setState((state) => {
+      const workspace = state.workspaces[0] as Workspace;
+      if (workspace.rootPane.type !== 'leaf') throw new Error('expected leaf fixture');
+      workspace.rootPane.surfaces.push(surface);
+      workspace.rootPane.activeSurfaceId = surface.id;
+    });
+    const recovery = { spawnCwd: 'D:\\spawn', cwd: 'D:\\live' };
+
+    store.getState().clearSurfacePtyIdByPty('pty-dead', recovery);
+
+    expect(store.getState().workspaces[0].rootPane).toMatchObject({
+      surfaces: [{ id: surface.id, ptyId: '' }],
+    });
+    expect(store.getState().pendingDeadPaneRecoveryBySurfaceId[surface.id]).toEqual(recovery);
+  });
+
+  it('does not stage metadata when the pty no longer belongs to a surface', () => {
+    const store = createTestStore();
+    store.getState().clearSurfacePtyIdByPty('pty-gone', { spawnCwd: 'D:\\spawn' });
+    expect(store.getState().pendingDeadPaneRecoveryBySurfaceId).toEqual({});
+  });
+});

--- a/src/renderer/stores/slices/__tests__/workspaceSlice.deadPaneRecovery.test.ts
+++ b/src/renderer/stores/slices/__tests__/workspaceSlice.deadPaneRecovery.test.ts
@@ -4,9 +4,14 @@ import { immer } from 'zustand/middleware/immer';
 import { createWorkspaceSlice, type WorkspaceSlice } from '../workspaceSlice';
 import { createSurface, type Workspace } from '../../../../shared/types';
 import type { DeadPaneRecovery } from '../../../../shared/ptyRecovery';
+import type { ResumeBinding } from '../../../../shared/agentResume';
+import type { AgentSlug } from '../../../../shared/events';
 
 type TestState = WorkspaceSlice & {
   pendingDeadPaneRecoveryBySurfaceId: Record<string, DeadPaneRecovery>;
+  deadPaneRecoveryOfferByPtyId: Record<string, DeadPaneRecovery>;
+  resumeHintByPtyId: Record<string, AgentSlug>;
+  resumeBindingByPtyId: Record<string, ResumeBinding>;
 };
 
 function createTestStore() {
@@ -15,6 +20,9 @@ function createTestStore() {
       // @ts-expect-error — intentionally minimal cross-slice test store.
       ...createWorkspaceSlice(...args),
       pendingDeadPaneRecoveryBySurfaceId: {},
+      deadPaneRecoveryOfferByPtyId: {},
+      resumeHintByPtyId: {},
+      resumeBindingByPtyId: {},
     })),
   );
 }
@@ -43,5 +51,40 @@ describe('WorkspaceSlice.clearSurfacePtyIdByPty (#650)', () => {
     const store = createTestStore();
     store.getState().clearSurfacePtyIdByPty('pty-gone', { spawnCwd: 'D:\\spawn' });
     expect(store.getState().pendingDeadPaneRecoveryBySurfaceId).toEqual({});
+  });
+
+  it('carries an unconsumed resume offer across another replacement', () => {
+    const store = createTestStore();
+    const surface = createSurface('pty-dead', 'pwsh', 'C:\\old');
+    const resumeBinding: ResumeBinding = {
+      agent: 'claude',
+      sessionId: 'conversation-1',
+      cwd: 'D:\\repo',
+      ts: 1,
+    };
+    store.setState((state) => {
+      const workspace = state.workspaces[0] as Workspace;
+      if (workspace.rootPane.type !== 'leaf') throw new Error('expected leaf fixture');
+      workspace.rootPane.surfaces.push(surface);
+      state.deadPaneRecoveryOfferByPtyId['pty-dead'] = {
+        spawnCwd: 'D:\\spawn',
+        resumeAgent: 'claude',
+        resumeBinding,
+      };
+      state.resumeHintByPtyId['pty-dead'] = 'claude';
+      state.resumeBindingByPtyId['pty-dead'] = resumeBinding;
+    });
+
+    store.getState().clearSurfacePtyIdByPty('pty-dead', { cwd: 'D:\\live' });
+
+    expect(store.getState().pendingDeadPaneRecoveryBySurfaceId[surface.id]).toEqual({
+      spawnCwd: 'D:\\spawn',
+      cwd: 'D:\\live',
+      resumeAgent: 'claude',
+      resumeBinding,
+    });
+    expect(store.getState().deadPaneRecoveryOfferByPtyId['pty-dead']).toBeUndefined();
+    expect(store.getState().resumeHintByPtyId['pty-dead']).toBeUndefined();
+    expect(store.getState().resumeBindingByPtyId['pty-dead']).toBeUndefined();
   });
 });

--- a/src/renderer/stores/slices/resumeSlice.ts
+++ b/src/renderer/stores/slices/resumeSlice.ts
@@ -13,8 +13,29 @@ import type { StateCreator } from 'zustand';
 import type { StoreState } from '../index';
 import type { AgentSlug } from '../../../shared/events';
 import type { ResumeBinding } from '../../../shared/agentResume';
+import {
+  asRecoveryAgentSlug,
+  mergeDeadPaneRecovery,
+  type DeadPaneRecovery,
+} from '../../../shared/ptyRecovery';
 
 export interface ResumeSlice {
+  /** One-shot recovery metadata keyed by the stable renderer surface id. */
+  pendingDeadPaneRecoveryBySurfaceId: Record<string, DeadPaneRecovery>;
+
+  /**
+   * Recovery offers rebound to a replacement pty. Kept separately so the
+   * daemon's normal 15-second hydration (which does not list dead tombstones)
+   * cannot erase the offer before the user accepts or dismisses it.
+   */
+  deadPaneRecoveryOfferByPtyId: Record<string, DeadPaneRecovery>;
+
+  /** Stage a known-dead session before clearing its surface ptyId. */
+  stageDeadPaneRecovery: (surfaceId: string, recovery: DeadPaneRecovery, previousPtyId?: string) => void;
+
+  /** Move staged metadata onto the freshly-created replacement pty. */
+  completeDeadPaneRecovery: (surfaceId: string, ptyId: string) => void;
+
   /** Per-ptyId resume hint (agent slug). Absent key = no pill for this pane. */
   resumeHintByPtyId: Record<string, AgentSlug>;
 
@@ -91,6 +112,35 @@ export const createResumeSlice: StateCreator<
   commandRunningByPtyId: {},
   agentAliveByPtyId: {},
   ptyReadyByPtyId: {},
+  pendingDeadPaneRecoveryBySurfaceId: {},
+  deadPaneRecoveryOfferByPtyId: {},
+
+  stageDeadPaneRecovery: (surfaceId, recovery, previousPtyId) => set((draft: StoreState) => {
+    if (!surfaceId) return;
+    const previous = draft.pendingDeadPaneRecoveryBySurfaceId[surfaceId]
+      ?? (previousPtyId ? draft.deadPaneRecoveryOfferByPtyId[previousPtyId] : undefined);
+    draft.pendingDeadPaneRecoveryBySurfaceId[surfaceId] = mergeDeadPaneRecovery(previous, recovery);
+    if (previousPtyId && draft.deadPaneRecoveryOfferByPtyId[previousPtyId]) {
+      delete draft.deadPaneRecoveryOfferByPtyId[previousPtyId];
+      delete draft.resumeHintByPtyId[previousPtyId];
+      delete draft.resumeBindingByPtyId[previousPtyId];
+    }
+  }),
+
+  completeDeadPaneRecovery: (surfaceId, ptyId) => set((draft: StoreState) => {
+    if (!surfaceId || !ptyId) return;
+    const recovery = draft.pendingDeadPaneRecoveryBySurfaceId[surfaceId];
+    if (!recovery) return;
+    delete draft.pendingDeadPaneRecoveryBySurfaceId[surfaceId];
+
+    const agent = recovery.resumeAgent ?? asRecoveryAgentSlug(recovery.resumeBinding?.agent);
+    if (!agent) return;
+    draft.deadPaneRecoveryOfferByPtyId[ptyId] = recovery;
+    draft.resumeHintByPtyId[ptyId] = agent;
+    if (recovery.resumeBinding) {
+      draft.resumeBindingByPtyId[ptyId] = recovery.resumeBinding;
+    }
+  }),
 
   markPtyReady: (ptyId) => set((draft: StoreState) => {
     if (!draft.ptyReadyByPtyId[ptyId]) draft.ptyReadyByPtyId[ptyId] = true;
@@ -105,14 +155,22 @@ export const createResumeSlice: StateCreator<
     // (clicked, dismissed, typed-into, or agent relaunched).
     if (draft.resumeHintByPtyId[ptyId]) delete draft.resumeHintByPtyId[ptyId];
     if (draft.resumeBindingByPtyId[ptyId]) delete draft.resumeBindingByPtyId[ptyId];
+    if (draft.deadPaneRecoveryOfferByPtyId[ptyId]) delete draft.deadPaneRecoveryOfferByPtyId[ptyId];
   }),
 
   hydrateResume: (snapshot) => set((draft: StoreState) => {
     draft.resumeHintByPtyId = { ...snapshot };
+    for (const [ptyId, recovery] of Object.entries(draft.deadPaneRecoveryOfferByPtyId)) {
+      const agent = recovery.resumeAgent ?? asRecoveryAgentSlug(recovery.resumeBinding?.agent);
+      if (agent) draft.resumeHintByPtyId[ptyId] = agent;
+    }
   }),
 
   hydrateResumeBindings: (snapshot) => set((draft: StoreState) => {
     draft.resumeBindingByPtyId = { ...snapshot };
+    for (const [ptyId, recovery] of Object.entries(draft.deadPaneRecoveryOfferByPtyId)) {
+      if (recovery.resumeBinding) draft.resumeBindingByPtyId[ptyId] = recovery.resumeBinding;
+    }
   }),
 
   hydrateCommandRunning: (snapshot) => set((draft: StoreState) => {

--- a/src/renderer/stores/slices/surfaceSlice.ts
+++ b/src/renderer/stores/slices/surfaceSlice.ts
@@ -223,6 +223,14 @@ export const createSurfaceSlice: StateCreator<StoreState, [['zustand/immer', nev
     // the OTHER real teardown site — clear it here too so a closed surface's
     // last activity string doesn't survive on a re-used ptyId.
     const closedPtyId = pane.surfaces[idx].ptyId;
+    if (state.pendingDeadPaneRecoveryBySurfaceId) {
+      delete state.pendingDeadPaneRecoveryBySurfaceId[surfaceId];
+    }
+    if (closedPtyId && state.deadPaneRecoveryOfferByPtyId?.[closedPtyId]) {
+      delete state.deadPaneRecoveryOfferByPtyId[closedPtyId];
+      delete state.resumeHintByPtyId[closedPtyId];
+      delete state.resumeBindingByPtyId[closedPtyId];
+    }
     if (closedPtyId && state.surfaceAgent) delete state.surfaceAgent[closedPtyId];
     if (closedPtyId && state.surfaceActivity) delete state.surfaceActivity[closedPtyId];
     // Drop the pending question too: a leaked entry would let a REUSED ptyId

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -157,6 +157,7 @@ export interface WorkspaceSlice {
    * Clearing the surface ptyId triggers re-mount with externalPtyId='',
    * which falls into Terminal.tsx's self-create path. Without this, the
    * Terminal sits with a stale ptyId forever and reproduces input-mute.
+   * Optional recovery metadata is staged on the matched surface first.
    */
   clearSurfacePtyIdByPty: (ptyId: string, recovery?: DeadPaneRecovery) => void;
 }

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -12,6 +12,7 @@ import { MULTIVIEW_ARRANGEMENTS } from '../../utils/multiviewGrid';
 import { publishWorkspaceMetadataChanged, publishA2aTask } from '../../events/publisher';
 import { retentionMigrationDone, markRetentionMigrationDone } from '../retentionMigration';
 import { decUnread } from './notificationSlice';
+import { mergeDeadPaneRecovery, type DeadPaneRecovery } from '../../../shared/ptyRecovery';
 
 /** Collect all leaf panes from a pane tree */
 function collectLeafPanes(pane: Pane): PaneLeaf[] {
@@ -157,7 +158,7 @@ export interface WorkspaceSlice {
    * which falls into Terminal.tsx's self-create path. Without this, the
    * Terminal sits with a stale ptyId forever and reproduces input-mute.
    */
-  clearSurfacePtyIdByPty: (ptyId: string) => void;
+  clearSurfacePtyIdByPty: (ptyId: string, recovery?: DeadPaneRecovery) => void;
 }
 
 export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', never]], [], WorkspaceSlice> = (set, get) => {
@@ -385,6 +386,27 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
         const collectPtyIds = (p: Pane): string[] =>
           p.type === 'leaf' ? p.surfaces.map((s) => s.ptyId).filter(Boolean) : p.children.flatMap(collectPtyIds);
         for (const pid of collectPtyIds(removedWs.rootPane)) delete state.taskPtyRegistry[pid];
+      }
+      // #650 recovery metadata is transient but hydration-sticky. A removed
+      // workspace must evict both surface-keyed pending hand-offs and offers
+      // rebound to its ptys, otherwise the normal list poll intentionally keeps
+      // them alive forever.
+      {
+        const removedWs = state.workspaces[idx];
+        const collectSurfaces = (p: Pane): Array<{ id: string; ptyId: string }> =>
+          p.type === 'leaf'
+            ? p.surfaces.map((s) => ({ id: s.id, ptyId: s.ptyId }))
+            : p.children.flatMap(collectSurfaces);
+        for (const surface of collectSurfaces(removedWs.rootPane)) {
+          if (state.pendingDeadPaneRecoveryBySurfaceId) {
+            delete state.pendingDeadPaneRecoveryBySurfaceId[surface.id];
+          }
+          if (surface.ptyId && state.deadPaneRecoveryOfferByPtyId?.[surface.ptyId]) {
+            delete state.deadPaneRecoveryOfferByPtyId[surface.ptyId];
+            delete state.resumeHintByPtyId[surface.ptyId];
+            delete state.resumeBindingByPtyId[surface.ptyId];
+          }
+        }
       }
       // Order matters: capture the group BEFORE pruning so the promotion below
       // can still tell who this workspace's neighbours in the grid were.
@@ -971,13 +993,25 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
     // covered (floating pane, bookmarks, token data, company members).
     // After this runs, Terminal.tsx self-create sees externalPtyId='' on
     // mount and creates fresh PTYs — the well-tested new-pane path.
-    clearSurfacePtyIdByPty: (ptyId: string) => set((state: StoreState) => {
+    clearSurfacePtyIdByPty: (ptyId: string, recovery?: DeadPaneRecovery) => set((state: StoreState) => {
       if (!ptyId) return;
       const walk = (pane: Pane) => {
         if (pane.type === 'leaf') {
           for (const s of pane.surfaces) {
             // 유틸 surface(git·review)는 pty 없음 — 명시적으로 제외해 방어.
             if (s.ptyId === ptyId && s.surfaceType !== 'browser' && s.surfaceType !== 'editor' && s.surfaceType !== 'diff' && s.surfaceType !== 'git' && s.surfaceType !== 'review') {
+              const previousOffer = state.deadPaneRecoveryOfferByPtyId?.[ptyId];
+              if ((recovery || previousOffer) && state.pendingDeadPaneRecoveryBySurfaceId) {
+                state.pendingDeadPaneRecoveryBySurfaceId[s.id] = mergeDeadPaneRecovery(
+                  state.pendingDeadPaneRecoveryBySurfaceId[s.id] ?? previousOffer,
+                  recovery ?? {},
+                );
+              }
+              if (previousOffer) {
+                delete state.deadPaneRecoveryOfferByPtyId[ptyId];
+                delete state.resumeHintByPtyId[ptyId];
+                delete state.resumeBindingByPtyId[ptyId];
+              }
               s.ptyId = '';
             }
           }
@@ -1009,6 +1043,8 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
       state.terminalBookmarks = {};
       // X1 per-surface port map is ptyId-keyed — same wipe contract.
       if (state.surfacePorts) state.surfacePorts = {};
+      if (state.pendingDeadPaneRecoveryBySurfaceId) state.pendingDeadPaneRecoveryBySurfaceId = {};
+      if (state.deadPaneRecoveryOfferByPtyId) state.deadPaneRecoveryOfferByPtyId = {};
 
       // 3. companySlice — member.ptyId across all departments.
       if (state.company) {

--- a/src/renderer/utils/__tests__/ptyCreateOptions.test.ts
+++ b/src/renderer/utils/__tests__/ptyCreateOptions.test.ts
@@ -201,9 +201,10 @@ describe('resolveStartupCwd', () => {
   });
 });
 
-// Issue #515: a self-create (dead-session respawn / blank-slate recovery) is a
-// NEW shell, so the workspace default OUTRANKS the surface's tracked cwd — the
-// inverse of resolveStartupCwd's split-seed-first semantics.
+// Issue #515: an ordinary blank-slate self-create is a NEW shell, so the
+// workspace default OUTRANKS the surface's tracked cwd — the inverse of
+// resolveStartupCwd's split-seed-first semantics. Known dead-session recovery
+// bypasses this helper through #650's main-validated recoveryCwds path.
 describe('resolveRespawnCwd', () => {
   it('prefers profile.startupCwd over a non-empty (contaminated) surface cwd', () => {
     // This is the core #515 heal: the surface tracks home, the profile is

--- a/src/renderer/utils/__tests__/ptyCreateOptions.test.ts
+++ b/src/renderer/utils/__tests__/ptyCreateOptions.test.ts
@@ -256,4 +256,15 @@ describe('shouldHealSurfaceCwd', () => {
     })).toBe(false);
     expect(shouldHealSurfaceCwd({ spawnedCwd: 'C:\\Users\\me', recoveryCwds: {} })).toBe(false);
   });
+
+  it('preserves POSIX case sensitivity while normalizing separators', () => {
+    expect(shouldHealSurfaceCwd({
+      spawnedCwd: '/Users/Foo/project/',
+      recoveryCwds: { spawnCwd: '/Users/Foo/project' },
+    })).toBe(true);
+    expect(shouldHealSurfaceCwd({
+      spawnedCwd: '/users/foo/project',
+      recoveryCwds: { spawnCwd: '/Users/Foo/project' },
+    })).toBe(false);
+  });
 });

--- a/src/renderer/utils/__tests__/ptyCreateOptions.test.ts
+++ b/src/renderer/utils/__tests__/ptyCreateOptions.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { resolveRespawnCwd, resolveStartupCwd, withDefaultShell, withWorkspaceProfile, withRoleBinding } from '../ptyCreateOptions';
+import { resolveRespawnCwd, resolveStartupCwd, shouldHealSurfaceCwd, withDefaultShell, withWorkspaceProfile, withRoleBinding } from '../ptyCreateOptions';
 
 describe('withRoleBinding (D2)', () => {
   const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
@@ -233,5 +233,27 @@ describe('resolveRespawnCwd', () => {
   it('treats an empty/whitespace surface cwd and global as unset', () => {
     expect(resolveRespawnCwd({ surfaceCwd: '   ', startupDirectory: '  ' })).toBeUndefined();
     expect(resolveRespawnCwd({ surfaceCwd: '' })).toBeUndefined();
+  });
+});
+
+describe('shouldHealSurfaceCwd', () => {
+  it('keeps ordinary #515 behavior for explicit and implicit cwd requests', () => {
+    expect(shouldHealSurfaceCwd({ spawnedCwd: 'C:\\repo', requestedCwd: 'c:\\repo\\' })).toBe(true);
+    expect(shouldHealSurfaceCwd({ spawnedCwd: 'C:\\Users\\me', requestedCwd: 'C:\\missing' })).toBe(false);
+    expect(shouldHealSurfaceCwd({ spawnedCwd: 'C:\\Users\\me' })).toBe(true);
+  });
+
+  it('accepts either validated dead-session recovery candidate', () => {
+    const recoveryCwds = { spawnCwd: 'D:\\project', cwd: 'D:\\project\\subdir' };
+    expect(shouldHealSurfaceCwd({ spawnedCwd: 'd:\\project\\', recoveryCwds })).toBe(true);
+    expect(shouldHealSurfaceCwd({ spawnedCwd: 'D:\\project\\subdir', recoveryCwds })).toBe(true);
+  });
+
+  it('does not engrave a recovery home fallback onto the surface', () => {
+    expect(shouldHealSurfaceCwd({
+      spawnedCwd: 'C:\\Users\\me',
+      recoveryCwds: { spawnCwd: 'D:\\missing', cwd: 'D:\\also-missing' },
+    })).toBe(false);
+    expect(shouldHealSurfaceCwd({ spawnedCwd: 'C:\\Users\\me', recoveryCwds: {} })).toBe(false);
   });
 });

--- a/src/renderer/utils/ptyCreateOptions.ts
+++ b/src/renderer/utils/ptyCreateOptions.ts
@@ -1,9 +1,13 @@
 import type { SpawnKind } from '../../shared/spawnKind';
+import type { DeadPaneRecovery } from '../../shared/ptyRecovery';
 import { applyRoleBinding, type RoleBinding } from '../../shared/orchestratorRole';
 
 export interface PtyCreateOptions {
   shell?: string;
   cwd?: string;
+  /** Known-dead session cwd candidates. Main validates them in order and
+   * falls back to home; ordinary blank-surface creates leave this absent. */
+  recoveryCwds?: Pick<DeadPaneRecovery, 'spawnCwd' | 'cwd'>;
   cols?: number;
   rows?: number;
   workspaceId?: string;
@@ -163,9 +167,11 @@ export function resolveStartupCwd(args: {
 
 /**
  * Resolve the starting directory when a mounted Terminal SELF-CREATES a PTY
- * (issue #515). This is a fresh shell for a blank surface — recovery blank-slate,
- * rebind failure, or a dead-session respawn — so the workspace default is
- * authoritative and OUTRANKS the surface's tracked cwd.
+ * (issue #515). This is a fresh shell for an ordinary blank surface — recovery
+ * blank-slate or an unclassified rebind failure — so the workspace default is
+ * authoritative and OUTRANKS the surface's tracked cwd. A known daemon
+ * tombstone takes #650's separate recoveryCwds path and does not call this
+ * resolver.
  *
  * Priority differs from resolveStartupCwd on purpose: profile.startupCwd >
  * surface.cwd (prop) > global startupDirectory > undefined. A contaminated

--- a/src/renderer/utils/ptyCreateOptions.ts
+++ b/src/renderer/utils/ptyCreateOptions.ts
@@ -212,7 +212,15 @@ export function shouldHealSurfaceCwd({
   recoveryCwds,
 }: SurfaceCwdHealInput): boolean {
   if (!spawnedCwd) return false;
-  const normalize = (value: string) => value.replace(/[\\/]+$/, '').toLowerCase();
+  const normalize = (value: string) => {
+    let normalized = value.replace(/\\/g, '/').replace(/\/+$/, '');
+    // Match the renderer's existing cwd policy: Windows drive letters are
+    // case-insensitive, while POSIX path segments retain their case.
+    if (/^[A-Za-z]:\//.test(normalized)) {
+      normalized = normalized[0].toLowerCase() + normalized.slice(1);
+    }
+    return normalized;
+  };
   const spawned = normalize(spawnedCwd);
 
   if (recoveryCwds !== undefined) {

--- a/src/renderer/utils/ptyCreateOptions.ts
+++ b/src/renderer/utils/ptyCreateOptions.ts
@@ -50,6 +50,12 @@ export interface PtyCreateOptions {
   };
 }
 
+export interface SurfaceCwdHealInput {
+  spawnedCwd?: string;
+  requestedCwd?: string;
+  recoveryCwds?: Pick<DeadPaneRecovery, 'spawnCwd' | 'cwd'>;
+}
+
 import type { WorkspaceProfile } from '../../shared/types';
 
 const LEGACY_DEFAULT_SHELL_VALUES = new Set(['powershell', 'cmd', 'gitbash', 'wsl']);
@@ -190,6 +196,31 @@ export function resolveRespawnCwd(args: {
   if (args.surfaceCwd && args.surfaceCwd.trim().length > 0) return args.surfaceCwd;
   if (args.startupDirectory && args.startupDirectory.trim().length > 0) return args.startupDirectory.trim();
   return undefined;
+}
+
+/**
+ * Decide whether main's actual spawn cwd is safe to persist on the surface.
+ * Ordinary creates preserve the #515 policy: an explicit request must match,
+ * while an unspecified request may accept main's home/default. A known-dead
+ * replacement may persist only one of its two recovery candidates; if main
+ * rejected both and fell back to home, keeping the old surface cwd avoids
+ * turning that fallback into the next pane's apparent working directory.
+ */
+export function shouldHealSurfaceCwd({
+  spawnedCwd,
+  requestedCwd,
+  recoveryCwds,
+}: SurfaceCwdHealInput): boolean {
+  if (!spawnedCwd) return false;
+  const normalize = (value: string) => value.replace(/[\\/]+$/, '').toLowerCase();
+  const spawned = normalize(spawnedCwd);
+
+  if (recoveryCwds !== undefined) {
+    return [recoveryCwds.spawnCwd, recoveryCwds.cwd]
+      .some((candidate) => candidate !== undefined && normalize(candidate) === spawned);
+  }
+
+  return requestedCwd === undefined || normalize(requestedCwd) === spawned;
 }
 
 /**

--- a/src/shared/__tests__/ptyRecovery.test.ts
+++ b/src/shared/__tests__/ptyRecovery.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { createDeadPaneRecovery, mergeDeadPaneRecovery } from '../ptyRecovery';
+
+describe('createDeadPaneRecovery', () => {
+  it('preserves both cwd candidates for main-side validation', () => {
+    expect(createDeadPaneRecovery({ spawnCwd: 'D:\\spawn', cwd: 'D:\\live' })).toEqual({
+      spawnCwd: 'D:\\spawn',
+      cwd: 'D:\\live',
+    });
+  });
+
+  it('drops blank cwd candidates without losing recovery intent', () => {
+    expect(createDeadPaneRecovery({ spawnCwd: '  ', cwd: '' })).toEqual({});
+  });
+
+  it('derives the resume agent from a surviving binding', () => {
+    const resumeBinding = {
+      agent: 'claude' as const,
+      sessionId: 'conversation-1',
+      cwd: 'D:\\repo',
+      ts: 1,
+    };
+    expect(createDeadPaneRecovery({ resumeBinding })).toEqual({
+      resumeAgent: 'claude',
+      resumeBinding,
+    });
+  });
+
+  it('keeps an explicit resume agent when no exact binding survives', () => {
+    expect(createDeadPaneRecovery({ resumeAgent: 'codex' })).toEqual({ resumeAgent: 'codex' });
+  });
+});
+
+describe('mergeDeadPaneRecovery', () => {
+  it('keeps an unconsumed resume offer while taking newer cwd metadata', () => {
+    const resumeBinding = {
+      agent: 'claude',
+      sessionId: 'conversation-1',
+      cwd: 'D:\\repo',
+      ts: 1,
+    };
+    expect(mergeDeadPaneRecovery(
+      { spawnCwd: 'D:\\old', resumeAgent: 'claude', resumeBinding },
+      { spawnCwd: 'D:\\new', cwd: 'D:\\live' },
+    )).toEqual({
+      spawnCwd: 'D:\\new',
+      cwd: 'D:\\live',
+      resumeAgent: 'claude',
+      resumeBinding,
+    });
+  });
+});

--- a/src/shared/__tests__/ptyRecovery.test.ts
+++ b/src/shared/__tests__/ptyRecovery.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createDeadPaneRecovery, mergeDeadPaneRecovery } from '../ptyRecovery';
+import { asRecoveryAgentSlug, createDeadPaneRecovery, mergeDeadPaneRecovery } from '../ptyRecovery';
 
 describe('createDeadPaneRecovery', () => {
   it('preserves both cwd candidates for main-side validation', () => {
@@ -29,6 +29,20 @@ describe('createDeadPaneRecovery', () => {
   it('keeps an explicit resume agent when no exact binding survives', () => {
     expect(createDeadPaneRecovery({ resumeAgent: 'codex' })).toEqual({ resumeAgent: 'codex' });
   });
+
+  it('rejects unknown daemon agent values and falls back to a valid binding', () => {
+    const resumeBinding = {
+      agent: 'claude' as const,
+      sessionId: 'conversation-1',
+      cwd: 'D:\\repo',
+      ts: 1,
+    };
+    expect(asRecoveryAgentSlug('bogus')).toBeUndefined();
+    expect(createDeadPaneRecovery({ resumeAgent: 'bogus', resumeBinding })).toEqual({
+      resumeAgent: 'claude',
+      resumeBinding,
+    });
+  });
 });
 
 describe('mergeDeadPaneRecovery', () => {
@@ -44,6 +58,23 @@ describe('mergeDeadPaneRecovery', () => {
       { spawnCwd: 'D:\\new', cwd: 'D:\\live' },
     )).toEqual({
       spawnCwd: 'D:\\new',
+      cwd: 'D:\\live',
+      resumeAgent: 'claude',
+      resumeBinding,
+    });
+  });
+
+  it('keeps an unconsumed offer when incoming optional fields are explicitly undefined', () => {
+    const resumeBinding = {
+      agent: 'claude',
+      sessionId: 'conversation-1',
+      cwd: 'D:\\repo',
+      ts: 1,
+    };
+    expect(mergeDeadPaneRecovery(
+      { resumeAgent: 'claude', resumeBinding },
+      { cwd: 'D:\\live', resumeAgent: undefined, resumeBinding: undefined },
+    )).toEqual({
       cwd: 'D:\\live',
       resumeAgent: 'claude',
       resumeBinding,

--- a/src/shared/ptyRecovery.ts
+++ b/src/shared/ptyRecovery.ts
@@ -1,0 +1,75 @@
+import type { ResumeBinding } from './agentResume';
+import type { AgentSlug } from './events';
+
+/**
+ * Minimal metadata carried while a renderer surface replaces a known-dead
+ * daemon session. Both cwd candidates remain untrusted until main validates
+ * them at PTY-create time.
+ */
+export interface DeadPaneRecovery {
+  spawnCwd?: string;
+  cwd?: string;
+  resumeAgent?: AgentSlug;
+  resumeBinding?: ResumeBinding;
+}
+
+export interface DeadPaneSessionSnapshot {
+  spawnCwd?: string;
+  cwd?: string;
+  resumeAgent?: AgentSlug;
+  resumeBinding?: ResumeBinding;
+}
+
+function nonBlank(value: string | undefined): string | undefined {
+  return value && value.trim().length > 0 ? value : undefined;
+}
+
+const RECOVERY_AGENT_SLUGS: ReadonlySet<string> = new Set([
+  'claude',
+  'codex',
+  'gemini',
+  'aider',
+  'opencode',
+  'copilot',
+  'openclaude',
+  'kiro',
+]);
+
+export function asRecoveryAgentSlug(value: string | undefined): AgentSlug | undefined {
+  return value && RECOVERY_AGENT_SLUGS.has(value) ? value as AgentSlug : undefined;
+}
+
+/**
+ * Build the renderer hand-off from a daemon tombstone. A descriptor is
+ * returned even when both cwd fields are absent: its presence tells the create
+ * path this is a dead-session replacement, for which home is the final fallback
+ * instead of the workspace profile used by ordinary blank surfaces.
+ */
+export function createDeadPaneRecovery(session: DeadPaneSessionSnapshot): DeadPaneRecovery {
+  const resumeBinding = session.resumeBinding;
+  const resumeAgent = session.resumeAgent ?? asRecoveryAgentSlug(resumeBinding?.agent);
+  return {
+    ...(nonBlank(session.spawnCwd) ? { spawnCwd: session.spawnCwd } : {}),
+    ...(nonBlank(session.cwd) ? { cwd: session.cwd } : {}),
+    ...(resumeAgent ? { resumeAgent } : {}),
+    ...(resumeBinding ? { resumeBinding } : {}),
+  };
+}
+
+/** Carry a still-pending resume offer across a second replacement. */
+export function mergeDeadPaneRecovery(
+  previous: DeadPaneRecovery | undefined,
+  incoming: DeadPaneRecovery,
+): DeadPaneRecovery {
+  if (!previous) return incoming;
+  return {
+    ...previous,
+    ...incoming,
+    ...(incoming.resumeAgent ?? previous.resumeAgent
+      ? { resumeAgent: incoming.resumeAgent ?? previous.resumeAgent }
+      : {}),
+    ...(incoming.resumeBinding ?? previous.resumeBinding
+      ? { resumeBinding: incoming.resumeBinding ?? previous.resumeBinding }
+      : {}),
+  };
+}

--- a/src/shared/ptyRecovery.ts
+++ b/src/shared/ptyRecovery.ts
@@ -16,7 +16,8 @@ export interface DeadPaneRecovery {
 export interface DeadPaneSessionSnapshot {
   spawnCwd?: string;
   cwd?: string;
-  resumeAgent?: AgentSlug;
+  /** Untrusted daemon/RPC value; normalized before entering renderer state. */
+  resumeAgent?: string;
   resumeBinding?: ResumeBinding;
 }
 
@@ -24,7 +25,7 @@ function nonBlank(value: string | undefined): string | undefined {
   return value && value.trim().length > 0 ? value : undefined;
 }
 
-const RECOVERY_AGENT_SLUGS: ReadonlySet<string> = new Set([
+const RECOVERY_AGENT_SLUG_VALUES = [
   'claude',
   'codex',
   'gemini',
@@ -33,7 +34,8 @@ const RECOVERY_AGENT_SLUGS: ReadonlySet<string> = new Set([
   'copilot',
   'openclaude',
   'kiro',
-]);
+] as const satisfies readonly AgentSlug[];
+const RECOVERY_AGENT_SLUGS: ReadonlySet<string> = new Set(RECOVERY_AGENT_SLUG_VALUES);
 
 export function asRecoveryAgentSlug(value: string | undefined): AgentSlug | undefined {
   return value && RECOVERY_AGENT_SLUGS.has(value) ? value as AgentSlug : undefined;
@@ -47,7 +49,8 @@ export function asRecoveryAgentSlug(value: string | undefined): AgentSlug | unde
  */
 export function createDeadPaneRecovery(session: DeadPaneSessionSnapshot): DeadPaneRecovery {
   const resumeBinding = session.resumeBinding;
-  const resumeAgent = session.resumeAgent ?? asRecoveryAgentSlug(resumeBinding?.agent);
+  const resumeAgent = asRecoveryAgentSlug(session.resumeAgent)
+    ?? asRecoveryAgentSlug(resumeBinding?.agent);
   return {
     ...(nonBlank(session.spawnCwd) ? { spawnCwd: session.spawnCwd } : {}),
     ...(nonBlank(session.cwd) ? { cwd: session.cwd } : {}),


### PR DESCRIPTION
## Summary

- request dead-session tombstones during renderer startup reconciliation and carry their persisted recovery metadata into self-created replacements
- validate replacement cwd in main with `spawnCwd -> live cwd -> home` precedence while preserving the ordinary #515 profile-first path
- retain surviving agent resume offers across replacement PTY binding and periodic daemon hydration
- avoid persisting the home fallback as the surface cwd when both recovery candidates are invalid

Closes #650

## Verification

- `npm run test:parallel` — 663 files passed, 2 skipped; 9,735 tests passed, 27 skipped
- focused #650 suite — 9 files / 88 tests passed
- `npx tsc --noEmit` — passed
- `npx tsc -p tsconfig.daemon.json --noEmit` — passed
- targeted ESLint over the changed low-noise files — passed
- `npm run test:runtime` — 96 passed, 2 failed, 6 skipped; both failures are the existing Windows PowerShell OSC 133 cases where node-pty reports `AttachConsole failed` and then times out waiting for `command_start`

## Notes

- `pty.list` exposes dead metadata only when the renderer opts into `includeDead`; existing callers retain the live-only response.
- Main remains the authority that validates recovery paths, including filesystem races.
- Dead and suspended sessions are never exposed as live `surfaceId` rebind targets.
- Rebinds to an already-live session retain that session's own metadata; dead-session metadata is staged only for self-create.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dead panes now reopen in their original working directory when available.
  * Recovery prioritizes the previous launch directory, then the last known directory.
  * If recovery directories are unavailable, the app uses a safe fallback directory.
  * Available agent resume offers and recovery details are preserved when replacing dead panes.

* **Bug Fixes**
  * Improved handling of dead sessions during reconnection and pane replacement.
  * Prevented invalid, inaccessible, or unsupported directories from being reused during recovery.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->