### PR TITLE
feat(daemon): outbound webhook/ntfy notification sink

### DIFF
--- a/changelog.d/t3-webhook-sink.md
+++ b/changelog.d/t3-webhook-sink.md
@@ -1,0 +1,24 @@
+### Added
+
+- **Webhook and ntfy notifications, no phone app required.** Point
+  `notifySinks` in `~/.wmux/config.json` at a webhook URL or an ntfy topic and
+  the daemon pings it when an agent asks for an approval or finishes a turn.
+  Until now the only way to hear about a blocked agent from away from the
+  keyboard was the iOS app and its push relay; this is the plain-HTTP path for
+  everyone else. Off unless you configure it, outbound only — the daemon opens
+  no new port — and `WMUX_NOTIFY_SINKS=0` turns it off without editing config.
+
+  ```json
+  "notifySinks": [
+    { "type": "ntfy", "url": "https://ntfy.sh/my-topic", "events": ["approval"] },
+    { "type": "webhook", "url": "https://hooks.example/wmux" }
+  ]
+  ```
+
+  The ping is deliberately thin: the event kind, a fixed title, the agent name,
+  short pane and workspace id prefixes, a derived risk tier and a timestamp. It
+  never carries the agent's question, tool input, terminal output, file paths or
+  any id that can address a pane — the destination is a server you chose but the
+  body travels in the clear, and a shared ntfy topic is not the place for your
+  terminal. Approvals go out at ntfy's high priority; turn-completions at
+  default.

--- a/changelog.d/t3-webhook-sink.md
+++ b/changelog.d/t3-webhook-sink.md
@@ -20,5 +20,8 @@
   never carries the agent's question, tool input, terminal output, file paths or
   any id that can address a pane — the destination is a server you chose but the
   body travels in the clear, and a shared ntfy topic is not the place for your
-  terminal. Approvals go out at ntfy's high priority; turn-completions at
-  default.
+  terminal. On ntfy the priority follows the stakes — an approval that names a
+  destructive action goes out at max, an ordinary approval at high, a
+  turn-completion at default — so the two never arrive looking equally urgent.
+  Approvals also get their own queue, so a busy afternoon of turn-completions
+  can never push out the one notification somebody is actually blocked on.

--- a/src/daemon/__tests__/config.test.ts
+++ b/src/daemon/__tests__/config.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { createDefaultConfig, loadConfig, saveConfig, getWmuxDir } from '../config';
+import {
+  createDefaultConfig,
+  loadConfig,
+  saveConfig,
+  getWmuxDir,
+  readNotifySinks,
+  resetNotifySinksCache,
+} from '../config';
 import type { DaemonConfig } from '../types';
 
 /** Use a temp directory instead of the real ~/.wmux */
@@ -455,5 +462,65 @@ describe('loadConfig — browser.cdp backfill (#613, non-destructive)', () => {
     const c0 = createDefaultConfig();
     writeRawConfig({ ...c0, browser: { cdp: { enabled: false } } });
     expect(loadConfig().browser).toEqual({ cdp: { enabled: false } });
+  });
+});
+
+describe("readNotifySinks — the notify path's read-only view", () => {
+  const configFile = (): string => path.join(getWmuxDir(), 'config.json');
+
+  beforeEach(() => {
+    // The mtime cache is module state, and each test writes a fresh
+    // config.json into a NEW temp dir — without this, test N could be served
+    // test N-1's entry.
+    resetNotifySinksCache();
+  });
+
+  it('reads and coerces the slice', () => {
+    const c0 = createDefaultConfig();
+    writeRawConfig({
+      ...c0,
+      notifySinks: [
+        { type: 'ntfy', url: 'https://ntfy.sh/topic', events: ['approval'] },
+        { type: 'webhook', url: 'file:///etc/passwd' },
+      ],
+    });
+    expect(readNotifySinks()).toEqual([
+      { type: 'ntfy', url: 'https://ntfy.sh/topic', events: ['approval'] },
+    ]);
+  });
+
+  it('★ NEVER rewrites config.json — not even when it cannot be parsed', () => {
+    // The whole reason this function exists rather than reusing loadConfig.
+    // loadConfig repairs a broken file by replacing it with defaults, which is
+    // right at boot and catastrophic on a per-notification path: one transient
+    // failure would silently discard the operator's entire configuration.
+    const garbage = '{ this is not json';
+    fs.mkdirSync(getWmuxDir(), { recursive: true });
+    fs.writeFileSync(configFile(), garbage, 'utf-8');
+
+    expect(readNotifySinks()).toEqual([]);
+    expect(fs.readFileSync(configFile(), 'utf-8')).toBe(garbage);
+  });
+
+  it('★ does not CREATE config.json when none exists', () => {
+    expect(readNotifySinks()).toEqual([]);
+    expect(fs.existsSync(configFile())).toBe(false);
+  });
+
+  it('picks up an edit rather than serving the cache forever', () => {
+    const c0 = createDefaultConfig();
+    writeRawConfig({ ...c0, notifySinks: [{ type: 'ntfy', url: 'https://ntfy.sh/one' }] });
+    expect(readNotifySinks()).toHaveLength(1);
+
+    // Two sinks, so the (mtimeMs, size) cache key changes even if the clock
+    // has not ticked between the two writes.
+    writeRawConfig({
+      ...c0,
+      notifySinks: [
+        { type: 'ntfy', url: 'https://ntfy.sh/one' },
+        { type: 'webhook', url: 'https://hooks.example/two' },
+      ],
+    });
+    expect(readNotifySinks()).toHaveLength(2);
   });
 });

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import os from 'node:os';
 import type { BrowserCdpConfig, ChannelRetentionConfig, DaemonConfig } from './types';
 import { coerceGate, createDefaultGateConfig } from './approvals/gateConfig';
-import { coerceNotifySinks } from './push/WebhookSink';
+import { coerceNotifySinks, type NotifySinkConfig } from './push/WebhookSink';
 import type { GateConfig } from './approvals/gateConfig';
 import {
   CHANNEL_AUTO_TRASH_ARCHIVED_HOURS_DEFAULT,
@@ -198,6 +198,66 @@ function coerceBrowserCdp(raw: unknown, defaults: BrowserCdpConfig): BrowserCdpC
       enabled: typeof enabledRaw === 'boolean' ? enabledRaw : defaults.cdp.enabled,
     },
   };
