### PR TITLE
Fix two CLI lifecycle defects: meta.* pane identity and workspace.close false receipts

### DIFF
--- a/changelog.d/801.md
+++ b/changelog.d/801.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **`wmux set-status` and `wmux set-progress` work again.** Both commands failed
+  every time with an internal message about an unresolvable calling pane, so
+  there was no way for automation to publish a run's live status or progress
+  into the workspace chrome. They now identify the calling pane the same way
+  `wmux send` does, and `--pane <ptyId>` targets another pane's workspace.
+  Outside a wmux pane they exit with a message that says what to do instead of
+  the daemon's internal resolver text. (#801)

--- a/changelog.d/801.md
+++ b/changelog.d/801.md
@@ -7,3 +7,9 @@
   `wmux send` does, and `--pane <ptyId>` targets another pane's workspace.
   Outside a wmux pane they exit with a message that says what to do instead of
   the daemon's internal resolver text. (#801)
+- **`wmux close-workspace` no longer reports closing a workspace it did not
+  close.** Closing an unknown workspace, or the last remaining one (wmux always
+  keeps one open), printed `Closed workspace: ws-…` and exited 0 while the
+  workspace stayed open — so a cleanup script had no way to tell a real close
+  from a refused one. Both cases now fail with an explanation, and the success
+  receipt is only issued after the workspace is confirmed gone. (#801)

--- a/src/cli/commands/__tests__/system.test.ts
+++ b/src/cli/commands/__tests__/system.test.ts
@@ -111,6 +111,52 @@ describe('set-status / set-progress carry a senderPtyId (#800)', () => {
     });
   });
 
