### PR TITLE
Deliver liveness, code-block fetch, and gate state to the phone

### DIFF
--- a/changelog.d/796.md
+++ b/changelog.d/796.md
@@ -1,0 +1,21 @@
+### Added
+
+- **The phone can show what a pane is doing right now.** The turn view carries a
+  live activity header — thinking, which tool is running and for how long, waiting
+  for you — instead of leaving you to guess from a conversation that has stopped
+  growing. It rides its own channel rather than being read off the transcript, so
+  an agent that stalls mid-turn looks different from one that is still working.
+- **Code blocks and large tool outputs open on the phone.** Tapping a code chip
+  fetches the body instead of showing a chip that does nothing. Oversized bodies
+  arrive as a head and say they were cut, rather than pretending the block ends
+  there.
+- **The permission gate's state is visible and stays in sync.** A phone's gate
+  toggle opens showing whether the gate is actually armed, and turning it off from
+  one device updates the others immediately instead of leaving them showing the old
+  position until something else makes them re-read.
+
+### Fixed
+
+- **The orchestrator's own conversation is no longer readable from a phone.** The
+  brain pane is hidden from the pane list, but the transcript routes only checked
+  that a session existed — a device holding its id could read the whole thing.

--- a/docs/phone-client-contract.md
+++ b/docs/phone-client-contract.md
@@ -186,6 +186,7 @@ JSON backlog fetch (Bearer only).
 | `approval` | `{sessionId, approvalId, phase, state, agent, createdAt, tier, risk?, ...}` |
 | `transcript.nudge` | `{sessionId}` — the turn view for that pane has new content; re-fetch |
 | `agent.liveness` | `{sessionId, state, tool?, agent, at}` — what the pane is doing right now |
+| `gate.state` | `{gateEnabled}` — the permission gate was armed or disarmed |
 
 `phase` is `create` / `resolve` / `expire` / `supersede`.
 
@@ -202,8 +203,13 @@ the turn snapshot instead**. An agent that stalls mid-turn writes nothing, so a
 snapshot-derived header cannot tell a stalled pane from a thinking one; this
 channel can, because it is fed by the agent's own hooks.
 
-**`transcript.nudge` and `agent.liveness` are the two events that are NOT in the
-backlog.** Every other
+`gate.state` fires when any device (or the operator) flips the permission gate,
+which is daemon-wide state: without it, the other phones' toggles keep showing
+what was true before. It is live-only like the two above — `GET /api/config`
+holds the authoritative value, so read that on reconnect rather than trying to
+replay transitions.
+
+**These three events are the ones that are NOT in the backlog.** Every other
 kind is recorded, carries `id`/`epoch`, and replays on `?since=<cursor>`. The
 nudge is live-only and deliberately so: a busy pane raises one roughly every
 second, and recording those would push a pending `approval` out of the bounded
@@ -309,14 +315,24 @@ GET /api/events?since=<cursor>     (Bearer)
 ## 5. Panes
 
 ```
-GET /api/config    → {allowInput, allowUpload, allowTranscript, protocolVersion,
-                      minProtocolVersion, serverVersion}
+GET /api/config    → {allowInput, allowUpload, allowTranscript, gatedTools,
+                      gateEnabled?, protocolVersion, minProtocolVersion,
+                      serverVersion}
 GET /api/sessions  → {sessions: [{id, cwd, cols, rows, state, agent, lastActivity, workspace?, shell?}]}
 POST /api/input?session=<id>   body: raw bytes
 ```
 
 `agent` is null when the pane is not running one; `shell` then says what to call
 it.
+
+`gatedTools` lists the tools whose calls wait for a remote answer, so a client
+can say *why* something is pending. `gateEnabled` says whether that gate is
+armed at all — it is what a settings toggle should open showing. **Absent is not
+`false`**: a daemon that predates the field simply does not report it, and the
+gate defaults to on, so treat a missing key as "unknown" and not as "off". The
+gate is daemon-wide rather than per-device, so a change made from one phone
+applies to every device; see `gate.state` above for the push that keeps them in
+step, and re-read this route on reconnect for the authoritative value.
 
 `POST /api/input` is **403 unless the server was started with `--allow-input`**.
 Check `/api/config` and hide the keyboard rather than letting a user type into a

--- a/docs/phone-client-contract.md
+++ b/docs/phone-client-contract.md
@@ -592,11 +592,18 @@ per request and caches nothing, so expanding the same block twice is two reads
 rather than a stale copy.
 
 `bytes` is the body's true size. `truncated: true` means what you got is only
-its head (the server caps one body at 1 MB) — say so in the UI rather than
-letting someone copy a shortened body out believing it is whole. **`404 block
-not found` means the ref is stale**, not that the block was empty: the file
-rotated, or the offset no longer starts a line. Re-fetch the turn page rather
-than rendering an empty expansion.
+its head (the server caps one body at 256 KB) — say so in the UI rather than
+letting someone copy a shortened body out believing it is whole.
+
+**`404 block not found` never means "the block was empty".** It means the ref
+did not resolve, and there are two reasons it might not. Usually the ref is
+stale — the file rotated, or the offset no longer starts a line — and re-fetching
+the turn page fixes it. But the daemon also reads one transcript line up to a
+fixed ceiling, so a block inside an unusually large entry (roughly half a
+megabyte of JSON) cannot be parsed at all and answers 404 permanently. Re-fetch
+once; if the fresh chip 404s again, show the block as unavailable rather than
+retrying, and keep the chip's `lines`/`lang` visible so the user still sees what
+is there.
 
 ---
 

--- a/docs/phone-client-contract.md
+++ b/docs/phone-client-contract.md
@@ -552,6 +552,36 @@ conversation being unavailable.
 watching the same pane — no subscription, no shared cursor. Two devices and a
 desk can read one session at once and none of them can move the others.
 
+#### Opening a code block or a tool body
+
+```
+GET /api/sessions/<id>/turns/block?srcOffset=<n>&n=<n>[&eventId=<id>]
+  → 200 {body, bytes, truncated?}
+  → 400 {error: 'bad-block-ref', detail}
+  → 403 {error: 'transcript-disabled: …'}
+  → 404 {error: 'session not found'} | {error: 'block not found'}
+  → 503 {error: 'transcript projector unavailable'}
+```
+
+Turn pages never carry large bodies. A fenced code block arrives as a chip
+(`codeBlocks: [{n, lines, lang, path?, srcOffset}]`, with the prose carrying an
+inline ` code:<n> ` marker where it belongs), and a tool body over the
+inline cap arrives as `{n, bytes, inline?, truncated, srcOffset}`. Both are
+handles: pass the ref's `srcOffset` and `n` here when the user expands one.
+
+Send `eventId` — the id of the event the ref came from — whenever you have it.
+Transcripts rotate, and without it an offset from an older file can resolve
+inside a different conversation. The server re-reads that one transcript line
+per request and caches nothing, so expanding the same block twice is two reads
+rather than a stale copy.
+
+`bytes` is the body's true size. `truncated: true` means what you got is only
+its head (the server caps one body at 1 MB) — say so in the UI rather than
+letting someone copy a shortened body out believing it is whole. **`404 block
+not found` means the ref is stale**, not that the block was empty: the file
+rotated, or the offset no longer starts a line. Re-fetch the turn page rather
+than rendering an empty expansion.
+
 ---
 
 ## 6. Approvals

--- a/docs/phone-client-contract.md
+++ b/docs/phone-client-contract.md
@@ -185,10 +185,25 @@ JSON backlog fetch (Bearer only).
 | `notify` | `{...payload, tier, id, epoch}` |
 | `approval` | `{sessionId, approvalId, phase, state, agent, createdAt, tier, risk?, ...}` |
 | `transcript.nudge` | `{sessionId}` — the turn view for that pane has new content; re-fetch |
+| `agent.liveness` | `{sessionId, state, tool?, agent, at}` — what the pane is doing right now |
 
 `phase` is `create` / `resolve` / `expire` / `supersede`.
 
-**`transcript.nudge` is the one event that is NOT in the backlog.** Every other
+`state` is `busy` / `tool` / `awaiting_permission` / `awaiting_input` / `idle`,
+and the union is **additive** — render an unknown state as a neutral "working"
+rather than dropping the event, the same rule `TurnEventKind` follows. `tool`
+carries the tool name when the daemon knows it, and only for the two tool
+states. `at` is the ms epoch the state was entered: render elapsed time from it
+rather than from when the event arrived, because the event may have waited out a
+coalescing window.
+
+Use this for a persistent activity header, and **do not derive that header from
+the turn snapshot instead**. An agent that stalls mid-turn writes nothing, so a
+snapshot-derived header cannot tell a stalled pane from a thinking one; this
+channel can, because it is fed by the agent's own hooks.
+
+**`transcript.nudge` and `agent.liveness` are the two events that are NOT in the
+backlog.** Every other
 kind is recorded, carries `id`/`epoch`, and replays on `?since=<cursor>`. The
 nudge is live-only and deliberately so: a busy pane raises one roughly every
 second, and recording those would push a pending `approval` out of the bounded
