### PR TITLE
feat(fanout): per-task port assignment and trust-gated worktree setup hook

### DIFF
--- a/changelog.d/t2-fanout-ports.md
+++ b/changelog.d/t2-fanout-ports.md
@@ -5,8 +5,11 @@
   spawns is assigned one free port from that window, exported to its pane as
   `WMUX_TASK_PORT`. Before this, eight tasks that all ran `npm run dev` fought
   over one port and seven of them died on startup. Ports are probed and assigned
-  before any task spawns, so no two tasks in a fan-out collide; if the window
-  runs out, the remaining tasks simply start without the variable.
+  before any task spawns, so no two tasks in a fan-out collide — and a port just
+  handed out stays claimed for ten minutes, so a second fan-out started while
+  the first one's servers are still booting doesn't reuse it either. Windows are
+  capped at 512 ports; if one runs out, the remaining tasks simply start without
+  the variable.
 
 - **Worktree setup hook for fan-out.** `fanout.setup` in `wmux.json` is a shell
   command run inside each freshly created worktree *before* its agent starts —
@@ -17,5 +20,9 @@
   review it. An edit demotes the file to stale and the hook stops running. When
   a declared hook is skipped for lack of trust the fan-out says so instead of
   quietly doing nothing, and a hook that fails leaves its task unspawned with
