### PR TITLE
docs(relay): correct which builds the sandbox worker serves

### DIFF
--- a/relay/wrangler.toml
+++ b/relay/wrangler.toml
@@ -23,7 +23,16 @@ enabled = true
 #                        serve rather than becoming an open proxy to Apple.
 
 # `wrangler deploy --env sandbox` publishes a second worker that talks to
-# Apple's sandbox host, for TestFlight/debug builds. Its secrets are separate.
+# Apple's sandbox host, for builds installed straight from Xcode — the ones
+# whose `aps-environment` entitlement reads `development`.
+#
+# TestFlight is NOT one of them. A TestFlight build is signed `production` and
+# its device tokens only resolve on Apple's production host, so pointing a
+# TestFlight install at this worker leaves `APNS_ENV` as a fallback that is
+# wrong for it. The per-request `apnsEnvironment` in src/index.ts covers for
+# that when the app reports its own stage, but the deployment default should
+# not need covering for: TestFlight and App Store installs belong on the
+# production worker above. Its secrets are separate.
 [env.sandbox]
 name = "wmux-push-relay-sandbox"
 


### PR DESCRIPTION
The sandbox worker's comment in `relay/wrangler.toml` claimed it was "for TestFlight/debug builds". Only the second half is right.

A TestFlight build is signed with `aps-environment: production` and its device tokens resolve only on Apple's production host. Pointing a TestFlight install at the sandbox worker therefore leaves `APNS_ENV` as a deployment default that is wrong for it. The per-request `apnsEnvironment` in `src/index.ts` still routes such a push correctly when the app reports its own stage, but that is a fallback covering for a misconfiguration rather than the intended shape.

Comment only — no behavior change.

## How this surfaced

While switching this Mac's relay LaunchAgent to the production worker ahead of the first TestFlight build, this comment is what made the sandbox worker look like the correct target for it.