### PR TITLE
Re-place native window controls under a renderer zoom

### DIFF
--- a/changelog.d/824.md
+++ b/changelog.d/824.md
@@ -1,0 +1,8 @@
+### Added
+
+- **The native window controls now follow a renderer zoom.** Scaling the UI used
+  to leave the macOS traffic lights and the Windows window buttons behind — they
+  are drawn by the OS and do not move with the renderer, so the custom titlebar
+  grew while the controls stayed put. They are now re-placed whenever the zoom
+  changes, which keeps them centred in the titlebar at any scale. Nothing in the
+  app zooms yet; this is the groundwork for a configurable UI size.

--- a/src/main/window/__tests__/uiZoom.test.ts
+++ b/src/main/window/__tests__/uiZoom.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import {
+  clampUiZoom,
+  macTrafficLightPosition,
+  winOverlayHeight,
+  UI_ZOOM_MIN,
+  UI_ZOOM_MAX,
+} from '../uiZoom';
+
+/**
+ * #822 — the arithmetic that decides whether UI zoom can keep the native
+ * window controls aligned with DESIGN.md's 36px chrome module.
+ *
+ * The plan's rejected-alternative claim was that the native controls "do not
+ * follow a renderer zoom", so zoom desyncs the titlebar. These cases pin the
+ * correction: the controls are re-placeable, and the offset must be
+ * RE-CENTERED against the scaled bar, not itself scaled. Scaling the y-offset
+ * (11 → 15.4 at 1.4) is what produces the desync the plan feared.
+ */
+
+describe('clampUiZoom', () => {
+  it('clamps below the minimum and above the maximum', () => {
+    expect(clampUiZoom(0.1)).toBe(UI_ZOOM_MIN);
+    expect(clampUiZoom(9)).toBe(UI_ZOOM_MAX);
+  });
+
+  it('passes valid values through and falls back to 1 on garbage', () => {
+    expect(clampUiZoom(1.4)).toBe(1.4);
+    expect(clampUiZoom(Number.NaN)).toBe(1);
+    expect(clampUiZoom('1.4')).toBe(1);
+    expect(clampUiZoom(undefined)).toBe(1);
+  });
+});
+
+describe('macTrafficLightPosition', () => {
+  it('reproduces the shipped position at zoom 1', () => {
+    // createWindow.ts uses { x: 12, y: 11 } — (36 - 14) / 2 = 11.
+    expect(macTrafficLightPosition(1)).toEqual({ x: 12, y: 11 });
+  });
+
+  it('re-centers rather than scaling the y-offset', () => {
+    // At 1.4 the renderer's bar is 50.4pt tall; the 14pt lights center at 18.2.
+    // The naive "scale the offset" answer would be 11 * 1.4 = 15.4 — 3pt high,
+    // which is exactly the desync the plan cited as the blocker.
+    const { y } = macTrafficLightPosition(1.4);
+    expect(y).toBe(18);
+    expect(y).not.toBe(Math.round(11 * 1.4));
+  });
+
+  it('never returns a negative offset when the bar is smaller than the lights', () => {
+    expect(macTrafficLightPosition(0.2).y).toBe(0);
+  });
+});
+
+describe('winOverlayHeight', () => {
+  it('tracks the scaled chrome row', () => {
+    expect(winOverlayHeight(1)).toBe(36);
+    expect(winOverlayHeight(1.4)).toBe(50);
+  });
+});

--- a/src/main/window/createWindow.ts
+++ b/src/main/window/createWindow.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { platformChoice } from '../../shared/platform';
 import { IPC } from '../../shared/constants';
 import { attachFlashFrameAutoClear } from './flashFrame';
+import { applyUiZoom } from './uiZoom';
 
 // OS-aware window-icon extension. Mirrors tray.ts so the same generated asset
 // set (icon.ico / icon.icns / icon.png) is used in both places.
@@ -135,6 +136,25 @@ export function createWindow(opts: { deferLoad?: boolean } = {}): BrowserWindow 
   };
   mainWindow.on('enter-full-screen', () => pushFullscreen(true));
   mainWindow.on('leave-full-screen', () => pushFullscreen(false));
