### PR TITLE
fix(setup-hooks): install and report the AskUserQuestion approval-card hooks

### DIFF
--- a/changelog.d/785.md
+++ b/changelog.d/785.md
@@ -1,0 +1,2 @@
+### Fixed
+- `wmux setup-hooks` now installs the `PreToolUse`/`PostToolUse` hooks scoped to `AskUserQuestion` on the plugin-less CLI path (previously only the marketplace plugin installed them), so the in-app approval inbox works no matter how wmux was installed. `wmux setup-hooks --status` now reports each feature — conversation read, approval card, turn-end signal, permission gate — as `OK`/`OFF` with the fix command on the same line, instead of silently reporting all-clear when the approval-card hook is missing. (#785)

--- a/src/cli/commands/__tests__/setupHooks.test.ts
+++ b/src/cli/commands/__tests__/setupHooks.test.ts
@@ -66,7 +66,7 @@ describe('installHooks', () => {
     expect(outcome.ok).toBe(true);
     expect(outcome.error).toBeNull();
     expect(outcome.events.sort()).toEqual(
-      ['SessionStart', 'Stop', 'SubagentStop'],
+      ['PostToolUse', 'PreToolUse', 'SessionStart', 'Stop', 'SubagentStop'],
     );
     expect(fs.existsSync(bridgeDest)).toBe(true);
     expect(fs.readFileSync(bridgeDest, 'utf8')).toBe('BRIDGE_CONTENT_V1\n');
@@ -74,7 +74,7 @@ describe('installHooks', () => {
     const s = readSettings();
     const hooks = s.hooks as Record<string, unknown[]>;
     expect(Object.keys(hooks).sort()).toEqual(
-      ['SessionStart', 'Stop', 'SubagentStop'],
+      ['PostToolUse', 'PreToolUse', 'SessionStart', 'Stop', 'SubagentStop'],
     );
     // Each entry references the stable dest path, NOT the source/install dir.
     const stop = hooks.Stop[0] as { hooks: { command: string }[] };
@@ -117,10 +117,14 @@ describe('installHooks', () => {
     expect(s.permissions).toEqual({ allow: ['Bash'] });
 
     const hooks = s.hooks as Record<string, unknown[]>;
-    // Foreign PreToolUse untouched.
-    expect(hooks.PreToolUse).toEqual([
-      { matcher: '', hooks: [{ type: 'command', command: 'echo foreign-pre' }] },
-    ]);
+    // Foreign PreToolUse (matcher '') is preserved AND the wmux PreToolUse
+    // (matcher AskUserQuestion) is appended — both coexist on the same event.
+    const pre = hooks.PreToolUse as { matcher: string; hooks: { command: string }[] }[];
+    expect(pre).toHaveLength(2);
+    expect(pre.some((g) => g.matcher === '' && g.hooks[0].command === 'echo foreign-pre')).toBe(true);
+    expect(
+      pre.some((g) => g.matcher === 'AskUserQuestion' && g.hooks[0].command.includes('wmux-bridge.mjs')),
+    ).toBe(true);
     // Stop keeps the foreign entry AND gains the wmux entry.
     const stopCmds = (hooks.Stop as { hooks: { command: string }[] }[]).map(
       (g) => g.hooks[0].command,
@@ -135,7 +139,7 @@ describe('installHooks', () => {
     installHooks(paths());
 
     const hooks = readSettings().hooks as Record<string, unknown[]>;
-    for (const event of ['Stop', 'SubagentStop', 'SessionStart']) {
+    for (const event of ['Stop', 'SubagentStop', 'SessionStart', 'PreToolUse', 'PostToolUse']) {
       const wmuxGroups = (hooks[event] as { hooks: { command: string }[] }[]).filter((g) =>
         g.hooks.some((h) => h.command.includes('wmux-bridge.mjs')),
       );
@@ -182,9 +186,12 @@ describe('installHooks — plugin-aware', () => {
       matcher: '',
       hooks: [{ type: 'command', command: 'echo foreign-stop' }],
     });
-    (s0.hooks as Record<string, unknown[]>).PreToolUse = [
-      { matcher: '', hooks: [{ type: 'command', command: 'echo foreign-pre' }] },
-    ];
+    // Push (not replace) so the wmux PreToolUse coexists with the foreign one —
+    // plugin-mode stripWmuxHooks then removes all 5 wmux groups and keeps this.
+    (s0.hooks as Record<string, unknown[]>).PreToolUse.push({
+      matcher: '',
+      hooks: [{ type: 'command', command: 'echo foreign-pre' }],
+    });
     fs.writeFileSync(settingsPath, JSON.stringify(s0), 'utf8');
 
     // Now the marketplace plugin appears.
@@ -195,7 +202,7 @@ describe('installHooks — plugin-aware', () => {
     const outcome = installHooks(paths());
     expect(outcome.ok).toBe(true);
     expect(outcome.pluginDetected).toBe(true);
-    expect(outcome.removedForPlugin).toBe(3);
+    expect(outcome.removedForPlugin).toBe(5);
     expect(outcome.events).toEqual([]);
 
     // No wmux command remains; both foreign hooks are preserved.
@@ -215,9 +222,9 @@ describe('installHooks — plugin-aware', () => {
     const outcome = installHooks(paths());
     expect(outcome.ok).toBe(true);
     expect(outcome.pluginDetected).toBe(false);
-    expect(outcome.events.sort()).toEqual(['SessionStart', 'Stop', 'SubagentStop']);
+    expect(outcome.events.sort()).toEqual(['PostToolUse', 'PreToolUse', 'SessionStart', 'Stop', 'SubagentStop']);
     const hooks = readSettings().hooks as Record<string, unknown[]>;
-    expect(Object.keys(hooks).sort()).toEqual(['SessionStart', 'Stop', 'SubagentStop']);
+    expect(Object.keys(hooks).sort()).toEqual(['PostToolUse', 'PreToolUse', 'SessionStart', 'Stop', 'SubagentStop']);
   });
 
   it('treats a malformed installed_plugins.json as plugin-absent (normal install)', () => {
@@ -225,7 +232,7 @@ describe('installHooks — plugin-aware', () => {
     const outcome = installHooks(paths());
     expect(outcome.ok).toBe(true);
     expect(outcome.pluginDetected).toBe(false);
-    expect(outcome.events.sort()).toEqual(['SessionStart', 'Stop', 'SubagentStop']);
+    expect(outcome.events.sort()).toEqual(['PostToolUse', 'PreToolUse', 'SessionStart', 'Stop', 'SubagentStop']);
     expect(allHookCommands().some((c) => c.includes('wmux-bridge.mjs'))).toBe(true);
   });
 
@@ -254,7 +261,7 @@ describe('installHooks — plugin-aware', () => {
     const outcome = installHooks(paths());
     expect(outcome.ok).toBe(true);
     expect(outcome.pluginDetected).toBe(false);
-    expect(outcome.events.sort()).toEqual(['SessionStart', 'Stop', 'SubagentStop']);
+    expect(outcome.events.sort()).toEqual(['PostToolUse', 'PreToolUse', 'SessionStart', 'Stop', 'SubagentStop']);
     expect(allHookCommands().some((c) => c.includes('wmux-bridge.mjs'))).toBe(true);
     // The user's enabledPlugins map is preserved untouched.
     expect((readSettings().enabledPlugins as Record<string, unknown>)[
@@ -298,7 +305,7 @@ describe('removeHooks', () => {
 
     const outcome = removeHooks(paths());
     expect(outcome.ok).toBe(true);
-    expect(outcome.removed).toBe(3);
+    expect(outcome.removed).toBe(5);
 
     const s = readSettings();
     expect(s.model).toBe('opus');
@@ -360,7 +367,7 @@ describe('statusHooks', () => {
     const s = statusHooks(paths());
     expect(s.settingsExists).toBe(true);
     expect(s.installedEvents.sort()).toEqual(
-      ['SessionStart', 'Stop', 'SubagentStop'],
+      ['PostToolUse', 'PreToolUse', 'SessionStart', 'Stop', 'SubagentStop'],
     );
     expect(s.bridgeExists).toBe(true);
     expect(s.bridgeStale).toBe(false);
@@ -392,6 +399,39 @@ describe('statusHooks', () => {
     fs.mkdirSync(pluginDir, { recursive: true });
     const s = statusHooks(paths());
     expect(s.pluginAlsoInstalled).toBe(true);
+  });
+
+  it('reports approvalCard OFF before install and OK after (#781)', () => {
+    // Fresh: no hooks → features are 'off' with a fix command on the same line.
+    const before = statusHooks(paths());
+    expect(before.features.approvalCard.state).toBe('off');
+    expect(before.features.approvalCard.detail).toContain('wmux setup-hooks');
+    expect(before.features.conversationRead.state).toBe('off');
+    expect(before.features.turnEnd.state).toBe('off');
+    // permissionGate is not yet a shipped hook — always off, and crucially it
+    // must NOT advertise `wmux setup-hooks` as a fix (that would not help).
+    expect(before.features.permissionGate.state).toBe('off');
+    expect(before.features.permissionGate.detail).not.toContain('wmux setup-hooks');
+
+    installHooks(paths());
+    const after = statusHooks(paths());
+    expect(after.features.conversationRead.state).toBe('ok');
+    expect(after.features.approvalCard.state).toBe('ok');
+    expect(after.features.turnEnd.state).toBe('ok');
+    expect(after.features.permissionGate.state).toBe('off'); // still off until #783
+  });
+
+  it('installs PreToolUse/PostToolUse scoped to AskUserQuestion (not matcher "")', () => {
+    installHooks(paths());
+    const hooks = readSettings().hooks as Record<string, { matcher: string }[]>;
+    expect(hooks.PreToolUse).toBeDefined();
+    expect(hooks.PostToolUse).toBeDefined();
+    // The approval-card pair is scoped to AskUserQuestion so it fires once per
+    // question, not on every tool call (the 2026-07-13 PostToolUse removal was
+    // about a matcher:'' per-tool cost). Turn-boundary hooks stay matcher:''.
+    expect(hooks.PreToolUse.some((g) => g.matcher === 'AskUserQuestion')).toBe(true);
+    expect(hooks.PostToolUse.some((g) => g.matcher === 'AskUserQuestion')).toBe(true);
+    expect(hooks.Stop[0].matcher).toBe('');
   });
 });
 

--- a/src/cli/commands/setupHooks.ts
+++ b/src/cli/commands/setupHooks.ts
@@ -41,12 +41,39 @@ GLOBAL FLAGS
   --json       Output raw JSON (useful for scripting).
 `.trimStart();
 
-/** The Claude Code hook events wmux subscribes to (mirrors hooks.json).
- *  PostToolUse was removed 2026-07-13: it fired a ~110ms node bridge on EVERY
- *  tool call only to feed the fleet "running" dot, which the daemon's
- *  byte-based ActivityMonitor now drives for free (see markSurfaceRunning). */
+/** Claude Code hook events wmux owns at matcher:'' (mirrors hooks.json). These
+ *  fire at turn boundaries, never per tool call. */
 const HOOK_EVENTS = ['Stop', 'SubagentStop', 'SessionStart'] as const;
-type HookEvent = (typeof HOOK_EVENTS)[number];
+
+/**
+ * AskUserQuestion-scoped hook pair that drives the in-app approval card:
+ *   PreToolUse  → card created  (agent.awaiting_input)
+ *   PostToolUse → card expired   (agent.input_answered, fired:true)
+ * Both are scoped to the AskUserQuestion matcher so they fire ONCE per
+ * question, not on every tool call. The 2026-07-13 PostToolUse removal was
+ * about a matcher:'' cost — a ~110ms node bridge per tool call feeding the
+ * fleet "running" dot, which the daemon's byte-based ActivityMonitor now
+ * drives for free. The approval card has no such replacement, so it gets its
+ * own scoped pair. This closes #781: the plugin path (hooks.json) installed
+ * these but the CLI (plugin-less) path did not, so the approval inbox silently
+ * died for plugin-less users — `setup-hooks` even wiped a hand-registered
+ * PreToolUse that pointed at our own bridge (isWmuxGroup match). */
+const ASK_QUESTION_MATCHER = 'AskUserQuestion';
+const ASK_QUESTION_HOOKS = [
+  { event: 'PreToolUse', matcher: ASK_QUESTION_MATCHER },
+  { event: 'PostToolUse', matcher: ASK_QUESTION_MATCHER },
+] as const;
+
+type HookEvent =
+  | (typeof HOOK_EVENTS)[number]
+  | (typeof ASK_QUESTION_HOOKS)[number]['event'];
+
+/** Every wmux-owned hook in settings.json as (event, matcher) specs — the
+ *  single source `installHooks` writes and `statusHooks` checks against. */
+const HOOK_SPECS: readonly { event: HookEvent; matcher: string }[] = [
+  ...HOOK_EVENTS.map((event) => ({ event, matcher: '' })),
+  ...ASK_QUESTION_HOOKS,
+];
 
 /** Substring that identifies a wmux-owned hook command in settings.json. */
 const WMUX_BRIDGE_MARKER = 'wmux-bridge.mjs';
@@ -218,6 +245,14 @@ function loadSettings(settingsPath: string): LoadResult {
  * Strip all wmux-owned hook groups from a settings.hooks map, dropping any event
  * arrays (and the `hooks` key itself) left empty. Returns the count removed.
  * Mutates `settings` in place. Used by both install (clear-then-add) and remove.
+ *
+ * PRESERVES every foreign (non-wmux) hook group: a group is removed only when
+ * `isWmuxGroup` confirms it carries a wmux-bridge.mjs command leaf. A user's
+ * hand-registered foreign PreToolUse pointing at a DIFFERENT script is never
+ * touched — `installHooks` then re-adds only wmux's own specs. (#781: the
+ * report of "setup-hooks wiped my PreToolUse" was a group whose command
+ * pointed at wmux-bridge.mjs itself, which is correctly wmux-owned and thus
+ * refreshed, not a foreign hook destroyed.)
  */
 function stripWmuxHooks(settings: Record<string, unknown>): number {
   const hooks = settings.hooks;
@@ -407,13 +442,13 @@ export function installHooks(paths: SetupHooksPaths): InstallOutcome {
       ? (settings.hooks as Record<string, unknown>)
       : {};
 
-  for (const event of HOOK_EVENTS) {
+  for (const spec of HOOK_SPECS) {
     const group: HookGroup = {
-      matcher: '',
-      hooks: [{ type: 'command', command: bridgeCommand(paths.bridgeDest, event) }],
+      matcher: spec.matcher,
+      hooks: [{ type: 'command', command: bridgeCommand(paths.bridgeDest, spec.event) }],
     };
-    const existing = hooks[event];
-    hooks[event] = Array.isArray(existing) ? [...existing, group] : [group];
+    const existing = hooks[spec.event];
+    hooks[spec.event] = Array.isArray(existing) ? [...existing, group] : [group];
   }
   settings.hooks = hooks;
 
@@ -424,7 +459,7 @@ export function installHooks(paths: SetupHooksPaths): InstallOutcome {
     ...base,
     ok: true,
     bridgeCopied: true,
-    events: [...HOOK_EVENTS],
+    events: HOOK_SPECS.map((s) => s.event),
   };
 }
 
@@ -540,6 +575,15 @@ export function removeHooks(paths: SetupHooksPaths): RemoveOutcome {
 
 // ----- Status -------------------------------------------------------------
 
+/** Feature-oriented status entry: what the user cares about ("does the approval
+ *  card work?"), not which hook event name is registered. */
+export interface HookFeatureStatus {
+  /** 'ok' when the hook(s) backing this feature are installed, 'off' otherwise. */
+  state: 'ok' | 'off';
+  /** Human-readable explanation; includes the fix command when state is 'off'. */
+  detail: string;
+}
+
 export interface StatusOutcome {
   settingsPath: string;
   settingsExists: boolean;
@@ -556,6 +600,18 @@ export interface StatusOutcome {
    * active — each turn would then fire double signals. Best-effort detection.
    */
   pluginAlsoInstalled: boolean;
+  /**
+   * Feature-oriented status — the primary surface for users, who ask "does the
+   * approval card work?" not "is PreToolUse registered?". `installedEvents`
+   * remains for scripts; `features` answers what works and how to fix it.
+   * `permissionGate` is 'off' until the phone permission gate ships (#783).
+   */
+  features: {
+    conversationRead: HookFeatureStatus;
+    approvalCard: HookFeatureStatus;
+    turnEnd: HookFeatureStatus;
+    permissionGate: HookFeatureStatus;
+  };
 }
 
 /**
@@ -600,10 +656,11 @@ export function statusHooks(paths: SetupHooksPaths): StatusOutcome {
     const hooks = load.settings.hooks;
     if (hooks && typeof hooks === 'object' && !Array.isArray(hooks)) {
       const hooksMap = hooks as Record<string, unknown>;
-      for (const event of HOOK_EVENTS) {
-        const groups = hooksMap[event];
+      for (const spec of HOOK_SPECS) {
+        const groups = hooksMap[spec.event];
         if (Array.isArray(groups) && groups.some((g) => isWmuxGroup(g))) {
-          installedEvents.push(event);
+          // HOOK_SPECS carries each event once, but dedup defensively.
+          if (!installedEvents.includes(spec.event)) installedEvents.push(spec.event);
         }
       }
     }
@@ -621,6 +678,28 @@ export function statusHooks(paths: SetupHooksPaths): StatusOutcome {
     }
   }
 
+  // Feature-oriented view derived from installedEvents. Each 'off' detail
+  // names the fix command, so the user can act without re-reading — the core
+  // ask of #781 (status must report what's broken, not just list hook names).
+  const has = (e: HookEvent): boolean => installedEvents.includes(e);
+  const FIX = 'wmux setup-hooks';
+  const features = {
+    conversationRead: has('SessionStart')
+      ? { state: 'ok' as const, detail: 'SessionStart → transcript binding on session start' }
+      : { state: 'off' as const, detail: `SessionStart missing → run \`${FIX}\`` },
+    approvalCard:
+      has('PreToolUse') && has('PostToolUse')
+        ? { state: 'ok' as const, detail: 'PreToolUse + PostToolUse (AskUserQuestion) → card create + expire' }
+        : { state: 'off' as const, detail: `PreToolUse/PostToolUse:AskUserQuestion missing → run \`${FIX}\`` },
+    turnEnd:
+      has('Stop') && has('SubagentStop')
+        ? { state: 'ok' as const, detail: 'Stop + SubagentStop → turn-end nudge' }
+        : { state: 'off' as const, detail: `Stop/SubagentStop missing → run \`${FIX}\`` },
+    // The phone permission gate (#783) is not yet a hook this install owns —
+    // report 'off' honestly rather than implying it can be fixed here.
+    permissionGate: { state: 'off' as const, detail: 'phone permission gate — not yet available' },
+  };
+
   return {
     settingsPath: paths.settingsPath,
     settingsExists: load.exists,
@@ -631,6 +710,7 @@ export function statusHooks(paths: SetupHooksPaths): StatusOutcome {
     bridgeSource: paths.bridgeSource,
     bridgeStale,
     pluginAlsoInstalled: detectPluginInstalled(paths.settingsPath),
+    features,
   };
 }
 
@@ -691,12 +771,28 @@ function printStatus(outcome: StatusOutcome, jsonMode: boolean): void {
     console.log(JSON.stringify(outcome, null, 2));
     return;
   }
+
+  // Feature table first — users ask "does the approval card work?", not "which
+  // hook event names are registered?". Each row shows state + how to fix it on
+  // one line (#781).
+  const featureRows: Array<[string, HookFeatureStatus]> = [
+    ['conversation read', outcome.features.conversationRead],
+    ['approval card', outcome.features.approvalCard],
+    ['turn-end signal', outcome.features.turnEnd],
+    ['permission gate', outcome.features.permissionGate],
+  ];
+  for (const [label, f] of featureRows) {
+    const tag = f.state === 'ok' ? 'OK ' : 'OFF';
+    console.log(`${label.padEnd(18)} ${tag}  ${f.detail}`);
+  }
+
+  console.log('');
   if (outcome.settingsCorrupted) {
     console.log(`settings: ${outcome.settingsPath} (UNPARSEABLE — fix before installing)`);
   } else if (outcome.installedEvents.length > 0) {
-    console.log(`settings: wmux hooks installed for ${outcome.installedEvents.join(', ')}`);
+    console.log(`settings: ${outcome.settingsPath} (hooks: ${outcome.installedEvents.join(', ')})`);
   } else {
-    console.log('settings: wmux hooks NOT installed — run `wmux setup-hooks` to add them.');
+    console.log(`settings: ${outcome.settingsPath} (wmux hooks NOT installed)`);
   }
 
   if (!outcome.bridgeExists) {


### PR DESCRIPTION
Closes #781.

## What

The plugin-less CLI path never installed the `PreToolUse`/`PostToolUse` hooks scoped to `AskUserQuestion` that drive the in-app approval card — only the marketplace plugin did. So the approval inbox silently died for plugin-less users, and `wmux setup-hooks --status` could not report the gap because it only walked `Stop`/`SubagentStop`/`SessionStart`.

## Changes

- **Install the approval-card hooks.** `HOOK_SPECS` adds `PreToolUse` + `PostToolUse` scoped to `AskUserQuestion`, so they fire once per question, not per tool call. (The 2026-07-13 `PostToolUse` removal was about a `matcher:''` per-tool cost the daemon's byte-based ActivityMonitor now covers for free; the approval card has no such replacement, so it gets its own scoped pair.)
- **Feature-oriented status.** `--status` now prints a table — `conversation read` / `approval card` / `turn-end signal` / `permission gate` — each line showing `OK`/`OFF` with the fix command right there when a feature is off. The in-app install button reuses the same `statusHooks`/`installHooks`, so it inherits the fix.
- **Foreign hooks stay untouched.** `stripWmuxHooks` already preserved every non-wmux group; the contract is now stated explicitly (the earlier "wiped my PreToolUse" report was a group whose command pointed at our own bridge, correctly wmux-owned).

## Verification

- `eslint`, `tsc --noEmit`, `test:parallel` (10024 passed), `test:runtime` (138 passed), `build:daemon` — all green.
- New tests: approval-card feature `OFF`→`OK` transition across install; `PreToolUse`/`PostToolUse` scoped to `AskUserQuestion` (not `matcher:''`); permission gate stays `OFF` until #783.

## Notes

- First of three PRs for the phone turn view (#781 → #782 → #783). #783's permission-gate hook install builds on this.
- No version bump (repo policy). Changelog fragment will be added once this PR number is known.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `wmux setup-hooks` now installs approval-related hooks for plugin-less CLI setups.
  * Approval hooks are scoped to approval prompts while preserving unrelated hooks.
  * `wmux setup-hooks --status` now reports individual feature states and provides corresponding fix commands.

* **Bug Fixes**
  * Improved hook installation, removal, and status detection across plugin-enabled and plugin-less configurations.
  * Repeated setup operations are now handled safely without duplicating hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->