### PR TITLE
Mirrored remote panes: app font and theme, shared width model, and clipping

### DIFF
--- a/changelog.d/819.md
+++ b/changelog.d/819.md
@@ -1,22 +1,31 @@
 ### Fixed
 
-- **Mirrored remote panes now use your terminal font and theme.** An attached
-  remote workspace built its terminal without any of the app's visual settings,
-  so it fell back to xterm's own defaults — `monospace` at 15px on black,
-  outside the theme's ANSI palette. Next to a local pane it read as slightly
-  bolder and slightly larger, because it was. Font size, font family, theme and
-  the contrast floor now match a local pane, and changing them updates the
-  mirror without dropping what the remote has already sent.
+- **Mirrored remote panes use your terminal font, theme and contrast floor.**
+  An attached remote workspace built its terminal without any of the app's
+  visual settings, so it fell back to xterm's own defaults — `monospace` at
+  15px on black, outside the theme's ANSI palette. Next to a local pane it read
+  as slightly bolder and slightly larger, because it was. Changing the settings
+  now updates the mirror without dropping what the remote has already sent.
 
-- **Mirrored remote panes no longer tear on Korean and other wide text.** The
-  mirror re-renders a grid the remote daemon computed, but it was the one
-  terminal in the app that skipped the shared Unicode width model — so every
-  double-width character put the two grids one cell further apart, and rows
-  arrived interleaved and torn. It now measures the way every other wmux
-  terminal does.
+  One difference remains: local panes render through WebGL and mirrors use
+  xterm's DOM renderer, whose text antialiasing differs. Matching size, family
+  and palette removes most of the mismatch, not all of it.
+
+- **Mirrored panes no longer tear on Korean and other wide text.** The mirror
+  re-renders a grid the remote daemon computed, but it was the one terminal in
+  the app that skipped the shared Unicode width model — so every double-width
+  character put the two grids one cell further apart, and rows arrived
+  interleaved and torn.
 
 - **Mirrored panes stay inside their box.** A remote pane with more rows than
   the local cell can show rendered taller than its container, and nothing in
   the chain clipped it, so terminal output painted over the composer bar and
   the sidebar. Typing made it obvious because that is when the overflowing rows
   got repainted.
+
+  This clips rather than scales: geometry belongs to the remote daemon and the
+  mirror never resizes it, so a remote grid taller than the local cell now has
+  its lower rows cut off instead of drawn over the app. That is the better of
+  two bad outcomes, not a good one — the cropped region is where the cursor and
+  live output are. Fitting the mirror to the cell needs a geometry negotiation
+  that does not exist yet.

--- a/changelog.d/819.md
+++ b/changelog.d/819.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- **Mirrored remote panes now use your terminal font and theme.** An attached
+  remote workspace built its terminal without any of the app's visual settings,
+  so it fell back to xterm's own defaults — `monospace` at 15px on black,
+  outside the theme's ANSI palette. Next to a local pane it read as slightly
+  bolder and slightly larger, because it was. Font size, font family, theme and
+  the contrast floor now match a local pane, and changing them updates the
+  mirror without dropping what the remote has already sent.
+
+- **Mirrored remote panes no longer tear on Korean and other wide text.** The
+  mirror re-renders a grid the remote daemon computed, but it was the one
+  terminal in the app that skipped the shared Unicode width model — so every
+  double-width character put the two grids one cell further apart, and rows
+  arrived interleaved and torn. It now measures the way every other wmux
+  terminal does.
+
+- **Mirrored panes stay inside their box.** A remote pane with more rows than
+  the local cell can show rendered taller than its container, and nothing in
+  the chain clipped it, so terminal output painted over the composer bar and
+  the sidebar. Typing made it obvious because that is when the overflowing rows
+  got repainted.

--- a/changelog.d/mirror-font.md
+++ b/changelog.d/mirror-font.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Mirrored remote panes now use your terminal font and theme.** An attached
+  remote workspace built its terminal without any of the app's visual settings,
+  so it fell back to xterm's own defaults — `monospace` at 15px on black,
+  outside the theme's ANSI palette. Next to a local pane it read as slightly
+  bolder and slightly larger, because it was. Font size, font family, theme and
+  the contrast floor now match a local pane, and changing them updates the
+  mirror without dropping what the remote has already sent.

