### PR TITLE
Stop workspace.close acknowledging a refused removal

### DIFF
--- a/changelog.d/802.md
+++ b/changelog.d/802.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **`wmux close-workspace` no longer reports closing a workspace it did not
+  close.** Closing an unknown workspace, or the last remaining one (wmux always
+  keeps one open), printed `Closed workspace: ws-…` and exited 0 while the
+  workspace stayed open — so a cleanup script had no way to tell a real close
+  from a refused one. Both cases now fail with an explanation, and the success
+  receipt is only issued after the workspace is confirmed gone. (#802)

--- a/src/renderer/hooks/__tests__/useRpcBridge.workspaceClose.test.ts
+++ b/src/renderer/hooks/__tests__/useRpcBridge.workspaceClose.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * `workspace.close` must not hand out a false receipt (issue #799).
+ *
+ * The handler returned `{ok:true}` unconditionally, but `removeWorkspace` is a
+ * silent no-op in two cases: an id that matches nothing, and the store's
+ * last-workspace guard (wmux always keeps one workspace open). A scripted
+ * cleanup therefore saw `Closed workspace: ws-…` for a workspace that was still
+ * open — and the reporter's "confirmed-closed workspace reappeared and is now
+ * the only workspace" was never a resurrection: it was the last one, the removal
+ * was refused, and only the CLI lied about it.
+ *
+ * Same false-receipt class `getResultError()` (cli/utils.ts) was introduced for
+ * on surface.close — the CLI already exits 1 on a payload-level `{error}`, so
+ * returning one is all it takes for `close-workspace` to report honestly.
+ *
+ * handleRpcMethod is not exported and pulls in the store/window, so it can't be
+ * imported under vitest (same constraint as useRpcBridge.browserClose.test.ts /
+ * useRpcBridge.focus.test.ts); these are source-structural guards.
+ */
+describe('useRpcBridge — workspace.close receipt honesty (#799)', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'useRpcBridge.ts'), 'utf-8');
+
+  /** Isolate the workspace.close handler so no other close path can match. */
+  function closeHandler(): string {
+    const m = src.match(
+      /if \(method === 'workspace\.close'\)[\s\S]*?\n {2}\}\n/,
+    );
+    if (!m) {
+      throw new Error(
+        "workspace.close handler not found in useRpcBridge.ts. " +
+          'Update the regex if the handler layout changed.',
+      );
+    }
+    return m[0];
+  }
+
+  it('errors on an unknown workspace id instead of acknowledging it', () => {
+    const block = closeHandler();
+    expect(block).toMatch(/if \(!ws\)\s*\{[\s\S]*?return \{ error:/);
+  });
+
+  it('errors when the last workspace cannot be removed', () => {
+    const block = closeHandler();
+    // The guard that used to only skip the PTY dispose now also refuses the
+    // call. Asserting the length check and the error return separately would
+    // still pass if a rewrite left the old silent-success fall-through.
+    expect(block).toMatch(
+      /if \(store\.workspaces\.length <= 1\)\s*\{[\s\S]*?return \{[\s\S]*?error:/,
+    );
+  });
+
+  it('verifies the removal actually landed before returning ok', () => {
+    const block = closeHandler();
+    // Post-check against FRESH state — the entry-time guards cannot see a
+    // concurrent close that consumed the second-to-last workspace.
+    const postCheck = block.match(
+      /useStore\.getState\(\)\.workspaces\.some\([\s\S]*?\)\s*\)\s*\{[\s\S]*?return \{ error:/,
+    );
+    expect(postCheck).not.toBeNull();
+    // …and it has to sit AFTER the mutation, or it proves nothing.
+    expect(block.indexOf('store.removeWorkspace(id)')).toBeLessThan(
+      block.indexOf('useStore.getState().workspaces.some'),
+    );
+  });
+
+  it('still disposes the workspace PTYs before dropping it', () => {
+    const block = closeHandler();
+    expect(block).toMatch(/collectAllPtyIds\(ws\.rootPane\)/);
+    expect(block).toMatch(/window\.electronAPI\.pty\.dispose\(ptyId\)/);
+    expect(block.indexOf('pty.dispose')).toBeLessThan(
+      block.indexOf('store.removeWorkspace(id)'),
+    );
+  });
+
+  it('has exactly one ok receipt, and it is the last statement', () => {
+    const block = closeHandler();
+    expect(block.match(/return \{ ok: true \};/g)).toHaveLength(1);
+  });
+});

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -500,21 +500,45 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // agent inside them — while the workspace stays in the UI with dead
     // surfaces. Mirror the slice's guard so dispose only runs when the removal
     // will actually happen. (codex review P2)
+    //
+    // #799: report a refused removal as an ERROR instead of {ok:true}. Both
+    // no-op branches of removeWorkspace (unknown id, last-workspace guard) used
+    // to come back as success, so `wmux close-workspace <id>` printed
+    // "Closed workspace: ws-…" for a workspace that was still open — a scripted
+    // cleanup then treated a live workspace as gone. Same false-receipt class
+    // getResultError() was introduced for (surface.close).
     const ws = store.workspaces.find((w) => w.id === id);
-    if (ws && store.workspaces.length > 1) {
-      for (const ptyId of collectAllPtyIds(ws.rootPane)) {
-        // dispose() returns an IPC Promise, so a daemon-side failure (mid-
-        // respawn, session already dead) rejects asynchronously — a plain
-        // try/catch wouldn't catch it and workspace.close would emit an
-        // unhandled rejection while still reporting success. Swallow the
-        // rejection via .catch; the outer try guards a synchronous throw
-        // (e.g. electronAPI missing). Best-effort either way. (codex review P2)
-        try {
-          void window.electronAPI.pty.dispose(ptyId).catch(() => { /* best-effort */ });
-        } catch { /* best-effort */ }
-      }
+    if (!ws) {
+      return { error: `workspace.close: no workspace with id "${id}"` };
+    }
+    if (store.workspaces.length <= 1) {
+      return {
+        error:
+          `workspace.close: refusing to close "${id}" — it is the only workspace, ` +
+          'and wmux always keeps one open. Create another workspace first.',
+      };
+    }
+    for (const ptyId of collectAllPtyIds(ws.rootPane)) {
+      // dispose() returns an IPC Promise, so a daemon-side failure (mid-
+      // respawn, session already dead) rejects asynchronously — a plain
+      // try/catch wouldn't catch it and workspace.close would emit an
+      // unhandled rejection while still reporting success. Swallow the
+      // rejection via .catch; the outer try guards a synchronous throw
+      // (e.g. electronAPI missing). Best-effort either way. (codex review P2)
+      try {
+        void window.electronAPI.pty.dispose(ptyId).catch(() => { /* best-effort */ });
+      } catch { /* best-effort */ }
     }
     store.removeWorkspace(id);
+    // Confirm the removal actually landed before acknowledging it. The guards
+    // above read the state at handler entry; concurrent closes (a cleanup
+    // script firing several `close-workspace` calls at once) can each pass a
+    // length>1 check and still have the slice's own last-workspace guard refuse
+    // the final one. Verifying afterwards is what makes the receipt truthful in
+    // that race, not just in the sequential case.
+    if (useStore.getState().workspaces.some((w) => w.id === id)) {
+      return { error: `workspace.close: "${id}" is still open — the removal was refused` };
+    }
     return { ok: true };
   }
 


### PR DESCRIPTION
Addresses half of #799 — the confirmed half. See "What this does not fix" below.

## Cause

`workspace.close` in `useRpcBridge.ts` returned `{ ok: true }` unconditionally.
`removeWorkspace` is a silent no-op in two cases: an id that matches nothing,
and the store's last-workspace guard (wmux always keeps one workspace open). So
`wmux close-workspace <id>` printed `Closed workspace: ws-…` for a workspace
that was still open.

That is the reporter's second symptom. The workspace the CLI confirmed closing
did not reappear — it was the last one, the removal was refused, and only the
CLI's receipt lied. A scripted cleanup then had no way to tell the difference.

Same false-receipt class `getResultError()` (`src/cli/utils.ts`) was introduced
for on `surface.close`, so the CLI already exits 1 on a payload-level `{error}`
— returning one is all it takes for the command to report honestly.

## Change

- unknown id → `{ error }` instead of a receipt;
- last-workspace refusal → `{ error }` explaining why, instead of the previous
  behaviour where the guard only skipped the PTY dispose and still reported
  success;
- the `{ ok: true }` receipt is issued only after re-reading the store to
  confirm the workspace is actually gone. The post-check is what makes
  concurrent closes honest as well: several `close-workspace` calls firing at
  once can each pass the entry-time length guard and still have the slice
  refuse the last one.

PTY disposal ordering is unchanged.

## What this does not fix

The report's first symptom — a pre-existing workspace vanishing from
`list-workspaces` without ever being named in a `close-workspace` call, with 4
of its 6 agent processes dead — is not explained by this path. `removeWorkspace`
only ever removes the id it is given, and nothing else in the RPC touches
another workspace. Chasing it needs the daemon/main logs the reporter offered
(2026-08-04 00:50–01:15 +02:00); I have asked for them on the issue, so #799
stays open.

Worth noting the two symptoms are consistent in order: something removed
`Workspace 1` first, which left the scratch workspace as the last one, which is
what made its close get refused and produce the false receipt.

## Verification

- New `src/renderer/hooks/__tests__/useRpcBridge.workspaceClose.test.ts` — 5
  source-structural tests (`handleRpcMethod` is not exported and pulls in the
  store/window, same constraint as the existing `useRpcBridge.browserClose` /
  `useRpcBridge.focus` tests). Confirmed they fail 3/5 against the pre-fix
  handler.
- `npx vitest run src/renderer/hooks` — 556 passed.
- `tsc --noEmit` clean, eslint no new warnings.