### PR TITLE
fix(mcp): reclaim a stale pinned terminal route

### DIFF
--- a/changelog.d/797.md
+++ b/changelog.d/797.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **External MCP terminals now recover when their claimed workspace is deleted.**
+  Closing an external caller's dedicated MCP workspace used to leave every later
+  terminal operation targeting the dead PTY until the MCP server restarted. A
+  stale route is now released so the next operation claims a fresh workspace
+  automatically. (#797)

--- a/src/mcp/__tests__/connectionScope.test.ts
+++ b/src/mcp/__tests__/connectionScope.test.ts
@@ -90,6 +90,7 @@ describe('connectionScope isolation', () => {
       sendRpc: async () => ({ ptyId: pty, workspaceId: ws }),
     });
 
+    await claimPinnedRoute(claimFor('ws-global', 'pty-global'));
     await runInConnectionScope(a, () => claimPinnedRoute(claimFor('ws-a', 'pty-a')));
     await runInConnectionScope(b, () => claimPinnedRoute(claimFor('ws-b', 'pty-b')));
 
@@ -100,7 +101,10 @@ describe('connectionScope isolation', () => {
       ptyId: 'pty-b',
       workspaceId: 'ws-b',
     });
-    expect(getPinnedRoute()).toBeNull();
+    expect(getPinnedRoute()).toEqual({
+      ptyId: 'pty-global',
+      workspaceId: 'ws-global',
+    });
   });
 
   it('PlaywrightEngine.getInstance is per scope, stable within a scope, singleton outside', () => {

--- a/src/mcp/__tests__/connectionScope.test.ts
+++ b/src/mcp/__tests__/connectionScope.test.ts
@@ -9,7 +9,12 @@ import {
   getClientIdentity,
   clearClientIdentity,
 } from '../wmux-client';
-import { getPinnedRoute, claimPinnedRoute, __resetPaneResolverForTesting } from '../paneResolver';
+import {
+  claimPinnedRoute,
+  clearPinnedRoute,
+  getPinnedRoute,
+  __resetPaneResolverForTesting,
+} from '../paneResolver';
 import { PlaywrightEngine } from '../playwright/PlaywrightEngine';
 
 // Broker isolation invariants (Option A). The broker hosts N MCP server
@@ -75,6 +80,26 @@ describe('connectionScope isolation', () => {
       workspaceId: 'ws-b',
     });
     // No leak into the process-global pin (single-child mode).
+    expect(getPinnedRoute()).toBeNull();
+  });
+
+  it('clearing a stale pin affects only the current connection', async () => {
+    const a = createConnectionScope();
+    const b = createConnectionScope();
+    const claimFor = (ws: string, pty: string) => ({
+      sendRpc: async () => ({ ptyId: pty, workspaceId: ws }),
+    });
+
+    await runInConnectionScope(a, () => claimPinnedRoute(claimFor('ws-a', 'pty-a')));
+    await runInConnectionScope(b, () => claimPinnedRoute(claimFor('ws-b', 'pty-b')));
+
+    runInConnectionScope(a, () => clearPinnedRoute());
+
+    expect(runInConnectionScope(a, () => getPinnedRoute())).toBeNull();
+    expect(runInConnectionScope(b, () => getPinnedRoute())).toEqual({
+      ptyId: 'pty-b',
+      workspaceId: 'ws-b',
+    });
     expect(getPinnedRoute()).toBeNull();
   });
 

--- a/src/mcp/__tests__/paneResolver.test.ts
+++ b/src/mcp/__tests__/paneResolver.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   claimPinnedRoute,
+  clearPinnedRoute,
   getPinnedRoute,
   __resetPaneResolverForTesting,
 } from '../paneResolver';
