### PR TITLE
fix(setup-hooks): report effective hook feature status

### DIFF
--- a/changelog.d/787.md
+++ b/changelog.d/787.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **Hook feature status now reflects the active integration.** The
+  `wmux setup-hooks --status` command requires the precise `AskUserQuestion`
+  scope for manual approval hooks and recognizes features supplied by an enabled
+  `wmux-claude-integration` plugin, instead of treating stale broad hooks as
+  healthy or a plugin-managed installation as off. (#787)

--- a/src/cli/commands/__tests__/setupHooks.test.ts
+++ b/src/cli/commands/__tests__/setupHooks.test.ts
@@ -36,6 +36,17 @@ function writePluginManifest(raw: string): void {
   fs.writeFileSync(manifestPath, raw, 'utf8');
 }
 
+/** Build a wmux-owned hook group without invoking the installer. */
+function wmuxHookGroup(event: string, matcher?: string): {
+  matcher?: string;
+  hooks: { type: string; command: string }[];
+} {
+  return {
+    ...(matcher === undefined ? {} : { matcher }),
+    hooks: [{ type: 'command', command: `node "${bridgeDest}" ${event}` }],
+  };
+}
+
 /** Flatten every hook command string across all events in settings.json. */
 function allHookCommands(): string[] {
   const hooks = (readSettings().hooks ?? {}) as Record<string, unknown[]>;
@@ -399,6 +410,100 @@ describe('statusHooks', () => {
     fs.mkdirSync(pluginDir, { recursive: true });
     const s = statusHooks(paths());
     expect(s.pluginAlsoInstalled).toBe(true);
+  });
+
+  it('does not count unscoped approval hooks as AskUserQuestion-scoped', () => {
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [wmuxHookGroup('PreToolUse', '')],
+          PostToolUse: [wmuxHookGroup('PostToolUse', '')],
+        },
+      }),
+      'utf8',
+    );
+
+    const s = statusHooks(paths());
+    expect(s.installedEvents).toEqual([]);
+    expect(s.features.approvalCard.state).toBe('off');
+    expect(s.features.permissionGate.state).toBe('off');
+  });
+
+  it('reports correctly scoped manual approval hooks as healthy', () => {
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [wmuxHookGroup('PreToolUse', 'AskUserQuestion')],
+          PostToolUse: [wmuxHookGroup('PostToolUse', 'AskUserQuestion')],
+        },
+      }),
+      'utf8',
+    );
+
+    const s = statusHooks(paths());
+    expect(s.installedEvents.sort()).toEqual(['PostToolUse', 'PreToolUse']);
+    expect(s.features.approvalCard.state).toBe('ok');
+    expect(s.features.permissionGate.state).toBe('off');
+  });
+
+  it('uses effective match-all semantics for turn-boundary hooks', () => {
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          SessionStart: [wmuxHookGroup('SessionStart')],
+          Stop: [wmuxHookGroup('Stop', 'ignored-by-Claude-Code')],
+          SubagentStop: [wmuxHookGroup('SubagentStop', '*')],
+        },
+      }),
+      'utf8',
+    );
+
+    const s = statusHooks(paths());
+    expect(s.features.conversationRead.state).toBe('ok');
+    expect(s.features.turnEnd.state).toBe('ok');
+    expect(s.features.approvalCard.state).toBe('off');
+    expect(s.features.permissionGate.state).toBe('off');
+  });
+
+  it('reports an active plugin-only installation as plugin-managed', () => {
+    writePluginManifest(
+      JSON.stringify({ 'wmux-claude-integration@wmux-marketplace': { version: '1.0.0' } }),
+    );
+
+    const s = statusHooks(paths());
+    expect(s.installedEvents).toEqual([]);
+    expect(s.features.conversationRead.state).toBe('ok');
+    expect(s.features.conversationRead.detail).toContain('plugin-managed');
+    expect(s.features.approvalCard.state).toBe('ok');
+    expect(s.features.approvalCard.detail).toContain('plugin-managed');
+    expect(s.features.turnEnd.state).toBe('ok');
+    expect(s.features.turnEnd.detail).toContain('plugin-managed');
+    expect(s.features.permissionGate.state).toBe('off');
+  });
+
+  it('does not count an explicitly disabled plugin without manual hooks', () => {
+    writePluginManifest(
+      JSON.stringify({ 'wmux-claude-integration@wmux-marketplace': { version: '1.0.0' } }),
+    );
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({ enabledPlugins: { 'wmux-claude-integration@wmux-marketplace': false } }),
+      'utf8',
+    );
+
+    const s = statusHooks(paths());
+    expect(s.installedEvents).toEqual([]);
+    expect(s.features.conversationRead.state).toBe('off');
+    expect(s.features.approvalCard.state).toBe('off');
+    expect(s.features.turnEnd.state).toBe('off');
+    expect(s.features.permissionGate.state).toBe('off');
   });
 
   it('reports approvalCard OFF before install and OK after (#781)', () => {

--- a/src/cli/commands/setupHooks.ts
+++ b/src/cli/commands/setupHooks.ts
@@ -198,6 +198,27 @@ function isWmuxGroup(group: unknown): boolean {
   );
 }
 
+/**
+ * True when a wmux-owned group has the effective scope required by a spec.
+ * Claude Code treats an omitted matcher, `""`, and `"*"` as match-all.
+ * `Stop` does not support matchers at all, so any string value is ignored.
+ * Tool hooks stay stricter: the approval-card pair must name
+ * `AskUserQuestion` exactly, rather than merely including it in a broader
+ * scope that would reintroduce per-tool hook execution.
+ */
+function isEffectiveWmuxGroupForSpec(
+  group: unknown,
+  spec: { event: HookEvent; matcher: string },
+): boolean {
+  if (!isWmuxGroup(group)) return false;
+  const matcher = (group as HookGroup).matcher;
+  if (matcher !== undefined && typeof matcher !== 'string') return false;
+
+  if (spec.matcher !== '') return matcher === spec.matcher;
+  if (spec.event === 'Stop') return true;
+  return matcher === undefined || matcher === '' || matcher === '*';
+}
+
 // ----- Settings load (corruption-aware) -----------------------------------
 
 interface LoadResult {
@@ -603,7 +624,8 @@ export interface StatusOutcome {
   /**
    * Feature-oriented status — the primary surface for users, who ask "does the
    * approval card work?" not "is PreToolUse registered?". `installedEvents`
-   * remains for scripts; `features` answers what works and how to fix it.
+   * remains the effective settings.json view for scripts; `features` also
+   * accounts for hooks supplied by an active marketplace plugin.
    * `permissionGate` is 'off' until the phone permission gate ships (#783).
    */
   features: {
@@ -650,6 +672,10 @@ function detectPluginInstalled(settingsPath: string): boolean {
 
 export function statusHooks(paths: SetupHooksPaths): StatusOutcome {
   const load = loadSettings(paths.settingsPath);
+  const pluginActive =
+    !load.corrupted &&
+    detectPluginViaManifest(paths.settingsPath) &&
+    !isPluginExplicitlyDisabled(load.settings);
 
   const installedEvents: HookEvent[] = [];
   if (!load.corrupted) {
@@ -658,7 +684,10 @@ export function statusHooks(paths: SetupHooksPaths): StatusOutcome {
       const hooksMap = hooks as Record<string, unknown>;
       for (const spec of HOOK_SPECS) {
         const groups = hooksMap[spec.event];
-        if (Array.isArray(groups) && groups.some((g) => isWmuxGroup(g))) {
+        if (
+          Array.isArray(groups) &&
+          groups.some((group) => isEffectiveWmuxGroupForSpec(group, spec))
+        ) {
           // HOOK_SPECS carries each event once, but dedup defensively.
           if (!installedEvents.includes(spec.event)) installedEvents.push(spec.event);
         }
@@ -678,23 +707,54 @@ export function statusHooks(paths: SetupHooksPaths): StatusOutcome {
     }
   }
 
-  // Feature-oriented view derived from installedEvents. Each 'off' detail
-  // names the fix command, so the user can act without re-reading — the core
-  // ask of #781 (status must report what's broken, not just list hook names).
+  // Feature-oriented view derived from effective settings hooks plus the
+  // authoritative active-plugin signal. The bundled plugin supplies
+  // SessionStart, Stop/SubagentStop, and the approval-card lifecycle: its
+  // PreToolUse is AskUserQuestion-scoped, while its broad PostToolUse bridge
+  // promotes only AskUserQuestion completion to agent.input_answered.
+  // Permission gating remains deliberately separate until #783 ships.
   const has = (e: HookEvent): boolean => installedEvents.includes(e);
   const FIX = 'wmux setup-hooks';
+  const featureStatus = (
+    pluginSupplies: boolean,
+    manualHooksSupply: boolean,
+    okDetail: string,
+    offDetail: string,
+  ): HookFeatureStatus => {
+    if (pluginSupplies) {
+      return {
+        state: 'ok',
+        detail: `plugin-managed by ${WMUX_PLUGIN_MARKER}: ${okDetail}`,
+      };
+    }
+    return manualHooksSupply
+      ? { state: 'ok', detail: okDetail }
+      : { state: 'off', detail: offDetail };
+  };
+  const pluginFeatures = {
+    conversationRead: pluginActive,
+    approvalCard: pluginActive,
+    turnEnd: pluginActive,
+  };
   const features = {
-    conversationRead: has('SessionStart')
-      ? { state: 'ok' as const, detail: 'SessionStart → transcript binding on session start' }
-      : { state: 'off' as const, detail: `SessionStart missing → run \`${FIX}\`` },
-    approvalCard:
-      has('PreToolUse') && has('PostToolUse')
-        ? { state: 'ok' as const, detail: 'PreToolUse + PostToolUse (AskUserQuestion) → card create + expire' }
-        : { state: 'off' as const, detail: `PreToolUse/PostToolUse:AskUserQuestion missing → run \`${FIX}\`` },
-    turnEnd:
-      has('Stop') && has('SubagentStop')
-        ? { state: 'ok' as const, detail: 'Stop + SubagentStop → turn-end nudge' }
-        : { state: 'off' as const, detail: `Stop/SubagentStop missing → run \`${FIX}\`` },
+    conversationRead: featureStatus(
+      pluginFeatures.conversationRead,
+      has('SessionStart'),
+      'SessionStart → transcript binding on session start',
+      `SessionStart missing → run \`${FIX}\``,
+    ),
+    approvalCard: featureStatus(
+      pluginFeatures.approvalCard,
+      has('PreToolUse') && has('PostToolUse'),
+      'PreToolUse + PostToolUse (AskUserQuestion) → card create + expire',
+      `PreToolUse/PostToolUse:AskUserQuestion missing → run \`${FIX}\``,
+    ),
+    turnEnd: featureStatus(
+      pluginFeatures.turnEnd,
+      has('Stop') && has('SubagentStop'),
+      'Stop + SubagentStop → turn-end nudge',
+      `Stop/SubagentStop missing → run \`${FIX}\``,
+    ),
     // The phone permission gate (#783) is not yet a hook this install owns —
     // report 'off' honestly rather than implying it can be fixed here.
     permissionGate: { state: 'off' as const, detail: 'phone permission gate — not yet available' },


### PR DESCRIPTION
## Summary

This is a correctness follow-up to #785.

- Match manual wmux hooks by their effective `(event, matcher)` scope, so unscoped `PreToolUse` / `PostToolUse` groups cannot satisfy the `AskUserQuestion` approval-card feature.
- Honor Claude Code's match-all contract for turn-boundary hooks (`matcher` omitted, `""`, or `"*"`; `Stop` ignores matchers).
- Report conversation read, approval card, and turn-end features as plugin-managed when the installed-plugins manifest identifies an active `wmux-claude-integration` plugin.
- Keep explicitly disabled plugins unhealthy and keep `permissionGate` `OFF` until the larger gate work lands.

`installedEvents` remains the effective settings.json view; no external status fields were added or removed. Existing foreign hooks remain untouched.

Refs #783

## Verification

- `npx vitest run src/cli/commands/__tests__/setupHooks.test.ts --maxWorkers=1` — 44 passed
- `npx eslint src/cli/commands/setupHooks.ts src/cli/commands/__tests__/setupHooks.test.ts` — passed
- `npx tsc --noEmit` — passed
- `npm run build:cli` — passed
- `npm run test:parallel` — 681 files / 10,045 tests passed; 2 files / 24 tests skipped by the suite
- `node scripts/collect-changelog.mjs --check` — passed (3 fragments, nothing written)
- `git diff --check upstream/main...HEAD` — passed

`npm run test:runtime` was not run; this status-only change is covered by isolated unit tests and the regular parallel suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hook status reporting for manual approval hooks by requiring the precise `AskUserQuestion` scope.
  * Correctly recognizes match-all turn-boundary hooks.
  * Detects enabled `wmux-claude-integration` plugin features and reports plugin-managed capabilities accurately.
  * Preserves clear status and remediation details for manually configured hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->