### PR TITLE
Give the Claude integrations a place to live

### DIFF
--- a/changelog.d/779.md
+++ b/changelog.d/779.md
@@ -1,0 +1,14 @@
+### Added
+
+- Settings → Claude integration now opens with a **Setup** card listing the
+  hook bridge, the MCP registration, and the usage statusline — each with its
+  real install state and a one-click install for whatever is missing.
+  Previously the first-run wizard was the only place these were ever offered,
+  and skipping it left the CLI as the only way back.
+- The first-run wizard now offers the Claude Code hook bridge alongside the
+  statusline, and shows it as installed when it already is.
+
+### Fixed
+
+- The wizard's statusline offer never appeared: it looked for the preload
+  bridge at the wrong path and silently hid itself when it came back empty.

--- a/src/renderer/components/FirstRunWizard.tsx
+++ b/src/renderer/components/FirstRunWizard.tsx
@@ -54,8 +54,8 @@ function firstRunBridge(): FirstRunBridge {
   return api.firstRun;
 }
 
-// Statusline bridge (preload `statuslineBridge`). Optional: older preloads may
-// not expose it, so the accessor returns null instead of throwing and the
+// Statusline bridge (preload `deck.statuslineBridge`). Optional: older preloads
+// may not expose it, so the accessor returns null instead of throwing and the
 // wizard simply hides the statusline offer.
 interface StatuslineBridge {
   status: () => Promise<{
@@ -75,11 +75,36 @@ interface StatuslineBridge {
 
 export type StatuslineTargetState = 'none' | 'wmux' | 'foreign' | 'corrupt' | 'missing';
 
-function statuslineBridge(): StatuslineBridge | null {
+// Hook bridge (preload `deck.hooksBridge`). Same shape of contract as the
+// statusline: an opt-in install the user clicks, never an edit behind their
+// back. Unlike the statusline this one is not cosmetic — without it every
+// lifecycle signal degrades to the regex detector, so the wizard is the one
+// place a new install is guaranteed to see the offer.
+interface HooksBridge {
+  status: () => Promise<{ installed: boolean }>;
+  install: () => Promise<{ ok: boolean; error: string | null }>;
+}
+
+/** Exported for the same contract test as {@link statuslineBridge}. */
+export function hooksBridge(): HooksBridge | null {
   const api = (window as unknown as {
-    electronAPI?: { statuslineBridge?: StatuslineBridge };
+    electronAPI?: { deck?: { hooksBridge?: HooksBridge } };
   }).electronAPI;
-  return api?.statuslineBridge ?? null;
+  return api?.deck?.hooksBridge ?? null;
+}
+
+// Exported for the contract test: the accessor and the preload must agree on
+// where the bridge lives, and reading the wrong path fails silently by design.
+export function statuslineBridge(): StatuslineBridge | null {
+  // The bridge lives under `deck` (preload.ts) — reading it off the root of
+  // electronAPI returned undefined in every real build, and the "older preload"
+  // fallback below turned that into silence: the statusline offer has never
+  // rendered outside tests. Read the real path, keep the null fallback for
+  // preloads that genuinely predate the bridge.
+  const api = (window as unknown as {
+    electronAPI?: { deck?: { statuslineBridge?: StatuslineBridge } };
+  }).electronAPI;
+  return api?.deck?.statuslineBridge ?? null;
 }
 
 function shellOpenExternal(url: string): Promise<void> {
@@ -205,6 +230,9 @@ export type StatuslineSubState =
   | 'installed'
   | 'error';
 
+/** Same lifecycle as the statusline block; `unknown` keeps it hidden. */
+export type HooksSubState = StatuslineSubState;
+
 const PTYID_WAIT_TIMEOUT_MS = 10_000;
 
 export default function FirstRunWizard({ mode, onClose }: FirstRunWizardProps) {
@@ -220,6 +248,8 @@ export default function FirstRunWizard({ mode, onClose }: FirstRunWizardProps) {
   const [sampleState, setSampleState] = useState<SampleSubState>('idle');
   const [statuslineState, setStatuslineState] = useState<StatuslineSubState>('unknown');
   const [statuslineError, setStatuslineError] = useState<string | null>(null);
+  const [hooksState, setHooksState] = useState<HooksSubState>('unknown');
+  const [hooksError, setHooksError] = useState<string | null>(null);
 
   const dialogRef = useRef<HTMLDivElement>(null);
   const firstFocusRef = useRef<HTMLButtonElement>(null);
@@ -276,6 +306,45 @@ export default function FirstRunWizard({ mode, onClose }: FirstRunWizardProps) {
       .catch(() => {
         // Status probe failing is not worth surfacing — just keep the block hidden.
       });
+  }, []);
+
+  // ─── Hook bridge offer ─────────────────────────────────────────────────────
+  // Already-installed shows as a ✓ line rather than hiding: this one is a
+  // REQUIREMENT, and a first-run checklist that silently omits its most
+  // important item teaches the operator it does not exist.
+  useEffect(() => {
+    const bridge = hooksBridge();
+    if (!bridge) return;
+    bridge
+      .status()
+      .then((s) => {
+        if (!isMountedRef.current) return;
+        setHooksState(s.installed ? 'installed' : 'offer');
+      })
+      .catch(() => {
+        // Probe failure is not worth surfacing — keep the block hidden.
+      });
+  }, []);
+
+  const handleInstallHooks = useCallback(async () => {
+    const bridge = hooksBridge();
+    if (!bridge) return;
+    setHooksState('installing');
+    setHooksError(null);
+    try {
+      const outcome = await bridge.install();
+      if (!isMountedRef.current) return;
+      if (outcome.ok) {
+        setHooksState('installed');
+      } else {
+        setHooksError(outcome.error);
+        setHooksState('error');
+      }
+    } catch (err) {
+      if (!isMountedRef.current) return;
+      setHooksError(err instanceof Error ? err.message : null);
+      setHooksState('error');
+    }
   }, []);
 
   const handleInstallStatusline = useCallback(async () => {
@@ -612,6 +681,16 @@ export default function FirstRunWizard({ mode, onClose }: FirstRunWizardProps) {
               </div>
             )}
 
+            {/* Hook bridge — the required half of the integration. Shown even
+                when already installed, as a ✓, so the checklist is complete. */}
+            {result.status.claudeFound && hooksState !== 'unknown' && (
+              <HooksBlock
+                state={hooksState}
+                errorDetail={hooksError}
+                onInstall={() => void handleInstallHooks()}
+              />
+            )}
+
             {/* Statusline opt-in (only when Claude detected & installable) */}
             {result.status.claudeFound && statuslineState !== 'unknown' && (
               <StatuslineBlock
@@ -738,6 +817,80 @@ export function ClaudeStatusBlock({
           </button>
         </div>
       )}
+    </div>
+  );
+}
+
+export function HooksBlock({
+  state,
+  errorDetail,
+  onInstall,
+}: {
+  state: HooksSubState;
+  errorDetail?: string | null;
+  onInstall: () => void;
+}) {
+  const t = useT();
+
+  if (state === 'installed') {
+    return (
+      <div
+        className="flex flex-col gap-1 p-3 rounded-lg"
+        style={{
+          backgroundColor: 'var(--bg-surface)',
+          border: '1px solid var(--accent-green, #a6e3a1)',
+        }}
+        data-testid="first-run-wizard-hooks-installed"
+      >
+        <p className="text-sm font-semibold" style={{ color: 'var(--text-main)', margin: 0 }}>
+          ✓ {t('firstRunWizard.hooksInstalled')}
+        </p>
+        <p className="text-xs" style={{ color: 'var(--text-sub)', margin: 0 }}>
+          {t('firstRunWizard.hooksInstalledHint')}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-2 p-3 rounded-lg"
+      style={{ backgroundColor: 'var(--bg-surface)' }}
+      data-testid="first-run-wizard-hooks-offer"
+    >
+      <p className="text-sm font-semibold" style={{ color: 'var(--text-main)', margin: 0 }}>
+        {t('firstRunWizard.hooksHeading')}
+      </p>
+      <p className="text-xs" style={{ color: 'var(--text-sub)', margin: 0 }}>
+        {t('firstRunWizard.hooksDescription')}
+      </p>
+      {state === 'error' && (
+        <p
+          className="text-xs"
+          style={{ color: 'var(--accent-red, #f38ba8)', margin: 0 }}
+          data-testid="first-run-wizard-hooks-error"
+        >
+          {t('firstRunWizard.hooksError')}
+          {errorDetail ? ` (${errorDetail})` : ''}
+        </p>
+      )}
+      <button
+        onClick={onInstall}
+        disabled={state === 'installing'}
+        data-testid="first-run-wizard-hooks-install"
+        className="self-start px-3 py-1 rounded text-xs font-medium"
+        style={{
+          backgroundColor: 'var(--accent)',
+          color: 'var(--bg-base)',
+          border: 'none',
+          cursor: state === 'installing' ? 'wait' : 'pointer',
+          opacity: state === 'installing' ? 0.7 : 1,
+        }}
+      >
+        {state === 'installing'
+          ? t('firstRunWizard.hooksInstalling')
+          : t('firstRunWizard.hooksEnableButton')}
+      </button>
     </div>
   );
 }

--- a/src/renderer/components/Settings/IntegrationSetupSection.tsx
+++ b/src/renderer/components/Settings/IntegrationSetupSection.tsx
@@ -24,17 +24,21 @@
 // existing nudge (HooksInstallPrompt, at launch and on a mode raise) stays as
 // it is — this card is the place you go, not a thing that comes to you.
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useT } from '../../hooks/useT';
 
 // ─── Injected API (jsdom-testable; the container binds the preload bridges) ───
 
 export interface IntegrationSetupApi {
-  hooks: {
-    status: () => Promise<{ installed: boolean }>;
+  hooks?: {
+    /** `installed` counts settings.json entries only. The marketplace plugin
+     *  owns the same four hook events when it is present, and then an install
+     *  deliberately writes nothing — so a row that read `installed` alone would
+     *  sit at "not installed" forever while the signals actually flow. */
+    status: () => Promise<{ installed: boolean; outcome?: { pluginAlsoInstalled?: boolean } }>;
     install: () => Promise<{ ok: boolean; error: string | null }>;
   };
-  statusline: {
+  statusline?: {
     status: () => Promise<{ installed: boolean }>;
     /** `ok` only means nothing broke: every target can be skipped when another
      *  tool owns its settings.json. A row is installed when a target took it. */
@@ -44,16 +48,43 @@ export interface IntegrationSetupApi {
       targets: Array<{ outcome: string }>;
     }>;
   };
-  mcp: {
-    /** `verified` is the per-target truth; the row is installed when any target has it. */
-    check: () => Promise<{ targets: Array<{ displayName: string; verified: boolean }> }>;
-    reregister: () => Promise<{ targets: Array<{ displayName: string; verified: boolean }> }>;
+  mcp?: {
+    /** Registration state is `wmux.registered`. `verified` is a static property
+     *  of the TARGET (we have verified that client's MCP wiring), true for
+     *  Claude Code whether or not wmux is registered — reading it as install
+     *  state made the row claim "installed" on an untouched config. */
+    check: () => Promise<{ targets: McpTarget[] }>;
+    reregister: () => Promise<{ targets: McpTarget[] }>;
   };
+}
+
+export interface McpTarget {
+  displayName: string;
+  wmux?: { registered: boolean };
+}
+
+/** True when any client actually has wmux registered. */
+export function mcpRegistered(targets: McpTarget[]): boolean {
+  return targets.some((x) => x.wmux?.registered === true);
+}
+
+/** Why an install that "succeeded" wrote nothing: the per-target outcomes.
+ *  Returns null when there is nothing to say. */
+export function skippedReason(targets?: Array<{ outcome: string }>): string | null {
+  if (!targets || targets.length === 0) return null;
+  const skipped = [...new Set(targets.map((x) => x.outcome))].filter((o) => o !== 'installed');
+  return skipped.length > 0 ? skipped.join(', ') : null;
 }
 
 /** One row's lifecycle. `unknown` is the pre-probe state and reads as its own
  *  thing — never as "not installed", which would be a lie the user acts on. */
-export type RowState = 'unknown' | 'installed' | 'missing' | 'working' | 'error';
+export type RowState =
+  | 'unknown'      // pre-probe; never rendered as "not installed"
+  | 'installed'
+  | 'missing'
+  | 'working'
+  | 'error'
+  | 'unavailable'; // this preload does not expose the bridge at all
 
 interface RowModel {
   state: RowState;
@@ -61,6 +92,7 @@ interface RowModel {
 }
 
 const INITIAL: RowModel = { state: 'unknown', error: null };
+const UNAVAILABLE: RowModel = { state: 'unavailable', error: null };
 
 /** Probe → row state. Kept separate so the mapping is testable without a DOM. */
 export function rowStateFromProbe(installed: boolean): RowState {
@@ -79,25 +111,58 @@ export function IntegrationSetupSection({
   const [mcp, setMcp] = useState<RowModel>(INITIAL);
   const [statusline, setStatusline] = useState<RowModel>(INITIAL);
 
+  // Every write below lands after an await, and the settings panel is a tab the
+  // user closes mid-probe. Without this the card sets state on an unmounted
+  // component — and an install that resolves after a close would try to paint a
+  // row that no longer exists.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
+  // Probes are fire-and-forget and the card re-probes after every install, so
+  // two answers for the same row can be in flight at once. Each write carries
+  // the generation it was issued under; a stale one is dropped rather than
+  // repainting "not installed" over a finished install — which would put the
+  // Install button back and invite a second write to the same config.
+  const genRef = useRef(0);
+  const commit = useCallback(
+    (set: (m: RowModel) => void, model: RowModel, gen: number) => {
+      if (!mountedRef.current || gen !== genRef.current) return;
+      set(model);
+    },
+    [],
+  );
+
   // A probe that throws leaves the row `unknown` rather than claiming "missing":
   // an install button offered because IPC hiccuped would write to a config the
   // user never asked to touch.
   const probeAll = useCallback(() => {
-    api.hooks
+    const gen = ++genRef.current;
+    if (!api.hooks) commit(setHooks, UNAVAILABLE, gen);
+    else api.hooks
       .status()
-      .then((s) => setHooks({ state: rowStateFromProbe(s.installed), error: null }))
-      .catch(() => setHooks(INITIAL));
-    api.statusline
-      .status()
-      .then((s) => setStatusline({ state: rowStateFromProbe(s.installed), error: null }))
-      .catch(() => setStatusline(INITIAL));
-    api.mcp
-      .check()
       .then((s) =>
-        setMcp({ state: rowStateFromProbe(s.targets.some((x) => x.verified)), error: null }),
+        commit(setHooks, {
+          // Plugin-owned hooks fire the same signals, and an install against
+          // them writes nothing — without this the row sits at "not installed"
+          // forever while an Install click reports success and changes nothing.
+          state: rowStateFromProbe(s.installed || s.outcome?.pluginAlsoInstalled === true),
+          error: null,
+        }, gen),
       )
-      .catch(() => setMcp(INITIAL));
-  }, [api]);
+      .catch(() => commit(setHooks, INITIAL, gen));
+    if (!api.statusline) commit(setStatusline, UNAVAILABLE, gen);
+    else api.statusline
+      .status()
+      .then((s) => commit(setStatusline, { state: rowStateFromProbe(s.installed), error: null }, gen))
+      .catch(() => commit(setStatusline, INITIAL, gen));
+    if (!api.mcp) commit(setMcp, UNAVAILABLE, gen);
+    else api.mcp
+      .check()
+      .then((s) => commit(setMcp, { state: rowStateFromProbe(mcpRegistered(s.targets)), error: null }, gen))
+      .catch(() => commit(setMcp, INITIAL, gen));
+  }, [api, commit]);
 
   useEffect(() => { probeAll(); }, [probeAll]);
 
@@ -110,42 +175,50 @@ export function IntegrationSetupSection({
         targets?: Array<{ outcome: string }>;
       }>,
     ) => {
-      set({ state: 'working', error: null });
+      const gen = ++genRef.current;
+      commit(set, { state: 'working', error: null }, gen);
       try {
         const outcome = await install();
         // When the install reports per-target outcomes, `ok` alone is not
         // success: every target can be skipped because another tool owns its
         // settings.json, and claiming "Installed" there is a receipt for
-        // something that did not happen.
+        // something that did not happen. The skipped outcomes ARE the reason,
+        // so they go into the error text — otherwise the user retries blindly.
         const took = outcome.targets ? outcome.targets.some((x) => x.outcome === 'installed') : true;
-        set(
-          outcome.ok && took
-            ? { state: 'installed', error: null }
-            : { state: 'error', error: outcome.error },
-        );
+        if (outcome.ok && took) {
+          // Re-probe rather than trusting the install's own word: the file is
+          // the truth, and it can have been rewritten by another tool between
+          // the write and this line.
+          probeAll();
+          return;
+        }
+        commit(set, { state: 'error', error: outcome.error ?? skippedReason(outcome.targets) }, gen);
       } catch (err) {
-        set({ state: 'error', error: err instanceof Error ? err.message : null });
+        commit(set, { state: 'error', error: err instanceof Error ? err.message : null }, gen);
       }
     },
-    [],
+    [commit, probeAll],
   );
 
   // MCP's register path answers with a status payload, not an ok/error pair, so
   // it reads its own result rather than sharing runInstall.
   const registerMcp = useCallback(async () => {
-    setMcp({ state: 'working', error: null });
+    if (!api.mcp) return;
+    const gen = ++genRef.current;
+    commit(setMcp, { state: 'working', error: null }, gen);
     try {
       const status = await api.mcp.reregister();
-      const verified = status.targets.some((x) => x.verified);
-      setMcp(
-        verified
-          ? { state: 'installed', error: null }
-          : { state: 'error', error: null },
-      );
+      if (mcpRegistered(status.targets)) {
+        probeAll();
+        return;
+      }
+      // Nothing took. Name the configs that did not, so the failure is
+      // actionable instead of a bare "Failed".
+      commit(setMcp, { state: 'error', error: status.targets.map((x) => x.displayName).join(', ') || null }, gen);
     } catch (err) {
-      setMcp({ state: 'error', error: err instanceof Error ? err.message : null });
+      commit(setMcp, { state: 'error', error: err instanceof Error ? err.message : null }, gen);
     }
-  }, [api]);
+  }, [api, commit, probeAll]);
 
   return (
     <div
@@ -169,7 +242,7 @@ export function IntegrationSetupSection({
         description={t('integrationSetup.hooks.description')}
         model={hooks}
         actionLabel={t('integrationSetup.installButton')}
-        onAction={() => void runInstall(setHooks, api.hooks.install)}
+        onAction={() => { if (api.hooks) void runInstall(setHooks, api.hooks.install); }}
       />
       <SetupRow
         id="mcp"
@@ -187,7 +260,7 @@ export function IntegrationSetupSection({
         description={t('integrationSetup.statusline.description')}
         model={statusline}
         actionLabel={t('integrationSetup.installButton')}
-        onAction={() => void runInstall(setStatusline, api.statusline.install)}
+        onAction={() => { if (api.statusline) void runInstall(setStatusline, api.statusline.install); }}
       />
     </div>
   );
@@ -247,7 +320,9 @@ function SetupRow({
       </div>
       <div className="shrink-0 flex items-center gap-2">
         <StateChip state={model.state} />
-        {!installed && model.state !== 'unknown' && (
+        {/* Nothing to click for a row we cannot act on: `unknown` has not been
+            probed, and `unavailable` has no bridge to install through. */}
+        {!installed && model.state !== 'unknown' && model.state !== 'unavailable' && (
           <button
             type="button"
             onClick={onAction}
@@ -278,6 +353,10 @@ function StateChip({ state }: { state: RowState }): React.ReactElement {
     state === 'installed' ? t('integrationSetup.state.installed')
     : state === 'working' ? t('integrationSetup.state.working')
     : state === 'unknown' ? t('integrationSetup.state.unknown')
+    // Without its own label an error row read "not installed" right next to the
+    // failure text it had just printed — two answers to the same question.
+    : state === 'error' ? t('integrationSetup.state.error')
+    : state === 'unavailable' ? t('integrationSetup.state.unavailable')
     : t('integrationSetup.state.missing');
   return (
     <span
@@ -293,11 +372,13 @@ function StateChip({ state }: { state: RowState }): React.ReactElement {
   );
 }
 
-/** Container: binds the preload bridges. Renders nothing when any of them is
- *  absent (older preload / pure jsdom parent tests) — a card whose rows cannot
- *  report state is worse than no card. */
+/** Container: binds whichever preload bridges exist. A missing one costs its own
+ *  row (rendered `unavailable`), never the card — hiding the two REQUIRED
+ *  integrations because the optional statusline bridge was absent is exactly
+ *  the disappearing-surface bug this card was built to end. Renders nothing only
+ *  when no bridge is exposed at all (pure jsdom parent tests / no preload). */
 export function IntegrationSetupSectionContainer(): React.ReactElement | null {
-  const api = (window as unknown as {
+  const electronAPI = (window as unknown as {
     electronAPI?: {
       deck?: {
         hooksBridge?: IntegrationSetupApi['hooks'];
@@ -306,9 +387,13 @@ export function IntegrationSetupSectionContainer(): React.ReactElement | null {
       mcp?: IntegrationSetupApi['mcp'];
     };
   }).electronAPI;
-  const hooks = api?.deck?.hooksBridge;
-  const statusline = api?.deck?.statuslineBridge;
-  const mcp = api?.mcp;
-  if (!hooks || !statusline || !mcp) return null;
-  return <IntegrationSetupSection api={{ hooks, statusline, mcp }} />;
+  const hooks = electronAPI?.deck?.hooksBridge;
+  const statusline = electronAPI?.deck?.statuslineBridge;
+  const mcp = electronAPI?.mcp;
+  // Stable identity: the card's probe effect keys off this object, and a fresh
+  // literal every render re-probed all three bridges on every parent render —
+  // and could land a stale answer on top of a finished install.
+  const api = useMemo(() => ({ hooks, statusline, mcp }), [hooks, statusline, mcp]);
+  if (!hooks && !statusline && !mcp) return null;
+  return <IntegrationSetupSection api={api} />;
 }

--- a/src/renderer/components/Settings/IntegrationSetupSection.tsx
+++ b/src/renderer/components/Settings/IntegrationSetupSection.tsx
@@ -1,0 +1,314 @@
+// ─── Settings → Claude integration — the setup card ──────────────────────────
+//
+// Everything wmux installs into someone else's config lives here, in one place,
+// with its real state read from a probe rather than inferred.
+//
+// Why it exists: all three integrations shipped with a working IPC probe and an
+// install path, but the only UI that ever offered them was the first-run
+// wizard. Skip that once and there was no way back — the CLI commands
+// (`wmux setup-hooks`, `wmux mcp register`, `wmux setup-statusline`) were the
+// entire re-entry path, and an operator who could not remember them had no way
+// to discover the feature existed. The wizard is a moment; settings is a place.
+//
+// Two rows are REQUIRED and one is RECOMMENDED, and the card says which:
+//
+//   hooks       required     lifecycle signals; without it every completion
+//                            detection degrades to the regex fallback
+//   mcp         required     the agent's access to wmux tools at all
+//   statusline  recommended  model / context / rate limits under the input box;
+//                            purely informational, costs nothing to run
+//
+// No nagging: this card never raises a banner or a toast. wmux does not edit
+// ~/.claude/settings.json behind the operator's back (owner decision
+// 2026-07-17), so every row's action is a button the human clicks. The one
+// existing nudge (HooksInstallPrompt, at launch and on a mode raise) stays as
+// it is — this card is the place you go, not a thing that comes to you.
+
+import { useCallback, useEffect, useState } from 'react';
+import { useT } from '../../hooks/useT';
+
+// ─── Injected API (jsdom-testable; the container binds the preload bridges) ───
+
+export interface IntegrationSetupApi {
+  hooks: {
+    status: () => Promise<{ installed: boolean }>;
+    install: () => Promise<{ ok: boolean; error: string | null }>;
+  };
+  statusline: {
+    status: () => Promise<{ installed: boolean }>;
+    /** `ok` only means nothing broke: every target can be skipped when another
+     *  tool owns its settings.json. A row is installed when a target took it. */
+    install: () => Promise<{
+      ok: boolean;
+      error: string | null;
+      targets: Array<{ outcome: string }>;
+    }>;
+  };
+  mcp: {
+    /** `verified` is the per-target truth; the row is installed when any target has it. */
+    check: () => Promise<{ targets: Array<{ displayName: string; verified: boolean }> }>;
+    reregister: () => Promise<{ targets: Array<{ displayName: string; verified: boolean }> }>;
+  };
+}
+
+/** One row's lifecycle. `unknown` is the pre-probe state and reads as its own
+ *  thing — never as "not installed", which would be a lie the user acts on. */
+export type RowState = 'unknown' | 'installed' | 'missing' | 'working' | 'error';
+
+interface RowModel {
+  state: RowState;
+  error: string | null;
+}
+
+const INITIAL: RowModel = { state: 'unknown', error: null };
+
+/** Probe → row state. Kept separate so the mapping is testable without a DOM. */
+export function rowStateFromProbe(installed: boolean): RowState {
+  return installed ? 'installed' : 'missing';
+}
+
+// ─── The card ────────────────────────────────────────────────────────────────
+
+export function IntegrationSetupSection({
+  api,
+}: {
+  api: IntegrationSetupApi;
+}): React.ReactElement {
+  const t = useT();
+  const [hooks, setHooks] = useState<RowModel>(INITIAL);
+  const [mcp, setMcp] = useState<RowModel>(INITIAL);
+  const [statusline, setStatusline] = useState<RowModel>(INITIAL);
+
+  // A probe that throws leaves the row `unknown` rather than claiming "missing":
+  // an install button offered because IPC hiccuped would write to a config the
+  // user never asked to touch.
+  const probeAll = useCallback(() => {
+    api.hooks
+      .status()
+      .then((s) => setHooks({ state: rowStateFromProbe(s.installed), error: null }))
+      .catch(() => setHooks(INITIAL));
+    api.statusline
+      .status()
+      .then((s) => setStatusline({ state: rowStateFromProbe(s.installed), error: null }))
+      .catch(() => setStatusline(INITIAL));
+    api.mcp
+      .check()
+      .then((s) =>
+        setMcp({ state: rowStateFromProbe(s.targets.some((x) => x.verified)), error: null }),
+      )
+      .catch(() => setMcp(INITIAL));
+  }, [api]);
+
+  useEffect(() => { probeAll(); }, [probeAll]);
+
+  const runInstall = useCallback(
+    async (
+      set: (m: RowModel) => void,
+      install: () => Promise<{
+        ok: boolean;
+        error: string | null;
+        targets?: Array<{ outcome: string }>;
+      }>,
+    ) => {
+      set({ state: 'working', error: null });
+      try {
+        const outcome = await install();
+        // When the install reports per-target outcomes, `ok` alone is not
+        // success: every target can be skipped because another tool owns its
+        // settings.json, and claiming "Installed" there is a receipt for
+        // something that did not happen.
+        const took = outcome.targets ? outcome.targets.some((x) => x.outcome === 'installed') : true;
+        set(
+          outcome.ok && took
+            ? { state: 'installed', error: null }
+            : { state: 'error', error: outcome.error },
+        );
+      } catch (err) {
+        set({ state: 'error', error: err instanceof Error ? err.message : null });
+      }
+    },
+    [],
+  );
+
+  // MCP's register path answers with a status payload, not an ok/error pair, so
+  // it reads its own result rather than sharing runInstall.
+  const registerMcp = useCallback(async () => {
+    setMcp({ state: 'working', error: null });
+    try {
+      const status = await api.mcp.reregister();
+      const verified = status.targets.some((x) => x.verified);
+      setMcp(
+        verified
+          ? { state: 'installed', error: null }
+          : { state: 'error', error: null },
+      );
+    } catch (err) {
+      setMcp({ state: 'error', error: err instanceof Error ? err.message : null });
+    }
+  }, [api]);
+
+  return (
+    <div
+      className="rounded-lg p-4 flex flex-col gap-3"
+      style={{ backgroundColor: 'var(--bg-mantle)', border: '1px solid var(--bg-surface)' }}
+      data-integration-setup
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-semibold text-[color:var(--text-main)] font-mono">
+          {t('integrationSetup.title')}
+        </span>
+      </div>
+      <p className="text-xs text-[color:var(--text-muted)] leading-relaxed">
+        {t('integrationSetup.description')}
+      </p>
+
+      <SetupRow
+        id="hooks"
+        required
+        title={t('integrationSetup.hooks.title')}
+        description={t('integrationSetup.hooks.description')}
+        model={hooks}
+        actionLabel={t('integrationSetup.installButton')}
+        onAction={() => void runInstall(setHooks, api.hooks.install)}
+      />
+      <SetupRow
+        id="mcp"
+        required
+        title={t('integrationSetup.mcp.title')}
+        description={t('integrationSetup.mcp.description')}
+        model={mcp}
+        actionLabel={t('integrationSetup.registerButton')}
+        onAction={() => void registerMcp()}
+      />
+      <SetupRow
+        id="statusline"
+        required={false}
+        title={t('integrationSetup.statusline.title')}
+        description={t('integrationSetup.statusline.description')}
+        model={statusline}
+        actionLabel={t('integrationSetup.installButton')}
+        onAction={() => void runInstall(setStatusline, api.statusline.install)}
+      />
+    </div>
+  );
+}
+
+function SetupRow({
+  id,
+  required,
+  title,
+  description,
+  model,
+  actionLabel,
+  onAction,
+}: {
+  id: string;
+  required: boolean;
+  title: string;
+  description: string;
+  model: RowModel;
+  actionLabel: string;
+  onAction: () => void;
+}): React.ReactElement {
+  const t = useT();
+  const installed = model.state === 'installed';
+  const working = model.state === 'working';
+
+  return (
+    <div
+      className="flex items-start justify-between gap-3 py-2 border-t"
+      style={{ borderColor: 'var(--bg-surface)' }}
+      data-setup-row={id}
+      data-setup-row-state={model.state}
+    >
+      <div className="flex flex-col gap-0.5 min-w-0">
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs font-medium text-[color:var(--text-main)]">{title}</span>
+          {/* Required is stated in text, not color: the color grammar reserves
+              red for destructive, and a red "required" on a healthy install
+              would read as an error. */}
+          <span className="text-[10px] text-[color:var(--text-muted)]">
+            {required ? t('integrationSetup.required') : t('integrationSetup.recommended')}
+          </span>
+        </div>
+        <span className="text-[11px] text-[color:var(--text-muted)] leading-relaxed">
+          {description}
+        </span>
+        {model.state === 'error' && (
+          <span
+            className="text-[11px]"
+            style={{ color: 'var(--accent-red, #f38ba8)' }}
+            data-setup-row-error
+          >
+            {t('integrationSetup.installFailed')}
+            {model.error ? ` (${model.error})` : ''}
+          </span>
+        )}
+      </div>
+      <div className="shrink-0 flex items-center gap-2">
+        <StateChip state={model.state} />
+        {!installed && model.state !== 'unknown' && (
+          <button
+            type="button"
+            onClick={onAction}
+            disabled={working}
+            data-setup-row-action
+            className="text-[11px] font-mono px-2.5 py-1 rounded-md transition-colors disabled:opacity-50"
+            style={{
+              backgroundColor: 'var(--bg-surface)',
+              color: 'var(--text-main)',
+              border: '1px solid var(--bg-overlay)',
+              cursor: working ? 'wait' : 'pointer',
+            }}
+          >
+            {working ? t('integrationSetup.working') : actionLabel}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StateChip({ state }: { state: RowState }): React.ReactElement {
+  const t = useT();
+  // Installed is the only state that earns the alive accent; everything else is
+  // muted status text (DESIGN.md — amber means alive, and a checklist of grey
+  // rows should not glow).
+  const label =
+    state === 'installed' ? t('integrationSetup.state.installed')
+    : state === 'working' ? t('integrationSetup.state.working')
+    : state === 'unknown' ? t('integrationSetup.state.unknown')
+    : t('integrationSetup.state.missing');
+  return (
+    <span
+      className="text-[10px] font-mono px-1.5 py-0.5 rounded"
+      style={{
+        color: state === 'installed' ? 'var(--accent)' : 'var(--text-muted)',
+        backgroundColor: 'rgba(var(--bg-surface-rgb), 0.6)',
+      }}
+      data-setup-row-chip
+    >
+      {label}
+    </span>
+  );
+}
+
+/** Container: binds the preload bridges. Renders nothing when any of them is
+ *  absent (older preload / pure jsdom parent tests) — a card whose rows cannot
+ *  report state is worse than no card. */
+export function IntegrationSetupSectionContainer(): React.ReactElement | null {
+  const api = (window as unknown as {
+    electronAPI?: {
+      deck?: {
+        hooksBridge?: IntegrationSetupApi['hooks'];
+        statuslineBridge?: IntegrationSetupApi['statusline'];
+      };
+      mcp?: IntegrationSetupApi['mcp'];
+    };
+  }).electronAPI;
+  const hooks = api?.deck?.hooksBridge;
+  const statusline = api?.deck?.statuslineBridge;
+  const mcp = api?.mcp;
+  if (!hooks || !statusline || !mcp) return null;
+  return <IntegrationSetupSection api={{ hooks, statusline, mcp }} />;
+}

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -31,6 +31,7 @@ import type { FirstRunCheckResult } from '../../../shared/firstRun';
 import { FIRST_RUN_REOPEN_EVENT } from '../../../shared/firstRun';
 import { notifyBriefingConfigChanged } from '../Deck/deckBriefingConfigBus';
 import { ClaudeIntegrationSection } from './ClaudeIntegrationSection';
+import { IntegrationSetupSectionContainer } from './IntegrationSetupSection';
 import { AccountsSection } from './AccountsSection';
 import { terminalFontFamilyCss } from '../../utils/terminalFont';
 import { hasBareFunctionKeyBinding } from '../../utils/functionKeyBinding';
@@ -4713,7 +4714,7 @@ export default function SettingsPanel() {
               {activeTab === 'appearance'         && <TabAppearance />}
               {activeTab === 'notifications'      && <TabNotifications />}
               {activeTab === 'shortcuts'          && <TabShortcuts />}
-              {activeTab === 'claude-integration' && <><ClaudeIntegrationSection /><AccountsSection /></>}
+              {activeTab === 'claude-integration' && <><IntegrationSetupSectionContainer /><ClaudeIntegrationSection /><AccountsSection /></>}
               {activeTab === 'agents'             && <TabAgents />}
               {activeTab === 'lanlink'            && <><LanLinkSection /><LanLinkPairingSection /></>}
               {activeTab === 'about'              && <><TabAbout /><TabFirstRunSetup /></>}

--- a/src/renderer/components/Settings/__tests__/IntegrationSetupSection.test.tsx
+++ b/src/renderer/components/Settings/__tests__/IntegrationSetupSection.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+//
+// Settings → Claude integration → setup card: probes three integrations on
+// mount, offers an install only for the ones that are actually missing, and
+// never reports a success the install did not produce.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import {
+  IntegrationSetupSection,
+  IntegrationSetupSectionContainer,
+  rowStateFromProbe,
+  type IntegrationSetupApi,
+} from '../IntegrationSetupSection';
+
+function render(ui: React.ReactElement): { container: HTMLElement; cleanup: () => void } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(ui));
+  return {
+    container,
+    cleanup: () => { act(() => root.unmount()); container.remove(); },
+  };
+}
+
+const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve(); }); };
+
+const cleanups: Array<() => void> = [];
+afterEach(() => { while (cleanups.length) cleanups.pop()!(); });
+
+function fakeApi(over: Partial<{
+  hooksInstalled: boolean;
+  statuslineInstalled: boolean;
+  mcpVerified: boolean;
+  hooksInstall: () => Promise<{ ok: boolean; error: string | null }>;
+  statuslineInstall: () => Promise<{ ok: boolean; error: string | null; targets: Array<{ outcome: string }> }>;
+  hooksStatusThrows: boolean;
+}> = {}): IntegrationSetupApi {
+  return {
+    hooks: {
+      status: async () => {
+        if (over.hooksStatusThrows) throw new Error('ipc down');
+        return { installed: over.hooksInstalled ?? false };
+      },
+      install: over.hooksInstall ?? (async () => ({ ok: true, error: null })),
+    },
+    statusline: {
+      status: async () => ({ installed: over.statuslineInstalled ?? false }),
+      install:
+        over.statuslineInstall ??
+        (async () => ({ ok: true, error: null, targets: [{ outcome: 'installed' }] })),
+    },
+    mcp: {
+      check: async () => ({ targets: [{ displayName: 'Claude Code', verified: over.mcpVerified ?? false }] }),
+      reregister: async () => ({ targets: [{ displayName: 'Claude Code', verified: true }] }),
+    },
+  };
+}
+
+const row = (c: HTMLElement, id: string) => c.querySelector(`[data-setup-row="${id}"]`) as HTMLElement;
+const state = (c: HTMLElement, id: string) => row(c, id).getAttribute('data-setup-row-state');
+const action = (c: HTMLElement, id: string) =>
+  row(c, id).querySelector('[data-setup-row-action]') as HTMLButtonElement | null;
+
+describe('IntegrationSetupSection', () => {
+  it('reports each integration from its own probe', async () => {
+    const { container, cleanup } = render(
+      <IntegrationSetupSection api={fakeApi({ hooksInstalled: true, mcpVerified: true })} />,
+    );
+    cleanups.push(cleanup);
+    await flush();
+
+    expect(state(container, 'hooks')).toBe('installed');
+    expect(state(container, 'mcp')).toBe('installed');
+    expect(state(container, 'statusline')).toBe('missing');
+    // No action offered for what is already there — the row is a receipt, not a
+    // button that would rewrite a healthy config.
+    expect(action(container, 'hooks')).toBeNull();
+    expect(action(container, 'statusline')).not.toBeNull();
+  });
+
+  it('installs the missing one and flips its row', async () => {
+    const { container, cleanup } = render(<IntegrationSetupSection api={fakeApi()} />);
+    cleanups.push(cleanup);
+    await flush();
+    expect(state(container, 'hooks')).toBe('missing');
+
+    await act(async () => { action(container, 'hooks')!.click(); await Promise.resolve(); });
+    await flush();
+    expect(state(container, 'hooks')).toBe('installed');
+  });
+
+  // `ok: true` with every target skipped means another tool owns those
+  // settings files and nothing was written. Reporting "installed" there is a
+  // receipt for something that did not happen.
+  it('does not claim success when no target took the statusline install', async () => {
+    const api = fakeApi({
+      statuslineInstall: async () => ({ ok: true, error: null, targets: [{ outcome: 'skipped' }] }),
+    });
+    const { container, cleanup } = render(<IntegrationSetupSection api={api} />);
+    cleanups.push(cleanup);
+    await flush();
+
+    await act(async () => { action(container, 'statusline')!.click(); await Promise.resolve(); });
+    await flush();
+    expect(state(container, 'statusline')).toBe('error');
+  });
+
+  it('surfaces an install error with its detail', async () => {
+    const api = fakeApi({ hooksInstall: async () => ({ ok: false, error: 'EACCES' }) });
+    const { container, cleanup } = render(<IntegrationSetupSection api={api} />);
+    cleanups.push(cleanup);
+    await flush();
+
+    await act(async () => { action(container, 'hooks')!.click(); await Promise.resolve(); });
+    await flush();
+    expect(state(container, 'hooks')).toBe('error');
+    expect(row(container, 'hooks').querySelector('[data-setup-row-error]')!.textContent).toContain('EACCES');
+  });
+
+  // A probe that throws must not read as "not installed": the install button
+  // would write to a config the user never asked us to touch.
+  it('stays unknown (and offers nothing) when the probe fails', async () => {
+    const { container, cleanup } = render(
+      <IntegrationSetupSection api={fakeApi({ hooksStatusThrows: true })} />,
+    );
+    cleanups.push(cleanup);
+    await flush();
+
+    expect(state(container, 'hooks')).toBe('unknown');
+    expect(action(container, 'hooks')).toBeNull();
+  });
+
+  it('maps a probe answer to a row state', () => {
+    expect(rowStateFromProbe(true)).toBe('installed');
+    expect(rowStateFromProbe(false)).toBe('missing');
+  });
+
+  it('renders nothing when a preload bridge is missing', () => {
+    (window as unknown as { electronAPI?: unknown }).electronAPI = { deck: {} };
+    const { container, cleanup } = render(<IntegrationSetupSectionContainer />);
+    cleanups.push(cleanup);
+    expect(container.querySelector('[data-integration-setup]')).toBeNull();
+    delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+  });
+});

--- a/src/renderer/components/Settings/__tests__/IntegrationSetupSection.test.tsx
+++ b/src/renderer/components/Settings/__tests__/IntegrationSetupSection.test.tsx
@@ -11,6 +11,8 @@ import {
   IntegrationSetupSection,
   IntegrationSetupSectionContainer,
   rowStateFromProbe,
+  mcpRegistered,
+  skippedReason,
   type IntegrationSetupApi,
 } from '../IntegrationSetupSection';
 
@@ -32,31 +34,44 @@ afterEach(() => { while (cleanups.length) cleanups.pop()!(); });
 
 function fakeApi(over: Partial<{
   hooksInstalled: boolean;
+  hooksPluginOwned: boolean;
   statuslineInstalled: boolean;
-  mcpVerified: boolean;
+  mcpRegistered: boolean;
   hooksInstall: () => Promise<{ ok: boolean; error: string | null }>;
   statuslineInstall: () => Promise<{ ok: boolean; error: string | null; targets: Array<{ outcome: string }> }>;
   hooksStatusThrows: boolean;
+  omit: 'hooks' | 'statusline' | 'mcp';
 }> = {}): IntegrationSetupApi {
-  return {
+  // Probes re-run after a successful install, so the fakes read live flags.
+  const flags = {
+    hooks: over.hooksInstalled ?? false,
+    statusline: over.statuslineInstalled ?? false,
+    mcp: over.mcpRegistered ?? false,
+  };
+  const api: IntegrationSetupApi = {
     hooks: {
       status: async () => {
         if (over.hooksStatusThrows) throw new Error('ipc down');
-        return { installed: over.hooksInstalled ?? false };
+        return {
+          installed: flags.hooks,
+          outcome: { pluginAlsoInstalled: over.hooksPluginOwned ?? false },
+        };
       },
-      install: over.hooksInstall ?? (async () => ({ ok: true, error: null })),
+      install: over.hooksInstall ?? (async () => { flags.hooks = true; return { ok: true, error: null }; }),
     },
     statusline: {
-      status: async () => ({ installed: over.statuslineInstalled ?? false }),
+      status: async () => ({ installed: flags.statusline }),
       install:
         over.statuslineInstall ??
-        (async () => ({ ok: true, error: null, targets: [{ outcome: 'installed' }] })),
+        (async () => { flags.statusline = true; return { ok: true, error: null, targets: [{ outcome: 'installed' }] }; }),
     },
     mcp: {
-      check: async () => ({ targets: [{ displayName: 'Claude Code', verified: over.mcpVerified ?? false }] }),
-      reregister: async () => ({ targets: [{ displayName: 'Claude Code', verified: true }] }),
+      check: async () => ({ targets: [{ displayName: 'Claude Code', wmux: { registered: flags.mcp } }] }),
+      reregister: async () => { flags.mcp = true; return { targets: [{ displayName: 'Claude Code', wmux: { registered: true } }] }; },
     },
   };
+  if (over.omit) delete api[over.omit];
+  return api;
 }
 
 const row = (c: HTMLElement, id: string) => c.querySelector(`[data-setup-row="${id}"]`) as HTMLElement;
@@ -67,7 +82,7 @@ const action = (c: HTMLElement, id: string) =>
 describe('IntegrationSetupSection', () => {
   it('reports each integration from its own probe', async () => {
     const { container, cleanup } = render(
-      <IntegrationSetupSection api={fakeApi({ hooksInstalled: true, mcpVerified: true })} />,
+      <IntegrationSetupSection api={fakeApi({ hooksInstalled: true, mcpRegistered: true })} />,
     );
     cleanups.push(cleanup);
     await flush();
@@ -138,7 +153,55 @@ describe('IntegrationSetupSection', () => {
     expect(rowStateFromProbe(false)).toBe('missing');
   });
 
-  it('renders nothing when a preload bridge is missing', () => {
+  // `verified` is a property of the TARGET (we have verified that client's MCP
+  // wiring), true for Claude Code whether or not wmux is registered. Reading it
+  // as install state made the row claim "installed" on an untouched config and
+  // hid the Register button that would have fixed it.
+  it('reads MCP registration from wmux.registered, not from verified', async () => {
+    expect(mcpRegistered([{ displayName: 'Claude Code' }])).toBe(false);
+    expect(mcpRegistered([{ displayName: 'Claude Code', wmux: { registered: false } }])).toBe(false);
+    expect(mcpRegistered([{ displayName: 'Claude Code', wmux: { registered: true } }])).toBe(true);
+
+    const { container, cleanup } = render(<IntegrationSetupSection api={fakeApi()} />);
+    cleanups.push(cleanup);
+    await flush();
+    expect(state(container, 'mcp')).toBe('missing');
+    expect(action(container, 'mcp')).not.toBeNull();
+  });
+
+  // The marketplace plugin owns the same four hook events, and an install
+  // against it deliberately writes nothing. Reading settings.json alone left the
+  // row at "not installed" forever while the signals actually flowed.
+  it('counts plugin-owned hooks as installed', async () => {
+    const { container, cleanup } = render(
+      <IntegrationSetupSection api={fakeApi({ hooksPluginOwned: true })} />,
+    );
+    cleanups.push(cleanup);
+    await flush();
+    expect(state(container, 'hooks')).toBe('installed');
+  });
+
+  it('names the reason when an install succeeds but writes nothing', () => {
+    expect(skippedReason([{ outcome: 'installed' }])).toBeNull();
+    expect(skippedReason([{ outcome: 'skipped-foreign' }])).toBe('skipped-foreign');
+    expect(skippedReason(undefined)).toBeNull();
+  });
+
+  // One absent bridge must not take the two REQUIRED rows down with it — the
+  // disappearing surface is the bug this card exists to end.
+  it('keeps the card when only some bridges are exposed', async () => {
+    const { container, cleanup } = render(
+      <IntegrationSetupSection api={fakeApi({ omit: 'statusline' })} />,
+    );
+    cleanups.push(cleanup);
+    await flush();
+    expect(container.querySelector('[data-integration-setup]')).not.toBeNull();
+    expect(state(container, 'statusline')).toBe('unavailable');
+    expect(action(container, 'statusline')).toBeNull();
+    expect(state(container, 'hooks')).toBe('missing');
+  });
+
+  it('renders nothing only when no bridge is exposed at all', () => {
     (window as unknown as { electronAPI?: unknown }).electronAPI = { deck: {} };
     const { container, cleanup } = render(<IntegrationSetupSectionContainer />);
     cleanups.push(cleanup);

--- a/src/renderer/components/__tests__/FirstRunWizard.bridges.test.ts
+++ b/src/renderer/components/__tests__/FirstRunWizard.bridges.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+//
+// Where the wizard looks for its optional bridges.
+//
+// Both accessors are allowed to return null ("older preload"), and the wizard
+// then hides the offer without a word. That makes a wrong path invisible: the
+// statusline accessor read `electronAPI.statuslineBridge` while the preload
+// exposes `electronAPI.deck.statuslineBridge`, so the offer never rendered in
+// any real build and no test noticed. These pin the path itself.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { hooksBridge, statuslineBridge } from '../FirstRunWizard';
+
+const stubStatusline = {
+  status: async () => ({
+    installed: false,
+    outcome: { scriptDest: '', scriptExists: false, targets: [] },
+  }),
+  install: async () => ({ ok: true, error: null, targets: [] }),
+};
+const stubHooks = {
+  status: async () => ({ installed: false }),
+  install: async () => ({ ok: true, error: null }),
+};
+
+function setElectronApi(value: unknown): void {
+  (window as unknown as { electronAPI?: unknown }).electronAPI = value;
+}
+
+afterEach(() => { delete (window as unknown as { electronAPI?: unknown }).electronAPI; });
+
+describe('first-run wizard bridge accessors', () => {
+  it('finds both bridges under electronAPI.deck (the preload path)', () => {
+    setElectronApi({ deck: { statuslineBridge: stubStatusline, hooksBridge: stubHooks } });
+    expect(statuslineBridge()).toBe(stubStatusline);
+    expect(hooksBridge()).toBe(stubHooks);
+  });
+
+  it('does not read them off the root of electronAPI', () => {
+    setElectronApi({ statuslineBridge: stubStatusline, hooksBridge: stubHooks });
+    expect(statuslineBridge()).toBeNull();
+    expect(hooksBridge()).toBeNull();
+  });
+
+  it('returns null when the preload predates the bridges', () => {
+    setElectronApi({ deck: {} });
+    expect(statuslineBridge()).toBeNull();
+    expect(hooksBridge()).toBeNull();
+  });
+});

--- a/src/renderer/components/__tests__/FirstRunWizard.test.ts
+++ b/src/renderer/components/__tests__/FirstRunWizard.test.ts
@@ -24,6 +24,7 @@ import {
   ClaudeStatusBlock,
   SampleTaskBlock,
   StatuslineBlock,
+  HooksBlock,
   decideStatuslineOffer,
 } from '../FirstRunWizard';
 import type { FirstRunCheckResult } from '../../../shared/firstRun';
@@ -424,5 +425,37 @@ describe('StatuslineBlock', () => {
       createElement(StatuslineBlock, { state: 'error', onInstall: () => undefined }),
     );
     expect(error).toContain('first-run-wizard-statusline-error');
+  });
+});
+
+describe('HooksBlock', () => {
+  it('renders the install button in offer state and disables it while installing', () => {
+    const offer = renderToStaticMarkup(
+      createElement(HooksBlock, { state: 'offer', onInstall: () => undefined }),
+    );
+    expect(offer).toContain('first-run-wizard-hooks-offer');
+    expect(offer).toContain('first-run-wizard-hooks-install');
+    expect(offer).not.toContain('disabled');
+
+    const installing = renderToStaticMarkup(
+      createElement(HooksBlock, { state: 'installing', onInstall: () => undefined }),
+    );
+    expect(installing).toContain('disabled');
+  });
+
+  // Unlike the statusline offer, the installed state RENDERS rather than
+  // hides: hooks are a requirement, and a checklist that silently omits its
+  // most important item teaches the operator it does not exist.
+  it('renders the installed state as a receipt, not as nothing', () => {
+    const installed = renderToStaticMarkup(
+      createElement(HooksBlock, { state: 'installed', onInstall: () => undefined }),
+    );
+    expect(installed).toContain('first-run-wizard-hooks-installed');
+
+    const error = renderToStaticMarkup(
+      createElement(HooksBlock, { state: 'error', errorDetail: 'EACCES', onInstall: () => undefined }),
+    );
+    expect(error).toContain('first-run-wizard-hooks-error');
+    expect(error).toContain('EACCES');
   });
 });

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -795,6 +795,40 @@ export const en = {
   'firstRunWizard.statuslineInstalling': 'Installing…',
   'firstRunWizard.statuslineInstalled': 'Statusline enabled',
   'firstRunWizard.statuslineInstalledHint': 'New Claude Code sessions will show it automatically.',
+  // Hook bridge — the required half of the integration. Unlike the statusline
+  // offer, the installed state is shown too, so the checklist reads complete.
+  'firstRunWizard.hooksHeading': 'Claude Code hooks (required)',
+  'firstRunWizard.hooksDescription':
+    'Lets wmux see when an agent finishes a turn, needs approval, or spawns a subagent. Without it those signals fall back to reading the screen, which misses turns behind a redraw.',
+  'firstRunWizard.hooksEnableButton': 'Install hooks',
+  'firstRunWizard.hooksInstalling': 'Installing…',
+  'firstRunWizard.hooksInstalled': 'Hooks installed',
+  'firstRunWizard.hooksInstalledHint': 'New Claude Code sessions report their lifecycle to wmux.',
+  'firstRunWizard.hooksError': 'Install failed. You can retry, or run `wmux setup-hooks` from a terminal.',
+  // Settings → Claude integration → setup card. The re-entry path for every
+  // integration the first-run wizard offers once.
+  'integrationSetup.title': 'Setup',
+  'integrationSetup.description':
+    'What wmux installs into Claude Code. Nothing here is written without your click.',
+  'integrationSetup.required': '· required',
+  'integrationSetup.recommended': '· recommended',
+  'integrationSetup.installButton': 'Install',
+  'integrationSetup.registerButton': 'Register',
+  'integrationSetup.working': 'Working…',
+  'integrationSetup.installFailed': 'Failed',
+  'integrationSetup.state.installed': 'installed',
+  'integrationSetup.state.missing': 'not installed',
+  'integrationSetup.state.working': 'working',
+  'integrationSetup.state.unknown': 'unknown',
+  'integrationSetup.hooks.title': 'Hook bridge',
+  'integrationSetup.hooks.description':
+    'Turn completion, approval prompts, and subagent activity. Without it these are read off the screen instead.',
+  'integrationSetup.mcp.title': 'MCP tools',
+  'integrationSetup.mcp.description':
+    'Lets agents drive wmux — terminals, panes, channels, the browser.',
+  'integrationSetup.statusline.title': 'Usage statusline',
+  'integrationSetup.statusline.description':
+    'Model, context, and rate limits under Claude Code\'s input box. Local reads only — no token cost.',
   'firstRunWizard.statuslineError': 'Install failed. You can retry, or run `wmux setup-statusline` from a terminal.',
 
   // First-run wizard — registerMcp Tier 2 errors (D10, problem / cause / fix)

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -820,6 +820,8 @@ export const en = {
   'integrationSetup.state.missing': 'not installed',
   'integrationSetup.state.working': 'working',
   'integrationSetup.state.unknown': 'unknown',
+  'integrationSetup.state.error': 'failed',
+  'integrationSetup.state.unavailable': 'unavailable',
   'integrationSetup.hooks.title': 'Hook bridge',
   'integrationSetup.hooks.description':
     'Turn completion, approval prompts, and subagent activity. Without it these are read off the screen instead.',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -617,6 +617,8 @@ export const ko = {
   'integrationSetup.state.missing': '미설치',
   'integrationSetup.state.working': '처리 중',
   'integrationSetup.state.unknown': '확인 안 됨',
+  'integrationSetup.state.error': '실패',
+  'integrationSetup.state.unavailable': '사용 불가',
   'integrationSetup.hooks.title': '훅 브리지',
   'integrationSetup.hooks.description':
     '턴 종료·승인 요청·서브에이전트 활동을 감지합니다. 없으면 화면을 읽어 추정합니다.',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -596,6 +596,36 @@ export const ko = {
   'firstRunWizard.statuslineInstalling': '설치 중…',
   'firstRunWizard.statuslineInstalled': '상태줄 켜짐',
   'firstRunWizard.statuslineInstalledHint': '새 Claude Code 세션부터 자동으로 표시됩니다.',
+  'firstRunWizard.hooksHeading': 'Claude Code 훅 (필수)',
+  'firstRunWizard.hooksDescription':
+    '에이전트가 턴을 마쳤는지, 승인을 기다리는지, 서브에이전트를 띄웠는지 wmux가 알 수 있게 합니다. 없으면 화면을 읽어 추정하므로 리드로우에 가려진 턴을 놓칩니다.',
+  'firstRunWizard.hooksEnableButton': '훅 설치',
+  'firstRunWizard.hooksInstalling': '설치 중…',
+  'firstRunWizard.hooksInstalled': '훅 설치됨',
+  'firstRunWizard.hooksInstalledHint': '새 Claude Code 세션부터 생명주기를 wmux에 보고합니다.',
+  'firstRunWizard.hooksError': '설치에 실패했습니다. 다시 시도하거나 터미널에서 `wmux setup-hooks`를 실행하세요.',
+  'integrationSetup.title': '설치',
+  'integrationSetup.description':
+    'wmux가 Claude Code에 설치하는 항목입니다. 직접 누르지 않으면 아무것도 기록하지 않습니다.',
+  'integrationSetup.required': '· 필수',
+  'integrationSetup.recommended': '· 권장',
+  'integrationSetup.installButton': '설치',
+  'integrationSetup.registerButton': '등록',
+  'integrationSetup.working': '처리 중…',
+  'integrationSetup.installFailed': '실패',
+  'integrationSetup.state.installed': '설치됨',
+  'integrationSetup.state.missing': '미설치',
+  'integrationSetup.state.working': '처리 중',
+  'integrationSetup.state.unknown': '확인 안 됨',
+  'integrationSetup.hooks.title': '훅 브리지',
+  'integrationSetup.hooks.description':
+    '턴 종료·승인 요청·서브에이전트 활동을 감지합니다. 없으면 화면을 읽어 추정합니다.',
+  'integrationSetup.mcp.title': 'MCP 도구',
+  'integrationSetup.mcp.description':
+    '에이전트가 wmux를 조작할 수 있게 합니다 — 터미널·페인·채널·브라우저.',
+  'integrationSetup.statusline.title': '사용량 statusline',
+  'integrationSetup.statusline.description':
+    'Claude Code 입력창 밑에 모델·컨텍스트·레이트리밋을 표시합니다. 로컬 읽기만 하므로 토큰 비용이 없습니다.',
   'firstRunWizard.statuslineError': '설치에 실패했습니다. 다시 시도하거나 터미널에서 `wmux setup-statusline`을 실행하세요.',
 
   // First-run wizard — registerMcp Tier 2 errors (D10, problem / cause / fix)


### PR DESCRIPTION
### The gap

wmux installs three things into Claude Code, and all three already had a
working IPC probe and a one-click install path:

| | |
|---|---|
| hook bridge | lifecycle signals — turn completion, approvals, subagents |
| MCP registration | the agent's access to wmux tools at all |
| usage statusline | model / context / rate limits under the input box |

The only UI that ever offered any of them was the first-run wizard. Skip it
once and the CLI (`wmux setup-hooks`, `wmux mcp register`,
`wmux setup-statusline`) was the entire re-entry path — an operator who could
not remember those commands had no way to discover the feature existed.

### Settings → Claude integration → Setup

A card at the top of the tab: one row per integration, state read from the
real probe rather than inferred, and an install button only where something is
missing. Required vs recommended is stated in words — the color grammar
reserves red for destructive, and a red "required" on a healthy install reads
as an error.

Two things it deliberately does not do:

- **No nagging.** No banner, no toast. The one existing nudge (the hook
  install prompt at launch and on a mode raise) is untouched. This is a place
  you go, not a thing that comes to you.
- **No writing without a click.** A probe that throws leaves its row `unknown`,
  never `missing` — an install button offered because IPC hiccuped would write
  to a config the user never asked us to touch. And `ok: true` with every
  target skipped is reported as a failure, not a success, because nothing was
  written.

### The wizard gets the hook bridge

It offered the statusline but never the hooks — the required half. Now it
offers both, and shows the hook row even when it is already installed: a
first-run checklist that silently omits its most important item teaches the
operator that item does not exist.

### The bug underneath

`statuslineBridge()` read `electronAPI.statuslineBridge` while the preload
exposes `electronAPI.deck.statuslineBridge`. The accessor's "older preload"
fallback turned the miss into `null`, and `null` means "hide the offer without
a word" — so the wizard's statusline block has never rendered in any real
build, and no test caught it because none referenced the bridge. Fixed, with a
contract test that pins both bridges to the preload path and fails if either
is read off the root again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Claude integration setup card in Settings for managing hooks, MCP tools, and usage statusline.
  - Added one-click installation and registration actions with clear status, error, and skipped-state feedback.
  - Updated the first-run wizard to offer Claude hook setup and show its current installation state.
  - Added English and Korean localization for the new setup experiences.

- **Bug Fixes**
  - Corrected statusline detection during first-run setup.

- **Tests**
  - Added coverage for integration states, installation flows, bridge handling, and wizard rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->