### PR TITLE
fix(renderer): reset startup reconcile timeout on progress

### DIFF
--- a/changelog.d/805.md
+++ b/changelog.d/805.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Prevented slow startup reconciliation from clearing live terminal bindings.** Startup restore now measures stalled daemon stages instead of the total duration of multi-step list, promotion, and re-query work, so slow but responsive recovery no longer falls back to a blank slate. (#805)

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -58,6 +58,7 @@ import { FIRST_RUN_REOPEN_EVENT } from '../../../shared/firstRun';
 import { isFileDrag } from '../../../shared/dragDrop';
 import { terminalRegistry } from '../../hooks/useTerminal';
 import { resolvePtyIdsToClear } from '../../hooks/reconcileWithReQuery';
+import { runWithProgressTimeout } from '../../hooks/reconcileProgressTimeout';
 import { createLateReconcileOnConnect } from '../../hooks/lateReconcileOnConnect';
 import ProjectConfigDialog from '../Project/ProjectConfigDialog';
 import { probeProjectConfig, maybeAutoApplyProjectLayout, workspaceProbeCwd } from '../../utils/projectConfigProbe';
@@ -99,9 +100,9 @@ interface ReconcilePtySession extends DeadPaneSessionSnapshot {
  *     ▼                                      │
  *   gen = ++startupGenRef                    │
  *   abortCtl = new AbortController           │
- *   await raceWithAbort(                     │
- *     reconcilePtys(abortCtl.signal),        │
- *     RECONCILE_TIMEOUT_MS                   │
+ *   await runWithProgressTimeout(            │
+ *     report => reconcilePtys(signal, report),│
+ *     RECONCILE_TIMEOUT_MS (stall window)    │
  *   )                                        │
  *     │                                      │
  *     ├── success ──────────────────────────┤
@@ -118,10 +119,11 @@ interface ReconcilePtySession extends DeadPaneSessionSnapshot {
  * into reconcilePtys so its `signal.aborted` checks early-return.
  *
  * RCA A2 — RECONCILE_TIMEOUT_MS now lives in shared/timeouts.ts and is
- * derived as DAEMON_RPC_TIMEOUT_MS + 5s (= 15s). Previously this was a
- * standalone 5_000 that had drifted BELOW the 10s RPC ceiling, so a daemon
- * that answered pty.list in 6–9s under load still lost the race and the
- * startup catch wiped every live session via clearAllPtyState().
+ * derived as DAEMON_RPC_TIMEOUT_MS + 5s (= 15s). It is a rolling no-progress
+ * watchdog, re-armed after each reconcile IPC stage. A fixed total timeout is
+ * unsafe now that one pass can serially list, promote, and re-list sessions:
+ * two individually valid slow RPCs could otherwise exceed 15s and make the
+ * startup catch wipe every live session via clearAllPtyState().
  */
 
 /** Collect all terminal surfaces from a pane tree */
@@ -596,14 +598,25 @@ export default function AppLayout() {
   //      Terminal.tsx self-create on mount — the well-tested fresh-pane
   //      path. The mount gate guarantees Terminal mounts AFTER this
   //      reconcile resolves, so the race is gone.
-  const reconcilePtys = useCallback(async (signal?: AbortSignal): Promise<void> => {
+  const reconcilePtys = useCallback(async (
+    signal?: AbortSignal,
+    reportProgress?: () => void,
+  ): Promise<void> => {
     if (reconcileInFlightRef.current) {
       console.log('[AppLayout] reconcile already in flight — awaiting shared promise');
       return reconcileInFlightRef.current;
     }
     const run = (async () => {
       try {
-        const listResult = await ipcInvoke<ReconcilePtySession[]>(() =>
+        // Every remote stage gets the daemon RPC ceiling independently. Report
+        // completion so startup's rolling watchdog measures a stalled stage,
+        // not the total duration of a legitimate multi-RPC reconcile pass.
+        const invokeReconcile = async <T,>(call: () => Promise<T>) => {
+          const result = await ipcInvoke<T>(call);
+          reportProgress?.();
+          return result;
+        };
+        const listResult = await invokeReconcile<ReconcilePtySession[]>(() =>
           window.electronAPI.pty.list({ includeDead: true })
         );
         if (!listResult.ok) {
@@ -725,7 +738,7 @@ export default function AppLayout() {
           const stillAbsent: typeof absentCandidates = [];
           if (window.electronAPI?.pty?.promote) {
             // Ask the daemon for suspended sessions that match our absent ptyIds.
-            const allRes = await ipcInvoke<{ id: string; state?: string }[]>(() =>
+            const allRes = await invokeReconcile<{ id: string; state?: string }[]>(() =>
               window.electronAPI.pty.list({ includeSuspended: true }),
             );
             const suspendedIds = new Set(
@@ -740,7 +753,7 @@ export default function AppLayout() {
                 continue;
               }
               // Try to promote this suspended session.
-              const promoteRes = await ipcInvoke<{ success: boolean; error?: string }>(() =>
+              const promoteRes = await invokeReconcile<{ success: boolean; error?: string }>(() =>
                 window.electronAPI.pty.promote(candidate.ptyId),
               );
               if (promoteRes.ok && promoteRes.data.success) {
@@ -765,7 +778,7 @@ export default function AppLayout() {
           let secondSnapshot: { id: string; surfaceId?: string; createdAt?: string }[] | null = null;
           const toClear = await resolvePtyIdsToClear(firstAbsent, {
             reList: async () => {
-              const r = await ipcInvoke<{ id: string; surfaceId?: string; createdAt?: string }[]>(() => window.electronAPI.pty.list());
+              const r = await invokeReconcile<{ id: string; surfaceId?: string; createdAt?: string }[]>(() => window.electronAPI.pty.list());
               if (r.ok) secondSnapshot = r.data;
               return r.ok
                 ? { ok: true, ids: new Set(r.data.map((p: { id: string }) => p.id)) }
@@ -917,20 +930,20 @@ export default function AppLayout() {
           return;
         }
 
-        // Fix 0 — generation-tokened, AbortController-cancellable
-        // reconcile race. Timeout aborts the in-flight reconcile so
-        // late mutations don't overwrite the cleared-fallback state.
+        // Fix 0 — generation-tokened, AbortController-cancellable reconcile.
+        // The rolling watchdog aborts only after one stage makes no progress
+        // for the full budget; total duration may exceed one RPC timeout when
+        // list/promote/re-list stages each complete legitimately under load.
         abortCtl = new AbortController();
         const signal = abortCtl.signal;
-        await Promise.race([
-          reconcilePtys(signal),
-          new Promise<never>((_, reject) =>
-            setTimeout(() => {
-              abortCtl?.abort();
-              reject(new Error(`reconcile timeout after ${RECONCILE_TIMEOUT_MS}ms`));
-            }, RECONCILE_TIMEOUT_MS)
-          ),
-        ]);
+        await runWithProgressTimeout(
+          (reportProgress) => reconcilePtys(signal, reportProgress),
+          {
+            timeoutMs: RECONCILE_TIMEOUT_MS,
+            label: 'startup reconcile',
+            onTimeout: () => abortCtl?.abort(),
+          },
+        );
         // v2 RCA fix (axis A): persist the reconciled layout ON SUCCESS ONLY.
         // Rebinds/clears from a completed reconcile must reach disk now — not
         // wait for the 5s tick a reboot could pre-empt. Deliberately NOT in the

--- a/src/renderer/components/Layout/__tests__/appLayout.sessionSaveInvariants.test.ts
+++ b/src/renderer/components/Layout/__tests__/appLayout.sessionSaveInvariants.test.ts
@@ -15,6 +15,8 @@
  *   3. Rebind/clear actions apply through a compare-and-swap on the surface's
  *      CURRENT ptyId (a ≥600ms-stale snapshot must not stomp a ptyId that
  *      useTerminal's own reattach already replaced — Claude adversarial P2).
+ *   4. Startup's timeout is a rolling no-progress watchdog, and every remote
+ *      reconcile stage resets it (a valid multi-RPC pass may exceed 15s).
  */
 import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
@@ -38,6 +40,35 @@ describe('AppLayout — axis A session-save invariants', () => {
     expect(finallyIdx).toBeGreaterThan(0);
     const finallyBlock = region.slice(finallyIdx, region.indexOf('})();', finallyIdx));
     expect(finallyBlock).not.toContain('saveSessionNow');
+  });
+
+  it('uses a rolling progress timeout and routes every reconcile IPC through it', () => {
+    const startup = startupRegion();
+    expect(startup).toContain('runWithProgressTimeout(');
+    expect(startup).toMatch(/reconcilePtys\(signal, reportProgress\)/);
+    expect(startup).not.toContain('Promise.race([');
+
+    const reconcileStart = source.indexOf('const reconcilePtys = useCallback');
+    const reconcileEnd = source.indexOf('// 앱 시작 시 세션 복원', reconcileStart);
+    expect(reconcileStart, 'reconcile callback not found').toBeGreaterThanOrEqual(0);
+    expect(reconcileEnd, 'startup effect boundary not found').toBeGreaterThan(reconcileStart);
+    const reconcile = source.slice(reconcileStart, reconcileEnd);
+
+    const helperStart = reconcile.indexOf('const invokeReconcile = async <T,>');
+    const firstStageStart = reconcile.indexOf('const listResult = await invokeReconcile', helperStart);
+    expect(helperStart, 'progress-aware IPC helper not found').toBeGreaterThanOrEqual(0);
+    expect(firstStageStart, 'first reconcile IPC stage not found').toBeGreaterThan(helperStart);
+
+    const helper = reconcile.slice(helperStart, firstStageStart);
+    expect(helper).toMatch(
+      /const result = await ipcInvoke<T>\(call\);\s*reportProgress\?\.\(\);\s*return result;/,
+    );
+
+    // Keep the invariant extensible: every current or future reconcile IPC
+    // stage must use the progress-aware helper, without pinning an exact count.
+    const stages = reconcile.slice(firstStageStart);
+    expect(stages).not.toMatch(/await ipcInvoke</);
+    expect(stages).toMatch(/await invokeReconcile</);
   });
 
   it('registered saver and beforeunload share the sessionLoadedRef guard', () => {

--- a/src/renderer/hooks/__tests__/reconcileProgressTimeout.test.ts
+++ b/src/renderer/hooks/__tests__/reconcileProgressTimeout.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { runWithProgressTimeout } from '../reconcileProgressTimeout';
+
+describe('runWithProgressTimeout', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('allows a multi-step reconcile to exceed one timeout window while each step makes progress', async () => {
+    vi.useFakeTimers();
+    const onTimeout = vi.fn();
+
+    const run = runWithProgressTimeout(
+      async (reportProgress) => {
+        for (let step = 0; step < 3; step++) {
+          await new Promise<void>((resolve) => setTimeout(resolve, 900));
+          reportProgress();
+        }
+        return 'reconciled';
+      },
+      { timeoutMs: 1_000, label: 'startup reconcile', onTimeout },
+    );
+
+    await vi.advanceTimersByTimeAsync(2_700);
+
+    await expect(run).resolves.toBe('reconciled');
+    expect(onTimeout).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('starts a fresh timeout window after progress and still rejects a later stalled step', async () => {
+    vi.useFakeTimers();
+    const onTimeout = vi.fn();
+
+    const run = runWithProgressTimeout(
+      async (reportProgress) => {
+        await new Promise<void>((resolve) => setTimeout(resolve, 900));
+        reportProgress();
+        await new Promise<never>(() => { /* next stage stalled */ });
+      },
+      { timeoutMs: 1_000, label: 'startup reconcile', onTimeout },
+    );
+    const rejected = expect(run).rejects.toThrow(
+      'startup reconcile made no progress for 1000ms',
+    );
+
+    await vi.advanceTimersByTimeAsync(1_899);
+    expect(onTimeout).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await rejected;
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects and invokes the timeout hook when one step stops making progress', async () => {
+    vi.useFakeTimers();
+    const onTimeout = vi.fn();
+    const run = runWithProgressTimeout(
+      async () => new Promise<never>(() => { /* stalled */ }),
+      { timeoutMs: 1_000, label: 'startup reconcile', onTimeout },
+    );
+    const rejected = expect(run).rejects.toThrow(
+      'startup reconcile made no progress for 1000ms',
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await rejected;
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the watchdog when the work rejects on its own', async () => {
+    vi.useFakeTimers();
+    const onTimeout = vi.fn();
+    const failure = new Error('pty.list failed');
+
+    const run = runWithProgressTimeout(
+      async () => { throw failure; },
+      { timeoutMs: 1_000, label: 'startup reconcile', onTimeout },
+    );
+
+    await expect(run).rejects.toBe(failure);
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/hooks/reconcileProgressTimeout.ts
+++ b/src/renderer/hooks/reconcileProgressTimeout.ts
@@ -1,0 +1,66 @@
+/**
+ * Run a multi-step operation with a rolling no-progress watchdog.
+ *
+ * A fixed wall-clock timeout is unsafe for startup reconcile because one pass
+ * can legitimately perform several serial daemon RPCs. Each RPC has its own
+ * bounded timeout, so the watchdog should fire only when one stage stops making
+ * progress, not merely because the complete pass took longer than one RPC.
+ */
+
+export interface ProgressTimeoutOptions {
+  timeoutMs: number;
+  label: string;
+  /** Called immediately before the watchdog rejects (for example, to abort IO). */
+  onTimeout?: () => void;
+}
+
+export function runWithProgressTimeout<T>(
+  work: (reportProgress: () => void) => Promise<T>,
+  options: ProgressTimeoutOptions,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearWatchdog = () => {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+
+    const armWatchdog = () => {
+      if (settled) return;
+      clearWatchdog();
+      timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        timer = null;
+        try {
+          options.onTimeout?.();
+        } catch {
+          // Timeout reporting must not replace the original watchdog failure.
+        }
+        reject(new Error(`${options.label} made no progress for ${options.timeoutMs}ms`));
+      }, options.timeoutMs);
+    };
+
+    armWatchdog();
+    void Promise.resolve()
+      .then(() => work(armWatchdog))
+      .then(
+        (value) => {
+          if (settled) return;
+          settled = true;
+          clearWatchdog();
+          resolve(value);
+        },
+        (error: unknown) => {
+          if (settled) return;
+          settled = true;
+          clearWatchdog();
+          reject(error);
+        },
+      );
+  });
+}

--- a/src/renderer/hooks/reconcileWithReQuery.ts
+++ b/src/renderer/hooks/reconcileWithReQuery.ts
@@ -41,9 +41,9 @@ export interface ReconcileReQueryDeps {
 }
 
 /**
- * Backoff before the second daemon snapshot. Kept well under
- * RECONCILE_TIMEOUT_MS (DAEMON_RPC_TIMEOUT_MS + 5s = 15s) so one backoff plus
- * a second pty.list round-trip still fits the reconcile budget.
+ * Backoff before the second daemon snapshot. Kept well under the rolling
+ * RECONCILE_TIMEOUT_MS no-progress window (DAEMON_RPC_TIMEOUT_MS + 5s = 15s)
+ * so this backoff plus one pty.list round-trip fits within a single stage.
  */
 export const RECONCILE_REQUERY_BACKOFF_MS = 600;
 

--- a/src/shared/timeouts.ts
+++ b/src/shared/timeouts.ts
@@ -9,9 +9,11 @@
  * `clearAllPtyState()`, replacing every live session with a fresh empty one.
  *
  * The invariant that must hold: RECONCILE_TIMEOUT_MS > DAEMON_RPC_TIMEOUT_MS,
- * so the RPC always gets a chance to resolve (or reject) before the renderer
- * gives up and falls back to its destructive path. Derive one from the other
- * here and import on both sides so they can never drift again.
+ * so each RPC always gets a chance to resolve (or reject) before the renderer
+ * gives up and falls back to its destructive path. Startup uses this as a
+ * rolling no-progress watchdog because one reconcile pass can contain several
+ * serial RPCs; late reconnect uses it as a non-destructive total abort budget.
+ * Derive one from the other here so the per-stage ordering cannot drift again.
  *
  * This module has zero runtime dependencies and is safe to import from the
  * daemon, main, and renderer bundles alike.
@@ -21,8 +23,8 @@
 export const DAEMON_RPC_TIMEOUT_MS = 10_000;
 
 /**
- * Renderer startup reconcile timeout. Must exceed the RPC ceiling with a
- * margin so a single slow-but-successful `pty.list` (= daemon.listSessions)
+ * Renderer reconcile timeout. Must exceed the RPC ceiling with a margin so a
+ * single slow-but-successful daemon stage (including the re-query backoff)
  * never trips the destructive startup fallback.
  */
 export const RECONCILE_TIMEOUT_MS = DAEMON_RPC_TIMEOUT_MS + 5_000;


### PR DESCRIPTION
## Summary

- replace startup reconcile's fixed 15-second total timeout with a rolling no-progress watchdog
- reset the watchdog after every completed reconcile IPC stage, including each suspended-session promotion
- preserve the existing abort and blank-slate fallback when one stage genuinely stalls
- add deterministic coverage for multi-stage progress, post-progress stalls, timer cleanup, and AppLayout wiring

## Root cause

Startup reconcile can now serially perform the initial `pty.list`, an `includeSuspended` list, one or more promotions, a 600 ms backoff, and a second `pty.list`. Each daemon RPC independently permits up to 10 seconds, so two valid slow stages can exceed the old fixed 15-second total budget. That made a healthy reconcile lose the race and enter AppLayout's destructive `clearAllPtyState()` fallback.

The timeout is now a rolling stall window. Each completed remote stage reports progress and re-arms the watchdog. A stage that makes no progress for the full window still aborts and follows the existing fallback.

## Audit context

This defect was found while auditing #799, but the reporter's logs are still absent. It is **not** a confirmed root cause of the vanished workspace reported there, and this PR does not close or claim to resolve #799.

## Verification

- `npx vitest run src/renderer/hooks/__tests__/reconcileProgressTimeout.test.ts src/renderer/hooks/__tests__/reconcileWithReQuery.test.ts src/renderer/hooks/__tests__/lateReconcileOnConnect.test.ts src/renderer/components/Layout/__tests__/appLayout.sessionSaveInvariants.test.ts` — 4 files, 29 tests passed
- `npm run test:parallel` — 689 files passed, 3 skipped; 10,148 tests passed, 27 skipped
- `npx tsc --noEmit` — passed
- `npx vite build --config vite.renderer.config.ts` — passed
- strict lint passed for the five other touched TypeScript files; full-file AppLayout lint has the same 4 errors / 5 warnings on untouched `upstream/main`
- `npm run test:runtime` — 140 passed, 10 skipped, 2 failed under local Node 24.18.0; both failures are the existing PowerShell `shellIntegration.runtime.test.ts` / node-pty `AttachConsole failed` baseline and reproduce unchanged on untouched `upstream/main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup recovery for slow terminal connections.
  - Prevented active terminal bindings from being cleared while multi-stage reconciliation is still making progress.
  - Startup recovery now times out only after a stage stalls, rather than after the total recovery process exceeds a fixed duration.

- **Tests**
  - Added coverage for progress-based timeout handling, stalled stages, failures, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->