@@ -203,6 +218,15 @@ and is dropped outright while your SSE is down. Re-fetch the turn view once on
 every reconnect rather than waiting to be told. And **you only get nudges for
 panes whose turn view you have actually read** — the server starts sending them
 after your first successful `/turns` call for that pane.
+
+`agent.liveness` is live-only for the same reason and follows the same two
+rules, with one difference: its coalescing window keeps the **newest** state
+rather than the first, since a header is a state and not a "something changed"
+ping. The three settled states (`idle`, `awaiting_input`, `awaiting_permission`)
+skip the window entirely and are sent immediately — those are the transitions a
+user is watching the header to catch. A client that reconnects gets no liveness
+replay and should show a neutral header until the next event; a pane that went
+idle while the SSE was down is caught by the turn view, not by this channel.
 
 Identity fields (`id`, `epoch`) — and `tier` — are stamped **last**, so a
 pane-supplied payload can never shadow them.

--- a/src/daemon/hooks/__tests__/agentLiveness.test.ts
+++ b/src/daemon/hooks/__tests__/agentLiveness.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import type { AgentSignal, AgentSignalKind } from '../../../shared/hooks/signal-types';
+import type { HookAgentEventData } from '../HookIngest';
+import { deriveAgentLiveness, isTerminalLiveness } from '../agentLiveness';
+
+const signal = (kind: AgentSignalKind, payload: Record<string, unknown> = {}): AgentSignal => ({
+  kind,
+  agent: 'claude',
+  cwd: '/repo',
+  payload,
+  ts: 1000,
+});
+
+const data = (over: Partial<HookAgentEventData>): HookAgentEventData => ({
+  agent: 'Claude Code',
+  status: 'running',
+  message: '',
+  source: 'hook',
+  signal: signal('agent.activity'),
+  ...over,
+});
+
+describe('deriveAgentLiveness', () => {
+  it('maps each hook shape onto the header state the phone renders', () => {
+    const cases: Array<[HookAgentEventData, string, string | undefined]> = [
+      // A settled pane: status wins regardless of which stop hook produced it.
+      [data({ status: 'complete', signal: signal('agent.stop') }), 'idle', undefined],
+      [data({ status: 'awaiting_input', signal: signal('agent.awaiting_input') }), 'awaiting_input', undefined],
+      // Metadata kinds all carry status:'running' and only refine the busy case.
+      [
+        data({
+          hookKind: 'agent.tool_started',
+          decision: 'activity',
+          signal: signal('agent.tool_started', { tool_name: 'Bash' }),
+        }),
+        'tool',
+        'Bash',
+      ],
+      [
+        data({
+          hookKind: 'agent.awaiting_permission',
+          decision: 'activity',
+          signal: signal('agent.awaiting_permission', { tool_name: 'Write' }),
+        }),
+        'awaiting_permission',
+        'Write',
+      ],
+      [data({ hookKind: 'agent.activity', decision: 'activity' }), 'busy', undefined],
+    ];
+    for (const [input, state, tool] of cases) {
+      const body = deriveAgentLiveness('s1', input, 4242);
+      expect(body).toMatchObject({ sessionId: 's1', state, agent: 'Claude Code', at: 4242 });
+      expect(body.tool).toBe(tool);
+    }
+  });
+
+  it('a stop hook that still names a tool settles the pane instead of showing the tool', () => {
+    // PostToolUse-shaped payloads carry `tool_name` too. Reading the tool name
+    // ahead of the status would leave the header saying "Bash running" on a pane
+    // that has already finished — the exact lie the header exists to prevent.
+    const body = deriveAgentLiveness(
+      's1',
+      data({ status: 'complete', signal: signal('agent.stop', { tool_name: 'Bash' }) }),
+      1,
+    );
+    expect(body.state).toBe('idle');
+    expect(body.tool).toBeUndefined();
+    expect(isTerminalLiveness(body.state)).toBe(true);
+  });
+
+  it('busy states are the only ones that may wait out a coalescing window', () => {
+    expect(isTerminalLiveness('busy')).toBe(false);
+    expect(isTerminalLiveness('tool')).toBe(false);
+    expect(isTerminalLiveness('idle')).toBe(true);
+    expect(isTerminalLiveness('awaiting_input')).toBe(true);
+    expect(isTerminalLiveness('awaiting_permission')).toBe(true);
+  });
+});

--- a/src/daemon/hooks/__tests__/agentLiveness.test.ts
+++ b/src/daemon/hooks/__tests__/agentLiveness.test.ts
@@ -68,6 +68,41 @@ describe('deriveAgentLiveness', () => {
     expect(isTerminalLiveness(body.state)).toBe(true);
   });
 