-  the worktree preserved rather than starting an agent in a half-prepared tree.
+  the worktree preserved rather than starting an agent in a half-prepared tree —
+  only that task; the rest of the fan-out continues. Output is never capped (a
+  chatty `npm ci` won't be killed), and a hook that hits its five-minute ceiling
+  has its whole process tree killed, so a background install can't outlive it
+  and keep writing into the preserved worktree.
   See `docs/how-to/fan-out-task-environment.md`.

--- a/changelog.d/t2-fanout-ports.md
+++ b/changelog.d/t2-fanout-ports.md
@@ -1,0 +1,21 @@
+### Added
+
+- **Fan-out tasks can each get their own port.** Declare `fanout.portRange`
+  (e.g. `"3000-3010"`) in your repo's `wmux.json` and every task a fan-out
+  spawns is assigned one free port from that window, exported to its pane as
+  `WMUX_TASK_PORT`. Before this, eight tasks that all ran `npm run dev` fought
+  over one port and seven of them died on startup. Ports are probed and assigned
+  before any task spawns, so no two tasks in a fan-out collide; if the window
+  runs out, the remaining tasks simply start without the variable.
+
+- **Worktree setup hook for fan-out.** `fanout.setup` in `wmux.json` is a shell
+  command run inside each freshly created worktree *before* its agent starts —
+  the `cp ../../.env .` and `npm ci` you used to type into every agent's first
+  turn. It is trust-gated exactly like supervised panes: the command is shown
+  verbatim in the trust dialog and runs only against `wmux.json` bytes you have
+  explicitly approved, so a hook arriving via a pull request is inert until you
+  review it. An edit demotes the file to stale and the hook stops running. When
+  a declared hook is skipped for lack of trust the fan-out says so instead of
+  quietly doing nothing, and a hook that fails leaves its task unspawned with
+  the worktree preserved rather than starting an agent in a half-prepared tree.
+  See `docs/how-to/fan-out-task-environment.md`.

--- a/docs/how-to/fan-out-task-environment.md
+++ b/docs/how-to/fan-out-task-environment.md
@@ -18,7 +18,9 @@ Both are declared once, in your repo's `wmux.json`:
 
 ## `fanout.portRange`
 
-Written as `"min-max"`, inclusive, within 1024–65535. Each spawned task is
+Written as `"min-max"`, inclusive, within 1024–65535 and at most 512 ports wide
+(the window is probed by binding, so a whole-ephemeral-space range would mean
+tens of thousands of probes before the first task starts). Each spawned task is
 assigned one free port from the window and gets it as **`WMUX_TASK_PORT`** in
 its pane's environment, so eight parallel `npm run dev` runs don't fight:
 
@@ -27,11 +29,18 @@ its pane's environment, so eight parallel `npm run dev` runs don't fight:
 "scripts": { "dev": "vite --port ${WMUX_TASK_PORT:-3000}" }
 ```
 
-Ports are probed for availability and assigned before any task spawns, so no two
-tasks in one fan-out get the same number. If the window runs out, the remaining
-tasks simply start without `WMUX_TASK_PORT` — nothing fails, you just get the
-old behavior for those tasks. The probe is advisory: nothing holds the port
-between the check and your dev server's own bind.
+Ports are probed for availability on both IPv4 and IPv6 loopback and assigned
+before any task spawns, so no two tasks in one fan-out get the same number. A
+port that has just been handed out stays claimed for 10 minutes, so a *second*
+fan-out started while the first one's dev servers are still booting doesn't
+reuse those numbers either. If the window runs out, the remaining tasks simply
+start without `WMUX_TASK_PORT` — nothing fails, you just get the old behavior
+for those tasks. The probe is advisory: nothing holds the port between the check
+and your dev server's own bind.
+
+A `portRange` the schema rejects (typo, privileged or inverted bounds, wider
+than the cap) is dropped and reported — it never disables your `setup` hook, and
+it is never confused with "no range declared".
 
 ## `fanout.setup`
 
@@ -44,7 +53,19 @@ directory is the new worktree, so `../..` reaches out toward your main checkout.
 If the hook fails (non-zero exit, or 5 minutes elapsed), that task is **not**
 spawned: its mission is closed and the worktree is preserved for inspection,
 because an agent that starts in a half-prepared tree just burns a turn
-discovering it. Other tasks continue.
+discovering it. Other tasks continue — a failure or timeout is scoped to the one
+task it happened in. On timeout the hook's whole process tree is killed, not
+just the shell, so a background `npm` can't outlive it and keep writing into the
+preserved worktree.
+
+The hook's output is not capped: a chatty install is truncated only in the
+failure report, never killed mid-run.
+
+> **Budget note.** Hooks currently run **serially**, one per task, each with its
+> own 5-minute ceiling — so a fan-out of 8 tasks whose hooks all time out can
+> spend ~40 minutes before the last task spawns. Keep the hook short (prefer a
+> warm cache: `npm ci` against a shared store, not a cold full build). Running
+> the hooks in parallel is a follow-up.
 
 ### Trust gating
 
@@ -59,7 +80,8 @@ hook is a shell command and is therefore gated exactly like supervised panes:
 
 When a hook is declared but the config isn't trusted, the fan-out still runs and
 reports why the hook was skipped (`untrusted`, `stale`, `denied`) instead of
-failing silently.
+failing silently. A hook the schema rejected reports `malformed` — the two
+fields validate independently, so neither typo can quietly disarm the other.
 
 `portRange` is not trust-gated: the only thing the file can choose is a number,
 and that number never reaches a shell — it stays inside `WMUX_TASK_PORT`.

--- a/docs/how-to/fan-out-task-environment.md
+++ b/docs/how-to/fan-out-task-environment.md
@@ -1,0 +1,65 @@
+# Give fan-out tasks a port and a prepared worktree
+
+A fan-out turns one prompt into up to 8 tasks, each in its own git worktree. Two
+things break at that scale: every task's dev server wants the same port, and
+every task starts in a worktree with no `node_modules` and no `.env`.
+
+Both are declared once, in your repo's `wmux.json`:
+
+```json
+{
+  "version": 1,
+  "fanout": {
+    "portRange": "3000-3010",
+    "setup": "cp ../../.env . && npm ci"
+  }
+}
+```
+
+## `fanout.portRange`
+
+Written as `"min-max"`, inclusive, within 1024–65535. Each spawned task is
+assigned one free port from the window and gets it as **`WMUX_TASK_PORT`** in
+its pane's environment, so eight parallel `npm run dev` runs don't fight:
+
+```jsonc
+// package.json
+"scripts": { "dev": "vite --port ${WMUX_TASK_PORT:-3000}" }
+```
+
+Ports are probed for availability and assigned before any task spawns, so no two
+tasks in one fan-out get the same number. If the window runs out, the remaining
+tasks simply start without `WMUX_TASK_PORT` — nothing fails, you just get the
+old behavior for those tasks. The probe is advisory: nothing holds the port
+between the check and your dev server's own bind.
+
+## `fanout.setup`
+
+A shell command run **inside each fresh worktree, before the agent starts**. Use
+it for the per-worktree preparation you'd otherwise type into every agent's
+first turn — copying secrets that aren't in git, installing dependencies,
+generating a local config. It sees `WMUX_TASK_PORT` too, and its working
+directory is the new worktree, so `../..` reaches out toward your main checkout.
+
+If the hook fails (non-zero exit, or 5 minutes elapsed), that task is **not**
+spawned: its mission is closed and the worktree is preserved for inspection,
+because an agent that starts in a half-prepared tree just burns a turn
+discovering it. Other tasks continue.
+
+### Trust gating
+
+`wmux.json` is checked into the repo, so a pull request can edit it. The setup
+hook is a shell command and is therefore gated exactly like supervised panes:
+
+- It runs **only** when you have explicitly trusted the file's current bytes.
+- Any edit to `wmux.json` demotes it to *stale* and the hook stops running until
+  you review and approve again.
+- The hook command is shown verbatim in the trust dialog's command list before
+  you approve.
+
+When a hook is declared but the config isn't trusted, the fan-out still runs and
+reports why the hook was skipped (`untrusted`, `stale`, `denied`) instead of
+failing silently.
+
+`portRange` is not trust-gated: the only thing the file can choose is a number,
+and that number never reaches a shell — it stays inside `WMUX_TASK_PORT`.

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -39,6 +39,7 @@ import type { DaemonSupervisionPolicy } from '../../../shared/rpc';
 import type { ResumeBinding } from '../../../shared/agentResume';
 import { createDeadPaneRecovery, type DeadPaneRecovery } from '../../../shared/ptyRecovery';
 import { resolvePtyCreateCwd, type PtyCwdSource } from '../../pty/resolvePtyCwd';
+import { FANOUT_TASK_PORT_ENV } from '../../worktask/fanoutEnvironment';
 
 /**
  * Allowed shell basenames (compared case-insensitively).
@@ -410,6 +411,22 @@ export function registerPTYHandlers(
         }
       }
       if (options?.surfaceId) identity[ENV_KEYS.SURFACE_ID] = options.surfaceId;
+      // T2 — the fan-out task port has to be FORCED here rather than ride the
+      // caller's env overlay. `resolveSpawnEnv` clears the whole reserved
+      // WMUX_* namespace and `applyOverlay` skips WMUX_* keys outright, which
+      // is what makes "a profile can never spoof pane identity" unconditional.
+      // A port handed in as `options.env` therefore never reached the child at
+      // all: measured on a live fan-out, both task panes spawned with the port
+      // assigned in the result payload and absent from their environment.
+      //
+      // Forcing it keeps the documented `WMUX_TASK_PORT` name and is the honest
+      // description of what it is — something the app stamps, not something a
+      // caller supplies. Digits only, so this narrow exception to the reserved
+      // prefix cannot be used to smuggle an arbitrary value through.
+      const requestedTaskPort = options?.env?.[FANOUT_TASK_PORT_ENV];
+      if (typeof requestedTaskPort === 'string' && /^\d{1,5}$/.test(requestedTaskPort)) {
+        identity[FANOUT_TASK_PORT_ENV] = requestedTaskPort;
+      }
       // 1d: default channel member id = the pane's session id (mirrors the
       // daemon's WMUX_PTY_ID stamp). Forced identity, so a profile cannot
       // spoof another pane's member id.

--- a/src/main/pty/__tests__/resolveSpawnEnv.test.ts
+++ b/src/main/pty/__tests__/resolveSpawnEnv.test.ts
@@ -323,3 +323,38 @@ describe('resolveSpawnEnv — terminal capability defaults (#680)', () => {
     expect(env.TERM_PROGRAM).toBe('wmux');
   });
 });
+
+// #826 fan-out: the task port is handed to the pane as WMUX_TASK_PORT. It has
+// to arrive as FORCED identity, never as caller env — these pin why, so the
+// mechanism cannot be "fixed" back into the overlay by a later change.
+describe('resolveSpawnEnv — the reserved namespace and the fan-out task port', () => {
+  it('drops a WMUX_* key supplied as caller env (this is what ate the task port)', () => {
+    const env = resolveSpawnEnv(
+      { PATH: '/usr/bin' },
+      { WMUX_TASK_PORT: '3200', NORMAL_KEY: 'kept' },
+      {},
+    );
+    expect(env.WMUX_TASK_PORT).toBeUndefined();
+    // …while an ordinary caller key on the same overlay does arrive, so the
+    // failure is the reserved prefix and not the overlay itself.
+    expect(env.NORMAL_KEY).toBe('kept');
+  });
+
+  it('keeps a WMUX_* key that arrives as forced identity', () => {
+    const env = resolveSpawnEnv(
+      { PATH: '/usr/bin' },
+      undefined,
+      { WMUX_TASK_PORT: '3201' },
+    );
+    expect(env.WMUX_TASK_PORT).toBe('3201');
+  });
+
+  it('identity wins over a caller trying to set the same reserved key', () => {
+    const env = resolveSpawnEnv(
+      { PATH: '/usr/bin' },
+      { WMUX_TASK_PORT: '9999' },
+      { WMUX_TASK_PORT: '3202' },
+    );
+    expect(env.WMUX_TASK_PORT).toBe('3202');
+  });
+});

--- a/src/main/worktask/FanOutService.ts
+++ b/src/main/worktask/FanOutService.ts
@@ -40,6 +40,7 @@ import type { ProjectConfigState } from '../../shared/wmuxProjectConfig';
 import {
   FANOUT_TASK_PORT_ENV,
   assignFanoutPorts,
+  releaseFanoutPorts,
   resolveFanoutSetup,
   runFanoutSetup,
   type FanoutSetupSkipReason,
@@ -164,6 +165,10 @@ export interface FanOutResult {
    *  fan-out. Absent when it ran. Reported rather than silent: "trusted the
    *  file, still nothing installed" is otherwise invisible. */
   setupSkipped?: FanoutSetupSkipReason;
+  /** T2 — the repo declared a `fanout.portRange` the schema rejected (typo,
+   *  privileged/inverted bounds, or wider than the cap), so no task got a
+   *  WMUX_TASK_PORT. Distinct from "no range declared", which reports nothing. */
+  portRangeInvalid?: true;
 }
 
 export interface FanOutServiceOptions {
@@ -340,8 +345,16 @@ export class FanOutService {
       tasks.push(r);
     }
 
+    // 배정됐지만 태스크가 뜨지 못한 포트는 창에 돌려준다(예약 TTL을 기다리지 않게).
+    releaseFanoutPorts(tasks.filter((t) => !t.ok).map((t) => env.ports[t.index]));
+
     const allOk = tasks.every((t) => t.ok);
-    return { ok: allOk, tasks, ...(env.setupSkipped ? { setupSkipped: env.setupSkipped } : {}) };
+    return {
+      ok: allOk,
+      tasks,
+      ...(env.setupSkipped ? { setupSkipped: env.setupSkipped } : {}),
+      ...(env.portRangeInvalid ? { portRangeInvalid: true as const } : {}),
+    };
   }
 
   /**
@@ -353,7 +366,12 @@ export class FanOutService {
   private async resolveEnvironment(
     repoPath: string,
     count: number,
-  ): Promise<{ ports: (number | undefined)[]; setupCommand?: string; setupSkipped?: FanoutSetupSkipReason }> {
+  ): Promise<{
+    ports: (number | undefined)[];
+    setupCommand?: string;
+    setupSkipped?: FanoutSetupSkipReason;
+    portRangeInvalid?: true;
+  }> {
     const empty = { ports: new Array<number | undefined>(count).fill(undefined) };
     if (!this.project) return empty;
 
@@ -364,7 +382,8 @@ export class FanOutService {
       return empty;
     }
 
-    const range = state.config?.fanout?.portRange;
+    const fanout = state.config?.fanout;
+    const range = fanout?.portRange;
     // 포트 배정은 실행이 아니라 값 주입이라 신뢰 게이트를 요구하지 않는다 —
     // wmux.json이 고를 수 있는 것은 숫자 하나이고, 그 숫자는 `WMUX_TASK_PORT`
     // 안에 머문다(setup 훅과 달리 셸에 닿지 않는다).
@@ -376,12 +395,19 @@ export class FanOutService {
         ports = empty.ports;
       }
     }
+    // 스키마가 거부한 portRange는 "선언 없음"과 구분해 보고한다(오타 진단 가능).
+    const portRangeInvalid = fanout?.invalidFields?.includes('portRange') === true;
 
     const setup = resolveFanoutSetup(state);
-    if (setup.run) return { ports, setupCommand: setup.command };
+    const rangeReport = portRangeInvalid ? { portRangeInvalid: true as const } : {};
+    if (setup.run) return { ports, setupCommand: setup.command, ...rangeReport };
     // 'none-declared'는 보고할 게 없다(선언 자체가 없음). 나머지는 "선언은 됐는데
-    // 신뢰가 없어서 안 돌았다"라 반드시 노출된다.
-    return { ports, ...(setup.reason === 'none-declared' ? {} : { setupSkipped: setup.reason }) };
+    // (신뢰 부재·형식 오류로) 안 돌았다"라 반드시 노출된다.
+    return {
+      ports,
+      ...rangeReport,
+      ...(setup.reason === 'none-declared' ? {} : { setupSkipped: setup.reason }),
+    };
   }
 
   /** 태스크 1개 스폰(①~⑤). 실패 시 태스크 단위 보상. */
@@ -472,9 +498,14 @@ export class FanOutService {
     if (ctx.setupCommand !== undefined) {
       const setupRun = await runFanoutSetup(ctx.setupCommand, plan.worktreePath, taskEnv);
       if (!setupRun.ok) {
+        // 이 태스크만 보상한다 — 훅 타임아웃/실패는 fan-out 전체를 접지 않고,
+        // 호출부 루프가 다음 태스크를 그대로 이어간다.
         await this.compensate(taskId, ctx.verifiedWorkspaceId, plan);
+        // 페인이 뜨지 않았으니 포트는 이 태스크의 것이 아니다 — 결과에서 뺀다
+        // (run()이 예약도 함께 반납한다).
+        const { port: _unusedPort, ...withoutPort } = base;
         return {
-          ...base,
+          ...withoutPort,
           setupFailed: true,
           error: `worktree setup hook failed: ${setupRun.error}`,
           preservedWorktree: plan.worktreePath,

--- a/src/main/worktask/FanOutService.ts
+++ b/src/main/worktask/FanOutService.ts
@@ -36,6 +36,14 @@ import {
 } from '../../shared/workTask';
 import { TaskWorktreeManager } from './TaskWorktreeManager';
 import type { TaskWorktreePlan } from './TaskWorktreeManager';
+import type { ProjectConfigState } from '../../shared/wmuxProjectConfig';
+import {
+  FANOUT_TASK_PORT_ENV,
+  assignFanoutPorts,
+  resolveFanoutSetup,
+  runFanoutSetup,
+  type FanoutSetupSkipReason,
+} from './fanoutEnvironment';
 
 /**
  * A3 (delegation contract, worker side) — appended to every fan-out prompt.md.
@@ -78,7 +86,17 @@ export interface FanOutRendererPort {
     name: string;
     cwd: string;
     initialCommand: string;
+    /** T2 — extra env for the task pane (currently WMUX_TASK_PORT). */
+    env?: Record<string, string>;
   }): Promise<{ workspaceId: string; ptyId?: string } | { error: string }>;
+}
+
+/**
+ * T2 — per-project `wmux.json` state + trust verdict (ProjectConfigStore.getState).
+ * Injected as a port so the fan-out tests don't need a trust DB on disk.
+ */
+export interface FanOutProjectPort {
+  getState(cwd: string): Promise<ProjectConfigState>;
 }
 
 /** fan-out 호출 입력(렌더러 다이얼로그 → IPC). */
@@ -129,6 +147,12 @@ export interface FanOutTaskResult {
   channelDisconnected?: boolean;
   /** 보상 시 보존된 worktree 경로(삭제 안 함 — J3 회수 몫). */
   preservedWorktree?: string;
+  /** T2 — port handed to this task as WMUX_TASK_PORT (absent when the repo
+   *  declares no `fanout.portRange`, or the window ran out of free ports). */
+  port?: number;
+  /** T2 — the worktree setup hook failed; the agent was NOT started (a task
+   *  whose dependencies never installed would burn a turn discovering that). */
+  setupFailed?: boolean;
 }
 
 export interface FanOutResult {
@@ -136,12 +160,18 @@ export interface FanOutResult {
   /** 프리플라이트 부적격 등 fan-out 전체 거부 사유(태스크 생성 0). */
   error?: string;
   tasks: FanOutTaskResult[];
+  /** T2 — why the repo's declared `fanout.setup` hook did not run for this
+   *  fan-out. Absent when it ran. Reported rather than silent: "trusted the
+   *  file, still nothing installed" is otherwise invisible. */
+  setupSkipped?: FanoutSetupSkipReason;
 }
 
 export interface FanOutServiceOptions {
   daemon: FanOutDaemonPort;
   renderer: FanOutRendererPort;
   worktrees?: TaskWorktreeManager;
+  /** T2 — trust-gated `wmux.json` reader. Omitted → no ports, no setup hook. */
+  project?: FanOutProjectPort;
 }
 
 /**
@@ -160,6 +190,8 @@ export class FanOutService {
   private readonly daemon: FanOutDaemonPort;
   private readonly renderer: FanOutRendererPort;
   private readonly worktrees: TaskWorktreeManager;
+  /** T2 — per-project wmux.json reader (absent = feature off). */
+  private readonly project?: FanOutProjectPort;
 
   /** §2 G1 멱등: 키 → 완료 결과 LRU. 동일 키 재호출은 직전 결과 반환. */
   private readonly results = new Map<string, FanOutResult>();
@@ -170,6 +202,7 @@ export class FanOutService {
     this.daemon = opts.daemon;
     this.renderer = opts.renderer;
     this.worktrees = opts.worktrees ?? new TaskWorktreeManager();
+    this.project = opts.project;
   }
 
   /**
@@ -282,6 +315,12 @@ export class FanOutService {
       }
     }
 
+    // ── T2 per-repo fan-out environment(포트 창·setup 훅) ──
+    // 신뢰 게이트를 한 번만 통과하고 N개 태스크가 그 결과를 공유한다. 포트는 스폰
+    // 전에 전부 확정한다 — 태스크 k가 뜬 뒤 k+1이 같은 창을 다시 스캔하면 아직
+    // 바인드되지 않은 포트를 중복 배정할 수 있기 때문이다.
+    const env = await this.resolveEnvironment(req.repoPath, n);
+
     // ── 태스크 순차 처리(직렬 큐가 이미 강제하지만, 스폰 부하도 직렬로) ──
     const tasks: FanOutTaskResult[] = [];
     for (const [k, title] of titles.entries()) {
@@ -295,12 +334,54 @@ export class FanOutService {
         verifiedWorkspaceId,
         memberId,
         missionIdemKey,
+        port: env.ports[k],
+        setupCommand: env.setupCommand,
       });
       tasks.push(r);
     }
 
     const allOk = tasks.every((t) => t.ok);
-    return { ok: allOk, tasks };
+    return { ok: allOk, tasks, ...(env.setupSkipped ? { setupSkipped: env.setupSkipped } : {}) };
+  }
+
+  /**
+   * T2 — read the repo's `wmux.json` once and derive the per-task environment:
+   * a distinct port per task from `fanout.portRange`, and the trust-gated
+   * `fanout.setup` hook. Any failure here is non-fatal: a fan-out that can't
+   * read its project config still spawns, it just spawns the pre-T2 way.
+   */
+  private async resolveEnvironment(
+    repoPath: string,
+    count: number,
+  ): Promise<{ ports: (number | undefined)[]; setupCommand?: string; setupSkipped?: FanoutSetupSkipReason }> {
+    const empty = { ports: new Array<number | undefined>(count).fill(undefined) };
+    if (!this.project) return empty;
+
+    let state: ProjectConfigState;
+    try {
+      state = await this.project.getState(repoPath);
+    } catch {
+      return empty;
+    }
+
+    const range = state.config?.fanout?.portRange;
+    // 포트 배정은 실행이 아니라 값 주입이라 신뢰 게이트를 요구하지 않는다 —
+    // wmux.json이 고를 수 있는 것은 숫자 하나이고, 그 숫자는 `WMUX_TASK_PORT`
+    // 안에 머문다(setup 훅과 달리 셸에 닿지 않는다).
+    let ports: (number | undefined)[] = empty.ports;
+    if (range) {
+      try {
+        ports = await assignFanoutPorts(range, count);
+      } catch {
+        ports = empty.ports;
+      }
+    }
+
+    const setup = resolveFanoutSetup(state);
+    if (setup.run) return { ports, setupCommand: setup.command };
+    // 'none-declared'는 보고할 게 없다(선언 자체가 없음). 나머지는 "선언은 됐는데
+    // 신뢰가 없어서 안 돌았다"라 반드시 노출된다.
+    return { ports, ...(setup.reason === 'none-declared' ? {} : { setupSkipped: setup.reason }) };
   }
 
   /** 태스크 1개 스폰(①~⑤). 실패 시 태스크 단위 보상. */
@@ -313,6 +394,10 @@ export class FanOutService {
     verifiedWorkspaceId: string;
     memberId: string;
     missionIdemKey: string;
+    /** T2 — WMUX_TASK_PORT for this task (absent = no range / window empty). */
+    port?: number;
+    /** T2 — trust-gated worktree setup hook (absent = nothing to run). */
+    setupCommand?: string;
   }): Promise<FanOutTaskResult> {
     const base: FanOutTaskResult = { index: ctx.index, title: ctx.title, ok: false };
 
@@ -374,6 +459,29 @@ export class FanOutService {
       return { ...base, error: `prompt file write failed: ${(err as Error).message}`, preservedWorktree: plan.worktreePath };
     }
 
+    // T2 — 태스크 환경 변수(포트). 훅과 에이전트 페인이 같은 값을 본다.
+    const taskEnv: Record<string, string> = {};
+    if (ctx.port !== undefined) {
+      taskEnv[FANOUT_TASK_PORT_ENV] = String(ctx.port);
+      base.port = ctx.port;
+    }
+
+    // T2 — worktree setup 훅(신뢰된 wmux.json에서만 도달). 에이전트 기동 **전**에
+    // 돌린다. 실패는 태스크 실패로 취급하고 페인을 열지 않는다 — 의존성이 안 깔린
+    // worktree에서 에이전트를 띄우면 그 사실을 발견하는 데 한 턴을 태운다.
+    if (ctx.setupCommand !== undefined) {
+      const setupRun = await runFanoutSetup(ctx.setupCommand, plan.worktreePath, taskEnv);
+      if (!setupRun.ok) {
+        await this.compensate(taskId, ctx.verifiedWorkspaceId, plan);
+        return {
+          ...base,
+          setupFailed: true,
+          error: `worktree setup hook failed: ${setupRun.error}`,
+          preservedWorktree: plan.worktreePath,
+        };
+      }
+    }
+
     // ③ 렌더러 spawn — 전용 워크스페이스 + 에이전트 페인. cwd=worktreePath,
     //    initialCommand=`{agentCmd} "$(cat '{promptPath}')"`(경로 쿼팅) — 프롬프트가
     //    없으면 인자 없이 agentCmd만(사람이 페인에서 직접 입력). 실제 workspaceId 회수.
@@ -386,6 +494,7 @@ export class FanOutService {
         name: wsName,
         cwd: plan.worktreePath,
         initialCommand,
+        ...(Object.keys(taskEnv).length > 0 ? { env: taskEnv } : {}),
       });
       if ('error' in spawned) {
         await this.compensate(taskId, ctx.verifiedWorkspaceId, plan);

--- a/src/main/worktask/__tests__/FanOutService.test.ts
+++ b/src/main/worktask/__tests__/FanOutService.test.ts
@@ -11,6 +11,7 @@ import { execFileSync } from 'node:child_process';
 import { FanOutService, buildInitialCommand, WORKER_DELIVERY_PREAMBLE } from '../FanOutService';
 import type { FanOutDaemonPort, FanOutRendererPort } from '../FanOutService';
 import type { TaskWorktreePlan } from '../TaskWorktreeManager';
+import type { ProjectConfigState } from '../../../shared/wmuxProjectConfig';
 
 let metaRoot: string;
 beforeEach(() => {
@@ -90,7 +91,14 @@ function makeDaemonFake(opts?: {
 /** renderer fake — spawnWorkspace가 실제 workspaceId를 회수 반환. 반환한 ptyId도
  *  기록해 FanOutService가 그 id를 결과에 무변형 전달하는지 검증 가능케 한다(F11). */
 function makeRendererFake(opts?: { spawnFailOn?: (name: string) => boolean }) {
-  const spawned: Array<{ name: string; cwd: string; initialCommand: string; returnedPtyId?: string }> = [];
+  const spawned: Array<{
+    name: string;
+    cwd: string;
+    initialCommand: string;
+    /** T2 — per-task env (WMUX_TASK_PORT) main hands the renderer. */
+    env?: Record<string, string>;
+    returnedPtyId?: string;
+  }> = [];
   let seq = 0;
   const port: FanOutRendererPort = {
     spawnWorkspace: vi.fn(async (p) => {
@@ -540,5 +548,65 @@ describe('statusOf — the idempotency key as a poll handle', () => {
     const second = await svc.start(baseReq());
     expect(second).toBe(first);
     expect(worktrees.preflight.mock.calls.length).toBe(preflightCalls);
+  });
+});
+
+describe('T2 per-repo fan-out environment (ports + setup hook)', () => {
+  /** project fake — the trust-gated wmux.json reader FanOutService consumes. */
+  function makeProjectFake(state: ProjectConfigState) {
+    return { getState: vi.fn(async () => state) };
+  }
+
+  it('hands each task a distinct WMUX_TASK_PORT from the declared range', async () => {
+    const daemon = makeDaemonFake();
+    const renderer = makeRendererFake();
+    const worktrees = makeWorktreesFake();
+    const svc = new FanOutService({
+      daemon: daemon.port,
+      renderer: renderer.port,
+      worktrees,
+      project: makeProjectFake({
+        found: true,
+        root: '/repo',
+        trust: 'trusted',
+        config: { version: 1, fanout: { portRange: { min: 39100, max: 39120 } } },
+      }),
+    });
+
+    const res = await svc.start(baseReq());
+    expect(res.ok).toBe(true);
+    const ports = res.tasks.map((t) => t.port);
+    expect(ports.every((p) => typeof p === 'number')).toBe(true);
+    expect(new Set(ports).size).toBe(2);
+    // The same value reaches the pane's environment, not just the report.
+    for (const [k, t] of res.tasks.entries()) {
+      expect(renderer.spawned[k]?.env?.WMUX_TASK_PORT).toBe(String(t.port));
+    }
+  });
+
+  it('never runs a setup hook from an untrusted wmux.json, and says so', async () => {
+    const daemon = makeDaemonFake();
+    const renderer = makeRendererFake();
+    const worktrees = makeWorktreesFake();
+    // A hook that would leave a marker file behind if it were ever executed.
+    const marker = path.join(metaRoot, 'hook-ran');
+    const svc = new FanOutService({
+      daemon: daemon.port,
+      renderer: renderer.port,
+      worktrees,
+      project: makeProjectFake({
+        found: true,
+        root: '/repo',
+        trust: 'stale',
+        config: { version: 1, fanout: { setup: `node -e "require('fs').writeFileSync('${marker}','x')"` } },
+      }),
+    });
+
+    const res = await svc.start(baseReq());
+    expect(res.ok).toBe(true);
+    expect(res.setupSkipped).toBe('stale');
+    expect(fs.existsSync(marker)).toBe(false);
+    // The tasks themselves still spawn — an ungated hook is skipped, not fatal.
+    expect(res.tasks.every((t) => t.ok)).toBe(true);
   });
 });

--- a/src/main/worktask/__tests__/FanOutService.test.ts
+++ b/src/main/worktask/__tests__/FanOutService.test.ts
@@ -12,6 +12,7 @@ import { FanOutService, buildInitialCommand, WORKER_DELIVERY_PREAMBLE } from '..
 import type { FanOutDaemonPort, FanOutRendererPort } from '../FanOutService';
 import type { TaskWorktreePlan } from '../TaskWorktreeManager';
 import type { ProjectConfigState } from '../../../shared/wmuxProjectConfig';
+import { clearFanoutPortReservationsForTest } from '../fanoutEnvironment';
 
 let metaRoot: string;
 beforeEach(() => {
@@ -557,6 +558,12 @@ describe('T2 per-repo fan-out environment (ports + setup hook)', () => {
     return { getState: vi.fn(async () => state) };
   }
 
+  // Port reservations are module state shared by every fan-out in the process,
+  // so each case starts from an empty ledger.
+  beforeEach(() => {
+    clearFanoutPortReservationsForTest();
+  });
+
   it('hands each task a distinct WMUX_TASK_PORT from the declared range', async () => {
     const daemon = makeDaemonFake();
     const renderer = makeRendererFake();
@@ -608,5 +615,91 @@ describe('T2 per-repo fan-out environment (ports + setup hook)', () => {
     expect(fs.existsSync(marker)).toBe(false);
     // The tasks themselves still spawn — an ungated hook is skipped, not fatal.
     expect(res.tasks.every((t) => t.ok)).toBe(true);
+  });
+
+  it('reports a malformed portRange instead of silently handing out no ports', async () => {
+    const daemon = makeDaemonFake();
+    const renderer = makeRendererFake();
+    const svc = new FanOutService({
+      daemon: daemon.port,
+      renderer: renderer.port,
+      worktrees: makeWorktreesFake(),
+      // The schema rejected the range but KEPT the trusted setup declaration —
+      // one typo must not disarm the other field.
+      project: makeProjectFake({
+        found: true,
+        root: '/repo',
+        trust: 'trusted',
+        config: { version: 1, fanout: { invalidFields: ['portRange'] } },
+      }),
+    });
+
+    const res = await svc.start(baseReq());
+    expect(res.ok).toBe(true);
+    expect(res.portRangeInvalid).toBe(true);
+    expect(res.tasks.every((t) => t.port === undefined)).toBe(true);
+    expect(renderer.spawned.every((s) => s.env === undefined)).toBe(true);
+  });
+
+  it('fails ONLY the task whose setup hook failed, and gives it no port', async () => {
+    const daemon = makeDaemonFake();
+    const renderer = makeRendererFake();
+    // A hook that fails the first time it runs and succeeds afterwards, so one
+    // task's failure can be observed not to take the other one down.
+    const sentinel = path.join(metaRoot, 'first-run');
+    const hookScript = path.join(metaRoot, 'hook.js');
+    fs.writeFileSync(
+      hookScript,
+      `const fs = require('fs');\n` +
+        `if (!fs.existsSync(${JSON.stringify(sentinel)})) {\n` +
+        `  fs.writeFileSync(${JSON.stringify(sentinel)}, '1');\n` +
+        `  console.error('setup exploded');\n` +
+        `  process.exit(1);\n` +
+        `}\n`,
+      'utf8',
+    );
+    // The hook runs IN the worktree, so this fake has to materialize the
+    // directory git would have created.
+    const worktrees = makeWorktreesFake();
+    const create = worktrees.createWorktree;
+    worktrees.createWorktree = vi.fn(async (plan: TaskWorktreePlan) => {
+      fs.mkdirSync(plan.worktreePath, { recursive: true });
+      return create(plan);
+    });
+    const svc = new FanOutService({
+      daemon: daemon.port,
+      renderer: renderer.port,
+      worktrees,
+      project: makeProjectFake({
+        found: true,
+        root: '/repo',
+        trust: 'trusted',
+        config: {
+          version: 1,
+          fanout: { portRange: { min: 39200, max: 39220 }, setup: `node ${JSON.stringify(hookScript)}` },
+        },
+      }),
+    });
+
+    const res = await svc.start(baseReq());
+    expect(res.ok).toBe(false);
+
+    const [first, second] = res.tasks;
+    expect(first.ok).toBe(false);
+    expect(first.setupFailed).toBe(true);
+    expect(first.error).toMatch(/setup exploded/);
+    expect(first.preservedWorktree).toBeTruthy();
+    // No pane was ever opened for it, so it owns no port.
+    expect(first.port).toBeUndefined();
+    expect(renderer.spawned.some((s) => s.env?.WMUX_TASK_PORT === '39200')).toBe(false);
+
+    // The next task ran its (now-succeeding) hook and spawned normally.
+    expect(second.ok).toBe(true);
+    expect(typeof second.port).toBe('number');
+    expect(renderer.spawned).toHaveLength(1);
+    // Compensation was scoped to the failed task only.
+    const closed = daemon.calls.filter((c) => c.method === 'task.mission.close');
+    expect(closed).toHaveLength(1);
+    expect(closed[0]?.params.taskId).toBe(first.taskId);
   });
 });

--- a/src/main/worktask/__tests__/fanoutEnvironment.test.ts
+++ b/src/main/worktask/__tests__/fanoutEnvironment.test.ts
@@ -4,32 +4,111 @@
 // shows up as "task 3's dev server died", and a trust-gate hole only shows up
 // as a command from an unreviewed wmux.json having already run.
 
-import { describe, it, expect } from 'vitest';
-import { assignFanoutPorts, resolveFanoutSetup } from '../fanoutEnvironment';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as net from 'node:net';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  assignFanoutPorts,
+  clearFanoutPortReservationsForTest,
+  isFanoutPortReserved,
+  isPortFree,
+  releaseFanoutPorts,
+  resolveFanoutSetup,
+  runFanoutSetup,
+  FANOUT_PORT_RESERVATION_TTL_MS,
+} from '../fanoutEnvironment';
 import { parseFanoutPortRange } from '../../../shared/wmuxProjectConfig';
 import type { ProjectConfigState, ProjectTrustState } from '../../../shared/wmuxProjectConfig';
+
+beforeEach(() => {
+  clearFanoutPortReservationsForTest();
+});
+afterEach(() => {
+  clearFanoutPortReservationsForTest();
+});
 
 describe('assignFanoutPorts', () => {
   it('gives every task a distinct free port and skips busy ones', async () => {
     const busy = new Set([3001, 3002]);
-    const ports = await assignFanoutPorts({ min: 3000, max: 3010 }, 3, async (p) => !busy.has(p));
+    const ports = await assignFanoutPorts({ min: 3000, max: 3010 }, 3, { probe: async (p) => !busy.has(p) });
     expect(ports).toEqual([3000, 3003, 3004]);
     expect(new Set(ports).size).toBe(ports.length);
   });
 
   it('leaves later tasks unassigned when the window runs out instead of reusing ports', async () => {
-    const ports = await assignFanoutPorts({ min: 4000, max: 4001 }, 4, async () => true);
+    const ports = await assignFanoutPorts({ min: 4000, max: 4001 }, 4, { probe: async () => true });
     expect(ports).toEqual([4000, 4001, undefined, undefined]);
+  });
+
+  it('never re-hands a port to a CONCURRENT fan-out before the dev server binds', async () => {
+    // The probe says "free" for everything — exactly the real race: fan-out A's
+    // tasks have not booted their dev servers yet when fan-out B assigns.
+    const alwaysFree = { probe: async () => true };
+    const first = await assignFanoutPorts({ min: 5000, max: 5010 }, 3, alwaysFree);
+    const second = await assignFanoutPorts({ min: 5000, max: 5010 }, 3, alwaysFree);
+    expect(first).toEqual([5000, 5001, 5002]);
+    expect(second).toEqual([5003, 5004, 5005]);
+    expect(new Set([...first, ...second]).size).toBe(6);
+  });
+
+  it('reclaims a reserved port once its TTL lapses', async () => {
+    let now = 1_000_000;
+    const opts = { probe: async () => true, now: () => now };
+    const first = await assignFanoutPorts({ min: 6000, max: 6000 }, 1, opts);
+    expect(first).toEqual([6000]);
+    // Still reserved → the window has nothing left to give.
+    expect(await assignFanoutPorts({ min: 6000, max: 6000 }, 1, opts)).toEqual([undefined]);
+    now += FANOUT_PORT_RESERVATION_TTL_MS + 1;
+    expect(await assignFanoutPorts({ min: 6000, max: 6000 }, 1, opts)).toEqual([6000]);
+  });
+
+  it('releases ports handed to tasks that never spawned', async () => {
+    const opts = { probe: async () => true };
+    const ports = await assignFanoutPorts({ min: 7000, max: 7005 }, 2, opts);
+    expect(isFanoutPortReserved(ports[0] as number)).toBe(true);
+    releaseFanoutPorts(ports);
+    expect(isFanoutPortReserved(ports[0] as number)).toBe(false);
+    expect(await assignFanoutPorts({ min: 7000, max: 7005 }, 2, opts)).toEqual(ports);
+  });
+});
+
+describe('isPortFree', () => {
+  it('reports a port bound on IPv6 loopback as busy (not just IPv4)', async () => {
+    // A dev server listening on ::1 makes the port unusable even though a
+    // 127.0.0.1 bind still succeeds on most stacks.
+    const server = net.createServer();
+    const bound = await new Promise<number | null>((resolve) => {
+      server.once('error', () => resolve(null)); // no IPv6 on this host
+      server.listen(0, '::1', () => {
+        const addr = server.address();
+        resolve(typeof addr === 'object' && addr ? addr.port : null);
+      });
+    });
+    if (bound === null) return; // IPv6-less host — nothing to assert
+    try {
+      expect(await isPortFree(bound)).toBe(false);
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
   });
 });
 
 describe('parseFanoutPortRange', () => {
-  it('accepts "3000-3010" and rejects malformed / privileged / inverted windows', () => {
-    expect(parseFanoutPortRange('3000-3010')).toEqual({ min: 3000, max: 3010 });
-    expect(parseFanoutPortRange('3000')).toBeNull();
-    expect(parseFanoutPortRange('80-90')).toBeNull();
-    expect(parseFanoutPortRange('3010-3000')).toBeNull();
-    expect(parseFanoutPortRange(3000)).toBeNull();
+  it('accepts "3000-3010"', () => {
+    expect(parseFanoutPortRange('3000-3010')).toEqual({ ok: true, range: { min: 3000, max: 3010 } });
+  });
+
+  it('rejects malformed, privileged, inverted and oversized windows with a reason', () => {
+    expect(parseFanoutPortRange('3000')).toEqual({ ok: false, reason: 'not-a-range' });
+    expect(parseFanoutPortRange('80-90')).toEqual({ ok: false, reason: 'out-of-bounds' });
+    expect(parseFanoutPortRange('3010-3000')).toEqual({ ok: false, reason: 'inverted' });
+    expect(parseFanoutPortRange(3000)).toEqual({ ok: false, reason: 'not-a-string' });
+    // The whole ephemeral space would mean tens of thousands of bind probes.
+    expect(parseFanoutPortRange('1024-65535')).toEqual({ ok: false, reason: 'too-wide' });
+    expect(parseFanoutPortRange('3000-3511')).toEqual({ ok: true, range: { min: 3000, max: 3511 } });
+    expect(parseFanoutPortRange('3000-3512')).toEqual({ ok: false, reason: 'too-wide' });
   });
 });
 
@@ -61,4 +140,84 @@ describe('resolveFanoutSetup', () => {
     expect(resolveFanoutSetup({ found: false })).toEqual({ run: false, reason: 'none-declared' });
     expect(resolveFanoutSetup(null)).toEqual({ run: false, reason: 'none-declared' });
   });
+
+  it('reports "malformed" — not "none-declared" — when a declared hook failed validation', () => {
+    const state: ProjectConfigState = {
+      found: true,
+      root: '/repo',
+      trust: 'trusted',
+      config: { version: 1, fanout: { invalidFields: ['setup'] } },
+    };
+    expect(resolveFanoutSetup(state)).toEqual({ run: false, reason: 'malformed' });
+  });
+});
+
+describe('runFanoutSetup', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-hook-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('runs in the worktree with the task env and succeeds', async () => {
+    const res = await runFanoutSetup(
+      process.platform === 'win32'
+        ? 'node -e "require(\'fs\').writeFileSync(\'marker\', process.env.WMUX_TASK_PORT)"'
+        : "node -e \"require('fs').writeFileSync('marker', process.env.WMUX_TASK_PORT)\"",
+      dir,
+      { WMUX_TASK_PORT: '4321' },
+    );
+    expect(res).toEqual({ ok: true });
+    expect(fs.readFileSync(path.join(dir, 'marker'), 'utf8')).toBe('4321');
+  });
+
+  it('does NOT kill a chatty hook — heavy output is truncated for the report only', async () => {
+    // ~2MB of stdout. The old implementation passed a 64KB `maxBuffer` to
+    // exec(), which killed the child at that point and failed a healthy hook.
+    const script = "node -e \"const l='x'.repeat(1000); for(let i=0;i<2000;i++) console.log(l)\"";
+    const res = await runFanoutSetup(script, dir, {});
+    expect(res).toEqual({ ok: true });
+  });
+
+  it('reports a failing hook with the tail of its output', async () => {
+    const res = await runFanoutSetup("node -e \"console.error('boom detail'); process.exit(3)\"", dir, {});
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error).toContain('exited with code 3');
+      expect(res.error).toContain('boom detail');
+    }
+  });
+
+  it('kills the whole process tree on timeout, not just the shell', async () => {
+    if (process.platform === 'win32') return; // POSIX process-group assertion
+    const pidFile = path.join(dir, 'grandchild.pid');
+    const marker = path.join(dir, 'grandchild-survived');
+    // The shell backgrounds a node grandchild that would keep writing into the
+    // preserved worktree; the hook itself then hangs past the timeout.
+    const grandchild = path.join(dir, 'grandchild.js');
+    fs.writeFileSync(
+      grandchild,
+      `const fs = require('fs');\n` +
+        `fs.writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));\n` +
+        `setTimeout(() => fs.writeFileSync(${JSON.stringify(marker)}, 'x'), 3000);\n`,
+      'utf8',
+    );
+    const res = await runFanoutSetup(`node ${JSON.stringify(grandchild)} & sleep 30`, dir, {}, 700);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('timed out');
+
+    // Give the grandchild's timer more than enough time to fire if it lived.
+    await new Promise((r) => setTimeout(r, 3500));
+    expect(fs.existsSync(marker)).toBe(false);
+    const pid = Number(fs.readFileSync(pidFile, 'utf8'));
+    let alive = true;
+    try {
+      process.kill(pid, 0);
+    } catch {
+      alive = false;
+    }
+    expect(alive).toBe(false);
+  }, 15000);
 });

--- a/src/main/worktask/__tests__/fanoutEnvironment.test.ts
+++ b/src/main/worktask/__tests__/fanoutEnvironment.test.ts
@@ -1,0 +1,64 @@
+// ─── T2 fan-out environment: port assignment + setup-hook trust gate ─────────
+//
+// Both units are the ones a bug would be invisible in: a port collision only
+// shows up as "task 3's dev server died", and a trust-gate hole only shows up
+// as a command from an unreviewed wmux.json having already run.
+
+import { describe, it, expect } from 'vitest';
+import { assignFanoutPorts, resolveFanoutSetup } from '../fanoutEnvironment';
+import { parseFanoutPortRange } from '../../../shared/wmuxProjectConfig';
+import type { ProjectConfigState, ProjectTrustState } from '../../../shared/wmuxProjectConfig';
+
+describe('assignFanoutPorts', () => {
+  it('gives every task a distinct free port and skips busy ones', async () => {
+    const busy = new Set([3001, 3002]);
+    const ports = await assignFanoutPorts({ min: 3000, max: 3010 }, 3, async (p) => !busy.has(p));
+    expect(ports).toEqual([3000, 3003, 3004]);
+    expect(new Set(ports).size).toBe(ports.length);
+  });
+
+  it('leaves later tasks unassigned when the window runs out instead of reusing ports', async () => {
+    const ports = await assignFanoutPorts({ min: 4000, max: 4001 }, 4, async () => true);
+    expect(ports).toEqual([4000, 4001, undefined, undefined]);
+  });
+});
+
+describe('parseFanoutPortRange', () => {
+  it('accepts "3000-3010" and rejects malformed / privileged / inverted windows', () => {
+    expect(parseFanoutPortRange('3000-3010')).toEqual({ min: 3000, max: 3010 });
+    expect(parseFanoutPortRange('3000')).toBeNull();
+    expect(parseFanoutPortRange('80-90')).toBeNull();
+    expect(parseFanoutPortRange('3010-3000')).toBeNull();
+    expect(parseFanoutPortRange(3000)).toBeNull();
+  });
+});
+
+function stateWithSetup(trust: ProjectTrustState | undefined, setup?: string): ProjectConfigState {
+  return {
+    found: true,
+    root: '/repo',
+    configPath: '/repo/wmux.json',
+    config: { version: 1, fanout: setup === undefined ? {} : { setup } },
+    trust,
+  };
+}
+
+describe('resolveFanoutSetup', () => {
+  it('runs the hook only for currently-trusted bytes', () => {
+    expect(resolveFanoutSetup(stateWithSetup('trusted', 'npm ci'))).toEqual({ run: true, command: 'npm ci' });
+  });
+
+  it('refuses to run a hook from untrusted, edited-since-approval, or denied config', () => {
+    expect(resolveFanoutSetup(stateWithSetup('untrusted', 'npm ci'))).toEqual({ run: false, reason: 'untrusted' });
+    expect(resolveFanoutSetup(stateWithSetup('stale', 'npm ci'))).toEqual({ run: false, reason: 'stale' });
+    expect(resolveFanoutSetup(stateWithSetup('denied', 'npm ci'))).toEqual({ run: false, reason: 'denied' });
+    // No trust verdict at all (config never evaluated) must fail closed too.
+    expect(resolveFanoutSetup(stateWithSetup(undefined, 'npm ci'))).toEqual({ run: false, reason: 'untrusted' });
+  });
+
+  it('reports "none-declared" when there is no hook or no config', () => {
+    expect(resolveFanoutSetup(stateWithSetup('trusted'))).toEqual({ run: false, reason: 'none-declared' });
+    expect(resolveFanoutSetup({ found: false })).toEqual({ run: false, reason: 'none-declared' });
+    expect(resolveFanoutSetup(null)).toEqual({ run: false, reason: 'none-declared' });
+  });
+});

--- a/src/main/worktask/createFanOutService.ts
+++ b/src/main/worktask/createFanOutService.ts
@@ -18,6 +18,7 @@ import type { BrowserWindow } from 'electron';
 import type { DaemonClient } from '../DaemonClient';
 import type { RpcMethod } from '../../shared/rpc';
 import { sendToRenderer } from '../pipe/handlers/_bridge';
+import { getProjectConfigStore } from '../project/ProjectConfigStore';
 import { FanOutService } from './FanOutService';
 
 type GetWindow = () => BrowserWindow | null;
@@ -48,6 +49,12 @@ export function createFanOutService(
         }
         return { error: 'fanout.spawnWorkspace: renderer returned no workspaceId' };
       },
+    },
+    // T2 — the per-project wmux.json reader. The SAME store instance the
+    // supervised-pane funnel uses, so a fan-out setup hook is gated by exactly
+    // the trust decision the user already made for this repo.
+    project: {
+      getState: (cwd: string) => getProjectConfigStore().getState(cwd),
     },
   });
 }

--- a/src/main/worktask/fanoutEnvironment.ts
+++ b/src/main/worktask/fanoutEnvironment.ts
@@ -19,7 +19,7 @@
  */
 
 import * as net from 'node:net';
-import { exec } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import type { ProjectConfigState } from '../../shared/wmuxProjectConfig';
 import { getExecEnv } from '../../shared/execEnv';
 
@@ -29,18 +29,114 @@ export const FANOUT_TASK_PORT_ENV = 'WMUX_TASK_PORT';
 /** Setup hooks are allowed to install dependencies, so the budget is minutes. */
 export const FANOUT_SETUP_TIMEOUT_MS = 300_000;
 
-/** Cap the captured hook output kept for the failure report. */
-const FANOUT_SETUP_MAX_OUTPUT_BYTES = 64 * 1024;
+/**
+ * Tail of the hook's output kept for a failure report. This is a REPORT cap,
+ * not an execution cap: the child streams as much as it likes and we simply
+ * forget the older bytes. (The previous implementation passed this size as
+ * `exec`'s `maxBuffer`, which KILLS the child on overflow — a chatty but
+ * perfectly healthy `npm ci` would have failed the task.)
+ */
+const FANOUT_SETUP_REPORT_TAIL_BYTES = 64 * 1024;
 
-/** Probe: is `port` free to bind on loopback? (PortAllocator's technique.) */
-export function isPortFree(port: number): Promise<boolean> {
+/** Slice of the tail actually pasted into the error string. */
+const FANOUT_SETUP_ERROR_DETAIL_CHARS = 2000;
+
+// ── Cross-fan-out port reservations ──────────────────────────────────────────
+// Ports are handed out BEFORE any dev server binds them, so a bind probe cannot
+// see a port that a task spawned seconds ago was given. Within one fan-out the
+// ascending scan covers that; ACROSS concurrent fan-outs (two idempotency keys,
+// same repo, same window) it does not — both would probe the same free port and
+// both would get it. This module-level ledger remembers what was handed out
+// recently so the second fan-out skips it.
+//
+// Process-local by design: fan-out spawning lives in this one main process
+// (see FanOutService's header — the spawn path is renderer-bridged from here).
+
+/** How long a handed-out port stays claimed if nobody releases it. Long enough
+ *  for the task's agent to boot and its dev server to actually bind. */
+export const FANOUT_PORT_RESERVATION_TTL_MS = 10 * 60 * 1000;
+
+/** port → expiry timestamp (ms). */
+const portReservations = new Map<number, number>();
+
+/** Drop expired entries so the ledger can't grow without bound. */
+function pruneReservations(now: number): void {
+  for (const [port, expiry] of portReservations) {
+    if (expiry <= now) portReservations.delete(port);
+  }
+}
+
+/** Is `port` still claimed by a recent fan-out? */
+export function isFanoutPortReserved(port: number, now: number = Date.now()): boolean {
+  const expiry = portReservations.get(port);
+  if (expiry === undefined) return false;
+  if (expiry <= now) {
+    portReservations.delete(port);
+    return false;
+  }
+  return true;
+}
+
+/** Claim `port` for TTL. Called for every port handed to a task. */
+export function reserveFanoutPort(port: number, now: number = Date.now()): void {
+  pruneReservations(now);
+  portReservations.set(port, now + FANOUT_PORT_RESERVATION_TTL_MS);
+}
+
+/**
+ * Release ports back to the window — the task that held them is gone (spawn
+ * failed, setup hook failed, task closed). Not required for correctness (the
+ * TTL expires anyway), it just stops a failed fan-out from parking its window.
+ */
+export function releaseFanoutPorts(ports: readonly (number | undefined)[]): void {
+  for (const port of ports) {
+    if (port !== undefined) portReservations.delete(port);
+  }
+}
+
+/** Test seam — the ledger is module state shared by every fan-out. */
+export function clearFanoutPortReservationsForTest(): void {
+  portReservations.clear();
+}
+
+/**
+ * Probe: is `port` free? Binds on BOTH loopback families — a dev server that
+ * listens on `::1` (or on `0.0.0.0`/`::`) makes the port unusable even when the
+ * IPv4 probe succeeds, so either family being taken means busy.
+ *
+ * A host with IPv6 disabled fails the `::1` bind with EAFNOSUPPORT /
+ * EADDRNOTAVAIL / EINVAL — that is "no such stack", not "port taken", and must
+ * not mark every port in the window busy.
+ */
+export async function isPortFree(port: number): Promise<boolean> {
+  const v4 = await probeBind(port, '127.0.0.1');
+  if (v4 === 'busy') return false;
+  const v6 = await probeBind(port, '::1');
+  return v6 !== 'busy';
+}
+
+type BindProbe = 'free' | 'busy' | 'unsupported';
+
+/** Error codes that mean "this address family isn't available here". */
+const ADDRESS_FAMILY_UNAVAILABLE = new Set(['EAFNOSUPPORT', 'EADDRNOTAVAIL', 'EINVAL', 'EPROTONOSUPPORT']);
+
+function probeBind(port: number, host: string): Promise<BindProbe> {
   return new Promise((resolve) => {
     const server = net.createServer();
-    server.once('error', () => resolve(false));
-    server.listen(port, '127.0.0.1', () => {
-      server.close(() => resolve(true));
+    server.once('error', (err: NodeJS.ErrnoException) => {
+      resolve(ADDRESS_FAMILY_UNAVAILABLE.has(err.code ?? '') ? 'unsupported' : 'busy');
+    });
+    server.listen(port, host, () => {
+      server.close(() => resolve('free'));
     });
   });
+}
+
+export interface AssignFanoutPortsOptions {
+  /** Bind probe; injectable for tests. Defaults to the real dual-stack probe. */
+  probe?: (port: number) => Promise<boolean>;
+  /** Clock; injectable for tests of the reservation TTL. */
+  now?: () => number;
 }
 
 /**
@@ -51,15 +147,18 @@ export function isPortFree(port: number): Promise<boolean> {
  * — the task still spawns, it just gets no `WMUX_TASK_PORT` and behaves the way
  * it did before the range was declared.
  *
- * `probe` is injectable for tests; it defaults to a real bind test. Note the
- * probe result is advisory: nothing holds the port between this check and the
- * dev server's own bind, exactly like PortAllocator.
+ * Every port handed out is also RESERVED (see the ledger above) so a fan-out
+ * started while this one's dev servers are still booting doesn't hand out the
+ * same numbers. The probe result itself is advisory: nothing holds the port
+ * between the check and the dev server's own bind, exactly like PortAllocator.
  */
 export async function assignFanoutPorts(
   range: { min: number; max: number },
   count: number,
-  probe: (port: number) => Promise<boolean> = isPortFree,
+  options: AssignFanoutPortsOptions = {},
 ): Promise<(number | undefined)[]> {
+  const probe = options.probe ?? isPortFree;
+  const clock = options.now ?? Date.now;
   const assigned: (number | undefined)[] = [];
   let next = range.min;
   for (let i = 0; i < count; i++) {
@@ -67,8 +166,10 @@ export async function assignFanoutPorts(
     while (next <= range.max) {
       const candidate = next;
       next++;
+      if (isFanoutPortReserved(candidate, clock())) continue;
       if (await probe(candidate)) {
         found = candidate;
+        reserveFanoutPort(candidate, clock());
         break;
       }
     }
@@ -77,8 +178,15 @@ export async function assignFanoutPorts(
   return assigned;
 }
 
-/** Why no setup hook will run for this fan-out (reported, never silent). */
-export type FanoutSetupSkipReason = 'none-declared' | 'untrusted' | 'stale' | 'denied';
+/**
+ * Why no setup hook will run for this fan-out (reported, never silent).
+ *   - 'none-declared' — the repo declares no hook
+ *   - 'malformed'     — a hook IS declared but the value was rejected by the
+ *                       schema, so it never became a runnable command
+ *   - untrusted / stale / denied — declared and well-formed, but the bytes are
+ *                       not currently approved
+ */
+export type FanoutSetupSkipReason = 'none-declared' | 'malformed' | 'untrusted' | 'stale' | 'denied';
 
 export type FanoutSetupResolution =
   | { run: true; command: string }
@@ -91,8 +199,14 @@ export type FanoutSetupResolution =
  * is inert until the user reviews and approves those exact bytes.
  */
 export function resolveFanoutSetup(state: ProjectConfigState | null | undefined): FanoutSetupResolution {
-  const setup = state?.config?.fanout?.setup;
-  if (!state?.found || setup === undefined) return { run: false, reason: 'none-declared' };
+  const fanout = state?.config?.fanout;
+  const setup = fanout?.setup;
+  if (!state?.found || setup === undefined) {
+    // A declared-but-rejected `setup` must not read as "nothing was asked for"
+    // — the author wrote a hook and it is not going to run.
+    if (fanout?.invalidFields?.includes('setup')) return { run: false, reason: 'malformed' };
+    return { run: false, reason: 'none-declared' };
+  }
   if (state.trust === 'denied') return { run: false, reason: 'denied' };
   if (state.trust === 'stale') return { run: false, reason: 'stale' };
   if (state.trust !== 'trusted') return { run: false, reason: 'untrusted' };
@@ -106,30 +220,105 @@ export type FanoutSetupRunResult = { ok: true } | { ok: false; error: string };
  * is a shell line by contract (`cp … && npm ci`), so it goes through the
  * platform shell — the trust gate, not quoting, is what makes that safe.
  * Failure is reported to the caller; it does NOT throw.
+ *
+ * The child is spawned as its own PROCESS GROUP (`detached`). Killing the shell
+ * alone on timeout would leave its grandchildren (the actual `npm`) running,
+ * still writing into a worktree we have just declared failed and preserved for
+ * inspection — so the timeout kills the whole group instead.
  */
 export async function runFanoutSetup(
   command: string,
   cwd: string,
   env: Record<string, string>,
+  timeoutMs: number = FANOUT_SETUP_TIMEOUT_MS,
 ): Promise<FanoutSetupRunResult> {
   return new Promise((resolve) => {
-    exec(
-      command,
-      {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(command, {
         cwd,
         env: { ...getExecEnv(), ...env },
-        timeout: FANOUT_SETUP_TIMEOUT_MS,
-        maxBuffer: FANOUT_SETUP_MAX_OUTPUT_BYTES,
+        shell: true,
+        // Own process group / job, so a timeout can take the grandchildren too.
+        detached: process.platform !== 'win32',
         windowsHide: true,
-      },
-      (err, _stdout, stderr) => {
-        if (err) {
-          const detail = String(stderr ?? '').trim().slice(-2000);
-          resolve({ ok: false, error: detail.length > 0 ? `${err.message}: ${detail}` : err.message });
-          return;
-        }
-        resolve({ ok: true });
-      },
-    );
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (err) {
+      resolve({ ok: false, error: `failed to start: ${(err as Error).message}` });
+      return;
+    }
+
+    // Report tail only — the child is never killed for being chatty.
+    let tail = '';
+    const capture = (chunk: Buffer): void => {
+      tail = (tail + chunk.toString('utf8')).slice(-FANOUT_SETUP_REPORT_TAIL_BYTES);
+    };
+    child.stdout?.on('data', capture);
+    child.stderr?.on('data', capture);
+
+    let timedOut = false;
+    let settled = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      killProcessTree(child.pid);
+    }, timeoutMs);
+
+    const settle = (result: FanoutSetupRunResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    child.on('error', (err) => {
+      settle({ ok: false, error: `failed to start: ${err.message}` });
+    });
+
+    child.on('close', (code, signal) => {
+      if (timedOut) {
+        settle({ ok: false, error: `timed out after ${timeoutMs}ms${detailSuffix(tail)}` });
+        return;
+      }
+      if (code === 0) {
+        settle({ ok: true });
+        return;
+      }
+      const how = signal ? `killed by ${signal}` : `exited with code ${code}`;
+      settle({ ok: false, error: `${how}${detailSuffix(tail)}` });
+    });
   });
+}
+
+function detailSuffix(tail: string): string {
+  const detail = tail.trim().slice(-FANOUT_SETUP_ERROR_DETAIL_CHARS);
+  return detail.length > 0 ? `: ${detail}` : '';
+}
+
+/**
+ * Kill the hook's whole process tree. POSIX: negative pid = the process group
+ * the `detached` spawn created. Windows has no process groups for this — the
+ * documented equivalent is `taskkill /T /F`, which walks the child tree.
+ */
+function killProcessTree(pid: number | undefined): void {
+  if (pid === undefined) return;
+  if (process.platform === 'win32') {
+    try {
+      spawn('taskkill', ['/pid', String(pid), '/T', '/F'], { windowsHide: true, stdio: 'ignore' });
+    } catch {
+      // best-effort — the close handler still settles the promise.
+    }
+    return;
+  }
+  try {
+    process.kill(-pid, 'SIGKILL');
+  } catch {
+    // Group already gone, or we never became a group leader — fall back to the
+    // direct child so at least the shell dies.
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      // best-effort
+    }
+  }
 }

--- a/src/main/worktask/fanoutEnvironment.ts
+++ b/src/main/worktask/fanoutEnvironment.ts
@@ -1,0 +1,135 @@
+/**
+ * T2 — per-task environment for a fan-out: a unique port and an optional
+ * worktree setup hook. Both are declared in the repo's `wmux.json`
+ * (`fanout.portRange` / `fanout.setup`) and both are read through the SAME
+ * trust gate the supervised panes use.
+ *
+ * Port assignment: N tasks each get one free port out of the declared window,
+ * exported to the task pane as `WMUX_TASK_PORT`. Without it, eight tasks that
+ * all run `npm run dev` fight over one port and seven of them fail. The probe
+ * mirrors browser-session/PortAllocator's bind test (that class allocates ONE
+ * port for the CDP endpoint and holds it as instance state, so it can't hand
+ * out N at once — the technique is reused, the module is left alone).
+ *
+ * Setup hook: a shell command run in the fresh worktree BEFORE the agent
+ * starts, so `.env` copies and `npm ci` happen once per worktree instead of
+ * being typed into every agent's first turn. It is trust-gated: a wmux.json
+ * that is merely present ('untrusted'), edited since approval ('stale') or
+ * refused ('denied') runs nothing at all.
+ */
+
+import * as net from 'node:net';
+import { exec } from 'node:child_process';
+import type { ProjectConfigState } from '../../shared/wmuxProjectConfig';
+import { getExecEnv } from '../../shared/execEnv';
+
+/** Env var carrying a fan-out task's assigned port into its pane. */
+export const FANOUT_TASK_PORT_ENV = 'WMUX_TASK_PORT';
+
+/** Setup hooks are allowed to install dependencies, so the budget is minutes. */
+export const FANOUT_SETUP_TIMEOUT_MS = 300_000;
+
+/** Cap the captured hook output kept for the failure report. */
+const FANOUT_SETUP_MAX_OUTPUT_BYTES = 64 * 1024;
+
+/** Probe: is `port` free to bind on loopback? (PortAllocator's technique.) */
+export function isPortFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once('error', () => resolve(false));
+    server.listen(port, '127.0.0.1', () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+/**
+ * Assign up to `count` DISTINCT free ports from `range`, in ascending order.
+ *
+ * The result is index-aligned with the task list: entry k is task k's port, or
+ * undefined when the window ran out of free ports. Running out is not an error
+ * — the task still spawns, it just gets no `WMUX_TASK_PORT` and behaves the way
+ * it did before the range was declared.
+ *
+ * `probe` is injectable for tests; it defaults to a real bind test. Note the
+ * probe result is advisory: nothing holds the port between this check and the
+ * dev server's own bind, exactly like PortAllocator.
+ */
+export async function assignFanoutPorts(
+  range: { min: number; max: number },
+  count: number,
+  probe: (port: number) => Promise<boolean> = isPortFree,
+): Promise<(number | undefined)[]> {
+  const assigned: (number | undefined)[] = [];
+  let next = range.min;
+  for (let i = 0; i < count; i++) {
+    let found: number | undefined;
+    while (next <= range.max) {
+      const candidate = next;
+      next++;
+      if (await probe(candidate)) {
+        found = candidate;
+        break;
+      }
+    }
+    assigned.push(found);
+  }
+  return assigned;
+}
+
+/** Why no setup hook will run for this fan-out (reported, never silent). */
+export type FanoutSetupSkipReason = 'none-declared' | 'untrusted' | 'stale' | 'denied';
+
+export type FanoutSetupResolution =
+  | { run: true; command: string }
+  | { run: false; reason: FanoutSetupSkipReason };
+
+/**
+ * Trust gate for the setup hook. A command runs ONLY when the project's live
+ * wmux.json bytes are currently 'trusted' — the same verdict ProjectConfigStore
+ * computes for supervised panes, so an attacker-authored hook arriving via a PR
+ * is inert until the user reviews and approves those exact bytes.
+ */
+export function resolveFanoutSetup(state: ProjectConfigState | null | undefined): FanoutSetupResolution {
+  const setup = state?.config?.fanout?.setup;
+  if (!state?.found || setup === undefined) return { run: false, reason: 'none-declared' };
+  if (state.trust === 'denied') return { run: false, reason: 'denied' };
+  if (state.trust === 'stale') return { run: false, reason: 'stale' };
+  if (state.trust !== 'trusted') return { run: false, reason: 'untrusted' };
+  return { run: true, command: setup };
+}
+
+export type FanoutSetupRunResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Run a resolved setup command inside `cwd` (the fresh worktree). The command
+ * is a shell line by contract (`cp … && npm ci`), so it goes through the
+ * platform shell — the trust gate, not quoting, is what makes that safe.
+ * Failure is reported to the caller; it does NOT throw.
+ */
+export async function runFanoutSetup(
+  command: string,
+  cwd: string,
+  env: Record<string, string>,
+): Promise<FanoutSetupRunResult> {
+  return new Promise((resolve) => {
+    exec(
+      command,
+      {
+        cwd,
+        env: { ...getExecEnv(), ...env },
+        timeout: FANOUT_SETUP_TIMEOUT_MS,
+        maxBuffer: FANOUT_SETUP_MAX_OUTPUT_BYTES,
+        windowsHide: true,
+      },
+      (err, _stdout, stderr) => {
+        if (err) {
+          const detail = String(stderr ?? '').trim().slice(-2000);
+          resolve({ ok: false, error: detail.length > 0 ? `${err.message}: ${detail}` : err.message });
+          return;
+        }
+        resolve({ ok: true });
+      },
+    );
+  });
+}

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -636,6 +636,14 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     const name = typeof params.name === 'string' && params.name.length > 0 ? params.name : undefined;
     const cwd = typeof params.cwd === 'string' ? params.cwd : '';
     const initialCommand = typeof params.initialCommand === 'string' ? params.initialCommand : '';
+    // T2 — per-task env from main (WMUX_TASK_PORT). String values only; the
+    // workspace profile's own env still applies underneath (withWorkspaceProfile).
+    const taskEnv: Record<string, string> = {};
+    if (params.env !== null && typeof params.env === 'object' && !Array.isArray(params.env)) {
+      for (const [k, v] of Object.entries(params.env as Record<string, unknown>)) {
+        if (typeof v === 'string') taskEnv[k] = v;
+      }
+    }
 
     store.addWorkspace(name);
     const afterAdd = useStore.getState();
@@ -655,6 +663,7 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
               workspaceId: newWsId,
               cwd: cwd || undefined,
               ...(initialCommand ? { initialCommand } : {}),
+              ...(Object.keys(taskEnv).length > 0 ? { env: taskEnv } : {}),
             },
             useStore.getState().defaultShell,
           ),

--- a/src/shared/wmuxProjectConfig.ts
+++ b/src/shared/wmuxProjectConfig.ts
@@ -60,6 +60,13 @@ export const PROJECT_SUPERVISION_HEALTHY_UPTIME_SEC_MAX = 3600;
 export const PROJECT_FANOUT_PORT_MIN = 1024;
 /** Highest port a `fanout.portRange` may claim. */
 export const PROJECT_FANOUT_PORT_MAX = 65535;
+/**
+ * Widest window accepted. Assignment probes the window serially by binding, so
+ * `"1024-65535"` would mean tens of thousands of binds before the first task
+ * spawns. A fan-out is capped at 8 tasks; 512 is already two orders of
+ * magnitude of headroom, and a wider window is a typo, not an intent.
+ */
+export const PROJECT_FANOUT_MAX_RANGE_WIDTH = 512;
 
 export interface WmuxProjectCommand {
   id: string;
@@ -68,10 +75,11 @@ export interface WmuxProjectCommand {
 }
 
 /**
- * Per-repo fan-out settings (T2). Both fields are optional; an invalid value
- * drops the whole `fanout` section (the rest of the file still applies), which
- * fails closed for `setup` — nothing runs — and merely returns port assignment
- * to its pre-feature state.
+ * Per-repo fan-out settings (T2). Both fields are optional and normalize
+ * INDEPENDENTLY: a typo'd `portRange` must not throw away a `setup` hook the
+ * user already reviewed and trusted. A rejected field is dropped (failing
+ * closed — nothing malformed ever runs) and named in `invalidFields` so the
+ * fan-out can report "declared but malformed" instead of "not declared".
  */
 export interface WmuxProjectFanout {
   /**
@@ -86,6 +94,8 @@ export interface WmuxProjectFanout {
    * has trusted THESE wmux.json bytes — see ProjectConfigStore.
    */
   setup?: string;
+  /** Fields the author wrote that failed validation and were dropped. */
+  invalidFields?: ('portRange' | 'setup')[];
 }
 
 export interface WmuxProjectLayoutLeaf {
@@ -511,50 +521,68 @@ function normalizeLayoutNode(input: unknown, depth: number, budget: LayoutBudget
 
 // ── fanout ───────────────────────────────────────────────────────────────────
 
+/** Why a `portRange` string was rejected — surfaced so a typo is diagnosable
+ *  instead of silently behaving like "no range declared". */
+export type FanoutPortRangeError =
+  | 'not-a-string'
+  | 'not-a-range'
+  | 'out-of-bounds'
+  | 'inverted'
+  | 'too-wide';
+
+export type FanoutPortRangeResult =
+  | { ok: true; range: { min: number; max: number } }
+  | { ok: false; reason: FanoutPortRangeError };
+
 /**
- * Parse a `"min-max"` port window. Returns null for anything that isn't two
- * plain decimal numbers inside the allowed range with min <= max — a typo must
- * not resolve to a half-window that silently collides.
+ * Parse a `"min-max"` port window. Anything that isn't two plain decimal
+ * numbers inside the allowed bounds, ascending, and no wider than
+ * PROJECT_FANOUT_MAX_RANGE_WIDTH is rejected with a reason — a typo must not
+ * resolve to a half-window that silently collides, and an enormous window must
+ * not turn task spawning into tens of thousands of serial bind probes.
  */
-export function parseFanoutPortRange(input: unknown): { min: number; max: number } | null {
-  if (typeof input !== 'string') return null;
+export function parseFanoutPortRange(input: unknown): FanoutPortRangeResult {
+  if (typeof input !== 'string') return { ok: false, reason: 'not-a-string' };
   const match = /^\s*(\d{1,5})\s*-\s*(\d{1,5})\s*$/.exec(input);
-  if (!match) return null;
+  if (!match) return { ok: false, reason: 'not-a-range' };
   const min = Number(match[1]);
   const max = Number(match[2]);
-  if (!Number.isInteger(min) || !Number.isInteger(max)) return null;
-  if (min < PROJECT_FANOUT_PORT_MIN || max > PROJECT_FANOUT_PORT_MAX) return null;
-  if (min > max) return null;
-  return { min, max };
+  if (min < PROJECT_FANOUT_PORT_MIN || max > PROJECT_FANOUT_PORT_MAX) return { ok: false, reason: 'out-of-bounds' };
+  if (min > max) return { ok: false, reason: 'inverted' };
+  if (max - min + 1 > PROJECT_FANOUT_MAX_RANGE_WIDTH) return { ok: false, reason: 'too-wide' };
+  return { ok: true, range: { min, max } };
 }
 
 /**
- * Normalize the `fanout` section. Returns undefined when nothing usable
- * remains — including when a field is present but malformed, so a bad `setup`
- * string can never partially survive into an executable position.
+ * Normalize the `fanout` section. The two fields are INDEPENDENT: a malformed
+ * `portRange` drops only the range, never the `setup` hook the user already
+ * approved (and vice versa). Dropped fields are named in `invalidFields` so the
+ * fan-out reports "declared but malformed" rather than staying silent.
  */
 function normalizeFanout(input: unknown): WmuxProjectFanout | undefined {
   if (input === null || typeof input !== 'object' || Array.isArray(input)) return undefined;
   const src = input as { portRange?: unknown; setup?: unknown };
+  const invalidFields: ('portRange' | 'setup')[] = [];
 
   let portRange: { min: number; max: number } | undefined;
   if (src.portRange !== undefined) {
     const parsed = parseFanoutPortRange(src.portRange);
-    if (parsed === null) return undefined;
-    portRange = parsed;
+    if (parsed.ok) portRange = parsed.range;
+    else invalidFields.push('portRange');
   }
 
   let setup: string | undefined;
   if (src.setup !== undefined) {
     const cmd = normCommand(src.setup);
-    if (cmd === undefined) return undefined;
-    setup = cmd;
+    if (cmd === undefined) invalidFields.push('setup');
+    else setup = cmd;
   }
 
-  if (portRange === undefined && setup === undefined) return undefined;
+  if (portRange === undefined && setup === undefined && invalidFields.length === 0) return undefined;
   const out: WmuxProjectFanout = {};
   if (portRange !== undefined) out.portRange = portRange;
   if (setup !== undefined) out.setup = setup;
+  if (invalidFields.length > 0) out.invalidFields = invalidFields;
   return out;
 }
 

--- a/src/shared/wmuxProjectConfig.ts
+++ b/src/shared/wmuxProjectConfig.ts
@@ -50,10 +50,42 @@ export const PROJECT_SUPERVISION_BURST_MAX = 20;
 export const PROJECT_SUPERVISION_HEALTHY_UPTIME_SEC_MIN = 30;
 export const PROJECT_SUPERVISION_HEALTHY_UPTIME_SEC_MAX = 3600;
 
+// ── T2 fan-out caps ──────────────────────────────────────────────────────────
+// A fan-out spawns up to FANOUT_MAX_TASKS worktrees at once; each one may want
+// its own dev-server port, and each one may need a repo-specific preparation
+// step (copy `.env`, `npm install`) before its agent starts. Both are declared
+// here, in the SAME trust-gated file the supervised panes use — `setup` is a
+// shell command and therefore only ever runs from a 'trusted' wmux.json.
+/** Lowest port a `fanout.portRange` may claim (privileged ports are refused). */
+export const PROJECT_FANOUT_PORT_MIN = 1024;
+/** Highest port a `fanout.portRange` may claim. */
+export const PROJECT_FANOUT_PORT_MAX = 65535;
+
 export interface WmuxProjectCommand {
   id: string;
   title: string;
   command: string;
+}
+
+/**
+ * Per-repo fan-out settings (T2). Both fields are optional; an invalid value
+ * drops the whole `fanout` section (the rest of the file still applies), which
+ * fails closed for `setup` — nothing runs — and merely returns port assignment
+ * to its pre-feature state.
+ */
+export interface WmuxProjectFanout {
+  /**
+   * Inclusive port window, authored as `"3000-3010"`. Each fan-out task is
+   * assigned one free port from it, exported as `WMUX_TASK_PORT` in the task
+   * pane's environment, so N parallel dev servers don't collide.
+   */
+  portRange?: { min: number; max: number };
+  /**
+   * Shell command run inside a freshly created fan-out worktree BEFORE the
+   * agent starts (e.g. `cp ../../.env . && npm ci`). Runs only when the user
+   * has trusted THESE wmux.json bytes — see ProjectConfigStore.
+   */
+  setup?: string;
 }
 
 export interface WmuxProjectLayoutLeaf {
@@ -124,6 +156,7 @@ export interface WmuxProjectConfig {
   version: 1;
   commands?: WmuxProjectCommand[];
   layout?: WmuxProjectLayoutNode;
+  fanout?: WmuxProjectFanout;
 }
 
 /**
@@ -476,6 +509,55 @@ function normalizeLayoutNode(input: unknown, depth: number, budget: LayoutBudget
   return leaf;
 }
 
+// ── fanout ───────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a `"min-max"` port window. Returns null for anything that isn't two
+ * plain decimal numbers inside the allowed range with min <= max — a typo must
+ * not resolve to a half-window that silently collides.
+ */
+export function parseFanoutPortRange(input: unknown): { min: number; max: number } | null {
+  if (typeof input !== 'string') return null;
+  const match = /^\s*(\d{1,5})\s*-\s*(\d{1,5})\s*$/.exec(input);
+  if (!match) return null;
+  const min = Number(match[1]);
+  const max = Number(match[2]);
+  if (!Number.isInteger(min) || !Number.isInteger(max)) return null;
+  if (min < PROJECT_FANOUT_PORT_MIN || max > PROJECT_FANOUT_PORT_MAX) return null;
+  if (min > max) return null;
+  return { min, max };
+}
+
+/**
+ * Normalize the `fanout` section. Returns undefined when nothing usable
+ * remains — including when a field is present but malformed, so a bad `setup`
+ * string can never partially survive into an executable position.
+ */
+function normalizeFanout(input: unknown): WmuxProjectFanout | undefined {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) return undefined;
+  const src = input as { portRange?: unknown; setup?: unknown };
+
+  let portRange: { min: number; max: number } | undefined;
+  if (src.portRange !== undefined) {
+    const parsed = parseFanoutPortRange(src.portRange);
+    if (parsed === null) return undefined;
+    portRange = parsed;
+  }
+
+  let setup: string | undefined;
+  if (src.setup !== undefined) {
+    const cmd = normCommand(src.setup);
+    if (cmd === undefined) return undefined;
+    setup = cmd;
+  }
+
+  if (portRange === undefined && setup === undefined) return undefined;
+  const out: WmuxProjectFanout = {};
+  if (portRange !== undefined) out.portRange = portRange;
+  if (setup !== undefined) out.setup = setup;
+  return out;
+}
+
 // ── Entry point ──────────────────────────────────────────────────────────────
 
 /**
@@ -487,7 +569,7 @@ function normalizeLayoutNode(input: unknown, depth: number, budget: LayoutBudget
  */
 export function normalizeWmuxProjectConfig(input: unknown): WmuxProjectConfig | undefined {
   if (input === null || typeof input !== 'object' || Array.isArray(input)) return undefined;
-  const src = input as { version?: unknown; commands?: unknown; layout?: unknown };
+  const src = input as { version?: unknown; commands?: unknown; layout?: unknown; fanout?: unknown };
 
   if (src.version !== undefined && src.version !== 1) return undefined;
 
@@ -499,17 +581,22 @@ export function normalizeWmuxProjectConfig(input: unknown): WmuxProjectConfig | 
     layout = normalizeLayoutNode(src.layout, 1, { leaves: 0 }) ?? undefined;
   }
 
-  if (commands.length === 0 && layout === undefined) return undefined;
+  const fanout = normalizeFanout(src.fanout);
+
+  if (commands.length === 0 && layout === undefined && fanout === undefined) return undefined;
   const config: WmuxProjectConfig = { version: 1 };
   if (commands.length > 0) config.commands = commands;
   if (layout !== undefined) config.layout = layout;
+  if (fanout !== undefined) config.fanout = fanout;
   return config;
 }
 
 /**
  * Every shell command the config can run — what the trust dialog must show
  * verbatim before the user approves. Order: custom commands first, then
- * layout startup commands (depth-first, matching visual order).
+ * layout startup commands (depth-first, matching visual order), then the
+ * fan-out worktree setup hook (T2) — it executes on the same grant, so it has
+ * to be visible in the same list.
  */
 export function collectConfigCommands(config: WmuxProjectConfig): string[] {
   const out: string[] = [];
@@ -522,6 +609,7 @@ export function collectConfigCommands(config: WmuxProjectConfig): string[] {
     node.children.forEach(walk);
   };
   if (config.layout !== undefined) walk(config.layout);
+  if (config.fanout?.setup !== undefined) out.push(config.fanout.setup);
   return out;
 }
 


### PR DESCRIPTION
## What

Two quality-of-life gaps in the fan-out journey:

1. **Port range** — `wmux.json` can declare `fanout.portRange` (e.g. `"3000-3010"`). Each spawned task gets a distinct free port injected as `WMUX_TASK_PORT` in its pane env, so N tasks starting dev servers stop colliding. Ports are pre-assigned before any spawn (re-scanning per task would double-assign ports a dev server has not bound yet). The port value never reaches a shell — env overlay only — so it is not trust-gated.
2. **Setup hook** — `fanout.setup` declares a shell command run in each fresh worktree before the agent starts (install deps, copy `.env`). It rides the existing `wmux.json` trust gate: shown verbatim in the trust dialog, runs only on trusted bytes, and anything else (untrusted / stale / denied) fail-closes — a stale config skips the hook and reports `setupSkipped` rather than running old bytes. Hook failure fails that task closed: mission compensated, worktree preserved, no pane.

## Tests

- `fanoutEnvironment.test.ts` (new, 6): distinct ports, busy-port skip, exhausted range, parse rejections, trust-gate matrix.
- `FanOutService.test.ts` (+2): distinct `WMUX_TASK_PORT` reaches spawn env; stale-config hook does not execute.

## Notes

- Changelog fragment: `changelog.d/t2-fanout-ports.md`; how-to at `docs/how-to/fan-out-task-environment.md`.
- Result fields `port` / `setupFailed` / `setupSkipped` are not yet surfaced in the fan-out report UI — follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fan-out task port allocation through `wmux.json`, with assigned ports exposed as `WMUX_TASK_PORT`.
  * Added optional trusted worktree setup commands that run before task startup.
  * Added reporting for skipped setup hooks and unavailable ports.
* **Bug Fixes**
  * Failed setup commands prevent task startup while preserving the prepared worktree.
  * Invalid, privileged, busy, or exhausted port ranges are handled safely.
  * Setup timeouts terminate related processes without blocking other tasks.
* **Documentation**
  * Added configuration and behavior guidance for fan-out ports and setup hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Prior art

Concept-level borrowing only, no code imported: per-task port ranges appear in uzi (devflowinc/uzi); post-create worktree setup hooks appear in Orca (stablyai/orca) repository hooks. The implementation here is built on wmux's own PortAllocator pattern and wmux.json trust gate.