@@ -52,6 +53,28 @@ describe('claimPinnedRoute / getPinnedRoute', () => {
     // All three calls share a single claim RPC — re-claiming on every tool call
     // would spawn a new workspace each time.
     expect(sendRpc).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears a stale pin so the next call can claim a fresh route', async () => {
+    const sendRpc = vi
+      .fn()
+      .mockResolvedValueOnce({ ptyId: 'pty-dead', workspaceId: 'ws-dead' })
+      .mockResolvedValueOnce({ ptyId: 'pty-fresh', workspaceId: 'ws-fresh' });
+    const deps = makeDeps({ sendRpc });
+
+    await expect(claimPinnedRoute(deps)).resolves.toEqual({
+      ptyId: 'pty-dead',
+      workspaceId: 'ws-dead',
+    });
+
+    clearPinnedRoute();
+
+    expect(getPinnedRoute()).toBeNull();
+    await expect(claimPinnedRoute(deps)).resolves.toEqual({
+      ptyId: 'pty-fresh',
+      workspaceId: 'ws-fresh',
+    });
+    expect(sendRpc).toHaveBeenCalledTimes(2);
   });
 
   it('de-duplicates concurrent first calls so only one claim RPC fires', async () => {

--- a/src/mcp/__tests__/paneResolver.test.ts
+++ b/src/mcp/__tests__/paneResolver.test.ts
@@ -77,6 +77,27 @@ describe('claimPinnedRoute / getPinnedRoute', () => {
     expect(sendRpc).toHaveBeenCalledTimes(2);
   });
 
+  it('does not let a late stale response clear a newer claim', async () => {
+    const sendRpc = vi
+      .fn()
+      .mockResolvedValueOnce({ ptyId: 'pty-old', workspaceId: 'ws-old' })
+      .mockResolvedValueOnce({ ptyId: 'pty-new', workspaceId: 'ws-new' });
+    const deps = makeDeps({ sendRpc });
+    const oldRoute = await claimPinnedRoute(deps);
+
+    // The first stale response releases the old generation, allowing a new
+    // route to be claimed while another RPC for the old route is still pending.
+    clearPinnedRoute(oldRoute);
+    const newRoute = await claimPinnedRoute(deps);
+
+    // That older RPC now reports the same stale route. Its captured generation
+    // must not invalidate the replacement that was claimed in the meantime.
+    clearPinnedRoute(oldRoute);
+
+    expect(getPinnedRoute()).toBe(newRoute);
+    expect(getPinnedRoute()).toEqual({ ptyId: 'pty-new', workspaceId: 'ws-new' });
+  });
+
   it('de-duplicates concurrent first calls so only one claim RPC fires', async () => {
     let resolveRpc!: (value: unknown) => void;
     const sendRpc = vi.fn().mockImplementation(

--- a/src/mcp/__tests__/workspaceRouting.test.ts
+++ b/src/mcp/__tests__/workspaceRouting.test.ts
@@ -121,6 +121,22 @@ describe('MCP workspace routing (source-level invariants)', () => {
     expect(block).toMatch(/workspaceResolved\s*\?\s*MY_WORKSPACE_ID\s*:\s*''/);
   });
 
+  it('stale RPC outcomes invalidate both verified identity and an external pin', () => {
+    // A deleted first-party workspace is recovered through the verified cache;
+    // a deleted external claim is recovered through paneResolver. Leaving the
+    // latter intact makes every later terminal call reuse the dead PTY until
+    // the MCP process restarts.
+    const start = src.indexOf('function invalidateStaleRoute');
+    expect(start).toBeGreaterThan(0);
+    const block = src.slice(start, src.indexOf('\n}', start) + 2);
+    expect(block).toContain('invalidateWorkspaceId()');
+    expect(block).toContain('clearPinnedRoute()');
+
+    const callRpcStart = src.indexOf('async function callRpc');
+    const callRpcBlock = src.slice(callRpcStart, src.indexOf('\n}', callRpcStart) + 2);
+    expect(callRpcBlock.match(/invalidateStaleRoute\(\)/g)).toHaveLength(2);
+  });
+
   it('the env-hint resolver (verifiedOnly) is fully removed — terminal IO never reaches it', () => {
     // resolveVerifiedWorkspaceId / the verifiedOnly opt were the old seam. They
     // are gone; terminal routing now has its own verified path. If they ever

--- a/src/mcp/__tests__/workspaceRouting.test.ts
+++ b/src/mcp/__tests__/workspaceRouting.test.ts
@@ -121,7 +121,7 @@ describe('MCP workspace routing (source-level invariants)', () => {
     expect(block).toMatch(/workspaceResolved\s*\?\s*MY_WORKSPACE_ID\s*:\s*''/);
   });
 
-  it('stale RPC outcomes invalidate both verified identity and an external pin', () => {
+  it('stale RPC outcomes invalidate identity and only the route generation they used', () => {
     // A deleted first-party workspace is recovered through the verified cache;
     // a deleted external claim is recovered through paneResolver. Leaving the
     // latter intact makes every later terminal call reuse the dead PTY until
@@ -130,11 +130,16 @@ describe('MCP workspace routing (source-level invariants)', () => {
     expect(start).toBeGreaterThan(0);
     const block = src.slice(start, src.indexOf('\n}', start) + 2);
     expect(block).toContain('invalidateWorkspaceId()');
-    expect(block).toContain('clearPinnedRoute()');
+    expect(block).toContain('clearPinnedRoute(pinnedRouteAtDispatch)');
 
     const callRpcStart = src.indexOf('async function callRpc');
     const callRpcBlock = src.slice(callRpcStart, src.indexOf('\n}', callRpcStart) + 2);
-    expect(callRpcBlock.match(/invalidateStaleRoute\(\)/g)).toHaveLength(2);
+    expect(callRpcBlock).toMatch(
+      /const pinnedRouteAtDispatch = getPinnedRoute\(\);[\s\S]*await sendRpc/,
+    );
+    expect(
+      callRpcBlock.match(/invalidateStaleRoute\(pinnedRouteAtDispatch\)/g),
+    ).toHaveLength(2);
   });
 
   it('the env-hint resolver (verifiedOnly) is fully removed — terminal IO never reaches it', () => {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { sendRpc, setClientIdentity, setCommanderRole } from './wmux-client';
 import { COMMANDER_TOOL_SURFACE } from '../shared/commanderSurface';
 import type { RpcMethod } from '../shared/rpc';
-import { claimPinnedRoute, getPinnedRoute } from './paneResolver';
+import { claimPinnedRoute, clearPinnedRoute, getPinnedRoute } from './paneResolver';
 import { resolveTerminalRoute, resolveCommanderRoute, type PidMapLookup } from './terminalRouting';
 import { classifyWorkspaceListResult, type WorkspaceLiveness } from './workspaceIdentity';
 import { PlaywrightEngine } from './playwright/PlaywrightEngine';
@@ -443,15 +443,27 @@ async function callRpc(
 ): Promise<{ content: { type: 'text'; text: string }[] }> {
   try {
     const result = await sendRpc(method, params);
-    if (isStaleIdentityResult(result)) invalidateWorkspaceId();
+    if (isStaleIdentityResult(result)) invalidateStaleRoute();
     const text = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
     return { content: [{ type: 'text', text }] };
   } catch (err) {
     if (isStaleIdentityResult(err instanceof Error ? err.message : String(err))) {
-      invalidateWorkspaceId();
+      invalidateStaleRoute();
     }
     throw err;
   }
+}
+
+/**
+ * Drop every cached coordinate that can keep an RPC on a re-minted route.
+ *
+ * First-party callers use the verified workspace cache. External callers use
+ * paneResolver's process/connection-local claim instead, so clearing only the
+ * former leaves them pinned to a deleted PTY until the MCP server restarts.
+ */
+function invalidateStaleRoute(): void {
+  invalidateWorkspaceId();
+  clearPinnedRoute();
 }
 
 /**

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -4,7 +4,12 @@ import { z } from 'zod';
 import { sendRpc, setClientIdentity, setCommanderRole } from './wmux-client';
 import { COMMANDER_TOOL_SURFACE } from '../shared/commanderSurface';
 import type { RpcMethod } from '../shared/rpc';
-import { claimPinnedRoute, clearPinnedRoute, getPinnedRoute } from './paneResolver';
+import {
+  claimPinnedRoute,
+  clearPinnedRoute,
+  getPinnedRoute,
+  type PinnedRoute,
+} from './paneResolver';
 import { resolveTerminalRoute, resolveCommanderRoute, type PidMapLookup } from './terminalRouting';
 import { classifyWorkspaceListResult, type WorkspaceLiveness } from './workspaceIdentity';
 import { PlaywrightEngine } from './playwright/PlaywrightEngine';
@@ -441,14 +446,15 @@ async function callRpc(
   method: RpcMethod,
   params: Record<string, unknown> = {},
 ): Promise<{ content: { type: 'text'; text: string }[] }> {
+  const pinnedRouteAtDispatch = getPinnedRoute();
   try {
     const result = await sendRpc(method, params);
-    if (isStaleIdentityResult(result)) invalidateStaleRoute();
+    if (isStaleIdentityResult(result)) invalidateStaleRoute(pinnedRouteAtDispatch);
     const text = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
     return { content: [{ type: 'text', text }] };
   } catch (err) {
     if (isStaleIdentityResult(err instanceof Error ? err.message : String(err))) {
-      invalidateStaleRoute();
+      invalidateStaleRoute(pinnedRouteAtDispatch);
     }
     throw err;
   }
@@ -461,9 +467,9 @@ async function callRpc(
  * paneResolver's process/connection-local claim instead, so clearing only the
  * former leaves them pinned to a deleted PTY until the MCP server restarts.
  */
-function invalidateStaleRoute(): void {
+function invalidateStaleRoute(pinnedRouteAtDispatch: PinnedRoute | null): void {
   invalidateWorkspaceId();
-  clearPinnedRoute();
+  clearPinnedRoute(pinnedRouteAtDispatch);
 }
 
 /**

--- a/src/mcp/paneResolver.ts
+++ b/src/mcp/paneResolver.ts
@@ -74,6 +74,19 @@ export function getPinnedRoute(): PinnedRoute | null {
 }
 
 /**
+ * Drop the route claimed by the current process/connection.
+ *
+ * A claim is normally process-lived, but the user can delete its workspace
+ * while the MCP server stays alive. Once an RPC proves that route is stale,
+ * clearing the pin lets the next terminal call claim a fresh workspace rather
+ * than retrying the dead PTY forever. `slots()` keeps broker callers isolated:
+ * invalidating one connection never disturbs another connection's route.
+ */
+export function clearPinnedRoute(): void {
+  slots().set(null);
+}
+
+/**
  * Claim a dedicated workspace + PTY for an external caller and pin both ids
  * for the rest of this process's lifetime.
  *

--- a/src/mcp/paneResolver.ts
+++ b/src/mcp/paneResolver.ts
@@ -28,8 +28,8 @@ import type { RpcMethod } from '../shared/rpc';
 import { getConnectionScope } from './connectionScope';
 
 export interface PinnedRoute {
-  ptyId: string;
-  workspaceId: string;
+  readonly ptyId: string;
+  readonly workspaceId: string;
 }
 
 export interface ClaimDeps {
@@ -81,9 +81,15 @@ export function getPinnedRoute(): PinnedRoute | null {
  * clearing the pin lets the next terminal call claim a fresh workspace rather
  * than retrying the dead PTY forever. `slots()` keeps broker callers isolated:
  * invalidating one connection never disturbs another connection's route.
+ *
+ * When `expectedRoute` is supplied, object identity acts as the claim
+ * generation: a late response for an older claim cannot clear a newer one.
+ * Omitting it retains the unconditional form used by explicit resets.
  */
-export function clearPinnedRoute(): void {
-  slots().set(null);
+export function clearPinnedRoute(expectedRoute?: PinnedRoute | null): void {
+  const s = slots();
+  if (expectedRoute !== undefined && s.get() !== expectedRoute) return;
+  s.set(null);
 }
 
 /**


### PR DESCRIPTION
## Summary

- clear an external MCP caller's process/connection-scoped terminal pin when an RPC proves the route is stale
- let the next terminal operation claim a fresh workspace instead of retrying a deleted PTY until restart
- preserve shared-broker isolation so one connection cannot invalidate another caller's route

## Why

The MCP self-heal path already invalidated its cached verified workspace when a request returned `no workspace found` or `not owned by workspace`. External callers do not route through that cache: they reuse a `PinnedRoute` claimed on first terminal use. If the user deleted that workspace while the MCP process stayed alive, the stale-result handler left the dead pin intact, so every later terminal call selected the same missing PTY forever.

`clearPinnedRoute()` uses the existing connection-aware slots. Single-child mode clears module state; broker mode clears only the active connection. Both result-shaped and thrown stale errors now invalidate the verified cache and the pin together.

## Verification

- `npx vitest run src/mcp/__tests__/paneResolver.test.ts src/mcp/__tests__/connectionScope.test.ts src/mcp/__tests__/workspaceRouting.test.ts` — 29 passed
- `npx tsc -p tsconfig.mcp.json --noEmit` — passed
- `npm run build:mcp` — passed
- `npm run test:parallel` — 10,106 passed, 24 skipped
- `npm run test:runtime` — 149 passed, 2 unrelated existing PowerShell OSC 133 tests failed locally because `node-pty` reported `AttachConsole failed` under Node 24.18.0; the focused MCP coverage is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery for external MCP terminals when their claimed workspace is deleted.
  - Stale workspace routes are now released automatically, allowing terminals to reclaim a fresh workspace.
  - Route cleanup is scoped correctly to the affected connection, preventing disruption to other active connections.
  - Prevented stale cleanup from removing newer, valid route claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->