### PR TITLE
fix(cli): surface transcript access in web help and status

### DIFF
--- a/changelog.d/793.md
+++ b/changelog.d/793.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Full transcript access is now visible in web help and status.** The
+  `--allow-transcript` flag and its sensitive data scope are documented, and
+  `wmux web --status` reports whether the permission is enabled instead of
+  leaving operators unable to audit the grant. (#793)

--- a/src/cli/__tests__/web.status.test.ts
+++ b/src/cli/__tests__/web.status.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { sendDaemonStringRequestMock } = vi.hoisted(() => ({
+  sendDaemonStringRequestMock: vi.fn(),
+}));
+
+vi.mock('../client', () => ({
+  sendDaemonStringRequest: sendDaemonStringRequestMock,
+}));
+
+import { handleWeb } from '../commands/web';
+
+let lines: string[];
+
+beforeEach(() => {
+  lines = [];
+  sendDaemonStringRequestMock.mockReset();
+  vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    lines.push(args.map(String).join(' '));
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function statusResponse(allowTranscript?: boolean) {
+  return {
+    id: 'web-status',
+    ok: true as const,
+    result: {
+      running: true,
+      port: 7681,
+      host: '127.0.0.1',
+      allowInput: false,
+      allowUpload: false,
+      ...(allowTranscript === undefined ? {} : { allowTranscript }),
+      tls: false,
+      urls: [],
+    },
+  };
+}
+
+describe('wmux web --status transcript access', () => {
+  it('makes enabled full-transcript access visible', async () => {
+    sendDaemonStringRequestMock.mockResolvedValue(statusResponse(true));
+
+    await handleWeb(['--status'], false);
+
+    expect(sendDaemonStringRequestMock).toHaveBeenCalledWith('daemon.web.status', {});
+    const output = lines.join('\n');
+    expect(output).toContain('transcript ENABLED');
+    expect(output).toContain('Transcript access is ENABLED');
+    expect(output).toContain('thinking, tool inputs, and file contents');
+  });
+
+  it.each([
+    ['disabled', false],
+    ['unreported by an older daemon', undefined],
+  ])('reports transcript access as off when it is %s', async (_case, allowTranscript) => {
+    sendDaemonStringRequestMock.mockResolvedValue(statusResponse(allowTranscript));
+
+    await handleWeb(['--status'], false);
+
+    const output = lines.join('\n');
+    expect(output).not.toContain('transcript ENABLED');
+    expect(output).toContain('Transcript access is off');
+    expect(output).toContain('--allow-transcript');
+  });
+});

--- a/src/cli/commands/web.ts
+++ b/src/cli/commands/web.ts
@@ -360,7 +360,7 @@ function report(
   const nativeTls = info.tls === true;
 
   console.log('');
-  console.log(`  wmux web ${mode === 'start' ? 'started' : 'running'} — ${info.allowInput ? 'INPUT ENABLED' : 'read-only'}${info.allowUpload ? '  ·  uploads ENABLED' : ''}`);
+  console.log(`  wmux web ${mode === 'start' ? 'started' : 'running'} — ${info.allowInput ? 'INPUT ENABLED' : 'read-only'}${info.allowUpload ? '  ·  uploads ENABLED' : ''}${info.allowTranscript ? '  ·  transcript ENABLED' : ''}`);
   console.log(`  bind ${info.host}:${info.port}${typeof info.clients === 'number' ? `  ·  ${info.clients} viewer(s)` : ''}`);
   console.log('');
 
@@ -455,6 +455,14 @@ function report(
   } else {
     console.log('  Photo upload is off. Re-run with --allow-upload to let a paired');
     console.log('  phone send photos into ~/.wmux/uploads/phone.');
+  }
+  if (info.allowTranscript) {
+    console.log('  Transcript access is ENABLED: a paired phone can read the full Claude');
+    console.log('  session transcript, including thinking, tool inputs, and file contents');
+    console.log('  the agent read.');
+  } else {
+    console.log('  Transcript access is off. Re-run with --allow-transcript to let a');
+    console.log('  paired phone read the full Claude session transcript.');
   }
   if (tailnet || nativeTls) {
     console.log('  PWA: served over HTTPS, so "Add to Home Screen", Android install and');

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -78,6 +78,10 @@ WEB ACCESS (browser / PWA)
         [--allow-upload]            Enable photo upload from a paired phone
                                     (JPEG/PNG, 10 MB cap, files kept 24h in
                                     ~/.wmux/uploads/phone). Off by default
+        [--allow-transcript]        Enable full Claude transcript access for a
+                                    paired phone (thinking, tool inputs, and
+                                    contents of files the agent read). Off by
+                                    default
         [--allow-host <h1,h2>]      Extra Host names to accept and advertise,
                                     for a reverse proxy or native TLS DNS name
         [--new-token]               Mint a fresh access token, revoking every

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -1328,6 +1328,7 @@ export class WebTerminalServer {
       host: this.opts.host,
       allowInput: this.opts.allowInput,
       allowUpload: this.opts.allowUpload,
+      allowTranscript: this.opts.allowTranscript === true,
       tls: this.opts.tls !== undefined,
       token: this.token,
       urls: this.buildUrls(),

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -639,6 +639,16 @@ describe('WebTerminalServer', () => {
     expect((info.pairExpiresAt as number)).toBeGreaterThan(Date.now());
   });
 
+  it('reports transcript access in normal pairing-capable status responses', async () => {
+    const disabled = await startRO();
+    expect(disabled).toHaveProperty('allowTranscript', false);
+
+    await server.stop();
+    const enabled = await startWithTranscript();
+    expect(enabled).toHaveProperty('allowTranscript', true);
+    expect(server.status()).toHaveProperty('allowTranscript', true);
+  });
+
   it('/api/pair with the right code returns a credential once, then 403 (single use)', async () => {
     const info = await startRO();
     const code = info.pairCode as string;


### PR DESCRIPTION
## Summary

- document `--allow-transcript` in `wmux web --help`, including the data it exposes and its off-by-default posture
- show the effective transcript-access state in the web status header and detailed permission summary
- make the normal pairing-capable daemon status response carry the same boolean permission field as the pairing-refusal path
- cover CLI rendering plus enabled and disabled daemon status contracts with focused regression tests

## Context

This is a correctness and discoverability follow-up to #786 and [its review finding](https://github.com/openwong2kim/wmux/pull/786#discussion_r3706538575). The flag was parsed and forwarded to the daemon, but operators could not discover it in CLI help or inspect its effective state in normal status output.

The new CLI regression tests failed against the original renderer. The daemon producer-contract test also failed before its fix because the normal status response returned `undefined` instead of `false`.

## Verification

- `npx vitest run src/cli/__tests__/web.status.test.ts --maxWorkers=1` (3 passed after reproducing 3 failures before the CLI change)
- `npx vitest run src/daemon/web/__tests__/WebTerminalServer.test.ts src/cli/__tests__/web.test.ts src/cli/__tests__/web.tls.test.ts src/cli/__tests__/web.status.test.ts --maxWorkers=1` (170 passed after reproducing the daemon contract failure)
- `npx eslint src/daemon/web/WebTerminalServer.ts src/daemon/web/__tests__/WebTerminalServer.test.ts src/cli/index.ts src/cli/commands/web.ts src/cli/__tests__/web.status.test.ts` (0 errors; 9 existing warnings on unchanged non-null assertions)
- `npx tsc --noEmit`
- `npx tsc -p tsconfig.cli.json --noEmit`
- `npx tsc -p tsconfig.daemon.json --noEmit`
- `npm run build:cli`
- `npm run build:daemon`
- `node dist/cli-bundle/index.js --help` (verified the rendered flag description)
- `npm run test:parallel` (10,083 passed, 24 skipped; 684 files passed, 2 skipped)
- `node scripts/collect-changelog.mjs --check`
- `git diff --check upstream/main...HEAD`

Not run: runtime tests and full-repository lint. Every changed TypeScript file was linted directly, all applicable typechecks and builds passed, and the full non-runtime suite passed.