### PR TITLE
fix(hooks): make the AskUserQuestion answered-locally signal actually fire

### DIFF
--- a/changelog.d/808.md
+++ b/changelog.d/808.md
@@ -8,3 +8,8 @@
   alone (and the OpenClaude bridge, which was missing the promotion entirely,
   gained it too), so the pending card expires within seconds of the local
   answer. (#808)
+- **A question answered on the PC no longer cancels a permission request
+  waiting on your phone.** Clearing the answered question swept every pending
+  approval on that pane, so a tool permission the same turn had asked for
+  disappeared from the inbox and fell back to the local prompt. Each now
+  clears only its own kind of request. (#808)

--- a/changelog.d/808.md
+++ b/changelog.d/808.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Questions answered on the PC now clear from the phone approval inbox
+  right away.** The signal that reports a locally answered AskUserQuestion
+  never actually fired: the hook bridge required a payload field Claude Code
+  does not send, so answered questions sat as pending ghost cards until the
+  agent's turn ended. The bridge now promotes the answer on the tool name
+  alone (and the OpenClaude bridge, which was missing the promotion entirely,
+  gained it too), so the pending card expires within seconds of the local
+  answer. (#808)

--- a/integrations/claude/__tests__/bridgeInputAnswered.test.ts
+++ b/integrations/claude/__tests__/bridgeInputAnswered.test.ts
@@ -1,0 +1,89 @@
+/**
+ * PostToolUse kind promotion (#770).
+ *
+ * A locally-answered AskUserQuestion must reach the daemon as
+ * `agent.input_answered` so the pending approval record — the card a phone is
+ * still showing — is expired the moment the user answers on the PC, instead of
+ * waiting for the `agent.stop` backstop at the end of a turn.
+ *
+ * This file exists because the first cut of the promotion additionally
+ * required `payload.fired`, a field Claude Code's PostToolUse payload does not
+ * carry, so the branch was unreachable and every AskUserQuestion still went out
+ * as a plain activity stamp. Assert against payloads shaped like the real hook
+ * contract (session_id / transcript_path / cwd / tool_name / tool_input /
+ * tool_response) and nothing else.
+ *
+ * Same harness as bridgeActivityThrottle.test.ts: strip the CLI entrypoint,
+ * re-export the function under test, dynamic-import a temp copy.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const BRIDGE_PATH = path.resolve(process.cwd(), 'integrations/claude/bin/wmux-bridge.mjs');
+const ENTRYPOINT_MARKER = '// Run; never throw upward';
+
+let tmp: string;
+let getPostToolUseKind: (payload: unknown) => string;
+
+/** A PostToolUse payload with exactly the fields Claude Code sends. */
+function postToolUsePayload(toolName: string) {
+  return {
+    session_id: 'c0ffee00-0000-4000-8000-000000000000',
+    transcript_path: '/home/u/.claude/projects/p/c0ffee00-0000-4000-8000-000000000000.jsonl',
+    cwd: '/home/u/project',
+    hook_event_name: 'PostToolUse',
+    tool_name: toolName,
+    tool_input: {},
+    tool_response: {},
+  };
+}
+
+beforeAll(async () => {
+  tmp = mkdtempSync(path.join(tmpdir(), 'wmux-bridge-answered-'));
+  const src = readFileSync(BRIDGE_PATH, 'utf8');
+  const cut = src.indexOf(ENTRYPOINT_MARKER);
+  expect(cut).toBeGreaterThan(-1);
+  const testable = src.slice(0, cut).replace(/^#![^\n]*\n/, '')
+    + '\nexport { getPostToolUseKind };\n';
+  const mod = path.join(tmp, 'bridge-under-test.mjs');
+  writeFileSync(mod, testable, 'utf8');
+  ({ getPostToolUseKind } = await import(pathToFileURL(mod).href));
+});
+
+afterAll(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('getPostToolUseKind', () => {
+  it('promotes a completed AskUserQuestion to agent.input_answered', () => {
+    expect(getPostToolUseKind(postToolUsePayload('AskUserQuestion')))
+      .toBe('agent.input_answered');
+  });
+
+  it('does not depend on any field beyond tool_name', () => {
+    // Regression guard for the `payload.fired` predicate: the real payload
+    // never carries it, so requiring it made the promotion dead code.
+    expect(getPostToolUseKind({ tool_name: 'AskUserQuestion' }))
+      .toBe('agent.input_answered');
+  });
+
+  it('leaves every other tool as a plain activity stamp', () => {
+    for (const tool of ['Bash', 'Read', 'Edit', 'Write', 'Task', 'WebFetch']) {
+      expect(getPostToolUseKind(postToolUsePayload(tool))).toBe('agent.activity');
+    }
+  });
+
+  it('falls back to activity for a missing or malformed payload', () => {
+    expect(getPostToolUseKind(undefined)).toBe('agent.activity');
+    expect(getPostToolUseKind(null)).toBe('agent.activity');
+    expect(getPostToolUseKind({})).toBe('agent.activity');
+  });
+
+  it('is not fooled by a tool whose name merely contains AskUserQuestion', () => {
+    expect(getPostToolUseKind(postToolUsePayload('mcp__x__AskUserQuestion')))
+      .toBe('agent.activity');
+  });
+});

--- a/integrations/claude/__tests__/bridgeInputAnswered.test.ts
+++ b/integrations/claude/__tests__/bridgeInputAnswered.test.ts
@@ -13,6 +13,10 @@
  * contract (session_id / transcript_path / cwd / tool_name / tool_input /
  * tool_response) and nothing else.
  *
+ * Both bridges are checked. They are separate hand-maintained JS files (the
+ * OpenClaude one is a slimmed adaptation, not a byte copy), so a promotion
+ * added to one silently skips the other unless something asserts on both.
+ *
  * Same harness as bridgeActivityThrottle.test.ts: strip the CLI entrypoint,
  * re-export the function under test, dynamic-import a temp copy.
  */
@@ -22,11 +26,14 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-const BRIDGE_PATH = path.resolve(process.cwd(), 'integrations/claude/bin/wmux-bridge.mjs');
+const BRIDGES = [
+  ['claude', 'integrations/claude/bin/wmux-bridge.mjs'],
+  ['openclaude', 'integrations/openclaude/bin/wmux-bridge.mjs'],
+] as const;
 const ENTRYPOINT_MARKER = '// Run; never throw upward';
 
 let tmp: string;
-let getPostToolUseKind: (payload: unknown) => string;
+const kindOf: Record<string, (payload: unknown) => string> = {};
 
 /** A PostToolUse payload with exactly the fields Claude Code sends. */
 function postToolUsePayload(toolName: string) {
@@ -43,47 +50,49 @@ function postToolUsePayload(toolName: string) {
 
 beforeAll(async () => {
   tmp = mkdtempSync(path.join(tmpdir(), 'wmux-bridge-answered-'));
-  const src = readFileSync(BRIDGE_PATH, 'utf8');
-  const cut = src.indexOf(ENTRYPOINT_MARKER);
-  expect(cut).toBeGreaterThan(-1);
-  const testable = src.slice(0, cut).replace(/^#![^\n]*\n/, '')
-    + '\nexport { getPostToolUseKind };\n';
-  const mod = path.join(tmp, 'bridge-under-test.mjs');
-  writeFileSync(mod, testable, 'utf8');
-  ({ getPostToolUseKind } = await import(pathToFileURL(mod).href));
+  for (const [name, rel] of BRIDGES) {
+    const src = readFileSync(path.resolve(process.cwd(), rel), 'utf8');
+    const cut = src.indexOf(ENTRYPOINT_MARKER);
+    expect(cut, `${rel} entrypoint marker`).toBeGreaterThan(-1);
+    const testable = src.slice(0, cut).replace(/^#![^\n]*\n/, '')
+      + '\nexport { getPostToolUseKind };\n';
+    const mod = path.join(tmp, `${name}-under-test.mjs`);
+    writeFileSync(mod, testable, 'utf8');
+    ({ getPostToolUseKind: kindOf[name] } = await import(pathToFileURL(mod).href));
+  }
 });
 
 afterAll(() => {
   rmSync(tmp, { recursive: true, force: true });
 });
 
-describe('getPostToolUseKind', () => {
+describe.each(BRIDGES.map(([name]) => name))('%s bridge getPostToolUseKind', (name) => {
   it('promotes a completed AskUserQuestion to agent.input_answered', () => {
-    expect(getPostToolUseKind(postToolUsePayload('AskUserQuestion')))
+    expect(kindOf[name](postToolUsePayload('AskUserQuestion')))
       .toBe('agent.input_answered');
   });
 
   it('does not depend on any field beyond tool_name', () => {
     // Regression guard for the `payload.fired` predicate: the real payload
     // never carries it, so requiring it made the promotion dead code.
-    expect(getPostToolUseKind({ tool_name: 'AskUserQuestion' }))
+    expect(kindOf[name]({ tool_name: 'AskUserQuestion' }))
       .toBe('agent.input_answered');
   });
 
   it('leaves every other tool as a plain activity stamp', () => {
     for (const tool of ['Bash', 'Read', 'Edit', 'Write', 'Task', 'WebFetch']) {
-      expect(getPostToolUseKind(postToolUsePayload(tool))).toBe('agent.activity');
+      expect(kindOf[name](postToolUsePayload(tool))).toBe('agent.activity');
     }
   });
 
   it('falls back to activity for a missing or malformed payload', () => {
-    expect(getPostToolUseKind(undefined)).toBe('agent.activity');
-    expect(getPostToolUseKind(null)).toBe('agent.activity');
-    expect(getPostToolUseKind({})).toBe('agent.activity');
+    expect(kindOf[name](undefined)).toBe('agent.activity');
+    expect(kindOf[name](null)).toBe('agent.activity');
+    expect(kindOf[name]({})).toBe('agent.activity');
   });
 
   it('is not fooled by a tool whose name merely contains AskUserQuestion', () => {
-    expect(getPostToolUseKind(postToolUsePayload('mcp__x__AskUserQuestion')))
+    expect(kindOf[name](postToolUsePayload('mcp__x__AskUserQuestion')))
       .toBe('agent.activity');
   });
 });

--- a/integrations/claude/bin/wmux-bridge.mjs
+++ b/integrations/claude/bin/wmux-bridge.mjs
@@ -87,11 +87,21 @@ const HOOK_TO_KIND = {
   UserPromptSubmit: 'agent.user_prompt_submit',
 };
 
-// Determine signal kind for PostToolUse: if it's AskUserQuestion that fired
-// (completed), treat as input_answered (user answered locally); otherwise as
-// activity. Fired is true only on PostToolUse — PreToolUse never sets it.
+// Determine the signal kind for a PostToolUse hook. AskUserQuestion completing
+// means the user answered it right here on this machine, so it is promoted to
+// agent.input_answered — the daemon expires the approval record that a remote
+// device is still showing as pending (#770). Every other tool stays a plain
+// activity stamp.
+//
+// Only the tool name is consulted. PostToolUse fires exclusively AFTER a tool
+// completes, so reaching this function at all already means "it finished";
+// there is no second payload field to confirm that. (An earlier revision also
+// required `payload.fired`, which Claude Code's PostToolUse payload does not
+// carry — the promotion could never fire and #770 stayed broken.) Callers only
+// invoke this for hookName === 'PostToolUse', so a PreToolUse AskUserQuestion
+// can never reach it and be mistaken for an answer.
 function getPostToolUseKind(payload) {
-  if (payload && payload.tool_name === 'AskUserQuestion' && payload.fired) {
+  if (payload && payload.tool_name === 'AskUserQuestion') {
     return 'agent.input_answered';
   }
   return 'agent.activity';

--- a/integrations/openclaude/bin/wmux-bridge.mjs
+++ b/integrations/openclaude/bin/wmux-bridge.mjs
@@ -50,6 +50,18 @@ const HOOK_TO_KIND = {
   SessionStart: 'agent.session_start',
 };
 
+// AskUserQuestion completing means the user answered it on this machine, so
+// PostToolUse is promoted to agent.input_answered and the daemon expires the
+// approval record a remote device is still showing as pending (#770). Every
+// other tool stays a plain activity stamp. PostToolUse only runs after a tool
+// completes, so the tool name is the whole signal.
+function getPostToolUseKind(payload) {
+  if (payload && payload.tool_name === 'AskUserQuestion') {
+    return 'agent.input_answered';
+  }
+  return 'agent.activity';
+}
+
 // ----- Path helpers (Node built-ins only) ---------------------------------
 
 function getAuthTokenPath() {
@@ -516,7 +528,9 @@ async function main() {
 
   // Build the AgentSignal envelope.
   const envelope = {
-    kind: HOOK_TO_KIND[hookName],
+    kind: hookName === 'PostToolUse'
+      ? getPostToolUseKind(payload)
+      : HOOK_TO_KIND[hookName],
     agent: 'openclaude',
     agentSessionId: sessionIdFromTranscript(
       transcriptPath,

--- a/src/cli/commands/setupHooks.ts
+++ b/src/cli/commands/setupHooks.ts
@@ -48,7 +48,7 @@ const HOOK_EVENTS = ['Stop', 'SubagentStop', 'SessionStart'] as const;
 /**
  * AskUserQuestion-scoped hook pair that drives the in-app approval card:
  *   PreToolUse  → card created  (agent.awaiting_input)
- *   PostToolUse → card expired   (agent.input_answered, fired:true)
+ *   PostToolUse → card expired   (agent.input_answered, on tool name alone)
  * Both are scoped to the AskUserQuestion matcher so they fire ONCE per
  * question, not on every tool call. The 2026-07-13 PostToolUse removal was
  * about a matcher:'' cost — a ~110ms node bridge per tool call feeding the

--- a/src/daemon/approvals/ApprovalRegistry.ts
+++ b/src/daemon/approvals/ApprovalRegistry.ts
@@ -346,10 +346,26 @@ export class ApprovalRegistry implements ApprovalRegistryApi, ApprovalHookSink {
    * `agent.subagent_stop` deliberately does NOT expire: a subagent finishing
    * says nothing about the main agent's question still sitting on screen.
    *
+   * `kind` narrows the sweep to one record kind. A locally answered
+   * AskUserQuestion says nothing about a permission gate the same turn opened
+   * in parallel, and expiring one drops its waiter (see expirePendingWhere) —
+   * the tool falls back to the local prompt while the phone operator, watching
+   * only the phone, sees the card vanish. That is the exact harm the supersede
+   * rule in noteHookAwaitingInput already refuses to cause; the sweep has to
+   * refuse it too. Omitted ⇒ every kind, which is what the turn/pane-lifecycle
+   * callers want.
+   *
    * Returns the settled promise for the same reason noteHookAwaitingInput does.
    */
-  expireForSession(sessionId: string, reason: ApprovalExpiryReason): Promise<void> {
-    return this.mutate(() => this.expirePendingWhere((r) => r.sessionId === sessionId, reason));
+  expireForSession(
+    sessionId: string,
+    reason: ApprovalExpiryReason,
+    kind?: ApprovalRequest['kind'],
+  ): Promise<void> {
+    return this.mutate(() => this.expirePendingWhere(
+      (r) => r.sessionId === sessionId && (kind === undefined || r.kind === kind),
+      reason,
+    ));
   }
 
   /**

--- a/src/daemon/approvals/__tests__/ApprovalRegistry.test.ts
+++ b/src/daemon/approvals/__tests__/ApprovalRegistry.test.ts
@@ -255,6 +255,56 @@ describe('ApprovalRegistry — supersede and expire', () => {
     expect(h.events.filter((e) => e.type === 'expire')).toHaveLength(1);
   });
 
+  /**
+   * A turn that opens SEVERAL gated tools plus an AskUserQuestion. Only one
+   * pending record is superseded when the question arrives, so a second gate
+   * stays pending alongside it — the one way the two kinds coexist (a gate
+   * never supersedes another gate; see noteGateAwaiting).
+   */
+  async function gatesPlusQuestion(dropped: string[]): Promise<{ h: Harness; survivor: string }> {
+    const h = makeRegistry({ notifyGateDropped: (id) => { dropped.push(id); } });
+    await h.registry.noteGateAwaiting({
+      sessionId: 'pty-a', agent: 'claude', workspaceId: 'ws-1', toolName: 'Bash',
+    });
+    await settle();
+    const survivor = await h.registry.noteGateAwaiting({
+      sessionId: 'pty-a', agent: 'claude', workspaceId: 'ws-1', toolName: 'Write',
+    });
+    await settle();
+    await awaitingInput(h.registry, 'pty-a');
+    await settle();
+    return { h, survivor };
+  }
+
+  it('expireForSession scoped to awaiting_input leaves a pending gate and its waiter alive', async () => {
+    // #770 — answering the question on the PC says nothing about a gate the
+    // same turn opened. Sweeping it drops its waiter, so the tool falls back
+    // to the local prompt while the phone operator just sees the card vanish.
+    const dropped: string[] = [];
+    const { h, survivor } = await gatesPlusQuestion(dropped);
+    dropped.length = 0; // the question's own supersede already dropped one gate
+
+    await h.registry.expireForSession('pty-a', 'answered-locally', 'awaiting_input');
+    await settle();
+
+    const { pending } = h.registry.list();
+    expect(pending.map((r) => r.kind)).toEqual(['awaiting_permission']);
+    expect(pending[0].id).toBe(survivor);
+    expect(dropped).toEqual([]);
+  });
+
+  it('an unscoped expireForSession still sweeps every kind (turn-ended backstop)', async () => {
+    const dropped: string[] = [];
+    const { h, survivor } = await gatesPlusQuestion(dropped);
+    dropped.length = 0;
+
+    await h.registry.expireForSession('pty-a', 'turn-ended');
+    await settle();
+
+    expect(h.registry.list().pending).toHaveLength(0);
+    expect(dropped).toEqual([survivor]);
+  });
+
   it('expiring a pane with nothing pending emits nothing', async () => {
     const h = makeRegistry();
     await h.registry.expireForSession('pty-a', 'pane-gone');

--- a/src/daemon/approvals/types.ts
+++ b/src/daemon/approvals/types.ts
@@ -252,7 +252,12 @@ export interface ApprovalHookSink {
     toolName: string;
     toolInputSummary?: string;
   }): string;
-  expireForSession(sessionId: string, reason: ApprovalExpiryReason): void;
+  /** `kind` narrows the sweep to one record kind; omitted ⇒ every kind. */
+  expireForSession(
+    sessionId: string,
+    reason: ApprovalExpiryReason,
+    kind?: ApprovalRequest['kind'],
+  ): void;
 }
 
 export interface ApprovalListResult {

--- a/src/daemon/hooks/HookIngest.ts
+++ b/src/daemon/hooks/HookIngest.ts
@@ -605,7 +605,7 @@ export class HookIngest {
 
     // User answered a pending approval locally — no turn boundary, just expire the request.
     if (signal.kind === 'agent.input_answered') {
-      this.deps.approvals?.expireForSession(sessionId, 'answered-locally');
+      this.deps.approvals?.expireForSession(sessionId, 'answered-locally', 'awaiting_input');
       return { ok: true };
     }
 
@@ -616,7 +616,7 @@ export class HookIngest {
     // returned 'defer' to Claude Code and is gone. The expiry is for the
     // /api/approvals list so the phone stops showing the card.
     if (signal.kind === 'agent.permission_answered') {
-      this.deps.approvals?.expireForSession(sessionId, 'answered-locally');
+      this.deps.approvals?.expireForSession(sessionId, 'answered-locally', 'awaiting_permission');
       return { ok: true };
     }
 

--- a/src/daemon/hooks/__tests__/HookIngest.test.ts
+++ b/src/daemon/hooks/__tests__/HookIngest.test.ts
@@ -45,7 +45,7 @@ function makeDeps(sessions: HookIngestSession[] = [session({ id: 'pty-a' })]) {
   const nudges: Array<{ sessionId: string; kind: AgentSignalKind }> = [];
   // #770 — track every approval-sink call so the locally-answered expiry path
   // can be asserted (expireForSession reason + that nothing broadcasts).
-  const approvalsCalls: Array<{ sessionId: string; reason: string }> = [];
+  const approvalsCalls: Array<{ sessionId: string; reason: string; kind?: string }> = [];
   let clock = 10_000;
   const deps = {
     listLiveSessions: () => sessions,
@@ -61,8 +61,8 @@ function makeDeps(sessions: HookIngestSession[] = [session({ id: 'pty-a' })]) {
     approvals: {
       noteHookAwaitingInput: () => { /* tracked at the registry level */ },
       noteGateAwaiting: () => 'gate-id',
-      expireForSession: (sessionId: string, reason: string) => {
-        approvalsCalls.push({ sessionId, reason });
+      expireForSession: (sessionId: string, reason: string, kind?: string) => {
+        approvalsCalls.push({ sessionId, reason, kind });
       },
     },
     log: () => { /* silent in tests */ },
@@ -201,10 +201,28 @@ describe('HookIngest', () => {
       const res = ingest.handle(makeSignal({ ptyId: 'pty-a', kind: 'agent.input_answered' }));
       expect(res).toEqual({ ok: true });
       expect(fixture.approvalsCalls).toEqual([
-        { sessionId: 'pty-a', reason: 'answered-locally' },
+        { sessionId: 'pty-a', reason: 'answered-locally', kind: 'awaiting_input' },
       ]);
       // Not a turn boundary or even a metadata ping: nothing fans out.
       expect(fixture.emitted).toHaveLength(0);
+    });
+
+    it('scopes the sweep to awaiting_input so a parallel permission gate survives', () => {
+      // A turn can open a gate and an AskUserQuestion at once. Answering the
+      // question locally says nothing about the gate, and expiring the gate
+      // record drops its waiter — the tool falls back to the local prompt
+      // while the phone operator just sees the card vanish.
+      ingest.handle(makeSignal({ ptyId: 'pty-a', kind: 'agent.input_answered' }));
+      expect(fixture.approvalsCalls[0].kind).toBe('awaiting_input');
+    });
+
+    it('scopes a locally-answered permission gate to awaiting_permission', () => {
+      // The mirror of the rule above: a gate answered in the TUI must not
+      // expire a question card still on screen.
+      ingest.handle(makeSignal({ ptyId: 'pty-a', kind: 'agent.permission_answered' }));
+      expect(fixture.approvalsCalls).toEqual([
+        { sessionId: 'pty-a', reason: 'answered-locally', kind: 'awaiting_permission' },
+      ]);
     });
 
     it('does not capture a resume binding or nudge the transcript (early return)', () => {
@@ -225,8 +243,10 @@ describe('HookIngest', () => {
       fixture.advance(100);
       ingest.handle(makeSignal({ ptyId: 'pty-a', kind: 'agent.stop' }));
       expect(fixture.approvalsCalls).toEqual([
-        { sessionId: 'pty-a', reason: 'answered-locally' },
-        { sessionId: 'pty-a', reason: 'turn-ended' },
+        { sessionId: 'pty-a', reason: 'answered-locally', kind: 'awaiting_input' },
+        // The backstop stays kind-agnostic: the turn ended, so every pending
+        // record on the pane is moot regardless of kind.
+        { sessionId: 'pty-a', reason: 'turn-ended', kind: undefined },
       ]);
       // Only the stop broadcasts — input_answered stayed silent.
       expect(fixture.emitted).toHaveLength(1);


### PR DESCRIPTION
## Problem

Fixes #770.

The #773/#783 fix for ghost pending approval cards was dead code: the bridge only promoted an AskUserQuestion `PostToolUse` to `agent.input_answered` when `payload.fired` was truthy, but `fired` is not a field Claude Code sends in PostToolUse payloads (the real fields are `session_id` / `transcript_path` / `cwd` / `hook_event_name` / `tool_name` / `tool_input` / `tool_response`). The promotion therefore never fired, the daemon never received the signal, and locally answered questions stayed pending on the phone until `agent.stop`. The daemon and installer paths from #773/#783 are correct — only the signal source was broken, and the bridge had no tests to catch it.

## Changes

- **claude bridge**: drop the `payload.fired` predicate — reaching a PostToolUse handler is itself proof the tool completed, and the call site is already gated on `hookName === 'PostToolUse'`, so no second field is needed.
- **openclaude bridge**: the promotion logic was missing entirely (this file is an adapted variant, not a copy, which is how the first fix landed on only one side). Ported the same tool-name gate; no throttle bypass needed since this bridge has no source-side activity throttle.
- **tests** (new, parameterized over both bridges — 5 cases × 2): promotion on AskUserQuestion, no reliance on fields beyond `tool_name` (regression guard for `fired`), other tools still map to `agent.activity`, missing/malformed payload falls back to activity, and partial tool-name matches like `mcp__x__AskUserQuestion` are not promoted. Reverting the old predicate makes the guard cases fail.

No notification spam: `agent.input_answered` is absent from both emit whitelists (daemon `HookIngest` and main `hooks.rpc`), so it only expires the pending approval record silently.

## Verification

- `npx tsc --noEmit` clean
- Full test suite: 691 files / 10,171 tests passing
- `npm run lint` clean on the changed files

Real-device check after merge: answer an AskUserQuestion on the PC mid-turn and confirm the phone approval inbox clears within seconds (expire event → SSE nudge → refetch, all existing wiring).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Answered approval questions now disappear from the phone inbox immediately after being completed on the computer, instead of lingering as pending cards.
  * Question answers are now recognized more reliably, so completed items clear within seconds rather than waiting until the end of the session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->