### PR TITLE
feat(terminal): floating scroll-to-bottom button when scrolled up

### DIFF
--- a/changelog.d/806.md
+++ b/changelog.d/806.md
@@ -1,0 +1,7 @@
+### Added
+
+- **Scroll-to-bottom button on the terminal.** When a terminal's scrollback
+  runs far ahead of the viewport, a small button now appears at the
+  bottom-right; one click returns to the latest output. It shows only while
+  you are scrolled up and hides again the moment you are back at the bottom.
+  (#806)

--- a/src/renderer/components/Terminal/ScrollToBottomButton.tsx
+++ b/src/renderer/components/Terminal/ScrollToBottomButton.tsx
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { Terminal } from '@xterm/xterm';
+import { useT } from '../../hooks/useT';
+import { FOCUS_RING } from '../focusRing';
+
+/**
+ * Floating "scroll to bottom" button. Appears at the bottom-right of the
+ * terminal ONLY while the user is scrolled up (not following output) and
+ * disappears the moment they are back at the bottom. Clicking jumps to the
+ * latest output.
+ *
+ * Per DESIGN.md's "no dead gauges" rule: never a permanent overlay over the
+ * terminal hero — the affordance exists exactly when scrollback has run far
+ * ahead and is otherwise invisible.
+ */
+export default function ScrollToBottomButton({ terminal }: { terminal: Terminal | null }) {
+  const t = useT();
+  const [scrolledUp, setScrolledUp] = useState(false);
+
+  const update = useCallback(() => {
+    if (!terminal) {
+      setScrolledUp(false);
+      return;
+    }
+    // xterm: at the bottom means viewportY equals baseY (following output);
+    // scrolled up means viewportY < baseY. Same relation the resize
+    // preservation logic in useTerminal relies on.
+    const { baseY, viewportY } = terminal.buffer.active;
+    setScrolledUp(viewportY < baseY);
+  }, [terminal]);
+
+  // Re-evaluate on scroll, on new output (baseY grows / viewport shifts),
+  // and on resize (rows change the at-bottom relation). Setting the same
+  // boolean value is a no-op for React, so an output flood does not re-render.
+  useEffect(() => {
+    if (!terminal) return;
+    update();
+    const subs = [
+      terminal.onScroll(update),
+      terminal.onWriteParsed(update),
+      terminal.onResize(update),
+    ];
+    return () => subs.forEach((d) => d.dispose());
+  }, [terminal, update]);
+
+  if (!terminal || !scrolledUp) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => terminal.scrollToBottom()}
+      title={t('terminal.scrollToBottom')}
+      aria-label={t('terminal.scrollToBottom')}
+      className={`absolute bottom-3 right-4 z-20 flex h-7 w-7 cursor-pointer items-center justify-center rounded-[5px] border bg-[color-mix(in_srgb,var(--bg-surface)_72%,transparent)] border-[color-mix(in_srgb,var(--text-main)_10%,transparent)] text-[var(--text-muted)] shadow-[inset_0_1px_0_color-mix(in_srgb,var(--text-main)_6%,transparent)] transition-colors hover:bg-[var(--bg-surface)] hover:border-[color-mix(in_srgb,var(--text-main)_16%,transparent)] hover:text-[var(--accent)] hover:shadow-[0_1px_3px_rgba(0,0,0,0.25)] ${FOCUS_RING}`}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M3 5.5 7 9l4-3.5" />
+      </svg>
+    </button>
+  );
+}

--- a/src/renderer/components/Terminal/Terminal.tsx
+++ b/src/renderer/components/Terminal/Terminal.tsx
@@ -12,6 +12,7 @@ import ViCopyMode from './ViCopyMode';
 import SearchBar from './SearchBar';
 import BookmarkIndicator from './BookmarkIndicator';
 import ContextMenu from './ContextMenu';
+import ScrollToBottomButton from './ScrollToBottomButton';
 import '@xterm/xterm/css/xterm.css';
 
 const EMPTY_BOOKMARKS: number[] = [];
@@ -407,6 +408,9 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
         bookmarks={bookmarks}
         containerRef={containerRef}
       />
+
+      {/* Floating scroll-to-bottom button — appears only when scrolled up */}
+      <ScrollToBottomButton terminal={terminalRef.current} />
 
       {/* Search bar overlay */}
       {showSearchBar && (

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -269,6 +269,7 @@ export const en = {
   'terminal.openPathBlocked': 'Executable blocked — opened parent folder',
   'terminal.openPathFailed': "Couldn't open — showing folder",
   'terminal.bookmarkAdded': 'Bookmark added',
+  'terminal.scrollToBottom': 'Scroll to bottom',
   'terminal.imeInputRecovered': 'Keyboard input was stuck in the IME and has been recovered automatically',
 
   // Context menu


### PR DESCRIPTION
## Summary

When a terminal's scrollback runs far ahead of the current viewport, there
was no one-click way to get back to the latest output — you had to mouse it
all the way down or use the scrollbar. This PR adds a **scroll-to-bottom
button**: a small chip floating at the bottom-right of the terminal that
appears only while you are scrolled up, and jumps to the latest output on
click.

Per DESIGN.md's "no dead gauges" rule, it is invisible at rest — the
affordance exists exactly when scrollback has run ahead, and disappears the
moment you are back at the bottom.

## Design

- **Auto-hide, not always-on.** The button is rendered only while the user is
  scrolled up. This avoids any permanent chrome over the terminal hero.
- **Bare arrow icon.** A monochrome chevron; per the 5±2 amber-points grammar
  it does not show a distance count. Warm accent appears on hover only.
- **Scroll semantics reused from the existing code.** The "scrolled up"
  state mirrors the resize-preservation logic in `useTerminal`:
  `viewportY < baseY` means scrolled up; `viewportY === baseY` means at the
  bottom (following output). So the button's visibility judgement is provably
  consistent with the rest of the terminal.
- **`scrollToBottom()`.** Clicking calls xterm's built-in `scrollToBottom()`.

## Changes

- **New `ScrollToBottomButton.tsx`** — floating button component. Subscribes
  to `onScroll`, `onWriteParsed` (new output / baseY growth), and `onResize`,
  refreshing the scrolled-up boolean each time; React bails out on unchanged
  values, so an output flood does not cause re-render churn. Disposables are
  cleaned up on unmount. Uses the app's established gpui raised-button recipe
  (`bg-surface` fill + hairline + inset highlight), `FOCUS_RING`, and the
  `useT` i18n hook.
- **`Terminal.tsx`** — renders the button as an overlay next to
  `BookmarkIndicator`, passing `terminalRef.current`.
- **`en.ts`** — adds the `terminal.scrollToBottom` i18n key (other locales
  fall back to English).

## Test plan

- [ ] `npm start`, open a pane, generate a long scrollback (e.g. `seq 1 5000`)
- [ ] Scroll up → button appears bottom-right; scroll back to bottom → it
      disappears
- [ ] Click the button while scrolled up → jumps to the latest output
- [ ] While following output at the bottom, new output arrives → button stays
      hidden and terminal keeps following
- [ ] Resize the pane while scrolled up → button state stays correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a terminal “Scroll to bottom” button that appears when viewing earlier output.
  - Clicking the button returns the terminal viewport to the latest output.
  - Added accessible English labeling for the new control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->