### PR TITLE
Budget RemoteHostsStore's tests for the Windows ACL cost

### DIFF
--- a/src/main/remote/__tests__/RemoteHostsStore.test.ts
+++ b/src/main/remote/__tests__/RemoteHostsStore.test.ts
@@ -20,6 +20,29 @@ vi.mock('../../../shared/security', async () => {
   };
 });
 
+/**
+ * Windows needs more than the 5s default here, and the reason is a real cost
+ * rather than a slow test.
+ *
+ * `RemoteHostsStore.persist()` goes through `secureWriteTokenFile`, which
+ * writes IN PLACE. On Windows an in-place overwrite preserves the existing
+ * file's ACL, so any broad EXPLICIT ACE on it survives and only the PowerShell
+ * DACL rebuild removes one — measured at 1.8-3.8s under antivirus, per the
+ * note in `daemon/web/DeviceStore.ts`. Every test here that writes twice
+ * therefore spends most of a 5s budget inside two ACL rebuilds, and whether it
+ * finishes comes down to how fast the runner is that minute.
+ *
+ * That marginality has failed `removes a host by id` and `tolerates a corrupt
+ * file on construct` on unrelated PRs, so the flake is a tax on every change in
+ * the repo, not on this file.
+ *
+ * The budget is raised rather than the cost hidden: the stall is real, it lands
+ * on the × button in the attach modal on Windows, and fixing it properly is
+ * tracked in #820. This only stops a documented cost from being measured
+ * against a budget that never accounted for it.
+ */
+vi.setConfig({ testTimeout: 30_000 });
+
 describe('RemoteHostsStore', () => {
   let dir: string;
   let filePath: string;


### PR DESCRIPTION
`RemoteHostsStore.test.ts` fails intermittently on `Baseline (windows-latest)`
at the 5s default, on PRs that do not touch it. Most recently #819, which only
changes a renderer component. It has taken down `removes a host by id` and
`tolerates a corrupt file on construct` on separate runs, and passed both on
others.

## Not a slow test

`persist()` calls `secureWriteTokenFile`, which writes **in place**. On Windows
an in-place overwrite preserves the existing file's ACL, so a broad EXPLICIT ACE
survives and only the PowerShell DACL rebuild removes it — 1.8-3.8s under
antivirus, per the measurement recorded in `daemon/web/DeviceStore.ts`.

Every test here that writes twice therefore spends most of a 5s budget inside
two ACL rebuilds. It is marginal by construction; the runner decides.

## Raising the budget, not hiding the cost

The stall is real. On Windows it lands on the × button in the attach modal, and
fixing it properly is tracked in **#820** — where a first attempt is drafted
together with the panel findings on why that attempt was wrong (harden-before-
write does not close the window, because Windows evaluates access at handle-open
time; and non-ASCII profile paths fall back to PowerShell anyway).

This change does one thing: stops a documented cost from being measured against
a budget that never accounted for it. `vi.setConfig({ testTimeout: 30_000 })`
for the file, with the reasoning in a comment so the next person does not read
it as an arbitrary bump.

Unblocks #819, which is otherwise green.