### PR TITLE
fix(transcript): preserve budget-drop receipt on reset

### DIFF
--- a/changelog.d/791.md
+++ b/changelog.d/791.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **Transcript reset pages retain omission receipts.** Phone clients now receive
+  `budgetDropped` when a reset snapshot skips an oversized transcript entry, so
+  they can render an omission seam instead of silently closing the gap. (#791)

--- a/src/daemon/transcript/TranscriptProjector.ts
+++ b/src/daemon/transcript/TranscriptProjector.ts
@@ -232,9 +232,16 @@ export class TranscriptProjector {
     // A shrunk file (stat.size < from) is readTranscriptDelta's own reset path.
 
     if (reset) {
-      const page = this.snapshot(sessionId);
+      const { result: page, budgetDropped } = this.fitWithReceipt((maxBytes) =>
+        readTranscriptPage(resolved.transcriptPath, { maxBytes }),
+      );
       if (!page) return null;
-      return { events: page.events, cursor: page.cursor, reset: true };
+      return {
+        events: page.events,
+        cursor: page.cursor,
+        reset: true,
+        ...(budgetDropped ? { budgetDropped: true } : {}),
+      };
     }
 
     const { result, budgetDropped } = this.fitWithReceipt((maxBytes) => {

--- a/src/daemon/transcript/__tests__/TranscriptProjector.test.ts
+++ b/src/daemon/transcript/__tests__/TranscriptProjector.test.ts
@@ -639,6 +639,23 @@ describe('TranscriptProjector.codeBlock — tool bodies', () => {
 });
 
 describe('TranscriptProjector — #782 phone turn-view contract (stateless delta)', () => {
+  /**
+   * A valid entry whose normalized events exceed BUDGET_BYTES while the raw
+   * JSONL record still fits inside the projector's smallest read window. The
+   * long entry id is repeated across every projected tool event, forcing the
+   * budget fitter (rather than readTail's raw-record skip) to omit the row.
+   */
+  function budgetDroppingEntry(): string {
+    return JSON.stringify({
+      type: 'assistant',
+      uuid: `oversized-${'u'.repeat(500)}`,
+      message: {
+        role: 'assistant',
+        content: Array.from({ length: 300 }, () => ({ type: 'tool_use' })),
+      },
+    });
+  }
+
   it('delta is stateless: a phone read arms no watch and resets no subscriber', () => {
     const file = fixture('claude-basic.jsonl');
     harness.bindings.set('pty-1', binding({ transcriptPath: file }));
@@ -672,6 +689,56 @@ describe('TranscriptProjector — #782 phone turn-view contract (stateless delta
     expect(result.reset).toBe(true);
     // A reset carries a fresh snapshot, not an empty delta.
     expect(result.events.length).toBe(snap.events.length);
+  });
+
+  it('reports a budget drop on the normal forward path', () => {
+    const file = path.join(harness.projects, 'forward-budget-drop.jsonl');
+    fs.writeFileSync(file, JSON.stringify({
+      type: 'user',
+      uuid: 'seed',
+      message: { role: 'user', content: 'before the oversized entry' },
+    }) + '\n', 'utf8');
+    harness.bindings.set('pty-1', binding({ transcriptPath: file }));
+    const snap = harness.projector.snapshot('pty-1');
+    if (!snap) throw new Error('expected an initial snapshot');
+
+    const oversized = `${budgetDroppingEntry()}\n`;
+    expect(Buffer.byteLength(oversized, 'utf8')).toBeLessThan(8 * 1024);
+    fs.appendFileSync(file, oversized, 'utf8');
+
+    const result = harness.projector.delta('pty-1', snap.cursor.tailOffset, {
+      cursorFileSize: snap.cursor.fileSize,
+    });
+    if (!result) throw new Error('expected a forward delta');
+    expect(result.reset).toBe(false);
+    expect(result.budgetDropped).toBe(true);
+    expect(result.events).toEqual([]);
+    expect(result.cursor.tailOffset).toBe(fs.statSync(file).size);
+  });
+
+  it('preserves the budget-drop receipt when reset returns a fresh snapshot', () => {
+    const file = path.join(harness.projects, 'reset-budget-drop.jsonl');
+    fs.writeFileSync(file, JSON.stringify({
+      type: 'user',
+      uuid: 'old-session',
+      message: { role: 'user', content: 'x'.repeat(16 * 1024) },
+    }) + '\n', 'utf8');
+    harness.bindings.set('pty-1', binding({ transcriptPath: file }));
+    const snap = harness.projector.snapshot('pty-1');
+    if (!snap) throw new Error('expected an initial snapshot');
+
+    const oversized = `${budgetDroppingEntry()}\n`;
+    fs.writeFileSync(file, oversized, 'utf8');
+    expect(fs.statSync(file).size).toBeLessThan(snap.cursor.fileSize);
+
+    const result = harness.projector.delta('pty-1', snap.cursor.tailOffset, {
+      cursorFileSize: snap.cursor.fileSize,
+    });
+    if (!result) throw new Error('expected a reset delta');
+    expect(result.reset).toBe(true);
+    expect(result.budgetDropped).toBe(true);
+    expect(result.events).toEqual([]);
+    expect(result.cursor.tailOffset).toBe(fs.statSync(file).size);
   });
 
   it('delta resets when the cursor offset is no longer a line boundary', () => {


### PR DESCRIPTION
## Summary

- preserve the `budgetDropped` receipt when a forward transcript cursor resets to a fresh snapshot
- keep the existing reset, cursor, paging, and snapshot semantics unchanged
- add focused forward-path and reset-path regression coverage

This is a correctness follow-up to #786 and addresses [the unhandled review finding](https://github.com/openwong2kim/wmux/pull/786#discussion_r3706538581). It does not close a separate issue.

The reset regression was confirmed before the implementation change: the targeted file had 40 passing tests and one failure because the reset result returned `budgetDropped: undefined`; the forward-path receipt test already passed.

## Verification

- [x] `npx vitest run src/daemon/transcript/__tests__/TranscriptProjector.test.ts --maxWorkers=1` — 41 passed
- [x] `npx eslint src/daemon/transcript/TranscriptProjector.ts src/daemon/transcript/__tests__/TranscriptProjector.test.ts` — 0 errors; 10 pre-existing non-null-assertion warnings in the test file
- [x] `npx tsc --noEmit`
- [x] `npx tsc -p tsconfig.daemon.json --noEmit`
- [x] `npm run build:daemon`
- [x] `npm run test:parallel` — 10,048 passed, 24 skipped (681 files passed, 2 skipped)
- [x] `node scripts/collect-changelog.mjs --check`
- [x] `git diff --check upstream/main...HEAD`

Not run: the runtime test suite and full-repository lint. The selected verification uses the focused lint, both TypeScript projects, daemon build, and the full non-runtime suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Phone clients now receive a `budgetDropped` indicator when oversized transcript entries are omitted from reset snapshots.
  - Reset and forward transcript updates now consistently respect event size limits.
  - Transcript cursors advance correctly when oversized entries are skipped, preventing repeated processing.

- **Tests**
  - Added coverage for oversized transcript entries in forward and reset updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->