+  it('accepts the --pane=<v> form instead of publishing it as the status', async () => {
+    // The two-parser version posted the literal "--pane=pty-other" to the
+    // caller's own workspace and exited 0.
+    await handleSystem('set-status', ['--pane=pty-other', 'hello'], false);
+    expect(rpc).toHaveBeenCalledWith('meta.setStatus', {
+      text: 'hello',
+      senderPtyId: 'pty-other',
+    });
+  });
+
+  it('joins the whole payload instead of dropping every word after the first', async () => {
+    await handleSystem('set-status', ['Build', 'failed'], false);
+    expect(rpc).toHaveBeenCalledWith('meta.setStatus', {
+      text: 'Build failed',
+      senderPtyId: 'pty-self',
+    });
+  });
+
+  it('rejects --pane with no value rather than eating the payload', async () => {
+    await expect(handleSystem('set-status', ['--pane'], false)).rejects.toThrow(ExitCalled);
+    await expect(handleSystem('set-status', ['--pane', '-x', 'hi'], false)).rejects.toThrow(
+      ExitCalled,
+    );
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown flag rather than publishing it as text', async () => {
+    await expect(handleSystem('set-status', ['--panne', 'pty-x'], false)).rejects.toThrow(
+      ExitCalled,
+    );
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('passes a dash-leading payload through after --', async () => {
+    await handleSystem('set-status', ['--', '--not-a-flag'], false);
+    expect(rpc).toHaveBeenCalledWith('meta.setStatus', {
+      text: '--not-a-flag',
+      senderPtyId: 'pty-self',
+    });
+  });
+
+  it('still treats a negative progress value as out-of-range, not an unknown flag', async () => {
+    await expect(handleSystem('set-progress', ['-5'], false)).rejects.toThrow(ExitCalled);
+    expect(errSpy.mock.calls.flat().join(' ')).toMatch(/between 0 and 100/);
+  });
+
   it('fails closed BEFORE any RPC when no identity resolves', async () => {
     selfContext.mockResolvedValue({});
     await expect(handleSystem('set-status', ['nope'], false)).rejects.toThrow(ExitCalled);

--- a/src/cli/commands/__tests__/system.test.ts
+++ b/src/cli/commands/__tests__/system.test.ts
@@ -152,6 +152,18 @@ describe('set-status / set-progress carry a senderPtyId (#800)', () => {
     });
   });
 
+  it('rejects an empty progress value instead of reporting 0%', async () => {
+    // Number('') is 0, so this used to succeed as "Progress set: 0%".
+    await expect(handleSystem('set-progress', [''], false)).rejects.toThrow(ExitCalled);
+    await expect(handleSystem('set-progress', ['   '], false)).rejects.toThrow(ExitCalled);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('rejects a stray extra progress token instead of dropping it', async () => {
+    await expect(handleSystem('set-progress', ['10', 'extra'], false)).rejects.toThrow(ExitCalled);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
   it('still treats a negative progress value as out-of-range, not an unknown flag', async () => {
     await expect(handleSystem('set-progress', ['-5'], false)).rejects.toThrow(ExitCalled);
     expect(errSpy.mock.calls.flat().join(' ')).toMatch(/between 0 and 100/);

--- a/src/cli/commands/__tests__/system.test.ts
+++ b/src/cli/commands/__tests__/system.test.ts
@@ -1,0 +1,120 @@
+/**
+ * `wmux set-status` / `wmux set-progress` — issue #800.
+ *
+ * `meta.*` writes are workspace-scoped SERVER-SIDE from `senderPtyId` (U8,
+ * meta.rpc.ts). The CLI never attached one, so both commands failed 100% of the
+ * time with "cannot resolve the calling pane's workspace — send a verified
+ * senderPtyId", even from a shell inside a pane where `wmux send` self-resolved
+ * fine, and even with an explicit `--pane`.
+ *
+ * What these tests pin:
+ *  1. senderPtyId rides along on both commands (verified walk),
+ *  2. `--pane <ptyId>` overrides the walk and is NOT swallowed into the payload,
+ *  3. env WMUX_PTY_ID is the fallback when the walk misses (descendant shells),
+ *  4. no resolvable identity → exit 1 BEFORE any RPC, with an actionable message.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../client', () => ({
+  sendRequest: vi.fn(),
+  sendDaemonRequest: vi.fn(),
+}));
+vi.mock('../../identity', () => ({
+  resolveSelfContext: vi.fn(),
+  getParentPidDefault: vi.fn(),
+}));
+
+import { sendRequest } from '../../client';
+import { resolveSelfContext } from '../../identity';
+import { handleSystem } from '../system';
+
+const rpc = sendRequest as unknown as ReturnType<typeof vi.fn>;
+const selfContext = resolveSelfContext as unknown as ReturnType<typeof vi.fn>;
+
+class ExitCalled extends Error {
+  constructor(public readonly code: number | undefined) {
+    super(`exit(${code})`);
+  }
+}
+
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.WMUX_PTY_ID;
+  selfContext.mockResolvedValue({ ptyId: 'pty-self', workspaceId: 'ws-self' });
+  rpc.mockResolvedValue({ ok: true, result: { ok: true } });
+  vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    throw new ExitCalled(code);
+  }) as never);
+  vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.WMUX_PTY_ID;
+});
+
+describe('set-status / set-progress carry a senderPtyId (#800)', () => {
+  it('attaches the verified-walk ptyId to meta.setStatus', async () => {
+    await handleSystem('set-status', ['building'], false);
+    expect(rpc).toHaveBeenCalledWith('meta.setStatus', {
+      text: 'building',
+      senderPtyId: 'pty-self',
+    });
+  });
+
+  it('attaches the verified-walk ptyId to meta.setProgress', async () => {
+    await handleSystem('set-progress', ['42'], false);
+    expect(rpc).toHaveBeenCalledWith('meta.setProgress', {
+      value: 42,
+      senderPtyId: 'pty-self',
+    });
+  });
+
+  it('lets --pane override the walk without leaking into the payload', async () => {
+    await handleSystem('set-status', ['hello', '--pane', 'pty-other'], false);
+    expect(rpc).toHaveBeenCalledWith('meta.setStatus', {
+      text: 'hello',
+      senderPtyId: 'pty-other',
+    });
+    // The walk must not even be attempted when the caller named a pane.
+    expect(selfContext).not.toHaveBeenCalled();
+  });
+
+  it('reads the payload past a leading --pane instead of taking the flag as text', async () => {
+    await handleSystem('set-status', ['--pane', 'pty-other', 'hello'], false);
+    expect(rpc).toHaveBeenCalledWith('meta.setStatus', {
+      text: 'hello',
+      senderPtyId: 'pty-other',
+    });
+  });
+
+  it('falls back to WMUX_PTY_ID when the walk misses', async () => {
+    selfContext.mockResolvedValue({});
+    process.env.WMUX_PTY_ID = 'pty-env';
+    await handleSystem('set-progress', ['7'], false);
+    expect(rpc).toHaveBeenCalledWith('meta.setProgress', {
+      value: 7,
+      senderPtyId: 'pty-env',
+    });
+  });
+
+  it('survives a walk that throws (main pipe down) via the env hint', async () => {
+    selfContext.mockRejectedValue(new Error('pipe closed'));
+    process.env.WMUX_PTY_ID = 'pty-env';
+    await handleSystem('set-status', ['headless'], false);
+    expect(rpc).toHaveBeenCalledWith('meta.setStatus', {
+      text: 'headless',
+      senderPtyId: 'pty-env',
+    });
+  });
+
+  it('fails closed BEFORE any RPC when no identity resolves', async () => {
+    selfContext.mockResolvedValue({});
+    await expect(handleSystem('set-status', ['nope'], false)).rejects.toThrow(ExitCalled);
+    expect(rpc).not.toHaveBeenCalled();
+    expect(errSpy.mock.calls.flat().join(' ')).toMatch(/--pane <ptyId>/);
+  });
+});

--- a/src/cli/commands/system.ts
+++ b/src/cli/commands/system.ts
@@ -1,7 +1,9 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { sendRequest } from '../client';
-import { printResult, ensureOk } from '../utils';
+import { printResult, ensureOk, parseFlag } from '../utils';
+import { resolveSelfContext, getParentPidDefault } from '../identity';
+import { ENV_KEYS } from '../../shared/constants';
 import type { RpcResponse } from '../../shared/rpc';
 
 function getFallbackVersion(): string {
@@ -17,6 +19,69 @@ interface IdentifyResult {
   app: string;
   version: string;
   platform: string;
+}
+
+/**
+ * `meta.*` writes are workspace-scoped SERVER-SIDE from `senderPtyId` (U8,
+ * meta.rpc.ts): the daemon resolves the calling pane's workspace itself and
+ * ignores any caller-supplied workspaceId, so an external caller that sends no
+ * senderPtyId is refused outright. `set-status` / `set-progress` never attached
+ * one, which made both commands fail unconditionally (#800).
+ *
+ * Same resolution ladder `wmux channel` uses, plus an explicit override:
+ *   1. `--pane <ptyId>` — name the pane whose workspace to write;
+ *   2. verified PID-map walk via the main pipe (resolveSelfContext, X4);
+ *   3. env WMUX_PTY_ID — stamped into the pane env at spawn; survives a walk
+ *      miss (descendant processes several hops up the tree).
+ * Returns '' when none resolve — the caller is not in a wmux pane.
+ */
+async function resolveMetaSenderPtyId(args: string[]): Promise<string> {
+  const explicitPane = parseFlag(args, '--pane');
+  if (explicitPane) return explicitPane;
+  try {
+    const ctx = await resolveSelfContext({
+      sendRequest,
+      env: process.env,
+      ppid: process.ppid,
+      getParentPid: getParentPidDefault,
+    });
+    if (ctx.ptyId) return ctx.ptyId;
+  } catch {
+    // main pipe unavailable — fall through to the env hint
+  }
+  const envPty = process.env[ENV_KEYS.PTY_ID];
+  return typeof envPty === 'string' && envPty.trim().length > 0 ? envPty.trim() : '';
+}
+
+/**
+ * Fail closed BEFORE the RPC with a readable message. Without this the server's
+ * own guard produces "cannot resolve the calling pane's workspace — send a
+ * verified senderPtyId", which tells a human nothing about what to do.
+ */
+async function requireMetaSenderPtyId(cmd: string, args: string[]): Promise<string> {
+  const senderPtyId = await resolveMetaSenderPtyId(args);
+  if (!senderPtyId) {
+    console.error(
+      `Error: ${cmd} cannot tell which workspace to write — no resolvable pane identity ` +
+        '(PID walk missed and WMUX_PTY_ID is unset).\n' +
+        'Run it from a shell inside a wmux pane, or pass --pane <ptyId>.',
+    );
+    process.exit(1);
+  }
+  return senderPtyId;
+}
+
+/** Strip routing flags so the remaining args are the command payload. */
+function stripSystemFlags(args: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--pane') {
+      i++; // skip value
+      continue;
+    }
+    out.push(args[i]);
+  }
+  return out;
 }
 
 export async function handleSystem(
@@ -63,12 +128,13 @@ export async function handleSystem(
     }
 
     case 'set-status': {
-      const text = args[0];
+      const text = stripSystemFlags(args)[0];
       if (text === undefined) {
         console.error('Error: set-status requires <text>');
         process.exit(1);
       }
-      response = await sendRequest('meta.setStatus', { text });
+      const senderPtyId = await requireMetaSenderPtyId('set-status', args);
+      response = await sendRequest('meta.setStatus', { text, senderPtyId });
       if (jsonMode) {
         printResult(response);
       } else {
@@ -79,7 +145,7 @@ export async function handleSystem(
     }
 
     case 'set-progress': {
-      const raw = args[0];
+      const raw = stripSystemFlags(args)[0];
       if (raw === undefined) {
         console.error('Error: set-progress requires <0-100>');
         process.exit(1);
@@ -89,7 +155,8 @@ export async function handleSystem(
         console.error('Error: progress value must be a number between 0 and 100');
         process.exit(1);
       }
-      response = await sendRequest('meta.setProgress', { value });
+      const senderPtyId = await requireMetaSenderPtyId('set-progress', args);
+      response = await sendRequest('meta.setProgress', { value, senderPtyId });
       if (jsonMode) {
         printResult(response);
       } else {

--- a/src/cli/commands/system.ts
+++ b/src/cli/commands/system.ts
@@ -34,6 +34,13 @@ interface IdentifyResult {
  *   3. env WMUX_PTY_ID — stamped into the pane env at spawn; survives a walk
  *      miss (descendant processes several hops up the tree).
  * Returns '' when none resolve — the caller is not in a wmux pane.
+ *
+ * Only rung 2 is verified. `--pane` and the env hint are same-user forgeable:
+ * the daemon derives the workspace from the ptyId it is handed, but nothing
+ * proves the calling process owns that pane. That is the accepted #113 ceiling
+ * and exactly what `wmux send --pane` already allows, so this adds no new
+ * authority — but it is why the verified walk is tried before the env hint
+ * rather than the other way round, even though the hint is cheaper.
  */
 async function resolveMetaSenderPtyId(explicitPane: string): Promise<string> {
   if (explicitPane) return explicitPane;

--- a/src/cli/commands/system.ts
+++ b/src/cli/commands/system.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { sendRequest } from '../client';
-import { printResult, ensureOk, parseFlag } from '../utils';
+import { printResult, ensureOk } from '../utils';
 import { resolveSelfContext, getParentPidDefault } from '../identity';
 import { ENV_KEYS } from '../../shared/constants';
 import type { RpcResponse } from '../../shared/rpc';
@@ -35,8 +35,7 @@ interface IdentifyResult {
  *      miss (descendant processes several hops up the tree).
  * Returns '' when none resolve — the caller is not in a wmux pane.
  */
-async function resolveMetaSenderPtyId(args: string[]): Promise<string> {
-  const explicitPane = parseFlag(args, '--pane');
+async function resolveMetaSenderPtyId(explicitPane: string): Promise<string> {
   if (explicitPane) return explicitPane;
   try {
     const ctx = await resolveSelfContext({
@@ -58,8 +57,8 @@ async function resolveMetaSenderPtyId(args: string[]): Promise<string> {
  * own guard produces "cannot resolve the calling pane's workspace — send a
  * verified senderPtyId", which tells a human nothing about what to do.
  */
-async function requireMetaSenderPtyId(cmd: string, args: string[]): Promise<string> {
-  const senderPtyId = await resolveMetaSenderPtyId(args);
+async function requireMetaSenderPtyId(cmd: string, explicitPane: string): Promise<string> {
+  const senderPtyId = await resolveMetaSenderPtyId(explicitPane);
   if (!senderPtyId) {
     console.error(
       `Error: ${cmd} cannot tell which workspace to write — no resolvable pane identity ` +
@@ -71,17 +70,58 @@ async function requireMetaSenderPtyId(cmd: string, args: string[]): Promise<stri
   return senderPtyId;
 }
 
-/** Strip routing flags so the remaining args are the command payload. */
-function stripSystemFlags(args: string[]): string[] {
-  const out: string[] = [];
+interface SystemArgs {
+  /** Explicit `--pane` target; '' when the caller did not name one. */
+  paneId: string;
+  /** Everything that was not a routing flag, in order. */
+  payload: string[];
+}
+
+/**
+ * Parse the routing flag and the payload in ONE pass.
+ *
+ * Two independent passes (parseFlag for the value, a stripper for the payload)
+ * disagree at the edges: parseFlag ignores a value starting with `-` while the
+ * stripper consumed the next token unconditionally, and neither recognised
+ * `--pane=<v>` — so `set-status --pane=pty-x hello` published the literal string
+ * "--pane=pty-x" to the caller's own workspace and exited 0. Parsing once
+ * removes that whole class rather than patching each case.
+ *
+ * An unrecognised `--flag` is an error, not payload: silently posting a mistyped
+ * flag as a status message is the same failure in a different costume. `--`
+ * ends flag parsing for a payload that legitimately starts with dashes.
+ */
+function parseSystemArgs(cmd: string, args: string[]): SystemArgs {
+  let paneId = '';
+  const payload: string[] = [];
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--pane') {
-      i++; // skip value
+    const a = args[i];
+    if (a === '--') {
+      payload.push(...args.slice(i + 1));
+      break;
+    }
+    if (a === '--pane' || a.startsWith('--pane=')) {
+      const value = a.startsWith('--pane=') ? a.slice('--pane='.length) : args[i + 1];
+      if (!value || value.startsWith('-')) {
+        console.error(`Error: ${cmd}: --pane requires a <ptyId>`);
+        process.exit(1);
+      }
+      if (!a.includes('=')) i++; // consume the separate value token
+      paneId = value;
       continue;
     }
-    out.push(args[i]);
+    // Only double-dash is a flag — `set-progress -5` must reach the range check
+    // as a value, not die here as an unknown flag.
+    if (a.startsWith('--')) {
+      console.error(
+        `Error: ${cmd}: unknown flag "${a}". ` +
+          'Put -- before a payload that starts with dashes.',
+      );
+      process.exit(1);
+    }
+    payload.push(a);
   }
-  return out;
+  return { paneId, payload };
 }
 
 export async function handleSystem(
@@ -128,12 +168,15 @@ export async function handleSystem(
     }
 
     case 'set-status': {
-      const text = stripSystemFlags(args)[0];
-      if (text === undefined) {
+      const { paneId, payload } = parseSystemArgs('set-status', args);
+      // Join, don't take [0]: `set-status Build failed` used to publish "Build"
+      // and drop the rest without a word. `wmux send` has always joined.
+      const text = payload.join(' ');
+      if (!text) {
         console.error('Error: set-status requires <text>');
         process.exit(1);
       }
-      const senderPtyId = await requireMetaSenderPtyId('set-status', args);
+      const senderPtyId = await requireMetaSenderPtyId('set-status', paneId);
       response = await sendRequest('meta.setStatus', { text, senderPtyId });
       if (jsonMode) {
         printResult(response);
@@ -145,7 +188,8 @@ export async function handleSystem(
     }
 
     case 'set-progress': {
-      const raw = stripSystemFlags(args)[0];
+      const { paneId, payload } = parseSystemArgs('set-progress', args);
+      const raw = payload[0];
       if (raw === undefined) {
         console.error('Error: set-progress requires <0-100>');
         process.exit(1);
@@ -155,7 +199,7 @@ export async function handleSystem(
         console.error('Error: progress value must be a number between 0 and 100');
         process.exit(1);
       }
-      const senderPtyId = await requireMetaSenderPtyId('set-progress', args);
+      const senderPtyId = await requireMetaSenderPtyId('set-progress', paneId);
       response = await sendRequest('meta.setProgress', { value, senderPtyId });
       if (jsonMode) {
         printResult(response);

--- a/src/cli/commands/system.ts
+++ b/src/cli/commands/system.ts
@@ -196,9 +196,16 @@ export async function handleSystem(
 
     case 'set-progress': {
       const { paneId, payload } = parseSystemArgs('set-progress', args);
+      // Exactly one non-blank token. `Number('')` is 0, so an empty argument
+      // used to report "Progress set: 0%" — the same false success this PR
+      // exists to remove — and a stray second token was dropped in silence.
       const raw = payload[0];
-      if (raw === undefined) {
+      if (raw === undefined || raw.trim() === '') {
         console.error('Error: set-progress requires <0-100>');
+        process.exit(1);
+      }
+      if (payload.length > 1) {
+        console.error(`Error: set-progress takes one value, got ${payload.length}`);
         process.exit(1);
       }
       const value = Number(raw);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -95,8 +95,11 @@ NOTIFICATION COMMANDS
          [--type info|warning|error|agent] [--workspace <id>]
 
 SYSTEM COMMANDS
-  set-status <text>                 Set a status message on the active workspace
-  set-progress <0-100>              Set a progress value on the active workspace
+  set-status <text> [--pane <id>]   Set a status message on your own workspace
+  set-progress <0-100> [--pane <id>]
+                                    Set a progress value on your own workspace
+                                    (both target the pane you are calling from;
+                                     --pane names another pane's workspace)
   identify                          Show wmux app info
   capabilities                      List all supported RPC methods
 

--- a/src/renderer/hooks/__tests__/useRpcBridge.workspaceClose.test.ts
+++ b/src/renderer/hooks/__tests__/useRpcBridge.workspaceClose.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * `workspace.close` must not hand out a false receipt (issue #799).
+ *
+ * The handler returned `{ok:true}` unconditionally, but `removeWorkspace` is a
+ * silent no-op in two cases: an id that matches nothing, and the store's
+ * last-workspace guard (wmux always keeps one workspace open). A scripted
+ * cleanup therefore saw `Closed workspace: ws-…` for a workspace that was still
+ * open — and the reporter's "confirmed-closed workspace reappeared and is now
+ * the only workspace" was never a resurrection: it was the last one, the removal
+ * was refused, and only the CLI lied about it.
+ *
+ * Same false-receipt class `getResultError()` (cli/utils.ts) was introduced for
+ * on surface.close — the CLI already exits 1 on a payload-level `{error}`, so
+ * returning one is all it takes for `close-workspace` to report honestly.
+ *
+ * handleRpcMethod is not exported and pulls in the store/window, so it can't be
+ * imported under vitest (same constraint as useRpcBridge.browserClose.test.ts /
+ * useRpcBridge.focus.test.ts); these are source-structural guards.
+ */
+describe('useRpcBridge — workspace.close receipt honesty (#799)', () => {
+  // Normalize CRLF: a Windows checkout hands this file to us with \r\n, which
+  // breaks the \n-anchored handler-isolation regex (same treatment as
+  // useTerminal.deferredFit.test.ts).
+  const src = fs
+    .readFileSync(path.join(__dirname, '..', 'useRpcBridge.ts'), 'utf-8')
+    .replace(/\r\n/g, '\n');
+
+  /** Isolate the workspace.close handler so no other close path can match. */
+  function closeHandler(): string {
+    const m = src.match(
+      /if \(method === 'workspace\.close'\)[\s\S]*?\n {2}\}\n/,
+    );
+    if (!m) {
+      throw new Error(
+        "workspace.close handler not found in useRpcBridge.ts. " +
+          'Update the regex if the handler layout changed.',
+      );
+    }
+    return m[0];
+  }
+
+  it('errors on an unknown workspace id instead of acknowledging it', () => {
+    const block = closeHandler();
+    expect(block).toMatch(/if \(!ws\)\s*\{[\s\S]*?return \{ error:/);
+  });
+
+  it('errors when the last workspace cannot be removed', () => {
+    const block = closeHandler();
+    // The guard that used to only skip the PTY dispose now also refuses the
+    // call. Asserting the length check and the error return separately would
+    // still pass if a rewrite left the old silent-success fall-through.
+    expect(block).toMatch(
+      /if \(store\.workspaces\.length <= 1\)\s*\{[\s\S]*?return \{[\s\S]*?error:/,
+    );
+  });
+
+  it('verifies the removal actually landed before returning ok', () => {
+    const block = closeHandler();
+    // Post-check against FRESH state — the entry-time guards cannot see a
+    // concurrent close that consumed the second-to-last workspace.
+    const postCheck = block.match(
+      /useStore\.getState\(\)\.workspaces\.some\([\s\S]*?\)\s*\)\s*\{[\s\S]*?return \{ error:/,
+    );
+    expect(postCheck).not.toBeNull();
+    // …and it has to sit AFTER the mutation, or it proves nothing.
+    expect(block.indexOf('store.removeWorkspace(id)')).toBeLessThan(
+      block.indexOf('useStore.getState().workspaces.some'),
+    );
+  });
+
+  it('still disposes the workspace PTYs before dropping it', () => {
+    const block = closeHandler();
+    expect(block).toMatch(/collectAllPtyIds\(ws\.rootPane\)/);
+    expect(block).toMatch(/window\.electronAPI\.pty\.dispose\(ptyId\)/);
+    expect(block.indexOf('pty.dispose')).toBeLessThan(
+      block.indexOf('store.removeWorkspace(id)'),
+    );
+  });
+
+  it('has exactly one ok receipt, and it is the last statement', () => {
+    const block = closeHandler();
+    expect(block.match(/return \{ ok: true \};/g)).toHaveLength(1);
+  });
+});

--- a/src/renderer/hooks/__tests__/useRpcBridge.workspaceClose.test.ts
+++ b/src/renderer/hooks/__tests__/useRpcBridge.workspaceClose.test.ts
@@ -83,8 +83,13 @@ describe('useRpcBridge — workspace.close receipt honesty (#799)', () => {
     );
   });
 
-  it('has exactly one ok receipt, and it is the last statement', () => {
+  it('has exactly one ok receipt, and it comes after the removal check', () => {
     const block = closeHandler();
     expect(block.match(/return \{ ok: true \};/g)).toHaveLength(1);
+    // Counting alone would still pass if the single receipt were returned
+    // BEFORE the check — which is the old behaviour this test exists to forbid.
+    expect(block.indexOf('useStore.getState().workspaces.some')).toBeLessThan(
+      block.indexOf('return { ok: true };'),
+    );
   });
 });

--- a/src/renderer/hooks/__tests__/useRpcBridge.workspaceClose.test.ts
+++ b/src/renderer/hooks/__tests__/useRpcBridge.workspaceClose.test.ts
@@ -60,8 +60,10 @@ describe('useRpcBridge — workspace.close receipt honesty (#799)', () => {
 
   it('verifies the removal actually landed before returning ok', () => {
     const block = closeHandler();
-    // Post-check against FRESH state — the entry-time guards cannot see a
-    // concurrent close that consumed the second-to-last workspace.
+    // Post-check against FRESH state. Not a race fix — nothing awaits between
+    // the guards and the mutation, so the check cannot fail today. It is an
+    // assertion that the handler's guards and removeWorkspace's own agree,
+    // which is precisely what drifted apart to produce #799.
     const postCheck = block.match(
       /useStore\.getState\(\)\.workspaces\.some\([\s\S]*?\)\s*\)\s*\{[\s\S]*?return \{ error:/,
     );

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -530,12 +530,15 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       } catch { /* best-effort */ }
     }
     store.removeWorkspace(id);
-    // Confirm the removal actually landed before acknowledging it. The guards
-    // above read the state at handler entry; concurrent closes (a cleanup
-    // script firing several `close-workspace` calls at once) can each pass a
-    // length>1 check and still have the slice's own last-workspace guard refuse
-    // the final one. Verifying afterwards is what makes the receipt truthful in
-    // that race, not just in the sequential case.
+    // Confirm the removal actually landed before acknowledging it. Today this
+    // cannot fail: nothing awaits between the guards above and here, so two
+    // concurrent closes cannot interleave on the renderer's single thread, and
+    // the guards mirror the slice's own. It is kept as an assertion, not as a
+    // race fix — the guards duplicate conditions that live in removeWorkspace,
+    // and the whole bug being fixed here is that the two drifted apart without
+    // anything noticing. If a future edit adds an await above, or the slice
+    // grows a third refusal, the receipt stays truthful instead of silently
+    // regressing to what #799 reported.
     if (useStore.getState().workspaces.some((w) => w.id === id)) {
       return { error: `workspace.close: "${id}" is still open — the removal was refused` };
     }

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -500,21 +500,45 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // agent inside them — while the workspace stays in the UI with dead
     // surfaces. Mirror the slice's guard so dispose only runs when the removal
     // will actually happen. (codex review P2)
+    //
+    // #799: report a refused removal as an ERROR instead of {ok:true}. Both
+    // no-op branches of removeWorkspace (unknown id, last-workspace guard) used
+    // to come back as success, so `wmux close-workspace <id>` printed
+    // "Closed workspace: ws-…" for a workspace that was still open — a scripted
+    // cleanup then treated a live workspace as gone. Same false-receipt class
+    // getResultError() was introduced for (surface.close).
     const ws = store.workspaces.find((w) => w.id === id);
-    if (ws && store.workspaces.length > 1) {
-      for (const ptyId of collectAllPtyIds(ws.rootPane)) {
-        // dispose() returns an IPC Promise, so a daemon-side failure (mid-
-        // respawn, session already dead) rejects asynchronously — a plain
-        // try/catch wouldn't catch it and workspace.close would emit an
-        // unhandled rejection while still reporting success. Swallow the
-        // rejection via .catch; the outer try guards a synchronous throw
-        // (e.g. electronAPI missing). Best-effort either way. (codex review P2)
-        try {
-          void window.electronAPI.pty.dispose(ptyId).catch(() => { /* best-effort */ });
-        } catch { /* best-effort */ }
-      }
+    if (!ws) {
+      return { error: `workspace.close: no workspace with id "${id}"` };
+    }
+    if (store.workspaces.length <= 1) {
+      return {
+        error:
+          `workspace.close: refusing to close "${id}" — it is the only workspace, ` +
+          'and wmux always keeps one open. Create another workspace first.',
+      };
+    }
+    for (const ptyId of collectAllPtyIds(ws.rootPane)) {
+      // dispose() returns an IPC Promise, so a daemon-side failure (mid-
+      // respawn, session already dead) rejects asynchronously — a plain
+      // try/catch wouldn't catch it and workspace.close would emit an
+      // unhandled rejection while still reporting success. Swallow the
+      // rejection via .catch; the outer try guards a synchronous throw
+      // (e.g. electronAPI missing). Best-effort either way. (codex review P2)
+      try {
+        void window.electronAPI.pty.dispose(ptyId).catch(() => { /* best-effort */ });
+      } catch { /* best-effort */ }
     }
     store.removeWorkspace(id);
+    // Confirm the removal actually landed before acknowledging it. The guards
+    // above read the state at handler entry; concurrent closes (a cleanup
+    // script firing several `close-workspace` calls at once) can each pass a
+    // length>1 check and still have the slice's own last-workspace guard refuse
+    // the final one. Verifying afterwards is what makes the receipt truthful in
+    // that race, not just in the sequential case.
+    if (useStore.getState().workspaces.some((w) => w.id === id)) {
+      return { error: `workspace.close: "${id}" is still open — the removal was refused` };
+    }
     return { ok: true };
   }
 


### PR DESCRIPTION
Fixes #800. Addresses the confirmed half of #799 (details below — #799 stays open for the other half).

Two independent CLI-facing defects from the same scripting session, one PR per the owner's call.

## 1. `set-status` / `set-progress` always failed (#800)

`meta.setStatus` / `meta.setProgress` resolve the caller's workspace
server-side from `senderPtyId` and refuse a caller they cannot place (the U8
scoping change — a workspace-less metadata write lands on whichever workspace
the human happens to be looking at). `src/cli/commands/system.ts` sent only
`{ text }` / `{ value }`, so there was nothing to resolve. `wmux channel`
already had the resolution ladder; `system.ts` was never wired to it, and it
did not parse `--pane` at all.

Both commands now walk the same ladder `wmux channel` uses:

1. `--pane <ptyId>` — name the pane whose workspace to write (also stripped
   from the payload, so a leading `--pane` no longer gets read as the status
   text);
2. the verified PID-map walk (`resolveSelfContext`);
3. the `WMUX_PTY_ID` pane env, which survives a walk miss from a descendant
   process and a down main pipe.

With none of them resolvable the command exits 1 **before** the RPC with an
actionable message instead of surfacing the daemon's internal resolver text.
Server-side scoping is untouched: the CLI still never claims a workspace, it
only supplies the pane the daemon resolves from.

## 2. `workspace.close` handed out false receipts (#799, second symptom)

The handler returned `{ ok: true }` unconditionally, but `removeWorkspace` is a
silent no-op in two cases: an id that matches nothing, and the store's
last-workspace guard (wmux always keeps one workspace open). So
`wmux close-workspace <id>` printed `Closed workspace: ws-…` for a workspace
that was still open.

That is the reporter's "confirmed-closed workspace reappeared" — it did not
reappear. It was the last one, the removal was refused, and only the CLI's
receipt lied. Now:

- unknown id → `{ error }`;
- last-workspace refusal → `{ error }` explaining why, instead of the previous
  behaviour where the guard only skipped the PTY dispose and still reported
  success;
- the `{ ok: true }` receipt is issued only after re-reading the store to
  confirm the workspace is actually gone.

The post-check is an assertion, **not** a race fix — panel review correctly
pointed out that nothing awaits between the guards and the mutation, so two
concurrent closes cannot interleave and the check cannot fail today. It is kept
because the guards duplicate conditions that live in `removeWorkspace`, and the
entire bug here is that those two drifted apart without anything noticing.

`getResultError()` in the CLI already exits 1 on a payload-level `{error}`
(the same false-receipt class fixed for `surface.close`), so no CLI change is
needed for this half.

### What this does not fix

The #799 first symptom — a pre-existing workspace vanishing from
`list-workspaces` without ever being named in a `close-workspace` call — is not
explained by this path. `removeWorkspace` only ever removes the id it is given.
Daemon/main logs are requested on the issue (2026-08-04 00:50–01:15 +02:00);
#799 stays open for that half. The two symptoms are consistent in order:
something removed `Workspace 1` first, which left the scratch workspace as the
last one, which is what made its close get refused and produce the false
receipt.

## Verification

- New `src/cli/commands/__tests__/system.test.ts` — 7 tests: walk hit, `--pane`
  override (and that it skips the walk), leading `--pane` not read as payload,
  env fallback, throwing walk, fail-closed exit before any RPC.
- New `src/renderer/hooks/__tests__/useRpcBridge.workspaceClose.test.ts` — 5
  source-structural tests (`handleRpcMethod` is not exported and pulls in the
  store/window, same constraint as the existing `useRpcBridge.browserClose` /
  `useRpcBridge.focus` tests). Confirmed they fail 3/5 against the pre-fix
  handler. Source is CRLF-normalized before matching so a Windows checkout
  cannot break the \n-anchored regexes (this was the one CI failure on the
  split-out predecessor PR).
- `npx vitest run src/cli src/renderer/hooks` — all green locally
  (269 + 556); `tsc --noEmit` on `tsconfig.json` + `tsconfig.cli.json`, eslint
  clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `set-status` and `set-progress` pane targeting with optional `--pane` selection.
  - Added clearer errors for invalid targets or commands run outside recognized panes.
  - Improved handling of multi-word status messages and progress values.
  - `close-workspace` now reports clear errors for unknown workspaces and attempts to close the last remaining workspace.
  - Success is reported only after workspace closure is confirmed.

- **Documentation**
  - Updated CLI help to describe pane targeting options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->