+}
+
+/**
+ * The notify path's READ-ONLY view of `notifySinks`.
+ *
+ * Deliberately not `loadConfig()`. That function is a boot-time repair tool: a
+ * read error or a parse failure makes it REWRITE config.json with defaults,
+ * which is right when the daemon is starting and needs a usable file, and
+ * catastrophic on a per-notification hot path — one transient `EMFILE` while an
+ * approval fires would silently replace the operator's whole config with
+ * defaults. Nothing here writes, creates a directory, or mutates anything.
+ *
+ * Cached on (mtimeMs, size) so the steady state is one `stat` per notification
+ * rather than a full read+parse, while a `wmux` config edit still takes effect
+ * on the next event without a daemon restart.
+ *
+ * A failure degrades to "no sinks" — the same OFF that an absent key means.
+ */
+let notifySinksCache: { mtimeMs: number; size: number; sinks: NotifySinkConfig[] } | null = null;
+
+export function readNotifySinks(
+  log?: (level: 'warn', message: string) => void,
+): NotifySinkConfig[] {
+  const configPath = getConfigPath();
+  try {
+    const stat = fs.statSync(configPath);
+    if (
+      notifySinksCache &&
+      notifySinksCache.mtimeMs === stat.mtimeMs &&
+      notifySinksCache.size === stat.size
+    ) {
+      return notifySinksCache.sinks;
+    }
+    const raw = fs.readFileSync(configPath, 'utf-8');
+    const parsed: unknown = JSON.parse(raw, (key, value) => {
+      // Same prototype-pollution guard loadConfig uses.
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') return undefined;
+      return value;
+    });
+    const slice =
+      parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)['notifySinks']
+        : undefined;
+    // Coercion warnings ride the caller's logger, and the cache means they are
+    // emitted once per config EDIT rather than once per notification.
+    const sinks = coerceNotifySinks(slice, log);
+    notifySinksCache = { mtimeMs: stat.mtimeMs, size: stat.size, sinks };
+    return sinks;
+  } catch {
+    // No file, unreadable, or unparseable — all mean "no sinks" here, and none
+    // of them means "rewrite the operator's config". The cache is cleared so a
+    // repaired file is picked up rather than shadowed by a stale entry.
+    notifySinksCache = null;
+    return [];
+  }
+}
+
+/** Test seam: forget the mtime cache so a rewritten temp config is re-read. */
+export function resetNotifySinksCache(): void {
+  notifySinksCache = null;
 }
 
 /**

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import os from 'node:os';
 import type { BrowserCdpConfig, ChannelRetentionConfig, DaemonConfig } from './types';
 import { coerceGate, createDefaultGateConfig } from './approvals/gateConfig';
+import { coerceNotifySinks } from './push/WebhookSink';
 import type { GateConfig } from './approvals/gateConfig';
 import {
   CHANNEL_AUTO_TRASH_ARCHIVED_HOURS_DEFAULT,
@@ -136,6 +137,9 @@ export function createDefaultConfig(): DaemonConfig {
     browser: { cdp: { enabled: true } },
     // #783 — PreToolUse permission gate. Defaults to high-risk tools only.
     gate: createDefaultGateConfig(),
+    // Outbound webhook/ntfy notifications. Empty = off; written out so a fresh
+    // config.json shows operators the key exists without turning anything on.
+    notifySinks: [],
   };
 }
 
@@ -336,6 +340,16 @@ export function loadConfig(): DaemonConfig {
     // Absent slice (old config.json) → DEFAULT_GATED_TOOLS. A malformed slice
     // degrades to the defaults too, never silently disabling the gate.
     config.gate = coerceGate(config.gate);
+
+    // ── Outbound notification sinks: per-field backfill ──
+    // Absent slice (every config.json written before this existed) → an empty
+    // list, i.e. no outbound traffic. Degrading to "off" rather than to a
+    // default is the point: a sink the operator did not configure would be a
+    // connection they did not ask for. validateConfig ignores the field, so a
+    // malformed entry drops on its own without resetting the file.
+    config.notifySinks = coerceNotifySinks(config.notifySinks, (level, message) => {
+      console.warn(`[daemon/config] ${level}: ${message}`);
+    });
 
     return config;
   } catch (err) {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { loadConfig, saveConfig, getWmuxDir } from './config';
+import { loadConfig, saveConfig, getWmuxDir, readNotifySinks } from './config';
 import { DaemonSessionManager } from './DaemonSessionManager';
 import { PaneSupervisor } from './PaneSupervisor';
 import { DaemonPipeServer } from './DaemonPipeServer';
@@ -74,7 +74,7 @@ import { TranscriptProjector } from './transcript/TranscriptProjector';
 import { TranscriptDiscovery, DISCOVERABLE_AGENT } from './transcript/TranscriptDiscovery';
 import { PushSender } from './push/PushSender';
 import { approvalPushCollapseId, buildApprovalPushPayload } from './push/approvalPushPayload';
-import { WebhookSink, coerceNotifySinks } from './push/WebhookSink';
+import { WebhookSink } from './push/WebhookSink';
 import { buildApprovalNotifyPayload, buildAttentionNotifyPayload } from './push/notifyPayload';
 import { ApprovalRegistry } from './approvals/ApprovalRegistry';
 import { GateBroker } from './approvals/GateBroker';
@@ -4946,10 +4946,15 @@ async function main(): Promise<void> {
   // the operator puts a URL in `config.notifySinks`; `WMUX_NOTIFY_SINKS=0`
   // turns it off outright. Outbound only — no new listening surface.
   //
-  // `sinks()` re-reads config on every notification so an edit takes effect
-  // without a daemon restart, matching how `gateConfig` is wired above.
+  // `sinks()` re-reads config so an edit takes effect without a daemon restart,
+  // matching how `gateConfig` is wired above — but through `readNotifySinks`,
+  // NOT `loadConfig`. loadConfig repairs a bad file by overwriting it with
+  // defaults, which is correct at boot and unacceptable on a per-notification
+  // path: one transient read error while an approval fires would replace the
+  // operator's entire config. readNotifySinks only ever reads, and caches on
+  // mtime so the steady state is a stat rather than a parse.
   webhookSink = new WebhookSink({
-    sinks: () => coerceNotifySinks(loadConfig().notifySinks),
+    sinks: () => readNotifySinks((level, msg) => log(level, msg)),
     log: (level, msg) => log(level, msg),
   });
   approvalRegistry.onEvent((event) => {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -74,6 +74,8 @@ import { TranscriptProjector } from './transcript/TranscriptProjector';
 import { TranscriptDiscovery, DISCOVERABLE_AGENT } from './transcript/TranscriptDiscovery';
 import { PushSender } from './push/PushSender';
 import { approvalPushCollapseId, buildApprovalPushPayload } from './push/approvalPushPayload';
+import { WebhookSink, coerceNotifySinks } from './push/WebhookSink';
+import { buildApprovalNotifyPayload, buildAttentionNotifyPayload } from './push/notifyPayload';
 import { ApprovalRegistry } from './approvals/ApprovalRegistry';
 import { GateBroker } from './approvals/GateBroker';
 import { coerceGate } from './approvals/gateConfig';
@@ -97,6 +99,11 @@ let webTerminalServer: WebTerminalServer | null = null;
 // those two live in separate functions; registerRpcHandlers runs first and
 // constructs it.
 let hookIngest: HookIngest | null = null;
+// Outbound webhook/ntfy notifications. Module-scoped for the same reason
+// `webTerminalServer` is: the hook-event site that fires attention pings is
+// registered before the boot path that constructs this, so both sides read the
+// handle at fire time and a null is simply "not configured yet".
+let webhookSink: WebhookSink | null = null;
 let transcriptProjector: TranscriptProjector | null = null;
 let transcriptDiscovery: TranscriptDiscovery | null = null;
 
@@ -2854,6 +2861,18 @@ function registerRpcHandlers(
         // WebTerminalServer.emitAgentLiveness). Harmless when the web server is
         // off or nobody opened the pane's turn view.
         webTerminalServer?.emitAgentLiveness(deriveAgentLiveness(sessionId, data, Date.now()));
+        // Outbound notification sinks: the END of a turn, and only the real one.
+        // `agent.subagent_stop` also reports `status:'complete'`, and a run with
+        // a dozen subagents would fire a dozen pings for one turn — so this keys
+        // on the signal kind, not the projected status.
+        if (data.signal.kind === 'agent.stop') {
+          webhookSink?.notify(
+            buildAttentionNotifyPayload(
+              { sessionId, ...(data.agent ? { agent: data.agent } : {}) },
+              { id: randomUUID(), now: Date.now() },
+            ),
+          );
+        }
       },
       applyResumeBinding: (id, binding) => { applyResumeBinding(id, binding); },
       log: (level, message) => log(level, message),
@@ -4923,12 +4942,25 @@ async function main(): Promise<void> {
     forgetPush: (deviceId) => getDeviceStore().forgetPush(deviceId),
     log: (level, msg) => log(level, msg),
   });
+  // The phone-less path, alongside push rather than instead of it. Inert until
+  // the operator puts a URL in `config.notifySinks`; `WMUX_NOTIFY_SINKS=0`
+  // turns it off outright. Outbound only — no new listening surface.
+  //
+  // `sinks()` re-reads config on every notification so an edit takes effect
+  // without a daemon restart, matching how `gateConfig` is wired above.
+  webhookSink = new WebhookSink({
+    sinks: () => coerceNotifySinks(loadConfig().notifySinks),
+    log: (level, msg) => log(level, msg),
+  });
   approvalRegistry.onEvent((event) => {
     // Only a NEW request is worth a phone buzzing. A resolve or an expire is
     // the thing the notification was asking for, already handled.
     if (event.type !== 'create') return;
     const r = event.request;
     pushSender.notify(buildApprovalPushPayload(r), { collapseId: approvalPushCollapseId(r) });
+    webhookSink?.notify(
+      buildApprovalNotifyPayload(r, { id: randomUUID(), now: Date.now() }),
+    );
   });
   const pipeServer = new DaemonPipeServer(config.daemon.pipeName);
   // Channels (a2a-channels U3). Channels live in their own file

--- a/src/daemon/push/WebhookSink.ts
+++ b/src/daemon/push/WebhookSink.ts
@@ -37,8 +37,8 @@ const EVENT_KINDS: readonly NotifyEventKind[] = ['approval', 'attention'];
 /**
  * How many sinks one config may name.
  *
- * Every notification fans out to all of them serially, so an unbounded list is
- * an unbounded stall on a slow endpoint. Eight is well past any real setup.
+ * Every notification fans out to all of them at once, so the list is also the
+ * concurrency of one send. Eight is well past any real setup.
  */
 export const NOTIFY_SINKS_MAX = 8;
 
@@ -74,7 +74,7 @@ export function coerceNotifySinks(
       log?.('warn', `[notify] ignoring a ${type} sink: the url must be an absolute http(s) URL`);
       continue;
     }
