### PR TITLE
fix(web): prevent transcript response caching

### DIFF
--- a/changelog.d/788.md
+++ b/changelog.d/788.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Phone turn-view responses now use `Cache-Control: no-store`, preventing browsers and intermediaries from retaining cached transcript pages after transcript access is revoked. (#788)

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -1735,6 +1735,10 @@ export class WebTerminalServer {
     sessionId: string,
     principal: WebPrincipal,
   ): void {
+    // Transcript pages can contain thinking blocks, full tool inputs, and file
+    // contents. Keep every response on this route out of client/intermediary
+    // caches so revoking transcript access does not leave a replayable copy.
+    res.setHeader('Cache-Control', 'no-store');
     if (this.opts?.allowTranscript !== true) {
       this.json(res, 403, {
         error: 'transcript-disabled: server started without --allow-transcript',

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -3480,6 +3480,7 @@ describe('WebTerminalServer', () => {
       const h = bearer(info.token as string);
       const turns = await fetch(`${base()}/api/sessions/s1/turns`, { headers: h });
       expect(turns.status).toBe(403);
+      expect(turns.headers.get('cache-control')).toBe('no-store');
       const body = await turns.json();
       // Matched by the machine-readable TAG, the way a client must: the prose
       // after the colon may be reworded, `transcript-disabled:` may not.
@@ -3512,6 +3513,36 @@ describe('WebTerminalServer', () => {
         expect(res.status).toBe(200);
         expect(await res.json()).toMatchObject({ available: false, reason });
       }
+    });
+
+    it('★ turn-view responses are never cacheable', async () => {
+      const info = await startWithTranscript();
+      const h = bearer(info.token as string);
+
+      const unavailable = await fetch(`${base()}/api/sessions/s1/turns`, { headers: h });
+      expect(unavailable.status).toBe(200);
+      expect(unavailable.headers.get('cache-control')).toBe('no-store');
+
+      projectorMock.status.mockReturnValue({ available: true, reason: 'ok', transcriptBasename: 's.jsonl' });
+      projectorMock.snapshot.mockReturnValue({
+        events: [{ id: 'snapshot', kind: 'user_text', text: 'private snapshot' }],
+        cursor: { headOffset: 0, tailOffset: 10, fileSize: 10, mtimeMs: 1234 },
+        hasMore: false,
+        truncatedHead: false,
+      });
+      const snapshot = await fetch(`${base()}/api/sessions/s1/turns`, { headers: h });
+      expect(snapshot.status).toBe(200);
+      expect(snapshot.headers.get('cache-control')).toBe('no-store');
+
+      projectorMock.delta.mockReturnValue({
+        events: [{ id: 'delta', kind: 'assistant_text', text: 'private delta' }],
+        cursor: { headOffset: 0, tailOffset: 20, fileSize: 20, mtimeMs: 1234 },
+        reset: false,
+      });
+      const cursor = Buffer.from(JSON.stringify({ head: 0, tail: 10 })).toString('base64url');
+      const delta = await fetch(`${base()}/api/sessions/s1/turns?cursor=${cursor}`, { headers: h });
+      expect(delta.status).toBe(200);
+      expect(delta.headers.get('cache-control')).toBe('no-store');
     });
 
     it('a forward delta is served from projector.delta with an opaque cursor', async () => {


### PR DESCRIPTION
## Summary
- mark every response produced by `GET /api/sessions/:id/turns` as `Cache-Control: no-store`
- cover disabled, unavailable, snapshot, and forward-delta responses
- add the numbered changelog fragment for #788

## Why
The turn view can contain thinking blocks, full tool inputs, and contents from files the agent read. Without an explicit cache policy, a phone or intermediary can retain a replayable transcript response after the operator revokes transcript access.

This is a focused privacy/correctness follow-up to #786 and addresses the unhandled review finding at https://github.com/openwong2kim/wmux/pull/786#discussion_r3706538615.

## Verification
- `npx vitest run src/daemon/web/__tests__/WebTerminalServer.test.ts --maxWorkers=1` — 154 passed
- `npx eslint src/daemon/web/WebTerminalServer.ts src/daemon/web/__tests__/WebTerminalServer.test.ts` — 0 errors; 9 unchanged warnings outside the diff
- `npx tsc --noEmit` — passed
- `npx tsc -p tsconfig.daemon.json --noEmit` — passed
- `npm run build:daemon` — passed
- `npm run test:parallel` — 681 files / 10,041 tests passed; 2 files / 24 tests skipped
- `node scripts/collect-changelog.mjs --check` — passed with 3 fragments (2 Fixed, 1 Added)
- `git diff --check upstream/main...HEAD` — passed