+  it('★ a finished SUBAGENT does not settle the pane', () => {
+    // agent.subagent_stop arrives as status:'complete' ("Subagent finished")
+    // while the pane's own turn keeps going. Read at face value it flips the
+    // header to idle — and being terminal it skips coalescing, so a pane running
+    // a fan-out of subagents would report idle over and over while working.
+    const body = deriveAgentLiveness(
+      's1',
+      data({
+        status: 'complete',
+        hookKind: 'agent.subagent_stop',
+        signal: signal('agent.subagent_stop'),
+      }),
+      1,
+    );
+    expect(body.state).toBe('busy');
+    expect(isTerminalLiveness(body.state)).toBe(false);
+  });
+
+  it('a hostile tool name cannot inject control characters or unbounded text', () => {
+    // `daemon.hooks.signal` is reachable by anything on the local pipe, and this
+    // string is rendered on every watching device.
+    const body = deriveAgentLiveness(
+      's1',
+      data({
+        hookKind: 'agent.tool_started',
+        signal: signal('agent.tool_started', { tool_name: `Ba\u0007sh\ndrop\r${'x'.repeat(500)}` }),
+      }),
+      1,
+    );
+    expect(body.tool).toBeDefined();
+    // eslint-disable-next-line no-control-regex
+    expect(body.tool).not.toMatch(/[\u0000-\u001F\u007F]/);
+    expect((body.tool ?? '').length).toBeLessThanOrEqual(64);
+  });
+
   it('busy states are the only ones that may wait out a coalescing window', () => {
     expect(isTerminalLiveness('busy')).toBe(false);
     expect(isTerminalLiveness('tool')).toBe(false);

--- a/src/daemon/hooks/agentLiveness.ts
+++ b/src/daemon/hooks/agentLiveness.ts
@@ -57,23 +57,50 @@ export function isTerminalLiveness(state: AgentLivenessState): boolean {
   return state === 'idle' || state === 'awaiting_input' || state === 'awaiting_permission';
 }
 
+/** A tool name is an identifier; anything longer than this is not one. */
+const MAX_TOOL_NAME_CHARS = 64;
+
+/**
+ * The tool name as it may be shown in a header, or nothing.
+ *
+ * The value comes off a hook envelope, and `daemon.hooks.signal` is reachable by
+ * anything on the local pipe rather than first-party callers only — so this is
+ * an untrusted string that ends up rendered on every watching device. Control
+ * characters go (they have no place in an identifier and are how a payload
+ * smuggles line structure into a display), and the length is bounded.
+ */
+function sanitizeToolName(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') return undefined;
+  // eslint-disable-next-line no-control-regex
+  const cleaned = raw.replace(/[\u0000-\u001F\u007F]/g, '').trim();
+  if (!cleaned) return undefined;
+  return cleaned.length > MAX_TOOL_NAME_CHARS
+    ? cleaned.slice(0, MAX_TOOL_NAME_CHARS)
+    : cleaned;
+}
+
 /**
  * Project one `agent.event` payload onto the header state.
  *
- * `status` wins over `hookKind`: the stop kinds settle the pane regardless of
- * which hook produced them, and the metadata kinds all carry `status:'running'`
- * so they only ever refine the busy case.
+ * `status` mostly wins over `hookKind` — the stop kinds settle the pane, and the
+ * metadata kinds all carry `status:'running'` so they only ever refine the busy
+ * case. The ONE exception is `agent.subagent_stop`, which also arrives as
+ * `status:'complete'` ("Subagent finished") while the pane's own turn keeps
+ * going: taking that at face value would flip the header to idle every time a
+ * subagent finishes, on a pane that is still working. HookIngest already treats
+ * it as not-a-turn-boundary; the header has to agree.
  */
 export function deriveAgentLiveness(
   sessionId: string,
   data: HookAgentEventData,
   at: number,
 ): AgentLivenessBody {
-  const tool = typeof data.signal?.payload?.['tool_name'] === 'string'
-    ? (data.signal.payload['tool_name'] as string)
-    : undefined;
+  const tool = sanitizeToolName(data.signal?.payload?.['tool_name']);
   let state: AgentLivenessState = 'busy';
-  if (data.status === 'complete') state = 'idle';
+  const subagentStop = data.hookKind === 'agent.subagent_stop'
+    || data.signal?.kind === 'agent.subagent_stop';
+  if (subagentStop) state = 'busy';
+  else if (data.status === 'complete') state = 'idle';
   else if (data.status === 'awaiting_input') state = 'awaiting_input';
   else if (data.hookKind === 'agent.awaiting_permission') state = 'awaiting_permission';
   else if (data.hookKind === 'agent.tool_started') state = 'tool';

--- a/src/daemon/hooks/agentLiveness.ts
+++ b/src/daemon/hooks/agentLiveness.ts
@@ -1,0 +1,87 @@
+/**
+ * Phone liveness — the pane-state projection of an `agent.event`.
+ *
+ * The phone turn view carries a persistent activity header ("thinking", "Bash
+ * running · 12s", "waiting for you"). That header is deliberately NOT derived
+ * from the turn snapshot: an agent that stalls mid-turn writes nothing, so a
+ * snapshot-derived header would look identical to a healthy pause and the phone
+ * would show a frozen turn as a working one. So it rides its own channel, and
+ * this module is the projection that channel carries.
+ *
+ * Kept out of `WebTerminalServer` on purpose: the web server is a consumer of
+ * already-shaped payloads and must not learn hook envelope shapes (the same
+ * reasoning as the approval registry and the transcript projector, which it
+ * also takes as types only).
+ */
+import type { HookAgentEventData } from './HookIngest';
+
+/**
+ * What the header says the pane is doing.
+ *
+ * ADDITIVE union, same rule as `TurnEventKind`: a client that meets an unknown
+ * state must fall back to a neutral "working" rendering rather than dropping
+ * the event, so a later daemon can add a state without a phone update.
+ *
+ * `awaiting_permission` overlaps the approval event the phone already gets, and
+ * is carried anyway: approvals ride the recorded attention log for the badge,
+ * while this is the header's own view of the same moment. A phone that has not
+ * opened the pane never sees this one.
+ */
+export type AgentLivenessState =
+  | 'busy'
+  | 'tool'
+  | 'awaiting_permission'
+  | 'awaiting_input'
+  | 'idle';
+
+/** The `agent.liveness` SSE payload. */
+export interface AgentLivenessBody {
+  sessionId: string;
+  state: AgentLivenessState;
+  /** Tool name, for `tool` / `awaiting_permission`. Absent when unknown. */
+  tool?: string;
+  /** Agent DISPLAY name ("Claude Code"), matching `agent.event`. */
+  agent: string;
+  /** ms epoch the state was entered. The phone renders elapsed from this. */
+  at: number;
+}
+
+/**
+ * States that must reach the phone NOW rather than at the end of a coalescing
+ * window. All three mean "the pane stopped on its own" — a header that says
+ * "Bash running" for another second after the agent started waiting for a human
+ * is a worse lie than a tool name that lags, because it is the exact state the
+ * user is watching the header to catch.
+ */
+export function isTerminalLiveness(state: AgentLivenessState): boolean {
+  return state === 'idle' || state === 'awaiting_input' || state === 'awaiting_permission';
+}
+
+/**
+ * Project one `agent.event` payload onto the header state.
+ *
+ * `status` wins over `hookKind`: the stop kinds settle the pane regardless of
+ * which hook produced them, and the metadata kinds all carry `status:'running'`
+ * so they only ever refine the busy case.
+ */
+export function deriveAgentLiveness(
+  sessionId: string,
+  data: HookAgentEventData,
+  at: number,
+): AgentLivenessBody {
+  const tool = typeof data.signal?.payload?.['tool_name'] === 'string'
+    ? (data.signal.payload['tool_name'] as string)
+    : undefined;
+  let state: AgentLivenessState = 'busy';
+  if (data.status === 'complete') state = 'idle';
+  else if (data.status === 'awaiting_input') state = 'awaiting_input';
+  else if (data.hookKind === 'agent.awaiting_permission') state = 'awaiting_permission';
+  else if (data.hookKind === 'agent.tool_started') state = 'tool';
+  return {
+    sessionId,
+    state,
+    ...(tool && (state === 'tool' || state === 'awaiting_permission') ? { tool } : {}),
+    agent: data.agent,
+    at,
+  };
+}

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -67,6 +67,7 @@ import { toResumeCommand, resumeOfferForRecovered, mergeResumeBinding, normalize
 import type { ResumeBinding } from '../shared/agentResume';
 import { agentDisplayToSlug } from '../main/pty/AgentDetector';
 import { HookIngest, type HookArbitration } from './hooks/HookIngest';
+import { deriveAgentLiveness } from './hooks/agentLiveness';
 import { isAgentSignal, type AgentSignal } from '../shared/hooks/signal-types';
 import { checkTranscriptPath } from './hooks/transcriptPathGuard';
 import { TranscriptProjector } from './transcript/TranscriptProjector';
@@ -2812,6 +2813,12 @@ function registerRpcHandlers(
         sessionManager.getSession(sessionId)?.bridge.noteAgentStatus(data.status);
         const event: DaemonEvent = { type: 'agent.event', sessionId, data };
         pipeServer.broadcast(event);
+        // Phone liveness header. The desktop reads pane state off this same
+        // broadcast; the phone has no pipe, so the web server gets the projected
+        // state (non-recording, coalesced, watchers only — see
+        // WebTerminalServer.emitAgentLiveness). Harmless when the web server is
+        // off or nobody opened the pane's turn view.
+        webTerminalServer?.emitAgentLiveness(deriveAgentLiveness(sessionId, data, Date.now()));
       },
       applyResumeBinding: (id, binding) => { applyResumeBinding(id, binding); },
       log: (level, message) => log(level, message),

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -68,7 +68,7 @@ import type { ResumeBinding } from '../shared/agentResume';
 import { agentDisplayToSlug } from '../main/pty/AgentDetector';
 import { HookIngest, type HookArbitration } from './hooks/HookIngest';
 import { deriveAgentLiveness } from './hooks/agentLiveness';
-import { isAgentSignal, type AgentSignal } from '../shared/hooks/signal-types';
+import { agentSlugToDisplay, isAgentSignal, type AgentSignal } from '../shared/hooks/signal-types';
 import { checkTranscriptPath } from './hooks/transcriptPathGuard';
 import { TranscriptProjector } from './transcript/TranscriptProjector';
 import { TranscriptDiscovery, DISCOVERABLE_AGENT } from './transcript/TranscriptDiscovery';
@@ -2900,6 +2900,24 @@ function registerRpcHandlers(
         : verdict.decision === 'deny'
           ? 'deny' as const
           : 'ask' as const;
+      // Release the phone's liveness header. `agent.awaiting_permission` put it
+      // in "waiting on you, elapsed N s", and nothing else would take it back
+      // out: the wide PostToolUse hook this used to ride was removed, so the
+      // next signal may be a whole tool call away — and after a 120 s self-defer
+      // there may not be one at all. Without this the header keeps counting up
+      // on a pane that is running again. Allowed → the tool is executing now;
+      // denied or deferred → the pane is working but not on this call.
+      if (gate.sessionId) {
+        webTerminalServer?.emitAgentLiveness(deriveAgentLiveness(gate.sessionId, {
+          agent: agentSlugToDisplay(signal.agent),
+          status: 'running',
+          message: '',
+          source: 'hook',
+          hookKind: permissionDecision === 'allow' ? 'agent.tool_started' : 'agent.activity',
+          decision: 'activity',
+          signal,
+        }, Date.now()));
+      }
       return { ok: true, permissionDecision };
     }
     return ingest.handle(params);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -320,6 +320,9 @@ async function restoreWebServer(sessionManager: DaemonSessionManager): Promise<v
         // #783 — expose the gated-tools list and the runtime escape hatch at
         // BOTH construction sites (restore + operator start).
         gateConfig: () => coerceGate(loadConfig().gate),
+        // Read side of the same flag, so `/api/config` can answer "is the gate
+        // armed?" instead of leaving a client's toggle to guess.
+        gateEnabled: () => !gateRuntimeOff,
         setGateEnabled: (enabled) => {
           gateRuntimeOff = !enabled;
           log('info', `[gate] runtime escape: gate ${enabled ? 'on' : 'off'}`);
@@ -2355,6 +2358,8 @@ function registerRpcHandlers(
       projector: () => transcriptProjector,
       // #783 — see the restore path.
       gateConfig: () => coerceGate(loadConfig().gate),
+      // See the restore path — the read side of the runtime escape hatch.
+      gateEnabled: () => !gateRuntimeOff,
       setGateEnabled: (enabled) => {
         gateRuntimeOff = !enabled;
         log('info', `[gate] runtime escape: gate ${enabled ? 'on' : 'off'}`);

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -526,12 +526,18 @@ const AGENT_LIVENESS_COALESCE_MS = 1000;
 /** A decision body is two fields; anything larger is not one of ours. */
 const MAX_JSON_BODY_BYTES = 8 * 1024;
 /**
- * Ceiling on ONE expanded code block / tool body served to a phone. A single
- * transcript line can legitimately hold megabytes (a `cat` of a large file), and
- * the desktop reads those over a local pipe while a phone may be on cellular.
- * Over the cap the response is a head plus `truncated`, never a silent cut.
+ * Ceiling on ONE expanded code block / tool body served to a phone. The desktop
+ * reads these over a local pipe; a phone may be on cellular, and a `cat` of a
+ * large file is one legitimate transcript entry. Over the cap the response is a
+ * head plus `truncated`, never a silent cut.
+ *
+ * Must stay UNDER the projector's own line-read ceiling (`LINE_READ_BYTES`,
+ * 512 KB in readTail.ts) or the branch is unreachable: a body can never exceed
+ * the line it was parsed out of, so a cap at or above that limit is a promise
+ * the route cannot keep. It was 1 MB and was exactly that dead branch
+ * (2-MODEL review).
  */
-const MAX_BLOCK_BODY_BYTES = 1024 * 1024;
+const MAX_BLOCK_BODY_BYTES = 256 * 1024;
 /**
  * Who the registry records as having answered, for anything resolved over HTTP.
  *
@@ -1559,7 +1565,15 @@ export class WebTerminalServer {
         // write. Omitted (not defaulted) when the daemon did not wire the getter:
         // a client reading a missing key as "off" would be wrong on every daemon
         // that predates this, and the gate defaults to ON.
-        ...(this.deps.gateEnabled ? { gateEnabled: this.deps.gateEnabled() } : {}),
+        //
+        // EFFECTIVE, not the runtime flag alone. The daemon arms the gate only
+        // when `gateRuntimeOff` is clear AND this server can actually resolve a
+        // gate — a read-only server (the default) raises cards nobody can
+        // answer, so it lets every tool through. Reporting the flag by itself
+        // would tell a phone the gate is on while nothing is being held.
+        ...(this.deps.gateEnabled
+          ? { gateEnabled: this.deps.gateEnabled() && this.canResolveGates }
+          : {}),
         protocolVersion: PHONE_PROTOCOL_VERSION,
         minProtocolVersion: MIN_PHONE_PROTOCOL_VERSION,
         serverVersion: daemonServerVersion(),
@@ -1866,8 +1880,9 @@ export class WebTerminalServer {
     }
     // Unknown pane → 404, the same contract as the other `/api/sessions/:id/*`
     // routes: a phone that fetched a pane id the daemon no longer owns learns the
-    // pane is gone, not that its conversation is unavailable.
-    if (!this.deps.sessionManager.getSession(sessionId)) {
+    // pane is gone, not that its conversation is unavailable. A brain pty answers
+    // the same way — see readableSession.
+    if (!this.readableSession(sessionId)) {
       this.json(res, 404, { error: 'session not found' });
       return;
     }
@@ -1928,6 +1943,24 @@ export class WebTerminalServer {
   }
 
   /**
+   * The pane a phone is allowed to READ, or null.
+   *
+   * `getSession` alone is not that question. The orchestrator brain's own TUI is
+   * a live daemon session, and `listSessions` already excludes it from the phone
+   * — it is not a worker pane, and it must not be attachable or approvable from
+   * a phone. The transcript routes checked existence only, so a device that
+   * learned a brain id (the prefix is guessable, and an approval or notify event
+   * can carry one) could read the orchestrator's whole conversation. Same 404 as
+   * a missing pane on purpose: "not yours to read" and "gone" are one answer
+   * here, and a distinct error would confirm the id.
+   */
+  private readableSession(sessionId: string): ReturnType<DaemonSessionManager['getSession']> {
+    const managed = this.deps.sessionManager.getSession(sessionId);
+    if (!managed) return undefined;
+    return isBrainPty({ id: sessionId, env: managed.meta.env }) ? undefined : managed;
+  }
+
+  /**
    * `GET /api/sessions/:id/turns/block?srcOffset=&n=&eventId=` — the body behind
    * a code-block or tool-body chip, the phone's half of what the desktop does
    * over `daemon.transcript.codeBlock`.
@@ -1953,7 +1986,7 @@ export class WebTerminalServer {
       });
       return;
     }
-    if (!this.deps.sessionManager.getSession(sessionId)) {
+    if (!this.readableSession(sessionId)) {
       this.json(res, 404, { error: 'session not found' });
       return;
     }

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -4,6 +4,7 @@ import crypto from 'node:crypto';
 import os from 'node:os';
 import fs from 'node:fs';
 import path from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
 import type { DaemonSessionManager } from '../DaemonSessionManager';
 // Types only — the registry implementation, its persistence and its
 // headless-terminal dependency chain stay out of this module. The web server is
@@ -514,6 +515,13 @@ const TRANSCRIPT_NUDGE_COALESCE_MS = 1000;
 const AGENT_LIVENESS_COALESCE_MS = 1000;
 /** A decision body is two fields; anything larger is not one of ours. */
 const MAX_JSON_BODY_BYTES = 8 * 1024;
+/**
+ * Ceiling on ONE expanded code block / tool body served to a phone. A single
+ * transcript line can legitimately hold megabytes (a `cat` of a large file), and
+ * the desktop reads those over a local pipe while a phone may be on cellular.
+ * Over the cap the response is a head plus `truncated`, never a silent cut.
+ */
+const MAX_BLOCK_BODY_BYTES = 1024 * 1024;
 /**
  * Who the registry records as having answered, for anything resolved over HTTP.
  *
@@ -1552,6 +1560,9 @@ export class WebTerminalServer {
       if (req.method === 'GET' && rest.endsWith('/diff')) {
         return this.handleSessionDiff(res, rest.slice(0, -'/diff'.length));
       }
+      if (req.method === 'GET' && rest.endsWith('/turns/block')) {
+        return this.handleSessionTurnBlock(req, res, rest.slice(0, -'/turns/block'.length));
+      }
       if (req.method === 'GET' && rest.endsWith('/turns')) {
         return this.handleSessionTurns(req, res, rest.slice(0, -'/turns'.length), principal);
       }
@@ -1893,6 +1904,95 @@ export class WebTerminalServer {
       reset: result.reset,
       ...(result.budgetDropped ? { budgetDropped: true } : {}),
     });
+  }
+
+  /**
+   * `GET /api/sessions/:id/turns/block?srcOffset=&n=&eventId=` — the body behind
+   * a code-block or tool-body chip, the phone's half of what the desktop does
+   * over `daemon.transcript.codeBlock`.
+   *
+   * Bodies never ride the turn page itself (A3): the page carries a chip with
+   * `{n, lines, lang, srcOffset}` and the body is fetched here, on expand, as a
+   * single bounded line read. Without this route the phone could render the chip
+   * and nothing else — there was no way to open one.
+   *
+   * Same gate, same tag, same 404/503 split as `/turns`: this serves transcript
+   * content, so `--allow-transcript` governs it and nothing else may.
+   */
+  private handleSessionTurnBlock(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    sessionId: string,
+  ): void {
+    res.setHeader('Cache-Control', 'no-store');
+    if (this.opts?.allowTranscript !== true) {
+      this.json(res, 403, {
+        error: 'transcript-disabled: server started without --allow-transcript',
+        detail: 'restart with: wmux web --allow-transcript <your other flags>',
+      });
+      return;
+    }
+    if (!this.deps.sessionManager.getSession(sessionId)) {
+      this.json(res, 404, { error: 'session not found' });
+      return;
+    }
+    const projector = this.deps.projector?.() ?? null;
+    if (!projector) {
+      this.json(res, 503, { error: 'transcript projector unavailable' });
+      return;
+    }
+
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    // Read the raw params first: `Number(null)` is 0, so a MISSING srcOffset
+    // would otherwise read as "offset 0" and quietly answer with a block from
+    // the first line of the transcript instead of refusing.
+    const rawOffset = url.searchParams.get('srcOffset');
+    const rawN = url.searchParams.get('n');
+    const srcOffset = rawOffset === null ? NaN : Number(rawOffset);
+    const n = rawN === null ? NaN : Number(rawN);
+    if (!Number.isFinite(srcOffset) || srcOffset < 0 || !Number.isFinite(n) || n < 1) {
+      this.json(res, 400, {
+        error: 'bad-block-ref',
+        detail: 'srcOffset must be a non-negative integer and n a positive one',
+      });
+      return;
+    }
+    // The event id is what stops a rotated file from answering with a DIFFERENT
+    // conversation's code at the same offset. Optional on the wire because a
+    // producer may not have attributed one, and the projector then falls back to
+    // matching `n` alone — exactly the desktop RPC's contract.
+    const eventId = url.searchParams.get('eventId') ?? undefined;
+
+    const found = projector.codeBlock(sessionId, {
+      srcOffset: Math.floor(srcOffset),
+      n: Math.floor(n),
+      ...(eventId ? { eventId } : {}),
+    });
+    // A ref that no longer resolves is a 404 rather than an empty 200: the chip
+    // is stale (file rotated, offset mid-line, block gone), and a phone that got
+    // `{body: ''}` would render an empty expansion as if the block were empty.
+    if (!found) {
+      this.json(res, 404, { error: 'block not found' });
+      return;
+    }
+    // The desktop reads this over a local pipe; the phone may be on a hotel
+    // network, and one transcript line can legitimately hold megabytes of tool
+    // output. Cut at the cap and SAY so, rather than shipping the whole thing or
+    // pretending the block ends here — `truncated` is what stops a user copying
+    // a shortened body out with nothing saying it was shortened.
+    const bytes = Buffer.byteLength(found.body, 'utf8');
+    if (bytes > MAX_BLOCK_BODY_BYTES) {
+      // StringDecoder rather than `.toString()`: a byte cut lands mid-sequence
+      // as often as not, and toString would hand the phone a U+FFFD at the seam.
+      // The decoder holds the incomplete tail back instead, and never calling
+      // `end()` is what discards it.
+      const head = new StringDecoder('utf8').write(
+        Buffer.from(found.body, 'utf8').subarray(0, MAX_BLOCK_BODY_BYTES),
+      );
+      this.json(res, 200, { body: head, bytes, truncated: true });
+      return;
+    }
+    this.json(res, 200, { body: found.body, bytes });
   }
 
   private handleSessionResize(

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -1997,13 +1997,14 @@ export class WebTerminalServer {
     }
 
     const url = new URL(req.url ?? '/', 'http://localhost');
-    // Read the raw params first: `Number(null)` is 0, so a MISSING srcOffset
-    // would otherwise read as "offset 0" and quietly answer with a block from
-    // the first line of the transcript instead of refusing.
-    const rawOffset = url.searchParams.get('srcOffset');
-    const rawN = url.searchParams.get('n');
-    const srcOffset = rawOffset === null ? NaN : Number(rawOffset);
-    const n = rawN === null ? NaN : Number(rawN);
+    // Read the raw params first. `Number()` maps BOTH a missing param (null) and
+    // an empty one ('') to 0, so `?n=1` and `?srcOffset=&n=1` would each read as
+    // "offset 0" and quietly answer with a block from the first line of the
+    // transcript instead of refusing (review: CodeRabbit).
+    const num = (raw: string | null): number =>
+      raw === null || raw.trim() === '' ? NaN : Number(raw);
+    const srcOffset = num(url.searchParams.get('srcOffset'));
+    const n = num(url.searchParams.get('n'));
     if (!Number.isFinite(srcOffset) || srcOffset < 0 || !Number.isFinite(n) || n < 1) {
       this.json(res, 400, {
         error: 'bad-block-ref',

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -14,6 +14,9 @@ import type { ApprovalEvent, ApprovalRegistryApi, ApprovalRequest } from '../app
 // fs watching) stays out of this module. The web server is a STATELESS consumer
 // of its `delta()` for the phone turn view (#782); it must never `subscribe()`.
 import type { TranscriptProjector } from '../transcript/TranscriptProjector';
+// Type only — the projection from hook envelope to header state lives in the
+// hooks layer (see agentLiveness.ts). This module only fans the result out.
+import { isTerminalLiveness, type AgentLivenessBody } from '../hooks/agentLiveness';
 import { ENV_KEYS, isBrainPty } from '../../shared/constants';
 import { webHostIsLoopback, type PairRefusal, type WebTlsConfig } from '../../shared/web';
 import { capSnapshot } from './snapshotWindow';
@@ -499,6 +502,16 @@ const ATTENTION_TTL_MS = 30 * 60 * 1000;
  * keeps a write burst from fanning into one fetch per write.
  */
 const TRANSCRIPT_NUDGE_COALESCE_MS = 1000;
+/**
+ * Coalescing window for the non-recording liveness event. Same 1Hz floor as the
+ * nudge and for the same reason: a tool-heavy turn raises one PreToolUse per
+ * call, and the header only has to be RIGHT, not instantaneous. Unlike the
+ * nudge this window keeps the LATEST state rather than the first — a header is
+ * a state, not a "something changed" ping, so collapsing a burst to its head
+ * would leave the phone showing the tool that started the burst. Terminal
+ * states skip the window entirely (`isTerminalLiveness`).
+ */
+const AGENT_LIVENESS_COALESCE_MS = 1000;
 /** A decision body is two fields; anything larger is not one of ours. */
 const MAX_JSON_BODY_BYTES = 8 * 1024;
 /**
@@ -778,6 +791,10 @@ export class WebTerminalServer {
   private readonly transcriptWatchers = new Map<string, Set<string>>();
   /** Per-pane coalescing timers for the non-recording transcript nudge. */
   private readonly transcriptNudgeTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  /** Per-pane coalescing timers for the non-recording liveness event. */
+  private readonly livenessTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  /** Latest liveness state per pane, held for the open coalescing window. */
+  private readonly pendingLiveness = new Map<string, AgentLivenessBody>();
 
   /**
    * Attention replay state.
@@ -1073,6 +1090,9 @@ export class WebTerminalServer {
     // stale (a device re-opens its panes and re-registers as it reads them).
     for (const timer of this.transcriptNudgeTimers.values()) clearTimeout(timer);
     this.transcriptNudgeTimers.clear();
+    for (const timer of this.livenessTimers.values()) clearTimeout(timer);
+    this.livenessTimers.clear();
+    this.pendingLiveness.clear();
     this.transcriptWatchers.clear();
 
     const server = this.server;
@@ -2136,6 +2156,12 @@ export class WebTerminalServer {
           clearTimeout(timer);
           this.transcriptNudgeTimers.delete(id);
         }
+        const liveness = this.livenessTimers.get(id);
+        if (liveness) {
+          clearTimeout(liveness);
+          this.livenessTimers.delete(id);
+        }
+        this.pendingLiveness.delete(id);
         res.writeHead(204, this.securityHeaders());
         res.end();
       })
@@ -2827,6 +2853,68 @@ export class WebTerminalServer {
       if (!watchers.has(this.watcherKey(client.principal))) continue;
       try {
         writeSse(client.res, 'transcript.nudge', body);
+      } catch {
+        /* client stream broken — its own 'close' handler cleans up */
+      }
+    }
+  }
+
+  /**
+   * Push one liveness state to the device(s) watching this pane, WITHOUT
+   * recording it — the same three rules the transcript nudge established, for
+   * the same reasons:
+   *
+   *   - NON-RECORDING. A busy pane raises one of these per tool call; through
+   *     `attentionLog` they would evict a pending approval from the replay
+   *     window, and a phone reconnecting would re-derive its badge from a log
+   *     that no longer holds the approval it is waiting on (#782 CRITICAL 3).
+   *     Liveness is a live signal by nature: a header state from before the
+   *     reconnect is worthless, so there is nothing to replay anyway.
+   *   - COALESCED per pane, keeping the newest state (see the constant).
+   *   - WATCHERS ONLY. A device that never opened this pane's turn view has no
+   *     header to feed, and its SSE channel should not carry another pane's
+   *     per-tool-call traffic.
+   *
+   * Terminal states (`isTerminalLiveness`) flush immediately and cancel any
+   * open window, so "waiting for you" never queues behind a stale tool name.
+   */
+  emitAgentLiveness(body: AgentLivenessBody): void {
+    if (this.eventClients.size === 0) return;
+    const { sessionId } = body;
+    if (isTerminalLiveness(body.state)) {
+      const timer = this.livenessTimers.get(sessionId);
+      if (timer) {
+        clearTimeout(timer);
+        this.livenessTimers.delete(sessionId);
+      }
+      this.pendingLiveness.delete(sessionId);
+      this.deliverLiveness(body);
+      return;
+    }
+    // Busy states: keep the newest and let the open window deliver it. Assigning
+    // before the timer check is what makes this last-write-wins rather than
+    // first-write-wins.
+    this.pendingLiveness.set(sessionId, body);
+    if (this.livenessTimers.has(sessionId)) return;
+    const timer = setTimeout(() => {
+      this.livenessTimers.delete(sessionId);
+      const pending = this.pendingLiveness.get(sessionId);
+      if (!pending) return;
+      this.pendingLiveness.delete(sessionId);
+      this.deliverLiveness(pending);
+    }, AGENT_LIVENESS_COALESCE_MS);
+    timer.unref?.();
+    this.livenessTimers.set(sessionId, timer);
+  }
+
+  private deliverLiveness(body: AgentLivenessBody): void {
+    const watchers = this.transcriptWatchers.get(body.sessionId);
+    if (!watchers || watchers.size === 0) return;
+    const wire = JSON.stringify(body);
+    for (const client of this.eventClients) {
+      if (!watchers.has(this.watcherKey(client.principal))) continue;
+      try {
+        writeSse(client.res, 'agent.liveness', wire);
       } catch {
         /* client stream broken — its own 'close' handler cleans up */
       }

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -433,6 +433,16 @@ interface WebTerminalServerDeps {
    * a server that did not wire it answers 503, and `WMUX_GATE=0` still works.
    */
   setGateEnabled?: (enabled: boolean) => void;
+  /**
+   * Whether the runtime escape hatch above is currently ARMED. The daemon owns
+   * the flag; without a way to read it back, `/api/config` could report which
+   * tools are gated but not whether the gate itself was on, so a client's toggle
+   * had to guess its own initial state and only learned the truth from the
+   * response to its first write. Optional, and absent means the field is omitted
+   * from `/api/config` rather than defaulted — "this daemon does not say" is not
+   * the same answer as "off".
+   */
+  gateEnabled?: () => boolean;
 }
 
 /** Cap a single input POST body so a hostile client cannot exhaust memory. */
@@ -1544,6 +1554,12 @@ export class WebTerminalServer {
         // waiting because Bash is in the gate list". Absent gateConfig → empty
         // array (a daemon that predates the gate or did not wire it).
         gatedTools: this.deps.gateConfig?.().gatedTools ?? [],
+        // #783 — whether the gate is armed right now, so a client's toggle opens
+        // showing the truth instead of a default it has to correct on first
+        // write. Omitted (not defaulted) when the daemon did not wire the getter:
+        // a client reading a missing key as "off" would be wrong on every daemon
+        // that predates this, and the gate defaults to ON.
+        ...(this.deps.gateEnabled ? { gateEnabled: this.deps.gateEnabled() } : {}),
         protocolVersion: PHONE_PROTOCOL_VERSION,
         minProtocolVersion: MIN_PHONE_PROTOCOL_VERSION,
         serverVersion: daemonServerVersion(),
@@ -1624,6 +1640,11 @@ export class WebTerminalServer {
       if (!this.deps.setGateEnabled) return this.json(res, 503, { error: 'gate control unavailable' });
       const enable = p === '/api/gate/on';
       this.deps.setGateEnabled(enable);
+      // The gate is DAEMON-wide, so a phone that disarms it changes what every
+      // other paired device is looking at. Without this push the other devices
+      // keep showing the old toggle until something else makes them re-read
+      // `/api/config`, which for a screen nobody navigated away from is never.
+      this.broadcastGateState(enable);
       return this.json(res, 200, {
         ok: true,
         gateEnabled: enable,
@@ -3005,6 +3026,30 @@ export class WebTerminalServer {
     }, AGENT_LIVENESS_COALESCE_MS);
     timer.unref?.();
     this.livenessTimers.set(sessionId, timer);
+  }
+
+  /**
+   * Tell every connected device the gate was armed or disarmed.
+   *
+   * NOT recorded, for the opposite reason to the liveness event: this is rare
+   * (a human presses it) but it is also pure STATE, and the authoritative copy
+   * is one `/api/config` call away. A replayed transition would be a second
+   * source of truth that can disagree with that call after a reconnect, so the
+   * push is live-only and a reconnecting client re-reads config as it already
+   * does on every start.
+   *
+   * Unlike liveness this reaches every client, not just watchers: the gate is
+   * daemon-wide, not per-pane.
+   */
+  private broadcastGateState(gateEnabled: boolean): void {
+    const body = JSON.stringify({ gateEnabled });
+    for (const client of this.eventClients) {
+      try {
+        writeSse(client.res, 'gate.state', body);
+      } catch {
+        /* client stream broken — its own 'close' handler cleans up */
+      }
+    }
   }
 
   private deliverLiveness(body: AgentLivenessBody): void {

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -3723,14 +3723,20 @@ describe('WebTerminalServer', () => {
       }
     });
 
-    it('a read-only server neither flips the gate nor lies about it', async () => {
+    it('★ a read-only server reports the gate as OFF — it cannot hold anything', async () => {
       const info = await startRO();
       const h = bearer(info.token as string);
       // Disarming widens what runs without review, so it takes the same grant as
-      // typing — but the STATE is still reported, or the toggle cannot render.
+      // typing.
       const res = await fetch(`${base()}/api/gate/off`, { method: 'POST', headers: h });
       expect(res.status).toBe(403);
-      expect((await (await fetch(`${base()}/api/config`, { headers: h })).json()).gateEnabled).toBe(true);
+      // ...but the reported state must be the EFFECTIVE one. The daemon only
+      // holds a tool call when the runtime flag is clear AND this server can
+      // resolve gates; a read-only server raises cards nobody can answer, so it
+      // lets everything through. `gateArmed` is still true here — reporting that
+      // would tell the phone calls are being held while none are.
+      expect(gateArmed).toBe(true);
+      expect((await (await fetch(`${base()}/api/config`, { headers: h })).json()).gateEnabled).toBe(false);
     });
 
     it('serves a code-block body behind the same grant as the turn page', async () => {
@@ -3773,9 +3779,11 @@ describe('WebTerminalServer', () => {
       }
       expect(projectorMock.codeBlock).not.toHaveBeenCalled();
 
-      // A multi-megabyte tool body is cut at the cap, and SAYS it was cut —
-      // the seam lands mid-character here, which must not surface as U+FFFD.
-      const huge = `${'a'.repeat(1024 * 1024 - 1)}가나다`;
+      // A large tool body is cut at the cap, and SAYS it was cut — the seam
+      // lands mid-character here, which must not surface as U+FFFD. The cap is
+      // 256 KB and must stay under the projector's 512 KB line-read ceiling: at
+      // or above it, no body could ever reach the branch (2-MODEL review).
+      const huge = `${'a'.repeat(256 * 1024 - 1)}가나다`;
       projectorMock.codeBlock.mockReturnValue({ body: huge });
       const capped = await fetch(`${base()}/api/sessions/s1/turns/block?srcOffset=0&n=1`, { headers: h });
       const body = await capped.json();
@@ -3783,7 +3791,40 @@ describe('WebTerminalServer', () => {
       expect(body.truncated).toBe(true);
       expect(body.bytes).toBe(Buffer.byteLength(huge, 'utf8'));
       expect(body.body).not.toContain('�');
-      expect(Buffer.byteLength(body.body, 'utf8')).toBeLessThanOrEqual(1024 * 1024);
+      expect(Buffer.byteLength(body.body, 'utf8')).toBeLessThanOrEqual(256 * 1024);
+    });
+
+    it('★ the orchestrator brain pane is unreadable, even with its id in hand', async () => {
+      const info = await startWithTranscript();
+      const h = bearer(info.token as string);
+      // A brain pty IS a live daemon session, and `getSession` says so. It is
+      // excluded from the pane list, so a phone should never see one — but ids
+      // are guessable by prefix and can ride an approval payload, and existence
+      // alone used to be the whole check on these two routes.
+      live.push({
+        id: 'brain-ws-1', cwd: '/x', cols: 80, rows: 24, state: 'detached',
+        agent: undefined, lastDetectedAgent: undefined, lastActivity: '2020-01-01T00:00:00.000Z',
+        env: { WMUX_BRAIN_PTY: '1' }, cmd: '/usr/bin/claude',
+      });
+      projectorMock.status.mockReturnValue({ available: true, reason: 'ok', transcriptBasename: 's.jsonl' });
+      projectorMock.snapshot.mockReturnValue({
+        events: [{ id: 'e', kind: 'assistant_text', text: 'orchestrator secrets' }],
+        cursor: { headOffset: 0, tailOffset: 1, fileSize: 1, mtimeMs: 0 },
+        hasMore: false,
+        truncatedHead: false,
+      });
+      projectorMock.codeBlock.mockReturnValue({ body: 'orchestrator secrets' });
+
+      const turns = await fetch(`${base()}/api/sessions/brain-ws-1/turns`, { headers: h });
+      expect(turns.status).toBe(404);
+      const block = await fetch(
+        `${base()}/api/sessions/brain-ws-1/turns/block?srcOffset=0&n=1`,
+        { headers: h },
+      );
+      expect(block.status).toBe(404);
+      // Refused before the projector was consulted at all.
+      expect(projectorMock.snapshot).not.toHaveBeenCalled();
+      expect(projectorMock.codeBlock).not.toHaveBeenCalled();
     });
 
     it('the block route refuses without --allow-transcript, by tag', async () => {

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -110,6 +110,10 @@ function makeDeps() {
               rows: row.rows,
               cwd: '/tmp/osc7-said-so',
               spawnCwd: row.cwd,
+              // The real manager carries the child env on `meta`. Without it here
+              // an env-marker check reads as absent and a test can only ever
+              // exercise the id-prefix half of it (review: CodeRabbit).
+              env: row.env,
             },
           }
         : undefined;
@@ -3773,7 +3777,13 @@ describe('WebTerminalServer', () => {
 
       // Garbage refs never reach the projector.
       projectorMock.codeBlock.mockClear();
-      for (const q of ['srcOffset=-1&n=1', 'srcOffset=0&n=0', 'srcOffset=abc&n=1', 'n=1']) {
+      // `Number('')` and `Number(null)` are both 0, so an empty param and a
+      // missing one would each read as "offset 0" and serve a block from the
+      // first line of the file.
+      for (const q of [
+        'srcOffset=-1&n=1', 'srcOffset=0&n=0', 'srcOffset=abc&n=1',
+        'n=1', 'srcOffset=&n=1', 'srcOffset=0&n=', 'srcOffset=%20&n=1',
+      ]) {
         const bad = await fetch(`${base()}/api/sessions/s1/turns/block?${q}`, { headers: h });
         expect(bad.status).toBe(400);
       }
@@ -3801,8 +3811,16 @@ describe('WebTerminalServer', () => {
       // excluded from the pane list, so a phone should never see one — but ids
       // are guessable by prefix and can ride an approval payload, and existence
       // alone used to be the whole check on these two routes.
+      // Both marks, on separate panes: `isBrainPty` checks the env marker first
+      // and falls back to the id prefix, and a daemon build that omits env from a
+      // session must still refuse. One pane per mark keeps them independent.
       live.push({
         id: 'brain-ws-1', cwd: '/x', cols: 80, rows: 24, state: 'detached',
+        agent: undefined, lastDetectedAgent: undefined, lastActivity: '2020-01-01T00:00:00.000Z',
+        env: {}, cmd: '/usr/bin/claude',
+      });
+      live.push({
+        id: 'pty-orchestrator', cwd: '/x', cols: 80, rows: 24, state: 'detached',
         agent: undefined, lastDetectedAgent: undefined, lastActivity: '2020-01-01T00:00:00.000Z',
         env: { WMUX_BRAIN_PTY: '1' }, cmd: '/usr/bin/claude',
       });
@@ -3815,16 +3833,22 @@ describe('WebTerminalServer', () => {
       });
       projectorMock.codeBlock.mockReturnValue({ body: 'orchestrator secrets' });
 
-      const turns = await fetch(`${base()}/api/sessions/brain-ws-1/turns`, { headers: h });
-      expect(turns.status).toBe(404);
-      const block = await fetch(
-        `${base()}/api/sessions/brain-ws-1/turns/block?srcOffset=0&n=1`,
-        { headers: h },
-      );
-      expect(block.status).toBe(404);
+      for (const id of ['brain-ws-1', 'pty-orchestrator']) {
+        const turns = await fetch(`${base()}/api/sessions/${id}/turns`, { headers: h });
+        expect(turns.status).toBe(404);
+        const block = await fetch(
+          `${base()}/api/sessions/${id}/turns/block?srcOffset=0&n=1`,
+          { headers: h },
+        );
+        expect(block.status).toBe(404);
+      }
       // Refused before the projector was consulted at all.
       expect(projectorMock.snapshot).not.toHaveBeenCalled();
       expect(projectorMock.codeBlock).not.toHaveBeenCalled();
+
+      // The guard is not "refuse everything" — an ordinary pane still reads.
+      const ok = await fetch(`${base()}/api/sessions/s2/turns`, { headers: h });
+      expect(ok.status).toBe(200);
     });
 
     it('the block route refuses without --allow-transcript, by tag', async () => {

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -361,8 +361,11 @@ describe('WebTerminalServer', () => {
   let live: ReturnType<typeof makeDeps>['live'];
   let uploadsDir: string;
   let projectorMock: ReturnType<typeof makeDeps>['projectorMock'];
+  /** #783 — the daemon's runtime gate flag, which the server only reads/writes. */
+  let gateArmed: boolean;
 
   beforeEach(() => {
+    gateArmed = true;
     const deps = makeDeps();
     bridge = deps.bridge;
     write = deps.write;
@@ -396,6 +399,9 @@ describe('WebTerminalServer', () => {
       git: deps.git,
       uploadsDir: deps.uploadsDir,
       projector: () => projectorMock as unknown as TranscriptProjector,
+      gateConfig: () => ({ gatedTools: ['Bash'] }),
+      gateEnabled: () => gateArmed,
+      setGateEnabled: (enabled) => { gateArmed = enabled; },
       log: () => { /* silent in tests */ },
       assetsDir: os.tmpdir(), // no terminal.html needed for the /api/* tests
     });
@@ -3665,6 +3671,66 @@ describe('WebTerminalServer', () => {
       const after = await (await fetch(`${base()}/api/events`, { headers: h })).json();
       expect(after.headId).toBe(before.headId);
       expect(after.events).toEqual(before.events);
+    });
+
+    it('★ /api/config reports whether the gate is armed, and a flip reaches other devices', async () => {
+      const info = await server.start({
+        port: 0, host: '127.0.0.1', allowInput: true, allowUpload: false,
+      });
+      const h = bearer(info.token as string);
+
+      const armed = await (await fetch(`${base()}/api/config`, { headers: h })).json();
+      expect(armed.gateEnabled).toBe(true);
+      expect(armed.gatedTools).toEqual(['Bash']);
+
+      // A second device is watching the attention channel. The gate is daemon-
+      // wide, so the flip below is a change to what IT is looking at.
+      const ac = new AbortController();
+      const stream = await fetch(`${base()}/api/events`, {
+        signal: ac.signal,
+        headers: { ...h, Accept: 'text/event-stream' },
+      });
+      const reader = (stream.body as ReadableStream<Uint8Array>).getReader();
+      let wire = '';
+      const pump = (async () => {
+        try {
+          for (;;) {
+            const chunk = await reader.read();
+            if (chunk.done) break;
+            if (chunk.value) wire += Buffer.from(chunk.value).toString('utf8');
+          }
+        } catch {
+          /* aborted at the end of the test */
+        }
+      })();
+
+      try {
+        const off = await fetch(`${base()}/api/gate/off`, { method: 'POST', headers: h });
+        expect(off.status).toBe(200);
+        expect((await off.json()).gateEnabled).toBe(false);
+
+        await new Promise((r) => setTimeout(r, 150));
+        expect(wire).toContain('event: gate.state');
+        expect(wire).toContain('"gateEnabled":false');
+
+        // ...and the next client to ask reads the new state rather than the
+        // default it would have had to guess.
+        const disarmed = await (await fetch(`${base()}/api/config`, { headers: h })).json();
+        expect(disarmed.gateEnabled).toBe(false);
+      } finally {
+        ac.abort();
+        await pump;
+      }
+    });
+
+    it('a read-only server neither flips the gate nor lies about it', async () => {
+      const info = await startRO();
+      const h = bearer(info.token as string);
+      // Disarming widens what runs without review, so it takes the same grant as
+      // typing — but the STATE is still reported, or the toggle cannot render.
+      const res = await fetch(`${base()}/api/gate/off`, { method: 'POST', headers: h });
+      expect(res.status).toBe(403);
+      expect((await (await fetch(`${base()}/api/config`, { headers: h })).json()).gateEnabled).toBe(true);
     });
 
     it('serves a code-block body behind the same grant as the turn page', async () => {

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -3666,5 +3666,75 @@ describe('WebTerminalServer', () => {
       expect(after.headId).toBe(before.headId);
       expect(after.events).toEqual(before.events);
     });
+
+    it('★ liveness is non-recording and reaches only panes the device has read', async () => {
+      const info = await startWithTranscript();
+      const h = bearer(info.token as string);
+      projectorMock.status.mockReturnValue({ available: true, reason: 'ok', transcriptBasename: 's.jsonl' });
+      projectorMock.snapshot.mockReturnValue({
+        events: [],
+        cursor: { headOffset: 0, tailOffset: 0, fileSize: 0, mtimeMs: 0 },
+        hasMore: false,
+        truncatedHead: false,
+      });
+
+      const ac = new AbortController();
+      const stream = await fetch(`${base()}/api/events`, {
+        signal: ac.signal,
+        headers: { ...h, Accept: 'text/event-stream' },
+      });
+      const reader = (stream.body as ReadableStream<Uint8Array>).getReader();
+      // One continuous pump into a buffer. A read-with-timeout loop would leave
+      // a pending read() behind on every timeout, and that orphan consumes the
+      // next chunk into a promise nobody awaits — the event vanishes.
+      let wire = '';
+      const pump = (async () => {
+        try {
+          for (;;) {
+            const chunk = await reader.read();
+            if (chunk.done) break;
+            if (chunk.value) wire += Buffer.from(chunk.value).toString('utf8');
+          }
+        } catch {
+          /* aborted at the end of the test */
+        }
+      })();
+      const settle = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+      try {
+        // Not a watcher yet — the device never opened s1's turn view, so its SSE
+        // must not carry s1's per-tool-call traffic.
+        server.emitAgentLiveness({ sessionId: 's1', state: 'idle', agent: 'Claude Code', at: 1 });
+        await settle(150);
+        expect(wire).not.toContain('agent.liveness');
+
+        expect((await fetch(`${base()}/api/sessions/s1/turns`, { headers: h })).status).toBe(200);
+
+        // A settled state skips the coalescing window: it is the transition the
+        // header exists to catch, so it must not wait out a second.
+        const before = await (await fetch(`${base()}/api/events`, { headers: h })).json();
+        server.emitAgentLiveness({
+          sessionId: 's1',
+          state: 'awaiting_input',
+          agent: 'Claude Code',
+          at: 2,
+        });
+        await settle(200);
+        expect(wire).toContain('event: agent.liveness');
+        expect(wire).toContain('"state":"awaiting_input"');
+
+        // ...and none of it is recorded: a busy pane's liveness must never evict
+        // a pending approval from the replay window (#782 CRITICAL 3).
+        for (let i = 0; i < 60; i++) {
+          server.emitAgentLiveness({ sessionId: 's1', state: 'tool', tool: 'Bash', agent: 'Claude Code', at: i });
+        }
+        const after = await (await fetch(`${base()}/api/events`, { headers: h })).json();
+        expect(after.headId).toBe(before.headId);
+        expect(after.events).toEqual(before.events);
+      } finally {
+        ac.abort();
+        await pump;
+      }
+    });
   });
 });

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -3667,6 +3667,68 @@ describe('WebTerminalServer', () => {
       expect(after.events).toEqual(before.events);
     });
 
+    it('serves a code-block body behind the same grant as the turn page', async () => {
+      const info = await startWithTranscript();
+      const h = bearer(info.token as string);
+      projectorMock.codeBlock.mockReturnValue({ body: 'console.log(1)\n' });
+
+      const res = await fetch(
+        `${base()}/api/sessions/s1/turns/block?srcOffset=64&n=2&eventId=ev-1`,
+        { headers: h },
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get('cache-control')).toBe('no-store');
+      expect(await res.json()).toEqual({ body: 'console.log(1)\n', bytes: 15 });
+      // The eventId rides through: without it a rotated file answers at the same
+      // offset with another conversation's code.
+      expect(projectorMock.codeBlock).toHaveBeenCalledWith('s1', {
+        srcOffset: 64,
+        n: 2,
+        eventId: 'ev-1',
+      });
+    });
+
+    it('★ a stale ref is a 404, and an over-cap body says it was cut', async () => {
+      const info = await startWithTranscript();
+      const h = bearer(info.token as string);
+
+      // Rotated file / mid-line offset — the projector refuses. An empty 200
+      // here would render as "this block is empty" instead of "re-fetch".
+      projectorMock.codeBlock.mockReturnValue(null);
+      const stale = await fetch(`${base()}/api/sessions/s1/turns/block?srcOffset=9&n=1`, { headers: h });
+      expect(stale.status).toBe(404);
+      expect((await stale.json()).error).toBe('block not found');
+
+      // Garbage refs never reach the projector.
+      projectorMock.codeBlock.mockClear();
+      for (const q of ['srcOffset=-1&n=1', 'srcOffset=0&n=0', 'srcOffset=abc&n=1', 'n=1']) {
+        const bad = await fetch(`${base()}/api/sessions/s1/turns/block?${q}`, { headers: h });
+        expect(bad.status).toBe(400);
+      }
+      expect(projectorMock.codeBlock).not.toHaveBeenCalled();
+
+      // A multi-megabyte tool body is cut at the cap, and SAYS it was cut —
+      // the seam lands mid-character here, which must not surface as U+FFFD.
+      const huge = `${'a'.repeat(1024 * 1024 - 1)}가나다`;
+      projectorMock.codeBlock.mockReturnValue({ body: huge });
+      const capped = await fetch(`${base()}/api/sessions/s1/turns/block?srcOffset=0&n=1`, { headers: h });
+      const body = await capped.json();
+      expect(capped.status).toBe(200);
+      expect(body.truncated).toBe(true);
+      expect(body.bytes).toBe(Buffer.byteLength(huge, 'utf8'));
+      expect(body.body).not.toContain('�');
+      expect(Buffer.byteLength(body.body, 'utf8')).toBeLessThanOrEqual(1024 * 1024);
+    });
+
+    it('the block route refuses without --allow-transcript, by tag', async () => {
+      const info = await startRO();
+      const res = await fetch(`${base()}/api/sessions/s1/turns/block?srcOffset=0&n=1`, {
+        headers: bearer(info.token as string),
+      });
+      expect(res.status).toBe(403);
+      expect((await res.json()).error.startsWith('transcript-disabled:')).toBe(true);
+    });
+
     it('★ liveness is non-recording and reaches only panes the device has read', async () => {
       const info = await startWithTranscript();
       const h = bearer(info.token as string);


### PR DESCRIPTION
## Summary

Three additions to the daemon's phone surface, handed over from the iOS turn-view
work: each one was a contract gap that made a planned iOS feature unbuildable.

**Liveness header.** The turn view wants a persistent activity header — thinking,
tool running with elapsed time, waiting for you — and that header cannot come from
the turn snapshot: an agent that stalls mid-turn writes nothing, so a
snapshot-derived header shows a frozen pane as a working one. `agent.tool_started`
already existed for exactly this ("feeds the phone header" is in its comment) but
never left the main pipe. Each `agent.event` is now projected onto a header state
and fanned out over `/api/events` as `agent.liveness`, following the three rules
`transcript.nudge` set: non-recording, coalesced per pane, watchers only.

**Code block fetch.** Turn pages carry code blocks and large tool outputs as chips
and never the body — one 256KB tail re-encoded with bodies would blow past main's
control-buffer cap. The desktop expands a chip over the `daemon.transcript.codeBlock`
RPC; the phone had no equivalent, so every chip it rendered was display-only. Adds
`GET /api/sessions/:id/turns/block`, the same bounded line read behind the same
`--allow-transcript` grant.

**Gate state.** `/api/config` listed which tools are gated but never whether the
gate was armed, so a client's toggle opened on a guessed default and could only
learn the truth by flipping something. Adds `gateEnabled`, plus a `gate.state` push
so one phone disarming the gate does not leave every other device showing the old
position.

## Review

Two-model panel (Claude + GLM) on the finished diff. Six defects found and fixed in
`4c7e2224`, four of them verified against the code before fixing:

- `agent.subagent_stop` arrives as `status:'complete'`, so every finished subagent
  flipped the header to idle on a pane that was still working — and being a settled
  state it skipped coalescing.
- Nothing released the header from "waiting on you". The wide PostToolUse hook that
  would have is gone, so after a phone answered a gate (or the 120s self-defer fell
  back to the local prompt) the elapsed counter kept climbing.
- `/api/config` reported the runtime gate flag rather than the effective state. The
  daemon arms the gate only when the flag is clear AND the web server can resolve
  gates, so a read-only server let everything through while config said "on".
- The orchestrator brain's TUI was readable. It is a live session, `listSessions`
  excludes it, and both transcript routes checked existence alone. Both now answer
  404 — the same as a missing pane, so the id is not confirmed.
- The 1MB body cap was unreachable (the projector reads one line up to 512KB), so
  the documented `truncated` flag could never appear. Now 256KB, and the contract
  says what a 404 on an oversized line actually means.
- `tool_name` reached every watching device unvalidated. Bounded and stripped.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Full suite: 10113 passed. Two failures are outside this diff and pre-existing
      on the base — `THIRD_PARTY_NOTICES` drift and a `bridgePermissionGate`
      subprocess timeout.
- [x] 10 new tests: liveness projection (including the subagent regression and tool
      name sanitizing), non-recording / watcher-only / immediate-flush delivery,
      block route stale-ref + param validation + cap, brain-pane 404, effective gate
      state and its SSE push.

## Follow-ups not taken here

- `at` is the daemon's clock and the phone renders elapsed from it, so device clock
  skew lands in the number. Switching to a relative value would drop the coalescing
  delay, so this is worth revisiting only if iOS actually sees bad values.
- Gate transitions leave no audit trail. Recording who disarmed it is worth doing,
  but it turns `gate.state` into a recorded event and re-opens the replay contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live activity indicators for agent panes, including working, waiting, permission, and completed states.
  - Added mobile access to code blocks and large tool outputs from transcripts.
  - Added synchronized permission-gate status across connected clients.

- **Bug Fixes**
  - Prevented phones from accessing the orchestrator’s hidden conversation through its session ID.
  - Improved status updates after permission approval so activity no longer appears stuck.

- **Documentation**
  - Documented live activity and permission events, reconnect behavior, transcript expansion, access rules, and size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->