### PR TITLE
fix(remote): make /api/stream snapshots mode-safe, resize-aware, and query-silent

### DIFF
--- a/changelog.d/830.md
+++ b/changelog.d/830.md
@@ -1,0 +1,24 @@
+### Fixed
+
+- **Mirrored remote panes running a fullscreen app no longer paint a garbled
+  screen.** Attaching to a pane that had been running vim, htop or an agent CLI
+  for a while showed rows interleaved over old scrollback, with fragments of
+  earlier frames stuck along the left edge, and the app never took over the
+  screen. The initial paint is capped to a window of recent output, and a
+  fullscreen app announces itself exactly once, at startup — so hours later that
+  announcement was outside the window and the terminal was still on the ordinary
+  buffer while the bytes assumed the fullscreen one. The daemon now tracks which
+  modes a pane's output has switched on and restores them ahead of the paint.
+  This affects phones and tablets opening the web terminal too, not only
+  mirrored workspaces.
+
+- **Resizing a pane no longer breaks every viewer watching it.** Geometry was
+  sent once when a viewer connected, so after a resize on the machine that owns
+  the pane, everything drawn afterwards was positioned for a grid the viewer no
+  longer had. Viewers are now repainted at the new size once the resize settles.
+
+- **A mirrored pane no longer types into the remote shell by itself.** Terminals
+  answer certain queries automatically, and a mirror was sending its answers on
+  to the remote pane's input — so replaying scrollback that contained such a
+  query injected stray characters into a live shell on the other machine. The
+  machine that owns the pane is the only one that answers now.

--- a/changelog.d/830.md
+++ b/changelog.d/830.md
@@ -8,17 +8,21 @@
   fullscreen app announces itself exactly once, at startup — so hours later that
   announcement was outside the window and the terminal was still on the ordinary
   buffer while the bytes assumed the fullscreen one. The daemon now tracks which
-  modes a pane's output has switched on and restores them ahead of the paint.
-  This affects phones and tablets opening the web terminal too, not only
-  mirrored workspaces.
+  modes a pane's output has switched on and restores them ahead of the paint,
+  including for panes restored after a restart. This affects phones and tablets
+  opening the web terminal too, not only mirrored workspaces.
 
 - **Resizing a pane no longer breaks every viewer watching it.** Geometry was
   sent once when a viewer connected, so after a resize on the machine that owns
   the pane, everything drawn afterwards was positioned for a grid the viewer no
-  longer had. Viewers are now repainted at the new size once the resize settles.
+  longer had. Viewers now follow the new size once the resize settles — and only
+  the size: a viewer's scrollback and scroll position survive someone resizing
+  the pane on the other machine.
 
 - **A mirrored pane no longer types into the remote shell by itself.** Terminals
   answer certain queries automatically, and a mirror was sending its answers on
-  to the remote pane's input — so replaying scrollback that contained such a
-  query injected stray characters into a live shell on the other machine. The
-  machine that owns the pane is the only one that answers now.
+  to the remote pane's input — so a live app, or replayed scrollback containing
+  such a query, injected stray characters into a shell on the other machine. A
+  mirror no longer sends those answers; the machine that owns the pane is the
+  one that responds. The same injection is fixed in the phone and tablet web
+  terminal.

--- a/src/daemon/DaemonPTYBridge.ts
+++ b/src/daemon/DaemonPTYBridge.ts
@@ -8,6 +8,7 @@ import { parseOsc7Cwd, detectPromptCwd } from '../main/pty/cwdDetect';
 import { sanitizeTitle } from '../main/pty/titleDetect';
 import { RingBuffer } from './RingBuffer';
 import { PromptEventLog, parseOsc133Payload } from './PromptEventLog';
+import { OutputModeTracker } from './util/outputModeTracker';
 import { RESIZE_REDRAW_GUARD_MS } from '../main/notification/idleSuppression';
 
 /**
@@ -23,9 +24,12 @@ import { RESIZE_REDRAW_GUARD_MS } from '../main/notification/idleSuppression';
  *  - 'active'   → { sessionId: string }                — onActive cycle start
  *  - 'idle'     → { sessionId: string }                — onActiveToIdle
  *  - 'exit'     → { sessionId: string, exitCode, signal }
+ *  - 'resize'   → (no payload) — an applied geometry change; consumers read the
+ *                 new size from the session's own meta.
  */
 export class DaemonPTYBridge extends EventEmitter {
   private oscParser: OscParser | null = null;
+  private modeTracker: OutputModeTracker | null = null;
   private agentDetector: AgentDetector | null = null;
   private activityMonitor: ActivityMonitor | null = null;
   private dataDisposable: (() => void) | null = null;
@@ -93,6 +97,21 @@ export class DaemonPTYBridge extends EventEmitter {
   /** Called by DaemonSessionManager.resizeSession on every applied resize. */
   noteResize(): void {
     this.lastResizeAtMs = Date.now();
+    // One event for BOTH resize paths (the phone's /api/sessions/:id/resize and
+    // the desk's RPC) — they both land in resizeSession, and an SSE viewer whose
+    // grid is now the wrong size renders every later absolute-positioned frame
+    // in the wrong place.
+    this.emit('resize');
+  }
+
+  /**
+   * Live terminal-mode state reconstructed from this session's output, or null
+   * before data forwarding is set up. Read by the SSE snapshot path so a capped
+   * window that no longer contains the mode switches can still be replayed
+   * faithfully — see util/outputModeTracker.ts.
+   */
+  get outputModes(): OutputModeTracker | null {
+    return this.modeTracker;
   }
 
   /**
@@ -178,6 +197,11 @@ export class DaemonPTYBridge extends EventEmitter {
   ): void {
     const oscParser = new OscParser();
     this.oscParser = oscParser;
+
+    // Fed from the same place the ring is written, so the tracked modes always
+    // describe exactly the bytes the ring holds.
+    const modeTracker = new OutputModeTracker();
+    this.modeTracker = modeTracker;
 
     const agentDetector = new AgentDetector();
     this.agentDetector = agentDetector;
@@ -331,6 +355,7 @@ export class DaemonPTYBridge extends EventEmitter {
       if (this.muted) return;
       try {
         ringBuffer.write(buf);
+        modeTracker.feed(data);
         oscParser.process(data);
 
         // Prompt-based CWD detection — fallback for shells WITHOUT the
@@ -440,6 +465,7 @@ export class DaemonPTYBridge extends EventEmitter {
     this.submittedTurnPending = false;
     this.inputInBracketedPaste = false;
     this.oscParser = null;
+    this.modeTracker = null;
     this.agentDetector = null;
     this.activityMonitor = null;
     this.sessionId = null;

--- a/src/daemon/DaemonPTYBridge.ts
+++ b/src/daemon/DaemonPTYBridge.ts
@@ -200,8 +200,20 @@ export class DaemonPTYBridge extends EventEmitter {
 
     // Fed from the same place the ring is written, so the tracked modes always
     // describe exactly the bytes the ring holds.
+    //
+    // Including the bytes that were already there: a RECOVERED session's ring is
+    // pre-filled with saved scrollback BEFORE this bridge exists (see
+    // DaemonSessionManager.createSession), and those are precisely the
+    // long-running fullscreen sessions the preamble exists for — a tracker that
+    // started at power-on defaults here would report "no alt screen" for a pane
+    // that has been inside vim since before the daemon restarted. One pass over
+    // the ring, once per PTY lifetime.
     const modeTracker = new OutputModeTracker();
     this.modeTracker = modeTracker;
+    const prefilled = ringBuffer.readAll();
+    if (prefilled.length > 0) {
+      modeTracker.feed(prefilled.toString('utf8'), ringBuffer.totalBytesWritten);
+    }
 
     const agentDetector = new AgentDetector();
     this.agentDetector = agentDetector;
@@ -355,7 +367,9 @@ export class DaemonPTYBridge extends EventEmitter {
       if (this.muted) return;
       try {
         ringBuffer.write(buf);
-        modeTracker.feed(data);
+        // AFTER the ring write: the tracker's offsets are in the ring's own
+        // coordinate system, so it needs the counter this chunk already moved.
+        modeTracker.feed(data, ringBuffer.totalBytesWritten);
         oscParser.process(data);
 
         // Prompt-based CWD detection — fallback for shells WITHOUT the

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -492,7 +492,14 @@ export class DaemonSessionManager extends EventEmitter {
       : DEFAULT_BUFFER_SIZE;
     const ringBuffer = new RingBuffer(bufferSize);
 
-    // Pre-fill ring buffer with saved scrollback (session recovery)
+    // Pre-fill ring buffer with saved scrollback (session recovery).
+    //
+    // MUST stay ahead of the `bridge.setupDataForwarding` call below: that is
+    // where the OutputModeTracker is built, and it primes itself by reading
+    // whatever the ring already holds. Filling the ring afterwards would leave
+    // the tracker blind to the restored bytes, and a session recovered mid-vim
+    // would replay its alt-screen frames onto a client still on the normal
+    // buffer — the exact garbling util/outputModeTracker.ts exists to prevent.
     if (params.scrollbackData && params.scrollbackData.length > 0) {
       ringBuffer.write(params.scrollbackData);
     }

--- a/src/daemon/__tests__/DaemonPTYBridge.outputModes.test.ts
+++ b/src/daemon/__tests__/DaemonPTYBridge.outputModes.test.ts
@@ -1,0 +1,94 @@
+// The tracker/ring wiring, exercised through the REAL setupDataForwarding
+// path rather than by handing WebTerminalServer a hand-built tracker.
+//
+// The preamble is only correct while the tracker's state describes exactly the
+// bytes the ring holds — and the two are filled in two different places (a
+// recovered session's scrollback goes straight into the ring, before any bridge
+// exists), so a divergence here is invisible to every test that stubs
+// `bridge.outputModes`.
+import { describe, it, expect, afterEach } from 'vitest';
+import type { IPty } from 'node-pty';
+import { DaemonPTYBridge } from '../DaemonPTYBridge';
+import { RingBuffer } from '../RingBuffer';
+
+function makeFakePty(): { pty: IPty; feed: (data: string) => void } {
+  let dataHandler: ((data: string) => void) | null = null;
+  const pty = {
+    onData: (cb: (data: string) => void) => {
+      dataHandler = cb;
+      return { dispose: () => { dataHandler = null; } };
+    },
+    onExit: () => ({ dispose: () => { /* noop */ } }),
+  } as unknown as IPty;
+  return { pty, feed: (data: string) => dataHandler?.(data) };
+}
+
+const ALT_PREAMBLE = '\x1b[?1049h\x1b[2J\x1b[H';
+
+/** What WebTerminalServer computes: the absolute offset of the window's first byte. */
+function windowStart(ring: RingBuffer, windowBytes: number): number {
+  return ring.totalBytesWritten - Math.min(windowBytes, ring.size);
+}
+
+describe('DaemonPTYBridge output-mode tracking', () => {
+  let bridge: DaemonPTYBridge | null = null;
+
+  afterEach(() => {
+    bridge?.cleanup();
+    bridge = null;
+  });
+
+  it('tracks modes off live PTY output', () => {
+    const ring = new RingBuffer(65536);
+    const fake = makeFakePty();
+    bridge = new DaemonPTYBridge();
+    bridge.setupDataForwarding(fake.pty, ring, 'sess-live');
+
+    expect(bridge.outputModes?.altScreen).toBe(false);
+    fake.feed('\x1b[?1049h\x1b[2J');
+    expect(bridge.outputModes?.altScreen).toBe(true);
+  });
+
+  it('★ sees the scrollback a RECOVERED session pre-filled into the ring', () => {
+    // DaemonSessionManager writes the saved buffer dump into the ring BEFORE
+    // constructing the bridge. A tracker that only watched live output would
+    // report "normal buffer" for a pane that has been inside a fullscreen app
+    // since before the daemon restarted — no preamble, and the garbling this
+    // whole mechanism exists to prevent comes straight back.
+    const ring = new RingBuffer(65536);
+    ring.write(Buffer.from('\x1b[?1049h\x1b[2J\x1b[Hrestored frame\r\n', 'utf8'));
+    const fake = makeFakePty();
+    bridge = new DaemonPTYBridge();
+    bridge.setupDataForwarding(fake.pty, ring, 'sess-recovered');
+
+    expect(bridge.outputModes?.altScreen).toBe(true);
+  });
+
+  it('★ keeps ring and tracker offsets in one coordinate system across a prefill', () => {
+    const ring = new RingBuffer(65536);
+    // Restored scrollback: the alt entry is at the very front of it.
+    ring.write(Buffer.from('\x1b[?1049h\x1b[2J\x1b[H', 'utf8'));
+    const fake = makeFakePty();
+    bridge = new DaemonPTYBridge();
+    bridge.setupDataForwarding(fake.pty, ring, 'sess-offsets');
+    // …then the app keeps painting, pushing the entry back.
+    fake.feed('frame\r\n'.repeat(200));
+
+    const modes = bridge.outputModes;
+    expect(modes).not.toBeNull();
+    // A window big enough to reach the restored entry must NOT re-assert it.
+    expect(modes?.preamble(windowStart(ring, ring.size))).toBe('');
+    // A window that only covers the live frames must.
+    expect(modes?.preamble(windowStart(ring, 64))).toBe(ALT_PREAMBLE);
+  });
+
+  it('drops the tracker on cleanup', () => {
+    const ring = new RingBuffer(4096);
+    const fake = makeFakePty();
+    bridge = new DaemonPTYBridge();
+    bridge.setupDataForwarding(fake.pty, ring, 'sess-cleanup');
+    expect(bridge.outputModes).not.toBeNull();
+    bridge.cleanup();
+    expect(bridge.outputModes).toBeNull();
+  });
+});

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -713,6 +713,34 @@ describe('DaemonSessionManager', () => {
       );
     });
 
