### PR TITLE
refactor: remove dead approval request IPC

### DIFF
--- a/src/main/notification/DaemonNotificationRouter.ts
+++ b/src/main/notification/DaemonNotificationRouter.ts
@@ -2,7 +2,6 @@ import type { BrowserWindow } from 'electron';
 import type { DaemonClient } from '../DaemonClient';
 import type { AgentStatus } from '../../shared/types';
 import type { HookSignalRouter } from '../hooks/HookSignalRouter';
-import { IPC } from '../../shared/constants';
 import { dispatchNotification } from './dispatchNotification';
 import { clearPty as clearSuppression } from './idleSuppression';
 import { broadcastMetadataUpdate } from '../ipc/handlers/metadata.handler';
@@ -104,13 +103,6 @@ function lifecycleKindFor(ev: AgentEventPayload): AgentLifecycleKind {
   return ev.status === 'awaiting_input' ? 'agent.awaiting_input' : 'agent.stop';
 }
 
-interface CriticalEventPayload {
-  action: string;
-  riskLevel: 'review' | 'critical';
-  /** The matched PTY line. Optional: a pre-#605 daemon does not send one. */
-  matchedLine?: string;
-}
-
 /**
  * In daemon mode, PTY data flows through DaemonPTYBridge inside the daemon
  * process — main never sees raw bytes, so the local PTYBridge subscriptions
@@ -125,7 +117,6 @@ interface CriticalEventPayload {
  *   - session:active → METADATA_UPDATE (agentStatus = 'running')
  *   - session:idle → fallback NOTIFICATION, suppressed if a recent agent
  *     event already covered it
- *   - session:critical → APPROVAL_REQUEST IPC
  *   - session:died → METADATA_UPDATE (agentStatus = 'idle')
  *
  * The router does NOT reset AgentDetector emission state on 'active' the way
@@ -960,22 +951,6 @@ export class DaemonNotificationRouter {
       }
     };
 
-    const onCritical = (payload: { sessionId: string; event: unknown }) => {
-      try {
-        const win = this.getWindow();
-        if (!win || win.isDestroyed()) return;
-        const ev = payload.event as CriticalEventPayload;
-        if (!ev || typeof ev !== 'object') return;
-        win.webContents.send(IPC.APPROVAL_REQUEST, payload.sessionId, {
-          action: ev.action,
-          riskLevel: ev.riskLevel,
-          matchedLine: ev.matchedLine,
-        });
-      } catch (err) {
-        console.warn('[DaemonNotificationRouter] session:critical error:', err);
-      }
-    };
-
     // session:died (natural PTY exit) and session:destroyed (pty:dispose)
     // both clear agentStatus. Only listening to session:died left a stale
     // sidebar dot when the user closed a terminal intentionally (Codex P2).
@@ -1068,7 +1043,6 @@ export class DaemonNotificationRouter {
     this.daemonClient.on('session:agent', onAgent);
     this.daemonClient.on('session:active', onActive);
     this.daemonClient.on('session:idle', onIdle);
-    this.daemonClient.on('session:critical', onCritical);
     this.daemonClient.on('session:prompt', onPrompt);
     this.daemonClient.on('session:notification', onNotification);
     this.daemonClient.on('session:died', onSessionEnd);
@@ -1101,7 +1075,6 @@ export class DaemonNotificationRouter {
       () => this.daemonClient.off('session:agent', onAgent),
       () => this.daemonClient.off('session:active', onActive),
       () => this.daemonClient.off('session:idle', onIdle),
-      () => this.daemonClient.off('session:critical', onCritical),
       () => this.daemonClient.off('session:prompt', onPrompt),
       () => this.daemonClient.off('session:notification', onNotification),
       () => this.daemonClient.off('session:died', onSessionEnd),

--- a/src/main/pty/PTYBridge.ts
+++ b/src/main/pty/PTYBridge.ts
@@ -384,21 +384,6 @@ export class PTYBridge {
       }
     });
 
-    // Critical action detection (kept — this is precise and valuable)
-    const unsubCritical = agentDetector.onCritical((criticalEvent) => {
-      try {
-        const win = this.getWindow();
-        if (!win || win.isDestroyed()) return;
-        win.webContents.send(IPC.APPROVAL_REQUEST, ptyId, {
-          action: criticalEvent.action,
-          riskLevel: criticalEvent.riskLevel,
-          matchedLine: criticalEvent.matchedLine,
-        });
-      } catch (err) {
-        console.warn('[PTYBridge] onCritical callback error:', err);
-      }
-    });
-
     // Agent status events: emit METADATA_UPDATE (drives sidebar dot) and a
     // NOTIFICATION (drives unread badge + in-app toast + optional OS toast).
     // The 'waiting'/'complete' transition is the strong "task done" signal.
@@ -547,7 +532,6 @@ export class PTYBridge {
     });
 
     this.agentDetectorCleanups.set(ptyId, [
-      unsubCritical,
       unsubAgent,
       unsubActive,
       () => { if (resizeGuardTimer) clearTimeout(resizeGuardTimer); },

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -317,8 +317,6 @@ export const IPC = {
   // no-renderer toast fallback in dispatchNotification can honor them.
   MUTED_NOTIFICATION_CATEGORIES: 'settings:muted-notification-categories',
   AUTO_UPDATE_ENABLED: 'settings:auto-update-enabled',
-  // Agent critical action approval
-  APPROVAL_REQUEST: 'approval:request',
   // Phase 2.2 — MCP plugin permission approval (main → renderer subscribe,
   // renderer → main response). Emitted when the enforcer rejects an
   // unconfirmed plugin in enforce mode and the ApprovalQueue mints a


### PR DESCRIPTION
## Summary

Remove the dead desktop `approval:request` IPC path. Neither preload nor renderer consumes this channel, and its approval-oriented name conflates notify-only critical-output detection with the real approval registry.

## Changes

- remove `IPC.APPROVAL_REQUEST` and the local `PTYBridge` critical-event subscription
- stop `DaemonNotificationRouter` from forwarding `session:critical` to the unconsumed desktop IPC
- remove the obsolete payload type and matching cleanup entries
- leave daemon critical-event production and the web/phone SSE path unchanged

## CHANGELOG entry

No CHANGELOG — internal-only dead-code cleanup with no user-visible behavior.

## Stability tier impact

- [x] No external surface touched (internal refactor / docs / tests / CI).
- [ ] Additive change to a `stable` surface (new optional param, new field, new event type).
- [ ] Breaking change to a `stable` surface (requires major bump — block until release planning is in scope).
- [ ] Change to an `experimental` surface (note in release notes).
- [ ] Change to an `internal` surface (no contract impact).

## Substrate contract impact (Substrate 3.0)

n/a — no RPC method, EventBus type, wire shape, permission boundary, or named-pipe contract changes.

## Test plan

- `npx vitest run` over the PTYBridge and DaemonNotificationRouter suites: 9 files, 98 tests passed
- web SSE `session:critical` targeted test: passed
- `npx tsc --noEmit`: passed
- targeted ESLint for the changed main-process files: passed
- `npm run test:parallel`: 663 files, 9,735 tests passed (27 skipped)
- `npm run test:runtime`: 96 passed, 6 skipped, 2 unrelated `shellIntegration.runtime.test.ts` cases failed because `node-pty` reported `AttachConsole failed` on local Node 24.18.0; reproduced unchanged when run alone
- `npm run lint`: blocked by the existing repository-wide baseline (218 errors, 1,106 warnings); no finding is on a changed line
- `git diff --check`: passed
- repo-wide search confirms zero remaining `APPROVAL_REQUEST` / `approval:request` references

No new test was added because this PR only deletes an unconsumed path; existing wiring suites and the retained web SSE regression test cover the affected boundaries.

## Related issues / PRs

Closes #758

## Reviewer checklist

- [ ] CHANGELOG entry above is filled in or explicitly marked n/a.
- [ ] Stability tier impact is correctly classified.
- [ ] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed.
- [ ] Tests cover the new behavior and the regression case (if a bug fix).
- [ ] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed legacy approval request notifications from the application.
  * Critical session and agent actions are no longer forwarded directly to the renderer through the deprecated approval channel.
  * Existing agent status, activity, lifecycle, and notification handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->