### PR TITLE
Move panes around the layout (#645)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -437,7 +437,7 @@
 
 ## RPC timeout abandons live server work (P2, from #756 eng review outside voice 2026-08-02)
 - **What:** Give RPC a propagated deadline, cancellation, and a status/idempotency path so a timeout is recoverable instead of terminal.
-- **Why:** Restores the stated principle above ("timeout/예외 = unknown, 절대 dead 아님") instead of widening the window around the violation. Today slow work masquerades as failure and a retry can duplicate side effects (a navigation, a click).
+- **Why:** Restores the principle already stated further up this file — a timeout or an exception means `unknown`, never `dead` — instead of widening the window around the violation. Today slow work masquerades as failure and a retry can duplicate side effects (a navigation, a click).
 - **Context:** Surfaced by Codex outside voice reviewing the #756 plan, 2026-08-02. `wmux-client.ts:141` rejects and destroys the socket while the main-side handler keeps running uncancelled; `RpcRouter.ts:385` flattens errors to a bare string so no machine-readable cause survives the wire. #756 only bounds one handler wait (the DNS guard) and deliberately does NOT fix this. Touching the RPC envelope is a Substrate contract change (PROTOCOL.md, inventory.md, stability tier).
 - **Depends on:** Should follow #756 so the timeout path has a known-good case to test against. **Effort:** L. **Priority:** P2.
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -428,3 +428,28 @@
 - **Depends on:** P0-0 measurement fixes. **Effort:** M → S-M (CC). **Priority:** P2-P3.
 
 - [ ] Update the release procedure in CLAUDE.md: main is a protected branch, so the chore(release) commit must land through a release PR (squash), with the v* tag pushed onto the release commit — direct `git push` to main is rejected. (2026-07-30, found while shipping v3.38.1)
+
+## Browser guest discard/wake path has never actually run (P3, from #756 eng review 2026-08-02)
+- **What:** Determine whether the #517 lightweight discard/wake path is reachable in practice, and either exercise it or retire the 15s wake budget.
+- **Why:** `ensureAwake`/`WAKE_TIMEOUT_MS = 15_000` (`WebviewCdpManager.ts`) is live code that appears never to execute: lightweight mode is default-off and `waking discarded surface` / `wake timed out` occur **zero times** across every `%APPDATA%\wmux\logs\main-*.log`. Untested, unexercised code that sits in the path of every browser RPC is a standing hazard — it was mistaken for the cause of #756 precisely because it looks load-bearing.
+- **Context:** Found 2026-08-02 while diagnosing #756. Earlier notes here claimed a discarded guest "fails to remount"; that observation came from `browser_close`, which *unregisters* the surface rather than discarding it, so no wake was ever attempted. Start by enabling lightweight mode and confirming a guest is discarded after `DISCARD_AFTER_MS`, then that `ensureAwake` wakes it.
+- **Depends on:** — **Effort:** M. **Priority:** P3.
+
+## RPC timeout abandons live server work (P2, from #756 eng review outside voice 2026-08-02)
+- **What:** Give RPC a propagated deadline, cancellation, and a status/idempotency path so a timeout is recoverable instead of terminal.
+- **Why:** Restores the stated principle above ("timeout/예외 = unknown, 절대 dead 아님") instead of widening the window around the violation. Today slow work masquerades as failure and a retry can duplicate side effects (a navigation, a click).
+- **Context:** Surfaced by Codex outside voice reviewing the #756 plan, 2026-08-02. `wmux-client.ts:141` rejects and destroys the socket while the main-side handler keeps running uncancelled; `RpcRouter.ts:385` flattens errors to a bare string so no machine-readable cause survives the wire. #756 only bounds one handler wait (the DNS guard) and deliberately does NOT fix this. Touching the RPC envelope is a Substrate contract change (PROTOCOL.md, inventory.md, stability tier).
+- **Depends on:** Should follow #756 so the timeout path has a known-good case to test against. **Effort:** L. **Priority:** P2.
+
+
+## Expose pane.move over RPC/MCP (P3, from #645 eng review 2026-08-02)
+- **What:** Add a `pane.move` (and `pane.swap`) verb so an agent can re-lay-out panes it owns, mirroring the existing `pane.split` / `pane.close` / `pane.focus` family.
+- **Why:** Once humans can drag panes around, an orchestrator asking "put the worker pane next to mine" is the obvious next request. Deliberately NOT in the #645 PR — the human UX should settle first, and nobody has asked for the agent-facing version yet.
+- **Context:** #645 ships renderer-only (keyboard + drag). The RPC version is not a thin wrapper: it needs an entry in `src/main/mcp/methodCapabilityMap.ts`, first-party gating (`firstParty.ts`), a `#236`-style workspace-scope + fail-closed guard like `pane.split` has (`pane.rpc.ts:267-301`), `node scripts/gen-api-reference.mjs` regeneration, and a `docs/api` stability-tier decision. Start from `movePane` in `paneSlice.ts` once #645 lands.
+- **Depends on:** #645. **Effort:** M. **Priority:** P3.
+
+## Cross-workspace pane move / break-pane (P3, from #645 eng review 2026-08-02)
+- **What:** Move a pane into a different workspace, and break a pane out into a new one (tmux `break-pane`).
+- **Why:** The natural follow-up question after in-workspace move ships: "why can't I drag it to the other workspace?" Scoped out of #645 because it is an identity problem, not a layout one.
+- **Context:** Three constraints make this an epic rather than an extension. (1) `panePrincipalId(wsId, paneId)` is the channel-membership coordinate (`paneSlice.ts:518`, purged on close via `purgeMembershipDaemon`), so a moved pane changes principal and its channel rows must migrate rather than be dropped. (2) Workspace env profiles (`WorkspaceProfile.env` / `startupCwd`) differ, so the PTY arrives under the wrong environment. (3) The auto-name `w<wsOrdinal>-<ordinal>` embeds the workspace, so the pane must be reissued an ordinal from the destination's `nextPaneOrdinal` — which breaks the "a pane's name is stable for its lifetime" property that `paneSlice.ts:411` calls critical.
+- **Depends on:** #645. **Effort:** L. **Priority:** P3.

--- a/changelog.d/645.md
+++ b/changelog.d/645.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **Closing a pane no longer misaligns its neighbours.** In a row or column of
+  three or more panes, closing one left the remaining panes rendering at the
+  wrong widths — the sizes list still had an entry for the pane that was gone,
+  so every panel after it was drawn one slot off. Two-pane splits were never
+  affected, which is why this hid for so long. (#645)

--- a/changelog.d/645.md
+++ b/changelog.d/645.md
@@ -1,3 +1,15 @@
+### Added
+
+- **Move panes around your layout.** Panes could only be created and closed, so
+  getting the arrangement you wanted meant splitting in exactly the right order
+  from the start. Now you can rearrange one you already have: drag the grip in a
+  pane's tab strip and drop it on another pane's edge to move it there, or on
+  its centre to swap the two. From the keyboard, `Ctrl+B` then `H`/`J`/`K`/`L`
+  walks the active pane left/down/up/right, and `{` / `}` swap it with its
+  neighbour, mirroring tmux. The command palette carries the four directional
+  moves as well. Panes keep their names and their scrollback wherever they land.
+  (#645)
+
 ### Fixed
 
 - **Closing a pane no longer misaligns its neighbours.** In a row or column of

--- a/changelog.d/776.md
+++ b/changelog.d/776.md
@@ -8,7 +8,7 @@
   walks the active pane left/down/up/right, and `{` / `}` swap it with its
   neighbour, mirroring tmux. The command palette carries the four directional
   moves as well. Panes keep their names and their scrollback wherever they land.
-  (#645)
+  (#776)
 
 ### Fixed
 
@@ -16,4 +16,4 @@
   three or more panes, closing one left the remaining panes rendering at the
   wrong widths — the sizes list still had an entry for the pane that was gone,
   so every panel after it was drawn one slot off. Two-pane splits were never
-  affected, which is why this hid for so long. (#645)
+  affected, which is why this hid for so long. (#776)

--- a/src/renderer/components/Palette/CommandPalette.tsx
+++ b/src/renderer/components/Palette/CommandPalette.tsx
@@ -223,6 +223,13 @@ export default function CommandPalette() {
           setVisible(false);
         },
       },
+      // #645 — move the active pane. Four entries rather than one "move pane"
+      // with a follow-up prompt: the palette is a single-stage list, and
+      // typing "move pane l" should just do it.
+      ...(['left', 'right', 'up', 'down'] as const).map((dir) => ({
+        label: t(`palette.cmd.movePane.${dir}` as Parameters<typeof t>[0]),
+        action: () => { useStore.getState().moveActivePaneDirection(dir); setVisible(false); },
+      })),
       {
         label: t('palette.cmd.newWorkspace'),
         action: () => { useStore.getState().addWorkspace(); setVisible(false); },

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -319,6 +319,16 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
     return () => document.removeEventListener('wmux:flash-pane', handler);
   }, [isActive]);
 
+  // #645 — is a pane drag currently hovering THIS pane, and where?
+  //
+  // Returns a STRING, not an object. A selector that builds `{ kind }` returns
+  // a fresh reference on every store read, so zustand's Object.is comparison
+  // always reports a change and the pane re-renders forever ("Maximum update
+  // depth exceeded"). A primitive compares by value and settles.
+  const dropIndicator = useStore((s) =>
+    s.paneDropTarget?.paneId === pane.id ? (s.paneDropTarget.edge ?? 'swap') : null,
+  );
+
   const handleClick = useCallback(() => {
     setActivePane(pane.id);
     // 최신 state에서 직접 읽어 stale closure 방지
@@ -470,6 +480,13 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
         borderRightWidth: 1,
         borderBottomWidth: 1,
         borderLeftWidth: 1,
+      }}
+      {...{
+        // #645 — hit-test anchors for the pane drag. collectDropRects reads
+        // both: the id to address the pane, the workspace to keep a drag
+        // inside the tile it started in under multiview.
+        'data-pane-root': pane.id,
+        'data-pane-workspace': workspace.id,
       }}
       onClick={handleClick}
       data-onboarding-target="pane-area"
@@ -834,6 +851,31 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
           {paneRoleBinding.model}
         </span>
       )}
+      {/* #645 — drop indicator. Drawn by the pane being hovered, not by the
+          one being dragged, so it lands in the right coordinate space with no
+          overlay layer. Steel accent (navigation), a thin edge line, no wash —
+          DESIGN.md's two-accent grammar reserves amber for alive/attention. */}
+      {dropIndicator && (
+        <div
+          data-pane-drop-indicator={dropIndicator}
+          style={{
+            position: 'absolute',
+            zIndex: 30,
+            pointerEvents: 'none',
+            transition: 'all 120ms ease-out',
+            ...(dropIndicator === 'swap'
+              ? {
+                  // A swap has no edge, so outline the whole pane instead.
+                  inset: 0,
+                  border: '2px solid var(--accent-blue)',
+                }
+              : dropIndicator === 'left' || dropIndicator === 'right'
+                ? { backgroundColor: 'var(--accent-blue)', top: 0, bottom: 0, width: 2, [dropIndicator]: 0 }
+                : { backgroundColor: 'var(--accent-blue)', left: 0, right: 0, height: 2, [dropIndicator]: 0 }),
+          }}
+        />
+      )}
+
       <SurfaceTabs
         surfaces={pane.surfaces}
         activeSurfaceId={pane.activeSurfaceId}

--- a/src/renderer/components/Pane/PaneContainer.tsx
+++ b/src/renderer/components/Pane/PaneContainer.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useEffect, useRef } from 'react';
+import { Fragment, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { Panel, Group, Separator, useGroupRef } from 'react-resizable-panels';
 import type { Layout } from 'react-resizable-panels';
 import type { Pane as PaneType, Workspace } from '../../../shared/types';
@@ -54,9 +54,14 @@ export default function PaneContainer({ pane, workspace, isWorkspaceVisible = tr
   // widths would then travel with the panes instead of staying with the slots.
   const childIdKey = paneChildren?.map((c) => c.id).join('|');
 
-  // Latest children, readable from a stale timer callback (see below).
+  // Latest children, readable from a stale timer callback (see below). Written
+  // in a layout effect rather than during render: a render can be thrown away
+  // (StrictMode, a concurrent re-render), and a ref written during one would
+  // then describe children that were never committed.
   const childIdKeyRef = useRef(childIdKey);
-  childIdKeyRef.current = childIdKey;
+  useLayoutEffect(() => {
+    childIdKeyRef.current = childIdKey;
+  }, [childIdKey]);
 
   useEffect(() => {
     if (!paneSizes || !paneChildren || !groupRef.current) return;
@@ -77,7 +82,10 @@ export default function PaneContainer({ pane, workspace, isWorkspaceVisible = tr
       programmaticRef.current = true;
       groupRef.current.setLayout(layout);
     }
-  }, [paneSizes, childIdKey]); // eslint-disable-line react-hooks/exhaustive-deps
+    // paneChildren is intentionally not a dependency: childIdKey already
+    // encodes the child set, and the array identity changes on unrelated
+    // store writes.
+  }, [paneSizes, childIdKey]);
 
   // A resize that ends just before the tree is restructured would otherwise
   // land AFTER it: the 200ms timer below fires, writes the pre-move sizes onto

--- a/src/renderer/components/Pane/PaneContainer.tsx
+++ b/src/renderer/components/Pane/PaneContainer.tsx
@@ -46,6 +46,18 @@ export default function PaneContainer({ pane, workspace, isWorkspaceVisible = tr
 
   const paneSizes = pane.type === 'branch' ? pane.sizes : undefined;
   const paneChildren = pane.type === 'branch' ? pane.children : undefined;
+
+  // The library keys its layout by CHILD ID, so the set and order of children
+  // is as much an input to the sync below as `sizes` is. Issue #645 made this
+  // load-bearing: swapping two panes exchanges the ids without touching
+  // `sizes`, and a `[paneSizes]`-only dependency would skip the re-sync — the
+  // widths would then travel with the panes instead of staying with the slots.
+  const childIdKey = paneChildren?.map((c) => c.id).join('|');
+
+  // Latest children, readable from a stale timer callback (see below).
+  const childIdKeyRef = useRef(childIdKey);
+  childIdKeyRef.current = childIdKey;
+
   useEffect(() => {
     if (!paneSizes || !paneChildren || !groupRef.current) return;
 
@@ -65,7 +77,16 @@ export default function PaneContainer({ pane, workspace, isWorkspaceVisible = tr
       programmaticRef.current = true;
       groupRef.current.setLayout(layout);
     }
-  }, [paneSizes]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [paneSizes, childIdKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // A resize that ends just before the tree is restructured would otherwise
+  // land AFTER it: the 200ms timer below fires, writes the pre-move sizes onto
+  // a branch whose children have changed, and the panes visibly snap to the
+  // wrong widths — looking, to the user, like the move failed. Drop any
+  // pending write when this branch unmounts.
+  useEffect(() => () => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+  }, []);
 
   const handleLayoutChanged = useCallback(
     (layout: Layout) => {
@@ -76,8 +97,14 @@ export default function PaneContainer({ pane, workspace, isWorkspaceVisible = tr
       if (!paneChildren) return;
       const sizes = paneChildren.map((child) => layout[child.id] ?? 100 / paneChildren.length);
 
+      // Which children these sizes describe. A branch that survives the
+      // restructure (same node, different children) would not unmount, so the
+      // cleanup above cannot catch that case — compare instead.
+      const scheduledFor = paneChildren.map((child) => child.id).join('|');
+
       if (debounceRef.current) clearTimeout(debounceRef.current);
       debounceRef.current = setTimeout(() => {
+        if (childIdKeyRef.current !== scheduledFor) return; // stale: the branch changed under us
         updatePaneSizes(pane.id, sizes);
       }, 200);
     },

--- a/src/renderer/components/Pane/PaneDragGrip.tsx
+++ b/src/renderer/components/Pane/PaneDragGrip.tsx
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useStore } from '../../stores';
+import { t } from '../../i18n';
+import {
+  DRAG_THRESHOLD_PX,
+  collectDropRects,
+  resolveDropTarget,
+  type DropTarget,
+  type PaneRect,
+} from './paneDrag';
+
+interface PaneDragGripProps {
+  paneId: string;
+  workspaceId: string;
+}
+
+/**
+ * Issue #645 — the handle you grab to move a pane.
+ *
+ * Sits in the tab strip row, never on a tab: tabs own their own HTML5 drag
+ * (terminal text export), and this uses pointer events precisely so the two
+ * never meet. Under the movement threshold the gesture is left alone as a
+ * click, so tapping the grip still just focuses the pane.
+ *
+ * Drop feedback is published to the store rather than drawn here, because the
+ * indicator belongs to the pane being hovered, not to the pane being dragged.
+ */
+export default function PaneDragGrip({ paneId, workspaceId }: PaneDragGripProps) {
+  const movePane = useStore((s) => s.movePane);
+  const swapPanes = useStore((s) => s.swapPanes);
+  const setPaneDropTarget = useStore((s) => s.setPaneDropTarget);
+  const setPaneDragSource = useStore((s) => s.setPaneDragSource);
+  const setActivePane = useStore((s) => s.setActivePane);
+
+  const [armed, setArmed] = useState(false);
+  const originRef = useRef<{ x: number; y: number } | null>(null);
+  const draggingRef = useRef(false);
+  const rectsRef = useRef<PaneRect[]>([]);
+  const targetRef = useRef<DropTarget | null>(null);
+  /** Did the gesture that just ended actually drag? Read by the click handler. */
+  const wasDragRef = useRef(false);
+
+  const endDrag = useCallback(() => {
+    draggingRef.current = false;
+    originRef.current = null;
+    rectsRef.current = [];
+    targetRef.current = null;
+    setArmed(false);
+    setPaneDragSource(null);
+    setPaneDropTarget(null);
+  }, [setPaneDragSource, setPaneDropTarget]);
+
+  // Escape aborts mid-drag, leaving the tree untouched. Bound only while armed
+  // so the app's other Escape handling is unaffected the rest of the time.
+  useEffect(() => {
+    if (!armed) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        endDrag();
+      }
+    };
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [armed, endDrag]);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0) return;
+      // Keep the pane's own click-to-focus from firing when this turns into a
+      // drag — otherwise "Escape cancelled the drag" would still have moved
+      // focus, and the cancel would not be a true no-op.
+      e.stopPropagation();
+      e.currentTarget.setPointerCapture(e.pointerId);
+      originRef.current = { x: e.clientX, y: e.clientY };
+      // Fresh gesture: only a real drag may set this, and only the trailing
+      // click clears it.
+      wasDragRef.current = false;
+      setArmed(true);
+    },
+    [],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const origin = originRef.current;
+      if (!origin) return;
+
+      if (!draggingRef.current) {
+        const moved = Math.hypot(e.clientX - origin.x, e.clientY - origin.y);
+        if (moved < DRAG_THRESHOLD_PX) return; // still a click
+        draggingRef.current = true;
+        // Latch it here rather than at pointerup: Escape ends the drag first,
+        // so by the time pointerup runs draggingRef is already false and a
+        // cancelled drag would look like a plain click (and steal focus).
+        wasDragRef.current = true;
+        // Measure once at drag start: the layout cannot change mid-drag (no
+        // pane is created or closed), and re-measuring every move would thrash.
+        rectsRef.current = collectDropRects({
+          root: document,
+          sourcePaneId: paneId,
+          workspaceId,
+        });
+        setPaneDragSource(paneId);
+      }
+
+      const target = resolveDropTarget(rectsRef.current, e.clientX, e.clientY);
+      targetRef.current = target;
+      setPaneDropTarget(target);
+    },
+    [paneId, workspaceId, setPaneDragSource, setPaneDropTarget],
+  );
+
+  // A `click` still fires after the gesture, and pointer capture sends it to
+  // the GRIP — so it bubbles into the pane root's click-to-focus. Stopping
+  // pointerdown does not prevent that (click is a separate event). Left alone,
+  // a cancelled drag would still move focus and "Escape changes nothing" would
+  // be a lie. Swallow the click here and do the focusing ourselves, only when
+  // the gesture really was a click.
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      if (!wasDragRef.current) setActivePane(paneId);
+      wasDragRef.current = false;
+    },
+    [paneId, setActivePane],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    const wasDragging = draggingRef.current;
+    const target = targetRef.current;
+    endDrag();
+    if (!wasDragging || !target) return;
+
+    if (target.edge === null) {
+      swapPanes(workspaceId, paneId, target.paneId);
+    } else {
+      // The user grabbed this pane, so it keeps focus after landing.
+      movePane(workspaceId, paneId, target.paneId, target.edge, { focusSource: true });
+    }
+  }, [endDrag, movePane, swapPanes, paneId, workspaceId]);
+
+  return (
+    <div
+      data-pane-drag-grip
+      role="button"
+      tabIndex={-1}
+      aria-label={t('pane.dragGrip')}
+      title={t('pane.dragGrip')}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onClick={handleClick}
+      onPointerCancel={endDrag}
+      style={{
+        width: 14,
+        height: 18,
+        flexShrink: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        cursor: armed ? 'grabbing' : 'grab',
+        // Quiet by default; the grip is an affordance, not an instrument.
+        color: armed ? 'var(--accent-blue)' : 'var(--text-muted)',
+        opacity: armed ? 1 : 0.55,
+        transition: 'opacity 120ms ease-out, color 120ms ease-out',
+        userSelect: 'none',
+        touchAction: 'none', // let pointermove through instead of scrolling
+      }}
+    >
+      {/* Six-dot grip: the conventional "this is draggable" mark. */}
+      <svg width="6" height="12" viewBox="0 0 6 12" aria-hidden="true">
+        {[2, 6, 10].map((cy) =>
+          [1, 5].map((cx) => <circle key={`${cx}-${cy}`} cx={cx} cy={cy} r="1" fill="currentColor" />),
+        )}
+      </svg>
+    </div>
+  );
+}

--- a/src/renderer/components/Pane/PaneDragGrip.tsx
+++ b/src/renderer/components/Pane/PaneDragGrip.tsx
@@ -176,9 +176,13 @@ export default function PaneDragGrip({ paneId, workspaceId }: PaneDragGripProps)
   return (
     <div
       data-pane-drag-grip
-      role="button"
-      tabIndex={-1}
-      aria-label={t('pane.dragGrip')}
+      // Deliberately NOT role="button": this is a pointer-only affordance and
+      // it cannot be operated from the keyboard, so announcing it as a button
+      // would promise an interaction that does not exist. The keyboard has
+      // full equivalents elsewhere (prefix H/J/K/L and {/}, plus the "Move
+      // pane …" palette commands), so nothing is lost by leaving the grip out
+      // of the tab order and the accessibility tree.
+      aria-hidden="true"
       title={t('pane.dragGrip')}
       ref={gripRef}
       onPointerDown={handlePointerDown}
@@ -186,6 +190,10 @@ export default function PaneDragGrip({ paneId, workspaceId }: PaneDragGripProps)
       onPointerUp={handlePointerUp}
       onClick={handleClick}
       onPointerCancel={endDrag}
+      // The browser can revoke the capture without a pointercancel — the
+      // element being removed, or the OS taking the pointer. Without this the
+      // drag would keep listening for moves that will never arrive.
+      onLostPointerCapture={endDrag}
       style={{
         width: 14,
         height: 18,

--- a/src/renderer/components/Pane/PaneDragGrip.tsx
+++ b/src/renderer/components/Pane/PaneDragGrip.tsx
@@ -39,8 +39,18 @@ export default function PaneDragGrip({ paneId, workspaceId }: PaneDragGripProps)
   const targetRef = useRef<DropTarget | null>(null);
   /** Did the gesture that just ended actually drag? Read by the click handler. */
   const wasDragRef = useRef(false);
+  const gripRef = useRef<HTMLDivElement>(null);
+  const capturedPointerRef = useRef<number | null>(null);
 
   const endDrag = useCallback(() => {
+    // Escape ends the drag while the button is still held, so the capture
+    // would otherwise stay on this grip and swallow every other pane's
+    // pointer events until the user lets go.
+    const el = gripRef.current;
+    if (el && capturedPointerRef.current !== null) {
+      try { el.releasePointerCapture(capturedPointerRef.current); } catch { /* already gone */ }
+      capturedPointerRef.current = null;
+    }
     draggingRef.current = false;
     originRef.current = null;
     rectsRef.current = [];
@@ -64,6 +74,17 @@ export default function PaneDragGrip({ paneId, workspaceId }: PaneDragGripProps)
     return () => window.removeEventListener('keydown', onKey, true);
   }, [armed, endDrag]);
 
+  // A pane can vanish under the user: an agent or the daemon may close it
+  // mid-drag, and then this grip unmounts without ever seeing pointerup,
+  // pointercancel, or Escape. Without this, paneDropTarget stays set and the
+  // drop indicator is painted on some pane forever. endDrag is read through a
+  // ref so the cleanup runs ONLY on unmount, not whenever its identity changes.
+  const endDragRef = useRef(endDrag);
+  endDragRef.current = endDrag;
+  useEffect(() => () => {
+    if (draggingRef.current || originRef.current) endDragRef.current();
+  }, []);
+
   const handlePointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       if (e.button !== 0) return;
@@ -72,6 +93,7 @@ export default function PaneDragGrip({ paneId, workspaceId }: PaneDragGripProps)
       // focus, and the cancel would not be a true no-op.
       e.stopPropagation();
       e.currentTarget.setPointerCapture(e.pointerId);
+      capturedPointerRef.current = e.pointerId;
       originRef.current = { x: e.clientX, y: e.clientY };
       // Fresh gesture: only a real drag may set this, and only the trailing
       // click clears it.
@@ -147,6 +169,7 @@ export default function PaneDragGrip({ paneId, workspaceId }: PaneDragGripProps)
       tabIndex={-1}
       aria-label={t('pane.dragGrip')}
       title={t('pane.dragGrip')}
+      ref={gripRef}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}

--- a/src/renderer/components/Pane/PaneDragGrip.tsx
+++ b/src/renderer/components/Pane/PaneDragGrip.tsx
@@ -30,7 +30,7 @@ export default function PaneDragGrip({ paneId, workspaceId }: PaneDragGripProps)
   const swapPanes = useStore((s) => s.swapPanes);
   const setPaneDropTarget = useStore((s) => s.setPaneDropTarget);
   const setPaneDragSource = useStore((s) => s.setPaneDragSource);
-  const setActivePane = useStore((s) => s.setActivePane);
+  const focusPaneSurface = useStore((s) => s.focusPaneSurface);
 
   const [armed, setArmed] = useState(false);
   const originRef = useRef<{ x: number; y: number } | null>(null);
@@ -134,19 +134,21 @@ export default function PaneDragGrip({ paneId, workspaceId }: PaneDragGripProps)
   );
 
   // A `click` still fires after the gesture, and pointer capture sends it to
-  // the GRIP — so it bubbles into the pane root's click-to-focus. Stopping
-  // pointerdown does not prevent that (click is a separate event). Left alone,
-  // a cancelled drag would still move focus and "Escape changes nothing" would
-  // be a lie. Swallow the click here and do the focusing ourselves, only when
-  // the gesture really was a click.
-  const handleClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      e.stopPropagation();
-      if (!wasDragRef.current) setActivePane(paneId);
-      wasDragRef.current = false;
-    },
-    [paneId, setActivePane],
-  );
+  // the GRIP, so it bubbles on into the pane root's click-to-focus. Stopping
+  // pointerdown does not prevent that (click is a separate event), and left
+  // alone a cancelled drag would still move focus — "Escape changes nothing"
+  // would be a lie.
+  //
+  // So swallow ONLY the click that ends a drag. A plain click is left to
+  // bubble exactly like a click anywhere else in the pane: the pane root
+  // focuses itself, and in multiview the tile's own handler makes its
+  // workspace active. Swallowing every click broke that second path — the
+  // grip became the one spot in a background tile you could click with no
+  // effect at all.
+  const handleClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    if (wasDragRef.current) e.stopPropagation();
+    wasDragRef.current = false;
+  }, []);
 
   const handlePointerUp = useCallback(() => {
     const wasDragging = draggingRef.current;
@@ -154,13 +156,22 @@ export default function PaneDragGrip({ paneId, workspaceId }: PaneDragGripProps)
     endDrag();
     if (!wasDragging || !target) return;
 
+    // Either way the user grabbed this pane, so it ends up focused. movePane
+    // takes focus as an input; swapPanes deliberately does not touch focus, so
+    // do it here — otherwise a centre-drop (swap) would leave the pane the
+    // user just dragged inactive while an edge-drop focuses it.
+    //
+    // focusPaneSurface, not setActivePane: setActivePane resolves paneIds
+    // against activeWorkspaceId only, so it silently refuses a pane in a
+    // background multiview tile.
     if (target.edge === null) {
-      swapPanes(workspaceId, paneId, target.paneId);
+      if (swapPanes(workspaceId, paneId, target.paneId)) {
+        focusPaneSurface(workspaceId, paneId);
+      }
     } else {
-      // The user grabbed this pane, so it keeps focus after landing.
       movePane(workspaceId, paneId, target.paneId, target.edge, { focusSource: true });
     }
-  }, [endDrag, movePane, swapPanes, paneId, workspaceId]);
+  }, [endDrag, movePane, swapPanes, focusPaneSurface, paneId, workspaceId]);
 
   return (
     <div

--- a/src/renderer/components/Pane/SurfaceTabs.tsx
+++ b/src/renderer/components/Pane/SurfaceTabs.tsx
@@ -9,6 +9,7 @@ import {
 import { tokenAttrs } from '../../themes';
 import { computePaneAutoName, paneDisplayName } from '../../utils/paneNaming';
 import { findPane } from '../../../shared/paneUtils';
+import PaneDragGrip from './PaneDragGrip';
 import { FOCUS_RING } from '../focusRing';
 import { IconSplitRight, IconSplitDown, IconBrowser } from '../icons';
 import { displayPath } from '../../utils/displayPath';
@@ -232,6 +233,11 @@ export default function SurfaceTabs({
       {...tokenAttrs('bgMantle', 'bg')}
       {...tokenAttrs('bgSurface', 'border')}
     >
+      {/* #645 — pane move grip. First in the strip, OUTSIDE the scroll region,
+          so it stays reachable however many tabs there are. Never on a tab
+          itself: tabs own an HTML5 drag that exports terminal text. */}
+      <PaneDragGrip paneId={paneId} workspaceId={workspace.id} />
+
       {/* Scroll region: pane label + tabs share the horizontal overflow so the
           action cluster below stays pinned to the right on narrow panes. */}
       <div className="flex items-center flex-1 min-w-0 overflow-x-auto h-full">

--- a/src/renderer/components/Pane/__tests__/PaneContainer.moveSizes.test.tsx
+++ b/src/renderer/components/Pane/__tests__/PaneContainer.moveSizes.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+//
+// Issue #645 — PaneContainer's rendering contract for a pane move.
+//
+// WHAT THIS FILE CAN AND CANNOT PROVE. Under jsdom the panels-library never
+// applies a layout: with no real measurement (ResizeObserver is a stub, every
+// element is 0x0) `setLayout` is a no-op and every Panel keeps flex-grow: 50
+// no matter what sizes the store holds. Two of the three things the move work
+// changed are therefore NOT verifiable here, by construction:
+//
+//   • that a stale debounced size write is dropped — arming the debounce needs
+//     a real separator drag; the library does not fire onLayoutChanged on
+//     mount or on a programmatic setLayout.
+//   • that the layout is re-pushed after a swap (the child-id dependency) —
+//     the push itself is invisible in jsdom.
+//
+// Both belong to the Phase 0 harness, which runs against a real window. What
+// jsdom CAN prove is that the render tree follows the store: after a swap the
+// panes exchange DOM slots and both stay mounted. That is the regression guard
+// for "a swap dropped a pane" or "a swap rendered the same pane twice".
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+vi.mock('../Pane', () => ({
+  default: ({ pane }: { pane: { id: string } }) =>
+    React.createElement('div', { 'data-testid': `leaf-${pane.id}` }),
+}));
+
+import PaneContainer from '../PaneContainer';
+import { useStore } from '../../../stores';
+import { getLeafPanes } from '../../../../shared/paneUtils';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+class ResizeObserverStub {
+  observe(): void { /* layout reflow is irrelevant under jsdom */ }
+  unobserve(): void { /* no-op */ }
+  disconnect(): void { /* no-op */ }
+}
+(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver ??= ResizeObserverStub;
+
+let container: HTMLDivElement;
+let root: Root;
+
+const ws = () =>
+  useStore.getState().workspaces.find((w) => w.id === useStore.getState().activeWorkspaceId)!;
+
+function render(): void {
+  const w = ws();
+  act(() => {
+    root.render(
+      React.createElement(PaneContainer, {
+        pane: w.rootPane,
+        workspace: w,
+        isWorkspaceVisible: true,
+      }),
+    );
+  });
+}
+
+/** Leaf ids in the order they appear in the DOM. */
+function renderedLeafOrder(): string[] {
+  return Array.from(container.querySelectorAll('[data-testid^="leaf-"]')).map((el) =>
+    el.getAttribute('data-testid')!.slice('leaf-'.length),
+  );
+}
+
+beforeEach(() => {
+  const state = useStore.getState();
+  for (const w of [...state.workspaces]) state.removeWorkspace(w.id);
+  state.addWorkspace();
+  useStore.setState({ zoomedPaneId: null });
+
+  // Three leaves: root(h)[ A, inner(v)[ B, C ] ]
+  useStore.getState().splitPane(ws().rootPane.id, 'horizontal');
+  useStore.getState().splitPane(ws().activePaneId, 'vertical');
+
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  render();
+});
+
+afterEach(() => {
+  act(() => { root.unmount(); });
+  container.remove();
+});
+
+describe('PaneContainer — rendering a moved layout (#645)', () => {
+  it('swapping two panes exchanges their DOM slots and keeps both mounted', () => {
+    const [a, b, c] = renderedLeafOrder();
+    expect([a, b, c]).toHaveLength(3);
+
+    act(() => { useStore.getState().swapPanes(ws().id, a, c); });
+    render();
+
+    expect(renderedLeafOrder()).toEqual([c, b, a]);
+  });
+
+  it('moving a pane re-renders the new tree with every leaf still mounted', () => {
+    const before = renderedLeafOrder();
+    const [a, , c] = before;
+
+    act(() => { useStore.getState().movePane(ws().id, c, a, 'left'); });
+    render();
+
+    const after = renderedLeafOrder();
+    expect(new Set(after)).toEqual(new Set(before)); // same panes, no drops, no dupes
+    expect(after).toHaveLength(before.length);
+    expect(after[0]).toBe(c); // edge='left' put the moved pane ahead of its target
+  });
+
+  it('unmounting a branch with a resize pending does not throw', () => {
+    // The debounce cannot be armed from jsdom (see the header), so this only
+    // pins the cleanup path itself: unmount must not leave a timer that blows
+    // up when it fires.
+    vi.useFakeTimers();
+    act(() => { root.unmount(); });
+    root = createRoot(container); // keep afterEach's unmount valid
+    expect(() => { act(() => { vi.advanceTimersByTime(500); }); }).not.toThrow();
+    vi.useRealTimers();
+  });
+});

--- a/src/renderer/components/Pane/__tests__/PaneDragGrip.test.tsx
+++ b/src/renderer/components/Pane/__tests__/PaneDragGrip.test.tsx
@@ -114,6 +114,23 @@ describe('PaneDragGrip', () => {
     root = createRoot(container); // keep the shared teardown valid
   });
 
+  it('ends the drag when the browser revokes the pointer capture', () => {
+    // lostpointercapture arrives without a pointercancel when the element is
+    // removed or the OS takes the pointer. Without handling it the drag would
+    // sit waiting for moves that never come. (Found by the Codex reviewer.)
+    pointer('pointerdown', 10, 10);
+    pointer('pointermove', 90, 90);
+    setPaneDropTarget.mockClear();
+    setPaneDragSource.mockClear();
+
+    act(() => {
+      grip.dispatchEvent(new MouseEvent('lostpointercapture', { bubbles: true }));
+    });
+
+    expect(setPaneDragSource).toHaveBeenCalledWith(null);
+    expect(setPaneDropTarget).toHaveBeenCalledWith(null);
+  });
+
   it('does not touch drag state when it unmounts with no gesture in flight', () => {
     setPaneDropTarget.mockClear();
     setPaneDragSource.mockClear();

--- a/src/renderer/components/Pane/__tests__/PaneDragGrip.test.tsx
+++ b/src/renderer/components/Pane/__tests__/PaneDragGrip.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+//
+// Issue #645 — the grip's gesture contract.
+//
+// Both cases here are regressions caught in a live dev build, not invented:
+//
+//   1. Escape mid-drag left the tree alone but MOVED FOCUS. `pointerup` was
+//      overwriting the "this was a drag" latch with `draggingRef`, which
+//      Escape had already cleared — so the trailing click looked like a plain
+//      click and focused the pane. "Cancel changes nothing" was a lie.
+//   2. A click on the grip must still focus its pane, and must not reach the
+//      pane root (whose own click handler would double-handle it).
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+const setActivePane = vi.hoisted(() => vi.fn());
+const movePane = vi.hoisted(() => vi.fn());
+const swapPanes = vi.hoisted(() => vi.fn());
+const setPaneDropTarget = vi.hoisted(() => vi.fn());
+const setPaneDragSource = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../stores', () => ({
+  useStore: (sel: (s: unknown) => unknown) =>
+    sel({ setActivePane, movePane, swapPanes, setPaneDropTarget, setPaneDragSource }),
+}));
+vi.mock('../../../i18n', () => ({ t: (k: string) => k }));
+
+import PaneDragGrip from '../PaneDragGrip';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+let grip: HTMLElement;
+
+/** jsdom has no pointer capture; the component calls it unconditionally. */
+function stubCapture(el: HTMLElement) {
+  el.setPointerCapture = () => {};
+  el.releasePointerCapture = () => {};
+  el.hasPointerCapture = () => false;
+}
+
+function pointer(type: string, x: number, y: number) {
+  const e = new MouseEvent(type, { bubbles: true, clientX: x, clientY: y, button: 0 });
+  Object.defineProperty(e, 'pointerId', { value: 1 });
+  act(() => { grip.dispatchEvent(e); });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(React.createElement(PaneDragGrip, { paneId: 'pane-a', workspaceId: 'ws-1' }));
+  });
+  grip = container.querySelector('[data-pane-drag-grip]')!;
+  stubCapture(grip);
+});
+
+describe('PaneDragGrip', () => {
+  it('a click with no movement focuses the pane and moves nothing', () => {
+    pointer('pointerdown', 10, 10);
+    pointer('pointerup', 10, 10);
+    act(() => { grip.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    expect(setActivePane).toHaveBeenCalledWith('pane-a');
+    expect(movePane).not.toHaveBeenCalled();
+    expect(swapPanes).not.toHaveBeenCalled();
+  });
+
+  it('movement under the threshold is still a click', () => {
+    pointer('pointerdown', 10, 10);
+    pointer('pointermove', 12, 11); // ~2.2px — below the 4px threshold
+    expect(setPaneDragSource).not.toHaveBeenCalled();
+  });
+
+  it('Escape mid-drag leaves focus alone (the live regression)', () => {
+    pointer('pointerdown', 10, 10);
+    pointer('pointermove', 80, 80); // well past the threshold → a real drag
+    expect(setPaneDragSource).toHaveBeenCalledWith('pane-a');
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    pointer('pointerup', 80, 80);
+    act(() => { grip.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    // The whole point: a cancelled drag changes NOTHING.
+    expect(movePane).not.toHaveBeenCalled();
+    expect(swapPanes).not.toHaveBeenCalled();
+    expect(setActivePane).not.toHaveBeenCalled();
+    expect(setPaneDropTarget).toHaveBeenLastCalledWith(null);
+  });
+
+  it('does not let its click reach the pane root', () => {
+    // Mirror the real structure: the pane root is a React element WRAPPING the
+    // grip, with its own onClick (click-to-focus). A native listener on the
+    // React root container would fire regardless — React delegates there, so
+    // the event has already bubbled past it before synthetic dispatch.
+    const onPaneRootClick = vi.fn();
+    act(() => {
+      root.render(
+        React.createElement(
+          'div',
+          { onClick: onPaneRootClick },
+          React.createElement(PaneDragGrip, { paneId: 'pane-a', workspaceId: 'ws-1' }),
+        ),
+      );
+    });
+    grip = container.querySelector('[data-pane-drag-grip]')!;
+    stubCapture(grip);
+
+    pointer('pointerdown', 10, 10);
+    pointer('pointerup', 10, 10);
+    act(() => { grip.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    expect(setActivePane).toHaveBeenCalledWith('pane-a'); // the grip focuses it
+    expect(onPaneRootClick).not.toHaveBeenCalled(); // exactly once, not twice
+  });
+});

--- a/src/renderer/components/Pane/__tests__/PaneDragGrip.test.tsx
+++ b/src/renderer/components/Pane/__tests__/PaneDragGrip.test.tsx
@@ -94,6 +94,37 @@ describe('PaneDragGrip', () => {
     expect(setPaneDropTarget).toHaveBeenLastCalledWith(null);
   });
 
+  it('clears the drag when the grip unmounts mid-drag', () => {
+    // An agent or the daemon can close a pane while the user is dragging it.
+    // The grip then unmounts having seen neither pointerup nor pointercancel
+    // nor Escape, and without a cleanup the store keeps paneDropTarget set —
+    // painting a drop indicator on some pane forever. (Found by GLM review.)
+    pointer('pointerdown', 10, 10);
+    pointer('pointermove', 90, 90); // a real drag is in flight
+    expect(setPaneDragSource).toHaveBeenCalledWith('pane-a');
+    setPaneDropTarget.mockClear();
+    setPaneDragSource.mockClear();
+
+    act(() => { root.unmount(); });
+
+    expect(setPaneDragSource).toHaveBeenCalledWith(null);
+    expect(setPaneDropTarget).toHaveBeenCalledWith(null);
+    root = createRoot(container); // keep the shared teardown valid
+  });
+
+  it('does not touch drag state when it unmounts with no gesture in flight', () => {
+    setPaneDropTarget.mockClear();
+    setPaneDragSource.mockClear();
+
+    act(() => { root.unmount(); });
+
+    // Every pane has a grip; a pane closing while ANOTHER pane is being
+    // dragged must not clear that drag.
+    expect(setPaneDragSource).not.toHaveBeenCalled();
+    expect(setPaneDropTarget).not.toHaveBeenCalled();
+    root = createRoot(container);
+  });
+
   it('does not let its click reach the pane root', () => {
     // Mirror the real structure: the pane root is a React element WRAPPING the
     // grip, with its own onClick (click-to-focus). A native listener on the

--- a/src/renderer/components/Pane/__tests__/PaneDragGrip.test.tsx
+++ b/src/renderer/components/Pane/__tests__/PaneDragGrip.test.tsx
@@ -36,8 +36,8 @@ let grip: HTMLElement;
 
 /** jsdom has no pointer capture; the component calls it unconditionally. */
 function stubCapture(el: HTMLElement) {
-  el.setPointerCapture = () => {};
-  el.releasePointerCapture = () => {};
+  el.setPointerCapture = vi.fn();
+  el.releasePointerCapture = vi.fn();
   el.hasPointerCapture = () => false;
 }
 

--- a/src/renderer/components/Pane/__tests__/PaneDragGrip.test.tsx
+++ b/src/renderer/components/Pane/__tests__/PaneDragGrip.test.tsx
@@ -14,15 +14,15 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
-const setActivePane = vi.hoisted(() => vi.fn());
-const movePane = vi.hoisted(() => vi.fn());
-const swapPanes = vi.hoisted(() => vi.fn());
+const focusPaneSurface = vi.hoisted(() => vi.fn(() => true));
+const movePane = vi.hoisted(() => vi.fn(() => true));
+const swapPanes = vi.hoisted(() => vi.fn(() => true));
 const setPaneDropTarget = vi.hoisted(() => vi.fn());
 const setPaneDragSource = vi.hoisted(() => vi.fn());
 
 vi.mock('../../../stores', () => ({
   useStore: (sel: (s: unknown) => unknown) =>
-    sel({ setActivePane, movePane, swapPanes, setPaneDropTarget, setPaneDragSource }),
+    sel({ focusPaneSurface, movePane, swapPanes, setPaneDropTarget, setPaneDragSource }),
 }));
 vi.mock('../../../i18n', () => ({ t: (k: string) => k }));
 
@@ -60,12 +60,14 @@ beforeEach(() => {
 });
 
 describe('PaneDragGrip', () => {
-  it('a click with no movement focuses the pane and moves nothing', () => {
+  it('a plain click moves nothing and is left to bubble', () => {
+    // The grip does NOT focus the pane itself: it lets the click through so
+    // the pane root focuses as usual and, in multiview, the tile activates
+    // its workspace. See the click-through test below.
     pointer('pointerdown', 10, 10);
     pointer('pointerup', 10, 10);
     act(() => { grip.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
 
-    expect(setActivePane).toHaveBeenCalledWith('pane-a');
     expect(movePane).not.toHaveBeenCalled();
     expect(swapPanes).not.toHaveBeenCalled();
   });
@@ -90,7 +92,7 @@ describe('PaneDragGrip', () => {
     // The whole point: a cancelled drag changes NOTHING.
     expect(movePane).not.toHaveBeenCalled();
     expect(swapPanes).not.toHaveBeenCalled();
-    expect(setActivePane).not.toHaveBeenCalled();
+    expect(focusPaneSurface).not.toHaveBeenCalled();
     expect(setPaneDropTarget).toHaveBeenLastCalledWith(null);
   });
 
@@ -125,11 +127,12 @@ describe('PaneDragGrip', () => {
     root = createRoot(container);
   });
 
-  it('does not let its click reach the pane root', () => {
-    // Mirror the real structure: the pane root is a React element WRAPPING the
-    // grip, with its own onClick (click-to-focus). A native listener on the
-    // React root container would fire regardless — React delegates there, so
-    // the event has already bubbled past it before synthetic dispatch.
+  it('lets a plain click through, but swallows the one that ends a drag', () => {
+    // The pane root (and, in multiview, the workspace tile) has its own click
+    // handler. A plain grip click must reach it — swallowing every click made
+    // the grip the one spot in a background tile that did nothing at all.
+    // The click that TERMINATES a drag must still be swallowed, or a
+    // cancelled drag would move focus.
     const onPaneRootClick = vi.fn();
     act(() => {
       root.render(
@@ -143,11 +146,59 @@ describe('PaneDragGrip', () => {
     grip = container.querySelector('[data-pane-drag-grip]')!;
     stubCapture(grip);
 
+    // Plain click → reaches the pane root.
     pointer('pointerdown', 10, 10);
     pointer('pointerup', 10, 10);
     act(() => { grip.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onPaneRootClick).toHaveBeenCalledTimes(1);
 
-    expect(setActivePane).toHaveBeenCalledWith('pane-a'); // the grip focuses it
-    expect(onPaneRootClick).not.toHaveBeenCalled(); // exactly once, not twice
+    // Drag, then its trailing click → swallowed.
+    onPaneRootClick.mockClear();
+    pointer('pointerdown', 10, 10);
+    pointer('pointermove', 90, 90);
+    pointer('pointerup', 90, 90);
+    act(() => { grip.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onPaneRootClick).not.toHaveBeenCalled();
+  });
+
+  it('focuses the dragged pane after a centre-drop swap', () => {
+    // swapPanes deliberately does not touch focus, so without this the pane
+    // the user just dragged stays inactive after a centre drop — unlike an
+    // edge drop, which focuses via movePane's focusSource. The focus call must
+    // be the explicit-workspace one: setActivePane resolves paneIds against
+    // activeWorkspaceId only and would silently refuse a background tile.
+    // (Found by the Codex reviewer.)
+    const other = document.createElement('div');
+    other.setAttribute('data-pane-root', 'pane-b');
+    other.setAttribute('data-pane-workspace', 'ws-1');
+    other.getBoundingClientRect = () =>
+      ({ left: 200, top: 200, width: 200, height: 200 }) as DOMRect;
+    document.body.appendChild(other);
+
+    pointer('pointerdown', 10, 10);
+    pointer('pointermove', 300, 300); // dead centre of pane-b → a swap
+    pointer('pointerup', 300, 300);
+
+    expect(swapPanes).toHaveBeenCalledWith('ws-1', 'pane-a', 'pane-b');
+    expect(focusPaneSurface).toHaveBeenCalledWith('ws-1', 'pane-a');
+    expect(movePane).not.toHaveBeenCalled();
+    other.remove();
+  });
+
+  it('focuses via movePane, not a second call, on an edge drop', () => {
+    const other = document.createElement('div');
+    other.setAttribute('data-pane-root', 'pane-b');
+    other.setAttribute('data-pane-workspace', 'ws-1');
+    other.getBoundingClientRect = () =>
+      ({ left: 200, top: 200, width: 200, height: 200 }) as DOMRect;
+    document.body.appendChild(other);
+
+    pointer('pointerdown', 10, 10);
+    pointer('pointermove', 210, 300); // left band of pane-b
+    pointer('pointerup', 210, 300);
+
+    expect(movePane).toHaveBeenCalledWith('ws-1', 'pane-a', 'pane-b', 'left', { focusSource: true });
+    expect(swapPanes).not.toHaveBeenCalled();
+    other.remove();
   });
 });

--- a/src/renderer/components/Pane/__tests__/paneDrag.test.ts
+++ b/src/renderer/components/Pane/__tests__/paneDrag.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+//
+// Issue #645 — drop-target resolution and eligibility.
+//
+// These are the two places a pane drag can go quietly wrong: dropping onto a
+// pane the user cannot see, and picking the wrong edge near a corner. Both are
+// pure given a set of rects, so they are tested without a drag gesture.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { collectDropRects, resolveDropTarget, type PaneRect } from '../paneDrag';
+
+describe('resolveDropTarget', () => {
+  const pane: PaneRect = { paneId: 'p1', left: 100, top: 100, width: 300, height: 200 };
+  const rects = [pane];
+
+  it('returns null when the pointer is outside every pane', () => {
+    expect(resolveDropTarget(rects, 50, 50)).toBeNull();
+    expect(resolveDropTarget(rects, 500, 150)).toBeNull();
+  });
+
+  it('resolves the centre to a swap', () => {
+    const t = resolveDropTarget(rects, 250, 200); // dead centre
+    expect(t).toEqual({ paneId: 'p1', edge: null });
+  });
+
+  it.each([
+    ['left', 110, 200],
+    ['right', 390, 200],
+    ['top', 250, 110],
+    ['bottom', 250, 290],
+  ] as const)('resolves the %s band', (edge, x, y) => {
+    expect(resolveDropTarget(rects, x, y)).toEqual({ paneId: 'p1', edge });
+  });
+
+  it('picks the proportionally nearest edge in a corner', () => {
+    // Top-left corner, but much closer to the top edge in relative terms:
+    // fx = 30/300 = 0.10, fy = 6/200 = 0.03 → top wins.
+    expect(resolveDropTarget(rects, 130, 106)).toEqual({ paneId: 'p1', edge: 'top' });
+    // Same corner, now relatively closer to the left: fx = 0.02, fy = 0.10.
+    expect(resolveDropTarget(rects, 106, 120)).toEqual({ paneId: 'p1', edge: 'left' });
+  });
+
+  it('compares edges fairly across very different aspect ratios', () => {
+    // A wide, short pane. 20px from the left is a 2% inset; 20px from the top
+    // is 40%. An absolute-pixel comparison would wrongly call this "top".
+    const wide: PaneRect = { paneId: 'w', left: 0, top: 0, width: 1000, height: 50 };
+    expect(resolveDropTarget([wide], 20, 20)).toEqual({ paneId: 'w', edge: 'left' });
+  });
+});
+
+describe('collectDropRects', () => {
+  let root: HTMLElement;
+
+  function addPane(id: string, opts: { ws?: string; zoomHidden?: boolean; size?: [number, number] } = {}) {
+    const { ws = 'ws1', zoomHidden = false, size = [200, 100] } = opts;
+    const host = document.createElement('div');
+    if (zoomHidden) host.setAttribute('data-wmux-zoom-hidden', 'true');
+    const el = document.createElement('div');
+    el.setAttribute('data-pane-root', id);
+    el.setAttribute('data-pane-workspace', ws);
+    // jsdom has no layout, so getBoundingClientRect is stubbed per element.
+    el.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: size[0], height: size[1] }) as DOMRect;
+    host.appendChild(el);
+    root.appendChild(host);
+    return el;
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('div');
+    document.body.appendChild(root);
+  });
+
+  it('excludes the pane being dragged', () => {
+    addPane('a');
+    addPane('b');
+    const ids = collectDropRects({ root, sourcePaneId: 'a', workspaceId: 'ws1' }).map((r) => r.paneId);
+    expect(ids).toEqual(['b']);
+  });
+
+  it('excludes panes in another workspace tile (multiview)', () => {
+    addPane('mine');
+    addPane('theirs', { ws: 'ws2' });
+    const ids = collectDropRects({ root, sourcePaneId: 'src', workspaceId: 'ws1' }).map((r) => r.paneId);
+    expect(ids).toEqual(['mine']);
+  });
+
+  it('excludes panes hidden behind a zoom', () => {
+    addPane('visible');
+    addPane('behindZoom', { zoomHidden: true });
+    const ids = collectDropRects({ root, sourcePaneId: 'src', workspaceId: 'ws1' }).map((r) => r.paneId);
+    expect(ids).toEqual(['visible']);
+  });
+
+  it('excludes zero-sized panes', () => {
+    addPane('real');
+    addPane('collapsed', { size: [0, 0] });
+    const ids = collectDropRects({ root, sourcePaneId: 'src', workspaceId: 'ws1' }).map((r) => r.paneId);
+    expect(ids).toEqual(['real']);
+  });
+});

--- a/src/renderer/components/Pane/paneDrag.ts
+++ b/src/renderer/components/Pane/paneDrag.ts
@@ -1,0 +1,123 @@
+import type { Pane } from '../../../shared/types';
+
+/**
+ * Issue #645 — pointer-driven pane drag.
+ *
+ * Deliberately NOT HTML5 drag-and-drop. Surface tabs are already `draggable`
+ * and their drag exports terminal text to other apps through `dataTransfer`
+ * (SurfaceTabs.handleDragStart), and there is a separate file-drop path onto
+ * terminals. Sharing that machinery would mean every pane drag competes with
+ * both. Pointer events live in a different world entirely, so the two cannot
+ * interfere.
+ *
+ *   pointerdown on the grip
+ *        │  (movement < THRESHOLD_PX → it was a click; pane just focuses)
+ *        ▼
+ *   pointermove ─────────────▶ hit-test eligible panes ──▶ {target, edge}
+ *        │                          │
+ *        │                          └── quadrant of the hovered pane:
+ *        │                              left/right/top/bottom, centre = swap
+ *        ▼
+ *   pointerup → commit          Escape / pointercancel → abort, nothing moved
+ */
+
+/** Movement below this is a click, not a drag — so the grip stays clickable. */
+export const DRAG_THRESHOLD_PX = 4;
+
+/** Fraction of a pane's width/height that counts as its "centre" (= swap). */
+const CENTRE_FRACTION = 0.34;
+
+export type DropEdge = 'left' | 'right' | 'top' | 'bottom';
+
+export interface DropTarget {
+  paneId: string;
+  /** null = drop on the centre, meaning swap rather than re-parent. */
+  edge: DropEdge | null;
+}
+
+export interface PaneRect {
+  paneId: string;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Which panes may receive a drop.
+ *
+ * "Rendered" is not the same as "eligible": panes hidden behind a zoom are
+ * mounted (hide-don't-unmount), a multiview grid mounts several workspaces at
+ * once, and the pane being dragged cannot receive itself.
+ */
+export function collectDropRects(opts: {
+  root: ParentNode;
+  sourcePaneId: string;
+  workspaceId: string;
+}): PaneRect[] {
+  const { root, sourcePaneId, workspaceId } = opts;
+  const rects: PaneRect[] = [];
+
+  for (const el of Array.from(root.querySelectorAll<HTMLElement>('[data-pane-root]'))) {
+    const paneId = el.dataset.paneRoot;
+    if (!paneId || paneId === sourcePaneId) continue;
+    // Multiview mounts other workspaces' trees in sibling tiles; v1 keeps a
+    // drag inside the workspace it started in.
+    if (el.dataset.paneWorkspace !== workspaceId) continue;
+    // Behind a zoom: mounted but invisible, so a drop there would look like it
+    // vanished into nothing.
+    if (el.closest('[data-wmux-zoom-hidden]')) continue;
+
+    const r = el.getBoundingClientRect();
+    if (r.width <= 0 || r.height <= 0) continue; // parked / collapsed
+    rects.push({ paneId, left: r.left, top: r.top, width: r.width, height: r.height });
+  }
+
+  return rects;
+}
+
+/**
+ * Resolve a pointer position to a drop target.
+ *
+ *   ┌─────────────────┐   outer third on each axis → that edge
+ *   │ ╲     top     ╱ │   middle → swap (edge: null)
+ *   │  ┌───────────┐  │
+ *   │l │  centre   │r │   The dominant axis wins when the pointer is in a
+ *   │  └───────────┘  │   corner: whichever edge it is proportionally
+ *   │ ╱    bottom   ╲ │   closest to.
+ *   └─────────────────┘
+ */
+export function resolveDropTarget(
+  rects: readonly PaneRect[],
+  x: number,
+  y: number,
+): DropTarget | null {
+  const hit = rects.find(
+    (r) => x >= r.left && x <= r.left + r.width && y >= r.top && y <= r.top + r.height,
+  );
+  if (!hit) return null;
+
+  const fx = (x - hit.left) / hit.width;
+  const fy = (y - hit.top) / hit.height;
+
+  const inCentreX = fx > CENTRE_FRACTION && fx < 1 - CENTRE_FRACTION;
+  const inCentreY = fy > CENTRE_FRACTION && fy < 1 - CENTRE_FRACTION;
+  if (inCentreX && inCentreY) return { paneId: hit.paneId, edge: null };
+
+  // Distance to each edge as a fraction, so a 2000px-wide pane and a 200px-tall
+  // one are compared fairly.
+  const candidates: Array<{ edge: DropEdge; d: number }> = [
+    { edge: 'left', d: fx },
+    { edge: 'right', d: 1 - fx },
+    { edge: 'top', d: fy },
+    { edge: 'bottom', d: 1 - fy },
+  ];
+  candidates.sort((a, b) => a.d - b.d);
+  return { paneId: hit.paneId, edge: candidates[0].edge };
+}
+
+/** Leaf ids of a pane tree, in layout order. Used to validate a drag source. */
+export function isLeafPane(root: Pane, paneId: string): boolean {
+  if (root.type === 'leaf') return root.id === paneId;
+  return root.children.some((c) => isLeafPane(c, paneId));
+}

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -3910,6 +3910,8 @@ const PREFIX_ACTION_IDS = [
   'hideWindow', 'toggleZoom', 'commandPalette',
   'renameWorkspace', 'killWorkspace', 'showCheatSheet',
   'focusUp', 'focusDown', 'focusLeft', 'focusRight',
+  'movePaneUp', 'movePaneDown', 'movePaneLeft', 'movePaneRight',
+  'swapPanePrev', 'swapPaneNext',
 ] as const;
 
 function prefixActionLabel(actionId: string, t: (key: string) => string): string {

--- a/src/renderer/hooks/__tests__/useKeyboard.test.ts
+++ b/src/renderer/hooks/__tests__/useKeyboard.test.ts
@@ -169,6 +169,34 @@ describe('createPrefixActions — registry shape', () => {
     }
   });
 
+  it('keeps all THREE prefix lists aligned (registry, defaults, settings UI)', () => {
+    // The registry doc comment warns that createPrefixActions,
+    // DEFAULT_PREFIX_CONFIG.bindings and SettingsPanel's PREFIX_ACTION_IDS must
+    // stay in sync. The first two are checked above; the third lives in a
+    // component that is expensive to mount, so read it out of the source. An
+    // action missing from PREFIX_ACTION_IDS silently vanishes from Settings —
+    // it still works, but the user can never see or rebind it.
+    const settingsSrc = fs.readFileSync(
+      path.join(__dirname, '..', '..', 'components', 'Settings', 'SettingsPanel.tsx'),
+      'utf-8',
+    );
+    const arrayLiteral = /const PREFIX_ACTION_IDS = \[([\s\S]*?)\] as const;/.exec(settingsSrc);
+    expect(arrayLiteral, 'PREFIX_ACTION_IDS array not found in SettingsPanel').not.toBeNull();
+    const settingsIds = new Set(
+      Array.from(arrayLiteral![1].matchAll(/'([^']+)'/g), (m) => m[1]),
+    );
+
+    const { deps } = makeMockDeps();
+    const registryIds = Object.keys(createPrefixActions(deps));
+
+    expect([...registryIds].sort()).toEqual([...settingsIds].sort());
+
+    // And every default binding points at something all three lists know.
+    for (const id of Object.values(DEFAULT_PREFIX_CONFIG.bindings)) {
+      expect(settingsIds.has(id), `${id} is bound by default but missing from Settings`).toBe(true);
+    }
+  });
+
   it('includes the three tmux-compat actions added in the prefix expansion', () => {
     const { deps } = makeMockDeps();
     const actions = createPrefixActions(deps);

--- a/src/renderer/hooks/useKeyboard.ts
+++ b/src/renderer/hooks/useKeyboard.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useStore } from '../stores';
-import { findLeaf } from '../../shared/paneUtils';
+import { findLeaf, getLeafPanes } from '../../shared/paneUtils';
 import { terminalRegistry } from './useTerminal';
 import { t } from '../i18n';
 import { resolveStartupCwd, withDefaultShell, withWorkspaceProfile } from '../utils/ptyCreateOptions';
@@ -101,6 +101,34 @@ export interface PrefixActionDeps {
 }
 
 /**
+ * tmux `{` / `}` — swap the active pane with its neighbour in layout order.
+ *
+ * Layout order is the DFS leaf order the user sees on screen (same order
+ * `cyclePane` walks), and it wraps: swapping the last pane "next" trades it
+ * with the first. Two leaves or fewer with no wrap-around target is a no-op.
+ */
+function swapActiveWithAdjacentLeaf(
+  store: PrefixActionDeps['store'],
+  direction: 'prev' | 'next',
+): void {
+  const state = store.getState();
+  const ws = state.workspaces.find((w) => w.id === state.activeWorkspaceId);
+  if (!ws) return;
+
+  const leaves = getLeafPanes(ws.rootPane);
+  if (leaves.length <= 1) return;
+
+  const idx = leaves.findIndex((l) => l.id === ws.activePaneId);
+  if (idx === -1) return;
+
+  const delta = direction === 'next' ? 1 : -1;
+  const neighbour = leaves[(idx + delta + leaves.length) % leaves.length];
+  if (neighbour.id === ws.activePaneId) return;
+
+  state.swapPanes(ws.id, ws.activePaneId, neighbour.id);
+}
+
+/**
  * Build the prefix-mode action registry.
  *
  * Exported as a pure factory so {@link useKeyboard} can wire it to live
@@ -166,6 +194,17 @@ export function createPrefixActions(deps: PrefixActionDeps): Record<string, () =
     focusDown: () => { store.getState().focusPaneDirection('down'); },
     focusLeft: () => { store.getState().focusPaneDirection('left'); },
     focusRight: () => { store.getState().focusPaneDirection('right'); },
+    // #645 — move the pane itself. Same four directions as focus, so the
+    // muscle memory carries over; the store resolves the neighbour with the
+    // same traversal focusPaneDirection uses.
+    movePaneUp: () => { store.getState().moveActivePaneDirection('up'); },
+    movePaneDown: () => { store.getState().moveActivePaneDirection('down'); },
+    movePaneLeft: () => { store.getState().moveActivePaneDirection('left'); },
+    movePaneRight: () => { store.getState().moveActivePaneDirection('right'); },
+    // tmux's `{` / `}` — swap the active pane with the previous / next leaf in
+    // layout order, wrapping at the ends like cyclePane does.
+    swapPanePrev: () => { swapActiveWithAdjacentLeaf(store, 'prev'); },
+    swapPaneNext: () => { swapActiveWithAdjacentLeaf(store, 'next'); },
     renameWorkspace: () => {
       doc.dispatchEvent(new CustomEvent('wmux:rename-workspace'));
     },

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -98,6 +98,7 @@ export const en = {
   'workspaceProfile.cancel': 'Cancel',
 
   // Pane
+  'pane.dragGrip': 'Drag to move this pane',
   'pane.empty': 'Empty pane',
   'pane.splitRight': 'Split right',
   'pane.splitDown': 'Split down',

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -144,6 +144,10 @@ export const en = {
   'palette.cmd.newSurface': 'New Surface',
   'palette.cmd.splitRight': 'Split Right',
   'palette.cmd.splitDown': 'Split Down',
+  'palette.cmd.movePane.left': 'Move Pane Left',
+  'palette.cmd.movePane.right': 'Move Pane Right',
+  'palette.cmd.movePane.up': 'Move Pane Up',
+  'palette.cmd.movePane.down': 'Move Pane Down',
   'palette.cmd.showNotifications': 'Show Notifications',
   'palette.cmd.openSettings': 'Open Settings',
   'palette.cmd.openBrowser': 'Open Browser',
@@ -641,6 +645,12 @@ export const en = {
   'settings.prefix.focusDown': 'Focus down',
   'settings.prefix.focusLeft': 'Focus left',
   'settings.prefix.focusRight': 'Focus right',
+  'settings.prefix.movePaneUp': 'Move pane up',
+  'settings.prefix.movePaneDown': 'Move pane down',
+  'settings.prefix.movePaneLeft': 'Move pane left',
+  'settings.prefix.movePaneRight': 'Move pane right',
+  'settings.prefix.swapPanePrev': 'Swap with previous pane',
+  'settings.prefix.swapPaneNext': 'Swap with next pane',
 
   // Custom keybindings
   'settings.customKeybindings': 'Custom Keybindings',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -41,6 +41,7 @@ export const ko = {
   'workspace.idleTooltip': '{time} 동안 에이전트 활동 없음',
 
   // Pane
+  'pane.dragGrip': '드래그해서 페인 이동',
   'pane.empty': '빈 창',
   'pane.splitRight': '오른쪽 분할',
   'pane.splitDown': '아래 분할',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -85,6 +85,10 @@ export const ko = {
   'palette.cmd.newSurface': '새 서피스',
   'palette.cmd.splitRight': '오른쪽 분할',
   'palette.cmd.splitDown': '아래 분할',
+  'palette.cmd.movePane.left': '페인 왼쪽으로 이동',
+  'palette.cmd.movePane.right': '페인 오른쪽으로 이동',
+  'palette.cmd.movePane.up': '페인 위로 이동',
+  'palette.cmd.movePane.down': '페인 아래로 이동',
   'palette.cmd.showNotifications': '알림 보기',
   'palette.cmd.openSettings': '설정 열기',
   'palette.cmd.openBrowser': '브라우저 열기',
@@ -474,6 +478,12 @@ export const ko = {
   'settings.prefix.focusDown': '아래로 포커스',
   'settings.prefix.focusLeft': '왼쪽으로 포커스',
   'settings.prefix.focusRight': '오른쪽으로 포커스',
+  'settings.prefix.movePaneUp': '페인 위로 이동',
+  'settings.prefix.movePaneDown': '페인 아래로 이동',
+  'settings.prefix.movePaneLeft': '페인 왼쪽으로 이동',
+  'settings.prefix.movePaneRight': '페인 오른쪽으로 이동',
+  'settings.prefix.swapPanePrev': '이전 페인과 교환',
+  'settings.prefix.swapPaneNext': '다음 페인과 교환',
 
   // Custom keybindings
   'settings.customKeybindings': '커스텀 키바인딩',

--- a/src/renderer/stores/slices/__tests__/paneMove.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneMove.test.ts
@@ -373,6 +373,23 @@ describe('swapPanes (#645)', () => {
     }
   });
 
+  it('swaps two SIBLING leaves — the path prefix {/} takes most often', () => {
+    // Both nodes live in the SAME children array, so the swap assigns two
+    // immer drafts across one another. Every other swap test here crosses
+    // parents, which never exercises that.
+    const store2 = createTestStore();
+    const ws = () => activeWs(store2);
+    const a = ws().rootPane.id;
+    const b = store2.getState().splitPane(a, 'horizontal') as string;
+    expect(leafIds(store2)).toEqual([a, b]);
+
+    expect(store2.getState().swapPanes(ws().id, a, b)).toBe(true);
+
+    const after = leafIds(store2);
+    expect(after).toEqual([b, a]);
+    expect(new Set(after).size).toBe(2); // neither pane duplicated
+  });
+
   it('keeps ordinals with their panes', () => {
     const { a, c } = threePaneTree(store);
     const ordinalOf = (id: string) =>

--- a/src/renderer/stores/slices/__tests__/paneMove.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneMove.test.ts
@@ -1,0 +1,466 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { createPaneSlice, type PaneSlice } from '../paneSlice';
+import { createWorkspace, type Workspace, type Pane } from '../../../../shared/types';
+import { findPane, findParent, getLeafPanes } from '../../../../shared/paneUtils';
+
+// Issue #645 — movePane / swapPanes / moveActivePaneDirection.
+//
+// The model rules these tests pin down (each one is a rule from the plan):
+//   • ordinals and auto-names never change — a moved pane keeps its identity
+//   • insert always builds a FRESH binary [50,50] branch, like splitPane
+//   • detach collapses the source's old parent, including when it was the root
+//   • swap trades nodes, never sizes — geometry belongs to the slot
+//   • every guard is a real no-op: no mutation, no focus change, no save
+//   • zoom clears, because a move re-flows the layout underneath it
+
+const saveSessionNow = vi.hoisted(() => vi.fn());
+vi.mock('../../../utils/sessionSaveBridge', () => ({ saveSessionNow }));
+
+const publishPaneFocused = vi.hoisted(() => vi.fn());
+vi.mock('../../../events/publisher', () => ({
+  publishPaneCreated: vi.fn(),
+  publishPaneClosed: vi.fn(),
+  publishPaneFocused,
+}));
+
+type TestState = PaneSlice & {
+  workspaces: Workspace[];
+  activeWorkspaceId: string;
+  pushToast: ReturnType<typeof vi.fn>;
+  zoomedPaneId: string | null;
+};
+
+function createTestStore() {
+  const ws = createWorkspace('Test');
+  return create<TestState>()(
+    immer((...args) => ({
+      workspaces: [ws],
+      activeWorkspaceId: ws.id,
+      pushToast: vi.fn(),
+      zoomedPaneId: null,
+      // @ts-expect-error — minimal test store doesn't match full StoreState
+      ...createPaneSlice(...args),
+    }))
+  );
+}
+
+type Store = ReturnType<typeof createTestStore>;
+
+function activeWs(store: Store): Workspace {
+  const s = store.getState();
+  return s.workspaces.find((w) => w.id === s.activeWorkspaceId)!;
+}
+
+/** Leaf ids in DFS order — the same order the UI lays them out. */
+function leafIds(store: Store, ws?: Workspace): string[] {
+  return getLeafPanes((ws ?? activeWs(store)).rootPane).map((l) => l.id);
+}
+
+/**
+ * Build `A | B` (horizontal), then split B again to get a nested tree:
+ *
+ *   root(h) ── A
+ *           └─ inner(h) ── B
+ *                       └─ C
+ */
+function threePaneTree(store: Store): { a: string; b: string; c: string } {
+  const a = activeWs(store).rootPane.id;
+  const b = store.getState().splitPane(a, 'horizontal') as string;
+  const c = store.getState().splitPane(b, 'horizontal') as string;
+  return { a, b, c };
+}
+
+describe('movePane (#645)', () => {
+  let store: Store;
+
+  beforeEach(() => {
+    store = createTestStore();
+    saveSessionNow.mockClear();
+    publishPaneFocused.mockClear();
+  });
+
+  describe('insert geometry', () => {
+    it.each([
+      ['left', 'horizontal', true],
+      ['right', 'horizontal', false],
+      ['top', 'vertical', true],
+      ['bottom', 'vertical', false],
+    ] as const)(
+      'edge=%s builds a %s branch with the source %s',
+      (edge, direction, sourceFirst) => {
+        const { a, b, c } = threePaneTree(store);
+        const ws = activeWs(store);
+
+        expect(store.getState().movePane(ws.id, c, a, edge)).toBe(true);
+
+        const parent = findParent(activeWs(store).rootPane, c)!;
+        expect(parent.direction).toBe(direction);
+        expect(parent.sizes).toEqual([50, 50]);
+        expect(parent.children.map((ch) => ch.id)).toEqual(
+          sourceFirst ? [c, a] : [a, c],
+        );
+        // b is untouched by a move of c next to a
+        expect(findPane(activeWs(store).rootPane, b)).not.toBeNull();
+      },
+    );
+
+    it('always wraps in a fresh binary branch, never flattens into an n-ary one', () => {
+      const { a, b, c } = threePaneTree(store);
+      const ws = activeWs(store);
+
+      // c moves next to b, whose parent is ALREADY a horizontal branch. A
+      // flattening implementation would produce one branch with 2+ children
+      // reusing the parent; we deliberately wrap instead, so the tree a move
+      // produces is indistinguishable from the tree a split produces.
+      store.getState().movePane(ws.id, c, b, 'right');
+
+      const parent = findParent(activeWs(store).rootPane, c)!;
+      expect(parent.children).toHaveLength(2);
+      expect(parent.children.map((ch) => ch.id).sort()).toEqual([b, c].sort());
+      expect(leafIds(store).sort()).toEqual([a, b, c].sort());
+    });
+
+    it('installs the new branch as the root when the target has no parent', () => {
+      // Two leaves: detaching the source collapses the root branch down to the
+      // bare target leaf, so the insert has no parent to splice into and must
+      // put its new branch at ws.rootPane.
+      const a = activeWs(store).rootPane.id;
+      const b = store.getState().splitPane(a, 'horizontal') as string;
+      const ws = activeWs(store);
+      const oldRootId = activeWs(store).rootPane.id;
+
+      store.getState().movePane(ws.id, b, a, 'right');
+
+      const root = activeWs(store).rootPane;
+      expect(root.type).toBe('branch');
+      expect(root.id).not.toBe(oldRootId); // a brand new branch node, not the collapsed one
+      if (root.type === 'branch') {
+        expect(root.children.map((c) => c.id)).toEqual([a, b]);
+        expect(root.sizes).toEqual([50, 50]);
+      }
+    });
+  });
+
+  describe('detach side', () => {
+    it("collapses the source's former parent", () => {
+      const { a, b, c } = threePaneTree(store);
+      const ws = activeWs(store);
+      // Before: root(h)[ A, inner(h)[ B, C ] ]
+      store.getState().movePane(ws.id, c, a, 'left');
+
+      // inner had two children; losing C collapses it, so B is now a direct
+      // child of the root — no empty or single-child branch is left behind.
+      const root = activeWs(store).rootPane;
+      expect(root.type).toBe('branch');
+      if (root.type === 'branch') {
+        const ids = root.children.map((ch) => ch.id);
+        expect(ids).toContain(b);
+        expect(ids).toHaveLength(2);
+      }
+      expect(leafIds(store).sort()).toEqual([a, b, c].sort());
+    });
+
+    it('handles source and target being siblings', () => {
+      // The tricky ordering case: detaching the source collapses the very
+      // branch that also holds the target, so the target node the insert uses
+      // must be re-resolved after the detach.
+      const a = activeWs(store).rootPane.id;
+      const b = store.getState().splitPane(a, 'horizontal') as string;
+      const ws = activeWs(store);
+
+      expect(store.getState().movePane(ws.id, b, a, 'bottom')).toBe(true);
+
+      const root = activeWs(store).rootPane;
+      expect(root.type).toBe('branch');
+      if (root.type === 'branch') {
+        expect(root.direction).toBe('vertical');
+        // edge='bottom' → the source lands second (below the target)
+        expect(root.children.map((c) => c.id)).toEqual([a, b]);
+      }
+      expect(leafIds(store)).toHaveLength(2);
+    });
+  });
+
+  describe('identity and persistence', () => {
+    it('never reassigns ordinals or bumps the workspace counter', () => {
+      const { a, c } = threePaneTree(store);
+      const before = new Map(
+        getLeafPanes(activeWs(store).rootPane).map((l) => [l.id, l.ordinal]),
+      );
+      const nextOrdinalBefore = activeWs(store).nextPaneOrdinal;
+
+      store.getState().movePane(activeWs(store).id, c, a, 'right');
+
+      for (const leaf of getLeafPanes(activeWs(store).rootPane)) {
+        expect(leaf.ordinal).toBe(before.get(leaf.id));
+      }
+      expect(activeWs(store).nextPaneOrdinal).toBe(nextOrdinalBefore);
+    });
+
+    it('flushes the session immediately', () => {
+      const { a, c } = threePaneTree(store);
+      store.getState().movePane(activeWs(store).id, c, a, 'right');
+      expect(saveSessionNow).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the zoom, because the layout re-flows underneath it', () => {
+      const { a, c } = threePaneTree(store);
+      store.setState((s) => { s.zoomedPaneId = a; });
+
+      store.getState().movePane(activeWs(store).id, c, a, 'right');
+
+      expect(store.getState().zoomedPaneId).toBeNull();
+    });
+  });
+
+  describe('focus', () => {
+    it('leaves the active pane alone by default', () => {
+      const { a, b, c } = threePaneTree(store);
+      const ws = activeWs(store);
+      store.getState().setActivePane(b);
+      publishPaneFocused.mockClear();
+
+      store.getState().movePane(ws.id, c, a, 'right');
+
+      expect(activeWs(store).activePaneId).toBe(b);
+      expect(publishPaneFocused).not.toHaveBeenCalled();
+    });
+
+    it('focuses the source and emits pane.focused when asked', () => {
+      const { a, b, c } = threePaneTree(store);
+      const ws = activeWs(store);
+      store.getState().setActivePane(b);
+      publishPaneFocused.mockClear();
+
+      store.getState().movePane(ws.id, c, a, 'right', { focusSource: true });
+
+      expect(activeWs(store).activePaneId).toBe(c);
+      expect(publishPaneFocused).toHaveBeenCalledWith(ws.id, c, b);
+    });
+
+    it('does not emit when the source was already active', () => {
+      const { a, c } = threePaneTree(store);
+      const ws = activeWs(store);
+      store.getState().setActivePane(c);
+      publishPaneFocused.mockClear();
+
+      store.getState().movePane(ws.id, c, a, 'right', { focusSource: true });
+
+      expect(publishPaneFocused).not.toHaveBeenCalled();
+    });
+
+    it('does not touch the visible workspace when moving in a background one', () => {
+      threePaneTree(store);
+      const visibleId = activeWs(store).id;
+      const visibleActive = activeWs(store).activePaneId;
+      const visibleTree = JSON.stringify(activeWs(store).rootPane);
+
+      const bg = createWorkspace('Background');
+      store.setState((s) => { s.workspaces.push(bg); });
+      const bgFirst = bg.rootPane.id;
+      const bgSecond = store.getState().splitPane(bgFirst, 'horizontal', bg.id) as string;
+
+      store.getState().movePane(bg.id, bgSecond, bgFirst, 'bottom', { focusSource: true });
+
+      // The background workspace really moved…
+      const bgAfter = store.getState().workspaces.find((w) => w.id === bg.id)!;
+      expect(bgAfter.rootPane.type).toBe('branch');
+      expect(bgAfter.activePaneId).toBe(bgSecond);
+      // …and the workspace on screen is byte-for-byte untouched.
+      expect(activeWs(store).id).toBe(visibleId);
+      expect(activeWs(store).activePaneId).toBe(visibleActive);
+      expect(JSON.stringify(activeWs(store).rootPane)).toBe(visibleTree);
+    });
+  });
+
+  describe('no-op guards', () => {
+    /** Snapshot enough state to prove "nothing happened". */
+    function snapshot(store: Store) {
+      return {
+        tree: JSON.stringify(activeWs(store).rootPane),
+        active: activeWs(store).activePaneId,
+        saves: saveSessionNow.mock.calls.length,
+      };
+    }
+
+    it.each([
+      [
+        'source === target',
+        (s: Store, ids: { a: string; c: string }) =>
+          s.getState().movePane(activeWs(s).id, ids.c, ids.c, 'right'),
+      ],
+      [
+        'unknown workspace',
+        (s: Store, ids: { a: string; c: string }) =>
+          s.getState().movePane('ws-does-not-exist', ids.c, ids.a, 'right'),
+      ],
+      [
+        'unknown source',
+        (s: Store, ids: { a: string; c: string }) =>
+          s.getState().movePane(activeWs(s).id, 'pane-nope', ids.a, 'right'),
+      ],
+      [
+        'unknown target',
+        (s: Store, ids: { a: string; c: string }) =>
+          s.getState().movePane(activeWs(s).id, ids.c, 'pane-nope', 'right'),
+      ],
+      [
+        'branch id as source',
+        (s: Store, ids: { a: string; c: string }) =>
+          s.getState().movePane(activeWs(s).id, activeWs(s).rootPane.id, ids.a, 'right'),
+      ],
+      [
+        'branch id as target',
+        (s: Store, ids: { a: string; c: string }) =>
+          s.getState().movePane(activeWs(s).id, ids.c, activeWs(s).rootPane.id, 'right'),
+      ],
+    ])('%s → false, no mutation, no save', (_label, act) => {
+      const { a, c } = threePaneTree(store);
+      saveSessionNow.mockClear();
+      const before = snapshot(store);
+
+      expect(act(store, { a, c })).toBe(false);
+
+      expect(snapshot(store)).toEqual(before);
+    });
+
+    it('refuses to move the only pane in a workspace', () => {
+      const only = activeWs(store).rootPane.id;
+      const ws = activeWs(store);
+      expect(store.getState().movePane(ws.id, only, only, 'right')).toBe(false);
+      expect(saveSessionNow).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('swapPanes (#645)', () => {
+  let store: Store;
+
+  beforeEach(() => {
+    store = createTestStore();
+    saveSessionNow.mockClear();
+  });
+
+  it('trades two leaves without touching the tree shape', () => {
+    const { a, b, c } = threePaneTree(store);
+    const shapeBefore = describeShape(activeWs(store).rootPane);
+
+    expect(store.getState().swapPanes(activeWs(store).id, a, c)).toBe(true);
+
+    expect(describeShape(activeWs(store).rootPane)).toEqual(shapeBefore);
+    // a and c changed places in DFS order; b did not move
+    expect(leafIds(store)).toEqual([c, b, a]);
+  });
+
+  it('leaves sizes with the SLOT, not with the pane', () => {
+    const { a, c } = threePaneTree(store);
+    store.setState((s) => {
+      const ws = s.workspaces.find((w) => w.id === s.activeWorkspaceId)!;
+      if (ws.rootPane.type === 'branch') ws.rootPane.sizes = [70, 30];
+    });
+
+    store.getState().swapPanes(activeWs(store).id, a, c);
+
+    const root = activeWs(store).rootPane;
+    expect(root.type).toBe('branch');
+    if (root.type === 'branch') {
+      // A pane swapped into the 70% slot becomes 70% wide. That is what a swap
+      // looks like on screen; carrying sizes along would be a "move" instead.
+      expect(root.sizes).toEqual([70, 30]);
+      expect(root.children[0].id).toBe(c);
+    }
+  });
+
+  it('keeps ordinals with their panes', () => {
+    const { a, c } = threePaneTree(store);
+    const ordinalOf = (id: string) =>
+      getLeafPanes(activeWs(store).rootPane).find((l) => l.id === id)!.ordinal;
+    const aOrdinal = ordinalOf(a);
+    const cOrdinal = ordinalOf(c);
+
+    store.getState().swapPanes(activeWs(store).id, a, c);
+
+    expect(ordinalOf(a)).toBe(aOrdinal);
+    expect(ordinalOf(c)).toBe(cOrdinal);
+  });
+
+  it('flushes the session', () => {
+    const { a, c } = threePaneTree(store);
+    store.getState().swapPanes(activeWs(store).id, a, c);
+    expect(saveSessionNow).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['same pane', (s: Store, ids: { a: string; c: string }) => s.getState().swapPanes(activeWs(s).id, ids.a, ids.a)],
+    ['unknown workspace', (s: Store, ids: { a: string; c: string }) => s.getState().swapPanes('nope', ids.a, ids.c)],
+    ['unknown pane', (s: Store, ids: { a: string; c: string }) => s.getState().swapPanes(activeWs(s).id, ids.a, 'nope')],
+    ['branch id', (s: Store, ids: { a: string; c: string }) => s.getState().swapPanes(activeWs(s).id, ids.a, activeWs(s).rootPane.id)],
+  ])('%s → false, no mutation', (_label, act) => {
+    const { a, c } = threePaneTree(store);
+    saveSessionNow.mockClear();
+    const before = JSON.stringify(activeWs(store).rootPane);
+
+    expect(act(store, { a, c })).toBe(false);
+
+    expect(JSON.stringify(activeWs(store).rootPane)).toBe(before);
+    expect(saveSessionNow).not.toHaveBeenCalled();
+  });
+});
+
+describe('moveActivePaneDirection (#645)', () => {
+  let store: Store;
+
+  beforeEach(() => {
+    store = createTestStore();
+    saveSessionNow.mockClear();
+  });
+
+  it('walks the pane across the layout instead of oscillating', () => {
+    // A | B | C with the active pane A. Moving right twice should end with A
+    // on the far right, not bouncing between the first two slots.
+    const { a } = threePaneTree(store);
+    store.getState().setActivePane(a);
+
+    expect(store.getState().moveActivePaneDirection('right')).toBe(true);
+    const afterFirst = leafIds(store);
+    expect(afterFirst[afterFirst.length - 1]).not.toBe(a); // moved, not yet last
+
+    store.getState().moveActivePaneDirection('right');
+    const afterSecond = leafIds(store);
+    expect(afterSecond[afterSecond.length - 1]).toBe(a);
+    expect(afterSecond).toHaveLength(3);
+  });
+
+  it('keeps focus on the pane the user is moving', () => {
+    const { a } = threePaneTree(store);
+    store.getState().setActivePane(a);
+
+    store.getState().moveActivePaneDirection('right');
+
+    expect(activeWs(store).activePaneId).toBe(a);
+  });
+
+  it('returns false when there is no neighbour that way', () => {
+    const { a } = threePaneTree(store);
+    store.getState().setActivePane(a);
+    const before = JSON.stringify(activeWs(store).rootPane);
+
+    // The tree is purely horizontal, so there is nothing above A.
+    expect(store.getState().moveActivePaneDirection('up')).toBe(false);
+    expect(JSON.stringify(activeWs(store).rootPane)).toBe(before);
+    expect(saveSessionNow).not.toHaveBeenCalled();
+  });
+
+  it('returns false in a single-pane workspace', () => {
+    expect(store.getState().moveActivePaneDirection('left')).toBe(false);
+    expect(saveSessionNow).not.toHaveBeenCalled();
+  });
+});
+
+/** Structural fingerprint: shape and direction only, ignoring which leaf sits where. */
+function describeShape(pane: Pane): unknown {
+  if (pane.type === 'leaf') return 'leaf';
+  return { direction: pane.direction, children: pane.children.map(describeShape) };
+}

--- a/src/renderer/stores/slices/__tests__/paneSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneSlice.test.ts
@@ -260,6 +260,43 @@ describe('PaneSlice', () => {
   });
 
   describe('closePane', () => {
+    it('keeps sizes[] aligned with children when a 3-child branch loses its middle pane', () => {
+      // A 3-child branch is the only shape where the misalignment is visible:
+      // 2 children collapse the branch away, so `sizes` is discarded with it.
+      const ws = getActiveWorkspace(store);
+      const a = ws.rootPane.id;
+      const b = store.getState().splitPane(a, 'horizontal') as string;
+      store.getState().splitPane(b, 'horizontal');
+
+      // Flatten to one branch with three leaves and uneven sizes, which is what
+      // a user produces by dragging the separators after two splits.
+      const rootBranchId = getActiveWorkspace(store).rootPane.id;
+      const leaves = getLeafPanes(getActiveWorkspace(store).rootPane).map((l) => l.id);
+      store.setState((s) => {
+        const w = s.workspaces.find((x) => x.id === s.activeWorkspaceId)!;
+        w.rootPane = {
+          id: rootBranchId,
+          type: 'branch',
+          direction: 'horizontal',
+          children: leaves.map((id) => findPane(w.rootPane, id)!),
+          sizes: [20, 50, 30],
+        };
+      });
+
+      store.getState().closePane(leaves[1]);
+
+      const root = getActiveWorkspace(store).rootPane;
+      expect(root.type).toBe('branch');
+      if (root.type === 'branch') {
+        expect(root.children.map((c) => c.id)).toEqual([leaves[0], leaves[2]]);
+        expect(root.sizes).toHaveLength(2);
+        expect(root.sizes!.reduce((sum, s) => sum + s, 0)).toBeCloseTo(100);
+        // The survivors keep their 20:30 ratio, renormalized to 40:60.
+        expect(root.sizes![0]).toBeCloseTo(40);
+        expect(root.sizes![1]).toBeCloseTo(60);
+      }
+    });
+
     it('closes a pane in a non-active workspace via the workspaceId parameter', () => {
       const ws1 = getActiveWorkspace(store);
       const ws2 = createWorkspace('Other');

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -21,6 +21,7 @@ import { t } from '../../i18n';
 import { clearNudgesFor } from '../../hooks/channelMentionRateLimit';
 import { panePrincipalId } from '../../../shared/principals';
 import { computePaneAutoName } from '../../utils/paneNaming';
+import { saveSessionNow } from '../../utils/sessionSaveBridge';
 
 // Per-workspace leaf cap. xterm.js + node-pty memory scales linearly with
 // pane count, and the project memory budget targets ~200 MB for 10 panes
@@ -50,6 +51,51 @@ export interface PaneSlice {
    * non-active workspace (defaults to the active one — existing callers are
    * unchanged). */
   closePane: (paneId: string, workspaceId?: string) => void;
+  /**
+   * Issue #645 — move a leaf next to another leaf, tmux `join-pane` style.
+   *
+   * `workspaceId` is EXPLICIT and never inferred: a multiview drag can start in
+   * a workspace that is not `activeWorkspaceId`, and the store cannot guess
+   * which tile the gesture came from.
+   *
+   * `edge` picks the branch direction and the child order — left/right build a
+   * horizontal branch, top/bottom a vertical one; left/top put the source
+   * first. The insert always wraps the target in a FRESH binary `[50,50]`
+   * branch, exactly like `splitPane`, so a moved tree is indistinguishable
+   * from a split tree and every existing invariant keeps applying.
+   *
+   * `focusSource` defaults to false — the active pane is left alone. A drag of
+   * an inactive pane passes true, because grabbing a pane means you meant it.
+   * When the active pane really changes, `pane.focused` is emitted (the "no new
+   * events" rule is about a `pane.moved` type, not about hiding a real focus
+   * change).
+   *
+   * Returns false — with no mutation, no emit, no save — for every guard:
+   * unknown workspace, unknown/non-leaf source or target, source === target,
+   * or a source that has no parent (the root, i.e. the only pane).
+   */
+  movePane: (
+    workspaceId: string,
+    sourceId: string,
+    targetId: string,
+    edge: 'left' | 'right' | 'top' | 'bottom',
+    opts?: { focusSource?: boolean },
+  ) => boolean;
+  /**
+   * Issue #645 — exchange two leaves in place (tmux `swap-pane`). The tree
+   * shape and every `sizes` array are untouched: only the two nodes trade
+   * slots, so each pane inherits the geometry of the slot it lands in.
+   * Returns false on the same guards as `movePane`.
+   */
+  swapPanes: (workspaceId: string, aId: string, bId: string) => boolean;
+  /**
+   * Issue #645 — move the active pane one step in a direction, reusing the
+   * spatial traversal that `focusPaneDirection` already uses so navigation and
+   * movement agree by construction. The pane lands on the FAR side of the
+   * neighbour it displaces, so repeating the command walks it across the
+   * layout instead of oscillating. No neighbour → false.
+   */
+  moveActivePaneDirection: (direction: 'up' | 'down' | 'left' | 'right') => boolean;
   setActivePane: (paneId: string) => void;
   /**
    * Focus a leaf pane (and optionally one of its surfaces) in an EXPLICIT
@@ -191,6 +237,52 @@ const ATTENTION_STATUSES: ReadonlySet<AgentStatus> = new Set<AgentStatus>([
   'waiting',
   'awaiting_input',
 ]);
+
+/** First (leftmost/topmost) leaf of a subtree. */
+function firstLeaf(pane: Pane): PaneLeaf {
+  if (pane.type === 'leaf') return pane;
+  return firstLeaf(pane.children[0]);
+}
+
+/** Last (rightmost/bottommost) leaf of a subtree. */
+function lastLeaf(pane: Pane): PaneLeaf {
+  if (pane.type === 'leaf') return pane;
+  return lastLeaf(pane.children[pane.children.length - 1]);
+}
+
+/**
+ * Tree-based spatial navigation: the leaf you reach by moving `dir` out of
+ * `paneId`. Walks up until it finds an ancestor split along the requested axis
+ * with a sibling on that side, then descends to the nearest leaf.
+ *
+ * Shared by `focusPaneDirection` and (issue #645) `moveActivePaneDirection`, so
+ * "the pane to my right" means the same thing whether you are moving focus or
+ * moving the pane itself. It is tree-order-based, not geometric — in deeply
+ * nested asymmetric layouts the neighbour can differ from what is literally
+ * adjacent on screen, which has always been true of focus movement here.
+ */
+function navigateFrom(root: Pane, paneId: string, dir: 'up' | 'down' | 'left' | 'right'): string | null {
+  const parent = findParent(root, paneId);
+  if (!parent) return null; // at root
+
+  const idx = parent.children.findIndex((c) => c.id === paneId);
+  const isAligned =
+    (parent.direction === 'horizontal' && (dir === 'left' || dir === 'right')) ||
+    (parent.direction === 'vertical' && (dir === 'up' || dir === 'down'));
+
+  if (isAligned) {
+    const delta = dir === 'right' || dir === 'down' ? 1 : -1;
+    const nextIdx = idx + delta;
+    if (nextIdx >= 0 && nextIdx < parent.children.length) {
+      // Move to adjacent sibling — descend to nearest leaf
+      const sibling = parent.children[nextIdx];
+      return (delta > 0 ? firstLeaf(sibling) : lastLeaf(sibling)).id;
+    }
+  }
+
+  // Direction not aligned or no sibling in that direction — go up
+  return navigateFrom(root, parent.id, dir);
+}
 
 /**
  * Detach a child from its parent branch and collapse the parent when only one
@@ -653,6 +745,126 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
     }
   },
 
+  movePane: (workspaceId, sourceId, targetId, edge, opts) => {
+    let event: { wsId: string; paneId: string; previousActiveId: string } | null = null;
+    let moved = false;
+    set((state: StoreState) => {
+      const ws = state.workspaces.find((w: Workspace) => w.id === workspaceId);
+      if (!ws) return;
+      if (sourceId === targetId) return;
+
+      const source = findPane(ws.rootPane, sourceId);
+      const target = findPane(ws.rootPane, targetId);
+      if (!source || source.type !== 'leaf') return;
+      if (!target || target.type !== 'leaf') return;
+      // A leaf with no parent is the whole workspace — nothing to move it out of.
+      if (!findParent(ws.rootPane, sourceId)) return;
+
+      const detached = detachPane(ws, sourceId);
+      if (!detached) return;
+
+      // Re-resolve the target AFTER the detach: collapsing the source's former
+      // parent can replace the node that held it, so a reference captured
+      // before the splice may no longer be the one in the tree.
+      const targetParent = findParent(ws.rootPane, targetId);
+      const liveTarget = findPane(ws.rootPane, targetId);
+      if (!liveTarget) return; // unreachable: only the source was removed
+
+      const direction = edge === 'left' || edge === 'right' ? 'horizontal' : 'vertical';
+      const sourceFirst = edge === 'left' || edge === 'top';
+      const branch: PaneBranch = {
+        id: generateId('pane'),
+        type: 'branch',
+        direction,
+        children: sourceFirst ? [detached, liveTarget] : [liveTarget, detached],
+        sizes: [50, 50],
+      };
+
+      if (targetParent) {
+        const idx = targetParent.children.findIndex((c) => c.id === targetId);
+        if (idx !== -1) targetParent.children[idx] = branch;
+      } else {
+        ws.rootPane = branch;
+      }
+
+      // #182: a move re-flows the layout, so a pane hidden behind the zoom would
+      // reappear somewhere unexpected. Same reasoning as splitPane.
+      if (state.zoomedPaneId !== null && findPane(ws.rootPane, state.zoomedPaneId)) {
+        state.zoomedPaneId = null;
+      }
+
+      if (opts?.focusSource) {
+        const previousActiveId = ws.activePaneId;
+        if (previousActiveId !== sourceId) {
+          ws.activePaneId = sourceId;
+          event = { wsId: ws.id, paneId: sourceId, previousActiveId };
+        }
+      }
+
+      moved = true;
+    });
+    if (event) {
+      const e = event as { wsId: string; paneId: string; previousActiveId: string };
+      publishPaneFocused(e.wsId, e.paneId, e.previousActiveId);
+    }
+    // Pane-tree mutations otherwise ride only the 5s autosave, so a move
+    // followed by an immediate quit would be lost. Flush outside the producer.
+    if (moved) saveSessionNow();
+    return moved;
+  },
+
+  swapPanes: (workspaceId, aId, bId) => {
+    let swapped = false;
+    set((state: StoreState) => {
+      const ws = state.workspaces.find((w: Workspace) => w.id === workspaceId);
+      if (!ws) return;
+      if (aId === bId) return;
+
+      const a = findPane(ws.rootPane, aId);
+      const b = findPane(ws.rootPane, bId);
+      if (!a || a.type !== 'leaf') return;
+      if (!b || b.type !== 'leaf') return;
+
+      const aParent = findParent(ws.rootPane, aId);
+      const bParent = findParent(ws.rootPane, bId);
+      // Neither can be the root: a root leaf is the only pane in the workspace.
+      if (!aParent || !bParent) return;
+
+      const aIdx = aParent.children.findIndex((c) => c.id === aId);
+      const bIdx = bParent.children.findIndex((c) => c.id === bId);
+      if (aIdx === -1 || bIdx === -1) return;
+
+      // Only the two nodes trade places. `sizes` belongs to the SLOT, not to
+      // the pane, so it is deliberately left alone — a pane swapped into a 70%
+      // slot becomes 70% wide, which is what "swap" means on screen.
+      aParent.children[aIdx] = b;
+      bParent.children[bIdx] = a;
+
+      swapped = true;
+    });
+    if (swapped) saveSessionNow();
+    return swapped;
+  },
+
+  moveActivePaneDirection: (direction) => {
+    const state = get();
+    const ws = state.workspaces.find((w: Workspace) => w.id === state.activeWorkspaceId);
+    if (!ws) return false;
+
+    const neighbourId = navigateFrom(ws.rootPane, ws.activePaneId, direction);
+    if (!neighbourId || neighbourId === ws.activePaneId) return false;
+
+    // Land on the FAR side of the displaced neighbour: moving right past a
+    // right-hand neighbour puts the pane to that neighbour's right, so the next
+    // "move right" keeps walking instead of swapping back and forth.
+    const edge =
+      direction === 'left' ? 'left' : direction === 'right' ? 'right' : direction === 'up' ? 'top' : 'bottom';
+
+    // The pane the user is moving is the one they are looking at, so it keeps
+    // focus — otherwise focus would be left behind on whatever slot it vacated.
+    return get().movePane(ws.id, ws.activePaneId, neighbourId, edge, { focusSource: true });
+  },
+
   setActivePane: (paneId) => {
     let event: { wsId: string; paneId: string; previousActiveId: string } | null = null;
     set((state: StoreState) => {
@@ -778,44 +990,9 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
     const leaves = getLeafPanes(ws.rootPane);
     if (leaves.length <= 1) return;
 
-    // Helper: get first leaf in a subtree (leftmost/topmost)
-    const firstLeaf = (pane: Pane): PaneLeaf => {
-      if (pane.type === 'leaf') return pane;
-      return firstLeaf(pane.children[0]);
-    };
-
-    // Helper: get last leaf in a subtree (rightmost/bottommost)
-    const lastLeaf = (pane: Pane): PaneLeaf => {
-      if (pane.type === 'leaf') return pane;
-      return lastLeaf(pane.children[pane.children.length - 1]);
-    };
-
-    // Tree-based spatial navigation
-    const navigate = (paneId: string, dir: 'up' | 'down' | 'left' | 'right'): string | null => {
-      const parent = findParent(ws.rootPane, paneId);
-      if (!parent) return null; // at root
-
-      const idx = parent.children.findIndex(c => c.id === paneId);
-      const isAligned =
-        (parent.direction === 'horizontal' && (dir === 'left' || dir === 'right')) ||
-        (parent.direction === 'vertical' && (dir === 'up' || dir === 'down'));
-
-      if (isAligned) {
-        const delta = (dir === 'right' || dir === 'down') ? 1 : -1;
-        const nextIdx = idx + delta;
-        if (nextIdx >= 0 && nextIdx < parent.children.length) {
-          // Move to adjacent sibling — descend to nearest leaf
-          const sibling = parent.children[nextIdx];
-          const leaf = delta > 0 ? firstLeaf(sibling) : lastLeaf(sibling);
-          return leaf.id;
-        }
-      }
-
-      // Direction not aligned or no sibling in that direction — go up
-      return navigate(parent.id, dir);
-    };
-
-    const targetId = navigate(ws.activePaneId, direction);
+    // Spatial navigation lives in navigateFrom (module scope) so that moving a
+    // pane and moving focus resolve "the pane to my right" identically (#645).
+    const targetId = navigateFrom(ws.rootPane, ws.activePaneId, direction);
     if (targetId && targetId !== ws.activePaneId) {
       event = { wsId: ws.id, paneId: targetId, previousActiveId: ws.activePaneId };
       ws.activePaneId = targetId;

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -220,6 +220,21 @@ function detachPane(ws: Workspace, paneId: string): Pane | null {
 
   const [detached] = parent.children.splice(idx, 1);
 
+  // Keep `sizes` aligned with `children`. Before this existed, closePane
+  // spliced the child and left `sizes` untouched, so a branch with three or
+  // more children rendered its survivors at the wrong widths after a close
+  // (sizes[] was longer than children[] and the extra entry shifted every
+  // panel one slot to the left). A two-child branch hid the bug because it
+  // collapses away below.
+  if (parent.sizes) {
+    parent.sizes.splice(idx, 1);
+    const total = parent.sizes.reduce((sum, s) => sum + s, 0);
+    parent.sizes =
+      total > 0
+        ? parent.sizes.map((s) => (s / total) * 100)
+        : parent.children.map(() => 100 / parent.children.length);
+  }
+
   if (parent.children.length === 1) {
     // Collapse: replace the parent with its remaining child.
     const remaining = parent.children[0];

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -7,6 +7,12 @@ import {
   generateId,
 } from '../../../shared/types';
 import {
+  findPane,
+  findParent,
+  collectLeafIds,
+  getLeafPanes,
+} from '../../../shared/paneUtils';
+import {
   publishPaneCreated,
   publishPaneClosed,
   publishPaneFocused,
@@ -186,36 +192,50 @@ const ATTENTION_STATUSES: ReadonlySet<AgentStatus> = new Set<AgentStatus>([
   'awaiting_input',
 ]);
 
-function findPane(root: Pane, id: string): Pane | null {
-  if (root.id === id) return root;
-  if (root.type === 'branch') {
-    for (const child of root.children) {
-      const found = findPane(child, id);
-      if (found) return found;
+/**
+ * Detach a child from its parent branch and collapse the parent when only one
+ * child is left — the structural half of both `closePane` and (issue #645)
+ * `movePane`. Pure structure: it never touches surfaces, PTY maps, principals,
+ * or focus, so a caller that wants a pane GONE must do that teardown itself.
+ *
+ *   before                    detach(B)              collapse
+ *   ┌── branch ──┐            ┌── branch ──┐
+ *   │  A   B   C │    ──▶     │  A     C   │   (3 children → no collapse)
+ *   └────────────┘            └────────────┘
+ *
+ *   ┌── branch ──┐            ┌─ branch ─┐
+ *   │   A    B   │    ──▶     │    A     │    ──▶   A replaces the branch
+ *   └────────────┘            └──────────┘         (in the grandparent, or
+ *                                                   as ws.rootPane)
+ *
+ * Returns the detached subtree, or null when the id is unknown or is the root
+ * (the root has no parent, so there is nothing to detach it from).
+ */
+function detachPane(ws: Workspace, paneId: string): Pane | null {
+  const parent = findParent(ws.rootPane, paneId);
+  if (!parent) return null; // unknown id, or the root pane itself
+
+  const idx = parent.children.findIndex((c) => c.id === paneId);
+  if (idx === -1) return null;
+
+  const [detached] = parent.children.splice(idx, 1);
+
+  if (parent.children.length === 1) {
+    // Collapse: replace the parent with its remaining child.
+    const remaining = parent.children[0];
+    const grandParent = findParent(ws.rootPane, parent.id);
+    if (grandParent) {
+      const parentIdx = grandParent.children.findIndex((c) => c.id === parent.id);
+      if (parentIdx !== -1) {
+        grandParent.children[parentIdx] = remaining;
+      }
+    } else {
+      // Parent was root
+      ws.rootPane = remaining;
     }
   }
-  return null;
-}
 
-function findParent(root: Pane, id: string): PaneBranch | null {
-  if (root.type === 'branch') {
-    for (const child of root.children) {
-      if (child.id === id) return root;
-      const found = findParent(child, id);
-      if (found) return found;
-    }
-  }
-  return null;
-}
-
-function collectLeafIds(pane: Pane): string[] {
-  if (pane.type === 'leaf') return [pane.id];
-  return pane.children.flatMap(collectLeafIds);
-}
-
-function getLeafPanes(root: Pane): PaneLeaf[] {
-  if (root.type === 'leaf') return [root];
-  return root.children.flatMap(getLeafPanes);
+  return detached;
 }
 
 export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]], [], PaneSlice> = (set, get) => ({
@@ -569,22 +589,10 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
       }
 
       const previousActiveId = ws.activePaneId;
-      parent.children.splice(idx, 1);
-
-      if (parent.children.length === 1) {
-        // Collapse: replace parent with the remaining child
-        const remaining = parent.children[0];
-        const grandParent = findParent(ws.rootPane, parent.id);
-        if (grandParent) {
-          const parentIdx = grandParent.children.findIndex((c) => c.id === parent.id);
-          if (parentIdx !== -1) {
-            grandParent.children[parentIdx] = remaining;
-          }
-        } else {
-          // Parent was root
-          ws.rootPane = remaining;
-        }
-      }
+      // Structural removal lives in detachPane (shared with movePane, #645);
+      // everything above and below this line is the destructive teardown that
+      // only closing does.
+      detachPane(ws, paneId);
 
       // Update active pane
       const leaves = getLeafPanes(ws.rootPane);

--- a/src/renderer/stores/slices/uiSlice.ts
+++ b/src/renderer/stores/slices/uiSlice.ts
@@ -577,6 +577,15 @@ export interface UISlice {
   zoomedPaneId: string | null;
   togglePaneZoom: (paneId: string) => void;
 
+  // ─── Pane drag (#645) ─────────────────────────────────────────────
+  // Transient drag feedback, never persisted. The GRIP publishes both; the
+  // pane being hovered reads paneDropTarget to draw its own indicator, which
+  // is why this lives in the store rather than in the dragging component.
+  paneDragSourceId: string | null;
+  paneDropTarget: { paneId: string; edge: 'left' | 'right' | 'top' | 'bottom' | null } | null;
+  setPaneDragSource: (paneId: string | null) => void;
+  setPaneDropTarget: (target: { paneId: string; edge: 'left' | 'right' | 'top' | 'bottom' | null } | null) => void;
+
   // ─── Plugin pane decorations (B-1 ui.pane-decoration) ─────────────
   // paneId → plugin → decoration. Written by the ui.decoratePane RPC push
   // (usePaneDecorationChannel); badge=null payloads delete the entry.
@@ -1526,6 +1535,18 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
 
   togglePaneZoom: (paneId) => set((state) => {
     state.zoomedPaneId = state.zoomedPaneId === paneId ? null : paneId;
+  }),
+
+  // ─── Pane drag (#645) ─────────────────────────────────────────────
+  paneDragSourceId: null,
+  paneDropTarget: null,
+
+  setPaneDragSource: (paneId) => set((state) => {
+    state.paneDragSourceId = paneId;
+  }),
+
+  setPaneDropTarget: (target) => set((state) => {
+    state.paneDropTarget = target;
   }),
 
   // ─── Plugin pane decorations (B-1 ui.pane-decoration) ─────────────

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -589,6 +589,14 @@ export const DEFAULT_PREFIX_CONFIG: PrefixConfig = {
     'ArrowDown': 'focusDown',
     'ArrowLeft': 'focusLeft',
     'ArrowRight': 'focusRight',
+    // #645 — pane movement. `{`/`}` are tmux's swap-pane keys; the uppercase
+    // arrows pair with the lowercase ones above (focus vs move the pane).
+    '{': 'swapPanePrev',
+    '}': 'swapPaneNext',
+    'K': 'movePaneUp',
+    'J': 'movePaneDown',
+    'H': 'movePaneLeft',
+    'L': 'movePaneRight',
   },
 };
 


### PR DESCRIPTION
Panes could only be created and closed. Getting the arrangement you wanted meant splitting in exactly the right order from the start, and if you got it wrong the only way back was to close panes and re-split — which is what #645 asked us to fix.

Now you can rearrange a layout you already have, three ways:

- **Drag** the grip in a pane's tab strip. Drop on another pane's edge to move it there; drop on its centre to swap the two. The pane you are hovering shows where it will land. `Esc` aborts.
- **Keyboard**: `Ctrl+B` then `H`/`J`/`K`/`L` walks the active pane left/down/up/right; `{` / `}` swap it with its neighbour, as in tmux.
- **Command palette**: the four directional moves.

Panes keep their names (ordinals are never reissued) and their scrollback wherever they land.

## Why there is no "keep the pane mounted" machinery

The plan for this started with a DOM-stable pane host: render each pane body once and move that node between layout slots, so a pane never unmounts and never loses anything. It was dropped after measuring, not after arguing.

A cross-parent move does recreate the xterm instance — but the daemon resync ladder restores the buffer faithfully. Measured on a live build: **500 → 500 lines, and at depth 6000 → 6000 lines including the oldest**. The only thing actually lost is the text selection. Browser surfaces are `<webview>` tags whose guest is recreated on any DOM reparent, so the host would not have saved them either. The complexity had nothing left to buy.

## Semantics

tmux, not a free-form grid. An insert always wraps the target in a fresh binary `[50,50]` branch, exactly as `splitPane` does, so a moved tree is indistinguishable from a split tree and every existing invariant keeps applying.

`movePane` and `swapPanes` both take an explicit `workspaceId` — a multiview gesture can start in a workspace that is not the active one, and the store cannot guess which. Focus is an input rather than a side effect.

## Pre-existing defects fixed along the way

- `closePane` spliced a child out and left `parent.sizes` untouched. With three or more children the survivors rendered at the wrong widths. Two-pane splits collapse the branch, which is why it stayed hidden. Now fixed in the shared `detachPane` primitive, with its own test.
- `PaneContainer`'s 200ms resize debounce had no unmount cleanup and no idea which children its sizes described, so a resize ending just before a restructure could overwrite the new layout.

## Verification

Unit and jsdom tests throughout (the drag test file is explicit about what jsdom cannot prove — the panels library never applies a layout without real measurement).

Live dogfood on a dev build, all passing: a terminal pane moved across the tree (PTY alive, scrollback intact), a browser pane moved (URL preserved), and move → restart → restore returning an identical tree with identical ordinals. The drag gesture itself was driven end to end: the indicator predicts the landing spot, `Esc` leaves both tree and focus untouched, and the tabs' existing text-export drag is unaffected.

Two bugs were caught only by driving the real app — a selector returning a fresh object each read (infinite render), and `Esc` cancelling the drag but still moving focus. Both are covered by tests now.

## Three-way review

Reviewed independently by Claude, Codex and GLM-5.2. No P1. Five P2s, all fixed with a regression test each: drag state stranded when a pane closes mid-drag, pointer capture never released, the grip dead in a background multiview tile, no focus after a centre swap, and `lostpointercapture` unhandled. Notably the three reviewers overlapped almost not at all — each found a different class of problem.

Closes #645

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rearrange panes by dragging and dropping, with support for swapping or moving panes to specific edges.
  * Move the active pane using keyboard shortcuts or command-palette commands.
  * Added pane movement and swapping actions to configurable key bindings.
  * Pane names, scrollback, focus, and layout sizing are preserved during rearrangement.

* **Bug Fixes**
  * Fixed incorrect pane sizing after closing a pane in layouts with three or more panes.

* **Tests**
  * Added comprehensive coverage for pane movement, dragging, swapping, sizing, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->