+    it('★ the mode tracker sees pre-filled scrollback, in the ring\'s offsets', () => {
+      // A pane that was inside vim when the daemon went down: the alt-screen
+      // switch lives in the RESTORED bytes, which are written to the ring
+      // before the bridge exists. If the tracker misses them, `/api/stream`
+      // sends no preamble and the replayed frames land on the client's normal
+      // buffer — the exact garbling outputModeTracker.ts exists to prevent.
+      const restored = '\x1b[?1049h\x1b[2J\x1b[H' + 'frame line\r\n'.repeat(50);
+      manager.createSession({
+        id: 'rec-modes',
+        cmd: 'cmd.exe',
+        cwd: '.',
+        scrollbackData: Buffer.from(restored, 'utf8'),
+        deferOutput: true,
+      });
+      const managed = manager.getSession('rec-modes');
+      const modes = managed?.bridge.outputModes;
+      expect(modes?.altScreen).toBe(true);
+
+      const total = managed?.ringBuffer.totalBytesWritten ?? 0;
+      const alt = '\x1b[?1049h\x1b[2J\x1b[H';
+      // A window that still reaches the restored switch must NOT re-assert it
+      // (that would paint the scrollback ahead of it into the alt buffer)…
+      expect(modes?.preamble(0)).toBe('');
+      // …and one that starts after it must.
+      expect(modes?.preamble(1)).toBe(alt);
+      expect(modes?.preamble(total - 16)).toBe(alt);
+    });
+
     it('unmutes after first resize plus the drain delay', () => {
       vi.useFakeTimers();
       try {

--- a/src/daemon/util/__tests__/outputModeTracker.test.ts
+++ b/src/daemon/util/__tests__/outputModeTracker.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { OutputModeTracker } from '../outputModeTracker';
+
+/** Feed a stream one char at a time — every possible chunk boundary at once. */
+function feedByChar(tracker: OutputModeTracker, text: string): void {
+  for (const ch of text) tracker.feed(ch);
+}
+
+describe('OutputModeTracker', () => {
+  it('starts at the power-on defaults and asks for no preamble', () => {
+    const t = new OutputModeTracker();
+    expect(t.altScreen).toBe(false);
+    expect(t.isSet(7)).toBe(true); // autowrap on
+    expect(t.isSet(25)).toBe(true); // cursor visible
+    expect(t.preamble()).toBe('');
+  });
+
+  it('plain output never moves a mode', () => {
+    const t = new OutputModeTracker();
+    t.feed('$ ls -la\r\n\x1b[0m\x1b[32mfile.txt\x1b[0m\r\n');
+    expect(t.preamble()).toBe('');
+  });
+
+  it('tracks the alt-screen switch and its matching reset', () => {
+    const t = new OutputModeTracker();
+    t.feed('\x1b[?1049h');
+    expect(t.altScreen).toBe(true);
+    expect(t.preamble()).toBe('\x1b[?1049h\x1b[2J\x1b[H');
+    t.feed('\x1b[?1049l');
+    expect(t.altScreen).toBe(false);
+    expect(t.preamble()).toBe('');
+  });
+
+  it('treats ?47 and ?1047 as alt screen too, and normalises to ?1049 on replay', () => {
+    for (const mode of [47, 1047]) {
+      const t = new OutputModeTracker();
+      t.feed(`\x1b[?${mode}h`);
+      expect(t.altScreen).toBe(true);
+      expect(t.preamble()).toBe('\x1b[?1049h\x1b[2J\x1b[H');
+    }
+  });
+
+  it('last writer wins per mode', () => {
+    const t = new OutputModeTracker();
+    t.feed('\x1b[?1049h\x1b[?1049l\x1b[?1049h\x1b[?1049l\x1b[?1049h');
+    expect(t.altScreen).toBe(true);
+    t.feed('\x1b[?1049l');
+    expect(t.altScreen).toBe(false);
+  });
+
+  it('applies every parameter of a multi-mode set/reset', () => {
+    const t = new OutputModeTracker();
+    t.feed('\x1b[?1000;1002;1006;2004h');
+    expect(t.isSet(1000)).toBe(true);
+    expect(t.isSet(1002)).toBe(true);
+    expect(t.isSet(1006)).toBe(true);
+    expect(t.isSet(2004)).toBe(true);
+    t.feed('\x1b[?1002;1006l');
+    expect(t.isSet(1000)).toBe(true);
+    expect(t.isSet(1002)).toBe(false);
+    expect(t.isSet(1006)).toBe(false);
+  });
+
+  it('survives a sequence split across chunk boundaries', () => {
+    const split = new OutputModeTracker();
+    split.feed('output\x1b[?10');
+    split.feed('49h more output');
+    expect(split.altScreen).toBe(true);
+
+    // The pathological case: one char per feed, for a whole realistic startup.
+    const byChar = new OutputModeTracker();
+    feedByChar(byChar, 'banner\r\n\x1b[?1049h\x1b[?25l\x1b[?1002;1006h\x1b[2J');
+    expect(byChar.altScreen).toBe(true);
+    expect(byChar.isSet(25)).toBe(false);
+    expect(byChar.isSet(1002)).toBe(true);
+    expect(byChar.isSet(1006)).toBe(true);
+  });
+
+  it('keeps mouse protocol and encoding independent in the preamble', () => {
+    const t = new OutputModeTracker();
+    t.feed('\x1b[?1003h\x1b[?1006h');
+    const preamble = t.preamble();
+    expect(preamble).toContain('\x1b[?1003h');
+    expect(preamble).toContain('\x1b[?1006h');
+    expect(preamble).not.toContain('\x1b[?1000h');
+    // Switching encodings replaces, it does not accumulate.
+    t.feed('\x1b[?1006l\x1b[?1015h');
+    expect(t.preamble()).toContain('\x1b[?1015h');
+    expect(t.preamble()).not.toContain('\x1b[?1006h');
+  });
+
+  it('emits the RESET form for modes whose default is on', () => {
+    const t = new OutputModeTracker();
+    t.feed('\x1b[?25l\x1b[?7l');
+    const preamble = t.preamble();
+    expect(preamble).toContain('\x1b[?25l');
+    expect(preamble).toContain('\x1b[?7l');
+    // Turning them back on returns to silence, not to an explicit `h`.
+    t.feed('\x1b[?25h\x1b[?7h');
+    expect(t.preamble()).toBe('');
+  });
+
+  it('RIS (ESC c) puts everything back to defaults', () => {
+    const t = new OutputModeTracker();
+    t.feed('\x1b[?1049h\x1b[?2004h\x1b[?25l');
+    expect(t.preamble()).not.toBe('');
+    t.feed('\x1bc');
+    expect(t.altScreen).toBe(false);
+    expect(t.preamble()).toBe('');
+  });
+
+  it('applies a reset that lands between two set-mode sequences in stream order', () => {
+    const t = new OutputModeTracker();
+    t.feed('\x1b[?1049h\x1bc\x1b[?2004h');
+    expect(t.altScreen).toBe(false);
+    expect(t.isSet(2004)).toBe(true);
+  });
+
+  it('ignores private modes it does not track and non-private mode changes', () => {
+    const t = new OutputModeTracker();
+    t.feed('\x1b[?12h\x1b[?1004h\x1b[4h\x1b[20h');
+    expect(t.preamble()).toBe('');
+  });
+
+  it('leads the preamble with the alt-screen switch before anything else', () => {
+    const t = new OutputModeTracker();
+    t.feed('\x1b[?2004h\x1b[?25l\x1b[?1049h');
+    expect(t.preamble().startsWith('\x1b[?1049h\x1b[2J\x1b[H')).toBe(true);
+  });
+});

--- a/src/daemon/util/__tests__/outputModeTracker.test.ts
+++ b/src/daemon/util/__tests__/outputModeTracker.test.ts
@@ -1,10 +1,28 @@
 import { describe, it, expect } from 'vitest';
 import { OutputModeTracker } from '../outputModeTracker';
 
+/**
+ * `feed()` takes the ring's running byte offset. Tests that only care about
+ * mode state should not have to bookkeep it, so this keeps one per tracker.
+ */
+const offsets = new WeakMap<OutputModeTracker, number>();
+function feed(t: OutputModeTracker, chunk: string): void {
+  const next = (offsets.get(t) ?? 0) + Buffer.byteLength(chunk, 'utf8');
+  offsets.set(t, next);
+  t.feed(chunk, next);
+}
+
 /** Feed a stream one char at a time — every possible chunk boundary at once. */
 function feedByChar(tracker: OutputModeTracker, text: string): void {
-  for (const ch of text) tracker.feed(ch);
+  for (const ch of text) feed(tracker, ch);
 }
+
+/**
+ * A window that starts after everything fed so far, i.e. "the mode switches
+ * have scrolled out of the snapshot". The alt-screen gate is an offset
+ * comparison, so tests about the OTHER modes pass this to opt out of it.
+ */
+const WINDOW_AFTER_EVERYTHING = Number.MAX_SAFE_INTEGER;
 
 describe('OutputModeTracker', () => {
   it('starts at the power-on defaults and asks for no preamble', () => {
@@ -12,50 +30,94 @@ describe('OutputModeTracker', () => {
     expect(t.altScreen).toBe(false);
     expect(t.isSet(7)).toBe(true); // autowrap on
     expect(t.isSet(25)).toBe(true); // cursor visible
-    expect(t.preamble()).toBe('');
+    expect(t.preamble(WINDOW_AFTER_EVERYTHING)).toBe('');
   });
 
   it('plain output never moves a mode', () => {
     const t = new OutputModeTracker();
-    t.feed('$ ls -la\r\n\x1b[0m\x1b[32mfile.txt\x1b[0m\r\n');
-    expect(t.preamble()).toBe('');
+    feed(t, '$ ls -la\r\n\x1b[0m\x1b[32mfile.txt\x1b[0m\r\n');
+    expect(t.preamble(WINDOW_AFTER_EVERYTHING)).toBe('');
   });
 
   it('tracks the alt-screen switch and its matching reset', () => {
     const t = new OutputModeTracker();
-    t.feed('\x1b[?1049h');
+    feed(t, '\x1b[?1049h');
     expect(t.altScreen).toBe(true);
-    expect(t.preamble()).toBe('\x1b[?1049h\x1b[2J\x1b[H');
-    t.feed('\x1b[?1049l');
+    expect(t.preamble(WINDOW_AFTER_EVERYTHING)).toBe('\x1b[?1049h\x1b[2J\x1b[H');
+    feed(t, '\x1b[?1049l');
     expect(t.altScreen).toBe(false);
-    expect(t.preamble()).toBe('');
+    expect(t.preamble(WINDOW_AFTER_EVERYTHING)).toBe('');
   });
 
-  it('treats ?47 and ?1047 as alt screen too, and normalises to ?1049 on replay', () => {
-    for (const mode of [47, 1047]) {
+  // ★ regression for the blocker: the tracker's state describes the WHOLE
+  // stream, the snapshot only its tail. Re-asserting an entry the window still
+  // carries paints the scrollback ahead of it into the alternate buffer, the
+  // window's own entry then no-ops, and leaving the app strands the user on an
+  // empty normal buffer with the scrollback gone.
+  it('★ skips the alt preamble while the window still contains the entry', () => {
+    const t = new OutputModeTracker();
+    feed(t, 'line1\r\nline2\r\n'); // 14 bytes
+    feed(t, '\x1b[?1049h'); // entry at byte 14, ends at 22
+    feed(t, '\x1b[HVIM FRAME');
+
+    // A window that opens at or before byte 14 carries the entry itself.
+    expect(t.preamble(14)).toBe('');
+    expect(t.preamble(0)).toBe('');
+    // One byte later and the entry is outside — it has to be re-asserted.
+    expect(t.preamble(15)).toBe('\x1b[?1049h\x1b[2J\x1b[H');
+  });
+
+  it('★ dates the alt entry from the LATEST one, not the first', () => {
+    const t = new OutputModeTracker();
+    feed(t, '\x1b[?1049h'); // bytes 0..8
+    feed(t, 'x'.repeat(500)); // bytes 8..508
+    feed(t, '\x1b[?1049l\x1b[?1049h'); // exit at 508, re-entry at 516
+    expect(t.preamble(600)).toBe('\x1b[?1049h\x1b[2J\x1b[H');
+    // A window reaching back to the re-entry carries it, so nothing is added —
+    // even though the FIRST entry is long gone.
+    expect(t.preamble(516)).toBe('');
+    expect(t.preamble(517)).toBe('\x1b[?1049h\x1b[2J\x1b[H');
+  });
+
+  it('★ measures the alt entry offset in BYTES, not chars', () => {
+    const head = 'héllo→'; // 6 chars, 9 bytes
+    expect(head.length).toBe(6);
+    expect(Buffer.byteLength(head, 'utf8')).toBe(9);
+    const t = new OutputModeTracker();
+    feed(t, head);
+    feed(t, '\x1b[?1049h');
+    expect(t.preamble(9)).toBe(''); // entry starts exactly at byte 9
+    expect(t.preamble(10)).toBe('\x1b[?1049h\x1b[2J\x1b[H');
+    // A char-length offset (6) would have put the entry outside a window that
+    // in fact contains it.
+    expect(t.preamble(6)).toBe('');
+  });
+
+  it('emits the alt-screen mode that was actually used, not a normalised 1049', () => {
+    for (const mode of [47, 1047, 1049]) {
       const t = new OutputModeTracker();
-      t.feed(`\x1b[?${mode}h`);
+      feed(t, `\x1b[?${mode}h`);
       expect(t.altScreen).toBe(true);
-      expect(t.preamble()).toBe('\x1b[?1049h\x1b[2J\x1b[H');
+      expect(t.preamble(WINDOW_AFTER_EVERYTHING)).toBe(`\x1b[?${mode}h\x1b[2J\x1b[H`);
     }
   });
 
   it('last writer wins per mode', () => {
     const t = new OutputModeTracker();
-    t.feed('\x1b[?1049h\x1b[?1049l\x1b[?1049h\x1b[?1049l\x1b[?1049h');
+    feed(t, '\x1b[?1049h\x1b[?1049l\x1b[?1049h\x1b[?1049l\x1b[?1049h');
     expect(t.altScreen).toBe(true);
-    t.feed('\x1b[?1049l');
+    feed(t, '\x1b[?1049l');
     expect(t.altScreen).toBe(false);
   });
 
   it('applies every parameter of a multi-mode set/reset', () => {
     const t = new OutputModeTracker();
-    t.feed('\x1b[?1000;1002;1006;2004h');
+    feed(t, '\x1b[?1000;1002;1006;2004h');
     expect(t.isSet(1000)).toBe(true);
     expect(t.isSet(1002)).toBe(true);
     expect(t.isSet(1006)).toBe(true);
     expect(t.isSet(2004)).toBe(true);
-    t.feed('\x1b[?1002;1006l');
+    feed(t, '\x1b[?1002;1006l');
     expect(t.isSet(1000)).toBe(true);
     expect(t.isSet(1002)).toBe(false);
     expect(t.isSet(1006)).toBe(false);
@@ -63,8 +125,8 @@ describe('OutputModeTracker', () => {
 
   it('survives a sequence split across chunk boundaries', () => {
     const split = new OutputModeTracker();
-    split.feed('output\x1b[?10');
-    split.feed('49h more output');
+    feed(split, 'output\x1b[?10');
+    feed(split, '49h more output');
     expect(split.altScreen).toBe(true);
 
     // The pathological case: one char per feed, for a whole realistic startup.
@@ -76,55 +138,133 @@ describe('OutputModeTracker', () => {
     expect(byChar.isSet(1006)).toBe(true);
   });
 
+  it('re-scanning the carry does not change the state it already applied', () => {
+    // `\x1b[?1049l` lands inside the carry the next feed re-scans. Applying it
+    // twice must be indistinguishable from applying it once — and, critically,
+    // must not make the tracker think the alt entry happened in THIS chunk.
+    const t = new OutputModeTracker();
+    feed(t, '\x1b[?1049h');
+    feed(t, 'painting');
+    expect(t.altScreen).toBe(true);
+    expect(t.preamble(1)).toBe('\x1b[?1049h\x1b[2J\x1b[H');
+    // The entry is still reported at offset 0, not re-dated to the later feeds.
+    expect(t.preamble(0)).toBe('');
+    feed(t, 'more');
+    expect(t.preamble(0)).toBe('');
+    expect(t.altScreen).toBe(true);
+  });
+
+  it('matches a mode sequence longer than the carry window', () => {
+    // 11 parameters — the realistic worst case a TUI sends in one go, and the
+    // shape that a 64-char carry could not hold.
+    const long = '\x1b[?1000;1001;1002;1003;1004;1005;1006;1007;1015;1016;2004h';
+    expect(long.length).toBeGreaterThan(50);
+    const t = new OutputModeTracker();
+    // Split three chars in, so the ESC is only reachable through the carry.
+    feed(t, long.slice(0, 3));
+    feed(t, long.slice(3));
+    expect(t.isSet(1002)).toBe(true);
+    expect(t.isSet(1006)).toBe(true);
+    expect(t.isSet(2004)).toBe(true);
+  });
+
   it('keeps mouse protocol and encoding independent in the preamble', () => {
     const t = new OutputModeTracker();
-    t.feed('\x1b[?1003h\x1b[?1006h');
-    const preamble = t.preamble();
+    feed(t, '\x1b[?1003h\x1b[?1006h');
+    const preamble = t.preamble(WINDOW_AFTER_EVERYTHING);
     expect(preamble).toContain('\x1b[?1003h');
     expect(preamble).toContain('\x1b[?1006h');
     expect(preamble).not.toContain('\x1b[?1000h');
     // Switching encodings replaces, it does not accumulate.
-    t.feed('\x1b[?1006l\x1b[?1015h');
-    expect(t.preamble()).toContain('\x1b[?1015h');
-    expect(t.preamble()).not.toContain('\x1b[?1006h');
+    feed(t, '\x1b[?1006l\x1b[?1015h');
+    expect(t.preamble(WINDOW_AFTER_EVERYTHING)).toContain('\x1b[?1015h');
+    expect(t.preamble(WINDOW_AFTER_EVERYTHING)).not.toContain('\x1b[?1006h');
   });
 
   it('emits the RESET form for modes whose default is on', () => {
     const t = new OutputModeTracker();
-    t.feed('\x1b[?25l\x1b[?7l');
-    const preamble = t.preamble();
+    feed(t, '\x1b[?25l\x1b[?7l');
+    const preamble = t.preamble(WINDOW_AFTER_EVERYTHING);
     expect(preamble).toContain('\x1b[?25l');
     expect(preamble).toContain('\x1b[?7l');
     // Turning them back on returns to silence, not to an explicit `h`.
-    t.feed('\x1b[?25h\x1b[?7h');
-    expect(t.preamble()).toBe('');
+    feed(t, '\x1b[?25h\x1b[?7h');
+    expect(t.preamble(WINDOW_AFTER_EVERYTHING)).toBe('');
+  });
+
+  it('reports the documented DEFAULT for a mode nothing has touched', () => {
+    const t = new OutputModeTracker();
+    // Default-on modes must not read back as false just because no sequence
+    // has mentioned them — a caller gating on isSet(7) would conclude autowrap
+    // is off on a terminal that has it on.
+    expect(t.isSet(7)).toBe(true);
+    expect(t.isSet(25)).toBe(true);
+    expect(t.isSet(2004)).toBe(false);
+    // Untracked modes fall through to false, as before.
+    expect(t.isSet(9999)).toBe(false);
   });
 
   it('RIS (ESC c) puts everything back to defaults', () => {
     const t = new OutputModeTracker();
-    t.feed('\x1b[?1049h\x1b[?2004h\x1b[?25l');
-    expect(t.preamble()).not.toBe('');
-    t.feed('\x1bc');
+    feed(t, '\x1b[?1049h\x1b[?2004h\x1b[?25l');
+    expect(t.preamble(WINDOW_AFTER_EVERYTHING)).not.toBe('');
+    feed(t, '\x1bc');
     expect(t.altScreen).toBe(false);
-    expect(t.preamble()).toBe('');
+    expect(t.preamble(WINDOW_AFTER_EVERYTHING)).toBe('');
+  });
+
+  it('DECSTR (CSI ! p) soft-resets the modes a real terminal resets', () => {
+    // terminfo `rs2` is literally `\E[!p`, so `reset` / `tput init` takes this
+    // path. Without it the tracker keeps asserting modes the remote dropped —
+    // application cursor keys on a shell that expects arrows, a hidden cursor.
+    const t = new OutputModeTracker();
+    feed(t, '\x1b[?1h\x1b[?7l\x1b[?25l\x1b[?2004h\x1b[?1002;1006h');
+    expect(t.preamble(WINDOW_AFTER_EVERYTHING)).not.toBe('');
+    feed(t, '\x1b[!p');
+    expect(t.isSet(1)).toBe(false);
+    expect(t.isSet(7)).toBe(true);
+    expect(t.isSet(25)).toBe(true);
+    expect(t.isSet(2004)).toBe(false);
+    expect(t.isSet(1002)).toBe(false);
+    expect(t.preamble(WINDOW_AFTER_EVERYTHING)).toBe('');
+  });
+
+  it('DECSTR does NOT pretend the alternate screen was left', () => {
+    // A soft reset does not swap the buffer back, and claiming it did would
+    // drop the client onto the normal buffer while the stream keeps painting
+    // absolute frames.
+    const t = new OutputModeTracker();
+    feed(t, '\x1b[?1049h\x1b[?25l');
+    feed(t, '\x1b[!p');
+    expect(t.altScreen).toBe(true);
+    expect(t.preamble(WINDOW_AFTER_EVERYTHING)).toBe('\x1b[?1049h\x1b[2J\x1b[H');
+  });
+
+  it('does not mistake DA1 (ESC[c) for RIS (ESC c)', () => {
+    const t = new OutputModeTracker();
+    feed(t, '\x1b[?1049h\x1b[?2004h');
+    // An app querying device attributes must not wipe the tracked state.
+    feed(t, '\x1b[c\x1b[>c\x1b[=c');
+    expect(t.altScreen).toBe(true);
+    expect(t.isSet(2004)).toBe(true);
   });
 
   it('applies a reset that lands between two set-mode sequences in stream order', () => {
     const t = new OutputModeTracker();
-    t.feed('\x1b[?1049h\x1bc\x1b[?2004h');
+    feed(t, '\x1b[?1049h\x1bc\x1b[?2004h');
     expect(t.altScreen).toBe(false);
     expect(t.isSet(2004)).toBe(true);
   });
 
   it('ignores private modes it does not track and non-private mode changes', () => {
     const t = new OutputModeTracker();
-    t.feed('\x1b[?12h\x1b[?1004h\x1b[4h\x1b[20h');
-    expect(t.preamble()).toBe('');
+    feed(t, '\x1b[?12h\x1b[?1004h\x1b[4h\x1b[20h');
+    expect(t.preamble(WINDOW_AFTER_EVERYTHING)).toBe('');
   });
 
   it('leads the preamble with the alt-screen switch before anything else', () => {
     const t = new OutputModeTracker();
-    t.feed('\x1b[?2004h\x1b[?25l\x1b[?1049h');
-    expect(t.preamble().startsWith('\x1b[?1049h\x1b[2J\x1b[H')).toBe(true);
+    feed(t, '\x1b[?2004h\x1b[?25l\x1b[?1049h');
+    expect(t.preamble(WINDOW_AFTER_EVERYTHING).startsWith('\x1b[?1049h\x1b[2J\x1b[H')).toBe(true);
   });
 });

--- a/src/daemon/util/outputModeTracker.ts
+++ b/src/daemon/util/outputModeTracker.ts
@@ -1,0 +1,139 @@
+/**
+ * Live tracker for the terminal MODES a PTY's output stream has switched on.
+ *
+ * The ring buffer holds raw bytes and `/api/stream` paints only the LAST
+ * window of it (see web/snapshotWindow.ts). Byte-safety is not enough: a
+ * fullscreen TUI sends `ESC[?1049h` once, at startup, and then paints with
+ * absolute cursor positioning forever. Hours later that switch is far outside
+ * the 256 KB window, so a client replaying the window is still on the normal
+ * buffer while the bytes assume the alternate one — absolute-positioned frames
+ * land interleaved over scrollback instead of repainting a screen.
+ *
+ * The local GUI never hits this because HeadlessSnapshot refuses alt-screen and
+ * SessionPipe falls back to a full raw replay. The SSE path cannot afford that
+ * (that is the whole reason the window exists), so it reconstructs the mode
+ * state instead: this tracker is fed every chunk written to the ring — O(chunk)
+ * at write time — and answers in O(1) at stream-open time, which keeps
+ * snapshotWindow.ts's "work per call is independent of buffer size" invariant.
+ *
+ * Only DEC private modes that change how SUBSEQUENT bytes are interpreted are
+ * tracked. Colors, charsets and cursor position are carried by the window's own
+ * bytes and need no reconstruction.
+ */
+
+/**
+ * The tracked DEC private modes and their power-on values. A mode that is at
+ * its default contributes nothing to the preamble.
+ */
+const MODE_DEFAULTS: ReadonlyMap<number, boolean> = new Map([
+  [1, false], // DECCKM — application cursor keys
+  [7, true], // DECAWM — autowrap
+  [25, true], // DECTCEM — cursor visible
+  [47, false], // alt screen (legacy)
+  [1047, false], // alt screen (clear-on-exit)
+  [1049, false], // alt screen + saved cursor — what modern TUIs use
+  [1000, false], // mouse: normal tracking
+  [1002, false], // mouse: button-event tracking
+  [1003, false], // mouse: any-event tracking
+  [1005, false], // mouse encoding: UTF-8
+  [1006, false], // mouse encoding: SGR
+  [1015, false], // mouse encoding: urxvt
+  [2004, false], // bracketed paste
+]);
+
+/** The three alt-screen modes, in the order a preamble should assert them. */
+const ALT_SCREEN_MODES: readonly number[] = [47, 1047, 1049];
+
+/**
+ * Chars kept across feeds so a mode sequence split at a chunk boundary still
+ * matches. `ESC[?1000;1002;1003;1005;1006;1015;2004h` is the longest realistic
+ * shape; 64 covers it with room to spare. Same technique as
+ * ansiStreamScan.ts's REGEX_CARRY_CHARS.
+ */
+const CARRY_CHARS = 64;
+
+/**
+ * DEC private mode set/reset (`CSI ? Ps ; Ps ... h|l`) or RIS (`ESC c`).
+ * Matched together so a reset that lands between two set-mode sequences is
+ * applied in stream order rather than by group.
+ */
+// eslint-disable-next-line no-control-regex
+const MODE_RE = /\x1b(?:\[\?([0-9;]*)([hl])|c)/g;
+
+export class OutputModeTracker {
+  private carry = '';
+  private readonly state = new Map<number, boolean>(MODE_DEFAULTS);
+
+  /**
+   * Feed one decoded output chunk, in stream order.
+   *
+   * The carry means a chunk boundary inside a sequence does not lose it, at the
+   * cost of re-scanning at most CARRY_CHARS chars per chunk. A sequence that
+   * spans the boundary is matched once, on the feed that completes it — the
+   * previous feed saw no final `h`/`l` so it could not have matched.
+   */
+  feed(chunk: string): void {
+    if (chunk.length === 0) return;
+    const text = this.carry + chunk;
+    MODE_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = MODE_RE.exec(text)) !== null) {
+      if (m[1] === undefined) {
+        this.reset();
+        continue;
+      }
+      const on = m[2] === 'h';
+      for (const raw of m[1].split(';')) {
+        if (raw === '') continue;
+        const mode = Number(raw);
+        // Last writer wins, per mode: a stream that toggles 1049 a hundred
+        // times leaves the value the last sequence asked for.
+        if (this.state.has(mode)) this.state.set(mode, on);
+      }
+    }
+    this.carry = text.slice(-CARRY_CHARS);
+  }
+
+  /** Back to power-on defaults, as RIS (`ESC c`) does to a real terminal. */
+  reset(): void {
+    for (const [mode, def] of MODE_DEFAULTS) this.state.set(mode, def);
+  }
+
+  /** Current value of one tracked mode (defaults for anything untracked). */
+  isSet(mode: number): boolean {
+    return this.state.get(mode) ?? false;
+  }
+
+  /** True while the stream is painting into an alternate screen buffer. */
+  get altScreen(): boolean {
+    return ALT_SCREEN_MODES.some((m) => this.state.get(m) === true);
+  }
+
+  /**
+   * A sequence that puts a fresh terminal into the mode state this stream is
+   * actually in, to be PREPENDED to a capped snapshot. Empty when every tracked
+   * mode is at its default, so a plain shell session is byte-identical to
+   * before this existed.
+   *
+   * Alt screen is asserted first and followed by an erase + cursor home: the
+   * window that follows was produced by an app that owns the whole screen and
+   * repaints by absolute positioning, so it must start from a known-blank grid
+   * rather than over whatever the client had.
+   *
+   * Accepted limitation: an alt-screen app that has been IDLE since before the
+   * window starts contributes no repaint of its own, so the client shows only
+   * the part of its frame that the window happens to contain until the app next
+   * redraws. Mostly-right beats the garbled interleave this replaces.
+   */
+  preamble(): string {
+    let out = '';
+    if (this.altScreen) out += '\x1b[?1049h\x1b[2J\x1b[H';
+    for (const [mode, def] of MODE_DEFAULTS) {
+      if (ALT_SCREEN_MODES.includes(mode)) continue; // handled above
+      const value = this.state.get(mode) ?? def;
+      if (value === def) continue;
+      out += `\x1b[?${mode}${value ? 'h' : 'l'}`;
+    }
+    return out;
+  }
+}

--- a/src/daemon/util/outputModeTracker.ts
+++ b/src/daemon/util/outputModeTracker.ts
@@ -46,40 +46,69 @@ const ALT_SCREEN_MODES: readonly number[] = [47, 1047, 1049];
 
 /**
  * Chars kept across feeds so a mode sequence split at a chunk boundary still
- * matches. `ESC[?1000;1002;1003;1005;1006;1015;2004h` is the longest realistic
- * shape; 64 covers it with room to spare. Same technique as
+ * matches. The longest realistic shape is a full mouse-mode declaration —
+ * `ESC[?1000;1001;1002;1003;1004;1005;1006;1007;1015;1016;2004h` is already 60
+ * chars — so the old 64 left a boundary a few chars in dropping the ESC and
+ * missing the whole sequence. 256 gives real margin. Same technique as
  * ansiStreamScan.ts's REGEX_CARRY_CHARS.
  */
-const CARRY_CHARS = 64;
+const CARRY_CHARS = 256;
 
 /**
- * DEC private mode set/reset (`CSI ? Ps ; Ps ... h|l`) or RIS (`ESC c`).
- * Matched together so a reset that lands between two set-mode sequences is
- * applied in stream order rather than by group.
+ * DEC private mode set/reset (`CSI ? Ps ; Ps ... h|l`), RIS (`ESC c`) or DECSTR
+ * soft reset (`CSI ! p`). Matched together so a reset that lands between two
+ * set-mode sequences is applied in stream order rather than by group.
+ *
+ * DECSTR is not optional: terminfo's `rs2` — what `reset` and `tput init` send
+ * — is literally `\E[!p`, so a stream that resets its terminal that way would
+ * otherwise leave the tracker asserting modes the remote no longer has.
  */
 // eslint-disable-next-line no-control-regex
-const MODE_RE = /\x1b(?:\[\?([0-9;]*)([hl])|c)/g;
+const MODE_RE = /\x1b(?:\[\?([0-9;]*)([hl])|\[!p|c)/g;
+
+/** RIS — a full power-on reset. */
+const RIS = '\x1bc';
 
 export class OutputModeTracker {
   private carry = '';
   private readonly state = new Map<number, boolean>(MODE_DEFAULTS);
+  /**
+   * Absolute stream offset (in BYTES, in the ring's own coordinate system) of
+   * the last alt-screen ENTRY, and which mode performed it. -1 until one is
+   * seen. See {@link preamble} for what the offset decides.
+   */
+  private lastAltEntryOffset = -1;
+  private lastAltEntryMode = 0;
 
   /**
    * Feed one decoded output chunk, in stream order.
+   *
+   * `streamEndOffset` is the ring's `totalBytesWritten` AFTER this chunk was
+   * written to it. The ring's counter is used rather than one this class keeps
+   * itself because the two must share a coordinate system with the snapshot
+   * window, and only the ring's is authoritative: a recovered session's ring is
+   * PRE-FILLED with saved scrollback (DaemonSessionManager.createSession), so a
+   * counter started at zero here would be off by the whole prefill and
+   * mis-decide every window comparison below.
    *
    * The carry means a chunk boundary inside a sequence does not lose it, at the
    * cost of re-scanning at most CARRY_CHARS chars per chunk. A sequence that
    * spans the boundary is matched once, on the feed that completes it — the
    * previous feed saw no final `h`/`l` so it could not have matched.
    */
-  feed(chunk: string): void {
+  feed(chunk: string, streamEndOffset: number): void {
     if (chunk.length === 0) return;
     const text = this.carry + chunk;
     MODE_RE.lastIndex = 0;
     let m: RegExpExecArray | null;
+    // Char index of the last alt-screen ENTRY in `text`, resolved to a byte
+    // offset once after the loop: converting per match would be O(chunk) each
+    // time, and only the last entry can be the current one.
+    let altEntryIndex = -1;
     while ((m = MODE_RE.exec(text)) !== null) {
       if (m[1] === undefined) {
-        this.reset();
+        if (m[0] === RIS) this.reset();
+        else this.softReset(); // DECSTR
         continue;
       }
       const on = m[2] === 'h';
@@ -88,8 +117,20 @@ export class OutputModeTracker {
         const mode = Number(raw);
         // Last writer wins, per mode: a stream that toggles 1049 a hundred
         // times leaves the value the last sequence asked for.
-        if (this.state.has(mode)) this.state.set(mode, on);
+        if (!this.state.has(mode)) continue;
+        this.state.set(mode, on);
+        if (on && ALT_SCREEN_MODES.includes(mode)) {
+          altEntryIndex = m.index;
+          this.lastAltEntryMode = mode;
+        }
       }
+    }
+    if (altEntryIndex >= 0) {
+      // Bytes from the entry's first char to the end of this chunk. `text` is
+      // carry + chunk and the carry is a verbatim char-suffix of the PREVIOUS
+      // chunk, so subtracting that byte length from the chunk's end offset is
+      // exact even when the sequence started before this chunk.
+      this.lastAltEntryOffset = streamEndOffset - Buffer.byteLength(text.slice(altEntryIndex), 'utf8');
     }
     this.carry = text.slice(-CARRY_CHARS);
   }
@@ -97,11 +138,31 @@ export class OutputModeTracker {
   /** Back to power-on defaults, as RIS (`ESC c`) does to a real terminal. */
   reset(): void {
     for (const [mode, def] of MODE_DEFAULTS) this.state.set(mode, def);
+    this.lastAltEntryOffset = -1;
+    this.lastAltEntryMode = 0;
+  }
+
+  /**
+   * DECSTR (`CSI ! p`) — a SOFT reset. Everything tracked here goes back to its
+   * default EXCEPT the alt-screen modes: a soft reset does not swap the screen
+   * buffer back, so claiming it did would drop a live TUI's client onto the
+   * normal buffer while the stream keeps painting absolute frames.
+   *
+   * Mouse modes are reset even though real terminals vary, because the two
+   * failure directions are not symmetric: under-declaring costs the viewer its
+   * mouse reporting, while over-declaring types raw mouse escape sequences into
+   * whatever is at the prompt.
+   */
+  private softReset(): void {
+    for (const [mode, def] of MODE_DEFAULTS) {
+      if (ALT_SCREEN_MODES.includes(mode)) continue;
+      this.state.set(mode, def);
+    }
   }
 
   /** Current value of one tracked mode (defaults for anything untracked). */
   isSet(mode: number): boolean {
-    return this.state.get(mode) ?? false;
+    return this.state.get(mode) ?? MODE_DEFAULTS.get(mode) ?? false;
   }
 
   /** True while the stream is painting into an alternate screen buffer. */
@@ -110,10 +171,38 @@ export class OutputModeTracker {
   }
 
   /**
+   * Which alt-screen mode is actually in effect — the one that last ENTERED it
+   * when that one is still set, otherwise whichever remains. Replaying the mode
+   * the stream really used (rather than normalising everything to 1049) keeps a
+   * later `ESC[?47l` / `ESC[?1047l` inside the window meaning what it meant on
+   * the remote.
+   */
+  private activeAltMode(): number | null {
+    if (this.state.get(this.lastAltEntryMode) === true) return this.lastAltEntryMode;
+    return ALT_SCREEN_MODES.find((m) => this.state.get(m) === true) ?? null;
+  }
+
+  /**
    * A sequence that puts a fresh terminal into the mode state this stream is
    * actually in, to be PREPENDED to a capped snapshot. Empty when every tracked
    * mode is at its default, so a plain shell session is byte-identical to
    * before this existed.
+   *
+   * `windowStartOffset` is the absolute stream offset of the snapshot's FIRST
+   * byte (`ringBuffer.totalBytesWritten - snapshot.bytes.length`). It gates the
+   * alt-screen half, and nothing else, because that half is the only part that
+   * is not idempotent:
+   *
+   *   This tracker describes the whole stream's final state, but the snapshot
+   *   is only the stream's TAIL. When the window ALREADY CONTAINS the app's own
+   *   `ESC[?1049h` — the ordinary "launched vim a moment ago" case — asserting
+   *   it first would paint the shell scrollback that precedes it INTO the
+   *   alternate buffer; the window's own entry then no-ops (xterm's
+   *   BufferSet.activateAltBuffer early-returns), and the app's eventual
+   *   `ESC[?1049l` drops the user on an empty normal buffer with the whole
+   *   scrollback gone. So the entry is asserted only when it fell outside the
+   *   window. Note this is an OFFSET comparison, not `!truncated`: the ring
+   *   itself wraps, and an entry dropped by the wrap is just as absent.
    *
    * Alt screen is asserted first and followed by an erase + cursor home: the
    * window that follows was produced by an app that owns the whole screen and
@@ -125,9 +214,12 @@ export class OutputModeTracker {
    * the part of its frame that the window happens to contain until the app next
    * redraws. Mostly-right beats the garbled interleave this replaces.
    */
-  preamble(): string {
+  preamble(windowStartOffset: number): string {
     let out = '';
-    if (this.altScreen) out += '\x1b[?1049h\x1b[2J\x1b[H';
+    const alt = this.activeAltMode();
+    if (alt !== null && this.lastAltEntryOffset < windowStartOffset) {
+      out += `\x1b[?${alt}h\x1b[2J\x1b[H`;
+    }
     for (const [mode, def] of MODE_DEFAULTS) {
       if (ALT_SCREEN_MODES.includes(mode)) continue; // handled above
       const value = this.state.get(mode) ?? def;

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -2478,7 +2478,22 @@ export class WebTerminalServer {
       ...this.securityHeaders(),
     });
 
-    this.writeSnapshotFrame(res, managed);
+    // The headers are already out, so there is no status code left to send on
+    // failure — but `readAll()` + `Buffer.concat` on a ring of up to 64 MB can
+    // throw (allocation), and an exception escaping a request handler reaches
+    // `uncaughtException` and takes the whole daemon with it. One client's
+    // initial paint is not worth the fleet.
+    try {
+      this.writeSnapshotFrame(res, managed);
+    } catch (err) {
+      this.deps.log('warn', `[web] initial snapshot failed for ${sessionId}: ${errMsg(err)}`);
+      try {
+        res.end();
+      } catch {
+        /* socket already gone — the end state we wanted either way */
+      }
+      return;
+    }
 
     // Live tee off the bridge. This is a SECOND, independent listener — it does
     // not disturb the GUI's SessionPipe. maxListeners is relaxed because each
@@ -2570,7 +2585,15 @@ export class WebTerminalServer {
       truncated: snapshot.truncated,
       omittedBytes: snapshot.omittedBytes,
     };
-    const preamble = managed.bridge.outputModes?.preamble() ?? '';
+    // Absolute stream offset of the window's FIRST byte. The tracker needs it
+    // to decide whether the alt-screen entry is something the window already
+    // carries — re-asserting one that is still in there paints the scrollback
+    // ahead of it into the alternate buffer and loses it (see
+    // util/outputModeTracker.ts). Derived from the ring's own monotonic
+    // counter, which is stable across wraps and counts a recovered session's
+    // pre-filled scrollback, so both sides speak the same coordinates.
+    const windowStart = managed.ringBuffer.totalBytesWritten - snapshot.bytes.length;
+    const preamble = managed.bridge.outputModes?.preamble(windowStart) ?? '';
     const payload = preamble
       ? Buffer.concat([Buffer.from(preamble, 'utf8'), snapshot.bytes])
       : snapshot.bytes;

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -5,7 +5,7 @@ import os from 'node:os';
 import fs from 'node:fs';
 import path from 'node:path';
 import { StringDecoder } from 'node:string_decoder';
-import type { DaemonSessionManager } from '../DaemonSessionManager';
+import type { DaemonSessionManager, ManagedSession } from '../DaemonSessionManager';
 // Types only — the registry implementation, its persistence and its
 // headless-terminal dependency chain stay out of this module. The web server is
 // a CONSUMER: it lists, it resolves, it republishes lifecycle events. It never
@@ -666,6 +666,14 @@ const MIN_RESIZE_INTERVAL_MS = 250;
 
 /** Sessions tracked for rate limiting before the map is swept against the roster. */
 const RESIZE_TRACKING_CAP = 256;
+
+/**
+ * Trailing debounce before an SSE stream answers an applied resize with a fresh
+ * meta+snapshot pair. A drag-resize applies a geometry per frame and each pair
+ * costs a full window; one repaint once the drag settles is what a viewer
+ * actually needs.
+ */
+const RESIZE_RESEND_DEBOUNCE_MS = 150;
 
 /**
  * Did the caller mention this field at all — as opposed to sending a value the
@@ -2470,20 +2478,7 @@ export class WebTerminalServer {
       ...this.securityHeaders(),
     });
 
-    // Initial paint: the bytes SessionPipe flushes to the GUI on attach, capped
-    // to a window — the ring is 8 MB by default and up to 64 MB, and base64
-    // inflates it by a third, which a phone reconnecting at every tunnel would
-    // pull each time. The truncation rides `meta` rather than a new event name,
-    // so a cached frontend that predates it is unaffected.
-    const snapshot = capSnapshot(managed.ringBuffer.readAll());
-    const meta = {
-      cols: managed.meta.cols,
-      rows: managed.meta.rows,
-      truncated: snapshot.truncated,
-      omittedBytes: snapshot.omittedBytes,
-    };
-    writeSse(res, 'meta', JSON.stringify(meta));
-    writeSse(res, 'snapshot', snapshot.bytes.toString('base64'));
+    this.writeSnapshotFrame(res, managed);
 
     // Live tee off the bridge. This is a SECOND, independent listener — it does
     // not disturb the GUI's SessionPipe. maxListeners is relaxed because each
@@ -2504,15 +2499,42 @@ export class WebTerminalServer {
         /* ignore */
       }
     };
+    // An applied resize invalidates the client's grid: every absolute-positioned
+    // frame that follows was computed for the new size. `meta` alone is not
+    // enough — the Electron mirror client holds a meta until a snapshot follows
+    // it and never dispatches a lone one — so the answer is a fresh PAIR.
+    // Trailing-debounced because a drag-resize applies many geometries in a
+    // second and each pair costs a full window.
+    let resizeTimer: ReturnType<typeof setTimeout> | null = null;
+    const onResize = (): void => {
+      if (resizeTimer) clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => {
+        resizeTimer = null;
+        const current = this.deps.sessionManager.getSession(sessionId);
+        if (!current) return;
+        try {
+          this.writeSnapshotFrame(res, current);
+        } catch {
+          /* client stream broken — the 'close' handler cleans up */
+        }
+      }, RESIZE_RESEND_DEBOUNCE_MS);
+    };
+
     bridge.on('data', onData);
     bridge.on('exit', onExit);
+    bridge.on('resize', onResize);
 
     const stopHeartbeat = startSseHeartbeat(res);
 
     const detach = (): void => {
       stopHeartbeat();
+      if (resizeTimer) {
+        clearTimeout(resizeTimer);
+        resizeTimer = null;
+      }
       bridge.removeListener('data', onData);
       bridge.removeListener('exit', onExit);
+      bridge.removeListener('resize', onResize);
     };
     const client: SseClient = { res, sessionId, detach, principal };
     this.clients.add(client);
@@ -2521,6 +2543,39 @@ export class WebTerminalServer {
       detach();
       this.clients.delete(client);
     });
+  }
+
+  /**
+   * One `meta` + `snapshot` pair: the initial paint, and the repaint after an
+   * applied resize. Always both events, in that order — every client resets its
+   * terminal on the pair, and the Electron mirror only delivers a `meta` that a
+   * `snapshot` follows.
+   *
+   * The snapshot payload is the capped window PREFIXED by a synthetic
+   * mode preamble (see util/outputModeTracker.ts). The prefix rides the
+   * existing `snapshot` event rather than a new event name, so a cached
+   * frontend that predates it replays it as ordinary bytes — which is exactly
+   * what it is. `omittedBytes` still counts only the ring bytes dropped from
+   * the front; the preamble was never in the ring.
+   */
+  private writeSnapshotFrame(res: http.ServerResponse, managed: ManagedSession): void {
+    // Capped to a window — the ring is 8 MB by default and up to 64 MB, and
+    // base64 inflates it by a third, which a phone reconnecting at every tunnel
+    // would pull each time. The truncation rides `meta` rather than a new event
+    // name, so a cached frontend that predates it is unaffected.
+    const snapshot = capSnapshot(managed.ringBuffer.readAll());
+    const meta = {
+      cols: managed.meta.cols,
+      rows: managed.meta.rows,
+      truncated: snapshot.truncated,
+      omittedBytes: snapshot.omittedBytes,
+    };
+    const preamble = managed.bridge.outputModes?.preamble() ?? '';
+    const payload = preamble
+      ? Buffer.concat([Buffer.from(preamble, 'utf8'), snapshot.bytes])
+      : snapshot.bytes;
+    writeSse(res, 'meta', JSON.stringify(meta));
+    writeSse(res, 'snapshot', payload.toString('base64'));
   }
 
   // --- input (opt-in) -----------------------------------------------------

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -668,12 +668,14 @@ const MIN_RESIZE_INTERVAL_MS = 250;
 const RESIZE_TRACKING_CAP = 256;
 
 /**
- * Trailing debounce before an SSE stream answers an applied resize with a fresh
- * meta+snapshot pair. A drag-resize applies a geometry per frame and each pair
- * costs a full window; one repaint once the drag settles is what a viewer
- * actually needs.
+ * Trailing debounce before an SSE stream answers an applied resize with fresh
+ * geometry. Deliberately LONGER than MIN_RESIZE_INTERVAL_MS: with a shorter
+ * window every resize the rate limiter lets through is already spaced far
+ * enough apart to defeat the debounce, so a device alternating two geometries
+ * would fan one message per accepted resize out to every viewer. Above the
+ * limiter's own floor, a storm collapses into one message.
  */
-const RESIZE_RESEND_DEBOUNCE_MS = 150;
+const RESIZE_META_DEBOUNCE_MS = 400;
 
 /**
  * Did the caller mention this field at all — as opposed to sending a value the
@@ -2515,11 +2517,16 @@ export class WebTerminalServer {
       }
     };
     // An applied resize invalidates the client's grid: every absolute-positioned
-    // frame that follows was computed for the new size. `meta` alone is not
-    // enough — the Electron mirror client holds a meta until a snapshot follows
-    // it and never dispatches a lone one — so the answer is a fresh PAIR.
-    // Trailing-debounced because a drag-resize applies many geometries in a
-    // second and each pair costs a full window.
+    // frame that follows was computed for the new size. The answer is the new
+    // GEOMETRY and nothing else.
+    //
+    // Not a fresh snapshot: re-sending the window would be ~341 KB of base64
+    // per viewer per resize plus a full ring copy each, and every client does
+    // `reset()` before replaying it — so a viewer scrolled up reading would be
+    // wiped and yanked to the bottom every time someone dragged a divider on
+    // the machine that owns the pane. A TUI repaints itself on SIGWINCH and a
+    // shell at a prompt behaves exactly as a local terminal does, so the bytes
+    // that follow are enough on their own.
     let resizeTimer: ReturnType<typeof setTimeout> | null = null;
     const onResize = (): void => {
       if (resizeTimer) clearTimeout(resizeTimer);
@@ -2528,11 +2535,11 @@ export class WebTerminalServer {
         const current = this.deps.sessionManager.getSession(sessionId);
         if (!current) return;
         try {
-          this.writeSnapshotFrame(res, current);
+          writeSse(res, 'meta', JSON.stringify(this.streamMeta(current, { resize: true })));
         } catch {
           /* client stream broken — the 'close' handler cleans up */
         }
-      }, RESIZE_RESEND_DEBOUNCE_MS);
+      }, RESIZE_META_DEBOUNCE_MS);
     };
 
     bridge.on('data', onData);
@@ -2561,10 +2568,21 @@ export class WebTerminalServer {
   }
 
   /**
-   * One `meta` + `snapshot` pair: the initial paint, and the repaint after an
-   * applied resize. Always both events, in that order — every client resets its
-   * terminal on the pair, and the Electron mirror only delivers a `meta` that a
-   * `snapshot` follows.
+   * The `meta` event body. `resize: true` marks the geometry-only form a client
+   * gets mid-stream: there is no snapshot behind it, so a client that pairs the
+   * two must dispatch this one on its own rather than hold it for a partner
+   * that will never arrive.
+   */
+  private streamMeta(
+    managed: ManagedSession,
+    extra: Record<string, unknown> = {},
+  ): Record<string, unknown> {
+    return { cols: managed.meta.cols, rows: managed.meta.rows, ...extra };
+  }
+
+  /**
+   * The `meta` + `snapshot` pair that paints a stream on attach. Always both
+   * events, in that order — every client resets its terminal on the pair.
    *
    * The snapshot payload is the capped window PREFIXED by a synthetic
    * mode preamble (see util/outputModeTracker.ts). The prefix rides the
@@ -2579,12 +2597,10 @@ export class WebTerminalServer {
     // would pull each time. The truncation rides `meta` rather than a new event
     // name, so a cached frontend that predates it is unaffected.
     const snapshot = capSnapshot(managed.ringBuffer.readAll());
-    const meta = {
-      cols: managed.meta.cols,
-      rows: managed.meta.rows,
+    const meta = this.streamMeta(managed, {
       truncated: snapshot.truncated,
       omittedBytes: snapshot.omittedBytes,
-    };
+    });
     // Absolute stream offset of the window's FIRST byte. The tracker needs it
     // to decide whether the alt-screen entry is something the window already
     // carries — re-asserting one that is still in there paints the scrollback

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -10,6 +10,7 @@ import type { TranscriptProjector } from '../../transcript/TranscriptProjector';
 import type { TranscriptStatus } from '../../../shared/transcript/turnEvents';
 import { GIT_HARDENING_CONFIG, type GitRunner } from '../sessionDiff';
 import { MIN_PHONE_PROTOCOL_VERSION, PHONE_PROTOCOL_VERSION } from '../protocolVersion';
+import { OutputModeTracker } from '../../util/outputModeTracker';
 
 /** Drop the fixed `-c key=value` hardening prefix, leaving the command itself. */
 const gitBody = (args: readonly string[]): string[] => args.slice(GIT_HARDENING_CONFIG.length);
@@ -368,7 +369,14 @@ describe('WebTerminalServer', () => {
   let gitCalls: Array<{ args: readonly string[]; cwd: string }>;
   let gitScript: Record<string, { ok: boolean; stdout: string; stderr: string; ran?: boolean }>;
   let gitGate: { hold: Promise<void> | null };
-  let managed: { meta: Record<string, unknown>; deferred: boolean; viewerVisible: boolean };
+  let managed: {
+    meta: Record<string, unknown>;
+    deferred: boolean;
+    viewerVisible: boolean;
+    // Reassigned by the snapshot-preamble tests to stage a ring larger than the
+    // 256 KB window.
+    ringBuffer: { readAll: () => Buffer };
+  };
   let live: ReturnType<typeof makeDeps>['live'];
   let uploadsDir: string;
   let projectorMock: ReturnType<typeof makeDeps>['projectorMock'];
@@ -4208,6 +4216,182 @@ describe('WebTerminalServer', () => {
       } finally {
         live.length = 3;
       }
+    });
+  });
+
+  // ── mode-safe snapshot window + resize propagation ────────────────────────
+  //
+  // `/api/stream` paints the LAST 256 KB of the ring. A fullscreen TUI switched
+  // to the alternate screen once, long before that window, so the window's
+  // absolute-positioned frames used to land on the client's normal buffer and
+  // interleave with scrollback. The daemon reconstructs the mode state instead
+  // (OutputModeTracker) and prepends a preamble to the snapshot payload.
+  describe('stream snapshot mode preamble', () => {
+    /** Read the SSE body until `until` holds (or 2s), then return the text. */
+    const readStream = async (
+      url: string,
+      ac: AbortController,
+      until: (text: string) => boolean,
+    ): Promise<string> => {
+      const res = await fetch(url, { signal: ac.signal });
+      expect(res.status).toBe(200);
+      const reader = (res.body as ReadableStream<Uint8Array>).getReader();
+      let text = '';
+      const deadline = Date.now() + 2000;
+      while (Date.now() < deadline && !until(text)) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (value) text += Buffer.from(value).toString('utf8');
+      }
+      return text;
+    };
+
+    /** Every `snapshot` event payload, decoded from base64. */
+    const snapshots = (text: string): string[] =>
+      [...text.matchAll(/event: snapshot\ndata: ([^\n]*)\n/g)].map((m) =>
+        Buffer.from(m[1], 'base64').toString('utf8'),
+      );
+
+    /** Every `meta` event payload, parsed. */
+    const metas = (text: string): Array<Record<string, unknown>> =>
+      [...text.matchAll(/event: meta\ndata: ([^\n]*)\n/g)].map(
+        (m) => JSON.parse(m[1]) as Record<string, unknown>,
+      );
+
+    /**
+     * Fill the fake session's ring with `head` followed by enough filler that
+     * `head` falls outside the snapshot window, and feed the same bytes to a
+     * real tracker hung off the fake bridge (the daemon does this at ring-write
+     * time in DaemonPTYBridge).
+     */
+    const primeRing = (head: string): void => {
+      const filler = 'x'.repeat(400 * 1024) + '\n';
+      const text = head + filler;
+      managed.ringBuffer.readAll = () => Buffer.from(text, 'utf8');
+      const tracker = new OutputModeTracker();
+      tracker.feed(text);
+      Object.assign(bridge, { outputModes: tracker });
+    };
+
+    it('★ prepends an alt-screen preamble when ?1049h scrolled out of the window', async () => {
+      // The exact field shape: the app entered the alternate screen at startup
+      // and has been painting ever since, so the switch is 400 KB back.
+      primeRing('\x1b[?1049h\x1b[2J\x1b[H');
+      const info = await startRO();
+      const ac = new AbortController();
+      const text = await readStream(
+        `${base()}/api/stream?session=s1&token=${encodeURIComponent(info.token as string)}`,
+        ac,
+        (t) => snapshots(t).length >= 1,
+      );
+      ac.abort();
+
+      const [first] = snapshots(text);
+      expect(first).toBeDefined();
+      // The window itself no longer contains the switch…
+      expect(first.slice(32)).not.toContain('\x1b[?1049h');
+      // …so the payload has to open with it, plus an erase + home so the
+      // absolute-positioned frames that follow start from a blank grid.
+      expect(first.startsWith('\x1b[?1049h\x1b[2J\x1b[H')).toBe(true);
+    });
+
+    it('sends no preamble for a plain normal-buffer session', async () => {
+      primeRing('hello from a shell\n');
+      const info = await startRO();
+      const ac = new AbortController();
+      const text = await readStream(
+        `${base()}/api/stream?session=s1&token=${encodeURIComponent(info.token as string)}`,
+        ac,
+        (t) => snapshots(t).length >= 1,
+      );
+      ac.abort();
+
+      const [first] = snapshots(text);
+      expect(first).toBeDefined();
+      expect(first.startsWith('\x1b')).toBe(false);
+    });
+
+    it('carries non-default modes other than alt screen (bracketed paste, mouse SGR)', async () => {
+      primeRing('\x1b[?2004h\x1b[?1002;1006h');
+      const info = await startRO();
+      const ac = new AbortController();
+      const text = await readStream(
+        `${base()}/api/stream?session=s1&token=${encodeURIComponent(info.token as string)}`,
+        ac,
+        (t) => snapshots(t).length >= 1,
+      );
+      ac.abort();
+
+      const [first] = snapshots(text);
+      expect(first).toContain('\x1b[?1002h');
+      expect(first).toContain('\x1b[?1006h');
+      expect(first).toContain('\x1b[?2004h');
+      // No alt-screen switch was sent, so none is asserted.
+      expect(first).not.toContain('\x1b[?1049h');
+    });
+
+    it('★ re-sends meta AND a snapshot on an applied resize, debounced', async () => {
+      // A lone `meta` is never delivered by the Electron mirror client — it
+      // buffers meta and only dispatches it merged with the NEXT snapshot — so
+      // resize propagation has to be a pair, not a bare geometry update.
+      primeRing('\x1b[?1049h');
+      const info = await startRO();
+      const ac = new AbortController();
+      const url = `${base()}/api/stream?session=s1&token=${encodeURIComponent(info.token as string)}`;
+      const res = await fetch(url, { signal: ac.signal });
+      expect(res.status).toBe(200);
+      const reader = (res.body as ReadableStream<Uint8Array>).getReader();
+      let text = '';
+      // `reader.read()` on an idle SSE stream never settles, so every read is
+      // raced against the remaining budget rather than checked after the fact.
+      const pump = async (untilCount: number, budgetMs: number): Promise<void> => {
+        const deadline = Date.now() + budgetMs;
+        while (Date.now() < deadline && snapshots(text).length < untilCount) {
+          const chunk = await Promise.race([
+            reader.read(),
+            new Promise<null>((r) => setTimeout(() => r(null), Math.max(1, deadline - Date.now()))),
+          ]);
+          if (!chunk) break;
+          if (chunk.done) break;
+          if (chunk.value) text += Buffer.from(chunk.value).toString('utf8');
+        }
+      };
+      await pump(1, 2000);
+      expect(snapshots(text)).toHaveLength(1);
+
+      // A drag-resize: several applied resizes in a burst. The stream must
+      // answer with ONE refreshed pair, not one per event.
+      managed.meta.cols = 100;
+      managed.meta.rows = 40;
+      for (let i = 0; i < 5; i++) bridge.emit('resize');
+      await pump(2, 2000);
+      // Give the debounce window room to fire a second time if it were going to.
+      await new Promise((r) => setTimeout(r, 300));
+      await pump(3, 100);
+
+      expect(snapshots(text)).toHaveLength(2);
+      const metaEvents = metas(text);
+      expect(metaEvents).toHaveLength(2);
+      expect(metaEvents[1]).toMatchObject({ cols: 100, rows: 40 });
+      // The refreshed snapshot carries the preamble too — the client resets its
+      // terminal on every meta+snapshot pair.
+      expect(snapshots(text)[1].startsWith('\x1b[?1049h')).toBe(true);
+    }, 15000);
+
+    it('drops the pending resize resend when the client disconnects', async () => {
+      primeRing('hello\n');
+      const info = await startRO();
+      const ac = new AbortController();
+      await readStream(
+        `${base()}/api/stream?session=s1&token=${encodeURIComponent(info.token as string)}`,
+        ac,
+        (t) => snapshots(t).length >= 1,
+      );
+      bridge.emit('resize');
+      ac.abort();
+      await new Promise((r) => setTimeout(r, 300));
+      // No listener left behind by the aborted stream.
+      expect(bridge.listenerCount('resize')).toBe(0);
     });
   });
 });

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -11,6 +11,7 @@ import type { TranscriptStatus } from '../../../shared/transcript/turnEvents';
 import { GIT_HARDENING_CONFIG, type GitRunner } from '../sessionDiff';
 import { MIN_PHONE_PROTOCOL_VERSION, PHONE_PROTOCOL_VERSION } from '../protocolVersion';
 import { OutputModeTracker } from '../../util/outputModeTracker';
+import { capSnapshot } from '../snapshotWindow';
 
 /** Drop the fixed `-c key=value` hardening prefix, leaving the command itself. */
 const gitBody = (args: readonly string[]): string[] => args.slice(GIT_HARDENING_CONFIG.length);
@@ -41,7 +42,14 @@ function makeDeps() {
     // #766 — the desk is showing the pane unless a test flips this; the
     // resize route only honors 'attached' when this is also true.
     viewerVisible: true,
-    ringBuffer: { readAll: () => Buffer.from('screen-bytes') },
+    ringBuffer: {
+      readAll: () => Buffer.from('screen-bytes'),
+      // The real ring's monotonic lifetime counter. A fake ring never wraps,
+      // so "everything ever written" is exactly what readAll returns — and
+      // keeping it a getter means a test that restages readAll gets a
+      // consistent counter for free.
+      get totalBytesWritten(): number { return this.readAll().length; },
+    },
     bridge,
     ptyProcess: { write },
   };
@@ -375,7 +383,7 @@ describe('WebTerminalServer', () => {
     viewerVisible: boolean;
     // Reassigned by the snapshot-preamble tests to stage a ring larger than the
     // 256 KB window.
-    ringBuffer: { readAll: () => Buffer };
+    ringBuffer: { readAll: () => Buffer; readonly totalBytesWritten: number };
   };
   let live: ReturnType<typeof makeDeps>['live'];
   let uploadsDir: string;
@@ -4258,76 +4266,111 @@ describe('WebTerminalServer', () => {
         (m) => JSON.parse(m[1]) as Record<string, unknown>,
       );
 
+    /** 400 KB of output — comfortably more than the 256 KB snapshot window. */
+    const FILLER = 'x'.repeat(400 * 1024) + '\n';
+
     /**
-     * Fill the fake session's ring with `head` followed by enough filler that
-     * `head` falls outside the snapshot window, and feed the same bytes to a
-     * real tracker hung off the fake bridge (the daemon does this at ring-write
-     * time in DaemonPTYBridge).
+     * Stage the fake session's ring on `text` and feed the SAME bytes, with the
+     * same offsets, to a real tracker hung off the fake bridge — which is what
+     * DaemonPTYBridge does at ring-write time.
      */
-    const primeRing = (head: string): void => {
-      const filler = 'x'.repeat(400 * 1024) + '\n';
-      const text = head + filler;
+    const stageRing = (text: string): void => {
       managed.ringBuffer.readAll = () => Buffer.from(text, 'utf8');
       const tracker = new OutputModeTracker();
-      tracker.feed(text);
+      tracker.feed(text, Buffer.byteLength(text, 'utf8'));
       Object.assign(bridge, { outputModes: tracker });
+    };
+
+    /** `head` far enough back that it has scrolled out of the window. */
+    const primeRing = (head: string): void => stageRing(head + FILLER);
+
+    /** Exactly what the client SHOULD receive when nothing is prepended. */
+    const bareWindow = (): string =>
+      capSnapshot(managed.ringBuffer.readAll()).bytes.toString('utf8');
+
+    /** Open the stream and return the first snapshot payload. */
+    const firstSnapshot = async (): Promise<string> => {
+      const info = await startRO();
+      const ac = new AbortController();
+      const text = await readStream(
+        `${base()}/api/stream?session=s1&token=${encodeURIComponent(info.token as string)}`,
+        ac,
+        (t) => snapshots(t).length >= 1,
+      );
+      ac.abort();
+      const [first] = snapshots(text);
+      expect(first).toBeDefined();
+      return first;
     };
 
     it('★ prepends an alt-screen preamble when ?1049h scrolled out of the window', async () => {
       // The exact field shape: the app entered the alternate screen at startup
       // and has been painting ever since, so the switch is 400 KB back.
       primeRing('\x1b[?1049h\x1b[2J\x1b[H');
-      const info = await startRO();
-      const ac = new AbortController();
-      const text = await readStream(
-        `${base()}/api/stream?session=s1&token=${encodeURIComponent(info.token as string)}`,
-        ac,
-        (t) => snapshots(t).length >= 1,
-      );
-      ac.abort();
-
-      const [first] = snapshots(text);
-      expect(first).toBeDefined();
+      const first = await firstSnapshot();
       // The window itself no longer contains the switch…
-      expect(first.slice(32)).not.toContain('\x1b[?1049h');
+      expect(bareWindow()).not.toContain('\x1b[?1049h');
       // …so the payload has to open with it, plus an erase + home so the
       // absolute-positioned frames that follow start from a blank grid.
-      expect(first.startsWith('\x1b[?1049h\x1b[2J\x1b[H')).toBe(true);
+      expect(first).toBe('\x1b[?1049h\x1b[2J\x1b[H' + bareWindow());
     });
 
-    it('sends no preamble for a plain normal-buffer session', async () => {
-      primeRing('hello from a shell\n');
-      const info = await startRO();
-      const ac = new AbortController();
-      const text = await readStream(
-        `${base()}/api/stream?session=s1&token=${encodeURIComponent(info.token as string)}`,
-        ac,
-        (t) => snapshots(t).length >= 1,
-      );
-      ac.abort();
+    it('★ sends NO alt preamble when the window still contains the entry', async () => {
+      // The common case: an app launched a moment ago, so its own `?1049h` is
+      // inside the window. Asserting the switch first would paint the shell
+      // scrollback ahead of it into the ALTERNATE buffer; the window's own
+      // switch then no-ops, and the app's eventual `?1049l` would drop the user
+      // on an empty normal buffer with the scrollback gone.
+      stageRing(FILLER + 'line1\r\nline2\r\n\x1b[?1049h\x1b[2J\x1b[HVIM FRAME');
+      const first = await firstSnapshot();
+      expect(bareWindow()).toContain('\x1b[?1049h');
+      expect(first).toBe(bareWindow());
+    });
 
-      const [first] = snapshots(text);
-      expect(first).toBeDefined();
-      expect(first.startsWith('\x1b')).toBe(false);
+    it('sends no preamble at all for a plain normal-buffer session', async () => {
+      // Deliberately full of escape sequences — colours, and an alt screen the
+      // app entered AND left — so "the payload happens not to start with ESC"
+      // cannot pass for a real assertion. The only acceptable answer is the
+      // window, byte for byte.
+      primeRing('\x1b[32m$ vim\x1b[0m\n\x1b[?1049h\x1b[2Jediting\x1b[?1049l\x1b[?1002l\n');
+      const first = await firstSnapshot();
+      expect(first).toBe(bareWindow());
     });
 
     it('carries non-default modes other than alt screen (bracketed paste, mouse SGR)', async () => {
       primeRing('\x1b[?2004h\x1b[?1002;1006h');
-      const info = await startRO();
-      const ac = new AbortController();
-      const text = await readStream(
-        `${base()}/api/stream?session=s1&token=${encodeURIComponent(info.token as string)}`,
-        ac,
-        (t) => snapshots(t).length >= 1,
-      );
-      ac.abort();
-
-      const [first] = snapshots(text);
+      const first = await firstSnapshot();
       expect(first).toContain('\x1b[?1002h');
       expect(first).toContain('\x1b[?1006h');
       expect(first).toContain('\x1b[?2004h');
       // No alt-screen switch was sent, so none is asserted.
       expect(first).not.toContain('\x1b[?1049h');
+    });
+
+    it('ends just this stream when the initial frame cannot be built', async () => {
+      // `readAll()` copies the whole ring — up to 64 MB — and `Buffer.concat`
+      // allocates again on top. The headers are already out by then, so there
+      // is no error status left to send; what matters is that the throw does
+      // NOT escape the request handler, because an uncaught exception in a
+      // daemon request handler ends the daemon, not the request.
+      managed.ringBuffer.readAll = () => { throw new Error('Array buffer allocation failed'); };
+      const info = await startRO();
+      const ac = new AbortController();
+      const res = await fetch(
+        `${base()}/api/stream?session=s1&token=${encodeURIComponent(info.token as string)}`,
+        { signal: ac.signal },
+      );
+      expect(res.status).toBe(200);
+      // The stream closes rather than hanging, and carries no frames.
+      const body = await res.text();
+      expect(snapshots(body)).toHaveLength(0);
+
+      // The daemon is still serving — the failure was scoped to one client.
+      managed.ringBuffer.readAll = () => Buffer.from('recovered');
+      const after = await fetch(`${base()}/api/sessions`, {
+        headers: { Authorization: `Bearer ${info.token as string}` },
+      });
+      expect(after.status).toBe(200);
     });
 
     it('★ re-sends meta AND a snapshot on an applied resize, debounced', async () => {

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -4373,68 +4373,126 @@ describe('WebTerminalServer', () => {
       expect(after.status).toBe(200);
     });
 
-    it('★ re-sends meta AND a snapshot on an applied resize, debounced', async () => {
-      // A lone `meta` is never delivered by the Electron mirror client — it
-      // buffers meta and only dispatches it merged with the NEXT snapshot — so
-      // resize propagation has to be a pair, not a bare geometry update.
-      primeRing('\x1b[?1049h');
-      const info = await startRO();
-      const ac = new AbortController();
-      const url = `${base()}/api/stream?session=s1&token=${encodeURIComponent(info.token as string)}`;
-      const res = await fetch(url, { signal: ac.signal });
-      expect(res.status).toBe(200);
-      const reader = (res.body as ReadableStream<Uint8Array>).getReader();
-      let text = '';
-      // `reader.read()` on an idle SSE stream never settles, so every read is
-      // raced against the remaining budget rather than checked after the fact.
-      const pump = async (untilCount: number, budgetMs: number): Promise<void> => {
-        const deadline = Date.now() + budgetMs;
-        while (Date.now() < deadline && snapshots(text).length < untilCount) {
-          const chunk = await Promise.race([
-            reader.read(),
-            new Promise<null>((r) => setTimeout(() => r(null), Math.max(1, deadline - Date.now()))),
-          ]);
-          if (!chunk) break;
-          if (chunk.done) break;
-          if (chunk.value) text += Buffer.from(chunk.value).toString('utf8');
-        }
+    // ── resize propagation ──────────────────────────────────────────────
+    //
+    // An applied resize invalidates the viewer's grid, so it has to hear about
+    // it. What it must NOT get is a fresh snapshot: that is a full ring copy
+    // and ~341 KB of base64 per viewer per resize, and every client resets its
+    // terminal before replaying one — so a viewer scrolled up reading would be
+    // wiped and dragged to the bottom each time someone resized the pane on
+    // the machine that owns it.
+    describe('applied resize', () => {
+      /** Open a stream and keep pumping its body into a growing string. */
+      const openPumped = async (): Promise<{
+        ac: AbortController;
+        body: () => string;
+        pump: (budgetMs: number) => Promise<void>;
+      }> => {
+        const info = await startRO();
+        const ac = new AbortController();
+        const res = await fetch(
+          `${base()}/api/stream?session=s1&token=${encodeURIComponent(info.token as string)}`,
+          { signal: ac.signal },
+        );
+        expect(res.status).toBe(200);
+        const reader = (res.body as ReadableStream<Uint8Array>).getReader();
+        let text = '';
+        // `reader.read()` on an idle SSE stream never settles, so every read is
+        // raced against the remaining budget. The losing read is CARRIED to the
+        // next pump rather than dropped — an orphaned read still consumes the
+        // next chunk, which is how a resize frame goes missing without anyone
+        // noticing the test never saw it.
+        let pending: Promise<ReadableStreamReadResult<Uint8Array>> | null = null;
+        const pump = async (budgetMs: number): Promise<void> => {
+          const deadline = Date.now() + budgetMs;
+          for (;;) {
+            const remaining = deadline - Date.now();
+            if (remaining <= 0) return;
+            if (!pending) pending = reader.read();
+            const settled = await Promise.race([
+              pending.then((v) => ({ v })),
+              new Promise<null>((r) => setTimeout(() => r(null), remaining)),
+            ]);
+            if (!settled) return; // budget spent; `pending` survives for next time
+            pending = null;
+            if (settled.v.done) return;
+            if (settled.v.value) text += Buffer.from(settled.v.value).toString('utf8');
+          }
+        };
+        await pump(500);
+        return { ac, body: () => text, pump };
       };
-      await pump(1, 2000);
-      expect(snapshots(text)).toHaveLength(1);
 
-      // A drag-resize: several applied resizes in a burst. The stream must
-      // answer with ONE refreshed pair, not one per event.
-      managed.meta.cols = 100;
-      managed.meta.rows = 40;
-      for (let i = 0; i < 5; i++) bridge.emit('resize');
-      await pump(2, 2000);
-      // Give the debounce window room to fire a second time if it were going to.
-      await new Promise((r) => setTimeout(r, 300));
-      await pump(3, 100);
+      it('★ answers with meta ONLY — never a second snapshot', async () => {
+        primeRing('\x1b[?1049h');
+        const s = await openPumped();
+        expect(snapshots(s.body())).toHaveLength(1);
 
-      expect(snapshots(text)).toHaveLength(2);
-      const metaEvents = metas(text);
-      expect(metaEvents).toHaveLength(2);
-      expect(metaEvents[1]).toMatchObject({ cols: 100, rows: 40 });
-      // The refreshed snapshot carries the preamble too — the client resets its
-      // terminal on every meta+snapshot pair.
-      expect(snapshots(text)[1].startsWith('\x1b[?1049h')).toBe(true);
-    }, 15000);
+        managed.meta.cols = 100;
+        managed.meta.rows = 40;
+        bridge.emit('resize');
+        await s.pump(1200);
+        s.ac.abort();
 
-    it('drops the pending resize resend when the client disconnects', async () => {
-      primeRing('hello\n');
-      const info = await startRO();
-      const ac = new AbortController();
-      await readStream(
-        `${base()}/api/stream?session=s1&token=${encodeURIComponent(info.token as string)}`,
-        ac,
-        (t) => snapshots(t).length >= 1,
-      );
-      bridge.emit('resize');
-      ac.abort();
-      await new Promise((r) => setTimeout(r, 300));
-      // No listener left behind by the aborted stream.
-      expect(bridge.listenerCount('resize')).toBe(0);
+        // The new geometry arrived…
+        const metaEvents = metas(s.body());
+        expect(metaEvents).toHaveLength(2);
+        expect(metaEvents[1]).toMatchObject({ cols: 100, rows: 40, resize: true });
+        // …and the viewer's scrollback was not re-sent under it.
+        expect(snapshots(s.body())).toHaveLength(1);
+      }, 15000);
+
+      it('★ collapses a storm into one, and still answers the next one', async () => {
+        // The debounce has to outlast MIN_RESIZE_INTERVAL_MS (250) or every
+        // resize the rate limiter lets through is already spaced far enough
+        // apart to defeat it — which is exactly what a 150 ms window did.
+        primeRing('hello\n');
+        const s = await openPumped();
+        expect(metas(s.body())).toHaveLength(1);
+
+        // Two accepted resizes one limiter-interval apart still merge…
+        bridge.emit('resize');
+        await new Promise((r) => setTimeout(r, 260));
+        bridge.emit('resize');
+        await s.pump(1200);
+        expect(metas(s.body())).toHaveLength(2);
+
+        // …while one that lands after the window has closed is its own message.
+        managed.meta.cols = 132;
+        bridge.emit('resize');
+        await s.pump(1200);
+        s.ac.abort();
+        const metaEvents = metas(s.body());
+        expect(metaEvents).toHaveLength(3);
+        expect(metaEvents[2]).toMatchObject({ cols: 132, resize: true });
+      }, 20000);
+
+      it('drops the pending resize when the client disconnects', async () => {
+        primeRing('hello\n');
+        // The debounce callback re-reads the session, so counting that read is
+        // a direct signal for "the timer fired" — an assertion that a leftover
+        // `clearTimeout` deletion cannot pass, unlike a listener count.
+        const mgr = sessionManager as unknown as { getSession: (id: string) => unknown };
+        const inner = mgr.getSession.bind(mgr);
+        let reads = 0;
+        mgr.getSession = (id: string) => { reads += 1; return inner(id); };
+
+        const info = await startRO();
+        const ac = new AbortController();
+        await readStream(
+          `${base()}/api/stream?session=s1&token=${encodeURIComponent(info.token as string)}`,
+          ac,
+          (t) => snapshots(t).length >= 1,
+        );
+        bridge.emit('resize');
+        ac.abort();
+        const atAbort = reads;
+        // Long enough for the debounce to have fired twice over.
+        await new Promise((r) => setTimeout(r, 1200));
+
+        expect(reads).toBe(atAbort); // nothing woke up behind the closed stream
+        expect(bridge.listenerCount('resize')).toBe(0);
+      }, 15000);
     });
   });
 });

--- a/src/daemon/web/frontend/app.js
+++ b/src/daemon/web/frontend/app.js
@@ -150,11 +150,47 @@
   }
   if (termHost) termHost.addEventListener('click', function () { focusFromGesture(term); });
 
+  // Repaint gate: how many snapshots are currently being fed to the parser.
+  //
+  // xterm answers device queries ITSELF — DA1 (ESC[c), DSR/CPR (ESC[6n),
+  // DECRPM — and delivers those answers through the same onData that carries
+  // typing. A replayed snapshot contains whatever queries the pane's app sent,
+  // so replaying one made this browser type phantom answers into a live shell.
+  // The machine that owns the pane has its own terminal and is the
+  // authoritative responder; a viewer must never answer.
+  //
+  // A count rather than a flag: xterm parses a big write in slices, so a
+  // reconnect can start a second repaint while the first is still being
+  // consumed, and a flag would let the first callback reopen the gate under it.
+  //
+  // The eventual root fix is to neutralise the QUERIES rather than filter the
+  // answers — either in xterm (parser.registerCsiHandler swallowing DA/DSR/
+  // DECRQM) or by having the daemon strip them from the bytes it fans out.
+  // Both are bigger than this file.
+  var termRepaints = 0;
+
+  /** Replay `bytes` into `t` with the gate held for as long as it parses. */
+  function repaint(t, bytes, inc, dec) {
+    t.reset();
+    inc();
+    try {
+      t.write(bytes, dec);
+    } catch (e) {
+      // write() can throw before the callback is ever queued (xterm refuses
+      // past its discard watermark). Not releasing here would latch the gate
+      // and silently swallow every keystroke for the rest of the page's life.
+      dec();
+    }
+  }
+
   function ensureTerm(cols, rows) {
     if (!term) {
       term = newTerm(cols, rows);
       term.open(termHost);
-      if (allowInput) term.onData(function (d) { sendInput(d); });
+      if (allowInput) term.onData(function (d) {
+        if (termRepaints > 0) return; // parser reply to a replayed query
+        sendInput(d);
+      });
     } else if (cols && rows) {
       term.resize(cols, rows);
     }
@@ -1150,7 +1186,11 @@
       attention: true,
       meta: function (m) { ensureTerm(m.cols, m.rows); },
       snapshot: function (bytes) {
-        if (term) { term.reset(); term.write(bytes); }
+        if (term) {
+          repaint(term, bytes,
+            function () { termRepaints += 1; },
+            function () { termRepaints = Math.max(0, termRepaints - 1); });
+        }
         hideOverlay();
         setConn('live', 'live');
       },
@@ -1258,7 +1298,7 @@
     // detached node measures as 0 and renders nothing.
     gridEl.appendChild(el);
 
-    var tile = { sessionId: s.id, term: null, es: null, el: el, head: head, scaler: scaler, ended: false };
+    var tile = { sessionId: s.id, term: null, es: null, el: el, head: head, scaler: scaler, ended: false, repaints: 0 };
     tile.term = newTerm(s.cols, s.rows);
     tile.term.open(host);
     // Same reason as the single-pane host: on iOS the keyboard only comes up
@@ -1274,7 +1314,10 @@
       // focus back on each reply, which pinned the page to whichever pane
       // chattered most (caught in live dogfood — a tap looked like it did
       // nothing). Focus moves on an explicit tap only.
-      tile.term.onData(function (d) { sendTo(tile.sessionId, d); });
+      tile.term.onData(function (d) {
+        if (tile.repaints > 0) return; // parser reply to a replayed query
+        sendTo(tile.sessionId, d);
+      });
     }
     renderTileHead(tile);
     el.addEventListener('pointerdown', function () { focusTile(tile); });
@@ -1286,7 +1329,11 @@
         rescale();
       },
       snapshot: function (bytes) {
-        if (tile.term) { tile.term.reset(); tile.term.write(bytes); }
+        if (tile.term) {
+          repaint(tile.term, bytes,
+            function () { tile.repaints += 1; },
+            function () { tile.repaints = Math.max(0, tile.repaints - 1); });
+        }
         rescale();
         if (tile.sessionId === currentSession) setConn('live', 'live');
       },

--- a/src/main/ipc/handlers/__tests__/remote.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/remote.handler.test.ts
@@ -40,7 +40,7 @@ vi.mock('electron', () => {
 import { registerRemoteHandlers } from '../remote.handler';
 import { IPC } from '../../../../shared/constants';
 import type { RemoteHost, RemoteHostPublic, RemoteWorkspacesResponse } from '../../../../shared/remoteHosts';
-import type { RemoteHostClient, RemoteMetaEvent, RemoteDataEvent, RemoteExitEvent, RemoteErrorEvent } from '../../../remote/RemoteHostClient';
+import type { RemoteHostClient, RemoteMetaEvent, RemoteResizeEvent, RemoteDataEvent, RemoteExitEvent, RemoteErrorEvent } from '../../../remote/RemoteHostClient';
 
 function getHandler(channel: string): (...args: unknown[]) => unknown {
   const fn = ipcHandlers.get(channel);
@@ -97,6 +97,7 @@ function fakeSender(id: number) {
  *  test can push a fake event straight through the shared client wiring. */
 function fakeClient(host: RemoteHost) {
   const metaCbs: Array<(e: RemoteMetaEvent) => void> = [];
+  const resizeCbs: Array<(e: RemoteResizeEvent) => void> = [];
   const dataCbs: Array<(e: RemoteDataEvent) => void> = [];
   const exitCbs: Array<(e: RemoteExitEvent) => void> = [];
   const errorCbs: Array<(e: RemoteErrorEvent) => void> = [];
@@ -109,10 +110,12 @@ function fakeClient(host: RemoteHost) {
     write: vi.fn(async () => undefined),
     listWorkspaces: vi.fn(async (): Promise<RemoteWorkspacesResponse> => ({ workspaces: [] })),
     onMeta: vi.fn((cb: (e: RemoteMetaEvent) => void) => { metaCbs.push(cb); }),
+    onResize: vi.fn((cb: (e: RemoteResizeEvent) => void) => { resizeCbs.push(cb); }),
     onData: vi.fn((cb: (e: RemoteDataEvent) => void) => { dataCbs.push(cb); }),
     onExit: vi.fn((cb: (e: RemoteExitEvent) => void) => { exitCbs.push(cb); }),
     onError: vi.fn((cb: (e: RemoteErrorEvent) => void) => { errorCbs.push(cb); }),
     emitMeta: (e: RemoteMetaEvent) => metaCbs.forEach((cb) => cb(e)),
+    emitResize: (e: RemoteResizeEvent) => resizeCbs.forEach((cb) => cb(e)),
     emitData: (e: RemoteDataEvent) => dataCbs.forEach((cb) => cb(e)),
     emitExit: (e: RemoteExitEvent) => exitCbs.forEach((cb) => cb(e)),
     emitError: (e: RemoteErrorEvent) => errorCbs.forEach((cb) => cb(e)),
@@ -123,6 +126,7 @@ function fakeClient(host: RemoteHost) {
     write: ReturnType<typeof vi.fn>;
     listWorkspaces: ReturnType<typeof vi.fn>;
     emitMeta: (e: RemoteMetaEvent) => void;
+    emitResize: (e: RemoteResizeEvent) => void;
     emitData: (e: RemoteDataEvent) => void;
     emitExit: (e: RemoteExitEvent) => void;
     emitError: (e: RemoteErrorEvent) => void;
@@ -477,11 +481,15 @@ describe('remote.handler — pane attach/detach/write push routing', () => {
     expect(res.ok).toBe(true);
 
     client.emitMeta({ attachId: res.attachId, cols: 80, rows: 24, snapshotB64: 'AA==' });
+    // Geometry-only, on its own channel: the renderer re-grids without the
+    // reset+repaint a META implies.
+    client.emitResize({ attachId: res.attachId, cols: 100, rows: 40 });
     client.emitData({ attachId: res.attachId, dataB64: 'BB==' });
     client.emitExit({ attachId: res.attachId });
 
     expect(sender.sent).toEqual([
       { channel: IPC.REMOTE_PANE_META, payload: { attachId: res.attachId, cols: 80, rows: 24, snapshotB64: 'AA==' } },
+      { channel: IPC.REMOTE_PANE_RESIZE, payload: { attachId: res.attachId, cols: 100, rows: 40 } },
       { channel: IPC.REMOTE_PANE_DATA, payload: { attachId: res.attachId, dataB64: 'BB==' } },
       { channel: IPC.REMOTE_PANE_EXIT, payload: { attachId: res.attachId } },
     ]);

--- a/src/main/ipc/handlers/remote.handler.ts
+++ b/src/main/ipc/handlers/remote.handler.ts
@@ -236,6 +236,7 @@ export function registerRemoteHandlers(deps: RegisterRemoteHandlersDeps): () => 
     // callbacks; the attachId on each event is how a shared callback fans a
     // single client's events back out to the RIGHT sender.
     client.onMeta((e) => pushToOwner(e.attachId, IPC.REMOTE_PANE_META, e));
+    client.onResize((e) => pushToOwner(e.attachId, IPC.REMOTE_PANE_RESIZE, e));
     client.onData((e) => pushToOwner(e.attachId, IPC.REMOTE_PANE_DATA, e));
     client.onExit((e) => {
       pushToOwner(e.attachId, IPC.REMOTE_PANE_EXIT, e);

--- a/src/main/remote/RemoteHostClient.ts
+++ b/src/main/remote/RemoteHostClient.ts
@@ -21,6 +21,18 @@ export interface RemoteMetaEvent {
   omittedBytes?: number;
 }
 
+/**
+ * A geometry-only update: the remote pane was resized while we were attached.
+ * Separate from {@link RemoteMetaEvent} because it carries NO snapshot — the
+ * receiver resizes its grid and keeps everything already on screen, where a
+ * meta event means "reset and repaint".
+ */
+export interface RemoteResizeEvent {
+  attachId: string;
+  cols: number;
+  rows: number;
+}
+
 export interface RemoteDataEvent {
   attachId: string;
   dataB64: string;
@@ -37,6 +49,7 @@ export interface RemoteErrorEvent {
 
 export interface RemotePaneEvents {
   onMeta(cb: (e: RemoteMetaEvent) => void): void;
+  onResize(cb: (e: RemoteResizeEvent) => void): void;
   onData(cb: (e: RemoteDataEvent) => void): void;
   onExit(cb: (e: RemoteExitEvent) => void): void;
   onError(cb: (e: RemoteErrorEvent) => void): void;
@@ -72,6 +85,11 @@ interface Attachment {
   // Buffered meta JSON, held until the paired `snapshot` frame arrives so a
   // single onMeta callback carries cols/rows/snapshotB64/truncated together
   // (matching the RemotePaneEvents contract — there is no separate onSnapshot).
+  //
+  // Only the ATTACH frame is a pair. A mid-stream geometry update arrives on
+  // its own and is dispatched as a resize instead — holding it here for a
+  // partner that never comes is how a resize used to reach the mirror as
+  // nothing at all.
   pendingMeta: { cols: number; rows: number; truncated?: boolean; omittedBytes?: number } | null;
   reconnectAttempt: number;
   reconnectTimer: ReturnType<typeof setTimeout> | null;
@@ -106,6 +124,7 @@ export class RemoteHostClient implements RemotePaneEvents {
   private readonly writeQueues = new Map<string, WriteQueueState>();
 
   private metaCbs: Array<(e: RemoteMetaEvent) => void> = [];
+  private resizeCbs: Array<(e: RemoteResizeEvent) => void> = [];
   private dataCbs: Array<(e: RemoteDataEvent) => void> = [];
   private exitCbs: Array<(e: RemoteExitEvent) => void> = [];
   private errorCbs: Array<(e: RemoteErrorEvent) => void> = [];
@@ -117,6 +136,10 @@ export class RemoteHostClient implements RemotePaneEvents {
 
   onMeta(cb: (e: RemoteMetaEvent) => void): void {
     this.metaCbs.push(cb);
+  }
+
+  onResize(cb: (e: RemoteResizeEvent) => void): void {
+    this.resizeCbs.push(cb);
   }
 
   onData(cb: (e: RemoteDataEvent) => void): void {
@@ -330,12 +353,26 @@ export class RemoteHostClient implements RemotePaneEvents {
 
     switch (event) {
       case 'meta': {
-        let parsed: { cols: number; rows: number; truncated?: boolean; omittedBytes?: number };
+        let parsed: {
+          cols: number; rows: number;
+          truncated?: boolean; omittedBytes?: number; resize?: boolean;
+        };
         try {
           parsed = JSON.parse(data);
         } catch {
           return; // malformed frame — drop rather than crash the pump
         }
+        // Geometry-only: the daemon marks the mid-stream form, which has no
+        // snapshot behind it. Dispatch it straight through so the mirror
+        // resizes its grid WITHOUT resetting and losing its scrollback.
+        if (parsed.resize) {
+          this.dispatchResize(attachment, parsed);
+          return;
+        }
+        // Belt and braces for a peer that sends a bare meta without the marker:
+        // a held meta that a second meta overtakes was never going to get its
+        // snapshot either, so let it out as geometry rather than dropping it.
+        this.flushPendingMetaAsResize(attachment);
         attachment.pendingMeta = parsed;
         return;
       }
@@ -355,10 +392,12 @@ export class RemoteHostClient implements RemotePaneEvents {
         return;
       }
       case 'data': {
+        this.flushPendingMetaAsResize(attachment);
         for (const cb of this.dataCbs) cb({ attachId: attachment.attachId, dataB64: data });
         return;
       }
       case 'exit': {
+        this.flushPendingMetaAsResize(attachment);
         for (const cb of this.exitCbs) cb({ attachId: attachment.attachId });
         return;
       }
@@ -366,6 +405,23 @@ export class RemoteHostClient implements RemotePaneEvents {
         // Unknown/fan-out event (e.g. `attention`) — never treat as pane bytes.
         return;
     }
+  }
+
+  /** A held meta that turned out to have no snapshot behind it is geometry. */
+  private flushPendingMetaAsResize(attachment: Attachment): void {
+    const held = attachment.pendingMeta;
+    if (!held) return;
+    attachment.pendingMeta = null;
+    this.dispatchResize(attachment, held);
+  }
+
+  private dispatchResize(attachment: Attachment, geometry: { cols: number; rows: number }): void {
+    const evt: RemoteResizeEvent = {
+      attachId: attachment.attachId,
+      cols: geometry.cols,
+      rows: geometry.rows,
+    };
+    for (const cb of this.resizeCbs) cb(evt);
   }
 
   private scheduleReconnect(attachment: Attachment, err: unknown): void {

--- a/src/main/remote/__tests__/RemoteHostClient.test.ts
+++ b/src/main/remote/__tests__/RemoteHostClient.test.ts
@@ -121,6 +121,53 @@ describe('RemoteHostClient', () => {
       expect(init?.redirect).toBe('error');
     });
 
+    // ── geometry-only frames ─────────────────────────────────────────────
+    //
+    // The daemon answers a resize with `meta` and nothing else: re-sending the
+    // window would cost a full ring copy per viewer and every client resets its
+    // terminal before replaying one, wiping the viewer's scrollback. A meta
+    // held for a snapshot that is never coming is how those resizes used to
+    // reach the mirror as nothing at all.
+    it('★ dispatches a resize-marked meta as geometry, not as a repaint', async () => {
+      const body =
+        META_SNAPSHOT +
+        'event: meta\ndata: {"cols":100,"rows":40,"resize":true}\n\n' +
+        'event: data\ndata: aGVsbG8=\n\n';
+      const fetchImpl = vi.fn(async () => sseResponse([body]));
+      const client = new RemoteHostClient(host, fetchImpl as unknown as typeof fetch);
+
+      const received: string[] = [];
+      client.onMeta((e) => received.push(`meta:${e.cols}x${e.rows}`));
+      client.onResize((e) => received.push(`resize:${e.cols}x${e.rows}`));
+      client.onData((e) => received.push(`data:${e.dataB64}`));
+
+      client.attach('sess-1');
+      await vi.waitFor(() => {
+        expect(received).toEqual(['meta:80x24', 'resize:100x40', 'data:aGVsbG8=']);
+      });
+    });
+
+    it('★ releases a bare meta that no snapshot follows, as geometry', async () => {
+      // Belt and braces for a peer that omits the marker: a held meta must not
+      // sit in the buffer for the rest of the stream.
+      const body =
+        META_SNAPSHOT +
+        'event: meta\ndata: {"cols":120,"rows":30}\n\n' +
+        'event: data\ndata: aGVsbG8=\n\n';
+      const fetchImpl = vi.fn(async () => sseResponse([body]));
+      const client = new RemoteHostClient(host, fetchImpl as unknown as typeof fetch);
+
+      const received: string[] = [];
+      client.onMeta((e) => received.push(`meta:${e.cols}x${e.rows}`));
+      client.onResize((e) => received.push(`resize:${e.cols}x${e.rows}`));
+      client.onData((e) => received.push(`data:${e.dataB64}`));
+
+      client.attach('sess-1');
+      await vi.waitFor(() => {
+        expect(received).toEqual(['meta:80x24', 'resize:120x30', 'data:aGVsbG8=']);
+      });
+    });
+
     it('forwards truncated and omittedBytes from meta', async () => {
       const body =
         'event: meta\ndata: {"cols":80,"rows":24,"truncated":true,"omittedBytes":42}\n\n' +

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1253,6 +1253,11 @@ document.addEventListener('DOMContentLoaded', () => {
     ipcRenderer.on(IPC.REMOTE_PANE_META, listener);
     return () => { ipcRenderer.removeListener(IPC.REMOTE_PANE_META, listener); };
   },
+  onPaneResize: (callback: (e: { attachId: string; cols: number; rows: number }) => void) => {
+    const listener = (_event: unknown, payload: { attachId: string; cols: number; rows: number }) => callback(payload);
+    ipcRenderer.on(IPC.REMOTE_PANE_RESIZE, listener);
+    return () => { ipcRenderer.removeListener(IPC.REMOTE_PANE_RESIZE, listener); };
+  },
   onPaneData: (callback: (e: { attachId: string; dataB64: string }) => void) => {
     const listener = (_event: unknown, payload: { attachId: string; dataB64: string }) => callback(payload);
     ipcRenderer.on(IPC.REMOTE_PANE_DATA, listener);

--- a/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
+++ b/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
@@ -46,6 +46,26 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
   readOnlyRef.current = readOnly;
 
   /**
+   * True while a snapshot/repaint is being fed to the parser, to keep xterm's
+   * automatic REPLIES off the remote pane's stdin.
+   *
+   * xterm answers device queries itself — DA1 (`ESC[c`), DSR/CPR (`ESC[6n`),
+   * DECRPM — and it delivers those answers through the SAME `onData` this
+   * component forwards to `remote.paneWrite`. A replayed snapshot contains
+   * whatever queries the remote app sent, so replaying it made the mirror type
+   * phantom responses into the remote pane. The remote's own GUI terminal is
+   * the authoritative responder; a mirror must never answer. This is the same
+   * reason HeadlessSnapshot states in its header that "no onData handler is
+   * ever wired" to its offscreen terminal.
+   *
+   * A repaint cannot distinguish a parser reply from a keystroke the user
+   * raced into the same window, so the gate suppresses `paneWrite` outright.
+   * Repaint windows are milliseconds; losing a keystroke to one is far cheaper
+   * than injecting query answers into a live remote shell.
+   */
+  const repaintingRef = useRef(false);
+
+  /**
    * The same visual settings a local pane gets.
    *
    * A mirror is still one of this app's terminals, and it sits in the sidebar
@@ -169,7 +189,10 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
       if (!term) return;
       term.reset();
       term.resize(e.cols, e.rows);
-      term.write(decodeBase64Bytes(e.snapshotB64));
+      repaintingRef.current = true;
+      term.write(decodeBase64Bytes(e.snapshotB64), () => {
+        repaintingRef.current = false;
+      });
     });
     const offData = remote.onPaneData((e) => {
       if (e.attachId !== attachId) return;
@@ -187,6 +210,7 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
     });
     const dataDisposable = termRef.current?.onData((data) => {
       if (readOnlyRef.current) return; // read-only host — swallow locally, don't POST a write that'll be rejected
+      if (repaintingRef.current) return; // parser reply to a replayed query — see repaintingRef
       remote.paneWrite(attachId, data);
     });
 

--- a/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
+++ b/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
@@ -27,6 +27,47 @@ function decodeBase64Bytes(b64: string): Uint8Array {
 }
 
 /**
+ * Answers xterm generates BY ITSELF in response to a device query, which it
+ * delivers through the same `onData` a user's keystrokes come out of.
+ *
+ * A mirror must never answer: the machine that owns the pane has its own
+ * terminal, that one is the authoritative responder, and a second answer is a
+ * line of garbage typed into a live remote shell. (HeadlessSnapshot avoids the
+ * whole problem by never wiring `onData` at all — a mirror cannot, because it
+ * also has to carry real typing.)
+ *
+ * Matching by SHAPE is what makes this safe to apply to the live stream and not
+ * just to a replay: no key or key combination xterm encodes produces any of
+ * these. Arrows and function keys end in `A`–`H`, `~`, or an uppercase letter;
+ * a reply ends in lowercase `c`, `n`, `y`, `t`, or the specific `R` of a cursor
+ * report, and the DCS/OSC forms have no keyboard analogue at all.
+ *
+ * The stronger fix is upstream: neutralise the QUERIES so no reply is ever
+ * generated (xterm's `parser.registerCsiHandler` can swallow DA/DSR/DECRQM
+ * before the default handler answers), or have the daemon strip them from the
+ * bytes it fans out. Both are larger than this pane and out of scope here.
+ */
+// eslint-disable-next-line no-control-regex
+const DEVICE_REPLY_RE = new RegExp(
+  '^(?:' +
+    // Device attributes (DA1/DA2/DA3) and device status / cursor position.
+    '\\x1b\\[[?>=]?[0-9;]*[cnR]' +
+    // DECRPM — "mode Ps is currently Pm".
+    '|\\x1b\\[\\?[0-9;]*\\$y' +
+    // Window / text-area reports (CSI 8 ; rows ; cols t and friends).
+    '|\\x1b\\[[0-9;]+t' +
+    // DCS replies: DECRQSS, XTVERSION, DA3.
+    '|\\x1bP[^\\x1b]*\\x1b\\\\' +
+    // OSC colour reports (`rgb:....` under BEL or ST).
+    '|\\x1b\\][0-9;]*;?rgb:[^\\x07\\x1b]*(?:\\x07|\\x1b\\\\)' +
+    ')$',
+);
+
+export function isDeviceReply(data: string): boolean {
+  return DEVICE_REPLY_RE.test(data);
+}
+
+/**
  * One @xterm/xterm mirror of a single remote pane. Read-mostly: the remote's
  * own geometry events (meta on attach, resize afterwards) are the ONLY thing
  * that drives `term.resize()` — this component never calls a resize API back
@@ -47,24 +88,22 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
   readOnlyRef.current = readOnly;
 
   /**
-   * True while a snapshot/repaint is being fed to the parser, to keep xterm's
-   * automatic REPLIES off the remote pane's stdin.
+   * How many snapshot repaints are currently being fed to the parser. Second
+   * line of defence behind {@link isDeviceReply}: a reply shape that list does
+   * not know about still cannot escape during a replay, which is where a
+   * snapshot's worth of queries arrives at once.
    *
-   * xterm answers device queries itself — DA1 (`ESC[c`), DSR/CPR (`ESC[6n`),
-   * DECRPM — and it delivers those answers through the SAME `onData` this
-   * component forwards to `remote.paneWrite`. A replayed snapshot contains
-   * whatever queries the remote app sent, so replaying it made the mirror type
-   * phantom responses into the remote pane. The remote's own GUI terminal is
-   * the authoritative responder; a mirror must never answer. This is the same
-   * reason HeadlessSnapshot states in its header that "no onData handler is
-   * ever wired" to its offscreen terminal.
+   * A COUNT, not a flag. xterm parses a large write in ~12 ms slices, so a
+   * second repaint can start while the first is still being consumed — and with
+   * a boolean the first callback would open the gate while the second snapshot
+   * was still parsing.
    *
-   * A repaint cannot distinguish a parser reply from a keystroke the user
-   * raced into the same window, so the gate suppresses `paneWrite` outright.
-   * Repaint windows are milliseconds; losing a keystroke to one is far cheaper
-   * than injecting query answers into a live remote shell.
+   * A repaint cannot distinguish a reply from a keystroke the user raced into
+   * the same window, so the gate suppresses `paneWrite` outright. Repaint
+   * windows are milliseconds; losing a keystroke to one is far cheaper than
+   * injecting query answers into a live remote shell.
    */
-  const repaintingRef = useRef(false);
+  const repaintDepthRef = useRef(0);
 
   /**
    * The same visual settings a local pane gets.
@@ -190,10 +229,19 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
       if (!term) return;
       term.reset();
       term.resize(e.cols, e.rows);
-      repaintingRef.current = true;
-      term.write(decodeBase64Bytes(e.snapshotB64), () => {
-        repaintingRef.current = false;
-      });
+      repaintDepthRef.current += 1;
+      try {
+        term.write(decodeBase64Bytes(e.snapshotB64), () => {
+          repaintDepthRef.current = Math.max(0, repaintDepthRef.current - 1);
+        });
+      } catch {
+        // `write` can throw before it ever queues the callback (xterm's
+        // WriteBuffer refuses past DISCARD_WATERMARK). Not decrementing here
+        // would latch the gate for the rest of the pane's life and silently
+        // swallow every keystroke — a far worse outcome than a lost repaint,
+        // which the next attach or reconnect replaces anyway.
+        repaintDepthRef.current = Math.max(0, repaintDepthRef.current - 1);
+      }
     });
     // A resize on the machine that owns the pane. Geometry only: no reset and
     // no repaint, so the mirrored scrollback and the user's scroll position
@@ -219,7 +267,11 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
     });
     const dataDisposable = termRef.current?.onData((data) => {
       if (readOnlyRef.current) return; // read-only host — swallow locally, don't POST a write that'll be rejected
-      if (repaintingRef.current) return; // parser reply to a replayed query — see repaintingRef
+      // A query answer xterm produced on its own, from a replayed snapshot OR
+      // from live output — the remote app sends `ESC[6n` mid-session too, and
+      // gating only the repaint left that path answering. See isDeviceReply.
+      if (isDeviceReply(data)) return;
+      if (repaintDepthRef.current > 0) return;
       remote.paneWrite(attachId, data);
     });
 

--- a/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
+++ b/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
@@ -28,10 +28,11 @@ function decodeBase64Bytes(b64: string): Uint8Array {
 
 /**
  * One @xterm/xterm mirror of a single remote pane. Read-mostly: the remote's
- * meta event (cols/rows) is the ONLY thing that drives `term.resize()` — this
- * component never calls a resize API back toward the remote (geometry has a
- * single owner, the remote daemon). A container/remote aspect mismatch is
- * letterboxed by the parent's CSS, not by resizing the terminal.
+ * own geometry events (meta on attach, resize afterwards) are the ONLY thing
+ * that drives `term.resize()` — this component never calls a resize API back
+ * toward the remote (geometry has a single owner, the remote daemon). A
+ * container/remote aspect mismatch is letterboxed by the parent's CSS, not by
+ * resizing the terminal.
  */
 export default function RemoteMirrorTerminal({ attachId, error, readOnly }: RemoteMirrorTerminalProps) {
   const t = useT();
@@ -173,9 +174,9 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
     }
   }, [terminalFontSize, terminalFontFamily, xtermTheme, minimumContrastRatio]);
 
-  // Subscribe/attach lifecycle keyed on attachId. Geometry arrives once per
-  // connection — every onPaneMeta (fresh attach OR reconnect) means "reset
-  // terminal, resize, repaint", never a delta.
+  // Subscribe/attach lifecycle keyed on attachId. Every onPaneMeta (fresh
+  // attach OR reconnect) means "reset terminal, resize, repaint", never a
+  // delta; a later geometry change comes through onPaneResize instead.
   useEffect(() => {
     if (!attachId) return;
     setExited(false);
@@ -193,6 +194,14 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
       term.write(decodeBase64Bytes(e.snapshotB64), () => {
         repaintingRef.current = false;
       });
+    });
+    // A resize on the machine that owns the pane. Geometry only: no reset and
+    // no repaint, so the mirrored scrollback and the user's scroll position
+    // survive someone dragging a divider on the other machine. The remote app
+    // repaints itself on SIGWINCH; those bytes arrive through onPaneData.
+    const offResize = remote.onPaneResize((e) => {
+      if (e.attachId !== attachId) return;
+      termRef.current?.resize(e.cols, e.rows);
     });
     const offData = remote.onPaneData((e) => {
       if (e.attachId !== attachId) return;
@@ -216,6 +225,7 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
 
     return () => {
       offMeta();
+      offResize();
       offData();
       offExit();
       offError();

--- a/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
+++ b/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
@@ -98,6 +98,7 @@ function render(ui: React.ReactElement) {
 
 describe('RemoteMirrorTerminal', () => {
   let metaHandlers: Handler[];
+  let resizeHandlers: Handler[];
   let dataHandlers: Handler[];
   let exitHandlers: Handler[];
   let errorHandlers: Handler[];
@@ -108,6 +109,7 @@ describe('RemoteMirrorTerminal', () => {
     setupLog.length = 0;
     termInstances.length = 0;
     metaHandlers = [];
+    resizeHandlers = [];
     dataHandlers = [];
     exitHandlers = [];
     errorHandlers = [];
@@ -119,6 +121,10 @@ describe('RemoteMirrorTerminal', () => {
         onPaneMeta: (cb: Handler) => {
           metaHandlers.push(cb);
           return () => { metaHandlers = metaHandlers.filter((h) => h !== cb); };
+        },
+        onPaneResize: (cb: Handler) => {
+          resizeHandlers.push(cb);
+          return () => { resizeHandlers = resizeHandlers.filter((h) => h !== cb); };
         },
         onPaneData: (cb: Handler) => {
           dataHandlers.push(cb);
@@ -226,6 +232,44 @@ describe('RemoteMirrorTerminal', () => {
     expect(paneWrite).toHaveBeenCalledTimes(1);
     expect(paneWrite).toHaveBeenCalledWith('a1', 'ls\n');
 
+    unmount();
+  });
+
+  // A resize on the machine that owns the pane arrives as GEOMETRY. Answering
+  // it with a fresh snapshot would mean `reset()` + replay on every viewer —
+  // wiping the mirrored scrollback and yanking a user who was scrolled up back
+  // to the bottom every time someone dragged a divider on the other machine.
+  it('★ re-grids on a resize event without resetting or repainting', () => {
+    const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+    const term = termInstances[0];
+
+    act(() => {
+      metaHandlers.forEach((h) =>
+        h({ attachId: 'a1', cols: 80, rows: 24, snapshotB64: btoa('scrollback') }),
+      );
+      term.flushWrites();
+    });
+    const resetsAfterAttach = term.resetCalls;
+    const writesAfterAttach = term.written.length;
+
+    act(() => {
+      resizeHandlers.forEach((h) => h({ attachId: 'a1', cols: 120, rows: 40 }));
+    });
+
+    expect(term.resized.at(-1)).toEqual({ cols: 120, rows: 40 });
+    expect(term.resetCalls).toBe(resetsAfterAttach); // scrollback survives
+    expect(term.written).toHaveLength(writesAfterAttach); // nothing repainted
+
+    unmount();
+  });
+
+  it('ignores a resize aimed at a different attach', () => {
+    const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+    const term = termInstances[0];
+    act(() => {
+      resizeHandlers.forEach((h) => h({ attachId: 'other', cols: 10, rows: 5 }));
+    });
+    expect(term.resized).toHaveLength(0);
     unmount();
   });
 

--- a/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
+++ b/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
@@ -50,7 +50,11 @@ class FakeTerminal {
    * separately, and `flushWrites()` is the "after".
    */
   pendingWriteCallbacks: Array<() => void> = [];
+  /** Set to make write() throw the way xterm's WriteBuffer does past its
+   *  discard watermark — BEFORE the callback is ever queued. */
+  writeThrows = false;
   write(data: unknown, cb?: () => void): void {
+    if (this.writeThrows) throw new Error('write buffer full');
     this.written.push(data);
     if (cb) this.pendingWriteCallbacks.push(cb);
   }
@@ -206,24 +210,30 @@ describe('RemoteMirrorTerminal', () => {
   });
 
   // ①c — xterm auto-answers DA1/DSR/CPR through the same onData this component
-  // forwards, so replaying a snapshot that contains those queries used to type
-  // phantom responses into the REMOTE pane's stdin. The remote's own GUI is the
-  // authoritative responder (HeadlessSnapshot never wires onData for the same
-  // reason); the mirror must stay silent for the duration of the repaint.
+  // forwards, so anything it parses can make the mirror type into the REMOTE
+  // pane's stdin. The remote's own GUI is the authoritative responder
+  // (HeadlessSnapshot never wires onData for the same reason).
+  //
+  // Two layers: replies are filtered by shape wherever they come from, and the
+  // whole channel is closed for the duration of a repaint, where a snapshot's
+  // worth of queries lands at once.
+  const attach = (snapshot = 'scrollback'): void => {
+    act(() => {
+      metaHandlers.forEach((h) =>
+        h({ attachId: 'a1', cols: 80, rows: 24, snapshotB64: btoa(snapshot) }),
+      );
+    });
+  };
+
   it('★ suppresses paneWrite while a snapshot repaint is being written', () => {
     const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
     const term = termInstances[0];
+    attach('\x1b[?1049h\x1b[c');
 
-    act(() => {
-      metaHandlers.forEach((h) =>
-        h({ attachId: 'a1', cols: 80, rows: 24, snapshotB64: btoa('\x1b[?1049h\x1b[c') }),
-      );
-    });
-    // The write callback has NOT fired yet — the parser is still consuming, and
-    // this is exactly when it emits its reply.
-    act(() => {
-      term.onDataHandler?.('\x1b[?62;c'); // a DA1 response xterm generated itself
-    });
+    // Ordinary typing, not a reply — so this asserts the GATE, not the filter.
+    // The write callback has not fired yet: the parser is still consuming, and
+    // that is exactly when it emits its answers.
+    act(() => { term.onDataHandler?.('x'); });
     expect(paneWrite).not.toHaveBeenCalled();
 
     // Once the chunk is consumed the gate drops and real typing flows again.
@@ -231,6 +241,87 @@ describe('RemoteMirrorTerminal', () => {
     act(() => { term.onDataHandler?.('ls\n'); });
     expect(paneWrite).toHaveBeenCalledTimes(1);
     expect(paneWrite).toHaveBeenCalledWith('a1', 'ls\n');
+
+    unmount();
+  });
+
+  it('★ keeps the gate closed while two repaints overlap', () => {
+    // xterm parses a big write in ~12 ms slices, so a reconnect can start a
+    // second repaint while the first is still being consumed. With a boolean
+    // gate the FIRST callback reopened the channel underneath the second.
+    const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+    const term = termInstances[0];
+    attach('first');
+    attach('second');
+    expect(term.pendingWriteCallbacks).toHaveLength(2);
+
+    // The first snapshot finishes parsing; the second has not.
+    act(() => { term.pendingWriteCallbacks.shift()?.(); });
+    act(() => { term.onDataHandler?.('x'); });
+    expect(paneWrite).not.toHaveBeenCalled();
+
+    // Both done — back to normal.
+    act(() => { term.flushWrites(); });
+    act(() => { term.onDataHandler?.('x'); });
+    expect(paneWrite).toHaveBeenCalledTimes(1);
+
+    unmount();
+  });
+
+  it('★ a throwing write does not latch the gate shut forever', () => {
+    // xterm's WriteBuffer refuses past its discard watermark, and it throws
+    // before the callback exists — so nothing would ever reopen the gate, and
+    // the pane would silently swallow every keystroke from then on.
+    const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+    const term = termInstances[0];
+    term.writeThrows = true;
+    attach('too much');
+    term.writeThrows = false;
+
+    act(() => { term.onDataHandler?.('ls\n'); });
+    expect(paneWrite).toHaveBeenCalledWith('a1', 'ls\n');
+
+    unmount();
+  });
+
+  it('★ never forwards a device-query reply on the LIVE data path', () => {
+    // The repaint gate does not cover this: a TUI sends `ESC[6n` mid-session,
+    // long after any snapshot, and the mirror was answering it.
+    const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+    const term = termInstances[0];
+    attach();
+    act(() => { term.flushWrites(); }); // repaint over — the gate is open
+
+    const replies = [
+      '\x1b[?62;1;6c', // DA1
+      '\x1b[>0;276;0c', // DA2
+      '\x1b[0n', // DSR
+      '\x1b[24;80R', // CPR
+      '\x1b[?2004;1$y', // DECRPM
+      '\x1b[8;24;80t', // text-area report
+      '\x1bP1$r0m\x1b\\', // DECRQSS
+      '\x1b]11;rgb:1e1e/1e1e/2e2e\x07', // OSC background report
+    ];
+    act(() => { replies.forEach((r) => term.onDataHandler?.(r)); });
+    expect(paneWrite).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it('still forwards the escape sequences a KEY produces', () => {
+    // The filter is shape-based, so it has to leave real input alone: arrows,
+    // modified arrows, function keys, shift-tab, bracketed paste, mouse.
+    const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+    const term = termInstances[0];
+    attach();
+    act(() => { term.flushWrites(); });
+
+    const keys = [
+      '\x1b[A', '\x1b[D', '\x1b[1;5C', '\x1b[3~', '\x1b[15~', '\x1b[Z',
+      '\x1bOR', '\x1b[200~pasted\x1b[201~', '\x1b[<0;10;5M', '\x03',
+    ];
+    act(() => { keys.forEach((k) => term.onDataHandler?.(k)); });
+    expect(paneWrite).toHaveBeenCalledTimes(keys.length);
 
     unmount();
   });

--- a/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
+++ b/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
@@ -43,7 +43,22 @@ class FakeTerminal {
   }
   reset(): void { this.resetCalls++; }
   resize(cols: number, rows: number): void { this.resized.push({ cols, rows }); }
-  write(data: unknown): void { this.written.push(data); }
+  /**
+   * xterm's `write(data, callback)` — the callback fires once the parser has
+   * consumed the chunk, which is the seam the repaint gate hangs off. The fake
+   * holds it so a test can drive "during the write" and "after the write"
+   * separately, and `flushWrites()` is the "after".
+   */
+  pendingWriteCallbacks: Array<() => void> = [];
+  write(data: unknown, cb?: () => void): void {
+    this.written.push(data);
+    if (cb) this.pendingWriteCallbacks.push(cb);
+  }
+  flushWrites(): void {
+    const cbs = this.pendingWriteCallbacks;
+    this.pendingWriteCallbacks = [];
+    cbs.forEach((cb) => cb());
+  }
   onData(cb: (data: string) => void): { dispose: () => void } {
     this.onDataHandler = cb;
     return { dispose: vi.fn() };
@@ -179,6 +194,36 @@ describe('RemoteMirrorTerminal', () => {
       term.onDataHandler?.('ls\n');
     });
 
+    expect(paneWrite).toHaveBeenCalledWith('a1', 'ls\n');
+
+    unmount();
+  });
+
+  // ①c — xterm auto-answers DA1/DSR/CPR through the same onData this component
+  // forwards, so replaying a snapshot that contains those queries used to type
+  // phantom responses into the REMOTE pane's stdin. The remote's own GUI is the
+  // authoritative responder (HeadlessSnapshot never wires onData for the same
+  // reason); the mirror must stay silent for the duration of the repaint.
+  it('★ suppresses paneWrite while a snapshot repaint is being written', () => {
+    const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+    const term = termInstances[0];
+
+    act(() => {
+      metaHandlers.forEach((h) =>
+        h({ attachId: 'a1', cols: 80, rows: 24, snapshotB64: btoa('\x1b[?1049h\x1b[c') }),
+      );
+    });
+    // The write callback has NOT fired yet — the parser is still consuming, and
+    // this is exactly when it emits its reply.
+    act(() => {
+      term.onDataHandler?.('\x1b[?62;c'); // a DA1 response xterm generated itself
+    });
+    expect(paneWrite).not.toHaveBeenCalled();
+
+    // Once the chunk is consumed the gate drops and real typing flows again.
+    act(() => { term.flushWrites(); });
+    act(() => { term.onDataHandler?.('ls\n'); });
+    expect(paneWrite).toHaveBeenCalledTimes(1);
     expect(paneWrite).toHaveBeenCalledWith('a1', 'ls\n');
 
     unmount();

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -527,6 +527,10 @@ export const IPC = {
   REMOTE_PANE_WRITE: 'remote:pane:write',
   REMOTE_PANE_DATA: 'remote:pane:data',      // main → renderer push
   REMOTE_PANE_META: 'remote:pane:meta',      // main → renderer push (cols/rows/snapshot)
+  // main → renderer push (cols/rows only). A resize on the machine that owns
+  // the pane: the mirror re-grids and KEEPS what it has, where META means
+  // "reset and repaint".
+  REMOTE_PANE_RESIZE: 'remote:pane:resize',
   REMOTE_PANE_EXIT: 'remote:pane:exit',      // main → renderer push
   REMOTE_PANE_ERROR: 'remote:pane:error',    // main → renderer push (reconnect gave up)
 } as const;

--- a/src/shared/electron.d.ts
+++ b/src/shared/electron.d.ts
@@ -209,6 +209,11 @@ declare global {
         onPaneMeta: (
           callback: (e: { attachId: string; cols: number; rows: number; snapshotB64: string; truncated?: boolean; omittedBytes?: number }) => void,
         ) => () => void;
+        /** Geometry-only: the remote pane was resized while attached. Re-grid
+         *  and keep what is on screen — unlike onPaneMeta, nothing is reset. */
+        onPaneResize: (
+          callback: (e: { attachId: string; cols: number; rows: number }) => void,
+        ) => () => void;
         onPaneData: (callback: (e: { attachId: string; dataB64: string }) => void) => () => void;
         onPaneExit: (callback: (e: { attachId: string }) => void) => () => void;
         /** Fires once reconnection gives up after too many consecutive


### PR DESCRIPTION
Attaching a remote workspace to a long-running fullscreen TUI painted a garbled, interleaved screen: rows landed on top of scrollback, fragments of earlier frames stayed on the left edge, and the app never took over the screen.

Three independent defects on the `/api/stream` path, all of which also affect the phone web frontend — this is not mirror-specific.

## 1. The snapshot window was byte-safe but not mode-safe

`capSnapshot` sends the last 256 KB of the ring and cuts only at UTF-8 and escape-sequence boundaries. Terminal MODE state is not a boundary. A fullscreen app sends `ESC[?1049h` exactly once, at startup, then paints with absolute cursor positioning forever, so hours later that switch sits far outside the window. The client replayed absolute-positioned frames while still on the normal buffer, which is precisely the interleaved-over-scrollback symptom.

The local GUI never hits this because `HeadlessSnapshot` refuses alt-screen and `SessionPipe` falls back to a full raw replay. The SSE path cannot afford that — the window exists to keep a reconnecting phone from pulling megabytes — so it now reconstructs the mode state instead.

`OutputModeTracker` is fed every chunk written to the ring (O(chunk) at write time) and answers in O(1) at stream open, preserving `snapshotWindow.ts`'s invariant that per-call work is independent of buffer size. Its `preamble()` is prepended to the capped window, riding the existing `snapshot` event rather than a new event name, so a cached frontend replays it as ordinary bytes — which is what it is.

Accepted limitation, documented at the source: an alt-screen app idle since before the window contributes no repaint of its own, so only the part of its frame the window happens to contain shows until it next redraws. Mostly-right beats garbled.

## 2. Geometry changes never reached an open stream

`meta` was sent once per connection. After a remote-side resize every subsequent absolute-positioned frame was computed for a grid the client no longer had. Applied resizes now emit from `noteResize()` — one event covering both the phone route and the desk RPC — and each stream answers with a fresh `meta` + `snapshot` PAIR, trailing-debounced 150 ms so a drag-resize costs one repaint. The pair matters: the Electron mirror client holds a `meta` until a `snapshot` follows and never dispatches a lone one.

## 3. The mirror answered device queries on the remote's stdin

xterm replies to DA1, DSR/CPR and DECRPM itself and delivers those replies through the same `onData` the mirror forwards to `paneWrite`. Replaying a snapshot that contained such queries made the mirror type phantom responses into the remote pane's shell. The remote's own GUI terminal is the authoritative responder — the same reason `HeadlessSnapshot` wires no `onData` at all. `paneWrite` is now gated while a repaint is being parsed.

## Tests

215 passing across the touched suites.

- `outputModeTracker.test.ts` (new) — mode toggles, `h`/`l` pairs, last-writer-wins, sequences split across chunk boundaries, mouse encoding pairs, RIS.
- `WebTerminalServer.test.ts` — a ring holding `ESC[?1049h` followed by more than 256 KB of output yields a snapshot that opens with the alt-screen preamble; a normal-buffer session gets no preamble at all (byte-identical to before); an applied resize produces a debounced `meta`+`snapshot` pair on an open stream.
- `RemoteMirrorTerminal.test.tsx` — parser output during a gated repaint does not reach `paneWrite`.