### PR TITLE
feat(push): suppress phone push while the desktop app is present

### DIFF
--- a/changelog.d/t4-presence-suppression.md
+++ b/changelog.d/t4-presence-suppression.md
@@ -1,0 +1,16 @@
+### Added
+
+- **Your phone stops buzzing for approvals you are already looking at.** When
+  the desktop app is connected and its window was focused within the last 90
+  seconds, the push notification for a new approval is skipped — the request
+  still lands in the in-app inbox, which is the thing you were reading anyway.
+  Before this, sitting at the desk answering prompts also meant a phone
+  lighting up for every one of them.
+
+  Every uncertainty still sends: a daemon with no desktop attached, a version
+  of the app too old to report focus, or a focus report that has gone stale all
+  fall back to notifying. A `critical`-risk approval is pushed even when you are
+  present — a destructive action is worth the second channel.
+
+  Configurable via `pushPresenceSuppression` in `~/.wmux/config.json`
+  (`enabled`, default `true`; `staleAfterMs`, default `90000`).

--- a/changelog.d/t4-presence-suppression.md
+++ b/changelog.d/t4-presence-suppression.md
@@ -2,15 +2,26 @@
 
 - **Your phone stops buzzing for approvals you are already looking at.** When
   the desktop app is connected and its window was focused within the last 90
-  seconds, the push notification for a new approval is skipped — the request
+  seconds, the push notification for a new approval is held back — the request
   still lands in the in-app inbox, which is the thing you were reading anyway.
   Before this, sitting at the desk answering prompts also meant a phone
   lighting up for every one of them.
 
+  Held, not dropped. The moment you leave — the window blurs, you lock the
+  screen, the machine sleeps, the app quits, or the focus report simply ages
+  out because you walked away — any still-pending approval's push is delivered.
+  It carries the same collapse id as the original, so the phone replaces that
+  pane's banner rather than stacking a second one. An approval you answered
+  while parked is dropped instead of sent.
+
   Every uncertainty still sends: a daemon with no desktop attached, a version
-  of the app too old to report focus, or a focus report that has gone stale all
-  fall back to notifying. A `critical`-risk approval is pushed even when you are
-  present — a destructive action is worth the second channel.
+  of the app too old to report focus, an unreadable config, or a focus report
+  that has gone stale all fall back to notifying. A `critical`-risk approval is
+  pushed even when you are present — a destructive action is worth the second
+  channel. Only the app's own process can report presence; the CLI, the MCP
+  server, and anything an agent can reach are refused, so nothing can silence
+  its own approval prompts.
 
   Configurable via `pushPresenceSuppression` in `~/.wmux/config.json`
-  (`enabled`, default `true`; `staleAfterMs`, default `90000`).
+  (`enabled`, default `true`; `staleAfterMs`, default `90000`, capped at ten
+  minutes).

--- a/src/daemon/__tests__/config.test.ts
+++ b/src/daemon/__tests__/config.test.ts
@@ -2,7 +2,17 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { createDefaultConfig, loadConfig, saveConfig, getWmuxDir } from '../config';
+import {
+  createDefaultConfig,
+  loadConfig,
+  readPushPresenceSuppression,
+  saveConfig,
+  getWmuxDir,
+} from '../config';
+import {
+  DESKTOP_PRESENCE_STALE_AFTER_MS,
+  DESKTOP_PRESENCE_STALE_CAP_MS,
+} from '../push/presence';
 import type { DaemonConfig } from '../types';
 
 /** Use a temp directory instead of the real ~/.wmux */