--- a/changelog.d/mirror-font.md
+++ b/changelog.d/mirror-font.md
@@ -1,9 +1,0 @@
-### Fixed
-
-- **Mirrored remote panes now use your terminal font and theme.** An attached
-  remote workspace built its terminal without any of the app's visual settings,
-  so it fell back to xterm's own defaults — `monospace` at 15px on black,
-  outside the theme's ANSI palette. Next to a local pane it read as slightly
-  bolder and slightly larger, because it was. Font size, font family, theme and
-  the contrast floor now match a local pane, and changing them updates the
-  mirror without dropping what the remote has already sent.

--- a/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
+++ b/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { useT } from '../../hooks/useT';
+import { applyUnicodeWidthModel } from '../../../shared/terminalUnicode';
 import { useStore } from '../../stores';
 import { terminalFontFamilyCss } from '../../utils/terminalFont';
 import { XTERM_THEMES, extractXtermColors, type BuiltinThemeId, type ThemeId } from '../../themes';
@@ -96,6 +97,17 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
       theme: xtermThemeRef.current,
       minimumContrastRatio: minimumContrastRatioRef.current,
     });
+    // The width model, BEFORE open() — same order as the local pane.
+    //
+    // `terminalUnicode.ts` exists because two grids that must agree will drift
+    // silently if each names its own addon: "the daemon wraps a row at a
+    // different column than the screen does, and everything after it sits one
+    // or more cells off." A mirror is exactly that situation — the remote
+    // daemon computed the grid, this terminal re-renders it — and it was the
+    // one terminal not going through the helper. On CJK text, where every
+    // character is double-width, the drift is visible as torn, interleaved
+    // rows rather than a subtle offset.
+    applyUnicodeWidthModel(term);
     term.open(containerRef.current);
     containerRef.current.style.backgroundColor = xtermThemeRef.current.background ?? '';
     termRef.current = term;