-    const events = coerceEvents(slice['events']);
+    const events = coerceEvents(slice['events'], type, log);
     out.push({
       type: type as NotifySinkConfig['type'],
       url,
@@ -84,14 +84,33 @@ export function coerceNotifySinks(
   return out;
 }
 
-function coerceEvents(raw: unknown): NotifyEventKind[] | undefined {
+function coerceEvents(
+  raw: unknown,
+  type: string,
+  log?: (level: 'warn', message: string) => void,
+): NotifyEventKind[] | undefined {
   if (!Array.isArray(raw)) return undefined;
-  const events = raw.filter(
-    (e): e is NotifyEventKind => typeof e === 'string' && EVENT_KINDS.includes(e as NotifyEventKind),
-  );
+  const events: NotifyEventKind[] = [];
+  for (const entry of raw) {
+    if (typeof entry === 'string' && EVENT_KINDS.includes(entry as NotifyEventKind)) {
+      events.push(entry as NotifyEventKind);
+      continue;
+    }
+    // NAMED, because the failure mode is invisible: `"aproval"` silences the
+    // sink forever and looks exactly like a sink whose events never fire.
+    log?.(
+      'warn',
+      `[notify] ${type} sink: unknown event ${JSON.stringify(entry)} — known events are ` +
+        `${EVENT_KINDS.join(', ')}`,
+    );
+  }
   // An array that named nothing we recognise stays an EMPTY list rather than
   // becoming "all events": the operator was clearly trying to narrow, and
-  // widening on a typo is the wrong direction to fail in.
+  // widening on a typo is the wrong direction to fail in. It is loud, though —
+  // a permanently silent sink is worth a line in the log.
+  if (events.length === 0) {
+    log?.('warn', `[notify] ${type} sink: no recognised events — it will never fire`);
+  }
   return events;
 }
 
@@ -116,15 +135,31 @@ export function isSendableUrl(raw: string): boolean {
   return parsed.protocol === 'http:' || parsed.protocol === 'https:';
 }
 
-/** Same reasoning as PUSH_QUEUE_CAP: a backlog of "answer me now" is not worth delivering. */
+/**
+ * Same reasoning as PUSH_QUEUE_CAP: a backlog of "answer me now" is not worth
+ * delivering. Applied PER EVENT KIND — see `queues`.
+ */
 export const NOTIFY_QUEUE_CAP = 32;
 
 /** Give up rather than hold a slot indefinitely. */
 export const NOTIFY_TIMEOUT_MS = 5_000;
 
-/** ntfy priority levels. 4 = high (buzzes through), 3 = default. */
+/**
+ * ntfy priority levels. 5 = max (bypasses most quiet settings), 4 = high,
+ * 3 = default.
+ *
+ * The tiers are the point: a `rm -rf` approval and a turn-completion ping
+ * arriving with the same urgency trains people to ignore both.
+ */
+const NTFY_PRIORITY_MAX = '5';
 const NTFY_PRIORITY_HIGH = '4';
 const NTFY_PRIORITY_DEFAULT = '3';
+
+/** The ntfy `Priority` header for one payload. */
+function ntfyPriority(payload: NotifyPayload): string {
+  if (payload.event !== 'approval') return NTFY_PRIORITY_DEFAULT;
+  return payload.risk === 'critical' ? NTFY_PRIORITY_MAX : NTFY_PRIORITY_HIGH;
+}
 
 export interface WebhookSinkDeps {
   /** Re-read per notification, so a config edit takes effect without a restart. */
@@ -137,12 +172,30 @@ export interface WebhookSinkDeps {
 export class WebhookSink {
   private readonly deps: WebhookSinkDeps;
   private readonly fetchImpl: typeof fetch;
-  private readonly queue: NotifyPayload[] = [];
+  /**
+   * One queue PER EVENT KIND, not one shared FIFO.
+   *
+   * A shared queue with drop-oldest has a failure mode that defeats the whole
+   * feature: `attention` fires on every turn a machine completes, so a busy
+   * afternoon can push 32 turn-completions through the queue and evict the one
+   * `approval` that is actually blocking an agent. Notifications are not
+   * fungible, so they do not share a budget — a flood of the chatty kind can
+   * only ever evict its own.
+   *
+   * `approval` also drains first, so a backlog of the chatty kind cannot delay
+   * the kind someone is waiting on.
+   */
+  private readonly queues: Record<NotifyEventKind, NotifyPayload[]> = {
+    approval: [],
+    attention: [],
+  };
   /** The in-flight drain, or null — same seam PushSender uses so `flush` waits. */
   private drainPromise: Promise<void> | null = null;
-  private dropped = 0;
+  private readonly dropped: Record<NotifyEventKind, number> = { approval: 0, attention: 0 };
   /** Last failure per sink url, so a steady outage logs once, not per send. */
   private readonly lastFailure = new Map<string, number | null>();
+  /** Urls already warned about for cleartext, so the notice is once per url. */
+  private readonly cleartextWarned = new Set<string>();
 
   constructor(deps: WebhookSinkDeps) {
     this.deps = deps;
@@ -165,36 +218,60 @@ export class WebhookSink {
    */
   notify(payload: NotifyPayload): void {
     if (!this.enabled) return;
-    if (this.queue.length >= NOTIFY_QUEUE_CAP) {
-      this.queue.shift();
-      this.dropped += 1;
+    const queue = this.queues[payload.event];
+    if (queue.length >= NOTIFY_QUEUE_CAP) {
+      queue.shift();
+      this.dropped[payload.event] += 1;
+      const n = this.dropped[payload.event];
       // One line per burst, not per drop.
-      if (this.dropped === 1 || this.dropped % 25 === 0) {
-        this.deps.log?.('warn', `[notify] queue full, dropped ${this.dropped} notification(s)`);
+      if (n === 1 || n % 25 === 0) {
+        this.deps.log?.('warn', `[notify] ${payload.event} queue full, dropped ${n} notification(s)`);
       }
     }
-    this.queue.push(payload);
+    queue.push(payload);
     void this.drain();
   }
 
-  /** Test seam: wait for the queue to empty. */
+  /** Anything queued, in either kind? */
+  private pending(): boolean {
+    return this.queues.approval.length > 0 || this.queues.attention.length > 0;
+  }
+
+  /** The next payload to send — approvals first, then attention. */
+  private take(): NotifyPayload | undefined {
+    return this.queues.approval.shift() ?? this.queues.attention.shift();
+  }
+
+  /**
+   * Test seam: wait until nothing is queued AND no drain is running.
+   *
+   * The loop is not belt-and-braces. A drain that finished can be restarted
+   * from its own `finally` (see `drain`), so a single `await` can return while
+   * a freshly restarted drain is still in flight.
+   */
   async flush(): Promise<void> {
-    await this.drain();
+    while (this.drainPromise || this.pending()) {
+      await this.drain();
+    }
   }
 
   private drain(): Promise<void> {
     if (!this.drainPromise) {
       this.drainPromise = this.runDrain().finally(() => {
         this.drainPromise = null;
+        // RESTART, do not just clear. `runDrain` returns synchronously when it
+        // finds the queues empty, but this callback runs a microtask later —
+        // and a `notify()` landing in that gap sees a non-null `drainPromise`,
+        // joins the drain that is already finishing, and has its payload
+        // stranded until some unrelated event happens to start another one.
+        if (this.pending()) void this.drain();
       });
     }
     return this.drainPromise;
   }
 
   private async runDrain(): Promise<void> {
-    while (this.queue.length > 0) {
-      const next = this.queue.shift();
-      if (!next) break;
+    for (let next = this.take(); next !== undefined; next = this.take()) {
       try {
         await this.send(next);
       } catch (err) {
@@ -204,21 +281,57 @@ export class WebhookSink {
     }
   }
 
+  /**
+   * Fan one payload out to every matching sink CONCURRENTLY.
+   *
+   * Serially, one endpoint that black-holes packets costs every sink behind it
+   * the full 5 s timeout — with the cap at eight sinks that is a 40 s stall on
+   * a queue whose entire purpose is telling someone an agent is blocked right
+   * now. `allSettled` because one dead sink must not abort delivery to the
+   * healthy ones, and because a rejection here would unwind into `runDrain`'s
+   * catch and get logged as if the whole notification failed.
+   */
   private async send(payload: NotifyPayload): Promise<void> {
-    for (const sink of this.deps.sinks()) {
-      if (sink.events && !sink.events.includes(payload.event)) continue;
+    const matching = this.deps.sinks().filter((sink) => {
+      if (sink.events && !sink.events.includes(payload.event)) return false;
       // Re-checked at send time, not just at coerce time: `sinks()` re-reads
       // config, so an edit between boot and now has not been through coercion.
-      if (!isSendableUrl(sink.url)) continue;
-      const status = await this.postOnce(sink, payload);
-      this.noteOutcome(sink, status);
-    }
+      return isSendableUrl(sink.url);
+    });
+    await Promise.allSettled(
+      matching.map(async (sink) => {
+        this.warnCleartextOnce(sink);
+        const status = await this.postOnce(sink, payload);
+        this.noteOutcome(sink, status);
+      }),
+    );
+  }
+
+  /**
+   * Say once, per url, that an `http:` sink is not private.
+   *
+   * `http:` stays ALLOWED — a self-hosted ntfy on the LAN is the main reason
+   * this feature exists and forcing TLS there would just mean nobody uses it.
+   * But the body names which machine wants attention, and on ntfy the topic in
+   * the URL is the only thing standing between a stranger and the notification
+   * stream. That is worth knowing once, not suppressing.
+   */
+  private warnCleartextOnce(sink: NotifySinkConfig): void {
+    if (this.cleartextWarned.has(sink.url)) return;
+    if (!sink.url.startsWith('http://')) return;
+    this.cleartextWarned.add(sink.url);
+    this.deps.log?.(
+      'warn',
+      `[notify] the ${sink.type} sink uses http:// — notifications, and an ntfy topic name, ` +
+        'travel in cleartext. Use https:// unless this stays on a trusted network.',
+    );
   }
 
   /** One attempt. Returns the HTTP status, or null when it never got an answer. */
   private async postOnce(sink: NotifySinkConfig, payload: NotifyPayload): Promise<number | null> {
+    let res: Response;
     try {
-      const res = await this.fetchImpl(sink.url, {
+      res = await this.fetchImpl(sink.url, {
         method: 'POST',
         ...(sink.type === 'ntfy'
           ? {
@@ -226,7 +339,7 @@ export class WebhookSink {
                 'content-type': 'text/plain; charset=utf-8',
                 // ntfy reads these; both are derived, never agent text.
                 Title: payload.title,
-                Priority: payload.event === 'approval' ? NTFY_PRIORITY_HIGH : NTFY_PRIORITY_DEFAULT,
+                Priority: ntfyPriority(payload),
               },
               body: notifyMessageText(payload),
             }
@@ -238,12 +351,18 @@ export class WebhookSink {
         redirect: 'manual',
         signal: AbortSignal.timeout(NOTIFY_TIMEOUT_MS),
       });
-      return res.status;
     } catch {
       // Never log the URL — it can carry an ntfy topic that is itself the
       // secret protecting the notification stream.
       return null;
     }
+    // The status is all we want, but undici holds the connection and its
+    // buffers until the body is consumed or cancelled. Reading only `res.status`
+    // and dropping the response leaks a socket per notification until GC gets
+    // round to it — on a long-lived daemon sending these all day, that is a
+    // slow leak plus a connection pool that never recycles.
+    await discardBody(res);
+    return res.status;
   }
 
   /**
@@ -269,6 +388,27 @@ export class WebhookSink {
         ? `[notify] no response from the ${sink.type} sink`
         : `[notify] the ${sink.type} sink answered ${status}`,
     );
+  }
+}
+
+/**
+ * Release the response body without looking at it.
+ *
+ * `cancel()` is the cheap path — it tells the transport we want none of it, so
+ * nothing is buffered. A body that was already consumed (or a stub response in
+ * a test) has no stream, and `arrayBuffer()` covers that; both are wrapped
+ * because a failure to drain is not a failure to notify, and must never turn a
+ * delivered notification into a logged error.
+ */
+async function discardBody(res: Response): Promise<void> {
+  try {
+    if (res.body && !res.bodyUsed) {
+      await res.body.cancel();
+      return;
+    }
+    if (!res.bodyUsed) await res.arrayBuffer();
+  } catch {
+    // Nothing to do — the status was already read.
   }
 }
 

--- a/src/daemon/push/WebhookSink.ts
+++ b/src/daemon/push/WebhookSink.ts
@@ -1,0 +1,277 @@
+// The daemon's phone-less notification path: POST a small plaintext JSON body
+// to an operator-configured URL, or a one-line message to an ntfy topic.
+//
+// A sibling of `PushSender`, not a generalisation of it. The two share a shape
+// — fire and forget, bounded queue, drop oldest — and share nothing else: push
+// seals its payload to a device key and speaks the relay's protocol, while this
+// one hands readable text to a server the operator picked. Merging them would
+// mean one module holding both "the payload is opaque to the transport" and
+// "the payload is the transport's message body", and the first of those is a
+// security claim worth keeping unqualified.
+//
+// This adds NO listening surface. The daemon's loopback-only default is
+// untouched; everything here is outbound.
+
+import {
+  notifyMessageText,
+  type NotifyEventKind,
+  type NotifyPayload,
+} from './notifyPayload';
+
+/** Where one notification goes, and which events reach it. */
+export interface NotifySinkConfig {
+  /**
+   * `webhook` — POST the payload as JSON.
+   * `ntfy`    — POST the message text as the body, metadata in headers.
+   */
+  type: 'webhook' | 'ntfy';
+  /** Absolute http(s) URL. For ntfy this is the topic URL. */
+  url: string;
+  /** Which events to send. Absent = all of them. */
+  events?: NotifyEventKind[];
+}
+
+const SINK_TYPES: readonly NotifySinkConfig['type'][] = ['webhook', 'ntfy'];
+const EVENT_KINDS: readonly NotifyEventKind[] = ['approval', 'attention'];
+
+/**
+ * How many sinks one config may name.
+ *
+ * Every notification fans out to all of them serially, so an unbounded list is
+ * an unbounded stall on a slow endpoint. Eight is well past any real setup.
+ */
+export const NOTIFY_SINKS_MAX = 8;
+
+/**
+ * Per-field coercion for the `notifySinks` slice, in the convention the
+ * `lanlink` / `browser` / `gate` slices already follow: `validateConfig` never
+ * inspects this key, so a malformed entry degrades HERE and cannot trigger the
+ * whole-file reset that would take `pipeName` with it.
+ *
+ * Degrades to "off", not to a default: a notification the operator did not
+ * configure would be an outbound connection they did not ask for. A garbage
+ * entry is dropped individually; its siblings survive.
+ */
+export function coerceNotifySinks(
+  raw: unknown,
+  log?: (level: 'warn', message: string) => void,
+): NotifySinkConfig[] {
+  if (!Array.isArray(raw)) return [];
+  const out: NotifySinkConfig[] = [];
+  for (const entry of raw) {
+    if (out.length >= NOTIFY_SINKS_MAX) {
+      log?.('warn', `[notify] more than ${NOTIFY_SINKS_MAX} sinks configured — ignoring the rest`);
+      break;
+    }
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const slice = entry as Record<string, unknown>;
+    const type = slice['type'];
+    const url = slice['url'];
+    if (typeof type !== 'string' || !SINK_TYPES.includes(type as NotifySinkConfig['type'])) continue;
+    if (typeof url !== 'string' || !isSendableUrl(url)) {
+      // Named, because a silently ignored sink looks exactly like a sink that
+      // is working and whose notifications are being lost.
+      log?.('warn', `[notify] ignoring a ${type} sink: the url must be an absolute http(s) URL`);
+      continue;
+    }
+    const events = coerceEvents(slice['events']);
+    out.push({
+      type: type as NotifySinkConfig['type'],
+      url,
+      ...(events ? { events } : {}),
+    });
+  }
+  return out;
+}
+
+function coerceEvents(raw: unknown): NotifyEventKind[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const events = raw.filter(
+    (e): e is NotifyEventKind => typeof e === 'string' && EVENT_KINDS.includes(e as NotifyEventKind),
+  );
+  // An array that named nothing we recognise stays an EMPTY list rather than
+  // becoming "all events": the operator was clearly trying to narrow, and
+  // widening on a typo is the wrong direction to fail in.
+  return events;
+}
+
+/**
+ * The only URL rule.
+ *
+ * The destination is operator-configured, so this is not the untrusted-input
+ * problem the navigation SSRF guard solves — a private-range host is a normal
+ * answer here (a self-hosted ntfy on the LAN is the common case) and blocking
+ * it would break the feature for the people most likely to use it. What is
+ * never legitimate is a non-http(s) scheme: `file:`, `data:` and friends are
+ * not destinations, they are ways to make `fetch` do something other than send
+ * a notification.
+ */
+export function isSendableUrl(raw: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return false;
+  }
+  return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+}
+
+/** Same reasoning as PUSH_QUEUE_CAP: a backlog of "answer me now" is not worth delivering. */
+export const NOTIFY_QUEUE_CAP = 32;
+
+/** Give up rather than hold a slot indefinitely. */
+export const NOTIFY_TIMEOUT_MS = 5_000;
+
+/** ntfy priority levels. 4 = high (buzzes through), 3 = default. */
+const NTFY_PRIORITY_HIGH = '4';
+const NTFY_PRIORITY_DEFAULT = '3';
+
+export interface WebhookSinkDeps {
+  /** Re-read per notification, so a config edit takes effect without a restart. */
+  sinks: () => NotifySinkConfig[];
+  log?: (level: 'info' | 'warn' | 'error', message: string) => void;
+  /** Injected for tests; defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+export class WebhookSink {
+  private readonly deps: WebhookSinkDeps;
+  private readonly fetchImpl: typeof fetch;
+  private readonly queue: NotifyPayload[] = [];
+  /** The in-flight drain, or null — same seam PushSender uses so `flush` waits. */
+  private drainPromise: Promise<void> | null = null;
+  private dropped = 0;
+  /** Last failure per sink url, so a steady outage logs once, not per send. */
+  private readonly lastFailure = new Map<string, number | null>();
+
+  constructor(deps: WebhookSinkDeps) {
+    this.deps = deps;
+    this.fetchImpl = deps.fetchImpl ?? globalThis.fetch;
+  }
+
+  /**
+   * Whether a send would do anything. No sinks configured is the normal state
+   * and is inert, never an error. `WMUX_NOTIFY_SINKS=0` is the kill switch.
+   */
+  get enabled(): boolean {
+    if (process.env.WMUX_NOTIFY_SINKS === '0') return false;
+    return this.deps.sinks().length > 0;
+  }
+
+  /**
+   * Queue one notification. Returns immediately — the hook path and the
+   * approval registry both call this and neither may wait on a network round
+   * trip.
+   */
+  notify(payload: NotifyPayload): void {
+    if (!this.enabled) return;
+    if (this.queue.length >= NOTIFY_QUEUE_CAP) {
+      this.queue.shift();
+      this.dropped += 1;
+      // One line per burst, not per drop.
+      if (this.dropped === 1 || this.dropped % 25 === 0) {
+        this.deps.log?.('warn', `[notify] queue full, dropped ${this.dropped} notification(s)`);
+      }
+    }
+    this.queue.push(payload);
+    void this.drain();
+  }
+
+  /** Test seam: wait for the queue to empty. */
+  async flush(): Promise<void> {
+    await this.drain();
+  }
+
+  private drain(): Promise<void> {
+    if (!this.drainPromise) {
+      this.drainPromise = this.runDrain().finally(() => {
+        this.drainPromise = null;
+      });
+    }
+    return this.drainPromise;
+  }
+
+  private async runDrain(): Promise<void> {
+    while (this.queue.length > 0) {
+      const next = this.queue.shift();
+      if (!next) break;
+      try {
+        await this.send(next);
+      } catch (err) {
+        // A send that throws must not wedge the queue.
+        this.deps.log?.('warn', `[notify] send failed: ${errMsg(err)}`);
+      }
+    }
+  }
+
+  private async send(payload: NotifyPayload): Promise<void> {
+    for (const sink of this.deps.sinks()) {
+      if (sink.events && !sink.events.includes(payload.event)) continue;
+      // Re-checked at send time, not just at coerce time: `sinks()` re-reads
+      // config, so an edit between boot and now has not been through coercion.
+      if (!isSendableUrl(sink.url)) continue;
+      const status = await this.postOnce(sink, payload);
+      this.noteOutcome(sink, status);
+    }
+  }
+
+  /** One attempt. Returns the HTTP status, or null when it never got an answer. */
+  private async postOnce(sink: NotifySinkConfig, payload: NotifyPayload): Promise<number | null> {
+    try {
+      const res = await this.fetchImpl(sink.url, {
+        method: 'POST',
+        ...(sink.type === 'ntfy'
+          ? {
+              headers: {
+                'content-type': 'text/plain; charset=utf-8',
+                // ntfy reads these; both are derived, never agent text.
+                Title: payload.title,
+                Priority: payload.event === 'approval' ? NTFY_PRIORITY_HIGH : NTFY_PRIORITY_DEFAULT,
+              },
+              body: notifyMessageText(payload),
+            }
+          : {
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify(payload),
+            }),
+        // A redirect can move the destination off the host the operator named.
+        redirect: 'manual',
+        signal: AbortSignal.timeout(NOTIFY_TIMEOUT_MS),
+      });
+      return res.status;
+    } catch {
+      // Never log the URL — it can carry an ntfy topic that is itself the
+      // secret protecting the notification stream.
+      return null;
+    }
+  }
+
+  /**
+   * Log a terminal failure only when it CHANGES for that sink, and log the
+   * recovery once. A dead endpoint fails identically every time; one line per
+   * notification would bury the transition that matters.
+   */
+  private noteOutcome(sink: NotifySinkConfig, status: number | null): void {
+    const ok = status !== null && status >= 200 && status < 300;
+    const previous = this.lastFailure.get(sink.url);
+    if (ok) {
+      if (previous !== undefined) {
+        this.lastFailure.delete(sink.url);
+        this.deps.log?.('info', `[notify] ${sink.type} sink is answering again`);
+      }
+      return;
+    }
+    if (previous === status) return;
+    this.lastFailure.set(sink.url, status);
+    this.deps.log?.(
+      'warn',
+      status === null
+        ? `[notify] no response from the ${sink.type} sink`
+        : `[notify] the ${sink.type} sink answered ${status}`,
+    );
+  }
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/daemon/push/__tests__/WebhookSink.test.ts
+++ b/src/daemon/push/__tests__/WebhookSink.test.ts
@@ -13,6 +13,8 @@ import {
   buildAttentionNotifyPayload,
   type NotifyPayload,
 } from '../notifyPayload';
+import { buildApprovalPushPayload } from '../approvalPushPayload';
+import { PUSH_RISK_CRITICAL } from '../../../shared/push/pushEnvelope';
 import type { ApprovalRequest } from '../../approvals/types';
 
 const IDENTITY = { id: 'evt-1', now: Date.UTC(2026, 0, 2, 3, 4, 5) };
@@ -54,6 +56,29 @@ function harness(sinks: NotifySinkConfig[], status = 200): Harness {
     }) as unknown as typeof fetch,
   });
   return { sink, calls, logs };
+}
+
+/**
+ * A sink whose first send hangs until `release()`, so everything after it is
+ * observably sitting in the queue. `calls` is the payload ids, in send order.
+ */
+function holdingSink(): { sink: WebhookSink; calls: string[]; release: () => void } {
+  let release!: () => void;
+  const gate = new Promise<void>((r) => { release = r; });
+  const calls: string[] = [];
+  let first = true;
+  const sink = new WebhookSink({
+    sinks: () => [{ type: 'webhook', url: 'https://hooks.example/wmux' }],
+    fetchImpl: (async (_url: string, init: RequestInit) => {
+      calls.push(JSON.parse(String(init.body)).id);
+      if (first) {
+        first = false;
+        await gate;
+      }
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch,
+  });
+  return { sink, calls, release };
 }
 
 describe('notifyPayload — the outbound allowlist', () => {
@@ -106,6 +131,39 @@ describe('notifyPayload — the outbound allowlist', () => {
       ).risk,
     ).toBeUndefined();
   });
+
+  it('agrees with the sealed push payload on danger, input for input', () => {
+    // The two paths must never disagree about what counts as destructive: one
+    // decides a lock-screen approve button, the other how loudly a phone rings.
+    // They call the same helper, and this is the test that keeps it that way.
+    const cases: ApprovalRequest[] = [
+      approval(),
+      approval({ question: 'Which colour should the button be?', options: ['Blue'], choices: undefined }),
+      approval({ risk: 'critical', question: 'Proceed?', options: undefined, choices: undefined }),
+      approval({ question: 'Pick one', options: ['Keep it', 'DROP TABLE users'], choices: undefined }),
+      approval({
+        kind: 'awaiting_permission',
+        question: undefined,
+        options: undefined,
+        choices: undefined,
+        toolName: 'Bash',
+        toolInputSummary: 'rm -rf /tmp/build',
+      }),
+      approval({
+        kind: 'awaiting_permission',
+        question: undefined,
+        options: undefined,
+        choices: undefined,
+        toolName: 'Read',
+        toolInputSummary: 'package.json',
+      }),
+    ];
+    for (const request of cases) {
+      const pushSaysCritical = buildApprovalPushPayload(request).risk === PUSH_RISK_CRITICAL;
+      const webhookSaysCritical = buildApprovalNotifyPayload(request, IDENTITY).risk === 'critical';
+      expect(webhookSaysCritical).toBe(pushSaysCritical);
+    }
+  });
 });
 
 describe('WebhookSink', () => {
@@ -130,8 +188,51 @@ describe('WebhookSink', () => {
     expect(String(ntfy.init.body)).toBe('Approval needed · claude · pane 11111111 · ws 99999999');
     const headers = ntfy.init.headers as Record<string, string>;
     expect(headers['Title']).toBe('Approval needed');
-    // approval = high priority.
-    expect(headers['Priority']).toBe('4');
+  });
+
+  it('maps risk onto the ntfy Priority header', async () => {
+    const priorities: string[] = [];
+    const h = harness([{ type: 'ntfy', url: 'https://ntfy.sh/t' }]);
+    const calm = approval({
+      question: 'Which colour should the button be?',
+      options: ['Blue', 'Green'],
+      choices: undefined,
+    });
+    // critical approval → max, ordinary approval → high, attention → default.
+    h.sink.notify(buildApprovalNotifyPayload(approval(), IDENTITY));
+    h.sink.notify(buildApprovalNotifyPayload(calm, IDENTITY));
+    h.sink.notify(buildAttentionNotifyPayload({ sessionId: 's' }, IDENTITY));
+    await h.sink.flush();
+    for (const call of h.calls) {
+      priorities.push((call.init.headers as Record<string, string>)['Priority']);
+    }
+    expect(priorities).toEqual(['5', '4', '3']);
+  });
+
+  it('releases the response body instead of leaking the socket', async () => {
+    const cancel = vi.fn(async () => undefined);
+    const sink = new WebhookSink({
+      sinks: () => [{ type: 'webhook', url: 'https://hooks.example/wmux' }],
+      fetchImpl: (async () =>
+        ({ status: 200, bodyUsed: false, body: { cancel } }) as unknown as Response) as unknown as typeof fetch,
+    });
+    sink.notify(buildAttentionNotifyPayload({ sessionId: 's' }, IDENTITY));
+    await sink.flush();
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns once per http:// sink that the notification travels cleartext', async () => {
+    const h = harness([{ type: 'ntfy', url: 'http://192.168.1.10/wmux' }]);
+    for (let i = 0; i < 3; i += 1) {
+      h.sink.notify(buildAttentionNotifyPayload({ sessionId: 's' }, { id: `n${i}`, now: 0 }));
+    }
+    await h.sink.flush();
+    const cleartext = h.logs.filter((l) => l.includes('cleartext'));
+    expect(cleartext).toHaveLength(1);
+    // The warning must not itself leak the url it is warning about.
+    expect(cleartext[0]).not.toContain('192.168.1.10');
+    // Still delivered — http stays allowed.
+    expect(h.calls).toHaveLength(3);
   });
 
   it('honours the per-sink event filter', async () => {
@@ -141,32 +242,113 @@ describe('WebhookSink', () => {
     expect(h.calls).toHaveLength(0);
   });
 
-  it('drops the OLDEST notification when the queue is full', async () => {
-    let release!: () => void;
-    const gate = new Promise<void>((r) => { release = r; });
-    const calls: string[] = [];
-    const sink = new WebhookSink({
-      sinks: () => [{ type: 'webhook', url: 'https://hooks.example/wmux' }],
-      fetchImpl: (async (_url: string, init: RequestInit) => {
-        calls.push(JSON.parse(String(init.body)).id);
-        await gate;
-        return new Response(null, { status: 200 });
-      }) as unknown as typeof fetch,
-    });
+  it('drops the OLDEST notification of its own kind when the queue is full', async () => {
+    const held = holdingSink();
 
     // The first send is held in-flight, so everything after it queues.
     const total = NOTIFY_QUEUE_CAP + 5;
     for (let i = 0; i < total; i += 1) {
-      sink.notify(buildAttentionNotifyPayload({ sessionId: 'sess-1' }, { id: `n${i}`, now: 0 }));
+      held.sink.notify(buildAttentionNotifyPayload({ sessionId: 'sess-1' }, { id: `n${i}`, now: 0 }));
     }
-    release();
-    await sink.flush();
+    held.release();
+    await held.sink.flush();
 
     // n0 went in flight immediately; the cap then evicted the oldest waiters.
-    expect(calls[0]).toBe('n0');
-    expect(calls).toHaveLength(NOTIFY_QUEUE_CAP + 1);
-    expect(calls).not.toContain('n1');
-    expect(calls[calls.length - 1]).toBe(`n${total - 1}`);
+    expect(held.calls[0]).toBe('n0');
+    expect(held.calls).toHaveLength(NOTIFY_QUEUE_CAP + 1);
+    expect(held.calls).not.toContain('n1');
+    expect(held.calls[held.calls.length - 1]).toBe(`n${total - 1}`);
+  });
+
+  it('never lets an attention flood evict a queued approval', async () => {
+    const held = holdingSink();
+
+    // One approval, then far more attention events than the whole queue holds.
+    // A single shared FIFO with drop-oldest would evict the approval first —
+    // it is the oldest entry, and it is the only one anybody is blocked on.
+    held.sink.notify(buildAttentionNotifyPayload({ sessionId: 's' }, { id: 'head', now: 0 }));
+    held.sink.notify(buildApprovalNotifyPayload(approval(), { id: 'the-approval', now: 0 }));
+    for (let i = 0; i < NOTIFY_QUEUE_CAP * 3; i += 1) {
+      held.sink.notify(buildAttentionNotifyPayload({ sessionId: 's' }, { id: `flood${i}`, now: 0 }));
+    }
+    held.release();
+    await held.sink.flush();
+
+    expect(held.calls).toContain('the-approval');
+    // And it goes out FIRST — ahead of the attention backlog it was queued behind.
+    expect(held.calls[1]).toBe('the-approval');
+    // The flood only ever evicted its own kind.
+    expect(held.calls.filter((id) => id.startsWith('flood'))).toHaveLength(NOTIFY_QUEUE_CAP);
+  });
+
+  it('fans out to sinks in parallel, so one dead sink cannot stall the others', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const started: string[] = [];
+    const sink = new WebhookSink({
+      sinks: () => [
+        { type: 'webhook', url: 'https://slow.example/a' },
+        { type: 'webhook', url: 'https://fast.example/b' },
+        { type: 'webhook', url: 'https://fast.example/c' },
+      ],
+      fetchImpl: (async (url: string) => {
+        started.push(String(url));
+        // The first sink black-holes the request until we let it go. Serially,
+        // b and c would not even be attempted until it did.
+        if (String(url).includes('slow')) await gate;
+        return new Response(null, { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+
+    sink.notify(buildAttentionNotifyPayload({ sessionId: 's' }, IDENTITY));
+    // Let the microtasks settle while the slow sink is still hanging.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(started).toHaveLength(3);
+
+    release();
+    await sink.flush();
+  });
+
+  it('delivers a notification raised at ANY point while a drain is finishing', async () => {
+    // The bug this guards is a one-microtask window: `runDrain` returns when it
+    // finds the queues empty, but `drainPromise` is only cleared a microtask
+    // later. A notify() landing in between sees a non-null drainPromise, joins
+    // the drain that is already on its way out, and is stranded until some
+    // unrelated event starts another one.
+    //
+    // The window is a single hop, and which hop it is depends on how many awaits
+    // sit between the fetch resolving and the drain returning. So rather than
+    // guess, sweep the delay across the whole range — one of these lands in the
+    // window, and without the restart in `drain`'s finally that one strands.
+    for (let hops = 0; hops < 12; hops += 1) {
+      const calls: string[] = [];
+      const sink: WebhookSink = new WebhookSink({
+        sinks: () => [{ type: 'webhook', url: 'https://hooks.example/wmux' }],
+        fetchImpl: (async (_url: string, init: RequestInit) => {
+          const id = JSON.parse(String(init.body)).id as string;
+          calls.push(id);
+          if (id === 'first') {
+            let chain = Promise.resolve();
+            for (let i = 0; i < hops; i += 1) chain = chain.then(() => undefined);
+            void chain.then(() => {
+              sink.notify(buildAttentionNotifyPayload({ sessionId: 's' }, { id: 'second', now: 0 }));
+            });
+          }
+          return new Response(null, { status: 200 });
+        }) as unknown as typeof fetch,
+      });
+
+      sink.notify(buildAttentionNotifyPayload({ sessionId: 's' }, { id: 'first', now: 0 }));
+      // Deliberately NOT `flush()`. Flush loops until quiescent, so it would
+      // itself restart a stranded drain and hide exactly the bug under test.
+      // Production has no such prompt: the sink must recover on its own.
+      for (let i = 0; i < 4; i += 1) await new Promise((r) => setTimeout(r, 0));
+      expect(calls, `stranded when the notify landed ${hops} microtask(s) in`).toEqual([
+        'first',
+        'second',
+      ]);
+    }
   });
 
   it('logs a failing sink once, not once per notification', async () => {
@@ -200,7 +382,7 @@ describe('coerceNotifySinks', () => {
       [
         { type: 'webhook', url: 'file:///etc/passwd' },
         { type: 'ntfy', url: 'not a url' },
-        { type: 'webhook', url: 'https://hooks.example/wmux', events: ['approval', 'bogus'] },
+        { type: 'webhook', url: 'https://hooks.example/wmux', events: ['approval'] },
       ],
       warn,
     );
@@ -208,6 +390,20 @@ describe('coerceNotifySinks', () => {
       { type: 'webhook', url: 'https://hooks.example/wmux', events: ['approval'] },
     ]);
     expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('warns about an unrecognised event name instead of silently dropping it', () => {
+    const warn = vi.fn();
+    // A typo here is the worst kind of bug: the sink loads fine and never fires.
+    const out = coerceNotifySinks(
+      [{ type: 'ntfy', url: 'https://ntfy.sh/t', events: ['aproval'] }],
+      warn,
+    );
+    expect(out).toEqual([{ type: 'ntfy', url: 'https://ntfy.sh/t', events: [] }]);
+    const said = warn.mock.calls.map((c) => String(c[1])).join('\n');
+    expect(said).toContain('aproval');
+    // Both the unknown name AND the resulting permanent silence are called out.
+    expect(said).toContain('never fire');
   });
 
   it('accepts a private-range host — a self-hosted ntfy is the common case', () => {

--- a/src/daemon/push/__tests__/WebhookSink.test.ts
+++ b/src/daemon/push/__tests__/WebhookSink.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  WebhookSink,
+  coerceNotifySinks,
+  isSendableUrl,
+  NOTIFY_QUEUE_CAP,
+  type NotifySinkConfig,
+} from '../WebhookSink';
+import {
+  NOTIFY_PAYLOAD_FIELDS,
+  buildApprovalNotifyPayload,
+  buildAttentionNotifyPayload,
+  type NotifyPayload,
+} from '../notifyPayload';
+import type { ApprovalRequest } from '../../approvals/types';
+
+const IDENTITY = { id: 'evt-1', now: Date.UTC(2026, 0, 2, 3, 4, 5) };
+
+function approval(over: Partial<ApprovalRequest> = {}): ApprovalRequest {
+  return {
+    id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    sessionId: '11111111-2222-3333-4444-555555555555',
+    workspaceId: '99999999-8888-7777-6666-555555555555',
+    agent: 'claude',
+    kind: 'awaiting_input',
+    question: 'Delete /Users/someone/secret-project/.env and drop table users?',
+    options: ['Yes, rm -rf it', 'No'],
+    choices: [
+      { key: '1', label: 'Yes, rm -rf it' },
+      { key: '2', label: 'No' },
+    ],
+    createdAt: IDENTITY.now,
+    state: 'pending',
+    ...over,
+  };
+}
+
+interface Harness {
+  sink: WebhookSink;
+  calls: Array<{ url: string; init: RequestInit }>;
+  logs: string[];
+}
+
+function harness(sinks: NotifySinkConfig[], status = 200): Harness {
+  const calls: Harness['calls'] = [];
+  const logs: string[] = [];
+  const sink = new WebhookSink({
+    sinks: () => sinks,
+    log: (level, msg) => logs.push(`${level}: ${msg}`),
+    fetchImpl: (async (url: string, init: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return new Response(null, { status });
+    }) as unknown as typeof fetch,
+  });
+  return { sink, calls, logs };
+}
+
+describe('notifyPayload — the outbound allowlist', () => {
+  it('never emits a field outside NOTIFY_PAYLOAD_FIELDS', () => {
+    const payloads: NotifyPayload[] = [
+      buildApprovalNotifyPayload(approval(), IDENTITY),
+      buildApprovalNotifyPayload(
+        approval({
+          kind: 'awaiting_permission',
+          question: undefined,
+          options: undefined,
+          choices: undefined,
+          toolName: 'Bash',
+          toolInputSummary: 'rm -rf /Users/someone/project',
+        }),
+        IDENTITY,
+      ),
+      buildAttentionNotifyPayload({ sessionId: 'abcdefgh-ijkl', agent: 'Claude Code' }, IDENTITY),
+    ];
+    for (const payload of payloads) {
+      for (const key of Object.keys(payload)) {
+        expect(NOTIFY_PAYLOAD_FIELDS).toContain(key);
+      }
+    }
+  });
+
+  it('carries no agent-authored text, no paths and no full ids', () => {
+    const request = approval();
+    const serialized = JSON.stringify(buildApprovalNotifyPayload(request, IDENTITY));
+    // The question, the choice labels and the file path in them.
+    expect(serialized).not.toContain('Delete');
+    expect(serialized).not.toContain('rm -rf');
+    expect(serialized).not.toContain('.env');
+    expect(serialized).not.toContain('drop table');
+    // The approval id resolves a pane over RPC — it must not travel at all.
+    expect(serialized).not.toContain(request.id);
+    // Pane / workspace ids travel only as a short prefix.
+    expect(serialized).not.toContain(request.sessionId);
+    expect(serialized).not.toContain(request.workspaceId);
+    expect(JSON.parse(serialized).pane).toBe('11111111');
+  });
+
+  it('re-derives the risk tier from the agent text without shipping the text', () => {
+    // `risk` is unset on the record: a copy would score this as ordinary.
+    expect(buildApprovalNotifyPayload(approval(), IDENTITY).risk).toBe('critical');
+    expect(
+      buildApprovalNotifyPayload(
+        approval({ question: 'Which colour should the button be?', options: ['Blue', 'Green'], choices: undefined }),
+        IDENTITY,
+      ).risk,
+    ).toBeUndefined();
+  });
+});
+
+describe('WebhookSink', () => {
+  it('is inert with no sinks configured', () => {
+    const h = harness([]);
+    expect(h.sink.enabled).toBe(false);
+    h.sink.notify(buildApprovalNotifyPayload(approval(), IDENTITY));
+    expect(h.calls).toHaveLength(0);
+  });
+
+  it('posts JSON to a webhook and text+headers to ntfy', async () => {
+    const h = harness([
+      { type: 'webhook', url: 'https://hooks.example/wmux' },
+      { type: 'ntfy', url: 'https://ntfy.sh/my-topic' },
+    ]);
+    h.sink.notify(buildApprovalNotifyPayload(approval(), IDENTITY));
+    await h.sink.flush();
+
+    expect(h.calls).toHaveLength(2);
+    const [hook, ntfy] = h.calls;
+    expect(JSON.parse(String(hook.init.body)).event).toBe('approval');
+    expect(String(ntfy.init.body)).toBe('Approval needed · claude · pane 11111111 · ws 99999999');
+    const headers = ntfy.init.headers as Record<string, string>;
+    expect(headers['Title']).toBe('Approval needed');
+    // approval = high priority.
+    expect(headers['Priority']).toBe('4');
+  });
+
+  it('honours the per-sink event filter', async () => {
+    const h = harness([{ type: 'ntfy', url: 'https://ntfy.sh/t', events: ['approval'] }]);
+    h.sink.notify(buildAttentionNotifyPayload({ sessionId: 'sess-1' }, IDENTITY));
+    await h.sink.flush();
+    expect(h.calls).toHaveLength(0);
+  });
+
+  it('drops the OLDEST notification when the queue is full', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const calls: string[] = [];
+    const sink = new WebhookSink({
+      sinks: () => [{ type: 'webhook', url: 'https://hooks.example/wmux' }],
+      fetchImpl: (async (_url: string, init: RequestInit) => {
+        calls.push(JSON.parse(String(init.body)).id);
+        await gate;
+        return new Response(null, { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+
+    // The first send is held in-flight, so everything after it queues.
+    const total = NOTIFY_QUEUE_CAP + 5;
+    for (let i = 0; i < total; i += 1) {
+      sink.notify(buildAttentionNotifyPayload({ sessionId: 'sess-1' }, { id: `n${i}`, now: 0 }));
+    }
+    release();
+    await sink.flush();
+
+    // n0 went in flight immediately; the cap then evicted the oldest waiters.
+    expect(calls[0]).toBe('n0');
+    expect(calls).toHaveLength(NOTIFY_QUEUE_CAP + 1);
+    expect(calls).not.toContain('n1');
+    expect(calls[calls.length - 1]).toBe(`n${total - 1}`);
+  });
+
+  it('logs a failing sink once, not once per notification', async () => {
+    const h = harness([{ type: 'ntfy', url: 'https://ntfy.sh/t' }], 500);
+    for (let i = 0; i < 3; i += 1) {
+      h.sink.notify(buildAttentionNotifyPayload({ sessionId: 's' }, { id: `n${i}`, now: 0 }));
+    }
+    await h.sink.flush();
+    expect(h.calls).toHaveLength(3);
+    expect(h.logs.filter((l) => l.includes('answered 500'))).toHaveLength(1);
+  });
+
+  it('never logs the sink url — an ntfy topic is a secret', async () => {
+    const h = harness([{ type: 'ntfy', url: 'https://ntfy.sh/secret-topic-name' }], 500);
+    h.sink.notify(buildAttentionNotifyPayload({ sessionId: 's' }, IDENTITY));
+    await h.sink.flush();
+    expect(h.logs.join('\n')).not.toContain('secret-topic-name');
+  });
+});
+
+describe('coerceNotifySinks', () => {
+  it('degrades an absent or malformed slice to OFF', () => {
+    expect(coerceNotifySinks(undefined)).toEqual([]);
+    expect(coerceNotifySinks('nope')).toEqual([]);
+    expect(coerceNotifySinks([null, 42, {}, { type: 'smoke-signal', url: 'https://x.example' }])).toEqual([]);
+  });
+
+  it('rejects non-http(s) schemes and keeps the valid siblings', () => {
+    const warn = vi.fn();
+    const out = coerceNotifySinks(
+      [
+        { type: 'webhook', url: 'file:///etc/passwd' },
+        { type: 'ntfy', url: 'not a url' },
+        { type: 'webhook', url: 'https://hooks.example/wmux', events: ['approval', 'bogus'] },
+      ],
+      warn,
+    );
+    expect(out).toEqual([
+      { type: 'webhook', url: 'https://hooks.example/wmux', events: ['approval'] },
+    ]);
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('accepts a private-range host — a self-hosted ntfy is the common case', () => {
+    expect(isSendableUrl('http://192.168.1.10:8080/wmux')).toBe(true);
+    expect(isSendableUrl('data:text/plain,hi')).toBe(false);
+  });
+});

--- a/src/daemon/push/approvalPushPayload.ts
+++ b/src/daemon/push/approvalPushPayload.ts
@@ -10,8 +10,8 @@
  * version of it shipped a `risk` that was only ever set on the critical branch
  * — which switched the button off for every approval on earth.
  */
-import { hasElevatedRisk } from '../../shared/criticalPatterns';
 import { PUSH_RISK_CRITICAL, PUSH_RISK_NORMAL, type PushPayload } from '../../shared/push/pushEnvelope';
+import { approvalHasElevatedRisk } from './approvalRisk';
 import type { ApprovalChoice, ApprovalRequest } from '../approvals/types';
 
 /** Shown when the agent gave us no question text to quote. */
@@ -49,7 +49,7 @@ export function buildApprovalPushPayload(request: ApprovalRequest): PushPayload 
     // and the button was withheld, so a careless copy would turn a
     // fail-CLOSED into a fail-OPEN for the softer tier. `hasElevatedRisk`
     // counts both tiers for exactly this decision.
-    risk: elevatedRisk(request) ? PUSH_RISK_CRITICAL : PUSH_RISK_NORMAL,
+    risk: approvalHasElevatedRisk(request) ? PUSH_RISK_CRITICAL : PUSH_RISK_NORMAL,
   };
 }
 
@@ -99,7 +99,8 @@ const AFFIRMATIVE_MAX_CHOICES = 2;
  * use. An empty or missing label cannot title a button, so it falls back
  * rather than borrowing a generic word.
  *
- * `risk` is unaffected and still decides this independently — `elevatedRisk`
+ * `risk` is unaffected and still decides this independently — the shared
+ * `approvalHasElevatedRisk`
  * already scans choice labels precisely so that this relaxation could not turn
  * into a gap.
  */
@@ -115,31 +116,6 @@ function lockScreenChoiceFields(
     return { requiresInAppChoice: true };
   }
   return { firstOption: labels[0] };
-}
-
-/**
- * Does anything the agent wrote name a destructive action, at either tier?
- *
- * `choices` labels are scanned too. Today a request that has them also sets
- * `requiresInAppChoice`, which withholds the affirmative on its own — but that
- * is two independent reasons agreeing, not one covering the other, and the day
- * the choice rule changes this must not quietly become the gap.
- */
-function elevatedRisk(request: ApprovalRequest): boolean {
-  if (request.risk === 'critical') return true;
-  // A permission gate (#783) carries no question and no choices — the thing
-  // being approved is the tool call itself. Scanning only the question would
-  // score every gate as `normal` and light up the one-tap lock-screen button
-  // for `rm -rf` with nothing on screen to read (review: Claude). The tool name
-  // and its input summary ARE the text to judge here.
-  if (request.kind === 'awaiting_permission') {
-    return hasElevatedRisk(request.toolName, request.toolInputSummary);
-  }
-  return hasElevatedRisk(
-    request.question,
-    ...(request.options ?? []),
-    ...(request.choices ?? []).map((c) => c.label),
-  );
 }
 
 /** One pending request per pane, so a re-prompt replaces its own banner. */

--- a/src/daemon/push/approvalRisk.ts
+++ b/src/daemon/push/approvalRisk.ts
@@ -1,0 +1,43 @@
+/**
+ * The ONE danger verdict on an approval request, shared by every notification
+ * path.
+ *
+ * It lives in its own module because there are now two consumers with very
+ * different consequences — the sealed phone payload, where the verdict decides
+ * whether a one-tap lock-screen approve button exists, and the outbound
+ * webhook/ntfy sink, where it decides how loudly the phone rings. A second copy
+ * of this logic is not a duplication smell, it is a future disagreement about
+ * what counts as dangerous: the day someone tightens one scan, the other path
+ * keeps calling `rm -rf` ordinary. One function, one verdict, both callers.
+ *
+ * Note what does NOT leave here: only a boolean. The strings scanned are
+ * agent-authored text that the webhook path must never transmit.
+ */
+import { hasElevatedRisk } from '../../shared/criticalPatterns';
+import type { ApprovalRequest } from '../approvals/types';
+
+/**
+ * Does anything the agent wrote name a destructive action, at either tier?
+ *
+ * `choices` labels are scanned too. Today a request that has them also sets
+ * `requiresInAppChoice`, which withholds the affirmative on its own — but that
+ * is two independent reasons agreeing, not one covering the other, and the day
+ * the choice rule changes this must not quietly become the gap.
+ *
+ * A permission gate (#783) carries no question and no choices — the thing being
+ * approved is the tool call itself. Scanning only the question would score every
+ * gate as `normal` and light up the one-tap lock-screen button for `rm -rf` with
+ * nothing on screen to read (review: Claude). The tool name and its input
+ * summary ARE the text to judge there.
+ */
+export function approvalHasElevatedRisk(request: ApprovalRequest): boolean {
+  if (request.risk === 'critical') return true;
+  if (request.kind === 'awaiting_permission') {
+    return hasElevatedRisk(request.toolName, request.toolInputSummary);
+  }
+  return hasElevatedRisk(
+    request.question,
+    ...(request.options ?? []),
+    ...(request.choices ?? []).map((c) => c.label),
+  );
+}

--- a/src/daemon/push/notifyPayload.ts
+++ b/src/daemon/push/notifyPayload.ts
@@ -20,7 +20,7 @@
  * payload stays inside it. Adding a field is a decision about what a third
  * party gets to read; make it there, on purpose.
  */
-import { hasElevatedRisk } from '../../shared/criticalPatterns';
+import { approvalHasElevatedRisk } from './approvalRisk';
 import type { ApprovalRequest } from '../approvals/types';
 
 /** What raised the notification. */
@@ -104,16 +104,16 @@ export function buildApprovalNotifyPayload(
     pane: shortId(request.sessionId),
     ...(request.workspaceId ? { workspace: shortId(request.workspaceId) } : {}),
     ...(request.agent ? { agent: request.agent } : {}),
-    // RE-DERIVED, not copied from `request.risk`, for the same reason
-    // `approvalPushPayload` re-derives it: the record's field is set only on
-    // the harder tier, so copying it would score a softer destructive match as
-    // ordinary. Here the consequence is only a notification priority, not a
-    // lock-screen button — but the two paths disagreeing about what is
-    // dangerous is its own bug, so they run the same scan.
+    // RE-DERIVED, not copied from `request.risk`: the record's field is set
+    // only on the harder tier, so copying it would score a softer destructive
+    // match as ordinary. Here the consequence is only a notification priority,
+    // not a lock-screen button — but the two paths disagreeing about what is
+    // dangerous is its own bug, so this calls the SAME function the sealed
+    // phone payload calls. See `approvalRisk.ts`.
     //
     // Deliberately the ONLY thing derived from the agent's text. The text
     // itself does not travel.
-    ...(elevatedRisk(request) ? { risk: 'critical' as const } : {}),
+    ...(approvalHasElevatedRisk(request) ? { risk: 'critical' as const } : {}),
     at: new Date(identity.now).toISOString(),
   };
 }
@@ -152,26 +152,4 @@ export function notifyMessageText(payload: NotifyPayload): string {
   parts.push(`pane ${payload.pane}`);
   if (payload.workspace) parts.push(`ws ${payload.workspace}`);
   return parts.join(' · ');
-}
-
-/**
- * Does anything the agent wrote name a destructive action, at either tier?
- *
- * Mirrors `approvalPushPayload`'s `elevatedRisk` rather than importing it: that
- * function belongs to the sealed phone path, and this module must be readable
- * as a self-contained statement of what a third party learns. Both count both
- * tiers, and a permission gate is judged on its tool name and input summary
- * because it carries no question. NEITHER of those strings leaves this
- * function — only the boolean does.
- */
-function elevatedRisk(request: ApprovalRequest): boolean {
-  if (request.risk === 'critical') return true;
-  if (request.kind === 'awaiting_permission') {
-    return hasElevatedRisk(request.toolName, request.toolInputSummary);
-  }
-  return hasElevatedRisk(
-    request.question,
-    ...(request.options ?? []),
-    ...(request.choices ?? []).map((c) => c.label),
-  );
 }

--- a/src/daemon/push/notifyPayload.ts
+++ b/src/daemon/push/notifyPayload.ts
@@ -1,0 +1,177 @@
+/**
+ * The one place a daemon event turns into the PLAINTEXT that leaves this
+ * machine for a third party.
+ *
+ * This is not the phone path. `approvalPushPayload` builds a payload that is
+ * sealed to a key only the user's own device holds, so it can afford to quote
+ * the agent's question. Here the destination is an operator-configured URL —
+ * commonly a shared ntfy topic on a public server — and the body travels in
+ * the clear through whoever runs it. So the rule this module encodes is:
+ *
+ *   a notification that says SOMETHING HAPPENED and WHERE, never WHAT.
+ *
+ * Concretely, and deliberately absent: the agent's question text, tool names,
+ * tool input summaries, choice labels, terminal output, file paths, cwd,
+ * commands, tokens, and the full ids that address a pane over RPC. Panes and
+ * workspaces are named by a short id PREFIX — enough to tell two panes apart
+ * on a phone screen, not enough to be a handle.
+ *
+ * `NOTIFY_PAYLOAD_FIELDS` is the allowlist, and a test asserts every built
+ * payload stays inside it. Adding a field is a decision about what a third
+ * party gets to read; make it there, on purpose.
+ */
+import { hasElevatedRisk } from '../../shared/criticalPatterns';
+import type { ApprovalRequest } from '../approvals/types';
+
+/** What raised the notification. */
+export type NotifyEventKind = 'approval' | 'attention';
+
+/**
+ * The complete outbound shape. Every field here is either derived by this
+ * module or an opaque short id — nothing is copied verbatim from agent-authored
+ * text.
+ */
+export interface NotifyPayload {
+  /** Schema version, so a receiver can branch without sniffing. */
+  v: 1;
+  /** Random per notification. NOT the approval id — that one resolves a pane. */
+  id: string;
+  event: NotifyEventKind;
+  /** Short, STATIC human title. Never the agent's own words. */
+  title: string;
+  /** Agent display name ('Claude Code'). Absent when unknown. */
+  agent?: string;
+  /** Short prefix of the pane id — an eyeball discriminator, not a handle. */
+  pane: string;
+  /** Short prefix of the workspace id, when the event carried one. */
+  workspace?: string;
+  /** Derived risk tier, present only when elevated. Drives ntfy Priority. */
+  risk?: 'critical';
+  /** ISO 8601. */
+  at: string;
+}
+
+/**
+ * The allowlist. A payload with any other key must never be sent — see the
+ * module doc for why that is a security property rather than tidiness.
+ */
+export const NOTIFY_PAYLOAD_FIELDS = [
+  'v',
+  'id',
+  'event',
+  'title',
+  'agent',
+  'pane',
+  'workspace',
+  'risk',
+  'at',
+] as const;
+
+/** Static titles. Chosen so no branch can ever interpolate agent text. */
+export const NOTIFY_TITLE_APPROVAL = 'Approval needed';
+export const NOTIFY_TITLE_ATTENTION = 'Agent finished a turn';
+
+/**
+ * How much of an id travels.
+ *
+ * A pane id is an RPC target. The phone path ships it whole because the
+ * envelope is sealed; here it would be sitting in a third party's log, so only
+ * a prefix goes — long enough that two panes on one machine read differently,
+ * short enough to be useless as an address.
+ */
+const SHORT_ID_LEN = 8;
+
+function shortId(raw: string): string {
+  return raw.replace(/[^A-Za-z0-9-]/g, '').slice(0, SHORT_ID_LEN);
+}
+
+export interface NotifyIdentity {
+  /** Injected so a test can pin it; defaults to a fresh uuid. */
+  id: string;
+  /** Epoch ms. */
+  now: number;
+}
+
+export function buildApprovalNotifyPayload(
+  request: ApprovalRequest,
+  identity: NotifyIdentity,
+): NotifyPayload {
+  return {
+    v: 1,
+    id: identity.id,
+    event: 'approval',
+    title: NOTIFY_TITLE_APPROVAL,
+    pane: shortId(request.sessionId),
+    ...(request.workspaceId ? { workspace: shortId(request.workspaceId) } : {}),
+    ...(request.agent ? { agent: request.agent } : {}),
+    // RE-DERIVED, not copied from `request.risk`, for the same reason
+    // `approvalPushPayload` re-derives it: the record's field is set only on
+    // the harder tier, so copying it would score a softer destructive match as
+    // ordinary. Here the consequence is only a notification priority, not a
+    // lock-screen button — but the two paths disagreeing about what is
+    // dangerous is its own bug, so they run the same scan.
+    //
+    // Deliberately the ONLY thing derived from the agent's text. The text
+    // itself does not travel.
+    ...(elevatedRisk(request) ? { risk: 'critical' as const } : {}),
+    at: new Date(identity.now).toISOString(),
+  };
+}
+
+export interface AttentionNotifyInput {
+  /** Daemon session (pane) id. */
+  sessionId: string;
+  /** Agent DISPLAY name, as the hook event carries it. */
+  agent?: string;
+}
+
+export function buildAttentionNotifyPayload(
+  input: AttentionNotifyInput,
+  identity: NotifyIdentity,
+): NotifyPayload {
+  return {
+    v: 1,
+    id: identity.id,
+    event: 'attention',
+    title: NOTIFY_TITLE_ATTENTION,
+    pane: shortId(input.sessionId),
+    ...(input.agent ? { agent: input.agent } : {}),
+    at: new Date(identity.now).toISOString(),
+  };
+}
+
+/**
+ * The one line a receiver reads when it only gets text (ntfy).
+ *
+ * Assembled from allowlisted fields only — never from the request — so the
+ * text body cannot become a side door around the allowlist.
+ */
+export function notifyMessageText(payload: NotifyPayload): string {
+  const parts = [payload.title];
+  if (payload.agent) parts.push(payload.agent);
+  parts.push(`pane ${payload.pane}`);
+  if (payload.workspace) parts.push(`ws ${payload.workspace}`);
+  return parts.join(' · ');
+}
+
+/**
+ * Does anything the agent wrote name a destructive action, at either tier?
+ *
+ * Mirrors `approvalPushPayload`'s `elevatedRisk` rather than importing it: that
+ * function belongs to the sealed phone path, and this module must be readable
+ * as a self-contained statement of what a third party learns. Both count both
+ * tiers, and a permission gate is judged on its tool name and input summary
+ * because it carries no question. NEITHER of those strings leaves this
+ * function — only the boolean does.
+ */
+function elevatedRisk(request: ApprovalRequest): boolean {
+  if (request.risk === 'critical') return true;
+  if (request.kind === 'awaiting_permission') {
+    return hasElevatedRisk(request.toolName, request.toolInputSummary);
+  }
+  return hasElevatedRisk(
+    request.question,
+    ...(request.options ?? []),
+    ...(request.choices ?? []).map((c) => c.label),
+  );
+}

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -5,6 +5,7 @@ import type { AgentSlug } from '../shared/events';
 import type { ResumeBinding } from '../shared/agentResume';
 import type { LanLinkConfig } from '../shared/lanlink';
 import type { GateConfig } from './approvals/gateConfig';
+import type { NotifySinkConfig } from './push/WebhookSink';
 
 /** Session lifecycle state */
 export type DaemonSessionState = 'detached' | 'attached' | 'dead' | 'suspended';
@@ -254,6 +255,23 @@ export interface DaemonConfig {
    * entirely (same as `WMUX_GATE=0`, but durable).
    */
   gate?: GateConfig;
+  /**
+   * Outbound notification sinks — a webhook or ntfy URL that gets a small
+   * plaintext ping when an approval is raised or an agent turn ends. For people
+   * running wmux without the phone app; the sealed APNs path is unaffected and
+   * independent.
+   *
+   * OPTIONAL and OFF by default (absent = an empty list = no outbound traffic).
+   * `validateConfig` deliberately ignores it and `loadConfig` backfills it
+   * per-field, same convention as `browser`/`lanlink`/`gate`. A malformed entry
+   * is dropped individually rather than resetting the file.
+   *
+   * The payload is a hard-allowlisted summary — event kind, static title, agent
+   * name, short pane/workspace id prefixes, a derived risk tier and a timestamp.
+   * It never carries the agent's question, tool input, terminal output, paths or
+   * tokens. See `push/notifyPayload.ts`.
+   */
+  notifySinks?: NotifySinkConfig[];
 }
 
 /**


### PR DESCRIPTION
## What

An outbound-only notification path for users without the paired phone app: the daemon POSTs a minimal JSON payload to user-configured sinks (`{type: "webhook"|"ntfy", url, events?}`, max 8) when an approval is raised or an agent turn ends. Off unless configured; `WMUX_NOTIFY_SINKS=0` kill switch. No new listening surface — the loopback-only default is untouched.

## Payload policy (the important part)

Hard allowlist (`NOTIFY_PAYLOAD_FIELDS`): event kind, static title, agent name, 8-char pane/workspace prefixes, re-derived `risk` boolean, timestamp, fresh random id. **No agent-authored text travels** — not the approval question, not tool names, not paths. The APNs path may quote them because its envelope is sealed to the device; a webhook body lands in third-party logs (a public ntfy topic being the common case). `risk` is re-derived via `hasElevatedRisk` so this path can never disagree with the push path about what is dangerous.

Delivery is fire-and-forget: queue cap 32, drop-oldest, 5s timeout, no retry, manual redirect, http(s) only. Sink URLs are never logged (an ntfy topic is itself the secret). Turn-end taps fire on `agent.stop` only — not `subagent_stop`, which would ping a dozen times per turn.

## Tests

12 added: payload allowlist (negative assertions that question text, commands, paths, full ids never serialize), queue cap/drop-oldest behavior, config coercion rejections.

## Notes

- Changelog fragment: `changelog.d/t3-webhook-sink.md`.
- No CLI surface yet (config.json editing only); attention pings carry no workspace id (would need new plumbing) — follow-ups.

## Prior art

Concept-level borrowing only, no code imported: outbound ntfy/webhook notification for blocked agents follows the pattern of community Claude Code ntfy hooks. Payload policy and delivery semantics are wmux's own (modeled on this repo's PushSender).