@@ -455,5 +465,79 @@ describe('loadConfig — browser.cdp backfill (#613, non-destructive)', () => {
     const c0 = createDefaultConfig();
     writeRawConfig({ ...c0, browser: { cdp: { enabled: false } } });
     expect(loadConfig().browser).toEqual({ cdp: { enabled: false } });
+  });
+});
+
+describe('pushPresenceSuppression — per-field backfill', () => {
+  it('ships ON with the default freshness window', () => {
+    expect(createDefaultConfig().pushPresenceSuppression).toEqual({
+      enabled: true,
+      staleAfterMs: DESKTOP_PRESENCE_STALE_AFTER_MS,
+    });
+  });
+
+  it('backfills an absent slice (old config.json) to ON without touching siblings', () => {
+    const c0 = createDefaultConfig();
+    const withoutSlice = { ...c0 };
+    delete withoutSlice.pushPresenceSuppression;
+    writeRawConfig(withoutSlice);
+    const loaded = loadConfig();
+    expect(loaded.pushPresenceSuppression?.enabled).toBe(true);
+    expect(loaded.daemon.pipeName).toBe(c0.daemon.pipeName);
+  });
+
+  it('honours enabled:false verbatim (the opt-out path)', () => {
+    const c0 = createDefaultConfig();
+    writeRawConfig({ ...c0, pushPresenceSuppression: { enabled: false } });
+    expect(loadConfig().pushPresenceSuppression?.enabled).toBe(false);
+  });
+
+  it('resolves a non-boolean enabled toward SENDING, not toward the ON default', () => {
+    const c0 = createDefaultConfig();
+    writeRawConfig({ ...c0, pushPresenceSuppression: { enabled: 'yes' } });
+    expect(loadConfig().pushPresenceSuppression?.enabled).toBe(false);
+  });
+
+  it('clamps a huge staleAfterMs — permanent suppression is not a preference', () => {
+    const c0 = createDefaultConfig();
+    writeRawConfig({
+      ...c0,
+      pushPresenceSuppression: { enabled: true, staleAfterMs: 24 * 60 * 60_000 },
+    });
+    expect(loadConfig().pushPresenceSuppression?.staleAfterMs).toBe(DESKTOP_PRESENCE_STALE_CAP_MS);
+  });
+});
+
+describe('readPushPresenceSuppression', () => {
+  it('reads the slice without rewriting the file', () => {
+    const c0 = createDefaultConfig();
+    writeRawConfig({ ...c0, pushPresenceSuppression: { enabled: true, staleAfterMs: 1234 } });
+    const configPath = path.join(getWmuxDir(), 'config.json');
+    const before = fs.readFileSync(configPath, 'utf-8');
+    expect(readPushPresenceSuppression()).toEqual({ enabled: true, staleAfterMs: 1234 });
+    expect(fs.readFileSync(configPath, 'utf-8')).toBe(before);
+  });
+
+  it('falls back to SENDING when the file is missing', () => {
+    expect(readPushPresenceSuppression().enabled).toBe(false);
+  });
+
+  it('falls back to SENDING on malformed JSON, and does NOT repair the file', () => {
+    const wmuxDir = getWmuxDir();
+    fs.mkdirSync(wmuxDir, { recursive: true });
+    const configPath = path.join(wmuxDir, 'config.json');
+    fs.writeFileSync(configPath, '{ not json', 'utf-8');
+
+    expect(readPushPresenceSuppression().enabled).toBe(false);
+    // loadConfig would have overwritten the user's file with defaults here.
+    expect(fs.readFileSync(configPath, 'utf-8')).toBe('{ not json');
+  });
+
+  it('treats a readable file that predates the feature as ON', () => {
+    const c0 = createDefaultConfig();
+    const withoutSlice = { ...c0 };
+    delete withoutSlice.pushPresenceSuppression;
+    writeRawConfig(withoutSlice);
+    expect(readPushPresenceSuppression().enabled).toBe(true);
   });
 });

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -11,6 +11,10 @@ import {
 import { getWindowsDefaultShell } from '../shared/shellResolution';
 import { dataSuffix, getDaemonSocketPath, getLegacyDaemonSocketPath } from '../shared/constants';
 import { coerceLanLinkConfig, defaultLanLinkConfig } from '../shared/lanlink';
+import {
+  DESKTOP_PRESENCE_STALE_AFTER_MS,
+  type PushPresenceSuppressionConfig,
+} from './push/presence';
 
 /** ~/.wmux directory (인스턴스 격리 suffix 반영 — main에서 상속된 WMUX_DATA_SUFFIX) */
 export function getWmuxDir(): string {
@@ -136,6 +140,41 @@ export function createDefaultConfig(): DaemonConfig {
     browser: { cdp: { enabled: true } },
     // #783 — PreToolUse permission gate. Defaults to high-risk tools only.
     gate: createDefaultGateConfig(),
+    // Presence-based push suppression. ON by default: a phone buzz while the
+    // user is looking at the desktop inbox is noise. Every uncertainty still
+    // sends — see `daemon/push/presence.ts`.
+    pushPresenceSuppression: {
+      enabled: true,
+      staleAfterMs: DESKTOP_PRESENCE_STALE_AFTER_MS,
+    },
+  };
+}
+
+/**
+ * Per-field backfill for `pushPresenceSuppression` (same discipline as
+ * `browser.cdp`). `validateConfig` ignores the slice, so a garbage value here
+ * can never trigger the whole-file reset.
+ *
+ * The asymmetry that matters: a malformed `staleAfterMs` falls back to the
+ * default rather than to "infinite", because a huge freshness window would
+ * suppress pushes forever off one ancient focus report. A non-positive value
+ * is left as-is and read by `isDesktopPresent` as "never fresh", which sends.
+ */
+function coercePushPresenceSuppression(
+  raw: unknown,
+  defaults: PushPresenceSuppressionConfig,
+): PushPresenceSuppressionConfig {
+  const slice = (raw !== null && typeof raw === 'object' && !Array.isArray(raw)
+    ? (raw as Record<string, unknown>)
+    : {});
+  const enabledRaw = slice['enabled'];
+  const staleRaw = slice['staleAfterMs'];
+  return {
+    enabled: typeof enabledRaw === 'boolean' ? enabledRaw : defaults.enabled,
+    staleAfterMs:
+      typeof staleRaw === 'number' && Number.isFinite(staleRaw)
+        ? Math.floor(staleRaw)
+        : defaults.staleAfterMs,
   };
 }
 
@@ -336,6 +375,16 @@ export function loadConfig(): DaemonConfig {
     // Absent slice (old config.json) → DEFAULT_GATED_TOOLS. A malformed slice
     // degrades to the defaults too, never silently disabling the gate.
     config.gate = coerceGate(config.gate);
+
+    // ── Presence-based push suppression: per-field backfill ──
+    // Absent slice (old config.json) → ON with the default freshness window.
+    config.pushPresenceSuppression = coercePushPresenceSuppression(
+      config.pushPresenceSuppression,
+      defaults.pushPresenceSuppression ?? {
+        enabled: true,
+        staleAfterMs: DESKTOP_PRESENCE_STALE_AFTER_MS,
+      },
+    );
 
     return config;
   } catch (err) {

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -13,6 +13,8 @@ import { dataSuffix, getDaemonSocketPath, getLegacyDaemonSocketPath } from '../s
 import { coerceLanLinkConfig, defaultLanLinkConfig } from '../shared/lanlink';
 import {
   DESKTOP_PRESENCE_STALE_AFTER_MS,
+  DESKTOP_PRESENCE_STALE_CAP_MS,
+  failOpenPresenceConfig,
   type PushPresenceSuppressionConfig,
 } from './push/presence';
 
@@ -155,10 +157,20 @@ export function createDefaultConfig(): DaemonConfig {
  * `browser.cdp`). `validateConfig` ignores the slice, so a garbage value here
  * can never trigger the whole-file reset.
  *
- * The asymmetry that matters: a malformed `staleAfterMs` falls back to the
- * default rather than to "infinite", because a huge freshness window would
- * suppress pushes forever off one ancient focus report. A non-positive value
- * is left as-is and read by `isDesktopPresent` as "never fresh", which sends.
+ * Exactly what happens, so the doc and the code cannot drift:
+ *
+ * - An ABSENT slice, or an absent `enabled`, takes `defaults.enabled` — which
+ *   is `true` for a config file that merely predates the feature, and `false`
+ *   for the error paths that pass `failOpenPresenceConfig()`. Absence in a
+ *   readable file is a preference; absence because nothing could be read is
+ *   not, and only the caller can tell those apart.
+ * - A non-boolean `enabled` is garbage rather than a preference, and garbage
+ *   resolves toward SENDING: suppression goes off.
+ * - `staleAfterMs` is clamped to `(0, DESKTOP_PRESENCE_STALE_CAP_MS]`. A huge
+ *   finite value is not a preference either — it is permanent suppression off
+ *   one ancient focus report. Absent/non-numeric takes the default; `0` or
+ *   negative is preserved and read by `isDesktopPresent` as "never fresh",
+ *   which sends.
  */
 function coercePushPresenceSuppression(
   raw: unknown,
@@ -169,13 +181,50 @@ function coercePushPresenceSuppression(
     : {});
   const enabledRaw = slice['enabled'];
   const staleRaw = slice['staleAfterMs'];
+  const stale =
+    typeof staleRaw === 'number' && Number.isFinite(staleRaw)
+      ? Math.floor(staleRaw)
+      : defaults.staleAfterMs;
   return {
-    enabled: typeof enabledRaw === 'boolean' ? enabledRaw : defaults.enabled,
-    staleAfterMs:
-      typeof staleRaw === 'number' && Number.isFinite(staleRaw)
-        ? Math.floor(staleRaw)
-        : defaults.staleAfterMs,
+    enabled:
+      enabledRaw === undefined
+        ? defaults.enabled
+        : typeof enabledRaw === 'boolean'
+          ? enabledRaw
+          : false,
+    staleAfterMs: Math.min(stale, DESKTOP_PRESENCE_STALE_CAP_MS),
   };
+}
+
+/**
+ * Read `pushPresenceSuppression` WITHOUT the repair behaviour of `loadConfig`.
+ *
+ * `loadConfig` rewrites config.json with defaults when it cannot parse the
+ * file. That is right for boot — a daemon needs a config — and wrong for a
+ * per-approval read on the push path, where an unlucky moment (a half-written
+ * file, a transient EIO) would silently discard the user's whole config to
+ * answer a question about one notification. This reads, never writes, and
+ * resolves every failure to `failOpenPresenceConfig()`, i.e. send the push.
+ */
+export function readPushPresenceSuppression(): PushPresenceSuppressionConfig {
+  const failOpen = failOpenPresenceConfig();
+  try {
+    const raw = fs.readFileSync(getConfigPath(), 'utf-8');
+    const parsed: unknown = JSON.parse(raw, (key, value) => {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') return undefined;
+      return value;
+    });
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return failOpen;
+    const slice = (parsed as Record<string, unknown>)['pushPresenceSuppression'];
+    // A file that simply predates the feature is not an error — it gets the
+    // shipped default (ON). Only unreadable/unparseable lands on fail-open.
+    return coercePushPresenceSuppression(slice, {
+      enabled: true,
+      staleAfterMs: DESKTOP_PRESENCE_STALE_AFTER_MS,
+    });
+  } catch {
+    return failOpen;
+  }
 }
 
 /**

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { loadConfig, saveConfig, getWmuxDir } from './config';
+import { loadConfig, saveConfig, getWmuxDir, readPushPresenceSuppression } from './config';
 import { DaemonSessionManager } from './DaemonSessionManager';
 import { PaneSupervisor } from './PaneSupervisor';
 import { DaemonPipeServer } from './DaemonPipeServer';
@@ -75,9 +75,12 @@ import { TranscriptDiscovery, DISCOVERABLE_AGENT } from './transcript/Transcript
 import { PushSender } from './push/PushSender';
 import { approvalPushCollapseId, buildApprovalPushPayload } from './push/approvalPushPayload';
 import {
-  DESKTOP_PRESENCE_STALE_AFTER_MS,
+  DeferredPushQueue,
   DesktopPresenceTracker,
+  createPresenceRpcHandler,
+  isDesktopPresent,
   shouldSuppressPush,
+  type PushPresenceSuppressionConfig,
 } from './push/presence';
 import { ApprovalRegistry } from './approvals/ApprovalRegistry';
 import { GateBroker } from './approvals/GateBroker';
@@ -4934,29 +4937,44 @@ async function main(): Promise<void> {
   // question. `desktopPresence` is fed by the `daemon.presence.desktop` RPC
   // registered below.
   const desktopPresence = new DesktopPresenceTracker();
+  // A read that never repairs the file. `loadConfig` rewrites config.json with
+  // defaults when it cannot parse it, which is right at boot and catastrophic
+  // on a per-approval path — see `readPushPresenceSuppression`.
+  const presenceConfig = (): PushPresenceSuppressionConfig => readPushPresenceSuppression();
+  const desktopIsPresent = (): boolean =>
+    isDesktopPresent(desktopPresence.snapshot(), Date.now(), presenceConfig().staleAfterMs);
+  // Suppression must not be loss. A held push is delivered as soon as presence
+  // ends — by a reported transition, or by the freshness window expiring with
+  // nobody there to report anything. Same collapseId, so the phone replaces
+  // the pane's banner rather than stacking a second one.
+  const deferredPush = new DeferredPushQueue({
+    send: (payload, opts) => pushSender.notify(payload, opts),
+    isPresent: desktopIsPresent,
+    staleAfterMs: () => presenceConfig().staleAfterMs,
+    log: (level, msg) => log(level, msg),
+  });
   approvalRegistry.onEvent((event) => {
-    // Only a NEW request is worth a phone buzzing. A resolve or an expire is
-    // the thing the notification was asking for, already handled.
-    if (event.type !== 'create') return;
+    // A resolve/expire/supersede is the thing the notification was asking for.
+    // If one is still parked, it is now moot — drop it rather than buzzing a
+    // phone about a question that has already been answered.
+    if (event.type !== 'create') {
+      deferredPush.forget(event.request.id);
+      return;
+    }
     const r = event.request;
     const payload = buildApprovalPushPayload(r);
-    // A getter, like `gateConfig`, so toggling the knob takes effect without a
-    // daemon restart.
-    const presenceConfig = loadConfig().pushPresenceSuppression ?? {
-      enabled: true,
-      staleAfterMs: DESKTOP_PRESENCE_STALE_AFTER_MS,
-    };
     if (
       shouldSuppressPush({
         state: desktopPresence.snapshot(),
         now: Date.now(),
-        config: presenceConfig,
+        config: presenceConfig(),
         ...(payload.risk !== undefined ? { risk: payload.risk } : {}),
       })
     ) {
       // The approval id only — never the question, the choices, or anything
       // else the payload carries.
-      log('info', `[push] suppressed for ${r.id}: desktop is present`);
+      log('info', `[push] held for ${r.id}: desktop is present`);
+      deferredPush.park(r.id, payload, approvalPushCollapseId(r));
       return;
     }
     pushSender.notify(payload, { collapseId: approvalPushCollapseId(r) });
@@ -4972,15 +4990,28 @@ async function main(): Promise<void> {
   // focus that is never followed by anything simply ages out of the freshness
   // window. That keeps the RPC silent while the user works, which is the whole
   // point of not running a timer.
-  pipeServer.onRpc('daemon.presence.desktop', async (params, ctx) => {
-    const focused = params['focused'] === true;
-    desktopPresence.report(ctx.clientId, focused, Date.now());
-    return { ok: true };
+  //
+  // First-party only — the gate and its reasoning live in
+  // `createPresenceRpcHandler`, which is where the test for the spoofed-report
+  // case can reach it.
+  const presenceRpc = createPresenceRpcHandler({
+    isFirstParty: (clientId) => pipeServer.isFirstParty(clientId),
+    tracker: desktopPresence,
+    // A blur is the main release signal for a held push — check immediately
+    // rather than waiting for the expiry timer.
+    onPresenceChanged: () => deferredPush.onPresenceChanged(),
+    log: (level, msg) => log(level, msg),
   });
+  pipeServer.onRpc('daemon.presence.desktop', async (params, ctx) =>
+    presenceRpc(params, ctx.clientId),
+  );
   // A desktop that went away is not present, whatever it last reported. Without
   // this, killing the app mid-focus would leave a fresh report standing for the
   // rest of the freshness window and swallow the pushes it was meant to hand off.
-  pipeServer.onClientClose((clientId) => desktopPresence.forget(clientId));
+  pipeServer.onClientClose((clientId) => {
+    desktopPresence.forget(clientId);
+    deferredPush.onPresenceChanged();
+  });
   // Channels (a2a-channels U3). Channels live in their own file
   // (`channels.json`, see ChannelStateWriter doc) so a channel-loss event
   // cannot cascade into session-state failure. The service receives

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -74,6 +74,11 @@ import { TranscriptProjector } from './transcript/TranscriptProjector';
 import { TranscriptDiscovery, DISCOVERABLE_AGENT } from './transcript/TranscriptDiscovery';
 import { PushSender } from './push/PushSender';
 import { approvalPushCollapseId, buildApprovalPushPayload } from './push/approvalPushPayload';
+import {
+  DESKTOP_PRESENCE_STALE_AFTER_MS,
+  DesktopPresenceTracker,
+  shouldSuppressPush,
+} from './push/presence';
 import { ApprovalRegistry } from './approvals/ApprovalRegistry';
 import { GateBroker } from './approvals/GateBroker';
 import { coerceGate } from './approvals/gateConfig';
@@ -4923,14 +4928,59 @@ async function main(): Promise<void> {
     forgetPush: (deviceId) => getDeviceStore().forgetPush(deviceId),
     log: (level, msg) => log(level, msg),
   });
+  // Presence-based suppression. The predicate lives in `push/presence.ts` and
+  // is consulted HERE rather than inside PushSender: the answer is about the
+  // human, not the transport, so every notification sink can ask the same
+  // question. `desktopPresence` is fed by the `daemon.presence.desktop` RPC
+  // registered below.
+  const desktopPresence = new DesktopPresenceTracker();
   approvalRegistry.onEvent((event) => {
     // Only a NEW request is worth a phone buzzing. A resolve or an expire is
     // the thing the notification was asking for, already handled.
     if (event.type !== 'create') return;
     const r = event.request;
-    pushSender.notify(buildApprovalPushPayload(r), { collapseId: approvalPushCollapseId(r) });
+    const payload = buildApprovalPushPayload(r);
+    // A getter, like `gateConfig`, so toggling the knob takes effect without a
+    // daemon restart.
+    const presenceConfig = loadConfig().pushPresenceSuppression ?? {
+      enabled: true,
+      staleAfterMs: DESKTOP_PRESENCE_STALE_AFTER_MS,
+    };
+    if (
+      shouldSuppressPush({
+        state: desktopPresence.snapshot(),
+        now: Date.now(),
+        config: presenceConfig,
+        ...(payload.risk !== undefined ? { risk: payload.risk } : {}),
+      })
+    ) {
+      // The approval id only — never the question, the choices, or anything
+      // else the payload carries.
+      log('info', `[push] suppressed for ${r.id}: desktop is present`);
+      return;
+    }
+    pushSender.notify(payload, { collapseId: approvalPushCollapseId(r) });
   });
   const pipeServer = new DaemonPipeServer(config.daemon.pipeName);
+  // Desktop presence, reported by the Electron main process on every
+  // focus/blur transition. Registered here rather than in `registerRpcHandlers`
+  // so the wiring stays additive — the tracker is a boot-scope value and
+  // threading it through that function's parameter list would touch a
+  // signature many call sites share.
+  //
+  // Transitions only, no heartbeat: a blur retracts presence immediately, and a
+  // focus that is never followed by anything simply ages out of the freshness
+  // window. That keeps the RPC silent while the user works, which is the whole
+  // point of not running a timer.
+  pipeServer.onRpc('daemon.presence.desktop', async (params, ctx) => {
+    const focused = params['focused'] === true;
+    desktopPresence.report(ctx.clientId, focused, Date.now());
+    return { ok: true };
+  });
+  // A desktop that went away is not present, whatever it last reported. Without
+  // this, killing the app mid-focus would leave a fresh report standing for the
+  // rest of the freshness window and swallow the pushes it was meant to hand off.
+  pipeServer.onClientClose((clientId) => desktopPresence.forget(clientId));
   // Channels (a2a-channels U3). Channels live in their own file
   // (`channels.json`, see ChannelStateWriter doc) so a channel-loss event
   // cannot cascade into session-state failure. The service receives

--- a/src/daemon/push/__tests__/presence.test.ts
+++ b/src/daemon/push/__tests__/presence.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  DESKTOP_PRESENCE_STALE_AFTER_MS,
+  DesktopPresenceTracker,
+  emptyDesktopPresence,
+  isDesktopPresent,
+  shouldSuppressPush,
+  type DesktopPresenceState,
+  type PushPresenceSuppressionConfig,
+} from '../presence';
+import { PUSH_RISK_CRITICAL, PUSH_RISK_NORMAL } from '../../../shared/push/pushEnvelope';
+
+const NOW = 1753420800000;
+
+const ON: PushPresenceSuppressionConfig = {
+  enabled: true,
+  staleAfterMs: DESKTOP_PRESENCE_STALE_AFTER_MS,
+};
+
+function present(overrides: Partial<DesktopPresenceState> = {}): DesktopPresenceState {
+  return { connected: true, focused: true, reportedAt: NOW, ...overrides };
+}
+
+describe('isDesktopPresent', () => {
+  it('is present for a connected client that reported focus just now', () => {
+    expect(isDesktopPresent(present(), NOW)).toBe(true);
+  });
+
+  it('is present up to the freshness bound and absent one ms past it', () => {
+    const at = present({ reportedAt: NOW - DESKTOP_PRESENCE_STALE_AFTER_MS });
+    expect(isDesktopPresent(at, NOW)).toBe(true);
+    expect(isDesktopPresent(present({ reportedAt: NOW - DESKTOP_PRESENCE_STALE_AFTER_MS - 1 }), NOW))
+      .toBe(false);
+  });
+
+  it('is absent when never reported, blurred, disconnected, or future-dated', () => {
+    expect(isDesktopPresent(emptyDesktopPresence(), NOW)).toBe(false);
+    expect(isDesktopPresent(present({ focused: false }), NOW)).toBe(false);
+    expect(isDesktopPresent(present({ connected: false }), NOW)).toBe(false);
+    expect(isDesktopPresent(present({ reportedAt: NOW + 5_000 }), NOW)).toBe(false);
+  });
+
+  it('is absent when the freshness window is non-positive or not a number', () => {
+    expect(isDesktopPresent(present(), NOW, 0)).toBe(false);
+    expect(isDesktopPresent(present(), NOW, Number.NaN)).toBe(false);
+  });
+});
+
+describe('shouldSuppressPush', () => {
+  it('suppresses a normal-risk push while the desktop is freshly focused', () => {
+    expect(
+      shouldSuppressPush({ state: present(), now: NOW, config: ON, risk: PUSH_RISK_NORMAL }),
+    ).toBe(true);
+  });
+
+  it('sends when the presence report has gone stale', () => {
+    const stale = present({ reportedAt: NOW - DESKTOP_PRESENCE_STALE_AFTER_MS - 1 });
+    expect(
+      shouldSuppressPush({ state: stale, now: NOW, config: ON, risk: PUSH_RISK_NORMAL }),
+    ).toBe(false);
+  });
+
+  it('sends a critical-risk push even when the desktop is present', () => {
+    expect(
+      shouldSuppressPush({ state: present(), now: NOW, config: ON, risk: PUSH_RISK_CRITICAL }),
+    ).toBe(false);
+  });
+
+  it('sends when suppression is disabled by config', () => {
+    expect(
+      shouldSuppressPush({
+        state: present(),
+        now: NOW,
+        config: { ...ON, enabled: false },
+        risk: PUSH_RISK_NORMAL,
+      }),
+    ).toBe(false);
+  });
+
+  it('sends when the daemon has never heard from a desktop (headless)', () => {
+    expect(
+      shouldSuppressPush({ state: emptyDesktopPresence(), now: NOW, config: ON }),
+    ).toBe(false);
+  });
+});
+
+describe('DesktopPresenceTracker', () => {
+  it('records a focus report and retracts it on that client disconnecting', () => {
+    const tracker = new DesktopPresenceTracker();
+    expect(isDesktopPresent(tracker.snapshot(), NOW)).toBe(false);
+
+    tracker.report('c1', true, NOW);
+    expect(isDesktopPresent(tracker.snapshot(), NOW)).toBe(true);
+
+    tracker.forget('c1');
+    expect(isDesktopPresent(tracker.snapshot(), NOW)).toBe(false);
+  });
+
+  it('ignores a disconnect from a client that no longer owns the report', () => {
+    const tracker = new DesktopPresenceTracker();
+    tracker.report('c1', true, NOW);
+    // c1 was replaced by c2 (reconnect) — c1's late close must not blank it.
+    tracker.report('c2', true, NOW);
+    tracker.forget('c1');
+    expect(isDesktopPresent(tracker.snapshot(), NOW)).toBe(true);
+  });
+
+  it('treats a blur report as absent immediately', () => {
+    const tracker = new DesktopPresenceTracker();
+    tracker.report('c1', true, NOW);
+    tracker.report('c1', false, NOW);
+    expect(isDesktopPresent(tracker.snapshot(), NOW)).toBe(false);
+  });
+});

--- a/src/daemon/push/__tests__/presence.test.ts
+++ b/src/daemon/push/__tests__/presence.test.ts
@@ -1,15 +1,20 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 import {
+  DEFERRED_PUSH_CAP,
   DESKTOP_PRESENCE_STALE_AFTER_MS,
+  DESKTOP_PRESENCE_STALE_CAP_MS,
+  DeferredPushQueue,
   DesktopPresenceTracker,
+  createPresenceRpcHandler,
   emptyDesktopPresence,
+  failOpenPresenceConfig,
   isDesktopPresent,
   shouldSuppressPush,
   type DesktopPresenceState,
   type PushPresenceSuppressionConfig,
 } from '../presence';
-import { PUSH_RISK_CRITICAL, PUSH_RISK_NORMAL } from '../../../shared/push/pushEnvelope';
+import { PUSH_RISK_CRITICAL, PUSH_RISK_NORMAL, type PushPayload } from '../../../shared/push/pushEnvelope';
 
 const NOW = 1753420800000;
 
@@ -18,26 +23,25 @@ const ON: PushPresenceSuppressionConfig = {
   staleAfterMs: DESKTOP_PRESENCE_STALE_AFTER_MS,
 };
 
-function present(overrides: Partial<DesktopPresenceState> = {}): DesktopPresenceState {
-  return { connected: true, focused: true, reportedAt: NOW, ...overrides };
+function present(overrides: { focused?: boolean; reportedAt?: number } = {}): DesktopPresenceState {
+  return { clients: [{ focused: true, reportedAt: NOW, ...overrides }] };
 }
 
 describe('isDesktopPresent', () => {
-  it('is present for a connected client that reported focus just now', () => {
+  it('is present for a client that reported focus just now', () => {
     expect(isDesktopPresent(present(), NOW)).toBe(true);
   });
 
   it('is present up to the freshness bound and absent one ms past it', () => {
-    const at = present({ reportedAt: NOW - DESKTOP_PRESENCE_STALE_AFTER_MS });
-    expect(isDesktopPresent(at, NOW)).toBe(true);
+    expect(isDesktopPresent(present({ reportedAt: NOW - DESKTOP_PRESENCE_STALE_AFTER_MS }), NOW))
+      .toBe(true);
     expect(isDesktopPresent(present({ reportedAt: NOW - DESKTOP_PRESENCE_STALE_AFTER_MS - 1 }), NOW))
       .toBe(false);
   });
 
-  it('is absent when never reported, blurred, disconnected, or future-dated', () => {
+  it('is absent when never reported, blurred, or future-dated', () => {
     expect(isDesktopPresent(emptyDesktopPresence(), NOW)).toBe(false);
     expect(isDesktopPresent(present({ focused: false }), NOW)).toBe(false);
-    expect(isDesktopPresent(present({ connected: false }), NOW)).toBe(false);
     expect(isDesktopPresent(present({ reportedAt: NOW + 5_000 }), NOW)).toBe(false);
   });
 
@@ -45,43 +49,55 @@ describe('isDesktopPresent', () => {
     expect(isDesktopPresent(present(), NOW, 0)).toBe(false);
     expect(isDesktopPresent(present(), NOW, Number.NaN)).toBe(false);
   });
+
+  it('clamps an oversized freshness window rather than honouring it', () => {
+    const ancient = present({ reportedAt: NOW - DESKTOP_PRESENCE_STALE_CAP_MS - 1 });
+    // A day-long window would otherwise make this report "fresh" forever.
+    expect(isDesktopPresent(ancient, NOW, 24 * 60 * 60_000)).toBe(false);
+  });
+
+  it('is present when ANY client is freshly focused', () => {
+    const state: DesktopPresenceState = {
+      clients: [
+        { focused: false, reportedAt: NOW },
+        { focused: true, reportedAt: NOW },
+      ],
+    };
+    expect(isDesktopPresent(state, NOW)).toBe(true);
+  });
 });
 
 describe('shouldSuppressPush', () => {
-  it('suppresses a normal-risk push while the desktop is freshly focused', () => {
-    expect(
-      shouldSuppressPush({ state: present(), now: NOW, config: ON, risk: PUSH_RISK_NORMAL }),
-    ).toBe(true);
+  it('holds a normal-risk push while the desktop is freshly focused', () => {
+    expect(shouldSuppressPush({ state: present(), now: NOW, config: ON, risk: PUSH_RISK_NORMAL }))
+      .toBe(true);
   });
 
   it('sends when the presence report has gone stale', () => {
     const stale = present({ reportedAt: NOW - DESKTOP_PRESENCE_STALE_AFTER_MS - 1 });
-    expect(
-      shouldSuppressPush({ state: stale, now: NOW, config: ON, risk: PUSH_RISK_NORMAL }),
-    ).toBe(false);
+    expect(shouldSuppressPush({ state: stale, now: NOW, config: ON, risk: PUSH_RISK_NORMAL }))
+      .toBe(false);
   });
 
   it('sends a critical-risk push even when the desktop is present', () => {
-    expect(
-      shouldSuppressPush({ state: present(), now: NOW, config: ON, risk: PUSH_RISK_CRITICAL }),
-    ).toBe(false);
+    expect(shouldSuppressPush({ state: present(), now: NOW, config: ON, risk: PUSH_RISK_CRITICAL }))
+      .toBe(false);
   });
 
   it('sends when suppression is disabled by config', () => {
     expect(
-      shouldSuppressPush({
-        state: present(),
-        now: NOW,
-        config: { ...ON, enabled: false },
-        risk: PUSH_RISK_NORMAL,
-      }),
+      shouldSuppressPush({ state: present(), now: NOW, config: { ...ON, enabled: false } }),
+    ).toBe(false);
+  });
+
+  it('sends on the fail-open config, which is what every error path uses', () => {
+    expect(
+      shouldSuppressPush({ state: present(), now: NOW, config: failOpenPresenceConfig() }),
     ).toBe(false);
   });
 
   it('sends when the daemon has never heard from a desktop (headless)', () => {
-    expect(
-      shouldSuppressPush({ state: emptyDesktopPresence(), now: NOW, config: ON }),
-    ).toBe(false);
+    expect(shouldSuppressPush({ state: emptyDesktopPresence(), now: NOW, config: ON })).toBe(false);
   });
 });
 
@@ -97,13 +113,38 @@ describe('DesktopPresenceTracker', () => {
     expect(isDesktopPresent(tracker.snapshot(), NOW)).toBe(false);
   });
 
-  it('ignores a disconnect from a client that no longer owns the report', () => {
+  it('does not let a second client flip a real blur back to present', () => {
     const tracker = new DesktopPresenceTracker();
     tracker.report('c1', true, NOW);
-    // c1 was replaced by c2 (reconnect) — c1's late close must not blank it.
+    tracker.report('c1', false, NOW);
+    // A second client reporting focus is its OWN slot; it does not overwrite
+    // c1's blur, but it is genuinely a focused window, so presence holds.
+    tracker.report('c2', true, NOW);
+    expect(isDesktopPresent(tracker.snapshot(), NOW)).toBe(true);
+    // ...and when that second client blurs, nothing is left claiming presence.
+    tracker.report('c2', false, NOW);
+    expect(isDesktopPresent(tracker.snapshot(), NOW)).toBe(false);
+  });
+
+  it('removes only the disconnecting client entry', () => {
+    const tracker = new DesktopPresenceTracker();
+    tracker.report('c1', true, NOW);
     tracker.report('c2', true, NOW);
     tracker.forget('c1');
+    // c2 is still focused and still counts.
     expect(isDesktopPresent(tracker.snapshot(), NOW)).toBe(true);
+    tracker.forget('c2');
+    expect(isDesktopPresent(tracker.snapshot(), NOW)).toBe(false);
+  });
+
+  it('starts empty, so a reconnecting daemon has no inherited presence', () => {
+    const tracker = new DesktopPresenceTracker();
+    expect(tracker.snapshot().clients).toHaveLength(0);
+    // A new connection is a new client id; the old one is gone with its socket.
+    tracker.report('c1', true, NOW);
+    tracker.forget('c1');
+    tracker.report('c2', false, NOW);
+    expect(isDesktopPresent(tracker.snapshot(), NOW)).toBe(false);
   });
 
   it('treats a blur report as absent immediately', () => {
@@ -111,5 +152,152 @@ describe('DesktopPresenceTracker', () => {
     tracker.report('c1', true, NOW);
     tracker.report('c1', false, NOW);
     expect(isDesktopPresent(tracker.snapshot(), NOW)).toBe(false);
+  });
+});
+
+describe('createPresenceRpcHandler', () => {
+  function handler(isFirstParty: (id: string) => boolean) {
+    const tracker = new DesktopPresenceTracker();
+    const onPresenceChanged = vi.fn();
+    const log = vi.fn();
+    const rpc = createPresenceRpcHandler({
+      isFirstParty,
+      tracker,
+      onPresenceChanged,
+      now: () => NOW,
+      log,
+    });
+    return { rpc, tracker, onPresenceChanged, log };
+  }
+
+  it('records a report from the first-party client', () => {
+    const h = handler(() => true);
+    expect(h.rpc({ focused: true }, 'c1')).toEqual({ ok: true });
+    expect(isDesktopPresent(h.tracker.snapshot(), NOW)).toBe(true);
+    expect(h.onPresenceChanged).toHaveBeenCalled();
+  });
+
+  it('ignores a spoofed report from a non-first-party client and warns once', () => {
+    const h = handler(() => false);
+    // What an MCP client or a prompt-injected agent would try: claim focus so
+    // its own gated tool calls never reach the phone.
+    expect(h.rpc({ focused: true }, 'mcp-7')).toEqual({ ok: false, reason: 'not-authorized' });
+    expect(isDesktopPresent(h.tracker.snapshot(), NOW)).toBe(false);
+    expect(h.tracker.snapshot().clients).toHaveLength(0);
+    expect(h.onPresenceChanged).not.toHaveBeenCalled();
+    expect(h.log).toHaveBeenCalledTimes(1);
+    expect(h.log.mock.calls[0]?.[0]).toBe('warn');
+  });
+
+  it('reads a missing or non-true focused field as a blur', () => {
+    const h = handler(() => true);
+    h.rpc({}, 'c1');
+    expect(isDesktopPresent(h.tracker.snapshot(), NOW)).toBe(false);
+    h.rpc({ focused: 'yes' }, 'c1');
+    expect(isDesktopPresent(h.tracker.snapshot(), NOW)).toBe(false);
+  });
+});
+
+describe('DeferredPushQueue', () => {
+  function payload(id: string): PushPayload {
+    return { title: 'Approval needed', body: 'q', approvalId: id, sessionId: 's1' };
+  }
+
+  function harness(initiallyPresent = true) {
+    const send = vi.fn();
+    let presentNow = initiallyPresent;
+    let fire: (() => void) | null = null;
+    const queue = new DeferredPushQueue({
+      send,
+      isPresent: () => presentNow,
+      staleAfterMs: () => DESKTOP_PRESENCE_STALE_AFTER_MS,
+      setTimer: (fn) => {
+        fire = fn;
+        return 1;
+      },
+      clearTimer: () => {
+        fire = null;
+      },
+    });
+    return {
+      queue,
+      send,
+      setPresent: (v: boolean) => {
+        presentNow = v;
+      },
+      fireTimer: () => fire?.(),
+      hasTimer: () => fire !== null,
+    };
+  }
+
+  it('delivers a held push when presence goes away, with the same collapseId', () => {
+    const h = harness();
+    h.queue.park('ap-1', payload('ap-1'), 'ap-sess-1');
+    expect(h.send).not.toHaveBeenCalled();
+
+    h.setPresent(false);
+    h.queue.onPresenceChanged();
+    expect(h.send).toHaveBeenCalledTimes(1);
+    expect(h.send).toHaveBeenCalledWith(payload('ap-1'), { collapseId: 'ap-sess-1' });
+    expect(h.queue.size).toBe(0);
+  });
+
+  it('keeps holding while presence persists', () => {
+    const h = harness();
+    h.queue.park('ap-1', payload('ap-1'));
+    h.queue.onPresenceChanged();
+    expect(h.send).not.toHaveBeenCalled();
+    expect(h.queue.size).toBe(1);
+  });
+
+  it('delivers on the stale-expiry timer when nobody reports a transition', () => {
+    const h = harness();
+    h.queue.park('ap-1', payload('ap-1'));
+    // The user walked away without blurring; the window simply ages out.
+    h.setPresent(false);
+    h.fireTimer();
+    expect(h.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-arms rather than delivering when the timer fires and presence is fresh', () => {
+    const h = harness();
+    h.queue.park('ap-1', payload('ap-1'));
+    h.fireTimer();
+    expect(h.send).not.toHaveBeenCalled();
+    expect(h.queue.size).toBe(1);
+    expect(h.hasTimer()).toBe(true);
+  });
+
+  it('does not deliver a push whose approval was already resolved', () => {
+    const h = harness();
+    h.queue.park('ap-1', payload('ap-1'));
+    h.queue.forget('ap-1');
+
+    h.setPresent(false);
+    h.queue.onPresenceChanged();
+    h.fireTimer();
+    expect(h.send).not.toHaveBeenCalled();
+  });
+
+  it('drops the oldest held push past the cap', () => {
+    const h = harness();
+    for (let i = 0; i < DEFERRED_PUSH_CAP + 1; i++) {
+      h.queue.park(`ap-${i}`, payload(`ap-${i}`));
+    }
+    expect(h.queue.size).toBe(DEFERRED_PUSH_CAP);
+
+    h.setPresent(false);
+    h.queue.onPresenceChanged();
+    const sentIds = h.send.mock.calls.map((c) => (c[0] as PushPayload).approvalId);
+    expect(sentIds).not.toContain('ap-0');
+    expect(sentIds).toContain(`ap-${DEFERRED_PUSH_CAP}`);
+  });
+
+  it('drops everything on dispose without sending', () => {
+    const h = harness();
+    h.queue.park('ap-1', payload('ap-1'));
+    h.queue.dispose();
+    expect(h.queue.size).toBe(0);
+    expect(h.send).not.toHaveBeenCalled();
   });
 });

--- a/src/daemon/push/presence.ts
+++ b/src/daemon/push/presence.ts
@@ -16,6 +16,12 @@
 // the desktop app stays connected while it sits minimized behind a full-screen
 // editor for an hour. "A window was focused at time T" is not presence either
 // once T is old enough. Presence is connected AND recently focused.
+//
+// Suppression is a DEFERRAL, not a drop. See `DeferredPushQueue` below: a
+// suppressed push is parked and delivered the moment presence goes away while
+// the approval is still pending. Suppressing without that is data loss — the
+// user walks away from a focused window and the prompt they were meant to
+// answer from the phone never arrives.
 
 import { PUSH_RISK_CRITICAL, type PushPayload } from '../../shared/push/pushEnvelope';
 
@@ -32,6 +38,16 @@ import { PUSH_RISK_CRITICAL, type PushPayload } from '../../shared/push/pushEnve
 export const DESKTOP_PRESENCE_STALE_AFTER_MS = 90_000;
 
 /**
+ * Hard ceiling on a configured freshness window.
+ *
+ * A large finite `staleAfterMs` is not a preference, it is an outage: one
+ * focus report would suppress every push for as long as it stood. Ten minutes
+ * is already far past any honest reading of "the user is at the desk right
+ * now", so anything above it is clamped rather than honoured.
+ */
+export const DESKTOP_PRESENCE_STALE_CAP_MS = 10 * 60_000;
+
+/**
  * A critical-risk approval is pushed even when the desktop is present.
  *
  * This is a deliberate exception to the whole feature, not an oversight. The
@@ -44,23 +60,31 @@ export const DESKTOP_PRESENCE_STALE_AFTER_MS = 90_000;
  */
 export const CRITICAL_RISK_IGNORES_PRESENCE = true;
 
-/** What the daemon currently believes about the desktop app. */
-export interface DesktopPresenceState {
-  /** Is a desktop client's control pipe open right now? */
-  connected: boolean;
-  /** Was the last focus report a focus (`true`) or a blur (`false`)? */
+/** One desktop client's last focus report. */
+export interface DesktopClientReport {
+  /** Was the last report a focus (`true`) or a blur (`false`)? */
   focused: boolean;
-  /**
-   * When that report arrived, epoch ms. `null` means the desktop never told us
-   * anything — a headless daemon, or an app too old to send the RPC. Never
-   * treated as presence.
-   */
-  reportedAt: number | null;
+  /** When that report arrived, epoch ms. */
+  reportedAt: number;
+}
+
+/**
+ * What the daemon currently believes about the desktop app.
+ *
+ * A LIST, not a single slot. One slot was last-writer-wins, and that is two
+ * bugs at once: a second client (a second window, a reconnect racing its own
+ * close) could overwrite a real blur back into presence, and the real client's
+ * later disconnect was then ignored because the id no longer matched. An empty
+ * list is a daemon that has heard nothing — headless, or an app too old to send
+ * the RPC — and is never treated as presence.
+ */
+export interface DesktopPresenceState {
+  clients: DesktopClientReport[];
 }
 
 /** The state of a daemon that has heard nothing from any desktop app. */
 export function emptyDesktopPresence(): DesktopPresenceState {
-  return { connected: false, focused: false, reportedAt: null };
+  return { clients: [] };
 }
 
 /** Knobs from `DaemonConfig.pushPresenceSuppression`, already normalised. */
@@ -70,26 +94,42 @@ export interface PushPresenceSuppressionConfig {
 }
 
 /**
+ * The reading to fall back on whenever the config cannot be trusted — missing
+ * slice, unreadable file, malformed JSON.
+ *
+ * OFF, i.e. send. An indeterminate config must not switch on a feature whose
+ * whole effect is to withhold a notification; the fail-open direction for this
+ * subsystem is always "the phone rings".
+ */
+export function failOpenPresenceConfig(): PushPresenceSuppressionConfig {
+  return { enabled: false, staleAfterMs: DESKTOP_PRESENCE_STALE_AFTER_MS };
+}
+
+/**
  * Is the desktop app both attached and recently at the user's attention?
  *
- * Fails toward "absent" on every uncertainty: no report, a blur, a report older
- * than the freshness window, a disconnected client, or a nonsense clock all
- * answer `false`, and `false` is what lets the push through.
+ * True when ANY reporting client is freshly focused. Two windows open with one
+ * of them focused is still the user being present.
+ *
+ * Fails toward "absent" on every uncertainty: no reports, only blurs, reports
+ * older than the freshness window, or a nonsense clock all answer `false`, and
+ * `false` is what lets the push through.
  */
 export function isDesktopPresent(
   state: DesktopPresenceState,
   now: number,
   staleAfterMs: number = DESKTOP_PRESENCE_STALE_AFTER_MS,
 ): boolean {
-  if (!state.connected) return false;
-  if (!state.focused) return false;
-  if (state.reportedAt === null) return false;
   if (!Number.isFinite(staleAfterMs) || staleAfterMs <= 0) return false;
-  const age = now - state.reportedAt;
-  // A future-dated report (clock step, or a client that sent its own clock)
-  // is not evidence of anything; only a report in the recent past counts.
-  if (age < 0) return false;
-  return age <= staleAfterMs;
+  const window = Math.min(staleAfterMs, DESKTOP_PRESENCE_STALE_CAP_MS);
+  return state.clients.some((c) => {
+    if (!c.focused) return false;
+    const age = now - c.reportedAt;
+    // A future-dated report (clock step, or a client that sent its own clock)
+    // is not evidence of anything; only a report in the recent past counts.
+    if (age < 0) return false;
+    return age <= window;
+  });
 }
 
 export interface SuppressPushInput {
@@ -104,10 +144,11 @@ export interface SuppressPushInput {
 }
 
 /**
- * Should this push be skipped because the user is already looking at it?
+ * Should this push be HELD because the user is already looking at it?
  *
  * The event itself is unaffected — it has already reached the in-app inbox by
- * the time anybody asks this. Only the phone's copy is at stake.
+ * the time anybody asks this. Only the phone's copy is at stake, and only its
+ * timing: a held push is parked, not discarded.
  */
 export function shouldSuppressPush(input: SuppressPushInput): boolean {
   if (!input.config.enabled) return false;
@@ -118,33 +159,220 @@ export function shouldSuppressPush(input: SuppressPushInput): boolean {
 /**
  * The mutable half: what the presence RPC writes and the predicate reads.
  *
- * Single-client on purpose. There is one desktop app per daemon in practice,
- * and "any connected desktop is focused" is the reading that matters anyway —
- * if two were ever open, one of them being focused is still the user being
- * present. The client id is kept only so a disconnect can retract a report
- * that a LATER client has since replaced.
+ * Keyed by pipe client id, so a socket close removes exactly one client's
+ * report and nothing else. Only first-party clients are ever admitted — the
+ * caller enforces that, because the pipe server owns the classification.
  */
 export class DesktopPresenceTracker {
-  private state: DesktopPresenceState = emptyDesktopPresence();
-  private clientId: string | null = null;
+  private readonly reports = new Map<string, DesktopClientReport>();
 
   /** Record a focus/blur transition reported by a desktop client. */
   report(clientId: string, focused: boolean, at: number): void {
-    this.clientId = clientId;
-    this.state = { connected: true, focused, reportedAt: at };
+    this.reports.set(clientId, { focused, reportedAt: at });
   }
 
-  /**
-   * A client went away. Only the client that owns the current report can
-   * retract it — a second app closing must not blank a live one's presence.
-   */
+  /** A client's pipe closed. Removes only that client's report. */
   forget(clientId: string): void {
-    if (this.clientId !== clientId) return;
-    this.clientId = null;
-    this.state = emptyDesktopPresence();
+    this.reports.delete(clientId);
   }
 
   snapshot(): DesktopPresenceState {
-    return { ...this.state };
+    return { clients: [...this.reports.values()].map((r) => ({ ...r })) };
+  }
+}
+
+export interface PresenceRpcHandlerDeps {
+  /** The pipe server's classification. See `DaemonPipeServer.markFirstParty`. */
+  isFirstParty: (clientId: string) => boolean;
+  tracker: DesktopPresenceTracker;
+  /** Called after a report lands, so a held push can be released on a blur. */
+  onPresenceChanged: () => void;
+  now?: () => number;
+  log?: (level: 'info' | 'warn' | 'error', message: string) => void;
+}
+
+export interface PresenceRpcResult {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * The `daemon.presence.desktop` handler, as a testable unit.
+ *
+ * FIRST-PARTY ONLY. This method is a request to WITHHOLD a notification, so an
+ * unauthenticated caller — the MCP server, the CLI, or an agent talked into it
+ * by prompt injection — could otherwise report `focused:true` on a loop and
+ * silence the approval pushes for its own gated tool calls. That is the one
+ * way this feature turns into a security hole rather than a convenience.
+ *
+ * Honest scope, as with the transcript RPCs: this is a classification over one
+ * shared token, not a second credential. It removes the accidental and
+ * prompt-injection paths, not a local attacker holding the token.
+ */
+export function createPresenceRpcHandler(
+  deps: PresenceRpcHandlerDeps,
+): (params: Record<string, unknown>, clientId: string) => PresenceRpcResult {
+  const now = deps.now ?? Date.now;
+  return (params, clientId) => {
+    if (!deps.isFirstParty(clientId)) {
+      deps.log?.(
+        'warn',
+        `[push] ignored presence report from non-first-party client ${clientId}`,
+      );
+      return { ok: false, reason: 'not-authorized' };
+    }
+    deps.tracker.report(clientId, params['focused'] === true, now());
+    deps.onPresenceChanged();
+    return { ok: true };
+  };
+}
+
+// ── Deferred delivery ────────────────────────────────────────────────────────
+
+/**
+ * How many held pushes are remembered.
+ *
+ * Same reasoning as `PUSH_QUEUE_CAP`: these are "someone is blocked on you"
+ * events, and a backlog past a couple of dozen is a sign nobody is answering
+ * anyway. Drop-oldest keeps the ones still worth delivering.
+ */
+export const DEFERRED_PUSH_CAP = 32;
+
+/**
+ * Slack added to the stale horizon before the queue re-checks presence.
+ *
+ * The timer exists to catch the case where presence expires by AGE with no
+ * transition to hook on — a user who focused the window and walked away
+ * without locking the screen. Firing a moment after the window closes rather
+ * than exactly on it avoids a re-arm loop from millisecond rounding.
+ */
+export const DEFERRED_PUSH_TIMER_SLACK_MS = 1_000;
+
+interface ParkedPush {
+  payload: PushPayload;
+  collapseId?: string;
+}
+
+export interface DeferredPushQueueDeps {
+  /** Hand a payload to the sender. Same collapseId as the original attempt. */
+  send: (payload: PushPayload, opts: { collapseId?: string }) => void;
+  /** Ask the predicate whether the desktop is present RIGHT NOW. */
+  isPresent: () => boolean;
+  /** The freshness window in force, for sizing the re-check timer. */
+  staleAfterMs: () => number;
+  now?: () => number;
+  setTimer?: (fn: () => void, ms: number) => unknown;
+  clearTimer?: (handle: unknown) => void;
+  log?: (level: 'info' | 'warn' | 'error', message: string) => void;
+}
+
+/**
+ * Pushes held back by presence, waiting for the user to actually leave.
+ *
+ * Two release paths, because presence can end two ways. A TRANSITION (blur,
+ * screen lock, the app quitting) is reported and calls `onPresenceChanged`.
+ * An EXPIRY has nobody to report it — the user simply walked away — so a
+ * single timer at the freshness horizon re-checks and releases.
+ *
+ * An approval that gets answered or expires while parked is dropped rather
+ * than sent: the notification was asking for the thing that already happened.
+ */
+export class DeferredPushQueue {
+  private readonly parked = new Map<string, ParkedPush>();
+  private readonly deps: DeferredPushQueueDeps;
+  private readonly now: () => number;
+  private readonly setTimerImpl: (fn: () => void, ms: number) => unknown;
+  private readonly clearTimerImpl: (handle: unknown) => void;
+  private timer: unknown = null;
+
+  constructor(deps: DeferredPushQueueDeps) {
+    this.deps = deps;
+    this.now = deps.now ?? Date.now;
+    this.setTimerImpl =
+      deps.setTimer ??
+      ((fn, ms) => {
+        const t = setTimeout(fn, ms);
+        // A held notification must never be the reason a daemon stays up.
+        t.unref?.();
+        return t;
+      });
+    this.clearTimerImpl = deps.clearTimer ?? ((h) => clearTimeout(h as NodeJS.Timeout));
+  }
+
+  get size(): number {
+    return this.parked.size;
+  }
+
+  /** Hold a push that presence suppressed, and arm the expiry re-check. */
+  park(approvalId: string, payload: PushPayload, collapseId?: string): void {
+    if (!this.parked.has(approvalId) && this.parked.size >= DEFERRED_PUSH_CAP) {
+      const oldest = this.parked.keys().next();
+      if (!oldest.done) this.parked.delete(oldest.value);
+    }
+    this.parked.set(approvalId, { payload, ...(collapseId ? { collapseId } : {}) });
+    this.arm();
+  }
+
+  /** The approval was answered, expired, or superseded — the push is moot. */
+  forget(approvalId: string): void {
+    this.parked.delete(approvalId);
+    if (this.parked.size === 0) this.disarm();
+  }
+
+  /**
+   * Presence may have changed (a report arrived, or a client disconnected).
+   * Releases everything if the desktop is no longer present.
+   */
+  onPresenceChanged(): void {
+    if (this.parked.size === 0) return;
+    if (this.deps.isPresent()) {
+      this.arm();
+      return;
+    }
+    this.release();
+  }
+
+  /** Drop every held push without sending. For daemon shutdown. */
+  dispose(): void {
+    this.parked.clear();
+    this.disarm();
+  }
+
+  private release(): void {
+    const entries = [...this.parked.entries()];
+    this.parked.clear();
+    this.disarm();
+    for (const [approvalId, item] of entries) {
+      // The approval id only — never the question or the choices.
+      this.deps.log?.('info', `[push] desktop went away, delivering held push for ${approvalId}`);
+      this.deps.send(item.payload, item.collapseId ? { collapseId: item.collapseId } : {});
+    }
+  }
+
+  private arm(): void {
+    this.disarm();
+    if (this.parked.size === 0) return;
+    const window = this.deps.staleAfterMs();
+    const delay =
+      (Number.isFinite(window) && window > 0
+        ? Math.min(window, DESKTOP_PRESENCE_STALE_CAP_MS)
+        : DESKTOP_PRESENCE_STALE_AFTER_MS) + DEFERRED_PUSH_TIMER_SLACK_MS;
+    this.timer = this.setTimerImpl(() => {
+      this.timer = null;
+      if (this.parked.size === 0) return;
+      // Still present means a fresher report landed after we armed; wait again.
+      if (this.deps.isPresent()) {
+        this.arm();
+        return;
+      }
+      this.release();
+    }, delay);
+  }
+
+  private disarm(): void {
+    if (this.timer !== null) {
+      this.clearTimerImpl(this.timer);
+      this.timer = null;
+    }
   }
 }

--- a/src/daemon/push/presence.ts
+++ b/src/daemon/push/presence.ts
@@ -1,0 +1,150 @@
+// Is the person already looking at the desktop app?
+//
+// A push exists to reach somebody who is not at the machine. When the desktop
+// app is open, connected, and its window was focused moments ago, the phone
+// buzzing is pure noise — the same approval is already sitting in the in-app
+// inbox that the user is staring at. This module answers "is the desktop
+// present?" and nothing else.
+//
+// Deliberately NOT inside PushSender. The decision is about the human, not
+// about the transport: an approval push, a webhook, and any future sink all
+// want the same answer, and a predicate that lives in one sender's internals
+// can only ever be consulted by that sender. Call sites ask this module and
+// then decide.
+//
+// Two bits are required, never one. "A client is connected" is not presence —
+// the desktop app stays connected while it sits minimized behind a full-screen
+// editor for an hour. "A window was focused at time T" is not presence either
+// once T is old enough. Presence is connected AND recently focused.
+
+import { PUSH_RISK_CRITICAL, type PushPayload } from '../../shared/push/pushEnvelope';
+
+/**
+ * How long a focus report stays believable.
+ *
+ * The desktop reports focus on transition, not on a timer, so a user who
+ * focused the window and then walked away leaves a report that ages without
+ * ever being contradicted. Ninety seconds is short enough that "stepped away"
+ * stops counting as present within the lifetime of a single approval prompt,
+ * and long enough that a person reading a card for a minute is not suddenly
+ * declared absent.
+ */
+export const DESKTOP_PRESENCE_STALE_AFTER_MS = 90_000;
+
+/**
+ * A critical-risk approval is pushed even when the desktop is present.
+ *
+ * This is a deliberate exception to the whole feature, not an oversight. The
+ * suppression trades a notification for quiet, and that trade is only worth
+ * making for routine prompts. A destructive action deserves the second channel
+ * — the cost of a redundant buzz is annoyance, the cost of a missed one is a
+ * `DELETE FROM users` that got approved by somebody who never saw it, or an
+ * unanswered gate blocking an agent because the user actually was away and the
+ * stale-window heuristic guessed wrong.
+ */
+export const CRITICAL_RISK_IGNORES_PRESENCE = true;
+
+/** What the daemon currently believes about the desktop app. */
+export interface DesktopPresenceState {
+  /** Is a desktop client's control pipe open right now? */
+  connected: boolean;
+  /** Was the last focus report a focus (`true`) or a blur (`false`)? */
+  focused: boolean;
+  /**
+   * When that report arrived, epoch ms. `null` means the desktop never told us
+   * anything — a headless daemon, or an app too old to send the RPC. Never
+   * treated as presence.
+   */
+  reportedAt: number | null;
+}
+
+/** The state of a daemon that has heard nothing from any desktop app. */
+export function emptyDesktopPresence(): DesktopPresenceState {
+  return { connected: false, focused: false, reportedAt: null };
+}
+
+/** Knobs from `DaemonConfig.pushPresenceSuppression`, already normalised. */
+export interface PushPresenceSuppressionConfig {
+  enabled: boolean;
+  staleAfterMs: number;
+}
+
+/**
+ * Is the desktop app both attached and recently at the user's attention?
+ *
+ * Fails toward "absent" on every uncertainty: no report, a blur, a report older
+ * than the freshness window, a disconnected client, or a nonsense clock all
+ * answer `false`, and `false` is what lets the push through.
+ */
+export function isDesktopPresent(
+  state: DesktopPresenceState,
+  now: number,
+  staleAfterMs: number = DESKTOP_PRESENCE_STALE_AFTER_MS,
+): boolean {
+  if (!state.connected) return false;
+  if (!state.focused) return false;
+  if (state.reportedAt === null) return false;
+  if (!Number.isFinite(staleAfterMs) || staleAfterMs <= 0) return false;
+  const age = now - state.reportedAt;
+  // A future-dated report (clock step, or a client that sent its own clock)
+  // is not evidence of anything; only a report in the recent past counts.
+  if (age < 0) return false;
+  return age <= staleAfterMs;
+}
+
+export interface SuppressPushInput {
+  state: DesktopPresenceState;
+  now: number;
+  config: PushPresenceSuppressionConfig;
+  /**
+   * The risk tier already stamped on the payload. `critical` is pushed
+   * regardless — see {@link CRITICAL_RISK_IGNORES_PRESENCE}.
+   */
+  risk?: PushPayload['risk'];
+}
+
+/**
+ * Should this push be skipped because the user is already looking at it?
+ *
+ * The event itself is unaffected — it has already reached the in-app inbox by
+ * the time anybody asks this. Only the phone's copy is at stake.
+ */
+export function shouldSuppressPush(input: SuppressPushInput): boolean {
+  if (!input.config.enabled) return false;
+  if (CRITICAL_RISK_IGNORES_PRESENCE && input.risk === PUSH_RISK_CRITICAL) return false;
+  return isDesktopPresent(input.state, input.now, input.config.staleAfterMs);
+}
+
+/**
+ * The mutable half: what the presence RPC writes and the predicate reads.
+ *
+ * Single-client on purpose. There is one desktop app per daemon in practice,
+ * and "any connected desktop is focused" is the reading that matters anyway —
+ * if two were ever open, one of them being focused is still the user being
+ * present. The client id is kept only so a disconnect can retract a report
+ * that a LATER client has since replaced.
+ */
+export class DesktopPresenceTracker {
+  private state: DesktopPresenceState = emptyDesktopPresence();
+  private clientId: string | null = null;
+
+  /** Record a focus/blur transition reported by a desktop client. */
+  report(clientId: string, focused: boolean, at: number): void {
+    this.clientId = clientId;
+    this.state = { connected: true, focused, reportedAt: at };
+  }
+
+  /**
+   * A client went away. Only the client that owns the current report can
+   * retract it — a second app closing must not blank a live one's presence.
+   */
+  forget(clientId: string): void {
+    if (this.clientId !== clientId) return;
+    this.clientId = null;
+    this.state = emptyDesktopPresence();
+  }
+
+  snapshot(): DesktopPresenceState {
+    return { ...this.state };
+  }
+}

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -5,6 +5,7 @@ import type { AgentSlug } from '../shared/events';
 import type { ResumeBinding } from '../shared/agentResume';
 import type { LanLinkConfig } from '../shared/lanlink';
 import type { GateConfig } from './approvals/gateConfig';
+import type { PushPresenceSuppressionConfig } from './push/presence';
 
 /** Session lifecycle state */
 export type DaemonSessionState = 'detached' | 'attached' | 'dead' | 'suspended';
@@ -254,6 +255,20 @@ export interface DaemonConfig {
    * entirely (same as `WMUX_GATE=0`, but durable).
    */
   gate?: GateConfig;
+  /**
+   * Presence-based push suppression. OPTIONAL — old config.json files predate
+   * it and must keep loading, so `validateConfig` deliberately ignores this
+   * field and `loadConfig` backfills it per-field without resetting the rest of
+   * the file (same convention as `gate`/`browser`/`lanlink`).
+   *
+   * When the desktop app is attached to the daemon AND its window was focused
+   * within `staleAfterMs`, the phone push for an approval is skipped — the
+   * event still reaches the in-app inbox the user is already looking at. Ships
+   * ON, because the default failure mode is toward notifying: an unknown,
+   * stale, or never-reported presence sends the push, and a `critical`-risk
+   * approval sends it regardless. See `daemon/push/presence.ts`.
+   */
+  pushPresenceSuppression?: PushPresenceSuppressionConfig;
 }
 
 /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -529,8 +529,13 @@ registerSessionHandlers(() => daemonClient?.isConnected === true);
 
 // Presence reporting for push suppression. Registered once on `app` (not on a
 // BrowserWindow) so it survives window recreation; the getter closes over the
-// live `daemonClient` for the same reason as above.
-attachDesktopPresenceReporter(app, () => daemonClient);
+// live `daemonClient` for the same reason as above. powerMonitor is wired too:
+// a lock screen does not blur the window, so without it the daemon would keep
+// holding notifications after the user locked up and left.
+attachDesktopPresenceReporter(app, () => daemonClient, {
+  powerMonitor,
+  isFocused: () => BrowserWindow.getFocusedWindow() !== null,
+});
 
 // Bridge the in-renderer `__wmuxEventsPoll` / `__wmuxChannelsRpc` globals
 // (installed in `src/renderer/hooks/useRpcBridge.ts`) into the live pipe
@@ -1142,10 +1147,27 @@ app.on('ready', async () => {
     onInstall: async (client) => {
       daemonClient = client;
       console.log('[Main] Connected to wmux-daemon (auth verified)');
-      // A fresh daemon has never heard a focus transition, and the user may
-      // have been sitting in a focused window the whole time. Without this
-      // one-shot the app would look absent until the next alt-tab.
-      reportDesktopPresence(() => client, BrowserWindow.getFocusedWindow() !== null);
+      // Claim the first-party role, then report presence. The daemon refuses
+      // `daemon.presence.desktop` from a client it cannot place — a report
+      // that withholds a notification must not be sendable by the MCP server,
+      // the CLI, or an agent talked into it — so the handshake has to land
+      // first. Both are best-effort: an old daemon without either method
+      // simply never learns the user is present and keeps sending pushes.
+      //
+      // The presence report is a one-shot because a fresh daemon has never
+      // heard a focus transition, and the user may have been sitting in a
+      // focused window the whole time. Without it the app looks absent until
+      // the next alt-tab. A new connection is a new pipe client id, so the
+      // daemon starts from empty presence and this is the only thing that
+      // fills it in.
+      void client
+        .rpc('daemon.client.identify', { role: 'main' })
+        .then(() => {
+          reportDesktopPresence(() => client, BrowserWindow.getFocusedWindow() !== null);
+        })
+        .catch(() => {
+          // Old daemon: no identify, therefore no presence, therefore pushes.
+        });
       // Handler swap to daemon-routed mode. The microsecond window where
       // pty/* handlers are torn down and re-registered is the same
       // surface the original code used; the swap is logged for the

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -37,6 +37,7 @@ import * as path from 'path';
 import { app, BrowserWindow, dialog, ipcMain, powerMonitor } from 'electron';
 import { checkUserDataIsolation } from './dataIsolation';
 import { createWindow, loadMainRenderer } from './window/createWindow';
+import { attachDesktopPresenceReporter, reportDesktopPresence } from './window/desktopPresence';
 import { PTYManager } from './pty/PTYManager';
 import { PTYBridge } from './pty/PTYBridge';
 import { registerAllHandlers } from './ipc/registerHandlers';
@@ -525,6 +526,11 @@ const mcpHandlerOptions = {
 // handlers see every connect/disconnect transition that mutates that
 // variable (no closure snapshot).
 registerSessionHandlers(() => daemonClient?.isConnected === true);
+
+// Presence reporting for push suppression. Registered once on `app` (not on a
+// BrowserWindow) so it survives window recreation; the getter closes over the
+// live `daemonClient` for the same reason as above.
+attachDesktopPresenceReporter(app, () => daemonClient);
 
 // Bridge the in-renderer `__wmuxEventsPoll` / `__wmuxChannelsRpc` globals
 // (installed in `src/renderer/hooks/useRpcBridge.ts`) into the live pipe
@@ -1136,6 +1142,10 @@ app.on('ready', async () => {
     onInstall: async (client) => {
       daemonClient = client;
       console.log('[Main] Connected to wmux-daemon (auth verified)');
+      // A fresh daemon has never heard a focus transition, and the user may
+      // have been sitting in a focused window the whole time. Without this
+      // one-shot the app would look absent until the next alt-tab.
+      reportDesktopPresence(() => client, BrowserWindow.getFocusedWindow() !== null);
       // Handler swap to daemon-routed mode. The microsecond window where
       // pty/* handlers are torn down and re-registered is the same
       // surface the original code used; the swap is logged for the

--- a/src/main/window/__tests__/desktopPresence.test.ts
+++ b/src/main/window/__tests__/desktopPresence.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  DESKTOP_PRESENCE_RPC,
+  attachDesktopPresenceReporter,
+  reportDesktopPresence,
+  type PresenceApp,
+  type PresenceRpcClient,
+} from '../desktopPresence';
+
+function client(overrides: Partial<PresenceRpcClient> = {}): PresenceRpcClient {
+  return {
+    isConnected: true,
+    rpc: vi.fn().mockResolvedValue({ ok: true }),
+    ...overrides,
+  } as PresenceRpcClient;
+}
+
+describe('reportDesktopPresence', () => {
+  it('sends the focus bit over the presence RPC', () => {
+    const c = client();
+    reportDesktopPresence(() => c, true);
+    expect(c.rpc).toHaveBeenCalledWith(DESKTOP_PRESENCE_RPC, { focused: true });
+  });
+
+  it('is a no-op with no client or a disconnected one', () => {
+    expect(() => reportDesktopPresence(() => null, true)).not.toThrow();
+    const c = client({ isConnected: false });
+    reportDesktopPresence(() => c, true);
+    expect(c.rpc).not.toHaveBeenCalled();
+  });
+
+  it('swallows a rejected RPC — an old daemon must not surface an error here', () => {
+    const c = client({ rpc: vi.fn().mockRejectedValue(new Error('unknown method')) });
+    expect(() => reportDesktopPresence(() => c, false)).not.toThrow();
+  });
+});
+
+describe('attachDesktopPresenceReporter', () => {
+  it('reports true on window focus and false on blur', () => {
+    const listeners = new Map<string, () => void>();
+    const app: PresenceApp = {
+      on: (event, listener) => {
+        listeners.set(event, listener);
+        return app;
+      },
+    };
+    const c = client();
+    attachDesktopPresenceReporter(app, () => c);
+
+    listeners.get('browser-window-focus')?.();
+    expect(c.rpc).toHaveBeenLastCalledWith(DESKTOP_PRESENCE_RPC, { focused: true });
+
+    listeners.get('browser-window-blur')?.();
+    expect(c.rpc).toHaveBeenLastCalledWith(DESKTOP_PRESENCE_RPC, { focused: false });
+  });
+});

--- a/src/main/window/__tests__/desktopPresence.test.ts
+++ b/src/main/window/__tests__/desktopPresence.test.ts
@@ -5,6 +5,7 @@ import {
   attachDesktopPresenceReporter,
   reportDesktopPresence,
   type PresenceApp,
+  type PresencePowerMonitor,
   type PresenceRpcClient,
 } from '../desktopPresence';
 
@@ -14,6 +15,20 @@ function client(overrides: Partial<PresenceRpcClient> = {}): PresenceRpcClient {
     rpc: vi.fn().mockResolvedValue({ ok: true }),
     ...overrides,
   } as PresenceRpcClient;
+}
+
+/** Collects `on(event, fn)` registrations so a test can fire them. */
+function listenerSink(): { on: (e: string, fn: () => void) => unknown; fire: (e: string) => void } {
+  const map = new Map<string, (() => void)[]>();
+  return {
+    on: (e, fn) => {
+      map.set(e, [...(map.get(e) ?? []), fn]);
+      return undefined;
+    },
+    fire: (e) => {
+      for (const fn of map.get(e) ?? []) fn();
+    },
+  };
 }
 
 describe('reportDesktopPresence', () => {
@@ -30,28 +45,87 @@ describe('reportDesktopPresence', () => {
     expect(c.rpc).not.toHaveBeenCalled();
   });
 
-  it('swallows a rejected RPC — an old daemon must not surface an error here', () => {
-    const c = client({ rpc: vi.fn().mockRejectedValue(new Error('unknown method')) });
-    expect(() => reportDesktopPresence(() => c, false)).not.toThrow();
+  it('swallows a rejected focus report without retrying — a lost buzz is cheap', async () => {
+    const rpc = vi.fn().mockRejectedValue(new Error('unknown method'));
+    const c = client({ rpc });
+    vi.useFakeTimers();
+    try {
+      expect(() => reportDesktopPresence(() => c, true)).not.toThrow();
+      await Promise.resolve();
+      vi.advanceTimersByTime(5_000);
+      expect(rpc).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retries a failed BLUR once — a lost blur keeps notifications held', async () => {
+    const rpc = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('transport blip'))
+      .mockResolvedValue({ ok: true });
+    const c = client({ rpc });
+    vi.useFakeTimers();
+    try {
+      reportDesktopPresence(() => c, false, { retryMs: 10 });
+      // Let the rejected promise's catch run before the timer is scheduled.
+      await vi.advanceTimersByTimeAsync(50);
+      expect(rpc).toHaveBeenCalledTimes(2);
+      expect(rpc).toHaveBeenLastCalledWith(DESKTOP_PRESENCE_RPC, { focused: false });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
 describe('attachDesktopPresenceReporter', () => {
   it('reports true on window focus and false on blur', () => {
-    const listeners = new Map<string, () => void>();
-    const app: PresenceApp = {
-      on: (event, listener) => {
-        listeners.set(event, listener);
-        return app;
-      },
-    };
+    const sink = listenerSink();
+    const app = { on: sink.on } as unknown as PresenceApp;
     const c = client();
     attachDesktopPresenceReporter(app, () => c);
 
-    listeners.get('browser-window-focus')?.();
+    sink.fire('browser-window-focus');
     expect(c.rpc).toHaveBeenLastCalledWith(DESKTOP_PRESENCE_RPC, { focused: true });
 
-    listeners.get('browser-window-blur')?.();
+    sink.fire('browser-window-blur');
     expect(c.rpc).toHaveBeenLastCalledWith(DESKTOP_PRESENCE_RPC, { focused: false });
+  });
+
+  it('reports a blur on lock-screen, suspend, and shutdown — none of which blur a window', () => {
+    for (const event of ['lock-screen', 'suspend', 'shutdown']) {
+      const appSink = listenerSink();
+      const powerSink = listenerSink();
+      const c = client();
+      attachDesktopPresenceReporter(
+        { on: appSink.on } as unknown as PresenceApp,
+        () => c,
+        {
+          powerMonitor: { on: powerSink.on } as unknown as PresencePowerMonitor,
+          isFocused: () => true,
+        },
+      );
+
+      powerSink.fire(event);
+      expect(c.rpc, event).toHaveBeenCalledWith(DESKTOP_PRESENCE_RPC, { focused: false });
+    }
+  });
+
+  it('re-reports the real focus state on unlock and resume', () => {
+    const appSink = listenerSink();
+    const powerSink = listenerSink();
+    const c = client();
+    let focused = false;
+    attachDesktopPresenceReporter({ on: appSink.on } as unknown as PresenceApp, () => c, {
+      powerMonitor: { on: powerSink.on } as unknown as PresencePowerMonitor,
+      isFocused: () => focused,
+    });
+
+    powerSink.fire('unlock-screen');
+    expect(c.rpc).toHaveBeenLastCalledWith(DESKTOP_PRESENCE_RPC, { focused: false });
+
+    focused = true;
+    powerSink.fire('resume');
+    expect(c.rpc).toHaveBeenLastCalledWith(DESKTOP_PRESENCE_RPC, { focused: true });
   });
 });

--- a/src/main/window/desktopPresence.ts
+++ b/src/main/window/desktopPresence.ts
@@ -1,18 +1,40 @@
 // Tell the daemon when the user is actually looking at the desktop app.
 //
-// The daemon uses this to skip the phone push for an approval it can see the
-// user is already staring at (`daemon/push/presence.ts`). One bit, sent on
-// transition, and that is the entire contract — the daemon owns the freshness
-// rules and the fail-open behaviour, so nothing here has to be clever.
+// The daemon uses this to hold back the phone push for an approval it can see
+// the user is already staring at (`daemon/push/presence.ts`). One bit, sent on
+// transition, and that is nearly the entire contract — the daemon owns the
+// freshness rules and the fail-open behaviour, so little here has to be clever.
 //
 // Hung on the `app`-level `browser-window-focus`/`browser-window-blur` events
 // rather than on a BrowserWindow: they fire for every window, they survive the
 // window being recreated (macOS dock re-activate), and there is exactly one
 // place to register them.
+//
+// The two directions are NOT symmetric, and that asymmetry drives the retry
+// below. A lost `focused:true` costs a redundant buzz. A lost `focused:false`
+// leaves the daemon believing the user is present when they are not, and holds
+// their notifications — so a blur that fails to send is retried, and a focus
+// that fails is not.
 
 /** The slice of Electron's `app` this touches, so a test can pass a stub. */
 export interface PresenceApp {
   on(event: 'browser-window-focus' | 'browser-window-blur', listener: () => void): unknown;
+}
+
+/**
+ * The slice of Electron's `powerMonitor` this touches.
+ *
+ * Locking the screen, the display sleeping, and the machine suspending do NOT
+ * fire a window blur — the window keeps focus behind the lock screen. Without
+ * these the daemon would hold notifications for the whole freshness window
+ * after the user locked up and walked away, which is precisely the moment the
+ * phone is the only channel left.
+ */
+export interface PresencePowerMonitor {
+  on(
+    event: 'lock-screen' | 'unlock-screen' | 'suspend' | 'resume' | 'shutdown',
+    listener: () => void,
+  ): unknown;
 }
 
 /** The slice of DaemonClient this touches. */
@@ -23,32 +45,68 @@ export interface PresenceRpcClient {
 
 export const DESKTOP_PRESENCE_RPC = 'daemon.presence.desktop';
 
+/** How long to wait before re-sending a blur that failed. */
+export const PRESENCE_BLUR_RETRY_MS = 750;
+
 /**
- * Send one presence report. Never throws and never awaits anything a caller
- * cares about: a daemon that is down, restarting, or too old to know the
- * method simply does not learn the user is present, and the daemon's fail-open
- * default then sends the push. That is the correct degradation — the
- * suppression is a nicety, the notification is not.
+ * Send one presence report.
+ *
+ * Never throws and never awaits anything a caller cares about: a daemon that
+ * is down, restarting, or too old to know the method simply does not learn the
+ * user is present, and the daemon's fail-open default then sends the push.
+ *
+ * A failed `focused:false` is retried once — see the module note. A failed
+ * retry is dropped: the daemon's own freshness window is the backstop, and an
+ * unbounded retry loop against a dead daemon is worse than a late notification.
  */
 export function reportDesktopPresence(
   getClient: () => PresenceRpcClient | null,
   focused: boolean,
+  opts: { retryMs?: number } = {},
 ): void {
   const client = getClient();
   if (!client?.isConnected) return;
   void client.rpc(DESKTOP_PRESENCE_RPC, { focused }).catch(() => {
-    // Deliberately silent. This fires on every window focus change; a daemon
-    // without the method would otherwise write a log line per alt-tab.
+    // Deliberately silent otherwise. This fires on every window focus change;
+    // a daemon without the method would write a log line per alt-tab.
+    if (focused) return;
+    const timer = setTimeout(() => {
+      const retryClient = getClient();
+      if (!retryClient?.isConnected) return;
+      void retryClient.rpc(DESKTOP_PRESENCE_RPC, { focused: false }).catch(() => {
+        // One retry only. The daemon's own freshness window is the backstop,
+        // and a loop against a dead daemon is worse than a late notification.
+      });
+    }, opts.retryMs ?? PRESENCE_BLUR_RETRY_MS);
+    timer.unref?.();
   });
 }
 
 /**
  * Wire focus/blur reporting. Call once at boot — `app` outlives every window.
+ *
+ * `isFocused` is read on wake-up (`unlock-screen`/`resume`) to re-report the
+ * truth: the window may or may not still be the focused one, and guessing
+ * either way would be wrong half the time.
  */
 export function attachDesktopPresenceReporter(
   electronApp: PresenceApp,
   getClient: () => PresenceRpcClient | null,
+  opts: { powerMonitor?: PresencePowerMonitor; isFocused?: () => boolean } = {},
 ): void {
   electronApp.on('browser-window-focus', () => reportDesktopPresence(getClient, true));
   electronApp.on('browser-window-blur', () => reportDesktopPresence(getClient, false));
+
+  const power = opts.powerMonitor;
+  if (!power) return;
+  // The user is behind a lock screen or the machine is going down: absent,
+  // whatever the window still thinks it owns.
+  for (const event of ['lock-screen', 'suspend', 'shutdown'] as const) {
+    power.on(event, () => reportDesktopPresence(getClient, false));
+  }
+  // Back at the machine. Re-report what is actually true rather than assuming
+  // the user came back to THIS window.
+  for (const event of ['unlock-screen', 'resume'] as const) {
+    power.on(event, () => reportDesktopPresence(getClient, opts.isFocused?.() ?? false));
+  }
 }

--- a/src/main/window/desktopPresence.ts
+++ b/src/main/window/desktopPresence.ts
@@ -1,0 +1,54 @@
+// Tell the daemon when the user is actually looking at the desktop app.
+//
+// The daemon uses this to skip the phone push for an approval it can see the
+// user is already staring at (`daemon/push/presence.ts`). One bit, sent on
+// transition, and that is the entire contract — the daemon owns the freshness
+// rules and the fail-open behaviour, so nothing here has to be clever.
+//
+// Hung on the `app`-level `browser-window-focus`/`browser-window-blur` events
+// rather than on a BrowserWindow: they fire for every window, they survive the
+// window being recreated (macOS dock re-activate), and there is exactly one
+// place to register them.
+
+/** The slice of Electron's `app` this touches, so a test can pass a stub. */
+export interface PresenceApp {
+  on(event: 'browser-window-focus' | 'browser-window-blur', listener: () => void): unknown;
+}
+
+/** The slice of DaemonClient this touches. */
+export interface PresenceRpcClient {
+  readonly isConnected: boolean;
+  rpc(method: string, params?: Record<string, unknown>): Promise<unknown>;
+}
+
+export const DESKTOP_PRESENCE_RPC = 'daemon.presence.desktop';
+
+/**
+ * Send one presence report. Never throws and never awaits anything a caller
+ * cares about: a daemon that is down, restarting, or too old to know the
+ * method simply does not learn the user is present, and the daemon's fail-open
+ * default then sends the push. That is the correct degradation — the
+ * suppression is a nicety, the notification is not.
+ */
+export function reportDesktopPresence(
+  getClient: () => PresenceRpcClient | null,
+  focused: boolean,
+): void {
+  const client = getClient();
+  if (!client?.isConnected) return;
+  void client.rpc(DESKTOP_PRESENCE_RPC, { focused }).catch(() => {
+    // Deliberately silent. This fires on every window focus change; a daemon
+    // without the method would otherwise write a log line per alt-tab.
+  });
+}
+
+/**
+ * Wire focus/blur reporting. Call once at boot — `app` outlives every window.
+ */
+export function attachDesktopPresenceReporter(
+  electronApp: PresenceApp,
+  getClient: () => PresenceRpcClient | null,
+): void {
+  electronApp.on('browser-window-focus', () => reportDesktopPresence(getClient, true));
+  electronApp.on('browser-window-blur', () => reportDesktopPresence(getClient, false));
+}


### PR DESCRIPTION
## What

Approval pushes currently fire even when the user is sitting in front of the desktop app with the inbox open. This adds presence-based suppression: when the desktop client is connected AND a window was focused within the last 90s (configurable), the APNs push for an approval is skipped. The event still reaches the in-app inbox — only the phone ping is suppressed.

## Semantics

- **Signal**: transition-based, no heartbeat. Electron main reports `browser-window-focus`/`blur` over a new tiny RPC (`daemon.presence.desktop`, `{focused: boolean}`), plus a one-shot sync when a daemon connection is established (a fresh daemon has heard no transitions).
- **Present** = connected && focused && report age within `staleAfterMs` (default 90s).
- **Fail-open toward notifying**: unreported, blurred, stale, clock-skewed, garbage config, or headless daemon → the push is sent. Suppression requires a positively fresh signal. Pipe close reclaims only that client's report (a late close from a replaced connection is ignored).
- **Critical carve-out**: `risk === 'critical'` payloads always push, present or not (`CRITICAL_RISK_IGNORES_PRESENCE` named constant).
- Decision lives in one pure module (`src/daemon/push/presence.ts`); `PushSender` internals untouched, so other outbound sinks can adopt the same predicate.

## Config

`pushPresenceSuppression: { enabled: true, staleAfterMs: 90000 }` with per-field backfill; garbage values restore defaults without touching sibling fields.

## Tests

17 added: predicate boundary cases (exactly 90s vs +1ms, stale, critical, disabled, headless, future-clock, NaN window), tracker ownership/blur reclaim, main-side reporter transitions and no-op paths.

## Notes

- Changelog fragment: `changelog.d/t4-presence-suppression.md`.
- `attention` events have no APNs call site today; when one appears it should consult the same predicate.

## Prior art

Concept-level borrowing only, no code imported: presence-based push suppression is the pattern Claude Code remote control uses (skip push while the desktop client is active). Signal design (transition-based focus RPC, fail-open, critical carve-out) is wmux's own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Push notifications for non-critical approvals are now suppressed while the desktop app is recently focused.
  * Suppressed notifications remain available in the in-app inbox and are delivered when presence ends or becomes stale.
  * Critical-risk notifications and uncertain presence states continue to trigger pushes immediately.
  * Presence detection responds to focus, blur, lock, suspend, unlock, and resume events.
  * Added configurable suppression with a default 90-second freshness window.

* **Documentation**
  * Documented desktop presence-based push-notification suppression behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->