### PR TITLE
Drop each pane's render model when the atlas guard wipes the pool

### DIFF
--- a/changelog.d/798.md
+++ b/changelog.d/798.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Terminal panes no longer render scattered wrong glyphs (worst on Korean and
+  other CJK text) during heavy multi-pane output. The shared-atlas guard emptied
+  the glyph pool and repainted, but a repaint skips every cell whose text has not
+  changed — so those cells kept pointing at glyph positions that no longer
+  existed. Each pane now rebuilds its render model alongside the wipe, the way
+  the renderer does it internally. The guard's speculative wipes are also rate
+  limited, so a saturated glyph pool no longer means a full re-raster of every
+  pane every two seconds.

--- a/src/renderer/terminal/__tests__/atlasGuard.test.ts
+++ b/src/renderer/terminal/__tests__/atlasGuard.test.ts
@@ -3,6 +3,7 @@ import {
   clearAtlasTexture,
   createAtlasGuard,
   detectMerge,
+  clearRenderModel,
   extractAtlas,
   GUARD_POLL_MS,
   GUARD_MARGIN_PAGES,
@@ -29,8 +30,20 @@ class FakeAtlas {
    *  effect (upstream early-returns unless _pages[0] is idle), so PREVENT
    *  re-fires on every tick instead of being gated by the anti-thrash rule. */
   clearIsNoop = false;
+  /** clearTexture calls made by the guard's own pool wipe. Kept separate from
+   *  `paneClears` so a test can still say "the guard rebuilt N times" — the
+   *  per-pane model clear reaches the same upstream method. */
   clearTexture(): void {
     this.clearCalls++;
+    this.applyClear();
+  }
+  /** clearTexture reached through a pane's `addon.clearTextureAtlas()`. */
+  paneClears = 0;
+  clearTextureFromPane(): void {
+    this.paneClears++;
+    this.applyClear();
+  }
+  private applyClear(): void {
     if (this.clearIsNoop) return;
     // Faithful to upstream: it decides "already clean, nothing to do" by
     // probing ONLY page 0, then empties every page IN PLACE (count unchanged).
@@ -106,15 +119,42 @@ class FakeAtlas {
   }
 }
 
-function addonFor(atlas: FakeAtlas | null): unknown {
-  return { _renderer: { _charAtlas: atlas } };
+/** The addon surface the guard walks. `clearTextureAtlas` is upstream's public
+ *  wrapper and does what WebglRenderer.clearTextureAtlas does: clear the shared
+ *  texture, then clear THIS pane's render model + glyph renderer. Omit it
+ *  (`withModelClear: false`) to model a reshaped/DOM-renderer addon. */
+function addonFor(
+  atlas: FakeAtlas | null,
+  onModelClear?: () => void,
+  withModelClear = true,
+): unknown {
+  const base: Record<string, unknown> = { _renderer: { _charAtlas: atlas } };
+  if (withModelClear) {
+    base.clearTextureAtlas = (): void => {
+      atlas?.clearTextureFromPane();
+      onModelClear?.();
+    };
+  }
+  return base;
 }
 
-function makePane(atlas: FakeAtlas | null): { entry: { getAddon(): unknown; refresh(): void }; refreshes: () => number } {
+function makePane(
+  atlas: FakeAtlas | null,
+  withModelClear = true,
+): {
+  entry: { getAddon(): unknown; refresh(): void };
+  refreshes: () => number;
+  modelClears: () => number;
+} {
   let count = 0;
+  let modelClears = 0;
   return {
-    entry: { getAddon: () => addonFor(atlas), refresh: () => { count++; } },
+    entry: {
+      getAddon: () => addonFor(atlas, () => { modelClears++; }, withModelClear),
+      refresh: () => { count++; },
+    },
     refreshes: () => count,
+    modelClears: () => modelClears,
   };
 }
 
@@ -236,7 +276,9 @@ describe('atlasGuard', () => {
     try {
       const atlas = new FakeAtlas(PREVENT_AT, true);
       atlas.clearIsNoop = true; // pressure never drops → PREVENT every tick
-      const guard = createAtlasGuard();
+      // Cooldown off: this test is specifically about surviving a PREVENT
+      // storm, so it needs the storm the rate limit exists to damp.
+      const guard = createAtlasGuard({ preventCooldownMs: 0 });
       const pane = makePane(atlas);
       guard.register(pane.entry);
 
@@ -414,9 +456,11 @@ describe('atlasGuard', () => {
     guard.register(pane.entry);
 
     vi.advanceTimersByTime(GUARD_POLL_MS);
-    expect(atlas.skippedClears).toBe(0); // the short-circuit was defeated…
-    expect(atlas.effectiveClears).toBe(1); // …so the clear took effect…
+    expect(atlas.effectiveClears).toBe(1); // the short-circuit was defeated…
     expect(atlas.anyPageInUse()).toBe(false); // …and the pressure dropped
+    // The only short-circuited call is the pane's own pairing clear, which runs
+    // after the wipe and is meant to be a no-op on the (now empty) pool.
+    expect(atlas.skippedClears).toBe(atlas.paneClears);
 
     // …so the anti-thrash gate engages: no further firing while occupancy is low.
     vi.advanceTimersByTime(GUARD_POLL_MS * 5);
@@ -513,5 +557,132 @@ describe('atlasGuard', () => {
     guard.register(healthy.entry);
     vi.advanceTimersByTime(GUARD_POLL_MS);
     expect(healthy.refreshes()).toBe(1);
+  });
+
+  // --- The corruption the rebuild itself was causing (2026-08-05, v3.38.7) ---
+
+  it('every rebuild drops each pane render model, not just the shared texture', () => {
+    // Without this, refresh() re-renders rows but skips every cell whose text
+    // is unchanged, so each pane keeps vertex UVs pointing into the pool we
+    // just emptied — the "scattered wrong Hangul" report.
+    const atlas = new FakeAtlas(PREVENT_AT, true);
+    const guard = createAtlasGuard();
+    const a = makePane(atlas);
+    const b = makePane(atlas);
+    guard.register(a.entry);
+    guard.register(b.entry);
+
+    vi.advanceTimersByTime(GUARD_POLL_MS);
+    expect(atlas.effectiveClears).toBe(1); // pool wiped once, for everyone
+    expect(a.modelClears()).toBe(1); // …and every owner re-derives its glyphs
+    expect(b.modelClears()).toBe(1);
+  });
+
+  it('drops the model on CURE and on recoverNow too, not only on PREVENT', () => {
+    const atlas = new FakeAtlas(6, true);
+    const guard = createAtlasGuard();
+    const pane = makePane(atlas);
+    guard.register(pane.entry);
+
+    vi.advanceTimersByTime(GUARD_POLL_MS); // baseline poll, well under PREVENT
+    expect(pane.modelClears()).toBe(0);
+
+    atlas.mergePages(4); // a real merge → CURE
+    vi.advanceTimersByTime(GUARD_POLL_MS);
+    expect(pane.modelClears()).toBe(1);
+
+    guard.recoverNow('system-resumed');
+    expect(pane.modelClears()).toBe(2);
+  });
+
+  it('wipes the shared pool BEFORE dropping any model', () => {
+    // Reverse that order and a pane repopulates from the doomed atlas, then the
+    // wipe invalidates it again — stale on arrival.
+    const atlas = new FakeAtlas(PREVENT_AT, true);
+    const order: string[] = [];
+    const guard = createAtlasGuard();
+    const pane = {
+      getAddon: () => addonFor(atlas, () => { order.push(`model:${atlas.anyPageInUse()}`); }),
+      refresh: () => { order.push('refresh'); },
+    };
+    guard.register(pane);
+
+    vi.advanceTimersByTime(GUARD_POLL_MS);
+    // `false` = the pool was already empty when the model was dropped.
+    expect(order).toEqual(['model:false', 'refresh']);
+  });
+
+  it('warns, rather than silently half-repairing, when a pane cannot drop its model', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const atlas = new FakeAtlas(PREVENT_AT, true);
+      const guard = createAtlasGuard();
+      const reachable = makePane(atlas);
+      const reshaped = makePane(atlas, false); // no clearTextureAtlas on the addon
+      guard.register(reachable.entry);
+      guard.register(reshaped.entry);
+
+      vi.advanceTimersByTime(GUARD_POLL_MS);
+      expect(reachable.modelClears()).toBe(1);
+      expect(reshaped.modelClears()).toBe(0);
+      expect(
+        warn.mock.calls.map((c) => String(c[0])).some((l) => /render model NOT cleared for 1\/2/.test(l)),
+      ).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('clearRenderModel: reports failure instead of throwing on a reshaped or dead addon', () => {
+    expect(clearRenderModel(null)).toBe(false);
+    expect(clearRenderModel({})).toBe(false);
+    expect(clearRenderModel({ clearTextureAtlas: 'not a function' })).toBe(false);
+    expect(clearRenderModel({ clearTextureAtlas: () => { throw new Error('disposed'); } })).toBe(false);
+    let called = 0;
+    expect(clearRenderModel({ clearTextureAtlas: () => { called++; } })).toBe(true);
+    expect(called).toBe(1);
+  });
+
+  // --- Anti-thrash: the rebuild is no longer cheap ---
+
+  it('PREVENT is rate-limited while the pool stays saturated', () => {
+    // The v3.38.7 field state: `pages=16/16 used` sustained, so the gate re-arms
+    // on the very next poll. Nine wipes in 90s, each one now a full re-raster of
+    // every pane.
+    const atlas = new FakeAtlas(PREVENT_AT, true);
+    const guard = createAtlasGuard({ preventCooldownMs: GUARD_POLL_MS * 5 });
+    const pane = {
+      getAddon: () => addonFor(atlas),
+      // Faithful: the re-raster immediately refills the pool to saturation.
+      refresh: () => { for (const p of atlas.pages) p.currentRow = { x: 9, y: 9 }; },
+    };
+    guard.register(pane);
+
+    vi.advanceTimersByTime(GUARD_POLL_MS);
+    expect(atlas.effectiveClears).toBe(1);
+
+    // Saturated again on every following poll, but the cooldown holds it to one.
+    vi.advanceTimersByTime(GUARD_POLL_MS * 4);
+    expect(atlas.effectiveClears).toBe(1);
+
+    vi.advanceTimersByTime(GUARD_POLL_MS);
+    expect(atlas.effectiveClears).toBe(2);
+  });
+
+  it('the cooldown never delays CURE — a real merge is repaired immediately', () => {
+    const atlas = new FakeAtlas(PREVENT_AT, true);
+    const guard = createAtlasGuard({ preventCooldownMs: GUARD_POLL_MS * 100 });
+    const pane = {
+      getAddon: () => addonFor(atlas),
+      refresh: () => { for (const p of atlas.pages) p.currentRow = { x: 9, y: 9 }; },
+    };
+    guard.register(pane);
+
+    vi.advanceTimersByTime(GUARD_POLL_MS); // PREVENT fires, cooldown now armed
+    expect(atlas.effectiveClears).toBe(1);
+
+    atlas.mergePages(4); // corruption is real now, not speculative
+    vi.advanceTimersByTime(GUARD_POLL_MS);
+    expect(atlas.effectiveClears).toBe(2);
   });
 });

--- a/src/renderer/terminal/atlasGuard.ts
+++ b/src/renderer/terminal/atlasGuard.ts
@@ -91,7 +91,8 @@
 //      so `refresh()` skipped every unchanged cell and kept its old glyph
 //      coordinates into a pool that had just been emptied and re-packed. That
 //      IS the corruption. It was invisible while (1) made the clear a no-op;
-//      fixing (1) armed it. Field log, v3.38.7 on 2026-08-05: nine
+//      fixing (1) armed it. Field log, v3.38.7 on 2026-08-05 KST (the lines
+//      themselves are UTC, `2026-08-04T20:40-20:41Z`): nine
 //      `prevent … clear=cleared` events in the 90s before a corrupted-Hangul
 //      screenshot, zero merge cures — the merge path never ran. See
 //      `clearRenderModel` for the upstream pairing this now reproduces.
@@ -332,7 +333,8 @@ export interface ModelClearableAddon {
  * (we already emptied the pool, so upstream's page-0 probe short-circuits),
  * which is why the pool wipe stays a single shared operation.
  *
- * Field evidence for the ordering, 2026-08-05: v3.38.7 logged nine
+ * Field evidence for the ordering, 2026-08-05 KST (`2026-08-04T20:4xZ` in the
+ * log itself): v3.38.7 logged nine
  * `prevent … clear=cleared` events in the 90s before a corruption screenshot,
  * and zero merge cures. Under v3.38.6 the same clear was a silent no-op and
  * the same workload did not corrupt — the repair, not the merge, was the

--- a/src/renderer/terminal/atlasGuard.ts
+++ b/src/renderer/terminal/atlasGuard.ts
@@ -27,14 +27,17 @@
 //            OCCUPIED (a long pool of empty pages is nowhere near a merge —
 //            see defect 2 below), clear the atlas
 //            (clearTexture empties every page in place and clears both cache
-//            maps) and refresh every pane sharing it in the same tick. That is
-//            the coherent all-owners rebuild upstream itself performs on font
-//            changes — the #191 hazard was clearing from ONE pane while its
-//            siblings kept stale references, which this never does.
+//            maps) and then drop the render model of every pane sharing it, in
+//            the same tick. That is the coherent all-owners rebuild upstream
+//            itself performs on font changes — the #191 hazard was clearing
+//            from ONE pane while its siblings kept stale references, which
+//            this never does. Speculative firings are rate-limited
+//            (GUARD_PREVENT_COOLDOWN_MS); a saturated pool re-arms the gate
+//            every poll and the rebuild is not free.
 //
-//   CURE     If a merge slips through anyway, do the same clear+refresh-all.
-//            Corruption is visible for at most one poll interval instead of
-//            indefinitely.
+//   CURE     If a merge slips through anyway, do the same clear+rebuild-all,
+//            with no rate limit. Corruption is visible for at most one poll
+//            interval instead of indefinitely.
 //
 //            Three signals feed it, strongest first — a page-removal EVENT, a
 //            page-count drop, and a page-identity change. Count alone is not
@@ -64,8 +67,9 @@
 //            before the deletes, making it an exact real-time signal with no
 //            sampling gap.
 //
-// Two independent defects made that repair fire 4657 times in one day and
-// achieve nothing. Both are fixed here.
+// Three independent defects made that repair fire 4657 times in one day and
+// achieve nothing — then, once (1) and (2) were fixed, made it start causing
+// the very corruption it was written to repair. All three are fixed here.
 //
 //   1. The clear did not clear. Upstream `clearTexture()` short-circuits on a
 //      page-0-only "already clean" probe, and page 0 is exactly the page that
@@ -83,9 +87,19 @@
 //      the field at the moment of a PREVENT storm: 15 pages, 1 in use — every
 //      one of those firings was spurious.
 //
-// Fixing only (1) would have been worse than shipping neither: the no-op loop
-// would have become a real full-atlas wipe plus an all-pane re-raster, every
-// two seconds, forever.
+//   3. The rebuild wiped the atlas but left every pane's render model intact,
+//      so `refresh()` skipped every unchanged cell and kept its old glyph
+//      coordinates into a pool that had just been emptied and re-packed. That
+//      IS the corruption. It was invisible while (1) made the clear a no-op;
+//      fixing (1) armed it. Field log, v3.38.7 on 2026-08-05: nine
+//      `prevent … clear=cleared` events in the 90s before a corrupted-Hangul
+//      screenshot, zero merge cures — the merge path never ran. See
+//      `clearRenderModel` for the upstream pairing this now reproduces.
+//
+// Fixing (1) alone was worse than shipping neither, in both directions: the
+// no-op loop became a real full-atlas wipe plus an all-pane re-raster every
+// two seconds, and each of those wipes desynced the panes it was meant to
+// repair.
 //
 // Internal-field dependency: reaching the atlas needs `addon._renderer
 // ._charAtlas` (same accepted trade-off as webglTeardown.ts's `_renderer._gl`)
@@ -102,6 +116,11 @@ export const GUARD_POLL_MS = 2_000;
 /** Fallback merge trigger when maxAtlasPages is unreadable: matches the
  *  smallest real-world cap (min(32, 16 texture units) on Apple Silicon). */
 export const FALLBACK_MAX_PAGES = 16;
+/** Minimum gap between two speculative (PREVENT) rebuilds of the same atlas.
+ *  A rebuild now re-rasters every pane, and a saturated pool re-arms the gate
+ *  on the next poll, so without this the guard wipes the atlas every `pollMs`
+ *  for the whole duration of a CJK-heavy stream. CURE is exempt. */
+export const GUARD_PREVENT_COOLDOWN_MS = 30_000;
 
 /** One registered pane: how to reach its WebGL addon and repaint it. */
 export interface AtlasGuardEntry {
@@ -114,8 +133,11 @@ export interface AtlasGuardEntry {
 export interface AtlasGuardOptions {
   pollMs?: number;
   marginPages?: number;
+  preventCooldownMs?: number;
   setIntervalFn?: typeof setInterval;
   clearIntervalFn?: typeof clearInterval;
+  /** Injectable clock for tests. */
+  now?: () => number;
 }
 
 interface AtlasLike {
@@ -279,6 +301,54 @@ export function clearAtlasTexture(atlas: ClearableAtlas): ClearOutcome {
   return 'cleared';
 }
 
+/** The one public addon method that performs upstream's own atlas-clear
+ *  sequence: clear the texture, clear the render model AND the glyph
+ *  renderer, request a viewport redraw. */
+export interface ModelClearableAddon {
+  clearTextureAtlas?: () => void;
+}
+
+/**
+ * Drop one pane's render model so it re-derives every glyph from the atlas.
+ *
+ * This is the half of the repair the guard used to be missing, and without it
+ * the clear above does not fix corruption — it CAUSES it.
+ *
+ * `terminal.refresh()` re-runs `WebglRenderer._updateModel` over every row, but
+ * that loop skips any cell whose CONTENT is unchanged
+ * (WebglRenderer.ts:507 — "Nothing has changed, no updates needed" → continue).
+ * The skip is keyed on code/bg/fg/ext only; it knows nothing about the atlas.
+ * So a cell that still holds the same character keeps the vertex UVs written
+ * when it was last rendered — coordinates into an atlas we have since emptied
+ * and started re-packing from scratch. The pane then samples the new atlas at
+ * old positions: scattered wrong glyphs, worst on CJK (11,172 Hangul syllables
+ * churn the pool while ASCII sits undisturbed in the first page).
+ *
+ * Upstream never clears the atlas without clearing the model in the same
+ * breath — `WebglRenderer.clearTextureAtlas()` (WebglRenderer.ts:307) is
+ * exactly `_charAtlas.clearTexture(); _clearModel(true); _requestRedrawViewport()`.
+ * Calling the addon's public wrapper per owner reproduces that pairing without
+ * reaching for another internal. Its own `clearTexture()` is a no-op by then
+ * (we already emptied the pool, so upstream's page-0 probe short-circuits),
+ * which is why the pool wipe stays a single shared operation.
+ *
+ * Field evidence for the ordering, 2026-08-05: v3.38.7 logged nine
+ * `prevent … clear=cleared` events in the 90s before a corruption screenshot,
+ * and zero merge cures. Under v3.38.6 the same clear was a silent no-op and
+ * the same workload did not corrupt — the repair, not the merge, was the
+ * trigger.
+ */
+export function clearRenderModel(addon: unknown): boolean {
+  const clear = (addon as ModelClearableAddon | null | undefined)?.clearTextureAtlas;
+  if (typeof clear !== 'function') return false;
+  try {
+    clear.call(addon);
+    return true;
+  } catch {
+    return false; // pane disposing, or upstream reshaped — the next tick retries
+  }
+}
+
 /** Duck-typed walk to the shared TextureAtlas behind a WebglAddon. Returns
  *  null whenever any internal is missing (DOM renderer, upstream reshape). */
 export function extractAtlas(addon: unknown): AtlasLike | null {
@@ -307,8 +377,10 @@ export function createAtlasGuard(options: AtlasGuardOptions = {}): AtlasGuard {
   const {
     pollMs = GUARD_POLL_MS,
     marginPages = GUARD_MARGIN_PAGES,
+    preventCooldownMs = GUARD_PREVENT_COOLDOWN_MS,
     setIntervalFn = setInterval,
     clearIntervalFn = clearInterval,
+    now: nowMs = Date.now,
   } = options;
 
   const entries = new Set<AtlasGuardEntry>();
@@ -320,6 +392,8 @@ export function createAtlasGuard(options: AtlasGuardOptions = {}): AtlasGuard {
   // first sight; never unsubscribed, because the listener cannot outlive the
   // emitter it lives on (both die with the atlas).
   const removalLatch = new WeakMap<object, { fired: boolean }>();
+  // Last speculative (PREVENT) rebuild per atlas, for the cooldown in tick().
+  const lastPreventAt = new WeakMap<object, number>();
   let timer: ReturnType<typeof setInterval> | null = null;
 
   /** Latch for this atlas, subscribing on first sight. null when upstream does
@@ -355,7 +429,12 @@ export function createAtlasGuard(options: AtlasGuardOptions = {}): AtlasGuard {
   }
 
   // The coherent rebuild both PREVENT/CURE and recoverNow perform: empty the
-  // shared atlas, then re-raster every owner pane in the same tick.
+  // shared atlas, then make every owner pane re-derive its glyphs from it in
+  // the same tick.
+  //
+  // Both halves are load-bearing, and the ORDER is too. Wipe the shared pool
+  // once, then drop each owner's render model: a model dropped before the wipe
+  // would repopulate from the doomed atlas and be stale again immediately.
   function rebuildGroup(atlas: AtlasLike, group: AtlasGuardEntry[]): string {
     // shared — one call empties it for every owner. Goes through
     // clearAtlasTexture so upstream's page-0-only "already clean" probe cannot
@@ -364,12 +443,25 @@ export function createAtlasGuard(options: AtlasGuardOptions = {}): AtlasGuard {
     if (outcome === 'failed') {
       console.warn('[wmux:atlas-guard] clear did not take effect — pool pressure will not drop');
     }
+    let modelsCleared = 0;
     for (const entry of group) {
+      // Drop the render model FIRST: refresh() alone re-renders rows but skips
+      // every unchanged cell, so on its own it preserves exactly the stale
+      // glyph coordinates the wipe just invalidated (see clearRenderModel).
+      if (clearRenderModel(entry.getAddon())) modelsCleared++;
       try {
         entry.refresh();
       } catch {
         // pane may be disposing — the next tick simply won't see it
       }
+    }
+    if (modelsCleared < group.length) {
+      // Any pane we could not reach keeps stale glyph references against a
+      // pool we just emptied. Surface it: a silent partial repair is how this
+      // class of corruption stayed unexplained for three releases.
+      console.warn(
+        `[wmux:atlas-guard] render model NOT cleared for ${group.length - modelsCleared}/${group.length} pane(s) — they may render stale glyphs`,
+      );
     }
     return outcome;
   }
@@ -416,6 +508,22 @@ export function createAtlasGuard(options: AtlasGuardOptions = {}): AtlasGuard {
       const mergeSignal: MergeSignal | null = removed ? 'page-removed' : detectMerge(prev, tags);
       const nearTrigger = len >= preventAt && used >= preventAt;
       if (!mergeSignal && !nearTrigger) continue;
+
+      // PREVENT-only cooldown. A rebuild is no longer cheap: it now drops every
+      // owner pane's render model and forces a full viewport redraw, which is
+      // what makes the repair actually work. A saturated pool re-arms the gate
+      // on the very next poll — the field log for v3.38.7 shows sustained
+      // `pages=16/16 used`, i.e. a wipe every 2s for as long as CJK output
+      // flows. At that point there is nothing left to prevent: the pool is
+      // already full, and letting the merge land is fine because CURE repairs
+      // it coherently. Rate-limit the speculative path so it cannot become a
+      // permanent re-raster treadmill. CURE is never rate-limited — it is the
+      // repair, and it only fires on a real merge.
+      if (!mergeSignal) {
+        const lastPrevent = lastPreventAt.get(atlas as object) ?? -Infinity;
+        if (nowMs() - lastPrevent < preventCooldownMs) continue;
+        lastPreventAt.set(atlas as object, nowMs());
+      }
 
       const outcome = rebuildGroup(atlas, group);
       console.warn(


### PR DESCRIPTION
## What

`atlasGuard`'s rebuild emptied the shared WebGL glyph atlas and then called `terminal.refresh()` on each owner pane. That is only half of what upstream does, and the missing half is what makes the repair work.

`refresh()` re-runs `WebglRenderer._updateModel` over every row, but the loop skips any cell whose content is unchanged:

```ts
// WebglRenderer.ts:507 — @xterm/addon-webgl 0.19.0
// Nothing has changed, no updates needed
if (this._model.cells[i] === code && ...bg && ...fg && ...ext) {
  continue;
}
```

The skip is keyed on `code/bg/fg/ext` alone and knows nothing about atlas state. So every unchanged cell kept the vertex UVs written when it was last rendered — coordinates into a pool that had just been emptied and was re-packing from scratch. The pane sampled the new atlas at old positions: scattered wrong glyphs, worst on CJK (11,172 Hangul syllables churn the pool while ASCII sits undisturbed in the first page).

Upstream never separates the two operations — `WebglRenderer.clearTextureAtlas()` (`WebglRenderer.ts:307`) is exactly `_charAtlas.clearTexture(); _clearModel(true); _requestRedrawViewport()`.

## Why it appeared now

Latent until #790. While `clearTexture()` was a permanent no-op the rebuild changed nothing, so it could not desync anything. Fixing the clear armed it.

Field log, v3.38.7 on 2026-08-05 — nine wipes in the 90s before a corrupted-Hangul screenshot, and **zero** merge cures, so the merge path never ran:

```
20:40:58Z prevent — pages=16/16 used, cap=16, panes=3, clear=cleared
20:41:02Z prevent — pages=13/16 used, cap=16, panes=2, clear=cleared
20:41:38Z prevent — pages=16/16 used, cap=16, panes=3, clear=cleared
20:41:40Z prevent — pages=13/16 used, cap=16, panes=4, clear=cleared
```

## Changes

- `rebuildGroup` wipes the shared pool once, then calls each owner addon's public `clearTextureAtlas()` (its own `clearTexture` short-circuits by then, so the pool is still emptied exactly once). Order matters: a model dropped before the wipe would repopulate from the doomed atlas.
- Warn when a pane cannot be reached, instead of half-repairing in silence.
- Rate-limit PREVENT (`GUARD_PREVENT_COOLDOWN_MS`, 30s). A rebuild now re-rasters every pane, and a saturated pool re-arms the gate on the next poll. At saturation there is nothing left to prevent, and a merge that does land is repaired coherently by CURE — which is never rate limited.

## Tests

7 new cases in `atlasGuard.test.ts`, and the fake addon now models `clearTextureAtlas` faithfully:

- every rebuild drops each pane's render model, not just the shared texture
- model dropped on CURE and `recoverNow`, not only PREVENT
- pool wiped **before** any model is dropped (ordering)
- warns when a pane cannot drop its model
- `clearRenderModel` degrades to `false` on a reshaped/dead addon
- PREVENT rate-limited while the pool stays saturated
- the cooldown never delays CURE

`31 passed` in `atlasGuard.test.ts`, `213 passed` across `src/renderer/terminal` + `useTerminal.atlasClear`, `tsc --noEmit` and `eslint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering reliability for CJK characters during heavy multi-pane output.
  * Panes now refresh correctly after shared glyph resources are cleared.
  * Reduced unnecessary recovery operations through rate limiting.
  * Added clearer diagnostics when pane rendering data cannot be refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->