### PR TITLE
fix(gate): let a bypassPermissions session through the permission gate

### DIFF
--- a/changelog.d/829.md
+++ b/changelog.d/829.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **A bypass-mode session no longer stops at the permission gate.** An agent
+  launched with `--dangerously-skip-permissions` has already declared that it
+  should never be asked, but the remote permission gate opened an approval
+  record for it anyway — on every `Bash`, `Write`, `Edit`, `MultiEdit`,
+  `NotebookEdit`, `Task`, and `KillShell` call. With no phone attached, each of
+  those calls paused for the full gate deadline and then fell back to exactly
+  the local prompt the user had opted out of, which read as "bypass mode asks
+  for approval on every tool call". The gate now reads the session's live
+  permission mode and lets a bypass session straight through, while the pane's
+  liveness header keeps updating as before. Sessions that do still prompt —
+  `acceptEdits`, `plan`, and the default mode — keep their gates unchanged.
+  (#829)

--- a/src/daemon/hooks/HookIngest.ts
+++ b/src/daemon/hooks/HookIngest.ts
@@ -511,10 +511,22 @@ export class HookIngest {
       ? signal.payload.tool_name
       : null;
     const gatedTools = this.deps.gateConfig?.().gatedTools ?? [];
-    const isGated = toolName !== null && gatedTools.includes(toolName);
+    // A `bypassPermissions` session has already declared "never ask me" — the
+    // user launched it with `--dangerously-skip-permissions` (or set
+    // `permissions.defaultMode`). Gating it anyway re-asks the exact question
+    // they opted out of, and when no phone is attached EVERY gated tool call
+    // stalls until the gate deadline before falling back to a local prompt.
+    // Claude Code stamps the live mode on every PreToolUse payload, so honour
+    // it. Only `bypassPermissions` passes through: `acceptEdits` still prompts
+    // for Bash and `plan`/`default` prompt for everything, so their gates stay
+    // meaningful.
+    const bypassing = typeof signal.payload?.permission_mode === 'string'
+      && signal.payload.permission_mode === 'bypassPermissions';
+    const isGated = !bypassing && toolName !== null && gatedTools.includes(toolName);
 
     if (!isGated) {
-      // Non-gated tool — emit tool_started for phone liveness header, allow.
+      // Non-gated tool (or a bypass session) — emit tool_started for the phone
+      // liveness header, allow.
       this.broadcast(sessionId, {
         agent: agentSlugToDisplay(signal.agent),
         status: 'running',

--- a/src/daemon/hooks/__tests__/HookIngest.test.ts
+++ b/src/daemon/hooks/__tests__/HookIngest.test.ts
@@ -596,6 +596,65 @@ describe('HookIngest', () => {
       expect(stats.perAgent.claude).toBe(12);
     });
   });
+
+  describe('permission gate vs the session permission mode', () => {
+    // Build an ingest whose gate config actually gates Bash, and count the
+    // gate records it opens. The shared fixture leaves gateConfig unset (=
+    // nothing gated), which would make every assertion here vacuously pass.
+    function gatingIngest() {
+      const base = makeDeps();
+      let gatesOpened = 0;
+      const ingestWithGate = new HookIngest({
+        ...base.deps,
+        gateConfig: () => ({ gatedTools: ['Bash'] }),
+        approvals: {
+          ...base.deps.approvals,
+          noteGateAwaiting: () => {
+            gatesOpened += 1;
+            return 'gate-id';
+          },
+        },
+      });
+      return { ingestWithGate, gates: () => gatesOpened, emitted: base.emitted };
+    }
+
+    function gateSignal(permissionMode?: string): AgentSignal {
+      return makeSignal({
+        kind: 'agent.awaiting_permission',
+        ptyId: 'pty-a',
+        payload: {
+          tool_name: 'Bash',
+          ...(permissionMode ? { permission_mode: permissionMode } : {}),
+        },
+      });
+    }
+
+    it('passes a bypassPermissions session straight through without opening a gate', () => {
+      // The user launched with --dangerously-skip-permissions: re-asking is the
+      // exact thing they opted out of, and with no phone attached every gated
+      // call would stall until the deadline.
+      const { ingestWithGate, gates, emitted } = gatingIngest();
+      const result = ingestWithGate.handlePermissionGate(gateSignal('bypassPermissions'));
+
+      expect(result.ok).toBe(true);
+      expect(result.gateId).toBeUndefined();
+      expect(gates()).toBe(0);
+      // Liveness still flows, so the phone header keeps showing the pane busy.
+      expect(emitted.at(-1)?.data.hookKind).toBe('agent.tool_started');
+    });
+
+    it('still gates the same tool when the session prompts (acceptEdits / default / absent)', () => {
+      // acceptEdits auto-approves edits but still prompts for Bash, so its gate
+      // stays meaningful — only bypassPermissions is a declared opt-out.
+      for (const mode of ['acceptEdits', 'default', 'plan', undefined]) {
+        const { ingestWithGate, gates } = gatingIngest();
+        const result = ingestWithGate.handlePermissionGate(gateSignal(mode));
+
+        expect(result.gateId, `mode=${String(mode)}`).toBe('gate-id');
+        expect(gates(), `mode=${String(mode)}`).toBe(1);
+      }
+    });
+  });
 });
 
 describe('resolveSessionIdForSignal', () => {


### PR DESCRIPTION
## The bug

The #783 permission gate opens a remote approval record for every gated tool —
`Bash`, `Write`, `Edit`, `MultiEdit`, `NotebookEdit`, `Task`, `KillShell` — and
holds the hook's RPC open until a phone answers or the deadline fires.

It did that **regardless of the session's own permission mode**. A session
launched with `--dangerously-skip-permissions` has explicitly opted out of being
asked, yet it still stalled on every `Bash` call and then fell back to exactly
the local prompt the user opted out of. With no phone attached, that is a
deadline-length pause on *every* gated tool call.

From the user's seat this reads as **"I launched in bypass mode and it asks for
approval on every tool call."** `gatedTools` defaults to the full list, and
`wmux setup-hooks` installs the wide PreToolUse matcher unconditionally, so any
user who ran `setup-hooks` and launched in bypass mode hits this.

## The fix

Claude Code stamps the live mode on every PreToolUse payload as
`permission_mode` (verified against a real payload: `permission_mode:
"bypassPermissions"`), and the bridge already forwards the payload verbatim. So
the daemon can honour it with **no bridge change and no config migration**.

A `bypassPermissions` signal now skips the gate and broadcasts
`agent.tool_started` like any non-gated tool, so the phone's liveness header is
unchanged.

Only that one mode passes through. `acceptEdits` still prompts for `Bash`, so
its gate stays meaningful, as do `plan`, `default`, and an absent mode.

## Tests

Two cases added to `HookIngest.test.ts`, in a block that injects a gate config
that actually gates `Bash` (the shared fixture leaves `gateConfig` unset, which
would make the assertions vacuous):

- a `bypassPermissions` signal opens no gate record, returns no `gateId`, and
  still emits `agent.tool_started`
- `acceptEdits`, `default`, `plan`, and an absent mode each still open exactly
  one gate

Verified these fail without the fix: reverting the `!bypassing &&` guard fails
exactly one test, restoring it passes all 62 in the file.

`tsc -p tsconfig.daemon.json` clean. Full `test:parallel` run: the only failures
are in `notificationSlice.test.ts`, which passes 23/23 on its own — a
parallel-run flake unrelated to this change (nothing here touches the renderer).