### PR TITLE
fix(approvals): expire pending requests when user answers locally

### DIFF
--- a/integrations/claude/bin/wmux-bridge.mjs
+++ b/integrations/claude/bin/wmux-bridge.mjs
@@ -87,6 +87,15 @@ const HOOK_TO_KIND = {
   UserPromptSubmit: 'agent.user_prompt_submit',
 };
 
+// Determine signal kind for PostToolUse: if it's AskUserQuestion, treat as
+// input_answered (user answered locally); otherwise as activity.
+function getPostToolUseKind(payload) {
+  if (payload && payload.tool_name === 'AskUserQuestion') {
+    return 'agent.input_answered';
+  }
+  return 'agent.activity';
+}
+
 // ----- Path helpers (Node built-ins only) ---------------------------------
 
 // Instance suffix ('' in production, '-dev' under a dev build). PTY spawn
@@ -819,8 +828,11 @@ async function main() {
   // Build the AgentSignal envelope. Schema mirrors
   // integrations/shared/signal-types.ts (kept in sync manually because
   // this is JS-only).
+  const kind = hookName === 'PostToolUse'
+    ? getPostToolUseKind(payload)
+    : HOOK_TO_KIND[hookName];
   const envelope = {
-    kind: HOOK_TO_KIND[hookName],
+    kind,
     agent: 'claude',
     // #12235-safe: derive from the transcript filename, NOT payload.session_id.
     agentSessionId: sessionIdFromTranscript(

--- a/integrations/claude/bin/wmux-bridge.mjs
+++ b/integrations/claude/bin/wmux-bridge.mjs
@@ -87,10 +87,11 @@ const HOOK_TO_KIND = {
   UserPromptSubmit: 'agent.user_prompt_submit',
 };
 
-// Determine signal kind for PostToolUse: if it's AskUserQuestion, treat as
-// input_answered (user answered locally); otherwise as activity.
+// Determine signal kind for PostToolUse: if it's AskUserQuestion that fired
+// (completed), treat as input_answered (user answered locally); otherwise as
+// activity. Fired is true only on PostToolUse — PreToolUse never sets it.
 function getPostToolUseKind(payload) {
-  if (payload && payload.tool_name === 'AskUserQuestion') {
+  if (payload && payload.tool_name === 'AskUserQuestion' && payload.fired) {
     return 'agent.input_answered';
   }
   return 'agent.activity';
@@ -743,13 +744,18 @@ async function main() {
   // session id, else by cwd — the same identity the server routes on, so
   // suppression maps 1:1 to what the server would have dropped. Skips are
   // deliberately NOT logged: at N sessions × M subagents the skip volume is
-  // exactly the churn this throttle exists to remove.
+  // exactly the churn this throttle exists to remove. Input-answered signals
+  // (AskUserQuestion completion) must never be throttled — a delayed/dropped
+  // signal leaves the phone with a pending approval the user already answered.
   if (hookName === 'PostToolUse') {
-    const throttleKey = process.env.WMUX_PTY_ID
-      || (payload && typeof payload.session_id === 'string' && payload.session_id)
-      || (payload && typeof payload.cwd === 'string' && payload.cwd)
-      || process.cwd();
-    if (shouldThrottleActivity(throttleKey)) return;
+    const kind = getPostToolUseKind(payload);
+    if (kind === 'agent.activity') {
+      const throttleKey = process.env.WMUX_PTY_ID
+        || (payload && typeof payload.session_id === 'string' && payload.session_id)
+        || (payload && typeof payload.cwd === 'string' && payload.cwd)
+        || process.cwd();
+      if (shouldThrottleActivity(throttleKey)) return;
+    }
   }
 
   // Endpoints to try, daemon first (see resolveTargets). No token for either

--- a/integrations/shared/__tests__/signal-types.test.ts
+++ b/integrations/shared/__tests__/signal-types.test.ts
@@ -24,6 +24,7 @@ describe('isAgentSignal', () => {
     'agent.subagent_stop',
     'agent.session_start',
     'agent.awaiting_input',
+    'agent.input_answered',
   ])('accepts kind = %s', (kind) => {
     expect(isAgentSignal({ ...valid, kind })).toBe(true);
   });

--- a/src/daemon/approvals/__tests__/approvalHookWiring.test.ts
+++ b/src/daemon/approvals/__tests__/approvalHookWiring.test.ts
@@ -164,6 +164,14 @@ describe('hook → approval registry wiring', () => {
     expect(approvals.expired).toEqual([{ sessionId: 'pty-a', reason: 'turn-ended' }]);
   });
 
+  it('agent.input_answered expires the pending request — user answered on the local machine', () => {
+    const { ingest, approvals } = makeIngest();
+
+    ingest.handle(makeSignal({ kind: 'agent.input_answered' }));
+
+    expect(approvals.expired).toEqual([{ sessionId: 'pty-a', reason: 'answered-locally' }]);
+  });
+
   it('agent.session_start expires it — a new session never asked the old question', () => {
     const { ingest, approvals } = makeIngest();
 

--- a/src/daemon/approvals/types.ts
+++ b/src/daemon/approvals/types.ts
@@ -198,7 +198,8 @@ export type ApprovalExpiryReason =
   | 'turn-ended'
   | 'session-start'
   | 'pane-gone'
-  | 'prompt-gone';
+  | 'prompt-gone'
+  | 'answered-locally';
 
 /**
  * The half of the registry HookIngest drives. Separate from the read/resolve

--- a/src/daemon/hooks/HookIngest.ts
+++ b/src/daemon/hooks/HookIngest.ts
@@ -442,6 +442,12 @@ export class HookIngest {
     // isGovernedFor before fanning out its own notifications.
     this.router.touchAuthority(sessionId, signal.agent, this.now());
 
+    // User answered a pending approval locally — no turn boundary, just expire the request.
+    if (signal.kind === 'agent.input_answered') {
+      this.deps.approvals?.expireForSession(sessionId, 'answered-locally');
+      return { ok: true };
+    }
+
     // X6 ③: capture the resume binding on session-LIFECYCLE kinds. Runs
     // BEFORE the emit-kind gate on purpose — SessionStart is dropped for the
     // notification path but is the EARLIEST point the origin session id is

--- a/src/main/pipe/handlers/hooks.rpc.ts
+++ b/src/main/pipe/handlers/hooks.rpc.ts
@@ -1217,6 +1217,8 @@ function titleFor(signal: AgentSignal): string {
       return `${display}: Session started`;
     case 'agent.awaiting_input':
       return `${display}: Awaiting input`;
+    case 'agent.input_answered':
+      return `${display}: Input received`;
     // Brain-pty only: claimed by the deck lane long before dispatch. Mapped so
     // the switch stays exhaustive.
     case 'agent.user_prompt_submit':
@@ -1240,6 +1242,7 @@ function categoryFor(signal: AgentSignal): NotificationCategory {
     case 'agent.stop':
     case 'agent.activity':
     case 'agent.session_start':
+    case 'agent.input_answered':
     case 'agent.user_prompt_submit':
       return 'agent-turn';
   }
@@ -1260,6 +1263,8 @@ function bodyFor(signal: AgentSignal): string {
       return 'Session initialized';
     case 'agent.awaiting_input':
       return 'Approval requested';
+    case 'agent.input_answered':
+      return 'Answer received locally';
     case 'agent.user_prompt_submit':
       return 'Prompt submitted';
   }

--- a/src/shared/hooks/signal-types.ts
+++ b/src/shared/hooks/signal-types.ts
@@ -38,6 +38,10 @@ export type AgentSignalKind =
   | 'agent.subagent_stop'
   | 'agent.session_start'
   | 'agent.awaiting_input'
+  // User answered a pending AskUserQuestion locally (on the same machine the
+  // agent is running on). Emitted on PostToolUse: AskUserQuestion to expire
+  // approval requests that are still pending on remote devices.
+  | 'agent.input_answered'
   // A prompt was submitted INSIDE the agent's own TUI. Only the deck's brain
   // pty configures this hook, and the brain-pty lane claims the signal before
   // it can reach the fleet ledger — it exists so the orchestrator's "one turn
@@ -187,6 +191,7 @@ export function isAgentSignal(value: unknown): value is AgentSignal {
     v['kind'] !== 'agent.subagent_stop' &&
     v['kind'] !== 'agent.session_start' &&
     v['kind'] !== 'agent.awaiting_input' &&
+    v['kind'] !== 'agent.input_answered' &&
     v['kind'] !== 'agent.user_prompt_submit'
   ) return false;
   if (typeof v['agent'] !== 'string' || !ALLOWED_AGENT_SLUGS.has(v['agent'])) return false;


### PR DESCRIPTION
## Summary

Approvals that fire on AskUserQuestion remain pending on phones even after the user answers on the PC. The issue had two root causes:

1. **No local-answer signal**: Approval lifecycle only had awaiting_input (created) and agent.stop (turn-ended). When user answered locally, daemon had no signal to expire the request.
2. **PostToolUse throttle race**: Source-side throttle (2.5s) was dropping ALL PostToolUse events including AskUserQuestion completion, preventing input_answered signals from reaching daemon within throttle window.

## Solution

- Add `agent.input_answered` signal kind — fired on PostToolUse: AskUserQuestion with `fired=true`
- Daemon expires pending request immediately with reason 'answered-locally'
- Exclude input_answered from PostToolUse throttle to prevent race condition
- Validate fired field to ensure signal fires only on completion (PostToolUse), not on initialization (PreToolUse)
- Update signal-types validation and approval reason enum

## Test plan

- [x] Unit tests (9747+ passing)
- [x] TypeScript compilation (daemon + cli)
- [x] Team review: Claude + GLM (found and fixed 2 critical issues)
  - ✓ Throttle race (GLM, confidence 9)
  - ✓ Fired field validation (Claude, confidence 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing when an agent’s question is answered locally.
  * Local answers now automatically resolve pending approval requests.
  * Added notifications for locally answered agent questions.

* **Bug Fixes**
  * Prevented locally answered questions from being misclassified as agent activity or turn boundaries.
  * Preserved normal activity handling and throttling for other agent events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->