### PR TITLE
fix(web): visibility-based PTY size ownership for the phone (#766, #770)

### DIFF
--- a/changelog.d/795.md
+++ b/changelog.d/795.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **The phone now gets the right pane shape when the desk isn't looking.** A
+  pane the Mac app holds open used to be `attached` whether or not anyone could
+  see it, so a phone rendering it always got a desk-shaped (e.g. 151×47)
+  geometry and letterboxed a third of its portrait screen — every live pane
+  answered `409 desk-owns-size`. Size ownership is now visibility-based: the
+  renderer reports whether a pane is actually on screen (workspace + tab active
+  AND the window visible), and the route only keeps the desk's geometry when the
+  desk is watching. An attached-but-hidden pane (background workspace, inactive
+  tab, minimized window) takes the phone's numbers, and the desk silently
+  reclaims the size the moment somebody looks again. (#766)

--- a/docs/phone-client-contract.md
+++ b/docs/phone-client-contract.md
@@ -311,7 +311,7 @@ app-owned conversation history. Without `--allow-input`, send neither; never
 forward generic taps or drags, guess a mouse protocol, or pretend the alternate
 buffer is locally scrollable.
 
-### Resizing a pane — the desk owns the size whenever it is attached
+### Resizing a pane — the desk owns the size while it is actually showing it
 
 ```
 POST /api/sessions/<id>/resize   body: {cols, rows}
@@ -329,13 +329,21 @@ only thing that can fix it.
 
 **Ownership.** There is one PTY behind both views and it can have one geometry.
 While a desk renderer has the pane wired (`state: 'attached'` in
-`/api/sessions`), that geometry is the desk's: the 409 carries the current
-`cols`/`rows` so you can render to them without a second request. A `detached`
-pane takes your numbers. You do not have to hand ownership back — a desk client
-re-derives its geometry from its own bounds and resizes on attach.
+`/api/sessions`) **and is actually showing it** — the pane's workspace and tab
+are active and the window itself is visible — that geometry is the desk's: the
+409 carries the current `cols`/`rows` so you can render to them without a
+second request. A `detached` pane takes your numbers, and so does an attached
+pane the desk is not looking at (background workspace, inactive tab, minimized
+window): nobody is watching the layout your numbers would break. You cannot see
+the desk's visibility in `/api/sessions` — the probe is the request itself. You
+do not have to hand ownership back — a desk client re-derives its geometry from
+its own bounds and resizes on attach and on every reveal, silently taking the
+size back the moment somebody looks.
 
-Do not treat the 409 as an error to retry. It is the answer: render at the size
-it names, and try again after the pane's `state` goes `detached`.
+Do not treat the 409 as an error to retry in a loop. It is the answer: render
+at the size it names. A fresh attempt is reasonable when something on YOUR side
+changed (the pane was reopened, your viewport rotated) — the desk may have
+stopped looking since.
 
 **Render at the geometry in the 200, not at the one you asked for.** The daemon
 answers with what it stored, which is not promised to equal the request.

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -77,6 +77,20 @@ export interface ManagedSession {
    * `false` for the rest of the session's lifetime.
    */
   deferred: boolean;
+  /**
+   * #766 — whether a desk renderer is actually SHOWING this pane (workspace +
+   * tab active and the window itself visible), as last reported by the
+   * renderer. Orthogonal to `meta.state`: an attached pane in a background
+   * workspace stays 'attached' but is not visible. Consumed only by the phone
+   * resize route — `attached && viewerVisible` keeps the desk's ownership of
+   * the PTY geometry; attached-but-hidden lets the phone reshape the pane.
+   *
+   * Defaults to true and is reset to true on detach (not attach — the
+   * renderer's mount-time report can land before its attach RPC): a renderer
+   * that never reports (older build) behaves exactly as before #766, and a
+   * renderer that does report sends the real value on mount and every flip.
+   */
+  viewerVisible: boolean;
 }
 
 /**
@@ -495,6 +509,7 @@ export class DaemonSessionManager extends EventEmitter {
       bridge,
       promptLog,
       deferred,
+      viewerVisible: true,
     };
     this.sessions.set(params.id, managed);
 
@@ -718,12 +733,34 @@ export class DaemonSessionManager extends EventEmitter {
     this.emit('session:stateChanged', { id, state: 'attached' as DaemonSessionState });
   }
 
+  /**
+   * #766 — record whether the desk renderer is actually showing this pane.
+   * Fire-and-forget from the renderer's point of view, so unknown ids are
+   * ignored rather than thrown: the report can race a dispose, and there is
+   * nothing the caller would do with the error. No state event — visibility
+   * is not part of the attach/detach lifecycle, and the only consumer
+   * (the phone resize route) reads it at request time.
+   */
+  setSessionViewerVisibility(id: string, visible: boolean): void {
+    const managed = this.sessions.get(id);
+    if (!managed) return;
+    managed.viewerVisible = visible;
+  }
+
   detachSession(id: string): void {
     const managed = this.sessions.get(id);
     if (!managed) throw new Error(`Session '${id}' not found`);
     if (managed.meta.state === 'dead') throw new Error(`Session '${id}' is dead`);
 
     managed.meta.state = 'detached';
+    // #766 — conservative reset on DETACH, deliberately not on attach: the
+    // renderer's mount-time visibility report can land before its attach RPC,
+    // and an attach-time reset would overwrite a fresh "hidden" with the
+    // default. Resetting here instead means the next attacher starts at the
+    // safe default (desk owns the size) — an older renderer that never
+    // reports keeps pre-#766 behavior, a current one re-reports on mount and
+    // on every flip.
+    managed.viewerVisible = true;
     this.emit('session:stateChanged', { id, state: 'detached' as DaemonSessionState });
   }
 

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -389,6 +389,30 @@ describe('DaemonSessionManager', () => {
     expect(sessions[0].state).toBe('detached');
   });
 
+  // #766 — viewer visibility: renderer-reported "is this pane on screen",
+  // consumed by the phone resize route (attached && viewerVisible → 409).
+  it('records viewer visibility and resets it to visible on detach, not attach', () => {
+    manager.createSession({ id: 'vis', cmd: 'cmd.exe', cwd: '.' });
+    // Safe default: nobody has reported, so the desk owns the size.
+    expect(manager.getSession('vis')?.viewerVisible).toBe(true);
+
+    // The mount-time report can land BEFORE the attach RPC — attach must not
+    // overwrite it (that would mark every hidden retained pane visible).
+    manager.setSessionViewerVisibility('vis', false);
+    manager.attachSession('vis');
+    expect(manager.getSession('vis')?.viewerVisible).toBe(false);
+
+    // Detach resets to the safe default so the next attacher — possibly an
+    // older renderer that never reports — starts with the desk owning.
+    manager.detachSession('vis');
+    expect(manager.getSession('vis')?.viewerVisible).toBe(true);
+  });
+
+  it('ignores a visibility report for an unknown session', () => {
+    // Fire-and-forget path: the report can race a dispose.
+    expect(() => manager.setSessionViewerVisibility('nope', false)).not.toThrow();
+  });
+
   // 5. destroySession → session removed
   it('destroys a session and removes it from the list', () => {
     manager.createSession({ id: 'kill', cmd: 'cmd.exe', cwd: '.' });

--- a/src/daemon/hooks/__tests__/HookIngest.test.ts
+++ b/src/daemon/hooks/__tests__/HookIngest.test.ts
@@ -43,6 +43,9 @@ function makeDeps(sessions: HookIngestSession[] = [session({ id: 'pty-a' })]) {
   const emitted: Array<{ sessionId: string; data: HookAgentEventData }> = [];
   const bindings: Array<{ ptyId: string; binding: ResumeBinding }> = [];
   const nudges: Array<{ sessionId: string; kind: AgentSignalKind }> = [];
+  // #770 — track every approval-sink call so the locally-answered expiry path
+  // can be asserted (expireForSession reason + that nothing broadcasts).
+  const approvalsCalls: Array<{ sessionId: string; reason: string }> = [];
   let clock = 10_000;
   const deps = {
     listLiveSessions: () => sessions,
@@ -55,6 +58,13 @@ function makeDeps(sessions: HookIngestSession[] = [session({ id: 'pty-a' })]) {
     onTranscriptNudge: (sessionId: string, kind: AgentSignalKind) => {
       nudges.push({ sessionId, kind });
     },
+    approvals: {
+      noteHookAwaitingInput: () => { /* tracked at the registry level */ },
+      noteGateAwaiting: () => 'gate-id',
+      expireForSession: (sessionId: string, reason: string) => {
+        approvalsCalls.push({ sessionId, reason });
+      },
+    },
     log: () => { /* silent in tests */ },
     now: () => clock,
   };
@@ -63,6 +73,7 @@ function makeDeps(sessions: HookIngestSession[] = [session({ id: 'pty-a' })]) {
     emitted,
     bindings,
     nudges,
+    approvalsCalls,
     advance: (ms: number) => { clock += ms; },
   };
 }
@@ -179,6 +190,47 @@ describe('HookIngest', () => {
       }));
       expect(fixture.bindings).toHaveLength(1);
       expect(fixture.bindings[0].binding.sessionId).toBe('origin-1');
+    });
+  });
+
+  describe('input_answered (#770 — locally-answered AskUserQuestion expires the phone card)', () => {
+    it('expires the pending request with reason answered-locally and never broadcasts', () => {
+      // PC answers an AskUserQuestion directly: the bridge promotes the
+      // AskUserQuestion PostToolUse to agent.input_answered, and the daemon
+      // expires the still-pending phone card mid-turn — before agent.stop.
+      const res = ingest.handle(makeSignal({ ptyId: 'pty-a', kind: 'agent.input_answered' }));
+      expect(res).toEqual({ ok: true });
+      expect(fixture.approvalsCalls).toEqual([
+        { sessionId: 'pty-a', reason: 'answered-locally' },
+      ]);
+      // Not a turn boundary or even a metadata ping: nothing fans out.
+      expect(fixture.emitted).toHaveLength(0);
+    });
+
+    it('does not capture a resume binding or nudge the transcript (early return)', () => {
+      ingest.handle(makeSignal({
+        ptyId: 'pty-a',
+        kind: 'agent.input_answered',
+        agentSessionId: 'origin-1',
+      }));
+      expect(fixture.bindings).toHaveLength(0);
+      expect(fixture.nudges).toHaveLength(0);
+    });
+
+    it('keeps the agent.stop backstop — a later stop still expires + broadcasts', () => {
+      // If PostToolUse never arrives (turn interrupted), agent.stop is the
+      // backstop. A second expireForSession on an already-expired record is a
+      // registry-level no-op; here we confirm the signal path still routes it.
+      ingest.handle(makeSignal({ ptyId: 'pty-a', kind: 'agent.input_answered' }));
+      fixture.advance(100);
+      ingest.handle(makeSignal({ ptyId: 'pty-a', kind: 'agent.stop' }));
+      expect(fixture.approvalsCalls).toEqual([
+        { sessionId: 'pty-a', reason: 'answered-locally' },
+        { sessionId: 'pty-a', reason: 'turn-ended' },
+      ]);
+      // Only the stop broadcasts — input_answered stayed silent.
+      expect(fixture.emitted).toHaveLength(1);
+      expect(fixture.emitted[0].data.hookKind).toBe('agent.stop');
     });
   });
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -2004,6 +2004,20 @@ function registerRpcHandlers(
     return { ok: true };
   });
 
+  // daemon.setSessionViewerVisibility (#766) — the renderer's "is this pane
+  // actually on screen" report. Not persisted and not a lifecycle event: the
+  // flag lives on the managed session and is read at request time by the
+  // phone resize route. Unknown ids are a no-op (the report can race a
+  // dispose), matching the fire-and-forget relay in pty.handler.
+  pipeServer.onRpc('daemon.setSessionViewerVisibility', async (params) => {
+    const p = params as unknown as { id: string; visible: boolean };
+    if (typeof p.id !== 'string' || typeof p.visible !== 'boolean') {
+      throw new Error('setSessionViewerVisibility: id (string) and visible (boolean) are required');
+    }
+    sessionManager.setSessionViewerVisibility(p.id, p.visible);
+    return { ok: true };
+  });
+
   // daemon.resyncSession (phase 3 PR-B) — re-run the flush sequence on the
   // live, already-connected session pipe: RESYNC_BEGIN marker → headless
   // snapshot (or raw-replay degrade) → FLUSH_DONE marker. The socket is never

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -1759,11 +1759,18 @@ export class WebTerminalServer {
    * policy but a fight: the phone resizes, the desk's next frame resizes back,
    * and the PTY thrashes between two geometries while both views redraw.
    *
-   * So: `attached` (a desk renderer has this pane wired) → `409 desk-owns-size`,
-   * carrying the current geometry so the caller can render to it without a
-   * second request. `detached` → the phone's numbers are applied. A pane that
-   * the desk later attaches resizes itself on mount, so ownership returns
-   * without anything here having to take it back.
+   * So (#766, visibility-based ownership): `attached` AND VISIBLE — a desk
+   * renderer has this pane wired and is actually showing it (workspace + tab
+   * active, window not hidden; `ManagedSession.viewerVisible`, reported by the
+   * renderer) → `409 desk-owns-size`, carrying the current geometry so the
+   * caller can render to it without a second request. `detached`, or attached
+   * but not visible (background workspace, inactive tab, minimized window) →
+   * the phone's numbers are applied: nobody is looking at the layout the
+   * phone would break, so the fight the paragraph above describes cannot
+   * start — the hidden renderer's fit is silent (zero-size container guard)
+   * until the pane is revealed again. A pane the desk attaches or reveals
+   * re-fits itself and resizes unconditionally, so ownership returns without
+   * anything here having to take it back.
    *
    * NOT GATED ON `--allow-input`, on the same reasoning as
    * `GET /api/sessions/:id/diff` and `POST /api/approvals/:id`: this delivers a
@@ -1896,7 +1903,7 @@ export class WebTerminalServer {
       // by the desk in between.
       const current = this.deps.sessionManager.getSession(id);
       if (!current) return this.json(res, 404, { error: 'session not found' });
-      if (current.meta.state === 'attached') {
+      if (current.meta.state === 'attached' && current.viewerVisible) {
         return this.json(res, 409, {
           error: 'desk-owns-size',
           cols: current.meta.cols,

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -37,6 +37,9 @@ function makeDeps() {
     // A session recovered from a reboot that has not had its first resize yet.
     // The resize route refuses it — that first resize is the desk's unmute.
     deferred: false,
+    // #766 — the desk is showing the pane unless a test flips this; the
+    // resize route only honors 'attached' when this is also true.
+    viewerVisible: true,
     ringBuffer: { readAll: () => Buffer.from('screen-bytes') },
     bridge,
     ptyProcess: { write },
@@ -354,7 +357,7 @@ describe('WebTerminalServer', () => {
   let gitCalls: Array<{ args: readonly string[]; cwd: string }>;
   let gitScript: Record<string, { ok: boolean; stdout: string; stderr: string; ran?: boolean }>;
   let gitGate: { hold: Promise<void> | null };
-  let managed: { meta: Record<string, unknown>; deferred: boolean };
+  let managed: { meta: Record<string, unknown>; deferred: boolean; viewerVisible: boolean };
   let live: ReturnType<typeof makeDeps>['live'];
   let uploadsDir: string;
   let projectorMock: ReturnType<typeof makeDeps>['projectorMock'];
@@ -2689,6 +2692,18 @@ describe('WebTerminalServer', () => {
       owner: 'desk',
     });
     expect(resizeCalls).toEqual([]);
+  });
+
+  it('★ hands the size to the phone when the desk holds the pane but is not showing it (#766)', async () => {
+    const token = (await startRO()).token as string;
+    // s2 is attached, but the renderer reported the pane off screen
+    // (background workspace / inactive tab / minimized window). Nobody is
+    // looking at the layout the phone would break, so its numbers apply.
+    managed.viewerVisible = false;
+    const res = await postResize('s2', token, { cols: 60, rows: 30 });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ cols: 60, rows: 30, owner: 'caller' });
+    expect(resizeCalls).toEqual([{ id: 's2', cols: 60, rows: 30 }]);
   });
 
   it('★ reports the record, never the request', async () => {

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -736,6 +736,22 @@ export function registerPTYHandlers(
     }));
   }
 
+  // pty:setViewerVisibility (#766)
+  // Fire-and-forget relay of the renderer's "is this pane actually on screen"
+  // report. Daemon mode only — the flag exists solely so the phone resize
+  // route (`POST /api/sessions/:id/resize`) can distinguish an attached pane
+  // the desk is watching from one it merely holds; local mode has no phone.
+  // Errors are swallowed: a not-found session means the report raced a
+  // dispose, and a lost report self-heals on the next visibility flip (the
+  // daemon also resets the flag to visible on detach).
+  ipcMain.removeAllListeners(IPC.PTY_SET_VIEWER_VISIBILITY);
+  if (useDaemon && daemonClient) {
+    ipcMain.on(IPC.PTY_SET_VIEWER_VISIBILITY, (_event: Electron.IpcMainEvent, id: string, visible: boolean) => {
+      if (typeof id !== 'string' || typeof visible !== 'boolean') return;
+      daemonClient.rpc('daemon.setSessionViewerVisibility', { id, visible }).catch(() => undefined);
+    });
+  }
+
   // pty:dispose
   ipcMain.removeHandler(IPC.PTY_DISPOSE);
   if (useDaemon && daemonClient) {
@@ -1247,6 +1263,7 @@ export function registerPTYHandlers(
     ipcMain.removeHandler(IPC.PTY_CREATE);
     ipcMain.removeAllListeners(IPC.PTY_WRITE);
     ipcMain.removeHandler(IPC.PTY_RESIZE);
+    ipcMain.removeAllListeners(IPC.PTY_SET_VIEWER_VISIBILITY);
     ipcMain.removeHandler(IPC.PTY_DISPOSE);
     ipcMain.removeHandler(IPC.PTY_LIST);
     ipcMain.removeHandler(IPC.PTY_PROMOTE);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -55,6 +55,12 @@ const electronAPI = {
     },
     resize: (id: string, cols: number, rows: number) =>
       ipcRenderer.invoke(IPC.PTY_RESIZE, id, cols, rows),
+    // #766 — fire-and-forget visibility report (send, not invoke: the renderer
+    // has nothing useful to do with an ack, and a lost report self-heals on
+    // the next visibility flip or the daemon's detach-time reset).
+    setViewerVisibility: (id: string, visible: boolean) => {
+      ipcRenderer.send(IPC.PTY_SET_VIEWER_VISIBILITY, id, visible);
+    },
     dispose: (id: string) =>
       ipcRenderer.invoke(IPC.PTY_DISPOSE, id),
     // `supervision` (X8) is additive and present only on supervised daemon-mode

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback, useState } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebglAddon } from '@xterm/addon-webgl';
@@ -2404,6 +2404,40 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       }
     }
   }, [isVisible, fit, startResync]);
+
+  // #766 — visibility-based size ownership. Report to the daemon whether this
+  // pane is actually on screen: `isVisible` (workspace shown + active tab) AND
+  // the window itself visible (`document.visibilityState` — minimized, fully
+  // occluded, or hidden windows report 'hidden'). While the report says
+  // hidden, the daemon lets a phone reshape the PTY; while it says visible,
+  // the phone gets `409 desk-owns-size` as before.
+  const [docVisible, setDocVisible] = useState(() => document.visibilityState === 'visible');
+  useEffect(() => {
+    const onChange = () => setDocVisible(document.visibilityState === 'visible');
+    document.addEventListener('visibilitychange', onChange);
+    return () => document.removeEventListener('visibilitychange', onChange);
+  }, []);
+  const effectiveVisible = isVisible && docVisible;
+  const prevDocVisibleRef = useRef(docVisible);
+  useEffect(() => {
+    // Optional-chain style guard, as at resync above: a stale preload
+    // (packaged app updated under a running renderer) may not expose it yet.
+    if (ptyId && typeof window.electronAPI.pty.setViewerVisibility === 'function') {
+      // Fire-and-forget: local mode ignores it, and a report lost to a race
+      // is corrected by the next flip or the detach-time reset to visible.
+      window.electronAPI.pty.setViewerVisibility(ptyId, effectiveVisible);
+    }
+    // Reclaim on window-level reveal. Workspace/tab reveals re-fit via the
+    // visibility effect above, but a restored window's container never
+    // changed size, so no ResizeObserver tick fires — if a phone reshaped
+    // the PTY while the window was hidden, nothing would take the size back.
+    // fit() resizes unconditionally (no last-sent dedup), and the daemon
+    // drops the SIGWINCH when the geometry is already ours, so this is free
+    // when nothing changed.
+    const docRevealed = docVisible && !prevDocVisibleRef.current;
+    prevDocVisibleRef.current = docVisible;
+    if (docRevealed && isVisible) fit();
+  }, [ptyId, effectiveVisible, docVisible, isVisible, fit]);
 
   const getSearchDecorations = useCallback(() => {
     const y = getComputedStyle(document.documentElement).getPropertyValue('--accent-yellow').trim();

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -3,6 +3,11 @@ export const IPC = {
   PTY_CREATE: 'pty:create',
   PTY_WRITE: 'pty:write',
   PTY_RESIZE: 'pty:resize',
+  // #766 visibility-based size ownership. Renderer → main fire-and-forget:
+  // reports whether a pane is actually on screen (workspace + tab active AND
+  // the window itself visible). Forwarded to the daemon so the phone resize
+  // route can tell "attached and watched" from "attached but nobody looking".
+  PTY_SET_VIEWER_VISIBILITY: 'pty:setViewerVisibility',
   PTY_DISPOSE: 'pty:dispose',
   PTY_DATA: 'pty:data',
   PTY_EXIT: 'pty:exit',


### PR DESCRIPTION
Closes #766. #770 is already resolved on `main` (daemon expiry in #770, hook registration in #785, bridge promotion of the AskUserQuestion PostToolUse to `agent.input_answered`); this PR adds the missing regression test for that path.

## #766 — hand the PTY size to the phone when the desk is not looking

`POST /api/sessions/:id/resize` refused every live pane with `409 desk-owns-size`, because a pane the Mac app holds open is `attached` whether or not anyone can see it — so the phone always rendered a desk-shaped (e.g. 151×47) pane letterboxed on a portrait screen.

Ownership is now **visibility-based**. The renderer reports whether a pane is actually on screen — workspace shown, tab active, AND the window itself visible (`document.visibilityState` covers minimize/occlusion) — via a fire-and-forget `pty:setViewerVisibility` IPC relayed to a new `daemon.setSessionViewerVisibility` RPC. The route answers `409` only for `attached` AND visible; attached-but-hidden panes take the phone's numbers, since the hidden renderer's own fit is already silent (zero-size container guard) and cannot start a resize fight.

Reclaim is the existing mount/reveal fit (resizes unconditionally), plus one new case: a window-level reveal (restore from minimize) fires no ResizeObserver tick, so the visibility effect re-runs `fit()` when the document becomes visible while the pane is shown.

The flag resets to visible on **detach**, deliberately not attach: the renderer's mount-time report can land before its attach RPC, and an attach-time reset would overwrite a fresh `hidden` with the default. An older renderer that never reports keeps pre-#766 behavior exactly (flag stays `true`, always 409).

Touches daemon + renderer + preload + the phone-client contract doc.

## #770 — regression test for locally-answered AskUserQuestion expiry

The daemon path that expires a still-pending phone approval card when the user answers an AskUserQuestion on the same machine (`agent.input_answered` → `expireForSession('answered-locally')`) shipped without a test. Add three cases in `HookIngest.test.ts`:
- the expiry fires with reason `answered-locally` and nothing broadcasts (not a turn boundary);
- the early return skips resume-binding capture and transcript nudge;
- a following `agent.stop` still expires + broadcasts (backstop intact).

## Tests / gates
- `tsc --noEmit` — exit 0
- `npm run test:parallel` — 10085 passed / 24 skipped
- `npm run build:daemon` / `build:cli` / `build:mcp` — OK
- #766 core tests (WebTerminalServer + DaemonSessionManager) — 232 passed
- #770 regression tests (HookIngest) — 58 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Terminal panes now automatically report whether they are visible.
  - Hidden, minimized, background, or detached panes can accept phone-based resizing.
  - Visible desktop panes retain control of terminal sizing and reclaim it when shown again.
  - Terminals automatically refit when the application becomes visible.

- **Bug Fixes**
  - Answering an agent approval locally now closes the pending approval without triggering unnecessary broadcasts or session resumes.
  - Session visibility remains consistent across attachment and detachment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->