@@ -168,8 +180,15 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
   }, [attachId]);
 
   return (
-    <div className="relative w-full h-full min-h-0 min-w-0">
-      <div ref={containerRef} className="absolute inset-0" />
+    // `overflow-hidden` is the letterboxing this component's header describes
+    // ("letterboxed by the parent's CSS, not by resizing the terminal") and
+    // that nothing in the chain actually applied — not here, not PaneCell, not
+    // WorkspaceCenter. Geometry has a single owner, the remote daemon, so a
+    // remote pane with more rows than this cell can show renders an element
+    // TALLER than its box; with nothing clipping it, the overflow painted over
+    // the composer and the sidebar.
+    <div className="relative w-full h-full min-h-0 min-w-0 overflow-hidden">
+      <div ref={containerRef} className="absolute inset-0 overflow-hidden" />
       {error && (
         <div
           className="absolute inset-0 flex items-center justify-center text-[11px] font-mono px-2 text-center"

--- a/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
+++ b/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { useT } from '../../hooks/useT';
 import { applyUnicodeWidthModel } from '../../../shared/terminalUnicode';
@@ -59,13 +59,25 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
   const terminalFontFamily = useStore((s) => s.terminalFontFamily);
   const theme = useStore((s) => s.theme) as ThemeId;
   const customThemeColors = useStore((s) => s.customThemeColors);
-  const xtermTheme = theme === 'custom' && customThemeColors
-    ? extractXtermColors(customThemeColors)
-    : XTERM_THEMES[theme as BuiltinThemeId] ?? XTERM_THEMES['catppuccin-mocha'];
+  // Memoised on identity, not just value. `extractXtermColors` builds a new
+  // object every call, so a custom theme would hand the settings effect below a
+  // dep that never compares equal — re-assigning `options.theme` on every
+  // parent render, and with it an xterm ColorSet rebuild, a glyph-atlas clear
+  // and a full refresh. Builtin themes come from a module constant and were
+  // already stable; this makes custom ones behave the same.
+  const xtermTheme = useMemo(
+    () => (theme === 'custom' && customThemeColors
+      ? extractXtermColors(customThemeColors)
+      : XTERM_THEMES[theme as BuiltinThemeId] ?? XTERM_THEMES['catppuccin-mocha']),
+    [theme, customThemeColors],
+  );
   // True-colour foregrounds from remote TUIs land here the same way they do
   // locally, so the same contrast floor applies — see useTerminal.ts for why
   // dark themes get a lower one.
-  const minimumContrastRatio = resolveMinimumContrastRatio(xtermTheme.background);
+  const minimumContrastRatio = useMemo(
+    () => resolveMinimumContrastRatio(xtermTheme.background),
+    [xtermTheme],
+  );
 
   // Read inside the mount effect without joining its deps — same discipline as
   // `readOnlyRef` above. The effect must stay `[]`-keyed (see below), but it
@@ -96,6 +108,12 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
       fontFamily: terminalFontFamilyCss(terminalFontFamilyRef.current),
       theme: xtermThemeRef.current,
       minimumContrastRatio: minimumContrastRatioRef.current,
+      // REQUIRED by the width model below. `Unicode11Addon.activate` reads
+      // `term.unicode`, which xterm gates behind this flag and throws without
+      // it — synchronously, inside a mount effect, where the nearest boundary
+      // is the one wrapping the whole main area. One attached remote workspace
+      // would take the entire local pane grid down with it.
+      allowProposedApi: true,
     });
     // The width model, BEFORE open() — same order as the local pane.
     //
@@ -107,10 +125,13 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
     // one terminal not going through the helper. On CJK text, where every
     // character is double-width, the drift is visible as torn, interleaved
     // rows rather than a subtle offset.
+    // Registered BEFORE the addon and open(). If either throws, the cleanup
+    // below still runs against a terminal this ref knows about, instead of
+    // leaking the instance (DOM, listeners, buffers) on every mount attempt.
+    termRef.current = term;
     applyUnicodeWidthModel(term);
     term.open(containerRef.current);
     containerRef.current.style.backgroundColor = xtermThemeRef.current.background ?? '';
-    termRef.current = term;
     return () => {
       term.dispose();
       termRef.current = null;

--- a/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
+++ b/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { useT } from '../../hooks/useT';
+import { useStore } from '../../stores';
+import { terminalFontFamilyCss } from '../../utils/terminalFont';
+import { XTERM_THEMES, extractXtermColors, type BuiltinThemeId, type ThemeId } from '../../themes';
+import { resolveMinimumContrastRatio } from '../../tailwindPalette';
 
 export interface RemoteMirrorTerminalProps {
   /** null while the pane attach is still in flight. */
@@ -40,17 +44,81 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
   const readOnlyRef = useRef(readOnly);
   readOnlyRef.current = readOnly;
 
+  /**
+   * The same visual settings a local pane gets.
+   *
+   * A mirror is still one of this app's terminals, and it sits in the sidebar
+   * next to local ones. Constructing it bare left it on xterm's own defaults —
+   * `monospace` at 15px against a black background — so it rendered in a
+   * different face, one pixel larger, and outside the theme's ANSI palette
+   * (DESIGN.md: terminal content owns that palette). Visible as "why is this
+   * pane slightly bolder and bigger", which is exactly what it was.
+   */
+  const terminalFontSize = useStore((s) => s.terminalFontSize);
+  const terminalFontFamily = useStore((s) => s.terminalFontFamily);
+  const theme = useStore((s) => s.theme) as ThemeId;
+  const customThemeColors = useStore((s) => s.customThemeColors);
+  const xtermTheme = theme === 'custom' && customThemeColors
+    ? extractXtermColors(customThemeColors)
+    : XTERM_THEMES[theme as BuiltinThemeId] ?? XTERM_THEMES['catppuccin-mocha'];
+  // True-colour foregrounds from remote TUIs land here the same way they do
+  // locally, so the same contrast floor applies — see useTerminal.ts for why
+  // dark themes get a lower one.
+  const minimumContrastRatio = resolveMinimumContrastRatio(xtermTheme.background);
+
+  // Read inside the mount effect without joining its deps — same discipline as
+  // `readOnlyRef` above. The effect must stay `[]`-keyed (see below), but it
+  // still needs the CURRENT settings at construction so the first paint is
+  // already correct rather than flashing xterm's defaults.
+  const terminalFontSizeRef = useRef(terminalFontSize);
+  terminalFontSizeRef.current = terminalFontSize;
+  const terminalFontFamilyRef = useRef(terminalFontFamily);
+  terminalFontFamilyRef.current = terminalFontFamily;
+  const xtermThemeRef = useRef(xtermTheme);
+  xtermThemeRef.current = xtermTheme;
+  const minimumContrastRatioRef = useRef(minimumContrastRatio);
+  minimumContrastRatioRef.current = minimumContrastRatio;
+
   // Mount the xterm instance once, for the lifetime of this component.
+  //
+  // Settings are passed at construction AND kept in sync by the effect below,
+  // rather than listed in this effect's deps: re-creating the terminal on a
+  // font change would drop the mirrored scrollback, and the remote only
+  // repaints on a fresh attach.
   useEffect(() => {
     if (!containerRef.current) return;
-    const term = new Terminal({ convertEol: false, scrollback: 2000, disableStdin: false });
+    const term = new Terminal({
+      convertEol: false,
+      scrollback: 2000,
+      disableStdin: false,
+      fontSize: terminalFontSizeRef.current,
+      fontFamily: terminalFontFamilyCss(terminalFontFamilyRef.current),
+      theme: xtermThemeRef.current,
+      minimumContrastRatio: minimumContrastRatioRef.current,
+    });
     term.open(containerRef.current);
+    containerRef.current.style.backgroundColor = xtermThemeRef.current.background ?? '';
     termRef.current = term;
     return () => {
       term.dispose();
       termRef.current = null;
     };
   }, []);
+
+  // Apply visual settings at runtime without recreating the terminal, so
+  // tweaking the font does not wipe what the remote has already sent. Mirrors
+  // the local pane's own settings effect.
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+    term.options.fontSize = terminalFontSize;
+    term.options.fontFamily = terminalFontFamilyCss(terminalFontFamily);
+    term.options.theme = xtermTheme;
+    term.options.minimumContrastRatio = minimumContrastRatio;
+    if (containerRef.current) {
+      containerRef.current.style.backgroundColor = xtermTheme.background ?? '';
+    }
+  }, [terminalFontSize, terminalFontFamily, xtermTheme, minimumContrastRatio]);
 
   // Subscribe/attach lifecycle keyed on attachId. Geometry arrives once per
   // connection — every onPaneMeta (fresh attach OR reconnect) means "reset

--- a/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.ctor.test.ts
+++ b/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.ctor.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+//
+// The options the mirror actually constructs its terminal with, checked
+// against the REAL @xterm/xterm and the REAL width model.
+//
+// This file exists because the sibling suite mocks both of those, so it
+// verified mock-to-mock call ordering and passed 15/15 while the component
+// threw on every mount in production: `applyUnicodeWidthModel` installs
+// Unicode11Addon, which reads `term.unicode`, which xterm gates behind
+// `allowProposedApi` and throws without. A mount effect that throws reaches the
+// boundary around the whole main area, so a single attached remote workspace
+// took the entire local pane grid down.
+//
+// Nothing here is mocked. If the ctor options and the addon ever disagree
+// again, this fails.
+
+import { describe, it, expect } from 'vitest';
+import { Terminal } from '@xterm/xterm';
+import { applyUnicodeWidthModel } from '../../../../shared/terminalUnicode';
+
+/** The exact option bag RemoteMirrorTerminal passes, minus the store reads. */
+function mirrorCtorOptions() {
+  return {
+    convertEol: false,
+    scrollback: 2000,
+    disableStdin: false,
+    fontSize: 14,
+    fontFamily: 'Cascadia Code, monospace',
+    theme: { background: '#1e1e2e', foreground: '#cdd6f4' },
+    minimumContrastRatio: 2.5,
+    allowProposedApi: true,
+  };
+}
+
+describe('RemoteMirrorTerminal terminal construction', () => {
+  it('survives the shared width model — the addon needs proposed API', () => {
+    const term = new Terminal(mirrorCtorOptions());
+    try {
+      expect(() => applyUnicodeWidthModel(term)).not.toThrow();
+    } finally {
+      term.dispose();
+    }
+  });
+
+  // The negative control. Without the flag the same call throws, which is what
+  // the component shipped as before this test existed — so a regression here
+  // cannot pass by accident.
+  it('throws without allowProposedApi, proving the flag is load-bearing', () => {
+    const { allowProposedApi: _omitted, ...withoutFlag } = mirrorCtorOptions();
+    void _omitted;
+    const term = new Terminal(withoutFlag);
+    try {
+      expect(() => applyUnicodeWidthModel(term)).toThrow(/proposed API/i);
+    } finally {
+      term.dispose();
+    }
+  });
+});

--- a/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
+++ b/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
@@ -13,8 +13,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react';
 import RemoteMirrorTerminal from '../RemoteMirrorTerminal';
+import { useStore } from '../../../stores';
 
 class FakeTerminal {
+  /** What the component asked for at construction. */
+  ctorOptions: Record<string, unknown> = {};
+  /** Live options bag, like xterm's — the runtime settings effect writes here. */
+  options: Record<string, unknown> = {};
   written: unknown[] = [];
   resized: Array<{ cols: number; rows: number }> = [];
   resetCalls = 0;
@@ -36,8 +41,10 @@ const termInstances: FakeTerminal[] = [];
 
 vi.mock('@xterm/xterm', () => ({
   Terminal: class {
-    constructor() {
+    constructor(opts: Record<string, unknown>) {
       const t = new FakeTerminal();
+      t.ctorOptions = { ...opts };
+      t.options = { ...opts };
       termInstances.push(t);
       return t as unknown as this;
     }
@@ -233,5 +240,47 @@ describe('RemoteMirrorTerminal', () => {
     expect(errorHandlers).toHaveLength(1);
     unmount();
     expect(errorHandlers).toHaveLength(0);
+  });
+
+  /**
+   * A mirror sits in the sidebar next to local panes and must not look like a
+   * different application. Constructed bare it fell back to xterm's own
+   * defaults — `monospace` at 15px on black, outside the theme's ANSI palette
+   * — which read as "this pane is slightly bolder and bigger" and was.
+   */
+  describe('visual settings', () => {
+    it('constructs with the app font and theme, not xterm defaults', () => {
+      const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+
+      const opts = termInstances[0]!.ctorOptions;
+      // xterm's own defaults are fontSize 15 / fontFamily 'monospace'. Asserting
+      // against those specifically is the point: this is the regression.
+      expect(opts['fontSize']).toBe(useStore.getState().terminalFontSize);
+      expect(opts['fontSize']).not.toBe(15);
+      expect(String(opts['fontFamily'])).toContain(useStore.getState().terminalFontFamily);
+      expect(opts['fontFamily']).not.toBe('monospace');
+      expect(opts['theme']).toBeTruthy();
+      expect(typeof opts['minimumContrastRatio']).toBe('number');
+
+      unmount();
+    });
+
+    it('applies a font-size change without recreating the terminal', async () => {
+      const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+      const term = termInstances[0]!;
+      const before = termInstances.length;
+
+      await act(async () => {
+        useStore.setState({ terminalFontSize: 22 });
+      });
+
+      // Same instance, new option — recreating would drop everything the
+      // remote has already sent, and the remote only repaints on re-attach.
+      expect(termInstances).toHaveLength(before);
+      expect(term.disposed).toBe(false);
+      expect(term.options['fontSize']).toBe(22);
+
+      unmount();
+    });
   });
 });

--- a/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
+++ b/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
@@ -294,6 +294,15 @@ describe('RemoteMirrorTerminal', () => {
   });
 
   describe('visual settings', () => {
+    // Reads the COMPONENT's ctor bag. The sibling ctor suite proves this flag
+    // is what keeps the width model from throwing; this proves the component
+    // actually sends it. Neither test alone would have caught the crash.
+    it('asks for proposed API, which the width model requires', () => {
+      const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+      expect(termInstances[0]!.ctorOptions['allowProposedApi']).toBe(true);
+      unmount();
+    });
+
     it('constructs with the app font and theme, not xterm defaults', () => {
       const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
 

--- a/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
+++ b/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
@@ -15,6 +15,17 @@ import { act } from 'react';
 import RemoteMirrorTerminal from '../RemoteMirrorTerminal';
 import { useStore } from '../../../stores';
 
+// One shared log so "before open()" is an assertion about the same clock.
+// Two independent counters would compare cleanly and prove nothing.
+const setupLog = vi.hoisted(() => [] as string[]);
+const widthModelMock = vi.hoisted(() => vi.fn());
+vi.mock('../../../../shared/terminalUnicode', () => ({
+  applyUnicodeWidthModel: (t: unknown) => {
+    setupLog.push('width-model');
+    widthModelMock(t);
+  },
+}));
+
 class FakeTerminal {
   /** What the component asked for at construction. */
   ctorOptions: Record<string, unknown> = {};
@@ -26,7 +37,10 @@ class FakeTerminal {
   disposed = false;
   onDataHandler: ((data: string) => void) | null = null;
 
-  open(): void { /* noop — the fake never touches the DOM container */ }
+  open(): void {
+    // Ordering only — the fake never touches the DOM container.
+    setupLog.push('open');
+  }
   reset(): void { this.resetCalls++; }
   resize(cols: number, rows: number): void { this.resized.push({ cols, rows }); }
   write(data: unknown): void { this.written.push(data); }
@@ -76,6 +90,7 @@ describe('RemoteMirrorTerminal', () => {
   let paneWrite: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    setupLog.length = 0;
     termInstances.length = 0;
     metaHandlers = [];
     dataHandlers = [];
@@ -248,6 +263,36 @@ describe('RemoteMirrorTerminal', () => {
    * defaults — `monospace` at 15px on black, outside the theme's ANSI palette
    * — which read as "this pane is slightly bolder and bigger" and was.
    */
+  /**
+   * The mirror re-renders a grid the REMOTE daemon computed. `terminalUnicode`
+   * exists because two grids that must agree drift silently otherwise, and
+   * this was the one terminal that skipped it — visible as torn, interleaved
+   * rows on CJK text, where every character is double-width.
+   */
+  it('applies the shared Unicode width model, before open()', () => {
+    const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+
+    expect(widthModelMock).toHaveBeenCalledWith(termInstances[0]);
+    // The addon has to be installed before the terminal is attached, or the
+    // first paint measures with the wrong model.
+    expect(setupLog).toEqual(['width-model', 'open']);
+
+    unmount();
+  });
+
+  // The component's header claims the parent CSS letterboxes an aspect
+  // mismatch. Nothing in the chain did, so a remote pane taller than its cell
+  // painted over the composer and the sidebar.
+  it('clips its own overflow rather than trusting a parent to do it', () => {
+    const { container, unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+
+    const outer = container.firstElementChild as HTMLElement;
+    expect(outer.className).toContain('overflow-hidden');
+    expect((outer.firstElementChild as HTMLElement).className).toContain('overflow-hidden');
+
+    unmount();
+  });
+
   describe('visual settings', () => {
     it('constructs with the app font and theme, not xterm defaults', () => {
       const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);


### PR DESCRIPTION
Reported from dogfooding: "is the text in this pane oddly bold and slightly
bigger, or am I imagining it?"

Not imagining it.

## Root cause

`RemoteMirrorTerminal` was the only terminal in the app constructed with no
visual settings:

```ts
const term = new Terminal({ convertEol: false, scrollback: 2000, disableStdin: false });
```

So it ran on xterm's defaults. Side by side with what a local pane gets from
`useTerminal.ts`:

|                        | local pane            | mirrored pane            |
|------------------------|-----------------------|--------------------------|
| `fontSize`             | 14 (setting)          | **15** (xterm default)   |
| `fontFamily`           | Cascadia Code         | **`monospace`**          |
| `theme`                | selected theme        | **xterm default**        |
| `minimumContrastRatio` | applied               | **absent**               |

One pixel larger and a different typeface is precisely what "slightly bigger
and bolder" looks like.

The theme was the part that would not have been named: DESIGN.md gives terminal
content the theme's ANSI palette, and this pane was rendering remote output in
xterm's own — so remote ANSI colours and the pane background were both off, on
the one surface where a wrong colour reads as the remote host's output rather
than as a local bug.

## Fix

Read the same four settings a local pane reads, pass them at construction so
the first paint is already correct, and keep them in sync with a runtime effect.

The settings deliberately do **not** join the mount effect's dependency list.
Re-creating the terminal on a font change would drop the mirrored scrollback,
and the remote only repaints on a fresh attach — there is nothing to rebuild
from. Same reason `useTerminal.ts` mutates `options` in place.

## Tests

Two, both failing against the previous code:

- construction carries the app's font size, family, theme and contrast floor —
  asserted against xterm's specific defaults (`15`, `'monospace'`), since those
  defaults are the regression
- a font-size change mutates the existing instance rather than replacing it
  (instance count unchanged, not disposed, new value visible)

The existing suite's fake Terminal grew an options bag to make this observable;
its other 11 tests are unchanged and still pass.

## Verification

`tsc --noEmit` clean, eslint clean, Remote + Sidebar suites 55/55.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mirrored remote terminals now inherit local font, theme, background, and contrast settings.
  * Wide Unicode characters render correctly in remote terminal panes.
  * Terminal content is clipped to prevent visual overflow.
  * Font-size changes now apply immediately without recreating the terminal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->