### PR TITLE
fix(terminal): rebuild the shared glyph atlas at wake boundaries

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1363,6 +1363,13 @@ app.on('ready', async () => {
   // exploded" because the OS hadn't finished waking up.
   powerMonitor.on('resume', async () => {
     console.log('[Main] System resumed from sleep — checking PTY health');
+    // Sleep can invalidate GPU texture memory without any context-loss event
+    // firing; tell the renderer so it can rebuild the shared glyph atlas
+    // (terminal/atlasWakeRecovery.ts). Sent before the PTY health check —
+    // the visual repair must not wait on tasklist round-trips.
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send(IPC.SYSTEM_RESUMED);
+    }
     const active = ptyManager.getActiveInstances();
     if (active.length === 0) return;
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -197,6 +197,16 @@ const electronAPI = {
      * V8 JS heap (~10MB) and under-reported real usage by ~10x.
      */
     getMemoryUsage: () => ipcRenderer.invoke(IPC.APP_MEMORY) as Promise<number>,
+    /**
+     * System woke from sleep (main's powerMonitor 'resume'). Used to rebuild
+     * renderer GPU state that sleep can silently invalidate (shared glyph
+     * atlas — terminal/atlasWakeRecovery.ts). Returns the unsubscribe.
+     */
+    onResumed: (callback: () => void) => {
+      const listener = () => callback();
+      ipcRenderer.on(IPC.SYSTEM_RESUMED, listener);
+      return () => { ipcRenderer.removeListener(IPC.SYSTEM_RESUMED, listener); };
+    },
   },
   settings: {
     setToastEnabled: (enabled: boolean) => ipcRenderer.send(IPC.TOAST_ENABLED, enabled),

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -24,6 +24,7 @@ import FileTreePanel from '../FileTree/FileTreePanel';
 import ApprovalDialog from '../Company/ApprovalDialog';
 import ExecuteApprovalDialog from '../A2a/ExecuteApprovalDialog';
 import PermissionApprovalDialogContainer from '../Approval/PermissionApprovalDialogContainer';
+import { initAtlasWakeRecovery } from '../../terminal/atlasWakeRecovery';
 import CompanyView from '../Company/CompanyView';
 import MessageFeedPanel from '../Company/MessageFeedPanel';
 import OnboardingOverlay from '../Onboarding/OnboardingOverlay';
@@ -418,6 +419,20 @@ export default function AppLayout() {
       (window as any).electronAPI?.browser?.setLightweight?.(browserLightweightMode);
     } catch { /* older main without the handler — setting stays inert */ }
   }, [browserLightweightMode]);
+
+  // Wake-boundary glyph-atlas recovery — sleep can trash the shared WebGL
+  // atlas's texture content without any event or page-structure change, so
+  // atlasGuard's poll never fires. Rebuild at the wake boundaries instead.
+  // Rationale and trigger choice live in terminal/atlasWakeRecovery.ts.
+  useEffect(() => {
+    // optional-chain electronAPI — jsdom (tests) has no preload bridge; an
+    // older main without the push degrades to visibility-only recovery.
+    const onResumed = (window as any).electronAPI?.system?.onResumed;
+    return initAtlasWakeRecovery({
+      onSystemResumed:
+        typeof onResumed === 'function' ? onResumed : () => () => {},
+    });
+  }, []);
 
   // #517 slice C — discard mode mirrors the same way. Effective only while
   // lightweight mode is also on (belt-and-braces: main enforces this too).

--- a/src/renderer/terminal/__tests__/atlasGuard.test.ts
+++ b/src/renderer/terminal/__tests__/atlasGuard.test.ts
@@ -177,6 +177,28 @@ describe('atlasGuard', () => {
     expect(setCalls).toBe(2);
   });
 
+  it('recoverNow: unconditional clear + refresh-all, even with a healthy-looking pool', () => {
+    const atlas = new FakeAtlas(3, true); // far below every poll threshold
+    const guard = createAtlasGuard();
+    const a = makePane(atlas);
+    const b = makePane(atlas);
+    guard.register(a.entry);
+    guard.register(b.entry);
+    guard.recoverNow('system-resumed');
+    expect(atlas.clearCalls).toBe(1);
+    expect(a.refreshes()).toBe(1);
+    expect(b.refreshes()).toBe(1);
+    // Baseline reset: the rebuild must not read as a "merge" on the next poll
+    // and trigger a second, redundant CURE rebuild.
+    vi.advanceTimersByTime(GUARD_POLL_MS);
+    expect(atlas.clearCalls).toBe(1);
+  });
+
+  it('recoverNow with no registered panes is a no-op', () => {
+    const guard = createAtlasGuard();
+    expect(() => guard.recoverNow('visibility')).not.toThrow();
+  });
+
   it('a refresh() that throws does not break the other panes in the group', () => {
     const atlas = new FakeAtlas(PREVENT_AT, true);
     const guard = createAtlasGuard();

--- a/src/renderer/terminal/__tests__/atlasWakeRecovery.test.ts
+++ b/src/renderer/terminal/__tests__/atlasWakeRecovery.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { initAtlasWakeRecovery, WAKE_RECOVER_THROTTLE_MS } from '../atlasWakeRecovery';
+
+type Listener = () => void;
+
+function makeFakeDocument(initial: DocumentVisibilityState = 'hidden') {
+  const listeners = new Set<Listener>();
+  return {
+    visibilityState: initial,
+    addEventListener: (_type: string, cb: EventListener) => { listeners.add(cb as Listener); },
+    removeEventListener: (_type: string, cb: EventListener) => { listeners.delete(cb as Listener); },
+    show(): void {
+      this.visibilityState = 'visible';
+      for (const cb of [...listeners]) cb();
+    },
+    listenerCount: () => listeners.size,
+  };
+}
+
+function setup(nowStart = 0) {
+  let now = nowStart;
+  let resumeCb: Listener | null = null;
+  let unsubscribed = 0;
+  const recovered: string[] = [];
+  const doc = makeFakeDocument();
+  const teardown = initAtlasWakeRecovery({
+    onSystemResumed: (cb) => {
+      resumeCb = cb;
+      return () => { unsubscribed++; };
+    },
+    recoverNow: (reason) => recovered.push(reason),
+    documentRef: doc,
+    now: () => now,
+  });
+  return {
+    doc,
+    recovered,
+    teardown,
+    fireResume: () => resumeCb?.(),
+    unsubscribes: () => unsubscribed,
+    advance: (ms: number) => { now += ms; },
+  };
+}
+
+describe('atlasWakeRecovery', () => {
+  it('rebuilds once when resume and visibility fire together (real wake), again after the throttle', () => {
+    const s = setup();
+    // A real wake: powerMonitor resume and visibilitychange land within ms.
+    s.fireResume();
+    s.doc.show();
+    expect(s.recovered).toEqual(['system-resumed']); // second trigger throttled
+    // Next wake, past the throttle window → recovers again.
+    s.advance(WAKE_RECOVER_THROTTLE_MS);
+    s.fireResume();
+    expect(s.recovered).toEqual(['system-resumed', 'system-resumed']);
+  });
+
+  it('visibility trigger only fires on becoming visible; teardown detaches both triggers', () => {
+    const s = setup();
+    s.doc.visibilityState = 'hidden';
+    s.doc.show();
+    expect(s.recovered).toEqual(['visibility']);
+    s.teardown();
+    expect(s.unsubscribes()).toBe(1);
+    s.advance(WAKE_RECOVER_THROTTLE_MS);
+    s.doc.show();
+    expect(s.recovered).toEqual(['visibility']); // detached — no further recovery
+  });
+});

--- a/src/renderer/terminal/atlasGuard.ts
+++ b/src/renderer/terminal/atlasGuard.ts
@@ -89,6 +89,16 @@ export interface AtlasGuard {
   /** Register a pane; returns its unregister function. The poll timer runs
    *  only while at least one pane is registered. */
   register(entry: AtlasGuardEntry): () => void;
+  /**
+   * Unconditional coherent rebuild: clear every shared atlas and refresh all
+   * of its owner panes in the same tick. For recovery boundaries the poll
+   * cannot see — sleep→wake can trash atlas TEXTURE CONTENT while the page
+   * structures the poll reads stay perfectly consistent, so PREVENT/CURE
+   * never fire. (Boundary-driven rebuild pattern borrowed from Orca's
+   * wake-recovery design — idea only, no code:
+   * github.com/stablyai/orca pane-webgl-renderer.ts.)
+   */
+  recoverNow(reason: string): void;
 }
 
 export function createAtlasGuard(options: AtlasGuardOptions = {}): AtlasGuard {
@@ -106,10 +116,10 @@ export function createAtlasGuard(options: AtlasGuardOptions = {}): AtlasGuard {
   const prevPageCount = new WeakMap<object, number>();
   let timer: ReturnType<typeof setInterval> | null = null;
 
-  function tick(): void {
-    // Group live panes by shared atlas identity so clear+refresh covers every
-    // owner in the same tick (the whole point — no pane may keep sampling a
-    // rebuilt atlas with stale references).
+  // Group live panes by shared atlas identity so clear+refresh covers every
+  // owner in the same tick (the whole point — no pane may keep sampling a
+  // rebuilt atlas with stale references).
+  function groupByAtlas(): Map<AtlasLike, AtlasGuardEntry[]> {
     const groups = new Map<AtlasLike, AtlasGuardEntry[]>();
     for (const entry of entries) {
       const atlas = extractAtlas(entry.getAddon());
@@ -118,6 +128,28 @@ export function createAtlasGuard(options: AtlasGuardOptions = {}): AtlasGuard {
       if (group) group.push(entry);
       else groups.set(atlas, [entry]);
     }
+    return groups;
+  }
+
+  // The coherent rebuild both PREVENT/CURE and recoverNow perform: empty the
+  // shared atlas, then re-raster every owner pane in the same tick.
+  function rebuildGroup(atlas: AtlasLike, group: AtlasGuardEntry[]): void {
+    try {
+      atlas.clearTexture?.(); // shared — one call empties it for every owner
+    } catch {
+      // atlas mid-teardown; refresh below is still harmless
+    }
+    for (const entry of group) {
+      try {
+        entry.refresh();
+      } catch {
+        // pane may be disposing — the next tick simply won't see it
+      }
+    }
+  }
+
+  function tick(): void {
+    const groups = groupByAtlas();
 
     for (const [atlas, group] of groups) {
       const pages = atlas.pages;
@@ -145,18 +177,7 @@ export function createAtlasGuard(options: AtlasGuardOptions = {}): AtlasGuard {
       console.warn(
         `[wmux:atlas-guard] ${merged ? 'cure (merge detected)' : 'prevent'} — pages=${len}/${mergeTrigger}, panes=${group.length}`,
       );
-      try {
-        atlas.clearTexture?.(); // shared — one call empties it for every owner
-      } catch {
-        // atlas mid-teardown; refresh below is still harmless
-      }
-      for (const entry of group) {
-        try {
-          entry.refresh();
-        } catch {
-          // pane may be disposing — the next tick simply won't see it
-        }
-      }
+      rebuildGroup(atlas, group);
     }
   }
 
@@ -171,6 +192,18 @@ export function createAtlasGuard(options: AtlasGuardOptions = {}): AtlasGuard {
           timer = null;
         }
       };
+    },
+    recoverNow(reason: string): void {
+      const groups = groupByAtlas();
+      if (groups.size === 0) return;
+      console.warn(`[wmux:atlas-guard] recover (${reason}) — atlases=${groups.size}`);
+      for (const [atlas, group] of groups) {
+        // Reset the poll's merge-detection baseline: the rebuild empties the
+        // page pool, and a stale prev count would read that as a "merge" and
+        // trigger a second, redundant rebuild on the next tick.
+        prevPageCount.delete(atlas as object);
+        rebuildGroup(atlas, group);
+      }
     },
   };
 }

--- a/src/renderer/terminal/atlasWakeRecovery.ts
+++ b/src/renderer/terminal/atlasWakeRecovery.ts
@@ -1,0 +1,79 @@
+// Wake-boundary glyph-atlas recovery — the corruption class atlasGuard's poll
+// cannot see.
+//
+// atlasGuard (#741) watches the shared atlas's PAGE STRUCTURES (count, fill)
+// and repairs the page-merge corruption class. But macOS sleep→wake can trash
+// the atlas's TEXTURE CONTENT on the GPU without firing webglcontextlost and
+// without touching any page structure the poll reads: every pane then samples
+// garbage pixels for perfectly consistent-looking pages, and no existing
+// repair path fires (refresh() re-rasters from the same corrupted texture;
+// PREVENT/CURE see nothing wrong). Observed in the field on v3.38.4, which
+// already ships #741 — this module covers the residual class.
+//
+// Strategy (boundary-driven rebuild, adapted from Orca's wake-recovery design
+// — idea only, no code imported; github.com/stablyai/orca,
+// use-terminal-window-wake-recovery.ts): at the moments GPU state is suspect,
+// unconditionally rebuild the shared atlas via atlasGuard.recoverNow — the
+// same coherent clear+refresh-all PREVENT/CURE performs, so the #191
+// stale-sibling hazard cannot occur.
+//
+// Triggers:
+//   - system resume  — main's powerMonitor 'resume' over IPC. The decisive
+//                      signal: texture memory is invalidated by sleep.
+//   - visibility     — document became visible again. Backstop for the
+//                      unlock-screen gap where the resume event can land
+//                      while the window is still hidden and Chromium may
+//                      re-jig GPU memory before first present.
+//
+// Window FOCUS is deliberately NOT a trigger: plain refocus (alt-tab) is
+// frequent and often lands mid-stream, and wiping the shared atlas while
+// output is flowing re-arms xterm's page-merge race (xterm.js #4480) — the
+// same reason glyphRepaint's focus path never touches the atlas.
+//
+// The two triggers routinely fire together on a real wake; the throttle
+// collapses them into one rebuild.
+
+import { atlasGuard } from './atlasGuard';
+
+/** Minimum gap between rebuilds. Resume + visibilitychange arrive within
+ *  milliseconds of each other on a real wake; one rebuild covers both. */
+export const WAKE_RECOVER_THROTTLE_MS = 1_000;
+
+export interface AtlasWakeRecoveryDeps {
+  /** Subscribe to main's system-resumed push; returns the unsubscribe. */
+  onSystemResumed(callback: () => void): () => void;
+  recoverNow?: (reason: string) => void;
+  documentRef?: Pick<Document, 'addEventListener' | 'removeEventListener'> & {
+    visibilityState: DocumentVisibilityState;
+  };
+  now?: () => number;
+}
+
+/** Wire the wake triggers; returns the teardown. Called once from App. */
+export function initAtlasWakeRecovery(deps: AtlasWakeRecoveryDeps): () => void {
+  const {
+    onSystemResumed,
+    recoverNow = (reason) => atlasGuard.recoverNow(reason),
+    documentRef = document,
+    now = Date.now,
+  } = deps;
+
+  let lastRecoverAt = -Infinity;
+  const recover = (reason: string): void => {
+    const t = now();
+    if (t - lastRecoverAt < WAKE_RECOVER_THROTTLE_MS) return;
+    lastRecoverAt = t;
+    recoverNow(reason);
+  };
+
+  const unsubscribeResumed = onSystemResumed(() => recover('system-resumed'));
+  const onVisibilityChange = (): void => {
+    if (documentRef.visibilityState === 'visible') recover('visibility');
+  };
+  documentRef.addEventListener('visibilitychange', onVisibilityChange);
+
+  return () => {
+    unsubscribeResumed();
+    documentRef.removeEventListener('visibilitychange', onVisibilityChange);
+  };
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -304,6 +304,10 @@ export const IPC = {
   CLIPBOARD_READ_IMAGE: 'clipboard:read-image',
   CLIPBOARD_HAS_IMAGE: 'clipboard:has-image',
   SYSTEM_BUILTIN_DISPLAY: 'system:builtin-display',
+  // Fired by main's powerMonitor 'resume' so the renderer can rebuild GPU
+  // state that sleep may have invalidated (shared glyph atlas — see
+  // terminal/atlasWakeRecovery.ts).
+  SYSTEM_RESUMED: 'system:resumed',
   // Phase 4: Auto updater
   UPDATE_CHECK: 'update:check',
   UPDATE_AVAILABLE: 'update:available',


### PR DESCRIPTION
## Problem

The #741 atlas guard repairs the page-merge corruption class by watching the shared atlas's page structures. But the corruption reported on v3.38.4 — which already ships #741 — persists: sleep can invalidate the atlas's texture content on the GPU without firing `webglcontextlost` and without changing any page structure the poll reads. Every pane then samples garbage pixels from perfectly consistent-looking pages, and neither PREVENT nor CURE ever fires.

## Fix

Rebuild the shared atlas unconditionally at the boundaries where GPU state is suspect, reusing #741's coherent clear+refresh-all (`atlasGuard.recoverNow`) so the #191 stale-sibling hazard cannot occur:

- **System resume** — main's `powerMonitor 'resume'` pushed to the renderer over a new `system:resumed` IPC channel, sent before the PTY health check so the visual repair does not wait on tasklist round-trips.
- **Document visibility return** — backstop for the unlock-screen gap where the resume event can land while the window is still hidden.

Window **focus is deliberately not a trigger**: refocus is frequent and often lands mid-stream, and wiping the shared atlas while output flows re-arms xterm's page-merge race (xterm.js #4480) — the same reason the glyph-repaint focus path never touches the atlas. The two wake triggers routinely fire together on a real wake; a 1s throttle collapses them into one rebuild.

The boundary-driven rebuild pattern is adapted from Orca's wake-recovery design (idea only — no code imported; attribution in the module header).

## Tests

- `atlasGuard`: `recoverNow` performs an unconditional clear + refresh-all across every owner pane and resets the merge-detection baseline so the rebuild is not misread as a merge on the next poll; no-op with no registered panes.
- `atlasWakeRecovery`: resume + visibility firing together (a real wake) collapse into one rebuild; visibility only triggers on becoming visible; teardown detaches both triggers.
- Full `src/renderer/terminal` suite: 192 passing. `tsc --noEmit` clean.