+
+  // #822 prototype — UI zoom via WMUX_UI_ZOOM (e.g. WMUX_UI_ZOOM=1.4). Applied
+  // after first paint so the renderer has drawn the 36px bar the native
+  // controls are being centered against. Absent/invalid → untouched at 1.
+  const zoomEnv = process.env.WMUX_UI_ZOOM;
+  if (zoomEnv) {
+    const requested = Number(zoomEnv);
+    if (Number.isFinite(requested)) {
+      // `on`, not `once`: the dev path retries the Vite URL and each failed
+      // load still fires did-finish-load, so a one-shot apply lands on the
+      // error page and the real load resets the zoom factor.
+      mainWindow.webContents.on('did-finish-load', () => {
+        applyUiZoom(mainWindow, requested, {
+          color: '#151517',
+          symbolColor: '#A5A29C',
+        });
+      });
+    }
+  }
 
   if (!opts.deferLoad) {
     loadMainRenderer(mainWindow);

--- a/src/main/window/uiZoom.ts
+++ b/src/main/window/uiZoom.ts
@@ -1,0 +1,92 @@
+import type { BrowserWindow } from 'electron';
+
+/**
+ * UI zoom (#822 prototype) — scale the whole renderer, then re-place the
+ * native window controls so DESIGN.md's 36px chrome module still lines up.
+ *
+ * The premise under test: "trafficLightPosition and titleBarOverlay are in OS
+ * coordinates and do not follow a renderer zoom, so zoom desyncs the custom
+ * titlebar from the native controls." The first half is true. The second half
+ * only holds if the positions are write-once — they are not. Both are runtime
+ * setters, and the titleBarOverlay one is already wired for theme changes
+ * (registerHandlers.ts), so the resync rides an existing path.
+ *
+ * Coordinate note (this is the whole trick): `setZoomFactor` scales CSS px,
+ * so the renderer's 36px bar occupies `36 * z` window points. The native
+ * controls do NOT scale — traffic lights stay ~14pt tall at any zoom. So the
+ * y-offset that centers them is `(36 * z - LIGHTS_H) / 2`, not `11 * z`.
+ * Scaling the offset instead of re-centering is what actually desyncs.
+ */
+
+/** Custom titlebar height in CSS px — DESIGN.md's chrome module. */
+const CHROME_H = 36;
+/** Rendered height of the macOS traffic-light cluster, in window points. */
+const MAC_LIGHTS_H = 14;
+/** Left inset of the traffic lights at zoom 1. */
+const MAC_LIGHTS_X = 12;
+
+export const UI_ZOOM_MIN = 0.8;
+export const UI_ZOOM_MAX = 1.6;
+
+/** Clamp to the supported range; non-finite input falls back to 1. */
+export function clampUiZoom(factor: unknown): number {
+  const n = typeof factor === 'number' ? factor : Number.NaN;
+  if (!Number.isFinite(n)) return 1;
+  return Math.min(UI_ZOOM_MAX, Math.max(UI_ZOOM_MIN, n));
+}
+
+/**
+ * Where the traffic lights must sit so they stay vertically centered in a
+ * titlebar that the renderer draws `CHROME_H * zoom` points tall.
+ *
+ * Exported for the unit test: this is the one piece of arithmetic that decides
+ * whether the premise holds, so it is verified without booting Electron.
+ */
+export function macTrafficLightPosition(zoom: number): { x: number; y: number } {
+  const barH = CHROME_H * zoom;
+  return {
+    x: Math.round(MAC_LIGHTS_X * zoom),
+    y: Math.max(0, Math.round((barH - MAC_LIGHTS_H) / 2)),
+  };
+}
+
+/** Native titleBarOverlay height matching the scaled chrome row (Windows). */
+export function winOverlayHeight(zoom: number): number {
+  return Math.round(CHROME_H * zoom);
+}
+
+/**
+ * Apply a zoom factor and re-place the native chrome to match.
+ *
+ * Every native call is guarded: these APIs exist only on the platform whose
+ * window options requested them, and a cosmetic resync must never crash main
+ * (same posture as the existing setTitleBarOverlay handler).
+ */
+export function applyUiZoom(
+  win: BrowserWindow,
+  factor: number,
+  overlayColors?: { color: string; symbolColor: string },
+): number {
+  const zoom = clampUiZoom(factor);
+  if (win.isDestroyed()) return zoom;
+
+  win.webContents.setZoomFactor(zoom);
+
+  if (process.platform === 'darwin') {
+    try {
+      win.setWindowButtonPosition(macTrafficLightPosition(zoom));
+    } catch {
+      // Window created without titleBarStyle:'hidden' — nothing to re-place.
+    }
+  }
+
+  if (process.platform === 'win32' && overlayColors) {
+    try {
+      win.setTitleBarOverlay({ ...overlayColors, height: winOverlayHeight(zoom) });
+    } catch {
+      // Window created without titleBarOverlay (flag/rollback path).
+    }
+  }
+
+  return zoom;
+}


### PR DESCRIPTION
Groundwork for the configurable UI scale asked for in #822. This lands the
mechanism only — there is no user-facing setting yet.

## Why not the sweep

The obvious route to a scalable UI is to rewrite every hard-coded font size.
That is 481 `text-[Npx]` sites across 61 files plus 23 inline styles, and it
mints a permanent `text-ui-N` vocabulary that every future contributor has to
learn — while `globals.css` already declares a semantic 16/14/13/11 ramp it
intends to migrate to.

The cheaper route is `webFrame.setZoomFactor`, which is what VS Code's
`window.zoomLevel` does. The reason to reject it was that the native window
controls are positioned in OS coordinates and do not follow a renderer zoom, so
zooming desyncs them from the custom 36px titlebar that DESIGN.md's chrome
module is built around.

That desync is real. It is also fixable, which is what this PR shows.

## Measured

A harness with the same window options as `createWindow` (`titleBarStyle:
'hidden'`, `trafficLightPosition: {x:12, y:11}`) drawing a 36px bar with a
hairline at its bottom edge, captured and measured at the pixel level:

| Condition | Bar height | Light centre | Misalignment |
|---|---|---|---|
| zoom 1.0 (today) | 35.5pt | 17.75pt | **0.00pt** |
| zoom 1.4, no re-place | 50.0pt | 17.75pt | **-7.25pt** |
| zoom 1.4, re-placed | 50.0pt | 24.75pt | **-0.25pt** |

0.25pt is rounding — under one physical pixel on a retina display.

## The arithmetic

The traffic lights render at a fixed 14pt at every zoom level. So the offset
that centres them has to be recomputed against the scaled bar:

```
y = (36 * zoom - 14) / 2
```

Scaling the shipped offset instead (`11 * 1.4 = 15.4`) lands 3pt high and
reintroduces the desync. `uiZoom.test.ts` asserts against that wrong answer by
name so the mistake cannot come back.

## What is in

- `uiZoom.ts` — clamp, the re-centring arithmetic, and a guarded apply that
  calls `setWindowButtonPosition` on macOS and rides the existing
  theme-following `setTitleBarOverlay` path on Windows.
- `uiZoom.test.ts` — 6 cases covering the clamp, the zoom-1 identity, the
  re-centring, and the degenerate small-bar case.
- `createWindow.ts` — `WMUX_UI_ZOOM` applies a factor at launch so this can be
  dogfooded before the Settings surface is designed.

Unset, the window is untouched and every computed value is identical to today.

## Not verified

- **Windows.** The `titleBarOverlay` height path is written and typechecked but
  not run — the measurements above are macOS. It needs a Windows dogfood pass
  before any setting ships on top of this.
- **The real renderer.** The numbers come from the harness, not from wmux's own
  titlebar. Same window options, but not the same app.
- **Terminal double-scaling.** xterm reads `fontSize` from JS, so at a non-1
  zoom the terminal scales twice — once by the user's own font setting, once by
  the window zoom. Dividing by the zoom factor in `useTerminal` is the likely
  answer, but it is not in this PR.

Refs #822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved window scaling support across macOS and Windows.
  * Native macOS traffic-light controls and Windows title-bar overlays now remain correctly positioned and sized when the interface zoom changes.
  * Zoom values are safely constrained to supported limits, preventing invalid sizing or negative positioning.
* **Reliability**
  * Window display updates are handled safely across supported configurations, including windows that are closing or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->