### PR TITLE
Hand PTY size to the phone when the desk is not looking

### DIFF
--- a/changelog.d/769.md
+++ b/changelog.d/769.md
@@ -1,0 +1,11 @@
+### Changed
+
+- **A phone can reshape a pane the desk holds but is not looking at.** `POST
+  /api/sessions/<id>/resize` used to answer `409 desk-owns-size` for every
+  attached pane, and every live pane is attached while the Mac app is open —
+  so the phone always rendered a desk-shaped (151×47-ish) pane letterboxed on
+  a portrait screen. Ownership is now visibility-based: the renderer reports
+  whether a pane is actually on screen (workspace + tab active, window not
+  minimized or occluded), and the 409 is reserved for panes somebody is
+  actually watching. The desk silently takes the size back on the next
+  attach or reveal. (#769)

--- a/docs/phone-client-contract.md
+++ b/docs/phone-client-contract.md
@@ -291,7 +291,7 @@ app-owned conversation history. Without `--allow-input`, send neither; never
 forward generic taps or drags, guess a mouse protocol, or pretend the alternate
 buffer is locally scrollable.
 
-### Resizing a pane — the desk owns the size whenever it is attached
+### Resizing a pane — the desk owns the size while it is actually showing it
 
 ```
 POST /api/sessions/<id>/resize   body: {cols, rows}
@@ -309,13 +309,21 @@ only thing that can fix it.
 
 **Ownership.** There is one PTY behind both views and it can have one geometry.
 While a desk renderer has the pane wired (`state: 'attached'` in
-`/api/sessions`), that geometry is the desk's: the 409 carries the current
-`cols`/`rows` so you can render to them without a second request. A `detached`
-pane takes your numbers. You do not have to hand ownership back — a desk client
-re-derives its geometry from its own bounds and resizes on attach.
+`/api/sessions`) **and is actually showing it** — the pane's workspace and tab
+are active and the window itself is visible — that geometry is the desk's: the
+409 carries the current `cols`/`rows` so you can render to them without a
+second request. A `detached` pane takes your numbers, and so does an attached
+pane the desk is not looking at (background workspace, inactive tab, minimized
+window): nobody is watching the layout your numbers would break. You cannot see
+the desk's visibility in `/api/sessions` — the probe is the request itself. You
+do not have to hand ownership back — a desk client re-derives its geometry from
+its own bounds and resizes on attach and on every reveal, silently taking the
+size back the moment somebody looks.
 
-Do not treat the 409 as an error to retry. It is the answer: render at the size
-it names, and try again after the pane's `state` goes `detached`.
+Do not treat the 409 as an error to retry in a loop. It is the answer: render
+at the size it names. A fresh attempt is reasonable when something on YOUR side
+changed (the pane was reopened, your viewport rotated) — the desk may have
+stopped looking since.
 
 **Render at the geometry in the 200, not at the one you asked for.** The daemon
 answers with what it stored, which is not promised to equal the request.

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -77,6 +77,20 @@ export interface ManagedSession {
    * `false` for the rest of the session's lifetime.
    */
   deferred: boolean;
+  /**
+   * #766 — whether a desk renderer is actually SHOWING this pane (workspace +
+   * tab active and the window itself visible), as last reported by the
+   * renderer. Orthogonal to `meta.state`: an attached pane in a background
+   * workspace stays 'attached' but is not visible. Consumed only by the phone
+   * resize route — `attached && viewerVisible` keeps the desk's ownership of
+   * the PTY geometry; attached-but-hidden lets the phone reshape the pane.
+   *
+   * Defaults to true and is reset to true on detach (not attach — the
+   * renderer's mount-time report can land before its attach RPC): a renderer
+   * that never reports (older build) behaves exactly as before #766, and a
+   * renderer that does report sends the real value on mount and every flip.
+   */
+  viewerVisible: boolean;
 }
 
 /**
@@ -495,6 +509,7 @@ export class DaemonSessionManager extends EventEmitter {
       bridge,
       promptLog,
       deferred,
+      viewerVisible: true,
     };
     this.sessions.set(params.id, managed);
 
@@ -718,12 +733,34 @@ export class DaemonSessionManager extends EventEmitter {
     this.emit('session:stateChanged', { id, state: 'attached' as DaemonSessionState });
   }
 
+  /**
+   * #766 — record whether the desk renderer is actually showing this pane.
+   * Fire-and-forget from the renderer's point of view, so unknown ids are
+   * ignored rather than thrown: the report can race a dispose, and there is
+   * nothing the caller would do with the error. No state event — visibility
+   * is not part of the attach/detach lifecycle, and the only consumer
+   * (the phone resize route) reads it at request time.
+   */
+  setSessionViewerVisibility(id: string, visible: boolean): void {
+    const managed = this.sessions.get(id);
+    if (!managed) return;
+    managed.viewerVisible = visible;
+  }
+
   detachSession(id: string): void {
     const managed = this.sessions.get(id);
     if (!managed) throw new Error(`Session '${id}' not found`);
     if (managed.meta.state === 'dead') throw new Error(`Session '${id}' is dead`);
 
     managed.meta.state = 'detached';
+    // #766 — conservative reset on DETACH, deliberately not on attach: the
+    // renderer's mount-time visibility report can land before its attach RPC,
+    // and an attach-time reset would overwrite a fresh "hidden" with the
+    // default. Resetting here instead means the next attacher starts at the
+    // safe default (desk owns the size) — an older renderer that never
+    // reports keeps pre-#766 behavior, a current one re-reports on mount and
+    // on every flip.
+    managed.viewerVisible = true;
     this.emit('session:stateChanged', { id, state: 'detached' as DaemonSessionState });
   }
 

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -389,6 +389,30 @@ describe('DaemonSessionManager', () => {
     expect(sessions[0].state).toBe('detached');
   });
 
+  // #766 — viewer visibility: renderer-reported "is this pane on screen",
+  // consumed by the phone resize route (attached && viewerVisible → 409).
+  it('records viewer visibility and resets it to visible on detach, not attach', () => {
+    manager.createSession({ id: 'vis', cmd: 'cmd.exe', cwd: '.' });
+    // Safe default: nobody has reported, so the desk owns the size.
+    expect(manager.getSession('vis')?.viewerVisible).toBe(true);
+
+    // The mount-time report can land BEFORE the attach RPC — attach must not
+    // overwrite it (that would mark every hidden retained pane visible).
+    manager.setSessionViewerVisibility('vis', false);
+    manager.attachSession('vis');
+    expect(manager.getSession('vis')?.viewerVisible).toBe(false);
+
+    // Detach resets to the safe default so the next attacher — possibly an
+    // older renderer that never reports — starts with the desk owning.
+    manager.detachSession('vis');
+    expect(manager.getSession('vis')?.viewerVisible).toBe(true);
+  });
+
+  it('ignores a visibility report for an unknown session', () => {
+    // Fire-and-forget path: the report can race a dispose.
+    expect(() => manager.setSessionViewerVisibility('nope', false)).not.toThrow();
+  });
+
   // 5. destroySession → session removed
   it('destroys a session and removes it from the list', () => {
     manager.createSession({ id: 'kill', cmd: 'cmd.exe', cwd: '.' });

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1923,6 +1923,20 @@ function registerRpcHandlers(
     return { ok: true };
   });
 
+  // daemon.setSessionViewerVisibility (#766) — the renderer's "is this pane
+  // actually on screen" report. Not persisted and not a lifecycle event: the
+  // flag lives on the managed session and is read at request time by the
+  // phone resize route. Unknown ids are a no-op (the report can race a
+  // dispose), matching the fire-and-forget relay in pty.handler.
+  pipeServer.onRpc('daemon.setSessionViewerVisibility', async (params) => {
+    const p = params as unknown as { id: string; visible: boolean };
+    if (typeof p.id !== 'string' || typeof p.visible !== 'boolean') {
+      throw new Error('setSessionViewerVisibility: id (string) and visible (boolean) are required');
+    }
+    sessionManager.setSessionViewerVisibility(p.id, p.visible);
+    return { ok: true };
+  });
+
   // daemon.resyncSession (phase 3 PR-B) — re-run the flush sequence on the
   // live, already-connected session pipe: RESYNC_BEGIN marker → headless
   // snapshot (or raw-replay degrade) → FLUSH_DONE marker. The socket is never

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -1557,11 +1557,18 @@ export class WebTerminalServer {
    * policy but a fight: the phone resizes, the desk's next frame resizes back,
    * and the PTY thrashes between two geometries while both views redraw.
    *
-   * So: `attached` (a desk renderer has this pane wired) → `409 desk-owns-size`,
-   * carrying the current geometry so the caller can render to it without a
-   * second request. `detached` → the phone's numbers are applied. A pane that
-   * the desk later attaches resizes itself on mount, so ownership returns
-   * without anything here having to take it back.
+   * So (#766, visibility-based ownership): `attached` AND VISIBLE — a desk
+   * renderer has this pane wired and is actually showing it (workspace + tab
+   * active, window not hidden; `ManagedSession.viewerVisible`, reported by the
+   * renderer) → `409 desk-owns-size`, carrying the current geometry so the
+   * caller can render to it without a second request. `detached`, or attached
+   * but not visible (background workspace, inactive tab, minimized window) →
+   * the phone's numbers are applied: nobody is looking at the layout the
+   * phone would break, so the fight the paragraph above describes cannot
+   * start — the hidden renderer's fit is silent (zero-size container guard)
+   * until the pane is revealed again. A pane the desk attaches or reveals
+   * re-fits itself and resizes unconditionally, so ownership returns without
+   * anything here having to take it back.
    *
    * NOT GATED ON `--allow-input`, on the same reasoning as
    * `GET /api/sessions/:id/diff` and `POST /api/approvals/:id`: this delivers a
@@ -1601,7 +1608,7 @@ export class WebTerminalServer {
       // by the desk in between.
       const current = this.deps.sessionManager.getSession(id);
       if (!current) return this.json(res, 404, { error: 'session not found' });
-      if (current.meta.state === 'attached') {
+      if (current.meta.state === 'attached' && current.viewerVisible) {
         return this.json(res, 409, {
           error: 'desk-owns-size',
           cols: current.meta.cols,

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -35,6 +35,9 @@ function makeDeps() {
     // A session recovered from a reboot that has not had its first resize yet.
     // The resize route refuses it — that first resize is the desk's unmute.
     deferred: false,
+    // #766 — the desk is showing the pane unless a test flips this; the
+    // resize route only honors 'attached' when this is also true.
+    viewerVisible: true,
     ringBuffer: { readAll: () => Buffer.from('screen-bytes') },
     bridge,
     ptyProcess: { write },
@@ -341,7 +344,7 @@ describe('WebTerminalServer', () => {
   let gitCalls: Array<{ args: readonly string[]; cwd: string }>;
   let gitScript: Record<string, { ok: boolean; stdout: string; stderr: string; ran?: boolean }>;
   let gitGate: { hold: Promise<void> | null };
-  let managed: { meta: Record<string, unknown>; deferred: boolean };
+  let managed: { meta: Record<string, unknown>; deferred: boolean; viewerVisible: boolean };
   let live: ReturnType<typeof makeDeps>['live'];
   let uploadsDir: string;
 
@@ -2614,6 +2617,18 @@ describe('WebTerminalServer', () => {
       owner: 'desk',
     });
     expect(resizeCalls).toEqual([]);
+  });
+
+  it('★ hands the size to the phone when the desk holds the pane but is not showing it (#766)', async () => {
+    const token = (await startRO()).token as string;
+    // s2 is attached, but the renderer reported the pane off screen
+    // (background workspace / inactive tab / minimized window). Nobody is
+    // looking at the layout the phone would break, so its numbers apply.
+    managed.viewerVisible = false;
+    const res = await postResize('s2', token, { cols: 60, rows: 30 });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ cols: 60, rows: 30, owner: 'caller' });
+    expect(resizeCalls).toEqual([{ id: 's2', cols: 60, rows: 30 }]);
   });
 
   it('★ reports the record, never the request', async () => {

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -736,6 +736,22 @@ export function registerPTYHandlers(
     }));
   }
 
+  // pty:setViewerVisibility (#766)
+  // Fire-and-forget relay of the renderer's "is this pane actually on screen"
+  // report. Daemon mode only — the flag exists solely so the phone resize
+  // route (`POST /api/sessions/:id/resize`) can distinguish an attached pane
+  // the desk is watching from one it merely holds; local mode has no phone.
+  // Errors are swallowed: a not-found session means the report raced a
+  // dispose, and a lost report self-heals on the next visibility flip (the
+  // daemon also resets the flag to visible on detach).
+  ipcMain.removeAllListeners(IPC.PTY_SET_VIEWER_VISIBILITY);
+  if (useDaemon && daemonClient) {
+    ipcMain.on(IPC.PTY_SET_VIEWER_VISIBILITY, (_event: Electron.IpcMainEvent, id: string, visible: boolean) => {
+      if (typeof id !== 'string' || typeof visible !== 'boolean') return;
+      daemonClient.rpc('daemon.setSessionViewerVisibility', { id, visible }).catch(() => undefined);
+    });
+  }
+
   // pty:dispose
   ipcMain.removeHandler(IPC.PTY_DISPOSE);
   if (useDaemon && daemonClient) {
@@ -1247,6 +1263,7 @@ export function registerPTYHandlers(
     ipcMain.removeHandler(IPC.PTY_CREATE);
     ipcMain.removeAllListeners(IPC.PTY_WRITE);
     ipcMain.removeHandler(IPC.PTY_RESIZE);
+    ipcMain.removeAllListeners(IPC.PTY_SET_VIEWER_VISIBILITY);
     ipcMain.removeHandler(IPC.PTY_DISPOSE);
     ipcMain.removeHandler(IPC.PTY_LIST);
     ipcMain.removeHandler(IPC.PTY_PROMOTE);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -55,6 +55,12 @@ const electronAPI = {
     },
     resize: (id: string, cols: number, rows: number) =>
       ipcRenderer.invoke(IPC.PTY_RESIZE, id, cols, rows),
+    // #766 — fire-and-forget visibility report (send, not invoke: the renderer
+    // has nothing useful to do with an ack, and a lost report self-heals on
+    // the next visibility flip or the daemon's detach-time reset).
+    setViewerVisibility: (id: string, visible: boolean) => {
+      ipcRenderer.send(IPC.PTY_SET_VIEWER_VISIBILITY, id, visible);
+    },
     dispose: (id: string) =>
       ipcRenderer.invoke(IPC.PTY_DISPOSE, id),
     // `supervision` (X8) is additive and present only on supervised daemon-mode

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback, useState } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebglAddon } from '@xterm/addon-webgl';
@@ -2404,6 +2404,40 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       }
     }
   }, [isVisible, fit, startResync]);
+
+  // #766 — visibility-based size ownership. Report to the daemon whether this
+  // pane is actually on screen: `isVisible` (workspace shown + active tab) AND
+  // the window itself visible (`document.visibilityState` — minimized, fully
+  // occluded, or hidden windows report 'hidden'). While the report says
+  // hidden, the daemon lets a phone reshape the PTY; while it says visible,
+  // the phone gets `409 desk-owns-size` as before.
+  const [docVisible, setDocVisible] = useState(() => document.visibilityState === 'visible');
+  useEffect(() => {
+    const onChange = () => setDocVisible(document.visibilityState === 'visible');
+    document.addEventListener('visibilitychange', onChange);
+    return () => document.removeEventListener('visibilitychange', onChange);
+  }, []);
+  const effectiveVisible = isVisible && docVisible;
+  const prevDocVisibleRef = useRef(docVisible);
+  useEffect(() => {
+    // Optional-chain style guard, as at resync above: a stale preload
+    // (packaged app updated under a running renderer) may not expose it yet.
+    if (ptyId && typeof window.electronAPI.pty.setViewerVisibility === 'function') {
+      // Fire-and-forget: local mode ignores it, and a report lost to a race
+      // is corrected by the next flip or the detach-time reset to visible.
+      window.electronAPI.pty.setViewerVisibility(ptyId, effectiveVisible);
+    }
+    // Reclaim on window-level reveal. Workspace/tab reveals re-fit via the
+    // visibility effect above, but a restored window's container never
+    // changed size, so no ResizeObserver tick fires — if a phone reshaped
+    // the PTY while the window was hidden, nothing would take the size back.
+    // fit() resizes unconditionally (no last-sent dedup), and the daemon
+    // drops the SIGWINCH when the geometry is already ours, so this is free
+    // when nothing changed.
+    const docRevealed = docVisible && !prevDocVisibleRef.current;
+    prevDocVisibleRef.current = docVisible;
+    if (docRevealed && isVisible) fit();
+  }, [ptyId, effectiveVisible, docVisible, isVisible, fit]);
 
   const getSearchDecorations = useCallback(() => {
     const y = getComputedStyle(document.documentElement).getPropertyValue('--accent-yellow').trim();

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -3,6 +3,11 @@ export const IPC = {
   PTY_CREATE: 'pty:create',
   PTY_WRITE: 'pty:write',
   PTY_RESIZE: 'pty:resize',
+  // #766 visibility-based size ownership. Renderer → main fire-and-forget:
+  // reports whether a pane is actually on screen (workspace + tab active AND
+  // the window itself visible). Forwarded to the daemon so the phone resize
+  // route can tell "attached and watched" from "attached but nobody looking".
+  PTY_SET_VIEWER_VISIBILITY: 'pty:setViewerVisibility',
   PTY_DISPOSE: 'pty:dispose',
   PTY_DATA: 'pty:data',
   PTY_EXIT: 'pty:exit',


### PR DESCRIPTION
## Problem

`POST /api/sessions/:id/resize` exists so a phone can reflow a pane to its own viewport, but on a live install it never fires: every session the Mac app holds open is `attached`, so the route answers `409 desk-owns-size` without exception. A 151×47 desk pane rendered width-fit on a 402×559 portrait viewport wastes nearly half the screen (#766).

Simply dropping the 409 would start the fight the route's own comment warns about: the desk re-derives its geometry on every layout pass, so "last writer wins" is a PTY thrashing between two shapes.

## Change — visibility-based ownership

Only one side re-asserts its shape at any moment, so there is no fight to referee:

- **Renderer** reports whether a pane is actually on screen — workspace shown, tab active (`isVisible`, already computed by `Terminal.tsx`), AND the window itself visible (`document.visibilityState`, which covers minimize and full occlusion). Fire-and-forget `pty:setViewerVisibility` IPC → new `daemon.setSessionViewerVisibility` RPC. A hidden pane's own fit was already silent (zero-size container guard), so a hidden desk cannot resize back.
- **Daemon** (`handleSessionResize`) answers `409 desk-owns-size` only for `attached && viewerVisible`. Attached-but-hidden takes the phone's numbers. The deferred-pane unmute handshake and the 250 ms rate limit are unchanged and still checked after ownership.
- **Reclaim** is the existing mount/reveal fit, which resizes unconditionally. One new case: restoring a minimized window fires no ResizeObserver tick (the container never changed size), so the visibility effect re-runs `fit()` on document reveal — the desk silently takes the size back the moment somebody looks.

### The one ordering decision worth reviewing

The flag resets to visible on **detach**, deliberately not attach. The renderer's mount-time visibility report can land before its attach RPC completes; an attach-time reset would overwrite a fresh "hidden" with the default and permanently mark every hidden retained pane as visible. Resetting on detach means the next attacher starts at the safe default (desk owns), and a current renderer re-reports on mount and on every flip.

### Compatibility

- Older renderer that never reports: flag stays `true` → pre-#766 behavior exactly (always 409 while attached).
- Older daemon: the RPC is unknown → error swallowed by the fire-and-forget relay; phone behavior unchanged.
- Contract doc (`docs/phone-client-contract.md`) resize section updated: visibility is not observable in `/api/sessions` — the probe is the request itself; desk and phone both watching stays 409 with the existing fit+scale fallback.

## Tests

- `DaemonSessionManager`: default-visible, report survives attach, detach resets, unknown-id report is a no-op.
- `WebTerminalServer`: attached-but-hidden pane hands the size to the phone (200 with applied geometry); attached-and-visible still 409.

## Verification

- `tsc --noEmit` (main + daemon tsconfigs) clean
- eslint on touched files: error count identical to baseline
- full `test:parallel` suite: 9744 passed
