### PR TITLE
Keep the mode menu and the composer note on screen

### DIFF
--- a/changelog.d/777.md
+++ b/changelog.d/777.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- The workspace mode dropdown no longer runs off the top of the window. It
+  opens toward whichever side has room and caps its height there, so `Off`
+  stays reachable in a short window — autonomy can always be lowered again.
+- The orchestrator's "mode is off" note in the deck composer is no longer cut
+  off. The placeholder shows a one-line form; the full explanation stays on
+  hover.

--- a/src/renderer/components/Deck/AgentModeChip.tsx
+++ b/src/renderer/components/Deck/AgentModeChip.tsx
@@ -18,7 +18,7 @@
 // the container. Renders nothing when the preload is absent, so pure jsdom tests
 // of the parent view are unaffected.
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { tokenAttrs } from '../../themes';
 import { FOCUS_RING } from '../focusRing';
 import type { AgentMode } from '../../../main/deck/deckAutonomyStore';
@@ -91,6 +91,15 @@ export function AgentModeChip({
   const [mode, setMode] = useState<AgentMode | null>(null);
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
+  // Where the dropdown fits, measured on every open. The chip lives in a bar at
+  // the BOTTOM of the deck, so the menu opens upward by default — but the deck
+  // rail is also the shortest column on screen, and three items with
+  // descriptions are taller than the space above a chip in a short window. The
+  // menu then overflowed past the top of the window and the first option (`off`)
+  // became unclickable: the operator could raise autonomy but never lower it.
+  // Clamp to whichever side has more room and cap the height there, so every
+  // option is always reachable (scrolling when it has to be).
+  const [menuFit, setMenuFit] = useState<{ below: boolean; maxHeight: number } | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -100,6 +109,26 @@ export function AgentModeChip({
       .catch(() => { if (!cancelled) setMode('off'); });
     return () => { cancelled = true; };
   }, [api, workspaceId]);
+
+  // Measure the room around the chip whenever the menu opens (and on resize,
+  // since the deck rail grows/shrinks with the window).
+  useLayoutEffect(() => {
+    if (!open) return;
+    const measure = () => {
+      const rect = rootRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const GAP = 8; // breathing room against the window edge
+      const above = rect.top - GAP;
+      const below = window.innerHeight - rect.bottom - GAP;
+      const dropDown = below > above;
+      // Floor at 120px: a window too short for even that is already unusable,
+      // and a 0-height menu would look like the click did nothing.
+      setMenuFit({ below: dropDown, maxHeight: Math.max(120, Math.floor(dropDown ? below : above)) });
+    };
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }, [open]);
 
   // Close the dropdown on outside click / Escape.
   useEffect(() => {
@@ -164,7 +193,10 @@ export function AgentModeChip({
       {open && (
         <div
           role="listbox"
-          className="absolute bottom-full left-0 mb-1 z-50 w-64 bg-[var(--bg-overlay)] border border-[var(--bg-surface)] rounded-md shadow-lg py-1 text-xs"
+          className={`absolute left-0 z-50 w-64 overflow-y-auto bg-[var(--bg-overlay)] border border-[var(--bg-surface)] rounded-md shadow-lg py-1 text-xs ${
+            menuFit?.below ? 'top-full mt-1' : 'bottom-full mb-1'
+          }`}
+          style={menuFit ? { maxHeight: menuFit.maxHeight } : undefined}
         >
           {MODE_ORDER.map((m) => (
             <button

--- a/src/renderer/components/Deck/AgentModeChip.tsx
+++ b/src/renderer/components/Deck/AgentModeChip.tsx
@@ -121,9 +121,10 @@ export function AgentModeChip({
       const above = rect.top - GAP;
       const below = window.innerHeight - rect.bottom - GAP;
       const dropDown = below > above;
-      // Floor at 120px: a window too short for even that is already unusable,
-      // and a 0-height menu would look like the click did nothing.
-      setMenuFit({ below: dropDown, maxHeight: Math.max(120, Math.floor(dropDown ? below : above)) });
+      // No floor under the measured room: a minimum that outgrows the room is
+      // the original bug again, just smaller. A window too short to show an
+      // option is already unusable, and the menu scrolls either way.
+      setMenuFit({ below: dropDown, maxHeight: Math.max(0, Math.floor(dropDown ? below : above)) });
     };
     measure();
     window.addEventListener('resize', measure);

--- a/src/renderer/components/Deck/CommanderView.tsx
+++ b/src/renderer/components/Deck/CommanderView.tsx
@@ -176,6 +176,11 @@ export function CommanderViewContent({
   const modeOffReason =
     t('deck.composerModeOff') ||
     'The orchestrator is off for this workspace. Set Mode to Assist or Danger to talk to it.';
+  // The composer is two rows tall — the full reason wraps past it and the tail
+  // of the sentence is clipped. Placeholder gets the one-line form; the full
+  // sentence stays on the hover title, where there is room for it.
+  const modeOffPlaceholder =
+    t('deck.composerModeOffShort') || 'Orchestrator off — set Mode to Assist or Danger';
   // Collapsed state of the pty layout's report rail. Local by design: it is a
   // view preference, resets on remount, and needs no persistence. Default COLLAPSED: the TUI
   // is the conversation, the rail is the durable receipt you open when you want
@@ -579,7 +584,7 @@ export function CommanderViewContent({
           disabled={brainBusy || modeOff}
           placeholder={
             modeOff
-              ? modeOffReason
+              ? modeOffPlaceholder
               : t('deck.commanderPlaceholder') || 'Tell the orchestrator, or @mention panes…'
           }
           t={t}

--- a/src/renderer/components/Deck/__tests__/AgentModeChip.test.tsx
+++ b/src/renderer/components/Deck/__tests__/AgentModeChip.test.tsx
@@ -91,6 +91,38 @@ describe('AgentModeChip', () => {
     expect(container.querySelector('[data-agent-mode-dot]')!.className).toContain('--text-muted');
   });
 
+  // The chip lives at the bottom of the deck rail, so the menu opens UPWARD by
+  // default. In a short window three options with descriptions are taller than
+  // the room above the chip, and the menu ran off the top of the window — the
+  // first option (`off`) was rendered but unreachable, so the operator could
+  // raise autonomy and never lower it. Reported live 2026-08-03.
+  async function openMenuWithChipAt(top: number, bottom: number): Promise<HTMLElement> {
+    const { api } = fakeApi('danger');
+    const { container, cleanup } = render(<AgentModeChip api={api} workspaceId="ws-1" t={t} />);
+    cleanups.push(cleanup);
+    await flush();
+    const root = container.querySelector('[data-agent-mode-chip]') as HTMLElement;
+    root.getBoundingClientRect = () => ({ top, bottom, left: 0, right: 0, width: 0, height: bottom - top, x: 0, y: top, toJSON: () => ({}) }) as DOMRect;
+    act(() => (container.querySelector('[data-agent-mode-chip] > button') as HTMLButtonElement).click());
+    return container.querySelector('[role="listbox"]') as HTMLElement;
+  }
+
+  it('caps the upward menu at the room above the chip', async () => {
+    window.innerHeight = 768;
+    const menu = await openMenuWithChipAt(700, 720);
+    expect(menu.className).toContain('bottom-full'); // more room above → opens up
+    expect(menu.style.maxHeight).toBe('692px');      // 700 - 8 gap
+    expect(menu.className).toContain('overflow-y-auto');
+  });
+
+  it('flips the menu downward when the chip is pinned near the top', async () => {
+    window.innerHeight = 768;
+    const menu = await openMenuWithChipAt(10, 30);
+    expect(menu.className).toContain('top-full');
+    expect(menu.className).not.toContain('bottom-full');
+    expect(menu.style.maxHeight).toBe('730px'); // 768 - 30 - 8 gap
+  });
+
   it('renders nothing until the first read resolves (no label flash)', () => {
     const api: AgentModeApi = { get: () => new Promise(() => {}), set: async () => ({ ok: true }) };
     const { container, cleanup } = render(<AgentModeChip api={api} workspaceId="ws-1" t={t} />);

--- a/src/renderer/components/Deck/__tests__/AgentModeChip.test.tsx
+++ b/src/renderer/components/Deck/__tests__/AgentModeChip.test.tsx
@@ -96,6 +96,15 @@ describe('AgentModeChip', () => {
   // the room above the chip, and the menu ran off the top of the window — the
   // first option (`off`) was rendered but unreachable, so the operator could
   // raise autonomy and never lower it. Reported live 2026-08-03.
+  //
+  // Viewport height is global state — restore it so a later test never inherits
+  // the short window these cases set up.
+  const realInnerHeight = window.innerHeight;
+  afterEach(() => { Object.defineProperty(window, 'innerHeight', { value: realInnerHeight, writable: true, configurable: true }); });
+  function setViewportHeight(px: number): void {
+    Object.defineProperty(window, 'innerHeight', { value: px, writable: true, configurable: true });
+  }
+
   async function openMenuWithChipAt(top: number, bottom: number): Promise<HTMLElement> {
     const { api } = fakeApi('danger');
     const { container, cleanup } = render(<AgentModeChip api={api} workspaceId="ws-1" t={t} />);
@@ -108,7 +117,7 @@ describe('AgentModeChip', () => {
   }
 
   it('caps the upward menu at the room above the chip', async () => {
-    window.innerHeight = 768;
+    setViewportHeight(768);
     const menu = await openMenuWithChipAt(700, 720);
     expect(menu.className).toContain('bottom-full'); // more room above → opens up
     expect(menu.style.maxHeight).toBe('692px');      // 700 - 8 gap
@@ -116,11 +125,21 @@ describe('AgentModeChip', () => {
   });
 
   it('flips the menu downward when the chip is pinned near the top', async () => {
-    window.innerHeight = 768;
+    setViewportHeight(768);
     const menu = await openMenuWithChipAt(10, 30);
     expect(menu.className).toContain('top-full');
     expect(menu.className).not.toContain('bottom-full');
     expect(menu.style.maxHeight).toBe('730px'); // 768 - 30 - 8 gap
+  });
+
+  // A minimum height that outgrows the measured room is the same overflow bug
+  // in miniature: the menu would extend past the window edge again and clip the
+  // option nearest it. In a window this short the menu is small and scrolls.
+  it('never claims more height than the room it measured', async () => {
+    setViewportHeight(200);
+    const menu = await openMenuWithChipAt(60, 80);
+    expect(menu.style.maxHeight).toBe('112px'); // 200 - 80 - 8, the larger side
+    expect(parseInt(menu.style.maxHeight, 10)).toBeLessThan(200);
   });
 
   it('renders nothing until the first read resolves (no label flash)', () => {

--- a/src/renderer/components/Deck/__tests__/CommanderView.brain.dynamic.test.tsx
+++ b/src/renderer/components/Deck/__tests__/CommanderView.brain.dynamic.test.tsx
@@ -119,9 +119,11 @@ describe('CommanderViewContent — brain surface', () => {
     expect(input.disabled).toBe(true);
     const shell = container.querySelector('[data-commander-composer]') as HTMLElement;
     expect(shell.getAttribute('data-mode-off')).toBe('true');
-    // The reason is reachable both as a tooltip and as the placeholder.
+    // The reason is reachable both as a tooltip and as the placeholder — the
+    // placeholder in its one-line form, because the composer box is two rows
+    // tall and the full sentence gets clipped there.
     expect(shell.getAttribute('title')).toBe('deck.composerModeOff');
-    expect(input.placeholder).toBe('deck.composerModeOff');
+    expect(input.placeholder).toBe('deck.composerModeOffShort');
   });
 
   it('leaves the composer live in any other mode', () => {

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -459,6 +459,10 @@ export const en = {
   // Composer lock reason for mode `off` (main refuses the send too — this is
   // the explanation, not the enforcement).
   'deck.composerModeOff': 'The orchestrator is off for this workspace. Set Mode to Assist or Danger to talk to it.',
+  // Same reason, one line: the composer is a two-row box, so the full sentence
+  // above wraps to three lines and gets clipped. The long form stays as the
+  // hover title; this short form is what the placeholder shows.
+  'deck.composerModeOffShort': 'Orchestrator off — set Mode to Assist or Danger',
   // Global event-push kill switch: OFF stops the unrequested wake-turns
   // (each one is a real token-spending SDK turn); a running loop still wakes.
   'settings.autoWake': 'Auto-wake on pane events',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -326,7 +326,7 @@ export const ko = {
   'deck.mode.danger': 'Danger',
   'deck.mode.dangerDesc': 'Claude를 bypass 모드(--dangerously-skip-permissions)로 실행. 아무것도 묻지 않고 스스로 판단해 진행.',
   'deck.composerModeOff': '이 워크스페이스의 orchestrator가 꺼져 있습니다. Mode를 Assist나 Danger로 바꾸면 대화할 수 있습니다.',
-  'deck.composerModeOffShort': 'Orchestrator 꺼짐 — Mode를 Assist나 Danger로',
+  'deck.composerModeOffShort': 'Orchestrator 꺼짐 — Mode를 Assist나 Danger로 바꾸세요',
   // 이벤트 자동 깨우기 킬스위치: 끄면 요청하지 않은 자동 요약 턴(토큰 소비)이
   // 멈춘다. 실행 중인 루프는 계속 깨운다.
   'settings.autoWake': 'pane 이벤트 자동 깨우기',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -326,6 +326,7 @@ export const ko = {
   'deck.mode.danger': 'Danger',
   'deck.mode.dangerDesc': 'Claude를 bypass 모드(--dangerously-skip-permissions)로 실행. 아무것도 묻지 않고 스스로 판단해 진행.',
   'deck.composerModeOff': '이 워크스페이스의 orchestrator가 꺼져 있습니다. Mode를 Assist나 Danger로 바꾸면 대화할 수 있습니다.',
+  'deck.composerModeOffShort': 'Orchestrator 꺼짐 — Mode를 Assist나 Danger로',
   // 이벤트 자동 깨우기 킬스위치: 끄면 요청하지 않은 자동 요약 턴(토큰 소비)이
   // 멈춘다. 실행 중인 루프는 계속 깨운다.
   'settings.autoWake': 'pane 이벤트 자동 깨우기',


### PR DESCRIPTION
Two clipping fixes in the deck rail, both reported from a live session.

### The mode dropdown ran off the top of the window

The mode chip sits in a bar at the bottom of the deck rail, so its menu opens
upward. Three options with descriptions are taller than the room above that
chip in a short window, so the menu overflowed past the top of the screen and
the first option — `off` — was rendered but unreachable. Autonomy could be
raised and never lowered, which is the wrong direction for a control whose
whole job is to be the brake.

The menu now measures the room on each open, opens toward whichever side has
more of it, and caps its height there (scrolling when it has to). Two tests
cover both directions.

### The composer's mode-off note was cut off

The composer is a two-row box and it was showing the full two-sentence reason
as its placeholder, so the tail of the sentence was clipped. The placeholder
now carries a one-line form; the full sentence stays on the hover title, where
there is room for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace mode menus now automatically position above or below the control and remain scrollable within the available screen space.
  * Improved visibility of the orchestrator-disabled message in the deck composer with a concise placeholder and full details available on hover.
  * Added English and Korean translations for the updated composer message.
* **Tests**
  * Added regression coverage for menu positioning, height limits, and the disabled composer state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->